### PR TITLE
feat(cli): --ops-target flag for non-derivable ops URLs (ops-yaeh)

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -118,12 +118,32 @@ function resolveTarget(opts: { target?: string }): string | undefined {
   return opts.target || process.env.FLAIR_TARGET || undefined;
 }
 
+/** Resolve the ops API target URL from --ops-target flag or FLAIR_OPS_TARGET env.
+ *  Returns undefined if neither is set (caller should fall back to derivation or localhost).
+ */
+function resolveOpsTarget(opts: { opsTarget?: string }): string | undefined {
+  return opts.opsTarget || process.env.FLAIR_OPS_TARGET || undefined;
+}
+
 /** Derive the ops API URL from a Flair base URL.
  *  Convention: ops port = HTTP port - 1.
  *  If target has an explicit port, use port-1 (validated: must be 1-65535).
  *  If no explicit port: https → 442 (443-1), http → 19925 (19926-1), bare host → https://<host>:19925.
  *  Throws on unparseable URLs.
  */
+/** Compute the effective ops API URL for remote commands.
+ *  - If --ops-target is set, use it directly (no derivation).
+ *  - Else if --target is set, derive ops URL via resolveOpsUrlFromTarget.
+ *  - Else return undefined (fall back to localhost resolution).
+ */
+function resolveEffectiveOpsUrl(opts: { target?: string; opsTarget?: string }): string | undefined {
+  const opsTarget = resolveOpsTarget(opts);
+  if (opsTarget) return opsTarget.replace(/\/$/, "");
+  const target = resolveTarget(opts);
+  if (target) return resolveOpsUrlFromTarget(target);
+  return undefined;
+}
+
 function resolveOpsUrlFromTarget(targetUrl: string): string {
   // Normalise bare hosts: add https:// prefix so URL parser can handle them.
   const normalised = targetUrl.includes("://") ? targetUrl : `https://${targetUrl}`;
@@ -622,26 +642,36 @@ program
   .option("--skip-soul", "Skip interactive personality setup")
   .option("--target <url>", "Remote Flair URL (env: FLAIR_TARGET)")
   .option("--remote", "When used with --target, init as hub for remote federation")
+  .option("--ops-target <url>", "Explicit ops API URL (env: FLAIR_OPS_TARGET; bypasses port derivation)")
   .option("--force", "Skip confirmation prompt for remote writes (required with --target)")
   .action(async (opts) => {
     const agentId: string = opts.agentId;
     const target = resolveTarget(opts);
+    const opsTarget = resolveOpsTarget(opts);
 
-    // ── Remote init: --target drives a remote Flair instance ──
-    if (target) {
+    // ── Remote init: --target and/or --ops-target drive a remote Flair instance ──
+    if (target || opsTarget) {
       const adminPass: string | undefined = opts.adminPass;
       if (!adminPass) {
-        console.error("Error: --admin-pass is required with --target (remote init)");
+        console.error("Error: --admin-pass is required with --target/--ops-target (remote init)");
         process.exit(1);
       }
       if (!opts.force) {
-        console.error(`Error: --force is required with --target. Remote init writes to a live Flair instance at ${target}.`);
+        const displayTarget = target || opsTarget;
+        console.error(`Error: --force is required with --target/--ops-target. Remote init writes to a live Flair instance at ${displayTarget}.`);
         console.error("  Pass --force to confirm this is intended.");
         process.exit(1);
       }
       const adminUser = DEFAULT_ADMIN_USER;
-      const baseUrl = target.replace(/\/$/, "");
-      const opsUrl = resolveOpsUrlFromTarget(baseUrl);
+      // When -only- --ops-target is provided, attempt to derive REST URL
+      if (!target && opsTarget) {
+        console.error("Error: --ops-target requires --target as well. Pass --target <rest-url> for the REST API surface.");
+        console.error("  Currently only explicit --ops-target + --target combination is supported.");
+        process.exit(1);
+      }
+      const baseUrl = target!.replace(/\/$/, "");
+      // --ops-target overrides derivation; otherwise derive from --target
+      const opsUrl = opsTarget ? opsTarget.replace(/\/$/, "") : resolveOpsUrlFromTarget(baseUrl);
       const auth = `Basic ${Buffer.from(`${adminUser}:${adminPass}`).toString("base64")}`;
       const role = opts.remote ? "hub" : undefined;
 
@@ -1851,6 +1881,7 @@ federation
   .description("Show federation status and peer connections")
   .option("--port <port>", "Harper HTTP port")
   .option("--target <url>", "Remote Flair URL (env: FLAIR_TARGET)")
+  .option("--ops-target <url>", "Explicit ops API URL (env: FLAIR_OPS_TARGET; bypasses port derivation)")
   .action(async (opts) => {
     const target = resolveTarget(opts);
     const baseUrl = target ? target.replace(/\/$/, "") : undefined;
@@ -1886,6 +1917,7 @@ federation
   .option("--ops-port <port>", "Harper operations API port")
   .option("--token <token>", "One-time pairing token from hub admin")
   .option("--target <url>", "Remote Flair URL (env: FLAIR_TARGET)")
+  .option("--ops-target <url>", "Explicit ops API URL (env: FLAIR_OPS_TARGET; bypasses port derivation)")
   .action(async (hubUrl: string, opts) => {
     const target = resolveTarget(opts);
     const baseUrl = target ? target.replace(/\/$/, "") : undefined;
@@ -1927,7 +1959,7 @@ federation
       const adminPass = opts.adminPass ?? process.env.FLAIR_ADMIN_PASS ?? "";
       if (adminPass) {
         const auth = `Basic ${Buffer.from(`${DEFAULT_ADMIN_USER}:${adminPass}`).toString("base64")}`;
-        const opsEndpoint = baseUrl ? resolveOpsUrlFromTarget(baseUrl) : `http://127.0.0.1:${resolveOpsPort(opts)}`;
+        const opsEndpoint = resolveEffectiveOpsUrl(opts) ?? `http://127.0.0.1:${resolveOpsPort(opts)}`;
         await fetch(`${opsEndpoint}/`, {
           method: "POST",
           headers: { "Content-Type": "application/json", Authorization: auth },
@@ -1959,6 +1991,7 @@ federation
   .option("--ops-port <port>", "Harper operations API port")
   .option("--ttl <minutes>", "Token TTL in minutes (default: 60)", "60")
   .option("--target <url>", "Remote Flair URL (env: FLAIR_TARGET)")
+  .option("--ops-target <url>", "Explicit ops API URL (env: FLAIR_OPS_TARGET; bypasses port derivation)")
   .action(async (opts) => {
     const target = resolveTarget(opts);
     const baseUrl = target ? target.replace(/\/$/, "") : undefined;
@@ -1968,7 +2001,7 @@ federation
       const ttlMinutes = parseInt(opts.ttl, 10) || 60;
       const expiresAt = new Date(Date.now() + ttlMinutes * 60 * 1000).toISOString();
 
-      const opsEndpoint = baseUrl ? resolveOpsUrlFromTarget(baseUrl) : `http://127.0.0.1:${resolveOpsPort(opts)}`;
+      const opsEndpoint = resolveEffectiveOpsUrl(opts) ?? `http://127.0.0.1:${resolveOpsPort(opts)}`;
       const adminPass: string = opts.adminPass ?? process.env.FLAIR_ADMIN_PASS ?? "";
       const auth = `Basic ${Buffer.from(`${DEFAULT_ADMIN_USER}:${adminPass}`).toString("base64")}`;
 
@@ -2003,6 +2036,7 @@ federation
   .option("--admin-pass <pass>", "Admin password")
   .option("--ops-port <port>", "Harper operations API port")
   .option("--target <url>", "Remote Flair URL (env: FLAIR_TARGET)")
+  .option("--ops-target <url>", "Explicit ops API URL (env: FLAIR_OPS_TARGET; bypasses port derivation)")
   .action(async (opts) => {
     const target = resolveTarget(opts);
     const baseUrl = target ? target.replace(/\/$/, "") : undefined;
@@ -2017,7 +2051,7 @@ federation
 
       console.log(`Syncing to hub: ${hub.id}...`);
       const since = hub.lastSyncAt ?? new Date(0).toISOString();
-      const opsEndpoint = baseUrl ? resolveOpsUrlFromTarget(baseUrl) : `http://127.0.0.1:${resolveOpsPort(opts)}`;
+      const opsEndpoint = resolveEffectiveOpsUrl(opts) ?? `http://127.0.0.1:${resolveOpsPort(opts)}`;
       const adminPass: string = opts.adminPass ?? process.env.FLAIR_ADMIN_PASS ?? "";
       const auth = `Basic ${Buffer.from(`${DEFAULT_ADMIN_USER}:${adminPass}`).toString("base64")}`;
       const tables = ["Memory", "Soul", "Agent", "Relationship"];
@@ -4854,6 +4888,8 @@ export {
   resolveHttpPort,
   resolveOpsPort,
   resolveTarget,
+  resolveOpsTarget,
+  resolveEffectiveOpsUrl,
   resolveOpsUrlFromTarget,
   signRequestBody,
   b64,

--- a/test/unit/cli-target-flag.test.ts
+++ b/test/unit/cli-target-flag.test.ts
@@ -14,6 +14,8 @@
 import { describe, test, expect, beforeEach, afterEach, mock } from "bun:test";
 import {
   resolveTarget,
+  resolveOpsTarget,
+  resolveEffectiveOpsUrl,
   resolveOpsUrlFromTarget,
   resolveHttpPort,
   program,
@@ -57,6 +59,101 @@ describe("resolveTarget", () => {
 
   test("returns undefined for empty string flag (falsy)", () => {
     expect(resolveTarget({ target: "" })).toBeUndefined();
+  });
+});
+
+// ─── resolveOpsTarget ──────────────────────────────────────────────────────────
+
+describe("resolveOpsTarget", () => {
+  let origFlairOpsTarget: string | undefined;
+
+  beforeEach(() => {
+    origFlairOpsTarget = process.env.FLAIR_OPS_TARGET;
+  });
+
+  afterEach(() => {
+    if (origFlairOpsTarget === undefined) delete process.env.FLAIR_OPS_TARGET;
+    else process.env.FLAIR_OPS_TARGET = origFlairOpsTarget;
+  });
+
+  test("returns undefined when no --ops-target and no FLAIR_OPS_TARGET env", () => {
+    delete process.env.FLAIR_OPS_TARGET;
+    expect(resolveOpsTarget({})).toBeUndefined();
+  });
+
+  test("returns --ops-target flag value when provided", () => {
+    delete process.env.FLAIR_OPS_TARGET;
+    expect(resolveOpsTarget({ opsTarget: "https://fabric.harper.dev:9925" }))
+      .toBe("https://fabric.harper.dev:9925");
+  });
+
+  test("falls back to FLAIR_OPS_TARGET env when --ops-target is not set", () => {
+    process.env.FLAIR_OPS_TARGET = "https://fabric.harper.dev:9925";
+    expect(resolveOpsTarget({})).toBe("https://fabric.harper.dev:9925");
+  });
+
+  test("--ops-target flag takes precedence over FLAIR_OPS_TARGET env", () => {
+    process.env.FLAIR_OPS_TARGET = "https://env-ops.example.com:9999";
+    expect(resolveOpsTarget({ opsTarget: "https://flag-ops.example.com:9925" }))
+      .toBe("https://flag-ops.example.com:9925");
+  });
+});
+
+// ─── resolveEffectiveOpsUrl ────────────────────────────────────────────────────
+
+describe("resolveEffectiveOpsUrl", () => {
+  let origFlairTarget: string | undefined;
+  let origFlairOpsTarget: string | undefined;
+
+  beforeEach(() => {
+    origFlairTarget = process.env.FLAIR_TARGET;
+    origFlairOpsTarget = process.env.FLAIR_OPS_TARGET;
+  });
+
+  afterEach(() => {
+    if (origFlairTarget === undefined) delete process.env.FLAIR_TARGET;
+    else process.env.FLAIR_TARGET = origFlairTarget;
+    if (origFlairOpsTarget === undefined) delete process.env.FLAIR_OPS_TARGET;
+    else process.env.FLAIR_OPS_TARGET = origFlairOpsTarget;
+  });
+
+  test("returns undefined when neither --target nor --ops-target set", () => {
+    delete process.env.FLAIR_TARGET;
+    delete process.env.FLAIR_OPS_TARGET;
+    expect(resolveEffectiveOpsUrl({})).toBeUndefined();
+  });
+
+  test("derives ops URL from --target when --ops-target is not set", () => {
+    delete process.env.FLAIR_OPS_TARGET;
+    expect(resolveEffectiveOpsUrl({ target: "https://flair.example.com:9926" }))
+      .toBe("https://flair.example.com:9925");
+  });
+
+  test("uses --ops-target directly when both flags are set (Fabric path)", () => {
+    expect(resolveEffectiveOpsUrl({
+      target: "https://flair.heskew.harperfabric.com",
+      opsTarget: "https://flair.heskew.harperfabric.com:9925",
+    })).toBe("https://flair.heskew.harperfabric.com:9925");
+  });
+
+  test("uses --ops-target directly even with no --target (edge case)", () => {
+    expect(resolveEffectiveOpsUrl({
+      opsTarget: "https://ops-only.example.com:9925",
+    })).toBe("https://ops-only.example.com:9925");
+  });
+
+  test("--ops-target takes precedence over derived ops URL", () => {
+    expect(resolveEffectiveOpsUrl({
+      target: "https://flair.example.com:19926",
+      opsTarget: "https://different-ops.example.com:9925",
+    })).toBe("https://different-ops.example.com:9925");
+  });
+
+  test("FLAIR_OPS_TARGET env works with resolveEffectiveOpsUrl", () => {
+    process.env.FLAIR_OPS_TARGET = "https://env-ops.example.com:9925";
+    delete process.env.FLAIR_TARGET;
+    expect(resolveEffectiveOpsUrl({}))
+      .toBe("https://env-ops.example.com:9925");
   });
 });
 
@@ -169,6 +266,31 @@ describe("Commander program: --target option", () => {
     expect(hasOption(sync, "--target")).toBe(true);
   });
 
+  test("flair init has --ops-target option", () => {
+    const init = findCommand("init");
+    expect(hasOption(init, "--ops-target")).toBe(true);
+  });
+
+  test("flair federation status has --ops-target option", () => {
+    const status = findSubcommand("federation", "status");
+    expect(hasOption(status, "--ops-target")).toBe(true);
+  });
+
+  test("flair federation token has --ops-target option", () => {
+    const token = findSubcommand("federation", "token");
+    expect(hasOption(token, "--ops-target")).toBe(true);
+  });
+
+  test("flair federation pair has --ops-target option", () => {
+    const pair = findSubcommand("federation", "pair");
+    expect(hasOption(pair, "--ops-target")).toBe(true);
+  });
+
+  test("flair federation sync has --ops-target option", () => {
+    const sync = findSubcommand("federation", "sync");
+    expect(hasOption(sync, "--ops-target")).toBe(true);
+  });
+
   test("flair status has --target option (alias for --url)", () => {
     const status = findCommand("status");
     expect(status).not.toBeNull();
@@ -224,5 +346,55 @@ describe("api() baseUrl override routes HTTP calls to target", () => {
     expect(init).not.toBeNull();
     const hasForce = init!.options.some((o: any) => o.flags.includes("--force"));
     expect(hasForce).toBe(true);
+  });
+});
+
+// ─── ops-target override: Fabric-style non-derivable ops URL ───────────────────
+
+describe("--ops-target overrides ops URL derivation", () => {
+  test("ops-target is used directly for ops calls, separate from --target REST", () => {
+    const opsTarget = resolveOpsTarget({
+      opsTarget: "https://flair.heskew.harperfabric.com:9925",
+    });
+    expect(opsTarget).toBe("https://flair.heskew.harperfabric.com:9925");
+
+    const target = resolveTarget({
+      target: "https://flair.heskew.harperfabric.com",
+    });
+    expect(target).toBe("https://flair.heskew.harperfabric.com");
+
+    // opsTarget is a completely different URL from target — no port-1 derivation
+    expect(opsTarget).not.toBe("https://flair.heskew.harperfabric.com:442");
+  });
+
+  test("Fabric acceptance criteria: target rest + ops on separate port", () => {
+    // Simulate the Fabric use case from spec:
+    // --target https://flair.heskew.harperfabric.com
+    // --ops-target https://flair.heskew.harperfabric.com:9925
+    const baseUrl = resolveTarget({
+      target: "https://flair.heskew.harperfabric.com",
+    })!.replace(/\/$/, "");
+    const opsUrl = resolveOpsTarget({
+      opsTarget: "https://flair.heskew.harperfabric.com:9925",
+    })!.replace(/\/$/, "");
+
+    expect(baseUrl).toBe("https://flair.heskew.harperfabric.com");
+    expect(opsUrl).toBe("https://flair.heskew.harperfabric.com:9925");
+
+    // Verify no derivation contamination: opsUrl is explicit, not port-1
+    const derivedFromBase = resolveOpsUrlFromTarget(baseUrl);
+    expect(derivedFromBase).toBe("https://flair.heskew.harperfabric.com:442");
+    expect(opsUrl).not.toBe(derivedFromBase);
+  });
+
+  test("only --target (rockit-style) still derives ops URL correctly", () => {
+    // Back-compat: no --ops-target, only --target
+    const baseUrl = resolveTarget({
+      target: "https://localhost:19926",
+    })!.replace(/\/$/, "");
+    const opsUrl = resolveEffectiveOpsUrl({ target: baseUrl });
+
+    expect(baseUrl).toBe("https://localhost:19926");
+    expect(opsUrl).toBe("https://localhost:19925"); // port-1 derivation
   });
 });


### PR DESCRIPTION
## ops-yaeh: Fix ops-port derivation for non-rockit topologies

Follows ops-n3ob (#293). The merged --target flag derives ops URLs by subtracting 1 from the target port. That breaks on Fabric (and other non-rockit topologies) where REST and ops ports have no port-1 relationship — e.g. REST on :443, ops on :9925.

### What changed
- **--ops-target <url>** (env: FLAIR_OPS_TARGET) added to init, federation status/token/pair/sync
- When provided, ops API URL comes directly from --ops-target, bypassing derivation
- resolveOpsTarget() and resolveEffectiveOpsUrl() helpers added
- resolveEffectiveOpsUrl() prioritises --ops-target, falls back to derivation from --target, returns undefined for localhost
- Init action: --ops-target without --target errors with clear message
- 45 tests total (17 new) including Fabric acceptance criteria

### Behavior matrix
| --target | --ops-target | REST URL | Ops URL |
|---|---|---|---|
| yes | yes | --target | --ops-target (no derivation) |
| yes | no | --target | derived (port-1) |
| no | yes | error (pass --target) | --ops-target |
| no | no | localhost | localhost |

### Acceptance criteria
- flair init --target https://flair.heskew.harperfabric.com --ops-target https://flair.heskew.harperfabric.com:9925 --remote --force ... works on Fabric
- Existing rockit-style --target without --ops-target unchanged
- All existing tests pass