### PR TITLE
feat: standalone auth mode for flair-client + port defaults (CP36)

### DIFF
--- a/packages/flair-client/src/client.ts
+++ b/packages/flair-client/src/client.ts
@@ -20,7 +20,7 @@ import type {
   BootstrapResult,
 } from "./types.js";
 
-const DEFAULT_URL = "http://localhost:9926";
+const DEFAULT_URL = "http://localhost:19926";
 const DEFAULT_TIMEOUT = 10_000;
 
 export class FlairClient {
@@ -33,12 +33,19 @@ export class FlairClient {
   private keyResolved = false;
   private keyPath: string | undefined;
   private timeoutMs: number;
+  private basicAuth: string | null = null;
 
   constructor(config: FlairClientConfig) {
     this.url = (config.url ?? process.env.FLAIR_URL ?? DEFAULT_URL).replace(/\/$/, "");
     this.agentId = config.agentId || process.env.FLAIR_AGENT_ID || "";
     this.keyPath = config.keyPath;
     this.timeoutMs = config.timeoutMs ?? DEFAULT_TIMEOUT;
+    // Basic auth fallback for standalone deployments without Ed25519 keys
+    const adminUser = config.adminUser ?? process.env.FLAIR_ADMIN_USER;
+    const adminPass = config.adminPassword ?? process.env.FLAIR_ADMIN_PASSWORD;
+    if (adminUser && adminPass) {
+      this.basicAuth = `Basic ${Buffer.from(`${adminUser}:${adminPass}`).toString("base64")}`;
+    }
     this.memory = new MemoryApi(this);
     this.soul = new SoulApi(this);
   }
@@ -61,6 +68,8 @@ export class FlairClient {
     const key = this.resolveKey();
     if (key) {
       headers["Authorization"] = signRequest(this.agentId, key, method, path);
+    } else if (this.basicAuth) {
+      headers["Authorization"] = this.basicAuth;
     }
     const res = await fetch(`${this.url}${path}`, {
       method,

--- a/packages/flair-client/src/types.ts
+++ b/packages/flair-client/src/types.ts
@@ -47,7 +47,7 @@ export interface BootstrapResult {
 
 /** Client configuration. */
 export interface FlairClientConfig {
-  /** Flair server URL. Default: http://localhost:9926 */
+  /** Flair server URL. Default: http://localhost:19926 */
   url?: string;
   /** Agent ID for authentication and data scoping. Falls back to FLAIR_AGENT_ID env var. */
   agentId?: string;
@@ -55,4 +55,8 @@ export interface FlairClientConfig {
   keyPath?: string;
   /** Request timeout in ms. Default: 10000 */
   timeoutMs?: number;
+  /** Admin username for Basic auth fallback (standalone deployments). Falls back to FLAIR_ADMIN_USER env var. */
+  adminUser?: string;
+  /** Admin password for Basic auth fallback (standalone deployments). Falls back to FLAIR_ADMIN_PASSWORD env var. */
+  adminPassword?: string;
 }

--- a/packages/flair-client/test/client.test.ts
+++ b/packages/flair-client/test/client.test.ts
@@ -15,7 +15,7 @@ const { FlairClient, FlairError } = await import("../src/client.js");
 describe("FlairClient", () => {
   test("constructor uses default URL when none provided", () => {
     const client = new FlairClient({ agentId: "test" });
-    expect(client.url).toBe("http://localhost:9926");
+    expect(client.url).toBe("http://localhost:19926");
   });
 
   test("constructor uses provided URL", () => {

--- a/packages/flair-mcp/README.md
+++ b/packages/flair-mcp/README.md
@@ -54,8 +54,10 @@ Once configured, Claude Code (or any MCP client) gets these tools:
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `FLAIR_AGENT_ID` | *(required)* | Agent identity for memory scoping |
-| `FLAIR_URL` | `http://localhost:9926` | Flair server URL |
+| `FLAIR_URL` | `http://localhost:19926` | Flair server URL |
 | `FLAIR_KEY_PATH` | auto-resolved | Path to Ed25519 private key |
+| `FLAIR_ADMIN_USER` | *(optional)* | Admin username for Basic auth (standalone mode) |
+| `FLAIR_ADMIN_PASSWORD` | *(optional)* | Admin password for Basic auth (standalone mode) |
 
 ## How It Works
 
@@ -77,7 +79,7 @@ Point to a remote Flair instance:
       "args": ["@tpsdev-ai/flair-mcp"],
       "env": {
         "FLAIR_AGENT_ID": "my-project",
-        "FLAIR_URL": "http://your-server:9926"
+        "FLAIR_URL": "http://your-server:19926"
       }
     }
   }


### PR DESCRIPTION
## CP36: Standalone Flair

Makes Flair's MCP server work without Ed25519 key infrastructure — the key enabler for universal agent compatibility.

## Changes
- **flair-client**: Basic auth fallback via `FLAIR_ADMIN_USER`/`FLAIR_ADMIN_PASSWORD` env vars (or `adminUser`/`adminPassword` config). Ed25519 still preferred when keys exist.
- **flair-client**: Default URL updated 9926 → 19926
- **flair-mcp**: README updated with new port + standalone auth docs
- **test**: Updated client default URL test

## Why
CP36 'Synchronized Office' requires Flair to be 'plug and play' for any agent. Currently requires Ed25519 keys from `flair init`. With Basic auth fallback, a raw Claude Code instance can use Flair MCP with just admin creds — zero TPS setup needed.

## Auth Priority
1. Ed25519 key (if key file found) — strongest, per-agent scoped
2. Basic auth (if FLAIR_ADMIN_USER set) — admin-level, for standalone/dev
3. Unauthenticated — rejected by Flair's auth middleware