### PR TITLE
feat(rem): flair rem promote + reject commands (ops-2qq slice 2)

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -3740,6 +3740,55 @@ rem
     }
   });
 
+// ─── flair rem promote / reject helpers ──────────────────────────────────────
+// Pure validators extracted for testability. The action callbacks below thread
+// these through process.exit on failure; the helpers themselves are
+// side-effect-free.
+
+export function validatePromoteOpts(opts: { rationale?: string; to?: string; key?: string }): string | null {
+  if (!opts.rationale || !opts.rationale.trim()) {
+    return "--rationale is required (per spec § 5: no rubber-stamp)";
+  }
+  if (!opts.to || (opts.to !== "soul" && opts.to !== "memory")) {
+    return "--to must be 'soul' or 'memory'";
+  }
+  if (opts.to === "soul" && (!opts.key || !opts.key.trim())) {
+    return "--key is required when --to=soul (gives the Soul entry a meaningful identifier)";
+  }
+  return null;
+}
+
+export function validateRejectOpts(opts: { reason?: string }): string | null {
+  if (!opts.reason || !opts.reason.trim()) {
+    return "--reason is required";
+  }
+  return null;
+}
+
+/**
+ * Decide whether a promote/reject action can proceed against a candidate's
+ * current state, and what message to surface to the operator. Pure function;
+ * action side effects happen in the CLI body after this returns ok.
+ */
+export function decideCandidateAction(
+  candidate: { status?: string; target?: string; reviewerId?: string; decidedAt?: string } | null,
+  action: "promote" | "reject",
+): { ok: true } | { ok: false; severity: "error" | "info"; message: string } {
+  if (!candidate) return { ok: false, severity: "error", message: "candidate not found" };
+  const status = candidate.status;
+  if (status === "promoted") {
+    return action === "promote"
+      ? { ok: false, severity: "error", message: `already promoted (target=${candidate.target}, reviewer=${candidate.reviewerId})` }
+      : { ok: false, severity: "error", message: `already promoted; cannot reject after promotion` };
+  }
+  if (status === "rejected") {
+    return action === "reject"
+      ? { ok: false, severity: "info", message: `already rejected on ${candidate.decidedAt} by ${candidate.reviewerId}` }
+      : { ok: false, severity: "error", message: `already rejected; use a fresh candidate or reset status manually` };
+  }
+  return { ok: true };
+}
+
 // ─── flair rem promote ───────────────────────────────────────────────────────
 // Slice 2 of FLAIR-NIGHTLY-REM (ops-2qq). Promote a candidate to either Soul
 // or persistent Memory. Both --rationale and --to are required (spec § 5: no
@@ -3762,16 +3811,9 @@ rem
   .option("--key <key>", "Soul key (required when --to=soul; e.g. 'lessons', 'preference-X')")
   .option("--reviewer <id>", "Reviewer agent id (default: FLAIR_AGENT_ID or 'admin')")
   .action(async (candidateId, opts) => {
-    if (!opts.rationale || !opts.rationale.trim()) {
-      console.error("Error: --rationale is required (per spec § 5: no rubber-stamp)");
-      process.exit(1);
-    }
-    if (!opts.to || (opts.to !== "soul" && opts.to !== "memory")) {
-      console.error("Error: --to must be 'soul' or 'memory'");
-      process.exit(1);
-    }
-    if (opts.to === "soul" && (!opts.key || !opts.key.trim())) {
-      console.error("Error: --key is required when --to=soul (gives the Soul entry a meaningful identifier)");
+    const validationErr = validatePromoteOpts(opts);
+    if (validationErr) {
+      console.error(`Error: ${validationErr}`);
       process.exit(1);
     }
     const reviewerId = opts.reviewer || process.env.FLAIR_AGENT_ID || "admin";
@@ -3779,16 +3821,10 @@ rem
     try {
       // Fetch the candidate
       const candidate = await api("GET", `/MemoryCandidate/${encodeURIComponent(candidateId)}`);
-      if (!candidate || candidate.error) {
-        console.error(`Error: candidate ${candidateId} not found`);
-        process.exit(1);
-      }
-      if (candidate.status === "promoted") {
-        console.error(`Error: candidate ${candidateId} already promoted (target=${candidate.target}, reviewer=${candidate.reviewerId})`);
-        process.exit(1);
-      }
-      if (candidate.status === "rejected") {
-        console.error(`Error: candidate ${candidateId} was rejected. Use a fresh candidate or reset status manually.`);
+      const candidateData = (candidate && !candidate.error) ? candidate : null;
+      const decision = decideCandidateAction(candidateData, "promote");
+      if (!decision.ok) {
+        console.error(`Error: candidate ${candidateId} ${decision.message}`);
         process.exit(1);
       }
 
@@ -3866,25 +3902,24 @@ rem
   .option("--reason <text>", "Why this candidate is being rejected (required)")
   .option("--reviewer <id>", "Reviewer agent id (default: FLAIR_AGENT_ID or 'admin')")
   .action(async (candidateId, opts) => {
-    if (!opts.reason || !opts.reason.trim()) {
-      console.error("Error: --reason is required");
+    const validationErr = validateRejectOpts(opts);
+    if (validationErr) {
+      console.error(`Error: ${validationErr}`);
       process.exit(1);
     }
     const reviewerId = opts.reviewer || process.env.FLAIR_AGENT_ID || "admin";
 
     try {
       const candidate = await api("GET", `/MemoryCandidate/${encodeURIComponent(candidateId)}`);
-      if (!candidate || candidate.error) {
-        console.error(`Error: candidate ${candidateId} not found`);
+      const candidateData = (candidate && !candidate.error) ? candidate : null;
+      const decision = decideCandidateAction(candidateData, "reject");
+      if (!decision.ok) {
+        if (decision.severity === "info") {
+          console.log(`(candidate ${candidateId} ${decision.message})`);
+          return;
+        }
+        console.error(`Error: candidate ${candidateId} ${decision.message}`);
         process.exit(1);
-      }
-      if (candidate.status === "promoted") {
-        console.error(`Error: candidate ${candidateId} already promoted (cannot reject after promotion)`);
-        process.exit(1);
-      }
-      if (candidate.status === "rejected") {
-        console.log(`(candidate ${candidateId} was already rejected on ${candidate.decidedAt} by ${candidate.reviewerId})`);
-        return;
       }
 
       const decidedAt = new Date().toISOString();

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -3740,6 +3740,173 @@ rem
     }
   });
 
+// ─── flair rem promote ───────────────────────────────────────────────────────
+// Slice 2 of FLAIR-NIGHTLY-REM (ops-2qq). Promote a candidate to either Soul
+// or persistent Memory. Both --rationale and --to are required (spec § 5: no
+// rubber-stamp). When --to=soul, --key is also required so the resulting
+// Soul row has a meaningful identifier.
+//
+// Trust-tier policy is enforced by the caller's authentication today (1.0):
+// admin pass → any promote; agent key → can write to own Memory/Soul. Server-
+// side trust-tier enforcement (endorsed agents → memory only, never soul) is
+// scoped for slice 2b when agent-routed promotion lands. For now, the
+// human-operator workflow is the supported path.
+
+rem
+  .command("promote")
+  .description("Promote a memory candidate to Soul or persistent Memory (rationale required)")
+  .argument("<candidate-id>", "MemoryCandidate id to promote")
+  .option("--port <port>", "Harper HTTP port")
+  .option("--rationale <text>", "Why this candidate is being promoted (required, no rubber-stamp)")
+  .option("--to <target>", "Promotion target: 'soul' or 'memory'")
+  .option("--key <key>", "Soul key (required when --to=soul; e.g. 'lessons', 'preference-X')")
+  .option("--reviewer <id>", "Reviewer agent id (default: FLAIR_AGENT_ID or 'admin')")
+  .action(async (candidateId, opts) => {
+    if (!opts.rationale || !opts.rationale.trim()) {
+      console.error("Error: --rationale is required (per spec § 5: no rubber-stamp)");
+      process.exit(1);
+    }
+    if (!opts.to || (opts.to !== "soul" && opts.to !== "memory")) {
+      console.error("Error: --to must be 'soul' or 'memory'");
+      process.exit(1);
+    }
+    if (opts.to === "soul" && (!opts.key || !opts.key.trim())) {
+      console.error("Error: --key is required when --to=soul (gives the Soul entry a meaningful identifier)");
+      process.exit(1);
+    }
+    const reviewerId = opts.reviewer || process.env.FLAIR_AGENT_ID || "admin";
+
+    try {
+      // Fetch the candidate
+      const candidate = await api("GET", `/MemoryCandidate/${encodeURIComponent(candidateId)}`);
+      if (!candidate || candidate.error) {
+        console.error(`Error: candidate ${candidateId} not found`);
+        process.exit(1);
+      }
+      if (candidate.status === "promoted") {
+        console.error(`Error: candidate ${candidateId} already promoted (target=${candidate.target}, reviewer=${candidate.reviewerId})`);
+        process.exit(1);
+      }
+      if (candidate.status === "rejected") {
+        console.error(`Error: candidate ${candidateId} was rejected. Use a fresh candidate or reset status manually.`);
+        process.exit(1);
+      }
+
+      const decidedAt = new Date().toISOString();
+
+      // Write the resulting Soul or Memory entry
+      if (opts.to === "memory") {
+        const memId = `${candidate.agentId}-promoted-${Date.now()}`;
+        const memWrite = await api("PUT", `/Memory/${encodeURIComponent(memId)}`, {
+          id: memId,
+          agentId: candidate.agentId,
+          content: candidate.claim,
+          durability: "persistent",
+          tags: ["nightly-rem-promoted", `from:${candidateId}`],
+          derivedFrom: candidate.sourceMemoryIds ?? [],
+          promotionStatus: "approved",
+          promotedAt: decidedAt,
+          promotedBy: reviewerId,
+          createdAt: decidedAt,
+        });
+        if (memWrite?.error) {
+          console.error(`Error writing Memory: ${memWrite.error}`);
+          process.exit(1);
+        }
+        console.log(`✅ Wrote Memory ${memId} (durability=persistent)`);
+      } else {
+        // soul
+        const soulId = `${candidate.agentId}-${opts.key}`;
+        const soulWrite = await api("PUT", `/Soul/${encodeURIComponent(soulId)}`, {
+          id: soulId,
+          agentId: candidate.agentId,
+          key: opts.key,
+          value: candidate.claim,
+          priority: "standard",
+          durability: "persistent",
+          createdAt: decidedAt,
+          updatedAt: decidedAt,
+        });
+        if (soulWrite?.error) {
+          console.error(`Error writing Soul: ${soulWrite.error}`);
+          process.exit(1);
+        }
+        console.log(`✅ Wrote Soul ${soulId} (key=${opts.key})`);
+      }
+
+      // Update the candidate row
+      const upd = await api("PUT", `/MemoryCandidate/${encodeURIComponent(candidateId)}`, {
+        ...candidate,
+        status: "promoted",
+        target: opts.to,
+        reviewerId,
+        reviewRationale: opts.rationale,
+        decidedAt,
+      });
+      if (upd?.error) {
+        console.error(`Warning: candidate row update returned: ${upd.error}`);
+      }
+      console.log(`✅ Candidate ${candidateId} marked promoted → ${opts.to}, reviewer=${reviewerId}`);
+    } catch (err: any) {
+      console.error(`Error: ${err.message}`);
+      process.exit(1);
+    }
+  });
+
+// ─── flair rem reject ────────────────────────────────────────────────────────
+// Reject a candidate with a required --reason. Per spec § 5, rejected
+// candidates retain full decision history so recurring proposals are visible
+// via the supersedes chain.
+
+rem
+  .command("reject")
+  .description("Reject a memory candidate with a required reason")
+  .argument("<candidate-id>", "MemoryCandidate id to reject")
+  .option("--port <port>", "Harper HTTP port")
+  .option("--reason <text>", "Why this candidate is being rejected (required)")
+  .option("--reviewer <id>", "Reviewer agent id (default: FLAIR_AGENT_ID or 'admin')")
+  .action(async (candidateId, opts) => {
+    if (!opts.reason || !opts.reason.trim()) {
+      console.error("Error: --reason is required");
+      process.exit(1);
+    }
+    const reviewerId = opts.reviewer || process.env.FLAIR_AGENT_ID || "admin";
+
+    try {
+      const candidate = await api("GET", `/MemoryCandidate/${encodeURIComponent(candidateId)}`);
+      if (!candidate || candidate.error) {
+        console.error(`Error: candidate ${candidateId} not found`);
+        process.exit(1);
+      }
+      if (candidate.status === "promoted") {
+        console.error(`Error: candidate ${candidateId} already promoted (cannot reject after promotion)`);
+        process.exit(1);
+      }
+      if (candidate.status === "rejected") {
+        console.log(`(candidate ${candidateId} was already rejected on ${candidate.decidedAt} by ${candidate.reviewerId})`);
+        return;
+      }
+
+      const decidedAt = new Date().toISOString();
+      const upd = await api("PUT", `/MemoryCandidate/${encodeURIComponent(candidateId)}`, {
+        ...candidate,
+        status: "rejected",
+        reviewerId,
+        reviewRationale: opts.reason,
+        decidedAt,
+      });
+      if (upd?.error) {
+        console.error(`Error: candidate row update failed: ${upd.error}`);
+        process.exit(1);
+      }
+      console.log(`✅ Candidate ${candidateId} rejected by ${reviewerId}`);
+      console.log(`   Reason: ${opts.reason}`);
+    } catch (err: any) {
+      console.error(`Error: ${err.message}`);
+      process.exit(1);
+    }
+  });
+
 // ─── flair status ─────────────────────────────────────────────────────────────
 
 function humanBytes(n: number): string {

--- a/test/unit/cli-rem-promote-reject.test.ts
+++ b/test/unit/cli-rem-promote-reject.test.ts
@@ -1,0 +1,119 @@
+/**
+ * cli-rem-promote-reject.test.ts — Unit tests for the FLAIR-NIGHTLY-REM
+ * slice 2 promote/reject CLI helpers (ops-2qq).
+ *
+ * Tests the pure validators + decideCandidateAction. The action callbacks
+ * themselves spawn process.exit and call api() — those side effects make
+ * direct callback testing high-effort low-value. The helpers are the
+ * contract; the callbacks thread them.
+ */
+
+import { describe, test, expect } from "bun:test";
+import { validatePromoteOpts, validateRejectOpts, decideCandidateAction } from "../../src/cli.ts";
+
+describe("validatePromoteOpts", () => {
+  test("accepts a fully-specified memory promotion", () => {
+    expect(validatePromoteOpts({ rationale: "matches existing rule", to: "memory" })).toBeNull();
+  });
+
+  test("accepts a fully-specified soul promotion with key", () => {
+    expect(validatePromoteOpts({ rationale: "concrete behavioral guardrail", to: "soul", key: "no-secrets" })).toBeNull();
+  });
+
+  test("rejects missing rationale", () => {
+    expect(validatePromoteOpts({ to: "memory" })).toMatch(/--rationale is required/);
+  });
+
+  test("rejects whitespace-only rationale", () => {
+    expect(validatePromoteOpts({ rationale: "   ", to: "memory" })).toMatch(/--rationale is required/);
+  });
+
+  test("rejects missing target", () => {
+    expect(validatePromoteOpts({ rationale: "x" })).toMatch(/--to must be 'soul' or 'memory'/);
+  });
+
+  test("rejects invalid target", () => {
+    expect(validatePromoteOpts({ rationale: "x", to: "graphql" as any })).toMatch(/--to must be 'soul' or 'memory'/);
+  });
+
+  test("requires --key when --to=soul", () => {
+    expect(validatePromoteOpts({ rationale: "x", to: "soul" })).toMatch(/--key is required when --to=soul/);
+  });
+
+  test("rejects whitespace-only --key for soul", () => {
+    expect(validatePromoteOpts({ rationale: "x", to: "soul", key: "  " })).toMatch(/--key is required when --to=soul/);
+  });
+
+  test("does NOT require --key when --to=memory", () => {
+    expect(validatePromoteOpts({ rationale: "x", to: "memory" })).toBeNull();
+    expect(validatePromoteOpts({ rationale: "x", to: "memory", key: undefined })).toBeNull();
+  });
+});
+
+describe("validateRejectOpts", () => {
+  test("accepts a non-empty reason", () => {
+    expect(validateRejectOpts({ reason: "low-signal duplicate" })).toBeNull();
+  });
+
+  test("rejects missing reason", () => {
+    expect(validateRejectOpts({})).toMatch(/--reason is required/);
+  });
+
+  test("rejects empty-string reason", () => {
+    expect(validateRejectOpts({ reason: "" })).toMatch(/--reason is required/);
+  });
+
+  test("rejects whitespace-only reason", () => {
+    expect(validateRejectOpts({ reason: "  \t\n" })).toMatch(/--reason is required/);
+  });
+});
+
+describe("decideCandidateAction", () => {
+  test("ok for a pending candidate being promoted", () => {
+    const r = decideCandidateAction({ status: "pending" }, "promote");
+    expect(r.ok).toBe(true);
+  });
+
+  test("ok for a pending candidate being rejected", () => {
+    const r = decideCandidateAction({ status: "pending" }, "reject");
+    expect(r.ok).toBe(true);
+  });
+
+  test("error for a null candidate (not found)", () => {
+    const r = decideCandidateAction(null, "promote") as any;
+    expect(r.ok).toBe(false);
+    expect(r.severity).toBe("error");
+    expect(r.message).toMatch(/not found/);
+  });
+
+  test("error for promoting an already-promoted candidate", () => {
+    const r = decideCandidateAction({ status: "promoted", target: "soul", reviewerId: "flint" }, "promote") as any;
+    expect(r.ok).toBe(false);
+    expect(r.severity).toBe("error");
+    expect(r.message).toMatch(/already promoted/);
+    expect(r.message).toMatch(/target=soul/);
+    expect(r.message).toMatch(/reviewer=flint/);
+  });
+
+  test("error for rejecting an already-promoted candidate", () => {
+    const r = decideCandidateAction({ status: "promoted" }, "reject") as any;
+    expect(r.ok).toBe(false);
+    expect(r.severity).toBe("error");
+    expect(r.message).toMatch(/cannot reject after promotion/);
+  });
+
+  test("error for promoting an already-rejected candidate", () => {
+    const r = decideCandidateAction({ status: "rejected" }, "promote") as any;
+    expect(r.ok).toBe(false);
+    expect(r.severity).toBe("error");
+    expect(r.message).toMatch(/already rejected/);
+  });
+
+  test("INFO (idempotent) for rejecting an already-rejected candidate", () => {
+    const r = decideCandidateAction({ status: "rejected", decidedAt: "2026-05-03T12:00:00Z", reviewerId: "flint" }, "reject") as any;
+    expect(r.ok).toBe(false);
+    expect(r.severity).toBe("info");
+    expect(r.message).toMatch(/already rejected on 2026-05-03/);
+    expect(r.message).toMatch(/by flint/);
+  });
+});


### PR DESCRIPTION
## Summary

Slice 2 of **FLAIR-NIGHTLY-REM** (ops-2qq). Builds on PR #324 (slice 1 — schema + listing). Adds the operator-facing CLI commands for acting on staged candidates: `flair rem promote` and `flair rem reject`.

**Stacked on PR #324** — base branch is `cp-ops-2qq-slice1-memorycandidate-schema`. Will rebase to main automatically after slice 1 lands.

## What's in this slice

**`flair rem promote <id>` — required args:**
- `--rationale "<why>"` (per spec § 5: no rubber-stamp)
- `--to soul|memory`
- `--key <key>` when `--to=soul` (Soul rows need a meaningful identifier)

Writes the resulting Memory (durability=persistent, derivedFrom links to source memories) or Soul row BEFORE marking the candidate promoted, so a failed write doesn't strand the candidate in an unactionable state.

Refuses to act on already-promoted or already-rejected candidates.

**`flair rem reject <id> --reason "<why>"`**

Marks `status=rejected`, retains full decision history. Per spec § 5, recurring proposals surface as supersedes chains in slice 3+ (when nightly cycle starts populating with reflection-proposed lessons).

## Trust-tier enforcement deferred to slice 2b

Spec § 5 calls out three tiers: human admin (any), endorsed agent (memory only, never soul), unverified (cannot promote). Today's path is the human-operator workflow (admin pass via `flair` CLI) — pre-existing trust model. Server-side trust-tier gating lands when agent-routed promotion wires up in slice 3+. Filed for follow-up.

## Sample output

```
$ flair rem promote MC-xyz-1 --rationale "matches existing soul-rule about scope" --to memory
✅ Wrote Memory flint-promoted-1746289523912 (durability=persistent)
✅ Candidate MC-xyz-1 marked promoted → memory, reviewer=flint

$ flair rem promote MC-xyz-2 --rationale "concrete behavioral guardrail" --to soul --key "no-secrets-in-messages"
✅ Wrote Soul flint-no-secrets-in-messages (key=no-secrets-in-messages)
✅ Candidate MC-xyz-2 marked promoted → soul, reviewer=flint

$ flair rem reject MC-xyz-3 --reason "low-signal — paraphrase of an existing rule"
✅ Candidate MC-xyz-3 rejected by flint
   Reason: low-signal — paraphrase of an existing rule
```

## Future slices

| Slice | Scope |
|---|---|
| 2b | Server-side trust-tier enforcement (endorsed → memory only, never soul) when agent-routed promotion lands |
| 3 | Nightly cycle: snapshot + maintenance + trust-filter + distillation populates the table |
| 4 | Scheduler install (launchd/systemd) |
| 5 | Observability: rem-nightly.jsonl, `rem nightly status`, surfaced count in `flair status` |
| 6 | Pause/restore: sentinel + env-var + snapshot restore with dry-run |

## Test plan

- [x] `bun test test/unit/` — 606 pass, no regression
- [x] Refuses to act on already-decided candidates
- [x] Validates rationale + target before any write
- [x] Memory write happens before candidate-row update (failed write doesn't strand the candidate)
- [ ] CI green
- [ ] K&S review (architecture: command shape, write-then-update ordering; security: rationale-required gates, no admin-bypass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)