### PR TITLE
fix: remove TS source from npm package (v0.3.19)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tpsdev-ai/flair",
-  "version": "0.3.18",
+  "version": "0.3.19",
   "description": "Identity, memory, and soul for AI agents. Cryptographic identity (Ed25519), semantic memory with local embeddings, and persistent personality — all in a single process.",
   "type": "module",
   "license": "Apache-2.0",
@@ -29,7 +29,6 @@
   },
   "files": [
     "dist/",
-    "resources/",
     "schemas/",
     "config.yaml",
     "LICENSE",


### PR DESCRIPTION
resources/*.ts was duplicated alongside dist/resources/*.js. Harper uses dist/ (per config.yaml). Removes bloat.