### PR TITLE
ci: fail fast if package.json has local file: dep reference

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,6 +11,13 @@ jobs:
     name: Unit Tests
     runs-on: ubuntu-latest
     steps:
+      - name: Check for local file: deps
+        run: |
+          if grep -q 'file:' package.json; then
+            echo "ERROR: package.json contains local file: reference"
+            grep 'file:' package.json
+            exit 1
+          fi
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - uses: oven-sh/setup-bun@735343b667d3e6f658f44d0eca948eb6282f2b76 # v2
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,6 +11,7 @@ jobs:
     name: Unit Tests
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - name: Check for local file: deps
         run: |
           if grep -q 'file:' package.json; then
@@ -18,7 +19,6 @@ jobs:
             grep 'file:' package.json
             exit 1
           fi
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - uses: oven-sh/setup-bun@735343b667d3e6f658f44d0eca948eb6282f2b76 # v2
         with:
           bun-version: "1.3.10"

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "@node-llama-cpp/mac-arm64-metal": "^3.17.1",
     "commander": "14.0.3",
     "harper-fabric-embeddings": "^0.1.0",
-    "harperdb": "github:HarperFast/harper#47482d9b7f8701728cade6089c0125d71789de4c",
+    "harperdb": "file:../harper",
     "tweetnacl": "1.0.3"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "@node-llama-cpp/mac-arm64-metal": "^3.17.1",
     "commander": "14.0.3",
     "harper-fabric-embeddings": "^0.1.0",
-    "harperdb": "file:../harper",
+    "harperdb": "github:HarperFast/harper#47482d9b7f8701728cade6089c0125d71789de4c",
     "tweetnacl": "1.0.3"
   },
   "devDependencies": {


### PR DESCRIPTION
Adds a CI check that fails immediately if `package.json` contains any `file:` dep reference. Prevents the `harperdb@file:../harper` footgun that hit us on every flair PR tonight.