### PR TITLE
feat(rem): MemoryCandidate schema + flair rem candidates command (ops-2qq slice 1)

### DIFF
--- a/schemas/memory.graphql
+++ b/schemas/memory.graphql
@@ -68,3 +68,29 @@ type MemoryGrant @table(database: "flair") @export {
   filter: String
   createdAt: String
 }
+
+# MemoryCandidate — staged distillations from the FLAIR-NIGHTLY-REM cycle.
+# Per specs/FLAIR-NIGHTLY-REM.md § 7. Slice 1 of ops-2qq adds the schema +
+# `flair rem candidates` listing command. Future slices wire the nightly
+# cycle that populates this table and the promote/reject endpoints.
+#
+# Inviolable contract: candidates are NEVER auto-promoted. Promotion is a
+# separate, deliberate action (`flair rem promote <id> --rationale "<why>"`)
+# that requires both --rationale and --to (soul|memory). Rejected candidates
+# retain their decision history so recurring false-positives become visible
+# via the `supersedes` chain.
+type MemoryCandidate @table(database: "flair") {
+  id: ID @primaryKey
+  agentId: String! @indexed
+  claim: String!                   # distilled lesson text
+  sourceMemoryIds: [String]        # episodic memories feeding the distillation
+  rationalePrompt: String          # the prompt given to the distillation LLM
+  generatedBy: String              # model identifier (e.g. "claude-opus-4-7")
+  generatedAt: String! @indexed
+  status: String! @indexed         # pending | promoted | rejected
+  target: String                   # soul | memory (set on promote)
+  reviewerId: String               # who decided (agentId or human admin)
+  reviewRationale: String          # required on promote/reject (no rubber-stamp)
+  decidedAt: String
+  supersedes: String @indexed      # previous rejected candidate this replaces
+}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -3631,6 +3631,87 @@ rem
     }
   });
 
+// ─── flair rem candidates ─────────────────────────────────────────────────────
+// Slice 1 of FLAIR-NIGHTLY-REM (ops-2qq). Lists staged distillations from the
+// MemoryCandidate table. Empty until the nightly cycle (later slice) starts
+// populating. Per spec § 5: candidates are NEVER auto-promoted; this command
+// is the operator's review surface.
+
+rem
+  .command("candidates")
+  .description("List staged memory candidates from the FLAIR-NIGHTLY-REM cycle (pending review)")
+  .option("--port <port>", "Harper HTTP port")
+  .option("--agent <id>", "Agent ID (or FLAIR_AGENT_ID env)")
+  .option("--status <s>", "Filter by status: pending | promoted | rejected (default: pending)")
+  .option("--json", "Output as JSON for scripting")
+  .action(async (opts) => {
+    const agentId = opts.agent || process.env.FLAIR_AGENT_ID;
+    const status = opts.status ?? "pending";
+    const validStatuses = new Set(["pending", "promoted", "rejected"]);
+    if (!validStatuses.has(status)) {
+      console.error(`Error: --status must be one of: pending, promoted, rejected (got: ${status})`);
+      process.exit(1);
+    }
+
+    if (!agentId) {
+      console.error("Error: --agent is required (or set FLAIR_AGENT_ID)");
+      process.exit(1);
+    }
+
+    try {
+      const result = await api("POST", "/MemoryCandidate/search_by_conditions", {
+        operator: "and",
+        conditions: [
+          { search_attribute: "agentId", search_type: "equals", search_value: agentId },
+          { search_attribute: "status", search_type: "equals", search_value: status },
+        ],
+        get_attributes: ["id", "claim", "generatedBy", "generatedAt", "status", "target", "reviewerId", "decidedAt", "supersedes"],
+      });
+
+      // search_by_conditions returns either an array or { error }; tolerate both shapes
+      const candidates: any[] = Array.isArray(result) ? result : (result?.results ?? []);
+
+      if (opts.json) {
+        console.log(JSON.stringify({ agentId, status, count: candidates.length, candidates }, null, 2));
+        return;
+      }
+
+      console.log(`\n-- rem candidates (agent=${agentId}, status=${status}) --\n`);
+
+      if (candidates.length === 0) {
+        console.log(`No ${status} candidates.`);
+        if (status === "pending") {
+          console.log("\n(Run `flair rem nightly enable` to start the nightly distillation cycle that populates this table.)");
+        }
+        return;
+      }
+
+      // Sort newest-first by generatedAt
+      candidates.sort((a, b) => String(b.generatedAt ?? "").localeCompare(String(a.generatedAt ?? "")));
+
+      for (const c of candidates) {
+        const tag = c.status === "promoted"
+          ? `[promoted → ${c.target ?? "?"} by ${c.reviewerId ?? "?"} @ ${relativeTime(c.decidedAt)}]`
+          : c.status === "rejected"
+            ? `[rejected by ${c.reviewerId ?? "?"} @ ${relativeTime(c.decidedAt)}]`
+            : `[pending — ${c.generatedBy ?? "?"} @ ${relativeTime(c.generatedAt)}]`;
+        console.log(`  ${c.id}  ${tag}`);
+        console.log(`    ${c.claim}`);
+        if (c.supersedes) console.log(`    (supersedes ${c.supersedes} — recurring proposal)`);
+        console.log("");
+      }
+
+      console.log(`${candidates.length} candidate${candidates.length > 1 ? "s" : ""}.`);
+      if (status === "pending") {
+        console.log(`Promote: flair rem promote <id> --rationale "<why>" --to (soul|memory)`);
+        console.log(`Reject:  flair rem reject <id> --reason "<why>"`);
+      }
+    } catch (err: any) {
+      console.error(`Error: ${err.message}`);
+      process.exit(1);
+    }
+  });
+
 // ─── flair status ─────────────────────────────────────────────────────────────
 
 function humanBytes(n: number): string {


### PR DESCRIPTION
## Summary

First slice of **FLAIR-NIGHTLY-REM** (ops-2qq, P1, 1.0). See [specs/FLAIR-NIGHTLY-REM.md](https://github.com/tpsdev-ai/flair/blob/main/specs/FLAIR-NIGHTLY-REM.md).

Adds the `MemoryCandidate` table per § 7 and a `flair rem candidates` listing command per § 8. Sets up the operator's review surface before the nightly cycle (later slice) starts populating it.

## What's in this slice

**Schema (`schemas/memory.graphql`)**
- `MemoryCandidate` type with the spec's full field set: id, agentId, claim, sourceMemoryIds, rationalePrompt, generatedBy, generatedAt, status, target, reviewerId, reviewRationale, decidedAt, supersedes
- @indexed: agentId, generatedAt, status, supersedes
- Comment block names the inviolable contract: candidates are NEVER auto-promoted; promotion is a separate, deliberate action (later slice)

**Command (`flair rem candidates`)**
- Lists candidates by `--agent` + optional `--status (pending|promoted|rejected)` (default `pending`)
- `--json` output for scripting / future automation
- Empty-state copy points at `flair rem nightly enable` so the operator knows where candidates come from
- Pending candidates show promote/reject command hints inline (target later slice)

## Sample output

```
$ flair rem candidates --agent flint
-- rem candidates (agent=flint, status=pending) --

No pending candidates.

(Run `flair rem nightly enable` to start the nightly distillation cycle that populates this table.)
```

```
$ flair rem candidates --agent flint                    # with content (later slice will exercise this)
-- rem candidates (agent=flint, status=pending) --

  MC-xyz-1  [pending — claude-opus-4 @ 2h ago]
    Always set local git identity to Flint before committing in ~/ops.

  MC-xyz-2  [pending — claude-opus-4 @ 2h ago]
    Don't echo embedded-PAT URLs — git push -u leaks them.
    (supersedes MC-abc-3 — recurring proposal)

2 candidates.
Promote: flair rem promote <id> --rationale "<why>" --to (soul|memory)
Reject:  flair rem reject <id> --reason "<why>"
```

## Future slices (sequenced)

| Slice | Scope |
|---|---|
| 2 | promote/reject endpoints (rationale required, trust-tier policy) |
| 3 | nightly cycle: snapshot + maintenance + trust-filter + distillation |
| 4 | scheduler install (launchd/systemd templates) |
| 5 | observability: rem-nightly.jsonl, `rem nightly status`, surfaced count in `flair status` |
| 6 | pause/restore: sentinel + env-var + snapshot restore with dry-run |

## Test plan

- [x] `bun test test/unit/` — 606 pass (no regression)
- [x] Typecheck: only pre-existing `bridges/runtime/load-bridge.ts` errors (unrelated)
- [x] Schema follows existing patterns (Memory, Soul, Relationship)
- [x] Command structure matches existing `rem light/rapid/restorative` shape
- [ ] CI green
- [ ] K&S architecture + security review (light — schema add + CLI command, no new attack surface)

🤖 Generated with [Claude Code](https://claude.com/claude-code)