### PR TITLE
ci: realistic clean-VM gate — non-root sudo-install + embed→search verify (ops-cd37)

### DIFF
--- a/.github/workflows/docker-test.yml
+++ b/.github/workflows/docker-test.yml
@@ -44,8 +44,8 @@ jobs:
           push: false
           load: true
           tags: flair-test:ci
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=gha,scope=from-scratch
+          cache-to: type=gha,mode=max,scope=from-scratch
 
       - name: Run from-scratch validation
         run: docker run --rm flair-test:ci
@@ -53,3 +53,44 @@ jobs:
       - name: Show container logs on failure
         if: failure()
         run: docker run --rm flair-test:ci || true
+
+  # ── Realistic clean-VM gate (ops-cd37) ──────────────────────────────────────
+  # The from-scratch job above runs as ROOT and sets FLAIR_MODELS_DIR (a writable
+  # override), so its "clean install" is NOT the user's environment — which is
+  # exactly why it never caught the #538 embeddings showstopper (a fresh
+  # `sudo npm install -g @tpsdev-ai/flair` left semantic search dead: the model
+  # targeted the root-owned package dir, Harper-as-user couldn't write it).
+  #
+  # This gate reproduces the REAL user env: a root/global `npm install -g` of the
+  # HEAD tarball, then `flair init` + Harper run as a NON-ROOT user with NO
+  # FLAIR_MODELS_DIR override. The assertion is a genuine embed→paraphrase
+  # semantic round-trip (#533 / `flair doctor`), not keyword-match — so if the
+  # #538 fix regresses, semantic search goes DEGRADED and this gate FAILS.
+  clean-vm-gate:
+    name: Realistic clean-VM gate (non-root sudo-install)
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3
+
+      - name: Build clean-VM gate image
+        uses: docker/build-push-action@14487ce63c7a62a4a324b0bfb37086795e31c6c1 # v6
+        with:
+          context: .
+          file: docker/Dockerfile.clean-vm
+          push: false
+          load: true
+          tags: flair-clean-vm:ci
+          cache-from: type=gha,scope=clean-vm
+          cache-to: type=gha,mode=max,scope=clean-vm
+
+      - name: Run clean-VM gate (non-root sudo-install + embed→search verify)
+        run: docker run --rm flair-clean-vm:ci
+
+      - name: Show container logs on failure
+        if: failure()
+        run: docker run --rm flair-clean-vm:ci || true

--- a/.github/workflows/docker-test.yml
+++ b/.github/workflows/docker-test.yml
@@ -77,6 +77,30 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3
 
+      # Stage the embeddings model in the build context BEFORE the build so the
+      # Dockerfile COPYs it in (no live HuggingFace curl during `docker build`).
+      # HF intermittently 429s/503s the model download — a bare in-build curl
+      # flaked this gate and blocked merges (HF 503 → curl exit 22; the #463/#465
+      # 429/503 issue). actions/cache persists the ~80MB .gguf across runs, keyed
+      # on the model filename, so we download it at most once.
+      - name: Cache embeddings model
+        id: model-cache
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          path: models/nomic-embed-text-v1.5.Q4_K_M.gguf
+          key: nomic-embed-text-v1.5-Q4_K_M-gguf
+
+      - name: Download embeddings model into build context
+        if: steps.model-cache.outputs.cache-hit != 'true'
+        run: |
+          mkdir -p models
+          # --retry-all-errors so 429/4xx/5xx (incl. the HF 503 that flaked the
+          # gate) are retried, not just connection-level failures.
+          curl -fSL --retry 5 --retry-delay 10 --retry-all-errors --connect-timeout 30 \
+            "https://huggingface.co/nomic-ai/nomic-embed-text-v1.5-GGUF/resolve/main/nomic-embed-text-v1.5.Q4_K_M.gguf" \
+            -o models/nomic-embed-text-v1.5.Q4_K_M.gguf
+          echo "Model downloaded ($(du -sh models/*.gguf | cut -f1))"
+
       - name: Build clean-VM gate image
         uses: docker/build-push-action@14487ce63c7a62a4a324b0bfb37086795e31c6c1 # v6
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## [Unreleased]
 
+### 🧪 CI clean-VM gate — exercise the REALISTIC user env so the #538 embeddings showstopper can't silently regress (ops-cd37)
+
+The #538 fix (above) addressed a fresh `sudo npm install -g @tpsdev-ai/flair` leaving semantic search **dead** (model targeted the root-owned package dir; Harper-as-user couldn't write it). The uncomfortable part: **CI never caught it.** The existing `docker/Dockerfile.test` from-scratch job runs as **root** (no perms mismatch) *and* sets `FLAIR_MODELS_DIR=/opt/flair-models` (a writable override), so its "clean install" is not the user's environment — root + a pre-solved model path made the bug structurally invisible. The tarball smoke test (`test.yml`) also installs as root and its write/search round-trip uses a **keyword-matching** marker, so it passes even with embeddings dead.
+
+This adds a gate that reproduces what a real user actually has:
+
+- **New `docker/Dockerfile.clean-vm` + `docker/test-clean-vm.sh`.** Builds the **HEAD tarball** (`npm pack`, the exact published file set), installs it **globally as root** (`npm install -g` → root-owned `/usr/lib/node_modules` package dir), creates a **non-root `flairuser`**, and runs `flair init` + the daemon **as that user with NO `FLAIR_MODELS_DIR` override** — the real default model-path resolution (`<ROOTPATH=~/.flair/data>/models`, the #538 default). The embeddings model is pre-staged at that exact user-owned path (to avoid an ~80MB live download stalling the seed loop); if #538 regresses and the model resolves back to the package dir, that staged copy is in the wrong place → `EACCES` on download → DEGRADED.
+- **The assertion is genuine semantic recall, not keyword match.** The gate asserts `flair init` reports `Semantic search operational` (the #533 in-init check, which prints `DEGRADED` but does *not* exit non-zero), then runs `flair doctor` as the hard gate — `doctor` performs the same embed→**paraphrase** round-trip (`verifySemanticSearch`: query "a cat hunting a mouse in the evening" vs. content "feline predator stalked its rodent quarry at dusk", **zero keyword overlap**, real semantic score > 0.05) and `process.exit(1)` on degraded. Keyword-only fallback cannot satisfy it. Embeddings dead → the gate FAILS.
+- **Wired into `.github/workflows/docker-test.yml`** as a new `clean-vm-gate` job that runs on PRs, alongside (not replacing) the existing from-scratch job — the from-scratch coverage stays, the gate adds the realistic non-root / no-override variant. Each Docker build uses a distinct GHA cache scope. Validated locally: builds + runs green on current main (post-#538) with a real semantic score; the assertion is semantic, so it would catch a regression that the old root-+-override CI could not.
+
 ### 🩺 Fix dead semantic search on a sudo/root-owned global install — model dir defaults to `~/.flair` (ops-am0v)
 
 A fresh `sudo npm install -g @tpsdev-ai/flair` left semantic search **dead**: the package landed root-owned (e.g. `/usr/lib/node_modules`), Harper runs as the *user*, so the embeddings model download hit `EACCES` and recall silently fell back to keyword-only. The `flair doctor` / `flair init` round-trip check (#533) caught it loud, but recall was still broken — this fixes the underlying cause.

--- a/docker/Dockerfile.clean-vm
+++ b/docker/Dockerfile.clean-vm
@@ -61,9 +61,11 @@ RUN npm pack && mv tpsdev-ai-flair-*.tgz /flair-head.tgz && \
 # the regression we are guarding.
 FROM node:24-slim AS cleanvm
 
-# Tools: curl for the model fetch; sudo not needed (we install as root, the
-# container's default user, then drop to flairuser via `su`/gosu-free `runuser`).
-RUN apt-get update && apt-get install -y --no-install-recommends curl ca-certificates && \
+# Tools: ca-certificates for npm/HTTPS. The embeddings model is NOT curled here
+# (see below) — it is staged via COPY from the build context, so this image never
+# depends on a live HuggingFace download during `docker build`. (That live curl
+# is what flaked the gate on an HF 503 — the #463/#465 429/503 issue.)
+RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates && \
     apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # Create the realistic NON-ROOT user.
@@ -87,15 +89,28 @@ RUN GLOBAL_FLAIR_DIR="$(dirname "$(dirname "$(readlink -f "$(command -v flair)")
     npm install --no-save @node-llama-cpp/linux-x64@3 && \
     echo "Installed linux-x64 native addon into the global package."
 
-# Pre-stage the model in flairuser's home at the #538 default path. Done AS
-# flairuser so ownership is correct; NO FLAIR_MODELS_DIR is set anywhere.
+# Pre-stage the model in flairuser's home at the #538 default path, owned by
+# flairuser, with NO FLAIR_MODELS_DIR set anywhere.
+#
+# The model is COPIED from the build context — NOT curled from HuggingFace at
+# build time. The clean-vm-gate workflow job downloads the model ONCE (resilient
+# retry + actions/cache keyed on the model name) into the repo-root `models/`
+# dir before the build, so `docker build` never makes a live HF request. This
+# removes the build's dependency on a flaky HF endpoint (the gate previously
+# failed on an HF 503 mid-build — the #463/#465 429/503 issue).
+#
+# COPY runs as root (the active stage user before `USER flairuser` below). Its
+# --chown lands the file at the exact #538 default path
+# (<ROOTPATH=~/.flair/data>/models) owned by the non-root flairuser, and COPY
+# auto-creates the parent dirs with the same ownership. Identical end-state to
+# the old in-build curl, minus the live HF dependency.
+COPY --chown=flairuser:flairuser models/nomic-embed-text-v1.5.Q4_K_M.gguf \
+     /home/flairuser/.flair/data/models/nomic-embed-text-v1.5.Q4_K_M.gguf
+RUN echo "Model staged at the #538 default path (user-owned): $(du -sh /home/flairuser/.flair/data/models/*.gguf | cut -f1)" && \
+    ls -la /home/flairuser/.flair/data/models/
+
 USER flairuser
 WORKDIR /home/flairuser
-RUN mkdir -p /home/flairuser/.flair/data/models && \
-    curl -fSL \
-      "https://huggingface.co/nomic-ai/nomic-embed-text-v1.5-GGUF/resolve/main/nomic-embed-text-v1.5.Q4_K_M.gguf" \
-      -o /home/flairuser/.flair/data/models/nomic-embed-text-v1.5.Q4_K_M.gguf && \
-    echo "Model staged at the #538 default path (user-owned): $(du -sh /home/flairuser/.flair/data/models/*.gguf | cut -f1)"
 
 # The test runs as flairuser. Explicitly DO NOT inherit any FLAIR_MODELS_DIR.
 COPY --chown=flairuser:flairuser docker/test-clean-vm.sh /home/flairuser/test-clean-vm.sh

--- a/docker/Dockerfile.clean-vm
+++ b/docker/Dockerfile.clean-vm
@@ -1,0 +1,106 @@
+# Dockerfile.clean-vm — the REALISTIC user-environment gate (ops-cd37)
+#
+# Extends the from-scratch CI to the environment a real user actually has:
+#   flair installed via a ROOT/global `npm install -g` (root-owned package dir),
+#   then `flair init` + Harper run as a NON-ROOT user, with NO FLAIR_MODELS_DIR
+#   override (the real default model-path resolution).
+#
+# This is the exact shape of the showstopper fixed in #538. The existing
+# Dockerfile.test runs as ROOT (no perms mismatch) AND sets
+# FLAIR_MODELS_DIR=/opt/flair-models (a writable override), so it can never
+# reproduce — or catch a regression of — the bug. This Dockerfile can.
+#
+# Build:  docker build -f docker/Dockerfile.clean-vm -t flair-clean-vm .
+# Run:    docker run --rm flair-clean-vm
+#
+# Tests the LOCAL HEAD build (the tarball packed from this branch), not the
+# published npm version.
+
+# ── Builder: build + pack the HEAD tarball ──────────────────────────────────
+FROM node:24-slim AS builder
+
+WORKDIR /app
+
+# Install bun (pinned to match bun.lock version — bump together).
+RUN apt-get update && apt-get install -y --no-install-recommends curl unzip ca-certificates && \
+    curl -fsSL https://bun.sh/install | bash -s "bun-v1.3.10" && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
+
+ENV PATH="/root/.bun/bin:$PATH"
+ENV BUN_INSTALL="/root/.bun"
+
+# Copy repo (include workspace packages so bun lockfile is consistent).
+COPY package.json bun.lock* tsconfig.json tsconfig.cli.json config.yaml ./
+COPY src/ ./src/
+COPY resources/ ./resources/
+COPY schemas/ ./schemas/
+COPY packages/ ./packages/
+
+RUN bun install --frozen-lockfile
+RUN bun run build && bun run build:cli
+
+# Pack the exact published file set (dist/, schemas/, templates/, config.yaml…).
+# `npm pack` honors the package.json "files" array — this is byte-for-byte what
+# a user installs from the registry, so the gate exercises the published surface
+# (NOT the repo's resources/ TS source the dev Dockerfile.test relies on).
+RUN npm pack && mv tpsdev-ai-flair-*.tgz /flair-head.tgz && \
+    echo "Packed HEAD tarball: $(du -sh /flair-head.tgz | cut -f1)"
+
+# ── Pre-stage the embeddings model in the NON-ROOT user's home ───────────────
+# Why pre-stage: a live ~80MB download during `flair init` can outlast the
+# Harper seed retry loop (the same reason the dev Dockerfile.test pre-downloads).
+#
+# Where it goes is the whole point of the gate: the model is placed at the EXACT
+# path the #538 default resolves to for a non-root install —
+# <ROOTPATH=~/.flair/data>/models — owned by the non-root user. We do NOT set
+# FLAIR_MODELS_DIR; resolution is the real default.
+#
+# If #538 regresses (model resolves back to the root-owned package dir), this
+# user-home copy is in the WRONG place → cache miss → download attempt into the
+# root-owned dir → EACCES → semantic search DEGRADED → the gate FAILS. That is
+# the regression we are guarding.
+FROM node:24-slim AS cleanvm
+
+# Tools: curl for the model fetch; sudo not needed (we install as root, the
+# container's default user, then drop to flairuser via `su`/gosu-free `runuser`).
+RUN apt-get update && apt-get install -y --no-install-recommends curl ca-certificates && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
+
+# Create the realistic NON-ROOT user.
+RUN useradd --create-home --shell /bin/bash flairuser
+
+# ── Install flair GLOBALLY AS ROOT (the `sudo npm install -g` a user runs) ───
+# The package lands root-owned under /usr/lib/node_modules — Harper running as
+# flairuser cannot write into it. This is the perms mismatch the gate requires.
+COPY --from=builder /flair-head.tgz /flair-head.tgz
+RUN npm install -g /flair-head.tgz && \
+    echo "Installed flair globally (root-owned):" && \
+    ls -ld "$(dirname "$(readlink -f "$(command -v flair)")")/.."
+
+# Native embedding binary: flair declares mac-arm64 as the optional dep present
+# on dev machines; on linux x64 we ensure the matching native variant is
+# resolvable next to the globally-installed package so Harper's embeddings
+# component can load it. (Same need as the existing tarball smoke test.)
+RUN GLOBAL_FLAIR_DIR="$(dirname "$(dirname "$(readlink -f "$(command -v flair)")")")" && \
+    echo "Global flair package dir: $GLOBAL_FLAIR_DIR" && \
+    cd "$GLOBAL_FLAIR_DIR" && \
+    npm install --no-save @node-llama-cpp/linux-x64@3 && \
+    echo "Installed linux-x64 native addon into the global package."
+
+# Pre-stage the model in flairuser's home at the #538 default path. Done AS
+# flairuser so ownership is correct; NO FLAIR_MODELS_DIR is set anywhere.
+USER flairuser
+WORKDIR /home/flairuser
+RUN mkdir -p /home/flairuser/.flair/data/models && \
+    curl -fSL \
+      "https://huggingface.co/nomic-ai/nomic-embed-text-v1.5-GGUF/resolve/main/nomic-embed-text-v1.5.Q4_K_M.gguf" \
+      -o /home/flairuser/.flair/data/models/nomic-embed-text-v1.5.Q4_K_M.gguf && \
+    echo "Model staged at the #538 default path (user-owned): $(du -sh /home/flairuser/.flair/data/models/*.gguf | cut -f1)"
+
+# The test runs as flairuser. Explicitly DO NOT inherit any FLAIR_MODELS_DIR.
+COPY --chown=flairuser:flairuser docker/test-clean-vm.sh /home/flairuser/test-clean-vm.sh
+USER root
+RUN chmod +x /home/flairuser/test-clean-vm.sh
+USER flairuser
+
+CMD ["/home/flairuser/test-clean-vm.sh"]

--- a/docker/Dockerfile.test
+++ b/docker/Dockerfile.test
@@ -63,9 +63,14 @@ RUN bun add @node-llama-cpp/linux-x64@3 --no-save 2>/dev/null || \
 # only downloads once — subsequent builds reuse the cached layer.
 # Required because Harper blocks on model download during schema init,
 # causing the seed retry loop to time out.
+#
+# HuggingFace intermittently 429s/503s the model download; retry with backoff
+# (--retry-all-errors so 4xx/5xx are retried, not just connection failures). A
+# bare curl here flaked the from-scratch build on an HF 503 — same root cause
+# the clean-vm gate hit (#463/#465 429/503 issue).
 ENV FLAIR_MODELS_DIR=/opt/flair-models
 RUN mkdir -p /opt/flair-models && \
-    curl -fSL \
+    curl -fSL --retry 5 --retry-delay 10 --retry-all-errors --connect-timeout 30 \
       "https://huggingface.co/nomic-ai/nomic-embed-text-v1.5-GGUF/resolve/main/nomic-embed-text-v1.5.Q4_K_M.gguf" \
       -o /opt/flair-models/nomic-embed-text-v1.5.Q4_K_M.gguf && \
     echo "Embeddings model cached ($(du -sh /opt/flair-models/*.gguf | cut -f1))"

--- a/docker/test-clean-vm.sh
+++ b/docker/test-clean-vm.sh
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+# test-clean-vm.sh — the REALISTIC user-environment gate (ops-cd37).
+#
+# Reproduces what a real user gets and what CI's existing from-scratch test
+# does NOT: flair installed via a ROOT/global `npm install -g` (root-owned
+# package dir), then `flair init` + Harper run as a NON-ROOT user, with NO
+# FLAIR_MODELS_DIR override (the real default model-path resolution).
+#
+# This is the exact shape of the showstopper fixed in #538: a fresh
+#   sudo npm install -g @tpsdev-ai/flair
+# left semantic search dead because the embeddings model targeted the
+# root-owned package dir and Harper-as-user couldn't write it (EACCES) →
+# recall silently fell back to keyword-only while `flair init` reported success.
+#
+# The old Dockerfile.test never caught it because it runs as ROOT (no perms
+# mismatch) AND sets FLAIR_MODELS_DIR=/opt/flair-models (a writable override).
+# That isn't the user's environment. This script IS.
+#
+# Runs as the non-root flairuser inside the container (see Dockerfile.clean-vm).
+# Exit 0 on success, non-zero on any failure.
+
+set -euo pipefail
+
+# flair was installed globally as root → `flair` is on PATH, package dir is
+# root-owned. We invoke the global binary, NOT a repo-relative dist/cli.js,
+# so we exercise the published file set exactly as a real user gets it.
+ADMIN_PASS="cleanvm-admin"
+PORT="9926"
+AGENT_ID="cleanvmbot"
+
+# Sanity: we must NOT be root (the whole point of this gate).
+if [ "$(id -u)" = "0" ]; then
+  echo "ERROR: test-clean-vm.sh must run as a non-root user (running as uid 0)."
+  echo "       The realistic gate requires a non-root user against a root-owned install."
+  exit 1
+fi
+
+# Sanity: NO model-path override may be set — we test the real default.
+if [ -n "${FLAIR_MODELS_DIR:-}" ]; then
+  echo "ERROR: FLAIR_MODELS_DIR is set ($FLAIR_MODELS_DIR) — this gate must test"
+  echo "       the DEFAULT model-path resolution, not a writable override."
+  exit 1
+fi
+
+# Dump diagnostics on any failure (Harper + HDB logs) for CI debugging.
+trap '
+  echo ""
+  echo "=== Harper stdout/stderr log ==="
+  cat "$HOME/.flair/data/harper.log" 2>/dev/null || echo "(no flair log found)"
+  echo "=== HDB log ==="
+  find "$HOME" /tmp -name "hdb.log" 2>/dev/null | head -3 | while read -r f; do echo "--- $f ---"; tail -100 "$f"; done
+  echo "=== whoami / perms ==="
+  echo "uid=$(id -u) user=$(whoami) HOME=$HOME"
+  echo "global flair: $(command -v flair) → $(readlink -f "$(command -v flair)" 2>/dev/null)"
+  echo "package dir owner: $(ls -ld "$(dirname "$(readlink -f "$(command -v flair)")")/.." 2>/dev/null)"
+  echo "user models dir: $(ls -la "$HOME/.flair/data/models" 2>&1 | head)"
+  echo "=== end ==="
+' ERR
+
+echo "=============================================="
+echo " Clean-VM gate: non-root sudo-install + embed→search verify"
+echo "=============================================="
+echo "user:  $(whoami) (uid $(id -u))"
+echo "HOME:  $HOME"
+echo "flair: $(command -v flair)"
+echo "FLAIR_MODELS_DIR: ${FLAIR_MODELS_DIR:-<unset> (testing real default)}"
+echo ""
+
+# ── Step 1: flair init as the non-root user ──────────────────────────────────
+# All defaults: data → ~/.flair/data, keys → ~/.flair/keys, model →
+# <ROOTPATH=~/.flair/data>/models (the #538 user-writable default). No
+# FLAIR_MODELS_DIR. `flair init` runs the #533 embed-verification at the end.
+echo "[1/3] flair init --agent-id $AGENT_ID --port $PORT (no model-dir override)"
+INIT_OUTPUT=$(flair init \
+  --agent-id "$AGENT_ID" \
+  --admin-pass "$ADMIN_PASS" \
+  --port "$PORT" \
+  --skip-soul 2>&1) || { echo "$INIT_OUTPUT"; echo "ERROR: flair init exited non-zero"; exit 1; }
+echo "$INIT_OUTPUT"
+echo ""
+
+# ── Step 2: assert init's #533 embed-verification reported OPERATIONAL ────────
+# `flair init` PRINTS "Semantic search DEGRADED" but does NOT exit non-zero on
+# degraded — so the exit code alone would not catch a regression. Assert on the
+# verification line directly: it must say operational, never degraded.
+echo "[2/3] Asserting init's semantic-search verification (#533)..."
+if echo "$INIT_OUTPUT" | grep -qi "Semantic search DEGRADED"; then
+  echo "FAIL: init reported 'Semantic search DEGRADED' — embeddings not loaded."
+  echo "      This is the #538 regression: model targeted a non-writable dir on a"
+  echo "      root-owned install and recall fell back to keyword-only."
+  exit 1
+fi
+if ! echo "$INIT_OUTPUT" | grep -qi "Semantic search operational"; then
+  echo "FAIL: init did not report 'Semantic search operational' — semantic"
+  echo "      verification did not pass (degraded or skipped). Recall-by-meaning"
+  echo "      is not confirmed working on this realistic install."
+  exit 1
+fi
+echo "  ✓ init: Semantic search operational"
+echo ""
+
+# ── Step 3: hard gate — `flair doctor` must exit 0 ───────────────────────────
+# `flair doctor` runs the SAME real embed→paraphrase round-trip
+# (verifySemanticSearch) and `process.exit(1)` if issues > 0. A degraded
+# semantic search is an issue → doctor exits non-zero. This is the
+# belt-and-suspenders hard assertion: a genuine semantic score on a paraphrase
+# query with ZERO keyword overlap. Keyword-only fallback cannot satisfy it.
+echo "[3/3] flair doctor --agent $AGENT_ID --port $PORT (hard semantic gate)"
+DOCTOR_OUTPUT=$(flair doctor --agent "$AGENT_ID" --port "$PORT" 2>&1) || {
+  echo "$DOCTOR_OUTPUT"
+  echo ""
+  echo "FAIL: flair doctor exited non-zero — semantic search is DEGRADED on a"
+  echo "      realistic non-root sudo-install. The embeddings model could not be"
+  echo "      written/loaded (the #538 showstopper class). Recall-by-meaning is dead."
+  exit 1
+}
+echo "$DOCTOR_OUTPUT"
+echo ""
+# Defense in depth: doctor exited 0, but also confirm the semantic line is OK
+# and not a degraded line that somehow slipped past the exit code.
+if echo "$DOCTOR_OUTPUT" | grep -qi "Semantic search DEGRADED"; then
+  echo "FAIL: flair doctor exited 0 but still printed 'Semantic search DEGRADED'."
+  exit 1
+fi
+echo "  ✓ doctor: exit 0, semantic search verified"
+echo ""
+
+echo "=============================================="
+echo "✅ Clean-VM gate PASSED"
+echo "   Realistic non-root sudo-install → flair init → embed→paraphrase"
+echo "   round-trip returns a genuine semantic score. The #538 fix holds."
+echo "=============================================="


### PR DESCRIPTION
## CI clean-VM gate — exercise the realistic user environment (ops-cd37)

#538 fixed a showstopper: a fresh `sudo npm install -g @tpsdev-ai/flair` left semantic search **dead** — the embeddings model targeted the root-owned package dir, Harper runs as the *user*, so the download hit `EACCES` and recall silently fell back to keyword-only while `flair init` reported success.

**The uncomfortable part: CI never caught it.** It couldn't, by construction:

- `docker/Dockerfile.test` runs as **root** (no perms mismatch) **and** sets `FLAIR_MODELS_DIR=/opt/flair-models` (a writable override). Root + a pre-solved model path made the bug structurally invisible — that "clean install" is not the user's environment.
- The tarball smoke test (`test.yml`) also installs as root, and its write/search round-trip asserts a **keyword-matching** marker, so it passes even with embeddings dead.

This PR adds a gate that reproduces what a real user actually has, and asserts genuine *semantic* recall — so a #538-class regression fails CI.

### The gate

- **`docker/Dockerfile.clean-vm`** — builds the **HEAD tarball** (`npm pack`, the exact published `files` set), installs it **globally as root** (`npm install -g` → root-owned `/usr/local/lib/node_modules`), creates a **non-root `flairuser`**, and runs `flair init` + the daemon **as that user with NO `FLAIR_MODELS_DIR` override** — the real default resolution (`<ROOTPATH=~/.flair/data>/models`, the #538 default). The embeddings model is pre-staged at that exact user-owned path so an ~80MB live download doesn't stall the seed loop. If the fix regresses and the model resolves back to the package dir, the staged copy is in the wrong place → `EACCES` on download → `DEGRADED`.
- **`docker/test-clean-vm.sh`** — the assertion is genuine semantic recall, not keyword match:
  1. Asserts `flair init` reports `Semantic search operational` (the #533 in-init check — note it *prints* `DEGRADED` but does **not** exit non-zero, so the exit code alone wouldn't catch a regression).
  2. Runs `flair doctor` as the hard gate — it performs the same embed→**paraphrase** round-trip (`verifySemanticSearch`: query "a cat hunting a mouse in the evening" vs. content "feline predator stalked its rodent quarry at dusk", **zero keyword overlap**, real semantic score `> 0.05`) and `process.exit(1)` on degraded. Keyword-only fallback cannot satisfy it.
- **`.github/workflows/docker-test.yml`** — new `clean-vm-gate` job runs on PRs **alongside** (not replacing) the existing from-scratch job; the from-scratch coverage stays, this adds the realistic non-root / no-override variant. Distinct GHA cache scopes so the two builds don't clobber each other.

### Validation (local, against current `main` post-#538)

Built and ran both directions:

- **Pass (the fix holds):** non-root global install → `flair init` → `Semantic search operational ✓ (paraphrase recall verified, score 0.73)`; `flair doctor` → `Embeddings: semantic search operational (paraphrase recall verified, score 0.74)`, exit 0. Gate **PASSED**.
- **Would catch a regression:** a faithful #538 sim — model dir made non-writable to `flairuser`, data dir left writable so Harper still starts — → `flair init` reports `✗ Semantic search DEGRADED — embeddings not loaded` → the gate's assertion fires and it **FAILS (exit 1)**. This also confirms the gate doesn't rely on init's exit code (which is 0 even when degraded).

Closes ops-cd37.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
