### PR TITLE
fix(health): replace dead soul priority breakdown with by-key (#453)

### DIFF
--- a/packages/flair-client/src/types.ts
+++ b/packages/flair-client/src/types.ts
@@ -30,7 +30,18 @@ export interface SoulEntry {
   agentId: string;
   key: string;
   value: string;
+  /**
+   * Optional governance fields. These exist on the Harper `Soul` schema
+   * (see schemas/memory.graphql) but are not set by `flair soul set`, so they
+   * are absent on hand-authored entries. `priority` is reserved for skill
+   * governance and is currently only ever written as "standard".
+   */
+  priority?: "critical" | "high" | "standard" | "low";
+  durability?: Durability;
+  /** JSON blob (skill governance: source, version, hash, etc.). */
+  metadata?: string;
   createdAt: string;
+  updatedAt?: string;
 }
 
 /** Semantic search result. */

--- a/resources/health.ts
+++ b/resources/health.ts
@@ -191,12 +191,18 @@ export class HealthDetail extends Resource {
       const souls: any[] = [];
       for await (const s of db.flair.Soul.search({})) souls.push(s);
       stats.soulEntries = souls.length;
-      const byPriority = { critical: 0, high: 0, standard: 0, low: 0 } as Record<string, number>;
+      // Soul entries have no severity dimension — they are keyed identity facts
+      // (role / project / standards / …). A per-priority breakdown was dead
+      // telemetry: nothing writes Soul.priority to anything but "standard", and
+      // the `?? "standard"` fallback also mislabelled *unset* as *standard*, so
+      // it always read 100% standard regardless of the data. Report the honest
+      // dimension instead — a count per key.
+      const byKey: Record<string, number> = {};
       for (const s of souls) {
-        const p = (s.priority ?? "standard") as string;
-        if (p in byPriority) byPriority[p]++;
+        const k = (s.key ?? "(unkeyed)") as string;
+        byKey[k] = (byKey[k] ?? 0) + 1;
       }
-      stats.soul = { total: souls.length, byPriority };
+      stats.soul = { total: souls.length, byKey };
     } catch { stats.soulEntries = null; stats.soul = null; }
 
     // ── Federation ──

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -975,6 +975,17 @@ export function probeOpenclawPluginVersion(extensionName: string): string | null
   }
 }
 
+/**
+ * Order a soul key→count map for display: highest count first, ties broken
+ * alphabetically for stable output. Soul entries are keyed identity facts
+ * (role / project / standards / …) — this is the honest breakdown dimension.
+ * (Replaced a priority breakdown that was dead telemetry — see flair#453:
+ * nothing ever writes Soul.priority to anything but "standard".)
+ */
+export function sortSoulKeyEntries(byKey: Record<string, number>): Array<[string, number]> {
+  return Object.entries(byKey ?? {}).sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]));
+}
+
 // ─── First-run soul wizard ────────────────────────────────────────────────────
 
 type SoulEntries = [string, string][];
@@ -5191,15 +5202,13 @@ const statusCmd = program
 
     if (healthData?.soul && healthData.soul.total > 0) {
       const s = healthData.soul;
-      const bp = s.byPriority ?? {};
       console.log(`\n${render.wrap(render.c.bold, "Soul")}`);
-      const parts = [
-        `${render.wrap(render.c.red, "critical")}:${bp.critical ?? 0}`,
-        `${render.wrap(render.c.yellow, "high")}:${bp.high ?? 0}`,
-        `${render.wrap(render.c.cyan, "standard")}:${bp.standard ?? 0}`,
-        `${render.wrap(render.c.gray, "low")}:${bp.low ?? 0}`,
-      ];
-      console.log(render.kv("Entries", `${render.wrap(render.c.bold, String(s.total))} ${render.wrap(render.c.dim, "—")} ${parts.join(render.wrap(render.c.dim, " · "))}`));
+      const entries = sortSoulKeyEntries(s.byKey ?? {});
+      const parts = entries.map(([k, n]) => `${render.wrap(render.c.cyan, k)}:${n}`);
+      const suffix = parts.length > 0
+        ? ` ${render.wrap(render.c.dim, "—")} ${parts.join(render.wrap(render.c.dim, " · "))}`
+        : "";
+      console.log(render.kv("Entries", `${render.wrap(render.c.bold, String(s.total))}${suffix}`));
     } else if (typeof healthData?.soulEntries === "number" && healthData.soulEntries > 0) {
       console.log(`\n${render.wrap(render.c.bold, "Soul")}`);
       console.log(render.kv("Entries", String(healthData.soulEntries)));
@@ -5643,10 +5652,12 @@ statusCmd
 
     if (healthData?.soul && healthData.soul.total > 0) {
       const s = healthData.soul;
-      const bp = s.byPriority ?? {};
       console.log("\n═══ Soul ═════════════════════════════════════════");
       console.log(`Total:        ${s.total} entries`);
-      console.log(`Priority:     ${bp.critical ?? 0} critical / ${bp.high ?? 0} high / ${bp.standard ?? 0} standard / ${bp.low ?? 0} low`);
+      const entries = sortSoulKeyEntries(s.byKey ?? {});
+      if (entries.length > 0) {
+        console.log(`Keys:         ${entries.map(([k, n]) => `${n} ${k}`).join(" / ")}`);
+      }
     } else if (typeof healthData?.soulEntries === "number" && healthData.soulEntries > 0) {
       console.log("\n═══ Soul ═════════════════════════════════════════");
       console.log(`Total:        ${healthData.soulEntries} entries`);

--- a/test/unit/soul-key-breakdown.test.ts
+++ b/test/unit/soul-key-breakdown.test.ts
@@ -1,0 +1,59 @@
+import { describe, test, expect } from "bun:test";
+import { sortSoulKeyEntries } from "../../src/cli";
+
+/**
+ * Tests for the soul stats breakdown (flair#453).
+ *
+ * The health detail surface used to bucket soul entries by a `priority`
+ * taxonomy (critical/high/standard/low). That was dead telemetry: nothing
+ * ever writes Soul.priority to anything but "standard", so the breakdown
+ * always read 100% standard regardless of the data. It's been replaced with
+ * a breakdown by `key` — the honest dimension soul entries actually have.
+ *
+ * sortSoulKeyEntries() is the shared ordering used by both the plain and the
+ * styled `flair health` renderers.
+ */
+
+describe("sortSoulKeyEntries", () => {
+  test("empty map → empty list (no breakdown rendered)", () => {
+    expect(sortSoulKeyEntries({})).toEqual([]);
+  });
+
+  test("nullish input is tolerated → empty list", () => {
+    // @ts-expect-error exercising the runtime guard against missing byKey
+    expect(sortSoulKeyEntries(undefined)).toEqual([]);
+  });
+
+  test("orders by count descending", () => {
+    const out = sortSoulKeyEntries({ role: 1, standards: 3, project: 2 });
+    expect(out).toEqual([
+      ["standards", 3],
+      ["project", 2],
+      ["role", 1],
+    ]);
+  });
+
+  test("ties broken alphabetically for stable output", () => {
+    const out = sortSoulKeyEntries({ project: 1, role: 1, standards: 1 });
+    expect(out).toEqual([
+      ["project", 1],
+      ["role", 1],
+      ["standards", 1],
+    ]);
+  });
+
+  test("single key passes through", () => {
+    expect(sortSoulKeyEntries({ role: 5 })).toEqual([["role", 5]]);
+  });
+
+  test("does not invent a priority taxonomy — keys are whatever the data has", () => {
+    // A typical hand-authored soul: role/project/standards, all keyed, none
+    // carrying a severity. The breakdown reflects keys, never critical/high/low.
+    const out = sortSoulKeyEntries({ role: 1, project: 1, standards: 1 });
+    const keys = out.map(([k]) => k);
+    expect(keys).toEqual(["project", "role", "standards"]);
+    expect(keys).not.toContain("critical");
+    expect(keys).not.toContain("high");
+    expect(keys).not.toContain("low");
+  });
+});


### PR DESCRIPTION
Closes #453.

## Problem

The `flair health` soul section reports a severity breakdown:

```
Soul:   5 entries — critical:0 · high:0 · standard:5 · low:0
```

This always reads 100% `standard` regardless of the data. The issue diagnosed it as "the Soul model has no severity field" — but the root cause is sharper: the Harper `Soul` schema **does** have a `priority` field (reserved for skill governance), it's just **dead telemetry**. Nothing ever writes a non-standard value:

- `flair soul set` has no `--priority` flag (only `--durability`)
- `rem promote --to soul` **hardcodes** `priority: "standard"` (`cli.ts`)
- bootstrap ranks soul by **key** via `SOUL_KEY_PRIORITY`, not a stored field

On top of that, the `?? "standard"` fallback in `health.ts` mislabelled *unset* as *standard*, so the bucket was a tautology either way.

There were **two** renderers printing this: a plain one and the styled `Entries: N — …` one (the surface in the issue screenshot). Both fixed.

## Fix

Soul entries have no severity dimension — they're keyed identity facts (`role` / `project` / `standards` / …). Report that honest dimension instead: a count per key, ordered by count then name.

- `resources/health.ts` — emit `stats.soul.byKey` instead of `byPriority`; drop the `?? "standard"` coercion
- `src/cli.ts` — both renderers now share a pure, exported `sortSoulKeyEntries` helper
- `packages/flair-client/src/types.ts` — reconcile `SoulEntry` with the Harper schema (`priority` / `durability` / `metadata` / `updatedAt` were all unmodelled — the issue's "Related" note)

## Tests

- New `test/unit/soul-key-breakdown.test.ts` (6 cases): count ordering, alphabetical tiebreak, empty/nullish guard, and a guard asserting the breakdown never reintroduces a critical/high/low taxonomy
- Full unit suite: **926 pass** (was 920)
- `tsconfig.check.json` + `tsconfig.cli.json` typecheck clean; flair-client build clean

## Note

Lands post-v0.10.0 (already merged, awaiting publish) — rides v0.10.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)