### PR TITLE
fix: auto-deploy + CI export validation + watchdog stale-build detection

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,6 +37,13 @@ jobs:
       - run: bun install --frozen-lockfile
       - name: Build Flair resources
         run: bun run build
+      - name: Verify critical exports in dist
+        run: |
+          echo "Checking embeddings-provider exports..."
+          grep -q "export.*function getEmbedding" dist/resources/embeddings-provider.js || { echo "FATAL: getEmbedding missing"; exit 1; }
+          grep -q "export.*function initEmbeddings" dist/resources/embeddings-provider.js || { echo "FATAL: initEmbeddings missing"; exit 1; }
+          grep -q "export.*function getMode" dist/resources/embeddings-provider.js || { echo "FATAL: getMode missing"; exit 1; }
+          echo "All critical exports present ✅"
       - name: Start Harper Pro with Flair component
         run: |
           docker run -d \

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,0 +1,97 @@
+#!/bin/bash
+# deploy.sh — Pull latest flair, rebuild, verify exports, restart Harper
+# Usage: ./scripts/deploy.sh
+# Safe to run from cron, watchdog, or manually after merges
+set -euo pipefail
+
+FLAIR_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+LOG="${HOME}/.tps/logs/flair-deploy.log"
+HARPER_PORT="${HARPER_PORT:-9926}"
+
+log() { echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] $*" | tee -a "$LOG"; }
+
+cd "$FLAIR_DIR"
+
+# 1. Pull latest
+log "Pulling latest from origin/main..."
+git fetch origin main 2>&1 | tee -a "$LOG"
+LOCAL=$(git rev-parse HEAD)
+REMOTE=$(git rev-parse origin/main)
+
+if [ "$LOCAL" = "$REMOTE" ]; then
+  log "Already up to date ($LOCAL). Skipping deploy."
+  exit 0
+fi
+
+git pull origin main 2>&1 | tee -a "$LOG"
+NEW_HEAD=$(git rev-parse --short HEAD)
+log "Updated to $NEW_HEAD"
+
+# 2. Install deps
+log "Installing dependencies..."
+bun install 2>&1 | tee -a "$LOG"
+
+# 3. Build
+log "Building dist/..."
+npx tsc -p tsconfig.json 2>&1 | tee -a "$LOG"
+
+# 4. Verify critical exports exist in compiled output
+log "Verifying exports..."
+EXPORTS_OK=true
+
+if ! grep -q "export.*function getEmbedding" dist/resources/embeddings-provider.js 2>/dev/null; then
+  log "FATAL: getEmbedding export missing from dist/resources/embeddings-provider.js"
+  EXPORTS_OK=false
+fi
+
+if ! grep -q "export.*function initEmbeddings" dist/resources/embeddings-provider.js 2>/dev/null; then
+  log "FATAL: initEmbeddings export missing from dist/resources/embeddings-provider.js"
+  EXPORTS_OK=false
+fi
+
+if ! grep -q "export.*function getMode" dist/resources/embeddings-provider.js 2>/dev/null; then
+  log "FATAL: getMode export missing from dist/resources/embeddings-provider.js"
+  EXPORTS_OK=false
+fi
+
+if [ "$EXPORTS_OK" = false ]; then
+  log "DEPLOY ABORTED: Critical exports missing. dist/ is broken. Rolling back."
+  git checkout "$LOCAL" 2>&1 | tee -a "$LOG"
+  npx tsc -p tsconfig.json 2>&1 | tee -a "$LOG"
+  exit 1
+fi
+
+log "All critical exports verified ✅"
+
+# 5. Restart Harper
+log "Restarting Harper..."
+HARPER_PID=$(pgrep -f "harper.js" 2>/dev/null | head -1 || true)
+if [ -n "$HARPER_PID" ]; then
+  kill "$HARPER_PID" 2>/dev/null || true
+  sleep 3
+fi
+
+# Let launchd restart it, or kick manually
+launchctl kickstart -k "gui/$(id -u)/ai.tpsdev.flair" 2>/dev/null || \
+  launchctl start "ai.tpsdev.flair" 2>/dev/null || true
+
+# 6. Wait for health
+log "Waiting for Harper to become healthy..."
+for i in $(seq 1 30); do
+  if curl -sf --max-time 5 "http://localhost:${HARPER_PORT}/Health" -o /dev/null 2>/dev/null; then
+    log "Harper healthy after ${i}s ✅"
+    log "Deploy complete: $NEW_HEAD"
+    exit 0
+  fi
+  # Accept 401 as "running but needs auth" — that's fine
+  HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" --max-time 5 "http://localhost:${HARPER_PORT}/Health" 2>/dev/null || echo "000")
+  if [ "$HTTP_CODE" = "401" ]; then
+    log "Harper responding (401 auth required) after ${i}s ✅"
+    log "Deploy complete: $NEW_HEAD"
+    exit 0
+  fi
+  sleep 1
+done
+
+log "WARNING: Harper did not become healthy within 30s. Check manually."
+exit 1

--- a/scripts/harper-watchdog.sh
+++ b/scripts/harper-watchdog.sh
@@ -46,3 +46,14 @@ else
 fi
 
 log "Watchdog cycle complete"
+
+# --- Stale build detection ---
+# Check if dist/ is behind source (origin/main has newer commits)
+cd "$HOME/ops/flair" 2>/dev/null || exit 0
+git fetch origin main --quiet 2>/dev/null || exit 0
+LOCAL=$(git rev-parse HEAD 2>/dev/null)
+REMOTE=$(git rev-parse origin/main 2>/dev/null)
+if [ "$LOCAL" != "$REMOTE" ]; then
+  log "STALE BUILD: local=$LOCAL remote=$REMOTE — running deploy.sh"
+  "$HOME/ops/flair/scripts/deploy.sh" 2>&1 || log "Deploy failed — check logs"
+fi


### PR DESCRIPTION
Three layers of protection against stale dist/ breaking Harper:

1. **scripts/deploy.sh** — pull, build, verify exports, restart Harper. Rolls back if critical exports missing.
2. **CI: Verify critical exports** — new step after build. Fails pipeline if getEmbedding/initEmbeddings/getMode missing from compiled output.
3. **Watchdog: stale-build detection** — detects local HEAD != origin/main and auto-deploys.

**Root cause:** flair/#112 merged but dist/ wasn't rebuilt on rockit. embeddings-provider.js compiled to `export {};` breaking all Harper resources. All agent Flair syncs failed for hours.