### PR TITLE
fix: Memory search auth scoping — use this.getContext() instead of parameter

### DIFF
--- a/resources/Memory.ts
+++ b/resources/Memory.ts
@@ -13,13 +13,16 @@ export class Memory extends (databases as any).flair.Memory {
    * Admin agents and unauthenticated internal calls pass through unfiltered.
    * Non-admin calls also check MemoryGrant to include granted memories.
    */
-  async search(query?: any, context?: any) {
-    const authAgent: string | undefined = context?.request?.tpsAgent;
-    const isAdminAgent: boolean = context?.request?.tpsAgentIsAdmin ?? false;
+  async search(query?: any) {
+    // Access request context via Harper's Resource instance context
+    const ctx = (this as any).getContext?.();
+    const request = ctx?.request ?? ctx;
+    const authAgent: string | undefined = request?.tpsAgent;
+    const isAdminAgent: boolean = request?.tpsAgentIsAdmin ?? false;
 
     // No auth context (internal admin call) or admin agent — unfiltered
     if (!authAgent || isAdminAgent) {
-      return super.search(query, context);
+      return super.search(query);
     }
 
     // Collect agentIds this agent may read: own + any granted owners
@@ -58,7 +61,7 @@ export class Memory extends (databases as any).flair.Memory {
       scopedQuery = { conditions: [agentIdCondition], and: query };
     }
 
-    return super.search(scopedQuery, context);
+    return super.search(scopedQuery);
   }
 
   async post(content: any, context?: any) {

--- a/resources/Memory.ts
+++ b/resources/Memory.ts
@@ -95,10 +95,10 @@ export class Memory extends (databases as any).flair.Memory {
       content.expiresAt = new Date(Date.now() + ttlHours * 3600_000).toISOString();
     }
 
-    return super.post(content, context);
+    return super.post(content);
   }
 
-  async put(content: any, context?: any) {
+  async put(content: any) {
     const now = new Date().toISOString();
     content.updatedAt = now;
 
@@ -118,16 +118,18 @@ export class Memory extends (databases as any).flair.Memory {
       content.durability = "permanent";
     }
 
-    return super.put(content, context);
+    return super.put(content);
   }
 
-  async delete(id: any, context?: any) {
+  async delete(id: any) {
     const record = await this.get(id);
-    if (!record) return super.delete(id, context);
+    if (!record) return super.delete(id);
 
     if (record.durability === "permanent") {
       // Middleware already guards this for non-admins, but belt-and-suspenders
-      const actorId = context?.request?.tpsAgent;
+      const ctx = (this as any).getContext?.();
+      const request = ctx?.request ?? ctx;
+      const actorId = request?.tpsAgent;
       if (actorId && !(await isAdmin(actorId))) {
         return new Response(JSON.stringify({ error: "permanent_memory_cannot_be_deleted_by_non_admin" }), {
           status: 403,
@@ -136,6 +138,6 @@ export class Memory extends (databases as any).flair.Memory {
       }
     }
 
-    return super.delete(id, context);
+    return super.delete(id);
   }
 }

--- a/resources/WorkspaceState.ts
+++ b/resources/WorkspaceState.ts
@@ -3,6 +3,9 @@
  *
  * Auth: Ed25519 middleware sets request.tpsAgent. Agent can only read/write own records.
  * Pattern follows Memory.ts — extends Harper auto-generated table class.
+ *
+ * Note: Harper's static methods call instance methods with positional args only.
+ * Use this.getContext() to access request context (tpsAgent, tpsAgentIsAdmin).
  */
 
 import { databases } from "@harperfast/harper";
@@ -10,15 +13,26 @@ import { isAdmin } from "./auth-middleware.js";
 
 export class WorkspaceState extends (databases as any).flair.WorkspaceState {
   /**
+   * Helper to extract auth info from Harper's Resource instance context.
+   */
+  private _authInfo() {
+    const ctx = (this as any).getContext?.();
+    const request = ctx?.request ?? ctx;
+    return {
+      agentId: request?.tpsAgent as string | undefined,
+      isAdmin: request?.tpsAgentIsAdmin as boolean ?? false,
+    };
+  }
+
+  /**
    * Override search() to scope collection GETs to the authenticated agent's
    * own workspace state records. Admin agents see all records.
    */
-  async search(query?: any, context?: any) {
-    const authAgent: string | undefined = context?.request?.tpsAgent;
-    const isAdminAgent: boolean = context?.request?.tpsAgentIsAdmin ?? false;
+  async search(query?: any) {
+    const { agentId: authAgent, isAdmin: isAdminAgent } = this._authInfo();
 
     if (!authAgent || isAdminAgent) {
-      return super.search(query, context);
+      return super.search(query);
     }
 
     const agentIdCondition = { attribute: "agentId", comparator: "equals", value: authAgent };
@@ -30,14 +44,14 @@ export class WorkspaceState extends (databases as any).flair.WorkspaceState {
       scopedQuery = { conditions: [agentIdCondition], and: query };
     }
 
-    return super.search(scopedQuery, context);
+    return super.search(scopedQuery);
   }
 
-  async post(content: any, context?: any) {
-    const agentId = context?.request?.tpsAgent;
+  async post(content: any) {
+    const { agentId, isAdmin: isAdminAgent } = this._authInfo();
 
     // Agent-scoped: agentId in body must match authenticated agent
-    if (agentId && !context?.request?.tpsAgentIsAdmin && content.agentId !== agentId) {
+    if (agentId && !isAdminAgent && content.agentId !== agentId) {
       return new Response(
         JSON.stringify({ error: "forbidden: cannot write workspace state for another agent" }),
         { status: 403, headers: { "Content-Type": "application/json" } },
@@ -47,36 +61,36 @@ export class WorkspaceState extends (databases as any).flair.WorkspaceState {
     content.createdAt = new Date().toISOString();
     content.timestamp ||= content.createdAt;
 
-    return super.post(content, context);
+    return super.post(content);
   }
 
-  async put(content: any, context?: any) {
-    const agentId = context?.request?.tpsAgent;
+  async put(content: any) {
+    const { agentId, isAdmin: isAdminAgent } = this._authInfo();
 
-    if (agentId && !context?.request?.tpsAgentIsAdmin && content.agentId !== agentId) {
+    if (agentId && !isAdminAgent && content.agentId !== agentId) {
       return new Response(
         JSON.stringify({ error: "forbidden: cannot write workspace state for another agent" }),
         { status: 403, headers: { "Content-Type": "application/json" } },
       );
     }
 
-    return super.put(content, context);
+    return super.put(content);
   }
 
-  async delete(id: any, context?: any) {
-    const agentId = context?.request?.tpsAgent;
-    if (!agentId) return super.delete(id, context);
+  async delete(id: any) {
+    const { agentId, isAdmin: isAdminAgent } = this._authInfo();
+    if (!agentId) return super.delete(id);
 
     const record = await this.get(id);
-    if (!record) return super.delete(id, context);
+    if (!record) return super.delete(id);
 
-    if (!context?.request?.tpsAgentIsAdmin && record.agentId !== agentId) {
+    if (!isAdminAgent && record.agentId !== agentId) {
       return new Response(
         JSON.stringify({ error: "forbidden: cannot delete workspace state for another agent" }),
         { status: 403, headers: { "Content-Type": "application/json" } },
       );
     }
 
-    return super.delete(id, context);
+    return super.delete(id);
   }
 }


### PR DESCRIPTION
## Problem

`GET /Memory/` returned all agents' memories regardless of authentication. Auth scoping was completely bypassed.

## Root Cause

Harper's `static search()` calls `resource.search(query)` with **one argument**. Our Memory class overrode `search(query?, context?)` expecting context as a second parameter — but Harper never passes it. The `context` was always `undefined`, so the scoping check fell through to the unfiltered path.

## Fix

Use `this.getContext()` (Harper's Resource instance context) to access the request object, which contains `tpsAgent` set by auth-middleware. This is the documented way to access request context inside instance methods.

## Verification

```
Before: GET /Memory/ as flint → 113 records (all agents)
After:  GET /Memory/ as flint → only flint's records
        GET /Memory/ as kern  → only kern's records
```

**Security fix** — memory isolation between agents was not enforced on collection listings.