### PR TITLE
ci(release): trigger stage-publish on tag push instead of workflow_dispatch

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -1,22 +1,28 @@
 name: Release — stage-publish (OIDC)
 
-# Tokenless release pipeline. Authenticates to npm via OIDC trusted publishing
-# (no NPM_TOKEN stored anywhere) and submits every workspace package to npm's
-# STAGING area via `npm stage publish` rather than publishing live. A maintainer
-# then reviews the staged tarballs and approves them on npmjs.com with 2FA to go
-# live — that approval is the release gate (see docs/releasing.md).
+# Tokenless release pipeline, triggered by pushing a vX.Y.Z tag. Authenticates to
+# npm via OIDC trusted publishing (no NPM_TOKEN lives anywhere) and submits every
+# workspace package to npm's STAGING area via `npm stage publish` rather than
+# publishing live. A maintainer approves the staged tarballs on npmjs.com with 2FA
+# to go live — that approval is the release gate (see docs/releasing.md).
 #
-# Trigger: manual, after the `release: vX.Y.Z` PR is merged to main.
-#   gh-as flint workflow run release-publish.yml -f version=0.11.0
+# Cut a release: after the `release: vX.Y.Z` PR merges to main, push the tag:
+#   git tag v0.11.0 && git push origin v0.11.0
+# The tag push triggers this workflow. (workflow_dispatch is a manual fallback.)
 #
 # One-time setup (npmjs.com, per package): add a Trusted Publisher pointing at
 #   org=tpsdev-ai, repo=flair, workflow=release-publish.yml, environment=release
+# and allow ONLY "npm stage publish". The `release` GitHub environment must permit
+# `v*` tag deploys.
 
 on:
+  push:
+    tags:
+      - "v*"
   workflow_dispatch:
     inputs:
       version:
-        description: "Version to stage (must already be merged to main, e.g. 0.11.0)"
+        description: "Fallback only: version to stage (a vX.Y.Z tag must already exist on a merged commit)"
         required: true
         type: string
 
@@ -33,17 +39,49 @@ jobs:
     name: Stage-publish all packages
     runs-on: ubuntu-latest
     # `release` is an OIDC-scoping environment, NOT an approval gate: it pins the
-    # trusted-publisher trust to this environment and restricts deploys to main.
-    # The human gate is the npm staging approval (2FA), not a GitHub reviewer.
+    # trusted-publisher trust to this environment. The human gate is the npm
+    # staging approval (2FA), not a GitHub reviewer.
     environment: release
     permissions:
       id-token: write   # mint the short-lived OIDC token for npm trusted publishing
-      contents: write   # push the release tag
+      contents: read    # checkout + fetch main for the ancestry guard
     steps:
+      - name: Resolve version
+        id: ver
+        env:
+          EVENT: ${{ github.event_name }}
+          REF_NAME: ${{ github.ref_name }}
+          INPUT_VERSION: ${{ inputs.version }}
+        run: |
+          set -euo pipefail
+          if [ "$EVENT" = "workflow_dispatch" ]; then
+            VERSION="$INPUT_VERSION"
+          else
+            # tag push: github.ref_name is the tag (vX.Y.Z)
+            VERSION="${REF_NAME#v}"
+          fi
+          if ! [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9.]+)?$ ]]; then
+            echo "::error::Invalid version '$VERSION'. Expected semver (e.g. 0.11.0 or 1.0.0-rc.1)."
+            exit 1
+          fi
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Resolved version: $VERSION"
+
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
-          ref: main
           fetch-depth: 0
+
+      - name: Verify tagged commit is on main
+        # A tag can point at any commit; require it to be merged to main so a tag
+        # can never ship un-reviewed code past the npm staging gate.
+        run: |
+          set -euo pipefail
+          git fetch --no-tags origin main
+          if ! git merge-base --is-ancestor "$GITHUB_SHA" origin/main; then
+            echo "::error::Commit ${GITHUB_SHA} is not an ancestor of origin/main. Tag a merged release commit."
+            exit 1
+          fi
+          echo "  ok ${GITHUB_SHA} is on main"
 
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
@@ -68,17 +106,13 @@ jobs:
       - name: Install
         run: sfw bun install --frozen-lockfile
 
-      - name: Verify versions and tag
+      - name: Verify all workspace versions match the tag
         # All values flow through env, never ${{ }} interpolation inside the
-        # script body — keeps a crafted `version` input out of the shell.
+        # script body — keeps the resolved version out of the shell parser.
         env:
-          VERSION: ${{ inputs.version }}
+          VERSION: ${{ steps.ver.outputs.version }}
         run: |
           set -euo pipefail
-          if ! [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9.]+)?$ ]]; then
-            echo "::error::Invalid version '$VERSION'. Expected semver (e.g. 0.11.0 or 1.0.0-rc.1)."
-            exit 1
-          fi
           PKG_JSONS=(
             package.json
             packages/flair-client/package.json
@@ -92,15 +126,11 @@ jobs:
             name="$(node -p "require('./$pj').name")"
             pv="$(node -p "require('./$pj').version")"
             if [ "$pv" != "$VERSION" ]; then
-              echo "::error::$name is at $pv, expected $VERSION. Has the release PR been merged?"
+              echo "::error::$name is at $pv, expected $VERSION (tag v$VERSION). Tag a merged release commit."
               exit 1
             fi
             echo "  ok $name @ $pv"
           done
-          if git rev-parse "v$VERSION" >/dev/null 2>&1; then
-            echo "::error::Tag v$VERSION already exists. Did this version already ship?"
-            exit 1
-          fi
 
       - name: Build
         run: |
@@ -132,19 +162,9 @@ jobs:
             echo "::endgroup::"
           done
 
-      - name: Tag release
-        env:
-          VERSION: ${{ inputs.version }}
-        run: |
-          set -euo pipefail
-          git config user.name "tps-flint"
-          git config user.email "263629284+tps-flint@users.noreply.github.com"
-          git tag -a "v$VERSION" -m "Release v$VERSION"
-          git push origin "v$VERSION"
-
       - name: Summary
         env:
-          VERSION: ${{ inputs.version }}
+          VERSION: ${{ steps.ver.outputs.version }}
         run: |
           {
             echo "### 🚀 v$VERSION staged for release"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -93,15 +93,17 @@ package to npm from CI — no local npm login. Full runbook: [docs/releasing.md]
 ./scripts/release.sh 0.7.0
 # ... review and merge the PR on GitHub ...
 
-# Phase 2 — stage-publish via CI (OIDC trusted publishing, no token)
-gh workflow run release-publish.yml -f version=0.7.0
+# Phase 2 — tag the merged release; the tag push triggers the stage-publish CI
+git checkout main && git pull
+git tag v0.7.0 && git push origin v0.7.0
 ```
 
-Phase 2 runs the [`release-publish`](.github/workflows/release-publish.yml) workflow: it
-authenticates to npm with a short-lived **OIDC** token (no stored `NPM_TOKEN`), builds, and
-submits all packages to npm **staging** with provenance. They are **not live** until a
-maintainer reviews the staged tarballs and **approves them on npmjs.com with 2FA** — that
-approval is the release gate.
+Pushing the `vX.Y.Z` tag triggers the [`release-publish`](.github/workflows/release-publish.yml)
+workflow: it authenticates to npm with a short-lived **OIDC** token (no stored `NPM_TOKEN`),
+builds, and submits all packages to npm **staging** with provenance. They are **not live**
+until a maintainer reviews the staged tarballs and **approves them on npmjs.com with 2FA** —
+that approval is the release gate. Tagging needs only repo push access (no npm creds, no
+`Actions: write`).
 
 Update `CHANGELOG.md` to promote `## Unreleased` to the new version before phase 1. The
 legacy `./scripts/release.sh 0.7.0 --publish` direct-publish path remains as a break-glass

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -6,16 +6,19 @@ Flair publishes seven workspace packages to npm under `@tpsdev-ai/*`. Releases a
 A maintainer then approves the staged tarballs on npmjs.com with 2FA to make them live.
 
 ```
- merge release PR ──▶ gh workflow run release-publish.yml ──▶ npm staging
-                                                                  │
-                                          maintainer reviews + approves (2FA)
-                                                                  ▼
-                                                              live on npm
+ merge release PR ──▶ push tag v0.11.0 ──▶ CI stages all packages ──▶ npm staging
+                                                                          │
+                                                  maintainer reviews + approves (2FA)
+                                                                          ▼
+                                                                      live on npm
 ```
 
-This replaces the old "run `release.sh --publish` from a laptop logged into npm" flow.
-Nothing publishes without a human 2FA approval, and every package ships with a
-provenance attestation (public repo → verifiable build origin).
+Pushing a `vX.Y.Z` tag triggers the release. This replaces the old "run
+`release.sh --publish` from a laptop logged into npm" flow. Nothing publishes without
+a human 2FA approval, and every package ships with a provenance attestation (public
+repo → verifiable build origin). The person who tags the release does **not** need npm
+credentials or `Actions: write` — only repo push access; the only privileged step is
+the maintainer's 2FA approval.
 
 ## Cutting a release
 
@@ -30,24 +33,30 @@ This bumps every workspace package to the version, aligns internal deps, refresh
 `bun.lock`, builds, tests, and opens a `release: v0.11.0` PR. Review and merge it
 (CI green + K&S approval) the same as any other PR.
 
-### Phase 2 — stage-publish from CI
+### Phase 2 — tag the release
 
-After the release PR is merged to `main`:
+After the release PR is merged to `main`, push the version tag:
 
 ```bash
-gh-as flint workflow run release-publish.yml -f version=0.11.0
+git checkout main && git pull
+git tag v0.11.0 && git push origin v0.11.0
 ```
 
-The [`release-publish`](../.github/workflows/release-publish.yml) workflow:
+The tag push triggers the [`release-publish`](../.github/workflows/release-publish.yml)
+workflow, which:
 
-1. Checks out `main`, verifies all 7 `package.json` files are at the requested version
-   and that tag `vX.Y.Z` does not already exist.
-2. Builds every package.
-3. Runs `npm stage publish` for each package in dependency order (flair-client first).
-4. Tags `vX.Y.Z` and pushes the tag.
+1. Resolves the version from the tag and validates it as semver.
+2. Verifies the tagged commit is an ancestor of `main` (a tag can't ship un-merged code).
+3. Verifies all 7 `package.json` files are at that version.
+4. Builds every package.
+5. Runs `npm stage publish` for each package in dependency order (flair-client first).
 
-It authenticates via OIDC — no secrets. Watch the run; when it's green, the packages
-are staged but **not yet live**.
+It authenticates via OIDC — no secrets, and it does **not** create or move any tag (the
+tag you pushed is the trigger). Watch the run; when it's green, the packages are staged
+but **not yet live**.
+
+> `workflow_dispatch` with a `version` input remains as a manual fallback (needs
+> `Actions: write`), but the tag push is the normal path.
 
 ### Phase 3 — approve the staged packages
 
@@ -79,13 +88,18 @@ These are configured once and reused for every release.
 For **each** of the seven packages, on npmjs.com → the package → **Settings → Trusted
 Publisher → Add**:
 
-| Field         | Value                  |
-| ------------- | ---------------------- |
-| Provider      | GitHub Actions         |
-| Organization  | `tpsdev-ai`            |
-| Repository    | `flair`                |
-| Workflow      | `release-publish.yml`  |
-| Environment   | `release`              |
+| Field           | Value                       |
+| --------------- | --------------------------- |
+| Provider        | GitHub Actions              |
+| Organization    | `tpsdev-ai`                 |
+| Repository      | `flair`                     |
+| Workflow        | `release-publish.yml`       |
+| Environment     | `release`                   |
+| Allowed actions | **`npm stage publish` only** |
+
+Leave `npm publish` **unchecked** under allowed actions. This structurally prevents the
+CI/OIDC identity from publishing anything live directly — the only path to live is the
+human 2FA approval of a staged package.
 
 Packages: `flair-client`, `flair-mcp`, `flair`, `openclaw-flair`, `pi-flair`,
 `n8n-nodes-flair`, `langgraph-flair`.
@@ -95,10 +109,11 @@ Packages: `flair-client`, `flair-mcp`, `flair`, `openclaw-flair`, `pi-flair`,
 
 ### GitHub `release` environment
 
-A repository environment named `release` scopes the OIDC trust and restricts the
-workflow to `main`. It has **no required reviewers** — the human gate is the npm
-staging approval, not a GitHub deployment review. (Settings → Environments → `release`,
-deployment branch policy: `main` only.)
+A repository environment named `release` scopes the OIDC trust. It has **no required
+reviewers** — the human gate is the npm staging approval, not a GitHub deployment
+review. Because the release is triggered by a tag push, its deployment policy must allow
+**`v*` tags** (Settings → Environments → `release` → Deployment branches and tags →
+Selected branches and tags → add tag rule `v*`).
 
 ### Approver 2FA
 
@@ -107,10 +122,10 @@ The maintainer who approves staged packages must have 2FA enabled on their npm a
 ## If something goes wrong
 
 - **A staged package looks wrong** — reject it on npmjs.com instead of approving; it
-  never goes live. Fix forward on `main` and re-run phase 2 with a new patch version.
-- **The workflow tagged `vX.Y.Z` but you rejected the stage** — delete the tag
-  (`git push origin :vX.Y.Z`) before re-cutting, or the version-exists guard will block
-  the re-run.
+  never goes live. Fix forward on `main` and cut a new patch version.
+- **Re-run the stage for the same version** — delete and re-push the tag
+  (`git push origin :v0.11.0` then `git tag -f v0.11.0 && git push origin v0.11.0`).
+  The tag push re-triggers the workflow.
 - **Break-glass (CI down):** `./scripts/release.sh X.Y.Z --publish` still works from a
   machine logged into npm. Prefer the staged flow; this bypasses the staging gate.
 


### PR DESCRIPTION
## What

Switches the release pipeline trigger from the manual `workflow_dispatch` button to **`on: push: tags: ['v*']`**. Pushing a `vX.Y.Z` tag now triggers the staged-publish run.

## Why

The flint automation token has repo push access but **not** `Actions: write`, so it can't trigger a `workflow_dispatch` — that left the run as a button a human had to click. Tag-push needs only push access. Result: the release is fully creatable by automation (push the tag), and the **only** privileged human step is the maintainer's 2FA approval of the staged packages — which is exactly the intended gate.

## Flow

```
merge release PR -> git push origin v0.11.0 -> CI stages all 7 -> npm staging -> maintainer 2FA approve -> live
```

## Changes
- **Trigger:** `push: tags: ['v*']` (+ `workflow_dispatch` kept as a manual fallback).
- **Version source:** resolved from the tag ref (`github.ref_name`), still semver-validated.
- **New guard:** the tagged commit must be an ancestor of `origin/main` — a tag can't ship un-merged/un-reviewed code past the staging gate.
- **Removed:** the in-workflow tag-creation step (the pushed tag *is* the trigger) and the now-unneeded `contents: write`. Job runs with `id-token: write` + `contents: read`.
- **Docs:** `docs/releasing.md` + `CONTRIBUTING.md` updated for the tag flow; documents the `release` environment needing `v*` tag deploys and the trusted-publisher "stage publish only" allowed-action.

## Security notes for review
- Version still flows through `env:`, never `${{ }}` interpolation inside `run:` bodies.
- The ancestry guard (`git merge-base --is-ancestor`) replaces the previous `environment: main`-branch restriction, since tag-triggered runs have ref `refs/tags/v*`. The `release` environment's deployment policy will be set to allow `v*` tags (one-time repo-admin change, documented).
- Trust is still pinned to env `release` + workflow `release-publish.yml`, and the trusted publisher allows only `npm stage publish` — so even a tag pointing at a crafted commit can at most *stage*, never publish live, and only a merged-to-main commit passes the ancestry guard.
- `contents: write` dropped — strictly less privilege than before.

## Follow-up (not in this PR)
Builds on #482. After merge, the `release` environment deployment policy needs a `v*` tag rule added (repo admin). Then 0.11.0 ships by pushing its tag.
