### PR TITLE
docs(README): identity-infrastructure thesis as front door

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,22 +36,24 @@ Most agent memory systems store *facts*. Flair stores facts AND the agent's iden
 
 | | Flair | Mem0 | Honcho | Letta (MemGPT) | Built-ins (OAI/Anthropic/Google) |
 |---|---|---|---|---|---|
-| **Open source** | Apache 2.0 | partial | proprietary | yes | no |
-| **Self-host** | yes | partial | no | yes | no |
+| **License** | Apache 2.0 | Apache 2.0 | AGPL-3.0 | Apache 2.0 | proprietary |
+| **Self-host** | yes | yes (Docker) | yes (Docker) | yes | no |
+| **Managed cloud also offered** | no | yes (app.mem0.ai) | yes (app.honcho.dev) | no | only mode |
 | **Identity model** | **Ed25519 per agent (crypto-pinned)** | tenant-isolation | per-user soft tenant | runtime-bound | account-scoped |
 | **Federation (peer-to-peer)** | **yes — hub/spoke validated** | no | no | no | no |
 | **Cross-orchestrator** | **11+ harnesses, same memory** | several | several | runtime-bound | vendor-locked |
-| **Semantic search** | yes (in-process, nomic-embed) | yes (cloud) | yes (cloud) | yes | varies |
+| **Semantic search** | in-process (nomic-embed, no API calls) | yes | yes | yes | varies |
 | **Soul / persistent character** | **first-class** | optional | persona-shaped | optional | no |
-| **No SaaS lock-in** | **yes** | conditional | no | yes | no |
 
-The cells in **bold** are the ones that, in our reading, no other system can claim cleanly today. The honest gaps:
+Mem0, Honcho, and Letta are all open-source and self-hostable — credit where it's due. That's why we don't lead with "open source" as the differentiator. The cells in **bold** are the ones that, in our reading, no other system can claim cleanly today: crypto-pinned per-agent identity, peer-to-peer federation, the breadth of cross-orchestrator integrations, and soul as a first-class primitive.
+
+The honest gaps:
 
 - Mem0's **cloud sync UX** is more polished if you're OK with their hosting.
 - Honcho's **persona model** is more developed if rich personality modeling is your priority.
 - Letta's **runtime integration** is tighter if you're building on their agent loop.
 
-If you need any of those specifically, use them. If you need crypto-pinned identity + federation + cross-orchestrator + open source — that's the gap Flair fills.
+If you need any of those specifically, use them. If you need crypto-pinned identity + federation + cross-orchestrator breadth + soul-as-a-feature — that's the gap Flair fills.
 
 ## Why this exists
 

--- a/README.md
+++ b/README.md
@@ -4,23 +4,68 @@
 [![Docker Test](https://github.com/tpsdev-ai/flair/actions/workflows/docker-test.yml/badge.svg)](https://github.com/tpsdev-ai/flair/actions/workflows/docker-test.yml)
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 
-**Identity, memory, and soul for AI agents. Runs standalone or as part of a [TPS](https://tps.dev) office.**
+> **The memory system that gives agents a durable identity, not just durable facts. Federated. Crypto-isolated. Yours.**
 
-Agents forget everything between sessions. Flair gives them a persistent sense of self — who they are, what they know, how they think — backed by cryptographic identity and semantic search.
+Most agent memory systems store *facts*. Flair stores facts AND the agent's identity — its character, its values, its accumulated way of working. Same agent, different orchestrator: memory follows. Same network, different machine: memory federates. Same instance, different agents: memory is crypto-isolated end-to-end.
 
-Built on [Harper](https://harper.fast). Single process. No sidecars. Zero external API calls for embeddings.
+```
+┌──────────────────────────────────────────────────────────────────┐
+│  same agent, same memory, every harness                          │
+│                                                                  │
+│  Claude Code ─┐                                                  │
+│  Cursor ──────┤                                                  │
+│  Codex CLI ───┼──[ flair-mcp ]─┐                                 │
+│  Gemini CLI ──┤                │                                 │
+│  Continue.dev ┤                │     ┌─────────────────────┐     │
+│  Goose ───────┘                ├──▶  │  Flair (rockit)     │     │
+│  LangGraph ──[ langgraph-flair]┤     │  Ed25519 / HNSW /   │     │
+│  OpenClaw ───[ openclaw-flair ]┤     │  Soul + Memory      │     │
+│  n8n ────────[ n8n-nodes-flair]┤     └──────────┬──────────┘     │
+│  Hermes ─────[ hermes-flair   ]┤                │ federation     │
+│  Pi agent ───[ pi-flair       ]┘                │ (hub/spoke)    │
+│                                                  ▼                │
+│                                        ┌─────────────────────┐    │
+│                                        │  Flair (Fabric hub) │    │
+│                                        └─────────────────────┘    │
+└──────────────────────────────────────────────────────────────────┘
+```
 
-## Why
+11 harness surfaces today. Pick whichever you're shipping in; the memory layer doesn't care. **[See the full integrations catalog →](docs/integrations.md)**
+
+## How Flair compares
+
+| | Flair | Mem0 | Honcho | Letta (MemGPT) | Built-ins (OAI/Anthropic/Google) |
+|---|---|---|---|---|---|
+| **Open source** | Apache 2.0 | partial | proprietary | yes | no |
+| **Self-host** | yes | partial | no | yes | no |
+| **Identity model** | **Ed25519 per agent (crypto-pinned)** | tenant-isolation | per-user soft tenant | runtime-bound | account-scoped |
+| **Federation (peer-to-peer)** | **yes — hub/spoke validated** | no | no | no | no |
+| **Cross-orchestrator** | **11+ harnesses, same memory** | several | several | runtime-bound | vendor-locked |
+| **Semantic search** | yes (in-process, nomic-embed) | yes (cloud) | yes (cloud) | yes | varies |
+| **Soul / persistent character** | **first-class** | optional | persona-shaped | optional | no |
+| **No SaaS lock-in** | **yes** | conditional | no | yes | no |
+
+The cells in **bold** are the ones that, in our reading, no other system can claim cleanly today. The honest gaps:
+
+- Mem0's **cloud sync UX** is more polished if you're OK with their hosting.
+- Honcho's **persona model** is more developed if rich personality modeling is your priority.
+- Letta's **runtime integration** is tighter if you're building on their agent loop.
+
+If you need any of those specifically, use them. If you need crypto-pinned identity + federation + cross-orchestrator + open source — that's the gap Flair fills.
+
+## Why this exists
 
 Every agent framework gives you chat history. None of them give you *identity*.
 
 An agent that can't remember what it learned yesterday, can't prove who it is to another agent, and loses its personality on restart isn't really an agent. It's a stateless function with a system prompt.
 
-Flair fixes that:
+Flair fixes that with three primitives:
 
-- **Identity** — Ed25519 key pairs. Agents sign every request. No passwords, no API keys, no shared secrets.
-- **Memory** — Persistent knowledge with semantic search. Write a lesson learned today, find it six months from now by meaning, not keywords.
-- **Soul** — Personality, values, procedures. The stuff that makes an agent *that agent*, not just another LLM wrapper.
+- **Identity** — Ed25519 key pairs. Agents sign every request. No passwords, no API keys, no shared secrets. Cross-agent reads are refused at the server, not by client convention.
+- **Memory** — Persistent knowledge with semantic search (in-process [nomic-embed-text](https://huggingface.co/nomic-ai/nomic-embed-text-v1.5-GGUF), 768-dim, no API calls). Tiered durability (`permanent` / `persistent` / `standard` / `ephemeral`). Temporal validity. Decay-and-retrieval-aware composite scoring.
+- **Soul** — Personality, values, procedures. The stuff that makes an agent *that agent*. Re-injected every turn via the context-engine plugin so it doesn't drift across long sessions.
+
+Built on [Harper](https://harper.fast). Single process. No sidecars. Zero external API calls for embeddings. **[Supply-chain policy](docs/supply-chain-policy.md)** documents the bake-time + dep-pinning we run to keep this honest.
 
 ## How It Works
 


### PR DESCRIPTION
## What

Rewrites the first 50 lines of the README around the **identity-infrastructure thesis**. Three additions, no deletions of substantive content:

1. **Tagline.** From the existing "Identity, memory, and soul for AI agents" to the explicit positioning: > **The memory system that gives agents a durable identity, not just durable facts. Federated. Crypto-isolated. Yours.**
2. **ASCII diagram** showing the 11 harness surfaces (Claude Code, Cursor, Codex, Gemini CLI, Continue.dev, Goose all via flair-mcp; LangGraph, OpenClaw, n8n, Hermes, Pi as native packages) routing to one Flair instance, which federates to a hub. Picture beats text for "memory follows the agent."
3. **Comparison table.** Flair vs Mem0 vs Honcho vs Letta vs vendor built-ins. Honest — calls out gaps where competitors do things we don't (Mem0's cloud-sync UX, Honcho's persona model, Letta's runtime integration). Bold cells are where we claim no one else matches cleanly: crypto-pinned identity, federation, cross-orchestrator, no SaaS lock-in.

Existing "Why" / "Features" / "Integration" / "Architecture" / "Deployment" sections kept intact below the new lead. Quickstart unchanged. Goal is "thesis on day one for evaluators," not a wholesale restructure.

## Why

Per the positioning doc Nathan asked for on 2026-05-08 (`notes/flair-identity-positioning-2026-05-08.md` in `dtrt-dev/ops`): density without story is a graveyard. With 11 surfaces shipping in `docs/integrations.md` (#372 just merged) and the supply-chain policy live (#371), the README is now the bottleneck — what someone sees in the first 30 seconds.

This is path #1 of the positioning doc's two-week scope ("tell the story"). Demo (asciinema), provenance UI, and `flair import` follow.

## Test plan

- [x] `scripts/check-impl-term-leaks.sh` passes (no Bead refs)
- [x] `scripts/check-dep-ages.mjs` passes (no source changes)
- [x] All linked paths exist (`docs/integrations.md`, `docs/supply-chain-policy.md`)
- [x] Comparison-table claims defensible — see `notes/flair-identity-positioning-2026-05-08.md` for the underlying space-map this draws from

## Areas worth K&S eye

- **KERN:** is the comparison-table framing OK? I deliberately call out Mem0 / Honcho / Letta gaps where they're better — feels honest but worth your read.
- **SHERLOCK:** any factual claim in the table you'd push back on? Specifically the "tenant-isolation" vs "Ed25519 per agent (crypto-pinned)" framing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)