### PR TITLE
fix: remove admin token filesystem read — use HDB_ADMIN_PASSWORD env only

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,8 @@ flair/
 - **Harper-native** — No Express, no middleware frameworks. Harper IS the runtime.
 - **In-process embeddings** — `process.dlopen()` loads llama.cpp's native addon directly inside Harper's sandboxed VM. No sidecar, no HTTP calls.
 - **Schema-driven** — GraphQL schemas with `@table @export` auto-generate REST CRUD. Custom resources extend behavior (durability guards, auto-embedding, search).
-- **Auth header swap** — After Ed25519 verification, middleware swaps the auth header for Harper's internal auth. Agent never needs Harper credentials.
+- **Auth header swap** — After Ed25519 verification, middleware swaps the auth header for Harper's internal Basic auth (sourced from `HDB_ADMIN_PASSWORD` env var, set at startup). No admin token file on disk — credentials live only in the process environment.
+- **No filesystem admin tokens** — Admin credentials come exclusively from `HDB_ADMIN_PASSWORD` (Harper's own env var) or the deprecated `FLAIR_ADMIN_TOKEN` env var. The old `~/.tps/secrets/flair/harper-admin-token` file path is no longer read; any such file can be safely deleted.
 
 ## Development
 

--- a/resources/auth-middleware.ts
+++ b/resources/auth-middleware.ts
@@ -1,28 +1,39 @@
 import { patchRecord } from "./table-helpers.js";
 import { server, tables } from "@harperfast/harper";
 import { initEmbeddings, getEmbedding } from "./embeddings-provider.js";
-import { readFileSync } from "node:fs";
 
-// --- Admin token (loaded once at startup, never hardcoded) ---
-// Reads from ~/.tps/secrets/flair/harper-admin-token, then env vars.
-// Fails loudly rather than falling back to a hardcoded default.
-let _adminToken: string | null = null;
-function getAdminToken(): string {
-  if (_adminToken) return _adminToken;
-  const tokenFile = (process.env.HOME ?? "") + "/.tps/secrets/flair/harper-admin-token";
-  try {
-    _adminToken = readFileSync(tokenFile, "utf8").trim();
-    return _adminToken;
-  } catch {
-    const envToken = process.env.FLAIR_ADMIN_TOKEN ?? process.env.HDB_ADMIN_PASSWORD;
-    if (envToken) {
-      _adminToken = envToken;
-      return _adminToken;
-    }
-    const msg = "[auth] FATAL: no admin token found. Run: tps flair install";
-    console.error(msg);
-    throw new Error(msg);
+// --- Admin credentials ---
+// Admin auth is sourced exclusively from Harper's own environment variables
+// (HDB_ADMIN_PASSWORD / FLAIR_ADMIN_PASSWORD). No filesystem token file.
+//
+// FLAIR_ADMIN_TOKEN env var is still accepted for backwards compat but
+// emits a deprecation warning on first use.
+let _adminPass: string | null = null;
+let _deprecationWarned = false;
+
+function getAdminPass(): string {
+  if (_adminPass) return _adminPass;
+
+  // Primary source: Harper's own admin password (set at startup via env)
+  const primary = process.env.HDB_ADMIN_PASSWORD ?? process.env.FLAIR_ADMIN_PASSWORD;
+  if (primary) {
+    _adminPass = primary;
+    return _adminPass;
   }
+
+  // Backwards compat: FLAIR_ADMIN_TOKEN (deprecated — never write to disk)
+  if (process.env.FLAIR_ADMIN_TOKEN) {
+    if (!_deprecationWarned) {
+      console.warn("[auth] DEPRECATION: FLAIR_ADMIN_TOKEN is deprecated. Use HDB_ADMIN_PASSWORD instead.");
+      _deprecationWarned = true;
+    }
+    _adminPass = process.env.FLAIR_ADMIN_TOKEN;
+    return _adminPass;
+  }
+
+  const msg = "[auth] FATAL: no admin password found. Set HDB_ADMIN_PASSWORD env var.";
+  console.error(msg);
+  throw new Error(msg);
 }
 
 const WINDOW_MS = 30_000;
@@ -169,7 +180,7 @@ server.http(async (request: any, nextLayer: any) => {
   (request as any)._tpsAuthVerified = true;
   request.tpsAgentIsAdmin = await isAdmin(agentId);
 
-  const superAuth = "Basic " + btoa("admin:" + getAdminToken());
+  const superAuth = "Basic " + btoa("admin:" + getAdminPass());
   request.headers.set("authorization", superAuth);
   if (request.headers.asObject) request.headers.asObject.authorization = superAuth;
 


### PR DESCRIPTION
## Security fix

**Problem:** `auth-middleware.ts` read admin credentials from `~/.tps/secrets/flair/harper-admin-token` on disk. Any process running as the same OS user could read this file and forge admin-level requests, bypassing all Ed25519 scoping.

**Fix:** Remove `getAdminToken()` and the filesystem read entirely. Admin credentials now come exclusively from env vars that are set at Harper startup:

1. `HDB_ADMIN_PASSWORD` (primary — Harper's own env var, already required to start the process)
2. `FLAIR_ADMIN_PASSWORD` (alias)
3. `FLAIR_ADMIN_TOKEN` (backwards compat — still accepted but logs a deprecation warning; was never safe to write to disk)

**Key insight:** Harper requires `HDB_ADMIN_PASSWORD` to start. The middleware already had access to this env var as a fallback. The filesystem read was redundant and a security liability.

### Changes
- `resources/auth-middleware.ts`: Replace `getAdminToken()` + `readFileSync` with `getAdminPass()` reading from env
- Remove `import { readFileSync } from 'node:fs'`
- `README.md`: Update security section to document no-filesystem-token policy

### Backwards compat
- `FLAIR_ADMIN_TOKEN` env var still works (with deprecation warning)
- The `~/.tps/secrets/flair/harper-admin-token` file is simply ignored — existing deployments can delete it

No test changes needed — 92 existing tests pass, 0 new failures.