### PR TITLE
auth-middleware: config-driven extra public paths (FLAIR_PUBLIC_PATHS) — composable on a multi-component hub

### DIFF
--- a/resources/auth-middleware.ts
+++ b/resources/auth-middleware.ts
@@ -115,6 +115,17 @@ async function backfillEmbedding(memoryId: string): Promise<void> {
 
 // ─── HTTP middleware ──────────────────────────────────────────────────────────
 
+// Extra public (no-auth) route paths, declared by the deployment via the
+// FLAIR_PUBLIC_PATHS env var (comma-separated). Lets flair compose on a
+// multi-component hub: the hub declares which sibling routes are public
+// (e.g. "/RosterView,/Observatory") instead of flair hardcoding them.
+const EXTRA_PUBLIC_PATHS = new Set(
+  (process.env.FLAIR_PUBLIC_PATHS ?? "")
+    .split(",")
+    .map((p: string) => p.trim())
+    .filter(Boolean),
+);
+
 server.http(async (request: any, nextLayer: any) => {
   const url = new URL(request.url, "http://" + (request.headers.get("host") || "localhost"));
 
@@ -156,7 +167,11 @@ server.http(async (request: any, nextLayer: any) => {
     // Presence roster is public-safe (field-allowlisted); GET serves the
     // Office Space renderer without auth. POST handles Ed25519 auth internally
     // (allowCreate=true on the Resource).
-    url.pathname === "/Presence"
+    url.pathname === "/Presence" ||
+    // Extra public routes declared by the hub deployment (FLAIR_PUBLIC_PATHS),
+    // so sibling components' public surfaces (e.g. the composite hub's roster
+    // /RosterView + observatory /Observatory) aren't gated by flair's middleware.
+    EXTRA_PUBLIC_PATHS.has(url.pathname)
   ) return nextLayer(request);
 
   // If Harper has already authorized this request (e.g. authorizeLocal=true on localhost),


### PR DESCRIPTION
Lets flair compose on a multi-component Harper hub (the composite TPS hub: flair + roster + observatory on one Fabric instance).

## Problem
flair's auth-middleware registers an instance-wide `server.http` hook with a **hardcoded** public-path allow-list. When flair is one component among several on a shared Harper instance, it intercepts and 401s the **sibling** components' public routes. Concretely: deploying flair to tps.dtrt — which already serves a public roster (`/RosterView`) + observatory (`/Observatory`) UI — took those routes from 200 → 401 and broke the public Office Space.

## Fix
Env-driven extra public paths. The middleware reads `FLAIR_PUBLIC_PATHS` (comma-separated) once at module load and treats those exact pathnames as public:

```
FLAIR_PUBLIC_PATHS=/RosterView,/Observatory
```

The **hub deployment** declares its public surface; flair doesn't hardcode knowledge of sibling components. Backward-compatible: env unset → empty set → zero behavior change. Single-instance flair (rockit) is unaffected.

## Review focus
- **Sherlock (security):** this widens the public, no-auth surface by exactly the env-declared exact-match paths. The *operator* controls the env at deploy time; nothing arbitrary can open a route at runtime. Anything risky in letting a deploy-time env declare pre-auth-public routes? (Exact `===` match via a Set — no prefix/wildcard.)
- **Kern (architecture):** module-scope `Set` parse + integration into the existing allow-list. Right approach for a global `server.http` hook (which can't easily read component options), or would you route it through config differently?
