### PR TITLE
ci: bump harperfast/harper Docker image 5.0.0 → 5.0.1

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -73,7 +73,7 @@ jobs:
             -e OPERATIONSAPI_NETWORK_PORT=9925 \
             -e HTTP_PORT=9926 \
             --entrypoint /bin/sh \
-            harperfast/harper:5.0.0 \
+            harperfast/harper:5.0.1 \
             -c "harper install && harper dev /flair"
           # Wait for Harper to be healthy (Basic auth required by Harper's authorizeLocal)
           for i in $(seq 1 60); do


### PR DESCRIPTION
## Summary
- Integration-test job launches Harper via Docker; that image tag is pinned independently of the npm `@harperfast/harper` library.
- #247 bumped the library to 5.0.1 for the HNSW concurrent-write fix. CI still ran `harperfast/harper:5.0.0`, so the concurrent-writes test (#246) kept failing on the old Harper runtime.
- This bumps the Docker tag to match. Image exists on Docker Hub (pushed 2026-04-14, arm64 + amd64).

## Test plan
- [ ] CI green on this PR (unit + e2e integration)
- [ ] Rebase #246 onto main after merge; confirm concurrent-writes test passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)