### PR TITLE
test: poll opsURL in waitForHealth to close startup race

### DIFF
--- a/test/helpers/harper-lifecycle.ts
+++ b/test/helpers/harper-lifecycle.ts
@@ -123,7 +123,11 @@ export async function startHarper(): Promise<HarperInstance> {
 
   const httpURL = `http://127.0.0.1:${httpPort}`;
   const opsURL = `http://127.0.0.1:${opsPort}`;
-  await waitForHealth(httpURL);
+  // Poll both ports. Harper binds httpURL and opsURL at different moments during
+  // startup; callers hit opsURL immediately (admin seed), so returning as soon
+  // as httpURL answers was racy — agent-journey intermittently ECONNREFUSED on
+  // opsURL even though httpURL was already serving 404s.
+  await Promise.all([waitForHealth(httpURL), waitForHealth(opsURL)]);
 
   return { httpURL, opsURL, installDir, process: proc, admin: { username: "admin", password: "test123" }, external: false };
 }


### PR DESCRIPTION
## Summary

`agent-journey` intermittently failed with `ECONNREFUSED` on opsURL right after `startHarper()` returned. Harper binds the HTTP and operations ports at separate moments during startup, and `waitForHealth` only polled the HTTP port. All four integration test files hit opsURL immediately for admin seeding — a fast test file could win the race to opsURL before the port was bound.

Poll both ports before returning from `startHarper()`.

## Context

This is a latent race in the harness that was exposed by the HFE 0.2.3 bump on #253 (CI run [24691759849](https://github.com/tpsdev-ai/flair/actions/runs/24691759849)). Log excerpt from the failing job:

\`\`\`
[harper-lifecycle] waitForHealth: server alive after 4005ms
error: Unable to connect. Is the computer able to access the url?
  path: "http://127.0.0.1:37176/",
 errno: 0,
  code: "ConnectionRefused"
(fail) Authenticated agent journey > (unnamed) [7875.22ms]
\`\`\`

## Test plan

- [ ] CI's Integration Tests job passes (all 4 files).
- [ ] #253 can rebase on top of this and go green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)