### PR TITLE
fix(flair-mcp): loud Node-version preflight — npx -y @tpsdev-ai/flair-mcp was silently failing on unsupported Node — ops-fomi

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## [Unreleased]
 
+### 🛟 Loud Node-version preflight for `flair-mcp` — silent failure on old Node (ops-fomi)
+
+The `flair-mcp` bin (`dist/index.js`) is an ES module: top-level imports are hoisted and the whole module graph is linked + evaluated before the file body runs. flair-mcp's deps (`@modelcontextprotocol/sdk`, `@tpsdev-ai/flair-client` and its transitive deps) need a modern engine, so on an old Node the import graph crashes during linking — **before** any in-file version guard could run. Result: a user wiring `npx -y @tpsdev-ai/flair-mcp` on an unsupported Node gets zero output and a dead MCP server, with no actionable signal. This is the same exposure flair's CLI had, fixed in #524 — now mirrored for the MCP server.
+
+- **The `flair-mcp` bin now points at a CommonJS preflight shim** (`dist/mcp-shim.cjs`, compiled from `src/mcp-shim.cts`). CJS evaluates top-to-bottom with lazy `import()`, so the Node-version check runs and prints **before** anything loads the ESM server or any modern dep. On an unsupported Node → an actionable message (`flair-mcp requires Node.js >= 22. You are running Node.js X. ... https://nodejs.org/`) + `process.exit(1)`. On a supported Node → a transparent no-op that dynamically imports the server and hands off to `runMcp()`.
+- **The shim uses only ancient-safe syntax** (`var`, plain functions, string ops, `console.error`, `process.exit`) so the guard itself can never fail to parse on the oldest Node a user could have. `node --check` confirms parse-safety.
+- **`src/index.ts` now exports `runMcp()`** — all runtime side effects (the `FLAIR_AGENT_ID` check, `FlairClient` construction, the parent-exit watcher, tool registration, the stdio connect) moved inside it, so merely importing the module (from the shim before the version check, or from a test) does nothing until `runMcp()` is called. Direct invocation (`node dist/index.js`, `bun src/index.ts`) still works via an `import.meta.main` entry-point guard.
+- **`engines.node` bumped `>=18` → `>=22`** to match flair's CLI and the deps' real floor, so `npm install` also warns on an unsupported Node. Postinstall now `chmod +x` the shim.
+- New unit test (`test/mcp-node-preflight.test.ts`) proves: loud non-zero failure on a simulated old Node without loading the ESM server, no-op handoff to `runMcp()` on the supported Node the suite runs on, and parse-safety of the emitted shim. (packages/flair-mcp/*)
+
 ### 🛟 Harper watchdog now recovers an UNLOADED launchd job + alerts on state transitions (ops-6nv7)
 
 On 2026-06-27 ~04:20 prod Flair (`:9926`) was **down** — the `ai.tpsdev.flair` launchd job wasn't loaded (no Harper PID) — and it stayed down, undetected, until a memory write happened to fail. Two gaps: (1) `harper-watchdog.sh` only handled the *PID-alive-but-`/Health`-dead* zombie case (`kill -9` + `launchctl kickstart -k`); `kickstart`/`start` are **no-ops on an unloaded job**, so the job-unloaded failure mode went unrecovered. (2) There was **no alerting at all** — a Flair-down was invisible. Recovery was a manual `launchctl load ~/Library/LaunchAgents/ai.tpsdev.flair.plist`.

--- a/packages/flair-mcp/package.json
+++ b/packages/flair-mcp/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "main": "dist/index.js",
   "bin": {
-    "flair-mcp": "dist/index.js",
+    "flair-mcp": "dist/mcp-shim.cjs",
     "flair-session-start": "dist/session-start-hook.js"
   },
   "files": [
@@ -17,13 +17,13 @@
     "build": "tsc --noCheck",
     "test": "bun test",
     "prepublishOnly": "npm run build",
-    "postinstall": "node -e \"try{const{chmodSync,statSync}=require('fs');for(const p of ['dist/index.js','dist/session-start-hook.js']){try{if(statSync(p).isFile()){chmodSync(p,0o755);console.error('@tpsdev-ai/flair-mcp: chmod +x ' + p + ' OK')}}catch(e){if(e.code!=='ENOENT')console.error('postinstall warn:',e.message)}}}catch(e){console.error('postinstall warn:',e.message)}\""
+    "postinstall": "node -e \"try{const{chmodSync,statSync}=require('fs');for(const p of ['dist/mcp-shim.cjs','dist/index.js','dist/session-start-hook.js']){try{if(statSync(p).isFile()){chmodSync(p,0o755);console.error('@tpsdev-ai/flair-mcp: chmod +x ' + p + ' OK')}}catch(e){if(e.code!=='ENOENT')console.error('postinstall warn:',e.message)}}}catch(e){console.error('postinstall warn:',e.message)}\""
   },
   "publishConfig": {
     "access": "public"
   },
   "engines": {
-    "node": ">=18"
+    "node": ">=22"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "1.27.1",

--- a/packages/flair-mcp/src/index.ts
+++ b/packages/flair-mcp/src/index.ts
@@ -19,6 +19,16 @@
  *
  * Claude Code .mcp.json:
  *   { "mcpServers": { "flair": { "command": "npx", "args": ["-y", "@tpsdev-ai/flair-mcp"] } } }
+ *
+ * BIN ENTRY / NODE-VERSION PREFLIGHT
+ * ----------------------------------
+ * The published `flair-mcp` bin is NOT this file — it is the CommonJS preflight
+ * shim (dist/mcp-shim.cjs, compiled from src/mcp-shim.cts). This module is an
+ * ES module: its top-level imports are hoisted and the whole graph is linked +
+ * evaluated before any in-file guard could run, so on an old Node it crashes
+ * during linking (the SDK + flair deps need Node >= 22) before printing anything
+ * — the silent `npx -y @tpsdev-ai/flair-mcp` failure. The shim checks the Node
+ * version FIRST, then dynamically imports this module and calls runMcp().
  */
 
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
@@ -66,74 +76,85 @@ function errorResult(err: unknown, flairUrl: string) {
   return { content: [{ type: "text" as const, text: classifyError(err, flairUrl) }], isError: true };
 }
 
-// ─── Parent-exit watcher ────────────────────────────────────────────────────
+// ─── Entry point ──────────────────────────────────────────────────────────────
 //
-// flair-mcp runs as a child of an MCP host (Claude Code, Cursor, etc) over
-// stdio. When the host exits cleanly it should close stdin/stdout — but in
-// practice we've seen flair-mcp processes orphaned for weeks (PID 1 as
-// parent), holding stale tokens and consuming RAM.
-//
-// Poll process.ppid every 5s. If it drops to 1 (init), the parent died and
-// we got reparented — exit cleanly. Cheap, cross-platform, no native deps.
+// runMcp() is the real entry point. It is exported so the CommonJS preflight
+// shim (mcp-shim.cts → dist/mcp-shim.cjs, the published bin) can invoke it after
+// its Node-version check passes — the shim imports this module, so a top-level
+// `import.meta.main` guard would be false there. Everything that has runtime
+// side effects (the FLAIR_AGENT_ID check, FlairClient construction, the parent-
+// exit watcher, tool registration, and the stdio connect) lives inside runMcp()
+// so that merely importing this module (e.g. from the shim before the version
+// check, or from a test) does nothing until runMcp() is called.
+export async function runMcp(): Promise<void> {
+  // ─── Parent-exit watcher ──────────────────────────────────────────────────
+  //
+  // flair-mcp runs as a child of an MCP host (Claude Code, Cursor, etc) over
+  // stdio. When the host exits cleanly it should close stdin/stdout — but in
+  // practice we've seen flair-mcp processes orphaned for weeks (PID 1 as
+  // parent), holding stale tokens and consuming RAM.
+  //
+  // Poll process.ppid every 5s. If it drops to 1 (init), the parent died and
+  // we got reparented — exit cleanly. Cheap, cross-platform, no native deps.
 
-// Clamp the poll interval to a safe range. `process.env.FOO ?? 5000` is NOT
-// safe on its own: `??` only falls through on null/undefined, so an empty-string
-// override (`FLAIR_MCP_PARENT_POLL_MS=`) yields `Number("") === 0` and creates
-// a tight CPU-busy loop. Validate explicitly. (Sherlock review on #315.)
-const PARENT_POLL_INTERVAL_MS = (() => {
-  const raw = process.env.FLAIR_MCP_PARENT_POLL_MS;
-  const parsed = raw != null ? Number(raw) : NaN;
-  const FLOOR_MS = 100;
-  const CEILING_MS = 30_000;
-  return Number.isFinite(parsed) && parsed >= FLOOR_MS && parsed <= CEILING_MS
-    ? parsed
-    : 5000;
-})();
-const initialPpid = process.ppid;
-setInterval(() => {
-  // ppid === 1 means init/launchd has adopted us — original parent died.
-  if (process.ppid === 1 && initialPpid !== 1) {
-    console.error("flair-mcp: parent process died (re-parented to init); exiting cleanly.");
+  // Clamp the poll interval to a safe range. `process.env.FOO ?? 5000` is NOT
+  // safe on its own: `??` only falls through on null/undefined, so an empty-string
+  // override (`FLAIR_MCP_PARENT_POLL_MS=`) yields `Number("") === 0` and creates
+  // a tight CPU-busy loop. Validate explicitly. (Sherlock review on #315.)
+  const PARENT_POLL_INTERVAL_MS = (() => {
+    const raw = process.env.FLAIR_MCP_PARENT_POLL_MS;
+    const parsed = raw != null ? Number(raw) : NaN;
+    const FLOOR_MS = 100;
+    const CEILING_MS = 30_000;
+    return Number.isFinite(parsed) && parsed >= FLOOR_MS && parsed <= CEILING_MS
+      ? parsed
+      : 5000;
+  })();
+  const initialPpid = process.ppid;
+  setInterval(() => {
+    // ppid === 1 means init/launchd has adopted us — original parent died.
+    if (process.ppid === 1 && initialPpid !== 1) {
+      console.error("flair-mcp: parent process died (re-parented to init); exiting cleanly.");
+      process.exit(0);
+    }
+  }, PARENT_POLL_INTERVAL_MS).unref();
+
+  // Also handle stdin EOF — MCP host closing the pipe means session ended.
+  // (StdioServerTransport handles this internally for the MCP protocol, but
+  // belt-and-suspenders: if stdin closes we exit, full stop.)
+  process.stdin.on("close", () => {
+    console.error("flair-mcp: stdin closed; exiting cleanly.");
     process.exit(0);
+  });
+  process.stdin.on("end", () => {
+    console.error("flair-mcp: stdin EOF; exiting cleanly.");
+    process.exit(0);
+  });
+
+  // ─── Client setup ────────────────────────────────────────────────────────────
+
+  const agentId = process.env.FLAIR_AGENT_ID;
+  if (!agentId) {
+    console.error("FLAIR_AGENT_ID is required. Set it in your .mcp.json env or shell.");
+    process.exit(1);
   }
-}, PARENT_POLL_INTERVAL_MS).unref();
 
-// Also handle stdin EOF — MCP host closing the pipe means session ended.
-// (StdioServerTransport handles this internally for the MCP protocol, but
-// belt-and-suspenders: if stdin closes we exit, full stop.)
-process.stdin.on("close", () => {
-  console.error("flair-mcp: stdin closed; exiting cleanly.");
-  process.exit(0);
-});
-process.stdin.on("end", () => {
-  console.error("flair-mcp: stdin EOF; exiting cleanly.");
-  process.exit(0);
-});
+  const flair = new FlairClient({
+    agentId,
+    url: process.env.FLAIR_URL,
+    keyPath: process.env.FLAIR_KEY_PATH,
+  });
 
-// ─── Client setup ────────────────────────────────────────────────────────────
+  // ─── MCP Server ──────────────────────────────────────────────────────────────
 
-const agentId = process.env.FLAIR_AGENT_ID;
-if (!agentId) {
-  console.error("FLAIR_AGENT_ID is required. Set it in your .mcp.json env or shell.");
-  process.exit(1);
-}
+  const server = new McpServer({
+    name: "flair",
+    version: "0.1.0",
+  });
 
-const flair = new FlairClient({
-  agentId,
-  url: process.env.FLAIR_URL,
-  keyPath: process.env.FLAIR_KEY_PATH,
-});
+  // ─── Tools ───────────────────────────────────────────────────────────────────
 
-// ─── MCP Server ──────────────────────────────────────────────────────────────
-
-const server = new McpServer({
-  name: "flair",
-  version: "0.1.0",
-});
-
-// ─── Tools ───────────────────────────────────────────────────────────────────
-
-server.tool(
+  server.tool(
   "memory_search",
   "Search memories by meaning. Understands temporal queries like 'what happened today'.",
   {
@@ -386,7 +407,29 @@ server.tool(
   },
 );
 
-// ─── Start ───────────────────────────────────────────────────────────────────
+  // ─── Start ───────────────────────────────────────────────────────────────────
 
-const transport = new StdioServerTransport();
-await server.connect(transport);
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+}
+
+// ─── Entry point dispatch ──────────────────────────────────────────────────────
+//
+// Run directly when this module is the entry point — covers `bun src/index.ts`
+// and `node dist/index.js`. The packaged bin goes through mcp-shim.cjs → runMcp()
+// after its Node-version check, so import.meta.main is false there; without this
+// the server would never start when invoked through the shim. (Matches the
+// session-start-hook + CLI shim entry-point pattern.)
+const importMeta = import.meta as ImportMeta & { main?: boolean };
+const isMain =
+  importMeta.main === true ||
+  (typeof process !== "undefined" &&
+    process.argv[1] != null &&
+    import.meta.url === `file://${process.argv[1]}`);
+
+if (isMain) {
+  void runMcp().catch((err) => {
+    console.error(err && (err as Error).stack ? (err as Error).stack : err);
+    process.exit(1);
+  });
+}

--- a/packages/flair-mcp/src/mcp-shim.cts
+++ b/packages/flair-mcp/src/mcp-shim.cts
@@ -1,0 +1,71 @@
+#!/usr/bin/env node
+/**
+ * mcp-shim.cts — Node-version PREFLIGHT for the Flair MCP server.
+ *
+ * THIS IS THE BIN ENTRY (`package.json` "bin": { "flair-mcp": "dist/mcp-shim.cjs" }).
+ *
+ * Why a separate CommonJS file instead of a guard inside index.ts:
+ *   The real MCP server (dist/index.js) is an ES module. In ESM, every top-level
+ *   `import` is HOISTED and the whole module graph is LINKED + EVALUATED before
+ *   the first statement in the file body runs. flair-mcp's deps (@modelcontext-
+ *   protocol/sdk, @tpsdev-ai/flair-client and its transitive deps) require a
+ *   modern engine, so on an older Node the import graph fails to load — and a
+ *   Node-version check placed even at the very top of index.ts never executes:
+ *   the import graph crashes first. That is exactly the silent-failure bug — a
+ *   user wiring `npx -y @tpsdev-ai/flair-mcp` on an old Node gets zero output and
+ *   a dead MCP server, with no actionable signal (the same exposure flair's CLI
+ *   had before #524).
+ *
+ *   CommonJS evaluates top-to-bottom and `require()`/`import()` are evaluated
+ *   lazily — so the version check below runs and prints BEFORE anything tries to
+ *   load the ESM server or any modern dependency. Because every Node since v0.x
+ *   parses and runs CommonJS, this shim is guaranteed to run and print on the
+ *   oldest Node a user could plausibly have.
+ *
+ *   The check itself deliberately uses ONLY ancient-safe syntax — `var`, plain
+ *   functions, string `.split`/`parseInt`, `console.error`, `process.exit`. No
+ *   top-level await, no optional chaining, no template literals reaching
+ *   modern-only APIs — so the guard can never become the thing that fails to
+ *   parse.
+ */
+
+// ── Node-version preflight (must stay parse-safe + runtime-safe on old Node) ──
+var MIN_NODE_MAJOR = 22;
+
+function flairMcpCurrentNodeMajor() {
+  // process.versions.node is e.g. "18.20.4"; take the leading integer.
+  var raw = (process && process.versions && process.versions.node) || "0";
+  return parseInt(String(raw).split(".")[0], 10) || 0;
+}
+
+var flairMcpNodeMajor = flairMcpCurrentNodeMajor();
+
+if (flairMcpNodeMajor < MIN_NODE_MAJOR) {
+  // Plain string concatenation — no template literals, no chalk, nothing that
+  // could itself trip on an old engine.
+  console.error("");
+  console.error("  flair-mcp requires Node.js >= " + MIN_NODE_MAJOR + ".");
+  console.error("  You are running Node.js " + (process.versions && process.versions.node ? process.versions.node : "(unknown)") + ".");
+  console.error("");
+  console.error("  Please upgrade Node and try again:");
+  console.error("    https://nodejs.org/  (or use nvm / fnm / volta)");
+  console.error("");
+  process.exit(1);
+}
+
+// Node is new enough — hand off to the real ESM MCP server. Dynamic import()
+// from CommonJS is the supported ESM-from-CJS bridge. We only reach this line on
+// a supported Node, so the import() expression is never evaluated on an engine
+// that can't load the ESM graph.
+import("./index.js")
+  .then(function (mod) {
+    if (mod && typeof mod.runMcp === "function") {
+      return mod.runMcp();
+    }
+    // Older builds auto-ran on import via import.meta.main; nothing to call.
+    return undefined;
+  })
+  .catch(function (err) {
+    console.error(err && err.stack ? err.stack : err);
+    process.exit(1);
+  });

--- a/packages/flair-mcp/test/mcp-node-preflight.test.ts
+++ b/packages/flair-mcp/test/mcp-node-preflight.test.ts
@@ -1,0 +1,99 @@
+/**
+ * mcp-node-preflight.test.ts — the Node-version preflight shim must FAIL LOUD,
+ * not silently, on an unsupported Node.
+ *
+ * Background: the flair-mcp bin is `dist/mcp-shim.cjs`, a CommonJS preflight
+ * that checks process.versions.node before dynamically importing the ESM MCP
+ * server (dist/index.js). On an old Node the ESM import graph crashes during
+ * linking — BEFORE any in-module guard could run — so a user wiring
+ * `npx -y @tpsdev-ai/flair-mcp` on an old Node gets zero output and a dead
+ * server (the same exposure flair's CLI had before #524). The CJS shim runs
+ * top-to-bottom and bails with an actionable message before touching the ESM
+ * graph.
+ *
+ * These tests spawn `node` against the BUILT shim (the thing users actually run)
+ * and:
+ *   1. simulate an old Node by overriding process.versions.node, asserting the
+ *      shim prints the upgrade guidance and exits non-zero — and never loads the
+ *      ESM server (no flair-mcp runtime output);
+ *   2. confirm the shim is a NO-OP on the supported Node the suite runs on: it
+ *      hands off to runMcp(), which (with no FLAIR_AGENT_ID) reaches the server's
+ *      own env-check — proving the preflight passed and the real entry ran;
+ *   3. confirm the emitted shim is parse-safe (it loads & runs under plain node).
+ */
+
+import { describe, test, expect, beforeAll } from "bun:test";
+import { spawnSync, execSync } from "node:child_process";
+import { existsSync, mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+const PKG = join(__dirname, "..");
+const SHIM = join(PKG, "dist", "mcp-shim.cjs");
+
+// Build flair-mcp (incl. the shim) once if it isn't already present, so the test
+// is self-contained whether or not a prior `npm run build` ran.
+beforeAll(() => {
+  if (!existsSync(SHIM)) {
+    execSync("npm run build", { cwd: PKG, stdio: "ignore" });
+  }
+});
+
+describe("Node-version preflight shim (dist/mcp-shim.cjs)", () => {
+  test("the built shim exists (it is the published bin entry)", () => {
+    expect(existsSync(SHIM)).toBe(true);
+  });
+
+  test("fails LOUD + non-zero on an unsupported (old) Node, without loading the ESM server", () => {
+    // Harness: override process.versions.node to an old value, then require the
+    // shim. If the shim tried to import the ESM index.js, we'd see server output
+    // or an import crash; we assert it never does — only the preflight message
+    // appears.
+    const dir = mkdtempSync(join(tmpdir(), "flair-mcp-preflight-"));
+    const harness = join(dir, "harness.cjs");
+    writeFileSync(
+      harness,
+      [
+        "Object.defineProperty(process.versions, 'node', { value: '18.20.4', configurable: true });",
+        `require(${JSON.stringify(SHIM)});`,
+      ].join("\n"),
+    );
+    try {
+      const r = spawnSync("node", [harness], { encoding: "utf8", timeout: 15_000 });
+      const out = (r.stderr ?? "") + (r.stdout ?? "");
+      expect(r.status).not.toBe(0);
+      // Actionable, specific message naming the running version + upgrade path.
+      expect(out).toMatch(/flair-mcp requires Node\.js >= 22/);
+      expect(out).toMatch(/18\.20\.4/);
+      expect(out.toLowerCase()).toMatch(/upgrade|nodejs\.org/);
+      // Must NOT have reached the real server (no env-check message, no SDK output).
+      expect(out).not.toMatch(/FLAIR_AGENT_ID is required/);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("is a NO-OP on the supported Node the suite runs on (hands off to runMcp)", () => {
+    // On a supported Node the preflight passes and the shim hands off to
+    // runMcp(). With FLAIR_AGENT_ID unset, runMcp() reaches the server's own
+    // env-check and exits 1 with the FLAIR_AGENT_ID message — which is proof the
+    // preflight did NOT fire and the real entry point actually ran. Closing
+    // stdin (no input) keeps the run deterministic and offline.
+    const env = { ...process.env };
+    delete env.FLAIR_AGENT_ID;
+    const r = spawnSync("node", [SHIM], { encoding: "utf8", timeout: 20_000, input: "", env });
+    const out = (r.stdout ?? "") + (r.stderr ?? "");
+    // The preflight error must NOT fire on a supported Node.
+    expect(out).not.toMatch(/flair-mcp requires Node\.js/);
+    // The real server entry ran (its own env-check is the deterministic landmark).
+    expect(out).toMatch(/FLAIR_AGENT_ID is required/);
+    expect(r.status).toBe(1);
+  });
+
+  test("the emitted shim is parse-safe under plain node (it is CommonJS, not ESM)", () => {
+    // `node --check` parses without executing — proves the shim can be parsed by
+    // the Node engine. (CommonJS so it parses on every Node since v0.x.)
+    const r = spawnSync("node", ["--check", SHIM], { encoding: "utf8", timeout: 10_000 });
+    expect(r.status).toBe(0);
+  });
+});


### PR DESCRIPTION
## Loud Node-version preflight for `flair-mcp` (mirror of #524 for the MCP server) — ops-fomi

The `flair-mcp` bin (`dist/index.js`) is an **ES module**: top-level imports are hoisted and the whole module graph is linked + evaluated *before* the file body runs. flair-mcp's deps (`@modelcontextprotocol/sdk`, `@tpsdev-ai/flair-client` and its transitive deps) need a modern engine, so on an old Node the import graph crashes during linking — **before** any in-file version guard could run.

Result: a user wiring `npx -y @tpsdev-ai/flair-mcp` on an unsupported Node gets **zero output and a dead MCP server**, with no actionable signal. This is the exact same exposure flair's CLI had, fixed in #524 — now mirrored for the MCP server.

### The fix

- **The `flair-mcp` bin now points at a CommonJS preflight shim** (`dist/mcp-shim.cjs`, compiled from `src/mcp-shim.cts`). CJS evaluates top-to-bottom with lazy `import()`, so the Node-version check runs and prints **before** anything loads the ESM server or any modern dep.
  - Unsupported Node → actionable message (`flair-mcp requires Node.js >= 22. You are running Node.js X. ... https://nodejs.org/`) + `process.exit(1)`.
  - Supported Node → transparent no-op that dynamically imports the server and hands off to `runMcp()`.
- **The shim uses only ancient-safe syntax** (`var`, plain functions, string ops, `console.error`, `process.exit`) so the guard itself can never fail to parse on the oldest Node a user could have. `node --check` confirms parse-safety.
- **`src/index.ts` now exports `runMcp()`** — all runtime side effects (the `FLAIR_AGENT_ID` check, `FlairClient` construction, the parent-exit watcher, tool registration, the stdio connect) moved inside it, so merely importing the module (from the shim before the version check, or from a test) is inert until `runMcp()` is called. Direct invocation (`node dist/index.js`, `bun src/index.ts`) still works via an `import.meta.main` entry-point guard.
- **`engines.node` bumped `>=18` → `>=22`** to match flair's CLI and the deps' real floor, so `npm install` also warns on an unsupported Node. Postinstall now `chmod +x` the shim.

### Verification

- **Old Node (simulated `process.versions.node = 18.20.4`):** prints the upgrade message naming the running version + exits 1, and **never reaches the ESM import** (no server output, no SDK crash).
- **Supported Node (the one this suite runs on):** transparent no-op — the shim hands off to `runMcp()`, which (with no `FLAIR_AGENT_ID`) reaches the server's own env-check, proving the preflight passed and the real entry ran. With a valid env the full server launches on stdio and stays alive.
- **Parse-safety:** `node --check dist/mcp-shim.cjs` passes (it's emitted as CommonJS, parseable on every Node).
- New unit test `test/mcp-node-preflight.test.ts` codifies all three.
- **Suite:** full flair-mcp suite green — **34 pass, 0 fail** (30 baseline + 4 new). Typecheck + build clean.

### Files

- `packages/flair-mcp/src/mcp-shim.cts` (new) — the CommonJS preflight bin entry
- `packages/flair-mcp/src/index.ts` — export `runMcp()` + entry-point guard
- `packages/flair-mcp/package.json` — `bin.flair-mcp` → shim, `engines.node` `>=18` → `>=22`, postinstall chmod
- `packages/flair-mcp/test/mcp-node-preflight.test.ts` (new) — preflight unit test
- `CHANGELOG.md` — Unreleased entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)