### PR TITLE
fix: A2A advertises real HTTP port (#507) + memory add --visibility (#509)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## Unreleased
+
+### 🐛 A2A discovery advertised a dead port — #507
+
+The A2A agent-card `url` (and the streaming catch-up self-fetch) hardcoded port `9926`, but a default local install listens on `DEFAULT_HTTP_PORT` (`19926`) — so a remote A2A peer following discovery hit a dead port. The agent card now resolves the URL the caller actually reached us on (`FLAIR_PUBLIC_URL` → request `Host`/`X-Forwarded-*` headers → `127.0.0.1:${HTTP_PORT}`, mirroring the admin-pane `resolvePublicUrl` from #404), and the in-process catch-up fetch targets the real `HTTP_PORT` loopback. (Reported by @kriszyp — closes #507.)
+
+### ✨ `flair memory add --visibility` — #509
+
+`memory add` now accepts `--visibility <value>` (e.g. `--visibility office`) so a CLI-written memory can be shared office-wide with every team agent in one step, instead of needing a per-pair `flair grant` for each. Omitting it keeps the memory private-by-default. (Reported by @kriszyp — closes #509.)
+
 ## 0.13.0 (2026-06-23)
 
 > **Onboarding that actually works, plus sharper memory hygiene.** First-run `flair install` now provisions an agent cleanly end-to-end, recall stops letting a single hot memory dominate unrelated queries, and consolidation no longer flags brand-new memories for archival. Adds `memory add --derived-from` for reflection provenance, and the auth-middleware suite now runs against real Harper.

--- a/resources/A2AAdapter.ts
+++ b/resources/A2AAdapter.ts
@@ -2,6 +2,7 @@ import { Resource, databases } from "@harperfast/harper";
 import { access, readFile, readdir } from "node:fs/promises";
 import { constants } from "node:fs";
 import { basename, extname, join } from "node:path";
+import { localBaseUrl, resolvePublicBaseUrl } from "./a2a-url.js";
 
 type JsonRpcRequest = {
   jsonrpc: string;
@@ -307,7 +308,13 @@ export class A2AAdapter extends Resource {
   allowCreate() { return true; }
 
   async get() {
-    const host = process.env.FLAIR_PUBLIC_URL || "http://localhost:9926";
+    // Resolve the URL remote peers should use to reach this Flair. Prefer the
+    // request Host header (how the caller actually reached us) over a
+    // hardcoded port, so a default local install advertises the REAL HTTP
+    // port (19926), not the dead legacy 9926 (flair#507).
+    const ctx = (this as any).getContext?.() ?? {};
+    const ctxRequest = ctx.request ?? ctx;
+    const host = resolvePublicBaseUrl(ctxRequest);
     return new Response(JSON.stringify({
       name: "TPS Agent Team",
       description: "TPS — agent OS for humans and AI agents. Coordinates via Flair.",
@@ -402,7 +409,7 @@ export class A2AAdapter extends Resource {
               if (Date.now() - startedAt >= timeoutMs) { closeStream(); return; }
 
               const catchupUrl =
-                `http://localhost:9926/OrgEventCatchup/${encodeURIComponent(agentId)}?since=${lastSeen}`;
+                `${localBaseUrl()}/OrgEventCatchup/${encodeURIComponent(agentId)}?since=${lastSeen}`;
 
               let events: any[] = [];
               try {

--- a/resources/a2a-url.ts
+++ b/resources/a2a-url.ts
@@ -1,0 +1,63 @@
+// URL resolution for the A2A adapter — flair#507.
+//
+// A default local Flair install listens on DEFAULT_HTTP_PORT (19926, the
+// CLI's `DEFAULT_PORT` in src/cli.ts), NOT on 9926 (the legacy early-install
+// port). The A2A agent-card `url` and the streaming catch-up self-fetch must
+// reflect the REAL listening port, or a remote A2A peer that follows discovery
+// hits a dead port.
+//
+// Kept free of any @harperfast/harper import so the resolution logic is
+// unit-testable without spinning up Harper (mirrors agentcard-fields.ts —
+// avoids the simulator-pattern drift that let the AdminInstance predicate be
+// reproduced-not-imported).
+
+// The CLI's DEFAULT_HTTP_PORT (src/cli.ts `DEFAULT_PORT`). Keep in sync.
+export const DEFAULT_HTTP_PORT = 19926;
+
+export type RequestLike = { headers?: any } | undefined;
+
+// Loopback base URL for in-process self-calls (e.g. the streaming catch-up
+// fetch). Points at the port Flair is ACTUALLY listening on, which Harper
+// exposes via HTTP_PORT in the runtime env — never the public/proxy URL.
+// Falls back to DEFAULT_HTTP_PORT for a default local install.
+export function localBaseUrl(env: NodeJS.ProcessEnv = process.env): string {
+  return `http://127.0.0.1:${env.HTTP_PORT || DEFAULT_HTTP_PORT}`;
+}
+
+// Public base URL advertised in the A2A agent card so remote peers can reach
+// this Flair. Mirrors AdminInstance.resolvePublicUrl (flair#404):
+//   1. FLAIR_PUBLIC_URL (explicit override, always wins)
+//   2. Request headers (X-Forwarded-Proto/Host or Host) — how the caller
+//      actually reached us
+//   3. http://127.0.0.1:${HTTP_PORT} — local-only fallback on the REAL port
+export function resolvePublicBaseUrl(
+  request?: RequestLike,
+  env: NodeJS.ProcessEnv = process.env,
+): string {
+  if (env.FLAIR_PUBLIC_URL) {
+    return env.FLAIR_PUBLIC_URL.replace(/\/$/, "");
+  }
+
+  const getHeader = (name: string): string | undefined => {
+    const h = request?.headers;
+    if (!h) return undefined;
+    if (typeof h.get === "function") return h.get(name) ?? h.get(name.toLowerCase()) ?? undefined;
+    if (typeof h === "object") {
+      const obj = h.asObject ?? h;
+      return obj[name] ?? obj[name.toLowerCase()] ?? undefined;
+    }
+    return undefined;
+  };
+
+  const fwdProto = getHeader("X-Forwarded-Proto");
+  const fwdHost = getHeader("X-Forwarded-Host");
+  const host = fwdHost ?? getHeader("Host");
+
+  if (host && /^[\w.\-:]+$/.test(host)) {
+    const scheme = fwdProto && (fwdProto === "http" || fwdProto === "https") ? fwdProto : "https";
+    const effectiveScheme = fwdProto ? scheme : (host.includes(":") ? "http" : scheme);
+    return `${effectiveScheme}://${host}`;
+  }
+
+  return localBaseUrl(env);
+}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -7275,6 +7275,7 @@ memory.command("add [content]").requiredOption("--agent <id>")
   .option("--summary <text>", "agent-set multi-sentence dense compression (3-tier chain: subject → summary → content; ops-wkoh)")
   .option("--subject <text>", "one-line title / entity this memory is about")
   .option("--derived-from <csv>", "Comma-separated source Memory IDs this memory was distilled/reflected from (sets Memory.derivedFrom; used by the `rem rapid` reflection loop)")
+  .option("--visibility <value>", "Memory visibility (sets Memory.visibility). Use 'office' to share office-wide with every team agent; omit (default) to keep it private to this agent (flair#509)")
   .action(async (contentArg, opts) => {
     const content = contentArg ?? opts.content;
     if (!content) { console.error("error: content required (positional arg or --content)"); process.exit(1); }
@@ -7286,6 +7287,7 @@ memory.command("add [content]").requiredOption("--agent <id>")
     };
     if (opts.summary) body.summary = opts.summary;
     if (opts.subject) body.subject = opts.subject;
+    if (opts.visibility) body.visibility = String(opts.visibility).trim();
     if (opts.derivedFrom) {
       body.derivedFrom = String(opts.derivedFrom).split(",").map((x: string) => x.trim()).filter(Boolean);
     }

--- a/test/unit/a2a-url.test.ts
+++ b/test/unit/a2a-url.test.ts
@@ -1,0 +1,84 @@
+// a2a-url.test.ts — flair#507
+//
+// The A2A agent-card `url` and the streaming catch-up self-fetch previously
+// hardcoded port 9926. But a default local install listens on
+// DEFAULT_HTTP_PORT (19926), so discovery advertised a DEAD port — a remote
+// A2A peer following the agent card couldn't reach the instance.
+//
+// These tests exercise the REAL resolution helpers (imported, not reproduced)
+// so the predicate can't silently drift from production.
+
+import { describe, test, expect } from "bun:test";
+import {
+  DEFAULT_HTTP_PORT,
+  localBaseUrl,
+  resolvePublicBaseUrl,
+} from "../../resources/a2a-url";
+
+describe("DEFAULT_HTTP_PORT", () => {
+  test("matches the CLI's default HTTP port (19926), not the legacy 9926", () => {
+    expect(DEFAULT_HTTP_PORT).toBe(19926);
+  });
+});
+
+describe("localBaseUrl (loopback self-call target)", () => {
+  test("falls back to DEFAULT_HTTP_PORT when HTTP_PORT is unset", () => {
+    expect(localBaseUrl({} as NodeJS.ProcessEnv)).toBe("http://127.0.0.1:19926");
+  });
+
+  test("never advertises the dead legacy 9926 by default (flair#507)", () => {
+    expect(localBaseUrl({} as NodeJS.ProcessEnv)).not.toContain(":9926");
+  });
+
+  test("uses the real listening port from HTTP_PORT when set", () => {
+    expect(localBaseUrl({ HTTP_PORT: "9926" } as NodeJS.ProcessEnv)).toBe("http://127.0.0.1:9926");
+    expect(localBaseUrl({ HTTP_PORT: "31415" } as NodeJS.ProcessEnv)).toBe("http://127.0.0.1:31415");
+  });
+});
+
+describe("resolvePublicBaseUrl (agent-card url)", () => {
+  test("FLAIR_PUBLIC_URL wins and is trailing-slash trimmed", () => {
+    expect(
+      resolvePublicBaseUrl(undefined, { FLAIR_PUBLIC_URL: "https://flair.example.com/" } as NodeJS.ProcessEnv),
+    ).toBe("https://flair.example.com");
+  });
+
+  test("no env, no headers → local fallback on the REAL HTTP_PORT, not 9926", () => {
+    const out = resolvePublicBaseUrl(undefined, { HTTP_PORT: "19926" } as NodeJS.ProcessEnv);
+    expect(out).toBe("http://127.0.0.1:19926");
+    expect(out).not.toContain(":9926");
+  });
+
+  test("no env, no headers, no HTTP_PORT → DEFAULT_HTTP_PORT (19926)", () => {
+    expect(resolvePublicBaseUrl(undefined, {} as NodeJS.ProcessEnv)).toBe("http://127.0.0.1:19926");
+  });
+
+  test("derives from a Host header with a port (Map-style headers)", () => {
+    const headers = new Map<string, string>([["host", "192.168.1.10:19926"]]);
+    const req = { headers: { get: (n: string) => headers.get(n.toLowerCase()) } };
+    expect(resolvePublicBaseUrl(req, {} as NodeJS.ProcessEnv)).toBe("http://192.168.1.10:19926");
+  });
+
+  test("derives from a Host header (asObject-style headers)", () => {
+    const req = { headers: { asObject: { Host: "192.168.1.10:19926" } } };
+    expect(resolvePublicBaseUrl(req, {} as NodeJS.ProcessEnv)).toBe("http://192.168.1.10:19926");
+  });
+
+  test("honors X-Forwarded-Proto/Host from a reverse proxy", () => {
+    const req = {
+      headers: {
+        asObject: {
+          "X-Forwarded-Proto": "https",
+          "X-Forwarded-Host": "flair.example.com",
+          Host: "internal-host:19926",
+        },
+      },
+    };
+    expect(resolvePublicBaseUrl(req, {} as NodeJS.ProcessEnv)).toBe("https://flair.example.com");
+  });
+
+  test("bare host (no port, no proxy header) assumes https", () => {
+    const req = { headers: { asObject: { Host: "flair.example.com" } } };
+    expect(resolvePublicBaseUrl(req, {} as NodeJS.ProcessEnv)).toBe("https://flair.example.com");
+  });
+});

--- a/test/unit/cli-memory-add-visibility.test.ts
+++ b/test/unit/cli-memory-add-visibility.test.ts
@@ -1,0 +1,101 @@
+// cli-memory-add-visibility.test.ts — Flair #509
+//
+// `flair memory add` must expose `--visibility <value>` so a CLI-written
+// memory can be shared office-wide (`visibility=office`) without setting up a
+// per-pair `flair grant` for every team agent. Before the fix the option
+// didn't exist, so a memory could only ever be written private-by-default.
+//
+// We spawn the real CLI against a mock HTTP server (FLAIR_URL), capture the PUT
+// /Memory/<id> body, and assert visibility is populated. Mirrors
+// cli-memory-add-derived-from.test.ts.
+
+import { describe, it, expect } from "bun:test";
+import { spawn } from "node:child_process";
+import { createServer, Server } from "node:http";
+
+type Capture = { method?: string; path?: string; body?: any };
+
+function startMockServer(onRequest: (cap: Capture) => void): Promise<{ server: Server; url: string }> {
+  return new Promise((resolve) => {
+    const server = createServer((req, res) => {
+      let body = "";
+      req.on("data", (c) => (body += c));
+      req.on("end", () => {
+        let parsed: any = undefined;
+        try { parsed = body ? JSON.parse(body) : undefined; } catch { parsed = body; }
+        onRequest({ method: req.method, path: req.url, body: parsed });
+        res.writeHead(200, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({ ok: true }));
+      });
+    });
+    server.listen(0, "127.0.0.1", () => {
+      const port = (server.address() as any).port;
+      resolve({ server, url: `http://127.0.0.1:${port}` });
+    });
+  });
+}
+
+function runCli(args: string[], env: NodeJS.ProcessEnv): Promise<{ code: number | null; stdout: string; stderr: string }> {
+  return new Promise((resolve) => {
+    const child = spawn("bun", ["src/cli.ts", ...args], { cwd: ".", env });
+    let out = "";
+    let err = "";
+    child.stdout?.on("data", (d) => (out += d.toString()));
+    child.stderr?.on("data", (d) => (err += d.toString()));
+    child.on("close", (code) => resolve({ code, stdout: out, stderr: err }));
+  });
+}
+
+describe("flair memory add --visibility (Flair #509)", () => {
+  it("sets visibility=office on the written memory so it's shared office-wide", async () => {
+    const captures: Capture[] = [];
+    const { server, url } = await startMockServer((c) => captures.push(c));
+    try {
+      const { code } = await runCli(
+        ["memory", "add", "team-wide announcement", "--agent", "krais", "--visibility", "office"],
+        { ...process.env, FLAIR_URL: url, FLAIR_AGENT_ID: "" },
+      );
+      expect(code).toBe(0);
+
+      const put = captures.find((c) => c.method === "PUT" && c.path?.startsWith("/Memory/"));
+      expect(put).toBeTruthy();
+      expect(put!.body.visibility).toBe("office");
+      expect(put!.body.agentId).toBe("krais");
+    } finally {
+      await new Promise<void>((r) => server.close(() => r()));
+    }
+  });
+
+  it("trims surrounding whitespace on the visibility value", async () => {
+    const captures: Capture[] = [];
+    const { server, url } = await startMockServer((c) => captures.push(c));
+    try {
+      const { code } = await runCli(
+        ["memory", "add", "another shared note", "--agent", "krais", "--visibility", "  office  "],
+        { ...process.env, FLAIR_URL: url, FLAIR_AGENT_ID: "" },
+      );
+      expect(code).toBe(0);
+      const put = captures.find((c) => c.method === "PUT" && c.path?.startsWith("/Memory/"));
+      expect(put!.body.visibility).toBe("office");
+    } finally {
+      await new Promise<void>((r) => server.close(() => r()));
+    }
+  });
+
+  it("omits visibility when --visibility is not passed (stays private-by-default; no regression)", async () => {
+    const captures: Capture[] = [];
+    const { server, url } = await startMockServer((c) => captures.push(c));
+    try {
+      const { code } = await runCli(
+        ["memory", "add", "a private memory", "--agent", "krais"],
+        { ...process.env, FLAIR_URL: url, FLAIR_AGENT_ID: "" },
+      );
+      expect(code).toBe(0);
+      const put = captures.find((c) => c.method === "PUT" && c.path?.startsWith("/Memory/"));
+      expect(put).toBeTruthy();
+      expect(put!.body.visibility).toBeUndefined();
+    } finally {
+      await new Promise<void>((r) => server.close(() => r()));
+    }
+  });
+});


### PR DESCRIPTION
Two fixes from external EXPERT dogfooder @kriszyp.

## #507 — A2A discovery advertised a dead port

The A2A agent-card `url` (and the streaming catch-up self-fetch) hardcoded port `9926`, but a default local install listens on `DEFAULT_HTTP_PORT` (`19926`, the CLI's `DEFAULT_PORT`). A remote A2A peer that follows discovery therefore hit a **dead port** — `curl -s http://127.0.0.1:19926/a2a | jq .url` returned `http://localhost:9926/a2a`.

**Root cause (verified in code):** `resources/A2AAdapter.ts` resolved the advertised host as `process.env.FLAIR_PUBLIC_URL || "http://localhost:9926"`, ignoring the real `HTTP_PORT`. The loopback catch-up fetch hardcoded `http://localhost:9926/OrgEventCatchup/...` the same way.

**Fix:** Extracted `resolvePublicBaseUrl` / `localBaseUrl` into a Harper-free `resources/a2a-url.ts` (mirrors `agentcard-fields.ts` so the logic is imported, not reproduced — no simulator drift):
- The agent-card `url` now resolves the URL the caller actually reached us on: `FLAIR_PUBLIC_URL` → request `Host` / `X-Forwarded-Proto`/`-Host` headers → `http://127.0.0.1:${HTTP_PORT}` fallback. This mirrors `AdminInstance.resolvePublicUrl` (#404).
- The in-process catch-up `fetch` now targets the **real** local listening port via `http://127.0.0.1:${HTTP_PORT || 19926}` — never the public/proxy URL, since it's a loopback self-call.
- `DEFAULT_HTTP_PORT` (19926) is centralized in `a2a-url.ts` and kept in lockstep with the CLI's `DEFAULT_PORT`.

## #509 — `flair memory add` had no `--visibility` flag

Memory is private-by-default. To share office-wide you set `visibility=office` (checked by `auth-middleware` GET gate and `SemanticSearch`), but `flair memory add` exposed only `--content/--durability/--tags/--summary/--subject/--derived-from`. So a CLI memory could only be shared via per-pair `flair grant`, which doesn't scale to "every team agent sees this."

**Fix:** Added `--visibility <value>` to `flair memory add` (mirrors the recently-added `--derived-from`): it sets `Memory.visibility` (trimmed) on the written record. `--visibility office` shares office-wide; omitting it keeps the memory private-by-default (no regression).

## Tests & gates

- `test/unit/a2a-url.test.ts` — exercises the **real** `resolvePublicBaseUrl`/`localBaseUrl` helpers (env override, Host/X-Forwarded-* derivation, default-port fallback, and explicit regression that the dead `:9926` is never advertised by default).
- `test/unit/cli-memory-add-visibility.test.ts` — spawns the real CLI against a mock server, asserts `visibility=office` lands on the PUT body, value is trimmed, and is omitted when the flag is absent (mirrors `cli-memory-add-derived-from.test.ts`).
- Full unit suite green (1038 pass, 0 fail). Both typecheck gates clean (`tsconfig.check.json` + `tsconfig.cli.json`). `bun run build` emits `dist/resources/a2a-url.js` referenced by the built A2AAdapter.

Fixes #507
Fixes #509

🤖 Generated with [Claude Code](https://claude.com/claude-code)