### PR TITLE
specs: lifecycle commands + embedding fallback cleanup

### DIFF
--- a/specs/FLAIR-EMBEDDING-FALLBACK.md
+++ b/specs/FLAIR-EMBEDDING-FALLBACK.md
@@ -1,0 +1,77 @@
+# Flair Embedding Fallback Cleanup — Spec
+
+**Issue:** #165 (hash-based embedding fallback provides no semantic quality)  
+**Priority:** P1  
+**Author:** Flint  
+
+## Problem
+
+`resources/embeddings.ts` contains a hash-based `fallbackEmbed()` function that maps text to a 512-dim vector using character hashing. This provides zero semantic quality — it's essentially a sparse bag-of-words hash that can't distinguish "happy dog" from "joyful puppy."
+
+The file is **dead code** — nothing imports `fallbackEmbed`. The actual embedding provider (`embeddings-provider.ts`) returns `null` on failure, and `SemanticSearch` falls back to keyword-only matching.
+
+The problem: keyword-only matching with a 0.05 score cap means search quality degrades dramatically when embeddings are unavailable, and there's no visibility into when this happens.
+
+## Solution
+
+### 1. Remove Dead Code
+Delete `resources/embeddings.ts` entirely. The `fallbackEmbed` function is unused and misleading.
+
+### 2. Add Observability to Embedding Failures
+
+In `embeddings-provider.ts`:
+- Log a **single warning** (not per-request) when `ensureInit()` fails: `[embeddings] WARN: native embeddings unavailable, falling back to keyword-only search`
+- Track init state with a tri-state: `uninitialized | ready | failed`
+- Expose a `getStatus()` function returning `{ mode: "local" | "none", initError?: string }`
+
+### 3. Surface in Status Endpoint
+
+In `flair status` CLI output and the `/Health` or `/Status` API response, include:
+```json
+{
+  "embeddings": {
+    "mode": "local",
+    "model": "nomic-embed-text-v1.5",
+    "dims": 768
+  }
+}
+```
+
+Or when failed:
+```json
+{
+  "embeddings": {
+    "mode": "none",
+    "error": "Failed to load native binary: ..."
+  }
+}
+```
+
+### 4. Return Degradation Warning in Search Results
+
+When `SemanticSearch` falls back to keyword-only, include a `_warning` field:
+```json
+{
+  "results": [...],
+  "_warning": "semantic search unavailable — results are keyword-only"
+}
+```
+
+This lets callers (like BootstrapMemories) surface the degradation to agents.
+
+## Files Changed
+
+- `resources/embeddings.ts` — **DELETE**
+- `resources/embeddings-provider.ts` — add status tracking, single warning log
+- `resources/SemanticSearch.ts` — add `_warning` when in keyword-only mode
+- `src/cli.ts` (status command) — surface embedding status
+
+## Testing
+
+- With working embeddings: no warning, status shows `mode: "local"`
+- With broken/missing native binary: warning logged once, status shows `mode: "none"`, search results include `_warning`
+- No imports of deleted `embeddings.ts` anywhere
+
+## Risk
+
+Very low. Removing dead code + adding observability. No behavior change for working installations. Degraded installations get better visibility instead of silent failure.

--- a/specs/FLAIR-LIFECYCLE.md
+++ b/specs/FLAIR-LIFECYCLE.md
@@ -1,0 +1,82 @@
+# Flair Lifecycle Commands — Spec
+
+**Issues:** #150 (lifecycle), #151 (conflict-free ports)  
+**Priority:** P1  
+**Author:** Flint  
+
+## Problem
+
+1. **No lifecycle management:** `flair init` starts Harper but there's no `flair stop`, `flair restart`, or `flair uninstall`. Operators must manually find PIDs or manipulate launchd.
+
+2. **Port conflicts:** Flair defaults to 9926/9925 which collide with standalone Harper installations. Users running both get silent failures.
+
+## Solution
+
+### 1. Lifecycle Commands
+
+Add three new top-level commands to `src/cli.ts`:
+
+#### `flair stop`
+- Check for running Flair process (launchd on macOS, PID file on Linux)
+- On macOS: `launchctl unload` the plist
+- On Linux: read PID from `~/.flair/data/flair.pid`, send SIGTERM, wait up to 10s, SIGKILL if needed
+- Print confirmation or "not running" message
+
+#### `flair restart`  
+- `stop` + `init` with same config
+- Preserve existing config from `~/.flair/config.json` (written by `init`)
+- If not initialized, error with "run flair init first"
+
+#### `flair uninstall`
+- `stop` first
+- Remove launchd plist (macOS) or systemd unit (Linux)
+- Ask interactively whether to remove data (`~/.flair/data`) and keys (`~/.flair/keys`)
+- Default: keep data and keys (safe)
+- `--purge` flag to remove everything without prompting
+
+### 2. Conflict-Free Ports
+
+Change defaults in `src/cli.ts`:
+```typescript
+const DEFAULT_PORT = 19926;      // was 9926
+const DEFAULT_OPS_PORT = 19925;  // was 9925
+```
+
+Update `config.yaml` accordingly. The `init` command already accepts `--port` for custom overrides.
+
+**Migration:** Existing installations with explicit port config in `~/.flair/config.json` are unaffected (the stored config takes precedence). Only new `flair init` runs get the new defaults.
+
+### 3. Config Persistence
+
+`flair init` already writes config. Ensure it stores:
+```json
+{
+  "port": 19926,
+  "opsPort": 19925,
+  "dataDir": "~/.flair/data",
+  "keysDir": "~/.flair/keys",
+  "adminUser": "admin"
+}
+```
+
+`flair restart` reads this config to reinitialize correctly.
+
+## Files Changed
+
+- `src/cli.ts` — new commands + default port change
+- `config.yaml` — default port update
+- `README.md` — update port references
+
+## Testing
+
+- `flair init` → starts on 19926
+- `flair status` → shows running, correct port
+- `flair stop` → stops cleanly
+- `flair restart` → restarts with same config
+- `flair uninstall` → removes service, data intact
+- `flair uninstall --purge` → removes everything
+- Existing users with port 9926 in config → still works (no breakage)
+
+## Risk
+
+Low-medium. Port change affects new installations only. Lifecycle commands are additive. The `uninstall --purge` path needs careful testing since it's destructive.


### PR DESCRIPTION
## Specs for Review

Two specs for K&S architectural/security review before implementation:

### 1. FLAIR-LIFECYCLE.md (#150 + #151)
- `flair stop`, `flair restart`, `flair uninstall` commands
- Change default ports from 9926/9925 → 19926/19925 (conflict-free)
- Config persistence for restart

### 2. FLAIR-EMBEDDING-FALLBACK.md (#165)
- Remove dead `embeddings.ts` (unused hash-based fallback)
- Add observability to embedding failures (single warning, status endpoint)
- Surface degradation warning in search results

@tps-kern @tps-sherlock — requesting design review before we implement.