### PR TITLE
ci(pack-smoke): extend to daemon lifecycle round-trip

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -114,6 +114,7 @@ jobs:
   pack-smoke:
     name: Install-from-tarball smoke
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - uses: oven-sh/setup-bun@735343b667d3e6f658f44d0eca948eb6282f2b76 # v2
@@ -121,16 +122,51 @@ jobs:
           bun-version: "1.3.10"
       - run: bun install --frozen-lockfile
       - run: bun run build && bun run build:cli
-      - name: Pack and install into clean project
+      - name: Pack
+        id: pack
         run: |
           npm pack
-          TGZ=$(ls tpsdev-ai-flair-*.tgz)
+          echo "TGZ_PATH=$(pwd)/$(ls tpsdev-ai-flair-*.tgz)" >> $GITHUB_OUTPUT
+      - name: Install-from-tarball + daemon lifecycle round-trip
+        run: |
+          set -euo pipefail
           TMPDIR=$(mktemp -d)
-          cp "$TGZ" "$TMPDIR/"
           cd "$TMPDIR"
           npm init -y > /dev/null
-          npm install "./$TGZ"
-          node ./node_modules/@tpsdev-ai/flair/dist/cli.js --version
+          npm install "${{ steps.pack.outputs.TGZ_PATH }}"
+          # Native embedding binary — flair declares mac-arm64 as optional; on linux
+          # CI we install the matching variant so Harper's embeddings component can
+          # resolve it when started by `flair init`.
+          npm install --no-save @node-llama-cpp/linux-x64@3
+
+          FLAIR="node $(pwd)/node_modules/@tpsdev-ai/flair/dist/cli.js"
+          PORT=19999
+          export FLAIR_ADMIN_PASS=pack-smoke-admin
+
+          # Packaging guard (0.5.3 regression): tarball can execute end-to-end
+          $FLAIR --version
+
+          # Full init: installs Harper + downloads embedding model + starts daemon
+          # + generates Ed25519 keypair + seeds agent record via ops API
+          $FLAIR init --agent-id smoke --port $PORT --admin-pass "$FLAIR_ADMIN_PASS" --skip-soul
+
+          # Post-init status sanity
+          STATUS=$($FLAIR status --port $PORT); echo "$STATUS"
+          echo "$STATUS" | grep -q "running" || { echo "FAIL: not running after init"; exit 1; }
+
+          # Restart race guard (0.5.4 regression): `flair restart` must block until
+          # Harper is actually reachable, so an immediately following `flair status`
+          # must not report unreachable.
+          $FLAIR restart --port $PORT
+          STATUS=$($FLAIR status --port $PORT); echo "$STATUS"
+          if echo "$STATUS" | grep -q "unreachable"; then
+            echo "FAIL: unreachable immediately after restart (0.5.4 regression)"
+            exit 1
+          fi
+          echo "$STATUS" | grep -q "running" || { echo "FAIL: not running after restart"; exit 1; }
+
+          # Tear down
+          $FLAIR stop --port $PORT || true
 
   typecheck:
     name: Type Check

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -120,6 +120,12 @@ jobs:
       - uses: oven-sh/setup-bun@735343b667d3e6f658f44d0eca948eb6282f2b76 # v2
         with:
           bun-version: "1.3.10"
+      # Node 22+ is required by flair's engines; ubuntu-latest ships Node 20.
+      # The CLI spawns Harper via process.execPath, so we need real node (not
+      # bun) on PATH for that to resolve correctly.
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: "22"
       - run: bun install --frozen-lockfile
       - run: bun run build && bun run build:cli
       - name: Pack


### PR DESCRIPTION
## Summary

Coverage plan `bd ops-dks` item #1. The last two P0 hotfixes (0.5.3 import, 0.5.4 restart race) both shipped because `pack-smoke` only ran `flair --version` against the installed tarball — barely touched the package surface.

Extends the job to a full lifecycle round-trip:
```
flair init → flair status → flair restart → flair status → flair stop
```

Regression guards:
- **0.5.3 (packaging):** any cross-boundary import break in `dist/` fails during `flair init` (which exercises most of the module graph)
- **0.5.4 (restart race):** explicit assertion that `flair status` does NOT print `unreachable` immediately after `flair restart`

Installs `@node-llama-cpp/linux-x64` into the test project so Harper's embeddings component resolves at runtime — mirrors the existing `integration-tests` job. Timeout bumped to 15min to absorb the Harper install + embedding model download.

## Test plan

- [x] YAML parses
- [ ] CI: the new pack-smoke should run `init → restart → status` and pass
- [ ] Sanity: verify the timeout is sufficient (Harper install + ~80MB model download on ubuntu-latest)

Requesting K&S review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)