### PR TITLE
fix(flair-client): typed request + result narrowing (release-blocker)

### DIFF
--- a/packages/flair-client/src/client.ts
+++ b/packages/flair-client/src/client.ts
@@ -248,9 +248,9 @@ class MemoryApi {
     };
     if (opts.limit) body.limit = opts.limit;
 
-    const result = await this.client.request("POST", "/Memory/search_by_conditions", body);
+    const result = await this.client.request<unknown>("POST", "/Memory/search_by_conditions", body);
     // search_by_conditions returns either an array or { results: [...] }
-    const memories: Memory[] = Array.isArray(result) ? result : (result?.results ?? []);
+    const memories: Memory[] = Array.isArray(result) ? result : ((result as { results?: Memory[] })?.results ?? []);
 
     // Client-side sort (Harper's search_by_conditions does not accept sort in body)
     if (opts.order) {


### PR DESCRIPTION
## Summary

Strict tsc (release flow) caught a property access on `{}` at line 253 of flair-client/src/client.ts. The daily build (`tsc --noCheck`) was masking it.

```
src/client.ts:253:74 - error TS2339: Property 'results' does not exist on type '{}'.
```

Pass an explicit type parameter to client.request() and narrow via type assertion when reading the body. Pattern matches line 178 (which already does this correctly).

## Why this is a release-blocker

`./scripts/release.sh 0.7.1` ran `npm run build` for the workspace which invokes flair-client's `tsc` (strict, no --noCheck). Build failed → release blocked.

## Systemic followup

The daily build uses `--noCheck` which skips type checking entirely. Type errors only surface at release time. Worth filing as ops-NEW: enable a strict-tsc CI job that runs without --noCheck so this class of error fails fast at PR-time, not on release-day.

## Test plan

- [x] `cd packages/flair-client && npx tsc` passes locally
- [x] Pattern matches existing line 178 (no new shape)