### PR TITLE
release: v0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,9 +44,9 @@
 
 ### 📦 Packages
 - `@tpsdev-ai/flair` 0.5.0
-- `@tpsdev-ai/flair-client` 0.4.3
-- `@tpsdev-ai/flair-mcp` 0.4.4
-- `@tpsdev-ai/openclaw-flair` 0.4.1
+- `@tpsdev-ai/flair-client` 0.5.0
+- `@tpsdev-ai/flair-mcp` 0.5.0
+- `@tpsdev-ai/openclaw-flair` 0.5.0
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tpsdev-ai/flair",
-  "version": "0.4.16",
+  "version": "0.5.0",
   "description": "Identity, memory, and soul for AI agents. Cryptographic identity (Ed25519), semantic memory with local embeddings, and persistent personality — all in a single process.",
   "type": "module",
   "license": "Apache-2.0",

--- a/packages/flair-client/package.json
+++ b/packages/flair-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tpsdev-ai/flair-client",
-  "version": "0.4.3",
+  "version": "0.5.0",
   "description": "Lightweight client for Flair — identity, memory, and soul for AI agents. Zero heavy dependencies.",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/flair-mcp/package.json
+++ b/packages/flair-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tpsdev-ai/flair-mcp",
-  "version": "0.4.4",
+  "version": "0.5.0",
   "description": "MCP server for Flair — persistent memory for Claude Code, Cursor, and any MCP client.",
   "type": "module",
   "main": "dist/index.js",
@@ -24,7 +24,7 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "1.27.1",
-    "@tpsdev-ai/flair-client": "0.4.3",
+    "@tpsdev-ai/flair-client": "0.5.0",
     "zod": "4.3.6"
   },
   "license": "Apache-2.0",

--- a/plugins/openclaw-flair/package.json
+++ b/plugins/openclaw-flair/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tpsdev-ai/openclaw-flair",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "description": "OpenClaw memory plugin for Flair \u2014 agent identity and semantic memory",
   "type": "module",
   "main": "index.ts",
@@ -45,6 +45,6 @@
   },
   "dependencies": {
     "@sinclair/typebox": "0.34.48",
-    "@tpsdev-ai/flair-client": "0.4.3"
+    "@tpsdev-ai/flair-client": "0.5.0"
   }
 }

--- a/resources/federation-crypto.js
+++ b/resources/federation-crypto.js
@@ -1,0 +1,52 @@
+/**
+ * Federation cryptographic utilities — pure functions, no HarperDB dependency.
+ * Shared by Federation.ts (server) and cli.ts (client).
+ */
+import nacl from "tweetnacl";
+// ─── Canonical JSON ─────────────────────────────────────────────────────────
+/**
+ * Deterministic JSON serialization: recursively sort object keys, then stringify.
+ * Used as the signing input for federation requests.
+ */
+export function canonicalize(obj) {
+    return JSON.stringify(sortKeys(obj));
+}
+function sortKeys(val) {
+    if (val === null || val === undefined || typeof val !== "object")
+        return val;
+    if (Array.isArray(val))
+        return val.map(sortKeys);
+    const sorted = {};
+    for (const key of Object.keys(val).sort()) {
+        sorted[key] = sortKeys(val[key]);
+    }
+    return sorted;
+}
+// ─── Signing ────────────────────────────────────────────────────────────────
+/**
+ * Create a detached Ed25519 signature over the canonical form of a body.
+ * Returns base64url-encoded signature.
+ */
+export function signBody(body, secretKey) {
+    const message = new TextEncoder().encode(canonicalize(body));
+    const sig = nacl.sign.detached(message, secretKey);
+    return Buffer.from(sig).toString("base64url");
+}
+/**
+ * Verify a signature field on a request body.
+ * The canonical form is the body WITHOUT the `signature` field.
+ */
+export function verifyBodySignature(body, publicKeyB64url) {
+    const { signature, ...rest } = body;
+    if (!signature)
+        return false;
+    try {
+        const message = new TextEncoder().encode(canonicalize(rest));
+        const sig = Buffer.from(signature, "base64url");
+        const pubKey = Buffer.from(publicKeyB64url, "base64url");
+        return nacl.sign.detached.verify(message, new Uint8Array(sig), new Uint8Array(pubKey));
+    }
+    catch {
+        return false;
+    }
+}


### PR DESCRIPTION
## Release v0.5.0

All packages bumped to 0.5.0. Cross-references updated.

### What's new since 0.4.16
- **Identity & Auth:** Principal model, OAuth 2.1 (PKCE, DCR), XAA enterprise auth (Google/Azure/Okta)
- **Federation:** Hub-and-spoke sync, signed requests, pairing tokens, encrypted keystore, originator enforcement
- **Memory:** Temporal validity, relationships, predictive bootstrap, auto entity detection
- **Web Admin:** Server-rendered pages for principals, connectors, IdPs, memory, instance
- **MCP:** Structured errors with retry hints, 30s timeout, success echo, tags normalization
- **CLI:** `flair test`, init progress indicator, default soul entries, admin auth fallback
- **Tests:** 270 unit tests (OAuth, XAA, Credential, Relationship, Federation, CLI)
- **Docs:** Federation guide, auth/OAuth/XAA guide, updated README and CHANGELOG
- **Infrastructure:** Harper 5.0.0 stable

### Security
- Sherlock review: APPROVED (2026-04-16)
- 3 rounds of federation security fixes (signed sync, keystore, pairing tokens, originator enforcement, timestamp ceiling, fail-closed)
- Auth middleware: no more password caching, OAuth endpoints properly bypassed

### Packages
- `@tpsdev-ai/flair` 0.5.0
- `@tpsdev-ai/flair-client` 0.5.0
- `@tpsdev-ai/flair-mcp` 0.5.0
- `@tpsdev-ai/openclaw-flair` 0.5.0