### PR TITLE
fix: rename MemoryQuery → SemanticSearch to avoid Harper table routing collision

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "@node-llama-cpp/mac-arm64-metal": "^3.17.1",
     "commander": "14.0.3",
     "harper-fabric-embeddings": "^0.1.0",
-    "harperdb": "github:HarperFast/harper#47482d9b7f8701728cade6089c0125d71789de4c",
+    "harperdb": "file:../harper",
     "tweetnacl": "1.0.3"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "@node-llama-cpp/mac-arm64-metal": "^3.17.1",
     "commander": "14.0.3",
     "harper-fabric-embeddings": "^0.1.0",
-    "harperdb": "file:../harper",
+    "harperdb": "github:HarperFast/harper#47482d9b7f8701728cade6089c0125d71789de4c",
     "tweetnacl": "1.0.3"
   },
   "devDependencies": {

--- a/resources/SemanticSearch.ts
+++ b/resources/SemanticSearch.ts
@@ -8,7 +8,7 @@ function cosineSimilarity(a: number[], b: number[]): number {
   return dot;
 }
 
-export class MemoryQuery extends Resource {
+export class SemanticSearch extends Resource {
   async post(data: any) {
     const { agentId, q, queryEmbedding, tag, limit = 10, includeSuperseded = false } = data || {};
 


### PR DESCRIPTION
Harper v5 routes POST requests to the table handler when a custom resource name starts with a table name prefix (e.g. `MemoryQuery` → routed to `Memory` table).

`SemanticSearch` has no overlap with any table name and routes correctly. Verified working by Flint in production on the fresh DB.

Also updates `scripts/flair-client.mjs` to use `/SemanticSearch`.

Supersedes the `MemoryQuery` rename from #38 — same root cause, correct final fix.