### PR TITLE
release: v0.14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
-## Unreleased
+## 0.14.0 (2026-06-24)
+
+> **A2A discovery fix + office-wide memory sharing from the CLI.** The A2A agent-card now advertises the port a caller actually reached us on (not a hardcoded dead port), and `flair memory add --visibility office` shares a memory team-wide in one step. Both reported by @kriszyp dogfooding the coordination layer.
 
 ### 🐛 A2A discovery advertised a dead port — #507
 
@@ -9,6 +11,10 @@ The A2A agent-card `url` (and the streaming catch-up self-fetch) hardcoded port 
 ### ✨ `flair memory add --visibility` — #509
 
 `memory add` now accepts `--visibility <value>` (e.g. `--visibility office`) so a CLI-written memory can be shared office-wide with every team agent in one step, instead of needing a per-pair `flair grant` for each. Omitting it keeps the memory private-by-default. (Reported by @kriszyp — closes #509.)
+
+### 🧹 Internal — #508
+
+The E2E Playwright suite now serializes on CI (`workers: 1`) so concurrent writes don't trip the Docker-Harper HNSW race (HarperFast/harper#386), plus transient connection drops auto-retry — ending the intermittent `socket hang up` / `ERR_CONNECTION_RESET` flake that reddened otherwise-green releases.
 
 ## 0.13.0 (2026-06-23)
 

--- a/bun.lock
+++ b/bun.lock
@@ -33,21 +33,21 @@
     },
     "packages/flair-client": {
       "name": "@tpsdev-ai/flair-client",
-      "version": "0.13.0",
+      "version": "0.14.0",
       "devDependencies": {
         "typescript": "5.9.3",
       },
     },
     "packages/flair-mcp": {
       "name": "@tpsdev-ai/flair-mcp",
-      "version": "0.13.0",
+      "version": "0.14.0",
       "bin": {
         "flair-mcp": "dist/index.js",
         "flair-session-start": "dist/session-start-hook.js",
       },
       "dependencies": {
         "@modelcontextprotocol/sdk": "1.27.1",
-        "@tpsdev-ai/flair-client": "0.13.0",
+        "@tpsdev-ai/flair-client": "0.14.0",
         "zod": "4.3.6",
       },
       "devDependencies": {
@@ -56,7 +56,7 @@
     },
     "packages/langgraph-flair": {
       "name": "@tpsdev-ai/langgraph-flair",
-      "version": "0.13.0",
+      "version": "0.14.0",
       "dependencies": {
         "@tpsdev-ai/flair-client": "0.8.3",
       },
@@ -66,7 +66,7 @@
     },
     "packages/n8n-nodes-flair": {
       "name": "@tpsdev-ai/n8n-nodes-flair",
-      "version": "0.13.0",
+      "version": "0.14.0",
       "dependencies": {
         "@tpsdev-ai/flair-client": "0.8.1",
         "zod": "3.25.76",
@@ -85,7 +85,7 @@
     },
     "packages/openclaw-flair": {
       "name": "@tpsdev-ai/openclaw-flair",
-      "version": "0.13.0",
+      "version": "0.14.0",
       "dependencies": {
         "@sinclair/typebox": "0.34.48",
         "@tpsdev-ai/flair-client": "0.8.3",
@@ -99,7 +99,7 @@
     },
     "packages/pi-flair": {
       "name": "@tpsdev-ai/pi-flair",
-      "version": "0.13.0",
+      "version": "0.14.0",
       "dependencies": {
         "@sinclair/typebox": "0.34.48",
         "@tpsdev-ai/flair-client": "0.8.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tpsdev-ai/flair",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "description": "Identity, memory, and soul for AI agents. Cryptographic identity (Ed25519), semantic memory with local embeddings, and persistent personality — all in a single process.",
   "type": "module",
   "license": "Apache-2.0",

--- a/packages/flair-client/package.json
+++ b/packages/flair-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tpsdev-ai/flair-client",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "description": "Lightweight client for Flair — identity, memory, and soul for AI agents. Zero heavy dependencies.",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/flair-mcp/package.json
+++ b/packages/flair-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tpsdev-ai/flair-mcp",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "description": "MCP server for Flair — persistent memory for Claude Code, Cursor, and any MCP client.",
   "type": "module",
   "main": "dist/index.js",
@@ -27,7 +27,7 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "1.27.1",
-    "@tpsdev-ai/flair-client": "0.13.0",
+    "@tpsdev-ai/flair-client": "0.14.0",
     "zod": "4.3.6"
   },
   "license": "Apache-2.0",

--- a/packages/langgraph-flair/package.json
+++ b/packages/langgraph-flair/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tpsdev-ai/langgraph-flair",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "description": "LangGraph BaseStore adapter backed by Flair — durable agent memory with crypto-pinned identity, federation, and cross-orchestrator portability.",
   "type": "module",
   "main": "dist/index.js",
@@ -36,7 +36,7 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
-    "@tpsdev-ai/flair-client": "0.13.0"
+    "@tpsdev-ai/flair-client": "0.14.0"
   },
   "peerDependencies": {
     "@langchain/langgraph-checkpoint": ">=0.0.10"

--- a/packages/n8n-nodes-flair/package.json
+++ b/packages/n8n-nodes-flair/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tpsdev-ai/n8n-nodes-flair",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "description": "n8n community node — use Flair as your AI Agent's memory backend. Includes FlairChatMemory (Memory port) and FlairSearch (Tool port).",
   "type": "commonjs",
   "main": "dist/index.js",
@@ -48,7 +48,7 @@
     "langchain"
   ],
   "dependencies": {
-    "@tpsdev-ai/flair-client": "0.13.0",
+    "@tpsdev-ai/flair-client": "0.14.0",
     "zod": "3.25.76"
   },
   "peerDependencies": {

--- a/packages/openclaw-flair/package.json
+++ b/packages/openclaw-flair/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tpsdev-ai/openclaw-flair",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "description": "OpenClaw memory plugin for Flair — agent identity and semantic memory",
   "type": "module",
   "main": "./dist/index.js",
@@ -58,7 +58,7 @@
   },
   "dependencies": {
     "@sinclair/typebox": "0.34.48",
-    "@tpsdev-ai/flair-client": "0.13.0"
+    "@tpsdev-ai/flair-client": "0.14.0"
   },
   "devDependencies": {
     "typescript": "5.9.3"

--- a/packages/pi-flair/package.json
+++ b/packages/pi-flair/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tpsdev-ai/pi-flair",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "description": "Flair memory extension for pi — persistent memory access from within pi sessions",
   "type": "module",
   "main": "dist/index.js",
@@ -21,7 +21,7 @@
     "node": ">=18"
   },
   "dependencies": {
-    "@tpsdev-ai/flair-client": "0.13.0",
+    "@tpsdev-ai/flair-client": "0.14.0",
     "@sinclair/typebox": "0.34.48"
   },
   "license": "Apache-2.0",


### PR DESCRIPTION
## Release v0.14.0

Version bump across all 7 workspace packages + CHANGELOG. Full notes in `CHANGELOG.md`.

**Headlines:**
- 🐛 A2A discovery advertised a dead port — now resolves the real `HTTP_PORT` (closes #507, @kriszyp)
- ✨ `flair memory add --visibility office` — share memories office-wide from the CLI (closes #509, @kriszyp)
- 🧹 E2E flake fix — serialize Playwright on CI + retry transient drops (#508)

_Tests: 1167 pass / 0 fail locally. After merge:_ `git tag v0.14.0` _+ push → CI stages all 7 to npm via OIDC → maintainer 2FA-approves._