### PR TITLE
release: v0.8.3

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -24,20 +24,20 @@
     },
     "packages/flair-client": {
       "name": "@tpsdev-ai/flair-client",
-      "version": "0.8.2",
+      "version": "0.8.3",
       "devDependencies": {
         "typescript": "5.9.3",
       },
     },
     "packages/flair-mcp": {
       "name": "@tpsdev-ai/flair-mcp",
-      "version": "0.8.2",
+      "version": "0.8.3",
       "bin": {
         "flair-mcp": "dist/index.js",
       },
       "dependencies": {
         "@modelcontextprotocol/sdk": "1.27.1",
-        "@tpsdev-ai/flair-client": "0.8.2",
+        "@tpsdev-ai/flair-client": "0.8.3",
         "zod": "4.3.6",
       },
       "devDependencies": {
@@ -46,9 +46,9 @@
     },
     "packages/langgraph-flair": {
       "name": "@tpsdev-ai/langgraph-flair",
-      "version": "0.8.2",
+      "version": "0.8.3",
       "dependencies": {
-        "@tpsdev-ai/flair-client": "0.8.2",
+        "@tpsdev-ai/flair-client": "0.8.3",
       },
       "peerDependencies": {
         "@langchain/langgraph-checkpoint": ">=0.0.10",
@@ -56,7 +56,7 @@
     },
     "packages/n8n-nodes-flair": {
       "name": "@tpsdev-ai/n8n-nodes-flair",
-      "version": "0.8.2",
+      "version": "0.8.3",
       "dependencies": {
         "@tpsdev-ai/flair-client": "0.8.1",
         "zod": "3.25.76",
@@ -75,10 +75,10 @@
     },
     "packages/openclaw-flair": {
       "name": "@tpsdev-ai/openclaw-flair",
-      "version": "0.8.2",
+      "version": "0.8.3",
       "dependencies": {
         "@sinclair/typebox": "0.34.48",
-        "@tpsdev-ai/flair-client": "0.8.2",
+        "@tpsdev-ai/flair-client": "0.8.3",
       },
       "devDependencies": {
         "typescript": "5.9.3",
@@ -89,7 +89,7 @@
     },
     "packages/pi-flair": {
       "name": "@tpsdev-ai/pi-flair",
-      "version": "0.8.2",
+      "version": "0.8.3",
       "dependencies": {
         "@sinclair/typebox": "0.34.48",
         "@tpsdev-ai/flair-client": "0.8.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tpsdev-ai/flair",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "description": "Identity, memory, and soul for AI agents. Cryptographic identity (Ed25519), semantic memory with local embeddings, and persistent personality — all in a single process.",
   "type": "module",
   "license": "Apache-2.0",

--- a/packages/flair-client/package.json
+++ b/packages/flair-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tpsdev-ai/flair-client",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "description": "Lightweight client for Flair — identity, memory, and soul for AI agents. Zero heavy dependencies.",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/flair-mcp/package.json
+++ b/packages/flair-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tpsdev-ai/flair-mcp",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "description": "MCP server for Flair — persistent memory for Claude Code, Cursor, and any MCP client.",
   "type": "module",
   "main": "dist/index.js",
@@ -25,7 +25,7 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "1.27.1",
-    "@tpsdev-ai/flair-client": "0.8.2",
+    "@tpsdev-ai/flair-client": "0.8.3",
     "zod": "4.3.6"
   },
   "license": "Apache-2.0",

--- a/packages/langgraph-flair/package.json
+++ b/packages/langgraph-flair/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tpsdev-ai/langgraph-flair",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "description": "LangGraph BaseStore adapter backed by Flair — durable agent memory with crypto-pinned identity, federation, and cross-orchestrator portability.",
   "type": "module",
   "main": "dist/index.js",
@@ -36,7 +36,7 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
-    "@tpsdev-ai/flair-client": "0.8.2"
+    "@tpsdev-ai/flair-client": "0.8.3"
   },
   "peerDependencies": {
     "@langchain/langgraph-checkpoint": ">=0.0.10"

--- a/packages/n8n-nodes-flair/package.json
+++ b/packages/n8n-nodes-flair/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tpsdev-ai/n8n-nodes-flair",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "description": "n8n community node — use Flair as your AI Agent's memory backend. Includes FlairChatMemory (Memory port) and FlairSearch (Tool port).",
   "type": "commonjs",
   "main": "dist/index.js",
@@ -48,7 +48,7 @@
     "langchain"
   ],
   "dependencies": {
-    "@tpsdev-ai/flair-client": "0.8.2",
+    "@tpsdev-ai/flair-client": "0.8.3",
     "zod": "3.25.76"
   },
   "peerDependencies": {

--- a/packages/openclaw-flair/package.json
+++ b/packages/openclaw-flair/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tpsdev-ai/openclaw-flair",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "description": "OpenClaw memory plugin for Flair — agent identity and semantic memory",
   "type": "module",
   "main": "./dist/index.js",
@@ -52,7 +52,7 @@
   },
   "dependencies": {
     "@sinclair/typebox": "0.34.48",
-    "@tpsdev-ai/flair-client": "0.8.2"
+    "@tpsdev-ai/flair-client": "0.8.3"
   },
   "devDependencies": {
     "typescript": "5.9.3"

--- a/packages/pi-flair/package.json
+++ b/packages/pi-flair/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tpsdev-ai/pi-flair",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "description": "Flair memory extension for pi — persistent memory access from within pi sessions",
   "type": "module",
   "main": "dist/index.js",
@@ -21,7 +21,7 @@
     "node": ">=18"
   },
   "dependencies": {
-    "@tpsdev-ai/flair-client": "0.8.2",
+    "@tpsdev-ai/flair-client": "0.8.3",
     "@sinclair/typebox": "0.34.48"
   },
   "license": "Apache-2.0",

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -182,7 +182,9 @@ echo "🔗 Aligning internal dependencies..."
 for INTERNAL_DEPENDENT in \
     "$ROOT/packages/flair-mcp/package.json" \
     "$ROOT/packages/pi-flair/package.json" \
-    "$ROOT/packages/n8n-nodes-flair/package.json"; do
+    "$ROOT/packages/n8n-nodes-flair/package.json" \
+    "$ROOT/packages/openclaw-flair/package.json" \
+    "$ROOT/packages/langgraph-flair/package.json"; do
   node -e "
     const fs = require('fs');
     const path = '$INTERNAL_DEPENDENT';


### PR DESCRIPTION
## Summary

Workspace v0.8.3 — bundles two fixes that landed today:

- PR #386 — `fix(health): /Health truly public via allowRead — works for remote callers`
- PR #389 — `fix(n8n-nodes-flair): rebuild worked example workflow + ship node icons`

Also patches `scripts/release.sh` to include `openclaw-flair` + `langgraph-flair` in the internal-deps alignment loop — the v0.8.3 attempt caught both stuck at `@tpsdev-ai/flair-client@0.8.2` instead of bumping to 0.8.3.

## Test plan

- [x] release.sh phase-1 ran tests (910 pass, 0 fail) before commit
- [x] pre-commit workspace-deps consistency check passes (post fix)
- [ ] CI green on all matrix jobs (in flight)

After CI green + merge:

```
git checkout main && git pull
./scripts/release.sh 0.8.3 --publish
```

(Nathan's npm publish step — rockit isn't logged into npm by design.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)