### PR TITLE
fix: CLI auth + port auto-detect from config

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -58,7 +58,17 @@ function b64url(bytes: Uint8Array): string {
 }
 
 async function api(method: string, path: string, body?: any): Promise<any> {
-  const base = process.env.FLAIR_URL || "http://127.0.0.1:9926";
+  // Resolve port: FLAIR_URL env > ~/.flair/config.yaml > default 9926
+  let defaultUrl = "http://127.0.0.1:9926";
+  try {
+    const configPath = join(homedir(), ".flair", "config.yaml");
+    if (existsSync(configPath)) {
+      const yaml = readFileSync(configPath, "utf-8");
+      const portMatch = yaml.match(/port:\s*(\d+)/);
+      if (portMatch) defaultUrl = `http://127.0.0.1:${portMatch[1]}`;
+    }
+  } catch { /* ignore config read errors */ }
+  const base = process.env.FLAIR_URL || defaultUrl;
   const token = process.env.FLAIR_TOKEN;
   const res = await fetch(`${base}${path}`, {
     method,


### PR DESCRIPTION
Two bugs found dogfooding on fresh exe.dev VM:

1. **CLI auth broken** — `search` and `bootstrap` used `createSign('ed25519')` which produces different signatures than flair-client's `sign(null, ...)`. MCP server (which uses flair-client) worked fine; only CLI was broken.

2. **Port mismatch** — CLI defaulted to 9926 but `flair init` creates config with 9925. Now reads port from `~/.flair/config.yaml` if it exists.

These are the first bugs a real user would hit.