### PR TITLE
fix(health): make /Health truly public via allowRead — works for remote callers

### DIFF
--- a/resources/health.ts
+++ b/resources/health.ts
@@ -15,13 +15,32 @@ const exists = async (path: string): Promise<boolean> => {
 };
 
 /**
- * Health endpoint — unauthenticated, returns only { ok: true }.
+ * Health endpoint — truly public, returns only { ok: true }.
+ *
+ * `allowRead() { return true }` opens Harper's role gate for anonymous GETs,
+ * which is what makes /Health work for callers outside `authorizeLocal`'s
+ * localhost-bypass. Without this, Harper's intrinsic Basic-auth gate fires
+ * BEFORE our HTTP middleware can apply the /Health bypass list in
+ * auth-middleware.ts, so remote callers (e.g., from rockit hitting a Fabric-
+ * hosted Flair) get a 401 even though the Resource handler is intentionally
+ * unauthenticated. Symptom matched: Fabric returned 401 + WWW-Authenticate:
+ * Basic on /Health while rockit-localhost returned 200 — the difference was
+ * Harper's localhost-auto-auth, not anything in our code.
+ *
+ * Same pattern as `FederationPair.allowCreate(){ return true }` (PR #299):
+ * declare the Resource anonymously-accessible at the Harper layer; let the
+ * handler itself enforce whatever it needs (in this case, nothing — /Health
+ * is intentionally and always public).
  *
  * Rich stats (memory counts, agent names, etc.) are behind /HealthDetail
  * which requires authentication. This prevents information leakage on
  * publicly exposed instances.
  */
 export class Health extends Resource {
+  // Anyone can call /Health — no auth, no role check. Truly public.
+  allowRead(_user: any) {
+    return true;
+  }
   async get() {
     return { ok: true };
   }


### PR DESCRIPTION
## Summary

Per Nathan today: "health should always be a 200 and provide a simple status (i.e. no sensitive info leaked, data, timing, etc.)".

Investigation: rockit returned 200 on /Health while Fabric returned 401 + `WWW-Authenticate: Basic`. Same Flair code, same Resource. **Root cause: Harper has an intrinsic Basic-auth gate that fires BEFORE our `server.http()` middleware.**

- On rockit, `config.yaml` has `authorizeLocal: true` which auto-auths localhost callers as superuser, satisfying Harper's gate before our bypass-list logic runs.
- On Fabric (or any remote caller), no localhost bypass — Harper's gate rejects with 401, and our `/Health` entry in `auth-middleware.ts`'s public-allowlist never gets a chance to take effect.

## Fix

Same pattern as PR #299 (`FederationPair.allowCreate(){ return true }`): declare the Resource anonymously-accessible at the Harper role-gate layer.

```ts
export class Health extends Resource {
  allowRead(_user: any) { return true; }
  async get() { return { ok: true }; }
}
```

`allowRead` is Harper's canonical "this Resource is public for GET" signal. Our existing `/Health` entry in `auth-middleware.ts`'s public-allowlist stays (belt-and-suspenders — if Harper's allowRead semantic changes in a future release, our middleware bypass remains).

## What didn't change

- `/HealthDetail` stays authentication-required. Rich stats (memory counts, agent names, process info) remain protected — only the trivial `{ ok: true }` is public.
- Memory/Soul/Agent/Federation/Admin* surfaces all stay auth-required.

## Verification

- **rockit unchanged**: still returns 200 on /Health. The localhost-bypass continues to satisfy Harper's gate, and `allowRead` is harmless overlap.
- **Fabric will return 200 once redeployed**. Currently 401; post-deploy will be 200.
- After merge + Fabric redeploy, sherlock-sweep's Fabric bundle will go from yellow (1 finding on /Health) to fully green (20/20 endpoints).

## Test plan
- [x] `bun test test/unit/` → 859/859 pass (no regressions)
- [x] `bunx tsc --noEmit -p tsconfig.check.json` → clean
- [x] Pre-commit hook all green
- [ ] Post-merge: redeploy to Fabric; verify `curl https://flair.heskew.harperfabric.com/Health` returns 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)