### PR TITLE
release: v0.18.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 ## [Unreleased]
 
+## [0.18.0] - 2026-07-03
+
+### 🧠 Memory integrity: the dedup gate no longer silently loses writes (#553 — closes #526, #548)
+
+`memory_store`'s dedup gate was raw-cosine-only at 0.95 and **silently dropped** the new write on a match — so distinct-but-topically-close findings vanished (#526, the field case: replication route-directionality vs an unrelated DDL/schema memory) and update-intent writes preserved stale state (#548). Since `flair-mcp` enabled dedup by default, every MCP write was exposed. The fix:
+
+- **Never-silent-loss invariant** — the gate never suppresses a write. It always writes; a near-duplicate is surfaced only as a signal (`deduplicated` / `matchedId` / `matchConfidence`), never a reason to drop.
+- **Conservative same-fact detection** — a candidate is a duplicate only if cosine **AND** lexical (Jaccard token-overlap) both clear their thresholds, so a topic collision (high cosine, low lexical) is no longer merged.
+- **Gate moved server-side** into `Memory` — both the HTTP write path and the native `/mcp` path (which previously had *no* dedup) now behave identically.
+- **`memory_update`** (new MCP tool, both surfaces) — id-targeted, dedup-bypassed, default **same-id overwrite**; opt-in supersede-link mode. Retires the racy, identity-breaking delete+store workaround.
+- **Supersede is transactional + observable** — validity-window close is write-new-before-close-old and logs on failure (no more silent `.catch(() => {})`); a cross-agent supersede requires a `write` grant.
+
+### 🔎 Cross-encoder reranker in SemanticSearch — default-OFF (#496)
+
+An in-process cross-encoder re-scores query+candidate together and reorders the retrieval set before the final slice, composing with the BM25+union-RRF hybrid path, fail-open to vector order. **Default-OFF** behind `FLAIR_RERANK_ENABLED`; enabling waits on the recall measurement gate.
+
 ## [0.17.0] - 2026-07-02
 
 ### 🔒 SECURITY: cross-agent isolation break — `getContext()` not `this.request` (#551, ops-sal4)

--- a/bun.lock
+++ b/bun.lock
@@ -60,7 +60,7 @@
       "name": "@tpsdev-ai/langgraph-flair",
       "version": "0.18.0",
       "dependencies": {
-        "@tpsdev-ai/flair-client": "0.17.0",
+        "@tpsdev-ai/flair-client": "0.18.0",
       },
       "peerDependencies": {
         "@langchain/langgraph-checkpoint": ">=0.0.10",
@@ -70,7 +70,7 @@
       "name": "@tpsdev-ai/n8n-nodes-flair",
       "version": "0.18.0",
       "dependencies": {
-        "@tpsdev-ai/flair-client": "0.17.0",
+        "@tpsdev-ai/flair-client": "0.18.0",
         "zod": "3.25.76",
       },
       "devDependencies": {
@@ -90,7 +90,7 @@
       "version": "0.18.0",
       "dependencies": {
         "@sinclair/typebox": "0.34.48",
-        "@tpsdev-ai/flair-client": "0.17.0",
+        "@tpsdev-ai/flair-client": "0.18.0",
       },
       "devDependencies": {
         "typescript": "5.9.3",
@@ -104,7 +104,7 @@
       "version": "0.18.0",
       "dependencies": {
         "@sinclair/typebox": "0.34.48",
-        "@tpsdev-ai/flair-client": "0.17.0",
+        "@tpsdev-ai/flair-client": "0.18.0",
       },
       "devDependencies": {
         "@mariozechner/pi-coding-agent": "0.73.0",

--- a/bun.lock
+++ b/bun.lock
@@ -35,21 +35,21 @@
     },
     "packages/flair-client": {
       "name": "@tpsdev-ai/flair-client",
-      "version": "0.17.0",
+      "version": "0.18.0",
       "devDependencies": {
         "typescript": "5.9.3",
       },
     },
     "packages/flair-mcp": {
       "name": "@tpsdev-ai/flair-mcp",
-      "version": "0.17.0",
+      "version": "0.18.0",
       "bin": {
         "flair-mcp": "dist/mcp-shim.cjs",
         "flair-session-start": "dist/session-start-hook.js",
       },
       "dependencies": {
         "@modelcontextprotocol/sdk": "1.27.1",
-        "@tpsdev-ai/flair-client": "0.17.0",
+        "@tpsdev-ai/flair-client": "0.18.0",
         "zod": "4.3.6",
       },
       "devDependencies": {
@@ -58,7 +58,7 @@
     },
     "packages/langgraph-flair": {
       "name": "@tpsdev-ai/langgraph-flair",
-      "version": "0.17.0",
+      "version": "0.18.0",
       "dependencies": {
         "@tpsdev-ai/flair-client": "0.17.0",
       },
@@ -68,7 +68,7 @@
     },
     "packages/n8n-nodes-flair": {
       "name": "@tpsdev-ai/n8n-nodes-flair",
-      "version": "0.17.0",
+      "version": "0.18.0",
       "dependencies": {
         "@tpsdev-ai/flair-client": "0.17.0",
         "zod": "3.25.76",
@@ -87,7 +87,7 @@
     },
     "packages/openclaw-flair": {
       "name": "@tpsdev-ai/openclaw-flair",
-      "version": "0.17.0",
+      "version": "0.18.0",
       "dependencies": {
         "@sinclair/typebox": "0.34.48",
         "@tpsdev-ai/flair-client": "0.17.0",
@@ -101,7 +101,7 @@
     },
     "packages/pi-flair": {
       "name": "@tpsdev-ai/pi-flair",
-      "version": "0.17.0",
+      "version": "0.18.0",
       "dependencies": {
         "@sinclair/typebox": "0.34.48",
         "@tpsdev-ai/flair-client": "0.17.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tpsdev-ai/flair",
-  "version": "0.17.0",
+  "version": "0.18.0",
   "description": "Identity, memory, and soul for AI agents. Cryptographic identity (Ed25519), semantic memory with local embeddings, and persistent personality — all in a single process.",
   "type": "module",
   "license": "Apache-2.0",

--- a/packages/flair-client/package.json
+++ b/packages/flair-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tpsdev-ai/flair-client",
-  "version": "0.17.0",
+  "version": "0.18.0",
   "description": "Lightweight client for Flair — identity, memory, and soul for AI agents. Zero heavy dependencies.",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/flair-mcp/package.json
+++ b/packages/flair-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tpsdev-ai/flair-mcp",
-  "version": "0.17.0",
+  "version": "0.18.0",
   "description": "MCP server for Flair — persistent memory for Claude Code, Cursor, and any MCP client.",
   "type": "module",
   "main": "dist/index.js",
@@ -27,7 +27,7 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "1.27.1",
-    "@tpsdev-ai/flair-client": "0.17.0",
+    "@tpsdev-ai/flair-client": "0.18.0",
     "zod": "4.3.6"
   },
   "license": "Apache-2.0",

--- a/packages/langgraph-flair/package.json
+++ b/packages/langgraph-flair/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tpsdev-ai/langgraph-flair",
-  "version": "0.17.0",
+  "version": "0.18.0",
   "description": "LangGraph BaseStore adapter backed by Flair — durable agent memory with crypto-pinned identity, federation, and cross-orchestrator portability.",
   "type": "module",
   "main": "dist/index.js",
@@ -36,7 +36,7 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
-    "@tpsdev-ai/flair-client": "0.17.0"
+    "@tpsdev-ai/flair-client": "0.18.0"
   },
   "peerDependencies": {
     "@langchain/langgraph-checkpoint": ">=0.0.10"

--- a/packages/n8n-nodes-flair/package.json
+++ b/packages/n8n-nodes-flair/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tpsdev-ai/n8n-nodes-flair",
-  "version": "0.17.0",
+  "version": "0.18.0",
   "description": "n8n community node — use Flair as your AI Agent's memory backend. Includes FlairChatMemory (Memory port) and FlairSearch (Tool port).",
   "type": "commonjs",
   "main": "dist/index.js",
@@ -48,7 +48,7 @@
     "langchain"
   ],
   "dependencies": {
-    "@tpsdev-ai/flair-client": "0.17.0",
+    "@tpsdev-ai/flair-client": "0.18.0",
     "zod": "3.25.76"
   },
   "peerDependencies": {

--- a/packages/openclaw-flair/package.json
+++ b/packages/openclaw-flair/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tpsdev-ai/openclaw-flair",
-  "version": "0.17.0",
+  "version": "0.18.0",
   "description": "OpenClaw memory plugin for Flair — agent identity and semantic memory",
   "type": "module",
   "main": "./dist/index.js",
@@ -58,7 +58,7 @@
   },
   "dependencies": {
     "@sinclair/typebox": "0.34.48",
-    "@tpsdev-ai/flair-client": "0.17.0"
+    "@tpsdev-ai/flair-client": "0.18.0"
   },
   "devDependencies": {
     "typescript": "5.9.3"

--- a/packages/pi-flair/package.json
+++ b/packages/pi-flair/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tpsdev-ai/pi-flair",
-  "version": "0.17.0",
+  "version": "0.18.0",
   "description": "Flair memory extension for pi — persistent memory access from within pi sessions",
   "type": "module",
   "main": "dist/index.js",
@@ -21,7 +21,7 @@
     "node": ">=18"
   },
   "dependencies": {
-    "@tpsdev-ai/flair-client": "0.17.0",
+    "@tpsdev-ai/flair-client": "0.18.0",
     "@sinclair/typebox": "0.34.48"
   },
   "license": "Apache-2.0",


### PR DESCRIPTION
Version bump across workspace packages to v0.18.0.

See CHANGELOG.md for what's in this release.

After CI is green and this is merged:
```
git checkout main && git pull
./scripts/release.sh 0.18.0 --publish
```