### PR TITLE
feat: content-hash dedup for FeedMemories (ops-65)

### DIFF
--- a/resources/MemoryFeed.ts
+++ b/resources/MemoryFeed.ts
@@ -1,9 +1,42 @@
-import { Resource, tables } from 'harperdb';
+import { Resource, tables } from "harperdb";
+import { computeContentHash, findExistingMemoryByContentHash } from "./memory-feed-lib.js";
 
 export class FeedMemories extends Resource {
+  async post(content: any) {
+    const agentId = String(content?.agentId ?? "");
+    const body = String(content?.content ?? "");
+    if (!agentId || !body) {
+      return new Response(JSON.stringify({ error: "agentId and content are required" }), {
+        status: 400,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+
+    const now = new Date().toISOString();
+    const contentHash = computeContentHash(agentId, body);
+
+    const existing = await findExistingMemoryByContentHash((tables as any).Memory.search(), agentId, contentHash);
+    if (existing) return existing;
+
+    const record = {
+      ...content,
+      id: content.id ?? `${agentId}-${Date.now()}`,
+      agentId,
+      content: body,
+      contentHash,
+      durability: content.durability ?? "standard",
+      createdAt: content.createdAt ?? now,
+      updatedAt: content.updatedAt ?? now,
+      archived: content.archived ?? false,
+    };
+
+    await (tables as any).Memory.put(record);
+    return record;
+  }
+
   async *connect(target: any, incomingMessages: any) {
     const subscription = await (tables as any).Memory.subscribe(target);
-    
+
     if (!incomingMessages) {
       return subscription;
     }

--- a/resources/memory-feed-lib.ts
+++ b/resources/memory-feed-lib.ts
@@ -1,0 +1,22 @@
+import { createHash } from "node:crypto";
+
+export function computeContentHash(agentId: string, content: string): string {
+  return createHash("sha256")
+    .update(`${agentId}${content}`)
+    .digest("hex")
+    .slice(0, 16);
+}
+
+export async function findExistingMemoryByContentHash(
+  records: AsyncIterable<any> | Iterable<any>,
+  agentId: string,
+  contentHash: string,
+): Promise<any | null> {
+  for await (const record of records) {
+    if (record?.agentId === agentId && record?.contentHash === contentHash) {
+      return record;
+    }
+  }
+
+  return null;
+}

--- a/schemas/memory.graphql
+++ b/schemas/memory.graphql
@@ -2,6 +2,7 @@ type Memory @table {
   id: ID @primaryKey
   agentId: String! @indexed
   content: String!
+  contentHash: String @indexed
   visibility: String
   embedding: [Float] @indexed(type: "HNSW")
   tags: [String] @indexed

--- a/test/unit/memory-feed-lib.test.ts
+++ b/test/unit/memory-feed-lib.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, test } from "bun:test";
+import { computeContentHash, findExistingMemoryByContentHash } from "../../resources/memory-feed-lib";
+
+describe("memory-feed-lib", () => {
+  test("computes a stable 16-char content hash from agentId and content", () => {
+    const hash = computeContentHash("ember", "dedup me");
+
+    expect(hash).toHaveLength(16);
+    expect(hash).toBe(computeContentHash("ember", "dedup me"));
+    expect(hash).not.toBe(computeContentHash("anvil", "dedup me"));
+  });
+
+  test("finds an existing memory only for the matching agent and hash", async () => {
+    const emberHash = computeContentHash("ember", "same memory");
+    const anvilHash = computeContentHash("anvil", "same memory");
+    const existing = await findExistingMemoryByContentHash(
+      [
+        { id: "other-agent", agentId: "anvil", contentHash: anvilHash },
+        { id: "match", agentId: "ember", contentHash: emberHash },
+      ],
+      "ember",
+      emberHash,
+    );
+
+    expect(existing?.id).toBe("match");
+  });
+
+  test("returns null when no duplicate exists", async () => {
+    const existing = await findExistingMemoryByContentHash(
+      [{ id: "mem-1", agentId: "ember", contentHash: "aaaaaaaaaaaaaaaa" }],
+      "ember",
+      "bbbbbbbbbbbbbbbb",
+    );
+
+    expect(existing).toBeNull();
+  });
+});


### PR DESCRIPTION
Ember implemented via Flair task loop. SHA-256(agentId + content) → 16-char contentHash. Deduplicates on insert. 3 unit tests, build clean.

Note: Ember couldn't git commit due to sandbox .git write restriction. Anvil committed on Ember's behalf.

Also: Flair repo needs `~/ops/flair` added to Ember's `extraDirs` with git write access, or sandbox policy needs adjustment for .git operations.