### PR TITLE
feat(search): BM25 + union-RRF hybrid retrieval (feature-flagged) — ops-i39b

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ## [Unreleased]
 
+### ✨ BM25 + union-RRF hybrid retrieval (feature-flagged) — ops-i39b
+
+Flair semantic recall (HNSW over Q4-nomic embeddings) buries known-good **near-verbatim** memories past rank 100 — outside the HNSW candidate window — so `SemanticSearch` never returns them (confirmed by the recall-eval diagnosis, ops-ti82: 6 known-good memories missing in both raw and composite scoring; the misses are lexical exact-term cases the weak embedding cannot surface). This adds a **feature-flagged** BM25 + candidate-union Reciprocal Rank Fusion hybrid path in `resources/SemanticSearch.ts`, between the HNSW candidate fetch and the composite scoring.
+
+- **In-memory per-query BM25** (`k1=1.2`, `b=0.75`, lowercased tokenize, trivial-stopword drop, standard +1-variant IDF) over the caller's scoped corpus — no persistent index, no schema change, no write-path coupling. Extracted to the Harper-free `resources/bm25.ts` so the scoring + fusion are unit-tested against the shipped code.
+- **Candidate-UNION RRF** (`rrf = 1/(K+rank_sem) + 1/(K+rank_bm25)`, `K=60`, absent-from-a-list = 0 contribution) over the dedup'd union of the semantic and BM25 (top-50) candidate pools → **normalized** to `[0,1]` (`rrf / max_rrf_in_union`) → fed as the `rawScore` input to the existing `compositeScore`, so durability/recency/`retrievalBoost` and the `RBOOST_RELEVANCE_FLOOR` / `minScore` thresholds all still apply. Naive whole-corpus RRF was rejected (pilot: 0/6 — the broken semantic top-50 floods the fusion and buries BM25's rank-1 hits); union-RRF is the production shape.
+- **SECURITY — conditions-filter-before-fusion (the cross-agent trust boundary):** the BM25 candidate corpus is fetched WITH the same `conditions[]` filter the HNSW path uses (agent scoping, archived exclusion, tag/subject), AND the identical predicate + per-record temporal filters are re-applied in-process (`resources/bm25-filter.ts`, `isAllowedBm25Candidate`, fail-closed on unknown comparators) BEFORE the index is built or any score is fused. No other agent's content or term-frequency ever enters BM25 scoring or the union — defense at the boundary, not after fusion.
+- **Removes** the `+0.05` exact-substring keyword bump on the hybrid path (BM25 subsumes it). **No-embedding fallback** → BM25-only ranking (RRF degrades naturally as the semantic list is empty). `CANDIDATE_MULTIPLIER` (HNSW fetch size) unchanged; BM25 uses a fixed `SEM_LIMIT=50` candidate window.
+- **Feature flag `FLAIR_HYBRID_RETRIEVAL`** (`true` / `1` / `on`; default OFF). **Flag OFF is byte-identical to current behavior** — the legacy HNSW and no-embedding branches are untouched and only the flag-ON path runs the hybrid logic.
+
+Recall-eval (flag-ON vs flag-OFF, against the live flint corpus through the shipped modules): the NEW-8 within-cluster gate **p@3 holds 0.88** (no regression); the OLD-6 severe near-verbatim misses go from **0/6 → 4/6 into top-10** (1/6 into top-3). Sherlock-gated on the security boundary. (ops-i39b — spec `FLAIR-BM25-HYBRID-RETRIEVAL`.)
+
 ### ✨ Coordination write surface — `flair orgevent` + `flair workspace set` + MCP tools (ops-wmgx / Kris #510)
 
 Completes the Office Space coordination layer so multi-agent coordination no longer requires hand-rolling signed HTTP (validated need from the Rivet collision dogfood). Adds two CLI commands and two MCP tools that write the coordination layer:

--- a/resources/SemanticSearch.ts
+++ b/resources/SemanticSearch.ts
@@ -10,6 +10,12 @@ import { wrapUntrusted } from "./content-safety.js";
 // unit-tested directly (see test/unit/temporal-scoring.test.ts).
 import { compositeScore } from "./scoring.js";
 
+// BM25 + union-RRF hybrid retrieval (ops-i39b / FLAIR-BM25-HYBRID-RETRIEVAL).
+// Harper-free modules so the BM25 scoring, the candidate-union RRF, and the
+// SECURITY conditions-filter are unit-tested against the shipped code.
+import { buildBM25, fuseRrfNormalized, hybridEnabled, SEM_LIMIT } from "./bm25.js";
+import { isAllowedBm25Candidate, type Condition } from "./bm25-filter.js";
+
 // Convert HNSW cosine distance (1 - similarity) to similarity score
 function distanceToSimilarity(distance: number): number {
   return 1 - distance;
@@ -18,6 +24,10 @@ function distanceToSimilarity(distance: number): number {
 // Candidate multiplier: fetch more candidates than needed from the HNSW index
 // so composite re-ranking has enough headroom to reorder results.
 const CANDIDATE_MULTIPLIER = 5;
+
+// The BM25 + union-RRF hybrid path is feature-flagged via hybridEnabled()
+// (imported from ./bm25 — Harper-free so it's unit-testable). Flag OFF (default)
+// → byte-identical to the pre-hybrid HNSW + +0.05 keyword-bump behavior.
 
 export class SemanticSearch extends Resource {
   // Self-authorize via the Ed25519 agent verify instead of relying on the auth
@@ -169,9 +179,121 @@ export class SemanticSearch extends Resource {
     }
 
     const results: any[] = [];
+    const hybrid = hybridEnabled();
 
-    // ─── HNSW vector search path ───────────────────────────────────────────
-    if (qEmb) {
+    if (hybrid) {
+      // ─── BM25 + union-RRF hybrid path (ops-i39b) ─────────────────────────
+      // 1. Semantic candidates via HNSW (unchanged fetch). 2. BM25 lexical pass
+      //    over the SCOPED corpus. 3. SECURITY: the BM25 candidate set is filtered
+      //    by the SAME conditions[] + temporal filters BEFORE fusion (the corpus
+      //    is fetched with those conditions, AND re-checked in-process as
+      //    defense-in-depth) so no other agent's memory is ever scored or fused.
+      //    4. Candidate-union RRF → normalize → feed as rawScore to compositeScore.
+      const ctx = (this as any).getContext?.();
+
+      // ── (a) Semantic candidate records (best-first) ──────────────────────
+      // Same HNSW query as the legacy path; we keep the raw records so the BM25
+      // pass + fusion can re-derive rawScore. No embedding → empty semantic list
+      // (RRF degrades naturally to BM25-only).
+      const semRecords: any[] = [];
+      const semIds: string[] = [];
+      if (qEmb) {
+        const candidateLimit = limit * CANDIDATE_MULTIPLIER;
+        const semQuery: any = {
+          sort: { attribute: "embedding", target: qEmb, distance: "cosine" },
+          select: ["id", "agentId", "content", "contentHash", "visibility", "tags", "durability",
+            "source", "createdAt", "updatedAt", "expiresAt", "retrievalCount", "lastRetrieved",
+            "promotionStatus", "promotedAt", "promotedBy", "archived", "archivedAt", "archivedBy",
+            "parentId", "derivedFrom", "sessionId", "lastReflected", "supersedes", "subject",
+            "validFrom", "validTo", "_safetyFlags", "$distance"],
+          limit: candidateLimit,
+        };
+        if (conditions.length > 0) semQuery.conditions = conditions;
+        const semResults = withDetachedTxn(ctx, () => (databases as any).flair.Memory.search(semQuery));
+        for await (const record of semResults) {
+          // Same per-record temporal gate as the legacy HNSW loop.
+          if (record.expiresAt && Date.parse(record.expiresAt) < Date.now()) continue;
+          if (sinceDate && record.createdAt && new Date(record.createdAt) < sinceDate) continue;
+          if (asOf && record.validFrom && record.validFrom > asOf) continue;
+          if (asOf && record.validTo && record.validTo <= asOf) continue;
+          semRecords.push(record);
+          semIds.push(record.id);
+        }
+      }
+
+      // ── (b) BM25 candidate records over the SCOPED corpus ────────────────
+      // SECURITY: fetch the corpus WITH the same conditions[] so Harper applies
+      // the agent boundary, then re-apply the identical predicate + temporal
+      // filters in-process (isAllowedBm25Candidate) BEFORE building/scoring the
+      // index. The BM25 index therefore only ever contains the caller's allowed
+      // memories — no other agent's content/term-frequency enters scoring or
+      // fusion. This is the conditions-filter-before-fusion gate.
+      // Explicit select (same fields as the HNSW path, no embedding / $distance)
+      // so the large embedding vector is never fetched into the BM25 corpus and
+      // never spread into a result payload.
+      const corpusSelect = ["id", "agentId", "content", "contentHash", "visibility", "tags", "durability",
+        "source", "createdAt", "updatedAt", "expiresAt", "retrievalCount", "lastRetrieved",
+        "promotionStatus", "promotedAt", "promotedBy", "archived", "archivedAt", "archivedBy",
+        "parentId", "derivedFrom", "sessionId", "lastReflected", "supersedes", "subject",
+        "validFrom", "validTo", "_safetyFlags"];
+      const corpusQuery: any = conditions.length > 0
+        ? { conditions, select: corpusSelect }
+        : { select: corpusSelect };
+      const corpusResults = withDetachedTxn(ctx, () => (databases as any).flair.Memory.search(corpusQuery));
+      const allowedById = new Map<string, any>();
+      const bm25Docs: { id: string; content?: string }[] = [];
+      for await (const record of corpusResults) {
+        // Defense-in-depth: re-check the SAME conditions[] + temporal filters
+        // in-process. Even if a Harper query change ever let an out-of-scope
+        // record through, it is dropped here BEFORE it can be BM25-scored/fused.
+        if (!isAllowedBm25Candidate(record, conditions as Condition[], { sinceDate, asOf })) continue;
+        allowedById.set(record.id, record);
+        bm25Docs.push({ id: record.id, content: record.content });
+      }
+
+      // Carry semantic candidates that survived their temporal gate into the
+      // allowed map too (so a fused id always resolves to a record). Semantic
+      // records were fetched with the SAME conditions[], so they're in-scope.
+      for (const r of semRecords) {
+        if (!allowedById.has(r.id)) {
+          const { $distance, ...rest } = r;
+          allowedById.set(r.id, rest);
+        }
+      }
+
+      // ── (c) BM25 lexical ranking → top SEM_LIMIT (only when q present) ────
+      let bm25Ids: string[] = [];
+      if (q) {
+        const bm25 = buildBM25(bm25Docs);
+        const ranked = bm25.rank(String(q));
+        // Drop zero-score docs (no query-term overlap → contribute nothing) and
+        // cap at SEM_LIMIT — the production BM25 candidate window.
+        bm25Ids = ranked.filter(r => r.score > 0).slice(0, SEM_LIMIT).map(r => r.id);
+      }
+
+      // ── (d) Candidate-union RRF → normalized [0,1] rawScore ──────────────
+      // Union dedupes semantic ∪ bm25 ids; absent-from-a-list = 0 contribution.
+      const fused = fuseRrfNormalized(semIds, bm25Ids);
+
+      for (const [id, rrfRaw] of fused) {
+        const record = allowedById.get(id);
+        if (!record) continue; // should not happen — union ⊆ allowed
+        const rawScore = rrfRaw; // already normalized to [0,1]
+        let finalScore = scoring === "raw" ? rawScore : compositeScore(rawScore, record);
+        if (temporalBoost > 1.0) finalScore *= temporalBoost;
+
+        const isFlagged = record._safetyFlags && Array.isArray(record._safetyFlags) && record._safetyFlags.length > 0;
+        const source = record.agentId !== agentId ? record.agentId : undefined;
+        results.push({
+          ...record,
+          content: isFlagged ? wrapUntrusted(record.content, source) : record.content,
+          _score: Math.round(finalScore * 1000) / 1000,
+          _rawScore: scoring !== "raw" ? Math.round(rawScore * 1000) / 1000 : undefined,
+          _source: source,
+        });
+      }
+    } else if (qEmb) {
+      // ─── HNSW vector search path ───────────────────────────────────────────
       const candidateLimit = limit * CANDIDATE_MULTIPLIER;
       const query: any = {
         sort: { attribute: "embedding", target: qEmb, distance: "cosine" },

--- a/resources/bm25-filter.ts
+++ b/resources/bm25-filter.ts
@@ -1,0 +1,108 @@
+// ─── BM25 candidate SECURITY filter (the hard cross-agent trust boundary) ────
+// Per spec FLAIR-BM25-HYBRID-RETRIEVAL §26 + Sherlock's gate (§45-46):
+//
+//   "apply the SAME conditions[] filter (agent scoping, archived exclusion,
+//    tag/subject) to the BM25 candidates BEFORE fusion. BM25-scoring other
+//    agents' private memories and filtering only after fusion would leak
+//    term-frequency / content metadata across agent boundaries. The conditions
+//    filter MUST precede the union/fusion."
+//
+// The HNSW path gets this filter FOR FREE — Harper applies conditions[] inside
+// Memory.search(). The BM25 pass runs in-process over the corpus, so it MUST
+// re-apply the IDENTICAL predicate itself, BEFORE any scoring is fused or even
+// returned. This module is the single source of that predicate.
+//
+// Harper-free + pure so the security test exercises the SHIPPED predicate
+// directly (test/unit/bm25-security.test.ts).
+//
+// The condition shapes mirror EXACTLY what SemanticSearch.ts builds:
+//   - leaf:  { attribute, comparator, value }
+//   - group: { operator: "or", conditions: [...] }
+// supported comparators: "equals", "not_equal" (the only ones SemanticSearch
+// emits into conditions[]). An unknown comparator/shape is treated as NON-matching
+// (fail closed — never leak on an unrecognized condition).
+
+export interface LeafCondition {
+  attribute: string;
+  comparator: string;
+  value: any;
+}
+export interface GroupCondition {
+  operator: "or" | "and";
+  conditions: Condition[];
+}
+export type Condition = LeafCondition | GroupCondition;
+
+function isGroup(c: Condition): c is GroupCondition {
+  return (c as GroupCondition).operator !== undefined && Array.isArray((c as GroupCondition).conditions);
+}
+
+// Evaluate a single leaf condition against a record. `tags` is array-valued in
+// Harper; "equals" on an array attribute is membership (matches Harper's
+// array-attribute equals semantics used by the tag filter).
+function matchLeaf(cond: LeafCondition, record: any): boolean {
+  const actual = record?.[cond.attribute];
+  switch (cond.comparator) {
+    case "equals":
+      if (Array.isArray(actual)) return actual.includes(cond.value);
+      return actual === cond.value;
+    case "not_equal":
+      // Harper "not_equal" semantics used for `archived not_equal true`: a record
+      // WITHOUT the field (undefined) is included — it is "not equal" to true.
+      if (Array.isArray(actual)) return !actual.includes(cond.value);
+      return actual !== cond.value;
+    default:
+      // Unknown comparator → fail closed (do NOT pass a record on a condition we
+      // can't evaluate; that could leak across the agent boundary).
+      return false;
+  }
+}
+
+function matchCondition(cond: Condition, record: any): boolean {
+  if (isGroup(cond)) {
+    const results = cond.conditions.map((c) => matchCondition(c, record));
+    return cond.operator === "or" ? results.some(Boolean) : results.every(Boolean);
+  }
+  return matchLeaf(cond, record);
+}
+
+// AND across the top-level conditions[] (Harper's default for a conditions array
+// — same as SemanticSearch passing them as the implicit-AND query.conditions).
+export function matchesConditions(conditions: Condition[], record: any): boolean {
+  for (const c of conditions) {
+    if (!matchCondition(c, record)) return false;
+  }
+  return true;
+}
+
+// The per-record temporal/expiry filters the HNSW result loop applies AFTER the
+// Harper conditions[] (SemanticSearch.ts lines ~194-198). The BM25 pass must
+// apply these too so the BM25 candidate set is identical to what the HNSW path
+// would surface for the same record.
+export interface RecordTimeFilters {
+  now?: number; // Date.now() override for testing; defaults to Date.now()
+  sinceDate?: Date | null;
+  asOf?: string | null;
+}
+
+export function passesRecordFilters(record: any, f: RecordTimeFilters = {}): boolean {
+  const now = f.now ?? Date.now();
+  if (record?.expiresAt && Date.parse(record.expiresAt) < now) return false;
+  if (f.sinceDate && record?.createdAt && new Date(record.createdAt) < f.sinceDate) return false;
+  if (f.asOf && record?.validFrom && record.validFrom > f.asOf) return false;
+  if (f.asOf && record?.validTo && record.validTo <= f.asOf) return false;
+  return true;
+}
+
+// The full BM25-candidate security filter: a record is a valid BM25 candidate
+// ONLY if it passes BOTH the agent-scoping/archived/tag/subject conditions[] AND
+// the per-record temporal filters — IDENTICAL to the HNSW candidate gate. Apply
+// this to the corpus BEFORE building/scoring the union (defense at the boundary,
+// not after fusion).
+export function isAllowedBm25Candidate(
+  record: any,
+  conditions: Condition[],
+  timeFilters: RecordTimeFilters = {},
+): boolean {
+  return matchesConditions(conditions, record) && passesRecordFilters(record, timeFilters);
+}

--- a/resources/bm25.ts
+++ b/resources/bm25.ts
@@ -1,0 +1,155 @@
+// ─── BM25 + union-RRF hybrid retrieval (Harper-free, unit-testable) ──────────
+// Per spec FLAIR-BM25-HYBRID-RETRIEVAL (Kern-approved, ops-i39b). This module is
+// deliberately Harper-free — same rationale as ./scoring.ts — so the BM25
+// scoring, the candidate-union RRF fusion, and the security conditions-filter
+// can be unit-tested directly against the SHIPPED code without a live Harper.
+//
+// Ported from the pilot ops/tools/agent-fabric/bm25-rrf-pilot.mjs (commit
+// 5552320), which validated: BM25 alone recovers 5/6 severe misses into top-3;
+// candidate-UNION RRF (NOT naive whole-corpus RRF) recovers 4/6 into top-10 with
+// no regression on the within-cluster gate (p@3 holds 0.88).
+
+// ─── Feature flag: BM25 + union-RRF hybrid retrieval ────────────────────────
+// Flag OFF (default) → SemanticSearch behavior is byte-identical to the
+// pre-hybrid path (HNSW + the +0.05 exact-substring keyword bump). Flag ON → the
+// hybrid path. Toggle with FLAIR_HYBRID_RETRIEVAL=true (also "1" / "on"). Read
+// per-call so it can be flipped without a rebuild and set per-case in tests.
+// Lives here (Harper-free) so it's unit-testable.
+export function hybridEnabled(): boolean {
+  const v = (process.env.FLAIR_HYBRID_RETRIEVAL ?? "").toLowerCase();
+  return v === "true" || v === "1" || v === "on";
+}
+
+// BM25 parameters (Kern-approved): k1≈1.2, b≈0.75; standard IDF + BM25.
+export const BM25_K1 = 1.2;
+export const BM25_B = 0.75;
+
+// RRF constant (Cormack et al. 2009 default). A doc absent from a list
+// contributes 0 from that list (rank = ∞).
+export const RRF_K = 60;
+
+// BM25 candidate window — top-N by BM25 score fused into the union (spec §35:
+// "BM25 uses a fixed SEM_LIMIT=50"). Independent of CANDIDATE_MULTIPLIER (the
+// HNSW fetch size, which is left untouched).
+export const SEM_LIMIT = 50;
+
+// Tokenize: lowercase, split on non-alphanumeric, drop trivial stopwords and
+// 1-char tokens. Standard, language-agnostic enough for the corpus.
+const STOP = new Set(
+  (
+    "a an the and or but of to in on at for with from by as is are was were be been being " +
+    "this that these those it its do does did so if then than when how what why who whom which while " +
+    "i you he she we they them his her our your their not no yes can will would should could may might " +
+    "have has had get got into out over under again about up down off all any each"
+  ).split(" "),
+);
+
+export function tokenize(text: string): string[] {
+  return ((text || "").toLowerCase().match(/[a-z0-9]+/g) || []).filter(
+    (t) => t.length > 1 && !STOP.has(t),
+  );
+}
+
+export interface BM25Doc {
+  id: string;
+  content?: string;
+}
+
+export interface BM25Scored {
+  id: string;
+  score: number;
+}
+
+export interface BM25Index {
+  // Ranked (id, score) descending for a query string. Includes every doc
+  // (score 0 for no-overlap docs) — callers slice/threshold as needed.
+  rank(query: string): BM25Scored[];
+  readonly N: number;
+  readonly avgdl: number;
+}
+
+// Build a BM25 index over docs[].content. Standard Robertson/Sparck-Jones BM25
+// with the +1 IDF variant (always non-negative — the common Lucene/Elasticsearch
+// form).
+export function buildBM25(docs: BM25Doc[]): BM25Index {
+  const N = docs.length;
+  const docTokens = docs.map((d) => tokenize(d.content || ""));
+  const docLen = docTokens.map((t) => t.length);
+  const avgdl = docLen.reduce((s, x) => s + x, 0) / (N || 1);
+
+  const tfPerDoc = docTokens.map((toks) => {
+    const tf = new Map<string, number>();
+    for (const t of toks) tf.set(t, (tf.get(t) || 0) + 1);
+    return tf;
+  });
+  const df = new Map<string, number>();
+  for (const tf of tfPerDoc) for (const term of tf.keys()) df.set(term, (df.get(term) || 0) + 1);
+  const idf = new Map<string, number>();
+  for (const [term, n] of df) idf.set(term, Math.log(1 + (N - n + 0.5) / (n + 0.5)));
+
+  function rank(query: string): BM25Scored[] {
+    const qToks = [...new Set(tokenize(query))];
+    const scored = docs.map((d, i) => {
+      const tf = tfPerDoc[i];
+      const dl = docLen[i];
+      let s = 0;
+      for (const term of qToks) {
+        const f = tf.get(term);
+        if (!f) continue;
+        const numer = f * (BM25_K1 + 1);
+        const denom = f + BM25_K1 * (1 - BM25_B + BM25_B * (dl / (avgdl || 1)));
+        s += (idf.get(term) || 0) * (numer / denom);
+      }
+      return { id: d.id, score: s };
+    });
+    scored.sort((a, b) => b.score - a.score);
+    return scored;
+  }
+
+  return { rank, get N() { return N; }, get avgdl() { return avgdl; } };
+}
+
+// ─── Reciprocal Rank Fusion over a candidate UNION ──────────────────────────
+// rankings: array of ordered id-lists (best-first). A doc absent from a list
+// contributes 0 from that list. `universe` = the id set fused over — for the
+// production hybrid this is the candidate UNION (semantic ∪ bm25), NOT the whole
+// corpus (naive whole-corpus RRF FAILS — the broken semantic list floods the
+// fusion and buries BM25's rank-1 hits; pilot confirmed 0/6).
+//
+// Returns a Map id → raw RRF score. Caller normalizes + sorts.
+export function rrfScores(rankings: string[][], universe: Iterable<string>): Map<string, number> {
+  const score = new Map<string, number>();
+  for (const id of universe) score.set(id, 0);
+  for (const list of rankings) {
+    list.forEach((id, idx) => {
+      if (!score.has(id)) return; // doc not in this universe (union mode)
+      score.set(id, (score.get(id) || 0) + 1 / (RRF_K + idx + 1)); // idx+1 = 1-based rank
+    });
+  }
+  return score;
+}
+
+// Fuse semantic + BM25 candidate id-lists via candidate-union RRF and return a
+// per-id score normalized to [0,1] (rrf / max_rrf_in_union). This normalized
+// value is the rawScore fed to compositeScore so durability/recency/rBoost and
+// the RBOOST_RELEVANCE_FLOOR / minScore thresholds still apply unchanged.
+//
+//   semIds  — semantic candidate ids, best-first (from the HNSW pass).
+//   bm25Ids — BM25 candidate ids, best-first, already sliced to SEM_LIMIT and
+//             already SECURITY-FILTERED (see filterBm25Candidates) BEFORE this call.
+//
+// The union dedupes ids across both lists. Absent-from-a-list = 0 contribution.
+export function fuseRrfNormalized(semIds: string[], bm25Ids: string[]): Map<string, number> {
+  const union = new Set<string>([...semIds, ...bm25Ids]);
+  const raw = rrfScores([semIds, bm25Ids], union);
+  let maxRrf = 0;
+  for (const v of raw.values()) if (v > maxRrf) maxRrf = v;
+  const norm = new Map<string, number>();
+  if (maxRrf <= 0) {
+    // Degenerate (empty union) — nothing to normalize.
+    for (const [id] of raw) norm.set(id, 0);
+    return norm;
+  }
+  for (const [id, v] of raw) norm.set(id, v / maxRrf);
+  return norm;
+}

--- a/test/unit/bm25-security.test.ts
+++ b/test/unit/bm25-security.test.ts
@@ -1,0 +1,145 @@
+import { describe, test, expect } from "bun:test";
+// ─── SECURITY: conditions-filter-before-fusion (Sherlock's gate) ────────────
+// FLAIR-BM25-HYBRID §26/§45-46, ops-i39b. The HARD trust boundary: a BM25
+// candidate belonging to another agent MUST be excluded BEFORE the union/fusion,
+// so no cross-agent term-frequency / content metadata leaks. These tests
+// exercise the SHIPPED predicate (resources/bm25-filter.ts) that the
+// SemanticSearch hybrid path applies to the BM25 corpus before scoring.
+import {
+  isAllowedBm25Candidate,
+  matchesConditions,
+  passesRecordFilters,
+  type Condition,
+} from "../../resources/bm25-filter.ts";
+
+// Reconstruct the EXACT conditions[] SemanticSearch.ts builds for a single-agent
+// scope: (agentId == me OR visibility == office) AND archived != true.
+function conditionsForAgent(me: string, extra: Condition[] = []): Condition[] {
+  return [
+    {
+      operator: "or",
+      conditions: [
+        { attribute: "agentId", comparator: "equals", value: me },
+        { attribute: "visibility", comparator: "equals", value: "office" },
+      ],
+    },
+    { attribute: "archived", comparator: "not_equal", value: true },
+    ...extra,
+  ];
+}
+
+describe("conditions-filter-before-fusion (cross-agent leak gate)", () => {
+  const me = "flint";
+  const conditions = conditionsForAgent(me);
+
+  test("a BM25 candidate belonging to ANOTHER agent is excluded BEFORE fusion", () => {
+    const mine = { id: "m1", agentId: "flint", content: "Harper getUser phantom user", visibility: "private" };
+    const theirs = { id: "t1", agentId: "anvil", content: "Harper getUser phantom user", visibility: "private" };
+
+    expect(isAllowedBm25Candidate(mine, conditions)).toBe(true);
+    // The leak case: identical content owned by anvil — MUST be excluded so its
+    // term-frequency never enters the BM25 index / union / fusion.
+    expect(isAllowedBm25Candidate(theirs, conditions)).toBe(false);
+  });
+
+  test("simulated full pre-fusion filter: only the caller's docs survive", () => {
+    const corpus = [
+      { id: "m1", agentId: "flint", content: "secret flint plan alpha", visibility: "private" },
+      { id: "m2", agentId: "flint", content: "flint roadmap beta", visibility: "private" },
+      { id: "t1", agentId: "anvil", content: "secret anvil plan alpha", visibility: "private" },
+      { id: "t2", agentId: "kern", content: "kern review notes", visibility: "private" },
+      { id: "o1", agentId: "anvil", content: "shared office doc", visibility: "office" }, // office-visible → allowed
+    ];
+    const allowed = corpus.filter(r => isAllowedBm25Candidate(r, conditions));
+    const allowedIds = allowed.map(r => r.id).sort();
+    // flint's own (m1, m2) + the office-visible doc (o1). NEVER anvil/kern private.
+    expect(allowedIds).toEqual(["m1", "m2", "o1"]);
+    // Explicitly assert no other-agent PRIVATE doc leaked into the candidate set.
+    expect(allowed.some(r => r.id === "t1")).toBe(false);
+    expect(allowed.some(r => r.id === "t2")).toBe(false);
+  });
+
+  test("office-visible memories from other agents ARE allowed (matches HNSW scope)", () => {
+    const officeDoc = { id: "o1", agentId: "anvil", content: "office wide note", visibility: "office" };
+    expect(isAllowedBm25Candidate(officeDoc, conditions)).toBe(true);
+  });
+
+  test("archived records are excluded (archived == true fails not_equal)", () => {
+    const archived = { id: "a1", agentId: "flint", content: "old", visibility: "private", archived: true };
+    const live = { id: "a2", agentId: "flint", content: "new", visibility: "private", archived: false };
+    const noField = { id: "a3", agentId: "flint", content: "legacy", visibility: "private" }; // no archived field
+    expect(isAllowedBm25Candidate(archived, conditions)).toBe(false);
+    expect(isAllowedBm25Candidate(live, conditions)).toBe(true);
+    // not_equal must INCLUDE records without the field (Harper semantics).
+    expect(isAllowedBm25Candidate(noField, conditions)).toBe(true);
+  });
+
+  test("multi-agent scope (grants): each granted owner + office, never ungranted", () => {
+    // searchAgentIds = {flint, anvil} (anvil granted flint a search scope).
+    const grantConditions: Condition[] = [
+      {
+        operator: "or",
+        conditions: [
+          { attribute: "agentId", comparator: "equals", value: "flint" },
+          { attribute: "agentId", comparator: "equals", value: "anvil" },
+          { attribute: "visibility", comparator: "equals", value: "office" },
+        ],
+      },
+      { attribute: "archived", comparator: "not_equal", value: true },
+    ];
+    const flintDoc = { id: "f", agentId: "flint", visibility: "private" };
+    const anvilGranted = { id: "g", agentId: "anvil", visibility: "private" };
+    const kernUngranted = { id: "k", agentId: "kern", visibility: "private" };
+    expect(isAllowedBm25Candidate(flintDoc, grantConditions)).toBe(true);
+    expect(isAllowedBm25Candidate(anvilGranted, grantConditions)).toBe(true);
+    expect(isAllowedBm25Candidate(kernUngranted, grantConditions)).toBe(false);
+  });
+
+  test("tag/subject conditions are applied to the BM25 set too", () => {
+    const withTagSubject = conditionsForAgent(me, [
+      { attribute: "tags", comparator: "equals", value: "security" },
+      { attribute: "subject", comparator: "equals", value: "flair" },
+    ]);
+    const match = { id: "x", agentId: "flint", visibility: "private", tags: ["security", "ops"], subject: "flair" };
+    const wrongSubject = { id: "y", agentId: "flint", visibility: "private", tags: ["security"], subject: "tps" };
+    const wrongTag = { id: "z", agentId: "flint", visibility: "private", tags: ["ops"], subject: "flair" };
+    expect(isAllowedBm25Candidate(match, withTagSubject)).toBe(true);
+    expect(isAllowedBm25Candidate(wrongSubject, withTagSubject)).toBe(false);
+    expect(isAllowedBm25Candidate(wrongTag, withTagSubject)).toBe(false);
+  });
+
+  test("fail-closed: an unknown comparator excludes the record (never leaks)", () => {
+    const bad: Condition[] = [{ attribute: "agentId", comparator: "regex_pwn", value: ".*" }];
+    const anyDoc = { id: "x", agentId: "flint" };
+    expect(matchesConditions(bad, anyDoc)).toBe(false);
+  });
+});
+
+describe("per-record temporal filters mirror the HNSW loop", () => {
+  const fixedNow = Date.parse("2026-06-24T00:00:00Z");
+
+  test("expired records are excluded", () => {
+    const expired = { id: "e", expiresAt: "2020-01-01T00:00:00Z" };
+    const live = { id: "l", expiresAt: "2099-01-01T00:00:00Z" };
+    expect(passesRecordFilters(expired, { now: fixedNow })).toBe(false);
+    expect(passesRecordFilters(live, { now: fixedNow })).toBe(true);
+  });
+
+  test("sinceDate excludes older createdAt", () => {
+    const since = new Date("2026-06-20T00:00:00Z");
+    const older = { id: "o", createdAt: "2026-06-01T00:00:00Z" };
+    const newer = { id: "n", createdAt: "2026-06-23T00:00:00Z" };
+    expect(passesRecordFilters(older, { now: fixedNow, sinceDate: since })).toBe(false);
+    expect(passesRecordFilters(newer, { now: fixedNow, sinceDate: since })).toBe(true);
+  });
+
+  test("asOf bitemporal window (validFrom/validTo) is enforced", () => {
+    const asOf = "2026-06-15T00:00:00Z";
+    const notYetValid = { id: "f", validFrom: "2026-06-20T00:00:00Z" };
+    const expiredValidity = { id: "g", validTo: "2026-06-10T00:00:00Z" };
+    const inWindow = { id: "h", validFrom: "2026-06-01T00:00:00Z", validTo: "2026-06-30T00:00:00Z" };
+    expect(passesRecordFilters(notYetValid, { now: fixedNow, asOf })).toBe(false);
+    expect(passesRecordFilters(expiredValidity, { now: fixedNow, asOf })).toBe(false);
+    expect(passesRecordFilters(inWindow, { now: fixedNow, asOf })).toBe(true);
+  });
+});

--- a/test/unit/bm25.test.ts
+++ b/test/unit/bm25.test.ts
@@ -1,0 +1,167 @@
+import { describe, test, expect } from "bun:test";
+// Exercise the SHIPPED BM25 module (resources/bm25.ts) directly — Harper-free,
+// same convention as temporal-scoring.test.ts. ops-i39b / FLAIR-BM25-HYBRID.
+import {
+  tokenize,
+  buildBM25,
+  fuseRrfNormalized,
+  rrfScores,
+  hybridEnabled,
+  BM25_K1,
+  BM25_B,
+  RRF_K,
+  SEM_LIMIT,
+} from "../../resources/bm25.ts";
+
+describe("feature flag — FLAIR_HYBRID_RETRIEVAL (default OFF = unchanged behavior)", () => {
+  const orig = process.env.FLAIR_HYBRID_RETRIEVAL;
+  const restore = () => {
+    if (orig === undefined) delete process.env.FLAIR_HYBRID_RETRIEVAL;
+    else process.env.FLAIR_HYBRID_RETRIEVAL = orig;
+  };
+
+  test("unset → OFF (legacy path, byte-identical behavior)", () => {
+    delete process.env.FLAIR_HYBRID_RETRIEVAL;
+    expect(hybridEnabled()).toBe(false);
+    restore();
+  });
+  test("'false' / 'off' / '0' / '' → OFF", () => {
+    for (const v of ["false", "off", "0", "", "FALSE", "no"]) {
+      process.env.FLAIR_HYBRID_RETRIEVAL = v;
+      expect(hybridEnabled()).toBe(false);
+    }
+    restore();
+  });
+  test("'true' / '1' / 'on' (any case) → ON", () => {
+    for (const v of ["true", "1", "on", "TRUE", "On"]) {
+      process.env.FLAIR_HYBRID_RETRIEVAL = v;
+      expect(hybridEnabled()).toBe(true);
+    }
+    restore();
+  });
+});
+
+describe("BM25 params (Kern-approved)", () => {
+  test("k1≈1.2, b≈0.75, RRF K=60, SEM_LIMIT=50", () => {
+    expect(BM25_K1).toBe(1.2);
+    expect(BM25_B).toBe(0.75);
+    expect(RRF_K).toBe(60);
+    expect(SEM_LIMIT).toBe(50);
+  });
+});
+
+describe("tokenize", () => {
+  test("lowercases, splits on non-alphanumeric, drops 1-char tokens", () => {
+    expect(tokenize("Hello, WORLD! a x42")).toEqual(["hello", "world", "x42"]);
+  });
+  test("drops trivial stopwords", () => {
+    // "the", "of", "a", "to" are stopwords; "harper" / "user" survive.
+    expect(tokenize("the phantom of a Harper user to")).toEqual(["phantom", "harper", "user"]);
+  });
+  test("handles empty / nullish content", () => {
+    expect(tokenize("")).toEqual([]);
+    expect(tokenize(undefined as any)).toEqual([]);
+  });
+});
+
+describe("BM25 scoring", () => {
+  const docs = [
+    { id: "a", content: "Harper getUser returns a phantom user for a nonexistent username" },
+    { id: "b", content: "the flair npm release flow uses OIDC staging and 2FA approval" },
+    { id: "c", content: "Kern and Sherlock production model assignments on ollama" },
+    { id: "d", content: "completely unrelated content about gardening and soil" },
+  ];
+
+  test("ranks the near-verbatim doc first for a lexical query", () => {
+    const bm25 = buildBM25(docs);
+    const ranked = bm25.rank("Harper getUser phantom user nonexistent");
+    expect(ranked[0].id).toBe("a");
+    expect(ranked[0].score).toBeGreaterThan(0);
+  });
+
+  test("a doc with no query-term overlap scores exactly 0", () => {
+    const bm25 = buildBM25(docs);
+    const ranked = bm25.rank("Harper getUser phantom");
+    const gardening = ranked.find(r => r.id === "d");
+    expect(gardening!.score).toBe(0);
+  });
+
+  test("rarer terms (lower df → higher idf) contribute more than common ones", () => {
+    // "phantom" appears in 1 doc; "and" is a stopword (dropped). "content"
+    // appears once too — but "getuser"/"phantom"/"username" are unique to a.
+    const bm25 = buildBM25(docs);
+    const rareHit = bm25.rank("phantom")[0];
+    expect(rareHit.id).toBe("a");
+    expect(rareHit.score).toBeGreaterThan(0);
+  });
+
+  test("empty corpus does not throw and yields no positive scores", () => {
+    const bm25 = buildBM25([]);
+    expect(bm25.N).toBe(0);
+    expect(bm25.rank("anything")).toEqual([]);
+  });
+
+  test("term frequency saturates per BM25 k1 (not unbounded)", () => {
+    const repeated = [
+      { id: "x1", content: "alpha" },
+      { id: "x5", content: "alpha alpha alpha alpha alpha" },
+    ];
+    const bm25 = buildBM25(repeated);
+    const r = bm25.rank("alpha");
+    const s1 = r.find(d => d.id === "x1")!.score;
+    const s5 = r.find(d => d.id === "x5")!.score;
+    // More occurrences score higher, but sub-linearly (saturation), so 5x tf is
+    // far less than 5x the score.
+    expect(s5).toBeGreaterThan(s1);
+    expect(s5).toBeLessThan(s1 * 5);
+  });
+});
+
+describe("RRF — union fusion, K=60, normalization", () => {
+  test("rrfScores: a doc absent from a list contributes 0 from that list", () => {
+    const semIds = ["a", "b", "c"]; // a is rank-1 semantically
+    const bm25Ids = ["c", "z"];     // c rank-1, z rank-2 in BM25
+    const union = new Set(["a", "b", "c", "z"]);
+    const scores = rrfScores([semIds, bm25Ids], union);
+    // a: 1/(60+1) from sem only
+    expect(scores.get("a")).toBeCloseTo(1 / 61, 12);
+    // c: 1/(60+3) from sem + 1/(60+1) from bm25
+    expect(scores.get("c")).toBeCloseTo(1 / 63 + 1 / 61, 12);
+    // z: 1/(60+2) from bm25 only
+    expect(scores.get("z")).toBeCloseTo(1 / 62, 12);
+  });
+
+  test("uses K=60 exactly (rank-1 in one list → 1/61)", () => {
+    const scores = rrfScores([["only"]], new Set(["only"]));
+    expect(scores.get("only")).toBeCloseTo(1 / 61, 12);
+  });
+
+  test("fuseRrfNormalized: union dedupes ids and normalizes max to 1.0", () => {
+    const semIds = ["a", "b"];
+    const bm25Ids = ["b", "c"]; // b appears in both → highest raw RRF
+    const norm = fuseRrfNormalized(semIds, bm25Ids);
+    // union = {a, b, c}, no duplicates
+    expect([...norm.keys()].sort()).toEqual(["a", "b", "c"]);
+    // b is in both lists → top score → normalized to exactly 1.0
+    expect(norm.get("b")).toBeCloseTo(1.0, 12);
+    // every normalized score is in [0,1]
+    for (const v of norm.values()) {
+      expect(v).toBeGreaterThanOrEqual(0);
+      expect(v).toBeLessThanOrEqual(1);
+    }
+  });
+
+  test("BM25-only fusion (empty semantic list) degrades to BM25 ranking", () => {
+    // No-embedding fallback: semIds = [] → RRF is BM25-only, normalized.
+    const bm25Ids = ["top", "mid", "low"];
+    const norm = fuseRrfNormalized([], bm25Ids);
+    expect(norm.get("top")).toBeCloseTo(1.0, 12);          // rank-1 normalizes to 1
+    expect(norm.get("mid")!).toBeLessThan(norm.get("top")!);
+    expect(norm.get("low")!).toBeLessThan(norm.get("mid")!);
+  });
+
+  test("empty union normalizes to nothing without dividing by zero", () => {
+    const norm = fuseRrfNormalized([], []);
+    expect(norm.size).toBe(0);
+  });
+});


### PR DESCRIPTION
## BM25 + union-RRF hybrid retrieval (feature-flagged) — ops-i39b

Implements the Kern-designed, pilot-validated hybrid retrieval per spec **FLAIR-BM25-HYBRID-RETRIEVAL** (bead **ops-i39b**). Recovers known-good **near-verbatim** memories the HNSW path buries past rank 100 (outside limit x CANDIDATE_MULTIPLIER), confirmed by the recall-eval diagnosis (ops-ti82): 6 known-good memories miss in both raw and composite scoring — lexical exact-term cases the weak Q4-nomic embedding cannot surface.

### What it does
In-memory per-query **BM25** (k1=1.2, b=0.75, lowercased tokenize, trivial-stopword drop, standard +1-variant IDF) runs over the caller's scoped corpus, fused with the HNSW semantic candidates via **candidate-union Reciprocal Rank Fusion** (rrf = 1/(K+rank_sem) + 1/(K+rank_bm25), K=60, absent-from-a-list = 0), normalized to [0,1] (rrf / max_rrf_in_union), and fed as the rawScore into the existing compositeScore so durability/recency/retrievalBoost and the RBOOST_RELEVANCE_FLOOR / minScore thresholds are preserved. Naive whole-corpus RRF was rejected (pilot: 0/6 — the broken semantic top-50 floods the fusion and buries BM25's rank-1 hits); **union-RRF** is the production shape. No persistent index, no schema change, no write-path coupling. The Harper-free BM25 + RRF live in resources/bm25.ts so they're unit-tested against the shipped code.

### Security boundary — conditions-filter-before-fusion (Sherlock's gate)
The hard cross-agent trust boundary. The HNSW path gets the conditions[] filter for free (Harper applies it inside Memory.search). The BM25 pass runs in-process, so it re-applies the IDENTICAL filter BEFORE fusion: the BM25 corpus is fetched **with the same conditions[]** (agent scoping, archived exclusion, tag/subject), AND the same predicate + per-record temporal filters are re-checked in-process (resources/bm25-filter.ts) BEFORE the index is built or any score is fused. No other agent's content or term-frequency ever enters BM25 scoring or the union.

The in-process gate (defense-in-depth, fail-closed):

    // resources/bm25-filter.ts
    export function isAllowedBm25Candidate(
      record: any,
      conditions: Condition[],
      timeFilters: RecordTimeFilters = {},
    ): boolean {
      return matchesConditions(conditions, record) && passesRecordFilters(record, timeFilters);
    }

Applied in SemanticSearch.ts over the BM25 corpus **before** the index is built:

    const corpusResults = withDetachedTxn(ctx, () => databases.flair.Memory.search(corpusQuery));
    const allowedById = new Map();
    const bm25Docs = [];
    for await (const record of corpusResults) {
      // Defense-in-depth: re-check the SAME conditions[] + temporal filters in-process.
      // Dropped here BEFORE it can be BM25-scored/fused.
      if (!isAllowedBm25Candidate(record, conditions, { sinceDate, asOf })) continue;
      allowedById.set(record.id, record);
      bm25Docs.push({ id: record.id, content: record.content });
    }
    // ... buildBM25(bm25Docs) -> rank -> fuse. The index only ever contains allowed docs.

matchesConditions mirrors exactly the conditions[] shapes SemanticSearch builds (the (agentId==me OR visibility==office) OR-group + archived != true + optional tag/subject) and **fails closed** on any unknown comparator/shape — it never passes a record on a condition it can't evaluate.

### Feature flag
**FLAIR_HYBRID_RETRIEVAL** — true / 1 / on (any case) enables the hybrid path; **default OFF**. Flag OFF is **byte-identical** to current behavior: the legacy HNSW and no-embedding branches are untouched and only run when the flag is off. The +0.05 exact-substring keyword bump is removed **only** on the hybrid path. No-embedding fallback -> BM25-only (RRF degrades naturally). CANDIDATE_MULTIPLIER (HNSW fetch size) unchanged; BM25 uses a fixed SEM_LIMIT=50 window.

### Recall-eval — flag-ON vs flag-OFF (through the shipped modules, live flint corpus)
| metric | flag-OFF (current) | flag-ON (hybrid) |
|---|---|---|
| NEW-8 within-cluster gate **p@3** | 0.88 | **0.88 (holds, no regression)** |
| NEW-8 MRR | 0.781 | 0.771 |
| OLD-6 severe near-verbatim misses -> top-10 | 0/6 | **4/6** |
| OLD-6 severe misses -> top-3 | 0/6 | **1/6** |

The gate holds and the severe-miss class improves exactly as the pilot validated (union-RRF recovers 4/6 into top-10). The eval mutates retrievalCount (rich-get-richer) — run sparingly; this was a couple of passes only, all read-only against prod.

### Tests
- test/unit/bm25.test.ts — BM25 scoring (rank, zero-overlap=0, tf saturation, empty corpus); RRF union + K=60 + normalization; BM25-only fallback; **feature-flag default-OFF** + on/off parsing.
- test/unit/bm25-security.test.ts — **the conditions-filter-before-fusion security test**: an other-agent BM25 candidate is excluded BEFORE fusion (no cross-agent leak); office-visible allowed; archived excluded (incl. missing-field include); multi-agent grant scope; tag/subject; fail-closed on unknown comparator; per-record temporal filters.
- Full test/unit/ suite green (1111 pass / 0 fail). Typecheck clean — one **pre-existing** baseline error in resources/auth-middleware.ts:85 on origin/main, unrelated and not introduced here.

**Sherlock-gated** on the security boundary — do not merge without Sherlock's explicit approval. Spec: FLAIR-BM25-HYBRID-RETRIEVAL. Bead: ops-i39b.

Generated with [Claude Code](https://claude.com/claude-code)
