### PR TITLE
feat(flair-client): memory.list({ subject }) filter (ops-q3qf PR-1)

### DIFF
--- a/packages/flair-client/src/client.ts
+++ b/packages/flair-client/src/client.ts
@@ -187,13 +187,27 @@ class MemoryApi {
     }
   }
 
-  /** List recent memories. */
-  async list(opts: { limit?: number; type?: MemoryType; durability?: Durability } = {}): Promise<Memory[]> {
+  /**
+   * List recent memories. All filters combine with AND.
+   *
+   * Note: this hits Harper's REST `GET /Memory?...` path; non-condition
+   * URL params (limit) are parsed by Harper directly, condition params
+   * (subject, type, durability) are translated to equality conditions
+   * by Memory.search()'s scoping override.
+   */
+  async list(opts: {
+    limit?: number;
+    type?: MemoryType;
+    durability?: Durability;
+    /** Filter by subject (entity the memory is about). Indexed; efficient. */
+    subject?: string;
+  } = {}): Promise<Memory[]> {
     const params = new URLSearchParams();
     params.set("agentId", this.client.agentId);
     if (opts.limit) params.set("limit", String(opts.limit));
     if (opts.type) params.set("type", opts.type);
     if (opts.durability) params.set("durability", opts.durability);
+    if (opts.subject) params.set("subject", opts.subject);
     return this.client.request("GET", `/Memory?${params}`);
   }
 

--- a/packages/flair-client/test/client.test.ts
+++ b/packages/flair-client/test/client.test.ts
@@ -165,6 +165,62 @@ describe("MemoryApi", () => {
     expect(mockFetch).toHaveBeenCalledTimes(1);
     expect(result.content).toBe("short");
   });
+
+  test("list defaults include agentId, no other params", async () => {
+    mockFetch = mock(() => Promise.resolve(new Response("[]", { status: 200 })));
+    globalThis.fetch = mockFetch as any;
+
+    const client = new FlairClient({ agentId: "test" });
+    await client.memory.list();
+
+    const url = (mockFetch as any).mock.calls[0][0] as string;
+    expect(url).toContain("/Memory?");
+    expect(url).toContain("agentId=test");
+    expect(url).not.toContain("limit=");
+    expect(url).not.toContain("type=");
+    expect(url).not.toContain("subject=");
+  });
+
+  test("list passes subject filter through to URL", async () => {
+    mockFetch = mock(() => Promise.resolve(new Response("[]", { status: 200 })));
+    globalThis.fetch = mockFetch as any;
+
+    const client = new FlairClient({ agentId: "test" });
+    await client.memory.list({ subject: "project-x" });
+
+    const url = (mockFetch as any).mock.calls[0][0] as string;
+    expect(url).toContain("subject=project-x");
+  });
+
+  test("list combines all filters in URL", async () => {
+    mockFetch = mock(() => Promise.resolve(new Response("[]", { status: 200 })));
+    globalThis.fetch = mockFetch as any;
+
+    const client = new FlairClient({ agentId: "test" });
+    await client.memory.list({
+      limit: 10,
+      type: "session",
+      durability: "ephemeral",
+      subject: "chat:abc",
+    });
+
+    const url = (mockFetch as any).mock.calls[0][0] as string;
+    expect(url).toContain("limit=10");
+    expect(url).toContain("type=session");
+    expect(url).toContain("durability=ephemeral");
+    expect(url).toContain("subject=chat%3Aabc");
+  });
+
+  test("list URL-encodes subject special characters", async () => {
+    mockFetch = mock(() => Promise.resolve(new Response("[]", { status: 200 })));
+    globalThis.fetch = mockFetch as any;
+
+    const client = new FlairClient({ agentId: "test" });
+    await client.memory.list({ subject: "n8n workflow & test" });
+
+    const url = (mockFetch as any).mock.calls[0][0] as string;
+    expect(url).toContain("subject=n8n+workflow+%26+test");
+  });
 });
 
 describe("SoulApi", () => {


### PR DESCRIPTION
## Summary

PR-1 of the six-PR ops-q3qf sequence (n8n community node). Adds a `subject` filter to `MemoryApi.list()`. The n8n chat-history adapter — \`FlairChatMessageHistory.getMessages()\` per the spec at PR #333 — needs to fetch all memories for a given subject (the chat session); today \`memory.list\` takes \`limit/type/durability\` but not \`subject\`.

## Change
- New optional \`subject\` field on \`MemoryApi.list\` opts. Indexed in the schema (Memory.subject is \`@indexed\`), so equality filter is efficient.
- The URL goes through Memory's auth-scoped \`search()\` override which translates URL params to equality conditions for non-admin agents (see resources/Memory.ts:48-65).
- Four new unit tests cover: default URL has only agentId; subject-only filter; combined filters; URL encoding of special characters.

## Test plan
- [x] \`bun test packages/flair-client/test/client.test.ts\` — 22 pass / 0 fail (18 existing + 4 new)
- [x] No new project-level TypeScript errors
- [x] Public API addition is backward-compatible (new optional field)

🤖 Generated with [Claude Code](https://claude.com/claude-code)