### PR TITLE
fix: importEd25519Key handles hex public keys + FlairClient raw key support

### DIFF
--- a/resources/auth-middleware.ts
+++ b/resources/auth-middleware.ts
@@ -48,11 +48,20 @@ function b64ToArrayBuffer(b64: string): ArrayBuffer {
 }
 
 const keyCache = new Map<string, CryptoKey>();
-async function importEd25519Key(publicKeyB64: string): Promise<CryptoKey> {
-  if (keyCache.has(publicKeyB64)) return keyCache.get(publicKeyB64)!;
-  const raw = b64ToArrayBuffer(publicKeyB64);
+async function importEd25519Key(publicKeyStr: string): Promise<CryptoKey> {
+  if (keyCache.has(publicKeyStr)) return keyCache.get(publicKeyStr)!;
+  // Accept hex (64-char) or base64 (44-char) encoded 32-byte Ed25519 public key
+  let raw: ArrayBuffer;
+  if (/^[0-9a-f]{64}$/i.test(publicKeyStr)) {
+    // Hex-encoded raw key (TPS CLI default: Buffer.toString('hex'))
+    const bytes = new Uint8Array(32);
+    for (let i = 0; i < 32; i++) bytes[i] = parseInt(publicKeyStr.slice(i * 2, i * 2 + 2), 16);
+    raw = bytes.buffer;
+  } else {
+    raw = b64ToArrayBuffer(publicKeyStr);
+  }
   const key = await crypto.subtle.importKey("raw", raw, { name: "Ed25519" } as any, false, ["verify"]);
-  keyCache.set(publicKeyB64, key);
+  keyCache.set(publicKeyStr, key);
   return key;
 }
 


### PR DESCRIPTION
Found during Anvil dogfooding. Two interrelated fixes:

**Flair (this PR):**
`importEd25519Key` used `atob()` (base64) but TPS CLI stores publicKey as hex (`Buffer.toString('hex')`). Fix: detect 64-char hex and decode manually. Base64 still works.

**CLI (tpsdev-ai/cli#70):**
`FlairClient.loadKey()` was parsing the raw 32-byte `.key` file as UTF-8 text. Fix: detect binary 32-byte seed files and build PKCS8 DER wrapper manually.

Together these make `tps agent create --id anvil` (and any new agent) work end-to-end with native TPS key files.