### PR TITLE
release: v0.7.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tpsdev-ai/flair",
-  "version": "0.6.3",
+  "version": "0.7.0",
   "description": "Identity, memory, and soul for AI agents. Cryptographic identity (Ed25519), semantic memory with local embeddings, and persistent personality — all in a single process.",
   "type": "module",
   "license": "Apache-2.0",

--- a/packages/flair-client/package.json
+++ b/packages/flair-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tpsdev-ai/flair-client",
-  "version": "0.6.3",
+  "version": "0.7.0",
   "description": "Lightweight client for Flair — identity, memory, and soul for AI agents. Zero heavy dependencies.",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/flair-mcp/package.json
+++ b/packages/flair-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tpsdev-ai/flair-mcp",
-  "version": "0.6.3",
+  "version": "0.7.0",
   "description": "MCP server for Flair — persistent memory for Claude Code, Cursor, and any MCP client.",
   "type": "module",
   "main": "dist/index.js",
@@ -24,7 +24,7 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "1.27.1",
-    "@tpsdev-ai/flair-client": "0.6.3",
+    "@tpsdev-ai/flair-client": "0.7.0",
     "zod": "4.3.6"
   },
   "license": "Apache-2.0",

--- a/packages/pi-flair/package.json
+++ b/packages/pi-flair/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tpsdev-ai/pi-flair",
-  "version": "0.1.0",
+  "version": "0.7.0",
   "description": "Flair memory extension for pi — persistent memory access from within pi sessions",
   "type": "module",
   "main": "dist/index.js",
@@ -21,7 +21,7 @@
     "node": ">=18"
   },
   "dependencies": {
-    "@tpsdev-ai/flair-client": "0.6.3",
+    "@tpsdev-ai/flair-client": "0.7.0",
     "@sinclair/typebox": "0.34.48"
   },
   "license": "Apache-2.0",

--- a/plugins/openclaw-flair/package.json
+++ b/plugins/openclaw-flair/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tpsdev-ai/openclaw-flair",
-  "version": "0.6.3",
+  "version": "0.7.0",
   "description": "OpenClaw memory plugin for Flair — agent identity and semantic memory",
   "type": "module",
   "main": "index.ts",


### PR DESCRIPTION
Version bump across workspace packages to v0.7.0.

| Package | From | To |
|---|---|---|
| `@tpsdev-ai/flair` | 0.6.3 | 0.7.0 |
| `@tpsdev-ai/flair-client` | 0.6.3 | 0.7.0 |
| `@tpsdev-ai/flair-mcp` | 0.6.3 | 0.7.0 |
| `@tpsdev-ai/openclaw-flair` | 0.6.3 | 0.7.0 |
| `@tpsdev-ai/pi-flair` | 0.1.0 | 0.7.0 |

## What's in this release

See [CHANGELOG.md](https://github.com/tpsdev-ai/flair/blob/release/v0.7.0/CHANGELOG.md). Headline: `@tpsdev-ai/openclaw-flair` now registers the `flair` context engine for behavioral-anchor re-injection (PR #317, ops-czop). Plus the `flair init` localhost auth UX improvement (ops-vu31) that was already on `Unreleased`.

## Note on pi-flair

`pi-flair` was at `0.1.0` with an explicit pin to `flair-client@0.6.3` — a version that was committed in the monorepo but never published to npm (latest published is 0.6.2). `bun install` failed at the lockfile-refresh step because of that broken pin. Brought `pi-flair` into the family bump and updated its `flair-client` dep to `0.7.0`.

`scripts/release.sh`'s `PACKAGES` array doesn't include `pi-flair`; this release was completed manually after the script aborted. Follow-up will be filed to add `pi-flair` to the script so future releases work script-only.

## After CI green + this PR is merged

\`\`\`
git checkout main && git pull
./scripts/release.sh 0.7.0 --publish
\`\`\`

(Phase 2 — npm publish + tag — runs from main and is Nathan's hand for npm MFA per `feedback_npm_publish_nathan`.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)