### PR TITLE
feat: GET /a2a — A2A discovery endpoint

### DIFF
--- a/resources/A2AAdapter.ts
+++ b/resources/A2AAdapter.ts
@@ -294,6 +294,37 @@ function statusFromOrgEvent(event: any): string | null {
 }
 
 export class A2AAdapter extends Resource {
+  async get() {
+    const host = process.env.FLAIR_PUBLIC_URL || "http://localhost:9926";
+    return new Response(JSON.stringify({
+      name: "TPS Agent Team",
+      description: "TPS — agent OS for humans and AI agents. Coordinates via Flair.",
+      url: `${host}/a2a`,
+      version: "0.1.0",
+      capabilities: {
+        streaming: true,
+        pushNotifications: false,
+      },
+      defaultInputModes: ["text"],
+      defaultOutputModes: ["text"],
+      skills: [
+        {
+          id: "task-management",
+          name: "Task Management",
+          description: "Create, list, and track tasks via Beads issue tracker",
+        },
+        {
+          id: "agent-coordination",
+          name: "Agent Coordination", 
+          description: "Send messages to agents and coordinate work via OrgEvents",
+        },
+      ],
+    }, null, 2), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
   async post(content: any, _context?: any) {
     const body: JsonRpcRequest = content as JsonRpcRequest;
 


### PR DESCRIPTION
A2A spec requires a discovery endpoint. Harper can't serve `/.well-known/agent.json` (routing by class name), so `GET /a2a` returns the agent discovery card instead.

- `GET /a2a` → discovery card (name, capabilities, skills, endpoint URL)
- `POST /a2a` → JSON-RPC (unchanged)

Stacks on flair/#29 (body parsing fix). Production `.well-known` will be handled by reverse proxy.

Verified: both GET and POST work on live Harper.