### PR TITLE
fix(openclaw-flair): rename memory_recall to memory_search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 ### 🧹 Cleanup
 - **Removed `flair migrate-keys`:** the `~/.tps/secrets/flair/` layout only existed while Flair lived in the TPS monorepo pre-0.1. No published user ever had that path, so the CLI command was dead code from an external perspective. Anyone still sitting on the old layout can migrate manually: `mv ~/.tps/secrets/flair/<agent>-priv.key ~/.flair/keys/<agent>.key` (strip the `-priv` suffix) and run `flair doctor` to confirm.
 
+### 🔌 Plugin
+- **`@tpsdev-ai/openclaw-flair` 0.5.7 — surface memory search to the LLM:** the plugin registered its semantic search tool as `memory_recall`, but OpenClaw's `coding` profile only allows `memory_search` and `memory_get` by canonical name; non-canonical memory tool names are filtered out of the agent's LLM-visible toolset. That left Pulse with only `memory_get` (fetch-by-id) and no way to semantically search its own Flair memory. Renamed to `memory_search` to match the canonical OpenClaw contract — now surfaces under the default `coding` profile with zero config. `memory_store` is still plugin-namespaced; README documents the `tools.alsoAllow: ["memory_store"]` config needed to surface it.
+
 ## 0.5.6 (2026-04-17)
 
 ### 🐛 Bug Fixes

--- a/plugins/openclaw-flair/README.md
+++ b/plugins/openclaw-flair/README.md
@@ -6,7 +6,7 @@ Uses Flair's native Harper vector embeddings — no OpenAI API key required.
 
 ## Features
 
-- **Semantic search** via `memory_recall` → Flair's HNSW vector index
+- **Semantic search** via `memory_search` → Flair's HNSW vector index
 - **Persistent storage** via `memory_store` → Ed25519-authenticated writes
 - **Memory retrieval** via `memory_get` → fetch by ID
 - **Auto-bootstrap** — injects relevant memories into context at session start
@@ -69,7 +69,18 @@ In your OpenClaw config (`openclaw.json`):
 | `keyPath` | string | auto-resolved | Path to Ed25519 private key |
 | `autoCapture` | boolean | `true` | Auto-capture important info from conversations |
 | `autoRecall` | boolean | `true` | Inject relevant memories at session start |
-| `maxRecallResults` | number | `5` | Max results for `memory_recall` |
+| `maxRecallResults` | number | `5` | Max results for `memory_search` |
+
+## Tool naming
+
+OpenClaw's `coding` profile allows `memory_search` and `memory_get` by canonical name. `memory_store` is not a core tool name, so it's filtered out by the default profile. To surface it to the LLM, add it to your openclaw.json:
+
+```json
+"tools": {
+  "profile": "coding",
+  "alsoAllow": ["memory_store"]
+}
+```
 | `maxBootstrapTokens` | number | `4000` | Max tokens for bootstrap context injection |
 
 ## Auth

--- a/plugins/openclaw-flair/index.ts
+++ b/plugins/openclaw-flair/index.ts
@@ -6,7 +6,7 @@
  * embeddings — no OpenAI API key required.
  *
  * Implements the OpenClaw "memory" plugin slot:
- *   - memory_recall  → POST /SemanticSearch (semantic search)
+ *   - memory_search  → POST /SemanticSearch (semantic search)
  *   - memory_store   → PUT  /Memory/<id>  (write + embed)
  *   - memory_get     → GET  /Memory/<id>  (fetch by id)
  *   - before_agent_start hook → inject recent/relevant memories
@@ -314,12 +314,12 @@ export default {
     const displayAgent = isAutoMode ? "auto (per-session)" : cfg.agentId;
     api.logger.info(`openclaw-flair: registered (agent=${displayAgent}, url=${cfg.url ?? DEFAULT_URL})`);
 
-    // ── memory_recall ──────────────────────────────────────────────────────
+    // ── memory_search ──────────────────────────────────────────────────────
 
     api.registerTool(
       {
-        name: "memory_recall",
-        label: "Memory Recall",
+        name: "memory_search",
+        label: "Memory Search",
         description:
           "Search long-term memory via Flair semantic search. Use when you need context about user preferences, past decisions, or previously discussed topics.",
         parameters: Type.Object({
@@ -342,12 +342,12 @@ export default {
               details: { count: results.length, memories: results },
             };
           } catch (err: any) {
-            api.logger.warn(`openclaw-flair: recall failed: ${err.message}`);
-            return { content: [{ type: "text", text: `Memory recall unavailable: ${err.message}` }], details: { count: 0 } };
+            api.logger.warn(`openclaw-flair: search failed: ${err.message}`);
+            return { content: [{ type: "text", text: `Memory search unavailable: ${err.message}` }], details: { count: 0 } };
           }
         },
       },
-      { name: "memory_recall" },
+      { name: "memory_search" },
     );
 
     // ── memory_store ───────────────────────────────────────────────────────

--- a/plugins/openclaw-flair/package.json
+++ b/plugins/openclaw-flair/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tpsdev-ai/openclaw-flair",
-  "version": "0.5.6",
+  "version": "0.5.7",
   "description": "OpenClaw memory plugin for Flair — agent identity and semantic memory",
   "type": "module",
   "main": "index.ts",

--- a/plugins/openclaw-flair/test/plugin.test.ts
+++ b/plugins/openclaw-flair/test/plugin.test.ts
@@ -43,7 +43,7 @@ describe("memory-flair plugin", () => {
     const api = createMockApi();
     plugin.register(api as any);
 
-    expect(api._tools.has("memory_recall")).toBe(true);
+    expect(api._tools.has("memory_search")).toBe(true);
     expect(api._tools.has("memory_store")).toBe(true);
     expect(api._tools.has("memory_get")).toBe(true);
   });
@@ -79,12 +79,12 @@ describe("memory-flair plugin", () => {
     expect(result.content[0].text).toContain("unavailable");
   });
 
-  test("memory_recall returns error when no agentId in auto mode", async () => {
+  test("memory_search returns error when no agentId in auto mode", async () => {
     const plugin = (await import("../index.ts")).default;
     const api = createMockApi({ agentId: "auto" });
     plugin.register(api as any);
 
-    const tool = api._tools.get("memory_recall")!;
+    const tool = api._tools.get("memory_search")!;
     const result = await tool.execute("test", { query: "hello" });
     expect(result.content[0].text).toContain("unavailable");
   });


### PR DESCRIPTION
## Summary

- Pulse (Nathan's EA, running openclaw-flair 0.5.6 on the new stack) had only `memory_get` in her LLM toolkit — no way to semantically search Flair memory. Root cause: OpenClaw's `coding` profile filters plugin-registered tools by canonical name. Only `memory_search` and `memory_get` are allowed; `memory_recall` and `memory_store` were getting stripped silently at profile-policy time.
- Renamed the plugin's semantic-search tool `memory_recall` → `memory_search` to match the canonical OpenClaw contract. Now surfaces under the default `coding` profile with zero user config.
- `memory_store` remains plugin-namespaced (there's no canonical memory-write tool in OpenClaw). README now documents the `tools.alsoAllow: ["memory_store"]` config needed to expose it.
- Bumped `@tpsdev-ai/openclaw-flair` to 0.5.7.

## How the filter works

1. `api.registerTool({name: "memory_recall", ...}, {name: "memory_recall"})` succeeds; the tool lands in `registry.tools`.
2. At agent-start, `applyToolPolicyPipeline` filters tools against the `coding` profile's allowlist (`listCoreToolIdsForProfile("coding")`), which contains `memory_search` + `memory_get` but not `memory_recall`.
3. Tools with non-canonical names get dropped unless they appear in `tools.allow` / `tools.alsoAllow` / `group:<pluginId>`.

Canonical names are defined in `openclaw/dist/tool-policy-*.js` — this is the same list the bundled `memory-core` plugin uses.

## Test plan

- [x] `bun test` in `plugins/openclaw-flair/` — 14 pass
- [ ] Install 0.5.7 on pulse, restart gateway, verify `memory_search` appears in Pulse's toolset
- [ ] Verify `memory_store` appears after adding `tools.alsoAllow: ["memory_store"]` to pulse's openclaw.json
- [ ] Pulse uses `memory_search` end-to-end against Flair

🤖 Generated with [Claude Code](https://claude.com/claude-code)