### PR TITLE
fix: handle 204 No Content + GET request auth (v0.3.11)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tpsdev-ai/flair",
-  "version": "0.3.10",
+  "version": "0.3.11",
   "description": "Identity, memory, and soul for AI agents. Cryptographic identity (Ed25519), semantic memory with local embeddings, and persistent personality — all in a single process.",
   "type": "module",
   "license": "Apache-2.0",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -87,12 +87,19 @@ async function api(method: string, path: string, body?: any): Promise<any> {
   if (token) {
     authHeader = `Bearer ${token}`;
   } else {
-    const agentId = process.env.FLAIR_AGENT_ID || (body && typeof body === "object" ? body.agentId : undefined);
+    // Extract agentId from body (POST/PUT) or URL query params (GET)
+    let agentId = process.env.FLAIR_AGENT_ID || (body && typeof body === "object" ? body.agentId : undefined);
+    if (!agentId && path.includes("agentId=")) {
+      const match = path.match(/agentId=([^&]+)/);
+      if (match) agentId = decodeURIComponent(match[1]);
+    }
     if (agentId) {
       const keyPath = resolveKeyPath(agentId);
       if (keyPath) {
         try {
-          authHeader = buildEd25519Auth(agentId, method, path, keyPath);
+          // Sign the path without query params — auth middleware verifies the clean path
+          const signPath = path.split("?")[0];
+          authHeader = buildEd25519Auth(agentId, method, signPath, keyPath);
         } catch (err: any) {
           // Key exists but auth build failed — warn and continue without auth
           console.error(`Warning: Ed25519 auth failed for agent '${agentId}': ${err.message}`);
@@ -109,9 +116,15 @@ async function api(method: string, path: string, body?: any): Promise<any> {
     },
     body: body ? JSON.stringify(body) : undefined,
   });
-  const json = await res.json();
-  if (!res.ok) throw new Error(JSON.stringify(json));
-  return json;
+  // Handle 204 No Content (e.g., PUT upsert returns empty body)
+  if (res.status === 204 || res.headers.get("content-length") === "0") {
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+    return { ok: true };
+  }
+  const text = await res.text();
+  if (!res.ok) throw new Error(text || `HTTP ${res.status}`);
+  if (!text) return { ok: true };
+  return JSON.parse(text);
 }
 
 /** Find the agent's private key file from standard locations. */

--- a/test/unit/cli-api.test.ts
+++ b/test/unit/cli-api.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect, mock, beforeEach, afterEach } from "bun:test";
+
+/**
+ * Tests for CLI api() helper behavior:
+ * - 204 No Content handling
+ * - GET request agentId extraction from query params
+ * - Auth header generation for different HTTP methods
+ */
+
+// We can't easily import api() directly (it's not exported), so we test
+// the specific behaviors by testing the building blocks.
+
+describe("CLI api() behaviors", () => {
+
+  describe("204 No Content handling", () => {
+    it("should return { ok: true } for empty response body", () => {
+      // Simulates what api() does when res.text() returns ""
+      const text = "";
+      const result = text ? JSON.parse(text) : { ok: true };
+      expect(result).toEqual({ ok: true });
+    });
+
+    it("should parse valid JSON normally", () => {
+      const text = '{"results":[{"id":"123"}]}';
+      const result = text ? JSON.parse(text) : { ok: true };
+      expect(result.results).toHaveLength(1);
+      expect(result.results[0].id).toBe("123");
+    });
+
+    it("should return { ok: true } for content-length 0", () => {
+      const contentLength = "0";
+      const isEmpty = contentLength === "0";
+      expect(isEmpty).toBe(true);
+    });
+  });
+
+  describe("agentId extraction from query params", () => {
+    it("should extract agentId from URL query string", () => {
+      const path = "/Memory?agentId=test-bot&tag=important";
+      const match = path.match(/agentId=([^&]+)/);
+      expect(match).not.toBeNull();
+      expect(decodeURIComponent(match![1])).toBe("test-bot");
+    });
+
+    it("should handle URL-encoded agentId", () => {
+      const path = "/Memory?agentId=my%20bot";
+      const match = path.match(/agentId=([^&]+)/);
+      expect(decodeURIComponent(match![1])).toBe("my bot");
+    });
+
+    it("should return null when no agentId in query", () => {
+      const path = "/Memory?tag=important";
+      const match = path.match(/agentId=([^&]+)/);
+      expect(match).toBeNull();
+    });
+
+    it("should not match agentId in path segments", () => {
+      const path = "/Memory/agentId-123";
+      const hasQueryAgentId = path.includes("agentId=");
+      expect(hasQueryAgentId).toBe(false);
+    });
+  });
+
+  describe("auth signing path extraction", () => {
+    it("should sign clean path without query params", () => {
+      const path = "/Memory?agentId=test-bot&tag=foo";
+      const signPath = path.split("?")[0];
+      expect(signPath).toBe("/Memory");
+    });
+
+    it("should handle path with no query params", () => {
+      const path = "/SemanticSearch";
+      const signPath = path.split("?")[0];
+      expect(signPath).toBe("/SemanticSearch");
+    });
+
+    it("should handle root path", () => {
+      const path = "/";
+      const signPath = path.split("?")[0];
+      expect(signPath).toBe("/");
+    });
+  });
+
+  describe("auth source priority", () => {
+    it("should prefer FLAIR_TOKEN over agentId", () => {
+      const token = "my-bearer-token";
+      const agentId = "test-bot";
+      // Token takes priority
+      const authHeader = token ? `Bearer ${token}` : `Ed25519 ${agentId}`;
+      expect(authHeader).toBe("Bearer my-bearer-token");
+    });
+
+    it("should use agentId from body when no env vars", () => {
+      const token = undefined;
+      const envAgentId = undefined;
+      const body = { agentId: "from-body", content: "test" };
+      const agentId = envAgentId || (body && typeof body === "object" ? body.agentId : undefined);
+      expect(agentId).toBe("from-body");
+    });
+
+    it("should use FLAIR_AGENT_ID over body agentId", () => {
+      const envAgentId = "from-env";
+      const body = { agentId: "from-body" };
+      const agentId = envAgentId || body.agentId;
+      expect(agentId).toBe("from-env");
+    });
+
+    it("should extract agentId from query when no body", () => {
+      const body = undefined;
+      const path = "/Memory?agentId=from-query";
+      let agentId = body && typeof body === "object" ? (body as any).agentId : undefined;
+      if (!agentId && path.includes("agentId=")) {
+        const match = path.match(/agentId=([^&]+)/);
+        if (match) agentId = decodeURIComponent(match[1]);
+      }
+      expect(agentId).toBe("from-query");
+    });
+  });
+});


### PR DESCRIPTION
Two issues from fresh install testing on v0.3.10:

1. **`memory add` crashes** — PUT returns 204 No Content (empty body), CLI calls `.json()` on it. Fix: detect empty responses and return `{ ok: true }`.

2. **`memory list` returns 401** — GET requests put agentId in query params, not body. The auth signing extracts agentId from body only. Fix: also extract from URL query params. Signs the clean path (no query string) since auth middleware verifies path only.

Bump to v0.3.11.