### PR TITLE
feat(cli): route FederationInstance write through ops API on remote init (ops-bxuo)

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -406,6 +406,51 @@ async function seedAgentViaOpsApi(
   }
 }
 
+// ─── FederationInstance seed via ops API ──────────────────────────────────────
+//
+// Remote init writes FederationInstance through the ops API (Basic auth with
+// admin:admin-pass), not the REST API (which needs server-side HDB_ADMIN_PASSWORD
+// — unavailable on Fabric).  Same pattern as seedAgentViaOpsApi above.
+
+export async function seedFederationInstanceViaOpsApi(
+  opsPortOrUrl: number | string,
+  instanceId: string,
+  publicKey: string,
+  role: string,
+  adminUser: string,
+  adminPass: string,
+): Promise<void> {
+  const url = typeof opsPortOrUrl === "number"
+    ? `http://127.0.0.1:${opsPortOrUrl}/`
+    : `${opsPortOrUrl.replace(/\/$/, "")}/`;
+  const auth = Buffer.from(`${adminUser}:${adminPass}`).toString("base64");
+  const now = new Date().toISOString();
+  const body = {
+    operation: "insert",
+    database: "flair",
+    table: "FederationInstance",
+    records: [{
+      id: instanceId,
+      publicKey,
+      role,
+      status: "active",
+      createdAt: now,
+      updatedAt: now,
+    }],
+  };
+  const res = await fetch(url, {
+    method: "POST",
+    headers: { "Content-Type": "application/json", Authorization: `Basic ${auth}` },
+    body: JSON.stringify(body),
+    signal: AbortSignal.timeout(10_000),
+  });
+  if (!res.ok) {
+    const text = await res.text().catch(() => "");
+    if (res.status === 409 || text.includes("duplicate") || text.includes("already exists")) return;
+    throw new Error(`FederationInstance insert via ops API failed (${res.status}): ${text}`);
+  }
+}
+
 // ─── Upgrade presence probes ──────────────────────────────────────────────────
 //
 // `flair upgrade` previously called `npm list -g <pkg>` to detect the installed
@@ -705,16 +750,9 @@ program
 
       // Write FederationInstance row if --remote (hub role)
       if (role) {
-        console.log(`Writing FederationInstance (role=${role}) on ${baseUrl}...`);
         const instanceId = randomUUID();
-        await api("PUT", "/FederationInstance", {
-          id: instanceId,
-          publicKey: pubKeyB64url,
-          role,
-          status: "active",
-          createdAt: new Date().toISOString(),
-          updatedAt: new Date().toISOString(),
-        }, { baseUrl });
+        console.log(`Writing FederationInstance (role=${role}) via ops API...`);
+        await seedFederationInstanceViaOpsApi(opsUrl, instanceId, pubKeyB64url, role, adminUser, adminPass!);
         console.log(`FederationInstance created: ${instanceId} (${role}) ✓`);
       }
 

--- a/test/unit/cli-target-flag.test.ts
+++ b/test/unit/cli-target-flag.test.ts
@@ -19,6 +19,7 @@ import {
   resolveOpsUrlFromTarget,
   resolveHttpPort,
   program,
+  seedFederationInstanceViaOpsApi,
 } from "../../src/cli.js";
 
 // ─── resolveTarget ────────────────────────────────────────────────────────────
@@ -396,5 +397,176 @@ describe("--ops-target overrides ops URL derivation", () => {
 
     expect(baseUrl).toBe("https://localhost:19926");
     expect(opsUrl).toBe("https://localhost:19925"); // port-1 derivation
+  });
+});
+
+// ─── seedFederationInstanceViaOpsApi ────────────────────────────────────────────
+
+describe("seedFederationInstanceViaOpsApi", () => {
+  test("builds correct URL, body, auth for remote ops API call", async () => {
+    // Intercept fetch to inspect what the helper sends
+    let capturedUrl: string | undefined;
+    let capturedBody: any;
+    let capturedHeaders: Record<string, string> | undefined;
+
+    const origFetch = globalThis.fetch;
+    globalThis.fetch = async (url: any, opts: any) => {
+      capturedUrl = typeof url === "string" ? url : url.toString();
+      capturedBody = JSON.parse(opts.body);
+      capturedHeaders = opts.headers;
+      return new Response(null, { status: 200 });
+    };
+
+    try {
+      await seedFederationInstanceViaOpsApi(
+        "https://flair.heskew.harperfabric.com:9925",
+        "test-instance-uuid",
+        "base64pubkey==",
+        "hub",
+        "admin",
+        "sekret",
+      );
+    } finally {
+      globalThis.fetch = origFetch;
+    }
+
+    // Verify URL has trailing slash (as seedAgentViaOpsApi does)
+    expect(capturedUrl).toBe("https://flair.heskew.harperfabric.com:9925/");
+
+    // Verify auth header
+    expect(capturedHeaders!["Authorization"]).toBe(
+      "Basic " + Buffer.from("admin:sekret").toString("base64"),
+    );
+
+    // Verify body structure
+    expect(capturedBody.operation).toBe("insert");
+    expect(capturedBody.database).toBe("flair");
+    expect(capturedBody.table).toBe("FederationInstance");
+    expect(capturedBody.records).toHaveLength(1);
+    expect(capturedBody.records[0].id).toBe("test-instance-uuid");
+    expect(capturedBody.records[0].publicKey).toBe("base64pubkey==");
+    expect(capturedBody.records[0].role).toBe("hub");
+    expect(capturedBody.records[0].status).toBe("active");
+    expect(capturedBody.records[0].createdAt).toBeDefined();
+    expect(capturedBody.records[0].updatedAt).toBeDefined();
+  });
+
+  test("normalizes trailing slash on ops URL", async () => {
+    const origFetch = globalThis.fetch;
+    let capturedUrl: string | undefined;
+    globalThis.fetch = async (url: any) => {
+      capturedUrl = typeof url === "string" ? url : url.toString();
+      return new Response(null, { status: 200 });
+    };
+
+    try {
+      await seedFederationInstanceViaOpsApi(
+        "https://flair.heskew.harperfabric.com:9925/",
+        "id",
+        "pk",
+        "hub",
+        "admin",
+        "pass",
+      );
+    } finally {
+      globalThis.fetch = origFetch;
+    }
+
+    expect(capturedUrl).toBe("https://flair.heskew.harperfabric.com:9925/");
+  });
+
+  test("uses localhost URL when opsPortOrUrl is a number", async () => {
+    const origFetch = globalThis.fetch;
+    let capturedUrl: string | undefined;
+    globalThis.fetch = async (url: any) => {
+      capturedUrl = typeof url === "string" ? url : url.toString();
+      return new Response(null, { status: 200 });
+    };
+
+    try {
+      await seedFederationInstanceViaOpsApi(
+        19925,
+        "id",
+        "pk",
+        "hub",
+        "admin",
+        "pass",
+      );
+    } finally {
+      globalThis.fetch = origFetch;
+    }
+
+    expect(capturedUrl).toBe("http://127.0.0.1:19925/");
+  });
+
+  test("handles 409 conflict idempotently (does not throw)", async () => {
+    const origFetch = globalThis.fetch;
+    globalThis.fetch = async () => {
+      return new Response("409 Conflict — duplicate key", { status: 409 });
+    };
+
+    try {
+      // Should not throw on 409
+      await seedFederationInstanceViaOpsApi(
+        19925,
+        "existing-id",
+        "pk",
+        "hub",
+        "admin",
+        "pass",
+      );
+    } finally {
+      globalThis.fetch = origFetch;
+    }
+
+    // If we get here without throw, test passes
+    expect(true).toBe(true);
+  });
+
+  test("handles duplicate/already-exists response idempotently", async () => {
+    const origFetch = globalThis.fetch;
+    globalThis.fetch = async () => {
+      return new Response("already exists", { status: 500 });
+    };
+
+    try {
+      // Should not throw because body contains "already exists"
+      await seedFederationInstanceViaOpsApi(
+        19925,
+        "existing-id",
+        "pk",
+        "hub",
+        "admin",
+        "pass",
+      );
+    } finally {
+      globalThis.fetch = origFetch;
+    }
+
+    expect(true).toBe(true);
+  });
+
+  test("throws on non-409 error", async () => {
+    const origFetch = globalThis.fetch;
+    globalThis.fetch = async () => {
+      return new Response("Internal server error", { status: 500 });
+    };
+
+    try {
+      await seedFederationInstanceViaOpsApi(
+        19925,
+        "id",
+        "pk",
+        "hub",
+        "admin",
+        "pass",
+      );
+      // Should not reach here
+      expect("should have thrown").toBe("never");
+    } catch (e: any) {
+      expect(e.message).toContain("FederationInstance insert via ops API failed (500)");
+    } finally {
+      globalThis.fetch = origFetch;
+    }
   });
 });


### PR DESCRIPTION
## ops-bxuo: Route FederationInstance write through ops API

Follow-on to ops-yaeh (#294) and ops-n3ob (#293). Remote init's FederationInstance PUT hits the REST API which requires server-side `HDB_ADMIN_PASSWORD` — inaccessible on Fabric. Route it through the ops API (Basic auth with admin:admin-pass), same pattern as `seedAgentViaOpsApi`.

### What changed
- **`seedFederationInstanceViaOpsApi()`**: new helper mirroring `seedAgentViaOpsApi`
- **Init action**: FederationInstance write now goes through ops API instead of REST
- Handles 409/duplicate idempotently
- Local init path unchanged (uses `api()` as before)

### Why not REST
The REST endpoint (`PUT /FederationInstance`) validates `HDB_ADMIN_PASSWORD` header matching server-side env. On Fabric that env is platform-managed and not exposed. The ops API uses Basic auth with the admin:admin-pass pair, which is available to the CLI.

### Tests
5 new tests: URL/body/auth construction, trailing slash normalization, localhost (numeric port), 409 idempotency, non-409 error propagation. All 51 tests pass.