### PR TITLE
fix(admin): emit WWW-Authenticate Basic header for /Admin* unauth requests

### DIFF
--- a/resources/auth-middleware.ts
+++ b/resources/auth-middleware.ts
@@ -234,6 +234,20 @@ server.http(async (request: any, nextLayer: any) => {
   const m = header.match(/^TPS-Ed25519\s+([^:]+):(\d+):([^:]+):(.+)$/);
 
   if (!m) {
+    // For browser-accessible admin pages, emit `WWW-Authenticate: Basic` so
+    // the browser shows a native auth dialog instead of a bare 401 page.
+    // JSON API endpoints don't get this — they should keep the structured
+    // 401 body so the client can parse the error.
+    const isAdminPage = url.pathname === "/Admin" || url.pathname.startsWith("/Admin");
+    if (isAdminPage) {
+      return new Response("Authentication required.", {
+        status: 401,
+        headers: {
+          "WWW-Authenticate": 'Basic realm="Flair Admin"',
+          "content-type": "text/plain; charset=utf-8",
+        },
+      });
+    }
     return new Response(JSON.stringify({ error: "missing_or_invalid_authorization" }), { status: 401 });
   }
 


### PR DESCRIPTION
## Bug
Operators hitting Fabric Flair's admin UI (e.g. `https://flair.heskew.harperfabric.com/AdminDashboard`) in a browser see a bare 401 page with no auth prompt. Browsers only show the native HTTP Basic Auth dialog when the 401 response includes `WWW-Authenticate: Basic ...`. Flair was emitting 401 without that header.

## Repro
`curl -s -D - https://flair.heskew.harperfabric.com/AdminDashboard` → 401, no `WWW-Authenticate` header → browser shows blank 401.

## Fix
In `auth-middleware.ts`, when the unauth path is hit AND the requested pathname starts with `/Admin`, emit `WWW-Authenticate: Basic realm="Flair Admin"` on the 401. JSON API endpoints (`/Memory`, `/Soul`, etc.) keep the structured JSON 401 — clients should parse the error code, not get hit with a browser auth popup.

## Verified locally on rockit
- `GET /AdminDashboard` (no auth) → 401 with `www-authenticate: Basic realm="Flair Admin"` ✓
- `GET /Memory` (no auth) → 401 without WWW-Authenticate ✓ (unchanged)

## 1.0 impact
Without this, operators can't actually use the admin UI on any remote Flair from a browser. Real 1.0 blocker per @tps-flint admin-is-1.0 framing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)