### PR TITLE
fix(federation): stop the re-upsert blob loop (task #146 + receiver gate)

### DIFF
--- a/resources/Federation.ts
+++ b/resources/Federation.ts
@@ -386,6 +386,25 @@ export class FederationSync extends Resource {
           continue;
         }
 
+        // No-op skip: if the local record exists, has the same contentHash, and
+        // the remote isn't strictly newer, the sync is a phantom — same bytes,
+        // same logical version. Writing it anyway re-blobs the HNSW embedding
+        // (BlobDB stores each version separately) and bloats the dataset
+        // quadratically with poll frequency. Caught 2026-05-19 after the
+        // Fabric cluster hit its 4.7G XFS quota with 5,899 blob entries
+        // across 109 unique IDs (~54 versions per live record).
+        const remoteContentHash = (record.data as any)?.contentHash;
+        if (
+          local &&
+          local.contentHash &&
+          remoteContentHash &&
+          local.contentHash === remoteContentHash &&
+          record.updatedAt <= (local.updatedAt ?? "")
+        ) {
+          skipped++;
+          continue;
+        }
+
         const mergedData = mergeRecord(local, record);
 
         // Preserve originator for provenance

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -3358,6 +3358,12 @@ export async function runFederationSyncOnce(opts: any): Promise<{ pushed: number
 
     console.log(`Syncing to hub: ${hub.id}...`);
     const since = hub.lastSyncAt ?? new Date(0).toISOString();
+    // Capture sync start time BEFORE we query records. We advance the local
+    // hub peer's lastSyncAt to this value after success so the next poll's
+    // `since` cursor moves forward — fixes task #146 (federation peer
+    // .lastSyncAt update bug). Records updated DURING this sync will have
+    // updatedAt > syncStartedAt and be picked up next cycle, not missed.
+    const syncStartedAt = new Date().toISOString();
     const opsEndpoint = resolveEffectiveOpsUrl(opts) ?? `http://127.0.0.1:${resolveOpsPort(opts)}`;
     const adminPass: string = opts.adminPass ?? process.env.FLAIR_ADMIN_PASS ?? "";
     const auth = `Basic ${Buffer.from(`${DEFAULT_ADMIN_USER}:${adminPass}`).toString("base64")}`;
@@ -3442,6 +3448,35 @@ export async function runFederationSyncOnce(opts: any): Promise<{ pushed: number
         totalSkipped += result.skipped;
         totalBatches++;
       }
+    }
+
+    // Advance the local hub peer's lastSyncAt cursor. The hub-side
+    // FederationSync handler updates ITS view of the spoke peer, but the
+    // spoke never updated its own view of the hub — so `since` stayed at
+    // whatever value was on the peer record at pair time (often near-epoch),
+    // and every poll re-queried `updatedAt > since` and re-sent every
+    // memory ever written. The receiver-side contentHash gate in
+    // Federation.ts prevents the actual blob re-write, but advancing the
+    // cursor here stops the redundant network traffic + Lambda compute
+    // entirely. Task #146. Even no-change runs should advance.
+    try {
+      const advanceRes = await fetch(`${opsEndpoint}/`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json", Authorization: auth },
+        body: JSON.stringify({
+          operation: "update",
+          database: "flair",
+          table: "Peer",
+          records: [{ id: hub.id, lastSyncAt: syncStartedAt }],
+        }),
+        signal: AbortSignal.timeout(10_000),
+      });
+      if (!advanceRes.ok) {
+        const txt = await advanceRes.text().catch(() => "");
+        console.warn(`⚠️  Local hub.lastSyncAt advance failed (${advanceRes.status}): ${txt.slice(0, 200)}. Next poll will re-send memories.`);
+      }
+    } catch (advErr: any) {
+      console.warn(`⚠️  Local hub.lastSyncAt advance error: ${advErr?.message ?? advErr}. Next poll will re-send memories.`);
     }
 
     if (totalBatches === 0) {

--- a/test/integration/federation-sync-e2e.test.ts
+++ b/test/integration/federation-sync-e2e.test.ts
@@ -94,6 +94,21 @@ describe("FederationSync resource logic (transitional)", () => {
 
       if (local && local.updatedAt && local.updatedAt > ts) { skipped++; continue; }
 
+      // contentHash gate (matches Federation.ts production code) — skip the
+      // write if local and remote agree on contentHash and remote isn't
+      // strictly newer. Prevents the federation-watch re-upsert loop.
+      const remoteContentHash = (record.data as any)?.contentHash;
+      if (
+        local &&
+        local.contentHash &&
+        remoteContentHash &&
+        local.contentHash === remoteContentHash &&
+        ts <= (local.updatedAt ?? "")
+      ) {
+        skipped++;
+        continue;
+      }
+
       const mergedData = {
         ...(record.data ?? {}),
         id: record.id,
@@ -338,5 +353,123 @@ describe("FederationSync resource logic (transitional)", () => {
 
     const updated = memoryGet("mem-1");
     expect(updated.content).toBe("new");
+  });
+
+  test("re-sync of identical record (same contentHash, same updatedAt) is skipped — no re-blob loop", async () => {
+    // Regression for the federation-watch re-upsert loop diagnosed 2026-05-19:
+    // sender's `since` cursor never advanced, so every poll re-sent every
+    // memory. Receiver was put-ing each one, generating fresh HNSW vector
+    // blobs every cycle. Fabric cluster hit XFS quota with 5,899 blob
+    // entries across 109 unique IDs. The contentHash gate stops the
+    // re-blob even if the sender keeps re-sending.
+    const kp = nacl.sign.keyPair();
+    const instanceId = "spoke-resync";
+    peerStore.set(instanceId, {
+      id: instanceId,
+      publicKey: Buffer.from(kp.publicKey).toString("base64url"),
+      role: "spoke",
+      status: "paired",
+    });
+
+    const ts = new Date().toISOString();
+    const record = {
+      table: "Memory",
+      id: "mem-resync-1",
+      data: {
+        id: "mem-resync-1",
+        content: "stable content",
+        contentHash: "sha256-abc123",
+      },
+      updatedAt: ts,
+      originatorInstanceId: instanceId,
+    };
+
+    // First sync: record should land in memoryStore.
+    const first = await handleSyncRequest(
+      signBodyFresh(
+        { instanceId, records: [record], lamportClock: Date.now() },
+        kp.secretKey,
+      ),
+    );
+    expect(first.status).toBe(200);
+    expect(first.body.merged).toBe(1);
+    expect(first.body.skipped).toBe(0);
+
+    // The mock memoryPut doesn't propagate contentHash by default; mirror
+    // the production receiver-side merge by ensuring the stored record
+    // carries contentHash (Federation.ts's mergeRecord spreads record.data).
+    const stored = memoryGet("mem-resync-1");
+    expect(stored.contentHash).toBe("sha256-abc123");
+
+    // Second sync: same record sent again. Should be SKIPPED, not merged.
+    // Without the gate this writes a new blob version with the embedding.
+    const second = await handleSyncRequest(
+      signBodyFresh(
+        { instanceId, records: [record], lamportClock: Date.now() + 1 },
+        kp.secretKey,
+      ),
+    );
+    expect(second.status).toBe(200);
+    expect(second.body.merged).toBe(0);
+    expect(second.body.skipped).toBe(1);
+  });
+
+  test("re-sync with newer updatedAt but same contentHash still gets stored (real edit-then-revert case)", async () => {
+    // Edge case: contentHash matches but remote has strictly newer
+    // updatedAt. Could mean the record was edited and reverted, or just
+    // metadata-changed. We still write so the updatedAt advances; LWW
+    // merge wins the latest provenance. The gate only skips when
+    // remote.updatedAt <= local.updatedAt.
+    const kp = nacl.sign.keyPair();
+    const instanceId = "spoke-resync-newer";
+    peerStore.set(instanceId, {
+      id: instanceId,
+      publicKey: Buffer.from(kp.publicKey).toString("base64url"),
+      role: "spoke",
+      status: "paired",
+    });
+
+    const initial = new Date(Date.now() - 60_000).toISOString();
+    const later = new Date().toISOString();
+
+    // Initial
+    await handleSyncRequest(
+      signBodyFresh(
+        {
+          instanceId,
+          records: [{
+            table: "Memory",
+            id: "mem-edit-revert",
+            data: { id: "mem-edit-revert", content: "x", contentHash: "sha-x" },
+            updatedAt: initial,
+            originatorInstanceId: instanceId,
+          }],
+          lamportClock: Date.now(),
+        },
+        kp.secretKey,
+      ),
+    );
+
+    // Same contentHash but newer timestamp
+    const second = await handleSyncRequest(
+      signBodyFresh(
+        {
+          instanceId,
+          records: [{
+            table: "Memory",
+            id: "mem-edit-revert",
+            data: { id: "mem-edit-revert", content: "x", contentHash: "sha-x" },
+            updatedAt: later,
+            originatorInstanceId: instanceId,
+          }],
+          lamportClock: Date.now() + 1,
+        },
+        kp.secretKey,
+      ),
+    );
+
+    expect(second.status).toBe(200);
+    expect(second.body.merged).toBe(1);
+    expect(second.body.skipped).toBe(0);
   });
 });

--- a/test/integration/federation-watch.test.ts
+++ b/test/integration/federation-watch.test.ts
@@ -120,7 +120,14 @@ describe("federation watch", () => {
         );
       }
       if (init?.method === "POST" && !url.includes("/FederationSync")) {
-        syncCalls++;
+        // Distinguish search_by_conditions (one per table per sync) from
+        // the lastSyncAt cursor-advance update (one per sync, added in
+        // task #146 fix). Test only counts the per-table search ops.
+        let opType: string | undefined;
+        try { opType = JSON.parse(String(init?.body ?? "{}"))?.operation; } catch { /* ignore */ }
+        if (opType === "search_by_conditions") {
+          syncCalls++;
+        }
         return new Response(JSON.stringify([]), {
           status: 200,
           headers: { "content-type": "application/json" },
@@ -137,7 +144,9 @@ describe("federation watch", () => {
     const elapsed = Date.now() - start;
 
     // With interval clamped to 5s, we should only see 1 sync run in 500ms.
-    // Each sync run issues 4 ops POSTs (one per table: Memory, Soul, Agent, Relationship).
+    // Each sync run issues 4 search_by_conditions POSTs (one per table:
+    // Memory, Soul, Agent, Relationship). The Peer.update for cursor
+    // advancement is NOT counted (filtered above) — orthogonal concern.
     expect(syncCalls).toBe(4);
     expect(elapsed).toBeLessThan(1000);
   });


### PR DESCRIPTION
## Summary

The federation-watch poll has been re-sending and re-storing every memory every 5 minutes for weeks, generating a fresh HNSW vector blob in BlobDB on each cycle. Diagnosed 2026-05-19 after our Fabric cluster hit its 4.7G XFS quota and crash-looped on EDQUOT — RocksDB BlobDB held **5,899 memory-version entries across 109 unique IDs** (~54 versions per live record).

This PR fixes both halves of the bug.

## Root cause

**Bug 1 (sender, task #146):** `runFederationSyncOnce` in `src/cli.ts` computes the query cutoff as `since = hub.lastSyncAt`. After a successful sync, the receiver updates ITS view of the spoke peer's `lastSyncAt` — but the spoke never updates its own view of the hub. The local `hub.lastSyncAt` stays at the value it had at pair time (often near-epoch), so every poll re-queries `updatedAt > epoch` and re-ships everything.

**Bug 2 (receiver):** `FederationSync` in `resources/Federation.ts` calls `table.put(mergedData)` for every record. Even when content is identical, the merge stamps `_syncedAt = now`, so the put writes a new RocksDB version → fresh HNSW vector blob. With bug #1 firing every 5 min, every memory got re-blobbed on every poll.

## Fix

### `resources/Federation.ts` (receiver gate)

Before `table.put`, skip when local and remote agree on contentHash AND remote isn't strictly newer:

```ts
if (local && local.contentHash && remoteContentHash &&
    local.contentHash === remoteContentHash &&
    record.updatedAt <= (local.updatedAt ?? "")) {
  skipped++;
  continue;
}
```

Defense-in-depth — even if a spoke's `since` cursor lags (legacy peers, recovery scenarios), the receiver won't churn the blob store.

### `src/cli.ts` (sender cursor advancement, task #146)

Capture `syncStartedAt` BEFORE the query, then after batches succeed, advance the local hub Peer's `lastSyncAt` via Harper's ops API. Records updated DURING the sync still have `updatedAt > syncStartedAt` and ship next cycle — no records missed.

Note: the advancement is best-effort. On failure we warn but don't fail the sync; next poll will re-send (which the receiver gate will then dedup).

## Test plan

`test/integration/federation-sync-e2e.test.ts`:

- [x] Mock receiver mirrors the contentHash gate (consistent with production code path).
- [x] **New: \"re-sync of identical record is skipped\"** — same record sent twice; second call returns `merged=0, skipped=1`. Without the gate this would re-blob.
- [x] **New: \"re-sync with newer updatedAt but same contentHash still gets stored\"** — gate only skips when remote isn't strictly newer; edit-then-revert advances cleanly.
- [x] 12/12 tests pass (10 existing + 2 new).
- [x] Local `tsc --noEmit` clean against my changes (one pre-existing strict error in `auth-middleware.ts` line 118 is on main).

## Operational follow-up (not in this PR)

Fabric's RocksDB needs blob-GC + a one-shot compaction post-merge to reclaim the 200M pile + 3G of transaction logs. That's an ops action on the Fabric host. Nathan is handling the unstick separately.

## Related

- Closes task #146 (\"flair federation peer.lastSyncAt update bug\")
- Adjacent: the Fabric 4.7G XFS quota itself is worth a HarperDB ticket — Flair workloads will hit this ceiling again with normal growth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)