### PR TITLE
ci: wrap bun install with Socket Firewall (sfw)

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -22,7 +22,13 @@ jobs:
         with:
           node-version: "22"
 
-      - run: bun install --frozen-lockfile
+      - uses: socketdev/action@ba6de6cc0565af1f42295590380973573297e31f # v1.3.2
+
+        with:
+
+          mode: firewall-free
+
+      - run: sfw bun install --frozen-lockfile
 
       - name: Install linux-x64 native binary for embeddings
         run: bun add --no-save @node-llama-cpp/linux-x64@3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,7 +45,10 @@ jobs:
       - uses: oven-sh/setup-bun@735343b667d3e6f658f44d0eca948eb6282f2b76 # v2
         with:
           bun-version: "1.3.10"
-      - run: bun install --frozen-lockfile
+      - uses: socketdev/action@ba6de6cc0565af1f42295590380973573297e31f # v1.3.2
+        with:
+          mode: firewall-free
+      - run: sfw bun install --frozen-lockfile
       - run: bun test test/unit/
 
   test-integration:
@@ -68,7 +71,10 @@ jobs:
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: "22"
-      - run: bun install --frozen-lockfile
+      - uses: socketdev/action@ba6de6cc0565af1f42295590380973573297e31f # v1.3.2
+        with:
+          mode: firewall-free
+      - run: sfw bun install --frozen-lockfile
       - name: Install linux-x64 native binary for embeddings
         run: bun add --no-save @node-llama-cpp/linux-x64@3
       - name: Build Flair resources and CLI
@@ -150,7 +156,10 @@ jobs:
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: "22"
-      - run: bun install --frozen-lockfile
+      - uses: socketdev/action@ba6de6cc0565af1f42295590380973573297e31f # v1.3.2
+        with:
+          mode: firewall-free
+      - run: sfw bun install --frozen-lockfile
       - run: bun run build && bun run build:cli
       - name: Verify dist/ modules import cleanly (dev surface)
         run: node scripts/check-imports.mjs dist
@@ -247,7 +256,10 @@ jobs:
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: "22"
-      - run: bun install --frozen-lockfile
+      - uses: socketdev/action@ba6de6cc0565af1f42295590380973573297e31f # v1.3.2
+        with:
+          mode: firewall-free
+      - run: sfw bun install --frozen-lockfile
       - run: bun run build && bun run build:cli
       - name: Pack HEAD
         id: pack
@@ -340,7 +352,10 @@ jobs:
       - uses: oven-sh/setup-bun@735343b667d3e6f658f44d0eca948eb6282f2b76 # v2
         with:
           bun-version: "1.3.10"
-      - run: bun install --frozen-lockfile
+      - uses: socketdev/action@ba6de6cc0565af1f42295590380973573297e31f # v1.3.2
+        with:
+          mode: firewall-free
+      - run: sfw bun install --frozen-lockfile
       - run: bunx tsc --noEmit -p tsconfig.check.json
 
   typecheck-strict:
@@ -351,7 +366,10 @@ jobs:
       - uses: oven-sh/setup-bun@735343b667d3e6f658f44d0eca948eb6282f2b76 # v2
         with:
           bun-version: "1.3.10"
-      - run: bun install --frozen-lockfile
+      - uses: socketdev/action@ba6de6cc0565af1f42295590380973573297e31f # v1.3.2
+        with:
+          mode: firewall-free
+      - run: sfw bun install --frozen-lockfile
       # Root resources (tsconfig.check.json has @harperfast/harper paths override
       # so harper's raw .ts internals don't pollute the output)
       - name: Type check root (resources)
@@ -393,7 +411,10 @@ jobs:
       - uses: oven-sh/setup-bun@735343b667d3e6f658f44d0eca948eb6282f2b76 # v2
         with:
           bun-version: "1.3.10"
-      - run: bun install --frozen-lockfile
+      - uses: socketdev/action@ba6de6cc0565af1f42295590380973573297e31f # v1.3.2
+        with:
+          mode: firewall-free
+      - run: sfw bun install --frozen-lockfile
       - name: Run audit (advisory-only for transitive deps)
         run: bun audit || echo "::warning::Audit found vulnerabilities — all in harper transitive deps (unreleased v5 build)"
         continue-on-error: true


### PR DESCRIPTION
## Summary

Adds [Socket Firewall (sfw)](https://socket.dev/firewall) to wrap every \`bun install --frozen-lockfile\` step in CI.

Closes the supply-chain gap that the existing \`check-dep-ages.mjs\` (release-age) and \`bun audit\` (known vulns) can't: confirmed malware regardless of age, regardless of whether it's in our audit DB yet.

### What changes

- \`test.yml\` — 7 install sites wrapped
- \`smoke.yml\` — 1 install site wrapped
- All \`socketdev/action\` uses pinned to \`ba6de6cc05 # v1.3.2\`

### Mechanism

\`socketdev/action\` sets up an ephemeral HTTP proxy + installs the sfw binary. \`sfw bun install\` routes npm-registry traffic through the proxy, which checks each fetch against Socket's safety API before allowing it.

Verified locally: sfw wraps bun cleanly despite docs only listing npm/yarn/pnpm/pip/uv/cargo.

### Part of an org-wide rollout

Same change shipping in parallel for:
- tpsdev-ai/bob — PR https://github.com/tpsdev-ai/bob/pull/14
- tpsdev-ai/cli — PR https://github.com/tpsdev-ai/cli/pull/303

### Test plan

- [ ] CI green with sfw wrapping each install
- [ ] K&S ensemble (post via gh-as — GH review IS the reply, no TPS mail):
  - Sherlock: pinned SHA correctness; mode=firewall-free safe in public-repo CI context?
  - Kern: any perf regression from the proxy across 8 install sites?

🤖 Generated with [Claude Code](https://claude.com/claude-code)