### PR TITLE
feat(admin): AdminMemory provenance pane — per-memory detail view

### DIFF
--- a/resources/AdminMemory.ts
+++ b/resources/AdminMemory.ts
@@ -2,12 +2,37 @@ import { Resource, databases } from "@harperfast/harper";
 import { layout, htmlResponse, esc } from "./admin-layout.js";
 
 /**
- * GET /AdminMemory — browse and search memories.
+ * GET /AdminMemory                browse + search memories (list view)
+ * GET /AdminMemory?id=<id>        per-memory detail view with full provenance pane
+ *
+ * Provenance pane surfaces:
+ *   - Identity: id, agentId, subject, contentHash
+ *   - Tags (with source:* / import:* highlighted as origin chips)
+ *   - Lineage: derivedFrom, parentId, supersedes (+ reverse: what supersedes this)
+ *   - Lifecycle: createdAt, updatedAt, validFrom, validTo, expiresAt,
+ *     archived/archivedAt/archivedBy, promotionStatus/promotedBy/promotedAt
+ *   - Usage: retrievalCount, lastRetrieved
+ *   - Safety: _safetyFlags
+ *
+ * "memory that follows the agent across orchestrators" — the provenance pane
+ * makes that legible: every memory shows where it came from, what it derived
+ * from, and what it superseded.
  */
 export class AdminMemory extends Resource {
   async get() {
     const request = (this as any).request;
     const url = new URL(request?.url ?? "http://localhost", "http://localhost");
+    const id = url.searchParams.get("id") ?? "";
+
+    if (id) {
+      return this.renderDetail(id);
+    }
+    return this.renderList(url);
+  }
+
+  // ─── List view ─────────────────────────────────────────────────────────────
+
+  async renderList(url: URL) {
     const query = url.searchParams.get("q") ?? "";
     const subject = url.searchParams.get("subject") ?? "";
     const limit = Math.min(Number(url.searchParams.get("limit") ?? 50), 200);
@@ -37,10 +62,10 @@ export class AdminMemory extends Resource {
 
     let tableRows = "";
     if (memories.length === 0) {
-      tableRows = `<tr><td colspan="5" class="empty">No memories found${query ? ` matching "${query}"` : ""}.</td></tr>`;
+      tableRows = `<tr><td colspan="6" class="empty">No memories found${query ? ` matching "${query}"` : ""}.</td></tr>`;
     } else {
       for (const m of memories) {
-        const preview = (m.content || "").slice(0, 120) + ((m.content || "").length > 120 ? "…" : "");
+        const preview = (m.content || "").slice(0, 100) + ((m.content || "").length > 100 ? "…" : "");
         const durability = m.durability ?? "standard";
         const durBadge = durability === "permanent"
           ? `<span class="badge badge-green">${durability}</span>`
@@ -51,11 +76,19 @@ export class AdminMemory extends Resource {
         const created = m.createdAt?.slice(0, 10) ?? "—";
         const validity = m.validTo ? `<small>expired ${m.validTo.slice(0, 10)}</small>` : "";
 
+        // Surface a small "origin" hint in the list — the source:* tag if
+        // present, otherwise blank. Full provenance lives on the detail view.
+        const sourceTag = (m.tags ?? []).find((t: string) => t.startsWith("source:"));
+        const origin = sourceTag
+          ? `<span class="badge badge-yellow">${esc(sourceTag.replace("source:", ""))}</span>`
+          : "—";
+
         tableRows += `
           <tr>
-            <td style="max-width:400px">${esc(preview)}</td>
+            <td style="max-width:380px"><a href="/AdminMemory?id=${esc(m.id)}" style="color:#2563eb;text-decoration:none">${esc(preview)}</a></td>
             <td>${durBadge}</td>
             <td>${esc(subjectStr)}</td>
+            <td>${origin}</td>
             <td>${esc(m.agentId ?? "—")}</td>
             <td>${created} ${validity}</td>
           </tr>`;
@@ -82,6 +115,7 @@ export class AdminMemory extends Resource {
             <th>Content</th>
             <th>Durability</th>
             <th>Subject</th>
+            <th>Origin</th>
             <th>Agent</th>
             <th>Created</th>
           </tr>
@@ -93,5 +127,188 @@ export class AdminMemory extends Resource {
     `;
 
     return htmlResponse(layout("Memory", content, "memory"));
+  }
+
+  // ─── Detail view ───────────────────────────────────────────────────────────
+
+  async renderDetail(id: string) {
+    const memDb = (databases as any).flair.Memory;
+
+    let memory: any = null;
+    try {
+      memory = await memDb.get(id);
+    } catch { /* table missing or other error */ }
+
+    if (!memory) {
+      const notFound = `
+        <h1>Memory not found</h1>
+        <p class="subtitle">No memory with id <code>${esc(id)}</code>.</p>
+        <p><a href="/AdminMemory" class="btn btn-primary">Back to memory list</a></p>
+      `;
+      return htmlResponse(layout("Memory not found", notFound, "memory"));
+    }
+
+    // Lookup memories that supersede this one (reverse of supersedes field).
+    const supersededBy: any[] = [];
+    try {
+      for await (const m of memDb.search({ conditions: [{ attribute: "supersedes", comparator: "equals", value: id }] })) {
+        supersededBy.push(m);
+        if (supersededBy.length >= 5) break;
+      }
+    } catch { /* swallow */ }
+
+    // Reverse-lookup: memories whose derivedFrom contains this id.
+    // Note: derivedFrom is an array; Harper's contains-on-array search via
+    // search_by_value is used here. If unavailable, leave empty.
+    const derivatives: any[] = [];
+    try {
+      for await (const m of memDb.search({ conditions: [{ attribute: "derivedFrom", comparator: "contains", value: id }] })) {
+        derivatives.push(m);
+        if (derivatives.length >= 5) break;
+      }
+    } catch { /* swallow */ }
+
+    const content = this.renderProvenancePane(memory, supersededBy, derivatives);
+    return htmlResponse(layout(`Memory ${id.slice(0, 8)}…`, content, "memory"));
+  }
+
+  // ─── Provenance pane HTML ──────────────────────────────────────────────────
+
+  renderProvenancePane(m: any, supersededBy: any[], derivatives: any[]): string {
+    const tags: string[] = Array.isArray(m.tags) ? m.tags : [];
+    const sourceTag = tags.find((t) => t.startsWith("source:"));
+    const importTag = tags.find((t) => t.startsWith("import:"));
+    const otherTags = tags.filter((t) => !t.startsWith("source:") && !t.startsWith("import:"));
+
+    const tagChips = [
+      sourceTag ? `<span class="badge badge-yellow" title="origin">${esc(sourceTag)}</span>` : "",
+      importTag ? `<span class="badge badge-blue" title="import path">${esc(importTag)}</span>` : "",
+      ...otherTags.map((t) => `<span class="badge badge-gray">${esc(t)}</span>`),
+    ].filter(Boolean).join(" ");
+
+    // Lineage links (derivedFrom + parentId + supersedes pointers)
+    const derivedFrom: string[] = Array.isArray(m.derivedFrom) ? m.derivedFrom : [];
+    const derivedFromLinks = derivedFrom.length > 0
+      ? derivedFrom.map((d) => `<a href="/AdminMemory?id=${esc(d)}" style="color:#2563eb">${esc(d.slice(0, 12))}…</a>`).join(", ")
+      : "<em style='color:#888'>none</em>";
+
+    const parentLink = m.parentId
+      ? `<a href="/AdminMemory?id=${esc(m.parentId)}" style="color:#2563eb">${esc(m.parentId.slice(0, 12))}…</a>`
+      : "<em style='color:#888'>none</em>";
+
+    const supersedesLink = m.supersedes
+      ? `<a href="/AdminMemory?id=${esc(m.supersedes)}" style="color:#2563eb">${esc(m.supersedes.slice(0, 12))}…</a>`
+      : "<em style='color:#888'>nothing — this is an original</em>";
+
+    const supersededByLinks = supersededBy.length > 0
+      ? supersededBy.map((s) => `<a href="/AdminMemory?id=${esc(s.id)}" style="color:#2563eb">${esc(s.id.slice(0, 12))}…</a>`).join(", ")
+      : "<em style='color:#888'>nothing — this is current</em>";
+
+    const derivativesLinks = derivatives.length > 0
+      ? derivatives.map((d) => `<a href="/AdminMemory?id=${esc(d.id)}" style="color:#2563eb">${esc(d.id.slice(0, 12))}…</a>`).join(", ")
+      : "<em style='color:#888'>none</em>";
+
+    // Promotion details (if promoted)
+    const promotionInfo = m.promotionStatus
+      ? `<dl style="display:grid;grid-template-columns:140px 1fr;gap:8px;margin-top:8px">
+           <dt style="color:#666">Status</dt><dd>${esc(m.promotionStatus)}</dd>
+           ${m.promotedAt ? `<dt style="color:#666">Promoted at</dt><dd>${esc(m.promotedAt)}</dd>` : ""}
+           ${m.promotedBy ? `<dt style="color:#666">Promoted by</dt><dd>${esc(m.promotedBy)}</dd>` : ""}
+         </dl>`
+      : "<em style='color:#888'>not promoted</em>";
+
+    // Archive details
+    const archiveInfo = m.archived
+      ? `<dl style="display:grid;grid-template-columns:140px 1fr;gap:8px;margin-top:8px">
+           <dt style="color:#666">Archived at</dt><dd>${esc(m.archivedAt ?? "—")}</dd>
+           <dt style="color:#666">Archived by</dt><dd>${esc(m.archivedBy ?? "—")}</dd>
+         </dl>`
+      : "<em style='color:#888'>active</em>";
+
+    const safetyFlags: string[] = Array.isArray(m._safetyFlags) ? m._safetyFlags : [];
+    const safetyDisplay = safetyFlags.length > 0
+      ? safetyFlags.map((f) => `<span class="badge badge-yellow">${esc(f)}</span>`).join(" ")
+      : "<em style='color:#888'>clean</em>";
+
+    return `
+      <div style="margin-bottom:16px">
+        <a href="/AdminMemory" style="color:#666;text-decoration:none;font-size:0.9em">← Back to memory list</a>
+      </div>
+
+      <h1>Memory ${esc(m.id.slice(0, 8))}…</h1>
+      <p class="subtitle">
+        agentId: <code>${esc(m.agentId ?? "—")}</code> ·
+        subject: ${m.subject ? `<code>${esc(m.subject)}</code>` : "—"}
+      </p>
+
+      <div class="card">
+        <h3>Content</h3>
+        <p style="white-space:pre-wrap;font-family:ui-monospace,SF Mono,monospace;font-size:0.95em;line-height:1.5;margin-top:8px">${esc(m.content ?? "")}</p>
+        ${m.summary ? `<div style="margin-top:12px;padding-top:12px;border-top:1px solid #eee"><strong style="color:#666;font-size:0.85em">SUMMARY</strong><p style="margin-top:4px">${esc(m.summary)}</p></div>` : ""}
+      </div>
+
+      <div class="card">
+        <h3>Tags</h3>
+        <div style="margin-top:8px;display:flex;gap:6px;flex-wrap:wrap">
+          ${tagChips || "<em style='color:#888'>untagged</em>"}
+        </div>
+      </div>
+
+      <div class="card">
+        <h3>Lineage</h3>
+        <dl style="display:grid;grid-template-columns:200px 1fr;gap:10px;margin-top:8px">
+          <dt style="color:#666">Derived from</dt><dd>${derivedFromLinks}</dd>
+          <dt style="color:#666">Parent</dt><dd>${parentLink}</dd>
+          <dt style="color:#666">Supersedes</dt><dd>${supersedesLink}</dd>
+          <dt style="color:#666">Superseded by</dt><dd>${supersededByLinks}</dd>
+          <dt style="color:#666">Derivatives (downstream)</dt><dd>${derivativesLinks}</dd>
+          ${m.sessionId ? `<dt style="color:#666">Session</dt><dd><code>${esc(m.sessionId)}</code></dd>` : ""}
+        </dl>
+      </div>
+
+      <div class="card">
+        <h3>Lifecycle</h3>
+        <dl style="display:grid;grid-template-columns:200px 1fr;gap:10px;margin-top:8px">
+          <dt style="color:#666">Durability</dt><dd>${esc(m.durability ?? "standard")}</dd>
+          <dt style="color:#666">Created</dt><dd>${esc(m.createdAt ?? "—")}</dd>
+          <dt style="color:#666">Updated</dt><dd>${esc(m.updatedAt ?? "—")}</dd>
+          <dt style="color:#666">Valid from</dt><dd>${esc(m.validFrom ?? "—")}</dd>
+          <dt style="color:#666">Valid to</dt><dd>${esc(m.validTo ?? "still valid")}</dd>
+          <dt style="color:#666">Expires</dt><dd>${esc(m.expiresAt ?? "never")}</dd>
+        </dl>
+      </div>
+
+      <div class="card">
+        <h3>Promotion</h3>
+        ${promotionInfo}
+      </div>
+
+      <div class="card">
+        <h3>Archive</h3>
+        ${archiveInfo}
+      </div>
+
+      <div class="card">
+        <h3>Usage</h3>
+        <dl style="display:grid;grid-template-columns:200px 1fr;gap:10px;margin-top:8px">
+          <dt style="color:#666">Retrievals</dt><dd>${m.retrievalCount ?? 0}</dd>
+          <dt style="color:#666">Last retrieved</dt><dd>${esc(m.lastRetrieved ?? "—")}</dd>
+        </dl>
+      </div>
+
+      <div class="card">
+        <h3>Safety</h3>
+        ${safetyDisplay}
+      </div>
+
+      <div class="card" style="background:#f8f9fa">
+        <h3 style="color:#666;font-size:0.9em">RAW IDENTITY</h3>
+        <dl style="display:grid;grid-template-columns:200px 1fr;gap:6px;margin-top:8px;font-family:ui-monospace,SF Mono,monospace;font-size:0.85em">
+          <dt style="color:#666">id</dt><dd>${esc(m.id)}</dd>
+          <dt style="color:#666">contentHash</dt><dd>${esc(m.contentHash ?? "—")}</dd>
+          <dt style="color:#666">visibility</dt><dd>${esc(m.visibility ?? "private")}</dd>
+        </dl>
+      </div>
+    `;
   }
 }


### PR DESCRIPTION
## Summary

Extends `/AdminMemory` with a per-memory drill-down that surfaces every provenance signal already in the schema. List view stays the default; clicking any memory opens `/AdminMemory?id=<id>` with the full provenance pane.

**Why this matters strategically:** the README thesis is "memory that follows the agent across orchestrators." Until now, an operator browsing AdminMemory could see *what* was stored but not *where it came from*. The provenance pane makes the stack legible — origin tags, dedup ancestors, version chains, promotion lineage.

## Provenance pane sections

| Section | Surfaces |
|---|---|
| Content | Full text + `summary` if present |
| Tags | `source:*` / `import:*` highlighted as origin chips; rest as gray badges |
| Lineage | `derivedFrom` (forward), `parentId`, `supersedes`, **superseded-by** (reverse), **derivatives** (reverse — memories whose derivedFrom contains this id), `sessionId` |
| Lifecycle | durability, createdAt, updatedAt, validFrom, validTo, expiresAt |
| Promotion | promotionStatus + promotedAt + promotedBy |
| Archive | archivedAt + archivedBy |
| Usage | retrievalCount, lastRetrieved |
| Safety | `_safetyFlags` |
| Raw identity | id, contentHash, visibility |

## List view changes

- New **Origin** column showing the `source:*` tag if present (yellow chip)
- Content preview is now a link to the detail view
- Preview width slightly tightened to make room for the link

## Implementation notes

- Single Resource handles both views via `?id=<id>` query param
- Reverse lookups (superseded-by, derivatives) bounded at 5 each to cap render cost on highly-derived chains
- Federation peer source field **not surfaced yet** — Memory schema doesn't track origin-peer explicitly. Filed as follow-up to add that signal in a future schema bump

## Test plan

- [x] `bun test test/unit/` → 854/854 pass (no regressions)
- [x] `bunx tsc --noEmit -p tsconfig.check.json` → clean
- [x] Pre-commit (workspace-deps + dep-ages + impl-term-leaks) all green
- [ ] Live browser smoke against rockit Flair after merge (CI integration tests exercise the resource server-side)

🤖 Generated with [Claude Code](https://claude.com/claude-code)