### PR TITLE
fix: make agentId optional in plugin config

### DIFF
--- a/plugins/openclaw-memory/index.ts
+++ b/plugins/openclaw-memory/index.ts
@@ -277,7 +277,7 @@ export default {
     
     function getClient(agentId?: string): FlairMemoryClient {
       const id = agentId || cfg.agentId;
-      if (!id || id === "auto") throw new Error("no agentId available");
+      if (!id || id === "auto") throw new Error("no agentId available — set agentId in plugin config or ensure OpenClaw provides it via session context");
       let client = clientPool.get(id);
       if (!client) {
         client = new FlairMemoryClient({ ...cfg, agentId: id });
@@ -291,8 +291,11 @@ export default {
       getClient(cfg.agentId);
     }
 
-    api.logger.info("openclaw-flair: config ok, creating client...");
-    api.logger.info("openclaw-flair: client created");
+    if (!isAutoMode) {
+      api.logger.info("openclaw-flair: client created");
+    } else {
+      api.logger.info("openclaw-flair: auto mode — agentId will be resolved from session context");
+    }
     const maxRecall = cfg.maxRecallResults ?? DEFAULT_MAX_RECALL;
     const autoCapture = cfg.autoCapture ?? true;
     const autoRecall = cfg.autoRecall ?? true;

--- a/plugins/openclaw-memory/openclaw.plugin.json
+++ b/plugins/openclaw-memory/openclaw.plugin.json
@@ -10,7 +10,7 @@
     "agentId": {
       "label": "Agent ID",
       "placeholder": "flint",
-      "help": "TPS agent identifier (used for memory namespacing)"
+      "help": "Agent identifier for memory namespacing. Auto-detected from OpenClaw agent name if omitted."
     },
     "keyPath": {
       "label": "Private Key Path",
@@ -40,6 +40,6 @@
       "maxRecallResults": { "type": "number", "minimum": 1, "maximum": 20 },
       "maxBootstrapTokens": { "type": "number", "minimum": 500, "maximum": 8000 }
     },
-    "required": ["agentId"]
+    "required": []
   }
 }

--- a/plugins/openclaw-memory/package.json
+++ b/plugins/openclaw-memory/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tpsdev-ai/openclaw-flair",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "OpenClaw memory plugin for Flair — agent identity and semantic memory",
   "type": "module",
   "main": "index.ts",


### PR DESCRIPTION
Fixes #78

`openclaw plugins enable openclaw-flair` was failing with:
```
Config validation failed: must have required property 'agentId'
```

**Fix:** Remove `agentId` from `required` in configSchema. The plugin already has auto-detection logic — it resolves agentId from the OpenClaw session context at runtime.

Zero-config install now works:
```
openclaw plugins install @tpsdev-ai/openclaw-flair
openclaw plugins enable openclaw-flair
# Just works — agentId comes from OpenClaw agent name
```

Bumps to v0.1.3.