### PR TITLE
chore: pre-publish fixes — scope rename, CI bump, README

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,7 +51,7 @@ jobs:
             -e OPERATIONSAPI_NETWORK_PORT=9925 \
             -e HTTP_PORT=9926 \
             --entrypoint /bin/sh \
-            harperfast/harper-pro:5.0.0-alpha.3 \
+            harperfast/harper:5.0.0-beta.1 \
             -c "harper install && harper dev /flair" 
       - name: Run integration tests against Docker Harper
         run: bun test test/integration/

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ One Flair instance serves any number of agents. Each agent has its own keys, mem
 
 ```bash
 # Install
-npm install -g @tps/flair
+npm install -g @tpsdev-ai/flair
 
 # Bootstrap a Flair instance (installs Harper, creates database, starts service)
 flair init
@@ -95,14 +95,14 @@ That's it. Your agent now has identity and memory.
 ### Use with OpenClaw
 
 ```bash
-npm install @tps/openclaw-flair
+npm install @tpsdev-ai/openclaw-flair
 ```
 
 Add to your `openclaw.json`:
 ```json
 {
   "memory": {
-    "provider": "@tps/openclaw-flair"
+    "provider": "@tpsdev-ai/openclaw-flair"
   }
 }
 ```
@@ -158,7 +158,7 @@ flair/
 │   ├── MemoryBootstrap.ts    # Cold start context assembly
 │   └── MemoryFeed.ts         # Real-time memory changes
 ├── plugins/
-│   └── openclaw-memory/       # @tps/openclaw-flair plugin
+│   └── openclaw-memory/       # @tpsdev-ai/openclaw-flair plugin
 └── SECURITY.md                # Threat model + auth documentation
 ```
 
@@ -219,7 +219,7 @@ Integration tests spin up a real Harper instance on a random port, run the test 
 
 ## Status
 
-> **Note:** Flair uses [Harper v5](https://github.com/HarperFast/harper), currently in alpha. We run it in production daily and track upstream closely. Pin your Harper version.
+> **Note:** Flair uses [Harper v5](https://github.com/HarperFast/harper), currently in beta. We run it in production daily and track upstream closely. Pin your Harper version.
 
 Flair is in active development and daily use. We dogfood it — the agents that build Flair use Flair for their own memory and identity. 7 agents, 150+ memories, running continuously since March 2026.
 

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@tps/flair",
+  "name": "@tpsdev-ai/flair",
   "version": "0.2.0",
   "description": "Identity, memory, and soul for AI agents. Cryptographic identity (Ed25519), semantic memory with local embeddings, and persistent personality — all in a single process.",
   "type": "module",

--- a/plugins/openclaw-memory/README.md
+++ b/plugins/openclaw-memory/README.md
@@ -1,4 +1,4 @@
-# @tps/openclaw-flair
+# @tpsdev-ai/openclaw-flair
 
 OpenClaw memory plugin for Flair — agent identity and semantic memory. Replaces the built-in `MEMORY.md` / `memory-lancedb` system with [Flair](https://github.com/tpsdev-ai/flair) as the single source of truth for agent memory.
 
@@ -25,7 +25,7 @@ Uses Flair's native Harper vector embeddings — no OpenAI API key required.
 
 ```bash
 # From npm (when published)
-openclaw plugin install @tps/openclaw-flair
+openclaw plugin install @tpsdev-ai/openclaw-flair
 
 # From source
 cd plugins/openclaw-memory

--- a/plugins/openclaw-memory/package.json
+++ b/plugins/openclaw-memory/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@tps/openclaw-flair",
+  "name": "@tpsdev-ai/openclaw-flair",
   "version": "0.1.0",
   "description": "OpenClaw memory plugin for Flair — agent identity and semantic memory",
   "type": "module",


### PR DESCRIPTION
Prep for npm publish:

- **Scope rename**: `@tps/flair` → `@tpsdev-ai/flair`, `@tps/openclaw-flair` → `@tpsdev-ai/openclaw-flair` (matches existing npm org)
- **CI**: Docker image `harper-pro:5.0.0-alpha.3` → `5.0.0-beta.1` (matches production)
- **README**: Harper 'alpha' → 'beta'

All references updated across README, plugin README, both package.json files, and CI workflow.