### PR TITLE
fix(cli): seedAgentViaOpsApi sets kind=agent + status=active (#521)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### 🐛 `seedAgentViaOpsApi` seeded agents with `kind=null` / `status=null` (invisible to roster/presence) — ops-3b9i / #521
+
+Remote agent seeding (`flair agent add`, `flair import`, remote init) writes the `Agent` record through the Harper operations API (`operation: "insert"`), which **bypasses the `Agent` resource layer** — so `Agent.post()`'s 1.0 Principal defaults (`kind="agent"`, `status="active"`, `displayName`, `admin`, `defaultTrustTier`, `type`) never ran. The seed body only carried `{id, name, publicKey, createdAt}`, so remotely-seeded agents landed `kind=null, status=null` and were **invisible to roster / presence / Office-Space queries** that filter `status='active'` or `kind='agent'`. `seedAgentViaOpsApi` now writes those fields explicitly, mirroring `Agent.post()` exactly. (ops-3b9i / closes #521.)
+
 ### ✨ BM25 + union-RRF hybrid retrieval (feature-flagged) — ops-i39b
 
 Flair semantic recall (HNSW over Q4-nomic embeddings) buries known-good **near-verbatim** memories past rank 100 — outside the HNSW candidate window — so `SemanticSearch` never returns them (confirmed by the recall-eval diagnosis, ops-ti82: 6 known-good memories missing in both raw and composite scoring; the misses are lexical exact-term cases the weak embedding cannot surface). This adds a **feature-flagged** BM25 + candidate-union Reciprocal Rank Fusion hybrid path in `resources/SemanticSearch.ts`, between the HNSW candidate fetch and the composite scoring.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -525,11 +525,29 @@ export async function seedAgentViaOpsApi(
   // Send Basic auth whenever the caller passed an adminPass. The caller decides
   // when to omit it (e.g., local target with authorizeLocal=true).
   const auth = adminPass !== undefined ? Buffer.from(`${adminUser}:${adminPass}`).toString("base64") : undefined;
+  // The ops-API insert bypasses the Agent resource layer, so Agent.post()'s
+  // 1.0 Principal defaults (kind/status/displayName/admin/defaultTrustTier/type)
+  // never run. Without them a remote-seeded agent lands kind=null, status=null
+  // and is invisible to roster/presence/Office-Space queries that filter on
+  // status='active' or kind='agent' (#521). Mirror Agent.post() exactly here.
+  const now = new Date().toISOString();
   const body = {
     operation: "insert",
     database: "flair",
     table: "Agent",
-    records: [{ id: agentId, name: agentId, publicKey: pubKeyB64url, createdAt: new Date().toISOString() }],
+    records: [{
+      id: agentId,
+      name: agentId,
+      type: "agent",
+      kind: "agent",
+      status: "active",
+      displayName: agentId,
+      admin: false,
+      defaultTrustTier: "unverified",
+      publicKey: pubKeyB64url,
+      createdAt: now,
+      updatedAt: now,
+    }],
   };
   const res = await fetch(url, {
     method: "POST",

--- a/test/unit/cli-target-flag.test.ts
+++ b/test/unit/cli-target-flag.test.ts
@@ -632,6 +632,54 @@ describe("seedAgentViaOpsApi targets remote vs localhost (#514)", () => {
   });
 });
 
+// ─── #521: seeded Agent carries roster/presence invariants ──────────────────────
+//
+// The ops-API insert bypasses the Agent resource layer, so Agent.post()'s
+// 1.0 Principal defaults never run. Before #521 the seed body only carried
+// {id, name, publicKey, createdAt}, so a remote-seeded agent landed
+// kind=null/status=null and was invisible to roster/presence/Office-Space
+// queries that filter status='active' or kind='agent'. These tests pin the
+// seed body to the same fields Agent.post() applies.
+describe("seedAgentViaOpsApi sets kind/status invariants (#521)", () => {
+  async function captureSeedBody(): Promise<any> {
+    const origFetch = globalThis.fetch;
+    let capturedBody: any;
+    globalThis.fetch = async (_url: any, opts: any) => {
+      capturedBody = JSON.parse(opts.body);
+      return new Response(null, { status: 200 });
+    };
+    try {
+      await seedAgentViaOpsApi(19925, "kris-agent", "pubkeyb64==", "admin", "sekret");
+    } finally {
+      globalThis.fetch = origFetch;
+    }
+    return capturedBody;
+  }
+
+  test("seeded Agent record has kind=agent and status=active (not null)", async () => {
+    const body = await captureSeedBody();
+    const rec = body.records[0];
+    expect(rec.kind).toBe("agent");
+    expect(rec.status).toBe("active");
+    expect(rec.kind).not.toBeNull();
+    expect(rec.status).not.toBeNull();
+  });
+
+  test("seeded Agent record mirrors Agent.post() Principal defaults", async () => {
+    const body = await captureSeedBody();
+    const rec = body.records[0];
+    expect(rec.id).toBe("kris-agent");
+    expect(rec.name).toBe("kris-agent");
+    expect(rec.type).toBe("agent");
+    expect(rec.displayName).toBe("kris-agent");
+    expect(rec.admin).toBe(false);
+    expect(rec.defaultTrustTier).toBe("unverified");
+    expect(rec.publicKey).toBe("pubkeyb64==");
+    expect(rec.createdAt).toBeDefined();
+    expect(rec.updatedAt).toBeDefined();
+  });
+});
+
 // ─── #514: import / agent add seed-target resolution ────────────────────────────
 //
 // The command handlers compute the seed target with:


### PR DESCRIPTION
Fix seedAgentViaOpsApi: set kind=agent + status=active so remote-seeded agents are visible to roster/presence (closes #521).

## Root cause

Remote agent seeding (`flair agent add`, `flair import`, remote init) writes the `Agent` record through the Harper **operations API** (`operation: "insert"`), which bypasses the `Agent` resource layer. So `Agent.post()`'s 1.0 Principal defaults (`kind`, `status`, `displayName`, `admin`, `defaultTrustTier`, `type`) never ran. The seed body only carried `{id, name, publicKey, createdAt}` — remotely-seeded agents landed `kind=null, status=null` and were invisible to roster / presence / Office-Space queries that filter `status='active'` or `kind='agent'`.

## Fix

`seedAgentViaOpsApi` now writes the Principal fields explicitly in the insert body, mirroring `Agent.post()` exactly:

| field | value |
|---|---|
| `kind` | `"agent"` |
| `status` | `"active"` |
| `type` | `"agent"` |
| `displayName` | `agentId` |
| `admin` | `false` |
| `defaultTrustTier` | `"unverified"` |
| `updatedAt` | now |

These are precisely the defaults `Agent.post()` applies for a non-admin agent (`content.kind ||= "agent"`, `content.status ||= "active"`, `content.displayName ||= content.name`, `content.admin ??= false`, `defaultTrustTier = admin ? "endorsed" : "unverified"`, `content.type ||= "agent"`). The minimum scope per the issue is `kind` + `status`; the other fields are included because the same null-field class bug applies to the `@indexed` `defaultTrustTier` / `admin` columns, and matching `Agent.post()` is the single source of truth for a complete Agent record.

## Tests

New describe block in `test/unit/cli-target-flag.test.ts` captures the seed body and asserts `kind === "agent"`, `status === "active"` (not null), plus the full set of mirrored `Agent.post()` defaults.

- Unit suite: 1113 pass / 0 fail (was 1109 before the 4 new assertions).
- Typecheck: `tsconfig.cli.json` and `tsconfig.check.json` both green.

Do not merge — K&S-gated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)