### PR TITLE
fix(security): AgentCard no longer leaks arbitrary souls on the public endpoint

### DIFF
--- a/resources/AgentCard.ts
+++ b/resources/AgentCard.ts
@@ -1,19 +1,5 @@
 import { Resource, databases } from "@harperfast/harper";
-
-type SoulLike = {
-  key?: string;
-  value?: string;
-  kind?: string;
-  content?: string;
-};
-
-function readSoulKind(entry: SoulLike): string {
-  return String(entry.kind ?? entry.key ?? "").trim().toLowerCase();
-}
-
-function readSoulContent(entry: SoulLike): string {
-  return String(entry.content ?? entry.value ?? "").trim();
-}
+import { type SoulLike, selectPublicDescription, selectPublicSkills } from "./agentcard-fields.js";
 
 export class AgentCard extends Resource {
   async get(pathInfo?: any) {
@@ -42,22 +28,15 @@ export class AgentCard extends Resource {
       if (row?.agentId === agentId) souls.push(row);
     }
 
-    const descriptionEntry =
-      souls.find((s) => readSoulKind(s) === "description" && readSoulContent(s)) ??
-      souls.find((s) => readSoulContent(s));
-
-    const skills = souls
-      .filter((s) => readSoulKind(s) === "capability")
-      .map((s) => readSoulContent(s))
-      .filter(Boolean);
-
     return {
       name: String(agent.name ?? agent.id ?? agentId),
-      description: descriptionEntry ? readSoulContent(descriptionEntry) : "",
+      // Only an explicit kind="description" soul publishes — no private-soul
+      // fallback (ops-vz6j). See agentcard-fields.ts for the security rationale.
+      description: selectPublicDescription(souls),
       url: String(agent.url ?? ""),
       version: String(agent.version ?? "1.0.0"),
       capabilities: agent.capabilities && typeof agent.capabilities === "object" ? agent.capabilities : {},
-      skills,
+      skills: selectPublicSkills(souls),
       defaultInputModes: ["text"],
       defaultOutputModes: ["text"],
     };

--- a/resources/agentcard-fields.ts
+++ b/resources/agentcard-fields.ts
@@ -1,0 +1,51 @@
+// Pure selection logic for what an agent's public AgentCard exposes.
+//
+// SECURITY: `GET /AgentCard/{id}` is intentionally UNAUTHENTICATED (A2A spec —
+// agent cards are public discovery metadata, and the auth-middleware allow-list
+// lets it bypass auth). Everything these helpers return is therefore world-
+// readable. They must publish ONLY explicitly-kinded souls — never an implicit
+// fallback that could surface a private soul (an operator's internal note,
+// prompt fragment, or credential reminder) on the public endpoint.
+//
+// Kept free of any @harperfast/harper import so the real logic is unit-testable
+// without spinning up Harper (avoids the simulator-pattern that let the
+// description-fallback leak ship untested — ops-vz6j).
+
+export type SoulLike = {
+  key?: string;
+  value?: string;
+  kind?: string;
+  content?: string;
+};
+
+export function readSoulKind(entry: SoulLike): string {
+  return String(entry.kind ?? entry.key ?? "").trim().toLowerCase();
+}
+
+export function readSoulContent(entry: SoulLike): string {
+  return String(entry.content ?? entry.value ?? "").trim();
+}
+
+/**
+ * The public description is ONLY an explicit `kind="description"` soul.
+ *
+ * There is deliberately no fallback to "the first soul with any content": that
+ * was the ops-vz6j leak — an agent with no description soul would publish an
+ * arbitrary private soul on the unauthenticated card. Absent an explicit
+ * description, publish nothing.
+ */
+export function selectPublicDescription(souls: SoulLike[]): string {
+  const entry = souls.find((s) => readSoulKind(s) === "description" && readSoulContent(s));
+  return entry ? readSoulContent(entry) : "";
+}
+
+/**
+ * Public skills are ONLY `kind="capability"` souls — an explicit, operator-
+ * intended allow-list. Any other soul kind is never published.
+ */
+export function selectPublicSkills(souls: SoulLike[]): string[] {
+  return souls
+    .filter((s) => readSoulKind(s) === "capability")
+    .map((s) => readSoulContent(s))
+    .filter(Boolean);
+}

--- a/test/unit/agentcard-fields.test.ts
+++ b/test/unit/agentcard-fields.test.ts
@@ -1,0 +1,100 @@
+import { describe, test, expect } from "bun:test";
+import {
+  readSoulKind,
+  readSoulContent,
+  selectPublicDescription,
+  selectPublicSkills,
+} from "../../resources/agentcard-fields";
+
+/**
+ * Tests for what the public (unauthenticated) AgentCard exposes — ops-vz6j.
+ *
+ * `GET /AgentCard/{id}` bypasses auth (A2A spec). The prior code fell back to
+ * publishing the first soul with ANY content as the description when no
+ * explicit kind="description" soul existed — leaking arbitrary private souls
+ * (internal notes, prompt fragments, credential reminders) on a public surface.
+ *
+ * The central guard here: an agent with private souls but NO description soul
+ * must publish an EMPTY description, never one of those private souls.
+ */
+
+describe("selectPublicDescription", () => {
+  test("publishes an explicit kind=description soul", () => {
+    const souls = [
+      { kind: "note", content: "INTERNAL: do not ship" },
+      { kind: "description", content: "Strategic cofounder agent." },
+    ];
+    expect(selectPublicDescription(souls)).toBe("Strategic cofounder agent.");
+  });
+
+  test("SECURITY: no description soul → empty string, never a private soul (ops-vz6j)", () => {
+    const souls = [
+      { kind: "note", content: "INTERNAL reminder: rotate the admin pass" },
+      { kind: "prompt", content: "You have access to the production keys at..." },
+      { kind: "capability", content: "code-review" },
+    ];
+    const out = selectPublicDescription(souls);
+    expect(out).toBe("");
+    expect(out).not.toContain("INTERNAL");
+    expect(out).not.toContain("production keys");
+  });
+
+  test("SECURITY: empty description soul does not fall back to a private soul", () => {
+    const souls = [
+      { kind: "description", content: "   " },
+      { kind: "note", content: "private internal note" },
+    ];
+    expect(selectPublicDescription(souls)).toBe("");
+  });
+
+  test("no souls at all → empty string", () => {
+    expect(selectPublicDescription([])).toBe("");
+  });
+
+  test("legacy soul shape (key/value) is honored for the description kind", () => {
+    const souls = [{ key: "description", value: "Legacy-shaped description." }];
+    expect(selectPublicDescription(souls)).toBe("Legacy-shaped description.");
+  });
+});
+
+describe("selectPublicSkills", () => {
+  test("publishes only kind=capability souls", () => {
+    const souls = [
+      { kind: "capability", content: "strategy" },
+      { kind: "capability", content: "code-review" },
+      { kind: "note", content: "secret-model: gpt-x at internal-endpoint" },
+      { kind: "description", content: "public description" },
+    ];
+    expect(selectPublicSkills(souls)).toEqual(["strategy", "code-review"]);
+  });
+
+  test("SECURITY: a non-capability soul is never published as a skill", () => {
+    const skills = selectPublicSkills([
+      { kind: "credentials", content: "token=abc123" },
+      { kind: "note", content: "internal" },
+    ]);
+    expect(skills).toEqual([]);
+  });
+
+  test("filters out empty-content capability souls", () => {
+    const souls = [
+      { kind: "capability", content: "strategy" },
+      { kind: "capability", content: "  " },
+    ];
+    expect(selectPublicSkills(souls)).toEqual(["strategy"]);
+  });
+});
+
+describe("soul field readers", () => {
+  test("readSoulKind prefers kind, falls back to key, lowercases + trims", () => {
+    expect(readSoulKind({ kind: "  Description " })).toBe("description");
+    expect(readSoulKind({ key: "Capability" })).toBe("capability");
+    expect(readSoulKind({})).toBe("");
+  });
+
+  test("readSoulContent prefers content, falls back to value, trims", () => {
+    expect(readSoulContent({ content: "  hello " })).toBe("hello");
+    expect(readSoulContent({ value: "legacy" })).toBe("legacy");
+    expect(readSoulContent({})).toBe("");
+  });
+});


### PR DESCRIPTION
Closes ops-vz6j.

## Impact (live, unauthenticated leak)

`GET /AgentCard/{id}` is intentionally **public/unauthenticated** (A2A spec; allow-listed in `auth-middleware`). `AgentCard.get()` fell back to publishing the **first soul with any content** as the agent `description` when no `kind="description"` soul existed:

```ts
souls.find(s => kind === "description" && content) ?? souls.find(s => content)
```

Souls iterate in arbitrary order, so this surfaced whatever private soul came first — an internal note, prompt fragment, or credential reminder. **Confirmed live before the fix:**

```
GET /AgentCard/flint → description: "kern --key dogfood Test value for verification"
```

(an internal test soul, published to anyone on the network).

## Fix

Publish **only explicitly-kinded souls**:
- `description` ← only a `kind="description"` soul; **no fallback** — absent it, publish `""`.
- `skills` ← only `kind="capability"` souls (operator-intended allow-list).

`name` and `url` stay published — A2A-required public discovery metadata, operator-controlled, not a soul-leak vector.

Selection logic extracted to `resources/agentcard-fields.ts` (no `@harperfast/harper` import) so the **real shipped logic** is unit-testable without spinning up Harper — the absence of such a test is exactly what let this leak ship (same class as #457).

## Verification

- **Live before → after:** `/AgentCard/flint` description `"kern --key dogfood Test value..."` → `""`.
- 10 new unit tests: the leak guard (private souls + no description → empty), empty-description-doesn't-fall-back, skill allow-list (non-capability souls never published), legacy soul shape.
- 936 unit pass; typecheck + build clean.
- **Deployed on live rockit** (Ed25519 auth + REM unaffected); rollback = revert + reload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)