### PR TITLE
fix: increase query truncation from 500 to 8000 chars

### DIFF
--- a/resources/SemanticSearch.ts
+++ b/resources/SemanticSearch.ts
@@ -90,7 +90,8 @@ export class SemanticSearch extends Resource {
     let qEmb = queryEmbedding;
     if (!qEmb && q) {
       if (getMode() !== "none") {
-        try { qEmb = await getEmbedding(String(q).slice(0, 500)); } catch {}
+        // align truncation with model's context window (~8000 chars / 2048 tokens)
+        try { qEmb = await getEmbedding(String(q).slice(0, 8000)); } catch {}
       }
     }
 


### PR DESCRIPTION
## What
Increases the query text truncation limit in `SemanticSearch.post` from 500 to 8000 characters before passing to the embedding model.

## Why
The nomic-embed-text-v1.5 model has a 2048 token context window (~8000 chars). The previous 500 char limit was silently degrading semantic search quality for longer queries — cutting off context that the model could have used to produce better embeddings.

## Risk
Low — this is a one-line change that relaxes an overly conservative limit. The model itself handles truncation beyond its context window gracefully.

Fixes #164