### PR TITLE
feat: add @tpsdev/openclaw-memory-flair plugin (OPS-120 Phase 1)

### DIFF
--- a/plugins/openclaw-memory/.gitignore
+++ b/plugins/openclaw-memory/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+bun.lock

--- a/plugins/openclaw-memory/README.md
+++ b/plugins/openclaw-memory/README.md
@@ -1,0 +1,84 @@
+# @tpsdev/openclaw-memory-flair
+
+OpenClaw memory plugin that replaces the built-in `MEMORY.md` / `memory-lancedb` system with [Flair](https://github.com/tpsdev-ai/flair) as the single source of truth for agent memory.
+
+Uses Flair's native Harper vector embeddings — no OpenAI API key required.
+
+## Features
+
+- **Semantic search** via `memory_recall` → Flair's HNSW vector index
+- **Persistent storage** via `memory_store` → Ed25519-authenticated writes
+- **Memory retrieval** via `memory_get` → fetch by ID
+- **Auto-bootstrap** — injects relevant memories into context at session start
+- **Auto-capture** — automatically stores important information from conversations
+- **Multi-agent** — `agentId: "auto"` resolves per-session for shared gateways
+- **Durability levels** — permanent, persistent, standard, ephemeral
+- **Memory versioning** — `supersedes` field creates version chains
+
+## Prerequisites
+
+- A running [Flair](https://github.com/tpsdev-ai/flair) instance (Harper v5+)
+- An agent record in Flair with an Ed25519 public key
+- The corresponding private key at `~/.tps/secrets/flair/<agentId>-priv.key`
+
+## Installation
+
+```bash
+# From npm (when published)
+openclaw plugin install @tpsdev/openclaw-memory-flair
+
+# From source
+cd plugins/openclaw-memory
+npm install
+```
+
+## Configuration
+
+In your OpenClaw config (`openclaw.json`):
+
+```json
+{
+  "plugins": {
+    "allow": ["memory-flair"],
+    "slots": {
+      "memory": "memory-flair"
+    },
+    "entries": {
+      "memory-flair": {
+        "enabled": true,
+        "config": {
+          "url": "http://localhost:9926",
+          "agentId": "auto",
+          "autoCapture": true,
+          "autoRecall": true,
+          "maxRecallResults": 5,
+          "maxBootstrapTokens": 4000
+        }
+      }
+    }
+  }
+}
+```
+
+### Config Options
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `url` | string | `http://127.0.0.1:9926` | Flair server URL |
+| `agentId` | string | *required* | Agent ID for memory namespacing. Use `"auto"` for multi-agent gateways. |
+| `keyPath` | string | auto-resolved | Path to Ed25519 private key |
+| `autoCapture` | boolean | `true` | Auto-capture important info from conversations |
+| `autoRecall` | boolean | `true` | Inject relevant memories at session start |
+| `maxRecallResults` | number | `5` | Max results for `memory_recall` |
+| `maxBootstrapTokens` | number | `4000` | Max tokens for bootstrap context injection |
+
+## Auth
+
+Uses TPS Ed25519 signatures. The plugin looks for private keys at:
+1. `keyPath` from config (if set)
+2. `~/.tps/secrets/flair/<agentId>-priv.key`
+3. `~/.tps/secrets/<agentId>-flair.key`
+
+## License
+
+Apache-2.0

--- a/plugins/openclaw-memory/index.ts
+++ b/plugins/openclaw-memory/index.ts
@@ -1,0 +1,388 @@
+/**
+ * memory-flair — OpenClaw Memory Plugin backed by Flair
+ *
+ * Replaces the built-in MEMORY.md / memory-lancedb system with Flair as the
+ * single source of truth for agent memory. Uses Flair's native Harper
+ * embeddings — no OpenAI API key required.
+ *
+ * Implements the OpenClaw "memory" plugin slot:
+ *   - memory_recall  → POST /SemanticSearch (semantic search)
+ *   - memory_store   → PUT  /Memory/<id>  (write + embed)
+ *   - memory_get     → GET  /Memory/<id>  (fetch by id)
+ *   - before_agent_start hook → inject recent/relevant memories
+ *   - agent_end hook → auto-capture from conversation
+ */
+
+import { randomUUID } from "node:crypto";
+import { existsSync, readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { resolve } from "node:path";
+import { Type } from "@sinclair/typebox";
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
+
+// ─── Config ──────────────────────────────────────────────────────────────────
+
+interface FlairMemoryConfig {
+  url?: string;
+  agentId: string;
+  keyPath?: string;
+  autoCapture?: boolean;
+  autoRecall?: boolean;
+  maxRecallResults?: number;
+  maxBootstrapTokens?: number;
+}
+
+const DEFAULT_URL = "http://127.0.0.1:9926";
+const DEFAULT_MAX_RECALL = 5;
+const DEFAULT_MAX_BOOTSTRAP_TOKENS = 4000;
+
+// ─── Flair HTTP Client ────────────────────────────────────────────────────────
+
+class FlairMemoryClient {
+  private readonly baseUrl: string;
+  private readonly agentId: string;
+  private readonly keyPath: string | null;
+
+  constructor(config: FlairMemoryConfig) {
+    this.baseUrl = (config.url ?? DEFAULT_URL).replace(/\/$/, "");
+    this.agentId = config.agentId;
+    this.keyPath = config.keyPath
+      ? resolve(config.keyPath.replace(/^~/, homedir()))
+      : this.resolveDefaultKey(config.agentId);
+  }
+
+  private resolveDefaultKey(agentId: string): string | null {
+    const candidates = [
+      resolve(homedir(), ".tps", "secrets", "flair", `${agentId}-priv.key`),
+      resolve(homedir(), ".tps", "secrets", `${agentId}-flair.key`),
+    ];
+    return candidates.find(existsSync) ?? null;
+  }
+
+  private buildAuthHeader(method: string, path: string): Record<string, string> {
+    if (!this.keyPath || !existsSync(this.keyPath)) return {};
+    try {
+      const { sign: ed25519Sign, createPrivateKey, randomUUID: rv } = require("node:crypto");
+      const raw = readFileSync(this.keyPath).toString("utf-8").trim();
+      const rawBuf = Buffer.from(raw, "base64");
+      let privateKey: ReturnType<typeof createPrivateKey>;
+      if (rawBuf.length === 32) {
+        // Raw Ed25519 seed — wrap in PKCS8 DER envelope
+        const pkcs8Header = Buffer.from("302e020100300506032b657004220420", "hex");
+        privateKey = createPrivateKey({ key: Buffer.concat([pkcs8Header, rawBuf]), format: "der", type: "pkcs8" });
+      } else {
+        privateKey = createPrivateKey({ key: rawBuf, format: "der", type: "pkcs8" });
+      }
+      const ts = Date.now().toString();
+      const nonce = rv();
+      const payload = `${this.agentId}:${ts}:${nonce}:${method}:${path}`;
+      const sig = ed25519Sign(null, Buffer.from(payload), privateKey);
+      return { Authorization: `TPS-Ed25519 ${this.agentId}:${ts}:${nonce}:${sig.toString("base64")}` };
+    } catch {
+      return {};
+    }
+  }
+
+  private async request<T>(method: string, path: string, body?: unknown): Promise<T> {
+    const res = await fetch(`${this.baseUrl}${path}`, {
+      method,
+      headers: {
+        "Content-Type": "application/json",
+        ...this.buildAuthHeader(method, path),
+      },
+      body: body !== undefined ? JSON.stringify(body) : undefined,
+      signal: AbortSignal.timeout(10_000),
+    });
+    if (!res.ok) {
+      const text = await res.text().catch(() => "");
+      throw new Error(`Flair ${method} ${path} → ${res.status}: ${text.slice(0, 200)}`);
+    }
+    const text = await res.text();
+    return text ? (JSON.parse(text) as T) : ({} as T);
+  }
+
+  async writeMemory(id: string, content: string, opts: { durability?: string; type?: string; tags?: string[]; supersedes?: string } = {}): Promise<void> {
+    const record: Record<string, unknown> = {
+      id,
+      agentId: this.agentId,
+      content,
+      durability: opts.durability ?? "standard",
+      type: opts.type ?? "session",
+      createdAt: new Date().toISOString(),
+    };
+    if (opts.tags?.length) record.tags = opts.tags;
+    if (opts.supersedes) record.supersedes = opts.supersedes;
+    await this.request("PUT", `/Memory/${id}`, record);
+  }
+
+  async searchMemories(query: string, limit: number): Promise<Array<{ id: string; content: string; score: number; tags?: string[] }>> {
+    const result = await this.request<{ results?: Array<{ id: string; content: string; score?: number; similarity?: number; memory?: { id: string; content: string; tags?: string[] } }> }>(
+      "POST",
+      "/SemanticSearch",
+      { agentId: this.agentId, q: query, limit },
+    );
+    return (result.results ?? []).map((r) => ({
+      id: r.id ?? r.memory?.id ?? "",
+      content: r.content ?? r.memory?.content ?? "",
+      score: r.score ?? r.similarity ?? 0,
+      tags: r.memory?.tags,
+    }));
+  }
+
+  async getMemory(id: string): Promise<{ id: string; content: string; createdAt?: string } | null> {
+    try {
+      return await this.request("GET", `/Memory/${id}`);
+    } catch {
+      return null;
+    }
+  }
+
+  async bootstrap(opts: { days?: number } = {}): Promise<string> {
+    try {
+      const days = opts.days ?? 7;
+      const since = new Date(Date.now() - days * 86_400_000).toISOString();
+      const result = await this.request<{ context?: string; text?: string }>(
+        "POST",
+        "/BootstrapMemories",
+        { agentId: this.agentId, since },
+      );
+      return result.context ?? result.text ?? "";
+    } catch {
+      return "";
+    }
+  }
+}
+
+// ─── Auto-capture helpers ─────────────────────────────────────────────────────
+
+const CAPTURE_TRIGGERS = [
+  /\b(remember|note that|important:|keep in mind|don't forget)\b/i,
+  /\b(preference|prefer|always|never|my name is|i am|i'm)\b/i,
+  /\b(decided|agreed|confirmed|finalized)\b/i,
+];
+
+function shouldCapture(text: string): boolean {
+  return CAPTURE_TRIGGERS.some((re) => re.test(text));
+}
+
+function excerptForCapture(text: string, maxChars = 500): string {
+  return text.length > maxChars ? `${text.slice(0, maxChars)}…` : text;
+}
+
+// ─── Plugin export ────────────────────────────────────────────────────────────
+
+export default {
+  kind: "memory" as const,
+
+  register(api: OpenClawPluginApi) {
+    try {
+    const cfg = api.pluginConfig as FlairMemoryConfig;
+    const isAutoMode = !cfg.agentId || cfg.agentId === "auto";
+
+    // Client pool: one client per agentId, created lazily
+    const clientPool = new Map<string, FlairMemoryClient>();
+    
+    function getClient(agentId?: string): FlairMemoryClient {
+      const id = agentId || cfg.agentId;
+      if (!id || id === "auto") throw new Error("no agentId available");
+      let client = clientPool.get(id);
+      if (!client) {
+        client = new FlairMemoryClient({ ...cfg, agentId: id });
+        clientPool.set(id, client);
+      }
+      return client;
+    }
+
+    // For non-auto mode, pre-create the client
+    if (!isAutoMode) {
+      getClient(cfg.agentId);
+    }
+
+    api.logger.info("memory-flair: config ok, creating client...");
+    api.logger.info("memory-flair: client created");
+    const maxRecall = cfg.maxRecallResults ?? DEFAULT_MAX_RECALL;
+    const autoCapture = cfg.autoCapture ?? true;
+    const autoRecall = cfg.autoRecall ?? true;
+
+    // Track current agent per-session via hooks (tools don't get agentId in execute)
+    let currentAgentId: string | undefined = isAutoMode ? undefined : cfg.agentId;
+    
+    api.on("before_agent_start", async (event: any, ctx: any) => {
+      const eventAgentId = ctx?.agentId || (event as any).agentId;
+      if (eventAgentId) currentAgentId = eventAgentId;
+    });
+    
+    // Helper to get client using tracked agentId
+    function getCurrentClient(): FlairMemoryClient {
+      return getClient(currentAgentId);
+    }
+
+    const displayAgent = isAutoMode ? "auto (per-session)" : cfg.agentId;
+    api.logger.info(`memory-flair: registered (agent=${displayAgent}, url=${cfg.url ?? DEFAULT_URL})`);
+
+    // ── memory_recall ──────────────────────────────────────────────────────
+
+    api.registerTool(
+      {
+        name: "memory_recall",
+        label: "Memory Recall",
+        description:
+          "Search long-term memory via Flair semantic search. Use when you need context about user preferences, past decisions, or previously discussed topics.",
+        parameters: Type.Object({
+          query: Type.String({ description: "Search query" }),
+          limit: Type.Optional(Type.Number({ description: "Max results (default: 5)" })),
+        }),
+        async execute(_id, params) {
+          const { query, limit = maxRecall } = params as { query: string; limit?: number };
+          try {
+            const client = getCurrentClient();
+            const results = await client.searchMemories(query, limit);
+            if (results.length === 0) {
+              return { content: [{ type: "text", text: "No relevant memories found." }], details: { count: 0 } };
+            }
+            const text = results
+              .map((r, i) => `${i + 1}. ${r.content} (${(r.score * 100).toFixed(0)}%)`)
+              .join("\n");
+            return {
+              content: [{ type: "text", text: `Found ${results.length} memories:\n\n${text}` }],
+              details: { count: results.length, memories: results },
+            };
+          } catch (err: any) {
+            api.logger.warn(`memory-flair: recall failed: ${err.message}`);
+            return { content: [{ type: "text", text: `Memory recall unavailable: ${err.message}` }], details: { count: 0 } };
+          }
+        },
+      },
+      { name: "memory_recall" },
+    );
+
+    // ── memory_store ───────────────────────────────────────────────────────
+
+    api.registerTool(
+      {
+        name: "memory_store",
+        label: "Memory Store",
+        description: "Save important information in long-term memory via Flair. Use for preferences, facts, decisions, and key context.",
+        parameters: Type.Object({
+          text: Type.String({ description: "Information to remember" }),
+          importance: Type.Optional(Type.Number({ description: "Importance 0-1 (default: 0.7)" })),
+          tags: Type.Optional(Type.Array(Type.String(), { description: "Optional tags" })),
+          durability: Type.Optional(Type.Union([
+            Type.Literal("permanent"),
+            Type.Literal("persistent"),
+            Type.Literal("standard"),
+            Type.Literal("ephemeral"),
+          ], { description: "Memory durability: permanent (inviolable), persistent (key decisions), standard (default), ephemeral (auto-expires)" })),
+          type: Type.Optional(Type.Union([
+            Type.Literal("session"),
+            Type.Literal("lesson"),
+            Type.Literal("decision"),
+            Type.Literal("preference"),
+            Type.Literal("fact"),
+            Type.Literal("goal"),
+          ], { description: "Memory type for categorization" })),
+          supersedes: Type.Optional(Type.String({ description: "ID of memory this replaces (creates version chain)" })),
+        }),
+        async execute(_id, params) {
+          const { text, tags, durability, type, supersedes } = params as {
+            text: string; importance?: number; tags?: string[];
+            durability?: string; type?: string; supersedes?: string;
+          };
+          try {
+            const agentId = currentAgentId || cfg.agentId;
+            const client = getCurrentClient();
+            const memId = `${agentId}-${Date.now()}`;
+            await client.writeMemory(memId, text, { tags, durability, type, supersedes });
+            return {
+              content: [{ type: "text", text: `Memory stored (id: ${memId})` }],
+              details: { id: memId },
+            };
+          } catch (err: any) {
+            api.logger.warn(`memory-flair: store failed: ${err.message}`);
+            return { content: [{ type: "text", text: `Memory store unavailable: ${err.message}` }], details: {} };
+          }
+        },
+      },
+      { name: "memory_store" },
+    );
+
+    // ── memory_get ─────────────────────────────────────────────────────────
+
+    api.registerTool(
+      {
+        name: "memory_get",
+        label: "Memory Get",
+        description: "Retrieve a specific memory by ID from Flair.",
+        parameters: Type.Object({
+          id: Type.String({ description: "Memory ID" }),
+        }),
+        async execute(_toolId, params) {
+          const { id } = params as { id: string };
+          try {
+            const client = getCurrentClient();
+            const mem = await client.getMemory(id);
+            if (!mem) return { content: [{ type: "text", text: `Memory ${id} not found.` }], details: {} };
+            return {
+              content: [{ type: "text", text: mem.content }],
+              details: mem,
+            };
+          } catch (err: any) {
+            return { content: [{ type: "text", text: `Memory get failed: ${err.message}` }], details: {} };
+          }
+        },
+      },
+      { name: "memory_get" },
+    );
+
+    // ── Lifecycle: auto-recall on session start ────────────────────────────
+
+    if (autoRecall) {
+      api.on("before_agent_start", async (event: any, ctx: any) => {
+        try {
+          // Ensure agentId is set (in case this fires before the tracking hook)
+          if (ctx?.agentId && !currentAgentId) currentAgentId = ctx.agentId;
+          const client = getCurrentClient();
+          const context = await client.bootstrap({ days: 7 });
+          if (context && typeof context === "string" && context.trim().length > 0) {
+            const truncated = context.slice(0, (cfg.maxBootstrapTokens ?? DEFAULT_MAX_BOOTSTRAP_TOKENS) * 4);
+            event.injectContext?.(`\n## Memory Context (from Flair)\n\n${truncated}\n`);
+            api.logger.info(`memory-flair: injected bootstrap context (${context.length} chars)`);
+          }
+        } catch (err: any) {
+          api.logger.warn(`memory-flair: bootstrap recall failed: ${err.message}`);
+        }
+      });
+    }
+
+    // ── Lifecycle: auto-capture on session end ────────────────────────────
+
+    if (autoCapture) {
+      api.on("agent_end", async (event) => {
+        try {
+          const agentId = currentAgentId || cfg.agentId;
+          const client = getCurrentClient();
+          const messages = (event.messages ?? []) as Array<{ role: string; content?: string }>;
+          let stored = 0;
+          for (const msg of messages) {
+            if (msg.role !== "user" && msg.role !== "assistant") continue;
+            const text = typeof msg.content === "string" ? msg.content : "";
+            if (!text || !shouldCapture(text)) continue;
+            const excerpt = excerptForCapture(text);
+            const memId = `${agentId}-${Date.now()}-${stored}`;
+            await client.writeMemory(memId, excerpt, { type: "session", tags: ["auto-captured"] });
+            stored++;
+            if (stored >= 3) break; // cap at 3 per session
+          }
+          if (stored > 0) api.logger.info(`memory-flair: auto-captured ${stored} memories`);
+        } catch (err: any) {
+          api.logger.warn(`memory-flair: auto-capture failed: ${err.message}`);
+        }
+      });
+    }
+
+    } catch (err: any) {
+      api.logger.error(`memory-flair register error: ${err.message}`);
+      throw err;
+    }
+  },
+};

--- a/plugins/openclaw-memory/openclaw.plugin.json
+++ b/plugins/openclaw-memory/openclaw.plugin.json
@@ -1,0 +1,45 @@
+{
+  "id": "memory-flair",
+  "kind": "memory",
+  "uiHints": {
+    "url": {
+      "label": "Flair URL",
+      "placeholder": "http://localhost:9926",
+      "help": "Base URL for the Flair server"
+    },
+    "agentId": {
+      "label": "Agent ID",
+      "placeholder": "flint",
+      "help": "TPS agent identifier (used for memory namespacing)"
+    },
+    "keyPath": {
+      "label": "Private Key Path",
+      "placeholder": "~/.tps/secrets/flair/flint-priv.key",
+      "help": "Path to Ed25519 private key for Flair auth",
+      "sensitive": true,
+      "advanced": true
+    },
+    "autoCapture": {
+      "label": "Auto-Capture",
+      "help": "Automatically capture important information from conversations"
+    },
+    "autoRecall": {
+      "label": "Auto-Recall",
+      "help": "Automatically inject relevant memories into context at session start"
+    }
+  },
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+      "url": { "type": "string" },
+      "agentId": { "type": "string" },
+      "keyPath": { "type": "string" },
+      "autoCapture": { "type": "boolean" },
+      "autoRecall": { "type": "boolean" },
+      "maxRecallResults": { "type": "number", "minimum": 1, "maximum": 20 },
+      "maxBootstrapTokens": { "type": "number", "minimum": 500, "maximum": 8000 }
+    },
+    "required": ["agentId"]
+  }
+}

--- a/plugins/openclaw-memory/package.json
+++ b/plugins/openclaw-memory/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "@tpsdev/openclaw-memory-flair",
+  "version": "0.1.0",
+  "description": "OpenClaw memory plugin backed by Flair — replaces built-in memory with semantic vector search via Harper",
+  "type": "module",
+  "main": "index.ts",
+  "exports": {
+    ".": "./index.ts"
+  },
+  "files": [
+    "index.ts",
+    "openclaw.plugin.json",
+    "README.md"
+  ],
+  "keywords": [
+    "openclaw",
+    "openclaw-plugin",
+    "memory",
+    "flair",
+    "harper",
+    "semantic-search",
+    "agent-memory"
+  ],
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/tpsdev-ai/flair.git",
+    "directory": "plugins/openclaw-memory"
+  },
+  "homepage": "https://github.com/tpsdev-ai/flair/tree/main/plugins/openclaw-memory",
+  "peerDependencies": {
+    "openclaw": ">=2025.0.0"
+  },
+  "dependencies": {
+    "@sinclair/typebox": "^0.34.0"
+  }
+}

--- a/plugins/openclaw-memory/test/plugin.test.ts
+++ b/plugins/openclaw-memory/test/plugin.test.ts
@@ -1,0 +1,88 @@
+import { describe, test, expect, mock } from "bun:test";
+
+// Minimal mock of OpenClawPluginApi
+function createMockApi(config: Record<string, unknown> = {}) {
+  const tools = new Map<string, { execute: Function }>();
+  const hooks = new Map<string, Function[]>();
+
+  return {
+    pluginConfig: {
+      url: "http://localhost:9926",
+      agentId: "test-agent",
+      autoCapture: false,
+      autoRecall: false,
+      ...config,
+    },
+    logger: {
+      info: mock(() => {}),
+      warn: mock(() => {}),
+      error: mock(() => {}),
+      debug: mock(() => {}),
+    },
+    registerTool(spec: { name: string; execute: Function }, opts: { name: string }) {
+      tools.set(opts.name, { execute: spec.execute });
+    },
+    on(event: string, handler: Function) {
+      const list = hooks.get(event) ?? [];
+      list.push(handler);
+      hooks.set(event, list);
+    },
+    // Test helpers
+    _tools: tools,
+    _hooks: hooks,
+  };
+}
+
+describe("memory-flair plugin", () => {
+  test("registers all three tools", async () => {
+    // Import triggers registration
+    const plugin = (await import("../index.ts")).default;
+    const api = createMockApi();
+    plugin.register(api as any);
+
+    expect(api._tools.has("memory_recall")).toBe(true);
+    expect(api._tools.has("memory_store")).toBe(true);
+    expect(api._tools.has("memory_get")).toBe(true);
+  });
+
+  test("kind is 'memory'", async () => {
+    const plugin = (await import("../index.ts")).default;
+    expect(plugin.kind).toBe("memory");
+  });
+
+  test("registers before_agent_start hook", async () => {
+    const plugin = (await import("../index.ts")).default;
+    const api = createMockApi();
+    plugin.register(api as any);
+
+    const hooks = api._hooks.get("before_agent_start") ?? [];
+    expect(hooks.length).toBeGreaterThanOrEqual(1);
+  });
+
+  test("auto mode does not pre-create client", async () => {
+    const plugin = (await import("../index.ts")).default;
+    const api = createMockApi({ agentId: "auto" });
+    // Should not throw — auto mode defers client creation
+    expect(() => plugin.register(api as any)).not.toThrow();
+  });
+
+  test("memory_store returns error when no agentId in auto mode", async () => {
+    const plugin = (await import("../index.ts")).default;
+    const api = createMockApi({ agentId: "auto" });
+    plugin.register(api as any);
+
+    const tool = api._tools.get("memory_store")!;
+    const result = await tool.execute("test", { text: "hello" });
+    expect(result.content[0].text).toContain("unavailable");
+  });
+
+  test("memory_recall returns error when no agentId in auto mode", async () => {
+    const plugin = (await import("../index.ts")).default;
+    const api = createMockApi({ agentId: "auto" });
+    plugin.register(api as any);
+
+    const tool = api._tools.get("memory_recall")!;
+    const result = await tool.execute("test", { query: "hello" });
+    expect(result.content[0].text).toContain("unavailable");
+  });
+});


### PR DESCRIPTION
Moves the memory-flair OpenClaw plugin from local `~/.openclaw/extensions/` into the flair repo as a publishable npm package at `plugins/openclaw-memory/`.

### What it does
Replaces OpenClaw's built-in `MEMORY.md` / `memory-lancedb` system with Flair as the single source of truth for agent memory. Uses Flair's native Harper HNSW vector embeddings — no OpenAI API key required.

### Tools
- `memory_recall` → semantic search via `POST /SemanticSearch`
- `memory_store` → authenticated write via `PUT /Memory/<id>`
- `memory_get` → fetch by ID via `GET /Memory/<id>`

### Features
- `agentId: "auto"` for multi-agent gateways (resolves per-session)
- Ed25519 auth with TPS key auto-resolution
- Auto-bootstrap on session start (injects relevant memories)
- Auto-capture on session end (stores important conversation excerpts)
- Graceful degradation when Flair is unavailable
- Memory durability levels: permanent, persistent, standard, ephemeral
- Memory versioning via `supersedes` chains

### Tests
6 unit tests covering registration, auto mode, and graceful error handling.

### Publishing
Package name: `@tpsdev/openclaw-memory-flair`. Ready for `npm publish` when we're ready.

Ref: OPS-120 Phase 1