### PR TITLE
fix(openclaw-flair): declare contracts.tools so memory tools register

### DIFF
--- a/packages/openclaw-flair/openclaw.plugin.json
+++ b/packages/openclaw-flair/openclaw.plugin.json
@@ -44,5 +44,12 @@
       "maxBootstrapTokens": { "type": "number", "minimum": 500, "maximum": 8000 }
     },
     "required": []
+  },
+  "contracts": {
+    "tools": [
+      { "name": "memory_search" },
+      { "name": "memory_store" },
+      { "name": "memory_get" }
+    ]
   }
 }


### PR DESCRIPTION
## Problem
OpenClaw now blocks a plugin from registering agent tools unless it declares them in `contracts.tools`. `openclaw-flair` registers **memory_search / memory_store / memory_get** but never declared them, so the gateway logs `plugin must declare contracts.tools before registering agent tools` and the three tools never register. Agents have been left with **auto-recall only** (context engine), no explicit memory tools, since ~2026-05-12.

## Fix
Declare the three tools in the manifest's `contracts.tools`. (The validator maps `contracts.tools[].name`; minimal `{name}` entries satisfy it.)

## Validation
Patched the installed manifest on rockit + restarted the gateway: the `contracts.tools` block is gone, the three tools register, and the context engine / auto-recall are unaffected (gateway stable, 3 plugins listening).

Note: a separate `plugins.entries.openclaw-flair.hooks.allowConversationAccess` config gate still disables the `agent_end` capture hook — tracked separately; not in this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)