### PR TITLE
fix: thread ops target through import / agent add so remote seeds don't split (#514)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### 🐛 `flair import` / `flair agent add` could only seed the Agent on localhost — #514
+
+A remote `flair import <file> --url https://<remote>:9926` split: memories and soul PUT to the remote (correct), but the Agent principal was seeded via `seedAgentViaOpsApi(<numeric ops port>, …)`, which always builds `http://127.0.0.1:<port>` — so the agent record landed on the **local** instance, not the remote. `flair agent add` had the same localhost-only assumption. Both now accept `--ops-target <url>` (env `FLAIR_OPS_TARGET`), and `import` derives the remote ops URL from `--url` (port-1 convention) when `--ops-target` is omitted, so a remote import seeds the agent on the same remote instead of splitting. With neither flag set, seeding stays on localhost — local behavior is unchanged. (Reported by @kriszyp dogfooding the Fabric move — closes #514.)
+
 ## 0.14.0 (2026-06-24)
 
 > **A2A discovery fix + office-wide memory sharing from the CLI.** The A2A agent-card now advertises the port a caller actually reached us on (not a hardcoded dead port), and `flair memory add --visibility office` shares a memory team-wide in one step. Both reported by @kriszyp dogfooding the coordination layer.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2263,6 +2263,8 @@ agent
   .option("--admin-pass <pass>", "Admin password for registration")
   .option("--keys-dir <dir>", "Directory for Ed25519 keys")
   .option("--ops-port <port>", "Harper operations API port")
+  .option("--target <url>", "Remote Flair REST URL; derives the ops API URL (port-1) to seed the Agent there (env: FLAIR_TARGET)")
+  .option("--ops-target <url>", "Explicit ops API URL to seed the Agent on (env: FLAIR_OPS_TARGET; bypasses port derivation)")
   .action(async (id: string, opts) => {
     const httpPort = resolveHttpPort(opts);
     const opsPort = resolveOpsPort(opts);
@@ -2270,6 +2272,12 @@ agent
     const adminPass: string | undefined = opts.adminPass;
     const adminUser = DEFAULT_ADMIN_USER;
     const name: string = opts.name ?? id;
+    // Where to seed the Agent record. Default is localhost (opsPort). When
+    // --ops-target or --target is given, seed on the remote instead of localhost
+    // (#514 — agent add could only ever hit localhost ops). Precedence matches
+    // `flair import`: explicit --ops-target > derive from --target > localhost.
+    const seedOpsTarget: number | string =
+      resolveEffectiveOpsUrl({ target: opts.target, opsTarget: opts.opsTarget }) ?? opsPort;
 
     if (!adminPass) {
       console.error("Error: --admin-pass is required for agent add (needed to insert into Agent table)");
@@ -2296,8 +2304,12 @@ agent
       console.log(`Keypair written: ${privPath}`);
     }
 
-    await seedAgentViaOpsApi(opsPort, id, pubKeyB64url, adminUser, adminPass);
-    console.log(`✅ Agent '${id}' (${name}) registered`);
+    await seedAgentViaOpsApi(seedOpsTarget, id, pubKeyB64url, adminUser, adminPass);
+    console.log(
+      typeof seedOpsTarget === "string"
+        ? `✅ Agent '${id}' (${name}) registered (ops: ${seedOpsTarget})`
+        : `✅ Agent '${id}' (${name}) registered`,
+    );
     console.log(`   Private key: ${privPath}`);
     console.log(`   Public key:  ${pubKeyB64url}`);
   });
@@ -8962,11 +8974,21 @@ program
   .option("--port <port>", "Harper HTTP port")
   .option("--ops-port <port>", "Harper operations API port")
   .option("--url <url>", "Flair base URL (overrides --port)")
+  .option("--ops-target <url>", "Explicit ops API URL for the Agent seed (env: FLAIR_OPS_TARGET; bypasses port derivation). Use when --url is remote and the ops port isn't HTTP-1.")
   .option("--admin-pass <pass>", "Admin password (or set FLAIR_ADMIN_PASS env)")
   .option("--keys-dir <dir>", "Keys directory", defaultKeysDir())
   .action(async (importPath, opts) => {
     const baseUrl: string = opts.url ?? `http://127.0.0.1:${resolveHttpPort(opts)}`;
     const opsPort = resolveOpsPort(opts);
+    // Resolve where the Agent record is seeded. The Agent goes through the ops
+    // API (the REST surface has no Agent POST handler), so a remote --url import
+    // must NOT silently seed on localhost (#514 — split import). Precedence:
+    //   1. --ops-target / FLAIR_OPS_TARGET → use directly
+    //   2. --url given → derive ops URL from it (port-1 convention)
+    //   3. neither → localhost opsPort (preserves local default)
+    // The remote REST base (--url) is mapped to `target` for derivation.
+    const seedOpsTarget: number | string =
+      resolveEffectiveOpsUrl({ target: opts.url, opsTarget: opts.opsTarget }) ?? opsPort;
     const adminPass: string = opts.adminPass ?? process.env.FLAIR_ADMIN_PASS ?? "";
     if (!adminPass) { console.error("Error: --admin-pass or FLAIR_ADMIN_PASS required"); process.exit(1); }
 
@@ -9011,9 +9033,13 @@ program
       : nacl.sign.keyPair.fromSeed(new Uint8Array(decodedSeed.subarray(0, 32))).publicKey;
     const pubKeyB64url = b64url(pubKey);
 
-    // Register agent via ops API
-    await seedAgentViaOpsApi(opsPort, agentId, pubKeyB64url, DEFAULT_ADMIN_USER, adminPass);
-    console.log(`  Agent registered`);
+    // Register agent via ops API (remote when --url/--ops-target points off-box)
+    await seedAgentViaOpsApi(seedOpsTarget, agentId, pubKeyB64url, DEFAULT_ADMIN_USER, adminPass);
+    console.log(
+      typeof seedOpsTarget === "string"
+        ? `  Agent registered (ops: ${seedOpsTarget})`
+        : `  Agent registered`,
+    );
 
     // Restore memories
     const auth = `Basic ${Buffer.from(`${DEFAULT_ADMIN_USER}:${adminPass}`).toString("base64")}`;

--- a/test/unit/cli-target-flag.test.ts
+++ b/test/unit/cli-target-flag.test.ts
@@ -20,6 +20,7 @@ import {
   resolveHttpPort,
   program,
   seedFederationInstanceViaOpsApi,
+  seedAgentViaOpsApi,
 } from "../../src/cli.js";
 
 // ─── resolveTarget ────────────────────────────────────────────────────────────
@@ -302,6 +303,30 @@ describe("Commander program: --target option", () => {
     const status = findCommand("status");
     expect(hasOption(status, "--url")).toBe(true);
   });
+
+  // ─── #514: import / agent add must be able to seed the Agent on a remote ──────
+
+  test("flair import has --ops-target option (#514)", () => {
+    const importCmd = findCommand("import");
+    expect(importCmd).not.toBeNull();
+    expect(hasOption(importCmd, "--ops-target")).toBe(true);
+  });
+
+  test("flair import still has --url option (REST surface, back-compat)", () => {
+    const importCmd = findCommand("import");
+    expect(hasOption(importCmd, "--url")).toBe(true);
+  });
+
+  test("flair agent add has --ops-target option (#514)", () => {
+    const add = findSubcommand("agent", "add");
+    expect(add).not.toBeNull();
+    expect(hasOption(add, "--ops-target")).toBe(true);
+  });
+
+  test("flair agent add has --target option (#514)", () => {
+    const add = findSubcommand("agent", "add");
+    expect(hasOption(add, "--target")).toBe(true);
+  });
 });
 
 // ─── api() with baseUrl override routes to target URL ──────────────────────────
@@ -568,5 +593,112 @@ describe("seedFederationInstanceViaOpsApi", () => {
     } finally {
       globalThis.fetch = origFetch;
     }
+  });
+});
+
+// ─── #514: Agent seed targets the remote, not localhost ─────────────────────────
+//
+// Root cause: `flair import` / `flair agent add` resolved the ops target to a
+// NUMBER and handed it to seedAgentViaOpsApi, which builds http://127.0.0.1:<n>.
+// So a remote `--url`/`--ops-target` import seeded the Agent on LOCALHOST — a
+// split import (memories remote, principal local). These tests pin the resolved
+// ops target and the URL seedAgentViaOpsApi actually hits.
+
+describe("seedAgentViaOpsApi targets remote vs localhost (#514)", () => {
+  async function captureSeedUrl(opsPortOrUrl: number | string): Promise<string> {
+    const origFetch = globalThis.fetch;
+    let capturedUrl = "";
+    globalThis.fetch = async (url: any) => {
+      capturedUrl = typeof url === "string" ? url : url.toString();
+      return new Response(null, { status: 200 });
+    };
+    try {
+      await seedAgentViaOpsApi(opsPortOrUrl, "kris-agent", "pubkeyb64==", "admin", "sekret");
+    } finally {
+      globalThis.fetch = origFetch;
+    }
+    return capturedUrl;
+  }
+
+  test("a remote ops URL string seeds the Agent on the REMOTE (not 127.0.0.1)", async () => {
+    const url = await captureSeedUrl("https://flair.example.harperfabric.com:9925");
+    expect(url).toBe("https://flair.example.harperfabric.com:9925/");
+    expect(url).not.toContain("127.0.0.1");
+  });
+
+  test("a numeric ops port still seeds on localhost (local default preserved)", async () => {
+    const url = await captureSeedUrl(19925);
+    expect(url).toBe("http://127.0.0.1:19925/");
+  });
+});
+
+// ─── #514: import / agent add seed-target resolution ────────────────────────────
+//
+// The command handlers compute the seed target with:
+//   resolveEffectiveOpsUrl({ target: <rest-url>, opsTarget: <ops-url> }) ?? opsPort
+// These tests mirror that exact expression: --ops-target wins; else derive from
+// the REST url; else fall back to the numeric localhost ops port. The number
+// fallback is what keeps the localhost default unchanged.
+
+describe("import / agent add seed-target resolution (#514)", () => {
+  let origFlairTarget: string | undefined;
+  let origFlairOpsTarget: string | undefined;
+
+  beforeEach(() => {
+    origFlairTarget = process.env.FLAIR_TARGET;
+    origFlairOpsTarget = process.env.FLAIR_OPS_TARGET;
+    delete process.env.FLAIR_TARGET;
+    delete process.env.FLAIR_OPS_TARGET;
+  });
+
+  afterEach(() => {
+    if (origFlairTarget === undefined) delete process.env.FLAIR_TARGET;
+    else process.env.FLAIR_TARGET = origFlairTarget;
+    if (origFlairOpsTarget === undefined) delete process.env.FLAIR_OPS_TARGET;
+    else process.env.FLAIR_OPS_TARGET = origFlairOpsTarget;
+  });
+
+  // localhost ops port stand-in: the handlers use `?? opsPort` (a number).
+  const LOCAL_OPS_PORT = 19925;
+
+  test("explicit --ops-target seeds on the REMOTE (string, not localhost number)", () => {
+    const seedTarget =
+      resolveEffectiveOpsUrl({
+        target: "https://flair.example.harperfabric.com",
+        opsTarget: "https://flair.example.harperfabric.com:9925",
+      }) ?? LOCAL_OPS_PORT;
+    expect(seedTarget).toBe("https://flair.example.harperfabric.com:9925");
+    expect(typeof seedTarget).toBe("string");
+  });
+
+  test("remote --url (no --ops-target) derives the remote ops URL — not localhost", () => {
+    // `flair import --url https://remote:9926` maps --url to `target`.
+    const seedTarget =
+      resolveEffectiveOpsUrl({ target: "https://remote.example.com:9926" }) ?? LOCAL_OPS_PORT;
+    expect(seedTarget).toBe("https://remote.example.com:9925"); // port-1, remote host
+    expect(seedTarget).not.toBe(LOCAL_OPS_PORT);
+  });
+
+  test("neither flag → falls back to the localhost numeric ops port (default unchanged)", () => {
+    const seedTarget =
+      resolveEffectiveOpsUrl({ target: undefined, opsTarget: undefined }) ?? LOCAL_OPS_PORT;
+    expect(seedTarget).toBe(LOCAL_OPS_PORT);
+    expect(typeof seedTarget).toBe("number");
+  });
+
+  test("--ops-target wins over a remote --url (no port-1 derivation contamination)", () => {
+    const seedTarget =
+      resolveEffectiveOpsUrl({
+        target: "https://remote.example.com:9926",
+        opsTarget: "https://ops.example.com:9925",
+      }) ?? LOCAL_OPS_PORT;
+    expect(seedTarget).toBe("https://ops.example.com:9925");
+  });
+
+  test("FLAIR_OPS_TARGET env seeds on the remote when no flags given", () => {
+    process.env.FLAIR_OPS_TARGET = "https://env-ops.example.com:9925";
+    const seedTarget =
+      resolveEffectiveOpsUrl({ target: undefined, opsTarget: undefined }) ?? LOCAL_OPS_PORT;
+    expect(seedTarget).toBe("https://env-ops.example.com:9925");
   });
 });


### PR DESCRIPTION
## Summary

Fixes #514. `flair import <file> --url https://<remote>:9926` **split** the import: memories and soul PUT to the remote (correct), but the Agent principal was seeded via `seedAgentViaOpsApi(<numeric ops port>, …)`, and the helper builds `http://127.0.0.1:<port>` from a number — so the **agent record landed on localhost**, not the remote. `flair agent add` carried the same localhost-only assumption.

## Root cause

- `import` (`src/cli.ts`): `opsPort = resolveOpsPort(opts)` is always a **number**, passed straight into `seedAgentViaOpsApi(opsPort, …)` → `http://127.0.0.1:<port>`.
- `agent add`: same — `seedAgentViaOpsApi(opsPort, …)`, no way to point at a remote.
- The helper **already** supports a URL string (`typeof x === "number" ? http://127.0.0.1:${port} : url`). The capability existed; it was never plumbed through from these two commands. Plumbing, not new infra.

## Fix

- Add `--ops-target <url>` (env `FLAIR_OPS_TARGET`) to **both** `flair import` and `flair agent add`; `agent add` also gets `--target <url>` (REST URL → derive ops).
- Resolve the seed target with the existing `resolveEffectiveOpsUrl({ target, opsTarget })` helper, falling back to the numeric localhost ops port:
  1. explicit `--ops-target` / `FLAIR_OPS_TARGET` → use directly (Fabric / non-port-1 deployments)
  2. `--url` (import) / `--target` (agent add) given → derive remote ops URL (port-1 convention)
  3. neither → **numeric localhost ops port — local behavior unchanged**
- For `import`, the remote REST base (`--url`) is mapped to `target` for derivation, so a remote import now seeds the agent on the **same remote** instead of splitting.

### Default-UX decision

Default stays **localhost** (numeric ops port) when nothing is specified — no behavior change for local installs. When `--url` is remote, the ops URL is **derived from it** (port-1), so the common case (`flair import --url https://remote:9926`) seeds the agent on that same remote with no extra flag. For deployments where the ops port isn't `HTTP-1` (e.g. Harper Fabric), `--ops-target` is the explicit escape hatch — mirroring the pattern `flair init` / `flair federation` already use. This keeps the least-surprising behavior: a remote import puts the agent on the remote, never a silent localhost split.

## Test

`test/unit/cli-target-flag.test.ts` (mirrors the existing `seedFederationInstanceViaOpsApi` suite):
- `seedAgentViaOpsApi` with a remote URL string hits the **remote** (`…:9925/`, asserts NOT `127.0.0.1`); a numeric port still hits `http://127.0.0.1:<port>/`.
- import / agent-add seed-target resolution: `--ops-target` → remote string; remote `--url` with no `--ops-target` → derived remote ops URL (not localhost); neither flag → numeric localhost port (default preserved); `--ops-target` wins over derivation; `FLAIR_OPS_TARGET` env path.
- Commander option-registration: `import` and `agent add` expose `--ops-target` (and `agent add` `--target`).

Full unit suite green: **1049 pass / 0 fail**. `cli.ts` typechecks clean (the one pre-existing `resources/auth-middleware.ts` TS error is on `main`, untouched here).

Reported by @kriszyp dogfooding the Fabric move.

🤖 Generated with [Claude Code](https://claude.com/claude-code)