### PR TITLE
fix(release): two-phase PR flow — respect main branch protection

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -22,6 +22,15 @@ VERSION="${1:?Usage: release.sh <version> [--publish|--dry]}"
 MODE="${2:-}"
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 
+# VERSION is interpolated into node -e heredocs and git/gh commands below.
+# Anchored semver-ish pattern: digits, dots, optional pre-release (-rc.1,
+# -alpha, etc.). Rejects quotes, backticks, semicolons — nothing that could
+# break out of the string literal in `pkg.version = '$VERSION';`.
+if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9.]+)?$ ]]; then
+  echo "❌ Invalid version: '$VERSION'. Expected semver (e.g. 0.5.6 or 1.0.0-rc.1)."
+  exit 1
+fi
+
 PACKAGES=(
   "$ROOT/packages/flair-client"
   "$ROOT/packages/flair-mcp"

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -3,12 +3,23 @@ set -euo pipefail
 
 # release.sh — Bump all workspace packages to a single version and publish.
 #
-# Usage:
-#   ./scripts/release.sh 0.5.0        # bump + publish
-#   ./scripts/release.sh 0.5.0 --dry  # bump + build + test, skip publish
+# Two-phase flow (respects main branch protection — no direct pushes, no bypass):
+#
+#   Phase 1 — open release PR:
+#     ./scripts/release.sh 0.5.0
+#       → creates branch release/v0.5.0, bumps + builds + tests,
+#         commits, pushes, opens PR. Review and merge via GitHub.
+#
+#   Phase 2 — publish after merge:
+#     ./scripts/release.sh 0.5.0 --publish
+#       → verifies main HEAD matches v0.5.0, publishes all packages
+#         to npm in dep order, tags, pushes the tag.
+#
+#   ./scripts/release.sh 0.5.0 --dry
+#       → phase-1 bump + build + test on a local branch, skip push/PR.
 
-VERSION="${1:?Usage: release.sh <version> [--dry]}"
-DRY="${2:-}"
+VERSION="${1:?Usage: release.sh <version> [--publish|--dry]}"
+MODE="${2:-}"
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 
 PACKAGES=(
@@ -18,7 +29,87 @@ PACKAGES=(
   "$ROOT"
 )
 
-echo "=== Flair Release v${VERSION} ==="
+PACKAGE_JSONS=(
+  "$ROOT/packages/flair-client/package.json"
+  "$ROOT/packages/flair-mcp/package.json"
+  "$ROOT/plugins/openclaw-flair/package.json"
+  "$ROOT/package.json"
+)
+
+# Prefer gh-as flint (tpsdev-ai org access) per CLAUDE.md
+if command -v gh-as >/dev/null 2>&1; then
+  GH="gh-as flint"
+else
+  GH="gh"
+fi
+
+# -----------------------------------------------------------------------------
+# Phase 2: publish after release PR is merged
+# -----------------------------------------------------------------------------
+if [[ "$MODE" == "--publish" ]]; then
+  echo "=== Flair Release v${VERSION} — PUBLISH ==="
+
+  if [[ -n "$(git -C "$ROOT" status --porcelain)" ]]; then
+    echo "❌ Working tree is dirty. Check out main at the release commit."
+    exit 1
+  fi
+
+  BRANCH="$(git -C "$ROOT" branch --show-current)"
+  if [[ "$BRANCH" != "main" ]]; then
+    echo "❌ --publish must run from main (on: $BRANCH)."
+    exit 1
+  fi
+
+  echo "🔄 Pulling latest main..."
+  git -C "$ROOT" pull --ff-only origin main
+
+  # Verify every package.json is at the declared version — catches running
+  # --publish before the release PR was actually merged.
+  for pj in "${PACKAGE_JSONS[@]}"; do
+    name="$(node -e "console.log(require('$pj').name)")"
+    pv="$(node -e "console.log(require('$pj').version)")"
+    if [[ "$pv" != "$VERSION" ]]; then
+      echo "❌ $name is at $pv, expected $VERSION. Has the release PR been merged?"
+      exit 1
+    fi
+  done
+
+  if git -C "$ROOT" rev-parse "v${VERSION}" >/dev/null 2>&1; then
+    echo "❌ Tag v${VERSION} already exists. Did you already publish?"
+    exit 1
+  fi
+
+  echo "🔨 Building from merged main..."
+  (cd "$ROOT" && npm run build && npm run build:cli) || { echo "❌ Build failed"; exit 1; }
+  (cd "$ROOT/packages/flair-client" && npm run build) || { echo "❌ flair-client build failed"; exit 1; }
+  (cd "$ROOT/packages/flair-mcp" && npm run build) || { echo "❌ flair-mcp build failed"; exit 1; }
+
+  echo "🚀 Publishing to npm..."
+  echo "  Publishing @tpsdev-ai/flair-client..."
+  (cd "$ROOT/packages/flair-client" && npm publish) || { echo "❌ flair-client publish failed"; exit 1; }
+
+  echo "  Publishing @tpsdev-ai/flair-mcp..."
+  (cd "$ROOT/packages/flair-mcp" && npm publish) || { echo "❌ flair-mcp publish failed"; exit 1; }
+
+  echo "  Publishing @tpsdev-ai/flair..."
+  (cd "$ROOT" && npm publish) || { echo "❌ flair publish failed"; exit 1; }
+
+  echo "  Publishing @tpsdev-ai/openclaw-flair..."
+  (cd "$ROOT/plugins/openclaw-flair" && npm publish) || { echo "⚠️  openclaw-flair publish failed (may need build step)"; }
+
+  echo "🏷️  Tagging v${VERSION} on main..."
+  git -C "$ROOT" tag -a "v${VERSION}" -m "Release v${VERSION}"
+  git -C "$ROOT" push origin "v${VERSION}"
+
+  echo ""
+  echo "✅ Flair v${VERSION} published and tagged."
+  exit 0
+fi
+
+# -----------------------------------------------------------------------------
+# Phase 1: prepare release PR
+# -----------------------------------------------------------------------------
+echo "=== Flair Release v${VERSION} — PR PREP ==="
 
 # 1. Validate git state
 if [[ -n "$(git -C "$ROOT" status --porcelain)" ]]; then
@@ -28,11 +119,23 @@ fi
 
 BRANCH="$(git -C "$ROOT" branch --show-current)"
 if [[ "$BRANCH" != "main" ]]; then
-  echo "⚠️  Not on main (on: $BRANCH). Publishing from non-main branch."
-  read -p "Continue? [y/N] " -n 1 -r
+  echo "⚠️  Not on main (on: $BRANCH). Release PRs must branch from main."
+  read -p "Continue anyway? [y/N] " -n 1 -r
   echo
   [[ $REPLY =~ ^[Yy]$ ]] || exit 1
 fi
+
+echo "🔄 Pulling latest main..."
+git -C "$ROOT" pull --ff-only origin main
+
+RELEASE_BRANCH="release/v${VERSION}"
+if git -C "$ROOT" show-ref --verify --quiet "refs/heads/$RELEASE_BRANCH"; then
+  echo "❌ Branch $RELEASE_BRANCH already exists locally. Delete it first if re-running."
+  exit 1
+fi
+
+echo "🌿 Creating $RELEASE_BRANCH..."
+git -C "$ROOT" checkout -b "$RELEASE_BRANCH"
 
 # 2. Bump versions in all package.json files
 echo "📦 Bumping all packages to v${VERSION}..."
@@ -73,40 +176,47 @@ echo "🧪 Running tests..."
 (cd "$ROOT" && bun test) || { echo "❌ Tests failed"; exit 1; }
 echo "  ✓ Tests passed"
 
-# 6. Commit version bump
+# 6. Commit version bump (explicit paths — no -A)
 echo "📝 Committing version bump..."
-git -C "$ROOT" add -A
+git -C "$ROOT" add \
+  "$ROOT/package.json" \
+  "$ROOT/packages/flair-client/package.json" \
+  "$ROOT/packages/flair-mcp/package.json" \
+  "$ROOT/plugins/openclaw-flair/package.json"
 git -C "$ROOT" commit -m "release: v${VERSION} — align all workspace packages"
 
-if [[ "$DRY" == "--dry" ]]; then
+if [[ "$MODE" == "--dry" ]]; then
   echo ""
-  echo "🏁 Dry run complete. All packages at v${VERSION}, built and tested."
-  echo "   To publish: git push && run this script again without --dry"
+  echo "🏁 Dry run complete. All packages at v${VERSION}, built and tested, commit on $RELEASE_BRANCH."
+  echo "   To open PR: re-run without --dry after resetting the branch."
   exit 0
 fi
 
-# 7. Publish in dependency order
-echo "🚀 Publishing to npm..."
-echo "  Publishing @tpsdev-ai/flair-client..."
-(cd "$ROOT/packages/flair-client" && npm publish) || { echo "❌ flair-client publish failed"; exit 1; }
+# 7. Push branch + open PR
+echo "📤 Pushing $RELEASE_BRANCH..."
+git -C "$ROOT" push -u origin "$RELEASE_BRANCH"
 
-echo "  Publishing @tpsdev-ai/flair-mcp..."
-(cd "$ROOT/packages/flair-mcp" && npm publish) || { echo "❌ flair-mcp publish failed"; exit 1; }
+echo "🔖 Opening release PR..."
+PR_URL="$($GH pr create \
+  --repo tpsdev-ai/flair \
+  --base main \
+  --head "$RELEASE_BRANCH" \
+  --title "release: v${VERSION}" \
+  --body "Version bump across workspace packages to v${VERSION}.
 
-echo "  Publishing @tpsdev-ai/flair..."
-(cd "$ROOT" && npm publish) || { echo "❌ flair publish failed"; exit 1; }
+See CHANGELOG.md for what's in this release.
 
-echo "  Publishing @tpsdev-ai/openclaw-flair..."
-(cd "$ROOT/plugins/openclaw-flair" && npm publish) || { echo "⚠️  openclaw-flair publish failed (may need build step)"; }
-
-# 8. Tag and push
-echo "🏷️  Tagging v${VERSION}..."
-git -C "$ROOT" tag "v${VERSION}"
-git -C "$ROOT" push && git -C "$ROOT" push --tags
+After CI is green and this is merged:
+\`\`\`
+git checkout main && git pull
+./scripts/release.sh ${VERSION} --publish
+\`\`\`")"
 
 echo ""
-echo "✅ Flair v${VERSION} released!"
-echo "   @tpsdev-ai/flair@${VERSION}"
-echo "   @tpsdev-ai/flair-client@${VERSION}"
-echo "   @tpsdev-ai/flair-mcp@${VERSION}"
-echo "   @tpsdev-ai/openclaw-flair@${VERSION}"
+echo "✅ Release PR opened: $PR_URL"
+echo ""
+echo "Next steps:"
+echo "  1. Wait for CI green on the PR"
+echo "  2. Merge via GitHub UI (or: $GH pr merge --squash --repo tpsdev-ai/flair <num>)"
+echo "  3. git checkout main && git pull"
+echo "  4. ./scripts/release.sh ${VERSION} --publish"


### PR DESCRIPTION
## Summary
- release.sh used to `git push` the release commit straight to main, which branch protection blocks. Two recent releases (0.5.0 #222, 0.5.1 #225, 0.5.2 #230) actually went via PR — my earlier assumption that the script's direct-push worked was wrong.
- Split the script into two phases so it respects the same merge rules as every other change.

## Flow

**Phase 1** — `./scripts/release.sh 0.5.6`
- Branches `release/v0.5.6` from main
- Bumps all workspace packages, builds, runs `bun test`
- Commits only the four `package.json` files (no `-A`, per the "never `git add -A`" rule)
- Pushes, opens PR via `gh-as flint pr create`

**Phase 2** — `./scripts/release.sh 0.5.6 --publish`
- Run after the PR is merged
- Verifies `main` HEAD carries the declared version and the tag doesn't already exist
- Publishes to npm in dep order (flair-client → flair-mcp → flair → openclaw-flair)
- Tags `v0.5.6` on main, pushes the tag

Tag push doesn't hit branch protection.

## Test plan
- [ ] CI green
- [ ] After merge: run `./scripts/release.sh 0.5.6` to cut 0.5.6 as the first user of the new flow