### PR TITLE
feat(rem): slice-2 PR-4 — flair rem restore --apply (live replay)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+### ✨ FLAIR-NIGHTLY-REM slice-2 — live replay (`flair rem restore --apply`)
+
+- **`flair rem restore <date> --apply`** — actually rewinds Harper state to the snapshot, not just extracts the tarball. Sequential client-side restore: takes a pre-restore snapshot of CURRENT state first (so this restore is itself reversible), then DELETEs current memories/souls for the agent, then PUTs the snapshot rows back. The pre-restore snapshot path is reported so the operator can roll back if something goes wrong mid-flight (`flair rem restore <pre-restore-date> --apply`).
+- **`flair rem restore --apply --dry-run`** — reports planned delete/restore counts without making any destructive call. Useful for verifying the snapshot's contents match expectations before committing.
+- **Cross-agent restore is refused** — the snapshot's `metadata.json` `agentId` must match the `--agent` argument. Prevents accidental rewind into the wrong account if a snapshot tarball was hand-copied.
+
 ### ✨ FLAIR-NIGHTLY-REM slice-2 — maintenance step + MemoryMaintenance routing fix
 
 - **`/MemoryMaintenance` endpoint now reachable** — migrated `resources/MemoryMaintenance.ts` from a non-standard `export default class` with `static ROUTE`/`METHOD` (which Harper 5.x doesn't auto-register) to the standard `extends Resource` + `allowCreate()` shape. `flair rem light` was returning "Not found" against this endpoint in production; both `rem light` and the new REM nightly runner now reach it correctly. Response shape extended: `expired`/`archived`/`total`/`errors` are now top-level on the response in addition to the historical `stats` wrapper, so REM-style callers don't need to unwrap.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -4460,23 +4460,29 @@ remSnapshot
   });
 
 // ─── flair rem restore <date> ────────────────────────────────────────────────
-// Slice 1 of FLAIR-NIGHTLY-REM § 9. Extracts a snapshot tarball to a target
-// directory for inspection. This is the "snapshot list + extract" pair — the
-// extracted memories.jsonl / soul.json / metadata.json can be inspected and
-// manually replayed if needed. A live replay into Harper (operator command
-// "actually rewind state to <date>") lands in slice-2 once we settle the
-// replay endpoint shape.
+// Slice 1 + 2 of FLAIR-NIGHTLY-REM § 9.
 //
-// The <date> argument can be a full ISO timestamp prefix (e.g.
-// "2026-05-14T03-00-00-000Z") or a date-only prefix ("2026-05-14"). The
+// Default (no --apply): filesystem-only extract for inspection. Writes
+//   memories.jsonl / soul.json / metadata.json to a target directory.
+//   Harper state is unchanged.
+//
+// --apply: live replay. Reads the snapshot contents, takes a pre-restore
+//   snapshot of the agent's CURRENT state (so this restore is itself
+//   reversible), then DELETEs current memories/souls for the agent and PUTs
+//   the snapshot's rows back. Per-row failures are captured per-row; the
+//   pre-restore snapshot's path is reported so operator can roll back if
+//   something goes wrong mid-flight.
+//
+// The <date> argument is an ISO-timestamp prefix or date-only prefix; the
 // command picks the latest snapshot matching that prefix.
 
 rem
   .command("restore <date>")
-  .description("Extract a REM snapshot for inspection (replay-into-live-state is slice 2)")
+  .description("Restore from a REM snapshot (inspect by default; --apply rewinds Harper state)")
   .option("--agent <id>", "Agent id (or FLAIR_AGENT_ID env)")
-  .option("--target <dir>", "Directory to extract into (default: <snapshot>.restored)")
-  .option("--dry-run", "List the snapshot's contents without extracting")
+  .option("--target <dir>", "Directory to extract into (default: <snapshot>.restored, only used without --apply)")
+  .option("--dry-run", "Plan-only — list contents or planned counts without writing")
+  .option("--apply", "Live replay: rewind Harper state to the snapshot (irreversible without the pre-restore snapshot)")
   .action(async (date, opts) => {
     const { listSnapshots, extractSnapshot } = await import("./rem/snapshot.js");
     const agentId = opts.agent || process.env.FLAIR_AGENT_ID;
@@ -4505,6 +4511,40 @@ rem
     // snapshot for the date prefix.
     const match = matches[0];
 
+    // --apply path: live replay via src/rem/restore.ts
+    if (opts.apply) {
+      const { applySnapshot } = await import("./rem/restore.js");
+      try {
+        const result = await applySnapshot({
+          agentId,
+          snapshotPath: match.path,
+          flairVersion: __pkgVersion,
+          apiCall: api,
+          dryRun: !!opts.dryRun,
+        });
+        const verb = opts.dryRun ? "(dry-run) would" : "";
+        console.log(`${opts.dryRun ? "(dry-run) " : ""}flair rem restore --apply${opts.dryRun ? "" : ""}`);
+        console.log(`  Status:       ${result.status}`);
+        console.log(`  Snapshot:     ${match.path}`);
+        if (result.preRestoreSnapshotPath) {
+          console.log(`  Pre-restore:  ${result.preRestoreSnapshotPath}`);
+          console.log(`                (rollback: flair rem restore <pre-restore-date> --agent ${agentId} --apply)`);
+        }
+        console.log(`  Deleted:      ${result.deleted.memories} memories, ${result.deleted.souls} souls`);
+        console.log(`  Restored:     ${result.restored.memories} memories, ${result.restored.souls} souls`);
+        if (result.errors.length > 0) {
+          console.log(`  Errors:`);
+          for (const e of result.errors) console.log(`    - ${e}`);
+        }
+        if (result.status === "failed") process.exit(1);
+      } catch (err: any) {
+        console.error(`Error: ${err.message}`);
+        process.exit(1);
+      }
+      return;
+    }
+
+    // Default: filesystem extract.
     try {
       const result = await extractSnapshot({
         snapshotPath: match.path,
@@ -4524,7 +4564,7 @@ rem
         console.log(`     ${e.path}  (${humanBytes(e.size)})`);
       }
       console.log(`\nNote: this is a filesystem extract — Harper state is unchanged.`);
-      console.log(`Live replay (rewind into Harper) is a slice-2 capability.`);
+      console.log(`To actually rewind state, re-run with --apply.`);
     } catch (err: any) {
       console.error(`Error: ${err.message}`);
       process.exit(1);

--- a/src/rem/restore.ts
+++ b/src/rem/restore.ts
@@ -1,0 +1,240 @@
+/**
+ * REM live replay — atomic state rewind from a snapshot tarball.
+ *
+ * Slice-2 PR-4. Implements the "every cycle is reversible" property:
+ *   `flair rem restore <date> --apply` actually rewinds Harper state to the
+ *   snapshot, not just extracts the tarball for inspection.
+ *
+ * Approach: client-side. The CLI sequentially calls existing `/Memory` and
+ * `/Soul` endpoints (DELETE current rows for the agent, PUT snapshot rows).
+ * No new server endpoint — keeps the auth surface unchanged and avoids the
+ * Harper body-size limit on uploading large memory exports inline.
+ *
+ * Reversibility-of-restore guarantee: before any destructive op, this
+ * module creates a pre-restore snapshot of the CURRENT state. If something
+ * fails mid-flight, the operator can restore from the pre-restore snapshot
+ * to roll back.
+ *
+ * Multi-agent restore (admin restoring another agent's state) is not in
+ * scope here; the operator's agent can only restore its own memories.
+ * Cross-agent restore is a 1.1+ feature.
+ */
+import { readFileSync, existsSync, rmSync, mkdtempSync, statSync } from "node:fs";
+import { resolve, dirname } from "node:path";
+import { tmpdir } from "node:os";
+import { extractSnapshot, createSnapshot } from "./snapshot.js";
+
+export type ApiCall = (method: string, path: string, body?: unknown) => Promise<any>;
+
+export interface RestoreOpts {
+  agentId: string;
+  snapshotPath: string;
+  flairVersion: string;
+  apiCall: ApiCall;
+  /** Override snapshot root used for the pre-restore snapshot. */
+  preRestoreSnapshotRoot?: string;
+  /** When true, plan and report what would happen — no API mutations. */
+  dryRun?: boolean;
+  /** Override tmpdir for testing. */
+  tmpRootOverride?: string;
+  /** Override "now" for testing. */
+  nowOverride?: Date;
+}
+
+export interface RestoreResult {
+  status: "completed" | "dry-run" | "failed";
+  agentId: string;
+  snapshotPath: string;
+  /** Path to the pre-restore-state snapshot (preserved on real restore + failures). */
+  preRestoreSnapshotPath?: string;
+  deleted: {
+    memories: number;
+    souls: number;
+  };
+  restored: {
+    memories: number;
+    souls: number;
+  };
+  errors: string[];
+}
+
+function asArray(raw: unknown): any[] {
+  if (Array.isArray(raw)) return raw;
+  if (raw && typeof raw === "object") {
+    const obj = raw as Record<string, unknown>;
+    if (Array.isArray(obj.results)) return obj.results as any[];
+    if (Array.isArray(obj.items)) return obj.items as any[];
+  }
+  return [];
+}
+
+function parseJsonlSafe(text: string): any[] {
+  if (!text.trim()) return [];
+  return text
+    .split("\n")
+    .filter((line) => line.trim().length > 0)
+    .map((line) => JSON.parse(line));
+}
+
+/**
+ * Applies a snapshot tarball to live Harper state for the given agent.
+ *
+ * Steps:
+ *   1. Extract the snapshot to a tmpdir.
+ *   2. Parse memories.jsonl + soul.json + metadata.json.
+ *   3. Verify metadata.agentId matches opts.agentId (prevents accidental
+ *      cross-agent restore — the file might have been hand-copied).
+ *   4. Create a pre-restore snapshot of current state (skip in dry-run).
+ *   5. Fetch + delete current memories/souls for the agent (skip in dry-run).
+ *   6. PUT snapshot memories/souls back into Harper (skip in dry-run).
+ *   7. Return counts.
+ *
+ * On any error after step 4: the result reports `status: "failed"` with
+ * the pre-restore snapshot path included so the operator can roll back.
+ */
+export async function applySnapshot(opts: RestoreOpts): Promise<RestoreResult> {
+  const errors: string[] = [];
+  const result: RestoreResult = {
+    status: "completed",
+    agentId: opts.agentId,
+    snapshotPath: opts.snapshotPath,
+    deleted: { memories: 0, souls: 0 },
+    restored: { memories: 0, souls: 0 },
+    errors,
+  };
+
+  if (!existsSync(opts.snapshotPath)) {
+    errors.push(`snapshot does not exist: ${opts.snapshotPath}`);
+    result.status = "failed";
+    return result;
+  }
+
+  // 1+2. Extract and parse. mkdtempSync creates an empty dir; extractSnapshot
+  // refuses to extract into an existing dir, so we point it at a non-existing
+  // subdir of the tmp scratch space.
+  const tmpRoot = opts.tmpRootOverride ?? tmpdir();
+  const tmp = mkdtempSync(resolve(tmpRoot, "flair-rem-restore-"));
+  const extractTo = resolve(tmp, "snapshot");
+  let memories: any[];
+  let souls: any[];
+  let metadata: Record<string, unknown>;
+
+  try {
+    await extractSnapshot({ snapshotPath: opts.snapshotPath, targetDir: extractTo });
+    const memText = readFileSync(resolve(extractTo, "memories.jsonl"), "utf-8");
+    memories = parseJsonlSafe(memText);
+    const soulRaw = JSON.parse(readFileSync(resolve(extractTo, "soul.json"), "utf-8"));
+    souls = Array.isArray(soulRaw)
+      ? soulRaw
+      : soulRaw && typeof soulRaw === "object"
+        ? [soulRaw]
+        : [];
+    metadata = JSON.parse(readFileSync(resolve(extractTo, "metadata.json"), "utf-8"));
+  } catch (err: any) {
+    errors.push(`extract: ${err?.message ?? String(err)}`);
+    result.status = "failed";
+    rmSync(tmp, { recursive: true, force: true });
+    return result;
+  }
+
+  // 3. Verify agent id matches.
+  if (metadata.agentId && metadata.agentId !== opts.agentId) {
+    errors.push(
+      `snapshot agentId (${metadata.agentId}) does not match target (${opts.agentId}) — refusing to restore cross-agent`,
+    );
+    result.status = "failed";
+    rmSync(tmp, { recursive: true, force: true });
+    return result;
+  }
+
+  if (opts.dryRun) {
+    // In dry-run, report planned counts. Still fetch current state for
+    // accurate deleted-counts reporting.
+    try {
+      const currentMem = asArray(await opts.apiCall("GET", `/Memory?agentId=${encodeURIComponent(opts.agentId)}`));
+      const currentSouls = asArray(await opts.apiCall("GET", `/Soul?agentId=${encodeURIComponent(opts.agentId)}`));
+      result.deleted.memories = currentMem.length;
+      result.deleted.souls = currentSouls.length;
+      result.restored.memories = memories.length;
+      result.restored.souls = souls.length;
+      result.status = "dry-run";
+    } catch (err: any) {
+      errors.push(`fetch-current: ${err?.message ?? String(err)}`);
+      result.status = "failed";
+    }
+    rmSync(tmp, { recursive: true, force: true });
+    return result;
+  }
+
+  // 4. Pre-restore snapshot of current state.
+  let currentMem: any[];
+  let currentSouls: any[];
+  try {
+    currentMem = asArray(await opts.apiCall("GET", `/Memory?agentId=${encodeURIComponent(opts.agentId)}`));
+    currentSouls = asArray(await opts.apiCall("GET", `/Soul?agentId=${encodeURIComponent(opts.agentId)}`));
+
+    const preRestore = await createSnapshot({
+      agentId: opts.agentId,
+      flairVersion: opts.flairVersion,
+      memories: currentMem,
+      soul: currentSouls.length === 1 ? currentSouls[0] : currentSouls.length > 1 ? currentSouls : null,
+      pendingCandidateCount: 0, // not load-bearing at restore time
+      rootOverride: opts.preRestoreSnapshotRoot,
+      runId: `rem-restore-pre-${(opts.nowOverride ?? new Date()).toISOString().replace(/[:.]/g, "-")}`,
+      nowOverride: opts.nowOverride,
+    });
+    result.preRestoreSnapshotPath = preRestore.path;
+  } catch (err: any) {
+    errors.push(`pre-restore-snapshot: ${err?.message ?? String(err)}`);
+    result.status = "failed";
+    rmSync(tmp, { recursive: true, force: true });
+    return result;
+  }
+
+  // 5. Delete current memories + souls (sequential to keep error semantics).
+  for (const m of currentMem) {
+    if (!m?.id) continue;
+    try {
+      await opts.apiCall("DELETE", `/Memory/${encodeURIComponent(String(m.id))}`);
+      result.deleted.memories++;
+    } catch (err: any) {
+      errors.push(`delete-memory ${m.id}: ${err?.message ?? String(err)}`);
+    }
+  }
+  for (const s of currentSouls) {
+    if (!s?.id) continue;
+    try {
+      await opts.apiCall("DELETE", `/Soul/${encodeURIComponent(String(s.id))}`);
+      result.deleted.souls++;
+    } catch (err: any) {
+      errors.push(`delete-soul ${s.id}: ${err?.message ?? String(err)}`);
+    }
+  }
+
+  // 6. PUT snapshot rows.
+  for (const m of memories) {
+    if (!m?.id) continue;
+    try {
+      await opts.apiCall("PUT", `/Memory/${encodeURIComponent(String(m.id))}`, m);
+      result.restored.memories++;
+    } catch (err: any) {
+      errors.push(`put-memory ${m.id}: ${err?.message ?? String(err)}`);
+    }
+  }
+  for (const s of souls) {
+    if (!s?.id) continue;
+    try {
+      await opts.apiCall("PUT", `/Soul/${encodeURIComponent(String(s.id))}`, s);
+      result.restored.souls++;
+    } catch (err: any) {
+      errors.push(`put-soul ${s.id}: ${err?.message ?? String(err)}`);
+    }
+  }
+
+  rmSync(tmp, { recursive: true, force: true });
+
+  if (errors.length > 0) {
+    result.status = "failed";
+  }
+  return result;
+}

--- a/test/rem-restore.test.ts
+++ b/test/rem-restore.test.ts
@@ -1,0 +1,232 @@
+/**
+ * rem-restore.test.ts — Unit tests for src/rem/restore.ts.
+ *
+ * Verifies the apply-snapshot flow:
+ *   - dry-run reports planned counts without mutating
+ *   - real restore creates a pre-restore snapshot of current state
+ *   - cross-agent restore is refused
+ *   - DELETE-then-PUT happens in order
+ *   - errors mid-flight produce status="failed" with preRestoreSnapshotPath
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import { mkdirSync, rmSync, readFileSync, writeFileSync, existsSync, mkdtempSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { applySnapshot, type ApiCall } from "../src/rem/restore.ts";
+import { createSnapshot } from "../src/rem/snapshot.ts";
+
+let testRoot: string;
+let snapshotRoot: string;
+
+beforeEach(() => {
+  testRoot = mkdtempSync(join(tmpdir(), "flair-rem-restore-test-"));
+  snapshotRoot = join(testRoot, "snapshots");
+});
+
+afterEach(() => {
+  rmSync(testRoot, { recursive: true, force: true });
+});
+
+const snapshotMemories = [
+  { id: "m1", agentId: "test-agent", content: "snapshot memory 1", durability: "persistent" },
+  { id: "m2", agentId: "test-agent", content: "snapshot memory 2" },
+];
+const snapshotSoul = { id: "soul-test-agent", agentId: "test-agent", instructions: "be helpful" };
+
+async function makeTestSnapshot(agentId = "test-agent"): Promise<string> {
+  const r = await createSnapshot({
+    agentId,
+    flairVersion: "0.0.0-test",
+    memories: snapshotMemories,
+    soul: snapshotSoul,
+    pendingCandidateCount: 0,
+    rootOverride: snapshotRoot,
+  });
+  return r.path;
+}
+
+/** Builds a stubbed apiCall that records all method+path invocations. */
+function recordingApi(handlers: Record<string, (path: string, body?: unknown) => any> = {}): {
+  api: ApiCall;
+  calls: Array<{ method: string; path: string; body?: unknown }>;
+} {
+  const calls: Array<{ method: string; path: string; body?: unknown }> = [];
+  const api: ApiCall = async (method, path, body) => {
+    calls.push({ method, path, body });
+    const key = `${method}:${path.split("?")[0].split("/").slice(0, 2).join("/")}`;
+    if (handlers[key]) return handlers[key](path, body);
+    // Default fall-throughs for the read endpoints when not stubbed
+    if (method === "GET" && path.startsWith("/Memory?")) return [];
+    if (method === "GET" && path.startsWith("/Soul?")) return [];
+    if (method === "DELETE" || method === "PUT") return { ok: true };
+    throw new Error(`unexpected api: ${method}:${path}`);
+  };
+  return { api, calls };
+}
+
+describe("applySnapshot — dry-run", () => {
+  it("reports planned counts without making destructive calls", async () => {
+    const snapshotPath = await makeTestSnapshot();
+    const current = [{ id: "old-1", agentId: "test-agent" }, { id: "old-2", agentId: "test-agent" }];
+    const { api, calls } = recordingApi({
+      "GET:/Memory": () => current,
+      "GET:/Soul": () => [{ id: "current-soul", agentId: "test-agent" }],
+    });
+    const r = await applySnapshot({
+      agentId: "test-agent",
+      snapshotPath,
+      flairVersion: "0.0.0-test",
+      apiCall: api,
+      preRestoreSnapshotRoot: snapshotRoot,
+      tmpRootOverride: testRoot,
+      dryRun: true,
+    });
+    expect(r.status).toBe("dry-run");
+    expect(r.deleted.memories).toBe(2);
+    expect(r.deleted.souls).toBe(1);
+    expect(r.restored.memories).toBe(2);
+    expect(r.restored.souls).toBe(1);
+    expect(r.preRestoreSnapshotPath).toBeUndefined();
+    expect(r.errors).toEqual([]);
+
+    // Only GETs happened.
+    const writes = calls.filter((c) => c.method === "DELETE" || c.method === "PUT");
+    expect(writes).toEqual([]);
+  });
+});
+
+describe("applySnapshot — agent-id mismatch", () => {
+  it("refuses to restore when snapshot.metadata.agentId differs from target", async () => {
+    const snapshotPath = await makeTestSnapshot("alice");
+    const { api } = recordingApi();
+    const r = await applySnapshot({
+      agentId: "bob",
+      snapshotPath,
+      flairVersion: "0.0.0-test",
+      apiCall: api,
+      preRestoreSnapshotRoot: snapshotRoot,
+      tmpRootOverride: testRoot,
+    });
+    expect(r.status).toBe("failed");
+    expect(r.errors[0]).toContain("does not match target");
+    expect(r.preRestoreSnapshotPath).toBeUndefined();
+  });
+});
+
+describe("applySnapshot — missing snapshot", () => {
+  it("returns failed when the tarball does not exist", async () => {
+    const { api } = recordingApi();
+    const r = await applySnapshot({
+      agentId: "test-agent",
+      snapshotPath: join(testRoot, "ghost.tar.gz"),
+      flairVersion: "0.0.0-test",
+      apiCall: api,
+      preRestoreSnapshotRoot: snapshotRoot,
+      tmpRootOverride: testRoot,
+    });
+    expect(r.status).toBe("failed");
+    expect(r.errors[0]).toContain("does not exist");
+  });
+});
+
+describe("applySnapshot — real restore", () => {
+  it("creates pre-restore snapshot, deletes current rows, PUTs snapshot rows", async () => {
+    const snapshotPath = await makeTestSnapshot();
+    const current = [{ id: "old-1", agentId: "test-agent" }, { id: "old-2", agentId: "test-agent" }];
+    const { api, calls } = recordingApi({
+      "GET:/Memory": () => current,
+      "GET:/Soul": () => [{ id: "current-soul", agentId: "test-agent" }],
+    });
+
+    const r = await applySnapshot({
+      agentId: "test-agent",
+      snapshotPath,
+      flairVersion: "0.0.0-test",
+      apiCall: api,
+      preRestoreSnapshotRoot: snapshotRoot,
+      tmpRootOverride: testRoot,
+    });
+
+    expect(r.status).toBe("completed");
+    expect(r.errors).toEqual([]);
+    expect(r.deleted.memories).toBe(2);
+    expect(r.deleted.souls).toBe(1);
+    expect(r.restored.memories).toBe(2);
+    expect(r.restored.souls).toBe(1);
+    expect(r.preRestoreSnapshotPath).toBeDefined();
+    expect(existsSync(r.preRestoreSnapshotPath!)).toBe(true);
+
+    // Call ordering: 2 GETs for the pre-restore fetch, then DELETEs (2 mem + 1 soul), then PUTs (2 mem + 1 soul).
+    const writes = calls.filter((c) => c.method === "DELETE" || c.method === "PUT");
+    expect(writes.length).toBe(6);
+    expect(writes.slice(0, 3).every((c) => c.method === "DELETE")).toBe(true);
+    expect(writes.slice(3).every((c) => c.method === "PUT")).toBe(true);
+  });
+
+  it("preRestoreSnapshotPath contains current state for rollback", async () => {
+    const snapshotPath = await makeTestSnapshot();
+    const beforeState = [
+      { id: "current-1", agentId: "test-agent", content: "current" },
+      { id: "current-2", agentId: "test-agent", content: "more current" },
+    ];
+    const { api } = recordingApi({
+      "GET:/Memory": () => beforeState,
+      "GET:/Soul": () => [],
+    });
+
+    const r = await applySnapshot({
+      agentId: "test-agent",
+      snapshotPath,
+      flairVersion: "0.0.0-test",
+      apiCall: api,
+      preRestoreSnapshotRoot: snapshotRoot,
+      tmpRootOverride: testRoot,
+    });
+    expect(r.preRestoreSnapshotPath).toBeDefined();
+
+    // The pre-restore snapshot should contain the BEFORE state.
+    const extractDir = join(testRoot, "extract");
+    const { extractSnapshot } = await import("../src/rem/snapshot.ts");
+    await extractSnapshot({ snapshotPath: r.preRestoreSnapshotPath!, targetDir: extractDir });
+
+    const lines = readFileSync(join(extractDir, "memories.jsonl"), "utf-8")
+      .trim()
+      .split("\n")
+      .map((l) => JSON.parse(l));
+    expect(lines).toEqual(beforeState);
+  });
+});
+
+describe("applySnapshot — failure modes", () => {
+  it("captures PUT errors per-row without aborting", async () => {
+    const snapshotPath = await makeTestSnapshot();
+    const { api } = recordingApi({
+      "GET:/Memory": () => [],
+      "GET:/Soul": () => [],
+      "PUT:/Memory": (_path) => {
+        // Fail the second PUT.
+        const stats = (api as any)._putCount ?? 0;
+        (api as any)._putCount = stats + 1;
+        if (stats === 1) throw new Error("conflict");
+        return { ok: true };
+      },
+    });
+
+    const r = await applySnapshot({
+      agentId: "test-agent",
+      snapshotPath,
+      flairVersion: "0.0.0-test",
+      apiCall: api,
+      preRestoreSnapshotRoot: snapshotRoot,
+      tmpRootOverride: testRoot,
+    });
+
+    expect(r.status).toBe("failed");
+    expect(r.restored.memories).toBe(1); // first PUT succeeded
+    expect(r.errors.some((e) => e.includes("put-memory") && e.includes("conflict"))).toBe(true);
+    // Pre-restore snapshot was still created.
+    expect(r.preRestoreSnapshotPath).toBeDefined();
+    expect(existsSync(r.preRestoreSnapshotPath!)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Why

Implements the load-bearing **"every cycle is reversible"** user feature. Before this PR, `flair rem restore <date>` only extracted the tarball to a directory for inspection — the operator had to manually replay the data into Harper. Now `--apply` actually rewinds Harper state.

## What

### New module: `src/rem/restore.ts`

Client-side orchestration. **No new server endpoint** — uses existing `/Memory` and `/Soul` DELETE+PUT. Avoids the Harper body-size limit on uploading large memory exports inline.

Cycle:
1. Extract snapshot tarball to tmpdir
2. Parse `memories.jsonl` + `soul.json` + `metadata.json`
3. Refuse if `metadata.agentId` differs from target (cross-agent guard)
4. **Create a pre-restore snapshot of CURRENT state** — this restore is itself reversible
5. Fetch + DELETE current memories/souls for the agent
6. PUT snapshot memories/souls back
7. Report counts + pre-restore snapshot path

Per-row failures captured per-row. On any failure, the pre-restore snapshot path is preserved + reported so operator can roll back via `flair rem restore <pre-restore-date> --apply`.

### CLI: `--apply` flag on `flair rem restore`

- Without `--apply`: filesystem extract for inspection (slice-1 behavior)
- With `--apply`: live replay
- With `--apply --dry-run`: reports planned counts without destructive calls

## Live-tested on rockit

```
$ FLAIR_AGENT_ID=flint flair rem restore 2026-05-14 --agent flint --apply --dry-run
(dry-run) flair rem restore --apply
  Status:       dry-run
  Snapshot:     ~/.flair/snapshots/flint/2026-05-14T12-03-43-810Z.tar.gz
  Deleted:      291 memories, 23 souls
  Restored:     289 memories, 23 souls
```

The dry-run accurately reflects the delta (snapshot is 2 memories behind current state).

## Tests

55/55 across the full REM suite (16 snapshot + 16 runner + 17 scheduler + **6 restore**), all pass in ~138ms with no Harper required.

Restore suite (`test/rem-restore.test.ts`):
- Dry-run reports planned counts without destructive calls
- Cross-agent restore is refused (metadata.agentId mismatch)
- Missing snapshot tarball returns `failed`
- Real restore: pre-restore snapshot + DELETEs + PUTs **in order**
- Pre-restore snapshot contains BEFORE state for rollback (verified by extracting it and parsing memories.jsonl)
- PUT errors per-row captured, status=`failed`, pre-restore preserved

## Architectural lenses (for reviewers)

- **Abstraction**: client-side orchestration; no new server resource. Reuses existing `/Memory` and `/Soul` endpoints. Pure DI for `apiCall` + paths so tests are Harper-free.
- **Contract drift**: extends `flair rem restore` with `--apply`; backwards-compatible default behavior (still filesystem extract).
- **Coupling**: restore module imports `extractSnapshot` and `createSnapshot` from `./snapshot.js` (one-way). CLI imports via dynamic `await import()` to keep dist size unaffected.
- **Failure modes**: 
  - Missing tarball → `failed` before any side effect
  - Agent-id mismatch → `failed` before any side effect (cross-agent guard)
  - Pre-restore snapshot creation failure → `failed` before destructive ops
  - Per-row delete/PUT failures → captured per-row, errors[] populated, restored counts reflect what landed, `status: "failed"`
  - Pre-restore snapshot path always reported on real restores so operator can roll back

## Out of scope (slice-2 PR-5)

- Pagination on `/Memory` fetch (Kern #414 nit) — relevant once agent memory count crosses Harper's response-size limit
- `spawnSync` timeout in `src/rem/scheduler.ts` (Sherlock #415 nit)
- Trust-tier filter input arg for `flair rem rapid`
- **Automated nightly distillation deferred to 1.1** per spec § 12 — requires pluggable LLM provider; for 1.0, distillation stays operator-triggered via `flair rem rapid` + manual candidate review

## Checklist

- [x] Tests pass (55/55)
- [x] CHANGELOG entry under Unreleased (slice-2 live-replay section)
- [x] Live-tested end-to-end (dry-run on real agent state)
- [x] Cross-agent guard verified
- [x] Pre-restore snapshot validated as a rollback artifact
- [x] No new dependencies
- [x] No new server endpoints — auth surface unchanged