### PR TITLE
feat(flair-client): add in-memory privateKey config option

### DIFF
--- a/packages/flair-client/src/client.ts
+++ b/packages/flair-client/src/client.ts
@@ -9,6 +9,7 @@
  */
 
 import type { KeyObject } from "node:crypto";
+import { createPrivateKey } from "node:crypto";
 import { loadPrivateKey, resolveKeyPath, signRequest } from "./auth.js";
 import type {
   FlairClientConfig,
@@ -32,6 +33,7 @@ export class FlairClient {
   private privateKey: KeyObject | null = null;
   private keyResolved = false;
   private keyPath: string | undefined;
+  private rawPrivateKey: string | KeyObject | undefined;
   private timeoutMs: number;
   private basicAuth: string | null = null;
 
@@ -39,6 +41,9 @@ export class FlairClient {
     this.url = (config.url ?? process.env.FLAIR_URL ?? DEFAULT_URL).replace(/\/$/, "");
     this.agentId = config.agentId || process.env.FLAIR_AGENT_ID || "";
     this.keyPath = config.keyPath;
+    if (config.privateKey !== undefined) {
+      this.rawPrivateKey = config.privateKey;
+    }
     this.timeoutMs = config.timeoutMs ?? DEFAULT_TIMEOUT;
     // Basic auth fallback for standalone deployments without Ed25519 keys
     const adminUser = config.adminUser ?? process.env.FLAIR_ADMIN_USER;
@@ -53,6 +58,15 @@ export class FlairClient {
   private resolveKey(): KeyObject | null {
     if (this.keyResolved) return this.privateKey;
     this.keyResolved = true;
+    // In-memory key takes priority over file-based resolution.
+    if (this.rawPrivateKey) {
+      if (typeof this.rawPrivateKey === "string") {
+        this.privateKey = createPrivateKey(this.rawPrivateKey);
+      } else {
+        this.privateKey = this.rawPrivateKey;
+      }
+      return this.privateKey;
+    }
     const path = resolveKeyPath(this.agentId, this.keyPath);
     if (path) {
       // Key file exists — failure to parse is a hard error.

--- a/packages/flair-client/src/types.ts
+++ b/packages/flair-client/src/types.ts
@@ -1,3 +1,7 @@
+import type { KeyObject } from "node:crypto";
+
+export type { KeyObject };
+
 /** Memory durability levels. */
 export type Durability = "permanent" | "persistent" | "standard" | "ephemeral";
 
@@ -53,6 +57,9 @@ export interface FlairClientConfig {
   agentId?: string;
   /** Path to Ed25519 private key file. Auto-resolved if omitted. */
   keyPath?: string;
+  /** In-memory Ed25519 private key (PEM string or pre-loaded KeyObject).
+   *  Bypasses keyPath/file resolution. Wins over keyPath when both are supplied. */
+  privateKey?: string | KeyObject;
   /** Request timeout in ms. Default: 10000 */
   timeoutMs?: number;
   /** Admin username for Basic auth fallback (standalone deployments). Falls back to FLAIR_ADMIN_USER env var. */

--- a/packages/flair-client/test/client.test.ts
+++ b/packages/flair-client/test/client.test.ts
@@ -1,4 +1,4 @@
-import { describe, test, expect, mock, beforeEach } from "bun:test";
+import { describe, test, expect, mock, beforeEach, spyOn } from "bun:test";
 
 // Mock fetch globally
 const originalFetch = globalThis.fetch;
@@ -11,6 +11,8 @@ beforeEach(() => {
 
 // Import after mock setup
 const { FlairClient, FlairError } = await import("../src/client.js");
+const authMod = await import("../src/auth.js");
+import { generateKeyPairSync } from "node:crypto";
 
 describe("FlairClient", () => {
   test("constructor uses default URL when none provided", () => {
@@ -339,5 +341,77 @@ describe("bootstrap", () => {
     expect(result.context).toContain("Identity");
     const call = (mockFetch as any).mock.calls[0];
     expect(call[0]).toContain("/BootstrapMemories");
+  });
+});
+
+describe("privateKey config option", () => {
+  let resolveKeyPathSpy: ReturnType<typeof spyOn>;
+  let loadPrivateKeySpy: ReturnType<typeof spyOn>;
+
+  beforeEach(() => {
+    // Prevent any actual file reads when privateKey is supplied
+    resolveKeyPathSpy = spyOn(authMod, "resolveKeyPath").mockImplementation(() => null);
+    loadPrivateKeySpy = spyOn(authMod, "loadPrivateKey").mockImplementation(() => {
+      throw new Error("loadPrivateKey should not be called when privateKey is set");
+    });
+  });
+
+  test("privateKey as PEM string resolves to KeyObject without reading files", async () => {
+    const { privateKey } = generateKeyPairSync("ed25519");
+    const pem = privateKey.export({ format: "pem", type: "pkcs8" });
+
+    const client = new FlairClient({ agentId: "test", privateKey: pem as any });
+
+    // Trigger lazy resolution via health() call
+    await client.health();
+    // fetch was called — signing succeeded with the PEM key
+    expect(mockFetch).toHaveBeenCalled();
+    // resolveKeyPath and loadPrivateKey must never be called
+    expect(resolveKeyPathSpy).toHaveBeenCalledTimes(0);
+    expect(loadPrivateKeySpy).toHaveBeenCalledTimes(0);
+  });
+
+  test("privateKey as KeyObject is used directly without reading files", async () => {
+    const { privateKey } = generateKeyPairSync("ed25519");
+
+    const client = new FlairClient({ agentId: "test", privateKey: privateKey });
+
+    await client.health();
+    expect(mockFetch).toHaveBeenCalled();
+    expect(resolveKeyPathSpy).toHaveBeenCalledTimes(0);
+    expect(loadPrivateKeySpy).toHaveBeenCalledTimes(0);
+  });
+
+  test("privateKey wins when both privateKey and keyPath are supplied", async () => {
+    const { privateKey } = generateKeyPairSync("ed25519");
+    const pem = privateKey.export({ format: "pem", type: "pkcs8" });
+
+    const client = new FlairClient({
+      agentId: "test",
+      privateKey: pem as any,
+      keyPath: "/nonexistent/path/to/key.key",
+    });
+
+    await client.health();
+    expect(mockFetch).toHaveBeenCalled();
+    // resolveKeyPath should never be called — privateKey short-circuits
+    expect(resolveKeyPathSpy).toHaveBeenCalledTimes(0);
+  });
+
+  test("without privateKey, falls back to keyPath resolution (existing behavior)", async () => {
+    // Restore original implementation, then spy again to count calls
+    resolveKeyPathSpy.mockRestore();
+    loadPrivateKeySpy.mockRestore();
+
+    const resolveSpy = spyOn(authMod, "resolveKeyPath").mockImplementation(() => null);
+
+    const client = new FlairClient({ agentId: "test" });
+    await client.health();
+
+    // resolveKeyPath SHOULD be called (no privateKey → file fallback)
+    expect(resolveSpy).toHaveBeenCalledTimes(1);
+    expect(resolveSpy).toHaveBeenCalledWith("test", undefined);
+
+    resolveSpy.mockRestore();
   });
 });


### PR DESCRIPTION
## Summary

Extend `@tpsdev-ai/flair-client` with an in-memory `privateKey` config option that bypasses file-based key resolution.

## Changes

**packages/flair-client/src/types.ts** — add `privateKey?: string | KeyObject` to `FlairClientConfig`. Re-export `KeyObject` from `node:crypto` for convenience.

**packages/flair-client/src/client.ts** — constructor stores `rawPrivateKey`; `resolveKey()` checks it first:
- If `string`: parsed via `crypto.createPrivateKey(pem)`
- If `KeyObject`: used directly
- Falls back to existing `keyPath` / `resolveKeyPath` / `loadPrivateKey` path if not set

**packages/flair-client/test/client.test.ts** — 4 new tests:
1. privateKey as PEM string → resolves to KeyObject, no file reads
2. privateKey as KeyObject → used directly, no file reads
3. both privateKey AND keyPath → privateKey wins (short-circuits file path)
4. neither set → falls back to keyPath resolution (existing behavior preserved)

## Why

Unblocks PR-B (n8n credential update) which needs to pass the PEM from n8n's encrypted credential store directly, without a file on disk.

## Backward compatibility

Fully backward compatible. Existing callers using `keyPath` are unaffected. The `privateKey` field is optional and defaults to undefined.

## Tests

32 tests pass (28 existing + 4 new). Type-check clean for flair-client.

## Spec

N8N-ED25519-q3qf-followup.md §2.4 — PR-A in the 3-PR sequence