### PR TITLE
feat: XAA Enterprise-Managed Authorization

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "@harperfast/harper": "5.0.0",
     "commander": "14.0.3",
     "harper-fabric-embeddings": "0.2.2",
+    "jose": "^6.2.2",
     "tweetnacl": "1.0.3"
   },
   "devDependencies": {

--- a/resources/OAuth.ts
+++ b/resources/OAuth.ts
@@ -1,5 +1,6 @@
 import { Resource, databases } from "@harperfast/harper";
 import { createHash, randomBytes } from "node:crypto";
+import { handleJwtBearerGrant } from "./XAA.js";
 
 /**
  * OAuth 2.1 Authorization Server for Flair.
@@ -240,11 +241,7 @@ export class OAuthToken extends Resource {
     } else if (grantType === "refresh_token") {
       return this.handleRefreshToken(data);
     } else if (grantType === "urn:ietf:params:oauth:grant-type:jwt-bearer") {
-      // XAA path — stub for now, implemented in XAA PR
-      return new Response(JSON.stringify({
-        error: "unsupported_grant_type",
-        error_description: "jwt-bearer grant type not yet implemented",
-      }), { status: 400, headers: { "content-type": "application/json" } });
+      return handleJwtBearerGrant(data);
     }
 
     return new Response(JSON.stringify({ error: "unsupported_grant_type" }), {

--- a/resources/XAA.ts
+++ b/resources/XAA.ts
@@ -1,0 +1,349 @@
+import { databases } from "@harperfast/harper";
+import { createHash, randomBytes } from "node:crypto";
+
+/**
+ * XAA (Enterprise-Managed Authorization) — ID-JAG validation for Flair.
+ *
+ * Validates ID-JAG tokens from enterprise IdPs (Google Workspace, Azure AD,
+ * Okta) and issues Flair access tokens. Implements the jwt-bearer grant type
+ * (RFC 7523) at the OAuth token endpoint.
+ *
+ * Flow:
+ *   1. Client authenticates user via corporate SSO
+ *   2. IdP issues ID-JAG (signed JWT with policy decision)
+ *   3. Client presents ID-JAG to Flair's /OAuthToken endpoint
+ *   4. Flair validates signature, issuer, audience, domain, expiry, replay
+ *   5. Flair resolves or JIT-creates a Principal
+ *   6. Flair issues scoped access + refresh tokens
+ *
+ * Per FLAIR-XAA spec §§ 3-4.
+ */
+
+const ACCESS_TOKEN_TTL_MS = 3600_000;        // 1 hour
+const REFRESH_TOKEN_TTL_MS = 7 * 86400_000;  // 7 days
+const CLOCK_SKEW_MS = 30_000;                // 30 seconds
+
+// In-memory JWKS cache per issuer
+const jwksCache = new Map<string, { keys: any[]; fetchedAt: number }>();
+const JWKS_CACHE_TTL_MS = 3600_000; // 1 hour
+
+function sha256(input: string): string {
+  return createHash("sha256").update(input).digest("hex");
+}
+
+function randomToken(prefix: string): string {
+  return `${prefix}${randomBytes(32).toString("base64url")}`;
+}
+
+function nowISO(): string {
+  return new Date().toISOString();
+}
+
+function futureISO(ms: number): string {
+  return new Date(Date.now() + ms).toISOString();
+}
+
+/**
+ * Decode a JWT without verifying signature (for claim inspection).
+ * Actual verification uses the IdP's JWKS.
+ */
+function decodeJwt(token: string): { header: any; payload: any; signature: string } | null {
+  try {
+    const parts = token.split(".");
+    if (parts.length !== 3) return null;
+    const header = JSON.parse(Buffer.from(parts[0], "base64url").toString());
+    const payload = JSON.parse(Buffer.from(parts[1], "base64url").toString());
+    return { header, payload, signature: parts[2] };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Fetch JWKS from an IdP endpoint with caching.
+ */
+async function fetchJwks(jwksUri: string, forceRefresh = false): Promise<any[]> {
+  const cached = jwksCache.get(jwksUri);
+  if (cached && !forceRefresh && Date.now() - cached.fetchedAt < JWKS_CACHE_TTL_MS) {
+    return cached.keys;
+  }
+
+  try {
+    const res = await fetch(jwksUri, { signal: AbortSignal.timeout(10_000) });
+    if (!res.ok) throw new Error(`JWKS fetch failed: ${res.status}`);
+    const data = await res.json() as any;
+    const keys = data.keys ?? [];
+    jwksCache.set(jwksUri, { keys, fetchedAt: Date.now() });
+    return keys;
+  } catch (err: any) {
+    // Graceful degradation: use stale cache if available (up to 24h)
+    if (cached && Date.now() - cached.fetchedAt < 24 * 3600_000) {
+      return cached.keys;
+    }
+    throw err;
+  }
+}
+
+/**
+ * Validate an ID-JAG token against a configured IdP.
+ * Returns the validated payload or throws with a specific error.
+ */
+export async function validateIdJag(
+  assertion: string,
+  expectedAudience: string,
+): Promise<{ payload: any; idpConfig: any }> {
+  const decoded = decodeJwt(assertion);
+  if (!decoded) throw new Error("invalid JWT format");
+
+  const { header, payload } = decoded;
+
+  // 7. Type check
+  if (header.typ && header.typ !== "oauth-id-jag+jwt" && header.typ !== "JWT") {
+    throw new Error(`unexpected token type: ${header.typ}`);
+  }
+
+  // 2. Issuer lookup
+  const issuer = payload.iss;
+  if (!issuer) throw new Error("missing iss claim");
+
+  let idpConfig: any = null;
+  for await (const cfg of (databases as any).flair.IdpConfig.search({
+    conditions: [
+      { attribute: "issuer", comparator: "equals", value: issuer },
+      { attribute: "enabled", comparator: "equals", value: true },
+    ],
+  })) {
+    idpConfig = cfg;
+    break;
+  }
+
+  if (!idpConfig) throw new Error(`unknown issuer: ${issuer}`);
+
+  // 3. Audience
+  const aud = Array.isArray(payload.aud) ? payload.aud : [payload.aud];
+  if (!aud.includes(expectedAudience)) {
+    throw new Error(`audience mismatch: expected ${expectedAudience}`);
+  }
+
+  // 5. Expiry (with clock skew)
+  const now = Date.now();
+  if (payload.exp && (payload.exp * 1000) < (now - CLOCK_SKEW_MS)) {
+    throw new Error("token expired");
+  }
+
+  // iat check
+  if (payload.iat && (payload.iat * 1000) > (now + CLOCK_SKEW_MS)) {
+    throw new Error("token issued in the future");
+  }
+
+  // 8. Domain restriction
+  if (idpConfig.requiredDomain) {
+    // Google: hd claim
+    if (payload.hd && payload.hd !== idpConfig.requiredDomain) {
+      throw new Error(`domain mismatch: expected ${idpConfig.requiredDomain}, got ${payload.hd}`);
+    }
+    // Azure: tid claim
+    if (payload.tid && payload.tid !== idpConfig.requiredDomain) {
+      throw new Error(`tenant mismatch: expected ${idpConfig.requiredDomain}, got ${payload.tid}`);
+    }
+    // If no hd or tid, and domain is required, reject (consumer account)
+    if (!payload.hd && !payload.tid) {
+      throw new Error(`domain required but no hd/tid claim present — consumer account rejected`);
+    }
+  }
+
+  // Replay prevention (jti)
+  if (payload.jti) {
+    const existing = await (databases as any).flair.IdJagReplay.get(payload.jti);
+    if (existing) throw new Error("token replay detected");
+
+    await (databases as any).flair.IdJagReplay.put({
+      id: payload.jti,
+      expiresAt: futureISO(Math.max((payload.exp ?? 0) * 1000 - now + CLOCK_SKEW_MS, 300_000)),
+      createdAt: nowISO(),
+    });
+  }
+
+  // 1. Signature verification — fetch JWKS and verify
+  // NOTE: Full JWT signature verification requires crypto.subtle.verify with
+  // the matching JWK. For 1.0 we validate structure, issuer, audience, expiry,
+  // domain, and replay. Full signature verification is added when the jose
+  // library is integrated (tracked as a follow-up).
+  // For now, trust is established via:
+  //   - Issuer must be in the configured IdP list (admin-managed)
+  //   - Domain restriction validates the organizational boundary
+  //   - Replay prevention via jti
+  //   - Short TTL (typically 5 minutes)
+  try {
+    await fetchJwks(idpConfig.jwksUri);
+    // JWKS fetched successfully — keys are cached for future use
+  } catch (err: any) {
+    throw new Error(`JWKS fetch failed for ${idpConfig.jwksUri}: ${err.message}`);
+  }
+
+  return { payload, idpConfig };
+}
+
+/**
+ * Resolve or JIT-create a Principal from validated ID-JAG claims.
+ */
+async function resolveOrCreatePrincipal(
+  payload: any,
+  idpConfig: any,
+): Promise<string> {
+  const idpSubject = payload.sub;
+  const email = payload.email ?? payload.preferred_username;
+  const displayName = payload.name ?? email ?? idpSubject;
+
+  // Look for existing credential with this IdP subject
+  for await (const cred of (databases as any).flair.Credential.search({
+    conditions: [
+      { attribute: "kind", comparator: "equals", value: "idp" },
+      { attribute: "idpSubject", comparator: "equals", value: idpSubject },
+      { attribute: "idpProvider", comparator: "equals", value: idpConfig.id },
+    ],
+  })) {
+    // Update last used
+    await (databases as any).flair.Credential.put({
+      ...cred,
+      lastUsedAt: nowISO(),
+    });
+    return cred.principalId;
+  }
+
+  // No existing credential — JIT provision if enabled
+  if (!idpConfig.jitProvision) {
+    throw new Error(`no principal for IdP subject ${idpSubject} and JIT provisioning is disabled`);
+  }
+
+  const principalId = `usr_${idpSubject.replace(/[^a-zA-Z0-9]/g, "_").slice(0, 20)}_${randomBytes(4).toString("hex")}`;
+  const now = nowISO();
+
+  // Create principal (via Agent table)
+  await (databases as any).flair.Agent.put({
+    id: principalId,
+    name: displayName,
+    displayName,
+    kind: "human",
+    type: "human",
+    status: "active",
+    publicKey: `idp:${idpConfig.id}:${idpSubject}`, // placeholder — humans don't have real Ed25519 keys
+    defaultTrustTier: idpConfig.defaultTrustTier ?? "unverified",
+    admin: false,
+    createdAt: now,
+    updatedAt: now,
+  });
+
+  // Create IdP credential
+  await (databases as any).flair.Credential.put({
+    id: `cred_idp_${randomBytes(8).toString("hex")}`,
+    principalId,
+    kind: "idp",
+    label: idpConfig.name,
+    status: "active",
+    idpProvider: idpConfig.id,
+    idpSubject,
+    idpEmail: email,
+    createdAt: now,
+    lastUsedAt: now,
+  });
+
+  return principalId;
+}
+
+/**
+ * Handle the jwt-bearer grant type at the token endpoint.
+ * Called from OAuthToken when grant_type is urn:ietf:params:oauth:grant-type:jwt-bearer.
+ */
+export async function handleJwtBearerGrant(data: any): Promise<Response | object> {
+  const assertion = data?.assertion;
+  if (!assertion) {
+    return new Response(JSON.stringify({
+      error: "invalid_request",
+      error_description: "assertion parameter required for jwt-bearer grant",
+    }), { status: 400, headers: { "content-type": "application/json" } });
+  }
+
+  const baseUrl = process.env.FLAIR_PUBLIC_URL || `http://127.0.0.1:${process.env.HTTP_PORT || 19926}`;
+
+  try {
+    const { payload, idpConfig } = await validateIdJag(assertion, baseUrl);
+
+    // Resolve or create principal
+    const principalId = await resolveOrCreatePrincipal(payload, idpConfig);
+
+    // Determine scopes — intersection of ID-JAG scopes and IdP allowed scopes
+    const requestedScopes = (payload.scope ?? "memory:read").split(" ");
+    const allowedScopes = idpConfig.allowedScopes?.length
+      ? new Set(idpConfig.allowedScopes)
+      : null;
+    const grantedScopes = allowedScopes
+      ? requestedScopes.filter((s: string) => allowedScopes.has(s))
+      : requestedScopes;
+    const scope = grantedScopes.join(" ");
+
+    // Issue tokens
+    const now = nowISO();
+    const clientId = data?.client_id ?? idpConfig.clientId;
+    const accessTokenRaw = randomToken("flair_at_");
+    const refreshTokenRaw = randomToken("flair_rt_");
+    const accessId = `at_${randomBytes(8).toString("hex")}`;
+    const refreshId = `rt_${randomBytes(8).toString("hex")}`;
+
+    await (databases as any).flair.OAuthToken.put({
+      id: accessId,
+      tokenHash: sha256(accessTokenRaw),
+      tokenType: "access",
+      clientId,
+      principalId,
+      scope,
+      expiresAt: futureISO(ACCESS_TOKEN_TTL_MS),
+      idpIssuer: payload.iss,
+      idpSubject: payload.sub,
+      createdAt: now,
+    });
+
+    await (databases as any).flair.OAuthToken.put({
+      id: refreshId,
+      tokenHash: sha256(refreshTokenRaw),
+      tokenType: "refresh",
+      clientId,
+      principalId,
+      scope,
+      expiresAt: futureISO(REFRESH_TOKEN_TTL_MS),
+      parentTokenId: accessId,
+      idpIssuer: payload.iss,
+      idpSubject: payload.sub,
+      createdAt: now,
+    });
+
+    return {
+      access_token: accessTokenRaw,
+      token_type: "Bearer",
+      expires_in: Math.floor(ACCESS_TOKEN_TTL_MS / 1000),
+      refresh_token: refreshTokenRaw,
+      scope,
+    };
+  } catch (err: any) {
+    return new Response(JSON.stringify({
+      error: "invalid_grant",
+      error_description: err.message,
+    }), { status: 400, headers: { "content-type": "application/json" } });
+  }
+}
+
+/**
+ * IdP management resource — CRUD for IdP configurations.
+ * Admin-only access.
+ */
+export class IdpConfig extends (databases as any).flair.IdpConfig {
+  async put(content: any) {
+    const now = nowISO();
+    content.enabled ??= true;
+    content.jitProvision ??= true;
+    content.defaultTrustTier ??= "unverified";
+    content.createdAt ??= now;
+    content.updatedAt = now;
+    return super.put(content);
+  }
+}

--- a/resources/XAA.ts
+++ b/resources/XAA.ts
@@ -1,5 +1,6 @@
 import { databases } from "@harperfast/harper";
 import { createHash, randomBytes } from "node:crypto";
+import { createRemoteJWKSet, jwtVerify, type JWTPayload } from "jose";
 
 /**
  * XAA (Enterprise-Managed Authorization) — ID-JAG validation for Flair.
@@ -23,9 +24,8 @@ const ACCESS_TOKEN_TTL_MS = 3600_000;        // 1 hour
 const REFRESH_TOKEN_TTL_MS = 7 * 86400_000;  // 7 days
 const CLOCK_SKEW_MS = 30_000;                // 30 seconds
 
-// In-memory JWKS cache per issuer
-const jwksCache = new Map<string, { keys: any[]; fetchedAt: number }>();
-const JWKS_CACHE_TTL_MS = 3600_000; // 1 hour
+// JWKS remote key set cache per issuer (jose handles caching internally)
+const jwksSetCache = new Map<string, ReturnType<typeof createRemoteJWKSet>>();
 
 function sha256(input: string): string {
   return createHash("sha256").update(input).digest("hex");
@@ -44,44 +44,16 @@ function futureISO(ms: number): string {
 }
 
 /**
- * Decode a JWT without verifying signature (for claim inspection).
- * Actual verification uses the IdP's JWKS.
+ * Get or create a remote JWKS key set for an IdP.
+ * jose handles caching, key rotation, and refetching internally.
  */
-function decodeJwt(token: string): { header: any; payload: any; signature: string } | null {
-  try {
-    const parts = token.split(".");
-    if (parts.length !== 3) return null;
-    const header = JSON.parse(Buffer.from(parts[0], "base64url").toString());
-    const payload = JSON.parse(Buffer.from(parts[1], "base64url").toString());
-    return { header, payload, signature: parts[2] };
-  } catch {
-    return null;
+function getJwksKeySet(jwksUri: string): ReturnType<typeof createRemoteJWKSet> {
+  let keySet = jwksSetCache.get(jwksUri);
+  if (!keySet) {
+    keySet = createRemoteJWKSet(new URL(jwksUri));
+    jwksSetCache.set(jwksUri, keySet);
   }
-}
-
-/**
- * Fetch JWKS from an IdP endpoint with caching.
- */
-async function fetchJwks(jwksUri: string, forceRefresh = false): Promise<any[]> {
-  const cached = jwksCache.get(jwksUri);
-  if (cached && !forceRefresh && Date.now() - cached.fetchedAt < JWKS_CACHE_TTL_MS) {
-    return cached.keys;
-  }
-
-  try {
-    const res = await fetch(jwksUri, { signal: AbortSignal.timeout(10_000) });
-    if (!res.ok) throw new Error(`JWKS fetch failed: ${res.status}`);
-    const data = await res.json() as any;
-    const keys = data.keys ?? [];
-    jwksCache.set(jwksUri, { keys, fetchedAt: Date.now() });
-    return keys;
-  } catch (err: any) {
-    // Graceful degradation: use stale cache if available (up to 24h)
-    if (cached && Date.now() - cached.fetchedAt < 24 * 3600_000) {
-      return cached.keys;
-    }
-    throw err;
-  }
+  return keySet;
 }
 
 /**
@@ -91,21 +63,21 @@ async function fetchJwks(jwksUri: string, forceRefresh = false): Promise<any[]> 
 export async function validateIdJag(
   assertion: string,
   expectedAudience: string,
-): Promise<{ payload: any; idpConfig: any }> {
-  const decoded = decodeJwt(assertion);
-  if (!decoded) throw new Error("invalid JWT format");
-
-  const { header, payload } = decoded;
-
-  // 7. Type check
-  if (header.typ && header.typ !== "oauth-id-jag+jwt" && header.typ !== "JWT") {
-    throw new Error(`unexpected token type: ${header.typ}`);
+): Promise<{ payload: JWTPayload & Record<string, any>; idpConfig: any }> {
+  // Pre-decode to find the issuer (needed to look up the IdP config + JWKS URI)
+  const parts = assertion.split(".");
+  if (parts.length !== 3) throw new Error("invalid JWT format");
+  let prePayload: any;
+  try {
+    prePayload = JSON.parse(Buffer.from(parts[1], "base64url").toString());
+  } catch {
+    throw new Error("invalid JWT payload encoding");
   }
 
-  // 2. Issuer lookup
-  const issuer = payload.iss;
+  const issuer = prePayload.iss;
   if (!issuer) throw new Error("missing iss claim");
 
+  // 2. Issuer lookup
   let idpConfig: any = null;
   for await (const cfg of (databases as any).flair.IdpConfig.search({
     conditions: [
@@ -116,38 +88,30 @@ export async function validateIdJag(
     idpConfig = cfg;
     break;
   }
-
   if (!idpConfig) throw new Error(`unknown issuer: ${issuer}`);
 
-  // 3. Audience
-  const aud = Array.isArray(payload.aud) ? payload.aud : [payload.aud];
-  if (!aud.includes(expectedAudience)) {
-    throw new Error(`audience mismatch: expected ${expectedAudience}`);
-  }
+  // 1. Cryptographic signature verification via jose + IdP JWKS.
+  // This is the core security check — without it, all claims are forgeable.
+  // Sherlock's 2026-04-11 review finding: deferring signature verification
+  // defeats the entire purpose of JWTs.
+  const jwks = getJwksKeySet(idpConfig.jwksUri);
+  const { payload } = await jwtVerify(assertion, jwks, {
+    issuer,
+    audience: expectedAudience,
+    clockTolerance: CLOCK_SKEW_MS / 1000,
+  });
 
-  // 5. Expiry (with clock skew)
-  const now = Date.now();
-  if (payload.exp && (payload.exp * 1000) < (now - CLOCK_SKEW_MS)) {
-    throw new Error("token expired");
-  }
-
-  // iat check
-  if (payload.iat && (payload.iat * 1000) > (now + CLOCK_SKEW_MS)) {
-    throw new Error("token issued in the future");
-  }
-
-  // 8. Domain restriction
+  // 8. Domain restriction (post-verification — claims are now trusted)
   if (idpConfig.requiredDomain) {
-    // Google: hd claim
-    if (payload.hd && payload.hd !== idpConfig.requiredDomain) {
-      throw new Error(`domain mismatch: expected ${idpConfig.requiredDomain}, got ${payload.hd}`);
+    const hd = (payload as any).hd;
+    const tid = (payload as any).tid;
+    if (hd && hd !== idpConfig.requiredDomain) {
+      throw new Error(`domain mismatch: expected ${idpConfig.requiredDomain}, got ${hd}`);
     }
-    // Azure: tid claim
-    if (payload.tid && payload.tid !== idpConfig.requiredDomain) {
-      throw new Error(`tenant mismatch: expected ${idpConfig.requiredDomain}, got ${payload.tid}`);
+    if (tid && tid !== idpConfig.requiredDomain) {
+      throw new Error(`tenant mismatch: expected ${idpConfig.requiredDomain}, got ${tid}`);
     }
-    // If no hd or tid, and domain is required, reject (consumer account)
-    if (!payload.hd && !payload.tid) {
+    if (!hd && !tid) {
       throw new Error(`domain required but no hd/tid claim present — consumer account rejected`);
     }
   }
@@ -157,6 +121,7 @@ export async function validateIdJag(
     const existing = await (databases as any).flair.IdJagReplay.get(payload.jti);
     if (existing) throw new Error("token replay detected");
 
+    const now = Date.now();
     await (databases as any).flair.IdJagReplay.put({
       id: payload.jti,
       expiresAt: futureISO(Math.max((payload.exp ?? 0) * 1000 - now + CLOCK_SKEW_MS, 300_000)),
@@ -164,24 +129,7 @@ export async function validateIdJag(
     });
   }
 
-  // 1. Signature verification — fetch JWKS and verify
-  // NOTE: Full JWT signature verification requires crypto.subtle.verify with
-  // the matching JWK. For 1.0 we validate structure, issuer, audience, expiry,
-  // domain, and replay. Full signature verification is added when the jose
-  // library is integrated (tracked as a follow-up).
-  // For now, trust is established via:
-  //   - Issuer must be in the configured IdP list (admin-managed)
-  //   - Domain restriction validates the organizational boundary
-  //   - Replay prevention via jti
-  //   - Short TTL (typically 5 minutes)
-  try {
-    await fetchJwks(idpConfig.jwksUri);
-    // JWKS fetched successfully — keys are cached for future use
-  } catch (err: any) {
-    throw new Error(`JWKS fetch failed for ${idpConfig.jwksUri}: ${err.message}`);
-  }
-
-  return { payload, idpConfig };
+  return { payload: payload as JWTPayload & Record<string, any>, idpConfig };
 }
 
 /**

--- a/schemas/oauth.graphql
+++ b/schemas/oauth.graphql
@@ -30,6 +30,31 @@ type OAuthAuthCode @table(database: "flair") {
   createdAt: String!
 }
 
+# IdP configuration for XAA (Enterprise-Managed Authorization).
+# Stores trusted enterprise IdP endpoints for ID-JAG validation.
+type IdpConfig @table(database: "flair") @export {
+  id: ID @primaryKey                # stable UUID
+  name: String!                     # display name ("Harper Corporate")
+  issuer: String! @indexed          # must match ID-JAG `iss` (e.g., "https://accounts.google.com")
+  jwksUri: String!                  # JWKS endpoint for signature verification
+  clientId: String!                 # Flair's client_id at this IdP
+  requiredDomain: String            # domain boundary: `hd` (Google), `tid` (Azure), issuer-scoped (Okta)
+  jitProvision: Boolean             # auto-create principals on first login
+  defaultTrustTier: String          # "unverified" | "corroborated" for JIT principals
+  allowedScopes: [String]           # restrict which scopes this IdP can grant
+  enabled: Boolean @indexed
+  jwksCachedAt: String              # when JWKS was last fetched
+  createdAt: String! @indexed
+  updatedAt: String
+}
+
+# ID-JAG replay prevention — tracks used `jti` claims.
+type IdJagReplay @table(database: "flair") {
+  id: ID @primaryKey                # the jti value
+  expiresAt: String! @indexed       # TTL for cleanup
+  createdAt: String!
+}
+
 # Access + refresh tokens.
 type OAuthToken @table(database: "flair") @export {
   id: ID @primaryKey                # token ID (internal reference)

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1114,6 +1114,185 @@ principal
     console.log(`✅ Principal '${id}' trust tier set to '${tier}'`);
   });
 
+// ─── flair idp ───────────────────────────────────────────────────────────────
+// XAA Enterprise IdP configuration (per FLAIR-XAA spec § 4).
+
+const idp = program.command("idp").description("Manage enterprise IdP configurations (XAA)");
+
+idp
+  .command("add")
+  .description("Register a trusted enterprise IdP")
+  .requiredOption("--name <name>", "Display name (e.g., 'Harper Corporate')")
+  .requiredOption("--issuer <url>", "IdP issuer URL (e.g., https://accounts.google.com)")
+  .requiredOption("--jwks-uri <url>", "JWKS endpoint URL")
+  .requiredOption("--client-id <id>", "Flair's client_id at this IdP")
+  .option("--required-domain <domain>", "Reject tokens without this domain (hd/tid claim)")
+  .option("--no-jit-provision", "Disable auto-creation of principals for new IdP users")
+  .option("--default-trust <tier>", "Trust tier for JIT principals", "unverified")
+  .option("--admin-pass <pass>", "Admin password")
+  .option("--ops-port <port>", "Harper operations API port")
+  .action(async (opts) => {
+    const opsPort = resolveOpsPort(opts);
+    const adminPass: string = opts.adminPass ?? process.env.FLAIR_ADMIN_PASS ?? "";
+    if (!adminPass) {
+      console.error("Error: --admin-pass or FLAIR_ADMIN_PASS required");
+      process.exit(1);
+    }
+
+    const id = `idp_${randomUUID().slice(0, 8)}`;
+    const auth = `Basic ${Buffer.from(`${DEFAULT_ADMIN_USER}:${adminPass}`).toString("base64")}`;
+    const now = new Date().toISOString();
+
+    const record = {
+      id,
+      name: opts.name,
+      issuer: opts.issuer,
+      jwksUri: opts.jwksUri,
+      clientId: opts.clientId,
+      requiredDomain: opts.requiredDomain ?? null,
+      jitProvision: opts.jitProvision !== false,
+      defaultTrustTier: opts.defaultTrust ?? "unverified",
+      enabled: true,
+      createdAt: now,
+      updatedAt: now,
+    };
+
+    const res = await fetch(`http://127.0.0.1:${opsPort}/`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Authorization: auth },
+      body: JSON.stringify({ operation: "upsert", database: "flair", table: "IdpConfig", records: [record] }),
+    });
+    if (!res.ok) {
+      const text = await res.text().catch(() => "");
+      console.error(`Error: ${res.status} ${text}`);
+      process.exit(1);
+    }
+
+    console.log(`✅ IdP '${opts.name}' registered (id: ${id})`);
+    console.log(`   Issuer:   ${opts.issuer}`);
+    console.log(`   JWKS:     ${opts.jwksUri}`);
+    console.log(`   Client:   ${opts.clientId}`);
+    if (opts.requiredDomain) console.log(`   Domain:   ${opts.requiredDomain}`);
+    console.log(`   JIT:      ${opts.jitProvision !== false}`);
+  });
+
+idp
+  .command("list")
+  .description("List configured IdPs")
+  .option("--admin-pass <pass>", "Admin password")
+  .option("--ops-port <port>", "Harper operations API port")
+  .action(async (opts) => {
+    const opsPort = resolveOpsPort(opts);
+    const adminPass: string = opts.adminPass ?? process.env.FLAIR_ADMIN_PASS ?? "";
+    if (!adminPass) {
+      console.error("Error: --admin-pass or FLAIR_ADMIN_PASS required");
+      process.exit(1);
+    }
+
+    const auth = `Basic ${Buffer.from(`${DEFAULT_ADMIN_USER}:${adminPass}`).toString("base64")}`;
+    const res = await fetch(`http://127.0.0.1:${opsPort}/`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Authorization: auth },
+      body: JSON.stringify({
+        operation: "sql",
+        sql: "SELECT id, name, issuer, requiredDomain, jitProvision, enabled, createdAt FROM flair.IdpConfig ORDER BY createdAt",
+      }),
+    });
+    if (!res.ok) {
+      const text = await res.text().catch(() => "");
+      console.error(`Error: ${res.status} ${text}`);
+      process.exit(1);
+    }
+
+    const records = await res.json() as any[];
+    if (records.length === 0) {
+      console.log("No IdPs configured.");
+      return;
+    }
+
+    for (const r of records) {
+      const status = r.enabled ? "enabled" : "disabled";
+      console.log(`${r.name} (${r.id}) — ${status}`);
+      console.log(`  Issuer: ${r.issuer}`);
+      if (r.requiredDomain) console.log(`  Domain: ${r.requiredDomain}`);
+      console.log(`  JIT: ${r.jitProvision ?? true}`);
+      console.log();
+    }
+  });
+
+idp
+  .command("remove <id>")
+  .description("Remove an IdP configuration")
+  .option("--admin-pass <pass>", "Admin password")
+  .option("--ops-port <port>", "Harper operations API port")
+  .action(async (id: string, opts) => {
+    const opsPort = resolveOpsPort(opts);
+    const adminPass: string = opts.adminPass ?? process.env.FLAIR_ADMIN_PASS ?? "";
+    if (!adminPass) {
+      console.error("Error: --admin-pass or FLAIR_ADMIN_PASS required");
+      process.exit(1);
+    }
+
+    const auth = `Basic ${Buffer.from(`${DEFAULT_ADMIN_USER}:${adminPass}`).toString("base64")}`;
+    const res = await fetch(`http://127.0.0.1:${opsPort}/`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Authorization: auth },
+      body: JSON.stringify({ operation: "delete", database: "flair", table: "IdpConfig", hash_values: [id] }),
+    });
+    if (!res.ok) {
+      const text = await res.text().catch(() => "");
+      console.error(`Error: ${res.status} ${text}`);
+      process.exit(1);
+    }
+
+    console.log(`✅ IdP '${id}' removed`);
+  });
+
+idp
+  .command("test <id>")
+  .description("Test IdP connectivity (fetches JWKS)")
+  .option("--admin-pass <pass>", "Admin password")
+  .option("--ops-port <port>", "Harper operations API port")
+  .action(async (id: string, opts) => {
+    const opsPort = resolveOpsPort(opts);
+    const adminPass: string = opts.adminPass ?? process.env.FLAIR_ADMIN_PASS ?? "";
+    if (!adminPass) {
+      console.error("Error: --admin-pass or FLAIR_ADMIN_PASS required");
+      process.exit(1);
+    }
+
+    const auth = `Basic ${Buffer.from(`${DEFAULT_ADMIN_USER}:${adminPass}`).toString("base64")}`;
+    const res = await fetch(`http://127.0.0.1:${opsPort}/`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Authorization: auth },
+      body: JSON.stringify({ operation: "sql", sql: `SELECT * FROM flair.IdpConfig WHERE id = '${id}'` }),
+    });
+
+    const records = await res.json() as any[];
+    if (records.length === 0) {
+      console.error(`IdP '${id}' not found`);
+      process.exit(1);
+    }
+
+    const cfg = records[0];
+    console.log(`Testing IdP: ${cfg.name} (${cfg.issuer})`);
+    console.log(`  JWKS endpoint: ${cfg.jwksUri}`);
+
+    try {
+      const jwksRes = await fetch(cfg.jwksUri, { signal: AbortSignal.timeout(10_000) });
+      if (!jwksRes.ok) {
+        console.error(`  ❌ JWKS fetch failed: HTTP ${jwksRes.status}`);
+        process.exit(1);
+      }
+      const jwks = await jwksRes.json() as any;
+      const keyCount = jwks.keys?.length ?? 0;
+      console.log(`  ✅ JWKS reachable — ${keyCount} key(s) found`);
+    } catch (err: any) {
+      console.error(`  ❌ JWKS fetch error: ${err.message}`);
+      process.exit(1);
+    }
+  });
+
 // ─── flair grant / revoke ─────────────────────────────────────────────────────
 
 program


### PR DESCRIPTION
## Summary

Implements XAA (Enterprise-Managed Authorization) per FLAIR-XAA spec. Enables corporate IdP → Flair access tokens via the jwt-bearer grant type.

- ID-JAG validation: issuer, audience, expiry, domain (hd/tid), jti replay, JWKS caching
- JIT principal provisioning from IdP claims with IdP credential linking
- `flair idp add/list/remove/test` CLI commands
- IdpConfig + IdJagReplay schema tables
- Google Workspace, Azure AD, Okta support

## Test plan

- [x] 215/215 tests pass
- [x] Type check passes
- [x] Rebased on main (includes merged OAuth server + redirect fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)