### PR TITLE
feat(bridges): chatgpt builtin — import a ChatGPT memory dump into Flair

### DIFF
--- a/src/bridges/builtins/chatgpt.ts
+++ b/src/bridges/builtins/chatgpt.ts
@@ -172,8 +172,8 @@ export const chatgptMemoryBridge: MemoryBridge = {
   description: "Import a ChatGPT memory dump (memory.json from an OpenAI data export) into Flair",
   options: {
     source: {
-      kind: "string",
-      description: "Path to memory.json (or to the OpenAI-export directory containing it). Required.",
+      description: "Path to memory.json (or to the OpenAI-export directory containing it).",
+      required: true,
     },
   },
   import: importChatGPT,

--- a/src/bridges/builtins/chatgpt.ts
+++ b/src/bridges/builtins/chatgpt.ts
@@ -1,0 +1,182 @@
+/**
+ * Built-in bridge: chatgpt
+ *
+ * Imports a ChatGPT memory dump into Flair memories. The path that ships in
+ * v1 is the file-export shape — when a user requests their ChatGPT data
+ * archive, the export contains a `memory.json` (or older exports may have
+ * memory inlined into `user.json`). Each memory in the dump becomes one
+ * Flair memory tagged `source: "chatgpt/memory"`.
+ *
+ * Round-trip: this is a one-way import. ChatGPT's memory store is closed,
+ * so the export side is omitted (it'd have nowhere useful to write to).
+ *
+ * Why a Shape B (code) bridge and not Shape A (YAML descriptor):
+ * - The OpenAI export wraps memories under `{ memories: [...] }`. The Shape A
+ *   JSON parser treats the whole document as one record (it doesn't traverse
+ *   nested paths). A code plugin can unwrap cleanly.
+ * - We're lenient about field names — `content` first, then `text`, then
+ *   `body`, then bare-string. Easier to express in TS than in a YAML
+ *   fallback chain.
+ *
+ * Source shapes accepted:
+ *   1. A directory containing `memory.json` (the OpenAI export root)
+ *   2. A direct path to `memory.json`
+ *   3. The wrapper `{ memories: [...] }` OR a top-level array
+ *
+ * Usage:
+ *   flair bridge import chatgpt --cwd ./openai-export --agent <id>
+ *   flair bridge import chatgpt --cwd ./openai-export --agent <id> --dry-run
+ */
+
+import { promises as fsp } from "node:fs";
+import { join } from "node:path";
+import type { BridgeContext, BridgeMemory, MemoryBridge } from "../types.js";
+import { BridgeRuntimeError } from "../types.js";
+
+interface RawChatGPTMemory {
+  id?: string;
+  content?: string;
+  text?: string;
+  body?: string;
+  created_at?: string;
+}
+
+async function* importChatGPT(
+  opts: Record<string, unknown>,
+  ctx: BridgeContext,
+): AsyncIterable<BridgeMemory> {
+  // Resolve source. Caller passes `--source <path>` pointing at either
+  // the memory.json file directly OR the OpenAI export directory containing
+  // it. Absolute paths win; relative paths resolve against process.cwd
+  // (matching the markdown bridge's convention — BridgeContext doesn't
+  // carry a cwd field as of v1).
+  const { isAbsolute, resolve } = await import("node:path");
+  const sourceArg = typeof opts.source === "string" ? opts.source : "";
+  if (!sourceArg) {
+    throw new BridgeRuntimeError({
+      bridge: "chatgpt",
+      op: "import",
+      path: "(unset)",
+      field: "source",
+      expected: "path to memory.json or to the OpenAI export directory",
+      got: "missing",
+      hint: "pass --source <path>; example: flair bridge import chatgpt --source ./openai-export --agent <id>",
+    });
+  }
+  const sourceAbs = isAbsolute(sourceArg) ? sourceArg : resolve(process.cwd(), sourceArg);
+
+  let filePath: string;
+  try {
+    const stat = await fsp.stat(sourceAbs);
+    filePath = stat.isDirectory() ? join(sourceAbs, "memory.json") : sourceAbs;
+  } catch (err: any) {
+    throw new BridgeRuntimeError({
+      bridge: "chatgpt",
+      op: "import",
+      path: sourceAbs,
+      field: "source",
+      expected: "readable file or directory containing memory.json",
+      got: err?.code ?? "ENOENT",
+      hint: `could not resolve source: ${err?.message ?? err}`,
+    });
+  }
+
+  ctx.log.info("reading ChatGPT memory dump", { path: filePath });
+
+  let raw: string;
+  try {
+    raw = await fsp.readFile(filePath, "utf-8");
+  } catch (err: any) {
+    throw new BridgeRuntimeError({
+      bridge: "chatgpt",
+      op: "import",
+      path: filePath,
+      field: "source.path",
+      expected: "readable file",
+      got: err?.code ?? "ENOENT",
+      hint: `could not read source file: ${err?.message ?? err}`,
+    });
+  }
+
+  let parsed: any;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (err: any) {
+    throw new BridgeRuntimeError({
+      bridge: "chatgpt",
+      op: "import",
+      path: filePath,
+      field: "(document)",
+      expected: "valid JSON",
+      got: "parse error",
+      hint: `JSON parse failed: ${err?.message ?? err}`,
+    });
+  }
+
+  // Accept either { memories: [...] } or a top-level array. Anything else
+  // is unexpected; surface a helpful error rather than silently importing 0.
+  const memories: RawChatGPTMemory[] = Array.isArray(parsed)
+    ? parsed
+    : Array.isArray(parsed?.memories)
+      ? parsed.memories
+      : Array.isArray(parsed?.user_memory) // older exports occasionally use this
+        ? parsed.user_memory
+        : [];
+
+  if (!Array.isArray(parsed) && !Array.isArray(parsed?.memories) && !Array.isArray(parsed?.user_memory)) {
+    throw new BridgeRuntimeError({
+      bridge: "chatgpt",
+      op: "import",
+      path: filePath,
+      field: "(document)",
+      expected: "{ memories: [...] } or top-level array",
+      got: typeof parsed,
+      hint: `unexpected shape — keys at root: ${Object.keys(parsed ?? {}).join(", ") || "none"}`,
+    });
+  }
+
+  ctx.log.info("found memories", { count: memories.length });
+
+  let kept = 0;
+  let skipped = 0;
+  for (let i = 0; i < memories.length; i++) {
+    const m = memories[i];
+    // Lenient extract — try several common shapes.
+    const content =
+      typeof m === "string" ? m
+      : typeof m?.content === "string" ? m.content
+      : typeof m?.text === "string" ? m.text
+      : typeof m?.body === "string" ? m.body
+      : null;
+    if (!content || content.trim() === "") {
+      skipped++;
+      continue;
+    }
+    kept++;
+    yield {
+      foreignId: typeof m?.id === "string" ? `chatgpt:${m.id}` : `chatgpt:idx-${i}`,
+      content,
+      createdAt: typeof m?.created_at === "string" ? m.created_at : undefined,
+      tags: ["source:chatgpt", "import:chatgpt"],
+      durability: "persistent",
+    };
+  }
+
+  ctx.log.info("import complete", { kept, skipped });
+}
+
+export const chatgptMemoryBridge: MemoryBridge = {
+  name: "chatgpt",
+  version: 1,
+  kind: "file",
+  description: "Import a ChatGPT memory dump (memory.json from an OpenAI data export) into Flair",
+  options: {
+    source: {
+      kind: "string",
+      description: "Path to memory.json (or to the OpenAI-export directory containing it). Required.",
+    },
+  },
+  import: importChatGPT,
+  // No export — ChatGPT's memory store is closed; round-trip would have
+  // nowhere useful to write back to.
+};

--- a/src/bridges/builtins/index.ts
+++ b/src/bridges/builtins/index.ts
@@ -19,6 +19,7 @@ import type {
   YamlBridgeDescriptor,
 } from "../types.js";
 import { agenticStackDescriptor } from "./agentic-stack.js";
+import { chatgptMemoryBridge } from "./chatgpt.js";
 import { markdownMemoryBridge } from "./markdown.js";
 
 export interface BuiltinBridge {
@@ -59,6 +60,7 @@ function builtinPlugin(p: MemoryBridge): BuiltinBridge {
 /** All bridges shipped inside @tpsdev-ai/flair. Order doesn't matter. */
 export const BUILTINS: BuiltinBridge[] = [
   builtinDescriptor(agenticStackDescriptor),
+  builtinPlugin(chatgptMemoryBridge),
   builtinPlugin(markdownMemoryBridge),
 ];
 

--- a/test/unit/bridge-chatgpt.test.ts
+++ b/test/unit/bridge-chatgpt.test.ts
@@ -1,0 +1,170 @@
+import { describe, it, expect } from "bun:test";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+// We import from the dist'd plugin to mirror how the bridge runtime loads
+// it at runtime. That said, the parsing logic is pure — we exercise it
+// directly via the same code path.
+import { chatgptMemoryBridge } from "../../src/bridges/builtins/chatgpt";
+
+// Minimal stub of BridgeContext. The chatgpt bridge only uses ctx.log and
+// ctx.fetch (transitively, via no actual external HTTP — chatgpt is file-only).
+function fakeCtx() {
+  const logs: Array<{ level: string; msg: string; meta?: any }> = [];
+  return {
+    fetch: globalThis.fetch,
+    log: {
+      debug: (msg: string, meta?: any) => logs.push({ level: "debug", msg, meta }),
+      info:  (msg: string, meta?: any) => logs.push({ level: "info",  msg, meta }),
+      warn:  (msg: string, meta?: any) => logs.push({ level: "warn",  msg, meta }),
+      error: (msg: string, meta?: any) => logs.push({ level: "error", msg, meta }),
+    },
+    cache: {
+      get: async () => null,
+      set: async () => {},
+      del: async () => {},
+    },
+    logs, // exposed for assertions
+  };
+}
+
+async function collectMemories(opts: any, ctx: any) {
+  const out: any[] = [];
+  for await (const m of chatgptMemoryBridge.import!(opts, ctx)) {
+    out.push(m);
+  }
+  return out;
+}
+
+describe("chatgpt bridge: import", () => {
+  it("imports memories from { memories: [...] } wrapper", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "flair-chatgpt-test-"));
+    try {
+      writeFileSync(join(dir, "memory.json"), JSON.stringify({
+        memories: [
+          { id: "abc", content: "User uses TypeScript", created_at: "2026-04-15T00:00:00Z" },
+          { id: "def", content: "User runs newton on M3 Ultra" },
+        ],
+      }));
+      const ctx = fakeCtx();
+      const out = await collectMemories({ source: dir }, ctx);
+      expect(out).toHaveLength(2);
+      expect(out[0].content).toBe("User uses TypeScript");
+      expect(out[0].foreignId).toBe("chatgpt:abc");
+      expect(out[0].createdAt).toBe("2026-04-15T00:00:00Z");
+      expect(out[0].tags).toContain("source:chatgpt");
+      expect(out[0].tags).toContain("import:chatgpt");
+      expect(out[0].durability).toBe("persistent");
+      expect(out[1].foreignId).toBe("chatgpt:def");
+      expect(out[1].createdAt).toBeUndefined(); // missing in fixture
+    } finally { rmSync(dir, { recursive: true, force: true }); }
+  });
+
+  it("imports from a top-level array (no wrapper)", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "flair-chatgpt-test-"));
+    try {
+      writeFileSync(join(dir, "memory.json"), JSON.stringify([
+        { id: "x", content: "raw array shape" },
+      ]));
+      const out = await collectMemories({ source: dir }, fakeCtx());
+      expect(out).toHaveLength(1);
+      expect(out[0].content).toBe("raw array shape");
+    } finally { rmSync(dir, { recursive: true, force: true }); }
+  });
+
+  it("supports `text` and `body` field-name fallbacks", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "flair-chatgpt-test-"));
+    try {
+      writeFileSync(join(dir, "memory.json"), JSON.stringify({
+        memories: [
+          { id: "1", text: "older export shape uses 'text'" },
+          { id: "2", body: "even older 'body'" },
+        ],
+      }));
+      const out = await collectMemories({ source: dir }, fakeCtx());
+      expect(out).toHaveLength(2);
+      expect(out[0].content).toBe("older export shape uses 'text'");
+      expect(out[1].content).toBe("even older 'body'");
+    } finally { rmSync(dir, { recursive: true, force: true }); }
+  });
+
+  it("accepts a bare-string memory entry", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "flair-chatgpt-test-"));
+    try {
+      writeFileSync(join(dir, "memory.json"), JSON.stringify(["bare string memory"]));
+      const out = await collectMemories({ source: dir }, fakeCtx());
+      expect(out).toHaveLength(1);
+      expect(out[0].content).toBe("bare string memory");
+      // bare-string entries get an idx-based foreignId
+      expect(out[0].foreignId).toBe("chatgpt:idx-0");
+    } finally { rmSync(dir, { recursive: true, force: true }); }
+  });
+
+  it("skips entries with empty/missing content", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "flair-chatgpt-test-"));
+    try {
+      writeFileSync(join(dir, "memory.json"), JSON.stringify({
+        memories: [
+          { id: "good", content: "real content" },
+          { id: "empty", content: "" },
+          { id: "no-content-field" },
+          { id: "whitespace", content: "   \n\t  " },
+        ],
+      }));
+      const out = await collectMemories({ source: dir }, fakeCtx());
+      expect(out).toHaveLength(1);
+      expect(out[0].foreignId).toBe("chatgpt:good");
+    } finally { rmSync(dir, { recursive: true, force: true }); }
+  });
+
+  it("accepts a direct file path (not just a directory)", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "flair-chatgpt-test-"));
+    try {
+      const filePath = join(dir, "custom-name.json");
+      writeFileSync(filePath, JSON.stringify({ memories: [{ id: "1", content: "from custom path" }] }));
+      const out = await collectMemories({ source: filePath }, fakeCtx());
+      expect(out).toHaveLength(1);
+      expect(out[0].content).toBe("from custom path");
+    } finally { rmSync(dir, { recursive: true, force: true }); }
+  });
+
+  it("throws a helpful error when --source is missing", async () => {
+    await expect(collectMemories({}, fakeCtx())).rejects.toThrow(/--source/);
+  });
+
+  it("throws a helpful error when source path does not exist", async () => {
+    await expect(collectMemories({ source: "/nonexistent/path/that/should/not/exist" }, fakeCtx()))
+      .rejects.toThrow(/could not resolve source/);
+  });
+
+  it("throws a helpful error when JSON is malformed", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "flair-chatgpt-test-"));
+    try {
+      writeFileSync(join(dir, "memory.json"), "not valid json {");
+      await expect(collectMemories({ source: dir }, fakeCtx())).rejects.toThrow(/JSON parse failed/);
+    } finally { rmSync(dir, { recursive: true, force: true }); }
+  });
+
+  it("throws a helpful error when document shape is unexpected", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "flair-chatgpt-test-"));
+    try {
+      writeFileSync(join(dir, "memory.json"), JSON.stringify({ unrelated_field: "value" }));
+      await expect(collectMemories({ source: dir }, fakeCtx())).rejects.toThrow(/unexpected shape/);
+    } finally { rmSync(dir, { recursive: true, force: true }); }
+  });
+});
+
+describe("chatgpt bridge: metadata", () => {
+  it("registers as a 'file' kind builtin", () => {
+    expect(chatgptMemoryBridge.name).toBe("chatgpt");
+    expect(chatgptMemoryBridge.kind).toBe("file");
+    expect(chatgptMemoryBridge.version).toBe(1);
+  });
+  it("declares a `source` option", () => {
+    expect(chatgptMemoryBridge.options?.source).toBeDefined();
+  });
+  it("does NOT declare an export side (one-way bridge)", () => {
+    expect(chatgptMemoryBridge.export).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## What

`flair bridge import chatgpt` — first SaaS-memory import path, backing the "switch off SaaS memory in 30 seconds" positioning post.

```bash
flair bridge import chatgpt --source ./openai-export --agent <id>
flair bridge import chatgpt --source ./memory.json --agent <id> --dry-run
```

Imports a ChatGPT memory dump (`memory.json` from an OpenAI data export) into Flair. Each entry becomes one Flair memory tagged `source:chatgpt` + `import:chatgpt`, durability `persistent`, preserves `created_at` if present.

## Why this shape

- **Bridge, not new top-level command.** I initially scaffolded a `flair import` command and noticed `flair bridge import <name>` already exists for exactly this — pluggable file/API memory imports. Using the existing architecture is the right call: smaller surface, already documented, scales to mem0/honcho/claude-project as the same shape.
- **Shape B (code plugin) not Shape A (YAML descriptor).** The OpenAI export wraps memories under `{ memories: [...] }`. The Shape A JSON parser treats wrapper documents as a single record (it doesn't traverse nested paths). A code plugin unwraps cleanly + handles field-name fallbacks (`content` / `text` / `body` / bare-string) without a clunky YAML fallback chain.
- **One-way.** ChatGPT's memory store is closed. Round-trip would have nowhere to write to, so `export` is omitted rather than half-implemented.

## What's accepted

Source can be:
- a directory containing `memory.json` (the OpenAI export root), or
- a direct path to `memory.json`

Document shape:
- `{ memories: [...] }` (modern OpenAI export — most common)
- `{ user_memory: [...] }` (older exports)
- top-level `[...]` array (manually-pre-processed)

Per-record fallback chain: `content` → `text` → `body` → bare-string. Empty / whitespace-only entries are skipped with a reported count.

## Test plan

- [x] 13 unit tests in `test/unit/bridge-chatgpt.test.ts` covering wrapper / array / fallback fields / bare-string / empty-skip / direct-file / missing-source / nonexistent-path / malformed-JSON / unexpected-shape
- [x] Full unit suite still 802/0
- [x] All CI gates green locally (impl-term-leaks, dep-ages, workspace-deps)
- [x] **Live round-trip on rockit:** `flair bridge import chatgpt --source /tmp/fixture --agent flint --port 9926` imported 3 sample records; `flair search "TypeScript over Python" --agent flint` finds them at 64% semantic relevance. (Cleaned up post-test.)

## Follow-ups (community PRs welcome)

Same plugin pattern; ~80 lines each:
- **mem0** (REST API, Bearer token) — `flair bridge import mem0 --user <id>`
- **honcho** (REST API) — `flair bridge import honcho --session <id>`
- **claude-project** (zip export) — `flair bridge import claude-project --source <path>`

Will be added to `docs/integrations.md`'s "don't see your harness" section once one or more land.

## Areas worth K&S eye

- **KERN:** the field-name fallback chain (`content` → `text` → `body` → bare-string) is lenient by design — old export shapes vary. Right tradeoff vs strict?
- **SHERLOCK:** import writes go through standard authFetch path so per-agent isolation is enforced server-side. The `source:chatgpt` tag is auditable. Confirm there's no surface where untrusted JSON content could escape into a control-plane field (id, durability, etc.).

🤖 Generated with [Claude Code](https://claude.com/claude-code)