### PR TITLE
feat(n8n-nodes-flair): FlairWrite node + K&S review capture worked example (q3qf-PR-7)

### DIFF
--- a/packages/n8n-nodes-flair/examples/ks-review-capture/README.md
+++ b/packages/n8n-nodes-flair/examples/ks-review-capture/README.md
@@ -1,0 +1,87 @@
+# Worked example: K&S review capture → Flair
+
+This is the worked-example workflow for `@tpsdev-ai/n8n-nodes-flair`. It captures inbound TPS-mail review notes from the Kern (architecture) and Sherlock (security) review agents into Flair as structured, tagged memories — turning ephemeral review reasoning into a searchable, federated archive.
+
+It's also our first dogfood loop on n8n: every K&S review verdict that lands in Flint's TPS-mail inbox gets persisted with semantic search, durable across sessions and orchestrators.
+
+## Why this workflow earns the worked-example slot
+
+The q3qf positioning table calls out Flair's **agent-knowledge shape** vs n8n's built-in conversation-buffer memory connectors. This workflow is that shape in practice:
+
+- Captures **reasoning** (multi-paragraph review prose), not turn-by-turn chat
+- Tags every memory with the agent who wrote it, the PR number it's about, and the date — making queries like *"what does Sherlock typically flag in auth code"* or *"Kern's view on schema migrations"* possible six months later
+- Writes through the `@tpsdev-ai/n8n-nodes-flair` **Flair Write** node — the structured-write surface, not the LangChain chat-buffer adapter
+- Single-direction (TPS-mail → Flair); no cross-orchestrator chatter
+
+A second worked example (Pulse intel → Flair) was scoped originally but Pulse posts to Discord directly and never crosses TPS mail; this captured the higher-volume, higher-reasoning-density signal source instead.
+
+## Pipeline
+
+```
+Schedule (5 min) → ls ~/.tps/mail/flint/new/*.json → Split paths
+  → Read each file → Parse JSON → Filter from ∈ {kern, sherlock}
+  → Dedup by mail.id (workflow static data)
+  → Format (compose content, derive tags, set subject)
+  → Flair Write (durability=persistent, type=decision)
+```
+
+Notes on each step:
+
+- **Schedule trigger** — every 5 minutes. n8n also has a `Local File Trigger` node that watches a directory; we picked the schedule pattern because it doesn't compete with Flint's own mail consumer for file events. The two consumers cohabit cleanly: Flint may move files, n8n only reads.
+- **List inbox files** — bash one-liner. Returns one path per line on `stdout`; the next node splits it. Avoids a node-specific "list directory" abstraction and keeps the workflow portable to anywhere a similar maildir lives.
+- **Read + parse** — n8n's `Read Binary File` + `Extract from File` (`fromJson` mode). The mail file is dropped into `$json.mail`.
+- **Filter K&S only** — `containedInList` on `mail.from`. Flexible if you want to add `host` or `ember` later — comma-extend the list value.
+- **Skip already-written** — the dedup node uses `getWorkflowStaticData('global').processedIds` to avoid re-writing a memory each tick. Trims itself at >5000 entries (keeps last 4000) so the static data file doesn't bloat. Mail files in `flint/new/` may sit for hours before Flint drains them; without this, every tick would write the same review again.
+- **Format memory** — composes a multi-line content string, tries to extract a PR number from the body to tag/subject, and produces the `tags` and `subject` fields the Flair Write node consumes. PR-tagged memories share a `subject` so they group cleanly in `getBySubject` queries.
+- **Flair Write** — durability `persistent` (review reasoning is high-value, deserves the durable tier), type `decision` (review verdicts are decisions), tags surface the agent + date + PR for cross-cutting search.
+
+## Setup
+
+1. **Install the node**:
+   ```sh
+   # in your n8n custom-extensions dir (~/.n8n/custom by default)
+   npm install @tpsdev-ai/n8n-nodes-flair
+   ```
+   Or, if you ship a community-nodes-enabled n8n, add it via the in-app community node installer.
+
+2. **Configure the Flair credential**:
+   - Settings → Credentials → New → Flair API
+   - Base URL: `http://127.0.0.1:9926` (or your Flair host)
+   - Agent ID: any agent who should *own* the imported memories (e.g., `flint`, `pulse`, `archive`)
+   - Admin Password: contents of `~/.flair/admin-pass`
+
+3. **Import this workflow**:
+   - Workflows → Import from File → select `workflow.json` from this dir
+   - Open the **Flair Write** node, point its credential at the Flair API credential you just created
+   - Adjust the inbox path in **List inbox files** if your TPS mail lives elsewhere
+
+4. **Activate** — toggle the workflow active. First tick within 5 minutes.
+
+5. **Verify in Flair**:
+   ```sh
+   # search by tag
+   FLAIR_URL=http://127.0.0.1:9926 flair memory search "" \
+     --agent flint --tags kind:review --limit 5
+
+   # search by PR
+   FLAIR_URL=http://127.0.0.1:9926 flair memory search "" \
+     --subject pr-380 --limit 10
+   ```
+
+## Tuning knobs
+
+- **Filter expansion**: add `host`, `ember`, or any agent to the `containedInList` value to capture more sources. Pair with a `kind:` tag-update in the Format step so the search story stays clean.
+- **Deeper formatting**: the Format step is a Code node — you can pull more structure out of the body (e.g., bullet-point analysis vs paragraph prose), set `validFrom`/`validTo` for time-bounded reasoning, or branch durability by content (security flags → `permanent`, info → `standard`).
+- **Cross-instance**: this workflow writes to *one* Flair instance. The hub-spoke federation pair (rockit ↔ Fabric) propagates the writes without further n8n changes — every memory captured here becomes searchable from every federated peer.
+
+## Operational notes
+
+- The dedup index is workflow-static-data scoped, so re-importing the workflow (new ID) starts fresh. If you want hard de-duplication across imports, key the dedup off `mail.id` directly into Flair using `flair.memory.write` with a deterministic ID or a `foreignId` tag, and let Flair's content-hash dedup handle it.
+- The schedule trigger is 5 min on purpose — fast enough for review-mail freshness, slow enough that the inbox listing isn't burning CPU.
+- If Flint's inbox is full (the 100-message hard cap), TPS bounces inbound mail; this workflow only sees what's actually delivered. The inbox-cap is a separate operational concern (see `reference_flint_inbox_cap`).
+
+## What this dogfood loop is for
+
+Six months from now, when we want to know *what reasoning Sherlock typically applies to bridge-loading code*, we'll have a real archive. Today's review mail is reasoning that decays the moment the Discord/inbox scrolls past. This workflow is the bet that capturing the reasoning durably will compound into measurable signal.
+
+If after a month of dogfooding the search results turn up genuine value (we use them to inform new specs, new dispatches, new architecture decisions), we lift the workflow to a more durable host (own VM, or Pulse VM if we consolidate) and add it to the standard rockit deploy. If signal is noisy, no infra to dismantle — just deactivate.

--- a/packages/n8n-nodes-flair/examples/ks-review-capture/workflow.json
+++ b/packages/n8n-nodes-flair/examples/ks-review-capture/workflow.json
@@ -1,0 +1,194 @@
+{
+  "name": "K&S review capture → Flair",
+  "nodes": [
+    {
+      "parameters": {
+        "rule": {
+          "interval": [
+            {
+              "field": "minutes",
+              "minutesInterval": 5
+            }
+          ]
+        }
+      },
+      "id": "trigger-schedule",
+      "name": "Every 5 min",
+      "type": "n8n-nodes-base.scheduleTrigger",
+      "typeVersion": 1.2,
+      "position": [240, 300]
+    },
+    {
+      "parameters": {
+        "command": "ls -1 /Users/squeued/.tps/mail/flint/new/*.json 2>/dev/null || true"
+      },
+      "id": "list-inbox",
+      "name": "List inbox files",
+      "type": "n8n-nodes-base.executeCommand",
+      "typeVersion": 1,
+      "position": [460, 300]
+    },
+    {
+      "parameters": {
+        "fieldToSplitOut": "stdout",
+        "options": {}
+      },
+      "id": "split-paths",
+      "name": "Split file paths",
+      "type": "n8n-nodes-base.itemLists",
+      "typeVersion": 3,
+      "position": [680, 300],
+      "notesInFlow": true,
+      "notes": "stdout is one filename per line; Item Lists 'Split Out Items' produces one item per line."
+    },
+    {
+      "parameters": {
+        "fileSelector": "={{ $json.stdout }}",
+        "options": {}
+      },
+      "id": "read-file",
+      "name": "Read mail JSON",
+      "type": "n8n-nodes-base.readBinaryFile",
+      "typeVersion": 1,
+      "position": [900, 300]
+    },
+    {
+      "parameters": {
+        "operation": "fromJson",
+        "destinationKey": "mail",
+        "options": {}
+      },
+      "id": "parse-json",
+      "name": "Parse JSON",
+      "type": "n8n-nodes-base.extractFromFile",
+      "typeVersion": 1,
+      "position": [1120, 300]
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "options": {
+            "caseSensitive": true,
+            "typeValidation": "strict",
+            "version": 2
+          },
+          "conditions": [
+            {
+              "id": "from-is-ks",
+              "leftValue": "={{ $json.mail.from }}",
+              "rightValue": "kern,sherlock",
+              "operator": {
+                "type": "string",
+                "operation": "containedInList"
+              }
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      },
+      "id": "filter-ks",
+      "name": "Filter K&S only",
+      "type": "n8n-nodes-base.filter",
+      "typeVersion": 2.2,
+      "position": [1340, 300]
+    },
+    {
+      "parameters": {
+        "jsCode": "// Dedup: skip mails we've already written to Flair.\n// Uses workflow static data as a compact processed-id set.\nconst staticData = $getWorkflowStaticData('global');\nstaticData.processedIds = staticData.processedIds || {};\n\nconst out = [];\nfor (const item of $input.all()) {\n  const mail = item.json.mail;\n  const id = mail.id;\n  if (!id || staticData.processedIds[id]) continue;\n  staticData.processedIds[id] = new Date().toISOString();\n  // Trim the static-data set if it gets large (keep last 5000 ids)\n  const ids = Object.keys(staticData.processedIds);\n  if (ids.length > 5000) {\n    const sortedByTime = ids.sort((a, b) => (staticData.processedIds[a] < staticData.processedIds[b] ? -1 : 1));\n    for (const old of sortedByTime.slice(0, 1000)) delete staticData.processedIds[old];\n  }\n  out.push({ json: { mail } });\n}\nreturn out;\n"
+      },
+      "id": "dedup",
+      "name": "Skip already-written",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [1560, 300]
+    },
+    {
+      "parameters": {
+        "jsCode": "// Format the memory before write: build content, derive tags, set subject.\n// `mail` shape: { id, from, to, timestamp, body, headers }\nfor (const item of $input.all()) {\n  const m = item.json.mail;\n  const ts = m.timestamp || new Date().toISOString();\n  const day = ts.slice(0, 10);\n  // Try to extract a PR number from the body for foreignKey tagging\n  const prMatch = (m.body || '').match(/#(\\d{2,5})/);\n  const prTag = prMatch ? `pr:${prMatch[1]}` : null;\n  // Compose the memory body\n  const content = [\n    `${m.from} review note (${day}):`,\n    '',\n    m.body,\n  ].join('\\n');\n  // Tags\n  const tags = [\n    'source:tps-mail',\n    'kind:review',\n    `agent:${m.from}`,\n    `date:${day}`,\n    prTag,\n  ].filter(Boolean).join(', ');\n  const subject = prTag ? `pr-${prMatch[1]}` : `${m.from}-${day}`;\n  item.json = {\n    ...item.json,\n    content,\n    tags,\n    subject,\n  };\n}\nreturn $input.all();\n"
+      },
+      "id": "format",
+      "name": "Format memory",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [1780, 300]
+    },
+    {
+      "parameters": {
+        "content": "={{ $json.content }}",
+        "subject": "={{ $json.subject }}",
+        "tags": "={{ $json.tags }}",
+        "durability": "persistent",
+        "type": "decision",
+        "skipEmpty": true
+      },
+      "id": "flair-write",
+      "name": "Flair Write",
+      "type": "@tpsdev-ai/n8n-nodes-flair.flairWrite",
+      "typeVersion": 1,
+      "position": [2000, 300],
+      "credentials": {
+        "flairApi": {
+          "id": "REPLACE-ME",
+          "name": "Flair (rockit)"
+        }
+      }
+    }
+  ],
+  "connections": {
+    "Every 5 min": {
+      "main": [
+        [{ "node": "List inbox files", "type": "main", "index": 0 }]
+      ]
+    },
+    "List inbox files": {
+      "main": [
+        [{ "node": "Split file paths", "type": "main", "index": 0 }]
+      ]
+    },
+    "Split file paths": {
+      "main": [
+        [{ "node": "Read mail JSON", "type": "main", "index": 0 }]
+      ]
+    },
+    "Read mail JSON": {
+      "main": [
+        [{ "node": "Parse JSON", "type": "main", "index": 0 }]
+      ]
+    },
+    "Parse JSON": {
+      "main": [
+        [{ "node": "Filter K&S only", "type": "main", "index": 0 }]
+      ]
+    },
+    "Filter K&S only": {
+      "main": [
+        [{ "node": "Skip already-written", "type": "main", "index": 0 }]
+      ]
+    },
+    "Skip already-written": {
+      "main": [
+        [{ "node": "Format memory", "type": "main", "index": 0 }]
+      ]
+    },
+    "Format memory": {
+      "main": [
+        [{ "node": "Flair Write", "type": "main", "index": 0 }]
+      ]
+    }
+  },
+  "active": false,
+  "settings": {
+    "executionOrder": "v1"
+  },
+  "tags": [
+    {
+      "name": "flair",
+      "createdAt": "2026-05-10T19:30:00.000Z"
+    },
+    {
+      "name": "dogfood",
+      "createdAt": "2026-05-10T19:30:00.000Z"
+    }
+  ]
+}

--- a/packages/n8n-nodes-flair/package.json
+++ b/packages/n8n-nodes-flair/package.json
@@ -24,7 +24,8 @@
     ],
     "nodes": [
       "dist/nodes/FlairChatMemory/FlairChatMemory.node.js",
-      "dist/nodes/FlairSearch/FlairSearch.node.js"
+      "dist/nodes/FlairSearch/FlairSearch.node.js",
+      "dist/nodes/FlairWrite/FlairWrite.node.js"
     ]
   },
   "engines": {

--- a/packages/n8n-nodes-flair/src/nodes/FlairWrite/FlairWrite.node.ts
+++ b/packages/n8n-nodes-flair/src/nodes/FlairWrite/FlairWrite.node.ts
@@ -1,0 +1,219 @@
+/**
+ * FlairWrite — pipeline-mode node that writes a memory into Flair.
+ *
+ * Complement to FlairSearch (read-only AI Tool) and FlairChatMemory
+ * (LangChain BaseMemory adapter). FlairWrite is a regular Main-input /
+ * Main-output node intended for capture-and-archive workflows: take an
+ * incoming item (a TPS mail, a webhook payload, a parsed document) and
+ * persist its content as a Flair memory with operator-chosen tags,
+ * subject, and durability.
+ *
+ * Why a separate node from FlairSearch:
+ *   - FlairSearch is wired into the AI Tool socket; it's read-only by
+ *     design (write-as-LLM-tool needs guardrails we haven't designed
+ *     yet — content sanitization, rate limiting, audit trail).
+ *   - FlairWrite is operator-driven. Side effects are intentional and
+ *     scoped to the workflow author's choices, not the LLM's.
+ *   - Splitting keeps the AI-Tool-only contract on FlairSearch clean
+ *     and lets each node evolve independently.
+ *
+ * The dual-purpose alternative (one node with both AI Tool and Main
+ * sockets) is possible in n8n but harder to reason about — the same
+ * configuration would surface differently depending on which socket
+ * the user wires it to. Two narrow nodes are easier to discover and
+ * easier to dogfood.
+ */
+
+import {
+  type IExecuteFunctions,
+  type INodeExecutionData,
+  type INodeType,
+  type INodeTypeDescription,
+  NodeConnectionTypes,
+} from "n8n-workflow";
+
+import { FlairClient } from "@tpsdev-ai/flair-client";
+
+interface FlairCredentials {
+  baseUrl: string;
+  agentId: string;
+  adminPassword: string;
+}
+
+function makeClient(credentials: FlairCredentials): FlairClient {
+  return new FlairClient({
+    url: credentials.baseUrl,
+    agentId: credentials.agentId,
+    adminUser: "admin",
+    adminPassword: credentials.adminPassword,
+  });
+}
+
+export class FlairWrite implements INodeType {
+  description: INodeTypeDescription = {
+    displayName: "Flair Write",
+    name: "flairWrite",
+    icon: "file:flair.svg",
+    group: ["output"],
+    version: [1],
+    description:
+      "Write a memory into Flair from a workflow item. Use for capture-and-archive flows (mail → memory, webhook → memory, parsed-doc → memory).",
+    defaults: {
+      name: "Flair Write",
+    },
+    credentials: [
+      {
+        name: "flairApi",
+        required: true,
+      },
+    ],
+    codex: {
+      categories: ["AI"],
+      subcategories: {
+        AI: ["Memory"],
+      },
+      resources: {
+        primaryDocumentation: [
+          {
+            url: "https://github.com/tpsdev-ai/flair#n8n",
+          },
+        ],
+      },
+    },
+    inputs: [NodeConnectionTypes.Main],
+    outputs: [NodeConnectionTypes.Main],
+    properties: [
+      {
+        displayName: "Content",
+        name: "content",
+        type: "string",
+        typeOptions: { rows: 4 },
+        default: "={{ $json.content }}",
+        required: true,
+        description:
+          "The memory content to store. Defaults to the input item's `content` field; override with any expression that produces a string.",
+      },
+      {
+        displayName: "Subject",
+        name: "subject",
+        type: "string",
+        default: "",
+        description:
+          "Optional subject (the entity / conversation / topic this memory is about). Maps to Flair's `subject` field. Leave blank to omit.",
+      },
+      {
+        displayName: "Tags",
+        name: "tags",
+        type: "string",
+        default: "",
+        description:
+          'Comma-separated tags (e.g. "source:tps-mail, kind:review, agent:kern"). Whitespace around commas is trimmed.',
+      },
+      {
+        displayName: "Durability",
+        name: "durability",
+        type: "options",
+        options: [
+          { name: "Standard (default)", value: "standard" },
+          { name: "Persistent (key decisions)", value: "persistent" },
+          { name: "Permanent (inviolable)", value: "permanent" },
+          { name: "Ephemeral (auto-expires 72h)", value: "ephemeral" },
+        ],
+        default: "standard",
+        description:
+          "Durability tier. See Flair docs for the semantic differences.",
+      },
+      {
+        displayName: "Type",
+        name: "type",
+        type: "options",
+        options: [
+          { name: "Session (default)", value: "session" },
+          { name: "Lesson", value: "lesson" },
+          { name: "Decision", value: "decision" },
+          { name: "Preference", value: "preference" },
+          { name: "Fact", value: "fact" },
+          { name: "Goal", value: "goal" },
+        ],
+        default: "session",
+        description: "Memory type. Used by Flair's downstream filters and ranking.",
+      },
+      {
+        displayName: "Skip Empty Content",
+        name: "skipEmpty",
+        type: "boolean",
+        default: true,
+        description:
+          "If on, items whose content evaluates to an empty/whitespace-only string are passed through without writing. Off = the node throws on empty content (fail-loud for required-field workflows).",
+      },
+    ],
+  };
+
+  async execute(this: IExecuteFunctions): Promise<INodeExecutionData[][]> {
+    const credentials = (await this.getCredentials("flairApi")) as unknown as FlairCredentials;
+    const flair = makeClient(credentials);
+    const inputs = this.getInputData();
+    const out: INodeExecutionData[] = [];
+
+    for (let i = 0; i < inputs.length; i++) {
+      const content = this.getNodeParameter("content", i) as string;
+      const subject = this.getNodeParameter("subject", i, "") as string;
+      const tagsStr = this.getNodeParameter("tags", i, "") as string;
+      const durability = this.getNodeParameter("durability", i, "standard") as
+        | "standard"
+        | "persistent"
+        | "permanent"
+        | "ephemeral";
+      const type = this.getNodeParameter("type", i, "session") as
+        | "session"
+        | "lesson"
+        | "decision"
+        | "preference"
+        | "fact"
+        | "goal";
+      const skipEmpty = this.getNodeParameter("skipEmpty", i, true) as boolean;
+
+      const trimmedContent = (content ?? "").trim();
+      if (trimmedContent === "") {
+        if (skipEmpty) {
+          // Pass-through: surface that we skipped, but don't error.
+          out.push({
+            json: { ...inputs[i].json, _flair_skipped: "empty content" },
+            pairedItem: { item: i },
+          });
+          continue;
+        }
+        throw new Error(
+          `FlairWrite: empty content on item ${i} (skipEmpty is off). ` +
+            `Content evaluated to "${content ?? ""}".`,
+        );
+      }
+
+      const tags = tagsStr
+        .split(",")
+        .map((t) => t.trim())
+        .filter((t) => t.length > 0);
+
+      const result = await flair.memory.write(trimmedContent, {
+        type,
+        durability,
+        tags: tags.length > 0 ? tags : undefined,
+        subject: subject || undefined,
+      });
+
+      out.push({
+        json: {
+          ...inputs[i].json,
+          _flair_id: result.id,
+          _flair_subject: subject || null,
+          _flair_tags: tags,
+          _flair_durability: durability,
+          _flair_type: type,
+        },
+        pairedItem: { item: i },
+      });
+    }
+
+    return [out];
+  }
+}

--- a/packages/n8n-nodes-flair/test/FlairWrite.test.ts
+++ b/packages/n8n-nodes-flair/test/FlairWrite.test.ts
@@ -1,0 +1,67 @@
+import { describe, test, expect } from "bun:test";
+import { FlairWrite } from "../src/nodes/FlairWrite/FlairWrite.node";
+
+describe("FlairWrite node description", () => {
+  const node = new FlairWrite();
+
+  test("identifies as flairWrite on the Main socket", () => {
+    expect(node.description.name).toBe("flairWrite");
+    expect(node.description.displayName).toBe("Flair Write");
+    expect(node.description.inputs).toEqual(["main" as any] as any);
+    expect(node.description.outputs).toEqual(["main" as any] as any);
+  });
+
+  test("requires the flairApi credential", () => {
+    const cred = node.description.credentials!.find((c) => c.name === "flairApi")!;
+    expect(cred.required).toBe(true);
+  });
+
+  test("declares required content property defaulting to $json.content", () => {
+    const c = node.description.properties.find((p) => p.name === "content")!;
+    expect(c.required).toBe(true);
+    expect(c.default).toBe("={{ $json.content }}");
+  });
+
+  test("declares optional subject + tags", () => {
+    const subject = node.description.properties.find((p) => p.name === "subject")!;
+    expect(subject).toBeDefined();
+    expect(subject.required).toBeUndefined();
+
+    const tags = node.description.properties.find((p) => p.name === "tags")!;
+    expect(tags).toBeDefined();
+    expect(tags.default).toBe("");
+  });
+
+  test("declares durability with the four Flair tiers", () => {
+    const dur = node.description.properties.find((p) => p.name === "durability")!;
+    expect(dur).toBeDefined();
+    const values = ((dur as any).options ?? []).map((o: any) => o.value);
+    expect(values).toEqual(["standard", "persistent", "permanent", "ephemeral"]);
+    expect(dur.default).toBe("standard");
+  });
+
+  test("declares type with the six Flair memory types", () => {
+    const type = node.description.properties.find((p) => p.name === "type")!;
+    expect(type).toBeDefined();
+    const values = ((type as any).options ?? []).map((o: any) => o.value);
+    expect(values).toEqual(["session", "lesson", "decision", "preference", "fact", "goal"]);
+    expect(type.default).toBe("session");
+  });
+
+  test("declares skipEmpty boolean default true", () => {
+    const skip = node.description.properties.find((p) => p.name === "skipEmpty")!;
+    expect(skip).toBeDefined();
+    expect((skip as any).type).toBe("boolean");
+    expect(skip.default).toBe(true);
+  });
+
+  test("registers as an Output (group: output)", () => {
+    expect(node.description.group).toEqual(["output"]);
+  });
+
+  test("codex categorizes under AI / Memory", () => {
+    const codex = node.description.codex!;
+    expect(codex.categories).toContain("AI");
+    expect((codex.subcategories as any).AI).toContain("Memory");
+  });
+});


### PR DESCRIPTION
## Summary

Closes ops-q3qf 1.0. Adds the missing pipeline-mode write surface to the n8n node and ships the worked-example workflow that uses it.

**Why one PR not two:** building the worked example surfaced that the node had no pipeline-mode write surface — `FlairSearch` is AI-Tool-only (read), and `FlairChatMemory` is the LangChain conversation-buffer adapter (writes role/content turns, not standalone memories). Operator-driven capture-and-archive workflows had no path. Same dogfood lesson as last week's bridges: building the actual user workflow surfaced the gap.

## What's new

### `FlairWrite` node — operator-driven write surface

`packages/n8n-nodes-flair/src/nodes/FlairWrite/FlairWrite.node.ts`

Pipeline-mode (Main input → Main output) node. Explicitly **not** exposed as an AI Tool — write-as-LLM-tool needs guardrails (content sanitization, rate limiting, audit trail) that we haven't designed. Two narrow nodes (FlairSearch read, FlairWrite write) is cleaner than one dual-purpose node — easier to discover, easier to dogfood.

Operator surface:
- `content` (defaults to `{{ $json.content }}`)
- `subject`, `tags` (comma-separated, trimmed)
- `durability` (standard|persistent|permanent|ephemeral)
- `type` (session|lesson|decision|preference|fact|goal)
- `skipEmpty` (default true) — pass-through with `_flair_skipped` marker on empty content, vs. fail-loud when off

Output items get `_flair_id` + `_flair_subject` + `_flair_tags` + `_flair_durability` appended for downstream branching.

### Worked example: K&S review capture → Flair

`packages/n8n-nodes-flair/examples/ks-review-capture/{workflow.json,README.md}`

Captures every Kern + Sherlock review note from Flint's TPS-mail inbox into Flair as `durability:persistent` `type:decision` memories, tagged `source:tps-mail`, `kind:review`, `agent:<from>`, `date:<day>`, `pr:<n>`. Subject groups by PR for clean `getBySubject` queries.

Pipeline:
```
Schedule(5min) → ls inbox → split paths → read+parse
  → filter from∈{kern,sherlock} → dedup by mail.id
  → format → Flair Write
```

**Why K&S not the originally-scoped Pulse-intel:** Pulse posts to Discord directly and never crosses TPS mail (verified 0 mails from `pulse` in 10-day archive). K&S have 89 + 74 mails in the same window — higher signal density, real reasoning text, bigger ongoing dogfood loop.

## What didn't change

- `FlairSearch` stays AI-Tool-only — no breaking changes to existing workflows
- `FlairChatMemory` stays the LangChain BaseMemory adapter — separate use case
- No flair-client API changes — `FlairWrite` uses the existing `memory.write` surface

## Test plan

- [x] `bun test packages/n8n-nodes-flair/test/` → 31/31 pass (was 22 — 9 new for FlairWrite description shape)
- [x] `bunx tsc --noEmit -p tsconfig.check.json` → clean
- [x] `npm run build` clean (registers `dist/nodes/FlairWrite/FlairWrite.node.js` per `n8n.nodes`)
- [x] Pre-commit hook all green (workspace-deps + dep-ages + impl-term-leaks + ASCII boxes)
- [ ] Live activation against rockit n8n — n8n still booting (npx first-run), will smoke-test post-merge and append a dogfood-log entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)