### PR TITLE
fix(federation): truthful sync telemetry — split liveness from progress + categorize skips

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -22,7 +22,13 @@ jobs:
         with:
           node-version: "22"
 
-      - run: bun install --frozen-lockfile
+      - uses: socketdev/action@ba6de6cc0565af1f42295590380973573297e31f # v1.3.2
+
+        with:
+
+          mode: firewall-free
+
+      - run: sfw bun install --frozen-lockfile
 
       - name: Install linux-x64 native binary for embeddings
         run: bun add --no-save @node-llama-cpp/linux-x64@3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,7 +45,10 @@ jobs:
       - uses: oven-sh/setup-bun@735343b667d3e6f658f44d0eca948eb6282f2b76 # v2
         with:
           bun-version: "1.3.10"
-      - run: bun install --frozen-lockfile
+      - uses: socketdev/action@ba6de6cc0565af1f42295590380973573297e31f # v1.3.2
+        with:
+          mode: firewall-free
+      - run: sfw bun install --frozen-lockfile
       - run: bun test test/unit/
 
   test-integration:
@@ -68,7 +71,10 @@ jobs:
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: "22"
-      - run: bun install --frozen-lockfile
+      - uses: socketdev/action@ba6de6cc0565af1f42295590380973573297e31f # v1.3.2
+        with:
+          mode: firewall-free
+      - run: sfw bun install --frozen-lockfile
       - name: Install linux-x64 native binary for embeddings
         run: bun add --no-save @node-llama-cpp/linux-x64@3
       - name: Build Flair resources and CLI
@@ -150,7 +156,10 @@ jobs:
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: "22"
-      - run: bun install --frozen-lockfile
+      - uses: socketdev/action@ba6de6cc0565af1f42295590380973573297e31f # v1.3.2
+        with:
+          mode: firewall-free
+      - run: sfw bun install --frozen-lockfile
       - run: bun run build && bun run build:cli
       - name: Verify dist/ modules import cleanly (dev surface)
         run: node scripts/check-imports.mjs dist
@@ -247,7 +256,10 @@ jobs:
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: "22"
-      - run: bun install --frozen-lockfile
+      - uses: socketdev/action@ba6de6cc0565af1f42295590380973573297e31f # v1.3.2
+        with:
+          mode: firewall-free
+      - run: sfw bun install --frozen-lockfile
       - run: bun run build && bun run build:cli
       - name: Pack HEAD
         id: pack
@@ -340,7 +352,10 @@ jobs:
       - uses: oven-sh/setup-bun@735343b667d3e6f658f44d0eca948eb6282f2b76 # v2
         with:
           bun-version: "1.3.10"
-      - run: bun install --frozen-lockfile
+      - uses: socketdev/action@ba6de6cc0565af1f42295590380973573297e31f # v1.3.2
+        with:
+          mode: firewall-free
+      - run: sfw bun install --frozen-lockfile
       - run: bunx tsc --noEmit -p tsconfig.check.json
 
   typecheck-strict:
@@ -351,7 +366,10 @@ jobs:
       - uses: oven-sh/setup-bun@735343b667d3e6f658f44d0eca948eb6282f2b76 # v2
         with:
           bun-version: "1.3.10"
-      - run: bun install --frozen-lockfile
+      - uses: socketdev/action@ba6de6cc0565af1f42295590380973573297e31f # v1.3.2
+        with:
+          mode: firewall-free
+      - run: sfw bun install --frozen-lockfile
       # Root resources (tsconfig.check.json has @harperfast/harper paths override
       # so harper's raw .ts internals don't pollute the output)
       - name: Type check root (resources)
@@ -393,7 +411,10 @@ jobs:
       - uses: oven-sh/setup-bun@735343b667d3e6f658f44d0eca948eb6282f2b76 # v2
         with:
           bun-version: "1.3.10"
-      - run: bun install --frozen-lockfile
+      - uses: socketdev/action@ba6de6cc0565af1f42295590380973573297e31f # v1.3.2
+        with:
+          mode: firewall-free
+      - run: sfw bun install --frozen-lockfile
       - name: Run audit (advisory-only for transitive deps)
         run: bun audit || echo "::warning::Audit found vulnerabilities — all in harper transitive deps (unreleased v5 build)"
         continue-on-error: true

--- a/resources/Federation.ts
+++ b/resources/Federation.ts
@@ -12,6 +12,9 @@ import {
 } from "./federation-crypto.js";
 import type { NonceStore } from "./federation-crypto.js";
 import { initFederationCleanup } from "./federation-cleanup.js";
+import { classifyRecord } from "./federation-classify.js";
+export { classifyRecord } from "./federation-classify.js";
+export type { SkipReason, ClassifyResult } from "./federation-classify.js";
 
 // Module-level nonce store for federation anti-replay.
 // Shared across FederationPair + FederationSync — nonces are globally unique
@@ -350,6 +353,13 @@ export class FederationSync extends Resource {
     const startTime = Date.now();
     let merged = 0;
     let skipped = 0;
+    const skippedReasons: Record<string, number> = {};
+    const mergeErrors: string[] = [];
+
+    function recordSkip(reason: string) {
+      skipped++;
+      skippedReasons[reason] = (skippedReasons[reason] ?? 0) + 1;
+    }
 
     // Table name → Harper database table mapping
     const tableMap: Record<string, any> = {
@@ -358,93 +368,105 @@ export class FederationSync extends Resource {
       Agent: (databases as any).flair.Agent,
       Relationship: (databases as any).flair.Relationship,
     };
+    const knownTables = new Set(Object.keys(tableMap));
 
     for (const record of records as SyncRecord[]) {
-      const table = tableMap[record.table];
-      if (!table) {
-        skipped++;
-        continue;
-      }
-
-      // Originator enforcement: peers can only push records they originated.
-      // The hub can relay records from other peers (role === "hub"),
-      // but spokes can only push their own records.
-      const originator = record.originatorInstanceId ?? instanceId;
-      if (originator !== instanceId && peer.role !== "hub") {
-        skipped++;
-        continue;
-      }
-
       try {
-        const local = await table.get(record.id);
+        const table = tableMap[record.table];
+        const local = table ? await table.get(record.id) : null;
 
-        // Timestamp ceiling: reject records with updatedAt more than 5 minutes in the future.
-        // Prevents attackers from using far-future timestamps to permanently win LWW.
-        const fiveMinFromNow = new Date(Date.now() + 5 * 60 * 1000).toISOString();
-        if (record.updatedAt > fiveMinFromNow) {
-          skipped++;
-          continue;
-        }
+        const decision = classifyRecord(
+          record,
+          peer.role,
+          instanceId,
+          local,
+          knownTables,
+        );
 
-        // No-op skip: if the local record exists, has the same contentHash, and
-        // the remote isn't strictly newer, the sync is a phantom — same bytes,
-        // same logical version. Writing it anyway re-blobs the HNSW embedding
-        // (BlobDB stores each version separately) and bloats the dataset
-        // quadratically with poll frequency. Caught 2026-05-19 after the
-        // Fabric cluster hit its 4.7G XFS quota with 5,899 blob entries
-        // across 109 unique IDs (~54 versions per live record).
-        const remoteContentHash = (record.data as any)?.contentHash;
-        if (
-          local &&
-          local.contentHash &&
-          remoteContentHash &&
-          local.contentHash === remoteContentHash &&
-          record.updatedAt <= (local.updatedAt ?? "")
-        ) {
-          skipped++;
+        if (decision.action === "skip") {
+          recordSkip(decision.reason);
           continue;
         }
 
         const mergedData = mergeRecord(local, record);
-
-        // Preserve originator for provenance
-        mergedData._originatorInstanceId = originator;
+        mergedData._originatorInstanceId = decision.originator;
         mergedData._syncedFrom = instanceId;
         mergedData._syncedAt = new Date().toISOString();
 
         await table.put(mergedData);
         merged++;
-      } catch {
-        skipped++;
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        recordSkip("merge_error");
+        // Cap the captured-error list so a hostile/buggy peer can't blow up
+        // the SyncLog row, but ALWAYS log to console so operators don't lose
+        // the per-record signal — the silent-swallow is the bug we're fixing.
+        if (mergeErrors.length < 10) {
+          mergeErrors.push(`${record.table}/${record.id}: ${msg}`);
+        }
+        console.warn(
+          `[Federation] merge error for ${record.table}/${record.id} from ${instanceId}: ${msg}`,
+        );
       }
     }
 
-    // Update peer sync cursor
-    await (databases as any).flair.Peer.put({
+    // Peer cursor update — distinguish liveness from progress:
+    //   lastSyncAt → "we heard from this peer just now" (always update)
+    //   lastMergeAt → "data actually flowed in" (only when merged > 0)
+    // Conflating them produced the "green dashboard while burning" failure
+    // mode — dogfood pass 2026-05-26 surfaced unconditional update masking
+    // 100%-skip syncs.
+    const nowIso = new Date().toISOString();
+    const peerUpdate: Record<string, any> = {
       ...peer,
-      lastSyncAt: new Date().toISOString(),
-      lastSyncCursor: lamportClock?.toString() ?? new Date().toISOString(),
+      lastSyncAt: nowIso,
+      lastSyncCursor: lamportClock?.toString() ?? nowIso,
       status: "connected",
-      updatedAt: new Date().toISOString(),
-    });
+      updatedAt: nowIso,
+    };
+    if (merged > 0) {
+      peerUpdate.lastMergeAt = nowIso;
+    }
+    await (databases as any).flair.Peer.put(peerUpdate);
 
-    // Log sync operation
+    // Log sync operation with skip-reason breakdown so the partial state
+    // is debuggable instead of a black box.
     try {
+      const errorParts: string[] = [];
+      if (Object.keys(skippedReasons).length > 0) {
+        errorParts.push(
+          "skipped: " +
+            Object.entries(skippedReasons)
+              .map(([reason, n]) => `${n} ${reason}`)
+              .join(", "),
+        );
+      }
+      if (mergeErrors.length > 0) {
+        errorParts.push("merge_errors: " + mergeErrors.join("; "));
+      }
+      const errorSummary = errorParts.length > 0 ? errorParts.join(" | ") : undefined;
+      const status = mergeErrors.length > 0
+        ? "partial"
+        : skipped > 0 ? "partial" : "success";
+
       await (databases as any).flair.SyncLog.put({
         id: `sync_${Date.now()}_${randomBytes(4).toString("hex")}`,
         peerId: instanceId,
         direction: "pull",
         recordCount: merged,
-        status: skipped > 0 ? "partial" : "success",
-        error: skipped > 0 ? `${skipped} records skipped` : undefined,
+        skippedCount: skipped,
+        skippedReasons: JSON.stringify(skippedReasons),
+        status,
+        error: errorSummary,
         durationMs: Date.now() - startTime,
-        createdAt: new Date().toISOString(),
+        createdAt: nowIso,
       });
     } catch { /* non-fatal */ }
 
     return {
       merged,
       skipped,
+      skippedReasons,
       total: records.length,
       durationMs: Date.now() - startTime,
     };

--- a/resources/federation-classify.ts
+++ b/resources/federation-classify.ts
@@ -1,0 +1,63 @@
+/**
+ * Pure classifier for federation sync records — no Harper imports.
+ *
+ * Extracted from Federation.ts so the decision can be unit-tested without
+ * spinning up Harper's database module. The same SkipReason names are used
+ * in SyncLog.skippedReasons so operators can grep for them.
+ */
+
+export interface SyncRecord {
+  table: string;
+  id: string;
+  data: Record<string, any>;
+  updatedAt: string;
+  originatorInstanceId: string;
+  signature?: string;
+  principalId?: string;
+}
+
+export type SkipReason =
+  | "unknown_table"
+  | "non_originator"
+  | "future_timestamp"
+  | "no_op_same_hash";
+
+export type ClassifyResult =
+  | { action: "merge"; originator: string }
+  | { action: "skip"; reason: SkipReason };
+
+export function classifyRecord(
+  record: SyncRecord,
+  peerRole: string,
+  receiverInstanceId: string,
+  local: Record<string, any> | null,
+  knownTables: Set<string>,
+  now: Date = new Date(),
+): ClassifyResult {
+  if (!knownTables.has(record.table)) {
+    return { action: "skip", reason: "unknown_table" };
+  }
+
+  const originator = record.originatorInstanceId ?? receiverInstanceId;
+  if (originator !== receiverInstanceId && peerRole !== "hub") {
+    return { action: "skip", reason: "non_originator" };
+  }
+
+  const fiveMinFromNow = new Date(now.getTime() + 5 * 60 * 1000).toISOString();
+  if (record.updatedAt > fiveMinFromNow) {
+    return { action: "skip", reason: "future_timestamp" };
+  }
+
+  const remoteContentHash = (record.data as any)?.contentHash;
+  if (
+    local &&
+    local.contentHash &&
+    remoteContentHash &&
+    local.contentHash === remoteContentHash &&
+    record.updatedAt <= (local.updatedAt ?? "")
+  ) {
+    return { action: "skip", reason: "no_op_same_hash" };
+  }
+
+  return { action: "merge", originator };
+}

--- a/schemas/federation.graphql
+++ b/schemas/federation.graphql
@@ -30,7 +30,8 @@ type Peer @table(database: "flair") @export {
   role: String @indexed            # "hub" | "spoke"
   endpoint: String                 # wss:// URL for the peer
   status: String @indexed          # "paired" | "connected" | "disconnected" | "revoked"
-  lastSyncAt: String               # last successful sync timestamp
+  lastSyncAt: String               # last contact with this peer (liveness signal)
+  lastMergeAt: String              # last sync where merged > 0 (data-progress signal)
   lastSyncCursor: String           # Lamport clock or ISO timestamp for incremental sync
   relayOnly: Boolean               # true for spoke-to-spoke peers announced by hub
   pairedAt: String
@@ -43,9 +44,11 @@ type SyncLog @table(database: "flair") {
   id: ID @primaryKey
   peerId: String! @indexed         # which peer this sync was with
   direction: String! @indexed      # "push" | "pull"
-  recordCount: Int                 # how many records in this sync batch
+  recordCount: Int                 # how many records merged in this batch
+  skippedCount: Int                # how many records skipped (sum of skippedReasons)
+  skippedReasons: String           # JSON: { unknown_table: N, non_originator: N, future_timestamp: N, no_op_same_hash: N, merge_error: N }
   status: String @indexed          # "success" | "partial" | "failed"
-  error: String                    # error message if failed
+  error: String                    # human-readable summary if partial/failed (includes per-record error messages, capped)
   durationMs: Int                  # how long the sync took
   createdAt: String! @indexed
 }

--- a/test/unit/federation-classify-record.test.ts
+++ b/test/unit/federation-classify-record.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, test } from "bun:test";
+import { classifyRecord } from "../../resources/federation-classify.js";
+
+// classifyRecord is the pure decision function extracted from FederationSync.post.
+// Centralizing the skip-vs-merge decision lets us categorize skips for
+// observability — previously every skip path collapsed into `skipped++` with
+// no operator-visible reason ("green dashboard while burning").
+
+describe("classifyRecord — skip categorization", () => {
+  const knownTables = new Set(["Memory", "Soul", "Agent", "Relationship"]);
+  const receiverId = "flair_hub_1";
+  const now = new Date("2026-05-27T00:00:00Z");
+
+  function makeRecord(over: Record<string, any> = {}): any {
+    return {
+      table: "Memory",
+      id: "mem-1",
+      data: { id: "mem-1", content: "hi" },
+      updatedAt: "2026-05-27T00:00:00Z",
+      originatorInstanceId: receiverId,
+      ...over,
+    };
+  }
+
+  test("merges valid spoke-originated record", () => {
+    const r = makeRecord({ originatorInstanceId: "spoke-1" });
+    const result = classifyRecord(r, "spoke", "spoke-1", null, knownTables, now);
+    expect(result).toEqual({ action: "merge", originator: "spoke-1" });
+  });
+
+  test("hub may relay records originated by another peer", () => {
+    const r = makeRecord({ originatorInstanceId: "spoke-2" });
+    // Receiver is hub; sender is a hub-role peer (e.g., spokes' shared hub
+    // relaying spoke-2's record).
+    const result = classifyRecord(r, "hub", receiverId, null, knownTables, now);
+    expect(result).toEqual({ action: "merge", originator: "spoke-2" });
+  });
+
+  test("skip: unknown_table when table name not in tableMap", () => {
+    const r = makeRecord({ table: "NotARealTable" });
+    const result = classifyRecord(r, "spoke", receiverId, null, knownTables, now);
+    expect(result).toEqual({ action: "skip", reason: "unknown_table" });
+  });
+
+  test("skip: non_originator when spoke pushes a record it didn't originate", () => {
+    const r = makeRecord({ originatorInstanceId: "some-other-spoke" });
+    // peer is a spoke (not hub), so it cannot relay records.
+    const result = classifyRecord(r, "spoke", receiverId, null, knownTables, now);
+    expect(result).toEqual({ action: "skip", reason: "non_originator" });
+  });
+
+  test("skip: future_timestamp when updatedAt > 5min in the future", () => {
+    const tenMinFromNow = new Date(now.getTime() + 10 * 60 * 1000).toISOString();
+    const r = makeRecord({ updatedAt: tenMinFromNow });
+    const result = classifyRecord(r, "spoke", receiverId, null, knownTables, now);
+    expect(result).toEqual({ action: "skip", reason: "future_timestamp" });
+  });
+
+  test("allows: timestamps within the 5-minute ceiling", () => {
+    const fourMinFromNow = new Date(now.getTime() + 4 * 60 * 1000).toISOString();
+    const r = makeRecord({ updatedAt: fourMinFromNow });
+    const result = classifyRecord(r, "spoke", receiverId, null, knownTables, now);
+    expect(result.action).toBe("merge");
+  });
+
+  test("skip: no_op_same_hash when contentHash matches and remote not strictly newer", () => {
+    const r = makeRecord({
+      data: { id: "mem-1", content: "hi", contentHash: "h1" },
+      updatedAt: "2026-05-27T00:00:00Z",
+    });
+    const local = { id: "mem-1", contentHash: "h1", updatedAt: "2026-05-27T00:00:00Z" };
+    const result = classifyRecord(r, "spoke", receiverId, local, knownTables, now);
+    expect(result).toEqual({ action: "skip", reason: "no_op_same_hash" });
+  });
+
+  test("merges: same contentHash but remote is strictly newer (LWW progress)", () => {
+    const r = makeRecord({
+      data: { id: "mem-1", content: "hi", contentHash: "h1" },
+      updatedAt: "2026-05-27T00:00:01Z",
+    });
+    const local = { id: "mem-1", contentHash: "h1", updatedAt: "2026-05-27T00:00:00Z" };
+    const result = classifyRecord(r, "spoke", receiverId, local, knownTables, now);
+    expect(result.action).toBe("merge");
+  });
+
+  test("merges: different contentHash even if remote not newer (LWW field overwrites)", () => {
+    const r = makeRecord({
+      data: { id: "mem-1", content: "hi", contentHash: "h2" },
+      updatedAt: "2026-05-27T00:00:00Z",
+    });
+    const local = { id: "mem-1", contentHash: "h1", updatedAt: "2026-05-27T00:00:00Z" };
+    const result = classifyRecord(r, "spoke", receiverId, local, knownTables, now);
+    expect(result.action).toBe("merge");
+  });
+
+  test("originator defaults to receiverInstanceId when record omits it", () => {
+    // If the spoke didn't include originatorInstanceId, FederationSync treats
+    // the record as if the SENDER originated it — that's the spoke's own ID.
+    const r = makeRecord({ originatorInstanceId: undefined });
+    const result = classifyRecord(r, "spoke", "spoke-1", null, knownTables, now);
+    // receiverInstanceId is spoke-1 in this test, so default originator is spoke-1
+    // → spoke-1 === receiver, NOT non_originator skip.
+    expect(result).toEqual({ action: "merge", originator: "spoke-1" });
+  });
+});


### PR DESCRIPTION
## Summary

Dogfood pass 2026-05-26 surfaced a compound observability bug in `FederationSync.post`:

- Every per-record skip path collapsed into a single `skipped++` counter (no operator-visible reason)
- The merge-error catch was a silent swallow (`catch { skipped++ }`)
- `peer.lastSyncAt` updated unconditionally — green dashboard while 100% of records being dropped

This PR makes the receive side telemetry tell the truth.

## What changed

1. **Pure classifier**: extracted `classifyRecord` to `resources/federation-classify.ts` — no Harper imports, fully unit-testable. Returns a tagged result with one of four named skip reasons (`unknown_table`, `non_originator`, `future_timestamp`, `no_op_same_hash`) or `merge` with originator. **No behavior change** to the merge gate — just categorization.

2. **Skip-reason aggregation**: `FederationSync.post` now tracks `skippedReasons: Record<string, number>` alongside `skipped`. The merge-error catch logs via `console.warn` and captures the first 10 error messages (bounded so a hostile peer can't blow up the SyncLog row).

3. **Liveness vs. progress split** on the `Peer` record:
   - `lastSyncAt` — updates on every contact (\"we heard from this peer\")
   - `lastMergeAt` — updates only when `merged > 0` (\"data actually flowed in\")
   
   The unconditional `lastSyncAt` was the smoking gun for the \"green dashboard while burning\" failure mode.

4. **SyncLog row** gains `skippedCount` + `skippedReasons` (JSON string). `error` is now a human-readable summary including the skip breakdown and capped per-record error messages.

5. **Schema additions are purely additive** — no migration needed.

## Test plan

- [x] 10 new unit tests in `test/unit/federation-classify-record.test.ts` covering every classifier branch (merge / 4 skip reasons / hub-relay / originator default / LWW edge cases)
- [x] Existing federation tests (federation-sync-auth + federation-sync-e2e) pass unchanged — 26 total
- [x] Full unit suite green: **889 pass / 0 fail**
- [x] tsc clean (1 pre-existing error in `auth-middleware.ts` unrelated)

## Why now

This is a dogfood-mature fix: the bug class doesn't manifest until federation runs long enough for skip-causing edge cases to accumulate (clock-skewed peer pushing future-timestamped records, hash-collision no-ops, spoke pushing a non-originated record). On a quiet test cluster everything looks green. Surfacing the failure mode in the dashboard now beats discovering it after a production federation deployment masks it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)