### PR TITLE
fix(cli): correct ops table name from FederationInstance to Instance (ops-8s7j)

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -428,7 +428,7 @@ export async function seedFederationInstanceViaOpsApi(
   const body = {
     operation: "insert",
     database: "flair",
-    table: "FederationInstance",
+    table: "Instance",
     records: [{
       id: instanceId,
       publicKey,
@@ -447,7 +447,7 @@ export async function seedFederationInstanceViaOpsApi(
   if (!res.ok) {
     const text = await res.text().catch(() => "");
     if (res.status === 409 || text.includes("duplicate") || text.includes("already exists")) return;
-    throw new Error(`FederationInstance insert via ops API failed (${res.status}): ${text}`);
+    throw new Error(`Federation Instance insert via ops API failed (${res.status}): ${text}`);
   }
 }
 

--- a/test/unit/cli-target-flag.test.ts
+++ b/test/unit/cli-target-flag.test.ts
@@ -441,7 +441,7 @@ describe("seedFederationInstanceViaOpsApi", () => {
     // Verify body structure
     expect(capturedBody.operation).toBe("insert");
     expect(capturedBody.database).toBe("flair");
-    expect(capturedBody.table).toBe("FederationInstance");
+    expect(capturedBody.table).toBe("Instance");
     expect(capturedBody.records).toHaveLength(1);
     expect(capturedBody.records[0].id).toBe("test-instance-uuid");
     expect(capturedBody.records[0].publicKey).toBe("base64pubkey==");
@@ -564,7 +564,7 @@ describe("seedFederationInstanceViaOpsApi", () => {
       // Should not reach here
       expect("should have thrown").toBe("never");
     } catch (e: any) {
-      expect(e.message).toContain("FederationInstance insert via ops API failed (500)");
+      expect(e.message).toContain("Federation Instance insert via ops API failed (500)");
     } finally {
       globalThis.fetch = origFetch;
     }


### PR DESCRIPTION
## ops-8s7j: Fix table name in seedFederationInstanceViaOpsApi

Follow-on to ops-bxuo (#295). The correct ops API table name is `Instance` (per schemas/federation.graphql), not `FederationInstance`.

### What changed
- `table: FederationInstance` → `table: Instance`
- Error message updated to match
- Test assertions updated