### PR TITLE
Auth-RBAC reshape (foundation): per-agent identity + flair_agent role + resource hardening — gate unchanged

### DIFF
--- a/resources/Agent.ts
+++ b/resources/Agent.ts
@@ -1,5 +1,5 @@
 import { databases } from "@harperfast/harper";
-import { isAdmin } from "./auth-middleware.js";
+import { isAdmin } from "./agent-auth.js";
 
 /**
  * Agent resource — serves as the Principal table in 1.0.

--- a/resources/AgentCard.ts
+++ b/resources/AgentCard.ts
@@ -2,6 +2,13 @@ import { Resource, databases } from "@harperfast/harper";
 import { type SoulLike, selectPublicDescription, selectPublicSkills } from "./agentcard-fields.js";
 
 export class AgentCard extends Resource {
+  // Public discovery metadata (per A2A spec, agent cards are intentionally
+  // public). Self-gates as public so it survives the global gate's removal — and
+  // its get() already returns only field-allowlisted public-safe data.
+  allowRead(): boolean {
+    return true;
+  }
+
   async get(pathInfo?: any) {
     const agentId =
       (typeof pathInfo === "string" ? pathInfo : null) ??

--- a/resources/AgentSeed.ts
+++ b/resources/AgentSeed.ts
@@ -18,7 +18,7 @@
  */
 
 import { Resource, databases } from "@harperfast/harper";
-import { isAdmin } from "./agent-auth.js";
+import { isAdmin, verifyAgentRequest } from "./agent-auth.js";
 
 const DEFAULT_SOUL_KEYS = (agentId: string, displayName: string, role: string, now: string) => ({
   name: displayName,
@@ -36,6 +36,15 @@ const DEFAULT_MEMORIES = (agentId: string, now: string) => [
 ];
 
 export class AgentSeed extends Resource {
+  // Admin-only: permit verified ADMIN agents (Basic-admin is super_user and
+  // bypasses allow*); non-admin agents denied. Real authorization now that the
+  // gate no longer elevates agents to admin.
+  async allowCreate(): Promise<boolean> {
+    const ctx = (this as any).getContext?.();
+    const request = ctx?.request ?? ctx;
+    return (await verifyAgentRequest(request))?.isAdmin === true;
+  }
+
   async post(data: any) {
     const actorId = (this as any).request?.tpsAgent;
     if (!actorId || !(await isAdmin(actorId))) {

--- a/resources/AgentSeed.ts
+++ b/resources/AgentSeed.ts
@@ -18,7 +18,7 @@
  */
 
 import { Resource, databases } from "@harperfast/harper";
-import { isAdmin, verifyAgentRequest } from "./agent-auth.js";
+import { isAdmin, allowAdmin } from "./agent-auth.js";
 
 const DEFAULT_SOUL_KEYS = (agentId: string, displayName: string, role: string, now: string) => ({
   name: displayName,
@@ -40,9 +40,7 @@ export class AgentSeed extends Resource {
   // bypasses allow*); non-admin agents denied. Real authorization now that the
   // gate no longer elevates agents to admin.
   async allowCreate(): Promise<boolean> {
-    const ctx = (this as any).getContext?.();
-    const request = ctx?.request ?? ctx;
-    return (await verifyAgentRequest(request))?.isAdmin === true;
+    return allowAdmin((this as any).getContext?.());
   }
 
   async post(data: any) {

--- a/resources/AgentSeed.ts
+++ b/resources/AgentSeed.ts
@@ -18,7 +18,7 @@
  */
 
 import { Resource, databases } from "@harperfast/harper";
-import { isAdmin } from "./auth-middleware.js";
+import { isAdmin } from "./agent-auth.js";
 
 const DEFAULT_SOUL_KEYS = (agentId: string, displayName: string, role: string, now: string) => ({
   name: displayName,

--- a/resources/Credential.ts
+++ b/resources/Credential.ts
@@ -1,5 +1,5 @@
 import { databases } from "@harperfast/harper";
-import { isAdmin } from "./auth-middleware.js";
+import { isAdmin } from "./agent-auth.js";
 import { checkRateLimit, rateLimitResponse } from "./rate-limiter.js";
 
 /**

--- a/resources/Credential.ts
+++ b/resources/Credential.ts
@@ -16,7 +16,7 @@ import { checkRateLimit, rateLimitResponse } from "./rate-limiter.js";
 export class Credential extends (databases as any).flair.Credential {
 
   async search(query?: any) {
-    const auth = await resolveAgentAuth((this as any).getContext?.()?.request);
+    const auth = await resolveAgentAuth((this as any).getContext?.());
 
     // Anonymous HTTP must NOT read credentials. (Previously `!authAgent` was
     // treated as trusted/unfiltered — which leaked every credential to an
@@ -48,7 +48,7 @@ export class Credential extends (databases as any).flair.Credential {
     const result = await super.get();
     if (!result) return result;
 
-    const auth = await resolveAgentAuth((this as any).getContext?.()?.request);
+    const auth = await resolveAgentAuth((this as any).getContext?.());
 
     // Anonymous HTTP must NOT read a credential (previously it fell through the
     // ownership check and returned the record sans tokenHash — a metadata leak).

--- a/resources/Credential.ts
+++ b/resources/Credential.ts
@@ -1,5 +1,5 @@
 import { databases } from "@harperfast/harper";
-import { isAdmin } from "./agent-auth.js";
+import { resolveAgentAuth } from "./agent-auth.js";
 import { checkRateLimit, rateLimitResponse } from "./rate-limiter.js";
 
 /**
@@ -16,17 +16,24 @@ import { checkRateLimit, rateLimitResponse } from "./rate-limiter.js";
 export class Credential extends (databases as any).flair.Credential {
 
   async search(query?: any) {
-    const ctx = (this as any).getContext?.();
-    const request = ctx?.request ?? ctx;
-    const authAgent: string | undefined = request?.tpsAgent;
-    const isAdminAgent: boolean = request?.tpsAgentIsAdmin ?? false;
+    const auth = await resolveAgentAuth((this as any).getContext?.()?.request);
 
-    if (!authAgent || isAdminAgent) {
+    // Anonymous HTTP must NOT read credentials. (Previously `!authAgent` was
+    // treated as trusted/unfiltered — which leaked every credential to an
+    // unauthenticated caller once the gate stopped rejecting.)
+    if (auth.kind === "anonymous") {
+      return new Response(JSON.stringify({ error: "authentication required" }), {
+        status: 401, headers: { "content-type": "application/json" },
+      });
+    }
+
+    // Trusted internal call or admin agent → unfiltered.
+    if (auth.kind === "internal" || (auth.kind === "agent" && auth.isAdmin)) {
       return super.search(query);
     }
 
-    // Non-admin: scope to own credentials
-    const condition = { attribute: "principalId", comparator: "equals", value: authAgent };
+    // Non-admin agent: scope to own credentials.
+    const condition = { attribute: "principalId", comparator: "equals", value: auth.agentId };
     if (!query?.conditions) {
       return super.search({ conditions: [condition], ...(query || {}) });
     }
@@ -41,13 +48,18 @@ export class Credential extends (databases as any).flair.Credential {
     const result = await super.get();
     if (!result) return result;
 
-    const ctx = (this as any).getContext?.();
-    const request = ctx?.request ?? ctx;
-    const authAgent: string | undefined = request?.tpsAgent;
-    const isAdminAgent: boolean = request?.tpsAgentIsAdmin ?? false;
+    const auth = await resolveAgentAuth((this as any).getContext?.()?.request);
 
-    // Non-admin can only see their own credentials
-    if (authAgent && !isAdminAgent && result.principalId !== authAgent) {
+    // Anonymous HTTP must NOT read a credential (previously it fell through the
+    // ownership check and returned the record sans tokenHash — a metadata leak).
+    if (auth.kind === "anonymous") {
+      return new Response(JSON.stringify({ error: "forbidden" }), {
+        status: 403, headers: { "content-type": "application/json" },
+      });
+    }
+
+    // Non-admin agent can only see their own credentials. (Internal + admin pass.)
+    if (auth.kind === "agent" && !auth.isAdmin && result.principalId !== auth.agentId) {
       return new Response(JSON.stringify({ error: "forbidden" }), {
         status: 403, headers: { "content-type": "application/json" },
       });

--- a/resources/IngestEvents.ts
+++ b/resources/IngestEvents.ts
@@ -88,6 +88,14 @@ function verifyEd25519Signature(
 }
 
 export class IngestEvents extends Resource {
+  // Public POST by design: the handler self-verifies the OFFICE's Ed25519
+  // signature against ObsOffice.publicKey (not an agent identity), so it can't use
+  // agent auth. allowCreate=true lets the request reach post() where that
+  // verification happens — same self-gating pattern as FederationPair/FederationSync.
+  allowCreate(): boolean {
+    return true;
+  }
+
   async post(body: unknown, context?: unknown) {
     const request = (this as any).request;
     const authHeader: string | undefined = request?.headers?.get?.("authorization") ?? request?.headers?.authorization;

--- a/resources/Memory.ts
+++ b/resources/Memory.ts
@@ -1,6 +1,6 @@
 import { databases } from "@harperfast/harper";
 import { patchRecord, withDetachedTxn } from "./table-helpers.js";
-import { isAdmin } from "./auth-middleware.js";
+import { isAdmin } from "./agent-auth.js";
 import { getEmbedding, getModelId } from "./embeddings-provider.js";
 import { scanFields, isStrictMode } from "./content-safety.js";
 import { checkRateLimit, rateLimitResponse } from "./rate-limiter.js";

--- a/resources/Memory.ts
+++ b/resources/Memory.ts
@@ -74,6 +74,19 @@ export class Memory extends (databases as any).flair.Memory {
       if (!rl.allowed) return rateLimitResponse(rl.retryAfterMs!, "write");
     }
 
+    // Create ownership: a non-admin may only write memories it owns. The verified
+    // agentId is context.user.username (the auth gate stamps the per-agent identity
+    // onto request.user, which surfaces here); content.agentId is the body. Closes
+    // the create-spoofing gap. Internal calls (no user) and admins are exempt.
+    {
+      const writer: string | undefined = ctx?.user?.username;
+      if (writer && content?.agentId && content.agentId !== writer && !(await isAdmin(writer))) {
+        return new Response(JSON.stringify({ error: "forbidden: cannot write memory owned by another agent" }), {
+          status: 403, headers: { "Content-Type": "application/json" },
+        });
+      }
+    }
+
     content.durability ||= "standard";
     content.createdAt = new Date().toISOString();
     content.updatedAt = content.createdAt;
@@ -160,6 +173,19 @@ export class Memory extends (databases as any).flair.Memory {
       }
       delete content._reindex;
       return super.put(content);
+    }
+
+    // Create/update ownership (same rule as post): a non-admin may only write
+    // memories it owns. Identity via context.user.username (per-agent), not the
+    // gate's request.tpsAgent annotation. The _reindex admin path above bypasses.
+    {
+      const octx = (this as any).getContext?.();
+      const writer: string | undefined = octx?.user?.username;
+      if (writer && content?.agentId && content.agentId !== writer && !(await isAdmin(writer))) {
+        return new Response(JSON.stringify({ error: "forbidden: cannot write memory owned by another agent" }), {
+          status: 403, headers: { "Content-Type": "application/json" },
+        });
+      }
     }
 
     const now = new Date().toISOString();

--- a/resources/Memory.ts
+++ b/resources/Memory.ts
@@ -81,13 +81,13 @@ export class Memory extends (databases as any).flair.Memory {
       if (!rl.allowed) return rateLimitResponse(rl.retryAfterMs!, "write");
     }
 
-    // Create ownership: a non-admin may only write memories it owns. The verified
-    // agentId is context.user.username (the auth gate stamps the per-agent identity
-    // onto request.user, which surfaces here); content.agentId is the body. Closes
-    // the create-spoofing gap. Internal calls (no user) and admins are exempt.
+    // Create ownership: a non-admin agent may only write memories it owns. Use
+    // resolveAgentAuth (reads the gate's tpsAgent annotation) — NOT context.user
+    // .username, which is the fallback "admin" super_user while de-elevation is
+    // dormant and would wrongly 403 every agent's own write. internal/admin → pass.
     {
-      const writer: string | undefined = ctx?.user?.username;
-      if (writer && content?.agentId && content.agentId !== writer && !(await isAdmin(writer))) {
+      const auth = await resolveAgentAuth(ctx);
+      if (auth.kind === "agent" && !auth.isAdmin && content?.agentId && content.agentId !== auth.agentId) {
         return new Response(JSON.stringify({ error: "forbidden: cannot write memory owned by another agent" }), {
           status: 403, headers: { "Content-Type": "application/json" },
         });
@@ -182,13 +182,14 @@ export class Memory extends (databases as any).flair.Memory {
       return super.put(content);
     }
 
-    // Create/update ownership (same rule as post): a non-admin may only write
-    // memories it owns. Identity via context.user.username (per-agent), not the
-    // gate's request.tpsAgent annotation. The _reindex admin path above bypasses.
+    // Create/update ownership (same rule as post): a non-admin agent may only
+    // write memories it owns, via resolveAgentAuth (gate annotation), not
+    // context.user.username (the dormant-de-elevation fallback is "admin").
+    // The _reindex admin path above bypasses this.
     {
       const octx = (this as any).getContext?.();
-      const writer: string | undefined = octx?.user?.username;
-      if (writer && content?.agentId && content.agentId !== writer && !(await isAdmin(writer))) {
+      const auth = await resolveAgentAuth(octx);
+      if (auth.kind === "agent" && !auth.isAdmin && content?.agentId && content.agentId !== auth.agentId) {
         return new Response(JSON.stringify({ error: "forbidden: cannot write memory owned by another agent" }), {
           status: 403, headers: { "Content-Type": "application/json" },
         });

--- a/resources/Memory.ts
+++ b/resources/Memory.ts
@@ -1,6 +1,6 @@
 import { databases } from "@harperfast/harper";
 import { patchRecord, withDetachedTxn } from "./table-helpers.js";
-import { isAdmin } from "./agent-auth.js";
+import { isAdmin, resolveAgentAuth } from "./agent-auth.js";
 import { getEmbedding, getModelId } from "./embeddings-provider.js";
 import { scanFields, isStrictMode } from "./content-safety.js";
 import { checkRateLimit, rateLimitResponse } from "./rate-limiter.js";
@@ -17,18 +17,25 @@ export class Memory extends (databases as any).flair.Memory {
    * Non-admin calls also check MemoryGrant to include granted memories.
    */
   async search(query?: any) {
-    // Access request context via Harper's Resource instance context
+    // Access request context via Harper's Resource instance context.
     const ctx = (this as any).getContext?.();
-    const request = ctx?.request ?? ctx;
-    const authAgent: string | undefined = request?.tpsAgent;
-    const isAdminAgent: boolean = request?.tpsAgentIsAdmin ?? false;
+    const auth = await resolveAgentAuth(ctx?.request);
 
-    // No auth context (internal admin call) or admin agent — unfiltered
-    if (!authAgent || isAdminAgent) {
+    // Anonymous HTTP must NOT read memories. (Previously `!authAgent` was treated
+    // as unfiltered — the anonymous-read leak once the gate stops rejecting.)
+    if (auth.kind === "anonymous") {
+      return new Response(JSON.stringify({ error: "authentication required" }), {
+        status: 401, headers: { "content-type": "application/json" },
+      });
+    }
+
+    // Trusted internal call (no request context) or admin agent — unfiltered.
+    if (auth.kind === "internal" || (auth.kind === "agent" && auth.isAdmin)) {
       return super.search(query);
     }
 
-    // Collect agentIds this agent may read: own + any granted owners
+    // Non-admin agent: scope to own + granted owners.
+    const authAgent = auth.agentId;
     const allowedOwners: string[] = [authAgent];
     try {
       for await (const grant of (databases as any).flair.MemoryGrant.search({

--- a/resources/Memory.ts
+++ b/resources/Memory.ts
@@ -19,7 +19,7 @@ export class Memory extends (databases as any).flair.Memory {
   async search(query?: any) {
     // Access request context via Harper's Resource instance context.
     const ctx = (this as any).getContext?.();
-    const auth = await resolveAgentAuth(ctx?.request);
+    const auth = await resolveAgentAuth(ctx);
 
     // Anonymous HTTP must NOT read memories. (Previously `!authAgent` was treated
     // as unfiltered — the anonymous-read leak once the gate stops rejecting.)

--- a/resources/MemoryBootstrap.ts
+++ b/resources/MemoryBootstrap.ts
@@ -1,4 +1,5 @@
 import { Resource, databases } from "@harperfast/harper";
+import { verifyAgentRequest } from "./agent-auth.js";
 import { getEmbedding } from "./embeddings-provider.js";
 import { wrapUntrusted } from "./content-safety.js";
 
@@ -45,6 +46,16 @@ function formatMemory(m: any, supersedes?: boolean): string {
 }
 
 export class BootstrapMemories extends Resource {
+  // Self-authorize via the Ed25519 agent verify (the auth reshape removes the
+  // gate's admin super_user elevation, so custom resources must self-gate or
+  // Harper denies them for the least-privilege flair_agent role). Any verified
+  // agent may bootstrap; per-agent scoping is enforced in post() below.
+  async allowCreate(): Promise<boolean> {
+    const ctx = (this as any).getContext?.();
+    const request = ctx?.request ?? ctx;
+    return !!(await verifyAgentRequest(request));
+  }
+
   async post(data: any, _context?: any) {
     const {
       agentId: bodyAgentId,

--- a/resources/MemoryBootstrap.ts
+++ b/resources/MemoryBootstrap.ts
@@ -1,5 +1,5 @@
 import { Resource, databases } from "@harperfast/harper";
-import { verifyAgentRequest } from "./agent-auth.js";
+import { allowVerified } from "./agent-auth.js";
 import { getEmbedding } from "./embeddings-provider.js";
 import { wrapUntrusted } from "./content-safety.js";
 
@@ -51,9 +51,7 @@ export class BootstrapMemories extends Resource {
   // Harper denies them for the least-privilege flair_agent role). Any verified
   // agent may bootstrap; per-agent scoping is enforced in post() below.
   async allowCreate(): Promise<boolean> {
-    const ctx = (this as any).getContext?.();
-    const request = ctx?.request ?? ctx;
-    return !!(await verifyAgentRequest(request));
+    return allowVerified((this as any).getContext?.());
   }
 
   async post(data: any, _context?: any) {

--- a/resources/MemoryConsolidate.ts
+++ b/resources/MemoryConsolidate.ts
@@ -17,7 +17,7 @@
  */
 
 import { Resource, databases } from "@harperfast/harper";
-import { isAdmin } from "./auth-middleware.js";
+import { isAdmin } from "./agent-auth.js";
 
 function parseDuration(s: string): number {
   const m = s.match(/^(\d+)([dhm])$/);

--- a/resources/MemoryConsolidate.ts
+++ b/resources/MemoryConsolidate.ts
@@ -17,7 +17,7 @@
  */
 
 import { Resource, databases } from "@harperfast/harper";
-import { isAdmin, verifyAgentRequest } from "./agent-auth.js";
+import { isAdmin, allowVerified } from "./agent-auth.js";
 
 function parseDuration(s: string): number {
   const m = s.match(/^(\d+)([dhm])$/);
@@ -73,9 +73,7 @@ export class ConsolidateMemories extends Resource {
   // admin elevation). Any verified agent may consolidate; the isAdmin checks in
   // post() handle finer-grained authorization.
   async allowCreate(): Promise<boolean> {
-    const ctx = (this as any).getContext?.();
-    const request = ctx?.request ?? ctx;
-    return !!(await verifyAgentRequest(request));
+    return allowVerified((this as any).getContext?.());
   }
 
   async post(data: any) {

--- a/resources/MemoryConsolidate.ts
+++ b/resources/MemoryConsolidate.ts
@@ -17,7 +17,7 @@
  */
 
 import { Resource, databases } from "@harperfast/harper";
-import { isAdmin } from "./agent-auth.js";
+import { isAdmin, verifyAgentRequest } from "./agent-auth.js";
 
 function parseDuration(s: string): number {
   const m = s.match(/^(\d+)([dhm])$/);
@@ -69,6 +69,15 @@ function evaluate(record: any, now: number, olderThanMs: number): Candidate {
 }
 
 export class ConsolidateMemories extends Resource {
+  // Self-authorize via the Ed25519 agent verify (auth reshape removes the gate's
+  // admin elevation). Any verified agent may consolidate; the isAdmin checks in
+  // post() handle finer-grained authorization.
+  async allowCreate(): Promise<boolean> {
+    const ctx = (this as any).getContext?.();
+    const request = ctx?.request ?? ctx;
+    return !!(await verifyAgentRequest(request));
+  }
+
   async post(data: any) {
     const { agentId: bodyAgentId, scope = "persistent", olderThan = "30d", limit = 20 } = data || {};
 

--- a/resources/MemoryFeed.ts
+++ b/resources/MemoryFeed.ts
@@ -1,7 +1,18 @@
 import { Resource, databases } from "@harperfast/harper";
+import { verifyAgentRequest } from "./agent-auth.js";
 import { computeContentHash, findExistingMemoryByContentHash } from "./memory-feed-lib.js";
 
 export class FeedMemories extends Resource {
+  // Self-authorize via the Ed25519 agent verify (the auth reshape removes the
+  // gate's admin elevation). NOTE: post() trusts content.agentId from the body —
+  // closing that create-spoofing gap is tracked with the table-resource
+  // create-ownership work (Memory.allowCreate), not in this auth-coverage pass.
+  async allowCreate(): Promise<boolean> {
+    const ctx = (this as any).getContext?.();
+    const request = ctx?.request ?? ctx;
+    return !!(await verifyAgentRequest(request));
+  }
+
   async post(content: any) {
     const agentId = String(content?.agentId ?? "");
     const body = String(content?.content ?? "");

--- a/resources/MemoryFeed.ts
+++ b/resources/MemoryFeed.ts
@@ -1,5 +1,5 @@
 import { Resource, databases } from "@harperfast/harper";
-import { verifyAgentRequest } from "./agent-auth.js";
+import { allowVerified } from "./agent-auth.js";
 import { computeContentHash, findExistingMemoryByContentHash } from "./memory-feed-lib.js";
 
 export class FeedMemories extends Resource {
@@ -8,9 +8,7 @@ export class FeedMemories extends Resource {
   // closing that create-spoofing gap is tracked with the table-resource
   // create-ownership work (Memory.allowCreate), not in this auth-coverage pass.
   async allowCreate(): Promise<boolean> {
-    const ctx = (this as any).getContext?.();
-    const request = ctx?.request ?? ctx;
-    return !!(await verifyAgentRequest(request));
+    return allowVerified((this as any).getContext?.());
   }
 
   async post(content: any) {

--- a/resources/MemoryMaintenance.ts
+++ b/resources/MemoryMaintenance.ts
@@ -18,7 +18,7 @@
  */
 
 import { Resource, databases } from "@harperfast/harper";
-import { isAdmin } from "./auth-middleware.js";
+import { isAdmin } from "./agent-auth.js";
 
 export class MemoryMaintenance extends Resource {
   /** POST requires auth — either an agent acting on its own memories, or admin. */

--- a/resources/MemoryReflect.ts
+++ b/resources/MemoryReflect.ts
@@ -21,7 +21,7 @@
  */
 
 import { Resource, databases } from "@harperfast/harper";
-import { isAdmin, verifyAgentRequest } from "./agent-auth.js";
+import { isAdmin, allowVerified } from "./agent-auth.js";
 import { patchRecordSilent } from "./table-helpers.js";
 
 const FOCUS_PROMPTS: Record<string, string> = {
@@ -40,9 +40,7 @@ export class ReflectMemories extends Resource {
   // admin elevation). Any verified agent may reflect; the isAdmin checks in post()
   // handle finer-grained authorization.
   async allowCreate(): Promise<boolean> {
-    const ctx = (this as any).getContext?.();
-    const request = ctx?.request ?? ctx;
-    return !!(await verifyAgentRequest(request));
+    return allowVerified((this as any).getContext?.());
   }
 
   async post(data: any) {

--- a/resources/MemoryReflect.ts
+++ b/resources/MemoryReflect.ts
@@ -21,7 +21,7 @@
  */
 
 import { Resource, databases } from "@harperfast/harper";
-import { isAdmin } from "./auth-middleware.js";
+import { isAdmin } from "./agent-auth.js";
 import { patchRecordSilent } from "./table-helpers.js";
 
 const FOCUS_PROMPTS: Record<string, string> = {

--- a/resources/MemoryReflect.ts
+++ b/resources/MemoryReflect.ts
@@ -21,7 +21,7 @@
  */
 
 import { Resource, databases } from "@harperfast/harper";
-import { isAdmin } from "./agent-auth.js";
+import { isAdmin, verifyAgentRequest } from "./agent-auth.js";
 import { patchRecordSilent } from "./table-helpers.js";
 
 const FOCUS_PROMPTS: Record<string, string> = {
@@ -36,6 +36,15 @@ const FOCUS_PROMPTS: Record<string, string> = {
 };
 
 export class ReflectMemories extends Resource {
+  // Self-authorize via the Ed25519 agent verify (auth reshape removes the gate's
+  // admin elevation). Any verified agent may reflect; the isAdmin checks in post()
+  // handle finer-grained authorization.
+  async allowCreate(): Promise<boolean> {
+    const ctx = (this as any).getContext?.();
+    const request = ctx?.request ?? ctx;
+    return !!(await verifyAgentRequest(request));
+  }
+
   async post(data: any) {
     const {
       agentId: bodyAgentId,

--- a/resources/MemoryReindex.ts
+++ b/resources/MemoryReindex.ts
@@ -25,7 +25,7 @@
  */
 
 import { Resource, databases } from "@harperfast/harper";
-import { isAdmin, verifyAgentRequest } from "./agent-auth.js";
+import { isAdmin, allowAdmin } from "./agent-auth.js";
 
 type AgentDrift = { agentId: string; primary: number; indexed: number; missing: number };
 
@@ -46,9 +46,7 @@ export class MemoryReindex extends Resource {
   // bypasses allow*); non-admin agents denied. Mirrors the handler's admin gate
   // but is the real authorization now that the gate no longer elevates agents.
   async allowCreate(): Promise<boolean> {
-    const ctx = (this as any).getContext?.();
-    const request = ctx?.request ?? ctx;
-    return (await verifyAgentRequest(request))?.isAdmin === true;
+    return allowAdmin((this as any).getContext?.());
   }
 
   async post(data: any) {

--- a/resources/MemoryReindex.ts
+++ b/resources/MemoryReindex.ts
@@ -25,7 +25,7 @@
  */
 
 import { Resource, databases } from "@harperfast/harper";
-import { isAdmin } from "./auth-middleware.js";
+import { isAdmin } from "./agent-auth.js";
 
 type AgentDrift = { agentId: string; primary: number; indexed: number; missing: number };
 

--- a/resources/MemoryReindex.ts
+++ b/resources/MemoryReindex.ts
@@ -25,7 +25,7 @@
  */
 
 import { Resource, databases } from "@harperfast/harper";
-import { isAdmin } from "./agent-auth.js";
+import { isAdmin, verifyAgentRequest } from "./agent-auth.js";
 
 type AgentDrift = { agentId: string; primary: number; indexed: number; missing: number };
 
@@ -42,6 +42,15 @@ type ReindexStats = {
 };
 
 export class MemoryReindex extends Resource {
+  // Admin-only: permit verified ADMIN agents (Basic-admin is super_user and
+  // bypasses allow*); non-admin agents denied. Mirrors the handler's admin gate
+  // but is the real authorization now that the gate no longer elevates agents.
+  async allowCreate(): Promise<boolean> {
+    const ctx = (this as any).getContext?.();
+    const request = ctx?.request ?? ctx;
+    return (await verifyAgentRequest(request))?.isAdmin === true;
+  }
+
   async post(data: any) {
     const ctx = (this as any).getContext?.();
     const request = ctx?.request ?? ctx ?? (this as any).request;

--- a/resources/OrgEventCatchup.ts
+++ b/resources/OrgEventCatchup.ts
@@ -11,8 +11,19 @@
  */
 
 import { Resource, databases } from "@harperfast/harper";
+import { verifyAgentRequest } from "./agent-auth.js";
 
 export class OrgEventCatchup extends Resource {
+  // Self-authorize via the Ed25519 agent verify (auth reshape removes the gate's
+  // admin elevation). Any verified agent may catch up; participant scoping is in
+  // get(). Uses getContext().request — the reliable v5 path (this.request is not
+  // populated on Harper v5 Resources).
+  async allowRead(): Promise<boolean> {
+    const ctx = (this as any).getContext?.();
+    const request = ctx?.request ?? ctx;
+    return !!(await verifyAgentRequest(request));
+  }
+
   // HarperDB calls get(pathInfo, context) where pathInfo is the URL segment after /OrgEventCatchup/
   async get(pathInfo?: any) {
     const request = (this as any).request;

--- a/resources/OrgEventCatchup.ts
+++ b/resources/OrgEventCatchup.ts
@@ -11,7 +11,7 @@
  */
 
 import { Resource, databases } from "@harperfast/harper";
-import { verifyAgentRequest } from "./agent-auth.js";
+import { allowVerified } from "./agent-auth.js";
 
 export class OrgEventCatchup extends Resource {
   // Self-authorize via the Ed25519 agent verify (auth reshape removes the gate's
@@ -19,9 +19,7 @@ export class OrgEventCatchup extends Resource {
   // get(). Uses getContext().request — the reliable v5 path (this.request is not
   // populated on Harper v5 Resources).
   async allowRead(): Promise<boolean> {
-    const ctx = (this as any).getContext?.();
-    const request = ctx?.request ?? ctx;
-    return !!(await verifyAgentRequest(request));
+    return allowVerified((this as any).getContext?.());
   }
 
   // HarperDB calls get(pathInfo, context) where pathInfo is the URL segment after /OrgEventCatchup/

--- a/resources/OrgEventMaintenance.ts
+++ b/resources/OrgEventMaintenance.ts
@@ -6,8 +6,18 @@
  */
 
 import { Resource, databases } from "@harperfast/harper";
+import { verifyAgentRequest } from "./agent-auth.js";
 
 export class OrgEventMaintenance extends Resource {
+  // Admin-only: permit verified ADMIN agents (Basic-admin is super_user and
+  // bypasses allow*); non-admin agents denied. Real authorization now that the
+  // gate no longer elevates agents to admin.
+  async allowCreate(): Promise<boolean> {
+    const ctx = (this as any).getContext?.();
+    const request = ctx?.request ?? ctx;
+    return (await verifyAgentRequest(request))?.isAdmin === true;
+  }
+
   async post(_data: any, context?: any) {
     // Admin-only
     if (!context?.request?.tpsAgentIsAdmin) {

--- a/resources/OrgEventMaintenance.ts
+++ b/resources/OrgEventMaintenance.ts
@@ -6,16 +6,14 @@
  */
 
 import { Resource, databases } from "@harperfast/harper";
-import { verifyAgentRequest } from "./agent-auth.js";
+import { allowAdmin } from "./agent-auth.js";
 
 export class OrgEventMaintenance extends Resource {
   // Admin-only: permit verified ADMIN agents (Basic-admin is super_user and
   // bypasses allow*); non-admin agents denied. Real authorization now that the
   // gate no longer elevates agents to admin.
   async allowCreate(): Promise<boolean> {
-    const ctx = (this as any).getContext?.();
-    const request = ctx?.request ?? ctx;
-    return (await verifyAgentRequest(request))?.isAdmin === true;
+    return allowAdmin((this as any).getContext?.());
   }
 
   async post(_data: any, context?: any) {

--- a/resources/Relationship.ts
+++ b/resources/Relationship.ts
@@ -1,5 +1,5 @@
 import { databases } from "@harperfast/harper";
-import { isAdmin } from "./auth-middleware.js";
+import { isAdmin } from "./agent-auth.js";
 import { checkRateLimit, rateLimitResponse } from "./rate-limiter.js";
 
 /**

--- a/resources/Relationship.ts
+++ b/resources/Relationship.ts
@@ -16,7 +16,7 @@ import { checkRateLimit, rateLimitResponse } from "./rate-limiter.js";
 export class Relationship extends (databases as any).flair.Relationship {
 
   async search(query?: any) {
-    const auth = await resolveAgentAuth((this as any).getContext?.()?.request);
+    const auth = await resolveAgentAuth((this as any).getContext?.());
 
     // Anonymous HTTP must NOT read relationships (previously `!authAgent` was
     // treated as unfiltered — the anonymous-read leak).

--- a/resources/Relationship.ts
+++ b/resources/Relationship.ts
@@ -1,5 +1,5 @@
 import { databases } from "@harperfast/harper";
-import { isAdmin } from "./agent-auth.js";
+import { resolveAgentAuth } from "./agent-auth.js";
 import { checkRateLimit, rateLimitResponse } from "./rate-limiter.js";
 
 /**
@@ -16,17 +16,22 @@ import { checkRateLimit, rateLimitResponse } from "./rate-limiter.js";
 export class Relationship extends (databases as any).flair.Relationship {
 
   async search(query?: any) {
-    const ctx = (this as any).getContext?.();
-    const request = ctx?.request ?? ctx;
-    const authAgent: string | undefined = request?.tpsAgent;
-    const isAdminAgent: boolean = request?.tpsAgentIsAdmin ?? false;
+    const auth = await resolveAgentAuth((this as any).getContext?.()?.request);
 
-    if (!authAgent || isAdminAgent) {
+    // Anonymous HTTP must NOT read relationships (previously `!authAgent` was
+    // treated as unfiltered — the anonymous-read leak).
+    if (auth.kind === "anonymous") {
+      return new Response(JSON.stringify({ error: "authentication required" }), {
+        status: 401, headers: { "content-type": "application/json" },
+      });
+    }
+    // Trusted internal call or admin agent → unfiltered.
+    if (auth.kind === "internal" || (auth.kind === "agent" && auth.isAdmin)) {
       return super.search(query);
     }
 
-    // Non-admin: scope to own relationships
-    const agentCondition = { attribute: "agentId", comparator: "equals", value: authAgent };
+    // Non-admin agent: scope to own relationships.
+    const agentCondition = { attribute: "agentId", comparator: "equals", value: auth.agentId };
     if (!query?.conditions) {
       return super.search({ conditions: [agentCondition], ...(query || {}) });
     }

--- a/resources/SemanticSearch.ts
+++ b/resources/SemanticSearch.ts
@@ -1,5 +1,5 @@
 import { Resource, databases } from "@harperfast/harper";
-import { verifyAgentRequest } from "./agent-auth.js";
+import { verifyAgentRequest, resolveAgentAuth } from "./agent-auth.js";
 import { getEmbedding, getMode } from "./embeddings-provider.js";
 import { patchRecord, withDetachedTxn } from "./table-helpers.js";
 import { checkRateLimit, rateLimitResponse } from "./rate-limiter.js";
@@ -76,13 +76,21 @@ export class SemanticSearch extends Resource {
     // silently returned undefined and the defense-in-depth scope check below
     // was bypassed, letting a non-admin agent read another agent's memories
     // by putting the victim's id in the body.
-    const ctx = (this as any).getContext?.();
-    const request = ctx?.request ?? ctx;
-    const authenticatedAgent: string | undefined =
-      request?.tpsAgent ?? request?.headers?.get?.("x-tps-agent");
-    const callerIsAdmin: boolean = request?.tpsAgentIsAdmin === true;
+    const auth = await resolveAgentAuth((this as any).getContext?.());
 
-    // Rate limiting — use authenticated agent ID, not client-supplied body
+    // Anonymous HTTP must NOT search. Previously the no-auth path fell through to
+    // honoring the body-supplied agentId (line below), so an unauthenticated
+    // caller could read any agent's memories by putting that id in the body.
+    if (auth.kind === "anonymous") {
+      return new Response(JSON.stringify({ error: "authentication required" }), {
+        status: 401, headers: { "Content-Type": "application/json" },
+      });
+    }
+
+    const authenticatedAgent: string | undefined = auth.kind === "agent" ? auth.agentId : undefined;
+    const callerIsAdmin: boolean = auth.kind === "agent" && auth.isAdmin;
+
+    // Rate limiting — use authenticated agent ID (internal calls have none).
     if (authenticatedAgent) {
       const bucket = q && !queryEmbedding ? "embedding" : "general";
       const rl = checkRateLimit(authenticatedAgent, bucket);
@@ -97,15 +105,15 @@ export class SemanticSearch extends Resource {
 
     // Enforce agentId = authenticated agent for non-admins. A mismatched body
     // agentId is a cross-agent read attempt — reject outright. Admins can query
-    // any agentId (needed for bootstrap / consolidation scripts).
+    // any agentId (bootstrap / consolidation).
     if (authenticatedAgent && !callerIsAdmin && bodyAgentId && bodyAgentId !== authenticatedAgent) {
       return new Response(JSON.stringify({
         error: "forbidden: agentId must match authenticated agent",
       }), { status: 403, headers: { "Content-Type": "application/json" } });
     }
 
-    // Scope search to the authenticated agent (own + granted). For admins or
-    // unauthenticated internal calls, honor the body-supplied agentId.
+    // Scope: non-admin agent → own (+ granted). Admin agent or trusted internal
+    // call (no request) → honor the body-supplied agentId.
     const agentId: string | undefined = (authenticatedAgent && !callerIsAdmin)
       ? authenticatedAgent
       : bodyAgentId;

--- a/resources/SemanticSearch.ts
+++ b/resources/SemanticSearch.ts
@@ -1,4 +1,5 @@
 import { Resource, databases } from "@harperfast/harper";
+import { verifyAgentRequest } from "./agent-auth.js";
 import { getEmbedding, getMode } from "./embeddings-provider.js";
 import { patchRecord, withDetachedTxn } from "./table-helpers.js";
 import { checkRateLimit, rateLimitResponse } from "./rate-limiter.js";
@@ -55,6 +56,18 @@ function distanceToSimilarity(distance: number): number {
 const CANDIDATE_MULTIPLIER = 5;
 
 export class SemanticSearch extends Resource {
+  // Self-authorize via the Ed25519 agent verify instead of relying on the auth
+  // gate's admin super_user elevation (removed in the auth reshape). Any
+  // cryptographically-verified agent may search; per-agent RESULT scoping is
+  // enforced in post() below (an agent only sees its own + office-visible +
+  // granted memories). Without this, Harper's default denies the POST for the
+  // least-privilege flair_agent role (AccessViolation 403).
+  async allowCreate(): Promise<boolean> {
+    const ctx = (this as any).getContext?.();
+    const request = ctx?.request ?? ctx;
+    return !!(await verifyAgentRequest(request));
+  }
+
   async post(data: any) {
     const { agentId: bodyAgentId, q, queryEmbedding, tag, subject, subjects, limit = 10, includeSuperseded = false, scoring = "composite", minScore = 0, since, asOf } = data || {};
 

--- a/resources/SemanticSearch.ts
+++ b/resources/SemanticSearch.ts
@@ -1,5 +1,5 @@
 import { Resource, databases } from "@harperfast/harper";
-import { verifyAgentRequest, resolveAgentAuth } from "./agent-auth.js";
+import { resolveAgentAuth, allowVerified } from "./agent-auth.js";
 import { getEmbedding, getMode } from "./embeddings-provider.js";
 import { patchRecord, withDetachedTxn } from "./table-helpers.js";
 import { checkRateLimit, rateLimitResponse } from "./rate-limiter.js";
@@ -63,9 +63,7 @@ export class SemanticSearch extends Resource {
   // granted memories). Without this, Harper's default denies the POST for the
   // least-privilege flair_agent role (AccessViolation 403).
   async allowCreate(): Promise<boolean> {
-    const ctx = (this as any).getContext?.();
-    const request = ctx?.request ?? ctx;
-    return !!(await verifyAgentRequest(request));
+    return allowVerified((this as any).getContext?.());
   }
 
   async post(data: any) {

--- a/resources/SoulFeed.ts
+++ b/resources/SoulFeed.ts
@@ -1,14 +1,12 @@
 import { Resource, databases } from '@harperfast/harper';
-import { verifyAgentRequest } from './agent-auth.js';
+import { allowVerified } from './agent-auth.js';
 
 export class FeedSouls extends Resource {
   // Self-authorize the subscription via the Ed25519 agent verify (auth reshape
   // removes the gate's admin elevation). FeedSouls extends Resource (not a Table),
   // so getContext().request is reachable in allow* — same pattern as SemanticSearch.
   async allowRead(): Promise<boolean> {
-    const ctx = (this as any).getContext?.();
-    const request = ctx?.request ?? ctx;
-    return !!(await verifyAgentRequest(request));
+    return allowVerified((this as any).getContext?.());
   }
 
   async *connect(target: any, incomingMessages: any) {

--- a/resources/SoulFeed.ts
+++ b/resources/SoulFeed.ts
@@ -1,6 +1,16 @@
 import { Resource, databases } from '@harperfast/harper';
+import { verifyAgentRequest } from './agent-auth.js';
 
 export class FeedSouls extends Resource {
+  // Self-authorize the subscription via the Ed25519 agent verify (auth reshape
+  // removes the gate's admin elevation). FeedSouls extends Resource (not a Table),
+  // so getContext().request is reachable in allow* — same pattern as SemanticSearch.
+  async allowRead(): Promise<boolean> {
+    const ctx = (this as any).getContext?.();
+    const request = ctx?.request ?? ctx;
+    return !!(await verifyAgentRequest(request));
+  }
+
   async *connect(target: any, incomingMessages: any) {
     const subscription = await (databases as any).flair.Soul.subscribe(target);
     

--- a/resources/WorkspaceLatest.ts
+++ b/resources/WorkspaceLatest.ts
@@ -6,16 +6,14 @@
  */
 
 import { Resource, databases } from "@harperfast/harper";
-import { verifyAgentRequest } from "./agent-auth.js";
+import { allowVerified } from "./agent-auth.js";
 
 export class WorkspaceLatest extends Resource {
   // Self-authorize via the Ed25519 agent verify (auth reshape removes the gate's
   // admin elevation). Any verified agent may read; the path-vs-agent ownership
   // check stays in get().
   async allowRead(): Promise<boolean> {
-    const ctx = (this as any).getContext?.();
-    const request = ctx?.request ?? ctx;
-    return !!(await verifyAgentRequest(request));
+    return allowVerified((this as any).getContext?.());
   }
 
   async get(pathInfo?: any) {

--- a/resources/WorkspaceLatest.ts
+++ b/resources/WorkspaceLatest.ts
@@ -6,8 +6,18 @@
  */
 
 import { Resource, databases } from "@harperfast/harper";
+import { verifyAgentRequest } from "./agent-auth.js";
 
 export class WorkspaceLatest extends Resource {
+  // Self-authorize via the Ed25519 agent verify (auth reshape removes the gate's
+  // admin elevation). Any verified agent may read; the path-vs-agent ownership
+  // check stays in get().
+  async allowRead(): Promise<boolean> {
+    const ctx = (this as any).getContext?.();
+    const request = ctx?.request ?? ctx;
+    return !!(await verifyAgentRequest(request));
+  }
+
   async get(pathInfo?: any) {
     const request = (this as any).context?.request ?? (this as any).request;
     const callerAgent = request?.tpsAgent;

--- a/resources/WorkspaceState.ts
+++ b/resources/WorkspaceState.ts
@@ -9,36 +9,36 @@
  */
 
 import { databases } from "@harperfast/harper";
-import { isAdmin } from "./agent-auth.js";
+import { resolveAgentAuth } from "./agent-auth.js";
+
+const FORBIDDEN = (msg: string) =>
+  new Response(JSON.stringify({ error: msg }), { status: 403, headers: { "Content-Type": "application/json" } });
+const UNAUTH = () =>
+  new Response(JSON.stringify({ error: "authentication required" }), { status: 401, headers: { "Content-Type": "application/json" } });
 
 export class WorkspaceState extends (databases as any).flair.WorkspaceState {
-  /**
-   * Helper to extract auth info from Harper's Resource instance context.
-   */
-  private _authInfo() {
-    const ctx = (this as any).getContext?.();
-    const request = ctx?.request ?? ctx;
-    return {
-      agentId: request?.tpsAgent as string | undefined,
-      isAdmin: request?.tpsAgentIsAdmin as boolean ?? false,
-    };
+  /** Auth verdict from the request context. internal = trusted in-process call;
+   *  agent = verified Ed25519; anonymous = HTTP with no valid agent → deny. */
+  private _auth() {
+    return resolveAgentAuth((this as any).getContext?.());
   }
 
   /**
-   * Override search() to scope collection GETs to the authenticated agent's
-   * own workspace state records. Admin agents see all records.
+   * Override search() to scope collection GETs to the authenticated agent's own
+   * records. Internal calls + admin agents see all; anonymous is denied
+   * (previously `!authAgent` was treated as unfiltered — the anonymous-read leak).
    */
   async search(query?: any) {
-    const { agentId: authAgent, isAdmin: isAdminAgent } = this._authInfo();
-
-    if (!authAgent || isAdminAgent) {
+    const auth = await this._auth();
+    if (auth.kind === "anonymous") return UNAUTH();
+    if (auth.kind === "internal" || (auth.kind === "agent" && auth.isAdmin)) {
       return super.search(query);
     }
 
-    const agentIdCondition = { attribute: "agentId", comparator: "equals", value: authAgent };
+    const agentIdCondition = { attribute: "agentId", comparator: "equals", value: auth.agentId };
 
-    // Harper passes `query` as a request target object (with pathname, id, isCollection, etc.)
-    // Inject scope condition into its `.conditions` array so Table.search() processes it correctly.
+    // Harper passes `query` as a request target object (pathname, id, isCollection…).
+    // Inject the scope condition into its `.conditions` array.
     if (query && typeof query === "object" && !Array.isArray(query)) {
       const existing = query.conditions ?? [];
       query.conditions = Array.isArray(existing)
@@ -54,14 +54,12 @@ export class WorkspaceState extends (databases as any).flair.WorkspaceState {
   }
 
   async post(content: any) {
-    const { agentId, isAdmin: isAdminAgent } = this._authInfo();
-
-    // Agent-scoped: agentId in body must match authenticated agent
-    if (agentId && !isAdminAgent && content.agentId !== agentId) {
-      return new Response(
-        JSON.stringify({ error: "forbidden: cannot write workspace state for another agent" }),
-        { status: 403, headers: { "Content-Type": "application/json" } },
-      );
+    const auth = await this._auth();
+    // Anonymous must NOT write (previously the agentId check was skipped when
+    // there was no authenticated agent, so anonymous could write any record).
+    if (auth.kind === "anonymous") return UNAUTH();
+    if (auth.kind === "agent" && !auth.isAdmin && content.agentId !== auth.agentId) {
+      return FORBIDDEN("forbidden: cannot write workspace state for another agent");
     }
 
     content.createdAt = new Date().toISOString();
@@ -71,32 +69,29 @@ export class WorkspaceState extends (databases as any).flair.WorkspaceState {
   }
 
   async put(content: any) {
-    const { agentId, isAdmin: isAdminAgent } = this._authInfo();
-
-    if (agentId && !isAdminAgent && content.agentId !== agentId) {
-      return new Response(
-        JSON.stringify({ error: "forbidden: cannot write workspace state for another agent" }),
-        { status: 403, headers: { "Content-Type": "application/json" } },
-      );
+    const auth = await this._auth();
+    if (auth.kind === "anonymous") return UNAUTH();
+    if (auth.kind === "agent" && !auth.isAdmin && content.agentId !== auth.agentId) {
+      return FORBIDDEN("forbidden: cannot write workspace state for another agent");
     }
 
     return super.put(content);
   }
 
   async delete(id: any) {
-    const { agentId, isAdmin: isAdminAgent } = this._authInfo();
-    if (!agentId) return super.delete(id);
+    const auth = await this._auth();
+    // Anonymous must NOT delete (previously `!agentId → super.delete` let anonymous
+    // delete any record).
+    if (auth.kind === "anonymous") return UNAUTH();
+    if (auth.kind === "internal" || (auth.kind === "agent" && auth.isAdmin)) {
+      return super.delete(id);
+    }
 
     const record = await this.get(id);
     if (!record) return super.delete(id);
-
-    if (!isAdminAgent && record.agentId !== agentId) {
-      return new Response(
-        JSON.stringify({ error: "forbidden: cannot delete workspace state for another agent" }),
-        { status: 403, headers: { "Content-Type": "application/json" } },
-      );
+    if (record.agentId !== auth.agentId) {
+      return FORBIDDEN("forbidden: cannot delete workspace state for another agent");
     }
-
     return super.delete(id);
   }
 }

--- a/resources/WorkspaceState.ts
+++ b/resources/WorkspaceState.ts
@@ -9,7 +9,7 @@
  */
 
 import { databases } from "@harperfast/harper";
-import { isAdmin } from "./auth-middleware.js";
+import { isAdmin } from "./agent-auth.js";
 
 export class WorkspaceState extends (databases as any).flair.WorkspaceState {
   /**

--- a/resources/agent-auth.ts
+++ b/resources/agent-auth.ts
@@ -164,18 +164,48 @@ export type AgentAuthVerdict =
  * Three-way auth verdict for a resource — the safe replacement for the old
  * `if (!authAgent) → unfiltered/trusted` pattern that leaked to anonymous callers
  * once the gate stopped rejecting them. Distinguishes:
- *   - **internal**: no HTTP request context → a programmatic/in-process call
+ *   - **internal**: no HTTP request at all → a programmatic/in-process call
  *     (maintenance, consolidation). Trusted; callers may run unfiltered.
- *   - **agent**: request carries a valid TPS-Ed25519 signature → the agent.
- *   - **anonymous**: request present but NO valid agent → an unauthenticated HTTP
- *     caller. MUST be denied. (This is the case the old code wrongly trusted.)
+ *   - **agent**: a verified agent (Ed25519). Carries agentId + isAdmin.
+ *   - **anonymous**: an HTTP request with NO valid agent → MUST be denied.
  *
- * Mirrors @harperfast/oauth's withOAuthValidation: no request object → pass
- * through; request without valid auth → reject. Pass `getContext()?.request`.
+ * Pass the RESOURCE CONTEXT (`getContext()`), not `getContext().request`:
+ * `getContext().request` is inconsistently populated across resource methods
+ * (present for search/GET, undefined for PUT/POST in Table resources), so we read
+ * the gate's annotations off `context.request ?? context` — exactly how the
+ * pre-reshape resources read `request.tpsAgent`. Resolution order:
+ *   1. explicit anonymous marker (`tpsAnonymous`, set by the non-rejecting gate)
+ *   2. gate's verified-agent annotation (`tpsAgent` / `tpsAgentIsAdmin`)
+ *   3. per-agent identity on `context.user` (the de-elevated user; username=agentId)
+ *   4. header verify (custom-resource allow*, where the raw request is present)
+ *      — and if a request object IS present but yields no agent → anonymous
+ *   5. nothing at all → trusted internal call
  */
-export async function resolveAgentAuth(request: any): Promise<AgentAuthVerdict> {
-  if (!request) return { kind: "internal" };
-  const auth = await verifyAgentRequest(request);
-  if (auth) return { kind: "agent", agentId: auth.agentId, isAdmin: auth.isAdmin };
-  return { kind: "anonymous" };
+export async function resolveAgentAuth(context: any): Promise<AgentAuthVerdict> {
+  const c = context?.request ?? context;
+  if (!c) return { kind: "internal" };
+
+  if (c.tpsAnonymous === true) return { kind: "anonymous" };
+
+  if (c.tpsAgent) {
+    return { kind: "agent", agentId: String(c.tpsAgent), isAdmin: c.tpsAgentIsAdmin === true };
+  }
+
+  const user = context?.user ?? c.user;
+  if (user?.role?.permission?.super_user === true) {
+    return { kind: "agent", agentId: String(user.username ?? "admin"), isAdmin: true };
+  }
+  if (user?.username && user.username !== FLAIR_AGENT_USERNAME) {
+    return { kind: "agent", agentId: String(user.username), isAdmin: false };
+  }
+
+  // A raw request with headers is present → verify it; an HTTP request that
+  // yields no agent is anonymous (NOT internal).
+  if (c.headers?.get || c.headers?.asObject) {
+    const auth = await verifyAgentRequest(c);
+    if (auth) return { kind: "agent", agentId: auth.agentId, isAdmin: auth.isAdmin };
+    return { kind: "anonymous" };
+  }
+
+  return { kind: "internal" };
 }

--- a/resources/agent-auth.ts
+++ b/resources/agent-auth.ts
@@ -1,0 +1,146 @@
+/**
+ * flair-agent-auth — Ed25519 agent authentication.
+ *
+ * The verification logic that used to live in the instance-wide `server.http`
+ * auth-middleware, extracted into a per-resource helper. Resources call
+ * `verifyAgentRequest()` from their `allow*()` methods to identify + authorize
+ * the calling agent. This keeps flair's auth PER-RESOURCE (Harper-native) so it
+ * composes on a multi-component hub instead of a global gate that 401s siblings.
+ *
+ * Plugin-shaped on purpose (config via env today, extractable to a standalone
+ * @tps/agent-auth Harper plugin later — the "agent auth as its own plugin" path).
+ *
+ * Auth model: an agent presents `Authorization: TPS-Ed25519 <id>:<ts>:<nonce>:<sig>`.
+ * The signature covers `<id>:<ts>:<nonce>:<METHOD>:<pathname><search>` and is
+ * verified against the agent's stored Ed25519 public key. Replay is bounded by a
+ * 30s timestamp window + a per-(agent,nonce) seen-set pruned to that window.
+ */
+import { databases } from "@harperfast/harper";
+
+const WINDOW_MS = Number(process.env.FLAIR_AGENT_AUTH_WINDOW_MS) || 30_000;
+
+// Replay protection: remember recently-seen (agent:nonce), pruned by the window.
+const nonceSeen = new Map<string, number>();
+
+// ─── Crypto helpers ───────────────────────────────────────────────────────────
+
+function b64ToArrayBuffer(b64: string): ArrayBuffer {
+  // Handle both standard and URL-safe base64.
+  const std = b64.replace(/-/g, "+").replace(/_/g, "/");
+  const bin = atob(std);
+  const buf = new ArrayBuffer(bin.length);
+  const view = new Uint8Array(buf);
+  for (let i = 0; i < bin.length; i++) view[i] = bin.charCodeAt(i);
+  return buf;
+}
+
+const keyCache = new Map<string, CryptoKey>();
+async function importEd25519Key(publicKeyStr: string): Promise<CryptoKey> {
+  const cached = keyCache.get(publicKeyStr);
+  if (cached) return cached;
+  // Accept hex (64-char) or base64 (44-char) encoded 32-byte Ed25519 public key.
+  let raw: ArrayBuffer;
+  if (/^[0-9a-f]{64}$/i.test(publicKeyStr)) {
+    const bytes = new Uint8Array(32);
+    for (let i = 0; i < 32; i++) bytes[i] = parseInt(publicKeyStr.slice(i * 2, i * 2 + 2), 16);
+    raw = bytes.buffer;
+  } else {
+    raw = b64ToArrayBuffer(publicKeyStr);
+  }
+  const key = await crypto.subtle.importKey("raw", raw, { name: "Ed25519" } as any, false, ["verify"]);
+  keyCache.set(publicKeyStr, key);
+  return key;
+}
+
+// ─── Admin resolution ─────────────────────────────────────────────────────────
+// Admin agents come from FLAIR_ADMIN_AGENTS (comma-separated) OR Agent records
+// with role === "admin". OR-combined, cached 60s. Distinct from Harper's
+// super_user — admin here gates flair-policy decisions (promotions, raw ops).
+
+let adminCacheExpiry = 0;
+let adminCache: Set<string> = new Set();
+
+async function getAdminAgents(): Promise<Set<string>> {
+  const now = Date.now();
+  if (now < adminCacheExpiry) return adminCache;
+  const fromEnv = (process.env.FLAIR_ADMIN_AGENTS ?? "").split(",").map((s) => s.trim()).filter(Boolean);
+  const fromDb: string[] = [];
+  try {
+    const results = await (databases as any).flair.Agent.search([{ attribute: "role", value: "admin", condition: "equals" }]);
+    for await (const row of results) if (row?.id) fromDb.push(row.id);
+  } catch { /* Agent table may be empty */ }
+  adminCache = new Set([...fromEnv, ...fromDb]);
+  adminCacheExpiry = now + 60_000;
+  return adminCache;
+}
+
+export async function isAdmin(agentId: string): Promise<boolean> {
+  return (await getAdminAgents()).has(agentId);
+}
+
+// ─── Agent request verification ───────────────────────────────────────────────
+
+export interface AgentAuth {
+  agentId: string;
+  isAdmin: boolean;
+}
+
+const HEADER_RE = /^TPS-Ed25519\s+([^:]+):(\d+):([^:]+):(.+)$/;
+
+async function doVerify(request: any): Promise<AgentAuth | null> {
+  const header: string =
+    request?.headers?.get?.("authorization") ??
+    request?.headers?.asObject?.authorization ??
+    "";
+  const m = HEADER_RE.exec(header);
+  if (!m) return null;
+
+  const [, agentId, tsRaw, nonce, signatureB64] = m;
+  const ts = Number(tsRaw);
+  const now = Date.now();
+  if (!Number.isFinite(ts) || Math.abs(now - ts) > WINDOW_MS) return null;
+
+  // Prune expired nonces, then reject replays within the window.
+  for (const [k, t] of nonceSeen) if (now - t > WINDOW_MS) nonceSeen.delete(k);
+  const nonceKey = `${agentId}:${nonce}`;
+  if (nonceSeen.has(nonceKey)) return null;
+
+  const agent = await (databases as any).flair.Agent.get(agentId).catch(() => null);
+  if (!agent?.publicKey) return null;
+
+  // Canonical signed payload: id:ts:nonce:METHOD:pathname+search (must match the
+  // TPS CLI signer exactly — changing this breaks every agent's auth).
+  const url = new URL(request.url, "http://localhost");
+  const payload = `${agentId}:${tsRaw}:${nonce}:${request.method}:${url.pathname}${url.search}`;
+  try {
+    const key = await importEd25519Key(String(agent.publicKey));
+    const ok = await crypto.subtle.verify(
+      { name: "Ed25519" } as any,
+      key,
+      b64ToArrayBuffer(signatureB64),
+      new TextEncoder().encode(payload),
+    );
+    if (!ok) return null;
+  } catch {
+    return null;
+  }
+
+  nonceSeen.set(nonceKey, ts);
+  return { agentId, isAdmin: await isAdmin(agentId) };
+}
+
+/**
+ * Verify a TPS-Ed25519 signed request → the authenticated agent, or null.
+ *
+ * MEMOIZED per request object: `allow*` may run several times for one request,
+ * and re-running doVerify would (a) waste a crypto verify and (b) double-consume
+ * the nonce (the 2nd call would see a replay and fail). We verify once and cache
+ * the result (including null) on the request.
+ */
+export async function verifyAgentRequest(request: any): Promise<AgentAuth | null> {
+  if (!request) return null;
+  if (request._flairAgentAuth !== undefined) return request._flairAgentAuth;
+  const result = await doVerify(request);
+  try { request._flairAgentAuth = result; } catch { /* frozen request — fine, just no cache */ }
+  return result;
+}

--- a/resources/agent-auth.ts
+++ b/resources/agent-auth.ts
@@ -181,6 +181,26 @@ export type AgentAuthVerdict =
  *      — and if a request object IS present but yields no agent → anonymous
  *   5. nothing at all → trusted internal call
  */
+/**
+ * allow* for AGENT-FACING resources: permit verified agents, admins/super_user,
+ * and trusted internal calls; deny anonymous HTTP. Pass getContext(). Per-record
+ * scoping/ownership is still enforced in the handler. Replaces the
+ * `!!verifyAgentRequest(request)` pattern, which wrongly denied Basic-admin/
+ * super_user (no TPS header) — breaking the CLI/consolidation path.
+ */
+export async function allowVerified(context: any): Promise<boolean> {
+  return (await resolveAgentAuth(context)).kind !== "anonymous";
+}
+
+/**
+ * allow* for ADMIN-ONLY resources: permit admin agents + super_user + trusted
+ * internal calls; deny non-admin agents and anonymous.
+ */
+export async function allowAdmin(context: any): Promise<boolean> {
+  const a = await resolveAgentAuth(context);
+  return a.kind === "internal" || (a.kind === "agent" && a.isAdmin);
+}
+
 export async function resolveAgentAuth(context: any): Promise<AgentAuthVerdict> {
   const c = context?.request ?? context;
   if (!c) return { kind: "internal" };

--- a/resources/agent-auth.ts
+++ b/resources/agent-auth.ts
@@ -152,3 +152,30 @@ export async function verifyAgentRequest(request: any): Promise<AgentAuth | null
   try { request._flairAgentAuth = result; } catch { /* frozen request — fine, just no cache */ }
   return result;
 }
+
+// ─── Resource auth verdict ──────────────────────────────────────────────────
+
+export type AgentAuthVerdict =
+  | { kind: "internal" }                                  // no HTTP request → trusted in-process call
+  | { kind: "agent"; agentId: string; isAdmin: boolean }  // valid TPS-Ed25519 signature
+  | { kind: "anonymous" };                                // request present, no valid agent → DENY
+
+/**
+ * Three-way auth verdict for a resource — the safe replacement for the old
+ * `if (!authAgent) → unfiltered/trusted` pattern that leaked to anonymous callers
+ * once the gate stopped rejecting them. Distinguishes:
+ *   - **internal**: no HTTP request context → a programmatic/in-process call
+ *     (maintenance, consolidation). Trusted; callers may run unfiltered.
+ *   - **agent**: request carries a valid TPS-Ed25519 signature → the agent.
+ *   - **anonymous**: request present but NO valid agent → an unauthenticated HTTP
+ *     caller. MUST be denied. (This is the case the old code wrongly trusted.)
+ *
+ * Mirrors @harperfast/oauth's withOAuthValidation: no request object → pass
+ * through; request without valid auth → reject. Pass `getContext()?.request`.
+ */
+export async function resolveAgentAuth(request: any): Promise<AgentAuthVerdict> {
+  if (!request) return { kind: "internal" };
+  const auth = await verifyAgentRequest(request);
+  if (auth) return { kind: "agent", agentId: auth.agentId, isAdmin: auth.isAdmin };
+  return { kind: "anonymous" };
+}

--- a/resources/agent-auth.ts
+++ b/resources/agent-auth.ts
@@ -19,6 +19,14 @@ import { databases } from "@harperfast/harper";
 
 const WINDOW_MS = Number(process.env.FLAIR_AGENT_AUTH_WINDOW_MS) || 30_000;
 
+/**
+ * Shared Harper user that verified Ed25519 agents resolve to (least-privilege
+ * `flair_agent` role), replacing the old admin super_user elevation. Single
+ * source of truth — the auth gate resolves agents to this user and the CLI
+ * provisions it (ensureFlairAgentUser); they MUST agree on the name.
+ */
+export const FLAIR_AGENT_USERNAME = "flair-agent";
+
 // Replay protection: remember recently-seen (agent:nonce), pruned by the window.
 const nonceSeen = new Map<string, number>();
 

--- a/resources/auth-middleware.ts
+++ b/resources/auth-middleware.ts
@@ -1,7 +1,7 @@
 import { patchRecord } from "./table-helpers.js";
 import { server, databases } from "@harperfast/harper";
 import { getEmbedding } from "./embeddings-provider.js";
-import { isAdmin, FLAIR_AGENT_USERNAME } from "./agent-auth.js";
+import { isAdmin } from "./agent-auth.js";
 
 // --- Admin credentials ---
 // Admin auth is sourced exclusively from Harper's own environment variables
@@ -133,9 +133,18 @@ server.http(async (request: any, nextLayer: any) => {
     url.pathname === "/Presence"
   ) return nextLayer(request);
 
-  // If Harper has already authorized this request (e.g. authorizeLocal=true on localhost),
-  // trust Harper's auth decision and pass through without requiring additional headers.
+  // If Harper has already authorized this request (e.g. Basic admin, or
+  // authorizeLocal=true on localhost), trust Harper's auth decision and pass
+  // through. Annotate the admin identity so resources' resolveAgentAuth recognizes
+  // this as an ADMIN caller (not anonymous) — otherwise a Basic-admin request,
+  // which carries no TPS-Ed25519 header, gets classified anonymous and denied.
   if (request.user?.role?.permission?.super_user === true) {
+    request.tpsAgent = request.user.username ?? "admin";
+    request.tpsAgentIsAdmin = true;
+    try {
+      request.headers.set("x-tps-agent", request.tpsAgent);
+      if (request.headers.asObject) (request.headers.asObject as any)["x-tps-agent"] = request.tpsAgent;
+    } catch { /* frozen headers — annotation on request object still applies */ }
     return nextLayer(request);
   }
 
@@ -285,24 +294,18 @@ server.http(async (request: any, nextLayer: any) => {
   // `flair-agent` user, NOT admin super_user. The flair_agent role grants exactly
   // the table CRUD agents need; with no operations grant, /sql + /graphql become
   // natively 403. Row-level data isolation stays enforced via x-tps-agent below.
-  // Transitional fallback: if the flair-agent user isn't provisioned yet (older
-  // instances pre-ensureFlairAgentUser), fall back to admin so agents keep
-  // working until the deploy provisions it — logged so the gap is visible.
+  // Elevate the cryptographically-verified agent to admin (unchanged from
+  // pre-reshape behavior). getUser(admin, null) looks up the admin record WITHOUT
+  // password validation — safe because the Ed25519 signature already proved
+  // identity. Per-agent DE-ELEVATION (agents → the least-privilege flair_agent
+  // role instead of admin) is deferred to the non-rejecting-gate follow-up PR; it
+  // doesn't belong in this zero-behavior-change foundation. Resource scoping +
+  // ownership in this PR derive identity from the x-tps-agent annotation via
+  // resolveAgentAuth, independent of request.user, so they work under either model.
   try {
-    const flairAgentUser = await (server as any).getUser(FLAIR_AGENT_USERNAME, null, request);
-    if (flairAgentUser) {
-      // Per-agent identity: keep the flair_agent role (table grants) but stamp the
-      // verified agentId as the username, so resources' allow* see the SPECIFIC
-      // agent via context.user.username and can enforce row-ownership natively
-      // (Harper passes context.user into allow*). Spread to avoid mutating the
-      // shared, cached flair-agent user object.
-      request.user = { ...flairAgentUser, username: agentId };
-    } else {
-      console.warn(`[auth] '${FLAIR_AGENT_USERNAME}' user not provisioned — falling back to admin elevation for ${agentId}. Run flair init to provision the least-privilege user.`);
-      request.user = await (server as any).getUser("admin", null, request);
-    }
+    request.user = await (server as any).getUser("admin", null, request);
   } catch {
-    // User lookup unavailable — request proceeds as the verified tpsAgent
+    // Admin record unavailable — request proceeds as the verified tpsAgent
     // without elevated perms; resource-level scoping still applies.
   }
 

--- a/resources/auth-middleware.ts
+++ b/resources/auth-middleware.ts
@@ -1,7 +1,7 @@
 import { patchRecord } from "./table-helpers.js";
 import { server, databases } from "@harperfast/harper";
 import { getEmbedding } from "./embeddings-provider.js";
-import { isAdmin } from "./agent-auth.js";
+import { isAdmin, FLAIR_AGENT_USERNAME } from "./agent-auth.js";
 
 // --- Admin credentials ---
 // Admin auth is sourced exclusively from Harper's own environment variables
@@ -273,31 +273,31 @@ server.http(async (request: any, nextLayer: any) => {
   request.tpsAgentIsAdmin = await isAdmin(agentId);
 
   // Grant Harper-level permissions for the cryptographically-verified agent by
-  // setting request.user directly to the admin super_user.
+  // setting request.user directly. Setting request.user is the supported
+  // extension path (and the only one that works post-5.0.9: Harper resolves
+  // request.user from the Authorization header BEFORE this middleware runs, and
+  // a TPS-Ed25519 header matches no Basic/Bearer strategy, so request.user
+  // arrives null — see #456). getUser(name, null) looks up the record WITHOUT
+  // password validation, safe here because the Ed25519 signature already proved
+  // identity cryptographically.
   //
-  // Prior approach swapped the Authorization header to "Basic admin:<pass>" so
-  // Harper's auth pipeline would re-authenticate with full (HNSW-capable)
-  // permissions. That silently broke under Harper 5.0.9: its authentication
-  // layer (security/auth.ts `authentication()`) reads the Authorization header
-  // and resolves request.user BEFORE invoking this middleware via nextHandler.
-  // A TPS-Ed25519 header matches no Basic/Bearer strategy, so Harper sets
-  // request.user = null and never re-reads the header — our post-hoc swap was
-  // ignored, the request ran unauthenticated, and Harper surfaced it downstream
-  // as a generic "Login failed" 401. (Broke at the 2026-05-27 daemon restart,
-  // which loaded 5.0.9 fresh; the prior long-running process held an older
-  // in-memory Harper where the late header read still worked.)
-  //
-  // Setting request.user directly is the supported extension path and is honored
-  // by all downstream resources, including HNSW vector search. getUser(admin,
-  // null) looks up the admin record WITHOUT password validation — safe here
-  // because the Ed25519 signature verified above already proves agent identity
-  // cryptographically; no Basic credential is presented. This preserves the
-  // prior privilege model (verified agents act with admin perms; per-agent data
-  // isolation is still enforced downstream via the x-tps-agent header below).
+  // RESHAPE (auth-rbac): verified agents resolve to the least-privilege
+  // `flair-agent` user, NOT admin super_user. The flair_agent role grants exactly
+  // the table CRUD agents need; with no operations grant, /sql + /graphql become
+  // natively 403. Row-level data isolation stays enforced via x-tps-agent below.
+  // Transitional fallback: if the flair-agent user isn't provisioned yet (older
+  // instances pre-ensureFlairAgentUser), fall back to admin so agents keep
+  // working until the deploy provisions it — logged so the gap is visible.
   try {
-    request.user = await (server as any).getUser("admin", null, request);
+    const flairAgentUser = await (server as any).getUser(FLAIR_AGENT_USERNAME, null, request);
+    if (flairAgentUser) {
+      request.user = flairAgentUser;
+    } else {
+      console.warn(`[auth] '${FLAIR_AGENT_USERNAME}' user not provisioned — falling back to admin elevation for ${agentId}. Run flair init to provision the least-privilege user.`);
+      request.user = await (server as any).getUser("admin", null, request);
+    }
   } catch {
-    // Admin record unavailable — request proceeds as the verified tpsAgent
+    // User lookup unavailable — request proceeds as the verified tpsAgent
     // without elevated perms; resource-level scoping still applies.
   }
 

--- a/resources/auth-middleware.ts
+++ b/resources/auth-middleware.ts
@@ -1,6 +1,7 @@
 import { patchRecord } from "./table-helpers.js";
 import { server, databases } from "@harperfast/harper";
 import { getEmbedding } from "./embeddings-provider.js";
+import { isAdmin } from "./agent-auth.js";
 
 // --- Admin credentials ---
 // Admin auth is sourced exclusively from Harper's own environment variables
@@ -36,37 +37,10 @@ const WINDOW_MS = 30_000;
 const nonceSeen = new Map<string, number>();
 
 // ─── Admin resolution ─────────────────────────────────────────────────────────
-// Admin agents: from FLAIR_ADMIN_AGENTS env var (comma-separated) OR
-// Agent records with role === "admin". Both sources are OR-combined.
-// Result is cached for 60s to avoid per-request DB hits.
-
-let adminCacheExpiry = 0;
-let adminCache: Set<string> = new Set();
-
-async function getAdminAgents(): Promise<Set<string>> {
-  const now = Date.now();
-  if (now < adminCacheExpiry) return adminCache;
-
-  const from_env = (process.env.FLAIR_ADMIN_AGENTS ?? "")
-    .split(",").map((s) => s.trim()).filter(Boolean);
-
-  let from_db: string[] = [];
-  try {
-    const results = await (databases as any).flair.Agent.search([{ attribute: "role", value: "admin", condition: "equals" }]);
-    for await (const row of results) {
-      if (row?.id) from_db.push(row.id);
-    }
-  } catch { /* Agent table might not be populated yet */ }
-
-  adminCache = new Set([...from_env, ...from_db]);
-  adminCacheExpiry = now + 60_000;
-  return adminCache;
-}
-
-export async function isAdmin(agentId: string): Promise<boolean> {
-  const admins = await getAdminAgents();
-  return admins.has(agentId);
-}
+// `isAdmin` (FLAIR_ADMIN_AGENTS env + Agent role==="admin", 60s-cached) now lives
+// in agent-auth.ts as the single source of truth, imported above. During the
+// auth reshape this gate and the per-resource allow* helpers must agree on who's
+// an admin — one implementation guarantees they can't diverge.
 
 // ─── Crypto helpers ───────────────────────────────────────────────────────────
 

--- a/resources/auth-middleware.ts
+++ b/resources/auth-middleware.ts
@@ -291,7 +291,12 @@ server.http(async (request: any, nextLayer: any) => {
   try {
     const flairAgentUser = await (server as any).getUser(FLAIR_AGENT_USERNAME, null, request);
     if (flairAgentUser) {
-      request.user = flairAgentUser;
+      // Per-agent identity: keep the flair_agent role (table grants) but stamp the
+      // verified agentId as the username, so resources' allow* see the SPECIFIC
+      // agent via context.user.username and can enforce row-ownership natively
+      // (Harper passes context.user into allow*). Spread to avoid mutating the
+      // shared, cached flair-agent user object.
+      request.user = { ...flairAgentUser, username: agentId };
     } else {
       console.warn(`[auth] '${FLAIR_AGENT_USERNAME}' user not provisioned — falling back to admin elevation for ${agentId}. Run flair init to provision the least-privilege user.`);
       request.user = await (server as any).getUser("admin", null, request);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -899,6 +899,131 @@ export async function ensureFlairPairInitiatorRole(
   console.log(`Role '${ROLE_NAME}' updated ✓`);
 }
 
+// ─── flair_agent role ────────────────────────────────────────────────────────
+//
+// The auth reshape replaces the global gate's "verified agent borrows admin
+// super_user" elevation with a real, least-privilege Harper role. After an
+// agent's Ed25519 signature verifies, resources resolve the request to the
+// shared `flair_agent`-roled user instead of admin — so agents get exactly the
+// table CRUD below and nothing more. Critically: with no `super_user` and no
+// operations grants, /sql and /graphql become NATIVELY 403 for agents (the
+// raw-query block the gate hand-rolled is now enforced by Harper itself).
+//
+// Row-level ownership (an agent touches only its OWN memories/soul/events) is
+// NOT expressible in Harper's role model — it stays in each resource's allow*,
+// keyed on the Ed25519-verified agentId. So these per-table grants are the
+// coarse CRUD envelope; allow* is the ownership boundary inside it.
+//
+// VALIDATION GATES (must confirm against a live Harper before this role goes
+// live — flagged for Sherlock + the PR, not assumed):
+//   1. HNSW/vector search (SemanticSearch over Memory) works with table `read`
+//      alone — the old elevation comment claimed admin perms were needed for
+//      "HNSW-capable" access; confirm `read` suffices or widen precisely.
+//   2. Role table keys must EXACTLY match the @table names (Memory, OrgEvent,
+//      WorkspaceState, OAuthClient — NOT the logical Memory/Event/Workspace/OAuth
+//      shorthand the flair_pair_initiator spec used, which was harmless only
+//      because every grant there is false).
+//   3. Obs* writes: if the presence-emitter writes ObsAgentSnapshot AS the agent
+//      it needs insert/update — currently read-only here; confirm the writer's
+//      identity (system vs agent) and widen only if it's the agent.
+
+/** Canonical permission spec for flair_agent (least-privilege; real @table names). */
+const FLAIR_AGENT_PERMISSION = {
+  super_user: false,
+  cluster_user: false,
+  structure_user: false,
+  flair: {
+    tables: {
+      // Core agent-owned data — CRUD envelope; ownership enforced in allow*.
+      Memory:          { read: true,  insert: true,  update: true,  delete: true },
+      MemoryCandidate: { read: true,  insert: true,  update: true,  delete: true },
+      MemoryGrant:     { read: true,  insert: true,  update: true,  delete: true },
+      Soul:            { read: true,  insert: true,  update: true,  delete: false },
+      OrgEvent:        { read: true,  insert: true,  update: true,  delete: true },
+      WorkspaceState:  { read: true,  insert: true,  update: true,  delete: true },
+      Relationship:    { read: true,  insert: true,  update: true,  delete: true },
+      Integration:     { read: true,  insert: true,  update: true,  delete: true },
+      Credential:      { read: true,  insert: true,  update: true,  delete: true },
+      Presence:        { read: true,  insert: true,  update: true,  delete: false },
+      // Agent: read for discovery, update own card; creation/removal is admin.
+      Agent:           { read: true,  insert: false, update: true,  delete: false },
+      // Read-only reference data.
+      Instance:        { read: true,  insert: false, update: false, delete: false },
+      // Observatory read-models — public reads; writes are system-driven (gate 3).
+      ObsOffice:        { read: true, insert: false, update: false, delete: false },
+      ObsAgentSnapshot: { read: true, insert: false, update: false, delete: false },
+      ObsEventFeed:     { read: true, insert: false, update: false, delete: false },
+      // Federation / OAuth / IdP / internal — system + admin only; agents get none.
+      Peer:          { read: false, insert: false, update: false, delete: false },
+      PairingToken:  { read: false, insert: false, update: false, delete: false },
+      SyncLog:       { read: false, insert: false, update: false, delete: false },
+      OAuthClient:   { read: false, insert: false, update: false, delete: false },
+      OAuthToken:    { read: false, insert: false, update: false, delete: false },
+      OAuthAuthCode: { read: false, insert: false, update: false, delete: false },
+      IdpConfig:     { read: false, insert: false, update: false, delete: false },
+      IdJagReplay:   { read: false, insert: false, update: false, delete: false },
+    },
+  },
+} as const;
+
+/**
+ * Idempotently ensures the `flair_agent` role exists on the Harper instance at
+ * `opsUrl` with the canonical least-privilege spec. Same list/add/alter shape as
+ * ensureFlairPairInitiatorRole.
+ *
+ * - absent → `add_role`
+ * - exists with different permissions → `alter_role`
+ * - already matches → no-op
+ */
+export async function ensureFlairAgentRole(
+  opsUrl: string,
+  adminUser: string,
+  adminPass: string,
+): Promise<void> {
+  const ROLE_NAME = "flair_agent";
+
+  let roles: any[] = [];
+  try {
+    const result = await callOpsApi(opsUrl, { operation: "list_roles" }, adminUser, adminPass);
+    roles = Array.isArray(result) ? result : [];
+  } catch (err: unknown) {
+    const msg = err instanceof Error ? err.message : String(err);
+    throw new Error(`ensureFlairAgentRole: list_roles failed: ${msg}`);
+  }
+
+  const existing = roles.find(
+    (r: any) => r.role === ROLE_NAME || r.name === ROLE_NAME,
+  );
+
+  if (!existing) {
+    console.log(`Creating role '${ROLE_NAME}'...`);
+    await callOpsApi(opsUrl, {
+      operation: "add_role",
+      role: ROLE_NAME,
+      permission: FLAIR_AGENT_PERMISSION,
+    }, adminUser, adminPass);
+    console.log(`Role '${ROLE_NAME}' created ✓`);
+    return;
+  }
+
+  const existingPerm = existing.permission ?? existing.role?.permission;
+  const canonicalStr = JSON.stringify(FLAIR_AGENT_PERMISSION);
+  const existingStr  = JSON.stringify(existingPerm);
+
+  if (existingStr === canonicalStr) {
+    console.log(`Role '${ROLE_NAME}' already exists with correct permissions — skipping`);
+    return;
+  }
+
+  console.log(`Role '${ROLE_NAME}' exists but permissions differ — updating...`);
+  await callOpsApi(opsUrl, {
+    operation: "alter_role",
+    role: ROLE_NAME,
+    permission: FLAIR_AGENT_PERMISSION,
+  }, adminUser, adminPass);
+  console.log(`Role '${ROLE_NAME}' updated ✓`);
+}
+
 // ─── Upgrade presence probes ──────────────────────────────────────────────────
 //
 // `flair upgrade` previously called `npm list -g <pkg>` to detect the installed
@@ -1234,6 +1359,12 @@ program
         if (opts.remote) {
           await ensureFlairPairInitiatorRole(opsUrl, DEFAULT_ADMIN_USER, flairAdminPass);
         }
+
+        // Every flair instance has agents, so always provision the least-privilege
+        // flair_agent role. It replaces the auth gate's "verified agent borrows
+        // admin super_user" elevation: once resources resolve verified agents to
+        // this role, /sql and /graphql become natively 403 (no operations grant).
+        await ensureFlairAgentRole(opsUrl, DEFAULT_ADMIN_USER, flairAdminPass);
       } else {
         // ── Existing behavior: --admin-pass required for already-running Flair ──
         if (!opts.adminPass) {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -927,44 +927,53 @@ export async function ensureFlairPairInitiatorRole(
 //      it needs insert/update — currently read-only here; confirm the writer's
 //      identity (system vs agent) and widen only if it's the agent.
 
+// Harper 5.0.21 add_role requires an `attribute_permissions` array on EVERY table
+// grant (empty = no attribute-level restriction, so the table-level CRUD applies);
+// omitting it makes add_role reject the whole spec ("Missing 'attribute_permissions'
+// array"). Validated live against a spawned Harper. This helper guarantees the
+// array is never forgotten. Also: `cluster_user` is NOT a valid top-level key —
+// Harper reads unrecognized top-level keys as database names ("database
+// 'cluster_user' does not exist"); only super_user / structure_user are recognized.
+const grant = (read: boolean, insert: boolean, update: boolean, del: boolean) =>
+  ({ read, insert, update, delete: del, attribute_permissions: [] });
+
 /** Canonical permission spec for flair_agent (least-privilege; real @table names). */
 const FLAIR_AGENT_PERMISSION = {
   super_user: false,
-  cluster_user: false,
   structure_user: false,
   flair: {
     tables: {
       // Core agent-owned data — CRUD envelope; ownership enforced in allow*.
-      Memory:          { read: true,  insert: true,  update: true,  delete: true },
-      MemoryCandidate: { read: true,  insert: true,  update: true,  delete: true },
-      MemoryGrant:     { read: true,  insert: true,  update: true,  delete: true },
-      Soul:            { read: true,  insert: true,  update: true,  delete: false },
-      OrgEvent:        { read: true,  insert: true,  update: true,  delete: true },
-      WorkspaceState:  { read: true,  insert: true,  update: true,  delete: true },
-      Relationship:    { read: true,  insert: true,  update: true,  delete: true },
-      Integration:     { read: true,  insert: true,  update: true,  delete: true },
-      Credential:      { read: true,  insert: true,  update: true,  delete: true },
-      Presence:        { read: true,  insert: true,  update: true,  delete: false },
+      Memory:          grant(true,  true,  true,  true),
+      MemoryCandidate: grant(true,  true,  true,  true),
+      MemoryGrant:     grant(true,  true,  true,  true),
+      Soul:            grant(true,  true,  true,  false),
+      OrgEvent:        grant(true,  true,  true,  true),
+      WorkspaceState:  grant(true,  true,  true,  true),
+      Relationship:    grant(true,  true,  true,  true),
+      Integration:     grant(true,  true,  true,  true),
+      Credential:      grant(true,  true,  true,  true),
+      Presence:        grant(true,  true,  true,  false),
       // Agent: read for discovery, update own card; creation/removal is admin.
-      Agent:           { read: true,  insert: false, update: true,  delete: false },
+      Agent:           grant(true,  false, true,  false),
       // Read-only reference data.
-      Instance:        { read: true,  insert: false, update: false, delete: false },
+      Instance:        grant(true,  false, false, false),
       // Observatory read-models — public reads; writes are system-driven (gate 3).
-      ObsOffice:        { read: true, insert: false, update: false, delete: false },
-      ObsAgentSnapshot: { read: true, insert: false, update: false, delete: false },
-      ObsEventFeed:     { read: true, insert: false, update: false, delete: false },
+      ObsOffice:        grant(true, false, false, false),
+      ObsAgentSnapshot: grant(true, false, false, false),
+      ObsEventFeed:     grant(true, false, false, false),
       // Federation / OAuth / IdP / internal — system + admin only; agents get none.
-      Peer:          { read: false, insert: false, update: false, delete: false },
-      PairingToken:  { read: false, insert: false, update: false, delete: false },
-      SyncLog:       { read: false, insert: false, update: false, delete: false },
-      OAuthClient:   { read: false, insert: false, update: false, delete: false },
-      OAuthToken:    { read: false, insert: false, update: false, delete: false },
-      OAuthAuthCode: { read: false, insert: false, update: false, delete: false },
-      IdpConfig:     { read: false, insert: false, update: false, delete: false },
-      IdJagReplay:   { read: false, insert: false, update: false, delete: false },
+      Peer:          grant(false, false, false, false),
+      PairingToken:  grant(false, false, false, false),
+      SyncLog:       grant(false, false, false, false),
+      OAuthClient:   grant(false, false, false, false),
+      OAuthToken:    grant(false, false, false, false),
+      OAuthAuthCode: grant(false, false, false, false),
+      IdpConfig:     grant(false, false, false, false),
+      IdJagReplay:   grant(false, false, false, false),
     },
   },
-} as const;
+};
 
 /**
  * Idempotently ensures the `flair_agent` role exists on the Harper instance at
@@ -1022,6 +1031,60 @@ export async function ensureFlairAgentRole(
     permission: FLAIR_AGENT_PERMISSION,
   }, adminUser, adminPass);
   console.log(`Role '${ROLE_NAME}' updated ✓`);
+}
+
+/**
+ * Shared Harper user that verified Ed25519 agents are resolved to.
+ * MUST match FLAIR_AGENT_USERNAME in resources/agent-auth.ts (the gate side).
+ * Not imported from there because cli.ts is standalone and that module pulls in
+ * Harper's native bindings — kept as a cross-referenced literal instead.
+ */
+export const FLAIR_AGENT_USERNAME = "flair-agent";
+
+/**
+ * Idempotently ensures the shared `flair-agent` Harper user exists with the
+ * `flair_agent` role. Verified Ed25519 agents are resolved to THIS user
+ * (`getUser("flair-agent", null)` — no password check, identity already proven
+ * cryptographically), replacing the old `getUser("admin")` super_user elevation.
+ *
+ * The password is random and never used for authentication: the agent path
+ * resolves the user without it, and the auth gate's Basic path only accepts
+ * super_user / pair-bootstrap (a flair_agent Basic login is rejected there), so
+ * a Basic login as this user can't reach anything. Random + unused = safe.
+ *
+ * Row-level ownership stays in each resource's allow* (keyed on the verified
+ * agentId); this shared user only carries the flair_agent role's table grants.
+ */
+export async function ensureFlairAgentUser(
+  opsUrl: string,
+  adminUser: string,
+  adminPass: string,
+): Promise<void> {
+  const unusedPassword = randomBytes(32).toString("base64url");
+  try {
+    await callOpsApi(opsUrl, {
+      operation: "add_user",
+      username: FLAIR_AGENT_USERNAME,
+      password: unusedPassword,
+      role: "flair_agent",
+      active: true,
+    }, adminUser, adminPass);
+    console.log(`User '${FLAIR_AGENT_USERNAME}' created ✓`);
+  } catch (err: unknown) {
+    const msg = err instanceof Error ? err.message : String(err);
+    if (msg.includes("already exists") || msg.includes("duplicate")) {
+      // Idempotent: ensure the role is correct without churning the password.
+      await callOpsApi(opsUrl, {
+        operation: "alter_user",
+        username: FLAIR_AGENT_USERNAME,
+        role: "flair_agent",
+        active: true,
+      }, adminUser, adminPass);
+      console.log(`User '${FLAIR_AGENT_USERNAME}' already exists — role ensured ✓`);
+    } else {
+      throw err;
+    }
+  }
 }
 
 // ─── Upgrade presence probes ──────────────────────────────────────────────────
@@ -1360,11 +1423,15 @@ program
           await ensureFlairPairInitiatorRole(opsUrl, DEFAULT_ADMIN_USER, flairAdminPass);
         }
 
-        // Every flair instance has agents, so always provision the least-privilege
-        // flair_agent role. It replaces the auth gate's "verified agent borrows
-        // admin super_user" elevation: once resources resolve verified agents to
-        // this role, /sql and /graphql become natively 403 (no operations grant).
+        // Every flair instance has agents, so provision the least-privilege
+        // flair_agent role (idempotent, harmless until a user is assigned to it).
         await ensureFlairAgentRole(opsUrl, DEFAULT_ADMIN_USER, flairAdminPass);
+        // NOTE: ensureFlairAgentUser is intentionally NOT wired in yet. Provisioning
+        // the flair-agent user activates the gate's de-elevation (verified agents →
+        // flair_agent instead of admin), and that breaks any agent-facing CUSTOM
+        // resource still lacking an allow* (e.g. SemanticSearch relies on the admin
+        // super_user bypass today). Wire it in only once every agent-facing resource
+        // self-authorizes via allow*. Until then the gate falls back to admin.
       } else {
         // ── Existing behavior: --admin-pass required for already-running Flair ──
         if (!opts.adminPass) {

--- a/test/integration/flair-agent-deelevation.test.ts
+++ b/test/integration/flair-agent-deelevation.test.ts
@@ -96,6 +96,17 @@ describe("flair_agent de-elevation (verified agents act as flair-agent, not admi
     expect(Array.isArray(body.results)).toBe(true);
   }, 60_000);
 
+  test("SUFFICIENCY: agent POST /BootstrapMemories works under flair_agent (custom-resource allowCreate)", async () => {
+    const path = "/BootstrapMemories";
+    const res = await fetch(`${harper.httpURL}${path}`, {
+      method: "POST",
+      headers: { Authorization: ed25519Header(agent, "POST", path), "Content-Type": "application/json" },
+      body: JSON.stringify({ agentId: agent.id, maxTokens: 2000 }),
+    });
+    const text = await res.text();
+    expect(res.status, `bootstrap returned ${res.status}: ${text.slice(0, 300)}`).toBe(200);
+  }, 60_000);
+
   test("SUFFICIENCY: agent GET /Memory works under flair_agent (200)", async () => {
     const path = `/Memory/?agentId=${agent.id}`;
     const res = await fetch(`${harper.httpURL}${path}`, {

--- a/test/integration/flair-agent-deelevation.test.ts
+++ b/test/integration/flair-agent-deelevation.test.ts
@@ -231,12 +231,17 @@ describe("flair_agent de-elevation (verified agents act as flair-agent, not admi
     expect(res.status, `WS spoof returned ${res.status} (expected 403)`).toBe(403);
   }, 30_000);
 
-  // PRE-EXISTING gap (not a reshape regression): an agent can CREATE a Memory
-  // tagged with another agent's id. Resists the obvious fixes — a Table's allow*
-  // can't see the request in Harper's auth phase, and the gate's body-scoping
-  // (which works for WorkspaceState, proven by the guard above) silently fails to
-  // read the body for /Memory specifically (Memory's custom class changes how the
-  // request body stream is consumed). Needs deeper Harper-internals investigation;
-  // best solved alongside the gate-removal identity-attachment design. Surfaced.
-  test.todo("ISOLATION: agent cannot CREATE a Memory tagged as another agent (Memory body-read quirk — surfaced)");
+  // Now enforced natively in Memory.allowCreate via context.user.username (the
+  // per-agent identity the gate stamps). Proves the no-core-change approach: a
+  // per-agent request.user surfaces as context.user.username inside a Table allow*.
+  test("ISOLATION: agent cannot CREATE a Memory tagged as another agent (native allow* ownership)", async () => {
+    const id = `${other.id}-spoof-${Date.now()}`;
+    const path = `/Memory/${id}`;
+    const res = await fetch(`${harper.httpURL}${path}`, {
+      method: "PUT",
+      headers: { Authorization: ed25519Header(agent, "PUT", path), "Content-Type": "application/json" },
+      body: JSON.stringify({ id, agentId: other.id, content: "spoofed ownership attempt", durability: "standard" }),
+    });
+    expect(res.status, `spoofed create returned ${res.status} (expected 403)`).toBe(403);
+  }, 30_000);
 });

--- a/test/integration/flair-agent-deelevation.test.ts
+++ b/test/integration/flair-agent-deelevation.test.ts
@@ -79,13 +79,11 @@ describe("flair_agent de-elevation (verified agents act as flair-agent, not admi
 
   afterAll(async () => { if (harper) await stopHarper(harper); });
 
-  // PENDING per-resource migration: SemanticSearch is a CUSTOM Resource with no
-  // allow*, so under flair_agent (non-super_user) it 403s AccessViolation — it was
-  // relying on the admin super_user bypass. Un-skip once SemanticSearch (and the
-  // other agent-facing custom resources) gain an allow* that calls
-  // verifyAgentRequest. This is the coupling the de-elevation surfaced: agents
-  // can't be de-elevated until every custom resource self-authorizes.
-  test.skip("SUFFICIENCY: agent HNSW q-search works under flair_agent (needs SemanticSearch.allow*)", async () => {
+  // SemanticSearch now self-authorizes via allowCreate→verifyAgentRequest, so a
+  // de-elevated flair_agent can run HNSW search (the role's Memory.read grant
+  // covers the internal vector reads). Regression guard for the custom-resource
+  // coupling the de-elevation surfaced.
+  test("SUFFICIENCY: agent HNSW q-search works under flair_agent (SemanticSearch.allowCreate)", async () => {
     const path = "/SemanticSearch";
     const res = await fetch(`${harper.httpURL}${path}`, {
       method: "POST",

--- a/test/integration/flair-agent-deelevation.test.ts
+++ b/test/integration/flair-agent-deelevation.test.ts
@@ -1,0 +1,156 @@
+// flair_agent de-elevation integration test (auth-rbac reshape).
+//
+// Proves the security-critical claim of the reshape: a verified Ed25519 agent
+// resolved to the least-privilege `flair-agent` user (instead of admin
+// super_user) can STILL do everything a real agent needs — HNSW semantic
+// search, Memory read/write — i.e. the flair_agent role grants are sufficient.
+// If any of these regress to 401/403, the grant spec needs widening, and THIS
+// test is where we find out against a real Harper, not in production.
+//
+// Unlike ed25519-auth-hnsw.test.ts (which leaves flair-agent unprovisioned, so
+// the gate falls back to admin), this test provisions the role + user via the
+// real ensureFlairAgentRole/ensureFlairAgentUser, so the gate resolves agents to
+// flair-agent and these assertions exercise the de-elevated path.
+import { describe, expect, test, beforeAll, afterAll } from "bun:test";
+import nacl from "tweetnacl";
+import { randomUUID } from "node:crypto";
+import { startHarper, stopHarper, HarperInstance } from "../helpers/harper-lifecycle";
+import { ensureFlairAgentRole, ensureFlairAgentUser } from "../../src/cli";
+
+interface TestAgent { id: string; publicKey: string; secretKey: Uint8Array; }
+
+function mkAgent(id: string): TestAgent {
+  const kp = nacl.sign.keyPair();
+  return { id, publicKey: Buffer.from(kp.publicKey).toString("base64"), secretKey: kp.secretKey };
+}
+
+function ed25519Header(agent: TestAgent, method: string, path: string): string {
+  const ts = Date.now().toString();
+  const nonce = randomUUID();
+  const payload = `${agent.id}:${ts}:${nonce}:${method}:${path}`;
+  const sig = nacl.sign.detached(new TextEncoder().encode(payload), agent.secretKey);
+  return `TPS-Ed25519 ${agent.id}:${ts}:${nonce}:${Buffer.from(sig).toString("base64")}`;
+}
+
+async function adminOp(harper: HarperInstance, op: Record<string, any>): Promise<Response> {
+  return fetch(harper.opsURL, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: "Basic " + btoa(`${harper.admin.username}:${harper.admin.password}`),
+    },
+    body: JSON.stringify(op),
+  });
+}
+
+let harper: HarperInstance;
+const agent = mkAgent("deelev-agent");
+const other = mkAgent("deelev-other");
+
+describe("flair_agent de-elevation (verified agents act as flair-agent, not admin)", () => {
+  beforeAll(async () => {
+    harper = await startHarper();
+
+    // Provision the least-privilege role + shared user via the REAL functions,
+    // so the gate resolves verified agents to flair-agent.
+    await ensureFlairAgentRole(harper.opsURL, harper.admin.username, harper.admin.password);
+    await ensureFlairAgentUser(harper.opsURL, harper.admin.username, harper.admin.password);
+
+    for (const a of [agent, other]) {
+      const res = await adminOp(harper, {
+        operation: "insert", database: "flair", table: "Agent",
+        records: [{ id: a.id, name: a.id, role: "agent", publicKey: a.publicKey, createdAt: new Date().toISOString() }],
+      });
+      expect(res.status).toBe(200);
+    }
+
+    // Seed memories for `agent` so HNSW has candidates.
+    for (let i = 0; i < 5; i++) {
+      const id = `${agent.id}-${i}`;
+      const path = `/Memory/${id}`;
+      const r = await fetch(`${harper.httpURL}${path}`, {
+        method: "PUT",
+        headers: { Authorization: ed25519Header(agent, "PUT", path), "Content-Type": "application/json" },
+        body: JSON.stringify({ id, agentId: agent.id, content: `note ${i}: retrieval and vector search`, durability: "standard" }),
+      });
+      if (![200, 204].includes(r.status)) throw new Error(`seed PUT ${id} → ${r.status}: ${await r.text()}`);
+    }
+  }, 180_000);
+
+  afterAll(async () => { if (harper) await stopHarper(harper); });
+
+  // PENDING per-resource migration: SemanticSearch is a CUSTOM Resource with no
+  // allow*, so under flair_agent (non-super_user) it 403s AccessViolation — it was
+  // relying on the admin super_user bypass. Un-skip once SemanticSearch (and the
+  // other agent-facing custom resources) gain an allow* that calls
+  // verifyAgentRequest. This is the coupling the de-elevation surfaced: agents
+  // can't be de-elevated until every custom resource self-authorizes.
+  test.skip("SUFFICIENCY: agent HNSW q-search works under flair_agent (needs SemanticSearch.allow*)", async () => {
+    const path = "/SemanticSearch";
+    const res = await fetch(`${harper.httpURL}${path}`, {
+      method: "POST",
+      headers: { Authorization: ed25519Header(agent, "POST", path), "Content-Type": "application/json" },
+      body: JSON.stringify({ agentId: agent.id, q: "vector search retrieval", limit: 5 }),
+    });
+    const text = await res.text();
+    expect(res.status, `q-search returned ${res.status}: ${text.slice(0, 300)}`).toBe(200);
+    const body: any = JSON.parse(text);
+    expect(Array.isArray(body.results)).toBe(true);
+  }, 60_000);
+
+  test("SUFFICIENCY: agent GET /Memory works under flair_agent (200)", async () => {
+    const path = `/Memory/?agentId=${agent.id}`;
+    const res = await fetch(`${harper.httpURL}${path}`, {
+      headers: { Authorization: ed25519Header(agent, "GET", path) },
+    });
+    const text = await res.text();
+    expect(res.status, `GET /Memory returned ${res.status}: ${text.slice(0, 300)}`).toBe(200);
+  }, 30_000);
+
+  test("SUFFICIENCY: agent PUT own Memory works under flair_agent (insert/update grant)", async () => {
+    const id = `${agent.id}-put-check`;
+    const path = `/Memory/${id}`;
+    const res = await fetch(`${harper.httpURL}${path}`, {
+      method: "PUT",
+      headers: { Authorization: ed25519Header(agent, "PUT", path), "Content-Type": "application/json" },
+      body: JSON.stringify({ id, agentId: agent.id, content: "own write under flair_agent", durability: "standard" }),
+    });
+    expect([200, 204], `PUT own Memory returned ${res.status}: ${(await res.text()).slice(0, 200)}`).toContain(res.status);
+  }, 30_000);
+
+  test("DE-ELEVATION: agent POST /sql is forbidden (flair_agent has no operations grant)", async () => {
+    const path = "/sql";
+    const res = await fetch(`${harper.httpURL}${path}`, {
+      method: "POST",
+      headers: { Authorization: ed25519Header(agent, "POST", path), "Content-Type": "application/json" },
+      body: JSON.stringify({ operation: "sql", sql: "SELECT * FROM flair.Memory LIMIT 1" }),
+    });
+    // Agents are no longer admin → raw query endpoints denied (gate 403 + native).
+    expect([401, 403], `/sql returned ${res.status} (expected denied)`).toContain(res.status);
+  }, 30_000);
+
+  test("ISOLATION: agent cannot modify another agent's EXISTING Memory (ownership enforced)", async () => {
+    // `other` creates a memory it owns...
+    const id = `${other.id}-owned`;
+    const path = `/Memory/${id}`;
+    const create = await fetch(`${harper.httpURL}${path}`, {
+      method: "PUT",
+      headers: { Authorization: ed25519Header(other, "PUT", path), "Content-Type": "application/json" },
+      body: JSON.stringify({ id, agentId: other.id, content: "owned by other", durability: "standard" }),
+    });
+    expect([200, 204], `other's own create returned ${create.status}`).toContain(create.status);
+
+    // ...and `agent` must not be able to overwrite it (existing-record ownership).
+    const attack = await fetch(`${harper.httpURL}${path}`, {
+      method: "PUT",
+      headers: { Authorization: ed25519Header(agent, "PUT", path), "Content-Type": "application/json" },
+      body: JSON.stringify({ id, agentId: other.id, content: "hijacked by agent", durability: "standard" }),
+    });
+    expect(attack.status, `cross-agent overwrite returned ${attack.status} (expected 403)`).toBe(403);
+  }, 30_000);
+
+  // PENDING per-resource migration: creating a NEW Memory tagged with another
+  // agent's agentId is NOT blocked today (the gate only guards existing-record
+  // ownership). Memory.allowCreate must enforce body.agentId === verified agent.
+  test.todo("ISOLATION: agent cannot CREATE a Memory tagged as another agent (needs Memory.allowCreate)");
+});

--- a/test/integration/flair-agent-deelevation.test.ts
+++ b/test/integration/flair-agent-deelevation.test.ts
@@ -107,6 +107,17 @@ describe("flair_agent de-elevation (verified agents act as flair-agent, not admi
     expect(res.status, `bootstrap returned ${res.status}: ${text.slice(0, 300)}`).toBe(200);
   }, 60_000);
 
+  test("SUFFICIENCY: agent POST /FeedMemories works under flair_agent (custom-resource write path)", async () => {
+    const path = "/FeedMemories";
+    const res = await fetch(`${harper.httpURL}${path}`, {
+      method: "POST",
+      headers: { Authorization: ed25519Header(agent, "POST", path), "Content-Type": "application/json" },
+      body: JSON.stringify({ agentId: agent.id, content: "fed via MemoryFeed under flair_agent" }),
+    });
+    const text = await res.text();
+    expect([200, 201, 204], `MemoryFeed returned ${res.status}: ${text.slice(0, 300)}`).toContain(res.status);
+  }, 30_000);
+
   test("SUFFICIENCY: agent GET /Memory works under flair_agent (200)", async () => {
     const path = `/Memory/?agentId=${agent.id}`;
     const res = await fetch(`${harper.httpURL}${path}`, {

--- a/test/integration/flair-agent-deelevation.test.ts
+++ b/test/integration/flair-agent-deelevation.test.ts
@@ -138,6 +138,24 @@ describe("flair_agent de-elevation (verified agents act as flair-agent, not admi
     expect([200, 204], `PUT own Memory returned ${res.status}: ${(await res.text()).slice(0, 200)}`).toContain(res.status);
   }, 30_000);
 
+  test("SUFFICIENCY: agent GET /WorkspaceLatest authorized under flair_agent (allowRead, not 403)", async () => {
+    const path = `/WorkspaceLatest/${agent.id}`;
+    const res = await fetch(`${harper.httpURL}${path}`, {
+      headers: { Authorization: ed25519Header(agent, "GET", path) },
+    });
+    // allowRead fixes the AccessViolation 403 the custom resource would otherwise
+    // throw under flair_agent. 200/404 (data or none) both mean auth passed.
+    expect([401, 403], `WorkspaceLatest returned ${res.status}`).not.toContain(res.status);
+  }, 30_000);
+
+  test("SUFFICIENCY: agent GET /OrgEventCatchup authorized under flair_agent (allowRead, not 403)", async () => {
+    const path = `/OrgEventCatchup/${agent.id}`;
+    const res = await fetch(`${harper.httpURL}${path}`, {
+      headers: { Authorization: ed25519Header(agent, "GET", path) },
+    });
+    expect([401, 403], `OrgEventCatchup returned ${res.status}`).not.toContain(res.status);
+  }, 30_000);
+
   test("DE-ELEVATION: agent POST /sql is forbidden (flair_agent has no operations grant)", async () => {
     const path = "/sql";
     const res = await fetch(`${harper.httpURL}${path}`, {

--- a/test/integration/flair-agent-deelevation.test.ts
+++ b/test/integration/flair-agent-deelevation.test.ts
@@ -220,8 +220,23 @@ describe("flair_agent de-elevation (verified agents act as flair-agent, not admi
     expect(attack.status, `cross-agent overwrite returned ${attack.status} (expected 403)`).toBe(403);
   }, 30_000);
 
-  // PENDING per-resource migration: creating a NEW Memory tagged with another
-  // agent's agentId is NOT blocked today (the gate only guards existing-record
-  // ownership). Memory.allowCreate must enforce body.agentId === verified agent.
-  test.todo("ISOLATION: agent cannot CREATE a Memory tagged as another agent (needs Memory.allowCreate)");
+  test("ISOLATION: agent cannot write another agent's WorkspaceState (body-scoping regression guard)", async () => {
+    const id = `${other.id}-ws-spoof`;
+    const path = `/WorkspaceState/${id}`;
+    const res = await fetch(`${harper.httpURL}${path}`, {
+      method: "PUT",
+      headers: { Authorization: ed25519Header(agent, "PUT", path), "Content-Type": "application/json" },
+      body: JSON.stringify({ id, agentId: other.id, state: "spoof" }),
+    });
+    expect(res.status, `WS spoof returned ${res.status} (expected 403)`).toBe(403);
+  }, 30_000);
+
+  // PRE-EXISTING gap (not a reshape regression): an agent can CREATE a Memory
+  // tagged with another agent's id. Resists the obvious fixes — a Table's allow*
+  // can't see the request in Harper's auth phase, and the gate's body-scoping
+  // (which works for WorkspaceState, proven by the guard above) silently fails to
+  // read the body for /Memory specifically (Memory's custom class changes how the
+  // request body stream is consumed). Needs deeper Harper-internals investigation;
+  // best solved alongside the gate-removal identity-attachment design. Surfaced.
+  test.todo("ISOLATION: agent cannot CREATE a Memory tagged as another agent (Memory body-read quirk — surfaced)");
 });

--- a/test/integration/flair-agent-deelevation.test.ts
+++ b/test/integration/flair-agent-deelevation.test.ts
@@ -244,4 +244,28 @@ describe("flair_agent de-elevation (verified agents act as flair-agent, not admi
     });
     expect(res.status, `spoofed create returned ${res.status} (expected 403)`).toBe(403);
   }, 30_000);
+
+  test("ANONYMOUS: no-auth GET /Memory is denied (anonymous HTTP rejected)", async () => {
+    const res = await fetch(`${harper.httpURL}/Memory/?agentId=${agent.id}`);
+    expect([401, 403], `anon GET /Memory returned ${res.status} (expected 401/403)`).toContain(res.status);
+  }, 30_000);
+
+  test("ANONYMOUS: no-auth POST /SemanticSearch is denied (anonymous HTTP rejected)", async () => {
+    const res = await fetch(`${harper.httpURL}/SemanticSearch`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ agentId: agent.id, q: "anything", limit: 1 }),
+    });
+    expect([401, 403], `anon POST /SemanticSearch returned ${res.status} (expected 401/403)`).toContain(res.status);
+  }, 30_000);
+
+  test("ANONYMOUS: no-auth PUT /Memory is denied (anonymous write rejected)", async () => {
+    const id = `anon-write-${Date.now()}`;
+    const res = await fetch(`${harper.httpURL}/Memory/${id}`, {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ id, agentId: agent.id, content: "anon write attempt", durability: "standard" }),
+    });
+    expect([401, 403], `anon PUT /Memory returned ${res.status} (expected 401/403)`).toContain(res.status);
+  }, 30_000);
 });

--- a/test/integration/flair-agent-deelevation.test.ts
+++ b/test/integration/flair-agent-deelevation.test.ts
@@ -156,6 +156,11 @@ describe("flair_agent de-elevation (verified agents act as flair-agent, not admi
     expect([401, 403], `OrgEventCatchup returned ${res.status}`).not.toContain(res.status);
   }, 30_000);
 
+  test("PUBLIC: GET /AgentCard needs no auth (allowRead=true; survives gate removal)", async () => {
+    const res = await fetch(`${harper.httpURL}/AgentCard/${agent.id}`);
+    expect([401, 403], `AgentCard (no auth) returned ${res.status}`).not.toContain(res.status);
+  }, 30_000);
+
   test("DE-ELEVATION: agent POST /sql is forbidden (flair_agent has no operations grant)", async () => {
     const path = "/sql";
     const res = await fetch(`${harper.httpURL}${path}`, {

--- a/test/integration/flair-agent-deelevation.test.ts
+++ b/test/integration/flair-agent-deelevation.test.ts
@@ -46,6 +46,7 @@ async function adminOp(harper: HarperInstance, op: Record<string, any>): Promise
 let harper: HarperInstance;
 const agent = mkAgent("deelev-agent");
 const other = mkAgent("deelev-other");
+const adminAgent = mkAgent("deelev-admin");
 
 describe("flair_agent de-elevation (verified agents act as flair-agent, not admin)", () => {
   beforeAll(async () => {
@@ -63,6 +64,13 @@ describe("flair_agent de-elevation (verified agents act as flair-agent, not admi
       });
       expect(res.status).toBe(200);
     }
+    // Admin agent (role:"admin" → isAdmin via the Agent-table source) for the
+    // admin-only resource assertions.
+    const adminRes = await adminOp(harper, {
+      operation: "insert", database: "flair", table: "Agent",
+      records: [{ id: adminAgent.id, name: adminAgent.id, role: "admin", publicKey: adminAgent.publicKey, createdAt: new Date().toISOString() }],
+    });
+    expect(adminRes.status).toBe(200);
 
     // Seed memories for `agent` so HNSW has candidates.
     for (let i = 0; i < 5; i++) {
@@ -159,6 +167,26 @@ describe("flair_agent de-elevation (verified agents act as flair-agent, not admi
   test("PUBLIC: GET /AgentCard needs no auth (allowRead=true; survives gate removal)", async () => {
     const res = await fetch(`${harper.httpURL}/AgentCard/${agent.id}`);
     expect([401, 403], `AgentCard (no auth) returned ${res.status}`).not.toContain(res.status);
+  }, 30_000);
+
+  test("ADMIN-ONLY: non-admin agent POST /MemoryReindex is denied (allowCreate → isAdmin)", async () => {
+    const path = "/MemoryReindex";
+    const res = await fetch(`${harper.httpURL}${path}`, {
+      method: "POST",
+      headers: { Authorization: ed25519Header(agent, "POST", path), "Content-Type": "application/json" },
+      body: JSON.stringify({ dryRun: true }),
+    });
+    expect(res.status, `non-admin /MemoryReindex returned ${res.status} (expected 403)`).toBe(403);
+  }, 30_000);
+
+  test("ADMIN-ONLY: admin agent POST /MemoryReindex is authorized (allowCreate permits admins)", async () => {
+    const path = "/MemoryReindex";
+    const res = await fetch(`${harper.httpURL}${path}`, {
+      method: "POST",
+      headers: { Authorization: ed25519Header(adminAgent, "POST", path), "Content-Type": "application/json" },
+      body: JSON.stringify({ dryRun: true }),
+    });
+    expect([401, 403], `admin /MemoryReindex returned ${res.status} (expected authorized)`).not.toContain(res.status);
   }, 30_000);
 
   test("DE-ELEVATION: agent POST /sql is forbidden (flair_agent has no operations grant)", async () => {

--- a/test/unit/allow-helpers.test.ts
+++ b/test/unit/allow-helpers.test.ts
@@ -1,0 +1,74 @@
+import { mock, describe, it, expect } from "bun:test";
+
+// agent-auth.ts imports `databases` from @harperfast/harper (throws outside a
+// Harper runtime). Mock it — the annotation/internal/anonymous paths exercised
+// here never reach databases (they return before any Agent.get).
+mock.module("@harperfast/harper", () => ({ databases: {} }));
+
+const { allowVerified, allowAdmin } = await import("../../resources/agent-auth.ts");
+
+// Belt-and-suspenders for auth: the two allow* helpers every agent-facing /
+// admin-only resource delegates to. resolveAgentAuth's verdict logic is covered
+// in resolve-agent-auth.test.ts; here we pin the AUTHORIZATION truth table the
+// resources actually depend on — especially that admin-only (allowAdmin) DENIES a
+// non-admin agent (privilege-escalation guard) and that BOTH deny anonymous.
+
+const reqNoAuth = { headers: { get: () => undefined } };
+
+const CONTEXTS = {
+  internal:          undefined,                                              // no request → trusted in-process
+  anonymousMarker:   { tpsAnonymous: true },                                 // non-rejecting gate marked it anon
+  anonymousNoAuth:   reqNoAuth,                                              // raw request, no valid agent
+  agentNonAdmin:     { tpsAgent: "agent-x", tpsAgentIsAdmin: false },        // verified non-admin agent
+  agentAdmin:        { tpsAgent: "admin-x", tpsAgentIsAdmin: true },         // verified admin agent
+  superUser:         { user: { username: "admin", role: { permission: { super_user: true } } } }, // Basic super_user
+  perAgentUser:      { user: { username: "agent-y", role: { permission: {} } } }, // de-elevated per-agent user
+} as const;
+
+describe("allowVerified — agent-facing gate (deny anonymous, permit verified/admin/internal)", () => {
+  it("permits trusted internal calls", async () => {
+    expect(await allowVerified(CONTEXTS.internal)).toBe(true);
+  });
+  it("DENIES anonymous (explicit marker)", async () => {
+    expect(await allowVerified(CONTEXTS.anonymousMarker)).toBe(false);
+  });
+  it("DENIES anonymous (request with no valid agent)", async () => {
+    expect(await allowVerified(CONTEXTS.anonymousNoAuth)).toBe(false);
+  });
+  it("permits a verified non-admin agent", async () => {
+    expect(await allowVerified(CONTEXTS.agentNonAdmin)).toBe(true);
+  });
+  it("permits a verified admin agent", async () => {
+    expect(await allowVerified(CONTEXTS.agentAdmin)).toBe(true);
+  });
+  it("permits Basic super_user", async () => {
+    expect(await allowVerified(CONTEXTS.superUser)).toBe(true);
+  });
+  it("permits a de-elevated per-agent user", async () => {
+    expect(await allowVerified(CONTEXTS.perAgentUser)).toBe(true);
+  });
+});
+
+describe("allowAdmin — admin-only gate (deny anonymous AND non-admin agents)", () => {
+  it("permits trusted internal calls", async () => {
+    expect(await allowAdmin(CONTEXTS.internal)).toBe(true);
+  });
+  it("DENIES anonymous (explicit marker)", async () => {
+    expect(await allowAdmin(CONTEXTS.anonymousMarker)).toBe(false);
+  });
+  it("DENIES anonymous (request with no valid agent)", async () => {
+    expect(await allowAdmin(CONTEXTS.anonymousNoAuth)).toBe(false);
+  });
+  it("DENIES a verified NON-admin agent (privilege-escalation guard)", async () => {
+    expect(await allowAdmin(CONTEXTS.agentNonAdmin)).toBe(false);
+  });
+  it("DENIES a de-elevated per-agent (non-admin) user", async () => {
+    expect(await allowAdmin(CONTEXTS.perAgentUser)).toBe(false);
+  });
+  it("permits a verified admin agent", async () => {
+    expect(await allowAdmin(CONTEXTS.agentAdmin)).toBe(true);
+  });
+  it("permits Basic super_user", async () => {
+    expect(await allowAdmin(CONTEXTS.superUser)).toBe(true);
+  });
+});

--- a/test/unit/flair-agent-role.test.ts
+++ b/test/unit/flair-agent-role.test.ts
@@ -76,11 +76,20 @@ describe("ensureFlairAgentRole — security invariants of the grant spec", () =>
     return capturedBodies[1].permission;
   }
 
-  it("never grants super_user / cluster_user / structure_user", async () => {
+  it("never grants super_user/structure_user, and omits cluster_user (Harper misreads it as a db)", async () => {
     const perm = await captureSpec();
     expect(perm.super_user).toBe(false);
-    expect(perm.cluster_user).toBe(false);
     expect(perm.structure_user).toBe(false);
+    // cluster_user must NOT be present — Harper reads unknown top-level keys as
+    // database names and rejects add_role ("database 'cluster_user' does not exist").
+    expect(perm.cluster_user).toBeUndefined();
+  });
+
+  it("every table grant carries an attribute_permissions array (add_role requires it)", async () => {
+    const tables = (await captureSpec()).flair.tables;
+    for (const [name, t] of Object.entries<any>(tables)) {
+      expect(Array.isArray(t.attribute_permissions), `${name} missing attribute_permissions array`).toBe(true);
+    }
   });
 
   it("carries no operations grant → /sql and /graphql stay natively 403 for agents", async () => {
@@ -106,12 +115,12 @@ describe("ensureFlairAgentRole — security invariants of the grant spec", () =>
   it("lets agents CRUD their own core data but locks federation/oauth/idp internals", async () => {
     const tables = (await captureSpec()).flair.tables;
     // Agent-owned data: writable (row-ownership is enforced in allow*, not here).
-    expect(tables.Memory).toEqual({ read: true, insert: true, update: true, delete: true });
+    expect(tables.Memory).toEqual({ read: true, insert: true, update: true, delete: true, attribute_permissions: [] });
     expect(tables.OrgEvent.insert).toBe(true);
     expect(tables.WorkspaceState.update).toBe(true);
     // System/admin-only tables: no access at all.
     for (const t of ["Peer", "PairingToken", "SyncLog", "OAuthClient", "OAuthToken", "IdpConfig", "IdJagReplay"]) {
-      expect(tables[t]).toEqual({ read: false, insert: false, update: false, delete: false });
+      expect(tables[t]).toEqual({ read: false, insert: false, update: false, delete: false, attribute_permissions: [] });
     }
   });
 });

--- a/test/unit/flair-agent-role.test.ts
+++ b/test/unit/flair-agent-role.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect, mock, beforeEach, afterEach } from "bun:test";
+import { ensureFlairAgentRole } from "../../src/cli";
+
+// Mirrors the federation-pair-role.test.ts pattern: a sequenced global-fetch mock
+// that captures the ops-API bodies ensureFlairAgentRole sends.
+
+const OPS_URL = "http://localhost:9925";
+const ADMIN = "admin";
+const PASS = "secret";
+const ROLE_NAME = "flair_agent";
+
+let capturedBodies: Array<Record<string, any>> = [];
+const origFetch = globalThis.fetch;
+
+beforeEach(() => { capturedBodies = []; });
+afterEach(() => { globalThis.fetch = origFetch; });
+
+function installFetch(responses: Array<{ ok: boolean; body: unknown }>) {
+  capturedBodies = []; // each install starts a fresh capture window
+  let idx = 0;
+  globalThis.fetch = mock(async (_url: string, init?: RequestInit) => {
+    const body = init?.body ? JSON.parse(init.body as string) : {};
+    capturedBodies.push(body);
+    const resp = responses[idx++];
+    if (!resp) throw new Error(`Unexpected fetch call #${idx}`);
+    return {
+      ok: resp.ok,
+      status: resp.ok ? 200 : 500,
+      json: async () => resp.body,
+      text: async () => JSON.stringify(resp.body),
+    } as unknown as Response;
+  }) as any;
+}
+
+describe("ensureFlairAgentRole — idempotency", () => {
+  it("calls add_role when flair_agent does not exist", async () => {
+    installFetch([
+      { ok: true, body: [] },          // list_roles → empty
+      { ok: true, body: { ok: true } }, // add_role
+    ]);
+    await ensureFlairAgentRole(OPS_URL, ADMIN, PASS);
+    expect(capturedBodies).toHaveLength(2);
+    expect(capturedBodies[0].operation).toBe("list_roles");
+    expect(capturedBodies[1].operation).toBe("add_role");
+    expect(capturedBodies[1].role).toBe(ROLE_NAME);
+  });
+
+  it("is a no-op when the role already matches the canonical spec", async () => {
+    // First call to capture the canonical permission the impl sends...
+    installFetch([{ ok: true, body: [] }, { ok: true, body: { ok: true } }]);
+    await ensureFlairAgentRole(OPS_URL, ADMIN, PASS);
+    const canonical = capturedBodies[1].permission;
+
+    // ...then prove an existing role with that exact spec is left untouched.
+    installFetch([{ ok: true, body: [{ role: ROLE_NAME, permission: canonical }] }]);
+    await ensureFlairAgentRole(OPS_URL, ADMIN, PASS);
+    expect(capturedBodies).toHaveLength(1);
+    expect(capturedBodies[0].operation).toBe("list_roles");
+  });
+
+  it("calls alter_role when an existing role has different permissions", async () => {
+    installFetch([
+      { ok: true, body: [{ role: ROLE_NAME, permission: { super_user: true } }] },
+      { ok: true, body: { ok: true } },
+    ]);
+    await ensureFlairAgentRole(OPS_URL, ADMIN, PASS);
+    expect(capturedBodies[1].operation).toBe("alter_role");
+    expect(capturedBodies[1].role).toBe(ROLE_NAME);
+  });
+});
+
+describe("ensureFlairAgentRole — security invariants of the grant spec", () => {
+  async function captureSpec(): Promise<any> {
+    installFetch([{ ok: true, body: [] }, { ok: true, body: { ok: true } }]);
+    await ensureFlairAgentRole(OPS_URL, ADMIN, PASS);
+    return capturedBodies[1].permission;
+  }
+
+  it("never grants super_user / cluster_user / structure_user", async () => {
+    const perm = await captureSpec();
+    expect(perm.super_user).toBe(false);
+    expect(perm.cluster_user).toBe(false);
+    expect(perm.structure_user).toBe(false);
+  });
+
+  it("carries no operations grant → /sql and /graphql stay natively 403 for agents", async () => {
+    const perm = await captureSpec();
+    // No top-level operation/operations permission of any kind.
+    expect(perm.operation).toBeUndefined();
+    expect(perm.operations).toBeUndefined();
+  });
+
+  it("keys grants on real @table names, not the pair-initiator shorthand", async () => {
+    const perm = await captureSpec();
+    const tables = perm.flair.tables;
+    // Real names present...
+    for (const t of ["Memory", "OrgEvent", "WorkspaceState", "OAuthClient", "Soul"]) {
+      expect(tables[t]).toBeDefined();
+    }
+    // ...and the misleading shorthand the all-false pair role used is absent.
+    for (const t of ["Event", "Workspace", "OAuth"]) {
+      expect(tables[t]).toBeUndefined();
+    }
+  });
+
+  it("lets agents CRUD their own core data but locks federation/oauth/idp internals", async () => {
+    const tables = (await captureSpec()).flair.tables;
+    // Agent-owned data: writable (row-ownership is enforced in allow*, not here).
+    expect(tables.Memory).toEqual({ read: true, insert: true, update: true, delete: true });
+    expect(tables.OrgEvent.insert).toBe(true);
+    expect(tables.WorkspaceState.update).toBe(true);
+    // System/admin-only tables: no access at all.
+    for (const t of ["Peer", "PairingToken", "SyncLog", "OAuthClient", "OAuthToken", "IdpConfig", "IdJagReplay"]) {
+      expect(tables[t]).toEqual({ read: false, insert: false, update: false, delete: false });
+    }
+  });
+});

--- a/test/unit/resolve-agent-auth.test.ts
+++ b/test/unit/resolve-agent-auth.test.ts
@@ -1,0 +1,36 @@
+import { mock, describe, it, expect } from "bun:test";
+
+// agent-auth.ts imports `databases` from @harperfast/harper, whose module chain
+// throws when loaded outside a Harper runtime. Mock it — resolveAgentAuth's
+// internal/anonymous paths never touch databases (they return before Agent.get).
+mock.module("@harperfast/harper", () => ({ databases: {} }));
+
+const { resolveAgentAuth } = await import("../../resources/agent-auth.ts");
+
+// The internal-vs-anonymous distinction is the security-critical part: a missing
+// request = trusted in-process call; a request with no valid agent = anonymous
+// HTTP caller that MUST be denied. (The "agent" verdict needs a real Agent record
+// + signature, covered in the integration harness.)
+
+function reqWithAuth(header: string) {
+  return { headers: { get: (n: string) => (n === "authorization" ? header : undefined) } };
+}
+
+describe("resolveAgentAuth — internal vs anonymous", () => {
+  it("no request context → internal (trusted in-process call)", async () => {
+    expect(await resolveAgentAuth(undefined)).toEqual({ kind: "internal" });
+    expect(await resolveAgentAuth(null)).toEqual({ kind: "internal" });
+  });
+
+  it("request with NO Authorization header → anonymous (deny)", async () => {
+    expect(await resolveAgentAuth(reqWithAuth(""))).toEqual({ kind: "anonymous" });
+  });
+
+  it("request with a non-TPS scheme → anonymous (deny)", async () => {
+    expect(await resolveAgentAuth(reqWithAuth("Basic dXNlcjpwYXNz"))).toEqual({ kind: "anonymous" });
+  });
+
+  it("request with a malformed TPS-Ed25519 header → anonymous (deny)", async () => {
+    expect(await resolveAgentAuth(reqWithAuth("TPS-Ed25519 garbage-no-colons"))).toEqual({ kind: "anonymous" });
+  });
+});

--- a/test/unit/resolve-agent-auth.test.ts
+++ b/test/unit/resolve-agent-auth.test.ts
@@ -34,3 +34,37 @@ describe("resolveAgentAuth — internal vs anonymous", () => {
     expect(await resolveAgentAuth(reqWithAuth("TPS-Ed25519 garbage-no-colons"))).toEqual({ kind: "anonymous" });
   });
 });
+
+describe("resolveAgentAuth — gate annotations + context.user (handler phase)", () => {
+  it("gate tpsAgent annotation → agent (handler path; no header re-verify needed)", async () => {
+    expect(await resolveAgentAuth({ tpsAgent: "agent-1", tpsAgentIsAdmin: false }))
+      .toEqual({ kind: "agent", agentId: "agent-1", isAdmin: false });
+    expect(await resolveAgentAuth({ tpsAgent: "admin-1", tpsAgentIsAdmin: true }))
+      .toEqual({ kind: "agent", agentId: "admin-1", isAdmin: true });
+  });
+
+  it("annotation reachable via context.request (the ctx.request ?? ctx fallback)", async () => {
+    expect(await resolveAgentAuth({ request: { tpsAgent: "agent-2", tpsAgentIsAdmin: false } }))
+      .toEqual({ kind: "agent", agentId: "agent-2", isAdmin: false });
+  });
+
+  it("explicit tpsAnonymous marker → anonymous (set by the non-rejecting gate)", async () => {
+    expect(await resolveAgentAuth({ tpsAnonymous: true })).toEqual({ kind: "anonymous" });
+  });
+
+  it("per-agent context.user (de-elevated) → agent via username", async () => {
+    expect(await resolveAgentAuth({ user: { username: "agent-3", role: { permission: {} } } }))
+      .toEqual({ kind: "agent", agentId: "agent-3", isAdmin: false });
+  });
+
+  it("super_user context.user → admin agent", async () => {
+    const v = await resolveAgentAuth({ user: { username: "admin", role: { permission: { super_user: true } } } });
+    expect(v.kind).toBe("agent");
+    expect((v as any).isAdmin).toBe(true);
+  });
+
+  it("shared flair-agent user with no other signal → internal (not mistaken for an agent)", async () => {
+    expect(await resolveAgentAuth({ user: { username: "flair-agent", role: { permission: {} } } }))
+      .toEqual({ kind: "internal" });
+  });
+});

--- a/test/unit/resource-allow.test.ts
+++ b/test/unit/resource-allow.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+// Per-resource allow* WIRING guard (structural). Harper injects `Resource` as a
+// runtime global rather than an npm export, so resource classes can't be
+// instantiated in a bun unit context (the ESM linker rejects `import { Resource }`).
+// So we verify the wiring at the source level: every admin-only resource must gate
+// on allowAdmin (which denies non-admin agents) and every agent-facing resource on
+// allowVerified. The HELPER BEHAVIOR is truth-tabled in allow-helpers.test.ts, and
+// real-Harper per-resource behavior (admin-only denial, anonymous denial,
+// cross-agent ownership) is in flair-agent-deelevation.test.ts. This catches the
+// dangerous mis-wire: an admin-only endpoint dropped onto allowVerified, which
+// would let any verified agent call it.
+
+const SRC = (f: string) => readFileSync(join(import.meta.dir, "..", "..", "resources", f), "utf8");
+
+const ADMIN_ONLY = ["AgentSeed.ts", "MemoryReindex.ts", "OrgEventMaintenance.ts"];
+const AGENT_FACING = [
+  "MemoryBootstrap.ts", "MemoryFeed.ts", "MemoryReflect.ts", "MemoryConsolidate.ts",
+  "SoulFeed.ts", "OrgEventCatchup.ts", "SemanticSearch.ts", "WorkspaceLatest.ts",
+];
+
+describe("admin-only resources gate on allowAdmin (never allowVerified)", () => {
+  for (const f of ADMIN_ONLY) {
+    it(`${f} uses allowAdmin and not allowVerified`, () => {
+      const src = SRC(f);
+      expect(src.includes("allowAdmin("), `${f} must gate on allowAdmin`).toBe(true);
+      expect(src.includes("allowVerified("), `${f} must NOT use allowVerified (would permit non-admin agents)`).toBe(false);
+    });
+  }
+});
+
+describe("agent-facing resources gate on allowVerified", () => {
+  for (const f of AGENT_FACING) {
+    it(`${f} uses allowVerified`, () => {
+      expect(SRC(f).includes("allowVerified("), `${f} must gate on allowVerified`).toBe(true);
+    });
+  }
+});
+
+describe("every gated resource actually defines an allow* method", () => {
+  for (const f of [...ADMIN_ONLY, ...AGENT_FACING]) {
+    it(`${f} defines at least one allow* method`, () => {
+      expect(/async\s+allow(Create|Read|Update|Delete)\s*\(/.test(SRC(f)), `${f} has no allow* method`).toBe(true);
+    });
+  }
+});


### PR DESCRIPTION
## Auth-RBAC reshape — foundation (safe, zero behavior change)

Nathan-directed reshape of flair's auth toward Harper-native per-resource RBAC + an **auth-plugin** model (oauth-shaped), with **no Harper-core dependency**. This PR is the **foundation only** — reviewed on a diff that **does not change live behavior**. The security-critical flip (making the gate non-rejecting + de-elevation) is a **follow-up PR after sign-off** (Nathan's call: review the foundation first).

### Why this is zero-behavior-change today
- **The global gate still rejects anonymous** (unchanged) — so the new per-resource deny-paths are not exercised in prod yet.
- **De-elevation is dormant** — `ensureFlairAgentUser` is *not* wired into init, so verified agents still resolve to admin (via fallback), exactly as before.
- Validated: agents work, HNSW works, agent A cannot see agent B's memories (scoping intact). **993 unit + 14 integration (spawned-Harper) green.**

### What's in it
- **`flair_agent` role** (least-privilege, real `@table` grants; no super_user, no operations grant) + shared `flair-agent` user provisioning helper (`ensureFlairAgentRole` wired into init; `ensureFlairAgentUser` intentionally *not* wired yet).
- **Per-agent identity**: the gate's de-elevation resolves a verified agent to a per-agent `request.user` (`username=agentId`, role `flair_agent`). Harper surfaces it as `context.user.username` in `allow*` and handlers. *Dormant* until the flair-agent user is provisioned.
- **`resolveAgentAuth(getContext())`** — three-way verdict helper: `internal` (no request → trusted in-process call), `agent` (verified Ed25519 → scoped), `anonymous` (HTTP, no valid agent → **deny**). The safe replacement for the old `if (!authAgent) → unfiltered` pattern. Annotation-first (reads `tpsAgent`/`tpsAnonymous` off `context.request ?? context`, then `context.user`, then header-verify) — because `getContext().request` is populated for GET but **undefined for PUT/POST** on Table resources.
- **Per-resource `allow*` coverage**: every agent-facing custom resource (SemanticSearch, BootstrapMemories, Feed/Reflect/Consolidate, WorkspaceLatest, OrgEventCatchup, SoulFeed, IngestEvents), admin-only resources (AgentSeed, MemoryReindex, OrgEventMaintenance), and public (AgentCard) self-authorize.
- **Resource hardening** — 5 resources that trusted no-auth (and would leak to anonymous once the gate stops rejecting) now `deny anonymous / scope agent / trust internal`: **Credential** (secrets), **Memory.search**, **Relationship.search**, **WorkspaceState** (all methods), **SemanticSearch**.
- **Memory create-ownership** in the handler (`content.agentId === context.user.username`), closing a pre-existing create-spoofing gap.

### Review focus
- **Sherlock (security — hard):** the `resolveAgentAuth` verdict logic, esp. the **internal-vs-anonymous** distinction (no request = trusted; request + no agent = deny); the per-resource hardening (each resource's deny/scope/trust); the least-privilege `flair_agent` grants; create-ownership. Adversarial angle: can anything reach a resource as `internal` (trusted/unfiltered) while actually being an external HTTP caller? (Today the gate still rejects anonymous, so no — but the follow-up flip is where this matters; flagging now.)
- **Kern (architecture):** the auth-plugin shape (mirrors `@harperfast/oauth`: non-rejecting middleware + per-resource helper); the annotation-first resolver (and the `getContext().request` undefined-for-writes gotcha); the per-agent-identity model vs. Harper's role RBAC.

### Follow-up (NOT in this PR)
Make the gate **non-rejecting** (verified → per-agent `request.user` + `tpsAgent`; unverified HTTP → `tpsAnonymous=true`; pass everything else through → fixes the composite-hub bug) + **flip de-elevation** (wire `ensureFlairAgentUser` into init). That's the live-behavior change, in its own focused PR after this foundation is signed off. A new integration test will prove anon `/Memory`+`/Credential`+`/WorkspaceState` denied + sibling/unknown routes pass.

Spec: `dtrt-dev/ops:specs/flair-auth-rbac-reshape.md`. Harper-core `registerAuthStrategy` hook is a separate (Nathan-owned) upstream track — not a dependency.
