### PR TITLE
improve: wire supersedes + env var support in client

### DIFF
--- a/packages/flair-client/src/client.ts
+++ b/packages/flair-client/src/client.ts
@@ -35,8 +35,8 @@ export class FlairClient {
   private timeoutMs: number;
 
   constructor(config: FlairClientConfig) {
-    this.url = (config.url ?? DEFAULT_URL).replace(/\/$/, "");
-    this.agentId = config.agentId;
+    this.url = (config.url ?? process.env.FLAIR_URL ?? DEFAULT_URL).replace(/\/$/, "");
+    this.agentId = config.agentId || process.env.FLAIR_AGENT_ID || "";
     this.keyPath = config.keyPath;
     this.timeoutMs = config.timeoutMs ?? DEFAULT_TIMEOUT;
     this.memory = new MemoryApi(this);

--- a/packages/flair-client/src/types.ts
+++ b/packages/flair-client/src/types.ts
@@ -49,8 +49,8 @@ export interface BootstrapResult {
 export interface FlairClientConfig {
   /** Flair server URL. Default: http://localhost:9926 */
   url?: string;
-  /** Agent ID for authentication and data scoping. */
-  agentId: string;
+  /** Agent ID for authentication and data scoping. Falls back to FLAIR_AGENT_ID env var. */
+  agentId?: string;
   /** Path to Ed25519 private key file. Auto-resolved if omitted. */
   keyPath?: string;
   /** Request timeout in ms. Default: 10000 */

--- a/plugins/openclaw-flair/index.ts
+++ b/plugins/openclaw-flair/index.ts
@@ -256,12 +256,29 @@ export default {
           try {
             const client = getCurrentClient();
             const memId = `${client.agentId}-${Date.now()}`;
+            // If superseding an old memory, archive it
+            if (supersedes) {
+              try {
+                const old = await client.memory.get(supersedes);
+                if (old) {
+                  await client.request("PUT", `/Memory/${supersedes}`, {
+                    ...old,
+                    archived: true,
+                    archivedAt: new Date().toISOString(),
+                    supersededBy: memId,
+                  });
+                }
+              } catch {
+                // Old memory not found — continue with the write
+              }
+            }
+
             const result = await client.memory.write(text, {
               id: memId,
               tags,
               durability: durability as any,
               type: type as any,
-              dedup: true,
+              dedup: !supersedes, // skip dedup when explicitly superseding
               dedupThreshold: 0.7,
             });
             const wasDeduped = result.id !== memId;


### PR DESCRIPTION
Two improvements:

1. **supersedes actually works now** — `memory_store` with `supersedes: 'old-id'` archives the old memory and links it via `supersededBy`. Was accepted but silently ignored before.

2. **env var support** — `FLAIR_URL` and `FLAIR_AGENT_ID` work in the client library. `agentId` is optional in config when env is set.

K&S: please review.