### PR TITLE
fix: bump harper-fabric-embeddings 0.2.2 (v0.3.16)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -6,9 +6,8 @@
       "name": "@tpsdev-ai/flair",
       "dependencies": {
         "@harperfast/harper": "5.0.0-beta.4",
-        "@node-llama-cpp/mac-arm64-metal": "^3.17.1",
         "commander": "14.0.3",
-        "harper-fabric-embeddings": "^0.2.0",
+        "harper-fabric-embeddings": "^0.2.2",
         "tweetnacl": "1.0.3",
       },
       "devDependencies": {
@@ -16,17 +15,20 @@
         "bun-types": "^1.3.10",
         "typescript": "5.9.3",
       },
+      "optionalDependencies": {
+        "@node-llama-cpp/mac-arm64-metal": "^3.17.1",
+      },
     },
     "packages/flair-client": {
       "name": "@tpsdev-ai/flair-client",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "devDependencies": {
         "typescript": "5.9.3",
       },
     },
     "packages/flair-mcp": {
       "name": "@tpsdev-ai/flair-mcp",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "bin": {
         "flair-mcp": "dist/index.js",
       },
@@ -1137,7 +1139,7 @@
 
     "gunzip-maybe": ["gunzip-maybe@1.4.2", "", { "dependencies": { "browserify-zlib": "^0.1.4", "is-deflate": "^1.0.0", "is-gzip": "^1.0.0", "peek-stream": "^1.1.0", "pumpify": "^1.3.3", "through2": "^2.0.3" }, "bin": { "gunzip-maybe": "bin.js" } }, "sha512-4haO1M4mLO91PW57BMsDFf75UmwoRX0GkdD+Faw+Lr+r/OZrOCS0pIBwOL1xCKQqnQzbNFGgK2V2CpBUPeFNTw=="],
 
-    "harper-fabric-embeddings": ["harper-fabric-embeddings@0.2.0", "", { "optionalDependencies": { "@node-llama-cpp/linux-x64": "3.17.1" } }, "sha512-b9KNVTrmVdBl6ORFueDpCfe2jbsnM8rYKzH7y9xToSR2+a9WSjJ9glKTA4BUgL2o3E82xS+8SOIiMBtbY3U5Jg=="],
+    "harper-fabric-embeddings": ["harper-fabric-embeddings@0.2.2", "", { "optionalDependencies": { "@node-llama-cpp/linux-x64": "3.17.1" } }, "sha512-Sk6fJBmIPdH4cJbRn5jawzc+PG6xVa6pyzglU/qQa0HyIWt0ZbelYt7dSpynhpU88L8QcD9wf0yMYCWEt4yPqw=="],
 
     "has-flag": ["has-flag@4.0.0", "", {}, "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="],
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tpsdev-ai/flair",
-  "version": "0.3.15",
+  "version": "0.3.16",
   "description": "Identity, memory, and soul for AI agents. Cryptographic identity (Ed25519), semantic memory with local embeddings, and persistent personality — all in a single process.",
   "type": "module",
   "license": "Apache-2.0",
@@ -51,7 +51,7 @@
   "dependencies": {
     "@harperfast/harper": "5.0.0-beta.4",
     "commander": "14.0.3",
-    "harper-fabric-embeddings": "^0.2.0",
+    "harper-fabric-embeddings": "^0.2.2",
     "tweetnacl": "1.0.3"
   },
   "devDependencies": {


### PR DESCRIPTION
harper-fabric-embeddings 0.2.2: handleApplication awaits init(), model download safe across workers. Embeddings ready before requests served.