### PR TITLE
feat(backup): add --admin-pass-file flag (closes ops-147)

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -7350,14 +7350,25 @@ program
   .option("--agents <ids>", "Comma-separated agent IDs to include (default: all)")
   .option("--port <port>", "Harper HTTP port")
   .option("--url <url>", "Flair base URL (overrides --port)")
-  .option("--admin-pass <pass>", "Admin password (or set FLAIR_ADMIN_PASS env)")
+  .option("--admin-pass <pass>", "Admin password (or set FLAIR_ADMIN_PASS env, or use --admin-pass-file)")
+  .option("--admin-pass-file <path>", "Read admin password from a file (e.g., ~/.flair/admin-pass). Preferred over --admin-pass for launchd/cron — keeps the secret out of ps and shell history.")
   .action(async (opts) => {
     const baseUrl: string = opts.url ?? `http://127.0.0.1:${resolveHttpPort(opts)}`;
-    const adminPass: string = opts.adminPass ?? process.env.FLAIR_ADMIN_PASS ?? "";
+    let adminPass: string = opts.adminPass ?? process.env.FLAIR_ADMIN_PASS ?? "";
+    if (!adminPass && opts.adminPassFile) {
+      // Pull from file. Trim trailing newlines — common gotcha for files
+      // generated via `openssl rand -base64 24 > admin-pass`.
+      try {
+        adminPass = readFileSync(opts.adminPassFile, "utf-8").replace(/\s+$/, "");
+      } catch (err: any) {
+        console.error(`Error reading --admin-pass-file ${opts.adminPassFile}: ${err.message}`);
+        process.exit(1);
+      }
+    }
     const adminUser = DEFAULT_ADMIN_USER;
 
     if (!adminPass) {
-      console.error("Error: --admin-pass or FLAIR_ADMIN_PASS required for backup");
+      console.error("Error: --admin-pass, --admin-pass-file, or FLAIR_ADMIN_PASS required for backup");
       process.exit(1);
     }
 


### PR DESCRIPTION
## Summary

`flair backup` accepts admin credentials three ways now:
1. `--admin-pass <value>` (cli arg — visible in shell history + `ps eww`)
2. `FLAIR_ADMIN_PASS` env var (better, but visible in `/proc/<pid>/environ`)
3. `--admin-pass-file <path>` (**NEW** — secret stays on disk only)

The file path is the right shape for launchd / systemd / cron contexts: the password lives in `~/.flair/admin-pass` (mode 600), the unit invokes `flair backup --admin-pass-file ~/.flair/admin-pass`, and rotations work by overwriting the file in place — no plist edit, no env-var rotation.

## Why now

Productizes the wrapper script I built 2026-05-16 at `~/agents/flint/bin/flair-backup.sh` to escape the inline-cleartext plist anti-pattern that caused 60+ days of silent backup failures.

## Verification

- ✅ No password → clear error mentioning all 3 sources
- ✅ Missing file → graceful ENOENT error
- ✅ Valid file → reads, trims trailing whitespace, uses for auth

Closes ops-147.

🤖 Generated with [Claude Code](https://claude.com/claude-code)