### PR TITLE
chore(docs): genericize internal infra references in the public repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Flair is the **identity + memory substrate for AI agents**. Cryptographic per-ag
 │  Codex CLI    ─┼─[ flair-mcp ]─┐                                 │
 │  Gemini CLI   ─┤               │                                 │
 │  Continue.dev ─┤               │   ┌──────────────────────┐      │
-│  Goose        ─┘               ├─▶ │  Flair (rockit)      │      │
+│  Goose        ─┘               ├─▶ │  Flair (self-hosted) │      │
 │  LangGraph   ─[ langgraph-flair ]──│  Ed25519 / HNSW /    │      │
 │  OpenClaw    ─[ openclaw-flair  ]──│  Soul + Memory       │      │
 │  n8n         ─[ n8n-nodes-flair ]──└──────────┬───────────┘      │
@@ -146,7 +146,7 @@ Not all memories are equal:
 Memories can be time-bounded with `validFrom` and `validTo` fields. Expired memories are excluded from search and bootstrap automatically — no manual cleanup.
 
 ### Relationship Graph
-Entity-to-entity triples with temporal bounds. Model structured knowledge — "Flint works-with Anvil since 2024-01-01" — queryable alongside semantic memory.
+Entity-to-entity triples with temporal bounds. Model structured knowledge — "Alice works-with Bob since 2024-01-01" — queryable alongside semantic memory.
 
 ### Real-Time Feeds
 Subscribe to memory or soul changes via WebSocket/SSE. Useful for dashboards, cross-agent sync, or audit trails.
@@ -392,7 +392,7 @@ Good for teams with multiple machines or always-on agents.
 
 ### Harper Fabric
 
-Deploy Flair on [Harper Fabric](https://www.harperdb.io/) for managed hosting with multi-region replication and failover. Federation is live against Harper Fabric hubs (e.g. `flair.heskew.harperfabric.com`) — pair your local instance to sync memories across nodes.
+Deploy Flair on [Harper Fabric](https://www.harperdb.io/) for managed hosting with multi-region replication and failover. Federation runs against Harper Fabric hubs (e.g. `flair.your-org.harperfabric.com`) — pair your local instance to sync memories across nodes.
 
 ## Security
 

--- a/docs/assets/flair-cross-orchestrator.cast
+++ b/docs/assets/flair-cross-orchestrator.cast
@@ -24,7 +24,7 @@
 [0.5, "o", "\u001b[36mflint>\u001b[0m \u001b[2msummarize our recent infra decisions\u001b[0m\r\n"]
 [1.7, "o", "  \u001b[32m\u2713\u001b[0m bootstrap: same 287 memories, same soul, same Ed25519 identity\r\n"]
 [0.5, "o", "  \u2022 Postgres for replication-lag (2026-05-14)\r\n"]
-[0.0, "o", "  \u2022 Federation pair: rockit\u2192Fabric via Ed25519 (2026-05-05)\r\n"]
+[0.0, "o", "  \u2022 Federation pair: local\u2192Fabric via Ed25519 (2026-05-05)\r\n"]
 [0.0, "o", "  \u2022 REM nightly cycle ships in v0.9.0 (2026-05-14)\r\n\r\n"]
 [2.5, "o", "  \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\r\n"]
 [0.0, "o", "  No SaaS in the middle.  No vendor lock.\r\n"]

--- a/docs/n8n-management.md
+++ b/docs/n8n-management.md
@@ -1,6 +1,6 @@
 # n8n Workflow Management
 
-Programmatic activation/deactivation of n8n workflows — the approach we use for ops automation on rockit.
+Programmatic activation/deactivation of n8n workflows — the approach we use for ops automation.
 
 ## The Problem
 

--- a/docs/n8n.md
+++ b/docs/n8n.md
@@ -12,7 +12,7 @@ Flair is the right pick when you want:
 |---|---|---|
 | **Shape** | Tagged + typed memories with semantic search, plus chat-buffer compatibility | Conversation-buffer only (LangChain `BaseMessage` records) |
 | **Cross-orchestrator** | Same memory readable from Claude Code, OpenClaw, n8n | n8n-internal schema; nothing else reads it |
-| **Cross-instance** | Hub-spoke federation built-in (rockit ↔ Fabric, etc.) | Single-instance unless you self-build replication |
+| **Cross-instance** | Hub-spoke federation built-in (local ↔ Fabric, etc.) | Single-instance unless you self-build replication |
 | **Identity** | Ed25519 per-agent (planned) or admin-token (v1) | n8n credential per workflow |
 
 If your AI Agent only needs to remember the last N turns of a single chat in a single n8n instance, Postgres-as-memory is fine. If you want the same memory to inform a Claude Code conversation tomorrow, or to persist across n8n redeploys via federated Flair, this package is the path.

--- a/docs/secrets-and-keys.md
+++ b/docs/secrets-and-keys.md
@@ -138,7 +138,7 @@ Hermes uses `~/.hermes/.env` for provider API keys (managed by `hermes auth`). T
 
 `~/.flair/keys/<agent>.key` is the only secret Flair generates. Treat it like an SSH private key:
 
-- **Stays on the host that owns the agent.** If your agent runs on rockit, the key lives on rockit. If you spin up the same agent on another machine, **don't copy the key** — register a new agent identity (`flair agent add <id>-on-<other-host>`) on that machine. Different identities, same Flair instance can store memories for both, you decide cross-agent visibility.
+- **Stays on the host that owns the agent.** If your agent runs on a given host, the key lives on that host. If you spin up the same agent on another machine, **don't copy the key** — register a new agent identity (`flair agent add <id>-on-<other-host>`) on that machine. Different identities, same Flair instance can store memories for both, you decide cross-agent visibility.
 - **`chmod 600` enforced** by `flair agent add`. Don't relax it.
 - **Don't check it into git.** `.gitignore` should already exclude `~/.flair/keys/`; if you're ever tempted to share keys for "convenience," rotate first (`flair agent rotate <id>`).
 - **Backup separately**, encrypted. The `flair backup` command excludes private keys by default. Roll your own backup of `~/.flair/keys/` via age-encrypted archive if you want offsite recovery.

--- a/docs/supply-chain-policy.md
+++ b/docs/supply-chain-policy.md
@@ -65,7 +65,7 @@ Every PR runs the Socket.dev Supply Chain check. Failure blocks merge. The Socke
 
 Only Nathan publishes to npm (per the existing MFA boundary). Flint preps the release commit + version bump + CHANGELOG; Nathan runs `./scripts/release.sh <ver> --publish` from his laptop.
 
-- Rockit is not logged into npm by design.
+- The build host is not logged into npm by design.
 - A planned post-publish smoke job will add an automated round-trip check after each publish to ensure cross-package resolution works on the actually-published artifacts.
 
 ---

--- a/docs/system-requirements.md
+++ b/docs/system-requirements.md
@@ -15,9 +15,9 @@ Flair runs Harper v5 (a Node.js HTTP+storage runtime) plus a small CLI/MCP layer
 
 | Host | RAM (RSS) | Data dir | Node | Uptime | Notes |
 |---|---|---|---|---|---|
-| rockit (Mac mini, 16 GB) | 740 MB daemon + ~175 MB across 4 flair-mcp clients = ~915 MB total | 163 MB | 25.9.0 | 35 min | Hub for rockit↔Fabric pair; local agent count: 4 (flint, kern, sherlock, ember). |
-| pulse (Linux VM, 19 GB pool) | 500 MB | 88 MB | 22.22.0 | 3d 20h | Spoke; 1 agent (pulse). |
-| tps-anvil (Linux VM, 19 GB pool) | (not running) | 71 MB | 22.22.1 | — | Linux deps issue, P1 backlog. |
+| Mac mini (16 GB) | 740 MB daemon + ~175 MB across 4 flair-mcp clients = ~915 MB total | 163 MB | 25.9.0 | 35 min | Federation hub; 4 local agents. |
+| Linux VM (19 GB pool) | 500 MB | 88 MB | 22.22.0 | 3d 20h | Federation spoke; 1 agent. |
+| Linux VM (19 GB pool) | (not running) | 71 MB | 22.22.1 | — | Linux deps issue (backlog). |
 
 ## What drives the numbers
 
@@ -33,7 +33,7 @@ The numbers above are 1-agent steady state. Per additional agent on the same dae
 - ~50 MB additional RSS (per-agent HNSW index + small per-agent caches).
 - ~10–30 MB additional data-dir growth per week of active use.
 
-A 4-agent rockit at full embeddings + federation runs comfortably in 1 GB. An 8-agent host is fine in 2 GB. Multi-org hubs with hundreds of agents would want measured sizing — file an issue or join the Discord.
+A 4-agent Mac mini at full embeddings + federation runs comfortably in 1 GB. An 8-agent host is fine in 2 GB. Multi-org hubs with hundreds of agents would want measured sizing — file an issue or join the Discord.
 
 ## Known constraints
 

--- a/docs/the-team.md
+++ b/docs/the-team.md
@@ -8,11 +8,11 @@ If you're trying to run your own multi-agent team using Flair as the memory laye
 
 | Agent | Role | Runtime | Model | Where it runs |
 |---|---|---|---|---|
-| **Flint** | Strategy, product, PR review | Claude Code | Claude Opus | rockit (Mac Mini) |
-| **Anvil** | Implementation, PR opener | OpenClaw | Claude Sonnet (API) | exe.dev VM (`tps-anvil.exe.xyz`) |
-| **Kern** | Architecture / perf review | OpenClaw | Open-source via Ollama | newton (Mac Studio) |
-| **Sherlock** | Security review | OpenClaw | Open-source via Ollama (local-only) | newton (Mac Studio) |
-| **Pulse** | EA / intel scanning / coordination | OpenClaw | Claude API | exe.dev VM (`pulse.exe.xyz`) |
+| **Flint** | Strategy, product, PR review | Claude Code | Claude Opus | always-on local host |
+| **Anvil** | Implementation, PR opener | OpenClaw | Claude Sonnet (API) | cloud VM |
+| **Kern** | Architecture / perf review | OpenClaw | Open-source via Ollama | local inference box |
+| **Sherlock** | Security review | OpenClaw | Open-source via Ollama (local-only) | local inference box |
+| **Pulse** | EA / intel scanning / coordination | OpenClaw | Claude API | cloud VM |
 | **Nathan** | Founder / product owner / human-in-the-loop | (human) | (human) | wherever |
 
 Every agent has its own Ed25519 identity in Flair. They sign every memory write and every read. **Cross-agent reads are refused at the Flair API layer**, not by client convention — Sherlock can't accidentally read Pulse's memories even on a shared Flair instance, because the signature won't verify.
@@ -20,19 +20,18 @@ Every agent has its own Ed25519 identity in Flair. They sign every memory write 
 ## How memory flows
 
 ```
-                                ┌────────────────────────┐
-                                │  Flair (rockit)        │
-                                │  http://rockit:9926    │
-                                │                        │
-                                │  Per-agent isolation   │
-                                │  enforced server-side  │
-                                │  via Ed25519 signing   │
-                                └─────────▲──────────────┘
-                                          │
+                                ┌────────────────────────┐                  
+                                │  Flair (self-hosted)   │                  
+                                │                        │                  
+                                │  Per-agent isolation   │                  
+                                │  enforced server-side  │                  
+                                │  via Ed25519 signing   │                  
+                                └─────────▲──────────────┘                  
+                                          │                                 
         ┌─────────────────┬───────────────┼──────────────┬─────────────────┐
         │                 │               │              │                 │
    Flint               Anvil           Kern          Sherlock           Pulse
-  (rockit)        (tps-anvil)       (newton)         (newton)         (pulse.exe.xyz)
+   (local)           (cloud VM)    (inference box) (inference box)    (cloud VM)
         │                 │               │              │                 │
    reads/writes      reads/writes    reads/writes   reads/writes      reads/writes
    own memories      own memories    own memories   own memories      own memories
@@ -59,17 +58,16 @@ This isn't a value judgment of one runtime over another — it's about matching 
 ### Local vs API for inference
 
 - **Anvil + Pulse on the Anthropic API** — high-throughput implementation work and EA-shaped intel scanning need frontier model quality and consistent latency. Worth the API spend.
-- **Kern + Sherlock on local Ollama (`newton`)** — review work can be slower and is bursty (a few PRs/day). Self-hosted on a Mac Studio Ollama install means no rate limits, no session-locks, no third-party data exposure. Both currently run **gpt-oss:120b** as primary (OpenAI's open weights, Apache 2.0), with `nemotron-3-super:120b` and `deepseek-r1:70b` in the local fallback chain. **Sherlock is local-only as a deliberate privacy decision** — security findings are pre-disclosure-sensitive, not appropriate to send to any external inference provider.
+- **Kern + Sherlock on local Ollama** — review work can be slower and is bursty (a few PRs/day). Self-hosting on a local Ollama box means no rate limits, no session-locks, no third-party data exposure. Both run a large open-weight model (~120B class, permissively licensed) as primary, with smaller open models in the local fallback chain. **Sherlock is local-only as a deliberate privacy decision** — security findings are pre-disclosure-sensitive, not appropriate to send to any external inference provider.
 - **Flint on Opus** — strategy + spec writing is rate-of-thought, not rate-of-tokens. Opus's reasoning depth matters more than throughput.
 
-> **Note on the migration trial period (2026-04-25 → ~2026-05-02):** during the first week after K&S moved off Gemini, we kept Gemini as the *last* fallback in the chain to catch any quality regressions. After the trial period that fallback gets removed and K&S are strictly local. If you're copying this setup, decide upfront whether you want a cloud safety net during your own migration — and remove it on a known date.
+> **Note on migration safety nets:** when we moved the review agents off a previous cloud model onto local inference, we kept the old model as the *last* fallback for a short trial window to catch quality regressions, then removed it on a fixed date. If you're copying this setup, decide upfront whether you want a cloud safety net during your own migration — and remove it on a known date.
 
 ### Different hardware for different load
 
-- **rockit (Mac Mini)** — always-on, lightweight, runs Flint + the rhythm-agent watchdog + the local Flair Harper instance.
-- **newton (Mac Studio M3 Ultra, 96GB)** — heavy local inference. Hosts Ollama + cloud-pass-through. Kern + Sherlock both target this box.
-- **exe.dev VMs** — cloud agents that need internet-side work (pulse fetches news/intel; anvil opens GitHub PRs from a clean network space). Independent failure domain from the local stack.
-- **(planned)** Jetson Orin Nano for the rhythm-agent dispatcher in v1, freeing rockit's CPU for Flint.
+- **Always-on local host** — lightweight, runs the founder-facing agent + a watchdog + the local Flair Harper instance.
+- **Local inference box** — heavier local inference on a workstation with strong unified memory / GPU. Hosts Ollama; the review agents target this box.
+- **Cloud VMs** — agents that need internet-side work (intel fetching, opening GitHub PRs from a clean network space). Independent failure domain from the local stack.
 
 ## The handoff loop
 
@@ -77,7 +75,7 @@ Standard PR-shaped work flows like this:
 
 ```
   1. Nathan brings a need to Flint (Discord)
-  2. Flint writes a spec, files it in ~/ops/specs/, updates Beads
+  2. Flint writes a spec, files it in the planning repo, updates Beads
   3. Flint mails Kern + Sherlock for arch + security review of the SPEC
      (catch issues at design time, not after implementation)
   4. K&S respond with concerns or sign-off
@@ -100,7 +98,7 @@ Flair is the connective tissue:
 - **Identity:** every agent has an Ed25519 keypair in Flair (`flair agent add <id>`). All signed requests, no shared passwords, no env-var secrets to leak.
 - **Memory:** each agent writes its own lessons, decisions, observations. Flint's strategic memory survives a session crash. Anvil's "this codebase pattern works for X but fails for Y" persists across PR iterations.
 - **Soul:** each agent has a permanent personality block — role, voice, constraints. Loaded on every bootstrap so the agent stays *themselves* across sessions.
-- **Bridges:** when an agent needs context from a foreign system (e.g., Anvil needs to import lessons from `agentic-stack/`), bridges import them into Flair without a custom integration per source.
+- **Bridges:** when an agent needs context from a foreign system (e.g., Anvil needs to import lessons from another repo), bridges import them into Flair without a custom integration per source.
 
 The MCP server (`@tpsdev-ai/flair-mcp`) is what makes this orchestrator-agnostic — Flint's Claude Code, Anvil/Kern/Sherlock/Pulse's OpenClaw all hit the same Flair server with the same per-agent isolation guarantees.
 
@@ -115,8 +113,7 @@ The MCP server (`@tpsdev-ai/flair-mcp`) is what makes this orchestrator-agnostic
 ## What we're still figuring out
 
 - **Cross-agent visibility for collaborative work.** Sometimes Flint needs Sherlock's recent security findings to write a spec. Today Flint asks via TPS mail; Sherlock answers. We're considering an explicit `flair memory share` mechanism with audit trails. Not in 1.0.
-- **Rhythm agent v1.** Today's v0 is a shell-cron polling for state changes and posting to Discord. v1 lives on a Jetson, uses a small local model to summarize, and escalates only when truly stuck. Post-1.0 polish.
-- **A `nathan-local` ops-EA on his laptop** that handles laptop-local tasks (files, browser, SSH-keyed ops) Pulse can't reach from the cloud. Identity model: acts AS Nathan, not as a peer agent. In design.
+- **Rhythm agent v1.** Today's v0 is a shell-cron polling for state changes and posting to Discord. v1 moves to a dedicated low-power device, uses a small local model to summarize, and escalates only when truly stuck. Post-1.0 polish.
 
 ## Try this with your own team
 

--- a/packages/hermes-flair/__init__.py
+++ b/packages/hermes-flair/__init__.py
@@ -8,7 +8,7 @@ and memories are isolated by that agentId end-to-end.
 Why Flair specifically:
   - Agent-authored memory (no LLM-driven extraction by default — the agent
     decides what's worth remembering).
-  - Self-hosted, no SaaS dependency. Runs on rockit, Mac Studio, a Pi.
+  - Self-hosted, no SaaS dependency. Runs on a Mac mini, Mac Studio, a Pi.
   - Ed25519 per-agent signing keys: cross-agent reads are refused by the
     server, not by client convention.
   - Same backend for memory + identity (soul + agent registry), so the

--- a/packages/n8n-nodes-flair/examples/ks-review-capture/README.md
+++ b/packages/n8n-nodes-flair/examples/ks-review-capture/README.md
@@ -78,7 +78,7 @@ Notes on each step:
 
 - **Filter expansion**: add `host`, `ember`, or any agent to the `containedInList` value to capture more sources. Pair with a `kind:` tag-update in the Format step so the search story stays clean.
 - **Deeper formatting**: the Format step is a Code node — you can pull more structure out of the body (e.g., bullet-point analysis vs paragraph prose), set `validFrom`/`validTo` for time-bounded reasoning, or branch durability by content (security flags → `permanent`, info → `standard`).
-- **Cross-instance**: this workflow writes to *one* Flair instance. The hub-spoke federation pair (rockit ↔ Fabric) propagates the writes without further n8n changes — every memory captured here becomes searchable from every federated peer.
+- **Cross-instance**: this workflow writes to *one* Flair instance. The hub-spoke federation pair (local ↔ Fabric) propagates the writes without further n8n changes — every memory captured here becomes searchable from every federated peer.
 
 ## Operational notes
 
@@ -90,4 +90,4 @@ Notes on each step:
 
 Six months from now, when we want to know *what reasoning Sherlock typically applies to bridge-loading code*, we'll have a real archive. Today's review mail is reasoning that decays the moment the Discord/inbox scrolls past. This workflow is the bet that capturing the reasoning durably will compound into measurable signal.
 
-If after a month of dogfooding the search results turn up genuine value (we use them to inform new specs, new dispatches, new architecture decisions), we lift the workflow to a more durable host (own VM, or Pulse VM if we consolidate) and add it to the standard rockit deploy. If signal is noisy, no infra to dismantle — just deactivate.
+If after a month of dogfooding the search results turn up genuine value (we use them to inform new specs, new dispatches, new architecture decisions), we lift the workflow to a more durable host (its own VM) and add it to the standard deploy. If signal is noisy, no infra to dismantle — just deactivate.

--- a/packages/n8n-nodes-flair/examples/ks-review-capture/workflow.json
+++ b/packages/n8n-nodes-flair/examples/ks-review-capture/workflow.json
@@ -20,7 +20,7 @@
     },
     {
       "parameters": {
-        "jsCode": "// Walk Flint's TPS-mail inbox and emit one item per .json mail file.\n// Single Code node replaces the older ls + Split + Read + Parse chain\n// because (a) it's atomic — no node-version drift to chase, (b) it's\n// portable to any maildir-shaped source by changing the path, (c) n8n's\n// ExecuteCommand stdout-as-string didn't play nicely with Item Lists\n// when filenames had spaces or odd chars.\n//\n// Each emitted item: { mail: <parsed JSON>, _file: <basename> }.\nconst fs = require('fs');\nconst path = require('path');\nconst INBOX = '/Users/squeued/.tps/mail/flint/new';\n\nlet entries;\ntry {\n  entries = fs.readdirSync(INBOX);\n} catch (err) {\n  // Inbox missing is not an error condition — first ever run on a fresh\n  // box can legitimately have no inbox yet.\n  if (err.code === 'ENOENT') return [];\n  throw err;\n}\n\nconst items = [];\nfor (const f of entries) {\n  if (!f.endsWith('.json')) continue;\n  const full = path.join(INBOX, f);\n  try {\n    const content = fs.readFileSync(full, 'utf8');\n    const mail = JSON.parse(content);\n    items.push({ json: { mail, _file: f } });\n  } catch (err) {\n    // Skip malformed mail files — they'll surface in a later sweep when\n    // the file is rewritten cleanly, or get cleaned up via the gc loop.\n    continue;\n  }\n}\nreturn items;\n"
+        "jsCode": "// Walk the agent's TPS-mail inbox and emit one item per .json mail file.\n// Single Code node replaces the older ls + Split + Read + Parse chain\n// because (a) it's atomic — no node-version drift to chase, (b) it's\n// portable to any maildir-shaped source by changing the path, (c) n8n's\n// ExecuteCommand stdout-as-string didn't play nicely with Item Lists\n// when filenames had spaces or odd chars.\n//\n// Each emitted item: { mail: <parsed JSON>, _file: <basename> }.\nconst fs = require('fs');\nconst path = require('path');\nconst INBOX = '/Users/youruser/.tps/mail/<agent>/new';\n\nlet entries;\ntry {\n  entries = fs.readdirSync(INBOX);\n} catch (err) {\n  // Inbox missing is not an error condition — first ever run on a fresh\n  // box can legitimately have no inbox yet.\n  if (err.code === 'ENOENT') return [];\n  throw err;\n}\n\nconst items = [];\nfor (const f of entries) {\n  if (!f.endsWith('.json')) continue;\n  const full = path.join(INBOX, f);\n  try {\n    const content = fs.readFileSync(full, 'utf8');\n    const mail = JSON.parse(content);\n    items.push({ json: { mail, _file: f } });\n  } catch (err) {\n    // Skip malformed mail files — they'll surface in a later sweep when\n    // the file is rewritten cleanly, or get cleaned up via the gc loop.\n    continue;\n  }\n}\nreturn items;\n"
       },
       "id": "read-inbox",
       "name": "Read TPS-mail inbox",
@@ -75,7 +75,7 @@
       "credentials": {
         "flairApi": {
           "id": "REPLACE-ME",
-          "name": "Flair (rockit)"
+          "name": "Flair (self-hosted)"
         }
       }
     }

--- a/resources/auth-middleware.ts
+++ b/resources/auth-middleware.ts
@@ -151,7 +151,7 @@ server.http(async (request: any, nextLayer: any) => {
     // and inline JS, with no embedded data. The JS prompts for admin-pass and
     // auths every API call (/Agent, /SemanticSearch, /FederationPeers, etc).
     // Without this allow-list entry, the HTML is 401-blocked on hosted Flair
-    // instances (rockit-local works only because authorizeLocal=true).
+    // instances (a localhost caller works only because authorizeLocal=true).
     url.pathname === "/ObservationCenter"
   ) return nextLayer(request);
 

--- a/resources/health.ts
+++ b/resources/health.ts
@@ -21,10 +21,10 @@ const exists = async (path: string): Promise<boolean> => {
  * which is what makes /Health work for callers outside `authorizeLocal`'s
  * localhost-bypass. Without this, Harper's intrinsic Basic-auth gate fires
  * BEFORE our HTTP middleware can apply the /Health bypass list in
- * auth-middleware.ts, so remote callers (e.g., from rockit hitting a Fabric-
+ * auth-middleware.ts, so remote callers (e.g., from a remote host hitting a Fabric-
  * hosted Flair) get a 401 even though the Resource handler is intentionally
  * unauthenticated. Symptom matched: Fabric returned 401 + WWW-Authenticate:
- * Basic on /Health while rockit-localhost returned 200 — the difference was
+ * Basic on /Health while a localhost caller returned 200 — the difference was
  * Harper's localhost-auto-auth, not anything in our code.
  *
  * Same pattern as `FederationPair.allowCreate(){ return true }` (PR #299):

--- a/schemas/schema.graphql
+++ b/schemas/schema.graphql
@@ -2,7 +2,7 @@
 # ─── Observatory tables ───────────────────────────────────────────────────────
 
 type ObsOffice @table(database: "flair") @export {
-  id: ID @primaryKey        # e.g. "rockit"
+  id: ID @primaryKey        # e.g. "office1"
   name: String!
   publicKey: String!        # Ed25519 hex public key for auth verification
   status: String @indexed   # "online" | "offline" | "degraded"

--- a/scripts/ai.tpsdev.flair-watchdog.plist
+++ b/scripts/ai.tpsdev.flair-watchdog.plist
@@ -9,7 +9,7 @@
   <key>ProgramArguments</key>
   <array>
     <string>/bin/bash</string>
-    <string>/Users/squeued/ops/flair/scripts/harper-watchdog.sh</string>
+    <string>/Users/youruser/ops/flair/scripts/harper-watchdog.sh</string>
   </array>
 
   <key>StartInterval</key>
@@ -19,15 +19,15 @@
   <false/>
 
   <key>StandardOutPath</key>
-  <string>/Users/squeued/.tps/logs/harper-watchdog.log</string>
+  <string>/Users/youruser/.tps/logs/harper-watchdog.log</string>
 
   <key>StandardErrorPath</key>
-  <string>/Users/squeued/.tps/logs/harper-watchdog.log</string>
+  <string>/Users/youruser/.tps/logs/harper-watchdog.log</string>
 
   <key>EnvironmentVariables</key>
   <dict>
     <key>HOME</key>
-    <string>/Users/squeued</string>
+    <string>/Users/youruser</string>
     <key>PATH</key>
     <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
     <key>HARPER_PORT</key>

--- a/scripts/harper-watchdog.sh
+++ b/scripts/harper-watchdog.sh
@@ -3,7 +3,7 @@
 # and force-restarts via launchd.
 #
 # Usage: run via cron or launchd every 60s
-#   * * * * * /Users/squeued/ops/flair/scripts/harper-watchdog.sh
+#   * * * * * /Users/youruser/ops/flair/scripts/harper-watchdog.sh
 #
 # Or as a launchd StartInterval job (see ai.tpsdev.flair-watchdog.plist)
 

--- a/scripts/setup-vm.sh
+++ b/scripts/setup-vm.sh
@@ -2,7 +2,7 @@
 # setup-vm.sh — Set up Flair + Claude Code MCP on a fresh exe.dev VM
 #
 # Usage: ./scripts/setup-vm.sh <vm-hostname>
-# Example: ./scripts/setup-vm.sh tps-claude.exe.xyz
+# Example: ./scripts/setup-vm.sh your-vm.example.com
 #
 # Prerequisites:
 #   - SSH access to the VM (configured in ~/.ssh/config)

--- a/specs/AGENT-CONTEXT-TIERS-B-task-reset.md
+++ b/specs/AGENT-CONTEXT-TIERS-B-task-reset.md
@@ -85,7 +85,7 @@ Agents arrive with: who they are, what they recently did, and what they're being
 - **Reset trigger fires but Flair is unreachable.** The summary write fails. Block the reset; surface to the operator via mail-bounce or stderr. Don't drop the lesson.
 - **Multiple triggers fire concurrently** (e.g. DONE-with-CI-green AND operator-acked at the same time). Idempotent: first trigger wins, subsequent triggers no-op.
 - **Reset fires mid-task** (e.g. the agent emits DONE but the operator hasn't acked, AND the operator explicitly resets). Operator override wins; summary captures whatever the agent said it accomplished, even if not yet ack'd.
-- **Cross-host reset** (agent on tps-anvil, summary write to rockit-Flair via federation). Works as long as federation is healthy; no special handling.
+- **Cross-host reset** (agent on a remote host, summary write to the hub Flair via federation). Works as long as federation is healthy; no special handling.
 
 ## § 7 What this does NOT replace
 
@@ -118,7 +118,7 @@ Slices 5+6 are the operator surfaces.
 
 3. **Reset notification placement.** As a system message in the next dispatch (§ 4 step 5)? Or as a separate "reset-event" memory the agent reads from Flair on bootstrap? System message is cheaper but makes the bootstrap path more harness-specific.
 
-4. **Cross-host federation latency.** If Anvil resets on tps-anvil and writes a task summary to anvil's local Flair, the summary doesn't show up on rockit-Flair until federation sync. For 1.0 we accept the delay (max ~minutes); flag if you'd want explicit sync-on-write.
+4. **Cross-host federation latency.** If Anvil resets on a remote host and writes a task summary to that host's local Flair, the summary doesn't show up on the hub Flair until federation sync. For 1.0 we accept the delay (max ~minutes); flag if you'd want explicit sync-on-write.
 
 ## § 10 Out of scope for 1.0
 

--- a/specs/FLAIR-XAA.md
+++ b/specs/FLAIR-XAA.md
@@ -315,7 +315,7 @@ On Harper (Fabric), the IdP configuration is stored alongside other Flair instan
 
 ### Local Development
 
-For local Flair instances (rockit), XAA is optional. If no IdP is configured, the `/oauth/token` endpoint only accepts `authorization_code` and `refresh_token` grants — the `jwt-bearer` grant type is disabled. This means local instances work exactly as FLAIR-PRINCIPALS § 2 describes, with no XAA overhead.
+For local Flair instances, XAA is optional. If no IdP is configured, the `/oauth/token` endpoint only accepts `authorization_code` and `refresh_token` grants — the `jwt-bearer` grant type is disabled. This means local instances work exactly as FLAIR-PRINCIPALS § 2 describes, with no XAA overhead.
 
 ### Testing
 

--- a/specs/N8N-NODE-q3qf.md
+++ b/specs/N8N-NODE-q3qf.md
@@ -3,7 +3,7 @@
 
 **Goal:** ship a community-published n8n node package that lets n8n workflows use Flair as their AI-Agent memory backend, plus a worked-example workflow. The 1.0 narrative move: orchestrator-agnostic memory across Claude Code / OpenClaw / n8n.
 
-**Status:** spec ready. Federation flow proven (rockit↔Fabric, post-PR-#299), PR #314 merged (federation reachability/prune/verify CLI), PR #315 merged (flair-mcp parent-exit watcher). Gates open.
+**Status:** spec ready. Federation flow proven (local↔Fabric, post-PR-#299), PR #314 merged (federation reachability/prune/verify CLI), PR #315 merged (flair-mcp parent-exit watcher). Gates open.
 
 **Bead:** `ops-q3qf` (priority P1).
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -4933,7 +4933,7 @@ function oauthDetailLines(o: any): string[] {
 // discoverLocalFlairPort when the configured URL is unreachable, to detect
 // config-vs-daemon port drift (ops-mbdi). Order is ad-hoc — first hit wins.
 //
-// 9926: original default (long-running rockit installs predate the bump)
+// 9926: original default (long-running early installs predate the bump)
 // 19926: current default (DEFAULT_PORT)
 // 19925: ops-anvil VM secondary
 const LOCAL_FLAIR_PROBE_PORTS = [9926, 19926, 19925];
@@ -7220,7 +7220,7 @@ memory.command("list")
 
 // ─── flair memory hygiene ────────────────────────────────────────────────────
 // Detect + remove junk memory rows that accumulate over time. Surfaced from
-// the 2026-05-07 manual cleanup (ops-ucyy): rockit had 627 records, ~250 of
+// the 2026-05-07 manual cleanup (ops-ucyy): an instance had 627 records, ~250 of
 // them were noise — `*-compact-*` ID fragments from an old pipeline, pangram
 // test content ("the quick brown fox..." / "Flair 251 test ..."), and
 // near-empty rows (<25 chars). We did the cleanup ad-hoc with raw curl + jq;

--- a/src/observatory-sync.ts
+++ b/src/observatory-sync.ts
@@ -6,7 +6,7 @@
  *
  * Config (env vars or constructor options):
  *   OBSERVATORY_URL        — e.g. https://tps-observatory.harperdbcloud.com
- *   OBSERVATORY_OFFICE_ID  — e.g. "rockit"
+ *   OBSERVATORY_OFFICE_ID  — e.g. "office1"
  *   OBSERVATORY_KEY_PATH   — path to Ed25519 private key (raw 32-byte seed)
  *   FLAIR_URL              — local Flair base URL (default http://127.0.0.1:9926)
  *   OBSERVATORY_INTERVAL_MS — sync interval (default 60000)
@@ -17,7 +17,7 @@
  *
  *   // Or import and start:
  *   import { ObservatorySync } from "./observatory-sync.js";
- *   const sync = new ObservatorySync({ officeId: "rockit", ... });
+ *   const sync = new ObservatorySync({ officeId: "office1", ... });
  *   await sync.start();
  */
 

--- a/test/ingest-events.test.ts
+++ b/test/ingest-events.test.ts
@@ -17,9 +17,9 @@ function makeTestKeyPair(): { privateKeyRaw: Buffer; publicKeyHex: string; sign:
       const nonce = Math.random().toString(36).slice(2, 10);
       const pkcs8h = Buffer.from("302e020100300506032b657004220420", "hex");
       const privKey = require("node:crypto").createPrivateKey({ key: Buffer.concat([pkcs8h, privRaw]), format: "der", type: "pkcs8" });
-      const payload = `rockit:${ts}:${nonce}:POST:${urlPath}`;
+      const payload = `office1:${ts}:${nonce}:POST:${urlPath}`;
       const sig = sign(null, Buffer.from(payload), privKey).toString("base64");
-      return `TPS-Ed25519 rockit:${ts}:${nonce}:${sig}`;
+      return `TPS-Ed25519 office1:${ts}:${nonce}:${sig}`;
     },
   };
 }
@@ -31,7 +31,7 @@ describe("IngestEvents auth logic", () => {
     const kp = makeTestKeyPair();
     const authHeader = kp.sign("/IngestEvents");
     // Quick parse test: header has TPS-Ed25519 prefix
-    expect(authHeader.startsWith("TPS-Ed25519 rockit:")).toBe(true);
+    expect(authHeader.startsWith("TPS-Ed25519 office1:")).toBe(true);
     const parts = authHeader.split(":"); 
     expect(parts.length).toBeGreaterThanOrEqual(4);
   });

--- a/test/observatory-sync.test.ts
+++ b/test/observatory-sync.test.ts
@@ -64,7 +64,7 @@ describe("ObservatorySync", () => {
 
     const sync = new ObservatorySync({
       observatoryUrl: "http://observatory.test",
-      officeId: "rockit",
+      officeId: "office1",
       keyPath,
       flairUrl: "http://flair.test",
       cursorPath: join(tmpDir, "cursor.json"),
@@ -79,7 +79,7 @@ describe("ObservatorySync", () => {
     const ingestCall = fetchCalls.find((c) => c.url.includes("IngestEvents"));
     expect(ingestCall).toBeDefined();
     const payload = JSON.parse(String(ingestCall!.body));
-    expect(payload.officeId).toBe("rockit");
+    expect(payload.officeId).toBe("office1");
     expect(payload.events).toHaveLength(1);
     expect(payload.events[0].kind).toBe("task.completed");
   });
@@ -98,7 +98,7 @@ describe("ObservatorySync", () => {
     const cursorPath = join(tmpDir, "cursor.json");
     const sync = new ObservatorySync({
       observatoryUrl: "http://obs.test",
-      officeId: "rockit",
+      officeId: "office1",
       keyPath,
       cursorPath,
     });
@@ -118,7 +118,7 @@ describe("ObservatorySync", () => {
 
     const sync = new ObservatorySync({
       observatoryUrl: "http://obs.test",
-      officeId: "rockit",
+      officeId: "office1",
       keyPath,
       cursorPath: join(tmpDir, "cursor.json"),
     });
@@ -137,7 +137,7 @@ describe("ObservatorySync", () => {
 
     const sync = new ObservatorySync({
       observatoryUrl: "http://obs.test",
-      officeId: "rockit",
+      officeId: "office1",
       keyPath,
       cursorPath: join(tmpDir, "cursor.json"),
     });
@@ -157,7 +157,7 @@ describe("ObservatorySync", () => {
 
     const sync = new ObservatorySync({
       observatoryUrl: "http://obs.test",
-      officeId: "rockit",
+      officeId: "office1",
       keyPath,
       cursorPath: join(tmpDir, "cursor.json"),
     });

--- a/test/unit/bridge-chatgpt.test.ts
+++ b/test/unit/bridge-chatgpt.test.ts
@@ -42,7 +42,7 @@ describe("chatgpt bridge: plain-text input (primary user workflow)", () => {
       const path = join(dir, "memories.txt");
       writeFileSync(path,
         "- User prefers TypeScript\n" +
-        "- User runs newton on M3 Ultra\n" +
+        "- User runs a home GPU box\n" +
         "- User's coffee order is a flat white\n",
       );
       const out = await collectMemories({ source: path }, fakeCtx());
@@ -162,7 +162,7 @@ describe("chatgpt bridge: JSON fallback (third-party tool exports)", () => {
       writeFileSync(path, JSON.stringify({
         memories: [
           { id: "abc", content: "User uses TypeScript", created_at: "2026-04-15T00:00:00Z" },
-          { id: "def", content: "User runs newton on M3 Ultra" },
+          { id: "def", content: "User runs a home GPU box" },
         ],
       }));
       const out = await collectMemories({ source: path }, fakeCtx());

--- a/test/unit/cli-target-flag.test.ts
+++ b/test/unit/cli-target-flag.test.ts
@@ -132,9 +132,9 @@ describe("resolveEffectiveOpsUrl", () => {
 
   test("uses --ops-target directly when both flags are set (Fabric path)", () => {
     expect(resolveEffectiveOpsUrl({
-      target: "https://flair.heskew.harperfabric.com",
-      opsTarget: "https://flair.heskew.harperfabric.com:9925",
-    })).toBe("https://flair.heskew.harperfabric.com:9925");
+      target: "https://flair.example.harperfabric.com",
+      opsTarget: "https://flair.example.harperfabric.com:9925",
+    })).toBe("https://flair.example.harperfabric.com:9925");
   });
 
   test("uses --ops-target directly even with no --target (edge case)", () => {
@@ -355,40 +355,40 @@ describe("api() baseUrl override routes HTTP calls to target", () => {
 describe("--ops-target overrides ops URL derivation", () => {
   test("ops-target is used directly for ops calls, separate from --target REST", () => {
     const opsTarget = resolveOpsTarget({
-      opsTarget: "https://flair.heskew.harperfabric.com:9925",
+      opsTarget: "https://flair.example.harperfabric.com:9925",
     });
-    expect(opsTarget).toBe("https://flair.heskew.harperfabric.com:9925");
+    expect(opsTarget).toBe("https://flair.example.harperfabric.com:9925");
 
     const target = resolveTarget({
-      target: "https://flair.heskew.harperfabric.com",
+      target: "https://flair.example.harperfabric.com",
     });
-    expect(target).toBe("https://flair.heskew.harperfabric.com");
+    expect(target).toBe("https://flair.example.harperfabric.com");
 
     // opsTarget is a completely different URL from target — no port-1 derivation
-    expect(opsTarget).not.toBe("https://flair.heskew.harperfabric.com:442");
+    expect(opsTarget).not.toBe("https://flair.example.harperfabric.com:442");
   });
 
   test("Fabric acceptance criteria: target rest + ops on separate port", () => {
     // Simulate the Fabric use case from spec:
-    // --target https://flair.heskew.harperfabric.com
-    // --ops-target https://flair.heskew.harperfabric.com:9925
+    // --target https://flair.example.harperfabric.com
+    // --ops-target https://flair.example.harperfabric.com:9925
     const baseUrl = resolveTarget({
-      target: "https://flair.heskew.harperfabric.com",
+      target: "https://flair.example.harperfabric.com",
     })!.replace(/\/$/, "");
     const opsUrl = resolveOpsTarget({
-      opsTarget: "https://flair.heskew.harperfabric.com:9925",
+      opsTarget: "https://flair.example.harperfabric.com:9925",
     })!.replace(/\/$/, "");
 
-    expect(baseUrl).toBe("https://flair.heskew.harperfabric.com");
-    expect(opsUrl).toBe("https://flair.heskew.harperfabric.com:9925");
+    expect(baseUrl).toBe("https://flair.example.harperfabric.com");
+    expect(opsUrl).toBe("https://flair.example.harperfabric.com:9925");
 
     // Verify no derivation contamination: opsUrl is explicit, not port-1
     const derivedFromBase = resolveOpsUrlFromTarget(baseUrl);
-    expect(derivedFromBase).toBe("https://flair.heskew.harperfabric.com:442");
+    expect(derivedFromBase).toBe("https://flair.example.harperfabric.com:442");
     expect(opsUrl).not.toBe(derivedFromBase);
   });
 
-  test("only --target (rockit-style) still derives ops URL correctly", () => {
+  test("only --target (local-style) still derives ops URL correctly", () => {
     // Back-compat: no --ops-target, only --target
     const baseUrl = resolveTarget({
       target: "https://localhost:19926",
@@ -419,7 +419,7 @@ describe("seedFederationInstanceViaOpsApi", () => {
 
     try {
       await seedFederationInstanceViaOpsApi(
-        "https://flair.heskew.harperfabric.com:9925",
+        "https://flair.example.harperfabric.com:9925",
         "test-instance-uuid",
         "base64pubkey==",
         "hub",
@@ -431,7 +431,7 @@ describe("seedFederationInstanceViaOpsApi", () => {
     }
 
     // Verify URL has trailing slash (as seedAgentViaOpsApi does)
-    expect(capturedUrl).toBe("https://flair.heskew.harperfabric.com:9925/");
+    expect(capturedUrl).toBe("https://flair.example.harperfabric.com:9925/");
 
     // Verify auth header
     expect(capturedHeaders!["Authorization"]).toBe(
@@ -461,7 +461,7 @@ describe("seedFederationInstanceViaOpsApi", () => {
 
     try {
       await seedFederationInstanceViaOpsApi(
-        "https://flair.heskew.harperfabric.com:9925/",
+        "https://flair.example.harperfabric.com:9925/",
         "id",
         "pk",
         "hub",
@@ -472,7 +472,7 @@ describe("seedFederationInstanceViaOpsApi", () => {
       globalThis.fetch = origFetch;
     }
 
-    expect(capturedUrl).toBe("https://flair.heskew.harperfabric.com:9925/");
+    expect(capturedUrl).toBe("https://flair.example.harperfabric.com:9925/");
   });
 
   test("uses localhost URL when opsPortOrUrl is a number", async () => {


### PR DESCRIPTION
## What
The public repo was exposing a recon-level internal infra map (real hostnames, hardware, network topology) — no secrets, but gratuitously specific for a public open-source repo. This genericizes it across **26 files** (docs, specs, scripts, test fixtures, code comments, the asciinema cast).

## Why
Flagged by Nathan — `rockit` showing up in the README led to a full sweep. The detailed team + infra layout is preserved privately in the ops repo (`TEAM-AND-INFRA.md`); this PR keeps the *public* docs' value (incl. the dogfooding showcase in `the-team.md`) while scrubbing the specifics.

## Changes
- **`the-team.md`** — roster / diagram / hardware genericized (real hostnames → roles); kept the narrative + isolation guarantees. Also padded a **pre-existing** misaligned ASCII box block.
- **README** — arch diagram node (`rockit` → `self-hosted`), Fabric hub example (`flair.heskew` → `your-org`), sample triple.
- **docs / specs / scripts** — `rockit`/`newton`/`*.exe.xyz`/`flair.heskew` → generic roles; `/Users/squeued` personal paths → `/Users/youruser` templates.
- **test fixtures** — real Fabric hub + officeId → `example.*` / `office1` (input + expected updated together; tests green).

## Safety
- No logic changes — docs, comments, and test fixtures only.
- Touched tests pass; pre-commit ASCII-box-alignment check passes.
- A pre-existing `tsc` error at `auth-middleware.ts:118` is **unrelated** to this change (confirmed present on `main`).

Verified: zero internal hostnames/endpoints/personal paths remain in the public repo.