### PR TITLE
feat(cli): flair status auto-discovers port when localhost unreachable (ops-mbdi)

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -3338,6 +3338,54 @@ function oauthDetailLines(o: any): string[] {
   return out;
 }
 
+// Common localhost ports a running Flair daemon might be on. Used by
+// discoverLocalFlairPort when the configured URL is unreachable, to detect
+// config-vs-daemon port drift (ops-mbdi). Order is ad-hoc — first hit wins.
+//
+// 9926: original default (long-running rockit installs predate the bump)
+// 19926: current default (DEFAULT_PORT)
+// 19925: ops-anvil VM secondary
+const LOCAL_FLAIR_PROBE_PORTS = [9926, 19926, 19925];
+
+export function isLocalhostUrl(url: string): boolean {
+  try {
+    const u = new URL(url);
+    // URL.hostname keeps brackets around IPv6 (e.g. "[::1]") so match both forms.
+    return (
+      u.hostname === "127.0.0.1" ||
+      u.hostname === "localhost" ||
+      u.hostname === "::1" ||
+      u.hostname === "[::1]"
+    );
+  } catch { return false; }
+}
+
+/**
+ * When a configured-localhost URL is unreachable, probe a small candidate-port
+ * set to detect a daemon listening on a different port (config drift). Returns
+ * the first responsive port, or null if none. Excludes the original port from
+ * the probe set so we don't repeat the failed call.
+ *
+ * Runs sequentially with a 500ms timeout per probe — typical 3-port sweep
+ * completes in <1.5s on a healthy box, faster on an unhealthy one.
+ */
+export async function discoverLocalFlairPort(originalUrl: string): Promise<number | null> {
+  if (!isLocalhostUrl(originalUrl)) return null;
+  let originalPort: number | null = null;
+  try { originalPort = Number(new URL(originalUrl).port) || null; } catch { /* ignore */ }
+  for (const port of LOCAL_FLAIR_PROBE_PORTS) {
+    if (port === originalPort) continue;
+    try {
+      const res = await fetch(`http://127.0.0.1:${port}/Health`, { signal: AbortSignal.timeout(500) });
+      // Treat 401 (auth required) the same as 200 — the daemon is alive,
+      // we just can't see /Health without admin auth. The point is to detect
+      // "something is listening" not "we have full access".
+      if (res.ok || res.status === 401) return port;
+    } catch { /* port not listening, try next */ }
+  }
+  return null;
+}
+
 async function fetchHealthDetail(opts: { port?: string; url?: string; target?: string; agent?: string }): Promise<{
   healthy: boolean;
   baseUrl: string;
@@ -3407,8 +3455,18 @@ const statusCmd = program
   .action(async (opts) => {
     const { healthy, baseUrl, healthData } = await fetchHealthDetail(opts);
 
+    // When unreachable on a localhost URL, probe candidate ports to detect
+    // config-vs-daemon port drift (ops-mbdi). Surface the actually-listening
+    // port with a fix recipe — better UX than just "unreachable."
+    let discoveredPort: number | null = null;
+    if (!healthy && isLocalhostUrl(baseUrl)) {
+      discoveredPort = await discoverLocalFlairPort(baseUrl);
+    }
+
     if (opts.json) {
-      console.log(JSON.stringify({ healthy, url: baseUrl, flairVersion: __pkgVersion, ...healthData }, null, 2));
+      const out: any = { healthy, url: baseUrl, flairVersion: __pkgVersion, ...healthData };
+      if (discoveredPort != null) out.discoveredPort = discoveredPort;
+      console.log(JSON.stringify(out, null, 2));
       if (!healthy) process.exit(1);
       return;
     }
@@ -3416,7 +3474,16 @@ const statusCmd = program
     if (!healthy) {
       console.log(`Flair v${__pkgVersion} — 🔴 unreachable`);
       console.log(`  URL:  ${baseUrl}`);
-      console.log(`\n  Run: flair start  or  flair doctor`);
+      if (discoveredPort != null) {
+        const altUrl = `http://127.0.0.1:${discoveredPort}`;
+        console.log(`\n  ⚠ Found a Flair daemon listening on port ${discoveredPort} (URL: ${altUrl}).`);
+        console.log(`    Your config points at ${baseUrl} — drift detected.`);
+        console.log(`\n  Quick fix: FLAIR_URL=${altUrl} flair status`);
+        console.log(`  Permanent fix: edit ~/.flair/config.yaml to set port: ${discoveredPort}`);
+        console.log(`  Or: flair doctor (when port-drift detection lands there)`);
+      } else {
+        console.log(`\n  Run: flair start  or  flair doctor`);
+      }
       process.exit(1);
     }
 

--- a/test/unit/cli-port-autodiscover.test.ts
+++ b/test/unit/cli-port-autodiscover.test.ts
@@ -1,0 +1,115 @@
+/**
+ * cli-port-autodiscover.test.ts — Unit tests for the port-drift autodiscover
+ * helpers (ops-mbdi).
+ *
+ * The discoverLocalFlairPort helper probes a small candidate-port set when the
+ * configured Flair URL is unreachable. Tests cover:
+ *
+ *   - isLocalhostUrl: localhost / 127.0.0.1 / ::1 → true; remote hosts → false
+ *   - discoverLocalFlairPort: returns null for non-localhost URLs (no probing)
+ *   - discoverLocalFlairPort: returns the first responsive port from the
+ *     candidate set when fetch is mocked
+ *   - discoverLocalFlairPort: excludes the original port from the probe set
+ *   - discoverLocalFlairPort: treats 401 (auth required) as alive, since the
+ *     daemon is running even if /Health is auth-gated
+ */
+
+import { describe, test, expect, beforeEach, afterEach, mock } from "bun:test";
+import { isLocalhostUrl, discoverLocalFlairPort } from "../../src/cli.ts";
+
+describe("isLocalhostUrl", () => {
+  test("returns true for 127.0.0.1", () => {
+    expect(isLocalhostUrl("http://127.0.0.1:9926")).toBe(true);
+    expect(isLocalhostUrl("https://127.0.0.1/path")).toBe(true);
+  });
+
+  test("returns true for localhost", () => {
+    expect(isLocalhostUrl("http://localhost:9926")).toBe(true);
+  });
+
+  test("returns true for IPv6 ::1", () => {
+    expect(isLocalhostUrl("http://[::1]:9926")).toBe(true);
+  });
+
+  test("returns false for remote hosts", () => {
+    expect(isLocalhostUrl("https://flair.example.com")).toBe(false);
+    expect(isLocalhostUrl("http://10.0.0.1:9926")).toBe(false);
+    expect(isLocalhostUrl("http://flair.local:9926")).toBe(false);
+  });
+
+  test("returns false for malformed URLs", () => {
+    expect(isLocalhostUrl("not a url")).toBe(false);
+    expect(isLocalhostUrl("")).toBe(false);
+  });
+});
+
+describe("discoverLocalFlairPort", () => {
+  let originalFetch: typeof globalThis.fetch;
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  test("returns null for non-localhost URLs (no probing)", async () => {
+    let fetchCalled = false;
+    globalThis.fetch = (mock(async () => {
+      fetchCalled = true;
+      return new Response("", { status: 200 });
+    }) as unknown) as typeof globalThis.fetch;
+
+    const result = await discoverLocalFlairPort("https://flair.example.com:9926");
+    expect(result).toBeNull();
+    expect(fetchCalled).toBe(false);
+  });
+
+  test("returns the first responsive candidate port", async () => {
+    globalThis.fetch = (mock(async (url: any) => {
+      const u = new URL(String(url));
+      // 9926 responds, others fail
+      if (u.port === "9926") return new Response("", { status: 200 });
+      throw new Error("connection refused");
+    }) as unknown) as typeof globalThis.fetch;
+
+    // Original URL points at 19926 (which doesn't respond in the mock).
+    // Discovery should hit 9926.
+    const result = await discoverLocalFlairPort("http://127.0.0.1:19926");
+    expect(result).toBe(9926);
+  });
+
+  test("excludes the original port from the probe set", async () => {
+    const probedPorts: number[] = [];
+    globalThis.fetch = (mock(async (url: any) => {
+      const u = new URL(String(url));
+      probedPorts.push(Number(u.port));
+      throw new Error("connection refused");
+    }) as unknown) as typeof globalThis.fetch;
+
+    await discoverLocalFlairPort("http://127.0.0.1:9926");
+    // Original was 9926 — should not appear in the probe set.
+    expect(probedPorts).not.toContain(9926);
+  });
+
+  test("treats 401 as alive (auth-gated /Health is still a live daemon)", async () => {
+    globalThis.fetch = (mock(async (url: any) => {
+      const u = new URL(String(url));
+      if (u.port === "19926") return new Response("auth required", { status: 401 });
+      throw new Error("connection refused");
+    }) as unknown) as typeof globalThis.fetch;
+
+    const result = await discoverLocalFlairPort("http://127.0.0.1:9926");
+    expect(result).toBe(19926);
+  });
+
+  test("returns null when no candidates respond", async () => {
+    globalThis.fetch = (mock(async () => {
+      throw new Error("connection refused");
+    }) as unknown) as typeof globalThis.fetch;
+
+    const result = await discoverLocalFlairPort("http://127.0.0.1:9926");
+    expect(result).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

Fixes ops-mbdi (P2, 1.0). When `flair status` fails on a localhost URL, probe a small candidate-port set (9926, 19926, 19925) to detect config-vs-daemon port drift. If a daemon is found on a different port, surface it with a fix recipe instead of just "🔴 unreachable".

## Symptom

rockit's `~/.flair/config.yaml` says `port: 19926` but the launchd daemon listens on `9926` (set in `HARPER_SET_CONFIG` of `ai.tpsdev.flair.plist`). Today's behavior:

```
$ flair status
Flair v0.7.0 — 🔴 unreachable
  URL:  http://127.0.0.1:19926
```

Daemon is fine — config drifted. Confusing.

## After this PR

```
$ flair status
Flair v0.7.0 — 🔴 unreachable
  URL:  http://127.0.0.1:19926

  ⚠ Found a Flair daemon listening on port 9926 (URL: http://127.0.0.1:9926).
    Your config points at http://127.0.0.1:19926 — drift detected.

  Quick fix: FLAIR_URL=http://127.0.0.1:9926 flair status
  Permanent fix: edit ~/.flair/config.yaml to set port: 9926
  Or: flair doctor (when port-drift detection lands there)
```

## Implementation

- `isLocalhostUrl(url)` — exported helper, handles `127.0.0.1` / `localhost` / `::1` / `[::1]`. Tested.
- `discoverLocalFlairPort(originalUrl)` — exported helper, probes `LOCAL_FLAIR_PROBE_PORTS = [9926, 19926, 19925]` with a 500ms timeout each. Excludes the original port from the probe set (would just repeat the failed call). Treats 401 (auth-gated /Health) the same as 200 — daemon is alive, we just can't see /Health without admin auth. Tested.
- `flair status` unreachable branch: when localhost URL, run discovery; on hit, print drift detection + fix recipes; otherwise, fall back to existing "Run: flair start  or  flair doctor" message.
- `flair status --json` unreachable output gains a `discoveredPort` field when drift detected.

## Out of scope

- `flair doctor` integration — referenced as a future fix path in the message but not implemented here. Filed as informal follow-up; can ride a future polish PR.
- Auto-rewriting `~/.flair/config.yaml` — too aggressive for a status command. The fix recipe is human-actionable; doctor is the place for auto-correct.
- Other commands that resolve a base URL (search, memory, etc.) — they don't typically print "unreachable" in the same way; if drift hits there it surfaces as ENOTFOUND/ECONNREFUSED with a different code path. Single-command fix per ops-mbdi scope.

## Test plan

- [x] 10 new unit tests in `test/unit/cli-port-autodiscover.test.ts` — covers helpers' happy paths + edge cases (non-localhost, exclusion, 401, no-response)
- [x] Full unit suite: 606 pass (was 596 + 10 new)
- [x] No changes to the healthy code path
- [ ] CI green
- [ ] K&S architecture + security review

🤖 Generated with [Claude Code](https://claude.com/claude-code)