### PR TITLE
feat: web admin — server-rendered HTML pages

### DIFF
--- a/resources/admin/AdminConnectors.ts
+++ b/resources/admin/AdminConnectors.ts
@@ -1,5 +1,5 @@
 import { Resource, databases } from "@harperfast/harper";
-import { layout, htmlResponse } from "./layout.js";
+import { layout, htmlResponse, esc } from "./layout.js";
 
 /**
  * GET /AdminConnectors — OAuth clients and active sessions.
@@ -27,9 +27,9 @@ export class AdminConnectors extends Resource {
 
         tableRows += `
           <tr>
-            <td><strong>${c.name || "Unnamed"}</strong><br><small>${c.id}</small></td>
-            <td>${redirects || "—"}</td>
-            <td><span class="badge badge-gray">${source}</span></td>
+            <td><strong>${esc(c.name || "Unnamed")}</strong><br><small>${esc(c.id)}</small></td>
+            <td>${esc(redirects || "—")}</td>
+            <td><span class="badge badge-gray">${esc(source)}</span></td>
             <td>${created}</td>
           </tr>`;
       }

--- a/resources/admin/AdminConnectors.ts
+++ b/resources/admin/AdminConnectors.ts
@@ -1,0 +1,59 @@
+import { Resource, databases } from "@harperfast/harper";
+import { layout, htmlResponse } from "./layout.js";
+
+/**
+ * GET /AdminConnectors — OAuth clients and active sessions.
+ */
+export class AdminConnectors extends Resource {
+  async get() {
+    const clients: any[] = [];
+
+    try {
+      for await (const c of (databases as any).flair.OAuthClient.search()) {
+        clients.push(c);
+      }
+    } catch { /* table may not exist */ }
+
+    clients.sort((a, b) => (b.createdAt || "").localeCompare(a.createdAt || ""));
+
+    let tableRows = "";
+    if (clients.length === 0) {
+      tableRows = `<tr><td colspan="4" class="empty">No OAuth clients registered. Clients are created via Dynamic Client Registration when Claude connects.</td></tr>`;
+    } else {
+      for (const c of clients) {
+        const created = c.createdAt?.slice(0, 10) ?? "—";
+        const source = c.registeredBy === "dcr" ? "DCR" : c.registeredBy ?? "—";
+        const redirects = (c.redirectUris ?? []).join(", ");
+
+        tableRows += `
+          <tr>
+            <td><strong>${c.name || "Unnamed"}</strong><br><small>${c.id}</small></td>
+            <td>${redirects || "—"}</td>
+            <td><span class="badge badge-gray">${source}</span></td>
+            <td>${created}</td>
+          </tr>`;
+      }
+    }
+
+    const content = `
+      <h1>Connectors</h1>
+      <p class="subtitle">OAuth clients that can access this Flair instance</p>
+
+      <table>
+        <thead>
+          <tr>
+            <th>Client</th>
+            <th>Redirect URIs</th>
+            <th>Source</th>
+            <th>Created</th>
+          </tr>
+        </thead>
+        <tbody>
+          ${tableRows}
+        </tbody>
+      </table>
+    `;
+
+    return htmlResponse(layout("Connectors", content, "connectors"));
+  }
+}

--- a/resources/admin/AdminDashboard.ts
+++ b/resources/admin/AdminDashboard.ts
@@ -1,0 +1,69 @@
+import { Resource, databases } from "@harperfast/harper";
+import { layout, htmlResponse } from "./layout.js";
+
+/**
+ * GET /AdminDashboard — admin home page with system overview.
+ */
+export class AdminDashboard extends Resource {
+  async get() {
+    let principalCount = 0;
+    let memoryCount = 0;
+    let humanCount = 0;
+    let agentCount = 0;
+
+    try {
+      for await (const p of (databases as any).flair.Agent.search()) {
+        principalCount++;
+        if (p.kind === "human") humanCount++;
+        else agentCount++;
+      }
+    } catch { /* table may not exist */ }
+
+    try {
+      for await (const _ of (databases as any).flair.Memory.search()) {
+        memoryCount++;
+      }
+    } catch { /* table may not exist */ }
+
+    let idpCount = 0;
+    try {
+      for await (const _ of (databases as any).flair.IdpConfig.search()) {
+        idpCount++;
+      }
+    } catch { /* table may not exist */ }
+
+    let relationshipCount = 0;
+    try {
+      for await (const _ of (databases as any).flair.Relationship.search()) {
+        relationshipCount++;
+      }
+    } catch { /* table may not exist */ }
+
+    const content = `
+      <h1>Dashboard</h1>
+      <p class="subtitle">Flair instance overview</p>
+
+      <div class="stats">
+        <div class="card">
+          <h3>Principals</h3>
+          <div class="value">${principalCount}</div>
+          <div>${humanCount} human, ${agentCount} agent</div>
+        </div>
+        <div class="card">
+          <h3>Memories</h3>
+          <div class="value">${memoryCount}</div>
+        </div>
+        <div class="card">
+          <h3>Relationships</h3>
+          <div class="value">${relationshipCount}</div>
+        </div>
+        <div class="card">
+          <h3>IdP Configs</h3>
+          <div class="value">${idpCount}</div>
+        </div>
+      </div>
+    `;
+
+    return htmlResponse(layout("Dashboard", content, "home"));
+  }
+}

--- a/resources/admin/AdminIdp.ts
+++ b/resources/admin/AdminIdp.ts
@@ -1,5 +1,5 @@
 import { Resource, databases } from "@harperfast/harper";
-import { layout, htmlResponse } from "./layout.js";
+import { layout, htmlResponse, esc } from "./layout.js";
 
 /**
  * GET /AdminIdp — enterprise IdP configuration management.
@@ -27,9 +27,9 @@ export class AdminIdp extends Resource {
 
         tableRows += `
           <tr>
-            <td><strong>${cfg.name}</strong><br><small>${cfg.id}</small></td>
-            <td>${cfg.issuer}</td>
-            <td>${domain}</td>
+            <td><strong>${esc(cfg.name)}</strong><br><small>${esc(cfg.id)}</small></td>
+            <td>${esc(cfg.issuer)}</td>
+            <td>${esc(domain)}</td>
             <td>${jit}</td>
             <td>${status}</td>
           </tr>`;

--- a/resources/admin/AdminIdp.ts
+++ b/resources/admin/AdminIdp.ts
@@ -1,0 +1,61 @@
+import { Resource, databases } from "@harperfast/harper";
+import { layout, htmlResponse } from "./layout.js";
+
+/**
+ * GET /AdminIdp — enterprise IdP configuration management.
+ */
+export class AdminIdp extends Resource {
+  async get() {
+    const idps: any[] = [];
+
+    try {
+      for await (const cfg of (databases as any).flair.IdpConfig.search()) {
+        idps.push(cfg);
+      }
+    } catch { /* table may not exist */ }
+
+    let tableRows = "";
+    if (idps.length === 0) {
+      tableRows = `<tr><td colspan="5" class="empty">No IdPs configured. Use <code>flair idp add</code> to register an enterprise IdP.</td></tr>`;
+    } else {
+      for (const cfg of idps) {
+        const status = cfg.enabled
+          ? `<span class="badge badge-green">enabled</span>`
+          : `<span class="badge badge-gray">disabled</span>`;
+        const jit = cfg.jitProvision ? "yes" : "no";
+        const domain = cfg.requiredDomain ?? "—";
+
+        tableRows += `
+          <tr>
+            <td><strong>${cfg.name}</strong><br><small>${cfg.id}</small></td>
+            <td>${cfg.issuer}</td>
+            <td>${domain}</td>
+            <td>${jit}</td>
+            <td>${status}</td>
+          </tr>`;
+      }
+    }
+
+    const content = `
+      <h1>Enterprise IdP</h1>
+      <p class="subtitle">Identity providers for XAA (Enterprise-Managed Authorization)</p>
+
+      <table>
+        <thead>
+          <tr>
+            <th>Name</th>
+            <th>Issuer</th>
+            <th>Domain</th>
+            <th>JIT</th>
+            <th>Status</th>
+          </tr>
+        </thead>
+        <tbody>
+          ${tableRows}
+        </tbody>
+      </table>
+    `;
+
+    return htmlResponse(layout("IdP", content, "idp"));
+  }
+}

--- a/resources/admin/AdminInstance.ts
+++ b/resources/admin/AdminInstance.ts
@@ -1,0 +1,68 @@
+import { Resource } from "@harperfast/harper";
+import { layout, htmlResponse } from "./layout.js";
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { homedir } from "node:os";
+
+/**
+ * GET /AdminInstance — instance info, public key, version.
+ */
+export class AdminInstance extends Resource {
+  async get() {
+    const version = process.env.npm_package_version ?? "dev";
+    const httpPort = process.env.HTTP_PORT ?? "19926";
+    const publicUrl = process.env.FLAIR_PUBLIC_URL ?? `http://127.0.0.1:${httpPort}`;
+
+    // Try to read instance public key
+    let publicKey = "—";
+    const keyDir = join(homedir(), ".flair", "keys");
+    try {
+      // Look for any .pub file
+      const { readdirSync } = await import("node:fs");
+      const files = readdirSync(keyDir).filter((f: string) => f.endsWith(".pub") || f.endsWith(".key"));
+      if (files.length > 0) {
+        publicKey = `${files.length} key(s) in ${keyDir}`;
+      }
+    } catch {
+      publicKey = "Key directory not found";
+    }
+
+    const content = `
+      <h1>Instance</h1>
+      <p class="subtitle">Flair instance configuration and identity</p>
+
+      <div class="stats">
+        <div class="card">
+          <h3>Version</h3>
+          <div class="value" style="font-size:1.4em">${version}</div>
+        </div>
+        <div class="card">
+          <h3>Public URL</h3>
+          <div style="font-family:monospace;font-size:0.9em;word-break:break-all">${publicUrl}</div>
+        </div>
+      </div>
+
+      <div class="card">
+        <h3>Keys</h3>
+        <p>${publicKey}</p>
+        <p style="margin-top:8px;color:#666;font-size:0.9em">
+          Ed25519 keys are stored in <code>${keyDir}</code>. Each principal has its own keypair.
+        </p>
+      </div>
+
+      <div class="card">
+        <h3>Endpoints</h3>
+        <table style="box-shadow:none">
+          <tr><td>API</td><td><code>${publicUrl}/</code></td></tr>
+          <tr><td>MCP</td><td><code>${publicUrl}/mcp</code></td></tr>
+          <tr><td>OAuth Discovery</td><td><code>${publicUrl}/OAuthMetadata</code></td></tr>
+          <tr><td>OAuth Authorize</td><td><code>${publicUrl}/OAuthAuthorize</code></td></tr>
+          <tr><td>OAuth Token</td><td><code>${publicUrl}/OAuthToken</code></td></tr>
+          <tr><td>Admin</td><td><code>${publicUrl}/AdminDashboard</code></td></tr>
+        </table>
+      </div>
+    `;
+
+    return htmlResponse(layout("Instance", content, "instance"));
+  }
+}

--- a/resources/admin/AdminMemory.ts
+++ b/resources/admin/AdminMemory.ts
@@ -1,0 +1,97 @@
+import { Resource, databases } from "@harperfast/harper";
+import { layout, htmlResponse } from "./layout.js";
+
+/**
+ * GET /AdminMemory — browse and search memories.
+ */
+export class AdminMemory extends Resource {
+  async get() {
+    const request = (this as any).request;
+    const url = new URL(request?.url ?? "http://localhost", "http://localhost");
+    const query = url.searchParams.get("q") ?? "";
+    const subject = url.searchParams.get("subject") ?? "";
+    const limit = Math.min(Number(url.searchParams.get("limit") ?? 50), 200);
+
+    const memories: any[] = [];
+
+    try {
+      const conditions: any[] = [];
+      if (subject) {
+        conditions.push({ attribute: "subject", comparator: "equals", value: subject.toLowerCase() });
+      }
+      conditions.push({ attribute: "archived", comparator: "not_equal", value: true });
+
+      const searchQuery: any = conditions.length > 0 ? { conditions } : {};
+      let count = 0;
+
+      for await (const m of (databases as any).flair.Memory.search(searchQuery)) {
+        if (m.expiresAt && Date.parse(m.expiresAt) < Date.now()) continue;
+        if (query && !String(m.content || "").toLowerCase().includes(query.toLowerCase())) continue;
+        memories.push(m);
+        count++;
+        if (count >= limit) break;
+      }
+    } catch { /* table may not exist */ }
+
+    memories.sort((a, b) => (b.createdAt || "").localeCompare(a.createdAt || ""));
+
+    let tableRows = "";
+    if (memories.length === 0) {
+      tableRows = `<tr><td colspan="5" class="empty">No memories found${query ? ` matching "${query}"` : ""}.</td></tr>`;
+    } else {
+      for (const m of memories) {
+        const preview = (m.content || "").slice(0, 120) + ((m.content || "").length > 120 ? "…" : "");
+        const durability = m.durability ?? "standard";
+        const durBadge = durability === "permanent"
+          ? `<span class="badge badge-green">${durability}</span>`
+          : durability === "persistent"
+            ? `<span class="badge badge-blue">${durability}</span>`
+            : `<span class="badge badge-gray">${durability}</span>`;
+        const subjectStr = m.subject ?? "—";
+        const created = m.createdAt?.slice(0, 10) ?? "—";
+        const validity = m.validTo ? `<small>expired ${m.validTo.slice(0, 10)}</small>` : "";
+
+        tableRows += `
+          <tr>
+            <td style="max-width:400px">${preview}</td>
+            <td>${durBadge}</td>
+            <td>${subjectStr}</td>
+            <td>${m.agentId ?? "—"}</td>
+            <td>${created} ${validity}</td>
+          </tr>`;
+      }
+    }
+
+    const content = `
+      <h1>Memory</h1>
+      <p class="subtitle">${memories.length} memor${memories.length !== 1 ? "ies" : "y"} shown</p>
+
+      <div style="margin-bottom: 20px">
+        <form method="GET" action="/AdminMemory" style="display:flex;gap:8px">
+          <input type="text" name="q" value="${query}" placeholder="Search memories..."
+            style="flex:1;padding:8px 12px;border:1px solid #ddd;border-radius:6px;font-size:0.95em">
+          <input type="text" name="subject" value="${subject}" placeholder="Subject filter"
+            style="width:150px;padding:8px 12px;border:1px solid #ddd;border-radius:6px;font-size:0.95em">
+          <button type="submit" class="btn btn-primary">Search</button>
+        </form>
+      </div>
+
+      <table>
+        <thead>
+          <tr>
+            <th>Content</th>
+            <th>Durability</th>
+            <th>Subject</th>
+            <th>Agent</th>
+            <th>Created</th>
+          </tr>
+        </thead>
+        <tbody>
+          ${tableRows}
+        </tbody>
+      </table>
+    `;
+
+    return htmlResponse(layout("Memory", content, "memory"));
+  }
+}

--- a/resources/admin/AdminMemory.ts
+++ b/resources/admin/AdminMemory.ts
@@ -1,5 +1,5 @@
 import { Resource, databases } from "@harperfast/harper";
-import { layout, htmlResponse } from "./layout.js";
+import { layout, htmlResponse, esc } from "./layout.js";
 
 /**
  * GET /AdminMemory — browse and search memories.
@@ -53,10 +53,10 @@ export class AdminMemory extends Resource {
 
         tableRows += `
           <tr>
-            <td style="max-width:400px">${preview}</td>
+            <td style="max-width:400px">${esc(preview)}</td>
             <td>${durBadge}</td>
-            <td>${subjectStr}</td>
-            <td>${m.agentId ?? "—"}</td>
+            <td>${esc(subjectStr)}</td>
+            <td>${esc(m.agentId ?? "—")}</td>
             <td>${created} ${validity}</td>
           </tr>`;
       }
@@ -68,9 +68,9 @@ export class AdminMemory extends Resource {
 
       <div style="margin-bottom: 20px">
         <form method="GET" action="/AdminMemory" style="display:flex;gap:8px">
-          <input type="text" name="q" value="${query}" placeholder="Search memories..."
+          <input type="text" name="q" value="${esc(query)}" placeholder="Search memories..."
             style="flex:1;padding:8px 12px;border:1px solid #ddd;border-radius:6px;font-size:0.95em">
-          <input type="text" name="subject" value="${subject}" placeholder="Subject filter"
+          <input type="text" name="subject" value="${esc(subject)}" placeholder="Subject filter"
             style="width:150px;padding:8px 12px;border:1px solid #ddd;border-radius:6px;font-size:0.95em">
           <button type="submit" class="btn btn-primary">Search</button>
         </form>

--- a/resources/admin/AdminPrincipals.ts
+++ b/resources/admin/AdminPrincipals.ts
@@ -1,0 +1,76 @@
+import { Resource, databases } from "@harperfast/harper";
+import { layout, htmlResponse } from "./layout.js";
+
+/**
+ * GET /AdminPrincipals — list all principals with kind, trust, status.
+ */
+export class AdminPrincipals extends Resource {
+  async get() {
+    const principals: any[] = [];
+
+    try {
+      for await (const p of (databases as any).flair.Agent.search()) {
+        principals.push(p);
+      }
+    } catch { /* table may not exist */ }
+
+    principals.sort((a, b) => (a.createdAt || "").localeCompare(b.createdAt || ""));
+
+    let tableRows = "";
+    if (principals.length === 0) {
+      tableRows = `<tr><td colspan="6" class="empty">No principals registered yet.</td></tr>`;
+    } else {
+      for (const p of principals) {
+        const kind = p.kind ?? "agent";
+        const kindBadge = kind === "human"
+          ? `<span class="badge badge-blue">human</span>`
+          : `<span class="badge badge-gray">agent</span>`;
+        const trust = p.defaultTrustTier ?? "—";
+        const trustBadge = trust === "endorsed"
+          ? `<span class="badge badge-green">${trust}</span>`
+          : trust === "corroborated"
+            ? `<span class="badge badge-blue">${trust}</span>`
+            : `<span class="badge badge-yellow">${trust}</span>`;
+        const status = p.status ?? "active";
+        const statusBadge = status === "active"
+          ? `<span class="badge badge-green">${status}</span>`
+          : `<span class="badge badge-gray">${status}</span>`;
+        const admin = p.admin ? "yes" : "";
+        const created = p.createdAt?.slice(0, 10) ?? "—";
+
+        tableRows += `
+          <tr>
+            <td><strong>${p.id}</strong><br><small>${p.displayName || p.name || ""}</small></td>
+            <td>${kindBadge}</td>
+            <td>${trustBadge}</td>
+            <td>${statusBadge}</td>
+            <td>${admin}</td>
+            <td>${created}</td>
+          </tr>`;
+      }
+    }
+
+    const content = `
+      <h1>Principals</h1>
+      <p class="subtitle">${principals.length} registered principal${principals.length !== 1 ? "s" : ""}</p>
+
+      <table>
+        <thead>
+          <tr>
+            <th>ID / Name</th>
+            <th>Kind</th>
+            <th>Trust</th>
+            <th>Status</th>
+            <th>Admin</th>
+            <th>Created</th>
+          </tr>
+        </thead>
+        <tbody>
+          ${tableRows}
+        </tbody>
+      </table>
+    `;
+
+    return htmlResponse(layout("Principals", content, "principals"));
+  }
+}

--- a/resources/admin/AdminPrincipals.ts
+++ b/resources/admin/AdminPrincipals.ts
@@ -1,5 +1,5 @@
 import { Resource, databases } from "@harperfast/harper";
-import { layout, htmlResponse } from "./layout.js";
+import { layout, htmlResponse, esc } from "./layout.js";
 
 /**
  * GET /AdminPrincipals — list all principals with kind, trust, status.
@@ -40,7 +40,7 @@ export class AdminPrincipals extends Resource {
 
         tableRows += `
           <tr>
-            <td><strong>${p.id}</strong><br><small>${p.displayName || p.name || ""}</small></td>
+            <td><strong>${esc(p.id)}</strong><br><small>${esc(p.displayName || p.name || "")}</small></td>
             <td>${kindBadge}</td>
             <td>${trustBadge}</td>
             <td>${statusBadge}</td>

--- a/resources/admin/layout.ts
+++ b/resources/admin/layout.ts
@@ -1,0 +1,90 @@
+/**
+ * Shared HTML layout for the Flair web admin.
+ * Server-rendered, no JS framework. Minimal CSS for Nathan-grade UX.
+ */
+
+const VERSION = process.env.npm_package_version ?? "dev";
+
+export function layout(title: string, content: string, activePage?: string): string {
+  const nav = [
+    { href: "/AdminDashboard", label: "Home", id: "home" },
+    { href: "/AdminMemory", label: "Memory", id: "memory" },
+    { href: "/AdminPrincipals", label: "Principals", id: "principals" },
+    { href: "/AdminConnectors", label: "Connectors", id: "connectors" },
+    { href: "/AdminIdp", label: "IdP", id: "idp" },
+    { href: "/AdminInstance", label: "Instance", id: "instance" },
+  ];
+
+  const navHtml = nav.map(n =>
+    `<a href="${n.href}" class="nav-item${activePage === n.id ? " active" : ""}">${n.label}</a>`
+  ).join("\n        ");
+
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>${title} — Flair Admin</title>
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body { font-family: system-ui, -apple-system, sans-serif; background: #f8f9fa; color: #1a1a1a; }
+    .layout { display: flex; min-height: 100vh; }
+    .sidebar {
+      width: 220px; background: #1a1a2e; color: #e0e0e0; padding: 20px 0;
+      display: flex; flex-direction: column; flex-shrink: 0;
+    }
+    .sidebar-brand { padding: 0 20px 20px; font-size: 1.3em; font-weight: 700; color: #fff; border-bottom: 1px solid #2a2a4e; }
+    .nav-item {
+      display: block; padding: 10px 20px; color: #b0b0c0; text-decoration: none;
+      font-size: 0.95em; transition: background 0.15s;
+    }
+    .nav-item:hover { background: #2a2a4e; color: #fff; }
+    .nav-item.active { background: #2563eb; color: #fff; font-weight: 600; }
+    .main { flex: 1; padding: 32px 40px; max-width: 1100px; }
+    .main h1 { font-size: 1.6em; margin-bottom: 8px; }
+    .main .subtitle { color: #666; margin-bottom: 24px; }
+    table { width: 100%; border-collapse: collapse; background: #fff; border-radius: 8px; overflow: hidden; box-shadow: 0 1px 3px rgba(0,0,0,0.08); }
+    th { text-align: left; padding: 12px 16px; background: #f1f3f5; font-size: 0.85em; color: #555; text-transform: uppercase; letter-spacing: 0.5px; }
+    td { padding: 12px 16px; border-top: 1px solid #eee; font-size: 0.95em; }
+    tr:hover td { background: #f8f9ff; }
+    .badge { display: inline-block; padding: 2px 8px; border-radius: 10px; font-size: 0.8em; font-weight: 600; }
+    .badge-green { background: #d4edda; color: #155724; }
+    .badge-gray { background: #e9ecef; color: #495057; }
+    .badge-blue { background: #cce5ff; color: #004085; }
+    .badge-yellow { background: #fff3cd; color: #856404; }
+    .card { background: #fff; border-radius: 8px; padding: 20px; box-shadow: 0 1px 3px rgba(0,0,0,0.08); margin-bottom: 16px; }
+    .card h3 { font-size: 1.1em; margin-bottom: 8px; }
+    .card .value { font-size: 2em; font-weight: 700; color: #2563eb; }
+    .stats { display: grid; grid-template-columns: repeat(auto-fit, minmax(200px, 1fr)); gap: 16px; margin-bottom: 32px; }
+    .empty { text-align: center; padding: 40px; color: #888; }
+    .btn { display: inline-block; padding: 8px 16px; border-radius: 6px; font-size: 0.9em; text-decoration: none; cursor: pointer; border: none; }
+    .btn-primary { background: #2563eb; color: #fff; }
+    .btn-danger { background: #dc3545; color: #fff; }
+    .footer { padding: 20px; margin-top: auto; font-size: 0.8em; color: #666; border-top: 1px solid #2a2a4e; }
+    @media (max-width: 768px) {
+      .sidebar { width: 60px; } .sidebar-brand { display: none; } .nav-item { padding: 10px; text-align: center; font-size: 0.8em; }
+      .main { padding: 16px; }
+    }
+  </style>
+</head>
+<body>
+  <div class="layout">
+    <nav class="sidebar">
+      <div class="sidebar-brand">Flair</div>
+      ${navHtml}
+      <div class="footer">v${VERSION}</div>
+    </nav>
+    <main class="main">
+      ${content}
+    </main>
+  </div>
+</body>
+</html>`;
+}
+
+export function htmlResponse(html: string): Response {
+  return new Response(html, {
+    status: 200,
+    headers: { "content-type": "text/html; charset=utf-8" },
+  });
+}

--- a/resources/admin/layout.ts
+++ b/resources/admin/layout.ts
@@ -5,6 +5,17 @@
 
 const VERSION = process.env.npm_package_version ?? "dev";
 
+/** Escape HTML special characters to prevent stored XSS. */
+export function esc(str: string | undefined | null): string {
+  if (!str) return "";
+  return String(str)
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
 export function layout(title: string, content: string, activePage?: string): string {
   const nav = [
     { href: "/AdminDashboard", label: "Home", id: "home" },


### PR DESCRIPTION
## Summary

Server-rendered admin UI per FLAIR-WEB-ADMIN spec. Six pages, no JS frameworks — HTML + CSS, Nathan-grade UX.

## Pages

| Route | Description |
|---|---|
| `/AdminDashboard` | System overview — principal, memory, relationship, IdP counts |
| `/AdminPrincipals` | Principal list with kind/trust/status badges |
| `/AdminMemory` | Memory browser with text search + subject filter |
| `/AdminConnectors` | OAuth clients and registration source |
| `/AdminIdp` | Enterprise IdP configurations |
| `/AdminInstance` | Version, endpoints, key info |

## Design

- Shared layout with left sidebar navigation
- Responsive — collapses on mobile
- Consistent badge system (green/blue/yellow/gray)
- Empty states for all tables
- No external dependencies

## Test plan

- [x] 215/215 tests pass
- [x] Build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)