### PR TITLE
feat(rem): slice-2 PR-3 — wire /MemoryMaintenance into runner + fix routing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+### ✨ FLAIR-NIGHTLY-REM slice-2 — maintenance step + MemoryMaintenance routing fix
+
+- **`/MemoryMaintenance` endpoint now reachable** — migrated `resources/MemoryMaintenance.ts` from a non-standard `export default class` with `static ROUTE`/`METHOD` (which Harper 5.x doesn't auto-register) to the standard `extends Resource` + `allowCreate()` shape. `flair rem light` was returning "Not found" against this endpoint in production; both `rem light` and the new REM nightly runner now reach it correctly. Response shape extended: `expired`/`archived`/`total`/`errors` are now top-level on the response in addition to the historical `stats` wrapper, so REM-style callers don't need to unwrap.
+- **Nightly runner runs `/MemoryMaintenance` after snapshot** — soft-deletes expired memories + soft-archives stale standard session memories (>30 days). Audit row now populates `archived` and `expired`; `slice` field becomes `"2-maintenance"` to distinguish from slice-1 snapshot-only rows. Failure of maintenance after snapshot succeeds: cycle marked `failed`, snapshot preserved, error captured in `errors[]`.
+- **`rem nightly run-once` shows archived/expired** — CLI display gained `Archived:` and `Expired:` lines when the maintenance step ran.
+
 ### ✨ FLAIR-NIGHTLY-REM slice-1 (scheduler + manual cycle + snapshot/restore)
 
 - **`flair rem nightly enable [--agent <id>] [--at HH:MM] [--flair-url <url>]`** — installs the platform-native scheduler. On macOS, writes `~/Library/LaunchAgents/dev.flair.rem.nightly.plist` and `launchctl bootstrap`s it. On Linux, writes `~/.config/systemd/user/flair-rem-nightly.{timer,service}` and enables the timer. Also deploys `~/.flair/bin/flair-rem-nightly` as the shim the scheduler invokes. Defaults to 03:00 local time.

--- a/resources/MemoryMaintenance.ts
+++ b/resources/MemoryMaintenance.ts
@@ -1,32 +1,56 @@
 /**
  * MemoryMaintenance.ts — Maintenance worker for memory hygiene.
  *
- * POST /MemoryMaintenance/ — runs cleanup tasks:
+ * POST /MemoryMaintenance — runs cleanup tasks:
  *   1. Delete expired ephemeral memories (expiresAt < now)
  *   2. Archive old session memories (> 30 days, standard durability)
  *   3. Report stats
  *
- * Designed to run periodically (daily cron or heartbeat).
- * Requires admin auth.
+ * Designed to run periodically (daily cron, scheduler, or REM nightly cycle).
+ * Authenticated via Ed25519 (agent acts on own memories) or admin (system-wide).
+ *
+ * History: prior to slice-2 PR-3, this class used a static-ROUTE pattern
+ * (`export default class MemoryMaintenance` with `static ROUTE`/`METHOD`)
+ * that Harper 5.x does not auto-register. Both `flair rem light` and the
+ * REM nightly runner were returning "Not found" against the endpoint.
+ * Migrated to the standard `extends Resource` shape with `allowCreate()`
+ * to gate auth correctly.
  */
 
-export default class MemoryMaintenance {
-  static ROUTE = "MemoryMaintenance";
-  static METHOD = "POST";
+import { Resource, databases } from "@harperfast/harper";
+import { isAdmin } from "./auth-middleware.js";
+
+export class MemoryMaintenance extends Resource {
+  /** POST requires auth — either an agent acting on its own memories, or admin. */
+  allowCreate(): boolean {
+    const ctx = (this as any).getContext?.();
+    const request = ctx?.request ?? ctx;
+    return !!(request?.tpsAgent || request?.tpsAgentIsAdmin);
+  }
 
   async post(data: any) {
-    const { databases }: any = this;
-    const request = (this as any).request;
-    const { dryRun = false, agentId } = data || {};
+    const { dryRun = false, agentId: bodyAgentId } = data || {};
 
-    // Scope to authenticated agent. Admin can pass agentId for system-wide
-    // maintenance; non-admin always scoped to their own agent.
-    const authAgent = request?.headers?.get?.("x-tps-agent");
-    const isAdmin = (request as any)?.tpsAgentIsAdmin === true;
-    const targetAgent = isAdmin && agentId ? agentId : authAgent;
+    const ctx = (this as any).getContext?.();
+    const request = ctx?.request ?? ctx;
+    const actorId: string | undefined = request?.tpsAgent;
+    const callerIsAdmin: boolean = request?.tpsAgentIsAdmin === true
+      || (actorId ? await isAdmin(actorId) : false);
 
-    if (!targetAgent && !isAdmin) {
-      return { error: "agentId required" };
+    // Scope rules:
+    //   - Admin can pass agentId to maintain a specific agent (or omit it
+    //     for fleet-wide maintenance).
+    //   - Non-admin agents are scoped to their own memories — bodyAgentId
+    //     either matches the authenticated agent or is ignored.
+    const targetAgent: string | undefined = callerIsAdmin
+      ? bodyAgentId
+      : actorId;
+
+    if (!targetAgent && !callerIsAdmin) {
+      return new Response(JSON.stringify({ error: "agentId required" }), {
+        status: 400,
+        headers: { "content-type": "application/json" },
+      });
     }
 
     const now = new Date();
@@ -34,7 +58,7 @@ export default class MemoryMaintenance {
 
     try {
       for await (const record of (databases as any).flair.Memory.search()) {
-        // Skip records not belonging to target agent (unless admin running system-wide)
+        // Skip records not belonging to target agent (unless admin running fleet-wide).
         if (targetAgent && record.agentId !== targetAgent) continue;
         stats.total++;
 
@@ -53,9 +77,9 @@ export default class MemoryMaintenance {
           continue;
         }
 
-        // 2. Archive old standard session memories (> 30 days)
-        // These are low-value session notes that weren't promoted to persistent.
-        // Archiving removes them from search results but keeps the data.
+        // 2. Archive old standard session memories (> 30 days). These are
+        // low-value session notes that weren't promoted to persistent.
+        // Soft-archive removes them from search results but keeps the data.
         if (
           record.durability === "standard" &&
           record.type === "session" &&
@@ -67,7 +91,6 @@ export default class MemoryMaintenance {
           if (ageDays > 30) {
             if (!dryRun) {
               try {
-                // Soft archive — set archived flag, keep data
                 await (databases as any).flair.Memory.update(record.id, {
                   ...record,
                   archived: true,
@@ -84,12 +107,22 @@ export default class MemoryMaintenance {
         }
       }
     } catch (err: any) {
-      return { error: err.message, stats };
+      return new Response(
+        JSON.stringify({ error: err.message, stats }),
+        { status: 500, headers: { "content-type": "application/json" } },
+      );
     }
 
+    // Flatten the historical { stats } wrapper into the top level so callers
+    // can read `.expired` / `.archived` directly. The wrapper shape is kept
+    // for backward compatibility with `flair rem light`.
     return {
       message: dryRun ? "Dry run complete" : "Maintenance complete",
       stats,
+      expired: stats.expired,
+      archived: stats.archived,
+      total: stats.total,
+      errors: stats.errors,
     };
   }
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -4403,6 +4403,10 @@ remNightly
       console.log(`Memories:   ${row.memoryCount ?? "—"}`);
       console.log(`Souls:      ${row.soulCount ?? "—"}`);
       console.log(`Pending:    ${row.pendingCandidates ?? "—"}`);
+      if (typeof row.archived === "number" || typeof row.expired === "number") {
+        console.log(`Archived:   ${row.archived ?? "—"}`);
+        console.log(`Expired:    ${row.expired ?? "—"}`);
+      }
       console.log(`Duration:   ${row.durationMs}ms`);
       if (row.errors.length > 0) {
         console.log(`Errors:`);

--- a/src/rem/runner.ts
+++ b/src/rem/runner.ts
@@ -1,18 +1,26 @@
 /**
- * REM nightly runner — orchestrates the slice-1 cycle.
+ * REM nightly runner — orchestrates the cycle.
  *
  * Per FLAIR-NIGHTLY-REM § 4, in order:
  *   1. Pre-flight: check pause sentinel / FLAIR_REM_PAUSE env. Exit clean if paused.
  *   2. Snapshot agent state (memory + soul) to ~/.flair/snapshots/<agent>/.
- *   3. (slice-2) maintenance — soft-delete expired + soft-archive stale.
- *   4. (slice-2) trust-tier filter on input memories.
- *   5. (slice-2) distillation — call /ReflectMemories, persist candidates.
+ *   3. Maintenance — delegate to /MemoryMaintenance (same code path `flair rem light` uses).
+ *   4. (slice-2 next) trust-tier filter on input memories.
+ *   5. (slice-2 next) distillation — call /ReflectMemories, persist candidates.
  *   6. Append a row to ~/.flair/logs/rem-nightly.jsonl.
  *
- * Slice-1 ships steps 1, 2, and 6. Maintenance + distillation are deferred to
- * slice-2 so the load-bearing claim — "every cycle is reversible" — ships
- * first. The audit row marks slice-1 cycles with `slice: "1"` so slice-2
- * upgrades are visible in the history.
+ * Status today:
+ *   - Steps 1, 2, 6 shipped in slice-1 PR-1 (#414).
+ *   - Step 3 (maintenance) ships in this PR — fills `archived`/`expired` in
+ *     the audit row.
+ *   - Steps 4, 5 are slice-2 follow-ups; require an in-process distillation
+ *     LLM path (today `/ReflectMemories` returns a prompt for human/agent
+ *     consumption, not server-side candidate generation).
+ *
+ * The audit row's `slice` field tells readers which steps populated which
+ * counts: `slice: "1"` rows have `archived`/`expired` undefined; `slice:
+ * "2-maintenance"` rows populate them; future slice-2 rows will populate
+ * `consolidated` and `candidates`.
  *
  * Pure dependency injection so the runner is unit-testable without Harper.
  * The CLI wires the real `apiCall` + `pkgVersion`; tests pass stubs.
@@ -47,10 +55,21 @@ export interface RunnerOpts {
 
 export type RunnerStatus = "paused" | "completed" | "dry-run" | "failed";
 
+/**
+ * Audit-row `slice` field. Tracks which phase of FLAIR-NIGHTLY-REM
+ * produced this row so log readers can distinguish snapshot-only cycles
+ * from cycles with maintenance / distillation populated:
+ *
+ *   "1"             — snapshot + log only (slice-1, before #416)
+ *   "2-maintenance" — snapshot + /MemoryMaintenance (this PR, slice-2 PR-3)
+ *   "2"             — full slice-2 (adds /ReflectMemories distillation + replay)
+ */
+export type RunnerSlice = "1" | "2-maintenance" | "2";
+
 export interface RunnerLogRow {
   agentId: string;
   runAt: string;
-  slice: "1";
+  slice: RunnerSlice;
   status: RunnerStatus;
   dryRun?: boolean;
   snapshotPath?: string;
@@ -207,19 +226,62 @@ export async function runNightlyCycle(opts: RunnerOpts): Promise<RunnerResult> {
     return { status: "failed", logRow: row };
   }
 
+  // Step 3: maintenance — soft-delete expired + soft-archive stale.
+  // Delegates to /MemoryMaintenance (same endpoint `flair rem light` uses).
+  // In dry-run mode the snapshot wasn't written, but we still want to know
+  // what maintenance WOULD do — POST with dryRun=true so the response counts
+  // are accurate without mutating state.
+  let archived = 0;
+  let expired = 0;
+  let sliceLabel: RunnerLogRow["slice"] = "2-maintenance";
+
+  try {
+    const maintRaw = await opts.apiCall("POST", "/MemoryMaintenance", {
+      agentId: opts.agentId,
+      dryRun: opts.dryRun ?? false,
+    });
+    if (maintRaw && typeof maintRaw === "object") {
+      const obj = maintRaw as Record<string, unknown>;
+      if (obj.error) {
+        // /MemoryMaintenance returned { error: "..." } — treat as failure.
+        throw new Error(String(obj.error));
+      }
+      expired = typeof obj.expired === "number" ? obj.expired : 0;
+      archived = typeof obj.archived === "number" ? obj.archived : 0;
+    }
+  } catch (err: any) {
+    errors.push(`maintenance: ${err?.message ?? String(err)}`);
+    const row: RunnerLogRow = {
+      ...baseRow,
+      slice: sliceLabel,
+      status: "failed",
+      snapshotPath,
+      memoryCount,
+      soulCount,
+      pendingCandidates,
+      durationMs: Date.now() - startedMs,
+      errors,
+    };
+    appendLogRow(logPath, row);
+    return { status: "failed", logRow: row, snapshotPath };
+  }
+
   // Step 6: log
   const row: RunnerLogRow = {
     ...baseRow,
+    slice: sliceLabel,
     status: opts.dryRun ? "dry-run" : "completed",
     dryRun: opts.dryRun || undefined,
     snapshotPath,
     memoryCount,
     soulCount,
     pendingCandidates,
+    archived,
+    expired,
     durationMs: Date.now() - startedMs,
     errors,
-    // Slice-2 placeholders — left undefined for now so readers don't see
-    // confusing "0" archived/consolidated counts on slice-1 rows.
+    // `consolidated` and `candidates` populate when slice-2 PR-4 (distillation)
+    // lands; today they remain undefined so the row is honest about what ran.
   };
   appendLogRow(logPath, row);
   return { status: row.status, logRow: row, snapshotPath };

--- a/test/rem-runner.test.ts
+++ b/test/rem-runner.test.ts
@@ -14,6 +14,12 @@ import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { runNightlyCycle, type ApiCall, type RunnerOpts } from "../src/rem/runner.ts";
 
+const sampleMemories = [
+  { id: "m1", agentId: "test-agent", content: "first memory", durability: "persistent" },
+  { id: "m2", agentId: "test-agent", content: "second memory" },
+];
+const sampleSoul = { id: "soul-test-agent", agentId: "test-agent", instructions: "be helpful" };
+
 let testRoot: string;
 let snapshotRoot: string;
 let logPath: string;
@@ -55,6 +61,7 @@ function baseOpts(overrides: Partial<RunnerOpts> = {}): RunnerOpts {
       "GET:/Memory": () => [{ id: "m1" }, { id: "m2" }],
       "GET:/Soul": () => [{ id: "soul-test-agent", agentId: "test-agent" }],
       "POST:/MemoryCandidate/search_by_conditions": () => [],
+      "POST:/MemoryMaintenance": () => ({ expired: 0, archived: 0, total: 0, errors: 0 }),
     }),
     snapshotRoot,
     logPath,
@@ -97,7 +104,8 @@ describe("happy path", () => {
     expect(r.logRow.soulCount).toBe(1);
     expect(r.logRow.pendingCandidates).toBe(0);
     expect(r.logRow.errors).toEqual([]);
-    expect(r.logRow.slice).toBe("1");
+    // With maintenance wired in this PR, baseline cycles are now slice-2-maintenance.
+    expect(r.logRow.slice).toBe("2-maintenance");
 
     // Log file contains exactly one row.
     const rows = readLogRows();
@@ -114,6 +122,7 @@ describe("happy path", () => {
         "POST:/MemoryCandidate/search_by_conditions": () => [
           { id: "c1" }, { id: "c2" }, { id: "c3" },
         ],
+        "POST:/MemoryMaintenance": () => ({ expired: 0, archived: 0, total: 0, errors: 0 }),
       }),
     }));
     expect(r.logRow.pendingCandidates).toBe(3);
@@ -125,11 +134,48 @@ describe("happy path", () => {
         "GET:/Memory": () => ({ results: [{ id: "m1" }, { id: "m2" }, { id: "m3" }] }),
         "GET:/Soul": () => ({ items: [{ id: "s1" }] }),
         "POST:/MemoryCandidate/search_by_conditions": () => [],
+        "POST:/MemoryMaintenance": () => ({ expired: 0, archived: 0, total: 0, errors: 0 }),
       }),
     }));
     expect(r.status).toBe("completed");
     expect(r.logRow.memoryCount).toBe(3);
     expect(r.logRow.soulCount).toBe(1);
+  });
+
+  it("populates archived and expired from /MemoryMaintenance response", async () => {
+    const r = await runNightlyCycle(baseOpts({
+      apiCall: makeApi({
+        "GET:/Memory": () => sampleMemories,
+        "GET:/Soul": () => [sampleSoul],
+        "POST:/MemoryCandidate/search_by_conditions": () => [],
+        "POST:/MemoryMaintenance": () => ({ expired: 5, archived: 12, total: 200, errors: 0 }),
+      }),
+    }));
+    expect(r.status).toBe("completed");
+    expect(r.logRow.archived).toBe(12);
+    expect(r.logRow.expired).toBe(5);
+    expect(r.logRow.slice).toBe("2-maintenance");
+  });
+
+  it("forwards dryRun to /MemoryMaintenance so counts are accurate without mutation", async () => {
+    let receivedDryRun: unknown;
+    const r = await runNightlyCycle(baseOpts({
+      dryRun: true,
+      apiCall: async (method, path, body) => {
+        if (method === "POST" && path === "/MemoryMaintenance") {
+          receivedDryRun = (body as any)?.dryRun;
+          return { expired: 2, archived: 7, total: 100, errors: 0 };
+        }
+        if (method === "GET" && path.startsWith("/Memory?")) return sampleMemories;
+        if (method === "GET" && path.startsWith("/Soul?")) return [sampleSoul];
+        if (method === "POST" && path === "/MemoryCandidate/search_by_conditions") return [];
+        throw new Error(`unexpected api: ${method}:${path}`);
+      },
+    }));
+    expect(r.status).toBe("dry-run");
+    expect(receivedDryRun).toBe(true);
+    expect(r.logRow.archived).toBe(7);
+    expect(r.logRow.expired).toBe(2);
   });
 });
 
@@ -184,11 +230,43 @@ describe("failure modes", () => {
         "GET:/Memory": () => [{ id: "m1" }],
         "GET:/Soul": () => [],
         "POST:/MemoryCandidate/search_by_conditions": () => { throw new Error("candidate table missing"); },
+        "POST:/MemoryMaintenance": () => ({ expired: 0, archived: 0, total: 0, errors: 0 }),
       }),
     }));
     // Candidate count is a non-fatal signal — the cycle still completes.
     expect(r.status).toBe("completed");
     expect(r.logRow.pendingCandidates).toBe(0);
+  });
+
+  it("captures maintenance errors and exits failed (snapshot preserved)", async () => {
+    const r = await runNightlyCycle(baseOpts({
+      apiCall: makeApi({
+        "GET:/Memory": () => [{ id: "m1" }],
+        "GET:/Soul": () => [],
+        "POST:/MemoryCandidate/search_by_conditions": () => [],
+        "POST:/MemoryMaintenance": () => { throw new Error("maintenance worker offline"); },
+      }),
+    }));
+    expect(r.status).toBe("failed");
+    // Snapshot already wrote before maintenance ran — it's preserved.
+    expect(r.snapshotPath).toBeDefined();
+    expect(existsSync(r.snapshotPath!)).toBe(true);
+    expect(r.logRow.errors[0]).toContain("maintenance:");
+    expect(r.logRow.errors[0]).toContain("maintenance worker offline");
+    expect(r.logRow.slice).toBe("2-maintenance");
+  });
+
+  it("treats { error: '...' } maintenance response as failure", async () => {
+    const r = await runNightlyCycle(baseOpts({
+      apiCall: makeApi({
+        "GET:/Memory": () => [{ id: "m1" }],
+        "GET:/Soul": () => [],
+        "POST:/MemoryCandidate/search_by_conditions": () => [],
+        "POST:/MemoryMaintenance": () => ({ error: "agentId required" }),
+      }),
+    }));
+    expect(r.status).toBe("failed");
+    expect(r.logRow.errors[0]).toContain("agentId required");
   });
 });
 


### PR DESCRIPTION
## Why

First step of slice-2. Two coupled changes — the runner-wiring needed the endpoint to actually route, which it wasn't.

## What

### Fix: `/MemoryMaintenance` routing

`resources/MemoryMaintenance.ts` used `export default class` + `static ROUTE`/`METHOD` — a pattern Harper 5.x doesn't auto-register. **Both `flair rem light` and the new REM nightly runner returned "Not found" against the endpoint.** Pre-existing bug; surfacing it now because the runner needs to call it.

Migrated to standard `extends Resource` + `allowCreate()` shape:
- Class name matches the route (`/MemoryMaintenance`)
- Auth via `getContext().request` (matches the pattern Memory, SemanticSearch, ReflectMemories use after the 2026-04-17 fix)
- Non-admin agents scoped to their own memories
- Admin can pass `agentId` or omit for fleet-wide
- Response shape extended: `expired`/`archived`/`total`/`errors` top-level in addition to the historical `stats` wrapper (backwards-compatible with `flair rem light`)

### Runner: step 3 (maintenance)

After snapshot succeeds, the runner POSTs `/MemoryMaintenance` with the agent's id and dryRun flag. Response counts populate `archived` and `expired` on the audit row. Slice label becomes `"2-maintenance"`.

**Failure mode:** maintenance error after snapshot succeeds → `status: "failed"` audit row, error in `errors[]`, snapshot preserved. The reversible-safety property holds.

CLI `rem nightly run-once` display: gained `Archived:` / `Expired:` lines.

## Live-tested on rockit

```
$ FLAIR_AGENT_ID=flint flair rem nightly run-once --dry-run
-- rem nightly run-once (dry-run) --
Status:     dry-run
Memories:   290
Souls:      23
Pending:    0
Archived:   12        # stale standard session memories > 30d
Expired:    0
Duration:   165ms
```

Pre-fix: same call produced `status=failed, errors=["maintenance: Not found"]`. Post-fix: clean dry-run; 12 memories identified for archival on this agent.

## Tests

49/49 across the REM suite (rem-snapshot 16, rem-runner 16, rem-scheduler 17), all pass in ~108ms with no Harper required.

Runner suite gained 4 new tests:
- Populates `archived`/`expired` from `/MemoryMaintenance` response
- Forwards `dryRun` so counts are accurate without mutation
- Captures maintenance errors (snapshot preserved)
- Treats `{ error: "..." }` response as failure

Stubs updated across `baseOpts` + 4 prior tests to mock `/MemoryMaintenance`.

## Architectural lenses (for reviewers)

- **Abstraction**: runner orchestrates via injected `apiCall`, no direct Harper coupling. MemoryMaintenance migrated to the same Resource pattern as siblings — consistency.
- **Contract drift**: response shape extended (top-level + stats wrapper) — backwards-compatible with the one existing caller (`flair rem light`). Audit-row `slice` field grows from `"1" | "2"` to `"1" | "2-maintenance" | "2"` — extension, not breaking.
- **Coupling**: runner imports nothing new. MemoryMaintenance imports `Resource`, `databases`, `isAdmin` — all already used elsewhere in `resources/`.
- **Failure modes**: maintenance error → failed cycle, snapshot preserved (reversible-safety property holds). `{ error: "..." }` response treated as failure. dryRun forwarded so dry-runs are pure observation. Non-admin agents can't manipulate other agents' memories.

## Out of scope (subsequent slice-2 PRs)

- **PR-4**: trust-tier filter + `/ReflectMemories` distillation. Requires in-process LLM path; today `/ReflectMemories` returns a prompt for human/agent consumption rather than server-side candidate generation. Implementation needs a configured chat model.
- **PR-5**: live replay (`/MemoryRestore` + `/SoulRestore` endpoints, atomic rewind) + stragglers (pagination on `GET /Memory`, `--tz`, Sherlock's `#415` `spawnSync` timeout nit).

## Checklist

- [x] Tests pass (49/49)
- [x] CHANGELOG entry under Unreleased (slice-2 section)
- [x] Live-tested end-to-end on rockit (dry-run produced expected `archived=12, expired=0`)
- [x] MemoryMaintenance migration backwards-compatible with `flair rem light`
- [x] No new dependencies
- [x] No security-surface changes (auth gating moves from custom static to standard `allowCreate()`)