### PR TITLE
feat(openclaw-flair): 2026.5.7 plugin format compat

### DIFF
--- a/packages/openclaw-flair/openclaw.plugin.json
+++ b/packages/openclaw-flair/openclaw.plugin.json
@@ -1,6 +1,9 @@
 {
   "id": "openclaw-flair",
   "kind": "memory",
+  "activation": {
+    "onStartup": true
+  },
   "uiHints": {
     "url": {
       "label": "Flair URL",

--- a/packages/openclaw-flair/package.json
+++ b/packages/openclaw-flair/package.json
@@ -39,7 +39,13 @@
   "openclaw": {
     "extensions": [
       "./dist/index.js"
-    ]
+    ],
+    "runtimeExtensions": [
+      "./dist/index.js"
+    ],
+    "compat": {
+      "pluginApi": ">=2026.5.7"
+    }
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
Migration prep per ops-flair-tps-mail-2026.5.7.

- Adds activation.onStartup to manifest (required by 2026.5.2+ for explicit startup loading)
- Adds runtimeExtensions for compiled-first loading in 2026.5.7
- Declares compat.pluginApi + minGatewayVersion for 2026.5.7

Upstream 0.8.3 already ships compiled dist/; this adds the remaining 2026.5.7 manifest metadata. Smoke-tested against doctor on 2026.5.3-1.