### PR TITLE
feat(bootstrap): surface team roster + cross-agent search nudge

### DIFF
--- a/resources/MemoryBootstrap.ts
+++ b/resources/MemoryBootstrap.ts
@@ -14,6 +14,9 @@ import { wrapUntrusted } from "./content-safety.js";
  *   4. Task-relevant memories (semantic search if currentTask provided)
  *   5. Relationship context (active relationships for mentioned entities)
  *   6. Predicted context (based on channel/surface/subject hints)
+ *   7. Team roster (other active agents in this office + a search-first nudge —
+ *      bootstrap only ever loads the caller's own memories, so this is the one
+ *      place agents learn teammates' findings exist without a separate call)
  *
  * Prediction: when context signals (channel, surface, subjects) are provided,
  * the bootstrap loads more aggressively — Flair is fast enough that the
@@ -98,6 +101,7 @@ export class BootstrapMemories extends Resource {
     const sections: Record<string, string[]> = {
       soul: [],
       skills: [],
+      team: [],
       permanent: [],
       recent: [],
       predicted: [],
@@ -191,6 +195,33 @@ export class BootstrapMemories extends Resource {
         }
         sections.skills.push(line);
       }
+    }
+
+    // --- 1c. Team roster + cross-agent search nudge ---
+    // Bootstrap only ever loads the caller's OWN soul/memories (every query
+    // below filters record.agentId === agentId). Nothing here tells the agent
+    // that teammates exist or that their findings are one memory_search away
+    // — so agents never think to check before re-investigating something a
+    // teammate already solved. This section is fixed-cost (no query text to
+    // format per agent) so it's cheap enough to always include, not budgeted.
+    try {
+      const teammateIds: string[] = [];
+      for await (const record of (databases as any).flair.Agent.search()) {
+        if (record.id === agentId) continue;
+        if (record.kind && record.kind !== "agent") continue;
+        if (record.status && record.status !== "active") continue;
+        teammateIds.push(record.id);
+      }
+      if (teammateIds.length > 0) {
+        const plural = teammateIds.length === 1 ? "agent shares" : "agents share";
+        const line =
+          `${teammateIds.length} other ${plural} this Flair office (${teammateIds.join(", ")}). ` +
+          `Before deep-diving an unfamiliar problem, search their memories for related work — ` +
+          `\`memory_search\` covers any agent you hold a search grant from.`;
+        sections.team.push(line);
+      }
+    } catch {
+      // Agent table may not exist in older / standalone deployments
     }
 
     // --- 2. Permanent memories (always included, highest priority) ---
@@ -405,6 +436,9 @@ export class BootstrapMemories extends Resource {
     if (sections.skills.length > 0) {
       parts.push("## Active Skills\n" + sections.skills.join("\n"));
     }
+    if (sections.team.length > 0) {
+      parts.push("## Team\n" + sections.team.join("\n"));
+    }
     if (sections.permanent.length > 0) {
       parts.push("## Core Principles\n" + sections.permanent.join("\n"));
     }
@@ -433,6 +467,7 @@ export class BootstrapMemories extends Resource {
       sections: {
         soul: sections.soul.length,
         skills: sections.skills.length,
+        team: sections.team.length,
         permanent: sections.permanent.length,
         recent: sections.recent.length,
         predicted: sections.predicted.length,

--- a/resources/MemoryBootstrap.ts
+++ b/resources/MemoryBootstrap.ts
@@ -2,6 +2,7 @@ import { Resource, databases } from "@harperfast/harper";
 import { allowVerified } from "./agent-auth.js";
 import { getEmbedding } from "./embeddings-provider.js";
 import { wrapUntrusted } from "./content-safety.js";
+import { isTeammate, formatTeamLine } from "./memory-bootstrap-lib.js";
 
 /**
  * POST /MemoryBootstrap
@@ -204,22 +205,19 @@ export class BootstrapMemories extends Resource {
     // — so agents never think to check before re-investigating something a
     // teammate already solved. This section is fixed-cost (no query text to
     // format per agent) so it's cheap enough to always include, not budgeted.
+    //
+    // Permissive kind/status checks are DELIBERATE: Agent.ts registration
+    // defaults both (`kind ||= "agent"`, `status ||= "active"`), so pre-1.0
+    // records missing either field are legacy agents/active — a strict
+    // `!== "agent"` check would silently drop them. Assumes single-tenant
+    // (one instance = one office); grant-filtered roster is the multi-tenant follow-up.
     try {
       const teammateIds: string[] = [];
       for await (const record of (databases as any).flair.Agent.search()) {
-        if (record.id === agentId) continue;
-        if (record.kind && record.kind !== "agent") continue;
-        if (record.status && record.status !== "active") continue;
-        teammateIds.push(record.id);
+        if (isTeammate(record, agentId)) teammateIds.push(record.id);
       }
-      if (teammateIds.length > 0) {
-        const plural = teammateIds.length === 1 ? "agent shares" : "agents share";
-        const line =
-          `${teammateIds.length} other ${plural} this Flair office (${teammateIds.join(", ")}). ` +
-          `Before deep-diving an unfamiliar problem, search their memories for related work — ` +
-          `\`memory_search\` covers any agent you hold a search grant from.`;
-        sections.team.push(line);
-      }
+      const line = formatTeamLine(teammateIds);
+      if (line) sections.team.push(line);
     } catch {
       // Agent table may not exist in older / standalone deployments
     }

--- a/resources/memory-bootstrap-lib.ts
+++ b/resources/memory-bootstrap-lib.ts
@@ -1,0 +1,43 @@
+// ─── MemoryBootstrap — pure evaluation logic ────────────────────────────────
+// Pure helpers extracted from MemoryBootstrap.ts (section 1c, PR #549) so they
+// can be unit-tested directly. Importing MemoryBootstrap.ts pulls in the
+// Harper runtime (`databases` / `Resource`, storage init) and can't run
+// outside a live Harper; this module has no Harper dependency, so
+// test/unit/bootstrap-team.test.ts exercises the real shipped code.
+
+import { wrapUntrusted } from "./content-safety.js";
+
+/**
+ * Is `record` a live teammate of `callerId` for roster purposes?
+ *
+ * Permissive by design: pre-1.0 Agent records may not have `kind`/`status` at
+ * all (Agent.ts registration only started defaulting both — `kind ||= "agent"`,
+ * `status ||= "active"` — from the 1.0 auth reshape onward). A missing field
+ * means "legacy agent, active", not "unknown, exclude" — so we only exclude on
+ * an explicit non-matching value, never on absence.
+ */
+export function isTeammate(record: { id?: string; kind?: string; status?: string }, callerId: string): boolean {
+  if (record.id === callerId) return false;
+  if (record.kind && record.kind !== "agent") return false;
+  if (record.status && record.status !== "active") return false;
+  return true;
+}
+
+/**
+ * Format the "## Team" roster line for a list of teammate ids, or `null`
+ * when the roster is empty (caller should omit the section entirely).
+ *
+ * Teammate ids are registrant-chosen strings, not something Flair controls —
+ * they're untrusted the same way memory content is, so only the id list goes
+ * through wrapUntrusted; the surrounding instructional text is trusted and
+ * stays outside the wrap.
+ */
+export function formatTeamLine(teammateIds: string[]): string | null {
+  if (teammateIds.length === 0) return null;
+  const plural = teammateIds.length === 1 ? "agent shares" : "agents share";
+  return (
+    `${teammateIds.length} other ${plural} this Flair office (${wrapUntrusted(teammateIds.join(", "))}). ` +
+    `Before deep-diving an unfamiliar problem, search their memories for related work — ` +
+    `\`memory_search\` covers any agent you hold a search grant from.`
+  );
+}

--- a/test/unit/bootstrap-team.test.ts
+++ b/test/unit/bootstrap-team.test.ts
@@ -1,0 +1,71 @@
+// Unit tests for the MemoryBootstrap "## Team" roster helpers (PR #549 review
+// findings: injection hardening on teammate ids + pre-1.0 compat coverage).
+//
+// These exercise the real shipped logic via the Harper-free lib — importing
+// MemoryBootstrap.ts directly pulls in the Harper runtime (`databases` /
+// `Resource`, storage init) and can't run outside a live Harper.
+
+import { describe, test, expect } from "bun:test";
+import { isTeammate, formatTeamLine } from "../../resources/memory-bootstrap-lib.ts";
+
+describe("isTeammate", () => {
+  test("excludes the caller's own record", () => {
+    expect(isTeammate({ id: "flint", kind: "agent", status: "active" }, "flint")).toBe(false);
+  });
+
+  test("excludes kind=human", () => {
+    expect(isTeammate({ id: "nathan", kind: "human", status: "active" }, "flint")).toBe(false);
+  });
+
+  test("excludes status=deactivated", () => {
+    expect(isTeammate({ id: "old-agent", kind: "agent", status: "deactivated" }, "flint")).toBe(false);
+  });
+
+  test("includes a record with NO kind/status fields (pre-1.0 compat)", () => {
+    // Agent.ts only defaults kind/status on registration from the 1.0 auth
+    // reshape onward (`kind ||= "agent"`, `status ||= "active"`). Records
+    // written before that have neither field — this is the semantics that
+    // matters most: absence must mean "legacy agent, active", not "exclude".
+    expect(isTeammate({ id: "anvil" }, "flint")).toBe(true);
+  });
+
+  test("includes a normal active agent record", () => {
+    expect(isTeammate({ id: "kern", kind: "agent", status: "active" }, "flint")).toBe(true);
+  });
+});
+
+describe("formatTeamLine", () => {
+  test("empty roster produces no line", () => {
+    expect(formatTeamLine([])).toBeNull();
+  });
+
+  test("singular phrasing for exactly one teammate", () => {
+    const line = formatTeamLine(["anvil"]);
+    expect(line).toContain("1 other agent shares this Flair office");
+    expect(line).not.toContain("agents share");
+  });
+
+  test("plural phrasing for more than one teammate", () => {
+    const line = formatTeamLine(["anvil", "kern", "sherlock"]);
+    expect(line).toContain("3 other agents share this Flair office");
+  });
+
+  test("teammate ids pass through wrapUntrusted in the output", () => {
+    const line = formatTeamLine(["anvil"]);
+    expect(line).not.toBeNull();
+    expect(line).toContain("[⚠️ SAFETY:");
+    expect(line).toContain("[/SAFETY]");
+    expect(line).toContain("anvil");
+  });
+
+  test("the trusted instructional text is NOT inside the safety wrapper", () => {
+    const line = formatTeamLine(["anvil"]);
+    expect(line).not.toBeNull();
+    // The nudge sentence should appear after the closing [/SAFETY] marker,
+    // i.e. outside the untrusted block — only the id list is wrapped.
+    const safetyEnd = line!.indexOf("[/SAFETY]");
+    const nudgeStart = line!.indexOf("Before deep-diving an unfamiliar problem");
+    expect(safetyEnd).toBeGreaterThan(-1);
+    expect(nudgeStart).toBeGreaterThan(safetyEnd);
+  });
+});


### PR DESCRIPTION
## Summary
- `MemoryBootstrap` only ever loads the caller's own soul/memories — every query filters `record.agentId === agentId`. Nothing in the assembled context ever told an agent that teammates exist, or that a `memory_search` call could surface their findings.
- Adds a fixed-cost `## Team` section: lists other active agents in the office and a one-line nudge to search their memories before deep-diving an unfamiliar problem. Not budgeted, same precedent as `## Active Skills`.

## Why
Traced this from a real gap on `kris-test`: krais fully diagnosed and filed a customer prod incident (analytics-aggregation main-thread wedge, harper#1538). Two other office agents (`dAIvid`, `devain`) hold search grants against krais's memories and could have found it via `memory_search`, but nothing in their bootstrap prompted them to look — so it never got checked. Bootstrap is the one call every agent reliably makes at session start (either manual per CLAUDE.md, or via the SessionStart hook), so it's the highest-leverage place to fix this centrally — one deploy covers the whole office with zero further coordination.

## Test plan
- [x] `npx tsc -p tsconfig.check.json --noEmit` — clean
- [x] `bun test test/unit/bootstrap-budget.test.ts test/unit/federation-bootstrap-user.test.ts` — 24 pass
- [x] `bun test test/unit` (full suite) — 1208 pass, 0 fail
- [ ] Manual: hit `/BootstrapMemories` against a live instance with >1 registered agent, confirm `## Team` section renders with roster + nudge text

---
🤖 *Drafted by Claude (Sonnet 5), reviewed by Kris.*
