### PR TITLE
docs+cli: onboarding consistency — npx MCP-wiring + flair install front door + auth story

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## [Unreleased]
 
+### 📚 Onboarding consistency — one zero-install MCP-wiring pattern + `flair install` as the front door
+
+Three contradictions in the onboarding story, fixed so the docs and the code agree:
+
+- **MCP-wiring contradiction (FIX 1):** the `flair init --agent-id` auto-wire wrote `~/.claude.json` with a bare `command: "flair-mcp"` (no args), which assumes a global `flair-mcp` on `PATH` — but the README, `docs/`, and the `flair install` client snippets all tell users the zero-install `npx -y @tpsdev-ai/flair-mcp` form. The auto-wire now writes `command: "npx"`, `args: ["-y", "@tpsdev-ai/flair-mcp"]` (src/cli.ts), so init and the docs agree on one pattern. Generated config validated against the Claude Code `~/.claude.json` MCP shape.
+- **`flair install` is the documented front door (FIX 2):** the root README Quick Start now leads with the one-command `flair install` (init + agent + MCP wiring + smoke test) and moves the manual `flair init → flair agent add → flair status` flow to an "Advanced / manual setup" section. Corrected an inaccurate `flair agent add --role` example (no such flag).
+- **Auth across surfaces documented in one place (FIX 3):** a new "Auth across surfaces" table in `docs/auth.md` (and a pointer in the README) makes the model legible — CLI / SDK / MCP / plugins all use per-agent Ed25519 (default, secure); `n8n-nodes-flair` uses Harper admin-password Basic auth, which grants whole-instance read/write, flagged as a known limitation with the conditions under which it's acceptable.
+- **Docs/skills currency:** standardized every MCP-wiring snippet to the `npx -y @tpsdev-ai/flair-mcp` zero-install form (`docs/integrations.md`, `docs/upgrade.md`, `packages/flair-mcp/README.md`, the `packages/flair-mcp/src/index.ts` usage comment) — no remaining bare-binary `command: "flair-mcp"` wiring instructions. The out-of-repo `flair-best-practices` Claude Code skill was updated to match.
+
 ### 🛡️ Release hardening — `release.sh` push-auth + impl-term leak check on every PR
 
 Closes the two recurring papercuts from the v0.15.0 release:

--- a/README.md
+++ b/README.md
@@ -182,27 +182,53 @@ Pluggable import/export to foreign memory systems. Every agent-memory format (ag
 
 ### Install & Run
 
+`flair install` is the front door. One command does everything: installs and starts Harper, creates your agent's Ed25519 identity, detects and wires your MCP clients (Claude Code / Cursor / Codex / Gemini) to the zero-install `npx -y @tpsdev-ai/flair-mcp` server, and runs a smoke test.
+
 ```bash
-# Install
+# Install the CLI
 npm install -g @tpsdev-ai/flair
 
-# Bootstrap a Flair instance (installs Harper, creates database, starts service)
-flair init
+# One command: init + agent + MCP wiring + smoke test
+flair install
+```
 
-# Register your first agent
-flair agent add mybot --name "My Bot" --role assistant
+That's it. Your agent now has identity and memory, and any detected MCP client is wired up. Restart your MCP client (e.g. Claude Code) to pick up the new config, then ask the agent "what do you remember about me?"
 
-# Check everything is working
-flair status
+Useful flags:
 
-# Lifecycle management
+```bash
+flair install --agent mybot          # name the agent (defaults to hostname short-form)
+flair install --client claude-code   # wire one specific client (claude-code, codex, gemini, cursor, all, none)
+flair install --no-mcp               # init + agent only, skip MCP wiring
+flair install --skip-smoke           # skip the MCP smoke test
+```
+
+Lifecycle management:
+
+```bash
+flair status        # Check everything is working
 flair stop          # Stop the Flair instance
 flair restart       # Restart the Flair instance
 flair uninstall     # Remove the service (keeps data)
 flair uninstall --purge  # Remove everything including data and keys
 ```
 
-That's it. Your agent now has identity and memory.
+### Advanced / manual setup
+
+Prefer to drive each step yourself, or scripting an unattended install? The individual commands `flair install` orchestrates are still available:
+
+```bash
+# Bootstrap a Flair instance (installs Harper, creates database, starts service)
+flair init
+
+# Register your first agent (generates an Ed25519 keypair, registers it)
+flair agent add mybot --name "My Bot"
+
+# Check everything is working
+flair status
+```
+
+`flair init --agent-id mybot` bootstraps the instance and registers an agent in one step (and auto-wires `~/.claude.json` if Claude Code is present). Wire other MCP clients manually using the snippets in **[docs/mcp-clients.md](docs/mcp-clients.md)** — all of them use the `npx -y @tpsdev-ai/flair-mcp` zero-install form.
 
 ## Integration
 
@@ -330,6 +356,12 @@ curl -H "Authorization: TPS-Ed25519 mybot:$TS:$NONCE:$SIG" \
 ```
 
 Auth is Ed25519 — sign `agentId:timestamp:nonce:METHOD:/path` with your private key. See [SECURITY.md](SECURITY.md) for the full protocol.
+
+### Auth across surfaces
+
+The default, secure path everywhere is **Ed25519 per-agent**: each agent holds its own key (`~/.flair/keys/<agent>.key`), signs every request, and the server refuses cross-agent reads. The CLI, the `flair-mcp` server, and the OpenClaw / pi / Hermes plugins all use it.
+
+One exception: the **`n8n-nodes-flair`** community node authenticates with the Harper **admin password** (Basic auth), which grants **whole-instance read/write** access — not per-agent isolation. That's acceptable only on a single-tenant, operator-controlled n8n with trusted workflow inputs; otherwise prefer the CLI/SDK Ed25519 path. Full breakdown in **[docs/auth.md](docs/auth.md#auth-across-surfaces-read-this-first)**.
 
 ## Architecture
 

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -2,6 +2,29 @@
 
 Flair supports three authentication methods, from simplest to most enterprise-ready.
 
+## Auth across surfaces (read this first)
+
+Different surfaces authenticate differently. The model in one place:
+
+| Surface | Auth | Scope | Notes |
+|---------|------|-------|-------|
+| **CLI / SDK clients** (`flair`, `flair-client`) | **Ed25519 per-agent** | This agent only | Default, recommended. Signs every request; cross-agent reads refused server-side. |
+| **MCP server** (`@tpsdev-ai/flair-mcp`) | **Ed25519 per-agent** | This agent only | Same per-agent identity as the CLI — key auto-resolved from `~/.flair/keys/<agent>.key`. |
+| **OpenClaw / pi / Hermes plugins** | **Ed25519 per-agent** | This agent only | Same secure path; auto-detect agent identity. |
+| **`n8n-nodes-flair`** | **Harper admin-password Basic auth** | ⚠️ **Whole instance, read + write** | The admin credential grants every workflow read/write to the *entire* memory store, not just the configured Agent ID. |
+
+**The default, secure path is Ed25519 per-agent** (see below): each agent holds its own key, signs every request, and the server refuses cross-agent reads. Use this everywhere you can.
+
+### Known limitation — n8n uses admin-password Basic auth
+
+The `n8n-nodes-flair` community node authenticates with the Harper **admin password** (Basic auth), which grants **whole-instance read/write access**, not per-agent isolation. The blast radius is the entire memory store. This is acceptable only when **all** of the following hold:
+
+- The n8n instance is single-tenant and operator-controlled.
+- Workflow inputs are trusted (your own CRM, your own webhook source).
+- Memory leakage between agents is acceptable for the use case.
+
+If any of those don't hold, use Flair's CLI / SDK clients (which support per-agent Ed25519 today) and wait for the n8n credential to gain Ed25519 per-agent auth (planned). Full guidance in [docs/n8n.md](n8n.md#security).
+
 ## Ed25519 Agent Auth (Default)
 
 Every agent has an Ed25519 key pair. Requests are signed with `agentId:timestamp:nonce:METHOD:/path` and verified against the agent's registered public key. 30-second replay window with nonce deduplication.

--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -32,18 +32,13 @@ Don't see your harness? If it speaks **MCP** — Flair already works with `flair
 
 [`@tpsdev-ai/flair-mcp`](https://www.npmjs.com/package/@tpsdev-ai/flair-mcp) is a [Model Context Protocol](https://modelcontextprotocol.io/) server that exposes Flair as a memory tool to any MCP-speaking client. One server, every MCP client.
 
-Install:
-
-```bash
-npm install -g @tpsdev-ai/flair-mcp
-```
-
-Then wire into each tool's MCP config:
+No install step needed — every snippet below uses `npx -y @tpsdev-ai/flair-mcp`, which fetches and runs the server on demand (zero-install). The fastest path is `flair install`, which detects and wires these clients for you. To wire by hand, drop the relevant snippet into each tool's MCP config:
 
 **Claude Code** (`~/.config/claude-code/config.toml` or per-project `.claude/config.toml`):
 ```toml
 [mcp.servers.flair]
-command = "flair-mcp"
+command = "npx"
+args = ["-y", "@tpsdev-ai/flair-mcp"]
 env = { FLAIR_AGENT_ID = "claude-code" }
 ```
 
@@ -52,7 +47,8 @@ env = { FLAIR_AGENT_ID = "claude-code" }
 {
   "mcpServers": {
     "flair": {
-      "command": "flair-mcp",
+      "command": "npx",
+      "args": ["-y", "@tpsdev-ai/flair-mcp"],
       "env": { "FLAIR_AGENT_ID": "cursor" }
     }
   }
@@ -63,7 +59,7 @@ env = { FLAIR_AGENT_ID = "claude-code" }
 ```json
 {
   "mcpServers": {
-    "flair": { "command": "flair-mcp", "env": { "FLAIR_AGENT_ID": "codex" } }
+    "flair": { "command": "npx", "args": ["-y", "@tpsdev-ai/flair-mcp"], "env": { "FLAIR_AGENT_ID": "codex" } }
   }
 }
 ```
@@ -75,7 +71,8 @@ env = { FLAIR_AGENT_ID = "claude-code" }
 {
   "experimental": {
     "modelContextProtocolServer": {
-      "command": "flair-mcp",
+      "command": "npx",
+      "args": ["-y", "@tpsdev-ai/flair-mcp"],
       "env": { "FLAIR_AGENT_ID": "continue" }
     }
   }
@@ -87,7 +84,8 @@ env = { FLAIR_AGENT_ID = "claude-code" }
 default:
   extensions:
     flair:
-      cmd: flair-mcp
+      cmd: npx
+      args: ["-y", "@tpsdev-ai/flair-mcp"]
       envs: { FLAIR_AGENT_ID: goose }
 ```
 

--- a/docs/upgrade.md
+++ b/docs/upgrade.md
@@ -61,13 +61,13 @@ This re-generates embeddings for all memories using the current model. Runs in t
 
 ## MCP Server Upgrade
 
-If you use the MCP server with Claude Code:
+The recommended wiring runs the MCP server via `npx -y @tpsdev-ai/flair-mcp`, which fetches the latest published version on demand. To pick up a new release, just **restart your MCP client** (Claude Code, Cursor, etc.) — `npx` will resolve the newest version on next launch (clear the npx cache with `npx clear-npx-cache` if it pins an old one). No config changes needed — the MCP server reads `FLAIR_URL` and `FLAIR_AGENT_ID` from environment.
+
+If you pinned a version (e.g. `["-y", "@tpsdev-ai/flair-mcp@0.6.0"]`) or installed globally, bump it explicitly:
 
 ```bash
-npm install -g @tpsdev-ai/flair-mcp@latest
+npm install -g @tpsdev-ai/flair-mcp@latest   # only if you opted into a global install
 ```
-
-Then restart Claude Code to pick up the new version. No config changes needed — the MCP server reads `FLAIR_URL` and `FLAIR_AGENT_ID` from environment.
 
 ## Rollback
 

--- a/packages/flair-mcp/README.md
+++ b/packages/flair-mcp/README.md
@@ -13,7 +13,7 @@ cat > .mcp.json << 'EOF'
   "mcpServers": {
     "flair": {
       "command": "npx",
-      "args": ["@tpsdev-ai/flair-mcp"],
+      "args": ["-y", "@tpsdev-ai/flair-mcp"],
       "env": {
         "FLAIR_AGENT_ID": "my-project"
       }
@@ -23,16 +23,15 @@ cat > .mcp.json << 'EOF'
 EOF
 ```
 
-Or install globally and configure once in `~/.claude/settings.json`.
+`npx -y @tpsdev-ai/flair-mcp` fetches and runs the server on demand — no global install needed. (`flair install` wires this for you automatically; see below.)
 
 ### Prerequisites
 
-You need a running Flair instance:
+You need a running Flair instance. The one-command front door:
 
 ```bash
 npm install -g @tpsdev-ai/flair
-flair init
-flair agent add my-project
+flair install --agent my-project   # installs Harper, creates the agent, wires MCP clients
 ```
 
 ## Tools
@@ -76,7 +75,7 @@ Point to a remote Flair instance:
   "mcpServers": {
     "flair": {
       "command": "npx",
-      "args": ["@tpsdev-ai/flair-mcp"],
+      "args": ["-y", "@tpsdev-ai/flair-mcp"],
       "env": {
         "FLAIR_AGENT_ID": "my-project",
         "FLAIR_URL": "http://your-server:19926"

--- a/packages/flair-mcp/src/index.ts
+++ b/packages/flair-mcp/src/index.ts
@@ -15,10 +15,10 @@
  *   - flair_orgevent      — publish an OrgEvent attributed to self (no forging)
  *
  * Usage:
- *   npx @tpsdev-ai/flair-mcp
+ *   npx -y @tpsdev-ai/flair-mcp
  *
  * Claude Code .mcp.json:
- *   { "mcpServers": { "flair": { "command": "npx", "args": ["@tpsdev-ai/flair-mcp"] } } }
+ *   { "mcpServers": { "flair": { "command": "npx", "args": ["-y", "@tpsdev-ai/flair-mcp"] } } }
  */
 
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1872,10 +1872,14 @@ program
       // Auto-wire MCP config into ~/.claude.json if Claude Code is installed
       const claudeJsonPath = join(homedir(), ".claude.json");
       const mcpEnv: Record<string, string> = { FLAIR_AGENT_ID: agentId, FLAIR_URL: httpUrl };
+      // Zero-install wiring: `npx -y @tpsdev-ai/flair-mcp` fetches/runs the
+      // MCP server on demand, so this works without a prior global install and
+      // matches the npx form documented everywhere else (README, docs, and the
+      // `flair install` client-wiring snippets in src/install/clients.ts).
       const flairMcpConfig = {
         type: "stdio" as const,
-        command: "flair-mcp",
-        args: [] as string[],
+        command: "npx",
+        args: ["-y", "@tpsdev-ai/flair-mcp"] as string[],
         env: mcpEnv,
       };
       try {


### PR DESCRIPTION
Fixes three onboarding contradictions so the docs and the code agree on **one** zero-install pattern, and makes the auth model legible in one place. (ops-ogzp)

## FIX 1 — MCP-wiring contradiction

`flair init --agent-id <id>` auto-wired `~/.claude.json` with a bare `command: "flair-mcp"` (empty args), which assumes a **global** `flair-mcp` on `PATH` — but the README, `docs/`, and the `flair install` client snippets all use the zero-install `npx -y @tpsdev-ai/flair-mcp` form. The auto-wire now writes the npx form (`src/cli.ts`):

**Before**
```json
{ "mcpServers": { "flair": { "type": "stdio", "command": "flair-mcp", "args": [], "env": { "FLAIR_AGENT_ID": "mybot", "FLAIR_URL": "http://127.0.0.1:19926" } } } }
```

**After**
```json
{ "mcpServers": { "flair": { "type": "stdio", "command": "npx", "args": ["-y", "@tpsdev-ai/flair-mcp"], "env": { "FLAIR_AGENT_ID": "mybot", "FLAIR_URL": "http://127.0.0.1:19926" } } } }
```

Valid Claude Code `~/.claude.json` MCP shape (`type`/`command`/`args`/`env`). `flair install`'s own client-wiring (`src/install/clients.ts`) already used the npx form — this brings the `init` path into line with it.

## FIX 2 — `flair install` as the front door

The root README Quick Start now **leads with `flair install`** (one command: init + agent + MCP wiring + smoke test), with the useful flags (`--agent`, `--client`, `--no-mcp`, `--skip-smoke`). The manual `flair init → flair agent add → flair status` flow moved to an **"Advanced / manual setup"** section. Also corrected an inaccurate `flair agent add --role` example — `agent add` has no `--role` flag.

## FIX 3 — auth story in one place

New **"Auth across surfaces"** table in `docs/auth.md` (+ a pointer section in the README):

| Surface | Auth | Scope |
|---|---|---|
| CLI / SDK / MCP / OpenClaw·pi·Hermes plugins | **Ed25519 per-agent** (default, secure) | this agent only |
| `n8n-nodes-flair` | Harper **admin-password Basic auth** | ⚠️ **whole-instance read + write** |

The n8n path is flagged as a **known limitation** with the conditions under which it's acceptable (single-tenant, operator-controlled, trusted inputs).

## Docs / README / skills currency

Standardized **every** MCP-wiring snippet to the `npx -y @tpsdev-ai/flair-mcp` zero-install form: `docs/integrations.md` (Claude Code / Cursor / Codex / Gemini / Continue.dev / Goose), `docs/upgrade.md` (MCP upgrade is now "restart the client; npx fetches latest"), `packages/flair-mcp/README.md`, and the `packages/flair-mcp/src/index.ts` usage comment. Consistency grep confirms **no bare-binary `command: "flair-mcp"` wiring instructions remain**.

**Skills:** no `skills/` dir in this repo. The only flair skill found is the out-of-repo Claude Code skill `flair-best-practices` (`~/.claude/skills/`, not part of this repo) — its `integration-mcp` rule already used the npx config form; its Install section was updated to note zero-install + the `flair install` front door. That change is outside this PR's repo and isn't included here.

## Verification

- `tsc` typecheck clean.
- Full unit suite green: **1140 pass / 0 fail** (no pre-existing baseline failures).
- `check-impl-term-leaks` lint: **No leaks found.**
- Consistency grep: all MCP wiring now shows the npx `-y` form.

🤖 Generated with [Claude Code](https://claude.com/claude-code)