### PR TITLE
fix: add prepublishOnly hook for clean npm publishes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tpsdev-ai/flair",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Identity, memory, and soul for AI agents. Cryptographic identity (Ed25519), semantic memory with local embeddings, and persistent personality — all in a single process.",
   "type": "module",
   "license": "Apache-2.0",
@@ -39,6 +39,7 @@
   "scripts": {
     "build": "tsc -p tsconfig.json --noCheck",
     "build:cli": "tsc -p tsconfig.cli.json --noCheck",
+    "prepublishOnly": "npm run build && npm run build:cli",
     "test": "bun test"
   },
   "publishConfig": {


### PR DESCRIPTION
v0.2.0 on npm is missing `dist/cli.js` — the `flair` CLI command doesn't work. Published without building first.

**Fix:** Add `prepublishOnly` script that runs `build` + `build:cli` automatically before every `npm publish`. Can't publish a broken package anymore.

Bumps to v0.2.1.