### PR TITLE
fix: harden harper-lifecycle env + listener cleanup (ops-9v4g)

### DIFF
--- a/test/helpers/harper-lifecycle.ts
+++ b/test/helpers/harper-lifecycle.ts
@@ -96,8 +96,15 @@ export async function startHarper(): Promise<HarperInstance> {
   const httpPort = getRandomPort();
   const opsPort = httpPort + 1;
 
+  // Deny-list: strip CI secrets from the inherited env so Harper's child
+  // process (and any log dump on failure) doesn't leak them onto a public
+  // CI runner (Sherlock review on #467).
+  const parentEnv = { ...process.env as Record<string, string> };
+  delete parentEnv.GITHUB_TOKEN;
+  delete parentEnv.NPM_TOKEN;
+
   const env: Record<string, string> = {
-    ...process.env as Record<string, string>,
+    ...parentEnv,
     ROOTPATH: installDir,
     HOME: installDir,               // isolate from system Harper install (~/.harperdb)
     DEFAULTS_MODE: "dev",
@@ -185,6 +192,9 @@ export async function stopHarper(inst: HarperInstance): Promise<void> {
     inst.process?.on("exit", r);
     setTimeout(() => { try { inst.process?.kill("SIGKILL"); } catch {} r(); }, 3000);
   });
+  // Drain persistent listeners added in #467 (stdout/stderr/exit capture) so
+  // the emitter doesn't linger and keep the ChildProcess ref alive.
+  inst.process?.removeAllListeners();
   if (inst.installDir) {
     await rm(inst.installDir, { recursive: true, force: true, maxRetries: 4 });
   }


### PR DESCRIPTION
## What

Two small hardening items in `test/helpers/harper-lifecycle.ts` (Sherlock review on #467, ops-9v4g):

1. **Env deny-list**: `startHarper()` now strips `GITHUB_TOKEN` + `NPM_TOKEN` from the spawned Harper child env before spreading, preventing secret leak on public CI when #467's log-dump-on-failure fires.
2. **Listener cleanup**: `stopHarper()` calls `proc.removeAllListeners()` after the process exits to drain the persistent stdout/stderr/exit listeners added in #467, preventing the emitter from keeping the ChildProcess ref alive.

## Testing

- `bun test test/integration/smoke.test.ts` — 2/2 pass
- `npm run build` — green

## Diff

15 lines changed (1 file).