### PR TITLE
docs(changelog): catch up on 0.6.1 / 0.6.2 + record today's docs landings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,37 @@
 
 ## Unreleased
 
+### 📖 Docs
+
+- **`docs/mcp-clients.md` (#286)** — one page covering wiring the [`@tpsdev-ai/flair-mcp`](packages/flair-mcp) server into Claude Code, Gemini CLI, OpenAI Codex CLI, and Cursor. Per-CLI install snippets, env-var reference, troubleshooting. Closes the "we have an MCP server but no per-framework setup docs" gap.
+
+- **`docs/secrets-and-keys.md` (#287)** — draws the line between what Flair owns (Ed25519 agent identity) and what it doesn't (LLM provider API keys, third-party tokens). Patterns for OS keyring (macOS Keychain, Linux secret-service), 1Password CLI (`op run`), age + sops. Per-CLI examples for wiring API keys into Claude Code / Gemini CLI / Codex CLI / Hermes without leaking into shell history. Decision recorded inline: **no `flair secret` CLI in 1.0** — OS primitives are sufficient, adding a wrapper would be unowned bug surface.
+
+- **`docs/the-team.md` (#288)** — public reference implementation of how LifestyleLab runs the multi-agent team that builds Flair. Roster (Flint / Anvil / Kern / Sherlock / Pulse + Nathan), memory-flow diagram showing per-agent isolation, why we split runtimes / hardware tiers / API-vs-local, the standard PR handoff loop, and what we deliberately don't do (no shared team memory, no silent extraction). Becomes the operator-facing pattern for "copy this rig if you're trying to run your own."
+
+### 🔌 Plugin
+
+- **`plugins/hermes-flair/` (#285)** — Python `MemoryProvider` implementation of [Nous Research Hermes](https://github.com/NousResearch/hermes-agent)'s plugin contract. Makes Flair the durable memory backend for Hermes agents: bootstrap injection at session start, background prefetch between turns, two tools (`flair_search`, `flair_store`), built-in MEMORY.md mirroring, circuit breaker. TPS-Ed25519 auth with per-agent isolation enforced server-side. 23 unit tests pass with stubbed Hermes-side imports. First of several agent-framework integrations landing for 1.0; the others (Claude Code, Gemini CLI, OpenAI Codex CLI) all use the existing [`@tpsdev-ai/flair-mcp`](packages/flair-mcp) server (one MCP server, three install snippets) rather than per-framework adapters.
+
+## 0.6.2 (2026-04-25)
+
 ### 🔒 Security
 
 - **Bridge allow-list now pins approvals to package location + content digest (#283):** prior to this fix, `flair bridge allow <name>` stored only the short name. That left a local-squatting attack surface — a user who approved `mem0` in ProjectA could then `cd` into ProjectB shipping a planted `node_modules/flair-bridge-mem0` with the same npm name but different code, and the allow-list would happily pass it through to dynamic import. Approvals now record the canonical package directory and a sha256 of the package's `package.json`; at load time, both must still match the discovered package. Any mismatch refuses the load with a specific `path-mismatch` / `digest-mismatch` hint pointing back at `flair bridge allow <name>` for a deliberate re-approval. Legacy name-only entries from 0.6.0/0.6.1 are treated as invalid — operators must re-approve once. Reported by tps-sherlock on retroactive review of #282.
+
+### ✨ UX
+
+- **Operator-facing trust-error UX:** path-mismatch / digest-mismatch / not-allowed each render as a framed banner with operator-voice explanation, structured before/after values (approved location vs observed, approved digest vs observed), and the exact `flair bridge allow <name>` re-approve command. Replaces the spec-§10 JSON dump that was useful for descriptor-parse errors but buried the actionable command for trust events.
+
+## 0.6.1 (2026-04-24)
+
+### ✨ Features
+
+- **Memory Bridges — slice 3b: round-trip test harness (#281):** `flair bridge test` runs a fixture-to-fixture round-trip — parse a fixture file with the bridge's import map, filter by `when:` predicates, write via the bridge's export map, re-parse the output, and diff stable fields (content/subject/tags/durability). Single command verifies a bridge correctly preserves the data it claims to bridge.
+
+### 🐛 Bug Fixes
+
+- **`flair upgrade` detects installs outside the default npm prefix (#279):** now uses `execFileSync` with explicit argv (closes a CodeQL "uncontrolled command line" finding) and splits status into three states — current / outdated / unknown-prefix. Previously crashed on mise/fnm/nvm/volta setups whose npm-prefix probe returned a non-default location.
 
 ## 0.6.0 (2026-04-22)
 


### PR DESCRIPTION
## Summary

CHANGELOG had drifted from reality — 0.6.1 and 0.6.2 had no entries despite both shipping to npm, and today's four landings (#285 Hermes plugin, #286 mcp-clients docs, #287 secrets-and-keys docs, #288 the-team docs) sat on main without being noted in the Unreleased section.

This PR brings the file up to truth.

## What lands

- **0.6.2 (2026-04-25)** section promoting the squat fix (#283) from Unreleased + a UX bullet for the trust-error printer that shipped in the same release.
- **0.6.1 (2026-04-24)** section for slice-3b round-trip test harness (#281) + the `flair upgrade` out-of-prefix fix (#279).
- **Unreleased** section now lists today's four landings under 📖 Docs and 🔌 Plugin.

## Why

Pre-1.0 polish: the CHANGELOG is the canonical "what's in this release" reference, and right now it's lying. Bringing it up to truth is a no-brainer prerequisite to drafting the eventual 1.0 promotion.

## Test plan

- [x] No code changes — pure markdown
- [x] Each entry references a real merged PR
- [x] Section ordering: Unreleased → 0.6.2 → 0.6.1 → 0.6.0 → ...

🤖 Generated with [Claude Code](https://claude.com/claude-code)