### PR TITLE
fix(rem): scheduler spawnSync timeout (Sherlock #415) + spec 1.0 deferrals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+### 🛠 FLAIR-NIGHTLY-REM slice-2 PR-5 — scheduler hardening + 1.0 scope clarifications
+
+- **`spawnSync` timeout** in `src/rem/scheduler.ts` — `launchctl bootstrap`/`systemctl enable --now` invocations now cap at 30s so a hung service manager can't block the CLI indefinitely. Per Sherlock's #415 review nit.
+- **Spec § 11 expanded** — documents 1.0 deferrals explicitly: automated nightly distillation (operator runs `flair rem rapid` manually), cross-agent restore, cross-agent reflection, trust-tier input filter, pagination on memory fetch, fail-fast restore (Kern's #418 nit). All ship in 1.1+ as the pluggable distillation provider lands. The 1.0 nightly cycle ships the load-bearing reversibility (snapshot + maintenance + restore) without auto-distillation — distillation stays operator-driven.
+
 ### ✨ FLAIR-NIGHTLY-REM slice-2 — live replay (`flair rem restore --apply`)
 
 - **`flair rem restore <date> --apply`** — actually rewinds Harper state to the snapshot, not just extracts the tarball. Sequential client-side restore: takes a pre-restore snapshot of CURRENT state first (so this restore is itself reversible), then DELETEs current memories/souls for the agent, then PUTs the snapshot rows back. The pre-restore snapshot path is reported so the operator can roll back if something goes wrong mid-flight (`flair rem restore <pre-restore-date> --apply`).

--- a/specs/FLAIR-NIGHTLY-REM.md
+++ b/specs/FLAIR-NIGHTLY-REM.md
@@ -158,9 +158,14 @@ First time `flair rem nightly enable` is run for an agent, the next cycle runs w
 ## § 11 Out of Scope for 1.0
 
 - **Auto-promotion of any candidate.** 1.0 promotions are always human/high-trust-agent. Auto-promotion on high-confidence candidates is 1.1+.
+- **Automated nightly distillation.** Step 5 (distillation via `/ReflectMemories`) is operator-triggered in 1.0 via `flair rem rapid` — that command outputs an LLM prompt the operator or agent feeds to its own model and writes insights back manually. Server-side automated distillation requires a configured chat-completion provider per agent (anthropic / openai / ollama / etc.); pluggable distillation-provider interface lands in 1.1+. The nightly cycle in 1.0 ships the load-bearing reversibility (snapshot + maintenance + restore) without auto-distillation.
 - **Cross-agent reflection.** 1.0 REM only distills from a single agent's memories. Multi-agent reflection (e.g., "what did all reviewers learn this week?") is 1.1+.
+- **Cross-agent restore.** `flair rem restore --apply` refuses if the snapshot's `metadata.agentId` differs from `--agent`. Admin restoring another agent's state lands in 1.1+.
 - **LLM-authored rationale.** The rationale on promote/reject is operator-written. An LLM-drafted rationale the human edits is 1.1+.
 - **Cloud-hosted scheduler.** 1.0 uses platform-native schedulers (launchd/systemd). Fabric-hosted nightly is bundled with Flair-cloud post-1.0.
+- **Trust-tier filter on REM input.** Step 4 (filter input memories to `endorsed`+ tier before distillation) is operator-discipline in 1.0 — when the operator runs `rem rapid`, they choose what to promote based on visible source memories. Server-side trust-tier filter lands with the pluggable distillation provider in 1.1+.
+- **Pagination on memory fetch.** The nightly runner fetches all memories for an agent in a single `GET /Memory?agentId=...` call. Fine for the agents Flair targets in 1.0 (single operator, hundreds-to-low-thousands of memories). Pagination lands when the size envelope demands it.
+- **Fail-fast restore mode.** Per Kern's #418 review, current behavior is per-row-continue (with rollback path via pre-restore snapshot). A `--strict` mode that aborts on first error is a 1.1 follow-up.
 
 ## § 12 Open Questions — Resolved
 

--- a/src/rem/scheduler.ts
+++ b/src/rem/scheduler.ts
@@ -173,8 +173,15 @@ function writeFileWithDir(path: string, contents: string, mode: number = 0o600):
   writeFileSync(path, contents, { mode });
 }
 
+// 30s ceiling on launchctl/systemctl invocations so a hung service manager
+// can't block the CLI indefinitely. Sherlock #415 follow-up.
+const SPAWN_TIMEOUT_MS = 30_000;
+
 function spawnReport(cmd: string[]): { code: number | null; stdout: string; stderr: string } {
-  const r: SpawnSyncReturns<Buffer> = spawnSync(cmd[0], cmd.slice(1), { encoding: "buffer" });
+  const r: SpawnSyncReturns<Buffer> = spawnSync(cmd[0], cmd.slice(1), {
+    encoding: "buffer",
+    timeout: SPAWN_TIMEOUT_MS,
+  });
   return {
     code: r.status,
     stdout: r.stdout?.toString("utf-8") ?? "",


### PR DESCRIPTION
## Why

Small straggler PR wrapping FLAIR-NIGHTLY-REM slice-2:
1. **Sherlock's #415 review nit** — `spawnSync` lacks timeout; a hung service manager would block the CLI indefinitely.
2. **Make 1.0 scope explicit** in the spec so reviewers/operators know exactly what does and doesn't ship in 1.0. Important now that slice-2 PR-3 + PR-4 are merged and operators can use the cycle end-to-end.

## What

### `src/rem/scheduler.ts`

`spawnReport()` now passes `{ timeout: SPAWN_TIMEOUT_MS }` to `spawnSync` (30s). Applies to all `launchctl bootstrap` / `launchctl bootout` / `systemctl --user enable --now` / `systemctl --user daemon-reload` invocations.

Tests unchanged — `skipLoad`/`skipUnload` paths bypass `spawnReport` so the existing 17 scheduler tests still pass without shelling out.

### `specs/FLAIR-NIGHTLY-REM.md` § 11

Expanded the out-of-scope section. Eight items now explicitly deferred to 1.1:

- Automated nightly distillation (1.0 keeps `flair rem rapid` operator-triggered)
- Cross-agent reflection
- Cross-agent restore
- LLM-authored rationale on promote/reject
- Cloud-hosted scheduler
- Trust-tier filter on REM input
- Pagination on memory fetch
- Fail-fast restore mode (Kern #418 nit)

### `CHANGELOG.md`

PR-5 entry under Unreleased with the same content surfaced for operators reading release notes.

## Tests

17/17 on `rem-scheduler.test.ts` (same as before, no test changes — the timeout addition doesn't affect the skipLoad/skipUnload paths).

## Out of scope

- Item-by-item code for the 1.1 deferrals — those land separately when their dependent infrastructure (pluggable LLM provider, federation routing for cross-agent ops) ships.

## Checklist

- [x] Sherlock #415 nit addressed
- [x] Spec 1.0 scope explicit
- [x] CHANGELOG entry
- [x] No behavior change beyond timeout addition
- [x] No new dependencies