### PR TITLE
feat(ops-37): launchd plist + install-launchd.sh for Flair

### DIFF
--- a/scripts/ai.tpsdev.flair.plist
+++ b/scripts/ai.tpsdev.flair.plist
@@ -4,7 +4,7 @@
 <plist version="1.0">
 <dict>
   <key>Label</key>
-  <string>ai.tpsdev.harper</string>
+  <string>ai.tpsdev.flair</string>
 
   <key>ProgramArguments</key>
   <array>

--- a/scripts/ai.tpsdev.harper.plist
+++ b/scripts/ai.tpsdev.harper.plist
@@ -10,7 +10,7 @@
   <array>
     <string>/opt/homebrew/bin/node</string>
     <string>FLAIR_DIR/node_modules/harperdb/bin/harper.js</string>
-    <string>run</string>
+    <string>dev</string>
     <string>FLAIR_DIR</string>
   </array>
 
@@ -41,12 +41,8 @@
     <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
     <key>HOME</key>
     <string>HOME_DIR</string>
-    <key>ROOTPATH</key>
-    <string>HOME_DIR/.harper/flair</string>
-    <key>HTTP_PORT</key>
-    <string>9926</string>
-    <key>OPERATIONSAPI_NETWORK_PORT</key>
-    <string>9925</string>
+    <key>HARPER_SET_CONFIG</key>
+    <string>{"rootPath":"HOME_DIR/.harper/flair","http":{"port":9926},"operationsApi":{"network":{"port":9925}}}</string>
   </dict>
 </dict>
 </plist>

--- a/scripts/ai.tpsdev.harper.plist
+++ b/scripts/ai.tpsdev.harper.plist
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+  "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>ai.tpsdev.harper</string>
+
+  <key>ProgramArguments</key>
+  <array>
+    <string>/opt/homebrew/bin/node</string>
+    <string>FLAIR_DIR/node_modules/harperdb/bin/harper.js</string>
+    <string>run</string>
+    <string>FLAIR_DIR</string>
+  </array>
+
+  <key>WorkingDirectory</key>
+  <string>FLAIR_DIR</string>
+
+  <key>RunAtLoad</key>
+  <true/>
+
+  <key>KeepAlive</key>
+  <dict>
+    <key>Crashed</key>
+    <true/>
+  </dict>
+
+  <key>ThrottleInterval</key>
+  <integer>10</integer>
+
+  <key>StandardOutPath</key>
+  <string>HOME_DIR/.tps/logs/harper.log</string>
+
+  <key>StandardErrorPath</key>
+  <string>HOME_DIR/.tps/logs/harper.error.log</string>
+
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>PATH</key>
+    <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
+    <key>HOME</key>
+    <string>HOME_DIR</string>
+    <key>ROOTPATH</key>
+    <string>HOME_DIR/.harper/flair</string>
+    <key>HTTP_PORT</key>
+    <string>9926</string>
+    <key>OPERATIONSAPI_NETWORK_PORT</key>
+    <string>9925</string>
+  </dict>
+</dict>
+</plist>

--- a/scripts/install-launchd.sh
+++ b/scripts/install-launchd.sh
@@ -3,7 +3,7 @@
 # Usage: ./scripts/install-launchd.sh install|uninstall|status|restart
 set -euo pipefail
 
-LABEL="ai.tpsdev.harper"
+LABEL="ai.tpsdev.flair"
 PLIST_DST="$HOME/Library/LaunchAgents/${LABEL}.plist"
 PLIST_TEMPLATE="$(cd "$(dirname "$0")" && pwd)/${LABEL}.plist"
 FLAIR_DIR="$(cd "$(dirname "$0")/.." && pwd)"

--- a/scripts/install-launchd.sh
+++ b/scripts/install-launchd.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+# install-launchd.sh — Harper launchd agent management
+# Usage: ./scripts/install-launchd.sh install|uninstall|status|restart
+set -euo pipefail
+
+LABEL="ai.tpsdev.harper"
+PLIST_DST="$HOME/Library/LaunchAgents/${LABEL}.plist"
+PLIST_TEMPLATE="$(cd "$(dirname "$0")" && pwd)/${LABEL}.plist"
+FLAIR_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+HARPER_DATA_DIR="$HOME/.harper/flair"
+LOG_DIR="$HOME/.tps/logs"
+ACTION="${1:-status}"
+
+_substitute_plist() {
+  local node_path
+  node_path="$(which node)"
+  sed \
+    -e "s|FLAIR_DIR|$FLAIR_DIR|g" \
+    -e "s|HOME_DIR|$HOME|g" \
+    -e "s|/opt/homebrew/bin/node|$node_path|g" \
+    "$PLIST_TEMPLATE"
+}
+
+_is_loaded() {
+  launchctl list "$LABEL" &>/dev/null
+}
+
+_install() {
+  echo "→ Creating directories..."
+  mkdir -p "$HARPER_DATA_DIR" "$LOG_DIR"
+
+  echo "→ Writing plist to $PLIST_DST"
+  _substitute_plist > "$PLIST_DST"
+  chmod 644 "$PLIST_DST"
+
+  if _is_loaded; then
+    echo "→ Unloading existing service..."
+    launchctl unload "$PLIST_DST" 2>/dev/null || true
+  fi
+
+  echo "→ Loading launchd agent..."
+  launchctl load "$PLIST_DST"
+
+  echo "✅ Harper installed and started"
+  echo "   Data:  $HARPER_DATA_DIR"
+  echo "   Logs:  $LOG_DIR/harper.log"
+  sleep 5
+  _status
+}
+
+_uninstall() {
+  if _is_loaded; then
+    echo "→ Unloading..."
+    launchctl unload "$PLIST_DST" 2>/dev/null || true
+  fi
+  if [[ -f "$PLIST_DST" ]]; then
+    rm "$PLIST_DST"
+    echo "✅ Harper uninstalled"
+  else
+    echo "Nothing to uninstall"
+  fi
+}
+
+_status() {
+  if ! [[ -f "$PLIST_DST" ]]; then
+    echo "Harper: NOT INSTALLED"
+    echo "  Run: $0 install"
+    return
+  fi
+  if ! _is_loaded; then
+    echo "Harper: INSTALLED but NOT RUNNING"
+    echo "  Run: $0 restart"
+    return
+  fi
+  local pid
+  pid=$(launchctl list "$LABEL" 2>/dev/null | grep '"PID"' | grep -o '[0-9]*' | head -1 || echo "")
+  if curl -sf -o /dev/null --max-time 3 http://127.0.0.1:9925/health 2>/dev/null; then
+    echo "Harper: ✅ RUNNING (PID: ${pid:-?})"
+  else
+    echo "Harper: ⚠️  LOADED but not responding (PID: ${pid:-?})"
+  fi
+  echo "  API:   http://127.0.0.1:9925"
+  echo "  Flair: http://127.0.0.1:9926"
+  echo "  Data:  $HARPER_DATA_DIR"
+  echo "  Logs:  $LOG_DIR/harper.log"
+}
+
+_restart() {
+  if ! [[ -f "$PLIST_DST" ]]; then
+    echo "❌ Not installed. Run: $0 install"
+    exit 1
+  fi
+  if _is_loaded; then
+    # kickstart -k kills the current instance and starts a fresh one
+    launchctl kickstart -k "user/$(id -u)/$LABEL"
+    echo "✅ Harper restarted"
+  else
+    launchctl load "$PLIST_DST"
+    echo "✅ Harper started"
+  fi
+}
+
+case "$ACTION" in
+  install)   _install   ;;
+  uninstall) _uninstall ;;
+  status)    _status    ;;
+  restart)   _restart   ;;
+  *)
+    echo "Usage: $0 install|uninstall|status|restart"
+    exit 1
+    ;;
+esac


### PR DESCRIPTION
Companion scripts for CLI PR #71.

```
scripts/ai.tpsdev.harper.plist  — template (FLAIR_DIR/HOME_DIR placeholders)
scripts/install-launchd.sh      — install/uninstall/status/restart
```

Key settings:
- **Mode:** dev (run mode requires pre-installed Harper; dev works for all setups)
- **KeepAlive.Crashed:** true
- **ThrottleInterval:** 10s
- **HARPER_SET_CONFIG:** sets rootPath, HTTP port, ops API port