### PR TITLE
feat(status): tier health + embedding-model breakdown + hash-fallback inspector

### DIFF
--- a/resources/health.ts
+++ b/resources/health.ts
@@ -53,12 +53,18 @@ export class HealthDetail extends Resource {
       for await (const m of db.flair.Memory.search({})) {
         memoriesList.push(m);
       }
-      const withEmbeddings = memoriesList.filter(
-        (m: any) => m.embeddingModel && m.embeddingModel !== "hash-512d",
-      ).length;
-      const hashFallback = memoriesList.filter(
-        (m: any) => !m.embeddingModel || m.embeddingModel === "hash-512d",
-      ).length;
+      // Per-model counts: "hash-512d" is the hash-fallback marker; any other
+      // value (or missing value) is a real embedding. Multiple distinct
+      // non-hash models means mixed vector spaces — cross-space searches
+      // return garbage unless reconciled via `flair reembed`.
+      const modelCounts: Record<string, number> = {};
+      for (const m of memoriesList) {
+        const model = m.embeddingModel || "hash-512d";
+        modelCounts[model] = (modelCounts[model] ?? 0) + 1;
+      }
+      const hashFallback = modelCounts["hash-512d"] ?? 0;
+      const withEmbeddings = memoriesList.length - hashFallback;
+      const realModels = Object.keys(modelCounts).filter((k) => k !== "hash-512d");
       const byDurability = { permanent: 0, persistent: 0, standard: 0, ephemeral: 0 } as Record<string, number>;
       let archived = 0;
       let expired = 0;
@@ -72,6 +78,7 @@ export class HealthDetail extends Resource {
         total: memoriesList.length,
         withEmbeddings,
         hashFallback,
+        modelCounts,
         byDurability,
         archived,
         expired,
@@ -83,8 +90,24 @@ export class HealthDetail extends Resource {
         if (sorted[0]) stats.lastWrite = sorted[0].createdAt;
       }
       if (expired > 0) warnings.push({ level: "warn", message: `${expired} memories have expired validTo but aren't archived` });
-      if (withEmbeddings > 0 && hashFallback > withEmbeddings) {
-        warnings.push({ level: "warn", message: "embeddings degraded — more hash-fallback writes than embedded" });
+      // Hash-fallback coverage — tiered by percentage. Thresholds are
+      // first-pass defaults; Kern's review on ops-n4n may tune them.
+      if (memoriesList.length > 0) {
+        const pct = Math.round((hashFallback / memoriesList.length) * 100);
+        if (pct >= 10) {
+          warnings.push({
+            level: "warn",
+            message: `${hashFallback}/${memoriesList.length} (${pct}%) memories are hash-fallback — run: flair reembed --stale-only --dry-run`,
+          });
+        }
+      }
+      // Mixed embedding models — searches across vector spaces return garbage.
+      if (realModels.length > 1) {
+        const list = realModels.map((k) => `${k}:${modelCounts[k]}`).join(", ");
+        warnings.push({
+          level: "warn",
+          message: `multiple embedding models in use (${list}) — cross-model search unreliable; run: flair reembed against one model`,
+        });
       }
     } catch { stats.memories = null; }
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2111,8 +2111,11 @@ const statusCmd = program
     const agents = healthData?.agents;
     const memories = healthData?.memories;
     const warnings: Array<{ level: string; message: string }> = Array.isArray(healthData?.warnings) ? healthData.warnings : [];
+    const hasWarn = warnings.some((w) => w.level === "warn");
+    const headerIcon = hasWarn ? "🟡" : "🟢";
+    const headerState = hasWarn ? "degraded" : "running";
 
-    console.log(`Flair v${__pkgVersion} — 🟢 running${pid ? ` (PID ${pid}` : ""}${uptimeStr ? `, uptime ${uptimeStr})` : pid ? ")" : ""}`);
+    console.log(`Flair v${__pkgVersion} — ${headerIcon} ${headerState}${pid ? ` (PID ${pid}` : ""}${uptimeStr ? `, uptime ${uptimeStr})` : pid ? ")" : ""}`);
     console.log(`  URL:        ${baseUrl}`);
 
     if (warnings.length > 0) {
@@ -2126,6 +2129,15 @@ const statusCmd = program
       const hashStr = memories.hashFallback > 0 ? `${memories.hashFallback} hash` : "";
       const detail = [embStr, hashStr].filter(Boolean).join(", ");
       console.log(`  Total:       ${memories.total}${detail ? ` (${detail})` : ""}`);
+      if (memories.modelCounts && typeof memories.modelCounts === "object") {
+        const entries = Object.entries(memories.modelCounts as Record<string, number>)
+          .filter(([, n]) => n > 0)
+          .sort((a, b) => b[1] - a[1]);
+        if (entries.length > 0) {
+          const formatted = entries.map(([k, n]) => `${k}: ${n}`).join(", ");
+          console.log(`  Embeddings:  ${formatted}`);
+        }
+      }
       if (memories.byDurability) {
         const d = memories.byDurability;
         console.log(`  Durability:  ${d.permanent ?? 0} permanent / ${d.persistent ?? 0} persistent / ${d.standard ?? 0} standard / ${d.ephemeral ?? 0} ephemeral`);
@@ -3175,10 +3187,48 @@ memory.command("search [query]").requiredOption("--agent <id>")
     if (opts.tag) body.tag = opts.tag;
     console.log(JSON.stringify(await api("POST", "/SemanticSearch", body), null, 2));
   });
-memory.command("list").requiredOption("--agent <id>").option("--tag <tag>")
+memory.command("list")
+  .requiredOption("--agent <id>")
+  .option("--tag <tag>")
+  .option("--hash-fallback", "Only memories with missing or hash-fallback embeddings (for backfill triage)")
+  .option("--limit <n>", "Max rows when using --hash-fallback", "50")
   .action(async (opts) => {
     const q = new URLSearchParams({ agentId: opts.agent, ...(opts.tag ? { tag: opts.tag } : {}) }).toString();
-    console.log(JSON.stringify(await api("GET", `/Memory?${q}`), null, 2));
+    const raw = await api("GET", `/Memory?${q}`);
+    if (!opts.hashFallback) {
+      console.log(JSON.stringify(raw, null, 2));
+      return;
+    }
+    // --hash-fallback: filter to entries without a real embedding and print as a table.
+    // Same predicate HealthDetail uses: missing model or the "hash-512d" marker.
+    const all: any[] = Array.isArray(raw) ? raw : (raw?.results ?? raw?.items ?? []);
+    const fallback = all.filter((m: any) => !m.embeddingModel || m.embeddingModel === "hash-512d");
+    if (fallback.length === 0) {
+      console.log(`No hash-fallback memories for agent ${opts.agent}. All embedded.`);
+      return;
+    }
+    const limit = Math.max(1, parseInt(opts.limit, 10) || 50);
+    const rows = fallback
+      .slice()
+      .sort((a: any, b: any) => {
+        const ta = a.createdAt ? new Date(a.createdAt).getTime() : 0;
+        const tb = b.createdAt ? new Date(b.createdAt).getTime() : 0;
+        return tb - ta;
+      })
+      .slice(0, limit);
+    const idW = Math.max(2, ...rows.map((r: any) => String(r.id ?? "").length));
+    console.log(`${fallback.length} hash-fallback memories for agent ${opts.agent} (showing ${rows.length}):\n`);
+    console.log(`  ${"id".padEnd(idW)}  created_at            preview`);
+    for (const r of rows) {
+      const created = r.createdAt ? String(r.createdAt).slice(0, 19).replace("T", " ") : "—".padEnd(19);
+      const preview = String(r.content ?? "").replace(/\s+/g, " ").slice(0, 80);
+      console.log(`  ${String(r.id ?? "").padEnd(idW)}  ${created}  ${preview}`);
+    }
+    if (fallback.length > rows.length) {
+      console.log(`\n... ${fallback.length - rows.length} more (raise with --limit). To backfill: flair reembed --agent ${opts.agent} --stale-only`);
+    } else {
+      console.log(`\nTo backfill: flair reembed --agent ${opts.agent} --stale-only`);
+    }
   });
 
 // ─── flair search (top-level shortcut) ───────────────────────────────────────


### PR DESCRIPTION
Closes `ops-n4n` (health tiering), `ops-zzt` (model distribution), and the inspection half of `ops-6qy`. All three were dogfood findings from today showing 139/431 (32%) hash-fallback on rockit while `flair status` still reported green.

## Changes

**`resources/health.ts`**
- Compute per-model counts; expose as `memories.modelCounts`.
- Hash-fallback warning threshold lowered to **10% of total** (was `hashFallback > withEmbeddings`, i.e. only fired above 50% — why 32% looked green).
- New warning when multiple non-hash embedding models are present — cross-model search returns garbage without any visible signal today.

**`src/cli.ts` — `status` command**
- Tier the header: 🟢 running / 🟡 degraded (any `warn`-level entry) / 🔴 unreachable. Previously always showed 🟢 when reachable regardless of warnings.
- Print an `Embeddings:` line breaking down by model name, sorted by count, e.g.:
  ```
  Embeddings:  bge-small-en-v1.5: 280, hash-512d: 139, nomic-embed-text-v1.5: 12
  ```

**`src/cli.ts` — `memory list`**
- New `--hash-fallback` flag + `--limit` (default 50). Filters to memories without a real embedding and prints a compact `id / created_at / preview` table plus a tail nudge to `flair reembed --stale-only` for triage before backfill.

## Threshold choices (open for Kern)

These are first-pass defaults. TPS mail sent to Kern on `ops-n4n`/`ops-zzt` for design review; willing to tune when he weighs in.

- **10% hash-fallback** = warn. Chosen to catch meaningful degradation without firing on transient embedder restarts / large imports.
- **>1 non-hash model** = warn. Hard-warn because cross-model search is silently broken — soft warn keeps broken behavior invisible.

No 🔴 tier for degraded state (reserved for unreachable). Kern may want a percentage where we escalate to red.

## Backwards compatibility

`memory.modelCounts` is a new field — absent on older HealthDetail responses, handled with an `if` in cli.ts. Existing `withEmbeddings` / `hashFallback` counts unchanged.

## Tests

- `bun test` passes (324 → 456 across all suites; the 2 Playwright admin-ui failures are the same pre-existing harness issue, unrelated).
- No new tests for the status-print formatting — it's pure string concat over typed data. The threshold + modelCount logic in `resources/health.ts` would benefit from dedicated tests; happy to add in a follow-up if reviewers prefer.

## Test plan

- [ ] `flair status` on rockit (139/431 hash-fallback): confirm 🟡 header, warning line printed, embeddings breakdown visible.
- [ ] `flair memory list --agent flint --hash-fallback` on rockit: confirm table output with triage nudge.
- [ ] `flair status --json`: confirm `memory.modelCounts` in the payload.
- [ ] Fresh install (0% hash-fallback): confirm 🟢 header, no embedding warning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)