### PR TITLE
ci: integration tests use native Harper spawn (fix HNSW race signal)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,6 +42,14 @@ jobs:
       - uses: oven-sh/setup-bun@735343b667d3e6f658f44d0eca948eb6282f2b76 # v2
         with:
           bun-version: "1.3.10"
+      # Node 22+ is required by flair's engines. Integration tests spawn Harper
+      # natively (matches how real users run Flair) instead of via the Docker
+      # image, since the `harperfast/harper:5.0.1` Docker image bundles a
+      # different build than the npm package and still exhibits the HNSW
+      # concurrent-write race that npm 5.0.1 fixed.
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: "22"
       - run: bun install --frozen-lockfile
       - name: Install linux-x64 native binary for embeddings
         run: bun add --no-save @node-llama-cpp/linux-x64@3
@@ -60,7 +68,12 @@ jobs:
             "https://huggingface.co/nomic-ai/nomic-embed-text-v1.5-GGUF/resolve/main/nomic-embed-text-v1.5.Q4_K_M.gguf" \
             -o models/nomic-embed-text-v1.5.Q4_K_M.gguf
           echo "Model downloaded ($(du -sh models/*.gguf | cut -f1))"
-      - name: Start Harper with Flair component
+      - name: Run integration tests (native Harper spawn)
+        # No HARPER_HTTP_URL — harper-lifecycle spawns Harper from node_modules
+        # per the npm-installed @harperfast/harper@5.0.1. Avoids the Docker
+        # image's stale HNSW build.
+        run: bun test test/integration/
+      - name: Start Harper with Flair component (for E2E / Playwright)
         run: |
           docker run -d \
             --name harper-flair \
@@ -91,13 +104,6 @@ jobs:
             fi
             sleep 2
           done
-      - name: Run integration tests against Docker Harper
-        run: bun test test/integration/
-        env:
-          HARPER_HTTP_URL: http://localhost:9926
-          HARPER_OPS_URL: http://localhost:9925
-          HARPER_ADMIN_USER: admin
-          HARPER_ADMIN_PASS: admin123
       - name: E2E CLI smoke test
         run: bash test/e2e-cli.sh
         env:


### PR DESCRIPTION
## Summary
- The `harperfast/harper:5.0.1` Docker image bundles a **different build** than the npm `@harperfast/harper@5.0.1` package. Verified empirically:
  - **npm 5.0.1 locally:** concurrent-writes test (PR #246) passes **4/4**, all 50 parallel PUT /Memory succeed on first attempt.
  - **Docker 5.0.1 in CI:** same test still fails 3/4 with the same HNSW race signature (`Cannot read properties of undefined (reading '0')`) that 5.0.1 was supposed to fix.
- `harper-lifecycle.ts` already supports native spawn mode via `node_modules/@harperfast/harper`. This PR just stops pointing the integration test step at the Docker service.
- E2E CLI smoke + Playwright still use Docker since they don't exercise the HNSW race and the fixed 9926 port is ergonomic.
- Adds `actions/setup-node@v4` to the integration job (Ubuntu runners ship Node 20; flair's `engines` requires >=22).

## Why this is the right call
- **Matches reality.** Real users install Flair via npm; Harper runs as a Node process, not in Docker. CI should exercise that path.
- **Unblocks #246.** The concurrent-writes regression canary — which already found real bugs — can finally go green and merge.
- **No loss of coverage.** E2E + Playwright still run against Docker Harper, so we keep the "fresh install in a clean image" signal for the CLI/UI surface.

## Test plan
- [ ] CI green on this PR (unit + integration + E2E + Playwright + upgrade-smoke)
- [ ] After merge, rebase #246 onto main; concurrent-writes test passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)