### PR TITLE
fix(n8n-nodes-flair): dynamic-import flair-client (ESM/CJS interop)

### DIFF
--- a/packages/n8n-nodes-flair/src/nodes/FlairChatMemory/FlairChatMemory.node.ts
+++ b/packages/n8n-nodes-flair/src/nodes/FlairChatMemory/FlairChatMemory.node.ts
@@ -7,7 +7,10 @@ import {
   NodeConnectionTypes,
 } from "n8n-workflow";
 
-import { FlairClient } from "@tpsdev-ai/flair-client";
+// See FlairWrite.node.ts header for the rationale on dynamic-import.
+// flair-client is ESM-only; static import from CJS-compiled n8n node
+// crashes at boot on Node 24+ with "No exports main defined".
+import type { FlairClient } from "@tpsdev-ai/flair-client";
 
 import { FlairChatMessageHistory } from "./FlairChatMessageHistory";
 
@@ -89,7 +92,8 @@ export class FlairChatMemory implements INodeType {
 
     const composedSubject = sessionKey ? `${subject}:${sessionKey}` : subject;
 
-    const flair = new FlairClient({
+    const flairMod = await import("@tpsdev-ai/flair-client");
+    const flair = new flairMod.FlairClient({
       url: credentials.baseUrl,
       agentId: credentials.agentId,
       adminUser: "admin",

--- a/packages/n8n-nodes-flair/src/nodes/FlairSearch/FlairSearch.node.ts
+++ b/packages/n8n-nodes-flair/src/nodes/FlairSearch/FlairSearch.node.ts
@@ -10,7 +10,10 @@ import {
   NodeConnectionTypes,
 } from "n8n-workflow";
 
-import { FlairClient } from "@tpsdev-ai/flair-client";
+// See FlairWrite.node.ts header for the rationale on dynamic-import.
+// flair-client is ESM-only; static `import` from a CJS-compiled n8n node
+// crashes at boot on Node 24+ with "No exports main defined".
+import type { FlairClient } from "@tpsdev-ai/flair-client";
 
 interface FlairCredentials {
   baseUrl: string;
@@ -20,8 +23,9 @@ interface FlairCredentials {
 
 type Operation = "search" | "getBySubject";
 
-function makeClient(credentials: FlairCredentials): FlairClient {
-  return new FlairClient({
+async function makeClient(credentials: FlairCredentials): Promise<FlairClient> {
+  const mod = await import("@tpsdev-ai/flair-client");
+  return new mod.FlairClient({
     url: credentials.baseUrl,
     agentId: credentials.agentId,
     adminUser: "admin",
@@ -156,7 +160,7 @@ export class FlairSearch implements INodeType {
     const credentials = (await this.getCredentials("flairApi")) as unknown as FlairCredentials;
     const operation = this.getNodeParameter("operation", itemIndex) as Operation;
     const limit = this.getNodeParameter("limit", itemIndex, 5) as number;
-    const flair = makeClient(credentials);
+    const flair = await makeClient(credentials);
 
     if (operation === "search") {
       const tool = new DynamicStructuredTool({
@@ -193,7 +197,7 @@ export class FlairSearch implements INodeType {
 
   async execute(this: IExecuteFunctions): Promise<INodeExecutionData[][]> {
     const credentials = (await this.getCredentials("flairApi")) as unknown as FlairCredentials;
-    const flair = makeClient(credentials);
+    const flair = await makeClient(credentials);
     const inputs = this.getInputData();
     const out: INodeExecutionData[] = [];
 

--- a/packages/n8n-nodes-flair/src/nodes/FlairWrite/FlairWrite.node.ts
+++ b/packages/n8n-nodes-flair/src/nodes/FlairWrite/FlairWrite.node.ts
@@ -32,7 +32,17 @@ import {
   NodeConnectionTypes,
 } from "n8n-workflow";
 
-import { FlairClient } from "@tpsdev-ai/flair-client";
+// flair-client is published ESM-only. n8n nodes compile to CJS and load via
+// `require`, so a static `import { FlairClient } from "@tpsdev-ai/flair-client"`
+// crashes at boot on Node 24+ with "No exports main defined" because the
+// flair-client package only declares an `import` condition in its exports
+// map. The `import type` line emits no runtime require, and the dynamic
+// import inside `makeClient` is the standard CJS→ESM interop path.
+//
+// Filed: ops follow-up to ship a dual ESM/CJS build of flair-client so
+// static imports work too. Until then this dynamic-import pattern is the
+// load-bearing fix.
+import type { FlairClient } from "@tpsdev-ai/flair-client";
 
 interface FlairCredentials {
   baseUrl: string;
@@ -40,8 +50,9 @@ interface FlairCredentials {
   adminPassword: string;
 }
 
-function makeClient(credentials: FlairCredentials): FlairClient {
-  return new FlairClient({
+async function makeClient(credentials: FlairCredentials): Promise<FlairClient> {
+  const mod = await import("@tpsdev-ai/flair-client");
+  return new mod.FlairClient({
     url: credentials.baseUrl,
     agentId: credentials.agentId,
     adminUser: "admin",
@@ -151,7 +162,7 @@ export class FlairWrite implements INodeType {
 
   async execute(this: IExecuteFunctions): Promise<INodeExecutionData[][]> {
     const credentials = (await this.getCredentials("flairApi")) as unknown as FlairCredentials;
-    const flair = makeClient(credentials);
+    const flair = await makeClient(credentials);
     const inputs = this.getInputData();
     const out: INodeExecutionData[] = [];
 


### PR DESCRIPTION
## Summary

Live-activation of `@tpsdev-ai/n8n-nodes-flair@0.8.1` against n8n@1.123.38 on Node 24 caught a real-world failure that bun unit tests masked:

```
Error: No "exports" main defined in
  @tpsdev-ai/flair-client/package.json
```

`flair-client` is published ESM-only (`"type": "module"`, exports map has only `import` condition). n8n nodes compile to CJS and load via `require()` under Node. Bun's resolver is permissive; Node 24's is strict — the `require()` finds the package but the exports map rejects it because there's no `require` condition.

## Fix

Switch the three node files (FlairWrite, FlairSearch, FlairChatMemory) from static `import { FlairClient }` to `import type` (no runtime emit) plus `await import("@tpsdev-ai/flair-client")` inside the function that needs the client. Standard CJS→ESM interop, works on Node 18+.

## Verification

After this patch, activating n8n@1.123.38 on `/opt/homebrew/opt/node@24` boots clean, HTTP 200 at localhost:5678, all three Flair nodes register without the "No exports main" crash.

## Why this slipped through

Same simulator-vs-reality pattern as the three SaaS-import bridges (PRs #380/#381) and the dispatch reconciler:

- Unit tests use bun (permissive resolver) — passes
- CI doesn't activate a real n8n instance — passes
- `@tpsdev-ai/n8n-nodes-flair` shipped to npm at v0.8.1 without ever being tested in an actual Node-runtime n8n
- Today's dogfood is the first real-runtime exercise

Filed as a separate follow-up: ship dual ESM/CJS build from `flair-client` so static imports also work — proper fix beyond the dynamic-import workaround.

## Test plan

- [x] `bun test packages/n8n-nodes-flair/test/` → 31/31 pass
- [x] `bunx tsc --noEmit -p tsconfig.check.json` → clean
- [x] `npm run build` clean
- [x] **Live activation: n8n@1.123.38 + node@24, HTTP 200 confirmed**
- [x] Pre-commit hook all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)