### PR TITLE
fix: client reads _score from SemanticSearch + minScore filter

### DIFF
--- a/packages/flair-client/src/client.ts
+++ b/packages/flair-client/src/client.ts
@@ -117,20 +117,23 @@ class MemoryApi {
   }
 
   /** Search memories by meaning. */
-  async search(query: string, opts: { limit?: number } = {}): Promise<SearchResult[]> {
+  async search(query: string, opts: { limit?: number; minScore?: number } = {}): Promise<SearchResult[]> {
     const result = await this.client.request<{ results?: unknown[] }>(
       "POST", "/SemanticSearch",
       { agentId: this.client.agentId, q: query, limit: opts.limit ?? 5 },
     );
-    return (result.results ?? []).map((r: any) => ({
-      id: r.id ?? r.memory?.id ?? "",
-      content: r.content ?? r.memory?.content ?? "",
-      score: r.score ?? r.similarity ?? 0,
-      type: r.type ?? r.memory?.type,
-      durability: r.durability ?? r.memory?.durability,
-      tags: r.tags ?? r.memory?.tags,
-      createdAt: r.createdAt ?? r.memory?.createdAt,
-    }));
+    const minScore = opts.minScore ?? 0;
+    return (result.results ?? [])
+      .map((r: any) => ({
+        id: r.id ?? r.memory?.id ?? "",
+        content: r.content ?? r.memory?.content ?? "",
+        score: r._score ?? r.score ?? r.similarity ?? 0,
+        type: r.type ?? r.memory?.type,
+        durability: r.durability ?? r.memory?.durability,
+        tags: r.tags ?? r.memory?.tags,
+        createdAt: r.createdAt ?? r.memory?.createdAt,
+      }))
+      .filter((r) => r.score >= minScore);
   }
 
   /** Get a memory by ID. */


### PR DESCRIPTION
Dogfooding finding: `memory.search()` always returned scores of 0 because the client looked for `score`/`similarity` fields but SemanticSearch returns `_score` (composite) and `_rawScore`.

Also adds `minScore` option to filter irrelevant results client-side.

Found while testing search quality — this was masking the temporal decay + durability scoring that actually works well.