### PR TITLE
test: Docker test validates init from non-repo directory

### DIFF
--- a/.github/workflows/docker-test.yml
+++ b/.github/workflows/docker-test.yml
@@ -1,3 +1,8 @@
+# Docker From-Scratch Test
+#
+# Security: This workflow runs arbitrary code from the PR (Dockerfile + test script).
+# No secrets are used, but ensure "Require approval for first-time contributors"
+# is enabled in repo Settings → Actions → General to prevent abuse from fork PRs.
 name: Docker From-Scratch Test
 
 on:

--- a/docker/test-from-scratch.sh
+++ b/docker/test-from-scratch.sh
@@ -112,9 +112,37 @@ fi
 echo ""
 echo "[5/5] ✓ backup file valid: $BACKUP_FILE"
 
+# ── Step 6: test from non-repo directory (simulates real user) ────────────────
+echo ""
+echo "[6/7] Testing flair init from a different working directory..."
+
+# Kill previous Harper
+pkill -f "harper" 2>/dev/null || true
+sleep 2
+
+# Create a fresh home and run from /tmp (NOT the flair package dir)
+export HOME2="$(mktemp -d)"
+cd /tmp
+HOME="$HOME2" $FLAIR init \
+  --agent-id userbot \
+  --admin-pass "$ADMIN_PASS" \
+  --data-dir "$HOME2/.flair/data" \
+  --keys-dir "$HOME2/.flair/keys"
+
+echo "[6/7] ✓ init from /tmp succeeded (flairPackageDir resolved correctly)"
+
+# ── Step 7: verify agent add works from non-repo dir ──────────────────────────
+echo ""
+echo "[7/7] Testing agent add from /tmp..."
+HOME="$HOME2" $FLAIR agent add remotebot \
+  --admin-pass "$ADMIN_PASS" \
+  --keys-dir "$HOME2/.flair/keys"
+
+echo "[7/7] ✓ agent add from /tmp succeeded (ops API port correct)"
+
 # ── Summary ───────────────────────────────────────────────────────────────────
 echo ""
 echo "=============================="
-echo "✅ All 5 steps passed"
+echo "✅ All 7 steps passed"
 echo "   Agents in backup: $AGENT_COUNT"
 echo "=============================="


### PR DESCRIPTION
Adds steps 6-7 to Docker test: runs flair init + agent add from /tmp instead of the repo root. This catches the cwd bug (#120) and the ops port bug (#118) that passed CI but broke for real users.

Also adds security note about external PR safety for the Docker workflow.