### PR TITLE
Onboarding: consolidate `flair install` into `flair init`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## [Unreleased]
 
+### 🚪 Onboarding — consolidate `flair install` into `flair init` (one front door)
+
+The git mental model: `npm install -g @tpsdev-ai/flair`, then `flair init`. `flair install` (introduced in v0.15.0 as a separate one-command front door) is **removed entirely** — its full behavior (bootstrap the instance + register the agent + detect and wire MCP clients via the zero-install `npx -y @tpsdev-ai/flair-mcp` form + smoke test) now lives in `flair init`. No deprecated alias: `install` shipped only in v0.15.0 and is referenced by zero external scripts, so an alias would be needless baggage.
+
+- **`flair init` is now the full one-command setup.** It gained `install`'s flags — `--client <claude-code|codex|gemini|cursor|all|none>`, `--no-mcp`, `--skip-smoke` — alongside its existing instance/agent/remote/Fabric flags. With no MCP flag it detects and wires every installed client (Claude Code is auto-wired into `~/.claude.json`; others print copy-paste snippets) and runs an MCP smoke test, then degrades gracefully (warnings, never a hard failure). `--no-mcp` reduces it to the minimal instance + agent bootstrap, so existing callers like `flair init --agent-id X` keep working unchanged.
+- **Canonical agent flag is `--agent-id`** (init's existing flag, referenced in docs and callers); `--agent` (install's flag) is kept as a hidden alias so both forms work.
+- **Docs updated:** README Quick Start, `docs/integrations.md`, the cross-orchestrator demo cast, and `packages/flair-mcp/README.md` now lead with `flair init`. (ops-ogzp iteration 2.)
+
 ### 📚 Onboarding consistency — one zero-install MCP-wiring pattern + `flair install` as the front door
 
 Three contradictions in the onboarding story, fixed so the docs and the code agree:

--- a/README.md
+++ b/README.md
@@ -182,14 +182,14 @@ Pluggable import/export to foreign memory systems. Every agent-memory format (ag
 
 ### Install & Run
 
-`flair install` is the front door. One command does everything: installs and starts Harper, creates your agent's Ed25519 identity, detects and wires your MCP clients (Claude Code / Cursor / Codex / Gemini) to the zero-install `npx -y @tpsdev-ai/flair-mcp` server, and runs a smoke test.
+`flair init` is the front door. The mental model is git's: install the CLI globally, then `init`. One command does everything: installs and starts Harper, creates your agent's Ed25519 identity, detects and wires your MCP clients (Claude Code / Cursor / Codex / Gemini) to the zero-install `npx -y @tpsdev-ai/flair-mcp` server, and runs a smoke test.
 
 ```bash
 # Install the CLI
 npm install -g @tpsdev-ai/flair
 
-# One command: init + agent + MCP wiring + smoke test
-flair install
+# One command: instance + agent + MCP wiring + smoke test
+flair init
 ```
 
 That's it. Your agent now has identity and memory, and any detected MCP client is wired up. Restart your MCP client (e.g. Claude Code) to pick up the new config, then ask the agent "what do you remember about me?"
@@ -197,10 +197,10 @@ That's it. Your agent now has identity and memory, and any detected MCP client i
 Useful flags:
 
 ```bash
-flair install --agent mybot          # name the agent (defaults to hostname short-form)
-flair install --client claude-code   # wire one specific client (claude-code, codex, gemini, cursor, all, none)
-flair install --no-mcp               # init + agent only, skip MCP wiring
-flair install --skip-smoke           # skip the MCP smoke test
+flair init --agent mybot           # name the agent (--agent-id also works)
+flair init --client claude-code    # wire one specific client (claude-code, codex, gemini, cursor, all, none)
+flair init --no-mcp                # instance + agent only, skip MCP wiring
+flair init --skip-smoke            # skip the MCP smoke test
 ```
 
 Lifecycle management:
@@ -215,11 +215,11 @@ flair uninstall --purge  # Remove everything including data and keys
 
 ### Advanced / manual setup
 
-Prefer to drive each step yourself, or scripting an unattended install? The individual commands `flair install` orchestrates are still available:
+Prefer to drive each step yourself, or scripting an unattended setup? Run `flair init --no-mcp` to bootstrap the instance + agent without wiring any MCP clients, then drive each step on its own:
 
 ```bash
-# Bootstrap a Flair instance (installs Harper, creates database, starts service)
-flair init
+# Bootstrap a Flair instance without registering an agent or wiring MCP
+flair init --no-mcp
 
 # Register your first agent (generates an Ed25519 keypair, registers it)
 flair agent add mybot --name "My Bot"
@@ -228,7 +228,7 @@ flair agent add mybot --name "My Bot"
 flair status
 ```
 
-`flair init --agent-id mybot` bootstraps the instance and registers an agent in one step (and auto-wires `~/.claude.json` if Claude Code is present). Wire other MCP clients manually using the snippets in **[docs/mcp-clients.md](docs/mcp-clients.md)** — all of them use the `npx -y @tpsdev-ai/flair-mcp` zero-install form.
+`flair init --agent mybot --no-mcp` bootstraps the instance and registers an agent in one step without touching any MCP client config. To wire clients later, re-run `flair init --agent mybot --client <name>`, or wire them manually using the snippets in **[docs/mcp-clients.md](docs/mcp-clients.md)** — all of them use the `npx -y @tpsdev-ai/flair-mcp` zero-install form.
 
 ## Integration
 

--- a/docs/assets/flair-cross-orchestrator.cast
+++ b/docs/assets/flair-cross-orchestrator.cast
@@ -2,7 +2,7 @@
 [0.245, "o", "\u001b[H\u001b[J"]
 [0.001, "o", "  Flair  \u00b7  same identity, every orchestrator\r\n  \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\r\n\r\n"]
 [1.3, "o", "$ # One agent identity. One memory store. Three orchestrators.\r\n"]
-[1.2, "o", "$ flair install --claude --codex --gemini --agent flint\r\n"]
+[1.2, "o", "$ flair init --client all --agent flint\r\n"]
 [0.5, "o", "  \u001b[32m\u2713\u001b[0m Claude Code   wired (~/.claude/mcp.json)\r\n"]
 [0.18, "o", "  \u001b[32m\u2713\u001b[0m Codex CLI     wired (~/.codex/config.toml)\r\n"]
 [0.18, "o", "  \u001b[32m\u2713\u001b[0m Gemini CLI    wired (~/.gemini/settings.json)\r\n\r\n"]

--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -32,7 +32,7 @@ Don't see your harness? If it speaks **MCP** — Flair already works with `flair
 
 [`@tpsdev-ai/flair-mcp`](https://www.npmjs.com/package/@tpsdev-ai/flair-mcp) is a [Model Context Protocol](https://modelcontextprotocol.io/) server that exposes Flair as a memory tool to any MCP-speaking client. One server, every MCP client.
 
-No install step needed — every snippet below uses `npx -y @tpsdev-ai/flair-mcp`, which fetches and runs the server on demand (zero-install). The fastest path is `flair install`, which detects and wires these clients for you. To wire by hand, drop the relevant snippet into each tool's MCP config:
+No install step needed — every snippet below uses `npx -y @tpsdev-ai/flair-mcp`, which fetches and runs the server on demand (zero-install). The fastest path is `flair init`, which detects and wires these clients for you. To wire by hand, drop the relevant snippet into each tool's MCP config:
 
 **Claude Code** (`~/.config/claude-code/config.toml` or per-project `.claude/config.toml`):
 ```toml

--- a/packages/flair-mcp/README.md
+++ b/packages/flair-mcp/README.md
@@ -23,7 +23,7 @@ cat > .mcp.json << 'EOF'
 EOF
 ```
 
-`npx -y @tpsdev-ai/flair-mcp` fetches and runs the server on demand — no global install needed. (`flair install` wires this for you automatically; see below.)
+`npx -y @tpsdev-ai/flair-mcp` fetches and runs the server on demand — no global install needed. (`flair init` wires this for you automatically; see below.)
 
 ### Prerequisites
 
@@ -31,7 +31,7 @@ You need a running Flair instance. The one-command front door:
 
 ```bash
 npm install -g @tpsdev-ai/flair
-flair install --agent my-project   # installs Harper, creates the agent, wires MCP clients
+flair init --agent my-project   # installs Harper, creates the agent, wires MCP clients
 ```
 
 ## Tools

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -24,7 +24,7 @@ import { create as tarCreate, extract as tarExtract, list as tarList } from "tar
 import { keystore } from "./keystore.js";
 import { deploy as deployToFabric, validateOptions as validateDeployOptions, buildTargetUrl as buildDeployUrl } from "./deploy.js";
 import { fabricUpgrade } from "./fabric-upgrade.js";
-import { detectClients, wireClaudeCode, wireCodex, wireGemini, wireCursor, type ClientId } from "./install/clients.js";
+import { detectClients, wireCodex, wireGemini, wireCursor, type ClientId } from "./install/clients.js";
 
 // Federation crypto helpers — inlined to avoid cross-boundary imports from
 // src/ into resources/, which don't survive npm packaging (see also
@@ -1346,8 +1346,9 @@ program.name("flair").version(__pkgVersion, "-v, --version");
 
 program
   .command("init")
-  .description("Bootstrap a Flair (Harper) instance for an agent")
+  .description("One-command Flair setup — bootstrap the instance, register an agent, and wire MCP clients")
   .option("--agent-id <id>", "Agent ID to register (omit to bootstrap instance without agent)")
+  .option("--agent <id>", "Alias for --agent-id")
   .option("--port <port>", "Harper HTTP port", String(DEFAULT_PORT))
   .option("--ops-port <port>", "Harper operations API port")
   .option("--admin-pass <pass>", "Admin password (generated if omitted)")
@@ -1356,6 +1357,9 @@ program
   .option("--data-dir <dir>", "Harper data directory")
   .option("--skip-start", "Skip Harper startup (assume already running)")
   .option("--skip-soul", "Skip interactive personality setup")
+  .option("--client <client>", "MCP client(s) to wire: claude-code, codex, gemini, cursor, all, or none")
+  .option("--no-mcp", "Skip MCP client wiring (instance + agent only)")
+  .option("--skip-smoke", "Skip the MCP smoke test")
   .option("--target <url>", "Remote Flair URL (env: FLAIR_TARGET)")
   .option("--remote", "When used with --target, init as hub for remote federation")
   .option("--ops-target <url>", "Explicit ops API URL (env: FLAIR_OPS_TARGET; bypasses port derivation)")
@@ -1364,7 +1368,7 @@ program
   .option("--cluster-admin-pass <pass>", "Harper cluster admin password (env: FLAIR_CLUSTER_ADMIN_PASS)")
   .option("--flair-admin-pass <pass>", "Password for Flair's admin user (env: FLAIR_ADMIN_PASS; generated if omitted)")
   .action(async (opts) => {
-    const agentId: string | undefined = opts.agentId;
+    const agentId: string | undefined = opts.agentId ?? opts.agent;
     const target = resolveTarget(opts);
     const opsTarget = resolveOpsTarget(opts);
 
@@ -1549,11 +1553,27 @@ program
       return;
     }
 
-    // ── Local init (original behavior) ──
+    // ── Local init (full one-command setup) ──
     const httpPort = resolveHttpPort(opts);
     const opsPort = resolveOpsPort(opts);
     const keysDir: string = opts.keysDir ?? defaultKeysDir();
     const dataDir: string = opts.dataDir ?? defaultDataDir();
+
+    // Resolve MCP client selection (union of init's auto-wire + the multi-client
+    // detection/wiring that the front-door command provides). `--no-mcp` sets
+    // opts.mcp === false (commander negates the flag). Validate an explicit
+    // --client up front so a typo fails before Harper is touched.
+    const clientOpt: string | undefined = opts.client;
+    const noMcp = opts.mcp === false;
+    const selectedClients: ClientId[] = [];
+    if (clientOpt && clientOpt !== "all" && clientOpt !== "none" && !noMcp) {
+      const valid: ClientId[] = ["claude-code", "codex", "gemini", "cursor"];
+      if (!valid.includes(clientOpt as ClientId)) {
+        console.error(`Unknown client: ${clientOpt}. Valid: claude-code, codex, gemini, cursor, all, none`);
+        process.exit(1);
+      }
+      selectedClients.push(clientOpt as ClientId);
+    }
 
     // Admin password: determine from opts, env, or generate
     // Priority: 1) --admin-pass-file, 2) env vars, 3) generate new
@@ -1869,39 +1889,130 @@ program
       console.log(`\n   Claude Code: Add to your CLAUDE.md:`);
       console.log(`     At the start of every session, run mcp__flair__bootstrap before responding.`);
 
-      // Auto-wire MCP config into ~/.claude.json if Claude Code is installed
-      const claudeJsonPath = join(homedir(), ".claude.json");
-      const mcpEnv: Record<string, string> = { FLAIR_AGENT_ID: agentId, FLAIR_URL: httpUrl };
-      // Zero-install wiring: `npx -y @tpsdev-ai/flair-mcp` fetches/runs the
-      // MCP server on demand, so this works without a prior global install and
-      // matches the npx form documented everywhere else (README, docs, and the
-      // `flair install` client-wiring snippets in src/install/clients.ts).
-      const flairMcpConfig = {
-        type: "stdio" as const,
-        command: "npx",
-        args: ["-y", "@tpsdev-ai/flair-mcp"] as string[],
-        env: mcpEnv,
-      };
-      try {
-        if (existsSync(claudeJsonPath)) {
-          const claudeJson = JSON.parse(readFileSync(claudeJsonPath, "utf-8"));
-          const existing = claudeJson.mcpServers?.flair;
-          if (existing && existing.env?.FLAIR_URL === httpUrl && existing.env?.FLAIR_AGENT_ID === agentId) {
-            console.log(`\n   MCP config already set in ~/.claude.json ✓`);
-          } else {
-            claudeJson.mcpServers = claudeJson.mcpServers || {};
-            claudeJson.mcpServers.flair = flairMcpConfig;
-            writeFileSync(claudeJsonPath, JSON.stringify(claudeJson, null, 2));
-            console.log(`\n   MCP config written to ~/.claude.json ✓`);
-            console.log(`   Restart Claude Code to pick up the new config.`);
-          }
-        } else {
-          console.log(`\n   MCP config (add to ~/.claude.json):`);
-          console.log(`     { "mcpServers": { "flair": ${JSON.stringify(flairMcpConfig)} } }`);
+      // ── MCP client wiring ────────────────────────────────────────────────
+      // The full one-command front door: detect installed MCP clients and wire
+      // each to the zero-install `npx -y @tpsdev-ai/flair-mcp` server. Claude
+      // Code is auto-wired into ~/.claude.json (the only client the CLI can
+      // safely modify); other clients get copy-paste snippets. `--no-mcp`
+      // skips wiring entirely; `--client <name>` targets one client; the
+      // default (no flag) wires every detected client.
+      const mcpEnv: { FLAIR_AGENT_ID: string; FLAIR_URL: string } = { FLAIR_AGENT_ID: agentId, FLAIR_URL: httpUrl };
+      const wiringResults: { client: string; message: string }[] = [];
+
+      if (!noMcp && clientOpt !== "none") {
+        // Determine which clients to wire.
+        let clients = detectClients();
+        if (selectedClients.length > 0) {
+          clients = clients.filter(c => selectedClients.includes(c.id));
         }
-      } catch {
-        console.log(`\n   MCP config (add manually to ~/.claude.json):`);
-        console.log(`     { "mcpServers": { "flair": ${JSON.stringify(flairMcpConfig)} } }`);
+        const detected = clients.filter(c => c.detected);
+
+        if (!clientOpt) {
+          if (detected.length === 0) {
+            console.log("\n   No MCP clients detected. Run with --client <name> to wire a specific client.");
+          } else {
+            console.log(`\n   Detected MCP clients: ${detected.map(c => c.label).join(", ")}`);
+          }
+        }
+
+        const toWire: ClientId[] = clientOpt === "all"
+          ? clients.filter(c => c.detected).map(c => c.id)
+          : selectedClients.length > 0
+            ? selectedClients
+            : clients.filter(c => c.detected).map(c => c.id);
+
+        for (const clientId of toWire) {
+          if (clientId === "claude-code") {
+            // Claude Code gets real auto-wiring into ~/.claude.json (zero-install
+            // npx form; matches the snippets everywhere else). Other clients only
+            // get printed instructions — the CLI can't safely edit their configs.
+            const claudeJsonPath = join(homedir(), ".claude.json");
+            const flairMcpConfig = {
+              type: "stdio" as const,
+              command: "npx",
+              args: ["-y", "@tpsdev-ai/flair-mcp"] as string[],
+              env: mcpEnv,
+            };
+            try {
+              if (existsSync(claudeJsonPath)) {
+                const claudeJson = JSON.parse(readFileSync(claudeJsonPath, "utf-8"));
+                const existing = claudeJson.mcpServers?.flair;
+                if (existing && existing.env?.FLAIR_URL === httpUrl && existing.env?.FLAIR_AGENT_ID === agentId) {
+                  console.log(`   ✓ Claude Code already wired in ~/.claude.json`);
+                  wiringResults.push({ client: "claude-code", message: "already wired" });
+                } else {
+                  claudeJson.mcpServers = claudeJson.mcpServers || {};
+                  claudeJson.mcpServers.flair = flairMcpConfig;
+                  writeFileSync(claudeJsonPath, JSON.stringify(claudeJson, null, 2));
+                  console.log(`   ✓ Claude Code wired in ~/.claude.json (restart Claude Code to pick it up)`);
+                  wiringResults.push({ client: "claude-code", message: "wired ~/.claude.json" });
+                }
+              } else {
+                console.log(`   MCP config (add to ~/.claude.json):`);
+                console.log(`     { "mcpServers": { "flair": ${JSON.stringify(flairMcpConfig)} } }`);
+                wiringResults.push({ client: "claude-code", message: "snippet printed (no ~/.claude.json)" });
+              }
+            } catch {
+              console.log(`   MCP config (add manually to ~/.claude.json):`);
+              console.log(`     { "mcpServers": { "flair": ${JSON.stringify(flairMcpConfig)} } }`);
+              wiringResults.push({ client: "claude-code", message: "snippet printed" });
+            }
+          } else {
+            let result: { ok: boolean; message: string };
+            switch (clientId) {
+              case "codex": result = wireCodex(mcpEnv); break;
+              case "gemini": result = wireGemini(mcpEnv); break;
+              case "cursor": result = wireCursor(mcpEnv); break;
+              default: result = { ok: false, message: `Unknown client: ${clientId}` };
+            }
+            wiringResults.push({ client: clientId, message: result.message });
+            console.log(`   ${result.ok ? "✓" : "•"} ${result.message}`);
+          }
+        }
+      }
+
+      // ── Smoke-test the MCP server ────────────────────────────────────────
+      // Launch flair-mcp and confirm it answers a JSON-RPC initialize over
+      // stdio. Best-effort: failures warn but never fail the command. Skipped
+      // with --skip-smoke, --no-mcp, --client none, or when nothing was wired.
+      if (!opts.skipSmoke && !noMcp && clientOpt !== "none" && wiringResults.length > 0) {
+        console.log("\n   Smoke-testing MCP server...");
+        try {
+          const mcpProc = spawn("npx", ["-y", "@tpsdev-ai/flair-mcp"], {
+            env: { ...process.env, FLAIR_AGENT_ID: agentId, FLAIR_URL: httpUrl },
+            stdio: ["pipe", "pipe", "pipe"],
+            timeout: 15_000,
+          });
+          const initMsg = JSON.stringify({ jsonrpc: "2.0", id: 1, method: "initialize", params: { protocolVersion: "0.1", capabilities: {}, clientInfo: { name: "flair-init", version: "1.0.0" } } });
+          mcpProc.stdin!.write(initMsg + "\n");
+          mcpProc.stdin!.end();
+          let stdout = "";
+          mcpProc.stdout!.on("data", (d: Buffer) => { stdout += d.toString(); });
+          await new Promise<void>((resolve, reject) => {
+            mcpProc.on("exit", (code) => {
+              if (code === 0 && stdout.length > 0) resolve();
+              else reject(new Error(`MCP server exited with code ${code}`));
+            });
+            mcpProc.on("error", reject);
+            setTimeout(() => { mcpProc.kill(); reject(new Error("MCP smoke test timed out")); }, 15_000);
+          });
+          try {
+            const lines = stdout.split("\n").filter(l => l.trim());
+            for (const line of lines) {
+              const parsed = JSON.parse(line);
+              if (parsed.jsonrpc === "2.0" && parsed.id === 1 && !parsed.error) {
+                console.log("   ✓ MCP server responded");
+                break;
+              }
+            }
+          } catch {
+            console.log("   ⚠ MCP server responded but response could not be parsed");
+          }
+        } catch (err: unknown) {
+          const message = err instanceof Error ? err.message : String(err);
+          console.log(`   ⚠ MCP smoke test failed: ${message}`);
+          console.log("   Use --skip-smoke to bypass.");
+        }
       }
     } else {
       const httpUrl = `http://127.0.0.1:${httpPort}`;
@@ -1926,352 +2037,6 @@ program
       console.log(`\n   Export: FLAIR_URL=${httpUrl}`);
     }
 
-  });
-
-// ─── flair install ───────────────────────────────────────────────────────────
-
-program
-  .command("install")
-  .description("One-command Flair setup — init, agent, and MCP client wiring")
-  .option("--client <client>", "MCP client(s) to wire: claude-code, codex, gemini, cursor, all, or none")
-  .option("--agent <id>", "Agent ID (defaults to hostname short-form)")
-  .option("--no-mcp", "Skip MCP wiring (init + agent only)")
-  .option("--port <port>", "Harper HTTP port")
-  .option("--ops-port <port>", "Harper operations API port")
-  .option("--data-dir <dir>", "Harper data directory")
-  .option("--keys-dir <dir>", "Directory for Ed25519 keys")
-  .option("--skip-smoke", "Skip MCP smoke test")
-  .action(async (opts) => {
-    const httpPort = resolveHttpPort(opts);
-    const opsPort = resolveOpsPort(opts);
-    const keysDir: string = opts.keysDir ?? defaultKeysDir();
-    const dataDir: string = opts.dataDir ?? defaultDataDir();
-
-    // Resolve client selection
-    const clientOpt: string | undefined = opts.client;
-    const noMcp = opts.noMcp === true;
-    const selectedClients: ClientId[] = [];
-
-    if (clientOpt === "none" || noMcp) {
-      // Skip MCP entirely — just init + agent
-    } else if (clientOpt === "all") {
-      // Wire all detected clients
-    } else if (clientOpt) {
-      // Wire a specific client
-      const valid: ClientId[] = ["claude-code", "codex", "gemini", "cursor"];
-      if (!valid.includes(clientOpt as ClientId)) {
-        console.error(`Unknown client: ${clientOpt}. Valid: claude-code, codex, gemini, cursor, all, none`);
-        process.exit(1);
-      }
-      selectedClients.push(clientOpt as ClientId);
-    }
-    // If no --client flag: interactive detection later
-
-    // ── Step 1: Ensure Flair is initialized ──
-    let alreadyInitialized = false;
-    let alreadyRunning = false;
-    let adminPass: string = opts.adminPass ?? process.env.FLAIR_ADMIN_PASS ?? process.env.HDB_ADMIN_PASSWORD ?? "";
-    const adminUser = DEFAULT_ADMIN_USER;
-
-    // Check if Flair is already initialized (config with port exists)
-    try {
-      const cp = configPath();
-      if (existsSync(cp)) {
-        const yaml = readFileSync(cp, "utf-8");
-        if (yaml.match(/port:\s*\d+/)) {
-          alreadyInitialized = true;
-          console.log("Flair already initialized — skipping init.");
-        }
-      }
-    } catch { /* not initialized */ }
-
-    if (!alreadyInitialized) {
-      const major = parseInt(process.version.slice(1), 10);
-      if (major < 18) throw new Error(`Node.js >= 18 required (found ${process.version})`);
-
-      // Only generate a password if none provided via env (fresh install)
-      // If we generate, write it atomically to ~/.flair/admin-pass
-      let adminPassGenerated = false;
-      if (!adminPass) {
-        adminPass = Buffer.from(nacl.randomBytes(18)).toString("base64url");
-        adminPassGenerated = true;
-        
-        // Atomic write: create temp file in same dir, then rename
-        const flairDir = join(homedir(), ".flair");
-        mkdirSync(flairDir, { recursive: true });
-        const adminPassPath = join(flairDir, "admin-pass");
-        const tempPath = mkdtempSync(join(flairDir, ".admin-pass.tmp-"));
-        const finalTempPath = join(tempPath, "admin-pass");
-        try {
-          writeFileSync(finalTempPath, adminPass + "\n", { mode: 0o600 });
-          renameSync(finalTempPath, adminPassPath);
-          rmSync(tempPath, { recursive: true, force: true });
-        } catch (err) {
-          // Clean up temp dir on failure
-          try { rmSync(tempPath, { recursive: true, force: true }); } catch {}
-          throw err;
-        }
-        console.log(`Admin password saved to: ${adminPassPath}`);
-      }
-
-      // Check if Harper is already running on this port
-      try {
-        const res = await fetch(`http://127.0.0.1:${httpPort}/health`, { signal: AbortSignal.timeout(1000) });
-        if (res.status > 0) { alreadyRunning = true; console.log(`Harper already running on port ${httpPort} — skipping start`); }
-      } catch { /* not running */ }
-
-      if (!alreadyRunning) {
-        const bin = harperBin();
-        if (!bin) throw new Error("@harperfast/harper not found in node_modules.\nRun: npm install @harperfast/harper");
-
-        mkdirSync(dataDir, { recursive: true });
-
-        const alreadyInstalled = existsSync(join(dataDir, "harper-config.yaml"));
-
-        const harperSetConfig = JSON.stringify({
-          rootPath: dataDir,
-          http: { port: httpPort, cors: true, corsAccessList: [`http://127.0.0.1:${httpPort}`, `http://localhost:${httpPort}`] },
-          operationsApi: { network: { port: opsPort, cors: true }, domainSocket: join(dataDir, "operations-server") },
-          mqtt: { network: { port: null }, webSocket: false },
-          localStudio: { enabled: false },
-          authentication: { authorizeLocal: true, enableSessions: true },
-        });
-
-        const env: Record<string, string> = {
-          ...(process.env as Record<string, string>),
-          ROOTPATH: dataDir,
-          HARPER_SET_CONFIG: harperSetConfig,
-          DEFAULTS_MODE: "dev",
-          HDB_ADMIN_USERNAME: adminUser,
-          HDB_ADMIN_PASSWORD: adminPass,
-          THREADS_COUNT: "1",
-          NODE_HOSTNAME: "localhost",
-          HTTP_PORT: String(httpPort),
-          OPERATIONSAPI_NETWORK_PORT: String(opsPort),
-          LOCAL_STUDIO: "false",
-        };
-
-        if (alreadyInstalled) {
-          console.log("Existing Harper installation found — skipping install.");
-        } else {
-          const installEnv = { ...env, HOME: join(dataDir, "..") };
-          console.log("Installing Harper...");
-          console.log("Downloading embedding model (nomic-embed-text-v1.5, ~80MB) — this may take a minute...");
-          await new Promise<void>((resolve, reject) => {
-            let output = "";
-            let dotTimer: ReturnType<typeof setInterval> | null = null;
-            const install = spawn(process.execPath, [bin, "install"], { cwd: flairPackageDir(), env: installEnv });
-            dotTimer = setInterval(() => process.stdout.write("."), 3000);
-            install.stdout?.on("data", (d: Buffer) => { output += d.toString(); });
-            install.stderr?.on("data", (d: Buffer) => { output += d.toString(); });
-            install.on("exit", (code) => {
-              if (dotTimer) { clearInterval(dotTimer); process.stdout.write("\n"); }
-              code === 0 ? resolve() : reject(new Error(`Harper install failed (${code}): ${output}`));
-            });
-            install.on("error", (err) => {
-              if (dotTimer) { clearInterval(dotTimer); process.stdout.write("\n"); }
-              reject(err);
-            });
-            setTimeout(() => {
-              install.kill();
-              if (dotTimer) { clearInterval(dotTimer); process.stdout.write("\n"); }
-              reject(new Error(`Harper install timed out: ${output}`));
-            }, 60_000);
-          });
-        }
-
-        // Start Harper
-        console.log(`Starting Harper on port ${httpPort}...`);
-        const proc = spawn(process.execPath, [bin, "run", "."], { cwd: flairPackageDir(), env, detached: true, stdio: "ignore" });
-        proc.unref();
-      }
-
-      // Wait for health
-      console.log("Waiting for Harper health check...");
-      await waitForHealth(httpPort, adminUser, adminPass, STARTUP_TIMEOUT_MS);
-      console.log("Harper is healthy ✓");
-
-      // Write config so other commands can find this instance
-      writeConfig(httpPort);
-    } else {
-      // Flair already initialized — resolve admin pass from env, falling back to
-      // the persisted ~/.flair/admin-pass written at first install. Agent
-      // seeding now goes through the ops API (#499), which always requires Basic
-      // admin auth (it does NOT honor authorizeLocal), so a re-run of
-      // `flair install --agent <new-id>` against an already-initialized local
-      // Flair needs a real pass even when no env var is set.
-      adminPass = process.env.FLAIR_ADMIN_PASS ?? process.env.HDB_ADMIN_PASSWORD ?? "";
-      if (!adminPass) {
-        try {
-          const persisted = join(homedir(), ".flair", "admin-pass");
-          if (existsSync(persisted)) adminPass = readFileSync(persisted, "utf-8").trim();
-        } catch { /* fall through with empty pass */ }
-      }
-    }
-
-    const httpUrl = `http://127.0.0.1:${httpPort}`;
-
-    // ── Step 2: Detect MCP clients ──
-    let clients = detectClients();
-
-    if (selectedClients.length > 0) {
-      // Explicit --client flag — override detection
-      if (clientOpt === "all" || clientOpt === "none" || noMcp) {
-        // all/none handled below
-      } else {
-        // Filter to only the selected client (preserving wire function from detectClients)
-        clients = clients.filter(c => selectedClients.includes(c.id));
-      }
-    }
-
-    if (!clientOpt && !noMcp) {
-      // No --client flag — print detected clients
-      const detected = clients.filter(c => c.detected);
-      if (detected.length === 0) {
-        console.log("No MCP clients detected. Run with --client <name> to wire a specific client.");
-      } else {
-        console.log(`Detected MCP clients: ${detected.map(c => c.label).join(", ")}`);
-      }
-    }
-
-    // ── Step 3: Resolve agent identity ──
-    const agentId: string = opts.agent ?? (() => {
-      try {
-        const hn = hostname();
-        return hn.split(".")[0];
-      } catch {
-        return "flair-agent";
-      }
-    })();
-
-    // Validate agentId to prevent path traversal
-    const VALID_AGENT_ID = /^[a-zA-Z0-9_-]+$/;
-    if (!VALID_AGENT_ID.test(agentId)) {
-      throw new Error(`Invalid agent ID: ${agentId}. Agent ID must contain only letters, numbers, underscores, and hyphens.`);
-    }
-
-    let agentExists = false;
-
-    // Check if agent already exists locally
-    const privPath = privKeyPath(agentId, keysDir);
-    if (existsSync(privPath)) {
-      agentExists = true;
-      console.log(`Agent '${agentId}' already exists ✓`);
-    } else {
-      // Create agent
-      mkdirSync(keysDir, { recursive: true });
-      const pubPath = pubKeyPath(agentId, keysDir);
-      console.log("Generating Ed25519 keypair...");
-      const kp = nacl.sign.keyPair();
-      const seed = kp.secretKey.slice(0, 32);
-      writeFileSync(privPath, Buffer.from(seed));
-      chmodSync(privPath, 0o600);
-      writeFileSync(pubPath, Buffer.from(kp.publicKey));
-      const pubKeyB64url = b64url(kp.publicKey);
-      console.log(`Keypair written: ${privPath} ✓`);
-
-      // Seed agent via the Harper operations API. The Agent table is a REST
-      // resource without a POST handler, so the insert body must go to the ops
-      // API (POST <opsUrl>/ with {operation:"insert",...}), NOT the REST root
-      // (which 405s the body as a collection POST to /Agent). This is the same
-      // path `flair agent add` uses. (#499)
-      const seedOpsTarget = opts.opsTarget ?? opsPort;
-      console.log(
-        opts.opsTarget
-          ? `Seeding agent '${agentId}' via operations API (--ops-target)...`
-          : `Seeding agent '${agentId}' via operations API...`,
-      );
-      await seedAgentViaOpsApi(seedOpsTarget, agentId, pubKeyB64url, adminUser, adminPass);
-      console.log(`Agent '${agentId}' registered ✓`);
-    }
-
-    // ── Step 4: Wire MCP clients ──
-    const mcpEnv = { FLAIR_AGENT_ID: agentId, FLAIR_URL: httpUrl };
-    const wiringResults: { client: string; message: string }[] = [];
-
-    if (!noMcp && clientOpt !== "none") {
-      const toWire = clientOpt === "all"
-        ? clients.filter(c => c.detected).map(c => c.id)
-        : selectedClients.length > 0
-          ? selectedClients
-          : clients.filter(c => c.detected).map(c => c.id);
-
-      for (const clientId of toWire) {
-        let result: { ok: boolean; message: string };
-        switch (clientId) {
-          case "claude-code": result = wireClaudeCode(mcpEnv); break;
-          case "codex": result = wireCodex(mcpEnv); break;
-          case "gemini": result = wireGemini(mcpEnv); break;
-          case "cursor": result = wireCursor(mcpEnv); break;
-          default: result = { ok: false, message: `Unknown client: ${clientId}` };
-        }
-        wiringResults.push({ client: clientId, message: result.message });
-        console.log(`  ${result.ok ? "✓" : "✗"} ${result.message}`);
-      }
-    }
-
-    // ── Step 5: Smoke test the MCP server ──
-    if (!opts.skipSmoke && !noMcp && clientOpt !== "none" && wiringResults.length > 0) {
-      console.log("Smoke-testing MCP server...");
-      try {
-        // Launch flair-mcp and send initialize request over stdio
-        const mcpProc = spawn("npx", ["-y", "@tpsdev-ai/flair-mcp"], {
-          env: { ...process.env, FLAIR_AGENT_ID: agentId, FLAIR_URL: httpUrl },
-          stdio: ["pipe", "pipe", "pipe"],
-          timeout: 15_000,
-        });
-
-        // Send initialize request
-        const initMsg = JSON.stringify({ jsonrpc: "2.0", id: 1, method: "initialize", params: { protocolVersion: "0.1", capabilities: {}, clientInfo: { name: "flair-install", version: "1.0.0" } } });
-        mcpProc.stdin!.write(initMsg + "\n");
-        mcpProc.stdin!.end();
-
-        let stdout = "";
-        mcpProc.stdout!.on("data", (d: Buffer) => { stdout += d.toString(); });
-
-        await new Promise<void>((resolve, reject) => {
-          mcpProc.on("exit", (code) => {
-            if (code === 0 && stdout.length > 0) {
-              resolve();
-            } else {
-              reject(new Error(`MCP server exited with code ${code}`));
-            }
-          });
-          mcpProc.on("error", reject);
-          setTimeout(() => { mcpProc.kill(); reject(new Error("MCP smoke test timed out")); }, 15_000);
-        });
-
-        // Check for a valid JSON-RPC response
-        try {
-          const lines = stdout.split("\n").filter(l => l.trim());
-          for (const line of lines) {
-            const parsed = JSON.parse(line);
-            if (parsed.jsonrpc === "2.0" && parsed.id === 1 && !parsed.error) {
-              console.log("  ✓ MCP server responded");
-              break;
-            }
-          }
-        } catch {
-          console.log("  ⚠ MCP server responded but response could not be parsed");
-        }
-      } catch (err: unknown) {
-        const message = err instanceof Error ? err.message : String(err);
-        console.log(`  ⚠ MCP smoke test failed: ${message}`);
-        console.log("  Use --skip-smoke to bypass.");
-      }
-    }
-
-    // ── Step 6: Summary ──
-    console.log("");
-    console.log("✓ Flair installed.");
-    console.log(`   Agent: ${agentId}`);
-    if (existsSync(privKeyPath(agentId, keysDir))) {
-      console.log(`   Private key: ${privKeyPath(agentId, keysDir)}`);
-    }
-    console.log(`   Local: ${httpUrl}`);
-    console.log(`   MCP: ${wiringResults.length > 0 ? wiringResults.map(r => r.client).join(", ") + " ✓ wired" : "none wired"}`);
-    console.log("");
-    console.log(`   Try it: in Claude Code, ask the agent "what do you remember about me?"`);
   });
 
 // ─── flair agent ─────────────────────────────────────────────────────────────

--- a/test/integration/onboarding-smoke.test.ts
+++ b/test/integration/onboarding-smoke.test.ts
@@ -88,8 +88,8 @@ afterAll(async () => {
 
 describe("first-run onboarding (real CLI, isolated temp Harper + home)", () => {
   // #499: agent seeding goes through the ops API. `flair agent add` uses the
-  // exact seedAgentViaOpsApi(opsPort, ...) call the `flair install` fix now
-  // uses, so a green add proves the seed mechanism the install path depends on.
+  // exact seedAgentViaOpsApi(opsPort, ...) call the `flair init` agent path now
+  // uses, so a green add proves the seed mechanism the init path depends on.
   test("agent add seeds via ops API (#499)", async () => {
     // No --keys-dir: write the key to the default ~/.flair/keys (under the
     // isolated cliHome), so later Ed25519-authed commands resolve it.


### PR DESCRIPTION
Onboarding: consolidate `flair install` into `flair init` (git mental model — `npm install -g`, then `flair init`); remove `install`, no alias (shipped today, zero external scripts). ops-ogzp iteration 2.

## What moved into `flair init`

`flair init` is now the single one-command front door. It does everything `flair install` did:
- bootstrap the Harper instance
- register the agent (Ed25519 keypair + ops-API seed)
- detect installed MCP clients and wire them to the zero-install `npx -y @tpsdev-ai/flair-mcp` server (Claude Code auto-wired into `~/.claude.json`; Codex/Gemini/Cursor get copy-paste snippets)
- run the MCP smoke test

...alongside init's pre-existing remote/Fabric flags (`--target`, `--remote`, `--ops-target`, `--cluster-admin-*`, `--flair-admin-pass`).

### Flag union (added to `init`)
- `--client <claude-code|codex|gemini|cursor|all|none>` — wire a specific client / all detected / none
- `--no-mcp` — skip MCP wiring (instance + agent only)
- `--skip-smoke` — skip the MCP smoke test

### Canonical agent flag
`--agent-id` stays canonical (init's existing flag, used in docs + callers). `--agent` (install's flag) is kept as a **hidden alias** so both forms work.

### No behavior regression
With no MCP flag, `init` detects + wires every installed client and smoke-tests (the full front door). The smoke test degrades gracefully — warns, never hard-fails. `--no-mcp` reduces `init` to the minimal instance+agent bootstrap, so existing callers like `flair init --agent-id X` (used by `test/integration/onboarding-smoke.test.ts`) keep working unchanged.

## `flair install` removed
Deleted entirely — **no deprecated alias**. It shipped only in v0.15.0 (today) and is referenced by zero external scripts, so an alias would be needless baggage.

## Refs updated
- `README.md` — Quick Start now leads with `flair init`; advanced/manual section uses `flair init --no-mcp`
- `docs/integrations.md` — front-door mention → `flair init`
- `docs/assets/flair-cross-orchestrator.cast` — demo line `flair install --claude --codex --gemini --agent flint` → `flair init --client all --agent flint` (the old `--claude/--codex/--gemini` boolean flags never actually existed on `install`; `--client all` is the real form that wires all detected clients)
- `packages/flair-mcp/README.md` — both mentions → `flair init`
- `test/integration/onboarding-smoke.test.ts` — comment updated (the test drives `flair agent add`, not the front-door command)
- `CHANGELOG.md` — `## [Unreleased]` entry naming the rename

**Out of repo (noted, not in this PR):** the `flair-best-practices` Claude Code skill (`~/.claude/skills/flair-best-practices/rules/integration-mcp.md`) was updated `flair install` → `flair init` separately, same as the iteration-1 agent did.

## Verification
- `grep -rn 'flair install' README.md docs/ packages/ test/ src/` → **zero** matches
- typecheck clean: `tsc --noEmit -p tsconfig.cli.json` and `-p tsconfig.check.json`
- pre-commit passed (workspace-deps, dep-ages, **impl-term leak check**, ASCII boxes)
- unit suite: **1140 pass / 0 fail**
- onboarding-smoke integration: **3 pass / 0 fail** (green with `flair init` consolidation)
- `flair init --help` + README present ONE coherent front-door command; `flair install` no longer exists

K&S-gated. Do NOT merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)