### PR TITLE
ci: import-surface guard for packaging regressions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -128,6 +128,8 @@ jobs:
           node-version: "22"
       - run: bun install --frozen-lockfile
       - run: bun run build && bun run build:cli
+      - name: Verify dist/ modules import cleanly (dev surface)
+        run: node scripts/check-imports.mjs dist
       - name: Pack
         id: pack
         run: |
@@ -144,6 +146,11 @@ jobs:
           # CI we install the matching variant so Harper's embeddings component can
           # resolve it when started by `flair init`.
           npm install --no-save @node-llama-cpp/linux-x64@3
+
+          # Packaging surface guard (0.5.3 regression): every *.js in the INSTALLED
+          # tarball must import without ERR_MODULE_NOT_FOUND. Catches files-manifest
+          # gaps and cross-boundary imports that don't survive `npm pack`.
+          node "$GITHUB_WORKSPACE/scripts/check-imports.mjs" node_modules/@tpsdev-ai/flair/dist
 
           FLAIR="node $(pwd)/node_modules/@tpsdev-ai/flair/dist/cli.js"
           PORT=19999

--- a/scripts/check-imports.mjs
+++ b/scripts/check-imports.mjs
@@ -1,0 +1,61 @@
+#!/usr/bin/env node
+// Walk a dist directory and verify every *.js file can be dynamically imported
+// without ERR_MODULE_NOT_FOUND. Run per file in a subprocess so CLI entrypoints
+// (which execute `program.parse()` at top level) don't pollute or terminate
+// this runner.
+//
+// Intended use in CI: run against the INSTALLED tarball's dist/ so relative
+// imports that don't survive the npm `files` manifest fail fast. The 0.5.3
+// hotfix existed because dist/cli.js imported ../resources/federation-crypto.js
+// and `resources/` wasn't in the published tarball — this check would have
+// caught it before publish.
+import { readdirSync, statSync } from "node:fs";
+import { execFileSync } from "node:child_process";
+import { join, resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+
+function walk(dir) {
+  const out = [];
+  for (const name of readdirSync(dir)) {
+    const full = join(dir, name);
+    if (statSync(full).isDirectory()) out.push(...walk(full));
+    else if (name.endsWith(".js")) out.push(full);
+  }
+  return out;
+}
+
+const target = resolve(process.argv[2] ?? "dist");
+const files = walk(target);
+if (files.length === 0) {
+  console.error(`No .js files under ${target}`);
+  process.exit(1);
+}
+
+let failed = 0;
+for (const f of files) {
+  const url = pathToFileURL(f).href;
+  try {
+    execFileSync(
+      process.execPath,
+      ["--input-type=module", "-e", `await import(${JSON.stringify(url)})`],
+      { stdio: "pipe", timeout: 15_000 },
+    );
+  } catch (err) {
+    const stderr = (err.stderr ?? Buffer.alloc(0)).toString();
+    // We only fail on module-resolution errors. Any runtime behavior (including
+    // clean exits or unrelated errors from top-level code) is out of scope for
+    // this check.
+    if (
+      stderr.includes("ERR_MODULE_NOT_FOUND") ||
+      stderr.includes("Cannot find module") ||
+      stderr.includes("ERR_PACKAGE_PATH_NOT_EXPORTED")
+    ) {
+      console.error(`FAIL: ${f}`);
+      console.error(stderr.trim().split("\n").slice(0, 10).map(l => `  ${l}`).join("\n"));
+      failed++;
+    }
+  }
+}
+
+console.log(`${files.length} file(s) checked, ${failed} import failure(s)`);
+process.exit(failed > 0 ? 1 : 0);


### PR DESCRIPTION
## Summary

Coverage plan `bd ops-dks` item #2. Cheap static guard that would have caught the 0.5.3 hotfix shape.

Adds `scripts/check-imports.mjs` — walks a dist/ dir and dynamically imports every `.js` file in an isolated subprocess. Any `ERR_MODULE_NOT_FOUND` or package-export resolution error fails the check. Runtime errors or clean exits from module top-level code are ignored (we only care about the module graph, not behavior).

Wired into `pack-smoke` at two points:
1. **Against the source `dist/`** right after build — catches broken imports before pack, fastest local signal
2. **Against the installed tarball's `dist/`** after `npm install` — what users actually get, catches `files` manifest gaps

Verified locally:
- Clean pass on current source (46 files, 0 failures)
- Clean pass on installed tarball (46 files, 0 failures)
- Correctly fails on synthetic broken import (`1 import failure(s)`)

The 0.5.3 bug was `dist/cli.js` importing `../resources/federation-crypto.js` where `resources/` wasn't in the published tarball. Step 2 above would have caught that exactly.

## Test plan

- [x] YAML parses
- [x] Local: clean pass on dist/ and on installed tarball
- [x] Local: correctly fails on synthetic broken import
- [ ] CI: both new steps should pass on this branch

Requesting K&S review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)