### PR TITLE
feat: add order param to MemoryApi.list for server-side chronological sorting

### DIFF
--- a/packages/flair-client/src/client.ts
+++ b/packages/flair-client/src/client.ts
@@ -202,6 +202,8 @@ class MemoryApi {
     durability?: Durability;
     /** Filter by subject (entity the memory is about). Indexed; efficient. */
     subject?: string;
+    /** Server-side chronological ordering. Harper function-call syntax: ?sort(createdAt) or ?sort(createdAt,desc). */
+    order?: "createdAt-asc" | "createdAt-desc";
   } = {}): Promise<Memory[]> {
     const params = new URLSearchParams();
     params.set("agentId", this.client.agentId);
@@ -212,6 +214,11 @@ class MemoryApi {
     if (opts.type) params.set("type", opts.type);
     if (opts.durability) params.set("durability", opts.durability);
     if (opts.subject) params.set("subject", opts.subject);
+    if (opts.order === "createdAt-desc") {
+      params.append("sort(createdAt,desc)", "");
+    } else if (opts.order === "createdAt-asc") {
+      params.append("sort(createdAt)", "");
+    }
     return this.client.request("GET", `/Memory?${params}`);
   }
 

--- a/packages/flair-client/test/client.test.ts
+++ b/packages/flair-client/test/client.test.ts
@@ -255,6 +255,41 @@ describe("MemoryApi", () => {
     expect(url).not.toContain("tags=foo,bar");
   });
 
+  test("list with order asc contains sort(createdAt) param", async () => {
+    mockFetch = mock(() => Promise.resolve(new Response("[]", { status: 200 })));
+    globalThis.fetch = mockFetch as any;
+
+    const client = new FlairClient({ agentId: "test" });
+    await client.memory.list({ order: "createdAt-asc" });
+
+    const url = (mockFetch as any).mock.calls[0][0] as string;
+    // URLSearchParams encodes parens: sort(createdAt) → sort%28createdAt%29
+    expect(url).toContain("sort%28createdAt%29=");
+  });
+
+  test("list with order desc contains sort(createdAt,desc) param", async () => {
+    mockFetch = mock(() => Promise.resolve(new Response("[]", { status: 200 })));
+    globalThis.fetch = mockFetch as any;
+
+    const client = new FlairClient({ agentId: "test" });
+    await client.memory.list({ order: "createdAt-desc" });
+
+    const url = (mockFetch as any).mock.calls[0][0] as string;
+    // URLSearchParams encodes parens + comma: sort(createdAt,desc) → sort%28createdAt%2Cdesc%29
+    expect(url).toContain("sort%28createdAt%2Cdesc%29=");
+  });
+
+  test("list with no order has no sort param", async () => {
+    mockFetch = mock(() => Promise.resolve(new Response("[]", { status: 200 })));
+    globalThis.fetch = mockFetch as any;
+
+    const client = new FlairClient({ agentId: "test" });
+    await client.memory.list();
+
+    const url = (mockFetch as any).mock.calls[0][0] as string;
+    expect(url).not.toContain("sort");
+  });
+
 });
 
 describe("SoulApi", () => {

--- a/resources/Memory.ts
+++ b/resources/Memory.ts
@@ -57,6 +57,10 @@ export class Memory extends (databases as any).flair.Memory {
       } else if (typeof (query as any).entries === "function") {
         for (const [k, v] of (query as any).entries()) {
           if (k === "agentId") continue;
+          // Skip function-call URL params (e.g. sort(createdAt), sort(createdAt,desc)).
+          // They have empty values and are already handled by Harper's parseQuery which
+          // populates query.sort/query.limit directly from the URL string.
+          if (/^sort\(/.test(k) || v === "") continue;
           if (k === "tags") { existing.push({ attribute: k, comparator: "contains", value: v }); } else { existing.push({ attribute: k, comparator: "equals", value: v }); }
         }
       }


### PR DESCRIPTION
## Summary

Extend `flair-client.memory.list` with an `order` option so n8n's `FlairChatMessageHistory.getMessages` can request server-side chronological ordering instead of sorting client-side.

**Spec:** [N8N-NODE-q3qf.md §6](https://github.com/tpsdev-ai/flair/blob/main/specs/N8N-NODE-q3qf.md) — third extension (after #334 subject, #342 tags)

## Changes (3 files, ~30 lines + 3 tests)

### `packages/flair-client/src/client.ts`
- Add `order?: 'createdAt-asc' | 'createdAt-desc'` to `MemoryApi.list` opts
- When set, append Harper function-call URL param: `sort(createdAt)` for asc, `sort(createdAt,desc)` for desc
- URLSearchParams encodes parens (`%28`/) — Harper's `parseQuery` handles this

### `resources/Memory.ts`
- In `Memory.search` override, skip URL params matching `/^sort\(/ ^or with empty values when iterating conditions
- Harper's `parseQuery` already populates `query.sort` from the URL string — we just need to stop the override from clobbering them as equality conditions

### `packages/flair-client/test/client.test.ts`
- 3 new tests: order asc produces `sort%28createdAt%29=`, order desc produces `sort%28createdAt%2Cdesc%29=`, no order produces no sort param

## Test results
- Client tests: 28 pass (25 existing + 3 new)
- Full suite: 928 pass (main was 925, +3 new) — 2 playwright failures are pre-existing
- Type-check: clean on our files