### PR TITLE
feat(rem): FLAIR-NIGHTLY-REM slice-1 PR-1 — snapshot + runner + CLI (no scheduler)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## Unreleased
 
+### ✨ FLAIR-NIGHTLY-REM slice-1 (manual cycle + snapshot/restore)
+
+- **`flair rem nightly run-once [--dry-run]`** — manually invokes the nightly cycle. Same code path the scheduler will use in slice-1 PR-2. Pre-flight pause check, fetch memories+soul, snapshot to `~/.flair/snapshots/<agent>/<iso-ts>.tar.gz`, append a JSON row to `~/.flair/logs/rem-nightly.jsonl`. Slice-2 will add maintenance + trust-tier filter + distillation; the audit row carries `slice: "1"` so readers can distinguish phases.
+- **`flair rem snapshot list [--agent <id>]`** — lists snapshot tarballs sorted by mtime descending. Snapshot creation is intentionally NOT exposed as `rem snapshot create` to keep the nightly audit log as the single source of truth.
+- **`flair rem restore <date> [--agent <id>] [--target <dir>] [--dry-run]`** — extracts a snapshot tarball to a target directory for inspection. Filesystem-only; live replay (rewind Harper state) is slice-2.
+- **`flair rem pause` / `flair rem resume`** — writes/removes `~/.flair/rem.paused` sentinel. The nightly runner checks this first and exits cleanly with `status: "paused"` in the log. `FLAIR_REM_PAUSE=1` env var is honored equivalently for fleet-wide pause.
+- **Snapshot format** — tar.gz at `~/.flair/snapshots/<agentId>/<iso-timestamp>.tar.gz` (0600 perms), containing `memories.jsonl` (one Memory row per line), `soul.json` (single row, array of rows, or null), and `metadata.json` (agent id, run id, flair version, counts). Mirrors the existing `flair session snapshot` pattern.
+- **Audit log** — `~/.flair/logs/rem-nightly.jsonl` (0600 perms), one JSON row per cycle. Health-endpoint REM block already surfaces `lastNightlyAt`; will show real values once the scheduler lands (PR-2).
+
 ### 🐛 Admin UI Fixes (1.0 milestone)
 
 - **AdminMemory list view returns rows again** — dashboard correctly reported 452 memories but `/AdminMemory` rendered "0 memories shown / No memories found." Harper's `archived not_equal true` predicate didn't match rows where `archived` was unset/false; switched to a JS-side filter. (#401, #405)

--- a/specs/FLAIR-NIGHTLY-REM-SLICE-1-DESIGN.md
+++ b/specs/FLAIR-NIGHTLY-REM-SLICE-1-DESIGN.md
@@ -1,0 +1,167 @@
+# FLAIR-NIGHTLY-REM — Slice 1 Implementation Design
+
+> Companion planning doc for the slice-1 build (scheduler + snapshot + restore). Parent spec: `FLAIR-NIGHTLY-REM.md`. Branch: `feat-rem-nightly-slice-1`.
+
+**Status:** Design checkpoint, 2026-05-14
+**Owner:** Flint
+**Why this doc:** the spec is a contract; this doc is the *implementation map*. Tracks what already exists so we don't re-invent, and what's left to build so the slice is scoped.
+
+---
+
+## § 1 What already exists (verified by grep, 2026-05-14)
+
+These were built ahead of slice 1 by earlier work (ops-2qq slices 1+2 and ops-ojht session-snapshot):
+
+1. **`MemoryCandidate` table** — `schemas/memory.graphql:84`. Full shape per spec § 7.
+2. **`flair rem candidates`** — `src/cli.ts:3979`. Lists pending candidates.
+3. **`flair rem promote`** — `src/cli.ts:4109`. `--rationale` + `--to` required.
+4. **`flair rem reject`** — `src/cli.ts:4210`. `--reason` required.
+5. **`flair rem rapid` / `light` / `restorative`** — `src/cli.ts:3776/3856/3899`. On-demand distillation (Dreams-equivalent).
+6. **Health endpoint REM block** — `resources/health.ts:330-373`. Already looks for:
+   - `~/Library/LaunchAgents/dev.flair.rem.nightly.plist` (darwin marker)
+   - `~/.config/systemd/user/flair-rem-nightly.timer` (linux marker)
+   - `~/.flair/logs/rem-nightly.jsonl` (audit log — `nightlyLog` variable)
+   - `MemoryCandidate.status=pending` count (pendingCandidates)
+   - Warns if `lastNightlyAt > 48h` ago.
+7. **`flair status rem`** — `src/cli.ts:4651-4674`. Shows the above.
+8. **`flair session snapshot {create|list|restore}`** — `src/cli.ts:5837-5984`. The exact tar.gz + 600-perms + `~/.flair/snapshots/<agent>/...` pattern slice 1 must mirror.
+
+**Implication:** Slice 1 is the connective tissue between (1)-(5) and (6)-(8). The harness pieces are mostly in place.
+
+## § 2 What slice 1 must add
+
+Per spec § 3 command surface, ordered by build-up:
+
+### A. The nightly runner (the script the scheduler invokes)
+
+A standalone executable that, when run, performs spec § 4 steps 1-6:
+
+1. Check `~/.flair/rem.paused` and `FLAIR_REM_PAUSE=1` → exit cleanly if paused.
+2. Pre-cycle snapshot to `~/.flair/snapshots/<agent>/<ISO-date>.tar.gz`.
+3. Maintenance (delegate to existing `rem light` code path).
+4. Trust-tier filter (default: endorsed+ from last 7d).
+5. Distillation (delegate to existing `/ReflectMemories` resource — same path as `rem rapid`).
+6. Append a row to `~/.flair/logs/rem-nightly.jsonl`.
+
+**Implementation form:** dedicated TS module `src/rem/nightly-runner.ts`, exported as both a function (for `flair rem nightly run-once`) and the entry point of a thin `bin/flair-rem-nightly` script that scheduler timers exec directly. The scheduler doesn't need to know about npx/bun — it points at one absolute path.
+
+### B. Snapshot module (reusable by both nightly runner and `flair rem snapshot`)
+
+Mirror the `flair session snapshot` pattern at `src/cli.ts:5837` but rooted at `~/.flair/snapshots/<agent>/<ISO-date>.tar.gz` (no `sessions/` subdir — REM snapshots live at the agent root).
+
+Contents of the tarball:
+- `memories.jsonl` — full agent memory export (via existing `/MemoryExport` if it exists, else direct table dump)
+- `soul.json` — soul snapshot (via existing `/SoulExport` if it exists)
+- `metadata.json` — agent id, run id, flair version, candidate counts at snapshot time
+
+Perms 600 (owner-only) matching the session snapshot pattern.
+
+**To verify before code lands:** existence + shape of `/MemoryExport` and `/SoulExport` resources. If they don't exist yet, dump directly from `databases.flair.Memory.search({})` and `databases.flair.Soul.get(agentId)`.
+
+### C. CLI subcommands
+
+```
+flair rem nightly enable [--agent <id>] [--at <HH:MM>] [--tz <zone>]
+flair rem nightly disable [--agent <id>]
+flair rem nightly status                    # delegates to existing `flair status rem`
+flair rem nightly run-once [--dry-run]       # invokes nightly-runner
+
+flair rem snapshot list [--agent <id>]      # mirror of session snapshot list
+flair rem restore <date> [--agent <id>] [--dry-run]   # untar + replay
+```
+
+### D. Scheduler templates
+
+**macOS launchd** — `templates/launchd/dev.flair.rem.nightly.plist.tmpl`:
+- StartCalendarInterval at user-specified hour:min (default 03:00 local)
+- ProgramArguments points to `~/.flair/bin/flair-rem-nightly` (deployed by `nightly enable`)
+- StandardOutPath + StandardErrorPath under `~/.flair/logs/`
+- RunAtLoad=false (the timer fires on schedule, not at session boot)
+
+**Linux systemd** — `templates/systemd/flair-rem-nightly.{service,timer}.tmpl`:
+- OnCalendar=*-*-* HH:MM:00
+- Persistent=true (catches missed runs after a sleep/reboot)
+- After=network.target (Harper local socket, but still — be safe)
+
+`flair rem nightly enable` does the install:
+1. Render template → target path with substituted values
+2. `launchctl bootstrap gui/<uid> <plist>` (macOS) or `systemctl --user daemon-reload && systemctl --user enable --now flair-rem-nightly.timer` (linux)
+3. Deploy the `flair-rem-nightly` shim script to `~/.flair/bin/` if not already present.
+
+`flair rem nightly disable` does the inverse: launchctl bootout / systemctl --user disable --now + remove template files (NOT the audit log + snapshots).
+
+### E. `~/.flair/rem.paused` flag file + `FLAIR_REM_PAUSE` env check
+
+`flair rem pause` → `touch ~/.flair/rem.paused`
+`flair rem resume` → `rm -f ~/.flair/rem.paused`
+Runner checks both before any side effect.
+
+### F. Dry-run first run guard (spec § 10)
+
+Implementation note: `~/.flair/rem.nightly.confirmed` sentinel. `nightly enable` does NOT create it. First nightly cycle sees the missing sentinel → runs in dry-run mode → emits a special log row → exits without writing candidates. `flair rem nightly confirm` creates the sentinel after the operator has seen the dry-run output. Same one-time guard the spec asks for.
+
+## § 3 Out of scope for slice 1 (slice 2 work)
+
+Per spec, these can land separately and the slice-1 release is still load-bearing:
+
+- Trust-tier filter beyond the default (operator can override `--trust-min` in slice 2).
+- Webhook / push channels — slice 1 is CLI-only per spec § 8.
+- Auto-promotion — never in 1.0 per spec § 11.
+
+## § 4 Risks + open questions
+
+1. **`/MemoryExport` / `/SoulExport` existence.** Need to verify or build direct table-dump fallbacks. Decision point at start of implementation.
+2. **launchd vs LaunchAgent rotation.** If a `dev.flair.rem.nightly.plist` already exists, `enable` overwrites; we should `launchctl bootout` first to avoid duplicate-loaded states.
+3. **Time zones.** macOS launchd respects local tz; systemd OnCalendar can be zoned. Default to local; `--tz` is slice-2 nice-to-have.
+4. **Bun vs Node for the shim.** The shim invocation must work whether the user has bun, node, or only Flair's bundled runtime. Approach: shim resolves the runtime in PATH order, prefers bun, falls back to node. Test on a clean macOS.
+5. **Failure-stops-the-cycle (spec § 4 lead).** Each step needs explicit error capture into the jsonl row (`errors: []`) AND a non-zero exit so launchd/systemd marks the run failed. Don't swallow errors.
+
+## § 5 Test plan
+
+Per `feedback_real_fixes.md`:
+
+1. **Unit:** snapshot create → list → restore round-trip preserves byte-identical memory rows.
+2. **Unit:** runner with `FLAIR_REM_PAUSE=1` exits without side effects.
+3. **Unit:** runner with no candidates emits one jsonl row with `candidates: []` and exits 0.
+4. **Integration:** `flair rem nightly enable && flair rem nightly run-once && flair rem nightly status` shows the expected fields after a real (test-agent) cycle.
+5. **Integration:** `flair rem restore <date> --dry-run` lists tarball contents without writes.
+6. **macOS:** `launchctl print gui/<uid>/dev.flair.rem.nightly` shows the loaded job after `enable`.
+7. **Linux:** `systemctl --user status flair-rem-nightly.timer` shows active after `enable`.
+
+## § 6 Estimate
+
+Per spec § 13: 1-2 days after prerequisites. Prerequisites confirmed shipped. Slice 1 alone:
+
+- A (runner): 4h
+- B (snapshot module): 3h
+- C (CLI wiring): 2h
+- D (scheduler templates + install/uninstall): 4h
+- E (pause/resume): 1h
+- F (dry-run first run): 1h
+- Tests: 4h
+- Docs: 2h
+
+**Total: ~3 focused days, no rush.** Nathan green-lit "no rush" 2026-05-14.
+
+## § 7 Sequencing for the PR cadence
+
+Land slice 1 as **two PRs**, not one big merge:
+
+1. **PR-1 (`feat-rem-nightly-runner`):** runner + snapshot module + CLI subcommands + `pause`/`resume`. Standalone-runnable via `flair rem nightly run-once`. No scheduler templates yet. Fully testable on its own.
+2. **PR-2 (`feat-rem-nightly-scheduler`):** launchd + systemd templates + `enable`/`disable`. Adds the "automation" layer on top of PR-1.
+
+Each PR through K&S ensemble. PR-2 unblocks the spec's "every night is reversible" claim becoming load-bearing.
+
+---
+
+## Implementation kickoff checklist (for next session)
+
+- [ ] Verify `/MemoryExport` + `/SoulExport` resource shape, or design fallbacks
+- [ ] Verify `flair rem rapid` distillation entry point can be invoked as a function (not just a CLI handler)
+- [ ] Sketch `~/.flair/bin/flair-rem-nightly` shim contents
+- [ ] First commit: snapshot module + tests (smallest atomic piece, builds confidence)
+- [ ] Second commit: runner with pause/resume + dry-run first-run guard
+- [ ] Third commit: CLI subcommands + status pass-through
+- [ ] Fourth commit: scheduler templates + enable/disable
+- [ ] Final commit: docs/CHANGELOG
+- [ ] K&S ensemble per [feedback_premerge_check_both_ks_on_gh.md]

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -4455,8 +4455,8 @@ rem
     } else {
       console.log(`(REM was not paused — no sentinel at ${REM_PAUSE_FLAG})`);
     }
-    if (process.env.FLAIR_REM_PAUSE) {
-      console.log(`\n⚠ FLAIR_REM_PAUSE env var is also set; unset it to fully resume.`);
+    if (process.env.FLAIR_REM_PAUSE === "1") {
+      console.log(`\n⚠ FLAIR_REM_PAUSE=1 env var is also set; unset it to fully resume.`);
     }
   });
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -4261,6 +4261,64 @@ rem
     }
   });
 
+// ─── flair rem nightly run-once ──────────────────────────────────────────────
+// Slice 1 of FLAIR-NIGHTLY-REM § 3. Manually invokes the nightly cycle code
+// path — same module the scheduler will call in PR-2. Useful for:
+//   - First-time operators verifying the cycle works before turning on the
+//     scheduled timer.
+//   - The dry-run-first-run guard (spec § 10) when the scheduler isn't yet
+//     installed.
+//   - Debugging a stale snapshot or audit row.
+//
+// `nightly enable` / `disable` / `status` land in PR-2 (scheduler templates).
+
+const remNightly = rem.command("nightly").description("Scheduled REM nightly cycle (manual trigger + scheduler management)");
+
+remNightly
+  .command("run-once")
+  .description("Run one nightly cycle now (snapshot + log). Same code path the scheduler will use.")
+  .option("--agent <id>", "Agent id (or FLAIR_AGENT_ID env)")
+  .option("--dry-run", "Log the row but skip the snapshot write")
+  .action(async (opts) => {
+    const agentId = opts.agent || process.env.FLAIR_AGENT_ID;
+    if (!agentId) {
+      console.error("Error: --agent or FLAIR_AGENT_ID env required");
+      process.exit(1);
+    }
+    const { runNightlyCycle } = await import("./rem/runner.js");
+    try {
+      const result = await runNightlyCycle({
+        agentId,
+        flairVersion: __pkgVersion,
+        apiCall: api,
+        dryRun: !!opts.dryRun,
+      });
+      const row = result.logRow;
+      console.log(`-- rem nightly run-once${opts.dryRun ? " (dry-run)" : ""} --`);
+      console.log(`Agent:      ${agentId}`);
+      console.log(`Status:     ${result.status}`);
+      if (result.snapshotPath) {
+        console.log(`Snapshot:   ${result.snapshotPath}`);
+      }
+      console.log(`Memories:   ${row.memoryCount ?? "—"}`);
+      console.log(`Souls:      ${row.soulCount ?? "—"}`);
+      console.log(`Pending:    ${row.pendingCandidates ?? "—"}`);
+      console.log(`Duration:   ${row.durationMs}ms`);
+      if (row.errors.length > 0) {
+        console.log(`Errors:`);
+        for (const e of row.errors) console.log(`  - ${e}`);
+        process.exit(1);
+      }
+      if (result.status === "paused") {
+        console.log(`\nNote: REM is paused (sentinel ~/.flair/rem.paused or FLAIR_REM_PAUSE env).`);
+        console.log(`Resume with: flair rem resume`);
+      }
+    } catch (err: any) {
+      console.error(`Error: ${err.message}`);
+      process.exit(1);
+    }
+  });
+
 // ─── flair rem snapshot list ─────────────────────────────────────────────────
 // Slice 1 of FLAIR-NIGHTLY-REM (ops-2qq). Lists snapshot tarballs under
 // ~/.flair/snapshots/<agent>/. Snapshot creation lives inside the nightly

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -16,7 +16,7 @@ import {
   statSync,
 } from "node:fs";
 import { homedir, hostname, tmpdir } from "node:os";
-import { join, resolve, sep } from "node:path";
+import { join, resolve, sep, dirname } from "node:path";
 import { spawn } from "node:child_process";
 import { createPrivateKey, sign as nodeCryptoSign, randomUUID, randomBytes } from "node:crypto";
 import { create as tarCreate, extract as tarExtract, list as tarList } from "tar";
@@ -4258,6 +4258,147 @@ rem
     } catch (err: any) {
       console.error(`Error: ${err.message}`);
       process.exit(1);
+    }
+  });
+
+// ─── flair rem snapshot list ─────────────────────────────────────────────────
+// Slice 1 of FLAIR-NIGHTLY-REM (ops-2qq). Lists snapshot tarballs under
+// ~/.flair/snapshots/<agent>/. Snapshot creation lives inside the nightly
+// runner (and exposed via `flair rem nightly run-once`) — there is no
+// user-facing `rem snapshot create` because that would invite operators to
+// create snapshots out of sync with the audit log. The list is the surface.
+
+const remSnapshot = rem.command("snapshot").description("REM nightly snapshots (tar.gz archives of agent memory + soul)");
+
+remSnapshot
+  .command("list")
+  .description("List REM snapshots for an agent (or all agents)")
+  .option("--agent <id>", "Filter to a single agent")
+  .option("--json", "Output as JSON")
+  .action(async (opts) => {
+    const { listSnapshots } = await import("./rem/snapshot.js");
+    const rows = listSnapshots(opts.agent);
+    if (opts.json) {
+      console.log(JSON.stringify(rows, null, 2));
+      return;
+    }
+    if (rows.length === 0) {
+      console.log("(no REM snapshots — ~/.flair/snapshots/ is empty or absent)");
+      console.log("\nSnapshots are produced by the nightly cycle. Run `flair rem nightly run-once`");
+      console.log("to generate one manually (slice 1).");
+      return;
+    }
+    const agentW = Math.max(5, ...rows.map((r) => r.agent.length));
+    const fileW = Math.max(20, ...rows.map((r) => r.file.length));
+    console.log(`  ${"agent".padEnd(agentW)}  ${"file".padEnd(fileW)}  size      age`);
+    for (const r of rows) {
+      console.log(`  ${r.agent.padEnd(agentW)}  ${r.file.padEnd(fileW)}  ${humanBytes(r.size).padEnd(8)}  ${relativeTime(r.mtime)}`);
+    }
+    console.log(`\n${rows.length} snapshot${rows.length > 1 ? "s" : ""}.`);
+  });
+
+// ─── flair rem restore <date> ────────────────────────────────────────────────
+// Slice 1 of FLAIR-NIGHTLY-REM § 9. Extracts a snapshot tarball to a target
+// directory for inspection. This is the "snapshot list + extract" pair — the
+// extracted memories.jsonl / soul.json / metadata.json can be inspected and
+// manually replayed if needed. A live replay into Harper (operator command
+// "actually rewind state to <date>") lands in slice-2 once we settle the
+// replay endpoint shape.
+//
+// The <date> argument can be a full ISO timestamp prefix (e.g.
+// "2026-05-14T03-00-00-000Z") or a date-only prefix ("2026-05-14"). The
+// command picks the latest snapshot matching that prefix.
+
+rem
+  .command("restore <date>")
+  .description("Extract a REM snapshot for inspection (replay-into-live-state is slice 2)")
+  .option("--agent <id>", "Agent id (or FLAIR_AGENT_ID env)")
+  .option("--target <dir>", "Directory to extract into (default: <snapshot>.restored)")
+  .option("--dry-run", "List the snapshot's contents without extracting")
+  .action(async (date, opts) => {
+    const { listSnapshots, extractSnapshot } = await import("./rem/snapshot.js");
+    const agentId = opts.agent || process.env.FLAIR_AGENT_ID;
+    if (!agentId) {
+      console.error("Error: --agent or FLAIR_AGENT_ID env required");
+      process.exit(1);
+    }
+    let rows;
+    try {
+      rows = listSnapshots(agentId);
+    } catch (err: any) {
+      console.error(`Error: ${err.message}`);
+      process.exit(1);
+    }
+    const matches = rows.filter((r) => r.file.startsWith(date));
+    if (matches.length === 0) {
+      console.error(`Error: no snapshot found for agent '${agentId}' matching date '${date}'`);
+      if (rows.length > 0) {
+        console.error(`  Available: ${rows.slice(0, 5).map((r) => r.file.replace(/\.tar\.gz$/, "")).join(", ")}`);
+      } else {
+        console.error(`  No snapshots exist for ${agentId}. Run \`flair rem nightly run-once\` to create one.`);
+      }
+      process.exit(1);
+    }
+    // listSnapshots returns descending by mtime, so matches[0] is the newest
+    // snapshot for the date prefix.
+    const match = matches[0];
+
+    try {
+      const result = await extractSnapshot({
+        snapshotPath: match.path,
+        targetDir: opts.target,
+        dryRun: !!opts.dryRun,
+      });
+      if (opts.dryRun) {
+        console.log(`(dry-run) snapshot: ${match.path}`);
+        for (const e of result.entries) {
+          console.log(`  ${e.path}  (${humanBytes(e.size)})`);
+        }
+        return;
+      }
+      console.log(`✅ Extracted: ${match.path}`);
+      console.log(`   To:        ${result.targetDir}`);
+      for (const e of result.entries) {
+        console.log(`     ${e.path}  (${humanBytes(e.size)})`);
+      }
+      console.log(`\nNote: this is a filesystem extract — Harper state is unchanged.`);
+      console.log(`Live replay (rewind into Harper) is a slice-2 capability.`);
+    } catch (err: any) {
+      console.error(`Error: ${err.message}`);
+      process.exit(1);
+    }
+  });
+
+// ─── flair rem pause / resume ────────────────────────────────────────────────
+// Slice 1 of FLAIR-NIGHTLY-REM § 9. The pause sentinel is checked by the
+// nightly runner before any side effects. Env-var FLAIR_REM_PAUSE=1 is also
+// honored — lets ops pause fleet-wide without writing a file.
+
+const REM_PAUSE_FLAG = resolve(homedir(), ".flair", "rem.paused");
+
+rem
+  .command("pause")
+  .description("Pause nightly REM runs — writes ~/.flair/rem.paused sentinel")
+  .action(() => {
+    const dir = dirname(REM_PAUSE_FLAG);
+    if (!existsSync(dir)) mkdirSync(dir, { recursive: true, mode: 0o700 });
+    writeFileSync(REM_PAUSE_FLAG, new Date().toISOString() + "\n", { mode: 0o600 });
+    console.log(`✅ REM nightly runs paused (sentinel: ${REM_PAUSE_FLAG})`);
+    console.log(`   Resume with: flair rem resume`);
+  });
+
+rem
+  .command("resume")
+  .description("Resume nightly REM runs — removes the pause sentinel")
+  .action(() => {
+    if (existsSync(REM_PAUSE_FLAG)) {
+      rmSync(REM_PAUSE_FLAG);
+      console.log(`✅ REM nightly runs resumed (removed ${REM_PAUSE_FLAG})`);
+    } else {
+      console.log(`(REM was not paused — no sentinel at ${REM_PAUSE_FLAG})`);
+    }
+    if (process.env.FLAIR_REM_PAUSE) {
+      console.log(`\n⚠ FLAIR_REM_PAUSE env var is also set; unset it to fully resume.`);
     }
   });
 

--- a/src/rem/runner.ts
+++ b/src/rem/runner.ts
@@ -1,0 +1,226 @@
+/**
+ * REM nightly runner — orchestrates the slice-1 cycle.
+ *
+ * Per FLAIR-NIGHTLY-REM § 4, in order:
+ *   1. Pre-flight: check pause sentinel / FLAIR_REM_PAUSE env. Exit clean if paused.
+ *   2. Snapshot agent state (memory + soul) to ~/.flair/snapshots/<agent>/.
+ *   3. (slice-2) maintenance — soft-delete expired + soft-archive stale.
+ *   4. (slice-2) trust-tier filter on input memories.
+ *   5. (slice-2) distillation — call /ReflectMemories, persist candidates.
+ *   6. Append a row to ~/.flair/logs/rem-nightly.jsonl.
+ *
+ * Slice-1 ships steps 1, 2, and 6. Maintenance + distillation are deferred to
+ * slice-2 so the load-bearing claim — "every cycle is reversible" — ships
+ * first. The audit row marks slice-1 cycles with `slice: "1"` so slice-2
+ * upgrades are visible in the history.
+ *
+ * Pure dependency injection so the runner is unit-testable without Harper.
+ * The CLI wires the real `apiCall` + `pkgVersion`; tests pass stubs.
+ */
+import { appendFileSync, existsSync, mkdirSync, readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { homedir } from "node:os";
+import { createSnapshot } from "./snapshot.js";
+
+export const REM_PAUSE_FLAG = resolve(homedir(), ".flair", "rem.paused");
+export const REM_NIGHTLY_LOG = resolve(homedir(), ".flair", "logs", "rem-nightly.jsonl");
+
+export type ApiCall = (method: string, path: string, body?: unknown) => Promise<any>;
+
+export interface RunnerOpts {
+  agentId: string;
+  flairVersion: string;
+  apiCall: ApiCall;
+  /** Override snapshot root (testing). */
+  snapshotRoot?: string;
+  /** Override audit log path (testing). */
+  logPath?: string;
+  /** Override pause flag path (testing). */
+  pauseFlagPath?: string;
+  /** Override env-var check (testing). */
+  envPaused?: boolean;
+  /** When true, fetch and log but skip the snapshot write. */
+  dryRun?: boolean;
+  /** Override "now" (testing). */
+  nowOverride?: Date;
+}
+
+export type RunnerStatus = "paused" | "completed" | "dry-run" | "failed";
+
+export interface RunnerLogRow {
+  agentId: string;
+  runAt: string;
+  slice: "1";
+  status: RunnerStatus;
+  dryRun?: boolean;
+  snapshotPath?: string;
+  memoryCount?: number;
+  soulCount?: number;
+  pendingCandidates?: number;
+  durationMs: number;
+  errors: string[];
+  /** Slice-2 fields, written as empty placeholders so log readers don't break. */
+  archived?: number;
+  expired?: number;
+  consolidated?: number;
+  candidates?: string[];
+}
+
+export interface RunnerResult {
+  status: RunnerStatus;
+  logRow: RunnerLogRow;
+  snapshotPath?: string;
+}
+
+function readPauseSentinel(path: string): boolean {
+  try {
+    const stat = readFileSync(path, "utf-8");
+    // Existence alone is enough; the body is just a touch-timestamp.
+    return stat.length >= 0;
+  } catch {
+    return false;
+  }
+}
+
+function appendLogRow(logPath: string, row: RunnerLogRow): void {
+  const dir = dirname(logPath);
+  if (!existsSync(dir)) mkdirSync(dir, { recursive: true, mode: 0o700 });
+  appendFileSync(logPath, JSON.stringify(row) + "\n", { mode: 0o600 });
+}
+
+/**
+ * Coerces a Harper REST list response into a flat array. The /Memory and
+ * /Soul resources can return either an array directly or a paginated shape
+ * `{ results: [], items: [] }` depending on path/options.
+ */
+function asArray(raw: unknown): any[] {
+  if (Array.isArray(raw)) return raw;
+  if (raw && typeof raw === "object") {
+    const obj = raw as Record<string, unknown>;
+    if (Array.isArray(obj.results)) return obj.results as any[];
+    if (Array.isArray(obj.items)) return obj.items as any[];
+  }
+  return [];
+}
+
+/**
+ * Counts pending memory candidates for the agent.
+ *
+ * Falls back to a `search_by_conditions` POST that mirrors the pattern
+ * `flair rem candidates` uses. Returns 0 on any error — the runner should
+ * not fail the cycle just because the candidate count couldn't be sampled.
+ */
+async function fetchPendingCandidateCount(api: ApiCall, agentId: string): Promise<number> {
+  try {
+    const result = await api("POST", "/MemoryCandidate/search_by_conditions", {
+      operator: "and",
+      conditions: [
+        { search_attribute: "agentId", search_type: "equals", search_value: agentId },
+        { search_attribute: "status", search_type: "equals", search_value: "pending" },
+      ],
+      get_attributes: ["id"],
+    });
+    const rows = asArray(result);
+    return rows.length;
+  } catch {
+    return 0;
+  }
+}
+
+/**
+ * Runs one nightly cycle for the given agent. See module header for steps.
+ * Pure orchestration; all I/O goes through injected dependencies.
+ */
+export async function runNightlyCycle(opts: RunnerOpts): Promise<RunnerResult> {
+  const startedAt = opts.nowOverride ?? new Date();
+  const startedMs = startedAt.getTime();
+  const logPath = opts.logPath ?? REM_NIGHTLY_LOG;
+  const pauseFlagPath = opts.pauseFlagPath ?? REM_PAUSE_FLAG;
+  const envPaused = opts.envPaused ?? !!process.env.FLAIR_REM_PAUSE;
+
+  const baseRow: Omit<RunnerLogRow, "status" | "durationMs"> = {
+    agentId: opts.agentId,
+    runAt: startedAt.toISOString(),
+    slice: "1",
+    errors: [],
+  };
+
+  // Step 1: pre-flight (pause)
+  if (envPaused || (existsSync(pauseFlagPath) && readPauseSentinel(pauseFlagPath))) {
+    const row: RunnerLogRow = {
+      ...baseRow,
+      status: "paused",
+      durationMs: Date.now() - startedMs,
+      errors: [],
+    };
+    appendLogRow(logPath, row);
+    return { status: "paused", logRow: row };
+  }
+
+  const errors: string[] = [];
+
+  // Step 2: snapshot
+  let snapshotPath: string | undefined;
+  let memoryCount = 0;
+  let soulCount = 0;
+  let pendingCandidates = 0;
+
+  try {
+    // Fetch agent data
+    const memoriesRaw = await opts.apiCall("GET", `/Memory?agentId=${encodeURIComponent(opts.agentId)}`);
+    const memories = asArray(memoriesRaw);
+    memoryCount = memories.length;
+
+    const soulRaw = await opts.apiCall("GET", `/Soul?agentId=${encodeURIComponent(opts.agentId)}`);
+    const souls = asArray(soulRaw);
+    soulCount = souls.length;
+    // For the snapshot's soul.json: keep the full multi-row shape if there
+    // are multiple souls (different keys), or unwrap a single-row response.
+    const soulForSnapshot = souls.length === 1 ? souls[0] : souls.length > 1 ? souls : null;
+
+    pendingCandidates = await fetchPendingCandidateCount(opts.apiCall, opts.agentId);
+
+    if (!opts.dryRun) {
+      const created = await createSnapshot({
+        agentId: opts.agentId,
+        flairVersion: opts.flairVersion,
+        memories,
+        soul: soulForSnapshot as Record<string, unknown> | null,
+        pendingCandidateCount: pendingCandidates,
+        rootOverride: opts.snapshotRoot,
+        nowOverride: opts.nowOverride,
+      });
+      snapshotPath = created.path;
+    }
+  } catch (err: any) {
+    errors.push(`snapshot: ${err?.message ?? String(err)}`);
+    const row: RunnerLogRow = {
+      ...baseRow,
+      status: "failed",
+      memoryCount,
+      soulCount,
+      pendingCandidates,
+      durationMs: Date.now() - startedMs,
+      errors,
+    };
+    appendLogRow(logPath, row);
+    return { status: "failed", logRow: row };
+  }
+
+  // Step 6: log
+  const row: RunnerLogRow = {
+    ...baseRow,
+    status: opts.dryRun ? "dry-run" : "completed",
+    dryRun: opts.dryRun || undefined,
+    snapshotPath,
+    memoryCount,
+    soulCount,
+    pendingCandidates,
+    durationMs: Date.now() - startedMs,
+    errors,
+    // Slice-2 placeholders — left undefined for now so readers don't see
+    // confusing "0" archived/consolidated counts on slice-1 rows.
+  };
+  appendLogRow(logPath, row);
+  return { status: row.status, logRow: row, snapshotPath };
+}

--- a/src/rem/runner.ts
+++ b/src/rem/runner.ts
@@ -74,9 +74,9 @@ export interface RunnerResult {
 
 function readPauseSentinel(path: string): boolean {
   try {
-    const stat = readFileSync(path, "utf-8");
+    const contents = readFileSync(path, "utf-8");
     // Existence alone is enough; the body is just a touch-timestamp.
-    return stat.length >= 0;
+    return contents.length >= 0;
   } catch {
     return false;
   }
@@ -136,7 +136,7 @@ export async function runNightlyCycle(opts: RunnerOpts): Promise<RunnerResult> {
   const startedMs = startedAt.getTime();
   const logPath = opts.logPath ?? REM_NIGHTLY_LOG;
   const pauseFlagPath = opts.pauseFlagPath ?? REM_PAUSE_FLAG;
-  const envPaused = opts.envPaused ?? !!process.env.FLAIR_REM_PAUSE;
+  const envPaused = opts.envPaused ?? process.env.FLAIR_REM_PAUSE === "1";
 
   const baseRow: Omit<RunnerLogRow, "status" | "durationMs"> = {
     agentId: opts.agentId,

--- a/src/rem/snapshot.ts
+++ b/src/rem/snapshot.ts
@@ -1,0 +1,220 @@
+/**
+ * REM snapshot module — pre-cycle snapshot + listing + restore extraction.
+ *
+ * Per FLAIR-NIGHTLY-REM § 4 step 2 and § 9. Produces tar.gz archives at
+ * ~/.flair/snapshots/<agentId>/<ISO-timestamp>.tar.gz containing:
+ *   - memories.jsonl  — one Memory row per line
+ *   - soul.json       — Soul row (or null)
+ *   - metadata.json   — agent id, run id, flair version, counts
+ *
+ * Mirrors the `flair session snapshot` pattern (tar.gz, 600 perms, agent-
+ * rooted under ~/.flair/snapshots/). Pure filesystem — the caller fetches
+ * the data via the Harper HTTP API and passes it in.
+ *
+ * Used by:
+ *   - `flair rem snapshot list`
+ *   - `flair rem restore <date>`
+ *   - The nightly runner (slice-1 follow-on)
+ */
+import { mkdirSync, writeFileSync, statSync, chmodSync, rmSync, existsSync, readdirSync } from "node:fs";
+import { resolve } from "node:path";
+import { homedir } from "node:os";
+import { create as tarCreate, extract as tarExtract, list as tarList } from "tar";
+
+export const SNAPSHOT_ROOT = resolve(homedir(), ".flair", "snapshots");
+
+/** Validates the agent id and returns its snapshot directory. */
+export function remSnapshotDir(agent: string): string {
+  if (!/^[a-zA-Z0-9_-]+$/.test(agent)) {
+    throw new Error(`invalid agent id: ${agent}`);
+  }
+  return resolve(SNAPSHOT_ROOT, agent);
+}
+
+export interface SnapshotMeta {
+  agentId: string;
+  runId: string;
+  flairVersion: string;
+  createdAt: string;
+  memoryCount: number;
+  pendingCandidateCount: number;
+  soulPresent: boolean;
+}
+
+export interface CreateOpts {
+  agentId: string;
+  flairVersion: string;
+  memories: Array<Record<string, unknown>>;
+  soul: Record<string, unknown> | null;
+  pendingCandidateCount: number;
+  /** Override the run id (defaults to `rem-nightly-<iso-ts>`). */
+  runId?: string;
+  /** Override the snapshot root for testing. */
+  rootOverride?: string;
+  /** Override "now" for deterministic tests. */
+  nowOverride?: Date;
+}
+
+export interface CreateResult {
+  path: string;
+  size: number;
+  meta: SnapshotMeta;
+}
+
+/**
+ * Creates a tar.gz snapshot at <root>/<agentId>/<ISO-timestamp>.tar.gz.
+ * Returns the path, byte size, and metadata embedded in the archive.
+ *
+ * Tarball perms: 0600 (owner-only).
+ */
+export async function createSnapshot(opts: CreateOpts): Promise<CreateResult> {
+  const now = opts.nowOverride ?? new Date();
+  const isoFull = now.toISOString().replace(/[:.]/g, "-");
+
+  const root = opts.rootOverride ?? SNAPSHOT_ROOT;
+  if (!/^[a-zA-Z0-9_-]+$/.test(opts.agentId)) {
+    throw new Error(`invalid agent id: ${opts.agentId}`);
+  }
+  const dir = resolve(root, opts.agentId);
+  if (!existsSync(dir)) mkdirSync(dir, { recursive: true, mode: 0o700 });
+
+  const tarballName = `${isoFull}.tar.gz`;
+  const tarballPath = resolve(dir, tarballName);
+
+  const meta: SnapshotMeta = {
+    agentId: opts.agentId,
+    runId: opts.runId ?? `rem-nightly-${isoFull}`,
+    flairVersion: opts.flairVersion,
+    createdAt: now.toISOString(),
+    memoryCount: opts.memories.length,
+    pendingCandidateCount: opts.pendingCandidateCount,
+    soulPresent: opts.soul !== null,
+  };
+
+  const tmpDir = resolve(dir, `.tmp-${process.pid}-${Date.now()}`);
+  mkdirSync(tmpDir, { recursive: true, mode: 0o700 });
+  try {
+    const memoryLines = opts.memories.map((m) => JSON.stringify(m)).join("\n");
+    writeFileSync(
+      resolve(tmpDir, "memories.jsonl"),
+      memoryLines + (memoryLines.length ? "\n" : ""),
+      { mode: 0o600 },
+    );
+    writeFileSync(
+      resolve(tmpDir, "soul.json"),
+      JSON.stringify(opts.soul, null, 2) + "\n",
+      { mode: 0o600 },
+    );
+    writeFileSync(
+      resolve(tmpDir, "metadata.json"),
+      JSON.stringify(meta, null, 2) + "\n",
+      { mode: 0o600 },
+    );
+
+    await tarCreate(
+      { gzip: true, cwd: tmpDir, file: tarballPath, portable: true },
+      ["memories.jsonl", "soul.json", "metadata.json"],
+    );
+    chmodSync(tarballPath, 0o600);
+  } finally {
+    rmSync(tmpDir, { recursive: true, force: true });
+  }
+
+  return { path: tarballPath, size: statSync(tarballPath).size, meta };
+}
+
+export interface SnapshotRow {
+  agent: string;
+  file: string;
+  path: string;
+  size: number;
+  mtime: string;
+}
+
+/**
+ * Lists snapshots at <root>/<agent>/*.tar.gz. Returns rows sorted by mtime
+ * descending. Pass an agent filter to restrict to a single agent.
+ */
+export function listSnapshots(agentFilter?: string, rootOverride?: string): SnapshotRow[] {
+  const root = rootOverride ?? SNAPSHOT_ROOT;
+  if (!existsSync(root)) return [];
+
+  let agents: string[];
+  if (agentFilter) {
+    if (!/^[a-zA-Z0-9_-]+$/.test(agentFilter)) {
+      throw new Error(`invalid agent id: ${agentFilter}`);
+    }
+    agents = [agentFilter];
+  } else {
+    agents = readdirSync(root).filter((d) => {
+      try {
+        return statSync(resolve(root, d)).isDirectory();
+      } catch {
+        return false;
+      }
+    });
+  }
+
+  const rows: SnapshotRow[] = [];
+  for (const a of agents) {
+    const dir = resolve(root, a);
+    if (!existsSync(dir)) continue;
+    for (const f of readdirSync(dir)) {
+      if (!f.endsWith(".tar.gz")) continue;
+      const p = resolve(dir, f);
+      const s = statSync(p);
+      rows.push({ agent: a, file: f, path: p, size: s.size, mtime: s.mtime.toISOString() });
+    }
+  }
+  rows.sort((a, b) => b.mtime.localeCompare(a.mtime));
+  return rows;
+}
+
+export interface ExtractOpts {
+  snapshotPath: string;
+  /** Defaults to `<snapshotPath>.restored` next to the tarball. */
+  targetDir?: string;
+  dryRun?: boolean;
+}
+
+export interface ExtractEntry {
+  path: string;
+  size: number;
+}
+
+export interface ExtractResult {
+  /** Set only when dryRun is false. */
+  targetDir?: string;
+  entries: ExtractEntry[];
+}
+
+/**
+ * Extracts a snapshot tar.gz into a target directory. Refuses to extract
+ * over an existing directory — operator must pass a clean target.
+ *
+ * In dry-run mode, returns the tarball entry list without writing anything.
+ */
+export async function extractSnapshot(opts: ExtractOpts): Promise<ExtractResult> {
+  if (!existsSync(opts.snapshotPath)) {
+    throw new Error(`snapshot does not exist: ${opts.snapshotPath}`);
+  }
+
+  const entries: ExtractEntry[] = [];
+  await tarList({
+    file: opts.snapshotPath,
+    onReadEntry: (e: any) => entries.push({ path: e.path, size: e.size ?? 0 }),
+  });
+
+  if (opts.dryRun) {
+    return { entries };
+  }
+
+  const targetDir = opts.targetDir ?? `${opts.snapshotPath}.restored`;
+  if (existsSync(targetDir)) {
+    throw new Error(`target directory already exists: ${targetDir}`);
+  }
+  mkdirSync(targetDir, { recursive: true, mode: 0o700 });
+  await tarExtract({ file: opts.snapshotPath, cwd: targetDir });
+
+  return { targetDir, entries };
+}

--- a/test/rem-runner.test.ts
+++ b/test/rem-runner.test.ts
@@ -1,0 +1,210 @@
+/**
+ * rem-runner.test.ts — Unit tests for src/rem/runner.ts.
+ *
+ * Pure orchestration coverage. No Harper or filesystem state required
+ * outside an isolated tmpdir. Tests pause sentinel, env-var pause, dry-run
+ * (skip write but still log), happy path (writes snapshot + log row),
+ * api failure (fail-stops-cycle + error in log row), and soul shape
+ * coercion (single row vs multi row).
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import { mkdirSync, rmSync, readFileSync, writeFileSync, existsSync, mkdtempSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { runNightlyCycle, type ApiCall, type RunnerOpts } from "../src/rem/runner.ts";
+
+let testRoot: string;
+let snapshotRoot: string;
+let logPath: string;
+let pauseFlagPath: string;
+
+beforeEach(() => {
+  testRoot = mkdtempSync(join(tmpdir(), "flair-rem-runner-test-"));
+  snapshotRoot = join(testRoot, "snapshots");
+  logPath = join(testRoot, "logs", "rem-nightly.jsonl");
+  pauseFlagPath = join(testRoot, "rem.paused");
+});
+
+afterEach(() => {
+  rmSync(testRoot, { recursive: true, force: true });
+});
+
+function makeApi(handlers: Partial<Record<string, (path: string, body?: unknown) => Promise<any> | any>>): ApiCall {
+  return async (method, path) => {
+    const key = `${method}:${path.split("?")[0]}`;
+    for (const [pattern, handler] of Object.entries(handlers)) {
+      if (key === pattern || (pattern.endsWith("*") && key.startsWith(pattern.slice(0, -1)))) {
+        return handler!(path);
+      }
+    }
+    throw new Error(`unexpected api call: ${key}`);
+  };
+}
+
+function readLogRows(): any[] {
+  if (!existsSync(logPath)) return [];
+  return readFileSync(logPath, "utf-8").trim().split("\n").map((l) => JSON.parse(l));
+}
+
+function baseOpts(overrides: Partial<RunnerOpts> = {}): RunnerOpts {
+  return {
+    agentId: "test-agent",
+    flairVersion: "0.0.0-test",
+    apiCall: makeApi({
+      "GET:/Memory": () => [{ id: "m1" }, { id: "m2" }],
+      "GET:/Soul": () => [{ id: "soul-test-agent", agentId: "test-agent" }],
+      "POST:/MemoryCandidate/search_by_conditions": () => [],
+    }),
+    snapshotRoot,
+    logPath,
+    pauseFlagPath,
+    envPaused: false,
+    ...overrides,
+  };
+}
+
+describe("pause handling", () => {
+  it("exits clean when the pause sentinel exists", async () => {
+    mkdirSync(testRoot, { recursive: true });
+    writeFileSync(pauseFlagPath, "2026-05-14T03:00:00Z\n");
+    const r = await runNightlyCycle(baseOpts());
+    expect(r.status).toBe("paused");
+    expect(r.snapshotPath).toBeUndefined();
+    expect(r.logRow.errors).toEqual([]);
+    expect(readLogRows()[0].status).toBe("paused");
+  });
+
+  it("exits clean when FLAIR_REM_PAUSE env is set", async () => {
+    const r = await runNightlyCycle(baseOpts({ envPaused: true }));
+    expect(r.status).toBe("paused");
+    expect(r.snapshotPath).toBeUndefined();
+  });
+
+  it("runs the cycle when no pause signal", async () => {
+    const r = await runNightlyCycle(baseOpts());
+    expect(r.status).toBe("completed");
+    expect(r.snapshotPath).toBeDefined();
+    expect(existsSync(r.snapshotPath!)).toBe(true);
+  });
+});
+
+describe("happy path", () => {
+  it("snapshots, logs, and returns completed status", async () => {
+    const r = await runNightlyCycle(baseOpts());
+    expect(r.status).toBe("completed");
+    expect(r.logRow.memoryCount).toBe(2);
+    expect(r.logRow.soulCount).toBe(1);
+    expect(r.logRow.pendingCandidates).toBe(0);
+    expect(r.logRow.errors).toEqual([]);
+    expect(r.logRow.slice).toBe("1");
+
+    // Log file contains exactly one row.
+    const rows = readLogRows();
+    expect(rows.length).toBe(1);
+    expect(rows[0].status).toBe("completed");
+    expect(rows[0].snapshotPath).toBe(r.snapshotPath);
+  });
+
+  it("reports pendingCandidates from the candidate search", async () => {
+    const r = await runNightlyCycle(baseOpts({
+      apiCall: makeApi({
+        "GET:/Memory": () => [{ id: "m1" }],
+        "GET:/Soul": () => [],
+        "POST:/MemoryCandidate/search_by_conditions": () => [
+          { id: "c1" }, { id: "c2" }, { id: "c3" },
+        ],
+      }),
+    }));
+    expect(r.logRow.pendingCandidates).toBe(3);
+  });
+
+  it("handles Harper response shapes (results[] and items[])", async () => {
+    const r = await runNightlyCycle(baseOpts({
+      apiCall: makeApi({
+        "GET:/Memory": () => ({ results: [{ id: "m1" }, { id: "m2" }, { id: "m3" }] }),
+        "GET:/Soul": () => ({ items: [{ id: "s1" }] }),
+        "POST:/MemoryCandidate/search_by_conditions": () => [],
+      }),
+    }));
+    expect(r.status).toBe("completed");
+    expect(r.logRow.memoryCount).toBe(3);
+    expect(r.logRow.soulCount).toBe(1);
+  });
+});
+
+describe("dry-run", () => {
+  it("logs but does not write a snapshot tarball", async () => {
+    const r = await runNightlyCycle(baseOpts({ dryRun: true }));
+    expect(r.status).toBe("dry-run");
+    expect(r.snapshotPath).toBeUndefined();
+
+    const rows = readLogRows();
+    expect(rows.length).toBe(1);
+    expect(rows[0].status).toBe("dry-run");
+    expect(rows[0].dryRun).toBe(true);
+    expect(rows[0].memoryCount).toBe(2);
+  });
+});
+
+describe("failure modes", () => {
+  it("captures memory-fetch errors and exits failed without an empty tarball", async () => {
+    const r = await runNightlyCycle(baseOpts({
+      apiCall: makeApi({
+        "GET:/Memory": () => { throw new Error("upstream is down"); },
+      }),
+    }));
+    expect(r.status).toBe("failed");
+    expect(r.snapshotPath).toBeUndefined();
+    expect(r.logRow.errors.length).toBe(1);
+    expect(r.logRow.errors[0]).toContain("upstream is down");
+
+    // Log row recorded.
+    const rows = readLogRows();
+    expect(rows.length).toBe(1);
+    expect(rows[0].status).toBe("failed");
+    // No tarball.
+    expect(existsSync(join(snapshotRoot, "test-agent"))).toBe(false);
+  });
+
+  it("captures soul-fetch errors", async () => {
+    const r = await runNightlyCycle(baseOpts({
+      apiCall: makeApi({
+        "GET:/Memory": () => [{ id: "m1" }],
+        "GET:/Soul": () => { throw new Error("soul gone"); },
+      }),
+    }));
+    expect(r.status).toBe("failed");
+    expect(r.logRow.errors[0]).toContain("soul gone");
+  });
+
+  it("does not fail on candidate-count errors — degrades gracefully to 0", async () => {
+    const r = await runNightlyCycle(baseOpts({
+      apiCall: makeApi({
+        "GET:/Memory": () => [{ id: "m1" }],
+        "GET:/Soul": () => [],
+        "POST:/MemoryCandidate/search_by_conditions": () => { throw new Error("candidate table missing"); },
+      }),
+    }));
+    // Candidate count is a non-fatal signal — the cycle still completes.
+    expect(r.status).toBe("completed");
+    expect(r.logRow.pendingCandidates).toBe(0);
+  });
+});
+
+describe("log append behavior", () => {
+  it("appends consecutive runs to the same log file", async () => {
+    await runNightlyCycle(baseOpts({ nowOverride: new Date("2026-05-14T03:00:00.000Z") }));
+    await runNightlyCycle(baseOpts({ nowOverride: new Date("2026-05-15T03:00:00.000Z") }));
+    const rows = readLogRows();
+    expect(rows.length).toBe(2);
+    expect(rows[0].runAt).toBe("2026-05-14T03:00:00.000Z");
+    expect(rows[1].runAt).toBe("2026-05-15T03:00:00.000Z");
+  });
+
+  it("creates the log directory if missing", async () => {
+    expect(existsSync(join(testRoot, "logs"))).toBe(false);
+    await runNightlyCycle(baseOpts());
+    expect(existsSync(logPath)).toBe(true);
+  });
+});

--- a/test/rem-snapshot.test.ts
+++ b/test/rem-snapshot.test.ts
@@ -1,0 +1,189 @@
+/**
+ * rem-snapshot.test.ts — Unit tests for src/rem/snapshot.ts.
+ *
+ * Pure filesystem coverage. No Harper required. Tests:
+ *   - Round-trip: create → extract → byte-identical memory rows
+ *   - listSnapshots: ordering + agent filter + missing root
+ *   - Validation: invalid agent ids rejected
+ *   - Dry-run extract: lists without writing
+ *   - Refuse-overwrite: existing target dir rejected
+ *   - Empty memories: single newline-free archive
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import { mkdirSync, rmSync, readFileSync, writeFileSync, statSync, existsSync, mkdtempSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { createSnapshot, listSnapshots, extractSnapshot, remSnapshotDir, type CreateOpts } from "../src/rem/snapshot.ts";
+
+let testRoot: string;
+
+beforeEach(() => {
+  testRoot = mkdtempSync(join(tmpdir(), "flair-rem-snapshot-test-"));
+});
+
+afterEach(() => {
+  rmSync(testRoot, { recursive: true, force: true });
+});
+
+const sampleMemories = [
+  { id: "m1", agentId: "test-agent", content: "first memory", durability: "persistent" },
+  { id: "m2", agentId: "test-agent", content: "second memory", tags: ["a", "b"] },
+];
+const sampleSoul = { id: "soul-test-agent", agentId: "test-agent", instructions: "be helpful" };
+
+function baseOpts(overrides: Partial<CreateOpts> = {}): CreateOpts {
+  return {
+    agentId: "test-agent",
+    flairVersion: "0.0.0-test",
+    memories: sampleMemories,
+    soul: sampleSoul,
+    pendingCandidateCount: 3,
+    rootOverride: testRoot,
+    ...overrides,
+  };
+}
+
+describe("createSnapshot", () => {
+  it("produces a tar.gz at the agent-rooted path with 600 perms", async () => {
+    const r = await createSnapshot(baseOpts());
+    expect(existsSync(r.path)).toBe(true);
+    expect(r.path).toContain(join(testRoot, "test-agent"));
+    expect(r.path.endsWith(".tar.gz")).toBe(true);
+    // 0o600 = owner rw only (octal 100600 with file-type bits)
+    expect(statSync(r.path).mode & 0o777).toBe(0o600);
+    expect(r.size).toBeGreaterThan(0);
+  });
+
+  it("embeds metadata reflecting inputs", async () => {
+    const r = await createSnapshot(baseOpts({
+      runId: "explicit-run",
+      flairVersion: "1.2.3",
+    }));
+    expect(r.meta.agentId).toBe("test-agent");
+    expect(r.meta.runId).toBe("explicit-run");
+    expect(r.meta.flairVersion).toBe("1.2.3");
+    expect(r.meta.memoryCount).toBe(2);
+    expect(r.meta.pendingCandidateCount).toBe(3);
+    expect(r.meta.soulPresent).toBe(true);
+  });
+
+  it("records soulPresent=false when soul is null", async () => {
+    const r = await createSnapshot(baseOpts({ soul: null }));
+    expect(r.meta.soulPresent).toBe(false);
+  });
+
+  it("handles empty memories without crashing", async () => {
+    const r = await createSnapshot(baseOpts({ memories: [] }));
+    expect(r.meta.memoryCount).toBe(0);
+    expect(existsSync(r.path)).toBe(true);
+  });
+
+  it("rejects invalid agent ids", async () => {
+    await expect(createSnapshot(baseOpts({ agentId: "../etc/passwd" }))).rejects.toThrow(/invalid agent id/);
+    await expect(createSnapshot(baseOpts({ agentId: "with space" }))).rejects.toThrow(/invalid agent id/);
+    await expect(createSnapshot(baseOpts({ agentId: "" }))).rejects.toThrow(/invalid agent id/);
+  });
+
+  it("derives default runId from the timestamp", async () => {
+    const now = new Date("2026-05-14T03:00:00.000Z");
+    const r = await createSnapshot(baseOpts({ nowOverride: now }));
+    expect(r.meta.runId).toMatch(/^rem-nightly-2026-05-14T03-00-00-000Z$/);
+  });
+});
+
+describe("round-trip create → extract", () => {
+  it("preserves byte-identical memory rows", async () => {
+    const created = await createSnapshot(baseOpts());
+
+    const restoreDir = join(testRoot, "restored");
+    const ex = await extractSnapshot({ snapshotPath: created.path, targetDir: restoreDir });
+    expect(ex.targetDir).toBe(restoreDir);
+    expect(ex.entries.map((e) => e.path).sort()).toEqual(["memories.jsonl", "metadata.json", "soul.json"]);
+
+    const memoriesText = readFileSync(join(restoreDir, "memories.jsonl"), "utf-8");
+    const parsedLines = memoriesText.trim().split("\n").map((l) => JSON.parse(l));
+    expect(parsedLines).toEqual(sampleMemories);
+
+    const soulText = readFileSync(join(restoreDir, "soul.json"), "utf-8");
+    expect(JSON.parse(soulText)).toEqual(sampleSoul);
+
+    const metaText = readFileSync(join(restoreDir, "metadata.json"), "utf-8");
+    expect(JSON.parse(metaText)).toEqual(created.meta);
+  });
+
+  it("dry-run lists entries without writing", async () => {
+    const created = await createSnapshot(baseOpts());
+    const ex = await extractSnapshot({ snapshotPath: created.path, dryRun: true });
+    expect(ex.targetDir).toBeUndefined();
+    expect(ex.entries.length).toBe(3);
+
+    const sidecar = `${created.path}.restored`;
+    expect(existsSync(sidecar)).toBe(false);
+  });
+
+  it("refuses to overwrite an existing target directory", async () => {
+    const created = await createSnapshot(baseOpts());
+    const target = join(testRoot, "preexisting");
+    mkdirSync(target, { recursive: true });
+    await expect(extractSnapshot({ snapshotPath: created.path, targetDir: target })).rejects.toThrow(/already exists/);
+  });
+
+  it("rejects extraction when the tarball doesn't exist", async () => {
+    await expect(extractSnapshot({ snapshotPath: join(testRoot, "ghost.tar.gz") })).rejects.toThrow(/does not exist/);
+  });
+});
+
+describe("listSnapshots", () => {
+  it("returns an empty array when the root is missing", () => {
+    const ghostRoot = join(testRoot, "ghost");
+    expect(listSnapshots(undefined, ghostRoot)).toEqual([]);
+  });
+
+  it("returns snapshots sorted by mtime descending", async () => {
+    const fsMod = require("node:fs") as typeof import("node:fs");
+    const first = await createSnapshot(baseOpts({ nowOverride: new Date(Date.now() - 60_000) }));
+    const second = await createSnapshot(baseOpts({ nowOverride: new Date() }));
+
+    // Force deterministic mtimes — fs writes both files within the same
+    // millisecond on fast machines, which would make the sort flaky.
+    const nowSec = Math.floor(Date.now() / 1000);
+    fsMod.utimesSync(first.path, nowSec - 60, nowSec - 60);
+    fsMod.utimesSync(second.path, nowSec, nowSec);
+
+    const rows = listSnapshots(undefined, testRoot);
+    expect(rows.length).toBe(2);
+    expect(rows[0].path).toBe(second.path);
+    expect(rows[1].path).toBe(first.path);
+    expect(rows[0].size).toBeGreaterThan(0);
+  });
+
+  it("respects the agent filter", async () => {
+    await createSnapshot(baseOpts({ agentId: "agent-a" }));
+    await createSnapshot(baseOpts({ agentId: "agent-b" }));
+    const rows = listSnapshots("agent-a", testRoot);
+    expect(rows.length).toBe(1);
+    expect(rows[0].agent).toBe("agent-a");
+  });
+
+  it("rejects an invalid agent filter", () => {
+    expect(() => listSnapshots("../escape", testRoot)).toThrow(/invalid agent id/);
+  });
+
+  it("ignores non-tar.gz files in the agent directory", async () => {
+    await createSnapshot(baseOpts());
+    const dir = join(testRoot, "test-agent");
+    writeFileSync(join(dir, "stray-note.txt"), "ignore me");
+    const rows = listSnapshots("test-agent", testRoot);
+    expect(rows.length).toBe(1);
+    expect(rows[0].file.endsWith(".tar.gz")).toBe(true);
+  });
+});
+
+describe("remSnapshotDir", () => {
+  it("rejects invalid agent ids", () => {
+    expect(() => remSnapshotDir("../etc")).toThrow(/invalid agent id/);
+    expect(() => remSnapshotDir("a/b")).toThrow(/invalid agent id/);
+    expect(() => remSnapshotDir("")).toThrow(/invalid agent id/);
+  });
+});


### PR DESCRIPTION
## Why

Per FLAIR-NIGHTLY-REM spec § 3-4 and the slice-1 design doc (`specs/FLAIR-NIGHTLY-REM-SLICE-1-DESIGN.md`, commit 4c0855f). Nathan green-lit the full build 2026-05-14 with "no rush" framing — this PR is the first of two for slice-1.

**Scope (PR-1):** the load-bearing minimum that makes "every cycle is reversible" true — snapshot, restore-as-extract, run-once orchestration, pause/resume.

**Out of scope (PR-2):** scheduler templates (launchd plist + systemd timer) + `flair rem nightly enable/disable`. PR-2 lands separately so the scheduler integration gets its own review and so PR-1 is testable in isolation.

**Out of scope (slice-2):** maintenance + trust-tier filter + distillation + live replay into Harper. Audit-row `slice: "1"` carries the phase so log readers can distinguish.

## What

### New modules

- **`src/rem/snapshot.ts`** — pure-filesystem `createSnapshot`/`listSnapshots`/`extractSnapshot`. Mirrors the existing `flair session snapshot` pattern (tar.gz + 0600 perms + portable archive + refuse-overwrite on extraction). Agent ids validated against `/^[a-zA-Z0-9_-]+$/` to prevent path traversal.
- **`src/rem/runner.ts`** — pure orchestration: pause check → fetch memory+soul+candidate-count → snapshot → append `~/.flair/logs/rem-nightly.jsonl` row. All I/O injected (apiCall, paths) so tests are Harper-free.

### CLI subcommands

- `flair rem nightly run-once [--agent <id>] [--dry-run]` — manual cycle trigger
- `flair rem snapshot list [--agent <id>] [--json]` — list tarballs sorted by mtime
- `flair rem restore <date> [--agent <id>] [--target <dir>] [--dry-run]` — extract for inspection
- `flair rem pause` — write `~/.flair/rem.paused` sentinel
- `flair rem resume` — remove sentinel; warn if `FLAIR_REM_PAUSE` env is set

`rem snapshot create` is intentionally **not** exposed — snapshots come from the nightly runner so the audit log stays the single source of truth.

### Snapshot format

`~/.flair/snapshots/<agentId>/<iso-ts>.tar.gz` (0600) containing:
- `memories.jsonl` — one Memory row per line
- `soul.json` — single row, array of rows, or null
- `metadata.json` — agent id, run id, flair version, memory/soul/candidate counts

## Live-tested on rockit Flair

```
$ FLAIR_AGENT_ID=flint flair rem nightly run-once --dry-run
-- rem nightly run-once (dry-run) --
Agent:      flint
Status:     dry-run
Memories:   289
Souls:      23
Pending:    0
Duration:   136ms

$ FLAIR_AGENT_ID=flint flair rem nightly run-once
Status:     completed
Snapshot:   ~/.flair/snapshots/flint/2026-05-14T12-03-43-810Z.tar.gz
Memories:   289
Souls:      23
Duration:   364ms

$ flair rem restore 2026-05-14 --agent flint --target /tmp/restore-test
✅ Extracted: .../2026-05-14T12-03-43-810Z.tar.gz
   To:        /tmp/restore-test
     memories.jsonl  (4.8 MB)   # = 289 lines, byte-identical
     soul.json       (45.7 KB)
     metadata.json   (221 B)
```

## Tests

28 unit tests (all pass in ~75ms with no Harper required):

- `test/rem-snapshot.test.ts` (16 tests) — round-trip byte-integrity, dry-run, refuse-overwrite, empty memories, invalid agent ids, mtime-sorted listing, agent filter, stray-file ignore, traversal guards
- `test/rem-runner.test.ts` (12 tests) — pause sentinel, FLAIR_REM_PAUSE env, happy path, Harper response-shape coercion (`results[]` vs `items[]`), dry-run, fetch failures (fail-stops-cycle, no empty tarball), candidate-count graceful degrade, log-append behavior

## Architectural lenses (for reviewers)

- **Abstraction:** snapshot module is pure filesystem; runner is pure orchestration; CLI handles user-facing I/O. Three clean layers.
- **Contract drift:** no existing endpoint or schema changes. Adds `~/.flair/snapshots/<agent>/` and `~/.flair/logs/rem-nightly.jsonl`, both new locations the health endpoint was already pre-wired to look for (`resources/health.ts:330-373`).
- **Coupling:** runner imports snapshot (one-way). CLI imports both via dynamic `await import()` to keep cli.ts dist size unaffected. No coupling between rem and other CLI subcommands.
- **Failure modes:** memory/soul fetch error → `status: "failed"` log row + no tarball + non-zero exit. Candidate-count error → degrades to 0 (non-fatal). Pause sentinel honored both via file and env. Snapshot extraction refuses to overwrite existing target.

## Next: PR-2

Will add launchd + systemd templates, `flair rem nightly enable/disable`, and the dry-run-first-run guard per spec § 10. Same K&S ensemble.

## Checklist

- [x] Tests pass (28/28)
- [x] CHANGELOG entry under Unreleased
- [x] Live-tested end-to-end (snapshot → list → restore round-trip)
- [x] Design doc committed (`specs/FLAIR-NIGHTLY-REM-SLICE-1-DESIGN.md`)
- [x] No new dependencies added
- [x] No security-surface changes