### PR TITLE
fix: init starts Harper in flair package dir + correct ops port

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tpsdev-ai/flair",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "description": "Identity, memory, and soul for AI agents. Cryptographic identity (Ed25519), semantic memory with local embeddings, and persistent personality — all in a single process.",
   "type": "module",
   "license": "Apache-2.0",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -38,6 +38,12 @@ function pubKeyPath(agentId: string, keysDir: string): string {
   return join(keysDir, `${agentId}.pub`);
 }
 
+
+function flairPackageDir(): string {
+  // dist/cli.js → package root (one level up from dist/)
+  return join(import.meta.dirname ?? __dirname, "..");
+}
+
 function harperBin(): string | null {
   // Resolve relative to this file's location (dist/cli.js → ../node_modules/...)
   const candidates = [
@@ -252,7 +258,7 @@ program
         console.log("Installing Harper...");
         await new Promise<void>((resolve, reject) => {
           let output = "";
-          const install = spawn(process.execPath, [bin, "install"], { cwd: process.cwd(), env });
+          const install = spawn(process.execPath, [bin, "install"], { cwd: flairPackageDir(), env });
           install.stdout?.on("data", (d: Buffer) => { output += d.toString(); });
           install.stderr?.on("data", (d: Buffer) => { output += d.toString(); });
           install.on("exit", (code) => code === 0 ? resolve() : reject(new Error(`Harper install failed (${code}): ${output}`)));
@@ -262,7 +268,7 @@ program
 
         // Start (detached)
         console.log(`Starting Harper on port ${httpPort}...`);
-        const proc = spawn(process.execPath, [bin, "dev", "."], { cwd: process.cwd(), env, detached: true, stdio: "ignore" });
+        const proc = spawn(process.execPath, [bin, "run", "."], { cwd: flairPackageDir(), env, detached: true, stdio: "ignore" });
         proc.unref();
       }
 


### PR DESCRIPTION
Two critical fresh-install bugs:

1. Harper started in user cwd, not flair package dir → config.yaml/schemas not found → no flair database
2. Ops API port was httpPort+1 (9927) but Harper defaults to 9925

Also: harper dev → harper run

v0.3.6