### PR TITLE
feat: flair start command + fix multiline paste in soul onboarding

### DIFF
--- a/TODO-next.md
+++ b/TODO-next.md
@@ -1,7 +1,0 @@
-# Follow-up fixes
-
-## No `flair start` command
-Only `restart` (requires launchd service) and `init` exist. If Harper dies, there's no simple way to bring it back without re-running init. Add a `flair start` that starts Harper without reinstalling.
-
-## Multiline paste bug in soul onboarding
-Each newline in a pasted block submits a separate prompt answer, filling multiple soul fields with fragments of one answer. Options: detect rapid input and buffer, use a textarea-style prompt with explicit submit, or require empty line/Ctrl+D to submit.

--- a/specs/FLAIR-1.0-SPEC.md
+++ b/specs/FLAIR-1.0-SPEC.md
@@ -151,10 +151,27 @@ Output: problem description + fix command for each issue found.
 - MCP server connects and all 6 tools work
 - OpenClaw plugin installs and provides tools
 
-### Stress tests:
-- 10,000 memories → search still < 500ms
+### Security tests:
+- Agent A cannot read Agent B's memories (isolation enforcement)
+- Ed25519 auth rejects invalid/expired/replayed signatures
+- Content safety scan blocks prompt injection attempts
+- Permanent memories cannot be deleted by non-admin agents
+- Rate limiter triggers correctly under burst load
+
+### Performance benchmarks:
+- 1,000 memories → search < 100ms
+- 10,000 memories → search < 500ms
+- 100,000 memories → search < 2s
 - 5 concurrent agents writing → no corruption
+
+### Stress tests:
 - 30-day uptime simulation (Harper doesn't leak memory or degrade)
+- Machine restart → first request succeeds within 10s of Harper starting
+
+### Coverage as a product signal:
+- Publish test count + coverage % in README
+- Match Microsoft's Agent Governance Toolkit pattern: "covers X out of Y risks"
+- CI badge showing passing tests on every commit
 
 ---
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -524,7 +524,24 @@ program
 
       const { createInterface } = await import("node:readline");
       const rl = createInterface({ input: process.stdin, output: process.stdout });
-      const ask = (q: string): Promise<string> => new Promise(r => rl.question(q, r));
+      // Buffered ask: collects rapid input (pasted text) into one answer.
+      // Waits 200ms after last line before resolving, so pasted multiline
+      // blocks are captured as a single answer instead of spilling across prompts.
+      const ask = (q: string): Promise<string> => new Promise(resolve => {
+        let buffer = "";
+        let timer: ReturnType<typeof setTimeout> | null = null;
+        const finish = () => {
+          rl.removeListener("line", onLine);
+          resolve(buffer.trim());
+        };
+        const onLine = (line: string) => {
+          buffer += (buffer ? "\n" : "") + line;
+          if (timer) clearTimeout(timer);
+          timer = setTimeout(finish, 200);
+        };
+        process.stdout.write(q);
+        rl.on("line", onLine);
+      });
 
       const role = await ask("   What's this agent's role? (e.g., \"Senior dev, concise and direct\")\n   > ");
       const project = await ask("   What project is it working on?\n   > ");
@@ -1100,6 +1117,82 @@ program
       }
     } catch {
       console.log("Flair is not running (nothing found on port " + port + ").");
+    }
+  });
+
+// ─── flair start ──────────────────────────────────────────────────────────────
+
+program
+  .command("start")
+  .description("Start Flair (Harper) — requires a prior 'flair init'")
+  .option("--port <port>", "Harper HTTP port")
+  .action(async (opts) => {
+    const port = resolveHttpPort(opts);
+
+    // Check if already running
+    try {
+      const res = await fetch(`http://127.0.0.1:${port}/Health`, { signal: AbortSignal.timeout(2000) });
+      if (res.status > 0) {
+        console.log(`Flair is already running on port ${port}.`);
+        return;
+      }
+    } catch { /* not running — good */ }
+
+    const dataDir = defaultDataDir();
+    if (!existsSync(dataDir)) {
+      console.error("❌ No Flair data directory found. Run 'flair init' first.");
+      process.exit(1);
+    }
+
+    const platform = process.platform;
+    if (platform === "darwin") {
+      const label = "ai.tpsdev.flair";
+      const plistPath = join(homedir(), "Library", "LaunchAgents", `${label}.plist`);
+      if (existsSync(plistPath)) {
+        try {
+          const { execSync } = await import("node:child_process");
+          try { execSync(`launchctl load "${plistPath}"`, { stdio: "pipe" }); } catch {}
+          execSync(`launchctl start ${label}`, { stdio: "pipe" });
+          await waitForHealth(port, DEFAULT_ADMIN_USER, process.env.HDB_ADMIN_PASSWORD ?? "", STARTUP_TIMEOUT_MS);
+          console.log("✅ Flair started (launchd)");
+          return;
+        } catch (err: any) {
+          console.error(`launchd start failed, falling back to direct start: ${err.message}`);
+        }
+      }
+    }
+
+    // Direct start (Linux, or macOS fallback when no launchd plist)
+    const bin = harperBin();
+    if (!bin) {
+      console.error("❌ Harper binary not found. Run 'flair init' first.");
+      process.exit(1);
+    }
+
+    const adminPass = process.env.HDB_ADMIN_PASSWORD ?? "";
+    const opsPort = resolveOpsPort(opts);
+    const env: Record<string, string> = {
+      ...(process.env as Record<string, string>),
+      ROOTPATH: dataDir,
+      DEFAULTS_MODE: "dev",
+      HDB_ADMIN_USERNAME: DEFAULT_ADMIN_USER,
+      HDB_ADMIN_PASSWORD: adminPass,
+      HTTP_PORT: String(port),
+      OPERATIONSAPI_NETWORK_PORT: String(opsPort),
+      LOCAL_STUDIO: "false",
+    };
+
+    const proc = spawn(process.execPath, [bin, "run", "."], {
+      cwd: flairPackageDir(), env, detached: true, stdio: "ignore",
+    });
+    proc.unref();
+
+    try {
+      await waitForHealth(port, DEFAULT_ADMIN_USER, adminPass, STARTUP_TIMEOUT_MS);
+      console.log(`✅ Flair started on port ${port}`);
+    } catch {
+      console.error("❌ Flair failed to start within timeout. Check logs in " + join(dataDir, "harper.log"));
+      process.exit(1);
     }
   });
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1169,18 +1169,22 @@ program
       process.exit(1);
     }
 
-    const adminPass = process.env.HDB_ADMIN_PASSWORD ?? "";
+    const adminPass = process.env.HDB_ADMIN_PASSWORD || process.env.FLAIR_ADMIN_PASS || "";
     const opsPort = resolveOpsPort(opts);
     const env: Record<string, string> = {
       ...(process.env as Record<string, string>),
       ROOTPATH: dataDir,
       DEFAULTS_MODE: "dev",
       HDB_ADMIN_USERNAME: DEFAULT_ADMIN_USER,
-      HDB_ADMIN_PASSWORD: adminPass,
       HTTP_PORT: String(port),
       OPERATIONSAPI_NETWORK_PORT: String(opsPort),
       LOCAL_STUDIO: "false",
     };
+    // Only set HDB_ADMIN_PASSWORD if we have a real value — empty string
+    // would strip Harper's auth on an existing install
+    if (adminPass) {
+      env.HDB_ADMIN_PASSWORD = adminPass;
+    }
 
     const proc = spawn(process.execPath, [bin, "run", "."], {
       cwd: flairPackageDir(), env, detached: true, stdio: "ignore",


### PR DESCRIPTION
**1. `flair start` command**

If Harper dies, there was no way to bring it back without re-running `flair init`. Now:

```bash
flair start          # uses port from config
flair start --port 9943
```

- Tries launchd first on macOS, falls back to direct spawn
- Checks if already running (no-op if so)
- Requires prior `flair init` (won't create data dir)
- Sets ops port via `resolveOpsPort()`

**2. Multiline paste fix in soul onboarding**

Pasting multi-line text during `flair init` soul setup would split across prompts (each newline submitted a separate answer). Now uses a 200ms debounce — rapid input is buffered into a single answer.

**3. Removed TODO-next.md** (both items resolved)