### PR TITLE
refactor(flair-client): use search_by_conditions for memory.list (ops-xhme)

### DIFF
--- a/packages/flair-client/src/client.ts
+++ b/packages/flair-client/src/client.ts
@@ -204,10 +204,12 @@ class MemoryApi {
   /**
    * List recent memories. All filters combine with AND.
    *
-   * Note: this hits Harper's REST `GET /Memory?...` path; non-condition
-   * URL params (limit) are parsed by Harper directly, condition params
-   * (subject, type, durability) are translated to equality conditions
-   * by Memory.search()'s scoping override.
+   * Uses Harper's `POST /Memory/search_by_conditions` endpoint with an
+   * explicit conditions array. The Memory.search() override injects the
+   * agentId scoping condition.
+   *
+   * Note: `order` is applied client-side after retrieval. Harper's
+   * search_by_conditions does not accept a sort/order field in the body.
    */
   async list(opts: {
     tags?: string[];
@@ -216,24 +218,46 @@ class MemoryApi {
     durability?: Durability;
     /** Filter by subject (entity the memory is about). Indexed; efficient. */
     subject?: string;
-    /** Server-side chronological ordering. Harper function-call syntax: ?sort(createdAt) or ?sort(createdAt,desc). */
+    /** Chronological ordering applied client-side after retrieval.
+     *  Server-side sort is not available via search_by_conditions. */
     order?: "createdAt-asc" | "createdAt-desc";
   } = {}): Promise<Memory[]> {
-    const params = new URLSearchParams();
-    params.set("agentId", this.client.agentId);
-    if (opts.limit) params.set("limit", String(opts.limit));
-    if (opts.tags && opts.tags.length) {
-      for (const t of opts.tags) params.append("tags", t);
+    // Build conditions array — agentId is always scoped
+    const conditions: Array<{ search_attribute: string; search_type: string; search_value: unknown }> = [
+      { search_attribute: "agentId", search_type: "equals", search_value: this.client.agentId },
+    ];
+
+    if (opts.subject) {
+      conditions.push({ search_attribute: "subject", search_type: "equals", search_value: opts.subject });
     }
-    if (opts.type) params.set("type", opts.type);
-    if (opts.durability) params.set("durability", opts.durability);
-    if (opts.subject) params.set("subject", opts.subject);
-    if (opts.order === "createdAt-desc") {
-      params.append("sort(createdAt,desc)", "");
-    } else if (opts.order === "createdAt-asc") {
-      params.append("sort(createdAt)", "");
+    for (const tag of opts.tags ?? []) {
+      conditions.push({ search_attribute: "tags", search_type: "contains", search_value: tag });
     }
-    return this.client.request("GET", `/Memory?${params}`);
+    if (opts.type) {
+      conditions.push({ search_attribute: "type", search_type: "equals", search_value: opts.type });
+    }
+    if (opts.durability) {
+      conditions.push({ search_attribute: "durability", search_type: "equals", search_value: opts.durability });
+    }
+
+    const body: Record<string, unknown> = {
+      operator: "and",
+      conditions,
+      get_attributes: ["*"],
+    };
+    if (opts.limit) body.limit = opts.limit;
+
+    const result = await this.client.request("POST", "/Memory/search_by_conditions", body);
+    // search_by_conditions returns either an array or { results: [...] }
+    const memories: Memory[] = Array.isArray(result) ? result : (result?.results ?? []);
+
+    // Client-side sort (Harper's search_by_conditions does not accept sort in body)
+    if (opts.order) {
+      const dir = opts.order === "createdAt-desc" ? -1 : 1;
+      memories.sort((a, b) => dir * (a.createdAt > b.createdAt ? 1 : a.createdAt < b.createdAt ? -1 : 0));
+    }
+
+    return memories;
   }
 
   /** Delete a memory. */

--- a/packages/flair-client/test/client.test.ts
+++ b/packages/flair-client/test/client.test.ts
@@ -168,128 +168,182 @@ describe("MemoryApi", () => {
     expect(result.content).toBe("short");
   });
 
-  test("list defaults include agentId, no other params", async () => {
+  test("list POSTs conditions body with agentId scope", async () => {
     mockFetch = mock(() => Promise.resolve(new Response("[]", { status: 200 })));
     globalThis.fetch = mockFetch as any;
 
-    const client = new FlairClient({ agentId: "test" });
+    const client = new FlairClient({ agentId: "testAgentId" });
     await client.memory.list();
 
-    const url = (mockFetch as any).mock.calls[0][0] as string;
-    expect(url).toContain("/Memory?");
-    expect(url).toContain("agentId=test");
-    expect(url).not.toContain("limit=");
-    expect(url).not.toContain("type=");
-    expect(url).not.toContain("subject=");
+    expect(mockFetch).toHaveBeenCalled();
+    const call = (mockFetch as any).mock.calls[0];
+    expect(call[0]).toBe("http://localhost:19926/Memory/search_by_conditions");
+    expect(call[1].method).toBe("POST");
+    const body = JSON.parse(call[1].body);
+    expect(body.operator).toBe("and");
+    expect(body.get_attributes).toEqual(["*"]);
+    expect(body.conditions).toEqual([
+      { search_attribute: "agentId", search_type: "equals", search_value: "testAgentId" },
+    ]);
   });
 
-  test("list passes subject filter through to URL", async () => {
+  test("list with subject adds equals condition", async () => {
     mockFetch = mock(() => Promise.resolve(new Response("[]", { status: 200 })));
     globalThis.fetch = mockFetch as any;
 
     const client = new FlairClient({ agentId: "test" });
     await client.memory.list({ subject: "project-x" });
 
-    const url = (mockFetch as any).mock.calls[0][0] as string;
-    expect(url).toContain("subject=project-x");
+    const body = JSON.parse((mockFetch as any).mock.calls[0][1].body);
+    expect(body.conditions).toEqual([
+      { search_attribute: "agentId", search_type: "equals", search_value: "test" },
+      { search_attribute: "subject", search_type: "equals", search_value: "project-x" },
+    ]);
   });
 
-  test("list combines all filters in URL", async () => {
-    mockFetch = mock(() => Promise.resolve(new Response("[]", { status: 200 })));
-    globalThis.fetch = mockFetch as any;
-
-    const client = new FlairClient({ agentId: "test" });
-    await client.memory.list({
-      limit: 10,
-      type: "session",
-      durability: "ephemeral",
-      subject: "chat:abc",
-    });
-
-    const url = (mockFetch as any).mock.calls[0][0] as string;
-    expect(url).toContain("limit=10");
-    expect(url).toContain("type=session");
-    expect(url).toContain("durability=ephemeral");
-    expect(url).toContain("subject=chat%3Aabc");
-  });
-
-  test("list URL-encodes subject special characters", async () => {
-    mockFetch = mock(() => Promise.resolve(new Response("[]", { status: 200 })));
-    globalThis.fetch = mockFetch as any;
-
-    const client = new FlairClient({ agentId: "test" });
-    await client.memory.list({ subject: "n8n workflow & test" });
-
-    const url = (mockFetch as any).mock.calls[0][0] as string;
-    expect(url).toContain("subject=n8n+workflow+%26+test");
-  });
-  test("list with empty tags array has no tags param", async () => {
-    mockFetch = mock(() => Promise.resolve(new Response("[]", { status: 200 })));
-    globalThis.fetch = mockFetch as any;
-
-    const client = new FlairClient({ agentId: "test" });
-    await client.memory.list({ tags: [] });
-
-    const url = (mockFetch as any).mock.calls[0][0] as string;
-    expect(url).not.toContain("tags=");
-  });
-
-  test("list with one tag appends tags param", async () => {
-    mockFetch = mock(() => Promise.resolve(new Response("[]", { status: 200 })));
-    globalThis.fetch = mockFetch as any;
-
-    const client = new FlairClient({ agentId: "test" });
-    await client.memory.list({ tags: ["foo"] });
-
-    const url = (mockFetch as any).mock.calls[0][0] as string;
-    expect(url).toContain("tags=foo");
-  });
-
-  test("list with multiple tags appends repeated tags params (not comma-joined)", async () => {
+  test("list with tags creates separate contains condition per tag", async () => {
     mockFetch = mock(() => Promise.resolve(new Response("[]", { status: 200 })));
     globalThis.fetch = mockFetch as any;
 
     const client = new FlairClient({ agentId: "test" });
     await client.memory.list({ tags: ["foo", "bar"] });
 
-    const url = (mockFetch as any).mock.calls[0][0] as string;
-    expect(url).toMatch(/tags=foo.*tags=bar/);
-    expect(url).not.toContain("tags=foo,bar");
+    const body = JSON.parse((mockFetch as any).mock.calls[0][1].body);
+    expect(body.conditions).toEqual([
+      { search_attribute: "agentId", search_type: "equals", search_value: "test" },
+      { search_attribute: "tags", search_type: "contains", search_value: "foo" },
+      { search_attribute: "tags", search_type: "contains", search_value: "bar" },
+    ]);
   });
 
-  test("list with order asc contains sort(createdAt) param", async () => {
+  test("list with type adds equals condition", async () => {
     mockFetch = mock(() => Promise.resolve(new Response("[]", { status: 200 })));
     globalThis.fetch = mockFetch as any;
 
     const client = new FlairClient({ agentId: "test" });
-    await client.memory.list({ order: "createdAt-asc" });
+    await client.memory.list({ type: "session" });
 
-    const url = (mockFetch as any).mock.calls[0][0] as string;
-    // URLSearchParams encodes parens: sort(createdAt) → sort%28createdAt%29
-    expect(url).toContain("sort%28createdAt%29=");
+    const body = JSON.parse((mockFetch as any).mock.calls[0][1].body);
+    expect(body.conditions).toEqual([
+      { search_attribute: "agentId", search_type: "equals", search_value: "test" },
+      { search_attribute: "type", search_type: "equals", search_value: "session" },
+    ]);
   });
 
-  test("list with order desc contains sort(createdAt,desc) param", async () => {
+  test("list with durability adds equals condition", async () => {
     mockFetch = mock(() => Promise.resolve(new Response("[]", { status: 200 })));
     globalThis.fetch = mockFetch as any;
 
     const client = new FlairClient({ agentId: "test" });
-    await client.memory.list({ order: "createdAt-desc" });
+    await client.memory.list({ durability: "ephemeral" });
 
-    const url = (mockFetch as any).mock.calls[0][0] as string;
-    // URLSearchParams encodes parens + comma: sort(createdAt,desc) → sort%28createdAt%2Cdesc%29
-    expect(url).toContain("sort%28createdAt%2Cdesc%29=");
+    const body = JSON.parse((mockFetch as any).mock.calls[0][1].body);
+    expect(body.conditions).toEqual([
+      { search_attribute: "agentId", search_type: "equals", search_value: "test" },
+      { search_attribute: "durability", search_type: "equals", search_value: "ephemeral" },
+    ]);
   });
 
-  test("list with no order has no sort param", async () => {
+  test("list with limit puts it in body.limit field", async () => {
     mockFetch = mock(() => Promise.resolve(new Response("[]", { status: 200 })));
     globalThis.fetch = mockFetch as any;
 
     const client = new FlairClient({ agentId: "test" });
-    await client.memory.list();
+    await client.memory.list({ limit: 10 });
 
-    const url = (mockFetch as any).mock.calls[0][0] as string;
-    expect(url).not.toContain("sort");
+    const body = JSON.parse((mockFetch as any).mock.calls[0][1].body);
+    expect(body.limit).toBe(10);
+    // No limit in body when not specified
+    const client2 = new FlairClient({ agentId: "test2" });
+    await client2.memory.list();
+    const body2 = JSON.parse((mockFetch as any).mock.calls[1][1].body);
+    expect(body2.limit).toBeUndefined();
+  });
+
+  test("list with order sorts client-side (asc)", async () => {
+    const memories = [
+      { id: "a", agentId: "test", content: "first", type: "session", durability: "standard", tags: [], createdAt: "2026-01-01T00:00:00Z" },
+      { id: "b", agentId: "test", content: "second", type: "session", durability: "standard", tags: [], createdAt: "2026-03-01T00:00:00Z" },
+      { id: "c", agentId: "test", content: "third", type: "session", durability: "standard", tags: [], createdAt: "2026-02-01T00:00:00Z" },
+    ];
+    mockFetch = mock(() => Promise.resolve(new Response(JSON.stringify(memories), { status: 200 })));
+    globalThis.fetch = mockFetch as any;
+
+    const client = new FlairClient({ agentId: "test" });
+    const result = await client.memory.list({ order: "createdAt-asc" });
+
+    expect(result[0].id).toBe("a");
+    expect(result[1].id).toBe("c");
+    expect(result[2].id).toBe("b");
+  });
+
+  test("list with order sorts client-side (desc)", async () => {
+    const memories = [
+      { id: "a", agentId: "test", content: "first", type: "session", durability: "standard", tags: [], createdAt: "2026-01-01T00:00:00Z" },
+      { id: "b", agentId: "test", content: "second", type: "session", durability: "standard", tags: [], createdAt: "2026-03-01T00:00:00Z" },
+    ];
+    mockFetch = mock(() => Promise.resolve(new Response(JSON.stringify(memories), { status: 200 })));
+    globalThis.fetch = mockFetch as any;
+
+    const client = new FlairClient({ agentId: "test" });
+    const result = await client.memory.list({ order: "createdAt-desc" });
+
+    expect(result[0].id).toBe("b");
+    expect(result[1].id).toBe("a");
+  });
+
+  test("list handles { results: [...] } response shape", async () => {
+    const results = {
+      results: [
+        { id: "m1", agentId: "test", content: "x", type: "session", durability: "standard", tags: [], createdAt: "2026-01-01T00:00:00Z" },
+      ],
+    };
+    mockFetch = mock(() => Promise.resolve(new Response(JSON.stringify(results), { status: 200 })));
+    globalThis.fetch = mockFetch as any;
+
+    const client = new FlairClient({ agentId: "test" });
+    const result = await client.memory.list();
+
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe("m1");
+  });
+
+  test("list combines all filters in one conditions array", async () => {
+    mockFetch = mock(() => Promise.resolve(new Response("[]", { status: 200 })));
+    globalThis.fetch = mockFetch as any;
+
+    const client = new FlairClient({ agentId: "test" });
+    await client.memory.list({
+      limit: 10,
+      type: "lesson",
+      durability: "persistent",
+      subject: "chat:abc",
+      tags: ["important", "urgent"],
+    });
+
+    const body = JSON.parse((mockFetch as any).mock.calls[0][1].body);
+    expect(body.limit).toBe(10);
+    expect(body.conditions).toEqual([
+      { search_attribute: "agentId", search_type: "equals", search_value: "test" },
+      { search_attribute: "subject", search_type: "equals", search_value: "chat:abc" },
+      { search_attribute: "tags", search_type: "contains", search_value: "important" },
+      { search_attribute: "tags", search_type: "contains", search_value: "urgent" },
+      { search_attribute: "type", search_type: "equals", search_value: "lesson" },
+      { search_attribute: "durability", search_type: "equals", search_value: "persistent" },
+    ]);
+  });
+
+  test("list with empty tags array produces no tag conditions", async () => {
+    mockFetch = mock(() => Promise.resolve(new Response("[]", { status: 200 })));
+    globalThis.fetch = mockFetch as any;
+
+    const client = new FlairClient({ agentId: "test" });
+    await client.memory.list({ tags: [] });
+
+    const body = JSON.parse((mockFetch as any).mock.calls[0][1].body);
+    expect(body.conditions).toEqual([
+      { search_attribute: "agentId", search_type: "equals", search_value: "test" },
+    ]);
   });
 
 });

--- a/resources/Memory.ts
+++ b/resources/Memory.ts
@@ -45,27 +45,17 @@ export class Memory extends (databases as any).flair.Memory {
       ? { attribute: "agentId", comparator: "equals", value: allowedOwners[0] }
       : { conditions: allowedOwners.map(id => ({ attribute: "agentId", comparator: "equals", value: id })), operator: "or" };
 
-    // Harper passes `query` as a RequestTarget (extends URLSearchParams). Table.search()
-    // reads `target.conditions`; when that is unset, it iterates URLSearchParams entries
-    // as conditions instead. We inject our scope condition into `.conditions`, which
-    // means URL params (except agentId, which we always enforce) must also be translated
-    // to conditions or they'll be silently dropped.
+    // Harper passes `query` as a RequestTarget (extends URLSearchParams) or a
+    // conditions array. For URL-based GET /Memory?... calls, URL params are no
+    // longer translated to conditions here — callers should use
+    // POST /Memory/search_by_conditions with an explicit conditions array.
+    // For programmatic calls with a conditions array, we wrap with the agentId scope.
     if (query && typeof query === "object" && !Array.isArray(query)) {
-      const existing: any[] = [];
       if (Array.isArray(query.conditions) && query.conditions.length > 0) {
-        existing.push(...query.conditions);
-      } else if (typeof (query as any).entries === "function") {
-        for (const [k, v] of (query as any).entries()) {
-          if (k === "agentId") continue;
-          // Skip function-call URL params (e.g. sort(createdAt), sort(createdAt,desc)).
-          // They have empty values and are already handled by Harper's parseQuery which
-          // populates query.sort/query.limit directly from the URL string.
-          if (/^sort\(/.test(k) || v === "") continue;
-          if (k === "tags") { existing.push({ attribute: k, comparator: "contains", value: v }); } else { existing.push({ attribute: k, comparator: "equals", value: v }); }
-        }
+        query.conditions = [agentIdCondition, ...query.conditions];
+        return withDetachedTxn(ctx, () => super.search(query));
       }
-      query.conditions = [agentIdCondition, ...existing];
-      return withDetachedTxn(ctx, () => super.search(query));
+      // Fallback: no conditions array present — just scope and pass through
     }
 
     // Fallback: plain array or no query (internal calls)

--- a/test/data-scoping.test.ts
+++ b/test/data-scoping.test.ts
@@ -240,34 +240,10 @@ describe("Memory.search() / WorkspaceState.search() — collection scoping", () 
     expect(JSON.stringify(r.query.conditions)).toContain("attacker");
     expect(JSON.stringify(r.query.conditions)).not.toContain("starts_with");
   });
-  // ── URL param → conditions translation (mirrors Memory.search query iteration) ─
-  function paramsToConditions(entries: Iterable<[string, string]>): Array<{attribute: string; comparator: string; value: string}> {
-    const conditions: Array<{attribute: string; comparator: string; value: string}> = [];
-    for (const [k, v] of entries) {
-      if (k === "agentId") continue;
-      if (k === "tags") { conditions.push({ attribute: k, comparator: "contains", value: v }); }
-      else { conditions.push({ attribute: k, comparator: "equals", value: v }); }
-    }
-    return conditions;
-  }
 
-  it("uses contains comparator for tags, equals for other params", () => {
-    const entries: [string, string][] = [
-      ["type", "lesson"],
-      ["tags", "important"],
-      ["tags", "urgent"],
-      ["durability", "persistent"],
-      ["agentId", "should-be-skipped"],
-    ];
-    const conditions = paramsToConditions(entries);
-    expect(conditions).toEqual([
-      { attribute: "type", comparator: "equals", value: "lesson" },
-      { attribute: "tags", comparator: "contains", value: "important" },
-      { attribute: "tags", comparator: "contains", value: "urgent" },
-      { attribute: "durability", comparator: "equals", value: "persistent" },
-    ]);
-  });
-
+  // URL-param-to-conditions translation has been removed from Memory.search() in
+  // favor of search_by_conditions. The paramsToConditions helper and its test
+  // are no longer relevant.
 });
 
 describe("SQL/GraphQL endpoint blocking (non-admin)", () => {


### PR DESCRIPTION
## What changed

Refactored `flair-client` `MemoryApi.list()` and `resources/Memory.search()` to use Harper's `search_by_conditions` endpoint with an explicit conditions array, removing the URL-param-to-conditions translation layer.

### flair-client/src/client.ts
- `list()` now `POST /Memory/search_by_conditions` with JSON body containing `operator: "and"`, `conditions[]`, and `get_attributes: ["*"]`
- `agentId` is always the first condition (equals)
- `tags` use `search_type: "contains"` — one condition per tag
- `subject`, `type`, `durability` use `search_type: "equals"`
- `limit` placed in `body.limit` (was URL param)
- `order` now applied client-side after retrieval (search_by_conditions has no sort field)
- Handles both array and `{ results: [...] }` response shapes

### resources/Memory.ts
- Removed URLSearchParams iteration that translated query params to conditions
- Removed special-case handling for `tags` (contains), `sort()` (function-call skip), and empty-value params
- Now only wraps queries that have an existing `conditions` array with the agentId scope
- URL-based GET calls without explicit conditions fall through with agentId-only scoping (callers should use search_by_conditions for filtered queries)

### Tests
- 33 flair-client tests pass (rewritten for POST body assertions)
- 29 data-scoping tests pass (paramsToConditions helper and test removed)
- Full suite: 932 pass, 2 pre-existing playwright/bun failures (unrelated)

## Why

- URL-param translation was fragile and coupled to Harper's internal query parsing behavior
- `search_by_conditions` is the stable, explicit API for filtered memory queries
- Removes the `tags=contains` / `sort=function-call` / `v=="" skip` special cases from the Memory.search override
- Client-side sort is a minor trade-off; server-side sort was only available via URL syntax that search_by_conditions doesn't support

## Testing

```
bun test packages/flair-client/test/client.test.ts  # 33 pass
bun test test/data-scoping.test.ts                   # 29 pass
bun test                                              # 932 pass, 2 pre-existing failures
```