### PR TITLE
fix: OAuthToken conflicting paths crash on startup

### DIFF
--- a/schemas/oauth.graphql
+++ b/schemas/oauth.graphql
@@ -56,7 +56,7 @@ type IdJagReplay @table(database: "flair") {
 }
 
 # Access + refresh tokens.
-type OAuthToken @table(database: "flair") @export {
+type OAuthToken @table(database: "flair") {
   id: ID @primaryKey                # token ID (internal reference)
   tokenHash: String! @indexed       # SHA-256 of actual token — never store raw
   tokenType: String! @indexed       # "access" | "refresh"


### PR DESCRIPTION
## Summary
- Remove `@export` from `OAuthToken` GraphQL schema type
- The custom `OAuthToken` Resource class in `OAuth.ts` already handles the `/OAuthToken` endpoint
- Having both `@export` (auto-generated REST) and a custom Resource class on the same path causes Harper to crash with `ServerError: Conflicting paths for OAuthToken`

## Found via
Dogfooding — Flair on rockit was running a pre-merge process. On restart with the new code, Harper crashed immediately. This bug has existed since PR #209 (OAuth 2.1) was merged.

## Test plan
- [x] `bun test test/unit/` — all 203 tests pass
- [x] Manual: Harper starts cleanly, `/Health`, `/FederationInstance`, `/AdminDashboard` all respond