### PR TITLE
feat(ops-31.3): AgentSeed resource — zero-config agent onboarding

### DIFF
--- a/resources/AgentSeed.ts
+++ b/resources/AgentSeed.ts
@@ -82,23 +82,37 @@ export class AgentSeed extends Resource {
       : DEFAULT_MEMORIES(agentId, now);
 
     const memories: any[] = [];
-    for (let i = 0; i < memDefs.length; i++) {
-      const def = memDefs[i];
-      const id = `seed-${agentId}-${i}-${Date.now()}`;
-      const record = {
-        id,
-        agentId,
-        content: def.content,
-        durability: def.durability ?? "persistent",
-        tags: def.tags ?? ["onboarding"],
-        source: "seed",
-        createdAt: now,
-        updatedAt: now,
-        archived: false,
-      };
-      await (tables as any).Memory.put(record);
-      memories.push(record);
-    }
+    // Only seed memories if this is a first-time seed (none tagged onboarding yet)
+    const hasOnboardingMemory = await (async () => {
+      for await (const m of (tables as any).Memory.search()) {
+        if (m.agentId === agentId && (m.tags ?? []).includes("onboarding")) return true;
+      }
+      return false;
+    })();
+    if (hasOnboardingMemory) {
+      // Re-seed: return existing onboarding memories without writing new ones
+      for await (const m of (tables as any).Memory.search()) {
+        if (m.agentId === agentId && (m.tags ?? []).includes("onboarding")) memories.push(m);
+      }
+    } else {
+      for (let i = 0; i < memDefs.length; i++) {
+        const def = memDefs[i];
+        const id = `seed-${agentId}-${i}-${Date.now()}`;
+        const record = {
+          id,
+          agentId,
+          content: def.content,
+          durability: def.durability ?? "persistent",
+          tags: def.tags ?? ["onboarding"],
+          source: "seed",
+          createdAt: now,
+          updatedAt: now,
+          archived: false,
+        };
+        await (tables as any).Memory.put(record);
+        memories.push(record);
+      }
+    } // end !hasOnboardingMemory
 
     return { agent, soulEntries, memories };
   }


### PR DESCRIPTION
## ops-31.3 — Onboarding seed kit: Flair

### `POST /AgentSeed` (new resource, admin only)

Companion to `tps agent create` — seeds a new agent with soul + memories in one call.

**Request:**
```json
{
  "agentId": "anvil",
  "displayName": "Anvil",
  "role": "agent",
  "soulTemplate": { "team": "tps", "specialty": "execution" },
  "starterMemories": [{ "content": "...", "tags": ["onboarding"], "durability": "persistent" }]
}
```

**What it creates:**
- Agent record (if not exists; publicKey=pending until CLI sets the real key)
- Soul entries from template merged with defaults (name, role, created, status)
- Starter persistent memories tagged `["onboarding"]`

**Defaults if not supplied:**
- Soul: `{ name: agentId, role: "agent", created: now, status: "active" }`
- Memory: one record — `"Agent {id} initialized. No prior context."`

**Auth:** admin only (`isAdmin()` check)
**Validation:** agentId validated with `/^[a-zA-Z0-9_-]{1,64}$/`
**Safety:** only uses `put()` for fresh inserts — no modify-write needed (all new records)

### Companion CLI PR: tpsdev-ai/cli#69