### PR TITLE
feat(skill): SkillScan resource + MemoryBootstrap skill assignments (ops-31.4)

### DIFF
--- a/resources/MemoryBootstrap.ts
+++ b/resources/MemoryBootstrap.ts
@@ -48,6 +48,7 @@ export class BootstrapMemories extends Resource {
 
     const sections: Record<string, string[]> = {
       soul: [],
+      skills: [],
       permanent: [],
       recent: [],
       relevant: [],
@@ -59,16 +60,54 @@ export class BootstrapMemories extends Resource {
 
     // --- 1. Soul records (unconditional — not subject to token budget) ---
     // Soul is who you are. It's not optional context to be trimmed.
+    // Skill assignments (key='skill-assignment') are separated into their own section.
+    const skillAssignments: any[] = [];
     if (includeSoul) {
       let soulTokens = 0;
       for await (const record of (tables as any).Soul.search()) {
         if (record.agentId !== agentId) continue;
+        if (record.key === "skill-assignment") {
+          skillAssignments.push(record);
+          continue;
+        }
         const line = `**${record.key}:** ${record.value}`;
         sections.soul.push(line);
         soulTokens += estimateTokens(line);
       }
       // Soul tokens are tracked but don't reduce memory budget
       tokenBudget = maxTokens; // memory budget is separate from soul
+    }
+
+    // --- 1b. Skill assignments (ordered by priority, conflict detection) ---
+    if (skillAssignments.length > 0) {
+      const priorityOrder: Record<string, number> = { critical: 0, high: 1, standard: 2, low: 3 };
+      skillAssignments.sort((a, b) => {
+        const pa = priorityOrder[a.priority ?? "standard"] ?? 2;
+        const pb = priorityOrder[b.priority ?? "standard"] ?? 2;
+        return pa - pb;
+      });
+
+      // Detect conflicts at same priority level
+      const byPriority = new Map<string, any[]>();
+      for (const skill of skillAssignments) {
+        const p = skill.priority ?? "standard";
+        if (!byPriority.has(p)) byPriority.set(p, []);
+        byPriority.get(p)!.push(skill);
+      }
+
+      for (const skill of skillAssignments) {
+        const p = skill.priority ?? "standard";
+        let meta: any = {};
+        try { meta = typeof skill.metadata === "string" ? JSON.parse(skill.metadata) : (skill.metadata ?? {}); } catch {}
+        const source = meta.source ? `, source: ${meta.source}` : "";
+        let line = `- ${skill.value} (${p} priority${source})`;
+        // Flag conflicts at same priority level
+        const peers = byPriority.get(p) ?? [];
+        if (peers.length > 1) {
+          line += " [SKILL_CONFLICT]";
+        }
+        sections.skills.push(line);
+      }
     }
 
     // --- 2. Permanent memories (always included, highest priority) ---
@@ -187,6 +226,9 @@ export class BootstrapMemories extends Resource {
     if (sections.soul.length > 0) {
       parts.push("## Identity\n" + sections.soul.join("\n"));
     }
+    if (sections.skills.length > 0) {
+      parts.push("## Active Skills\n" + sections.skills.join("\n"));
+    }
     if (sections.permanent.length > 0) {
       parts.push("## Core Principles\n" + sections.permanent.join("\n"));
     }
@@ -208,6 +250,7 @@ export class BootstrapMemories extends Resource {
       context,
       sections: {
         soul: sections.soul.length,
+        skills: sections.skills.length,
         permanent: sections.permanent.length,
         recent: sections.recent.length,
         relevant: sections.relevant.length,

--- a/resources/SkillScan.ts
+++ b/resources/SkillScan.ts
@@ -1,0 +1,146 @@
+import { Resource } from "harperdb";
+
+/**
+ * POST /SkillScan/
+ *
+ * Static analysis of skill content for security violations.
+ * Scans for shell commands, network calls, fs writes, env access,
+ * encoded payloads, zero-width chars, and homoglyphs.
+ *
+ * Request:  { content: string }
+ * Response: { safe, violations, riskLevel }
+ *
+ * Auth: any authenticated agent (read-only analysis).
+ * Size limit: 8KB (8192 bytes).
+ */
+
+interface Violation {
+  type: string;
+  line: number;
+  content: string;
+}
+
+type RiskLevel = "low" | "medium" | "high" | "critical";
+
+const SHELL_PATTERNS = [
+  { regex: /\bexec\s*\(/, type: "shell_command" },
+  { regex: /\bspawn\s*\(/, type: "shell_command" },
+  { regex: /\bsystem\s*\(/, type: "shell_command" },
+  { regex: /`[^`]*`/, type: "shell_backtick" },
+  { regex: /\bchild_process\b/, type: "shell_command" },
+];
+
+const NETWORK_PATTERNS = [
+  { regex: /\bfetch\s*\(/, type: "network_call" },
+  { regex: /\bcurl\b/, type: "network_call" },
+  { regex: /https?:\/\//, type: "url_reference" },
+  { regex: /\bXMLHttpRequest\b/, type: "network_call" },
+  { regex: /\baxios\b/, type: "network_call" },
+];
+
+const FS_PATTERNS = [
+  { regex: /\bfs\.write/, type: "fs_write" },
+  { regex: /\bwriteFile/, type: "fs_write" },
+  { regex: />[>]?\s*[\/~]/, type: "fs_redirect" },
+];
+
+const ENV_PATTERNS = [
+  { regex: /\bprocess\.env\b/, type: "env_access" },
+  { regex: /\$ENV\b/, type: "env_access" },
+  { regex: /\$\{?\w+\}?/, type: "env_variable" },
+];
+
+const ENCODING_PATTERNS = [
+  { regex: /\batob\s*\(/, type: "base64_decode" },
+  { regex: /\bbtoa\s*\(/, type: "base64_encode" },
+  { regex: /Buffer\.from\s*\([^)]*,\s*['"]base64['"]/, type: "base64_decode" },
+  { regex: /Buffer\.from\s*\([^)]*,\s*['"]hex['"]/, type: "hex_decode" },
+  { regex: /\\x[0-9a-fA-F]{2}/, type: "hex_escape" },
+  { regex: /\\u200[b-f]|\\u2060|\\ufeff/, type: "zero_width_char" },
+];
+
+// Unicode zero-width and homoglyph detection (raw chars)
+const UNICODE_PATTERNS = [
+  { regex: /[\u200B-\u200F\u2060\uFEFF]/, type: "zero_width_char" },
+  { regex: /[\u0410-\u044F]/, type: "cyrillic_homoglyph" },  // Cyrillic chars that look like Latin
+];
+
+const ALL_PATTERNS = [
+  ...SHELL_PATTERNS,
+  ...NETWORK_PATTERNS,
+  ...FS_PATTERNS,
+  ...ENV_PATTERNS,
+  ...ENCODING_PATTERNS,
+  ...UNICODE_PATTERNS,
+];
+
+function assessRisk(violations: Violation[]): RiskLevel {
+  if (violations.length === 0) return "low";
+
+  const types = new Set(violations.map((v) => v.type));
+  const hasShell = types.has("shell_command") || types.has("shell_backtick");
+  const hasNetwork = types.has("network_call");
+  const hasFs = types.has("fs_write") || types.has("fs_redirect");
+  const hasZeroWidth = types.has("zero_width_char");
+  const hasHomoglyph = types.has("cyrillic_homoglyph");
+
+  // Critical: shell + encoding, or zero-width/homoglyph obfuscation
+  if ((hasShell && (types.has("base64_decode") || types.has("hex_decode"))) ||
+      hasZeroWidth || hasHomoglyph) {
+    return "critical";
+  }
+
+  // High: direct shell commands or fs writes
+  if (hasShell || hasFs) return "high";
+
+  // Medium: network calls or encoding without shell
+  if (hasNetwork || types.has("base64_decode") || types.has("hex_decode")) return "medium";
+
+  return "low";
+}
+
+export class SkillScan extends Resource {
+  async post(data: any, context?: any) {
+    const { content } = data || {};
+
+    if (!content || typeof content !== "string") {
+      return new Response(
+        JSON.stringify({ error: "content (string) required" }),
+        { status: 400, headers: { "Content-Type": "application/json" } },
+      );
+    }
+
+    // 8KB size limit
+    const byteLength = new TextEncoder().encode(content).length;
+    if (byteLength > 8192) {
+      return new Response(
+        JSON.stringify({ error: `Content exceeds 8KB limit (${byteLength} bytes)` }),
+        { status: 413, headers: { "Content-Type": "application/json" } },
+      );
+    }
+
+    const lines = content.split("\n");
+    const violations: Violation[] = [];
+
+    for (let i = 0; i < lines.length; i++) {
+      const line = lines[i];
+      for (const pattern of ALL_PATTERNS) {
+        if (pattern.regex.test(line)) {
+          violations.push({
+            type: pattern.type,
+            line: i + 1,
+            content: line.trim().slice(0, 200),
+          });
+        }
+      }
+    }
+
+    const riskLevel = assessRisk(violations);
+
+    return {
+      safe: violations.length === 0,
+      violations,
+      riskLevel,
+    };
+  }
+}

--- a/schemas/memory.graphql
+++ b/schemas/memory.graphql
@@ -30,6 +30,8 @@ type Soul @table {
   agentId: String! @indexed
   key: String! @indexed
   value: String!
+  priority: String              # critical | high | standard | low (skill governance)
+  metadata: String              # JSON blob (skill governance: source, version, hash, etc.)
   durability: String @indexed
   createdAt: String!
   updatedAt: String


### PR DESCRIPTION
## Summary
- **SkillScan resource**: POST `/SkillScan/` static analysis endpoint — scans skill content for shell commands, network calls, fs writes, env access, encoded payloads, zero-width chars, and homoglyphs. Returns `{ safe, violations, riskLevel }`. Enforces 8KB size limit.
- **MemoryBootstrap update**: Fetches `skill-assignment` Soul records, orders by priority (critical > high > standard > low), detects conflicts at same priority level with `[SKILL_CONFLICT]` marker, renders as `## Active Skills` section between Identity and Core Principles.
- **Soul schema**: Added `priority` and `metadata` fields to support skill governance.

## Test plan
- [ ] POST `/SkillScan/` with clean content → `{ safe: true, riskLevel: "low" }`
- [ ] POST `/SkillScan/` with `exec()` → violation detected, riskLevel "high"
- [ ] POST `/SkillScan/` with zero-width chars → riskLevel "critical"
- [ ] POST `/SkillScan/` with >8KB content → 413 rejection
- [ ] POST `/MemoryBootstrap/` with skill-assignment Soul records → `## Active Skills` section in context
- [ ] Multiple skills at same priority → `[SKILL_CONFLICT]` markers
- [ ] Skills ordered by priority in output

🤖 Generated with [Claude Code](https://claude.com/claude-code)