### PR TITLE
feat: memory supersede chains (ops-88)

### DIFF
--- a/resources/FindMemories.ts
+++ b/resources/FindMemories.ts
@@ -10,7 +10,7 @@ function cosineSimilarity(a: number[], b: number[]): number {
 
 export class FindMemories extends Resource {
   async post(data: any) {
-    const { agentId, q, queryEmbedding, tag, limit = 10 } = data || {};
+    const { agentId, q, queryEmbedding, tag, limit = 10, includeSuperseded = false } = data || {};
 
     // Determine searchable agent IDs (own + granted)
     const searchAgentIds = new Set<string>();
@@ -66,8 +66,18 @@ export class FindMemories extends Resource {
       });
     }
 
-    results.sort((a: any, b: any) => b._score - a._score);
-    const topResults = results.slice(0, limit);
+    // Build superseded set and filter (unless caller opts in to see full history)
+    let filteredResults = results;
+    if (!includeSuperseded) {
+      const supersededIds = new Set<string>();
+      for (const r of results) {
+        if (r.supersedes) supersededIds.add(r.supersedes);
+      }
+      filteredResults = results.filter((r: any) => !supersededIds.has(r.id));
+    }
+
+    filteredResults.sort((a: any, b: any) => b._score - a._score);
+    const topResults = filteredResults.slice(0, limit);
 
     // Async hit tracking — don't block the response
     const now = new Date().toISOString();

--- a/resources/Memory.ts
+++ b/resources/Memory.ts
@@ -22,6 +22,13 @@ export class Memory extends (tables as any).Memory {
       }
     }
 
+    // supersedes: optional reference to the ID of the memory this one replaces
+    if (content.supersedes !== undefined && typeof content.supersedes !== "string") {
+      return new Response(JSON.stringify({ error: "supersedes must be a string (memory ID)" }), {
+        status: 400, headers: { "Content-Type": "application/json" },
+      });
+    }
+
     if (content.durability === "ephemeral" && !content.expiresAt) {
       const ttlHours = Number(process.env.FLAIR_EPHEMERAL_TTL_HOURS || 24);
       content.expiresAt = new Date(Date.now() + ttlHours * 3600_000).toISOString();

--- a/resources/MemoryBootstrap.ts
+++ b/resources/MemoryBootstrap.ts
@@ -23,10 +23,11 @@ function estimateTokens(text: string): number {
   return Math.ceil(text.length / 4);
 }
 
-function formatMemory(m: any): string {
+function formatMemory(m: any, supersedes?: boolean): string {
   const tag = m.durability === "permanent" ? "🔒" : m.durability === "persistent" ? "📌" : "📝";
   const date = m.createdAt ? ` (${m.createdAt.slice(0, 10)})` : "";
-  return `${tag} ${m.content}${date}`;
+  const chain = m.supersedes ? " [supersedes earlier decision]" : "";
+  return `${tag} ${m.content}${date}${chain}`;
 }
 
 export class BootstrapMemories extends Resource {
@@ -119,7 +120,14 @@ export class BootstrapMemories extends Resource {
     }
     memoriesAvailable = allMemories.length;
 
-    const permanent = allMemories.filter((m) => m.durability === "permanent");
+    // Build superseded set: exclude memories that have been replaced by newer ones
+    const supersededIds = new Set<string>();
+    for (const m of allMemories) {
+      if (m.supersedes) supersededIds.add(m.supersedes);
+    }
+    const activeMemories = allMemories.filter((m) => !supersededIds.has(m.id));
+
+    const permanent = activeMemories.filter((m) => m.durability === "permanent");
     for (const m of permanent) {
       const line = formatMemory(m);
       const cost = estimateTokens(line);
@@ -134,7 +142,7 @@ export class BootstrapMemories extends Resource {
     const sinceDate = since
       ? new Date(since)
       : new Date(Date.now() - 48 * 3600_000);
-    const recent = allMemories
+    const recent = activeMemories
       .filter(
         (m) =>
           m.durability !== "permanent" &&
@@ -171,7 +179,7 @@ export class BootstrapMemories extends Resource {
         ]);
 
         const scored = allMemories
-          .filter((m) => !includedIds.has(m.id) && m.embedding?.length > 100)
+          .filter((m) => !includedIds.has(m.id) && !supersededIds.has(m.id) && m.embedding?.length > 100)
           .map((m) => {
             let dot = 0;
             const len = Math.min(queryEmbedding!.length, m.embedding.length);

--- a/scripts/flair-client.mjs
+++ b/scripts/flair-client.mjs
@@ -47,12 +47,20 @@ try {
       result = await flairFetch('GET', `/${table}/${rest[0]}`);
       break;
     case 'write': {
-      const content = rest.join(' ');
+      // Support --durability <level> and --supersedes <id> flags
+      const filteredRest = [];
+      let durability = 'standard';
+      let supersedes;
+      for (let i = 0; i < rest.length; i++) {
+        if (rest[i] === '--durability' && rest[i + 1]) { durability = rest[++i]; }
+        else if (rest[i] === '--supersedes' && rest[i + 1]) { supersedes = rest[++i]; }
+        else filteredRest.push(rest[i]);
+      }
+      const content = filteredRest.join(' ');
       const id = `${AGENT_ID}-${Date.now()}`;
-      result = await flairFetch('PUT', `/${table}/${id}`, {
-        id, agentId: AGENT_ID, content, durability: 'standard',
-        createdAt: new Date().toISOString(),
-      });
+      const body = { id, agentId: AGENT_ID, content, durability, createdAt: new Date().toISOString() };
+      if (supersedes) body.supersedes = supersedes;
+      result = await flairFetch('PUT', `/${table}/${id}`, body);
       break;
     }
     case 'set': {


### PR DESCRIPTION
Implements the memory supersede spec from `~/ops/shared/specs/MEMORY-SUPERSEDE.md`.

## What
Agents can supersede stale memories when decisions evolve. Old memories are preserved for audit but filtered from bootstrap/search.

## Changes
- **Memory.ts** — validates `supersedes` field (string or absent)
- **FindMemories.ts** — builds supersededIds set, filters by default; `includeSuperseded: true` for audit access
- **MemoryBootstrap.ts** — same filter on permanent/recent/relevant sections; adds `[supersedes earlier decision]` label on replacement memories
- **flair-client.mjs** — `memory write --supersedes <id> --durability <level>`

## Semantics
```
Memory B { supersedes: 'A-id' } → B is active, A is archived-in-place
Bootstrap/FindMemories: returns B only
FindMemories { includeSuperseded: true }: returns A + B for audit
Chains: A→B→C returns only C
```

## What This Doesn't Do
- No conflict detection (still manual)
- No approval workflow (same auth as any memory write)
- No migration needed (null supersedes = standalone)

29/31 tests pass (2 pre-existing Harper binary integration failures).