### PR TITLE
feat(auth): Path 5 — spoke Ed25519 auth for /FederationSync

### DIFF
--- a/resources/auth-middleware.ts
+++ b/resources/auth-middleware.ts
@@ -1,6 +1,7 @@
 import { patchRecord } from "./table-helpers.js";
 import { server, databases } from "@harperfast/harper";
 import { getEmbedding } from "./embeddings-provider.js";
+import nacl from "tweetnacl";
 
 // --- Admin credentials ---
 // Admin auth is sourced exclusively from Harper's own environment variables
@@ -126,8 +127,9 @@ server.http(async (request: any, nextLayer: any) => {
     url.pathname === "/AgentCard" ||
     url.pathname.startsWith("/A2AAdapter/") ||
     url.pathname.startsWith("/AgentCard/") ||
-    // FederationSync uses Ed25519 body-signature auth (handled by the resource)
-    url.pathname === "/FederationSync" ||
+    // FederationSync auth is handled by Path 5 (spoke Ed25519) below —
+    // it is NOT in the allowlist; requests must present a valid TPS-Ed25519
+    // header from a paired spoke peer to reach the FederationSync resource.
     // FederationPair uses one-time PairingToken in the request body, validated
     // by the resource itself (allowCreate=true on the Resource lets anonymous
     // POST through Harper's role gate). Bearer can't be used here because
@@ -204,6 +206,67 @@ server.http(async (request: any, nextLayer: any) => {
       }
     } catch { /* fall through to Ed25519 check */ }
     return new Response(JSON.stringify({ error: "invalid_admin_credentials" }), { status: 401 });
+  }
+
+  // ── Path 5: spoke instance Ed25519 auth (FederationSync only) ────────────
+  // Spoke instances authenticate using their own Ed25519 keypair (the same one
+  // used to sign pair body signatures). The pinned publicKey is looked up from
+  // the Peer table. Path-restricted: a spoke's Ed25519 cannot be used on any
+  // other endpoint.
+  if (url.pathname === "/FederationSync") {
+    const tpsHeader = header.match(/^TPS-Ed25519\s+([^:]+):(\d+):([^:]+):(.+)$/);
+    if (tpsHeader) {
+      const [, instanceId, tsRaw, nonce, signatureB64] = tpsHeader;
+      const ts = Number(tsRaw);
+      const now = Date.now();
+
+      // Anti-replay: timestamp window ±30s
+      if (!Number.isFinite(ts) || Math.abs(now - ts) > WINDOW_MS) {
+        return new Response(JSON.stringify({ error: "stale_or_future_timestamp" }), { status: 401 });
+      }
+
+      // Nonce dedup — namespaced key to avoid collision with agent nonces
+      for (const [k, sigTs] of nonceSeen.entries()) {
+        if (now - sigTs > WINDOW_MS) nonceSeen.delete(k);
+      }
+      const nonceKey = `spoke:${instanceId}:${nonce}`;
+      if (nonceSeen.has(nonceKey)) {
+        return new Response(JSON.stringify({ error: "nonce_replay_detected" }), { status: 401 });
+      }
+
+      // Look up the spoke in the Peer table
+      let peer: any = null;
+      try {
+        peer = await (databases as any).flair.Peer.get(instanceId);
+      } catch { /* table miss */ }
+      if (!peer || peer.status === "revoked" || peer.role !== "spoke") {
+        return new Response(JSON.stringify({ error: "unknown_or_revoked_peer" }), { status: 401 });
+      }
+
+      // Verify the signature against the pinned publicKey
+      const message = `${instanceId}:${tsRaw}:${nonce}:${request.method}:${url.pathname}`;
+      const valid = nacl.sign.detached.verify(
+        Buffer.from(message, "utf-8"),
+        Buffer.from(signatureB64, "base64"),
+        Buffer.from(peer.publicKey, "base64url"),
+      );
+      if (!valid) {
+        return new Response(JSON.stringify({ error: "invalid_signature" }), { status: 401 });
+      }
+
+      // Record nonce, set synthetic user for Harper downstream
+      nonceSeen.set(nonceKey, ts);
+      (request as any)._tpsAuthVerified = true;
+      request.user = {
+        username: `spoke-${instanceId}`,
+        role: { role: "flair_sync_initiator", permission: { super_user: false } },
+        active: true,
+      };
+      request.headers.set("x-tps-spoke", instanceId);
+      request.tpsAgent = `spoke-${instanceId}`;
+      request.tpsAgentIsAdmin = false;
+      return nextLayer(request);
+    }
   }
 
   // ── Ed25519 agent auth ────────────────────────────────────────────────────

--- a/test/unit/auth-middleware-spoke-sync.test.ts
+++ b/test/unit/auth-middleware-spoke-sync.test.ts
@@ -1,0 +1,248 @@
+import { describe, expect, test } from "bun:test";
+import nacl from "tweetnacl";
+
+// ─── Simulator: Path 5 spoke Ed25519 auth on /FederationSync ────────────────
+// Tests validate the auth logic in isolation using real nacl signatures.
+// Consistent with the existing auth-middleware.test.ts simulator pattern.
+
+const WINDOW_MS = 30_000;
+
+function makeSpokeHeader(
+  instanceId: string,
+  secretKey: Uint8Array,
+  method: string,
+  pathname: string,
+  ts?: number,
+  nonce?: string,
+): { header: string; ts: number; nonce: string } {
+  const now = ts ?? Date.now();
+  const n = nonce ?? Buffer.from(nacl.randomBytes(16)).toString("base64url");
+  const message = `${instanceId}:${now}:${n}:${method}:${pathname}`;
+  const sig = nacl.sign.detached(Buffer.from(message, "utf-8"), secretKey);
+  const sigB64 = Buffer.from(sig).toString("base64");
+  return { header: `TPS-Ed25519 ${instanceId}:${now}:${n}:${sigB64}`, ts: now, nonce: n };
+}
+
+describe("Path 5: spoke Ed25519 auth on /FederationSync", () => {
+  test("valid TPS-Ed25519 from paired spoke on /FederationSync → accepted", () => {
+    const kp = nacl.sign.keyPair();
+    const instanceId = "spoke-alpha-1";
+    const publicKeyB64url = Buffer.from(kp.publicKey).toString("base64url");
+
+    const { header } = makeSpokeHeader(instanceId, kp.secretKey, "POST", "/FederationSync");
+
+    // Simulate path check
+    const url = { pathname: "/FederationSync" };
+    expect(url.pathname === "/FederationSync").toBe(true);
+
+    // Simulate header parse
+    const match = header.match(/^TPS-Ed25519\s+([^:]+):(\d+):([^:]+):(.+)$/);
+    expect(match).not.toBeNull();
+    const [, parsedInstanceId, tsRaw, nonce, sigB64] = match!;
+
+    // Timestamp check
+    const ts = Number(tsRaw);
+    const now = Date.now();
+    expect(Math.abs(now - ts) <= WINDOW_MS).toBe(true);
+
+    // Signature verification
+    const message = `${parsedInstanceId}:${tsRaw}:${nonce}:POST:${url.pathname}`;
+    const valid = nacl.sign.detached.verify(
+      Buffer.from(message, "utf-8"),
+      Buffer.from(sigB64, "base64"),
+      Buffer.from(publicKeyB64url, "base64url"),
+    );
+    expect(valid).toBe(true);
+
+    // Synthetic user shape
+    const user = {
+      username: `spoke-${instanceId}`,
+      role: { role: "flair_sync_initiator", permission: { super_user: false } },
+      active: true,
+    };
+    expect(user.username).toBe(`spoke-${instanceId}`);
+    expect(user.role.role).toBe("flair_sync_initiator");
+    expect(user.role.permission.super_user).toBe(false);
+    expect(user.active).toBe(true);
+  });
+
+  test("invalid signature → 401", () => {
+    const kp = nacl.sign.keyPair();
+    const attackerKp = nacl.sign.keyPair(); // different keypair
+    const instanceId = "spoke-alpha-1";
+    const publicKeyB64url = Buffer.from(kp.publicKey).toString("base64url");
+
+    // Sign with the wrong keypair
+    const now = Date.now();
+    const nonce = "nonce-invalid-sig";
+    const message = `${instanceId}:${now}:${nonce}:POST:/FederationSync`;
+    const sig = nacl.sign.detached(Buffer.from(message, "utf-8"), attackerKp.secretKey);
+    const sigB64 = Buffer.from(sig).toString("base64");
+
+    // Verify against the correct public key — must fail
+    const valid = nacl.sign.detached.verify(
+      Buffer.from(message, "utf-8"),
+      Buffer.from(sigB64, "base64"),
+      Buffer.from(publicKeyB64url, "base64url"),
+    );
+    expect(valid).toBe(false);
+  });
+
+  test("revoked peer (status=revoked) → 401", () => {
+    // Simulate the peer lookup returning a revoked record
+    const peer = { id: "spoke-alpha-1", publicKey: "pk", role: "spoke", status: "revoked" };
+    const isRejected = !peer || peer.status === "revoked" || peer.role !== "spoke";
+    expect(isRejected).toBe(true);
+  });
+
+  test("unknown instance id (not in Peer table) → 401", () => {
+    // Simulate peer lookup returning null
+    const peer = null;
+    const isRejected = !peer || peer?.status === "revoked" || peer?.role !== "spoke";
+    expect(isRejected).toBe(true);
+  });
+
+  test("path-restriction: same valid TPS-Ed25519 on /Memory falls through", () => {
+    // Path 5 only triggers when url.pathname === "/FederationSync"
+    const syncUrl = { pathname: "/FederationSync" };
+    const memoryUrl = { pathname: "/Memory" };
+
+    // On /FederationSync → Path 5 intercepts
+    expect(syncUrl.pathname === "/FederationSync").toBe(true);
+
+    // On /Memory → Path 5 does NOT intercept (falls through to Ed25519 agent auth)
+    expect(memoryUrl.pathname === "/FederationSync").toBe(false);
+  });
+
+  test("stale timestamp (>30s old) → 401", () => {
+    const now = Date.now();
+    const staleTs = now - 31_001;
+    expect(Math.abs(now - staleTs) > WINDOW_MS).toBe(true);
+    expect(Number.isFinite(staleTs)).toBe(true);
+  });
+
+  test("future timestamp (>30s ahead) → 401", () => {
+    const now = Date.now();
+    const futureTs = now + 31_001;
+    expect(Math.abs(now - futureTs) > WINDOW_MS).toBe(true);
+    expect(Number.isFinite(futureTs)).toBe(true);
+  });
+
+  test("replayed nonce → 401", () => {
+    const nonceSeen = new Map<string, number>();
+    const instanceId = "spoke-alpha-1";
+    const nonce = "replay-nonce-42";
+    const nonceKey = `spoke:${instanceId}:${nonce}`;
+
+    // First use: record it
+    expect(nonceSeen.has(nonceKey)).toBe(false);
+    nonceSeen.set(nonceKey, Date.now());
+
+    // Second use: detected as replay
+    expect(nonceSeen.has(nonceKey)).toBe(true);
+  });
+
+  test("hub trying to use spoke Ed25519 on /FederationSync (peer.role !== spoke) → 401", () => {
+    const hubPeer = { id: "hub-main", publicKey: "pk", role: "hub", status: "paired" };
+    const isRejected = !hubPeer || hubPeer.status === "revoked" || hubPeer.role !== "spoke";
+    expect(isRejected).toBe(true);
+  });
+
+  test("tpsAgentIsAdmin is always false for spoke auth", () => {
+    // Spokes are NOT admins — admin-bypass downstream paths shouldn't apply
+    const tpsAgentIsAdmin = false;
+    expect(tpsAgentIsAdmin).toBe(false);
+  });
+
+  test("header sets x-tps-spoke and tpsAgent correctly", () => {
+    const instanceId = "spoke-alpha-1";
+    const tpsAgent = `spoke-${instanceId}`;
+    expect(tpsAgent).toBe("spoke-spoke-alpha-1");
+  });
+});
+
+// ─── Nonce namespace isolation ─────────────────────────────────────────────
+
+describe("nonce namespace isolation (spoke vs agent)", () => {
+  test("spoke and agent nonce keys don't collide", () => {
+    // An agent nonce key is `${agentId}:${nonce}`
+    // A spoke nonce key is `spoke:${instanceId}:${nonce}`
+    const agentKey = "flint:abc123";
+    const spokeKey = "spoke:spoke-alpha-1:abc123";
+    expect(agentKey).not.toBe(spokeKey);
+  });
+
+  test("nonce expiry cleans up old entries", () => {
+    const nonceSeen = new Map<string, number>();
+    const now = Date.now();
+
+    nonceSeen.set("spoke:spoke-alpha:abc", now - 60_000); // expired
+    nonceSeen.set("spoke:spoke-alpha:def", now); // fresh
+
+    // Simulate cleanup loop
+    for (const [k, sigTs] of nonceSeen.entries()) {
+      if (now - sigTs > WINDOW_MS) nonceSeen.delete(k);
+    }
+
+    expect(nonceSeen.has("spoke:spoke-alpha:abc")).toBe(false);
+    expect(nonceSeen.has("spoke:spoke-alpha:def")).toBe(true);
+  });
+});
+
+// ─── Edge cases ─────────────────────────────────────────────────────────────
+
+describe("Path 5 edge cases", () => {
+  test("non-numeric timestamp in header → 401", () => {
+    const header = "TPS-Ed25519 spoke-alpha:NaN:nonce:sig";
+    const match = header.match(/^TPS-Ed25519\s+([^:]+):(\d+):([^:]+):(.+)$/);
+    expect(match).toBeNull(); // regex rejects non-digit ts
+  });
+
+  test("missing TPS-Ed25519 header on /FederationSync falls through to 401", () => {
+    const header = "Bearer some-token";
+    const url = { pathname: "/FederationSync" };
+
+    // Path 5 tries the regex match on TPS-Ed25519...
+    const tpsMatch = header.match(/^TPS-Ed25519\s+([^:]+):(\d+):([^:]+):(.+)$/);
+    const isTpsEd25519 = tpsMatch !== null;
+    expect(isTpsEd25519).toBe(false);
+
+    // So Path 5 doesn't intercept, it falls through to the Ed25519 agent auth
+    // which will also fail to match, returning missing_or_invalid_authorization
+  });
+
+  test("signature verification with tampered message fails", () => {
+    const kp = nacl.sign.keyPair();
+    const instanceId = "spoke-alpha-1";
+    const publicKeyB64url = Buffer.from(kp.publicKey).toString("base64url");
+
+    const now = Date.now();
+    const nonce = "nonce-tampered";
+    // Signer computed signature over POST:/FederationSync
+    const originalMsg = `${instanceId}:${now}:${nonce}:POST:/FederationSync`;
+    const sig = nacl.sign.detached(Buffer.from(originalMsg, "utf-8"), kp.secretKey);
+    const sigB64 = Buffer.from(sig).toString("base64");
+
+    // Verifier checks against DELETE:/FederationSync (tampered method)
+    const tamperedMsg = `${instanceId}:${now}:${nonce}:DELETE:/FederationSync`;
+    const valid = nacl.sign.detached.verify(
+      Buffer.from(tamperedMsg, "utf-8"),
+      Buffer.from(sigB64, "base64"),
+      Buffer.from(publicKeyB64url, "base64url"),
+    );
+    expect(valid).toBe(false);
+  });
+
+  test("peer with status=disconnected but role=spoke is allowed", () => {
+    // disconnected != revoked — only revoked is blocked
+    const peer = { id: "spoke-alpha-1", publicKey: "pk", role: "spoke", status: "disconnected" };
+    const isRejected = !peer || peer.status === "revoked" || peer.role !== "spoke";
+    expect(isRejected).toBe(false);
+  });
+
+  test("peer with status=paired and role=spoke is allowed", () => {
+    const peer = { id: "spoke-alpha-1", publicKey: "pk", role: "spoke", status: "paired" };
+    const isRejected = !peer || peer.status === "revoked" || peer.role !== "spoke";
+    expect(isRejected).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Adds a new auth path (Path 5) to `resources/auth-middleware.ts` that authenticates federation spoke instances using their existing Ed25519 keypair — the same one used to sign pair body signatures. No new credential required.

## Problem

Federation sync 401s because the wire-level auth model doesn't match the platform gate. Pair requests work via bootstrap-user Basic auth, but sync needs a persistent model. The spoke already has an Ed25519 keypair; the Peer table already stores the pinned publicKey.

## Implementation

- **Removes `/FederationSync` from the public allowlist** — requests must now present valid auth to reach the FederationSync resource
- **Path 5: spoke instance Ed25519 auth** — restricted to `/FederationSync` only:
  - Parses `TPS-Ed25519 <instanceId>:<ts>:<nonce>:<sig>` header
  - Validates timestamp within ±30s window
  - Nonce dedup with namespaced keys (`spoke:<instanceId>:<nonce>`) to avoid collision with agent Ed25519 nonces
  - Looks up spoke in Peer table; rejects revoked, missing, or non-spoke peers
  - Verifies signature via `nacl.sign.detached.verify` against the pinned `publicKey`
  - Sets a synthetic Harper user (`flair_sync_initiator`) so downstream layers see `request.user` as truthy
  - `tpsAgentIsAdmin` is always `false` — spokes are not admins
  - Sets `x-tps-spoke` header for downstream resource identification

## Tests (`test/unit/auth-middleware-spoke-sync.test.ts`)

18 tests using the simulator pattern consistent with existing tests:

- ✅ Valid TPS-Ed25519 from paired spoke on /FederationSync → accepted, user set
- ✅ Invalid signature (wrong keypair) → 401
- ✅ Revoked peer (`status=revoked`) → 401
- ✅ Unknown instance ID (not in Peer table) → 401
- ✅ Path restriction: same valid header on /Memory → falls through
- ✅ Stale timestamp (>30s old) → 401
- ✅ Future timestamp (>30s ahead) → 401
- ✅ Replayed nonce → 401
- ✅ Hub peer attempting spoke Ed25519 (`role !== "spoke"`) → 401
- ✅ `tpsAgentIsAdmin` always false
- ✅ Nonce namespace isolation (spoke vs agent keys don't collide)
- ✅ Nonce expiry cleanup
- ✅ Edge cases: non-numeric timestamp, tampered messages, disconnected-but-not-revoked peers

## Out of scope for this PR

- CLI changes to send TPS-Ed25519 on sync → PR-B
- Documentation → PR-C

## Security notes

- **Path-restricted**: spoke Ed25519 cannot be used on any endpoint other than `/FederationSync`. The path check is `url.pathname === "/FederationSync"` — any other path falls through.
- **Namespaced nonces**: `spoke:<instanceId>:<nonce>` prefix avoids collision with agent Ed25519 (`<agentId>:<nonce>`)
- **Admin separation**: `tpsAgentIsAdmin = false` — admin-bypass downstream paths do not apply to spokes
- **No mutation of existing agent Ed25519 path**: Path 5 is entirely additive

---

Part of PR series: PR-A (this) → PR-B (CLI changes) → PR-C (docs)