### PR TITLE
bump: v0.3.10

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tpsdev-ai/flair",
-  "version": "0.3.9",
+  "version": "0.3.10",
   "description": "Identity, memory, and soul for AI agents. Cryptographic identity (Ed25519), semantic memory with local embeddings, and persistent personality — all in a single process.",
   "type": "module",
   "license": "Apache-2.0",


### PR DESCRIPTION
Version bump for npm publish. Includes auth fix (#132) and endpoint path fix (#134).