### PR TITLE
fix(status): keep 'running' as header state word; decouple from health tier

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2233,10 +2233,13 @@ const statusCmd = program
     const memories = healthData?.memories;
     const warnings: Array<{ level: string; message: string }> = Array.isArray(healthData?.warnings) ? healthData.warnings : [];
     const hasWarn = warnings.some((w) => w.level === "warn");
+    // Header state-word stays "running" whenever the process is alive; the
+    // icon conveys health (🟢 clean / 🟡 warnings). 🔴 unreachable is already
+    // handled above by the `!healthy` early-exit. Decoupling state from
+    // health keeps the smoke-test `grep -q "running"` stable across tiers.
     const headerIcon = hasWarn ? "🟡" : "🟢";
-    const headerState = hasWarn ? "degraded" : "running";
 
-    console.log(`Flair v${__pkgVersion} — ${headerIcon} ${headerState}${pid ? ` (PID ${pid}` : ""}${uptimeStr ? `, uptime ${uptimeStr})` : pid ? ")" : ""}`);
+    console.log(`Flair v${__pkgVersion} — ${headerIcon} running${pid ? ` (PID ${pid}` : ""}${uptimeStr ? `, uptime ${uptimeStr})` : pid ? ")" : ""}`);
     console.log(`  URL:        ${baseUrl}`);
 
     if (warnings.length > 0) {


### PR DESCRIPTION
Fixes CI red on release PR #269. The 'Upgrade from npm-stable' smoke greps for 'running' to confirm the process is alive post-upgrade; PR #266 switched the header from '🟢 running' to '🟡 degraded' on any warning, breaking that grep.

Fix: process-state word stays 'running' whenever the process is alive; icon alone conveys health tier (🟢 clean / 🟡 warnings / 🔴 unreachable was already handled by the !healthy early-exit). Also the cleaner semantic split — 'running' = 'process is alive', icon + warnings = 'is it healthy'.

One-line fix, 321 tests pass. Blocks 0.6.0 release.