### PR TITLE
docs(upgrade): 0.5.x → 0.6.0 section + freshen rollback example

### DIFF
--- a/docs/upgrade.md
+++ b/docs/upgrade.md
@@ -1,5 +1,21 @@
 # Upgrade Guide
 
+## Upgrading to 0.6.0 (from 0.5.x)
+
+### Behavior changes to know about
+
+- **`flair init --skip-soul` and non-TTY init no longer seed placeholder soul entries.** Pre-0.6.0 those paths inserted generic `role` / `personality` / `constraints` strings (e.g. `"AI assistant [default — customize with 'flair soul set']"`). Those entries leaked into `flair bootstrap` output and confused users, so 0.6.0 leaves the soul empty for non-interactive installs. `flair doctor` and `flair soul set` are the nudge/workflow for populating real entries. **If you're upgrading an existing agent**: your previously-seeded placeholder entries are still there and won't be auto-removed. Run `flair soul list --agent <id>` to check; `flair soul delete` if you want them gone.
+
+- **`flair status` header now tiers health.** 🟢 means healthy; 🟡 means the process is running but something's worth looking at (e.g. >10% of your memories are hash-fallback); 🔴 still means unreachable. The state word stays `"running"` for 🟢 and 🟡 — only the icon changes. Any `grep -q "running"` scripts you have against `flair status` output continue to work; scripts that checked for 🟢 specifically should switch to `grep -q "🟢"` or treat 🟡 as also healthy.
+
+### New surfaces in 0.6.0
+
+- **`flair status`** now shows an `Embeddings:` line breaking down memories by embedding model — useful for catching mixed vector spaces after an upstream model change.
+- **`flair memory list --hash-fallback`** lists memories that lack a real embedding. Feeds a cleaner triage workflow when paired with `flair reembed --stale-only`.
+- **Per-agent columns in `flair status`** — new `hash_fb` and `24h` columns show which agents are carrying the embedding-coverage burden and which are actively writing.
+- **`flair bridge list` / `flair bridge scaffold`** — slice 1 of the memory-bridges plugin system. Runtime (`import`/`export`/`test`) lands in the next release. See [bridges.md](bridges.md).
+- **Revamped `flair init` first-run wizard** — template picker with (1) Solo developer / (2) Team agent / (3) Research assistant / (4) Draft from Claude / (5) Custom / (s) Skip. Only affects fresh installs.
+
 ## Standard Upgrade
 
 ```bash
@@ -58,8 +74,8 @@ Then restart Claude Code to pick up the new version. No config changes needed �
 If an upgrade causes issues:
 
 ```bash
-# Install the previous version
-npm install -g @tpsdev-ai/flair@0.4.16
+# Install a specific previous version (substitute your last known-good)
+npm install -g @tpsdev-ai/flair@0.5.6
 
 # Restart
 flair restart
@@ -67,3 +83,5 @@ flair restart
 # If data is corrupted, restore from backup
 flair restore < ~/flair-backup-20260405.json
 ```
+
+Data written by a newer Flair is readable by the immediate predecessor — there are no schema breaks within the 0.5.x → 0.6.x window. Downgrading further back than one minor version is unsupported; use the backup path instead.


### PR DESCRIPTION
Third docs polish PR in today's 1.0-polish pass (after #271 CONTRIBUTING/bridges and #273 quickstart). Refreshes `docs/upgrade.md` for the 0.6.0 upgrade path.

## What changes

**New section at top — 'Upgrading to 0.6.0 (from 0.5.x)':**
- **Behavior changes an upgrader needs to know.** Two: `--skip-soul` / non-TTY no longer seeds placeholder soul entries (existing placeholder entries won't auto-remove — recipe provided). Status header now tiers (🟢 / 🟡 / 🔴) but the state word stays `running` across healthy tiers, so `grep -q 'running'` scripts continue to work.
- **New surfaces in 0.6.0.** Embeddings breakdown in status, `memory list --hash-fallback` inspector, per-agent `hash_fb` + `24h` columns, `flair bridge list` / `scaffold`, and the revamped `flair init` wizard.

**Freshened rollback example.** Was pinned to `0.4.16`; updated to `0.5.6` and added an honest caveat that downgrading more than one minor version is unsupported — use the backup path.

## Relationship to open PRs

- Independent of #272 (CHANGELOG) and #273 (quickstart). No code change. Docs-only.
- Release PR #269 already merged; main is at v0.6.0 awaiting Nathan's manual `npm publish`.

## Test plan

- [ ] Render on GitHub — confirm section headings, code fences, emoji all display
- [ ] Verify the 'existing placeholder soul entries won't auto-remove' recipe works against a rockit install that has the old defaults
- [ ] Cross-check that the 🟢/🟡 description matches what #266 actually ships

🤖 Generated with [Claude Code](https://claude.com/claude-code)