### PR TITLE
fix: Memory/WorkspaceState search — inject conditions into RequestTarget

### DIFF
--- a/resources/Memory.ts
+++ b/resources/Memory.ts
@@ -37,31 +37,26 @@ export class Memory extends (databases as any).flair.Memory {
       }
     } catch { /* MemoryGrant table not yet populated — ignore */ }
 
-    // Build an agentId condition: own memories OR granted owners
-    // If more than one allowed owner, use "or" across equals conditions
-    let agentIdCondition: any;
-    if (allowedOwners.length === 1) {
-      agentIdCondition = { attribute: "agentId", comparator: "equals", value: allowedOwners[0] };
-    } else {
-      agentIdCondition = allowedOwners.map((id, i) => {
-        const cond = { attribute: "agentId", comparator: "equals", value: id };
-        return i === 0 ? cond : ["or", cond];
-      });
+    // Build the agentId scope condition
+    const agentIdCondition: any = allowedOwners.length === 1
+      ? { attribute: "agentId", comparator: "equals", value: allowedOwners[0] }
+      : { conditions: allowedOwners.map(id => ({ attribute: "agentId", comparator: "equals", value: id })), operator: "or" };
+
+    // Harper passes `query` as a RequestTarget (extends URLSearchParams) with pathname, id, etc.
+    // Table.search() reads `target.conditions` from it. We inject our scope condition there.
+    if (query && typeof query === "object" && !Array.isArray(query)) {
+      const existing = query.conditions ?? [];
+      query.conditions = Array.isArray(existing)
+        ? [agentIdCondition, ...existing]
+        : [agentIdCondition, existing];
+      return super.search(query);
     }
 
-    // Firmly wrap user query in outer `and` so they cannot escape the scope check
-    let scopedQuery: any;
-    if (!query || (Array.isArray(query) && query.length === 0)) {
-      // No user query — just the agentId filter
-      scopedQuery = Array.isArray(agentIdCondition)
-        ? agentIdCondition
-        : [agentIdCondition];
-    } else {
-      // Wrap: { and: [agentIdCondition, userQuery] } expressed as Harper conditions
-      scopedQuery = { conditions: [agentIdCondition], and: query };
-    }
-
-    return super.search(scopedQuery);
+    // Fallback: plain array or no query (internal calls)
+    const conditions = Array.isArray(query) && query.length > 0
+      ? [agentIdCondition, ...query]
+      : [agentIdCondition];
+    return super.search(conditions);
   }
 
   async post(content: any, context?: any) {

--- a/resources/WorkspaceState.ts
+++ b/resources/WorkspaceState.ts
@@ -37,14 +37,20 @@ export class WorkspaceState extends (databases as any).flair.WorkspaceState {
 
     const agentIdCondition = { attribute: "agentId", comparator: "equals", value: authAgent };
 
-    let scopedQuery: any;
-    if (!query || (Array.isArray(query) && query.length === 0)) {
-      scopedQuery = [agentIdCondition];
-    } else {
-      scopedQuery = { conditions: [agentIdCondition], and: query };
+    // Harper passes `query` as a request target object (with pathname, id, isCollection, etc.)
+    // Inject scope condition into its `.conditions` array so Table.search() processes it correctly.
+    if (query && typeof query === "object" && !Array.isArray(query)) {
+      const existing = query.conditions ?? [];
+      query.conditions = Array.isArray(existing)
+        ? [agentIdCondition, ...existing]
+        : [agentIdCondition, existing];
+      return super.search(query);
     }
 
-    return super.search(scopedQuery);
+    const conditions = Array.isArray(query) && query.length > 0
+      ? [agentIdCondition, ...query]
+      : [agentIdCondition];
+    return super.search(conditions);
   }
 
   async post(content: any) {


### PR DESCRIPTION
## Problem

Scoped `GET /Memory/` returned only 19 of 48 flint memories after the auth scoping fix in #67. Auth worked (only flint's records returned), but most were missing.

## Root Causes

**1. Wrong query format**: Harper passes `query` as a `RequestTarget` object (extends `URLSearchParams`), not a plain object/array. Our code was wrapping it in `{ conditions: [...], and: query }` which Harper's `Table.search()` couldn't process correctly. 

**Fix**: Inject scope condition directly into `query.conditions` array on the original `RequestTarget`.

**2. Missing index entries**: Records batch-inserted via Operations API `insert` during the database migration didn't have secondary indexes (like `agentId`) fully built. Only ~19 of 48 records were indexed.

**Fix**: Ran Ops API `update` on all records to rebuild indexes. Documented for future migrations.

## Verification

```
Before: GET /Memory/ as flint → 19 records (partial)
After:  GET /Memory/ as flint → 48 records (all own memories)
        GET /Memory/ as kern  → 5 records (kern only)
        GET /Memory/ as admin → 113 records (all agents)
```

## Migration Note

After bulk `insert` via Operations API, run `update` on all records to rebuild secondary indexes. This is a Harper behavior — `insert` may not fully index all attributes.