### PR TITLE
fix(cli): flair_pair_initiator role spec rejected by add_role (breaks fresh hub provisioning)

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -817,25 +817,30 @@ export async function provisionFabric(
 // — the resource's own allowCreate bypass handles route-level access once the
 // request gets through the auth gate.
 
-/** Canonical permission spec for flair_pair_initiator. */
+/**
+ * Canonical permission spec for flair_pair_initiator.
+ *
+ * The role intentionally carries NO table permissions — its only job is to exist
+ * so bootstrap credentials can pass Harper platform auth before reaching the
+ * FederationPair resource handler (the resource's own allowCreate bypass handles
+ * route-level access). A bare role with both flags false is valid, grants nothing,
+ * and is exactly that intent.
+ *
+ * This previously carried an all-false `flair.tables` block, but Harper's add_role
+ * REJECTED the whole spec with a 400 (verified live against a spawned Harper):
+ *   - `cluster_user` is not a recognized top-level key — Harper reads unknown keys
+ *     as database names ("database 'cluster_user' does not exist");
+ *   - the table names were the logical shorthand, not the real @table names
+ *     ("Table 'flair.Workspace' does not exist" — it's WorkspaceState; "Event" is
+ *     OrgEvent; "OAuth" is OAuthClient);
+ *   - each grant omitted the required `attribute_permissions` array.
+ * The all-false block granted nothing anyway, so dropping it loses no capability
+ * and unbreaks fresh hub provisioning (where add_role runs and the 400 aborted
+ * `flair init --remote`). Only top-level booleans Harper recognizes remain.
+ */
 const PAIR_INITIATOR_PERMISSION = {
   super_user: false,
-  cluster_user: false,
   structure_user: false,
-  flair: {
-    tables: {
-      Memory:       { read: false, insert: false, update: false, delete: false },
-      Soul:         { read: false, insert: false, update: false, delete: false },
-      Agent:        { read: false, insert: false, update: false, delete: false },
-      Workspace:    { read: false, insert: false, update: false, delete: false },
-      Event:        { read: false, insert: false, update: false, delete: false },
-      OAuth:        { read: false, insert: false, update: false, delete: false },
-      Instance:     { read: false, insert: false, update: false, delete: false },
-      Peer:         { read: false, insert: false, update: false, delete: false },
-      PairingToken: { read: false, insert: false, update: false, delete: false },
-      SyncLog:      { read: false, insert: false, update: false, delete: false },
-    },
-  },
 } as const;
 
 /**

--- a/test/integration/flair-pair-initiator-role.test.ts
+++ b/test/integration/flair-pair-initiator-role.test.ts
@@ -1,0 +1,44 @@
+// flair_pair_initiator role — LIVE add_role acceptance (regression guard).
+//
+// The unit test (federation-pair-role.test.ts) mocks fetch, so it only proves the
+// impl SENDS a given spec — it cannot catch Harper rejecting that spec. An earlier
+// all-false `flair.tables` block (cluster_user + shorthand table names + missing
+// attribute_permissions) passed the mock test but made add_role return 400, which
+// silently broke fresh hub provisioning (`flair init --remote` aborts at
+// ensureFlairPairInitiatorRole). This test runs the REAL function against a spawned
+// Harper so that class of bug can't recur behind the mock.
+import { describe, expect, test, beforeAll, afterAll } from "bun:test";
+import { startHarper, stopHarper, HarperInstance } from "../helpers/harper-lifecycle";
+import { ensureFlairPairInitiatorRole } from "../../src/cli";
+
+let harper: HarperInstance;
+
+async function listRoleNames(): Promise<string[]> {
+  const res = await fetch(harper.opsURL, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: "Basic " + btoa(`${harper.admin.username}:${harper.admin.password}`),
+    },
+    body: JSON.stringify({ operation: "list_roles" }),
+  });
+  const roles = (await res.json()) as any[];
+  return roles.map((r) => r.role ?? r.name);
+}
+
+describe("ensureFlairPairInitiatorRole (live add_role)", () => {
+  beforeAll(async () => { harper = await startHarper(); }, 180_000);
+  afterAll(async () => { if (harper) await stopHarper(harper); });
+
+  test("add_role accepts the spec and the role is created", async () => {
+    // Must not throw — a 400 from add_role (the old bug) surfaces as a thrown error.
+    await ensureFlairPairInitiatorRole(harper.opsURL, harper.admin.username, harper.admin.password);
+    expect(await listRoleNames()).toContain("flair_pair_initiator");
+  }, 60_000);
+
+  test("is idempotent — a second call neither throws nor duplicates", async () => {
+    await ensureFlairPairInitiatorRole(harper.opsURL, harper.admin.username, harper.admin.password);
+    const names = await listRoleNames();
+    expect(names.filter((n) => n === "flair_pair_initiator")).toHaveLength(1);
+  }, 60_000);
+});

--- a/test/unit/federation-pair-role.test.ts
+++ b/test/unit/federation-pair-role.test.ts
@@ -3,25 +3,17 @@ import { ensureFlairPairInitiatorRole } from "../../src/cli";
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
 
-/** Minimal canonical permission spec mirrored from cli.ts. */
+/**
+ * Minimal canonical permission spec mirrored from cli.ts. The role carries NO
+ * table permissions by design — an all-false `flair.tables` block granted nothing
+ * yet made Harper's add_role reject the whole spec (cluster_user misread as a db,
+ * shorthand table names that don't exist, missing attribute_permissions arrays).
+ * See test/integration/flair-pair-initiator-role.test.ts for the live add_role
+ * acceptance guard this mock can't provide.
+ */
 const CANONICAL_PERM = {
   super_user: false,
-  cluster_user: false,
   structure_user: false,
-  flair: {
-    tables: {
-      Memory:       { read: false, insert: false, update: false, delete: false },
-      Soul:         { read: false, insert: false, update: false, delete: false },
-      Agent:        { read: false, insert: false, update: false, delete: false },
-      Workspace:    { read: false, insert: false, update: false, delete: false },
-      Event:        { read: false, insert: false, update: false, delete: false },
-      OAuth:        { read: false, insert: false, update: false, delete: false },
-      Instance:     { read: false, insert: false, update: false, delete: false },
-      Peer:         { read: false, insert: false, update: false, delete: false },
-      PairingToken: { read: false, insert: false, update: false, delete: false },
-      SyncLog:      { read: false, insert: false, update: false, delete: false },
-    },
-  },
 };
 
 /** Builds a mock ops-API fetch that returns sequenced responses. */


### PR DESCRIPTION
## Problem

`ensureFlairPairInitiatorRole` sends a permission spec that Harper's `add_role` **rejects with HTTP 400**, so `flair init --remote` aborts (right after `provisionFabric`) on any new hub running Harper 5.x. Federation hub provisioning is broken for fresh installs.

Confirmed live against a spawned Harper — `add_role` returns:

```
"database 'cluster_user' does not exist"
"Table 'flair.Workspace' does not exist"
"Table 'flair.Event' does not exist"
```

Three problems, all in the all-false `flair.tables` block:
1. `cluster_user` is not a recognized top-level key — Harper reads unknown top-level keys as **database names** (only `super_user` / `structure_user` are recognized).
2. The table names are logical shorthand that doesn't exist: `Workspace` → `WorkspaceState`, `Event` → `OrgEvent`, `OAuth` → `OAuthClient`.
3. Each grant omits the required `attribute_permissions` array.

Existing hubs are unaffected — the role was created on an older, lenient Harper and the idempotent check skips it. Only **fresh** provisioning hits the live `add_role` and 400s.

## Fix

The block granted nothing anyway. Per the call-site comment, the role exists only so bootstrap credentials pass Harper platform auth before the `FederationPair` resource's own `allowCreate` handles route-level access. So the spec collapses to the minimal valid role:

```js
const PAIR_INITIATOR_PERMISSION = { super_user: false, structure_user: false };
```

## Tests

- **`test/integration/flair-pair-initiator-role.test.ts`** (new): runs the real `ensureFlairPairInitiatorRole` against a spawned Harper and asserts `add_role` is accepted, the role is created, and the call is idempotent. The existing unit test mocks `fetch`, so it could only assert the impl *sends* a spec — it enshrined the invalid one and passed green. This live test is the guard that class of bug needs.
- **`federation-pair-role.test.ts`**: `CANONICAL_PERM` updated to the minimal spec.

Full suite green locally: **975 unit + 76 integration, 0 fail.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
