### PR TITLE
feat(bridges): slice 3a — export path (Shape A YAML)

### DIFF
--- a/src/bridges/builtins/agentic-stack.ts
+++ b/src/bridges/builtins/agentic-stack.ts
@@ -40,4 +40,22 @@ export const agenticStackDescriptor: YamlBridgeDescriptor = {
       },
     }],
   },
+  export: {
+    targets: [{
+      path: ".agent/memory/semantic/lessons.jsonl",
+      format: "jsonl",
+      // Only export memories durable enough to be worth round-tripping back
+      // into agentic-stack. ephemeral / standard scratch memory stays in Flair.
+      when: "durability in ['persistent', 'permanent']",
+      map: {
+        // Preserve the foreign id when round-tripping; if the memory was
+        // Flair-native it'll just be missing from the output (and import-side
+        // generates a new id on first import anyway).
+        id: "$.foreignId",
+        claim: "$.content",
+        topic: "$.subject",
+        tags: "$.tags[*]",
+      },
+    }],
+  },
 };

--- a/src/bridges/runtime/export-runner.ts
+++ b/src/bridges/runtime/export-runner.ts
@@ -1,0 +1,153 @@
+/**
+ * Export runner — drives a YAML descriptor's `export` block.
+ *
+ * Reads memories from Flair (via an injected fetcher), filters them
+ * through the descriptor's `when:` predicate when present, applies the
+ * `map:` to produce shaped output records, and writes to the target via
+ * the format writer.
+ *
+ * Slice 3a supports Shape A (YAML descriptors) and the jsonl/json
+ * formats. Markdown-frontmatter and code-plugin (Shape B) export land
+ * in slice 3b/3c.
+ *
+ * As with import-runner, the Flair I/O is injected so the runner stays
+ * unit-testable without spinning up a real Flair instance.
+ */
+
+import { isAbsolute, join } from "node:path";
+import type {
+  BridgeMemory,
+  YamlBridgeDescriptor,
+  BridgeContext,
+} from "../types.js";
+import { BridgeRuntimeError } from "../types.js";
+import { applyMap } from "./mapper.js";
+import { evaluatePredicate } from "./predicate.js";
+import { writeRecords } from "./writers.js";
+
+export interface ExportRunOptions {
+  descriptor: YamlBridgeDescriptor;
+  /** Filesystem root the descriptor's relative target paths resolve against. */
+  cwd: string;
+  /** Where the records come from. Receives the descriptor name + caller-passed filters. */
+  fetchMemories: (filters: ExportFilters) => AsyncIterable<BridgeMemory>;
+  /** Forwarded to `fetchMemories` and downstream telemetry. */
+  filters?: ExportFilters;
+  dryRun?: boolean;
+  ctx?: BridgeContext;
+  onProgress?: (event: ProgressEvent) => void;
+}
+
+export interface ExportFilters {
+  agentId?: string;
+  subject?: string;
+  durability?: BridgeMemory["durability"];
+  /** Matches the descriptor's `source:` tag — most useful for round-tripping a single bridge's own data. */
+  source?: string;
+  /** validFrom >= this timestamp */
+  since?: string;
+}
+
+export type ProgressEvent =
+  | { type: "target-write"; path: string; written: number }
+  | { type: "target-skipped"; path: string; reason: string }
+  | { type: "memory-skipped"; ordinal: number; reason: string }
+  | { type: "done"; total: number; exported: number };
+
+export interface ExportRunResult {
+  total: number;
+  exported: number;
+  perTarget: Array<{ path: string; written: number }>;
+}
+
+export async function runExport(opts: ExportRunOptions): Promise<ExportRunResult> {
+  if (!opts.descriptor.export) {
+    throw new BridgeRuntimeError({
+      bridge: opts.descriptor.name,
+      op: "export",
+      field: "export",
+      expected: "object with targets",
+      got: "missing",
+      hint: "descriptor has no `export` block — run `flair bridge import` instead, or add one",
+    });
+  }
+
+  const onProgress = opts.onProgress ?? (() => {});
+  const perTarget: ExportRunResult["perTarget"] = [];
+  let total = 0;
+  let exported = 0;
+
+  // Pull all memories once and reuse across targets — typical case is a
+  // single target. If a descriptor has multiple targets each with its own
+  // when:, re-fetching per target would surprise the operator with N×
+  // backend calls.
+  const memories: BridgeMemory[] = [];
+  for await (const m of opts.fetchMemories(opts.filters ?? {})) {
+    memories.push(m);
+    total++;
+  }
+
+  for (let tIdx = 0; tIdx < opts.descriptor.export.targets.length; tIdx++) {
+    const target = opts.descriptor.export.targets[tIdx];
+    const resolvedPath = isAbsolute(target.path) ? target.path : join(opts.cwd, target.path);
+
+    // Apply when: filter
+    const passing: BridgeMemory[] = [];
+    if (target.when && target.when.trim()) {
+      let unparsableSeen = false;
+      for (let i = 0; i < memories.length; i++) {
+        const result = evaluatePredicate(target.when, memories[i] as unknown as Record<string, unknown>);
+        if (result === "unparsable") {
+          if (!unparsableSeen) {
+            unparsableSeen = true;
+            opts.ctx?.log.warn(`when: clause unparsable, including all records for this target`, {
+              when: target.when,
+              targetPath: resolvedPath,
+            });
+          }
+          passing.push(memories[i]);
+        } else if (result === "match") {
+          passing.push(memories[i]);
+        } else {
+          onProgress({ type: "memory-skipped", ordinal: i + 1, reason: `when: ${target.when}` });
+        }
+      }
+    } else {
+      passing.push(...memories);
+    }
+
+    // Apply map: to each surviving memory
+    const shaped: Record<string, unknown>[] = [];
+    for (let i = 0; i < passing.length; i++) {
+      const out = applyMap(target.map, passing[i] as unknown as Record<string, unknown>);
+      // The ONLY hard requirement on output is that the map produced at
+      // least one field — empty mappings would produce empty JSONL lines
+      // which are technically valid but suspicious. Skip them with a hint.
+      if (Object.keys(out).length === 0) {
+        onProgress({ type: "memory-skipped", ordinal: i + 1, reason: "map produced no fields" });
+        continue;
+      }
+      shaped.push(out);
+    }
+
+    if (opts.dryRun) {
+      onProgress({ type: "target-skipped", path: resolvedPath, reason: "--dry-run" });
+      perTarget.push({ path: resolvedPath, written: 0 });
+      continue;
+    }
+
+    opts.ctx?.log.info(`exporting target`, {
+      target: target.path,
+      format: target.format,
+      records: shaped.length,
+    });
+
+    const { written } = await writeRecords(opts.descriptor.name, resolvedPath, target.format, shaped);
+    perTarget.push({ path: resolvedPath, written });
+    exported += written;
+    onProgress({ type: "target-write", path: resolvedPath, written });
+  }
+
+  onProgress({ type: "done", total, exported });
+  return { total, exported, perTarget };
+}

--- a/src/bridges/runtime/predicate.ts
+++ b/src/bridges/runtime/predicate.ts
@@ -1,0 +1,114 @@
+/**
+ * Tiny predicate evaluator for the YAML descriptor's `when:` clause.
+ *
+ * Slice 3a supports a deliberately small subset:
+ *
+ *   <field> in [<literal>, <literal>, ...]
+ *   <field> == <literal>
+ *   <field> != <literal>
+ *
+ * Where `<field>` is a `BridgeMemory`-shaped property name and `<literal>`
+ * is a single-quoted or double-quoted string, a bare identifier (treated
+ * as string), or a number/boolean. No nested expressions, no `&&`/`||`,
+ * no parenthesization.
+ *
+ * Slice 3b will widen this to a real mini-grammar (probably JMESPath or
+ * CEL or hand-rolled boolean operators). For now the goal is just to
+ * support the agentic-stack reference adapter's
+ *   when: "durability in ['persistent', 'permanent']"
+ * cleanly without pulling in a dep.
+ *
+ * Returns null on unparsable input — caller decides whether to default
+ * to true (always-export) or hard-fail.
+ */
+
+export type PredicateResult = "match" | "no-match" | "unparsable";
+
+const FIELD_RE = /^([a-zA-Z_][a-zA-Z0-9_]*)\s+(in|==|!=)\s+(.+)$/;
+
+export function evaluatePredicate(
+  expression: string,
+  record: Record<string, unknown>,
+): PredicateResult {
+  const trimmed = expression.trim();
+  if (!trimmed) return "match"; // empty = always match
+
+  const m = trimmed.match(FIELD_RE);
+  if (!m) return "unparsable";
+  const [, field, op, rhsRaw] = m;
+
+  const lhs = record[field];
+
+  if (op === "in") {
+    const list = parseList(rhsRaw);
+    if (list === null) return "unparsable";
+    return list.some((v) => v === lhs) ? "match" : "no-match";
+  }
+  if (op === "==" || op === "!=") {
+    const rhs = parseLiteral(rhsRaw.trim());
+    if (rhs === undefined) return "unparsable";
+    const eq = lhs === rhs;
+    return (op === "==" ? eq : !eq) ? "match" : "no-match";
+  }
+  return "unparsable";
+}
+
+function parseList(raw: string): unknown[] | null {
+  const trimmed = raw.trim();
+  if (!trimmed.startsWith("[") || !trimmed.endsWith("]")) return null;
+  const inner = trimmed.slice(1, -1).trim();
+  if (!inner) return [];
+  // Split on commas, ignoring commas inside quoted strings. Slice 3a's
+  // grammar doesn't allow quoted commas anyway; keep this naive.
+  const parts = splitCsvRespectingQuotes(inner);
+  const out: unknown[] = [];
+  for (const p of parts) {
+    const lit = parseLiteral(p.trim());
+    if (lit === undefined) return null;
+    out.push(lit);
+  }
+  return out;
+}
+
+function parseLiteral(raw: string): unknown {
+  if (raw === "") return undefined;
+  // Quoted string: single or double
+  if ((raw.startsWith("'") && raw.endsWith("'")) || (raw.startsWith('"') && raw.endsWith('"'))) {
+    return raw.slice(1, -1);
+  }
+  // Boolean / null
+  if (raw === "true") return true;
+  if (raw === "false") return false;
+  if (raw === "null") return null;
+  // Number
+  if (/^-?\d+(\.\d+)?$/.test(raw)) return Number(raw);
+  // Bare identifier — treat as string. Allows: in [persistent, permanent]
+  if (/^[a-zA-Z_][a-zA-Z0-9_-]*$/.test(raw)) return raw;
+  return undefined;
+}
+
+function splitCsvRespectingQuotes(s: string): string[] {
+  const out: string[] = [];
+  let depth = 0;
+  let buf = "";
+  let inQuote: '"' | "'" | null = null;
+  for (let i = 0; i < s.length; i++) {
+    const c = s[i];
+    if (inQuote) {
+      buf += c;
+      if (c === inQuote) inQuote = null;
+      continue;
+    }
+    if (c === '"' || c === "'") { inQuote = c; buf += c; continue; }
+    if (c === "[" || c === "(") depth++;
+    if (c === "]" || c === ")") depth--;
+    if (c === "," && depth === 0) {
+      out.push(buf);
+      buf = "";
+      continue;
+    }
+    buf += c;
+  }
+  if (buf.length > 0) out.push(buf);
+  return out;
+}

--- a/src/bridges/runtime/writers.ts
+++ b/src/bridges/runtime/writers.ts
@@ -1,0 +1,147 @@
+/**
+ * Output writers for export targets. Slice 3a ships `jsonl` and `json`.
+ * `yaml` and `markdown-frontmatter` land with slice 3b alongside any
+ * built-in that needs them.
+ *
+ * Each writer takes a stream of "shaped output records" (whatever the
+ * descriptor's `map:` produced) and writes to a target file path.
+ * Atomic via tmp-file + rename, so a crash mid-write doesn't leave a
+ * half-written target.
+ */
+
+import { promises as fsp } from "node:fs";
+import { dirname, basename } from "node:path";
+import { randomUUID } from "node:crypto";
+import yaml from "js-yaml";
+import type { YamlFormat } from "../types.js";
+import { BridgeRuntimeError } from "../types.js";
+
+export async function writeRecords(
+  bridge: string,
+  path: string,
+  format: YamlFormat,
+  records: Iterable<Record<string, unknown>>,
+): Promise<{ written: number }> {
+  switch (format) {
+    case "jsonl": return writeJsonl(bridge, path, records);
+    case "json":  return writeJson(bridge, path, records);
+    case "yaml":  return writeYaml(bridge, path, records);
+    case "markdown-frontmatter":
+      throw new BridgeRuntimeError({
+        bridge,
+        op: "export",
+        path,
+        field: "format",
+        expected: "jsonl | json | yaml",
+        got: "markdown-frontmatter",
+        hint: "markdown-frontmatter writer lands in slice 3b along with its reference adapter",
+      });
+  }
+}
+
+async function writeJsonl(
+  bridge: string,
+  path: string,
+  records: Iterable<Record<string, unknown>>,
+): Promise<{ written: number }> {
+  const tmpPath = await stageTmp(bridge, path, "export");
+  let written = 0;
+  try {
+    const fh = await fsp.open(tmpPath, "w");
+    try {
+      for (const r of records) {
+        await fh.write(JSON.stringify(r) + "\n");
+        written++;
+      }
+    } finally {
+      await fh.close();
+    }
+    await fsp.rename(tmpPath, path);
+  } catch (err: any) {
+    await fsp.unlink(tmpPath).catch(() => {});
+    throw new BridgeRuntimeError({
+      bridge,
+      op: "export",
+      path,
+      field: "(write)",
+      expected: "successful write",
+      got: err?.message ?? String(err),
+      hint: `failed writing to ${path}: ${err?.message ?? err}`,
+    });
+  }
+  return { written };
+}
+
+async function writeJson(
+  bridge: string,
+  path: string,
+  records: Iterable<Record<string, unknown>>,
+): Promise<{ written: number }> {
+  const arr: Record<string, unknown>[] = [];
+  for (const r of records) arr.push(r);
+  const tmpPath = await stageTmp(bridge, path, "export");
+  try {
+    await fsp.writeFile(tmpPath, JSON.stringify(arr, null, 2));
+    await fsp.rename(tmpPath, path);
+  } catch (err: any) {
+    await fsp.unlink(tmpPath).catch(() => {});
+    throw new BridgeRuntimeError({
+      bridge,
+      op: "export",
+      path,
+      field: "(write)",
+      expected: "successful write",
+      got: err?.message ?? String(err),
+      hint: `failed writing to ${path}: ${err?.message ?? err}`,
+    });
+  }
+  return { written: arr.length };
+}
+
+async function writeYaml(
+  bridge: string,
+  path: string,
+  records: Iterable<Record<string, unknown>>,
+): Promise<{ written: number }> {
+  const arr: Record<string, unknown>[] = [];
+  for (const r of records) arr.push(r);
+  const tmpPath = await stageTmp(bridge, path, "export");
+  try {
+    await fsp.writeFile(tmpPath, yaml.dump(arr));
+    await fsp.rename(tmpPath, path);
+  } catch (err: any) {
+    await fsp.unlink(tmpPath).catch(() => {});
+    throw new BridgeRuntimeError({
+      bridge,
+      op: "export",
+      path,
+      field: "(write)",
+      expected: "successful write",
+      got: err?.message ?? String(err),
+      hint: `failed writing to ${path}: ${err?.message ?? err}`,
+    });
+  }
+  return { written: arr.length };
+}
+
+/**
+ * Allocate a sibling temp file in the same directory as `targetPath`.
+ * Same-fs rename is atomic on POSIX; using a sibling guarantees that.
+ */
+async function stageTmp(bridge: string, targetPath: string, op: string): Promise<string> {
+  const dir = dirname(targetPath);
+  try {
+    await fsp.mkdir(dir, { recursive: true });
+  } catch (err: any) {
+    throw new BridgeRuntimeError({
+      bridge,
+      op: "export",
+      path: targetPath,
+      field: "(mkdir)",
+      expected: "writable directory",
+      got: err?.message ?? String(err),
+      hint: `could not create directory ${dir}: ${err?.message ?? err}`,
+    });
+  }
+  return `${dir}/.${basename(targetPath)}.${op}.${randomUUID().slice(0, 8)}.tmp`;
+}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -3640,19 +3640,138 @@ bridge
     }
   });
 
-// `test` and `export` still stub — `test` lands with the round-trip harness
-// in slice 3, `export` lands with the export path in slice 3.
-for (const op of ["test", "export"] as const) {
-  bridge
-    .command(`${op} <name> [args...]`)
-    .description(`${op} a bridge — not yet implemented (slice 3 of FLAIR-BRIDGES)`)
-    .allowUnknownOption()
-    .action(() => {
-      console.error(`\`flair bridge ${op}\` is not yet implemented — landing in slice 3 of FLAIR-BRIDGES.`);
-      console.error(`Slice 2 ships discovery + scaffold + import (Shape A YAML); export and round-trip test are the next slice.`);
-      process.exit(2);
-    });
-}
+bridge
+  .command("export <name> <dst>")
+  .description("Export memories from Flair to a foreign system via a bridge (Shape A YAML / built-in)")
+  .requiredOption("--agent <id>", "Agent ID to export memories for (or set FLAIR_AGENT_ID)")
+  .option("--source <tag>", "Filter to memories with a matching `source:` tag (typical for round-tripping a single bridge's data)")
+  .option("--subject <subj>", "Filter to memories with a matching `subject:` tag")
+  .option("--since <iso>", "Only memories with createdAt >= this ISO-8601 timestamp")
+  .option("--cwd <dir>", "Filesystem root the descriptor's relative target paths resolve against (default: cwd)")
+  .option("--dry-run", "Validate + count + apply maps, don't write to the target")
+  .option("--port <port>", "Harper HTTP port")
+  .option("--url <url>", "Flair base URL (overrides --port)")
+  .option("--key <path>", "Ed25519 private key path (default: resolved from agent)")
+  .action(async (name: string, dst: string, opts) => {
+    const agentId: string = opts.agent ?? process.env.FLAIR_AGENT_ID;
+    if (!agentId) {
+      console.error("error: --agent <id> required (or set FLAIR_AGENT_ID)");
+      process.exit(1);
+    }
+    const cwd: string = opts.cwd ?? dst;
+
+    const { discover } = await import("./bridges/discover.js");
+    const { builtinDiscoveryRecords } = await import("./bridges/builtins/index.js");
+    const { loadDescriptor } = await import("./bridges/runtime/load-descriptor.js");
+    const { runExport } = await import("./bridges/runtime/export-runner.js");
+    const { makeContext } = await import("./bridges/runtime/context.js");
+    const { BridgeRuntimeError } = await import("./bridges/types.js");
+
+    const found = await discover({ builtins: builtinDiscoveryRecords() });
+    const target = found.find((b) => b.name === name);
+    if (!target) {
+      console.error(`No bridge named "${name}" — run \`flair bridge list\` to see installed bridges.`);
+      process.exit(1);
+    }
+
+    let descriptor;
+    try {
+      descriptor = await loadDescriptor(target);
+    } catch (err: any) {
+      printBridgeError(err);
+      process.exit(1);
+    }
+    if (!descriptor.export) {
+      console.error(`Bridge "${name}" has no export block — cannot export through it.`);
+      process.exit(1);
+    }
+
+    const baseUrl: string = opts.url ?? `http://127.0.0.1:${resolveHttpPort(opts)}`;
+    const ctx = makeContext({ bridge: name });
+
+    // Memory fetcher — paginates GET /Memory?agentId=... applying any
+    // descriptor + caller-side filters in memory. Slice 3a does the
+    // simplest thing: one round trip, no streaming. Slice 3b can move
+    // to cursor-paginated streaming if real corpora warrant it.
+    const fetchMemories = async function*(filters: import("./bridges/runtime/export-runner.js").ExportFilters) {
+      const params = new URLSearchParams({ agentId });
+      if (opts.subject) params.set("subject", opts.subject);
+      const headers: Record<string, string> = { "content-type": "application/json" };
+      const keyPath: string | null = opts.key ?? resolveKeyPath(agentId);
+      const path = `/Memory?${params.toString()}`;
+      if (keyPath) headers["authorization"] = buildEd25519Auth(agentId, "GET", path, keyPath);
+      const res = await fetch(`${baseUrl}${path}`, { headers });
+      if (!res.ok) {
+        const text = await res.text().catch(() => "");
+        throw new Error(`GET /Memory → ${res.status}: ${text || res.statusText}`);
+      }
+      const raw = await res.json();
+      const all: any[] = Array.isArray(raw) ? raw : (raw?.results ?? raw?.items ?? []);
+      const sourceFilter = opts.source as string | undefined;
+      const sinceMs = opts.since ? new Date(opts.since).getTime() : null;
+      for (const m of all) {
+        if (sourceFilter && m.source !== sourceFilter) continue;
+        if (sinceMs !== null && m.createdAt && new Date(m.createdAt).getTime() < sinceMs) continue;
+        yield m as import("./bridges/types.js").BridgeMemory;
+      }
+      void filters;
+    };
+
+    let lastReportedAt = Date.now();
+    const onProgress = (ev: import("./bridges/runtime/export-runner.js").ProgressEvent): void => {
+      if (ev.type === "done") {
+        if (opts.dryRun) {
+          console.log(`\n${descriptor.name}: would export ${ev.exported} memor${ev.exported === 1 ? "y" : "ies"} from ${ev.total} total. Re-run without --dry-run to write.`);
+        } else {
+          console.log(`\n${descriptor.name}: exported ${ev.exported} memor${ev.exported === 1 ? "y" : "ies"} from ${ev.total} total.`);
+        }
+        return;
+      }
+      if (ev.type === "target-write") {
+        console.log(`  ✓ ${ev.path} (${ev.written} record${ev.written === 1 ? "" : "s"})`);
+        return;
+      }
+      if (ev.type === "target-skipped") {
+        console.log(`  · ${ev.path} skipped (${ev.reason})`);
+        return;
+      }
+      // memory-skipped events throttled to one line every 2s
+      const now = Date.now();
+      if (now - lastReportedAt < 2000) return;
+      lastReportedAt = now;
+      process.stdout.write(`\r  filtering memory ${ev.ordinal}...`.padEnd(60));
+    };
+
+    try {
+      await runExport({
+        descriptor,
+        cwd,
+        fetchMemories,
+        filters: { agentId, subject: opts.subject, source: opts.source, since: opts.since },
+        dryRun: !!opts.dryRun,
+        ctx,
+        onProgress,
+      });
+    } catch (err: any) {
+      if (err instanceof BridgeRuntimeError) {
+        printBridgeError(err);
+        process.exit(1);
+      }
+      console.error(`Bridge export failed: ${err?.message ?? err}`);
+      process.exit(1);
+    }
+  });
+
+// `test` still stubbed — round-trip harness lands in slice 3b.
+bridge
+  .command("test <name> [args...]")
+  .description("test a bridge — not yet implemented (slice 3b of FLAIR-BRIDGES)")
+  .allowUnknownOption()
+  .action(() => {
+    console.error(`\`flair bridge test\` is not yet implemented — landing in slice 3b of FLAIR-BRIDGES.`);
+    console.error(`Slice 3a ships export (Shape A YAML); the round-trip test harness pairs with it.`);
+    process.exit(2);
+  });
 
 function printBridgeError(err: unknown): void {
   // Pretty-print BridgeRuntimeError as the structured shape from §10 of the

--- a/test/unit/bridges-runtime-export-runner.test.ts
+++ b/test/unit/bridges-runtime-export-runner.test.ts
@@ -1,0 +1,153 @@
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { mkdirSync, rmSync, readFileSync, existsSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { runExport } from "../../src/bridges/runtime/export-runner";
+import type { YamlBridgeDescriptor, BridgeMemory } from "../../src/bridges/types";
+import { BridgeRuntimeError } from "../../src/bridges/types";
+
+function tmp(): string {
+  const d = join(tmpdir(), `flair-export-runner-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+  mkdirSync(d, { recursive: true });
+  return d;
+}
+
+const agenticDescriptor: YamlBridgeDescriptor = {
+  name: "agentic-stack",
+  version: 1,
+  kind: "file",
+  export: {
+    targets: [{
+      path: ".agent/memory/semantic/lessons.jsonl",
+      format: "jsonl",
+      when: "durability in ['persistent', 'permanent']",
+      map: {
+        id: "$.foreignId",
+        claim: "$.content",
+        topic: "$.subject",
+        tags: "$.tags[*]",
+      },
+    }],
+  },
+};
+
+async function* fromArray<T>(items: T[]): AsyncIterable<T> {
+  for (const i of items) yield i;
+}
+
+describe("runExport: end-to-end against an injected fetcher", () => {
+  let dir: string;
+  beforeEach(() => { dir = tmp(); });
+  afterEach(() => rmSync(dir, { recursive: true, force: true }));
+
+  test("filters by `when:` and applies `map:` to write the target", async () => {
+    const memories: BridgeMemory[] = [
+      { content: "permanent lesson", subject: "eng", tags: ["a"], durability: "permanent", foreignId: "f1" },
+      { content: "persistent lesson", subject: "eng", tags: ["b"], durability: "persistent", foreignId: "f2" },
+      { content: "scratch", subject: "eng", tags: [], durability: "ephemeral", foreignId: "f3" },
+    ];
+
+    const result = await runExport({
+      descriptor: agenticDescriptor,
+      cwd: dir,
+      fetchMemories: () => fromArray(memories),
+    });
+
+    expect(result.total).toBe(3);
+    expect(result.exported).toBe(2); // ephemeral filtered out by when:
+    const out = readFileSync(join(dir, ".agent/memory/semantic/lessons.jsonl"), "utf-8")
+      .split("\n").filter(Boolean).map((l) => JSON.parse(l));
+    expect(out).toHaveLength(2);
+    expect(out[0]).toEqual({ id: "f1", claim: "permanent lesson", topic: "eng", tags: ["a"] });
+    expect(out[1]).toEqual({ id: "f2", claim: "persistent lesson", topic: "eng", tags: ["b"] });
+  });
+
+  test("absent when: exports everything", async () => {
+    const desc: YamlBridgeDescriptor = {
+      ...agenticDescriptor,
+      export: {
+        targets: [{
+          ...agenticDescriptor.export!.targets[0],
+          when: undefined,
+        }],
+      },
+    };
+    const memories: BridgeMemory[] = [
+      { content: "a", durability: "ephemeral", foreignId: "1" },
+      { content: "b", durability: "persistent", foreignId: "2" },
+    ];
+    const result = await runExport({ descriptor: desc, cwd: dir, fetchMemories: () => fromArray(memories) });
+    expect(result.exported).toBe(2);
+  });
+
+  test("dry-run validates + counts but does not write the target", async () => {
+    const memories: BridgeMemory[] = [
+      { content: "x", durability: "permanent", foreignId: "f1" },
+    ];
+    const result = await runExport({
+      descriptor: agenticDescriptor,
+      cwd: dir,
+      fetchMemories: () => fromArray(memories),
+      dryRun: true,
+    });
+    expect(result.exported).toBe(0); // nothing written
+    expect(result.perTarget[0].written).toBe(0);
+    expect(existsSync(join(dir, ".agent/memory/semantic/lessons.jsonl"))).toBe(false);
+  });
+
+  test("missing export block throws a clear error", async () => {
+    const desc: YamlBridgeDescriptor = {
+      name: "import-only",
+      version: 1,
+      kind: "file",
+      import: { sources: [{ path: "x", format: "jsonl", map: { content: "$.c" } }] },
+    };
+    let thrown: any = null;
+    try {
+      await runExport({ descriptor: desc, cwd: dir, fetchMemories: async function*() {} });
+    } catch (e) { thrown = e; }
+    expect(thrown).toBeInstanceOf(BridgeRuntimeError);
+    expect(thrown.detail.field).toBe("export");
+  });
+
+  test("memories whose mapping produces zero fields are skipped", async () => {
+    const desc: YamlBridgeDescriptor = {
+      name: "weird",
+      version: 1,
+      kind: "file",
+      export: {
+        targets: [{
+          path: "out.jsonl",
+          format: "jsonl",
+          map: { content: "$.missingField" },
+        }],
+      },
+    };
+    const memories: BridgeMemory[] = [
+      { content: "real" },
+    ];
+    const result = await runExport({ descriptor: desc, cwd: dir, fetchMemories: () => fromArray(memories) });
+    // map.content resolved to undefined → applyMap dropped it → empty record → skipped
+    expect(result.exported).toBe(0);
+    expect(result.total).toBe(1);
+  });
+
+  test("absolute target path is honored (doesn't re-root to cwd)", async () => {
+    const absPath = join(dir, "absolute-out.jsonl");
+    const desc: YamlBridgeDescriptor = {
+      name: "abs",
+      version: 1,
+      kind: "file",
+      export: {
+        targets: [{
+          path: absPath,
+          format: "jsonl",
+          map: { content: "$.content" },
+        }],
+      },
+    };
+    const memories: BridgeMemory[] = [{ content: "absolute test" }];
+    await runExport({ descriptor: desc, cwd: "/somewhere/else", fetchMemories: () => fromArray(memories) });
+    expect(existsSync(absPath)).toBe(true);
+  });
+});

--- a/test/unit/bridges-runtime-predicate.test.ts
+++ b/test/unit/bridges-runtime-predicate.test.ts
@@ -1,0 +1,63 @@
+import { describe, test, expect } from "bun:test";
+import { evaluatePredicate } from "../../src/bridges/runtime/predicate";
+
+describe("predicate: in", () => {
+  test("matches a string in a list of bare identifiers", () => {
+    expect(evaluatePredicate("durability in [persistent, permanent]", { durability: "persistent" })).toBe("match");
+    expect(evaluatePredicate("durability in [persistent, permanent]", { durability: "ephemeral" })).toBe("no-match");
+  });
+
+  test("matches with single-quoted strings (agentic-stack form)", () => {
+    expect(evaluatePredicate("durability in ['persistent', 'permanent']", { durability: "persistent" })).toBe("match");
+    expect(evaluatePredicate("durability in ['persistent', 'permanent']", { durability: "ephemeral" })).toBe("no-match");
+  });
+
+  test("matches with double-quoted strings", () => {
+    expect(evaluatePredicate(`tag in ["a", "b"]`, { tag: "b" })).toBe("match");
+  });
+
+  test("missing field is no-match", () => {
+    expect(evaluatePredicate("durability in [persistent]", {})).toBe("no-match");
+  });
+
+  test("empty list is no-match for any value", () => {
+    expect(evaluatePredicate("durability in []", { durability: "persistent" })).toBe("no-match");
+  });
+});
+
+describe("predicate: == and !=", () => {
+  test("== with string literal", () => {
+    expect(evaluatePredicate(`durability == 'persistent'`, { durability: "persistent" })).toBe("match");
+    expect(evaluatePredicate(`durability == 'persistent'`, { durability: "ephemeral" })).toBe("no-match");
+  });
+
+  test("!= inverts ==", () => {
+    expect(evaluatePredicate(`durability != 'persistent'`, { durability: "ephemeral" })).toBe("match");
+    expect(evaluatePredicate(`durability != 'persistent'`, { durability: "persistent" })).toBe("no-match");
+  });
+
+  test("== with bare identifier (treated as string)", () => {
+    expect(evaluatePredicate("durability == persistent", { durability: "persistent" })).toBe("match");
+  });
+
+  test("== with number literal", () => {
+    expect(evaluatePredicate("retrievalCount == 0", { retrievalCount: 0 })).toBe("match");
+    expect(evaluatePredicate("retrievalCount == 1", { retrievalCount: 0 })).toBe("no-match");
+  });
+});
+
+describe("predicate: empty + unparsable", () => {
+  test("empty expression matches (always-export)", () => {
+    expect(evaluatePredicate("", { durability: "persistent" })).toBe("match");
+    expect(evaluatePredicate("   ", { durability: "persistent" })).toBe("match");
+  });
+
+  test("unsupported operators return unparsable", () => {
+    expect(evaluatePredicate("durability && permanent", { durability: "persistent" })).toBe("unparsable");
+    expect(evaluatePredicate("(durability == persistent)", { durability: "persistent" })).toBe("unparsable");
+  });
+
+  test("malformed list returns unparsable", () => {
+    expect(evaluatePredicate("durability in [persistent", { durability: "persistent" })).toBe("unparsable");
+  });
+});

--- a/test/unit/bridges-runtime-writers.test.ts
+++ b/test/unit/bridges-runtime-writers.test.ts
@@ -1,0 +1,112 @@
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { mkdirSync, rmSync, readFileSync, existsSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { writeRecords } from "../../src/bridges/runtime/writers";
+import { BridgeRuntimeError } from "../../src/bridges/types";
+
+function tmp(): string {
+  const d = join(tmpdir(), `flair-writers-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+  mkdirSync(d, { recursive: true });
+  return d;
+}
+
+describe("writers: jsonl", () => {
+  let dir: string;
+  beforeEach(() => { dir = tmp(); });
+  afterEach(() => rmSync(dir, { recursive: true, force: true }));
+
+  test("writes one JSON object per line", async () => {
+    const out = join(dir, "out.jsonl");
+    const result = await writeRecords("test", out, "jsonl", [
+      { id: "a", v: 1 }, { id: "b", v: 2 }, { id: "c", v: 3 },
+    ]);
+    expect(result.written).toBe(3);
+    const lines = readFileSync(out, "utf-8").split("\n").filter(Boolean);
+    expect(lines).toHaveLength(3);
+    expect(JSON.parse(lines[0])).toEqual({ id: "a", v: 1 });
+    expect(JSON.parse(lines[2])).toEqual({ id: "c", v: 3 });
+  });
+
+  test("creates the parent directory", async () => {
+    const out = join(dir, "nested", "deep", "out.jsonl");
+    await writeRecords("test", out, "jsonl", [{ x: 1 }]);
+    expect(existsSync(out)).toBe(true);
+  });
+
+  test("write is atomic — partial-write tmp file is gone after success", async () => {
+    const out = join(dir, "out.jsonl");
+    await writeRecords("test", out, "jsonl", [{ x: 1 }]);
+    // No `.export.tmp` siblings left over
+    const siblings = require("node:fs").readdirSync(dir);
+    expect(siblings.filter((f: string) => f.includes(".tmp"))).toEqual([]);
+  });
+
+  test("zero records still writes an empty file (legitimate output)", async () => {
+    const out = join(dir, "empty.jsonl");
+    const result = await writeRecords("test", out, "jsonl", []);
+    expect(result.written).toBe(0);
+    expect(readFileSync(out, "utf-8")).toBe("");
+  });
+});
+
+describe("writers: json", () => {
+  let dir: string;
+  beforeEach(() => { dir = tmp(); });
+  afterEach(() => rmSync(dir, { recursive: true, force: true }));
+
+  test("writes a JSON array of records", async () => {
+    const out = join(dir, "out.json");
+    const result = await writeRecords("test", out, "json", [{ a: 1 }, { a: 2 }]);
+    expect(result.written).toBe(2);
+    expect(JSON.parse(readFileSync(out, "utf-8"))).toEqual([{ a: 1 }, { a: 2 }]);
+  });
+});
+
+describe("writers: yaml", () => {
+  let dir: string;
+  beforeEach(() => { dir = tmp(); });
+  afterEach(() => rmSync(dir, { recursive: true, force: true }));
+
+  test("writes a yaml array of records", async () => {
+    const out = join(dir, "out.yaml");
+    const result = await writeRecords("test", out, "yaml", [{ a: 1 }, { a: 2 }]);
+    expect(result.written).toBe(2);
+    const yamlText = readFileSync(out, "utf-8");
+    // light check — should contain both record values
+    expect(yamlText).toContain("a: 1");
+    expect(yamlText).toContain("a: 2");
+  });
+});
+
+describe("writers: markdown-frontmatter (deferred)", () => {
+  let dir: string;
+  beforeEach(() => { dir = tmp(); });
+  afterEach(() => rmSync(dir, { recursive: true, force: true }));
+
+  test("throws a slice-3b pointer error", async () => {
+    const out = join(dir, "out.md");
+    let thrown: any = null;
+    try { await writeRecords("test", out, "markdown-frontmatter", [{ x: 1 }]); } catch (e) { thrown = e; }
+    expect(thrown).toBeInstanceOf(BridgeRuntimeError);
+    expect(thrown.detail.hint).toMatch(/slice 3b/);
+  });
+});
+
+describe("writers: error handling", () => {
+  let dir: string;
+  beforeEach(() => { dir = tmp(); });
+  afterEach(() => rmSync(dir, { recursive: true, force: true }));
+
+  test("write to an unwritable parent throws BridgeRuntimeError", async () => {
+    // Make the parent file (not directory) so mkdir fails
+    const blocker = join(dir, "blocked");
+    writeFileSync(blocker, "not a dir");
+    let thrown: any = null;
+    try {
+      await writeRecords("test", join(blocker, "out.jsonl"), "jsonl", [{ x: 1 }]);
+    } catch (e) { thrown = e; }
+    expect(thrown).toBeInstanceOf(BridgeRuntimeError);
+    expect(thrown.detail.field).toBe("(mkdir)");
+  });
+});


### PR DESCRIPTION
Stacks on **#276** (slice 2b — agentic-stack import + import CLI). Closes the round-trip half of the agentic-stack demo: an agent imports lessons from `.agent/`, edits them as Flair memories, exports them back out as agentic-stack-shaped jsonl that re-imports cleanly.

## What ships

| File | What it does |
|------|--------------|
| `src/bridges/runtime/predicate.ts` | Tiny `when:` evaluator — `<field> in [<literal>, ...]` / `==` / `!=`. Just enough for the agentic-stack `when: "durability in ['persistent', 'permanent']"` form. Real grammar (booleans, parens, JMESPath/CEL) is slice 3b. |
| `src/bridges/runtime/writers.ts` | Atomic writers for jsonl, json, yaml. Stage-tmp + rename so a crash mid-write doesn't leave a half-written target. `markdown-frontmatter` still slice-3b stub. |
| `src/bridges/runtime/export-runner.ts` | Pulls memories via injected fetcher (testable without Flair), filters with `when:`, applies `map:`, writes via the writer. Single fetch per invocation; multi-target descriptors share the fetched corpus. |
| `src/bridges/builtins/agentic-stack.ts` | Adds an `export` block — same path/format as import; `when:` keeps ephemeral/standard scratch in Flair; `map:` produces `{id, claim, topic, tags}` from BridgeMemory fields. |
| `src/cli.ts` | New `flair bridge export <name> <dst>` with `--agent`/`--source`/`--subject`/`--since`/`--cwd`/`--dry-run`/`--port`/`--url`/`--key`. Ed25519-signed GET `/Memory` via the standard auth path. `bridge test` re-stubbed with slice-3b pointer. |

## Tests — 26 new, 432/432 overall passing

| File | Count | Covers |
|------|-------|--------|
| `bridges-runtime-predicate.test.ts` | 12 | `in` / `==` / `!=` with bare/single-quote/double-quote/number literals. Empty (always-match), unsupported operators (unparsable), malformed list (unparsable), missing field (no-match) |
| `bridges-runtime-writers.test.ts` | 8 | jsonl one-per-line + parent-dir creation + atomic-tmp cleanup + zero-records-still-writes. json array shape. yaml dump. markdown-frontmatter stub. mkdir failure path |
| `bridges-runtime-export-runner.test.ts` | 6 | End-to-end with mock fetcher. `when:` filter applied; absent `when:` exports everything. Dry-run skips writes. Missing-export-block error. Zero-field records skipped. Absolute paths preserved |

## Smoke (verified)

```
$ flair bridge export --help                           ← real help, all flags listed
$ flair bridge export agentic-stack /tmp/demo \
    --agent alice --dry-run
agentic-stack: would export 0 memories from 0 total.   ← against empty Flair
                                                          Re-run without --dry-run to write.
```

## Out of scope

**Slice 3b:**
- `flair bridge test` — round-trip diff harness (pairs naturally with this PR)
- `markdown-frontmatter` writer (needs a built-in that uses it)
- Real `when:` grammar (booleans, parens, regex)
- `--subject` actually pushed into the `/Memory` query (today it's CLI-side filter; backend pushdown is a perf win for large corpora)

**Slice 3c:**
- Code-plugin loader (Shape B) + `flair bridge allow` trust prompt
- Rate-limiting / audit tap on `BridgeContext.fetch`

## Test plan

- [ ] `bun test test/unit/bridges-*` — 108/108 pass
- [ ] `bun test` (full) — 432/432 pass, no existing regressions
- [ ] Against rockit Flair: `flair bridge import agentic-stack <fixture-dir> --agent flint` → memories land. `flair bridge export agentic-stack /tmp/round-trip --agent flint --source agentic-stack/lessons` → tmp-dir lessons.jsonl matches the original fixture.

🤖 Generated with [Claude Code](https://claude.com/claude-code)