### PR TITLE
test(smoke): 30s timeout for embedding-backed golden-path steps (de-flake)

### DIFF
--- a/test/smoke/golden-path.test.ts
+++ b/test/smoke/golden-path.test.ts
@@ -71,6 +71,12 @@ describe("Golden path: agent + memory + search + bootstrap", () => {
     console.log(`  ✓ Created agent ${agentId} (${elapsed}ms)`);
   });
 
+  // Embedding-backed steps (write / search / bootstrap) run the embedding model,
+  // which takes ~3s locally and more on a cold CI runner. The default 5s test
+  // timeout is too tight and flakes intermittently; give these steps headroom.
+  // A genuine hang still fails at 30s.
+  const EMBED_TIMEOUT_MS = 30_000;
+
   test("Step 2: Write memory", async () => {
     expect(agentId).toBeTruthy();
     const t0 = performance.now();
@@ -84,7 +90,7 @@ describe("Golden path: agent + memory + search + bootstrap", () => {
 
     const elapsed = (performance.now() - t0).toFixed(1);
     console.log(`  ✓ Wrote memory ${markerId} (${elapsed}ms)`);
-  });
+  }, EMBED_TIMEOUT_MS);
 
   test("Step 3: Search memory (semantic)", async () => {
     expect(agentId).toBeTruthy();
@@ -113,7 +119,7 @@ describe("Golden path: agent + memory + search + bootstrap", () => {
 
     const elapsed = (performance.now() - t0).toFixed(1);
     console.log(`  ✓ Search returned ${results.length} result(s) (${elapsed}ms)`);
-  });
+  }, EMBED_TIMEOUT_MS);
 
   test("Step 4: Bootstrap context", async () => {
     expect(agentId).toBeTruthy();
@@ -141,7 +147,7 @@ describe("Golden path: agent + memory + search + bootstrap", () => {
 
     const elapsed = (performance.now() - t0).toFixed(1);
     console.log(`  ✓ Bootstrap returned context (${elapsed}ms)`);
-  });
+  }, EMBED_TIMEOUT_MS);
 
   test("Step 5: Cleanup (agent + memories deleted)", async () => {
     expect(agentId).toBeTruthy();


### PR DESCRIPTION
## Why
The Golden Path smoke flaked on the v0.11.0 release commit: **Step 2 (write memory) timed out at 5000ms**, while passing on the prior commit (same code). Root cause: steps 2–4 (write / search / bootstrap) run the embedding model — ~3s locally (measured), more on a cold CI runner — but used bun's **default 5s** test timeout.

## Fix
Shared `EMBED_TIMEOUT_MS = 30_000` applied to the three embedding-dependent steps. Fast non-embedding steps (create agent, cleanup) keep the default. A genuine hang still fails at 30s.

Verified: golden-path smoke passes locally (5/5) with the new timeouts. Matters before we promote Smoke to a required check (ops Bead filed earlier).

🤖 Generated with [Claude Code](https://claude.com/claude-code)