### PR TITLE
fix(release): include pi-flair in workspace bump + publish (ops-1pls)

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -35,6 +35,7 @@ PACKAGES=(
   "$ROOT/packages/flair-client"
   "$ROOT/packages/flair-mcp"
   "$ROOT/packages/openclaw-flair"
+  "$ROOT/packages/pi-flair"
   "$ROOT"
 )
 
@@ -42,6 +43,7 @@ PACKAGE_JSONS=(
   "$ROOT/packages/flair-client/package.json"
   "$ROOT/packages/flair-mcp/package.json"
   "$ROOT/packages/openclaw-flair/package.json"
+  "$ROOT/packages/pi-flair/package.json"
   "$ROOT/package.json"
 )
 
@@ -106,6 +108,9 @@ if [[ "$MODE" == "--publish" ]]; then
   echo "  Publishing @tpsdev-ai/openclaw-flair..."
   (cd "$ROOT/packages/openclaw-flair" && npm publish) || { echo "⚠️  openclaw-flair publish failed (may need build step)"; }
 
+  echo "  Publishing @tpsdev-ai/pi-flair..."
+  (cd "$ROOT/packages/pi-flair" && npm publish) || { echo "⚠️  pi-flair publish failed (may need build step)"; }
+
   echo "🏷️  Tagging v${VERSION} on main..."
   git -C "$ROOT" tag -a "v${VERSION}" -m "Release v${VERSION}"
   git -C "$ROOT" push origin "v${VERSION}"
@@ -160,18 +165,20 @@ for pkg in "${PACKAGES[@]}"; do
   echo "  ✓ $name → $VERSION"
 done
 
-# 3. Update internal dependency (flair-mcp → flair-client)
+# 3. Update internal dependencies (flair-mcp + pi-flair both depend on flair-client)
 echo "🔗 Aligning internal dependencies..."
-node -e "
-  const fs = require('fs');
-  const path = '$ROOT/packages/flair-mcp/package.json';
-  const pkg = JSON.parse(fs.readFileSync(path, 'utf8'));
-  if (pkg.dependencies?.['@tpsdev-ai/flair-client']) {
-    pkg.dependencies['@tpsdev-ai/flair-client'] = '$VERSION';
-    fs.writeFileSync(path, JSON.stringify(pkg, null, 2) + '\n');
-    console.log('  ✓ flair-mcp → flair-client: $VERSION');
-  }
-"
+for INTERNAL_DEPENDENT in "$ROOT/packages/flair-mcp/package.json" "$ROOT/packages/pi-flair/package.json"; do
+  node -e "
+    const fs = require('fs');
+    const path = '$INTERNAL_DEPENDENT';
+    const pkg = JSON.parse(fs.readFileSync(path, 'utf8'));
+    if (pkg.dependencies?.['@tpsdev-ai/flair-client']) {
+      pkg.dependencies['@tpsdev-ai/flair-client'] = '$VERSION';
+      fs.writeFileSync(path, JSON.stringify(pkg, null, 2) + '\n');
+      console.log('  ✓ ' + pkg.name + ' → flair-client: $VERSION');
+    }
+  "
+done
 
 # 3a. Refresh bun.lock so CI's --frozen-lockfile passes post-bump.
 # Omitting this was the 0.5.6 release failure: version bumps desynced the
@@ -201,6 +208,7 @@ git -C "$ROOT" add \
   "$ROOT/packages/flair-client/package.json" \
   "$ROOT/packages/flair-mcp/package.json" \
   "$ROOT/packages/openclaw-flair/package.json" \
+  "$ROOT/packages/pi-flair/package.json" \
   "$ROOT/bun.lock"
 git -C "$ROOT" commit -m "release: v${VERSION} — align all workspace packages"
 


### PR DESCRIPTION
## Summary

Fixes ops-1pls (P3, 1.0 milestone). `scripts/release.sh`'s `PACKAGES` + `PACKAGE_JSONS` arrays missed `pi-flair`. v0.7.0 phase-1 hit a wall at `bun install` because pi-flair's package.json pinned `flair-client@0.6.3` (an in-monorepo bump that was never published). Worked around manually for v0.7.0; this PR makes the flow script-only for future releases.

## Changes

- **`PACKAGES` + `PACKAGE_JSONS` arrays** include `packages/pi-flair`. Order: client → mcp → openclaw-flair → pi-flair → root (publish dep order; pi-flair depends on flair-client so it goes after).
- **Internal-dep alignment** now loops over both `flair-mcp` AND `pi-flair` package.jsons. Both depend on `@tpsdev-ai/flair-client`. Refactored to a `for` loop instead of a hardcoded single-package node command.
- **Phase 2 publish** step adds pi-flair after openclaw-flair. Warn-not-fail posture matches openclaw-flair's — pi-flair publish doesn't gate anything else.
- **Commit step's explicit `git add` list** includes `pi-flair/package.json`.

## Verification

- `bash -n scripts/release.sh` → syntax OK
- Diff is +19 / -11 across `scripts/release.sh` only
- Behavior parity with v0.7.0 manual workaround (which we know works because v0.7.0 shipped)
- Next release cycle will exercise this end-to-end

## Why P3 + 1.0 milestone

Caught + worked around for v0.7.0. Recurrence will hit anyone (Nathan or me) doing the next release. Trivial fix that should land before the 1.0 release cut.

## Test plan

- [x] Bash syntax check passes
- [x] No changes to runtime code — script-only
- [x] PACKAGES list ordered for dep correctness
- [ ] CI green
- [ ] K&S review (architecture only — no security surface change in script tooling)

🤖 Generated with [Claude Code](https://claude.com/claude-code)