### PR TITLE
feat(rem): FLAIR-NIGHTLY-REM slice-1 PR-2 — scheduler templates + enable/disable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,13 @@
 
 ## Unreleased
 
-### ✨ FLAIR-NIGHTLY-REM slice-1 (manual cycle + snapshot/restore)
+### ✨ FLAIR-NIGHTLY-REM slice-1 (scheduler + manual cycle + snapshot/restore)
+
+- **`flair rem nightly enable [--agent <id>] [--at HH:MM] [--flair-url <url>]`** — installs the platform-native scheduler. On macOS, writes `~/Library/LaunchAgents/dev.flair.rem.nightly.plist` and `launchctl bootstrap`s it. On Linux, writes `~/.config/systemd/user/flair-rem-nightly.{timer,service}` and enables the timer. Also deploys `~/.flair/bin/flair-rem-nightly` as the shim the scheduler invokes. Defaults to 03:00 local time.
+- **`flair rem nightly disable [--remove-shim]`** — removes the scheduler entry (`launchctl bootout` / `systemctl --user disable --now`). Snapshots at `~/.flair/snapshots/` and the audit log at `~/.flair/logs/rem-nightly.jsonl` are preserved; the shim is preserved by default (pass `--remove-shim` to delete it too).
+- **`flair rem nightly status`** — reports platform + install state + scheduler/shim paths. Filesystem-only — matches the health endpoint's existing detection logic.
+- **Scheduler templates** — `templates/launchd/dev.flair.rem.nightly.plist.tmpl`, `templates/systemd/flair-rem-nightly.{service,timer}.tmpl`, `templates/bin/flair-rem-nightly.sh.tmpl`. Single-pass `{{KEY}}` placeholder substitution. Shipped in the npm tarball under `files: [..., "templates/"]`.
+
 
 - **`flair rem nightly run-once [--dry-run]`** — manually invokes the nightly cycle. Same code path the scheduler will use in slice-1 PR-2. Pre-flight pause check, fetch memories+soul, snapshot to `~/.flair/snapshots/<agent>/<iso-ts>.tar.gz`, append a JSON row to `~/.flair/logs/rem-nightly.jsonl`. Slice-2 will add maintenance + trust-tier filter + distillation; the audit row carries `slice: "1"` so readers can distinguish phases.
 - **`flair rem snapshot list [--agent <id>]`** — lists snapshot tarballs sorted by mtime descending. Snapshot creation is intentionally NOT exposed as `rem snapshot create` to keep the nightly audit log as the single source of truth.

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   "files": [
     "dist/",
     "schemas/",
+    "templates/",
     "ui/",
     "config.yaml",
     "LICENSE",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -4274,6 +4274,106 @@ rem
 
 const remNightly = rem.command("nightly").description("Scheduled REM nightly cycle (manual trigger + scheduler management)");
 
+// `enable` / `disable` / `status` — scheduler install/uninstall (slice-1 PR-2).
+// macOS: writes ~/Library/LaunchAgents/dev.flair.rem.nightly.plist and bootstraps it.
+// Linux: writes ~/.config/systemd/user/flair-rem-nightly.{timer,service} and enables the timer.
+// Snapshot data and the audit log are preserved through enable/disable cycles.
+
+remNightly
+  .command("enable")
+  .description("Install the nightly scheduler (launchd on macOS, systemd timer on Linux)")
+  .option("--agent <id>", "Agent id (or FLAIR_AGENT_ID env)")
+  .option("--at <HH:MM>", "Local time to run nightly (default 03:00)", "03:00")
+  .option("--flair-url <url>", "Flair HTTP URL the runner will hit (default http://127.0.0.1:<port>)")
+  .action(async (opts) => {
+    const agentId = opts.agent || process.env.FLAIR_AGENT_ID;
+    if (!agentId) {
+      console.error("Error: --agent or FLAIR_AGENT_ID env required");
+      process.exit(1);
+    }
+    const match = /^(\d{1,2}):(\d{2})$/.exec(opts.at);
+    if (!match) {
+      console.error(`Error: --at must be HH:MM (got: ${opts.at})`);
+      process.exit(1);
+    }
+    const hour = parseInt(match[1], 10);
+    const minute = parseInt(match[2], 10);
+
+    const port = readPortFromConfig() ?? DEFAULT_PORT;
+    const flairUrl = opts.flairUrl || process.env.FLAIR_URL || `http://127.0.0.1:${port}`;
+
+    const { enableScheduler } = await import("./rem/scheduler.js");
+    try {
+      const r = enableScheduler({ agentId, flairUrl, hour, minute });
+      console.log(`✅ REM nightly scheduler enabled (${r.platform})`);
+      console.log(`   Schedule:    ${String(hour).padStart(2, "0")}:${String(minute).padStart(2, "0")} local time`);
+      console.log(`   Scheduler:   ${r.schedulerPath}`);
+      console.log(`   Shim:        ${r.shimPath}`);
+      console.log(`   Agent:       ${agentId}`);
+      console.log(`   Flair URL:   ${flairUrl}`);
+      if (r.loadResult) {
+        if (r.loadResult.code === 0) {
+          console.log(`   Load:        ${r.loadCommand.join(" ")} → ok`);
+        } else {
+          console.log(`   Load:        ${r.loadCommand.join(" ")} → code ${r.loadResult.code}`);
+          if (r.loadResult.stderr) console.log(`     stderr: ${r.loadResult.stderr.trim()}`);
+        }
+      }
+      console.log(`\nTip: run \`flair rem nightly run-once --dry-run\` to verify the cycle works`);
+      console.log(`     before the first scheduled fire. Disable with \`flair rem nightly disable\`.`);
+    } catch (err: any) {
+      console.error(`Error: ${err.message}`);
+      process.exit(1);
+    }
+  });
+
+remNightly
+  .command("disable")
+  .description("Remove the nightly scheduler (keeps snapshots + audit log)")
+  .option("--remove-shim", "Also delete the ~/.flair/bin/flair-rem-nightly shim")
+  .action(async (opts) => {
+    const { disableScheduler } = await import("./rem/scheduler.js");
+    try {
+      const r = disableScheduler({ removeShim: !!opts.removeShim });
+      if (r.removed.length === 0) {
+        console.log(`(REM nightly scheduler was not installed on ${r.platform})`);
+        return;
+      }
+      console.log(`✅ REM nightly scheduler disabled (${r.platform})`);
+      console.log(`   Removed:`);
+      for (const p of r.removed) console.log(`     ${p}`);
+      if (r.unloadResult && r.unloadResult.code !== 0) {
+        console.log(`   Unload:      ${r.unloadCommand.join(" ")} → code ${r.unloadResult.code}`);
+        if (r.unloadResult.stderr) console.log(`     stderr: ${r.unloadResult.stderr.trim()}`);
+      }
+      console.log(`\nSnapshots at ~/.flair/snapshots/ and the audit log at`);
+      console.log(`~/.flair/logs/rem-nightly.jsonl are preserved.`);
+    } catch (err: any) {
+      console.error(`Error: ${err.message}`);
+      process.exit(1);
+    }
+  });
+
+remNightly
+  .command("status")
+  .description("Show whether the nightly scheduler is installed")
+  .action(async () => {
+    const { schedulerStatus } = await import("./rem/scheduler.js");
+    try {
+      const s = schedulerStatus();
+      console.log(`REM nightly scheduler (${s.platform}):`);
+      console.log(`  Installed:   ${s.installed ? "yes" : "no"}`);
+      console.log(`  Scheduler:   ${s.schedulerPath}`);
+      console.log(`  Shim:        ${s.shimPath}${s.shimExists ? "" : " (missing)"}`);
+      if (!s.installed) {
+        console.log(`\nEnable with: flair rem nightly enable --agent <id> [--at HH:MM]`);
+      }
+    } catch (err: any) {
+      console.error(`Error: ${err.message}`);
+      process.exit(1);
+    }
+  });
+
 remNightly
   .command("run-once")
   .description("Run one nightly cycle now (snapshot + log). Same code path the scheduler will use.")

--- a/src/rem/scheduler.ts
+++ b/src/rem/scheduler.ts
@@ -1,0 +1,321 @@
+/**
+ * REM nightly scheduler — platform-native scheduler install/uninstall.
+ *
+ * Per FLAIR-NIGHTLY-REM § 3 (`flair rem nightly enable|disable`). Renders
+ * launchd plist (macOS) or systemd timer+service (Linux) from templates,
+ * deploys a shim script to `~/.flair/bin/flair-rem-nightly`, and loads the
+ * job into the user-session scheduler.
+ *
+ * Templates use `{{KEY}}` placeholders — single-pass substitution. The full
+ * placeholder set is enumerated in `interface SchedulerSubstitutions` so
+ * adding a new key requires touching both this module and the template.
+ *
+ * No daemon code lives here — the scheduler invokes the shim, the shim
+ * invokes `flair rem nightly run-once`, the runner module does the work.
+ */
+import { existsSync, mkdirSync, writeFileSync, readFileSync, chmodSync, rmSync, statSync } from "node:fs";
+import { resolve, dirname, join } from "node:path";
+import { homedir, platform } from "node:os";
+import { spawnSync, type SpawnSyncReturns } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+export const SHIM_PATH_DEFAULT = resolve(homedir(), ".flair", "bin", "flair-rem-nightly");
+export const LAUNCHD_PLIST_PATH = resolve(homedir(), "Library", "LaunchAgents", "dev.flair.rem.nightly.plist");
+export const SYSTEMD_USER_DIR = resolve(homedir(), ".config", "systemd", "user");
+export const SYSTEMD_TIMER_PATH = resolve(SYSTEMD_USER_DIR, "flair-rem-nightly.timer");
+export const SYSTEMD_SERVICE_PATH = resolve(SYSTEMD_USER_DIR, "flair-rem-nightly.service");
+
+export type SchedulerPlatform = "darwin" | "linux";
+
+export interface SchedulerSubstitutions {
+  /** Absolute path to the flair binary the shim should invoke. */
+  FLAIR_BIN: string;
+  /** Absolute path to the shim script the scheduler should call. */
+  SHIM_PATH: string;
+  /** Operator's home directory (HOME env var value). */
+  HOME: string;
+  /** Agent id passed via env. */
+  AGENT_ID: string;
+  /** Flair HTTP URL passed via env (e.g. http://127.0.0.1:9926). */
+  FLAIR_URL: string;
+  /** Hour (0-23). */
+  HOUR: string;
+  /** Zero-padded hour ("00"-"23") for systemd OnCalendar. */
+  HOUR_PAD: string;
+  /** Minute (0-59). */
+  MINUTE: string;
+  /** Zero-padded minute ("00"-"59") for systemd OnCalendar. */
+  MINUTE_PAD: string;
+}
+
+export interface EnableOpts {
+  agentId: string;
+  flairUrl: string;
+  /** Hour (0-23). */
+  hour: number;
+  /** Minute (0-59). */
+  minute: number;
+  /** Absolute path to the flair binary. Defaults to argv[0]'s nearest bin dir. */
+  flairBin?: string;
+  /** Override platform for testing. */
+  platformOverride?: SchedulerPlatform;
+  /** Override target paths for testing. */
+  shimPathOverride?: string;
+  launchdPlistOverride?: string;
+  systemdTimerOverride?: string;
+  systemdServiceOverride?: string;
+  /** Override the template root for testing. */
+  templateRootOverride?: string;
+  /** Skip the launchctl/systemctl invocation (testing). */
+  skipLoad?: boolean;
+}
+
+export interface EnableResult {
+  platform: SchedulerPlatform;
+  shimPath: string;
+  schedulerPath: string;
+  loadCommand: string[];
+  loadResult?: { code: number | null; stdout: string; stderr: string };
+}
+
+export interface DisableOpts {
+  platformOverride?: SchedulerPlatform;
+  shimPathOverride?: string;
+  launchdPlistOverride?: string;
+  systemdTimerOverride?: string;
+  systemdServiceOverride?: string;
+  skipUnload?: boolean;
+  /** When true, remove the shim too. Default false to keep state minimal. */
+  removeShim?: boolean;
+}
+
+export interface DisableResult {
+  platform: SchedulerPlatform;
+  removed: string[];
+  unloadCommand: string[];
+  unloadResult?: { code: number | null; stdout: string; stderr: string };
+}
+
+function detectPlatform(override?: SchedulerPlatform): SchedulerPlatform {
+  if (override) return override;
+  const p = platform();
+  if (p === "darwin") return "darwin";
+  if (p === "linux") return "linux";
+  throw new Error(`unsupported platform for REM nightly scheduler: ${p} (only darwin and linux)`);
+}
+
+function defaultTemplateRoot(): string {
+  // Templates live alongside dist/ in the published package and alongside
+  // src/rem/ in the source tree. Walk up from this file until we find
+  // a directory containing templates/.
+  const here = dirname(fileURLToPath(import.meta.url));
+  const candidates = [
+    resolve(here, "..", "..", "templates"),
+    resolve(here, "..", "..", "..", "templates"),
+    resolve(here, "..", "templates"),
+  ];
+  for (const c of candidates) {
+    if (existsSync(c)) return c;
+  }
+  throw new Error(`unable to locate templates directory (looked in: ${candidates.join(", ")})`);
+}
+
+export function renderTemplate(text: string, subs: SchedulerSubstitutions): string {
+  return text.replace(/\{\{([A-Z_]+)\}\}/g, (_, key) => {
+    const value = (subs as any)[key];
+    if (value === undefined) throw new Error(`unknown template placeholder: ${key}`);
+    return String(value);
+  });
+}
+
+export function readTemplate(rootDir: string, relativePath: string): string {
+  const full = resolve(rootDir, relativePath);
+  if (!existsSync(full)) {
+    throw new Error(`template not found: ${full}`);
+  }
+  return readFileSync(full, "utf-8");
+}
+
+/**
+ * Validates the hour:minute schedule. Throws on invalid input rather than
+ * silently coercing — surface bad input at the install boundary.
+ */
+function validateSchedule(hour: number, minute: number): void {
+  if (!Number.isInteger(hour) || hour < 0 || hour > 23) {
+    throw new Error(`hour must be an integer 0-23, got ${hour}`);
+  }
+  if (!Number.isInteger(minute) || minute < 0 || minute > 59) {
+    throw new Error(`minute must be an integer 0-59, got ${minute}`);
+  }
+}
+
+function buildSubstitutions(opts: EnableOpts, shimPath: string, flairBin: string): SchedulerSubstitutions {
+  validateSchedule(opts.hour, opts.minute);
+  if (!/^[a-zA-Z0-9_-]+$/.test(opts.agentId)) {
+    throw new Error(`invalid agent id: ${opts.agentId}`);
+  }
+  return {
+    FLAIR_BIN: flairBin,
+    SHIM_PATH: shimPath,
+    HOME: homedir(),
+    AGENT_ID: opts.agentId,
+    FLAIR_URL: opts.flairUrl,
+    HOUR: String(opts.hour),
+    HOUR_PAD: String(opts.hour).padStart(2, "0"),
+    MINUTE: String(opts.minute),
+    MINUTE_PAD: String(opts.minute).padStart(2, "0"),
+  };
+}
+
+function writeFileWithDir(path: string, contents: string, mode: number = 0o600): void {
+  const dir = dirname(path);
+  if (!existsSync(dir)) mkdirSync(dir, { recursive: true, mode: 0o700 });
+  writeFileSync(path, contents, { mode });
+}
+
+function spawnReport(cmd: string[]): { code: number | null; stdout: string; stderr: string } {
+  const r: SpawnSyncReturns<Buffer> = spawnSync(cmd[0], cmd.slice(1), { encoding: "buffer" });
+  return {
+    code: r.status,
+    stdout: r.stdout?.toString("utf-8") ?? "",
+    stderr: r.stderr?.toString("utf-8") ?? "",
+  };
+}
+
+/**
+ * Installs the platform-native scheduler entry and the shim script.
+ *
+ * macOS: writes ~/Library/LaunchAgents/dev.flair.rem.nightly.plist + bootstraps it via launchctl.
+ * Linux: writes ~/.config/systemd/user/flair-rem-nightly.{timer,service} + enables the timer.
+ *
+ * In both cases, also deploys ~/.flair/bin/flair-rem-nightly as the shim
+ * the scheduler invokes.
+ */
+export function enableScheduler(opts: EnableOpts): EnableResult {
+  const plat = detectPlatform(opts.platformOverride);
+  const flairBin = opts.flairBin ?? process.argv[1] ?? "flair";
+  const shimPath = opts.shimPathOverride ?? SHIM_PATH_DEFAULT;
+  const templateRoot = opts.templateRootOverride ?? defaultTemplateRoot();
+  const subs = buildSubstitutions(opts, shimPath, flairBin);
+
+  // 1. Deploy the shim (always — both platforms invoke it).
+  const shimContents = renderTemplate(readTemplate(templateRoot, "bin/flair-rem-nightly.sh.tmpl"), subs);
+  writeFileWithDir(shimPath, shimContents, 0o700);
+  chmodSync(shimPath, 0o700);
+
+  // 2. Write the scheduler entry.
+  if (plat === "darwin") {
+    const plistPath = opts.launchdPlistOverride ?? LAUNCHD_PLIST_PATH;
+    const plistContents = renderTemplate(readTemplate(templateRoot, "launchd/dev.flair.rem.nightly.plist.tmpl"), subs);
+    writeFileWithDir(plistPath, plistContents, 0o600);
+
+    const loadCommand = ["launchctl", "bootstrap", `gui/${process.getuid?.() ?? ""}`, plistPath];
+    let loadResult: EnableResult["loadResult"];
+    if (!opts.skipLoad) {
+      // Bootout first in case a prior install left the job loaded.
+      spawnReport(["launchctl", "bootout", `gui/${process.getuid?.() ?? ""}`, plistPath]);
+      loadResult = spawnReport(loadCommand);
+    }
+    return { platform: plat, shimPath, schedulerPath: plistPath, loadCommand, loadResult };
+  }
+
+  // Linux: systemd user units.
+  const timerPath = opts.systemdTimerOverride ?? SYSTEMD_TIMER_PATH;
+  const servicePath = opts.systemdServiceOverride ?? SYSTEMD_SERVICE_PATH;
+
+  const serviceContents = renderTemplate(readTemplate(templateRoot, "systemd/flair-rem-nightly.service.tmpl"), subs);
+  const timerContents = renderTemplate(readTemplate(templateRoot, "systemd/flair-rem-nightly.timer.tmpl"), subs);
+  writeFileWithDir(servicePath, serviceContents, 0o600);
+  writeFileWithDir(timerPath, timerContents, 0o600);
+
+  const loadCommand = ["systemctl", "--user", "enable", "--now", "flair-rem-nightly.timer"];
+  let loadResult: EnableResult["loadResult"];
+  if (!opts.skipLoad) {
+    spawnReport(["systemctl", "--user", "daemon-reload"]);
+    loadResult = spawnReport(loadCommand);
+  }
+  return { platform: plat, shimPath, schedulerPath: timerPath, loadCommand, loadResult };
+}
+
+/**
+ * Removes the scheduler entry. Audit log + snapshots are preserved.
+ */
+export function disableScheduler(opts: DisableOpts = {}): DisableResult {
+  const plat = detectPlatform(opts.platformOverride);
+  const removed: string[] = [];
+
+  if (plat === "darwin") {
+    const plistPath = opts.launchdPlistOverride ?? LAUNCHD_PLIST_PATH;
+    const unloadCommand = ["launchctl", "bootout", `gui/${process.getuid?.() ?? ""}`, plistPath];
+    let unloadResult: DisableResult["unloadResult"];
+    if (existsSync(plistPath)) {
+      if (!opts.skipUnload) {
+        unloadResult = spawnReport(unloadCommand);
+      }
+      rmSync(plistPath, { force: true });
+      removed.push(plistPath);
+    }
+    if (opts.removeShim) {
+      const shim = opts.shimPathOverride ?? SHIM_PATH_DEFAULT;
+      if (existsSync(shim)) {
+        rmSync(shim, { force: true });
+        removed.push(shim);
+      }
+    }
+    return { platform: plat, removed, unloadCommand, unloadResult };
+  }
+
+  const timerPath = opts.systemdTimerOverride ?? SYSTEMD_TIMER_PATH;
+  const servicePath = opts.systemdServiceOverride ?? SYSTEMD_SERVICE_PATH;
+  const unloadCommand = ["systemctl", "--user", "disable", "--now", "flair-rem-nightly.timer"];
+  let unloadResult: DisableResult["unloadResult"];
+  if (existsSync(timerPath) || existsSync(servicePath)) {
+    if (!opts.skipUnload) {
+      unloadResult = spawnReport(unloadCommand);
+      spawnReport(["systemctl", "--user", "daemon-reload"]);
+    }
+    if (existsSync(timerPath)) { rmSync(timerPath, { force: true }); removed.push(timerPath); }
+    if (existsSync(servicePath)) { rmSync(servicePath, { force: true }); removed.push(servicePath); }
+  }
+  if (opts.removeShim) {
+    const shim = opts.shimPathOverride ?? SHIM_PATH_DEFAULT;
+    if (existsSync(shim)) {
+      rmSync(shim, { force: true });
+      removed.push(shim);
+    }
+  }
+  return { platform: plat, removed, unloadCommand, unloadResult };
+}
+
+export interface SchedulerStatus {
+  platform: SchedulerPlatform;
+  installed: boolean;
+  schedulerPath: string;
+  shimPath: string;
+  shimExists: boolean;
+}
+
+/**
+ * Reports whether the scheduler is installed. Filesystem-only — does not
+ * shell out to launchctl/systemctl to query active state. The Health
+ * endpoint already does that via existence checks; same approach here.
+ */
+export function schedulerStatus(opts: { platformOverride?: SchedulerPlatform } = {}): SchedulerStatus {
+  const plat = detectPlatform(opts.platformOverride);
+  if (plat === "darwin") {
+    return {
+      platform: plat,
+      installed: existsSync(LAUNCHD_PLIST_PATH),
+      schedulerPath: LAUNCHD_PLIST_PATH,
+      shimPath: SHIM_PATH_DEFAULT,
+      shimExists: existsSync(SHIM_PATH_DEFAULT),
+    };
+  }
+  return {
+    platform: plat,
+    installed: existsSync(SYSTEMD_TIMER_PATH) && existsSync(SYSTEMD_SERVICE_PATH),
+    schedulerPath: SYSTEMD_TIMER_PATH,
+    shimPath: SHIM_PATH_DEFAULT,
+    shimExists: existsSync(SHIM_PATH_DEFAULT),
+  };
+}

--- a/templates/bin/flair-rem-nightly.sh.tmpl
+++ b/templates/bin/flair-rem-nightly.sh.tmpl
@@ -1,0 +1,9 @@
+#!/bin/sh
+# Flair REM nightly runner shim.
+# Deployed by `flair rem nightly enable` to {{SHIM_PATH}}.
+# Invoked by launchd (macOS) or systemd (Linux) on the configured schedule.
+#
+# Single line that invokes the CLI's run-once subcommand — the runner module
+# does all the work. Logs land in {{HOME}}/.flair/logs/.
+set -e
+exec {{FLAIR_BIN}} rem nightly run-once

--- a/templates/launchd/dev.flair.rem.nightly.plist.tmpl
+++ b/templates/launchd/dev.flair.rem.nightly.plist.tmpl
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+  "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>dev.flair.rem.nightly</string>
+
+  <key>ProgramArguments</key>
+  <array>
+    <string>{{SHIM_PATH}}</string>
+  </array>
+
+  <key>StartCalendarInterval</key>
+  <dict>
+    <key>Hour</key>
+    <integer>{{HOUR}}</integer>
+    <key>Minute</key>
+    <integer>{{MINUTE}}</integer>
+  </dict>
+
+  <key>RunAtLoad</key>
+  <false/>
+
+  <key>StandardOutPath</key>
+  <string>{{HOME}}/.flair/logs/rem-nightly.stdout.log</string>
+
+  <key>StandardErrorPath</key>
+  <string>{{HOME}}/.flair/logs/rem-nightly.stderr.log</string>
+
+  <key>WorkingDirectory</key>
+  <string>{{HOME}}</string>
+
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>HOME</key>
+    <string>{{HOME}}</string>
+    <key>PATH</key>
+    <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
+    <key>FLAIR_AGENT_ID</key>
+    <string>{{AGENT_ID}}</string>
+    <key>FLAIR_URL</key>
+    <string>{{FLAIR_URL}}</string>
+  </dict>
+</dict>
+</plist>

--- a/templates/systemd/flair-rem-nightly.service.tmpl
+++ b/templates/systemd/flair-rem-nightly.service.tmpl
@@ -1,0 +1,14 @@
+[Unit]
+Description=Flair REM nightly cycle ({{AGENT_ID}})
+After=network.target
+
+[Service]
+Type=oneshot
+ExecStart={{SHIM_PATH}}
+Environment=FLAIR_AGENT_ID={{AGENT_ID}}
+Environment=FLAIR_URL={{FLAIR_URL}}
+StandardOutput=append:{{HOME}}/.flair/logs/rem-nightly.stdout.log
+StandardError=append:{{HOME}}/.flair/logs/rem-nightly.stderr.log
+
+[Install]
+WantedBy=default.target

--- a/templates/systemd/flair-rem-nightly.timer.tmpl
+++ b/templates/systemd/flair-rem-nightly.timer.tmpl
@@ -1,0 +1,10 @@
+[Unit]
+Description=Flair REM nightly timer ({{AGENT_ID}})
+
+[Timer]
+OnCalendar=*-*-* {{HOUR_PAD}}:{{MINUTE_PAD}}:00
+Persistent=true
+Unit=flair-rem-nightly.service
+
+[Install]
+WantedBy=timers.target

--- a/test/rem-scheduler.test.ts
+++ b/test/rem-scheduler.test.ts
@@ -1,0 +1,246 @@
+/**
+ * rem-scheduler.test.ts — Unit tests for src/rem/scheduler.ts.
+ *
+ * Filesystem coverage + template substitution. The launchctl/systemctl
+ * spawn is opted out of (skipLoad/skipUnload) so tests run in isolation.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import { mkdirSync, rmSync, readFileSync, writeFileSync, existsSync, mkdtempSync, statSync } from "node:fs";
+import { join, resolve } from "node:path";
+import { tmpdir } from "node:os";
+import {
+  renderTemplate,
+  enableScheduler,
+  disableScheduler,
+  schedulerStatus,
+  type SchedulerSubstitutions,
+  type EnableOpts,
+} from "../src/rem/scheduler.ts";
+
+let testRoot: string;
+let shimPath: string;
+let plistPath: string;
+let timerPath: string;
+let servicePath: string;
+let templateRoot: string;
+
+beforeEach(() => {
+  testRoot = mkdtempSync(join(tmpdir(), "flair-rem-scheduler-test-"));
+  shimPath = join(testRoot, "bin", "flair-rem-nightly");
+  plistPath = join(testRoot, "LaunchAgents", "dev.flair.rem.nightly.plist");
+  timerPath = join(testRoot, "systemd", "flair-rem-nightly.timer");
+  servicePath = join(testRoot, "systemd", "flair-rem-nightly.service");
+  templateRoot = resolve(import.meta.dir, "..", "templates");
+});
+
+afterEach(() => {
+  rmSync(testRoot, { recursive: true, force: true });
+});
+
+function baseOpts(overrides: Partial<EnableOpts> = {}): EnableOpts {
+  return {
+    agentId: "test-agent",
+    flairUrl: "http://127.0.0.1:9926",
+    hour: 3,
+    minute: 0,
+    flairBin: "/usr/local/bin/flair",
+    shimPathOverride: shimPath,
+    launchdPlistOverride: plistPath,
+    systemdTimerOverride: timerPath,
+    systemdServiceOverride: servicePath,
+    templateRootOverride: templateRoot,
+    skipLoad: true,
+    ...overrides,
+  };
+}
+
+const sampleSubs: SchedulerSubstitutions = {
+  FLAIR_BIN: "/usr/local/bin/flair",
+  SHIM_PATH: "/Users/test/.flair/bin/flair-rem-nightly",
+  HOME: "/Users/test",
+  AGENT_ID: "test-agent",
+  FLAIR_URL: "http://127.0.0.1:9926",
+  HOUR: "3",
+  HOUR_PAD: "03",
+  MINUTE: "0",
+  MINUTE_PAD: "00",
+};
+
+describe("renderTemplate", () => {
+  it("substitutes single placeholder", () => {
+    expect(renderTemplate("hello {{AGENT_ID}}", sampleSubs)).toBe("hello test-agent");
+  });
+
+  it("substitutes multiple placeholders", () => {
+    expect(renderTemplate("{{HOUR}}:{{MINUTE_PAD}}", sampleSubs)).toBe("3:00");
+  });
+
+  it("throws on unknown placeholder", () => {
+    expect(() => renderTemplate("{{UNKNOWN}}", sampleSubs)).toThrow(/unknown template placeholder: UNKNOWN/);
+  });
+
+  it("ignores text without placeholders", () => {
+    expect(renderTemplate("plain text", sampleSubs)).toBe("plain text");
+  });
+});
+
+describe("enableScheduler (darwin)", () => {
+  it("writes shim and plist with substitutions applied", () => {
+    const r = enableScheduler(baseOpts({ platformOverride: "darwin" }));
+    expect(r.platform).toBe("darwin");
+    expect(r.schedulerPath).toBe(plistPath);
+    expect(r.shimPath).toBe(shimPath);
+
+    expect(existsSync(shimPath)).toBe(true);
+    expect(existsSync(plistPath)).toBe(true);
+
+    // Shim is executable.
+    expect(statSync(shimPath).mode & 0o777).toBe(0o700);
+
+    const plist = readFileSync(plistPath, "utf-8");
+    expect(plist).toContain("<key>Label</key>");
+    expect(plist).toContain("<string>dev.flair.rem.nightly</string>");
+    expect(plist).toContain(`<string>${shimPath}</string>`);
+    expect(plist).toContain("<integer>3</integer>");
+    expect(plist).toContain("<integer>0</integer>");
+    expect(plist).toContain("test-agent");
+    expect(plist).toContain("http://127.0.0.1:9926");
+    // No unresolved placeholders.
+    expect(plist).not.toContain("{{");
+
+    const shim = readFileSync(shimPath, "utf-8");
+    expect(shim).toContain("/usr/local/bin/flair rem nightly run-once");
+    expect(shim).toContain("#!/bin/sh");
+  });
+
+  it("does not invoke launchctl when skipLoad=true", () => {
+    const r = enableScheduler(baseOpts({ platformOverride: "darwin" }));
+    expect(r.loadResult).toBeUndefined();
+    expect(r.loadCommand[0]).toBe("launchctl");
+    expect(r.loadCommand).toContain("bootstrap");
+  });
+});
+
+describe("enableScheduler (linux)", () => {
+  it("writes shim, service, and timer with substitutions applied", () => {
+    const r = enableScheduler(baseOpts({ platformOverride: "linux" }));
+    expect(r.platform).toBe("linux");
+    expect(r.schedulerPath).toBe(timerPath);
+
+    expect(existsSync(shimPath)).toBe(true);
+    expect(existsSync(timerPath)).toBe(true);
+    expect(existsSync(servicePath)).toBe(true);
+
+    const timer = readFileSync(timerPath, "utf-8");
+    expect(timer).toContain("OnCalendar=*-*-* 03:00:00");
+    expect(timer).toContain("Unit=flair-rem-nightly.service");
+    expect(timer).not.toContain("{{");
+
+    const service = readFileSync(servicePath, "utf-8");
+    expect(service).toContain(`ExecStart=${shimPath}`);
+    expect(service).toContain("Environment=FLAIR_AGENT_ID=test-agent");
+    expect(service).toContain("Environment=FLAIR_URL=http://127.0.0.1:9926");
+    expect(service).not.toContain("{{");
+  });
+
+  it("zero-pads hour and minute for systemd OnCalendar", () => {
+    const r = enableScheduler(baseOpts({ platformOverride: "linux", hour: 7, minute: 5 }));
+    const timer = readFileSync(timerPath, "utf-8");
+    expect(timer).toContain("OnCalendar=*-*-* 07:05:00");
+  });
+});
+
+describe("enableScheduler validation", () => {
+  it("rejects invalid hour", () => {
+    expect(() => enableScheduler(baseOpts({ hour: 24 }))).toThrow(/hour must be/);
+    expect(() => enableScheduler(baseOpts({ hour: -1 }))).toThrow(/hour must be/);
+    expect(() => enableScheduler(baseOpts({ hour: 3.5 }))).toThrow(/hour must be/);
+  });
+
+  it("rejects invalid minute", () => {
+    expect(() => enableScheduler(baseOpts({ minute: 60 }))).toThrow(/minute must be/);
+    expect(() => enableScheduler(baseOpts({ minute: -1 }))).toThrow(/minute must be/);
+  });
+
+  it("rejects invalid agent id", () => {
+    expect(() => enableScheduler(baseOpts({ agentId: "../etc" }))).toThrow(/invalid agent id/);
+    expect(() => enableScheduler(baseOpts({ agentId: "" }))).toThrow(/invalid agent id/);
+  });
+});
+
+describe("disableScheduler (darwin)", () => {
+  it("removes the plist after install", () => {
+    enableScheduler(baseOpts({ platformOverride: "darwin" }));
+    expect(existsSync(plistPath)).toBe(true);
+
+    const r = disableScheduler({
+      platformOverride: "darwin",
+      launchdPlistOverride: plistPath,
+      shimPathOverride: shimPath,
+      skipUnload: true,
+    });
+    expect(r.removed).toContain(plistPath);
+    expect(existsSync(plistPath)).toBe(false);
+    // Shim preserved by default.
+    expect(existsSync(shimPath)).toBe(true);
+  });
+
+  it("removes the shim when removeShim=true", () => {
+    enableScheduler(baseOpts({ platformOverride: "darwin" }));
+    const r = disableScheduler({
+      platformOverride: "darwin",
+      launchdPlistOverride: plistPath,
+      shimPathOverride: shimPath,
+      skipUnload: true,
+      removeShim: true,
+    });
+    expect(r.removed).toContain(shimPath);
+    expect(existsSync(shimPath)).toBe(false);
+  });
+
+  it("is idempotent — disable on a non-installed state returns no-op", () => {
+    const r = disableScheduler({
+      platformOverride: "darwin",
+      launchdPlistOverride: plistPath,
+      shimPathOverride: shimPath,
+      skipUnload: true,
+    });
+    expect(r.removed).toEqual([]);
+  });
+});
+
+describe("disableScheduler (linux)", () => {
+  it("removes timer + service after install", () => {
+    enableScheduler(baseOpts({ platformOverride: "linux" }));
+    expect(existsSync(timerPath)).toBe(true);
+    expect(existsSync(servicePath)).toBe(true);
+
+    const r = disableScheduler({
+      platformOverride: "linux",
+      systemdTimerOverride: timerPath,
+      systemdServiceOverride: servicePath,
+      shimPathOverride: shimPath,
+      skipUnload: true,
+    });
+    expect(r.removed.sort()).toEqual([servicePath, timerPath].sort());
+    expect(existsSync(timerPath)).toBe(false);
+    expect(existsSync(servicePath)).toBe(false);
+  });
+});
+
+describe("schedulerStatus", () => {
+  // Status uses default paths, so we verify the function shape only.
+  it("returns the platform + paths it would check", () => {
+    const s = schedulerStatus({ platformOverride: "darwin" });
+    expect(s.platform).toBe("darwin");
+    expect(s.schedulerPath).toContain("dev.flair.rem.nightly.plist");
+    expect(s.shimPath).toContain("flair-rem-nightly");
+  });
+
+  it("reports linux paths under linux", () => {
+    const s = schedulerStatus({ platformOverride: "linux" });
+    expect(s.platform).toBe("linux");
+    expect(s.schedulerPath).toContain("flair-rem-nightly.timer");
+  });
+});


### PR DESCRIPTION
## Why

Completes FLAIR-NIGHTLY-REM slice-1 by adding the platform-native scheduler on top of PR #414's runner + snapshot module. With this PR, "every cycle is reversible" becomes load-bearing on a real timer — not just on `run-once` invocations.

## What

**New module** — `src/rem/scheduler.ts` (~290 lines, pure-filesystem):
- `enableScheduler(opts)` — writes shim + plist (darwin) or timer/service (linux), then bootstraps/enables via launchctl/systemctl
- `disableScheduler(opts)` — inverse, idempotent, preserves snapshots + audit log
- `schedulerStatus(opts)` — filesystem-only install-state check (matches health-endpoint detection)
- `renderTemplate(text, subs)` + `SchedulerSubstitutions` interface — single-pass `{{KEY}}` replacement, throws on unknown keys

**Templates** under `templates/` (added to package.json `files`):
- `launchd/dev.flair.rem.nightly.plist.tmpl` — macOS LaunchAgent
- `systemd/flair-rem-nightly.{service,timer}.tmpl` — Linux user-session units
- `bin/flair-rem-nightly.sh.tmpl` — single-line POSIX-sh shim that `exec`s `flair rem nightly run-once`

**CLI subcommands**:
```
flair rem nightly enable [--agent <id>] [--at HH:MM] [--flair-url <url>]
flair rem nightly disable [--remove-shim]
flair rem nightly status
```

Default schedule: 03:00 local time. `--at` accepts `HH:MM`. The scheduler entry passes `FLAIR_AGENT_ID` and `FLAIR_URL` to the runner via env, so the shim itself is a one-liner.

## Live-tested end-to-end on rockit (darwin)

```
$ flair rem nightly enable --agent flint --at 03:00
✅ REM nightly scheduler enabled (darwin)
   Schedule:    03:00 local time
   Scheduler:   ~/Library/LaunchAgents/dev.flair.rem.nightly.plist
   Shim:        ~/.flair/bin/flair-rem-nightly
   Load:        launchctl bootstrap gui/501 ... → ok

$ launchctl print gui/501/dev.flair.rem.nightly
gui/501/dev.flair.rem.nightly = {
    state = not running
    program = ~/.flair/bin/flair-rem-nightly
    stdout path = ~/.flair/logs/rem-nightly.stdout.log
    stderr path = ~/.flair/logs/rem-nightly.stderr.log
    ...
}

$ flair rem nightly status
REM nightly scheduler (darwin):
  Installed:   yes
  ...

$ flair rem nightly disable --remove-shim
✅ REM nightly scheduler disabled (darwin)
   Removed:
     ~/Library/LaunchAgents/dev.flair.rem.nightly.plist
     ~/.flair/bin/flair-rem-nightly
Snapshots at ~/.flair/snapshots/ and the audit log at ~/.flair/logs/rem-nightly.jsonl are preserved.
```

The plist was correctly registered with launchctl, with the right shim path + stdout/stderr destinations. After `disable`, status correctly reports `Installed: no`.

## Tests

17 new unit tests (`test/rem-scheduler.test.ts`, ~36ms with `skipLoad`/`skipUnload` opting out of the launchctl/systemctl shell-out). Total REM suite is now **45 tests across 3 files**, all pass in ~115ms.

Coverage:
- Template substitution (basic, multi-placeholder, unknown-key error, no-placeholder pass-through)
- `darwin enable`: plist contents, executable shim, no leaked `{{...}}` placeholders, agent-id/url/schedule baked in
- `linux enable`: service + timer + shim, zero-padded `OnCalendar`, env vars
- `disable`: idempotent (no-op when not installed), preserves shim by default, `--remove-shim` cleans
- Validation: hour 0-23 / minute 0-59 / agent-id path-traversal guard
- `schedulerStatus`: returns correct platform paths under each platform

## Architectural lenses (for reviewers)

- **Abstraction**: scheduler module is pure filesystem + template substitution; only the load/unload step shells out. Shim file is a single-line POSIX-sh wrapper — no logic, just an `exec`.
- **Contract drift**: no existing endpoint or schema changes. Adds `~/.flair/bin/` (new dir) and writes to standard scheduler locations. Health endpoint already pre-detects these paths.
- **Coupling**: scheduler module imports nothing from the REM tree beyond filesystem helpers. CLI imports via dynamic `await import()` to keep `dist/cli.js` size unaffected.
- **Failure modes**: `enable` calls `launchctl bootout` before `bootstrap` (idempotent — re-enable doesn't double-register). Template renderer throws on unknown placeholders (catch typos at install time, not at first scheduled fire). Validation throws on bad hour/minute/agent-id at the install boundary. `disable` is a no-op when not installed.

## Out of scope

- **Slice-2**: maintenance + trust-tier filter + distillation + live replay into Harper. Audit-row `slice: "1"` keeps phase distinguishable.
- **Custom timezones**: `--tz` argument. macOS launchd uses local; systemd `OnCalendar` is local by default. `--tz` lands in slice-2 if operators ask.
- **Dry-run first run** (spec § 10) — landed in PR-1 as `--dry-run` on `run-once`. The "first cycle is implicit dry-run" mechanic per spec § 10 is a slice-1.5 nice-to-have; safe to ship slice-1 without it because the scheduler default 03:00 is far enough from typical enable time that operators can dry-run beforehand.

## Checklist

- [x] Tests pass (45/45 across the full REM suite)
- [x] CHANGELOG entry updated
- [x] Live-tested end-to-end (enable → launchctl bootstrap → status → disable round-trip)
- [x] Templates added to package.json `files` so they ship in the npm tarball
- [x] No new dependencies
- [x] No security-surface changes
- [x] Same K&S ensemble + GH-post discipline as PR #414