### PR TITLE
feat: flair agent remove + flair grant/revoke

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -429,6 +429,224 @@ agent
     console.log(`   Old key backup: ${backupPrivPath}`);
   });
 
+// ─── flair agent remove ──────────────────────────────────────────────────────
+
+agent
+  .command("remove <id>")
+  .description("Remove an agent and all its data from Flair")
+  .option("--keep-keys", "Do not delete key files from disk")
+  .option("--port <port>", "Harper HTTP port", String(DEFAULT_PORT))
+  .option("--ops-port <port>", "Harper operations API port")
+  .option("--admin-pass <pass>", "Admin password (or set FLAIR_ADMIN_PASS env)")
+  .option("--keys-dir <dir>", "Directory for Ed25519 keys")
+  .option("--force", "Skip interactive confirmation (required when stdin is not a TTY)")
+  .action(async (id: string, opts) => {
+    const opsPort = opts.opsPort ? Number(opts.opsPort) : Number(opts.port) + 1;
+    const adminPass: string = opts.adminPass ?? process.env.FLAIR_ADMIN_PASS ?? "";
+    const adminUser = DEFAULT_ADMIN_USER;
+    const keysDir: string = opts.keysDir ?? defaultKeysDir();
+
+    if (!adminPass) {
+      console.error("Error: --admin-pass or FLAIR_ADMIN_PASS required for agent remove");
+      process.exit(1);
+    }
+
+    const auth = `Basic ${Buffer.from(`${adminUser}:${adminPass}`).toString("base64")}`;
+
+    async function opsPost(body: unknown): Promise<Response> {
+      return fetch(`http://127.0.0.1:${opsPort}/`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json", Authorization: auth },
+        body: JSON.stringify(body),
+        signal: AbortSignal.timeout(10_000),
+      });
+    }
+
+    // Fetch agent info and memory count for confirmation
+    const agentRes = await opsPost({ operation: "search_by_value", database: "flair", table: "Agent", search_attribute: "id", search_value: id, get_attributes: ["id", "name"] });
+    const agentData = agentRes.ok ? await agentRes.json().catch(() => null) : null;
+    const agentName = agentData?.[0]?.name ?? id;
+
+    const memRes = await opsPost({ operation: "search_by_value", database: "flair", table: "Memory", search_attribute: "agentId", search_value: id, get_attributes: ["id"] });
+    const memories = memRes.ok ? await memRes.json().catch(() => []) : [];
+    const memoryCount = Array.isArray(memories) ? memories.length : 0;
+
+    // Confirmation
+    const isInteractive = process.stdin.isTTY;
+    if (!opts.force) {
+      if (!isInteractive) {
+        console.error("Error: stdin is not a TTY. Use --force to skip confirmation.");
+        process.exit(1);
+      }
+      console.log(`⚠️  About to permanently remove agent '${agentName}' (${id})`);
+      console.log(`   Memories to delete: ${memoryCount}`);
+      process.stdout.write(`\nType 'yes' to confirm: `);
+      const answer = await new Promise<string>((resolve) => {
+        let buf = "";
+        process.stdin.setEncoding("utf-8");
+        process.stdin.resume();
+        process.stdin.on("data", (chunk: string) => {
+          buf += chunk;
+          if (buf.includes("\n")) { process.stdin.pause(); resolve(buf.trim()); }
+        });
+      });
+      if (answer !== "yes") {
+        console.log("Aborted.");
+        process.exit(0);
+      }
+    } else {
+      console.log(`Removing agent '${agentName}' (${id}) with ${memoryCount} memories...`);
+    }
+
+    // Delete all memories
+    if (memoryCount > 0) {
+      console.log(`Deleting ${memoryCount} memories...`);
+      for (const mem of (Array.isArray(memories) ? memories : [])) {
+        if (!mem?.id) continue;
+        await opsPost({ operation: "delete", database: "flair", table: "Memory", ids: [mem.id] }).catch(() => {});
+      }
+    }
+
+    // Delete all souls
+    const soulRes = await opsPost({ operation: "search_by_value", database: "flair", table: "Soul", search_attribute: "agentId", search_value: id, get_attributes: ["id"] });
+    const souls = soulRes.ok ? await soulRes.json().catch(() => []) : [];
+    if (Array.isArray(souls) && souls.length > 0) {
+      console.log(`Deleting ${souls.length} soul entries...`);
+      for (const soul of souls) {
+        if (!soul?.id) continue;
+        await opsPost({ operation: "delete", database: "flair", table: "Soul", ids: [soul.id] }).catch(() => {});
+      }
+    }
+
+    // Delete agent record
+    const delRes = await opsPost({ operation: "delete", database: "flair", table: "Agent", ids: [id] });
+    if (!delRes.ok) {
+      const text = await delRes.text().catch(() => "");
+      throw new Error(`Failed to delete agent record (${delRes.status}): ${text}`);
+    }
+
+    // Delete key files (unless --keep-keys)
+    if (!opts.keepKeys) {
+      const privPath = privKeyPath(id, keysDir);
+      const pubPath = pubKeyPath(id, keysDir);
+      const backupPath = privPath + ".bak";
+      for (const p of [privPath, pubPath, backupPath]) {
+        if (existsSync(p)) {
+          try { require("node:fs").unlinkSync(p); } catch { /* best effort */ }
+        }
+      }
+      console.log("Key files deleted.");
+    } else {
+      console.log("Key files preserved (--keep-keys).");
+    }
+
+    console.log(`\n✅ Agent '${id}' removed successfully`);
+  });
+
+// ─── flair grant / revoke ─────────────────────────────────────────────────────
+
+program
+  .command("grant <from-agent> <to-agent>")
+  .description("Grant an agent read access to another agent's memories")
+  .option("--scope <scope>", "Grant scope: read or search", "read")
+  .option("--port <port>", "Harper HTTP port", String(DEFAULT_PORT))
+  .option("--ops-port <port>", "Harper operations API port")
+  .option("--admin-pass <pass>", "Admin password (or set FLAIR_ADMIN_PASS env)")
+  .option("--keys-dir <dir>", "Directory for Ed25519 keys (for from-agent Ed25519 auth)")
+  .action(async (fromAgent: string, toAgent: string, opts) => {
+    const httpPort = Number(opts.port);
+    const opsPort = opts.opsPort ? Number(opts.opsPort) : httpPort + 1;
+    const adminPass: string = opts.adminPass ?? process.env.FLAIR_ADMIN_PASS ?? "";
+    const adminUser = DEFAULT_ADMIN_USER;
+    const scope: string = opts.scope ?? "read";
+
+    if (!adminPass) {
+      console.error("Error: --admin-pass or FLAIR_ADMIN_PASS required for grant");
+      process.exit(1);
+    }
+
+    const auth = `Basic ${Buffer.from(`${adminUser}:${adminPass}`).toString("base64")}`;
+    const grantId = `${fromAgent}:${toAgent}`;
+    const body = {
+      operation: "insert",
+      database: "flair",
+      table: "MemoryGrant",
+      records: [{
+        id: grantId,
+        fromAgentId: fromAgent,
+        toAgentId: toAgent,
+        scope,
+        createdAt: new Date().toISOString(),
+      }],
+    };
+
+    const res = await fetch(`http://127.0.0.1:${opsPort}/`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Authorization: auth },
+      body: JSON.stringify(body),
+      signal: AbortSignal.timeout(10_000),
+    });
+
+    if (!res.ok) {
+      const text = await res.text().catch(() => "");
+      if (res.status === 409 || text.includes("duplicate") || text.includes("already exists")) {
+        console.log(`ℹ️  Grant already exists: '${toAgent}' can already read '${fromAgent}'s memories`);
+        return;
+      }
+      throw new Error(`Failed to create grant (${res.status}): ${text}`);
+    }
+
+    console.log(`✅ Grant created: '${toAgent}' can now read '${fromAgent}'s memories`);
+    console.log(`   ID:    ${grantId}`);
+    console.log(`   Scope: ${scope}`);
+  });
+
+program
+  .command("revoke <from-agent> <to-agent>")
+  .description("Revoke a memory grant between two agents")
+  .option("--port <port>", "Harper HTTP port", String(DEFAULT_PORT))
+  .option("--ops-port <port>", "Harper operations API port")
+  .option("--admin-pass <pass>", "Admin password (or set FLAIR_ADMIN_PASS env)")
+  .action(async (fromAgent: string, toAgent: string, opts) => {
+    const httpPort = Number(opts.port);
+    const opsPort = opts.opsPort ? Number(opts.opsPort) : httpPort + 1;
+    const adminPass: string = opts.adminPass ?? process.env.FLAIR_ADMIN_PASS ?? "";
+    const adminUser = DEFAULT_ADMIN_USER;
+
+    if (!adminPass) {
+      console.error("Error: --admin-pass or FLAIR_ADMIN_PASS required for revoke");
+      process.exit(1);
+    }
+
+    const auth = `Basic ${Buffer.from(`${adminUser}:${adminPass}`).toString("base64")}`;
+    const grantId = `${fromAgent}:${toAgent}`;
+    const body = {
+      operation: "delete",
+      database: "flair",
+      table: "MemoryGrant",
+      ids: [grantId],
+    };
+
+    const res = await fetch(`http://127.0.0.1:${opsPort}/`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Authorization: auth },
+      body: JSON.stringify(body),
+      signal: AbortSignal.timeout(10_000),
+    });
+
+    if (!res.ok) {
+      const text = await res.text().catch(() => "");
+      if (res.status === 404 || text.includes("not found")) {
+        console.log(`ℹ️  No grant found: '${toAgent}' does not have access to '${fromAgent}'s memories`);
+        return;
+      }
+      throw new Error(`Failed to revoke grant (${res.status}): ${text}`);
+    }
+
+    console.log(`✅ Grant revoked: '${toAgent}' can no longer read '${fromAgent}'s memories`);
+    console.log(`   Removed grant ID: ${grantId}`);
+  });
+
 // ─── flair status ─────────────────────────────────────────────────────────────
 
 program

--- a/test/agent-remove-and-grants.test.ts
+++ b/test/agent-remove-and-grants.test.ts
@@ -1,0 +1,413 @@
+/**
+ * agent-remove-and-grants.test.ts
+ *
+ * Tests for:
+ *   1. flair agent remove — delete agent, memories, souls, key files
+ *   2. flair grant — create MemoryGrant record
+ *   3. flair revoke — delete MemoryGrant record
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import { mkdirSync, rmSync, existsSync, writeFileSync, chmodSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { createServer, IncomingMessage, ServerResponse, Server } from "node:http";
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function makeTmpDir(): string {
+  const dir = join(tmpdir(), `flair-rmgrant-test-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+  mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+type Handler = (req: IncomingMessage, body: string, res: ServerResponse) => void;
+
+function startMockServer(handler: Handler): Promise<{ server: Server; url: string; port: number }> {
+  return new Promise((resolve) => {
+    const server = createServer((req, res) => {
+      let body = "";
+      req.on("data", (c) => (body += c));
+      req.on("end", () => handler(req, body, res));
+    });
+    server.listen(0, "127.0.0.1", () => {
+      const port = (server.address() as any).port;
+      resolve({ server, url: `http://127.0.0.1:${port}`, port });
+    });
+  });
+}
+
+function stopServer(server: Server): Promise<void> {
+  return new Promise((resolve, reject) => server.close((e) => (e ? reject(e) : resolve())));
+}
+
+function jsonRes(res: ServerResponse, status: number, data: unknown) {
+  res.writeHead(status, { "Content-Type": "application/json" });
+  res.end(JSON.stringify(data));
+}
+
+// ─── Inline agent remove logic (mirrors CLI) ──────────────────────────────────
+
+interface RemoveOpts {
+  agentId: string;
+  keysDir: string;
+  opsPort: number;
+  adminPass: string;
+  keepKeys?: boolean;
+  force?: boolean;
+}
+
+async function runAgentRemove(opts: RemoveOpts): Promise<{
+  memoriesDeleted: number;
+  soulsDeleted: number;
+  agentDeleted: boolean;
+  keysDeleted: boolean;
+}> {
+  const { agentId, keysDir, opsPort, adminPass, keepKeys = false } = opts;
+  const adminUser = "admin";
+  const auth = `Basic ${Buffer.from(`${adminUser}:${adminPass}`).toString("base64")}`;
+
+  async function opsPost(body: unknown): Promise<any> {
+    const res = await fetch(`http://127.0.0.1:${opsPort}/`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Authorization: auth },
+      body: JSON.stringify(body),
+      signal: AbortSignal.timeout(5000),
+    });
+    if (!res.ok) {
+      const text = await res.text().catch(() => "");
+      if (res.status === 404 || text.includes("not found")) return [];
+      throw new Error(`ops failed (${res.status}): ${text}`);
+    }
+    return res.json().catch(() => []);
+  }
+
+  // Get memories
+  const memories = await opsPost({ operation: "search_by_value", database: "flair", table: "Memory", search_attribute: "agentId", search_value: agentId, get_attributes: ["id"] });
+  const memList = Array.isArray(memories) ? memories : [];
+
+  // Delete memories
+  for (const m of memList) {
+    if (m?.id) await opsPost({ operation: "delete", database: "flair", table: "Memory", ids: [m.id] }).catch(() => {});
+  }
+
+  // Get souls
+  const souls = await opsPost({ operation: "search_by_value", database: "flair", table: "Soul", search_attribute: "agentId", search_value: agentId, get_attributes: ["id"] });
+  const soulList = Array.isArray(souls) ? souls : [];
+
+  // Delete souls
+  for (const s of soulList) {
+    if (s?.id) await opsPost({ operation: "delete", database: "flair", table: "Soul", ids: [s.id] }).catch(() => {});
+  }
+
+  // Delete agent
+  await opsPost({ operation: "delete", database: "flair", table: "Agent", ids: [agentId] });
+
+  // Delete key files
+  let keysDeleted = false;
+  if (!keepKeys) {
+    const privPath = join(keysDir, `${agentId}.key`);
+    const pubPath = join(keysDir, `${agentId}.pub`);
+    const backupPath = privPath + ".bak";
+    const { unlinkSync } = require("node:fs") as typeof import("node:fs");
+    for (const p of [privPath, pubPath, backupPath]) {
+      if (existsSync(p)) { try { unlinkSync(p); keysDeleted = true; } catch { /* best effort */ } }
+    }
+  }
+
+  return { memoriesDeleted: memList.length, soulsDeleted: soulList.length, agentDeleted: true, keysDeleted };
+}
+
+// ─── Inline grant/revoke logic ────────────────────────────────────────────────
+
+async function runGrant(opts: {
+  fromAgent: string;
+  toAgent: string;
+  scope: string;
+  opsPort: number;
+  adminPass: string;
+}): Promise<{ grantId: string; alreadyExists: boolean }> {
+  const { fromAgent, toAgent, scope, opsPort, adminPass } = opts;
+  const auth = `Basic ${Buffer.from(`admin:${adminPass}`).toString("base64")}`;
+  const grantId = `${fromAgent}:${toAgent}`;
+
+  const res = await fetch(`http://127.0.0.1:${opsPort}/`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json", Authorization: auth },
+    body: JSON.stringify({
+      operation: "insert",
+      database: "flair",
+      table: "MemoryGrant",
+      records: [{ id: grantId, fromAgentId: fromAgent, toAgentId: toAgent, scope, createdAt: new Date().toISOString() }],
+    }),
+    signal: AbortSignal.timeout(5000),
+  });
+
+  if (!res.ok) {
+    const text = await res.text().catch(() => "");
+    if (res.status === 409 || text.includes("duplicate")) return { grantId, alreadyExists: true };
+    throw new Error(`grant failed (${res.status}): ${text}`);
+  }
+  return { grantId, alreadyExists: false };
+}
+
+async function runRevoke(opts: {
+  fromAgent: string;
+  toAgent: string;
+  opsPort: number;
+  adminPass: string;
+}): Promise<{ revoked: boolean; notFound: boolean }> {
+  const { fromAgent, toAgent, opsPort, adminPass } = opts;
+  const auth = `Basic ${Buffer.from(`admin:${adminPass}`).toString("base64")}`;
+  const grantId = `${fromAgent}:${toAgent}`;
+
+  const res = await fetch(`http://127.0.0.1:${opsPort}/`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json", Authorization: auth },
+    body: JSON.stringify({ operation: "delete", database: "flair", table: "MemoryGrant", ids: [grantId] }),
+    signal: AbortSignal.timeout(5000),
+  });
+
+  if (!res.ok) {
+    const text = await res.text().catch(() => "");
+    if (res.status === 404 || text.includes("not found")) return { revoked: false, notFound: true };
+    throw new Error(`revoke failed (${res.status}): ${text}`);
+  }
+  return { revoked: true, notFound: false };
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe("flair agent remove", () => {
+  let tmpDir: string;
+  let opsServer: { server: Server; url: string; port: number };
+  let requests: Array<{ method: string; body: any }>;
+
+  const MEMORIES = [{ id: "m1" }, { id: "m2" }];
+  const SOULS = [{ id: "flint:soul" }];
+
+  beforeEach(async () => {
+    tmpDir = makeTmpDir();
+    requests = [];
+
+    opsServer = await startMockServer((req, body, res) => {
+      let parsed: any = {};
+      try { parsed = JSON.parse(body); } catch {}
+      requests.push({ method: req.method ?? "GET", body: parsed });
+
+      if (parsed.operation === "search_by_value" && parsed.table === "Memory") return jsonRes(res, 200, MEMORIES);
+      if (parsed.operation === "search_by_value" && parsed.table === "Soul") return jsonRes(res, 200, SOULS);
+      if (parsed.operation === "search_by_value" && parsed.table === "Agent") return jsonRes(res, 200, [{ id: "flint", name: "Flint" }]);
+      if (parsed.operation === "delete") return jsonRes(res, 200, { deleted_hashes: 1 });
+      jsonRes(res, 200, {});
+    });
+  });
+
+  afterEach(async () => {
+    await stopServer(opsServer.server);
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("deletes all memories and souls before agent", async () => {
+    const result = await runAgentRemove({
+      agentId: "flint",
+      keysDir: join(tmpDir, "keys"),
+      opsPort: opsServer.port,
+      adminPass: "test123",
+      force: true,
+    });
+
+    expect(result.memoriesDeleted).toBe(2);
+    expect(result.soulsDeleted).toBe(1);
+    expect(result.agentDeleted).toBe(true);
+  });
+
+  it("sends correct delete operations for each record", async () => {
+    await runAgentRemove({
+      agentId: "flint",
+      keysDir: join(tmpDir, "keys"),
+      opsPort: opsServer.port,
+      adminPass: "test123",
+      force: true,
+    });
+
+    const deletes = requests.filter(r => r.body.operation === "delete");
+    // m1, m2, flint:soul, flint agent = 4 deletes
+    expect(deletes.length).toBe(4);
+
+    const memDeletes = deletes.filter(r => r.body.table === "Memory");
+    expect(memDeletes).toHaveLength(2);
+
+    const agentDelete = deletes.find(r => r.body.table === "Agent");
+    expect(agentDelete?.body.ids).toContain("flint");
+  });
+
+  it("deletes key files by default", async () => {
+    const keysDir = join(tmpDir, "keys");
+    mkdirSync(keysDir, { recursive: true });
+    const privPath = join(keysDir, "flint.key");
+    const pubPath = join(keysDir, "flint.pub");
+    writeFileSync(privPath, Buffer.alloc(32, 0x01));
+    writeFileSync(pubPath, Buffer.alloc(32, 0x02));
+
+    const result = await runAgentRemove({
+      agentId: "flint",
+      keysDir,
+      opsPort: opsServer.port,
+      adminPass: "test123",
+      force: true,
+    });
+
+    expect(result.keysDeleted).toBe(true);
+    expect(existsSync(privPath)).toBe(false);
+    expect(existsSync(pubPath)).toBe(false);
+  });
+
+  it("preserves key files with --keep-keys", async () => {
+    const keysDir = join(tmpDir, "keys");
+    mkdirSync(keysDir, { recursive: true });
+    const privPath = join(keysDir, "flint.key");
+    writeFileSync(privPath, Buffer.alloc(32, 0x01));
+
+    const result = await runAgentRemove({
+      agentId: "flint",
+      keysDir,
+      opsPort: opsServer.port,
+      adminPass: "test123",
+      keepKeys: true,
+      force: true,
+    });
+
+    expect(result.keysDeleted).toBe(false);
+    expect(existsSync(privPath)).toBe(true);
+  });
+
+  it("uses Basic auth for all operations API calls", async () => {
+    const authHeaders: string[] = [];
+    await stopServer(opsServer.server);
+    opsServer = await startMockServer((req, body, res) => {
+      authHeaders.push(req.headers.authorization ?? "");
+      let parsed: any = {};
+      try { parsed = JSON.parse(body); } catch {}
+      if (parsed.operation === "search_by_value") return jsonRes(res, 200, []);
+      jsonRes(res, 200, { deleted_hashes: 1 });
+    });
+
+    await runAgentRemove({
+      agentId: "flint",
+      keysDir: join(tmpDir, "keys"),
+      opsPort: opsServer.port,
+      adminPass: "removepass",
+      force: true,
+    });
+
+    expect(authHeaders.length).toBeGreaterThan(0);
+    for (const h of authHeaders) {
+      expect(h).toStartWith("Basic ");
+      const decoded = Buffer.from(h.replace("Basic ", ""), "base64").toString();
+      expect(decoded).toBe("admin:removepass");
+    }
+  });
+});
+
+describe("flair grant", () => {
+  let tmpDir: string;
+  let opsServer: { server: Server; url: string; port: number };
+  let requests: Array<{ body: any; authHeader: string }>;
+
+  beforeEach(async () => {
+    tmpDir = makeTmpDir();
+    requests = [];
+    opsServer = await startMockServer((req, body, res) => {
+      let parsed: any = {};
+      try { parsed = JSON.parse(body); } catch {}
+      requests.push({ body: parsed, authHeader: req.headers.authorization ?? "" });
+      jsonRes(res, 200, { inserted_hashes: 1 });
+    });
+  });
+
+  afterEach(async () => {
+    await stopServer(opsServer.server);
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("inserts MemoryGrant record with correct fields", async () => {
+    const result = await runGrant({
+      fromAgent: "flint",
+      toAgent: "kern",
+      scope: "read",
+      opsPort: opsServer.port,
+      adminPass: "test123",
+    });
+
+    expect(result.grantId).toBe("flint:kern");
+    expect(result.alreadyExists).toBe(false);
+
+    const req = requests[0];
+    expect(req.body.operation).toBe("insert");
+    expect(req.body.table).toBe("MemoryGrant");
+    expect(req.body.records[0].id).toBe("flint:kern");
+    expect(req.body.records[0].fromAgentId).toBe("flint");
+    expect(req.body.records[0].toAgentId).toBe("kern");
+    expect(req.body.records[0].scope).toBe("read");
+  });
+
+  it("supports custom scope", async () => {
+    await runGrant({ fromAgent: "flint", toAgent: "kern", scope: "search", opsPort: opsServer.port, adminPass: "test123" });
+    expect(requests[0].body.records[0].scope).toBe("search");
+  });
+
+  it("uses Basic auth", async () => {
+    await runGrant({ fromAgent: "flint", toAgent: "kern", scope: "read", opsPort: opsServer.port, adminPass: "grantpass" });
+    const decoded = Buffer.from(requests[0].authHeader.replace("Basic ", ""), "base64").toString();
+    expect(decoded).toBe("admin:grantpass");
+  });
+
+  it("handles 409 duplicate gracefully", async () => {
+    await stopServer(opsServer.server);
+    opsServer = await startMockServer((_req, _body, res) => jsonRes(res, 409, { error: "duplicate" }));
+
+    const result = await runGrant({ fromAgent: "flint", toAgent: "kern", scope: "read", opsPort: opsServer.port, adminPass: "test123" });
+    expect(result.alreadyExists).toBe(true);
+  });
+});
+
+describe("flair revoke", () => {
+  let tmpDir: string;
+  let opsServer: { server: Server; url: string; port: number };
+  let requests: Array<{ body: any }>;
+
+  beforeEach(async () => {
+    tmpDir = makeTmpDir();
+    requests = [];
+    opsServer = await startMockServer((req, body, res) => {
+      let parsed: any = {};
+      try { parsed = JSON.parse(body); } catch {}
+      requests.push({ body: parsed });
+      jsonRes(res, 200, { deleted_hashes: 1 });
+    });
+  });
+
+  afterEach(async () => {
+    await stopServer(opsServer.server);
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("deletes MemoryGrant with correct id", async () => {
+    const result = await runRevoke({ fromAgent: "flint", toAgent: "kern", opsPort: opsServer.port, adminPass: "test123" });
+
+    expect(result.revoked).toBe(true);
+    expect(requests[0].body.operation).toBe("delete");
+    expect(requests[0].body.table).toBe("MemoryGrant");
+    expect(requests[0].body.ids).toContain("flint:kern");
+  });
+
+  it("handles 404 not found gracefully", async () => {
+    await stopServer(opsServer.server);
+    opsServer = await startMockServer((_req, _body, res) => jsonRes(res, 404, { error: "not found" }));
+
+    const result = await runRevoke({ fromAgent: "flint", toAgent: "kern", opsPort: opsServer.port, adminPass: "test123" });
+    expect(result.notFound).toBe(true);
+    expect(result.revoked).toBe(false);
+  });
+});


### PR DESCRIPTION
## feat/agent-remove-and-grants

### `flair agent remove <id>`
```
flair agent remove <id> [--keep-keys] [--force] [--port] [--admin-pass]
```
- Fetches memory count for confirmation message
- Interactive confirmation: prints agent name + memory count, requires typing `yes`
- Non-TTY: requires `--force` flag (fails with clear error otherwise)
- Deletes all memories → all souls → agent record (via ops API)
- Deletes key files (`<agent>.key`, `<agent>.pub`, `<agent>.key.bak`) unless `--keep-keys`
- All ops API calls use Basic admin auth

### `flair grant <from-agent> <to-agent>`
```
flair grant <from> <to> [--scope read|search] [--admin-pass]
```
- Inserts MemoryGrant record: `{id: 'from:to', fromAgentId, toAgentId, scope, createdAt}`
- 409 duplicate handled gracefully (prints info, exits 0)

### `flair revoke <from-agent> <to-agent>`
```
flair revoke <from> <to> [--admin-pass]
```
- Deletes MemoryGrant record by id `from:to`
- 404 not found handled gracefully

### Tests (11 passing, 0 new failures)
- remove: deletes memories+souls+agent; correct ops sequence; key file deletion; --keep-keys; Basic auth
- grant: correct fields; custom scope; Basic auth; 409 graceful
- revoke: correct delete id; 404 graceful