### PR TITLE
fix(security): P0 cross-agent isolation break — getContext() not this.request (ops-sal4)

### DIFF
--- a/resources/AdminMemory.ts
+++ b/resources/AdminMemory.ts
@@ -23,7 +23,12 @@ import { layout, htmlResponse, esc } from "./admin-layout.js";
  */
 export class AdminMemory extends Resource {
   async get() {
-    const request = (this as any).request;
+    // Harper v5 does not populate this.request on Resource subclasses —
+    // getContext() is the only reliable path (ops-sal4: the previous
+    // `(this as any).request` read was always undefined, so query params
+    // (?id=, ?q=, ?subject=, ?limit=) were always ignored).
+    const ctx = (this as any).getContext?.();
+    const request = ctx?.request ?? ctx;
     const url = new URL(request?.url ?? "http://localhost", "http://localhost");
     const id = url.searchParams.get("id") ?? "";
 

--- a/resources/AgentSeed.ts
+++ b/resources/AgentSeed.ts
@@ -44,7 +44,14 @@ export class AgentSeed extends Resource {
   }
 
   async post(data: any) {
-    const actorId = (this as any).request?.tpsAgent;
+    // Harper v5 does not populate this.request on Resource subclasses —
+    // getContext() is the only reliable path (ops-sal4: the previous
+    // `(this as any).request` read was always undefined, so actorId was always
+    // undefined and this belt-and-suspenders check fail-closed every request,
+    // even from a real admin already verified by allowCreate()).
+    const ctx = (this as any).getContext?.();
+    const request = ctx?.request ?? ctx;
+    const actorId = request?.tpsAgent;
     if (!actorId || !(await isAdmin(actorId))) {
       return new Response(JSON.stringify({ error: "forbidden: admin only" }), { status: 403 });
     }

--- a/resources/IngestEvents.ts
+++ b/resources/IngestEvents.ts
@@ -97,7 +97,13 @@ export class IngestEvents extends Resource {
   }
 
   async post(body: unknown, context?: unknown) {
-    const request = (this as any).request;
+    // Harper v5 does not populate this.request on Resource subclasses —
+    // getContext() is the only reliable path (ops-sal4: the previous
+    // `(this as any).request` read was always undefined, so authHeader was
+    // always undefined and every request 401'd before reaching the office
+    // Ed25519 signature check below).
+    const ctx = (this as any).getContext?.();
+    const request = ctx?.request ?? ctx;
     const authHeader: string | undefined = request?.headers?.get?.("authorization") ?? request?.headers?.authorization;
 
     // Parse and validate body

--- a/resources/OAuth.ts
+++ b/resources/OAuth.ts
@@ -1,6 +1,7 @@
 import { Resource, databases } from "@harperfast/harper";
 import { createHash, randomBytes } from "node:crypto";
 import { handleJwtBearerGrant } from "./XAA.js";
+import { resolveAgentAuth } from "./agent-auth.js";
 
 /**
  * OAuth 2.1 Authorization Server for Flair.
@@ -141,7 +142,12 @@ export class OAuthAuthorize extends Resource {
   async get() {
     // In 1.0, this returns a simple HTML consent page.
     // The user (Nathan) approves or denies, which POSTs back.
-    const request = (this as any).request;
+    // Harper v5 does not populate this.request on Resource subclasses —
+    // getContext() is the only reliable path (ops-sal4: the previous
+    // `(this as any).request` read was always undefined, so query params were
+    // always empty).
+    const ctx = (this as any).getContext?.();
+    const request = ctx?.request ?? ctx;
     const url = new URL(request?.url ?? "http://localhost", "http://localhost");
     const clientId = url.searchParams.get("client_id") ?? "";
     const redirectUri = url.searchParams.get("redirect_uri") ?? "";
@@ -222,9 +228,29 @@ ${scope.split(" ").map((s: string) => `<div class="scope">${s}</div>`).join("")}
       return Response.redirect(`${redirectUri}?${params}`, 302);
     }
 
-    // Determine authenticated principal
-    const request = (this as any).request;
-    const principalId: string = request?.tpsAgent ?? "admin";
+    // Determine authenticated principal. Harper v5 does not populate
+    // this.request on Resource subclasses, so `(this as any).request?.tpsAgent`
+    // was always undefined and this ALWAYS fell back to the hardcoded "admin" —
+    // every approved consent grant was minted for the admin principal
+    // regardless of who actually approved it (ops-sal4 identity spoof).
+    // resolveAgentAuth(getContext()) resolves Basic super_user/admin auth to
+    // { kind: "agent", agentId: username, isAdmin: true } (see agent-auth.ts).
+    // We do NOT silently fall back to "admin" on an unresolved principal — if
+    // no principal can be resolved, that's an error state, not an admin grant.
+    //
+    // SECURITY REVIEW (Sherlock): is resolving the approving principal via
+    // resolveAgentAuth the correct policy for "who may approve OAuth consent"
+    // in 1.0 — i.e. must the approver be Basic-authenticated as super_user/
+    // admin, or should any verified (non-admin) agent be able to approve its
+    // own consent grant? The previous code always resolved to "admin" for
+    // every caller, so this is a genuine policy decision, not just a bug fix.
+    const auth = await resolveAgentAuth((this as any).getContext?.());
+    if (auth.kind !== "agent") {
+      return new Response(JSON.stringify({ error: "authentication required" }), {
+        status: 401, headers: { "content-type": "application/json" },
+      });
+    }
+    const principalId: string = auth.agentId;
 
     // Generate authorization code
     const code = randomBytes(32).toString("base64url");

--- a/resources/OrgEventCatchup.ts
+++ b/resources/OrgEventCatchup.ts
@@ -11,7 +11,7 @@
  */
 
 import { Resource, databases } from "@harperfast/harper";
-import { allowVerified } from "./agent-auth.js";
+import { allowVerified, resolveAgentAuth } from "./agent-auth.js";
 
 export class OrgEventCatchup extends Resource {
   // Self-authorize via the Ed25519 agent verify (auth reshape removes the gate's
@@ -24,9 +24,12 @@ export class OrgEventCatchup extends Resource {
 
   // HarperDB calls get(pathInfo, context) where pathInfo is the URL segment after /OrgEventCatchup/
   async get(pathInfo?: any) {
-    const request = (this as any).request;
-    const callerAgent = request?.tpsAgent;
-    const callerIsAdmin = request?.tpsAgentIsAdmin === true;
+    // Harper v5 does not populate this.request on Resource subclasses —
+    // getContext() is the only reliable path to the gate's tpsAgent/
+    // tpsAgentIsAdmin annotations (ops-sal4: the previous `(this as
+    // any).request` read was always undefined, so the ownership check below
+    // never ran — fail-open cross-agent read).
+    const auth = await resolveAgentAuth((this as any).getContext?.());
 
     // Harper routes /OrgEventCatchup/{id} with pathInfo.id as the path segment
     const participantId: string | null =
@@ -42,8 +45,16 @@ export class OrgEventCatchup extends Resource {
       );
     }
 
-    // Auth: requesting agent must match participantId (or admin)
-    if (callerAgent && !callerIsAdmin && callerAgent !== participantId) {
+    // Auth: internal calls and admins pass unfiltered; a verified agent may only
+    // fetch its own catchup feed; anonymous is denied. allowRead() already
+    // blocks anonymous HTTP, but this handler must fail closed on its own too.
+    if (auth.kind === "anonymous") {
+      return new Response(
+        JSON.stringify({ error: "forbidden: can only fetch events for yourself" }),
+        { status: 403, headers: { "Content-Type": "application/json" } },
+      );
+    }
+    if (auth.kind === "agent" && !auth.isAdmin && auth.agentId !== participantId) {
       return new Response(
         JSON.stringify({ error: "forbidden: can only fetch events for yourself" }),
         { status: 403, headers: { "Content-Type": "application/json" } },

--- a/resources/WorkspaceLatest.ts
+++ b/resources/WorkspaceLatest.ts
@@ -6,7 +6,7 @@
  */
 
 import { Resource, databases } from "@harperfast/harper";
-import { allowVerified } from "./agent-auth.js";
+import { allowVerified, resolveAgentAuth } from "./agent-auth.js";
 
 export class WorkspaceLatest extends Resource {
   // Self-authorize via the Ed25519 agent verify (auth reshape removes the gate's
@@ -17,9 +17,13 @@ export class WorkspaceLatest extends Resource {
   }
 
   async get(pathInfo?: any) {
-    const request = (this as any).context?.request ?? (this as any).request;
-    const callerAgent = request?.tpsAgent;
-    const callerIsAdmin = request?.tpsAgentIsAdmin === true;
+    // Harper v5 does not populate this.context / this.request on Resource
+    // subclasses — getContext() is the only reliable path to the gate's
+    // tpsAgent/tpsAgentIsAdmin annotations (ops-sal4: the previous
+    // `(this as any).context?.request ?? (this as any).request` read was always
+    // undefined, so the ownership check below never ran — fail-open cross-agent
+    // read).
+    const auth = await resolveAgentAuth((this as any).getContext?.());
 
     // Extract agentId from path: /WorkspaceLatest/{agentId}
     const agentId =
@@ -34,8 +38,16 @@ export class WorkspaceLatest extends Resource {
       );
     }
 
-    // Auth: requesting agent must match path agentId (or admin)
-    if (callerAgent && !callerIsAdmin && callerAgent !== agentId) {
+    // Auth: internal calls and admins pass unfiltered; a verified agent may only
+    // read its own workspace state; anonymous is denied. allowRead() already
+    // blocks anonymous HTTP, but this handler must fail closed on its own too.
+    if (auth.kind === "anonymous") {
+      return new Response(
+        JSON.stringify({ error: "forbidden: cannot read workspace state for another agent" }),
+        { status: 403, headers: { "Content-Type": "application/json" } },
+      );
+    }
+    if (auth.kind === "agent" && !auth.isAdmin && auth.agentId !== agentId) {
       return new Response(
         JSON.stringify({ error: "forbidden: cannot read workspace state for another agent" }),
         { status: 403, headers: { "Content-Type": "application/json" } },

--- a/test/unit/cross-agent-isolation.test.ts
+++ b/test/unit/cross-agent-isolation.test.ts
@@ -1,0 +1,256 @@
+/**
+ * cross-agent-isolation.test.ts — NECESSITY tests for the ops-sal4 P0 fix.
+ *
+ * flair-agent-deelevation.test.ts (integration) only asserts SUFFICIENCY: an
+ * agent CAN read its own WorkspaceLatest / OrgEventCatchup (`not.toContain([401,403])`).
+ * It never asserts NECESSITY — that an agent is DENIED another agent's data.
+ * That coverage gap is exactly why the fail-open cross-agent-read bug shipped
+ * and stayed CI-green:
+ *
+ *   - WorkspaceLatest.ts:20 read `(this as any).context?.request ?? (this as
+ *     any).request`, which Harper v5 never populates on Resource subclasses.
+ *     callerAgent was always undefined, so `if (callerAgent && ...)` never
+ *     ran — any verified agent could read any OTHER agent's workspace state.
+ *   - OrgEventCatchup.ts:27 had the identical bug via `(this as any).request`.
+ *
+ * Same mocking technique as coordination-write-auth.test.ts: mock
+ * @harperfast/harper (databases + Resource) so the resource classes can be
+ * imported and invoked directly with a synthetic context, outside a running
+ * Harper instance.
+ */
+
+import { mock, describe, it, expect, beforeEach } from "bun:test";
+
+// ─── Fixtures ─────────────────────────────────────────────────────────────
+
+let workspaceStateRecords: any[] = [];
+let orgEventRecords: any[] = [];
+let authCodePut: any = null;
+
+class BaseWorkspaceState {
+  static search(query: any) {
+    async function* gen() {
+      const cond = query?.conditions?.find((c: any) => c.attribute === "agentId");
+      for (const r of workspaceStateRecords) {
+        if (cond && r.agentId !== cond.value) continue;
+        yield r;
+      }
+    }
+    return gen();
+  }
+}
+
+class BaseOrgEvent {
+  static search(_query?: any) {
+    async function* gen() {
+      for (const r of orgEventRecords) yield r;
+    }
+    return gen();
+  }
+}
+
+// Minimal stand-in for Harper's runtime-injected `Resource` base class.
+// WorkspaceLatest / OrgEventCatchup / OAuth extend this directly (unlike
+// WorkspaceState / OrgEvent, which extend databases.flair.X).
+class MockResourceBase {
+  getContext() { return {}; }
+  getId() { return undefined; }
+}
+
+// Generic constructable stand-in for tables that other resources merely
+// `extends databases.flair.X` at module-load time — OAuth.ts imports XAA.ts
+// (for the jwt-bearer grant), and XAA.ts declares `class IdpConfig extends
+// (databases as any).flair.IdpConfig`. That class body never runs in these
+// tests, but the module-level `extends` needs a real constructor or the
+// import throws "superclass is not a constructor".
+class GenericTable {
+  static async get() { return null; }
+  static async put(rec: any) { return rec; }
+  static async delete() { return true; }
+  static async *search() {}
+}
+
+const databasesMock = {
+  flair: {
+    WorkspaceState: BaseWorkspaceState,
+    OrgEvent: BaseOrgEvent,
+    OAuthAuthCode: {
+      put: async (rec: any) => { authCodePut = rec; return rec; },
+    },
+    OAuthClient: { get: async () => null },
+    Agent: { get: async () => null, search: async function* () {} },
+    IdpConfig: GenericTable,
+    IdJagReplay: GenericTable,
+    Credential: GenericTable,
+    OAuthToken: GenericTable,
+  },
+};
+
+mock.module("@harperfast/harper", () => ({
+  databases: databasesMock,
+  Resource: MockResourceBase,
+}));
+
+const { WorkspaceLatest } = await import("../../resources/WorkspaceLatest.ts");
+const { OrgEventCatchup } = await import("../../resources/OrgEventCatchup.ts");
+const { OAuthAuthorize } = await import("../../resources/OAuth.ts");
+
+// ─── Helpers ──────────────────────────────────────────────────────────────
+
+// ctxRequest === undefined simulates a true internal call: getContext() itself
+// returns undefined, which resolveAgentAuth(undefined) resolves to
+// { kind: "internal" } (see resolve-agent-auth.test.ts). Any other value is
+// wrapped as { request: ctxRequest } — the gate's actual shape.
+function makeInstance<T>(Cls: any, ctxRequest: any | undefined): T {
+  const r: any = new Cls();
+  r.getContext = () => (ctxRequest === undefined ? undefined : { request: ctxRequest });
+  return r as T;
+}
+
+const agentCtx = (agentId: string, isAdmin = false) => ({ tpsAgent: agentId, tpsAgentIsAdmin: isAdmin });
+const anonCtx = () => ({ tpsAnonymous: true });
+
+beforeEach(() => {
+  workspaceStateRecords = [
+    { id: "ws-1", agentId: "agent-alpha", timestamp: "2026-01-01T00:00:00.000Z", ref: "main" },
+    { id: "ws-2", agentId: "agent-victim", timestamp: "2026-01-01T00:00:00.000Z", ref: "main" },
+  ];
+  orgEventRecords = [
+    { id: "ev-1", authorId: "agent-alpha", kind: "status", summary: "x", createdAt: "2026-01-01T00:00:01.000Z", targetIds: [] },
+  ];
+  authCodePut = null;
+});
+
+// ─── WorkspaceLatest ────────────────────────────────────────────────────────
+
+describe("WorkspaceLatest.get() — cross-agent isolation (ops-sal4)", () => {
+  it("agent requesting OWN id → allowed (reaches the query, not 403)", async () => {
+    const ws = makeInstance<any>(WorkspaceLatest, agentCtx("agent-alpha"));
+    const res = await ws.get("agent-alpha");
+    expect(res).not.toBeInstanceOf(Response);
+    expect(res.agentId).toBe("agent-alpha");
+  });
+
+  it("NECESSITY: agent requesting ANOTHER agent's id → 403 (MUST fail on unpatched main)", async () => {
+    const ws = makeInstance<any>(WorkspaceLatest, agentCtx("agent-alpha"));
+    const res = await ws.get("agent-victim");
+    expect(res).toBeInstanceOf(Response);
+    expect((res as Response).status).toBe(403);
+  });
+
+  it("admin requesting another agent's id → allowed", async () => {
+    const ws = makeInstance<any>(WorkspaceLatest, agentCtx("admin-1", true));
+    const res = await ws.get("agent-victim");
+    expect(res).not.toBeInstanceOf(Response);
+    expect(res.agentId).toBe("agent-victim");
+  });
+
+  it("internal call (no request context) → allowed", async () => {
+    const ws = makeInstance<any>(WorkspaceLatest, undefined);
+    const res = await ws.get("agent-victim");
+    expect(res).not.toBeInstanceOf(Response);
+    expect(res.agentId).toBe("agent-victim");
+  });
+
+  it("anonymous → 403", async () => {
+    const ws = makeInstance<any>(WorkspaceLatest, anonCtx());
+    const res = await ws.get("agent-alpha");
+    expect(res).toBeInstanceOf(Response);
+    expect((res as Response).status).toBe(403);
+  });
+});
+
+// ─── OrgEventCatchup ────────────────────────────────────────────────────────
+
+describe("OrgEventCatchup.get() — cross-agent isolation (ops-sal4)", () => {
+  const pathFor = (participantId: string) => ({
+    id: participantId,
+    conditions: [{ attribute: "since", value: "2020-01-01T00:00:00.000Z", comparator: "equals" }],
+  });
+
+  it("agent requesting OWN id → allowed (reaches the query, not 403)", async () => {
+    const oe = makeInstance<any>(OrgEventCatchup, agentCtx("agent-alpha"));
+    const res = await oe.get(pathFor("agent-alpha"));
+    expect(res).not.toBeInstanceOf(Response);
+    expect(Array.isArray(res)).toBe(true);
+  });
+
+  it("NECESSITY: agent requesting ANOTHER agent's id → 403 (MUST fail on unpatched main)", async () => {
+    const oe = makeInstance<any>(OrgEventCatchup, agentCtx("agent-alpha"));
+    const res = await oe.get(pathFor("agent-victim"));
+    expect(res).toBeInstanceOf(Response);
+    expect((res as Response).status).toBe(403);
+  });
+
+  it("admin requesting another agent's id → allowed", async () => {
+    const oe = makeInstance<any>(OrgEventCatchup, agentCtx("admin-1", true));
+    const res = await oe.get(pathFor("agent-victim"));
+    expect(res).not.toBeInstanceOf(Response);
+    expect(Array.isArray(res)).toBe(true);
+  });
+
+  it("internal call (no request context) → allowed", async () => {
+    const oe = makeInstance<any>(OrgEventCatchup, undefined);
+    const res = await oe.get(pathFor("agent-victim"));
+    expect(res).not.toBeInstanceOf(Response);
+    expect(Array.isArray(res)).toBe(true);
+  });
+
+  it("anonymous → 403", async () => {
+    const oe = makeInstance<any>(OrgEventCatchup, anonCtx());
+    const res = await oe.get(pathFor("agent-alpha"));
+    expect(res).toBeInstanceOf(Response);
+    expect((res as Response).status).toBe(403);
+  });
+});
+
+// ─── OAuthAuthorize — resolved principal (identity spoof fix) ──────────────
+
+describe("OAuthAuthorize.post() — resolved principal, not hardcoded admin (ops-sal4)", () => {
+  const approveBody = (extra: Record<string, any> = {}) => ({
+    action: "approve",
+    client_id: "cl1",
+    redirect_uri: "https://claude.com/api/mcp/auth_callback",
+    scope: "memory:read",
+    state: "st1",
+    code_challenge: "cc",
+    code_challenge_method: "S256",
+    ...extra,
+  });
+
+  it("approving principal is the authenticated agent (from the gate annotation, not a hardcoded 'admin')", async () => {
+    const oa = makeInstance<any>(OAuthAuthorize, agentCtx("agent-alpha", false));
+    const res = await oa.post(approveBody());
+    expect(res).toBeInstanceOf(Response);
+    expect((res as Response).status).toBe(302);
+    expect(authCodePut?.principalId).toBe("agent-alpha");
+    expect(authCodePut?.principalId).not.toBe("admin");
+  });
+
+  it("Basic super_user resolves via resolveAgentAuth to agentId=username (not the hardcoded literal)", async () => {
+    const oa: any = new (OAuthAuthorize as any)();
+    oa.getContext = () => ({ user: { username: "admin", role: { permission: { super_user: true } } } });
+    const res = await oa.post(approveBody());
+    expect(res).toBeInstanceOf(Response);
+    expect((res as Response).status).toBe(302);
+    // Coincidentally also "admin" here because the super_user's username IS
+    // "admin" — the point is it's DERIVED from the authenticated user, not a
+    // hardcoded fallback. See the next test for the case that tells them apart.
+    expect(authCodePut?.principalId).toBe("admin");
+  });
+
+  it("a different super_user username is preserved (proves it's not a hardcoded literal)", async () => {
+    const oa: any = new (OAuthAuthorize as any)();
+    oa.getContext = () => ({ user: { username: "nathan-basic", role: { permission: { super_user: true } } } });
+    await oa.post(approveBody());
+    expect(authCodePut?.principalId).toBe("nathan-basic");
+  });
+
+  it("no resolvable principal (anonymous) → 401, no auth code minted (fail closed, not admin grant)", async () => {
+    const oa = makeInstance<any>(OAuthAuthorize, anonCtx());
+    const res = await oa.post(approveBody());
+    expect(res).toBeInstanceOf(Response);
+    expect((res as Response).status).toBe(401);
+    expect(authCodePut).toBeNull();
+  });
+});


### PR DESCRIPTION
## P0 — cross-agent isolation break (ops-sal4)

**Live-confirmed** on a running instance: signing as one agent, `GET /WorkspaceLatest/{other-agent}` returned **HTTP 200 with the other agent's workspace record** instead of 403. A working ownership guard returns 403.

### Root cause
Harper v5 never populates `this.request` / `this.context` on `Resource` subclasses. The auth gate annotates the request with `tpsAgent` / `tpsAgentIsAdmin`; the only reliable read path is `getContext()`. The #236/#487 `this.request`→`getContext()` sweep fixed Memory/SemanticSearch/Bootstrap/Reflect/Consolidate but **missed 8 handlers**, which silently read `undefined` and either **fail-open** (security) or **fail-closed** (functional breakage). 31 resources use the canonical `resolveAgentAuth(getContext())` helper; these did not.

### Confirmed security fixes (fail-open → fail-closed)
| File | Bug |
|---|---|
| `WorkspaceLatest.ts` | `callerAgent` always `undefined` → `if (callerAgent && …)` ownership guard never ran → **any verified agent could read any other agent's WorkspaceState** (also closed an anonymous-read path). |
| `OrgEventCatchup.ts` | Identical bug on `GET /OrgEventCatchup/{participantId}`. |
| `OAuth.ts` (`OAuthAuthorize.post`) | `principalId = request?.tpsAgent ?? "admin"` → always `"admin"` → **every approved OAuth consent grant (and tokens minted from it) bound to the admin principal regardless of who approved it.** Now resolves via `resolveAgentAuth(getContext())` and returns **401 on an unresolved principal — no silent admin fallback**. |

New guard shape (Workspace/OrgEvent): internal calls + admins pass; a verified agent may only read **its own** id; anonymous → 403. The handler now fails closed on its own rather than trusting `allowRead()` alone.

### Functional-only fixes (same root cause, fail-closed, not exploitable)
- `OAuth.ts` (`OAuthAuthorize.get`) — consent-page query params were silently empty.
- `AgentSeed.ts` — `actorId` undefined → onboarding always 403'd even for verified admins.
- `IngestEvents.ts` — authHeader undefined → every office ingest 401'd before the Ed25519 check ran.
- `AdminMemory.ts` — `?id=/?q=/?subject=/?limit=` silently ignored.

**Verified safe, left unchanged:** `MemoryReindex.ts` already resolves `getContext()` first (`ctx?.request ?? ctx ?? this.request`).

### Why CI never caught this
The deelevation suite had only **SUFFICIENCY** coverage (agent reads its *own* data) and no **NECESSITY** coverage (agent *denied* another agent's data). `test/unit/cross-agent-isolation.test.ts` adds the missing negative tests for WorkspaceLatest + OrgEventCatchup (own id allowed, other agent's id → 403, admin allowed, internal allowed) plus OAuth principal-resolution.

**Proof the tests exercise the bug** (verified independently, not just self-reported): reverting only the 6 resource files to `origin/main` while keeping the new test → **7 of 14 fail** (the cross-agent/anonymous/principal cases return 302/200 where 401/403 is required). Restoring the fix → all 14 pass.

- `npx tsc -p tsconfig.check.json --noEmit` → clean
- `bun test test/unit` → **1222 pass / 0 fail** (baseline 1208 + 14 new; zero regressions)

### 🔴 Sherlock — HARD gate (auth trust boundary)
Two things need your explicit verdict:
1. **The fix itself** — the fail-closed ownership guards and the OAuth principal resolution.
2. **A policy question embedded in the OAuth fix** (inline comment at the `principalId` site): is resolving the approving principal via `resolveAgentAuth` the correct 1.0 policy for *who may approve OAuth consent* — must the approver be Basic-authenticated super_user/admin, or may any verified non-admin agent approve its own grant? The old code always resolved to `"admin"` for every caller, so this is a genuine policy decision, not just a mechanical fix.

Closes ops-sal4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)