### PR TITLE
release: v0.8.0 — Harper 5.0.9 upgrade migration (BREAKING)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -292,6 +292,12 @@ jobs:
           STATUS=$($FLAIR status --port $PORT); echo "$STATUS"
           echo "$STATUS" | grep -q "running" || { echo "FAIL: HEAD didn't start after upgrade from $BASELINE"; exit 1; }
 
+          # 4a. Run the documented post-upgrade migration: re-embed all memories
+          # so their stored vectors match the running Harper version's expected
+          # shape. Required when bumping @harperfast/harper across versions where
+          # HNSW storage internals changed (e.g. 5.0.1 → 5.0.9). See CHANGELOG.
+          $FLAIR reembed --port $PORT
+
           # 5. Pre-upgrade memory must still be readable (the core regression guard)
           POST=$($FLAIR memory search --agent upgrade --q "upgrade-smoke-pre-marker")
           echo "$POST"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,43 @@
 # Changelog
 
+## 0.8.0 (2026-05-07) — BREAKING
+
+### ⚠️ Required migration: `flair reembed` after upgrade from 0.7.x
+
+**If you have existing Flair data written by `@tpsdev-ai/flair@0.7.x`, run `flair reembed` once after upgrading to 0.8.0 before semantic search will work.**
+
+```sh
+# 1. Stop your old install
+flair stop
+
+# 2. Install 0.8.0
+npm install -g @tpsdev-ai/flair@0.8.0
+
+# 3. Start against your existing data dir
+flair start
+
+# 4. Re-encode every memory's embedding so it matches the new index format
+FLAIR_ADMIN_PASS=<your-admin-pass> flair reembed
+```
+
+Why: 0.8.0 ships with `@harperfast/harper@5.0.9` (was 5.0.1 in 0.7.x). Harper's HNSW vector-index storage internals changed across that version range, and embeddings written under 5.0.1 come back in a shape that 5.0.9's cosine path rejects (`Cosine distance comparison requires an array`). `flair reembed` re-computes every memory's embedding via the running version's pipeline and writes it back through the proper PUT path — one-time, idempotent, takes ~30s for 500 memories.
+
+Zero-data-loss: contents, durability, retrieval counts, and all other fields are preserved. Only the stored embedding column is rebuilt. New writes after 0.8.0 work without migration.
+
+Per the pre-1.0 versioning policy, this minor bump is breaking on purpose.
+
+### 🐛 Bug Fixes
+
+- **`flair reembed` no longer hits `/SemanticSearch` to enumerate memories.** The previous implementation called the very endpoint that breaks during a Harper upgrade, so it couldn't recover from the condition it was meant to fix. Now uses the Harper ops API directly (`search_by_conditions` on `flair.Memory`) so the migration path works even when the vector index is in an incompatible state.
+
+- **`flair reembed --agent <id>` also bypasses `/SemanticSearch` when an admin pass is available.** Falls back to the auth-fetch SemanticSearch path only when no admin pass is set (compatible with version-matched data).
+
+### 🛠 CI
+
+- **`Upgrade from npm-stable` job now runs `flair reembed` after upgrade**, mirroring the documented migration. Catches storage-format breakage at PR time instead of release-time.
+
+- **`test/unit/federation-pair-role.test.ts` restores `globalThis.fetch` in `afterEach`** — the previous mock leaked into integration tests, masquerading as Harper-unhealthy timeouts when running the full suite.
+
 ## Unreleased
 
 ### 🛠 Chores

--- a/bun.lock
+++ b/bun.lock
@@ -24,20 +24,20 @@
     },
     "packages/flair-client": {
       "name": "@tpsdev-ai/flair-client",
-      "version": "0.7.0",
+      "version": "0.7.1",
       "devDependencies": {
         "typescript": "5.9.3",
       },
     },
     "packages/flair-mcp": {
       "name": "@tpsdev-ai/flair-mcp",
-      "version": "0.7.0",
+      "version": "0.7.1",
       "bin": {
         "flair-mcp": "dist/index.js",
       },
       "dependencies": {
         "@modelcontextprotocol/sdk": "1.27.1",
-        "@tpsdev-ai/flair-client": "0.7.0",
+        "@tpsdev-ai/flair-client": "0.7.1",
         "zod": "4.3.6",
       },
       "devDependencies": {
@@ -46,7 +46,7 @@
     },
     "packages/n8n-nodes-flair": {
       "name": "@tpsdev-ai/n8n-nodes-flair",
-      "version": "0.1.0",
+      "version": "0.7.1",
       "dependencies": {
         "@tpsdev-ai/flair-client": "0.7.0",
         "zod": "3.25.76",
@@ -79,7 +79,7 @@
     },
     "packages/pi-flair": {
       "name": "@tpsdev-ai/pi-flair",
-      "version": "0.7.0",
+      "version": "0.7.1",
       "dependencies": {
         "@sinclair/typebox": "0.34.48",
         "@tpsdev-ai/flair-client": "0.7.0",

--- a/bun.lock
+++ b/bun.lock
@@ -24,20 +24,20 @@
     },
     "packages/flair-client": {
       "name": "@tpsdev-ai/flair-client",
-      "version": "0.7.1",
+      "version": "0.8.0",
       "devDependencies": {
         "typescript": "5.9.3",
       },
     },
     "packages/flair-mcp": {
       "name": "@tpsdev-ai/flair-mcp",
-      "version": "0.7.1",
+      "version": "0.8.0",
       "bin": {
         "flair-mcp": "dist/index.js",
       },
       "dependencies": {
         "@modelcontextprotocol/sdk": "1.27.1",
-        "@tpsdev-ai/flair-client": "0.7.1",
+        "@tpsdev-ai/flair-client": "0.8.0",
         "zod": "4.3.6",
       },
       "devDependencies": {
@@ -46,7 +46,7 @@
     },
     "packages/n8n-nodes-flair": {
       "name": "@tpsdev-ai/n8n-nodes-flair",
-      "version": "0.7.1",
+      "version": "0.8.0",
       "dependencies": {
         "@tpsdev-ai/flair-client": "0.7.0",
         "zod": "3.25.76",
@@ -65,7 +65,7 @@
     },
     "packages/openclaw-flair": {
       "name": "@tpsdev-ai/openclaw-flair",
-      "version": "0.7.1",
+      "version": "0.8.0",
       "dependencies": {
         "@sinclair/typebox": "0.34.48",
         "@tpsdev-ai/flair-client": "0.5.0",
@@ -79,7 +79,7 @@
     },
     "packages/pi-flair": {
       "name": "@tpsdev-ai/pi-flair",
-      "version": "0.7.1",
+      "version": "0.8.0",
       "dependencies": {
         "@sinclair/typebox": "0.34.48",
         "@tpsdev-ai/flair-client": "0.7.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tpsdev-ai/flair",
-  "version": "0.7.1",
+  "version": "0.8.0",
   "description": "Identity, memory, and soul for AI agents. Cryptographic identity (Ed25519), semantic memory with local embeddings, and persistent personality — all in a single process.",
   "type": "module",
   "license": "Apache-2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tpsdev-ai/flair",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "Identity, memory, and soul for AI agents. Cryptographic identity (Ed25519), semantic memory with local embeddings, and persistent personality — all in a single process.",
   "type": "module",
   "license": "Apache-2.0",

--- a/packages/flair-client/package.json
+++ b/packages/flair-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tpsdev-ai/flair-client",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "Lightweight client for Flair — identity, memory, and soul for AI agents. Zero heavy dependencies.",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/flair-client/package.json
+++ b/packages/flair-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tpsdev-ai/flair-client",
-  "version": "0.7.1",
+  "version": "0.8.0",
   "description": "Lightweight client for Flair — identity, memory, and soul for AI agents. Zero heavy dependencies.",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/flair-mcp/package.json
+++ b/packages/flair-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tpsdev-ai/flair-mcp",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "MCP server for Flair — persistent memory for Claude Code, Cursor, and any MCP client.",
   "type": "module",
   "main": "dist/index.js",
@@ -25,7 +25,7 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "1.27.1",
-    "@tpsdev-ai/flair-client": "0.7.0",
+    "@tpsdev-ai/flair-client": "0.7.1",
     "zod": "4.3.6"
   },
   "license": "Apache-2.0",

--- a/packages/flair-mcp/package.json
+++ b/packages/flair-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tpsdev-ai/flair-mcp",
-  "version": "0.7.1",
+  "version": "0.8.0",
   "description": "MCP server for Flair — persistent memory for Claude Code, Cursor, and any MCP client.",
   "type": "module",
   "main": "dist/index.js",
@@ -25,7 +25,7 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "1.27.1",
-    "@tpsdev-ai/flair-client": "0.7.1",
+    "@tpsdev-ai/flair-client": "0.8.0",
     "zod": "4.3.6"
   },
   "license": "Apache-2.0",

--- a/packages/n8n-nodes-flair/package.json
+++ b/packages/n8n-nodes-flair/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tpsdev-ai/n8n-nodes-flair",
-  "version": "0.7.1",
+  "version": "0.8.0",
   "description": "n8n community node — use Flair as your AI Agent's memory backend. Includes FlairChatMemory (Memory port) and FlairSearch (Tool port).",
   "type": "commonjs",
   "main": "dist/index.js",
@@ -47,7 +47,7 @@
     "langchain"
   ],
   "dependencies": {
-    "@tpsdev-ai/flair-client": "0.7.1",
+    "@tpsdev-ai/flair-client": "0.8.0",
     "zod": "3.25.76"
   },
   "peerDependencies": {

--- a/packages/n8n-nodes-flair/package.json
+++ b/packages/n8n-nodes-flair/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tpsdev-ai/n8n-nodes-flair",
-  "version": "0.1.0",
+  "version": "0.7.1",
   "description": "n8n community node — use Flair as your AI Agent's memory backend. Includes FlairChatMemory (Memory port) and FlairSearch (Tool port).",
   "type": "commonjs",
   "main": "dist/index.js",
@@ -47,7 +47,7 @@
     "langchain"
   ],
   "dependencies": {
-    "@tpsdev-ai/flair-client": "0.7.0",
+    "@tpsdev-ai/flair-client": "0.7.1",
     "zod": "3.25.76"
   },
   "peerDependencies": {

--- a/packages/openclaw-flair/package.json
+++ b/packages/openclaw-flair/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tpsdev-ai/openclaw-flair",
-  "version": "0.7.1",
+  "version": "0.8.0",
   "description": "OpenClaw memory plugin for Flair — agent identity and semantic memory",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/pi-flair/package.json
+++ b/packages/pi-flair/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tpsdev-ai/pi-flair",
-  "version": "0.7.1",
+  "version": "0.8.0",
   "description": "Flair memory extension for pi — persistent memory access from within pi sessions",
   "type": "module",
   "main": "dist/index.js",
@@ -21,7 +21,7 @@
     "node": ">=18"
   },
   "dependencies": {
-    "@tpsdev-ai/flair-client": "0.7.1",
+    "@tpsdev-ai/flair-client": "0.8.0",
     "@sinclair/typebox": "0.34.48"
   },
   "license": "Apache-2.0",

--- a/packages/pi-flair/package.json
+++ b/packages/pi-flair/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tpsdev-ai/pi-flair",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "Flair memory extension for pi — persistent memory access from within pi sessions",
   "type": "module",
   "main": "dist/index.js",
@@ -21,7 +21,7 @@
     "node": ">=18"
   },
   "dependencies": {
-    "@tpsdev-ai/flair-client": "0.7.0",
+    "@tpsdev-ai/flair-client": "0.7.1",
     "@sinclair/typebox": "0.34.48"
   },
   "license": "Apache-2.0",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -5231,21 +5231,40 @@ program
         process.exit(1);
       }
 
-      // Fetch all memories with admin auth
-      const searchRes = await fetch(`${baseUrl}/SemanticSearch`, {
+      // Fetch every memory via the Harper ops API (search_by_conditions on the
+      // Memory table) rather than POST /SemanticSearch. SemanticSearch goes
+      // through the HNSW cosine index, which throws "Cosine distance comparison
+      // requires an array" against rows whose stored embedding shape is
+      // incompatible with the running Harper version (e.g. data written under
+      // @harperfast/harper@5.0.1 read under 5.0.9). The ops API bypasses the
+      // vector index — exactly what we need when the goal is to replace every
+      // embedding with a freshly-computed one. Without this path, `flair
+      // reembed` could not recover from the very condition it exists to fix.
+      const opsPort = resolveOpsPort(opts);
+      const opsAuth = `Basic ${Buffer.from(`admin:${adminPass}`).toString("base64")}`;
+      // Harper rejects empty-value conditions ("not indexed for nulls"). Use
+      // `createdAt > 1970-01-01` as the "select all" pattern: every Memory row
+      // has a createdAt, the index is built, and the comparison is total.
+      const searchRes = await fetch(`http://127.0.0.1:${opsPort}/`, {
         method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          Authorization: `Basic ${Buffer.from(`admin:${adminPass}`).toString("base64")}`,
-        },
-        body: JSON.stringify({ limit: 10000 }),
+        headers: { "Content-Type": "application/json", Authorization: opsAuth },
+        body: JSON.stringify({
+          operation: "search_by_conditions",
+          database: "flair",
+          table: "Memory",
+          operator: "and",
+          conditions: [{ search_attribute: "createdAt", search_type: "greater_than", search_value: "1970-01-01" }],
+          get_attributes: ["*"],
+          limit: 100000,
+        }),
+        signal: AbortSignal.timeout(60_000),
       });
       if (!searchRes.ok) {
-        console.error(`❌ Failed to fetch memories: ${searchRes.status}`);
+        console.error(`❌ Failed to fetch memories via ops API: ${searchRes.status}`);
         process.exit(1);
       }
-      const data = await searchRes.json() as { results?: any[] };
-      const allMemories = data.results ?? [];
+      const raw = await searchRes.json() as unknown;
+      const allMemories: any[] = Array.isArray(raw) ? raw : ((raw as { results?: any[] })?.results ?? []);
 
       // Group by agentId
       const byAgent = new Map<string, any[]>();
@@ -5303,7 +5322,11 @@ program
       return;
     }
 
-    // Original single-agent path
+    // Single-agent path. Same rationale as above: fetch via the ops API
+    // (search_by_value on agentId) so the vector index isn't in the read path.
+    // This requires admin pass — fall back to the old SemanticSearch fetch only
+    // if no admin pass is available, since that path still works on
+    // version-matched data and requires only the agent's own key.
     const keysDir = defaultKeysDir();
     const privPath = privKeyPath(agentId, keysDir);
     if (!existsSync(privPath)) {
@@ -5311,15 +5334,41 @@ program
       process.exit(1);
     }
 
-    const searchRes = await authFetch(baseUrl, agentId, privPath, "POST", "/SemanticSearch", {
-      agentId, limit: 10000,
-    });
-    if (!searchRes.ok) {
-      console.error(`❌ Failed to fetch memories: ${searchRes.status}`);
-      process.exit(1);
+    const adminPassSingle = process.env.FLAIR_ADMIN_PASS ?? process.env.HDB_ADMIN_PASSWORD;
+    let allMemories: any[] = [];
+    if (adminPassSingle) {
+      const opsPort = resolveOpsPort(opts);
+      const opsAuth = `Basic ${Buffer.from(`admin:${adminPassSingle}`).toString("base64")}`;
+      const searchRes = await fetch(`http://127.0.0.1:${opsPort}/`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json", Authorization: opsAuth },
+        body: JSON.stringify({
+          operation: "search_by_value",
+          database: "flair",
+          table: "Memory",
+          search_attribute: "agentId",
+          search_value: agentId,
+          get_attributes: ["*"],
+        }),
+        signal: AbortSignal.timeout(60_000),
+      });
+      if (!searchRes.ok) {
+        console.error(`❌ Failed to fetch memories via ops API: ${searchRes.status}`);
+        process.exit(1);
+      }
+      const raw = await searchRes.json() as unknown;
+      allMemories = Array.isArray(raw) ? raw : ((raw as { results?: any[] })?.results ?? []);
+    } else {
+      const searchRes = await authFetch(baseUrl, agentId, privPath, "POST", "/SemanticSearch", {
+        agentId, limit: 10000,
+      });
+      if (!searchRes.ok) {
+        console.error(`❌ Failed to fetch memories: ${searchRes.status}`);
+        process.exit(1);
+      }
+      const data = await searchRes.json() as { results?: any[] };
+      allMemories = data.results ?? [];
     }
-    const data = await searchRes.json() as { results?: any[] };
-    const allMemories = data.results ?? [];
 
     const candidates = allMemories.filter((m: any) => {
       if (!m.content) return false;

--- a/test/unit/federation-pair-role.test.ts
+++ b/test/unit/federation-pair-role.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, mock, beforeEach } from "bun:test";
+import { describe, it, expect, mock, beforeEach, afterEach } from "bun:test";
 import { ensureFlairPairInitiatorRole } from "../../src/cli";
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
@@ -50,8 +50,17 @@ describe("ensureFlairPairInitiatorRole", () => {
   // Track which operations were sent to the mock ops API
   let capturedBodies: Array<Record<string, unknown>> = [];
 
+  // Save the original fetch so we can restore it after each test. Without this,
+  // the mock leaks to subsequent test files and breaks integration tests that
+  // need real fetch (manifests as "Unexpected fetch call #N" against Harper).
+  const origFetch = globalThis.fetch;
+
   beforeEach(() => {
     capturedBodies = [];
+  });
+
+  afterEach(() => {
+    globalThis.fetch = origFetch;
   });
 
   /**


### PR DESCRIPTION
**Replaces #366. Bumped from 0.7.1 → 0.8.0 because 0.7.x → 0.8.0 is a breaking storage-format change.**

## What's breaking

Existing 0.7.x users must run `flair reembed` once after upgrade to re-encode their stored embeddings into the new HNSW index format. Without it, semantic search returns `Cosine distance comparison requires an array`. Full migration steps in CHANGELOG.

## Why this jump exists

When the version was bumped from 0.7.0 → 0.7.1, the `Upgrade from npm-stable` CI job actually exercised the upgrade flow for the first time since v0.7.0 (every prior PR trivially-passed since baseline == HEAD). It surfaced that data written by `@harperfast/harper@5.0.1` (shipped in 0.7.0) is unreadable by the cosine path in 5.0.9 (bumped in #347 on May 4, untested by upgrade-smoke until now).

Per Nathan's pre-1.0 policy: minor bumps are breaking. This is deliberate.

## What's in this release vs 0.7.0

- **#358** fix: make memory dedup signal explicit (P0 silent data loss fix)
- **#359** feat(auth): Path 5 — spoke Ed25519 auth for /FederationSync
- **#360** feat(cli): send TPS-Ed25519 Authorization on /FederationSync
- **#361** feat(federation): replay-safe body signatures + FederationSync allowCreate
- **#363** feat(cli): chunked sync for large catch-up payloads
- **#364** fix(flair-client): typed request + result narrowing (release-blocker)
- **#365** ci: strict TypeScript type-check job
- **This PR**:
  - `flair reembed` now uses the Harper ops API instead of `/SemanticSearch` to enumerate memories — works during a Harper upgrade where the cosine path is broken
  - `Upgrade from npm-stable` CI job runs `flair reembed` after upgrade to mirror the documented migration
  - `test/unit/federation-pair-role.test.ts` restores `globalThis.fetch` in `afterEach` (was leaking the mock into integration tests)
  - Version aligned to 0.8.0 across all workspace packages

## After CI green + merge

```sh
git checkout main && git pull
./scripts/release.sh 0.8.0 --publish
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)