### PR TITLE
feat(cli): renderer module + pretty/JSON mode resolver (slice 1)

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2,6 +2,7 @@
 import { Command } from "commander";
 import nacl from "tweetnacl";
 import { load as parseYaml } from "js-yaml";
+import * as render from "./render.js";
 import {
   existsSync,
   mkdirSync,
@@ -7083,13 +7084,14 @@ program
         results = results.filter((r) => allowed.has(r._source ?? r.agentId ?? ""));
       }
 
-      if (opts.json) {
-        console.log(JSON.stringify(results, null, 2));
+      const mode = render.resolveOutputMode(opts);
+      if (mode === "json") {
+        console.log(render.asJSON(results));
         return;
       }
 
       if (results.length === 0) {
-        console.log("No results found.");
+        console.log(`${render.icons.info} ${render.wrap(render.c.dim, "No results found.")}`);
         const filters: string[] = [];
         if (opts.tag) filters.push(`tag=${opts.tag}`);
         if (opts.subject) filters.push(`subject=${opts.subject}`);
@@ -7098,39 +7100,63 @@ program
         if (opts.durability) filters.push(`durability=${opts.durability}`);
         if (opts.source) filters.push(`source=${opts.source}`);
         if (filters.length > 0) {
-          console.log(`  Filters: ${filters.join(", ")}`);
-          console.log(`  Try removing a filter or running: flair search "${query}" --agent ${agentId}`);
+          console.log(`  ${render.wrap(render.c.dim, "Filters:")} ${filters.join(render.wrap(render.c.dim, " · "))}`);
+          console.log(
+            `  ${render.icons.arrow} ${render.wrap(render.c.dim, "Try removing a filter or:")} flair search "${query}" --agent ${agentId}`,
+          );
         }
         return;
       }
 
+      const durabilityColor = (d: string): string => {
+        if (d === "permanent") return render.c.magenta;
+        if (d === "persistent") return render.c.blue;
+        if (d === "ephemeral") return render.c.gray;
+        return render.c.cyan;
+      };
+
       for (const r of results) {
         const date = r.createdAt ? String(r.createdAt).slice(0, 10) : "";
-        const scorePct = typeof r._score === "number" ? `${(r._score * 100).toFixed(0)}%` : "";
+        const scoreVal = typeof r._score === "number" ? r._score : 0;
+        const scorePct = typeof r._score === "number" ? `${(scoreVal * 100).toFixed(0)}%` : "";
+        const scoreColor = scoreVal >= 0.7 ? render.c.green : scoreVal >= 0.4 ? render.c.yellow : render.c.dim;
         const durability = r.durability ?? "standard";
-        const metaParts = [date, durability, scorePct].filter(Boolean);
-        if (r._source) metaParts.push(`from:${r._source}`);
-        const meta = metaParts.join(" · ");
+        const metaParts: string[] = [];
+        if (date) metaParts.push(render.wrap(render.c.dim, date));
+        metaParts.push(render.wrap(durabilityColor(durability), durability));
+        if (scorePct) metaParts.push(render.wrap(scoreColor, scorePct));
+        if (r._source) metaParts.push(render.wrap(render.c.cyan, `from:${r._source}`));
+        const meta = metaParts.join(render.wrap(render.c.dim, " · "));
         console.log(`  ${r.content}`);
-        if (meta) console.log(`  (${meta})`);
+        if (meta) console.log(`  ${render.wrap(render.c.dim, "(")} ${meta} ${render.wrap(render.c.dim, ")")}`);
         if (opts.explain) {
-          const lines: string[] = [];
-          if (typeof r._rawScore === "number") lines.push(`raw=${r._rawScore.toFixed(3)}`);
-          if (typeof r._score === "number") lines.push(`composite=${r._score.toFixed(3)}`);
-          if (typeof r.retrievalCount === "number" && r.retrievalCount > 0) lines.push(`retrievals=${r.retrievalCount}`);
-          if (r.tags && Array.isArray(r.tags) && r.tags.length > 0) lines.push(`tags=[${r.tags.join(",")}]`);
-          if (r.subject) lines.push(`subject=${r.subject}`);
-          if (r.supersedes) lines.push(`supersedes=${r.supersedes}`);
-          if (lines.length > 0) console.log(`    └─ ${lines.join(" · ")}`);
+          const parts: string[] = [];
+          if (typeof r._rawScore === "number") parts.push(`raw=${r._rawScore.toFixed(3)}`);
+          if (typeof r._score === "number") parts.push(`composite=${r._score.toFixed(3)}`);
+          if (typeof r.retrievalCount === "number" && r.retrievalCount > 0) parts.push(`retrievals=${r.retrievalCount}`);
+          if (r.tags && Array.isArray(r.tags) && r.tags.length > 0) parts.push(`tags=[${r.tags.join(",")}]`);
+          if (r.subject) parts.push(`subject=${r.subject}`);
+          if (r.supersedes) parts.push(`supersedes=${r.supersedes}`);
+          if (parts.length > 0) {
+            console.log(
+              `    ${render.wrap(render.c.gray, "└─")} ${render.wrap(render.c.dim, parts.join(" · "))}`,
+            );
+          }
         }
         console.log();
       }
 
       if (opts.explain) {
-        console.log(`Scoring: ${payload.scoring}  ${payload.scoring === "composite" ? "(semantic × durability-weight × recency-decay × retrieval-boost)" : "(cosine similarity only)"}`);
+        const formula =
+          payload.scoring === "composite"
+            ? "semantic × durability-weight × recency-decay × retrieval-boost"
+            : "cosine similarity only";
+        console.log(
+          `${render.wrap(render.c.dim, "Scoring:")} ${render.wrap(render.c.bold, payload.scoring)}  ${render.wrap(render.c.dim, `(${formula})`)}`,
+        );
       }
     } catch (err: any) {
-      console.error(`Search failed: ${err.message}`);
+      console.error(`${render.icons.error} Search failed: ${err.message}`);
       process.exit(1);
     }
   });
@@ -7160,13 +7186,15 @@ program
   .option("--url <url>", "Flair base URL (overrides --port)")
   .option("--target <url>", "Remote Flair URL (env: FLAIR_TARGET; alias for --url)")
   .option("--key <path>", "Ed25519 private key path")
+  .option("--json", "Emit JSON {context, tokenEstimate, memoriesIncluded, ...} (also: pipe + FLAIR_OUTPUT=json)")
   .action(async (opts) => {
     const agentId = resolveAgentIdOrEnv(opts);
     if (!agentId) {
-      console.error("error: --agent <id> required (or set FLAIR_AGENT_ID)");
+      console.error(`${render.icons.error} --agent <id> required (or set FLAIR_AGENT_ID)`);
       process.exit(2);
     }
     const baseUrl = resolveBaseUrl(opts);
+    const mode = render.resolveOutputMode(opts);
     try {
       const headers: Record<string, string> = { "content-type": "application/json" };
       const keyPath = opts.key || resolveKeyPath(agentId);
@@ -7182,21 +7210,34 @@ program
         const body = await res.text();
         throw new Error(`${res.status}: ${body}`);
       }
-      const result = await res.json() as any;
+      const result = (await res.json()) as any;
+
+      if (mode === "json") {
+        // Agent-first: emit the full server response, augmented with the cap
+        // that was requested. Includes context, sections, tokenEstimate, etc.
+        console.log(render.asJSON({ ...result, maxTokens: parseInt(opts.maxTokens, 10) }));
+        return;
+      }
+
+      // Human mode: print context to stdout, budget footer to stderr (parseable).
       if (result.context) {
         console.log(result.context);
       } else {
-        console.error("No context available.");
+        console.error(`${render.icons.error} No context available.`);
         process.exit(1);
       }
-      // Print budget footer to stderr (parseable, won't interfere with context output)
       const tokensUsed = result.tokenEstimate ?? 0;
       const maxTokens = parseInt(opts.maxTokens, 10);
       const included = result.memoriesIncluded ?? 0;
       const truncated = result.memoriesTruncated ?? 0;
-      console.error(`[budget: ${tokensUsed}/${maxTokens} tokens, ${included} included, ${truncated} truncated]`);
+      const tokenPct = maxTokens > 0 ? (tokensUsed / maxTokens) * 100 : 0;
+      const tokenIcon = tokenPct >= 90 ? render.icons.warn : tokenPct >= 70 ? render.icons.info : render.icons.ok;
+      const truncIcon = truncated > 0 ? render.icons.warn : render.icons.ok;
+      console.error(
+        `${tokenIcon} budget ${tokensUsed}/${maxTokens} tokens (${tokenPct.toFixed(0)}%) ${render.icons.bullet} ${render.icons.ok} ${included} included ${render.icons.bullet} ${truncIcon} ${truncated} truncated`,
+      );
     } catch (err: any) {
-      console.error(`Bootstrap failed: ${err.message}`);
+      console.error(`${render.icons.error} Bootstrap failed: ${err.message}`);
       process.exit(1);
     }
   });

--- a/src/render.ts
+++ b/src/render.ts
@@ -1,0 +1,195 @@
+// CLI output renderer — color, tables, icons, spinner, output-mode resolution.
+//
+// Two output modes coexist across every command:
+//
+//   human  — pretty default, ANSI color when stdout is a TTY and NO_COLOR/
+//            FLAIR_NO_COLOR aren't set
+//   json   — agent-default, also auto-selected when stdout is piped
+//
+// Precedence: --json flag > FLAIR_OUTPUT=json env > non-TTY stdout > TTY (human).
+// Setting FLAIR_OUTPUT=human forces human mode even when piped.
+//
+// No third-party deps — minimal ANSI by hand keeps the dependency tree flat
+// (the rest of the flair runtime already runs ANSI-free; we don't need
+// chalk/picocolors' edge-case coverage for SGR codes we don't use).
+
+const stdoutIsTTY = !!process.stdout.isTTY;
+const stderrIsTTY = !!process.stderr.isTTY;
+const noColorEnv = process.env.NO_COLOR != null || process.env.FLAIR_NO_COLOR != null;
+
+const enableColor = stdoutIsTTY && !noColorEnv;
+const C = (code: string) => (enableColor ? `\x1b[${code}m` : "");
+
+export const c = {
+  reset: C("0"),
+  bold: C("1"),
+  dim: C("2"),
+  italic: C("3"),
+  underline: C("4"),
+  red: C("31"),
+  green: C("32"),
+  yellow: C("33"),
+  blue: C("34"),
+  magenta: C("35"),
+  cyan: C("36"),
+  white: C("37"),
+  gray: C("90"),
+};
+
+export function wrap(color: string, text: string): string {
+  if (!color) return text;
+  return `${color}${text}${c.reset}`;
+}
+
+export type OutputMode = "human" | "json";
+
+export function resolveOutputMode(opts: { json?: boolean }): OutputMode {
+  if (opts.json) return "json";
+  const envOut = process.env.FLAIR_OUTPUT;
+  if (envOut === "json") return "json";
+  if (envOut === "human") return "human";
+  // No explicit selection — pipe-friendly default: non-TTY stdout → json.
+  return stdoutIsTTY ? "human" : "json";
+}
+
+export const icons = {
+  ok: wrap(c.green, "✓"),
+  warn: wrap(c.yellow, "⚠"),
+  error: wrap(c.red, "✗"),
+  info: wrap(c.cyan, "ℹ"),
+  bullet: wrap(c.gray, "·"),
+  pending: wrap(c.gray, "○"),
+  arrow: wrap(c.gray, "→"),
+};
+
+// Status header: bullet + bold label. Use for top-level command titles.
+export function header(label: string): string {
+  return wrap(c.bold, label);
+}
+
+// Section divider — used between groups inside one command's output.
+// Subtle line + bold label, no big ═══ banners (those compete with content).
+export function section(label: string): string {
+  return `\n${wrap(c.bold, label)}\n${wrap(c.gray, "─".repeat(Math.min(60, label.length + 8)))}`;
+}
+
+// Key/value pair with aligned label. Default label width 14 cols.
+export function kv(label: string, value: string, labelWidth = 14): string {
+  return `  ${wrap(c.dim, label.padEnd(labelWidth))} ${value}`;
+}
+
+// Table renderer. Columns can specify label, key, alignment, and a per-value
+// format function. Header row is dim; data rows plain.
+export interface TableColumn {
+  label: string;
+  key: string;
+  align?: "left" | "right";
+  format?: (value: unknown, row: Record<string, unknown>) => string;
+}
+
+export function table(
+  columns: TableColumn[],
+  rows: Array<Record<string, unknown>>,
+): string {
+  if (rows.length === 0) return wrap(c.dim, "  (no rows)");
+  const widths = columns.map((col) => col.label.length);
+  const cells: string[][] = rows.map((row) =>
+    columns.map((col, i) => {
+      const raw = row[col.key];
+      const formatted = col.format ? col.format(raw, row) : raw == null ? "—" : String(raw);
+      // Visible-width calculation — strip our own ANSI escapes before counting
+      const visibleLen = formatted.replace(/\x1b\[[0-9;]*m/g, "").length;
+      if (visibleLen > widths[i]) widths[i] = visibleLen;
+      return formatted;
+    }),
+  );
+
+  const align = (str: string, width: number, side?: "left" | "right") => {
+    const visibleLen = str.replace(/\x1b\[[0-9;]*m/g, "").length;
+    const pad = " ".repeat(Math.max(0, width - visibleLen));
+    return side === "right" ? pad + str : str + pad;
+  };
+
+  const headerRow =
+    "  " +
+    columns.map((col, i) => wrap(c.dim, align(col.label, widths[i], col.align))).join("  ");
+  const bodyRows = cells
+    .map((row) => "  " + row.map((cell, i) => align(cell, widths[i], columns[i].align)).join("  "))
+    .join("\n");
+  return `${headerRow}\n${bodyRows}`;
+}
+
+// Spinner for long-running operations. Writes to stderr so stdout stays clean
+// for human or JSON output. No-op when stderr isn't a TTY (CI, piped error
+// stream): just emits a one-line note at start.
+export interface Spinner {
+  stop(final?: string): void;
+  update(label: string): void;
+}
+
+export function spinner(label: string): Spinner {
+  if (!stderrIsTTY || noColorEnv) {
+    process.stderr.write(`${label}...\n`);
+    return {
+      stop: (final?: string) => {
+        if (final) process.stderr.write(`${final}\n`);
+      },
+      update: (next: string) => {
+        process.stderr.write(`${next}...\n`);
+      },
+    };
+  }
+  const frames = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
+  let current = label;
+  let i = 0;
+  const handle = setInterval(() => {
+    process.stderr.write(`\r${wrap(c.cyan, frames[i])} ${current}`);
+    i = (i + 1) % frames.length;
+  }, 80);
+  return {
+    stop: (final?: string) => {
+      clearInterval(handle);
+      process.stderr.write("\r\x1b[K");
+      if (final) process.stderr.write(`${final}\n`);
+    },
+    update: (next: string) => {
+      current = next;
+    },
+  };
+}
+
+// Canonical JSON output: 2-space indent, trailing newline omitted by caller.
+export function asJSON(value: unknown): string {
+  return JSON.stringify(value, null, 2);
+}
+
+// Bytes → human readable. Mirror of humanBytes in cli.ts; centralizing here
+// so render-aware code shares the same format.
+export function humanBytes(n: number): string {
+  if (!Number.isFinite(n) || n < 0) return "—";
+  if (n < 1024) return `${n} B`;
+  if (n < 1024 * 1024) return `${(n / 1024).toFixed(1)} KB`;
+  if (n < 1024 * 1024 * 1024) return `${(n / (1024 * 1024)).toFixed(1)} MB`;
+  return `${(n / (1024 * 1024 * 1024)).toFixed(2)} GB`;
+}
+
+// ISO timestamp → "12m ago" / "2h ago" / "5d ago" / "—" (null) / fallback.
+export function relativeTime(iso: string | null | undefined): string {
+  if (!iso) return "—";
+  const ago = Date.now() - new Date(iso).getTime();
+  if (!Number.isFinite(ago) || ago < 0) return "—";
+  const mins = Math.floor(ago / 60000);
+  const hrs = Math.floor(ago / 3600000);
+  const days = Math.floor(ago / 86400000);
+  return days > 0 ? `${days}d ago` : hrs > 0 ? `${hrs}h ago` : mins > 0 ? `${mins}m ago` : "just now";
+}
+
+// Convenience: print the right shape for the resolved output mode.
+// Caller passes both representations and the resolveOutputMode result.
+export function print(mode: OutputMode, jsonValue: unknown, humanText: string): void {
+  if (mode === "json") {
+    console.log(asJSON(jsonValue));
+  } else {
+    console.log(humanText);
+  }
+}


### PR DESCRIPTION
## Summary

First slice of the CLI polish pass. Adds a self-contained renderer module (\`src/render.ts\`) with ANSI helpers, tables, icons, spinner, and a central output-mode resolver, then applies it to two commands as proof of pattern.

Addresses Nathan's bar: **"not just clean, but beautiful. agent-first via \`--json\` is the standard now."**

Audit before this PR: 14/95 commands had \`--json\`; many defaulted to raw JSON instead of pretty. Three inconsistent modes coexisted. This PR establishes the renderer + the resolver; follow-up PRs fan out the pattern.

## src/render.ts (new, ~195 lines)

No third-party deps — minimal ANSI by hand. Exports:

- \`c.*\` — ANSI codes (auto-disabled when stdout isn't TTY or \`NO_COLOR\`/\`FLAIR_NO_COLOR\` env set)
- \`icons\` — ✓ / ⚠ / ✗ / ℹ / · / ○ / → (color-coded)
- \`section()\`, \`header()\`, \`kv()\` — building blocks for human output
- \`table()\` — auto-width columns, dim header, per-column alignment + format
- \`spinner()\` — TTY-aware, no-op when stderr isn't interactive
- \`resolveOutputMode(opts)\` — central output-mode resolver
- \`asJSON()\`, \`humanBytes()\`, \`relativeTime()\` — centralized formatters

### Output-mode precedence

\`--json flag > FLAIR_OUTPUT=json env > non-TTY stdout > TTY (human)\`

Means \`flair X | jq\` gets JSON automatically — agents don't need to remember \`--json\`. Interactive sessions get pretty by default.

## Applied to two commands

**flair bootstrap:**
- Added \`--json\` (response shape: full server payload + \`maxTokens\` echo)
- Auto-detects pipe → JSON; \`FLAIR_OUTPUT=human\` forces pretty
- Budget footer: icons + percentage + per-component severity icon

**flair search:**
- Output mode through \`resolveOutputMode\`
- Durability colored: permanent=magenta, persistent=blue, ephemeral=gray
- Score colored: ≥70% green, ≥40% yellow, <40% dim
- Source (cross-agent) cyan
- No-results: ℹ icon + dim filters + → arrow + dim suggestion
- \`--explain\` breakdown: dimmed metadata under each hit
- Error path: ✗ icon

## Scope for follow-up

PR-2 will apply the renderer to \`status\` / \`status deep\` / \`inspect\` / \`memory list\` / \`federation status\`. Each is small in isolation; bundling all into one PR would be unreviewable. Renderer surface is the load-bearing piece — once K&S signs off on the pattern, fan-out PRs follow.

## Test plan

- [x] tsc strict clean
- [x] Manual against rockit-local Flair (548 memories): search + bootstrap in all three modes (human / --json / pipe-auto), \`NO_COLOR=1\` disables ANSI, \`FLAIR_OUTPUT=human\` forces pretty
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)