### PR TITLE
fix: platform-specific embedding modules as optional deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tpsdev-ai/flair",
-  "version": "0.3.0",
+  "version": "0.3.3",
   "description": "Identity, memory, and soul for AI agents. Cryptographic identity (Ed25519), semantic memory with local embeddings, and persistent personality \u2014 all in a single process.",
   "type": "module",
   "license": "Apache-2.0",
@@ -53,7 +53,8 @@
     "@node-llama-cpp/mac-arm64-metal": "^3.17.1",
     "commander": "14.0.3",
     "harper-fabric-embeddings": "^0.2.0",
-    "tweetnacl": "1.0.3"
+    "tweetnacl": "1.0.3",
+    "node-llama-cpp": "3.18.1"
   },
   "devDependencies": {
     "@types/node": "24.11.0",
@@ -66,5 +67,12 @@
   "workspaces": [
     "packages/*",
     "plugins/*"
-  ]
+  ],
+  "optionalDependencies": {
+    "@node-llama-cpp/linux-x64": "3.18.1",
+    "@node-llama-cpp/linux-arm64": "3.18.1",
+    "@node-llama-cpp/mac-arm64-metal": "3.18.1",
+    "@node-llama-cpp/mac-x64": "3.18.1",
+    "@node-llama-cpp/win-x64": "3.18.1"
+  }
 }


### PR DESCRIPTION
Follow-up to #112. Instead of making all of node-llama-cpp optional (which loses the JS wrapper too), keep the wrapper as a regular dep and make only the platform-specific binary modules optional:

- `node-llama-cpp` (JS wrapper) → regular dependency  
- `@node-llama-cpp/linux-x64`, `mac-arm64-metal`, etc. → optionalDependencies

npm only installs the platform module that matches. Lighter footprint, works everywhere.

v0.3.3