### PR TITLE
fix: auth middleware caching, OAuth bypass, README update

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,11 +64,35 @@ Not all memories are equal:
 | `standard` | ✅ Allowed | None | Working memory (default) |
 | `ephemeral` | ✅ Allowed | 24h | Scratch space, temp context |
 
+### Temporal Validity
+Memories can be time-bounded with `validFrom` and `validTo` fields. Expired memories are excluded from search and bootstrap automatically — no manual cleanup.
+
+### Relationship Graph
+Entity-to-entity triples with temporal bounds. Model structured knowledge — "Flint works-with Anvil since 2024-01-01" — queryable alongside semantic memory.
+
 ### Real-Time Feeds
 Subscribe to memory or soul changes via WebSocket/SSE. Useful for dashboards, cross-agent sync, or audit trails.
 
 ### Multi-Agent
 One Flair instance serves any number of agents. Each agent has its own keys, memories, and soul. Agents can't read each other's data without explicit access grants.
+
+### OAuth 2.1 Authorization Server
+Built-in OAuth 2.1 server with PKCE, dynamic client registration, and a standards-compliant token endpoint. Agents and services can delegate auth to Flair without a separate IdP.
+
+### XAA (Enterprise-Managed Authorization)
+IdP integration for Google Workspace, Azure AD, and Okta. Bind agent identities to enterprise accounts — access follows your org's user lifecycle.
+
+### Web Admin
+Server-rendered admin UI for managing principals, connectors, IdPs, and instance configuration. No separate dashboard service.
+
+### Federation
+Hub-and-spoke sync between Flair instances using signed requests and pairing tokens. Originator enforcement prevents replay across federated nodes. Share memories across offices without giving any node raw access.
+
+### Predictive Bootstrap
+Context-signal-aware preloading. Bootstrap reads active project context, recent activity, and agent role to select the most relevant memories — not just the most recent ones.
+
+### Auto Entity Detection
+Passive extraction of entities from memory content on write. Entities are indexed automatically — no tagging required. Feeds the relationship graph without agent intervention.
 
 ## Quick Start
 
@@ -299,7 +323,7 @@ Integration tests spin up a real Harper instance on a random port, run the test 
 
 ### Test Coverage
 
-**212 tests** across 19 test files, covering 7 CI checks on every commit.
+**203+ unit tests** across 19 test files, covering 7 CI checks on every commit.
 
 | Category | Tests | What's covered |
 |----------|-------|----------------|
@@ -329,6 +353,14 @@ Flair is in active development and daily use. We dogfood it — the agents that 
 - ✅ Real-time feeds (WebSocket/SSE)
 - ✅ Agent-scoped data isolation
 - ✅ Cold start bootstrap with adaptive time window
+- ✅ Predictive bootstrap (context-signal-aware preloading)
+- ✅ Temporal validity (`validFrom`/`validTo` on memories)
+- ✅ Relationship graph (entity-to-entity triples with temporal bounds)
+- ✅ Auto entity detection (passive extraction from memory content)
+- ✅ OAuth 2.1 authorization server (PKCE, dynamic client registration, token endpoint)
+- ✅ XAA enterprise authorization (Google Workspace, Azure AD, Okta)
+- ✅ Web admin UI (principals, connectors, IdPs, instance config)
+- ✅ Federation (hub-and-spoke sync with signed requests and pairing tokens)
 - ✅ OpenClaw memory plugin
 - ✅ MCP server for Claude Code / Cursor / Windsurf
 - ✅ Lightweight client library (`@tpsdev-ai/flair-client`)

--- a/resources/auth-middleware.ts
+++ b/resources/auth-middleware.ts
@@ -8,18 +8,16 @@ import { getEmbedding } from "./embeddings-provider.js";
 //
 // FLAIR_ADMIN_TOKEN env var is still accepted for backwards compat but
 // emits a deprecation warning on first use.
-let _adminPass: string | null = null;
+//
+// No permanent cache — env vars are read on every call. This is a no-op
+// performance-wise (env reads are fast) but means a process restart with a
+// different password works immediately without stale state.
 let _deprecationWarned = false;
 
-function getAdminPass(): string {
-  if (_adminPass) return _adminPass;
-
+function getAdminPass(): string | null {
   // Primary source: Harper's own admin password (set at startup via env)
   const primary = process.env.HDB_ADMIN_PASSWORD ?? process.env.FLAIR_ADMIN_PASSWORD;
-  if (primary) {
-    _adminPass = primary;
-    return _adminPass;
-  }
+  if (primary) return primary;
 
   // Backwards compat: FLAIR_ADMIN_TOKEN (deprecated — never write to disk)
   if (process.env.FLAIR_ADMIN_TOKEN) {
@@ -27,13 +25,11 @@ function getAdminPass(): string {
       console.warn("[auth] DEPRECATION: FLAIR_ADMIN_TOKEN is deprecated. Use HDB_ADMIN_PASSWORD instead.");
       _deprecationWarned = true;
     }
-    _adminPass = process.env.FLAIR_ADMIN_TOKEN;
-    return _adminPass;
+    return process.env.FLAIR_ADMIN_TOKEN;
   }
 
-  const msg = "[auth] FATAL: no admin password found. Set HDB_ADMIN_PASSWORD env var.";
-  console.error(msg);
-  throw new Error(msg);
+  // No admin password configured — return null and let callers fall through
+  return null;
 }
 
 const WINDOW_MS = 30_000;
@@ -147,7 +143,8 @@ server.http(async (request: any, nextLayer: any) => {
     try {
       const decoded = Buffer.from(header.slice(6), "base64").toString("utf-8");
       const [user, pass] = decoded.split(":");
-      if (user === "admin" && pass === getAdminPass()) {
+      const adminPass = getAdminPass();
+      if (adminPass !== null && user === "admin" && pass === adminPass) {
         // Mark as verified and set Harper user directly
         (request as any)._tpsAuthVerified = true;
         try {
@@ -209,12 +206,20 @@ server.http(async (request: any, nextLayer: any) => {
   // pipeline (passport) authenticates the request with full permissions including
   // HNSW vector search. This requires HDB_ADMIN_PASSWORD to be set.
   // NOTE: server.getUser() alone doesn't grant HNSW permissions in Harper v5.
-  try {
-    const superAuth = "Basic " + btoa("admin:" + getAdminPass());
-    request.headers.set("authorization", superAuth);
-    if (request.headers.asObject) request.headers.asObject.authorization = superAuth;
-  } catch {
-    // No admin password — try server.getUser as fallback (limited permissions)
+  const adminPass = getAdminPass();
+  if (adminPass !== null) {
+    try {
+      const superAuth = "Basic " + btoa("admin:" + adminPass);
+      request.headers.set("authorization", superAuth);
+      if (request.headers.asObject) request.headers.asObject.authorization = superAuth;
+    } catch {
+      // Header manipulation failed — fall back to getUser
+      try {
+        request.user = await (server as any).getUser("admin", null, request);
+      } catch {}
+    }
+  } else {
+    // No admin password configured — try server.getUser as fallback (limited permissions)
     try {
       request.user = await (server as any).getUser("admin", null, request);
     } catch {}

--- a/resources/auth-middleware.ts
+++ b/resources/auth-middleware.ts
@@ -128,7 +128,14 @@ server.http(async (request: any, nextLayer: any) => {
     url.pathname.startsWith("/AgentCard/") ||
     // Federation endpoints handle their own auth via Ed25519 body signatures
     url.pathname === "/FederationPair" ||
-    url.pathname === "/FederationSync"
+    url.pathname === "/FederationSync" ||
+    // OAuth 2.1 public endpoints (spec requires no pre-auth)
+    url.pathname === "/OAuthRegister" ||
+    url.pathname === "/OAuthAuthorize" ||
+    url.pathname === "/OAuthToken" ||
+    url.pathname === "/OAuthRevoke" ||
+    url.pathname === "/.well-known/oauth-authorization-server" ||
+    url.pathname === "/OAuthMetadata"
   ) return nextLayer(request);
 
   // Skip re-entry: if we already swapped auth to Basic, pass through


### PR DESCRIPTION
## Summary
- **Auth middleware**: remove permanent password cache, read env vars fresh each call. Return null instead of throwing when no admin password is configured.
- **OAuth auth bypass**: add OAuthRegister, OAuthAuthorize, OAuthToken, OAuthRevoke, OAuthMetadata, and .well-known endpoints to the middleware bypass list. OAuth 2.1 spec requires these to be publicly accessible.
- **README**: updated with 1.0 features (OAuth, XAA, federation, temporal validity, relationships, predictive bootstrap, auto entity detection). Updated test count to 203+.

## Found via
Dogfooding — OAuth client registration returned 401, admin password changes weren't picked up.

## Test plan
- [x] `bun test test/unit/` — 203 pass, 0 fail
- [ ] Manual: OAuthRegister accepts POST without auth
- [ ] Manual: admin password change takes effect immediately