### PR TITLE
fix(a2a): require auth on POST /a2a (P0 — close OrgEvent forgery + Beads leak)

### DIFF
--- a/resources/A2AAdapter.ts
+++ b/resources/A2AAdapter.ts
@@ -294,9 +294,15 @@ function statusFromOrgEvent(event: any): string | null {
 }
 
 export class A2AAdapter extends Resource {
-  // A2A discovery surface — agent cards and adapter metadata are intentionally
-  // public so other agents/clients can discover this Flair as a memory peer.
-  // Handler enforces auth on actual A2A actions (POST below).
+  // A2A discovery surface — agent-card metadata (GET) is intentionally
+  // public so other agents/clients can discover this Flair as a memory
+  // peer. POST is JSON-RPC for actions (message/send writes OrgEvents,
+  // tasks/list reads Beads issues, message/stream subscribes to events)
+  // and is auth-gated upstream by auth-middleware's narrowed allow-list
+  // (GET /a2a passes through; POST /a2a must carry TPS-Ed25519 or admin
+  // Basic). The post() handler below additionally enforces sender ==
+  // params.agentId for message/send so an authenticated caller can only
+  // act AS themselves, not impersonate another agent.
   allowRead() { return true; }
   allowCreate() { return true; }
 
@@ -343,6 +349,21 @@ export class A2AAdapter extends Resource {
 
     const id = body.id ?? null;
     const params = body.params ?? {};
+
+    // Defense-in-depth: auth-middleware narrows the /a2a allow-list so
+    // POSTs only reach here after TPS-Ed25519 or admin Basic succeeds,
+    // which sets request.tpsAgent / tpsAgentIsAdmin. If middleware was
+    // misconfigured or someone added a back-door allow-list entry, fail
+    // closed here. Pattern matches WorkspaceState/Memory/etc.
+    const ctx = (this as any).getContext?.() ?? _context ?? {};
+    const ctxRequest = ctx.request ?? ctx;
+    const callerAgent: string | undefined = ctxRequest?.tpsAgent;
+    const callerIsAdmin: boolean = ctxRequest?.tpsAgentIsAdmin === true;
+    if (!callerAgent && !callerIsAdmin) {
+      return rpcError(id, -32001, "Unauthorized", {
+        detail: "POST /a2a requires TPS-Ed25519 or admin Basic auth",
+      });
+    }
 
     try {
       if (body.method === "message/stream") {
@@ -437,6 +458,17 @@ export class A2AAdapter extends Resource {
         const message = params.message;
         if (!agentId || !message || typeof message !== "object") {
           return rpcError(id, -32602, "Invalid params: agentId and message are required");
+        }
+
+        // Sender must match params.agentId — you can only send AS yourself.
+        // Admin agents may send as anyone (operational convenience).
+        // Without this check, an authenticated agent could forge OrgEvents
+        // attributed to any other agent — defeats the whole signed-envelopes
+        // model that delegationChain enforces for TPS mail.
+        if (!callerIsAdmin && callerAgent !== agentId) {
+          return rpcError(id, -32001, "Forbidden", {
+            detail: `caller ${callerAgent ?? "(anon)"} cannot send as ${agentId}`,
+          });
         }
 
         const agent = await (databases as any).flair.Agent.get(agentId).catch(() => null);

--- a/resources/auth-middleware.ts
+++ b/resources/auth-middleware.ts
@@ -118,13 +118,19 @@ async function backfillEmbedding(memoryId: string): Promise<void> {
 server.http(async (request: any, nextLayer: any) => {
   const url = new URL(request.url, "http://" + (request.headers.get("host") || "localhost"));
 
+  // A2A discovery endpoints: GET returns public agent-card metadata (per
+  // A2A spec, cards are intentionally public). POST invokes JSON-RPC
+  // actions (message/send writes OrgEvents on behalf of agents,
+  // tasks/list reads Beads issues, message/stream subscribes to
+  // OrgEvents) — those must be authenticated. Narrowing to GET-only
+  // closes the P0 where any caller could forge OrgEvents as any agent
+  // and read all internal Beads issues unauthenticated.
+  const isA2APath = url.pathname === "/a2a" || url.pathname === "/A2AAdapter" || url.pathname.startsWith("/A2AAdapter/");
   if (
     url.pathname === "/health" ||
     url.pathname === "/Health" ||
-    url.pathname === "/a2a" ||
-    url.pathname === "/A2AAdapter" ||
+    (request.method === "GET" && isA2APath) ||
     url.pathname === "/AgentCard" ||
-    url.pathname.startsWith("/A2AAdapter/") ||
     url.pathname.startsWith("/AgentCard/") ||
     // FederationSync uses Ed25519 body-signature auth with anti-replay, validated
     // by the resource handler (allowCreate=true, same pattern as FederationPair).

--- a/test/unit/a2a-auth.test.ts
+++ b/test/unit/a2a-auth.test.ts
@@ -1,0 +1,175 @@
+/**
+ * a2a-auth.test.ts — covers the P0 fix (ops-yhrr / similar): A2AAdapter
+ * POST /a2a was unauthenticated, allowing any caller to forge OrgEvents
+ * impersonating any agent and read all Beads issues.
+ *
+ * The fix has two parts and both are unit-tested here:
+ *
+ * 1. `auth-middleware` allow-list narrowed to GET-only for /a2a and
+ *    /A2AAdapter. POST falls through to TPS-Ed25519 / admin Basic
+ *    enforcement. Verified by simulating the predicate.
+ *
+ * 2. `A2AAdapter.post()` defense-in-depth check: if request.tpsAgent is
+ *    unset (no upstream auth) and not admin, reject with JSON-RPC -32001.
+ *    For message/send, sender must match params.agentId unless admin.
+ *
+ * Note: these tests use the "simulator" pattern (per ops-ketv P1 backlog
+ * to convert to real-module tests). They exercise the decision logic of
+ * the two guards but do NOT exercise Harper's full request/auth pipeline.
+ */
+import { describe, expect, test } from "bun:test";
+
+// ─── Allow-list narrowing (auth-middleware predicate) ─────────────────────
+
+/**
+ * Predicate copied from auth-middleware.ts line 121-150. Returns true
+ * when the request bypasses auth and is forwarded to the handler.
+ */
+function shouldBypassAuth(method: string, pathname: string): boolean {
+  const isA2APath = pathname === "/a2a" || pathname === "/A2AAdapter" || pathname.startsWith("/A2AAdapter/");
+  return (
+    pathname === "/health" ||
+    pathname === "/Health" ||
+    (method === "GET" && isA2APath) ||
+    pathname === "/AgentCard" ||
+    pathname.startsWith("/AgentCard/") ||
+    pathname === "/FederationSync" ||
+    pathname === "/FederationPair" ||
+    pathname === "/OAuthRegister" ||
+    pathname === "/OAuthAuthorize" ||
+    pathname === "/OAuthToken" ||
+    pathname === "/OAuthRevoke" ||
+    pathname === "/.well-known/oauth-authorization-server" ||
+    pathname === "/OAuthMetadata" ||
+    pathname === "/ObservationCenter"
+  );
+}
+
+describe("auth-middleware allow-list: A2A narrowed to GET-only", () => {
+  test("GET /a2a bypasses (public agent card per A2A spec)", () => {
+    expect(shouldBypassAuth("GET", "/a2a")).toBe(true);
+  });
+  test("GET /A2AAdapter bypasses", () => {
+    expect(shouldBypassAuth("GET", "/A2AAdapter")).toBe(true);
+  });
+  test("GET /A2AAdapter/agent-x bypasses", () => {
+    expect(shouldBypassAuth("GET", "/A2AAdapter/agent-x")).toBe(true);
+  });
+  test("POST /a2a does NOT bypass — requires auth", () => {
+    expect(shouldBypassAuth("POST", "/a2a")).toBe(false);
+  });
+  test("POST /A2AAdapter does NOT bypass", () => {
+    expect(shouldBypassAuth("POST", "/A2AAdapter")).toBe(false);
+  });
+  test("PUT /a2a does NOT bypass", () => {
+    expect(shouldBypassAuth("PUT", "/a2a")).toBe(false);
+  });
+  test("DELETE /a2a does NOT bypass", () => {
+    expect(shouldBypassAuth("DELETE", "/a2a")).toBe(false);
+  });
+  test("GET /AgentCard still bypasses (still public per A2A spec)", () => {
+    expect(shouldBypassAuth("GET", "/AgentCard")).toBe(true);
+  });
+  test("GET /AgentCard/flint still bypasses (path prefix)", () => {
+    expect(shouldBypassAuth("GET", "/AgentCard/flint")).toBe(true);
+  });
+});
+
+// ─── A2AAdapter.post() guard logic ────────────────────────────────────────
+
+/**
+ * Reproduces the auth-decision logic at the top of A2AAdapter.post(),
+ * plus the message/send sender-match check. Returns either:
+ *   { rejected: true, code, detail }  — rejection
+ *   { rejected: false, callerAgent, callerIsAdmin } — accepted
+ */
+type AuthCtx = { tpsAgent?: string; tpsAgentIsAdmin?: boolean };
+
+function postAuthDecision(
+  ctx: AuthCtx,
+): { rejected: true; code: number; detail: string } | { rejected: false; callerAgent: string | undefined; callerIsAdmin: boolean } {
+  const callerAgent: string | undefined = ctx?.tpsAgent;
+  const callerIsAdmin: boolean = ctx?.tpsAgentIsAdmin === true;
+  if (!callerAgent && !callerIsAdmin) {
+    return { rejected: true, code: -32001, detail: "POST /a2a requires TPS-Ed25519 or admin Basic auth" };
+  }
+  return { rejected: false, callerAgent, callerIsAdmin };
+}
+
+function messageSendSenderCheck(
+  callerAgent: string | undefined,
+  callerIsAdmin: boolean,
+  paramsAgentId: string,
+): { rejected: true; code: number } | { rejected: false } {
+  if (!callerIsAdmin && callerAgent !== paramsAgentId) {
+    return { rejected: true, code: -32001 };
+  }
+  return { rejected: false };
+}
+
+describe("A2AAdapter.post() — auth decision", () => {
+  test("anonymous request (no tpsAgent, not admin) rejected with -32001", () => {
+    const decision = postAuthDecision({});
+    expect(decision.rejected).toBe(true);
+    if (decision.rejected) {
+      expect(decision.code).toBe(-32001);
+      expect(decision.detail).toContain("TPS-Ed25519 or admin Basic");
+    }
+  });
+
+  test("tpsAgent set: accepted as callerAgent", () => {
+    const decision = postAuthDecision({ tpsAgent: "flint" });
+    expect(decision.rejected).toBe(false);
+    if (!decision.rejected) {
+      expect(decision.callerAgent).toBe("flint");
+      expect(decision.callerIsAdmin).toBe(false);
+    }
+  });
+
+  test("admin Basic accepted even without tpsAgent", () => {
+    const decision = postAuthDecision({ tpsAgentIsAdmin: true });
+    expect(decision.rejected).toBe(false);
+    if (!decision.rejected) {
+      expect(decision.callerIsAdmin).toBe(true);
+    }
+  });
+
+  test("tpsAgent + admin: accepted, both flags set", () => {
+    const decision = postAuthDecision({ tpsAgent: "flint", tpsAgentIsAdmin: true });
+    expect(decision.rejected).toBe(false);
+    if (!decision.rejected) {
+      expect(decision.callerAgent).toBe("flint");
+      expect(decision.callerIsAdmin).toBe(true);
+    }
+  });
+});
+
+describe("A2AAdapter.post() — message/send sender-match", () => {
+  test("caller flint cannot send AS pulse (no admin)", () => {
+    const r = messageSendSenderCheck("flint", false, "pulse");
+    expect(r.rejected).toBe(true);
+    if (r.rejected) expect(r.code).toBe(-32001);
+  });
+
+  test("caller flint can send AS flint", () => {
+    const r = messageSendSenderCheck("flint", false, "flint");
+    expect(r.rejected).toBe(false);
+  });
+
+  test("admin can send AS any agent (operational override)", () => {
+    const r = messageSendSenderCheck(undefined, true, "pulse");
+    expect(r.rejected).toBe(false);
+  });
+
+  test("admin who also has tpsAgent can still send AS others", () => {
+    const r = messageSendSenderCheck("admin-agent", true, "pulse");
+    expect(r.rejected).toBe(false);
+  });
+
+  test("anon (no callerAgent, not admin) — would have been blocked by postAuthDecision; redundant check also blocks", () => {
+    // This branch shouldn't be reachable in production (postAuthDecision
+    // would have already rejected), but the sender-match is defensive.
+    const r = messageSendSenderCheck(undefined, false, "flint");
+    expect(r.rejected).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Closes the **P0** dogfood finding surfaced 2026-05-27. Live-confirmed on rockit:

\`\`\`bash
curl -X POST http://localhost:9926/a2a -d '{
  \"jsonrpc\":\"2.0\", \"id\":\"x\",
  \"method\":\"message/send\",
  \"params\":{\"agentId\":\"flint\", \"message\":{\"parts\":[{\"text\":\"forged\"}]}}
}'
# → returned 200, wrote an OrgEvent attributed to \"flint\" with NO AUTH
\`\`\`

Same endpoint exposed all Beads issues via \`tasks/list\` to anonymous callers.

This directly bypassed the signed-envelopes delegation chain we shipped this week — exactly the boundary that chain enforces for TPS mail.

## Two-layer fix

### 1. `auth-middleware` allow-list narrowed to GET-only for A2A

\`/a2a\` and \`/A2AAdapter*\` previously bypassed auth unconditionally. Now bypass is gated on \`method === \"GET\"\`. GET still returns the public agent card (A2A spec requires cards be public). POST/PUT/DELETE fall through to TPS-Ed25519 / admin Basic enforcement.

\`/AgentCard*\` stays public — those resources are GET-only by design.

### 2. `A2AAdapter.post()` defense-in-depth

Even if the allow-list regresses, the post handler now reads \`request.tpsAgent\` / \`tpsAgentIsAdmin\` from context and returns JSON-RPC \`-32001 Unauthorized\` if neither is set.

Plus a **sender-match check** for \`message/send\`: caller must equal \`params.agentId\` unless they're admin. Without this, an authenticated agent could still impersonate other agents.

## Test plan

- [x] **18 new unit tests** in \`test/unit/a2a-auth.test.ts\`:
  - Allow-list predicate: GET passes for /a2a, /A2AAdapter, /A2AAdapter/<x>; POST/PUT/DELETE blocked; /AgentCard still public
  - post() guard: anon rejected, tpsAgent accepted, admin accepted
  - message/send sender-match: non-admin caller can only send AS self; admin can send AS anyone
- [x] **907/907 unit suite green**
- [x] tsc clean delta (1 pre-existing error in auth-middleware unrelated)

## Limitations / K&S note

These are simulator-pattern tests (per ops-ketv P1 backlog to convert to real-module tests). They exercise decision logic but do NOT spin up the full Harper request pipeline. **K&S diff review should compare the predicate inlined in the test against the real one in `auth-middleware.ts:121-150` to confirm they match.** Same pattern as recent K&S near-misses on inline crypto verify — the tests are necessary but not sufficient.

🤖 Generated with [Claude Code](https://claude.com/claude-code)