### PR TITLE
refactor(cli): drop Harper SQL — search_by_value / REST GET instead (ops-sdld)

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1164,14 +1164,16 @@ agent
       const res = await fetch(`http://127.0.0.1:${opsPort}/`, {
         method: "POST",
         headers: { "Content-Type": "application/json", Authorization: `Basic ${auth}` },
-        body: JSON.stringify({ operation: "sql", sql: "SELECT id, name, createdAt FROM flair.Agent ORDER BY createdAt" }),
+        body: JSON.stringify({ operation: "search_by_value", schema: "flair", table: "Agent", search_attribute: "id", search_type: "starts_with", search_value: "", get_attributes: ["id", "name", "createdAt"] }),
       });
       if (!res.ok) {
         const text = await res.text().catch(() => "");
         console.error(`Error: ${res.status} ${text}`);
         process.exit(1);
       }
-      console.log(JSON.stringify(await res.json(), null, 2));
+      const agents = await res.json() as any[];
+      agents.sort((a, b) => (a.createdAt ?? "").localeCompare(b.createdAt ?? ""));
+      console.log(JSON.stringify(agents, null, 2));
     } else {
       // Localhost operator path: allow IDs-only enumeration without per-agent auth
       // This treats localhost as a trusted boundary for read-only public metadata
@@ -1505,14 +1507,20 @@ principal
       process.exit(1);
     }
 
-    const kindFilter = opts.kind ? ` WHERE kind = '${opts.kind}'` : "";
     const auth = `Basic ${Buffer.from(`${DEFAULT_ADMIN_USER}:${adminPass}`).toString("base64")}`;
+    const conditions = opts.kind
+      ? [{ search_attribute: "kind", search_type: "equals", search_value: opts.kind }]
+      : [{ search_attribute: "id", search_type: "starts_with", search_value: "" }];
     const res = await fetch(`http://127.0.0.1:${opsPort}/`, {
       method: "POST",
       headers: { "Content-Type": "application/json", Authorization: auth },
       body: JSON.stringify({
-        operation: "sql",
-        sql: `SELECT id, name, kind, status, defaultTrustTier, admin, runtime, createdAt FROM flair.Agent${kindFilter} ORDER BY createdAt`,
+        operation: "search_by_conditions",
+        schema: "flair",
+        table: "Agent",
+        operator: "and",
+        conditions,
+        get_attributes: ["id", "name", "kind", "status", "defaultTrustTier", "admin", "runtime", "createdAt"],
       }),
     });
     if (!res.ok) {
@@ -1522,6 +1530,7 @@ principal
     }
 
     const records = await res.json() as any[];
+    records.sort((a, b) => (a.createdAt ?? "").localeCompare(b.createdAt ?? ""));
     if (records.length === 0) {
       console.log("No principals found.");
       return;
@@ -1701,8 +1710,13 @@ idp
       method: "POST",
       headers: { "Content-Type": "application/json", Authorization: auth },
       body: JSON.stringify({
-        operation: "sql",
-        sql: "SELECT id, name, issuer, requiredDomain, jitProvision, enabled, createdAt FROM flair.IdpConfig ORDER BY createdAt",
+        operation: "search_by_value",
+        schema: "flair",
+        table: "IdpConfig",
+        search_attribute: "id",
+        search_type: "starts_with",
+        search_value: "",
+        get_attributes: ["id", "name", "issuer", "requiredDomain", "jitProvision", "enabled", "createdAt"],
       }),
     });
     if (!res.ok) {
@@ -1712,6 +1726,7 @@ idp
     }
 
     const records = await res.json() as any[];
+    records.sort((a, b) => (a.createdAt ?? "").localeCompare(b.createdAt ?? ""));
     if (records.length === 0) {
       console.log("No IdPs configured.");
       return;
@@ -1768,20 +1783,13 @@ idp
       process.exit(1);
     }
 
-    const auth = `Basic ${Buffer.from(`${DEFAULT_ADMIN_USER}:${adminPass}`).toString("base64")}`;
-    const res = await fetch(`http://127.0.0.1:${opsPort}/`, {
-      method: "POST",
-      headers: { "Content-Type": "application/json", Authorization: auth },
-      body: JSON.stringify({ operation: "sql", sql: `SELECT * FROM flair.IdpConfig WHERE id = '${id}'` }),
-    });
-
-    const records = await res.json() as any[];
-    if (records.length === 0) {
+    let cfg: any;
+    try {
+      cfg = await api("GET", `/IdpConfig/${id}`);
+    } catch {
       console.error(`IdP '${id}' not found`);
       process.exit(1);
     }
-
-    const cfg = records[0];
     console.log(`Testing IdP: ${cfg.name} (${cfg.issuer})`);
     console.log(`  JWKS endpoint: ${cfg.jwksUri}`);
 
@@ -1924,7 +1932,7 @@ async function loadInstanceSecretKey(instanceId: string, opts: { adminPass?: str
   const res = await fetch(`http://127.0.0.1:${opsPort}/`, {
     method: "POST",
     headers: { "Content-Type": "application/json", Authorization: auth },
-    body: JSON.stringify({ operation: "sql", sql: `SELECT * FROM flair.Instance WHERE id = '${instanceId}'` }),
+    body: JSON.stringify({ operation: "search_by_value", schema: "flair", table: "Instance", search_attribute: "id", search_type: "equals", search_value: instanceId, get_attributes: ["*"] }),
   });
   if (res.ok) {
     const rows = await res.json() as any[];
@@ -2137,7 +2145,7 @@ export async function runFederationSyncOnce(opts: any): Promise<{ pushed: number
         res = await fetch(`${opsEndpoint}/`, {
           method: "POST",
           headers: { "Content-Type": "application/json", Authorization: auth },
-          body: JSON.stringify({ operation: "sql", sql: `SELECT * FROM flair.${table} WHERE updatedAt > '${since}'` }),
+          body: JSON.stringify({ operation: "search_by_conditions", schema: "flair", table, operator: "and", conditions: [{ search_attribute: "updatedAt", search_type: "greater_than", search_value: since }], get_attributes: ["*"] }),
           signal: AbortSignal.timeout(15_000),
         });
       } catch (err: any) {


### PR DESCRIPTION
## Summary

Replaces all 6 \`{operation: \"sql\", sql: \"SELECT ...\"}\` call sites in \`src/cli.ts\` with native Resource API calls. Harper's SQL support is a thin compat layer that's going away — this drops our dependency on it before it breaks.

Also folds in a security fix: the line-2140 site (\`runFederationSyncOnce\`, just shipped in PR #301) had string-interpolated SQL on the \`since\` value, which Sherlock flagged on PR #301 as a defense-in-depth concern. The new \`search_by_conditions\` call passes \`since\` as a structured parameter — exploit surface gone. Closes ops-0dkn.

## Changes

| Call site | Before | After |
|---|---|---|
| \`agent list\` | \`SELECT ... FROM flair.Agent ORDER BY createdAt\` | \`search_by_value\` open scan + client-side sort |
| \`principal list\` | \`SELECT ... FROM flair.Agent\${kindFilter} ORDER BY createdAt\` | \`search_by_conditions\` with kind filter / wide-open scan + client-side sort |
| \`idp list\` | \`SELECT ... FROM flair.IdpConfig\` | \`search_by_value\` open scan + client-side sort |
| \`idp test\` | \`SELECT * FROM flair.IdpConfig WHERE id = '\${id}'\` | REST \`GET /IdpConfig/\${id}\` via existing \`api()\` helper |
| \`loadInstanceSecretKey\` | \`SELECT * FROM flair.Instance WHERE id = '\${instanceId}'\` | \`search_by_value\` equals on \`flair.Instance.id\` |
| \`runFederationSyncOnce\` | \`SELECT * FROM flair.\${table} WHERE updatedAt > '\${since}'\` | \`search_by_conditions\` \`greater_than\` on \`updatedAt\` |

Net diff: +28/-20 lines, only \`src/cli.ts\` touched.

Acceptance check:
\`\`\`
\$ grep -c 'operation.*sql\\|\"sql\"' src/cli.ts
0
\`\`\`

## Authored by Ember (Pi + ollama-cloud kimi-k2.6)

Ember's second PR. Same orchestration pattern: Flint specs → Pi non-interactive → Ember commits → Flint pushes/PR/K&S/merge.

## Test plan

- [x] \`bun test test/unit/\` — 560 pass / 0 fail
- [x] \`bun test test/integration/federation-watch.test.ts test/unit/federation-security.test.ts\` — 28 pass / 0 fail
- [ ] CI green
- [ ] Smoke: run \`flair federation watch\` against the Fabric hub for ~2 min after merge; confirm sync still works (no SQL parsing under the hood)

## Closes

- ops-sdld (no-SQL refactor)
- ops-0dkn (SQL injection defense-in-depth, superseded)

🤖 Authored by Ember