### PR TITLE
release: v0.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,33 @@
 # Changelog
 
+## 0.13.0 (2026-06-23)
+
+> **Onboarding that actually works, plus sharper memory hygiene.** First-run `flair install` now provisions an agent cleanly end-to-end, recall stops letting a single hot memory dominate unrelated queries, and consolidation no longer flags brand-new memories for archival. Adds `memory add --derived-from` for reflection provenance, and the auth-middleware suite now runs against real Harper.
+
+### 🐛 First-run onboarding fixed — #501
+
+The one-command `flair install` couldn't register its own agent — it POSTed a Harper ops-API body to the REST root, which 405s as a collection write. Now it seeds via the ops API (the path `flair agent add` already uses). `flair soul set` now PUTs `/Soul/{agentId:key}` instead of POSTing the collection (was 405), and `flair agent list` no longer null-scans the primary key (was 400 on bundled Harper 5.0.21). A new end-to-end onboarding smoke test guards the `install → soul set → agent list` path so it can't regress. (Reported by @kriszyp dogfooding locally — closes #498, #499, #500.)
+
+### 🐛 Recall: bound the retrieval-boost feedback loop — #493
+
+`retrievalBoost` was an unbounded `1 + 0.1·log2(retrievalCount)`, auto-incremented on every recall — a rich-get-richer loop that let a frequently-retrieved memory float to the top of unrelated queries. It's now gated behind a semantic-relevance floor and capped at ×1.1 (a tie-breaker, not an override). Composite recall recovers toward raw and cross-query magnets are eliminated.
+
+### 🐛 Consolidation: don't archive brand-new memories — #505
+
+`rem` consolidation keyed staleness off `lastRetrieved` with no fallback, so a just-written, never-read memory read as "Infinity days" stale and became an archive candidate. Idle age is now `now − (lastRetrieved ?? createdAt)` with a creation-age grace window, and the consolidation scoring is extracted to a Harper-free, unit-tested lib. (Reported by @kriszyp — closes #502.)
+
+### ✨ `flair memory add --derived-from` — #505
+
+`memory add` can now set `derivedFrom` provenance, so the `rem rapid` reflection loop can link a distilled lesson back to its source memories as the prompt instructs. (Closes #503.)
+
+### 🧪 Auth-middleware tests → real Harper — #494
+
+The auth-middleware suite now exercises Harper's real auth chain instead of a simulator — closing the gap that previously let auth bugs slip past K&S-approved PRs.
+
+### 🔧 n8n example: K&S review capture → ephemeral — #497
+
+The shipped `ks-review-capture` example wrote memories at `persistent`, teaching an anti-pattern that floods recall; re-tiered to `ephemeral` with durability guidance in the README.
+
 ## 0.12.0 (2026-06-18)
 
 > **Auth-RBAC reshape + Claude Code auto-recall.** The agent-auth boundary moves from a single rejecting gate to a non-rejecting gate plus per-resource self-enforcement, with every agent running as a least-privilege identity. And Flair becomes *automatic* memory for Claude Code: a SessionStart hook injects soul + relevant memories at session start, no manual tool call.

--- a/bun.lock
+++ b/bun.lock
@@ -33,21 +33,21 @@
     },
     "packages/flair-client": {
       "name": "@tpsdev-ai/flair-client",
-      "version": "0.12.0",
+      "version": "0.13.0",
       "devDependencies": {
         "typescript": "5.9.3",
       },
     },
     "packages/flair-mcp": {
       "name": "@tpsdev-ai/flair-mcp",
-      "version": "0.12.0",
+      "version": "0.13.0",
       "bin": {
         "flair-mcp": "dist/index.js",
         "flair-session-start": "dist/session-start-hook.js",
       },
       "dependencies": {
         "@modelcontextprotocol/sdk": "1.27.1",
-        "@tpsdev-ai/flair-client": "0.12.0",
+        "@tpsdev-ai/flair-client": "0.13.0",
         "zod": "4.3.6",
       },
       "devDependencies": {
@@ -56,7 +56,7 @@
     },
     "packages/langgraph-flair": {
       "name": "@tpsdev-ai/langgraph-flair",
-      "version": "0.12.0",
+      "version": "0.13.0",
       "dependencies": {
         "@tpsdev-ai/flair-client": "0.8.3",
       },
@@ -66,7 +66,7 @@
     },
     "packages/n8n-nodes-flair": {
       "name": "@tpsdev-ai/n8n-nodes-flair",
-      "version": "0.12.0",
+      "version": "0.13.0",
       "dependencies": {
         "@tpsdev-ai/flair-client": "0.8.1",
         "zod": "3.25.76",
@@ -85,7 +85,7 @@
     },
     "packages/openclaw-flair": {
       "name": "@tpsdev-ai/openclaw-flair",
-      "version": "0.12.0",
+      "version": "0.13.0",
       "dependencies": {
         "@sinclair/typebox": "0.34.48",
         "@tpsdev-ai/flair-client": "0.8.3",
@@ -99,7 +99,7 @@
     },
     "packages/pi-flair": {
       "name": "@tpsdev-ai/pi-flair",
-      "version": "0.12.0",
+      "version": "0.13.0",
       "dependencies": {
         "@sinclair/typebox": "0.34.48",
         "@tpsdev-ai/flair-client": "0.8.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tpsdev-ai/flair",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "description": "Identity, memory, and soul for AI agents. Cryptographic identity (Ed25519), semantic memory with local embeddings, and persistent personality — all in a single process.",
   "type": "module",
   "license": "Apache-2.0",

--- a/packages/flair-client/package.json
+++ b/packages/flair-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tpsdev-ai/flair-client",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "description": "Lightweight client for Flair — identity, memory, and soul for AI agents. Zero heavy dependencies.",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/flair-mcp/package.json
+++ b/packages/flair-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tpsdev-ai/flair-mcp",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "description": "MCP server for Flair — persistent memory for Claude Code, Cursor, and any MCP client.",
   "type": "module",
   "main": "dist/index.js",
@@ -27,7 +27,7 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "1.27.1",
-    "@tpsdev-ai/flair-client": "0.12.0",
+    "@tpsdev-ai/flair-client": "0.13.0",
     "zod": "4.3.6"
   },
   "license": "Apache-2.0",

--- a/packages/langgraph-flair/package.json
+++ b/packages/langgraph-flair/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tpsdev-ai/langgraph-flair",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "description": "LangGraph BaseStore adapter backed by Flair — durable agent memory with crypto-pinned identity, federation, and cross-orchestrator portability.",
   "type": "module",
   "main": "dist/index.js",
@@ -36,7 +36,7 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
-    "@tpsdev-ai/flair-client": "0.12.0"
+    "@tpsdev-ai/flair-client": "0.13.0"
   },
   "peerDependencies": {
     "@langchain/langgraph-checkpoint": ">=0.0.10"

--- a/packages/n8n-nodes-flair/package.json
+++ b/packages/n8n-nodes-flair/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tpsdev-ai/n8n-nodes-flair",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "description": "n8n community node — use Flair as your AI Agent's memory backend. Includes FlairChatMemory (Memory port) and FlairSearch (Tool port).",
   "type": "commonjs",
   "main": "dist/index.js",
@@ -48,7 +48,7 @@
     "langchain"
   ],
   "dependencies": {
-    "@tpsdev-ai/flair-client": "0.12.0",
+    "@tpsdev-ai/flair-client": "0.13.0",
     "zod": "3.25.76"
   },
   "peerDependencies": {

--- a/packages/openclaw-flair/package.json
+++ b/packages/openclaw-flair/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tpsdev-ai/openclaw-flair",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "description": "OpenClaw memory plugin for Flair — agent identity and semantic memory",
   "type": "module",
   "main": "./dist/index.js",
@@ -58,7 +58,7 @@
   },
   "dependencies": {
     "@sinclair/typebox": "0.34.48",
-    "@tpsdev-ai/flair-client": "0.12.0"
+    "@tpsdev-ai/flair-client": "0.13.0"
   },
   "devDependencies": {
     "typescript": "5.9.3"

--- a/packages/pi-flair/package.json
+++ b/packages/pi-flair/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tpsdev-ai/pi-flair",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "description": "Flair memory extension for pi — persistent memory access from within pi sessions",
   "type": "module",
   "main": "dist/index.js",
@@ -21,7 +21,7 @@
     "node": ">=18"
   },
   "dependencies": {
-    "@tpsdev-ai/flair-client": "0.12.0",
+    "@tpsdev-ai/flair-client": "0.13.0",
     "@sinclair/typebox": "0.34.48"
   },
   "license": "Apache-2.0",


### PR DESCRIPTION
## Release v0.13.0

Version bump across all 7 workspace packages + CHANGELOG. Full notes in `CHANGELOG.md`.

**Headlines:**
- 🐛 First-run onboarding fixed — `flair install` / `soul set` / `agent list` now work (closes #498/#499/#500, reported by @kriszyp dogfooding locally)
- 🐛 Recall: bound the retrievalBoost feedback loop — semantic floor + cap (#493)
- 🐛 Consolidation: don't archive brand-new memories (closes #502)
- ✨ `memory add --derived-from` for reflection provenance (closes #503)
- 🧪 auth-middleware tests → real Harper (#494) · 🔧 n8n example re-tiered (#497)

_Tests: 1153 pass / 0 fail locally. After merge:_ `./scripts/release.sh 0.13.0 --publish` _tags v0.13.0 → CI stages all 7 packages to npm via OIDC → maintainer 2FA-approves on npmjs.com (nothing publishes without that)._