### PR TITLE
release: v0.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## 0.12.0 (2026-06-18)
+
+> **Auth-RBAC reshape + Claude Code auto-recall.** The agent-auth boundary moves from a single rejecting gate to a non-rejecting gate plus per-resource self-enforcement, with every agent running as a least-privilege identity. And Flair becomes *automatic* memory for Claude Code: a SessionStart hook injects soul + relevant memories at session start, no manual tool call.
+
+### 🔒 Auth-RBAC reshape: non-rejecting gate + per-agent de-elevation — #487, #489
+
+The HTTP auth boundary is rebuilt. The global gate no longer rejects; it annotates the request and every `@table`/custom resource self-enforces via a three-way verdict (internal / verified-agent / anonymous), denying anonymous writes per-resource. Each agent runs as a de-elevated least-privilege `flair-agent` user instead of admin. Closes anonymous-write holes across Memory, Soul, Integration, Presence, Agent, and the federation/pairing resources, and fixes a phantom-user fallback `getUser` returned for unprovisioned instances. (#487 laid the foundation — per-agent identity + the `flair_agent` role + resource hardening, gate unchanged; #489 flipped the gate and completed per-resource enforcement.)
+
+### 🐛 Fresh hub provisioning: flair_pair_initiator role spec — #488
+
+`add_role` rejected the `flair_pair_initiator` role spec, breaking fresh hub provisioning. Fixed so a new federation hub stands up cleanly.
+
+### ✨ Claude Code SessionStart auto-recall hook — #490
+
+`@tpsdev-ai/flair-mcp` ships a new `flair-session-start` bin: register it as a Claude Code SessionStart hook and every session boots with Flair's `bootstrap` context (soul + relevant memories) auto-injected — Flair as a *push* memory layer, not just pull tools. No-op on any failure (never blocks startup), context clamped, opt-in via `~/.claude/settings.json`. See `docs/mcp-clients.md`.
+
 ## 0.11.0 (2026-06-09)
 
 > **Presence & Heartbeat API — the live agent-activity layer.** Agents report liveness and current task via Ed25519-signed heartbeats; a field-allowlisted public read surface exposes derived status (active / idle / offline) without leaking private data. Built as the backend for The Office Space — a live visualization of the agent fleet — and a concrete instance of zero-trust agent identity: an agent can only write its own presence. Ships alongside federation and Harper-lifecycle hardening.

--- a/bun.lock
+++ b/bun.lock
@@ -33,20 +33,21 @@
     },
     "packages/flair-client": {
       "name": "@tpsdev-ai/flair-client",
-      "version": "0.11.0",
+      "version": "0.12.0",
       "devDependencies": {
         "typescript": "5.9.3",
       },
     },
     "packages/flair-mcp": {
       "name": "@tpsdev-ai/flair-mcp",
-      "version": "0.11.0",
+      "version": "0.12.0",
       "bin": {
         "flair-mcp": "dist/index.js",
+        "flair-session-start": "dist/session-start-hook.js",
       },
       "dependencies": {
         "@modelcontextprotocol/sdk": "1.27.1",
-        "@tpsdev-ai/flair-client": "0.11.0",
+        "@tpsdev-ai/flair-client": "0.12.0",
         "zod": "4.3.6",
       },
       "devDependencies": {
@@ -55,7 +56,7 @@
     },
     "packages/langgraph-flair": {
       "name": "@tpsdev-ai/langgraph-flair",
-      "version": "0.11.0",
+      "version": "0.12.0",
       "dependencies": {
         "@tpsdev-ai/flair-client": "0.8.3",
       },
@@ -65,7 +66,7 @@
     },
     "packages/n8n-nodes-flair": {
       "name": "@tpsdev-ai/n8n-nodes-flair",
-      "version": "0.11.0",
+      "version": "0.12.0",
       "dependencies": {
         "@tpsdev-ai/flair-client": "0.8.1",
         "zod": "3.25.76",
@@ -84,7 +85,7 @@
     },
     "packages/openclaw-flair": {
       "name": "@tpsdev-ai/openclaw-flair",
-      "version": "0.11.0",
+      "version": "0.12.0",
       "dependencies": {
         "@sinclair/typebox": "0.34.48",
         "@tpsdev-ai/flair-client": "0.8.3",
@@ -98,7 +99,7 @@
     },
     "packages/pi-flair": {
       "name": "@tpsdev-ai/pi-flair",
-      "version": "0.11.0",
+      "version": "0.12.0",
       "dependencies": {
         "@sinclair/typebox": "0.34.48",
         "@tpsdev-ai/flair-client": "0.8.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tpsdev-ai/flair",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "description": "Identity, memory, and soul for AI agents. Cryptographic identity (Ed25519), semantic memory with local embeddings, and persistent personality — all in a single process.",
   "type": "module",
   "license": "Apache-2.0",

--- a/packages/flair-client/package.json
+++ b/packages/flair-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tpsdev-ai/flair-client",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "description": "Lightweight client for Flair — identity, memory, and soul for AI agents. Zero heavy dependencies.",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/flair-mcp/package.json
+++ b/packages/flair-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tpsdev-ai/flair-mcp",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "description": "MCP server for Flair — persistent memory for Claude Code, Cursor, and any MCP client.",
   "type": "module",
   "main": "dist/index.js",
@@ -27,7 +27,7 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "1.27.1",
-    "@tpsdev-ai/flair-client": "0.11.0",
+    "@tpsdev-ai/flair-client": "0.12.0",
     "zod": "4.3.6"
   },
   "license": "Apache-2.0",

--- a/packages/langgraph-flair/package.json
+++ b/packages/langgraph-flair/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tpsdev-ai/langgraph-flair",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "description": "LangGraph BaseStore adapter backed by Flair — durable agent memory with crypto-pinned identity, federation, and cross-orchestrator portability.",
   "type": "module",
   "main": "dist/index.js",
@@ -36,7 +36,7 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
-    "@tpsdev-ai/flair-client": "0.11.0"
+    "@tpsdev-ai/flair-client": "0.12.0"
   },
   "peerDependencies": {
     "@langchain/langgraph-checkpoint": ">=0.0.10"

--- a/packages/n8n-nodes-flair/package.json
+++ b/packages/n8n-nodes-flair/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tpsdev-ai/n8n-nodes-flair",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "description": "n8n community node — use Flair as your AI Agent's memory backend. Includes FlairChatMemory (Memory port) and FlairSearch (Tool port).",
   "type": "commonjs",
   "main": "dist/index.js",
@@ -48,7 +48,7 @@
     "langchain"
   ],
   "dependencies": {
-    "@tpsdev-ai/flair-client": "0.11.0",
+    "@tpsdev-ai/flair-client": "0.12.0",
     "zod": "3.25.76"
   },
   "peerDependencies": {

--- a/packages/openclaw-flair/package.json
+++ b/packages/openclaw-flair/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tpsdev-ai/openclaw-flair",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "description": "OpenClaw memory plugin for Flair — agent identity and semantic memory",
   "type": "module",
   "main": "./dist/index.js",
@@ -58,7 +58,7 @@
   },
   "dependencies": {
     "@sinclair/typebox": "0.34.48",
-    "@tpsdev-ai/flair-client": "0.11.0"
+    "@tpsdev-ai/flair-client": "0.12.0"
   },
   "devDependencies": {
     "typescript": "5.9.3"

--- a/packages/pi-flair/package.json
+++ b/packages/pi-flair/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tpsdev-ai/pi-flair",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "description": "Flair memory extension for pi — persistent memory access from within pi sessions",
   "type": "module",
   "main": "dist/index.js",
@@ -21,7 +21,7 @@
     "node": ">=18"
   },
   "dependencies": {
-    "@tpsdev-ai/flair-client": "0.11.0",
+    "@tpsdev-ai/flair-client": "0.12.0",
     "@sinclair/typebox": "0.34.48"
   },
   "license": "Apache-2.0",


### PR DESCRIPTION
## Release v0.12.0

Version bump across all 7 workspace packages (`0.11.0` → `0.12.0`) plus the 5 internal `@tpsdev-ai/flair-client` dependency pins, refreshed `bun.lock`, and a new CHANGELOG section.

### What ships in 0.12.0
- 🔒 **Auth-RBAC reshape** — non-rejecting gate + per-resource self-enforcement + per-agent de-elevation to a least-privilege `flair-agent` identity (#487, #489)
- 🐛 **Fresh hub provisioning** — `flair_pair_initiator` role spec fix (#488)
- ✨ **Claude Code SessionStart auto-recall hook** — `flair-session-start` bin in `@tpsdev-ai/flair-mcp` (#490)

Full notes: see the new `## 0.12.0 (2026-06-18)` section in [CHANGELOG.md](https://github.com/tpsdev-ai/flair/blob/release-v0.12.0/CHANGELOG.md).

### Validation (in worktree)
- All 7 `package.json` files at `0.12.0`; all 5 internal `flair-client` deps at `0.12.0`
- `bun install` lockfile refreshed (`--frozen-lockfile` will pass)
- Builds clean: root, `build:cli`, `flair-client`, `flair-mcp`, `n8n-nodes-flair`
- Tests: **1139 pass, 0 fail** (`bun test test/unit/ test/integration/`)

### Release procedure (do NOT do as part of merge)
This PR only bumps versions + CHANGELOG. **Nothing is tagged or published here.** After merge:
1. Push tag `v0.12.0` → CI stages all 7 packages via OIDC trusted-publisher
2. Maintainer 2FA-approves the staged publish on npmjs.com

No tag, no publish, no merge as part of opening this PR.
