### PR TITLE
release: v0.16.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [0.16.0] - 2026-06-29
+
 ### 🧪 CI clean-VM gate — exercise the REALISTIC user env so the #538 embeddings showstopper can't silently regress (ops-cd37)
 
 The #538 fix (above) addressed a fresh `sudo npm install -g @tpsdev-ai/flair` leaving semantic search **dead** (model targeted the root-owned package dir; Harper-as-user couldn't write it). The uncomfortable part: **CI never caught it.** The existing `docker/Dockerfile.test` from-scratch job runs as **root** (no perms mismatch) *and* sets `FLAIR_MODELS_DIR=/opt/flair-models` (a writable override), so its "clean install" is not the user's environment — root + a pre-solved model path made the bug structurally invisible. The tarball smoke test (`test.yml`) also installs as root and its write/search round-trip uses a **keyword-matching** marker, so it passes even with embeddings dead.

--- a/bun.lock
+++ b/bun.lock
@@ -33,21 +33,21 @@
     },
     "packages/flair-client": {
       "name": "@tpsdev-ai/flair-client",
-      "version": "0.15.0",
+      "version": "0.16.0",
       "devDependencies": {
         "typescript": "5.9.3",
       },
     },
     "packages/flair-mcp": {
       "name": "@tpsdev-ai/flair-mcp",
-      "version": "0.15.0",
+      "version": "0.16.0",
       "bin": {
-        "flair-mcp": "dist/index.js",
+        "flair-mcp": "dist/mcp-shim.cjs",
         "flair-session-start": "dist/session-start-hook.js",
       },
       "dependencies": {
         "@modelcontextprotocol/sdk": "1.27.1",
-        "@tpsdev-ai/flair-client": "0.15.0",
+        "@tpsdev-ai/flair-client": "0.16.0",
         "zod": "4.3.6",
       },
       "devDependencies": {
@@ -56,9 +56,9 @@
     },
     "packages/langgraph-flair": {
       "name": "@tpsdev-ai/langgraph-flair",
-      "version": "0.15.0",
+      "version": "0.16.0",
       "dependencies": {
-        "@tpsdev-ai/flair-client": "0.8.3",
+        "@tpsdev-ai/flair-client": "0.16.0",
       },
       "peerDependencies": {
         "@langchain/langgraph-checkpoint": ">=0.0.10",
@@ -66,9 +66,9 @@
     },
     "packages/n8n-nodes-flair": {
       "name": "@tpsdev-ai/n8n-nodes-flair",
-      "version": "0.15.0",
+      "version": "0.16.0",
       "dependencies": {
-        "@tpsdev-ai/flair-client": "0.8.1",
+        "@tpsdev-ai/flair-client": "0.16.0",
         "zod": "3.25.76",
       },
       "devDependencies": {
@@ -85,10 +85,10 @@
     },
     "packages/openclaw-flair": {
       "name": "@tpsdev-ai/openclaw-flair",
-      "version": "0.15.0",
+      "version": "0.16.0",
       "dependencies": {
         "@sinclair/typebox": "0.34.48",
-        "@tpsdev-ai/flair-client": "0.8.3",
+        "@tpsdev-ai/flair-client": "0.16.0",
       },
       "devDependencies": {
         "typescript": "5.9.3",
@@ -99,10 +99,10 @@
     },
     "packages/pi-flair": {
       "name": "@tpsdev-ai/pi-flair",
-      "version": "0.15.0",
+      "version": "0.16.0",
       "dependencies": {
         "@sinclair/typebox": "0.34.48",
-        "@tpsdev-ai/flair-client": "0.15.0",
+        "@tpsdev-ai/flair-client": "0.16.0",
       },
       "devDependencies": {
         "@mariozechner/pi-coding-agent": "0.73.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tpsdev-ai/flair",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "description": "Identity, memory, and soul for AI agents. Cryptographic identity (Ed25519), semantic memory with local embeddings, and persistent personality — all in a single process.",
   "type": "module",
   "license": "Apache-2.0",

--- a/packages/flair-client/package.json
+++ b/packages/flair-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tpsdev-ai/flair-client",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "description": "Lightweight client for Flair — identity, memory, and soul for AI agents. Zero heavy dependencies.",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/flair-mcp/package.json
+++ b/packages/flair-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tpsdev-ai/flair-mcp",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "description": "MCP server for Flair — persistent memory for Claude Code, Cursor, and any MCP client.",
   "type": "module",
   "main": "dist/index.js",
@@ -27,7 +27,7 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "1.27.1",
-    "@tpsdev-ai/flair-client": "0.15.0",
+    "@tpsdev-ai/flair-client": "0.16.0",
     "zod": "4.3.6"
   },
   "license": "Apache-2.0",

--- a/packages/langgraph-flair/package.json
+++ b/packages/langgraph-flair/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tpsdev-ai/langgraph-flair",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "description": "LangGraph BaseStore adapter backed by Flair — durable agent memory with crypto-pinned identity, federation, and cross-orchestrator portability.",
   "type": "module",
   "main": "dist/index.js",
@@ -36,7 +36,7 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
-    "@tpsdev-ai/flair-client": "0.15.0"
+    "@tpsdev-ai/flair-client": "0.16.0"
   },
   "peerDependencies": {
     "@langchain/langgraph-checkpoint": ">=0.0.10"

--- a/packages/n8n-nodes-flair/package.json
+++ b/packages/n8n-nodes-flair/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tpsdev-ai/n8n-nodes-flair",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "description": "n8n community node — use Flair as your AI Agent's memory backend. Includes FlairChatMemory (Memory port) and FlairSearch (Tool port).",
   "type": "commonjs",
   "main": "dist/index.js",
@@ -48,7 +48,7 @@
     "langchain"
   ],
   "dependencies": {
-    "@tpsdev-ai/flair-client": "0.15.0",
+    "@tpsdev-ai/flair-client": "0.16.0",
     "zod": "3.25.76"
   },
   "peerDependencies": {

--- a/packages/openclaw-flair/dist/index.js
+++ b/packages/openclaw-flair/dist/index.js
@@ -417,12 +417,20 @@ export default {
                             dedup: !supersedes,
                             dedupThreshold: 0.7,
                         });
-                        const wasDeduped = result.id !== memId;
+                        const wasDeduped = result.id !== memId || result.deduped === true;
                         return {
-                            content: [{ type: "text", text: wasDeduped
-                                        ? `Similar memory already exists (id: ${result.id}): ${result.content?.slice(0, 200)}`
-                                        : `Memory stored (id: ${memId})` }],
-                            details: { id: result.id, deduplicated: wasDeduped },
+                            content: [{
+                                    type: "text",
+                                    text: wasDeduped
+                                        ? `⚠️ DEDUPLICATED — new content was NOT written. Matched existing memory id=${result.id}: ${result.content?.slice(0, 200)}`
+                                        : `Memory stored (id: ${memId})`,
+                                }],
+                            details: {
+                                id: result.id,
+                                deduplicated: wasDeduped,
+                                written: !wasDeduped,
+                                ...(wasDeduped ? { mergedWith: result.id } : {}),
+                            },
                         };
                     }
                     catch (err) {

--- a/packages/openclaw-flair/package.json
+++ b/packages/openclaw-flair/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tpsdev-ai/openclaw-flair",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "description": "OpenClaw memory plugin for Flair — agent identity and semantic memory",
   "type": "module",
   "main": "./dist/index.js",
@@ -58,7 +58,7 @@
   },
   "dependencies": {
     "@sinclair/typebox": "0.34.48",
-    "@tpsdev-ai/flair-client": "0.15.0"
+    "@tpsdev-ai/flair-client": "0.16.0"
   },
   "devDependencies": {
     "typescript": "5.9.3"

--- a/packages/pi-flair/package.json
+++ b/packages/pi-flair/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tpsdev-ai/pi-flair",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "description": "Flair memory extension for pi — persistent memory access from within pi sessions",
   "type": "module",
   "main": "dist/index.js",
@@ -21,7 +21,7 @@
     "node": ">=18"
   },
   "dependencies": {
-    "@tpsdev-ai/flair-client": "0.15.0",
+    "@tpsdev-ai/flair-client": "0.16.0",
     "@sinclair/typebox": "0.34.48"
   },
   "license": "Apache-2.0",


### PR DESCRIPTION
Version bump across all 7 published workspace packages to **v0.16.0** (minor: features + fixes, no breaking changes), aligning internal `@tpsdev-ai/flair-client` deps to 0.16.0, refreshing `bun.lock`, and promoting CHANGELOG `[Unreleased]` → `[0.16.0] - 2026-06-29`. Covers the 11 PRs (#530–#540) merged since v0.15.0.

## Highlights

- **🩺 Recall works on a fresh `sudo` install (#538, ops-am0v) — the headline fix.** A clean `sudo npm install -g @tpsdev-ai/flair` left semantic search **dead**: the embeddings model dir was hard-coded to the (root-owned, read-only) package dir, so the model download hit `EACCES` and recall silently fell back to keyword-only. The model dir now defaults to a user-writable location (`FLAIR_MODELS_DIR` → `<ROOTPATH=~/.flair/data>/models` → cached `<cwd>/models` → `~/.flair/data/models`), so embed→paraphrase recall round-trips (~0.74) on the exact install path users run.
- **🧪 CI clean-VM gate so #538 cannot silently regress (#540, ops-cd37).** New `docker/Dockerfile.clean-vm` reproduces the *real* user env — HEAD tarball, global root-owned install, **non-root** runtime user, **no `FLAIR_MODELS_DIR` override** — and asserts genuine semantic recall via `flair doctor`'s zero-keyword-overlap paraphrase round-trip (hard `exit 1` on degraded). The old root-plus-override from-scratch job made the bug structurally invisible; this gate would have caught it.
- **⬆️ Bundled Harper 5.0.21 → 5.1.14 (#534/#535, ops-xc0x).** Retires the 5.0.21 `packageComponent` empty-tarball pin (#513) and reaches parity with the Fabric (already on 5.1.14 in prod). Step 0 of the native-MCP arc — 5.1 unlocks Harper native MCP + the OAuth plugin. CI Docker image synced to 5.1.14 to validate the runtime users actually get.
- **🛡️ Release/ops guardrails.** Harper watchdog now recovers an **unloaded** launchd job (the 2026-06-27 prod-down mode) + alerts on up/down transitions (#537, ops-6nv7). All runtime deps **exact-pinned** to the tested lockfile versions + Renovate with a 7-day supply-chain cooldown matching the bake-time guard (#536, ops-sz4n). Impl-term leak check now builds packages and runs on **every** PR (not just at release), so a source-comment leak fails on the introducing PR (#530).
- **🛟 flair-mcp Node-version preflight (#539, ops-fomi).** `npx -y @tpsdev-ai/flair-mcp` on an unsupported Node was failing silently (the ESM import graph crashes before any in-file guard). A CJS preflight shim now prints an actionable message + exits non-zero before anything loads — mirrors the CLI fix from #524.
- **📚 Onboarding consolidation (#531/#532/#533).** One front door (`flair install` folded into `flair init`), one zero-install MCP-wiring pattern (`npx -y @tpsdev-ai/flair-mcp`), loud failure for dead semantic search in `flair doctor`/`flair init`, and accurate cross-orchestrator wiring (Codex/Gemini/Cursor actually write their config now).
- **Hybrid retrieval + coordination write surface** carried in via the dogfood rounds (loud-failure recall verification + the corrected `flair agent list` Ed25519 auth path).

## Release-correctness notes (please review)

- **bun.lock workspace metadata corrected.** Four internal `flair-client` dep strings in the lock were pre-existing drift that `bun install` never reconciled (langgraph `0.8.3`, n8n `0.8.1`, openclaw `0.8.3`, pi-flair `0.15.0`) — now all `0.16.0`, matching #536's precedent of keeping the lock honest. `bun install --frozen-lockfile` passes.
- **Rebuilt `packages/openclaw-flair/dist/index.js` — it was stale since #353 (2026-05-05).** The dedup-warning source fix landed in #450 (2026-05-27) but the *tracked* compiled artifact was never rebuilt-and-committed (the package's `dist/` is gitignored yet `dist/index.js` is tracked — a contradictory state), so the published openclaw-flair tarball has been shipping stale code. The rebuild matches source. **Pre-existing repo-hygiene issue flagged for follow-up** (decide: untrack the dist + build-on-publish, or commit it deliberately).

## Verification (all green, run in an isolated worktree — prod untouched)

- workspace-deps lockstep ✓ · dep-ages bake-time (10 pinned deps ≥ 7d) ✓ · impl-term-leaks (no leaks) ✓ · check-imports (98 files, 0 failures) ✓
- typecheck ✓ (tsconfig.check.json + tsconfig.cli.json + every workspace package)
- build ✓ (all 7 packages) · **full test suite: 1284 pass / 0 fail** (95 files, unit + integration)
- All 7 packages at 0.16.0; CHANGELOG `[0.16.0] - 2026-06-29` has all entries, `[Unreleased]` empty.

After CI green + K&S approval and merge, the v0.16.0 tag push triggers the OIDC stage → maintainer 2FA approval on npmjs.com (per `docs/releasing.md`). **Do not self-merge; do not push the tag from this PR — Flint shepherds the merge + tag.**