### PR TITLE
fix(public-endpoints): allowRead/allowCreate to bypass Harper role gate (#410)

### DIFF
--- a/resources/A2AAdapter.ts
+++ b/resources/A2AAdapter.ts
@@ -294,6 +294,12 @@ function statusFromOrgEvent(event: any): string | null {
 }
 
 export class A2AAdapter extends Resource {
+  // A2A discovery surface — agent cards and adapter metadata are intentionally
+  // public so other agents/clients can discover this Flair as a memory peer.
+  // Handler enforces auth on actual A2A actions (POST below).
+  allowRead() { return true; }
+  allowCreate() { return true; }
+
   async get() {
     const host = process.env.FLAIR_PUBLIC_URL || "http://localhost:9926";
     return new Response(JSON.stringify({

--- a/resources/OAuth.ts
+++ b/resources/OAuth.ts
@@ -44,6 +44,13 @@ function futureISO(ms: number): string {
 // ─── Discovery metadata ──────────────────────────────────────────────────────
 
 export class OAuthMetadata extends Resource {
+  // OAuth discovery metadata is intentionally public — RFC 8414 § 3 requires
+  // it be accessible without authentication so clients can bootstrap their
+  // flow. `allowRead() { return true }` opens Harper's role gate so remote
+  // operators (e.g. Fabric-hosted Flair) get the metadata document instead
+  // of a 401 from Harper's intrinsic auth layer. Same pattern as Health (#386).
+  allowRead() { return true; }
+
   async get() {
     const baseUrl = process.env.FLAIR_PUBLIC_URL || `http://127.0.0.1:${process.env.HTTP_PORT || 19926}`;
     return {
@@ -75,6 +82,11 @@ export class OAuthMetadata extends Resource {
 // ─── Dynamic Client Registration (RFC 7591) ──────────────────────────────────
 
 export class OAuthRegister extends Resource {
+  // Dynamic Client Registration (RFC 7591) — clients must be able to register
+  // anonymously to bootstrap. Validation (redirect_uri allow-list, etc.)
+  // happens in post(). Pattern matches FederationPair.allowCreate (#299).
+  allowCreate() { return true; }
+
   async post(data: any) {
     const redirectUris: string[] = data?.redirect_uris ?? [];
     const clientName: string = data?.client_name ?? "Unknown Client";
@@ -120,6 +132,12 @@ export class OAuthRegister extends Resource {
 // ─── Authorization endpoint ──────────────────────────────────────────────────
 
 export class OAuthAuthorize extends Resource {
+  // OAuth authorize endpoint must accept anonymous GET/POST — the whole
+  // point of authorize is to start an unauthenticated user's flow. PKCE
+  // and state-parameter validation in the handler enforce real auth.
+  allowRead() { return true; }
+  allowCreate() { return true; }
+
   async get() {
     // In 1.0, this returns a simple HTML consent page.
     // The user (Nathan) approves or denies, which POSTs back.
@@ -233,6 +251,11 @@ ${scope.split(" ").map((s: string) => `<div class="scope">${s}</div>`).join("")}
 // ─── Token endpoint ──────────────────────────────────────────────────────────
 
 export class OAuthToken extends Resource {
+  // OAuth token exchange — client must hit this without prior Harper auth
+  // since they're trading code/refresh for a token. Authentication is in
+  // the post() handler via PKCE verifier + client_secret_basic.
+  allowCreate() { return true; }
+
   async post(data: any) {
     const grantType = data?.grant_type;
 
@@ -414,6 +437,10 @@ export class OAuthToken extends Resource {
 // ─── Revocation endpoint ─────────────────────────────────────────────────────
 
 export class OAuthRevoke extends Resource {
+  // RFC 7009 — token revocation accepts the token itself as proof; clients
+  // may not have a separate auth credential. Handler validates the token.
+  allowCreate() { return true; }
+
   async post(data: any) {
     const token = data?.token;
     if (!token) {

--- a/resources/ObservationCenter.ts
+++ b/resources/ObservationCenter.ts
@@ -12,6 +12,11 @@ const HTML = readFileSync(HTML_PATH, "utf8");
  * The HTML handles its own Basic-auth prompt and polls authenticated JSON endpoints.
  */
 export class ObservationCenter extends Resource {
+  // The dashboard shell is just HTML + inline JS; the JS prompts the user
+  // for admin-pass and authenticates each API call. The shell itself is
+  // intentionally public so it can render before auth happens.
+  allowRead() { return true; }
+
   async get() {
     return new Response(HTML, {
       status: 200,


### PR DESCRIPTION
## Bug
Several supposedly-public endpoints (`/OAuthMetadata`, `/OAuthAuthorize`, `/OAuthToken`, `/OAuthRevoke`, `/A2AAdapter`, `/ObservationCenter`) return 401 on remote deployments like Fabric. Discovered while operator-testing Fabric admin access.

## Root cause
Harper's intrinsic role gate fires BEFORE Flair's HTTP middleware allow-list runs. On rockit-local, `authorizeLocal: true` bypasses this for localhost. On Fabric (no authorizeLocal), Harper 401s before our middleware sees the request.

PR #386 fixed this for `/Health` by adding `allowRead() { return true }`. This PR applies the same pattern to every resource in the middleware's public allow-list.

## Each resource still enforces its own auth
Harper's role gate is the wrong layer for OAuth/A2A auth — those have their own validation:
- OAuthRegister: redirect-URI allow-list
- OAuthAuthorize: PKCE + state
- OAuthToken: PKCE verifier + client_secret_basic
- OAuthRevoke: bearer token validation
- A2AAdapter: per-action auth in POST handler
- ObservationCenter: HTML shell only; JS prompts for admin-pass

## Verified locally
- /Health → 200 ✓
- /OAuthMetadata → 200 ✓ (was 401)
- /A2AAdapter → 200 ✓ (was 401)
- /ObservationCenter → 200 ✓ (was 401)
- /AdminDashboard → 401 ✓ (unchanged — admin pages remain gated)

Fixes #410. 1.0 milestone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)