### PR TITLE
fix: A2AAdapter body parsing — content is first arg

### DIFF
--- a/resources/A2AAdapter.ts
+++ b/resources/A2AAdapter.ts
@@ -294,8 +294,8 @@ function statusFromOrgEvent(event: any): string | null {
 }
 
 export class A2AAdapter extends Resource {
-  async post(targetOrData: any, maybeData?: any) {
-    const body: JsonRpcRequest = (maybeData ?? targetOrData) as JsonRpcRequest;
+  async post(content: any, _context?: any) {
+    const body: JsonRpcRequest = content as JsonRpcRequest;
 
     if (!body || typeof body !== "object") {
       return rpcError(null, -32600, "Invalid Request");


### PR DESCRIPTION
**Critical dogfood fix.** Harper passes POST body as first arg, context as second. A2AAdapter was picking up context object instead of JSON-RPC body, causing ALL requests to fail with 'Invalid Request'.

Verified end-to-end:
- `message/send` ✅ creates OrgEvent
- `tasks/list` ✅ returns 29 tasks from Beads
- `tasks/get` ✅ returns task with correct A2A status mapping

This is exactly what Nathan said: dogfood before announce.