### PR TITLE
chore(release): clean impl-term leaks + gitignore ui artifacts + fix release.sh PR-create

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,9 @@ test/e2e/screenshots/
 packages/**/__pycache__/
 plugins/**/*.pyc
 .pytest_cache/
+
+# Disposable hero-mock / screenshot artifacts (not shipped)
+ui/_shoot*.mjs
+ui/floor-*.png
+ui/hero-*.png
+ui/office-space*.html

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## [Unreleased]
 
+### 🧹 Release-readiness — impl-term leak cleanup + gitignore + release.sh PR-create fix
+
+Unblocks the release build and removes two recurring release-time papercuts:
+
+- **Impl-term leak cleanup (release blocker):** the `check-impl-term-leaks` lint (pre-commit hook + CI "Doc/Code Lint") flags raw internal references in shipped/user-facing output. A coordination-layer comment in `packages/flair-mcp/src/index.ts` compiled into `packages/flair-mcp/dist/index.js` carrying an internal bead ID + person ref, failing the release build. Rephrased the comment to keep the intent and drop the internal refs — comment-only, no behavior change. The full lint (all freshly-built `dist/`, docs, READMEs) is clean.
+- **Gitignore disposable UI artifacts:** added `ui/_shoot*.mjs`, `ui/floor-*.png`, `ui/hero-*.png`, `ui/office-space*.html` (hero-mock screenshot scripts + pngs from prior sessions) to `.gitignore` so they stop dirtying the tree and tripping `release.sh`'s clean-tree check. None were tracked or shipped.
+- **`release.sh` PR-create via REST:** the release PR step used `gh pr create`, which 401s with the flint token (it routes through GraphQL). Switched to `gh api -X POST repos/tpsdev-ai/flair/pulls` (REST works) with the same title/body/head/base, so the PR step actually succeeds.
+
 ### ✨ `flair upgrade --target <fabric>` — one-command Fabric upgrade — ops-e5bh
 
 Upgrading a Flair instance deployed to a Harper Fabric cluster used to require a manual deploy dance: stand up a fresh temp dir, hand-write a `package.json` that depends on `@tpsdev-ai/flair@<version>` **and** carries an `overrides` block pinning `@harperfast/harper` to a fixed version (because the published flair declares an old Harper — `@harperfast/harper@5.0.21` as of `flair@0.14.0` — whose component packager emits an empty tarball when the package root is under `node_modules`, flair#513), `npm install`, then run `flair deploy`. `flair upgrade --target <fabric-url>` now bakes that whole thing into one command: it resolves the target version (latest published `@tpsdev-ai/flair`, or `--version`), prepares a clean deployable in an isolated temp dir with the Harper pin (>= 5.1.13) applied automatically, **confirms the staged Harper is the fix version before deploying**, then **reuses `flair deploy`** to push to the Fabric and verifies the result. `--check` shows the version diff + plan without deploying; credentials mirror `flair deploy` (`--fabric-user`/`--fabric-password`, `FABRIC_USER`/`FABRIC_PASSWORD` env) and are never printed. The local-package `flair upgrade` (no `--target`) is unchanged. (ops-e5bh.)

--- a/packages/flair-mcp/src/index.ts
+++ b/packages/flair-mcp/src/index.ts
@@ -317,7 +317,7 @@ server.tool(
   },
 );
 
-// ─── Coordination write surface (ops-wmgx / Kris #510) ───────────────────────
+// ─── Coordination write surface ──────────────────────────────────────────────
 //
 // flair_workspace_set + flair_orgevent let an agent write the Office Space
 // coordination layer without hand-rolling signed HTTP. Both go through

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -254,20 +254,29 @@ echo "📤 Pushing $RELEASE_BRANCH..."
 git -C "$ROOT" push -u origin "$RELEASE_BRANCH"
 
 echo "🔖 Opening release PR..."
-PR_URL="$($GH pr create \
-  --repo tpsdev-ai/flair \
-  --base main \
-  --head "$RELEASE_BRANCH" \
-  --title "release: v${VERSION}" \
-  --body "Version bump across workspace packages to v${VERSION}.
+# Open the PR via the REST API rather than `gh pr create`: the flint token 401s on
+# `gh pr create` (it goes through GraphQL), but `gh api` (REST) works. Build the
+# JSON payload with node so the multi-line body is escaped correctly.
+PR_PAYLOAD="$(mktemp)"
+trap 'rm -f "$PR_PAYLOAD"' EXIT
+PR_TITLE="release: v${VERSION}" PR_HEAD="$RELEASE_BRANCH" PR_VERSION="$VERSION" node -e '
+  const body = `Version bump across workspace packages to v${process.env.PR_VERSION}.
 
-See CHANGELOG.md for what's in this release.
+See CHANGELOG.md for what'"'"'s in this release.
 
 After CI is green and this is merged:
 \`\`\`
 git checkout main && git pull
-./scripts/release.sh ${VERSION} --publish
-\`\`\`")"
+./scripts/release.sh ${process.env.PR_VERSION} --publish
+\`\`\``;
+  process.stdout.write(JSON.stringify({
+    title: process.env.PR_TITLE,
+    head: process.env.PR_HEAD,
+    base: "main",
+    body,
+  }));
+' > "$PR_PAYLOAD"
+PR_URL="$($GH api -X POST repos/tpsdev-ai/flair/pulls --input "$PR_PAYLOAD" --jq '.html_url')"
 
 echo ""
 echo "✅ Release PR opened: $PR_URL"


### PR DESCRIPTION
Release-readiness: clean impl-term leaks (unblocks v0.15.0) + gitignore disposable ui artifacts + fix release.sh PR-create (gh api). Comment-only leak cleanup, no behavior change.

## What & why

**FIX 1 — impl-term leak cleanup (v0.15.0 release BLOCKER).** `scripts/check-impl-term-leaks.sh` (pre-commit hook + CI "Doc/Code Lint") flags raw bead IDs / internal-person refs in shipped/user-facing output. The v0.15.0 release build failed on `packages/flair-mcp/dist/index.js:273` carrying `// Coordination write surface (ops-wmgx / Kris #510)`. Rephrased the source comment (`packages/flair-mcp/src/index.ts`) to keep intent and drop the internal refs. Comment-only — no behavior change. After a full rebuild of every package's `dist/`, the lint is clean.

**FIX 2 — gitignore disposable ui artifacts.** Added `ui/_shoot*.mjs`, `ui/floor-*.png`, `ui/hero-*.png`, `ui/office-space*.html` (hero-mock screenshot scripts + pngs from prior sessions) to `.gitignore`. Confirmed none are tracked and none are in `package.json` `files` — they're disposable and were dirtying the tree / tripping `release.sh`'s clean-tree check. (The one real tracked `ui/` file, `ui/observation-center.html`, is untouched.)

**FIX 3 — release.sh PR-create via REST.** The release PR step used `$GH pr create`, which 401s with the flint token (it routes through GraphQL). Switched to `gh api -X POST repos/tpsdev-ai/flair/pulls --input <payload>` (REST works), building the JSON payload from the same title/body/head/base. `bash -n scripts/release.sh` clean.

## Verification

- `scripts/check-impl-term-leaks.sh` passes (exit 0) after building all packages' `dist/`.
- Trial `git commit` passed the pre-commit hook: `✓ no impl-term leaks` (+ workspace-deps, dep-ages, ASCII-box all green).
- `bash -n scripts/release.sh` clean; PR-payload generation validated (valid JSON, body matches original).
- Unit suite green: 1140 pass / 0 fail. Typecheck: 1 pre-existing baseline error in `resources/auth-middleware.ts` (untouched by this PR; same count on origin/main). Integration failures are infra-only (no live Harper in the isolated worktree) — same baseline.
- Prod untouched (worktree-isolated from `~/ops/flair`, `~/.flair`, `:9926`).
