### PR TITLE
fix(release): drop setup-node registry-url so npm uses OIDC (fixes inaugural E401)

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -86,7 +86,11 @@ jobs:
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: "22"
-          registry-url: "https://registry.npmjs.org"
+          # NO registry-url: it makes setup-node write an .npmrc with
+          # _authToken=${NODE_AUTH_TOKEN} + always-auth, and with NODE_AUTH_TOKEN
+          # unset npm tries the EMPTY token and fails E401 instead of falling
+          # through to OIDC trusted publishing. OIDC needs no token config; npm
+          # defaults to registry.npmjs.org.
 
       - name: Upgrade npm to a staging-capable version
         # OIDC trusted publishing needs npm >= 11.5.1; `npm stage` needs >= 11.15.0.


### PR DESCRIPTION
## What

Removes `registry-url` from the `setup-node` step in the release workflow.

## Why — the inaugural v0.11.0 run failed E401

Pushing `v0.11.0` correctly triggered the pipeline; everything passed (ancestry guard, version verify, build) until `npm stage publish`, which failed:

```
npm error code E401
npm error Unable to authenticate, your authentication token seems to be invalid.
```

**Root cause:** `setup-node`'s `registry-url` writes a `~/.npmrc` containing `//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}` plus `always-auth=true`. With `NODE_AUTH_TOKEN` unset (we use OIDC, not a token), npm tries the **empty token** and 401s — it never falls through to OIDC trusted publishing.

Per [npm's trusted-publishing docs](https://docs.npmjs.com/trusted-publishers/), OIDC needs **no** token config: *"setting an empty NODE_AUTH_TOKEN prevents OIDC from working… NODE_AUTH_TOKEN should not be set at all."* Removing `registry-url` means no token `.npmrc` is written; npm defaults to `registry.npmjs.org` and uses the OIDC trusted-publisher flow (which `id-token: write` + npm ≥11.15.0 already enable).

**Nothing was staged** — it failed on the first package (flair-client), so there's no partial state. This was effectively the dry-run we wanted, just triggered for real.

## Verify
- `id-token: write` permission unchanged; npm ≥11.15.0 still installed.
- All 7 trusted publishers are configured (org `tpsdev-ai`, repo `flair`, workflow `release-publish.yml`, env `release`, stage-publish only).

After merge: re-point the `v0.11.0` tag at the new main and push to re-trigger.
