### PR TITLE
flair-mcp: Claude Code SessionStart auto-recall hook

### DIFF
--- a/docs/mcp-clients.md
+++ b/docs/mcp-clients.md
@@ -71,6 +71,52 @@ Or, if you prefer the project-scoped `.mcp.json` checked into your repo:
 }
 ```
 
+#### Auto-recall on session start (optional hook)
+
+The MCP server gives the agent *pull* access to memory — it calls `bootstrap` /
+`memory_search` when it decides to. If you'd rather have Flair context loaded
+automatically the moment a session opens (no "call the bootstrap tool" nudge),
+register Flair's `SessionStart` hook. It's a separate bin shipped in the same
+package and is entirely optional — it complements the MCP server, it doesn't
+replace it.
+
+Add a `SessionStart` hook to `~/.claude/settings.json`:
+
+```json
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "FLAIR_AGENT_ID=me npx -y @tpsdev-ai/flair-mcp flair-session-start"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+Swap `me` for your `FLAIR_AGENT_ID`. The hook reads Claude Code's SessionStart
+payload on stdin, calls Flair's `bootstrap` (soul + relevant memories +
+predicted context, scoped to your project by the session's working directory),
+and emits it as `hookSpecificOutput.additionalContext` — which Claude Code
+injects into the new session's context. The matcher is omitted, so it fires on
+every session start (`startup`, `resume`, `clear`, `compact`); add
+`"matcher": "startup"` to a hook group if you only want it on fresh sessions.
+
+It honors the same env as the MCP server (`FLAIR_AGENT_ID`, `FLAIR_URL`,
+`FLAIR_KEY_PATH`), plus `FLAIR_HOOK_TIMEOUT_MS` (default 8000, clamped
+500–30000) for the bootstrap timeout.
+
+**It degrades to a no-op, always.** No `FLAIR_AGENT_ID`, Flair down, an auth
+error, or a hung daemon (past the timeout) → the hook prints `{}` and exits 0.
+Claude Code treats that as "no context to add" and starts normally. The hook
+can never block or break session startup. The injected context is clamped to
+≤10,000 characters to keep the session-start payload small.
+
 ### Gemini CLI
 
 Edit `~/.gemini/settings.json` (create it if absent):

--- a/packages/flair-mcp/package.json
+++ b/packages/flair-mcp/package.json
@@ -5,7 +5,8 @@
   "type": "module",
   "main": "dist/index.js",
   "bin": {
-    "flair-mcp": "dist/index.js"
+    "flair-mcp": "dist/index.js",
+    "flair-session-start": "dist/session-start-hook.js"
   },
   "files": [
     "dist/",
@@ -14,8 +15,9 @@
   ],
   "scripts": {
     "build": "tsc --noCheck",
+    "test": "bun test",
     "prepublishOnly": "npm run build",
-    "postinstall": "node -e \"try{const{chmodSync,statSync}=require('fs');const p='dist/index.js';if(statSync(p).isFile()){chmodSync(p,0o755);console.error('@tpsdev-ai/flair-mcp: chmod +x ' + p + ' OK')}}catch(e){if(e.code!=='ENOENT')console.error('postinstall warn:',e.message)}\""
+    "postinstall": "node -e \"try{const{chmodSync,statSync}=require('fs');for(const p of ['dist/index.js','dist/session-start-hook.js']){try{if(statSync(p).isFile()){chmodSync(p,0o755);console.error('@tpsdev-ai/flair-mcp: chmod +x ' + p + ' OK')}}catch(e){if(e.code!=='ENOENT')console.error('postinstall warn:',e.message)}}}catch(e){console.error('postinstall warn:',e.message)}\""
   },
   "publishConfig": {
     "access": "public"

--- a/packages/flair-mcp/src/session-start-hook.ts
+++ b/packages/flair-mcp/src/session-start-hook.ts
@@ -1,0 +1,217 @@
+#!/usr/bin/env node
+
+/**
+ * Flair SessionStart hook for Claude Code — auto-recall on session start.
+ *
+ * Claude Code fires `SessionStart` hooks when a session begins (startup,
+ * resume, clear, compact). A hook of `type: "command"` receives the hook
+ * payload as JSON on stdin and may print a JSON object whose
+ * `hookSpecificOutput.additionalContext` string is injected into the model's
+ * context for that session. This binary uses that channel to inject Flair's
+ * `bootstrap` context (soul + relevant memories + predicted context), so a
+ * fresh Claude Code session starts already warmed with the agent's memory —
+ * no manual "call the bootstrap tool" nudge required.
+ *
+ * It complements the MCP server (`flair-mcp`): the MCP server gives the agent
+ * pull tools (memory_search / memory_store / bootstrap on demand) and push
+ * recall, while this hook does a one-shot context push at session start.
+ *
+ * NO-OP-ON-ANY-FAILURE GUARANTEE
+ * ------------------------------
+ * This hook can never block or break Claude Code startup. Every failure mode —
+ * missing FLAIR_AGENT_ID, malformed stdin, Flair unreachable, auth error, a
+ * hung daemon, an unexpected throw — degrades to printing `{}` (an empty,
+ * inert hook output) and exiting 0. It never throws, never writes to stderr in
+ * a way that surfaces to the user, and never exits non-zero.
+ *
+ * A hard timeout (FLAIR_HOOK_TIMEOUT_MS, default 8s) wraps the bootstrap call
+ * so a stalled Flair daemon can't hang session startup; on timeout we no-op.
+ *
+ * CONFIG (env, read identically to the MCP server)
+ * ------------------------------------------------
+ *   FLAIR_AGENT_ID   (required — absent → no-op)  agent identity
+ *   FLAIR_URL        (default http://localhost:19926 via flair-client)
+ *   FLAIR_KEY_PATH   (default ~/.flair/keys/<agent>.key via flair-client)
+ *   FLAIR_HOOK_TIMEOUT_MS (default 8000; clamped 500..30000)
+ *
+ * USAGE — register in ~/.claude/settings.json:
+ *   {
+ *     "hooks": {
+ *       "SessionStart": [
+ *         { "hooks": [ { "type": "command",
+ *           "command": "FLAIR_AGENT_ID=me npx -y @tpsdev-ai/flair-mcp flair-session-start" } ] }
+ *       ]
+ *     }
+ *   }
+ */
+
+import { FlairClient } from "@tpsdev-ai/flair-client";
+import { basename } from "node:path";
+
+/** Claude Code SessionStart additionalContext hard limit (chars). */
+const MAX_CHARS = 10_000;
+
+/** Token budget for the bootstrap call — matches the proven prototype. */
+const BOOTSTRAP_MAX_TOKENS = 2000;
+
+/** Default hard timeout on the bootstrap call (ms). */
+const DEFAULT_TIMEOUT_MS = 8000;
+const TIMEOUT_FLOOR_MS = 500;
+const TIMEOUT_CEILING_MS = 30_000;
+
+/** Empty, inert hook output. Printing this is always a safe no-op. */
+const NOOP_OUTPUT = "{}";
+
+/** Shape of the SessionStart payload Claude Code writes to stdin (subset). */
+interface SessionStartInput {
+  cwd?: string;
+  source?: string;
+  session_id?: string;
+  [key: string]: unknown;
+}
+
+/** Minimal surface of FlairClient this hook depends on (eases testing). */
+interface BootstrapClient {
+  bootstrap(opts: {
+    maxTokens?: number;
+    channel?: string;
+    subjects?: string[];
+  }): Promise<{ context?: string } | undefined>;
+}
+
+/** Resolve the bootstrap timeout from env, clamped to a sane range. */
+function resolveTimeoutMs(): number {
+  const raw = process.env.FLAIR_HOOK_TIMEOUT_MS;
+  const parsed = raw != null ? Number(raw) : NaN;
+  return Number.isFinite(parsed) && parsed >= TIMEOUT_FLOOR_MS && parsed <= TIMEOUT_CEILING_MS
+    ? parsed
+    : DEFAULT_TIMEOUT_MS;
+}
+
+/** Read all of stdin as a string. Resolves on EOF, with a short fallback for
+ *  interactive/manual runs where no stdin is piped (so it never hangs). */
+function readStdin(): Promise<string> {
+  return new Promise((resolve) => {
+    let data = "";
+    process.stdin.setEncoding("utf8");
+    process.stdin.on("data", (chunk) => (data += chunk));
+    process.stdin.on("end", () => resolve(data));
+    process.stdin.on("error", () => resolve(data));
+    // Manual-run fallback: if nothing is piped, don't block forever.
+    setTimeout(() => resolve(data), 200).unref?.();
+  });
+}
+
+/** Race a promise against a timeout. Rejects with a timeout error if exceeded. */
+function withTimeout<T>(promise: Promise<T>, ms: number): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error("bootstrap_timeout")), ms);
+    timer.unref?.();
+    promise.then(
+      (value) => {
+        clearTimeout(timer);
+        resolve(value);
+      },
+      (err) => {
+        clearTimeout(timer);
+        reject(err);
+      },
+    );
+  });
+}
+
+/** Build the SessionStart hook output JSON from a context string. */
+function hookOutput(context: string): string {
+  return JSON.stringify({
+    hookSpecificOutput: {
+      hookEventName: "SessionStart",
+      additionalContext: context,
+    },
+  });
+}
+
+/**
+ * Core hook logic, with injectable dependencies so it can be unit-tested
+ * without a live Flair daemon. Returns the exact string to print to stdout.
+ * NEVER throws — every failure path returns NOOP_OUTPUT.
+ *
+ * @param rawInput   the raw stdin string (may be empty / malformed)
+ * @param makeClient factory for the bootstrap client (defaults to FlairClient)
+ */
+export async function runHook(
+  rawInput: string,
+  makeClient: (agentId: string) => BootstrapClient = defaultClientFactory,
+): Promise<string> {
+  const agentId = process.env.FLAIR_AGENT_ID;
+  if (!agentId) return NOOP_OUTPUT; // no identity → no-op, never break the session
+
+  let input: SessionStartInput = {};
+  try {
+    input = (JSON.parse(rawInput || "{}") as SessionStartInput) ?? {};
+  } catch {
+    input = {}; // tolerate malformed stdin
+  }
+
+  const cwd = typeof input.cwd === "string" && input.cwd ? input.cwd : process.cwd();
+  const project = basename(cwd) || undefined;
+
+  let context = "";
+  try {
+    const client = makeClient(agentId);
+    const res = await withTimeout(
+      Promise.resolve(
+        client.bootstrap({
+          maxTokens: BOOTSTRAP_MAX_TOKENS,
+          channel: "claude-code",
+          subjects: project ? [project] : undefined,
+        }),
+      ),
+      resolveTimeoutMs(),
+    );
+    context = res && res.context ? String(res.context) : "";
+  } catch {
+    return NOOP_OUTPUT; // flair unreachable / auth error / timeout → no-op
+  }
+
+  if (!context.trim()) return NOOP_OUTPUT;
+  if (context.length > MAX_CHARS) context = context.slice(0, MAX_CHARS);
+
+  return hookOutput(context);
+}
+
+/** Default client factory — constructs a real FlairClient from FLAIR_* env,
+ *  identical to how src/index.ts builds it. */
+function defaultClientFactory(agentId: string): BootstrapClient {
+  return new FlairClient({
+    agentId,
+    url: process.env.FLAIR_URL,
+    keyPath: process.env.FLAIR_KEY_PATH,
+  });
+}
+
+/** Entry point. Reads stdin, runs the hook, prints the result, exits 0.
+ *  Wrapped so that even an unexpected throw degrades to a no-op. */
+async function main(): Promise<void> {
+  let output = NOOP_OUTPUT;
+  try {
+    output = await runHook(await readStdin());
+  } catch {
+    output = NOOP_OUTPUT;
+  }
+  process.stdout.write(output);
+}
+
+// Only run when executed as a script, not when imported by tests.
+// import.meta.main is set by Bun and Node 22.x; fall back to an argv check
+// for runtimes that don't populate it.
+const importMeta = import.meta as ImportMeta & { main?: boolean };
+const isMain =
+  importMeta.main === true ||
+  (typeof process !== "undefined" &&
+    process.argv[1] != null &&
+    import.meta.url === `file://${process.argv[1]}`);
+
+if (isMain) {
+  // .catch is belt-and-suspenders; main() already swallows everything.
+  void main().catch(() => process.stdout.write(NOOP_OUTPUT));
+}

--- a/packages/flair-mcp/test/session-start-hook.test.ts
+++ b/packages/flair-mcp/test/session-start-hook.test.ts
@@ -1,0 +1,139 @@
+import { describe, test, expect, afterEach } from "bun:test";
+import { runHook } from "../src/session-start-hook.ts";
+
+/**
+ * SessionStart hook tests — validate the no-op-on-any-failure guarantee and
+ * the happy-path output shape, with a stubbed bootstrap client so the tests
+ * never depend on a live Flair daemon.
+ *
+ * `runHook(rawInput, makeClient)` is the pure core: it reads FLAIR_AGENT_ID
+ * from env, parses the stdin payload, calls the injected client's bootstrap(),
+ * and returns the exact string the binary prints to stdout. It NEVER throws.
+ */
+
+const MAX_CHARS = 10_000;
+const NOOP = "{}";
+
+const ORIGINAL_AGENT_ID = process.env.FLAIR_AGENT_ID;
+
+afterEach(() => {
+  if (ORIGINAL_AGENT_ID === undefined) delete process.env.FLAIR_AGENT_ID;
+  else process.env.FLAIR_AGENT_ID = ORIGINAL_AGENT_ID;
+});
+
+const SAMPLE_INPUT = JSON.stringify({
+  cwd: "/Users/dev/project-x",
+  source: "startup",
+  session_id: "abc123",
+});
+
+/** A client factory that should never be called (asserts the no-op short-circuits). */
+function failIfCalled(): never {
+  throw new Error("client factory should not be called");
+}
+
+describe("session-start hook", () => {
+  describe("no-op guarantees", () => {
+    test("no FLAIR_AGENT_ID → outputs {} and never builds a client", async () => {
+      delete process.env.FLAIR_AGENT_ID;
+      const out = await runHook(SAMPLE_INPUT, failIfCalled);
+      expect(out).toBe(NOOP);
+    });
+
+    test("unreachable flair (bootstrap rejects) → outputs {}, never throws", async () => {
+      process.env.FLAIR_AGENT_ID = "test-agent";
+      const out = await runHook(SAMPLE_INPUT, () => ({
+        bootstrap: async () => {
+          throw new TypeError("fetch failed"); // simulate connection error
+        },
+      }));
+      expect(out).toBe(NOOP);
+    });
+
+    test("auth error (bootstrap rejects) → outputs {}", async () => {
+      process.env.FLAIR_AGENT_ID = "test-agent";
+      const out = await runHook(SAMPLE_INPUT, () => ({
+        bootstrap: async () => {
+          const e = new Error("401 invalid_signature");
+          throw e;
+        },
+      }));
+      expect(out).toBe(NOOP);
+    });
+
+    test("empty / whitespace context → outputs {}", async () => {
+      process.env.FLAIR_AGENT_ID = "test-agent";
+      const out = await runHook(SAMPLE_INPUT, () => ({
+        bootstrap: async () => ({ context: "   \n  " }),
+      }));
+      expect(out).toBe(NOOP);
+    });
+
+    test("missing context field → outputs {}", async () => {
+      process.env.FLAIR_AGENT_ID = "test-agent";
+      const out = await runHook(SAMPLE_INPUT, () => ({
+        bootstrap: async () => ({}),
+      }));
+      expect(out).toBe(NOOP);
+    });
+
+    test("malformed stdin JSON → tolerated, still produces context", async () => {
+      process.env.FLAIR_AGENT_ID = "test-agent";
+      const out = await runHook("not-json{{{", () => ({
+        bootstrap: async () => ({ context: "## Identity\nrole: test" }),
+      }));
+      const parsed = JSON.parse(out);
+      expect(parsed.hookSpecificOutput.hookEventName).toBe("SessionStart");
+    });
+  });
+
+  describe("happy path output shape", () => {
+    test("context present → valid SessionStart hook JSON", async () => {
+      process.env.FLAIR_AGENT_ID = "test-agent";
+      const context = "## Identity\nrole: test agent\n\n## Recent\n- shipped the hook";
+      const out = await runHook(SAMPLE_INPUT, () => ({
+        bootstrap: async () => ({ context }),
+      }));
+      const parsed = JSON.parse(out);
+      expect(parsed.hookSpecificOutput).toBeDefined();
+      expect(parsed.hookSpecificOutput.hookEventName).toBe("SessionStart");
+      expect(parsed.hookSpecificOutput.additionalContext).toBe(context);
+    });
+
+    test("derives project subject from cwd basename", async () => {
+      process.env.FLAIR_AGENT_ID = "test-agent";
+      let seenSubjects: string[] | undefined;
+      let seenChannel: string | undefined;
+      await runHook(SAMPLE_INPUT, () => ({
+        bootstrap: async (opts) => {
+          seenSubjects = opts.subjects;
+          seenChannel = opts.channel;
+          return { context: "ctx" };
+        },
+      }));
+      expect(seenSubjects).toEqual(["project-x"]);
+      expect(seenChannel).toBe("claude-code");
+    });
+
+    test("additionalContext is clamped to ≤ 10000 chars", async () => {
+      process.env.FLAIR_AGENT_ID = "test-agent";
+      const huge = "x".repeat(MAX_CHARS + 5000);
+      const out = await runHook(SAMPLE_INPUT, () => ({
+        bootstrap: async () => ({ context: huge }),
+      }));
+      const parsed = JSON.parse(out);
+      expect(parsed.hookSpecificOutput.additionalContext.length).toBeLessThanOrEqual(MAX_CHARS);
+      expect(parsed.hookSpecificOutput.additionalContext.length).toBe(MAX_CHARS);
+    });
+
+    test("output is always valid JSON", async () => {
+      process.env.FLAIR_AGENT_ID = "test-agent";
+      const out = await runHook(SAMPLE_INPUT, () => ({
+        bootstrap: async () => ({ context: 'has "quotes" and \n newlines \\ backslashes' }),
+      }));
+      expect(() => JSON.parse(out)).not.toThrow();
+      const parsed = JSON.parse(out);
+      expect(parsed.hookSpecificOutput.additionalContext).toContain("quotes");
+    });
+  });
+});


### PR DESCRIPTION
## What

Adds a `flair-session-start` bin to `@tpsdev-ai/flair-mcp` — a **Claude Code SessionStart hook** that auto-injects Flair's `bootstrap` context (soul + relevant memories + predicted context) into a fresh session, before turn one. Turns Flair from a *pull* tool the agent must remember to call into a *push* memory layer that's just there on boot.

This is phase 1 of making Flair the first-class **sovereign memory layer for Claude Code**: the MCP server (pull tools — `memory_search`/`bootstrap`/etc.) already ships; this adds the automatic-recall half. Phase 2 (a `Stop`-hook auto-persist) is a planned follow-up.

## How
- Reads the SessionStart payload on stdin → `flair.bootstrap({ channel: "claude-code", subjects: [project] })` → emits `hookSpecificOutput.additionalContext`.
- Registered via `~/.claude/settings.json` (recipe added to `docs/mcp-clients.md`).

## Safety — no-op on any failure
The hook **can never block or break CC startup**. Missing `FLAIR_AGENT_ID`, malformed stdin, Flair unreachable, auth error, hung daemon (8s clamped timeout), or any unexpected throw → prints `{}` and exits 0. Context clamped to 10k chars. `runHook` is dependency-injected and never throws.

## Tests / verification
- `test/session-start-hook.test.ts` — 11 tests (no-identity → `{}`; unreachable/stub → `{}`, never throws; valid output shape + ≤10k). **27 pass / 0 fail** in-package.
- `tsc --noEmit` (typecheck-strict gate): clean.
- Live (rockit, against the running daemon): valid SessionStart JSON with 10k chars of real context; no-identity → `{}`.

## Caveat (conscious call for review)
The flair-mcp **package tests are not CI-gated** — root `test.yml` runs `bun test test/unit/` only, so this package's tests (incl. the existing `mcp.test.ts`) don't gate the PR. `typecheck-strict` *does* cover the new source. Wiring package tests into CI is a separate change worth doing — flagging rather than silently shipping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
