### PR TITLE
feat(bridges): claude-project builtin — import a Claude project export into Flair

### DIFF
--- a/src/bridges/builtins/claude-project.ts
+++ b/src/bridges/builtins/claude-project.ts
@@ -1,0 +1,209 @@
+/**
+ * Built-in bridge: claude-project
+ *
+ * Imports a Claude project export into Flair memories. A Claude project
+ * export contains `memory.json` (the memories array) and optionally
+ * `project.json` (metadata about the project, including its name).
+ *
+ * Each memory becomes one Flair memory tagged `source:claude-project` +
+ * `import:claude-project`. When project.json is present, the project's
+ * name is used as the subject; foreignId embeds the project name for
+ * cross-project dedup.
+ *
+ * Why Shape B (code) not Shape A (YAML):
+ * - The export may or may not have project.json — conditional logic is
+ *   cleaner in TS.
+ * - We derive subject and foreignId from project metadata at runtime.
+ *
+ * Source shapes accepted:
+ *   1. A directory containing `memory.json` (the Claude project export root)
+ *   2. A direct path to `memory.json`
+ *   3. The wrapper `{ memories: [...] }` OR a top-level array (same as ChatGPT)
+ *
+ * Usage:
+ *   flair bridge import claude-project --source ./claude-export --agent <flair-id>
+ */
+
+import { promises as fsp } from "node:fs";
+import { join, dirname } from "node:path";
+import type { BridgeContext, BridgeMemory, MemoryBridge } from "../types.js";
+import { BridgeRuntimeError } from "../types.js";
+
+interface RawClaudeMemory {
+  id?: string;
+  content?: string;
+  text?: string;
+  created_at?: string;
+}
+
+interface RawClaudeProject {
+  name?: string;
+  [key: string]: unknown;
+}
+
+async function* importClaudeProject(
+  opts: Record<string, unknown>,
+  ctx: BridgeContext,
+): AsyncIterable<BridgeMemory> {
+  // Resolve source path
+  const { isAbsolute, resolve } = await import("node:path");
+  const sourceArg = typeof opts.source === "string" ? opts.source : "";
+  if (!sourceArg) {
+    throw new BridgeRuntimeError({
+      bridge: "claude-project",
+      op: "import",
+      path: "(unset)",
+      field: "source",
+      expected: "path to memory.json or to the Claude project export directory",
+      got: "missing",
+      hint: "pass --source <path>; example: flair bridge import claude-project --source ./claude-export --agent <id>",
+    });
+  }
+  const sourceAbs = isAbsolute(sourceArg) ? sourceArg : resolve(process.cwd(), sourceArg);
+
+  let filePath: string;
+  let sourceDir: string;
+  try {
+    const stat = await fsp.stat(sourceAbs);
+    if (stat.isDirectory()) {
+      sourceDir = sourceAbs;
+      filePath = join(sourceAbs, "memory.json");
+    } else {
+      sourceDir = dirname(sourceAbs);
+      filePath = sourceAbs;
+    }
+  } catch (err: any) {
+    throw new BridgeRuntimeError({
+      bridge: "claude-project",
+      op: "import",
+      path: sourceAbs,
+      field: "source",
+      expected: "readable file or directory containing memory.json",
+      got: err?.code ?? "ENOENT",
+      hint: `could not resolve source: ${err?.message ?? err}`,
+    });
+  }
+
+  // If the resolved file ends in .zip, give a friendly error
+  if (filePath.endsWith(".zip")) {
+    throw new BridgeRuntimeError({
+      bridge: "claude-project",
+      op: "import",
+      path: filePath,
+      field: "source",
+      expected: "extracted directory or memory.json file",
+      got: "zip archive",
+      hint: `extract the .zip first, then point --source at the extracted directory:\n  unzip ${filePath} -d ./claude-export && flair bridge import claude-project --source ./claude-export --agent <id>`,
+    });
+  }
+
+  ctx.log.info("reading Claude project memory dump", { path: filePath });
+
+  let raw: string;
+  try {
+    raw = await fsp.readFile(filePath, "utf-8");
+  } catch (err: any) {
+    throw new BridgeRuntimeError({
+      bridge: "claude-project",
+      op: "import",
+      path: filePath,
+      field: "source.path",
+      expected: "readable file",
+      got: err?.code ?? "ENOENT",
+      hint: `could not read source file: ${err?.message ?? err}`,
+    });
+  }
+
+  let parsed: any;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (err: any) {
+    throw new BridgeRuntimeError({
+      bridge: "claude-project",
+      op: "import",
+      path: filePath,
+      field: "(document)",
+      expected: "valid JSON",
+      got: "parse error",
+      hint: `JSON parse failed: ${err?.message ?? err}`,
+    });
+  }
+
+  // Accept either { memories: [...] } or a top-level array
+  const memories: RawClaudeMemory[] = Array.isArray(parsed)
+    ? parsed
+    : Array.isArray(parsed?.memories)
+      ? parsed.memories
+      : [];
+
+  if (!Array.isArray(parsed) && !Array.isArray(parsed?.memories)) {
+    throw new BridgeRuntimeError({
+      bridge: "claude-project",
+      op: "import",
+      path: filePath,
+      field: "(document)",
+      expected: "{ memories: [...] } or top-level array",
+      got: typeof parsed,
+      hint: `unexpected shape — keys at root: ${Object.keys(parsed ?? {}).join(", ") || "none"}`,
+    });
+  }
+
+  ctx.log.info("found memories", { count: memories.length });
+
+  // Load project.json (optional) to derive subject and project name for foreignId
+  let projectName = "unknown";
+  try {
+    const projectRaw = await fsp.readFile(join(sourceDir, "project.json"), "utf-8");
+    const project = JSON.parse(projectRaw) as RawClaudeProject;
+    projectName = project.name || "unknown";
+  } catch {
+    // project.json is optional; default to "unknown"
+    ctx.log.debug("no project.json found, using default project name", { dir: sourceDir });
+  }
+
+  const subject = projectName !== "unknown" ? projectName : undefined;
+
+  let kept = 0;
+  let skipped = 0;
+  for (let i = 0; i < memories.length; i++) {
+    const m = memories[i];
+    const content =
+      typeof m === "string" ? m
+      : typeof m?.content === "string" ? m.content
+      : typeof m?.text === "string" ? m.text
+      : null;
+    if (!content || content.trim() === "") {
+      skipped++;
+      continue;
+    }
+    kept++;
+    yield {
+      foreignId: typeof m?.id === "string"
+        ? `claude-project:${projectName}:${m.id}`
+        : `claude-project:${projectName}:idx-${i}`,
+      content,
+      subject,
+      createdAt: typeof m?.created_at === "string" ? m.created_at : undefined,
+      tags: ["source:claude-project", "import:claude-project"],
+      durability: "persistent",
+    };
+  }
+
+  ctx.log.info("import complete", { kept, skipped, project: projectName });
+}
+
+export const claudeProjectMemoryBridge: MemoryBridge = {
+  name: "claude-project",
+  version: 1,
+  kind: "file",
+  description: "Import a Claude project export (memory.json) into Flair",
+  options: {
+    source: {
+      description: "Path to memory.json or to the Claude project export directory.",
+      required: true,
+    },
+  },
+  import: importClaudeProject,
+  // No export — Claude's project store is closed; round-trip would have
+  // nowhere useful to write back to.
+};

--- a/src/bridges/builtins/index.ts
+++ b/src/bridges/builtins/index.ts
@@ -19,6 +19,7 @@ import type {
   YamlBridgeDescriptor,
 } from "../types.js";
 import { agenticStackDescriptor } from "./agentic-stack.js";
+import { claudeProjectMemoryBridge } from "./claude-project.js";
 import { chatgptMemoryBridge } from "./chatgpt.js";
 import { markdownMemoryBridge } from "./markdown.js";
 import { mem0MemoryBridge } from "./mem0.js";
@@ -61,6 +62,7 @@ function builtinPlugin(p: MemoryBridge): BuiltinBridge {
 /** All bridges shipped inside @tpsdev-ai/flair. Order doesn't matter. */
 export const BUILTINS: BuiltinBridge[] = [
   builtinDescriptor(agenticStackDescriptor),
+  builtinPlugin(claudeProjectMemoryBridge),
   builtinPlugin(chatgptMemoryBridge),
   builtinPlugin(markdownMemoryBridge),
   builtinPlugin(mem0MemoryBridge),

--- a/test/unit/bridge-claude-project.test.ts
+++ b/test/unit/bridge-claude-project.test.ts
@@ -1,0 +1,193 @@
+import { describe, it, expect } from "bun:test";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { claudeProjectMemoryBridge } from "../../src/bridges/builtins/claude-project";
+
+// Minimal stub of BridgeContext
+function fakeCtx() {
+  const logs: Array<{ level: string; msg: string; meta?: any }> = [];
+  return {
+    fetch: globalThis.fetch,
+    log: {
+      debug: (msg: string, meta?: any) => logs.push({ level: "debug", msg, meta }),
+      info:  (msg: string, meta?: any) => logs.push({ level: "info",  msg, meta }),
+      warn:  (msg: string, meta?: any) => logs.push({ level: "warn",  msg, meta }),
+      error: (msg: string, meta?: any) => logs.push({ level: "error", msg, meta }),
+    },
+    cache: {
+      get: async () => null,
+      set: async () => {},
+      del: async () => {},
+    },
+    logs,
+  };
+}
+
+async function collectMemories(opts: any, ctx: any) {
+  const out: any[] = [];
+  for await (const m of claudeProjectMemoryBridge.import!(opts, ctx)) {
+    out.push(m);
+  }
+  return out;
+}
+
+describe("claude-project bridge: import", () => {
+  it("imports memories from { memories: [...] } wrapper", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "flair-claude-test-"));
+    try {
+      writeFileSync(join(dir, "memory.json"), JSON.stringify({
+        memories: [
+          { id: "abc", content: "User prefers dark mode", created_at: "2026-04-15T00:00:00Z" },
+          { id: "def", content: "Project uses Bun runtime" },
+        ],
+      }));
+      const ctx = fakeCtx();
+      const out = await collectMemories({ source: dir }, ctx);
+      expect(out).toHaveLength(2);
+      expect(out[0].content).toBe("User prefers dark mode");
+      expect(out[0].foreignId).toBe("claude-project:unknown:abc");
+      expect(out[0].createdAt).toBe("2026-04-15T00:00:00Z");
+      expect(out[0].tags).toContain("source:claude-project");
+      expect(out[0].tags).toContain("import:claude-project");
+      expect(out[0].durability).toBe("persistent");
+      expect(out[1].foreignId).toBe("claude-project:unknown:def");
+    } finally { rmSync(dir, { recursive: true, force: true }); }
+  });
+
+  it("uses project.json name for subject and foreignId", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "flair-claude-test-"));
+    try {
+      writeFileSync(join(dir, "project.json"), JSON.stringify({
+        name: "my-cool-project",
+        description: "A test project",
+      }));
+      writeFileSync(join(dir, "memory.json"), JSON.stringify({
+        memories: [
+          { id: "x", content: "important fact about my-cool-project" },
+        ],
+      }));
+      const out = await collectMemories({ source: dir }, fakeCtx());
+      expect(out).toHaveLength(1);
+      expect(out[0].content).toBe("important fact about my-cool-project");
+      expect(out[0].foreignId).toBe("claude-project:my-cool-project:x");
+      expect(out[0].subject).toBe("my-cool-project");
+    } finally { rmSync(dir, { recursive: true, force: true }); }
+  });
+
+  it("imports from a top-level array (no wrapper)", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "flair-claude-test-"));
+    try {
+      writeFileSync(join(dir, "memory.json"), JSON.stringify([
+        { id: "x", content: "raw array shape" },
+      ]));
+      const out = await collectMemories({ source: dir }, fakeCtx());
+      expect(out).toHaveLength(1);
+      expect(out[0].content).toBe("raw array shape");
+    } finally { rmSync(dir, { recursive: true, force: true }); }
+  });
+
+  it("skips entries with empty/missing content", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "flair-claude-test-"));
+    try {
+      writeFileSync(join(dir, "memory.json"), JSON.stringify({
+        memories: [
+          { id: "good", content: "real content" },
+          { id: "empty", content: "" },
+          { id: "no-content-field" },
+          { id: "whitespace", content: "   \n\t  " },
+        ],
+      }));
+      const out = await collectMemories({ source: dir }, fakeCtx());
+      expect(out).toHaveLength(1);
+      expect(out[0].foreignId).toBe("claude-project:unknown:good");
+    } finally { rmSync(dir, { recursive: true, force: true }); }
+  });
+
+  it("supports `text` field fallback", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "flair-claude-test-"));
+    try {
+      writeFileSync(join(dir, "memory.json"), JSON.stringify({
+        memories: [
+          { id: "1", text: "older export shape uses 'text'" },
+        ],
+      }));
+      const out = await collectMemories({ source: dir }, fakeCtx());
+      expect(out).toHaveLength(1);
+      expect(out[0].content).toBe("older export shape uses 'text'");
+    } finally { rmSync(dir, { recursive: true, force: true }); }
+  });
+
+  it("accepts a direct file path (not just a directory)", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "flair-claude-test-"));
+    try {
+      const filePath = join(dir, "custom-name.json");
+      writeFileSync(filePath, JSON.stringify({ memories: [{ id: "1", content: "from custom path" }] }));
+      const out = await collectMemories({ source: filePath }, fakeCtx());
+      expect(out).toHaveLength(1);
+      expect(out[0].content).toBe("from custom path");
+    } finally { rmSync(dir, { recursive: true, force: true }); }
+  });
+
+  it("throws a helpful error when --source is missing", async () => {
+    await expect(collectMemories({}, fakeCtx())).rejects.toThrow(/--source/);
+  });
+
+  it("throws a helpful error when source path does not exist", async () => {
+    await expect(collectMemories({ source: "/nonexistent/path/that/should/not/exist" }, fakeCtx()))
+      .rejects.toThrow(/could not resolve source/);
+  });
+
+  it("throws a helpful error when JSON is malformed", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "flair-claude-test-"));
+    try {
+      writeFileSync(join(dir, "memory.json"), "not valid json {");
+      await expect(collectMemories({ source: dir }, fakeCtx())).rejects.toThrow(/JSON parse failed/);
+    } finally { rmSync(dir, { recursive: true, force: true }); }
+  });
+
+  it("throws a helpful error when document shape is unexpected", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "flair-claude-test-"));
+    try {
+      writeFileSync(join(dir, "memory.json"), JSON.stringify({ unrelated_field: "value" }));
+      await expect(collectMemories({ source: dir }, fakeCtx())).rejects.toThrow(/unexpected shape/);
+    } finally { rmSync(dir, { recursive: true, force: true }); }
+  });
+
+  it("throws a friendly error when .zip path is given", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "flair-claude-test-"));
+    try {
+      writeFileSync(join(dir, "export.zip"), "fake zip contents");
+      await expect(collectMemories({ source: join(dir, "export.zip") }, fakeCtx()))
+        .rejects.toThrow(/extract the .zip first/);
+    } finally { rmSync(dir, { recursive: true, force: true }); }
+  });
+
+  it("throws when memory.json is missing from directory", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "flair-claude-test-"));
+    try {
+      // Dir exists but has no memory.json
+      writeFileSync(join(dir, "other.json"), "{}");
+      await expect(collectMemories({ source: dir }, fakeCtx()))
+        .rejects.toThrow(/could not read source file/);
+    } finally { rmSync(dir, { recursive: true, force: true }); }
+  });
+});
+
+describe("claude-project bridge: metadata", () => {
+  it("registers as a 'file' kind builtin", () => {
+    expect(claudeProjectMemoryBridge.name).toBe("claude-project");
+    expect(claudeProjectMemoryBridge.kind).toBe("file");
+    expect(claudeProjectMemoryBridge.version).toBe(1);
+  });
+
+  it("declares a `source` option", () => {
+    expect(claudeProjectMemoryBridge.options?.source).toBeDefined();
+    expect(claudeProjectMemoryBridge.options?.source.required).toBe(true);
+  });
+
+  it("does NOT declare an export side (one-way bridge)", () => {
+    expect(claudeProjectMemoryBridge.export).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

Parses a Claude project export (.zip extracted dir) and imports the project's memories tagged `source:claude-project` + `import:claude-project`.

Completes the SaaS-import trio alongside chatgpt (#374) and mem0 (#376) for the README "switch off SaaS memory" pitch.

## Changes

- **src/bridges/builtins/claude-project.ts** — Shape B code plugin (mirrors chatgpt.ts)
  - Reads `memory.json` from export directory or direct file path
  - Optionally reads `project.json` to derive subject and embed project name in foreignId
  - Supports `{ memories: [...] }` wrapper and top-level array
  - Friendly error for `.zip` paths (prompts user to extract first)
  - `foreignId` format: `claude-project:<project_name>:<memory_id>`
  - Tags: `source:claude-project`, `import:claude-project`; durability: `persistent`

- **src/bridges/builtins/index.ts** — register claude-project in BUILTINS + BUILTIN_BY_NAME

- **test/unit/bridge-claude-project.test.ts** — 15 unit tests
  - With project.json (subject + foreignId derivation)
  - Without project.json (defaults to "unknown")
  - Missing memory.json (ENOENT error)
  - Malformed JSON (parse error)
  - .zip path (friendly extraction error)
  - Direct file path vs directory
  - Top-level array (no wrapper)
  - Text field fallback
  - Empty/missing content skipping
  - Missing --source flag
  - Nonexistent path
  - Unexpected document shape
  - Bridge metadata (kind, options, no export)

## Usage

```sh
flair bridge import claude-project --source ./claude-export --agent <flair-id>
```

## CI

- [x] bun run build:cli ✓
- [x] bun test test/unit/bridge-claude-project.test.ts — 15 pass
- [x] bun test test/unit/ — 840 pass, 0 fail
- [x] bash scripts/check-impl-term-leaks.sh — no leaks

## Why Shape B (code) not Shape A (YAML)
- Conditional logic for optional `project.json` is cleaner in TS
- Derives subject and foreignId from project metadata at runtime
