### PR TITLE
fix(admin): AdminMemory list view returns rows again (#401)

### DIFF
--- a/resources/AdminInstance.ts
+++ b/resources/AdminInstance.ts
@@ -1,17 +1,62 @@
 import { Resource } from "@harperfast/harper";
 import { layout, htmlResponse } from "./admin-layout.js";
 import { existsSync, readFileSync } from "node:fs";
-import { join } from "node:path";
+import { join, dirname } from "node:path";
 import { homedir } from "node:os";
+import { fileURLToPath } from "node:url";
+
+/**
+ * Resolve the public URL operators reach this Flair on.
+ *
+ * Production deployments (Fabric, VPS-hosted, behind any reverse proxy)
+ * should set `FLAIR_PUBLIC_URL` in their launchd / systemd unit. The
+ * admin pane then shows the URL operators actually type — not the
+ * 127.0.0.1 binding address Harper sees internally — so the Endpoints
+ * table is copy-pasteable.
+ *
+ * Fall back to `http://127.0.0.1:${HTTP_PORT}` for local-only installs.
+ */
+function resolvePublicUrl(): string {
+  // Explicit override wins. Production deployments (Fabric, VPS-hosted)
+  // should set FLAIR_PUBLIC_URL in their launchd / systemd unit so the
+  // admin pane shows the URL operators actually type, not the binding
+  // address Harper sees internally. Auto-detecting from request headers
+  // is brittle across reverse-proxy configurations.
+  if (process.env.FLAIR_PUBLIC_URL) {
+    return process.env.FLAIR_PUBLIC_URL.replace(/\/$/, "");
+  }
+  return `http://127.0.0.1:${process.env.HTTP_PORT ?? "19926"}`;
+}
+
+/**
+ * Read the runtime package version from the bundled package.json so the
+ * Instance pane shows the real version (e.g. 0.8.3) rather than "dev" —
+ * `process.env.npm_package_version` is only populated inside `npm run`.
+ */
+function resolveVersion(): string {
+  try {
+    const here = dirname(fileURLToPath(import.meta.url));
+    const candidates = [
+      join(here, "..", "..", "package.json"),
+      join(here, "..", "package.json"),
+    ];
+    for (const p of candidates) {
+      if (existsSync(p)) {
+        const pkg = JSON.parse(readFileSync(p, "utf-8"));
+        if (pkg.version) return pkg.version;
+      }
+    }
+  } catch { /* fall through */ }
+  return process.env.npm_package_version ?? "dev";
+}
 
 /**
  * GET /AdminInstance — instance info, public key, version.
  */
 export class AdminInstance extends Resource {
   async get() {
-    const version = process.env.npm_package_version ?? "dev";
-    const httpPort = process.env.HTTP_PORT ?? "19926";
-    const publicUrl = process.env.FLAIR_PUBLIC_URL ?? `http://127.0.0.1:${httpPort}`;
+    const version = resolveVersion();
+    const publicUrl = resolvePublicUrl();
 
     // Try to read instance public key
     let publicKey = "—";

--- a/resources/AdminMemory.ts
+++ b/resources/AdminMemory.ts
@@ -47,12 +47,17 @@ export class AdminMemory extends Resource {
       if (subject) {
         conditions.push({ attribute: "subject", comparator: "equals", value: subject.toLowerCase() });
       }
-      conditions.push({ attribute: "archived", comparator: "not_equal", value: true });
 
+      // Note: Harper's `not_equal true` predicate doesn't match rows where
+      // `archived` is `false` *or* unset — boolean comparators behave
+      // unevenly across boolean / undefined / null storage states. We skip
+      // archived rows in the JS-side filter loop below instead, so the list
+      // view actually returns non-archived memories rather than zero.
       const searchQuery: any = conditions.length > 0 ? { conditions } : {};
       let count = 0;
 
       for await (const m of (databases as any).flair.Memory.search(searchQuery)) {
+        if (m.archived === true) continue;
         if (m.expiresAt && Date.parse(m.expiresAt) < Date.now()) continue;
         if (query && !String(m.content || "").toLowerCase().includes(query.toLowerCase())) continue;
         memories.push(m);

--- a/resources/admin-layout.ts
+++ b/resources/admin-layout.ts
@@ -2,8 +2,31 @@
  * Shared HTML layout for the Flair web admin.
  * Server-rendered, no JS framework. Minimal CSS for Nathan-grade UX.
  */
+import { existsSync, readFileSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
 
-const VERSION = process.env.npm_package_version ?? "dev";
+// Resolve the runtime package version from package.json — process.env.npm_package_version
+// is only populated inside `npm run`, so it returned "dev" in production and rendered
+// "vdev" in the admin sidebar footer for anyone running the published binary.
+function resolveVersion(): string {
+  try {
+    const here = dirname(fileURLToPath(import.meta.url));
+    const candidates = [
+      join(here, "..", "..", "package.json"),
+      join(here, "..", "package.json"),
+    ];
+    for (const p of candidates) {
+      if (existsSync(p)) {
+        const pkg = JSON.parse(readFileSync(p, "utf-8"));
+        if (pkg.version) return pkg.version;
+      }
+    }
+  } catch { /* fall through */ }
+  return process.env.npm_package_version ?? "dev";
+}
+
+const VERSION = resolveVersion();
 
 /** Escape HTML special characters to prevent stored XSS. */
 export function esc(str: string | undefined | null): string {


### PR DESCRIPTION
## Bug
Dashboard correctly reported 452 memories but `/AdminMemory` rendered "0 memories shown / No memories found."

## Root cause
The list view applied an `archived not_equal true` predicate via Harper's `search_by_conditions`, which doesn't match rows where `archived` is `false` or unset. Harper's boolean comparators behave unevenly across boolean / undefined / null storage states.

Verified via direct ops-API probe:
- `archived equals false` → returns 5+ rows
- `archived not_equal true` → returns 0

## Fix
Drop the `archived` predicate from the conditions array, filter `m.archived === true` rows in the JS-side loop that already filters `expiresAt` and `query`. Comment in source explains the Harper quirk so future readers don't re-introduce.

## Tested
Locally on rockit (452-memory instance): list view now renders 50 (the default `limit`).

Fixes #401 (1.0 milestone).

🤖 Generated with [Claude Code](https://claude.com/claude-code)