### PR TITLE
fix: init embeddings in VM context — search works on fresh install (v0.3.17)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tpsdev-ai/flair",
-  "version": "0.3.16",
+  "version": "0.3.17",
   "description": "Identity, memory, and soul for AI agents. Cryptographic identity (Ed25519), semantic memory with local embeddings, and persistent personality — all in a single process.",
   "type": "module",
   "license": "Apache-2.0",

--- a/resources/embeddings-provider.ts
+++ b/resources/embeddings-provider.ts
@@ -1,25 +1,49 @@
 /**
  * embeddings-provider.ts
  *
- * Thin wrapper around harper-fabric-embeddings for Flair resources.
- * harper-fabric-embeddings is loaded by Harper as a sub-component
- * (declared in config.yaml). It downloads the model and initializes
- * in the background. We just call embed() — if it's not ready yet,
- * we return null and the caller handles it gracefully.
+ * Wrapper around harper-fabric-embeddings for Flair resources.
+ *
+ * Harper loads resources in a VM sandbox with a separate module cache from
+ * the main thread. This means our import of harper-fabric-embeddings gets
+ * a different (uninitialized) instance from the one Harper initialized via
+ * handleApplication in config.yaml.
+ *
+ * Solution: we call hfe.init() ourselves on first use. The model is already
+ * on disk (downloaded by Harper's plugin loader), so init just loads the
+ * native binary and model file — no download needed.
  */
 
 import * as hfe from "harper-fabric-embeddings";
+import { join } from "node:path";
+
+let _ready = false;
+
+async function ensureInit(): Promise<void> {
+  if (_ready) return;
+  try {
+    // Check if already initialized (e.g. shared context)
+    hfe.dimensions();
+    _ready = true;
+    return;
+  } catch {
+    // Not initialized — init with modelsDir pointing to where Harper's
+    // plugin loader downloaded the model (process.cwd() is the app dir)
+    const modelsDir = join(process.cwd(), "models");
+    await hfe.init({ modelsDir });
+    _ready = true;
+  }
+}
 
 /**
  * Generate an embedding vector for the given text.
- * Returns null if the embedding engine isn't ready yet (model still loading)
- * or not available on this platform. Never gives up permanently — each call
- * checks independently.
+ * Returns null if the embedding engine isn't available on this platform.
  */
 export async function getEmbedding(text: string): Promise<number[] | null> {
   try {
+    await ensureInit();
     return await hfe.embed(text);
-  } catch {
+  } catch (err: any) {
+    console.error(`[embeddings] embed failed: ${err.message}`);
     return null;
   }
 }


### PR DESCRIPTION
Harper's VM sandbox creates separate module instances. Fix: init hfe ourselves on first embed call. Model already on disk from plugin. Tested: 768-dim embeddings, semantic search returns ranked results on fresh Ubuntu VM.