### PR TITLE
feat(rem): post-restore state verification — detect silent PUT/DELETE drift

### DIFF
--- a/src/rem/restore.ts
+++ b/src/rem/restore.ts
@@ -35,6 +35,13 @@ export interface RestoreOpts {
   preRestoreSnapshotRoot?: string;
   /** When true, plan and report what would happen — no API mutations. */
   dryRun?: boolean;
+  /**
+   * After the PUT loop, GET back the agent's memories + souls and diff
+   * against the snapshot to detect silent failures (schema coercion, 4xx
+   * responses the apiCall layer masked, partial accepts). Default true.
+   * Disable only for tests that intentionally simulate inconsistent state.
+   */
+  verifyPostRestore?: boolean;
   /** Override tmpdir for testing. */
   tmpRootOverride?: string;
   /** Override "now" for testing. */
@@ -54,6 +61,23 @@ export interface RestoreResult {
   restored: {
     memories: number;
     souls: number;
+  };
+  /**
+   * Post-restore state verification. Populated when verifyPostRestore is on
+   * (default). `missing*` IDs were in the snapshot but absent from Harper
+   * afterwards (silent PUT failure). `extra*` IDs were present afterwards
+   * but not in the snapshot (silent DELETE failure / lingering rows).
+   * Both fields being empty means the restore is byte-clean.
+   */
+  verified?: {
+    expectedMemoryIds: string[];
+    expectedSoulIds: string[];
+    actualMemoryIds: string[];
+    actualSoulIds: string[];
+    missingMemoryIds: string[];
+    missingSoulIds: string[];
+    extraMemoryIds: string[];
+    extraSoulIds: string[];
   };
   errors: string[];
 }
@@ -228,6 +252,59 @@ export async function applySnapshot(opts: RestoreOpts): Promise<RestoreResult> {
       result.restored.souls++;
     } catch (err: any) {
       errors.push(`put-soul ${s.id}: ${err?.message ?? String(err)}`);
+    }
+  }
+
+  // 7. Verify post-restore state (default on; opt-out via verifyPostRestore=false).
+  //    Catches silent failures: Harper schema coercion, 4xx responses the
+  //    apiCall layer masked as ok, partial-DELETE leftovers. Per-ID diff,
+  //    not just counts — count parity can hide simultaneous PUT+DELETE
+  //    failures that wash out numerically. See ops-90dq.
+  if (opts.verifyPostRestore !== false) {
+    try {
+      const verifyMem = asArray(await opts.apiCall("GET", `/Memory?agentId=${encodeURIComponent(opts.agentId)}`));
+      const verifySouls = asArray(await opts.apiCall("GET", `/Soul?agentId=${encodeURIComponent(opts.agentId)}`));
+
+      const expectedMemoryIds = memories.filter((m) => m?.id).map((m) => String(m.id));
+      const expectedSoulIds = souls.filter((s) => s?.id).map((s) => String(s.id));
+      const actualMemoryIds = verifyMem.filter((m) => m?.id).map((m) => String(m.id));
+      const actualSoulIds = verifySouls.filter((s) => s?.id).map((s) => String(s.id));
+
+      const expMem = new Set(expectedMemoryIds);
+      const expSoul = new Set(expectedSoulIds);
+      const actMem = new Set(actualMemoryIds);
+      const actSoul = new Set(actualSoulIds);
+
+      const missingMemoryIds = [...expMem].filter((id) => !actMem.has(id));
+      const missingSoulIds = [...expSoul].filter((id) => !actSoul.has(id));
+      const extraMemoryIds = [...actMem].filter((id) => !expMem.has(id));
+      const extraSoulIds = [...actSoul].filter((id) => !expSoul.has(id));
+
+      result.verified = {
+        expectedMemoryIds,
+        expectedSoulIds,
+        actualMemoryIds,
+        actualSoulIds,
+        missingMemoryIds,
+        missingSoulIds,
+        extraMemoryIds,
+        extraSoulIds,
+      };
+
+      if (missingMemoryIds.length > 0) {
+        errors.push(`post-restore-verify: ${missingMemoryIds.length} memory rows missing (e.g. ${missingMemoryIds.slice(0, 3).join(", ")})`);
+      }
+      if (missingSoulIds.length > 0) {
+        errors.push(`post-restore-verify: ${missingSoulIds.length} soul rows missing (e.g. ${missingSoulIds.slice(0, 3).join(", ")})`);
+      }
+      if (extraMemoryIds.length > 0) {
+        errors.push(`post-restore-verify: ${extraMemoryIds.length} unexpected memory rows present (e.g. ${extraMemoryIds.slice(0, 3).join(", ")})`);
+      }
+      if (extraSoulIds.length > 0) {
+        errors.push(`post-restore-verify: ${extraSoulIds.length} unexpected soul rows present (e.g. ${extraSoulIds.slice(0, 3).join(", ")})`);
+      }
+    } catch (err: any) {
+      errors.push(`post-restore-verify: ${err?.message ?? String(err)}`);
     }
   }
 

--- a/test/rem-restore.test.ts
+++ b/test/rem-restore.test.ts
@@ -65,6 +65,55 @@ function recordingApi(handlers: Record<string, (path: string, body?: unknown) =>
   return { api, calls };
 }
 
+/**
+ * Stateful apiCall that simulates Harper's GET-after-PUT consistency.
+ * Use when a test exercises the full restore + verifyPostRestore loop —
+ * the verify pass GETs back the actual post-restore state, which the
+ * static recordingApi can't model.
+ *
+ * `seed` populates the initial state. Subsequent PUT/DELETE/GET mutate
+ * and read that state. `corruptOnPut` lets tests simulate Harper silently
+ * dropping rows (returns ok but skips the state write).
+ */
+function statefulApi(seed: { memories?: any[]; souls?: any[] } = {}, corruptOnPut?: (path: string) => boolean): {
+  api: ApiCall;
+  calls: Array<{ method: string; path: string; body?: unknown }>;
+  state: { memories: Map<string, any>; souls: Map<string, any> };
+} {
+  const calls: Array<{ method: string; path: string; body?: unknown }> = [];
+  const state = {
+    memories: new Map<string, any>((seed.memories ?? []).map((m) => [String(m.id), m])),
+    souls: new Map<string, any>((seed.souls ?? []).map((s) => [String(s.id), s])),
+  };
+  const api: ApiCall = async (method, path, body) => {
+    calls.push({ method, path, body });
+    if (method === "GET" && path.startsWith("/Memory?")) return Array.from(state.memories.values());
+    if (method === "GET" && path.startsWith("/Soul?")) return Array.from(state.souls.values());
+    if (method === "DELETE" && path.startsWith("/Memory/")) {
+      state.memories.delete(decodeURIComponent(path.split("/")[2]));
+      return { ok: true };
+    }
+    if (method === "DELETE" && path.startsWith("/Soul/")) {
+      state.souls.delete(decodeURIComponent(path.split("/")[2]));
+      return { ok: true };
+    }
+    if (method === "PUT" && path.startsWith("/Memory/")) {
+      if (!(corruptOnPut && corruptOnPut(path))) {
+        state.memories.set(decodeURIComponent(path.split("/")[2]), body);
+      }
+      return { ok: true };
+    }
+    if (method === "PUT" && path.startsWith("/Soul/")) {
+      if (!(corruptOnPut && corruptOnPut(path))) {
+        state.souls.set(decodeURIComponent(path.split("/")[2]), body);
+      }
+      return { ok: true };
+    }
+    throw new Error(`unexpected api: ${method}:${path}`);
+  };
+  return { api, calls, state };
+}
+
 describe("applySnapshot — dry-run", () => {
   it("reports planned counts without making destructive calls", async () => {
     const snapshotPath = await makeTestSnapshot();
@@ -131,12 +180,11 @@ describe("applySnapshot — missing snapshot", () => {
 });
 
 describe("applySnapshot — real restore", () => {
-  it("creates pre-restore snapshot, deletes current rows, PUTs snapshot rows", async () => {
+  it("creates pre-restore snapshot, deletes current rows, PUTs snapshot rows, verifies clean", async () => {
     const snapshotPath = await makeTestSnapshot();
-    const current = [{ id: "old-1", agentId: "test-agent" }, { id: "old-2", agentId: "test-agent" }];
-    const { api, calls } = recordingApi({
-      "GET:/Memory": () => current,
-      "GET:/Soul": () => [{ id: "current-soul", agentId: "test-agent" }],
+    const { api, calls } = statefulApi({
+      memories: [{ id: "old-1", agentId: "test-agent" }, { id: "old-2", agentId: "test-agent" }],
+      souls: [{ id: "current-soul", agentId: "test-agent" }],
     });
 
     const r = await applySnapshot({
@@ -157,7 +205,14 @@ describe("applySnapshot — real restore", () => {
     expect(r.preRestoreSnapshotPath).toBeDefined();
     expect(existsSync(r.preRestoreSnapshotPath!)).toBe(true);
 
-    // Call ordering: 2 GETs for the pre-restore fetch, then DELETEs (2 mem + 1 soul), then PUTs (2 mem + 1 soul).
+    // Verify pass ran and found a clean restore.
+    expect(r.verified).toBeDefined();
+    expect(r.verified!.missingMemoryIds).toEqual([]);
+    expect(r.verified!.missingSoulIds).toEqual([]);
+    expect(r.verified!.extraMemoryIds).toEqual([]);
+    expect(r.verified!.extraSoulIds).toEqual([]);
+
+    // Call ordering: pre-restore GETs, DELETEs (2 mem + 1 soul), PUTs (2 mem + 1 soul), post-restore verify GETs.
     const writes = calls.filter((c) => c.method === "DELETE" || c.method === "PUT");
     expect(writes.length).toBe(6);
     expect(writes.slice(0, 3).every((c) => c.method === "DELETE")).toBe(true);
@@ -170,10 +225,7 @@ describe("applySnapshot — real restore", () => {
       { id: "current-1", agentId: "test-agent", content: "current" },
       { id: "current-2", agentId: "test-agent", content: "more current" },
     ];
-    const { api } = recordingApi({
-      "GET:/Memory": () => beforeState,
-      "GET:/Soul": () => [],
-    });
+    const { api } = statefulApi({ memories: beforeState, souls: [] });
 
     const r = await applySnapshot({
       agentId: "test-agent",
@@ -195,6 +247,114 @@ describe("applySnapshot — real restore", () => {
       .split("\n")
       .map((l) => JSON.parse(l));
     expect(lines).toEqual(beforeState);
+  });
+});
+
+describe("applySnapshot — post-restore verification (ops-90dq)", () => {
+  it("flags drift when Harper silently drops PUT rows", async () => {
+    // Simulates the failure mode the verify pass is designed to catch:
+    // Harper returns ok on PUT but doesn't actually persist the row
+    // (schema coercion, BlobDB rejection, 4xx-masked-as-2xx, etc.).
+    const snapshotPath = await makeTestSnapshot();
+    // Drop the second memory PUT silently.
+    const { api } = statefulApi(
+      {},
+      (path) => path === "/Memory/m2",
+    );
+
+    const r = await applySnapshot({
+      agentId: "test-agent",
+      snapshotPath,
+      flairVersion: "0.0.0-test",
+      apiCall: api,
+      preRestoreSnapshotRoot: snapshotRoot,
+      tmpRootOverride: testRoot,
+    });
+
+    expect(r.status).toBe("failed");
+    expect(r.verified).toBeDefined();
+    expect(r.verified!.missingMemoryIds).toEqual(["m2"]);
+    expect(r.verified!.extraMemoryIds).toEqual([]);
+    expect(r.errors.some((e) => e.includes("post-restore-verify") && e.includes("memory rows missing") && e.includes("m2"))).toBe(true);
+    // restored.memories says 2 because the apiCall returned ok — that's the
+    // exact lie the verify pass is built to detect.
+    expect(r.restored.memories).toBe(2);
+  });
+
+  it("flags drift when DELETE leaves rows behind (lingering pre-state)", async () => {
+    const snapshotPath = await makeTestSnapshot();
+    // Seed with a leftover row that won't match the snapshot's IDs.
+    const { api } = statefulApi({
+      memories: [{ id: "old-leftover", agentId: "test-agent" }],
+    });
+
+    // Intercept DELETE /Memory/old-leftover to no-op (simulates Harper
+    // returning ok but not actually deleting).
+    const innerApi = api;
+    const interceptedApi: ApiCall = async (method, path, body) => {
+      if (method === "DELETE" && path === "/Memory/old-leftover") {
+        return { ok: true }; // silent no-op
+      }
+      return innerApi(method, path, body);
+    };
+
+    const r = await applySnapshot({
+      agentId: "test-agent",
+      snapshotPath,
+      flairVersion: "0.0.0-test",
+      apiCall: interceptedApi,
+      preRestoreSnapshotRoot: snapshotRoot,
+      tmpRootOverride: testRoot,
+    });
+
+    expect(r.status).toBe("failed");
+    expect(r.verified).toBeDefined();
+    expect(r.verified!.extraMemoryIds).toEqual(["old-leftover"]);
+    expect(r.errors.some((e) => e.includes("post-restore-verify") && e.includes("unexpected memory rows") && e.includes("old-leftover"))).toBe(true);
+  });
+
+  it("respects verifyPostRestore: false (opt-out for tests)", async () => {
+    const snapshotPath = await makeTestSnapshot();
+    const { api } = statefulApi(
+      {},
+      (path) => path === "/Memory/m2", // would normally trigger drift
+    );
+
+    const r = await applySnapshot({
+      agentId: "test-agent",
+      snapshotPath,
+      flairVersion: "0.0.0-test",
+      apiCall: api,
+      preRestoreSnapshotRoot: snapshotRoot,
+      tmpRootOverride: testRoot,
+      verifyPostRestore: false,
+    });
+
+    expect(r.status).toBe("completed");
+    expect(r.verified).toBeUndefined();
+  });
+
+  it("does not run verify in dry-run", async () => {
+    const snapshotPath = await makeTestSnapshot();
+    const { api, calls } = statefulApi({
+      memories: [{ id: "anything", agentId: "test-agent" }],
+    });
+
+    const r = await applySnapshot({
+      agentId: "test-agent",
+      snapshotPath,
+      flairVersion: "0.0.0-test",
+      apiCall: api,
+      preRestoreSnapshotRoot: snapshotRoot,
+      tmpRootOverride: testRoot,
+      dryRun: true,
+    });
+
+    expect(r.status).toBe("dry-run");
+    expect(r.verified).toBeUndefined();
+    // dry-run does the pre-restore fetch GETs, but no PUT/DELETE and no verify pass.
+    const writes = calls.filter((c) => c.method === "DELETE" || c.method === "PUT");
+    expect(writes).toEqual([]);
   });
 });
 


### PR DESCRIPTION
## Summary

Closes ops-90dq. Per 2026-05-26 dogfood code-read of `src/rem/restore.ts`.

After the PUT loop, `applySnapshot` returned without ever asking Harper whether the rows actually landed. Harper can silently coerce fields, return 2xx on partial accepts, or mask 4xx as ok at the apiCall layer. A silent DELETE failure leaves the pre-state lingering. Both failure modes look identical to a successful restore in the existing RestoreResult — operator sees `status:\"completed\"`.

## What changed

1. **Post-restore verify pass** (default on, opt-out via `verifyPostRestore: false`). After PUT loops, GET the agent's memories + souls back and diff IDs against the snapshot. Surface drift as structured fields on `RestoreResult.verified` AND as error messages that bump status to `\"failed\"`.

2. **Per-ID diff** (not count parity) — count parity can hide simultaneous PUT+DELETE failures that wash out numerically. `missingIds[]` catches rows that should have landed but didn't. `extraIds[]` catches rows that should have been deleted but weren't.

3. **Stateful test fixture** (`statefulApi`). Existing static `recordingApi` can't model GET-after-PUT consistency, which the verify pass now requires. Existing happy-path test upgraded; failure tests stay on `recordingApi` where intentional stub-trickery is the point.

4. **Three new tests** cover the failure modes the verify pass exists for:
   - Harper silently drops a PUT (apiCall returns ok, state unchanged)
   - DELETE leaves a row behind (apiCall returns ok, state unchanged)
   - `verifyPostRestore: false` opt-out path
   - dry-run skips verify

## Test plan

- [x] 10/10 rem-restore tests pass (3 new + 7 existing)
- [x] 889/889 unit suite pass
- [x] tsc clean delta

## Related

This closes the second of the two P2 dogfood findings on REM restore. The first (ops-bijw, missing-agentId hard-fail) is in flight at [#446](https://github.com/tpsdev-ai/flair/pull/446). Independent of Kern's #418 fail-fast follow-up (task #139), which targets per-row abort behavior — that's complementary, not overlapping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)