### PR TITLE
fix: make embeddings optional — Flair installs on Linux

### DIFF
--- a/resources/embeddings-provider.ts
+++ b/resources/embeddings-provider.ts
@@ -85,3 +85,16 @@ export async function embed(text: string): Promise<number[] | null> {
     return null;
   }
 }
+
+/** Alias for embed() — backwards compatibility */
+export const getEmbedding = embed;
+
+/** Returns "local" when embeddings are available, "none" otherwise. */
+export function getMode(): "local" | "none" {
+  // Synchronously check if the singleton is already loaded
+  const existing = (globalThis as any)[SINGLETON_KEY];
+  return existing ? "local" : "none";
+}
+
+/** Re-export initEmbeddings for callers that want eager initialisation. */
+export { initEmbeddings };


### PR DESCRIPTION
**Bug:** `npm install -g @tpsdev-ai/flair` fails on Linux because `node-llama-cpp` requires macOS ARM Metal binaries.

**Fix:** Move `node-llama-cpp` to `optionalDependencies`. Embeddings provider gracefully returns null when not available — semantic search falls back to keyword matching.

Found during real user testing on exe.dev VM (Linux x64).

v0.3.2