### PR TITLE
feat(org): OrgEvent table, catchup endpoint, bootstrap events

### DIFF
--- a/resources/Agent.ts
+++ b/resources/Agent.ts
@@ -2,6 +2,7 @@ import { tables } from "harperdb";
 
 export class Agent extends (tables as any).Agent {
   async post(content: any, context: any) {
+    content.type ||= "agent";
     content.createdAt = new Date().toISOString();
     content.updatedAt = content.createdAt;
     return super.post(content, context);

--- a/resources/MemoryBootstrap.ts
+++ b/resources/MemoryBootstrap.ts
@@ -51,6 +51,7 @@ export class BootstrapMemories extends Resource {
       permanent: [],
       recent: [],
       relevant: [],
+      events: [],
     };
     let tokenBudget = maxTokens;
     let memoriesIncluded = 0;
@@ -152,6 +153,34 @@ export class BootstrapMemories extends Resource {
       }
     }
 
+    // --- 5. Recent OrgEvents for this agent ---
+    try {
+      const eventSince = data?.lastBootAt
+        ? new Date(data.lastBootAt)
+        : new Date(Date.now() - 24 * 3600_000);
+      const eventSinceStr = eventSince.toISOString();
+      const eventResults: any[] = [];
+
+      for await (const event of (tables as any).OrgEvent.search()) {
+        if (!event.createdAt || event.createdAt < eventSinceStr) continue;
+        if (event.expiresAt && new Date(event.expiresAt) < new Date()) continue;
+        const targets = event.targetIds;
+        const isRelevant = !targets || targets.length === 0 || targets.includes(agentId);
+        if (!isRelevant) continue;
+        eventResults.push(event);
+      }
+
+      eventResults.sort((a: any, b: any) => (a.createdAt || "").localeCompare(b.createdAt || ""));
+      for (const evt of eventResults.slice(0, 10)) {
+        const elapsed = Date.now() - new Date(evt.createdAt).getTime();
+        const mins = Math.floor(elapsed / 60_000);
+        const relTime = mins < 60 ? `${mins}min ago` : `${Math.floor(mins / 60)}h ago`;
+        sections.events.push(`- ${evt.kind}: ${evt.summary} (${relTime})`);
+      }
+    } catch {
+      // non-fatal: OrgEvent table may not exist yet
+    }
+
     // --- Build context string ---
     const parts: string[] = [];
 
@@ -167,6 +196,9 @@ export class BootstrapMemories extends Resource {
     if (sections.relevant.length > 0) {
       parts.push("## Relevant Knowledge\n" + sections.relevant.join("\n"));
     }
+    if (sections.events.length > 0) {
+      parts.push("## Recent Org Events\n" + sections.events.join("\n"));
+    }
 
     const context = parts.join("\n\n");
     const soulTokens = sections.soul.reduce((sum, line) => sum + estimateTokens(line), 0);
@@ -179,6 +211,7 @@ export class BootstrapMemories extends Resource {
         permanent: sections.permanent.length,
         recent: sections.recent.length,
         relevant: sections.relevant.length,
+        events: sections.events.length,
       },
       tokenEstimate: soulTokens + memoryTokens,
       soulTokens,

--- a/resources/OrgEvent.ts
+++ b/resources/OrgEvent.ts
@@ -1,0 +1,62 @@
+/**
+ * OrgEvent.ts — Harper table resource for org-wide activity events.
+ *
+ * Auth: Ed25519 middleware sets request.tpsAgent.
+ * Write: authorId must match authenticated agent (or admin).
+ * Read: any authenticated participant can read (org-scoped).
+ */
+
+import { tables } from "harperdb";
+
+export class OrgEvent extends (tables as any).OrgEvent {
+  async post(content: any, context?: any) {
+    const agentId = context?.request?.tpsAgent;
+
+    // authorId must match authenticated agent (unless admin)
+    if (agentId && !context?.request?.tpsAgentIsAdmin && content.authorId !== agentId) {
+      return new Response(
+        JSON.stringify({ error: "forbidden: authorId must match authenticated agent" }),
+        { status: 403, headers: { "Content-Type": "application/json" } },
+      );
+    }
+
+    // Generate composite ID if not provided
+    if (!content.id) {
+      content.id = `${content.authorId}-${Date.now()}`;
+    }
+
+    content.createdAt = new Date().toISOString();
+
+    return super.post(content, context);
+  }
+
+  async put(content: any, context?: any) {
+    const agentId = context?.request?.tpsAgent;
+
+    if (agentId && !context?.request?.tpsAgentIsAdmin && content.authorId !== agentId) {
+      return new Response(
+        JSON.stringify({ error: "forbidden: authorId must match authenticated agent" }),
+        { status: 403, headers: { "Content-Type": "application/json" } },
+      );
+    }
+
+    return super.put(content, context);
+  }
+
+  async delete(id: any, context?: any) {
+    const agentId = context?.request?.tpsAgent;
+    if (!agentId) return super.delete(id, context);
+
+    const record = await this.get(id);
+    if (!record) return super.delete(id, context);
+
+    if (!context?.request?.tpsAgentIsAdmin && record.authorId !== agentId) {
+      return new Response(
+        JSON.stringify({ error: "forbidden: cannot delete events authored by another agent" }),
+        { status: 403, headers: { "Content-Type": "application/json" } },
+      );
+    }
+
+    return super.delete(id, context);
+  }
+}

--- a/resources/OrgEventCatchup.ts
+++ b/resources/OrgEventCatchup.ts
@@ -1,0 +1,78 @@
+/**
+ * OrgEventCatchup.ts — Custom resource for filtered event retrieval.
+ *
+ * GET /OrgEventCatchup/{participantId}?since=<ISO timestamp>
+ *
+ * Returns events where:
+ *   - targetIds includes participantId OR targetIds is empty/null
+ *   - createdAt >= since
+ * Sorted by createdAt ascending (oldest first for in-order processing).
+ * Limit 50 events max.
+ */
+
+import { Resource, tables } from "harperdb";
+
+export class OrgEventCatchup extends Resource {
+  async get(query: any, context?: any) {
+    const agentId = context?.request?.tpsAgent;
+    const url = new URL(context?.request?.url ?? "", "http://localhost");
+    const pathParts = url.pathname.split("/").filter(Boolean);
+
+    // Extract participantId from URL path: /OrgEventCatchup/{participantId}
+    const participantId = pathParts[1] ? decodeURIComponent(pathParts[1]) : null;
+    if (!participantId) {
+      return new Response(
+        JSON.stringify({ error: "participantId required in path" }),
+        { status: 400, headers: { "Content-Type": "application/json" } },
+      );
+    }
+
+    // Auth: requesting agent must match participantId (or admin)
+    if (agentId && !context?.request?.tpsAgentIsAdmin && agentId !== participantId) {
+      return new Response(
+        JSON.stringify({ error: "forbidden: can only fetch events for yourself" }),
+        { status: 403, headers: { "Content-Type": "application/json" } },
+      );
+    }
+
+    const since = url.searchParams.get("since");
+    if (!since) {
+      return new Response(
+        JSON.stringify({ error: "since query parameter required (ISO timestamp)" }),
+        { status: 400, headers: { "Content-Type": "application/json" } },
+      );
+    }
+
+    const sinceDate = new Date(since);
+    if (isNaN(sinceDate.getTime())) {
+      return new Response(
+        JSON.stringify({ error: "invalid since timestamp" }),
+        { status: 400, headers: { "Content-Type": "application/json" } },
+      );
+    }
+
+    // Query all OrgEvents and filter in-memory
+    // Harper search doesn't support complex compound filters, so we scan + filter
+    const results: any[] = [];
+    for await (const event of (tables as any).OrgEvent.search()) {
+      // Filter by createdAt >= since
+      if (!event.createdAt || event.createdAt < since) continue;
+
+      // Filter by targetIds: includes participantId OR empty/null
+      const targets = event.targetIds;
+      const isTargeted = !targets || targets.length === 0 || targets.includes(participantId);
+      if (!isTargeted) continue;
+
+      // Skip expired events
+      if (event.expiresAt && new Date(event.expiresAt) < new Date()) continue;
+
+      results.push(event);
+    }
+
+    // Sort ascending by createdAt (oldest first)
+    results.sort((a: any, b: any) => (a.createdAt || "").localeCompare(b.createdAt || ""));
+
+    // Limit to 50
+    return results.slice(0, 50);
+  }
+}

--- a/resources/OrgEventMaintenance.ts
+++ b/resources/OrgEventMaintenance.ts
@@ -1,0 +1,37 @@
+/**
+ * OrgEventMaintenance.ts — Maintenance worker for expired OrgEvents.
+ *
+ * POST /OrgEventMaintenance/ — deletes all records where expiresAt < now.
+ * Auth: admin only.
+ */
+
+import { Resource, tables } from "harperdb";
+
+export class OrgEventMaintenance extends Resource {
+  async post(_data: any, context?: any) {
+    // Admin-only
+    if (!context?.request?.tpsAgentIsAdmin) {
+      return new Response(
+        JSON.stringify({ error: "forbidden: admin only" }),
+        { status: 403, headers: { "Content-Type": "application/json" } },
+      );
+    }
+
+    const now = new Date().toISOString();
+    const toDelete: string[] = [];
+
+    for await (const event of (tables as any).OrgEvent.search()) {
+      if (event.expiresAt && event.expiresAt < now) {
+        toDelete.push(event.id);
+      }
+    }
+
+    for (const id of toDelete) {
+      try {
+        await (tables as any).OrgEvent.delete(id);
+      } catch {}
+    }
+
+    return { deleted: toDelete.length };
+  }
+}

--- a/resources/auth-middleware.ts
+++ b/resources/auth-middleware.ts
@@ -168,6 +168,40 @@ server.http(async (request: any, nextLayer: any) => {
   const isMutation = method === "POST" || method === "PUT" || method === "PATCH" || method === "DELETE";
 
   if (isMutation) {
+    // OrgEvent: authorId must match authenticated agent
+    if ((url.pathname === "/OrgEvent" || url.pathname.startsWith("/OrgEvent/")) &&
+        (method === "POST" || method === "PUT" || method === "PATCH")) {
+      if (!request.tpsAgentIsAdmin) {
+        try {
+          const clone = request.clone();
+          const body = await clone.json();
+          if (body?.authorId && body.authorId !== agentId) {
+            return new Response(JSON.stringify({
+              error: "forbidden: authorId must match authenticated agent"
+            }), { status: 403 });
+          }
+        } catch {}
+      }
+    }
+
+    // OrgEvent DELETE: ownership check
+    if (url.pathname.startsWith("/OrgEvent/") && method === "DELETE") {
+      if (!request.tpsAgentIsAdmin) {
+        try {
+          const pathParts = url.pathname.split("/").filter(Boolean);
+          const eventId = pathParts[1] ? decodeURIComponent(pathParts[1]) : null;
+          if (eventId) {
+            const record = await (tables as any).OrgEvent.get(eventId);
+            if (record && record.authorId && record.authorId !== agentId) {
+              return new Response(JSON.stringify({
+                error: "forbidden: cannot delete events authored by another agent"
+              }), { status: 403 });
+            }
+          }
+        } catch {}
+      }
+    }
+
     // WorkspaceState: agent-scoped mutations (non-admin can only write own records)
     if ((url.pathname === "/WorkspaceState" || url.pathname.startsWith("/WorkspaceState/")) &&
         (method === "POST" || method === "PUT" || method === "PATCH")) {

--- a/schemas/agent.graphql
+++ b/schemas/agent.graphql
@@ -2,6 +2,7 @@ type Agent @table @export {
   id: ID @primaryKey
   name: String!
   role: String
+  type: String @indexed
   publicKey: String!
   createdAt: String!
   updatedAt: String

--- a/schemas/event.graphql
+++ b/schemas/event.graphql
@@ -1,0 +1,12 @@
+type OrgEvent @table @export {
+  id: ID @primaryKey
+  authorId: String! @indexed
+  kind: String! @indexed
+  scope: String @indexed
+  summary: String!
+  detail: String
+  targetIds: [String] @indexed
+  refId: String @indexed
+  createdAt: String! @indexed
+  expiresAt: String @indexed
+}


### PR DESCRIPTION
## Summary
- **OrgEvent** Harper table resource with authorId write-auth scoping and org-wide read access
- **OrgEventCatchup** custom resource: `GET /OrgEventCatchup/{participantId}?since=<ISO>` returns filtered events (targeted + broadcast), sorted ascending, max 50
- **OrgEventMaintenance** admin-only endpoint to clean up expired events (expiresAt < now)
- **MemoryBootstrap** enhanced with `## Recent Org Events` section (last 24h or since lastBootAt, max 10)
- **Agent schema** gains `type` field (default `'agent'`, supports `'human'`)
- **Auth middleware** gains OrgEvent write/delete guards

## Test plan
- [ ] `npm run build` passes (verified locally)
- [ ] POST /OrgEvent with matching authorId succeeds
- [ ] POST /OrgEvent with mismatched authorId returns 403
- [ ] GET /OrgEventCatchup/{id}?since=... returns filtered events
- [ ] POST /MemoryBootstrap includes events section when OrgEvents exist
- [ ] POST /OrgEventMaintenance deletes expired events (admin only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)