### PR TITLE
fix(flair): postinstall script defends bin exec-bit (ops-k8p7)

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,8 @@
     "prepublishOnly": "npm run build && npm run build:cli",
     "test": "bun test",
     "test:e2e": "playwright test",
-    "release": "./scripts/release.sh"
+    "release": "./scripts/release.sh",
+    "postinstall": "node -e \"try{const{chmodSync,statSync}=require('fs');const p='dist/cli.js';if(statSync(p).isFile()){chmodSync(p,0o755);console.error('@tpsdev-ai/flair: chmod +x ' + p + ' OK')}}catch(e){if(e.code!=='ENOENT')console.error('postinstall warn:',e.message)}\""
   },
   "publishConfig": {
     "access": "public"

--- a/packages/flair-mcp/package.json
+++ b/packages/flair-mcp/package.json
@@ -14,7 +14,8 @@
   ],
   "scripts": {
     "build": "tsc --noCheck",
-    "prepublishOnly": "npm run build"
+    "prepublishOnly": "npm run build",
+    "postinstall": "node -e \"try{const{chmodSync,statSync}=require('fs');const p='dist/index.js';if(statSync(p).isFile()){chmodSync(p,0o755);console.error('@tpsdev-ai/flair-mcp: chmod +x ' + p + ' OK')}}catch(e){if(e.code!=='ENOENT')console.error('postinstall warn:',e.message)}\""
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
## Summary

Fixes ops-k8p7 (P3, dogfood). Closes the rockit-binary-exec-bit issue Nathan hit this morning: `/opt/homebrew/bin/flair: '...flair/dist/cli.js' exists but is not an executable file`.

## Why postinstall, not flair-doctor

Original ops-k8p7 plan was a check in `flair doctor`. Nathan caught the chicken-and-egg: if `flair` itself isn't executable, `flair doctor` can't run either. Postinstall runs at install time — before the bin is needed — and self-heals any bit-strip vector regardless of cause (corrupt tarball, rsync without -p, manual file copy without preserve, etc.).

## Implementation

```json
"postinstall": "node -e \"try{const{chmodSync,statSync}=require('fs');const p='dist/cli.js';if(statSync(p).isFile()){chmodSync(p,0o755);console.error('@tpsdev-ai/flair: chmod +x ' + p + ' OK')}}catch(e){if(e.code!=='ENOENT')console.error('postinstall warn:',e.message)}"
```

- Wrapped in `node -e` for cross-platform safety (no chmod on Windows; try/catch silently no-ops there)
- `ENOENT` swallowed — fresh checkouts before a build don't have `dist/`, fine
- Other errors logged to stderr (warn-not-fail; we'd rather install succeed than block on a chmod issue)
- Same hardening added to `@tpsdev-ai/flair-mcp` (also ships a bin: `dist/index.js`)

Other workspace packages don't ship bins so don't need it (verified: flair-client / openclaw-flair / pi-flair).

## Smoke test

Locally on a freshly-built dist/cli.js (mode 644 from a manual chmod -x reproducing the rockit symptom), the postinstall script:
- Detects file
- Sets mode 755
- Logs `@tpsdev-ai/flair: chmod +x dist/cli.js OK`

## Test plan

- [x] Smoke-tested locally — postinstall flips 644 → 755 cleanly
- [x] No state on Windows / no-dist scenarios (ENOENT swallowed)
- [ ] CI green
- [ ] K&S architecture review (light — package.json metadata only)
- [ ] Real validation: next `npm install -g @tpsdev-ai/flair` after this publishes should self-heal even if the published tarball had a stripped bit

🤖 Generated with [Claude Code](https://claude.com/claude-code)