### PR TITLE
release.sh: refresh bun.lock after version bumps

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -173,6 +173,12 @@ node -e "
   }
 "
 
+# 3a. Refresh bun.lock so CI's --frozen-lockfile passes post-bump.
+# Omitting this was the 0.5.6 release failure: version bumps desynced the
+# lockfile, --frozen-lockfile killed every CI job at install.
+echo "🔒 Refreshing bun.lock..."
+(cd "$ROOT" && bun install) || { echo "❌ bun install failed"; exit 1; }
+
 # 4. Build
 echo "🔨 Building..."
 (cd "$ROOT" && npm run build && npm run build:cli) || { echo "❌ Build failed"; exit 1; }
@@ -194,7 +200,8 @@ git -C "$ROOT" add \
   "$ROOT/package.json" \
   "$ROOT/packages/flair-client/package.json" \
   "$ROOT/packages/flair-mcp/package.json" \
-  "$ROOT/plugins/openclaw-flair/package.json"
+  "$ROOT/plugins/openclaw-flair/package.json" \
+  "$ROOT/bun.lock"
 git -C "$ROOT" commit -m "release: v${VERSION} — align all workspace packages"
 
 if [[ "$MODE" == "--dry" ]]; then


### PR DESCRIPTION
## Summary

Version bumps desync `bun.lock`, and CI's `bun install --frozen-lockfile` kills every job at install if the lock isn't regenerated. This was the 0.5.6 release failure — all nine CI jobs red on #242 until the lockfile was regenerated and force-pushed to the release branch.

## Change

- Insert `bun install` between dep-alignment (step 3) and build (step 4)
- Add `bun.lock` to the explicit file list in the release commit

## Why inline rather than in a pre-push hook or CI job

This is a property of the release flow itself — any script that writes to `package.json` and produces a commit destined for `--frozen-lockfile` CI must also write `bun.lock`. Encoding that coupling in the release script is the shortest correct fix.

## Verified

- `bash -n scripts/release.sh` — syntax clean
- Matches the remediation I applied manually on `release/v0.5.6` (commit 858ef2e) to unblock #242

## Test plan

- [ ] CI green on this PR
- [ ] Next release (v0.5.7) cut via `./scripts/release.sh 0.5.7` succeeds on first CI run without a force-push to refresh the lock

🤖 Generated with [Claude Code](https://claude.com/claude-code)