### PR TITLE
release(scripts): include n8n-nodes-flair in release.sh (ops-q3qf PR-6)

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -36,6 +36,7 @@ PACKAGES=(
   "$ROOT/packages/flair-mcp"
   "$ROOT/packages/openclaw-flair"
   "$ROOT/packages/pi-flair"
+  "$ROOT/packages/n8n-nodes-flair"
   "$ROOT"
 )
 
@@ -44,6 +45,7 @@ PACKAGE_JSONS=(
   "$ROOT/packages/flair-mcp/package.json"
   "$ROOT/packages/openclaw-flair/package.json"
   "$ROOT/packages/pi-flair/package.json"
+  "$ROOT/packages/n8n-nodes-flair/package.json"
   "$ROOT/package.json"
 )
 
@@ -94,6 +96,7 @@ if [[ "$MODE" == "--publish" ]]; then
   (cd "$ROOT" && npm run build && npm run build:cli) || { echo "❌ Build failed"; exit 1; }
   (cd "$ROOT/packages/flair-client" && npm run build) || { echo "❌ flair-client build failed"; exit 1; }
   (cd "$ROOT/packages/flair-mcp" && npm run build) || { echo "❌ flair-mcp build failed"; exit 1; }
+  (cd "$ROOT/packages/n8n-nodes-flair" && npm run build) || { echo "❌ n8n-nodes-flair build failed"; exit 1; }
 
   echo "🚀 Publishing to npm..."
   echo "  Publishing @tpsdev-ai/flair-client..."
@@ -110,6 +113,9 @@ if [[ "$MODE" == "--publish" ]]; then
 
   echo "  Publishing @tpsdev-ai/pi-flair..."
   (cd "$ROOT/packages/pi-flair" && npm publish) || { echo "⚠️  pi-flair publish failed (may need build step)"; }
+
+  echo "  Publishing @tpsdev-ai/n8n-nodes-flair..."
+  (cd "$ROOT/packages/n8n-nodes-flair" && npm publish) || { echo "⚠️  n8n-nodes-flair publish failed"; }
 
   echo "🏷️  Tagging v${VERSION} on main..."
   git -C "$ROOT" tag -a "v${VERSION}" -m "Release v${VERSION}"
@@ -165,9 +171,13 @@ for pkg in "${PACKAGES[@]}"; do
   echo "  ✓ $name → $VERSION"
 done
 
-# 3. Update internal dependencies (flair-mcp + pi-flair both depend on flair-client)
+# 3. Update internal dependencies (flair-mcp + pi-flair + n8n-nodes-flair all
+#    depend on flair-client)
 echo "🔗 Aligning internal dependencies..."
-for INTERNAL_DEPENDENT in "$ROOT/packages/flair-mcp/package.json" "$ROOT/packages/pi-flair/package.json"; do
+for INTERNAL_DEPENDENT in \
+    "$ROOT/packages/flair-mcp/package.json" \
+    "$ROOT/packages/pi-flair/package.json" \
+    "$ROOT/packages/n8n-nodes-flair/package.json"; do
   node -e "
     const fs = require('fs');
     const path = '$INTERNAL_DEPENDENT';
@@ -191,6 +201,7 @@ echo "🔨 Building..."
 (cd "$ROOT" && npm run build && npm run build:cli) || { echo "❌ Build failed"; exit 1; }
 (cd "$ROOT/packages/flair-client" && npm run build) || { echo "❌ flair-client build failed"; exit 1; }
 (cd "$ROOT/packages/flair-mcp" && npm run build) || { echo "❌ flair-mcp build failed"; exit 1; }
+(cd "$ROOT/packages/n8n-nodes-flair" && npm run build) || { echo "❌ n8n-nodes-flair build failed"; exit 1; }
 echo "  ✓ All packages built"
 
 # 5. Test
@@ -209,6 +220,7 @@ git -C "$ROOT" add \
   "$ROOT/packages/flair-mcp/package.json" \
   "$ROOT/packages/openclaw-flair/package.json" \
   "$ROOT/packages/pi-flair/package.json" \
+  "$ROOT/packages/n8n-nodes-flair/package.json" \
   "$ROOT/bun.lock"
 git -C "$ROOT" commit -m "release: v${VERSION} — align all workspace packages"
 


### PR DESCRIPTION
## Summary

Final PR of the q3qf sequence — makes \`release.sh\` aware of the new \`@tpsdev-ai/n8n-nodes-flair\` workspace package so Nathan can include it in the coordinated bump-and-publish flow.

### What's in
Five touchpoints in \`scripts/release.sh\`:

1. \`PACKAGES\` + \`PACKAGE_JSONS\` arrays now include n8n-nodes-flair
2. Internal-dependency alignment: n8n-nodes-flair depends on @tpsdev-ai/flair-client, so the dep version is bumped in lockstep (same pattern as flair-mcp + pi-flair)
3. Phase-1 build step adds n8n-nodes-flair to the per-package builds
4. Phase-2 build step does the same
5. Phase-2 npm publish step runs \`npm publish\` for n8n-nodes-flair alongside the others

### Workflow after merge

1. (Nathan) Decide version. Default candidate: **0.7.1** if you want a patch release that ships memory.summary scan + n8n-nodes-flair without claiming 1.0; **1.0.0** if you want this to be the moment Flair is "memory across orchestrators" complete.
2. (Nathan) From a clean main: \`./scripts/release.sh <version>\` → opens a release PR. Review and merge.
3. (Nathan) After merge: \`./scripts/release.sh <version> --publish\` → publishes all six workspace packages to npm in dep order, tags + pushes the tag.

The publish step stays Nathan's hand for MFA (rockit isn't logged in to npm by design).

## Test plan
- [x] No code changes outside scripts/release.sh — diff is +14/-2
- [x] release.sh syntax valid (\`bash -n scripts/release.sh\`)
- [x] Coordinated version-bump pattern matches existing flair-mcp / pi-flair entries (same internal-dep update + same build/publish ordering)

🤖 Generated with [Claude Code](https://claude.com/claude-code)