### PR TITLE
ci(e2e): serialize Playwright on CI + retry transient drops

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -7,7 +7,16 @@ const basicAuth = "Basic " + Buffer.from(`admin:${adminPass}`).toString("base64"
 export default defineConfig({
   testDir: "./test/e2e",
   timeout: 30_000,
-  retries: 0,
+  // The E2E suite runs against the Docker Harper 5.0.1 image, which carries the
+  // HarperFast/harper#386 HNSW concurrent-write race (the integration tests dodge
+  // it via native spawn; the browser/UI E2E path still needs the Docker server).
+  // Parallel Playwright workers fire concurrent writes that trip that race, which
+  // momentarily drops the server → `socket hang up` / `ERR_CONNECTION_RESET`
+  // failures (ops-qhp0). On CI: serialize to one worker so writes don't race, and
+  // retry transient connection drops instead of failing the whole job. Locally
+  // (no CI env) keep full parallelism + no retries for fast, honest feedback.
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 1 : undefined,
   reporter: "list",
   use: {
     baseURL,


### PR DESCRIPTION
Fixes the recurring flaky **Integration Tests** E2E failure (`socket hang up` / `ERR_CONNECTION_RESET` to the test server) — the flake that reddened #505 and the v0.13.0 main-branch CI run (it cried wolf next to a green, published release).

**Root cause:** the browser/UI E2E suite runs against the **Docker** Harper 5.0.1 image, which carries the HarperFast/harper#386 HNSW concurrent-write race. The integration tests already dodge it via native spawn; the browser E2E path still needs the Docker server. Playwright runs **parallel** workers by default, so concurrent writes trip that race → the server momentarily drops connections → the resets we keep seeing. And `retries: 0` meant a single blip failed the whole job.

**Fix (CI only):**
- `workers: 1` — serialize the E2E so writes don't race → doesn't trigger #386
- `retries: 2` — transient connection drops auto-retry instead of failing the job

Local runs keep full parallelism + `retries: 0` for fast, honest feedback. Tracked: ops-qhp0.