### PR TITLE
deps: bump harper-fabric-embeddings to 0.2.3

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -7,7 +7,7 @@
       "dependencies": {
         "@harperfast/harper": "5.0.1",
         "commander": "14.0.3",
-        "harper-fabric-embeddings": "0.2.2",
+        "harper-fabric-embeddings": "0.2.3",
         "jose": "^6.2.2",
         "tweetnacl": "1.0.3",
       },
@@ -16,9 +16,6 @@
         "@types/node": "24.11.0",
         "bun-types": "1.3.11",
         "typescript": "5.9.3",
-      },
-      "optionalDependencies": {
-        "@node-llama-cpp/mac-arm64-metal": "3.18.1",
       },
     },
     "packages/flair-client": {
@@ -469,9 +466,19 @@
 
     "@noble/hashes": ["@noble/hashes@1.4.0", "", {}, "sha512-V1JJ1WTRUqHHrOSh597hURcMqVKVGL/ea3kv0gSnEdsEZ0/+VyPghM1lMNGc00z7CIQorSvbKpuJkxvuHbvdbg=="],
 
-    "@node-llama-cpp/linux-x64": ["@node-llama-cpp/linux-x64@3.17.1", "", { "os": "linux", "cpu": "x64" }, "sha512-/o/UoqAdslg4ExdKYyYPqbw+21Dr4cQ2JgouXg8Ji3opRKoTMrlUNfrMwIsYZfbDDJ8l7xFnwfGIwdlQ5RPwJg=="],
+    "@node-llama-cpp/linux-arm64": ["@node-llama-cpp/linux-arm64@3.18.1", "", { "os": "linux", "cpu": [ "x64", "arm64", ] }, "sha512-rXMgZxUay78FOJV/fJ67apYP9eElH5jd4df5YRKPlLhLHHchuOSyDn+qtyW/L/EnPzpogoLkmULqCkdXU39XsQ=="],
+
+    "@node-llama-cpp/linux-armv7l": ["@node-llama-cpp/linux-armv7l@3.18.1", "", { "os": "linux", "cpu": [ "arm", "x64", ] }, "sha512-BrJL2cGo0pN5xd5nw+CzTn2rFMpz9MJyZZPUY81ptGkF2uIuXT2hdCVh56i9ImQrTwBfq1YcZL/l/Qe/1+HR/Q=="],
+
+    "@node-llama-cpp/linux-x64": ["@node-llama-cpp/linux-x64@3.18.1", "", { "os": "linux", "cpu": "x64" }, "sha512-tRmWcsyvAcqJHQHXHsaOkx6muGbcirA9nRdNgH6n7bjGUw4VuoBD3dChyNF3/Ktt7ohB9kz+XhhyZjbDHpXyMA=="],
 
     "@node-llama-cpp/mac-arm64-metal": ["@node-llama-cpp/mac-arm64-metal@3.18.1", "", { "os": "darwin", "cpu": [ "x64", "arm64", ] }, "sha512-cyZTdsUMlvuRlGmkkoBbN3v/DT6NuruEqoQYd9CqIrPyLa1xLNBTSKIZ9SgRnw23iCOj4URfITvRP+2pu63LuQ=="],
+
+    "@node-llama-cpp/mac-x64": ["@node-llama-cpp/mac-x64@3.18.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-GfCPgdltaIpBhEnQ7WfsrRXrZO9r9pBtDUAQMXRuJwOPP5q7xKrQZUXI6J6mpc8tAG0//CTIuGn4hTKoD/8V8w=="],
+
+    "@node-llama-cpp/win-arm64": ["@node-llama-cpp/win-arm64@3.18.1", "", { "os": "win32", "cpu": [ "x64", "arm64", ] }, "sha512-S05YUzBMVSRS5KNbOS26cDYugeQHqogI3uewtTUBVC0tPbTHRSKjsdicmgWru1eNAry399LWWhzOf/3St/qsAw=="],
+
+    "@node-llama-cpp/win-x64": ["@node-llama-cpp/win-x64@3.18.1", "", { "os": "win32", "cpu": "x64" }, "sha512-QLDVphPl+YDI+x/VYYgIV1N9g0GMXk3PqcoopOUG3cBRUtce7FO+YX903YdRJezs4oKbIp8YaO+xYBgeUSqhpA=="],
 
     "@nodelib/fs.scandir": ["@nodelib/fs.scandir@2.1.5", "", { "dependencies": { "@nodelib/fs.stat": "2.0.5", "run-parallel": "^1.1.9" } }, "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g=="],
 
@@ -1137,7 +1144,7 @@
 
     "gunzip-maybe": ["gunzip-maybe@1.4.2", "", { "dependencies": { "browserify-zlib": "^0.1.4", "is-deflate": "^1.0.0", "is-gzip": "^1.0.0", "peek-stream": "^1.1.0", "pumpify": "^1.3.3", "through2": "^2.0.3" }, "bin": { "gunzip-maybe": "bin.js" } }, "sha512-4haO1M4mLO91PW57BMsDFf75UmwoRX0GkdD+Faw+Lr+r/OZrOCS0pIBwOL1xCKQqnQzbNFGgK2V2CpBUPeFNTw=="],
 
-    "harper-fabric-embeddings": ["harper-fabric-embeddings@0.2.2", "", { "optionalDependencies": { "@node-llama-cpp/linux-x64": "3.17.1" } }, "sha512-Sk6fJBmIPdH4cJbRn5jawzc+PG6xVa6pyzglU/qQa0HyIWt0ZbelYt7dSpynhpU88L8QcD9wf0yMYCWEt4yPqw=="],
+    "harper-fabric-embeddings": ["harper-fabric-embeddings@0.2.3", "", { "optionalDependencies": { "@node-llama-cpp/linux-arm64": "3.18.1", "@node-llama-cpp/linux-armv7l": "3.18.1", "@node-llama-cpp/linux-x64": "3.18.1", "@node-llama-cpp/mac-arm64-metal": "3.18.1", "@node-llama-cpp/mac-x64": "3.18.1", "@node-llama-cpp/win-arm64": "3.18.1", "@node-llama-cpp/win-x64": "3.18.1" } }, "sha512-25F1xzRTJ+19NlDiMI0RLF47u4Fwd5Ve/V03q06kJjCioqvEc2yrAASQ3NY4O+LJDU9rNq9WQivFeU+9JKt4IA=="],
 
     "has-flag": ["has-flag@4.0.0", "", {}, "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="],
 

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
   "dependencies": {
     "@harperfast/harper": "5.0.1",
     "commander": "14.0.3",
-    "harper-fabric-embeddings": "0.2.2",
+    "harper-fabric-embeddings": "0.2.3",
     "jose": "^6.2.2",
     "tweetnacl": "1.0.3"
   },
@@ -70,8 +70,5 @@
   "workspaces": [
     "packages/*",
     "plugins/*"
-  ],
-  "optionalDependencies": {
-    "@node-llama-cpp/mac-arm64-metal": "3.18.1"
-  }
+  ]
 }


### PR DESCRIPTION
## What

Bumps `harper-fabric-embeddings` from 0.2.2 → 0.2.3 and drops our compensating `@node-llama-cpp/mac-arm64-metal` optionalDependency (HFE now carries it).

## Why

0.2.3 fixes two real bugs that hit us:

1. **[#251] Harper crash on >512-token embeddings.** HFE 0.2.2's default `batchSize=512` plumbed through to `n_ubatch` in `node-llama-cpp`'s `AddonContext`. Any input past 512 tokens tripped `GGML_ASSERT(cparams.n_ubatch >= n_tokens)` → `ggml_abort` → host process dies. The client saw a bare `SocketError: other side closed`; no HTTP status. 0.2.3 defaults `batchSize` to `contextSize` (2048) and adds a tokenizer-aware truncation guard for deployments that explicitly set a smaller batch. Fix: [heskew/harper-fabric-embeddings#1](https://github.com/heskew/harper-fabric-embeddings/pull/1).

2. **Latent config-override drop.** HFE 0.2.2 read `scope.options` as a plain object (`scope.options.batchSize`, etc.), but Harper 5.x's `scope.options` is an `OptionsWatcher` — config lives behind `.getAll()` / `.get([key])`, not direct properties. Every `config.yaml` override (`modelName`, `batchSize`, `threads`, `gpuLayers`, `addonPath`) was silently dropped in every HFE deployment since v0.1.0. 0.2.3 reads via `scope.options.getAll()` with a plain-object fallback for non-Harper hosts. Fix: same PR #1.

0.2.3 also widens `optionalDependencies` to cover all seven `@node-llama-cpp` platform packages ([heskew/harper-fabric-embeddings#2](https://github.com/heskew/harper-fabric-embeddings/pull/2)), so Flair no longer needs its own `@node-llama-cpp/mac-arm64-metal` compensating entry — and picks up `linux-arm64`, `linux-armv7l`, `win-x64`, `win-arm64`, `mac-x64` coverage as a bonus. Fabric (Linux) deploys are unchanged: npm's `os`/`cpu` metadata installs only the matching binary.

## Testing

- `bun install` clean on darwin-arm64 (rockit); native addon detected post-install.
- The fix's own regression test (long-input repro via `flair memory add --content "<~3KB natural English>"`) has been running green on rockit against a patched `node_modules/harper-fabric-embeddings` carrying the same fix since ~21:00Z. This PR just swaps that working-tree stopgap for the published 0.2.3 that lands the same code.
- No Flair source changes — purely a dep bump.

Closes: ops-eap