### PR TITLE
release: v0.5.2 — scoped-search P0 fix + _reindex security gate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## 0.5.2 (2026-04-16)
+
+### 🐛 Bug Fixes
+- **Agent-scoped memory search (P0):** scoped `Memory.search` and `SemanticSearch` returned 0 rows for authenticated agents despite data existing and the `agentId` index being healthy. Root cause is in Harper's `txnForContext` chain: when a request reads two tables sequentially, the first generator leaves its transaction CLOSED and the second inherits that state. Workaround applied at the Memory call sites via a `withDetachedTxn` helper that detaches the context for the inner call. Will file upstream with a minimal repro. (#229)
+
+### 🔒 Security
+- **`Memory.put` `_reindex` escape hatch gated on admin:** the `_reindex=true` flag used by `MemoryReindex` was reachable by any authenticated agent on a raw PUT, bypassing content-safety scan, embedding regeneration, and `updatedAt` tracking. Now mirrors the admin-check pattern from `Memory.delete`. (#229)
+
+### 🛠 Internal
+- **`MemoryReindex` admin endpoint:** dormant repair tool to re-PUT records when Harper's secondary-index backfill is incomplete. Unused today (index was healthy in the reported regression) but kept for future recovery. (#229)
+
+---
+
 ## 0.5.1 (2026-04-16)
 
 ### 🐛 Bug Fixes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tpsdev-ai/flair",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "Identity, memory, and soul for AI agents. Cryptographic identity (Ed25519), semantic memory with local embeddings, and persistent personality — all in a single process.",
   "type": "module",
   "license": "Apache-2.0",


### PR DESCRIPTION
## Summary
- Bumps root package to **0.5.2**
- Ships #229: scoped Memory/SemanticSearch P0 regression fix
- Ships #229: `_reindex` admin gate (Sherlock critical finding resolved before merge)

## CHANGELOG
See \`CHANGELOG.md\` — three entries under 0.5.2:
- **Bug Fixes:** agent-scoped search 0-row regression
- **Security:** `_reindex` escape hatch gated on admin
- **Internal:** dormant MemoryReindex repair tool kept for future index gaps

## Test plan
- [x] #229 merged green (all 8 checks passed)
- [x] Scoped flint list + semantic search verified 149/149 records
- [x] Sherlock approved re-review after admin gate added
- [ ] Kern arch sign-off on the release PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)