### PR TITLE
fix(bridges): pin allow-list approvals to package location + content digest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### 🔒 Security
+
+- **Bridge allow-list now pins approvals to package location + content digest (#283):** prior to this fix, `flair bridge allow <name>` stored only the short name. That left a local-squatting attack surface — a user who approved `mem0` in ProjectA could then `cd` into ProjectB shipping a planted `node_modules/flair-bridge-mem0` with the same npm name but different code, and the allow-list would happily pass it through to dynamic import. Approvals now record the canonical package directory and a sha256 of the package's `package.json`; at load time, both must still match the discovered package. Any mismatch refuses the load with a specific `path-mismatch` / `digest-mismatch` hint pointing back at `flair bridge allow <name>` for a deliberate re-approval. Legacy name-only entries from 0.6.0/0.6.1 are treated as invalid — operators must re-approve once. Reported by tps-sherlock on retroactive review of #282.
+
 ## 0.6.0 (2026-04-22)
 
 ### ✨ Features

--- a/src/bridges/runtime/allow-list.ts
+++ b/src/bridges/runtime/allow-list.ts
@@ -6,28 +6,48 @@
  * records the approval; subsequent invocations see the bridge on the
  * allow-list and skip the prompt. `flair bridge revoke <name>` removes it.
  *
- * This file is the persistence + query layer. CLI wiring lives in cli.ts.
+ * Approvals are pinned to a concrete package location and its package.json
+ * content digest. A name-only approval is not enough: a malicious package
+ * squatting on an allowed short-name in a different `node_modules` tree
+ * (e.g. the user approved `mem0` in ProjectA, then cd'd into ProjectB which
+ * ships a planted `node_modules/flair-bridge-mem0`) would otherwise load
+ * under the existing trust record. Each entry therefore captures:
+ *
+ *   - packageDir:        canonical (realpath) directory where the approved
+ *                        package lives on disk at allow-time.
+ *   - packageJsonSha256: hex sha256 of the package's package.json content.
+ *   - version:           the package's self-reported version (display only;
+ *                        the sha is what enforces identity).
+ *
+ * At load-time, `verifyAllow(discovered)` re-checks all three. A change in
+ * any triggers a BridgeRuntimeError pointing the operator back at
+ * `flair bridge allow` — either the move is intentional (re-approve) or
+ * it is a squat (refuse).
  *
  * Design notes:
  *  - YAML (Shape A) + built-in bridges skip this gate entirely. They don't
  *    execute arbitrary JS.
- *  - The store is a simple JSON file at ~/.flair/bridges-allowed.json with
- *    an `allowed: [{name, allowedAt}]` shape. No separate DB, no Harper
- *    dependency — the trust decision should work even when Flair's own
- *    service is down.
- *  - Each entry records when it was allowed. Future slice-3d can add
- *    `allowedVersion` to pin approval to a specific package version,
- *    but 1.0 just needs presence/absence.
+ *  - The store is a simple JSON file at ~/.flair/bridges-allowed.json.
+ *    No separate DB, no Harper dependency — the trust decision should
+ *    still work when Flair's own service is down.
+ *  - Migration: older entries from 0.6.0/0.6.1 carry only {name, allowedAt}.
+ *    `verifyAllow` treats those as invalid and forces re-approval on next
+ *    load. Acceptable cost — no known external consumers pre-1.0.
  */
 
 import { promises as fsp } from "node:fs";
 import { existsSync } from "node:fs";
 import { join, dirname } from "node:path";
 import { homedir } from "node:os";
+import { createHash } from "node:crypto";
+import type { DiscoveredBridge } from "../types.js";
 
 export interface AllowEntry {
   name: string;
   allowedAt: string;
+  packageDir: string;
+  packageJsonSha256: string;
+  version?: string;
 }
 
 export interface AllowList {
@@ -39,8 +59,25 @@ export interface AllowListOptions {
   path?: string;
 }
 
+export type VerifyResult =
+  | { ok: true; entry: AllowEntry }
+  | { ok: false; reason: "not-allowed"; entry?: undefined }
+  | { ok: false; reason: "path-mismatch"; entry: AllowEntry; observedPath: string }
+  | { ok: false; reason: "digest-mismatch"; entry: AllowEntry; observedDigest: string }
+  | { ok: false; reason: "entry-incomplete"; entry: AllowEntry }
+  | { ok: false; reason: "package-missing"; entry?: AllowEntry };
+
 function resolvePath(opts: AllowListOptions | undefined): string {
   return opts?.path ?? join(homedir(), ".flair", "bridges-allowed.json");
+}
+
+function hasEntryFields(e: any): e is AllowEntry {
+  return (
+    typeof e?.name === "string" &&
+    typeof e?.allowedAt === "string" &&
+    typeof e?.packageDir === "string" &&
+    typeof e?.packageJsonSha256 === "string"
+  );
 }
 
 async function read(path: string): Promise<AllowList> {
@@ -49,7 +86,17 @@ async function read(path: string): Promise<AllowList> {
     const raw = await fsp.readFile(path, "utf-8");
     const parsed = JSON.parse(raw);
     if (!parsed || !Array.isArray(parsed.allowed)) return { allowed: [] };
-    return { allowed: parsed.allowed.filter((e: any): e is AllowEntry => typeof e?.name === "string" && typeof e?.allowedAt === "string") };
+    // Keep structurally valid entries only. Legacy name-only rows are
+    // dropped here so `verifyAllow` reports not-allowed (forcing re-approve).
+    return {
+      allowed: parsed.allowed.filter(hasEntryFields).map((e: AllowEntry) => ({
+        name: e.name,
+        allowedAt: e.allowedAt,
+        packageDir: e.packageDir,
+        packageJsonSha256: e.packageJsonSha256,
+        ...(typeof (e as any).version === "string" ? { version: (e as any).version } : {}),
+      })),
+    };
   } catch {
     return { allowed: [] };
   }
@@ -57,39 +104,137 @@ async function read(path: string): Promise<AllowList> {
 
 async function write(path: string, data: AllowList): Promise<void> {
   await fsp.mkdir(dirname(path), { recursive: true });
-  // Stage + rename for atomicity
   const tmp = `${path}.tmp`;
   await fsp.writeFile(tmp, JSON.stringify(data, null, 2) + "\n", "utf-8");
   await fsp.rename(tmp, path);
 }
 
-export async function isAllowed(name: string, opts?: AllowListOptions): Promise<boolean> {
-  const list = await read(resolvePath(opts));
-  return list.allowed.some((e) => e.name === name);
+/**
+ * Canonicalize a filesystem path. Resolves symlinks so node_modules hoisting
+ * and pnpm-style content-addressed stores still hash-match reliably.
+ */
+async function canonical(path: string): Promise<string> {
+  try {
+    return await fsp.realpath(path);
+  } catch {
+    return path;
+  }
 }
 
-export async function allow(name: string, opts?: AllowListOptions): Promise<{ alreadyAllowed: boolean }> {
-  const path = resolvePath(opts);
-  const list = await read(path);
-  if (list.allowed.some((e) => e.name === name)) {
-    return { alreadyAllowed: true };
+/**
+ * Hash a package's package.json file. The sha changes whenever the package
+ * contents "change enough to matter" — version bumps, name changes, and
+ * realistically most substantive updates touch package.json. It is NOT a
+ * hash of every file in the package; that would be slower and more fragile
+ * without closing the meaningful attack paths (since a squatter needs the
+ * right package.json anyway to survive discovery).
+ */
+export async function digestPackage(
+  packageDir: string,
+): Promise<{ canonicalDir: string; sha256: string; version?: string }> {
+  const canonicalDir = await canonical(packageDir);
+  const pkgJsonPath = join(canonicalDir, "package.json");
+  const raw = await fsp.readFile(pkgJsonPath, "utf-8");
+  const sha = createHash("sha256").update(raw).digest("hex");
+  let version: string | undefined;
+  try {
+    const parsed = JSON.parse(raw);
+    if (typeof parsed?.version === "string") version = parsed.version;
+  } catch {
+    // A malformed package.json is itself a refusal signal — but leave that
+    // to the import path; here we just decline to record a version.
   }
-  list.allowed.push({ name, allowedAt: new Date().toISOString() });
-  // Sort by name for deterministic file contents.
-  list.allowed.sort((a, b) => a.name.localeCompare(b.name));
-  await write(path, list);
-  return { alreadyAllowed: false };
+  return { canonicalDir, sha256: sha, version };
+}
+
+/**
+ * Check if a name appears in the allow-list. Useful for UI listings; NOT a
+ * trust decision — use `verifyAllow` for load-time security checks.
+ */
+export async function isAllowed(name: string, opts?: AllowListOptions): Promise<boolean> {
+  const data = await read(resolvePath(opts));
+  return data.allowed.some((e) => e.name === name);
+}
+
+/**
+ * Load-time trust check. Verifies the discovered package still matches the
+ * approval record by canonical path AND package.json sha. Anything else is
+ * a refusal — the operator must re-run `flair bridge allow <name>`.
+ */
+export async function verifyAllow(
+  discovered: DiscoveredBridge,
+  opts?: AllowListOptions,
+): Promise<VerifyResult> {
+  const data = await read(resolvePath(opts));
+  const entry = data.allowed.find((e) => e.name === discovered.name);
+  if (!entry) return { ok: false, reason: "not-allowed" };
+
+  // Guard: if we ever loaded a partial record, refuse. Belt-and-braces;
+  // read() already filters these, but if someone hand-edits the file we
+  // don't want to silently bypass the check.
+  if (!entry.packageDir || !entry.packageJsonSha256) {
+    return { ok: false, reason: "entry-incomplete", entry };
+  }
+
+  let observed: { canonicalDir: string; sha256: string; version?: string };
+  try {
+    observed = await digestPackage(discovered.path);
+  } catch {
+    return { ok: false, reason: "package-missing", entry };
+  }
+
+  if (observed.canonicalDir !== entry.packageDir) {
+    return { ok: false, reason: "path-mismatch", entry, observedPath: observed.canonicalDir };
+  }
+  if (observed.sha256 !== entry.packageJsonSha256) {
+    return { ok: false, reason: "digest-mismatch", entry, observedDigest: observed.sha256 };
+  }
+  return { ok: true, entry };
+}
+
+/**
+ * Approve a package for code-plugin execution. `packageDir` must be the
+ * directory holding the package.json — typically discovered via
+ * `flair bridge list` and passed through by the CLI layer.
+ */
+export async function allow(
+  name: string,
+  packageDir: string,
+  opts?: AllowListOptions,
+): Promise<{ alreadyAllowed: boolean; updated: boolean; entry: AllowEntry }> {
+  const listPath = resolvePath(opts);
+  const data = await read(listPath);
+  const { canonicalDir, sha256, version } = await digestPackage(packageDir);
+  const now = new Date().toISOString();
+
+  const existing = data.allowed.find((e) => e.name === name);
+  if (existing && existing.packageDir === canonicalDir && existing.packageJsonSha256 === sha256) {
+    return { alreadyAllowed: true, updated: false, entry: existing };
+  }
+
+  const entry: AllowEntry = {
+    name,
+    allowedAt: now,
+    packageDir: canonicalDir,
+    packageJsonSha256: sha256,
+    ...(version ? { version } : {}),
+  };
+  data.allowed = data.allowed.filter((e) => e.name !== name);
+  data.allowed.push(entry);
+  data.allowed.sort((a, b) => a.name.localeCompare(b.name));
+  await write(listPath, data);
+  return { alreadyAllowed: false, updated: !!existing, entry };
 }
 
 export async function revoke(name: string, opts?: AllowListOptions): Promise<{ wasAllowed: boolean }> {
   const path = resolvePath(opts);
-  const list = await read(path);
-  const before = list.allowed.length;
-  list.allowed = list.allowed.filter((e) => e.name !== name);
-  if (list.allowed.length === before) {
+  const data = await read(path);
+  const before = data.allowed.length;
+  data.allowed = data.allowed.filter((e) => e.name !== name);
+  if (data.allowed.length === before) {
     return { wasAllowed: false };
   }
-  await write(path, list);
+  await write(path, data);
   return { wasAllowed: true };
 }
 

--- a/src/bridges/runtime/load-bridge.ts
+++ b/src/bridges/runtime/load-bridge.ts
@@ -76,12 +76,48 @@ export async function loadBridge(
             expected: verdict.reason === "not-allowed" ? "allow-listed code plugin" : "approved package at recorded location/digest",
             got: verdict.reason,
             hint: trustHint(discovered.name, verdict),
+            context: trustContext(discovered, verdict),
           });
         }
       }
       const plugin = await loadCodePlugin(discovered, { importer: opts.importer });
       return { kind: "code", plugin, source: discovered };
     }
+  }
+}
+
+function trustContext(
+  discovered: DiscoveredBridge,
+  verdict: Exclude<VerifyResult, { ok: true }>,
+): Record<string, string> {
+  switch (verdict.reason) {
+    case "not-allowed":
+      return { name: discovered.name };
+    case "path-mismatch":
+      return {
+        name: discovered.name,
+        approvedPath: verdict.entry.packageDir,
+        observedPath: verdict.observedPath,
+        approvedVersion: verdict.entry.version ?? "(unknown)",
+        approvedAt: verdict.entry.allowedAt,
+      };
+    case "digest-mismatch":
+      return {
+        name: discovered.name,
+        packagePath: verdict.entry.packageDir,
+        approvedVersion: verdict.entry.version ?? "(unknown)",
+        approvedDigest: verdict.entry.packageJsonSha256,
+        observedDigest: verdict.observedDigest,
+        approvedAt: verdict.entry.allowedAt,
+      };
+    case "entry-incomplete":
+      return { name: discovered.name };
+    case "package-missing":
+      return {
+        name: discovered.name,
+        approvedPath: verdict.entry?.packageDir ?? "(unknown)",
+        discoveredPath: discovered.path,
+      };
   }
 }
 

--- a/src/bridges/runtime/load-bridge.ts
+++ b/src/bridges/runtime/load-bridge.ts
@@ -20,7 +20,8 @@ import { BridgeRuntimeError } from "../types.js";
 import { loadYamlDescriptor } from "./yaml-loader.js";
 import { BUILTIN_BY_NAME } from "../builtins/index.js";
 import { loadCodePlugin } from "./load-plugin.js";
-import { isAllowed } from "./allow-list.js";
+import { verifyAllow } from "./allow-list.js";
+import type { VerifyResult } from "./allow-list.js";
 
 export type LoadedBridge =
   | { kind: "yaml"; descriptor: YamlBridgeDescriptor; source: DiscoveredBridge }
@@ -65,22 +66,38 @@ export async function loadBridge(
     }
     case "npm-package": {
       if (!opts.skipAllowCheck) {
-        const allowed = await isAllowed(discovered.name, { path: opts.allowListPath });
-        if (!allowed) {
+        const verdict = await verifyAllow(discovered, { path: opts.allowListPath });
+        if (!verdict.ok) {
           throw new BridgeRuntimeError({
             bridge: discovered.name,
             op: "import",
             path: discovered.path,
             field: "(trust)",
-            expected: "allow-listed code plugin",
-            got: "not allowed",
-            hint: `npm code plugins run arbitrary JavaScript. First-use approval required. Run: flair bridge allow ${discovered.name}`,
+            expected: verdict.reason === "not-allowed" ? "allow-listed code plugin" : "approved package at recorded location/digest",
+            got: verdict.reason,
+            hint: trustHint(discovered.name, verdict),
           });
         }
       }
       const plugin = await loadCodePlugin(discovered, { importer: opts.importer });
       return { kind: "code", plugin, source: discovered };
     }
+  }
+}
+
+function trustHint(name: string, verdict: Exclude<VerifyResult, { ok: true }>): string {
+  const reapprove = `flair bridge allow ${name}`;
+  switch (verdict.reason) {
+    case "not-allowed":
+      return `npm code plugins run arbitrary JavaScript. First-use approval required. Run: ${reapprove}`;
+    case "path-mismatch":
+      return `approved package lives at ${verdict.entry.packageDir}, but a different package with the same name was discovered at ${verdict.observedPath}. This is how local squatting attacks present. If the new location is intentional, re-run: ${reapprove}`;
+    case "digest-mismatch":
+      return `package.json contents changed since approval (recorded sha ${verdict.entry.packageJsonSha256.slice(0, 12)}…, observed ${verdict.observedDigest.slice(0, 12)}…). Re-run if the update is intentional: ${reapprove}`;
+    case "entry-incomplete":
+      return `allow-list entry for "${name}" is missing a location/digest (likely from a pre-fix Flair version). Re-run: ${reapprove}`;
+    case "package-missing":
+      return `package at ${verdict.entry?.packageDir ?? "(unknown)"} could not be read; allow-list verification cannot proceed`;
   }
 }
 

--- a/src/bridges/types.ts
+++ b/src/bridges/types.ts
@@ -182,6 +182,13 @@ export interface BridgeError {
   expected?: string;
   got?: string;
   hint: string;
+  /**
+   * Extra structured data for error classes that need more than the core
+   * fields above. Used today by trust-check failures to carry approved vs.
+   * observed location/digest so the CLI can render them side-by-side.
+   * Optional — spec §10 errors continue to work with just the core fields.
+   */
+  context?: Record<string, string>;
 }
 
 export class BridgeRuntimeError extends Error {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -4045,10 +4045,94 @@ function printBridgeError(err: unknown): void {
   // spec, plus a one-line human summary so the operator gets both.
   const detail = (err as { detail?: Record<string, unknown> })?.detail;
   if (detail && typeof detail === "object") {
+    // Trust-check failures get a dedicated, operator-facing rendering.
+    // Dumping the full spec-§10 JSON is useful when an operator is
+    // debugging a broken YAML descriptor; for trust errors it buries the
+    // one thing that matters — the command to re-approve.
+    if ((detail as any).field === "(trust)") {
+      printTrustError(detail as any);
+      return;
+    }
     console.error(`Bridge error: ${(detail as any).hint ?? (err as Error).message}`);
     console.error(JSON.stringify(detail, null, 2));
   } else {
     console.error(`Bridge error: ${(err as Error).message ?? String(err)}`);
+  }
+}
+
+function printTrustError(detail: { bridge?: string; got?: string; context?: Record<string, string> }): void {
+  const name = detail.bridge ?? "(unknown)";
+  const ctx = detail.context ?? {};
+  const reapprove = `  flair bridge allow ${name}`;
+  const bar = "─".repeat(60);
+
+  const header = (title: string) => {
+    console.error("");
+    console.error(`⚠ ${title} — ${name}`);
+    console.error(bar);
+  };
+
+  const footer = (label: string) => {
+    console.error("");
+    console.error(`${label}:`);
+    console.error(reapprove);
+    console.error("");
+  };
+
+  switch (detail.got) {
+    case "not-allowed":
+      header("Approval required");
+      console.error("This bridge is an npm code plugin — it runs arbitrary JavaScript.");
+      console.error("First-use approval is required before Flair will execute it.");
+      footer("Approve it with");
+      return;
+
+    case "path-mismatch":
+      header("Trust check failed: package location changed");
+      console.error("A different package with the same name was discovered. This is how");
+      console.error("local squatting attacks present — a planted `node_modules/flair-bridge-*`");
+      console.error("in an unrelated project tree.");
+      console.error("");
+      console.error(`  approved: ${ctx.approvedPath ?? "(unknown)"}`);
+      console.error(`            version ${ctx.approvedVersion ?? "?"} at ${ctx.approvedAt ?? "?"}`);
+      console.error(`  now:      ${ctx.observedPath ?? "(unknown)"}`);
+      footer("If the new location is intentional, re-approve");
+      return;
+
+    case "digest-mismatch":
+      header("Trust check failed: package contents changed");
+      console.error("The package.json at the approved location has changed since you");
+      console.error("approved this bridge. This fires on every upgrade — it's a trust");
+      console.error("event, not an error. If the update is intentional, re-approve.");
+      console.error("");
+      console.error(`  location:          ${ctx.packagePath ?? "(unknown)"}`);
+      console.error(`  approved version:  ${ctx.approvedVersion ?? "?"}   (at ${ctx.approvedAt ?? "?"})`);
+      console.error(`  approved digest:   sha256:${(ctx.approvedDigest ?? "").slice(0, 16)}…`);
+      console.error(`  observed digest:   sha256:${(ctx.observedDigest ?? "").slice(0, 16)}…`);
+      footer("Re-approve");
+      return;
+
+    case "entry-incomplete":
+      header("Trust check failed: approval record is incomplete");
+      console.error("The allow-list entry for this bridge is missing a location or digest.");
+      console.error("This usually means the record was created by a pre-fix Flair version");
+      console.error("(0.6.0 / 0.6.1) that only stored the name. Re-approve to upgrade.");
+      footer("Re-approve");
+      return;
+
+    case "package-missing":
+      header("Trust check failed: approved package missing on disk");
+      console.error("The package location recorded at allow-time is no longer readable.");
+      console.error("");
+      console.error(`  approved at:  ${ctx.approvedPath ?? "(unknown)"}`);
+      console.error(`  discovered:   ${ctx.discoveredPath ?? "(unknown)"}`);
+      footer("Reinstall the package, then re-approve");
+      return;
+
+    default:
+      // Unknown trust sub-reason — fall back to the raw structured print.
+      console.error(`Bridge error (trust): ${(detail as any).hint ?? detail.got ?? "unknown"}`);
+      console.error(JSON.stringify(detail, null, 2));
   }
 }
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -3968,16 +3968,41 @@ bridge
 
 bridge
   .command("allow <name>")
-  .description("Approve an npm code-plugin bridge for execution (required on first use; skips on subsequent invocations)")
+  .description("Approve an npm code-plugin bridge for execution. Approval is pinned to the package's location and package.json contents — a malicious package squatting on the same name in a different node_modules tree will be refused at load-time.")
   .action(async (name: string) => {
+    const { discover } = await import("./bridges/discover.js");
+    const { builtinDiscoveryRecords } = await import("./bridges/builtins/index.js");
     const { allow } = await import("./bridges/runtime/allow-list.js");
-    const result = await allow(name);
-    if (result.alreadyAllowed) {
-      console.log(`${name} was already allowed — no change.`);
-      return;
+
+    const found = await discover({ builtins: builtinDiscoveryRecords() });
+    const target = found.find((b) => b.name === name);
+    if (!target) {
+      console.error(`No bridge named "${name}" — run \`flair bridge list\` to see installed bridges.`);
+      process.exit(1);
     }
-    console.log(`✓ ${name} allowed. npm code plugin execution is now enabled for this bridge.`);
-    console.log(`  Revoke anytime with: flair bridge revoke ${name}`);
+    if (target.source !== "npm-package") {
+      console.error(`"${name}" is a ${target.source} bridge; only npm code plugins require allow-list approval.`);
+      console.error(`YAML and built-in bridges run via the descriptor runtime and don't execute arbitrary JS.`);
+      process.exit(1);
+    }
+
+    try {
+      const result = await allow(name, target.path);
+      if (result.alreadyAllowed) {
+        console.log(`${name} was already allowed at ${result.entry.packageDir} — no change.`);
+        return;
+      }
+      const verb = result.updated ? "re-approved" : "allowed";
+      console.log(`✓ ${name} ${verb}.`);
+      console.log(`  location: ${result.entry.packageDir}`);
+      console.log(`  version:  ${result.entry.version ?? "(not declared)"}`);
+      console.log(`  digest:   ${result.entry.packageJsonSha256.slice(0, 16)}…`);
+      console.log(`  If the package later moves or its package.json content changes, execution is refused until you re-run this command.`);
+      console.log(`  Revoke anytime with: flair bridge revoke ${name}`);
+    } catch (err: any) {
+      console.error(`Failed to approve "${name}": ${err?.message ?? err}`);
+      process.exit(1);
+    }
   });
 
 bridge
@@ -4007,8 +4032,12 @@ bridge
       return;
     }
     const nameW = Math.max(4, ...entries.map((e) => e.name.length));
-    console.log(`  ${"name".padEnd(nameW)}  allowed-at`);
-    for (const e of entries) console.log(`  ${e.name.padEnd(nameW)}  ${e.allowedAt}`);
+    const verW = Math.max(7, ...entries.map((e) => (e.version ?? "—").length));
+    console.log(`  ${"name".padEnd(nameW)}  ${"version".padEnd(verW)}  allowed-at               location / digest`);
+    for (const e of entries) {
+      console.log(`  ${e.name.padEnd(nameW)}  ${(e.version ?? "—").padEnd(verW)}  ${e.allowedAt}  ${e.packageDir}`);
+      console.log(`  ${" ".repeat(nameW)}  ${" ".repeat(verW)}  ${" ".repeat(24)}  sha256:${e.packageJsonSha256.slice(0, 16)}…`);
+    }
   });
 
 function printBridgeError(err: unknown): void {

--- a/test/unit/bridges-allow-list.test.ts
+++ b/test/unit/bridges-allow-list.test.ts
@@ -1,16 +1,45 @@
 import { describe, test, expect, beforeEach, afterEach } from "bun:test";
-import { mkdirSync, rmSync, existsSync, readFileSync, writeFileSync } from "node:fs";
+import { mkdirSync, rmSync, existsSync, readFileSync, writeFileSync, realpathSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
-import { allow, revoke, list, isAllowed } from "../../src/bridges/runtime/allow-list";
+import { createHash } from "node:crypto";
+import {
+  allow,
+  revoke,
+  list,
+  isAllowed,
+  verifyAllow,
+  digestPackage,
+} from "../../src/bridges/runtime/allow-list";
+import type { DiscoveredBridge } from "../../src/bridges/types";
 
-function sandbox(): { path: string; cleanup: () => void } {
-  const dir = join(tmpdir(), `flair-allow-${Date.now()}-${Math.random().toString(36).slice(2)}`);
-  mkdirSync(dir, { recursive: true });
+function sandbox(): {
+  allowPath: string;
+  makePackage: (name: string, pkgJson?: Record<string, unknown>) => string;
+  root: string;
+  cleanup: () => void;
+} {
+  const dir = realpathSync(tmpdir());
+  const root = join(dir, `flair-allow-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+  mkdirSync(root, { recursive: true });
   return {
-    path: join(dir, "bridges-allowed.json"),
-    cleanup: () => rmSync(dir, { recursive: true, force: true }),
+    allowPath: join(root, "bridges-allowed.json"),
+    root,
+    makePackage: (name, pkgJson = {}) => {
+      const pkgDir = join(root, `pkg-${name}-${Math.random().toString(36).slice(2)}`);
+      mkdirSync(pkgDir, { recursive: true });
+      writeFileSync(
+        join(pkgDir, "package.json"),
+        JSON.stringify({ name: `flair-bridge-${name}`, version: "1.0.0", ...pkgJson }, null, 2),
+      );
+      return pkgDir;
+    },
+    cleanup: () => rmSync(root, { recursive: true, force: true }),
   };
+}
+
+function discovered(name: string, path: string): DiscoveredBridge {
+  return { name, kind: "api", source: "npm-package", path };
 }
 
 describe("allow-list: basic CRUD", () => {
@@ -19,65 +48,202 @@ describe("allow-list: basic CRUD", () => {
   afterEach(() => sb.cleanup());
 
   test("isAllowed returns false for an empty list (file absent)", async () => {
-    expect(await isAllowed("anything", { path: sb.path })).toBe(false);
+    expect(await isAllowed("anything", { path: sb.allowPath })).toBe(false);
   });
 
-  test("allow creates the file and records the entry", async () => {
-    const result = await allow("mem0", { path: sb.path });
+  test("allow creates the file and records a full entry with location + digest", async () => {
+    const pkg = sb.makePackage("mem0");
+    const result = await allow("mem0", pkg, { path: sb.allowPath });
     expect(result.alreadyAllowed).toBe(false);
-    expect(existsSync(sb.path)).toBe(true);
-    expect(await isAllowed("mem0", { path: sb.path })).toBe(true);
-    const saved = JSON.parse(readFileSync(sb.path, "utf-8"));
-    expect(Array.isArray(saved.allowed)).toBe(true);
-    expect(saved.allowed[0].name).toBe("mem0");
-    expect(saved.allowed[0].allowedAt).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+    expect(existsSync(sb.allowPath)).toBe(true);
+
+    const saved = JSON.parse(readFileSync(sb.allowPath, "utf-8"));
+    const entry = saved.allowed[0];
+    expect(entry.name).toBe("mem0");
+    expect(entry.allowedAt).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+    expect(entry.packageDir).toBe(realpathSync(pkg));
+    expect(entry.packageJsonSha256).toMatch(/^[0-9a-f]{64}$/);
+    expect(entry.version).toBe("1.0.0");
   });
 
-  test("allow is idempotent — re-adding returns alreadyAllowed", async () => {
-    await allow("mem0", { path: sb.path });
-    const result = await allow("mem0", { path: sb.path });
-    expect(result.alreadyAllowed).toBe(true);
-    const entries = await list({ path: sb.path });
+  test("allow is idempotent when location+digest unchanged", async () => {
+    const pkg = sb.makePackage("mem0");
+    await allow("mem0", pkg, { path: sb.allowPath });
+    const second = await allow("mem0", pkg, { path: sb.allowPath });
+    expect(second.alreadyAllowed).toBe(true);
+    const entries = await list({ path: sb.allowPath });
     expect(entries).toHaveLength(1);
   });
 
+  test("allow re-runs cleanly on legitimate updates (new digest replaces old)", async () => {
+    const pkg = sb.makePackage("mem0");
+    await allow("mem0", pkg, { path: sb.allowPath });
+    // Simulate a package upgrade that rewrites package.json
+    writeFileSync(join(pkg, "package.json"), JSON.stringify({ name: "flair-bridge-mem0", version: "1.1.0" }, null, 2));
+    const result = await allow("mem0", pkg, { path: sb.allowPath });
+    expect(result.alreadyAllowed).toBe(false);
+    expect(result.updated).toBe(true);
+    const entries = await list({ path: sb.allowPath });
+    expect(entries).toHaveLength(1);
+    expect(entries[0].version).toBe("1.1.0");
+  });
+
   test("revoke removes the entry and reports wasAllowed", async () => {
-    await allow("mem0", { path: sb.path });
-    const result = await revoke("mem0", { path: sb.path });
+    const pkg = sb.makePackage("mem0");
+    await allow("mem0", pkg, { path: sb.allowPath });
+    const result = await revoke("mem0", { path: sb.allowPath });
     expect(result.wasAllowed).toBe(true);
-    expect(await isAllowed("mem0", { path: sb.path })).toBe(false);
+    expect(await isAllowed("mem0", { path: sb.allowPath })).toBe(false);
   });
 
   test("revoke on a missing entry reports wasAllowed=false, no-op", async () => {
-    const result = await revoke("never-allowed", { path: sb.path });
+    const result = await revoke("never-allowed", { path: sb.allowPath });
     expect(result.wasAllowed).toBe(false);
   });
 
   test("list returns entries sorted by name (deterministic file contents)", async () => {
-    await allow("zeta", { path: sb.path });
-    await allow("alpha", { path: sb.path });
-    await allow("middle", { path: sb.path });
-    const entries = await list({ path: sb.path });
+    await allow("zeta", sb.makePackage("zeta"), { path: sb.allowPath });
+    await allow("alpha", sb.makePackage("alpha"), { path: sb.allowPath });
+    await allow("middle", sb.makePackage("middle"), { path: sb.allowPath });
+    const entries = await list({ path: sb.allowPath });
     expect(entries.map((e) => e.name)).toEqual(["alpha", "middle", "zeta"]);
   });
 
   test("malformed JSON file is tolerated as an empty list", async () => {
-    writeFileSync(sb.path, "{definitely not valid json");
-    expect(await isAllowed("anything", { path: sb.path })).toBe(false);
-    // A subsequent allow overwrites the corrupt file cleanly.
-    await allow("mem0", { path: sb.path });
-    expect(await isAllowed("mem0", { path: sb.path })).toBe(true);
+    writeFileSync(sb.allowPath, "{definitely not valid json");
+    expect(await isAllowed("anything", { path: sb.allowPath })).toBe(false);
+    await allow("mem0", sb.makePackage("mem0"), { path: sb.allowPath });
+    expect(await isAllowed("mem0", { path: sb.allowPath })).toBe(true);
   });
 
-  test("entries missing required fields are filtered on read", async () => {
-    writeFileSync(sb.path, JSON.stringify({ allowed: [{ name: "ok", allowedAt: new Date().toISOString() }, { name: "bad" }, { foo: "missing name" }] }));
-    const entries = await list({ path: sb.path });
+  test("entries missing required fields are filtered on read (legacy migration)", async () => {
+    const pkg = sb.makePackage("ok");
+    const digest = createHash("sha256").update(readFileSync(join(pkg, "package.json"))).digest("hex");
+    writeFileSync(sb.allowPath, JSON.stringify({
+      allowed: [
+        { name: "ok", allowedAt: new Date().toISOString(), packageDir: realpathSync(pkg), packageJsonSha256: digest },
+        // Legacy name-only row from 0.6.0/0.6.1 — dropped on read.
+        { name: "legacy", allowedAt: new Date().toISOString() },
+        { name: "bad" },
+        { foo: "missing name" },
+      ],
+    }));
+    const entries = await list({ path: sb.allowPath });
     expect(entries.map((e) => e.name)).toEqual(["ok"]);
   });
 
   test("writes are atomic (no leftover .tmp on success)", async () => {
-    await allow("mem0", { path: sb.path });
-    const siblings = require("node:fs").readdirSync(require("node:path").dirname(sb.path));
+    await allow("mem0", sb.makePackage("mem0"), { path: sb.allowPath });
+    const siblings = require("node:fs").readdirSync(require("node:path").dirname(sb.allowPath));
     expect(siblings.filter((f: string) => f.endsWith(".tmp"))).toEqual([]);
+  });
+});
+
+describe("digestPackage: content hashing", () => {
+  let sb: ReturnType<typeof sandbox>;
+  beforeEach(() => { sb = sandbox(); });
+  afterEach(() => sb.cleanup());
+
+  test("returns stable sha + canonical path + version", async () => {
+    const pkg = sb.makePackage("mem0", { version: "2.5.0" });
+    const { canonicalDir, sha256, version } = await digestPackage(pkg);
+    expect(canonicalDir).toBe(realpathSync(pkg));
+    expect(sha256).toMatch(/^[0-9a-f]{64}$/);
+    expect(version).toBe("2.5.0");
+  });
+
+  test("sha changes when package.json content changes", async () => {
+    const pkg = sb.makePackage("mem0");
+    const first = await digestPackage(pkg);
+    writeFileSync(join(pkg, "package.json"), JSON.stringify({ name: "flair-bridge-mem0", version: "9.9.9" }, null, 2));
+    const second = await digestPackage(pkg);
+    expect(second.sha256).not.toBe(first.sha256);
+  });
+
+  test("throws when package.json is missing", async () => {
+    let thrown: any = null;
+    try { await digestPackage(join(sb.root, "does-not-exist")); } catch (e) { thrown = e; }
+    expect(thrown).not.toBeNull();
+  });
+});
+
+describe("verifyAllow: load-time squatting defense", () => {
+  let sb: ReturnType<typeof sandbox>;
+  beforeEach(() => { sb = sandbox(); });
+  afterEach(() => sb.cleanup());
+
+  test("ok when name + canonical path + digest all match the record", async () => {
+    const pkg = sb.makePackage("mem0");
+    await allow("mem0", pkg, { path: sb.allowPath });
+    const v = await verifyAllow(discovered("mem0", pkg), { path: sb.allowPath });
+    expect(v.ok).toBe(true);
+  });
+
+  test("not-allowed when name has no entry", async () => {
+    const pkg = sb.makePackage("mem0");
+    const v = await verifyAllow(discovered("mem0", pkg), { path: sb.allowPath });
+    expect(v.ok).toBe(false);
+    if (!v.ok) expect(v.reason).toBe("not-allowed");
+  });
+
+  test("path-mismatch when a squatter at a different directory uses the allowed name", async () => {
+    const real = sb.makePackage("mem0");
+    const squat = sb.makePackage("mem0"); // different dir, same short name
+    await allow("mem0", real, { path: sb.allowPath });
+    const v = await verifyAllow(discovered("mem0", squat), { path: sb.allowPath });
+    expect(v.ok).toBe(false);
+    if (!v.ok) {
+      expect(v.reason).toBe("path-mismatch");
+      if (v.reason === "path-mismatch") {
+        expect(v.entry.packageDir).toBe(realpathSync(real));
+        expect(v.observedPath).toBe(realpathSync(squat));
+      }
+    }
+  });
+
+  test("digest-mismatch when the package.json at the approved location changes after approval", async () => {
+    const pkg = sb.makePackage("mem0");
+    await allow("mem0", pkg, { path: sb.allowPath });
+    writeFileSync(join(pkg, "package.json"), JSON.stringify({ name: "flair-bridge-mem0", version: "9.9.9", backdoor: true }, null, 2));
+    const v = await verifyAllow(discovered("mem0", pkg), { path: sb.allowPath });
+    expect(v.ok).toBe(false);
+    if (!v.ok) expect(v.reason).toBe("digest-mismatch");
+  });
+
+  test("package-missing when the approved directory no longer exists on disk", async () => {
+    const pkg = sb.makePackage("mem0");
+    await allow("mem0", pkg, { path: sb.allowPath });
+    rmSync(pkg, { recursive: true, force: true });
+    const v = await verifyAllow(discovered("mem0", pkg), { path: sb.allowPath });
+    expect(v.ok).toBe(false);
+    if (!v.ok) expect(v.reason).toBe("package-missing");
+  });
+
+  test("entry-incomplete when someone hand-edits the file to drop the digest fields", async () => {
+    const pkg = sb.makePackage("mem0");
+    // Write a synthetic row that claims to be an entry but with only name+allowedAt.
+    // read() filters these out, so we bypass it by writing a structurally complete
+    // row whose packageDir + sha are the empty string — verifyAllow must still refuse.
+    writeFileSync(sb.allowPath, JSON.stringify({
+      allowed: [{
+        name: "mem0",
+        allowedAt: new Date().toISOString(),
+        packageDir: "",
+        packageJsonSha256: "",
+      }],
+    }));
+    const v = await verifyAllow(discovered("mem0", pkg), { path: sb.allowPath });
+    expect(v.ok).toBe(false);
+    if (!v.ok) expect(v.reason).toBe("entry-incomplete");
+  });
+
+  test("legacy name-only rows trigger not-allowed (read() filters them out)", async () => {
+    const pkg = sb.makePackage("mem0");
+    writeFileSync(sb.allowPath, JSON.stringify({
+      allowed: [{ name: "mem0", allowedAt: new Date().toISOString() }],
+    }));
+    const v = await verifyAllow(discovered("mem0", pkg), { path: sb.allowPath });
+    expect(v.ok).toBe(false);
+    if (!v.ok) expect(v.reason).toBe("not-allowed");
   });
 });

--- a/test/unit/bridges-load-bridge.test.ts
+++ b/test/unit/bridges-load-bridge.test.ts
@@ -1,15 +1,29 @@
 import { describe, test, expect, beforeEach, afterEach } from "bun:test";
-import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, rmSync, writeFileSync, realpathSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { loadBridge } from "../../src/bridges/runtime/load-bridge";
+import { allow } from "../../src/bridges/runtime/allow-list";
 import { BridgeRuntimeError } from "../../src/bridges/types";
 import type { DiscoveredBridge, MemoryBridge } from "../../src/bridges/types";
 
-function sandbox(): { dir: string; cleanup: () => void } {
-  const dir = join(tmpdir(), `flair-loadbridge-${Date.now()}-${Math.random().toString(36).slice(2)}`);
-  mkdirSync(dir, { recursive: true });
-  return { dir, cleanup: () => rmSync(dir, { recursive: true, force: true }) };
+function sandbox(): { dir: string; cleanup: () => void; makePackage: (name: string) => string } {
+  const dir = realpathSync(tmpdir());
+  const root = join(dir, `flair-loadbridge-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+  mkdirSync(root, { recursive: true });
+  return {
+    dir: root,
+    makePackage: (name: string) => {
+      const pkgDir = join(root, `pkg-${name}-${Math.random().toString(36).slice(2)}`);
+      mkdirSync(pkgDir, { recursive: true });
+      writeFileSync(
+        join(pkgDir, "package.json"),
+        JSON.stringify({ name: `flair-bridge-${name}`, version: "1.0.0" }, null, 2),
+      );
+      return pkgDir;
+    },
+    cleanup: () => rmSync(root, { recursive: true, force: true }),
+  };
 }
 
 const codePlugin: MemoryBridge = {
@@ -41,7 +55,8 @@ describe("loadBridge: dispatch by source", () => {
   });
 
   test("npm-package without allow-list entry → BridgeRuntimeError pointing at `flair bridge allow`", async () => {
-    const d: DiscoveredBridge = { name: "mem0", kind: "api", source: "npm-package", path: "/fake" };
+    const pkg = sb.makePackage("mem0");
+    const d: DiscoveredBridge = { name: "mem0", kind: "api", source: "npm-package", path: pkg };
     const allowPath = join(sb.dir, "bridges-allowed.json");
     let thrown: any = null;
     try {
@@ -49,19 +64,54 @@ describe("loadBridge: dispatch by source", () => {
     } catch (e) { thrown = e; }
     expect(thrown).toBeInstanceOf(BridgeRuntimeError);
     expect(thrown.detail.hint).toMatch(/flair bridge allow mem0/);
+    expect(thrown.detail.got).toBe("not-allowed");
   });
 
-  test("npm-package with allow-list entry → kind=code + loaded plugin", async () => {
+  test("npm-package with matching allow-list entry → kind=code + loaded plugin", async () => {
+    const pkg = sb.makePackage("mem0");
     const allowPath = join(sb.dir, "bridges-allowed.json");
-    writeFileSync(allowPath, JSON.stringify({ allowed: [{ name: "mem0", allowedAt: new Date().toISOString() }] }));
-    const d: DiscoveredBridge = { name: "mem0", kind: "api", source: "npm-package", path: "/fake" };
+    await allow("mem0", pkg, { path: allowPath });
+    const d: DiscoveredBridge = { name: "mem0", kind: "api", source: "npm-package", path: pkg };
     const loaded = await loadBridge(d, { allowListPath: allowPath, importer: async () => ({ bridge: codePlugin }) });
     expect(loaded.kind).toBe("code");
     if (loaded.kind === "code") expect(loaded.plugin.name).toBe("mem0");
   });
 
+  test("npm-package with allow entry but squatted path → refused with path-mismatch hint", async () => {
+    const real = sb.makePackage("mem0");
+    const squat = sb.makePackage("mem0"); // different dir, same short name
+    const allowPath = join(sb.dir, "bridges-allowed.json");
+    await allow("mem0", real, { path: allowPath });
+    const d: DiscoveredBridge = { name: "mem0", kind: "api", source: "npm-package", path: squat };
+    let thrown: any = null;
+    try {
+      await loadBridge(d, { allowListPath: allowPath, importer: async () => ({ bridge: codePlugin }) });
+    } catch (e) { thrown = e; }
+    expect(thrown).toBeInstanceOf(BridgeRuntimeError);
+    expect(thrown.detail.got).toBe("path-mismatch");
+    expect(thrown.detail.hint).toMatch(/squatting/);
+    expect(thrown.detail.hint).toMatch(/flair bridge allow mem0/);
+  });
+
+  test("npm-package with allow entry but modified package.json → refused with digest-mismatch hint", async () => {
+    const pkg = sb.makePackage("mem0");
+    const allowPath = join(sb.dir, "bridges-allowed.json");
+    await allow("mem0", pkg, { path: allowPath });
+    // Tamper with package.json after approval
+    writeFileSync(join(pkg, "package.json"), JSON.stringify({ name: "flair-bridge-mem0", version: "9.9.9", backdoor: true }, null, 2));
+    const d: DiscoveredBridge = { name: "mem0", kind: "api", source: "npm-package", path: pkg };
+    let thrown: any = null;
+    try {
+      await loadBridge(d, { allowListPath: allowPath, importer: async () => ({ bridge: codePlugin }) });
+    } catch (e) { thrown = e; }
+    expect(thrown).toBeInstanceOf(BridgeRuntimeError);
+    expect(thrown.detail.got).toBe("digest-mismatch");
+    expect(thrown.detail.hint).toMatch(/package\.json contents changed/);
+  });
+
   test("skipAllowCheck=true bypasses the allow-list (used by `bridge list`)", async () => {
-    const d: DiscoveredBridge = { name: "mem0", kind: "api", source: "npm-package", path: "/fake" };
+    const pkg = sb.makePackage("mem0");
+    const d: DiscoveredBridge = { name: "mem0", kind: "api", source: "npm-package", path: pkg };
     const loaded = await loadBridge(d, { skipAllowCheck: true, importer: async () => ({ bridge: codePlugin }) });
     expect(loaded.kind).toBe("code");
   });


### PR DESCRIPTION
## Summary

- Closes the local-squatting hole in the 0.6.1 bridge allow-list flagged by tps-sherlock on retroactive review of #282.
- `AllowEntry` now records `packageDir` (canonicalized) + `packageJsonSha256` + `version`. Load-time check refuses on any mismatch with a specific reason and a hint back to `flair bridge allow <name>`.
- CLI `flair bridge allow <name>` resolves the name via `discover()` before approval; rejects non-npm sources since YAML and built-ins don't execute arbitrary JS.

## Why

Prior to this fix, a user who ran `flair bridge allow mem0` in ProjectA also effectively approved any other `node_modules/flair-bridge-mem0` — including one planted in a cloned ProjectB with entirely different code. The allow-list key was the short name only; on load, `loadCodePlugin()` dynamically imported the discovered path without cross-checking against what was actually approved.

## Fix shape

- `AllowEntry`: `{ name, allowedAt, packageDir, packageJsonSha256, version? }`. `packageDir` is `fs.realpath` at allow-time (handles pnpm/hoisting). `packageJsonSha256` is hex sha256 of the package's `package.json` content.
- New `verifyAllow(discovered)` replaces `isAllowed(name)` in the load path. Result is `{ok:true}` or `{ok:false, reason: "not-allowed" | "path-mismatch" | "digest-mismatch" | "entry-incomplete" | "package-missing", ...}`. The trust-error hint is tailored per reason.
- `allow(name, packageDir)` requires a directory so the caller can't accidentally approve something without content.
- CLI `bridge allow <name>` runs `discover()` first; refuses non-npm sources with a clear message.
- Legacy name-only rows from 0.6.0/0.6.1 get filtered out on read → treated as `not-allowed` → operator re-approves once.

## Test plan

- [x] Unit tests: 24 new/updated cases in `bridges-allow-list.test.ts` + `bridges-load-bridge.test.ts`. All 456 unit tests pass.
- [x] Manual end-to-end: planted a squat-test scenario with two `flair-bridge-evil` packages in sibling projects. Approved from ProjectA. Loading from ProjectA succeeds; loading from ProjectB is refused with `path-mismatch` pointing at `flair bridge allow evil`. Tampering ProjectA's package.json after approval is refused with `digest-mismatch`.
- [x] `flair bridge allow-list` output updated to render the new fields (location + digest prefix) — operator can sanity-check what's recorded.

## Migration

- Operators on 0.6.1 with existing allow-list entries will hit `not-allowed` on next load → re-run `flair bridge allow <name>`. No known external consumers yet; acceptable one-time cost.

## Holds

- 0.6.2 cut held until this lands + tps-sherlock re-reviews the fix itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)