### PR TITLE
fix(upgrade): flair-mcp detection, openclaw noise, restart spacing, scope note

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1286,6 +1286,26 @@ export function probeOpenclawPluginVersion(extensionName: string): string | null
 }
 
 /**
+ * Status of a package in the `flair upgrade` listing.
+ *   current  — installed version matches registry latest
+ *   outdated — installed version is older than latest
+ *   missing  — not detected; default packages → install advised
+ *   optional — openclaw plugin; openclaw isn't installed (don't nag)
+ */
+export type UpgradeStatus = "current" | "outdated" | "missing" | "optional";
+
+/**
+ * Whether a package's status line should be printed in the default `flair
+ * upgrade` listing. Suppresses optional-because-openclaw-is-absent lines
+ * (ops-p42n) — pure noise on machines without openclaw — unless `--all`
+ * (showAll) is set. All other statuses always print.
+ */
+export function shouldPrintUpgradeLine(status: UpgradeStatus, showAll: boolean): boolean {
+  if (status === "optional" && !showAll) return false;
+  return true;
+}
+
+/**
  * Order a soul key→count map for display: highest count first, ties broken
  * alphabetically for stable output. Soul entries are keyed identity facts
  * (role / project / standards / …) — this is the honest breakdown dimension.
@@ -6156,11 +6176,14 @@ program
     //     directly (the OpenClaw plugin install layout — not on $PATH, not in
     //     flair's module graph).
     //
-    // Default UI shows only end-user-facing packages: flair, flair-mcp,
-    // openclaw-flair. flair-client is a transitive dep of flair-mcp and
-    // showing it as a top-level upgrade item invites a misleading
-    // "❔ missing — install with npm install -g" suggestion for users who
-    // installed flair without flair-mcp (ops-h5cd). --all opts in.
+    // Default UI shows the npm-global packages (flair, flair-mcp) plus
+    // openclaw-flair WHEN openclaw is installed. On machines without openclaw
+    // the openclaw-flair line is suppressed entirely (ops-p42n) rather than
+    // nagging with an install hint for a plugin the user can't use. flair-client
+    // is a transitive dep of flair-mcp and showing it as a top-level upgrade
+    // item invites a misleading "❔ missing — install with npm install -g"
+    // suggestion for users who installed flair without flair-mcp (ops-h5cd).
+    // --all opts in to both flair-client and the suppressed openclaw line.
     type ProbeKind = "bin" | "lib" | "openclaw-plugin";
     const packages: Array<{
       name: string;
@@ -6176,7 +6199,13 @@ program
       {
         name: "@tpsdev-ai/flair-mcp",
         kind: "bin",
-        probe: () => probeBinVersion(execFileSync,"flair-mcp"),
+        // Older flair-mcp installs (e.g. 0.10.0) either aren't on PATH or
+        // don't support `--version`, so the bin probe returns null even when
+        // the package IS globally installed (ops-p42n). Fall back to the lib
+        // probe, which require.resolves the package.json from a sibling global
+        // install regardless of PATH or --version support. kind stays "bin" so
+        // it remains npm-upgradeable (npm install -g), not the openclaw path.
+        probe: () => probeBinVersion(execFileSync, "flair-mcp") ?? probeLibVersion("@tpsdev-ai/flair-mcp"),
       },
       {
         name: "@tpsdev-ai/openclaw-flair",
@@ -6191,13 +6220,8 @@ program
       },
     ];
 
-    // Three-state status per package, plus a fourth for openclaw-plugin
-    // packages that aren't installed (since openclaw is optional):
-    //   current    — installed version matches registry latest
-    //   outdated   — installed version is older than latest
-    //   missing    — not detected; default packages → install advised
-    //   optional   — openclaw plugin; openclaw isn't installed (don't nag)
-    type Status = "current" | "outdated" | "missing" | "optional";
+    // Per-package status — see the UpgradeStatus type for the four states.
+    type Status = UpgradeStatus;
     const findings: Array<{ name: string; installed: string | null; latest: string; status: Status; kind: ProbeKind }> = [];
 
     for (const { name, probe, kind, transitive } of packages) {
@@ -6221,6 +6245,13 @@ program
         }
         findings.push({ name, installed, latest, status, kind });
 
+        // Suppress the line for openclaw plugins that are optional-because-
+        // openclaw-is-absent (ops-p42n): on machines without openclaw the
+        // "○ … not installed (openclaw not detected) → … (install via …)"
+        // line is pure noise. Still print it when openclaw IS installed
+        // (current/outdated) or under --all.
+        if (!shouldPrintUpgradeLine(status, showAll)) continue;
+
         const icon = status === "current" ? "✅"
           : status === "outdated" ? "⬆️"
           : status === "optional" ? "○"
@@ -6233,6 +6264,10 @@ program
         console.log(`  ${icon} ${name}: ${installedLabel} → ${latest}${suffix}`);
       } catch { /* skip unavailable packages */ }
     }
+
+    // Scope footer (ops-p42n): make explicit what `flair upgrade` does and
+    // doesn't cover, so "were the others checked?" has a one-line answer.
+    console.log("\nScope: npm-global packages (flair, flair-mcp) + openclaw plugins. Other integrations (pi-flair, langgraph-flair, n8n-nodes-flair, hermes-flair) upgrade in their own ecosystems (pi / pip / n8n).");
 
     const outdated = findings.filter((f) => f.status === "outdated");
     const missing = findings.filter((f) => f.status === "missing");
@@ -6317,7 +6352,7 @@ program
         console.log("Run: flair restart");
       }
     } else {
-      console.log("\nRun: flair restart  to use the new version");
+      console.log("\nRun: flair restart to use the new version");
     }
   });
 

--- a/test/unit/upgrade-probes.test.ts
+++ b/test/unit/upgrade-probes.test.ts
@@ -2,7 +2,7 @@ import { describe, test, expect, beforeEach, afterEach } from "bun:test";
 import { mkdtempSync, rmSync, writeFileSync, mkdirSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
-import { probeBinVersion, probeLibVersion, probeOpenclawPluginVersion } from "../../src/cli";
+import { probeBinVersion, probeLibVersion, probeOpenclawPluginVersion, shouldPrintUpgradeLine } from "../../src/cli";
 
 // execFileSync takes (file, args, opts) and returns Buffer|string. Tests
 // inject a fake that ignores input and returns a fixed string (or throws).
@@ -107,5 +107,73 @@ describe("probeOpenclawPluginVersion", () => {
     mkdirSync(extDir, { recursive: true });
     writeFileSync(join(extDir, "package.json"), JSON.stringify({ name: "@tpsdev-ai/openclaw-flair" }));
     expect(probeOpenclawPluginVersion("openclaw-flair")).toBeNull();
+  });
+});
+
+// The flair-mcp package entry in `flair upgrade` probes via
+//   probeBinVersion(execFileSync, "flair-mcp") ?? probeLibVersion("@tpsdev-ai/flair-mcp")
+// so an older install that's globally present but not on PATH / has no
+// `--version` (e.g. 0.10.0, ops-p42n) is still detected via the lib probe
+// instead of falsely reporting "not detected". These tests pin that
+// bin→lib fallback composition and the resulting detected/outdated status.
+describe("flair-mcp bin→lib probe fallback (ops-p42n)", () => {
+  // Mirror the upgrade command's status mapping for the assertions below.
+  const statusFor = (installed: string | null, latest: string) =>
+    installed === null ? "missing" : installed === latest ? "current" : "outdated";
+
+  test("falls back to the lib probe when the bin probe returns null (still detected)", () => {
+    // bin probe returns null (binary not on PATH / no --version support)…
+    const binNull = fake(() => { throw new Error("ENOENT: flair-mcp not found"); });
+    // …but the package IS resolvable in the module graph (js-yaml stands in
+    // for a sibling global install of flair-mcp — both are version-independent).
+    const detected = probeBinVersion(binNull, "flair-mcp") ?? probeLibVersion("js-yaml");
+    expect(detected).not.toBeNull();
+    expect(detected).toMatch(/^\d+\.\d+\.\d+/);
+  });
+
+  test("a globally-installed-but-binless flair-mcp is treated as outdated when < latest", () => {
+    // Real-world ops-p42n: 0.10.0 installed, bin probe null, lib probe finds it.
+    const binNull = fake(() => { throw new Error("not on PATH"); });
+    const libStub = (_pkg: string): string | null => "0.10.0"; // sibling global install
+    const installed = probeBinVersion(binNull, "flair-mcp") ?? libStub("@tpsdev-ai/flair-mcp");
+    expect(installed).toBe("0.10.0");
+    expect(statusFor(installed, "0.16.0")).toBe("outdated");
+    // …and not the false "missing" the bin-only probe produced before the fix.
+    expect(statusFor(installed, "0.16.0")).not.toBe("missing");
+  });
+
+  test("a current flair-mcp via the lib fallback reports 'current'", () => {
+    const binNull = fake(() => { throw new Error("not on PATH"); });
+    const libStub = (_pkg: string): string | null => "0.16.0";
+    const installed = probeBinVersion(binNull, "flair-mcp") ?? libStub("@tpsdev-ai/flair-mcp");
+    expect(statusFor(installed, "0.16.0")).toBe("current");
+  });
+
+  test("genuinely-uninstalled flair-mcp (both probes null) is still 'missing'", () => {
+    const binNull = fake(() => { throw new Error("not on PATH"); });
+    const installed = probeBinVersion(binNull, "flair-mcp")
+      ?? probeLibVersion("this-package-does-not-exist-anywhere-3f8c2a1b");
+    expect(installed).toBeNull();
+    expect(statusFor(installed, "0.16.0")).toBe("missing");
+  });
+});
+
+// fix #2 (ops-p42n): the optional openclaw-flair line is suppressed in the
+// default listing on machines without openclaw, but still shown under --all.
+describe("shouldPrintUpgradeLine", () => {
+  test("suppresses an optional (openclaw-absent) line by default", () => {
+    expect(shouldPrintUpgradeLine("optional", false)).toBe(false);
+  });
+
+  test("shows the optional line under --all (showAll)", () => {
+    expect(shouldPrintUpgradeLine("optional", true)).toBe(true);
+  });
+
+  test("always shows current / outdated / missing lines (default and --all)", () => {
+    for (const showAll of [false, true]) {
+      expect(shouldPrintUpgradeLine("current", showAll)).toBe(true);
+      expect(shouldPrintUpgradeLine("outdated", showAll)).toBe(true);
+      expect(shouldPrintUpgradeLine("missing", showAll)).toBe(true);
+    }
   });
 });


### PR DESCRIPTION
Fixes the local `flair upgrade` (no `--target`) command — 3 real bugs + 1 scope-clarity gap Nathan hit on v0.16.0 (**ops-p42n**).

## The 4 fixes (`src/cli.ts`)

1. **flair-mcp false "not detected" (the real bug).** The `@tpsdev-ai/flair-mcp` package entry probed only via `probeBinVersion(execFileSync, "flair-mcp")`, which returns `null` when the bin isn't on PATH or doesn't support `--version` (true for older installs like 0.10.0) — even though the package is globally installed (`npm ls -g @tpsdev-ai/flair-mcp` confirms). Now falls back to the lib probe: `probeBinVersion(...) ?? probeLibVersion("@tpsdev-ai/flair-mcp")`, so a sibling global install is detected regardless of PATH / `--version` support, and treated as outdated when `< latest`. `kind` stays `"bin"` → remains npm-upgradeable (`npm install -g`), not the openclaw path. (line 6208)

2. **openclaw noise.** On machines without openclaw, the optional `○ @tpsdev-ai/openclaw-flair: not installed (openclaw not detected) → … (install via …)` line is pure noise. Suppressed in the default listing via a new exported pure helper `shouldPrintUpgradeLine(status, showAll)` (+ `UpgradeStatus` type). Still printed when openclaw IS present (current/outdated) or under `--all`. Nearby block comment updated to match. (helper at line 1303; call at line 6253)

3. **restart-line double-space.** `"Run: flair restart  to use the new version"` → single space. (line 6355)

4. **scope note** (Nathan's "were the others checked?"). One concise footer after the listing clarifying scope: `flair upgrade` covers npm-global packages (flair, flair-mcp) + openclaw plugins; other integrations (pi-flair / langgraph-flair / n8n-nodes-flair / hermes-flair) upgrade in their own ecosystems (pi / pip / n8n). (line 6270)

## Tests (`test/unit/upgrade-probes.test.ts`)

- New `flair-mcp bin→lib probe fallback (ops-p42n)` block: bin probe `null` + lib probe returns a version → detected (not missing); a 0.10.0-style install is `outdated` when `< latest`; current when `== latest`; both-null stays `missing`.
- New `shouldPrintUpgradeLine` block: `optional` suppressed by default, shown under `--all`; current/outdated/missing always shown.
- `bun test test/unit/upgrade-probes.test.ts` → 21 pass / 0 fail. Full unit suite (81 files) green: 1162 pass / 0 fail.

## Verify

- Typecheck clean: `bunx tsc --noEmit -p tsconfig.cli.json` and `-p tsconfig.check.json` both exit 0.
- Build clean: `npm run build:cli` exit 0.
- No real upgrade run against prod / `~/.flair` / `:9926`.

Refs ops-p42n.

🤖 Generated with [Claude Code](https://claude.com/claude-code)