### PR TITLE
feat(n8n-nodes-flair): FlairChatMemory + LangChain adapter (ops-q3qf PR-3)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -51,10 +51,14 @@
         "@tpsdev-ai/flair-client": "0.7.0",
       },
       "devDependencies": {
+        "@langchain/classic": "1.0.32",
+        "@langchain/core": "1.1.44",
         "n8n-workflow": "1.119.0",
         "typescript": "5.9.3",
       },
       "peerDependencies": {
+        "@langchain/classic": "*",
+        "@langchain/core": "*",
         "n8n-workflow": "*",
       },
     },
@@ -226,6 +230,8 @@
 
     "@cbor-extract/cbor-extract-linux-x64": ["@cbor-extract/cbor-extract-linux-x64@2.2.2", "", { "os": "linux", "cpu": "x64" }, "sha512-rpiLnVEsqtPJ+mXTdx1rfz4RtUGYIUg2rUAZgd1KjiC1SehYUSkJN7Yh+aVfSjvCGtVP0/bfkQkXpPXKbmSUaA=="],
 
+    "@cfworker/json-schema": ["@cfworker/json-schema@4.1.1", "", {}, "sha512-gAmrUZSGtKc3AiBL71iNWxDsyUC5uMaKKGdvzYsBoTW/xi42JQHl7eKV2OYzCUqvc+D2RCcf7EXY2iCyFIk6og=="],
+
     "@clack/core": ["@clack/core@1.1.0", "", { "dependencies": { "sisteransi": "^1.0.5" } }, "sha512-SVcm4Dqm2ukn64/8Gub2wnlA5nS2iWJyCkdNHcvNHPIeBTGojpdJ+9cZKwLfmqy7irD4N5qLteSilJlE0WLAtA=="],
 
     "@clack/prompts": ["@clack/prompts@1.1.0", "", { "dependencies": { "@clack/core": "1.1.0", "sisteransi": "^1.0.5" } }, "sha512-pkqbPGtohJAvm4Dphs2M8xE29ggupihHdy1x84HNojZuMtFsHiUlRvqD24tM2+XmI+61LlfNceM3Wr7U5QES5g=="],
@@ -383,6 +389,14 @@
     "@keyv/bigmap": ["@keyv/bigmap@1.3.1", "", { "dependencies": { "hashery": "^1.4.0", "hookified": "^1.15.0" }, "peerDependencies": { "keyv": "^5.6.0" } }, "sha512-WbzE9sdmQtKy8vrNPa9BRnwZh5UF4s1KTmSK0KUVLo3eff5BlQNNWDnFOouNpKfPKDnms9xynJjsMYjMaT/aFQ=="],
 
     "@keyv/serialize": ["@keyv/serialize@1.1.1", "", {}, "sha512-dXn3FZhPv0US+7dtJsIi2R+c7qWYiReoEh5zUntWCf4oSpMNib8FDhSoed6m3QyZdx5hK7iLFkYk3rNxwt8vTA=="],
+
+    "@langchain/classic": ["@langchain/classic@1.0.32", "", { "dependencies": { "@langchain/openai": "1.4.5", "@langchain/textsplitters": "1.0.1", "handlebars": "^4.7.9", "js-yaml": "^4.1.1", "jsonpointer": "^5.0.1", "openapi-types": "^12.1.3", "yaml": "^2.8.3", "zod": "^3.25.76 || ^4" }, "optionalDependencies": { "langsmith": ">=0.4.0 <1.0.0" }, "peerDependencies": { "@langchain/core": "^1.0.0", "cheerio": "*", "peggy": "^5.1.0", "typeorm": "*" }, "optionalPeers": ["cheerio", "peggy", "typeorm"] }, "sha512-Unv3aRVNOwtJKfTyo0kS7u0ytrHtOw38ojBM8pIz7HAdai6vvCAr+rvT8mCkSKv5o78Rhrm+cn9ggTBhNukjgg=="],
+
+    "@langchain/core": ["@langchain/core@1.1.44", "", { "dependencies": { "@cfworker/json-schema": "^4.0.2", "@standard-schema/spec": "^1.1.0", "ansi-styles": "^5.0.0", "camelcase": "6", "decamelize": "1.2.0", "js-tiktoken": "^1.0.12", "langsmith": ">=0.5.0 <1.0.0", "mustache": "^4.2.0", "p-queue": "^6.6.2", "zod": "^3.25.76 || ^4" } }, "sha512-RePW1IjGCHr9ua2vcby3aE8mOOz3EnwDZxMEGbNDT91kf14eqkJqxDXvaZFviGdcN9DTrxM5RPQNAHmwSm4tbg=="],
+
+    "@langchain/openai": ["@langchain/openai@1.4.5", "", { "dependencies": { "js-tiktoken": "^1.0.12", "openai": "^6.34.0", "zod": "^3.25.76 || ^4" }, "peerDependencies": { "@langchain/core": "^1.1.42" } }, "sha512-bQ2WMIZfSh02trJLYSAtiIcD3j6EBCiAm9nw0dZWQsVaUxmWc3JJqs8uUte6AkMazmLHzcUIw+14UkXO5fRJvQ=="],
+
+    "@langchain/textsplitters": ["@langchain/textsplitters@1.0.1", "", { "dependencies": { "js-tiktoken": "^1.0.12" }, "peerDependencies": { "@langchain/core": "^1.0.0" } }, "sha512-rheJlB01iVtrOUzttscutRgLybPH9qR79EyzBEbf1u97ljWyuxQfCwIWK+SjoQTM9O8M7GGLLRBSYE26Jmcoww=="],
 
     "@larksuiteoapi/node-sdk": ["@larksuiteoapi/node-sdk@1.59.0", "", { "dependencies": { "axios": "~1.13.3", "lodash.identity": "^3.0.0", "lodash.merge": "^4.6.2", "lodash.pickby": "^4.6.0", "protobufjs": "^7.2.6", "qs": "^6.14.2", "ws": "^8.19.0" } }, "sha512-sBpkruTvZDOxnVtoTbepWKRX0j1Y1ZElQYu0x7+v088sI9pcpbVp6ZzCGn62dhrKPatzNyCJyzYCPXPYQWccrA=="],
 
@@ -702,6 +716,8 @@
 
     "@snazzah/davey-win32-x64-msvc": ["@snazzah/davey-win32-x64-msvc@0.1.10", "", { "os": "win32", "cpu": "x64" }, "sha512-kr6148VVBoUT4CtD+5hYshTFRny7R/xQZxXFhFc0fYjtmdMVM8Px9M91olg1JFNxuNzdfMfTufR58Q3wfBocug=="],
 
+    "@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
+
     "@tokenizer/inflate": ["@tokenizer/inflate@0.4.1", "", { "dependencies": { "debug": "^4.4.3", "token-types": "^6.1.1" } }, "sha512-2mAv+8pkG6GIZiF1kNg1jAjh27IDxEPKwdGul3snfztFerfPGI1LjDezZp3i7BElXompqEtPmoPx6c2wgtWsOA=="],
 
     "@tokenizer/token": ["@tokenizer/token@0.3.0", "", {}, "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A=="],
@@ -824,7 +840,7 @@
 
     "ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
-    "ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
+    "ansi-styles": ["ansi-styles@5.2.0", "", {}, "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA=="],
 
     "any-promise": ["any-promise@1.3.0", "", {}, "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A=="],
 
@@ -918,6 +934,8 @@
 
     "callsites": ["callsites@3.1.0", "", {}, "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ=="],
 
+    "camelcase": ["camelcase@6.3.0", "", {}, "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA=="],
+
     "cbor-extract": ["cbor-extract@2.2.2", "", { "dependencies": { "node-gyp-build-optional-packages": "5.1.1" }, "optionalDependencies": { "@cbor-extract/cbor-extract-darwin-arm64": "2.2.2", "@cbor-extract/cbor-extract-darwin-x64": "2.2.2", "@cbor-extract/cbor-extract-linux-arm": "2.2.2", "@cbor-extract/cbor-extract-linux-arm64": "2.2.2", "@cbor-extract/cbor-extract-linux-x64": "2.2.2", "@cbor-extract/cbor-extract-win32-x64": "2.2.2" }, "bin": { "download-cbor-prebuilds": "bin/download-prebuilds.js" } }, "sha512-hlSxxI9XO2yQfe9g6msd3g4xCfDqK5T5P0fRMLuaLHhxn4ViPrm+a+MUfhrvH2W962RGxcBwEGzLQyjbDG1gng=="],
 
     "cbor-x": ["cbor-x@1.6.4", "", { "optionalDependencies": { "cbor-extract": "^2.2.2" } }, "sha512-UGKHjp6RHC6QuZ2yy5LCKm7MojM4716DwoSaqwQpaH4DvZvbBTGcoDNTiG9Y2lByXZYFEs9WRkS5tLl96IrF1Q=="],
@@ -993,6 +1011,8 @@
     "data-uri-to-buffer": ["data-uri-to-buffer@6.0.2", "", {}, "sha512-7hvf7/GW8e86rW0ptuwS3OcBGDjIi6SZva7hCyWC0yYry2cOPmLIjXAUHI6DK2HsnwJd9ifmt57i8eV2n4YNpw=="],
 
     "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
+
+    "decamelize": ["decamelize@1.2.0", "", {}, "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA=="],
 
     "decimal.js": ["decimal.js@10.6.0", "", {}, "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg=="],
 
@@ -1080,7 +1100,7 @@
 
     "event-target-shim": ["event-target-shim@5.0.1", "", {}, "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ=="],
 
-    "eventemitter3": ["eventemitter3@5.0.4", "", {}, "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw=="],
+    "eventemitter3": ["eventemitter3@4.0.7", "", {}, "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw=="],
 
     "events": ["events@3.3.0", "", {}, "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q=="],
 
@@ -1206,6 +1226,8 @@
 
     "gunzip-maybe": ["gunzip-maybe@1.4.2", "", { "dependencies": { "browserify-zlib": "^0.1.4", "is-deflate": "^1.0.0", "is-gzip": "^1.0.0", "peek-stream": "^1.1.0", "pumpify": "^1.3.3", "through2": "^2.0.3" }, "bin": { "gunzip-maybe": "bin.js" } }, "sha512-4haO1M4mLO91PW57BMsDFf75UmwoRX0GkdD+Faw+Lr+r/OZrOCS0pIBwOL1xCKQqnQzbNFGgK2V2CpBUPeFNTw=="],
 
+    "handlebars": ["handlebars@4.7.9", "", { "dependencies": { "minimist": "^1.2.5", "neo-async": "^2.6.2", "source-map": "^0.6.1", "wordwrap": "^1.0.0" }, "optionalDependencies": { "uglify-js": "^3.1.4" }, "bin": { "handlebars": "bin/handlebars" } }, "sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ=="],
+
     "harper-fabric-embeddings": ["harper-fabric-embeddings@0.2.3", "", { "optionalDependencies": { "@node-llama-cpp/linux-arm64": "3.18.1", "@node-llama-cpp/linux-armv7l": "3.18.1", "@node-llama-cpp/linux-x64": "3.18.1", "@node-llama-cpp/mac-arm64-metal": "3.18.1", "@node-llama-cpp/mac-x64": "3.18.1", "@node-llama-cpp/win-arm64": "3.18.1", "@node-llama-cpp/win-x64": "3.18.1" } }, "sha512-25F1xzRTJ+19NlDiMI0RLF47u4Fwd5Ve/V03q06kJjCioqvEc2yrAASQ3NY4O+LJDU9rNq9WQivFeU+9JKt4IA=="],
 
     "has-flag": ["has-flag@4.0.0", "", {}, "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="],
@@ -1312,6 +1334,8 @@
 
     "js-base64": ["js-base64@3.7.2", "", {}, "sha512-NnRs6dsyqUXejqk/yv2aiXlAvOs56sLkX6nUdeaNezI5LFFLlsZjOThmwnrcwh5ZZRwZlCMnVAY3CvhIhoVEKQ=="],
 
+    "js-tiktoken": ["js-tiktoken@1.0.21", "", { "dependencies": { "base64-js": "^1.5.1" } }, "sha512-biOj/6M5qdgx5TKjDnFT1ymSpM5tbd3ylwDtrQvFQSu0Z7bBYko2dF+W/aUkXUPuk6IVpRxk/3Q2sHOzGlS36g=="],
+
     "js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
 
     "js-yaml": ["js-yaml@4.1.1", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA=="],
@@ -1336,6 +1360,8 @@
 
     "jsonfile": ["jsonfile@6.2.0", "", { "dependencies": { "universalify": "^2.0.0" }, "optionalDependencies": { "graceful-fs": "^4.1.6" } }, "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg=="],
 
+    "jsonpointer": ["jsonpointer@5.0.1", "", {}, "sha512-p/nXbhSEcu3pZRdkW1OfJhpsVtW1gd4Wa1fnQc9YLiTfAjn0312eMKimbdIQzuZl9aa9xUGaRlP9T/CJE/ditQ=="],
+
     "jsonrepair": ["jsonrepair@3.13.1", "", { "bin": { "jsonrepair": "bin/cli.js" } }, "sha512-WJeiE0jGfxYmtLwBTEk8+y/mYcaleyLXWaqp5bJu0/ZTSeG0KQq/wWQ8pmnkKenEdN6pdnn6QtcoSUkbqDHWNw=="],
 
     "jsonwebtoken": ["jsonwebtoken@9.0.3", "", { "dependencies": { "jws": "^4.0.1", "lodash.includes": "^4.3.0", "lodash.isboolean": "^3.0.3", "lodash.isinteger": "^4.0.4", "lodash.isnumber": "^3.0.3", "lodash.isplainobject": "^4.0.6", "lodash.isstring": "^4.0.1", "lodash.once": "^4.0.0", "ms": "^2.1.1", "semver": "^7.5.4" } }, "sha512-MT/xP0CrubFRNLNKvxJ2BYfy53Zkm++5bX9dtuPbqAeQpTVe0MQTFhao8+Cp//EmJp244xt6Drw/GVEGCUj40g=="],
@@ -1353,6 +1379,8 @@
     "knuth-shuffle": ["knuth-shuffle@1.0.8", "", {}, "sha512-IdC4Hpp+mx53zTt6VAGsAtbGM0g4BV9fP8tTcviCosSwocHcRDw9uG5Rnv6wLWckF4r72qeXFoK9NkvV1gUJCQ=="],
 
     "koffi": ["koffi@2.15.2", "", {}, "sha512-r9tjJLVRSOhCRWdVyQlF3/Ugzeg13jlzS4czS82MAgLff4W+BcYOW7g8Y62t9O5JYjYOLAjAovAZDNlDfZNu+g=="],
+
+    "langsmith": ["langsmith@0.6.0", "", { "dependencies": { "p-queue": "6.6.2" }, "peerDependencies": { "@opentelemetry/api": "*", "@opentelemetry/exporter-trace-otlp-proto": "*", "@opentelemetry/sdk-trace-base": "*", "openai": "*", "ws": ">=7" }, "optionalPeers": ["@opentelemetry/api", "@opentelemetry/exporter-trace-otlp-proto", "@opentelemetry/sdk-trace-base", "openai", "ws"] }, "sha512-GGaj5IMRfLv2HXXFzGk9diISMYLTpSTh6fzCZGKxWYW/NqEztIFtnXLq6G/RVhzFRmCykLap1fuC67LVKoQLcg=="],
 
     "layerr": ["layerr@0.1.2", "", {}, "sha512-ob5kTd9H3S4GOG2nVXyQhOu9O8nBgP555XxWPkJI0tR0JeRilfyTp8WtPdIJHLXBmHMSdEq5+KMxiYABeScsIQ=="],
 
@@ -1450,6 +1478,8 @@
 
     "music-metadata": ["music-metadata@11.12.3", "", { "dependencies": { "@borewit/text-codec": "^0.2.2", "@tokenizer/token": "^0.3.0", "content-type": "^1.0.5", "debug": "^4.4.3", "file-type": "^21.3.1", "media-typer": "^1.1.0", "strtok3": "^10.3.4", "token-types": "^6.1.2", "uint8array-extras": "^1.5.0", "win-guid": "^0.2.1" } }, "sha512-n6hSTZkuD59qWgHh6IP5dtDlDZQXoxk/bcA85Jywg8Z1iFrlNgl2+GTFgjZyn52W5UgQpV42V4XqrQZZAMbZTQ=="],
 
+    "mustache": ["mustache@4.2.0", "", { "bin": { "mustache": "bin/mustache" } }, "sha512-71ippSywq5Yb7/tVYyGbkBggbU8H3u5Rz56fH60jGFgr8uHwxs+aSKeqmluIVzM0m0kB7xQjKS6qPfd0b2ZoqQ=="],
+
     "mute-stream": ["mute-stream@0.0.8", "", {}, "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA=="],
 
     "mz": ["mz@2.7.0", "", { "dependencies": { "any-promise": "^1.0.0", "object-assign": "^4.0.1", "thenify-all": "^1.0.0" } }, "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q=="],
@@ -1461,6 +1491,8 @@
     "needle": ["needle@3.5.0", "", { "dependencies": { "iconv-lite": "^0.6.3", "sax": "^1.2.4" }, "bin": { "needle": "bin/needle" } }, "sha512-jaQyPKKk2YokHrEg+vFDYxXIHTCBgiZwSHOoVx/8V3GIBS8/VN6NdVRmg8q1ERtPkMvmOvebsgga4sAj5hls/w=="],
 
     "negotiator": ["negotiator@1.0.0", "", {}, "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg=="],
+
+    "neo-async": ["neo-async@2.6.2", "", {}, "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw=="],
 
     "netmask": ["netmask@2.0.2", "", {}, "sha512-dBpDMdxv9Irdq66304OLfEmQ9tbNRFnFTuZiLo+bD+r332bBmMJ8GBLXklIXXgxd3+v9+KUnZaUR5PJMa75Gsg=="],
 
@@ -1520,7 +1552,9 @@
 
     "onetime": ["onetime@5.1.2", "", { "dependencies": { "mimic-fn": "^2.1.0" } }, "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg=="],
 
-    "openai": ["openai@6.26.0", "", { "peerDependencies": { "ws": "^8.18.0", "zod": "^3.25 || ^4.0" }, "optionalPeers": ["ws", "zod"], "bin": { "openai": "bin/cli" } }, "sha512-zd23dbWTjiJ6sSAX6s0HrCZi41JwTA1bQVs0wLQPZ2/5o2gxOJA5wh7yOAUgwYybfhDXyhwlpeQf7Mlgx8EOCA=="],
+    "openai": ["openai@6.35.0", "", { "peerDependencies": { "ws": "^8.18.0", "zod": "^3.25 || ^4.0" }, "optionalPeers": ["ws", "zod"], "bin": { "openai": "bin/cli" } }, "sha512-L/skwIGnt5xQZHb0UfTu9uAUKbis3ehKypOuJKi20QvG7UStV6C8IC3myGYHcdiF4kms/bAvOJ9UqqNWqi8x/Q=="],
+
+    "openapi-types": ["openapi-types@12.1.3", "", {}, "sha512-N4YtSYJqghVu4iek2ZUvcN/0aqH1kRDuNqzcycDxhOUpg7GdvLa2F3DgS6yBNhInhv2r/6I0Flkn7CqL8+nIcw=="],
 
     "openclaw": ["openclaw@2026.3.13", "", { "dependencies": { "@agentclientprotocol/sdk": "0.16.1", "@aws-sdk/client-bedrock": "^3.1009.0", "@buape/carbon": "0.0.0-beta-20260216184201", "@clack/prompts": "^1.1.0", "@discordjs/voice": "^0.19.1", "@grammyjs/runner": "^2.0.3", "@grammyjs/transformer-throttler": "^1.2.1", "@homebridge/ciao": "^1.3.5", "@larksuiteoapi/node-sdk": "^1.59.0", "@line/bot-sdk": "^10.6.0", "@lydell/node-pty": "1.2.0-beta.3", "@mariozechner/pi-agent-core": "0.58.0", "@mariozechner/pi-ai": "0.58.0", "@mariozechner/pi-coding-agent": "0.58.0", "@mariozechner/pi-tui": "0.58.0", "@modelcontextprotocol/sdk": "1.27.1", "@mozilla/readability": "^0.6.0", "@sinclair/typebox": "0.34.48", "@slack/bolt": "^4.6.0", "@slack/web-api": "^7.15.0", "@whiskeysockets/baileys": "7.0.0-rc.9", "ajv": "^8.18.0", "chalk": "^5.6.2", "chokidar": "^5.0.0", "cli-highlight": "^2.1.11", "commander": "^14.0.3", "croner": "^10.0.1", "discord-api-types": "^0.38.42", "dotenv": "^17.3.1", "express": "^5.2.1", "file-type": "^21.3.2", "grammy": "^1.41.1", "hono": "4.12.7", "https-proxy-agent": "^8.0.0", "ipaddr.js": "^2.3.0", "jiti": "^2.6.1", "json5": "^2.2.3", "jszip": "^3.10.1", "linkedom": "^0.18.12", "long": "^5.3.2", "markdown-it": "^14.1.1", "node-edge-tts": "^1.2.10", "opusscript": "^0.1.1", "osc-progress": "^0.3.0", "pdfjs-dist": "^5.5.207", "playwright-core": "1.58.2", "qrcode-terminal": "^0.12.0", "sharp": "^0.34.5", "sqlite-vec": "0.1.7-alpha.2", "tar": "7.5.11", "tslog": "^4.10.2", "undici": "^7.24.1", "ws": "^8.19.0", "yaml": "^2.8.2", "zod": "^4.3.6" }, "peerDependencies": { "@napi-rs/canvas": "^0.1.89", "node-llama-cpp": "3.16.2" }, "optionalPeers": ["node-llama-cpp"], "bin": { "openclaw": "openclaw.mjs" } }, "sha512-/juSUb070Xz8K8CnShjaZQr7CVtRaW4FbR93lgr1hLepcRSbyz2PQR+V4w5giVWkea61opXWPA6Vb8dybaztFg=="],
 
@@ -1866,6 +1900,8 @@
 
     "uc.micro": ["uc.micro@2.1.0", "", {}, "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A=="],
 
+    "uglify-js": ["uglify-js@3.19.3", "", { "bin": { "uglifyjs": "bin/uglifyjs" } }, "sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ=="],
+
     "uhyphen": ["uhyphen@0.2.0", "", {}, "sha512-qz3o9CHXmJJPGBdqzab7qAYuW8kQGKNEuoHFYrBwV6hWIMcpAmxDLXojcHfFr9US1Pe6zUswEIJIbLI610fuqA=="],
 
     "uint8array-extras": ["uint8array-extras@1.5.0", "", {}, "sha512-rvKSBiC5zqCCiDZ9kAOszZcDvdAHwwIKJG33Ykj43OKcWsnmcBRL09YTU4nOeHZ8Y2a7l1MgTd08SBe9A8Qj6A=="],
@@ -1911,6 +1947,8 @@
     "win-guid": ["win-guid@0.2.1", "", {}, "sha512-gEIQU4mkgl2OPeoNrWflcJFJ3Ae2BPd4eCsHHA/XikslkIVms/nHhvnvzIZV7VLmBvtFlDOzLt9rrZT+n6D67A=="],
 
     "winston": ["winston@2.4.7", "", { "dependencies": { "async": "^2.6.4", "colors": "1.0.x", "cycle": "1.0.x", "eyes": "0.1.x", "isstream": "0.1.x", "stack-trace": "0.0.x" } }, "sha512-vLB4BqzCKDnnZH9PHGoS2ycawueX4HLqENXQitvFHczhgW2vFpSOn31LZtVr1KU8YTw7DS4tM+cqyovxo8taVg=="],
+
+    "wordwrap": ["wordwrap@1.0.0", "", {}, "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q=="],
 
     "wrap-ansi": ["wrap-ansi@6.2.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA=="],
 
@@ -1990,6 +2028,8 @@
 
     "@mariozechner/pi-ai/chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
 
+    "@mariozechner/pi-ai/openai": ["openai@6.26.0", "", { "peerDependencies": { "ws": "^8.18.0", "zod": "^3.25 || ^4.0" }, "optionalPeers": ["ws", "zod"], "bin": { "openai": "bin/cli" } }, "sha512-zd23dbWTjiJ6sSAX6s0HrCZi41JwTA1bQVs0wLQPZ2/5o2gxOJA5wh7yOAUgwYybfhDXyhwlpeQf7Mlgx8EOCA=="],
+
     "@mariozechner/pi-coding-agent/chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
 
     "@mariozechner/pi-coding-agent/strip-ansi": ["strip-ansi@7.2.0", "", { "dependencies": { "ansi-regex": "^6.2.2" } }, "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w=="],
@@ -2006,9 +2046,13 @@
 
     "@slack/socket-mode/@types/node": ["@types/node@25.5.0", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw=="],
 
+    "@slack/socket-mode/eventemitter3": ["eventemitter3@5.0.4", "", {}, "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw=="],
+
     "@slack/socket-mode/ws": ["ws@8.19.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg=="],
 
     "@slack/web-api/@types/node": ["@types/node@25.5.0", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw=="],
+
+    "@slack/web-api/eventemitter3": ["eventemitter3@5.0.4", "", {}, "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw=="],
 
     "@slack/web-api/form-data": ["form-data@4.0.5", "", { "dependencies": { "asynckit": "^0.4.0", "combined-stream": "^1.0.8", "es-set-tostringtag": "^2.1.0", "hasown": "^2.0.2", "mime-types": "^2.1.12" } }, "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w=="],
 
@@ -2050,6 +2094,8 @@
 
     "cbor-extract/node-gyp-build-optional-packages": ["node-gyp-build-optional-packages@5.1.1", "", { "dependencies": { "detect-libc": "^2.0.1" }, "bin": { "node-gyp-build-optional-packages": "bin.js", "node-gyp-build-optional-packages-test": "build-test.js", "node-gyp-build-optional-packages-optional": "optional.js" } }, "sha512-+P72GAjVAbTxjjwUmwjVrqrdZROD4nf8KgpBoDxqXXTiYZZt/ud60dE5yvCSr9lRO8e8yv6kgJIC0K0PfZFVQw=="],
 
+    "chalk/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
+
     "cliui/wrap-ansi": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
 
     "defaults/clone": ["clone@1.0.4", "", {}, "sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg=="],
@@ -2073,6 +2119,8 @@
     "gaxios/node-fetch": ["node-fetch@3.3.2", "", { "dependencies": { "data-uri-to-buffer": "^4.0.0", "fetch-blob": "^3.1.4", "formdata-polyfill": "^4.0.10" } }, "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA=="],
 
     "gunzip-maybe/pumpify": ["pumpify@1.5.1", "", { "dependencies": { "duplexify": "^3.6.0", "inherits": "^2.0.3", "pump": "^2.0.0" } }, "sha512-oClZI37HvuUJJxSKKrC17bZ9Cu0ZYhEAGPsPUy9KlMUmv9dKX2o77RUmq7f3XjIxbwyGwYzbzQ1L2Ks8sIradQ=="],
+
+    "handlebars/source-map": ["source-map@0.6.1", "", {}, "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="],
 
     "htmlparser2/entities": ["entities@7.0.1", "", {}, "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA=="],
 
@@ -2128,8 +2176,6 @@
 
     "ora/strip-ansi": ["strip-ansi@7.2.0", "", { "dependencies": { "ansi-regex": "^6.2.2" } }, "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w=="],
 
-    "p-queue/eventemitter3": ["eventemitter3@4.0.7", "", {}, "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw=="],
-
     "pac-proxy-agent/agent-base": ["agent-base@7.1.4", "", {}, "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ=="],
 
     "pac-proxy-agent/https-proxy-agent": ["https-proxy-agent@7.0.6", "", { "dependencies": { "agent-base": "^7.1.2", "debug": "4" } }, "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw=="],
@@ -2177,6 +2223,8 @@
     "transliteration/yargs": ["yargs@17.7.2", "", { "dependencies": { "cliui": "^8.0.1", "escalade": "^3.1.1", "get-caller-file": "^2.0.5", "require-directory": "^2.1.1", "string-width": "^4.2.3", "y18n": "^5.0.5", "yargs-parser": "^21.1.1" } }, "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w=="],
 
     "winston/async": ["async@2.6.4", "", { "dependencies": { "lodash": "^4.17.14" } }, "sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA=="],
+
+    "wrap-ansi/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
 
     "@aws-crypto/crc32/@aws-sdk/types/@smithy/types": ["@smithy/types@4.13.0", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-COuLsZILbbQsdrwKQpkkpyep7lCsByxwj7m0Mg5v66/ZTyenlfBc40/QFQ5chO0YN/PNEH1Bi3fGtfXPnYNeDw=="],
 
@@ -2254,6 +2302,8 @@
 
     "@types/yauzl/@types/node/undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
 
+    "@whiskeysockets/baileys/p-queue/eventemitter3": ["eventemitter3@5.0.4", "", {}, "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw=="],
+
     "@whiskeysockets/baileys/p-queue/p-timeout": ["p-timeout@7.0.1", "", {}, "sha512-AxTM2wDGORHGEkPCt8yqxOTMgpfbEHqF51f/5fJCmwFC3C/zNcGT63SymH2ttOAaiIws2zVg4+izQCjrakcwHg=="],
 
     "@whiskeysockets/baileys/pino/pino-abstract-transport": ["pino-abstract-transport@2.0.0", "", { "dependencies": { "split2": "^4.0.0" } }, "sha512-F63x5tizV6WCh4R6RHyi2Ml+M70DNRXt/+HANowMflpgGFMAym/VKm6G7ZOQRjqN7XbGxK1Lg9t6ZrtzOaivMw=="],
@@ -2267,6 +2317,8 @@
     "axios/form-data/mime-types": ["mime-types@2.1.35", "", { "dependencies": { "mime-db": "1.52.0" } }, "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw=="],
 
     "bun-types/@types/node/undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
+
+    "cliui/wrap-ansi/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
 
     "duplexify/readable-stream/safe-buffer": ["safe-buffer@5.1.2", "", {}, "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="],
 
@@ -2385,6 +2437,10 @@
     "@aws-sdk/lib-storage/@smithy/smithy-client/@smithy/util-stream/@smithy/fetch-http-handler/@smithy/querystring-builder": ["@smithy/querystring-builder@4.2.14", "", { "dependencies": { "@smithy/types": "^4.14.1", "@smithy/util-uri-escape": "^4.2.2", "tslib": "^2.6.2" } }, "sha512-XYA5Z0IqTeF+5XDdh4BBmSA0HvbgVZIyv4cmOoUheDNR57K1HgBp9ukUMx3Cr3XpDHHpLBnexPE3LAtDsZkj2A=="],
 
     "@aws-sdk/lib-storage/@smithy/smithy-client/@smithy/util-stream/@smithy/node-http-handler/@smithy/querystring-builder": ["@smithy/querystring-builder@4.2.14", "", { "dependencies": { "@smithy/types": "^4.14.1", "@smithy/util-uri-escape": "^4.2.2", "tslib": "^2.6.2" } }, "sha512-XYA5Z0IqTeF+5XDdh4BBmSA0HvbgVZIyv4cmOoUheDNR57K1HgBp9ukUMx3Cr3XpDHHpLBnexPE3LAtDsZkj2A=="],
+
+    "node-edge-tts/yargs/cliui/wrap-ansi/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
+
+    "transliteration/yargs/cliui/wrap-ansi/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
 
     "@aws-sdk/lib-storage/@smithy/middleware-endpoint/@smithy/core/@smithy/util-stream/@smithy/fetch-http-handler/@smithy/querystring-builder": ["@smithy/querystring-builder@4.2.14", "", { "dependencies": { "@smithy/types": "^4.14.1", "@smithy/util-uri-escape": "^4.2.2", "tslib": "^2.6.2" } }, "sha512-XYA5Z0IqTeF+5XDdh4BBmSA0HvbgVZIyv4cmOoUheDNR57K1HgBp9ukUMx3Cr3XpDHHpLBnexPE3LAtDsZkj2A=="],
 

--- a/packages/n8n-nodes-flair/README.md
+++ b/packages/n8n-nodes-flair/README.md
@@ -23,9 +23,9 @@ Then restart your n8n instance. The Flair API credential will appear under **Cre
 
 1. **Base URL** — your Flair instance, e.g. `http://localhost:9926`
 2. **Agent ID** — the logical identity that will own memories written from this n8n workspace. Workflows that share an Agent ID share memory ownership.
-3. **Admin Token** — your Flair admin token. **This grants read/write access to the entire instance.** For production with untrusted workflow inputs, wait for Ed25519 per-agent auth (post-1.0).
+3. **Admin Password** — your Flair (Harper) admin password. **This grants read/write access to the entire instance.** For production with untrusted workflow inputs, wait for Ed25519 per-agent auth (post-1.0).
 
-The credential test hits `/Health` — you'll know it works when the test succeeds.
+The credential test hits `/Memory` (auth-required) — you'll know it works when the test succeeds.
 
 ## License
 

--- a/packages/n8n-nodes-flair/package.json
+++ b/packages/n8n-nodes-flair/package.json
@@ -22,7 +22,9 @@
     "credentials": [
       "dist/credentials/FlairApi.credentials.js"
     ],
-    "nodes": []
+    "nodes": [
+      "dist/nodes/FlairChatMemory/FlairChatMemory.node.js"
+    ]
   },
   "engines": {
     "node": ">=18"
@@ -47,10 +49,14 @@
     "@tpsdev-ai/flair-client": "0.7.0"
   },
   "peerDependencies": {
-    "n8n-workflow": "*"
+    "n8n-workflow": "*",
+    "@langchain/core": "*",
+    "@langchain/classic": "*"
   },
   "devDependencies": {
     "n8n-workflow": "1.119.0",
+    "@langchain/core": "1.1.44",
+    "@langchain/classic": "1.0.32",
     "typescript": "5.9.3"
   }
 }

--- a/packages/n8n-nodes-flair/src/credentials/FlairApi.credentials.ts
+++ b/packages/n8n-nodes-flair/src/credentials/FlairApi.credentials.ts
@@ -6,9 +6,9 @@ import type {
 } from 'n8n-workflow';
 
 /**
- * Flair API credential — v1 admin-token authentication.
+ * Flair API credential — v1 Harper admin-password authentication.
  *
- * SECURITY NOTE: an admin token grants read/write to the entire Flair
+ * SECURITY NOTE: the admin password grants read/write to the entire Flair
  * instance, not just the specified agentId. The blast radius is the whole
  * memory store. This is acceptable for v1 / proof-of-concept where the
  * operator controls the n8n workflow inputs, but Ed25519 per-agent auth
@@ -18,6 +18,13 @@ import type {
  * The agentId field controls memory ownership — workflows that share an
  * agentId share memory ownership, allowing "this assistant remembers"
  * patterns across workflows. Use distinct agentIds when isolation matters.
+ *
+ * AUTH FLOW: Flair (Harper) accepts `Authorization: Basic` with the
+ * admin user (`admin`) and the admin password. We pass the password in
+ * via the `adminPassword` credential field; the Basic-auth header is
+ * constructed via the n8n expression engine. The credential test hits
+ * `/Memory` (auth-required) — `/Health` is unauthenticated, so testing
+ * against it would silently pass with wrong credentials.
  */
 export class FlairApi implements ICredentialType {
   name = 'flairApi';
@@ -45,14 +52,14 @@ export class FlairApi implements ICredentialType {
         'Logical identity used as the memory owner. Workflows that share an agentId share memory ownership.',
     },
     {
-      displayName: 'Admin Token',
-      name: 'adminToken',
+      displayName: 'Admin Password',
+      name: 'adminPassword',
       type: 'string',
       typeOptions: { password: true },
       default: '',
       required: true,
       description:
-        'Flair admin token. Sensitive: grants read/write to the entire instance. Use Ed25519 per-agent auth (post-1.0) for production with untrusted workflow inputs.',
+        "Flair (Harper) admin password. Sensitive: grants read/write to the entire instance. Use Ed25519 per-agent auth (post-1.0) for production with untrusted workflow inputs.",
     },
   ];
 
@@ -60,7 +67,8 @@ export class FlairApi implements ICredentialType {
     type: 'generic',
     properties: {
       headers: {
-        Authorization: '=Bearer {{$credentials.adminToken}}',
+        Authorization:
+          "=Basic {{ Buffer.from('admin:' + $credentials.adminPassword).toString('base64') }}",
       },
     },
   };
@@ -68,7 +76,7 @@ export class FlairApi implements ICredentialType {
   test: ICredentialTestRequest = {
     request: {
       baseURL: '={{ $credentials.baseUrl }}',
-      url: '/Health',
+      url: '/Memory',
     },
   };
 }

--- a/packages/n8n-nodes-flair/src/nodes/FlairChatMemory/FlairChatMemory.node.ts
+++ b/packages/n8n-nodes-flair/src/nodes/FlairChatMemory/FlairChatMemory.node.ts
@@ -1,0 +1,112 @@
+import { BufferWindowMemory } from "@langchain/classic/memory";
+import {
+  type ISupplyDataFunctions,
+  type INodeType,
+  type INodeTypeDescription,
+  type SupplyData,
+  NodeConnectionTypes,
+} from "n8n-workflow";
+
+import { FlairClient } from "@tpsdev-ai/flair-client";
+
+import { FlairChatMessageHistory } from "./FlairChatMessageHistory";
+
+interface FlairCredentials {
+  baseUrl: string;
+  agentId: string;
+  adminPassword: string;
+}
+
+export class FlairChatMemory implements INodeType {
+  description: INodeTypeDescription = {
+    displayName: "Flair Chat Memory",
+    name: "flairChatMemory",
+    icon: "file:flair.svg",
+    group: ["transform"],
+    version: [1],
+    description:
+      "Store n8n AI Agent chat history in Flair, a portable agent memory backend. The same memory is readable from Claude Code, OpenClaw, and any other Flair client.",
+    defaults: {
+      name: "Flair Chat Memory",
+    },
+    credentials: [
+      {
+        name: "flairApi",
+        required: true,
+      },
+    ],
+    codex: {
+      categories: ["AI"],
+      subcategories: {
+        AI: ["Memory"],
+        Memory: ["Other memories"],
+      },
+      resources: {
+        primaryDocumentation: [
+          {
+            url: "https://github.com/tpsdev-ai/flair#n8n",
+          },
+        ],
+      },
+    },
+    inputs: [],
+    outputs: [NodeConnectionTypes.AiMemory],
+    outputNames: ["Memory"],
+    properties: [
+      {
+        displayName: "Subject",
+        name: "subject",
+        type: "string",
+        default: '={{ $workflow.name }}',
+        required: true,
+        description:
+          "Flair subject that scopes the chat history. Defaults to the workflow name. Workflows that share a subject share memory.",
+      },
+      {
+        displayName: "Session Sub-Key",
+        name: "sessionKey",
+        type: "string",
+        default: "",
+        description:
+          "Optional sub-scope appended to the subject as `<subject>:<sessionKey>`. Use the n8n execution id (`={{ $execution.id }}`) for per-run isolation, or leave blank to share memory across runs.",
+      },
+      {
+        displayName: "Context Window Length",
+        name: "contextWindowLength",
+        type: "number",
+        default: 10,
+        description:
+          "How many message turns (user + AI = 1 turn) to keep in the buffer window.",
+      },
+    ],
+  };
+
+  async supplyData(this: ISupplyDataFunctions, itemIndex: number): Promise<SupplyData> {
+    const credentials = (await this.getCredentials("flairApi")) as unknown as FlairCredentials;
+    const subject = this.getNodeParameter("subject", itemIndex) as string;
+    const sessionKey = this.getNodeParameter("sessionKey", itemIndex, "") as string;
+    const k = this.getNodeParameter("contextWindowLength", itemIndex, 10) as number;
+
+    const composedSubject = sessionKey ? `${subject}:${sessionKey}` : subject;
+
+    const flair = new FlairClient({
+      url: credentials.baseUrl,
+      agentId: credentials.agentId,
+      adminUser: "admin",
+      adminPassword: credentials.adminPassword,
+    });
+
+    const history = new FlairChatMessageHistory(flair, composedSubject, k);
+
+    const memory = new BufferWindowMemory({
+      memoryKey: "chat_history",
+      chatHistory: history,
+      returnMessages: true,
+      inputKey: "input",
+      outputKey: "output",
+      k,
+    });
+
+    return { response: memory };
+  }
+}

--- a/packages/n8n-nodes-flair/src/nodes/FlairChatMemory/FlairChatMessageHistory.ts
+++ b/packages/n8n-nodes-flair/src/nodes/FlairChatMemory/FlairChatMessageHistory.ts
@@ -1,0 +1,102 @@
+import { BaseListChatMessageHistory } from "@langchain/core/chat_history";
+import {
+  type BaseMessage,
+  type StoredMessage,
+  mapChatMessagesToStoredMessages,
+  mapStoredMessagesToChatMessages,
+} from "@langchain/core/messages";
+import type { FlairClient } from "@tpsdev-ai/flair-client";
+
+/**
+ * LangChain `BaseListChatMessageHistory` adapter backed by Flair memory.
+ *
+ * Each chat message is stored as a single Flair memory:
+ *   - content: JSON.stringify(StoredMessage)
+ *   - subject: the composed chat-session subject
+ *   - tags: ["n8n-chat", `role:<type>`]
+ *   - type: "session"
+ *   - durability: "ephemeral"
+ *
+ * `getMessages()` reads memories filtered by subject and reconstructs the
+ * BaseMessage[] in createdAt-ascending order. Order is computed client-side
+ * from the createdAt timestamp because Memory.list does not yet expose a
+ * server-side sort param (tracked as the `order` extension in q3qf §6).
+ *
+ * The `windowK` constructor argument bounds the number of memories fetched
+ * per `getMessages()` call: each turn is two messages (user + AI), so we
+ * fetch up to `windowK * 2` to cover a windowing wrapper that keeps the
+ * last K turns.
+ */
+export class FlairChatMessageHistory extends BaseListChatMessageHistory {
+  lc_namespace = ["n8n-nodes", "flair"];
+
+  constructor(
+    private readonly client: FlairClient,
+    private readonly subject: string,
+    private readonly windowK: number = 10,
+  ) {
+    super();
+  }
+
+  async getMessages(): Promise<BaseMessage[]> {
+    const memories = await this.client.memory.list({
+      subject: this.subject,
+      type: "session",
+      limit: this.windowK * 2,
+    });
+    // Server returns most recent first by default; sort by createdAt asc
+    // so chat history reads chronologically (oldest first).
+    const sorted = [...memories].sort((a, b) => {
+      const ta = (a as any).createdAt ?? "";
+      const tb = (b as any).createdAt ?? "";
+      return ta < tb ? -1 : ta > tb ? 1 : 0;
+    });
+    const stored: StoredMessage[] = sorted
+      .map((m) => {
+        try {
+          return JSON.parse(m.content) as StoredMessage;
+        } catch {
+          // Memory content isn't a valid StoredMessage envelope — skip
+          // rather than throw. Most likely a memory written by another
+          // surface (CLI, MCP, another agent) sharing the subject.
+          return null;
+        }
+      })
+      .filter((s): s is StoredMessage => s !== null);
+    return mapStoredMessagesToChatMessages(stored);
+  }
+
+  async addMessage(message: BaseMessage): Promise<void> {
+    const [stored] = mapChatMessagesToStoredMessages([message]);
+    await this.client.memory.write(JSON.stringify(stored), {
+      type: "session",
+      durability: "ephemeral",
+      subject: this.subject,
+      tags: ["n8n-chat", `role:${stored.type}`],
+    });
+  }
+
+  async addMessages(messages: BaseMessage[]): Promise<void> {
+    // Flair has no batch-write today; fall back to sequential writes.
+    // BaseListChatMessageHistory's default does the same loop — the
+    // override exists so future flair-client batch support can drop in
+    // here without touching consumers.
+    for (const m of messages) await this.addMessage(m);
+  }
+
+  async clear(): Promise<void> {
+    // Best-effort delete of all session memories under this subject.
+    const memories = await this.client.memory.list({
+      subject: this.subject,
+      type: "session",
+      limit: 1000,
+    });
+    for (const m of memories) {
+      try {
+        await this.client.memory.delete(m.id);
+      } catch {
+        // best-effort — keep deleting siblings
+      }
+    }
+  }
+}

--- a/packages/n8n-nodes-flair/test/FlairChatMessageHistory.test.ts
+++ b/packages/n8n-nodes-flair/test/FlairChatMessageHistory.test.ts
@@ -1,0 +1,146 @@
+import { describe, test, expect, mock } from "bun:test";
+import { HumanMessage, AIMessage, SystemMessage } from "@langchain/core/messages";
+import { FlairChatMessageHistory } from "../src/nodes/FlairChatMemory/FlairChatMessageHistory";
+
+function makeFlairClient(stored: any[]) {
+  const calls: any[] = [];
+  const client: any = {
+    memory: {
+      list: mock(async (opts: any) => {
+        calls.push({ method: "list", opts });
+        return stored;
+      }),
+      write: mock(async (content: string, opts: any) => {
+        calls.push({ method: "write", content, opts });
+        return { id: `mock-${calls.length}`, content, ...opts };
+      }),
+      delete: mock(async (id: string) => {
+        calls.push({ method: "delete", id });
+      }),
+    },
+  };
+  return { client, calls };
+}
+
+describe("FlairChatMessageHistory", () => {
+  test("addMessage writes a single memory with correct shape", async () => {
+    const { client, calls } = makeFlairClient([]);
+    const history = new FlairChatMessageHistory(client, "subj-1");
+    await history.addMessage(new HumanMessage("hello world"));
+
+    expect(calls).toHaveLength(1);
+    const w = calls[0];
+    expect(w.method).toBe("write");
+    expect(w.opts.subject).toBe("subj-1");
+    expect(w.opts.type).toBe("session");
+    expect(w.opts.durability).toBe("ephemeral");
+    expect(w.opts.tags).toContain("n8n-chat");
+    expect(w.opts.tags).toContain("role:human");
+    // Content is stringified StoredMessage envelope
+    const parsed = JSON.parse(w.content);
+    expect(parsed.type).toBe("human");
+    expect(parsed.data.content).toBe("hello world");
+  });
+
+  test("addMessage tags AI vs Human roles distinctly", async () => {
+    const { client, calls } = makeFlairClient([]);
+    const history = new FlairChatMessageHistory(client, "subj-2");
+    await history.addMessage(new HumanMessage("Q"));
+    await history.addMessage(new AIMessage("A"));
+
+    expect(calls[0].opts.tags).toContain("role:human");
+    expect(calls[1].opts.tags).toContain("role:ai");
+  });
+
+  test("getMessages reconstructs BaseMessage[] in createdAt-ascending order", async () => {
+    const { client } = makeFlairClient([
+      // Out-of-order on purpose; getMessages should sort by createdAt asc
+      {
+        id: "m2",
+        content: JSON.stringify({ type: "ai", data: { content: "answer" } }),
+        createdAt: "2026-05-03T22:00:02.000Z",
+      },
+      {
+        id: "m1",
+        content: JSON.stringify({ type: "human", data: { content: "question" } }),
+        createdAt: "2026-05-03T22:00:01.000Z",
+      },
+    ]);
+    const history = new FlairChatMessageHistory(client, "subj-3");
+    const msgs = await history.getMessages();
+
+    expect(msgs).toHaveLength(2);
+    expect(msgs[0]).toBeInstanceOf(HumanMessage);
+    expect(msgs[0].content).toBe("question");
+    expect(msgs[1]).toBeInstanceOf(AIMessage);
+    expect(msgs[1].content).toBe("answer");
+  });
+
+  test("getMessages skips memories whose content isn't a valid StoredMessage", async () => {
+    const { client } = makeFlairClient([
+      {
+        id: "m1",
+        content: JSON.stringify({ type: "human", data: { content: "ok" } }),
+        createdAt: "2026-05-03T22:00:01.000Z",
+      },
+      {
+        id: "m2",
+        content: "not-json",
+        createdAt: "2026-05-03T22:00:02.000Z",
+      },
+      {
+        id: "m3",
+        content: JSON.stringify({ type: "ai", data: { content: "reply" } }),
+        createdAt: "2026-05-03T22:00:03.000Z",
+      },
+    ]);
+    const history = new FlairChatMessageHistory(client, "subj-4");
+    const msgs = await history.getMessages();
+
+    expect(msgs).toHaveLength(2);
+    expect(msgs[0].content).toBe("ok");
+    expect(msgs[1].content).toBe("reply");
+  });
+
+  test("getMessages requests up to windowK*2 memories filtered by subject", async () => {
+    const { client, calls } = makeFlairClient([]);
+    const history = new FlairChatMessageHistory(client, "subj-5", 7);
+    await history.getMessages();
+
+    const listCall = calls.find((c) => c.method === "list");
+    expect(listCall).toBeDefined();
+    expect(listCall.opts.subject).toBe("subj-5");
+    expect(listCall.opts.type).toBe("session");
+    expect(listCall.opts.limit).toBe(14); // 7 * 2
+  });
+
+  test("addMessages writes each message sequentially", async () => {
+    const { client, calls } = makeFlairClient([]);
+    const history = new FlairChatMessageHistory(client, "subj-6");
+    await history.addMessages([
+      new SystemMessage("sys"),
+      new HumanMessage("u"),
+      new AIMessage("a"),
+    ]);
+
+    const writes = calls.filter((c) => c.method === "write");
+    expect(writes).toHaveLength(3);
+    expect(writes[0].opts.tags).toContain("role:system");
+    expect(writes[1].opts.tags).toContain("role:human");
+    expect(writes[2].opts.tags).toContain("role:ai");
+  });
+
+  test("clear deletes every session memory under the subject", async () => {
+    const { client, calls } = makeFlairClient([
+      { id: "m1", content: "{}", createdAt: "x" },
+      { id: "m2", content: "{}", createdAt: "y" },
+      { id: "m3", content: "{}", createdAt: "z" },
+    ]);
+    const history = new FlairChatMessageHistory(client, "subj-7");
+    await history.clear();
+
+    const deletes = calls.filter((c) => c.method === "delete");
+    expect(deletes).toHaveLength(3);
+    expect(deletes.map((d) => d.id)).toEqual(["m1", "m2", "m3"]);
+  });
+});

--- a/packages/n8n-nodes-flair/test/credentials.test.ts
+++ b/packages/n8n-nodes-flair/test/credentials.test.ts
@@ -13,7 +13,7 @@ describe("FlairApi credential", () => {
     const names = cred.properties.map((p) => p.name);
     expect(names).toContain("baseUrl");
     expect(names).toContain("agentId");
-    expect(names).toContain("adminToken");
+    expect(names).toContain("adminPassword");
   });
 
   test("baseUrl defaults to localhost:9926", () => {
@@ -22,10 +22,10 @@ describe("FlairApi credential", () => {
     expect(baseUrl.required).toBe(true);
   });
 
-  test("adminToken is masked (password type)", () => {
-    const tok = cred.properties.find((p) => p.name === "adminToken")!;
-    expect((tok as any).typeOptions?.password).toBe(true);
-    expect(tok.required).toBe(true);
+  test("adminPassword is masked (password type)", () => {
+    const pw = cred.properties.find((p) => p.name === "adminPassword")!;
+    expect((pw as any).typeOptions?.password).toBe(true);
+    expect(pw.required).toBe(true);
   });
 
   test("agentId is required (memory ownership scope)", () => {
@@ -33,15 +33,22 @@ describe("FlairApi credential", () => {
     expect(agentId.required).toBe(true);
   });
 
-  test("authenticates via Bearer header", () => {
+  test("authenticates via Basic header (admin:adminPassword base64)", () => {
     expect(cred.authenticate.type).toBe("generic");
     const headers = (cred.authenticate.properties as any).headers;
-    expect(headers.Authorization).toContain("Bearer");
-    expect(headers.Authorization).toContain("$credentials.adminToken");
+    expect(headers.Authorization).toContain("Basic");
+    // Header constructs admin:<password> via n8n expression then base64-encodes
+    expect(headers.Authorization).toContain("admin:");
+    expect(headers.Authorization).toContain("$credentials.adminPassword");
+    expect(headers.Authorization).toContain("base64");
+    // Bearer must NOT be used — Flair admin auth is Basic
+    expect(headers.Authorization).not.toContain("Bearer");
   });
 
-  test("test request hits /Health on the configured baseUrl", () => {
-    expect(cred.test.request.url).toBe("/Health");
+  test("test request hits /Memory (auth-required) on the configured baseUrl", () => {
+    // /Health is unauthenticated and would silently pass with bad creds —
+    // /Memory returns 401 without a valid Authorization header.
+    expect(cred.test.request.url).toBe("/Memory");
     expect(cred.test.request.baseURL).toContain("$credentials.baseUrl");
   });
 });


### PR DESCRIPTION
## Summary

PR-3 of the q3qf sequence — implements the n8n AI Agent Memory port. Plus an important auth correction to PR-2's credential.

### What's in
- **\`FlairChatMessageHistory\`** — LangChain \`BaseListChatMessageHistory\` adapter backed by Flair memory. Each chat message becomes one Flair memory (\`type: session, durability: ephemeral, subject: composedSubject, tags: [\"n8n-chat\", \"role:<type>\"]\`). \`getMessages\` reads up to windowK*2, sorts client-side by \`createdAt\` asc, reconstructs BaseMessage[] via LangChain's standard StoredMessage map.
- **\`FlairChatMemory\` node** — n8n INodeType. Returns BufferWindowMemory wrapping the adapter. Properties: subject (default \`={{$workflow.name}}\`), optional sessionKey sub-scope, contextWindowLength.
- **Auth correction** — PR-2's credential used \`Authorization: Bearer\`. Flair admin auth is **Basic** with the user \`admin\` and the admin password. Bearer would 401 in production — Sherlock's static review couldn't catch it because the test request hit \`/Health\` (unauthenticated). This PR fixes both:
  - Rename \`adminToken\` → \`adminPassword\` and switch to Basic auth via n8n's expression engine: \`=Basic {{ Buffer.from('admin:' + $credentials.adminPassword).toString('base64') }}\`
  - Credential test request moves \`/Health\` → \`/Memory\` (auth-required, returns 401 without valid creds — verified end-to-end against the local Flair)
  - The \`credentials.test\` now asserts \`Basic\` and NOT \`Bearer\`, plus the encoded admin user

### Design references
- \`BaseListChatMessageHistory\` from \`@langchain/core/chat_history\` (matches what \`@n8n/nodes-langchain\` uses internally)
- \`BufferWindowMemory\` from \`@langchain/classic/memory\` (same as MemoryPostgresChat)
- StoredMessage envelope (\`{type, data}\`) is LangChain's canonical wire format

### Sherlock's PR-3 carry-forwards from #333 (spec)
- ✅ scanContent on JSON-wrapped chat messages — out of band: Flair already runs scanContent against \`Memory.content\`, which is the JSON-stringified envelope. Pattern regexes match substrings, so \`<system>...</system>\` embedded inside a JSON string still trips \`system_prompt_injection\`. Verified by manual test against local Flair.
- ⚠️ Admin-token blast-radius warning is in both README and credential docstring (unchanged from PR-2)
- ⚠️ Subject delimiter validation — sessionKey is concatenated with \`:\`, but Flair treats subject as opaque, so this is a data-quality concern not a security boundary. The 64-char schema bound applies. Documented in the credential's Session Sub-Key description.

## Test plan
- [x] \`bun test packages/n8n-nodes-flair/test/\` — 14 pass / 0 fail (7 credential, 7 adapter)
- [x] \`npm run build\` produces \`dist/\` with the new node + adapter .js / .d.ts
- [x] No new project-level TypeScript errors
- [x] Manually verified Flair admin auth is Basic (\`admin:password\`), NOT Bearer, against local instance: \`curl -u admin:\$(cat ~/.flair/admin-pass) http://localhost:9926/Memory\` → 200; \`curl -H 'Authorization: Bearer ...' /Memory\` → 401

🤖 Generated with [Claude Code](https://claude.com/claude-code)