### PR TITLE
feat(plugins): Hermes memory provider (Lane A.1.a)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@ resources/*.js
 test-results/
 playwright-report/
 test/e2e/screenshots/
+plugins/**/__pycache__/
+plugins/**/*.pyc
+.pytest_cache/

--- a/plugins/hermes-flair/README.md
+++ b/plugins/hermes-flair/README.md
@@ -1,0 +1,78 @@
+# Flair memory plugin for Hermes
+
+[Flair](https://github.com/tpsdev-ai/flair) is the open-source memory + identity layer for agents. This plugin makes Flair the durable memory backend for [Hermes](https://github.com/NousResearch/hermes-agent) agents — per-agent-scoped, Ed25519-signed, semantic-searchable.
+
+## Why Flair underneath Hermes
+
+Hermes already ships great built-in memory (MEMORY.md / USER.md). Flair extends it with:
+
+- **Per-agent isolation enforced server-side.** Each Hermes agent identity gets its own Ed25519 keypair; cross-agent reads are refused at the API layer, not by client convention.
+- **Agent-authored, no LLM-extraction-on-every-turn.** The agent decides what's worth remembering via the `flair_store` tool. No silent server-side fact extraction, no surprise persistence.
+- **Self-hosted, no SaaS dependency.** Runs on a Mac Mini, a Raspberry Pi, or a cloud VM. Single Harper-backed binary.
+- **Same backend for memory + identity.** Soul (who I am), agent registry (who else exists), and memories all live in one place — so the plugin can answer "who am I and what do I know" from a single source.
+- **Portable across orchestrators.** The same Flair memory works under Hermes, Claude Code, Gemini CLI, OpenAI Codex CLI, and any other agent runtime that has a memory plugin slot. Switch orchestrators without losing your agent's state.
+
+## Setup
+
+```bash
+# 1. Install Flair
+npm i -g @tpsdev-ai/flair
+flair init
+
+# 2. Provision an Ed25519 identity for your Hermes agent
+flair agent add hermes
+# → writes ~/.flair/keys/hermes.key (PKCS8 base64)
+
+# 3. Activate this plugin in Hermes
+hermes memory enable flair
+```
+
+## Configuration
+
+Provide via environment variables, or `$HERMES_HOME/flair.json`:
+
+| Setting          | Env var          | Default                             | Notes                                           |
+|------------------|------------------|-------------------------------------|-------------------------------------------------|
+| Server URL       | `FLAIR_URL`      | `http://127.0.0.1:9926`              | Override for remote Flair deployments           |
+| Agent ID         | `FLAIR_AGENT_ID` | `hermes`                            | Must match `flair agent add <id>`               |
+| Private key path | `FLAIR_KEY_PATH` | `~/.flair/keys/<agent>.key`         | PKCS8 base64 Ed25519 key created above          |
+
+Example `flair.json`:
+
+```json
+{
+  "url": "http://127.0.0.1:9926",
+  "agent_id": "hermes",
+  "bootstrap_limit": 10,
+  "recall_limit": 5
+}
+```
+
+## What this plugin does
+
+**At session start.** Pulls the agent's permanent + recent memories from Flair and injects them into the system prompt. Cheap (one HTTP GET).
+
+**Every turn.** Background-prefetches semantic-search results for the upcoming user message; injects relevant prior context into the next turn's prompt.
+
+**On demand.** Exposes two tools:
+
+- `flair_search(query, limit?)` — semantic search across this agent's memories.
+- `flair_store(content, durability?, tags?)` — persist a memory entry. Stored verbatim; no LLM extraction.
+
+**On Hermes built-in memory writes.** Mirrors `MEMORY.md` / `USER.md` `add` operations into Flair (tagged `hermes-builtin:memory|user`) so the durable record survives even if Hermes's local files get reset.
+
+## What this plugin deliberately doesn't do
+
+- **No background "summarize the conversation and persist insights."** The agent decides what's worth remembering. If it wanted something stored it should have called `flair_store`.
+- **No replace/remove mirroring** of Hermes built-in writes. Flair's model is append-only with explicit `supersedes` chaining; Hermes's substring-match replace doesn't translate cleanly. Replace operations stay local to MEMORY.md.
+- **No cross-agent reads.** Even if the same Flair instance hosts memories for several Hermes agents, each can only see its own memories. Cross-agent memory sharing is a Flair-layer feature (`flair memory share`) not exposed through this plugin.
+
+## Operational notes
+
+- **Circuit breaker.** After 5 consecutive Flair API failures, the plugin pauses calls for 2 minutes to avoid hammering a down server. The agent's built-in MEMORY.md continues to work normally during the outage.
+- **Non-primary contexts.** Cron-triggered Hermes runs and subagents skip Flair writes (per `agent_context` from `MemoryProvider.initialize`) to avoid corrupting the agent's representation of itself.
+- **Key safety.** The Ed25519 private key never leaves the Hermes host. Only signed requests cross the wire. `chmod 600 ~/.flair/keys/<agent>.key` is enforced by `flair agent add`.
+
+## Status
+
+Filed alongside Flair's other agent-framework adapters (Claude Code, Gemini CLI, OpenAI Codex). Tracking issue + roadmap in the [Flair repo](https://github.com/tpsdev-ai/flair). Upstream PR for `plugins/memory/flair/` in the Hermes repo to follow.

--- a/plugins/hermes-flair/__init__.py
+++ b/plugins/hermes-flair/__init__.py
@@ -1,0 +1,493 @@
+"""Flair memory plugin for Hermes — MemoryProvider interface.
+
+Flair is the open-source memory + identity layer for agents. This plugin
+makes Flair the durable memory backend for Hermes agents. Per-agent
+scoping is preserved: each Hermes agent identity maps to a Flair agentId
+and memories are isolated by that agentId end-to-end.
+
+Why Flair specifically:
+  - Agent-authored memory (no LLM-driven extraction by default — the agent
+    decides what's worth remembering).
+  - Self-hosted, no SaaS dependency. Runs on rockit, Mac Studio, a Pi.
+  - Ed25519 per-agent signing keys: cross-agent reads are refused by the
+    server, not by client convention.
+  - Same backend for memory + identity (soul + agent registry), so the
+    plugin can answer "who am I and what do I know" from one place.
+
+Config (env vars or $HERMES_HOME/flair.json):
+  FLAIR_URL          — Flair server URL (default: http://127.0.0.1:9926)
+  FLAIR_AGENT_ID     — Agent identifier (default: hermes)
+  FLAIR_KEY_PATH     — PKCS8 base64 private key file
+                       (default: ~/.flair/keys/<agent>.key)
+
+Bootstrap a Flair-side identity for this agent:
+  1. Install Flair: npm i -g @tpsdev-ai/flair
+  2. flair agent add <agent_id>      # creates ~/.flair/keys/<agent_id>.key
+  3. flair status                    # confirm server is healthy
+  4. hermes memory enable flair      # activates this provider
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import logging
+import os
+import threading
+import time
+import uuid
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from agent.memory_provider import MemoryProvider
+from tools.registry import tool_error
+
+logger = logging.getLogger(__name__)
+
+
+# ─── Config ────────────────────────────────────────────────────────────────
+
+DEFAULT_URL = "http://127.0.0.1:9926"
+DEFAULT_AGENT_ID = "hermes"
+DEFAULT_BOOTSTRAP_LIMIT = 10
+DEFAULT_RECALL_LIMIT = 5
+
+# Circuit breaker — cap consecutive failures before pausing API calls.
+_BREAKER_THRESHOLD = 5
+_BREAKER_COOLDOWN_SECS = 120
+
+
+def _default_key_path(agent_id: str) -> Path:
+    return Path.home() / ".flair" / "keys" / f"{agent_id}.key"
+
+
+def _load_config() -> dict:
+    """Load config from env vars, with $HERMES_HOME/flair.json overrides.
+
+    Env vars provide defaults; flair.json (if present) overrides individual
+    keys. Mirrors the pattern used by other Hermes memory plugins.
+    """
+    from hermes_constants import get_hermes_home
+
+    agent_id = os.environ.get("FLAIR_AGENT_ID", DEFAULT_AGENT_ID)
+    config = {
+        "url": os.environ.get("FLAIR_URL", DEFAULT_URL).rstrip("/"),
+        "agent_id": agent_id,
+        "key_path": os.environ.get("FLAIR_KEY_PATH", str(_default_key_path(agent_id))),
+        "bootstrap_limit": DEFAULT_BOOTSTRAP_LIMIT,
+        "recall_limit": DEFAULT_RECALL_LIMIT,
+    }
+
+    config_path = get_hermes_home() / "flair.json"
+    if config_path.exists():
+        try:
+            file_cfg = json.loads(config_path.read_text(encoding="utf-8"))
+            for k, v in file_cfg.items():
+                if v is not None and v != "":
+                    config[k] = v
+        except Exception:
+            logger.warning("flair.json present but unreadable — using env defaults")
+
+    return config
+
+
+# ─── Tool schemas ──────────────────────────────────────────────────────────
+
+SEARCH_SCHEMA = {
+    "name": "flair_search",
+    "description": (
+        "Semantic search across this agent's Flair memories. Returns relevant "
+        "entries ranked by similarity. Use when the agent needs prior context "
+        "from earlier sessions on this topic."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "query": {"type": "string", "description": "Natural-language query."},
+            "limit": {"type": "integer", "description": "Max results (default: 5, max: 20).",
+                      "minimum": 1, "maximum": 20},
+        },
+        "required": ["query"],
+    },
+}
+
+STORE_SCHEMA = {
+    "name": "flair_store",
+    "description": (
+        "Persist a memory entry to Flair. Stored verbatim — no LLM extraction. "
+        "Use for facts, decisions, preferences, lessons-learned. "
+        "Pick durability deliberately: 'permanent' for identity-defining facts "
+        "(rare), 'persistent' for important context, 'standard' for general "
+        "memories, 'ephemeral' for short-lived context."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "content": {"type": "string", "description": "What to remember."},
+            "durability": {
+                "type": "string",
+                "description": "Memory durability tier.",
+                "enum": ["permanent", "persistent", "standard", "ephemeral"],
+                "default": "standard",
+            },
+            "tags": {
+                "type": "array",
+                "description": "Optional tags for grouping (e.g. ['project:hermes', 'topic:auth']).",
+                "items": {"type": "string"},
+            },
+        },
+        "required": ["content"],
+    },
+}
+
+
+# ─── Ed25519 signing ───────────────────────────────────────────────────────
+
+def _load_private_key(key_path: str):
+    """Load PKCS8 base64-encoded Ed25519 key from a Flair-managed file."""
+    from cryptography.hazmat.primitives import serialization
+
+    raw = Path(key_path).read_text(encoding="utf-8").strip()
+    der = base64.b64decode(raw)
+    key = serialization.load_der_private_key(der, password=None)
+    return key
+
+
+def _sign_request(priv_key, agent_id: str, method: str, path: str) -> str:
+    """Build the TPS-Ed25519 Authorization header value."""
+    ts = str(int(time.time() * 1000))
+    nonce = str(uuid.uuid4())
+    payload = f"{agent_id}:{ts}:{nonce}:{method}:{path}".encode("utf-8")
+    sig = priv_key.sign(payload)
+    sig_b64 = base64.b64encode(sig).decode("ascii")
+    return f"TPS-Ed25519 {agent_id}:{ts}:{nonce}:{sig_b64}"
+
+
+# ─── Provider implementation ────────────────────────────────────────────────
+
+class FlairMemoryProvider(MemoryProvider):
+    """Flair-backed memory: per-agent-scoped, Ed25519-signed, semantic-searchable."""
+
+    def __init__(self):
+        self._config: Optional[dict] = None
+        self._url = DEFAULT_URL
+        self._agent_id = DEFAULT_AGENT_ID
+        self._key_path = ""
+        self._priv_key = None
+        self._client_lock = threading.Lock()
+        self._client = None  # httpx.Client
+        # Background prefetch state (next-turn recall)
+        self._prefetch_lock = threading.Lock()
+        self._prefetch_result = ""
+        self._prefetch_thread: Optional[threading.Thread] = None
+        # Bootstrap context (one-shot at session start)
+        self._bootstrap_text = ""
+        # Circuit breaker
+        self._consecutive_failures = 0
+        self._breaker_open_until = 0.0
+
+    # ── Identity ─────────────────────────────────────────────────────────────
+
+    @property
+    def name(self) -> str:
+        return "flair"
+
+    def is_available(self) -> bool:
+        cfg = _load_config()
+        # Available iff a key file exists for the configured agent.
+        # We deliberately do NOT touch the network here per the ABC contract.
+        try:
+            return Path(cfg["key_path"]).exists()
+        except Exception:
+            return False
+
+    def get_config_schema(self) -> List[Dict[str, Any]]:
+        return [
+            {
+                "key": "url",
+                "description": "Flair server URL",
+                "default": DEFAULT_URL,
+                "env_var": "FLAIR_URL",
+            },
+            {
+                "key": "agent_id",
+                "description": "Agent identifier (must match `flair agent add <id>`)",
+                "default": DEFAULT_AGENT_ID,
+                "required": True,
+                "env_var": "FLAIR_AGENT_ID",
+            },
+            {
+                "key": "key_path",
+                "description": "Path to PKCS8 base64 Ed25519 private key (created by `flair agent add`)",
+                "secret": True,
+                "env_var": "FLAIR_KEY_PATH",
+            },
+        ]
+
+    def save_config(self, values: Dict[str, Any], hermes_home: str) -> None:
+        """Persist non-secret config to $HERMES_HOME/flair.json."""
+        path = Path(hermes_home) / "flair.json"
+        existing = {}
+        if path.exists():
+            try:
+                existing = json.loads(path.read_text(encoding="utf-8"))
+            except Exception:
+                existing = {}
+        existing.update({k: v for k, v in values.items() if v is not None and v != ""})
+        path.write_text(json.dumps(existing, indent=2) + "\n", encoding="utf-8")
+
+    # ── Lifecycle ────────────────────────────────────────────────────────────
+
+    def initialize(self, session_id: str, **kwargs) -> None:
+        self._config = _load_config()
+        self._url = self._config["url"]
+        self._agent_id = self._config["agent_id"]
+        self._key_path = self._config["key_path"]
+        try:
+            self._priv_key = _load_private_key(self._key_path)
+        except Exception as exc:
+            logger.error("flair: failed to load private key at %s: %s", self._key_path, exc)
+            raise
+
+        agent_context = kwargs.get("agent_context", "primary")
+        # Skip writes from non-primary contexts (cron prompts, flush passes)
+        # to avoid corrupting the agent's representation of itself.
+        self._is_primary = agent_context in ("primary", "")
+
+        # Warm bootstrap: fetch recent + permanent memories synchronously so
+        # the first turn's prompt has context. Cheap (single GET).
+        self._bootstrap_text = self._fetch_bootstrap()
+        logger.info(
+            "flair: initialized (agent=%s, url=%s, primary=%s, bootstrap=%d chars)",
+            self._agent_id, self._url, self._is_primary, len(self._bootstrap_text),
+        )
+
+    def shutdown(self) -> None:
+        with self._client_lock:
+            if self._client is not None:
+                try:
+                    self._client.close()
+                except Exception:
+                    pass
+                self._client = None
+
+    # ── System prompt + recall ───────────────────────────────────────────────
+
+    def system_prompt_block(self) -> str:
+        if not self._bootstrap_text:
+            return ""
+        return (
+            "## Flair memory (recent + persistent)\n\n"
+            f"{self._bootstrap_text}\n\n"
+            "_Use `flair_search <query>` for prior context on a specific topic, "
+            "and `flair_store` to persist new facts you want to remember next session._"
+        )
+
+    def prefetch(self, query: str, *, session_id: str = "") -> str:
+        """Return last-prefetched recall text. The next-turn prefetch is queued
+        by `queue_prefetch` after each turn completes."""
+        with self._prefetch_lock:
+            text = self._prefetch_result
+            self._prefetch_result = ""
+        return text
+
+    def queue_prefetch(self, query: str, *, session_id: str = "") -> None:
+        """Kick off a background recall for the next turn."""
+        if self._is_breaker_open():
+            return
+
+        def _do_prefetch():
+            try:
+                results = self._semantic_search(query, limit=self._config.get("recall_limit", DEFAULT_RECALL_LIMIT))
+                if not results:
+                    return
+                lines = ["## Flair recall (relevant prior context)\n"]
+                for r in results:
+                    snippet = (r.get("content") or "").replace("\n", " ").strip()[:280]
+                    lines.append(f"- {snippet}")
+                with self._prefetch_lock:
+                    self._prefetch_result = "\n".join(lines)
+            except Exception as exc:
+                logger.debug("flair prefetch failed: %s", exc)
+
+        # Don't pile up threads; if a prior prefetch is still running, drop this request.
+        if self._prefetch_thread is not None and self._prefetch_thread.is_alive():
+            return
+        self._prefetch_thread = threading.Thread(target=_do_prefetch, daemon=True)
+        self._prefetch_thread.start()
+
+    def sync_turn(self, user_content: str, assistant_content: str, *, session_id: str = "") -> None:
+        """No-op: Flair memory is agent-authored. The model decides what to
+        store via `flair_store`. This avoids the LLM-extraction-on-every-turn
+        spam pattern that other backends fall into."""
+        return
+
+    # ── Tools ────────────────────────────────────────────────────────────────
+
+    def get_tool_schemas(self) -> List[Dict[str, Any]]:
+        return [SEARCH_SCHEMA, STORE_SCHEMA]
+
+    def handle_tool_call(self, tool_name: str, args: Dict[str, Any], **kwargs) -> str:
+        if self._is_breaker_open():
+            return tool_error(
+                "flair: circuit breaker open — too many consecutive Flair API failures. "
+                "Will retry in a couple minutes."
+            )
+        try:
+            if tool_name == "flair_search":
+                results = self._semantic_search(
+                    query=args["query"],
+                    limit=int(args.get("limit", DEFAULT_RECALL_LIMIT)),
+                )
+                self._record_success()
+                return json.dumps({"results": results})
+            if tool_name == "flair_store":
+                if not self._is_primary:
+                    return json.dumps({"stored": False, "reason": "non-primary agent context — write skipped"})
+                stored = self._store_memory(
+                    content=args["content"],
+                    durability=args.get("durability", "standard"),
+                    tags=args.get("tags") or [],
+                )
+                self._record_success()
+                return json.dumps({"stored": True, "id": stored.get("id")})
+        except Exception as exc:
+            self._record_failure()
+            logger.warning("flair: tool '%s' failed: %s", tool_name, exc)
+            return tool_error(f"flair: {tool_name} failed: {exc}")
+
+        return tool_error(f"flair: unknown tool '{tool_name}'")
+
+    # ── HTTP plumbing ────────────────────────────────────────────────────────
+
+    def _http(self):
+        with self._client_lock:
+            if self._client is None:
+                import httpx
+                self._client = httpx.Client(base_url=self._url, timeout=15.0)
+            return self._client
+
+    def _request(self, method: str, path: str, *, json_body: Optional[dict] = None) -> Any:
+        if self._priv_key is None:
+            raise RuntimeError("flair: provider not initialized")
+        auth = _sign_request(self._priv_key, self._agent_id, method, path)
+        headers = {"Authorization": auth}
+        if json_body is not None:
+            headers["Content-Type"] = "application/json"
+        resp = self._http().request(method, path, headers=headers, json=json_body)
+        if resp.status_code >= 400:
+            raise RuntimeError(f"flair {method} {path} → {resp.status_code} {resp.text[:200]}")
+        ctype = resp.headers.get("content-type", "")
+        if "json" in ctype:
+            return resp.json()
+        return resp.text
+
+    def _fetch_bootstrap(self) -> str:
+        """Pull the most recent memories + permanent ones for system-prompt seed."""
+        try:
+            rows = self._request("GET", f"/Memory/?agentId={self._agent_id}&limit={self._config.get('bootstrap_limit', DEFAULT_BOOTSTRAP_LIMIT)}")
+            if not isinstance(rows, list) or not rows:
+                return ""
+            lines = []
+            # Permanent first, then recent.
+            permanent = [r for r in rows if r.get("durability") == "permanent"]
+            recent = [r for r in rows if r.get("durability") != "permanent"]
+            for r in (permanent + recent)[: self._config.get("bootstrap_limit", DEFAULT_BOOTSTRAP_LIMIT)]:
+                content = (r.get("content") or "").replace("\n", " ").strip()[:280]
+                if content:
+                    lines.append(f"- {content}")
+            return "\n".join(lines)
+        except Exception as exc:
+            logger.warning("flair: bootstrap fetch failed: %s — system prompt will lack recall context", exc)
+            return ""
+
+    def _semantic_search(self, query: str, limit: int = DEFAULT_RECALL_LIMIT) -> List[Dict[str, Any]]:
+        body = {"agentId": self._agent_id, "q": query, "limit": min(max(limit, 1), 20)}
+        result = self._request("POST", "/SemanticSearch", json_body=body)
+        if isinstance(result, dict) and "results" in result:
+            return result["results"]
+        return []
+
+    def _store_memory(self, content: str, durability: str, tags: List[str]) -> Dict[str, Any]:
+        if durability not in ("permanent", "persistent", "standard", "ephemeral"):
+            durability = "standard"
+        memory_id = f"{self._agent_id}-{int(time.time() * 1000)}"
+        body = {
+            "id": memory_id,
+            "agentId": self._agent_id,
+            "content": content,
+            "durability": durability,
+            "createdAt": _iso_now(),
+        }
+        if tags:
+            body["tags"] = tags
+        result = self._request("PUT", f"/Memory/{memory_id}", json_body=body)
+        return {"id": memory_id, "result": result}
+
+    # ── Optional hooks ───────────────────────────────────────────────────────
+
+    def on_memory_write(
+        self,
+        action: str,
+        target: str,
+        content: str,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        """Mirror Hermes's built-in MEMORY.md/USER.md writes into Flair so the
+        agent's permanent recall stays consistent across restarts."""
+        if not self._is_primary or self._is_breaker_open():
+            return
+        if action != "add":
+            return  # Replace/remove map awkwardly to Flair's append-only model.
+        try:
+            tag = f"hermes-builtin:{target}"
+            self._store_memory(content=content, durability="persistent", tags=[tag])
+            self._record_success()
+        except Exception as exc:
+            logger.debug("flair: mirror write failed: %s", exc)
+            self._record_failure()
+
+    def on_session_end(self, messages: List[Dict[str, Any]]) -> None:
+        """Hermes calls this once per session. We deliberately do NOT extract
+        with an LLM here — Flair's contract is agent-authored. If the agent
+        wanted something stored, it should have used `flair_store` already."""
+        return
+
+    def on_pre_compress(self, messages: List[Dict[str, Any]]) -> str:
+        """Tell the compressor what Flair is contributing so it knows recall
+        will survive the compression discard."""
+        if self._bootstrap_text:
+            return (
+                "Flair memory layer is active and will retain agent-authored "
+                "facts independently of this conversation's window."
+            )
+        return ""
+
+    # ── Circuit breaker ──────────────────────────────────────────────────────
+
+    def _is_breaker_open(self) -> bool:
+        if self._consecutive_failures < _BREAKER_THRESHOLD:
+            return False
+        if time.monotonic() >= self._breaker_open_until:
+            self._consecutive_failures = 0
+            return False
+        return True
+
+    def _record_success(self):
+        self._consecutive_failures = 0
+
+    def _record_failure(self):
+        self._consecutive_failures += 1
+        if self._consecutive_failures >= _BREAKER_THRESHOLD:
+            self._breaker_open_until = time.monotonic() + _BREAKER_COOLDOWN_SECS
+            logger.warning(
+                "flair circuit breaker tripped after %d failures. Pausing %ds.",
+                self._consecutive_failures, _BREAKER_COOLDOWN_SECS,
+            )
+
+
+# ─── Helpers ───────────────────────────────────────────────────────────────
+
+def _iso_now() -> str:
+    from datetime import datetime, timezone
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.000Z")

--- a/plugins/hermes-flair/plugin.yaml
+++ b/plugins/hermes-flair/plugin.yaml
@@ -1,0 +1,10 @@
+name: flair
+version: 0.1.0
+description: "Flair memory — agent-authored, per-agent-scoped, Ed25519-signed memory + identity layer that follows the agent across orchestrators."
+pip_dependencies:
+  - cryptography
+  - httpx
+hooks:
+  - on_session_end
+  - on_pre_compress
+  - on_memory_write

--- a/plugins/hermes-flair/test_plugin.py
+++ b/plugins/hermes-flair/test_plugin.py
@@ -1,0 +1,328 @@
+"""Unit tests for the Hermes-Flair memory plugin.
+
+Tests run without Hermes installed by stubbing the two Hermes-side imports
+(`agent.memory_provider` and `tools.registry`). Real-Hermes integration is
+covered by the plugin's appearance in upstream Hermes CI once landed.
+
+Run: python -m pytest plugins/hermes-flair/test_plugin.py -v
+"""
+
+from __future__ import annotations
+
+import base64
+import importlib
+import json
+import os
+import sys
+import tempfile
+import time
+import types
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+# ─── Stub Hermes-side modules so the plugin imports cleanly ────────────────
+
+def _install_hermes_stubs() -> None:
+    """Inject minimal stand-ins for `agent.memory_provider` and `tools.registry`."""
+    if "agent.memory_provider" not in sys.modules:
+        agent_mod = types.ModuleType("agent")
+        memprov_mod = types.ModuleType("agent.memory_provider")
+
+        class MemoryProvider:  # minimal ABC stand-in
+            pass
+
+        memprov_mod.MemoryProvider = MemoryProvider
+        agent_mod.memory_provider = memprov_mod
+        sys.modules["agent"] = agent_mod
+        sys.modules["agent.memory_provider"] = memprov_mod
+
+    if "tools.registry" not in sys.modules:
+        tools_mod = types.ModuleType("tools")
+        reg_mod = types.ModuleType("tools.registry")
+        reg_mod.tool_error = lambda msg: json.dumps({"error": msg})
+        tools_mod.registry = reg_mod
+        sys.modules["tools"] = tools_mod
+        sys.modules["tools.registry"] = reg_mod
+
+    if "hermes_constants" not in sys.modules:
+        hc_mod = types.ModuleType("hermes_constants")
+        hc_mod.get_hermes_home = lambda: Path(tempfile.gettempdir()) / "hermes-test-home"
+        sys.modules["hermes_constants"] = hc_mod
+
+
+_install_hermes_stubs()
+
+# Now safe to import the plugin under test
+sys.path.insert(0, str(Path(__file__).parent))
+import importlib.util as _ilu
+_spec = _ilu.spec_from_file_location("flair_plugin", str(Path(__file__).parent / "__init__.py"))
+flair_plugin = _ilu.module_from_spec(_spec)
+_spec.loader.exec_module(flair_plugin)
+
+
+# ─── Fixtures ──────────────────────────────────────────────────────────────
+
+@pytest.fixture
+def ed25519_key_file(tmp_path):
+    """Generate a real Ed25519 key, write as PKCS8 base64, return the path."""
+    from cryptography.hazmat.primitives import serialization
+    from cryptography.hazmat.primitives.asymmetric import ed25519
+
+    priv = ed25519.Ed25519PrivateKey.generate()
+    der = priv.private_bytes(
+        encoding=serialization.Encoding.DER,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.NoEncryption(),
+    )
+    key_b64 = base64.b64encode(der).decode("ascii")
+    path = tmp_path / "test-agent.key"
+    path.write_text(key_b64, encoding="utf-8")
+    return path
+
+
+@pytest.fixture
+def configured_provider(ed25519_key_file, monkeypatch):
+    monkeypatch.setenv("FLAIR_AGENT_ID", "test-agent")
+    monkeypatch.setenv("FLAIR_KEY_PATH", str(ed25519_key_file))
+    monkeypatch.setenv("FLAIR_URL", "http://test.invalid")
+    p = flair_plugin.FlairMemoryProvider()
+    # Skip _fetch_bootstrap network call by patching _request
+    with patch.object(p, "_request", return_value=[]):
+        p.initialize(session_id="test-session")
+    return p
+
+
+# ─── Config loading ────────────────────────────────────────────────────────
+
+def test_load_config_uses_env_vars(monkeypatch):
+    monkeypatch.setenv("FLAIR_URL", "http://flair.test:9926")
+    monkeypatch.setenv("FLAIR_AGENT_ID", "alpha")
+    monkeypatch.setenv("FLAIR_KEY_PATH", "/tmp/alpha.key")
+    cfg = flair_plugin._load_config()
+    assert cfg["url"] == "http://flair.test:9926"
+    assert cfg["agent_id"] == "alpha"
+    assert cfg["key_path"] == "/tmp/alpha.key"
+
+
+def test_load_config_strips_trailing_slash_from_url(monkeypatch):
+    monkeypatch.setenv("FLAIR_URL", "http://flair.test:9926/")
+    cfg = flair_plugin._load_config()
+    assert cfg["url"] == "http://flair.test:9926"
+
+
+def test_load_config_default_key_path_uses_agent_id(monkeypatch):
+    monkeypatch.setenv("FLAIR_AGENT_ID", "betatron")
+    monkeypatch.delenv("FLAIR_KEY_PATH", raising=False)
+    cfg = flair_plugin._load_config()
+    assert cfg["key_path"].endswith("/.flair/keys/betatron.key")
+
+
+def test_load_config_json_overrides_env(monkeypatch, tmp_path):
+    monkeypatch.setenv("FLAIR_AGENT_ID", "from-env")
+    home = tmp_path / "hermes"
+    home.mkdir()
+    (home / "flair.json").write_text(json.dumps({"agent_id": "from-json"}))
+
+    sys.modules["hermes_constants"].get_hermes_home = lambda: home
+    try:
+        cfg = flair_plugin._load_config()
+        assert cfg["agent_id"] == "from-json"
+    finally:
+        sys.modules["hermes_constants"].get_hermes_home = lambda: Path(tempfile.gettempdir()) / "hermes-test-home"
+
+
+# ─── Ed25519 signing ───────────────────────────────────────────────────────
+
+def test_load_private_key_round_trip(ed25519_key_file):
+    key = flair_plugin._load_private_key(str(ed25519_key_file))
+    # Should be able to sign without raising
+    sig = key.sign(b"hello")
+    assert isinstance(sig, bytes) and len(sig) == 64  # Ed25519 sig is 64 bytes
+
+
+def test_sign_request_format(ed25519_key_file):
+    key = flair_plugin._load_private_key(str(ed25519_key_file))
+    auth = flair_plugin._sign_request(key, "alpha", "GET", "/Memory/abc")
+    assert auth.startswith("TPS-Ed25519 ")
+    body = auth[len("TPS-Ed25519 "):]
+    parts = body.split(":")
+    assert len(parts) == 4
+    agent_id, ts, nonce, sig_b64 = parts
+    assert agent_id == "alpha"
+    assert ts.isdigit()
+    assert len(nonce) == 36  # uuid4 length
+    sig_bytes = base64.b64decode(sig_b64)
+    assert len(sig_bytes) == 64
+
+
+def test_sign_request_uses_unique_nonces(ed25519_key_file):
+    key = flair_plugin._load_private_key(str(ed25519_key_file))
+    a1 = flair_plugin._sign_request(key, "alpha", "GET", "/Memory/abc")
+    a2 = flair_plugin._sign_request(key, "alpha", "GET", "/Memory/abc")
+    nonce1 = a1.split(":")[2]
+    nonce2 = a2.split(":")[2]
+    assert nonce1 != nonce2  # nonce reuse defeats replay protection
+
+
+# ─── Provider lifecycle ────────────────────────────────────────────────────
+
+def test_is_available_true_when_key_exists(ed25519_key_file, monkeypatch):
+    monkeypatch.setenv("FLAIR_AGENT_ID", "test-agent")
+    monkeypatch.setenv("FLAIR_KEY_PATH", str(ed25519_key_file))
+    p = flair_plugin.FlairMemoryProvider()
+    assert p.is_available() is True
+
+
+def test_is_available_false_when_key_missing(monkeypatch, tmp_path):
+    monkeypatch.setenv("FLAIR_KEY_PATH", str(tmp_path / "does-not-exist.key"))
+    p = flair_plugin.FlairMemoryProvider()
+    assert p.is_available() is False
+
+
+def test_initialize_loads_key_and_sets_state(configured_provider):
+    assert configured_provider._priv_key is not None
+    assert configured_provider._agent_id == "test-agent"
+    assert configured_provider._url == "http://test.invalid"
+
+
+def test_initialize_marks_non_primary_context(ed25519_key_file, monkeypatch):
+    monkeypatch.setenv("FLAIR_AGENT_ID", "test-agent")
+    monkeypatch.setenv("FLAIR_KEY_PATH", str(ed25519_key_file))
+    p = flair_plugin.FlairMemoryProvider()
+    with patch.object(p, "_request", return_value=[]):
+        p.initialize(session_id="x", agent_context="cron")
+    assert p._is_primary is False
+
+
+# ─── Tool schemas ──────────────────────────────────────────────────────────
+
+def test_tool_schemas_expose_search_and_store(configured_provider):
+    schemas = configured_provider.get_tool_schemas()
+    names = {s["name"] for s in schemas}
+    assert names == {"flair_search", "flair_store"}
+    for s in schemas:
+        assert "description" in s
+        assert "parameters" in s
+
+
+def test_store_schema_durability_enum(configured_provider):
+    store = next(s for s in configured_provider.get_tool_schemas() if s["name"] == "flair_store")
+    durability = store["parameters"]["properties"]["durability"]
+    assert set(durability["enum"]) == {"permanent", "persistent", "standard", "ephemeral"}
+
+
+# ─── Tool call dispatch ────────────────────────────────────────────────────
+
+def test_handle_tool_call_search_dispatches_to_semantic(configured_provider):
+    with patch.object(configured_provider, "_semantic_search", return_value=[{"id": "x", "content": "hi"}]) as m:
+        result = configured_provider.handle_tool_call("flair_search", {"query": "auth", "limit": 3})
+    m.assert_called_once_with(query="auth", limit=3)
+    assert json.loads(result) == {"results": [{"id": "x", "content": "hi"}]}
+
+
+def test_handle_tool_call_store_persists_via_request(configured_provider):
+    fake_resp = {"id": "test-agent-12345", "ok": True}
+    with patch.object(configured_provider, "_request", return_value=fake_resp) as m:
+        result = configured_provider.handle_tool_call("flair_store", {
+            "content": "Nathan prefers terse responses",
+            "durability": "persistent",
+            "tags": ["pref:tone"],
+        })
+    parsed = json.loads(result)
+    assert parsed["stored"] is True
+    # Verify the PUT body had the right shape
+    call_args = m.call_args
+    method, path = call_args.args[0], call_args.args[1]
+    body = call_args.kwargs.get("json_body") or {}
+    assert method == "PUT"
+    assert path.startswith("/Memory/test-agent-")
+    assert body["agentId"] == "test-agent"
+    assert body["content"] == "Nathan prefers terse responses"
+    assert body["durability"] == "persistent"
+    assert body["tags"] == ["pref:tone"]
+
+
+def test_handle_tool_call_store_skipped_in_non_primary_context(ed25519_key_file, monkeypatch):
+    monkeypatch.setenv("FLAIR_AGENT_ID", "test-agent")
+    monkeypatch.setenv("FLAIR_KEY_PATH", str(ed25519_key_file))
+    p = flair_plugin.FlairMemoryProvider()
+    with patch.object(p, "_request", return_value=[]):
+        p.initialize(session_id="x", agent_context="cron")
+    result = p.handle_tool_call("flair_store", {"content": "should not write"})
+    parsed = json.loads(result)
+    assert parsed["stored"] is False
+    assert "non-primary" in parsed["reason"]
+
+
+def test_handle_tool_call_unknown_tool_returns_error(configured_provider):
+    result = configured_provider.handle_tool_call("flair_nonsense", {})
+    parsed = json.loads(result)
+    assert "error" in parsed
+    assert "unknown tool" in parsed["error"]
+
+
+def test_handle_tool_call_invalid_durability_falls_back_to_standard(configured_provider):
+    fake_resp = {"id": "x", "ok": True}
+    with patch.object(configured_provider, "_request", return_value=fake_resp) as m:
+        configured_provider.handle_tool_call("flair_store", {
+            "content": "x", "durability": "forever-and-ever-amen",
+        })
+    body = m.call_args.kwargs["json_body"]
+    assert body["durability"] == "standard"
+
+
+# ─── Circuit breaker ───────────────────────────────────────────────────────
+
+def test_circuit_breaker_trips_after_threshold(configured_provider, monkeypatch):
+    # Force every request to fail
+    with patch.object(configured_provider, "_request", side_effect=RuntimeError("boom")):
+        for _ in range(flair_plugin._BREAKER_THRESHOLD):
+            configured_provider.handle_tool_call("flair_search", {"query": "x"})
+    # Now the breaker should be open; subsequent call returns breaker-error
+    result = configured_provider.handle_tool_call("flair_search", {"query": "x"})
+    parsed = json.loads(result)
+    assert "error" in parsed
+    assert "circuit breaker" in parsed["error"]
+
+
+def test_circuit_breaker_resets_after_cooldown(configured_provider, monkeypatch):
+    with patch.object(configured_provider, "_request", side_effect=RuntimeError("boom")):
+        for _ in range(flair_plugin._BREAKER_THRESHOLD):
+            configured_provider.handle_tool_call("flair_search", {"query": "x"})
+    # Fast-forward time past the cooldown
+    monkeypatch.setattr(flair_plugin.time, "monotonic", lambda: configured_provider._breaker_open_until + 1)
+    # A successful call should reset the breaker
+    with patch.object(configured_provider, "_semantic_search", return_value=[]):
+        configured_provider.handle_tool_call("flair_search", {"query": "x"})
+    assert configured_provider._consecutive_failures == 0
+
+
+# ─── on_memory_write mirroring ─────────────────────────────────────────────
+
+def test_on_memory_write_mirrors_add_with_builtin_tag(configured_provider):
+    fake_resp = {"id": "x", "ok": True}
+    with patch.object(configured_provider, "_request", return_value=fake_resp) as m:
+        configured_provider.on_memory_write("add", "memory", "Nathan ships at 11pm", metadata={})
+    body = m.call_args.kwargs["json_body"]
+    assert body["content"] == "Nathan ships at 11pm"
+    assert body["durability"] == "persistent"
+    assert "hermes-builtin:memory" in body["tags"]
+
+
+def test_on_memory_write_skips_replace_and_remove(configured_provider):
+    with patch.object(configured_provider, "_request", side_effect=AssertionError("should not be called")):
+        configured_provider.on_memory_write("replace", "memory", "x", metadata={})
+        configured_provider.on_memory_write("remove", "user", "x", metadata={})
+
+
+def test_on_memory_write_skipped_in_non_primary(ed25519_key_file, monkeypatch):
+    monkeypatch.setenv("FLAIR_AGENT_ID", "test-agent")
+    monkeypatch.setenv("FLAIR_KEY_PATH", str(ed25519_key_file))
+    p = flair_plugin.FlairMemoryProvider()
+    with patch.object(p, "_request", return_value=[]):
+        p.initialize(session_id="x", agent_context="subagent")
+    with patch.object(p, "_request", side_effect=AssertionError("should not be called")):
+        p.on_memory_write("add", "memory", "should not mirror", metadata={})


### PR DESCRIPTION
## Summary

Ships the Flair memory provider for Nous Research's Hermes agent — first of four 1.0 agent-framework adapters (Hermes / Gemini CLI / OpenAI Codex / Claude Code polish).

## What lands

- `plugins/hermes-flair/__init__.py` — `FlairMemoryProvider(MemoryProvider)`. Bootstrap on init, background prefetch between turns, two tools (`flair_search`, `flair_store`), built-in MEMORY.md mirroring, circuit breaker.
- `plugins/hermes-flair/plugin.yaml` — manifest (pip deps + opted-in hooks).
- `plugins/hermes-flair/README.md` — setup, config, what-this-plugin-does (and deliberately doesn't).
- `plugins/hermes-flair/test_plugin.py` — 23 unit tests, stubs Hermes-side imports so they run without Hermes installed.

## Positioning

This is the inverse of FLAIR-BRIDGES: bridges pull foreign memory INTO Flair; this makes Flair the BACKEND for a foreign agent. Both directions matter for "memory portable across orchestrators." Same Flair instance, multiple orchestrators on top.

## Auth + isolation

TPS-Ed25519 signing with PKCS8 keys at `~/.flair/keys/<agent>.key`. Per-agent isolation enforced server-side (refused at the API layer, not by client convention). Nonces are per-request UUID4 — replay-safe.

## What's deliberately out of scope

- No background "summarize the conversation and persist insights." Flair is agent-authored. If the agent wanted something stored it should have called `flair_store`.
- No replace/remove mirroring of Hermes built-in writes. Flair is append-only with `supersedes` chaining; substring-match replace doesn't translate cleanly.
- No cross-agent reads. Each Hermes agent identity maps to its own Flair agentId.

## Test plan

- [x] 23 unit tests pass (`python -m pytest plugins/hermes-flair/test_plugin.py -v`)
- [x] Python syntax valid
- [ ] Real Hermes integration: dogfood once Hermes is installed locally; full e2e validation comes via the upstream PR to `NousResearch/hermes-agent` adding `plugins/memory/flair/`
- [ ] Operator-facing setup walk-through video (Lane A.3, separate task)

## Follow-ups (not blocking 1.0)

- Upstream PR to NousResearch/hermes-agent at `plugins/memory/flair/`
- `flair_recall_recent(N)` tool if turns out the agent needs explicit "show me the last N memories" beyond semantic search
- Replace/remove mirroring once we settle on a `supersedes`-based mapping that holds up

🤖 Generated with [Claude Code](https://claude.com/claude-code)