### PR TITLE
fix(lint): impl-term regex — exclude CLI flags from Bead-ID match + repair dead version-label detection

### DIFF
--- a/scripts/check-impl-term-leaks.sh
+++ b/scripts/check-impl-term-leaks.sh
@@ -1,10 +1,15 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Define the patterns to search for
-# Bead IDs: ops-[a-z0-9]{4,}
+# Define the patterns to search for. Each uses a leading (^|[^-a-z0-9]) token guard so
+# the term only matches as a standalone token, never glued to a preceding word/hyphen.
+# This prevents false positives on legitimate CLI flags (e.g. --ops-target) and
+# compounds (e.g. devops-pipeline, blogpost-2.0).
+# Bead IDs:            ops-[a-z0-9]{4,}
 # Implementation labels: post-#.# or pre-#.# (where # is digit)
-PATTERNS='ops-[a-z0-9]{4,}|\\bpost-[0-9]+\\.[0-9]+\\b|\\bpre-[0-9]+\\.[0-9]+\\b'
+# NB: portable ERE only — earlier \b word-boundary anchors were double-escaped inside
+#     the single-quoted string (\\b -> literal "\b"), so post-/pre- detection was dead.
+PATTERNS='(^|[^-a-z0-9])ops-[a-z0-9]{4,}|(^|[^-a-z0-9])(post|pre)-[0-9]+\.[0-9]+'
 
 # Temporary file for list of files
 TMPFILE=$(mktemp)


### PR DESCRIPTION
## Problem
The public-repo genericization gate (`scripts/check-impl-term-leaks.sh`) failed CI on **#477** (Anvil's spoke bring-up docs) — a **false positive**. The Bead-ID pattern `ops-[a-z0-9]{4,}` matched the legitimate `--ops-target` CLI flag (`src/cli.ts:1179`). The doc was correct; the lint was too greedy.

While fixing it I found a second, latent bug: the `post-#.#` / `pre-#.#` version-label patterns used `\\b` word boundaries that were **double-escaped** inside the single-quoted string (`\\b` → literal `\\b`), so that detection had been **silently dead** since inception.

## Fix
Single-line change to `PATTERNS`:
- Bead IDs now carry a leading `(^|[^-a-z0-9])` token guard → matches standalone IDs (`ops-fnm2`, `(ops-9v4g)`) but **not** flags (`--ops-target`) or compounds (`devops-pipeline`).
- Version labels rewritten to portable token-guarded ERE → `post-1.0` / `pre-1.0` are caught again; no double-escape.

## Verification
- ✅ `--ops-target`, `devops-pipeline`, `blogpost-2.0` → no match (false positives gone)
- ✅ `ops-fnm2`, `(ops-9v4g)`, `post-1.0`, `pre-1.0` → all caught (gate restored)
- ✅ Full lint clean on current repo (0 real leaks — repaired detection has no blast radius)

Unblocks #477 once merged (its CI merge-ref picks up the fixed script).

🤖 Generated with [Claude Code](https://claude.com/claude-code)