### PR TITLE
fix: correct factual claims in ADK spike findings (Sherlock review follow-up)

### DIFF
--- a/docs/notes/adk-spike-findings-2026-05-05.md
+++ b/docs/notes/adk-spike-findings-2026-05-05.md
@@ -228,7 +228,7 @@ This is a `Tool` (callable by the agent model), not a service. Shipped implement
 
 | Package | Source | Description |
 |---|---|---|
-| `google-adk-redis` (0.1.5) | https://github.com/redis-developer/adk-redis | Redis integration — implements Memory, Sessions, and Search tools |
+| `google-adk-redis` (0.0.4) | https://github.com/redis-developer/adk-redis | Redis integration — implements Memory, Sessions, and Search tools |
 | `google-adk-community` (0.4.1) | PyPI | Community extensions (specifics unknown without install) |
 
 ### Shipped session backends (for reference)
@@ -295,20 +295,16 @@ memory = VertexAiRagMemoryService(
 In the ADK CLI web server (`adk web`), memory_service is injected at the server level:
 
 ```python
-class FastApiAdkRunner:
-    def __init__(
-        self,
-        *,
-        agent_loader: BaseAgentLoader,
-        session_service: BaseSessionService,
-        memory_service: BaseMemoryService,      # <-- injected here
-        artifact_service: BaseArtifactService,
-        credential_service: BaseCredentialService,
-        # ...
-    ):
+```python
+# WARNING: FastApiAdkRunner class name requires verification — not located in adk-python @ v1.32.0.
+# The adk-python main branch has `Runner` and `InMemoryRunner` in `google/adk/runners.py`,
+# and `adk_web_server.py` handles the HTTP entry point without a FastAPI-specific runner class.
+# The memory_service injection pattern (runner → InvocationContext → ctx) is correct,
+# but the specific class name may be internal, renamed, or from a different ADK version.
+# Verified against: https://github.com/google/adk-python (main branch, 2026-05-05)
 ```
 
-The runner then injects `memory_service` into each `InvocationContext`, making it available to all agents via `ctx.search_memory()`, `ctx.add_session_to_memory()`, etc.
+The runner pattern injects `memory_service` into each `InvocationContext`, making it available to all agents via `ctx.search_memory()`, `ctx.add_session_to_memory()`, etc.
 
 ### Session-scoped config
 


### PR DESCRIPTION
## Summary

Fact-check corrections for `docs/notes/adk-spike-findings-2026-05-05.md`, flagged by Sherlock during review of PR #348 (ADK spike).

### Changes

| Claim | Was | Now | Verification |
|---|---|---|---|
| **adk-redis version** | 0.1.5 | **0.0.4** | `pypi.org/pypi/adk-redis/json` — latest release is 0.0.4 |
| **FastApiAdkRunner** | Shown as concrete class in code block | **Marked "requires verification"** | Not located in `google/adk-python` main branch @ v1.32.0. Only `Runner` and `InMemoryRunner` exist in `google/adk/runners.py`. HTTP entry point is in `adk_web_server.py` without a FastAPI-specific runner class. |
| **google-adk-community version** | 0.4.1 | **0.4.1 (unchanged)** | Confirmed correct on `pypi.org/pypi/google-adk-community/json` |

### Verification steps

- `curl https://pypi.org/pypi/adk-redis/json` → latest: 0.0.4
- `curl https://pypi.org/pypi/google-adk-community/json` → latest: 0.4.1 ✓
- Full tree scan of `google/adk-python` main branch via GitHub API — no `FastApiAdkRunner` found
- Inspected `src/google/adk/runners.py` — only `Runner` and `InMemoryRunner` classes
- Inspected `src/google/adk/cli/adk_web_server.py` — no FastAPI runner class

### Notes

- The memory_service injection pattern (runner → InvocationContext → ctx) is correct; only the specific class name is unverified.
- google-adk-community 0.4.1 was already correct — no edit needed.

Follow-up to #348.