### PR TITLE
fix: handle empty pluginConfig on zero-config install

### DIFF
--- a/plugins/openclaw-flair/index.ts
+++ b/plugins/openclaw-flair/index.ts
@@ -271,7 +271,7 @@ export default {
 
   register(api: OpenClawPluginApi) {
     try {
-    const cfg = api.pluginConfig as FlairMemoryConfig;
+    const cfg = (api.pluginConfig ?? {}) as FlairMemoryConfig;
     const isAutoMode = !cfg.agentId || cfg.agentId === "auto";
 
     // Client pool: one client per agentId, created lazily

--- a/plugins/openclaw-flair/package.json
+++ b/plugins/openclaw-flair/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tpsdev-ai/openclaw-flair",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "OpenClaw memory plugin for Flair — agent identity and semantic memory",
   "type": "module",
   "main": "index.ts",


### PR DESCRIPTION
When `openclaw plugins install` creates an entry with just `{enabled: true}` and no `config` block, `api.pluginConfig` is undefined. The plugin crashed with:
```
Cannot read properties of undefined (reading 'agentId')
```

**Fix:** Default `pluginConfig` to `{}` so auto-mode works with truly zero config.

Found during end-to-end npm install test on Pulse. Bump to v0.1.4.