### PR TITLE
feat(n8n-nodes-flair): FlairSearch tool node (ops-q3qf PR-4)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -49,6 +49,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@tpsdev-ai/flair-client": "0.7.0",
+        "zod": "3.25.76",
       },
       "devDependencies": {
         "@langchain/classic": "1.0.32",
@@ -2055,6 +2056,8 @@
     "@slack/web-api/eventemitter3": ["eventemitter3@5.0.4", "", {}, "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw=="],
 
     "@slack/web-api/form-data": ["form-data@4.0.5", "", { "dependencies": { "asynckit": "^0.4.0", "combined-stream": "^1.0.8", "es-set-tostringtag": "^2.1.0", "hasown": "^2.0.2", "mime-types": "^2.1.12" } }, "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w=="],
+
+    "@tpsdev-ai/n8n-nodes-flair/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
 
     "@tpsdev-ai/openclaw-flair/@tpsdev-ai/flair-client": ["@tpsdev-ai/flair-client@0.5.0", "", {}, "sha512-ryCHIj3NuyP+wyMvFioLTrISE3kIuvAh4r3iV1uB7p6wDqKelCphuzR2cMbVffE5Vkg4QcAUXkJ/BkOa4Dvs1g=="],
 

--- a/packages/n8n-nodes-flair/README.md
+++ b/packages/n8n-nodes-flair/README.md
@@ -2,14 +2,13 @@
 
 n8n community node — use [Flair](https://github.com/tpsdev-ai/flair) as your AI Agent's memory backend.
 
-## Status
+## Nodes
 
-**0.1.0 — scaffold.** Credential type only; nodes ship in subsequent releases:
-
-- `FlairChatMemory` (Memory port, conversation buffer) — coming in 0.2.0
-- `FlairSearch` (Tool port, knowledge search) — coming in 0.3.0
-
-See [spec](https://github.com/tpsdev-ai/flair/blob/main/specs/N8N-NODE-q3qf.md) for the implementation plan.
+- **Flair Chat Memory** — n8n AI Agent Memory port. Stores chat history in Flair, replayable across runs and readable from Claude Code, OpenClaw, and any other Flair client. LangChain `BufferWindowMemory` under the hood.
+- **Flair Search** — n8n AI Agent Tool port. Two operations:
+  - *Semantic Search* — finds memories ranked by similarity to a natural-language query.
+  - *Get By Subject* — lists memories filtered by subject, ordered by recency.
+  - *Get By Tag* — coming in a follow-up once `flair-client.memory.list` exposes a `tags` filter (tracked in the [spec](https://github.com/tpsdev-ai/flair/blob/main/specs/N8N-NODE-q3qf.md) §6).
 
 ## Installation
 

--- a/packages/n8n-nodes-flair/package.json
+++ b/packages/n8n-nodes-flair/package.json
@@ -23,7 +23,8 @@
       "dist/credentials/FlairApi.credentials.js"
     ],
     "nodes": [
-      "dist/nodes/FlairChatMemory/FlairChatMemory.node.js"
+      "dist/nodes/FlairChatMemory/FlairChatMemory.node.js",
+      "dist/nodes/FlairSearch/FlairSearch.node.js"
     ]
   },
   "engines": {
@@ -46,7 +47,8 @@
     "langchain"
   ],
   "dependencies": {
-    "@tpsdev-ai/flair-client": "0.7.0"
+    "@tpsdev-ai/flair-client": "0.7.0",
+    "zod": "3.25.76"
   },
   "peerDependencies": {
     "n8n-workflow": "*",

--- a/packages/n8n-nodes-flair/src/nodes/FlairSearch/FlairSearch.node.ts
+++ b/packages/n8n-nodes-flair/src/nodes/FlairSearch/FlairSearch.node.ts
@@ -1,0 +1,216 @@
+import { DynamicStructuredTool } from "@langchain/core/tools";
+import { z } from "zod";
+import {
+  type IExecuteFunctions,
+  type INodeExecutionData,
+  type INodeType,
+  type INodeTypeDescription,
+  type ISupplyDataFunctions,
+  type SupplyData,
+  NodeConnectionTypes,
+} from "n8n-workflow";
+
+import { FlairClient } from "@tpsdev-ai/flair-client";
+
+interface FlairCredentials {
+  baseUrl: string;
+  agentId: string;
+  adminPassword: string;
+}
+
+type Operation = "search" | "getBySubject";
+
+function makeClient(credentials: FlairCredentials): FlairClient {
+  return new FlairClient({
+    url: credentials.baseUrl,
+    agentId: credentials.agentId,
+    adminUser: "admin",
+    adminPassword: credentials.adminPassword,
+  });
+}
+
+async function runSearch(
+  flair: FlairClient,
+  query: string,
+  limit: number,
+): Promise<Array<Record<string, unknown>>> {
+  const results = await flair.memory.search(query, { limit });
+  return results.map((r) => ({
+    id: r.id,
+    content: r.content,
+    score: r.score,
+    type: r.type,
+    tags: r.tags,
+    createdAt: r.createdAt,
+  }));
+}
+
+async function runGetBySubject(
+  flair: FlairClient,
+  subject: string,
+  limit: number,
+): Promise<Array<Record<string, unknown>>> {
+  const memories = await flair.memory.list({ subject, limit });
+  return memories.map((m: any) => ({
+    id: m.id,
+    content: m.content,
+    type: m.type,
+    tags: m.tags,
+    subject: m.subject,
+    createdAt: m.createdAt,
+  }));
+}
+
+export class FlairSearch implements INodeType {
+  description: INodeTypeDescription = {
+    displayName: "Flair Search",
+    name: "flairSearch",
+    icon: "file:flair.svg",
+    group: ["transform"],
+    version: [1],
+    description:
+      "Search Flair memory by semantic query or by subject. Use as an AI Agent tool to give the agent access to structured Flair memories.",
+    defaults: {
+      name: "Flair Search",
+    },
+    credentials: [
+      {
+        name: "flairApi",
+        required: true,
+      },
+    ],
+    codex: {
+      categories: ["AI"],
+      subcategories: {
+        AI: ["Tools"],
+        Tools: ["Other Tools"],
+      },
+      resources: {
+        primaryDocumentation: [
+          {
+            url: "https://github.com/tpsdev-ai/flair#n8n",
+          },
+        ],
+      },
+    },
+    inputs: [],
+    outputs: [NodeConnectionTypes.AiTool],
+    outputNames: ["Tool"],
+    properties: [
+      {
+        displayName: "Operation",
+        name: "operation",
+        type: "options",
+        noDataExpression: true,
+        options: [
+          {
+            name: "Semantic Search",
+            value: "search",
+            description: "Find memories most semantically similar to a query",
+          },
+          {
+            name: "Get By Subject",
+            value: "getBySubject",
+            description:
+              "List memories filtered by subject (the entity/conversation/topic they're about)",
+          },
+        ],
+        default: "search",
+      },
+      {
+        displayName: "Query",
+        name: "query",
+        type: "string",
+        default: "",
+        required: true,
+        displayOptions: { show: { operation: ["search"] } },
+        description: "The semantic query to search Flair memory for",
+      },
+      {
+        displayName: "Subject",
+        name: "subject",
+        type: "string",
+        default: "",
+        required: true,
+        displayOptions: { show: { operation: ["getBySubject"] } },
+        description: "The subject (entity / topic) to fetch memories for",
+      },
+      {
+        displayName: "Limit",
+        name: "limit",
+        type: "number",
+        default: 5,
+        description: "Maximum number of memories to return",
+      },
+      {
+        displayName:
+          "Get By Tag is not yet available — flair-client.memory.list does not yet expose a tag filter (tracked in q3qf spec §6). Workaround: use Semantic Search and let the model filter results by tags in the response.",
+        name: "tagNotice",
+        type: "notice",
+        default: "",
+      },
+    ],
+  };
+
+  async supplyData(this: ISupplyDataFunctions, itemIndex: number): Promise<SupplyData> {
+    const credentials = (await this.getCredentials("flairApi")) as unknown as FlairCredentials;
+    const operation = this.getNodeParameter("operation", itemIndex) as Operation;
+    const limit = this.getNodeParameter("limit", itemIndex, 5) as number;
+    const flair = makeClient(credentials);
+
+    if (operation === "search") {
+      const tool = new DynamicStructuredTool({
+        name: "flair_search",
+        description:
+          "Search Flair memory by semantic similarity. Returns memories ranked by relevance to the query.",
+        schema: z.object({
+          query: z
+            .string()
+            .describe("The natural-language query to search memory for"),
+        }),
+        func: async ({ query }: { query: string }) => {
+          const results = await runSearch(flair, query, limit);
+          return JSON.stringify(results);
+        },
+      });
+      return { response: tool };
+    }
+
+    // getBySubject — subject is bound at config time so the agent only
+    // chooses to invoke it (not which subject to fetch).
+    const subject = this.getNodeParameter("subject", itemIndex) as string;
+    const tool = new DynamicStructuredTool({
+      name: "flair_get_by_subject",
+      description: `Get memories about subject "${subject}" from Flair, ordered by recency.`,
+      schema: z.object({}),
+      func: async () => {
+        const results = await runGetBySubject(flair, subject, limit);
+        return JSON.stringify(results);
+      },
+    });
+    return { response: tool };
+  }
+
+  async execute(this: IExecuteFunctions): Promise<INodeExecutionData[][]> {
+    const credentials = (await this.getCredentials("flairApi")) as unknown as FlairCredentials;
+    const flair = makeClient(credentials);
+    const inputs = this.getInputData();
+    const out: INodeExecutionData[] = [];
+
+    for (let i = 0; i < inputs.length; i++) {
+      const operation = this.getNodeParameter("operation", i) as Operation;
+      const limit = this.getNodeParameter("limit", i, 5) as number;
+      let results: Array<Record<string, unknown>>;
+      if (operation === "search") {
+        const query = this.getNodeParameter("query", i) as string;
+        results = await runSearch(flair, query, limit);
+      } else {
+        const subject = this.getNodeParameter("subject", i) as string;
+        results = await runGetBySubject(flair, subject, limit);
+      }
+      out.push({ json: { operation, results }, pairedItem: { item: i } });
+    }
+
+    return [out];
+  }
+}

--- a/packages/n8n-nodes-flair/test/FlairSearch.test.ts
+++ b/packages/n8n-nodes-flair/test/FlairSearch.test.ts
@@ -1,0 +1,53 @@
+import { describe, test, expect } from "bun:test";
+import { FlairSearch } from "../src/nodes/FlairSearch/FlairSearch.node";
+
+describe("FlairSearch node description", () => {
+  const node = new FlairSearch();
+
+  test("identifies as flairSearch on the AI Tool socket", () => {
+    expect(node.description.name).toBe("flairSearch");
+    expect(node.description.displayName).toBe("Flair Search");
+    expect(node.description.outputs).toEqual(["ai_tool" as any] as any);
+  });
+
+  test("declares operation property with two operations", () => {
+    const op = node.description.properties.find((p) => p.name === "operation")!;
+    expect(op).toBeDefined();
+    const values = ((op as any).options ?? []).map((o: any) => o.value);
+    expect(values).toContain("search");
+    expect(values).toContain("getBySubject");
+  });
+
+  test("query is required when operation = search", () => {
+    const q = node.description.properties.find((p) => p.name === "query")!;
+    expect(q.required).toBe(true);
+    expect((q as any).displayOptions?.show?.operation).toEqual(["search"]);
+  });
+
+  test("subject is required when operation = getBySubject", () => {
+    const s = node.description.properties.find((p) => p.name === "subject")!;
+    expect(s.required).toBe(true);
+    expect((s as any).displayOptions?.show?.operation).toEqual(["getBySubject"]);
+  });
+
+  test("limit defaults to 5", () => {
+    const l = node.description.properties.find((p) => p.name === "limit")!;
+    expect(l.default).toBe(5);
+  });
+
+  test("includes notice about Get By Tag deferred to spec §6 carry-forward", () => {
+    const notice = node.description.properties.find((p) => p.name === "tagNotice");
+    expect(notice).toBeDefined();
+    expect((notice as any).type).toBe("notice");
+    expect((notice as any).displayName).toContain("Get By Tag");
+  });
+
+  test("requires the flairApi credential", () => {
+    const cred = node.description.credentials!.find((c) => c.name === "flairApi")!;
+    expect(cred.required).toBe(true);
+  });
+
+  test("declares an n8n AI Tool output", () => {
+    expect(node.description.outputs).toContain("ai_tool" as any);
+  });
+});


### PR DESCRIPTION
## Summary

PR-4 of the q3qf sequence — implements the n8n AI Agent Tool port. Companion to PR-3 (FlairChatMemory, just merged at #336).

### What's in
- **FlairSearch node** — INodeType with both \`supplyData\` (LangChain Tool, AI Tool socket) and \`execute\` (standalone Action node) implementations, mirroring n8n's ToolCalculator dual-path pattern.
- **Two operations:**
  - *Semantic Search* — surfaces \`flair_search\` tool to the agent with a single \`query\` arg. Calls \`FlairClient.memory.search\`.
  - *Get By Subject* — surfaces \`flair_get_by_subject\` with no args (subject is bound at config time). Calls \`FlairClient.memory.list({ subject, limit })\`.
- **\`zod\` 3.25.76** as a runtime dep (LangChain DynamicStructuredTool requires a Zod schema).
- 8 new unit tests covering description shape, operation set, conditional required fields, AiTool socket, credential dep, deferred-tag notice. Total package suite now 22 tests.

### Get By Tag is deferred
\`flair-client.memory.list\` doesn't yet expose a \`tags\` filter — that's the third extension noted in q3qf §6 carry-forward and waits for its consumer to surface the actual ordering and filter pain. The node UI ships a \`notice\` field explaining the workaround (use Semantic Search and let the model filter results by tags in the response).

### Sherlock from #333: scanContent on JSON
Same answer as PR-3: Flair already runs \`scanContent\` against \`Memory.content\` on write. Nothing FlairSearch does writes new memory. Read path returns whatever's stored — agents see the unwrapped \`content\` field of each result.

## Test plan
- [x] \`bun test packages/n8n-nodes-flair/test/\` — 22 pass / 0 fail
- [x] \`npm run build\` produces \`dist/nodes/FlairSearch/FlairSearch.node.js\`
- [x] No new project-level TypeScript errors
- [x] Both operations smoke-tested locally against running Flair via the FlairClient (semantic search and list-by-subject)

🤖 Generated with [Claude Code](https://claude.com/claude-code)