### PR TITLE
docs: CONTRIBUTING + docs/bridges + README mention (1.0 polish pass 1)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,100 @@
+# Contributing to Flair
+
+Thanks for your interest. Flair is open-source under Apache 2.0; contributions are welcome across code, docs, and bridges.
+
+## Quick orientation
+
+| You want to... | Start here |
+|----------------|------------|
+| Report a bug | [Open an issue](https://github.com/tpsdev-ai/flair/issues/new) — include `flair --version`, OS, and the steps to reproduce |
+| Propose a feature | Open a discussion or issue first; large PRs without prior alignment are hard to land |
+| Fix a typo or a doc rough edge | Just open a PR — no issue needed |
+| Write a new bridge | See [docs/bridges.md](docs/bridges.md) — scaffold with `flair bridge scaffold <name>` and publish as `flair-bridge-<name>` on npm |
+| Report a security issue | See [SECURITY.md](SECURITY.md) — **do not** open a public issue |
+
+## Local setup
+
+Flair is a Node.js monorepo with a single Harper v5 runtime and three published packages.
+
+```bash
+git clone https://github.com/tpsdev-ai/flair.git
+cd flair
+npm install
+npm run build && npm run build:cli
+```
+
+Run the test suite:
+
+```bash
+bun test                  # unit + integration; no external services needed
+bun test test/unit        # faster — unit only
+bun test test/integration # slower — exercises Harper lifecycle
+```
+
+Playwright e2e tests live under `test/e2e/` and run separately (`npm run test:e2e`). They're not required for most PRs; the `bun test` suite covers the main paths.
+
+Run the CLI against a local Flair instance:
+
+```bash
+./dist/cli.js --help
+./dist/cli.js init --data-dir /tmp/flair-dev --port 19926
+./dist/cli.js status --port 19926
+```
+
+## PR expectations
+
+Flair's main branch is protected. Landing a change means:
+
+1. **CI green.** Unit tests, integration tests, type-check, Semgrep SAST, and install-from-tarball smoke all pass.
+2. **Reviewed.** Each PR gets one architecture review and one security review. Both must approve.
+3. **Squash-merged.** Clean history; the PR body becomes the commit message.
+
+Before opening a PR:
+
+- Match the existing code style. We don't run a formatter; follow the surrounding conventions.
+- Keep commits logically grouped. A PR with one focused change is easier to review than a PR with eight unrelated ones.
+- Add tests for any new behavior. Unit tests live in `test/unit/`, integration tests in `test/integration/`.
+- Update [CHANGELOG.md](CHANGELOG.md) under `## Unreleased` if the change is user-visible.
+- Reference a bead or issue in the PR body when one exists.
+
+## What to avoid
+
+- **Breaking the memory record schema.** The fields listed in `src/bridges/types.ts` under `FLAIR_RESERVED_FIELDS` are computed by Flair on ingest; adding new reserved fields or changing existing ones is an architectural change that needs a design-review conversation first.
+- **Vendor lock-in.** Flair is model-agnostic and runtime-agnostic. Don't introduce hard dependencies on a specific LLM vendor, cloud provider, or agent framework. Compose with them, don't couple to them.
+- **Silent behavior changes.** If a release changes what an existing flag or command does, call it out in CHANGELOG and in the PR body.
+
+## Bridges
+
+Bridges are the easiest way to contribute — they extend Flair to new ecosystems without touching core code.
+
+Two shapes:
+
+- **File (YAML descriptor)** — no TypeScript required; declare the mapping from a foreign file format to the Flair memory schema.
+- **API (code plugin)** — for foreign systems with HTTP APIs. Ship as `flair-bridge-<name>` on npm.
+
+Start with:
+
+```bash
+flair bridge scaffold my-system --file   # or --api
+flair bridge list                        # confirm it's discovered
+# edit the descriptor + fixture, then:
+flair bridge test my-system              # round-trip diff
+```
+
+Full contract in [docs/bridges.md](docs/bridges.md) and the spec at [specs/FLAIR-BRIDGES.md](specs/FLAIR-BRIDGES.md). The round-trip test is the signal — if it passes, the bridge is ready.
+
+## Releases
+
+Releases are two-phase and driven by `scripts/release.sh`:
+
+```bash
+./scripts/release.sh 0.7.0           # Phase 1: bumps, builds, opens release PR
+# ... review and merge the PR on GitHub ...
+./scripts/release.sh 0.7.0 --publish  # Phase 2: publishes to npm, tags, pushes tag
+```
+
+Update `CHANGELOG.md` to promote `## Unreleased` to the new version before running phase 2.
+
+## Questions
+
+Open a discussion or issue. Flair is small enough that every question is welcome — "is this the right pattern?" is a better PR comment than a follow-up bug.

--- a/README.md
+++ b/README.md
@@ -94,6 +94,9 @@ Context-signal-aware preloading. Bootstrap reads active project context, recent 
 ### Auto Entity Detection
 Passive extraction of entities from memory content on write. Entities are indexed automatically — no tagging required. Feeds the relationship graph without agent intervention.
 
+### Memory Bridges
+Pluggable import/export to foreign memory systems. Every agent-memory format (agentic-stack, Mem0, Letta, Anthropic memory, the next viral one) shouldn't need its own Flair PR. Bridges give you one contract with two shapes — a YAML descriptor for file-format targets or a code plugin for API targets — and a scaffold/test loop that lets an agent ship a working adapter in one pass. See [docs/bridges.md](docs/bridges.md).
+
 ## Quick Start
 
 ### Prerequisites

--- a/docs/bridges.md
+++ b/docs/bridges.md
@@ -1,0 +1,262 @@
+# Memory Bridges
+
+> Pluggable import/export between Flair and foreign memory systems.
+
+Flair stores memories in its own schema. The rest of the agent ecosystem stores memories too — agentic-stack's `.agent/` directory, Mem0, Letta, Zep, Anthropic memory, and more every week. **Bridges** let Flair speak those formats without a core-code change per integration.
+
+The design goal is *agent-authorable first*: a capable agent should be able to ship a working bridge by reading this doc and running one command.
+
+## Two shapes
+
+| Shape | When to use | Artifact |
+|-------|-------------|----------|
+| **File** (YAML descriptor) | Foreign system stores memories as files on disk (`.agent/`, JSONL, Markdown) | `.flair-bridge/<name>.yaml` in a project, or `~/.flair/bridges/<name>.yaml` user-wide |
+| **API** (TypeScript plugin) | Foreign system exposes an HTTP API (Mem0, Letta, Zep, Anthropic memory) | npm package named `flair-bridge-<name>` |
+
+Pick one. The runtime normalizes both into the same memory-record shape before import.
+
+## The memory record
+
+Every bridge deals in `BridgeMemory` objects. Fields:
+
+```ts
+interface BridgeMemory {
+  // Identity
+  id?: string              // Flair ID if round-tripping; omit on first import
+  foreignId?: string       // original ID in the foreign system (preserved)
+
+  // Content
+  content: string          // REQUIRED
+  subject?: string
+  tags?: string[]
+  visibility?: "private" | "shared" | "public"
+
+  // Durability & lifecycle
+  durability?: "ephemeral" | "standard" | "persistent" | "permanent"
+  createdAt?: string       // ISO-8601; defaults to now on import
+  validFrom?: string
+  validTo?: string
+  expiresAt?: string
+
+  // Ownership
+  agentId?: string         // required on import unless --agent is passed
+
+  // Provenance
+  source?: string
+  derivedFrom?: string[]
+}
+```
+
+**Required on import:** `content` and (`agentId` or the `--agent` flag).
+
+**Flair-owned, never set by a bridge:** `contentHash`, `embedding`, `embeddingModel`, `retrievalCount`, `lastRetrieved`, `promotionStatus`, `_safetyFlags`, any `*By` audit field. These are computed on ingest; if a bridge emits them they're ignored.
+
+## Commands
+
+```bash
+flair bridge list                           # installed bridges
+flair bridge scaffold <name> [--file|--api] # emit starter files
+flair bridge test <name> [--fixture <path>] # round-trip diff (coming soon)
+flair bridge import <name> <src> [opts]     # foreign → Flair (coming soon)
+flair bridge export <name> <dst> [opts]     # Flair → foreign (coming soon)
+```
+
+Slice 1 of FLAIR-BRIDGES ships `list` and `scaffold`; the runtime commands (`test`, `import`, `export`) land in the next slice. Scaffold lets you author a working bridge *today* and confirm discovery; execution comes in the next release.
+
+Common runtime options (for the slice-2 commands):
+
+| Flag | Meaning |
+|------|---------|
+| `--agent <id>` | Scope to one agent (default: all agents visible to caller) |
+| `--subject <subj>` | Filter by subject tag |
+| `--since <iso>` | `validFrom >= this timestamp` |
+| `--durability <tier>` | Only `ephemeral` / `standard` / `persistent` / `permanent` |
+| `--dry-run` | Parse + validate, no writes |
+| `--allow-remote` | Required for bridges that hit a remote API |
+
+## Shape A — Declarative YAML
+
+For bridges whose source or target is a directory of files, write a YAML descriptor. No code required.
+
+```yaml
+# .flair-bridge/agentic-stack.yaml
+name: agentic-stack
+version: 1
+kind: file
+description: "agentic-stack .agent/memory/semantic/lessons.jsonl"
+
+detect:
+  anyExists:
+    - ".agent/AGENTS.md"
+    - ".agent/memory/semantic/lessons.jsonl"
+
+import:
+  sources:
+    - path: ".agent/memory/semantic/lessons.jsonl"
+      format: jsonl
+      map:
+        content: "$.claim"
+        subject: "$.topic"
+        tags: "$.tags"
+        foreignId: "$.id"
+        durability: "persistent"
+        source: "agentic-stack/lessons"
+
+export:
+  targets:
+    - path: ".agent/memory/semantic/lessons.jsonl"
+      format: jsonl
+      when: "durability in ['persistent', 'permanent']"
+      map:
+        id: "foreignId ?? id"
+        claim: "content"
+        topic: "subject"
+        tags: "tags"
+```
+
+- **Path expressions:** JSONPath subset — `$.field`, `$.nested.field`, `$.array[*]`.
+- **`when:`** boolean expression over `BridgeMemory` fields. Omit for "always".
+- **Formats supported in 1.0:** `jsonl`, `json`, `yaml`, `markdown-frontmatter`.
+- **What the runtime gives you:** file discovery, format parsing, schema validation, error reporting with `line:column`. You only describe the mapping.
+
+## Shape B — Code plugin
+
+For bridges that talk to HTTP APIs:
+
+```ts
+// flair-bridge-mem0/index.ts
+import type { MemoryBridge, BridgeMemory, BridgeContext } from "@tpsdev-ai/flair";
+
+export const bridge: MemoryBridge = {
+  name: "mem0",
+  version: 1,
+  kind: "api",
+
+  options: {
+    apiKey:  { env: "MEM0_API_KEY", required: true, description: "Mem0 API token" },
+    userId:  { required: true, description: "Mem0 user ID" },
+    baseUrl: { default: "https://api.mem0.ai" },
+  },
+
+  async *import(opts, ctx: BridgeContext) {
+    const res = await ctx.fetch(`${opts.baseUrl}/v1/memories/?user_id=${opts.userId}`, {
+      headers: { Authorization: `Token ${opts.apiKey}` },
+    });
+    const payload = await res.json();
+    for (const m of payload.results ?? []) {
+      yield {
+        foreignId: String(m.id),
+        content: String(m.memory),
+        createdAt: m.created_at,
+        tags: m.categories,
+        source: "mem0",
+      };
+    }
+  },
+
+  async export(memories, opts, ctx) {
+    for await (const m of memories) {
+      await ctx.fetch(`${opts.baseUrl}/v1/memories/`, {
+        method: "POST",
+        headers: { Authorization: `Token ${opts.apiKey}` },
+        body: JSON.stringify({
+          messages: [{ role: "user", content: m.content }],
+          user_id: opts.userId,
+        }),
+      });
+    }
+  },
+};
+```
+
+**`BridgeContext`** gives you:
+
+- `ctx.fetch` — instrumented, rate-limited HTTP. **Always use this instead of the global `fetch`** — it's how the runtime applies per-bridge throttling and audit logging.
+- `ctx.log` — structured `{debug, info, warn, error}` logger.
+- `ctx.cache` — per-bridge key/value cache with optional TTL. Useful for pagination cursors, auth refresh, etc.
+
+Code plugins have no direct filesystem or network access outside `ctx`. This keeps the surface area small and auditable.
+
+## Discovery
+
+`flair bridge list` scans, in precedence order:
+
+1. **Built-ins** shipped inside `@tpsdev-ai/flair`
+2. **Project YAML** — `.flair-bridge/*.yaml` in the current working directory
+3. **User YAML** — `~/.flair/bridges/*.yaml`
+4. **npm packages** — anything matching `flair-bridge-*` or `@scope/flair-bridge-*` under `node_modules/`
+
+Earlier sources win on name conflict. So a built-in adapter can't be accidentally shadowed by a same-named npm package, but a project-local YAML *can* intentionally override an npm bridge for local development.
+
+## Distribution
+
+Publish bridges to npm as `flair-bridge-<name>`. Example `package.json`:
+
+```json
+{
+  "name": "flair-bridge-mem0",
+  "version": "0.1.0",
+  "description": "Flair bridge for Mem0",
+  "main": "index.js",
+  "flair": { "kind": "api", "version": 1 },
+  "peerDependencies": { "@tpsdev-ai/flair": ">=0.6.0" }
+}
+```
+
+There's no registry to curate; npm is the registry. `flair bridge list` surfaces everything installed.
+
+## Round-trip testing
+
+Every bridge ships a fixture. `flair bridge test <name>` will run (slice 2):
+
+1. Import the fixture → `BridgeMemory[]`
+2. Export those memories to a tmp target
+3. Re-import the tmp target → `BridgeMemory[]`
+4. Structural diff on the round-trip-stable fields: `content`, `subject`, `tags`, `durability`
+5. Pass iff the diff is empty
+
+Pass = ship. Iterate against this signal.
+
+## Trust and security
+
+Different sources have different blast radii.
+
+| Source | Default trust |
+|--------|---------------|
+| Built-in | Allowed |
+| Declarative YAML (no code) | Allowed; remote API calls require `--allow-remote` at invocation |
+| Code plugin from npm | Requires `flair bridge allow <name>` on first use |
+| Remote API calls | Always require `--allow-remote` on the invocation |
+
+A code plugin is untrusted JavaScript. The explicit `allow` gate keeps an unreviewed npm package from executing on your machine the first time `flair bridge import` names it. VM isolation is a 1.1 hardening pass.
+
+## Error format
+
+Every bridge error is structured:
+
+```json
+{
+  "bridge": "agentic-stack",
+  "op": "import",
+  "path": ".agent/memory/semantic/lessons.jsonl",
+  "record": 42,
+  "field": "$.claim",
+  "expected": "string",
+  "got": "null",
+  "hint": "lessons.jsonl row 42 has no 'claim' field — skipped"
+}
+```
+
+Printed as a single JSON object per line when `--json`; human-formatted otherwise. Field paths, expected/got, and a hint — that's the minimum an LLM needs to self-correct without operator help.
+
+## Writing your own — the prompt
+
+If you want an agent to write a bridge for you, here's the one-shot prompt:
+
+> You are implementing a Flair bridge for **\<FOREIGN_SYSTEM\>**. Read the sections above on the memory record, on Shape A (file-format targets) or Shape B (API targets) depending on \<FOREIGN_SYSTEM\>, and on round-trip testing. Produce either `.flair-bridge/<name>.yaml` (file targets) or an `index.ts` implementing `MemoryBridge` (API targets). Include a fixture at `fixtures/<name>.fixture.json` or `fixtures/<name>.mock.json`. Run `flair bridge test <name>` and iterate until the round-trip diff is empty.
+
+That's the bar. If an agent can't ship a working bridge from this doc plus the scaffold, the doc is the bug.
+
+## Full spec
+
+The authoritative contract is in [`specs/FLAIR-BRIDGES.md`](../specs/FLAIR-BRIDGES.md). This doc is the user-facing view; the spec covers edge cases, future extensions, and design rationale.


### PR DESCRIPTION
First of what I expect to be several docs/repo polish PRs on the road to 1.0. Nathan flagged today that 1.0 needs experience-first polish, not just feature completeness — this is me starting on that.

## What ships

**`CONTRIBUTING.md` (new)** — the repo didn't have one. Covers:
- Entry points by audience (bug report, feature proposal, doc fix, new bridge, security issue)
- Local setup + test commands + running the CLI against a dev port
- PR expectations (CI green, arch + security review, squash merge)
- "What to avoid" (schema stability, no vendor lock-in, no silent behavior changes)
- Two-phase release process

**`docs/bridges.md` (new)** — user-facing guide for the memory-bridges feature shipped in 0.6.0. The spec at `specs/FLAIR-BRIDGES.md` is the authoritative contract; this doc is the user-facing view. Covers shapes, memory record, commands, discovery precedence, round-trip testing, trust model, error format. Includes a one-shot prompt an agent can use to write a bridge from this doc alone.

**`README.md`** — intentionally small edit. Adds Memory Bridges to the Features list with a link to the new doc. Didn't balloon the README with every 0.6.0 surface — status tiering and first-run wizard are visible through `flair --help` and covered in CHANGELOG.

## Relationship to open PRs

Independent of #269 (release PR) and #270 (status-header CI fix). No code changes in this PR. Can merge any time, in any order relative to the release.

## Next polish PRs likely to follow

- CHANGELOG: promote `## Unreleased` to `## 0.6.0` with today's features
- Quick-start doc: "five minutes from install to first memory write"
- `docs/upgrade.md` refresh for 0.5.x → 0.6.0
- `docs/troubleshooting.md` refresh for new `flair doctor` scenarios

## Test plan

- [ ] Render README on GitHub — confirm the new bullet and link work
- [ ] Render `docs/bridges.md` on GitHub — check code-fence syntax highlighting
- [ ] CONTRIBUTING.md opens from the repo landing page via the 'Contributing' affordance

🤖 Generated with [Claude Code](https://claude.com/claude-code)