### PR TITLE
fix: flair test writes via PUT /Memory/<id>

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -202,6 +202,11 @@ jobs:
             exit 1
           }
 
+          # `flair test` exercises PUT /Memory + POST /SemanticSearch + DELETE
+          # against the running daemon. Guards against the 0.5.6-era regression
+          # where `flair test` POSTed to /Memory and always failed.
+          $FLAIR test --agent smoke
+
           # Tear down
           $FLAIR stop --port $PORT || true
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2578,18 +2578,20 @@ program
       }
     };
 
-    // 1. Write a test memory via POST /Memory
-    await check("Write test memory (POST /Memory)", async () => {
+    // 1. Write a test memory via PUT /Memory/<id>.
+    // Schema only exposes PUT — POST returns 'Memory does not have a post method implemented'.
+    await check("Write test memory (PUT /Memory/<id>)", async () => {
+      const id = `flair-test-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
       const body: Record<string, any> = {
+        id,
         content: "flair test \u2014 this will be deleted",
         durability: "ephemeral",
         createdAt: new Date().toISOString(),
       };
       if (agentId) body.agentId = agentId;
-      const result = await api("POST", "/Memory", body);
-      // id may be returned directly or nested
-      memoryId = result?.id ?? result?.[0]?.id ?? null;
-      return !!memoryId || result?.ok === true;
+      await api("PUT", `/Memory/${id}`, body);
+      memoryId = id;
+      return true;
     });
 
     // 2. Search for the test memory via POST /SemanticSearch


### PR DESCRIPTION
## Why
The `flair test` CLI command POSTs to `/Memory`, but the Memory schema only exposes PUT. Every `flair test` run fails its write step with `ClientError - 'The Memory does not have a post method implemented'`, surfaced during 0.5.6 dogfood.

## What
- `src/cli.ts`: generate a client-side id and PUT to `/Memory/<id>`. Same pattern `flair memory add` already uses (line 2857) — zero schema change.
- `.github/workflows/test.yml`: `pack-smoke` now runs `$FLAIR test --agent smoke` after the memory round-trip. The existing round-trip only exercises PUT via `memory add`; this guards the `flair test` verb contract directly so the bug can't silently come back.

Fixes ops-pj5.

## Test plan
- [ ] CI green (unit + integration + pack-smoke now exercises `flair test`)
- [ ] Locally: `flair test --agent <id>` passes 3/3 instead of 1/3