### PR TITLE
feat(bridges): mem0 builtin — import a Mem0 instance into Flair

### DIFF
--- a/src/bridges/builtins/index.ts
+++ b/src/bridges/builtins/index.ts
@@ -20,6 +20,7 @@ import type {
 } from "../types.js";
 import { agenticStackDescriptor } from "./agentic-stack.js";
 import { markdownMemoryBridge } from "./markdown.js";
+import { mem0MemoryBridge } from "./mem0.js";
 
 export interface BuiltinBridge {
   /** The discovery record surfaced in `flair bridge list`. */
@@ -60,6 +61,7 @@ function builtinPlugin(p: MemoryBridge): BuiltinBridge {
 export const BUILTINS: BuiltinBridge[] = [
   builtinDescriptor(agenticStackDescriptor),
   builtinPlugin(markdownMemoryBridge),
+  builtinPlugin(mem0MemoryBridge),
 ];
 
 /** Map name → descriptor/plugin for O(1) runtime lookup. */

--- a/src/bridges/builtins/mem0.ts
+++ b/src/bridges/builtins/mem0.ts
@@ -1,0 +1,249 @@
+/**
+ * Built-in bridge: mem0
+ *
+ * Imports memories from a Mem0 instance (cloud at api.mem0.ai or self-hosted)
+ * into Flair. Pulls every memory for a given user_id via the Mem0 REST API,
+ * paginating until exhausted. Each imported row becomes one Flair memory
+ * tagged `source:mem0` + `import:mem0`, durability `persistent`.
+ *
+ * One-way import (we don't sync back). This backs the "switch off SaaS
+ * memory in 30 seconds" positioning.
+ *
+ * Why a Shape B (code) bridge and not Shape A (YAML descriptor):
+ *   - The Mem0 API requires bearer-auth headers and paginated GET requests
+ *     with a `next_page` cursor. The Shape A file-based parser can't drive
+ *     a REST API, so a code plugin is the right fit.
+ *   - Error handling needs to distinguish 401 (bad key) from network
+ *     failures from malformed responses — easier to express in TS.
+ *
+ * Usage:
+ *   flair bridge import mem0 --user <id> --api-key <key> --agent <flair-id>
+ *   flair bridge import mem0 --user <id> --base-url https://mem0.example.com --agent <flair-id>
+ *   MEM0_API_KEY=<key> flair bridge import mem0 --user <id> --agent <flair-id>
+ */
+
+import type { BridgeContext, BridgeMemory, MemoryBridge } from "../types.js";
+import { BridgeRuntimeError } from "../types.js";
+
+interface Mem0Memory {
+  id: string;
+  memory: string;
+  user_id: string;
+  created_at?: string;
+  updated_at?: string;
+  metadata?: Record<string, unknown>;
+}
+
+interface Mem0Page {
+  memories: Mem0Memory[];
+  next_page: string | null;
+}
+
+async function* importMem0(
+  opts: Record<string, unknown>,
+  ctx: BridgeContext,
+): AsyncIterable<BridgeMemory> {
+  const userId = typeof opts.user === "string" ? opts.user : "";
+  if (!userId) {
+    throw new BridgeRuntimeError({
+      bridge: "mem0",
+      op: "import",
+      field: "user",
+      expected: "Mem0 user_id string",
+      got: "missing",
+      hint: "pass --user <id>; example: flair bridge import mem0 --user <id> --api-key <key> --agent <flair-id>",
+    });
+  }
+
+  const apiKey = typeof opts.apiKey === "string" ? opts.apiKey : "";
+  if (!apiKey) {
+    throw new BridgeRuntimeError({
+      bridge: "mem0",
+      op: "import",
+      field: "apiKey",
+      expected: "Mem0 API token (cloud or self-hosted)",
+      got: "missing",
+      hint: "pass --api-key <token> or set MEM0_API_KEY in the environment",
+    });
+  }
+
+  const baseUrl = typeof opts.baseUrl === "string" && opts.baseUrl.length > 0
+    ? opts.baseUrl.replace(/\/+$/, "")
+    : "https://api.mem0.ai";
+
+  const maxPages = typeof opts.maxPages === "number" ? opts.maxPages : 0;
+
+  ctx.log.info("starting mem0 import", {
+    user_id: userId,
+    base_url: baseUrl,
+  });
+
+  let pageCount = 0;
+  let totalKept = 0;
+  let cursor: string | null = `${baseUrl}/v1/memories?user_id=${encodeURIComponent(userId)}&page=1&page_size=100`;
+
+  while (cursor !== null) {
+    if (maxPages > 0 && pageCount >= maxPages) {
+      ctx.log.info("stopping at max-pages limit", { pages: pageCount, kept: totalKept });
+      break;
+    }
+
+    ctx.log.debug("fetching page", { url: cursor, page: pageCount + 1 });
+
+    let res: Response;
+    try {
+      res = await ctx.fetch(cursor, {
+        headers: {
+          Authorization: `Token ${apiKey}`,
+          Accept: "application/json",
+        },
+      });
+    } catch (err: any) {
+      throw new BridgeRuntimeError({
+        bridge: "mem0",
+        op: "import",
+        path: cursor,
+        field: "fetch",
+        expected: "HTTP 200",
+        got: `network error: ${err?.message ?? err}`,
+        hint: "check the base URL is reachable and the network is up",
+      });
+    }
+
+    if (res.status === 401) {
+      throw new BridgeRuntimeError({
+        bridge: "mem0",
+        op: "import",
+        path: cursor,
+        field: "apiKey",
+        expected: "valid Mem0 API token",
+        got: "HTTP 401 Unauthorized",
+        hint: "the API key was rejected — check it's valid and scoped to the user_id",
+      });
+    }
+
+    if (res.status === 403) {
+      throw new BridgeRuntimeError({
+        bridge: "mem0",
+        op: "import",
+        path: cursor,
+        field: "apiKey",
+        expected: "authorized token",
+        got: "HTTP 403 Forbidden",
+        hint: "the API key doesn't have permission to read memories for this user_id",
+      });
+    }
+
+    if (res.status === 404) {
+      throw new BridgeRuntimeError({
+        bridge: "mem0",
+        op: "import",
+        path: cursor,
+        field: "user",
+        expected: "existing user_id",
+        got: "HTTP 404 Not Found",
+        hint: `user_id "${userId}" was not found on this Mem0 instance`,
+      });
+    }
+
+    if (!res.ok) {
+      const body = await res.text().catch(() => "(could not read body)");
+      throw new BridgeRuntimeError({
+        bridge: "mem0",
+        op: "import",
+        path: cursor,
+        field: "response",
+        expected: "HTTP 200",
+        got: `HTTP ${res.status} ${res.statusText}`,
+        hint: `unexpected response (${res.status}): ${body.slice(0, 200)}`,
+      });
+    }
+
+    let page: Mem0Page;
+    try {
+      const text = await res.text();
+      if (text.trim() === "") {
+        throw new BridgeRuntimeError({
+          bridge: "mem0",
+          op: "import",
+          path: cursor,
+          field: "(response)",
+          expected: "JSON body",
+          got: "empty response",
+          hint: "the Mem0 API returned an empty body — check the instance is healthy",
+        });
+      }
+      page = JSON.parse(text) as Mem0Page;
+    } catch (err: any) {
+      if (err instanceof BridgeRuntimeError) throw err;
+      throw new BridgeRuntimeError({
+        bridge: "mem0",
+        op: "import",
+        path: cursor,
+        field: "(response)",
+        expected: "valid JSON { memories: [...], next_page: string|null }",
+        got: "parse error",
+        hint: `could not parse response: ${err?.message ?? err}`,
+      });
+    }
+
+    if (!Array.isArray(page?.memories)) {
+      throw new BridgeRuntimeError({
+        bridge: "mem0",
+        op: "import",
+        path: cursor,
+        field: "(response)",
+        expected: "{ memories: [...] }",
+        got: typeof page,
+        hint: `unexpected response shape — got ${typeof page}, expected an object with a "memories" array`,
+      });
+    }
+
+    const mems = page.memories;
+    ctx.log.debug("received page", { count: mems.length, next: page.next_page });
+
+    for (const m of mems) {
+      const content = typeof m?.memory === "string" ? m.memory : "";
+      if (!content || content.trim() === "") continue;
+      totalKept++;
+      yield {
+        foreignId: `mem0:${m.id}`,
+        content,
+        createdAt: typeof m?.created_at === "string" ? m.created_at : undefined,
+        tags: ["source:mem0", "import:mem0"],
+        durability: "persistent",
+      };
+    }
+
+    pageCount++;
+    cursor = page.next_page;
+  }
+
+  ctx.log.info("mem0 import complete", { pages: pageCount, kept: totalKept });
+}
+
+export const mem0MemoryBridge: MemoryBridge = {
+  name: "mem0",
+  version: 1,
+  kind: "api",
+  description: "Import memories from a Mem0 instance (cloud or self-hosted) into Flair",
+  options: {
+    user: {
+      description: "Mem0 user_id whose memories to import.",
+      required: true,
+    },
+    apiKey: {
+      description: "Mem0 API token. Can also be set via MEM0_API_KEY env var.",
+      env: "MEM0_API_KEY",
+      required: true,
+    },
+    baseUrl: {
+      description: "Base URL of the Mem0 API (default: https://api.mem0.ai). Use your self-hosted URL for on-prem.",
+    },
+    maxPages: {
+      description: "Maximum number of pages to fetch (0 = unlimited, for testing/dry-run).",
+    },
+  },
+  import: importMem0,
+  // No export — one-way import; we don't sync back to Mem0.
+};

--- a/test/unit/bridge-mem0.test.ts
+++ b/test/unit/bridge-mem0.test.ts
@@ -1,0 +1,337 @@
+import { describe, it, expect, beforeAll, afterAll } from "bun:test";
+import { createServer, type Server, type IncomingMessage, type ServerResponse } from "node:http";
+
+import { mem0MemoryBridge } from "../../src/bridges/builtins/mem0";
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function fakeCtx() {
+  const logs: Array<{ level: string; msg: string; meta?: any }> = [];
+  return {
+    fetch: globalThis.fetch,
+    log: {
+      debug: (msg: string, meta?: any) => logs.push({ level: "debug", msg, meta }),
+      info:  (msg: string, meta?: any) => logs.push({ level: "info",  msg, meta }),
+      warn:  (msg: string, meta?: any) => logs.push({ level: "warn",  msg, meta }),
+      error: (msg: string, meta?: any) => logs.push({ level: "error", msg, meta }),
+    },
+    cache: {
+      get: async () => null,
+      set: async () => {},
+      del: async () => {},
+    },
+    logs,
+  };
+}
+
+async function collectMemories(opts: any, ctx: any) {
+  const out: any[] = [];
+  for await (const m of mem0MemoryBridge.import!(opts, ctx)) {
+    out.push(m);
+  }
+  return out;
+}
+
+// ─── Mini HTTP server for mocked Mem0 API ─────────────────────────────────────
+
+let server: Server;
+let port: number;
+let baseUrl: string;
+let handler: ((req: IncomingMessage, res: ServerResponse) => void) | null = null;
+
+beforeAll(async () => {
+  server = createServer((req, res) => {
+    if (handler) handler(req, res);
+    else {
+      res.writeHead(500);
+      res.end('{"error":"no handler set"}');
+    }
+  });
+  await new Promise<void>((resolve) => server.listen(0, () => resolve()));
+  port = (server.address() as any).port;
+  baseUrl = `http://127.0.0.1:${port}`;
+});
+
+afterAll(() => {
+  server.close();
+});
+
+function mockCtx() {
+  const base = fakeCtx();
+  return { ...base, fetch: (url: string, init?: RequestInit) => fetch(url, init) };
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe("mem0 bridge: import", () => {
+  it("imports a single page of memories", async () => {
+    handler = (_req, res) => {
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({
+        memories: [
+          { id: "m1", memory: "User prefers TypeScript", user_id: "u1", created_at: "2026-04-01T00:00:00Z" },
+          { id: "m2", memory: "User works at a startup", user_id: "u1" },
+        ],
+        next_page: null,
+      }));
+    };
+
+    const ctx = mockCtx();
+    const out = await collectMemories(
+      { user: "u1", apiKey: "test-key", baseUrl },
+      ctx,
+    );
+
+    expect(out).toHaveLength(2);
+    expect(out[0].foreignId).toBe("mem0:m1");
+    expect(out[0].content).toBe("User prefers TypeScript");
+    expect(out[0].createdAt).toBe("2026-04-01T00:00:00Z");
+    expect(out[0].tags).toContain("source:mem0");
+    expect(out[0].tags).toContain("import:mem0");
+    expect(out[0].durability).toBe("persistent");
+    expect(out[1].foreignId).toBe("mem0:m2");
+    expect(out[1].createdAt).toBeUndefined();
+  });
+
+  it("paginates across multiple pages", async () => {
+    let callCount = 0;
+    handler = (_req, res) => {
+      callCount++;
+      res.writeHead(200, { "Content-Type": "application/json" });
+      if (callCount === 1) {
+        res.end(JSON.stringify({
+          memories: [{ id: "p1", memory: "page-1 item", user_id: "u1" }],
+          next_page: `${baseUrl}/v1/memories?user_id=u1&page=2&page_size=100`,
+        }));
+      } else {
+        res.end(JSON.stringify({
+          memories: [{ id: "p2", memory: "page-2 item", user_id: "u1" }],
+          next_page: null,
+        }));
+      }
+    };
+
+    const ctx = mockCtx();
+    const out = await collectMemories(
+      { user: "u1", apiKey: "test-key", baseUrl },
+      ctx,
+    );
+
+    expect(out).toHaveLength(2);
+    expect(out[0].content).toBe("page-1 item");
+    expect(out[1].content).toBe("page-2 item");
+    expect(callCount).toBe(2);
+  });
+
+  it("stops at maxPages when set", async () => {
+    let callCount = 0;
+    handler = (_req, res) => {
+      callCount++;
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({
+        memories: [{ id: `m${callCount}`, memory: `memory-${callCount}`, user_id: "u1" }],
+        next_page: `${baseUrl}/v1/memories?user_id=u1&page=${callCount + 1}&page_size=100`,
+      }));
+    };
+
+    const ctx = mockCtx();
+    const out = await collectMemories(
+      { user: "u1", apiKey: "test-key", baseUrl, maxPages: 2 },
+      ctx,
+    );
+
+    expect(out).toHaveLength(2);
+    expect(callCount).toBe(2);
+  });
+
+  it("skips empty or whitespace-only memory content", async () => {
+    handler = (_req, res) => {
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({
+        memories: [
+          { id: "good", memory: "real memory", user_id: "u1" },
+          { id: "empty-str", memory: "", user_id: "u1" },
+          { id: "whitespace", memory: "   \n\t  ", user_id: "u1" },
+          { id: "also-good", memory: "another real one", user_id: "u1" },
+        ],
+        next_page: null,
+      }));
+    };
+
+    const ctx = mockCtx();
+    const out = await collectMemories(
+      { user: "u1", apiKey: "test-key", baseUrl },
+      ctx,
+    );
+
+    expect(out).toHaveLength(2);
+    expect(out[0].foreignId).toBe("mem0:good");
+    expect(out[1].foreignId).toBe("mem0:also-good");
+  });
+
+  it("throws when --user is missing", async () => {
+    await expect(
+      collectMemories({ apiKey: "test-key" }, mockCtx()),
+    ).rejects.toThrow(/--user/);
+  });
+
+  it("throws when --api-key is missing and not in env", async () => {
+    await expect(
+      collectMemories({ user: "u1" }, mockCtx()),
+    ).rejects.toThrow(/--api-key/);
+  });
+
+  it("throws on HTTP 401 (invalid key)", async () => {
+    handler = (_req, res) => {
+      res.writeHead(401, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ detail: "Invalid token." }));
+    };
+
+    await expect(
+      collectMemories({ user: "u1", apiKey: "bad-key", baseUrl }, mockCtx()),
+    ).rejects.toThrow(/API key was rejected/);
+  });
+
+  it("throws on HTTP 403 (forbidden)", async () => {
+    handler = (_req, res) => {
+      res.writeHead(403, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ detail: "You do not have permission." }));
+    };
+
+    await expect(
+      collectMemories({ user: "u1", apiKey: "test-key", baseUrl }, mockCtx()),
+    ).rejects.toThrow(/doesn't have permission/);
+  });
+
+  it("throws on HTTP 404 (user not found)", async () => {
+    handler = (_req, res) => {
+      res.writeHead(404, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ detail: "Not found." }));
+    };
+
+    await expect(
+      collectMemories({ user: "u1", apiKey: "test-key", baseUrl }, mockCtx()),
+    ).rejects.toThrow(/was not found/);
+  });
+
+  it("throws on a non-200, non-401/403/404 error (e.g. 500)", async () => {
+    handler = (_req, res) => {
+      res.writeHead(500, { "Content-Type": "text/plain" });
+      res.end("Internal Server Error");
+    };
+
+    await expect(
+      collectMemories({ user: "u1", apiKey: "test-key", baseUrl }, mockCtx()),
+    ).rejects.toThrow(/unexpected response/);
+  });
+
+  it("throws on a malformed (non-JSON) response", async () => {
+    handler = (_req, res) => {
+      res.writeHead(200, { "Content-Type": "text/html" });
+      res.end("<html>nginx error</html>");
+    };
+
+    await expect(
+      collectMemories({ user: "u1", apiKey: "test-key", baseUrl }, mockCtx()),
+    ).rejects.toThrow(/could not parse/);
+  });
+
+  it("throws on an empty response body", async () => {
+    handler = (_req, res) => {
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end("");
+    };
+
+    await expect(
+      collectMemories({ user: "u1", apiKey: "test-key", baseUrl }, mockCtx()),
+    ).rejects.toThrow(/empty body/);
+  });
+
+  it("throws on a response missing the `memories` array", async () => {
+    handler = (_req, res) => {
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ ok: true, not_memories: [] }));
+    };
+
+    await expect(
+      collectMemories({ user: "u1", apiKey: "test-key", baseUrl }, mockCtx()),
+    ).rejects.toThrow(/memories/);
+  });
+
+  it("throws on a network error (unreachable host)", async () => {
+    const ctx = mockCtx();
+    await expect(
+      collectMemories(
+        { user: "u1", apiKey: "test-key", baseUrl: "http://127.0.0.1:1" },
+        ctx,
+      ),
+    ).rejects.toThrow(/base URL is reachable/);
+  });
+
+  it("handles an empty memories array gracefully (zero imports)", async () => {
+    handler = (_req, res) => {
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ memories: [], next_page: null }));
+    };
+
+    const ctx = mockCtx();
+    const out = await collectMemories(
+      { user: "u1", apiKey: "test-key", baseUrl },
+      ctx,
+    );
+    expect(out).toHaveLength(0);
+  });
+
+  it("uses the default base URL when --base-url is not set (validates option spec)", async () => {
+    // We only validate the option spec exists with the right env fallback, not the URL default.
+    // The actual URL is hardcoded in the plugin; we verify the option is declared.
+    expect(mem0MemoryBridge.options?.baseUrl).toBeDefined();
+    expect(mem0MemoryBridge.options?.baseUrl?.description).toContain("https://api.mem0.ai");
+  });
+
+  it("respects the Authorization: Token header format", async () => {
+    let receivedAuth = "";
+    handler = (req, res) => {
+      receivedAuth = req.headers.authorization ?? "";
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ memories: [], next_page: null }));
+    };
+
+    const ctx = mockCtx();
+    await collectMemories(
+      { user: "u1", apiKey: "my-secret-token", baseUrl },
+      ctx,
+    );
+
+    expect(receivedAuth).toBe("Token my-secret-token");
+  });
+});
+
+describe("mem0 bridge: metadata", () => {
+  it("registers as an 'api' kind builtin", () => {
+    expect(mem0MemoryBridge.name).toBe("mem0");
+    expect(mem0MemoryBridge.kind).toBe("api");
+    expect(mem0MemoryBridge.version).toBe(1);
+  });
+
+  it("declares user and apiKey options", () => {
+    expect(mem0MemoryBridge.options?.user).toBeDefined();
+    expect(mem0MemoryBridge.options?.apiKey).toBeDefined();
+  });
+
+  it("declares apiKey with MEM0_API_KEY env fallback", () => {
+    expect(mem0MemoryBridge.options?.apiKey?.env).toBe("MEM0_API_KEY");
+  });
+
+  it("declares user as required", () => {
+    expect(mem0MemoryBridge.options?.user?.required).toBe(true);
+  });
+
+  it("declares apiKey as required", () => {
+    expect(mem0MemoryBridge.options?.apiKey?.required).toBe(true);
+  });
+
+  it("does NOT declare an export side (one-way bridge)", () => {
+    expect(mem0MemoryBridge.export).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## What

`flair bridge import mem0 --user <id> --api-key <key> --agent <flair-id>` — pulls memories from a Mem0 instance (cloud or self-hosted) and writes them into Flair as memories tagged `source:mem0` + `import:mem0`. One-way (we don't sync back).

Backs the "switch off SaaS memory in 30 seconds" positioning alongside the chatgpt bridge (#374).

## Why this shape

- **Shape B (code plugin)** — the Mem0 API requires bearer-auth headers and paginated GET requests with a `next_page` cursor. The Shape A file-based parser can't drive a REST API, so a code plugin is the right fit.
- **kind: "api"** — uses `ctx.fetch` (bridge-runtime-instrumented, rate-limited) instead of node:fs.
- **One-way** — we import from Mem0 but don't write back.

## Options

| Option | Required | Env fallback | Default |
|---|---|---|---|
| `--user` | ✅ | — | — |
| `--api-key` | ✅ | `MEM0_API_KEY` | — |
| `--base-url` | — | — | `https://api.mem0.ai` |
| `--maxPages` | — | — | 0 (unlimited) |

Pagination: follows `next_page` cursor until null.

## Test plan

- [x] 23 unit tests in `test/unit/bridge-mem0.test.ts` covering pagination, maxPages, empty-skip, missing user, missing api-key, HTTP 401/403/404/500, malformed JSON, empty body, missing memories array, network error, empty result, Token header format
- [x] Full unit suite: 796/798 pass (2 pre-existing failures in local-no-auth and federation-crypto-replay — unrelated)
- [x] Build clean: `bun run build:cli`
- [x] Impl-term-leaks: no leaks

Dispatched from Flint. Follows the chatgpt.ts pattern.