### PR TITLE
docs(changelog): record soul by-key fix (#453/#454) in v0.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 0.10.0 (2026-05-28)
 
-> **Dogfood-mature hardening.** This release is the result of a multi-day pass through Flair's load-bearing surfaces — federation sync, REM restore, A2A interop, memory_store — looking for silent-failure paths that pass tests but fail in production. Six were found and closed: a P0 security gap on `/a2a`, a 6-month-old silent data-loss bug in `memory_store`, and four telemetry/observability holes that would have shown "healthy" while data was being dropped. Plus the v0.9.x patch stream (renderer + CLI polish, federation re-upsert fix, smoke tests, README correctness).
+> **Dogfood-mature hardening.** This release is the result of a multi-day pass through Flair's load-bearing surfaces — federation sync, REM restore, A2A interop, memory_store — looking for silent-failure paths that pass tests but fail in production. Seven were found and closed: a P0 security gap on `/a2a`, a 6-month-old silent data-loss bug in `memory_store`, and five telemetry/observability holes that would have shown "healthy" while data was being dropped. Plus the v0.9.x patch stream (renderer + CLI polish, federation re-upsert fix, smoke tests, README correctness).
 
 ### 🔒 A2A endpoint requires authentication (P0 security fix) — #448
 
@@ -45,6 +45,10 @@ Two failure modes in `applySnapshot`:
 `/AdminInstance` Endpoints table rendered `http://127.0.0.1:19926/...` URLs on remote deployments where `FLAIR_PUBLIC_URL` wasn't set — operators on Fabric or VPS-hosted Flair couldn't copy-paste their actual hub URL. New resolution order: `FLAIR_PUBLIC_URL` env var (still wins), then **request headers** (`X-Forwarded-Proto`/`X-Forwarded-Host` from a proxy, or direct `Host`), then localhost fallback. Bare host assumes `https`; host with port assumes `http`. Host-header path is gated by a strict regex `/^[\w.\-:]+$/` to reject CRLF / space injection.
 
 Closes #402 (footer "vdev") as a side effect — that fix actually landed back in May (62af140) but the merging PR didn't use `Closes #N` syntax so GH kept the issue open.
+
+### 🐛 Soul stats: honest by-key breakdown — #454 (closes #453)
+
+`flair health` reported a soul severity breakdown (`critical / high / standard / low`) that always read 100% `standard` — dead telemetry. Nothing ever writes `Soul.priority` to a non-standard value (`soul set` has no `--priority` flag, `rem promote --to soul` hardcodes `"standard"`, and bootstrap ranks soul by *key* via `SOUL_KEY_PRIORITY`), and the `?? "standard"` fallback further mislabelled *unset* as *standard*. Same "passes tests, lies in production" class as the federation/REM telemetry fixes above. Soul entries have no severity dimension — they're keyed identity facts (`role` / `project` / `standards` / …), so both `flair health` renderers now show a count **per key** via a shared, tested `sortSoulKeyEntries` helper. Also reconciles the `SoulEntry` client type with the Harper schema (`priority` / `durability` / `metadata` / `updatedAt` were unmodelled).
 
 ### ✨ CLI polish: renderer module across all status commands — #427 through #440
 


### PR DESCRIPTION
Docs-only.

#454 (soul priority breakdown → by-key) merged into `main` without a version bump, so it now sits at version `0.10.0` on main's tip. `release.sh --publish` builds main's tip — so #454's code **ships inside the v0.10.0 npm packages**. But the 0.10.0 CHANGELOG (written in #452, before #454) enumerated exactly *six* fixes and didn't mention the soul fix, making the published notes inaccurate about what shipped — which trips the release's own "CHANGELOG accurately represents what shipped" criterion.

This adds the #453/#454 entry under 0.10.0 and corrects the intro count (six→seven; four→five telemetry/observability holes).

No code change. Gating this before v0.10.0 publish so the release notes are honest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)