### PR TITLE
fix(cli): first-run onboarding — agent seed (#499), soul set (#498), agent list (#500)

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -544,41 +544,11 @@ export async function seedAgentViaOpsApi(
   }
 }
 
-// Seed an agent record via the Harper REST API.
-// Uses localhost and the given HTTP port.
-export async function seedAgentViaRestApi(
-  httpPort: number,
-  agentId: string,
-  pubKeyB64url: string,
-  adminPass: string,
-): Promise<void> {
-  const baseUrl = `http://127.0.0.1:${httpPort}`;
-  const body = {
-    operation: "insert",
-    database: "flair",
-    table: "Agent",
-    records: [{ id: agentId, name: agentId, publicKey: pubKeyB64url, createdAt: new Date().toISOString() }],
-  };
-
-  // Only send Authorization header if adminPass is provided.
-  // Matches the auth pattern in api() which respects authorizeLocal=true.
-  const headers: Record<string, string> = { "Content-Type": "application/json" };
-  if (adminPass) {
-    headers.Authorization = `Basic ${Buffer.from(`admin:${adminPass}`).toString("base64")}`;
-  }
-
-  const res = await fetch(`${baseUrl}/Agent`, {
-    method: "POST",
-    headers,
-    body: JSON.stringify(body),
-    signal: AbortSignal.timeout(10_000),
-  });
-  if (!res.ok) {
-    const text = await res.text().catch(() => "");
-    if (res.status === 409 || text.includes("duplicate") || text.includes("already exists")) return;
-    throw new Error(`REST API insert failed (${res.status}): ${text}`);
-  }
-}
+// NOTE: agent records are seeded exclusively via the Harper operations API
+// (seedAgentViaOpsApi above). A former seedAgentViaRestApi() helper POSTed the
+// ops-insert body to the REST root, which Harper 405s as a collection POST to
+// /Agent (the Agent table resource has no POST handler). It was removed in the
+// #499 fix; do not reintroduce a REST-root insert path.
 
 // ─── FederationInstance seed via ops API ──────────────────────────────────────
 //
@@ -2101,8 +2071,19 @@ program
       // Write config so other commands can find this instance
       writeConfig(httpPort);
     } else {
-      // Flair already initialized — resolve admin pass from env or running instance
+      // Flair already initialized — resolve admin pass from env, falling back to
+      // the persisted ~/.flair/admin-pass written at first install. Agent
+      // seeding now goes through the ops API (#499), which always requires Basic
+      // admin auth (it does NOT honor authorizeLocal), so a re-run of
+      // `flair install --agent <new-id>` against an already-initialized local
+      // Flair needs a real pass even when no env var is set.
       adminPass = process.env.FLAIR_ADMIN_PASS ?? process.env.HDB_ADMIN_PASSWORD ?? "";
+      if (!adminPass) {
+        try {
+          const persisted = join(homedir(), ".flair", "admin-pass");
+          if (existsSync(persisted)) adminPass = readFileSync(persisted, "utf-8").trim();
+        } catch { /* fall through with empty pass */ }
+      }
     }
 
     const httpUrl = `http://127.0.0.1:${httpPort}`;
@@ -2166,16 +2147,18 @@ program
       const pubKeyB64url = b64url(kp.publicKey);
       console.log(`Keypair written: ${privPath} ✓`);
 
-      // Seed agent - use REST API for local Harper, Ops API only when --ops-target is specified
-      if (opts.opsTarget) {
-        // Remote Harper via explicit ops target
-        console.log(`Seeding agent '${agentId}' via operations API (--ops-target)...`);
-        await seedAgentViaOpsApi(opts.opsTarget, agentId, pubKeyB64url, adminUser, adminPass);
-      } else {
-        // Local Harper - use REST API
-        console.log(`Seeding agent '${agentId}' via REST API...`);
-        await seedAgentViaRestApi(httpPort, agentId, pubKeyB64url, adminPass);
-      }
+      // Seed agent via the Harper operations API. The Agent table is a REST
+      // resource without a POST handler, so the insert body must go to the ops
+      // API (POST <opsUrl>/ with {operation:"insert",...}), NOT the REST root
+      // (which 405s the body as a collection POST to /Agent). This is the same
+      // path `flair agent add` uses. (#499)
+      const seedOpsTarget = opts.opsTarget ?? opsPort;
+      console.log(
+        opts.opsTarget
+          ? `Seeding agent '${agentId}' via operations API (--ops-target)...`
+          : `Seeding agent '${agentId}' via operations API...`,
+      );
+      await seedAgentViaOpsApi(seedOpsTarget, agentId, pubKeyB64url, adminUser, adminPass);
       console.log(`Agent '${agentId}' registered ✓`);
     }
 
@@ -2341,10 +2324,16 @@ agent
     if (adminPass) {
       const opsPort = resolveOpsPort(opts);
       const auth = Buffer.from(`${DEFAULT_ADMIN_USER}:${adminPass}`).toString("base64");
+      // List every Agent without null-scanning the primary key. A
+      // `starts_with ""` on `id` makes Harper search the index for nulls, which
+      // the bundled Harper (5.0.21) rejects with "id is not indexed for nulls".
+      // Use `createdAt > 1970-01-01` as the total "select all" predicate: every
+      // Agent row has a non-null createdAt (schema: createdAt: String!), and its
+      // index is built — same pattern as the `flair reembed` Memory scan. (#500)
       const res = await fetch(`http://127.0.0.1:${opsPort}/`, {
         method: "POST",
         headers: { "Content-Type": "application/json", Authorization: `Basic ${auth}` },
-        body: JSON.stringify({ operation: "search_by_value", schema: "flair", table: "Agent", search_attribute: "id", search_type: "starts_with", search_value: "", get_attributes: ["id", "name", "createdAt"] }),
+        body: JSON.stringify({ operation: "search_by_conditions", schema: "flair", table: "Agent", operator: "and", conditions: [{ search_attribute: "createdAt", search_type: "greater_than", search_value: "1970-01-01" }], get_attributes: ["id", "name", "createdAt"] }),
       });
       if (!res.ok) {
         const text = await res.text().catch(() => "");
@@ -7932,12 +7921,17 @@ soul.command("set")
   .option("--durability <d>", "permanent")
   .option("--json", "Emit raw JSON response (also: pipe + FLAIR_OUTPUT=json)")
   .action(async (opts) => {
-    const out = await api("POST", "/Soul", {
-      id: `${opts.agent}:${opts.key}`,
+    // PUT /Soul/{agentId:key} (upsert by id), matching flair-client's soul.set().
+    // The Soul table resource has no POST handler, so a collection POST /Soul
+    // 405s; the record must be written by its primary key. (#498)
+    const id = `${opts.agent}:${opts.key}`;
+    const out = await api("PUT", `/Soul/${encodeURIComponent(id)}`, {
+      id,
       agentId: opts.agent,
       key: opts.key,
       value: opts.value,
       durability: opts.durability,
+      createdAt: new Date().toISOString(),
     });
     const mode = render.resolveOutputMode(opts);
     if (mode === "json") {

--- a/test/integration/onboarding-smoke.test.ts
+++ b/test/integration/onboarding-smoke.test.ts
@@ -1,0 +1,155 @@
+/**
+ * onboarding-smoke.test.ts — first-run onboarding smoke test.
+ *
+ * Regression guard for the three first-run CLI bugs reported by an external
+ * dogfooder (HarperDB engineer kriszyp):
+ *   #499 — agent seeding must use the Harper operations API, not a REST-root
+ *          ops-insert (which 405s as a collection POST to /Agent).
+ *   #498 — `flair soul set` must PUT /Soul/{agentId:key}, not POST /Soul
+ *          (which 405s — the Soul table resource has no POST handler).
+ *   #500 — `flair agent list --admin-pass` must not null-scan the primary key
+ *          ("id is not indexed for nulls" 400 on bundled Harper 5.0.21).
+ *
+ * Drives the REAL built CLI (dist/cli.js) as subprocesses against a throwaway
+ * Harper:
+ *   - startHarper() spins Harper from a mkdtemp install dir on OS-assigned free
+ *     ports — NEVER ~/.flair, NEVER port 9926.
+ *   - The CLI subprocesses run with HOME pointed at a separate mktemp dir, so
+ *     the CLI's own ~/.flair (keys, config, admin-pass) is fully isolated too.
+ *   - stopHarper() kills the process and removes the temp install dir; the
+ *     CLI HOME temp dir is removed in afterAll.
+ *
+ * End-to-end flow exercised: agent add (#499 seed path) → soul set (#498)
+ * → agent list (#500).
+ *
+ * Build prerequisite: dist/cli.js and dist/resources/*.js must exist
+ * (`bun run build && bun run build:cli`).
+ */
+
+import { describe, expect, test, beforeAll, afterAll } from "bun:test";
+import { spawn } from "node:child_process";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { startHarper, stopHarper, type HarperInstance } from "../helpers/harper-lifecycle";
+
+const CLI = join(process.cwd(), "dist", "cli.js");
+const AGENT_ID = "krais-onboarding";
+const ADMIN_PASS = "test123"; // matches harper-lifecycle's seeded admin pass
+
+let harper: HarperInstance;
+let cliHome: string; // isolated HOME for the CLI's own ~/.flair
+
+interface RunResult {
+  code: number | null;
+  stdout: string;
+  stderr: string;
+}
+
+// Run the built CLI as a subprocess, pointed at the throwaway Harper instance.
+// HOME is an isolated temp dir, FLAIR_URL + FLAIR_OPS_PORT target the alt ports,
+// so nothing reads or writes the developer's real ~/.flair or port 9926.
+function runCli(args: string[], extraEnv: Record<string, string> = {}): Promise<RunResult> {
+  const opsPort = new URL(harper.opsURL).port;
+  return new Promise((resolve, reject) => {
+    const child = spawn(process.execPath, [CLI, ...args], {
+      env: {
+        ...process.env,
+        HOME: cliHome, // isolates ~/.flair (keys, config, admin-pass)
+        FLAIR_URL: harper.httpURL,
+        FLAIR_OPS_PORT: opsPort,
+        // Defensive: ensure no inherited token/admin identity leaks in. The
+        // agent identity comes from the on-disk key written by `agent add`
+        // (under cliHome/.flair/keys), resolved via FLAIR_AGENT_ID per-command.
+        FLAIR_TOKEN: "",
+        FLAIR_ADMIN_PASS: "",
+        ...extraEnv,
+      },
+    });
+    let stdout = "";
+    let stderr = "";
+    child.stdout?.on("data", (d: Buffer) => { stdout += d.toString(); });
+    child.stderr?.on("data", (d: Buffer) => { stderr += d.toString(); });
+    child.on("error", reject);
+    child.on("exit", (code) => resolve({ code, stdout, stderr }));
+    setTimeout(() => { child.kill(); reject(new Error(`CLI timed out: ${args.join(" ")}\n${stdout}\n${stderr}`)); }, 30_000);
+  });
+}
+
+beforeAll(async () => {
+  harper = await startHarper();
+  cliHome = await mkdtemp(join(tmpdir(), "flair-onboarding-home-"));
+}, 120_000);
+
+afterAll(async () => {
+  if (harper) await stopHarper(harper);
+  if (cliHome) await rm(cliHome, { recursive: true, force: true, maxRetries: 4 });
+});
+
+describe("first-run onboarding (real CLI, isolated temp Harper + home)", () => {
+  // #499: agent seeding goes through the ops API. `flair agent add` uses the
+  // exact seedAgentViaOpsApi(opsPort, ...) call the `flair install` fix now
+  // uses, so a green add proves the seed mechanism the install path depends on.
+  test("agent add seeds via ops API (#499)", async () => {
+    // No --keys-dir: write the key to the default ~/.flair/keys (under the
+    // isolated cliHome), so later Ed25519-authed commands resolve it.
+    const r = await runCli([
+      "agent", "add", AGENT_ID,
+      "--admin-pass", ADMIN_PASS,
+      "--port", new URL(harper.httpURL).port,
+      "--ops-port", new URL(harper.opsURL).port,
+    ]);
+    if (r.code !== 0) console.error(`agent add failed:\n${r.stdout}\n${r.stderr}`);
+    expect(r.code).toBe(0);
+    expect(r.stdout).toContain("registered");
+    // The old bug surfaced as a REST 405; assert that error never appears.
+    expect(`${r.stdout}${r.stderr}`).not.toContain("405");
+    expect(`${r.stdout}${r.stderr}`).not.toContain("does not have a post method");
+  });
+
+  // #498: soul set must PUT /Soul/{id}, not POST the collection.
+  test("soul set succeeds via PUT /Soul/{id} (#498)", async () => {
+    // soul set talks to the REST API via api(), which resolves the target from
+    // FLAIR_URL (set by runCli). It has no --port/--ops-port flags.
+    const r = await runCli([
+      "soul", "set",
+      "--agent", AGENT_ID,
+      "--key", "role",
+      "--value", "onboarding smoke",
+    ], { FLAIR_AGENT_ID: AGENT_ID });
+    if (r.code !== 0) console.error(`soul set failed:\n${r.stdout}\n${r.stderr}`);
+    expect(r.code).toBe(0);
+    expect(`${r.stdout}${r.stderr}`).not.toContain("405");
+    expect(`${r.stdout}${r.stderr}`).not.toContain("does not have a post method");
+
+    // Confirm the record actually landed: read it back via the server.
+    const id = `${AGENT_ID}:role`;
+    const res = await fetch(`${harper.httpURL}/Soul/${encodeURIComponent(id)}`, {
+      headers: { Authorization: "Basic " + Buffer.from(`admin:${ADMIN_PASS}`).toString("base64") },
+    });
+    expect(res.ok).toBe(true);
+    const soul = await res.json() as { id?: string; value?: string };
+    expect(soul.id).toBe(id);
+    expect(soul.value).toBe("onboarding smoke");
+  });
+
+  // #500: agent list with --admin-pass must not null-scan the PK.
+  test("agent list does not null-scan the PK (#500)", async () => {
+    // agent list resolves the ops port from FLAIR_OPS_PORT (set by runCli);
+    // it exposes --port but not --ops-port.
+    const r = await runCli([
+      "agent", "list",
+      "--admin-pass", ADMIN_PASS,
+      "--port", new URL(harper.httpURL).port,
+      "--json",
+    ]);
+    if (r.code !== 0) console.error(`agent list failed:\n${r.stdout}\n${r.stderr}`);
+    expect(r.code).toBe(0);
+    // The old bug surfaced as a 400 "id is not indexed for nulls".
+    expect(`${r.stdout}${r.stderr}`).not.toContain("not indexed for nulls");
+    expect(`${r.stdout}${r.stderr}`).not.toContain("400");
+    const agents = JSON.parse(r.stdout) as Array<{ id: string }>;
+    expect(Array.isArray(agents)).toBe(true);
+    expect(agents.some(a => a.id === AGENT_ID)).toBe(true);
+  });
+});


### PR DESCRIPTION
Three first-run onboarding bugs reported by an external dogfooder — HarperDB engineer **kriszyp** (his agent "KrAIs") — while installing the Flair CLI on a clean `~/.flair`. Each blocks fresh-user onboarding. All three were verified against a real bundled **Harper 5.0.21** (reproduced the exact 405/400, then confirmed the fix) before changing code, and are now guarded by an isolated end-to-end smoke test.

## Fixes

### #499 — `flair install` agent seeding fails 405 (highest)
`flair install` seeded the agent by POSTing a Harper **operations-API** insert body (`{operation:"insert", table:"Agent", records:[...]}`) to the **REST root**, which Harper 405s as a collection POST to `/Agent` (the `Agent` table resource has no POST handler). A fresh install left a keypair but **no Agent record**.

Fix: seed via the ops API (`POST <opsUrl>/`), exactly like `flair agent add` already does. The dead `seedAgentViaRestApi()` helper is removed so it can't be reintroduced. Also hardened the already-initialized re-install branch to fall back to the persisted `~/.flair/admin-pass` — the ops API requires Basic admin auth even locally (it does not honor `authorizeLocal`).

### #498 — `flair soul set` fails 405
`flair soul set` POSTed `/Soul` (collection) → 405. Now PUTs `/Soul/{agentId:key}` by primary key, matching `flair-client`'s `soul.set()`.

### #500 — `flair agent list` fails 400 ("id is not indexed for nulls")
`flair agent list --admin-pass` null-scanned the primary key (`search_by_value` with `starts_with ""` on `id`), which Harper 5.0.21 rejects. Now uses the total `createdAt > 1970-01-01` predicate (every `Agent` row has a non-null `createdAt`; schema `createdAt: String!`) — the same "select all" pattern as the `flair reembed` Memory scan. Data was never missing; purely the list query.

## Test

`test/integration/onboarding-smoke.test.ts` drives the **real built CLI** end-to-end — `agent add` (#499 seed path) → `soul set` (#498) → `agent list` (#500) — against a throwaway Harper:

- Harper boots from a `mktemp` install dir on **OS-assigned free ports** (never `~/.flair`, never port 9926), via the existing `harper-lifecycle` helper.
- CLI subprocesses run with `HOME` pointed at a **separate temp dir**, so the CLI's own `~/.flair` (keys, config, admin-pass) is isolated too.
- Both temp instances are torn down in `afterAll`.

Each assertion also verifies the old error string (405 / "not indexed for nulls") never appears, and reads the Soul record back to confirm it landed.

## Verification

- Full unit suite: **1012 pass, 0 fail**
- Full integration suite (incl. the new smoke test): **129 pass, 0 fail**
- Typechecks (`tsconfig.check.json`, `tsconfig.cli.json`): clean
- Pre-fix repro confirmed all three (405 / 405 / 400); post-fix confirmed all three resolved against real Harper 5.0.21.

Fixes #498
Fixes #499
Fixes #500
