### PR TITLE
fix: remove config fallback for multi-agent gateway identity

### DIFF
--- a/plugins/openclaw-flair/index.ts
+++ b/plugins/openclaw-flair/index.ts
@@ -124,8 +124,8 @@ export default {
     const fallbackAgentId = resolveAgentId();
 
     function getClient(agentId?: string): FlairClient {
-      const id = agentId || cfg.agentId || fallbackAgentId;
-      if (!id || id === "auto") throw new Error("no agentId available — set agentId in plugin config, FLAIR_AGENT_ID env var, or ensure OpenClaw provides it via session context");
+      const id = agentId || (cfg.agentId && cfg.agentId !== "auto" ? cfg.agentId : null) || currentAgentId || fallbackAgentId;
+      if (!id || id === "auto") throw new Error("no agentId available — set agentId in plugin config, FLAIR_AGENT_ID env var, or ensure OpenClaw provides it via session context (before_agent_start)");
       let client = clientPool.get(id);
       if (!client) {
         client = new FlairClient({
@@ -153,17 +153,22 @@ export default {
     const autoCapture = cfg.autoCapture ?? false; // opt-in — trust the LLM to use memory_store
     const autoRecall = cfg.autoRecall ?? true;
 
-    // Per-session agentId — set from config, env, or session context.
-    // IMPORTANT: Only update from before_agent_start if it matches our configured agent,
-    // NOT from other agents' cron jobs sharing the same gateway.
-    let currentAgentId: string | undefined = isAutoMode ? fallbackAgentId ?? undefined : cfg.agentId;
-    const configuredAgentId = cfg.agentId && cfg.agentId !== "auto" ? cfg.agentId : fallbackAgentId;
+    // Per-session agentId — resolved from session context at runtime.
+    // In auto mode, each session gets its own agentId from before_agent_start.
+    // With explicit config, all sessions use the configured agentId.
+    let currentAgentId: string | undefined = isAutoMode ? (fallbackAgentId ?? undefined) : cfg.agentId;
+    const configuredAgentId = cfg.agentId && cfg.agentId !== "auto" ? cfg.agentId : null;
 
     api.on("before_agent_start", async (event: any, ctx: any) => {
       const eventAgentId = ctx?.agentId || (event as any).agentId;
-      // Only adopt the session agentId if we don't already have one configured,
-      // or if it matches our configured agent. Don't let kern's cron overwrite flint's agentId.
-      if (eventAgentId && (!configuredAgentId || eventAgentId === configuredAgentId)) {
+      if (!eventAgentId) return;
+
+      if (isAutoMode) {
+        // Auto mode: always adopt the session's agentId — each session is its own agent
+        currentAgentId = eventAgentId;
+        api.logger.info(`openclaw-flair: session agentId="${eventAgentId}"`);
+      } else if (eventAgentId === configuredAgentId) {
+        // Explicit mode: only accept matching agentId
         currentAgentId = eventAgentId;
       }
 

--- a/plugins/openclaw-flair/key-resolver.ts
+++ b/plugins/openclaw-flair/key-resolver.ts
@@ -2,36 +2,22 @@
  * OpenClaw-specific identity resolution.
  *
  * Key path and private key loading are now handled by @tpsdev-ai/flair-client.
- * This file only contains resolveAgentId() which reads OpenClaw config — something
- * the generic flair-client shouldn't know about.
+ * This file only contains resolveAgentId() which reads environment variables —
+ * something the generic flair-client shouldn't know about.
  */
-
-import { existsSync, readFileSync } from "node:fs";
-import { homedir } from "node:os";
-import { resolve } from "node:path";
 
 /**
- * Resolve agent ID when not explicitly configured.
- * Priority: FLAIR_AGENT_ID env > OpenClaw config file > null
+ * Resolve agent ID from environment when not explicitly configured.
+ *
+ * IMPORTANT: Does NOT read from openclaw.json agents list. On a multi-agent
+ * gateway, the first agent in the list is NOT necessarily the current session's
+ * agent. The plugin must get the real agentId from the session context via
+ * before_agent_start, not from config guessing.
+ *
+ * Priority: FLAIR_AGENT_ID env > null (let session context provide it)
  */
 export function resolveAgentId(): string | null {
-  // 1. Explicit env var
   const envId = process.env.FLAIR_AGENT_ID;
   if (envId) return envId;
-
-  // 2. Read from OpenClaw config — first agent name
-  try {
-    const configPath = resolve(homedir(), ".openclaw", "openclaw.json");
-    if (!existsSync(configPath)) return null;
-    const config = JSON.parse(readFileSync(configPath, "utf-8"));
-    const agents = config?.agents?.list;
-    if (Array.isArray(agents) && agents.length > 0) {
-      const name = agents[0]?.name;
-      if (typeof name === "string" && name) return name.toLowerCase();
-    }
-  } catch {
-    // Config unreadable — fall through
-  }
-
   return null;
 }


### PR DESCRIPTION
On a multi-agent gateway, the auto agentId fallback read the first agent from `openclaw.json` — always 'flint'. K&S sessions would silently use flint's identity.

**Fix:** `resolveAgentId()` no longer reads from config. Auto mode relies solely on session context (`before_agent_start`) or `FLAIR_AGENT_ID` env. No context = clear error, not silent wrong identity.

K&S: please review — this directly affects your memory isolation.