### PR TITLE
feat: add flair_pair_initiator role (Federation Pair Option B, PR-1)

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -753,6 +753,96 @@ export async function provisionFabric(
   }
 }
 
+// ─── flair_pair_initiator role ──────────────────────────────────────────────
+//
+// Hub instances need a `flair_pair_initiator` role so that bootstrap credentials
+// (created in PR-2) can pass platform auth on Harper Fabric before reaching the
+// FederationPair resource handler.  The role carries no table permissions itself
+// — the resource's own allowCreate bypass handles route-level access once the
+// request gets through the auth gate.
+
+/** Canonical permission spec for flair_pair_initiator. */
+const PAIR_INITIATOR_PERMISSION = {
+  super_user: false,
+  cluster_user: false,
+  structure_user: false,
+  flair: {
+    tables: {
+      Memory:       { read: false, insert: false, update: false, delete: false },
+      Soul:         { read: false, insert: false, update: false, delete: false },
+      Agent:        { read: false, insert: false, update: false, delete: false },
+      Workspace:    { read: false, insert: false, update: false, delete: false },
+      Event:        { read: false, insert: false, update: false, delete: false },
+      OAuth:        { read: false, insert: false, update: false, delete: false },
+      Instance:     { read: false, insert: false, update: false, delete: false },
+      Peer:         { read: false, insert: false, update: false, delete: false },
+      PairingToken: { read: false, insert: false, update: false, delete: false },
+      SyncLog:      { read: false, insert: false, update: false, delete: false },
+    },
+  },
+} as const;
+
+/**
+ * Idempotently ensures the `flair_pair_initiator` role exists on the Harper
+ * instance at `opsUrl` with the canonical permission spec.
+ *
+ * - If the role is absent → `add_role`
+ * - If it exists with different permissions → `alter_role` to bring it into spec
+ * - If it already matches → no-op
+ */
+export async function ensureFlairPairInitiatorRole(
+  opsUrl: string,
+  adminUser: string,
+  adminPass: string,
+): Promise<void> {
+  const ROLE_NAME = "flair_pair_initiator";
+
+  // 1. Check for existing role
+  let roles: any[] = [];
+  try {
+    const result = await callOpsApi(opsUrl, { operation: "list_roles" }, adminUser, adminPass);
+    roles = Array.isArray(result) ? result : [];
+  } catch (err: unknown) {
+    const msg = err instanceof Error ? err.message : String(err);
+    throw new Error(`ensureFlairPairInitiatorRole: list_roles failed: ${msg}`);
+  }
+
+  const existing = roles.find(
+    (r: any) => r.role === ROLE_NAME || r.name === ROLE_NAME,
+  );
+
+  if (!existing) {
+    // 2a. Role absent → create it
+    console.log(`Creating role '${ROLE_NAME}'...`);
+    await callOpsApi(opsUrl, {
+      operation: "add_role",
+      role: ROLE_NAME,
+      permission: PAIR_INITIATOR_PERMISSION,
+    }, adminUser, adminPass);
+    console.log(`Role '${ROLE_NAME}' created ✓`);
+    return;
+  }
+
+  // 2b. Role exists — check if permissions match the canonical spec
+  const existingPerm = existing.permission ?? existing.role?.permission;
+  const canonicalStr = JSON.stringify(PAIR_INITIATOR_PERMISSION);
+  const existingStr  = JSON.stringify(existingPerm);
+
+  if (existingStr === canonicalStr) {
+    console.log(`Role '${ROLE_NAME}' already exists with correct permissions — skipping`);
+    return;
+  }
+
+  // 2c. Permissions differ → bring into spec via alter_role
+  console.log(`Role '${ROLE_NAME}' exists but permissions differ — updating...`);
+  await callOpsApi(opsUrl, {
+    operation: "alter_role",
+    role: ROLE_NAME,
+    permission: PAIR_INITIATOR_PERMISSION,
+  }, adminUser, adminPass);
+  console.log(`Role '${ROLE_NAME}' updated ✓`);
+}
+
 // ─── Upgrade presence probes ──────────────────────────────────────────────────
 //
 // `flair upgrade` previously called `npm list -g <pkg>` to detect the installed
@@ -1070,6 +1160,13 @@ program
         // Atomic provisioning: deploy + wait + provision user
         await provisionFabric(baseUrl, opsUrl, clusterAdminUser, clusterAdminPass, flairAdminPass);
         didProvision = true;
+
+        // Hub instances (--remote) receive federation pair requests and need
+        // the flair_pair_initiator role so bootstrap credentials can pass
+        // platform auth before reaching the FederationPair resource handler.
+        if (opts.remote) {
+          await ensureFlairPairInitiatorRole(opsUrl, DEFAULT_ADMIN_USER, flairAdminPass);
+        }
       } else {
         // ── Existing behavior: --admin-pass required for already-running Flair ──
         if (!opts.adminPass) {

--- a/test/unit/federation-pair-role.test.ts
+++ b/test/unit/federation-pair-role.test.ts
@@ -1,0 +1,161 @@
+import { describe, it, expect, mock, beforeEach } from "bun:test";
+import { ensureFlairPairInitiatorRole } from "../../src/cli";
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+/** Minimal canonical permission spec mirrored from cli.ts. */
+const CANONICAL_PERM = {
+  super_user: false,
+  cluster_user: false,
+  structure_user: false,
+  flair: {
+    tables: {
+      Memory:       { read: false, insert: false, update: false, delete: false },
+      Soul:         { read: false, insert: false, update: false, delete: false },
+      Agent:        { read: false, insert: false, update: false, delete: false },
+      Workspace:    { read: false, insert: false, update: false, delete: false },
+      Event:        { read: false, insert: false, update: false, delete: false },
+      OAuth:        { read: false, insert: false, update: false, delete: false },
+      Instance:     { read: false, insert: false, update: false, delete: false },
+      Peer:         { read: false, insert: false, update: false, delete: false },
+      PairingToken: { read: false, insert: false, update: false, delete: false },
+      SyncLog:      { read: false, insert: false, update: false, delete: false },
+    },
+  },
+};
+
+/** Builds a mock ops-API fetch that returns sequenced responses. */
+function buildMockFetch(responses: Array<{ ok: boolean; body: unknown }>) {
+  let idx = 0;
+  return mock(async (_url: string, init?: RequestInit) => {
+    const resp = responses[idx++];
+    if (!resp) throw new Error(`Unexpected fetch call at index ${idx - 1}`);
+    return {
+      ok: resp.ok,
+      status: resp.ok ? 200 : 500,
+      json: async () => resp.body,
+      text: async () => JSON.stringify(resp.body),
+    } as unknown as Response;
+  });
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe("ensureFlairPairInitiatorRole", () => {
+  const OPS_URL   = "http://localhost:9925";
+  const ADMIN     = "admin";
+  const PASS      = "secret";
+  const ROLE_NAME = "flair_pair_initiator";
+
+  // Track which operations were sent to the mock ops API
+  let capturedBodies: Array<Record<string, unknown>> = [];
+
+  beforeEach(() => {
+    capturedBodies = [];
+  });
+
+  /**
+   * Install a global fetch mock that captures request bodies and returns the
+   * provided sequenced responses.
+   */
+  function installFetch(responses: Array<{ ok: boolean; body: unknown }>) {
+    let idx = 0;
+    globalThis.fetch = mock(async (_url: string, init?: RequestInit) => {
+      const body = init?.body ? JSON.parse(init.body as string) : {};
+      capturedBodies.push(body);
+      const resp = responses[idx++];
+      if (!resp) throw new Error(`Unexpected fetch call #${idx}`);
+      return {
+        ok: resp.ok,
+        status: resp.ok ? 200 : 500,
+        json: async () => resp.body,
+        text: async () => JSON.stringify(resp.body),
+      } as unknown as Response;
+    }) as any;
+  }
+
+  it("calls add_role when flair_pair_initiator does not exist", async () => {
+    installFetch([
+      // list_roles → empty list
+      { ok: true, body: [] },
+      // add_role → success
+      { ok: true, body: { ok: true } },
+    ]);
+
+    await ensureFlairPairInitiatorRole(OPS_URL, ADMIN, PASS);
+
+    expect(capturedBodies).toHaveLength(2);
+    expect(capturedBodies[0].operation).toBe("list_roles");
+    expect(capturedBodies[1].operation).toBe("add_role");
+    expect(capturedBodies[1].role).toBe(ROLE_NAME);
+    expect(capturedBodies[1].permission).toEqual(CANONICAL_PERM);
+  });
+
+  it("is a no-op when role already exists with matching permissions", async () => {
+    installFetch([
+      // list_roles → role present with canonical perms
+      {
+        ok: true,
+        body: [{ role: ROLE_NAME, permission: CANONICAL_PERM }],
+      },
+      // No further calls expected
+    ]);
+
+    await ensureFlairPairInitiatorRole(OPS_URL, ADMIN, PASS);
+
+    // Only list_roles should have been called
+    expect(capturedBodies).toHaveLength(1);
+    expect(capturedBodies[0].operation).toBe("list_roles");
+  });
+
+  it("calls alter_role when role exists with different permissions", async () => {
+    const differentPerm = {
+      ...CANONICAL_PERM,
+      super_user: true, // deliberately different
+    };
+
+    installFetch([
+      // list_roles → role present but with wrong perms
+      {
+        ok: true,
+        body: [{ role: ROLE_NAME, permission: differentPerm }],
+      },
+      // alter_role → success
+      { ok: true, body: { ok: true } },
+    ]);
+
+    await ensureFlairPairInitiatorRole(OPS_URL, ADMIN, PASS);
+
+    expect(capturedBodies).toHaveLength(2);
+    expect(capturedBodies[0].operation).toBe("list_roles");
+    expect(capturedBodies[1].operation).toBe("alter_role");
+    expect(capturedBodies[1].role).toBe(ROLE_NAME);
+    expect(capturedBodies[1].permission).toEqual(CANONICAL_PERM);
+  });
+
+  it("also handles role objects that use 'name' instead of 'role' key", async () => {
+    // Some Harper versions return { name: "...", permission: {} }
+    installFetch([
+      {
+        ok: true,
+        body: [{ name: ROLE_NAME, permission: CANONICAL_PERM }],
+      },
+    ]);
+
+    await ensureFlairPairInitiatorRole(OPS_URL, ADMIN, PASS);
+
+    // Match found → no-op (only list_roles call)
+    expect(capturedBodies).toHaveLength(1);
+    expect(capturedBodies[0].operation).toBe("list_roles");
+  });
+
+  it("throws a descriptive error when list_roles fails", async () => {
+    installFetch([
+      { ok: false, body: { error: "unauthorized" } },
+    ]);
+
+    await expect(
+      ensureFlairPairInitiatorRole(OPS_URL, ADMIN, PASS),
+    ).rejects.toThrow("list_roles failed");
+  });
+});


### PR DESCRIPTION
## Summary

Adds the `flair_pair_initiator` Harper role needed for the Option B federation pair handshake. This is the smallest first slice — role definition + idempotent boot-time ensure only. No CLI/resource changes in this PR.

## Why

Federation pair handshake fails on Harper Fabric because the platform auth gate fires _before_ the FederationPair Resource handler reaches `allowCreate`. Option B makes pairing auth-aware: hub generates short-TTL bootstrap creds + pairing token; spoke uses Basic auth with bootstrap creds + sends `pairingToken` in body. **PR-1** adds the role that bootstrap credentials (PR-2) will hold.

The role carries no table permissions — all flags are `false`. Its sole job is to let a request reach the FederationPair resource handler, which self-permits via the existing `allowCreate` bypass in `resources/Federation.ts`.

## What changed

### `src/cli.ts`

- **`PAIR_INITIATOR_PERMISSION`** — canonical (all-false) permission const
- **`ensureFlairPairInitiatorRole(opsUrl, adminUser, adminPass)`** — exported, idempotent:
  - `list_roles` → absent → `add_role`
  - present + same perms → no-op
  - present + different perms → `alter_role`
- Wired into `flair init` hub path (`--remote` flag) after `provisionFabric()`

### `test/unit/federation-pair-role.test.ts` (new)

5 unit tests covering all three idempotency paths, the `name`-key variant, and a `list_roles` failure case. All mocked; no live Harper required.

## Out of scope

- Bootstrap user creation → PR-2
- CLI rework of `flair federation token` / `flair federation pair` → PR-2/PR-3
- Server-side Basic auth handshake → PR-4
- Cleanup cron → PR-5
- Docs → PR-6

## Test results

```
5 pass, 0 fail (federation-pair-role.test.ts)
653 pass, 1 fail total (pre-existing Ed25519 local auth test, unrelated)
```