### PR TITLE
fix: harmonize flair memory add/search flags

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2850,19 +2850,31 @@ program
 // ─── Memory and Soul commands ────────────────────────────────────────────────
 
 const memory = program.command("memory").description("Manage agent memories");
-memory.command("add").requiredOption("--agent <id>").requiredOption("--content <text>")
+memory.command("add [content]").requiredOption("--agent <id>")
+  .option("--content <text>", "memory content (alias for positional arg)")
   .option("--durability <d>", "standard").option("--tags <csv>")
-  .action(async (opts) => {
+  .action(async (contentArg, opts) => {
+    const content = contentArg ?? opts.content;
+    if (!content) { console.error("error: content required (positional arg or --content)"); process.exit(1); }
     const memId = `${opts.agent}-${Date.now()}`;
     const out = await api("PUT", `/Memory/${memId}`, {
-      id: memId, agentId: opts.agent, content: opts.content, durability: opts.durability || "standard",
+      id: memId, agentId: opts.agent, content, durability: opts.durability || "standard",
       tags: opts.tags ? String(opts.tags).split(",").map((x: string) => x.trim()).filter(Boolean) : undefined,
       type: "memory", createdAt: new Date().toISOString(),
     });
     console.log(JSON.stringify(out, null, 2));
   });
-memory.command("search").requiredOption("--agent <id>").requiredOption("--q <query>").option("--tag <tag>")
-  .action(async (opts) => console.log(JSON.stringify(await api("POST", "/SemanticSearch", { agentId: opts.agent, q: opts.q, tag: opts.tag }), null, 2)));
+memory.command("search [query]").requiredOption("--agent <id>")
+  .option("--q <query>", "search query (alias for positional arg)")
+  .option("--limit <n>", "Max results", "5")
+  .option("--tag <tag>")
+  .action(async (queryArg, opts) => {
+    const q = queryArg ?? opts.q;
+    if (!q) { console.error("error: query required (positional arg or --q)"); process.exit(1); }
+    const body: Record<string, any> = { agentId: opts.agent, q, limit: parseInt(opts.limit, 10) || 5 };
+    if (opts.tag) body.tag = opts.tag;
+    console.log(JSON.stringify(await api("POST", "/SemanticSearch", body), null, 2));
+  });
 memory.command("list").requiredOption("--agent <id>").option("--tag <tag>")
   .action(async (opts) => {
     const q = new URLSearchParams({ agentId: opts.agent, ...(opts.tag ? { tag: opts.tag } : {}) }).toString();


### PR DESCRIPTION
## Why
CLI flag inconsistencies surfaced during 0.5.6 dogfood (ops-1zg):
- \`flair memory add\` required \`--content <text>\` with no positional alternative
- \`flair memory search\` required \`--q <query>\` with no positional alternative and no \`--limit\`
- \`flair search\` (the shortcut) already uses positional \`<query>\` + \`--limit\`

So the top-level shortcut had a better UX than the longhand it shortcuts to. This harmonizes them.

## What
- \`flair memory add [content] --agent <id>\` — positional content arg. \`--content\` kept as alias.
- \`flair memory search [query] --agent <id>\` — positional query arg. \`--q\` kept as alias.
- \`flair memory search\` now accepts \`--limit <n>\` (default 5) and passes it through to SemanticSearch — parity with \`flair search\`.

Backwards compatible: every existing script using \`--content\` or \`--q\` keeps working.

Fixes ops-1zg.

## Test plan
- [ ] CI green
- [ ] \`flair memory add --agent a --content "x"\` still works (flag form)
- [ ] \`flair memory add "x" --agent a\` now works (positional form)
- [ ] \`flair memory search "x" --agent a --limit 10\` returns up to 10 results