### PR TITLE
ci(lint): add job to check for implementation-term leaks

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -361,12 +361,8 @@ jobs:
         uses: github/codeql-action/analyze@480db559a14342288b67e54bd959dd52dc3ee68f # v3
 
   doclint:
-    name: Doc/Code Lint: implementation-term leaks
+    name: "Doc/Code Lint: implementation-term leaks"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
-      - uses: oven-sh/setup-bun@735343b667d3e6f658f44d0eca948eb6282f2b76 # v2
-        with:
-          bun-version: "1.3.10"
-      - run: bun install --frozen-lockfile
-      - run: ./scripts/check-impl-term-leaks.sh
+      - run: chmod +x ./scripts/check-impl-term-leaks.sh && ./scripts/check-impl-term-leaks.sh

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -359,3 +359,14 @@ jobs:
           config-file: ./.github/codeql/codeql-config.yml
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@480db559a14342288b67e54bd959dd52dc3ee68f # v3
+
+  doclint:
+    name: Doc/Code Lint: implementation-term leaks
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - uses: oven-sh/setup-bun@735343b667d3e6f658f44d0eca948eb6282f2b76 # v2
+        with:
+          bun-version: "1.3.10"
+      - run: bun install --frozen-lockfile
+      - run: ./scripts/check-impl-term-leaks.sh

--- a/docs/system-requirements.md
+++ b/docs/system-requirements.md
@@ -17,7 +17,7 @@ Flair runs Harper v5 (a Node.js HTTP+storage runtime) plus a small CLI/MCP layer
 |---|---|---|---|---|---|
 | rockit (Mac mini, 16 GB) | 740 MB daemon + ~175 MB across 4 flair-mcp clients = ~915 MB total | 163 MB | 25.9.0 | 35 min | Hub for rockit↔Fabric pair; local agent count: 4 (flint, kern, sherlock, ember). |
 | pulse (Linux VM, 19 GB pool) | 500 MB | 88 MB | 22.22.0 | 3d 20h | Spoke; 1 agent (pulse). |
-| tps-anvil (Linux VM, 19 GB pool) | (not running) | 71 MB | 22.22.1 | — | ops-fl87 — Linux deps issue, P1 backlog. |
+| tps-anvil (Linux VM, 19 GB pool) | (not running) | 71 MB | 22.22.1 | — | Linux deps issue, P1 backlog. |
 
 ## What drives the numbers
 

--- a/scripts/check-impl-term-leaks.sh
+++ b/scripts/check-impl-term-leaks.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Define the patterns to search for
+# Bead IDs: ops-[a-z0-9]{4,}
+# Implementation labels: post-#.# or pre-#.# (where # is digit)
+PATTERNS='ops-[a-z0-9]{4,}|\\bpost-[0-9]+\\.[0-9]+\\b|\\bpre-[0-9]+\\.[0-9]+\\b'
+
+# Temporary file for list of files
+TMPFILE=$(mktemp)
+trap "rm -f $TMPFILE" EXIT
+
+# Find files to search:
+# 1. All files under packages/*/dist/
+find packages -type f -path '*/dist/*' -not -path '*/.github/*' -not -path '*/specs/*' -not -path '*/test/*' 2>/dev/null >> "$TMPFILE"
+# 2. All packages/*/README.md
+find packages -type f -name 'README.md' -path 'packages/*' -not -path '*/.github/*' -not -path '*/specs/*' -not -path '*/test/*' 2>/dev/null >> "$TMPFILE"
+# 3. Root README.md
+if [[ -f README.md && ! README.md -ef */.github/* && ! README.md -ef */specs/* && ! README.md -ef */test/* ]]; then
+  echo "README.md" >> "$TMPFILE"
+fi
+# 4. All files under docs/
+find docs -type f -not -path '*/.github/*' -not -path '*/specs/*' -not -path '*/test/*' 2>/dev/null >> "$TMPFILE"
+
+# Sort and remove duplicates
+sort -u "$TMPFILE" > "${TMPFILE}.sorted"
+mv "${TMPFILE}.sorted" "$TMPFILE"
+
+# If no files found, exit 0
+if [[ ! -s "$TMPFILE" ]]; then
+  echo "No files to search."
+  exit 0
+fi
+
+# Search for patterns in the collected files
+echo "Searching for implementation term leaks in:"
+cat "$TMPFILE"
+echo "---"
+
+# Use grep with line numbers and filename
+# We use command substitution to pass the list of files as arguments
+OUTPUT=$(grep -n -E "$PATTERNS" $(cat "$TMPFILE") 2>/dev/null || true)
+
+if [[ -n "$OUTPUT" ]]; then
+  echo "$OUTPUT"
+  exit 1
+else
+  echo "No leaks found."
+  exit 0
+fi

--- a/specs/N8N-ED25519-q3qf-followup.md
+++ b/specs/N8N-ED25519-q3qf-followup.md
@@ -1,3 +1,4 @@
+**Internal planning doc — Bead IDs and version markers are for team coordination; do not appear in user-facing surfaces.**
 # Spec: Ed25519 per-agent auth in `@tpsdev-ai/n8n-nodes-flair`
 
 **Goal:** Add Ed25519 per-agent authentication to the n8n Flair credential, alongside the existing v1 admin-password mode. Sherlock flagged this as required before any production deployment with sensitive memories or untrusted workflow inputs (PR #333 review carry-forward).

--- a/specs/N8N-NODE-q3qf.md
+++ b/specs/N8N-NODE-q3qf.md
@@ -1,3 +1,4 @@
+**Internal planning doc — Bead IDs and version markers are for team coordination; do not appear in user-facing surfaces.**
 # Spec: `@tpsdev-ai/n8n-nodes-flair` (ops-q3qf)
 
 **Goal:** ship a community-published n8n node package that lets n8n workflows use Flair as their AI-Agent memory backend, plus a worked-example workflow. The 1.0 narrative move: orchestrator-agnostic memory across Claude Code / OpenClaw / n8n.


### PR DESCRIPTION
Adds a CI lint job to flag implementation terms in user-facing surfaces. Also adds banner to internal planning specs.