### PR TITLE
fix: MCP tags accepts string or array (v0.1.2)

### DIFF
--- a/packages/flair-mcp/package.json
+++ b/packages/flair-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tpsdev-ai/flair-mcp",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "MCP server for Flair — persistent memory for Claude Code, Cursor, and any MCP client.",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/flair-mcp/src/index.ts
+++ b/packages/flair-mcp/src/index.ts
@@ -79,7 +79,10 @@ server.tool(
     type: z.enum(["session", "lesson", "decision", "preference", "fact", "goal"]).optional().default("session"),
     durability: z.enum(["permanent", "persistent", "standard", "ephemeral"]).optional().default("standard")
       .describe("permanent=inviolable, persistent=key decisions, standard=default, ephemeral=auto-expires 72h"),
-    tags: z.array(z.string()).optional().describe("Optional tags for categorization"),
+    tags: z.union([
+      z.array(z.string()),
+      z.string().transform(s => s.startsWith("[") ? JSON.parse(s) : s.split(",").map(t => t.trim()).filter(Boolean)),
+    ]).optional().describe("Optional tags — array or comma-separated string"),
   },
   async ({ content, type, durability, tags }) => {
     const result = await flair.memory.write(content, {


### PR DESCRIPTION
Claude Code sends tags as a stringified array. MCP zod schema now accepts both and normalizes.

flair-mcp v0.1.2