### PR TITLE
ci: retry HuggingFace model download (fix 429 flake)

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -39,7 +39,10 @@ jobs:
       - name: Pre-download embedding model
         run: |
           mkdir -p models
-          curl -fSL \
+          # HuggingFace intermittently 429s the model download; retry with
+          # backoff (--retry-all-errors so 429/4xx are retried, not just 5xx).
+          # A bare curl here flaked the whole job and blocked merges (#463, #465).
+          curl -fSL --retry 5 --retry-delay 10 --retry-all-errors --connect-timeout 30 \
             "https://huggingface.co/nomic-ai/nomic-embed-text-v1.5-GGUF/resolve/main/nomic-embed-text-v1.5.Q4_K_M.gguf" \
             -o models/nomic-embed-text-v1.5.Q4_K_M.gguf
           echo "Model downloaded ($(du -sh models/*.gguf | cut -f1))"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -88,7 +88,10 @@ jobs:
       - name: Pre-download embedding model
         run: |
           mkdir -p models
-          curl -fSL \
+          # HuggingFace intermittently 429s the model download; retry with
+          # backoff (--retry-all-errors so 429/4xx are retried, not just 5xx).
+          # A bare curl here flaked the whole job and blocked merges (#463, #465).
+          curl -fSL --retry 5 --retry-delay 10 --retry-all-errors --connect-timeout 30 \
             "https://huggingface.co/nomic-ai/nomic-embed-text-v1.5-GGUF/resolve/main/nomic-embed-text-v1.5.Q4_K_M.gguf" \
             -o models/nomic-embed-text-v1.5.Q4_K_M.gguf
           echo "Model downloaded ($(du -sh models/*.gguf | cut -f1))"


### PR DESCRIPTION
## Problem
The `Pre-download embedding model` step in both `test.yml` (Integration Tests) and `smoke.yml` does a bare `curl -fSL` of the nomic-embed GGUF from HuggingFace. HF intermittently returns **HTTP 429**, failing the whole job in ~23s and **blocking merges on a non-code flake** — hit on #463 and again on #465 (the 0.10.1 release), where it cost a manual re-trigger.

## Fix
Add retry-with-backoff to both download steps:
```
curl -fSL --retry 5 --retry-delay 10 --retry-all-errors --connect-timeout 30 ...
```
`--retry-all-errors` is the key flag — plain `--retry` only retries transient/5xx, not 429. 5 attempts × 10s backoff rides out a short rate-limit window without masking a genuinely dead URL (still `-fSL`, so a real 404/persistent failure still fails the job).

No code or test changes — workflow-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)