### PR TITLE
fix: CLI memory commands use Ed25519 auth from agent key files

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -76,12 +76,36 @@ async function api(method: string, path: string, body?: any): Promise<any> {
     }
   } catch { /* ignore config read errors */ }
   const base = process.env.FLAIR_URL || defaultUrl;
+
+  // Auth resolution order:
+  // 1. FLAIR_TOKEN env → Bearer token (backward compat)
+  // 2. FLAIR_AGENT_ID env + key file → Ed25519 signature (standard)
+  // 3. --agent flag extracted from body.agentId + key file → Ed25519 signature
+  // 4. No auth (will 401 on any authenticated endpoint)
+  let authHeader: string | undefined;
   const token = process.env.FLAIR_TOKEN;
+  if (token) {
+    authHeader = `Bearer ${token}`;
+  } else {
+    const agentId = process.env.FLAIR_AGENT_ID || (body && typeof body === "object" ? body.agentId : undefined);
+    if (agentId) {
+      const keyPath = resolveKeyPath(agentId);
+      if (keyPath) {
+        try {
+          authHeader = buildEd25519Auth(agentId, method, path, keyPath);
+        } catch (err: any) {
+          // Key exists but auth build failed — warn and continue without auth
+          console.error(`Warning: Ed25519 auth failed for agent '${agentId}': ${err.message}`);
+        }
+      }
+    }
+  }
+
   const res = await fetch(`${base}${path}`, {
     method,
     headers: {
       "content-type": "application/json",
-      ...(token ? { authorization: `Bearer ${token}` } : {}),
+      ...(authHeader ? { authorization: authHeader } : {}),
     },
     body: body ? JSON.stringify(body) : undefined,
   });


### PR DESCRIPTION
## Problem

The `api()` helper function in the CLI only supported Bearer token auth via `FLAIR_TOKEN` env var. Commands like `flair memory add`, `flair memory search`, and `flair memory list` sent unauthenticated requests, failing with 401 on any Flair instance that requires auth.

**This means fresh installs were broken.** `flair init` succeeded but all subsequent memory commands returned `missing_or_invalid_authorization`.

## Root Cause

Two auth code paths existed:
- `authFetch()` — used by `flair init`, `flair agent add`, `flair search` — uses Ed25519 ✅
- `api()` — used by `flair memory *` commands — only supports Bearer token ❌

## Fix

`api()` now resolves auth in order:
1. `FLAIR_TOKEN` env → Bearer token (backward compat)
2. `FLAIR_AGENT_ID` env + key file → Ed25519 signature
3. `body.agentId` + key file → Ed25519 signature (auto-discovers from `--agent` flag)
4. No auth (will 401)

So `flair memory add --agent mybot --content hello` now automatically finds `~/.flair/keys/mybot.key` and signs the request. No extra env vars needed.

## Testing

Found during fresh install testing on a clean Ubuntu 24.04 VM (exe.dev). The `flair init` path worked because it uses `authFetch()`, but the memory commands silently failed because they used the unauthenticated `api()` path.

Compiles clean, unit tests pass.