### PR TITLE
ops-q3qf: add tags filter to flair-client memory.list

### DIFF
--- a/packages/flair-client/src/client.ts
+++ b/packages/flair-client/src/client.ts
@@ -196,6 +196,7 @@ class MemoryApi {
    * by Memory.search()'s scoping override.
    */
   async list(opts: {
+    tags?: string[];
     limit?: number;
     type?: MemoryType;
     durability?: Durability;
@@ -205,6 +206,9 @@ class MemoryApi {
     const params = new URLSearchParams();
     params.set("agentId", this.client.agentId);
     if (opts.limit) params.set("limit", String(opts.limit));
+    if (opts.tags && opts.tags.length) {
+      for (const t of opts.tags) params.append("tags", t);
+    }
     if (opts.type) params.set("type", opts.type);
     if (opts.durability) params.set("durability", opts.durability);
     if (opts.subject) params.set("subject", opts.subject);

--- a/packages/flair-client/test/client.test.ts
+++ b/packages/flair-client/test/client.test.ts
@@ -221,6 +221,40 @@ describe("MemoryApi", () => {
     const url = (mockFetch as any).mock.calls[0][0] as string;
     expect(url).toContain("subject=n8n+workflow+%26+test");
   });
+  test("list with empty tags array has no tags param", async () => {
+    mockFetch = mock(() => Promise.resolve(new Response("[]", { status: 200 })));
+    globalThis.fetch = mockFetch as any;
+
+    const client = new FlairClient({ agentId: "test" });
+    await client.memory.list({ tags: [] });
+
+    const url = (mockFetch as any).mock.calls[0][0] as string;
+    expect(url).not.toContain("tags=");
+  });
+
+  test("list with one tag appends tags param", async () => {
+    mockFetch = mock(() => Promise.resolve(new Response("[]", { status: 200 })));
+    globalThis.fetch = mockFetch as any;
+
+    const client = new FlairClient({ agentId: "test" });
+    await client.memory.list({ tags: ["foo"] });
+
+    const url = (mockFetch as any).mock.calls[0][0] as string;
+    expect(url).toContain("tags=foo");
+  });
+
+  test("list with multiple tags appends repeated tags params (not comma-joined)", async () => {
+    mockFetch = mock(() => Promise.resolve(new Response("[]", { status: 200 })));
+    globalThis.fetch = mockFetch as any;
+
+    const client = new FlairClient({ agentId: "test" });
+    await client.memory.list({ tags: ["foo", "bar"] });
+
+    const url = (mockFetch as any).mock.calls[0][0] as string;
+    expect(url).toMatch(/tags=foo.*tags=bar/);
+    expect(url).not.toContain("tags=foo,bar");
+  });
+
 });
 
 describe("SoulApi", () => {

--- a/resources/Memory.ts
+++ b/resources/Memory.ts
@@ -57,7 +57,7 @@ export class Memory extends (databases as any).flair.Memory {
       } else if (typeof (query as any).entries === "function") {
         for (const [k, v] of (query as any).entries()) {
           if (k === "agentId") continue;
-          existing.push({ attribute: k, comparator: "equals", value: v });
+          if (k === "tags") { existing.push({ attribute: k, comparator: "contains", value: v }); } else { existing.push({ attribute: k, comparator: "equals", value: v }); }
         }
       }
       query.conditions = [agentIdCondition, ...existing];

--- a/test/data-scoping.test.ts
+++ b/test/data-scoping.test.ts
@@ -240,6 +240,34 @@ describe("Memory.search() / WorkspaceState.search() — collection scoping", () 
     expect(JSON.stringify(r.query.conditions)).toContain("attacker");
     expect(JSON.stringify(r.query.conditions)).not.toContain("starts_with");
   });
+  // ── URL param → conditions translation (mirrors Memory.search query iteration) ─
+  function paramsToConditions(entries: Iterable<[string, string]>): Array<{attribute: string; comparator: string; value: string}> {
+    const conditions: Array<{attribute: string; comparator: string; value: string}> = [];
+    for (const [k, v] of entries) {
+      if (k === "agentId") continue;
+      if (k === "tags") { conditions.push({ attribute: k, comparator: "contains", value: v }); }
+      else { conditions.push({ attribute: k, comparator: "equals", value: v }); }
+    }
+    return conditions;
+  }
+
+  it("uses contains comparator for tags, equals for other params", () => {
+    const entries: [string, string][] = [
+      ["type", "lesson"],
+      ["tags", "important"],
+      ["tags", "urgent"],
+      ["durability", "persistent"],
+      ["agentId", "should-be-skipped"],
+    ];
+    const conditions = paramsToConditions(entries);
+    expect(conditions).toEqual([
+      { attribute: "type", comparator: "equals", value: "lesson" },
+      { attribute: "tags", comparator: "contains", value: "important" },
+      { attribute: "tags", comparator: "contains", value: "urgent" },
+      { attribute: "durability", comparator: "equals", value: "persistent" },
+    ]);
+  });
+
 });
 
 describe("SQL/GraphQL endpoint blocking (non-admin)", () => {


### PR DESCRIPTION
## Summary

Adds a tags filter to `flair-client.memory.list()` (ops-q3qf-list-tags-filter).

### Changes

1. **`packages/flair-client/src/client.ts`** — Extended `MemoryApi.list` opts to accept `tags?: string[]`. When provided with non-empty array, each tag is appended as a repeated URL parameter using `URLSearchParams.append` (NOT comma-joined).

2. **`resources/Memory.ts`** — Special-cased `tags` in the URL→conditions translator: uses comparator `contains` for tags params, `equals` for all other params. Each repeated `?tags=X` yields its own condition (AND semantics).

3. **`packages/flair-client/test/client.test.ts`** — 3 new tests:
   - `list({ tags: [] })` → URL has no `tags=` param
   - `list({ tags: ["foo"] })` → URL has `tags=foo`
   - `list({ tags: ["foo", "bar"] })` → URL has `tags=foo&tags=bar` (repeated, NOT comma-joined)

4. **`test/data-scoping.test.ts`** — Added `paramsToConditions` helper + unit test verifying `contains` comparator for tags vs `equals` for other params.

### Verification

```
bun install && bun test (packages/flair-client) → 25 pass, 0 fail
bun test test/data-scoping.test.ts → 30 pass, 0 fail
npx tsc -p tsconfig.json --noEmit → no new errors in changed packages
```

@Flint