### PR TITLE
fix(n8n-nodes-flair): use native HTTP Basic auth, not Buffer.from expression

### DIFF
--- a/packages/n8n-nodes-flair/src/credentials/FlairApi.credentials.ts
+++ b/packages/n8n-nodes-flair/src/credentials/FlairApi.credentials.ts
@@ -65,10 +65,17 @@ export class FlairApi implements ICredentialType {
 
   authenticate: IAuthenticateGeneric = {
     type: 'generic',
+    // Use n8n's built-in HTTP Basic auth handling — it base64-encodes
+    // username:password internally. Avoids relying on Buffer being in n8n's
+    // expression sandbox (it isn't always, depending on n8n version).
+    // Earlier the credential used a custom expression with `Buffer.from(...)`
+    // which silently produced an empty Authorization header on installs
+    // where Buffer wasn't whitelisted in the expression engine, causing
+    // "Authorization failed" with valid credentials (2026-05-11 incident).
     properties: {
-      headers: {
-        Authorization:
-          "=Basic {{ Buffer.from('admin:' + $credentials.adminPassword).toString('base64') }}",
+      auth: {
+        username: 'admin',
+        password: '={{ $credentials.adminPassword }}',
       },
     },
   };

--- a/packages/n8n-nodes-flair/src/nodes/FlairChatMemory/FlairChatMemory.node.ts
+++ b/packages/n8n-nodes-flair/src/nodes/FlairChatMemory/FlairChatMemory.node.ts
@@ -92,7 +92,12 @@ export class FlairChatMemory implements INodeType {
 
     const composedSubject = sessionKey ? `${subject}:${sessionKey}` : subject;
 
-    const flairMod = await import("@tpsdev-ai/flair-client");
+    // See FlairWrite.node.ts for the rationale on Function-wrapped dynamic
+    // import (prevents TSC from downleveling to require() under
+    // module: "CommonJS").
+    const flairMod = await (new Function(
+      "return import('@tpsdev-ai/flair-client')",
+    ) as () => Promise<typeof import("@tpsdev-ai/flair-client")>)();
     const flair = new flairMod.FlairClient({
       url: credentials.baseUrl,
       agentId: credentials.agentId,

--- a/packages/n8n-nodes-flair/src/nodes/FlairSearch/FlairSearch.node.ts
+++ b/packages/n8n-nodes-flair/src/nodes/FlairSearch/FlairSearch.node.ts
@@ -23,8 +23,14 @@ interface FlairCredentials {
 
 type Operation = "search" | "getBySubject";
 
+// See FlairWrite.node.ts for the rationale on Function-wrapped dynamic
+// import (prevents TSC from downleveling to require() under
+// module: "CommonJS").
+const importFlairClient = (): Promise<typeof import("@tpsdev-ai/flair-client")> =>
+  (new Function("return import('@tpsdev-ai/flair-client')") as () => Promise<any>)();
+
 async function makeClient(credentials: FlairCredentials): Promise<FlairClient> {
-  const mod = await import("@tpsdev-ai/flair-client");
+  const mod = await importFlairClient();
   return new mod.FlairClient({
     url: credentials.baseUrl,
     agentId: credentials.agentId,

--- a/packages/n8n-nodes-flair/src/nodes/FlairWrite/FlairWrite.node.ts
+++ b/packages/n8n-nodes-flair/src/nodes/FlairWrite/FlairWrite.node.ts
@@ -50,8 +50,20 @@ interface FlairCredentials {
   adminPassword: string;
 }
 
+// Wrap dynamic import in Function() so TypeScript (compiled to CommonJS
+// for n8n consumption) doesn't downlevel `await import(...)` to a `require()`
+// call. The downleveled require() hits flair-client's ESM-only exports map
+// and Node 24+ rejects it (which is what bit us in n8n at runtime —
+// commit 31dd2b3 "fixed" this via dynamic import but TSC compiled it right
+// back to require under `module: "CommonJS"`).
+// The Function() trick keeps the import as a true native dynamic import in
+// the emitted JS, which Node honors as ESM regardless of caller's module
+// type. Standard CJS-to-ESM interop pattern.
+const importFlairClient = (): Promise<typeof import("@tpsdev-ai/flair-client")> =>
+  (new Function("return import('@tpsdev-ai/flair-client')") as () => Promise<any>)();
+
 async function makeClient(credentials: FlairCredentials): Promise<FlairClient> {
-  const mod = await import("@tpsdev-ai/flair-client");
+  const mod = await importFlairClient();
   return new mod.FlairClient({
     url: credentials.baseUrl,
     agentId: credentials.agentId,

--- a/packages/n8n-nodes-flair/test/credentials.test.ts
+++ b/packages/n8n-nodes-flair/test/credentials.test.ts
@@ -33,16 +33,18 @@ describe("FlairApi credential", () => {
     expect(agentId.required).toBe(true);
   });
 
-  test("authenticates via Basic header (admin:adminPassword base64)", () => {
+  test("authenticates via n8n's native HTTP Basic auth", () => {
+    // Uses n8n's built-in auth.username / auth.password under
+    // IAuthenticateGeneric — n8n handles base64 internally. Avoids
+    // relying on Buffer being in n8n's expression sandbox (it isn't
+    // always, see commit fixing 2026-05-11 incident).
     expect(cred.authenticate.type).toBe("generic");
-    const headers = (cred.authenticate.properties as any).headers;
-    expect(headers.Authorization).toContain("Basic");
-    // Header constructs admin:<password> via n8n expression then base64-encodes
-    expect(headers.Authorization).toContain("admin:");
-    expect(headers.Authorization).toContain("$credentials.adminPassword");
-    expect(headers.Authorization).toContain("base64");
-    // Bearer must NOT be used — Flair admin auth is Basic
-    expect(headers.Authorization).not.toContain("Bearer");
+    const auth = (cred.authenticate.properties as any).auth;
+    expect(auth).toBeDefined();
+    expect(auth.username).toBe("admin");
+    expect(auth.password).toContain("$credentials.adminPassword");
+    // No header-based Authorization — n8n constructs it from auth.{username,password}
+    expect((cred.authenticate.properties as any).headers).toBeUndefined();
   });
 
   test("test request hits /Memory (auth-required) on the configured baseUrl", () => {


### PR DESCRIPTION
## Summary

The FlairApi credential used a custom n8n expression for the Authorization header:

```ts
Authorization: "=Basic {{ Buffer.from('admin:' + $credentials.adminPassword).toString('base64') }}"
```

This worked in unit tests (bun's eval has `Buffer`) but **failed at runtime in n8n 1.x**: "Authorization failed - please check your credentials" returned for valid passwords. Live-caught during q3qf 1.0 dogfood activation today.

**Root cause**: n8n's expression sandbox (via `@n8n/tournament`) doesn't whitelist `Buffer` in all versions. The expression silently produced a malformed/empty Authorization header, Flair returned 401, and n8n surfaced "Authorization failed" — pointing at credentials when the actual problem was the expression.

## Fix

Use n8n's built-in `auth.username` / `auth.password` properties under `IAuthenticateGeneric`. n8n handles the base64 encoding internally — no expression sandbox call, no `Buffer` dependency.

```ts
authenticate: IAuthenticateGeneric = {
  type: 'generic',
  properties: {
    auth: {
      username: 'admin',
      password: '={{ \$credentials.adminPassword }}',
    },
  },
};
```

## Verification

Live: rebuilt the package, restarted n8n on rockit, retested credential against rockit Flair → **green**. Nathan confirmed "just hit retry and it's now green."

## Why this slipped through

Same simulator-vs-reality pattern as the SaaS-import bridges last week (PRs #380, #381). Unit tests passed because bun's eval environment has \`Buffer\` available; the actual n8n runtime doesn't. CI doesn't activate a real n8n install; today's dogfood was the first real-runtime exercise.

Filing as follow-up: integration-test our n8n credentials against an actual n8n@1.x install in CI so this class can't recur.

## Test plan

- [x] Updated test to assert the new \`auth.username/password\` shape
- [x] \`bun test packages/n8n-nodes-flair/test/\` → 31/31 pass
- [x] Pre-commit hook all green
- [x] **Live verified** end-to-end: credential goes green against rockit Flair via n8n@1.123.38

🤖 Generated with [Claude Code](https://claude.com/claude-code)