### PR TITLE
ci: auto-cut GitHub release from CHANGELOG on tag push

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -1,10 +1,14 @@
-name: Release — stage-publish (OIDC)
+name: Release — stage-publish (OIDC) + GitHub release
 
 # Tokenless release pipeline, triggered by pushing a vX.Y.Z tag. Authenticates to
 # npm via OIDC trusted publishing (no NPM_TOKEN lives anywhere) and submits every
 # workspace package to npm's STAGING area via `npm stage publish` rather than
 # publishing live. A maintainer approves the staged tarballs on npmjs.com with 2FA
 # to go live — that approval is the release gate (see docs/releasing.md).
+#
+# A separate, INDEPENDENT job (github-release) cuts a GitHub release for the tag
+# from the matching CHANGELOG.md section. It does NOT depend on the npm staging
+# approval — the GitHub release documents the tagged commit immediately on push.
 #
 # Cut a release: after the `release: vX.Y.Z` PR merges to main, push the tag:
 #   git tag v0.11.0 && git push origin v0.11.0
@@ -179,3 +183,69 @@ jobs:
             echo "**To release:** open [npmjs.com → Staged Packages](https://www.npmjs.com/settings/tpsdev-ai/staging),"
             echo "review each tarball, and approve with 2FA. Or: \`npm stage list\` then \`npm stage approve <id>\`."
           } >> "$GITHUB_STEP_SUMMARY"
+
+  github-release:
+    name: Cut GitHub release from CHANGELOG
+    runs-on: ubuntu-latest
+    # Independent of stage-publish on purpose: the GitHub release documents the
+    # tagged commit and can be cut immediately on tag push. It does NOT wait on
+    # the npm staging 2FA approval (a manual external gate) — that gate governs
+    # what goes LIVE on npm, not whether the tag is recorded on GitHub.
+    if: github.event_name == 'push'
+    permissions:
+      contents: write   # create/edit the GitHub release for the tag
+    steps:
+      - name: Resolve version
+        id: ver
+        env:
+          REF_NAME: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          # tag push: github.ref_name is the tag (vX.Y.Z)
+          VERSION="${REF_NAME#v}"
+          if ! [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9.]+)?$ ]]; then
+            echo "::error::Invalid version '$VERSION'. Expected semver (e.g. 0.11.0 or 1.0.0-rc.1)."
+            exit 1
+          fi
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Resolved version: $VERSION"
+
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+
+      - name: Extract CHANGELOG section
+        # The node script reads CHANGELOG.md and writes the matching section body
+        # to a file. Version flows through env, never ${{ }} interpolation in the
+        # script body, and the body is captured to a file (never re-emitted into a
+        # shell string) so neither the tag nor the CHANGELOG text can be parsed as
+        # shell. Fails loudly (non-zero) if the section is missing or empty.
+        env:
+          VERSION: ${{ steps.ver.outputs.version }}
+        run: |
+          set -euo pipefail
+          node scripts/changelog-extract.mjs "$VERSION" CHANGELOG.md > release-notes.md
+          echo "Extracted $(wc -l < release-notes.md) lines for v$VERSION"
+
+      - name: Create or update GitHub release
+        # Idempotent: if a release for the tag already exists (re-run, or the
+        # manually-cut v0.16.0), update it in place instead of failing. The notes
+        # body is passed via --notes-file (a file on disk), and the tag/title via
+        # env-expanded argv — content is never interpolated into the command text.
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ github.ref_name }}
+          VERSION: ${{ steps.ver.outputs.version }}
+        run: |
+          set -euo pipefail
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            echo "Release $TAG exists — updating notes."
+            gh release edit "$TAG" \
+              --title "v$VERSION" \
+              --notes-file release-notes.md
+          else
+            echo "Creating release $TAG."
+            gh release create "$TAG" \
+              --title "v$VERSION" \
+              --notes-file release-notes.md \
+              --verify-tag
+          fi
+          echo "Release URL: $(gh release view "$TAG" --json url --jq .url)"

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -55,6 +55,15 @@ It authenticates via OIDC — no secrets, and it does **not** create or move any
 tag you pushed is the trigger). Watch the run; when it's green, the packages are staged
 but **not yet live**.
 
+In parallel — and **independent of the npm staging approval** — a `github-release` job
+auto-cuts a [GitHub release](https://github.com/tpsdev-ai/flair/releases) for the tag,
+using the matching `## [X.Y.Z]` section of `CHANGELOG.md` as the release notes (extracted
+by `scripts/changelog-extract.mjs`). It is idempotent: re-running the workflow or
+re-pushing the tag updates the existing release rather than failing. The GitHub release
+documents the tagged commit immediately; it does not wait on the npm 2FA gate. If the
+CHANGELOG has no section for the version, this job fails loudly rather than cutting an
+empty release — so always promote `## [Unreleased]` to `## [X.Y.Z]` in the release PR.
+
 > `workflow_dispatch` with a `version` input remains as a manual fallback (needs
 > `Actions: write`), but the tag push is the normal path.
 

--- a/scripts/changelog-extract.mjs
+++ b/scripts/changelog-extract.mjs
@@ -1,0 +1,86 @@
+#!/usr/bin/env node
+// Extract one version's section body from CHANGELOG.md.
+//
+// Usage: node scripts/changelog-extract.mjs <version> [changelog-path]
+//   <version>      bare semver, e.g. 0.16.0 (no leading "v")
+//   changelog-path defaults to ./CHANGELOG.md
+//
+// Prints the section body (the lines after the `## [<version>] ...` header,
+// up to but excluding the next `## [` header) to stdout, trimmed.
+// Exits non-zero with a message on stderr if the section is missing or empty,
+// so the caller can fail loudly rather than cut an empty release.
+
+import { readFileSync } from "node:fs";
+
+// A downstream reader closing the pipe early (e.g. `… | head`) raises EPIPE on
+// stdout. That is not an error for us — exit cleanly instead of crashing.
+process.stdout.on("error", (err) => {
+  if (err.code === "EPIPE") process.exit(0);
+  throw err;
+});
+
+const version = process.argv[2];
+const path = process.argv[3] ?? "CHANGELOG.md";
+
+if (!version) {
+  console.error("changelog-extract: missing <version> argument");
+  process.exit(2);
+}
+// Defence-in-depth: the workflow already validates the tag, but the script is
+// the one touching the file — never let a crafted "version" become a regex.
+if (!/^[0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9.]+)?$/.test(version)) {
+  console.error(`changelog-extract: invalid version '${version}'`);
+  process.exit(2);
+}
+
+let text;
+try {
+  text = readFileSync(path, "utf8");
+} catch (err) {
+  console.error(`changelog-extract: cannot read ${path}: ${err.message}`);
+  process.exit(2);
+}
+
+const lines = text.split("\n");
+// Match the header for THIS version literally: "## [<version>]" optionally
+// followed by " - <date>" or other trailing text. version is validated above,
+// but escape it anyway so it is matched as data, not pattern.
+const esc = version.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+const headerRe = new RegExp(`^## \\[${esc}\\]`);
+const anyHeaderRe = /^## \[/;
+
+let start = -1;
+for (let i = 0; i < lines.length; i++) {
+  if (headerRe.test(lines[i])) {
+    start = i;
+    break;
+  }
+}
+if (start === -1) {
+  console.error(
+    `changelog-extract: no '## [${version}]' section found in ${path}`,
+  );
+  process.exit(1);
+}
+
+let end = lines.length;
+for (let i = start + 1; i < lines.length; i++) {
+  if (anyHeaderRe.test(lines[i])) {
+    end = i;
+    break;
+  }
+}
+
+const body = lines
+  .slice(start + 1, end)
+  .join("\n")
+  .trim();
+
+if (body.length === 0) {
+  console.error(
+    `changelog-extract: section '## [${version}]' is empty in ${path}`,
+  );
+  process.exit(1);
+}
+
+process.stdout.write(body + "\n");


### PR DESCRIPTION
## What

Adds a `github-release` job to `release-publish.yml` that auto-cuts a GitHub release for each `v*` tag, using the matching `## [X.Y.Z]` section of `CHANGELOG.md` as the release notes. Now that others depend on Flair, every future tagged release gets a GitHub release without manual effort.

None of v0.11-v0.16 had a GitHub release until v0.16.0 was cut by hand; this automates it going forward.

## How

- **Independent of npm publish.** The new job has **no `needs:`** on `stage-publish` and does **not** wait on the manual npm 2FA staging approval (an external gate). The GitHub release documents the tagged commit immediately on push. It's gated to `github.event_name == 'push'` (real tag pushes only).
- **Version from the tag**, validated with the same `^[0-9]+\.[0-9]+\.[0-9]+(-...)?$` regex the staging job uses (`v0.16.0` -> `0.16.0`).
- **`scripts/changelog-extract.mjs`** - small Node script: extracts the lines after `## [<version>] ...` up to the next `## [`, trims, and **fails loudly (non-zero)** if the section is missing or empty, so an empty release is never cut silently. Re-validates the version as data and escapes it before building the literal header regex; handles EPIPE for piped readers.
- **Idempotent** - `gh release view` first; if the tag already has a release (re-run, or the manually-cut v0.16.0) it `gh release edit`s in place, otherwise `gh release create --verify-tag`. Re-runs and re-pushed tags update rather than fail.
- **`permissions: contents: write`** scoped to this job only; the workflow default stays `contents: read` and the staging job is untouched.

## Injection safety (Sherlock)

The job gains `contents: write` and runs `gh release`. The tag (`github.ref_name`) and the CHANGELOG body are passed as **data**, never interpolated into a shell string:
- Version flows through `env:` (`$VERSION`/`$TAG`/`$REF_NAME`), never `${{ }}` inside a `run:` body.
- The extracted notes are written to `release-notes.md` and passed via `--notes-file` - the body never re-enters the shell parser.
- The version regex is pinned in both the workflow step and the extraction script (defence in depth); the script escapes the version before using it in a `RegExp`.
- `actionlint` 1.7.12 (with embedded shellcheck) passes clean on all workflows (exit 0).

## Verification

- **Extraction tested against the live CHANGELOG for `0.16.0`**: yields 729 lines starting at the first `###` entry, contains **zero** `## [` markers (stops before `## [0.15.0]` - confirmed against a synthetic CHANGELOG with a following section).
- **Edge cases**: missing version -> exit 1 with a message; empty section -> exit 1; injection-shaped version arg (`0.16.0; rm -rf /`) -> rejected, exit 2.
- **YAML/CI**: `actionlint` clean on `release-publish.yml` and all workflows; YAML parses; pre-commit hooks green.

## Docs

`docs/releasing.md` now documents that the GitHub release is auto-cut from the CHANGELOG on tag, independent of the npm 2FA gate, with the reminder to promote `## [Unreleased]` in the release PR.

---

K&S-gated. Flagging Sherlock: this PR gives CI `contents: write` and runs `gh release` - please check the injection-safety of the tag/CHANGELOG handling. Do not self-merge.

Generated with [Claude Code](https://claude.com/claude-code)