### PR TITLE
feat: flair migrate-keys command

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -532,7 +532,7 @@ agent
       const backupPath = privPath + ".bak";
       for (const p of [privPath, pubPath, backupPath]) {
         if (existsSync(p)) {
-          try { require("node:fs").unlinkSync(p); } catch { /* best effort */ }
+          try { const { unlinkSync: ul } = await import("node:fs"); ul(p); } catch { /* best effort */ }
         }
       }
       console.log("Key files deleted.");
@@ -960,6 +960,120 @@ program
     console.log(`   Agents restored:   ${agentCount}/${agents.length}`);
     console.log(`   Memories restored: ${memoryCount}/${memories.length}`);
     console.log(`   Souls restored:    ${soulCount}/${souls.length}`);
+  });
+
+// ─── flair migrate-keys ───────────────────────────────────────────────────────
+
+program
+  .command("migrate-keys")
+  .description("Migrate agent keys from legacy path (~/.tps/secrets/flair/) to ~/.flair/keys/")
+  .option("--from <dir>", "Legacy keys directory", join(homedir(), ".tps", "secrets", "flair"))
+  .option("--to <dir>", "New keys directory", defaultKeysDir())
+  .option("--dry-run", "Show what would be migrated without copying")
+  .option("--port <port>", "Harper HTTP port (for agent list)", String(DEFAULT_PORT))
+  .option("--ops-port <port>", "Harper operations API port")
+  .option("--admin-pass <pass>", "Admin password (or set FLAIR_ADMIN_PASS env)")
+  .action(async (opts) => {
+    const fromDir: string = opts.from;
+    const toDir: string = opts.to;
+    const dryRun: boolean = opts.dryRun ?? false;
+    const opsPort = opts.opsPort ? Number(opts.opsPort) : Number(opts.port) + 1;
+    const adminPass: string = opts.adminPass ?? process.env.FLAIR_ADMIN_PASS ?? "";
+
+    if (!existsSync(fromDir)) {
+      console.log(`Legacy keys directory not found: ${fromDir}`);
+      console.log("Nothing to migrate.");
+      process.exit(0);
+    }
+
+    // Discover legacy keys: <id>-priv.key pattern
+    const { readdirSync, unlinkSync } = await import("node:fs");
+    const files = readdirSync(fromDir) as string[];
+    const keyFiles = files.filter((f: string) => f.endsWith("-priv.key"));
+
+    if (keyFiles.length === 0) {
+      console.log(`No legacy key files found in ${fromDir}`);
+      process.exit(0);
+    }
+
+    console.log(`Found ${keyFiles.length} legacy key file(s) in ${fromDir}:`);
+
+    let migrated = 0;
+    let skipped = 0;
+
+    for (const file of keyFiles) {
+      const agentId = file.replace("-priv.key", "");
+      const srcPath = join(fromDir, file);
+      const destPath = join(toDir, `${agentId}.key`);
+
+      if (existsSync(destPath)) {
+        console.log(`  skip: ${agentId} — already exists at ${destPath}`);
+        skipped++;
+        continue;
+      }
+
+      if (dryRun) {
+        console.log(`  would migrate: ${srcPath} → ${destPath}`);
+        migrated++;
+        continue;
+      }
+
+      mkdirSync(toDir, { recursive: true });
+      const keyData = readFileSync(srcPath);
+      writeFileSync(destPath, keyData);
+      chmodSync(destPath, 0o600);
+      console.log(`  migrated: ${agentId} → ${destPath}`);
+      migrated++;
+    }
+
+    if (dryRun) {
+      console.log(`\n🔍 Dry run: ${migrated} key(s) would be migrated, ${skipped} skipped`);
+    } else {
+      console.log(`\n✅ Migration complete: ${migrated} migrated, ${skipped} skipped`);
+      if (migrated > 0) {
+        console.log(`\nLegacy keys preserved at ${fromDir} (delete manually when confirmed working).`);
+
+        // Optionally verify keys match Flair records
+        if (adminPass) {
+          console.log("\nVerifying migrated keys against Flair...");
+          const auth = `Basic ${Buffer.from(`${DEFAULT_ADMIN_USER}:${adminPass}`).toString("base64")}`;
+          for (const file of keyFiles) {
+            const agentId = file.replace("-priv.key", "");
+            const destPath = join(toDir, `${agentId}.key`);
+            if (!existsSync(destPath)) continue;
+
+            try {
+              const keyB64 = readFileSync(destPath, "utf-8").trim();
+              const seed = Buffer.from(keyB64, "base64");
+              const kp = nacl.sign.keyPair.fromSeed(new Uint8Array(seed));
+              const localPub = b64url(kp.publicKey);
+
+              const res = await fetch(`http://127.0.0.1:${opsPort}/`, {
+                method: "POST",
+                headers: { "Content-Type": "application/json", Authorization: auth },
+                body: JSON.stringify({ operation: "search_by_value", database: "flair", table: "Agent", search_attribute: "id", search_value: agentId, get_attributes: ["id", "publicKey"] }),
+                signal: AbortSignal.timeout(10_000),
+              });
+              if (res.ok) {
+                const agents = await res.json();
+                if (Array.isArray(agents) && agents.length > 0) {
+                  const remotePub = agents[0].publicKey;
+                  if (remotePub === localPub) {
+                    console.log(`  ✅ ${agentId}: key matches Flair`);
+                  } else {
+                    console.log(`  ⚠️  ${agentId}: key MISMATCH — local key doesn't match Flair record`);
+                  }
+                } else {
+                  console.log(`  ⚠️  ${agentId}: not found in Flair`);
+                }
+              }
+            } catch (err: any) {
+              console.log(`  ⚠️  ${agentId}: verification failed — ${err.message}`);
+            }
+          }
+        }
+      }
+    }
   });
 
 await program.parseAsync();


### PR DESCRIPTION
Adds `flair migrate-keys` command to migrate agent Ed25519 keys from legacy `~/.tps/secrets/flair/<id>-priv.key` to new standard `~/.flair/keys/<id>.key`.

**Features:**
- Auto-discovers legacy keys by `*-priv.key` pattern
- Skips already-migrated keys
- `--dry-run` for preview
- Optional key verification against Flair records (`--admin-pass`)
- Preserves legacy keys (manual delete after confirming)
- `--from` / `--to` for custom source/destination dirs

Also fixes `require()` → `import()` in agent remove command (ESM compat).

**Testing:**
- Manual: `flair migrate-keys --dry-run` correctly found 8 legacy keys, all 8 already migrated
- Existing tests: 121 pass, 2 fail (pre-existing E2E — Harper v5 fresh install issue)