### PR TITLE
feat(auth): flip gate to non-rejecting + per-agent de-elevation + complete resource self-enforcement

### DIFF
--- a/resources/Agent.ts
+++ b/resources/Agent.ts
@@ -1,5 +1,5 @@
 import { databases } from "@harperfast/harper";
-import { isAdmin } from "./agent-auth.js";
+import { isAdmin, resolveAgentAuth, allowVerified, allowAdmin } from "./agent-auth.js";
 
 /**
  * Agent resource — serves as the Principal table in 1.0.
@@ -18,6 +18,15 @@ import { isAdmin } from "./agent-auth.js";
  *   - subjects: soul-level subject interests
  */
 export class Agent extends (databases as any).flair.Agent {
+  // Self-authorize now that the global gate is non-rejecting. Verified agents read
+  // the principal table for discovery; an agent updates only its OWN record (put
+  // handler enforces ownership). Creating/deleting principals is admin-only
+  // (flair_agent grant: insert=false, delete=false). Anonymous denied throughout.
+  allowRead()   { return allowVerified((this as any).getContext?.()); }
+  allowCreate() { return allowAdmin((this as any).getContext?.()); }
+  allowUpdate() { return allowVerified((this as any).getContext?.()); }
+  allowDelete() { return allowAdmin((this as any).getContext?.()); }
+
   async post(content: any, context: any) {
     const now = new Date().toISOString();
 
@@ -42,15 +51,18 @@ export class Agent extends (databases as any).flair.Agent {
   }
 
   async put(content: any) {
-    const ctx = (this as any).getContext?.();
-    const request = ctx?.request ?? ctx;
-    const authAgent: string | undefined = request?.tpsAgent;
-    const isAdminAgent: boolean = request?.tpsAgentIsAdmin ?? false;
-
-    // Only admin principals can modify other principals
-    if (authAgent && !isAdminAgent) {
+    const auth = await resolveAgentAuth((this as any).getContext?.());
+    // Anonymous denied (defense-in-depth alongside allowUpdate; the old check read
+    // tpsAgent and treated a missing agent as trusted, so anonymous slipped through).
+    if (auth.kind === "anonymous") {
+      return new Response(JSON.stringify({ error: "authentication required" }), {
+        status: 401, headers: { "content-type": "application/json" },
+      });
+    }
+    // Only admin principals can modify OTHER principals; an agent updates its own.
+    if (auth.kind === "agent" && !auth.isAdmin) {
       const existing = await super.get();
-      if (existing && existing.id !== authAgent) {
+      if (existing && existing.id !== auth.agentId) {
         return new Response(JSON.stringify({ error: "only admin principals can modify other principals" }), {
           status: 403, headers: { "content-type": "application/json" },
         });

--- a/resources/Instance.ts
+++ b/resources/Instance.ts
@@ -1,0 +1,14 @@
+import { databases } from "@harperfast/harper";
+import { allowVerified, allowAdmin } from "./agent-auth.js";
+
+/**
+ * Instance is read-only reference data for agents (flair_agent grant: read only).
+ * Verified agents + admin may read; writes are admin/internal only. Self-authorizes
+ * now that the global gate is non-rejecting (anonymous denied).
+ */
+export class Instance extends (databases as any).flair.Instance {
+  allowRead()   { return allowVerified((this as any).getContext?.()); }
+  allowCreate() { return allowAdmin((this as any).getContext?.()); }
+  allowUpdate() { return allowAdmin((this as any).getContext?.()); }
+  allowDelete() { return allowAdmin((this as any).getContext?.()); }
+}

--- a/resources/Integration.ts
+++ b/resources/Integration.ts
@@ -1,7 +1,44 @@
 import { databases } from "@harperfast/harper";
+import { resolveAgentAuth } from "./agent-auth.js";
 
+const FORBIDDEN = (msg: string) =>
+  new Response(JSON.stringify({ error: msg }), { status: 403, headers: { "Content-Type": "application/json" } });
+const UNAUTH = () =>
+  new Response(JSON.stringify({ error: "authentication required" }), { status: 401, headers: { "Content-Type": "application/json" } });
+
+/**
+ * Integration records are agent-owned. Auth: the non-rejecting gate annotates the
+ * request; this resource self-enforces (resolveAgentAuth → internal/agent/anonymous).
+ * Anonymous HTTP is denied on every path; non-admin agents are scoped to their own
+ * agentId. Mirrors the WorkspaceState pattern.
+ */
 export class Integration extends (databases as any).flair.Integration {
+  private _auth() {
+    return resolveAgentAuth((this as any).getContext?.());
+  }
+
+  async search(query?: any) {
+    const auth = await this._auth();
+    if (auth.kind === "anonymous") return UNAUTH();
+    if (auth.kind === "internal" || (auth.kind === "agent" && auth.isAdmin)) {
+      return super.search(query);
+    }
+    const agentIdCondition = { attribute: "agentId", comparator: "equals", value: auth.agentId };
+    if (query && typeof query === "object" && !Array.isArray(query)) {
+      const existing = query.conditions ?? [];
+      query.conditions = Array.isArray(existing) ? [agentIdCondition, ...existing] : [agentIdCondition, existing];
+      return super.search(query);
+    }
+    const conditions = Array.isArray(query) && query.length > 0 ? [agentIdCondition, ...query] : [agentIdCondition];
+    return super.search(conditions);
+  }
+
   async post(content: any, context?: any) {
+    const auth = await this._auth();
+    if (auth.kind === "anonymous") return UNAUTH();
+    if (auth.kind === "agent" && !auth.isAdmin && content?.agentId && content.agentId !== auth.agentId) {
+      return FORBIDDEN("forbidden: cannot write integration for another agent");
+    }
     // S31-A: API never accepts plaintext credentials.
     if (typeof content?.credential === "string" || typeof content?.token === "string") {
       return new Response(JSON.stringify({ error: "plaintext_credentials_forbidden" }), {
@@ -10,5 +47,34 @@ export class Integration extends (databases as any).flair.Integration {
       });
     }
     return super.post(content, context);
+  }
+
+  async put(content: any, context?: any) {
+    const auth = await this._auth();
+    if (auth.kind === "anonymous") return UNAUTH();
+    if (auth.kind === "agent" && !auth.isAdmin && content?.agentId && content.agentId !== auth.agentId) {
+      return FORBIDDEN("forbidden: cannot write integration for another agent");
+    }
+    if (typeof content?.credential === "string" || typeof content?.token === "string") {
+      return new Response(JSON.stringify({ error: "plaintext_credentials_forbidden" }), {
+        status: 400,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+    return super.put(content, context);
+  }
+
+  async delete(id: any) {
+    const auth = await this._auth();
+    if (auth.kind === "anonymous") return UNAUTH();
+    if (auth.kind === "internal" || (auth.kind === "agent" && auth.isAdmin)) {
+      return super.delete(id);
+    }
+    const record = await this.get(id);
+    if (!record) return super.delete(id);
+    if (record.agentId !== auth.agentId) {
+      return FORBIDDEN("forbidden: cannot delete integration for another agent");
+    }
+    return super.delete(id);
   }
 }

--- a/resources/Memory.ts
+++ b/resources/Memory.ts
@@ -87,6 +87,14 @@ export class Memory extends (databases as any).flair.Memory {
     // dormant and would wrongly 403 every agent's own write. internal/admin → pass.
     {
       const auth = await resolveAgentAuth(ctx);
+      // Anonymous HTTP must NOT write. Pre-flip the global gate rejected no-auth
+      // upstream; with the non-rejecting gate, each write path self-enforces (same
+      // rule search() applies to reads).
+      if (auth.kind === "anonymous") {
+        return new Response(JSON.stringify({ error: "authentication required" }), {
+          status: 401, headers: { "Content-Type": "application/json" },
+        });
+      }
       if (auth.kind === "agent" && !auth.isAdmin && content?.agentId && content.agentId !== auth.agentId) {
         return new Response(JSON.stringify({ error: "forbidden: cannot write memory owned by another agent" }), {
           status: 403, headers: { "Content-Type": "application/json" },
@@ -189,6 +197,12 @@ export class Memory extends (databases as any).flair.Memory {
     {
       const octx = (this as any).getContext?.();
       const auth = await resolveAgentAuth(octx);
+      // Anonymous HTTP must NOT write (non-rejecting gate → self-enforce here).
+      if (auth.kind === "anonymous") {
+        return new Response(JSON.stringify({ error: "authentication required" }), {
+          status: 401, headers: { "Content-Type": "application/json" },
+        });
+      }
       if (auth.kind === "agent" && !auth.isAdmin && content?.agentId && content.agentId !== auth.agentId) {
         return new Response(JSON.stringify({ error: "forbidden: cannot write memory owned by another agent" }), {
           status: 403, headers: { "Content-Type": "application/json" },

--- a/resources/MemoryGrant.ts
+++ b/resources/MemoryGrant.ts
@@ -1,0 +1,82 @@
+import { databases } from "@harperfast/harper";
+import { resolveAgentAuth } from "./agent-auth.js";
+
+const FORBIDDEN = (msg: string) =>
+  new Response(JSON.stringify({ error: msg }), { status: 403, headers: { "Content-Type": "application/json" } });
+const UNAUTH = () =>
+  new Response(JSON.stringify({ error: "authentication required" }), { status: 401, headers: { "Content-Type": "application/json" } });
+
+/**
+ * MemoryGrant — an agent (ownerId) grants another (granteeId) scoped access to its
+ * memories. Self-authorizes now that the global gate is non-rejecting (previously a
+ * pure @table protected only by the gate → anonymous could read/write any grant).
+ *
+ * Write: non-admin agents may only create/modify/delete grants they OWN
+ *        (ownerId === self) — you can only share your own memories.
+ * Read:  non-admin agents see grants where they are owner OR grantee.
+ * Internal calls (e.g. Memory.search's grant lookup) and admins pass unfiltered.
+ */
+export class MemoryGrant extends (databases as any).flair.MemoryGrant {
+  private _auth() {
+    return resolveAgentAuth((this as any).getContext?.());
+  }
+
+  async search(query?: any) {
+    const auth = await this._auth();
+    if (auth.kind === "anonymous") return UNAUTH();
+    if (auth.kind === "internal" || (auth.kind === "agent" && auth.isAdmin)) {
+      return super.search(query);
+    }
+    // owner OR grantee
+    const scope = {
+      operator: "or",
+      conditions: [
+        { attribute: "ownerId", comparator: "equals", value: auth.agentId },
+        { attribute: "granteeId", comparator: "equals", value: auth.agentId },
+      ],
+    };
+    if (query && typeof query === "object" && !Array.isArray(query)) {
+      const existing = query.conditions ?? [];
+      query.conditions = Array.isArray(existing) ? [scope, ...existing] : [scope, existing];
+      return super.search(query);
+    }
+    const conditions = Array.isArray(query) && query.length > 0 ? [scope, ...query] : [scope];
+    return super.search(conditions);
+  }
+
+  async post(content: any, context?: any) {
+    const denied = await this._enforceOwnerWrite(content);
+    if (denied) return denied;
+    content.createdAt ||= new Date().toISOString();
+    return super.post(content, context);
+  }
+
+  async put(content: any, context?: any) {
+    const denied = await this._enforceOwnerWrite(content);
+    if (denied) return denied;
+    return super.put(content, context);
+  }
+
+  async delete(id: any, context?: any) {
+    const auth = await this._auth();
+    if (auth.kind === "anonymous") return UNAUTH();
+    if (auth.kind === "internal" || (auth.kind === "agent" && auth.isAdmin)) {
+      return super.delete(id, context);
+    }
+    const record = await this.get(id);
+    if (!record) return super.delete(id, context);
+    if (record.ownerId !== auth.agentId) {
+      return FORBIDDEN("forbidden: cannot delete a grant owned by another agent");
+    }
+    return super.delete(id, context);
+  }
+
+  private async _enforceOwnerWrite(content: any): Promise<Response | null> {
+    const auth = await this._auth();
+    if (auth.kind === "anonymous") return UNAUTH();
+    if (auth.kind === "agent" && !auth.isAdmin && content?.ownerId && content.ownerId !== auth.agentId) {
+      return FORBIDDEN("forbidden: cannot grant access to another agent's memories");
+    }
+    return null;
+  }
+}

--- a/resources/OAuthClient.ts
+++ b/resources/OAuthClient.ts
@@ -1,0 +1,16 @@
+import { databases } from "@harperfast/harper";
+import { allowAdmin } from "./agent-auth.js";
+
+/**
+ * OAuthClient holds registered OAuth client records (incl. secrets) — admin/system
+ * only, no agent grant. OAuth endpoints (OAuthRegister/Authorize/Token) read+write
+ * clients via internal calls (allowAdmin permits internal), so the OAuth flows keep
+ * working; direct anonymous table access is denied. Self-authorizes now that the
+ * global gate is non-rejecting.
+ */
+export class OAuthClient extends (databases as any).flair.OAuthClient {
+  allowRead()   { return allowAdmin((this as any).getContext?.()); }
+  allowCreate() { return allowAdmin((this as any).getContext?.()); }
+  allowUpdate() { return allowAdmin((this as any).getContext?.()); }
+  allowDelete() { return allowAdmin((this as any).getContext?.()); }
+}

--- a/resources/ObsAgentSnapshot.ts
+++ b/resources/ObsAgentSnapshot.ts
@@ -1,0 +1,14 @@
+import { databases } from "@harperfast/harper";
+import { allowVerified, allowAdmin } from "./agent-auth.js";
+
+/**
+ * ObsAgentSnapshot — observatory per-agent snapshot read-model. Writes are
+ * system-driven (internal sync); agents may read. See ObsOffice for the
+ * allowRead=allowVerified security default (flag for Sherlock).
+ */
+export class ObsAgentSnapshot extends (databases as any).flair.ObsAgentSnapshot {
+  allowRead()   { return allowVerified((this as any).getContext?.()); }
+  allowCreate() { return allowAdmin((this as any).getContext?.()); }
+  allowUpdate() { return allowAdmin((this as any).getContext?.()); }
+  allowDelete() { return allowAdmin((this as any).getContext?.()); }
+}

--- a/resources/ObsEventFeed.ts
+++ b/resources/ObsEventFeed.ts
@@ -1,0 +1,14 @@
+import { databases } from "@harperfast/harper";
+import { allowVerified, allowAdmin } from "./agent-auth.js";
+
+/**
+ * ObsEventFeed — observatory event-feed read-model. Writes are system-driven
+ * (internal sync); agents may read. See ObsOffice for the allowRead=allowVerified
+ * security default (flag for Sherlock).
+ */
+export class ObsEventFeed extends (databases as any).flair.ObsEventFeed {
+  allowRead()   { return allowVerified((this as any).getContext?.()); }
+  allowCreate() { return allowAdmin((this as any).getContext?.()); }
+  allowUpdate() { return allowAdmin((this as any).getContext?.()); }
+  allowDelete() { return allowAdmin((this as any).getContext?.()); }
+}

--- a/resources/ObsOffice.ts
+++ b/resources/ObsOffice.ts
@@ -1,0 +1,20 @@
+import { databases } from "@harperfast/harper";
+import { allowVerified, allowAdmin } from "./agent-auth.js";
+
+/**
+ * ObsOffice — observatory office-layout read-model. Writes are system-driven
+ * (internal sync); agents may read. Self-authorizes now that the global gate is
+ * non-rejecting.
+ *
+ * SECURITY DEFAULT (flag for Sherlock): allowRead is allowVerified (anonymous
+ * denied). The ObservationCenter HTML shell is public but its data API calls
+ * authenticate (admin-pass). If the public Office Space renderer needs anonymous
+ * Obs reads, relax to allowRead=true WITH field-allowlisting (as Presence.get does)
+ * — do NOT expose raw rows publicly.
+ */
+export class ObsOffice extends (databases as any).flair.ObsOffice {
+  allowRead()   { return allowVerified((this as any).getContext?.()); }
+  allowCreate() { return allowAdmin((this as any).getContext?.()); }
+  allowUpdate() { return allowAdmin((this as any).getContext?.()); }
+  allowDelete() { return allowAdmin((this as any).getContext?.()); }
+}

--- a/resources/OrgEvent.ts
+++ b/resources/OrgEvent.ts
@@ -1,63 +1,63 @@
 /**
  * OrgEvent.ts — Harper table resource for org-wide activity events.
  *
- * Auth: Ed25519 middleware sets request.tpsAgent.
- * Write: authorId must match authenticated agent (or admin).
- * Read: any authenticated participant can read (org-scoped).
+ * Auth (self-enforced now that the global gate is non-rejecting):
+ *   Read  — any verified agent/admin (org-scoped); anonymous denied.
+ *   Write — authorId must match the authenticated agent (or admin); anonymous denied.
+ *
+ * The previous version read context.request.tpsAgent and treated a MISSING agent
+ * as trusted (`if (agentId && …)` / `if (!agentId) super.delete`), so anonymous
+ * requests slipped through once the gate stopped rejecting. resolveAgentAuth
+ * distinguishes internal/agent/anonymous explicitly.
  */
 
 import { databases } from "@harperfast/harper";
+import { resolveAgentAuth, allowVerified } from "./agent-auth.js";
+
+const FORBIDDEN = (msg: string) =>
+  new Response(JSON.stringify({ error: msg }), { status: 403, headers: { "Content-Type": "application/json" } });
+const UNAUTH = () =>
+  new Response(JSON.stringify({ error: "authentication required" }), { status: 401, headers: { "Content-Type": "application/json" } });
 
 export class OrgEvent extends (databases as any).flair.OrgEvent {
-  async post(content: any, context?: any) {
-    const agentId = context?.request?.tpsAgent;
+  allowRead() { return allowVerified((this as any).getContext?.()); }
 
-    // authorId must match authenticated agent (unless admin)
-    if (agentId && !context?.request?.tpsAgentIsAdmin && content.authorId !== agentId) {
-      return new Response(
-        JSON.stringify({ error: "forbidden: authorId must match authenticated agent" }),
-        { status: 403, headers: { "Content-Type": "application/json" } },
-      );
+  private _auth() {
+    return resolveAgentAuth((this as any).getContext?.());
+  }
+
+  async post(content: any) {
+    const auth = await this._auth();
+    if (auth.kind === "anonymous") return UNAUTH();
+    if (auth.kind === "agent" && !auth.isAdmin && content.authorId !== auth.agentId) {
+      return FORBIDDEN("forbidden: authorId must match authenticated agent");
     }
-
-    // Generate composite ID if not provided
-    if (!content.id) {
-      content.id = `${content.authorId}-${Date.now()}`;
-    }
-
+    if (!content.id) content.id = `${content.authorId}-${new Date().toISOString()}`;
     content.createdAt = new Date().toISOString();
-
-    // Harper 5: table resources use put() for create/upsert (post() removed)
+    // Harper 5: table resources use put() for create/upsert (post() removed).
     return (databases as any).flair.OrgEvent.put(content);
   }
 
-  async put(content: any, context?: any) {
-    const agentId = context?.request?.tpsAgent;
-
-    if (agentId && !context?.request?.tpsAgentIsAdmin && content.authorId !== agentId) {
-      return new Response(
-        JSON.stringify({ error: "forbidden: authorId must match authenticated agent" }),
-        { status: 403, headers: { "Content-Type": "application/json" } },
-      );
+  async put(content: any) {
+    const auth = await this._auth();
+    if (auth.kind === "anonymous") return UNAUTH();
+    if (auth.kind === "agent" && !auth.isAdmin && content.authorId !== auth.agentId) {
+      return FORBIDDEN("forbidden: authorId must match authenticated agent");
     }
-
     return (databases as any).flair.OrgEvent.put(content);
   }
 
   async delete(id: any, context?: any) {
-    const agentId = context?.request?.tpsAgent;
-    if (!agentId) return super.delete(id, context);
-
+    const auth = await this._auth();
+    if (auth.kind === "anonymous") return UNAUTH();
+    if (auth.kind === "internal" || (auth.kind === "agent" && auth.isAdmin)) {
+      return super.delete(id, context);
+    }
     const record = await this.get(id);
     if (!record) return super.delete(id, context);
-
-    if (!context?.request?.tpsAgentIsAdmin && record.authorId !== agentId) {
-      return new Response(
-        JSON.stringify({ error: "forbidden: cannot delete events authored by another agent" }),
-        { status: 403, headers: { "Content-Type": "application/json" } },
-      );
+    if (record.authorId !== auth.agentId) {
+      return FORBIDDEN("forbidden: cannot delete events authored by another agent");
     }
-
     return super.delete(id, context);
   }
 }

--- a/resources/PairingToken.ts
+++ b/resources/PairingToken.ts
@@ -1,0 +1,15 @@
+import { databases } from "@harperfast/harper";
+import { allowAdmin } from "./agent-auth.js";
+
+/**
+ * PairingToken holds one-time federation pairing secrets — admin/system only,
+ * no agent grant. The FederationPair endpoint consumes tokens via internal calls
+ * (allowAdmin permits internal), so dedicated flows keep working; direct anonymous
+ * table access is denied. Self-authorizes now that the global gate is non-rejecting.
+ */
+export class PairingToken extends (databases as any).flair.PairingToken {
+  allowRead()   { return allowAdmin((this as any).getContext?.()); }
+  allowCreate() { return allowAdmin((this as any).getContext?.()); }
+  allowUpdate() { return allowAdmin((this as any).getContext?.()); }
+  allowDelete() { return allowAdmin((this as any).getContext?.()); }
+}

--- a/resources/Peer.ts
+++ b/resources/Peer.ts
@@ -1,0 +1,16 @@
+import { databases } from "@harperfast/harper";
+import { allowAdmin } from "./agent-auth.js";
+
+/**
+ * Peer holds federation peer records (URLs + credentials) — system/admin data,
+ * no agent grant. Before the auth flip the global gate was its only protection;
+ * the non-rejecting gate means it must self-authorize. Admin/internal only on
+ * every path. (Federation pairing/sync use dedicated endpoints — FederationPair,
+ * FederationSync — not direct Peer table access.)
+ */
+export class Peer extends (databases as any).flair.Peer {
+  allowRead()   { return allowAdmin((this as any).getContext?.()); }
+  allowCreate() { return allowAdmin((this as any).getContext?.()); }
+  allowUpdate() { return allowAdmin((this as any).getContext?.()); }
+  allowDelete() { return allowAdmin((this as any).getContext?.()); }
+}

--- a/resources/Presence.ts
+++ b/resources/Presence.ts
@@ -18,6 +18,7 @@
  */
 
 import { databases } from "@harperfast/harper";
+import { resolveAgentAuth } from "./agent-auth.js";
 
 // ─── Constants ────────────────────────────────────────────────────────────────
 
@@ -337,5 +338,36 @@ export class Presence extends (databases as any).flair.Presence {
         { status: 500, headers: { "Content-Type": "application/json" } },
       );
     }
+  }
+
+  /**
+   * PUT/DELETE are not part of the agent heartbeat contract (writes go through
+   * POST, which carries its own Ed25519 auth). GET is intentionally public and
+   * allowCreate=true lets POST self-auth — but those bypasses must NOT extend to
+   * PUT/DELETE. The non-rejecting gate would otherwise let anonymous PUT/DELETE
+   * straight to Harper's default handler (the leak this closes). Require a verified
+   * non-anonymous principal, scoped to the agent's own record (Presence is keyed
+   * by agentId).
+   */
+  async put(content: any, context?: any) {
+    const auth = await resolveAgentAuth((this as any).getContext?.());
+    if (auth.kind === "anonymous") {
+      return new Response(JSON.stringify({ error: "authentication required" }), { status: 401, headers: { "Content-Type": "application/json" } });
+    }
+    if (auth.kind === "agent" && !auth.isAdmin && content?.agentId && content.agentId !== auth.agentId) {
+      return new Response(JSON.stringify({ error: "forbidden: cannot write presence for another agent" }), { status: 403, headers: { "Content-Type": "application/json" } });
+    }
+    return super.put(content, context);
+  }
+
+  async delete(id: any) {
+    const auth = await resolveAgentAuth((this as any).getContext?.());
+    if (auth.kind === "anonymous") {
+      return new Response(JSON.stringify({ error: "authentication required" }), { status: 401, headers: { "Content-Type": "application/json" } });
+    }
+    if (auth.kind === "agent" && !auth.isAdmin && id != null && String(id) !== auth.agentId) {
+      return new Response(JSON.stringify({ error: "forbidden: cannot delete presence for another agent" }), { status: 403, headers: { "Content-Type": "application/json" } });
+    }
+    return super.delete(id);
   }
 }

--- a/resources/Soul.ts
+++ b/resources/Soul.ts
@@ -1,19 +1,30 @@
 import { databases } from "@harperfast/harper";
+import { resolveAgentAuth } from "./agent-auth.js";
 
-function enforceAgentScope(self: any, data: any): Response | null {
-  const authenticatedAgent: string | undefined = self.request?.headers?.get?.("x-tps-agent");
-  const callerIsAdmin: boolean = self.request?.tpsAgentIsAdmin === true;
-  if (authenticatedAgent && !callerIsAdmin && data?.agentId && data.agentId !== authenticatedAgent) {
-    return new Response(JSON.stringify({
-      error: "forbidden: agentId must match authenticated agent",
-    }), { status: 403, headers: { "Content-Type": "application/json" } });
+const FORBIDDEN = (msg: string) =>
+  new Response(JSON.stringify({ error: msg }), { status: 403, headers: { "Content-Type": "application/json" } });
+const UNAUTH = () =>
+  new Response(JSON.stringify({ error: "authentication required" }), { status: 401, headers: { "Content-Type": "application/json" } });
+
+/**
+ * Deny anonymous; enforce per-agent write ownership for non-admin agents.
+ * The previous header-based check only fired when an agent WAS present (it read
+ * x-tps-agent), so an anonymous request — which carries no x-tps-agent — slipped
+ * through. With the non-rejecting gate, each write path self-enforces (resolveAgentAuth
+ * distinguishes internal/agent/anonymous). Mirrors the WorkspaceState pattern.
+ */
+async function enforceWriteAuth(self: any, data: any): Promise<Response | null> {
+  const auth = await resolveAgentAuth((self as any).getContext?.());
+  if (auth.kind === "anonymous") return UNAUTH();
+  if (auth.kind === "agent" && !auth.isAdmin && data?.agentId && data.agentId !== auth.agentId) {
+    return FORBIDDEN("forbidden: agentId must match authenticated agent");
   }
   return null;
 }
 
 export class Soul extends (databases as any).flair.Soul {
   async post(content: any, context?: any) {
-    const denied = enforceAgentScope(this, content);
+    const denied = await enforceWriteAuth(this, content);
     if (denied) return denied;
     content.durability ||= "permanent";
     content.createdAt = new Date().toISOString();
@@ -22,7 +33,7 @@ export class Soul extends (databases as any).flair.Soul {
   }
 
   async put(content: any, context?: any) {
-    const denied = enforceAgentScope(this, content);
+    const denied = await enforceWriteAuth(this, content);
     if (denied) return denied;
     content.updatedAt = new Date().toISOString();
     return super.put(content, context);

--- a/resources/XAA.ts
+++ b/resources/XAA.ts
@@ -1,4 +1,5 @@
 import { databases } from "@harperfast/harper";
+import { allowAdmin } from "./agent-auth.js";
 import { createHash, randomBytes } from "node:crypto";
 import { createRemoteJWKSet, jwtVerify, type JWTPayload } from "jose";
 
@@ -285,6 +286,14 @@ export async function handleJwtBearerGrant(data: any): Promise<Response | object
  * Admin-only access.
  */
 export class IdpConfig extends (databases as any).flair.IdpConfig {
+  // Admin-only on every path (the "Admin-only" comment was previously unenforced —
+  // a pure put() override with no auth check, so the non-rejecting gate let
+  // anonymous through to Harper's handler). allowAdmin permits admin + internal.
+  allowRead()   { return allowAdmin((this as any).getContext?.()); }
+  allowCreate() { return allowAdmin((this as any).getContext?.()); }
+  allowUpdate() { return allowAdmin((this as any).getContext?.()); }
+  allowDelete() { return allowAdmin((this as any).getContext?.()); }
+
   async put(content: any) {
     const now = nowISO();
     content.enabled ??= true;

--- a/resources/auth-middleware.ts
+++ b/resources/auth-middleware.ts
@@ -1,7 +1,7 @@
 import { patchRecord } from "./table-helpers.js";
 import { server, databases } from "@harperfast/harper";
 import { getEmbedding } from "./embeddings-provider.js";
-import { isAdmin } from "./agent-auth.js";
+import { isAdmin, FLAIR_AGENT_USERNAME } from "./agent-auth.js";
 
 // --- Admin credentials ---
 // Admin auth is sourced exclusively from Harper's own environment variables
@@ -219,8 +219,17 @@ server.http(async (request: any, nextLayer: any) => {
           return nextLayer(request);
         }
       }
-    } catch { /* fall through to Ed25519 check */ }
-    return new Response(JSON.stringify({ error: "invalid_admin_credentials" }), { status: 401 });
+    } catch { /* fall through to anonymous */ }
+    // NON-REJECTING (auth-rbac flip): a Basic header that matched no admin/super_user/
+    // pair path → annotate anonymous + pass through (don't 401 — a sibling component's
+    // Basic auth on a shared Harper must not be rejected by flair's gate). Resource
+    // allow* denies if the path is flair-protected.
+    request.tpsAnonymous = true;
+    try {
+      request.headers.set("x-tps-anonymous", "1");
+      if (request.headers.asObject) (request.headers.asObject as any)["x-tps-anonymous"] = "1";
+    } catch { /* frozen headers */ }
+    return nextLayer(request);
   }
 
   // ── Ed25519 agent auth ────────────────────────────────────────────────────
@@ -241,7 +250,17 @@ server.http(async (request: any, nextLayer: any) => {
         },
       });
     }
-    return new Response(JSON.stringify({ error: "missing_or_invalid_authorization" }), { status: 401 });
+    // NON-REJECTING GATE (auth-rbac flip): no valid agent → annotate anonymous and
+    // pass through. Per-resource allow* (resolveAgentAuth → anonymous → deny) is the
+    // enforcement; the gate no longer 401s instance-wide, which was breaking sibling
+    // components on a shared Harper / composite hub. Anonymous reaches only public
+    // allow-listed paths + resources whose allow* permit it.
+    request.tpsAnonymous = true;
+    try {
+      request.headers.set("x-tps-anonymous", "1");
+      if (request.headers.asObject) (request.headers.asObject as any)["x-tps-anonymous"] = "1";
+    } catch { /* frozen headers — annotation on the request object still applies */ }
+    return nextLayer(request);
   }
 
   const [, agentId, tsRaw, nonce, signatureB64] = m;
@@ -290,23 +309,37 @@ server.http(async (request: any, nextLayer: any) => {
   // password validation, safe here because the Ed25519 signature already proved
   // identity cryptographically.
   //
-  // RESHAPE (auth-rbac): verified agents resolve to the least-privilege
-  // `flair-agent` user, NOT admin super_user. The flair_agent role grants exactly
-  // the table CRUD agents need; with no operations grant, /sql + /graphql become
-  // natively 403. Row-level data isolation stays enforced via x-tps-agent below.
-  // Elevate the cryptographically-verified agent to admin (unchanged from
-  // pre-reshape behavior). getUser(admin, null) looks up the admin record WITHOUT
-  // password validation — safe because the Ed25519 signature already proved
-  // identity. Per-agent DE-ELEVATION (agents → the least-privilege flair_agent
-  // role instead of admin) is deferred to the non-rejecting-gate follow-up PR; it
-  // doesn't belong in this zero-behavior-change foundation. Resource scoping +
-  // ownership in this PR derive identity from the x-tps-agent annotation via
-  // resolveAgentAuth, independent of request.user, so they work under either model.
+  // RESHAPE (auth-rbac) — THE FLIP: per-agent DE-ELEVATION. A cryptographically-
+  // verified NON-admin agent resolves to the least-privilege `flair-agent` user,
+  // NOT admin super_user. The flair_agent role grants exactly the table CRUD agents
+  // need; with no operations grant, /sql + /graphql are natively 403 (the hand-
+  // rolled raw-query block below becomes belt-and-suspenders). Admins still resolve
+  // to admin. getUser(name, null) looks up WITHOUT password validation — safe
+  // because the Ed25519 signature already proved identity. Row-level ownership stays
+  // enforced via x-tps-agent / resolveAgentAuth, independent of request.user.
+  //
+  // GRACEFUL FALLBACK: if the flair-agent user isn't provisioned on this instance
+  // yet (pre-migration — ensureFlairAgentUser hasn't run), fall back to admin so
+  // agents keep working. De-elevation activates per-instance once the user exists.
   try {
-    request.user = await (server as any).getUser("admin", null, request);
+    if (request.tpsAgentIsAdmin) {
+      request.user = await (server as any).getUser("admin", null, request);
+    } else {
+      let deElevated: any = null;
+      try { deElevated = await (server as any).getUser(FLAIR_AGENT_USERNAME, null, request); } catch { /* not provisioned */ }
+      // getUser(name, null) returns a ROLE-LESS phantom `{ username }` (not null,
+      // not a throw) for a nonexistent user — harper security/user.js
+      // findAndValidateUser: `if (!userTmp) { if (!validatePassword) return { username } }`.
+      // A phantom is truthy, so `deElevated ?? admin` would keep it and the request
+      // would carry NO role → 403 AccessViolation. Require a real role to use the
+      // de-elevated user; otherwise fall back to admin (pre-migration instances).
+      request.user = (deElevated && deElevated.role)
+        ? deElevated
+        : await (server as any).getUser("admin", null, request);
+    }
   } catch {
-    // Admin record unavailable — request proceeds as the verified tpsAgent
-    // without elevated perms; resource-level scoping still applies.
+    // No usable user record — request proceeds as the verified tpsAgent without
+    // elevated perms; resource-level scoping (x-tps-agent) still applies.
   }
 
   // Propagate authenticated agent to downstream resources via header.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1431,12 +1431,13 @@ program
         // Every flair instance has agents, so provision the least-privilege
         // flair_agent role (idempotent, harmless until a user is assigned to it).
         await ensureFlairAgentRole(opsUrl, DEFAULT_ADMIN_USER, flairAdminPass);
-        // NOTE: ensureFlairAgentUser is intentionally NOT wired in yet. Provisioning
-        // the flair-agent user activates the gate's de-elevation (verified agents →
-        // flair_agent instead of admin), and that breaks any agent-facing CUSTOM
-        // resource still lacking an allow* (e.g. SemanticSearch relies on the admin
-        // super_user bypass today). Wire it in only once every agent-facing resource
-        // self-authorizes via allow*. Until then the gate falls back to admin.
+        // THE FLIP (auth-rbac): provision the shared least-privilege flair-agent user.
+        // This ACTIVATES the gate's per-agent de-elevation (verified non-admin agents
+        // resolve to flair-agent instead of admin super_user). Safe now: #487 gave
+        // every agent-facing resource its own allow* + resolveAgentAuth, so they no
+        // longer rely on the admin super_user bypass. The gate also falls back to
+        // admin if this user is ever absent, so de-elevation degrades gracefully.
+        await ensureFlairAgentUser(opsUrl, DEFAULT_ADMIN_USER, flairAdminPass);
       } else {
         // ── Existing behavior: --admin-pass required for already-running Flair ──
         if (!opts.adminPass) {

--- a/test/integration/flair-agent-deelevation.test.ts
+++ b/test/integration/flair-agent-deelevation.test.ts
@@ -268,4 +268,46 @@ describe("flair_agent de-elevation (verified agents act as flair-agent, not admi
     });
     expect([401, 403], `anon PUT /Memory returned ${res.status} (expected 401/403)`).toContain(res.status);
   }, 30_000);
+
+  // Belt-and-suspenders: the non-rejecting gate returns BEFORE its per-resource
+  // mutation guards (those only run for verified agents), so EVERY agent-facing
+  // @table write path must self-enforce anonymous denial in its own handler/allow*.
+  // One anonymous PUT per agent-writable resource; any 200/204 is an auth leak.
+  // EVERY @export @table must reject anonymous writes. Harper's role gate denies
+  // admin/system tables for a no-user request (→ 403, passes); a 200/204 is a real
+  // leak in a table that relied on the (now non-rejecting) global gate. MemoryCandidate
+  // is intentionally NOT @export (not REST-routable) so it's excluded.
+  const AGENT_WRITE_RESOURCES: Array<{ name: string; body: (id: string) => any }> = [
+    // agent-facing (agent-owned data)
+    { name: "Soul",            body: (id) => ({ id, agentId: agent.id, content: "anon soul" }) },
+    { name: "WorkspaceState",  body: (id) => ({ id, agentId: agent.id, state: { x: 1 } }) },
+    { name: "Relationship",    body: (id) => ({ id, agentId: agent.id, otherId: "x", kind: "knows" }) },
+    { name: "Integration",     body: (id) => ({ id, agentId: agent.id, kind: "test" }) },
+    { name: "Presence",        body: (id) => ({ id, agentId: agent.id, status: "online" }) },
+    { name: "Credential",      body: (id) => ({ id, agentId: agent.id, name: "k", value: "v" }) },
+    { name: "MemoryGrant",     body: (id) => ({ id, ownerId: agent.id, granteeId: "x", scope: "read" }) },
+    { name: "OrgEvent",        body: (id) => ({ id, authorId: agent.id, kind: "note", body: "anon" }) },
+    { name: "Agent",           body: (id) => ({ id, displayName: "anon", role: "agent" }) },
+    // observatory read-models (public read; writes are system-driven → must deny anon)
+    { name: "ObsOffice",        body: (id) => ({ id, data: "anon" }) },
+    { name: "ObsAgentSnapshot", body: (id) => ({ id, agentId: agent.id, data: "anon" }) },
+    { name: "ObsEventFeed",     body: (id) => ({ id, data: "anon" }) },
+    // admin / system / federation tables (no agent grant → must deny anon)
+    { name: "Instance",        body: (id) => ({ id, name: "anon" }) },
+    { name: "Peer",            body: (id) => ({ id, url: "http://x" }) },
+    { name: "PairingToken",    body: (id) => ({ id, token: "anon" }) },
+    { name: "OAuthClient",     body: (id) => ({ id, clientId: "anon" }) },
+    { name: "IdpConfig",       body: (id) => ({ id, issuer: "anon" }) },
+  ];
+  for (const r of AGENT_WRITE_RESOURCES) {
+    test(`ANONYMOUS: no-auth PUT /${r.name} is denied (anonymous write rejected)`, async () => {
+      const id = `anon-${r.name}-${Date.now()}`;
+      const res = await fetch(`${harper.httpURL}/${r.name}/${id}`, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(r.body(id)),
+      });
+      expect([401, 403], `anon PUT /${r.name} returned ${res.status} (expected 401/403)`).toContain(res.status);
+    }, 30_000);
+  }
 });

--- a/test/integration/smoke.test.ts
+++ b/test/integration/smoke.test.ts
@@ -33,8 +33,11 @@ describe("Flair API E2E Smoke", () => {
 
   test("REST endpoint returns data", async () => {
     const res = await fetch(`${harper.httpURL}/Agent/smoke-test`);
-    // authorizeLocal: true means we expect 401 without auth
-    expect([200, 401]).toContain(res.status);
+    // No auth: 200 if authorizeLocal trusts localhost, else denied. Post auth-flip
+    // the Agent table self-authorizes (allowRead=allowVerified), so anonymous is
+    // denied with 403 (the public discovery surface is AgentCard, not Agent). 401
+    // is the pre-flip gate rejection — accept all three.
+    expect([200, 401, 403]).toContain(res.status);
     if (res.status === 200) {
       const body = await res.json();
       expect(body.id).toBe("smoke-test");


### PR DESCRIPTION
Completes the auth-rbac reshape (spec: `flair-auth-flip.md`, Sherlock-hard). The flip itself is 3 changes; building it surfaced that **#487's per-resource self-enforcement was incomplete** — so this PR also closes the anonymous-access holes the flip exposes.

## The flip
- **Non-rejecting gate** (`auth-middleware.ts`): anonymous requests are annotated (`tpsAnonymous`) and passed through; per-resource `allow*` is the authority (fixes the composite-hub 401). Admin-page `WWW-Authenticate` 401 preserved.
- **Per-agent de-elevation**: a verified non-admin agent resolves to the least-privilege `flair-agent` user, not admin super_user. **Bug found+fixed:** `getUser(name, null)` returns a role-less phantom `{username}` for a nonexistent user (harper `security/user.js`), so `?? admin` kept the phantom → 403 cascade; now fall back to admin only when the resolved user has no `.role`.
- **`ensureFlairAgentUser` wired into init** (`src/cli.ts`) — activates de-elevation.

## The finding: #487 covered only ~6 of 18 @export tables
The non-rejecting gate returns for anonymous **before** its per-resource mutation guards (those only run for verified agents), and Harper's default `@table` handler does **not** deny no-user writes. So the global rejecting gate was the *only* protection for the rest. A full audit + a new parametrized anonymous-write test matrix (all 17 routable @export tables) found ~11 that accepted anonymous writes — including **`Agent.post` with no auth at all** (anyone could register a principal) and **`IdpConfig`** (a name-collision where the un-guarded `XAA.ts` class won; "admin-only" was a comment, not enforced).

Closed via the spec's per-resource model (G1 — no central gate deny):
- **agent-facing, own-scoped** (`resolveAgentAuth` → deny anonymous + ownership): Memory, Soul, Integration, OrgEvent, Agent, MemoryGrant (new), Presence (put/delete).
- **admin/system only** (`allowAdmin`; internal OAuth/pairing flows still pass): Peer, PairingToken, OAuthClient (new), IdpConfig (XAA class).
- **read-allowed / admin-write**: Instance, ObsOffice, ObsAgentSnapshot, ObsEventFeed.

## 🔒 For Sherlock
- **Obs\* `allowRead`** defaults to `allowVerified` (deny anonymous) — the secure default. If the public Office Space renderer needs anonymous Obs reads, relax to `allowRead=true` **WITH field-allowlisting** (like `Presence.get`), never raw rows. Please confirm.
- Admin/system tables use `allowAdmin` everywhere; OAuth/pairing public flows go through dedicated endpoints (internal calls → `allowAdmin` permits `internal`). Please confirm no direct-table read is needed by those flows.
- `allowCreate=allowAdmin` on Agent — confirm agent seeding (ops/REST internal path) still provisions.

## Tests
Full suite green locally after `bun run build`: **unit 1029/0, integration 110/0**. `tsc` has 1 pre-existing error (`auth-middleware.ts:92` TS2722, stash-confirmed — not from this PR). MemoryCandidate excluded from the matrix (no `@export` → not REST-routable).

**Not merging without Nathan's go.** K&S review requested via TPS mail.