### PR TITLE
ci: correct misleading test.yml comments about Docker vs npm

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,9 +44,12 @@ jobs:
           bun-version: "1.3.10"
       # Node 22+ is required by flair's engines. Integration tests spawn Harper
       # natively (matches how real users run Flair) instead of via the Docker
-      # image, since the `harperfast/harper:5.0.1` Docker image bundles a
-      # different build than the npm package and still exhibits the HNSW
-      # concurrent-write race that npm 5.0.1 fixed.
+      # image, because the harperfast/harper:5.0.1 Docker environment
+      # (bundled Node 24 + Debian bookworm) triggers an HNSW concurrent-write
+      # race that doesn't reproduce on native Node 22 spawns. The Harper
+      # server code is byte-identical across artifacts — only the runtime
+      # environment differs. Tracked upstream:
+      # https://github.com/HarperFast/harper/issues/386
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: "22"
@@ -71,7 +74,7 @@ jobs:
       - name: Run integration tests (native Harper spawn)
         # No HARPER_HTTP_URL — harper-lifecycle spawns Harper from node_modules
         # per the npm-installed @harperfast/harper@5.0.1. Avoids the Docker
-        # image's stale HNSW build.
+        # runtime environment that triggers HarperFast/harper#386.
         run: bun test test/integration/
       - name: Start Harper with Flair component (for E2E / Playwright)
         run: |


### PR DESCRIPTION
## Summary

The comments in `.github/workflows/test.yml` that I landed in #249 incorrectly claimed the `harperfast/harper:5.0.1` Docker image bundles "a different build than the npm package" and that the Docker image carried a "stale HNSW build." Both statements are wrong.

## Evidence

Verified 2026-04-20 by extracting `harper-5.0.1.tgz` from both sources and diffing:

- **Docker**: layer 11 of `harperfast/harper:5.0.1` contains `harper-5.0.1.tgz` (sha `8f5f1b…`, 8.77MB)
- **npm**: `@harperfast/harper@5.0.1` registry tgz (sha `bcb372…`, 9.02MB)

Differences between the extracted contents:
- `package/package.json` — `name` field (`harper` vs `@harperfast/harper`)
- `package/studio/web/assets/` — Vite content-hashed UI bundle names (DB studio, not server)

The entire `package/dist/` tree is byte-identical, including `HierarchicalNavigableSmallWorld.js`. The HNSW concurrent-write race that breaks the Docker-based CI path exists in **both artifacts**; it simply fails to trigger on the native Node 22 Ubuntu spawn we switched to.

## Changes

- Block at L45–52: reframe from "Docker image bundles a different build" to "Docker runtime environment (Node 24 + Debian bookworm) triggers the race, native Node 22 spawn doesn't."
- Block at L74–76: replace "Docker image's stale HNSW build" with the same runtime-environment framing.
- Both comments now link to the upstream tracking issue: HarperFast/harper#386.

## Test plan

- [x] Comments only — no functional change
- [x] test.yml still valid (no syntactic changes beyond comment text)
- [ ] CI green on this PR (all jobs should pass identically to main)

🤖 Generated with [Claude Code](https://claude.com/claude-code)