### PR TITLE
fix(rem): hard-fail restore on missing metadata.agentId (defense-in-depth)

### DIFF
--- a/src/rem/restore.ts
+++ b/src/rem/restore.ts
@@ -137,8 +137,22 @@ export async function applySnapshot(opts: RestoreOpts): Promise<RestoreResult> {
     return result;
   }
 
-  // 3. Verify agent id matches.
-  if (metadata.agentId && metadata.agentId !== opts.agentId) {
+  // 3. Verify agent id matches. Hard-fail on missing OR mismatched —
+  //    the previous `metadata.agentId && ...` short-circuited on missing,
+  //    which means a snapshot crafted without metadata.agentId would bypass
+  //    the cross-agent guard entirely. v0.9.0+ snapshots always write
+  //    metadata.agentId (see src/rem/snapshot.ts), so the missing case can
+  //    only originate from pre-v0.9.0 snapshots or external/hand-edited
+  //    input — both of which we must reject.
+  if (!metadata.agentId) {
+    errors.push(
+      `snapshot is missing metadata.agentId — refusing to restore (pre-v0.9.0 or untrusted snapshot)`,
+    );
+    result.status = "failed";
+    rmSync(tmp, { recursive: true, force: true });
+    return result;
+  }
+  if (metadata.agentId !== opts.agentId) {
     errors.push(
       `snapshot agentId (${metadata.agentId}) does not match target (${opts.agentId}) — refusing to restore cross-agent`,
     );

--- a/test/rem-restore.test.ts
+++ b/test/rem-restore.test.ts
@@ -15,6 +15,7 @@ import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { applySnapshot, type ApiCall } from "../src/rem/restore.ts";
 import { createSnapshot } from "../src/rem/snapshot.ts";
+import { create as tarCreate, extract as tarExtract } from "tar";
 
 let testRoot: string;
 let snapshotRoot: string;
@@ -110,6 +111,39 @@ describe("applySnapshot — agent-id mismatch", () => {
     });
     expect(r.status).toBe("failed");
     expect(r.errors[0]).toContain("does not match target");
+    expect(r.preRestoreSnapshotPath).toBeUndefined();
+  });
+
+  it("refuses to restore when snapshot.metadata.agentId is missing (pre-0.9.0 / crafted snapshot)", async () => {
+    // Build a tarball whose metadata.json omits agentId entirely — simulates
+    // pre-v0.9.0 snapshots, hand-edited input, or attacker-crafted tarballs.
+    // The original short-circuit predicate (`metadata.agentId && ...`) would
+    // silently bypass the cross-agent guard for this case.
+    const srcDir = await makeTestSnapshot("alice");
+    const extractDir = join(testRoot, "extract-no-agentid");
+    mkdirSync(extractDir, { recursive: true });
+    await tarExtract({ file: srcDir, cwd: extractDir });
+    const metaPath = join(extractDir, "metadata.json");
+    const meta = JSON.parse(readFileSync(metaPath, "utf-8"));
+    delete meta.agentId;
+    writeFileSync(metaPath, JSON.stringify(meta, null, 2));
+    const tamperedTarPath = join(testRoot, "tampered.tar.gz");
+    await tarCreate(
+      { gzip: true, cwd: extractDir, file: tamperedTarPath, portable: true },
+      ["memories.jsonl", "soul.json", "metadata.json"],
+    );
+
+    const { api } = recordingApi();
+    const r = await applySnapshot({
+      agentId: "bob",
+      snapshotPath: tamperedTarPath,
+      flairVersion: "0.0.0-test",
+      apiCall: api,
+      preRestoreSnapshotRoot: snapshotRoot,
+      tmpRootOverride: testRoot,
+    });
+    expect(r.status).toBe("failed");
+    expect(r.errors[0]).toContain("missing metadata.agentId");
     expect(r.preRestoreSnapshotPath).toBeUndefined();
   });
 });


### PR DESCRIPTION
## Summary

Closes [ops-bijw](https://github.com/dtrt-dev/ops). Per 2026-05-26 dogfood code-read of `src/rem/restore.ts:141`.

The original cross-agent guard was a short-circuit:

\`\`\`ts
if (metadata.agentId && metadata.agentId !== opts.agentId) { ... fail }
\`\`\`

If `metadata.agentId` was missing (undefined/empty/null), the **entire check was silently skipped** — the restore proceeded as if the snapshot belonged to the target agent.

v0.9.0+ snapshots always write `metadata.agentId` (see `src/rem/snapshot.ts:85`), so the missing case can only originate from:

- (a) snapshots created before v0.9.0
- (b) hand-edited / externally-supplied snapshots
- (c) attacker-crafted snapshots

All three should be rejected. This PR splits the check into two explicit clauses so missing is treated identically to mismatched.

## Test coverage

The existing test (\"refuses to restore when snapshot.metadata.agentId differs from target\") covered mismatch. **New test covers the missing case** by extracting a valid snapshot, deleting `metadata.agentId`, repacking, and asserting `status:\"failed\"` with the right error message.

## Test plan

- [x] 7/7 rem-restore tests pass (new test included)
- [x] 889/889 unit suite pass
- [x] tsc clean delta

🤖 Generated with [Claude Code](https://claude.com/claude-code)