### PR TITLE
ci(release): tokenless stage-publish via OIDC + npm staging

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -1,0 +1,157 @@
+name: Release — stage-publish (OIDC)
+
+# Tokenless release pipeline. Authenticates to npm via OIDC trusted publishing
+# (no NPM_TOKEN stored anywhere) and submits every workspace package to npm's
+# STAGING area via `npm stage publish` rather than publishing live. A maintainer
+# then reviews the staged tarballs and approves them on npmjs.com with 2FA to go
+# live — that approval is the release gate (see docs/releasing.md).
+#
+# Trigger: manual, after the `release: vX.Y.Z` PR is merged to main.
+#   gh-as flint workflow run release-publish.yml -f version=0.11.0
+#
+# One-time setup (npmjs.com, per package): add a Trusted Publisher pointing at
+#   org=tpsdev-ai, repo=flair, workflow=release-publish.yml, environment=release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to stage (must already be merged to main, e.g. 0.11.0)"
+        required: true
+        type: string
+
+# Default to read-only; the publish job opts into exactly what it needs.
+permissions:
+  contents: read
+
+concurrency:
+  group: release-publish
+  cancel-in-progress: false
+
+jobs:
+  stage-publish:
+    name: Stage-publish all packages
+    runs-on: ubuntu-latest
+    # `release` is an OIDC-scoping environment, NOT an approval gate: it pins the
+    # trusted-publisher trust to this environment and restricts deploys to main.
+    # The human gate is the npm staging approval (2FA), not a GitHub reviewer.
+    environment: release
+    permissions:
+      id-token: write   # mint the short-lived OIDC token for npm trusted publishing
+      contents: write   # push the release tag
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        with:
+          ref: main
+          fetch-depth: 0
+
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: "22"
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Upgrade npm to a staging-capable version
+        # OIDC trusted publishing needs npm >= 11.5.1; `npm stage` needs >= 11.15.0.
+        # Node 22 ships npm 10.x, so upgrade explicitly.
+        run: |
+          npm install -g npm@^11.15.0
+          echo "npm $(npm --version)"
+
+      - uses: oven-sh/setup-bun@735343b667d3e6f658f44d0eca948eb6282f2b76 # v2
+        with:
+          bun-version: "1.3.10"
+
+      - uses: socketdev/action@ba6de6cc0565af1f42295590380973573297e31f # v1.3.2
+        with:
+          mode: firewall-free
+
+      - name: Install
+        run: sfw bun install --frozen-lockfile
+
+      - name: Verify versions and tag
+        # All values flow through env, never ${{ }} interpolation inside the
+        # script body — keeps a crafted `version` input out of the shell.
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          set -euo pipefail
+          if ! [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9.]+)?$ ]]; then
+            echo "::error::Invalid version '$VERSION'. Expected semver (e.g. 0.11.0 or 1.0.0-rc.1)."
+            exit 1
+          fi
+          PKG_JSONS=(
+            package.json
+            packages/flair-client/package.json
+            packages/flair-mcp/package.json
+            packages/openclaw-flair/package.json
+            packages/pi-flair/package.json
+            packages/n8n-nodes-flair/package.json
+            packages/langgraph-flair/package.json
+          )
+          for pj in "${PKG_JSONS[@]}"; do
+            name="$(node -p "require('./$pj').name")"
+            pv="$(node -p "require('./$pj').version")"
+            if [ "$pv" != "$VERSION" ]; then
+              echo "::error::$name is at $pv, expected $VERSION. Has the release PR been merged?"
+              exit 1
+            fi
+            echo "  ok $name @ $pv"
+          done
+          if git rev-parse "v$VERSION" >/dev/null 2>&1; then
+            echo "::error::Tag v$VERSION already exists. Did this version already ship?"
+            exit 1
+          fi
+
+      - name: Build
+        run: |
+          set -euo pipefail
+          npm run build && npm run build:cli
+          (cd packages/flair-client && npm run build)
+          (cd packages/flair-mcp && npm run build)
+          (cd packages/n8n-nodes-flair && npm run build)
+
+      - name: Stage-publish all packages (dependency order)
+        # flair-client first — the other packages depend on it. Staging does not
+        # resolve dependencies (that happens at install, post-approval), but we
+        # keep dep order so the approve-and-go-live sequence is consistent.
+        run: |
+          set -euo pipefail
+          DIRS=(
+            packages/flair-client
+            packages/flair-mcp
+            .
+            packages/openclaw-flair
+            packages/pi-flair
+            packages/n8n-nodes-flair
+            packages/langgraph-flair
+          )
+          for dir in "${DIRS[@]}"; do
+            name="$(node -p "require('./$dir/package.json').name")"
+            echo "::group::npm stage publish — $name ($dir)"
+            ( cd "$dir" && npm stage publish )
+            echo "::endgroup::"
+          done
+
+      - name: Tag release
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          set -euo pipefail
+          git config user.name "tps-flint"
+          git config user.email "263629284+tps-flint@users.noreply.github.com"
+          git tag -a "v$VERSION" -m "Release v$VERSION"
+          git push origin "v$VERSION"
+
+      - name: Summary
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          {
+            echo "### 🚀 v$VERSION staged for release"
+            echo ""
+            echo "All 7 workspace packages submitted to npm **staging** with provenance."
+            echo "They are **not live yet**."
+            echo ""
+            echo "**To release:** open [npmjs.com → Staged Packages](https://www.npmjs.com/settings/tpsdev-ai/staging),"
+            echo "review each tarball, and approve with 2FA. Or: \`npm stage list\` then \`npm stage approve <id>\`."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -85,15 +85,27 @@ Full contract in [docs/bridges.md](docs/bridges.md) and the spec at [specs/FLAIR
 
 ## Releases
 
-Releases are two-phase and driven by `scripts/release.sh`:
+Releases are two-phase. **Phase 1** opens the version-bump PR; **phase 2** stages every
+package to npm from CI — no local npm login. Full runbook: [docs/releasing.md](docs/releasing.md).
 
 ```bash
-./scripts/release.sh 0.7.0           # Phase 1: bumps, builds, opens release PR
+# Phase 1 — open the release PR (bumps every workspace package, builds, tests)
+./scripts/release.sh 0.7.0
 # ... review and merge the PR on GitHub ...
-./scripts/release.sh 0.7.0 --publish  # Phase 2: publishes to npm, tags, pushes tag
+
+# Phase 2 — stage-publish via CI (OIDC trusted publishing, no token)
+gh workflow run release-publish.yml -f version=0.7.0
 ```
 
-Update `CHANGELOG.md` to promote `## Unreleased` to the new version before running phase 2.
+Phase 2 runs the [`release-publish`](.github/workflows/release-publish.yml) workflow: it
+authenticates to npm with a short-lived **OIDC** token (no stored `NPM_TOKEN`), builds, and
+submits all packages to npm **staging** with provenance. They are **not live** until a
+maintainer reviews the staged tarballs and **approves them on npmjs.com with 2FA** — that
+approval is the release gate.
+
+Update `CHANGELOG.md` to promote `## Unreleased` to the new version before phase 1. The
+legacy `./scripts/release.sh 0.7.0 --publish` direct-publish path remains as a break-glass
+fallback for when CI is unavailable.
 
 ## Questions
 

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -1,0 +1,122 @@
+# Releasing Flair
+
+Flair publishes seven workspace packages to npm under `@tpsdev-ai/*`. Releases are
+**tokenless** and **staged**: CI authenticates to npm with a short-lived OIDC token
+(no `NPM_TOKEN` lives anywhere) and submits each package to npm's **staging** area.
+A maintainer then approves the staged tarballs on npmjs.com with 2FA to make them live.
+
+```
+ merge release PR ──▶ gh workflow run release-publish.yml ──▶ npm staging
+                                                                  │
+                                          maintainer reviews + approves (2FA)
+                                                                  ▼
+                                                              live on npm
+```
+
+This replaces the old "run `release.sh --publish` from a laptop logged into npm" flow.
+Nothing publishes without a human 2FA approval, and every package ships with a
+provenance attestation (public repo → verifiable build origin).
+
+## Cutting a release
+
+### Phase 1 — open the release PR
+
+```bash
+# promote ## Unreleased to the new version in CHANGELOG.md first, then:
+./scripts/release.sh 0.11.0
+```
+
+This bumps every workspace package to the version, aligns internal deps, refreshes
+`bun.lock`, builds, tests, and opens a `release: v0.11.0` PR. Review and merge it
+(CI green + K&S approval) the same as any other PR.
+
+### Phase 2 — stage-publish from CI
+
+After the release PR is merged to `main`:
+
+```bash
+gh-as flint workflow run release-publish.yml -f version=0.11.0
+```
+
+The [`release-publish`](../.github/workflows/release-publish.yml) workflow:
+
+1. Checks out `main`, verifies all 7 `package.json` files are at the requested version
+   and that tag `vX.Y.Z` does not already exist.
+2. Builds every package.
+3. Runs `npm stage publish` for each package in dependency order (flair-client first).
+4. Tags `vX.Y.Z` and pushes the tag.
+
+It authenticates via OIDC — no secrets. Watch the run; when it's green, the packages
+are staged but **not yet live**.
+
+### Phase 3 — approve the staged packages
+
+Go to **[npmjs.com → tpsdev-ai → Staged Packages](https://www.npmjs.com/settings/tpsdev-ai/staging)**,
+review each staged tarball, and approve with 2FA. Or from a machine logged into npm:
+
+```bash
+npm stage list            # show staged packages + their stage-ids
+npm stage view <stage-id> # inspect one
+npm stage approve <stage-id>   # 2FA prompt; package goes live
+```
+
+There are seven packages, so there are seven approvals (the web UI lists them on one
+page). Approve in dependency order if installing immediately — flair-client before its
+dependents — though staging does not itself resolve dependencies.
+
+Verify when done:
+
+```bash
+npm view @tpsdev-ai/flair version   # should report the new version
+```
+
+## One-time setup
+
+These are configured once and reused for every release.
+
+### npm trusted publisher (per package)
+
+For **each** of the seven packages, on npmjs.com → the package → **Settings → Trusted
+Publisher → Add**:
+
+| Field         | Value                  |
+| ------------- | ---------------------- |
+| Provider      | GitHub Actions         |
+| Organization  | `tpsdev-ai`            |
+| Repository    | `flair`                |
+| Workflow      | `release-publish.yml`  |
+| Environment   | `release`              |
+
+Packages: `flair-client`, `flair-mcp`, `flair`, `openclaw-flair`, `pi-flair`,
+`n8n-nodes-flair`, `langgraph-flair`.
+
+> A package must already exist on npm before a trusted publisher can be added — all
+> seven already do. This account-level config can only be done by an npm org owner.
+
+### GitHub `release` environment
+
+A repository environment named `release` scopes the OIDC trust and restricts the
+workflow to `main`. It has **no required reviewers** — the human gate is the npm
+staging approval, not a GitHub deployment review. (Settings → Environments → `release`,
+deployment branch policy: `main` only.)
+
+### Approver 2FA
+
+The maintainer who approves staged packages must have 2FA enabled on their npm account.
+
+## If something goes wrong
+
+- **A staged package looks wrong** — reject it on npmjs.com instead of approving; it
+  never goes live. Fix forward on `main` and re-run phase 2 with a new patch version.
+- **The workflow tagged `vX.Y.Z` but you rejected the stage** — delete the tag
+  (`git push origin :vX.Y.Z`) before re-cutting, or the version-exists guard will block
+  the re-run.
+- **Break-glass (CI down):** `./scripts/release.sh X.Y.Z --publish` still works from a
+  machine logged into npm. Prefer the staged flow; this bypasses the staging gate.
+
+## Requirements
+
+- npm CLI **≥ 11.15.0** (`npm stage`) and **≥ 11.5.1** (OIDC) — the workflow upgrades
+  npm itself; local approvers need a recent npm.
+- Node **≥ 22.14**.
+- Trusted publishing runs on GitHub-hosted runners only (no self-hosted support yet).


### PR DESCRIPTION
## What

Moves the flair npm publish step off a laptop npm login. New `workflow_dispatch` pipeline that:
- authenticates to npm via **OIDC trusted publishing** — no stored `NPM_TOKEN`, short-lived per-run token
- submits all 7 workspace packages to npm **staging** (`npm stage publish`) instead of publishing live
- ships every package with a **provenance attestation** (public repo)

A maintainer then approves the staged tarballs on npmjs.com **with 2FA** to go live. That approval is the release gate — nothing publishes without a human 2FA step.

## Why

Today `release.sh --publish` runs `npm publish` from Nathan's laptop (the only machine logged into npm). This removes that dependency and is a net **security upgrade**: no long-lived token to leak, cryptographic provenance, and the human gate moves onto npm tied to the approver's 2FA.

## Files
- `.github/workflows/release-publish.yml` — the pipeline (dispatch, version input)
- `docs/releasing.md` — full runbook (cut a release, one-time setup, rejection/rollback, break-glass)
- `CONTRIBUTING.md` — Releases section updated for the staged flow

`release.sh --publish` is **kept** as a documented break-glass fallback. All 7 `package.json` `repository` fields already point at this repo, so no package edits were needed for provenance.

## Flow
```
merge release PR -> gh workflow run release-publish.yml -f version=X.Y.Z -> npm staging
                                                  maintainer approves (2FA) -> live
```

## Security notes for review
- **No interpolation in shell:** the `version` input flows through `env:` and is referenced as `$VERSION` — never `${{ inputs.version }}` inside a `run:` body (avoids shell injection from a crafted dispatch input). It is still validated against a semver regex.
- **Least privilege:** top-level `permissions: contents: read`; the publish job opts into `id-token: write` (OIDC) + `contents: write` (tag push) only.
- **Pinned actions:** all actions pinned by full SHA (reused from `test.yml`). Socket firewall wraps install.
- **OIDC scoping via `environment: release`:** restricts the trust to a named environment + `main` only, so a pushed branch cannot assume the publish identity. **Decision point for K&S:** this adds a one-time repo-admin step (create the env). If you would rather not, I can drop the environment and pin trust to org+repo+workflow only — slightly weaker scoping, simpler setup. I lean keep.

## One-time setup (NOT in this PR — needs repo admin + npm org owner)
1. Create a `release` GitHub environment, deployment branch policy = `main`, **no** reviewers (the flint PAT cannot — 403).
2. Add a trusted publisher to each of the 7 packages on npmjs.com (org `tpsdev-ai`, repo `flair`, workflow `release-publish.yml`, environment `release`).
3. 2FA enabled on the approver's npm account.

Details + table in `docs/releasing.md`.

## Rollout plan
`npm stage` is new (npm 11.15.0). Before trusting all 7 packages to it, I will **dry-run the stage step against flair-client only** end-to-end (stage -> inspect -> reject) once the env + one trusted publisher are configured, to shake out any quirk. 0.11.0 is parked to be the first real run through this pipe.
