### PR TITLE
feat(memory): add Memory.summary field + --summary write flag (ops-wkoh slice 1)

### DIFF
--- a/schemas/memory.graphql
+++ b/schemas/memory.graphql
@@ -26,6 +26,8 @@ type Memory @table(database: "flair") {
   lastReflected: String     # ISO timestamp of last reflection pass
   supersedes: String @indexed  # ID of memory this one replaces (version chain)
   subject: String @indexed     # entity this memory is about (person, service, project)
+  summary: String              # agent-set multi-sentence dense compression (optional; ops-wkoh)
+                               # 3-tier compression chain: subject (one-line) → summary (paragraph) → content (full)
   validFrom: String @indexed   # ISO timestamp — when this fact became true
   validTo: String @indexed     # ISO timestamp — when this fact stopped being true (null = still valid)
   _safetyFlags: [String]       # content safety flags from scanContent()

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -5472,15 +5472,20 @@ const memory = program.command("memory").description("Manage agent memories");
 memory.command("add [content]").requiredOption("--agent <id>")
   .option("--content <text>", "memory content (alias for positional arg)")
   .option("--durability <d>", "standard").option("--tags <csv>")
+  .option("--summary <text>", "agent-set multi-sentence dense compression (3-tier chain: subject → summary → content; ops-wkoh)")
+  .option("--subject <text>", "one-line title / entity this memory is about")
   .action(async (contentArg, opts) => {
     const content = contentArg ?? opts.content;
     if (!content) { console.error("error: content required (positional arg or --content)"); process.exit(1); }
     const memId = `${opts.agent}-${Date.now()}`;
-    const out = await api("PUT", `/Memory/${memId}`, {
+    const body: any = {
       id: memId, agentId: opts.agent, content, durability: opts.durability || "standard",
       tags: opts.tags ? String(opts.tags).split(",").map((x: string) => x.trim()).filter(Boolean) : undefined,
       type: "memory", createdAt: new Date().toISOString(),
-    });
+    };
+    if (opts.summary) body.summary = opts.summary;
+    if (opts.subject) body.subject = opts.subject;
+    const out = await api("PUT", `/Memory/${memId}`, body);
     console.log(JSON.stringify(out, null, 2));
   });
 memory.command("search [query]").requiredOption("--agent <id>")


### PR DESCRIPTION
## Summary

ops-wkoh slice 1 — adds nullable `summary` column to the Memory schema for the 3-tier compression chain agents can choose from at read time:

`subject` (one-line) → `summary` (paragraph) → `content` (full prose)

Today agents only get full `content` or the optional one-line `subject`. The new `summary` bridges those two compression levels and gives callers a clean read-time choice for token-tight context injections.

## Backwards compatibility

Schema add is additive + nullable — existing memories keep working with `summary=null`. Search responses include the new field automatically (Harper returns all columns by default).

## CLI

```
flair memory add <content> --agent flint --summary "<dense paragraph>"
flair memory add <content> --agent flint --subject "<one-line>"
```

Also surfaced `--subject` as an explicit flag (it was already in the schema but not exposed at the CLI write surface).

## Out of scope (slice 2 follow-up)

- Read-time fallback helper that returns the best-available compression (`summary || subject || first sentence of content`). Belongs in flair-client + bootstrap/search response shaping. File when the read side gets a clear consumer.
- SLM-generated summary at write time. Punted post-1.0 per ops-wkoh description (free-tier Fabric resource constraints; ops-pykg P3 tracks separately).

## Test plan

- [x] `bun test test/unit/` — 649 pass, no regression
- [x] Schema add is backwards-compatible (nullable column)
- [ ] CI green
- [ ] K&S review (light — schema add + CLI option, no security or runtime change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)