### PR TITLE
fix: resolve agentId from OpenClaw config in isolated sessions

### DIFF
--- a/plugins/openclaw-flair/index.ts
+++ b/plugins/openclaw-flair/index.ts
@@ -19,7 +19,7 @@ import { homedir } from "node:os";
 import { resolve } from "node:path";
 import { Type } from "@sinclair/typebox";
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
-import { resolveKeyPath, loadPrivateKey } from "./key-resolver.js";
+import { resolveKeyPath, loadPrivateKey, resolveAgentId } from "./key-resolver.js";
 
 // ─── Config ──────────────────────────────────────────────────────────────────
 
@@ -241,9 +241,12 @@ export default {
     // Client pool: one client per agentId, created lazily
     const clientPool = new Map<string, FlairMemoryClient>();
     
+    // Resolve fallback agentId once at registration time
+    const fallbackAgentId = resolveAgentId();
+
     function getClient(agentId?: string): FlairMemoryClient {
-      const id = agentId || cfg.agentId;
-      if (!id || id === "auto") throw new Error("no agentId available — set agentId in plugin config or ensure OpenClaw provides it via session context");
+      const id = agentId || cfg.agentId || fallbackAgentId;
+      if (!id || id === "auto") throw new Error("no agentId available — set agentId in plugin config, FLAIR_AGENT_ID env var, or ensure OpenClaw provides it via session context");
       let client = clientPool.get(id);
       if (!client) {
         client = new FlairMemoryClient({ ...cfg, agentId: id });
@@ -259,6 +262,8 @@ export default {
 
     if (!isAutoMode) {
       api.logger.info("openclaw-flair: client created");
+    } else if (fallbackAgentId) {
+      api.logger.info(`openclaw-flair: auto mode — fallback agentId="${fallbackAgentId}" (from config/env)`);
     } else {
       api.logger.info("openclaw-flair: auto mode — agentId will be resolved from session context");
     }
@@ -267,7 +272,7 @@ export default {
     const autoRecall = cfg.autoRecall ?? true;
 
     // Track current agent per-session via hooks (tools don't get agentId in execute)
-    let currentAgentId: string | undefined = isAutoMode ? undefined : cfg.agentId;
+    let currentAgentId: string | undefined = isAutoMode ? fallbackAgentId ?? undefined : cfg.agentId;
     
     api.on("before_agent_start", async (event: any, ctx: any) => {
       const eventAgentId = ctx?.agentId || (event as any).agentId;

--- a/plugins/openclaw-flair/key-resolver.ts
+++ b/plugins/openclaw-flair/key-resolver.ts
@@ -1,5 +1,5 @@
 /**
- * Key resolution for Flair Ed25519 authentication.
+ * Key and identity resolution for Flair authentication.
  * Separated from the HTTP client to avoid security scanner false positives
  * (env var access + network send in the same file).
  */
@@ -54,4 +54,31 @@ export function loadPrivateKey(keyPath: string): ReturnType<typeof import("node:
   } catch {
     return null;
   }
+}
+
+/**
+ * Resolve agent ID when not explicitly configured.
+ * Priority: FLAIR_AGENT_ID env > OpenClaw config file > null
+ */
+export function resolveAgentId(): string | null {
+  // 1. Explicit env var
+  const envId = process.env.FLAIR_AGENT_ID;
+  if (envId) return envId;
+
+  // 2. Read from OpenClaw config — first agent name
+  try {
+    const configPath = resolve(homedir(), ".openclaw", "openclaw.json");
+    if (!existsSync(configPath)) return null;
+    const config = JSON.parse(readFileSync(configPath, "utf-8"));
+    // agents.list[].name is the standard OpenClaw agent config
+    const agents = config?.agents?.list;
+    if (Array.isArray(agents) && agents.length > 0) {
+      const name = agents[0]?.name;
+      if (typeof name === "string" && name) return name.toLowerCase();
+    }
+  } catch {
+    // Config unreadable — fall through
+  }
+
+  return null;
 }

--- a/plugins/openclaw-flair/package.json
+++ b/plugins/openclaw-flair/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tpsdev-ai/openclaw-flair",
-  "version": "0.1.5",
+  "version": "0.2.0",
   "description": "OpenClaw memory plugin for Flair — agent identity and semantic memory",
   "type": "module",
   "main": "index.ts",


### PR DESCRIPTION
Fixes #84

Cron jobs and one-shot spawns don't provide `ctx.agentId` in session context, causing the plugin to fail with 'no agentId available'.

**Fix:** Add fallback resolution chain:
1. `FLAIR_AGENT_ID` env var (explicit override)
2. First agent name from `~/.openclaw/openclaw.json` (auto-detect)
3. Session context (existing behavior)

The fallback is resolved once at plugin registration and used as default for all sessions that don't provide their own agentId.

Bump to v0.2.0.