### PR TITLE
feat(cli): flair upgrade UX — drop flair-client default, add openclaw-flair, --all flag (ops-h5cd)

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -801,6 +801,34 @@ export function probeLibVersion(pkgName: string): string | null {
   }
 }
 
+/**
+ * Read the version of an OpenClaw plugin from `~/.openclaw/extensions/<name>/package.json`.
+ *
+ * `flair upgrade` uses this to surface the installed `@tpsdev-ai/openclaw-flair`
+ * version even though it isn't a globally-installed bin or a flair lib dep.
+ * Returns null if openclaw isn't installed, the extension isn't installed, or
+ * the package.json can't be parsed.
+ *
+ * @param extensionName — the directory name under `~/.openclaw/extensions/`
+ *                        (typically the plugin name without scope, e.g. `openclaw-flair`)
+ */
+export function probeOpenclawPluginVersion(extensionName: string): string | null {
+  try {
+    const { existsSync, readFileSync } = require("node:fs") as typeof import("node:fs");
+    const { homedir } = require("node:os") as typeof import("node:os");
+    const { resolve } = require("node:path") as typeof import("node:path");
+    // process.env.HOME first so tests can override; homedir() as fallback —
+    // homedir() doesn't honor runtime HOME changes (caches at module load).
+    const home = process.env.HOME ?? homedir();
+    const pkgJsonPath = resolve(home, ".openclaw", "extensions", extensionName, "package.json");
+    if (!existsSync(pkgJsonPath)) return null;
+    const pkg = JSON.parse(readFileSync(pkgJsonPath, "utf-8"));
+    return typeof pkg.version === "string" ? pkg.version : null;
+  } catch {
+    return null;
+  }
+}
+
 // ─── First-run soul wizard ────────────────────────────────────────────────────
 
 type SoulEntries = [string, string][];
@@ -4116,9 +4144,11 @@ program
   .description("Upgrade Flair and related packages to latest versions")
   .option("--check", "Only check for updates, don't install")
   .option("--restart", "Restart Flair after upgrade")
+  .option("--all", "Show transitive packages (e.g. flair-client) in the listing — verbose mode for debugging dep versions")
   .action(async (opts) => {
     const { execSync, execFileSync } = await import("node:child_process");
     const checkOnly = opts.check ?? false;
+    const showAll = opts.all ?? false;
 
     console.log("Checking for updates...\n");
 
@@ -4133,32 +4163,56 @@ program
     //   - For library packages: require.resolve the package.json from the
     //     running flair's module graph (works whether it's a sibling
     //     global install or a bundled dep).
+    //   - For openclaw plugins: read ~/.openclaw/extensions/<name>/package.json
+    //     directly (the OpenClaw plugin install layout — not on $PATH, not in
+    //     flair's module graph).
+    //
+    // Default UI shows only end-user-facing packages: flair, flair-mcp,
+    // openclaw-flair. flair-client is a transitive dep of flair-mcp and
+    // showing it as a top-level upgrade item invites a misleading
+    // "❔ missing — install with npm install -g" suggestion for users who
+    // installed flair without flair-mcp (ops-h5cd). --all opts in.
+    type ProbeKind = "bin" | "lib" | "openclaw-plugin";
     const packages: Array<{
       name: string;
       probe: () => string | null;
+      kind: ProbeKind;
+      transitive?: boolean; // hide from default UI; shown only with --all
     }> = [
       {
         name: "@tpsdev-ai/flair",
+        kind: "bin",
         probe: () => probeBinVersion(execFileSync,"flair"),
       },
       {
-        name: "@tpsdev-ai/flair-client",
-        probe: () => probeLibVersion("@tpsdev-ai/flair-client"),
+        name: "@tpsdev-ai/flair-mcp",
+        kind: "bin",
+        probe: () => probeBinVersion(execFileSync,"flair-mcp"),
       },
       {
-        name: "@tpsdev-ai/flair-mcp",
-        probe: () => probeBinVersion(execFileSync,"flair-mcp"),
+        name: "@tpsdev-ai/openclaw-flair",
+        kind: "openclaw-plugin",
+        probe: () => probeOpenclawPluginVersion("openclaw-flair"),
+      },
+      {
+        name: "@tpsdev-ai/flair-client",
+        kind: "lib",
+        probe: () => probeLibVersion("@tpsdev-ai/flair-client"),
+        transitive: true,
       },
     ];
 
-    // Three-state status per package:
+    // Three-state status per package, plus a fourth for openclaw-plugin
+    // packages that aren't installed (since openclaw is optional):
     //   current    — installed version matches registry latest
     //   outdated   — installed version is older than latest
-    //   missing    — not detected anywhere; optionally install
-    type Status = "current" | "outdated" | "missing";
-    const findings: Array<{ name: string; installed: string | null; latest: string; status: Status }> = [];
+    //   missing    — not detected; default packages → install advised
+    //   optional   — openclaw plugin; openclaw isn't installed (don't nag)
+    type Status = "current" | "outdated" | "missing" | "optional";
+    const findings: Array<{ name: string; installed: string | null; latest: string; status: Status; kind: ProbeKind }> = [];
 
-    for (const { name, probe } of packages) {
+    for (const { name, probe, kind, transitive } of packages) {
+      if (transitive && !showAll) continue;
       try {
         const res = await fetch(`https://registry.npmjs.org/${name}/latest`, { signal: AbortSignal.timeout(5000) });
         if (!res.ok) continue;
@@ -4166,19 +4220,44 @@ program
         const latest = data.version ?? "unknown";
 
         const installed = probe();
-        const status: Status = installed === null ? "missing" : installed === latest ? "current" : "outdated";
-        findings.push({ name, installed, latest, status });
+        let status: Status;
+        if (installed === null) {
+          // openclaw-plugin packages are optional — if openclaw isn't
+          // installed, don't surface a misleading "install with npm" advice.
+          status = kind === "openclaw-plugin" ? "optional" : "missing";
+        } else if (installed === latest) {
+          status = "current";
+        } else {
+          status = "outdated";
+        }
+        findings.push({ name, installed, latest, status, kind });
 
-        const icon = status === "current" ? "✅" : status === "outdated" ? "⬆️" : "❔";
-        const installedLabel = installed ?? "not detected";
-        const suffix = status === "current" ? " (current)" : status === "missing" ? " (run: npm install -g)" : "";
+        const icon = status === "current" ? "✅"
+          : status === "outdated" ? "⬆️"
+          : status === "optional" ? "○"
+          : "❔";
+        const installedLabel = installed ?? (status === "optional" ? "not installed (openclaw not detected)" : "not detected");
+        const suffix = status === "current" ? " (current)"
+          : status === "missing" ? " (run: npm install -g)"
+          : status === "optional" ? " (install via: openclaw plugins install @tpsdev-ai/openclaw-flair)"
+          : "";
         console.log(`  ${icon} ${name}: ${installedLabel} → ${latest}${suffix}`);
       } catch { /* skip unavailable packages */ }
     }
 
     const outdated = findings.filter((f) => f.status === "outdated");
     const missing = findings.filter((f) => f.status === "missing");
-    const upgrades = outdated.map(({ name, installed, latest }) => ({ pkg: name, installed: installed ?? "unknown", latest }));
+    // openclaw plugins upgrade through `openclaw plugins install`, not `npm
+    // install -g` (npm-installed wouldn't connect to OpenClaw's gateway slot).
+    // Split outdated into npm-upgradeable vs openclaw-plugin so we can use
+    // the right command for each.
+    const npmUpgrades = outdated
+      .filter((f) => f.kind !== "openclaw-plugin")
+      .map(({ name, installed, latest }) => ({ pkg: name, installed: installed ?? "unknown", latest }));
+    const openclawUpgrades = outdated
+      .filter((f) => f.kind === "openclaw-plugin")
+      .map(({ name, installed, latest }) => ({ pkg: name, installed: installed ?? "unknown", latest }));
+    const totalUpgrades = npmUpgrades.length + openclawUpgrades.length;
 
     if (outdated.length === 0 && missing.length === 0) {
       console.log("\n✅ Everything is up to date.");
@@ -4202,12 +4281,30 @@ program
     // Perform upgrade. `latest` comes from the npm registry's HTTP
     // response, so CodeQL (correctly) treats it as untrusted input.
     // Use execFileSync with argv — the spec `<name>@<version>` becomes a
-    // single argument to npm, no shell to inject into.
-    console.log(`\nUpgrading ${upgrades.length} package${upgrades.length > 1 ? "s" : ""}...\n`);
-    for (const { pkg, latest } of upgrades) {
+    // single argument to the upgrade command, no shell to inject into.
+    console.log(`\nUpgrading ${totalUpgrades} package${totalUpgrades > 1 ? "s" : ""}...\n`);
+    for (const { pkg, latest } of npmUpgrades) {
       try {
         console.log(`  Installing ${pkg}@${latest}...`);
         execFileSync("npm", ["install", "-g", `${pkg}@${latest}`], { stdio: "pipe" });
+        console.log(`  ✅ ${pkg}@${latest} installed`);
+      } catch (err: any) {
+        console.error(`  ❌ ${pkg} upgrade failed: ${err.message}`);
+      }
+    }
+    for (const { pkg, latest } of openclawUpgrades) {
+      // OpenClaw plugins upgrade via `openclaw plugins install --force --pin`.
+      // Requires openclaw on PATH; if not, surface the manual recipe instead
+      // of a confusing failure.
+      try {
+        execFileSync("openclaw", ["--version"], { stdio: "pipe", timeout: 2000 });
+      } catch {
+        console.error(`  ❌ ${pkg} upgrade skipped: openclaw not on PATH. Install manually: openclaw plugins install ${pkg}@${latest} --force --pin`);
+        continue;
+      }
+      try {
+        console.log(`  Installing ${pkg}@${latest} via openclaw...`);
+        execFileSync("openclaw", ["plugins", "install", `${pkg}@${latest}`, "--force", "--pin"], { stdio: "pipe" });
         console.log(`  ✅ ${pkg}@${latest} installed`);
       } catch (err: any) {
         console.error(`  ❌ ${pkg} upgrade failed: ${err.message}`);

--- a/test/unit/upgrade-probes.test.ts
+++ b/test/unit/upgrade-probes.test.ts
@@ -1,5 +1,8 @@
-import { describe, test, expect } from "bun:test";
-import { probeBinVersion, probeLibVersion } from "../../src/cli";
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { probeBinVersion, probeLibVersion, probeOpenclawPluginVersion } from "../../src/cli";
 
 // execFileSync takes (file, args, opts) and returns Buffer|string. Tests
 // inject a fake that ignores input and returns a fixed string (or throws).
@@ -56,5 +59,53 @@ describe("probeLibVersion", () => {
   test("returns null for a package that's not installed anywhere Node can find it", () => {
     const version = probeLibVersion("this-package-does-not-exist-anywhere-3f8c2a1b");
     expect(version).toBeNull();
+  });
+});
+
+describe("probeOpenclawPluginVersion", () => {
+  let tmpHome: string;
+  let originalHome: string | undefined;
+
+  beforeEach(() => {
+    tmpHome = mkdtempSync(join(tmpdir(), "tps-openclaw-probe-"));
+    originalHome = process.env.HOME;
+    process.env.HOME = tmpHome;
+  });
+
+  afterEach(() => {
+    if (originalHome !== undefined) process.env.HOME = originalHome;
+    else delete process.env.HOME;
+    rmSync(tmpHome, { recursive: true, force: true });
+  });
+
+  test("reads version from ~/.openclaw/extensions/<name>/package.json", () => {
+    const extDir = join(tmpHome, ".openclaw", "extensions", "openclaw-flair");
+    mkdirSync(extDir, { recursive: true });
+    writeFileSync(join(extDir, "package.json"), JSON.stringify({ name: "@tpsdev-ai/openclaw-flair", version: "0.7.0" }));
+    expect(probeOpenclawPluginVersion("openclaw-flair")).toBe("0.7.0");
+  });
+
+  test("returns null when ~/.openclaw doesn't exist (openclaw not installed)", () => {
+    expect(probeOpenclawPluginVersion("openclaw-flair")).toBeNull();
+  });
+
+  test("returns null when extension dir exists but no package.json", () => {
+    const extDir = join(tmpHome, ".openclaw", "extensions", "openclaw-flair");
+    mkdirSync(extDir, { recursive: true });
+    expect(probeOpenclawPluginVersion("openclaw-flair")).toBeNull();
+  });
+
+  test("returns null when package.json is malformed", () => {
+    const extDir = join(tmpHome, ".openclaw", "extensions", "openclaw-flair");
+    mkdirSync(extDir, { recursive: true });
+    writeFileSync(join(extDir, "package.json"), "{ this is not valid json");
+    expect(probeOpenclawPluginVersion("openclaw-flair")).toBeNull();
+  });
+
+  test("returns null when package.json has no version field", () => {
+    const extDir = join(tmpHome, ".openclaw", "extensions", "openclaw-flair");
+    mkdirSync(extDir, { recursive: true });
+    writeFileSync(join(extDir, "package.json"), JSON.stringify({ name: "@tpsdev-ai/openclaw-flair" }));
+    expect(probeOpenclawPluginVersion("openclaw-flair")).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary

Fixes ops-h5cd (P3, dogfood). `flair upgrade` default UI was misleading — it surfaced `@tpsdev-ai/flair-client` as a top-level upgrade item and suggested `npm install -g @tpsdev-ai/flair-client` for users who only installed `flair` (no MCP). flair-client is a transitive dep of flair-mcp; users shouldn't be told to install it directly.

## Before

```
$ flair upgrade --check
Checking for updates...

  ✅ @tpsdev-ai/flair: 0.7.0 → 0.7.0 (current)
  ❔ @tpsdev-ai/flair-client: not detected → 0.7.0 (run: npm install -g)   ← misleading
  ✅ @tpsdev-ai/flair-mcp: 0.7.0 → 0.7.0 (current)
```

## After

```
$ flair upgrade --check
Checking for updates...

  ✅ @tpsdev-ai/flair: 0.7.0 → 0.7.0 (current)
  ✅ @tpsdev-ai/flair-mcp: 0.7.0 → 0.7.0 (current)
  ✅ @tpsdev-ai/openclaw-flair: 0.7.0 → 0.7.0 (current)
```

```
$ flair upgrade --check --all   # verbose, includes transitive deps
Checking for updates...

  ✅ @tpsdev-ai/flair: 0.7.0 → 0.7.0 (current)
  ✅ @tpsdev-ai/flair-mcp: 0.7.0 → 0.7.0 (current)
  ✅ @tpsdev-ai/openclaw-flair: 0.7.0 → 0.7.0 (current)
  ✅ @tpsdev-ai/flair-client: 0.7.0 → 0.7.0 (current)
```

```
# user without openclaw installed:
  ○ @tpsdev-ai/openclaw-flair: not installed (openclaw not detected) → 0.7.0
    (install via: openclaw plugins install @tpsdev-ai/openclaw-flair)
```

## Implementation

- **Drop flair-client from default packages array, add openclaw-flair.** flair-client gets `transitive: true` flag, only shown with `--all`.
- **`probeOpenclawPluginVersion(extensionName)` — exported helper** that reads `~/.openclaw/extensions/<name>/package.json`. The OpenClaw plugin install layout (not on PATH, not in flair's module graph) needs its own probe shape.
- **Fourth status: `optional`** — for openclaw-plugin packages when openclaw isn't installed. Avoids the misleading "missing — install with npm" advice when the right command is `openclaw plugins install`.
- **Upgrade-execution split.** npm packages still use `execFileSync('npm install -g …')`. openclaw plugins use `execFileSync('openclaw plugins install … --force --pin')`. Probes for `openclaw` on PATH first; if missing, surfaces the manual recipe.
- **--all flag** added to the `flair upgrade` command spec.

## Test plan

- [x] 5 new `probeOpenclawPluginVersion` unit tests (happy path, no openclaw dir, no package.json, malformed JSON, no version field)
- [x] Full unit suite: 611 pass (was 606 + 5 new)
- [x] `bun test test/unit/upgrade-probes.test.ts`: 14 pass
- [x] No changes to existing probeBinVersion / probeLibVersion behavior
- [ ] CI green
- [ ] K&S architecture + security review

🤖 Generated with [Claude Code](https://claude.com/claude-code)