### PR TITLE
fix: never permanently disable embeddings (v0.3.15)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,7 +41,6 @@ jobs:
         run: |
           echo "Checking embeddings-provider exports..."
           grep -q "export.*function getEmbedding" dist/resources/embeddings-provider.js || { echo "FATAL: getEmbedding missing"; exit 1; }
-          grep -q "export.*function initEmbeddings" dist/resources/embeddings-provider.js || { echo "FATAL: initEmbeddings missing"; exit 1; }
           grep -q "export.*function getMode" dist/resources/embeddings-provider.js || { echo "FATAL: getMode missing"; exit 1; }
           echo "All critical exports present ✅"
       - name: Start Harper Pro with Flair component

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tpsdev-ai/flair",
-  "version": "0.3.14",
+  "version": "0.3.15",
   "description": "Identity, memory, and soul for AI agents. Cryptographic identity (Ed25519), semantic memory with local embeddings, and persistent personality — all in a single process.",
   "type": "module",
   "license": "Apache-2.0",

--- a/resources/auth-middleware.ts
+++ b/resources/auth-middleware.ts
@@ -1,6 +1,6 @@
 import { patchRecord } from "./table-helpers.js";
 import { server, databases } from "@harperfast/harper";
-import { initEmbeddings, getEmbedding } from "./embeddings-provider.js";
+import { getEmbedding } from "./embeddings-provider.js";
 
 // --- Admin credentials ---
 // Admin auth is sourced exclusively from Harper's own environment variables
@@ -102,7 +102,6 @@ async function importEd25519Key(publicKeyStr: string): Promise<CryptoKey> {
   return key;
 }
 
-initEmbeddings().catch((err: any) => console.error("[embeddings] init:", err.message));
 
 async function backfillEmbedding(memoryId: string): Promise<void> {
   try {

--- a/resources/embeddings-provider.ts
+++ b/resources/embeddings-provider.ts
@@ -2,66 +2,36 @@
  * embeddings-provider.ts
  *
  * Thin wrapper around harper-fabric-embeddings for Flair resources.
- * harper-fabric-embeddings handles loading and running the embedding model
- * at the Harper sub-component level — we just delegate to its exported API.
- *
- * On platforms where the native binary isn't available, getEmbedding()
- * returns null and semantic search falls back to keyword matching.
+ * harper-fabric-embeddings is loaded by Harper as a sub-component
+ * (declared in config.yaml). It downloads the model and initializes
+ * in the background. We just call embed() — if it's not ready yet,
+ * we return null and the caller handles it gracefully.
  */
 
 import * as hfe from "harper-fabric-embeddings";
 
-const SINGLETON_KEY = "__flair_hfe_provider_v1__";
-
-interface ProviderState {
-  initialized: boolean;
-  available: boolean;
-}
-
-function getState(): ProviderState {
-  if (!(globalThis as any)[SINGLETON_KEY]) {
-    (globalThis as any)[SINGLETON_KEY] = { initialized: false, available: false };
-  }
-  return (globalThis as any)[SINGLETON_KEY];
-}
-
-export async function initEmbeddings(): Promise<void> {
-  const state = getState();
-  if (state.initialized) return;
-
-  // harper-fabric-embeddings is initialized by Harper as a sub-component
-  // (declared in config.yaml). It inits in the background so it may not
-  // be ready when resources first load. Retry a few times before giving up.
-  for (let attempt = 1; attempt <= 10; attempt++) {
-    try {
-      const dims = hfe.dimensions();
-      state.available = true;
-      state.initialized = true;
-      console.log(`[embeddings] ready (${dims} dims, attempt ${attempt})`);
-      return;
-    } catch {
-      if (attempt < 10) await new Promise(r => setTimeout(r, 500));
-    }
-  }
-
-  console.log("[embeddings] not available after 10 attempts — search will be keyword-only");
-  state.available = false;
-  state.initialized = true;
-}
-
+/**
+ * Generate an embedding vector for the given text.
+ * Returns null if the embedding engine isn't ready yet (model still loading)
+ * or not available on this platform. Never gives up permanently — each call
+ * checks independently.
+ */
 export async function getEmbedding(text: string): Promise<number[] | null> {
-  const state = getState();
-  if (!state.initialized) await initEmbeddings();
-  if (!state.available) return null;
   try {
-    return hfe.embed(text);
-  } catch (err: any) {
-    console.log(`[embeddings] embed failed: ${err.message}`);
+    return await hfe.embed(text);
+  } catch {
     return null;
   }
 }
 
+/**
+ * Check if the embedding engine is currently available.
+ */
 export function getMode(): "local" | "none" {
-  const state = getState();
-  return state.available ? "local" : "none";
+  try {
+    hfe.dimensions();
+    return "local";
+  } catch {
+    return "none";
+  }
 }


### PR DESCRIPTION
The 5-second retry window was too short for first-time model load. Once timed out, embeddings were permanently disabled. Fix: no state machine, no retry loop. Each call tries independently. When model finishes loading, it just works.