### PR TITLE
fix: OrgEvent POST broken on Harper 5 — use tables.put() directly

### DIFF
--- a/resources/OrgEvent.ts
+++ b/resources/OrgEvent.ts
@@ -27,7 +27,8 @@ export class OrgEvent extends (tables as any).OrgEvent {
 
     content.createdAt = new Date().toISOString();
 
-    return super.post(content, context);
+    // Harper 5: table resources use put() for create/upsert (post() removed)
+    return (tables as any).OrgEvent.put(content);
   }
 
   async put(content: any, context?: any) {
@@ -40,7 +41,7 @@ export class OrgEvent extends (tables as any).OrgEvent {
       );
     }
 
-    return super.put(content, context);
+    return (tables as any).OrgEvent.put(content);
   }
 
   async delete(id: any, context?: any) {


### PR DESCRIPTION
Harper 5 removed `post()` from the table resource base class. `super.post()` threw 'does not have a post method implemented'.

Fix: `OrgEvent.post()` now calls `tables.OrgEvent.put(content)` directly after enriching with ID and createdAt.

Verified: `POST /OrgEvent` returns 204. Discovered during A2A dogfood testing.