### PR TITLE
feat(bridges): slice 3b — `flair bridge test` round-trip harness

### DIFF
--- a/src/bridges/runtime/roundtrip.ts
+++ b/src/bridges/runtime/roundtrip.ts
@@ -1,0 +1,207 @@
+/**
+ * Round-trip test harness for bridges.
+ *
+ * A bridge passes the round-trip test iff:
+ *   1. Parse the fixture (or descriptor's first import.source.path) → pass1 BridgeMemory[]
+ *   2. Apply export.targets[0]: when-filter → map → write to tmp in the
+ *      target's format
+ *   3. Re-import the tmp file using import.sources[0] → pass2 BridgeMemory[]
+ *   4. pass1 and pass2 must agree on the round-trip-stable fields from the
+ *      spec (§8): content, subject, tags, durability.
+ *
+ * This exercises the full mapper + predicate + writer + parser chain —
+ * if a bridge author's descriptor has mapping bugs, the round-trip
+ * surfaces them before memories ever reach Flair.
+ *
+ * Implementation note: does NOT talk to Flair. Fixture-to-fixture only.
+ * Lives here so slice-3c code plugins can reuse the same harness.
+ */
+
+import { promises as fsp } from "node:fs";
+import { join, isAbsolute } from "node:path";
+import { tmpdir } from "node:os";
+import { randomUUID } from "node:crypto";
+import type {
+  BridgeMemory,
+  YamlBridgeDescriptor,
+} from "../types.js";
+import { BridgeRuntimeError } from "../types.js";
+import { parseRecords } from "./formats.js";
+import { applyMap } from "./mapper.js";
+import { evaluatePredicate } from "./predicate.js";
+import { writeRecords } from "./writers.js";
+
+/** Fields the spec (§8) requires to survive round-trip. */
+export const ROUND_TRIP_STABLE_FIELDS = ["content", "subject", "tags", "durability"] as const;
+type StableField = typeof ROUND_TRIP_STABLE_FIELDS[number];
+
+export interface RoundTripOptions {
+  descriptor: YamlBridgeDescriptor;
+  /** Filesystem root the descriptor's relative paths resolve against. */
+  cwd: string;
+  /** Override the import source path. Defaults to descriptor's import.sources[0].path. */
+  fixturePath?: string;
+}
+
+export interface RoundTripMismatch {
+  /** 1-based index into the pass-1 memory list. */
+  ordinal: number;
+  /** foreignId (or content preview) used to match across passes. */
+  key: string;
+  /** Which stable field disagreed. */
+  field: StableField;
+  expected: unknown;
+  got: unknown;
+}
+
+export interface RoundTripResult {
+  passed: boolean;
+  /** Records in pass 1 that passed the when-filter (i.e., expected to round-trip). */
+  expectedCount: number;
+  /** Records we found in pass 2. */
+  actualCount: number;
+  /** Per-field disagreements. Empty iff passed === true. */
+  mismatches: RoundTripMismatch[];
+  /** Records in pass 1 that had no match in pass 2 by match-key. */
+  missingInPass2: Array<{ ordinal: number; key: string }>;
+  /** Records in pass 2 that had no match in pass 1 (unexpected extras). */
+  unexpectedInPass2: Array<{ key: string }>;
+  /** Path of the intermediate export artifact (useful for debugging). */
+  tmpExportPath: string;
+}
+
+export async function runRoundTrip(opts: RoundTripOptions): Promise<RoundTripResult> {
+  const { descriptor, cwd } = opts;
+
+  if (!descriptor.import || descriptor.import.sources.length === 0) {
+    throw new BridgeRuntimeError({
+      bridge: descriptor.name,
+      op: "test",
+      field: "import",
+      expected: "descriptor with at least one import source",
+      got: "missing or empty",
+      hint: "round-trip needs an import block to start from. Add `import.sources:` to the descriptor.",
+    });
+  }
+  if (!descriptor.export || descriptor.export.targets.length === 0) {
+    throw new BridgeRuntimeError({
+      bridge: descriptor.name,
+      op: "test",
+      field: "export",
+      expected: "descriptor with at least one export target",
+      got: "missing or empty",
+      hint: "round-trip needs an export block to round-trip through. Add `export.targets:` to the descriptor.",
+    });
+  }
+
+  const importSource = descriptor.import.sources[0];
+  const exportTarget = descriptor.export.targets[0];
+
+  const resolvedFixture = resolvePath(cwd, opts.fixturePath ?? importSource.path);
+  const tmpDir = await fsp.mkdtemp(join(tmpdir(), `flair-bridge-test-${descriptor.name}-`));
+  const tmpPath = join(tmpDir, `roundtrip.${suffixForFormat(exportTarget.format)}`);
+
+  // Pass 1: fixture → BridgeMemory[]
+  const pass1: BridgeMemory[] = [];
+  for await (const { record } of parseRecords(descriptor.name, resolvedFixture, importSource.format)) {
+    const mapped = applyMap(importSource.map, record) as unknown as BridgeMemory;
+    pass1.push(mapped);
+  }
+
+  // Filter pass1 by the export target's when: (records filtered out wouldn't make it to the target).
+  const expected: BridgeMemory[] = [];
+  for (const m of pass1) {
+    if (!exportTarget.when || exportTarget.when.trim() === "") {
+      expected.push(m);
+      continue;
+    }
+    const result = evaluatePredicate(exportTarget.when, m as unknown as Record<string, unknown>);
+    if (result === "match" || result === "unparsable") expected.push(m);
+  }
+
+  // Export phase: apply export.map, write to tmp
+  const shaped: Record<string, unknown>[] = [];
+  for (const m of expected) {
+    const out = applyMap(exportTarget.map, m as unknown as Record<string, unknown>);
+    if (Object.keys(out).length === 0) continue;
+    shaped.push(out);
+  }
+  await writeRecords(descriptor.name, tmpPath, exportTarget.format, shaped);
+
+  // Pass 2: re-import the tmp using import.sources[0]'s map + format
+  // (round-trip requires the bridge's own import map applied to what export wrote).
+  const pass2: BridgeMemory[] = [];
+  for await (const { record } of parseRecords(descriptor.name, tmpPath, importSource.format)) {
+    const mapped = applyMap(importSource.map, record) as unknown as BridgeMemory;
+    pass2.push(mapped);
+  }
+
+  // Match pass1[expected] with pass2 by key (foreignId if present, else content)
+  // and diff the stable fields.
+  const keyOf = (m: BridgeMemory): string => m.foreignId ?? (m.content ? `content:${m.content}` : "");
+  const pass2ByKey = new Map<string, BridgeMemory>();
+  for (const m of pass2) pass2ByKey.set(keyOf(m), m);
+
+  const mismatches: RoundTripMismatch[] = [];
+  const missingInPass2: Array<{ ordinal: number; key: string }> = [];
+  for (let i = 0; i < expected.length; i++) {
+    const a = expected[i];
+    const key = keyOf(a);
+    const b = pass2ByKey.get(key);
+    if (!b) {
+      missingInPass2.push({ ordinal: i + 1, key });
+      continue;
+    }
+    for (const field of ROUND_TRIP_STABLE_FIELDS) {
+      if (!deepEqualField(a[field], b[field])) {
+        mismatches.push({ ordinal: i + 1, key, field, expected: a[field], got: b[field] });
+      }
+    }
+    // Matched this pass2 entry; remove so leftover tracking works
+    pass2ByKey.delete(key);
+  }
+
+  const unexpectedInPass2 = Array.from(pass2ByKey.keys()).map((key) => ({ key }));
+
+  const passed = mismatches.length === 0 && missingInPass2.length === 0 && unexpectedInPass2.length === 0;
+
+  return {
+    passed,
+    expectedCount: expected.length,
+    actualCount: pass2.length,
+    mismatches,
+    missingInPass2,
+    unexpectedInPass2,
+    tmpExportPath: tmpPath,
+  };
+}
+
+function deepEqualField(a: unknown, b: unknown): boolean {
+  // tags is the only array-valued stable field today; deep-equal shallowly
+  // (order matters per our mapping; if a bridge re-orders tags, that's a
+  // round-trip regression worth catching).
+  if (Array.isArray(a) && Array.isArray(b)) {
+    if (a.length !== b.length) return false;
+    for (let i = 0; i < a.length; i++) if (a[i] !== b[i]) return false;
+    return true;
+  }
+  // string / number / boolean / undefined: strict equality
+  return a === b;
+}
+
+function suffixForFormat(format: string): string {
+  switch (format) {
+    case "jsonl": return "jsonl";
+    case "json": return "json";
+    case "yaml": return "yaml";
+    case "markdown-frontmatter": return "md";
+    default: return "out";
+  }
+}
+
+function resolvePath(cwd: string, p: string): string {
+  return isAbsolute(p) ? p : join(cwd, p);
+}
+
+// Keep randomUUID imported; future slice may use it for named tmp files.
+void randomUUID;

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -3849,15 +3849,75 @@ bridge
     }
   });
 
-// `test` still stubbed — round-trip harness lands in slice 3b.
 bridge
-  .command("test <name> [args...]")
-  .description("test a bridge — not yet implemented (slice 3b of FLAIR-BRIDGES)")
-  .allowUnknownOption()
-  .action(() => {
-    console.error(`\`flair bridge test\` is not yet implemented — landing in slice 3b of FLAIR-BRIDGES.`);
-    console.error(`Slice 3a ships export (Shape A YAML); the round-trip test harness pairs with it.`);
-    process.exit(2);
+  .command("test <name>")
+  .description("Round-trip a bridge through its fixture: import → export → re-import → diff. Pass iff the stable fields (content/subject/tags/durability) match.")
+  .option("--fixture <path>", "Override the import source path (defaults to descriptor's import.sources[0].path)")
+  .option("--cwd <dir>", "Filesystem root the descriptor's relative paths resolve against (default: cwd)")
+  .option("--json", "Emit the full RoundTripResult as JSON on stdout")
+  .action(async (name: string, opts) => {
+    const cwd: string = opts.cwd ?? process.cwd();
+
+    const { discover } = await import("./bridges/discover.js");
+    const { builtinDiscoveryRecords } = await import("./bridges/builtins/index.js");
+    const { loadDescriptor } = await import("./bridges/runtime/load-descriptor.js");
+    const { runRoundTrip } = await import("./bridges/runtime/roundtrip.js");
+    const { BridgeRuntimeError } = await import("./bridges/types.js");
+
+    const found = await discover({ builtins: builtinDiscoveryRecords() });
+    const target = found.find((b) => b.name === name);
+    if (!target) {
+      console.error(`No bridge named "${name}" — run \`flair bridge list\` to see installed bridges.`);
+      process.exit(1);
+    }
+
+    let descriptor;
+    try {
+      descriptor = await loadDescriptor(target);
+    } catch (err: any) {
+      printBridgeError(err);
+      process.exit(1);
+    }
+
+    try {
+      const result = await runRoundTrip({ descriptor, cwd, fixturePath: opts.fixture });
+      if (opts.json) {
+        console.log(JSON.stringify(result, null, 2));
+        process.exit(result.passed ? 0 : 1);
+      }
+      if (result.passed) {
+        console.log(`✅ ${descriptor.name} round-trip passed (${result.expectedCount} record${result.expectedCount === 1 ? "" : "s"}).`);
+        process.exit(0);
+      }
+      console.log(`❌ ${descriptor.name} round-trip failed.`);
+      console.log(`   expected ${result.expectedCount} records, got ${result.actualCount} back.`);
+      if (result.missingInPass2.length > 0) {
+        console.log(`   missing from re-import (${result.missingInPass2.length}):`);
+        for (const m of result.missingInPass2.slice(0, 5)) console.log(`     - ${m.key}`);
+        if (result.missingInPass2.length > 5) console.log(`     ... ${result.missingInPass2.length - 5} more`);
+      }
+      if (result.unexpectedInPass2.length > 0) {
+        console.log(`   unexpected extras in re-import (${result.unexpectedInPass2.length}):`);
+        for (const m of result.unexpectedInPass2.slice(0, 5)) console.log(`     - ${m.key}`);
+        if (result.unexpectedInPass2.length > 5) console.log(`     ... ${result.unexpectedInPass2.length - 5} more`);
+      }
+      if (result.mismatches.length > 0) {
+        console.log(`   field mismatches (${result.mismatches.length}):`);
+        for (const m of result.mismatches.slice(0, 10)) {
+          console.log(`     - record ${m.ordinal} (${m.key}) field ${m.field}: expected ${JSON.stringify(m.expected)}, got ${JSON.stringify(m.got)}`);
+        }
+        if (result.mismatches.length > 10) console.log(`     ... ${result.mismatches.length - 10} more`);
+      }
+      console.log(`\n   Intermediate export at: ${result.tmpExportPath}`);
+      process.exit(1);
+    } catch (err: any) {
+      if (err instanceof BridgeRuntimeError) {
+        printBridgeError(err);
+        process.exit(1);
+      }
+      console.error(`Bridge test failed: ${err?.message ?? err}`);
+      process.exit(1);
+    }
   });
 
 function printBridgeError(err: unknown): void {

--- a/test/unit/bridges-runtime-roundtrip.test.ts
+++ b/test/unit/bridges-runtime-roundtrip.test.ts
@@ -1,0 +1,169 @@
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { mkdirSync, rmSync, writeFileSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { runRoundTrip } from "../../src/bridges/runtime/roundtrip";
+import type { YamlBridgeDescriptor } from "../../src/bridges/types";
+import { BridgeRuntimeError } from "../../src/bridges/types";
+
+function sandbox(): string {
+  const d = join(tmpdir(), `flair-roundtrip-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+  mkdirSync(d, { recursive: true });
+  return d;
+}
+
+// Agentic-stack-like descriptor with matching import/export, for round-trip.
+const descriptor: YamlBridgeDescriptor = {
+  name: "test-bridge",
+  version: 1,
+  kind: "file",
+  import: {
+    sources: [{
+      path: "fixture.jsonl",
+      format: "jsonl",
+      map: {
+        content: "$.claim",
+        subject: "$.topic",
+        tags: "$.tags[*]",
+        foreignId: "$.id",
+        durability: "persistent",
+        source: "test-bridge/lessons",
+      },
+    }],
+  },
+  export: {
+    targets: [{
+      path: "out.jsonl",
+      format: "jsonl",
+      when: "durability in ['persistent', 'permanent']",
+      map: {
+        id: "$.foreignId",
+        claim: "$.content",
+        topic: "$.subject",
+        tags: "$.tags[*]",
+      },
+    }],
+  },
+};
+
+describe("runRoundTrip: passing paths", () => {
+  let dir: string;
+  beforeEach(() => { dir = sandbox(); });
+  afterEach(() => rmSync(dir, { recursive: true, force: true }));
+
+  test("symmetric import/export passes", async () => {
+    writeFileSync(join(dir, "fixture.jsonl"), [
+      JSON.stringify({ id: "l1", claim: "Always test before merging.", topic: "ci", tags: ["ci"] }),
+      JSON.stringify({ id: "l2", claim: "Stack PRs carefully.", topic: "git", tags: ["git", "ops"] }),
+    ].join("\n") + "\n");
+    const result = await runRoundTrip({ descriptor, cwd: dir });
+    expect(result.passed).toBe(true);
+    expect(result.expectedCount).toBe(2);
+    expect(result.actualCount).toBe(2);
+    expect(result.mismatches).toEqual([]);
+    expect(result.missingInPass2).toEqual([]);
+    expect(result.unexpectedInPass2).toEqual([]);
+  });
+
+  test("empty fixture round-trips trivially", async () => {
+    writeFileSync(join(dir, "fixture.jsonl"), "");
+    const result = await runRoundTrip({ descriptor, cwd: dir });
+    expect(result.passed).toBe(true);
+    expect(result.expectedCount).toBe(0);
+    expect(result.actualCount).toBe(0);
+  });
+});
+
+describe("runRoundTrip: failing paths", () => {
+  let dir: string;
+  beforeEach(() => { dir = sandbox(); });
+  afterEach(() => rmSync(dir, { recursive: true, force: true }));
+
+  test("descriptor without an import block throws", async () => {
+    const d: YamlBridgeDescriptor = {
+      name: "no-import",
+      version: 1,
+      kind: "file",
+      export: { targets: [{ path: "out.jsonl", format: "jsonl", map: { content: "$.c" } }] },
+    };
+    let thrown: any = null;
+    try { await runRoundTrip({ descriptor: d, cwd: dir }); } catch (e) { thrown = e; }
+    expect(thrown).toBeInstanceOf(BridgeRuntimeError);
+    expect(thrown.detail.field).toBe("import");
+  });
+
+  test("descriptor without an export block throws", async () => {
+    const d: YamlBridgeDescriptor = {
+      name: "no-export",
+      version: 1,
+      kind: "file",
+      import: { sources: [{ path: "x.jsonl", format: "jsonl", map: { content: "$.c" } }] },
+    };
+    let thrown: any = null;
+    try { await runRoundTrip({ descriptor: d, cwd: dir }); } catch (e) { thrown = e; }
+    expect(thrown).toBeInstanceOf(BridgeRuntimeError);
+    expect(thrown.detail.field).toBe("export");
+  });
+
+  test("catches a mapping bug where the export loses a field", async () => {
+    writeFileSync(join(dir, "fixture.jsonl"),
+      JSON.stringify({ id: "l1", claim: "test", topic: "eng", tags: ["ci", "dev"] }) + "\n");
+    const buggy: YamlBridgeDescriptor = {
+      ...descriptor,
+      export: {
+        targets: [{
+          ...descriptor.export!.targets[0],
+          map: {
+            id: "$.foreignId",
+            claim: "$.content",
+            topic: "$.subject",
+            // ← intentionally drop tags from export
+          },
+        }],
+      },
+    };
+    const result = await runRoundTrip({ descriptor: buggy, cwd: dir });
+    expect(result.passed).toBe(false);
+    expect(result.mismatches.length).toBeGreaterThan(0);
+    // The dropped field shows up in mismatches
+    expect(result.mismatches[0].field).toBe("tags");
+  });
+
+  test("catches when filter dropping records that wouldn't re-import", async () => {
+    writeFileSync(join(dir, "fixture.jsonl"), [
+      JSON.stringify({ id: "l1", claim: "ephemeral one", topic: "x", tags: [] }),
+    ].join("\n") + "\n");
+    const ephDesc: YamlBridgeDescriptor = {
+      ...descriptor,
+      import: {
+        sources: [{
+          ...descriptor.import!.sources[0],
+          map: { ...descriptor.import!.sources[0].map, durability: "ephemeral" },
+        }],
+      },
+    };
+    const result = await runRoundTrip({ descriptor: ephDesc, cwd: dir });
+    expect(result.passed).toBe(true);
+    expect(result.expectedCount).toBe(0);
+    expect(result.actualCount).toBe(0);
+  });
+
+  test("honors --fixture override for the import source", async () => {
+    const altPath = join(dir, "alt.jsonl");
+    writeFileSync(altPath,
+      JSON.stringify({ id: "alt-1", claim: "from alt fixture", topic: "misc" }) + "\n");
+    const result = await runRoundTrip({ descriptor, cwd: dir, fixturePath: altPath });
+    expect(result.passed).toBe(true);
+    expect(result.expectedCount).toBe(1);
+  });
+
+  test("tmpExportPath is a readable jsonl of the exported records", async () => {
+    writeFileSync(join(dir, "fixture.jsonl"),
+      JSON.stringify({ id: "l1", claim: "hi", topic: "t", tags: ["a"] }) + "\n");
+    const result = await runRoundTrip({ descriptor, cwd: dir });
+    const written = readFileSync(result.tmpExportPath, "utf-8");
+    expect(written.trim().split("\n").length).toBe(1);
+    const parsed = JSON.parse(written.trim());
+    expect(parsed).toEqual({ id: "l1", claim: "hi", topic: "t", tags: ["a"] });
+  });
+});


### PR DESCRIPTION
Closes the demo loop the spec promises: "ship a fixture, run round-trip, pass = ship." Before this, `flair bridge test` was a stub pointing at a future slice.

## What it does

`flair bridge test <name>`:
1. Parses the fixture (or `--fixture` override) via `import.sources[0]` format + map → `pass1`
2. Filters `pass1` by `export.targets[0].when` — records that wouldn't reach the target aren't expected to come back
3. Applies `export.targets[0].map` + writes to tmp in the target format
4. Re-imports the tmp file using `import.sources[0]` map → `pass2`
5. Matches records by `foreignId` (else content), diffs the round-trip-stable fields from spec §8: **content, subject, tags, durability**
6. Passes iff no mismatches, no missing records, no unexpected extras

Uses only already-shipped layers (`parseRecords` + `applyMap` + `evaluatePredicate` + `writeRecords`). **No Flair HTTP contact — fixture ↔ fixture, self-contained.**

## CLI surface

```
flair bridge test <name> [--fixture <path>] [--cwd <dir>] [--json]
```

- Pretty output: ✅ or ❌ + itemized mismatches, capped to 10 lines per category so a giant failure doesn't drown the terminal.
- `--json` emits full `RoundTripResult` for CI consumption + exits 0/1.
- Points at the intermediate export file (`tmpExportPath`) on failure so the author can eyeball the round-trip halfway through.

## Tests — 8 new, 449/449 overall

- symmetric import/export descriptor round-trips cleanly
- empty fixture trivially passes
- missing import or export block throws with field-specific hint
- **export that drops a round-trip-stable field (e.g. tags) surfaces in mismatches pointing at the dropped field** — the actual value the harness exists for
- ephemeral-durability records filtered by `when:` yield 0-expected / 0-actual (not a false failure)
- `--fixture` override works
- `tmpExportPath` contains the expected jsonl

## Smoke (verified end-to-end)

```
$ mkdir -p /tmp/rt/.agent/memory/semantic
$ echo '{"id":"l1","claim":"test","topic":"t","tags":["a"]}' \
    > /tmp/rt/.agent/memory/semantic/lessons.jsonl
$ (cd /tmp/rt && flair bridge test agentic-stack)
✅ agentic-stack round-trip passed (1 record).
```

## What this unlocks

**Bridge authors now have a real iteration signal.** Before: "does my descriptor look right?" Now: "run `flair bridge test mybridge`; if green, ship." This is the loop the spec promises non-coders can use to ship bridges — and it now works.

## Out of scope (slice 3c)

- Code-plugin (Shape B) round-trip support. Needs the code-plugin loader + an execution context first. Will reuse this harness verbatim once the normalized descriptor is produced.
- `markdown-frontmatter` parser/writer (needs a built-in that uses it).
- `flair bridge allow` trust prompt for npm code plugins.

## Test plan

- [ ] `bun test test/unit/bridges-runtime-roundtrip.test.ts` — 8/8 pass
- [ ] `bun test` (full) — 449/449 pass, no regressions
- [ ] Against a fresh agentic-stack fixture: `flair bridge test agentic-stack` prints ✅
- [ ] Intentionally break the descriptor (drop a map field); re-run test; ❌ output lists the dropped field in mismatches

🤖 Generated with [Claude Code](https://claude.com/claude-code)