### PR TITLE
fix(rem): don't archive brand-new memories; add `memory add --derived-from`

### DIFF
--- a/resources/MemoryConsolidate.ts
+++ b/resources/MemoryConsolidate.ts
@@ -18,55 +18,7 @@
 
 import { Resource, databases } from "@harperfast/harper";
 import { isAdmin, allowVerified } from "./agent-auth.js";
-
-function parseDuration(s: string): number {
-  const m = s.match(/^(\d+)([dhm])$/);
-  if (!m) return 30 * 86400_000;
-  const n = Number(m[1]);
-  if (m[2] === "d") return n * 86400_000;
-  if (m[2] === "h") return n * 3600_000;
-  if (m[2] === "m") return n * 60_000;
-  return 30 * 86400_000;
-}
-
-type Suggestion = "promote" | "archive" | "keep";
-
-interface Candidate {
-  memory: Record<string, unknown>;
-  suggestion: Suggestion;
-  reason: string;
-}
-
-function evaluate(record: any, now: number, olderThanMs: number): Candidate {
-  const ageMs = record.createdAt ? now - new Date(record.createdAt).getTime() : 0;
-  const count = record.retrievalCount ?? 0;
-  const daysSinceRetrieved = record.lastRetrieved
-    ? (now - new Date(record.lastRetrieved).getTime()) / 86400_000
-    : Infinity;
-  const { embedding, ...memory } = record;
-
-  // Promote: high retrieval + persistent durability
-  if (record.durability === "persistent" && count >= 5) {
-    return { memory, suggestion: "promote", reason: `Retrieved ${count} times — strong promotion candidate for permanent` };
-  }
-
-  // Promote: standard → persistent if retrieved frequently
-  if (record.durability === "standard" && count >= 3 && ageMs > 7 * 86400_000) {
-    return { memory, suggestion: "promote", reason: `Retrieved ${count} times over ${Math.round(ageMs / 86400_000)} days — worth persisting` };
-  }
-
-  // Archive: old + never retrieved
-  if (daysSinceRetrieved > 30 && count === 0 && ageMs > olderThanMs) {
-    return { memory, suggestion: "archive", reason: `Never retrieved, ${Math.round(ageMs / 86400_000)} days old` };
-  }
-
-  // Archive: last retrieved > 60 days
-  if (daysSinceRetrieved > 60 && count < 2) {
-    return { memory, suggestion: "archive", reason: `Not retrieved in ${Math.round(daysSinceRetrieved)} days (only ${count} total retrievals)` };
-  }
-
-  return { memory, suggestion: "keep", reason: `Retrieved ${count} times, ${Math.round(daysSinceRetrieved)} days since last retrieval` };
-}
+import { evaluate, parseDuration, type Suggestion, type Candidate } from "./memory-consolidate-lib.js";
 
 export class ConsolidateMemories extends Resource {
   // Self-authorize via the Ed25519 agent verify (auth reshape removes the gate's

--- a/resources/memory-consolidate-lib.ts
+++ b/resources/memory-consolidate-lib.ts
@@ -1,0 +1,85 @@
+// ─── Memory Consolidation — pure evaluation logic ───────────────────────────
+// Pure helpers extracted from MemoryConsolidate.ts (Flair #502) so they can be
+// unit-tested directly. Importing MemoryConsolidate.ts pulls in the Harper
+// runtime (`databases` / `Resource`, storage init) and can't run outside a live
+// Harper; this module has no Harper dependency, so
+// test/unit/memory-consolidate.test.ts exercises the real shipped code.
+
+export function parseDuration(s: string): number {
+  const m = s.match(/^(\d+)([dhm])$/);
+  if (!m) return 30 * 86400_000;
+  const n = Number(m[1]);
+  if (m[2] === "d") return n * 86400_000;
+  if (m[2] === "h") return n * 3600_000;
+  if (m[2] === "m") return n * 60_000;
+  return 30 * 86400_000;
+}
+
+export type Suggestion = "promote" | "archive" | "keep";
+
+export interface Candidate {
+  memory: Record<string, unknown>;
+  suggestion: Suggestion;
+  reason: string;
+}
+
+/**
+ * Classify a single memory record as a promote/archive/keep candidate.
+ *
+ * Idle age is `now - (lastRetrieved ?? createdAt)`: a memory that was just
+ * written and never read has lastRetrieved=null, so without the createdAt
+ * fallback its idle age would be Infinity and a minutes-old memory would read
+ * as maximally stale and be archived (Flair #502). The createdAt fallback
+ * measures "never retrieved" from when the memory was born.
+ *
+ * A grace window (olderThanMs — the maintenance olderThan) guarantees a
+ * freshly-created memory is never an archive candidate regardless of retrieval
+ * count: archival only considers memories that have had a fair chance to be read.
+ */
+export function evaluate(record: any, now: number, olderThanMs: number): Candidate {
+  const ageMs = record.createdAt ? now - new Date(record.createdAt).getTime() : 0;
+  const count = record.retrievalCount ?? 0;
+
+  const lastUse = record.lastRetrieved ?? record.createdAt;
+  const idleMs = lastUse ? now - new Date(lastUse).getTime() : 0;
+  const daysIdle = idleMs / 86400_000;
+  const everRetrieved = record.lastRetrieved != null;
+  const { embedding, ...memory } = record;
+
+  // Promote: high retrieval + persistent durability
+  if (record.durability === "persistent" && count >= 5) {
+    return { memory, suggestion: "promote", reason: `Retrieved ${count} times — strong promotion candidate for permanent` };
+  }
+
+  // Promote: standard → persistent if retrieved frequently
+  if (record.durability === "standard" && count >= 3 && ageMs > 7 * 86400_000) {
+    return { memory, suggestion: "promote", reason: `Retrieved ${count} times over ${Math.round(ageMs / 86400_000)} days — worth persisting` };
+  }
+
+  // Grace window: a freshly-created memory is never an archive candidate,
+  // regardless of retrieval count (Flair #502). Archive branches below are
+  // reachable only for memories older than the maintenance window.
+  if (ageMs <= olderThanMs) {
+    return { memory, suggestion: "keep", reason: everRetrieved
+      ? `Retrieved ${count} times, ${Math.round(daysIdle)} days since last retrieval`
+      : `Created ${Math.round(ageMs / 86400_000)} days ago, not yet retrieved (within grace window)` };
+  }
+
+  // Archive: old + never retrieved
+  if (daysIdle > 30 && count === 0) {
+    return { memory, suggestion: "archive", reason: everRetrieved
+      ? `Not retrieved in ${Math.round(daysIdle)} days, ${Math.round(ageMs / 86400_000)} days old`
+      : `Never retrieved, ${Math.round(ageMs / 86400_000)} days old` };
+  }
+
+  // Archive: idle > 60 days with few retrievals
+  if (daysIdle > 60 && count < 2) {
+    return { memory, suggestion: "archive", reason: everRetrieved
+      ? `Not retrieved in ${Math.round(daysIdle)} days (only ${count} total retrievals)`
+      : `Never retrieved, ${Math.round(ageMs / 86400_000)} days old (0 total retrievals)` };
+  }
+
+  return { memory, suggestion: "keep", reason: everRetrieved
+    ? `Retrieved ${count} times, ${Math.round(daysIdle)} days since last retrieval`
+    : `Created ${Math.round(ageMs / 86400_000)} days ago, not yet retrieved` };
+}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -4422,7 +4422,7 @@ rem
       console.log(result.prompt ?? "(no prompt returned)");
       console.log("--- End Prompt ---\n");
       console.log("Feed the prompt above to your LLM, then write insights back with:");
-      console.log("  flair memory add --agent <id> --content <insight> --durability persistent");
+      console.log("  flair memory add --agent <id> --content <insight> --durability persistent --derived-from <source-ids>");
     } catch (err: any) {
       console.error(`Error: ${err.message}`);
       process.exit(1);
@@ -7285,6 +7285,7 @@ memory.command("add [content]").requiredOption("--agent <id>")
   .option("--durability <d>", "standard").option("--tags <csv>")
   .option("--summary <text>", "agent-set multi-sentence dense compression (3-tier chain: subject → summary → content; ops-wkoh)")
   .option("--subject <text>", "one-line title / entity this memory is about")
+  .option("--derived-from <csv>", "Comma-separated source Memory IDs this memory was distilled/reflected from (sets Memory.derivedFrom; used by the `rem rapid` reflection loop)")
   .action(async (contentArg, opts) => {
     const content = contentArg ?? opts.content;
     if (!content) { console.error("error: content required (positional arg or --content)"); process.exit(1); }
@@ -7296,6 +7297,9 @@ memory.command("add [content]").requiredOption("--agent <id>")
     };
     if (opts.summary) body.summary = opts.summary;
     if (opts.subject) body.subject = opts.subject;
+    if (opts.derivedFrom) {
+      body.derivedFrom = String(opts.derivedFrom).split(",").map((x: string) => x.trim()).filter(Boolean);
+    }
     const out = await api("PUT", `/Memory/${memId}`, body);
     console.log(JSON.stringify(out, null, 2));
   });

--- a/test/unit/cli-memory-add-derived-from.test.ts
+++ b/test/unit/cli-memory-add-derived-from.test.ts
@@ -1,0 +1,87 @@
+// cli-memory-add-derived-from.test.ts — Flair #503
+//
+// `flair memory add` must expose `--derived-from <csv>` so the `rem rapid`
+// reflection loop can set provenance lineage (source episodic IDs → distilled
+// lesson) via the documented path. Before the fix the option didn't exist, so
+// derivedFrom could never be set through `memory add`.
+//
+// We spawn the real CLI against a mock HTTP server (FLAIR_URL), capture the PUT
+// /Memory/<id> body, and assert derivedFrom is populated. Mirrors cli-v2.test.ts.
+
+import { describe, it, expect } from "bun:test";
+import { spawn } from "node:child_process";
+import { createServer, IncomingMessage, ServerResponse, Server } from "node:http";
+
+type Capture = { method?: string; path?: string; body?: any };
+
+function startMockServer(onRequest: (cap: Capture) => void): Promise<{ server: Server; url: string }> {
+  return new Promise((resolve) => {
+    const server = createServer((req, res) => {
+      let body = "";
+      req.on("data", (c) => (body += c));
+      req.on("end", () => {
+        let parsed: any = undefined;
+        try { parsed = body ? JSON.parse(body) : undefined; } catch { parsed = body; }
+        onRequest({ method: req.method, path: req.url, body: parsed });
+        res.writeHead(200, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({ ok: true }));
+      });
+    });
+    server.listen(0, "127.0.0.1", () => {
+      const port = (server.address() as any).port;
+      resolve({ server, url: `http://127.0.0.1:${port}` });
+    });
+  });
+}
+
+function runCli(args: string[], env: NodeJS.ProcessEnv): Promise<{ code: number | null; stdout: string; stderr: string }> {
+  return new Promise((resolve) => {
+    const child = spawn("bun", ["src/cli.ts", ...args], { cwd: ".", env });
+    let out = "";
+    let err = "";
+    child.stdout?.on("data", (d) => (out += d.toString()));
+    child.stderr?.on("data", (d) => (err += d.toString()));
+    child.on("close", (code) => resolve({ code, stdout: out, stderr: err }));
+  });
+}
+
+describe("flair memory add --derived-from (Flair #503)", () => {
+  it("sets derivedFrom from a comma-separated list on the written memory", async () => {
+    const captures: Capture[] = [];
+    const { server, url } = await startMockServer((c) => captures.push(c));
+    try {
+      const { code } = await runCli(
+        ["memory", "add", "an insight distilled from episodics", "--agent", "krais", "--durability", "persistent", "--derived-from", "krais-111, krais-222 ,krais-333"],
+        { ...process.env, FLAIR_URL: url, FLAIR_AGENT_ID: "" },
+      );
+      expect(code).toBe(0);
+
+      const put = captures.find((c) => c.method === "PUT" && c.path?.startsWith("/Memory/"));
+      expect(put).toBeTruthy();
+      expect(Array.isArray(put!.body.derivedFrom)).toBe(true);
+      // CSV split + trim + drop empties
+      expect(put!.body.derivedFrom).toEqual(["krais-111", "krais-222", "krais-333"]);
+      expect(put!.body.agentId).toBe("krais");
+      expect(put!.body.durability).toBe("persistent");
+    } finally {
+      await new Promise<void>((r) => server.close(() => r()));
+    }
+  });
+
+  it("omits derivedFrom when --derived-from is not passed (no regression)", async () => {
+    const captures: Capture[] = [];
+    const { server, url } = await startMockServer((c) => captures.push(c));
+    try {
+      const { code } = await runCli(
+        ["memory", "add", "a plain memory", "--agent", "krais"],
+        { ...process.env, FLAIR_URL: url, FLAIR_AGENT_ID: "" },
+      );
+      expect(code).toBe(0);
+      const put = captures.find((c) => c.method === "PUT" && c.path?.startsWith("/Memory/"));
+      expect(put).toBeTruthy();
+      expect(put!.body.derivedFrom).toBeUndefined();
+    } finally {
+      await new Promise<void>((r) => server.close(() => r()));
+    }
+  });
+});

--- a/test/unit/memory-consolidate.test.ts
+++ b/test/unit/memory-consolidate.test.ts
@@ -1,0 +1,143 @@
+// Unit tests for the memory consolidation candidate logic (Flair #502).
+//
+// The bug: `rem light` flagged brand-new, never-retrieved memories for archive
+// because idle age keyed off `lastRetrieved` (null → Infinity) with no fallback
+// to `createdAt`. A minutes-old memory read as "Not retrieved in Infinity days"
+// and became an archive candidate.
+//
+// These tests exercise the real shipped `evaluate` from the Harper-free lib
+// (importing MemoryConsolidate.ts directly pulls in the Harper runtime).
+
+import { describe, test, expect } from "bun:test";
+import { evaluate, parseDuration } from "../../resources/memory-consolidate-lib.ts";
+
+const DAY = 86400_000;
+const NOW = Date.parse("2026-06-23T12:00:00.000Z");
+const ago = (ms: number) => new Date(NOW - ms).toISOString();
+const THIRTY_D = 30 * DAY;
+
+describe("parseDuration", () => {
+  test("parses days / hours / minutes", () => {
+    expect(parseDuration("7d")).toBe(7 * DAY);
+    expect(parseDuration("12h")).toBe(12 * 3600_000);
+    expect(parseDuration("90m")).toBe(90 * 60_000);
+  });
+  test("defaults to 30d on garbage input", () => {
+    expect(parseDuration("nonsense")).toBe(THIRTY_D);
+    expect(parseDuration("")).toBe(THIRTY_D);
+  });
+});
+
+describe("evaluate — Flair #502: brand-new memory must not be archived", () => {
+  test("a freshly-created, never-retrieved memory is NOT an archive candidate", () => {
+    // The exact repro: persistent memory written minutes ago, never read.
+    const record = {
+      id: "krais-1750000000000",
+      agentId: "krais",
+      durability: "persistent",
+      content: "a brand-new insight",
+      createdAt: ago(2 * 60_000), // 2 minutes ago
+      lastRetrieved: null,
+      retrievalCount: 0,
+    };
+    const c = evaluate(record, NOW, THIRTY_D);
+    expect(c.suggestion).toBe("keep");
+    expect(c.suggestion).not.toBe("archive");
+  });
+
+  test("the reason for a new memory never says 'Infinity days'", () => {
+    const record = {
+      id: "krais-x",
+      agentId: "krais",
+      durability: "persistent",
+      createdAt: ago(5 * 60_000),
+      lastRetrieved: null,
+      retrievalCount: 0,
+    };
+    const c = evaluate(record, NOW, THIRTY_D);
+    expect(c.reason).not.toContain("Infinity");
+  });
+
+  test("a never-retrieved memory just under the grace window is kept", () => {
+    const record = {
+      id: "krais-y",
+      agentId: "krais",
+      durability: "persistent",
+      createdAt: ago(THIRTY_D - DAY), // 29 days old — still in grace
+      lastRetrieved: null,
+      retrievalCount: 0,
+    };
+    expect(evaluate(record, NOW, THIRTY_D).suggestion).toBe("keep");
+  });
+
+  test("a standard never-retrieved memory inside grace is kept (count=0)", () => {
+    const record = {
+      id: "krais-z",
+      agentId: "krais",
+      durability: "standard",
+      createdAt: ago(3 * DAY),
+      lastRetrieved: null,
+      retrievalCount: 0,
+    };
+    const c = evaluate(record, NOW, THIRTY_D);
+    expect(c.suggestion).toBe("keep");
+    expect(c.reason).not.toContain("Infinity");
+  });
+});
+
+describe("evaluate — legitimately-old memories still archive (no regression)", () => {
+  test("never-retrieved memory older than the grace window IS archived", () => {
+    const record = {
+      id: "old-1",
+      agentId: "krais",
+      durability: "persistent",
+      createdAt: ago(90 * DAY),
+      lastRetrieved: null,
+      retrievalCount: 0,
+    };
+    const c = evaluate(record, NOW, THIRTY_D);
+    expect(c.suggestion).toBe("archive");
+    expect(c.reason).toContain("Never retrieved");
+    expect(c.reason).not.toContain("Infinity");
+  });
+
+  test("memory last retrieved >60 days ago with few retrievals IS archived", () => {
+    const record = {
+      id: "old-2",
+      agentId: "krais",
+      durability: "persistent",
+      createdAt: ago(100 * DAY),
+      lastRetrieved: ago(70 * DAY),
+      retrievalCount: 1,
+    };
+    const c = evaluate(record, NOW, THIRTY_D);
+    expect(c.suggestion).toBe("archive");
+    expect(c.reason).toContain("70 days");
+  });
+});
+
+describe("evaluate — promotion paths preserved", () => {
+  test("persistent memory retrieved >=5 times is a promote candidate", () => {
+    const record = {
+      id: "hot-1",
+      agentId: "krais",
+      durability: "persistent",
+      createdAt: ago(40 * DAY),
+      lastRetrieved: ago(DAY),
+      retrievalCount: 7,
+    };
+    expect(evaluate(record, NOW, THIRTY_D).suggestion).toBe("promote");
+  });
+
+  test("standard memory retrieved >=3 times over >7d is a promote candidate", () => {
+    const record = {
+      id: "hot-2",
+      agentId: "krais",
+      durability: "standard",
+      createdAt: ago(10 * DAY),
+      lastRetrieved: ago(DAY),
+      retrievalCount: 3,
+    };
+    expect(evaluate(record, NOW, THIRTY_D).suggestion).toBe("promote");
+  });
+});


### PR DESCRIPTION
Two memory-feature bugs reported by @kriszyp (HarperDB engineer, dogfooding Flair locally).

## #502 — `rem light` archives brand-new memories

**Root cause (reporter-diagnosed, verified in `resources/MemoryConsolidate.ts`):** idle age keyed off `lastRetrieved` with no fallback to `createdAt`:
```ts
const daysSinceRetrieved = record.lastRetrieved ? (now - new Date(record.lastRetrieved).getTime()) / 86400_000 : Infinity;
```
A just-written, never-read memory has `lastRetrieved=null` -> `daysSinceRetrieved = Infinity`, which hits the **unguarded** second archive branch (`daysSinceRetrieved > 60 && count < 2`) regardless of how recently the memory was created. The reported "Not retrieved in Infinity days (only 0 total retrievals)" is exactly `Math.round(Infinity)` in that branch's reason string.

**Fix:**
- Idle age is now `now - (lastRetrieved ?? createdAt)` — "never retrieved" is measured from when the memory was born, not from the epoch.
- A grace window (the maintenance `olderThan`) excludes any memory younger than the window from archival regardless of retrieval count.
- Null `lastRetrieved` no longer renders "Infinity days"; never-retrieved memories get a `Created N days ago, not yet retrieved` reason.
- Pure `evaluate`/`parseDuration` extracted into a Harper-free lib (`resources/memory-consolidate-lib.ts`) so they are unit-testable (mirrors the `scoring.ts` pattern).

Legitimately-old never-retrieved memories still archive — covered by no-regression tests.

## #503 — `flair memory add` has no `--derived-from`

The `rem rapid` reflection prompt instructs setting `derivedFrom=[<source ids>]` and writing via `memory add`, but `memory add` exposed no such option, so the provenance lineage could not be set via the documented loop.

**Fix:** added `--derived-from <csv>` to `flair memory add` (sets `Memory.derivedFrom`), matching `memory write-task-summary`'s existing shape. Updated the `rem rapid` hint to show the flag.

## Tests
- `test/unit/memory-consolidate.test.ts` — freshly-created never-retrieved memory is NOT an archive candidate; reason never says "Infinity"; grace-window boundary; no-regression for old memories; promotion paths preserved.
- `test/unit/cli-memory-add-derived-from.test.ts` — spawns the real CLI against a mock server; asserts `derivedFrom` is populated (CSV split/trim/drop-empties) and omitted when not passed.
- Full unit suite green: 1024 pass, 0 fail.

Fixes #502
Fixes #503

🤖 Generated with [Claude Code](https://claude.com/claude-code)