### PR TITLE
chore: bump Node.js engine to >=22

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ dist/
 .flair/
 .DS_Store
 package-lock.json
+*.gguf

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "test": "bun test"
   },
   "engines": {
-    "node": ">=20"
+    "node": ">=22"
   },
   "dependencies": {
     "@harperfast/harper": "5.0.0-beta.1",

--- a/plugins/openclaw-memory/package.json
+++ b/plugins/openclaw-memory/package.json
@@ -31,6 +31,9 @@
   "peerDependencies": {
     "openclaw": ">=2025.0.0"
   },
+  "engines": {
+    "node": ">=22"
+  },
   "dependencies": {
     "@sinclair/typebox": "^0.34.0"
   }


### PR DESCRIPTION
Bump minimum Node.js from 20 to 22 (current LTS) for both @tps/flair and @tps/openclaw-flair. Also adds *.gguf to .gitignore to prevent model files from being committed.

Prep for npm publish.