### PR TITLE
release: v0.9.0 — FLAIR-NIGHTLY-REM ships

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 0.9.0 (2026-05-14)
+
+> **FLAIR-NIGHTLY-REM ships.** The nightly memory hygiene cycle — snapshot, maintenance, candidate staging, and live replay — is load-bearing on a platform-native scheduler (launchd / systemd). "Every cycle is reversible" is a real property: each nightly run snapshots agent state before any destructive op, and `flair rem restore <date> --apply` rewinds Harper state to any snapshot (with its own pre-restore snapshot for rollback). Slice-1 + slice-2 of the spec land in this release; slice-3 (automated distillation via pluggable LLM provider, trust-tier input filter, fail-fast restore) defers to 1.1.
+
 ### 🛠 FLAIR-NIGHTLY-REM slice-2 PR-5 — scheduler hardening + 1.0 scope clarifications
 
 - **`spawnSync` timeout** in `src/rem/scheduler.ts` — `launchctl bootstrap`/`systemctl enable --now` invocations now cap at 30s so a hung service manager can't block the CLI indefinitely. Per Sherlock's #415 review nit.

--- a/bun.lock
+++ b/bun.lock
@@ -24,20 +24,20 @@
     },
     "packages/flair-client": {
       "name": "@tpsdev-ai/flair-client",
-      "version": "0.8.3",
+      "version": "0.9.0",
       "devDependencies": {
         "typescript": "5.9.3",
       },
     },
     "packages/flair-mcp": {
       "name": "@tpsdev-ai/flair-mcp",
-      "version": "0.8.3",
+      "version": "0.9.0",
       "bin": {
         "flair-mcp": "dist/index.js",
       },
       "dependencies": {
         "@modelcontextprotocol/sdk": "1.27.1",
-        "@tpsdev-ai/flair-client": "0.8.3",
+        "@tpsdev-ai/flair-client": "0.9.0",
         "zod": "4.3.6",
       },
       "devDependencies": {
@@ -46,7 +46,7 @@
     },
     "packages/langgraph-flair": {
       "name": "@tpsdev-ai/langgraph-flair",
-      "version": "0.8.3",
+      "version": "0.9.0",
       "dependencies": {
         "@tpsdev-ai/flair-client": "0.8.3",
       },
@@ -56,7 +56,7 @@
     },
     "packages/n8n-nodes-flair": {
       "name": "@tpsdev-ai/n8n-nodes-flair",
-      "version": "0.8.3",
+      "version": "0.9.0",
       "dependencies": {
         "@tpsdev-ai/flair-client": "0.8.1",
         "zod": "3.25.76",
@@ -75,7 +75,7 @@
     },
     "packages/openclaw-flair": {
       "name": "@tpsdev-ai/openclaw-flair",
-      "version": "0.8.3",
+      "version": "0.9.0",
       "dependencies": {
         "@sinclair/typebox": "0.34.48",
         "@tpsdev-ai/flair-client": "0.8.3",
@@ -89,7 +89,7 @@
     },
     "packages/pi-flair": {
       "name": "@tpsdev-ai/pi-flair",
-      "version": "0.8.3",
+      "version": "0.9.0",
       "dependencies": {
         "@sinclair/typebox": "0.34.48",
         "@tpsdev-ai/flair-client": "0.8.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tpsdev-ai/flair",
-  "version": "0.8.3",
+  "version": "0.9.0",
   "description": "Identity, memory, and soul for AI agents. Cryptographic identity (Ed25519), semantic memory with local embeddings, and persistent personality — all in a single process.",
   "type": "module",
   "license": "Apache-2.0",

--- a/packages/flair-client/package.json
+++ b/packages/flair-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tpsdev-ai/flair-client",
-  "version": "0.8.3",
+  "version": "0.9.0",
   "description": "Lightweight client for Flair — identity, memory, and soul for AI agents. Zero heavy dependencies.",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/flair-mcp/package.json
+++ b/packages/flair-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tpsdev-ai/flair-mcp",
-  "version": "0.8.3",
+  "version": "0.9.0",
   "description": "MCP server for Flair — persistent memory for Claude Code, Cursor, and any MCP client.",
   "type": "module",
   "main": "dist/index.js",
@@ -25,7 +25,7 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "1.27.1",
-    "@tpsdev-ai/flair-client": "0.8.3",
+    "@tpsdev-ai/flair-client": "0.9.0",
     "zod": "4.3.6"
   },
   "license": "Apache-2.0",

--- a/packages/langgraph-flair/package.json
+++ b/packages/langgraph-flair/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tpsdev-ai/langgraph-flair",
-  "version": "0.8.3",
+  "version": "0.9.0",
   "description": "LangGraph BaseStore adapter backed by Flair — durable agent memory with crypto-pinned identity, federation, and cross-orchestrator portability.",
   "type": "module",
   "main": "dist/index.js",
@@ -36,7 +36,7 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
-    "@tpsdev-ai/flair-client": "0.8.3"
+    "@tpsdev-ai/flair-client": "0.9.0"
   },
   "peerDependencies": {
     "@langchain/langgraph-checkpoint": ">=0.0.10"

--- a/packages/n8n-nodes-flair/package.json
+++ b/packages/n8n-nodes-flair/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tpsdev-ai/n8n-nodes-flair",
-  "version": "0.8.3",
+  "version": "0.9.0",
   "description": "n8n community node — use Flair as your AI Agent's memory backend. Includes FlairChatMemory (Memory port) and FlairSearch (Tool port).",
   "type": "commonjs",
   "main": "dist/index.js",
@@ -48,7 +48,7 @@
     "langchain"
   ],
   "dependencies": {
-    "@tpsdev-ai/flair-client": "0.8.3",
+    "@tpsdev-ai/flair-client": "0.9.0",
     "zod": "3.25.76"
   },
   "peerDependencies": {

--- a/packages/openclaw-flair/package.json
+++ b/packages/openclaw-flair/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tpsdev-ai/openclaw-flair",
-  "version": "0.8.3",
+  "version": "0.9.0",
   "description": "OpenClaw memory plugin for Flair — agent identity and semantic memory",
   "type": "module",
   "main": "./dist/index.js",
@@ -58,7 +58,7 @@
   },
   "dependencies": {
     "@sinclair/typebox": "0.34.48",
-    "@tpsdev-ai/flair-client": "0.8.3"
+    "@tpsdev-ai/flair-client": "0.9.0"
   },
   "devDependencies": {
     "typescript": "5.9.3"

--- a/packages/pi-flair/package.json
+++ b/packages/pi-flair/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tpsdev-ai/pi-flair",
-  "version": "0.8.3",
+  "version": "0.9.0",
   "description": "Flair memory extension for pi — persistent memory access from within pi sessions",
   "type": "module",
   "main": "dist/index.js",
@@ -21,7 +21,7 @@
     "node": ">=18"
   },
   "dependencies": {
-    "@tpsdev-ai/flair-client": "0.8.3",
+    "@tpsdev-ai/flair-client": "0.9.0",
     "@sinclair/typebox": "0.34.48"
   },
   "license": "Apache-2.0",

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -228,7 +228,18 @@ git -C "$ROOT" add \
   "$ROOT/packages/openclaw-flair/package.json" \
   "$ROOT/packages/pi-flair/package.json" \
   "$ROOT/packages/n8n-nodes-flair/package.json" \
+  "$ROOT/packages/langgraph-flair/package.json" \
   "$ROOT/bun.lock"
+
+# Also stage CHANGELOG.md and scripts/release.sh if they have pre-staged changes —
+# operators routinely write the release notes before invoking this script, and
+# script bugfixes (like the missing langgraph-flair stage line, 2026-05-14) need
+# to ride along with the release that surfaces them.
+for extra in "$ROOT/CHANGELOG.md" "$ROOT/scripts/release.sh"; do
+  if ! git -C "$ROOT" diff --quiet -- "$extra"; then
+    git -C "$ROOT" add "$extra"
+  fi
+done
 git -C "$ROOT" commit -m "release: v${VERSION} — align all workspace packages"
 
 if [[ "$MODE" == "--dry" ]]; then


### PR DESCRIPTION
## Why

Cuts v0.9.0. **FLAIR-NIGHTLY-REM (slice-1 + slice-2) is the headline feature.** Eight PRs merged today (#414/#415/#416/#418/#419/#417/admin UI batch from yesterday) wrap into a minor-version bump.

## What

Workspace bump 0.8.3 → 0.9.0 across all 7 packages + `bun.lock`.

CHANGELOG `Unreleased` section moved to `0.9.0 (2026-05-14)` with a top-line summary callout. The detailed entries (FLAIR-NIGHTLY-REM slice-1 PR-1 through slice-2 PR-5, admin UI 1.0 milestone batch, federation status polish, docs callouts) are preserved verbatim.

## Side-fixes riding along

**`scripts/release.sh`** — two-line fix caught during this release prep:

1. The git-add list omitted `packages/langgraph-flair/package.json`, so the dry-run committed bumps for 6 of 7 packages, leaving langgraph-flair desync'd from the workspace. Caught when the pre-commit `workspace-deps` hook rejected the next change.
2. Added opportunistic staging of `CHANGELOG.md` + `scripts/release.sh` so the release commit can carry related fixes (the release-script bugfix in this PR rides this lane).

## Capstone live-test

Full nightly cycle validated end-to-end on rockit before cutting the release:

```
$ flair rem nightly enable --agent flint --at 03:00
✅ Enabled (launchctl bootstrap ok)

$ flair rem nightly run-once  
Snapshot:   ~/.flair/snapshots/flint/2026-05-14T15-14-00-703Z.tar.gz
Memories:   291
Archived:   12         # 12 stale standard session memories archived live
Expired:    0
Duration:   679ms

$ flair rem nightly run-once  # idempotency check
Archived:   0          # ✅ already-archived rows skipped
```

12 memories were actually archived in Harper. Re-running showed 0 (idempotent). End-to-end validated.

## Tests

930/930 unit+integration tests pass. REM suite alone: 55/55.

## Publish flow

This is the **phase-1 PR**. After K&S + merge to main, Nathan runs:

```sh
./scripts/release.sh 0.9.0 --publish
```

…from his machine to publish all 7 packages to npm in dep order.

## Checklist

- [x] All package versions aligned at 0.9.0
- [x] Internal `@tpsdev-ai/flair-client` deps aligned at 0.9.0
- [x] `bun.lock` regenerated
- [x] Build clean (`bun run build` + `bun run build:cli`)
- [x] Tests pass (930/930)
- [x] CHANGELOG cut with 0.9.0 dated header + headline callout
- [x] `scripts/release.sh` git-add bug fixed
- [x] Live-tested nightly cycle on rockit
- [x] Idempotency verified