### PR TITLE
fix(cli): MemoryGrant field-name mismatch broke cross-agent sharing

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1407,8 +1407,8 @@ program
       table: "MemoryGrant",
       records: [{
         id: grantId,
-        fromAgentId: fromAgent,
-        toAgentId: toAgent,
+        ownerId: fromAgent,
+        granteeId: toAgent,
         scope,
         createdAt: new Date().toISOString(),
       }],

--- a/test/agent-remove-and-grants.test.ts
+++ b/test/agent-remove-and-grants.test.ts
@@ -138,7 +138,7 @@ async function runGrant(opts: {
       operation: "insert",
       database: "flair",
       table: "MemoryGrant",
-      records: [{ id: grantId, fromAgentId: fromAgent, toAgentId: toAgent, scope, createdAt: new Date().toISOString() }],
+      records: [{ id: grantId, ownerId: fromAgent, granteeId: toAgent, scope, createdAt: new Date().toISOString() }],
     }),
     signal: AbortSignal.timeout(5000),
   });
@@ -347,8 +347,8 @@ describe("flair grant", () => {
     expect(req.body.operation).toBe("insert");
     expect(req.body.table).toBe("MemoryGrant");
     expect(req.body.records[0].id).toBe("flint:kern");
-    expect(req.body.records[0].fromAgentId).toBe("flint");
-    expect(req.body.records[0].toAgentId).toBe("kern");
+    expect(req.body.records[0].ownerId).toBe("flint");
+    expect(req.body.records[0].granteeId).toBe("kern");
     expect(req.body.records[0].scope).toBe("read");
   });
 

--- a/test/integration/agent-journey.test.ts
+++ b/test/integration/agent-journey.test.ts
@@ -231,6 +231,66 @@ describe("Authenticated agent journey", () => {
     expect(leaked.length).toBe(0);
   }, 30_000);
 
+  test("MemoryGrant: alice grants bob scope=search → bob sees alice's 50 rows", async () => {
+    // Positive-case complement to the isolation checks above. With the 0.5.5
+    // tightening, bob cannot spoof agentId in the body — so grants are the
+    // only supported cross-agent path. This test validates that the grant
+    // expansion in SemanticSearch (conditions: granteeId == auth'd agent →
+    // add grant.ownerId to searchAgentIds) actually fires end-to-end.
+    //
+    // Also pins the MemoryGrant schema field names (ownerId/granteeId) —
+    // flair 0.5.5 had a silent CLI/schema mismatch where `flair grant` wrote
+    // fromAgentId/toAgentId and grants never took effect.
+
+    // Grant bob search-scope access to alice's memories
+    const grantRes = await adminOp(harper, {
+      operation: "insert",
+      database: "flair",
+      table: "MemoryGrant",
+      records: [{
+        id: `${alice.id}:${bob.id}`,
+        ownerId: alice.id,
+        granteeId: bob.id,
+        scope: "search",
+        createdAt: new Date().toISOString(),
+      }],
+    });
+    expect(grantRes.status).toBe(200);
+
+    try {
+      // Bob queries his own scope — grant expansion should surface alice's rows
+      const res = await authFetch(harper, bob, "POST", "/SemanticSearch", {
+        agentId: bob.id,
+        subject: SUBJECT,
+        limit: 100,
+      });
+      expect(res.status).toBe(200);
+      const body: any = await res.json();
+      expect(Array.isArray(body.results)).toBe(true);
+      expect(body.results.length).toBe(50);
+      // Every row belongs to alice (bob has 0 memories of his own)
+      for (const r of body.results) expect(r.agentId).toBe(alice.id);
+    } finally {
+      // Revoke so subsequent tests see clean isolation
+      await adminOp(harper, {
+        operation: "delete",
+        database: "flair",
+        table: "MemoryGrant",
+        ids: [`${alice.id}:${bob.id}`],
+      });
+    }
+
+    // After revoke, bob's scope is empty again — the grant was load-bearing
+    const afterRes = await authFetch(harper, bob, "POST", "/SemanticSearch", {
+      agentId: bob.id,
+      subject: SUBJECT,
+      limit: 100,
+    });
+    expect(afterRes.status).toBe(200);
+    const afterBody: any = await afterRes.json();
+    expect(afterBody.results.length).toBe(0);
+  }, 60_000);
+
   test("non-admin alice cannot use the _reindex admin escape hatch", async () => {
     // Pick any alice memory; attempting to re-PUT with _reindex=true must 403
     // regardless of ownership — this path bypasses content-safety / embedding


### PR DESCRIPTION
## Summary

- Bug: `flair grant` CLI inserted MemoryGrant records with `fromAgentId`/`toAgentId`, but the schema and all readers (`Memory.ts`, `SemanticSearch.ts`, `auth-middleware.ts`) use `ownerId`/`granteeId`. Grants never expanded in search — the feature was silently broken since 0.5.0.
- 0.5.5 made it user-visible: that release closed the body-`agentId` spoofing path, so grants became the *only* supported cross-agent read — and they didn't work.
- Fix: CLI writes the correct field names. Old mock-server test was pinning the wrong fields — updated to match schema.
- New integration test (Sherlock's PR #236 follow-up): alice grants bob scope=search → bob's `SemanticSearch` returns alice's 50 rows; revoke → bob sees 0 again.

## Discovery

Found while scoping Sherlock's recommended positive-case test. Existing `flair grant` unit test was a mock-server test asserting the CLI POSTed certain fields — it couldn't catch this because it never hit a real Harper. The new integration test closes that gap.

## Test plan

- [x] `bun test test/integration/agent-journey.test.ts` — 10/10 pass (was 9, +1 grant test)
- [x] `bun test test/agent-remove-and-grants.test.ts` — 11/11 pass (updated field-name assertions)
- [x] `bun test` full suite — 435 pass, 2 pre-existing Playwright E2E failures under bun (unrelated)
- [x] `bunx tsc --noEmit -p tsconfig.check.json` — clean

## Why one PR

The CLI fix and test are load-bearing for each other: fixing the CLI without the test means the next refactor can re-break grants silently; landing the test without the CLI fix means the test has to special-case the broken insert path. One PR keeps the invariant clear.