### PR TITLE
fix(federation): sync rows with null updatedAt via COALESCE(updatedAt, createdAt)

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -3644,24 +3644,34 @@ export async function runFederationSyncOnce(opts: any): Promise<{ pushed: number
     let totalBatches = 0;
 
     for (const table of tables) {
-      let res: Response;
-      try {
-        res = await fetch(`${opsEndpoint}/`, {
-          method: "POST",
-          headers: { "Content-Type": "application/json", Authorization: auth },
-          body: JSON.stringify({ operation: "search_by_conditions", schema: "flair", table, operator: "and", conditions: [{ search_attribute: "updatedAt", search_type: "greater_than", search_value: since }], get_attributes: ["*"] }),
-          signal: AbortSignal.timeout(15_000),
-        });
-      } catch (err: any) {
-        return { pushed: totalMerged, skipped: totalSkipped, error: err instanceof Error ? err : new Error(String(err)) };
+      let rows: any[] = [];
+      for (const query of [
+        { search_attribute: "updatedAt", search_type: "greater_than", search_value: since },
+        // Rows with null updatedAt (legacy direct-insert rows) use createdAt.
+        // COALESCE(updatedAt, createdAt) > since → pick up null-updatedAt rows
+        // whose createdAt > since. Filtered in JS below.
+        { search_attribute: "updatedAt", search_type: "equals", search_value: null },
+      ]) {
+        let res: Response;
+        try {
+          res = await fetch(`${opsEndpoint}/`, {
+            method: "POST",
+            headers: { "Content-Type": "application/json", Authorization: auth },
+            body: JSON.stringify({ operation: "search_by_conditions", schema: "flair", table, operator: "and", conditions: [query], get_attributes: ["*"] }),
+            signal: AbortSignal.timeout(15_000),
+          });
+        } catch (err: any) {
+          return { pushed: totalMerged, skipped: totalSkipped, error: err instanceof Error ? err : new Error(String(err)) };
+        }
+        if (!res.ok) {
+          const text = await res.text().catch(() => "");
+          return { pushed: totalMerged, skipped: totalSkipped, error: new Error(`SQL query failed (${res.status}): ${text}`) };
+        }
+        const batch = await res.json() as any[];
+        // For null-updatedAt rows, use createdAt as the effective timestamp.
+        // Skip rows created before the last sync cursor.
+        rows = rows.concat(batch.filter((r: any) => r.updatedAt !== null || r.createdAt > since));
       }
-      if (!res.ok) {
-        const text = await res.text().catch(() => "");
-        return { pushed: totalMerged, skipped: totalSkipped, error: new Error(`SQL query failed (${res.status}): ${text}`) };
-      }
-
-      // Stream-collect records into batches
-      const rows = await res.json() as any[];
       if (rows.length === 0) continue;
 
       let batch: any[] = [];

--- a/test/integration/federation-watch.test.ts
+++ b/test/integration/federation-watch.test.ts
@@ -144,10 +144,11 @@ describe("federation watch", () => {
     const elapsed = Date.now() - start;
 
     // With interval clamped to 5s, we should only see 1 sync run in 500ms.
-    // Each sync run issues 4 search_by_conditions POSTs (one per table:
-    // Memory, Soul, Agent, Relationship). The Peer.update for cursor
+    // Each sync run issues 8 search_by_conditions POSTs (2 per table:
+    // Memory, Soul, Agent, Relationship — one for updatedAt > since,
+    // one for updatedAt IS NULL). The Peer.update for cursor
     // advancement is NOT counted (filtered above) — orthogonal concern.
-    expect(syncCalls).toBe(4);
+    expect(syncCalls).toBe(8);
     expect(elapsed).toBeLessThan(1000);
   });
 });
@@ -241,5 +242,177 @@ describe("runFederationSyncOnce auth propagation", () => {
     });
     expect(result.error).toBeDefined();
     expect(result.error?.message).toContain("ECONNREFUSED");
+  });
+});
+
+
+describe("runFederationSyncOnce null-updatedAt fix", () => {
+  let origFetch: typeof fetch;
+
+  beforeEach(() => {
+    origFetch = globalThis.fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = origFetch;
+  });
+
+  test("syncs rows with null updatedAt using createdAt as effective timestamp", async () => {
+    const since = "2024-01-01T00:00:00Z";
+    let syncBodies: any[] = [];
+    // 32 zero bytes as base64url — valid nacl seed for signing
+    const zeroKeySeed = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+
+    globalThis.fetch = mock(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = input.toString();
+      if (url.includes("/FederationPeers")) {
+        return new Response(
+          JSON.stringify({
+            peers: [
+              {
+                role: "hub",
+                id: "hub1",
+                status: "active",
+                lastSyncAt: since,
+                endpoint: "http://hub",
+              },
+            ],
+          }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        );
+      }
+      if (url.includes("/FederationInstance")) {
+        return new Response(
+          JSON.stringify({ id: "inst1" }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        );
+      }
+      if (url.includes("/FederationSync")) {
+        const body = JSON.parse(String(init?.body ?? "{}"));
+        syncBodies.push(body);
+        return new Response(
+          JSON.stringify({ merged: body.records.length, skipped: 0, durationMs: 1 }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        );
+      }
+      if (init?.method === "POST" && !url.includes("/FederationSync")) {
+        const body = JSON.parse(String(init?.body ?? "{}"));
+        // Keystore fallback: loadInstanceSecretKey searches Instance table
+        if (body.operation === "search_by_value" && body.table === "Instance") {
+          return new Response(
+            JSON.stringify([{ id: "inst1", _keySeed: zeroKeySeed }]),
+            { status: 200, headers: { "content-type": "application/json" } },
+          );
+        }
+        const searchType = body.conditions?.[0]?.search_type;
+        if (searchType === "greater_than") {
+          return new Response(JSON.stringify([]), {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          });
+        }
+        if (searchType === "equals" && body.conditions?.[0]?.search_value === null) {
+          if (body.table !== "Memory") return new Response(JSON.stringify([]), { status: 200, headers: { "content-type": "application/json" } });
+          return new Response(
+            JSON.stringify([
+              {
+                id: "legacy-1",
+                table: "Memory",
+                content: "legacy memory",
+                createdAt: "2025-06-01T00:00:00Z",
+                updatedAt: null,
+              },
+            ]),
+            { status: 200, headers: { "content-type": "application/json" } },
+          );
+        }
+        return new Response(JSON.stringify([]), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        });
+      }
+      return new Response("not found", { status: 404 });
+    });
+
+    const result = await runFederationSyncOnce({
+      adminPass: "admin",
+      port: "19926",
+      opsPort: "19925",
+    });
+
+    expect(result.error).toBeUndefined();
+    expect(result.pushed).toBe(1);
+    expect(syncBodies).toHaveLength(1);
+    expect(syncBodies[0].records).toHaveLength(1);
+    expect(syncBodies[0].records[0].id).toBe("legacy-1");
+    expect(syncBodies[0].records[0].updatedAt).toBe("2025-06-01T00:00:00Z");
+  });
+
+  test("skips null-updatedAt rows whose createdAt is before the sync cursor", async () => {
+    const since = "2025-06-01T00:00:00Z";
+
+    globalThis.fetch = mock(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = input.toString();
+      if (url.includes("/FederationPeers")) {
+        return new Response(
+          JSON.stringify({
+            peers: [
+              {
+                role: "hub",
+                id: "hub1",
+                status: "active",
+                lastSyncAt: since,
+                endpoint: "http://hub",
+              },
+            ],
+          }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        );
+      }
+      if (url.includes("/FederationInstance")) {
+        return new Response(
+          JSON.stringify({ id: "inst1" }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        );
+      }
+      if (init?.method === "POST" && !url.includes("/FederationSync")) {
+        const body = JSON.parse(String(init?.body ?? "{}"));
+        const searchType = body.conditions?.[0]?.search_type;
+        if (searchType === "greater_than") {
+          return new Response(JSON.stringify([]), {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          });
+        }
+        if (searchType === "equals" && body.conditions?.[0]?.search_value === null) {
+          if (body.table !== "Memory") return new Response(JSON.stringify([]), { status: 200, headers: { "content-type": "application/json" } });
+          return new Response(
+            JSON.stringify([
+              {
+                id: "old-legacy",
+                content: "old legacy memory",
+                createdAt: "2024-01-01T00:00:00Z",
+                updatedAt: null,
+              },
+            ]),
+            { status: 200, headers: { "content-type": "application/json" } },
+          );
+        }
+        return new Response(JSON.stringify([]), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        });
+      }
+      return new Response("not found", { status: 404 });
+    });
+
+    const result = await runFederationSyncOnce({
+      adminPass: "admin",
+      port: "19926",
+      opsPort: "19925",
+    });
+
+    expect(result.error).toBeUndefined();
+    expect(result.pushed).toBe(0);
   });
 });


### PR DESCRIPTION
## Problem

Federation sync (`runFederationSyncOnce`) queries `updatedAt > since` to find changed rows. Rows with `null updatedAt` (legacy direct-insert rows from flint-demo/pulse/reed) never matched the filter and were silently never synced.

## Fix

Two queries per table per sync cycle:
1. `updatedAt > since` (existing, catches normal rows)
2. `updatedAt IS NULL` (new, catches legacy rows)

For null-updatedAt rows, filter by `createdAt > since` in JS — equivalent of `COALESCE(updatedAt, createdAt) > since`.

The sendBatch wrapper already handles this at the record level (`row.updatedAt ?? row.createdAt`), but the query itself was the bottleneck.

## Changes

- **src/cli.ts** — sync query loop now runs 2 queries per table (was 1)
- **test/integration/federation-watch.test.ts** — 2 new tests for null-updatedAt sync + fix existing query count assertion (4→8)

## Scope

Tight. Only affects `runFederationSyncOnce` in cli.ts. No API changes, no schema changes.