### PR TITLE
feat(mcp): native /mcp OAuth surface — Model 2 (withMCPAuth-guarded, default-OFF) [ops-b6uk]

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -36,7 +36,7 @@
     },
     {
       "description": "Keep-current allow-list — mirrors scripts/check-dep-ages.mjs DEFAULT_KEEP_CURRENT. These are tightly coupled to Flair runtime correctness (Harper / embedding fixes); we accept the bake-time risk and pull them eagerly, so Renovate skips the cooldown for them too. Keep this list in lockstep with the script and docs/supply-chain-policy.md.",
-      "matchPackageNames": ["@harperfast/harper", "harper-fabric-embeddings"],
+      "matchPackageNames": ["@harperfast/harper", "harper-fabric-embeddings", "@harperfast/oauth"],
       "minimumReleaseAge": "0 days"
     }
   ],

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 ## [Unreleased]
 
+### 🔐 Native `/mcp` OAuth surface — Model 2 (custom `withMCPAuth`-guarded handler), default-OFF (ops-b6uk)
+
+Flair speaks MCP natively over a custom in-process `/mcp` JSON-RPC handler wrapped with `@harperfast/oauth`'s `withMCPAuth` — a per-agent OAuth identity replaces the local `flair-mcp` stdio proxy's key-holding. This is the **Model 2** path (Nathan approved 2026-07-01): a custom handler rather than Harper's native application-MCP profile, so it sidesteps the Harper native-MCP gating gaps and is curated **by construction** (the handler only implements the 9 flair tools — no raw CRUD surface).
+
+**Default-OFF behind `FLAIR_MCP_OAUTH`.** When the flag is unset (the shipped default), flair boots byte-identically: no `/mcp` route is registered, `@harperfast/oauth` is never imported, and the default auth chain (Ed25519) is unchanged. `resources/auth-middleware.ts`, `XAA.ts`, `OAuth.ts`, `config.yaml`, and every delegated handler resource are **untouched**.
+
+- **`resources/mcp-handler.ts`** — a minimal MCP handler (`initialize` / `tools/list` / `tools/call` / `ping`). On `tools/call` it resolves the `withMCPAuth`-verified token `sub` → a flair `Agent` via `Credential(kind:"idp", idpSubject=sub)` → `principalId` (the same identity surface XAA uses), establishes the `request.tpsAgent` scoping context, and delegates to the existing resource handler. An unresolvable `sub` is **denied** — never run as anonymous or admin. JIT-provisioning of an unknown sub is gated behind an explicit trust anchor (`FLAIR_MCP_JIT_PROVISION`, default OFF).
+- **`resources/mcp-tools.ts`** — the 9 curated tools (memory_search/store/get/delete, bootstrap, soul_set/get, flair_workspace_set, flair_orgevent), each a thin wrapper over the existing handler (Memory / SemanticSearch / BootstrapMemories / Soul / WorkspaceState / OrgEvent). Handlers lazy-loaded so the /mcp module graph carries no top-level Harper link. Fixed a soul-keying bug carried from the design-A slice (soul_set now PUTs with `id = agentId:key` so soul_get can find it).
+- **`resources/mcp-oauth.ts`** — registers `server.http(withMCPAuth(mcpHandler), { urlPath: '/mcp' })` **only when the flag is on** (its own dispatch chain; flair's default auth-middleware doesn't run for `/mcp`). `getConfig` pins issuer/resource so iss/aud checks match the minted tokens.
+- **Sherlock's 4 reqs:** (1) short-lived tokens via `mcp.accessTokenTtl` (5–15 min) + refresh; (2) RS256 pinning — the plugin is RS256-only by construction (`none`/HS256 structurally rejected); (3) dual-auth precedence — `/mcp` is OAuth-only on its own chain, Ed25519 never reaches it, they can't collide; (4) DCR authentication via `initialAccessToken` + the JIT trust anchor.
+- **`@harperfast/oauth@2.1.0`** added exact-pinned; on the supply-chain keep-current allow-list (same high-trust `@harperfast/*` owner as `@harperfast/harper`; only loaded when the default-OFF surface is enabled — zero exposure in the default build). Documented in `docs/supply-chain-policy.md` and `docs/notes/mcp-oauth-model2.md`.
+- **Deferred (not shipped):** live `config.yaml` wiring of the AS plugin (kept out to preserve byte-identical flag-OFF; documented for operators) and migrating the homegrown `OAuth.ts`/`XAA.ts` (deprecate-don't-delete — they stay for the Ed25519 path).
+
 ## [0.16.1] - 2026-07-01
 
 ### 🐛 `flair upgrade` — detect an installed-but-stale flair-mcp, drop openclaw noise, fix formatting (#543)

--- a/bun.lock
+++ b/bun.lock
@@ -6,6 +6,7 @@
       "name": "@tpsdev-ai/flair",
       "dependencies": {
         "@harperfast/harper": "5.1.14",
+        "@harperfast/oauth": "2.1.0",
         "@types/js-yaml": "4.0.9",
         "commander": "14.0.3",
         "harper-fabric-embeddings": "0.2.3",
@@ -338,6 +339,8 @@
     "@harperfast/extended-iterable": ["@harperfast/extended-iterable@1.0.3", "", {}, "sha512-sSAYhQca3rDWtQUHSAPeO7axFIUJOI6hn1gjRC5APVE1a90tuyT8f5WIgRsFhhWA7htNkju2veB9eWL6YHi/Lw=="],
 
     "@harperfast/harper": ["@harperfast/harper@5.1.14", "", { "dependencies": { "@aws-sdk/client-s3": "^3.1012.0", "@aws-sdk/lib-storage": "3.1045.0", "@endo/static-module-record": "^1.1.2", "@fastify/autoload": "^6.3.1", "@fastify/compress": "^8.3.1", "@fastify/cors": "^11.2.0", "@fastify/static": "^9.1.3", "@harperfast/extended-iterable": "^1.0.1", "@harperfast/rocksdb-js": "^2.3.0", "@turf/area": "6.5.0", "@turf/boolean-contains": "6.5.0", "@turf/boolean-disjoint": "6.5.0", "@turf/boolean-equal": "6.5.0", "@turf/circle": "6.5.0", "@turf/difference": "6.5.0", "@turf/distance": "6.5.0", "@turf/helpers": "6.5.0", "@turf/length": "6.5.0", "alasql": "4.17.3", "amaro": "^1.1.8", "argon2": "0.44.0", "asn1js": "3.0.10", "busboy": "^1.6.0", "cbor-x": "1.6.4", "chalk": "4.1.2", "chokidar": "^4.0.3", "cli-progress": "3.12.0", "clone": "2.1.2", "dotenv": "^16.4.7", "easy-ocsp": "1.3.1", "fast-glob": "3.3.3", "fastify": "^5.8.2", "fastify-plugin": "^5.1.0", "fs-extra": "11.3.5", "graphql": "^16.10.0", "graphql-http": "^1.22.4", "gunzip-maybe": "1.4.2", "human-readable-ids": "1.0.4", "inquirer": "8.2.7", "is-number": "7.0.0", "joi": "17.13.3", "json-bigint-fixes": "1.1.0", "jsonata": "1.8.7", "jsonwebtoken": "9.0.3", "lmdb": "3.5.5", "lodash": "^4.17.23", "mathjs": "11.12.0", "micromatch": "^4.0.8", "minimist": "1.2.8", "moment": "2.30.1", "mqtt-packet": "~9.0.1", "msgpackr": "^2.0.4", "needle": "3.5.0", "node-forge": "^1.3.1", "node-stream-zip": "1.15.0", "normalize-path": "^3.0.0", "ora": "8.2.0", "ordered-binary": "1.6.1", "papaparse": "5.5.3", "passport": "0.7.0", "passport-http": "0.3.0", "passport-local": "1.0.0", "pino": "8.21.0", "pkijs": "3.4.0", "prompt": "1.3.0", "properties-reader": "2.3.0", "recursive-iterator": "3.3.0", "semver": "7.8.0", "send": "^1.2.0", "ses": "^1.15.0", "stream-chain": "2.2.5", "stream-json": "1.9.1", "structon": "^1.0.7", "systeminformation": "^5.31.4", "tar-fs": "^3.1.2", "ulidx": "0.5.0", "uuid": "11.1.1", "validate.js": "0.13.1", "ws": "8.20.0", "yaml": "2.9.0" }, "optionalDependencies": { "bufferutil": "^4.0.9", "segfault-handler": "^1.3.0", "utf-8-validate": "^5.0.10" }, "peerDependencies": { "@aws-sdk/client-bedrock-runtime": "^3.0.0" }, "optionalPeers": ["@aws-sdk/client-bedrock-runtime"], "bin": { "harper": "dist/bin/harper.js" } }, "sha512-c8zw/Bf4Wvzo4CurSq1PCft923RIObVDHcrSxtJri0kXwEWtRZxX15FgQFyf+x+UwtI9jNBd+O0dl6CwCx6WMA=="],
+
+    "@harperfast/oauth": ["@harperfast/oauth@2.1.0", "", { "dependencies": { "jsonwebtoken": "^9.0.2", "jwks-rsa": "^3.1.0" }, "peerDependencies": { "harper": ">=5.0.0" } }, "sha512-if31SgMret1EQRt09IKxXYnlENA9qoxRbQCdzqE8Y/FFjHZl478GLm4EVZ2x/prPoUdBw3cWuEDhGs6NxGzFFQ=="],
 
     "@harperfast/rocksdb-js": ["@harperfast/rocksdb-js@2.3.0", "", { "dependencies": { "@harperfast/extended-iterable": "1.0.3", "msgpackr": "2.0.4", "ordered-binary": "1.6.1" }, "optionalDependencies": { "@harperfast/rocksdb-js-darwin-arm64": "2.3.0", "@harperfast/rocksdb-js-darwin-x64": "2.3.0", "@harperfast/rocksdb-js-linux-arm64-glibc": "2.3.0", "@harperfast/rocksdb-js-linux-arm64-musl": "2.3.0", "@harperfast/rocksdb-js-linux-x64-glibc": "2.3.0", "@harperfast/rocksdb-js-linux-x64-musl": "2.3.0", "@harperfast/rocksdb-js-win32-arm64": "2.3.0", "@harperfast/rocksdb-js-win32-x64": "2.3.0" }, "bin": { "rocksdb-js": "./bin/rocksdb-js.mjs" } }, "sha512-AE0bIDjRALeqHepzrNN97ZVCCoxi2L63sYWKoD3ZHB4tAmmudguutyIH22XLjUZBSYbizA+8aNye2xcH3FOn0Q=="],
 
@@ -1357,6 +1360,8 @@
 
     "handlebars": ["handlebars@4.7.9", "", { "dependencies": { "minimist": "^1.2.5", "neo-async": "^2.6.2", "source-map": "^0.6.1", "wordwrap": "^1.0.0" }, "optionalDependencies": { "uglify-js": "^3.1.4" }, "bin": { "handlebars": "bin/handlebars" } }, "sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ=="],
 
+    "harper": ["harper@5.1.15", "", { "dependencies": { "@aws-sdk/client-s3": "^3.1012.0", "@aws-sdk/lib-storage": "3.1075.0", "@endo/static-module-record": "^1.1.2", "@fastify/autoload": "^6.3.1", "@fastify/compress": "^8.3.1", "@fastify/cors": "^11.2.0", "@fastify/static": "^9.1.3", "@harperfast/extended-iterable": "^1.0.1", "@harperfast/rocksdb-js": "^2.3.0", "@turf/area": "6.5.0", "@turf/boolean-contains": "6.5.0", "@turf/boolean-disjoint": "6.5.0", "@turf/boolean-equal": "6.5.0", "@turf/circle": "6.5.0", "@turf/difference": "6.5.0", "@turf/distance": "6.5.0", "@turf/helpers": "6.5.0", "@turf/length": "6.5.0", "alasql": "4.17.3", "amaro": "^1.1.8", "argon2": "0.44.0", "asn1js": "3.0.10", "busboy": "^1.6.0", "cbor-x": "1.6.4", "chalk": "4.1.2", "chokidar": "^4.0.3", "cli-progress": "3.12.0", "clone": "2.1.2", "dotenv": "^16.4.7", "easy-ocsp": "1.3.2", "fast-glob": "3.3.3", "fastify": "^5.8.2", "fastify-plugin": "^5.1.0", "fs-extra": "11.3.5", "graphql": "^16.10.0", "graphql-http": "^1.22.4", "gunzip-maybe": "1.4.2", "human-readable-ids": "1.0.4", "inquirer": "8.2.7", "is-number": "7.0.0", "joi": "17.13.4", "json-bigint-fixes": "1.1.0", "jsonata": "1.8.7", "jsonwebtoken": "9.0.3", "lmdb": "3.5.6", "lodash": "^4.17.23", "mathjs": "11.12.0", "micromatch": "^4.0.8", "minimist": "1.2.8", "moment": "2.30.1", "mqtt-packet": "~9.0.1", "msgpackr": "^2.0.4", "needle": "3.5.0", "node-forge": "^1.3.1", "node-stream-zip": "1.15.0", "normalize-path": "^3.0.0", "ora": "8.2.0", "ordered-binary": "1.6.1", "papaparse": "5.5.4", "passport": "0.7.0", "passport-http": "0.3.0", "passport-local": "1.0.0", "pino": "8.21.0", "pkijs": "3.4.0", "prompt": "1.3.0", "properties-reader": "2.3.0", "recursive-iterator": "3.3.0", "semver": "7.8.5", "send": "^1.2.0", "ses": "^1.15.0", "stream-chain": "2.2.5", "stream-json": "1.9.1", "structon": "^1.0.7", "systeminformation": "^5.31.4", "tar-fs": "^3.1.2", "ulidx": "0.5.0", "uuid": "11.1.1", "validate.js": "0.13.1", "ws": "8.21.0", "yaml": "2.9.0" }, "optionalDependencies": { "bufferutil": "^4.0.9", "segfault-handler": "^1.3.0", "utf-8-validate": "^5.0.10" }, "peerDependencies": { "@aws-sdk/client-bedrock-runtime": "^3.0.0" }, "optionalPeers": ["@aws-sdk/client-bedrock-runtime"], "bin": { "harper": "dist/bin/harper.js" } }, "sha512-H02vr0iXKqCTS3yanLqF20vnRdCpUgql5dZ38BpxBZGVgd+Bi45GT/gtgF2Y6fTE+whdcQslwib22Yxrv8t+SQ=="],
+
     "harper-fabric-embeddings": ["harper-fabric-embeddings@0.2.3", "", { "optionalDependencies": { "@node-llama-cpp/linux-arm64": "3.18.1", "@node-llama-cpp/linux-armv7l": "3.18.1", "@node-llama-cpp/linux-x64": "3.18.1", "@node-llama-cpp/mac-arm64-metal": "3.18.1", "@node-llama-cpp/mac-x64": "3.18.1", "@node-llama-cpp/win-arm64": "3.18.1", "@node-llama-cpp/win-x64": "3.18.1" } }, "sha512-25F1xzRTJ+19NlDiMI0RLF47u4Fwd5Ve/V03q06kJjCioqvEc2yrAASQ3NY4O+LJDU9rNq9WQivFeU+9JKt4IA=="],
 
     "has-flag": ["has-flag@4.0.0", "", {}, "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="],
@@ -1525,6 +1530,8 @@
 
     "jwa": ["jwa@2.0.1", "", { "dependencies": { "buffer-equal-constant-time": "^1.0.1", "ecdsa-sig-formatter": "1.0.11", "safe-buffer": "^5.0.1" } }, "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg=="],
 
+    "jwks-rsa": ["jwks-rsa@3.2.2", "", { "dependencies": { "@types/jsonwebtoken": "^9.0.4", "debug": "^4.3.4", "jose": "^4.15.4", "limiter": "^1.1.5", "lru-memoizer": "^2.2.0" } }, "sha512-BqTyEDV+lS8F2trk3A+qJnxV5Q9EqKCBJOPti3W97r7qTympCZjb7h2X6f2kc+0K3rsSTY1/6YG2eaXKoj497w=="],
+
     "jws": ["jws@4.0.1", "", { "dependencies": { "jwa": "^2.0.1", "safe-buffer": "^5.0.1" } }, "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA=="],
 
     "keyv": ["keyv@5.6.0", "", { "dependencies": { "@keyv/serialize": "^1.1.1" } }, "sha512-CYDD3SOtsHtyXeEORYRx2qBtpDJFjRTGXUtmNEMGyzYOKj1TE3tycdlho7kA1Ufx9OYWZzg52QFBGALTirzDSw=="],
@@ -1547,6 +1554,8 @@
 
     "lighthouse-logger": ["lighthouse-logger@1.4.2", "", { "dependencies": { "debug": "^2.6.9", "marky": "^1.2.2" } }, "sha512-gPWxznF6TKmUHrOQjlVo2UbaL2EJ71mb2CCeRs/2qBpi4L/g4LUVc9+3lKQ6DTUZwJswfM7ainGrLO1+fOqa2g=="],
 
+    "limiter": ["limiter@1.1.5", "", {}, "sha512-FWWMIEOxz3GwUI4Ts/IvgVy6LPvoMPgjMdQ185nN6psJyBJ4yOpzqm695/h5umdLJg2vW3GR5iG11MAkR2AzJA=="],
+
     "linkedom": ["linkedom@0.18.12", "", { "dependencies": { "css-select": "^5.1.0", "cssom": "^0.5.0", "html-escaper": "^3.0.3", "htmlparser2": "^10.0.0", "uhyphen": "^0.2.0" }, "peerDependencies": { "canvas": ">= 2" }, "optionalPeers": ["canvas"] }, "sha512-jalJsOwIKuQJSeTvsgzPe9iJzyfVaEJiEXl+25EkKevsULHvMJzpNqwvj1jOESWdmgKDiXObyjOYwlUqG7wo1Q=="],
 
     "linkify-it": ["linkify-it@5.0.0", "", { "dependencies": { "uc.micro": "^2.0.0" } }, "sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ=="],
@@ -1554,6 +1563,8 @@
     "lmdb": ["lmdb@3.5.5", "", { "dependencies": { "@harperfast/extended-iterable": "^1.0.3", "msgpackr": "^1.11.2", "node-addon-api": "^6.1.0", "node-gyp-build-optional-packages": "5.2.2", "ordered-binary": "^1.5.3", "weak-lru-cache": "^1.2.2" }, "optionalDependencies": { "@lmdb/lmdb-darwin-arm64": "3.5.5", "@lmdb/lmdb-darwin-x64": "3.5.5", "@lmdb/lmdb-linux-arm": "3.5.5", "@lmdb/lmdb-linux-arm64": "3.5.5", "@lmdb/lmdb-linux-x64": "3.5.5", "@lmdb/lmdb-win32-arm64": "3.5.5", "@lmdb/lmdb-win32-x64": "3.5.5" }, "bin": { "download-lmdb-prebuilds": "bin/download-prebuilds.js" } }, "sha512-e2q1RtHdJoDaQQNMJ55wJnD5BqpvzoJIEL3NBxfZXNBjYxY0QjCh3RSL/sqmi+y9l97cERdO4WwGFfYYVft1fA=="],
 
     "lodash": ["lodash@4.17.23", "", {}, "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w=="],
+
+    "lodash.clonedeep": ["lodash.clonedeep@4.5.0", "", {}, "sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ=="],
 
     "lodash.identity": ["lodash.identity@3.0.0", "", {}, "sha512-AupTIzdLQxJS5wIYUQlgGyk2XRTfGXA+MCghDHqZk0pzUNYvd3EESS6dkChNauNYVIutcb0dfHw1ri9Q1yPV8Q=="],
 
@@ -1584,6 +1595,8 @@
     "loose-envify": ["loose-envify@1.4.0", "", { "dependencies": { "js-tokens": "^3.0.0 || ^4.0.0" }, "bin": { "loose-envify": "cli.js" } }, "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q=="],
 
     "lru-cache": ["lru-cache@11.2.7", "", {}, "sha512-aY/R+aEsRelme17KGQa/1ZSIpLpNYYrhcrepKTZgE+W3WM16YMCaPwOHLHsmopZHELU0Ojin1lPVxKR0MihncA=="],
+
+    "lru-memoizer": ["lru-memoizer@2.3.0", "", { "dependencies": { "lodash.clonedeep": "^4.5.0", "lru-cache": "6.0.0" } }, "sha512-GXn7gyHAMhO13WSKrIiNfztwxodVsP8IoZ3XfrJV4yH2x0/OeTO/FIaAHTY5YekdGgW94njfuKmyyt1E0mR6Ug=="],
 
     "luxon": ["luxon@3.4.4", "", {}, "sha512-zobTr7akeGHnv7eBOXcRgMeCP6+uyYsczwmeRCauvpvaAltgNyTbLH/+VaEAPUeWBT+1GuNmz4wC/6jtQzbbVA=="],
 
@@ -2425,6 +2438,20 @@
 
     "gunzip-maybe/pumpify": ["pumpify@1.5.1", "", { "dependencies": { "duplexify": "^3.6.0", "inherits": "^2.0.3", "pump": "^2.0.0" } }, "sha512-oClZI37HvuUJJxSKKrC17bZ9Cu0ZYhEAGPsPUy9KlMUmv9dKX2o77RUmq7f3XjIxbwyGwYzbzQ1L2Ks8sIradQ=="],
 
+    "harper/@aws-sdk/lib-storage": ["@aws-sdk/lib-storage@3.1075.0", "", { "dependencies": { "@smithy/core": "^3.24.6", "@smithy/types": "^4.14.3", "buffer": "5.6.0", "events": "3.3.0", "stream-browserify": "3.0.0", "tslib": "^2.6.2" }, "peerDependencies": { "@aws-sdk/client-s3": "^3.1075.0" } }, "sha512-Npdac3/Fv994iCdFFeqloPel+95Zv6dRiRUpfey6W/CqpB/QdnYP60U4YBhBgJj6V5020Pm3ad0HV4WzCE5hHQ=="],
+
+    "harper/easy-ocsp": ["easy-ocsp@1.3.2", "", { "dependencies": { "asn1js": "^3.0.5", "pkijs": "^3.2.4" } }, "sha512-4TonRbfynC2IRMF9gqFA1bEEF41rp0oPJrPYf8YIBibc2QVbSSDmBbKL0+1U2nVrZ4siGA18SIKhm8B9jLGK+A=="],
+
+    "harper/joi": ["joi@17.13.4", "", { "dependencies": { "@hapi/hoek": "^9.3.0", "@hapi/topo": "^5.1.0", "@sideway/address": "^4.1.5", "@sideway/formula": "^3.0.1", "@sideway/pinpoint": "^2.0.0" } }, "sha512-1RuuER6kmt8K8I3nIWvPZKi5RQCb568ZPyY4Pwjlua+yo+63ZTmIwxLZH0heBmiKN4uxjvCiarDrjaeH84xicQ=="],
+
+    "harper/lmdb": ["lmdb@3.5.6", "", { "dependencies": { "@harperfast/extended-iterable": "^1.0.3", "msgpackr": "^1.11.2", "node-addon-api": "^6.1.0", "node-gyp-build-optional-packages": "5.2.2", "ordered-binary": "^1.5.3", "weak-lru-cache": "^1.2.2" }, "optionalDependencies": { "@lmdb/lmdb-darwin-arm64": "3.5.6", "@lmdb/lmdb-darwin-x64": "3.5.6", "@lmdb/lmdb-linux-arm": "3.5.6", "@lmdb/lmdb-linux-arm64": "3.5.6", "@lmdb/lmdb-linux-x64": "3.5.6", "@lmdb/lmdb-win32-arm64": "3.5.6", "@lmdb/lmdb-win32-x64": "3.5.6" }, "bin": { "download-lmdb-prebuilds": "bin/download-prebuilds.js" } }, "sha512-j3uE8ReKNyUWDjhfEFSJqE/1DLtfTR5Z8yFzVHvBjAk37wNg7HdScjcv8ttPHRvrdgPQMPWxFFI0SsdBzI5lBw=="],
+
+    "harper/papaparse": ["papaparse@5.5.4", "", {}, "sha512-SwzWD9gl/ElwYLCI0nUja1mFJzjq2D8ziShfNBa7zCHzkOozeOGDwHWQ+tvCzEZcewecWZ5U7kUopDnG+DFYEQ=="],
+
+    "harper/semver": ["semver@7.8.5", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA=="],
+
+    "harper/ws": ["ws@8.21.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g=="],
+
     "htmlparser2/entities": ["entities@7.0.1", "", {}, "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA=="],
 
     "http-proxy-agent/agent-base": ["agent-base@7.1.4", "", {}, "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ=="],
@@ -2447,6 +2474,8 @@
 
     "jszip/readable-stream": ["readable-stream@2.3.8", "", { "dependencies": { "core-util-is": "~1.0.0", "inherits": "~2.0.3", "isarray": "~1.0.0", "process-nextick-args": "~2.0.0", "safe-buffer": "~5.1.1", "string_decoder": "~1.1.1", "util-deprecate": "~1.0.1" } }, "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA=="],
 
+    "jwks-rsa/jose": ["jose@4.15.9", "", {}, "sha512-1vUQX+IdDMVPj4k8kOxgUqlcK518yluMuGZwqlr44FS1ppZB/5GWh4rZG89erpOBOJjU/OBsnCVFfapsRz6nEA=="],
+
     "libsignal/protobufjs": ["protobufjs@6.8.8", "", { "dependencies": { "@protobufjs/aspromise": "^1.1.2", "@protobufjs/base64": "^1.1.2", "@protobufjs/codegen": "^2.0.4", "@protobufjs/eventemitter": "^1.1.0", "@protobufjs/fetch": "^1.1.0", "@protobufjs/float": "^1.0.2", "@protobufjs/inquire": "^1.1.0", "@protobufjs/path": "^1.1.2", "@protobufjs/pool": "^1.1.0", "@protobufjs/utf8": "^1.1.0", "@types/long": "^4.0.0", "@types/node": "^10.1.0", "long": "^4.0.0" }, "bin": { "pbjs": "bin/pbjs", "pbts": "bin/pbts" } }, "sha512-AAmHtD5pXgZfi7GMpllpO3q1Xw1OYldr+dMUlAnffGTAhqkg72WdmSY71uKBF/JuyiKs8psYbtKrhi0ASCD8qw=="],
 
     "light-my-request/cookie": ["cookie@1.1.1", "", {}, "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ=="],
@@ -2462,6 +2491,8 @@
     "log-symbols/chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
 
     "log-symbols/is-unicode-supported": ["is-unicode-supported@1.3.0", "", {}, "sha512-43r2mRvz+8JRIKnWJ+3j8JtjRKZ6GmjzfaE/qiBJnikNnYv/6bagRJ1kUhNk8R5EX/GkobD+r+sfxCPJsiKBLQ=="],
+
+    "lru-memoizer/lru-cache": ["lru-cache@6.0.0", "", { "dependencies": { "yallist": "^4.0.0" } }, "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA=="],
 
     "metro/@babel/code-frame": ["@babel/code-frame@7.29.7", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.29.7", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw=="],
 
@@ -2785,6 +2816,28 @@
 
     "gunzip-maybe/pumpify/pump": ["pump@2.0.1", "", { "dependencies": { "end-of-stream": "^1.1.0", "once": "^1.3.1" } }, "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA=="],
 
+    "harper/@aws-sdk/lib-storage/@smithy/core": ["@smithy/core@3.28.0", "", { "dependencies": { "@smithy/types": "^4.15.0", "tslib": "^2.6.2" } }, "sha512-N/LoLG8pZ1zv5cIWpdF6vmSjtZtXKK9G0OqT5yYCOZU+CzPq1+nYA95VoKJBGWRScs7YbMugZ7lZx8Fj1vdHoA=="],
+
+    "harper/@aws-sdk/lib-storage/@smithy/types": ["@smithy/types@4.15.0", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-Z5TAOxygoFvybJV3igo5SloFflSokHx2hu1eFA+DxDTcn+FtKxUSui+rbTRG1pAafMA888Z3MVvCWUuvCrTXjg=="],
+
+    "harper/lmdb/@lmdb/lmdb-darwin-arm64": ["@lmdb/lmdb-darwin-arm64@3.5.6", "", { "os": "darwin", "cpu": "arm64" }, "sha512-mY5FG4TjPAkY4P0w+OhHaUka5mDh2TX2WKYIwuKzJ1zeW3VvRgxdam/lGJTquI+bthTx5CSHDW+BAQCnNAzkEA=="],
+
+    "harper/lmdb/@lmdb/lmdb-darwin-x64": ["@lmdb/lmdb-darwin-x64@3.5.6", "", { "os": "darwin", "cpu": "x64" }, "sha512-foa+pwitysO8k+xhs7psBFfTKnVgR69NlZRRTHaFVDqphh7AdGpLeyRzKw/ofatr/sN6TiHRRW6mmop0ZrrppQ=="],
+
+    "harper/lmdb/@lmdb/lmdb-linux-arm": ["@lmdb/lmdb-linux-arm@3.5.6", "", { "os": "linux", "cpu": "arm" }, "sha512-QR4YRyR5h5Z8eGXrNQjiyo2NNDfqi3tCc9dQG5Is1blCt+qWw1ZoBWhlWAr5d+jshkifMIJjVHzHGKbkKzF8Tw=="],
+
+    "harper/lmdb/@lmdb/lmdb-linux-arm64": ["@lmdb/lmdb-linux-arm64@3.5.6", "", { "os": "linux", "cpu": "arm64" }, "sha512-HmiyFFdJa38s1heCMSooSPaBSFTHJ3C+ERPp28xAPlDX1YiALJVOgbry065nXd8Y7KISWjnw05zpG1RX8IfftA=="],
+
+    "harper/lmdb/@lmdb/lmdb-linux-x64": ["@lmdb/lmdb-linux-x64@3.5.6", "", { "os": "linux", "cpu": "x64" }, "sha512-ADzCuCF2cTNiX9kDScqcz1fjnAkxPpQNneV3KFTdV3wWtVlI2sTGzySoMTgDpinkMMFj1NTJlxA6XR8fwc4hlA=="],
+
+    "harper/lmdb/@lmdb/lmdb-win32-arm64": ["@lmdb/lmdb-win32-arm64@3.5.6", "", { "os": "win32", "cpu": "arm64" }, "sha512-J7A9aEQsQiv0TYtBGL7NDIPp2lOS8nnl+zm4sWZm1xlsTTaQ4PgD096Adzdrk27rw3UxCkDXdCUa4ax41oztBQ=="],
+
+    "harper/lmdb/@lmdb/lmdb-win32-x64": ["@lmdb/lmdb-win32-x64@3.5.6", "", { "os": "win32", "cpu": "x64" }, "sha512-1g7G0knRX2iV/voDu54yxrGqw5Dk0w2oIYb7dgJq8IkOi+m7wbD8Q3QpPFjh0C01G58S88dqGn03len6UPCXsg=="],
+
+    "harper/lmdb/msgpackr": ["msgpackr@1.11.12", "", { "optionalDependencies": { "msgpackr-extract": "^3.0.2" } }, "sha512-RBdJ1Un7yGlXWajrkxcSa93nvQ0w4zBf60c0yYv7YtBelP8H2FA7XsfBbMHtXKXUMUxH7zV3Zuozh+kUQWhHvg=="],
+
+    "harper/lmdb/node-addon-api": ["node-addon-api@6.1.0", "", {}, "sha512-+eawOlIgy680F0kBzPUNFhMZGtJ1YmqM6l4+Crf4IkImjYrO/mqPwRMh352g23uIaQKFItcQ64I7KMaJxHgAVA=="],
+
     "inquirer/ora/bl": ["bl@4.1.0", "", { "dependencies": { "buffer": "^5.5.0", "inherits": "^2.0.4", "readable-stream": "^3.4.0" } }, "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w=="],
 
     "inquirer/ora/is-interactive": ["is-interactive@1.0.0", "", {}, "sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w=="],
@@ -2810,6 +2863,8 @@
     "lighthouse-logger/debug/ms": ["ms@2.0.0", "", {}, "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="],
 
     "lmdb/msgpackr/msgpackr-extract": ["msgpackr-extract@3.0.3", "", { "dependencies": { "node-gyp-build-optional-packages": "5.2.2" }, "optionalDependencies": { "@msgpackr-extract/msgpackr-extract-darwin-arm64": "3.0.3", "@msgpackr-extract/msgpackr-extract-darwin-x64": "3.0.3", "@msgpackr-extract/msgpackr-extract-linux-arm": "3.0.3", "@msgpackr-extract/msgpackr-extract-linux-arm64": "3.0.3", "@msgpackr-extract/msgpackr-extract-linux-x64": "3.0.3", "@msgpackr-extract/msgpackr-extract-win32-x64": "3.0.3" }, "bin": { "download-msgpackr-prebuilds": "bin/download-prebuilds.js" } }, "sha512-P0efT1C9jIdVRefqjzOQ9Xml57zpOXnIuS+csaB4MdZbTdmGDLo8XhzBG1N7aO11gKDDkJvBLULeFTo46wwreA=="],
+
+    "lru-memoizer/lru-cache/yallist": ["yallist@4.0.0", "", {}, "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="],
 
     "metro-babel-transformer/hermes-parser/hermes-estree": ["hermes-estree@0.35.0", "", {}, "sha512-xVx5Opwy8Oo1I5yGpVRhCvWL/iV3M+ylksSKVNlxxD90cpDpR/AR1jLYqK8HWihm065a6UI3HeyAmYzwS8NOOg=="],
 
@@ -3019,6 +3074,8 @@
 
     "axios/form-data/mime-types/mime-db": ["mime-db@1.52.0", "", {}, "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="],
 
+    "harper/lmdb/msgpackr/msgpackr-extract": ["msgpackr-extract@3.0.3", "", { "dependencies": { "node-gyp-build-optional-packages": "5.2.2" }, "optionalDependencies": { "@msgpackr-extract/msgpackr-extract-darwin-arm64": "3.0.3", "@msgpackr-extract/msgpackr-extract-darwin-x64": "3.0.3", "@msgpackr-extract/msgpackr-extract-linux-arm": "3.0.3", "@msgpackr-extract/msgpackr-extract-linux-arm64": "3.0.3", "@msgpackr-extract/msgpackr-extract-linux-x64": "3.0.3", "@msgpackr-extract/msgpackr-extract-win32-x64": "3.0.3" }, "bin": { "download-msgpackr-prebuilds": "bin/download-prebuilds.js" } }, "sha512-P0efT1C9jIdVRefqjzOQ9Xml57zpOXnIuS+csaB4MdZbTdmGDLo8XhzBG1N7aO11gKDDkJvBLULeFTo46wwreA=="],
+
     "inquirer/ora/bl/buffer": ["buffer@5.7.1", "", { "dependencies": { "base64-js": "^1.3.1", "ieee754": "^1.1.13" } }, "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ=="],
 
     "inquirer/ora/bl/readable-stream": ["readable-stream@3.6.2", "", { "dependencies": { "inherits": "^2.0.3", "string_decoder": "^1.1.1", "util-deprecate": "^1.0.1" } }, "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA=="],
@@ -3150,6 +3207,18 @@
     "@react-native/codegen/yargs/cliui/wrap-ansi/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
 
     "@react-native/dev-middleware/serve-static/send/debug/ms": ["ms@2.0.0", "", {}, "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="],
+
+    "harper/lmdb/msgpackr/msgpackr-extract/@msgpackr-extract/msgpackr-extract-darwin-arm64": ["@msgpackr-extract/msgpackr-extract-darwin-arm64@3.0.3", "", { "os": "darwin", "cpu": "arm64" }, "sha512-QZHtlVgbAdy2zAqNA9Gu1UpIuI8Xvsd1v8ic6B2pZmeFnFcMWiPLfWXh7TVw4eGEZ/C9TH281KwhVoeQUKbyjw=="],
+
+    "harper/lmdb/msgpackr/msgpackr-extract/@msgpackr-extract/msgpackr-extract-darwin-x64": ["@msgpackr-extract/msgpackr-extract-darwin-x64@3.0.3", "", { "os": "darwin", "cpu": "x64" }, "sha512-mdzd3AVzYKuUmiWOQ8GNhl64/IoFGol569zNRdkLReh6LRLHOXxU4U8eq0JwaD8iFHdVGqSy4IjFL4reoWCDFw=="],
+
+    "harper/lmdb/msgpackr/msgpackr-extract/@msgpackr-extract/msgpackr-extract-linux-arm": ["@msgpackr-extract/msgpackr-extract-linux-arm@3.0.3", "", { "os": "linux", "cpu": "arm" }, "sha512-fg0uy/dG/nZEXfYilKoRe7yALaNmHoYeIoJuJ7KJ+YyU2bvY8vPv27f7UKhGRpY6euFYqEVhxCFZgAUNQBM3nw=="],
+
+    "harper/lmdb/msgpackr/msgpackr-extract/@msgpackr-extract/msgpackr-extract-linux-arm64": ["@msgpackr-extract/msgpackr-extract-linux-arm64@3.0.3", "", { "os": "linux", "cpu": "arm64" }, "sha512-YxQL+ax0XqBJDZiKimS2XQaf+2wDGVa1enVRGzEvLLVFeqa5kx2bWbtcSXgsxjQB7nRqqIGFIcLteF/sHeVtQg=="],
+
+    "harper/lmdb/msgpackr/msgpackr-extract/@msgpackr-extract/msgpackr-extract-linux-x64": ["@msgpackr-extract/msgpackr-extract-linux-x64@3.0.3", "", { "os": "linux", "cpu": "x64" }, "sha512-cvwNfbP07pKUfq1uH+S6KJ7dT9K8WOE4ZiAcsrSes+UY55E/0jLYc+vq+DO7jlmqRb5zAggExKm0H7O/CBaesg=="],
+
+    "harper/lmdb/msgpackr/msgpackr-extract/@msgpackr-extract/msgpackr-extract-win32-x64": ["@msgpackr-extract/msgpackr-extract-win32-x64@3.0.3", "", { "os": "win32", "cpu": "x64" }, "sha512-x0fWaQtYp4E6sktbsdAqnehxDgEc/VwM7uLsRCYWaiGu0ykYdZPiS8zCWdnjHwyiumousxfBm4SO31eXqwEZhQ=="],
 
     "metro/yargs/cliui/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 

--- a/docs/notes/mcp-oauth-model2.md
+++ b/docs/notes/mcp-oauth-model2.md
@@ -1,0 +1,113 @@
+# Native /mcp OAuth surface — Model 2 (experimental, default-OFF)
+
+> **Status: experimental, opt-in, DEFAULT-OFF.** Gated behind `FLAIR_MCP_OAUTH`.
+> When the flag is unset, flair boots byte-identically to before — no `/mcp`
+> route, no authorization-server load, no change to the default auth chain.
+> Do NOT enable in production until Sherlock signs off on live enablement.
+
+This is the **Model 2** native-MCP path: a custom in-process `/mcp` JSON-RPC
+handler guarded by `@harperfast/oauth`'s `withMCPAuth`, serving the 9 curated
+flair tools with a per-agent OAuth identity. It is distinct from the
+native-application-MCP surface (design A / `FLAIR_MCP_ENABLED`); Model 2 does not
+use Harper's native MCP transport, so it is not blocked by the Harper native-MCP
+gating gaps.
+
+## What it is
+
+- `resources/mcp-handler.ts` — a minimal MCP (JSON-RPC 2.0) handler over
+  Streamable HTTP: `initialize` / `tools/list` / `tools/call` / `ping`. On
+  `tools/call` it resolves the verified token `sub` → a flair `Agent`, then
+  dispatches to the curated tool.
+- `resources/mcp-tools.ts` — the 9 curated tools (memory_search, memory_store,
+  memory_get, memory_delete, bootstrap, soul_set, soul_get, flair_workspace_set,
+  flair_orgevent), each a thin wrapper over the existing resource handler
+  (Memory / SemanticSearch / BootstrapMemories / Soul / WorkspaceState /
+  OrgEvent). No raw CRUD surface — the only path to the datastore through `/mcp`
+  is one of these 9 semantic tools. Curated **by construction**.
+- `resources/mcp-oauth.ts` — registers `server.http(withMCPAuth(mcpHandler),
+  { urlPath: '/mcp' })` **only when `FLAIR_MCP_OAUTH` is on.** `/mcp` runs on its
+  own dispatch chain; flair's default auth-middleware does not run for it.
+- `resources/mcp-oauth-flag.ts` — the flag + issuer/resource config helpers.
+
+## The sub → Agent mapping (identity)
+
+`withMCPAuth` verifies the RS256 JWT and sets `request.mcp = { sub, client_id,
+aud, scope }`. The handler maps `sub` → a flair `Agent` id:
+
+1. Look up `Credential` where `kind === "idp"` AND `idpSubject === sub` → its
+   `principalId` is the Agent id. (Same credential surface XAA's ID-JAG path
+   uses — one identity model.)
+2. If no mapping and `FLAIR_MCP_JIT_PROVISION` is on, JIT-provision a
+   non-admin `Agent` + `Credential(kind:"idp")` from the sub.
+3. Otherwise **deny** — an unresolvable sub never runs as anonymous or admin.
+
+The resolved agent is set as `request.tpsAgent` on a flair-shaped delegation
+context, so the wrapped handler scopes to the verified agent exactly as an
+Ed25519-signed REST call would. Identity always comes from the resolved agent,
+never from the tool arguments (no forging of agentId / authorId).
+
+## Enabling (operator checklist)
+
+1. **Install the AS plugin** — add `@harperfast/oauth` (already an exact-pinned
+   dependency) and declare it in `config.yaml`:
+
+   ```yaml
+   '@harperfast/oauth':
+     package: '@harperfast/oauth'
+     providers:
+       github:
+         clientId: ${OAUTH_GITHUB_CLIENT_ID}
+         clientSecret: ${OAUTH_GITHUB_CLIENT_SECRET}
+     mcp:
+       enabled: true
+       issuer: ${FLAIR_MCP_ISSUER}          # pin to your public origin — REQUIRED
+       resource: ${FLAIR_MCP_ISSUER}/mcp     # RFC-8707 audience the /mcp token binds to
+       accessTokenTtl: 900                    # 5–15 min (Sherlock req 1) — short-lived
+       dynamicClientRegistration:
+         initialAccessToken: ${FLAIR_MCP_DCR_TOKEN}   # gate DCR (Sherlock req 4)
+         allowedRedirectUriHosts:
+           - claude.com
+       signingKeyPem: ${FLAIR_MCP_SIGNING_KEY_PEM}    # pin in clusters
+   ```
+
+   The `config.yaml` block is intentionally NOT committed to the live config in
+   this slice — adding it changes boot behavior, which would break the
+   default-OFF / byte-identical contract. An operator adds it deliberately when
+   turning the surface on.
+
+2. **Set the env:**
+   - `FLAIR_MCP_OAUTH=1` — turns on the `/mcp` route registration.
+   - `FLAIR_MCP_ISSUER=https://your-public-origin` (or `FLAIR_PUBLIC_URL`).
+   - `FLAIR_MCP_JIT_PROVISION=1` — ONLY if you want unknown subjects
+     auto-provisioned (default OFF; pre-provision Agent+Credential otherwise).
+
+3. **Restart flair.** `/mcp` mounts, OAuth-guarded.
+
+## Sherlock's 4 requirements — how they are met
+
+1. **Token lifetime.** `mcp.accessTokenTtl: 900` (5–15 min) in the AS config +
+   the standard OAuth refresh flow (the plugin rotates refresh tokens on use).
+   `withMCPAuth` validates `exp` strictly. Documented as a required config value,
+   not a default (the plugin's own default is 1h — too long).
+2. **RS256 pinning.** The `@harperfast/oauth` plugin mints and verifies RS256-only
+   (per its docs: "Signing algorithms other than RS256 … are not supported"), so
+   `none`/HS256 confusion is structurally rejected — the verifier only knows
+   RS256. No configurable `alg` to widen.
+3. **Dual-auth precedence.** `/mcp` is OAuth-only on its own urlPath chain;
+   flair's default chain (Ed25519) never runs for `/mcp`, and the OAuth Bearer
+   never reaches the default chain. They cannot collide on the same request —
+   `/mcp` sees only the token, every other path sees only Ed25519/Basic. There is
+   no path that carries both.
+4. **DCR authentication.** `mcp.dynamicClientRegistration.initialAccessToken`
+   gates `/oauth/mcp/register` — open DCR would let an attacker register as any
+   agent. On the resolution side, JIT-provisioning of an unknown sub is itself
+   gated (`FLAIR_MCP_JIT_PROVISION`, default OFF) — a second explicit trust anchor.
+
+## Deferred (not in this slice)
+
+- Live `config.yaml` wiring of the `@harperfast/oauth` plugin (kept out to
+  preserve the byte-identical flag-OFF contract; documented above for operators).
+- Migrating the homegrown `OAuth.ts` / `XAA.ts` opaque-token AS to the plugin.
+  Per Kern: deprecate-don't-delete — they stay for the Ed25519/signed-REST path.
+  XAA's JIT-provisioning is kept; the Model-2 handler reuses the same
+  `Credential(kind:"idp")` surface.

--- a/docs/supply-chain-policy.md
+++ b/docs/supply-chain-policy.md
@@ -25,6 +25,7 @@ Some deps are tightly coupled to Flair's runtime correctness — Harper bug fixe
 |---------|------------------|
 | `@harperfast/harper` | Foundational. Vector-index and HNSW correctness fixes land here; we want them ASAP. High-volume upstream, fast detection if compromised. |
 | `harper-fabric-embeddings` | Embedding model loader. Coupled to Harper version. Same trust-and-volume reasoning. |
+| `@harperfast/oauth` | Same high-trust `@harperfast/*` owner as `@harperfast/harper`. Used ONLY by the **default-OFF** native-MCP OAuth surface (`FLAIR_MCP_OAUTH`), which dynamically imports it only when the flag is on — it is **not loaded in the shipped default build**, so bake-time exposure is zero until an operator explicitly opts in. Pinned to the exact version whose `withMCPAuth` API the surface was built against; the API surface (not a floating range) is what we depend on. |
 
 Adding to this list is a deliberate decision. The bar:
 - The upstream is well-known and high-volume (gets eyeballs fast).
@@ -74,7 +75,7 @@ Only Nathan publishes to npm (per the existing MFA boundary). Flint preps the re
 
 ### `.github/renovate.json` — deliberate, cooldown-gated update proposals
 
-Renovate opens PRs to propose dependency updates so we don't drift behind upstream indefinitely — but on our terms, not the registry's. It is configured to never auto-merge (`automerge: false`), to pin (`rangeStrategy: "pin"`, consistent with §2), and to respect the bake-time cooldown (`minimumReleaseAge: "7 days"`, matching `FLAIR_DEP_MIN_AGE_DAYS` in `check-dep-ages.mjs`) so it only proposes versions that have already cleared the detection window. Non-major updates are grouped; majors land as isolated PRs. The keep-current allow-list (`@harperfast/harper`, `harper-fabric-embeddings`) mirrors the script's `DEFAULT_KEEP_CURRENT` — keep the two in lockstep when either changes. Vulnerability alerts bypass the cooldown. Every Renovate PR still runs the full CI suite (including the bake-time and workspace-deps gates) and is K&S-reviewed before merge.
+Renovate opens PRs to propose dependency updates so we don't drift behind upstream indefinitely — but on our terms, not the registry's. It is configured to never auto-merge (`automerge: false`), to pin (`rangeStrategy: "pin"`, consistent with §2), and to respect the bake-time cooldown (`minimumReleaseAge: "7 days"`, matching `FLAIR_DEP_MIN_AGE_DAYS` in `check-dep-ages.mjs`) so it only proposes versions that have already cleared the detection window. Non-major updates are grouped; majors land as isolated PRs. The keep-current allow-list (`@harperfast/harper`, `harper-fabric-embeddings`, `@harperfast/oauth`) mirrors the script's `DEFAULT_KEEP_CURRENT` — keep the two in lockstep when either changes. Vulnerability alerts bypass the cooldown. Every Renovate PR still runs the full CI suite (including the bake-time and workspace-deps gates) and is K&S-reviewed before merge.
 
 ### `scripts/check-workspace-deps.mjs` (already shipped, PR #368)
 

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
   },
   "dependencies": {
     "@harperfast/harper": "5.1.14",
+    "@harperfast/oauth": "2.1.0",
     "@types/js-yaml": "4.0.9",
     "commander": "14.0.3",
     "harper-fabric-embeddings": "0.2.3",

--- a/resources/mcp-handler.ts
+++ b/resources/mcp-handler.ts
@@ -1,0 +1,272 @@
+/**
+ * mcp-handler.ts — the Model-2 custom MCP protocol handler.
+ *
+ * A minimal in-process MCP (JSON-RPC 2.0) handler serving the 9 curated flair
+ * tools over Streamable HTTP. It is wrapped by `@harperfast/oauth`'s
+ * `withMCPAuth` (see mcp-oauth.ts), which fails closed on any missing/invalid
+ * Bearer token BEFORE this handler runs and, on success, sets
+ * `request.mcp = { sub, client_id, aud, scope }` (verified RS256 JWT claims).
+ *
+ * ── This handler's job ──────────────────────────────────────────────────────
+ *   1. Parse the JSON-RPC request (initialize / tools/list / tools/call / ping).
+ *   2. For tools/call: resolve `request.mcp.sub` → a flair `Agent` id via the
+ *      `Credential(kind:"idp", idpSubject=sub)` lookup, JIT-provisioning a
+ *      Principal+Credential the first time IF the trust anchor allows it.
+ *   3. Establish the flair scoping context and invoke the tool, which delegates
+ *      to the existing resource handler (per-agent scoping enforced there).
+ *
+ * /mcp is its OWN dispatch chain (urlPath subroute) — flair's default
+ * auth-middleware does NOT run here, so this handler is solely responsible for
+ * turning the verified token into a scoped flair identity.
+ *
+ * ── Return shape ────────────────────────────────────────────────────────────
+ * Harper HTTP listeners return `{ status, body, headers? }`. MCP messages are
+ * JSON-RPC 2.0, so we serialize the JSON-RPC response object as the body.
+ */
+
+import { databases } from "@harperfast/harper";
+import { randomBytes } from "node:crypto";
+import { TOOLS, listToolDefs, type ResolvedAgent } from "./mcp-tools.js";
+
+// The MCP protocol revision we implement (initialize handshake).
+const PROTOCOL_VERSION = "2025-06-18";
+
+const JSON_HEADERS = { "content-type": "application/json" };
+
+// ─── JSON-RPC helpers ────────────────────────────────────────────────────────
+
+function rpcResult(id: any, result: any) {
+  return { status: 200, headers: JSON_HEADERS, body: JSON.stringify({ jsonrpc: "2.0", id, result }) };
+}
+
+function rpcError(id: any, code: number, message: string, httpStatus = 200) {
+  return {
+    status: httpStatus,
+    headers: JSON_HEADERS,
+    body: JSON.stringify({ jsonrpc: "2.0", id: id ?? null, error: { code, message } }),
+  };
+}
+
+// ─── sub → Agent resolution ─────────────────────────────────────────────────
+
+/**
+ * Should an unknown IdP subject be JIT-provisioned into a new Principal+
+ * Credential? Gated by an explicit, auditable trust anchor — an OPEN JIT-provision
+ * means anyone who can obtain a token (which requires passing the AS's own login
+ * + DCR gate) auto-materializes a flair agent. That is the Sherlock req-4 boundary
+ * on the resolution side: provisioning is a deliberate decision, not a default.
+ *
+ * `FLAIR_MCP_JIT_PROVISION` — truthy ("1"/"true"/"yes"/"on") enables it. Default
+ * OFF: an unknown subject is denied (the operator must pre-provision the
+ * Agent+Credential, or explicitly opt into JIT). This composes with the AS-side
+ * DCR gate (initialAccessToken) — both must be deliberately opened.
+ */
+function jitProvisionEnabled(): boolean {
+  const raw = (process.env.FLAIR_MCP_JIT_PROVISION ?? "").trim().toLowerCase();
+  return raw === "1" || raw === "true" || raw === "yes" || raw === "on";
+}
+
+/**
+ * Resolve the OAuth token `sub` to a flair `Agent` (Principal) id.
+ *
+ * Lookup: `Credential` where `kind === "idp"` AND `idpSubject === sub`. The
+ * Credential's `principalId` is the Agent id. This is the SAME credential surface
+ * XAA's ID-JAG path uses (resources/XAA.ts resolveOrCreatePrincipal) — one
+ * identity model, keyed on the IdP subject.
+ *
+ * Returns:
+ *   - `{ agentId, isAdmin }` when a Credential maps the sub to an Agent.
+ *   - null when no Credential maps the sub AND JIT-provisioning is disabled or
+ *     failed → the handler denies the tool call (sub is unresolvable).
+ */
+export async function resolveAgentFromSub(sub: string): Promise<ResolvedAgent | null> {
+  if (!sub) return null;
+
+  // 1. Existing IdP credential → its principalId is the Agent id.
+  try {
+    for await (const cred of (databases as any).flair.Credential.search({
+      conditions: [
+        { attribute: "kind", comparator: "equals", value: "idp" },
+        { attribute: "idpSubject", comparator: "equals", value: sub },
+      ],
+    })) {
+      if (cred?.principalId && cred.status !== "revoked") {
+        // Touch lastUsedAt (best-effort; a failure here must not deny a valid call).
+        try {
+          await (databases as any).flair.Credential.put({ ...cred, lastUsedAt: new Date().toISOString() });
+        } catch { /* non-fatal */ }
+        return { agentId: String(cred.principalId), isAdmin: await isAgentAdmin(cred.principalId) };
+      }
+    }
+  } catch { /* Credential table empty / search error → fall through to JIT/deny */ }
+
+  // 2. No mapping. JIT-provision only behind the explicit trust anchor.
+  if (!jitProvisionEnabled()) return null;
+
+  try {
+    const principalId = await jitProvisionPrincipal(sub);
+    // A JIT-provisioned principal is a fresh, non-admin agent by construction.
+    return { agentId: principalId, isAdmin: false };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * JIT-provision a Principal (Agent record) + an IdP Credential from a verified
+ * token subject. Mirrors XAA.resolveOrCreatePrincipal's provisioning shape (the
+ * `Credential.kind:"idp"` + `idpSubject` surface) but keyed on the MCP token sub.
+ * The created agent is non-admin, `kind:"agent"`, unverified trust tier.
+ */
+async function jitProvisionPrincipal(sub: string): Promise<string> {
+  const now = new Date().toISOString();
+  const principalId = `agt_mcp_${sub.replace(/[^a-zA-Z0-9]/g, "_").slice(0, 24)}_${randomBytes(4).toString("hex")}`;
+
+  await (databases as any).flair.Agent.put({
+    id: principalId,
+    name: principalId,
+    displayName: principalId,
+    kind: "agent",
+    type: "agent",
+    status: "active",
+    // Placeholder public key — an MCP-OAuth agent authenticates via bearer token,
+    // not an Ed25519 signing key. Marks provenance without forging a real key.
+    publicKey: `mcp-oauth:${sub}`,
+    defaultTrustTier: "unverified",
+    admin: false,
+    createdAt: now,
+    updatedAt: now,
+  });
+
+  await (databases as any).flair.Credential.put({
+    id: `cred_mcp_${randomBytes(8).toString("hex")}`,
+    principalId,
+    kind: "idp",
+    label: "MCP OAuth (native /mcp)",
+    status: "active",
+    idpProvider: "mcp-oauth",
+    idpSubject: sub,
+    createdAt: now,
+    lastUsedAt: now,
+  });
+
+  return principalId;
+}
+
+/**
+ * Is this Principal a flair admin? Reads the Agent record's `admin`/`role`
+ * fields. A MCP-OAuth agent is NON-admin unless an operator has explicitly
+ * marked its Agent record admin — the MCP surface never elevates on its own.
+ */
+async function isAgentAdmin(principalId: string): Promise<boolean> {
+  try {
+    const agent = await (databases as any).flair.Agent.get(principalId);
+    return agent?.admin === true || agent?.role === "admin";
+  } catch {
+    return false;
+  }
+}
+
+// ─── MCP protocol dispatch ───────────────────────────────────────────────────
+
+/**
+ * The custom /mcp handler. `withMCPAuth` guarantees `request.mcp` is present here
+ * (it fails closed before us on a missing/invalid token), so we read the verified
+ * `sub` directly. Handles a single JSON-RPC request per POST (the minimal
+ * Streamable-HTTP shape the curated surface needs; batching is not used by the
+ * MCP clients we target).
+ */
+export async function mcpHandler(request: any): Promise<any> {
+  // MCP is a POST-only JSON-RPC surface. A GET (e.g. an SSE stream open) is not
+  // part of the curated request/response tool flow — reject cleanly.
+  const method = String(request?.method ?? "POST").toUpperCase();
+  if (method !== "POST") {
+    return rpcError(null, -32600, "method not allowed: /mcp accepts JSON-RPC POST only", 405);
+  }
+
+  // Parse the JSON-RPC body. Harper's Request wraps a Node stream — read text.
+  let msg: any;
+  try {
+    const text = typeof request.text === "function" ? await request.text() : request.body;
+    msg = typeof text === "string" ? JSON.parse(text) : text;
+  } catch {
+    return rpcError(null, -32700, "parse error: invalid JSON");
+  }
+  if (!msg || typeof msg !== "object" || msg.jsonrpc !== "2.0" || typeof msg.method !== "string") {
+    return rpcError(msg?.id ?? null, -32600, "invalid request: expected JSON-RPC 2.0");
+  }
+
+  const { id, method: rpcMethod, params } = msg;
+
+  switch (rpcMethod) {
+    case "initialize":
+      return rpcResult(id, {
+        protocolVersion: PROTOCOL_VERSION,
+        capabilities: { tools: {} },
+        serverInfo: { name: "flair", version: "0.1.0" },
+      });
+
+    // Notifications (no id) — acknowledge with 202-ish empty 200; MCP clients send
+    // `notifications/initialized` after initialize.
+    case "notifications/initialized":
+      return { status: 200, headers: JSON_HEADERS, body: "" };
+
+    case "ping":
+      return rpcResult(id, {});
+
+    case "tools/list":
+      return rpcResult(id, { tools: listToolDefs() });
+
+    case "tools/call":
+      return handleToolCall(request, id, params);
+
+    default:
+      return rpcError(id, -32601, `method not found: ${rpcMethod}`);
+  }
+}
+
+/**
+ * tools/call: resolve the token sub → flair Agent, then dispatch to the curated
+ * tool. An unresolvable sub is DENIED (not silently run as anonymous or admin).
+ */
+async function handleToolCall(request: any, id: any, params: any): Promise<any> {
+  const toolName = params?.name;
+  const args = params?.arguments ?? {};
+
+  const entry = toolName ? TOOLS[toolName] : undefined;
+  if (!entry) {
+    return rpcError(id, -32602, `unknown tool: ${toolName ?? "(none)"}`);
+  }
+
+  // withMCPAuth guarantees request.mcp on success. Defense-in-depth: if it's
+  // somehow absent, deny (never run a tool without a verified sub).
+  const sub = request?.mcp?.sub;
+  if (!sub) {
+    return rpcError(id, -32001, "unauthorized: no verified token subject");
+  }
+
+  const agent = await resolveAgentFromSub(String(sub));
+  if (!agent) {
+    // Sub verified by the AS but not mapped to a flair Agent (and JIT disabled /
+    // failed). Deny — do NOT fall back to anonymous or admin.
+    return rpcError(id, -32001, "forbidden: token subject is not a provisioned flair agent");
+  }
+
+  try {
+    const result = await entry.impl(agent, args);
+    // MCP tools/call result: content blocks. Surface the handler's JSON payload
+    // as a text block (structuredContent carries the raw object for programmatic
+    // clients). A handler-level error object (from unwrap of a Response) is
+    // reported as an MCP tool error (isError) rather than a JSON-RPC error, so
+    // the client sees the structured message.
+    const text = typeof result === "string" ? result : JSON.stringify(result);
+    const isError = !!(result && typeof result === "object" && "error" in result && "status" in result);
+    return rpcResult(id, {
+      content: [{ type: "text", text }],
+      structuredContent: typeof result === "object" ? result : { value: result },
+      isError,
+    });
+  } catch (err: any) {
+    return rpcError(id, -32000, `tool execution failed: ${err?.message ?? String(err)}`);
+  }
+}

--- a/resources/mcp-oauth-flag.ts
+++ b/resources/mcp-oauth-flag.ts
@@ -1,0 +1,85 @@
+/**
+ * mcp-oauth-flag.ts — the feature flag + AS config for the native-MCP OAuth
+ * surface (FLAIR-NATIVE-MCP-OAUTH, Model 2).
+ *
+ * Model 2 = a CUSTOM in-process `/mcp` JSON-RPC handler wrapped with
+ * `@harperfast/oauth`'s `withMCPAuth` (a fail-closed Bearer-token guard). It is
+ * DISTINCT from the native-application-MCP surface (design A / the
+ * `native-mcp-surface` branch's `static mcpTools`) — Model 2 does not use
+ * Harper's native MCP transport at all, so it is not blocked by the Harper
+ * native-MCP timing/worker gating gaps. The curated 9 tools are curated
+ * BY CONSTRUCTION (the handler only implements those 9).
+ *
+ * ── Default-OFF ─────────────────────────────────────────────────────────────
+ * The whole surface is gated behind `FLAIR_MCP_OAUTH`, default-OFF. When off:
+ *   - NO `/mcp` route is registered (mcpOAuthResource() early-returns).
+ *   - The `@harperfast/oauth` authorization-server config is NOT injected.
+ *   - flair's default auth chain is byte-identical to today.
+ * There is zero prod-behavior change until an operator explicitly opts in AND
+ * Sherlock signs off on live enablement.
+ *
+ * NOTE — separate flag from the native-MCP surface: `FLAIR_MCP_ENABLED` gates the
+ * design-A native surface (other branch); `FLAIR_MCP_OAUTH` gates THIS Model-2
+ * OAuth-guarded custom handler. They are independent flags for independent
+ * mechanisms; neither implies the other.
+ */
+
+/**
+ * Is the Model-2 OAuth-guarded /mcp surface enabled? Default-OFF.
+ *
+ * Read from `FLAIR_MCP_OAUTH` — truthy values: "1", "true", "yes", "on"
+ * (case-insensitive). Anything else (incl. unset / empty) → OFF.
+ */
+export function mcpOAuthEnabled(): boolean {
+  const raw = (process.env.FLAIR_MCP_OAUTH ?? "").trim().toLowerCase();
+  return raw === "1" || raw === "true" || raw === "yes" || raw === "on";
+}
+
+/**
+ * The public origin the authorization server pins `iss` (and, via it, `aud`) to.
+ * REQUIRED when the surface is enabled — the @harperfast/oauth plugin refuses to
+ * start without `mcp.issuer`, and pinning it (rather than letting it float with
+ * the client-controlled Host header) is the audience-confusion defense called
+ * out in the plugin's production checklist.
+ *
+ * Configurable via `FLAIR_MCP_ISSUER` (fall back to `FLAIR_PUBLIC_URL`, which the
+ * XAA token path already uses as the canonical public base). No hardcoded
+ * default — an operator turning the flag on MUST set the public origin.
+ */
+export function mcpIssuer(): string | undefined {
+  const raw = (process.env.FLAIR_MCP_ISSUER ?? process.env.FLAIR_PUBLIC_URL ?? "").trim();
+  return raw || undefined;
+}
+
+/**
+ * The RFC-8707 resource identifier tokens are audience-bound to. This is the
+ * public URL of the `/mcp` endpoint itself: `<issuer>/mcp`. `withMCPAuth`
+ * verifies the `aud` claim equals this, so the token minted for flair's `/mcp`
+ * cannot be replayed against a different resource server.
+ */
+export function mcpResource(): string | undefined {
+  const iss = mcpIssuer();
+  if (!iss) return undefined;
+  return `${iss.replace(/\/+$/, "")}/mcp`;
+}
+
+/**
+ * `getConfig` payload injected into `withMCPAuth` so it verifies against the
+ * exact issuer/resource the authorization-server component mints tokens with —
+ * required because flair's `/mcp` handler and the @harperfast/oauth plugin may
+ * resolve different `node_modules` copies (docs/mcp-oauth.md §"Using withMCPAuth
+ * from a different component"), in which case the wrapper's live-config lookup
+ * reads `undefined` and fails closed. Pinning it here makes the iss/aud checks
+ * match the minted tokens.
+ *
+ * Returns undefined when the surface is off or the issuer is unset (the wrapper
+ * then denies — never serves a guarded route unconfigured, which is the safe
+ * failure mode).
+ */
+export function mcpAuthConfig(): { enabled: boolean; issuer: string; resource: string } | undefined {
+  if (!mcpOAuthEnabled()) return undefined;
+  const issuer = mcpIssuer();
+  const resource = mcpResource();
+  if (!issuer || !resource) return undefined;
+  return { enabled: true, issuer, resource };
+}

--- a/resources/mcp-oauth.ts
+++ b/resources/mcp-oauth.ts
@@ -1,0 +1,117 @@
+/**
+ * mcp-oauth.ts — registers the Model-2 OAuth-guarded /mcp surface.
+ *
+ * Wraps the custom `mcpHandler` (mcp-handler.ts) with `@harperfast/oauth`'s
+ * `withMCPAuth` (a fail-closed Bearer-token guard) and mounts it on the `/mcp`
+ * urlPath subroute — its OWN dispatch chain, so flair's default auth-middleware
+ * never runs for /mcp and can't clobber the Bearer challenge.
+ *
+ * ── Default-OFF (byte-identical when off) ───────────────────────────────────
+ * The route is registered ONLY when `FLAIR_MCP_OAUTH` is truthy. When off, this
+ * module does NOTHING at load — no `server.http` call, no `@harperfast/oauth`
+ * import, no config injection. flair's default auth chain and prod behavior are
+ * unchanged. This is the no-op contract the flag guarantees.
+ *
+ * The `@harperfast/oauth` authorization-server config itself (providers, mcp.*,
+ * DCR gating) lives in `config.yaml` under the `@harperfast/oauth` key, but is
+ * only meaningful when an operator has set the issuer + enabled the flag (see
+ * docs). The plugin serves DCR / authorize / token / JWKS / discovery.
+ */
+
+import * as harper from "@harperfast/harper";
+import { mcpOAuthEnabled, mcpAuthConfig } from "./mcp-oauth-flag.js";
+import { mcpHandler } from "./mcp-handler.js";
+
+/**
+ * Register the guarded /mcp route iff the flag is on. Called once at module load
+ * (and directly in tests). Kept async + guarded: `@harperfast/oauth` is only
+ * imported when the flag is on, so a flair install that never enables MCP-OAuth
+ * doesn't need the dep resolved at boot, and a broken/absent plugin degrades to
+ * "no /mcp route" (fail-safe: the surface simply doesn't mount) rather than
+ * crashing flair.
+ *
+ * Returns true if the route was mounted, false otherwise — the return value is
+ * for tests/observability; the load-time caller ignores it.
+ */
+export interface RegisterDeps {
+  /** The Harper server to register the route on (injectable for tests). */
+  server?: { http: (handler: any, options: any) => void };
+  /** Loader for withMCPAuth (injectable for tests; defaults to the real plugin). */
+  loadWithMCPAuth?: () => Promise<(handler: any, options?: any) => any>;
+}
+
+async function defaultLoadWithMCPAuth(): Promise<(handler: any, options?: any) => any> {
+  // Dynamic import so the dep is only required when the surface is enabled.
+  const mod = (await import("@harperfast/oauth")) as any;
+  return mod.withMCPAuth;
+}
+
+export async function registerMcpOAuthRoute(deps: RegisterDeps = {}): Promise<boolean> {
+  if (!mcpOAuthEnabled()) return false; // OFF → no route, no import, no side effects.
+
+  const config = mcpAuthConfig();
+  if (!config) {
+    // Flag on but issuer unset → we cannot safely pin iss/aud. Do NOT mount an
+    // unconfigured guard (withMCPAuth would fail closed anyway, but not mounting
+    // is the clearer signal). Log and bail — the operator must set FLAIR_MCP_ISSUER.
+    console.error(
+      "[mcp-oauth] FLAIR_MCP_OAUTH is on but no issuer configured " +
+        "(set FLAIR_MCP_ISSUER or FLAIR_PUBLIC_URL) — /mcp NOT mounted.",
+    );
+    return false;
+  }
+
+  let withMCPAuth: (handler: any, options?: any) => any;
+  try {
+    withMCPAuth = await (deps.loadWithMCPAuth ?? defaultLoadWithMCPAuth)();
+  } catch (err: any) {
+    console.error(
+      "[mcp-oauth] @harperfast/oauth not available — /mcp NOT mounted: " + (err?.message ?? err),
+    );
+    return false;
+  }
+
+  if (typeof withMCPAuth !== "function") {
+    console.error("[mcp-oauth] @harperfast/oauth has no withMCPAuth export — /mcp NOT mounted.");
+    return false;
+  }
+
+  // Read `server` lazily off the namespace (it's a runtime global on the Harper
+  // module, not a static named export) so this module links cleanly even where a
+  // stub build of @harperfast/harper lacks the export.
+  const srv = deps.server ?? ((harper as any).server);
+
+  // Primary registration: urlPath subroute → own chain (flair's auth-middleware
+  // does not run here). `getConfig` pins iss/resource to the AS's values so the
+  // wrapper's iss/aud checks match the minted tokens even if this component
+  // resolves a different node_modules copy of the plugin (docs/mcp-oauth.md
+  // §"Using withMCPAuth from a different component").
+  srv.http(
+    withMCPAuth(mcpHandler, {
+      getConfig: () => mcpAuthConfig(),
+    }),
+    { urlPath: "/mcp" },
+  );
+
+  console.error(`[mcp-oauth] /mcp mounted (OAuth-guarded); issuer=${config.issuer}`);
+  return true;
+}
+
+// Fire-and-forget at module load. Any failure is contained inside
+// registerMcpOAuthRoute (it logs and returns) so it can never crash flair boot.
+// When the flag is off it returns immediately without importing the plugin or
+// touching `server` — the byte-identical no-op contract.
+//
+// Skipped ONLY when a test explicitly opts out via FLAIR_MCP_NO_AUTOSTART, so
+// importing this module in a unit test doesn't trigger the real plugin/handler
+// import chain under a partial harper mock (registration is exercised directly
+// via the exported fn). Production never sets this, so boot behavior is
+// unchanged — and when the flag is off, registerMcpOAuthRoute() is a no-op
+// regardless. (bun test runs under Node's runtime here via the harper toolchain;
+// we don't gate on the runtime to avoid disabling the feature in a bun-hosted
+// deployment.)
+if (process.env.FLAIR_MCP_NO_AUTOSTART == null) {
+  void registerMcpOAuthRoute().catch((err) => {
+    console.error("[mcp-oauth] route registration failed (surface not mounted): " + (err?.message ?? err));
+  });
+}

--- a/resources/mcp-tools.ts
+++ b/resources/mcp-tools.ts
@@ -1,0 +1,403 @@
+/**
+ * mcp-tools.ts — the 9 curated flair tools for the Model-2 custom /mcp handler.
+ *
+ * Curated BY CONSTRUCTION: this module implements exactly the 9 tools that the
+ * `@tpsdev-ai/flair-mcp` stdio proxy exposes, each a thin wrapper over the
+ * existing flair Resource handler. No business logic is re-implemented — the
+ * wrapped handlers (Memory / SemanticSearch / BootstrapMemories / Soul /
+ * WorkspaceState / OrgEvent) enforce per-agent scoping/ownership via
+ * `resolveAgentAuth(getContext())`, so the MCP surface inherits the SAME security
+ * model as the signed-REST path. There is no raw CRUD surface — the only way to
+ * reach the datastore through /mcp is via one of these 9 semantic tools.
+ *
+ *   memory_search · memory_store · memory_get · memory_delete · bootstrap ·
+ *   soul_set · soul_get · flair_workspace_set · flair_orgevent
+ *
+ * ── The scoping seam ────────────────────────────────────────────────────────
+ * The /mcp handler resolves the OAuth token's `sub` → a flair `Agent` id, then
+ * calls a tool with a `ResolvedAgent { agentId, isAdmin }`. Each tool builds a
+ * flair-shaped Resource context (`delegationContext`) carrying `request.tpsAgent`
+ * + `request.tpsAgentIsAdmin`, so the wrapped handler scopes to the verified
+ * agent exactly as an Ed25519-signed REST call would. Identity ALWAYS comes from
+ * the resolved agent, never from the tool arguments — an agent can only act as
+ * itself (no forging of agentId / authorId in the body).
+ */
+
+/**
+ * The delegated handler classes, held in a mutable registry, LAZILY loaded on
+ * first use. Two reasons for the indirection:
+ *
+ *   1. Tests inject capture doubles via `__setHandlers` WITHOUT `mock.module`-ing
+ *      the shared `resources/*.ts` files (a process-global bun mock that leaks
+ *      into every other test file).
+ *   2. The handler classes statically `import { Resource, databases } from
+ *      "@harperfast/harper"`. Importing them lazily (dynamic import on first tool
+ *      call, not at module top) keeps `mcp-tools`/`mcp-handler` free of a
+ *      top-level Harper link, so importing the /mcp handler in a unit test never
+ *      requires the full Harper module surface up front.
+ *
+ * Prod: first tool call loads the real classes against a fully-real Harper.
+ */
+type HandlerKey = "SemanticSearch" | "Memory" | "BootstrapMemories" | "Soul" | "WorkspaceState" | "OrgEvent";
+const H: Partial<Record<HandlerKey, any>> = {};
+
+const LOADERS: Record<HandlerKey, () => Promise<any>> = {
+  SemanticSearch: async () => (await import("./SemanticSearch.js")).SemanticSearch,
+  Memory: async () => (await import("./Memory.js")).Memory,
+  BootstrapMemories: async () => (await import("./MemoryBootstrap.js")).BootstrapMemories,
+  Soul: async () => (await import("./Soul.js")).Soul,
+  WorkspaceState: async () => (await import("./WorkspaceState.js")).WorkspaceState,
+  OrgEvent: async () => (await import("./OrgEvent.js")).OrgEvent,
+};
+
+/** Resolve a handler class — from the test override if set, else lazy-load + cache. */
+async function handler(key: HandlerKey): Promise<any> {
+  if (H[key]) return H[key];
+  const cls = await LOADERS[key]();
+  H[key] = cls;
+  return cls;
+}
+
+/** TEST-ONLY: override the delegated handler classes. Returns a restore fn. */
+export function __setHandlers(overrides: Partial<Record<HandlerKey, any>>): () => void {
+  const prev = { ...H };
+  Object.assign(H, overrides);
+  return () => {
+    for (const k of Object.keys(H) as HandlerKey[]) delete H[k];
+    Object.assign(H, prev);
+  };
+}
+
+/** The verified agent identity for an MCP tool call (resolved from the token sub). */
+export interface ResolvedAgent {
+  agentId: string;
+  isAdmin: boolean;
+}
+
+/** MCP tool descriptor as returned by tools/list. */
+export interface McpToolDef {
+  name: string;
+  description: string;
+  inputSchema: Record<string, unknown>;
+  annotations?: Record<string, unknown>;
+}
+
+/**
+ * Build a flair-shaped Resource context for a delegated handler call. The
+ * handlers read identity via `resolveAgentAuth(getContext())`, which checks
+ * `context.request.tpsAgent` / `tpsAgentIsAdmin`. We construct exactly that shape
+ * so the wrapped handler scopes to the verified agent — identical to the
+ * signed-REST path. `headers.get("x-tps-agent")` is provided for handler paths
+ * that read the header directly (e.g. MemoryBootstrap fallback).
+ *
+ * Critically: `tpsAnonymous` is NOT set and no Authorization header is present,
+ * so `resolveAgentAuth` takes the `tpsAgent` annotation branch — a verified
+ * agent, never anonymous, never a header re-verify.
+ */
+function delegationContext(agent: ResolvedAgent): any {
+  return {
+    request: {
+      tpsAgent: agent.agentId,
+      tpsAgentIsAdmin: agent.isAdmin,
+      headers: {
+        get: (k: string) => (k.toLowerCase() === "x-tps-agent" ? agent.agentId : undefined),
+      },
+    },
+    user: undefined,
+  };
+}
+
+/**
+ * Unwrap a handler return value into a plain object/string for the MCP result.
+ * Handlers may return a `Response` (the 401/403/400 guards) — surface its JSON
+ * body (and status) so the client sees the structured error rather than an
+ * opaque object. A thrown handler error propagates to the caller (the handler
+ * maps it to a JSON-RPC error).
+ */
+async function unwrap(value: any): Promise<any> {
+  if (value && typeof value === "object" && typeof value.json === "function" && "status" in value) {
+    try {
+      const body = await value.json();
+      return { error: body?.error ?? "request failed", status: value.status, ...body };
+    } catch {
+      return { error: "request failed", status: (value as any).status };
+    }
+  }
+  return value;
+}
+
+// ── Tool implementations (thin wrappers over existing handlers) ──────────────
+//
+// Each takes the resolved agent + the parsed tool arguments and returns a plain
+// JSON-serializable value. Identity is taken from `agent`, never from `args`.
+
+async function memorySearch(agent: ResolvedAgent, args: any) {
+  const Cls = await handler("SemanticSearch");
+  const h = new Cls(undefined, delegationContext(agent));
+  return unwrap(await h.post({ q: args?.query, limit: args?.limit ?? 5 }));
+}
+
+async function memoryStore(agent: ResolvedAgent, args: any) {
+  const Cls = await handler("Memory");
+  const h = new Cls(undefined, delegationContext(agent));
+  (h as any).isCollection = true;
+  // agentId is the RESOLVED agent — Memory.post also re-checks ownership via
+  // resolveAgentAuth, so a mismatched body agentId would 403 anyway; we set it
+  // to the verified id so the write is correctly owned.
+  return unwrap(await h.post({
+    agentId: agent.agentId,
+    content: args?.content,
+    type: args?.type ?? "session",
+    durability: args?.durability ?? "standard",
+    tags: args?.tags,
+  }));
+}
+
+async function memoryGet(agent: ResolvedAgent, args: any) {
+  const Cls = await handler("Memory");
+  const h = new Cls(undefined, delegationContext(agent));
+  return unwrap(await h.get(args?.id));
+}
+
+async function memoryDelete(agent: ResolvedAgent, args: any) {
+  const Cls = await handler("Memory");
+  const h = new Cls(undefined, delegationContext(agent));
+  return unwrap(await h.delete(args?.id));
+}
+
+async function bootstrap(agent: ResolvedAgent, args: any) {
+  const Cls = await handler("BootstrapMemories");
+  const h = new Cls(undefined, delegationContext(agent));
+  return unwrap(await h.post({
+    agentId: agent.agentId,
+    maxTokens: args?.maxTokens ?? 4000,
+    currentTask: args?.currentTask,
+    channel: args?.channel,
+    surface: args?.surface,
+    subjects: args?.subjects,
+  }));
+}
+
+async function soulSet(agent: ResolvedAgent, args: any) {
+  const Cls = await handler("Soul");
+  const h = new Cls(undefined, delegationContext(agent));
+  // Soul records are keyed `id = agentId:key` (see flair-client SoulApi.set and
+  // schemas/memory.graphql). Use PUT with the explicit id so soul_get's
+  // `${agentId}:${key}` lookup finds it — a plain post() would mint a random id
+  // and orphan the entry from get(). Soul.put enforces write ownership via
+  // resolveAgentAuth (non-admin can only write agentId === self).
+  const id = `${agent.agentId}:${args?.key}`;
+  return unwrap(await h.put({
+    id,
+    agentId: agent.agentId,
+    key: args?.key,
+    value: args?.value,
+  }));
+}
+
+async function soulGet(agent: ResolvedAgent, args: any) {
+  const Cls = await handler("Soul");
+  const h = new Cls(undefined, delegationContext(agent));
+  return unwrap(await h.get(`${agent.agentId}:${args?.key}`));
+}
+
+async function workspaceSet(agent: ResolvedAgent, args: any) {
+  const Cls = await handler("WorkspaceState");
+  const h = new Cls(undefined, delegationContext(agent));
+  (h as any).isCollection = true;
+  // No agentId in the body — WorkspaceState.post attributes the record to the
+  // authenticated identity (from the context), never the body. Same no-forge
+  // contract as the flair-mcp stdio tool.
+  const body: Record<string, unknown> = {
+    id: `${agent.agentId}:${args?.ref}`,
+    ref: args?.ref,
+    provider: args?.provider ?? "mcp",
+    timestamp: new Date().toISOString(),
+  };
+  if (args?.label) body.label = args.label;
+  if (args?.task) body.taskId = args.task;
+  if (args?.phase) body.phase = args.phase;
+  if (args?.summary) body.summary = args.summary;
+  return unwrap(await h.post(body));
+}
+
+async function orgEvent(agent: ResolvedAgent, args: any) {
+  const Cls = await handler("OrgEvent");
+  const h = new Cls(undefined, delegationContext(agent));
+  (h as any).isCollection = true;
+  // No authorId in the body — OrgEvent.post attributes to the authenticated
+  // identity, never the body (no forging as another agent).
+  const body: Record<string, unknown> = { kind: args?.kind, summary: args?.summary };
+  if (args?.detail) body.detail = args.detail;
+  if (args?.scope) body.scope = args.scope;
+  if (Array.isArray(args?.targets) && args.targets.length > 0) body.targetIds = args.targets;
+  return unwrap(await h.post(body));
+}
+
+type ToolImpl = (agent: ResolvedAgent, args: any) => Promise<any>;
+
+/**
+ * The tool registry: definition (for tools/list) + implementation (for
+ * tools/call), keyed by tool name. The single source of truth for BOTH the
+ * advertised surface and the dispatch table — so tools/list and tools/call
+ * cannot drift (a tool listed but not callable, or vice versa, is impossible).
+ */
+interface ToolEntry {
+  def: McpToolDef;
+  impl: ToolImpl;
+}
+
+export const TOOLS: Record<string, ToolEntry> = {
+  memory_search: {
+    def: {
+      name: "memory_search",
+      description:
+        "Search memories by meaning. Understands temporal queries like 'what happened today'. Scoped to your agent's own + granted memories.",
+      annotations: { readOnlyHint: true },
+      inputSchema: {
+        type: "object",
+        properties: {
+          query: { type: "string", description: "Search query — natural language, semantic matching" },
+          limit: { type: "number", description: "Max results (default 5)" },
+        },
+        required: ["query"],
+      },
+    },
+    impl: memorySearch,
+  },
+  memory_store: {
+    def: {
+      name: "memory_store",
+      description:
+        "Save information to persistent memory. Use for lessons, decisions, preferences, facts. Attributed to your authenticated agent.",
+      inputSchema: {
+        type: "object",
+        properties: {
+          content: { type: "string", description: "What to remember" },
+          type: { type: "string", enum: ["session", "lesson", "decision", "preference", "fact", "goal"], description: "Memory type (default session)" },
+          durability: { type: "string", enum: ["permanent", "persistent", "standard", "ephemeral"], description: "permanent > persistent > standard > ephemeral (default standard)" },
+          tags: { type: "array", items: { type: "string" }, description: "Tag strings" },
+        },
+        required: ["content"],
+      },
+    },
+    impl: memoryStore,
+  },
+  memory_get: {
+    def: {
+      name: "memory_get",
+      description: "Retrieve a specific memory by ID.",
+      annotations: { readOnlyHint: true },
+      inputSchema: {
+        type: "object",
+        properties: { id: { type: "string", description: "Memory ID" } },
+        required: ["id"],
+      },
+    },
+    impl: memoryGet,
+  },
+  memory_delete: {
+    def: {
+      name: "memory_delete",
+      description: "Delete a memory by ID. You can only delete your own memories.",
+      annotations: { destructiveHint: true },
+      inputSchema: {
+        type: "object",
+        properties: { id: { type: "string", description: "Memory ID to delete" } },
+        required: ["id"],
+      },
+    },
+    impl: memoryDelete,
+  },
+  bootstrap: {
+    def: {
+      name: "bootstrap",
+      description:
+        "Get session context: soul + memories + predicted context. Run at session start. Pass subjects for predictive loading.",
+      annotations: { readOnlyHint: true },
+      inputSchema: {
+        type: "object",
+        properties: {
+          maxTokens: { type: "number", description: "Max tokens in output (default 4000)" },
+          currentTask: { type: "string", description: "Current task — enables semantic search for relevant memories" },
+          channel: { type: "string", description: "Channel name (discord, tps-mail, claude-code)" },
+          surface: { type: "string", description: "Surface name (tps-build, tps-review, cli-session)" },
+          subjects: { type: "array", items: { type: "string" }, description: "Entity names to preload context for" },
+        },
+      },
+    },
+    impl: bootstrap,
+  },
+  soul_set: {
+    def: {
+      name: "soul_set",
+      description: "Set a personality or project context entry. Included in every bootstrap.",
+      inputSchema: {
+        type: "object",
+        properties: {
+          key: { type: "string", description: "Entry key (e.g. 'role', 'standards', 'project')" },
+          value: { type: "string", description: "Entry value" },
+        },
+        required: ["key", "value"],
+      },
+    },
+    impl: soulSet,
+  },
+  soul_get: {
+    def: {
+      name: "soul_get",
+      description: "Get a personality or project context entry.",
+      annotations: { readOnlyHint: true },
+      inputSchema: {
+        type: "object",
+        properties: { key: { type: "string", description: "Entry key" } },
+        required: ["key"],
+      },
+    },
+    impl: soulGet,
+  },
+  flair_workspace_set: {
+    def: {
+      name: "flair_workspace_set",
+      description:
+        "Set your agent's current workspace state in the Office Space coordination layer. Attributed to you — you can only write your own state.",
+      inputSchema: {
+        type: "object",
+        properties: {
+          ref: { type: "string", description: "Workspace ref — branch, worktree, or task ref" },
+          label: { type: "string", description: "Human-readable label" },
+          provider: { type: "string", description: "Provider/runtime (default mcp)" },
+          task: { type: "string", description: "Task/issue id" },
+          phase: { type: "string", description: "Current phase (design, implement, review)" },
+          summary: { type: "string", description: "Short summary of current state" },
+        },
+        required: ["ref"],
+      },
+    },
+    impl: workspaceSet,
+  },
+  flair_orgevent: {
+    def: {
+      name: "flair_orgevent",
+      description:
+        "Publish an org-wide coordination event (claim/release/status) to the Office Space. Attributed to you — you cannot publish as another agent.",
+      inputSchema: {
+        type: "object",
+        properties: {
+          kind: { type: "string", description: "Event kind (coord.claim, coord.release, status)" },
+          summary: { type: "string", description: "Short summary of the event" },
+          detail: { type: "string", description: "Longer detail payload" },
+          scope: { type: "string", description: "Scope (an agent id, repo, or 'org')" },
+          targets: { type: "array", items: { type: "string" }, description: "Recipient agent ids" },
+        },
+        required: ["kind", "summary"],
+      },
+    },
+    impl: orgEvent,
+  },
+};
+
+/** The tool definitions for a tools/list response (exactly the 9 curated tools). */
+export function listToolDefs(): McpToolDef[] {
+  return Object.values(TOOLS).map((t) => t.def);
+}

--- a/scripts/check-dep-ages.mjs
+++ b/scripts/check-dep-ages.mjs
@@ -75,6 +75,13 @@ if (!Number.isFinite(MIN_AGE_DAYS) || MIN_AGE_DAYS < 0) {
 const DEFAULT_KEEP_CURRENT = new Set([
   "@harperfast/harper",
   "harper-fabric-embeddings",
+  // @harperfast/oauth: same high-trust @harperfast/* owner as @harperfast/harper
+  // (already exempt). Used ONLY by the default-OFF native-MCP OAuth surface
+  // (FLAIR_MCP_OAUTH), which dynamically imports it only when the flag is on — so
+  // it is not loaded in the shipped default build (zero exposure until an operator
+  // opts in). Pinned to the exact version whose withMCPAuth API the surface was
+  // built against. See docs/supply-chain-policy.md §1a.
+  "@harperfast/oauth",
 ]);
 const KEEP_CURRENT = new Set([
   ...DEFAULT_KEEP_CURRENT,

--- a/test/unit/mcp-handler.test.ts
+++ b/test/unit/mcp-handler.test.ts
@@ -1,0 +1,328 @@
+/**
+ * mcp-handler.test.ts — the Model-2 custom /mcp handler + sub→Agent resolution.
+ *
+ * These are the auth-critical assertions the integration harness can't make at
+ * the unit level:
+ *
+ *   - tools/list returns EXACTLY the 9 curated tools (no raw CRUD, no extras).
+ *   - sub → Agent resolution: an existing Credential(kind:"idp", idpSubject=sub)
+ *     maps to its principalId; an unknown sub with JIT OFF is DENIED (not run as
+ *     anonymous/admin); an unknown sub with JIT ON provisions a NON-admin agent.
+ *   - tools/call scopes to the RESOLVED agent: the delegated handler receives a
+ *     context whose request.tpsAgent is the resolved principalId — never the
+ *     tool arguments (no forging).
+ *   - a tools/call whose token has no sub, or an unresolvable sub, is denied.
+ *   - unknown tool / bad JSON-RPC → proper errors.
+ *
+ * We mock @harperfast/harper (databases: Credential/Agent) AND the 6 delegated
+ * handler modules, so each tool's invocation is capturable and we can assert the
+ * exact agent context + args it forwards.
+ */
+
+import { mock, describe, it, expect, beforeEach, afterEach, afterAll } from "bun:test";
+
+// ─── Capture state for the mocked handlers ───────────────────────────────────
+let lastCall: { resource: string; ctx: any; args: any } | null = null;
+
+// Each mocked handler records the delegation context (getContext via ctor arg2)
+// and the args it was called with, then returns a marker so we can assert the
+// dispatch reached the right tool.
+function makeHandlerMock(resource: string, method: string) {
+  return class {
+    _ctx: any;
+    constructor(_id: any, ctx: any) { this._ctx = ctx; }
+    async [method](args: any) {
+      lastCall = { resource, ctx: this._ctx, args };
+      return { ok: true, resource, agentId: this._ctx?.request?.tpsAgent };
+    }
+  };
+}
+
+// Memory has post/get/delete on the same class.
+class MemoryMock {
+  _ctx: any;
+  isCollection = false;
+  constructor(_id: any, ctx: any) { this._ctx = ctx; }
+  async post(args: any) { lastCall = { resource: "Memory.post", ctx: this._ctx, args }; return { ok: true, resource: "Memory.post", agentId: this._ctx?.request?.tpsAgent }; }
+  async get(id: any) { lastCall = { resource: "Memory.get", ctx: this._ctx, args: id }; return { ok: true, resource: "Memory.get", agentId: this._ctx?.request?.tpsAgent }; }
+  async delete(id: any) { lastCall = { resource: "Memory.delete", ctx: this._ctx, args: id }; return { ok: true, resource: "Memory.delete", agentId: this._ctx?.request?.tpsAgent }; }
+}
+class SoulMock {
+  _ctx: any;
+  isCollection = false;
+  constructor(_id: any, ctx: any) { this._ctx = ctx; }
+  async put(args: any) { lastCall = { resource: "Soul.put", ctx: this._ctx, args }; return { ok: true, resource: "Soul.put", agentId: this._ctx?.request?.tpsAgent }; }
+  async get(id: any) { lastCall = { resource: "Soul.get", ctx: this._ctx, args: id }; return { ok: true, resource: "Soul.get", agentId: this._ctx?.request?.tpsAgent }; }
+}
+
+// ─── Mock @harperfast/harper: Credential + Agent tables ──────────────────────
+// Configurable per-test via these mutable fixtures.
+let credentials: any[] = [];
+let agents: Record<string, any> = {};
+const puts: { table: string; record: any }[] = [];
+
+// Constructable no-op base classes so the REAL resource modules (which do
+// `class X extends databases.flair.X` or `extends Resource`) link + load — we
+// then OVERRIDE them via __setHandlers, so these bases are never actually hit by
+// a tool call. They exist only to satisfy the import graph.
+class NoopBase { constructor(_id?: any, _ctx?: any) {} }
+const databasesMock = {
+  flair: {
+    Credential: Object.assign(class extends NoopBase {}, {
+      search: async function* (_q: any) { for (const c of credentials) yield c; },
+      put: async (r: any) => { puts.push({ table: "Credential", record: r }); return r; },
+    }),
+    Agent: Object.assign(class extends NoopBase {}, {
+      get: async (id: string) => agents[id] ?? null,
+      put: async (r: any) => { puts.push({ table: "Agent", record: r }); agents[r.id] = r; return r; },
+    }),
+    Memory: class extends NoopBase {},
+    Soul: class extends NoopBase {},
+    WorkspaceState: class extends NoopBase {},
+    OrgEvent: Object.assign(class extends NoopBase {}, { put: async (r: any) => r }),
+    MemoryGrant: { search: async function* () {} },
+  },
+};
+mock.module("@harperfast/harper", () => ({ databases: databasesMock, Resource: NoopBase, server: { http: () => {} } }));
+
+const { mcpHandler, resolveAgentFromSub } = await import("../../resources/mcp-handler.ts");
+const { __setHandlers } = await import("../../resources/mcp-tools.ts");
+
+// Inject capture doubles for the delegated handlers via the tools registry —
+// NOT `mock.module` on the shared resources/*.ts (which is process-global in bun
+// and would leak into every other test file). Restored in afterAll.
+const restoreHandlers = __setHandlers({
+  SemanticSearch: makeHandlerMock("SemanticSearch.post", "post"),
+  Memory: MemoryMock,
+  BootstrapMemories: makeHandlerMock("BootstrapMemories.post", "post"),
+  Soul: SoulMock,
+  WorkspaceState: makeHandlerMock("WorkspaceState.post", "post"),
+  OrgEvent: makeHandlerMock("OrgEvent.post", "post"),
+});
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+function post(body: any, mcp?: any) {
+  return {
+    method: "POST",
+    mcp,
+    text: async () => JSON.stringify(body),
+  };
+}
+async function parse(res: any) {
+  return res?.body ? JSON.parse(res.body) : res;
+}
+
+beforeEach(() => {
+  lastCall = null;
+  credentials = [];
+  agents = {};
+  puts.length = 0;
+  delete process.env.FLAIR_MCP_JIT_PROVISION;
+});
+afterEach(() => {
+  delete process.env.FLAIR_MCP_JIT_PROVISION;
+});
+afterAll(() => {
+  restoreHandlers();
+});
+
+// ─── tools/list ──────────────────────────────────────────────────────────────
+describe("tools/list — exactly the 9 curated tools", () => {
+  it("returns exactly 9, matching the flair-mcp surface, no CRUD mutators", async () => {
+    const res = await mcpHandler(post({ jsonrpc: "2.0", id: 1, method: "tools/list" }, { sub: "s" }));
+    const body = await parse(res);
+    const names = body.result.tools.map((t: any) => t.name).sort();
+    expect(names).toEqual([
+      "bootstrap",
+      "flair_orgevent",
+      "flair_workspace_set",
+      "memory_delete",
+      "memory_get",
+      "memory_search",
+      "memory_store",
+      "soul_get",
+      "soul_set",
+    ]);
+    // No create_/update_/delete_ raw-resource mutators leaked in.
+    expect(names.some((n: string) => /^(create|update|delete)_/.test(n))).toBe(false);
+  });
+});
+
+// ─── initialize / ping ───────────────────────────────────────────────────────
+describe("protocol handshake", () => {
+  it("initialize advertises tools capability", async () => {
+    const res = await mcpHandler(post({ jsonrpc: "2.0", id: 1, method: "initialize" }, { sub: "s" }));
+    const body = await parse(res);
+    expect(body.result.capabilities.tools).toBeDefined();
+    expect(body.result.serverInfo.name).toBe("flair");
+  });
+  it("ping → empty result", async () => {
+    const res = await mcpHandler(post({ jsonrpc: "2.0", id: 2, method: "ping" }, { sub: "s" }));
+    expect((await parse(res)).result).toEqual({});
+  });
+});
+
+// ─── sub → Agent resolution ──────────────────────────────────────────────────
+describe("resolveAgentFromSub", () => {
+  it("existing idp Credential → its principalId", async () => {
+    credentials = [{ principalId: "agt_alice", kind: "idp", idpSubject: "sub-alice", status: "active" }];
+    const agent = await resolveAgentFromSub("sub-alice");
+    expect(agent).toEqual({ agentId: "agt_alice", isAdmin: false });
+  });
+
+  it("admin Agent record → isAdmin true", async () => {
+    credentials = [{ principalId: "agt_admin", kind: "idp", idpSubject: "sub-admin", status: "active" }];
+    agents["agt_admin"] = { id: "agt_admin", admin: true };
+    const agent = await resolveAgentFromSub("sub-admin");
+    expect(agent).toEqual({ agentId: "agt_admin", isAdmin: true });
+  });
+
+  it("revoked Credential is skipped", async () => {
+    credentials = [{ principalId: "agt_x", kind: "idp", idpSubject: "sub-x", status: "revoked" }];
+    expect(await resolveAgentFromSub("sub-x")).toBeNull();
+  });
+
+  it("unknown sub, JIT OFF → null (DENY, no provisioning)", async () => {
+    expect(await resolveAgentFromSub("nobody")).toBeNull();
+    expect(puts).toHaveLength(0); // nothing created
+  });
+
+  it("unknown sub, JIT ON → provisions a NON-admin Agent + Credential", async () => {
+    process.env.FLAIR_MCP_JIT_PROVISION = "1";
+    const agent = await resolveAgentFromSub("fresh-sub");
+    expect(agent).not.toBeNull();
+    expect(agent!.isAdmin).toBe(false);
+    // Created exactly one Agent + one Credential, both keyed to the sub.
+    const agentPut = puts.find((p) => p.table === "Agent");
+    const credPut = puts.find((p) => p.table === "Credential");
+    expect(agentPut?.record.admin).toBe(false);
+    expect(agentPut?.record.kind).toBe("agent");
+    expect(credPut?.record.kind).toBe("idp");
+    expect(credPut?.record.idpSubject).toBe("fresh-sub");
+    expect(credPut?.record.principalId).toBe(agent!.agentId);
+  });
+
+  it("empty sub → null", async () => {
+    expect(await resolveAgentFromSub("")).toBeNull();
+  });
+});
+
+// ─── tools/call scoping ──────────────────────────────────────────────────────
+describe("tools/call — scopes to the resolved agent (no forging)", () => {
+  beforeEach(() => {
+    credentials = [{ principalId: "agt_bob", kind: "idp", idpSubject: "sub-bob", status: "active" }];
+  });
+
+  it("memory_search delegates with request.tpsAgent = resolved id", async () => {
+    const res = await mcpHandler(post(
+      { jsonrpc: "2.0", id: 1, method: "tools/call", params: { name: "memory_search", arguments: { query: "hi", limit: 3 } } },
+      { sub: "sub-bob" },
+    ));
+    const body = await parse(res);
+    expect(lastCall?.resource).toBe("SemanticSearch.post");
+    expect(lastCall?.ctx.request.tpsAgent).toBe("agt_bob");
+    expect(lastCall?.args).toEqual({ q: "hi", limit: 3 });
+    expect(body.result.structuredContent.agentId).toBe("agt_bob");
+  });
+
+  it("memory_store uses resolved agentId, ignores a forged body agentId", async () => {
+    await mcpHandler(post(
+      { jsonrpc: "2.0", id: 1, method: "tools/call", params: { name: "memory_store", arguments: { content: "x", agentId: "agt_victim" } } },
+      { sub: "sub-bob" },
+    ));
+    // The tool sets agentId from the RESOLVED agent, not the (forged) arg.
+    expect(lastCall?.resource).toBe("Memory.post");
+    expect(lastCall?.args.agentId).toBe("agt_bob");
+    expect(lastCall?.ctx.request.tpsAgent).toBe("agt_bob");
+  });
+
+  it("soul_set PUTs with id = agentId:key (so soul_get can find it)", async () => {
+    await mcpHandler(post(
+      { jsonrpc: "2.0", id: 1, method: "tools/call", params: { name: "soul_set", arguments: { key: "role", value: "cofounder" } } },
+      { sub: "sub-bob" },
+    ));
+    expect(lastCall?.resource).toBe("Soul.put");
+    expect(lastCall?.args.id).toBe("agt_bob:role");
+    expect(lastCall?.args.agentId).toBe("agt_bob");
+    expect(lastCall?.args.key).toBe("role");
+  });
+
+  it("flair_orgevent carries NO authorId in the body (attributed from identity)", async () => {
+    await mcpHandler(post(
+      { jsonrpc: "2.0", id: 1, method: "tools/call", params: { name: "flair_orgevent", arguments: { kind: "status", summary: "alive", targets: ["x"] } } },
+      { sub: "sub-bob" },
+    ));
+    expect(lastCall?.resource).toBe("OrgEvent.post");
+    expect(lastCall?.args).not.toHaveProperty("authorId");
+    expect(lastCall?.args.targetIds).toEqual(["x"]);
+    expect(lastCall?.ctx.request.tpsAgent).toBe("agt_bob");
+  });
+
+  it("flair_workspace_set carries NO agentId in the body", async () => {
+    await mcpHandler(post(
+      { jsonrpc: "2.0", id: 1, method: "tools/call", params: { name: "flair_workspace_set", arguments: { ref: "main", phase: "implement" } } },
+      { sub: "sub-bob" },
+    ));
+    expect(lastCall?.resource).toBe("WorkspaceState.post");
+    expect(lastCall?.args).not.toHaveProperty("agentId");
+    expect(lastCall?.args.ref).toBe("main");
+    expect(lastCall?.args.id).toBe("agt_bob:main");
+  });
+});
+
+// ─── tools/call denial paths ─────────────────────────────────────────────────
+describe("tools/call — denial", () => {
+  it("no verified sub → denied, handler never invoked", async () => {
+    const res = await mcpHandler(post(
+      { jsonrpc: "2.0", id: 1, method: "tools/call", params: { name: "memory_search", arguments: { query: "x" } } },
+      {}, // request.mcp present but no sub
+    ));
+    const body = await parse(res);
+    expect(body.error).toBeDefined();
+    expect(lastCall).toBeNull();
+  });
+
+  it("unresolvable sub (JIT off) → forbidden, handler never invoked", async () => {
+    credentials = [];
+    const res = await mcpHandler(post(
+      { jsonrpc: "2.0", id: 1, method: "tools/call", params: { name: "memory_search", arguments: { query: "x" } } },
+      { sub: "ghost" },
+    ));
+    const body = await parse(res);
+    expect(body.error.message).toContain("not a provisioned flair agent");
+    expect(lastCall).toBeNull();
+  });
+
+  it("unknown tool → invalid params, handler never invoked", async () => {
+    const res = await mcpHandler(post(
+      { jsonrpc: "2.0", id: 1, method: "tools/call", params: { name: "drop_all_tables", arguments: {} } },
+      { sub: "sub-bob" },
+    ));
+    const body = await parse(res);
+    expect(body.error.message).toContain("unknown tool");
+    expect(lastCall).toBeNull();
+  });
+});
+
+// ─── protocol errors ─────────────────────────────────────────────────────────
+describe("protocol errors", () => {
+  it("non-POST → 405", async () => {
+    const res = await mcpHandler({ method: "GET", mcp: { sub: "s" } });
+    expect(res.status).toBe(405);
+  });
+  it("invalid JSON → parse error", async () => {
+    const res = await mcpHandler({ method: "POST", mcp: { sub: "s" }, text: async () => "{not json" });
+    const body = await parse(res);
+    expect(body.error.code).toBe(-32700);
+  });
+  it("non-JSON-RPC object → invalid request", async () => {
+    const res = await mcpHandler(post({ hello: "world" }, { sub: "s" }));
+    const body = await parse(res);
+    expect(body.error.code).toBe(-32600);
+  });
+  it("unknown method → method not found", async () => {
+    const res = await mcpHandler(post({ jsonrpc: "2.0", id: 9, method: "resources/list" }, { sub: "s" }));
+    const body = await parse(res);
+    expect(body.error.code).toBe(-32601);
+  });
+});

--- a/test/unit/mcp-oauth-flag.test.ts
+++ b/test/unit/mcp-oauth-flag.test.ts
@@ -1,0 +1,110 @@
+/**
+ * mcp-oauth-flag.test.ts — the FLAIR_MCP_OAUTH feature flag + AS config helpers.
+ *
+ * Pure env-driven logic (no Harper import), so it runs standalone. The
+ * security-relevant assertions: the flag is OFF by default and for any
+ * non-truthy value (so a typo can't silently enable an auth surface), and
+ * mcpAuthConfig() returns undefined unless BOTH the flag is on AND an issuer is
+ * configured (so withMCPAuth is never handed a half-configured, floating-issuer
+ * config — the audience-confusion risk the plugin's checklist warns about).
+ */
+
+import { describe, it, expect, afterEach } from "bun:test";
+import {
+  mcpOAuthEnabled,
+  mcpIssuer,
+  mcpResource,
+  mcpAuthConfig,
+} from "../../resources/mcp-oauth-flag.ts";
+
+const ENV_KEYS = ["FLAIR_MCP_OAUTH", "FLAIR_MCP_ISSUER", "FLAIR_PUBLIC_URL"];
+const saved: Record<string, string | undefined> = {};
+for (const k of ENV_KEYS) saved[k] = process.env[k];
+
+function clearEnv() {
+  for (const k of ENV_KEYS) delete process.env[k];
+}
+
+afterEach(() => {
+  for (const k of ENV_KEYS) {
+    if (saved[k] === undefined) delete process.env[k];
+    else process.env[k] = saved[k];
+  }
+});
+
+describe("mcpOAuthEnabled — default-OFF", () => {
+  it("unset → OFF", () => {
+    clearEnv();
+    expect(mcpOAuthEnabled()).toBe(false);
+  });
+
+  it("empty string → OFF", () => {
+    clearEnv();
+    process.env.FLAIR_MCP_OAUTH = "";
+    expect(mcpOAuthEnabled()).toBe(false);
+  });
+
+  it.each(["1", "true", "TRUE", "yes", "on", " On "])("truthy %p → ON", (v) => {
+    clearEnv();
+    process.env.FLAIR_MCP_OAUTH = v;
+    expect(mcpOAuthEnabled()).toBe(true);
+  });
+
+  it.each(["0", "false", "no", "off", "enabled", "2", "y"])("non-truthy %p → OFF", (v) => {
+    clearEnv();
+    process.env.FLAIR_MCP_OAUTH = v;
+    expect(mcpOAuthEnabled()).toBe(false);
+  });
+});
+
+describe("mcpIssuer / mcpResource", () => {
+  it("unset → undefined", () => {
+    clearEnv();
+    expect(mcpIssuer()).toBeUndefined();
+    expect(mcpResource()).toBeUndefined();
+  });
+
+  it("FLAIR_MCP_ISSUER wins", () => {
+    clearEnv();
+    process.env.FLAIR_MCP_ISSUER = "https://flair.example.com";
+    process.env.FLAIR_PUBLIC_URL = "https://other.example.com";
+    expect(mcpIssuer()).toBe("https://flair.example.com");
+  });
+
+  it("falls back to FLAIR_PUBLIC_URL", () => {
+    clearEnv();
+    process.env.FLAIR_PUBLIC_URL = "https://pub.example.com";
+    expect(mcpIssuer()).toBe("https://pub.example.com");
+  });
+
+  it("resource is issuer + /mcp (trailing slash trimmed)", () => {
+    clearEnv();
+    process.env.FLAIR_MCP_ISSUER = "https://flair.example.com/";
+    expect(mcpResource()).toBe("https://flair.example.com/mcp");
+  });
+});
+
+describe("mcpAuthConfig — requires flag ON *and* issuer set", () => {
+  it("flag off → undefined (even with issuer)", () => {
+    clearEnv();
+    process.env.FLAIR_MCP_ISSUER = "https://flair.example.com";
+    expect(mcpAuthConfig()).toBeUndefined();
+  });
+
+  it("flag on but no issuer → undefined (never a floating iss/aud)", () => {
+    clearEnv();
+    process.env.FLAIR_MCP_OAUTH = "1";
+    expect(mcpAuthConfig()).toBeUndefined();
+  });
+
+  it("flag on + issuer → pinned enabled config", () => {
+    clearEnv();
+    process.env.FLAIR_MCP_OAUTH = "1";
+    process.env.FLAIR_MCP_ISSUER = "https://flair.example.com";
+    expect(mcpAuthConfig()).toEqual({
+      enabled: true,
+      issuer: "https://flair.example.com",
+      resource: "https://flair.example.com/mcp",
+    });
+  });
+});

--- a/test/unit/mcp-oauth-register.test.ts
+++ b/test/unit/mcp-oauth-register.test.ts
@@ -1,0 +1,107 @@
+/**
+ * mcp-oauth-register.test.ts — the flag-OFF NO-OP contract for /mcp registration.
+ *
+ * registerMcpOAuthRoute() must:
+ *   - flag OFF  → NEVER call server.http, NEVER load the oauth plugin (returns
+ *     false). This is the byte-identical boot contract.
+ *   - flag ON but no issuer → NEVER mount (no floating-issuer guard) → false.
+ *   - flag ON + issuer → register withMCPAuth(handler) on urlPath '/mcp' ONLY.
+ *
+ * We call the exported registration function directly with injected deps (a spy
+ * server + a stub withMCPAuth loader), so the test never depends on the load-time
+ * side effect or the real Harper `server`. @harperfast/harper is mocked only so
+ * the module's static `import { server }` resolves; the module-level fire-and-
+ * forget call runs with the flag OFF (default) and returns before touching it.
+ */
+
+import { mock, describe, it, expect, beforeEach } from "bun:test";
+
+// Suppress the module-level auto-registration on import — we call
+// registerMcpOAuthRoute() directly with injected deps.
+process.env.FLAIR_MCP_NO_AUTOSTART = "1";
+
+// A complete-enough harper mock: `server` (what mcp-oauth.ts reads) PLUS
+// `Resource` + `databases` so that if the real mcp-handler → mcp-tools → resource
+// import graph loads under this mock (module-cache ordering in the full suite),
+// it still links. `mock.module` is process-global in bun, so a superset mock is
+// the safe shape.
+class NoopBase { constructor(_id?: any, _ctx?: any) {} }
+const dbStub = new Proxy({}, { get: () => new Proxy({}, { get: () => NoopBase }) });
+mock.module("@harperfast/harper", () => ({
+  server: { http: () => {} },
+  Resource: NoopBase,
+  databases: { flair: dbStub },
+}));
+// mcp-handler.ts (imported by mcp-oauth.ts) pulls in the resource handlers +
+// databases; stub so the import graph loads outside a Harper runtime.
+mock.module("../../resources/mcp-handler.ts", () => ({ mcpHandler: () => ({ status: 200 }) }));
+
+const { registerMcpOAuthRoute } = await import("../../resources/mcp-oauth.ts");
+
+const ENV = ["FLAIR_MCP_OAUTH", "FLAIR_MCP_ISSUER", "FLAIR_PUBLIC_URL"];
+function clearEnv() { for (const k of ENV) delete process.env[k]; }
+
+let httpCalls: { handler: any; options: any }[];
+let withMCPAuthCalls: { handler: any; options: any }[];
+let loadCount: number;
+
+function makeDeps() {
+  httpCalls = [];
+  withMCPAuthCalls = [];
+  loadCount = 0;
+  return {
+    server: { http: (handler: any, options: any) => { httpCalls.push({ handler, options }); } },
+    loadWithMCPAuth: async () => {
+      loadCount++;
+      return (handler: any, options: any) => {
+        withMCPAuthCalls.push({ handler, options });
+        return { __wrapped: true, handler, options };
+      };
+    },
+  };
+}
+
+beforeEach(clearEnv);
+
+describe("registerMcpOAuthRoute — flag-OFF no-op", () => {
+  it("flag OFF → server.http NEVER called, plugin NEVER loaded, returns false", async () => {
+    clearEnv();
+    const deps = makeDeps();
+    const mounted = await registerMcpOAuthRoute(deps);
+    expect(mounted).toBe(false);
+    expect(httpCalls).toHaveLength(0);
+    expect(loadCount).toBe(0); // the oauth plugin is not even imported when off
+  });
+
+  it("flag ON but no issuer → NOT mounted (no floating iss), returns false", async () => {
+    clearEnv();
+    process.env.FLAIR_MCP_OAUTH = "1";
+    const deps = makeDeps();
+    const mounted = await registerMcpOAuthRoute(deps);
+    expect(mounted).toBe(false);
+    expect(httpCalls).toHaveLength(0);
+    expect(loadCount).toBe(0); // bails before loading the plugin
+  });
+
+  it("flag ON + issuer → withMCPAuth(handler) mounted on urlPath '/mcp'", async () => {
+    clearEnv();
+    process.env.FLAIR_MCP_OAUTH = "1";
+    process.env.FLAIR_MCP_ISSUER = "https://flair.example.com";
+    const deps = makeDeps();
+    const mounted = await registerMcpOAuthRoute(deps);
+    expect(mounted).toBe(true);
+    expect(httpCalls).toHaveLength(1);
+    // Registered on the /mcp urlPath subroute (its own chain).
+    expect(httpCalls[0].options).toEqual({ urlPath: "/mcp" });
+    // The registered handler is the withMCPAuth-wrapped one.
+    expect(httpCalls[0].handler.__wrapped).toBe(true);
+    // getConfig pins iss/resource for the wrapper.
+    expect(withMCPAuthCalls).toHaveLength(1);
+    const cfg = withMCPAuthCalls[0].options.getConfig();
+    expect(cfg).toEqual({
+      enabled: true,
+      issuer: "https://flair.example.com",
+      resource: "https://flair.example.com/mcp",
+    });
+  });
+});


### PR DESCRIPTION
## Native `/mcp` OAuth surface — Model 2 (custom `withMCPAuth`-guarded handler), default-OFF

Spec: `~/ops/specs/FLAIR-NATIVE-MCP-OAUTH.md` · Bead: **ops-b6uk** (ties #520 / ops-t7lx). Nathan approved **Model 2** 2026-07-01.

Flair speaks MCP natively over a **custom in-process `/mcp` JSON-RPC handler** wrapped with `@harperfast/oauth`'s `withMCPAuth`, serving the 9 curated flair tools with a per-agent OAuth identity — replacing the local `flair-mcp` stdio proxy's key-holding. Model 2 is a custom handler (NOT Harper's native application-MCP profile), so it sidesteps the Harper native-MCP gating gaps and is **curated by construction** (only the 9 flair tools; no raw CRUD surface).

### Default-OFF (byte-identical flag-OFF)
Everything is gated behind **`FLAIR_MCP_OAUTH`, default-OFF**. Flag unset (shipped default) → no `/mcp` route registered, `@harperfast/oauth` never imported, default Ed25519 auth chain unchanged. **`auth-middleware.ts`, `XAA.ts`, `OAuth.ts`, `config.yaml`, and every delegated handler resource are untouched** (git-verified — the diff is purely additive resources + tests + deps/policy).

### The handler + sub→Agent mapping
- **`resources/mcp-handler.ts`** — `initialize` / `tools/list` / `tools/call` / `ping`. `withMCPAuth` fails closed before the handler and sets `request.mcp = {sub, client_id, aud, scope}`. On `tools/call`: `request.mcp.sub` → `Credential(kind:"idp", idpSubject=sub)` → `principalId` (the **same identity surface XAA uses**) → establish `request.tpsAgent` scoping → delegate to the existing resource handler (which enforces per-agent scoping via `resolveAgentAuth`). An **unresolvable sub is DENIED** — never anonymous, never admin.
- **`resources/mcp-tools.ts`** — the 9 tools, thin wrappers over Memory / SemanticSearch / BootstrapMemories / Soul / WorkspaceState / OrgEvent (lazy-loaded so the `/mcp` module graph carries no top-level Harper link). Identity always from the resolved agent, never the args (no forging of agentId/authorId). Fixed a soul-keying bug carried from the design-A slice: `soul_set` now PUTs `id = agentId:key` so `soul_get` finds it.
- **`resources/mcp-oauth.ts`** — `server.http(withMCPAuth(mcpHandler), { urlPath: '/mcp' })` **only when the flag is on** (own dispatch chain; default auth-middleware doesn't run for `/mcp`). `getConfig` pins issuer/resource so iss/aud match minted tokens.
- **`resources/mcp-oauth-flag.ts`** — the flag + issuer/resource config helpers.

### Sherlock's 4 requirements (auth trust boundary — HARD gate)
1. **Token lifetime** — short-lived MCP JWTs via `mcp.accessTokenTtl` (5–15 min, documented as required in `docs/notes/mcp-oauth-model2.md`) + the plugin's refresh-token rotation; `withMCPAuth` validates `exp` strictly.
2. **RS256 pinning** — verified against the real 2.1.0 package: `MCPConfig.signingAlgorithm?: 'RS256'` — "Only RS256 is supported in v1." The plugin mints/verifies RS256-only, so `none` / HS256-confusion is **structurally impossible** — no configurable `alg` to widen.
3. **Dual-auth precedence** — `/mcp` is OAuth-only on its **own urlPath chain**; flair's default (Ed25519) chain never runs for `/mcp`, and the OAuth Bearer never reaches the default chain. No request path carries both → they **cannot collide**.
4. **DCR authentication** — `mcp.dynamicClientRegistration.initialAccessToken` gates `/oauth/mcp/register`; on the resolution side, JIT-provisioning of an unknown sub is a **second** explicit trust anchor (`FLAIR_MCP_JIT_PROVISION`, default OFF).

### Supply-chain note (for review)
`@harperfast/oauth@2.1.0` is fresh (published <7 days). Added to the keep-current allow-list (`scripts/check-dep-ages.mjs` + `docs/supply-chain-policy.md` + `.github/renovate.json`) — same high-trust `@harperfast/*` owner as `@harperfast/harper` (already exempt), and it's **dynamically imported only when the default-OFF surface is enabled** (zero exposure in the shipped build). Flagging explicitly for Sherlock.

### Tests (46 new)
- `mcp-oauth-flag`: default-OFF for any non-truthy value; `mcpAuthConfig` requires flag ON **and** issuer set (never a floating iss/aud).
- `mcp-handler`: `tools/list` = **exactly 9** (no CRUD mutators); sub→Agent resolution (existing credential / admin / revoked-skip / JIT-on provisions non-admin / JIT-off → deny); `tools/call` scopes to the resolved agent + no-forge (memory_store ignores forged body agentId; orgevent/workspace carry no authorId/agentId; soul_set id=agentId:key); no-sub / unresolvable / unknown-tool → denied, handler never invoked; protocol errors.
- `mcp-oauth-register`: **flag-OFF → `server.http` never called, plugin never loaded**; flag-ON+no-issuer → not mounted; flag-ON+issuer → `withMCPAuth` on `urlPath '/mcp'`.

**Full unit suite: 1208 pass / 0 fail.** typecheck (strict, 0 errors) + build + `check-imports dist` + `check-dep-ages` + `check-workspace-deps` all green.

### Deferred (per spec fallback — did NOT ship a half-wired auth path)
- Live `config.yaml` wiring of the `@harperfast/oauth` AS plugin — kept out to preserve the byte-identical flag-OFF contract (adding a plugin block changes boot). The exact config block is documented for operators in `docs/notes/mcp-oauth-model2.md`.
- Migrating the homegrown `OAuth.ts` / `XAA.ts` — deprecate-don't-delete per Kern; they stay for the Ed25519/signed-REST path. This slice reuses XAA's `Credential(kind:"idp")` surface.

### Prior art context
An unmerged `native-mcp-surface` branch has slice-1 of the **design-A** path (Harper native application-MCP: `static mcpTools` + resource-level `static hidden` curation + a 5.1.14 registration workaround + root-config injection). Model 2 supersedes it as the recommended path per the spec (design A → optional/deferred). This PR reuses design-A's 9 tool schemas + delegation logic but drops the native-MCP scaffolding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
