### PR TITLE
feat(cli): add 'flair presence set' subcommand for agent heartbeats

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -9171,6 +9171,81 @@ program
     }
   });
 
+// ─── flair presence ─────────────────────────────────────────────────────────
+
+const VALID_PRESENCE_ACTIVITIES = ["coding", "reviewing", "planning", "idle"] as const;
+const MAX_TASK_LENGTH = 120;
+
+const presence = program.command("presence").description("Manage agent presence (The Office Space)");
+
+presence
+  .command("set")
+  .description("Set your agent's current activity and task (POST /Presence)")
+  .option("--activity <activity>", `Activity type (${VALID_PRESENCE_ACTIVITIES.join("|")})`)
+  .option("--task <text>", "Short description of what you're working on")
+  .option("--agent <id>", "Agent ID (env: FLAIR_AGENT_ID)")
+  .option("--port <port>", "Harper HTTP port")
+  .option("--target <url>", "Remote Flair URL (env: FLAIR_TARGET)")
+  .action(async (opts) => {
+    const agentId = resolveAgentIdOrEnv(opts);
+    if (!agentId) {
+      console.error("Error: agent ID required. Pass --agent <id> or set FLAIR_AGENT_ID environment variable.");
+      process.exit(1);
+    }
+
+    // Validate activity
+    if (!opts.activity) {
+      console.error("Error: --activity is required.");
+      process.exit(1);
+    }
+    const activity = opts.activity as string;
+    if (!VALID_PRESENCE_ACTIVITIES.includes(activity as any)) {
+      console.error(`Error: invalid activity '${activity}'. Must be one of: ${VALID_PRESENCE_ACTIVITIES.join(", ")}`);
+      process.exit(1);
+    }
+
+    // Validate task length
+    const task = opts.task ?? undefined;
+    if (task && task.length > MAX_TASK_LENGTH) {
+      console.error(`Error: --task exceeds ${MAX_TASK_LENGTH} character limit (got ${task.length}).`);
+      process.exit(1);
+    }
+
+    // Resolve key path
+    const keyPath = resolveKeyPath(agentId);
+    if (!keyPath) {
+      console.error(`Error: private key not found for agent '${agentId}'. Check ~/.flair/keys/ or set FLAIR_KEY_DIR.`);
+      process.exit(1);
+    }
+
+    // Build auth + POST
+    const baseUrl = resolveBaseUrl(opts).replace(/\/$/, "");
+    const auth = buildEd25519Auth(agentId, "POST", "/Presence", keyPath);
+    const body: Record<string, string> = { activity };
+    if (task) body.currentTask = task;
+
+    const res = await fetch(`${baseUrl}/Presence`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: auth,
+      },
+      body: JSON.stringify(body),
+    });
+
+    if (!res.ok) {
+      const text = await res.text().catch(() => "");
+      console.error(`Error: POST /Presence failed (${res.status}): ${text}`);
+      process.exit(1);
+    }
+
+    const data = await res.json().catch(() => null);
+    console.log(`✓ Presence updated for '${agentId}': activity=${activity}${task ? `, task="${task}"` : ""}`);
+    if (data?.presenceStatus) {
+      console.log(`  Status: ${data.presenceStatus}`);
+    }
+  });
+
 // Run CLI only when this is the entry point (not when imported for testing)
 if (import.meta.main) {
   await program.parseAsync();
@@ -9192,6 +9267,9 @@ export {
   b64url,
   program,
   api,
+  VALID_PRESENCE_ACTIVITIES,
+  MAX_TASK_LENGTH,
+
   isLocalBase,
   isLikelyRealSecret,
   shouldShowInlineSecretWarning,

--- a/test/unit/presence-set.test.ts
+++ b/test/unit/presence-set.test.ts
@@ -4,8 +4,8 @@
  * Uses mock HTTP servers. No real Harper instance required.
  */
 
-import { describe, it, expect, beforeEach, afterEach } from "bun:test";
-import { spawn } from "node:child_process";
+import { describe, it, expect, beforeAll, beforeEach, afterEach } from "bun:test";
+import { spawn, execSync } from "node:child_process";
 import { mkdirSync, rmSync, writeFileSync, chmodSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
@@ -80,6 +80,11 @@ function runCli(args: string[], env: Record<string, string> = {}): Promise<{ std
 describe("flair presence set", () => {
   let tmpDir: string;
   let keysDir: string;
+
+  beforeAll(() => {
+    // Ensure dist/cli.js is built. Owns its dependency so this works in any CI job.
+    execSync("bun run build:cli", { stdio: "ignore" });
+  });
 
   beforeEach(() => {
     tmpDir = makeTmpDir();

--- a/test/unit/presence-set.test.ts
+++ b/test/unit/presence-set.test.ts
@@ -1,0 +1,322 @@
+/**
+ * presence-set.test.ts — Unit tests for `flair presence set` CLI subcommand
+ *
+ * Uses mock HTTP servers. No real Harper instance required.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import { spawn } from "node:child_process";
+import { mkdirSync, rmSync, writeFileSync, chmodSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { createServer, IncomingMessage, ServerResponse, Server } from "node:http";
+import nacl from "tweetnacl";
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function makeTmpDir(): string {
+  const dir = join(tmpdir(), `flair-presence-test-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+  mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+type Handler = (req: IncomingMessage, body: string, res: ServerResponse) => void;
+
+function startMockServer(handler: Handler): Promise<{ server: Server; url: string; port: number }> {
+  return new Promise((resolve) => {
+    const server = createServer((req, res) => {
+      let body = "";
+      req.on("data", (c) => (body += c));
+      req.on("end", () => handler(req, body, res));
+    });
+    server.listen(0, "127.0.0.1", () => {
+      const addr = server.address();
+      const port = typeof addr === "object" && addr ? addr.port : 0;
+      resolve({ server, url: `http://127.0.0.1:${port}`, port });
+    });
+  });
+}
+
+function stopServer(server: Server): Promise<void> {
+  return new Promise((resolve, reject) => server.close((e) => (e ? reject(e) : resolve())));
+}
+
+function jsonRes(res: ServerResponse, status: number, data: unknown) {
+  res.writeHead(status, { "Content-Type": "application/json" });
+  res.end(JSON.stringify(data));
+}
+
+function b64url(bytes: Uint8Array): string {
+  return Buffer.from(bytes).toString("base64url");
+}
+
+function writeAgentKey(keysDir: string, agentId: string): { pubKeyB64url: string } {
+  const kp = nacl.sign.keyPair();
+  const seed = kp.secretKey.slice(0, 32);
+  writeFileSync(join(keysDir, `${agentId}.key`), Buffer.from(seed));
+  chmodSync(join(keysDir, `${agentId}.key`), 0o600);
+  const pubKeyPath = join(keysDir, `${agentId}.pub`);
+  writeFileSync(pubKeyPath, Buffer.from(kp.publicKey));
+  return { pubKeyB64url: b64url(kp.publicKey) };
+}
+
+function runCli(args: string[], env: Record<string, string> = {}): Promise<{ stdout: string; stderr: string; code: number | null }> {
+  const cliPath = join(import.meta.dirname ?? __dirname, "..", "..", "dist", "cli.js");
+  return new Promise((resolve) => {
+    const child = spawn("bun", [cliPath, ...args], {
+      env: { ...process.env, ...env },
+      stdio: ["inherit", "pipe", "pipe"],
+    });
+    let stdout = "";
+    let stderr = "";
+    child.stdout.on("data", (d) => (stdout += d));
+    child.stderr.on("data", (d) => (stderr += d));
+    child.on("close", (code) => resolve({ stdout, stderr, code }));
+  });
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe("flair presence set", () => {
+  let tmpDir: string;
+  let keysDir: string;
+
+  beforeEach(() => {
+    tmpDir = makeTmpDir();
+    keysDir = join(tmpDir, "keys");
+    mkdirSync(keysDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("rejects missing --activity", async () => {
+    const agentId = "test-agent-presence";
+    writeAgentKey(keysDir, agentId);
+
+    const { stderr, code } = await runCli(
+      ["presence", "set", "--task", "hello"],
+      { FLAIR_AGENT_ID: agentId, FLAIR_KEY_DIR: keysDir, FLAIR_URL: "http://127.0.0.1:99999" },
+    );
+
+    expect(code).toBe(1);
+    expect(stderr).toContain("--activity is required");
+  });
+
+  it("rejects invalid activity value", async () => {
+    const agentId = "test-agent-presence";
+    writeAgentKey(keysDir, agentId);
+
+    const { stderr, code } = await runCli(
+      ["presence", "set", "--activity", "sleeping", "--task", "napping"],
+      { FLAIR_AGENT_ID: agentId, FLAIR_KEY_DIR: keysDir, FLAIR_URL: "http://127.0.0.1:99999" },
+    );
+
+    expect(code).toBe(1);
+    expect(stderr).toContain("invalid activity");
+  });
+
+  it("rejects task exceeding 120 chars", async () => {
+    const agentId = "test-agent-presence";
+    writeAgentKey(keysDir, agentId);
+    const longTask = "a".repeat(121);
+
+    const { stderr, code } = await runCli(
+      ["presence", "set", "--activity", "coding", "--task", longTask],
+      { FLAIR_AGENT_ID: agentId, FLAIR_KEY_DIR: keysDir, FLAIR_URL: "http://127.0.0.1:99999" },
+    );
+
+    expect(code).toBe(1);
+    expect(stderr).toContain("120 character limit");
+  });
+
+  it("rejects task exactly 121 chars", async () => {
+    const agentId = "test-agent-presence";
+    writeAgentKey(keysDir, agentId);
+    const longTask = "x".repeat(121);
+
+    const { stderr, code } = await runCli(
+      ["presence", "set", "--activity", "coding", "--task", longTask],
+      { FLAIR_AGENT_ID: agentId, FLAIR_KEY_DIR: keysDir, FLAIR_URL: "http://127.0.0.1:99999" },
+    );
+
+    expect(code).toBe(1);
+    expect(stderr).toContain("120 character limit");
+  });
+
+  it("accepts task exactly 120 chars", async () => {
+    const agentId = "test-agent-presence";
+    writeAgentKey(keysDir, agentId);
+    const exactTask = "x".repeat(120);
+
+    const { server, url } = await startMockServer((req, body, res) => {
+      const parsed = JSON.parse(body);
+      expect(parsed.activity).toBe("coding");
+      expect(parsed.currentTask).toBe(exactTask);
+      jsonRes(res, 200, { ok: true, agentId, presenceStatus: "active" });
+    });
+
+    try {
+      const { stdout, code } = await runCli(
+        ["presence", "set", "--activity", "coding", "--task", exactTask],
+        { FLAIR_AGENT_ID: agentId, FLAIR_KEY_DIR: keysDir, FLAIR_URL: url },
+      );
+
+      expect(code).toBe(0);
+      expect(stdout).toContain("Presence updated");
+    } finally {
+      await stopServer(server);
+    }
+  });
+
+  it("posts to /Presence with correct activity and task", async () => {
+    const agentId = "test-agent-presence";
+    writeAgentKey(keysDir, agentId);
+
+    const { server, url } = await startMockServer((req, body, res) => {
+      expect(req.method).toBe("POST");
+      expect(req.url).toBe("/Presence");
+
+      const parsed = JSON.parse(body);
+      expect(parsed.activity).toBe("reviewing");
+      expect(parsed.currentTask).toBe("code review on PR #123");
+      expect(parsed.agentId).toBeUndefined(); // we don't send agentId in body
+
+      jsonRes(res, 200, { ok: true, agentId, presenceStatus: "active" });
+    });
+
+    try {
+      const { stdout, code } = await runCli(
+        ["presence", "set", "--activity", "reviewing", "--task", "code review on PR #123"],
+        { FLAIR_AGENT_ID: agentId, FLAIR_KEY_DIR: keysDir, FLAIR_URL: url },
+      );
+
+      expect(code).toBe(0);
+      expect(stdout).toContain("Presence updated");
+    } finally {
+      await stopServer(server);
+    }
+  });
+
+  it("posts activity-only (no task)", async () => {
+    const agentId = "test-agent-presence";
+    writeAgentKey(keysDir, agentId);
+
+    const { server, url } = await startMockServer((req, body, res) => {
+      const parsed = JSON.parse(body);
+      expect(parsed.activity).toBe("idle");
+      expect(parsed.currentTask).toBeUndefined();
+
+      jsonRes(res, 200, { ok: true, agentId, presenceStatus: "active" });
+    });
+
+    try {
+      const { stdout, code } = await runCli(
+        ["presence", "set", "--activity", "idle"],
+        { FLAIR_AGENT_ID: agentId, FLAIR_KEY_DIR: keysDir, FLAIR_URL: url },
+      );
+
+      expect(code).toBe(0);
+      expect(stdout).toContain("Presence updated");
+    } finally {
+      await stopServer(server);
+    }
+  });
+
+  it("sends Ed25519 Authorization header", async () => {
+    const agentId = "test-agent-presence";
+    writeAgentKey(keysDir, agentId);
+
+    const { server, url } = await startMockServer((req, _body, res) => {
+      const authHeader = req.headers["authorization"];
+      expect(authHeader).toBeDefined();
+      expect(typeof authHeader).toBe("string");
+      expect(authHeader).toMatch(/^TPS-Ed25519\s+/);
+
+      // The auth header should contain the agentId
+      const parts = (authHeader as string).split(" ")[1].split(":");
+      expect(parts[0]).toBe(agentId);
+
+      jsonRes(res, 200, { ok: true, agentId, presenceStatus: "active" });
+    });
+
+    try {
+      const { code } = await runCli(
+        ["presence", "set", "--activity", "planning", "--task", "architecture review"],
+        { FLAIR_AGENT_ID: agentId, FLAIR_KEY_DIR: keysDir, FLAIR_URL: url },
+      );
+
+      expect(code).toBe(0);
+    } finally {
+      await stopServer(server);
+    }
+  });
+
+  it("exits with error on server 5xx", async () => {
+    const agentId = "test-agent-presence";
+    writeAgentKey(keysDir, agentId);
+
+    const { server, url } = await startMockServer((_req, _body, res) => {
+      res.writeHead(500, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ error: "internal_error" }));
+    });
+
+    try {
+      const { stderr, code } = await runCli(
+        ["presence", "set", "--activity", "coding", "--task", "test"],
+        { FLAIR_AGENT_ID: agentId, FLAIR_KEY_DIR: keysDir, FLAIR_URL: url },
+      );
+
+      expect(code).toBe(1);
+      expect(stderr).toContain("POST /Presence failed");
+    } finally {
+      await stopServer(server);
+    }
+  });
+
+  it("rejects missing agent ID", async () => {
+    const { stderr, code } = await runCli(
+      ["presence", "set", "--activity", "coding"],
+      { FLAIR_KEY_DIR: keysDir, FLAIR_URL: "http://127.0.0.1:99999" },
+    );
+
+    expect(code).toBe(1);
+    expect(stderr).toContain("agent ID required");
+  });
+
+  it("rejects missing private key", async () => {
+    const agentId = "no-key-agent";
+
+    const { stderr, code } = await runCli(
+      ["presence", "set", "--activity", "coding"],
+      { FLAIR_AGENT_ID: agentId, FLAIR_KEY_DIR: keysDir, FLAIR_URL: "http://127.0.0.1:99999" },
+    );
+
+    expect(code).toBe(1);
+    expect(stderr).toContain("private key not found");
+  });
+
+  it("supports all valid activity values", async () => {
+    const agentId = "test-agent-presence";
+    writeAgentKey(keysDir, agentId);
+
+    const { server, url } = await startMockServer((req, body, res) => {
+      const parsed = JSON.parse(body);
+      jsonRes(res, 200, { ok: true, agentId, activity: parsed.activity, presenceStatus: "active" });
+    });
+
+    try {
+      for (const activity of ["coding", "reviewing", "planning", "idle"]) {
+        const { code, stdout } = await runCli(
+          ["presence", "set", "--activity", activity],
+          { FLAIR_AGENT_ID: agentId, FLAIR_KEY_DIR: keysDir, FLAIR_URL: url },
+        );
+        expect(code).toBe(0);
+        expect(stdout).toContain(`activity=${activity}`);
+      }
+    } finally {
+      await stopServer(server);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Add `flair presence set --activity <coding|reviewing|planning|idle> --task "<text>"` CLI subcommand that does an authed POST to `/Presence` for the current agent (`FLAIR_AGENT_ID`).

## What changed

- **src/cli.ts** — new top-level `flair presence` command group with `set` subcommand
  - Validates `--activity` against enum (`coding`, `reviewing`, `planning`, `idle`)
  - Caps `--task` at 120 characters client-side
  - Resolves agent ID from `--agent` flag or `FLAIR_AGENT_ID` env
  - Resolves private key from `~/.flair/keys/<agentId>.key` or `FLAIR_KEY_DIR`
  - Builds Ed25519 auth header via existing `buildEd25519Auth()` (same path as `federation watch`)
  - POSTs `{ activity, currentTask }` to `/Presence`
  - No changes to `resources/auth-middleware.ts`

- **test/unit/presence-set.test.ts** — 12 tests:
  - Validation: missing activity, invalid activity, task >120 chars, missing agent ID, missing key
  - Positive: posts with activity+task, activity-only, all 4 activity values, auth header format, server error handling

## Testing

```
bun test test/unit/presence-set.test.ts  # 12 pass, 0 fail
bun test test/unit/                      # 975 pass, 0 fail (full suite)
```

## Usage

```sh
FLAIR_AGENT_ID=my-agent flair presence set --activity coding --task "implementing presence CLI"
```

## Follow-up (piece 2)

Per-agent emitter wrapper + launchd deploy — separate PR after this lands.