### PR TITLE
fix(cli): inline federation-crypto to fix ERR_MODULE_NOT_FOUND (v0.5.3)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -111,6 +111,27 @@ jobs:
           FLAIR_URL: http://localhost:9926
           FLAIR_ADMIN_PASS: admin123
 
+  pack-smoke:
+    name: Install-from-tarball smoke
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - uses: oven-sh/setup-bun@735343b667d3e6f658f44d0eca948eb6282f2b76 # v2
+        with:
+          bun-version: "1.3.10"
+      - run: bun install --frozen-lockfile
+      - run: bun run build && bun run build:cli
+      - name: Pack and install into clean project
+        run: |
+          npm pack
+          TGZ=$(ls tpsdev-ai-flair-*.tgz)
+          TMPDIR=$(mktemp -d)
+          cp "$TGZ" "$TMPDIR/"
+          cd "$TMPDIR"
+          npm init -y > /dev/null
+          npm install "./$TGZ"
+          node ./node_modules/@tpsdev-ai/flair/dist/cli.js --version
+
   typecheck:
     name: Type Check
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.5.3 (2026-04-17)
+
+### 🐛 Bug Fixes
+- **CLI packaging (P0):** `flair` CLI threw `ERR_MODULE_NOT_FOUND` on any installed version >= 0.5.0 because `dist/cli.js` imported `../resources/federation-crypto.js`, which resolved to `<pkg>/resources/…` at install time — a path outside the published `files` manifest. Inlined the two tiny pure-fn helpers (`canonicalize`, `signBody`) directly into `src/cli.ts` so there are no cross-boundary imports from `src/` into `resources/`. Added a CI job that packs the tarball, installs it into a clean project, and runs `flair --version` so this can't silently re-break.
+
+---
+
 ## 0.5.2 (2026-04-16)
 
 ### 🐛 Bug Fixes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tpsdev-ai/flair",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "description": "Identity, memory, and soul for AI agents. Cryptographic identity (Ed25519), semantic memory with local embeddings, and persistent personality — all in a single process.",
   "type": "module",
   "license": "Apache-2.0",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -14,7 +14,27 @@ import { join, resolve as resolvePath } from "node:path";
 import { spawn } from "node:child_process";
 import { createPrivateKey, sign as nodeCryptoSign, randomUUID } from "node:crypto";
 import { keystore } from "./keystore.js";
-import { canonicalize, signBody } from "../resources/federation-crypto.js";
+
+// Federation crypto helpers — inlined to avoid cross-boundary imports from
+// src/ into resources/, which don't survive npm packaging (see also
+// resources/federation-crypto.ts; the two must stay in sync).
+function sortKeys(val: unknown): unknown {
+  if (val === null || val === undefined || typeof val !== "object") return val;
+  if (Array.isArray(val)) return val.map(sortKeys);
+  const sorted: Record<string, unknown> = {};
+  for (const key of Object.keys(val as Record<string, unknown>).sort()) {
+    sorted[key] = sortKeys((val as Record<string, unknown>)[key]);
+  }
+  return sorted;
+}
+function canonicalize(obj: unknown): string {
+  return JSON.stringify(sortKeys(obj));
+}
+function signBody(body: Record<string, any>, secretKey: Uint8Array): string {
+  const message = new TextEncoder().encode(canonicalize(body));
+  const sig = nacl.sign.detached(message, secretKey);
+  return Buffer.from(sig).toString("base64url");
+}
 
 // ─── Defaults ────────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary
- **P0 fix:** v0.5.0–v0.5.2 shipped a CLI that threw `ERR_MODULE_NOT_FOUND ... resources/federation-crypto.js` on any clean install. `src/cli.ts` imported `../resources/federation-crypto.js`, which compiles to a literal `../resources/…` path in `dist/cli.js` → resolves to `<pkg>/resources/federation-crypto.js` at install time, outside the published `files` manifest.
- Inlined `canonicalize` + `signBody` (~25 LoC of pure crypto helpers, no Harper deps) directly into `src/cli.ts`. No more cross-boundary imports from `src/` into `resources/`.
- Added a `pack-smoke` CI job that packs the tarball, installs it into a clean project, and runs `flair --version` — so this class of bug can't silently re-break release.
- Bumped to 0.5.3 with CHANGELOG entry.

## Reproduced & Verified
Nathan hit this dogfooding v0.5.2:
```
Error [ERR_MODULE_NOT_FOUND]: Cannot find module '…/@tpsdev-ai/flair/resources/federation-crypto.js'
  imported from …/@tpsdev-ai/flair/dist/cli.js
```

Local repro + verification:
```
npm pack
cd /tmp/flair-install-smoke && npm install ./tpsdev-ai-flair-0.5.3.tgz
node ./node_modules/@tpsdev-ai/flair/dist/cli.js --version
# → 0.5.3  ✅
```

## Test plan
- [x] Unit tests pass (270/270)
- [x] `tsc --noEmit` clean
- [x] Local pack + install + run succeeds
- [ ] CI `pack-smoke` job green
- [ ] Full CI suite green

🤖 Generated with [Claude Code](https://claude.com/claude-code)