### PR TITLE
feat: cleanup sweep for orphaned bootstrap users (Federation Pair Option B, PR-5)

### DIFF
--- a/resources/Federation.ts
+++ b/resources/Federation.ts
@@ -429,11 +429,9 @@ export class FederationPeers extends Resource {
 // will start on the next event loop tick and runs only on hub instances.
 if (typeof setTimeout !== "undefined") {
   setTimeout(() => {
-    try {
-      initFederationCleanup();
-    } catch (err: any) {
+    initFederationCleanup().catch((err: any) => {
       // Swallow — in test/resource-env the Harper databases may not be bound.
       // In production, initFederationCleanup handles its own error paths.
-    }
+    });
   }, 0);
 }

--- a/resources/Federation.ts
+++ b/resources/Federation.ts
@@ -1,7 +1,8 @@
-import { Resource, databases } from "@harperfast/harper";
+import { Resource, databases, server } from "@harperfast/harper";
 import { createHash, randomBytes } from "node:crypto";
 import nacl from "tweetnacl";
 import { canonicalize, signBody, verifyBodySignature } from "./federation-crypto.js";
+import { initFederationCleanup } from "./federation-cleanup.js";
 
 // Re-export for consumers that import from Federation.ts
 export { canonicalize, signBody, verifyBodySignature };
@@ -243,27 +244,16 @@ export class FederationPair extends Resource {
       });
 
       // Drop the bootstrap user that was created alongside this pairing token.
-      // Failure here is non-fatal: a cleanup cron (PR-5) will catch stragglers.
+      // Failure here is non-fatal: the cleanup sweep (PR-5) will catch stragglers.
       try {
         const bootstrapUsername = `pair-bootstrap-${pairingToken.slice(0, 8)}`;
-        const opsPort = process.env.FLAIR_OPS_PORT
-          ? Number(process.env.FLAIR_OPS_PORT)
-          : (process.env.FLAIR_PORT ? Number(process.env.FLAIR_PORT) - 1 : 19925);
-        const opsUrl = `http://127.0.0.1:${opsPort}/`;
-        const adminPass = process.env.HDB_ADMIN_PASSWORD ?? process.env.FLAIR_ADMIN_PASSWORD ?? "";
-        const auth = `Basic ${Buffer.from(`admin:${adminPass}`).toString("base64")}`;
-        const dropRes = await fetch(opsUrl, {
-          method: "POST",
-          headers: { "Content-Type": "application/json", Authorization: auth },
-          body: JSON.stringify({ operation: "drop_user", username: bootstrapUsername }),
-          signal: AbortSignal.timeout(10_000),
-        });
-        if (!dropRes.ok) {
-          const detail = await dropRes.text().catch(() => "");
-          console.warn(`[federation] drop_user ${bootstrapUsername} failed (${dropRes.status}): ${detail} — cleanup cron will retry`);
-        }
+        await server.operation(
+          { operation: "drop_user", username: bootstrapUsername },
+          ctx,
+          false,
+        );
       } catch (err: any) {
-        console.warn(`[federation] drop_user failed (network): ${err?.message} — cleanup cron will retry`);
+        console.warn(`[federation] drop_user failed: ${err?.message} — cleanup sweep will retry`);
       }
     }
 
@@ -431,3 +421,7 @@ export class FederationPeers extends Resource {
     return { peers };
   }
 }
+
+// ── Module initialisation ────────────────────────────────────────────────────
+// Start the cleanup sweep (PR-5). Only active on hub instances.
+initFederationCleanup();

--- a/resources/Federation.ts
+++ b/resources/Federation.ts
@@ -423,5 +423,17 @@ export class FederationPeers extends Resource {
 }
 
 // ── Module initialisation ────────────────────────────────────────────────────
-// Start the cleanup sweep (PR-5). Only active on hub instances.
-initFederationCleanup();
+// Deferred: the cleanup sweep (PR-5) starts after the module graph resolves.
+// In unit test environments (no Harper runtime), setTimeout never fires
+// synchronously and import is safe. In the live Harper process, the sweep
+// will start on the next event loop tick and runs only on hub instances.
+if (typeof setTimeout !== "undefined") {
+  setTimeout(() => {
+    try {
+      initFederationCleanup();
+    } catch (err: any) {
+      // Swallow — in test/resource-env the Harper databases may not be bound.
+      // In production, initFederationCleanup handles its own error paths.
+    }
+  }, 0);
+}

--- a/resources/federation-cleanup.ts
+++ b/resources/federation-cleanup.ts
@@ -168,7 +168,8 @@ export async function runCleanupTick(
         false, // bypass Harper permission checks
       );
       console.log(
-        `[federation-cleanup] dropped user, tid=${tokenId.slice(0, 8)}`,
+        "[federation-cleanup] dropped user",
+        { tid: tokenId.slice(0, 8) },
       );
     } catch (err: any) {
       const msg = err?.message ?? "";
@@ -181,8 +182,8 @@ export async function runCleanupTick(
         // Idempotent — user already gone, no action needed
       } else {
         console.error(
-          `[federation-cleanup] drop_user error, tid=${tokenId.slice(0, 8)}:`,
-          err?.message ?? err,
+          "[federation-cleanup] drop_user error",
+          { tid: tokenId.slice(0, 8), err: String(err?.message ?? err) },
         );
       }
     }
@@ -202,12 +203,13 @@ export async function runCleanupTick(
           false,
         );
         console.log(
-          `[federation-cleanup] deleted expired token, tid=${tokenId.slice(0, 8)}`,
+          "[federation-cleanup] deleted expired token",
+          { tid: tokenId.slice(0, 8) },
         );
       } catch (err: any) {
         console.error(
-          `[federation-cleanup] delete token error, tid=${tokenId.slice(0, 8)}:`,
-          err?.message ?? err,
+          "[federation-cleanup] delete token error",
+          { tid: tokenId.slice(0, 8), err: String(err?.message ?? err) },
         );
       }
     }
@@ -215,7 +217,8 @@ export async function runCleanupTick(
     // Consumed tokens: keep record for audit trail
     if (consumed) {
       console.log(
-        `[federation-cleanup] keeping audit record, tid=${tokenId.slice(0, 8)} (consumed by ${token.consumedBy})`,
+        "[federation-cleanup] keeping audit record",
+        { tid: tokenId.slice(0, 8), consumedBy: token.consumedBy },
       );
     }
   }

--- a/resources/federation-cleanup.ts
+++ b/resources/federation-cleanup.ts
@@ -1,5 +1,3 @@
-import { databases, server } from "@harperfast/harper";
-
 const CLEANUP_INTERVAL_MS = 300_000; // 5 minutes
 
 let cleanupTimer: ReturnType<typeof setInterval> | null = null;
@@ -13,72 +11,84 @@ let cleanupTimer: ReturnType<typeof setInterval> | null = null;
  * On hubs: ensures a 5-minute setInterval that sweeps PairingToken records
  * for consumed or expired tokens, drops the corresponding bootstrap users,
  * and performs housekeeping on expired/unconsumed token records.
+ *
+ * In test environments, callers pass mock serverOp/db via `opts` so this
+ * module never imports @harperfast/harper at the top level (which would
+ * crash when STORAGE_PATH isn't set).
  */
-export function initFederationCleanup(
+export async function initFederationCleanup(
   opts?: {
     instanceRole?: string | null;
-    serverOp?: typeof server.operation;
-    db?: typeof databases;
+    serverOp?: (op: any, ctx?: any, authorize?: boolean) => Promise<any>;
+    db?: any;
     immediateTick?: boolean;
   },
-): void {
-  const svr = opts?.serverOp ?? server.operation;
-  const db = opts?.db ?? databases;
+): Promise<void> {
   const immediate = opts?.immediateTick ?? true;
 
-  const rolePromise: Promise<string | null> =
-    opts?.instanceRole !== undefined
-      ? Promise.resolve(opts.instanceRole)
-      : getInstanceRole(db);
-
-  rolePromise
-    .then((role) => {
-      if (role !== "hub") {
-        console.log(
-          "[federation-cleanup] not a hub instance — cleanup disabled",
-        );
-        return;
-      }
-
-      console.log(
-        "[federation-cleanup] starting cleanup sweep (5-min cadence)",
-      );
-      if (cleanupTimer) clearInterval(cleanupTimer);
-
-      cleanupTimer = setInterval(() => {
-        runCleanupTick({ serverOp: svr, db }).catch((err: any) => {
-          console.error(
-            "[federation-cleanup] tick error:",
-            err?.message ?? err,
-          );
-        });
-      }, CLEANUP_INTERVAL_MS);
-
-      if (immediate) {
-        // Run an immediate first tick after role detection
-        runCleanupTick({ serverOp: svr, db }).catch((err: any) => {
-          console.error(
-            "[federation-cleanup] initial tick error:",
-            err?.message ?? err,
-          );
-        });
-      }
-    })
-    .catch((err: any) => {
+  // Resolve server / databases: use caller-supplied mocks when available,
+  // otherwise lazy-import @harperfast/harper at call time.
+  let svr: (op: any, ctx?: any, authorize?: boolean) => Promise<any>;
+  let db: any;
+  if (opts?.serverOp && opts?.db) {
+    svr = opts.serverOp;
+    db  = opts.db;
+  } else {
+    try {
+      const harper = await import("@harperfast/harper");
+      svr = opts?.serverOp ?? harper.server.operation;
+      db  = opts?.db ?? harper.databases;
+    } catch (err: any) {
       console.error(
-        "[federation-cleanup] role detection failed:",
+        "[federation-cleanup] failed to load @harperfast/harper:",
+        err?.message ?? err,
+      );
+      return;
+    }
+  }
+
+  const role: string | null =
+    opts?.instanceRole !== undefined
+      ? opts.instanceRole
+      : await getInstanceRole(db);
+
+  if (role !== "hub") {
+    console.log(
+      "[federation-cleanup] not a hub instance — cleanup disabled",
+    );
+    return;
+  }
+
+  console.log(
+    "[federation-cleanup] starting cleanup sweep (5-min cadence)",
+  );
+  if (cleanupTimer) clearInterval(cleanupTimer);
+
+  cleanupTimer = setInterval(() => {
+    runCleanupTick({ serverOp: svr, db }).catch((err: any) => {
+      console.error(
+        "[federation-cleanup] tick error:",
         err?.message ?? err,
       );
     });
+  }, CLEANUP_INTERVAL_MS);
+
+  if (immediate) {
+    // Run an immediate first tick after role detection
+    runCleanupTick({ serverOp: svr, db }).catch((err: any) => {
+      console.error(
+        "[federation-cleanup] initial tick error:",
+        err?.message ?? err,
+      );
+    });
+  }
 }
 
 /**
  * Look up the instance role from the Instance table.
  * Returns null if the table doesn't exist or no record is present.
  */
-async function getInstanceRole(
-  db: typeof databases,
-): Promise<string | null> {
+async function getInstanceRole(db: any): Promise<string | null> {
   try {
     for await (const inst of (db as any).flair.Instance.search()) {
       return inst.role ?? null;
@@ -105,13 +115,23 @@ async function getInstanceRole(
  */
 export async function runCleanupTick(
   opts: {
-    serverOp?: typeof server.operation;
-    db?: typeof databases;
+    serverOp?: (op: any, ctx?: any, authorize?: boolean) => Promise<any>;
+    db?: any;
     now?: Date;
   } = {},
 ): Promise<void> {
-  const svr = opts.serverOp ?? server.operation;
-  const db = opts.db ?? databases;
+  let svr: (op: any, ctx?: any, authorize?: boolean) => Promise<any>;
+  let db: any;
+
+  if (opts.serverOp && opts.db) {
+    svr = opts.serverOp;
+    db = opts.db;
+  } else {
+    const harper = await import("@harperfast/harper");
+    svr = opts.serverOp ?? harper.server.operation;
+    db = opts.db ?? harper.databases;
+  }
+
   const now = opts.now ?? new Date();
 
   // ── Query candidates ──────────────────────────────────────────────────

--- a/resources/federation-cleanup.ts
+++ b/resources/federation-cleanup.ts
@@ -1,0 +1,202 @@
+import { databases, server } from "@harperfast/harper";
+
+const CLEANUP_INTERVAL_MS = 300_000; // 5 minutes
+
+let cleanupTimer: ReturnType<typeof setInterval> | null = null;
+
+/**
+ * Initialise the federation cleanup sweep.
+ *
+ * Only active on hub instances — reads the Instance table to determine
+ * role. On spokes this is a no-op.
+ *
+ * On hubs: ensures a 5-minute setInterval that sweeps PairingToken records
+ * for consumed or expired tokens, drops the corresponding bootstrap users,
+ * and performs housekeeping on expired/unconsumed token records.
+ */
+export function initFederationCleanup(
+  opts?: {
+    instanceRole?: string | null;
+    serverOp?: typeof server.operation;
+    db?: typeof databases;
+    immediateTick?: boolean;
+  },
+): void {
+  const svr = opts?.serverOp ?? server.operation;
+  const db = opts?.db ?? databases;
+  const immediate = opts?.immediateTick ?? true;
+
+  const rolePromise: Promise<string | null> =
+    opts?.instanceRole !== undefined
+      ? Promise.resolve(opts.instanceRole)
+      : getInstanceRole(db);
+
+  rolePromise
+    .then((role) => {
+      if (role !== "hub") {
+        console.log(
+          "[federation-cleanup] not a hub instance — cleanup disabled",
+        );
+        return;
+      }
+
+      console.log(
+        "[federation-cleanup] starting cleanup sweep (5-min cadence)",
+      );
+      if (cleanupTimer) clearInterval(cleanupTimer);
+
+      cleanupTimer = setInterval(() => {
+        runCleanupTick({ serverOp: svr, db }).catch((err: any) => {
+          console.error(
+            "[federation-cleanup] tick error:",
+            err?.message ?? err,
+          );
+        });
+      }, CLEANUP_INTERVAL_MS);
+
+      if (immediate) {
+        // Run an immediate first tick after role detection
+        runCleanupTick({ serverOp: svr, db }).catch((err: any) => {
+          console.error(
+            "[federation-cleanup] initial tick error:",
+            err?.message ?? err,
+          );
+        });
+      }
+    })
+    .catch((err: any) => {
+      console.error(
+        "[federation-cleanup] role detection failed:",
+        err?.message ?? err,
+      );
+    });
+}
+
+/**
+ * Look up the instance role from the Instance table.
+ * Returns null if the table doesn't exist or no record is present.
+ */
+async function getInstanceRole(
+  db: typeof databases,
+): Promise<string | null> {
+  try {
+    for await (const inst of (db as any).flair.Instance.search()) {
+      return inst.role ?? null;
+    }
+  } catch {
+    /* table may not exist yet */
+  }
+  return null;
+}
+
+/**
+ * Core cleanup logic — exposed for unit testing.
+ *
+ * - Finds PairingToken records that are:
+ *   - consumedBy is non-null (pair succeeded, bootstrap user no longer needed)
+ *   - OR expiresAt < now (token expired without successful pair)
+ * - Drops the bootstrap user via the Harper ops API (idempotent: 404 is
+ *   swallowed).
+ * - Deletes the PairingToken record if expired AND not consumed
+ *   (housekeeping). Consumed records are kept for audit.
+ *
+ * Logging emits token-id prefix only (NEVER the full username, NEVER a
+ * password).
+ */
+export async function runCleanupTick(
+  opts: {
+    serverOp?: typeof server.operation;
+    db?: typeof databases;
+    now?: Date;
+  } = {},
+): Promise<void> {
+  const svr = opts.serverOp ?? server.operation;
+  const db = opts.db ?? databases;
+  const now = opts.now ?? new Date();
+
+  // ── Query candidates ──────────────────────────────────────────────────
+  const candidates: any[] = [];
+  try {
+    for await (const token of (db as any).flair.PairingToken.search()) {
+      const consumed = !!token.consumedBy;
+      const expired = token.expiresAt && new Date(token.expiresAt) < now;
+      if (consumed || expired) {
+        candidates.push(token);
+      }
+    }
+  } catch (err: any) {
+    console.error(
+      "[federation-cleanup] failed to query PairingToken records:",
+      err?.message ?? err,
+    );
+    return;
+  }
+
+  // ── Process each candidate ────────────────────────────────────────────
+  for (const token of candidates) {
+    const tokenId: string = token.id;
+    const consumed = !!token.consumedBy;
+    const expired =
+      token.expiresAt && new Date(token.expiresAt) < now;
+    const bootstrapUsername = `pair-bootstrap-${tokenId.slice(0, 8)}`;
+
+    // Drop the bootstrap user
+    try {
+      await svr(
+        { operation: "drop_user", username: bootstrapUsername },
+        { user: null },
+        false, // bypass Harper permission checks
+      );
+      console.log(
+        `[federation-cleanup] dropped user, tid=${tokenId.slice(0, 8)}`,
+      );
+    } catch (err: any) {
+      const msg = err?.message ?? "";
+      const isNotFound =
+        err?.statusCode === 404 ||
+        msg.toLowerCase().includes("not exist") ||
+        msg.toLowerCase().includes("not found");
+
+      if (isNotFound) {
+        // Idempotent — user already gone, no action needed
+      } else {
+        console.error(
+          `[federation-cleanup] drop_user error, tid=${tokenId.slice(0, 8)}:`,
+          err?.message ?? err,
+        );
+      }
+    }
+
+    // ── Housekeeping ────────────────────────────────────────────────────
+    if (expired && !consumed) {
+      // Delete the expired, unconsumed token record itself
+      try {
+        await svr(
+          {
+            operation: "delete",
+            database: "flair",
+            table: "PairingToken",
+            hash_value: tokenId,
+          },
+          { user: null },
+          false,
+        );
+        console.log(
+          `[federation-cleanup] deleted expired token, tid=${tokenId.slice(0, 8)}`,
+        );
+      } catch (err: any) {
+        console.error(
+          `[federation-cleanup] delete token error, tid=${tokenId.slice(0, 8)}:`,
+          err?.message ?? err,
+        );
+      }
+    }
+
+    // Consumed tokens: keep record for audit trail
+    if (consumed) {
+      console.log(
+        `[federation-cleanup] keeping audit record, tid=${tokenId.slice(0, 8)} (consumed by ${token.consumedBy})`,
+      );
+    }
+  }
+}

--- a/test/unit/federation-cleanup.test.ts
+++ b/test/unit/federation-cleanup.test.ts
@@ -1,0 +1,398 @@
+import { describe, it, expect, mock, beforeEach, afterEach } from "bun:test";
+import { runCleanupTick, initFederationCleanup } from "../../resources/federation-cleanup.js";
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function makeToken(id: string, opts: {
+  consumedBy?: string;
+  consumesAt?: string;
+  expiresAt?: string;
+} = {}) {
+  return {
+    id,
+    consumedBy: opts.consumedBy ?? null,
+    consumedAt: opts.consumesAt ?? null,
+    expiresAt: opts.expiresAt ?? new Date(Date.now() + 3600_000).toISOString(),
+    createdAt: new Date(Date.now() - 3600_000).toISOString(),
+  };
+}
+
+function tokenId(id: string) {
+  return id.slice(0, 8);
+}
+
+// ─── Mock factories ──────────────────────────────────────────────────────────
+
+interface CapturedOp {
+  body: Record<string, unknown>;
+  ctx: Record<string, unknown>;
+  authorize: boolean;
+}
+
+function createMockServerOp(
+  responses: Array<{ ok: true; data?: any } | { ok: false; error: Error }>,
+) {
+  let idx = 0;
+  const captured: CapturedOp[] = [];
+  const fn = mock(async (body: Record<string, unknown>, ctx: Record<string, unknown>, authorize: boolean) => {
+    captured.push({ body, ctx, authorize });
+    const resp = responses[idx++];
+    if (!resp) throw new Error(`Unexpected serverOp call #${idx}`);
+    if (!resp.ok) throw resp.error;
+    return resp.data ?? { message: "ok" };
+  });
+  return { fn, captured };
+}
+
+function createMockDb(tokens: any[]) {
+  // async iterable from an array
+  function fromArray<T>(items: T[]): AsyncIterable<T> {
+    return {
+      [Symbol.asyncIterator]() {
+        let i = 0;
+        return {
+          async next() {
+            if (i < items.length) return { value: items[i++], done: false };
+            return { value: undefined as any, done: true };
+          },
+        };
+      },
+    };
+  }
+
+  return {
+    flair: {
+      PairingToken: {
+        search: () => fromArray(tokens),
+      },
+    },
+  };
+}
+
+// ─── Tests: runCleanupTick ───────────────────────────────────────────────────
+
+describe("federation-cleanup sweep", () => {
+  describe("runCleanupTick", () => {
+    it("sweep skips tokens neither consumed nor expired", async () => {
+      const now = new Date("2026-05-05T22:00:00Z");
+      const tokens = [
+        makeToken("token_A_pending_ABCD", {
+          expiresAt: new Date("2026-05-05T23:00:00Z").toISOString(),
+        }), // not consumed, not expired → skip
+      ];
+
+      const db = createMockDb(tokens);
+      const { fn: serverOp, captured } = createMockServerOp([]);
+
+      await runCleanupTick({ serverOp, db: db as any, now });
+
+      expect(captured).toHaveLength(0);
+    });
+
+    it("sweep deletes user for consumed token", async () => {
+      const now = new Date("2026-05-05T22:00:00Z");
+      const tId = "token_B_consumed_ABCDEF01";
+      const tokens = [
+        makeToken(tId, {
+          consumedBy: "instance-xyz",
+          expiresAt: new Date("2026-05-05T22:30:00Z").toISOString(),
+        }),
+      ];
+
+      const db = createMockDb(tokens);
+      const { fn: serverOp, captured } = createMockServerOp([
+        { ok: true, data: { message: "user dropped" } },
+      ]);
+
+      await runCleanupTick({ serverOp, db: db as any, now });
+
+      expect(captured).toHaveLength(1);
+      const call = captured[0];
+      expect(call.body.operation).toBe("drop_user");
+      expect(call.body.username).toBe(`pair-bootstrap-${tokenId(tId)}`);
+      expect(call.authorize).toBe(false);
+
+      // Should NOT delete the token record (audit trail)
+      const deleteCalls = captured.filter((c) => c.body.operation === "delete");
+      expect(deleteCalls).toHaveLength(0);
+    });
+
+    it("sweep deletes user AND record for expired unconsumed token", async () => {
+      const now = new Date("2026-05-05T22:00:00Z");
+      const tId = "token_C_expired_XYZ12345";
+      const tokens = [
+        makeToken(tId, {
+          expiresAt: new Date("2026-05-05T21:00:00Z").toISOString(), // expired
+        }),
+      ];
+
+      const db = createMockDb(tokens);
+      const { fn: serverOp, captured } = createMockServerOp([
+        { ok: true, data: { message: "user dropped" } },  // drop_user
+        { ok: true, data: { message: "deleted 1 record" } },  // delete token record
+      ]);
+
+      await runCleanupTick({ serverOp, db: db as any, now });
+
+      expect(captured).toHaveLength(2);
+
+      // First call: drop_user
+      expect(captured[0].body.operation).toBe("drop_user");
+      expect(captured[0].body.username).toBe(`pair-bootstrap-${tokenId(tId)}`);
+
+      // Second call: delete token record
+      expect(captured[1].body.operation).toBe("delete");
+      expect(captured[1].body.database).toBe("flair");
+      expect(captured[1].body.table).toBe("PairingToken");
+      expect(captured[1].body.hash_value).toBe(tId);
+    });
+
+    it("sweep keeps record (just deletes user) for consumed token", async () => {
+      const now = new Date("2026-05-05T22:00:00Z");
+      const tokenId = "token_D_consumed_KEEPIT99";
+      const tokens = [
+        makeToken(tokenId, {
+          consumedBy: "instance-other",
+          expiresAt: new Date("2026-05-04T12:00:00Z").toISOString(), // also expired
+        }),
+      ];
+
+      const db = createMockDb(tokens);
+      const { fn: serverOp, captured } = createMockServerOp([
+        { ok: true, data: { message: "user dropped" } },
+      ]);
+
+      await runCleanupTick({ serverOp, db: db as any, now });
+
+      expect(captured).toHaveLength(1);
+      expect(captured[0].body.operation).toBe("drop_user");
+
+      // Even though expired, since consumed, do NOT delete the record
+      const deleteCalls = captured.filter((c) => c.body.operation === "delete");
+      expect(deleteCalls).toHaveLength(0);
+    });
+
+    it("drop_user 404 (user already gone) is swallowed", async () => {
+      const now = new Date("2026-05-05T22:00:00Z");
+      const tokenId = "token_E_gone_GHOST404";
+      const tokens = [
+        makeToken(tokenId, {
+          consumedBy: "instance-gone",
+        }),
+      ];
+
+      const db = createMockDb(tokens);
+      const fourOhFour = { statusCode: 404, message: "User 'pair-bootstrap-token_E_' does not exist" } as any;
+      const { fn: serverOp, captured } = createMockServerOp([
+        { ok: false, error: fourOhFour },
+      ]);
+
+      // Should not throw
+      await expect(
+        runCleanupTick({ serverOp, db: db as any, now }),
+      ).resolves.toBeUndefined();
+
+      expect(captured).toHaveLength(1);
+      expect(captured[0].body.operation).toBe("drop_user");
+    });
+
+    it("drop_user 404 with 'not found' message is swallowed (alternative)", async () => {
+      const now = new Date("2026-05-05T22:00:00Z");
+      const tokenId = "token_F_gone2_NOTFND";
+      const tokens = [
+        makeToken(tokenId, {
+          consumedBy: "instance-gone2",
+        }),
+      ];
+
+      const db = createMockDb(tokens);
+      const notFound = { statusCode: 404, message: "user not found in system" } as any;
+      const { fn: serverOp, captured } = createMockServerOp([
+        { ok: false, error: notFound },
+      ]);
+
+      await expect(
+        runCleanupTick({ serverOp, db: db as any, now }),
+      ).resolves.toBeUndefined();
+
+      expect(captured).toHaveLength(1);
+    });
+
+    it("drop_user other errors NOT swallowed", async () => {
+      const now = new Date("2026-05-05T22:00:00Z");
+      const tokenId = "token_G_realerr_500";
+      const tokens = [
+        makeToken(tokenId, {
+          consumedBy: "instance-realerr",
+        }),
+      ];
+
+      const db = createMockDb(tokens);
+      const realErr = { statusCode: 500, message: "internal server error" } as any;
+      const { fn: serverOp, captured } = createMockServerOp([
+        { ok: false, error: realErr },
+        // Should still try the delete for housekeeping
+        { ok: true },
+        { ok: true },
+      ]);
+
+      // Should NOT throw — the error is caught and logged inside runCleanupTick
+      await runCleanupTick({ serverOp, db: db as any, now });
+
+      expect(captured).toHaveLength(1);
+      expect(captured[0].body.operation).toBe("drop_user");
+    });
+
+    it("handles empty PairingToken table gracefully", async () => {
+      const now = new Date("2026-05-05T22:00:00Z");
+      const db = createMockDb([]);
+      const { fn: serverOp, captured } = createMockServerOp([]);
+
+      await runCleanupTick({ serverOp, db: db as any, now });
+
+      expect(captured).toHaveLength(0);
+    });
+
+    it("handles multiple mixed tokens in one sweep", async () => {
+      const now = new Date("2026-05-05T22:00:00Z");
+      const tokens = [
+        makeToken("tok_X1_consumed_AAAA", { consumedBy: "x1" }),
+        makeToken("tok_X2_expired__BBBB", {
+          expiresAt: new Date("2026-05-04T12:00:00Z").toISOString(),
+        }),
+        makeToken("tok_X3_pending__CCCC", {
+          expiresAt: new Date("2026-05-05T22:30:00Z").toISOString(),
+        }), // not expired, not consumed → skipped
+        makeToken("tok_X4_consumed_DDDD", { consumedBy: "x4" }),
+      ];
+
+      const db = createMockDb(tokens);
+      const { fn: serverOp, captured } = createMockServerOp([
+        { ok: true }, // drop tok_X1
+        { ok: true }, // drop tok_X2
+        { ok: true }, // delete tok_X2
+        { ok: true }, // drop tok_X4
+      ]);
+
+      await runCleanupTick({ serverOp, db: db as any, now });
+
+      expect(captured).toHaveLength(4);
+
+      const dropCalls = captured.filter((c) => c.body.operation === "drop_user");
+      expect(dropCalls).toHaveLength(3);
+      expect(dropCalls[0].body.username).toBe("pair-bootstrap-tok_X1_c");
+      expect(dropCalls[1].body.username).toBe("pair-bootstrap-tok_X2_e");
+      expect(dropCalls[2].body.username).toBe("pair-bootstrap-tok_X4_c");
+
+      const deleteCalls = captured.filter((c) => c.body.operation === "delete");
+      expect(deleteCalls).toHaveLength(1);
+      expect(deleteCalls[0].body.hash_value).toBe("tok_X2_expired__BBBB");
+    });
+
+    it("delete token record error does not prevent processing other tokens", async () => {
+      const now = new Date("2026-05-05T22:00:00Z");
+      const tokens = [
+        makeToken("tok_Y1_expired", {
+          expiresAt: new Date("2026-05-04T12:00:00Z").toISOString(),
+        }),
+        makeToken("tok_Y2_expired", {
+          expiresAt: new Date("2026-05-04T13:00:00Z").toISOString(),
+        }),
+      ];
+
+      const db = createMockDb(tokens);
+      const deleteErr = { statusCode: 500, message: "db error on delete" } as any;
+      const { fn: serverOp, captured } = createMockServerOp([
+        { ok: true },           // drop tok_Y1
+        { ok: false, error: deleteErr }, // delete tok_Y1 fails
+        { ok: true },           // drop tok_Y2
+        { ok: true },           // delete tok_Y2 succeeds
+      ]);
+
+      await runCleanupTick({ serverOp, db: db as any, now });
+
+      expect(captured).toHaveLength(4);
+      expect(captured[2].body.operation).toBe("drop_user");
+      expect(captured[3].body.operation).toBe("delete");
+      expect(captured[3].body.hash_value).toBe("tok_Y2_expired");
+    });
+
+    it("handles search failure gracefully (returns without throwing)", async () => {
+      const now = new Date("2026-05-05T22:00:00Z");
+      const failingDb = {
+        flair: {
+          PairingToken: {
+            search: () => {
+              throw new Error("table does not exist");
+            },
+          },
+        },
+      };
+      const { fn: serverOp, captured } = createMockServerOp([]);
+
+      await expect(
+        runCleanupTick({ serverOp, db: failingDb as any, now }),
+      ).resolves.toBeUndefined();
+
+      expect(captured).toHaveLength(0);
+    });
+  });
+
+  // ── Hub-vs-spoke guard ─────────────────────────────────────────────────────
+
+  describe("initFederationCleanup hub guard", () => {
+    it("spoke role → cleanup is a no-op", async () => {
+      const db = createMockDb([]);
+      const { fn: serverOp, captured } = createMockServerOp([]);
+
+      // Init with explicit role="spoke" + immediateTick=false so we just
+      // check the role guard path.
+      initFederationCleanup({
+        instanceRole: "spoke",
+        serverOp,
+        db: db as any,
+        immediateTick: false,
+      });
+
+      // Let the async rolePromise resolve
+      await new Promise((resolve) => setTimeout(resolve, 50));
+
+      expect(captured).toHaveLength(0);
+    });
+
+    it("hub role → cleanup starts", async () => {
+      const db = createMockDb([]);
+      const { fn: serverOp, captured } = createMockServerOp([]);
+
+      initFederationCleanup({
+        instanceRole: "hub",
+        serverOp,
+        db: db as any,
+        immediateTick: true,
+      });
+
+      // Let the async rolePromise + immediate tick run
+      await new Promise((resolve) => setTimeout(resolve, 100));
+
+      // immediateTick should have called runCleanupTick, which queries the
+      // empty table → 0 ops calls, but tick completed (no rejection)
+      expect(captured).toHaveLength(0);
+    });
+
+    it("no instance record → treated as no-op (role is null)", async () => {
+      const db = createMockDb([]);
+      const { fn: serverOp, captured } = createMockServerOp([]);
+
+      initFederationCleanup({
+        instanceRole: null,  // no instance record / role unknown
+        serverOp,
+        db: db as any,
+        immediateTick: false,
+      });
+
+      await new Promise((resolve) => setTimeout(resolve, 50));
+
+      expect(captured).toHaveLength(0);
+    });
+  });
+});

--- a/types/harper.d.ts
+++ b/types/harper.d.ts
@@ -1,6 +1,8 @@
 declare module "@harperfast/harper" {
   export const server: {
     http: (handler: (request: any, next: any) => any, options?: any) => void;
+    operation: (operation: Record<string, unknown>, context: any, authorize?: boolean) => Promise<any>;
+    getUser: (username: string, password: string | null, request: any) => Promise<any>;
   };
   export const tables: Record<string, any>;
   export const databases: Record<string, any>;


### PR DESCRIPTION
## What

Implements PR-5 of the Federation Pair Option B spec: a background cleanup sweep that removes stale bootstrap users left behind after pairing or token expiry.

### Key changes

- **resources/federation-cleanup.ts** — new module exporting `initFederationCleanup()` and `runCleanupTick()`. Runs a 5-minute `setInterval` that:
  - Queries `PairingToken` for consumed or expired tokens
  - Drops the `pair-bootstrap-*` user via `server.operation()` (internal ops API — no env-var dependency)
  - Deletes expired/unconsumed token records (housekeeping); keeps consumed records (audit trail)
  - Idempotent: 404 on already-deleted users is swallowed; other errors are logged

- **resources/Federation.ts** — refactored PR-2's `drop_user` to use `server.operation()` instead of `fetch` + env-var Basic auth. Wired `initFederationCleanup()` at module init (hub-guarded).

- **types/harper.d.ts** — added `server.operation` and `server.getUser` type declarations

- **test/unit/federation-cleanup.test.ts** — 14 tests covering sweep, hub/spoke gating, idempotency, and error handling

### Verification

```
bun test test/unit/federation-cleanup.test.ts  → 14 pass, 0 fail
bun test test/unit/                            → no regressions
bun run tsc --project tsconfig.check.json --noEmit → clean
```

### Anti-patterns avoided

- No cleanup at request time (setInterval-only)
- No username+token-id logged in same line
- No sweep on spokes (hub guard)
- No TTL extension on consumed tokens