### PR TITLE
ci: workflow_dispatch + integration_repeats to repro native-spawn flake

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -109,9 +109,14 @@ jobs:
         # integration_repeats (workflow_dispatch input, default 1) runs the
         # suite N times in one job to reproduce the intermittent native-spawn
         # flake (ops-wumd) under #467's diagnostics. Normal push/PR runs use 1,
-        # so this is a no-op for them.
+        # so this is a no-op for them. The input is passed via env (not
+        # interpolated into the script body) and validated numeric, to avoid
+        # ${{ ... }} shell-injection.
+        env:
+          INTEGRATION_REPEATS: ${{ github.event.inputs.integration_repeats || '1' }}
         run: |
-          repeats="${{ github.event.inputs.integration_repeats || '1' }}"
+          repeats="${INTEGRATION_REPEATS}"
+          case "$repeats" in ''|*[!0-9]*) repeats=1 ;; esac
           echo "Running integration suite ${repeats}x"
           for i in $(seq 1 "${repeats}"); do
             echo "::group::integration attempt ${i}/${repeats}"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,12 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  workflow_dispatch:
+    inputs:
+      integration_repeats:
+        description: "Run the integration suite N times in one job (native-spawn flake repro, ops-wumd). Default 1."
+        required: false
+        default: "1"
 
 jobs:
   test-unit:
@@ -99,7 +105,19 @@ jobs:
         # No HARPER_HTTP_URL — harper-lifecycle spawns Harper from node_modules
         # per the npm-installed @harperfast/harper@5.0.1. Avoids the Docker
         # runtime environment that triggers HarperFast/harper#386.
-        run: bun test test/integration/
+        #
+        # integration_repeats (workflow_dispatch input, default 1) runs the
+        # suite N times in one job to reproduce the intermittent native-spawn
+        # flake (ops-wumd) under #467's diagnostics. Normal push/PR runs use 1,
+        # so this is a no-op for them.
+        run: |
+          repeats="${{ github.event.inputs.integration_repeats || '1' }}"
+          echo "Running integration suite ${repeats}x"
+          for i in $(seq 1 "${repeats}"); do
+            echo "::group::integration attempt ${i}/${repeats}"
+            bun test test/integration/
+            echo "::endgroup::"
+          done
       - name: Start Harper with Flair component (for E2E / Playwright)
         run: |
           docker run -d \


### PR DESCRIPTION
## Why

ops-wumd (the ~30% native-Harper-spawn CI flake) is now *diagnosable* thanks to #467, but to actually fix it we need to **see one fail** with the new instrumentation. The death lives in the linux-x64 llama/HNSW startup path and does **not** reproduce on local darwin — so on-demand CI repro is the only way to capture the real exit code/signal + Harper log.

## What

- Adds `workflow_dispatch` to the CI workflow with an `integration_repeats` input (default `1`).
- The integration job runs the suite N times in one job, so a single dispatch with e.g. `repeats=10` force-reproduces the flake (~97% chance of at least one hit at a 30% rate).
- **No-op for normal runs:** push/PR runs default to 1 (single pass), unchanged.

## Security

The input is passed via the `INTEGRATION_REPEATS` env var (not interpolated as `${{ ... }}` into the script body) and validated numeric (`case … *[!0-9]* … repeats=1`), so there's no GHA script-injection surface — even though `workflow_dispatch` is already write-access-only.

## Plan

Merge → dispatch with `repeats=10` → read the Harper death cause from #467's diagnostics → ship the iteration-2 root-cause fix. This harness stays as a reusable repro tool.

Refs ops-wumd.