### PR TITLE
feat: agent-level data scoping for public Flair deployment

### DIFF
--- a/resources/MemoryBootstrap.ts
+++ b/resources/MemoryBootstrap.ts
@@ -47,6 +47,15 @@ export class BootstrapMemories extends Resource {
       });
     }
 
+    // Defense-in-depth: agentId must match authenticated agent
+    const authenticatedAgent: string | undefined = (this as any).request?.headers?.get?.("x-tps-agent");
+    const callerIsAdmin: boolean = (this as any).request?.tpsAgentIsAdmin === true;
+    if (authenticatedAgent && !callerIsAdmin && agentId !== authenticatedAgent) {
+      return new Response(JSON.stringify({
+        error: "forbidden: agentId must match authenticated agent",
+      }), { status: 403, headers: { "Content-Type": "application/json" } });
+    }
+
     const sections: Record<string, string[]> = {
       soul: [],
       skills: [],

--- a/resources/SemanticSearch.ts
+++ b/resources/SemanticSearch.ts
@@ -1,5 +1,6 @@
 import { Resource, tables } from "harperdb";
 import { getEmbedding, getMode } from "./embeddings-provider.js";
+import { patchRecord } from "./table-helpers.js";
 
 function cosineSimilarity(a: number[], b: number[]): number {
   let dot = 0;
@@ -11,6 +12,17 @@ function cosineSimilarity(a: number[], b: number[]): number {
 export class SemanticSearch extends Resource {
   async post(data: any) {
     const { agentId, q, queryEmbedding, tag, limit = 10, includeSuperseded = false } = data || {};
+
+    // Defense-in-depth: verify agentId matches authenticated agent.
+    // The middleware already enforces this for non-admins, but double-check here
+    // so direct Harper API calls (e.g., admin scripts) are also scoped correctly.
+    const authenticatedAgent: string | undefined = (this as any).request?.headers?.get?.("x-tps-agent");
+    const callerIsAdmin: boolean = (this as any).request?.tpsAgentIsAdmin === true;
+    if (authenticatedAgent && !callerIsAdmin && agentId && agentId !== authenticatedAgent) {
+      return new Response(JSON.stringify({
+        error: "forbidden: agentId must match authenticated agent",
+      }), { status: 403, headers: { "Content-Type": "application/json" } });
+    }
 
     // Determine searchable agent IDs (own + granted)
     const searchAgentIds = new Set<string>();
@@ -80,10 +92,10 @@ export class SemanticSearch extends Resource {
     const topResults = filteredResults.slice(0, limit);
 
     // Async hit tracking — don't block the response
+    // Use patchRecord to avoid wiping other fields (embedding, content, etc.)
     const now = new Date().toISOString();
     for (const r of topResults) {
-      (tables as any).Memory.put({
-        id: r.id,
+      patchRecord((tables as any).Memory, r.id, {
         retrievalCount: (r.retrievalCount || 0) + 1,
         lastRetrieved: now,
       }).catch(() => {});

--- a/resources/auth-middleware.ts
+++ b/resources/auth-middleware.ts
@@ -171,6 +171,11 @@ server.http(async (request: any, nextLayer: any) => {
   request.headers.set("authorization", superAuth);
   if (request.headers.asObject) request.headers.asObject.authorization = superAuth;
 
+  // Propagate authenticated agent to downstream resources via header.
+  // Resources can read this to enforce agent-level scoping.
+  request.headers.set("x-tps-agent", agentId);
+  if (request.headers.asObject) (request.headers.asObject as any)["x-tps-agent"] = agentId;
+
   // ── Server-side permission guards ──────────────────────────────────────────
 
   const method = request.method.toUpperCase();
@@ -311,6 +316,102 @@ server.http(async (request: any, nextLayer: any) => {
       if (queryAgent && queryAgent !== agentId) {
         return new Response(JSON.stringify({
           error: "forbidden: cannot read workspace state for another agent"
+        }), { status: 403, headers: { "Content-Type": "application/json" } });
+      }
+    }
+  }
+
+  // ── SemanticSearch: agentId must match authenticated agent ─────────────────
+  // Non-admin agents can only search their own memories (plus MemoryGrant access,
+  // which is enforced inside SemanticSearch.ts using the x-tps-agent header).
+  if (!request.tpsAgentIsAdmin &&
+      method === "POST" &&
+      (url.pathname === "/SemanticSearch" || url.pathname === "/SemanticSearch/")) {
+    try {
+      const clone = request.clone();
+      const body = await clone.json();
+      if (body?.agentId && body.agentId !== agentId) {
+        return new Response(JSON.stringify({
+          error: "forbidden: agentId must match authenticated agent",
+        }), { status: 403, headers: { "Content-Type": "application/json" } });
+      }
+    } catch { /* malformed body — let resource return its own error */ }
+  }
+
+  // ── BootstrapMemories: agentId must match authenticated agent ───────────────
+  if (!request.tpsAgentIsAdmin &&
+      method === "POST" &&
+      (url.pathname === "/BootstrapMemories" || url.pathname === "/BootstrapMemories/")) {
+    try {
+      const clone = request.clone();
+      const body = await clone.json();
+      if (body?.agentId && body.agentId !== agentId) {
+        return new Response(JSON.stringify({
+          error: "forbidden: agentId must match authenticated agent",
+        }), { status: 403, headers: { "Content-Type": "application/json" } });
+      }
+    } catch { /* malformed body — let resource return its own error */ }
+  }
+
+  // ── Memory POST (create): agentId must match authenticated agent ────────────
+  if (!request.tpsAgentIsAdmin &&
+      method === "POST" &&
+      (url.pathname === "/Memory" || url.pathname === "/Memory/")) {
+    try {
+      const clone = request.clone();
+      const body = await clone.json();
+      if (body?.agentId && body.agentId !== agentId) {
+        return new Response(JSON.stringify({
+          error: "forbidden: cannot create memories for another agent",
+        }), { status: 403, headers: { "Content-Type": "application/json" } });
+      }
+    } catch {}
+  }
+
+  // ── Memory GET: non-admin can only read own memories (by ID) ────────────────
+  if (!request.tpsAgentIsAdmin && method === "GET") {
+    if (url.pathname.startsWith("/Memory/")) {
+      try {
+        const pathParts = url.pathname.split("/").filter(Boolean);
+        const memId = pathParts[1] ? decodeURIComponent(pathParts[1]) : null;
+        if (memId) {
+          const record = await (tables as any).Memory.get(memId);
+          if (record && record.agentId && record.agentId !== agentId) {
+            // Allow office-wide memories
+            if (record.visibility !== "office") {
+              // Check MemoryGrant
+              let hasGrant = false;
+              try {
+                for await (const grant of (tables as any).MemoryGrant.search({
+                  conditions: [{ attribute: "granteeId", comparator: "equals", value: agentId }],
+                })) {
+                  if (grant.ownerId === record.agentId &&
+                      (grant.scope === "read" || grant.scope === "search")) {
+                    hasGrant = true;
+                    break;
+                  }
+                }
+              } catch {}
+              if (!hasGrant) {
+                return new Response(JSON.stringify({
+                  error: `forbidden: cannot read memory owned by ${record.agentId}`,
+                }), { status: 403, headers: { "Content-Type": "application/json" } });
+              }
+            }
+          }
+        }
+      } catch { /* record not found or table error — let resource handle */ }
+    }
+  }
+
+  // ── Soul GET: non-admin can only read own soul ──────────────────────────────
+  if (!request.tpsAgentIsAdmin && method === "GET") {
+    if (url.pathname.startsWith("/Soul/")) {
+      const pathParts = url.pathname.split("/").filter(Boolean);
+      const soulOwner = pathParts[1] ? decodeURIComponent(pathParts[1]) : null;
+      if (soulOwner && soulOwner !== agentId) {
+        return new Response(JSON.stringify({
+          error: "forbidden: cannot read another agent's soul",
         }), { status: 403, headers: { "Content-Type": "application/json" } });
       }
     }

--- a/test/data-scoping.test.ts
+++ b/test/data-scoping.test.ts
@@ -1,0 +1,150 @@
+/**
+ * data-scoping.test.ts — Unit tests for agent-level data scoping logic
+ *
+ * Tests the scoping rules without spinning up a full Harper instance.
+ * Validates the guard conditions that the middleware and resources enforce.
+ */
+import { describe, expect, it } from "bun:test";
+
+// ── Scoping rule helpers (mirrors auth-middleware logic) ───────────────────────
+
+/** Returns 403 message if agent tries to access another agent's data, null if allowed */
+function checkAgentScope(
+  authenticatedAgent: string,
+  requestedAgent: string,
+  isAdmin: boolean,
+): string | null {
+  if (isAdmin) return null;
+  if (!requestedAgent) return null; // no agentId in body — resource validates
+  if (requestedAgent === authenticatedAgent) return null;
+  return "forbidden: agentId must match authenticated agent";
+}
+
+/** Returns 403 message if agent tries to read another agent's memory without grant */
+function checkMemoryReadScope(
+  authenticatedAgent: string,
+  memoryOwner: string,
+  memoryVisibility: string | undefined,
+  hasGrant: boolean,
+  isAdmin: boolean,
+): string | null {
+  if (isAdmin) return null;
+  if (memoryOwner === authenticatedAgent) return null;
+  if (memoryVisibility === "office") return null;
+  if (hasGrant) return null;
+  return `forbidden: cannot read memory owned by ${memoryOwner}`;
+}
+
+/** Returns 403 message if agent tries to read another agent's soul */
+function checkSoulReadScope(
+  authenticatedAgent: string,
+  soulOwner: string,
+  isAdmin: boolean,
+): string | null {
+  if (isAdmin) return null;
+  if (soulOwner === authenticatedAgent) return null;
+  return "forbidden: cannot read another agent's soul";
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────────────
+
+describe("checkAgentScope (SemanticSearch / BootstrapMemories / Memory POST)", () => {
+  it("allows own agentId", () => {
+    expect(checkAgentScope("anvil", "anvil", false)).toBeNull();
+  });
+
+  it("blocks cross-agent access for non-admin", () => {
+    const err = checkAgentScope("anvil", "flint", false);
+    expect(err).not.toBeNull();
+    expect(err).toContain("forbidden");
+  });
+
+  it("allows admin to access any agent", () => {
+    expect(checkAgentScope("admin", "flint", true)).toBeNull();
+    expect(checkAgentScope("admin", "anvil", true)).toBeNull();
+  });
+
+  it("allows missing agentId (resource validates separately)", () => {
+    expect(checkAgentScope("anvil", "", false)).toBeNull();
+  });
+
+  it("blocks sherlock reading flint's memories via SemanticSearch", () => {
+    const err = checkAgentScope("sherlock", "flint", false);
+    expect(err).not.toBeNull();
+    expect(err).toContain("forbidden");
+  });
+});
+
+describe("checkMemoryReadScope (Memory GET by ID)", () => {
+  it("allows reading own memory", () => {
+    expect(checkMemoryReadScope("anvil", "anvil", "standard", false, false)).toBeNull();
+  });
+
+  it("allows reading office-wide memory", () => {
+    expect(checkMemoryReadScope("anvil", "flint", "office", false, false)).toBeNull();
+  });
+
+  it("allows reading with MemoryGrant", () => {
+    expect(checkMemoryReadScope("anvil", "flint", "standard", true, false)).toBeNull();
+  });
+
+  it("blocks reading another agent's standard memory without grant", () => {
+    const err = checkMemoryReadScope("anvil", "flint", "standard", false, false);
+    expect(err).not.toBeNull();
+    expect(err).toContain("flint");
+  });
+
+  it("allows admin to read any memory", () => {
+    expect(checkMemoryReadScope("admin", "flint", "standard", false, true)).toBeNull();
+  });
+
+  it("blocks kern reading sherlock's private memory", () => {
+    const err = checkMemoryReadScope("kern", "sherlock", undefined, false, false);
+    expect(err).not.toBeNull();
+    expect(err).toContain("sherlock");
+  });
+});
+
+describe("checkSoulReadScope (Soul GET)", () => {
+  it("allows reading own soul", () => {
+    expect(checkSoulReadScope("flint", "flint", false)).toBeNull();
+  });
+
+  it("blocks reading another agent's soul", () => {
+    const err = checkSoulReadScope("anvil", "flint", false);
+    expect(err).not.toBeNull();
+    expect(err).toContain("forbidden");
+  });
+
+  it("allows admin to read any soul", () => {
+    expect(checkSoulReadScope("admin", "flint", true)).toBeNull();
+    expect(checkSoulReadScope("admin", "ember", true)).toBeNull();
+  });
+});
+
+describe("cross-agent scoping scenarios", () => {
+  it("Pulse on remote VM cannot bootstrap as flint", () => {
+    const err = checkAgentScope("pulse", "flint", false);
+    expect(err).not.toBeNull();
+  });
+
+  it("Pulse can bootstrap as itself", () => {
+    expect(checkAgentScope("pulse", "pulse", false)).toBeNull();
+  });
+
+  it("office memory is public to all agents", () => {
+    for (const reader of ["anvil", "flint", "kern", "pulse", "sherlock"]) {
+      expect(checkMemoryReadScope(reader, "flint", "office", false, false)).toBeNull();
+    }
+  });
+
+  it("standard memory requires ownership or grant", () => {
+    for (const reader of ["anvil", "kern", "pulse", "sherlock"]) {
+      // Without grant
+      const err = checkMemoryReadScope(reader, "flint", "standard", false, false);
+      expect(err).not.toBeNull();
+      // With grant
+      expect(checkMemoryReadScope(reader, "flint", "standard", true, false)).toBeNull();
+    }
+  });
+});


### PR DESCRIPTION
P0 security requirement from `shared/specs/FLAIR-PUBLIC-DEPLOYMENT.md` before Fabric deployment.

## What changed

**auth-middleware.ts** — middleware-layer enforcement:
- Propagates `x-tps-agent` header to downstream resources
- Guards `SemanticSearch` POST: agentId must match authenticated agent
- Guards `BootstrapMemories` POST: agentId must match authenticated agent  
- Guards `Memory` POST (create): cannot create memories for another agent
- Guards `Memory` GET by ID: non-owner blocked (office-visibility + MemoryGrant exceptions apply)
- Guards `Soul` GET: non-owner blocked

**SemanticSearch.ts** — defense-in-depth check at resource layer + fix `retrievalCount` hit tracking to use `patchRecord()` instead of `put()` (would have wiped embeddings — same class as ops-31 bug).

**MemoryBootstrap.ts** — defense-in-depth check at resource layer.

## Scoping rules
- Non-admin: own data only
- MemoryGrant: grantee can read/search grantor's memories per grant scope
- `visibility: "office"`: readable by all authenticated agents
- Admin: unrestricted

## Tests
18 new unit tests in `test/data-scoping.test.ts` covering all scenarios including the Pulse remote-VM case. 2 pre-existing integration test failures (unrelated — require live Harper).