### PR TITLE
feat(search): rich filters + --explain + --json for flair search

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -5144,6 +5144,259 @@ statusCmd
     if (b.lastExport) console.log(`  Last export: ${relativeTime(b.lastExport)}`);
   });
 
+// ─── flair status --deep ──────────────────────────────────────────────────────
+//
+// Deeper observability than the default `flair status` summary — full
+// per-section detail with no condensing. Optional --bootstrap measures
+// cold-start context bytes per agent (slow; calls /MemoryBootstrap once per
+// agent, admin-auth required).
+//
+// Addresses ops-yph: Nathan's 2026-04-22 ask for "how much storage does my
+// memory take, how much context are bootstraps pulling, what's the real usage
+// pattern" — questions the default `flair status` summarizes but doesn't
+// surface in full. Agents should be able to self-audit via this too.
+
+statusCmd
+  .command("deep")
+  .description("Verbose status + optional bootstrap context size per agent (ops-yph)")
+  .option("--bootstrap", "Also measure bootstrap context bytes per agent (slow; admin auth required)")
+  .option("--max-tokens <n>", "Bootstrap maxTokens cap when --bootstrap is set", "4000")
+  .action(async function (this: Command) {
+    const opts = this.optsWithGlobals();
+    const { healthy, baseUrl, healthData } = await fetchHealthDetail(opts);
+
+    if (!healthy) {
+      if (opts.json) {
+        console.log(JSON.stringify({ healthy: false, url: baseUrl, error: "unreachable" }, null, 2));
+      } else {
+        console.log(`Flair v${__pkgVersion} — 🔴 unreachable`);
+        console.log(`  URL:  ${baseUrl}`);
+        console.log(`\n  Run: flair start  or  flair doctor`);
+      }
+      process.exit(1);
+    }
+
+    // Optional: per-agent bootstrap context bytes. Calls /MemoryBootstrap with
+    // admin auth (so we can measure on behalf of any agent without holding
+    // their keys). 15s timeout per call — bootstrap can be expensive on cold
+    // caches or large memory sets.
+    const agentList: string[] =
+      (Array.isArray(healthData?.agents?.names) && healthData.agents.names.length > 0
+        ? healthData.agents.names
+        : Array.isArray(healthData?.agents?.perAgent)
+          ? healthData.agents.perAgent.map((r: any) => r.id).filter(Boolean)
+          : []) as string[];
+    const bootstrapBytes: Record<string, { bytes: number; tokenEstimate?: number; memoriesIncluded?: number; error?: string }> = {};
+    if (opts.bootstrap && agentList.length > 0) {
+      const adminPass = process.env.HDB_ADMIN_PASSWORD || process.env.FLAIR_ADMIN_PASS;
+      if (!adminPass) {
+        if (!opts.json) {
+          console.log("⚠ --bootstrap requires HDB_ADMIN_PASSWORD or FLAIR_ADMIN_PASS env var");
+        }
+      } else {
+        const auth = `Basic ${Buffer.from(`${DEFAULT_ADMIN_USER}:${adminPass}`).toString("base64")}`;
+        const maxTokens = Number.parseInt(String(opts.maxTokens ?? "4000"), 10);
+        for (const agentId of agentList) {
+          try {
+            const res = await fetch(`${baseUrl}/BootstrapMemories`, {
+              method: "POST",
+              headers: { "Content-Type": "application/json", Authorization: auth },
+              body: JSON.stringify({ agentId, maxTokens }),
+              signal: AbortSignal.timeout(15000),
+            });
+            const text = await res.text();
+            const bytes = Buffer.byteLength(text, "utf8");
+            let tokenEstimate: number | undefined;
+            let memoriesIncluded: number | undefined;
+            try {
+              const json = JSON.parse(text);
+              tokenEstimate = typeof json.tokenEstimate === "number" ? json.tokenEstimate : undefined;
+              memoriesIncluded = typeof json.memoriesIncluded === "number" ? json.memoriesIncluded : undefined;
+            } catch { /* response wasn't JSON; bytes still valid */ }
+            if (!res.ok) {
+              bootstrapBytes[agentId] = { bytes, error: `HTTP ${res.status}` };
+            } else {
+              bootstrapBytes[agentId] = { bytes, tokenEstimate, memoriesIncluded };
+            }
+          } catch (e: any) {
+            bootstrapBytes[agentId] = { bytes: 0, error: e?.message ?? String(e) };
+          }
+        }
+      }
+    }
+
+    if (opts.json) {
+      const out: Record<string, any> = { healthy, url: baseUrl, flairVersion: __pkgVersion, ...healthData };
+      if (opts.bootstrap) out.bootstrapBytes = bootstrapBytes;
+      console.log(JSON.stringify(out, null, 2));
+      return;
+    }
+
+    // Human-readable verbose render.
+    const uptimeSec = healthData?.uptimeSeconds;
+    let uptimeStr = "";
+    if (uptimeSec != null) {
+      const d = Math.floor(uptimeSec / 86400);
+      const h = Math.floor((uptimeSec % 86400) / 3600);
+      const m = Math.floor((uptimeSec % 3600) / 60);
+      uptimeStr = d > 0 ? `${d}d ${h}h` : h > 0 ? `${h}h ${m}m` : `${m}m`;
+    }
+    const pid = healthData?.pid ?? "?";
+
+    console.log(`Flair v${__pkgVersion} — running (PID ${pid}${uptimeStr ? `, uptime ${uptimeStr}` : ""})`);
+    console.log(`URL: ${baseUrl}`);
+
+    const memories = healthData?.memories;
+    if (memories) {
+      console.log("\n═══ Memory ═══════════════════════════════════════");
+      console.log(`Total:        ${memories.total}`);
+      console.log(`Breakdown:    ${memories.withEmbeddings ?? 0} embedded, ${memories.hashFallback ?? 0} hash-fallback`);
+      if (memories.modelCounts && memories.total > 0) {
+        const entries = Object.entries(memories.modelCounts as Record<string, number>)
+          .filter(([, n]) => n > 0)
+          .sort((a, b) => b[1] - a[1]);
+        for (const [k, n] of entries) {
+          const pct = ((n / memories.total) * 100).toFixed(1);
+          console.log(`  ${k.padEnd(28)} ${String(n).padStart(6)}  (${pct}%)`);
+        }
+      }
+      if (memories.byDurability) {
+        const d = memories.byDurability;
+        console.log(`Durability:   ${d.permanent ?? 0} permanent / ${d.persistent ?? 0} persistent / ${d.standard ?? 0} standard / ${d.ephemeral ?? 0} ephemeral`);
+      }
+      console.log(`Archived:     ${memories.archived ?? 0}`);
+      console.log(`Expired:      ${memories.expired ?? 0}`);
+      if (healthData?.lastWrite) console.log(`Last write:   ${relativeTime(healthData.lastWrite)} (${healthData.lastWrite})`);
+    }
+
+    const agents = healthData?.agents;
+    if (agents && agents.count > 0) {
+      console.log("\n═══ Agents ═══════════════════════════════════════");
+      console.log(`Total:        ${agents.count}`);
+      if (Array.isArray(agents.names) && agents.names.length > 0) {
+        console.log(`Names:        ${agents.names.join(", ")}`);
+      }
+      if (Array.isArray(agents.perAgent) && agents.perAgent.length > 0) {
+        const idW = Math.max(2, ...agents.perAgent.map((r: any) => (r.id ?? "").length));
+        console.log(`\n  ${"id".padEnd(idW)}  memories  hash_fb  24h  last_write`);
+        for (const r of agents.perAgent) {
+          const fb = typeof r.hashFallback === "number" ? String(r.hashFallback) : "—";
+          const w24 = typeof r.writes24h === "number" ? String(r.writes24h) : "—";
+          console.log(
+            `  ${(r.id ?? "").padEnd(idW)}  ${String(r.memoryCount).padStart(8)}  ${fb.padStart(7)}  ${w24.padStart(3)}  ${relativeTime(r.lastWriteAt)}`,
+          );
+        }
+      }
+    }
+
+    // Bootstrap context section — always printed so users see how to opt in.
+    console.log("\n═══ Bootstrap context ═══════════════════════════");
+    if (!opts.bootstrap) {
+      console.log("  (not measured — pass --bootstrap to fetch per-agent context bytes)");
+    } else if (Object.keys(bootstrapBytes).length === 0) {
+      console.log("  (no agents found, or admin pass missing — see HDB_ADMIN_PASSWORD)");
+    } else {
+      const idW = Math.max(5, ...Object.keys(bootstrapBytes).map((id) => id.length));
+      console.log(`  ${"agent".padEnd(idW)}  ${"bytes".padStart(9)}  ${"~tokens".padStart(7)}  ${"mems".padStart(4)}  status`);
+      // Sort by bytes desc so heaviest bootstraps surface first.
+      const sortedEntries = Object.entries(bootstrapBytes).sort(
+        (a, b) => (b[1].bytes ?? 0) - (a[1].bytes ?? 0),
+      );
+      for (const [agentId, info] of sortedEntries) {
+        const bytesStr = info.error ? "error" : humanBytes(info.bytes);
+        const tok = info.tokenEstimate != null ? String(info.tokenEstimate) : "—";
+        const mems = info.memoriesIncluded != null ? String(info.memoriesIncluded) : "—";
+        const status = info.error ? info.error.slice(0, 40) : "ok";
+        console.log(`  ${agentId.padEnd(idW)}  ${bytesStr.padStart(9)}  ${tok.padStart(7)}  ${mems.padStart(4)}  ${status}`);
+      }
+    }
+
+    if (healthData?.relationships) {
+      const r = healthData.relationships;
+      console.log("\n═══ Relationships ═══════════════════════════════");
+      console.log(`Total:        ${r.total} (${r.active} active)`);
+    }
+
+    if (healthData?.soul && healthData.soul.total > 0) {
+      const s = healthData.soul;
+      const bp = s.byPriority ?? {};
+      console.log("\n═══ Soul ═════════════════════════════════════════");
+      console.log(`Total:        ${s.total} entries`);
+      console.log(`Priority:     ${bp.critical ?? 0} critical / ${bp.high ?? 0} high / ${bp.standard ?? 0} standard / ${bp.low ?? 0} low`);
+    } else if (typeof healthData?.soulEntries === "number" && healthData.soulEntries > 0) {
+      console.log("\n═══ Soul ═════════════════════════════════════════");
+      console.log(`Total:        ${healthData.soulEntries} entries`);
+    }
+
+    if (healthData?.rem) {
+      const r = healthData.rem;
+      console.log("\n═══ REM ══════════════════════════════════════════");
+      console.log(`Last light:        ${relativeTime(r.lastLightAt)}`);
+      console.log(`Last rapid:        ${relativeTime(r.lastRapidAt)}`);
+      console.log(`Last restorative:  ${relativeTime(r.lastRestorativeAt)}`);
+      const nightly = r.nightlyEnabled === true ? "enabled" : r.nightlyEnabled === false ? "disabled" : "unknown";
+      console.log(`Nightly:           ${nightly}`);
+      if (r.lastNightlyAt) console.log(`Last nightly:      ${relativeTime(r.lastNightlyAt)} (${r.lastNightlyAt})`);
+      if (typeof r.pendingCandidates === "number") console.log(`Pending candidates: ${r.pendingCandidates}`);
+    }
+
+    if (healthData?.federation) {
+      const f = healthData.federation;
+      console.log("\n═══ Federation ═══════════════════════════════════");
+      if (f.instance) console.log(`Instance:     ${f.instance.id} (${f.instance.role ?? "—"}, ${f.instance.status ?? "—"})`);
+      if (f.peers) console.log(`Peers:        ${f.peers.total} total (${f.peers.connected} connected, ${f.peers.disconnected} down, ${f.peers.revoked} revoked)`);
+      if (typeof f.pendingTokens === "number" && f.pendingTokens > 0) console.log(`Pairing:      ${f.pendingTokens} unconsumed token(s)`);
+      if (Array.isArray(f.peerList) && f.peerList.length > 0) {
+        const idW = Math.max(4, ...f.peerList.map((p: any) => (p.id ?? "").length));
+        console.log(`\n  ${"peer".padEnd(idW)}  ${"role".padEnd(5)}  ${"status".padEnd(13)}  last_sync`);
+        for (const p of f.peerList) {
+          console.log(`  ${(p.id ?? "").padEnd(idW)}  ${(p.role ?? "—").padEnd(5)}  ${(p.status ?? "—").padEnd(13)}  ${p.lastSyncAt ? `${relativeTime(p.lastSyncAt)} (${p.lastSyncAt})` : "never"}`);
+        }
+      }
+    } else {
+      console.log("\n═══ Federation ═══════════════════════════════════");
+      console.log("  not configured");
+    }
+
+    if (healthData?.oauth) {
+      const o = healthData.oauth;
+      console.log("\n═══ OAuth / IdP ══════════════════════════════════");
+      console.log(`Clients:       ${o.clients}`);
+      console.log(`IdP configs:   ${o.idpConfigs}`);
+      console.log(`Active tokens: ${o.activeTokens}`);
+      if (Array.isArray(o.clientList) && o.clientList.length > 0) {
+        console.log(`\n  Clients:`);
+        for (const c of o.clientList) {
+          console.log(`    ${c.id}  ${c.name ?? "—"}  ${c.registeredBy ?? "—"}  ${c.createdAt ?? "—"}`);
+        }
+      }
+    }
+
+    if (healthData?.bridges) {
+      const b = healthData.bridges;
+      console.log("\n═══ Bridges ══════════════════════════════════════");
+      if (Array.isArray(b.installed) && b.installed.length > 0) console.log(`Installed:    ${b.installed.join(", ")}`);
+      if (b.lastImport) console.log(`Last import:  ${relativeTime(b.lastImport)}`);
+      if (b.lastExport) console.log(`Last export:  ${relativeTime(b.lastExport)}`);
+    }
+
+    if (healthData?.disk) {
+      const d = healthData.disk;
+      console.log("\n═══ Disk ═════════════════════════════════════════");
+      console.log(`Data:         ${d.dataDir} — ${humanBytes(d.dataBytes ?? 0)}`);
+      console.log(`Snapshots:    ${d.snapshotDir} — ${humanBytes(d.snapshotBytes ?? 0)}`);
+      console.log(`Total:        ${humanBytes((d.dataBytes ?? 0) + (d.snapshotBytes ?? 0))}`);
+    }
+
+    const warnings: Array<{ level: string; message: string }> = Array.isArray(healthData?.warnings) ? healthData.warnings : [];
+    if (warnings.length > 0) {
+      console.log("\n═══ Warnings ═════════════════════════════════════");
+      for (const w of warnings) console.log(`  ${w.level === "warn" ? "⚠" : "ℹ"} ${w.message}`);
+    } else {
+      console.log("\n✅ no warnings");
+    }
+  });
+
 // ─── flair upgrade ────────────────────────────────────────────────────────────
 
 program

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -6959,41 +6959,141 @@ memory.command("hygiene")
 
 // ─── flair search (top-level shortcut) ───────────────────────────────────────
 
+// Parse --since / --as-of: accept ISO 8601 OR relative expressions
+// ("1h", "7d", "30m"). Returns ISO 8601 string or null if input is empty.
+// Returns the original string unchanged if it looks like a date (caller
+// passes through to server, which validates).
+function parseRelativeOrIso(input: string | undefined): string | null {
+  if (!input) return null;
+  const m = input.match(/^(\d+)([smhdw])$/);
+  if (!m) return input;
+  const n = Number.parseInt(m[1], 10);
+  const unit = m[2];
+  const multMs: Record<string, number> = { s: 1000, m: 60_000, h: 3_600_000, d: 86_400_000, w: 604_800_000 };
+  return new Date(Date.now() - n * (multMs[unit] ?? 0)).toISOString();
+}
+
 program
   .command("search <query>")
-  .description("Search memories by meaning (shortcut for memory search)")
-  .requiredOption("--agent <id>", "Agent ID")
+  .description("Search memories by meaning (shortcut for memory search) — filterable, with --explain ranking")
+  .option("--agent <id>", "Agent ID (or set FLAIR_AGENT_ID env)")
   .option("--limit <n>", "Max results", "5")
   .option("--port <port>", "Harper HTTP port")
   .option("--url <url>", "Flair base URL (overrides --port)")
+  .option("--target <url>", "Remote Flair URL (env: FLAIR_TARGET; alias for --url)")
   .option("--key <path>", "Ed25519 private key path")
+  // Server-side filters (forwarded to /SemanticSearch payload)
+  .option("--tag <tag>", "Filter to memories carrying this tag")
+  .option("--subject <subject>", "Filter to memories carrying this subject (case-insensitive)")
+  .option("--subjects <list>", "Comma-separated list of subjects to OR-filter (case-insensitive)")
+  .option("--since <iso-or-relative>", "Only memories created after this point (ISO 8601 or '7d'/'24h'/'30m')")
+  .option("--as-of <iso>", "Temporal validity: only memories valid at this point (ISO 8601)")
+  .option("--include-superseded", "Include memories that have been superseded")
+  .option("--scoring <mode>", "Scoring mode: composite (default) re-ranks by durability/recency/retrieval; raw uses cosine similarity only", "composite")
+  .option("--min-score <n>", "Drop results below this score (0..1)", "0")
+  // Client-side filters (applied after server response)
+  .option("--durability <level>", "Filter to permanent|persistent|standard|ephemeral (client-side)")
+  .option("--source <name>", "Filter by source/agentId (client-side)")
+  // Output modes
+  .option("--explain", "Show score breakdown (composite, raw, durability, age, retrieval) per hit")
+  .option("--json", "Output raw JSON array")
   .action(async (query, opts) => {
     try {
-      const baseUrl = opts.url || `http://127.0.0.1:${resolveHttpPort(opts)}`;
-      const headers: Record<string, string> = { "content-type": "application/json" };
-      const keyPath = opts.key || resolveKeyPath(opts.agent);
-      if (keyPath) {
-        headers["authorization"] = buildEd25519Auth(opts.agent, "POST", "/SemanticSearch", keyPath);
+      const agentId = opts.agent || process.env.FLAIR_AGENT_ID;
+      if (!agentId) {
+        console.error("error: --agent <id> required (or set FLAIR_AGENT_ID)");
+        process.exit(2);
       }
+      const baseUrl = opts.target || opts.url || process.env.FLAIR_TARGET || (process.env.FLAIR_URL ?? `http://127.0.0.1:${resolveHttpPort(opts)}`);
+      const headers: Record<string, string> = { "content-type": "application/json" };
+      const keyPath = opts.key || resolveKeyPath(agentId);
+      if (keyPath) {
+        headers["authorization"] = buildEd25519Auth(agentId, "POST", "/SemanticSearch", keyPath);
+      }
+
+      // Build payload from CLI options. Server validates types.
+      const payload: Record<string, any> = {
+        agentId,
+        q: query,
+        limit: Number.parseInt(opts.limit, 10) || 5,
+        scoring: opts.scoring === "raw" ? "raw" : "composite",
+      };
+      if (opts.tag) payload.tag = opts.tag;
+      if (opts.subject) payload.subject = opts.subject;
+      if (opts.subjects) payload.subjects = String(opts.subjects).split(",").map((s) => s.trim()).filter(Boolean);
+      const since = parseRelativeOrIso(opts.since);
+      if (since) payload.since = since;
+      if (opts.asOf) payload.asOf = opts.asOf;
+      if (opts.includeSuperseded) payload.includeSuperseded = true;
+      const minScore = Number.parseFloat(opts.minScore ?? "0");
+      if (Number.isFinite(minScore) && minScore > 0) payload.minScore = minScore;
+
       const res = await fetch(`${baseUrl}/SemanticSearch`, {
         method: "POST",
         headers,
-        body: JSON.stringify({ agentId: opts.agent, q: query, limit: parseInt(opts.limit, 10) }),
+        body: JSON.stringify(payload),
       });
       if (!res.ok) throw new Error(await res.text());
-      const result = await res.json() as any;
-      const results = result.results || result || [];
-      if (!Array.isArray(results) || results.length === 0) {
-        console.log("No results found.");
+      const result = (await res.json()) as any;
+      let results: any[] = result.results || result || [];
+      if (!Array.isArray(results)) results = [];
+
+      // Client-side filters: durability + source. Server doesn't expose these
+      // as conditions, so we filter after fetch.
+      if (opts.durability) {
+        const allowed = new Set(String(opts.durability).split(",").map((d) => d.trim()));
+        results = results.filter((r) => allowed.has(r.durability ?? "standard"));
+      }
+      if (opts.source) {
+        const allowed = new Set(String(opts.source).split(",").map((s) => s.trim()));
+        results = results.filter((r) => allowed.has(r._source ?? r.agentId ?? ""));
+      }
+
+      if (opts.json) {
+        console.log(JSON.stringify(results, null, 2));
         return;
       }
+
+      if (results.length === 0) {
+        console.log("No results found.");
+        const filters: string[] = [];
+        if (opts.tag) filters.push(`tag=${opts.tag}`);
+        if (opts.subject) filters.push(`subject=${opts.subject}`);
+        if (opts.subjects) filters.push(`subjects=${opts.subjects}`);
+        if (opts.since) filters.push(`since=${opts.since}`);
+        if (opts.durability) filters.push(`durability=${opts.durability}`);
+        if (opts.source) filters.push(`source=${opts.source}`);
+        if (filters.length > 0) {
+          console.log(`  Filters: ${filters.join(", ")}`);
+          console.log(`  Try removing a filter or running: flair search "${query}" --agent ${agentId}`);
+        }
+        return;
+      }
+
       for (const r of results) {
-        const date = r.createdAt ? r.createdAt.slice(0, 10) : "";
-        const score = r._score ? `${(r._score * 100).toFixed(0)}%` : "";
-        const meta = [date, r.type, score].filter(Boolean).join(" · ");
+        const date = r.createdAt ? String(r.createdAt).slice(0, 10) : "";
+        const scorePct = typeof r._score === "number" ? `${(r._score * 100).toFixed(0)}%` : "";
+        const durability = r.durability ?? "standard";
+        const metaParts = [date, durability, scorePct].filter(Boolean);
+        if (r._source) metaParts.push(`from:${r._source}`);
+        const meta = metaParts.join(" · ");
         console.log(`  ${r.content}`);
         if (meta) console.log(`  (${meta})`);
+        if (opts.explain) {
+          const lines: string[] = [];
+          if (typeof r._rawScore === "number") lines.push(`raw=${r._rawScore.toFixed(3)}`);
+          if (typeof r._score === "number") lines.push(`composite=${r._score.toFixed(3)}`);
+          if (typeof r.retrievalCount === "number" && r.retrievalCount > 0) lines.push(`retrievals=${r.retrievalCount}`);
+          if (r.tags && Array.isArray(r.tags) && r.tags.length > 0) lines.push(`tags=[${r.tags.join(",")}]`);
+          if (r.subject) lines.push(`subject=${r.subject}`);
+          if (r.supersedes) lines.push(`supersedes=${r.supersedes}`);
+          if (lines.length > 0) console.log(`    └─ ${lines.join(" · ")}`);
+        }
         console.log();
+      }
+
+      if (opts.explain) {
+        console.log(`Scoring: ${payload.scoring}  ${payload.scoring === "composite" ? "(semantic × durability-weight × recency-decay × retrieval-boost)" : "(cosine similarity only)"}`);
       }
     } catch (err: any) {
       console.error(`Search failed: ${err.message}`);


### PR DESCRIPTION
## Summary

`flair search` had only --agent and --limit. The /SemanticSearch server already supports tag/subject/since/as-of/include-superseded/scoring/min-score — the CLI just didn't pipe them through. This adds full server-side flag coverage plus two client-side filters (durability, source) plus output modes (--explain, --json).

Single-file change in `src/cli.ts`. No server changes.

## New flags

**Server-forwarded:**
- `--tag <tag>`
- `--subject <s>` / `--subjects a,b,c`
- `--since <iso-or-relative>` (accepts `7d`, `24h`, `30m`, `60s`, or full ISO 8601)
- `--as-of <iso>`
- `--include-superseded`
- `--scoring composite|raw`
- `--min-score <n>`

**Client-side filters** (applied post-fetch since server lacks these conditions):
- `--durability permanent|persistent|standard|ephemeral`
- `--source <agentId>`

**Output modes:**
- `--explain` — per-hit score breakdown (raw, composite, retrievals, tags, subject, supersedes) + scoring formula footer
- `--json` — emit the full filtered results array

**Env convenience:**
- `--target <url>` (alias for --url, picks up `FLAIR_TARGET`)
- `--agent` falls back to `FLAIR_AGENT_ID` env when omitted
- `--url` falls back to `FLAIR_URL` env

## Sample output

Default:
```
$ flair search "federation" --limit 2
  Federation 1.0 hub-spoke pair: VALIDATED end-to-end (2026-04-28...
  (2026-04-28 · persistent · 66%)

  Federation 1.0 hub-spoke three-host topology validated 2026-04-29...
  (2026-04-29 · persistent · 61%)
```

--explain:
```
  Federation 1.0 hub-spoke pair...
  (2026-04-28 · persistent · 66%)
    └─ raw=0.673 · composite=0.656 · retrievals=7

Scoring: composite  (semantic × durability-weight × recency-decay × retrieval-boost)
```

No-results:
```
$ flair search "xyzzy" --tag nonsense
No results found.
  Filters: tag=nonsense
  Try removing a filter or running: flair search "xyzzy" --agent flint
```

## Test plan

- [x] tsc --noCheck clean
- [x] Manual: --explain shows scores, --durability filters, --since 3d filters, --json emits parseable array, no-results path reprints filters
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)