### PR TITLE
feat: flair deploy — one-command Fabric deployment

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -202,6 +202,16 @@ jobs:
             exit 1
           }
 
+          # Deploy dry-run (FLAIR-DEPLOY guard): `flair deploy --dry-run` must
+          # resolve the installed package and validate args against a Fabric
+          # target. Doesn't call Fabric. Catches drift in the published `files`
+          # array vs. what deploy packages.
+          $FLAIR deploy --dry-run \
+            --fabric-org pack-smoke-org \
+            --fabric-cluster pack-smoke-cluster \
+            --fabric-user admin \
+            --fabric-password smoke-pw
+
           # Tear down
           $FLAIR stop --port $PORT || true
 

--- a/specs/FLAIR-DEPLOY.md
+++ b/specs/FLAIR-DEPLOY.md
@@ -1,0 +1,149 @@
+# FLAIR-DEPLOY: One-Command Fabric Deployment
+
+> Zero-install deploy of Flair as a component onto an existing Harper Fabric cluster.
+
+**Status:** Draft
+**Depends on:** Harper Fabric + `deploy_component` API
+**Audience:** 1.0 — anyone with a Fabric cluster wanting Flair in a minute
+
+---
+
+## § 1 Problem
+
+Getting Flair onto Harper Fabric today requires:
+
+1. Read Harper's deploy_component docs
+2. Install Flair locally (or clone the repo)
+3. Figure out the right `harperdb deploy_component` invocation with project/target/username/password flags
+4. Hope the runtime env matches
+
+That's a 20-minute first-run with several cliffs. We want the **one command demo**:
+
+```bash
+npx @tpsdev-ai/flair deploy --fabric-org acme --fabric-cluster prod
+```
+
+Someone who just read the README has Flair running on their Fabric cluster before their coffee is cold. Zero local Flair install, zero prior `flair init`, zero manual tarball handling.
+
+## § 2 What `flair deploy` Is
+
+A Flair CLI subcommand that:
+
+1. Resolves the currently-installed `@tpsdev-ai/flair` package (including via `npx`, which extracts the tarball to a temporary location)
+2. Packages `dist/` + `schemas/` + `config.yaml` + `ui/` as a Harper component
+3. Calls Harper's `deploy_component` API against the target Fabric cluster
+4. Reports the public URL + next-step command to the user
+
+It is **not** a Fabric cluster provisioner. Nathan confirmed 2026-04-20 that Fabric doesn't yet expose an API for org/cluster creation. Users bring their own cluster.
+
+## § 3 Command Surface
+
+```
+flair deploy [options]
+
+Required:
+  --fabric-org <org>            Fabric org identifier
+  --fabric-cluster <cluster>    Fabric cluster name within the org
+
+Required (one of):
+  --fabric-user <user>          Fabric admin username
+  --fabric-password <pass>      Fabric admin password
+  --fabric-token <token>        OAuth bearer token (preferred once available)
+
+Or via environment:
+  FABRIC_ORG, FABRIC_CLUSTER, FABRIC_USER, FABRIC_PASSWORD, FABRIC_TOKEN
+
+Optional:
+  --project <name>              Component name in Fabric (default: "flair")
+  --version <semver>            Pinned version (default: installed package version)
+  --replicated                  Replicate to every node in the cluster (default: true)
+  --restart                     Restart the component after deploy (default: true)
+  --dry-run                     Pack + validate, do NOT call Fabric API
+  --yes                         Skip the pre-deploy confirmation prompt
+```
+
+## § 4 Zero-State Requirements
+
+The command must work with **no local Flair state**. That means:
+
+- No `.flair/keys`, no `~/.flair/*`, no `~/.tps/secrets` lookup
+- No running daemon check (`flair status` is irrelevant for remote deploy)
+- No local config file lookup (`config.yaml` comes from the installed package itself)
+- No interactive prompts unless the user explicitly invoked a TTY
+
+All inputs come from CLI flags or environment variables. This makes `npx @tpsdev-ai/flair deploy ...` work in a CI job, a Dockerfile, or a fresh dev box.
+
+## § 5 Flow
+
+```
+1. Parse + validate args
+2. Resolve source package root:
+   - Prefer process.argv[1] resolution (where npx dropped us)
+   - Fallback: require.resolve("@tpsdev-ai/flair/package.json")
+3. Verify package contains dist/, schemas/, config.yaml, ui/
+4. Build component tarball:
+   - Tar the four dirs (+ package.json) in memory (or tmpdir)
+   - Name: flair-<version>.tgz
+5. Resolve Fabric target URL:
+   - https://<cluster>.<org>.harperfabric.com (default template)
+   - Or --target <url> override (for non-standard hosts)
+6. Call Harper deploy_component API (POST with Basic auth or Bearer)
+7. Poll component status until RUNNING (timeout 3 min)
+8. Print success payload:
+   - Public URL
+   - Admin seed command (next step)
+   - "flair agent add --remote <url>" hint
+```
+
+## § 6 Next-Step UX (the part users see)
+
+```
+$ npx @tpsdev-ai/flair deploy --fabric-org acme --fabric-cluster prod
+✓ Flair 0.6.0 packaged (1.2 MB)
+✓ Deploying to https://prod.acme.harperfabric.com
+✓ Component running (2.4s)
+
+Your Flair is live:  https://prod.acme.harperfabric.com
+Admin username:      admin
+Admin password:      <prompt: set via Fabric Studio>
+
+Seed your first agent:
+  npx @tpsdev-ai/flair agent add --remote https://prod.acme.harperfabric.com --name my-agent
+
+Next time, skip npx:
+  npm install -g @tpsdev-ai/flair
+```
+
+## § 7 Out of Scope (for 1.0)
+
+- **Cluster provisioning.** If Nathan's user doesn't have a Fabric cluster, they create one manually in Fabric Studio. We don't attempt to orchestrate cluster birth.
+- **Credential storage.** `flair deploy` reads credentials from flags/env but doesn't cache them. Re-running takes them again. A future `flair login --fabric` can cache short-lived tokens.
+- **Remote admin bootstrap.** The command deploys the code; it does not create an admin agent on the remote. That happens in `flair agent add --remote` (existing flow, minor extension).
+- **Rollback / multi-version management.** `deploy` replaces whatever's running. Version pinning via `--version` is enough for 1.0.
+
+## § 8 Dependencies
+
+- Harper's `deploy_component` API must accept the arguments we send. We use the documented shape: `project`, `target`, `username`, `password`, `restart`, `replicated`, and either a file upload or git URL source. Native tarball upload is the cleanest path for Flair since the package is self-contained.
+- `harper-fabric-embeddings` is already proven on Fabric (2026-04-20 confirmation) — the embedding path is not a blocker.
+
+## § 9 Risks + Open Questions
+
+- **Fabric auth flow.** Docs show Basic auth; OAuth bearer is the preferred path once Fabric exposes it. Design the deploy client to accept either from day one.
+- **Tarball vs. git deploy.** Fabric Studio's "Import Application" flow uses a git URL. `deploy_component` CLI uses file upload. Our `flair deploy` goes file-upload — keeps us zero-network-dependency (user might be offline re: GitHub, or running from a forked Flair).
+- **package.json `files` array at deploy time.** We already ship `dist/`, `schemas/`, `config.yaml`, `ui/`, and the LICENSE/README. The deploy command tars the same set — keep the list in a shared constant so we don't drift.
+- **First-deploy admin credentials.** Fabric's admin credentials aren't always knowable ahead of time if the cluster was created via Studio UI. The error message when `--fabric-password` is wrong should tell the user to check Fabric Studio → Cluster Settings → Admin. Small detail, big UX impact.
+
+## § 10 Test Plan
+
+- [ ] `flair deploy --dry-run --fabric-org x --fabric-cluster y --fabric-user u --fabric-password p` packs successfully, does NOT call Fabric
+- [ ] `npx @tpsdev-ai/flair deploy ...` works from a fresh directory with no `@tpsdev-ai/flair` installed
+- [ ] Missing required flags produce an actionable error (not a stack trace)
+- [ ] Wrong Fabric password produces "check Cluster Settings → Admin"
+- [ ] CI smoke: pack-smoke adds a `deploy --dry-run` call to guarantee the packaging never silently regresses
+- [ ] Integration-test new command surface with a Fabric START-tier target (real deploy, then teardown) — can be a manual checklist for 1.0 cut, not CI
+
+## § 11 Open Questions for Review
+
+**For Kern (arch):** Is there value in making `deploy` a generic Harper-component deploy primitive (`tpscomp deploy flair --fabric-org ...`) vs. baking it into the Flair CLI? The former sets up a reusable pattern if we ever ship other Harper components; the latter keeps the 1.0 surface tight. My instinct: bake it in, extract later if we actually ship a second component.
+
+**For Sherlock (sec):** The command holds admin credentials in memory briefly during the HTTP call. Any concern with how we accept them (flag vs env vs prompt)? My default: prefer env + prompt, warn when `--fabric-password` is passed via flag (leaks to shell history).

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -14,6 +14,7 @@ import { join, resolve as resolvePath } from "node:path";
 import { spawn } from "node:child_process";
 import { createPrivateKey, sign as nodeCryptoSign, randomUUID } from "node:crypto";
 import { keystore } from "./keystore.js";
+import { deploy as deployToFabric, validateOptions as validateDeployOptions, buildTargetUrl as buildDeployUrl } from "./deploy.js";
 
 // Federation crypto helpers — inlined to avoid cross-boundary imports from
 // src/ into resources/, which don't survive npm packaging (see also
@@ -2614,6 +2615,86 @@ program
 
     console.log(`\n${passed} passed, ${failed} failed`);
     if (failed > 0) process.exit(1);
+  });
+
+// ─── flair deploy ─────────────────────────────────────────────────────────────
+
+program
+  .command("deploy")
+  .description("Deploy Flair as a component to a remote Harper Fabric cluster")
+  .option("--fabric-org <org>", "Fabric org (env: FABRIC_ORG)")
+  .option("--fabric-cluster <cluster>", "Fabric cluster within the org (env: FABRIC_CLUSTER)")
+  .option("--fabric-user <user>", "Fabric admin username (env: FABRIC_USER)")
+  .option("--fabric-password <pass>", "Fabric admin password (env: FABRIC_PASSWORD)")
+  .option("--fabric-token <token>", "OAuth bearer token (env: FABRIC_TOKEN) — reserved for future Fabric bearer support")
+  .option("--target <url>", "Override the Fabric URL template (https://<cluster>.<org>.harperfabric.com)")
+  .option("--project <name>", "Component name in Fabric", "flair")
+  .option("--pkg-version <semver>", "Override version label (default: installed package version)")
+  .option("--no-replicated", "Disable cluster-wide replication (default: replicated=true)")
+  .option("--no-restart", "Do not restart the component after deploy (default: restart=true)")
+  .option("--dry-run", "Resolve package, validate args, skip the deploy call")
+  .option("--package-root <dir>", "Override package root (mainly for testing)")
+  .action(async (opts) => {
+    const green = (s: string) => `\x1b[32m${s}\x1b[0m`;
+    const red = (s: string) => `\x1b[31m${s}\x1b[0m`;
+    const dim = (s: string) => `\x1b[2m${s}\x1b[0m`;
+
+    const deployOpts = {
+      fabricOrg: opts.fabricOrg ?? process.env.FABRIC_ORG,
+      fabricCluster: opts.fabricCluster ?? process.env.FABRIC_CLUSTER,
+      fabricUser: opts.fabricUser ?? process.env.FABRIC_USER,
+      fabricPassword: opts.fabricPassword ?? process.env.FABRIC_PASSWORD,
+      fabricToken: opts.fabricToken ?? process.env.FABRIC_TOKEN,
+      target: opts.target,
+      project: opts.project,
+      version: opts.pkgVersion,
+      replicated: opts.replicated !== false,
+      restart: opts.restart !== false,
+      dryRun: opts.dryRun ?? false,
+      packageRoot: opts.packageRoot,
+    };
+
+    const errors = validateDeployOptions(deployOpts);
+    if (errors.length) {
+      console.error(red("flair deploy: missing required options"));
+      for (const e of errors) console.error(`  - ${e}`);
+      process.exit(1);
+    }
+
+    // Warn on password-via-flag (leaks to shell history). Env is preferred.
+    if (opts.fabricPassword && !process.env.FABRIC_PASSWORD) {
+      console.error(dim(
+        "warning: --fabric-password leaks to shell history. " +
+        "Prefer FABRIC_PASSWORD env.",
+      ));
+    }
+
+    const url = buildDeployUrl(deployOpts);
+    console.log(`${green("→")} Deploying ${deployOpts.project} to ${url}`);
+    if (deployOpts.dryRun) console.log(dim("  (dry-run: skipping API call)"));
+
+    try {
+      const result = await deployToFabric(deployOpts);
+      if (result.dryRun) {
+        console.log(`${green("✓")} dry-run OK: ${result.project} ${result.version} ready to deploy to ${result.url}`);
+        console.log(dim(`  package root: ${result.packageRoot}`));
+        return;
+      }
+      console.log(`\n${green("✓")} Flair ${result.version} deployed`);
+      console.log(`\n  URL:     ${result.url}`);
+      console.log(`  Project: ${result.project}`);
+      console.log(`\nNext steps:`);
+      console.log(dim(`  1. Set an admin password in Fabric Studio (Cluster Settings → Admin)`));
+      console.log(dim(`  2. Seed your first agent:`));
+      console.log(`     flair agent add --remote ${result.url} --name my-agent`);
+    } catch (err: any) {
+      console.error(red(`\n✗ deploy failed: ${err.message}`));
+      const hint = err.message?.toLowerCase();
+      if (hint?.includes("401") || hint?.includes("unauthoriz")) {
+        console.error(dim("  hint: check Fabric Studio → Cluster Settings → Admin for the admin password"));
+      }
+      process.exit(1);
+    }
   });
 
 // ─── flair doctor ─────────────────────────────────────────────────────────────

--- a/src/deploy.ts
+++ b/src/deploy.ts
@@ -1,0 +1,202 @@
+import { spawn } from "node:child_process";
+import { dirname, join, resolve } from "node:path";
+import { existsSync, readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { createRequire } from "node:module";
+
+export interface DeployOptions {
+  fabricOrg?: string;
+  fabricCluster?: string;
+  fabricUser?: string;
+  fabricPassword?: string;
+  fabricToken?: string;
+  target?: string;
+  project?: string;
+  version?: string;
+  replicated?: boolean;
+  restart?: boolean;
+  dryRun?: boolean;
+  packageRoot?: string;
+}
+
+export interface DeployResult {
+  url: string;
+  project: string;
+  version: string;
+  packageRoot: string;
+  dryRun: boolean;
+}
+
+// Files that must be present in a Flair package for deployment.
+// Mirrors the `files` array in package.json — keep in sync.
+export const REQUIRED_PACKAGE_FILES = [
+  "dist",
+  "schemas",
+  "ui",
+  "config.yaml",
+] as const;
+
+export function validateOptions(opts: DeployOptions): string[] {
+  const errors: string[] = [];
+  if (!opts.target) {
+    if (!opts.fabricOrg)
+      errors.push("--fabric-org required (or FABRIC_ORG env)");
+    if (!opts.fabricCluster)
+      errors.push("--fabric-cluster required (or FABRIC_CLUSTER env)");
+  }
+  const hasBasic = !!(opts.fabricUser && opts.fabricPassword);
+  const hasBearer = !!opts.fabricToken;
+  if (!hasBasic && !hasBearer) {
+    errors.push(
+      "credentials required: pass --fabric-user + --fabric-password " +
+        "(or FABRIC_USER / FABRIC_PASSWORD env), or --fabric-token " +
+        "(FABRIC_TOKEN env)",
+    );
+  }
+  return errors;
+}
+
+export function buildTargetUrl(opts: DeployOptions): string {
+  if (opts.target) return opts.target;
+  return `https://${opts.fabricCluster}.${opts.fabricOrg}.harperfabric.com`;
+}
+
+export function resolvePackageRoot(override?: string): string {
+  if (override) {
+    const abs = resolve(override);
+    if (!existsSync(join(abs, "package.json"))) {
+      throw new Error(`No package.json at ${abs}`);
+    }
+    return abs;
+  }
+
+  // Walk up from this module's location — works when installed locally
+  // and when npx extracts the tarball to a tmpdir.
+  try {
+    const here = dirname(fileURLToPath(import.meta.url));
+    let dir = here;
+    for (let i = 0; i < 8; i++) {
+      const pkgPath = join(dir, "package.json");
+      if (existsSync(pkgPath)) {
+        const json = JSON.parse(readFileSync(pkgPath, "utf8"));
+        if (json.name === "@tpsdev-ai/flair") return dir;
+      }
+      const parent = dirname(dir);
+      if (parent === dir) break;
+      dir = parent;
+    }
+  } catch {
+    /* fall through */
+  }
+
+  try {
+    const req = createRequire(import.meta.url);
+    return dirname(req.resolve("@tpsdev-ai/flair/package.json"));
+  } catch {
+    throw new Error(
+      "Could not locate @tpsdev-ai/flair package root. Try --package-root.",
+    );
+  }
+}
+
+export function validatePackageLayout(packageRoot: string): void {
+  const missing: string[] = [];
+  for (const f of REQUIRED_PACKAGE_FILES) {
+    if (!existsSync(join(packageRoot, f))) missing.push(f);
+  }
+  if (missing.length) {
+    throw new Error(
+      `Flair package at ${packageRoot} is missing required entries: ` +
+        missing.join(", "),
+    );
+  }
+}
+
+function resolveHarperBin(packageRoot: string): string {
+  const local = join(
+    packageRoot,
+    "node_modules/@harperfast/harper/dist/bin/harper.js",
+  );
+  if (existsSync(local)) return local;
+
+  try {
+    const req = createRequire(join(packageRoot, "package.json"));
+    const mainPath = req.resolve("@harperfast/harper");
+    let dir = dirname(mainPath);
+    for (let i = 0; i < 6; i++) {
+      const candidate = join(dir, "dist/bin/harper.js");
+      if (existsSync(candidate)) return candidate;
+      const parent = dirname(dir);
+      if (parent === dir) break;
+      dir = parent;
+    }
+  } catch {
+    /* fall through */
+  }
+  throw new Error(
+    "Could not locate Harper CLI binary (@harperfast/harper). " +
+      "Flair deploy requires Harper to be installed alongside Flair.",
+  );
+}
+
+function spawnHarper(
+  bin: string,
+  args: string[],
+  cwd: string,
+): Promise<void> {
+  return new Promise((resolveP, rejectP) => {
+    const p = spawn(process.execPath, [bin, ...args], {
+      cwd,
+      stdio: "inherit",
+    });
+    p.on("error", rejectP);
+    p.on("exit", (code) => {
+      if (code === 0) resolveP();
+      else rejectP(new Error(`harper deploy exited with code ${code}`));
+    });
+  });
+}
+
+export async function deploy(opts: DeployOptions): Promise<DeployResult> {
+  const errors = validateOptions(opts);
+  if (errors.length) {
+    throw new Error(errors.join("\n"));
+  }
+
+  const packageRoot = resolvePackageRoot(opts.packageRoot);
+  validatePackageLayout(packageRoot);
+
+  const pkg = JSON.parse(
+    readFileSync(join(packageRoot, "package.json"), "utf8"),
+  );
+  const version = opts.version ?? pkg.version;
+  const project = opts.project ?? "flair";
+  const url = buildTargetUrl(opts);
+
+  if (opts.dryRun) {
+    return { url, project, version, packageRoot, dryRun: true };
+  }
+
+  if (opts.fabricToken && !(opts.fabricUser && opts.fabricPassword)) {
+    throw new Error(
+      "Bearer token auth (--fabric-token) is not yet supported — " +
+        "Harper's deploy_component CLI path only accepts Basic auth today. " +
+        "Pass --fabric-user + --fabric-password instead.",
+    );
+  }
+
+  const harperBin = resolveHarperBin(packageRoot);
+  const args = [
+    "deploy",
+    `target=${url}`,
+    `project=${project}`,
+    `restart=${opts.restart !== false}`,
+    `replicated=${opts.replicated !== false}`,
+    `username=${opts.fabricUser}`,
+    `password=${opts.fabricPassword}`,
+  ];
+
+  await spawnHarper(harperBin, args, packageRoot);
+
+  return { url, project, version, packageRoot, dryRun: false };
+}

--- a/src/deploy.ts
+++ b/src/deploy.ts
@@ -143,11 +143,13 @@ function spawnHarper(
   bin: string,
   args: string[],
   cwd: string,
+  env: NodeJS.ProcessEnv,
 ): Promise<void> {
   return new Promise((resolveP, rejectP) => {
     const p = spawn(process.execPath, [bin, ...args], {
       cwd,
       stdio: "inherit",
+      env,
     });
     p.on("error", rejectP);
     p.on("exit", (code) => {
@@ -192,11 +194,18 @@ export async function deploy(opts: DeployOptions): Promise<DeployResult> {
     `project=${project}`,
     `restart=${opts.restart !== false}`,
     `replicated=${opts.replicated !== false}`,
-    `username=${opts.fabricUser}`,
-    `password=${opts.fabricPassword}`,
   ];
 
-  await spawnHarper(harperBin, args, packageRoot);
+  // Credentials go via env, not argv, so they don't appear in `ps` output
+  // for the lifetime of the Harper child process. Harper's cliOperations
+  // reads CLI_TARGET_USERNAME / CLI_TARGET_PASSWORD as env fallbacks.
+  const childEnv: NodeJS.ProcessEnv = {
+    ...process.env,
+    CLI_TARGET_USERNAME: opts.fabricUser,
+    CLI_TARGET_PASSWORD: opts.fabricPassword,
+  };
+
+  await spawnHarper(harperBin, args, packageRoot, childEnv);
 
   return { url, project, version, packageRoot, dryRun: false };
 }

--- a/test/unit/deploy.test.ts
+++ b/test/unit/deploy.test.ts
@@ -1,0 +1,143 @@
+/**
+ * deploy.test.ts — Unit tests for `flair deploy` pre-flight logic.
+ *
+ * Covers pure/extractable validation and resolution without making any
+ * network calls to Harper Fabric.
+ */
+
+import { describe, test, expect } from "bun:test";
+import { mkdtempSync, writeFileSync, mkdirSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import {
+  validateOptions,
+  buildTargetUrl,
+  resolvePackageRoot,
+  validatePackageLayout,
+  deploy,
+  REQUIRED_PACKAGE_FILES,
+} from "../../src/deploy.js";
+
+describe("flair deploy: validateOptions", () => {
+  test("rejects missing org + cluster", () => {
+    const errs = validateOptions({
+      fabricUser: "admin",
+      fabricPassword: "pw",
+    });
+    expect(errs).toContain("--fabric-org required (or FABRIC_ORG env)");
+    expect(errs).toContain("--fabric-cluster required (or FABRIC_CLUSTER env)");
+  });
+
+  test("rejects missing credentials", () => {
+    const errs = validateOptions({
+      fabricOrg: "acme",
+      fabricCluster: "prod",
+    });
+    expect(errs.some(e => e.startsWith("credentials required"))).toBe(true);
+  });
+
+  test("accepts basic auth", () => {
+    const errs = validateOptions({
+      fabricOrg: "acme",
+      fabricCluster: "prod",
+      fabricUser: "admin",
+      fabricPassword: "pw",
+    });
+    expect(errs).toEqual([]);
+  });
+
+  test("accepts bearer token", () => {
+    const errs = validateOptions({
+      fabricOrg: "acme",
+      fabricCluster: "prod",
+      fabricToken: "tok",
+    });
+    expect(errs).toEqual([]);
+  });
+
+  test("--target skips org/cluster requirement", () => {
+    const errs = validateOptions({
+      target: "https://custom.host",
+      fabricUser: "admin",
+      fabricPassword: "pw",
+    });
+    expect(errs).toEqual([]);
+  });
+});
+
+describe("flair deploy: buildTargetUrl", () => {
+  test("constructs fabric URL from org + cluster", () => {
+    expect(
+      buildTargetUrl({ fabricOrg: "acme", fabricCluster: "prod" }),
+    ).toBe("https://prod.acme.harperfabric.com");
+  });
+
+  test("--target wins over org/cluster", () => {
+    expect(
+      buildTargetUrl({
+        fabricOrg: "acme",
+        fabricCluster: "prod",
+        target: "https://custom.host:9925",
+      }),
+    ).toBe("https://custom.host:9925");
+  });
+});
+
+describe("flair deploy: package resolution", () => {
+  test("resolvePackageRoot finds the live package from its own module", () => {
+    const root = resolvePackageRoot();
+    // This test runs from inside the flair repo, so the resolved root
+    // must be the repo itself.
+    expect(root.endsWith("flair")).toBe(true);
+  });
+
+  test("validatePackageLayout accepts a proper layout", () => {
+    const dir = mkdtempSync(join(tmpdir(), "flair-deploy-test-"));
+    try {
+      for (const f of REQUIRED_PACKAGE_FILES) {
+        const p = join(dir, f);
+        if (f.endsWith(".yaml")) writeFileSync(p, "port: 9926\n");
+        else mkdirSync(p);
+      }
+      expect(() => validatePackageLayout(dir)).not.toThrow();
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("validatePackageLayout rejects missing dirs", () => {
+    const dir = mkdtempSync(join(tmpdir(), "flair-deploy-test-"));
+    try {
+      // Only create dist/, intentionally skip the rest
+      mkdirSync(join(dir, "dist"));
+      expect(() => validatePackageLayout(dir)).toThrow(/missing required/);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("flair deploy: dry-run end-to-end", () => {
+  test("returns success without calling Harper", async () => {
+    const result = await deploy({
+      fabricOrg: "acme",
+      fabricCluster: "prod",
+      fabricUser: "admin",
+      fabricPassword: "pw",
+      dryRun: true,
+    });
+    expect(result.dryRun).toBe(true);
+    expect(result.url).toBe("https://prod.acme.harperfabric.com");
+    expect(result.project).toBe("flair");
+    expect(result.version).toMatch(/^\d+\.\d+/);
+  });
+
+  test("rejects invalid options before any package work", async () => {
+    await expect(
+      deploy({
+        fabricOrg: "acme",
+        // missing cluster + creds
+      } as any),
+    ).rejects.toThrow();
+  });
+});

--- a/test/unit/deploy.test.ts
+++ b/test/unit/deploy.test.ts
@@ -118,18 +118,40 @@ describe("flair deploy: package resolution", () => {
 });
 
 describe("flair deploy: dry-run end-to-end", () => {
+  // Synthesize a minimal package-root so the test is independent of whether
+  // `dist/` has been built in the repo — unit tests run before build in CI.
+  function synthPkgRoot(): string {
+    const dir = mkdtempSync(join(tmpdir(), "flair-deploy-e2e-"));
+    for (const f of REQUIRED_PACKAGE_FILES) {
+      const p = join(dir, f);
+      if (f.endsWith(".yaml")) writeFileSync(p, "port: 9926\n");
+      else mkdirSync(p);
+    }
+    writeFileSync(
+      join(dir, "package.json"),
+      JSON.stringify({ name: "@tpsdev-ai/flair", version: "9.9.9-test" }),
+    );
+    return dir;
+  }
+
   test("returns success without calling Harper", async () => {
-    const result = await deploy({
-      fabricOrg: "acme",
-      fabricCluster: "prod",
-      fabricUser: "admin",
-      fabricPassword: "pw",
-      dryRun: true,
-    });
-    expect(result.dryRun).toBe(true);
-    expect(result.url).toBe("https://prod.acme.harperfabric.com");
-    expect(result.project).toBe("flair");
-    expect(result.version).toMatch(/^\d+\.\d+/);
+    const pkgRoot = synthPkgRoot();
+    try {
+      const result = await deploy({
+        fabricOrg: "acme",
+        fabricCluster: "prod",
+        fabricUser: "admin",
+        fabricPassword: "pw",
+        dryRun: true,
+        packageRoot: pkgRoot,
+      });
+      expect(result.dryRun).toBe(true);
+      expect(result.url).toBe("https://prod.acme.harperfabric.com");
+      expect(result.project).toBe("flair");
+      expect(result.version).toBe("9.9.9-test");
+    } finally {
+      rmSync(pkgRoot, { recursive: true, force: true });
+    }
   });
 
   test("rejects invalid options before any package work", async () => {


### PR DESCRIPTION
Implements `flair deploy` per **specs/FLAIR-DEPLOY.md** (#258).

## What it does

```
npx @tpsdev-ai/flair deploy \
  --fabric-org acme --fabric-cluster prod \
  --fabric-user admin --fabric-password "$FABRIC_PW"
```

Wraps Harper's `deploy_component` CLI with the packaging + resolution that makes zero-install deploys work:

- Resolves the installed `@tpsdev-ai/flair` package root from this module's location (walks up, then `require.resolve` fallback). Works when `npx` extracts the tarball to a tmpdir.
- Validates package layout (`dist/ schemas/ ui/ config.yaml`) before shelling to Harper.
- Derives the Fabric URL as `https://<cluster>.<org>.harperfabric.com`; `--target` overrides for non-standard hosts.
- Prints a success block that leads the user straight into `flair agent add --remote`.
- `--dry-run` validates everything short of calling the Fabric API.

All config comes from flags or `FABRIC_*` env vars. No local Flair state is read, so it works from a fresh directory / CI job / Dockerfile.

## Auth scope for 1.0

Basic auth (`--fabric-user` + `--fabric-password`) only. `--fabric-token` is declared on the surface but rejected with a clear error if no Basic creds are provided — Harper's `deploy_component` CLI path doesn't accept bearer today. Wiring bearer in is a follow-up once Fabric exposes it (§9 of the spec).

Warns on `--fabric-password` passed via flag (leaks to shell history). Env is preferred.

## Test coverage

- **`test/unit/deploy.test.ts`** — 12 tests exercising validation, URL building, package-root walk-up, layout validation, and a dry-run end-to-end path. No network.
- **pack-smoke CI** — added `flair deploy --dry-run` to guarantee the published tarball still contains everything deploy needs to pack (catches drift in the `files` array).

## Out of scope for this PR (per spec §7)

- Cluster provisioning (Fabric has no API yet; user creates the cluster in Fabric Studio)
- Credential caching (future `flair login --fabric`)
- Component polling / timing UI (Harper's CLI inherits stdio and prints progress)
- Bearer token auth (see above)

## Reviewer checklist

- **Kern (arch):** The deploy-wrapper vs. generic-primitive question from spec §11 — I went with the inline-subcommand approach. Happy to pull it out if you want the `tpscomp deploy flair` shape now.
- **Sherlock (sec):** Creds live in memory briefly during the spawned Harper process lifetime. They're passed as args (`password=...`) to a child process — visible in `ps` on shared hosts during the call. Flag-based passwords emit a "shell history" warning; env is preferred. Worth stepping up?

Closes ops-1fo once merged.