### PR TITLE
fix(cli): close flair restart race so ✅ means reachable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.5.4 (2026-04-17)
+
+### 🐛 Bug Fixes
+- **`flair restart` race (macOS launchd):** `flair restart` printed `✅ Flair restarted` before Harper was actually reachable, so an immediately following `flair status` could report `🔴 unreachable` for a brief window. Two bugs: (1) `waitForHealth` accepted *any* HTTP response (`res.status > 0` is always true), so it returned success against the still-shutting-down old process, and (2) on the launchd path we never confirmed the old process exited before polling, letting us race past the shutdown→KeepAlive→respawn gap. Now we read `hdb.pid` before `launchctl stop`, wait for that PID to actually exit, then poll `/Health` for 2xx (or 401 — server up, auth issue). Also aligned the health path on `/Health` (capital H) to match `flair status`.
+
+---
+
 ## 0.5.3 (2026-04-17)
 
 ### 🐛 Bug Fixes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tpsdev-ai/flair",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "description": "Identity, memory, and soul for AI agents. Cryptographic identity (Ed25519), semantic memory with local embeddings, and persistent personality — all in a single process.",
   "type": "module",
   "license": "Apache-2.0",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -268,7 +268,7 @@ async function authFetch(
 }
 
 async function waitForHealth(httpPort: number, adminUser: string, adminPass: string, timeoutMs: number): Promise<void> {
-  const url = `http://127.0.0.1:${httpPort}/health`;
+  const url = `http://127.0.0.1:${httpPort}/Health`;
   const deadline = Date.now() + timeoutMs;
   let attempt = 0;
   while (Date.now() < deadline) {
@@ -278,11 +278,37 @@ async function waitForHealth(httpPort: number, adminUser: string, adminPass: str
         headers: { Authorization: `Basic ${Buffer.from(`${adminUser}:${adminPass}`).toString("base64")}` },
         signal: AbortSignal.timeout(2000),
       });
-      if (res.status > 0) return;
+      // 2xx = healthy; 401 = Harper up but credentials wrong — still "reachable"
+      // enough for restart success. Anything else (5xx, 502 during shutdown) keeps polling.
+      if (res.ok || res.status === 401) return;
     } catch { /* not ready yet */ }
     await new Promise((r) => setTimeout(r, HEALTH_POLL_INTERVAL_MS));
   }
   throw new Error(`Harper at port ${httpPort} did not respond within ${timeoutMs}ms (${attempt} attempts)`);
+}
+
+// Blocks until the given PID is gone (ESRCH from signal 0), or timeout.
+// Used during restart to confirm the old Harper process actually exited before
+// we start polling /Health — otherwise the still-shutting-down old process can
+// answer and we'd declare restart success while a gap is still ahead.
+async function waitForProcessExit(pid: number, timeoutMs: number): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    try { process.kill(pid, 0); } catch { return; }
+    await new Promise((r) => setTimeout(r, HEALTH_POLL_INTERVAL_MS));
+  }
+  throw new Error(`Process ${pid} did not exit within ${timeoutMs}ms`);
+}
+
+function readHarperPid(dataDir: string): number | null {
+  const pidFile = join(dataDir, "hdb.pid");
+  if (!existsSync(pidFile)) return null;
+  try {
+    const n = Number(readFileSync(pidFile, "utf-8").trim());
+    return Number.isInteger(n) && n > 0 ? n : null;
+  } catch {
+    return null;
+  }
 }
 
 async function seedAgentViaOpsApi(
@@ -2287,8 +2313,12 @@ program
           const { execSync } = await import("node:child_process");
           // Ensure the service is loaded (init writes the plist but doesn't load it)
           try { execSync(`launchctl load "${plistPath}"`, { stdio: "pipe" }); } catch {}
-          // Stop the service — KeepAlive=true in the plist auto-restarts it
+          // Capture the current PID *before* stopping so we can verify exit. Without
+          // this, waitForHealth can race against the still-shutting-down old process
+          // and return success before KeepAlive brings the new one up.
+          const oldPid = readHarperPid(defaultDataDir());
           try { execSync(`launchctl stop ${label}`, { stdio: "pipe" }); } catch {}
+          if (oldPid) await waitForProcessExit(oldPid, STARTUP_TIMEOUT_MS);
           await waitForHealth(port, DEFAULT_ADMIN_USER, process.env.HDB_ADMIN_PASSWORD ?? "", STARTUP_TIMEOUT_MS);
           console.log("✅ Flair restarted");
           return;


### PR DESCRIPTION
## Summary

- Nathan hit this during 0.5.3 dogfooding: `flair restart` prints `✅ Flair restarted`, but an immediately following `flair status` can briefly show `🔴 unreachable`.
- Two root causes on the macOS launchd path:
  1. `waitForHealth` treated `res.status > 0` as healthy — always true for any HTTP response, including 5xx from the shutting-down old Harper process. So we'd race past the shutdown → KeepAlive → respawn gap and return success while a gap was still ahead.
  2. We never confirmed the old process actually exited before polling — `launchctl stop` is fire-and-forget, so we could see the old process's health endpoint and bail out thinking the restart was done.
- Fix: capture the Harper PID from `hdb.pid` before `launchctl stop`, wait for that specific PID to exit (via `process.kill(pid, 0)` probe), then poll `/Health` requiring 2xx or 401 (auth rejected still = server up). Also aligned the probe path on `/Health` (capital H) to match `flair status`.
- Port-based restart path (Linux / macOS fallback) untouched — it already does an explicit SIGTERM + wait before spawning, so it doesn't have this race.

## Test plan

- [x] `bun run build:cli` — clean
- [x] `bunx tsc --noEmit -p tsconfig.check.json` — clean
- [x] `bun test test/unit/` — 270 pass
- [ ] Manual: `flair restart && flair status` back-to-back on macOS should not show `unreachable`
- [ ] CI: pack-smoke, integration, Semgrep, CodeQL

Requesting K&S review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)