### PR TITLE
feat: bootstrap user lifecycle + auth-middleware extension (Federation Pair Option B, PR-2)

### DIFF
--- a/resources/Federation.ts
+++ b/resources/Federation.ts
@@ -228,6 +228,30 @@ export class FederationPair extends Resource {
         createdAt: new Date().toISOString(),
         updatedAt: new Date().toISOString(),
       });
+
+      // Drop the bootstrap user that was created alongside this pairing token.
+      // Failure here is non-fatal: a cleanup cron (PR-5) will catch stragglers.
+      try {
+        const bootstrapUsername = `pair-bootstrap-${pairingToken.slice(0, 8)}`;
+        const opsPort = process.env.FLAIR_OPS_PORT
+          ? Number(process.env.FLAIR_OPS_PORT)
+          : (process.env.FLAIR_PORT ? Number(process.env.FLAIR_PORT) - 1 : 19925);
+        const opsUrl = `http://127.0.0.1:${opsPort}/`;
+        const adminPass = process.env.HDB_ADMIN_PASSWORD ?? process.env.FLAIR_ADMIN_PASSWORD ?? "";
+        const auth = `Basic ${Buffer.from(`admin:${adminPass}`).toString("base64")}`;
+        const dropRes = await fetch(opsUrl, {
+          method: "POST",
+          headers: { "Content-Type": "application/json", Authorization: auth },
+          body: JSON.stringify({ operation: "drop_user", username: bootstrapUsername }),
+          signal: AbortSignal.timeout(10_000),
+        });
+        if (!dropRes.ok) {
+          const detail = await dropRes.text().catch(() => "");
+          console.warn(`[federation] drop_user ${bootstrapUsername} failed (${dropRes.status}): ${detail} — cleanup cron will retry`);
+        }
+      } catch (err: any) {
+        console.warn(`[federation] drop_user failed (network): ${err?.message} — cleanup cron will retry`);
+      }
     }
 
     // Return our own identity for the peer to record

--- a/resources/auth-middleware.ts
+++ b/resources/auth-middleware.ts
@@ -202,6 +202,29 @@ server.http(async (request: any, nextLayer: any) => {
         request.tpsAgentIsAdmin = true;
         return nextLayer(request);
       }
+
+      // Path 3: flair_pair_initiator — restricted to /FederationPair only.
+      // Bootstrap credentials (pair-bootstrap-<id>) may only be used on this
+      // one endpoint. Any other path must fall through to 401.
+      if (url.pathname === "/FederationPair" && user.startsWith("pair-bootstrap-")) {
+        let pairUser: any = null;
+        try {
+          pairUser = await (server as any).getUser(user, pass, request);
+        } catch { /* fall through */ }
+
+        if (
+          pairUser?.role === "flair_pair_initiator" &&
+          pairUser?.active === true
+        ) {
+          (request as any)._tpsAuthVerified = true;
+          request.user = pairUser;
+          request.headers.set("x-tps-agent", user);
+          if (request.headers.asObject) (request.headers.asObject as any)["x-tps-agent"] = user;
+          request.tpsAgent = user;
+          request.tpsAgentIsAdmin = false;
+          return nextLayer(request);
+        }
+      }
     } catch { /* fall through to Ed25519 check */ }
     return new Response(JSON.stringify({ error: "invalid_admin_credentials" }), { status: 401 });
   }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -3101,11 +3101,11 @@ federation
   .option("--ttl <minutes>", "Token TTL in minutes (default: 60)", "60")
   .option("--target <url>", "Remote Flair URL (env: FLAIR_TARGET)")
   .option("--ops-target <url>", "Explicit ops API URL (env: FLAIR_OPS_TARGET; bypasses port derivation)")
+  .option("--format <format>", "Output format: json (default) or text (bare token, deprecated)", "json")
   .action(async (opts) => {
     const target = resolveTarget(opts);
     const baseUrl = target ? target.replace(/\/$/, "") : undefined;
     try {
-      const { randomBytes } = await import("node:crypto");
       const token = randomBytes(24).toString("base64url");
       const ttlMinutes = parseInt(opts.ttl, 10) || 60;
       const expiresAt = new Date(Date.now() + ttlMinutes * 60 * 1000).toISOString();
@@ -3114,6 +3114,7 @@ federation
       const adminPass: string = opts.adminPass ?? process.env.FLAIR_ADMIN_PASS ?? "";
       const auth = `Basic ${Buffer.from(`${DEFAULT_ADMIN_USER}:${adminPass}`).toString("base64")}`;
 
+      // 1. Persist the PairingToken record
       const opsRes = await fetch(`${opsEndpoint}/`, {
         method: "POST",
         headers: { "Content-Type": "application/json", Authorization: auth },
@@ -3132,10 +3133,65 @@ federation
         throw new Error(`Failed to persist pairing token (${opsRes.status}): ${detail || "no body"}`);
       }
 
-      console.log(`Pairing token (expires in ${ttlMinutes}m):`);
-      console.log(`  ${token}`);
-      console.log(`\nGive this to the spoke admin to run:`);
-      console.log(`  flair federation pair <this-hub-url> --token ${token}`);
+      // 2. Create bootstrap user for this token
+      const bootstrapPassword = randomBytes(32).toString("base64url");
+      const bootstrapUsername = `pair-bootstrap-${token.slice(0, 8)}`;
+
+      let addUserRes: Response;
+      try {
+        addUserRes = await fetch(`${opsEndpoint}/`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json", Authorization: auth },
+          body: JSON.stringify({
+            operation: "add_user",
+            username: bootstrapUsername,
+            password: bootstrapPassword,
+            role: "flair_pair_initiator",
+            active: true,
+          }),
+          signal: AbortSignal.timeout(10_000),
+        });
+      } catch (err: any) {
+        // Network failure creating bootstrap user — roll back PairingToken
+        await fetch(`${opsEndpoint}/`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json", Authorization: auth },
+          body: JSON.stringify({
+            operation: "delete",
+            database: "flair",
+            table: "PairingToken",
+            hash_value: token,
+          }),
+          signal: AbortSignal.timeout(10_000),
+        }).catch(() => {});
+        throw new Error(`Failed to create bootstrap user (network): ${err.message}`);
+      }
+
+      if (!addUserRes.ok) {
+        // add_user failed — roll back PairingToken so the two stay in sync
+        await fetch(`${opsEndpoint}/`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json", Authorization: auth },
+          body: JSON.stringify({
+            operation: "delete",
+            database: "flair",
+            table: "PairingToken",
+            hash_value: token,
+          }),
+          signal: AbortSignal.timeout(10_000),
+        }).catch(() => {});
+        const detail = await addUserRes.text().catch(() => "");
+        throw new Error(`Failed to create bootstrap user (${addUserRes.status}): ${detail || "no body"}`);
+      }
+
+      // 3. Output
+      const format = (opts.format ?? "json").toLowerCase();
+      if (format === "text") {
+        process.stderr.write(`[DEPRECATION] --format text is deprecated. Default output is now JSON.\n`);
+        console.log(token);
+      } else {
+        console.log(JSON.stringify({ token, user: bootstrapUsername, password: bootstrapPassword, expiresAt }, null, 2));
+      }
     } catch (err: any) {
       console.error(`Error: ${err.message}`);
       process.exit(1);

--- a/test/unit/auth-middleware.test.ts
+++ b/test/unit/auth-middleware.test.ts
@@ -278,6 +278,137 @@ describe("auth header edge cases", () => {
   });
 });
 
+// ─── Basic auth: flair_pair_initiator support (PR-2) ────────────────────────
+
+describe("flair_pair_initiator Basic auth", () => {
+  /**
+   * Simulate the Path 3 branch of the auth middleware.
+   * Returns the "accept" / "reject" decision given the incoming request details.
+   */
+  function simulateAuthMiddleware(opts: {
+    pathname: string;
+    username: string;
+    password: string;
+    harperUser: any;
+  }): "accepted" | "rejected" {
+    const { pathname, username, password, harperUser } = opts;
+
+    // Simulate: Path 1 (admin fast-path) — not applicable for pair-bootstrap-* users
+    // Simulate: Path 2 (super_user) — pair-bootstrap users are not super_user
+    const isSuperUser = harperUser?.role?.permission?.super_user === true;
+    if (isSuperUser) return "accepted";
+
+    // Path 3: flair_pair_initiator — restricted to /FederationPair only
+    if (pathname === "/FederationPair" && username.startsWith("pair-bootstrap-")) {
+      // getUser succeeded and returned a flair_pair_initiator record
+      if (
+        harperUser?.role === "flair_pair_initiator" &&
+        harperUser?.active === true
+      ) {
+        return "accepted";
+      }
+    }
+
+    // Fall through → 401
+    return "rejected";
+  }
+
+  const PAIR_USER: any = {
+    role: "flair_pair_initiator",
+    active: true,
+  };
+
+  test("flair_pair_initiator Basic auth on /FederationPair → accepted", () => {
+    const result = simulateAuthMiddleware({
+      pathname: "/FederationPair",
+      username: "pair-bootstrap-abcd1234",
+      password: "correct-password",
+      harperUser: PAIR_USER,
+    });
+    expect(result).toBe("accepted");
+  });
+
+  test("flair_pair_initiator Basic auth on /Memory → 401", () => {
+    const result = simulateAuthMiddleware({
+      pathname: "/Memory",
+      username: "pair-bootstrap-abcd1234",
+      password: "correct-password",
+      harperUser: PAIR_USER,
+    });
+    expect(result).toBe("rejected");
+  });
+
+  test("flair_pair_initiator Basic auth on /Soul → 401", () => {
+    const result = simulateAuthMiddleware({
+      pathname: "/Soul",
+      username: "pair-bootstrap-abcd1234",
+      password: "correct-password",
+      harperUser: PAIR_USER,
+    });
+    expect(result).toBe("rejected");
+  });
+
+  test("wrong password → 401 (getUser returns null)", () => {
+    // When password is wrong, getUser would return null or throw
+    const result = simulateAuthMiddleware({
+      pathname: "/FederationPair",
+      username: "pair-bootstrap-abcd1234",
+      password: "wrong-password",
+      harperUser: null, // getUser returns null for bad creds
+    });
+    expect(result).toBe("rejected");
+  });
+
+  test("disabled (active=false) user → 401", () => {
+    const disabledUser = { role: "flair_pair_initiator", active: false };
+    const result = simulateAuthMiddleware({
+      pathname: "/FederationPair",
+      username: "pair-bootstrap-abcd1234",
+      password: "correct-password",
+      harperUser: disabledUser,
+    });
+    expect(result).toBe("rejected");
+  });
+
+  test("username not starting with pair-bootstrap- → falls through to 401 on /FederationPair", () => {
+    // Non-bootstrap username never hits Path 3
+    const result = simulateAuthMiddleware({
+      pathname: "/FederationPair",
+      username: "regular-user",
+      password: "correct-password",
+      harperUser: PAIR_USER, // even if user record matched, prefix check prevents acceptance
+    });
+    expect(result).toBe("rejected");
+  });
+
+  test("path-restriction: pair-bootstrap user cannot access /Agent", () => {
+    const result = simulateAuthMiddleware({
+      pathname: "/Agent",
+      username: "pair-bootstrap-abcd1234",
+      password: "correct-password",
+      harperUser: PAIR_USER,
+    });
+    expect(result).toBe("rejected");
+  });
+
+  test("path-restriction: pair-bootstrap user cannot access /FederationSync", () => {
+    const result = simulateAuthMiddleware({
+      pathname: "/FederationSync",
+      username: "pair-bootstrap-abcd1234",
+      password: "correct-password",
+      harperUser: PAIR_USER,
+    });
+    expect(result).toBe("rejected");
+  });
+
+  test("pair-bootstrap username format: starts with pair-bootstrap-", () => {
+    const tokenId = "abcdefgh123456"; // 14 chars, first 8 are used
+    const username = `pair-bootstrap-${tokenId.slice(0, 8)}`;
+    expect(username).toBe("pair-bootstrap-abcdefgh");
+    expect(username.startsWith("pair-bootstrap-")).toBe(true);
+  });
+});
+
 // ─── Basic auth: super_user support (ops-lzmg) ───────────────────────────────
 
 describe("Basic auth super_user path", () => {

--- a/test/unit/federation-bootstrap-user.test.ts
+++ b/test/unit/federation-bootstrap-user.test.ts
@@ -1,0 +1,348 @@
+import { describe, it, expect, mock, beforeEach } from "bun:test";
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+/**
+ * Minimal mock of the `flair federation token` action logic.
+ * Returns what the CLI action would emit / throw, without actually running CLI.
+ */
+async function runTokenGeneration(opts: {
+  opsEndpoint: string;
+  adminPass: string;
+  fetchImpl: typeof fetch;
+}): Promise<{ token: string; user: string; password: string; expiresAt: string }> {
+  const { opsEndpoint, adminPass, fetchImpl } = opts;
+  const { randomBytes } = await import("node:crypto");
+
+  const token = randomBytes(24).toString("base64url");
+  const ttlMinutes = 60;
+  const expiresAt = new Date(Date.now() + ttlMinutes * 60 * 1000).toISOString();
+  const auth = `Basic ${Buffer.from(`admin:${adminPass}`).toString("base64")}`;
+
+  // Step 1: Persist PairingToken
+  const opsRes = await fetchImpl(`${opsEndpoint}/`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json", Authorization: auth },
+    body: JSON.stringify({
+      operation: "upsert",
+      database: "flair",
+      table: "PairingToken",
+      records: [{ id: token, createdAt: new Date().toISOString(), expiresAt }],
+    }),
+    signal: AbortSignal.timeout(10_000),
+  });
+  if (!opsRes.ok) {
+    const detail = await opsRes.text().catch(() => "");
+    throw new Error(`Failed to persist pairing token (${opsRes.status}): ${detail || "no body"}`);
+  }
+
+  // Step 2: Create bootstrap user
+  const bootstrapPassword = randomBytes(32).toString("base64url");
+  const bootstrapUsername = `pair-bootstrap-${token.slice(0, 8)}`;
+
+  let addUserRes: Response;
+  try {
+    addUserRes = await fetchImpl(`${opsEndpoint}/`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Authorization: auth },
+      body: JSON.stringify({
+        operation: "add_user",
+        username: bootstrapUsername,
+        password: bootstrapPassword,
+        role: "flair_pair_initiator",
+        active: true,
+      }),
+      signal: AbortSignal.timeout(10_000),
+    });
+  } catch (err: any) {
+    // Roll back PairingToken
+    await fetchImpl(`${opsEndpoint}/`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Authorization: auth },
+      body: JSON.stringify({
+        operation: "delete",
+        database: "flair",
+        table: "PairingToken",
+        hash_value: token,
+      }),
+      signal: AbortSignal.timeout(10_000),
+    }).catch(() => {});
+    throw new Error(`Failed to create bootstrap user (network): ${err.message}`);
+  }
+
+  if (!addUserRes.ok) {
+    // Roll back PairingToken
+    await fetchImpl(`${opsEndpoint}/`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Authorization: auth },
+      body: JSON.stringify({
+        operation: "delete",
+        database: "flair",
+        table: "PairingToken",
+        hash_value: token,
+      }),
+      signal: AbortSignal.timeout(10_000),
+    }).catch(() => {});
+    const detail = await addUserRes.text().catch(() => "");
+    throw new Error(`Failed to create bootstrap user (${addUserRes.status}): ${detail || "no body"}`);
+  }
+
+  return { token, user: bootstrapUsername, password: bootstrapPassword, expiresAt };
+}
+
+/**
+ * Minimal mock of the FederationPair.post drop_user logic on successful pair.
+ */
+async function runPairSuccessDropUser(opts: {
+  pairingToken: string;
+  opsUrl: string;
+  adminPass: string;
+  fetchImpl: typeof fetch;
+}): Promise<{ dropped: boolean; warned: boolean }> {
+  const { pairingToken, opsUrl, adminPass, fetchImpl } = opts;
+  let dropped = false;
+  let warned = false;
+
+  try {
+    const bootstrapUsername = `pair-bootstrap-${pairingToken.slice(0, 8)}`;
+    const auth = `Basic ${Buffer.from(`admin:${adminPass}`).toString("base64")}`;
+    const dropRes = await fetchImpl(`${opsUrl}/`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Authorization: auth },
+      body: JSON.stringify({ operation: "drop_user", username: bootstrapUsername }),
+      signal: AbortSignal.timeout(10_000),
+    });
+    if (!dropRes.ok) {
+      warned = true;
+    } else {
+      dropped = true;
+    }
+  } catch {
+    warned = true;
+  }
+
+  return { dropped, warned };
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe("federation bootstrap user lifecycle", () => {
+  const OPS_URL = "http://localhost:19925";
+  const ADMIN_PASS = "secret";
+
+  let capturedBodies: Array<Record<string, unknown>> = [];
+
+  beforeEach(() => {
+    capturedBodies = [];
+  });
+
+  function makeFetch(responses: Array<{ ok: boolean; status?: number; body: unknown }>) {
+    let idx = 0;
+    return mock(async (_url: string, init?: RequestInit) => {
+      const body = init?.body ? JSON.parse(init.body as string) : {};
+      capturedBodies.push(body);
+      const resp = responses[idx++];
+      if (!resp) throw new Error(`Unexpected fetch call #${idx}`);
+      return {
+        ok: resp.ok,
+        status: resp.status ?? (resp.ok ? 200 : 500),
+        json: async () => resp.body,
+        text: async () => JSON.stringify(resp.body),
+      } as unknown as Response;
+    });
+  }
+
+  // ── Token generation ─────────────────────────────────────────────────────
+
+  it("token-gen: creates bootstrap user with role flair_pair_initiator and active=true", async () => {
+    const mockFetch = makeFetch([
+      { ok: true, body: { ok: true } },  // upsert PairingToken
+      { ok: true, body: { ok: true } },  // add_user
+    ]);
+
+    const result = await runTokenGeneration({
+      opsEndpoint: OPS_URL,
+      adminPass: ADMIN_PASS,
+      fetchImpl: mockFetch as any,
+    });
+
+    expect(capturedBodies).toHaveLength(2);
+
+    // First call: PairingToken upsert
+    expect(capturedBodies[0].operation).toBe("upsert");
+    expect(capturedBodies[0].table).toBe("PairingToken");
+
+    // Second call: add_user
+    const addUserCall = capturedBodies[1];
+    expect(addUserCall.operation).toBe("add_user");
+    expect(typeof addUserCall.username).toBe("string");
+    expect((addUserCall.username as string).startsWith("pair-bootstrap-")).toBe(true);
+    expect(addUserCall.role).toBe("flair_pair_initiator");
+    expect(addUserCall.active).toBe(true);
+    expect(typeof addUserCall.password).toBe("string");
+    // Password should never be the token itself
+    expect(addUserCall.password).not.toBe(result.token);
+
+    // Returned triple
+    expect(result.user).toBe(addUserCall.username);
+    expect(typeof result.password).toBe("string");
+    expect(result.password.length).toBeGreaterThan(0);
+    expect(typeof result.expiresAt).toBe("string");
+  });
+
+  it("token-gen: rolls back PairingToken if add_user fails (HTTP error)", async () => {
+    const mockFetch = makeFetch([
+      { ok: true, body: { ok: true } },         // upsert PairingToken — succeeds
+      { ok: false, status: 500, body: { error: "add_user failed" } },  // add_user — fails
+      { ok: true, body: { ok: true } },         // delete PairingToken (rollback)
+    ]);
+
+    await expect(
+      runTokenGeneration({
+        opsEndpoint: OPS_URL,
+        adminPass: ADMIN_PASS,
+        fetchImpl: mockFetch as any,
+      }),
+    ).rejects.toThrow("Failed to create bootstrap user");
+
+    // Rollback call should have been made
+    expect(capturedBodies).toHaveLength(3);
+    const rollbackCall = capturedBodies[2];
+    expect(rollbackCall.operation).toBe("delete");
+    expect(rollbackCall.table).toBe("PairingToken");
+  });
+
+  it("token-gen: rolls back PairingToken if add_user fails (network error)", async () => {
+    let idx = 0;
+    let capturedLocal: Array<Record<string, unknown>> = [];
+
+    const mockFetch = mock(async (_url: string, init?: RequestInit) => {
+      const body = init?.body ? JSON.parse(init.body as string) : {};
+      capturedLocal.push(body);
+      capturedBodies.push(body);
+      idx++;
+
+      if (idx === 1) {
+        // upsert PairingToken — succeeds
+        return {
+          ok: true, status: 200,
+          json: async () => ({ ok: true }),
+          text: async () => JSON.stringify({ ok: true }),
+        } as unknown as Response;
+      } else if (idx === 2) {
+        // add_user — network error
+        throw new Error("ECONNREFUSED");
+      } else {
+        // rollback delete — succeeds
+        return {
+          ok: true, status: 200,
+          json: async () => ({ ok: true }),
+          text: async () => JSON.stringify({ ok: true }),
+        } as unknown as Response;
+      }
+    });
+
+    await expect(
+      runTokenGeneration({
+        opsEndpoint: OPS_URL,
+        adminPass: ADMIN_PASS,
+        fetchImpl: mockFetch as any,
+      }),
+    ).rejects.toThrow("Failed to create bootstrap user (network)");
+
+    expect(capturedLocal).toHaveLength(3);
+    expect(capturedLocal[2].operation).toBe("delete");
+    expect(capturedLocal[2].table).toBe("PairingToken");
+  });
+
+  it("token-gen: username format is pair-bootstrap-<first8charsOfToken>", async () => {
+    const mockFetch = makeFetch([
+      { ok: true, body: { ok: true } },
+      { ok: true, body: { ok: true } },
+    ]);
+
+    const result = await runTokenGeneration({
+      opsEndpoint: OPS_URL,
+      adminPass: ADMIN_PASS,
+      fetchImpl: mockFetch as any,
+    });
+
+    expect(result.user).toBe(`pair-bootstrap-${result.token.slice(0, 8)}`);
+  });
+
+  // ── Pair success → drop bootstrap user ───────────────────────────────────
+
+  it("pair-success: drops bootstrap user after successful Peer.put", async () => {
+    const mockFetch = makeFetch([
+      { ok: true, body: { ok: true } },  // drop_user succeeds
+    ]);
+
+    const pairingToken = "xY3kP9abQw8mNrTv"; // 16+ chars
+    const result = await runPairSuccessDropUser({
+      pairingToken,
+      opsUrl: OPS_URL,
+      adminPass: ADMIN_PASS,
+      fetchImpl: mockFetch as any,
+    });
+
+    expect(result.dropped).toBe(true);
+    expect(result.warned).toBe(false);
+
+    // Check drop_user call
+    expect(capturedBodies).toHaveLength(1);
+    const dropCall = capturedBodies[0];
+    expect(dropCall.operation).toBe("drop_user");
+    expect(dropCall.username).toBe(`pair-bootstrap-${pairingToken.slice(0, 8)}`);
+  });
+
+  it("pair-success: does NOT fail response if drop_user fails (HTTP error)", async () => {
+    const mockFetch = makeFetch([
+      { ok: false, status: 500, body: { error: "drop failed" } },  // drop_user fails
+    ]);
+
+    const pairingToken = "tokenABCDxyz12345";
+    const result = await runPairSuccessDropUser({
+      pairingToken,
+      opsUrl: OPS_URL,
+      adminPass: ADMIN_PASS,
+      fetchImpl: mockFetch as any,
+    });
+
+    // Pair response should succeed even if drop_user fails
+    expect(result.dropped).toBe(false);
+    expect(result.warned).toBe(true);  // logged a warning
+  });
+
+  it("pair-success: does NOT fail response if drop_user throws (network error)", async () => {
+    const mockFetch = mock(async () => {
+      throw new Error("ECONNREFUSED");
+    });
+
+    const pairingToken = "tokenNETWORK12345";
+    const result = await runPairSuccessDropUser({
+      pairingToken,
+      opsUrl: OPS_URL,
+      adminPass: ADMIN_PASS,
+      fetchImpl: mockFetch as any,
+    });
+
+    expect(result.dropped).toBe(false);
+    expect(result.warned).toBe(true);
+  });
+
+  it("pair-success: uses correct username format (pair-bootstrap-<first8>)", async () => {
+    const mockFetch = makeFetch([
+      { ok: true, body: { ok: true } },
+    ]);
+
+    const pairingToken = "longTokenWith8CharsPrefix_extra";
+    await runPairSuccessDropUser({
+      pairingToken,
+      opsUrl: OPS_URL,
+      adminPass: ADMIN_PASS,
+      fetchImpl: mockFetch as any,
+    });
+
+    expect(capturedBodies[0].username).toBe(`pair-bootstrap-${pairingToken.slice(0, 8)}`);
+  });
+});


### PR DESCRIPTION
## Summary

Implements PR-2 of the Federation Pair Option B spec: bootstrap user lifecycle tied to pairing tokens.

### Changes

**auth-middleware.ts** — Path 3: `flair_pair_initiator` Basic auth
- Accepts Basic auth where username starts with `pair-bootstrap-` **only** on `/FederationPair`
- Validates Harper user has `role=flair_pair_initiator` and `active=true`
- Any other path falls through to 401 (path-restriction is enforced strictly)

**src/cli.ts** — `flair federation token` produces a JSON triple
- Generates `pair-bootstrap-<id8>` user via `add_user` ops API after persisting PairingToken
- User has `role=flair_pair_initiator`, `active=true`, random 32-byte password
- Rollback: if `add_user` fails (HTTP or network), PairingToken is deleted — token and user always exist as a pair
- Output: `{ token, user, password, expiresAt }` JSON by default
- `--format text` emits bare token with deprecation warning to stderr

**resources/Federation.ts** — drop bootstrap user on successful pair
- After `Peer.put()` succeeds in new-peer branch: calls `drop_user` via ops API
- Failure is non-fatal: logged as warning, cleanup cron in PR-5 catches stragglers

### Tests
- `test/unit/auth-middleware.test.ts`: 9 new tests for `flair_pair_initiator` path
- `test/unit/federation-bootstrap-user.test.ts`: 8 new tests for full bootstrap user lifecycle

### Test Results
- 670 pass, 1 pre-existing failure (unchanged from main)