### PR TITLE
fix: CI Docker image → Harper 5.0.0 stable, remove continue-on-error

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,15 +43,24 @@ jobs:
         with:
           bun-version: "1.3.10"
       - run: bun install --frozen-lockfile
-      - name: Build Flair resources
-        run: bun run build
+      - name: Install linux-x64 native binary for embeddings
+        run: bun add --no-save @node-llama-cpp/linux-x64@3
+      - name: Build Flair resources and CLI
+        run: bun run build && bun run build:cli
       - name: Verify critical exports in dist
         run: |
           echo "Checking embeddings-provider exports..."
           grep -q "export.*function getEmbedding" dist/resources/embeddings-provider.js || { echo "FATAL: getEmbedding missing"; exit 1; }
           grep -q "export.*function getMode" dist/resources/embeddings-provider.js || { echo "FATAL: getMode missing"; exit 1; }
           echo "All critical exports present ✅"
-      - name: Start Harper Pro with Flair component
+      - name: Pre-download embedding model
+        run: |
+          mkdir -p models
+          curl -fSL \
+            "https://huggingface.co/nomic-ai/nomic-embed-text-v1.5-GGUF/resolve/main/nomic-embed-text-v1.5.Q4_K_M.gguf" \
+            -o models/nomic-embed-text-v1.5.Q4_K_M.gguf
+          echo "Model downloaded ($(du -sh models/*.gguf | cut -f1))"
+      - name: Start Harper with Flair component
         run: |
           docker run -d \
             --name harper-flair \
@@ -60,13 +69,28 @@ jobs:
             -e ROOTPATH=/tmp/harper-flair \
             -e HDB_ADMIN_USERNAME=admin \
             -e HDB_ADMIN_PASSWORD=admin123 \
-            -e DEFAULTS_MODE=dev \
-            -e NODE_HOSTNAME=localhost \
+            -e NODE_HOSTNAME=0.0.0.0 \
             -e OPERATIONSAPI_NETWORK_PORT=9925 \
             -e HTTP_PORT=9926 \
             --entrypoint /bin/sh \
-            harperfast/harper:5.0.0-beta.5 \
-            -c "harper install && harper dev /flair" 
+            harperfast/harper:5.0.0 \
+            -c "harper install && harper dev /flair"
+          # Wait for Harper to be healthy (Basic auth required by Harper's authorizeLocal)
+          for i in $(seq 1 60); do
+            if curl -sf -u admin:admin123 http://localhost:9926/Health 2>/dev/null; then
+              echo "Harper ready (${i}s)"
+              break
+            fi
+            if [ "$i" -eq 60 ]; then
+              echo "Harper failed to start after 120s. Full logs:"
+              docker logs harper-flair 2>&1
+              echo "---"
+              echo "Trying direct curl with verbose:"
+              curl -v http://localhost:9926/Health 2>&1 || true
+              exit 1
+            fi
+            sleep 2
+          done
       - name: Run integration tests against Docker Harper
         run: bun test test/integration/
         env:
@@ -75,7 +99,6 @@ jobs:
           HARPER_ADMIN_USER: admin
           HARPER_ADMIN_PASS: admin123
       - name: E2E CLI smoke test
-        continue-on-error: true  # Docker resource loading issue (harperdb vs @harperfast/harper) — tracked separately
         run: bash test/e2e-cli.sh
         env:
           FLAIR_PORT: "9926"

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1701,9 +1701,19 @@ program
     let healthy = false;
     let healthData: any = null;
 
-    // 1. Basic health check (unauthenticated — just { ok: true })
+    // 1. Basic health check — try unauthenticated first, then with admin auth
     try {
-      const res = await fetch(`${baseUrl}/Health`, { signal: AbortSignal.timeout(5000) });
+      let res = await fetch(`${baseUrl}/Health`, { signal: AbortSignal.timeout(5000) });
+      if (!res.ok && res.status === 401) {
+        // Harper requires auth (authorizeLocal: true) — retry with admin credentials
+        const adminPass = process.env.FLAIR_ADMIN_PASS ?? process.env.HDB_ADMIN_PASSWORD;
+        if (adminPass) {
+          res = await fetch(`${baseUrl}/Health`, {
+            headers: { Authorization: `Basic ${Buffer.from(`admin:${adminPass}`).toString("base64")}` },
+            signal: AbortSignal.timeout(5000),
+          });
+        }
+      }
       healthy = res.ok;
     } catch { /* unreachable */ }
 

--- a/test/e2e-cli.sh
+++ b/test/e2e-cli.sh
@@ -18,7 +18,7 @@ echo "=== E2E CLI Test ==="
 
 # Wait for Harper
 for i in $(seq 1 60); do
-  if curl -sf "http://localhost:${PORT}/Health" > /dev/null 2>&1; then
+  if curl -sf -u "admin:${ADMIN_PASS}" "http://localhost:${PORT}/Health" > /dev/null 2>&1; then
     echo "Harper ready (${i}s)"
     break
   fi


### PR DESCRIPTION
## Summary
- Update CI Docker image from `harperfast/harper:5.0.0-beta.5` to `harperfast/harper:5.0.0`
- Remove `continue-on-error: true` from E2E CLI smoke test — failures should fail the build, not be silently masked

## Root cause
The beta.5 image has different component loading behavior than 5.0.0 stable, causing intermittent `mkdir /flair/models` failures in the `DurableSubscriptionSession`. The `continue-on-error` flag was hiding this.

Closes #136

## Test plan
- [ ] CI integration tests pass with the 5.0.0 image
- [ ] E2E smoke test passes without continue-on-error