### PR TITLE
fix(memory): stop dedup gate silently losing writes — co-gate + never-suppress + memory_update (#526, #548, ops-a4t5)

### DIFF
--- a/packages/flair-client/src/client.ts
+++ b/packages/flair-client/src/client.ts
@@ -128,37 +128,35 @@ export class FlairClient {
 class MemoryApi {
   constructor(private client: FlairClient) {}
 
-  /** Write a memory. Optionally checks for near-duplicates before writing. */
+  /**
+   * Write a memory. NEVER suppresses the write — the record is always
+   * created. `dedup`/`dedupThreshold` are passthrough HINTS forwarded to the
+   * server, which runs a conservative (cosine + lexical) near-duplicate check
+   * and, when a match is found, attaches a collision signal to the response
+   * (`deduplicated`, `matchedId`, `matchConfidence`) instead of dropping the
+   * new content. (Historical note: a near-duplicate previously short-circuited
+   * this method to return the EXISTING record without writing — that silently
+   * dropped distinct-but-similar content, e.g. flair#526. The check now lives
+   * server-side in Memory.put()/Memory.post() and never suppresses a write.)
+   */
   async write(content: string, opts: {
     id?: string;
     type?: MemoryType;
     durability?: Durability;
     tags?: string[];
     subject?: string;
-    /** Check for similar existing memories before writing. If a near-duplicate
-     *  is found (score >= threshold), returns it instead of creating a new one.
-     *  Default: false (no dedup check). */
+    /** Ask the server to run its conservative near-duplicate check for this
+     *  write and report a collision signal if found. Does NOT suppress the
+     *  write either way. Default: false (server still applies its own
+     *  default gate — this only requests the signal be computed/reported;
+     *  see dedupThreshold to tune it). */
     dedup?: boolean;
-    /** Similarity threshold for dedup. Default: 0.95 */
+    /** Cosine-similarity threshold hint for the server's dedup gate.
+     *  Default (server-side): 0.95 */
     dedupThreshold?: number;
   } = {}): Promise<Memory> {
-    // Near-duplicate check — skip for very short content where similarity
-    // is unreliable (e.g., "ok", "thanks" would match each other)
-    if (opts.dedup && content.length >= 20) {
-      const threshold = opts.dedupThreshold ?? 0.95;
-      // Use raw scoring to avoid retrieval-boost feedback loop where repeated
-      // dedup checks inflate scores above the threshold.
-      const existing = await this.search(content, { limit: 1, minScore: threshold, scoring: "raw" });
-      if (existing.length > 0) {
-        // Return the existing memory instead of creating a duplicate.
-        // Flag deduped so callers know this write was suppressed.
-        const match = await this.get(existing[0].id);
-        if (match) return { ...match, deduped: true };
-      }
-    }
-
     const id = opts.id ?? `${this.client.agentId}-${crypto.randomUUID()}`;
-    const record = {
+    const record: Record<string, unknown> = {
       id,
       agentId: this.client.agentId,
       content,
@@ -168,9 +166,81 @@ class MemoryApi {
       subject: opts.subject,
       createdAt: new Date().toISOString(),
     };
-    await this.client.request("PUT", `/Memory/${id}`, record);
-    // Harper PUT returns {} — return the record we constructed
-    return record as Memory;
+    // Passthrough hints — the server strips these before persisting; they are
+    // never stored on the record itself.
+    if (opts.dedup !== undefined) record.dedup = opts.dedup;
+    if (opts.dedupThreshold !== undefined) record.dedupThreshold = opts.dedupThreshold;
+
+    const response = await this.client.request<Record<string, unknown>>("PUT", `/Memory/${id}`, record);
+    // Merge the server response (deduplicated/matchedId/matchConfidence/
+    // written, plus any echoed fields) over the locally-constructed record —
+    // the write always happens, so `record` always reflects what was sent,
+    // and the server's signal fields (if any) always come through.
+    return { ...record, ...(response ?? {}) } as unknown as Memory;
+  }
+
+  /**
+   * Update an existing memory by id. Dedup-BYPASSED (this IS the intentional
+   * overwrite/version path, not an ambiguous new write) — always writes.
+   * Auth: the caller must own the memory (enforced server-side by the SAME
+   * ownership check Memory.put()/Memory.post() already run — no parallel
+   * check here).
+   *
+   * Default (`preserveHistory` unset/false): same-id overwrite via a
+   * full-record PUT. Harper's PUT is FULL RECORD REPLACEMENT, so we read the
+   * existing record first and merge the new content on top (never a bare
+   * partial). The stale embedding is cleared so the server's existing
+   * "generate embedding if missing" step recomputes it for the new content.
+   *
+   * `opts.preserveHistory: true`: write a NEW id with `supersedes: id`; the
+   * server closes the old record's `validTo` afterward, write-new BEFORE
+   * close-old (safe failure = two active records, never a lost write). If the
+   * old record is owned by a DIFFERENT agent, the server requires a "write"
+   * MemoryGrant from that owner — otherwise it denies the request (cross-agent
+   * write).
+   */
+  async update(id: string, content: string, opts: { preserveHistory?: boolean } = {}): Promise<Memory> {
+    const existing = await this.get(id);
+    if (!existing) {
+      throw new FlairError("PUT", `/Memory/${id}`, 404, `memory ${id} not found`);
+    }
+
+    if (opts.preserveHistory) {
+      const newId = `${this.client.agentId}-${crypto.randomUUID()}`;
+      const record: Record<string, unknown> = {
+        ...existing,
+        id: newId,
+        content,
+        supersedes: id,
+        createdAt: new Date().toISOString(),
+      };
+      delete record.updatedAt;
+      delete record.embedding;
+      delete record.embeddingModel;
+      delete record.validFrom;
+      delete record.validTo;
+      delete record.archivedAt;
+      delete record.deduped;
+      // The Memory schema does not expose a working HTTP POST route (see
+      // resources/Memory.ts) — Memory.post() is only reachable in-process
+      // (resources/mcp-tools.ts). So the supersede-link write goes through
+      // the same PUT-with-explicit-(new)-id path as a normal create; the
+      // server's Memory.put() validates/authorizes `supersedes`, writes this
+      // new record, then closes the old one transactionally (write-new
+      // BEFORE close-old — see resources/Memory.ts's closeSupersededIfNeeded).
+      // `supersedes` being set also makes the server bypass the dedup gate
+      // for this write (it's an intentional version link, not an ambiguous
+      // new write).
+      const response = await this.client.request<Record<string, unknown>>("PUT", `/Memory/${newId}`, record);
+      return { ...record, ...(response ?? {}) } as unknown as Memory;
+    }
+
+    const merged: Record<string, unknown> = { ...existing, content, updatedAt: new Date().toISOString() };
+    delete merged.embedding;
+    delete merged.embeddingModel;
+    delete merged.deduped;
+    const response = await this.client.request<Record<string, unknown>>("PUT", `/Memory/${id}`, merged);
+    return { ...merged, id, ...(response ?? {}) } as unknown as Memory;
   }
 
   /** Search memories by meaning. Optionally filter to facts valid at a specific point in time. */

--- a/packages/flair-client/src/types.ts
+++ b/packages/flair-client/src/types.ts
@@ -19,8 +19,26 @@ export interface Memory {
   subject?: string;
   createdAt: string;
   updatedAt?: string;
-  /** Set to true when write() returned an existing near-duplicate instead of
-   *  creating a new entry. Omitted/undefined for new writes. */
+  /** Always true after a successful write()/update() — the server never
+   *  suppresses a write, so this is never false/absent on a real response. */
+  written?: boolean;
+  /** True when the server's conservative dedup gate found a near-duplicate.
+   *  The new content was ALWAYS written regardless — this is a signal, not a
+   *  suppression flag. See `matchedId` / `matchConfidence`. */
+  deduplicated?: boolean;
+  /** The id of the existing memory the server's dedup gate matched against,
+   *  when `deduplicated` is true. */
+  matchedId?: string;
+  /** Confidence pair for the `matchedId` collision: raw cosine similarity and
+   *  Jaccard token-overlap against the new content, both in [0, 1]. */
+  matchConfidence?: { cosine: number; lexical: number };
+  /**
+   * @deprecated Historical field from the pre-fix client-side dedup gate,
+   * which suppressed the write and returned the EXISTING record instead
+   * (silently dropping distinct-but-similar content — flair#526). The gate is
+   * now server-side and NEVER suppresses a write; use `deduplicated` instead.
+   * No longer set by write()/update().
+   */
   deduped?: boolean;
 }
 

--- a/packages/flair-client/test/client.test.ts
+++ b/packages/flair-client/test/client.test.ts
@@ -155,17 +155,108 @@ describe("MemoryApi", () => {
     expect(call[1].method).toBe("DELETE");
   });
 
-  test("dedup skips for short content", async () => {
-    // Short content should NOT trigger a search
+  test("write() with dedup:true makes exactly one call — the gate is server-side now", async () => {
+    // No client-side pre-flight search exists anymore (memory-integrity fix,
+    // flair#526) — dedup/dedupThreshold are forwarded as hints in the SAME
+    // PUT body, never a separate search-then-write round trip.
     mockFetch = mock(() => Promise.resolve(new Response("{}", { status: 200 })));
     globalThis.fetch = mockFetch as any;
 
     const client = new FlairClient({ agentId: "test" });
     const result = await client.memory.write("short", { dedup: true });
 
-    // Should have made only 1 call (PUT), not 2 (search + PUT)
     expect(mockFetch).toHaveBeenCalledTimes(1);
     expect(result.content).toBe("short");
+    const call = (mockFetch as any).mock.calls[0];
+    expect(call[1].method).toBe("PUT");
+    const body = JSON.parse(call[1].body);
+    expect(body.dedup).toBe(true);
+  });
+
+  test("write() surfaces a server-reported dedup collision signal, never suppresses", async () => {
+    mockFetch = mock(() => Promise.resolve(new Response(JSON.stringify({
+      deduplicated: true,
+      matchedId: "test-existing-1",
+      matchConfidence: { cosine: 0.96, lexical: 0.7 },
+      written: true,
+    }), { status: 200 })));
+    globalThis.fetch = mockFetch as any;
+
+    const client = new FlairClient({ agentId: "test" });
+    const result = await client.memory.write("new distinct content that is long enough", { dedup: true });
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    expect(result.content).toBe("new distinct content that is long enough");
+    expect(result.id).not.toBe("test-existing-1");
+    expect((result as any).deduplicated).toBe(true);
+    expect((result as any).matchedId).toBe("test-existing-1");
+    expect((result as any).written).toBe(true);
+  });
+
+  test("update() default mode: reads existing, PUTs merged content to the SAME id, clears stale embedding", async () => {
+    const existing = {
+      id: "mem-1", agentId: "test", content: "old content", type: "session",
+      durability: "standard", tags: [], createdAt: "2026-01-01T00:00:00Z",
+      embedding: [0.1, 0.2, 0.3], embeddingModel: "test-model",
+    };
+    mockFetch = mock((_url: string, init?: any) => {
+      if (init?.method === "GET") {
+        return Promise.resolve(new Response(JSON.stringify(existing), { status: 200 }));
+      }
+      return Promise.resolve(new Response(JSON.stringify({ written: true, deduplicated: false }), { status: 200 }));
+    });
+    globalThis.fetch = mockFetch as any;
+
+    const client = new FlairClient({ agentId: "test" });
+    const result = await client.memory.update("mem-1", "new content");
+
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+    const putCall = (mockFetch as any).mock.calls.find((c: any) => c[1].method === "PUT");
+    expect(putCall[0]).toContain("/Memory/mem-1");
+    const putBody = JSON.parse(putCall[1].body);
+    expect(putBody.id).toBe("mem-1");
+    expect(putBody.content).toBe("new content");
+    expect(putBody.embedding).toBeUndefined();
+    expect(result.id).toBe("mem-1");
+    expect(result.content).toBe("new content");
+  });
+
+  test("update() preserveHistory: writes a NEW id with supersedes = old id", async () => {
+    const existing = {
+      id: "mem-1", agentId: "test", content: "old content", type: "session",
+      durability: "standard", tags: [], createdAt: "2026-01-01T00:00:00Z",
+      embedding: [0.1, 0.2, 0.3], embeddingModel: "test-model", validFrom: "2026-01-01T00:00:00Z",
+    };
+    mockFetch = mock((_url: string, init?: any) => {
+      if (init?.method === "GET") {
+        return Promise.resolve(new Response(JSON.stringify(existing), { status: 200 }));
+      }
+      return Promise.resolve(new Response(JSON.stringify({ written: true, deduplicated: false }), { status: 200 }));
+    });
+    globalThis.fetch = mockFetch as any;
+
+    const client = new FlairClient({ agentId: "test" });
+    const result = await client.memory.update("mem-1", "new version", { preserveHistory: true });
+
+    const putCall = (mockFetch as any).mock.calls.find((c: any) => c[1].method === "PUT");
+    const putBody = JSON.parse(putCall[1].body);
+    expect(putBody.id).not.toBe("mem-1");
+    expect(putBody.supersedes).toBe("mem-1");
+    expect(putBody.content).toBe("new version");
+    expect(putBody.embedding).toBeUndefined();
+    expect(putBody.validFrom).toBeUndefined();
+    expect(result.id).not.toBe("mem-1");
+    expect(result.content).toBe("new version");
+  });
+
+  test("update() on a nonexistent id throws rather than writing", async () => {
+    mockFetch = mock(() => Promise.resolve(new Response('{"error":"not found"}', { status: 404 })));
+    globalThis.fetch = mockFetch as any;
+
+    const client = new FlairClient({ agentId: "test" });
+    await expect(client.memory.update("nonexistent", "x")).rejects.toThrow();
+    // Only the GET happened — no PUT was attempted.
+    expect(mockFetch).toHaveBeenCalledTimes(1);
   });
 
   test("list POSTs conditions body with agentId scope", async () => {

--- a/packages/flair-mcp/src/index.ts
+++ b/packages/flair-mcp/src/index.ts
@@ -6,6 +6,7 @@
  * Tools:
  *   - memory_search  — semantic search across memories
  *   - memory_store   — save a memory with type + durability
+ *   - memory_update  — update an existing memory by ID (dedup-bypassed)
  *   - memory_get     — retrieve a specific memory by ID
  *   - memory_delete  — delete a memory
  *   - bootstrap      — cold-start context (soul + recent memories)
@@ -206,41 +207,64 @@ server.tool(
         dedup: true,
         dedupThreshold: 0.95,
       });
-      // Dedup path: existing memory matched, NEW content was NOT written.
-      // Emit both prose AND structuredContent so callers can react
-      // programmatically even when LLMs compress prose imprecisely
-      // (see flair#449 — work agent missed dedup signal and lost data).
-      if ((result as any).deduped) {
-        const sc = {
-          deduplicated: true,
-          mergedWith: result.id,
-          existingContent: result.content,
-          written: false,
-        };
-        return {
-          content: [{
-            type: "text",
-            text:
-              `⚠️ DEDUPLICATED — new content was NOT written. ` +
-              `Matched existing memory id=${result.id}: ${result.content?.slice(0, 200)}\n\n` +
-              `If the new content is genuinely distinct, retry with different phrasing ` +
-              `or call memory_store with the same id to update.`,
-          }],
-          structuredContent: sc,
-        };
-      }
+      // The server's conservative dedup gate NEVER suppresses a write
+      // (memory-integrity fix, flair#526) — `result.deduplicated` is a
+      // collision SIGNAL, not a "was this dropped" flag. The new content at
+      // `result.id` is ALWAYS written; when flagged, `result.matchedId` names
+      // the similar existing memory (see result.matchConfidence for the
+      // cosine/lexical scores). Emit both prose AND structuredContent so
+      // callers can react programmatically even when LLMs compress prose
+      // imprecisely. (Historical note: this tool used to treat a dedup hit as
+      // "new content was NOT written" — that WAS the flair#449/#526 silent
+      // data-loss bug. The gate is server-side now and never suppresses.)
+      const deduplicated = (result as any).deduplicated === true;
+      const matchedId = (result as any).matchedId as string | undefined;
       const preview = content.length > 120 ? content.slice(0, 120) + "..." : content;
       const tagStr = tags && tags.length > 0 ? tags.join(", ") : "none";
-      const text = [
+      const lines = [
         `Memory stored (id: ${result.id})`,
         `Preview: ${preview}`,
         `Size: ${content.length} chars`,
         `Tags: ${tagStr}`,
         `Type: ${type}, Durability: ${durability}`,
-      ].join("\n");
+      ];
+      if (deduplicated && matchedId) {
+        lines.push(
+          "",
+          `Note: similar to existing memory id=${matchedId} — both are kept. ` +
+          `If this was meant to UPDATE that memory rather than add a new one, use memory_update instead.`,
+        );
+      }
+      return {
+        content: [{ type: "text", text: lines.join("\n") }],
+        structuredContent: { deduplicated, id: result.id, written: true, ...(deduplicated ? { matchedId } : {}) },
+      };
+    } catch (err) {
+      return errorResult(err, flair.url);
+    }
+  },
+);
+
+server.tool(
+  "memory_update",
+  "Update an existing memory by ID. Dedup-bypassed — this is an intentional overwrite/version, not an ambiguous new write. " +
+    "Default: overwrites the same id in place. Pass preserveHistory=true to instead write a new version linked via " +
+    "`supersedes`, closing the old one's validity window (requires owning the memory, or a write grant if it's another agent's).",
+  {
+    id: z.string().describe("ID of the memory to update"),
+    content: z.string().describe("New content"),
+    preserveHistory: z.coerce.boolean().optional().default(false)
+      .describe("Write a new supersedes-linked version instead of overwriting in place (default false)"),
+  },
+  async ({ id, content, preserveHistory }) => {
+    try {
+      const result = await flair.memory.update(id, content, { preserveHistory });
+      const text = preserveHistory
+        ? `Memory updated: new version stored (id: ${result.id}), supersedes ${id}.`
+        : `Memory updated (id: ${id}).`;
       return {
         content: [{ type: "text", text }],
-        structuredContent: { deduplicated: false, id: result.id, written: true },
+        structuredContent: { id: result.id, supersedes: preserveHistory ? id : undefined, written: true },
       };
     } catch (err) {
       return errorResult(err, flair.url);

--- a/packages/openclaw-flair/index.ts
+++ b/packages/openclaw-flair/index.ts
@@ -582,23 +582,26 @@ export default {
               dedup: !supersedes, // skip dedup when explicitly superseding
               dedupThreshold: 0.7,
             });
-            // Two signals available: (1) id-mismatch (explicit memId vs
-            // returned id), (2) flair-client's `deduped` flag. Use both —
-            // the deduped flag is the authoritative one from flair-client,
-            // id-mismatch is the legacy check. Match either to be safe.
-            const wasDeduped = result.id !== memId || (result as any).deduped === true;
+            // The server's conservative dedup gate NEVER suppresses a write
+            // (memory-integrity fix, flair#526) — `result.deduplicated` is a
+            // collision SIGNAL, not a "was this dropped" flag; the content at
+            // `memId` is always written. (Historical note: this used to check
+            // the now-removed `result.deduped` flag AND an id-mismatch
+            // heuristic, both signals of the old client-side gate that DID
+            // suppress the write — that suppression is gone.)
+            const wasDeduplicated = (result as any).deduplicated === true;
             return {
               content: [{
                 type: "text",
-                text: wasDeduped
-                  ? `⚠️ DEDUPLICATED — new content was NOT written. Matched existing memory id=${result.id}: ${result.content?.slice(0, 200)}`
+                text: wasDeduplicated
+                  ? `Memory stored (id: ${memId}) — similar to existing memory id=${(result as any).matchedId}: ${result.content?.slice(0, 200)}`
                   : `Memory stored (id: ${memId})`,
               }],
               details: {
                 id: result.id,
-                deduplicated: wasDeduped,
-                written: !wasDeduped,
-                ...(wasDeduped ? { mergedWith: result.id } : {}),
+                deduplicated: wasDeduplicated,
+                written: true,
+                ...(wasDeduplicated ? { matchedId: (result as any).matchedId } : {}),
               },
             };
           } catch (err: any) {

--- a/packages/pi-flair/src/index.ts
+++ b/packages/pi-flair/src/index.ts
@@ -236,38 +236,35 @@ export default function (pi: ExtensionAPI) {
           dedupThreshold: 0.95,
         });
 
-        // Dedup signal: use the explicit `deduped` flag that flair-client
-        // sets on the returned record. The previous prefix-match check
-        // (`!result.id.startsWith(`${agentId}-`)`) was unreliable — when
-        // a dedup hit returned an existing memory from the SAME agent,
-        // both IDs start with the same prefix and the check silently
-        // returned the success path, dropping the new content. Same fix
-        // class as #358 (P0 silent data loss) applied to flair-mcp;
-        // pi-flair was missed. See flair#449 (filed by a Claude Code
-        // session that hit this exact failure).
-        const wasDeduped = (result as any).deduped === true;
-
-        if (wasDeduped) {
-          return {
-            content: [{
-              type: "text",
-              text: `Similar memory already exists (id: ${result.id}): ${result.content?.slice(0, 200)}\n(no new entry written)`,
-            }],
-            details: { deduplicated: true, mergedWith: result.id },
-          };
-        }
+        // Dedup signal: the server's conservative gate NEVER suppresses a
+        // write (memory-integrity fix, flair#526) — `result.deduplicated`
+        // is a collision SIGNAL, not a "was this dropped" flag. The content
+        // is always written; when flagged, `result.matchedId` names the
+        // similar existing memory. (Historical note: this tool used to check
+        // the now-removed `result.deduped` flag from a client-side gate that
+        // DID suppress the write, and told the user "no new entry written" —
+        // that was the #449/#526 silent-data-loss failure mode. Both the
+        // suppression and the misleading text are gone.)
+        const wasDeduplicated = (result as any).deduplicated === true;
+        const matchedId = (result as any).matchedId as string | undefined;
 
         const preview = content.length > 120 ? content.slice(0, 120) + "..." : content;
         const tagStr = (params.tags as string[] | undefined)?.length ? (params.tags as string[]).join(", ") : "none";
-        const text = [
+        const lines = [
           `Memory stored (id: ${result.id})`,
           `Preview: ${preview}`,
           `Size: ${content.length} chars`,
           `Tags: ${tagStr}`,
           `Durability: ${durability}`,
-        ].join("\n");
+        ];
+        if (wasDeduplicated && matchedId) {
+          lines.push(`Note: similar to existing memory (id: ${matchedId}) — both are kept.`);
+        }
 
-        return { content: [{ type: "text", text }], details: { deduplicated: false, id: result.id } };
+        return {
+          content: [{ type: "text", text: lines.join("\n") }],
+          details: { deduplicated: wasDeduplicated, id: result.id, written: true, ...(wasDeduplicated ? { matchedId } : {}) },
+        };
       } catch (err) {
         return errorResult(err, flair.url);
       }

--- a/resources/Memory.ts
+++ b/resources/Memory.ts
@@ -240,10 +240,14 @@ async function closeSupersededIfNeeded(ctx: any, content: any, methodLabel: "pos
       updatedAt: content.createdAt ?? content.updatedAt,
     });
   } catch (err) {
+    // Constant format string + structured data: memory ids are agent-controlled,
+    // so interpolating them into console.error's format position (with a trailing
+    // `err` arg) would let an id containing %s/%o consume/hide the real error
+    // (semgrep unsafe-formatstring). Keep all dynamic values in the data object.
     console.error(
-      `Memory.${methodLabel}: failed to close superseded record ${content.supersedes} after writing ${content.id} ` +
-      `(ops-a4t5 — observable, not silent; new record is safely written, old record remains active until retried):`,
-      err,
+      "Memory.closeSuperseded: failed to close superseded record after writing new record " +
+      "(ops-a4t5 — observable, not silent; new record is safely written, old record remains active until retried)",
+      { method: methodLabel, supersededId: content.supersedes, newRecordId: content.id, err },
     );
   }
 }

--- a/resources/Memory.ts
+++ b/resources/Memory.ts
@@ -1,9 +1,252 @@
 import { databases } from "@harperfast/harper";
 import { patchRecord, withDetachedTxn } from "./table-helpers.js";
-import { isAdmin, resolveAgentAuth } from "./agent-auth.js";
+import { isAdmin, resolveAgentAuth, type AgentAuthVerdict } from "./agent-auth.js";
 import { getEmbedding, getModelId } from "./embeddings-provider.js";
 import { scanFields, isStrictMode } from "./content-safety.js";
 import { checkRateLimit, rateLimitResponse } from "./rate-limiter.js";
+import {
+  DEDUP_COSINE_THRESHOLD_DEFAULT,
+  DEDUP_LEXICAL_THRESHOLD_DEFAULT,
+  DEDUP_MIN_CONTENT_LENGTH,
+  computeMatchConfidence,
+  isConservativeMatch,
+  type DedupMatch,
+} from "./dedup.js";
+
+const FORBIDDEN = (msg: string) =>
+  new Response(JSON.stringify({ error: msg }), { status: 403, headers: { "Content-Type": "application/json" } });
+const UNAUTH = () =>
+  new Response(JSON.stringify({ error: "authentication required" }), { status: 401, headers: { "Content-Type": "application/json" } });
+
+/**
+ * ─── Server-side conservative-duplicate gate (memory-integrity fix) ──────────
+ *
+ * NEVER SUPPRESSES A WRITE. This gate only computes a SIGNAL — the caller
+ * (Memory.post / Memory.put) always proceeds to write the new record. When a
+ * conservative match is found, the signal is attached to the RESPONSE only
+ * (deduplicated/matchedId/matchConfidence). There must be no code path where
+ * finding a match causes the write to be skipped: that was the #526 bug (two
+ * topically-close but DISTINCT findings — one about replication
+ * route-directionality, one about DDL/schema replication — and the SECOND was
+ * silently dropped because the old client-side gate returned the existing
+ * record instead of writing).
+ *
+ * Conservative match = raw cosine >= cosineThreshold AND Jaccard token-overlap
+ * >= lexicalThreshold, checked ONLY against the SINGLE top-cosine candidate
+ * (scoped to the same agentId as the write — never cross-agent). If that one
+ * candidate fails either gate, there is no match; we do not fall back to the
+ * 2nd-most-similar candidate.
+ *
+ * Previously this lived client-side (packages/flair-client/src/client.ts,
+ * pre-fix) and only ran for callers that opted into `dedup:true` over HTTP
+ * PUT — the Model-2 /mcp handler (resources/mcp-tools.ts), which calls
+ * Memory.post() directly, got ZERO dedup checking. Moving the gate here makes
+ * it apply uniformly regardless of transport (HTTP PUT vs in-process post()).
+ *
+ * NOTE on HTTP verbs: the Memory schema only exposes PUT over HTTP (a raw
+ * HTTP POST /Memory returns "Memory does not have a post method implemented"
+ * — see src/cli.ts's `flair test` command and commit 2fa6d22 / ops-pj5).
+ * `Memory.post()` IS reachable, but only via an in-process resource
+ * instantiation (as resources/mcp-tools.ts does) — never via the real HTTP
+ * POST route. Because flair-client's write() (used by flair-mcp, the CLI, and
+ * every other integration package) issues an HTTP PUT, the actual
+ * field-observed bug (#526) flows through Memory.put(), not Memory.post().
+ * The gate below is therefore a SHARED helper invoked from both post() and
+ * put() — anchored in the same place the design calls out (Memory.post), but
+ * wired into put() too so the write path real callers actually use is
+ * protected. See memory-integrity-fix report for the full writeup of this
+ * deviation from a literal "gate lives only in Memory.post" reading.
+ */
+async function findConservativeDedupMatch(
+  ctx: any,
+  agentId: string | undefined,
+  contentText: string,
+  embedding: number[] | null | undefined,
+  cosineThreshold: number,
+  lexicalThreshold: number,
+): Promise<DedupMatch | null> {
+  if (!agentId || !embedding || embedding.length === 0) return null;
+  try {
+    const query: any = {
+      sort: { attribute: "embedding", target: embedding, distance: "cosine" },
+      conditions: [
+        { attribute: "agentId", comparator: "equals", value: agentId },
+        { attribute: "archived", comparator: "not_equal", value: true },
+      ],
+      select: ["id", "content", "$distance"],
+      limit: 1,
+    };
+    let top: any = null;
+    // Detach ctx.transaction around this search — same rationale as
+    // Memory.search()/SemanticSearch.ts: a drained search generator can leave
+    // a CLOSED transaction in ctx's chain that the subsequent WRITE
+    // (super.post/super.put, right after this gate runs) would otherwise
+    // inherit. Detaching here protects that write, not this read.
+    const results = withDetachedTxn(ctx, () => (databases as any).flair.Memory.search(query));
+    for await (const record of results) {
+      top = record;
+      break; // single top-cosine candidate only — never fall back further
+    }
+    if (!top) return null;
+    const cosine = 1 - (top.$distance ?? 1);
+    const confidence = computeMatchConfidence(contentText, top.content, cosine);
+    if (!isConservativeMatch(confidence.cosine, confidence.lexical, cosineThreshold, lexicalThreshold)) {
+      return null;
+    }
+    return { matchedId: top.id, cosine: confidence.cosine, lexical: confidence.lexical };
+  } catch {
+    // Dedup-check failures (embedding engine down, search error, etc.) must
+    // NEVER block or alter the write — treat as "no match found".
+    return null;
+  }
+}
+
+/**
+ * Run the dedup gate for a create-shaped write. Mutates `content.embedding` /
+ * `content.embeddingModel` when it computes a fresh embedding, so the
+ * existing "generate embedding if missing" step later in post()/put() reuses
+ * it instead of recomputing. Always strips the client-forwarded hint fields
+ * (dedup / dedupThreshold / lexicalThreshold) so they never persist onto the
+ * stored record — they are passthrough tuning hints, not schema fields.
+ *
+ * Returns the match signal, or null (no match / gate not applicable).
+ */
+async function runDedupGate(ctx: any, content: any): Promise<DedupMatch | null> {
+  const cosineThreshold = typeof content.dedupThreshold === "number" ? content.dedupThreshold : DEDUP_COSINE_THRESHOLD_DEFAULT;
+  const lexicalThreshold = typeof content.lexicalThreshold === "number" ? content.lexicalThreshold : DEDUP_LEXICAL_THRESHOLD_DEFAULT;
+  delete content.dedup;
+  delete content.dedupThreshold;
+  delete content.lexicalThreshold;
+
+  if (typeof content.content !== "string" || content.content.length < DEDUP_MIN_CONTENT_LENGTH) {
+    return null;
+  }
+
+  let embedding: number[] | null = Array.isArray(content.embedding) ? content.embedding : null;
+  if (!embedding) {
+    try {
+      embedding = await getEmbedding(content.content);
+    } catch {
+      embedding = null;
+    }
+    if (embedding) {
+      content.embedding = embedding;
+      content.embeddingModel = getModelId();
+    }
+  }
+  if (!embedding) return null;
+
+  return findConservativeDedupMatch(ctx, content.agentId, content.content, embedding, cosineThreshold, lexicalThreshold);
+}
+
+/** Build the final write response: always `written: true`, always includes
+ *  `id`, and layers the dedup collision signal on top when present. Never a
+ *  code path where a match suppresses these base fields. */
+function buildWriteResponse(content: any, result: any, dedupMatch: DedupMatch | null): any {
+  const base = result && typeof result === "object" && !Array.isArray(result) ? result : {};
+  const response: any = {
+    id: content.id,
+    ...base,
+    written: true,
+    deduplicated: !!dedupMatch,
+  };
+  if (dedupMatch) {
+    response.matchedId = dedupMatch.matchedId;
+    response.matchConfidence = { cosine: dedupMatch.cosine, lexical: dedupMatch.lexical };
+  }
+  return response;
+}
+
+/**
+ * Read-modify-write close of a superseded record, with the SAME transaction
+ * detachment discipline as findConservativeDedupMatch (each discrete Harper
+ * call individually wrapped — see withDetachedTxn's doc for why a single
+ * wrap around a multi-await async function would not protect the later
+ * call). Does NOT swallow failures (ops-a4t5 fix) — throws so the caller can
+ * log it. Never called before the new record is already written.
+ */
+async function closeSupersededRecord(ctx: any, oldId: string, patch: Record<string, unknown>): Promise<void> {
+  const existing = await withDetachedTxn(ctx, () => (databases as any).flair.Memory.get(oldId));
+  if (!existing) {
+    throw new Error(`supersede-close: record ${oldId} not found`);
+  }
+  await withDetachedTxn(ctx, () => (databases as any).flair.Memory.put({ ...existing, ...patch }));
+}
+
+/** Does an agent hold a "write" grant from `ownerId`? Same MemoryGrant lookup
+ *  pattern as Memory.search()/SemanticSearch.ts (read/search scopes) — reused
+ *  here for the "write" scope that gates cross-agent supersede. */
+async function hasWriteGrant(granteeId: string, ownerId: string): Promise<boolean> {
+  try {
+    for await (const grant of (databases as any).flair.MemoryGrant.search({
+      conditions: [
+        { attribute: "granteeId", comparator: "equals", value: granteeId },
+        { attribute: "ownerId", comparator: "equals", value: ownerId },
+      ],
+    })) {
+      if (grant.scope === "write") return true;
+    }
+  } catch {
+    /* MemoryGrant table not yet populated — no grant */
+  }
+  return false;
+}
+
+/**
+ * Shared by post() AND put(): the Memory schema only exposes a working HTTP
+ * PUT route (a raw HTTP POST /Memory 404s with "Memory does not have a post
+ * method implemented" — see src/cli.ts's `flair test` command / commit
+ * 2fa6d22 / ops-pj5). Memory.post() IS reachable, but only via an in-process
+ * resource instantiation (resources/mcp-tools.ts does this). Since
+ * flair-client's write()/update() — used by flair-mcp, the CLI, and every
+ * other integration package — issue HTTP PUT, `supersedes` must be fully
+ * handled (validated, authorized, and closed) from BOTH entry points for the
+ * real-world write path to actually get the fix, not just the in-process one.
+ *
+ * Validates the `supersedes` field's shape and, for a cross-agent supersede,
+ * requires a "write" MemoryGrant from the target's owner (reuses the existing
+ * agent-auth/grant machinery — no parallel auth logic). Returns a Response to
+ * short-circuit with (400/403), or null to continue.
+ */
+async function validateAndAuthorizeSupersedes(content: any, auth: AgentAuthVerdict): Promise<Response | null> {
+  if (content.supersedes !== undefined && typeof content.supersedes !== "string") {
+    return new Response(JSON.stringify({ error: "supersedes must be a string (memory ID)" }), {
+      status: 400, headers: { "Content-Type": "application/json" },
+    });
+  }
+  if (content.supersedes && auth.kind === "agent" && !auth.isAdmin) {
+    const target = await (databases as any).flair.Memory.get(content.supersedes).catch(() => null);
+    if (target && target.agentId !== auth.agentId) {
+      if (!(await hasWriteGrant(auth.agentId, target.agentId))) {
+        return FORBIDDEN("forbidden: cannot supersede a memory owned by another agent without a write grant");
+      }
+    }
+  }
+  return null;
+}
+
+/**
+ * Close the superseded record — called AFTER the new record has already been
+ * written (write-new-BEFORE-close-old, ops-a4t5 fix). Safe failure state is
+ * two active records (recoverable), never a tombstoned-old-with-lost-new.
+ * Failure is logged (observable), never silently swallowed. No-op if
+ * `content.supersedes` is not set.
+ */
+async function closeSupersededIfNeeded(ctx: any, content: any, methodLabel: "post" | "put"): Promise<void> {
+  if (!content.supersedes) return;
+  try {
+    await closeSupersededRecord(ctx, content.supersedes, {
+      validTo: content.validFrom ?? content.createdAt,
+      updatedAt: content.createdAt ?? content.updatedAt,
+    });
+  } catch (err) {
+    console.error(
+      `Memory.${methodLabel}: failed to close superseded record ${content.supersedes} after writing ${content.id} ` +
+      `(ops-a4t5 — observable, not silent; new record is safely written, old record remains active until retried):`,
+      err,
+    );
+  }
+}
 
 export class Memory extends (databases as any).flair.Memory {
   /**
@@ -85,20 +328,17 @@ export class Memory extends (databases as any).flair.Memory {
     // resolveAgentAuth (reads the gate's tpsAgent annotation) — NOT context.user
     // .username, which is the fallback "admin" super_user while de-elevation is
     // dormant and would wrongly 403 every agent's own write. internal/admin → pass.
+    let auth: AgentAuthVerdict;
     {
-      const auth = await resolveAgentAuth(ctx);
+      auth = await resolveAgentAuth(ctx);
       // Anonymous HTTP must NOT write. Pre-flip the global gate rejected no-auth
       // upstream; with the non-rejecting gate, each write path self-enforces (same
       // rule search() applies to reads).
       if (auth.kind === "anonymous") {
-        return new Response(JSON.stringify({ error: "authentication required" }), {
-          status: 401, headers: { "Content-Type": "application/json" },
-        });
+        return UNAUTH();
       }
       if (auth.kind === "agent" && !auth.isAdmin && content?.agentId && content.agentId !== auth.agentId) {
-        return new Response(JSON.stringify({ error: "forbidden: cannot write memory owned by another agent" }), {
-          status: 403, headers: { "Content-Type": "application/json" },
-        });
+        return FORBIDDEN("forbidden: cannot write memory owned by another agent");
       }
     }
 
@@ -120,23 +360,15 @@ export class Memory extends (databases as any).flair.Memory {
       }
     }
 
-    // supersedes: optional reference to the ID of the memory this one replaces
-    if (content.supersedes !== undefined && typeof content.supersedes !== "string") {
-      return new Response(JSON.stringify({ error: "supersedes must be a string (memory ID)" }), {
-        status: 400, headers: { "Content-Type": "application/json" },
-      });
-    }
+    // supersedes: optional reference to the ID of the memory this one
+    // replaces. Validates shape + cross-agent-write authorization (shared
+    // with put() — see validateAndAuthorizeSupersedes doc).
+    const supersedesError = await validateAndAuthorizeSupersedes(content, auth);
+    if (supersedesError) return supersedesError;
 
     // Temporal validity: validFrom defaults to now, validTo left null for active facts.
-    // When a memory supersedes another, close the superseded memory's validity window.
     if (!content.validFrom) {
       content.validFrom = content.createdAt;
-    }
-    if (content.supersedes) {
-      patchRecord((databases as any).flair.Memory, content.supersedes, {
-        validTo: content.validFrom,
-        updatedAt: content.createdAt,
-      }).catch(() => {});
     }
 
     if (content.durability === "ephemeral" && !content.expiresAt) {
@@ -160,13 +392,39 @@ export class Memory extends (databases as any).flair.Memory {
       }
     }
 
-    // Generate embedding from content text
+    // Server-side conservative-duplicate gate (memory-integrity fix). A
+    // supersede write is an intentional version-link, not an ambiguous "is
+    // this a duplicate of something else" situation — bypass the gate for it
+    // (this also gives memory_update's preserveHistory mode dedup-bypass for
+    // free, without a separate flag). NEVER suppresses the write either way.
+    let dedupMatch: DedupMatch | null = null;
+    if (!content.supersedes) {
+      dedupMatch = await runDedupGate(ctx, content);
+    } else {
+      delete content.dedup;
+      delete content.dedupThreshold;
+      delete content.lexicalThreshold;
+    }
+
+    // Generate embedding from content text (no-op if the dedup gate above
+    // already computed one for this content).
     if (content.content && !content.embedding) {
       const vec = await getEmbedding(content.content);
       if (vec) { content.embedding = vec; content.embeddingModel = getModelId(); }
     }
 
-    return super.post(content);
+    // ── Write the new record FIRST ──────────────────────────────────────────
+    const result = await super.post(content);
+
+    // ── THEN close the superseded record (ops-a4t5 fix) ─────────────────────
+    // Write-new-BEFORE-close-old: the previous order (close-old via a fire-
+    // and-forget `.catch(()=>{})` BEFORE the new write) could tombstone the
+    // old record and then lose the new one if the write failed afterward.
+    // Now the safe failure state is two active records (recoverable), never
+    // a lost write — and the failure is logged, never silently swallowed.
+    await closeSupersededIfNeeded(ctx, content, "post");
+
+    return buildWriteResponse(content, result, dedupMatch);
   }
 
   async put(content: any) {
@@ -194,19 +452,16 @@ export class Memory extends (databases as any).flair.Memory {
     // write memories it owns, via resolveAgentAuth (gate annotation), not
     // context.user.username (the dormant-de-elevation fallback is "admin").
     // The _reindex admin path above bypasses this.
+    const ctx = (this as any).getContext?.();
+    let auth: AgentAuthVerdict;
     {
-      const octx = (this as any).getContext?.();
-      const auth = await resolveAgentAuth(octx);
+      auth = await resolveAgentAuth(ctx);
       // Anonymous HTTP must NOT write (non-rejecting gate → self-enforce here).
       if (auth.kind === "anonymous") {
-        return new Response(JSON.stringify({ error: "authentication required" }), {
-          status: 401, headers: { "Content-Type": "application/json" },
-        });
+        return UNAUTH();
       }
       if (auth.kind === "agent" && !auth.isAdmin && content?.agentId && content.agentId !== auth.agentId) {
-        return new Response(JSON.stringify({ error: "forbidden: cannot write memory owned by another agent" }), {
-          status: 403, headers: { "Content-Type": "application/json" },
-        });
+        return FORBIDDEN("forbidden: cannot write memory owned by another agent");
       }
     }
 
@@ -215,6 +470,16 @@ export class Memory extends (databases as any).flair.Memory {
     // Set defaults that post() sets — put() is also used for new records via CLI
     content.archived = content.archived ?? false;
     content.createdAt = content.createdAt ?? now;
+
+    // supersedes: optional reference to the ID of the memory this one
+    // replaces. Validates shape + cross-agent-write authorization (shared
+    // with post() — see validateAndAuthorizeSupersedes doc for why PUT needs
+    // this too: it's the only HTTP-reachable create path).
+    const supersedesError = await validateAndAuthorizeSupersedes(content, auth);
+    if (supersedesError) return supersedesError;
+    if (content.supersedes && !content.validFrom) {
+      content.validFrom = content.createdAt;
+    }
 
     // Content safety scan on updated content + summary (ops-i2jb).
     if (content.content || content.summary) {
@@ -234,7 +499,34 @@ export class Memory extends (databases as any).flair.Memory {
       }
     }
 
-    // Re-generate embedding if content changed
+    // Server-side conservative-duplicate gate (memory-integrity fix). PUT is
+    // an upsert: only run the gate for a FRESH create (target id does not yet
+    // exist) that is NOT a supersede-link write. An update of an EXISTING id
+    // (memory_update's default same-id overwrite path) is an intentional,
+    // explicit overwrite, and a supersede-link write is an intentional
+    // version-link — neither is an ambiguous "is this a duplicate of
+    // something else" write, so both are dedup-bypassed automatically, no
+    // separate flag needed. NEVER suppresses the write either way.
+    let dedupMatch: DedupMatch | null = null;
+    if (content.supersedes) {
+      delete content.dedup;
+      delete content.dedupThreshold;
+      delete content.lexicalThreshold;
+    } else if (content.id) {
+      const preExisting = await (databases as any).flair.Memory.get(content.id).catch(() => null);
+      if (!preExisting) {
+        dedupMatch = await runDedupGate(ctx, content);
+      } else {
+        delete content.dedup;
+        delete content.dedupThreshold;
+        delete content.lexicalThreshold;
+      }
+    } else {
+      dedupMatch = await runDedupGate(ctx, content);
+    }
+
+    // Re-generate embedding if content changed (no-op if the dedup gate above
+    // already computed one for this content).
     if (content.content && !content.embedding) {
       const vec = await getEmbedding(content.content);
       if (vec) { content.embedding = vec; content.embeddingModel = getModelId(); }
@@ -256,7 +548,13 @@ export class Memory extends (databases as any).flair.Memory {
       content.durability = "permanent";
     }
 
-    return super.put(content);
+    // ── Write the new/updated record FIRST ──────────────────────────────────
+    const result = await super.put(content);
+
+    // ── THEN close the superseded record (ops-a4t5 fix; see post()) ────────
+    await closeSupersededIfNeeded(ctx, content, "put");
+
+    return buildWriteResponse(content, result, dedupMatch);
   }
 
   async delete(id: any) {

--- a/resources/dedup.ts
+++ b/resources/dedup.ts
@@ -1,0 +1,80 @@
+// ─── Conservative near-duplicate detection primitives (Harper-free) ─────────
+// Memory-integrity fix (#526/#548 field regressions). This module is
+// deliberately Harper-free — same rationale as ./bm25.ts and ./scoring.ts —
+// so the cosine+Jaccard co-gate math is unit-testable directly against the
+// SHIPPED code without a live Harper. The DB-touching top-1-cosine lookup
+// (needs `databases`) lives in ./Memory.ts, built on top of these primitives.
+//
+// ── THE INVARIANT ────────────────────────────────────────────────────────────
+// This module NEVER decides whether to write. It only scores a candidate
+// match. Callers (Memory.post / Memory.put) always write the new record; a
+// "conservative match" is surfaced to the caller as a SIGNAL on the response
+// (deduplicated/matchedId/matchConfidence), never as a reason to skip the
+// write. That was the #526 bug: two topically-close but DISTINCT findings —
+// one about replication route-directionality, one about DDL/schema
+// replication — and the second was silently dropped because raw cosine alone
+// flagged it as a "duplicate" of the first. Requiring BOTH cosine AND lexical
+// (Jaccard token-overlap) to clear their thresholds against the SAME single
+// top-cosine candidate catches true near-dups while sparing topic collisions
+// (high cosine, low lexical) — and even then, only ever as a non-suppressing
+// signal.
+import { tokenize } from "./bm25.js";
+
+/** Default raw-cosine similarity threshold for a candidate to even be considered. */
+export const DEDUP_COSINE_THRESHOLD_DEFAULT = 0.95;
+
+/** Default Jaccard token-overlap threshold (of the top cosine candidate). */
+export const DEDUP_LEXICAL_THRESHOLD_DEFAULT = 0.5;
+
+/** Below this content length, similarity scoring is unreliable ("ok" would
+ *  match "ok" trivially) — the dedup gate is bypassed entirely. */
+export const DEDUP_MIN_CONTENT_LENGTH = 20;
+
+export interface DedupMatch {
+  matchedId: string;
+  cosine: number;
+  lexical: number;
+}
+
+/** Jaccard similarity of two token sets: |A∩B| / |A∪B|. An empty side yields 0
+ *  (no signal — never treated as "fully similar" by vacuous set equality). */
+export function jaccardSimilarity(tokensA: string[], tokensB: string[]): number {
+  const a = new Set(tokensA);
+  const b = new Set(tokensB);
+  if (a.size === 0 || b.size === 0) return 0;
+  let intersection = 0;
+  for (const t of a) if (b.has(t)) intersection++;
+  const union = a.size + b.size - intersection;
+  return union === 0 ? 0 : intersection / union;
+}
+
+/**
+ * Conservative match = cosine AND lexical BOTH clear their thresholds.
+ * Both gates are required — a topic collision (high cosine, low lexical: two
+ * DIFFERENT findings that merely share a topic/vocabulary) must NOT be
+ * flagged as a duplicate. Only a true near-duplicate (high cosine AND high
+ * lexical overlap) is flagged.
+ */
+export function isConservativeMatch(
+  cosine: number,
+  lexical: number,
+  cosineThreshold: number = DEDUP_COSINE_THRESHOLD_DEFAULT,
+  lexicalThreshold: number = DEDUP_LEXICAL_THRESHOLD_DEFAULT,
+): boolean {
+  return cosine >= cosineThreshold && lexical >= lexicalThreshold;
+}
+
+/** Compute the {cosine, lexical} confidence pair for a candidate against the
+ *  new content's text, using the shared bm25 tokenizer. Rounded to 3dp to
+ *  match the existing _score rounding convention (SemanticSearch.ts). */
+export function computeMatchConfidence(
+  newContent: string,
+  candidateContent: string | undefined,
+  cosine: number,
+): { cosine: number; lexical: number } {
+  const lexical = jaccardSimilarity(tokenize(newContent), tokenize(candidateContent || ""));
+  return {
+    cosine: Math.round(cosine * 1000) / 1000,
+    lexical: Math.round(lexical * 1000) / 1000,
+  };
+}

--- a/resources/mcp-tools.ts
+++ b/resources/mcp-tools.ts
@@ -1,17 +1,17 @@
 /**
- * mcp-tools.ts — the 9 curated flair tools for the Model-2 custom /mcp handler.
+ * mcp-tools.ts — the 10 curated flair tools for the Model-2 custom /mcp handler.
  *
- * Curated BY CONSTRUCTION: this module implements exactly the 9 tools that the
+ * Curated BY CONSTRUCTION: this module implements exactly the 10 tools that the
  * `@tpsdev-ai/flair-mcp` stdio proxy exposes, each a thin wrapper over the
  * existing flair Resource handler. No business logic is re-implemented — the
  * wrapped handlers (Memory / SemanticSearch / BootstrapMemories / Soul /
  * WorkspaceState / OrgEvent) enforce per-agent scoping/ownership via
  * `resolveAgentAuth(getContext())`, so the MCP surface inherits the SAME security
  * model as the signed-REST path. There is no raw CRUD surface — the only way to
- * reach the datastore through /mcp is via one of these 9 semantic tools.
+ * reach the datastore through /mcp is via one of these 10 semantic tools.
  *
- *   memory_search · memory_store · memory_get · memory_delete · bootstrap ·
- *   soul_set · soul_get · flair_workspace_set · flair_orgevent
+ *   memory_search · memory_store · memory_update · memory_get · memory_delete ·
+ *   bootstrap · soul_set · soul_get · flair_workspace_set · flair_orgevent
  *
  * ── The scoping seam ────────────────────────────────────────────────────────
  * The /mcp handler resolves the OAuth token's `sub` → a flair `Agent` id, then
@@ -153,6 +153,62 @@ async function memoryStore(agent: ResolvedAgent, args: any) {
   }));
 }
 
+/**
+ * memory_update — id-targeted, dedup-BYPASSED overwrite/version path (memory-
+ * integrity fix). Mirrors flair-client's MemoryApi.update() (packages/
+ * flair-client/src/client.ts), reimplemented against the resource instance
+ * API instead of HTTP since this handler calls the Memory resource directly
+ * (same pattern as memoryStore vs the flair-mcp stdio tool). Auth is enforced
+ * by Memory.get()/Memory.put()/Memory.post()'s EXISTING ownership checks — no
+ * parallel auth logic here.
+ *
+ * Default (preserveHistory unset/false): read the existing record, merge the
+ * new content on top (Harper PUT is full-record replacement — never send a
+ * bare partial), clear the stale embedding so the server regenerates it, and
+ * PUT the merged record back to the SAME id.
+ *
+ * preserveHistory: true: write a NEW id with `supersedes: id`. Memory.post()
+ * validates/authorizes the supersede (denying a cross-agent supersede without
+ * a "write" MemoryGrant) and closes the old record's validTo AFTER the new
+ * record is written (never the reverse — see resources/Memory.ts).
+ */
+async function memoryUpdate(agent: ResolvedAgent, args: any) {
+  const Cls = await handler("Memory");
+  const h = new Cls(undefined, delegationContext(agent));
+  const id = args?.id;
+  const content = args?.content;
+  const preserveHistory = args?.preserveHistory === true;
+
+  const existing = await h.get(id);
+  if (!existing) {
+    return { error: "memory not found", status: 404 };
+  }
+
+  if (preserveHistory) {
+    const newId = `${agent.agentId}-${crypto.randomUUID()}`;
+    const record: Record<string, unknown> = {
+      ...existing,
+      id: newId,
+      content,
+      supersedes: id,
+      createdAt: new Date().toISOString(),
+    };
+    delete record.updatedAt;
+    delete record.embedding;
+    delete record.embeddingModel;
+    delete record.validFrom;
+    delete record.validTo;
+    delete record.archivedAt;
+    (h as any).isCollection = true;
+    return unwrap(await h.post(record));
+  }
+
+  const merged: Record<string, unknown> = { ...existing, content, updatedAt: new Date().toISOString() };
+  delete merged.embedding;
+  delete merged.embeddingModel;
+  return unwrap(await h.put(merged));
+}
+
 async function memoryGet(agent: ResolvedAgent, args: any) {
   const Cls = await handler("Memory");
   const h = new Cls(undefined, delegationContext(agent));
@@ -282,6 +338,25 @@ export const TOOLS: Record<string, ToolEntry> = {
       },
     },
     impl: memoryStore,
+  },
+  memory_update: {
+    def: {
+      name: "memory_update",
+      description:
+        "Update an existing memory by ID. Dedup-bypassed (this is an intentional overwrite, not a new write). " +
+        "Default: overwrites the same id in place. Pass preserveHistory=true to instead write a new version " +
+        "linked via `supersedes`, closing the old one's validity window.",
+      inputSchema: {
+        type: "object",
+        properties: {
+          id: { type: "string", description: "ID of the memory to update" },
+          content: { type: "string", description: "New content" },
+          preserveHistory: { type: "boolean", description: "Write a new version (supersedes-linked) instead of overwriting in place (default false)" },
+        },
+        required: ["id", "content"],
+      },
+    },
+    impl: memoryUpdate,
   },
   memory_get: {
     def: {

--- a/test/unit/mcp-handler.test.ts
+++ b/test/unit/mcp-handler.test.ts
@@ -4,7 +4,7 @@
  * These are the auth-critical assertions the integration harness can't make at
  * the unit level:
  *
- *   - tools/list returns EXACTLY the 9 curated tools (no raw CRUD, no extras).
+ *   - tools/list returns EXACTLY the 10 curated tools (no raw CRUD, no extras).
  *   - sub → Agent resolution: an existing Credential(kind:"idp", idpSubject=sub)
  *     maps to its principalId; an unknown sub with JIT OFF is DENIED (not run as
  *     anonymous/admin); an unknown sub with JIT ON provisions a NON-admin agent.
@@ -44,7 +44,12 @@ class MemoryMock {
   isCollection = false;
   constructor(_id: any, ctx: any) { this._ctx = ctx; }
   async post(args: any) { lastCall = { resource: "Memory.post", ctx: this._ctx, args }; return { ok: true, resource: "Memory.post", agentId: this._ctx?.request?.tpsAgent }; }
-  async get(id: any) { lastCall = { resource: "Memory.get", ctx: this._ctx, args: id }; return { ok: true, resource: "Memory.get", agentId: this._ctx?.request?.tpsAgent }; }
+  async put(args: any) { lastCall = { resource: "Memory.put", ctx: this._ctx, args }; return { ok: true, resource: "Memory.put", agentId: this._ctx?.request?.tpsAgent }; }
+  async get(id: any) {
+    lastCall = { resource: "Memory.get", ctx: this._ctx, args: id };
+    if (id === "missing-id") return null;
+    return { id, agentId: this._ctx?.request?.tpsAgent, content: "existing content", ok: true, resource: "Memory.get" };
+  }
   async delete(id: any) { lastCall = { resource: "Memory.delete", ctx: this._ctx, args: id }; return { ok: true, resource: "Memory.delete", agentId: this._ctx?.request?.tpsAgent }; }
 }
 class SoulMock {
@@ -127,8 +132,8 @@ afterAll(() => {
 });
 
 // ─── tools/list ──────────────────────────────────────────────────────────────
-describe("tools/list — exactly the 9 curated tools", () => {
-  it("returns exactly 9, matching the flair-mcp surface, no CRUD mutators", async () => {
+describe("tools/list — exactly the 10 curated tools", () => {
+  it("returns exactly 10, matching the flair-mcp surface, no raw CRUD mutators", async () => {
     const res = await mcpHandler(post({ jsonrpc: "2.0", id: 1, method: "tools/list" }, { sub: "s" }));
     const body = await parse(res);
     const names = body.result.tools.map((t: any) => t.name).sort();
@@ -140,11 +145,14 @@ describe("tools/list — exactly the 9 curated tools", () => {
       "memory_get",
       "memory_search",
       "memory_store",
+      "memory_update",
       "soul_get",
       "soul_set",
     ]);
-    // No create_/update_/delete_ raw-resource mutators leaked in.
-    expect(names.some((n: string) => /^(create|update|delete)_/.test(n))).toBe(false);
+    // No raw create_/delete_ resource mutators leaked in. (memory_update
+    // itself is a curated semantic tool, not a raw `update_<resource>`
+    // mutator — it's explicitly allow-listed here rather than excluded.)
+    expect(names.some((n: string) => /^(create|delete)_/.test(n))).toBe(false);
   });
 });
 
@@ -234,6 +242,41 @@ describe("tools/call — scopes to the resolved agent (no forging)", () => {
     expect(lastCall?.resource).toBe("Memory.post");
     expect(lastCall?.args.agentId).toBe("agt_bob");
     expect(lastCall?.ctx.request.tpsAgent).toBe("agt_bob");
+  });
+
+  it("memory_update (default) reads then PUTs the same id, merging new content", async () => {
+    await mcpHandler(post(
+      { jsonrpc: "2.0", id: 1, method: "tools/call", params: { name: "memory_update", arguments: { id: "mem-1", content: "updated content" } } },
+      { sub: "sub-bob" },
+    ));
+    expect(lastCall?.resource).toBe("Memory.put");
+    expect(lastCall?.args.id).toBe("mem-1");
+    expect(lastCall?.args.content).toBe("updated content");
+    // Stale embedding must be cleared so the server regenerates it.
+    expect(lastCall?.args).not.toHaveProperty("embedding");
+  });
+
+  it("memory_update (preserveHistory) POSTs a NEW id with supersedes = old id", async () => {
+    await mcpHandler(post(
+      { jsonrpc: "2.0", id: 1, method: "tools/call", params: { name: "memory_update", arguments: { id: "mem-1", content: "new version", preserveHistory: true } } },
+      { sub: "sub-bob" },
+    ));
+    expect(lastCall?.resource).toBe("Memory.post");
+    expect(lastCall?.args.id).not.toBe("mem-1");
+    expect(lastCall?.args.supersedes).toBe("mem-1");
+    expect(lastCall?.args.content).toBe("new version");
+    expect(lastCall?.ctx.request.tpsAgent).toBe("agt_bob");
+  });
+
+  it("memory_update on a missing id returns a 404-shaped error, no write attempted", async () => {
+    const res = await mcpHandler(post(
+      { jsonrpc: "2.0", id: 1, method: "tools/call", params: { name: "memory_update", arguments: { id: "missing-id", content: "x" } } },
+      { sub: "sub-bob" },
+    ));
+    const body = await parse(res);
+    expect(lastCall?.resource).toBe("Memory.get");
+    expect(body.result.isError).toBe(true);
+    expect(body.result.structuredContent.status).toBe(404);
   });
 
   it("soul_set PUTs with id = agentId:key (so soul_get can find it)", async () => {

--- a/test/unit/memory-dedup-silent-failure.test.ts
+++ b/test/unit/memory-dedup-silent-failure.test.ts
@@ -1,116 +1,86 @@
 import { describe, it, expect, mock } from "bun:test";
 import { FlairClient } from "../../packages/flair-client/src/client";
-import type { Memory } from "../../packages/flair-client/src/types";
 
 /**
- * P0 regression: The dedup branch in write() returned the existing memory
- * without any signal, so callers got a success-shaped response with a real
- * ID + content + "Memory stored" when nothing was actually written.
+ * P0 regression (historical): the dedup branch in write() used to run a
+ * client-side pre-flight search and, on a match, return the EXISTING record
+ * WITHOUT writing the new content — a success-shaped response with a real
+ * ID + content + "Memory stored" when nothing new was actually persisted.
  *
- * Fix: dedup branch sets `deduped: true` on the return so callers can detect
- * that a new write was suppressed.
+ * Memory-integrity fix (flair#526): the dedup gate moved SERVER-SIDE
+ * (resources/Memory.ts, Memory.post()/Memory.put()) and NEVER suppresses a
+ * write. write() now always issues exactly one PUT and always returns the
+ * record it sent, merged with whatever collision signal the server reports
+ * (`deduplicated` / `matchedId` / `matchConfidence`) — never the old
+ * `deduped: true` + existing-record-swap shape. These tests guard against
+ * that suppression ever being reintroduced client-side.
  */
-describe("memory dedup silent failure (P0 regression)", () => {
+describe("memory dedup — never-silent-loss (flair#526 fix)", () => {
   const content1 = "Test memory about widgets and gadgets";
   const content2 = "Test memory about widgets";
 
-  const fakeMemory: Memory = {
-    id: "mem-abc-123",
-    agentId: "test-agent",
-    content: content1,
-    type: "session",
-    durability: "standard",
-    tags: [],
-    createdAt: new Date().toISOString(),
-  };
-
   it("first write succeeds and returns the written memory", async () => {
-    // For the first write: search returns empty (no dup), then PUT succeeds.
     const requestSpy = mock(async (_method: string, _path: string, _body?: unknown) => ({}));
-
     const client = new FlairClient({ agentId: "test-agent" });
     client.request = requestSpy as any;
 
-    // Override search to return empty (no duplicate)
-    const searchSpy = mock(async () => []);
-    (client.memory as any).search = searchSpy;
-
-    const result = await client.memory.write(content1, {
-      dedup: true,
-      dedupThreshold: 0.95,
-    });
+    const result = await client.memory.write(content1, { dedup: true, dedupThreshold: 0.95 });
 
     expect(result.id).toBeDefined();
     expect(result.content).toBe(content1);
-    expect(result.deduped).toBeUndefined();
-    expect(searchSpy).toHaveBeenCalledTimes(1);
-    expect(requestSpy).toHaveBeenCalled();
+    expect(requestSpy).toHaveBeenCalledTimes(1);
+    expect(requestSpy.mock.calls[0][0]).toBe("PUT");
   });
 
-  it("second write (near-duplicate) returns deduped: true with first write's content", async () => {
-    // For the second write: search returns a hit, then get resolves to fakeMemory.
-    // No PUT should be called.
-    const requestSpy = mock(async (_method: string, _path: string, _body?: unknown) => {
-      throw new Error("PUT should not be called on dedup hit");
-    });
-
+  it("a near-duplicate write is STILL written — never suppressed, never dropped", async () => {
+    // Simulate the server's dedup gate finding a conservative match: it
+    // still returns a normal PUT-success shape, PLUS the collision signal.
+    const requestSpy = mock(async (_method: string, _path: string, _body?: unknown) => ({
+      deduplicated: true,
+      matchedId: "test-agent-existing-1",
+      matchConfidence: { cosine: 0.97, lexical: 0.8 },
+      written: true,
+    }));
     const client = new FlairClient({ agentId: "test-agent" });
     client.request = requestSpy as any;
 
-    // Simulate search returning a near-duplicate hit
-    const searchSpy = mock(async () => [{ id: fakeMemory.id, content: fakeMemory.content, score: 0.97 }]);
-    (client.memory as any).search = searchSpy;
+    const result = await client.memory.write(content2, { dedup: true, dedupThreshold: 0.95 });
 
-    // get returns the existing memory
-    const getSpy = mock(async () => fakeMemory);
-    (client.memory as any).get = getSpy;
+    // Exactly one write call — no client-side pre-flight search exists anymore.
+    expect(requestSpy).toHaveBeenCalledTimes(1);
+    expect(requestSpy.mock.calls[0][0]).toBe("PUT");
+    // The NEW content was written under a NEW id — never swapped for the
+    // existing match's id/content (the old bug's exact failure mode).
+    expect(result.id).not.toBe("test-agent-existing-1");
+    expect(result.content).toBe(content2);
+    expect((result as any).written).toBe(true);
+    // The collision signal passes through as a SIGNAL, not a suppression flag.
+    expect((result as any).deduplicated).toBe(true);
+    expect((result as any).matchedId).toBe("test-agent-existing-1");
+    expect((result as any).matchConfidence).toEqual({ cosine: 0.97, lexical: 0.8 });
+  });
 
-    const result = await client.memory.write(content2, {
-      dedup: true,
-      dedupThreshold: 0.95,
+  it("dedup/dedupThreshold are forwarded as passthrough hints in the request body", async () => {
+    const requestSpy = mock(async (_method: string, _path: string, body?: unknown) => {
+      expect((body as any).dedup).toBe(true);
+      expect((body as any).dedupThreshold).toBe(0.8);
+      return {};
     });
-
-    // Must signal dedup was suppressed
-    expect((result as any).deduped).toBe(true);
-    // ID matches the first write's ID, not a newly generated one
-    expect(result.id).toBe(fakeMemory.id);
-    // Content matches the FIRST write, not the second
-    expect(result.content).toBe(content1);
-    // Search was called
-    expect(searchSpy).toHaveBeenCalledTimes(1);
-    // get was called
-    expect(getSpy).toHaveBeenCalled();
-  });
-
-  it("reads the originally-written memory — content matches first write, not second", async () => {
     const client = new FlairClient({ agentId: "test-agent" });
+    client.request = requestSpy as any;
 
-    const getSpy = mock(async () => fakeMemory);
-    (client.memory as any).get = getSpy;
-
-    const mem = await client.memory.get(fakeMemory.id);
-    expect(mem).not.toBeNull();
-    expect(mem!.content).toBe(content1);
+    await client.memory.write(content1, { dedup: true, dedupThreshold: 0.8 });
+    expect(requestSpy).toHaveBeenCalledTimes(1);
   });
 
-  it("dedup not triggered when content is short (< 20 chars)", async () => {
-    const shortContent = "ok";
+  it("short content still writes normally (server applies its own length bypass)", async () => {
     const requestSpy = mock(async () => ({}));
-
     const client = new FlairClient({ agentId: "test-agent" });
     client.request = requestSpy as any;
 
-    const searchSpy = mock(async () => [{ id: "match", content: "ok", score: 0.99 }]);
-    (client.memory as any).search = searchSpy;
+    const result = await client.memory.write("ok", { dedup: true, dedupThreshold: 0.95 });
 
-    await client.memory.write(shortContent, {
-      dedup: true,
-      dedupThreshold: 0.95,
-    });
-
-    // Search should NOT have been called for short content
-    expect(searchSpy).not.toHaveBeenCalled();
-    // PUT should have been called (it creates a new entry)
-    expect(requestSpy).toHaveBeenCalled();
+    expect(requestSpy).toHaveBeenCalledTimes(1);
+    expect(result.content).toBe("ok");
   });
 });

--- a/test/unit/memory-integrity.test.ts
+++ b/test/unit/memory-integrity.test.ts
@@ -1,0 +1,484 @@
+/**
+ * memory-integrity.test.ts — regression guard for the memory-integrity fix
+ * (flair#526 silent-drop, flair#548 stale-read-after-update, ops-a4t5
+ * supersede silent-fail).
+ *
+ * Exercises resources/Memory.ts (post/put) directly against a mocked
+ * @harperfast/harper, same technique as coordination-write-auth.test.ts and
+ * resolve-agent-auth.test.ts. The auth verdict is injected via
+ * getContext().request.tpsAgent/tpsAgentIsAdmin — exactly what the
+ * non-rejecting gate sets after verifying a signature.
+ *
+ * ── Deterministic dedup testing without a real embedding model ──────────────
+ * getEmbedding() is mocked to return the SAME constant vector for every
+ * input, so raw cosine similarity is ALWAYS 1.0 between any two memories in
+ * this file. This is deliberate: it isolates the Jaccard/lexical gate as the
+ * ONLY discriminator, proving the co-gate requirement (cosine AND lexical)
+ * rather than the pre-fix raw-cosine-only behavior, which — under this same
+ * fake — would flag literally every second write as a "duplicate". The
+ * lexical side of the gate runs on the REAL text via the real tokenize()/
+ * jaccardSimilarity() implementations — nothing about that math is mocked.
+ */
+import { describe, it, expect, beforeEach, mock, spyOn } from "bun:test";
+
+// Defensive: `bun test <dir>` runs every file in one process, and
+// resources/rate-limiter.ts reads process.env LAZILY (not cached at import
+// time). test/unit/rate-limiter.test.ts enables rate limiting for its own
+// assertions and restores it in afterAll — but this file's Memory.post()
+// calls (many, reusing a handful of fixed agent ids) must never be affected
+// by that or any future env leak, so pin it OFF explicitly here regardless
+// of load order.
+process.env.FLAIR_RATE_LIMIT_ENABLED = "false";
+delete (process.env as any).FLAIR_PUBLIC;
+
+const FAKE_EMBEDDING = [1, 0, 0, 0];
+
+mock.module("../../resources/embeddings-provider.ts", () => ({
+  getEmbedding: async (_text: string) => FAKE_EMBEDDING,
+  getModelId: () => "mock-embedding-model",
+}));
+
+// ─── In-memory Harper Memory / MemoryGrant / Agent mock ─────────────────────
+
+function cosineSim(a: number[], b: number[]): number {
+  let dot = 0, na = 0, nb = 0;
+  for (let i = 0; i < a.length; i++) {
+    dot += a[i] * b[i];
+    na += a[i] * a[i];
+    nb += b[i] * b[i];
+  }
+  if (na === 0 || nb === 0) return 0;
+  return dot / (Math.sqrt(na) * Math.sqrt(nb));
+}
+
+function matchesCondition(record: any, cond: any): boolean {
+  if (cond.operator && Array.isArray(cond.conditions)) {
+    const results = cond.conditions.map((c: any) => matchesCondition(record, c));
+    return cond.operator === "or" ? results.some(Boolean) : results.every(Boolean);
+  }
+  const fieldVal = record[cond.attribute];
+  if (cond.comparator === "equals") return fieldVal === cond.value;
+  if (cond.comparator === "not_equal") return fieldVal !== cond.value;
+  return true;
+}
+
+let memoryStore: Map<string, any>;
+let memoryGrants: any[];
+let callOrder: string[];
+let idCounter: number;
+
+function memorySearchGen(query: any) {
+  let records = Array.from(memoryStore.values());
+  const conditions = Array.isArray(query?.conditions) ? query.conditions : [];
+  for (const cond of conditions) records = records.filter((r) => matchesCondition(r, cond));
+  if (query?.sort?.attribute === "embedding" && query.sort.distance === "cosine") {
+    const target = query.sort.target;
+    records = records
+      .map((r) => ({ ...r, $distance: Array.isArray(r.embedding) ? 1 - cosineSim(r.embedding, target) : 1 }))
+      .sort((a, b) => a.$distance - b.$distance);
+  }
+  const limit = typeof query?.limit === "number" ? query.limit : undefined;
+  const sliced = limit !== undefined ? records.slice(0, limit) : records;
+  async function* gen() {
+    for (const r of sliced) yield r;
+  }
+  return gen();
+}
+
+class BaseMemory {
+  async post(content: any) {
+    const id = content.id ?? `mock-${++idCounter}`;
+    content.id = id; // mutate in place — matches real Harper create() semantics
+    callOrder.push(`post:${id}`);
+    const rec = { ...content };
+    memoryStore.set(id, rec);
+    return rec;
+  }
+  async put(content: any) {
+    callOrder.push(`put:${content.id}`);
+    const rec = { ...content };
+    memoryStore.set(content.id, rec);
+    return rec;
+  }
+  async get(id: any) {
+    return memoryStore.get(id) ?? null;
+  }
+  async delete(id: any) {
+    memoryStore.delete(id);
+    return { ok: true };
+  }
+  search(query: any) {
+    return memorySearchGen(query);
+  }
+
+  static async get(id: any) {
+    return memoryStore.get(id) ?? null;
+  }
+  static async put(content: any) {
+    callOrder.push(`static-put:${content.id}`);
+    const rec = { ...content };
+    memoryStore.set(content.id, rec);
+    return rec;
+  }
+  static search(query: any) {
+    return memorySearchGen(query);
+  }
+}
+
+const databasesMock = {
+  flair: {
+    Memory: BaseMemory,
+    MemoryGrant: {
+      search: (query: any) => {
+        const conditions = Array.isArray(query?.conditions) ? query.conditions : [];
+        let grants = memoryGrants.slice();
+        for (const cond of conditions) grants = grants.filter((g) => matchesCondition(g, cond));
+        async function* gen() {
+          for (const g of grants) yield g;
+        }
+        return gen();
+      },
+    },
+    Agent: { get: async () => null, search: async () => [] },
+  },
+};
+
+mock.module("@harperfast/harper", () => ({ databases: databasesMock }));
+
+const { Memory } = await import("../../resources/Memory.ts");
+const { jaccardSimilarity, isConservativeMatch, computeMatchConfidence } = await import("../../resources/dedup.ts");
+const { tokenize } = await import("../../resources/bm25.ts");
+
+function makeMemory(ctxRequest: any) {
+  const r: any = new (Memory as any)();
+  r.getContext = () => ({ request: ctxRequest });
+  return r;
+}
+const agentCtx = (agentId: string, isAdmin = false) => ({ tpsAgent: agentId, tpsAgentIsAdmin: isAdmin });
+const anonCtx = () => ({ tpsAnonymous: true });
+
+beforeEach(() => {
+  memoryStore = new Map();
+  memoryGrants = [];
+  callOrder = [];
+  idCounter = 0;
+});
+
+// ─── Fixture text for the #526 replay ────────────────────────────────────────
+// Models the real field case: two findings that share vocabulary (both about
+// federation "replication") but are substantively DIFFERENT facts, plus a
+// genuine reword of one of them (same substance, different phrasing).
+const FINDING_A =
+  "Federation replication direction is governed by a per-pair sends and receives knob in the pairing config.";
+const FINDING_B_DISTINCT =
+  "DDL and schema changes never replicate automatically across a federation pair; you must apply column additions manually on each spoke.";
+const FINDING_A_REWORDED =
+  "Federation replication direction is controlled by a per-pair sends/receives knob inside the pairing configuration.";
+
+// ─── Pure Jaccard / cosine co-gate math (Harper-free, no mocking needed) ─────
+describe("dedup co-gate — pure math (resources/dedup.ts)", () => {
+  it("topic collision: shares vocabulary but is substantively distinct → LOW jaccard", () => {
+    const j = jaccardSimilarity(tokenize(FINDING_A), tokenize(FINDING_B_DISTINCT));
+    expect(j).toBeLessThan(0.5);
+  });
+
+  it("true near-duplicate: reworded but same substance → HIGH jaccard", () => {
+    const j = jaccardSimilarity(tokenize(FINDING_A), tokenize(FINDING_A_REWORDED));
+    expect(j).toBeGreaterThanOrEqual(0.5);
+  });
+
+  it("isConservativeMatch requires BOTH cosine and lexical thresholds to clear", () => {
+    expect(isConservativeMatch(0.99, 0.2)).toBe(false); // high cosine, low lexical — topic collision
+    expect(isConservativeMatch(0.99, 0.6)).toBe(true); // both high — true near-dup
+    expect(isConservativeMatch(0.8, 0.9)).toBe(false); // low cosine, high lexical
+  });
+
+  it("computeMatchConfidence rounds to 3dp and derives lexical from real tokenize()", () => {
+    const conf = computeMatchConfidence("hello world foo", "hello world bar", 0.99996);
+    expect(conf.cosine).toBe(1);
+    expect(conf.lexical).toBeGreaterThan(0);
+    expect(conf.lexical).toBeLessThan(1);
+  });
+
+  it("jaccardSimilarity of two empty/no-overlap sets is 0, never treated as a match", () => {
+    expect(jaccardSimilarity([], [])).toBe(0);
+    expect(jaccardSimilarity(["a", "b"], [])).toBe(0);
+  });
+});
+
+// ─── #526 replay + never-silent-loss ─────────────────────────────────────────
+describe("Memory.post — server-side dedup gate never suppresses a write", () => {
+  it("#526 replay: two topically-close but DISTINCT findings are BOTH written (not merged)", async () => {
+    const m1 = makeMemory(agentCtx("agent-1"));
+    const r1 = await m1.post({ agentId: "agent-1", content: FINDING_A });
+    expect(r1.written).toBe(true);
+
+    const m2 = makeMemory(agentCtx("agent-1"));
+    const r2 = await m2.post({ agentId: "agent-1", content: FINDING_B_DISTINCT });
+
+    // THE regression: both records must exist — the second must NOT have
+    // been dropped/merged into the first, even though cosine is (mocked) 1.0.
+    expect(memoryStore.size).toBe(2);
+    expect(r2.written).toBe(true);
+    expect(r2.id).not.toBe(r1.id);
+    expect(r2.deduplicated).toBe(false);
+    const stored2 = await BaseMemory.get(r2.id);
+    expect(stored2.content).toBe(FINDING_B_DISTINCT);
+  });
+
+  it("a true near-duplicate is flagged (deduplicated:true) but STILL written as a new record", async () => {
+    const m1 = makeMemory(agentCtx("agent-1"));
+    const r1 = await m1.post({ agentId: "agent-1", content: FINDING_A });
+
+    const m2 = makeMemory(agentCtx("agent-1"));
+    const r2 = await m2.post({ agentId: "agent-1", content: FINDING_A_REWORDED });
+
+    expect(memoryStore.size).toBe(2); // never-suppress invariant
+    expect(r2.written).toBe(true);
+    expect(r2.deduplicated).toBe(true);
+    expect(r2.matchedId).toBe(r1.id);
+    expect(r2.matchConfidence.cosine).toBeGreaterThanOrEqual(0.95);
+    expect(r2.matchConfidence.lexical).toBeGreaterThanOrEqual(0.5);
+    const stored2 = await BaseMemory.get(r2.id);
+    expect(stored2.content).toBe(FINDING_A_REWORDED); // new content, never swapped for the old
+  });
+
+  it("never-silent-loss: a store whose content matches an existing record still produces a written record", async () => {
+    const m1 = makeMemory(agentCtx("agent-1"));
+    await m1.post({ agentId: "agent-1", content: FINDING_A });
+    const before = memoryStore.size;
+
+    const m2 = makeMemory(agentCtx("agent-1"));
+    const r2 = await m2.post({ agentId: "agent-1", content: FINDING_A_REWORDED });
+
+    expect(memoryStore.size).toBe(before + 1);
+    expect(await BaseMemory.get(r2.id)).not.toBeNull();
+  });
+
+  it("short content (<20 chars) bypasses the gate entirely — identical short content is never flagged", async () => {
+    const m1 = makeMemory(agentCtx("agent-1"));
+    await m1.post({ agentId: "agent-1", content: "hi there" });
+
+    const m2 = makeMemory(agentCtx("agent-1"));
+    const r2 = await m2.post({ agentId: "agent-1", content: "hi there" });
+
+    expect(r2.deduplicated).toBe(false);
+    expect(memoryStore.size).toBe(2);
+  });
+
+  it("collision-signal shape: deduplicated:true + matchedId present when flagged; written always true", async () => {
+    const m1 = makeMemory(agentCtx("agent-1"));
+    const r1 = await m1.post({ agentId: "agent-1", content: FINDING_A });
+    expect(r1.written).toBe(true);
+    expect(r1.deduplicated).toBe(false);
+    expect(r1.matchedId).toBeUndefined();
+
+    const m2 = makeMemory(agentCtx("agent-1"));
+    const r2 = await m2.post({ agentId: "agent-1", content: FINDING_A_REWORDED });
+    expect(r2.written).toBe(true);
+    expect(r2.deduplicated).toBe(true);
+    expect(typeof r2.matchedId).toBe("string");
+    expect(r2.matchConfidence).toEqual({ cosine: expect.any(Number), lexical: expect.any(Number) });
+  });
+
+  it("dedup match is scoped to the SAME agentId — no cross-agent false positive", async () => {
+    const m1 = makeMemory(agentCtx("agent-1"));
+    await m1.post({ agentId: "agent-1", content: FINDING_A });
+
+    const m2 = makeMemory(agentCtx("agent-2"));
+    const r2 = await m2.post({ agentId: "agent-2", content: FINDING_A_REWORDED }); // same text, different agent
+
+    expect(r2.deduplicated).toBe(false);
+    expect(memoryStore.size).toBe(2);
+  });
+
+  it("anonymous write is still denied (401), and never reaches the dedup gate", async () => {
+    const m = makeMemory(anonCtx());
+    const res = await m.post({ agentId: "agent-1", content: FINDING_A });
+    expect(res instanceof Response).toBe(true);
+    expect((res as Response).status).toBe(401);
+    expect(memoryStore.size).toBe(0);
+  });
+});
+
+// ─── #548 replay: memory_update same-id overwrite ────────────────────────────
+describe("#548 replay: memory_update — same-id overwrite reflects new content", () => {
+  it("a subsequent read returns the NEW content (not stale); the old id resolves to current", async () => {
+    const owner = agentCtx("agent-1");
+    const m = makeMemory(owner);
+    const initial = await m.post({ agentId: "agent-1", content: "Deploy status: pending review (evolving state)." });
+    const id = initial.id;
+
+    // Simulate memory_update's default mode: read existing, merge new content
+    // on top (never a bare partial — Harper PUT is full-record replacement),
+    // clear the stale embedding, PUT to the SAME id. Dedup-bypassed (no
+    // dedup/dedupThreshold hints set, and the id already exists).
+    const existing = await BaseMemory.get(id);
+    const merged: any = { ...existing, content: "Deploy status: shipped and verified in prod.", updatedAt: new Date().toISOString() };
+    delete merged.embedding;
+    delete merged.embeddingModel;
+
+    const mUpdate = makeMemory(owner);
+    const putResult = await mUpdate.put(merged);
+
+    expect(putResult.written).toBe(true);
+    expect(putResult.deduplicated).toBe(false); // update is dedup-bypassed, never flagged
+
+    const after = await BaseMemory.get(id);
+    expect(after.content).toBe("Deploy status: shipped and verified in prod.");
+    expect(after.id).toBe(id); // the OLD id resolves to the CURRENT content
+    expect(memoryStore.size).toBe(1); // same-id overwrite — no duplicate record
+  });
+
+  it("update requires ownership — a non-owner's PUT to another agent's memory id is denied, content untouched", async () => {
+    const mOwner = makeMemory(agentCtx("agent-owner"));
+    const owned = await mOwner.post({ agentId: "agent-owner", content: "Owner's evolving-state memory, long enough for the gate." });
+
+    const existing = await BaseMemory.get(owned.id);
+    const mAttacker = makeMemory(agentCtx("agent-attacker"));
+    const res = await mAttacker.put({ ...existing, content: "Hijacked content" });
+
+    expect(res instanceof Response).toBe(true);
+    expect((res as Response).status).toBe(403);
+    const stillOriginal = await BaseMemory.get(owned.id);
+    expect(stillOriginal.content).toBe("Owner's evolving-state memory, long enough for the gate.");
+  });
+
+  it("a fresh PUT with a not-yet-existing id still runs the dedup gate (only an EXISTING id bypasses it)", async () => {
+    const owner = agentCtx("agent-1");
+    const m1 = makeMemory(owner);
+    await m1.post({ agentId: "agent-1", content: FINDING_A });
+
+    const m2 = makeMemory(owner);
+    const r2 = await m2.put({ id: "agent-1-fresh-put-id", agentId: "agent-1", content: FINDING_A_REWORDED });
+
+    expect(r2.written).toBe(true);
+    expect(r2.deduplicated).toBe(true); // fresh id via PUT — not an update, gate applies
+    expect(memoryStore.size).toBe(2);
+  });
+});
+
+// ─── Supersede auth — reuses existing ownership/grant machinery ─────────────
+describe("supersede auth (memory_update preserveHistory mode)", () => {
+  it("cross-agent supersede WITHOUT a write grant is denied (403), nothing written, old record untouched", async () => {
+    const mOwner = makeMemory(agentCtx("agent-owner"));
+    const owned = await mOwner.post({ agentId: "agent-owner", content: "Owner's original finding, long enough for the dedup gate." });
+
+    const mAttacker = makeMemory(agentCtx("agent-attacker"));
+    const res = await mAttacker.post({
+      agentId: "agent-attacker",
+      content: "Attacker's replacement content, long enough for the gate too.",
+      supersedes: owned.id,
+    });
+
+    expect(res instanceof Response).toBe(true);
+    expect((res as Response).status).toBe(403);
+    expect(memoryStore.size).toBe(1); // nothing new written
+    const stillOwned = await BaseMemory.get(owned.id);
+    expect(stillOwned.validTo).toBeUndefined(); // old record untouched
+  });
+
+  it("cross-agent supersede WITH a write grant succeeds and closes the old record", async () => {
+    const mOwner = makeMemory(agentCtx("agent-owner"));
+    const owned = await mOwner.post({ agentId: "agent-owner", content: "Owner's original finding, long enough for the dedup gate." });
+
+    memoryGrants.push({ granteeId: "agent-attacker", ownerId: "agent-owner", scope: "write" });
+
+    const mGranted = makeMemory(agentCtx("agent-attacker"));
+    const res = await mGranted.post({
+      agentId: "agent-attacker",
+      content: "Granted agent's replacement content, long enough for the gate too.",
+      supersedes: owned.id,
+    });
+
+    expect(res instanceof Response).toBe(false);
+    expect((res as any).written).toBe(true);
+    const closedOld = await BaseMemory.get(owned.id);
+    expect(closedOld.validTo).toBeDefined();
+  });
+
+  it("a read-only grant (scope: read) does NOT satisfy the write-grant requirement", async () => {
+    const mOwner = makeMemory(agentCtx("agent-owner"));
+    const owned = await mOwner.post({ agentId: "agent-owner", content: "Owner's original finding, long enough for the dedup gate." });
+
+    memoryGrants.push({ granteeId: "agent-attacker", ownerId: "agent-owner", scope: "read" });
+
+    const mAttacker = makeMemory(agentCtx("agent-attacker"));
+    const res = await mAttacker.post({
+      agentId: "agent-attacker",
+      content: "Attacker's replacement content, long enough for the gate too.",
+      supersedes: owned.id,
+    });
+
+    expect(res instanceof Response).toBe(true);
+    expect((res as Response).status).toBe(403);
+  });
+
+  it("same-owner supersede needs no grant", async () => {
+    const m = makeMemory(agentCtx("agent-1"));
+    const owned = await m.post({ agentId: "agent-1", content: "Original finding text, long enough for the gate." });
+
+    const m2 = makeMemory(agentCtx("agent-1"));
+    const res = await m2.post({ agentId: "agent-1", content: "Updated finding text, long enough for the gate.", supersedes: owned.id });
+
+    expect((res as any).written).toBe(true);
+    const closedOld = await BaseMemory.get(owned.id);
+    expect(closedOld.validTo).toBeDefined();
+  });
+
+  it("supersedes must be a string — a non-string value is rejected with 400", async () => {
+    const m = makeMemory(agentCtx("agent-1"));
+    const res = await m.post({ agentId: "agent-1", content: "Some content, long enough for the gate.", supersedes: 12345 });
+    expect(res instanceof Response).toBe(true);
+    expect((res as Response).status).toBe(400);
+  });
+});
+
+// ─── Supersede transaction — write-new BEFORE close-old, observable failure ──
+describe("supersede transaction (ops-a4t5 fix)", () => {
+  it("write-new happens BEFORE close-old (call order)", async () => {
+    const owner = agentCtx("agent-1");
+    const mOwner = makeMemory(owner);
+    const owned = await mOwner.post({ agentId: "agent-1", content: "Original evolving state, long enough for the gate." });
+    callOrder.length = 0; // reset — only care about the ordering of the SECOND write
+
+    const mNew = makeMemory(owner);
+    await mNew.post({ agentId: "agent-1", content: "New version, long enough for the gate.", supersedes: owned.id });
+
+    const newWriteIdx = callOrder.findIndex((c) => c.startsWith("post:"));
+    const closeWriteIdx = callOrder.findIndex((c) => c.startsWith("static-put:"));
+    expect(newWriteIdx).toBeGreaterThanOrEqual(0);
+    expect(closeWriteIdx).toBeGreaterThan(newWriteIdx);
+  });
+
+  it("a close-old failure is logged (observable), never silent — and the new record is still safely written", async () => {
+    const errorSpy = spyOn(console, "error").mockImplementation(() => {});
+    try {
+      const owner = agentCtx("agent-1");
+      const mOwner = makeMemory(owner);
+      const owned = await mOwner.post({ agentId: "agent-1", content: "Original evolving state, long enough for the gate." });
+
+      // Force the close-old step to fail: remove the target record out from
+      // under it (simulates a lost/racing record) right before the superseding
+      // write — the write-new-before-close-old ordering means the auth check's
+      // earlier .get() already ran/passed for a same-owner supersede (no grant
+      // lookup needed), so removing it here only affects the LATER close step.
+      memoryStore.delete(owned.id);
+
+      const mNew = makeMemory(owner);
+      const result = await mNew.post({ agentId: "agent-1", content: "New version, long enough for the gate.", supersedes: owned.id });
+
+      // The new record's write must have succeeded regardless of the failed close.
+      expect((result as any).written).toBe(true);
+      expect(memoryStore.has((result as any).id)).toBe(true);
+
+      // The failure was logged, not swallowed (ops-a4t5).
+      expect(errorSpy).toHaveBeenCalled();
+      const loggedMsg = errorSpy.mock.calls.map((c) => c.join(" ")).join("\n");
+      expect(loggedMsg).toContain("ops-a4t5");
+      expect(loggedMsg).toContain(owned.id);
+    } finally {
+      errorSpy.mockRestore();
+    }
+  });
+});

--- a/test/unit/memory-integrity.test.ts
+++ b/test/unit/memory-integrity.test.ts
@@ -472,9 +472,14 @@ describe("supersede transaction (ops-a4t5 fix)", () => {
       expect((result as any).written).toBe(true);
       expect(memoryStore.has((result as any).id)).toBe(true);
 
-      // The failure was logged, not swallowed (ops-a4t5).
+      // The failure was logged, not swallowed (ops-a4t5). The log uses a
+      // constant format string + a structured data object (the record ids are
+      // agent-controlled, so they must not sit in console.error's format
+      // position — semgrep unsafe-formatstring), so flatten object args too.
       expect(errorSpy).toHaveBeenCalled();
-      const loggedMsg = errorSpy.mock.calls.map((c) => c.join(" ")).join("\n");
+      const loggedMsg = errorSpy.mock.calls
+        .map((c) => c.map((a) => (a && typeof a === "object" ? JSON.stringify(a, (_k, v) => (v instanceof Error ? v.message : v)) : String(a))).join(" "))
+        .join("\n");
       expect(loggedMsg).toContain("ops-a4t5");
       expect(loggedMsg).toContain(owned.id);
     } finally {

--- a/test/unit/rate-limiter.test.ts
+++ b/test/unit/rate-limiter.test.ts
@@ -1,10 +1,35 @@
-import { describe, test, expect, beforeEach } from "bun:test";
+import { describe, test, expect, beforeEach, afterAll } from "bun:test";
 
-// We need to enable rate limiting for tests
+// We need to enable rate limiting for tests. `checkRateLimit`/`isEnabled`
+// read process.env LAZILY on every call (not cached at import time), so it's
+// safe to set these here and restore them in afterAll below.
+//
+// Test-isolation note: `bun test <dir>` runs every file in ONE process, so an
+// unrestored `process.env` mutation here leaks into every OTHER test file
+// that runs afterward — including ones that exercise Memory.post()'s own
+// checkRateLimit("general") call with a small, fixed number of test agent
+// ids. Once this file set FLAIR_RATE_LIMIT_RPM=5 without cleanup, any other
+// suite doing >5 writes for the same agentId within the shared 60s window
+// started intermittently 429'ing depending on file execution order (caught
+// by test/unit/memory-integrity.test.ts flaking only in the full-suite run,
+// never in isolation — see that file's own defensive env override too).
+const ORIGINAL_ENV = {
+  FLAIR_RATE_LIMIT_ENABLED: process.env.FLAIR_RATE_LIMIT_ENABLED,
+  FLAIR_RATE_LIMIT_RPM: process.env.FLAIR_RATE_LIMIT_RPM,
+  FLAIR_RATE_LIMIT_EMBED: process.env.FLAIR_RATE_LIMIT_EMBED,
+  FLAIR_RATE_LIMIT_STORAGE: process.env.FLAIR_RATE_LIMIT_STORAGE,
+};
 process.env.FLAIR_RATE_LIMIT_ENABLED = "true";
 process.env.FLAIR_RATE_LIMIT_RPM = "5"; // Low limit for testing
 process.env.FLAIR_RATE_LIMIT_EMBED = "3";
 process.env.FLAIR_RATE_LIMIT_STORAGE = "100";
+
+afterAll(() => {
+  for (const [key, value] of Object.entries(ORIGINAL_ENV)) {
+    if (value === undefined) delete (process.env as any)[key];
+    else process.env[key] = value;
+  }
+});
 
 // Import after setting env vars
 const { checkRateLimit, checkStorageQuota, rateLimitResponse, storageQuotaResponse } = await import("../../resources/rate-limiter");


### PR DESCRIPTION
## Memory integrity — stop the dedup gate silently losing writes

Closes #526, #548; fixes ops-a4t5. Implements the design K&S reviewed on #548 ([design](https://github.com/tpsdev-ai/flair/issues/548#issuecomment-4872378367) + [locked adjudication](https://github.com/tpsdev-ai/flair/issues/548#issuecomment-4872405068)).

### The defect (high blast radius)
The dedup gate was raw-cosine-only @0.95 and, on a match, **returned the existing record and never wrote the new content** — and `flair-mcp` enabled it by default, so every MCP write was exposed. Two failures, one root: distinct-but-topically-close findings falsely merged and vanished (#526); update-intent writes got dedup-matched so stale state was actively preserved (#548).

### The fix
1. **Never-silent-loss invariant.** The write ALWAYS lands. `buildWriteResponse` unconditionally sets `written: true`; a conservative match is surfaced as a **signal** (`deduplicated`, `matchedId`, `matchConfidence`), never a reason to skip the write. No code path suppresses.
2. **Cosine AND lexical co-gate** (`resources/dedup.ts`, Harper-free/unit-tested): a candidate is a duplicate only if raw cosine ≥ 0.95 AND Jaccard token-overlap ≥ 0.5 (shared `tokenize()` from `bm25.ts`, a 2-doc set op — no BM25 index). Kills the #526 topic-collision merges (high cosine, low lexical → not flagged).
3. **Gate is server-side**, shared by `Memory.post()` (in-process, the Model-2 `/mcp` path) and `Memory.put()` (the HTTP path flair-client/CLI/flair-mcp actually use) — both transports now behave identically (previously `/mcp` did zero dedup).
4. **`memory_update`** on both MCP surfaces (10 curated tools now): default **same-id overwrite** (dedup-bypassed — an update is intentional, not an ambiguous dup); opt-in `supersedes`-link for history. Update-vs-create is decided by server-side pre-existence check, not a client flag.
5. **ops-a4t5 fixed:** supersede's validity-window close is **write-new-before-close-old** and **throws-then-logs** on failure (never the old `.catch(()=>{})`). Cross-agent supersede requires a `MemoryGrant` with `scope: "write"` (new grant scope) — else it's a cross-agent write, denied.

### Deviations from the literal spec (flagged for review)
- **PUT not POST.** A raw HTTP `POST /Memory` 404s ("Memory does not have a post method implemented" — `src/cli.ts` / ops-pj5); only PUT is HTTP-reachable, and `flair-client.write()/update()` (the field-observed #526 path) use PUT. So the gate is a **shared helper on both `post()` and `put()`**, not `post()`-only. A literal "gate in Memory.post" would have missed the actual field path entirely.
- **New `MemoryGrant.scope: "write"`** for cross-agent supersede authorization (extends the existing free-text scope alongside read/search) — Sherlock's design-review concern about cross-agent writes.
- Minor messaging fixes in `pi-flair`/`openclaw-flair` (they read the now-removed `.deduped` suppress flag). openclaw-flair's own separate non-transactional supersede pattern left untouched → tracked as a follow-up.
- Fixed an unrelated pre-existing test-isolation bug (`rate-limiter.test.ts` leaked `FLAIR_RATE_LIMIT_ENABLED` env across the process).

### Verification (independently re-run by me, not just self-reported)
- **Before/after proof:** reverting the source to main and running the new suite → **9 pass / 13 fail** (the #526/#548 replays + never-suppress/supersede cases fail — proving the tests exercise the bug); with the fix → **22/22**.
- `test/unit/memory-integrity.test.ts` (+22): #526 replay (both distinct findings written), #548 replay (same-id update returns current), Jaccard co-gate units, never-silent-loss, auth (update ownership + cross-agent supersede denial), supersede write-before-close + observable failure.
- Typecheck clean (all packages). Full unit suite **1257 pass / 0 fail** (main baseline 1232).

### 🔴 K&S — implementation sign-off (Sherlock hard-gate)
You reviewed the design; this is the code. Sherlock: the never-silent-loss invariant in the actual write paths, the new `scope:"write"` cross-agent auth, and the supersede ordering/observability. Kern: the server-side gate placement + the PUT/POST deviation + the update-vs-create pre-existence logic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)