### PR TITLE
fix(release): scope local tests to unit + integration

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -181,8 +181,11 @@ echo "🔨 Building..."
 echo "  ✓ All packages built"
 
 # 5. Test
+# Scope matches CI's test job split: unit + integration under bun. Playwright
+# e2e specs live under test/e2e/ and fail to load under bun — they're run via
+# `bunx playwright test` against a live server in CI, not locally here.
 echo "🧪 Running tests..."
-(cd "$ROOT" && bun test) || { echo "❌ Tests failed"; exit 1; }
+(cd "$ROOT" && bun test test/unit/ test/integration/) || { echo "❌ Tests failed"; exit 1; }
 echo "  ✓ Tests passed"
 
 # 6. Commit version bump (explicit paths — no -A)


### PR DESCRIPTION
## Summary
Second issue hit on the first attempt to cut 0.5.6 with the new PR flow: release.sh runs `bun test` which tries to load test/e2e/\*.spec.ts — those are Playwright specs. CI runs them via `bunx playwright test` against a live server, not under bun. Result: 2 errors + 2 fails on a green tree.

Scope to `test/unit/ test/integration/` to match the CI job split.

## Test plan
- [ ] CI green
- [ ] After merge, re-run `./scripts/release.sh 0.5.6` — local tests should pass