### PR TITLE
feat: embedding model tracking + reembed migration command

### DIFF
--- a/resources/Memory.ts
+++ b/resources/Memory.ts
@@ -1,7 +1,7 @@
 import { databases } from "@harperfast/harper";
 import { patchRecord } from "./table-helpers.js";
 import { isAdmin } from "./auth-middleware.js";
-import { getEmbedding } from "./embeddings-provider.js";
+import { getEmbedding, getModelId } from "./embeddings-provider.js";
 import { scanContent, isStrictMode } from "./content-safety.js";
 
 export class Memory extends (databases as any).flair.Memory {
@@ -110,7 +110,7 @@ export class Memory extends (databases as any).flair.Memory {
     // Generate embedding from content text
     if (content.content && !content.embedding) {
       const vec = await getEmbedding(content.content);
-      if (vec) content.embedding = vec;
+      if (vec) { content.embedding = vec; content.embeddingModel = getModelId(); }
     }
 
     return super.post(content);
@@ -141,7 +141,7 @@ export class Memory extends (databases as any).flair.Memory {
     // Re-generate embedding if content changed
     if (content.content && !content.embedding) {
       const vec = await getEmbedding(content.content);
-      if (vec) content.embedding = vec;
+      if (vec) { content.embedding = vec; content.embeddingModel = getModelId(); }
     }
 
     // If archiving, record who + when

--- a/resources/embeddings-provider.ts
+++ b/resources/embeddings-provider.ts
@@ -82,6 +82,14 @@ export function getMode(): "local" | "none" {
 }
 
 /**
+ * Get the current embedding model identifier.
+ * Used for stamping memories and detecting stale embeddings.
+ */
+export function getModelId(): string {
+  return process.env.FLAIR_EMBEDDING_MODEL ?? "nomic-embed-text-v1.5-Q4_K_M";
+}
+
+/**
  * Get embedding engine status for diagnostics.
  */
 export function getStatus(): {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1074,6 +1074,92 @@ program
     }
   });
 
+// ─── flair reembed ────────────────────────────────────────────────────────────
+
+program
+  .command("reembed")
+  .description("Re-generate embeddings for memories with stale or missing model tags")
+  .requiredOption("--agent <id>", "Agent ID to re-embed memories for")
+  .option("--stale-only", "Only re-embed memories with mismatched model tag")
+  .option("--dry-run", "Show count without modifying")
+  .option("--port <port>", "Harper HTTP port")
+  .option("--batch-size <n>", "Records per batch", "50")
+  .option("--delay-ms <ms>", "Delay between batches (ms)", "100")
+  .action(async (opts) => {
+    const port = opts.port ? Number(opts.port) : (readPortFromConfig() ?? DEFAULT_PORT);
+    const baseUrl = `http://127.0.0.1:${port}`;
+    const agentId = opts.agent;
+    const staleOnly = opts.staleOnly ?? false;
+    const dryRun = opts.dryRun ?? false;
+    const batchSize = Number(opts.batchSize);
+    const delayMs = Number(opts.delayMs);
+
+    const currentModel = process.env.FLAIR_EMBEDDING_MODEL ?? "nomic-embed-text-v1.5-Q4_K_M";
+
+    console.log(`Re-embedding memories for agent: ${agentId}`);
+    console.log(`Current model: ${currentModel}`);
+    if (staleOnly) console.log("Mode: stale-only (skipping up-to-date memories)");
+    if (dryRun) console.log("Mode: dry-run (no modifications)");
+    console.log("");
+
+    const keysDir = defaultKeysDir();
+    const privPath = privKeyPath(agentId, keysDir);
+    if (!existsSync(privPath)) {
+      console.error(`❌ Key not found: ${privPath}`);
+      process.exit(1);
+    }
+
+    const searchRes = await authFetch(baseUrl, agentId, privPath, "POST", "/SemanticSearch", {
+      agentId, limit: 10000,
+    });
+    if (!searchRes.ok) {
+      console.error(`❌ Failed to fetch memories: ${searchRes.status}`);
+      process.exit(1);
+    }
+    const data = await searchRes.json() as { results?: any[] };
+    const allMemories = data.results ?? [];
+
+    const candidates = allMemories.filter((m: any) => {
+      if (!m.content) return false;
+      if (staleOnly) return !m.embeddingModel || m.embeddingModel !== currentModel;
+      return true;
+    });
+
+    const total = candidates.length;
+    const skipped = allMemories.length - total;
+
+    console.log(`Total memories: ${allMemories.length}`);
+    console.log(`Candidates for re-embedding: ${total}`);
+    if (skipped > 0) console.log(`Skipped (up-to-date): ${skipped}`);
+
+    if (dryRun || total === 0) {
+      if (total === 0) console.log("\n✅ All memories are up-to-date!");
+      return;
+    }
+
+    console.log("");
+    let processed = 0;
+    let errors = 0;
+
+    for (let i = 0; i < candidates.length; i += batchSize) {
+      const batch = candidates.slice(i, i + batchSize);
+      for (const memory of batch) {
+        try {
+          const updateRes = await authFetch(baseUrl, agentId, privPath, "PUT", `/Memory/${memory.id}`, {
+            id: memory.id, content: memory.content, embedding: undefined, embeddingModel: undefined,
+          });
+          if (updateRes.ok) processed++;
+          else errors++;
+        } catch { errors++; }
+      }
+      const pct = Math.round(((i + batch.length) / total) * 100);
+      process.stdout.write(`\rRe-embedded ${processed}/${total} (${pct}%)${errors > 0 ? ` [${errors} errors]` : ""}`);
+      if (i + batchSize < candidates.length) await new Promise(r => setTimeout(r, delayMs));
+    }
+
+    console.log(`\n\n✅ Re-embedding complete: ${processed} updated, ${errors} errors`);
+  });
+
 // ─── Legacy identity/memory/soul commands (preserved) ────────────────────────
 
 const identity = program.command("identity").description("Legacy identity commands");


### PR DESCRIPTION
## What
Track which embedding model was used per memory, and provide a CLI command to re-embed stale memories when the model changes.

Rebased cleanly on current main (includes content safety, lifecycle commands, embedding fallback fixes).

## Changes
- `embeddings-provider.ts`: `getModelId()` — returns current model identifier
- `Memory.ts`: stamps `embeddingModel` field on every post/put
- `src/cli.ts`: new `flair reembed` command with batch processing + progress

## Testing
- Build: clean. Tests: 203 pass, 2 pre-existing integration failures.

Fixes #166