### PR TITLE
docs(deployment): document FLAIR_PUBLIC_URL + other production env vars

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -163,6 +163,17 @@ logging:
   stdStreams: true
 ```
 
+### Environment variables
+
+Set these in the Flair process environment (`~/Library/LaunchAgents/ai.tpsdev.flair.plist` on macOS, the systemd unit on Linux, the component env on Fabric).
+
+| Variable | What it does | When to set it |
+|----------|--------------|----------------|
+| `FLAIR_PUBLIC_URL` | The URL operators reach this Flair on (e.g. `https://flair.example.com`). Surfaced in the AdminInstance pane's Endpoints table and used by OAuth metadata + A2A discovery so external clients see a reachable URL. | **Always set on remote / Fabric / VPS deployments.** Local-only installs can leave it unset. |
+| `HDB_ADMIN_PASSWORD` | Bootstrap password for the embedded Harper. After first start, the persisted user record is the source of truth; rotate via the Harper ops API, not by changing this env var. | Set at install time. See [secrets-and-keys.md](secrets-and-keys.md) for rotation. |
+| `FLAIR_KEY_PASSPHRASE` | Passphrase used to derive the AES-256-GCM key that wraps federation private-key seeds at rest. Auto-generated to `~/.flair/keys/.passphrase` if unset. | Set explicitly for production federation deployments so the passphrase isn't auto-generated and lost on disk wipe. |
+| `HTTP_PORT` | Override the Harper HTTP port. Useful for sandboxes; production deployments should configure the port in `config.yaml` instead. | Rare. |
+
 ---
 
 ## Backup & Restore


### PR DESCRIPTION
## Why

`FLAIR_PUBLIC_URL` is used in 4 places in source (OAuth metadata, AdminInstance, A2AAdapter, XAA OAuth) but wasn't documented in `docs/` anywhere. Operators of remote / Fabric deployments need to know this is the lever to set so their admin pane shows the right URLs and OAuth metadata advertises a reachable issuer.

## What

Adds an "Environment variables" subsection to `docs/deployment.md` listing `FLAIR_PUBLIC_URL`, `HDB_ADMIN_PASSWORD`, `FLAIR_KEY_PASSPHRASE`, `HTTP_PORT` — what each does and when to set it.

Docs only. +14 lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)