### PR TITLE
release: v0.3.9

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tpsdev-ai/flair",
-  "version": "0.3.8",
+  "version": "0.3.9",
   "description": "Identity, memory, and soul for AI agents. Cryptographic identity (Ed25519), semantic memory with local embeddings, and persistent personality — all in a single process.",
   "type": "module",
   "license": "Apache-2.0",


### PR DESCRIPTION
Version bump. Changes since v0.3.8:
- #132: CLI memory commands use Ed25519 auth
- #131: Auto-deploy + CI export validation