### PR TITLE
release: v0.7.1

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -24,20 +24,20 @@
     },
     "packages/flair-client": {
       "name": "@tpsdev-ai/flair-client",
-      "version": "0.7.0",
+      "version": "0.7.1",
       "devDependencies": {
         "typescript": "5.9.3",
       },
     },
     "packages/flair-mcp": {
       "name": "@tpsdev-ai/flair-mcp",
-      "version": "0.7.0",
+      "version": "0.7.1",
       "bin": {
         "flair-mcp": "dist/index.js",
       },
       "dependencies": {
         "@modelcontextprotocol/sdk": "1.27.1",
-        "@tpsdev-ai/flair-client": "0.7.0",
+        "@tpsdev-ai/flair-client": "0.7.1",
         "zod": "4.3.6",
       },
       "devDependencies": {
@@ -46,7 +46,7 @@
     },
     "packages/n8n-nodes-flair": {
       "name": "@tpsdev-ai/n8n-nodes-flair",
-      "version": "0.1.0",
+      "version": "0.7.1",
       "dependencies": {
         "@tpsdev-ai/flair-client": "0.7.0",
         "zod": "3.25.76",
@@ -79,7 +79,7 @@
     },
     "packages/pi-flair": {
       "name": "@tpsdev-ai/pi-flair",
-      "version": "0.7.0",
+      "version": "0.7.1",
       "dependencies": {
         "@sinclair/typebox": "0.34.48",
         "@tpsdev-ai/flair-client": "0.7.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tpsdev-ai/flair",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "Identity, memory, and soul for AI agents. Cryptographic identity (Ed25519), semantic memory with local embeddings, and persistent personality — all in a single process.",
   "type": "module",
   "license": "Apache-2.0",

--- a/packages/flair-client/package.json
+++ b/packages/flair-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tpsdev-ai/flair-client",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "Lightweight client for Flair — identity, memory, and soul for AI agents. Zero heavy dependencies.",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/flair-mcp/package.json
+++ b/packages/flair-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tpsdev-ai/flair-mcp",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "MCP server for Flair — persistent memory for Claude Code, Cursor, and any MCP client.",
   "type": "module",
   "main": "dist/index.js",
@@ -25,7 +25,7 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "1.27.1",
-    "@tpsdev-ai/flair-client": "0.7.0",
+    "@tpsdev-ai/flair-client": "0.7.1",
     "zod": "4.3.6"
   },
   "license": "Apache-2.0",

--- a/packages/n8n-nodes-flair/package.json
+++ b/packages/n8n-nodes-flair/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tpsdev-ai/n8n-nodes-flair",
-  "version": "0.1.0",
+  "version": "0.7.1",
   "description": "n8n community node — use Flair as your AI Agent's memory backend. Includes FlairChatMemory (Memory port) and FlairSearch (Tool port).",
   "type": "commonjs",
   "main": "dist/index.js",
@@ -47,7 +47,7 @@
     "langchain"
   ],
   "dependencies": {
-    "@tpsdev-ai/flair-client": "0.7.0",
+    "@tpsdev-ai/flair-client": "0.7.1",
     "zod": "3.25.76"
   },
   "peerDependencies": {

--- a/packages/pi-flair/package.json
+++ b/packages/pi-flair/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tpsdev-ai/pi-flair",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "Flair memory extension for pi — persistent memory access from within pi sessions",
   "type": "module",
   "main": "dist/index.js",
@@ -21,7 +21,7 @@
     "node": ">=18"
   },
   "dependencies": {
-    "@tpsdev-ai/flair-client": "0.7.0",
+    "@tpsdev-ai/flair-client": "0.7.1",
     "@sinclair/typebox": "0.34.48"
   },
   "license": "Apache-2.0",

--- a/test/unit/federation-pair-role.test.ts
+++ b/test/unit/federation-pair-role.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, mock, beforeEach } from "bun:test";
+import { describe, it, expect, mock, beforeEach, afterEach } from "bun:test";
 import { ensureFlairPairInitiatorRole } from "../../src/cli";
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
@@ -50,8 +50,17 @@ describe("ensureFlairPairInitiatorRole", () => {
   // Track which operations were sent to the mock ops API
   let capturedBodies: Array<Record<string, unknown>> = [];
 
+  // Save the original fetch so we can restore it after each test. Without this,
+  // the mock leaks to subsequent test files and breaks integration tests that
+  // need real fetch (manifests as "Unexpected fetch call #N" against Harper).
+  const origFetch = globalThis.fetch;
+
   beforeEach(() => {
     capturedBodies = [];
+  });
+
+  afterEach(() => {
+    globalThis.fetch = origFetch;
   });
 
   /**


### PR DESCRIPTION
Version bump across workspace packages to v0.7.1.

Includes one test-only release-blocker fix (`test: restore global fetch in federation-pair-role afterEach`).

## What's in this release (since v0.7.0)
- **#358** fix: make memory dedup signal explicit (P0 silent data loss fix)
- **#359** feat(auth): Path 5 — spoke Ed25519 auth for /FederationSync
- **#360** feat(cli): send TPS-Ed25519 Authorization on /FederationSync
- **#361** feat(federation): replay-safe body signatures + FederationSync allowCreate=true
- **#363** feat(cli): chunked sync to handle large catch-up payloads
- **#364** fix(flair-client): typed request + result narrowing on search_by_conditions (release-blocker)
- **#365** ci: add strict type-check job for root CLI and workspace packages
- This PR: test fix for global fetch leak that was blocking local release runs

After CI is green and this is merged:
```
git checkout main && git pull
./scripts/release.sh 0.7.1 --publish
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)