### PR TITLE
improve: auto-capture, bootstrap window, recall output

### DIFF
--- a/plugins/openclaw-flair/index.ts
+++ b/plugins/openclaw-flair/index.ts
@@ -87,13 +87,19 @@ async function syncWorkspaceToFlair(
 
 // ─── Auto-capture helpers ─────────────────────────────────────────────────────
 
+// Auto-capture triggers — conservative patterns that indicate genuinely
+// important context, not casual conversation. The LLM has memory_store
+// for explicit saves; auto-capture is a safety net for things it misses.
 const CAPTURE_TRIGGERS = [
-  /\b(remember|note that|important:|keep in mind|don't forget)\b/i,
-  /\b(preference|prefer|always|never|my name is|i am|i'm)\b/i,
-  /\b(decided|agreed|confirmed|finalized)\b/i,
+  /\b(remember this|note for future|important lesson|key decision|for the record)\b/i,
+  /\b(my name is|call me|i go by)\b/i,
+  /\b(we decided|final decision|agreed to|commitment:)\b/i,
 ];
 
+const MIN_CAPTURE_LENGTH = 30; // skip very short messages
+
 function shouldCapture(text: string): boolean {
+  if (text.length < MIN_CAPTURE_LENGTH) return false;
   return CAPTURE_TRIGGERS.some((re) => re.test(text));
 }
 
@@ -144,7 +150,7 @@ export default {
       api.logger.info("openclaw-flair: auto mode — agentId will be resolved from session context");
     }
     const maxRecall = cfg.maxRecallResults ?? DEFAULT_MAX_RECALL;
-    const autoCapture = cfg.autoCapture ?? true;
+    const autoCapture = cfg.autoCapture ?? false; // opt-in — trust the LLM to use memory_store
     const autoRecall = cfg.autoRecall ?? true;
 
     // Per-session agentId — set from config, env, or session context.
@@ -261,7 +267,7 @@ export default {
             const wasDeduped = result.id !== memId;
             return {
               content: [{ type: "text", text: wasDeduped
-                ? `Similar memory already exists (id: ${result.id})`
+                ? `Similar memory already exists (id: ${result.id}): ${result.content?.slice(0, 200)}`
                 : `Memory stored (id: ${memId})` }],
               details: { id: result.id, deduplicated: wasDeduped },
             };

--- a/resources/MemoryBootstrap.ts
+++ b/resources/MemoryBootstrap.ts
@@ -178,18 +178,27 @@ export class BootstrapMemories extends Resource {
       }
     }
 
-    // --- 3. Recent memories (last 24-48h, standard + persistent) ---
-    const sinceDate = since
-      ? new Date(since)
-      : new Date(Date.now() - 48 * 3600_000);
-    const recent = activeMemories
-      .filter(
-        (m) =>
-          m.durability !== "permanent" &&
-          m.createdAt &&
-          new Date(m.createdAt) >= sinceDate
-      )
+    // --- 3. Recent memories (adaptive window) ---
+    // Start with 48h. If nothing found, widen to 7d, then 30d.
+    // This prevents empty recent sections for agents that were idle.
+    const nonPermanent = activeMemories
+      .filter((m) => m.durability !== "permanent" && m.createdAt)
       .sort((a: any, b: any) => (b.createdAt || "").localeCompare(a.createdAt || ""));
+
+    let effectiveSince: Date;
+    if (since) {
+      effectiveSince = new Date(since);
+    } else {
+      const windows = [48 * 3600_000, 7 * 24 * 3600_000, 30 * 24 * 3600_000];
+      effectiveSince = new Date(Date.now() - windows[0]);
+      for (const w of windows) {
+        effectiveSince = new Date(Date.now() - w);
+        const count = nonPermanent.filter((m) => new Date(m.createdAt!) >= effectiveSince).length;
+        if (count >= 3) break; // found enough recent memories
+      }
+    }
+
+    const recent = nonPermanent.filter((m) => new Date(m.createdAt!) >= effectiveSince);
 
     // Budget: up to 40% of remaining for recent
     const recentBudget = Math.floor(tokenBudget * 0.4);


### PR DESCRIPTION
Three quality improvements from dogfooding:

1. **Auto-capture default OFF** — was blindly matching 'always/never/prefer', generating noise. Now opt-in, tighter triggers, 30-char minimum.
2. **Adaptive bootstrap window** — 48h → 7d → 30d if fewer than 3 recent memories found. Idle agents get context.
3. **Recall metadata** — shows date/type/durability. Dedup shows matched content.

K&S: please review.