### PR TITLE
feat: temporal validity on memories + Relationship table

### DIFF
--- a/packages/flair-client/src/client.ts
+++ b/packages/flair-client/src/client.ts
@@ -148,11 +148,11 @@ class MemoryApi {
     return record as Memory;
   }
 
-  /** Search memories by meaning. */
-  async search(query: string, opts: { limit?: number; minScore?: number; scoring?: "composite" | "raw" } = {}): Promise<SearchResult[]> {
+  /** Search memories by meaning. Optionally filter to facts valid at a specific point in time. */
+  async search(query: string, opts: { limit?: number; minScore?: number; scoring?: "composite" | "raw"; asOf?: string } = {}): Promise<SearchResult[]> {
     const result = await this.client.request<{ results?: unknown[] }>(
       "POST", "/SemanticSearch",
-      { agentId: this.client.agentId, q: query, limit: opts.limit ?? 5, scoring: opts.scoring },
+      { agentId: this.client.agentId, q: query, limit: opts.limit ?? 5, scoring: opts.scoring, asOf: opts.asOf },
     );
     const minScore = opts.minScore ?? 0;
     return (result.results ?? [])

--- a/resources/Memory.ts
+++ b/resources/Memory.ts
@@ -96,6 +96,18 @@ export class Memory extends (databases as any).flair.Memory {
       });
     }
 
+    // Temporal validity: validFrom defaults to now, validTo left null for active facts.
+    // When a memory supersedes another, close the superseded memory's validity window.
+    if (!content.validFrom) {
+      content.validFrom = content.createdAt;
+    }
+    if (content.supersedes) {
+      patchRecord((databases as any).flair.Memory, content.supersedes, {
+        validTo: content.validFrom,
+        updatedAt: content.createdAt,
+      }).catch(() => {});
+    }
+
     if (content.durability === "ephemeral" && !content.expiresAt) {
       const ttlHours = Number(process.env.FLAIR_EPHEMERAL_TTL_HOURS || 24);
       content.expiresAt = new Date(Date.now() + ttlHours * 3600_000).toISOString();

--- a/resources/Relationship.ts
+++ b/resources/Relationship.ts
@@ -48,8 +48,8 @@ export class Relationship extends (databases as any).flair.Relationship {
       });
     }
 
-    const rateLimitResult = checkRateLimit(authAgent);
-    if (rateLimitResult) return rateLimitResponse(rateLimitResult);
+    const rl = checkRateLimit(authAgent);
+    if (!rl.allowed) return rateLimitResponse(rl.retryAfterMs!, "relationship");
 
     // Validate required fields
     if (!content.subject || typeof content.subject !== "string") {

--- a/resources/Relationship.ts
+++ b/resources/Relationship.ts
@@ -1,0 +1,110 @@
+import { databases } from "@harperfast/harper";
+import { isAdmin } from "./auth-middleware.js";
+import { checkRateLimit, rateLimitResponse } from "./rate-limiter.js";
+
+/**
+ * Relationship resource — entity-to-entity relationships with temporal validity.
+ *
+ * Enables knowledge graph queries like:
+ *   - "Who manages project X?" (active relationships)
+ *   - "Who was team lead in Q1?" (historical, validFrom/validTo bounded)
+ *   - "What changed about Nathan's role?" (all relationships for a subject, ordered by time)
+ *
+ * Relationships are scoped by agentId for multi-agent isolation.
+ * Admin agents can query across all agents.
+ */
+export class Relationship extends (databases as any).flair.Relationship {
+
+  async search(query?: any) {
+    const ctx = (this as any).getContext?.();
+    const request = ctx?.request ?? ctx;
+    const authAgent: string | undefined = request?.tpsAgent;
+    const isAdminAgent: boolean = request?.tpsAgentIsAdmin ?? false;
+
+    if (!authAgent || isAdminAgent) {
+      return super.search(query);
+    }
+
+    // Non-admin: scope to own relationships
+    const agentCondition = { attribute: "agentId", comparator: "equals", value: authAgent };
+    if (!query?.conditions) {
+      return super.search({ conditions: [agentCondition], ...(query || {}) });
+    }
+    return super.search({
+      ...query,
+      conditions: [agentCondition, { conditions: query.conditions, operator: query.operator || "and" }],
+      operator: "and",
+    });
+  }
+
+  async put(content: any) {
+    const ctx = (this as any).getContext?.();
+    const request = ctx?.request ?? ctx;
+    const authAgent: string | undefined = request?.tpsAgent;
+
+    if (!authAgent) {
+      return new Response(JSON.stringify({ error: "authentication required" }), {
+        status: 401, headers: { "content-type": "application/json" },
+      });
+    }
+
+    const rateLimitResult = checkRateLimit(authAgent);
+    if (rateLimitResult) return rateLimitResponse(rateLimitResult);
+
+    // Validate required fields
+    if (!content.subject || typeof content.subject !== "string") {
+      return new Response(JSON.stringify({ error: "subject is required (string)" }), {
+        status: 400, headers: { "content-type": "application/json" },
+      });
+    }
+    if (!content.predicate || typeof content.predicate !== "string") {
+      return new Response(JSON.stringify({ error: "predicate is required (string)" }), {
+        status: 400, headers: { "content-type": "application/json" },
+      });
+    }
+    if (!content.object || typeof content.object !== "string") {
+      return new Response(JSON.stringify({ error: "object is required (string)" }), {
+        status: 400, headers: { "content-type": "application/json" },
+      });
+    }
+
+    // Normalize
+    const now = new Date().toISOString();
+    content.agentId = authAgent;
+    content.subject = content.subject.toLowerCase();
+    content.predicate = content.predicate.toLowerCase();
+    content.object = content.object.toLowerCase();
+    content.createdAt = content.createdAt || now;
+    content.updatedAt = now;
+    content.validFrom = content.validFrom || now;
+    // validTo left as null/undefined for active relationships
+    content.confidence = content.confidence ?? 1.0;
+
+    return super.put(content);
+  }
+
+  async delete(_: any) {
+    const ctx = (this as any).getContext?.();
+    const request = ctx?.request ?? ctx;
+    const authAgent: string | undefined = request?.tpsAgent;
+    const isAdminAgent: boolean = request?.tpsAgentIsAdmin ?? false;
+
+    if (!authAgent) {
+      return new Response(JSON.stringify({ error: "authentication required" }), {
+        status: 401, headers: { "content-type": "application/json" },
+      });
+    }
+
+    // Non-admin: verify ownership before delete
+    if (!isAdminAgent) {
+      const existing = await super.get();
+      if (existing?.agentId && existing.agentId !== authAgent) {
+        return new Response(JSON.stringify({ error: "cannot delete another agent's relationship" }), {
+          status: 403, headers: { "content-type": "application/json" },
+        });
+      }
+    }
+
+    return super.delete(_);
+  }
+}

--- a/resources/SemanticSearch.ts
+++ b/resources/SemanticSearch.ts
@@ -56,7 +56,7 @@ const CANDIDATE_MULTIPLIER = 5;
 
 export class SemanticSearch extends Resource {
   async post(data: any) {
-    const { agentId, q, queryEmbedding, tag, subject, subjects, limit = 10, includeSuperseded = false, scoring = "composite", minScore = 0, since } = data || {};
+    const { agentId, q, queryEmbedding, tag, subject, subjects, limit = 10, includeSuperseded = false, scoring = "composite", minScore = 0, since, asOf } = data || {};
 
     // Rate limiting — use authenticated agent ID from request context, not client-supplied body
     const rateLimitAgent: string | undefined = (this as any).request?.headers?.get?.("x-tps-agent")
@@ -182,7 +182,7 @@ export class SemanticSearch extends Resource {
           "source", "createdAt", "updatedAt", "expiresAt", "retrievalCount", "lastRetrieved",
           "promotionStatus", "promotedAt", "promotedBy", "archived", "archivedAt", "archivedBy",
           "parentId", "derivedFrom", "sessionId", "lastReflected", "supersedes", "subject",
-          "_safetyFlags", "$distance"],
+          "validFrom", "validTo", "_safetyFlags", "$distance"],
         limit: candidateLimit,
       };
       if (conditions.length > 0) {
@@ -192,6 +192,9 @@ export class SemanticSearch extends Resource {
       for await (const record of (databases as any).flair.Memory.search(query)) {
         if (record.expiresAt && Date.parse(record.expiresAt) < Date.now()) continue;
         if (sinceDate && record.createdAt && new Date(record.createdAt) < sinceDate) continue;
+        // Temporal validity: if asOf is specified, only include memories valid at that point
+        if (asOf && record.validFrom && record.validFrom > asOf) continue;
+        if (asOf && record.validTo && record.validTo <= asOf) continue;
 
         const semanticScore = distanceToSimilarity(record.$distance ?? 1);
         let keywordHit = false;
@@ -222,6 +225,8 @@ export class SemanticSearch extends Resource {
       for await (const record of (databases as any).flair.Memory.search(query)) {
         if (record.expiresAt && Date.parse(record.expiresAt) < Date.now()) continue;
         if (sinceDate && record.createdAt && new Date(record.createdAt) < sinceDate) continue;
+        if (asOf && record.validFrom && record.validFrom > asOf) continue;
+        if (asOf && record.validTo && record.validTo <= asOf) continue;
 
         let keywordHit = false;
         if (q && String(record.content || "").toLowerCase().includes(String(q).toLowerCase())) {

--- a/schemas/memory.graphql
+++ b/schemas/memory.graphql
@@ -26,7 +26,26 @@ type Memory @table(database: "flair") {
   lastReflected: String     # ISO timestamp of last reflection pass
   supersedes: String @indexed  # ID of memory this one replaces (version chain)
   subject: String @indexed     # entity this memory is about (person, service, project)
+  validFrom: String @indexed   # ISO timestamp — when this fact became true
+  validTo: String @indexed     # ISO timestamp — when this fact stopped being true (null = still valid)
   _safetyFlags: [String]       # content safety flags from scanContent()
+}
+
+# Explicit entity-to-entity relationships with temporal validity.
+# Enables queries like "who was team lead in Q1?" or "what changed about X on date Y?"
+# Inspired by knowledge graph triples with time-bounded validity windows.
+type Relationship @table(database: "flair") {
+  id: ID @primaryKey
+  agentId: String! @indexed        # who created this relationship
+  subject: String! @indexed        # source entity (person, project, service)
+  predicate: String! @indexed      # relationship type (manages, owns, depends_on, etc.)
+  object: String! @indexed         # target entity
+  validFrom: String @indexed       # when this relationship became true
+  validTo: String @indexed         # when it ended (null = still active)
+  confidence: Float                # 0.0–1.0, how certain (1.0 = explicitly stated)
+  source: String                   # where this was learned (memory ID, conversation, etc.)
+  createdAt: String! @indexed
+  updatedAt: String
 }
 
 type Soul @table(database: "flair") {


### PR DESCRIPTION
## Summary

- Add `validFrom`/`validTo` fields to Memory schema for time-bounded facts
- New `Relationship` table for entity-to-entity knowledge graph triples with temporal validity
- `asOf` parameter on SemanticSearch for point-in-time queries
- Auto-close superseded memories' validity windows

## What this enables

- "Who managed project X in Q1?" → query relationships with `validFrom`/`validTo` bounds
- "What did we know about auth on March 15?" → `asOf: "2026-03-15"` filters to memories valid at that timestamp
- When memory A supersedes memory B, B's `validTo` is automatically set to A's `validFrom` — creating a clean version history with temporal boundaries
- Explicit entity relationships: `subject: "nathan", predicate: "manages", object: "flair", validFrom: "2026-01-01"` — queryable, time-bounded, agent-scoped

## Test plan

- [x] 215/215 tests pass
- [x] Build succeeds
- [ ] Integration test for asOf temporal filtering (to be added)
- [ ] Integration test for Relationship CRUD (to be added)

🤖 Generated with [Claude Code](https://claude.com/claude-code)