### PR TITLE
feat(phase2): memory + soul services with durability enforcement

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,3 +88,9 @@ Apache 2.0 — see [LICENSE](LICENSE).
 ## Contributing
 
 Flair is built by the [TPS](https://github.com/tpsdev-ai) team. Issues and PRs welcome.
+
+## Phase 2 Security Notes
+
+- All Memory and Soul endpoints require Ed25519 auth middleware.
+- Memory `content` is stored plaintext in Phase 2 (encryption-at-rest planned for Phase 3).
+- Soul keys should avoid direct PII by convention (e.g. use role/relationship labels, not personal identifiers).

--- a/harper/schema.graphql
+++ b/harper/schema.graphql
@@ -19,3 +19,26 @@ type Integration @table @export {
   createdAt: String!
   updatedAt: String
 }
+
+type Memory @table @export {
+  id: ID @primaryKey
+  agentId: String! @indexed
+  content: String!
+  embedding: [Float]
+  tags: [String] @indexed
+  durability: String @indexed
+  source: String
+  createdAt: String! @indexed
+  updatedAt: String
+  expiresAt: String @indexed
+}
+
+type Soul @table @export {
+  id: ID @primaryKey
+  agentId: String! @indexed
+  key: String! @indexed
+  value: String!
+  durability: String @indexed
+  createdAt: String!
+  updatedAt: String
+}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,8 +1,8 @@
 #!/usr/bin/env node
 import { Command } from "commander";
-import { randomBytes } from "node:crypto";
 import nacl from "tweetnacl";
-import { addIntegration, getAgent, listAgents, listIntegrations, upsertAgent } from "./store.js";
+import { addIntegration, createMemory, getAgent, getSoul, listAgents, listMemories, listSouls, searchMemories, upsertAgent, upsertSoul } from "./store.js";
+import type { Durability } from "./types.js";
 
 function b64(bytes: Uint8Array): string { return Buffer.from(bytes).toString("base64"); }
 
@@ -10,7 +10,6 @@ const program = new Command();
 program.name("flair").description("Flair CLI");
 
 const identity = program.command("identity").description("Identity commands");
-
 identity.command("register")
   .requiredOption("--id <id>")
   .requiredOption("--name <name>")
@@ -18,46 +17,22 @@ identity.command("register")
   .action((opts) => {
     const kp = nacl.sign.keyPair();
     const now = new Date().toISOString();
-    const row = upsertAgent({
-      id: opts.id,
-      name: opts.name,
-      role: opts.role,
-      publicKey: b64(kp.publicKey),
-      createdAt: now,
-      updatedAt: now,
-    });
-
-    // Private key output is local-only for operator handoff; never sent to API.
-    console.log(JSON.stringify({
-      agent: row,
-      privateKey: b64(kp.secretKey),
-      note: "Store privateKey in runtime keychain; Flair backend never receives private key.",
-    }, null, 2));
+    const row = upsertAgent({ id: opts.id, name: opts.name, role: opts.role, publicKey: b64(kp.publicKey), createdAt: now, updatedAt: now });
+    console.log(JSON.stringify({ agent: row, privateKey: b64(kp.secretKey), note: "Store privateKey in runtime keychain; Flair backend never receives private key." }, null, 2));
   });
-
-identity.command("show")
-  .argument("<id>")
-  .action((id) => {
-    const row = getAgent(id);
-    if (!row) {
-      console.error("agent not found");
-      process.exit(1);
-    }
-    console.log(JSON.stringify(row, null, 2));
-  });
-
-identity.command("list")
-  .action(() => {
-    console.log(JSON.stringify(listAgents(), null, 2));
-  });
-
+identity.command("show").argument("<id>").action((id) => {
+  const row = getAgent(id);
+  if (!row) { console.error("agent not found"); process.exit(1); }
+  console.log(JSON.stringify(row, null, 2));
+});
+identity.command("list").action(() => console.log(JSON.stringify(listAgents(), null, 2)));
 identity.command("add-integration")
   .requiredOption("--agent <agentId>")
   .requiredOption("--platform <platform>")
+  .requiredOption("--encrypted-credential <ciphertext>")
   .option("--username <username>")
   .option("--userid <userId>")
   .option("--email <email>")
-  .requiredOption("--encrypted-credential <ciphertext>")
   .option("--metadata <json>")
   .action((opts) => {
     const row = addIntegration({
@@ -73,6 +48,60 @@ identity.command("add-integration")
       updatedAt: new Date().toISOString(),
     });
     console.log(JSON.stringify(row, null, 2));
+  });
+
+const memory = program.command("memory").description("Memory commands");
+memory.command("add")
+  .requiredOption("--agent <agentId>")
+  .requiredOption("--content <text>")
+  .option("--tags <csv>")
+  .option("--source <source>")
+  .option("--durability <durability>", "permanent|persistent|standard|ephemeral", "standard")
+  .action((opts) => {
+    const row = createMemory({
+      agentId: opts.agent,
+      content: opts.content,
+      tags: opts.tags ? String(opts.tags).split(",").map((x: string) => x.trim()).filter(Boolean) : undefined,
+      source: opts.source,
+      durability: opts.durability as Durability,
+    });
+    console.log(JSON.stringify(row, null, 2));
+  });
+memory.command("search")
+  .requiredOption("--agent <agentId>")
+  .requiredOption("--q <query>")
+  .option("--tag <tag>")
+  .action((opts) => {
+    console.log(JSON.stringify(searchMemories({ agentId: opts.agent, q: opts.q, tag: opts.tag }), null, 2));
+  });
+memory.command("list")
+  .requiredOption("--agent <agentId>")
+  .option("--tag <tag>")
+  .action((opts) => {
+    console.log(JSON.stringify(listMemories({ agentId: opts.agent, tag: opts.tag }), null, 2));
+  });
+
+const soul = program.command("soul").description("Soul commands");
+soul.command("set")
+  .requiredOption("--agent <agentId>")
+  .requiredOption("--key <key>")
+  .requiredOption("--value <value>")
+  .option("--durability <durability>", "permanent|persistent|standard|ephemeral", "permanent")
+  .action((opts) => {
+    const row = upsertSoul({ agentId: opts.agent, key: opts.key, value: opts.value, durability: opts.durability as Durability });
+    console.log(JSON.stringify(row, null, 2));
+  });
+soul.command("get")
+  .argument("<id>")
+  .action((id) => {
+    const row = getSoul(id);
+    if (!row) { console.error("soul not found"); process.exit(1); }
+    console.log(JSON.stringify(row, null, 2));
+  });
+soul.command("list")
+  .requiredOption("--agent <agentId>")
+  .action((opts) => {
+    console.log(JSON.stringify(listSouls(opts.agent), null, 2));
   });
 
 program.parse();

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,14 +1,29 @@
 import express from "express";
 import { authMiddleware } from "./auth.js";
-import { addIntegration, getAgent, listAgents, listIntegrations, upsertAgent } from "./store.js";
+import {
+  addIntegration,
+  createMemory,
+  deleteMemory,
+  getAgent,
+  getMemory,
+  getSoul,
+  listAgents,
+  listIntegrations,
+  listMemories,
+  listSouls,
+  searchMemories,
+  upsertAgent,
+  upsertSoul,
+} from "./store.js";
+import type { Durability } from "./types.js";
 
+export function createApp() {
 const app = express();
 app.use(express.json({ limit: "1mb" }));
 app.use(authMiddleware);
 
 app.get("/health", (_req, res) => res.json({ ok: true }));
 
-// @export-like REST resources
 app.get("/Agent", (_req, res) => res.json(listAgents()));
 app.get("/Agent/:id", (req, res) => {
   const row = getAgent(req.params.id);
@@ -25,7 +40,6 @@ app.post("/Agent", (req, res) => {
 
 app.get("/Integration", (req, res) => res.json(listIntegrations(req.query.agentId as string | undefined)));
 app.post("/Integration", (req, res) => {
-  // S31-A: API never accepts plaintext credentials.
   if (typeof req.body?.credential === "string" || typeof req.body?.token === "string") {
     return res.status(400).json({ error: "plaintext_credentials_forbidden" });
   }
@@ -40,16 +54,79 @@ app.post("/Integration", (req, res) => {
   return res.status(201).json(row);
 });
 
-// Phase 2 placeholder endpoint
-app.post("/memory/search", (_req, res) => {
-  return res.status(501).json({
-    results: [],
-    status: "placeholder",
-    message: "memory semantic search ships in Phase 2",
+// Memory CRUD
+app.post("/memory", (req, res) => {
+  const { agentId, content, embedding, tags, durability, source, expiresAt } = req.body || {};
+  if (!agentId || typeof content !== "string") return res.status(400).json({ error: "agentId_content_required" });
+  const row = createMemory({
+    agentId,
+    content,
+    embedding: Array.isArray(embedding) ? embedding : undefined,
+    tags: Array.isArray(tags) ? tags : undefined,
+    durability: (durability || "standard") as Durability,
+    source,
+    expiresAt,
   });
+  return res.status(201).json(row);
 });
 
-const port = Number(process.env.PORT || 8787);
-app.listen(port, () => {
-  console.log(`flair listening on :${port}`);
+app.get("/memory/:id", (req, res) => {
+  const row = getMemory(req.params.id);
+  if (!row) return res.status(404).json({ error: "not_found" });
+  return res.json(row);
 });
+
+app.get("/memory", (req, res) => {
+  return res.json(listMemories({ agentId: req.query.agentId as string | undefined, tag: req.query.tag as string | undefined }));
+});
+
+app.delete("/memory/:id", (req, res) => {
+  try {
+    return res.json(deleteMemory(req.params.id));
+  } catch (e: any) {
+    if (e.message === "not_found") return res.status(404).json({ error: "not_found" });
+    if (e.message === "permanent_memory_cannot_be_deleted") return res.status(403).json({ error: e.message });
+    return res.status(400).json({ error: "delete_failed" });
+  }
+});
+
+app.post("/memory/search", (req, res) => {
+  const { agentId, q, tag } = req.body || {};
+  return res.json({ results: searchMemories({ agentId, q, tag }) });
+});
+
+// Soul CRUD
+app.post("/soul", (req, res) => {
+  const { id, agentId, key, value, durability } = req.body || {};
+  if (!agentId || !key || typeof value !== "string") return res.status(400).json({ error: "agentId_key_value_required" });
+  const row = upsertSoul({ id, agentId, key, value, durability: (durability || "permanent") as Durability });
+  return res.status(201).json(row);
+});
+
+app.get("/soul/:id", (req, res) => {
+  const row = getSoul(req.params.id);
+  if (!row) return res.status(404).json({ error: "not_found" });
+  return res.json(row);
+});
+
+app.get("/soul", (req, res) => {
+  return res.json(listSouls(req.query.agentId as string | undefined));
+});
+
+app.put("/soul/:id", (req, res) => {
+  const { agentId, key, value, durability } = req.body || {};
+  if (!agentId || !key || typeof value !== "string") return res.status(400).json({ error: "agentId_key_value_required" });
+  const row = upsertSoul({ id: req.params.id, agentId, key, value, durability: (durability || "permanent") as Durability });
+  return res.json(row);
+});
+
+return app;
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  const app = createApp();
+  const port = Number(process.env.PORT || 8787);
+  app.listen(port, () => {
+    console.log(`flair listening on :${port}`);
+  });
+}

--- a/src/store.ts
+++ b/src/store.ts
@@ -1,22 +1,43 @@
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { homedir } from "node:os";
-import type { Agent, DB, Integration } from "./types.js";
+import { randomUUID } from "node:crypto";
+import type { Agent, DB, Integration, Memory, Soul, Durability } from "./types.js";
 
-const DB_PATH = process.env.FLAIR_DB_PATH || join(process.env.HOME || homedir(), ".flair", "db.json");
+function dbPath(): string {
+  return process.env.FLAIR_DB_PATH || join(process.env.HOME || homedir(), ".flair", "db.json");
+}
+const EPHEMERAL_TTL_HOURS = Number(process.env.FLAIR_EPHEMERAL_TTL_HOURS || 24);
 
 function init(): DB {
-  return { agents: [], integrations: [] };
+  return { agents: [], integrations: [], memories: [], souls: [] };
 }
 
 function load(): DB {
-  if (!existsSync(DB_PATH)) return init();
-  return JSON.parse(readFileSync(DB_PATH, "utf-8")) as DB;
+  const path = dbPath();
+  if (!existsSync(path)) return init();
+  const db = JSON.parse(readFileSync(path, "utf-8")) as DB;
+  db.memories ||= [];
+  db.souls ||= [];
+  pruneExpired(db);
+  return db;
 }
 
 function save(db: DB): void {
-  mkdirSync(dirname(DB_PATH), { recursive: true, mode: 0o700 });
-  writeFileSync(DB_PATH, JSON.stringify(db, null, 2), { mode: 0o600 });
+  const path = dbPath();
+  mkdirSync(dirname(path), { recursive: true, mode: 0o700 });
+  writeFileSync(path, JSON.stringify(db, null, 2), { mode: 0o600 });
+}
+
+function pruneExpired(db: DB): void {
+  const now = Date.now();
+  db.memories = db.memories.filter((m) => !m.expiresAt || Date.parse(m.expiresAt) > now);
+}
+
+function makeExpiry(durability: Durability, explicit?: string): string | undefined {
+  if (explicit) return explicit;
+  if (durability !== "ephemeral") return undefined;
+  return new Date(Date.now() + EPHEMERAL_TTL_HOURS * 60 * 60 * 1000).toISOString();
 }
 
 export function listAgents(): Agent[] { return load().agents; }
@@ -43,4 +64,69 @@ export function addIntegration(integration: Integration): Integration {
   else db.integrations.push(integration);
   save(db);
   return db.integrations.find((x) => x.id === integration.id)!;
+}
+
+export function createMemory(input: Omit<Memory, "id" | "createdAt" | "updatedAt" | "expiresAt"> & { expiresAt?: string }): Memory {
+  const db = load();
+  const now = new Date().toISOString();
+  const durability = (input.durability || "standard") as Durability;
+  const m: Memory = {
+    ...input,
+    id: randomUUID(),
+    createdAt: now,
+    updatedAt: now,
+    durability,
+    expiresAt: makeExpiry(durability, input.expiresAt),
+  };
+  db.memories.push(m);
+  save(db);
+  return m;
+}
+
+export function getMemory(id: string): Memory | undefined {
+  return load().memories.find((m) => m.id === id);
+}
+
+export function listMemories(params: { agentId?: string; tag?: string } = {}): Memory[] {
+  const all = load().memories;
+  return all.filter((m) => (!params.agentId || m.agentId === params.agentId) && (!params.tag || (m.tags || []).includes(params.tag)));
+}
+
+export function searchMemories(params: { agentId?: string; q?: string; tag?: string }): Memory[] {
+  const q = (params.q || "").toLowerCase();
+  return listMemories({ agentId: params.agentId, tag: params.tag }).filter((m) => !q || m.content.toLowerCase().includes(q));
+}
+
+export function deleteMemory(id: string): { ok: true } {
+  const db = load();
+  const row = db.memories.find((m) => m.id === id);
+  if (!row) throw new Error("not_found");
+  if (row.durability === "permanent") throw new Error("permanent_memory_cannot_be_deleted");
+  db.memories = db.memories.filter((m) => m.id !== id);
+  save(db);
+  return { ok: true };
+}
+
+export function upsertSoul(input: Omit<Soul, "createdAt" | "updatedAt" | "id"> & { id?: string }): Soul {
+  const db = load();
+  const now = new Date().toISOString();
+  const id = input.id || `${input.agentId}:${input.key}`;
+  const durability: Durability = input.durability || "permanent";
+  const i = db.souls.findIndex((s) => s.id === id);
+  if (i >= 0) {
+    db.souls[i] = { ...db.souls[i], ...input, id, durability, updatedAt: now };
+  } else {
+    db.souls.push({ ...input, id, durability, createdAt: now, updatedAt: now });
+  }
+  save(db);
+  return db.souls.find((s) => s.id === id)!;
+}
+
+export function getSoul(id: string): Soul | undefined {
+  return load().souls.find((s) => s.id === id);
+}
+
+export function listSouls(agentId?: string): Soul[] {
+  const all = load().souls;
+  return agentId ? all.filter((s) => s.agentId === agentId) : all;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,5 @@
+export type Durability = "permanent" | "persistent" | "standard" | "ephemeral";
+
 export type Agent = {
   id: string;
   name: string;
@@ -20,7 +22,32 @@ export type Integration = {
   updatedAt?: string;
 };
 
+export type Memory = {
+  id: string;
+  agentId: string;
+  content: string;
+  embedding?: number[];
+  tags?: string[];
+  durability: Durability;
+  source?: string;
+  createdAt: string;
+  updatedAt?: string;
+  expiresAt?: string;
+};
+
+export type Soul = {
+  id: string;
+  agentId: string;
+  key: string;
+  value: string;
+  durability: Durability;
+  createdAt: string;
+  updatedAt?: string;
+};
+
 export type DB = {
   agents: Agent[];
   integrations: Integration[];
+  memories: Memory[];
+  souls: Soul[];
 };

--- a/test/api-phase2.test.ts
+++ b/test/api-phase2.test.ts
@@ -1,0 +1,133 @@
+import { beforeEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import nacl from "tweetnacl";
+
+let appUrl = "";
+let closeServer: (() => Promise<void>) | null = null;
+let secretKeyB64 = "";
+
+function signHeader(method: string, originalUrl: string, agentId: string): string {
+  const ts = Date.now();
+  const nonce = Math.random().toString(36).slice(2);
+  const payload = `${method}:${originalUrl}:${ts}:${nonce}`;
+  const sig = nacl.sign.detached(Buffer.from(payload), Buffer.from(secretKeyB64, "base64"));
+  return `TPS-Ed25519 ${agentId}:${ts}:${nonce}:${Buffer.from(sig).toString("base64")}`;
+}
+
+async function req(method: string, path: string, body?: any) {
+  const headers: Record<string, string> = {
+    authorization: signHeader(method, path, "flint"),
+  };
+  if (body !== undefined) headers["content-type"] = "application/json";
+  const res = await fetch(`${appUrl}${path}`, {
+    method,
+    headers,
+    body: body !== undefined ? JSON.stringify(body) : undefined,
+  });
+  const json = await res.json();
+  return { status: res.status, json };
+}
+
+beforeEach(async () => {
+  if (closeServer) await closeServer();
+
+  const dbRoot = mkdtempSync(join(tmpdir(), "flair-phase2-"));
+  process.env.FLAIR_DB_PATH = join(dbRoot, "db.json");
+
+  const kp = nacl.sign.keyPair();
+  secretKeyB64 = Buffer.from(kp.secretKey).toString("base64");
+  const publicKey = Buffer.from(kp.publicKey).toString("base64");
+
+  writeFileSync(process.env.FLAIR_DB_PATH, JSON.stringify({
+    agents: [{ id: "flint", name: "Flint", publicKey, createdAt: new Date().toISOString() }],
+    integrations: [],
+    memories: [],
+    souls: [],
+  }));
+
+  const { createApp } = await import(`../src/server.js?x=${Date.now()}`);
+  const app = createApp();
+  const server = app.listen(0);
+  const port = (server.address() as any).port;
+  appUrl = `http://127.0.0.1:${port}`;
+  closeServer = () => new Promise((resolve) => server.close(() => resolve()));
+});
+
+describe("phase2 api", () => {
+  test("requires auth on new endpoints", async () => {
+    const res = await fetch(`${appUrl}/memory`);
+    expect(res.status).toBe(401);
+  });
+
+  test("memory CRUD + search + durability delete guard", async () => {
+    const created = await req("POST", "/memory", {
+      agentId: "flint",
+      content: "we chose rocksdb",
+      tags: ["decision", "db"],
+      durability: "permanent",
+      source: "design-review",
+    });
+    expect(created.status).toBe(201);
+    const id = created.json.id;
+
+    const fetched = await req("GET", `/memory/${id}`);
+    expect(fetched.status).toBe(200);
+    expect(fetched.json.content).toContain("rocksdb");
+
+    const listed = await req("GET", "/memory?agentId=flint&tag=db");
+    expect(listed.status).toBe(200);
+    expect(Array.isArray(listed.json)).toBe(true);
+    expect(listed.json.length).toBe(1);
+
+    const search = await req("POST", "/memory/search", { agentId: "flint", q: "rocks", tag: "decision" });
+    expect(search.status).toBe(200);
+    expect(search.json.results.length).toBe(1);
+
+    const del = await req("DELETE", `/memory/${id}`);
+    expect(del.status).toBe(403);
+    expect(del.json.error).toBe("permanent_memory_cannot_be_deleted");
+  });
+
+  test("ephemeral memory uses ttl and expires", async () => {
+    const created = await req("POST", "/memory", {
+      agentId: "flint",
+      content: "temp note",
+      durability: "ephemeral",
+      expiresAt: new Date(Date.now() - 1000).toISOString(),
+    });
+    expect(created.status).toBe(201);
+
+    const listed = await req("GET", "/memory?agentId=flint");
+    expect(listed.status).toBe(200);
+    expect(listed.json.length).toBe(0);
+  });
+
+  test("soul CRUD defaults durability to permanent", async () => {
+    const created = await req("POST", "/soul", {
+      agentId: "flint",
+      key: "voice",
+      value: "direct",
+    });
+    expect(created.status).toBe(201);
+    expect(created.json.durability).toBe("permanent");
+    const id = created.json.id;
+
+    const got = await req("GET", `/soul/${id}`);
+    expect(got.status).toBe(200);
+
+    const upd = await req("PUT", `/soul/${id}`, {
+      agentId: "flint",
+      key: "voice",
+      value: "concise",
+      durability: "persistent",
+    });
+    expect(upd.status).toBe(200);
+    expect(upd.json.durability).toBe("persistent");
+
+    const listed = await req("GET", "/soul?agentId=flint");
+    expect(listed.status).toBe(200);
+    expect(listed.json.length).toBe(1);
+  });
+});


### PR DESCRIPTION
## Phase 2: Memory + Soul Service

### Implemented
1. **Schema additions**
- Added `Memory` and `Soul` tables in `harper/schema.graphql`
- Added durability classes: `permanent | persistent | standard | ephemeral`
- Included `durability` field on both models

2. **Memory CRUD**
- `POST /memory`
- `GET /memory/:id`
- `GET /memory?agentId=<id>&tag=<tag>`
- `DELETE /memory/:id`

3. **Soul CRUD**
- `POST /soul`
- `GET /soul/:id`
- `GET /soul?agentId=<id>`
- `PUT /soul/:id`

4. **Memory search endpoint**
- Replaced placeholder with `POST /memory/search`
- Phase 2 behavior: substring match on `content` + optional tag filter

5. **Durability enforcement**
- `permanent` memory rejects DELETE with `403 permanent_memory_cannot_be_deleted`
- `ephemeral` memory gets TTL (default 24h via `FLAIR_EPHEMERAL_TTL_HOURS`, overrideable per record with `expiresAt`)
- `Soul` records default to `permanent`

6. **CLI commands**
- `flair memory add`
- `flair memory search`
- `flair memory list`
- `flair soul set`
- `flair soul get`
- `flair soul list`

7. **Tests**
- Added API integration tests covering:
  - Auth required on new endpoints
  - Memory CRUD happy path + search
  - Permanent durability delete guard
  - Ephemeral expiry behavior
  - Soul CRUD + default durability

### Security notes
- New endpoints are behind Ed25519 auth middleware.
- Memory content is stored plaintext in Phase 2 (documented for Phase 3 follow-up).
- README documents convention to avoid PII in soul keys.

### Validation
- `bun run build` ✅
- `bun test` ✅
