### PR TITLE
release: v0.15.0 — Node preflight, flair upgrade --target, seed-invariants fix; bundle Harper 5.1.14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## 0.15.0 (2026-06-26)
+
 ### ✨ `flair upgrade --target <fabric>` — one-command Fabric upgrade — ops-e5bh
 
 Upgrading a Flair instance deployed to a Harper Fabric cluster used to require a manual deploy dance: stand up a fresh temp dir, hand-write a `package.json` that depends on `@tpsdev-ai/flair@<version>` **and** carries an `overrides` block pinning `@harperfast/harper` to a fixed version (because the published flair declares an old Harper — `@harperfast/harper@5.0.21` as of `flair@0.14.0` — whose component packager emits an empty tarball when the package root is under `node_modules`, flair#513), `npm install`, then run `flair deploy`. `flair upgrade --target <fabric-url>` now bakes that whole thing into one command: it resolves the target version (latest published `@tpsdev-ai/flair`, or `--version`), prepares a clean deployable in an isolated temp dir with the Harper pin (>= 5.1.13) applied automatically, **confirms the staged Harper is the fix version before deploying**, then **reuses `flair deploy`** to push to the Fabric and verifies the result. `--check` shows the version diff + plan without deploying; credentials mirror `flair deploy` (`--fabric-user`/`--fabric-password`, `FABRIC_USER`/`FABRIC_PASSWORD` env) and are never printed. The local-package `flair upgrade` (no `--target`) is unchanged. (ops-e5bh.)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tpsdev-ai/flair",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "description": "Identity, memory, and soul for AI agents. Cryptographic identity (Ed25519), semantic memory with local embeddings, and persistent personality — all in a single process.",
   "type": "module",
   "license": "Apache-2.0",
@@ -55,7 +55,7 @@
     "node": ">=22"
   },
   "dependencies": {
-    "@harperfast/harper": "5.0.21",
+    "@harperfast/harper": "5.1.14",
     "@types/js-yaml": "^4.0.9",
     "commander": "14.0.3",
     "harper-fabric-embeddings": "0.2.3",


### PR DESCRIPTION
Release v0.15.0. version 0.14.0 -> 0.15.0; bundled @harperfast/harper 5.0.21 -> 5.1.14 (the packageComponent fix, so plain flair deploy Just Works); CHANGELOG Unreleased -> 0.15.0. Ships the onboarding/upgrade cluster: loud Node-version preflight (#524), flair upgrade --target <fabric> (#525), seedAgentViaOpsApi invariants fix (#523). The Harper-dep bump is validated by this PR CI. After merge, tag v0.15.0 to stage-publish.