### PR TITLE
fix: generate embeddings on memory write (v0.3.14)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tpsdev-ai/flair",
-  "version": "0.3.13",
+  "version": "0.3.14",
   "description": "Identity, memory, and soul for AI agents. Cryptographic identity (Ed25519), semantic memory with local embeddings, and persistent personality — all in a single process.",
   "type": "module",
   "license": "Apache-2.0",

--- a/resources/Memory.ts
+++ b/resources/Memory.ts
@@ -1,6 +1,7 @@
 import { databases } from "@harperfast/harper";
 import { patchRecord } from "./table-helpers.js";
 import { isAdmin } from "./auth-middleware.js";
+import { getEmbedding } from "./embeddings-provider.js";
 
 export class Memory extends (databases as any).flair.Memory {
   /**
@@ -90,12 +91,24 @@ export class Memory extends (databases as any).flair.Memory {
       content.expiresAt = new Date(Date.now() + ttlHours * 3600_000).toISOString();
     }
 
+    // Generate embedding from content text
+    if (content.content && !content.embedding) {
+      const vec = await getEmbedding(content.content);
+      if (vec) content.embedding = vec;
+    }
+
     return super.post(content);
   }
 
   async put(content: any) {
     const now = new Date().toISOString();
     content.updatedAt = now;
+
+    // Re-generate embedding if content changed
+    if (content.content && !content.embedding) {
+      const vec = await getEmbedding(content.content);
+      if (vec) content.embedding = vec;
+    }
 
     // If archiving, record who + when
     if (content.archived === true && !content.archivedAt) {

--- a/test/e2e-cli.sh
+++ b/test/e2e-cli.sh
@@ -1,6 +1,5 @@
 #!/usr/bin/env bash
 # E2E CLI test — verifies CLI commands work against a running Flair instance.
-# Expects Harper to already be running (started by CI or manually).
 set -euo pipefail
 
 FLAIR_DIR="$(cd "$(dirname "$0")/.." && pwd)"
@@ -27,29 +26,38 @@ for i in $(seq 1 60); do
   sleep 1
 done
 
-# Status
 echo "--- status ---"
 $FLAIR status
 echo "PASS: status"
 
-# Agent add
 echo "--- agent add ---"
 $FLAIR agent add "$AGENT_ID" --name "E2E Bot" --admin-pass "$ADMIN_PASS" --port "$PORT"
 echo "PASS: agent add"
 
-# Memory add
 echo "--- memory add ---"
 $FLAIR memory add --agent "$AGENT_ID" --content "The quick brown fox jumps over the lazy dog"
 echo "PASS: memory add"
 
-# Memory search
-echo "--- memory search ---"
-$FLAIR memory search --agent "$AGENT_ID" --q "animals"
-echo "PASS: memory search"
+sleep 2
 
-# Memory list
 echo "--- memory list ---"
-$FLAIR memory list --agent "$AGENT_ID"
-echo "PASS: memory list"
+LIST_OUTPUT=$($FLAIR memory list --agent "$AGENT_ID")
+echo "$LIST_OUTPUT"
+if echo "$LIST_OUTPUT" | grep -q "quick brown fox"; then
+  echo "PASS: memory list (content found)"
+else
+  echo "FAIL: memory list — stored content not found"
+  exit 1
+fi
+
+echo "--- memory search ---"
+SEARCH_OUTPUT=$($FLAIR memory search --agent "$AGENT_ID" --q "animals jumping")
+echo "$SEARCH_OUTPUT"
+if echo "$SEARCH_OUTPUT" | grep -q '"results":\[\]'; then
+  echo "FAIL: memory search — empty results (embeddings not generated on write)"
+  exit 1
+else
+  echo "PASS: memory search (results returned)"
+fi
 
 echo "=== E2E CLI Test PASSED ==="


### PR DESCRIPTION
Memory.post() and put() never called getEmbedding(). Memories stored without vectors = search always empty.

Adds embedding generation on write + e2e test that fails if search returns empty.