### PR TITLE
fix(deps): declare all @node-llama-cpp platforms (non-mac installs resolve the embedding binary)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -21,6 +21,15 @@
         "bun-types": "1.3.11",
         "typescript": "5.9.3",
       },
+      "optionalDependencies": {
+        "@node-llama-cpp/linux-arm64": "3.18.1",
+        "@node-llama-cpp/linux-armv7l": "3.18.1",
+        "@node-llama-cpp/linux-x64": "3.18.1",
+        "@node-llama-cpp/mac-arm64-metal": "3.18.1",
+        "@node-llama-cpp/mac-x64": "3.18.1",
+        "@node-llama-cpp/win-arm64": "3.18.1",
+        "@node-llama-cpp/win-x64": "3.18.1",
+      },
     },
     "packages/flair-client": {
       "name": "@tpsdev-ai/flair-client",

--- a/package.json
+++ b/package.json
@@ -64,6 +64,15 @@
     "tar": "^7.5.13",
     "tweetnacl": "1.0.3"
   },
+  "optionalDependencies": {
+    "@node-llama-cpp/linux-arm64": "3.18.1",
+    "@node-llama-cpp/linux-armv7l": "3.18.1",
+    "@node-llama-cpp/linux-x64": "3.18.1",
+    "@node-llama-cpp/mac-arm64-metal": "3.18.1",
+    "@node-llama-cpp/mac-x64": "3.18.1",
+    "@node-llama-cpp/win-arm64": "3.18.1",
+    "@node-llama-cpp/win-x64": "3.18.1"
+  },
   "devDependencies": {
     "@playwright/test": "^1.59.1",
     "@types/node": "24.11.0",


### PR DESCRIPTION
## Problem
`harper-fabric-embeddings` declares `@node-llama-cpp/<platform>` as its own optionalDependencies, but **bun's lockfile only records the binary for the resolving platform.** A `bun.lock` generated on macOS-arm64 pins only `@node-llama-cpp/mac-arm64-metal` — so `bun install` on **Linux** follows the lockfile and installs **no** llama binary, and `harper-fabric-embeddings` fails at startup:

```
No llama-addon.node binary found. Install a @node-llama-cpp platform package (e.g., @node-llama-cpp/linux-x64).
```

(Hit this standing up a Flair spoke on a linux-x64 box — worked around with a manual `bun add @node-llama-cpp/linux-x64`, which shouldn't be necessary.)

## Fix
Hoist all 7 platform binaries `harper-fabric-embeddings` supports into flair's own `optionalDependencies` (@3.18.1) + regenerate the lockfile.

**Verified** (bun 1.3): the new `bun.lock` records *every* platform (linux-x64/arm64/armv7l, mac-arm64-metal/x64, win-arm64/x64), while each `bun install` still pulls only the **matching** one. So a Linux or Windows install resolves its embedding binary with no manual step. `bun run build` still passes.

## Scope
package.json + bun.lock only (no source). Done in an isolated scratch clone — the running rockit Flair instance was never touched.