### PR TITLE
docs(integrations): callout for memory bridges + See-also link

### DIFF
--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -24,6 +24,8 @@ Where Flair already runs. Each integration shown here is a working surface — t
 
 Don't see your harness? If it speaks **MCP** — Flair already works with `flair-mcp`. If it has a **custom memory protocol** like LangGraph's `BaseStore` or CrewAI's `RAGStorage`, an adapter is a ~200-line package; [open an issue](https://github.com/tpsdev-ai/flair/issues) or [send a PR](https://github.com/tpsdev-ai/flair).
 
+**Adjacent: memory bridges** — for moving memories between Flair and another memory product. Five bridges ship today (Mem0, ChatGPT exports, claude-project files, agentic-stack, markdown); see [bridges.md](bridges.md). Bridges are import/export plumbing, not live orchestrator integrations.
+
 ---
 
 ## Claude Code, Cursor, Codex, Gemini CLI, Continue.dev, Goose — via `flair-mcp`
@@ -190,6 +192,7 @@ If it has a custom memory protocol, the adapter pattern is small (~200 lines). L
 ## See also
 
 - [Quickstart](quickstart.md) — `flair init` to working memory in 30 seconds
+- [Memory bridges](bridges.md) — import/export Flair ↔ Mem0, ChatGPT, claude-project, markdown, agentic-stack (five bridges shipped)
 - [Federation](federation.md) — pair instances peer-to-peer for cross-machine sync
 - [Supply-chain policy](supply-chain-policy.md) — what we do to keep this list of integrations safe
 - [The team](the-team.md) — the multi-agent rig that builds Flair, dogfooded on every harness above


### PR DESCRIPTION
## Summary

`docs/integrations.md` catalogs HARNESS integrations (orchestrators where Flair plugs in). Memory bridges (import/export to/from other memory products) are the adjacent concept — and they weren't discoverable from this doc.

- Two-line callout near the top, naming the 5 shipped bridges (Mem0, ChatGPT, claude-project, markdown, agentic-stack)  
- "Memory bridges" entry in See also

+3 lines. No structural change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)