### PR TITLE
ci(hooks): pre-commit hook for flair monorepo (workspace-deps + dep-ages + impl-term-leaks)

### DIFF
--- a/docs/supply-chain-policy.md
+++ b/docs/supply-chain-policy.md
@@ -99,6 +99,21 @@ Blocks at stage time:
 
 Available in `ops/scripts/git-hooks/install.sh`. Required for any agent or operator with commit access.
 
+### Flair pre-commit hook (`scripts/git-hooks/`)
+
+Mirrors the CI test-unit gates locally so issues are caught at `git commit` time, not after the runner round-trip:
+
+```bash
+./scripts/git-hooks/install.sh
+```
+
+Runs three checks before each commit:
+- `check-workspace-deps.mjs` — workspace internal-dep version lockstep
+- `check-dep-ages.mjs` — supply-chain bake-time (≥7 days for external pinned deps)
+- `check-impl-term-leaks.sh` — no Bead refs / impl labels in user-facing docs
+
+Each check matches a CI gate exactly so the local and remote outcomes can't drift. Bypass with `git commit --no-verify` when warranted (rare; CI will still catch you). Skip just the dep-ages check (the slowest one, ~2-5s of registry fetches) with `FLAIR_PRECOMMIT_SKIP_DEP_AGES=1 git commit`.
+
 ---
 
 ## Adopting this policy in a downstream project
@@ -132,4 +147,5 @@ The script has no external dependencies — node 18+ is enough.
 - `notes/dogfood-log.md` — internal incidents that have shaped this policy
 - `scripts/check-workspace-deps.mjs` — the workspace-internal dep consistency gate
 - `scripts/check-dep-ages.mjs` — the bake-time dep guard
-- `ops/scripts/git-hooks/pre-commit-secret-guard.sh` — pre-commit secret blocker
+- `ops/scripts/git-hooks/pre-commit-secret-guard.sh` — pre-commit secret blocker (cross-repo)
+- `scripts/git-hooks/pre-commit` + `scripts/git-hooks/install.sh` — flair-specific pre-commit (mirrors test-unit CI gates)

--- a/scripts/git-hooks/install.sh
+++ b/scripts/git-hooks/install.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+# Install the Flair pre-commit hook into .git/hooks/.
+#
+# Usage: ./scripts/git-hooks/install.sh
+# Run from anywhere inside the flair repo.
+
+set -e
+
+cd "$(git rev-parse --show-toplevel)"
+HOOKS_DIR=$(git rev-parse --git-path hooks)
+
+cp scripts/git-hooks/pre-commit "$HOOKS_DIR/pre-commit"
+chmod +x "$HOOKS_DIR/pre-commit"
+
+echo "✓ installed flair pre-commit hook → $HOOKS_DIR/pre-commit"
+echo
+echo "Runs: workspace-deps + dep-ages (bake-time) + impl-term-leaks"
+echo "Bypass with --no-verify (rarely warranted; CI will catch anyway)."

--- a/scripts/git-hooks/pre-commit
+++ b/scripts/git-hooks/pre-commit
@@ -1,0 +1,73 @@
+#!/bin/sh
+# Pre-commit hook for the Flair monorepo.
+#
+# Runs the same lints the CI test-unit job runs, locally, before the commit
+# lands. Catches the staleness/leak/age classes 60s earlier than CI and
+# without burning a runner round-trip.
+#
+# Each check matches a CI gate exactly so they can't drift:
+#   - check-workspace-deps.mjs  → CI test-unit (workspace internal-dep lockstep)
+#   - check-dep-ages.mjs         → CI test-unit (supply-chain bake time, ≥7d)
+#   - check-impl-term-leaks.sh   → CI Doc/Code Lint (no Bead refs in user-facing docs)
+#
+# Install:
+#   ./scripts/git-hooks/install.sh           (from inside the flair repo)
+#
+# Bypass (rarely warranted):
+#   git commit --no-verify
+# Don't make a habit of it. CI will catch you anyway.
+#
+# Performance:
+#   The dep-ages check makes one HTTP request per pinned external dep
+#   (currently 6). Total ~2-5s on a warm registry. If that's painful,
+#   set FLAIR_PRECOMMIT_SKIP_DEP_AGES=1 (the CI job will still catch
+#   anything you missed).
+
+set -e
+
+cd "$(git rev-parse --show-toplevel)"
+
+red()   { printf '\033[31m%s\033[0m\n' "$1" >&2; }
+yellow(){ printf '\033[33m%s\033[0m\n' "$1" >&2; }
+green() { printf '\033[32m%s\033[0m\n' "$1" >&2; }
+
+FAIL=0
+
+if [ -f scripts/check-workspace-deps.mjs ]; then
+    if ! node scripts/check-workspace-deps.mjs >/dev/null 2>&1; then
+        red "✗ workspace-deps consistency check failed"
+        node scripts/check-workspace-deps.mjs >&2 || true
+        FAIL=1
+    else
+        green "✓ workspace-deps consistency"
+    fi
+fi
+
+if [ -f scripts/check-dep-ages.mjs ] && [ -z "$FLAIR_PRECOMMIT_SKIP_DEP_AGES" ]; then
+    if ! node scripts/check-dep-ages.mjs >/dev/null 2>&1; then
+        red "✗ dep-ages bake-time check failed"
+        node scripts/check-dep-ages.mjs >&2 || true
+        FAIL=1
+    else
+        green "✓ dep-ages bake-time"
+    fi
+fi
+
+if [ -f scripts/check-impl-term-leaks.sh ]; then
+    if ! bash scripts/check-impl-term-leaks.sh >/dev/null 2>&1; then
+        red "✗ impl-term-leaks lint failed"
+        bash scripts/check-impl-term-leaks.sh >&2 || true
+        FAIL=1
+    else
+        green "✓ no impl-term leaks"
+    fi
+fi
+
+if [ "$FAIL" = "1" ]; then
+    red ""
+    red "Pre-commit hook blocked this commit. CI would catch the same issues —"
+    red "fix them now or run with --no-verify if you genuinely need to bypass."
+    exit 1
+fi
+
+exit 0


### PR DESCRIPTION
## What

Pre-commit hook that mirrors the CI test-unit job locally — catches the staleness/leak/age classes 60s earlier than CI without burning a runner round-trip.

```bash
./scripts/git-hooks/install.sh
```

## Why

Layer-2 defense filed yesterday after the v0.8.0 / v0.8.1 dep-staleness incident. Layer-1 (CI gate) shipped in #368. This is the local-loop closer.

Three checks, each matching a CI gate exactly so they can't drift:

| Check | Mirrors |
|-------|---------|
| `check-workspace-deps.mjs` | CI test-unit (workspace internal-dep lockstep) |
| `check-dep-ages.mjs` | CI test-unit (supply-chain bake time, ≥7 days) |
| `check-impl-term-leaks.sh` | CI Doc/Code Lint (no Bead refs in user-facing docs) |

## Test plan

- [x] `./scripts/git-hooks/install.sh` writes to `.git/hooks/pre-commit`, chmod +x
- [x] Hook ran on its own commit (`b7750be`) — all three checks green ✓
- [x] Bypass works: `git commit --no-verify` skips
- [x] Speed escape hatch: `FLAIR_PRECOMMIT_SKIP_DEP_AGES=1 git commit` skips the registry-roundtrip step (~2-5s)

## Areas worth K&S eye

- **KERN:** the hook calls each check via `node` / `bash` directly. Right shape, or should we wrap into a single entrypoint?
- **SHERLOCK:** any concern about `--no-verify` being the documented bypass? My read: friction is the point + CI is the authoritative gate. Acceptable surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)