### PR TITLE
fix: update HARPER_BIN path to @harperfast/harper and fix admin password default

### DIFF
--- a/test/helpers/harper-lifecycle.ts
+++ b/test/helpers/harper-lifecycle.ts
@@ -6,15 +6,15 @@ import { join } from "node:path";
 const getRandomPort = () => 10000 + Math.floor(Math.random() * 50000);
 const STARTUP_TIMEOUT_MS = 45_000;
 
-// Use harperdb from node_modules — works on any system with Node
-const HARPER_BIN = join(process.cwd(), "node_modules", "harperdb", "bin", "harper.js");
+// Use @harperfast/harper from node_modules — works on any system with Node
+const HARPER_BIN = join(process.cwd(), "node_modules", "@harperfast", "harper", "dist", "bin", "harper.js");
 
 // External service mode: set HARPER_HTTP_URL (and optionally HARPER_OPS_URL) to
 // skip the local spawn and connect to an already-running Harper instance (e.g. Docker).
 const HARPER_HTTP_URL = process.env.HARPER_HTTP_URL;
 const HARPER_OPS_URL_ENV = process.env.HARPER_OPS_URL;
 const HARPER_ADMIN_USER = process.env.HARPER_ADMIN_USER ?? "admin";
-const HARPER_ADMIN_PASS = process.env.HARPER_ADMIN_PASS ?? "admin123";
+const HARPER_ADMIN_PASS = process.env.HARPER_ADMIN_PASS ?? "test123";
 
 export interface HarperInstance {
   httpURL: string;


### PR DESCRIPTION
## Changes

- Update `HARPER_BIN` from old `node_modules/harperdb/bin/harper.js` to `node_modules/@harperfast/harper/dist/bin/harper.js`
- Fix `HARPER_ADMIN_PASS` default from `admin123` to `test123` (matches actual `HDB_ADMIN_PASSWORD` used in local spawn)

Fixes the 2 E2E/integration test failures caused by the stale harperdb path.