### PR TITLE
build: clean dist/ on prebuild to drop orphan compiled artifacts

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,8 @@
     "SECURITY.md"
   ],
   "scripts": {
+    "clean": "node -e \"require('fs').rmSync('dist',{recursive:true,force:true})\"",
+    "prebuild": "npm run clean",
     "build": "tsc -p tsconfig.json --noCheck",
     "build:cli": "tsc -p tsconfig.cli.json --noCheck",
     "prepublishOnly": "npm run build && npm run build:cli",


### PR DESCRIPTION
## Summary
- Adds \`clean\` + \`prebuild\` scripts that wipe \`dist/\` before every \`npm run build\`
- Uses a node \`fs.rmSync\` one-liner so no new devDep is needed
- tsc leaves orphan .js for removed .ts; those .js files ship in the tarball and serve HTTP traffic when Harper registers them as resources

## Why
Found during ops-dcp investigation. \`dist/resources/\` held:
- DebugSearch.js
- DistillTribalKnowledge.js
- embeddings.js

…none of which had a corresponding .ts source. e.g. commit \`936d94f\` removed DebugSearch from source months ago but the compiled .js has been in the tarball ever since, registered by Harper's jsResource plugin.

## Risk
- Dev workflow change: \`npm run build\` alone now wipes \`dist/cli.js\` (emitted only by \`build:cli\`). Fix: run \`npm run build && npm run build:cli\` when you want both (already the canonical sequence in \`prepublishOnly\`).
- No functional change; purely build hygiene.

## Test plan
- [x] \`npm run build\` succeeds and dist is clean of the 3 orphans
- [x] \`npm run build:cli\` still emits dist/cli.js
- [x] Unit tests pass (data-scoping, content-safety)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)