### PR TITLE
fix: load embeddings as Harper plugin (v0.3.13)

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -10,6 +10,10 @@ graphqlSchema:
 jsResource:
   files: dist/resources/*.js
 
+'harper-fabric-embeddings':
+  package: 'harper-fabric-embeddings'
+  modelName: nomic-embed-text
+
 authentication:
   # Default secure. Set to false for local development only.
   authorizeLocal: true

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tpsdev-ai/flair",
-  "version": "0.3.12",
+  "version": "0.3.13",
   "description": "Identity, memory, and soul for AI agents. Cryptographic identity (Ed25519), semantic memory with local embeddings, and persistent personality — all in a single process.",
   "type": "module",
   "license": "Apache-2.0",

--- a/resources/embeddings-provider.ts
+++ b/resources/embeddings-provider.ts
@@ -28,14 +28,24 @@ function getState(): ProviderState {
 export async function initEmbeddings(): Promise<void> {
   const state = getState();
   if (state.initialized) return;
-  try {
-    await hfe.init({});
-    state.available = true;
-    console.log(`[embeddings] harper-fabric-embeddings ready (${hfe.dimensions()} dims)`);
-  } catch (err: any) {
-    console.log(`[embeddings] harper-fabric-embeddings unavailable: ${err.message}`);
-    state.available = false;
+
+  // harper-fabric-embeddings is initialized by Harper as a sub-component
+  // (declared in config.yaml). It inits in the background so it may not
+  // be ready when resources first load. Retry a few times before giving up.
+  for (let attempt = 1; attempt <= 10; attempt++) {
+    try {
+      const dims = hfe.dimensions();
+      state.available = true;
+      state.initialized = true;
+      console.log(`[embeddings] ready (${dims} dims, attempt ${attempt})`);
+      return;
+    } catch {
+      if (attempt < 10) await new Promise(r => setTimeout(r, 500));
+    }
   }
+
+  console.log("[embeddings] not available after 10 attempts — search will be keyword-only");
+  state.available = false;
   state.initialized = true;
 }
 


### PR DESCRIPTION
Root cause of empty search on fresh installs: embeddings never initialized because we imported harper-fabric-embeddings directly and called init({}) with no config. No modelsDir = no model download = no embeddings = empty search.

Fix: declare it as a Harper sub-component in config.yaml. Harper handles init, model download, lifecycle. This is how the package was designed to be used.

```yaml
'harper-fabric-embeddings':
  package: 'harper-fabric-embeddings'
  modelName: nomic-embed-text
```