### PR TITLE
feat(ops-57): AgentCard resource — A2A agent discovery endpoint

### DIFF
--- a/resources/AgentCard.ts
+++ b/resources/AgentCard.ts
@@ -1,0 +1,65 @@
+import { Resource, tables } from "harperdb";
+
+type SoulLike = {
+  key?: string;
+  value?: string;
+  kind?: string;
+  content?: string;
+};
+
+function readSoulKind(entry: SoulLike): string {
+  return String(entry.kind ?? entry.key ?? "").trim().toLowerCase();
+}
+
+function readSoulContent(entry: SoulLike): string {
+  return String(entry.content ?? entry.value ?? "").trim();
+}
+
+export class AgentCard extends Resource {
+  async get(pathInfo?: any) {
+    const agentId =
+      (typeof pathInfo === "string" ? pathInfo : null) ??
+      (this as any).getId?.() ??
+      null;
+
+    if (!agentId) {
+      return new Response(
+        JSON.stringify({ error: "agentId required in path: GET /AgentCard/{agentId}" }),
+        { status: 400, headers: { "Content-Type": "application/json" } },
+      );
+    }
+
+    const agent = await (tables as any).Agent.get(agentId).catch(() => null);
+    if (!agent) {
+      return new Response(JSON.stringify({ error: "agent_not_found", agentId }), {
+        status: 404,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+
+    const souls: SoulLike[] = [];
+    for await (const row of (tables as any).Soul.search()) {
+      if (row?.agentId === agentId) souls.push(row);
+    }
+
+    const descriptionEntry =
+      souls.find((s) => readSoulKind(s) === "description" && readSoulContent(s)) ??
+      souls.find((s) => readSoulContent(s));
+
+    const skills = souls
+      .filter((s) => readSoulKind(s) === "capability")
+      .map((s) => readSoulContent(s))
+      .filter(Boolean);
+
+    return {
+      name: String(agent.name ?? agent.id ?? agentId),
+      description: descriptionEntry ? readSoulContent(descriptionEntry) : "",
+      url: String(agent.url ?? ""),
+      version: String(agent.version ?? "1.0.0"),
+      capabilities: agent.capabilities && typeof agent.capabilities === "object" ? agent.capabilities : {},
+      skills,
+      defaultInputModes: ["text"],
+      defaultOutputModes: ["text"],
+    };
+  }
+}

--- a/resources/auth-middleware.ts
+++ b/resources/auth-middleware.ts
@@ -109,7 +109,12 @@ async function backfillEmbedding(memoryId: string): Promise<void> {
 server.http(async (request: any, nextLayer: any) => {
   const url = new URL(request.url, "http://" + (request.headers.get("host") || "localhost"));
 
-  if (url.pathname === "/health" || url.pathname === "/Health") return nextLayer(request);
+  if (
+    url.pathname === "/health" ||
+    url.pathname === "/Health" ||
+    url.pathname === "/AgentCard" ||
+    url.pathname.startsWith("/AgentCard/")
+  ) return nextLayer(request);
 
   // Skip re-entry: if we already swapped auth to Basic, pass through
   if ((request as any)._tpsAuthVerified) return nextLayer(request);


### PR DESCRIPTION
**Implemented by Ember (GPT-5 via Codex), reviewed by Anvil.** Supersedes #24 (stripped stale flair-activity.mjs commit).

Adds `GET /AgentCard/{agentId}` — A2A Phase 1 from ops-52.

**`resources/AgentCard.ts`** (new, 71 lines):
- Extends `Resource` (read-only projection, not a table)
- Looks up Agent record + iterates Soul entries for the agentId
- Returns A2A Agent Card JSON: `name`, `description`, `url`, `version`, `capabilities`, `skills[]`, `defaultInputModes`, `defaultOutputModes`
- 400 if no agentId, 404 if agent not found
- Note: Soul.search() iterates all souls + JS-side filter — fine for <100 records; can add agentId query index later

**`resources/auth-middleware.ts`**:
- Adds `/AgentCard` paths to auth bypass (public discovery, no Ed25519 required)

Build clean. Closes ops-57.