### PR TITLE
docs(CHANGELOG): backfill 0.8.2 + 0.8.3 release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## 0.8.3 (2026-05-11)
+
+### 🐛 Bug Fixes
+
+- **`/Health` endpoint truly public** — `allowRead() { return true }` opens the Harper role gate, making `/Health` work for remote callers. Previously `/Health` returned 401 from outside Harper's `authorizeLocal` localhost-bypass (e.g., calling Fabric-hosted Flair from rockit) even though the handler is intentionally unauthenticated. Pattern matches PR #299's `FederationPair.allowCreate()`. (#386)
+
+### 🛠 Internal
+
+- **`@tpsdev-ai/n8n-nodes-flair` worked example rebuilt** — the q3qf K&S-review-capture workflow replaced the 4-node `ExecuteCommand → Split → ReadBinaryFile → Parse JSON` chain with a single Code node (atomic, version-stable, immune to n8n node-API drift). Filter `containedInList` operator replaced with a Code-node `Set` membership check (the operator parses comma-strings ambiguously across n8n versions). Required env var on the n8n host: `NODE_FUNCTION_ALLOW_BUILTIN=fs,path`. Node icons shipped for FlairWrite / FlairSearch / FlairChatMemory. (#389)
+- **`scripts/release.sh` patched** — `openclaw-flair` and `langgraph-flair` added to the internal-deps alignment loop. v0.8.3 attempt caught both packages stuck at `@tpsdev-ai/flair-client@0.8.2` while the workspace bumped to `0.8.3`. (#390 self-fix)
+
+## 0.8.2 (2026-05-11)
+
+### 🐛 Bug Fixes
+
+- **`@tpsdev-ai/n8n-nodes-flair` install regression** — published 0.8.1 hit `No "exports" main defined in flair-client` because of TSC downleveling `await import()` to `Promise.resolve().then(() => require())`. The `FlairWrite` node now imports `@tpsdev-ai/flair-client` via a `Function("return import(...)")` wrapper that defeats TSC downleveling. (#385, #387)
+- **FlairApi credential auth fixed** — the n8n expression sandbox doesn't whitelist `Buffer.from`, so the Authorization header expression silently produced an invalid value. Switched to n8n's native `IAuthenticateGeneric.auth.username/password` which constructs Basic auth internally. (#387)
+
 ## 0.8.1 (2026-05-08)
 
 ### 🐛 Bug Fixes


### PR DESCRIPTION
## Summary

CHANGELOG entries for v0.8.2 and v0.8.3 — should have been in release PR #390 but the auto-merge fired on Kern approval before I pushed the CHANGELOG addition. Filing as a follow-up so the file matches what's actually shipped.

## Changes

- 0.8.3: `/Health` allowRead fix (#386); n8n-nodes-flair worked-example rebuild + icons (#389); release.sh internal-deps loop expansion (self-fix)
- 0.8.2: n8n-nodes-flair install regression fixes (#385, #387)

## Test plan

- [x] CHANGELOG.md is a doc-only change
- [ ] Pre-commit hooks pass (workspace-deps consistency / impl-term-leaks / ASCII-box) — they ran on commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)