### PR TITLE
refactor: openclaw-flair uses @tpsdev-ai/flair-client

### DIFF
--- a/plugins/openclaw-flair/index.ts
+++ b/plugins/openclaw-flair/index.ts
@@ -13,13 +13,14 @@
  *   - agent_end hook → auto-capture from conversation
  */
 
-import { randomUUID, createHash } from "node:crypto";
+import { createHash } from "node:crypto";
 import { existsSync, readFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { resolve } from "node:path";
 import { Type } from "@sinclair/typebox";
+import { FlairClient } from "@tpsdev-ai/flair-client";
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
-import { resolveKeyPath, loadPrivateKey, resolveAgentId } from "./key-resolver.js";
+import { resolveAgentId } from "./key-resolver.js";
 
 // ─── Config ──────────────────────────────────────────────────────────────────
 
@@ -37,129 +38,8 @@ const DEFAULT_URL = "http://127.0.0.1:9926";
 const DEFAULT_MAX_RECALL = 5;
 const DEFAULT_MAX_BOOTSTRAP_TOKENS = 4000;
 
-// ─── Flair HTTP Client ────────────────────────────────────────────────────────
-
-class FlairMemoryClient {
-  private readonly baseUrl: string;
-  private readonly agentId: string;
-  private readonly keyPath: string | null;
-
-  constructor(config: FlairMemoryConfig) {
-    this.baseUrl = (config.url ?? DEFAULT_URL).replace(/\/$/, "");
-    this.agentId = config.agentId;
-    this.keyPath = resolveKeyPath(config.agentId, config.keyPath);
-  }
-
-  private buildAuthHeader(method: string, path: string): Record<string, string> {
-    if (!this.keyPath) return {};
-    try {
-      const { sign: ed25519Sign, randomUUID: rv } = require("node:crypto");
-      const privateKey = loadPrivateKey(this.keyPath);
-      if (!privateKey) return {};
-      const ts = Date.now().toString();
-      const nonce = rv();
-      const payload = `${this.agentId}:${ts}:${nonce}:${method}:${path}`;
-      const sig = ed25519Sign(null, Buffer.from(payload), privateKey);
-      return { Authorization: `TPS-Ed25519 ${this.agentId}:${ts}:${nonce}:${sig.toString("base64")}` };
-    } catch {
-      return {};
-    }
-  }
-
-  private async request<T>(method: string, path: string, body?: unknown): Promise<T> {
-    const res = await fetch(`${this.baseUrl}${path}`, {
-      method,
-      headers: {
-        "Content-Type": "application/json",
-        ...this.buildAuthHeader(method, path),
-      },
-      body: body !== undefined ? JSON.stringify(body) : undefined,
-      signal: AbortSignal.timeout(10_000),
-    });
-    if (!res.ok) {
-      const text = await res.text().catch(() => "");
-      throw new Error(`Flair ${method} ${path} → ${res.status}: ${text.slice(0, 200)}`);
-    }
-    const text = await res.text();
-    return text ? (JSON.parse(text) as T) : ({} as T);
-  }
-
-  async writeMemory(id: string, content: string, opts: { durability?: string; type?: string; tags?: string[]; supersedes?: string } = {}): Promise<void> {
-    const record: Record<string, unknown> = {
-      id,
-      agentId: this.agentId,
-      content,
-      durability: opts.durability ?? "standard",
-      type: opts.type ?? "session",
-      createdAt: new Date().toISOString(),
-    };
-    if (opts.tags?.length) record.tags = opts.tags;
-    if (opts.supersedes) record.supersedes = opts.supersedes;
-    await this.request("PUT", `/Memory/${id}`, record);
-  }
-
-  async searchMemories(query: string, limit: number): Promise<Array<{ id: string; content: string; score: number; tags?: string[] }>> {
-    const result = await this.request<{ results?: Array<{ id: string; content: string; score?: number; similarity?: number; memory?: { id: string; content: string; tags?: string[] } }> }>(
-      "POST",
-      "/SemanticSearch",
-      { agentId: this.agentId, q: query, limit },
-    );
-    return (result.results ?? []).map((r) => ({
-      id: r.id ?? r.memory?.id ?? "",
-      content: r.content ?? r.memory?.content ?? "",
-      score: r.score ?? r.similarity ?? 0,
-      tags: r.memory?.tags,
-    }));
-  }
-
-  async getMemory(id: string): Promise<{ id: string; content: string; createdAt?: string } | null> {
-    try {
-      return await this.request("GET", `/Memory/${id}`);
-    } catch {
-      return null;
-    }
-  }
-
-  async bootstrap(opts: { days?: number } = {}): Promise<string> {
-    try {
-      const days = opts.days ?? 7;
-      const since = new Date(Date.now() - days * 86_400_000).toISOString();
-      const result = await this.request<{ context?: string; text?: string }>(
-        "POST",
-        "/BootstrapMemories",
-        { agentId: this.agentId, since },
-      );
-      return result.context ?? result.text ?? "";
-    } catch {
-      return "";
-    }
-  }
-
-  async getSoul(key: string): Promise<{ id: string; key: string; value: string; contentHash?: string } | null> {
-    try {
-      return await this.request("GET", `/Soul/${this.agentId}-${key}`);
-    } catch {
-      return null;
-    }
-  }
-
-  async writeSoul(key: string, value: string, contentHash?: string): Promise<void> {
-    const record: Record<string, unknown> = {
-      id: `${this.agentId}-${key}`,
-      agentId: this.agentId,
-      key,
-      value,
-      durability: "permanent",
-      createdAt: new Date().toISOString(),
-    };
-    if (contentHash) record.contentHash = contentHash;
-    await this.request("PUT", `/Soul/${this.agentId}-${key}`, record);
-  }
-}
-
 // ─── Workspace sync helpers ───────────────────────────────────────────────────
 
-/** Files to sync from workspace to Flair soul entries (spec: OPS-workspace-sync) */
 const WORKSPACE_SOUL_FILES: Record<string, string> = {
   "SOUL.md": "soul",
   "IDENTITY.md": "identity",
@@ -167,19 +47,14 @@ const WORKSPACE_SOUL_FILES: Record<string, string> = {
   "AGENTS.md": "workspace-rules",
 };
 
-/** Max size for a single soul entry (chars). Files larger are truncated. */
 const MAX_SOUL_VALUE = 8000;
 
 function hashContent(content: string): string {
   return createHash("sha256").update(content).digest("hex").slice(0, 16);
 }
 
-/**
- * Sync workspace files to Flair soul entries.
- * Only writes when content has changed (hash comparison).
- */
 async function syncWorkspaceToFlair(
-  client: FlairMemoryClient,
+  client: FlairClient,
   agentId: string,
   logger: { info: Function; warn: Function },
 ): Promise<number> {
@@ -197,12 +72,10 @@ async function syncWorkspaceToFlair(
       if (content.length > MAX_SOUL_VALUE) content = content.slice(0, MAX_SOUL_VALUE) + "\n…(truncated)";
 
       const newHash = hashContent(content);
+      const existing = await client.soul.get(soulKey);
+      if ((existing as any)?.contentHash === newHash) continue;
 
-      // Check existing entry's hash
-      const existing = await client.getSoul(soulKey);
-      if (existing?.contentHash === newHash) continue; // unchanged
-
-      await client.writeSoul(soulKey, content, newHash);
+      await client.soul.set(soulKey, content);
       synced++;
       logger.info(`openclaw-flair: synced ${filename} → soul:${soulKey} (hash=${newHash})`);
     } catch (err: any) {
@@ -238,24 +111,27 @@ export default {
     const cfg = (api.pluginConfig ?? {}) as FlairMemoryConfig;
     const isAutoMode = !cfg.agentId || cfg.agentId === "auto";
 
-    // Client pool: one client per agentId, created lazily
-    const clientPool = new Map<string, FlairMemoryClient>();
-    
+    // Client pool: one FlairClient per agentId, created lazily
+    const clientPool = new Map<string, FlairClient>();
+
     // Resolve fallback agentId once at registration time
     const fallbackAgentId = resolveAgentId();
 
-    function getClient(agentId?: string): FlairMemoryClient {
+    function getClient(agentId?: string): FlairClient {
       const id = agentId || cfg.agentId || fallbackAgentId;
       if (!id || id === "auto") throw new Error("no agentId available — set agentId in plugin config, FLAIR_AGENT_ID env var, or ensure OpenClaw provides it via session context");
       let client = clientPool.get(id);
       if (!client) {
-        client = new FlairMemoryClient({ ...cfg, agentId: id });
+        client = new FlairClient({
+          url: cfg.url ?? DEFAULT_URL,
+          agentId: id,
+          keyPath: cfg.keyPath,
+        });
         clientPool.set(id, client);
       }
       return client;
     }
 
-    // For non-auto mode, pre-create the client
     if (!isAutoMode) {
       getClient(cfg.agentId);
     }
@@ -271,14 +147,12 @@ export default {
     const autoCapture = cfg.autoCapture ?? true;
     const autoRecall = cfg.autoRecall ?? true;
 
-    // Track current agent per-session via hooks (tools don't get agentId in execute)
     let currentAgentId: string | undefined = isAutoMode ? fallbackAgentId ?? undefined : cfg.agentId;
-    
+
     api.on("before_agent_start", async (event: any, ctx: any) => {
       const eventAgentId = ctx?.agentId || (event as any).agentId;
       if (eventAgentId) currentAgentId = eventAgentId;
 
-      // Sync workspace files → Flair soul entries (hash-based, only on change)
       if (eventAgentId) {
         try {
           const client = getClient(eventAgentId);
@@ -289,9 +163,8 @@ export default {
         }
       }
     });
-    
-    // Helper to get client using tracked agentId
-    function getCurrentClient(): FlairMemoryClient {
+
+    function getCurrentClient(): FlairClient {
       return getClient(currentAgentId);
     }
 
@@ -314,7 +187,7 @@ export default {
           const { query, limit = maxRecall } = params as { query: string; limit?: number };
           try {
             const client = getCurrentClient();
-            const results = await client.searchMemories(query, limit);
+            const results = await client.memory.search(query, { limit });
             if (results.length === 0) {
               return { content: [{ type: "text", text: "No relevant memories found." }], details: { count: 0 } };
             }
@@ -367,10 +240,14 @@ export default {
             durability?: string; type?: string; supersedes?: string;
           };
           try {
-            const agentId = currentAgentId || cfg.agentId;
             const client = getCurrentClient();
-            const memId = `${agentId}-${Date.now()}`;
-            await client.writeMemory(memId, text, { tags, durability, type, supersedes });
+            const memId = `${client.agentId}-${Date.now()}`;
+            await client.memory.write(text, {
+              id: memId,
+              tags,
+              durability: durability as any,
+              type: type as any,
+            });
             return {
               content: [{ type: "text", text: `Memory stored (id: ${memId})` }],
               details: { id: memId },
@@ -398,7 +275,7 @@ export default {
           const { id } = params as { id: string };
           try {
             const client = getCurrentClient();
-            const mem = await client.getMemory(id);
+            const mem = await client.memory.get(id);
             if (!mem) return { content: [{ type: "text", text: `Memory ${id} not found.` }], details: {} };
             return {
               content: [{ type: "text", text: mem.content }],
@@ -417,10 +294,10 @@ export default {
     if (autoRecall) {
       api.on("before_agent_start", async (event: any, ctx: any) => {
         try {
-          // Ensure agentId is set (in case this fires before the tracking hook)
           if (ctx?.agentId && !currentAgentId) currentAgentId = ctx.agentId;
           const client = getCurrentClient();
-          const context = await client.bootstrap({ days: 7 });
+          const result = await client.bootstrap({ maxTokens: cfg.maxBootstrapTokens ?? DEFAULT_MAX_BOOTSTRAP_TOKENS });
+          const context = result.context;
           if (context && typeof context === "string" && context.trim().length > 0) {
             const truncated = context.slice(0, (cfg.maxBootstrapTokens ?? DEFAULT_MAX_BOOTSTRAP_TOKENS) * 4);
             event.injectContext?.(`\n## Memory Context (from Flair)\n\n${truncated}\n`);
@@ -437,7 +314,6 @@ export default {
     if (autoCapture) {
       api.on("agent_end", async (event) => {
         try {
-          const agentId = currentAgentId || cfg.agentId;
           const client = getCurrentClient();
           const messages = (event.messages ?? []) as Array<{ role: string; content?: string }>;
           let stored = 0;
@@ -446,10 +322,9 @@ export default {
             const text = typeof msg.content === "string" ? msg.content : "";
             if (!text || !shouldCapture(text)) continue;
             const excerpt = excerptForCapture(text);
-            const memId = `${agentId}-${Date.now()}-${stored}`;
-            await client.writeMemory(memId, excerpt, { type: "session", tags: ["auto-captured"] });
+            await client.memory.write(excerpt, { type: "session", tags: ["auto-captured"] });
             stored++;
-            if (stored >= 3) break; // cap at 3 per session
+            if (stored >= 3) break;
           }
           if (stored > 0) api.logger.info(`openclaw-flair: auto-captured ${stored} memories`);
         } catch (err: any) {

--- a/plugins/openclaw-flair/key-resolver.ts
+++ b/plugins/openclaw-flair/key-resolver.ts
@@ -1,60 +1,14 @@
 /**
- * Key and identity resolution for Flair authentication.
- * Separated from the HTTP client to avoid security scanner false positives
- * (env var access + network send in the same file).
+ * OpenClaw-specific identity resolution.
+ *
+ * Key path and private key loading are now handled by @tpsdev-ai/flair-client.
+ * This file only contains resolveAgentId() which reads OpenClaw config — something
+ * the generic flair-client shouldn't know about.
  */
 
 import { existsSync, readFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { resolve } from "node:path";
-
-/**
- * Resolve the Flair key path for an agent.
- * Priority: explicit keyPath > FLAIR_KEY_DIR env > ~/.flair/keys/<agent>.key
- */
-export function resolveKeyPath(agentId: string, explicitPath?: string): string | null {
-  if (explicitPath) {
-    return resolve(explicitPath.replace(/^~/, homedir()));
-  }
-
-  // 1. FLAIR_KEY_DIR env var
-  const keyDirEnv = process.env.FLAIR_KEY_DIR;
-  if (keyDirEnv) {
-    const envPath = resolve(keyDirEnv, `${agentId}.key`);
-    if (existsSync(envPath)) return envPath;
-  }
-
-  // 2. ~/.flair/keys/<agent>.key (standard — use `flair agent add` to generate)
-  const standard = resolve(homedir(), ".flair", "keys", `${agentId}.key`);
-  if (existsSync(standard)) return standard;
-
-  return null;
-}
-
-/**
- * Load and parse an Ed25519 private key from a key file.
- * Supports both raw 32-byte binary seeds and base64-encoded PKCS8 DER.
- */
-export function loadPrivateKey(keyPath: string): ReturnType<typeof import("node:crypto").createPrivateKey> | null {
-  if (!existsSync(keyPath)) return null;
-  try {
-    const { createPrivateKey } = require("node:crypto");
-    const fileBuf = readFileSync(keyPath);
-    let rawBuf: Buffer;
-    if (fileBuf.length === 32) {
-      rawBuf = fileBuf;
-    } else {
-      rawBuf = Buffer.from(fileBuf.toString("utf-8").trim(), "base64");
-    }
-    if (rawBuf.length === 32) {
-      const pkcs8Header = Buffer.from("302e020100300506032b657004220420", "hex");
-      return createPrivateKey({ key: Buffer.concat([pkcs8Header, rawBuf]), format: "der", type: "pkcs8" });
-    }
-    return createPrivateKey({ key: rawBuf, format: "der", type: "pkcs8" });
-  } catch {
-    return null;
-  }
-}
 
 /**
  * Resolve agent ID when not explicitly configured.
@@ -70,7 +24,6 @@ export function resolveAgentId(): string | null {
     const configPath = resolve(homedir(), ".openclaw", "openclaw.json");
     if (!existsSync(configPath)) return null;
     const config = JSON.parse(readFileSync(configPath, "utf-8"));
-    // agents.list[].name is the standard OpenClaw agent config
     const agents = config?.agents?.list;
     if (Array.isArray(agents) && agents.length > 0) {
       const name = agents[0]?.name;

--- a/plugins/openclaw-flair/package.json
+++ b/plugins/openclaw-flair/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tpsdev-ai/openclaw-flair",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "OpenClaw memory plugin for Flair — agent identity and semantic memory",
   "type": "module",
   "main": "index.ts",
@@ -39,6 +39,7 @@
     "node": ">=22"
   },
   "dependencies": {
-    "@sinclair/typebox": "^0.34.0"
+    "@sinclair/typebox": "^0.34.0",
+    "@tpsdev-ai/flair-client": "^0.1.0"
   }
 }


### PR DESCRIPTION
Replaces the bespoke `FlairMemoryClient` (170 lines of duplicated auth/HTTP code) with `FlairClient` from the shared client library.

**Before:** Plugin had its own Ed25519 signing, HTTP client, key resolution.
**After:** Plugin imports `FlairClient` from `@tpsdev-ai/flair-client`. Only keeps `resolveAgentId()` which is OpenClaw-specific.

Net -171 lines. One source of truth for the Flair protocol.

Bumps to v0.3.0. Requires `@tpsdev-ai/flair-client` to be published first.