### PR TITLE
bump openclaw-flair to v0.4.1

### DIFF
--- a/plugins/openclaw-flair/package.json
+++ b/plugins/openclaw-flair/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tpsdev-ai/openclaw-flair",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "OpenClaw memory plugin for Flair \u2014 agent identity and semantic memory",
   "type": "module",
   "main": "index.ts",


### PR DESCRIPTION
Version bump for the multi-agent identity fix (#105). Trivial — just the version number.