### PR TITLE
fix(admin): derive AdminInstance public URL from request headers (closes #404, #402)

### DIFF
--- a/resources/AdminInstance.ts
+++ b/resources/AdminInstance.ts
@@ -14,17 +14,51 @@ import { fileURLToPath } from "node:url";
  * 127.0.0.1 binding address Harper sees internally — so the Endpoints
  * table is copy-pasteable.
  *
- * Fall back to `http://127.0.0.1:${HTTP_PORT}` for local-only installs.
+ * Resolution order:
+ *   1. `FLAIR_PUBLIC_URL` env var (explicit override, always wins)
+ *   2. Request headers (X-Forwarded-Proto + X-Forwarded-Host, or Host)
+ *      — derives from how the operator actually reached the page
+ *   3. `http://127.0.0.1:${HTTP_PORT}` — local-only installs fallback
+ *
+ * The request-header path closes the common case from flair#404:
+ * remote/Fabric deployments without FLAIR_PUBLIC_URL set rendered
+ * localhost URLs that operators couldn't copy-paste. Trusting the Host
+ * header is correct when Harper terminates TLS directly; behind a
+ * reverse proxy that doesn't set X-Forwarded-* headers correctly, the
+ * operator should set FLAIR_PUBLIC_URL explicitly (which wins).
  */
-function resolvePublicUrl(): string {
-  // Explicit override wins. Production deployments (Fabric, VPS-hosted)
-  // should set FLAIR_PUBLIC_URL in their launchd / systemd unit so the
-  // admin pane shows the URL operators actually type, not the binding
-  // address Harper sees internally. Auto-detecting from request headers
-  // is brittle across reverse-proxy configurations.
+function resolvePublicUrl(request?: { headers?: any }): string {
   if (process.env.FLAIR_PUBLIC_URL) {
     return process.env.FLAIR_PUBLIC_URL.replace(/\/$/, "");
   }
+
+  // Best-effort header derivation. Harper's request.headers exposes
+  // both .get(name) and .asObject (case-insensitive). Prefer X-Forwarded-*
+  // when present (caller is behind a proxy that set them); fall back
+  // to the direct Host header.
+  const getHeader = (name: string): string | undefined => {
+    const h = request?.headers;
+    if (!h) return undefined;
+    if (typeof h.get === "function") return h.get(name) ?? h.get(name.toLowerCase()) ?? undefined;
+    if (typeof h === "object") {
+      const obj = h.asObject ?? h;
+      return obj[name] ?? obj[name.toLowerCase()] ?? undefined;
+    }
+    return undefined;
+  };
+
+  const fwdProto = getHeader("X-Forwarded-Proto");
+  const fwdHost = getHeader("X-Forwarded-Host");
+  const host = fwdHost ?? getHeader("Host");
+
+  if (host && /^[\w.\-:]+$/.test(host)) {
+    const scheme = fwdProto && (fwdProto === "http" || fwdProto === "https") ? fwdProto : "https";
+    // If no proxy headers and host has no port, assume http for safety —
+    // most production deployments are behind a proxy with X-Forwarded-Proto.
+    const effectiveScheme = fwdProto ? scheme : (host.includes(":") ? "http" : scheme);
+    return `${effectiveScheme}://${host}`;
+  }
+
   return `http://127.0.0.1:${process.env.HTTP_PORT ?? "19926"}`;
 }
 
@@ -56,7 +90,11 @@ function resolveVersion(): string {
 export class AdminInstance extends Resource {
   async get() {
     const version = resolveVersion();
-    const publicUrl = resolvePublicUrl();
+    // Pass the request through so URL resolution can derive from
+    // X-Forwarded-* / Host headers when FLAIR_PUBLIC_URL isn't set.
+    const ctx = (this as any).getContext?.() ?? {};
+    const request = ctx.request ?? ctx;
+    const publicUrl = resolvePublicUrl(request);
 
     // Try to read instance public key
     let publicKey = "—";

--- a/test/unit/admin-instance-resolve-url.test.ts
+++ b/test/unit/admin-instance-resolve-url.test.ts
@@ -1,0 +1,115 @@
+/**
+ * admin-instance-resolve-url.test.ts — covers flair#404 (admin pane shows
+ * 127.0.0.1 URLs on remote deployments).
+ *
+ * Tests the predicate logic of `resolvePublicUrl` from
+ * resources/AdminInstance.ts. Simulator-pattern (per ops-ketv) — exercises
+ * the decision branches without importing the real Resource class (which
+ * pulls Harper at import time).
+ */
+import { describe, expect, test, beforeEach, afterEach } from "bun:test";
+
+// Reproduces the predicate at resources/AdminInstance.ts:36-72. Keep this
+// in sync with the production function; K&S diff review should verify match.
+type HeaderMap = Record<string, string>;
+function resolvePublicUrl(
+  envPublicUrl: string | undefined,
+  headers: HeaderMap = {},
+  httpPort: string = "19926",
+): string {
+  if (envPublicUrl) return envPublicUrl.replace(/\/$/, "");
+
+  const getHeader = (name: string): string | undefined =>
+    headers[name] ?? headers[name.toLowerCase()] ?? undefined;
+
+  const fwdProto = getHeader("X-Forwarded-Proto");
+  const fwdHost = getHeader("X-Forwarded-Host");
+  const host = fwdHost ?? getHeader("Host");
+
+  if (host && /^[\w.\-:]+$/.test(host)) {
+    const scheme = fwdProto && (fwdProto === "http" || fwdProto === "https") ? fwdProto : "https";
+    const effectiveScheme = fwdProto ? scheme : (host.includes(":") ? "http" : scheme);
+    return `${effectiveScheme}://${host}`;
+  }
+
+  return `http://127.0.0.1:${httpPort}`;
+}
+
+describe("AdminInstance.resolvePublicUrl — flair#404", () => {
+  test("FLAIR_PUBLIC_URL wins over everything else", () => {
+    expect(resolvePublicUrl("https://my-flair.example.com", { Host: "wrong.example.com" }))
+      .toBe("https://my-flair.example.com");
+  });
+
+  test("trailing slash on env var is stripped", () => {
+    expect(resolvePublicUrl("https://my-flair.example.com/", {}))
+      .toBe("https://my-flair.example.com");
+  });
+
+  test("falls back to localhost when no env var AND no headers", () => {
+    expect(resolvePublicUrl(undefined, {})).toBe("http://127.0.0.1:19926");
+  });
+
+  test("HTTP_PORT override flows to localhost fallback", () => {
+    expect(resolvePublicUrl(undefined, {}, "9926")).toBe("http://127.0.0.1:9926");
+  });
+
+  test("Host header drives derivation when no env var, no proxy headers", () => {
+    // Bare host (no port) — assume https. Most cases: TLS-terminated direct.
+    expect(resolvePublicUrl(undefined, { Host: "my-flair.example.com" }))
+      .toBe("https://my-flair.example.com");
+  });
+
+  test("Host header with port → assume http (likely direct dev/test)", () => {
+    expect(resolvePublicUrl(undefined, { Host: "192.168.1.10:19926" }))
+      .toBe("http://192.168.1.10:19926");
+  });
+
+  test("X-Forwarded-Proto + X-Forwarded-Host (typical reverse-proxy setup)", () => {
+    expect(resolvePublicUrl(undefined, {
+      "X-Forwarded-Proto": "https",
+      "X-Forwarded-Host": "flair.example.com",
+      "Host": "internal-host:19926", // proxy's internal hostname
+    })).toBe("https://flair.example.com");
+  });
+
+  test("X-Forwarded-Proto alone (Host carries the public name)", () => {
+    expect(resolvePublicUrl(undefined, {
+      "X-Forwarded-Proto": "https",
+      "Host": "flair.example.com",
+    })).toBe("https://flair.example.com");
+  });
+
+  test("X-Forwarded-Proto=http honored (rare but valid)", () => {
+    expect(resolvePublicUrl(undefined, {
+      "X-Forwarded-Proto": "http",
+      "Host": "flair.example.com",
+    })).toBe("http://flair.example.com");
+  });
+
+  test("malicious Host with newline/CRLF rejected → localhost fallback", () => {
+    // Header injection defence: regex /^[\w.\-:]+$/ rejects \r\n etc.
+    expect(resolvePublicUrl(undefined, { Host: "evil.com\r\nSet-Cookie: x=1" }))
+      .toBe("http://127.0.0.1:19926");
+  });
+
+  test("malicious Host with embedded spaces rejected", () => {
+    expect(resolvePublicUrl(undefined, { Host: "evil.com /AdminMemory" }))
+      .toBe("http://127.0.0.1:19926");
+  });
+
+  test("malicious X-Forwarded-Host rejected", () => {
+    expect(resolvePublicUrl(undefined, {
+      "X-Forwarded-Host": "evil.com\nLog: pwned",
+      "Host": "fine.example.com",
+    })).toBe("http://127.0.0.1:19926");
+  });
+
+  test("X-Forwarded-Proto with garbage value falls back to https default", () => {
+    // Only "http" | "https" honored; anything else → default scheme path.
+    expect(resolvePublicUrl(undefined, {
+      "X-Forwarded-Proto": "javascript",
+      "Host": "flair.example.com",
+    })).toBe("https://flair.example.com");
+  });
+});


### PR DESCRIPTION
Cleans up two open admin-UI bugs Nathan flagged this morning.

## #404 — AdminInstance shows localhost URLs on remote deployments

The May 2026 fix (62af140) added \`FLAIR_PUBLIC_URL\` env-var support, but on deployments where that's NOT set (most fresh installs), the Endpoints table still rendered \`http://127.0.0.1:19926\` URLs that operators couldn't copy-paste.

**Fix**: resolution order is now (1) \`FLAIR_PUBLIC_URL\`, (2) request headers (\`X-Forwarded-Proto\`/\`X-Forwarded-Host\` from proxies; \`Host\` direct), (3) localhost fallback. Bare host assumes \`https\` (most production); host with port assumes \`http\` (dev/internal).

**Safety**: Host-header path is gated by \`/^[\\w.\\-:]+$/\` to reject CRLF / space-injection that could craft malicious admin URLs.

## #402 — Admin footer shows \"vdev\"

Already fixed in 62af140 (resolveVersion reads package.json), but that PR didn't use \`Closes #N\` syntax so GH kept the issue open. Closing it via this PR's body.

## Test plan

- [x] 13 new unit tests in \`test/unit/admin-instance-resolve-url.test.ts\` covering env-var precedence, header derivation, malicious-header rejection (CRLF, spaces), X-Forwarded-Proto variants, localhost fallback
- [x] 920/920 unit suite green
- [x] tsc clean delta

## K&S notes (security lane)

- The Host-header trust decision is the interesting one. The original 62af140 explicitly rejected this on \"brittle across reverse-proxy configurations\" grounds. Compromise: env var ALWAYS wins, headers are a best-effort fallback gated by a safety regex. Operators behind a proxy that doesn't set X-Forwarded-* should set FLAIR_PUBLIC_URL.
- The Host regex rejects newlines, spaces, and other CRLF-injection vectors. Verify the regex matches the spec.
- Tests inline the predicate (per ops-ketv) — confirm it tracks the production function at \`resources/AdminInstance.ts:36-72\`.

Closes #404
Closes #402

🤖 Generated with [Claude Code](https://claude.com/claude-code)