### PR TITLE
fix(smoke): include required publicKey and createdAt in createAgent

### DIFF
--- a/test/smoke/helpers/flair-instance.ts
+++ b/test/smoke/helpers/flair-instance.ts
@@ -10,6 +10,7 @@
  */
 
 import { randomBytes } from "node:crypto";
+import nacl from "tweetnacl";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -117,6 +118,9 @@ export async function createAgent(
   authHeader: string,
 ): Promise<string> {
   const id = `smoke-${Date.now()}-${randomBytes(4).toString("hex")}`;
+  // Generate a test Ed25519 keypair (matches real agent registration)
+  const kp = nacl.sign.keyPair();
+  const publicKey = Buffer.from(kp.publicKey).toString("base64url");
 
   const res = await fetch(`${baseUrl}/Agent/${encodeURIComponent(id)}`, {
     method: "PUT",
@@ -128,6 +132,8 @@ export async function createAgent(
       id,
       name: `Smoke Test ${id.slice(-8)}`,
       kind: "agent",
+      publicKey,
+      createdAt: new Date().toISOString(),
     }),
     signal: AbortSignal.timeout(10_000),
   });


### PR DESCRIPTION
## Problem

Smoke test Golden Path is RED: createAgent POSTs only id+name, but the Agent schema requires publicKey (String!) and createdAt (String!). This causes HTTP 400 on every create, and all 5 golden-path steps fail with undefined.

## Root cause

test/smoke/helpers/flair-instance.ts createAgent was missing two required fields. Real agent registration (flair agent register, CLI seed functions) always sends both publicKey (Ed25519 base64url) and createdAt (ISO timestamp). The resource handler does NOT inject defaults — these are NOT NULL schema constraints.

## Fix

- Import tweetnacl to generate a test Ed25519 keypair
- Encode publicKey as base64url (matching real registration format)
- Include createdAt: new Date().toISOString()
- Agent payload now: id, name, kind, publicKey, createdAt

## Verification

- Code compiles (bun transpile OK, pre-commit hooks pass)
- Matches real agent registration pattern in src/cli.ts (line 532)
- CI smoke workflow (Docker + Harper) will validate end-to-end on merge

## Note on CI checks

The Smoke Tests workflow is NOT a required check on main. This is why the RED state merged through the last few PRs. Flint — should this be promoted to a required status check?