### PR TITLE
release: v0.16.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## [Unreleased]
 
+## [0.16.1] - 2026-07-01
+
+### 🐛 `flair upgrade` — detect an installed-but-stale flair-mcp, drop openclaw noise, fix formatting (#543)
+
+The bin `--version` probe missed a globally-installed `flair-mcp` (older installs predate `--version`) → it now falls back to the lib probe (reads the installed `package.json` version, version-independent), so a stale-but-present flair-mcp is correctly detected. The `openclaw-flair` line is suppressed when openclaw isn't installed (still shown under `--all`), dropping noise on machines without openclaw. Fixed a double-space in the restart hint. Added a one-line scope note: `flair upgrade` covers the npm-global surface + openclaw plugins; `pi-flair` / `langgraph-flair` / `n8n-nodes-flair` / `hermes-flair` upgrade within their own ecosystems. Fixes ops-p42n (surfaced by Kyle's real-world use).
+
+### 🤖 Auto-cut GitHub releases from the CHANGELOG on tag (#544)
+
+Every `v*` tag now creates its GitHub release from the matching CHANGELOG section — idempotent (create-or-edit), injection-safe (tag/version passed via env, notes via `--notes-file`), and independent of the npm 2FA staging gate.
+
 ## [0.16.0] - 2026-06-29
 
 ### 🧪 CI clean-VM gate — exercise the REALISTIC user env so the #538 embeddings showstopper can't silently regress (ops-cd37)

--- a/bun.lock
+++ b/bun.lock
@@ -33,21 +33,21 @@
     },
     "packages/flair-client": {
       "name": "@tpsdev-ai/flair-client",
-      "version": "0.16.0",
+      "version": "0.16.1",
       "devDependencies": {
         "typescript": "5.9.3",
       },
     },
     "packages/flair-mcp": {
       "name": "@tpsdev-ai/flair-mcp",
-      "version": "0.16.0",
+      "version": "0.16.1",
       "bin": {
         "flair-mcp": "dist/mcp-shim.cjs",
         "flair-session-start": "dist/session-start-hook.js",
       },
       "dependencies": {
         "@modelcontextprotocol/sdk": "1.27.1",
-        "@tpsdev-ai/flair-client": "0.16.0",
+        "@tpsdev-ai/flair-client": "0.16.1",
         "zod": "4.3.6",
       },
       "devDependencies": {
@@ -56,7 +56,7 @@
     },
     "packages/langgraph-flair": {
       "name": "@tpsdev-ai/langgraph-flair",
-      "version": "0.16.0",
+      "version": "0.16.1",
       "dependencies": {
         "@tpsdev-ai/flair-client": "0.16.0",
       },
@@ -66,7 +66,7 @@
     },
     "packages/n8n-nodes-flair": {
       "name": "@tpsdev-ai/n8n-nodes-flair",
-      "version": "0.16.0",
+      "version": "0.16.1",
       "dependencies": {
         "@tpsdev-ai/flair-client": "0.16.0",
         "zod": "3.25.76",
@@ -85,7 +85,7 @@
     },
     "packages/openclaw-flair": {
       "name": "@tpsdev-ai/openclaw-flair",
-      "version": "0.16.0",
+      "version": "0.16.1",
       "dependencies": {
         "@sinclair/typebox": "0.34.48",
         "@tpsdev-ai/flair-client": "0.16.0",
@@ -99,7 +99,7 @@
     },
     "packages/pi-flair": {
       "name": "@tpsdev-ai/pi-flair",
-      "version": "0.16.0",
+      "version": "0.16.1",
       "dependencies": {
         "@sinclair/typebox": "0.34.48",
         "@tpsdev-ai/flair-client": "0.16.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tpsdev-ai/flair",
-  "version": "0.16.0",
+  "version": "0.16.1",
   "description": "Identity, memory, and soul for AI agents. Cryptographic identity (Ed25519), semantic memory with local embeddings, and persistent personality — all in a single process.",
   "type": "module",
   "license": "Apache-2.0",

--- a/packages/flair-client/package.json
+++ b/packages/flair-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tpsdev-ai/flair-client",
-  "version": "0.16.0",
+  "version": "0.16.1",
   "description": "Lightweight client for Flair — identity, memory, and soul for AI agents. Zero heavy dependencies.",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/flair-mcp/package.json
+++ b/packages/flair-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tpsdev-ai/flair-mcp",
-  "version": "0.16.0",
+  "version": "0.16.1",
   "description": "MCP server for Flair — persistent memory for Claude Code, Cursor, and any MCP client.",
   "type": "module",
   "main": "dist/index.js",
@@ -27,7 +27,7 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "1.27.1",
-    "@tpsdev-ai/flair-client": "0.16.0",
+    "@tpsdev-ai/flair-client": "0.16.1",
     "zod": "4.3.6"
   },
   "license": "Apache-2.0",

--- a/packages/langgraph-flair/package.json
+++ b/packages/langgraph-flair/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tpsdev-ai/langgraph-flair",
-  "version": "0.16.0",
+  "version": "0.16.1",
   "description": "LangGraph BaseStore adapter backed by Flair — durable agent memory with crypto-pinned identity, federation, and cross-orchestrator portability.",
   "type": "module",
   "main": "dist/index.js",
@@ -36,7 +36,7 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
-    "@tpsdev-ai/flair-client": "0.16.0"
+    "@tpsdev-ai/flair-client": "0.16.1"
   },
   "peerDependencies": {
     "@langchain/langgraph-checkpoint": ">=0.0.10"

--- a/packages/n8n-nodes-flair/package.json
+++ b/packages/n8n-nodes-flair/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tpsdev-ai/n8n-nodes-flair",
-  "version": "0.16.0",
+  "version": "0.16.1",
   "description": "n8n community node — use Flair as your AI Agent's memory backend. Includes FlairChatMemory (Memory port) and FlairSearch (Tool port).",
   "type": "commonjs",
   "main": "dist/index.js",
@@ -48,7 +48,7 @@
     "langchain"
   ],
   "dependencies": {
-    "@tpsdev-ai/flair-client": "0.16.0",
+    "@tpsdev-ai/flair-client": "0.16.1",
     "zod": "3.25.76"
   },
   "peerDependencies": {

--- a/packages/openclaw-flair/package.json
+++ b/packages/openclaw-flair/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tpsdev-ai/openclaw-flair",
-  "version": "0.16.0",
+  "version": "0.16.1",
   "description": "OpenClaw memory plugin for Flair — agent identity and semantic memory",
   "type": "module",
   "main": "./dist/index.js",
@@ -58,7 +58,7 @@
   },
   "dependencies": {
     "@sinclair/typebox": "0.34.48",
-    "@tpsdev-ai/flair-client": "0.16.0"
+    "@tpsdev-ai/flair-client": "0.16.1"
   },
   "devDependencies": {
     "typescript": "5.9.3"

--- a/packages/pi-flair/package.json
+++ b/packages/pi-flair/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tpsdev-ai/pi-flair",
-  "version": "0.16.0",
+  "version": "0.16.1",
   "description": "Flair memory extension for pi — persistent memory access from within pi sessions",
   "type": "module",
   "main": "dist/index.js",
@@ -21,7 +21,7 @@
     "node": ">=18"
   },
   "dependencies": {
-    "@tpsdev-ai/flair-client": "0.16.0",
+    "@tpsdev-ai/flair-client": "0.16.1",
     "@sinclair/typebox": "0.34.48"
   },
   "license": "Apache-2.0",


### PR DESCRIPTION
v0.16.1 — patch release.

Two PRs merged since v0.16.0, now released:

- **🐛 `flair upgrade` fixes (#543)** — detect an installed-but-stale `flair-mcp` (falls back to the lib probe so older installs that predate `--version` are still detected), suppress the `openclaw-flair` line when openclaw isn't installed (still shown under `--all`), fix a double-space in the restart hint, and add a one-line scope note. Fixes ops-p42n.
- **🤖 Auto-cut GitHub releases from the CHANGELOG on tag (#544)** — every `v*` tag now creates its GitHub release from the matching CHANGELOG section: idempotent, injection-safe (env for tag/version, `--notes-file` for notes), independent of the npm 2FA staging gate.

Neither PR added a CHANGELOG entry at merge time; both are backfilled here under `## [0.16.1]`. This is the first release to exercise the #544 auto-release workflow, which extracts the `[0.16.1]` section and fails loudly if empty — verified non-empty (`changelog-extract 0.16.1` prints both entries, exit 0).

All 7 workspace packages bumped 0.16.0 → 0.16.1 with internal `@tpsdev-ai/*` deps in lockstep + lockfile refreshed. Full release check suite green (dep-ages, workspace-deps, impl-term-leaks, typecheck, build all 7, full test suite 1291/1291).

After merge, Flint pushes the `v0.16.1` tag (triggers auto-release + OIDC stage → 2FA approval).