### PR TITLE
feat: observatory-sync — Flair → Observatory push plugin (ops-64)

### DIFF
--- a/src/observatory-sync.ts
+++ b/src/observatory-sync.ts
@@ -1,0 +1,255 @@
+/**
+ * observatory-sync.ts — Flair → Observatory push plugin
+ *
+ * Polls local Flair for OrgEvents + agent statuses every syncIntervalMs,
+ * then POSTs a batch to the Observatory IngestEvents endpoint with Ed25519 auth.
+ *
+ * Config (env vars or constructor options):
+ *   OBSERVATORY_URL        — e.g. https://tps-observatory.harperdbcloud.com
+ *   OBSERVATORY_OFFICE_ID  — e.g. "rockit"
+ *   OBSERVATORY_KEY_PATH   — path to Ed25519 private key (raw 32-byte seed)
+ *   FLAIR_URL              — local Flair base URL (default http://127.0.0.1:9926)
+ *   OBSERVATORY_INTERVAL_MS — sync interval (default 60000)
+ *
+ * Usage:
+ *   // Run as standalone script:
+ *   bun ~/ops/flair/src/observatory-sync.ts
+ *
+ *   // Or import and start:
+ *   import { ObservatorySync } from "./observatory-sync.js";
+ *   const sync = new ObservatorySync({ officeId: "rockit", ... });
+ *   await sync.start();
+ */
+
+import { createPrivateKey, sign } from "node:crypto";
+import { existsSync, readFileSync, writeFileSync, mkdirSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { homedir } from "node:os";
+
+export interface ObservatorySyncConfig {
+  observatoryUrl: string;
+  officeId: string;
+  keyPath: string;
+  flairUrl?: string;
+  syncIntervalMs?: number;
+  cursorPath?: string;
+  flairAgentId?: string;    // which agent identity to use for local Flair auth
+  flairKeyPath?: string;    // key for authenticating to local Flair
+}
+
+export interface OrgEventRecord {
+  id: string;
+  kind: string;
+  authorId: string;
+  summary: string;
+  refId?: string;
+  scope?: string;
+  targetIds?: string[];
+  createdAt: string;
+}
+
+export interface AgentStatus {
+  agentId: string;
+  name?: string;
+  role?: string;
+  status?: string;
+  model?: string;
+  lastSeen?: string;
+}
+
+export interface IngestPayload {
+  officeId: string;
+  events: OrgEventRecord[];
+  agents: AgentStatus[];
+  syncedAt: string;
+}
+
+export class ObservatorySync {
+  private config: Required<ObservatorySyncConfig>;
+  private privKey: ReturnType<typeof createPrivateKey> | null = null;
+  private flairPrivKey: ReturnType<typeof createPrivateKey> | null = null;
+  private running = false;
+
+  constructor(config: ObservatorySyncConfig) {
+    this.config = {
+      flairUrl: process.env.FLAIR_URL ?? "http://127.0.0.1:9926",
+      syncIntervalMs: Number(process.env.OBSERVATORY_INTERVAL_MS ?? 60_000),
+      cursorPath: join(homedir(), ".tps", "cursors", `${config.officeId}-observatory.json`),
+      flairAgentId: config.officeId,
+      flairKeyPath: config.keyPath,
+      ...config,
+    };
+  }
+
+  private loadKey(keyPath: string): ReturnType<typeof createPrivateKey> {
+    const raw = readFileSync(keyPath);
+    try {
+      return createPrivateKey(raw);
+    } catch {
+      const pkcs8Header = Buffer.from("302e020100300506032b657004220420", "hex");
+      return createPrivateKey({
+        key: Buffer.concat([pkcs8Header, Buffer.from(raw)]),
+        format: "der",
+        type: "pkcs8",
+      });
+    }
+  }
+
+  private makeObsAuth(method: string, urlPath: string): string {
+    if (!this.privKey) this.privKey = this.loadKey(this.config.keyPath);
+    const ts = Date.now().toString();
+    const nonce = Math.random().toString(36).slice(2, 10);
+    const payload = `${this.config.officeId}:${ts}:${nonce}:${method}:${urlPath}`;
+    const sig = sign(null, Buffer.from(payload), this.privKey).toString("base64");
+    return `TPS-Ed25519 ${this.config.officeId}:${ts}:${nonce}:${sig}`;
+  }
+
+  private makeFlairAuth(method: string, urlPath: string): string {
+    if (!this.flairPrivKey) this.flairPrivKey = this.loadKey(this.config.flairKeyPath);
+    const agentId = this.config.flairAgentId;
+    const ts = Date.now().toString();
+    const nonce = Math.random().toString(36).slice(2, 10);
+    const payload = `${agentId}:${ts}:${nonce}:${method}:${urlPath}`;
+    const sig = sign(null, Buffer.from(payload), this.flairPrivKey).toString("base64");
+    return `TPS-Ed25519 ${agentId}:${ts}:${nonce}:${sig}`;
+  }
+
+  private readCursor(): string {
+    try {
+      if (existsSync(this.config.cursorPath)) {
+        const data = JSON.parse(readFileSync(this.config.cursorPath, "utf-8"));
+        return data.since ?? new Date(Date.now() - 60 * 60 * 1000).toISOString().replace(/Z$/, ".000Z");
+      }
+    } catch { /* fall through */ }
+    // Default: last hour
+    return new Date(Date.now() - 60 * 60 * 1000).toISOString().replace(/Z$/, ".000Z");
+  }
+
+  private writeCursor(since: string): void {
+    mkdirSync(dirname(this.config.cursorPath), { recursive: true });
+    writeFileSync(this.config.cursorPath, JSON.stringify({ since, updatedAt: new Date().toISOString() }), "utf-8");
+  }
+
+  private async fetchEvents(since: string): Promise<OrgEventRecord[]> {
+    const urlPath = `/OrgEventCatchup/${this.config.flairAgentId}?since=${since}`;
+    const res = await fetch(this.config.flairUrl + urlPath, {
+      headers: { Authorization: this.makeFlairAuth("GET", urlPath) },
+    });
+    if (!res.ok) {
+      console.warn(`[observatory-sync] OrgEventCatchup returned ${res.status}`);
+      return [];
+    }
+    return res.json() as Promise<OrgEventRecord[]>;
+  }
+
+  private async fetchAgents(): Promise<AgentStatus[]> {
+    const urlPath = "/Agent/";
+    const res = await fetch(this.config.flairUrl + urlPath, {
+      headers: { Authorization: this.makeFlairAuth("GET", urlPath) },
+    });
+    if (!res.ok) {
+      console.warn(`[observatory-sync] Agent list returned ${res.status}`);
+      return [];
+    }
+    const raw = await res.json() as Array<Record<string, unknown>>;
+    return raw.map((a) => ({
+      agentId: String(a.id ?? a.agentId ?? ""),
+      name: a.name ? String(a.name) : undefined,
+      role: a.role ? String(a.role) : undefined,
+      status: a.status ? String(a.status) : undefined,
+      lastSeen: a.updatedAt ? String(a.updatedAt) : undefined,
+    }));
+  }
+
+  private async ingest(payload: IngestPayload): Promise<boolean> {
+    const urlPath = "/IngestEvents";
+    try {
+      const res = await fetch(this.config.observatoryUrl + urlPath, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: this.makeObsAuth("POST", urlPath),
+        },
+        body: JSON.stringify(payload),
+      });
+      if (!res.ok) {
+        console.warn(`[observatory-sync] IngestEvents returned ${res.status}: ${await res.text().catch(() => "")}`);
+        return false;
+      }
+      return true;
+    } catch (e) {
+      const err = e as Error;
+      console.warn(`[observatory-sync] IngestEvents failed: ${err.message}`);
+      return false;
+    }
+  }
+
+  async syncOnce(): Promise<{ events: number; agents: number; ok: boolean }> {
+    const since = this.readCursor();
+    const [events, agents] = await Promise.all([
+      this.fetchEvents(since),
+      this.fetchAgents(),
+    ]);
+
+    if (events.length === 0 && agents.length === 0) {
+      return { events: 0, agents: 0, ok: true };
+    }
+
+    const payload: IngestPayload = {
+      officeId: this.config.officeId,
+      events,
+      agents,
+      syncedAt: new Date().toISOString(),
+    };
+
+    const ok = await this.ingest(payload);
+    if (ok && events.length > 0) {
+      // Advance cursor to last event's createdAt
+      const latest = events[events.length - 1].createdAt;
+      // Add 1ms to avoid re-fetching the last event
+            const next = new Date(new Date(latest).getTime() + 1).toISOString();
+      this.writeCursor(next);
+    }
+
+    return { events: events.length, agents: agents.length, ok };
+  }
+
+  async start(): Promise<void> {
+    this.running = true;
+    console.log(`[observatory-sync] Starting — office=${this.config.officeId} interval=${this.config.syncIntervalMs}ms`);
+    console.log(`[observatory-sync] Target: ${this.config.observatoryUrl}`);
+
+    // Sync immediately, then on interval
+    while (this.running) {
+      try {
+        const result = await this.syncOnce();
+        if (result.events > 0 || result.agents > 0) {
+          console.log(`[observatory-sync] Synced ${result.events} events, ${result.agents} agents → ${result.ok ? "ok" : "failed"}`);
+        }
+      } catch (e) {
+        const err = e as Error;
+        console.warn(`[observatory-sync] Sync error: ${err.message}`);
+      }
+      await new Promise<void>((resolve) => setTimeout(resolve, this.config.syncIntervalMs));
+    }
+  }
+
+  stop(): void {
+    this.running = false;
+  }
+}
+
+// Standalone entry point
+if (import.meta.main) {
+  const observatoryUrl = process.env.OBSERVATORY_URL;
+  const officeId = process.env.OBSERVATORY_OFFICE_ID;
+  const keyPath = process.env.OBSERVATORY_KEY_PATH ?? join(homedir(), ".tps", "identity", `${officeId}.key`);
+
+  if (!observatoryUrl || !officeId) {
+    console.error("Required: OBSERVATORY_URL and OBSERVATORY_OFFICE_ID env vars");
+    process.exit(1);
+  }
+
+  const sync = new ObservatorySync({ observatoryUrl, officeId, keyPath });
+  await sync.start();
+}

--- a/test/observatory-sync.test.ts
+++ b/test/observatory-sync.test.ts
@@ -1,0 +1,172 @@
+import { describe, test, expect, beforeEach, afterEach, mock } from "bun:test";
+import { mkdtempSync, rmSync, existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { generateKeyPairSync } from "node:crypto";
+import { ObservatorySync, type OrgEventRecord, type AgentStatus } from "../src/observatory-sync.js";
+
+// Generate a real Ed25519 key for testing
+function makeTestKey(dir: string): string {
+  const keyPath = join(dir, "test.key");
+  const { privateKey } = generateKeyPairSync("ed25519");
+  const der = privateKey.export({ type: "pkcs8", format: "der" }) as Buffer;
+  const { writeFileSync } = require("node:fs");
+  writeFileSync(keyPath, der.subarray(16), { mode: 0o600 });
+  return keyPath;
+}
+
+describe("ObservatorySync", () => {
+  let tmpDir: string;
+  let keyPath: string;
+  let fetchCalls: Array<{ url: string; method: string; body?: unknown }>;
+  let originalFetch: typeof globalThis.fetch;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), "obs-sync-test-"));
+    keyPath = makeTestKey(tmpDir);
+    fetchCalls = [];
+    originalFetch = globalThis.fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  function mockFetch(handlers: Record<string, { status: number; body: unknown }>) {
+    globalThis.fetch = mock(async (url: string, opts?: RequestInit) => {
+      fetchCalls.push({ url: String(url), method: opts?.method ?? "GET", body: opts?.body });
+      for (const [pattern, resp] of Object.entries(handlers)) {
+        if (String(url).includes(pattern)) {
+          return new Response(JSON.stringify(resp.body), {
+            status: resp.status,
+            headers: { "Content-Type": "application/json" },
+          });
+        }
+      }
+      return new Response("{}", { status: 404 });
+    }) as typeof globalThis.fetch;
+  }
+
+  test("syncOnce: fetches events + agents and posts to Observatory", async () => {
+    const events: OrgEventRecord[] = [
+      { id: "e1", kind: "task.completed", authorId: "ember", summary: "done ops-69", createdAt: "2026-03-06T22:00:00.000Z" },
+    ];
+    const agents: AgentStatus[] = [
+      { agentId: "anvil", name: "Anvil", role: "agent", status: "online" },
+    ];
+
+    mockFetch({
+      "OrgEventCatchup": { status: 200, body: events },
+      "/Agent/": { status: 200, body: [{ id: "anvil", name: "Anvil", role: "agent" }] },
+      "IngestEvents": { status: 204, body: null },
+    });
+
+    const sync = new ObservatorySync({
+      observatoryUrl: "http://observatory.test",
+      officeId: "rockit",
+      keyPath,
+      flairUrl: "http://flair.test",
+      cursorPath: join(tmpDir, "cursor.json"),
+    });
+
+    const result = await sync.syncOnce();
+    expect(result.events).toBe(1);
+    expect(result.agents).toBeGreaterThan(0);
+    expect(result.ok).toBe(true);
+
+    // Verify IngestEvents was called with correct payload
+    const ingestCall = fetchCalls.find((c) => c.url.includes("IngestEvents"));
+    expect(ingestCall).toBeDefined();
+    const payload = JSON.parse(String(ingestCall!.body));
+    expect(payload.officeId).toBe("rockit");
+    expect(payload.events).toHaveLength(1);
+    expect(payload.events[0].kind).toBe("task.completed");
+  });
+
+  test("syncOnce: advances cursor after successful ingest", async () => {
+    const events: OrgEventRecord[] = [
+      { id: "e1", kind: "pr.opened", authorId: "anvil", summary: "PR #130", createdAt: "2026-03-06T20:00:00.000Z" },
+    ];
+
+    mockFetch({
+      "OrgEventCatchup": { status: 200, body: events },
+      "/Agent/": { status: 200, body: [] },
+      "IngestEvents": { status: 204, body: null },
+    });
+
+    const cursorPath = join(tmpDir, "cursor.json");
+    const sync = new ObservatorySync({
+      observatoryUrl: "http://obs.test",
+      officeId: "rockit",
+      keyPath,
+      cursorPath,
+    });
+
+    await sync.syncOnce();
+    expect(existsSync(cursorPath)).toBe(true);
+    const cursor = JSON.parse(readFileSync(cursorPath, "utf-8"));
+    // Cursor should be after the event timestamp
+    expect(new Date(cursor.since).getTime()).toBeGreaterThan(new Date("2026-03-06T20:00:00.000Z").getTime());
+  });
+
+  test("syncOnce: skips ingest when no events and no agents", async () => {
+    mockFetch({
+      "OrgEventCatchup": { status: 200, body: [] },
+      "/Agent/": { status: 200, body: [] },
+    });
+
+    const sync = new ObservatorySync({
+      observatoryUrl: "http://obs.test",
+      officeId: "rockit",
+      keyPath,
+      cursorPath: join(tmpDir, "cursor.json"),
+    });
+
+    const result = await sync.syncOnce();
+    expect(result.ok).toBe(true);
+    expect(fetchCalls.find((c) => c.url.includes("IngestEvents"))).toBeUndefined();
+  });
+
+  test("syncOnce: non-fatal on Observatory ingest failure", async () => {
+    mockFetch({
+      "OrgEventCatchup": { status: 200, body: [{ id: "e1", kind: "task.assigned", authorId: "flint", summary: "ops-99", createdAt: "2026-03-06T22:00:00.000Z" }] },
+      "/Agent/": { status: 200, body: [] },
+      "IngestEvents": { status: 500, body: { error: "server error" } },
+    });
+
+    const sync = new ObservatorySync({
+      observatoryUrl: "http://obs.test",
+      officeId: "rockit",
+      keyPath,
+      cursorPath: join(tmpDir, "cursor.json"),
+    });
+
+    // Should not throw
+    const result = await sync.syncOnce();
+    expect(result.ok).toBe(false);
+    expect(result.events).toBe(1);
+  });
+
+  test("syncOnce: includes Ed25519 auth header on IngestEvents call", async () => {
+    mockFetch({
+      "OrgEventCatchup": { status: 200, body: [{ id: "e1", kind: "task.done", authorId: "ember", summary: "s", createdAt: "2026-03-06T22:00:00.000Z" }] },
+      "/Agent/": { status: 200, body: [] },
+      "IngestEvents": { status: 204, body: null },
+    });
+
+    const sync = new ObservatorySync({
+      observatoryUrl: "http://obs.test",
+      officeId: "rockit",
+      keyPath,
+      cursorPath: join(tmpDir, "cursor.json"),
+    });
+
+    await sync.syncOnce();
+    // Auth header should have been set — we can't verify it directly via mock
+    // but we verify the call was made (auth failure would have caused a 401)
+    const ingestCall = fetchCalls.find((c) => c.url.includes("IngestEvents"));
+    expect(ingestCall).toBeDefined();
+    expect(ingestCall!.method).toBe("POST");
+  });
+});


### PR DESCRIPTION
Implements the Flair-side sync client per `OPS-64-OBSERVATORY-FABRIC` spec.

**What it does:**
1. Polls `/OrgEventCatchup` every 60s (cursor-tracked, first boot = last 1hr)
2. Fetches all agent statuses from `/Agent/`
3. POSTs `{ officeId, events, agents }` to Observatory `/IngestEvents` with Ed25519 auth
4. Advances cursor on success

**Usage:**
```bash
# Standalone
OBSERVATORY_URL=https://tps-observatory.harperdbcloud.com \
OBSERVATORY_OFFICE_ID=rockit \
bun src/observatory-sync.ts

# Or import
import { ObservatorySync } from './src/observatory-sync.js';
const sync = new ObservatorySync({ observatoryUrl, officeId, keyPath });
await sync.start();
```

Ready to wire up once Nathan drops the Fabric cluster creds. Can test against a local mock in the meantime.

5/5 tests pass.