### PR TITLE
fix(smoke): use ops API insert for agent creation in golden path smoke

### DIFF
--- a/test/smoke/golden-path.test.ts
+++ b/test/smoke/golden-path.test.ts
@@ -63,7 +63,7 @@ describe("Golden path: agent + memory + search + bootstrap", () => {
   test("Step 1: Create agent", async () => {
     const t0 = performance.now();
 
-    agentId = await createAgent(flair.baseUrl, flair.authHeader);
+    agentId = await createAgent(flair.opsUrl, flair.authHeader);
     expect(agentId).toBeTruthy();
     expect(agentId.startsWith("smoke-")).toBe(true);
 
@@ -77,7 +77,7 @@ describe("Golden path: agent + memory + search + bootstrap", () => {
 
     markerId = await writeMemory(flair.baseUrl, agentId, MARKER_CONTENT, {
       tags: ["smoke-test"],
-    });
+    }, flair.authHeader);
 
     expect(markerId).toBeTruthy();
     expect(markerId.startsWith(agentId)).toBe(true);
@@ -90,7 +90,7 @@ describe("Golden path: agent + memory + search + bootstrap", () => {
     expect(agentId).toBeTruthy();
     const t0 = performance.now();
 
-    const result = await searchMemories(flair.baseUrl, agentId, "smoke test marker", 5);
+    const result = await searchMemories(flair.baseUrl, agentId, "smoke test marker", 5, flair.authHeader);
 
     // The search response should have results
     assertShape(result, { results: null }, "searchResult");
@@ -119,7 +119,7 @@ describe("Golden path: agent + memory + search + bootstrap", () => {
     expect(agentId).toBeTruthy();
     const t0 = performance.now();
 
-    const result = await bootstrapAgent(flair.baseUrl, agentId, 4000);
+    const result = await bootstrapAgent(flair.baseUrl, agentId, 4000, flair.authHeader);
 
     // Bootstrap returns context, tokenEstimate, memoriesIncluded
     assertShape(result, {

--- a/test/smoke/helpers/flair-instance.ts
+++ b/test/smoke/helpers/flair-instance.ts
@@ -110,11 +110,11 @@ function httpPortFrom(baseUrl: string): number {
 }
 
 /**
- * Create an agent via the Flair REST API (which triggers key generation etc).
+ * Create an agent via the Harper operations API insert.
  * Returns the agent ID.
  */
 export async function createAgent(
-  baseUrl: string,
+  opsUrl: string,
   authHeader: string,
 ): Promise<string> {
   const id = `smoke-${Date.now()}-${randomBytes(4).toString("hex")}`;
@@ -122,25 +122,46 @@ export async function createAgent(
   const kp = nacl.sign.keyPair();
   const publicKey = Buffer.from(kp.publicKey).toString("base64url");
 
-  const res = await fetch(`${baseUrl}/Agent/${encodeURIComponent(id)}`, {
-    method: "PUT",
-    headers: {
-      "Content-Type": "application/json",
-      Authorization: authHeader,
-    },
-    body: JSON.stringify({
+  const body = JSON.stringify({
+    operation: "insert",
+    database: "flair",
+    table: "Agent",
+    records: [{
       id,
       name: `Smoke Test ${id.slice(-8)}`,
       kind: "agent",
       publicKey,
       createdAt: new Date().toISOString(),
-    }),
+    }],
+  });
+
+  // Try with auth first; if 401 (e.g. authorizeLocal=true with wrong password), retry without auth
+  let res = await fetch(opsUrl, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: authHeader,
+    },
+    body,
     signal: AbortSignal.timeout(10_000),
   });
+
+  if (res.status === 401) {
+    res = await fetch(opsUrl, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body,
+      signal: AbortSignal.timeout(10_000),
+    });
+  }
 
   if (!res.ok) {
     const text = await res.text().catch(() => "");
     throw new Error(`createAgent ${id}: HTTP ${res.status} ${text}`);
+  }
+  const text = await res.text();
+  if (!text.includes("inserted")) {
+    throw new Error(`createAgent ${id}: unexpected response: ${text}`);
   }
 
   return id;
@@ -154,6 +175,7 @@ export async function writeMemory(
   agentId: string,
   content: string,
   opts?: { tags?: string[]; durability?: string },
+  authHeader?: string,
 ): Promise<string> {
   const memId = `${agentId}-${Date.now()}-${randomBytes(4).toString("hex")}`;
 
@@ -170,7 +192,7 @@ export async function writeMemory(
 
   const res = await fetch(`${baseUrl}/Memory/${encodeURIComponent(memId)}`, {
     method: "PUT",
-    headers: { "Content-Type": "application/json" },
+    headers: { "Content-Type": "application/json", ...(authHeader ? { Authorization: authHeader } : {}) },
     body: JSON.stringify(body),
     signal: AbortSignal.timeout(10_000),
   });
@@ -194,10 +216,11 @@ export async function searchMemories(
   agentId: string,
   query: string,
   limit = 5,
+  authHeader?: string,
 ): Promise<any> {
   const res = await fetch(`${baseUrl}/SemanticSearch`, {
     method: "POST",
-    headers: { "Content-Type": "application/json" },
+    headers: { "Content-Type": "application/json", ...(authHeader ? { Authorization: authHeader } : {}) },
     body: JSON.stringify({ agentId, q: query, limit }),
     signal: AbortSignal.timeout(15_000),
   });
@@ -217,10 +240,11 @@ export async function bootstrapAgent(
   baseUrl: string,
   agentId: string,
   maxTokens = 4000,
+  authHeader?: string,
 ): Promise<any> {
   const res = await fetch(`${baseUrl}/BootstrapMemories`, {
     method: "POST",
-    headers: { "Content-Type": "application/json" },
+    headers: { "Content-Type": "application/json", ...(authHeader ? { Authorization: authHeader } : {}) },
     body: JSON.stringify({ agentId, maxTokens }),
     signal: AbortSignal.timeout(15_000),
   });
@@ -238,12 +262,22 @@ export async function bootstrapAgent(
 // ---------------------------------------------------------------------------
 
 async function opsPost(opsUrl: string, authHeader: string, body: unknown): Promise<any> {
-  const res = await fetch(opsUrl, {
+  const jsonBody = JSON.stringify(body);
+  // Try with auth first; if 401 (authorizeLocal=true), retry without auth
+  let res = await fetch(opsUrl, {
     method: "POST",
     headers: { "Content-Type": "application/json", Authorization: authHeader },
-    body: JSON.stringify(body),
+    body: jsonBody,
     signal: AbortSignal.timeout(10_000),
   });
+  if (res.status === 401) {
+    res = await fetch(opsUrl, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: jsonBody,
+      signal: AbortSignal.timeout(10_000),
+    });
+  }
   if (!res.ok) {
     const text = await res.text().catch(() => "");
     throw new Error(`opsPost: HTTP ${res.status} ${text}`);


### PR DESCRIPTION
## Problem

The golden path smoke test was RED on main. Root cause: `createAgent` helper used REST `PUT /Agent/{id}` (HTTP port 9926) which silently drops `publicKey` and `createdAt` from the payload, causing Harper to reject with HTTP 400.

## Fix

Replace the REST PUT with the operations API insert (port 9925), matching the real agent registration path used by `seedAgentViaOpsApi` in `src/cli.ts`.

### Changes

- **createAgent**: POST to `opsUrl` with `{operation: "insert", ...}` body instead of PUT to REST endpoint
- **Auth resilience**: ops API calls try with Basic auth first, retry without auth on 401 (handles `authorizeLocal=true` Harper instances)
- **REST helpers**: `writeMemory`/`searchMemories`/`bootstrapAgent` now accept optional `authHeader` for deployments that require auth on REST endpoints
- **Call sites**: pass `flair.authHeader` through to all helpers

## Verification

- Tested against local Flair instance — agent creation via ops API insert succeeds with publicKey + createdAt stored correctly
- CI will validate full golden path (Docker Harper with admin123 credentials)