### PR TITLE
feat(admin): /Admin → 302 redirect to /AdminDashboard (#403)

### DIFF
--- a/resources/Admin.ts
+++ b/resources/Admin.ts
@@ -1,0 +1,17 @@
+import { Resource } from "@harperfast/harper";
+
+/**
+ * GET /Admin — friendly redirect to /AdminDashboard.
+ *
+ * Operators bookmark or type the bare /Admin path. Without this resource
+ * they hit a 404 and assume the admin UI is broken. The dashboard is the
+ * canonical landing surface; redirect there.
+ */
+export class Admin extends Resource {
+  async get() {
+    return new Response("", {
+      status: 302,
+      headers: { Location: "/AdminDashboard" },
+    });
+  }
+}


### PR DESCRIPTION
## Why
Operators bookmark or type the bare `/Admin` path. Today it returns 404 and the admin UI looks broken.

## Fix
New `resources/Admin.ts` resource — `GET /Admin` returns 302 with relative `Location: /AdminDashboard`. 17-line addition.

## Tested
Locally verified that `GET /Admin` returns 302 with the expected Location header. Following the redirect lands on the dashboard.

Fixes #403 (1.0 milestone).

🤖 Generated with [Claude Code](https://claude.com/claude-code)