### PR TITLE
fix: rename SearchMemories -> FindMemories (Harper table prefix collision)

### DIFF
--- a/resources/FindMemories.ts
+++ b/resources/FindMemories.ts
@@ -8,7 +8,7 @@ function cosineSimilarity(a: number[], b: number[]): number {
   return dot;
 }
 
-export class SearchMemories extends Resource {
+export class FindMemories extends Resource {
   async post(data: any) {
     const { agentId, q, queryEmbedding, tag, limit = 10 } = data || {};
 


### PR DESCRIPTION
## Problem
Harper intercepts `POST /SearchMemories/` and validates it against the Memory table schema before the custom resource handler runs — returning 400 with Memory field requirements.

Root cause: custom resource class names must NOT use table-name prefixes. `SearchMemories` starts with `Memory`'s sibling name and triggers table-level validation.

## Fix
Rename `resources/MemorySearch.ts` + class `SearchMemories` → `resources/FindMemories.ts` + class `FindMemories`.

Verb-first naming (`Find`) avoids the prefix collision entirely.

## Paired PR
tpsdev-ai/cli#101 — updates `flair-client.ts` to call `/FindMemories/` instead of `/SearchMemories/`