### PR TITLE
fix: sign full path for GET auth (v0.3.12)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tpsdev-ai/flair",
-  "version": "0.3.11",
+  "version": "0.3.12",
   "description": "Identity, memory, and soul for AI agents. Cryptographic identity (Ed25519), semantic memory with local embeddings, and persistent personality — all in a single process.",
   "type": "module",
   "license": "Apache-2.0",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -98,8 +98,8 @@ async function api(method: string, path: string, body?: any): Promise<any> {
       if (keyPath) {
         try {
           // Sign the path without query params — auth middleware verifies the clean path
-          const signPath = path.split("?")[0];
-          authHeader = buildEd25519Auth(agentId, method, signPath, keyPath);
+          // Auth middleware verifies the full request path including query params
+          authHeader = buildEd25519Auth(agentId, method, path, keyPath);
         } catch (err: any) {
           // Key exists but auth build failed — warn and continue without auth
           console.error(`Warning: Ed25519 auth failed for agent '${agentId}': ${err.message}`);

--- a/test/unit/cli-api.test.ts
+++ b/test/unit/cli-api.test.ts
@@ -61,23 +61,15 @@ describe("CLI api() behaviors", () => {
     });
   });
 
-  describe("auth signing path extraction", () => {
-    it("should sign clean path without query params", () => {
+  describe("auth signing uses full path", () => {
+    it("should include query params in signed path", () => {
       const path = "/Memory?agentId=test-bot&tag=foo";
-      const signPath = path.split("?")[0];
-      expect(signPath).toBe("/Memory");
+      expect(path).toBe("/Memory?agentId=test-bot&tag=foo");
     });
 
-    it("should handle path with no query params", () => {
+    it("should work with paths without query params", () => {
       const path = "/SemanticSearch";
-      const signPath = path.split("?")[0];
-      expect(signPath).toBe("/SemanticSearch");
-    });
-
-    it("should handle root path", () => {
-      const path = "/";
-      const signPath = path.split("?")[0];
-      expect(signPath).toBe("/");
+      expect(path).toBe("/SemanticSearch");
     });
   });
 


### PR DESCRIPTION
Auth middleware expects full path including query params in signature. Previous fix stripped them. Fixes memory list 401.