### PR TITLE
fix(security): admin console reachable by verified non-admin agents (P0) + family read-gate (ops-oox7, ops-2ty0)

### DIFF
--- a/resources/Admin.ts
+++ b/resources/Admin.ts
@@ -1,4 +1,5 @@
 import { Resource } from "@harperfast/harper";
+import { allowAdmin } from "./agent-auth.js";
 
 /**
  * GET /Admin — friendly redirect to /AdminDashboard.
@@ -6,8 +7,20 @@ import { Resource } from "@harperfast/harper";
  * Operators bookmark or type the bare /Admin path. Without this resource
  * they hit a 404 and assume the admin UI is broken. The dashboard is the
  * canonical landing surface; redirect there.
+ *
+ * allowRead()=allowAdmin (ops-oox7 defense-in-depth): the /Admin* pathname
+ * gate in auth-middleware.ts only 401s when there's NO Authorization header
+ * at all (or Basic creds don't resolve to a real user) — a validly-verified
+ * TPS-Ed25519 agent that is NOT an admin, or a valid-but-non-super_user Basic
+ * user, currently sails through the middleware with no admin resource-level
+ * check at all. allowRead closes that gap the same way WorkspaceLatest.ts /
+ * MemoryReindex.ts already gate their own custom (non-@table) Resources.
  */
 export class Admin extends Resource {
+  async allowRead(): Promise<boolean> {
+    return allowAdmin((this as any).getContext?.());
+  }
+
   async get() {
     return new Response("", {
       status: 302,

--- a/resources/AdminConnectors.ts
+++ b/resources/AdminConnectors.ts
@@ -1,10 +1,17 @@
 import { Resource, databases } from "@harperfast/harper";
 import { layout, htmlResponse, esc } from "./admin-layout.js";
+import { allowAdmin } from "./agent-auth.js";
 
 /**
  * GET /AdminConnectors — OAuth clients and active sessions.
+ *
+ * allowRead()=allowAdmin (ops-oox7 defense-in-depth): see Admin.ts.
  */
 export class AdminConnectors extends Resource {
+  async allowRead(): Promise<boolean> {
+    return allowAdmin((this as any).getContext?.());
+  }
+
   async get() {
     const clients: any[] = [];
 

--- a/resources/AdminDashboard.ts
+++ b/resources/AdminDashboard.ts
@@ -1,10 +1,20 @@
 import { Resource, databases } from "@harperfast/harper";
 import { layout, htmlResponse } from "./admin-layout.js";
+import { allowAdmin } from "./agent-auth.js";
 
 /**
  * GET /AdminDashboard — admin home page with system overview.
+ *
+ * allowRead()=allowAdmin (ops-oox7 defense-in-depth): see Admin.ts for why
+ * this closes a real gap, not just belt-and-suspenders — a verified
+ * non-admin agent could otherwise read full instance stats (principal/agent/
+ * memory/relationship counts) with no admin check at all.
  */
 export class AdminDashboard extends Resource {
+  async allowRead(): Promise<boolean> {
+    return allowAdmin((this as any).getContext?.());
+  }
+
   async get() {
     let principalCount = 0;
     let memoryCount = 0;

--- a/resources/AdminIdp.ts
+++ b/resources/AdminIdp.ts
@@ -1,10 +1,17 @@
 import { Resource, databases } from "@harperfast/harper";
 import { layout, htmlResponse, esc } from "./admin-layout.js";
+import { allowAdmin } from "./agent-auth.js";
 
 /**
  * GET /AdminIdp — enterprise IdP configuration management.
+ *
+ * allowRead()=allowAdmin (ops-oox7 defense-in-depth): see Admin.ts.
  */
 export class AdminIdp extends Resource {
+  async allowRead(): Promise<boolean> {
+    return allowAdmin((this as any).getContext?.());
+  }
+
   async get() {
     const idps: any[] = [];
 

--- a/resources/AdminInstance.ts
+++ b/resources/AdminInstance.ts
@@ -4,6 +4,7 @@ import { existsSync, readFileSync } from "node:fs";
 import { join, dirname } from "node:path";
 import { homedir } from "node:os";
 import { fileURLToPath } from "node:url";
+import { allowAdmin } from "./agent-auth.js";
 
 /**
  * Resolve the public URL operators reach this Flair on.
@@ -86,8 +87,14 @@ function resolveVersion(): string {
 
 /**
  * GET /AdminInstance — instance info, public key, version.
+ *
+ * allowRead()=allowAdmin (ops-oox7 defense-in-depth): see Admin.ts.
  */
 export class AdminInstance extends Resource {
+  async allowRead(): Promise<boolean> {
+    return allowAdmin((this as any).getContext?.());
+  }
+
   async get() {
     const version = resolveVersion();
     // Pass the request through so URL resolution can derive from

--- a/resources/AdminMemory.ts
+++ b/resources/AdminMemory.ts
@@ -1,5 +1,6 @@
 import { Resource, databases } from "@harperfast/harper";
 import { layout, htmlResponse, esc } from "./admin-layout.js";
+import { allowAdmin } from "./agent-auth.js";
 
 /**
  * GET /AdminMemory                browse + search memories (list view)
@@ -20,8 +21,16 @@ import { layout, htmlResponse, esc } from "./admin-layout.js";
  * "memory that follows the agent across orchestrators" — the provenance pane
  * makes that legible: every memory shows where it came from, what it derived
  * from, what it superseded, and which peer it synced from.
+ *
+ * allowRead()=allowAdmin (ops-oox7 defense-in-depth): see Admin.ts — this
+ * page surfaces full memory content across ALL agents, so the gap it closes
+ * matters more here than on the other Admin* pages.
  */
 export class AdminMemory extends Resource {
+  async allowRead(): Promise<boolean> {
+    return allowAdmin((this as any).getContext?.());
+  }
+
   async get() {
     // Harper v5 does not populate this.request on Resource subclasses —
     // getContext() is the only reliable path (ops-sal4: the previous

--- a/resources/AdminPrincipals.ts
+++ b/resources/AdminPrincipals.ts
@@ -1,10 +1,17 @@
 import { Resource, databases } from "@harperfast/harper";
 import { layout, htmlResponse, esc } from "./admin-layout.js";
+import { allowAdmin } from "./agent-auth.js";
 
 /**
  * GET /AdminPrincipals — list all principals with kind, trust, status.
+ *
+ * allowRead()=allowAdmin (ops-oox7 defense-in-depth): see Admin.ts.
  */
 export class AdminPrincipals extends Resource {
+  async allowRead(): Promise<boolean> {
+    return allowAdmin((this as any).getContext?.());
+  }
+
   async get() {
     const principals: any[] = [];
 

--- a/resources/Integration.ts
+++ b/resources/Integration.ts
@@ -1,10 +1,12 @@
 import { databases } from "@harperfast/harper";
-import { resolveAgentAuth } from "./agent-auth.js";
+import { resolveAgentAuth, allowVerified } from "./agent-auth.js";
 
 const FORBIDDEN = (msg: string) =>
   new Response(JSON.stringify({ error: msg }), { status: 403, headers: { "Content-Type": "application/json" } });
 const UNAUTH = () =>
   new Response(JSON.stringify({ error: "authentication required" }), { status: 401, headers: { "Content-Type": "application/json" } });
+const NOT_FOUND = () =>
+  new Response(JSON.stringify({ error: "not found" }), { status: 404, headers: { "Content-Type": "application/json" } });
 
 /**
  * Integration records are agent-owned. Auth: the non-rejecting gate annotates the
@@ -15,6 +17,54 @@ const UNAUTH = () =>
 export class Integration extends (databases as any).flair.Integration {
   private _auth() {
     return resolveAgentAuth((this as any).getContext?.());
+  }
+
+  /**
+   * Self-authorize now that the global gate is non-rejecting (memory-soul-
+   * read-gate family fix, ops-oox7 — same pattern as Memory.ts/Soul.ts/
+   * WorkspaceState.ts/Relationship.ts). Closes the same P0 leak: Harper
+   * routes `GET /Integration/<id>` to get() and the collection describe
+   * (`GET /Integration`) outside search(), so neither was gated before this
+   * fix — an anonymous caller got a 200 with full record content. Per-record
+   * ownership scoping happens in get() below; the collection scope is still
+   * in search().
+   */
+  allowRead() { return allowVerified((this as any).getContext?.()); }
+
+  /**
+   * Override get() to scope by-id reads the same way search() scopes
+   * collection reads (memory-soul-read-gate family fix). Never distinguishes
+   * "doesn't exist" from "exists but not yours" — both return 404, never
+   * 403, so a denied caller can't use get() to enumerate other agents'
+   * integration ids.
+   */
+  async get(target?: any) {
+    // Collection / query reads arrive as a RequestTarget with
+    // `isCollection === true`, and are governed by search() (same owner
+    // scoping). Only a genuine by-id get is ownership-checked below — see
+    // Memory.ts's get() for the full rationale (same bug class).
+    if (!target || (typeof target === "object" && target.isCollection)) {
+      return this.search(target);
+    }
+
+    const auth = await this._auth();
+
+    // Anonymous by-id read is already blocked at the allowRead() gate (403);
+    // this is defense-in-depth if get() is ever reached directly.
+    if (auth.kind === "anonymous") {
+      return NOT_FOUND();
+    }
+
+    // Trusted internal call or admin agent — unfiltered, unchanged behavior.
+    if (auth.kind === "internal" || (auth.kind === "agent" && auth.isAdmin)) {
+      return super.get(target);
+    }
+
+    // Non-admin agent: only its own integrations.
+    const record = await super.get(target);
+    if (!record) return NOT_FOUND();
+    if (record.agentId !== auth.agentId) return NOT_FOUND();
+    return record;
   }
 
   async search(query?: any) {
@@ -70,7 +120,12 @@ export class Integration extends (databases as any).flair.Integration {
     if (auth.kind === "internal" || (auth.kind === "agent" && auth.isAdmin)) {
       return super.delete(id);
     }
-    const record = await this.get(id);
+    // Use super.get(id), NOT this.get(id): the new get() override above 404s
+    // (a truthy Response) for a non-owner id, which would otherwise defeat
+    // the `if (!record)` check below and mis-route a genuinely-missing
+    // record into the FORBIDDEN branch instead of a clean super.delete(id)
+    // no-op. Mirrors Memory.ts's delete() — same rationale, same fix.
+    const record = await super.get(id);
     if (!record) return super.delete(id);
     if (record.agentId !== auth.agentId) {
       return FORBIDDEN("forbidden: cannot delete integration for another agent");

--- a/resources/MemoryGrant.ts
+++ b/resources/MemoryGrant.ts
@@ -1,10 +1,12 @@
 import { databases } from "@harperfast/harper";
-import { resolveAgentAuth } from "./agent-auth.js";
+import { resolveAgentAuth, allowVerified } from "./agent-auth.js";
 
 const FORBIDDEN = (msg: string) =>
   new Response(JSON.stringify({ error: msg }), { status: 403, headers: { "Content-Type": "application/json" } });
 const UNAUTH = () =>
   new Response(JSON.stringify({ error: "authentication required" }), { status: 401, headers: { "Content-Type": "application/json" } });
+const NOT_FOUND = () =>
+  new Response(JSON.stringify({ error: "not found" }), { status: 404, headers: { "Content-Type": "application/json" } });
 
 /**
  * MemoryGrant — an agent (ownerId) grants another (granteeId) scoped access to its
@@ -19,6 +21,56 @@ const UNAUTH = () =>
 export class MemoryGrant extends (databases as any).flair.MemoryGrant {
   private _auth() {
     return resolveAgentAuth((this as any).getContext?.());
+  }
+
+  /**
+   * Self-authorize now that the global gate is non-rejecting (memory-soul-
+   * read-gate family fix, ops-oox7 — same pattern as Memory.ts/Soul.ts/
+   * WorkspaceState.ts/Relationship.ts/Integration.ts). Closes the same P0
+   * leak: Harper routes `GET /MemoryGrant/<id>` to get() and the collection
+   * describe (`GET /MemoryGrant`) outside search(), so neither was gated
+   * before this fix — an anonymous caller got a 200 with full grant content.
+   * Per-record owner/grantee scoping happens in get() below; the collection
+   * scope is still in search().
+   */
+  allowRead() { return allowVerified((this as any).getContext?.()); }
+
+  /**
+   * Override get() to scope by-id reads the same way search() scopes
+   * collection reads (memory-soul-read-gate family fix). A grant is visible
+   * to either party (ownerId OR granteeId), mirroring search()'s owner-OR-
+   * grantee scope. Never distinguishes "doesn't exist" from "exists but not
+   * yours" — both return 404, never 403, so a denied caller can't use get()
+   * to enumerate other agents' grant ids.
+   */
+  async get(target?: any) {
+    // Collection / query reads arrive as a RequestTarget with
+    // `isCollection === true`, and are governed by search() (same owner/
+    // grantee scoping). Only a genuine by-id get is ownership-checked below
+    // — see Memory.ts's get() for the full rationale (same bug class).
+    if (!target || (typeof target === "object" && target.isCollection)) {
+      return this.search(target);
+    }
+
+    const auth = await this._auth();
+
+    // Anonymous by-id read is already blocked at the allowRead() gate (403);
+    // this is defense-in-depth if get() is ever reached directly.
+    if (auth.kind === "anonymous") {
+      return NOT_FOUND();
+    }
+
+    // Trusted internal call or admin agent — unfiltered, unchanged behavior.
+    if (auth.kind === "internal" || (auth.kind === "agent" && auth.isAdmin)) {
+      return super.get(target);
+    }
+
+    // Non-admin agent: visible if it's the owner OR the grantee (parity with
+    // search()'s owner-OR-grantee scope).
+    const record = await super.get(target);
+    if (!record) return NOT_FOUND();
+    if (record.ownerId !== auth.agentId && record.granteeId !== auth.agentId) return NOT_FOUND();
+    return record;
   }
 
   async search(query?: any) {
@@ -63,7 +115,13 @@ export class MemoryGrant extends (databases as any).flair.MemoryGrant {
     if (auth.kind === "internal" || (auth.kind === "agent" && auth.isAdmin)) {
       return super.delete(id, context);
     }
-    const record = await this.get(id);
+    // Use super.get(id), NOT this.get(id): the new get() override above 404s
+    // (a truthy Response) for a non-owner/non-grantee id, which would
+    // otherwise defeat the `if (!record)` check below and mis-route a
+    // genuinely-missing record into the FORBIDDEN branch instead of a clean
+    // super.delete(id, context) no-op. Mirrors Memory.ts's delete() — same
+    // rationale, same fix.
+    const record = await super.get(id);
     if (!record) return super.delete(id, context);
     if (record.ownerId !== auth.agentId) {
       return FORBIDDEN("forbidden: cannot delete a grant owned by another agent");

--- a/resources/Relationship.ts
+++ b/resources/Relationship.ts
@@ -1,6 +1,9 @@
 import { databases } from "@harperfast/harper";
-import { resolveAgentAuth } from "./agent-auth.js";
+import { resolveAgentAuth, allowVerified } from "./agent-auth.js";
 import { checkRateLimit, rateLimitResponse } from "./rate-limiter.js";
+
+const NOT_FOUND = () =>
+  new Response(JSON.stringify({ error: "not found" }), { status: 404, headers: { "Content-Type": "application/json" } });
 
 /**
  * Relationship resource — entity-to-entity relationships with temporal validity.
@@ -14,6 +17,56 @@ import { checkRateLimit, rateLimitResponse } from "./rate-limiter.js";
  * Admin agents can query across all agents.
  */
 export class Relationship extends (databases as any).flair.Relationship {
+  /**
+   * Self-authorize now that the global gate is non-rejecting (memory-soul-
+   * read-gate family fix, ops-oox7 — same pattern as Memory.ts/Soul.ts/
+   * WorkspaceState.ts). Closes the same P0 leak: Harper routes
+   * `GET /Relationship/<id>` to get() and the collection describe
+   * (`GET /Relationship`) outside search(), so neither was gated before this
+   * fix — an anonymous caller got a 200 with full record content. Per-record
+   * ownership scoping happens in get() below; the collection scope is still
+   * in search().
+   */
+  allowRead() { return allowVerified((this as any).getContext?.()); }
+
+  /**
+   * Override get() to scope by-id reads the same way search() scopes
+   * collection reads (memory-soul-read-gate family fix). Never distinguishes
+   * "doesn't exist" from "exists but not yours" — both return 404, never
+   * 403, so a denied caller can't use get() to enumerate other agents'
+   * relationship ids.
+   */
+  async get(target?: any) {
+    // Collection / query reads arrive as a RequestTarget with
+    // `isCollection === true`, and are governed by search() (same owner
+    // scoping). Only a genuine by-id get is ownership-checked below — see
+    // Memory.ts's get() for the full rationale (same bug class: without this
+    // guard, a query's RequestTarget would flow into super.get(), return the
+    // whole result set, and the single-record ownership check below would
+    // find no `.agentId` on it).
+    if (!target || (typeof target === "object" && target.isCollection)) {
+      return this.search(target);
+    }
+
+    const auth = await resolveAgentAuth((this as any).getContext?.());
+
+    // Anonymous by-id read is already blocked at the allowRead() gate (403);
+    // this is defense-in-depth if get() is ever reached directly.
+    if (auth.kind === "anonymous") {
+      return NOT_FOUND();
+    }
+
+    // Trusted internal call or admin agent — unfiltered, unchanged behavior.
+    if (auth.kind === "internal" || (auth.kind === "agent" && auth.isAdmin)) {
+      return super.get(target);
+    }
+
+    // Non-admin agent: only its own relationships.
+    const record = await super.get(target);
+    if (!record) return NOT_FOUND();
+    if (record.agentId !== auth.agentId) return NOT_FOUND();
+    return record;
+  }
 
   async search(query?: any) {
     const auth = await resolveAgentAuth((this as any).getContext?.());

--- a/resources/WorkspaceState.ts
+++ b/resources/WorkspaceState.ts
@@ -9,18 +9,72 @@
  */
 
 import { databases } from "@harperfast/harper";
-import { resolveAgentAuth } from "./agent-auth.js";
+import { resolveAgentAuth, allowVerified } from "./agent-auth.js";
 
 const FORBIDDEN = (msg: string) =>
   new Response(JSON.stringify({ error: msg }), { status: 403, headers: { "Content-Type": "application/json" } });
 const UNAUTH = () =>
   new Response(JSON.stringify({ error: "authentication required" }), { status: 401, headers: { "Content-Type": "application/json" } });
+const NOT_FOUND = () =>
+  new Response(JSON.stringify({ error: "not found" }), { status: 404, headers: { "Content-Type": "application/json" } });
 
 export class WorkspaceState extends (databases as any).flair.WorkspaceState {
   /** Auth verdict from the request context. internal = trusted in-process call;
    *  agent = verified Ed25519; anonymous = HTTP with no valid agent → deny. */
   private _auth() {
     return resolveAgentAuth((this as any).getContext?.());
+  }
+
+  /**
+   * Self-authorize now that the global gate is non-rejecting (memory-soul-
+   * read-gate family fix, ops-oox7 — applying the Memory.ts/Soul.ts pattern
+   * to WorkspaceState/Relationship/Integration/MemoryGrant). Closes the same
+   * P0 leak: Harper routes `GET /WorkspaceState/<id>` to get() and the
+   * collection describe (`GET /WorkspaceState`) to a path outside search(),
+   * so neither was gated before this fix — an anonymous caller got a 200 with
+   * full record content. Per-record ownership scoping happens in get() below;
+   * the collection scope is still in search().
+   */
+  allowRead() { return allowVerified((this as any).getContext?.()); }
+
+  /**
+   * Override get() to scope by-id reads the same way search() scopes
+   * collection reads (memory-soul-read-gate family fix). Never distinguishes
+   * "doesn't exist" from "exists but not yours" — both return 404, never
+   * 403, so a denied caller can't use get() to enumerate other agents'
+   * workspace-state ids.
+   */
+  async get(target?: any) {
+    // Collection / query reads — the `GET /WorkspaceState/?<query>` form and
+    // the bare collection — arrive as a RequestTarget with `isCollection ===
+    // true`, and are governed by search() (same owner scoping). Only a
+    // genuine by-id get is ownership-checked below. Without this guard,
+    // get() would receive the query's RequestTarget, super.get() would
+    // return the (truthy) result set, and the single-record ownership check
+    // would find no `.agentId` on it (see Memory.ts's get() for the full
+    // rationale — same bug class).
+    if (!target || (typeof target === "object" && target.isCollection)) {
+      return this.search(target);
+    }
+
+    const auth = await this._auth();
+
+    // Anonymous by-id read is already blocked at the allowRead() gate (403);
+    // this is defense-in-depth if get() is ever reached directly.
+    if (auth.kind === "anonymous") {
+      return NOT_FOUND();
+    }
+
+    // Trusted internal call or admin agent — unfiltered, unchanged behavior.
+    if (auth.kind === "internal" || (auth.kind === "agent" && auth.isAdmin)) {
+      return super.get(target);
+    }
+
+    // Non-admin agent: only its own workspace-state records.
+    const record = await super.get(target);
+    if (!record) return NOT_FOUND();
+    if (record.agentId !== auth.agentId) return NOT_FOUND();
+    return record;
   }
 
   /**
@@ -97,7 +151,12 @@ export class WorkspaceState extends (databases as any).flair.WorkspaceState {
       return super.delete(id);
     }
 
-    const record = await this.get(id);
+    // Use super.get(id), NOT this.get(id): the new get() override above 404s
+    // (a truthy Response) for a non-owner id, which would otherwise defeat
+    // the `if (!record)` check below and mis-route a genuinely-missing
+    // record into the FORBIDDEN branch instead of a clean super.delete(id)
+    // no-op. Mirrors Memory.ts's delete() — same rationale, same fix.
+    const record = await super.get(id);
     if (!record) return super.delete(id);
     if (record.agentId !== auth.agentId) {
       return FORBIDDEN("forbidden: cannot delete workspace state for another agent");

--- a/test/integration/auth-middleware-e2e.test.ts
+++ b/test/integration/auth-middleware-e2e.test.ts
@@ -84,6 +84,39 @@ async function adminOp(
 
 let harper: HarperInstance;
 const agent = mkAgent("auth-e2e-agent");
+// Second agent for the family read-gate cross-agent 404 checks (ops-oox7).
+const agent2 = mkAgent("auth-e2e-agent-2");
+
+// ─── Family read-gate fixtures (ops-oox7) ────────────────────────────────────
+// WorkspaceState/Relationship/Integration/MemoryGrant — same P0 leak as
+// Memory.ts/Soul.ts (e1e3012, ops-ckrr): each gated write+search but had no
+// allowRead()/get() override, so anonymous GET /<Resource>/<id> and the
+// collection describe GET /<Resource> both returned 200 with full record
+// content. One record per table, owned by `agent`, seeded via direct DB
+// insert in beforeAll below (bypasses each resource's own write path — this
+// file exercises READS, not writes).
+const FAMILY_READ_GATE_RESOURCES: Array<{ table: string; id: string; seed: Record<string, any> }> = [
+  {
+    table: "WorkspaceState",
+    id: `family-ws-${Date.now()}`,
+    seed: { agentId: agent.id, ref: "main", provider: "cli", timestamp: new Date().toISOString(), createdAt: new Date().toISOString() },
+  },
+  {
+    table: "Relationship",
+    id: `family-rel-${Date.now()}`,
+    seed: { agentId: agent.id, subject: "nathan", predicate: "manages", object: "flint", createdAt: new Date().toISOString() },
+  },
+  {
+    table: "Integration",
+    id: `family-int-${Date.now()}`,
+    seed: { agentId: agent.id, platform: "slack", createdAt: new Date().toISOString() },
+  },
+  {
+    table: "MemoryGrant",
+    id: `family-grant-${Date.now()}`,
+    seed: { ownerId: agent.id, granteeId: "family-read-gate-someone-else", scope: "read", createdAt: new Date().toISOString() },
+  },
+];
 
 const PAIR_BOOTSTRAP_USER = "pair-bootstrap-test1234";
 const PAIR_BOOTSTRAP_PASS = "bootstrap-pass-123";
@@ -123,6 +156,23 @@ describe("auth-middleware e2e (real Harper)", () => {
       ],
     });
     expect(agentRes.status).toBe(200);
+
+    // 2b. Second agent (ops-oox7 family read-gate cross-agent checks).
+    const agent2Res = await adminOp(harper, {
+      operation: "insert",
+      database: "flair",
+      table: "Agent",
+      records: [
+        {
+          id: agent2.id,
+          name: agent2.id,
+          role: "agent",
+          publicKey: agent2.publicKey,
+          createdAt: new Date().toISOString(),
+        },
+      ],
+    });
+    expect(agent2Res.status).toBe(200);
 
     // 3. Create pair-bootstrap user with flair_pair_initiator role + active:true.
     //    This makes getUser return the REAL object-shaped role
@@ -167,6 +217,20 @@ describe("auth-middleware e2e (real Harper)", () => {
       active: true,
     });
     expect([200, 409]).toContain(nonSuperRes.status);
+
+    // 6. Seed one record per FAMILY_READ_GATE_RESOURCES table, owned by
+    //    `agent`. Direct DB insert (bypasses each resource's own write path —
+    //    irrelevant here, this file tests READS) so the by-id read-gate
+    //    invariants below have real records to fetch.
+    for (const r of FAMILY_READ_GATE_RESOURCES) {
+      const seedRes = await adminOp(harper, {
+        operation: "insert",
+        database: "flair",
+        table: r.table,
+        records: [{ id: r.id, ...r.seed }],
+      });
+      expect(seedRes.status, `seed ${r.table} returned ${seedRes.status}`).toBe(200);
+    }
   }, 180_000);
 
   afterAll(async () => {
@@ -446,4 +510,37 @@ describe("auth-middleware e2e (real Harper)", () => {
     );
     expect(res.status).toBe(403);
   }, 30_000);
+
+  // ═══════════════════════════════════════════════════════════════════════════
+  // FAMILY READ-GATE (ops-oox7): WorkspaceState / Relationship / Integration /
+  // MemoryGrant — applying the Memory.ts/Soul.ts allowRead()+get() pattern
+  // (e1e3012, ops-ckrr) to the remaining agent-owned @table resources that had
+  // the identical anonymous by-id / collection-describe read leak. These are
+  // REAL-Harper invariants exercising the actual RequestTarget routing
+  // (isCollection branch) that a mocked unit test cannot — see get()'s doc
+  // comment in each resource for why the branch matters.
+  // ═══════════════════════════════════════════════════════════════════════════
+  for (const r of FAMILY_READ_GATE_RESOURCES) {
+    test(`FAMILY READ-GATE: anonymous GET /${r.table} → 403 (allowRead gate denies anonymous, collection describe)`, async () => {
+      const res = await fetch(`${harper.httpURL}/${r.table}`);
+      expect(res.status, `anon GET /${r.table} returned ${res.status}`).toBe(403);
+    }, 30_000);
+
+    test(`FAMILY READ-GATE: authenticated self GET /${r.table}/<id> → 200`, async () => {
+      const path = `/${r.table}/${r.id}`;
+      const res = await fetch(`${harper.httpURL}${path}`, {
+        headers: { Authorization: ed25519Header(agent, "GET", path) },
+      });
+      const text = await res.text();
+      expect(res.status, `self GET ${path} returned ${res.status}: ${text.slice(0, 200)}`).toBe(200);
+    }, 30_000);
+
+    test(`FAMILY READ-GATE: cross-agent GET /${r.table}/<id> → 404 (no enumeration — never 403)`, async () => {
+      const path = `/${r.table}/${r.id}`;
+      const res = await fetch(`${harper.httpURL}${path}`, {
+        headers: { Authorization: ed25519Header(agent2, "GET", path) },
+      });
+      expect(res.status, `cross-agent GET ${path} returned ${res.status}`).toBe(404);
+    }, 30_000);
+  }
 });

--- a/test/integration/flair-agent-deelevation.test.ts
+++ b/test/integration/flair-agent-deelevation.test.ts
@@ -189,6 +189,29 @@ describe("flair_agent de-elevation (verified agents act as flair-agent, not admi
     expect([401, 403], `admin /MemoryReindex returned ${res.status} (expected authorized)`).not.toContain(res.status);
   }, 30_000);
 
+  // ops-oox7: Admin* custom (non-@table) Resources previously had NO
+  // resource-level read gate at all — reachability depended entirely on the
+  // auth-middleware's /Admin* pathname check, which only 401s when there's NO
+  // Authorization header. A validly-verified NON-admin agent (real TPS-Ed25519
+  // signature, just not an admin) sailed straight through to full dashboard
+  // data with zero admin check. allowRead()=allowAdmin closes that gap —
+  // same pattern MemoryReindex already uses for allowCreate above.
+  test("ADMIN-ONLY: non-admin agent GET /AdminDashboard is denied (allowRead → isAdmin)", async () => {
+    const path = "/AdminDashboard";
+    const res = await fetch(`${harper.httpURL}${path}`, {
+      headers: { Authorization: ed25519Header(agent, "GET", path) },
+    });
+    expect(res.status, `non-admin /AdminDashboard returned ${res.status} (expected 403)`).toBe(403);
+  }, 30_000);
+
+  test("ADMIN-ONLY: admin agent GET /AdminDashboard is authorized (allowRead permits admins)", async () => {
+    const path = "/AdminDashboard";
+    const res = await fetch(`${harper.httpURL}${path}`, {
+      headers: { Authorization: ed25519Header(adminAgent, "GET", path) },
+    });
+    expect([401, 403], `admin /AdminDashboard returned ${res.status} (expected authorized)`).not.toContain(res.status);
+  }, 30_000);
+
   test("DE-ELEVATION: agent POST /sql is forbidden (flair_agent has no operations grant)", async () => {
     const path = "/sql";
     const res = await fetch(`${harper.httpURL}${path}`, {

--- a/test/unit/allow-helpers.test.ts
+++ b/test/unit/allow-helpers.test.ts
@@ -3,7 +3,7 @@ import { mock, describe, it, expect } from "bun:test";
 // agent-auth.ts imports `databases` from @harperfast/harper (throws outside a
 // Harper runtime). Mock it — the annotation/internal/anonymous paths exercised
 // here never reach databases (they return before any Agent.get).
-mock.module("@harperfast/harper", () => ({ databases: {} }));
+mock.module("@harperfast/harper", () => ({ databases: {}, Resource: class {} }));
 
 const { allowVerified, allowAdmin } = await import("../../resources/agent-auth.ts");
 

--- a/test/unit/coordination-write-auth.test.ts
+++ b/test/unit/coordination-write-auth.test.ts
@@ -106,7 +106,7 @@ const databasesMock = {
   },
 };
 
-mock.module("@harperfast/harper", () => ({ databases: databasesMock }));
+mock.module("@harperfast/harper", () => ({ databases: databasesMock, Resource: class {} }));
 
 const { WorkspaceState } = await import("../../resources/WorkspaceState.ts");
 const { OrgEvent } = await import("../../resources/OrgEvent.ts");

--- a/test/unit/coordination-write-auth.test.ts
+++ b/test/unit/coordination-write-auth.test.ts
@@ -18,6 +18,17 @@
  * The auth verdict is injected via getContext().request.tpsAgent /
  * tpsAgentIsAdmin — exactly what the non-rejecting gate sets after verifying the
  * signature (see auth-middleware.ts) and what resolveAgentAuth() reads.
+ *
+ * ── WorkspaceState.allowRead() + get() ownership scoping (memory-soul-read-
+ * gate family fix, ops-oox7) ─────────────────────────────────────────────────
+ * These tests are ADDED HERE (not a separate file) deliberately: this file
+ * already `mock.module("@harperfast/harper", ...)` + dynamically imports
+ * "../../resources/WorkspaceState.ts". bun runs every test/unit/ file in ONE
+ * process and dynamic imports are cached by resolved path — a second file
+ * doing the same mock+import would silently reuse whichever mock won the
+ * import race (see memory-soul-read-gate.test.ts's doc comment for the full
+ * mechanics of this collision class). Reusing this file's existing
+ * mock/import avoids that entirely.
  */
 
 import { mock, describe, it, expect, beforeEach } from "bun:test";
@@ -26,19 +37,56 @@ import { mock, describe, it, expect, beforeEach } from "bun:test";
 let workspacePut: any = null;
 let orgEventPut: any = null;
 
+// In-memory WorkspaceState store, keyed by id — backs get()/search() for the
+// allowRead/get() ownership-scoping tests below. post()/put() still also set
+// `workspacePut` for the pre-existing attribution tests.
+let workspaceStore: Map<string, any>;
+
+function matchesCondition(record: any, cond: any): boolean {
+  if (cond.operator && Array.isArray(cond.conditions)) {
+    const results = cond.conditions.map((c: any) => matchesCondition(record, c));
+    return cond.operator === "or" ? results.some(Boolean) : results.every(Boolean);
+  }
+  const fieldVal = record[cond.attribute];
+  if (cond.comparator === "equals") return fieldVal === cond.value;
+  if (cond.comparator === "not_equal") return fieldVal !== cond.value;
+  return true;
+}
+
 // Mock @harperfast/harper:
 //   - databases.flair.WorkspaceState / OrgEvent are constructable base classes
 //     (the resources do `class X extends databases.flair.X`).
-//   - The base post()/put() capture their argument so we can assert attribution.
+//   - The base post()/put() capture their argument so we can assert attribution,
+//     AND persist into workspaceStore so get()/search() ownership-scoping tests
+//     have real records to scope against.
 //   - resolveAgentAuth (in agent-auth.ts) also imports databases; its agent path
 //     calls Agent.get / Agent.search, but our tests use the tpsAgent annotation
 //     path which returns before touching those — so a thin stub is enough.
 class BaseWorkspaceState {
-  async post(content: any) { workspacePut = content; return { ok: true, ...content }; }
-  async put(content: any) { workspacePut = content; return { ok: true, ...content }; }
-  async get(_id: any) { return null; }
-  async search(q: any) { return q; }
-  async delete(_id: any) { return { ok: true }; }
+  async post(content: any) {
+    workspacePut = content;
+    workspaceStore.set(content.id ?? `ws-${Math.random().toString(36).slice(2)}`, { ...content });
+    return { ok: true, ...content };
+  }
+  async put(content: any) {
+    workspacePut = content;
+    workspaceStore.set(content.id, { ...content });
+    return { ok: true, ...content };
+  }
+  async get(target: any) {
+    const id = typeof target === "string" ? target : target?.id;
+    return workspaceStore.get(id) ?? null;
+  }
+  async search(query: any) {
+    const conditions = Array.isArray(query) ? query : Array.isArray(query?.conditions) ? query.conditions : [];
+    let records = Array.from(workspaceStore.values());
+    for (const cond of conditions) records = records.filter((r) => matchesCondition(r, cond));
+    async function* gen() {
+      for (const r of records) yield r;
+    }
+    return gen();
+  }
+  async delete(id: any) { workspaceStore.delete(id); return { ok: true }; }
 }
 class BaseOrgEvent {
   async put(content: any) { orgEventPut = content; return { ok: true, ...content }; }
@@ -81,6 +129,7 @@ const anonCtx = () => ({ tpsAnonymous: true });
 beforeEach(() => {
   workspacePut = null;
   orgEventPut = null;
+  workspaceStore = new Map();
 });
 
 describe("WorkspaceState.post() — agent-self attribution (no forging)", () => {
@@ -144,5 +193,128 @@ describe("OrgEvent.post() — agent-self attribution (no forging)", () => {
     const oe = makeOrgEvent(agentCtx("agent-alpha"));
     await oe.post({ authorId: "agent-victim", kind: "status", summary: "x" });
     expect(String(orgEventPut.id).startsWith("agent-alpha-")).toBe(true);
+  });
+});
+
+// ─── WorkspaceState.allowRead + get() ownership scoping (ops-oox7) ──────────
+//
+// Regression guard for the family read-gate fix: WorkspaceState.ts previously
+// gated post()/put()/delete() but never defined `allowRead()` nor overrode
+// `get()`. Harper routes `GET /WorkspaceState/<id>` to get() and the
+// collection-describe `GET /WorkspaceState` outside search(), so BOTH were
+// ungated — an anonymous caller got a 200 with full record content.
+describe("WorkspaceState.allowRead — closes the anonymous GET /WorkspaceState/<id> and describe leak", () => {
+  it("anonymous is denied", async () => {
+    const ws = makeWorkspace(anonCtx());
+    expect(await (ws as any).allowRead()).toBe(false);
+  });
+
+  it("a verified non-admin agent is allowed (per-record scoping is in get())", async () => {
+    const ws = makeWorkspace(agentCtx("agent-1"));
+    expect(await (ws as any).allowRead()).toBe(true);
+  });
+
+  it("an admin agent is allowed", async () => {
+    const ws = makeWorkspace(agentCtx("agent-admin", true));
+    expect(await (ws as any).allowRead()).toBe(true);
+  });
+
+  it("an internal call (no request context) is allowed", async () => {
+    const r: any = new (WorkspaceState as any)();
+    r.getContext = () => undefined;
+    expect(await r.allowRead()).toBe(true);
+  });
+});
+
+describe("WorkspaceState.get() — anonymous denied, owner-scoped for non-admin, unfiltered for internal/admin", () => {
+  it("anonymous get(<id>) → 404, never leaks record content", async () => {
+    workspaceStore.set("ws-1", { id: "ws-1", agentId: "agent-owner", state: { secret: true } });
+    const ws = makeWorkspace(anonCtx());
+    const res = await (ws as any).get("ws-1");
+    expect(res instanceof Response).toBe(true);
+    expect((res as Response).status).toBe(404);
+  });
+
+  it("verified non-admin get() of ANOTHER agent's id → 404 (not 403 — no existence confirmation)", async () => {
+    workspaceStore.set("ws-1", { id: "ws-1", agentId: "agent-owner", state: {} });
+    const ws = makeWorkspace(agentCtx("agent-attacker"));
+    const res = await (ws as any).get("ws-1");
+    expect(res instanceof Response).toBe(true);
+    expect((res as Response).status).toBe(404);
+  });
+
+  it("verified non-admin get() of ITS OWN id → returns the real record", async () => {
+    workspaceStore.set("ws-1", { id: "ws-1", agentId: "agent-owner", state: { x: 1 } });
+    const ws = makeWorkspace(agentCtx("agent-owner"));
+    const res = await (ws as any).get("ws-1");
+    expect(res instanceof Response).toBe(false);
+    expect((res as any).state.x).toBe(1);
+  });
+
+  it("a non-existent id for a non-admin agent → 404", async () => {
+    const ws = makeWorkspace(agentCtx("agent-owner"));
+    const res = await (ws as any).get("does-not-exist");
+    expect(res instanceof Response).toBe(true);
+    expect((res as Response).status).toBe(404);
+  });
+
+  it("internal call (no request context) → returns any id unchanged", async () => {
+    workspaceStore.set("ws-1", { id: "ws-1", agentId: "agent-owner", state: { secret: true } });
+    const r: any = new (WorkspaceState as any)();
+    r.getContext = () => undefined;
+    const res = await r.get("ws-1");
+    expect(res instanceof Response).toBe(false);
+    expect((res as any).state.secret).toBe(true);
+  });
+
+  it("admin agent → returns any id unchanged, no ownership check", async () => {
+    workspaceStore.set("ws-1", { id: "ws-1", agentId: "agent-owner", state: { secret: true } });
+    const ws = makeWorkspace(agentCtx("agent-admin", true));
+    const res = await (ws as any).get("ws-1");
+    expect(res instanceof Response).toBe(false);
+    expect((res as any).state.secret).toBe(true);
+  });
+
+  it("a collection/query target (isCollection: true) delegates to search(), never a raw super.get() over the whole set", async () => {
+    workspaceStore.set("ws-own", { id: "ws-own", agentId: "agent-1", state: {} });
+    workspaceStore.set("ws-other", { id: "ws-other", agentId: "agent-other", state: {} });
+    const ws = makeWorkspace(agentCtx("agent-1"));
+    // Real Harper passes a RequestTarget object with isCollection:true for the
+    // bare-collection / query-string GET form — NOT a string id. Without the
+    // isCollection branch in get(), this would flow into super.get(target),
+    // which has no notion of a query and would behave unpredictably; the fix
+    // routes it through search() instead, which scopes by agentId.
+    const res: any = await (ws as any).get({ isCollection: true, conditions: [] });
+    const results: any[] = [];
+    for await (const r of res) results.push(r);
+    expect(results.map((r) => r.id)).toEqual(["ws-own"]);
+  });
+});
+
+describe("WorkspaceState.delete() — ownership check uses the raw record (super.get), not the new scoped get()", () => {
+  it("owner can still delete its own workspace-state record", async () => {
+    workspaceStore.set("ws-1", { id: "ws-1", agentId: "agent-owner" });
+    const ws = makeWorkspace(agentCtx("agent-owner"));
+    await (ws as any).delete("ws-1");
+    expect(workspaceStore.has("ws-1")).toBe(false);
+  });
+
+  it("a non-admin cannot delete ANOTHER agent's workspace-state record (403, untouched)", async () => {
+    workspaceStore.set("ws-1", { id: "ws-1", agentId: "agent-owner" });
+    const ws = makeWorkspace(agentCtx("agent-attacker"));
+    const res = await (ws as any).delete("ws-1");
+    expect(res instanceof Response).toBe(true);
+    expect((res as Response).status).toBe(403);
+    expect(workspaceStore.has("ws-1")).toBe(true); // untouched
+  });
+
+  it("deleting a non-existent id is a clean no-op (not mis-routed into FORBIDDEN by the new get() override)", async () => {
+    const ws = makeWorkspace(agentCtx("agent-owner"));
+    const res = await (ws as any).delete("does-not-exist");
+    // super.delete() on the mock always returns { ok: true } — asserting it's
+    // NOT the FORBIDDEN Response proves delete() used super.get() (raw lookup,
+    // null for a missing id), not this.get() (which would 404 a denied id as
+    // a truthy Response and fall through into the ownership-mismatch branch).
+    expect(res instanceof Response).toBe(false);
   });
 });

--- a/test/unit/integration-read-gate.test.ts
+++ b/test/unit/integration-read-gate.test.ts
@@ -62,7 +62,7 @@ const databasesMock = {
   },
 };
 
-mock.module("@harperfast/harper", () => ({ databases: databasesMock }));
+mock.module("@harperfast/harper", () => ({ databases: databasesMock, Resource: class {} }));
 
 const { Integration } = await import("../../resources/Integration.ts");
 

--- a/test/unit/integration-read-gate.test.ts
+++ b/test/unit/integration-read-gate.test.ts
@@ -1,0 +1,188 @@
+/**
+ * integration-read-gate.test.ts — regression guard for the memory-soul-
+ * read-gate FAMILY fix (ops-oox7): Integration.ts previously gated
+ * search()/post()/put()/delete() but never defined `allowRead()` nor
+ * overrode `get()`. Harper routes `GET /Integration/<id>` to get() and the
+ * collection-describe `GET /Integration` outside search(), so both were
+ * ungated — an anonymous caller got a 200 with full record content.
+ *
+ * Same mocking technique as memory-integrity.test.ts / coordination-write-
+ * auth.test.ts. No other test/unit/ file imports resources/Integration.ts,
+ * so this file owns that mock+import with no collision risk.
+ */
+import { describe, it, expect, beforeEach, mock } from "bun:test";
+
+let integrationStore: Map<string, any>;
+
+function matchesCondition(record: any, cond: any): boolean {
+  if (cond.operator && Array.isArray(cond.conditions)) {
+    const results = cond.conditions.map((c: any) => matchesCondition(record, c));
+    return cond.operator === "or" ? results.some(Boolean) : results.every(Boolean);
+  }
+  const fieldVal = record[cond.attribute];
+  if (cond.comparator === "equals") return fieldVal === cond.value;
+  if (cond.comparator === "not_equal") return fieldVal !== cond.value;
+  return true;
+}
+
+class BaseIntegration {
+  async get(target?: any) {
+    const id = typeof target === "string" ? target : target?.id;
+    return integrationStore.get(id) ?? null;
+  }
+  async post(content: any) {
+    const id = content.id ?? `int-${Math.random().toString(36).slice(2)}`;
+    content.id = id;
+    integrationStore.set(id, { ...content });
+    return { ...content };
+  }
+  async put(content: any) {
+    integrationStore.set(content.id, { ...content });
+    return { ...content };
+  }
+  async delete(id: any) {
+    integrationStore.delete(id);
+    return { ok: true };
+  }
+  search(query?: any) {
+    const conditions = Array.isArray(query) ? query : Array.isArray(query?.conditions) ? query.conditions : [];
+    let records = Array.from(integrationStore.values());
+    for (const cond of conditions) records = records.filter((r) => matchesCondition(r, cond));
+    async function* gen() {
+      for (const r of records) yield r;
+    }
+    return gen();
+  }
+}
+
+const databasesMock = {
+  flair: {
+    Integration: BaseIntegration,
+    Agent: { get: async () => null, search: async () => [] },
+  },
+};
+
+mock.module("@harperfast/harper", () => ({ databases: databasesMock }));
+
+const { Integration } = await import("../../resources/Integration.ts");
+
+function makeIntegration(ctxRequest: any) {
+  const r: any = new (Integration as any)();
+  r.getContext = () => ({ request: ctxRequest });
+  return r;
+}
+const agentCtx = (agentId: string, isAdmin = false) => ({ tpsAgent: agentId, tpsAgentIsAdmin: isAdmin });
+const anonCtx = () => ({ tpsAnonymous: true });
+
+beforeEach(() => {
+  integrationStore = new Map();
+});
+
+describe("Integration.allowRead — closes the anonymous GET /Integration/<id> and describe leak", () => {
+  it("anonymous is denied", async () => {
+    const i = makeIntegration(anonCtx());
+    expect(await (i as any).allowRead()).toBe(false);
+  });
+
+  it("a verified non-admin agent is allowed (per-record scoping is in get())", async () => {
+    const i = makeIntegration(agentCtx("agent-1"));
+    expect(await (i as any).allowRead()).toBe(true);
+  });
+
+  it("an admin agent is allowed", async () => {
+    const i = makeIntegration(agentCtx("agent-admin", true));
+    expect(await (i as any).allowRead()).toBe(true);
+  });
+
+  it("an internal call (no request context) is allowed", async () => {
+    const r: any = new (Integration as any)();
+    r.getContext = () => undefined;
+    expect(await r.allowRead()).toBe(true);
+  });
+});
+
+describe("Integration.get() — anonymous denied, owner-scoped for non-admin, unfiltered for internal/admin", () => {
+  it("anonymous get(<id>) → 404, never leaks record content", async () => {
+    integrationStore.set("int-1", { id: "int-1", agentId: "agent-owner", platform: "slack", encryptedCredential: "secret-blob" });
+    const i = makeIntegration(anonCtx());
+    const res = await (i as any).get("int-1");
+    expect(res instanceof Response).toBe(true);
+    expect((res as Response).status).toBe(404);
+    const body = await (res as Response).json();
+    expect(JSON.stringify(body)).not.toContain("secret-blob");
+  });
+
+  it("verified non-admin get() of ANOTHER agent's id → 404 (not 403 — no existence confirmation)", async () => {
+    integrationStore.set("int-1", { id: "int-1", agentId: "agent-owner", platform: "slack" });
+    const i = makeIntegration(agentCtx("agent-attacker"));
+    const res = await (i as any).get("int-1");
+    expect(res instanceof Response).toBe(true);
+    expect((res as Response).status).toBe(404);
+  });
+
+  it("verified non-admin get() of ITS OWN id → returns the real record", async () => {
+    integrationStore.set("int-1", { id: "int-1", agentId: "agent-owner", platform: "slack" });
+    const i = makeIntegration(agentCtx("agent-owner"));
+    const res = await (i as any).get("int-1");
+    expect(res instanceof Response).toBe(false);
+    expect((res as any).platform).toBe("slack");
+  });
+
+  it("a non-existent id for a non-admin agent → 404 (same as denied — no oracle for existence)", async () => {
+    const i = makeIntegration(agentCtx("agent-owner"));
+    const res = await (i as any).get("does-not-exist");
+    expect(res instanceof Response).toBe(true);
+    expect((res as Response).status).toBe(404);
+  });
+
+  it("internal call (no request context) → returns any id unchanged", async () => {
+    integrationStore.set("int-1", { id: "int-1", agentId: "agent-owner", platform: "secret-platform" });
+    const r: any = new (Integration as any)();
+    r.getContext = () => undefined;
+    const res = await r.get("int-1");
+    expect(res instanceof Response).toBe(false);
+    expect((res as any).platform).toBe("secret-platform");
+  });
+
+  it("admin agent → returns any id unchanged, no ownership check", async () => {
+    integrationStore.set("int-1", { id: "int-1", agentId: "agent-owner", platform: "secret-platform" });
+    const i = makeIntegration(agentCtx("agent-admin", true));
+    const res = await (i as any).get("int-1");
+    expect(res instanceof Response).toBe(false);
+    expect((res as any).platform).toBe("secret-platform");
+  });
+
+  it("a collection/query target (isCollection: true) delegates to search(), scoped by agentId", async () => {
+    integrationStore.set("int-own", { id: "int-own", agentId: "agent-1", platform: "own" });
+    integrationStore.set("int-other", { id: "int-other", agentId: "agent-other", platform: "other" });
+    const i = makeIntegration(agentCtx("agent-1"));
+    const res: any = await (i as any).get({ isCollection: true, conditions: [] });
+    const results: any[] = [];
+    for await (const rec of res) results.push(rec);
+    expect(results.map((rec) => rec.id)).toEqual(["int-own"]);
+  });
+});
+
+describe("Integration.delete() — ownership check uses the raw record (super.get), not the new scoped get()", () => {
+  it("owner can still delete its own integration", async () => {
+    integrationStore.set("int-1", { id: "int-1", agentId: "agent-owner" });
+    const i = makeIntegration(agentCtx("agent-owner"));
+    await (i as any).delete("int-1");
+    expect(integrationStore.has("int-1")).toBe(false);
+  });
+
+  it("a non-admin cannot delete ANOTHER agent's integration (403, untouched)", async () => {
+    integrationStore.set("int-1", { id: "int-1", agentId: "agent-owner" });
+    const i = makeIntegration(agentCtx("agent-attacker"));
+    const res = await (i as any).delete("int-1");
+    expect(res instanceof Response).toBe(true);
+    expect((res as Response).status).toBe(403);
+    expect(integrationStore.has("int-1")).toBe(true);
+  });
+
+  it("deleting a non-existent id is a clean no-op (not mis-routed into FORBIDDEN by the new get() override)", async () => {
+    const i = makeIntegration(agentCtx("agent-owner"));
+    const res = await (i as any).delete("does-not-exist");
+    expect(res instanceof Response).toBe(false);
+  });
+});

--- a/test/unit/memory-grant-read-gate.test.ts
+++ b/test/unit/memory-grant-read-gate.test.ts
@@ -68,7 +68,7 @@ const databasesMock = {
   },
 };
 
-mock.module("@harperfast/harper", () => ({ databases: databasesMock }));
+mock.module("@harperfast/harper", () => ({ databases: databasesMock, Resource: class {} }));
 
 const { MemoryGrant } = await import("../../resources/MemoryGrant.ts");
 

--- a/test/unit/memory-grant-read-gate.test.ts
+++ b/test/unit/memory-grant-read-gate.test.ts
@@ -1,0 +1,177 @@
+/**
+ * memory-grant-read-gate.test.ts — regression guard for the memory-soul-
+ * read-gate FAMILY fix (ops-oox7): MemoryGrant.ts previously gated
+ * search()/post()/put()/delete() but never defined `allowRead()` nor
+ * overrode `get()`. Harper routes `GET /MemoryGrant/<id>` to get() and the
+ * collection-describe `GET /MemoryGrant` outside search(), so both were
+ * ungated — an anonymous caller got a 200 with full grant content.
+ *
+ * MemoryGrant's ownership model differs from the other three (WorkspaceState/
+ * Relationship/Integration are single-owner via `agentId`): a grant is
+ * visible to EITHER the owner (ownerId) OR the grantee (granteeId) — mirrors
+ * search()'s existing owner-OR-grantee scope. get()'s ownership check is
+ * tested for both sides below.
+ *
+ * Same mocking technique as memory-integrity.test.ts / coordination-write-
+ * auth.test.ts. No other test/unit/ file imports resources/MemoryGrant.ts,
+ * so this file owns that mock+import with no collision risk.
+ */
+import { describe, it, expect, beforeEach, mock } from "bun:test";
+
+let grantStore: Map<string, any>;
+
+function matchesCondition(record: any, cond: any): boolean {
+  if (cond.operator && Array.isArray(cond.conditions)) {
+    const results = cond.conditions.map((c: any) => matchesCondition(record, c));
+    return cond.operator === "or" ? results.some(Boolean) : results.every(Boolean);
+  }
+  const fieldVal = record[cond.attribute];
+  if (cond.comparator === "equals") return fieldVal === cond.value;
+  if (cond.comparator === "not_equal") return fieldVal !== cond.value;
+  return true;
+}
+
+class BaseMemoryGrant {
+  async get(target?: any) {
+    const id = typeof target === "string" ? target : target?.id;
+    return grantStore.get(id) ?? null;
+  }
+  async post(content: any) {
+    const id = content.id ?? `grant-${Math.random().toString(36).slice(2)}`;
+    content.id = id;
+    grantStore.set(id, { ...content });
+    return { ...content };
+  }
+  async put(content: any) {
+    grantStore.set(content.id, { ...content });
+    return { ...content };
+  }
+  async delete(id: any) {
+    grantStore.delete(id);
+    return { ok: true };
+  }
+  search(query?: any) {
+    const conditions = Array.isArray(query) ? query : Array.isArray(query?.conditions) ? query.conditions : [];
+    let records = Array.from(grantStore.values());
+    for (const cond of conditions) records = records.filter((r) => matchesCondition(r, cond));
+    async function* gen() {
+      for (const r of records) yield r;
+    }
+    return gen();
+  }
+}
+
+const databasesMock = {
+  flair: {
+    MemoryGrant: BaseMemoryGrant,
+    Agent: { get: async () => null, search: async () => [] },
+  },
+};
+
+mock.module("@harperfast/harper", () => ({ databases: databasesMock }));
+
+const { MemoryGrant } = await import("../../resources/MemoryGrant.ts");
+
+function makeGrant(ctxRequest: any) {
+  const r: any = new (MemoryGrant as any)();
+  r.getContext = () => ({ request: ctxRequest });
+  return r;
+}
+const agentCtx = (agentId: string, isAdmin = false) => ({ tpsAgent: agentId, tpsAgentIsAdmin: isAdmin });
+const anonCtx = () => ({ tpsAnonymous: true });
+
+beforeEach(() => {
+  grantStore = new Map();
+});
+
+describe("MemoryGrant.allowRead — closes the anonymous GET /MemoryGrant/<id> and describe leak", () => {
+  it("anonymous is denied", async () => {
+    const g = makeGrant(anonCtx());
+    expect(await (g as any).allowRead()).toBe(false);
+  });
+
+  it("a verified non-admin agent is allowed (per-record scoping is in get())", async () => {
+    const g = makeGrant(agentCtx("agent-1"));
+    expect(await (g as any).allowRead()).toBe(true);
+  });
+
+  it("an admin agent is allowed", async () => {
+    const g = makeGrant(agentCtx("agent-admin", true));
+    expect(await (g as any).allowRead()).toBe(true);
+  });
+
+  it("an internal call (no request context) is allowed", async () => {
+    const r: any = new (MemoryGrant as any)();
+    r.getContext = () => undefined;
+    expect(await r.allowRead()).toBe(true);
+  });
+});
+
+describe("MemoryGrant.get() — anonymous denied, owner-OR-grantee scoped for non-admin, unfiltered for internal/admin", () => {
+  it("anonymous get(<id>) → 404, never leaks grant content", async () => {
+    grantStore.set("grant-1", { id: "grant-1", ownerId: "agent-owner", granteeId: "agent-grantee", scope: "read" });
+    const g = makeGrant(anonCtx());
+    const res = await (g as any).get("grant-1");
+    expect(res instanceof Response).toBe(true);
+    expect((res as Response).status).toBe(404);
+  });
+
+  it("verified non-admin get() of a grant where it's NEITHER owner NOR grantee → 404", async () => {
+    grantStore.set("grant-1", { id: "grant-1", ownerId: "agent-owner", granteeId: "agent-grantee", scope: "read" });
+    const g = makeGrant(agentCtx("agent-attacker"));
+    const res = await (g as any).get("grant-1");
+    expect(res instanceof Response).toBe(true);
+    expect((res as Response).status).toBe(404);
+  });
+
+  it("the OWNER can get() its own grant", async () => {
+    grantStore.set("grant-1", { id: "grant-1", ownerId: "agent-owner", granteeId: "agent-grantee", scope: "read" });
+    const g = makeGrant(agentCtx("agent-owner"));
+    const res = await (g as any).get("grant-1");
+    expect(res instanceof Response).toBe(false);
+    expect((res as any).scope).toBe("read");
+  });
+
+  it("the GRANTEE can also get() the same grant (owner-OR-grantee, not owner-only)", async () => {
+    grantStore.set("grant-1", { id: "grant-1", ownerId: "agent-owner", granteeId: "agent-grantee", scope: "read" });
+    const g = makeGrant(agentCtx("agent-grantee"));
+    const res = await (g as any).get("grant-1");
+    expect(res instanceof Response).toBe(false);
+    expect((res as any).scope).toBe("read");
+  });
+
+  it("a non-existent id for a non-admin agent → 404 (same as denied — no oracle for existence)", async () => {
+    const g = makeGrant(agentCtx("agent-owner"));
+    const res = await (g as any).get("does-not-exist");
+    expect(res instanceof Response).toBe(true);
+    expect((res as Response).status).toBe(404);
+  });
+
+  it("internal call (no request context) → returns any id unchanged", async () => {
+    grantStore.set("grant-1", { id: "grant-1", ownerId: "agent-owner", granteeId: "agent-grantee", scope: "secret-scope" });
+    const r: any = new (MemoryGrant as any)();
+    r.getContext = () => undefined;
+    const res = await r.get("grant-1");
+    expect(res instanceof Response).toBe(false);
+    expect((res as any).scope).toBe("secret-scope");
+  });
+
+  it("admin agent → returns any id unchanged, no ownership check", async () => {
+    grantStore.set("grant-1", { id: "grant-1", ownerId: "agent-owner", granteeId: "agent-grantee", scope: "secret-scope" });
+    const g = makeGrant(agentCtx("agent-admin", true));
+    const res = await (g as any).get("grant-1");
+    expect(res instanceof Response).toBe(false);
+    expect((res as any).scope).toBe("secret-scope");
+  });
+
+  it("a collection/query target (isCollection: true) delegates to search(), scoped by owner-OR-grantee", async () => {
+    grantStore.set("grant-owned", { id: "grant-owned", ownerId: "agent-1", granteeId: "agent-x", scope: "read" });
+    grantStore.set("grant-granted", { id: "grant-granted", ownerId: "agent-y", granteeId: "agent-1", scope: "read" });
+    grantStore.set("grant-unrelated", { id: "grant-unrelated", ownerId: "agent-y", granteeId: "agent-x", scope: "read" });
+    const g = makeGrant(agentCtx("agent-1"));
+    const res: any = await (g as any).get({ isCollection: true, conditions: [] });
+    const results: any[] = [];
+    for await (const rec of res) results.push(rec);
+    expect(results.map((rec) => rec.id).sort()).toEqual(["grant-granted", "grant-owned"]);
+  });
+});

--- a/test/unit/memory-integrity.test.ts
+++ b/test/unit/memory-integrity.test.ts
@@ -149,7 +149,7 @@ const databasesMock = {
   },
 };
 
-mock.module("@harperfast/harper", () => ({ databases: databasesMock }));
+mock.module("@harperfast/harper", () => ({ databases: databasesMock, Resource: class {} }));
 
 const { Memory } = await import("../../resources/Memory.ts");
 const { jaccardSimilarity, isConservativeMatch, computeMatchConfidence } = await import("../../resources/dedup.ts");

--- a/test/unit/memory-soul-read-gate.test.ts
+++ b/test/unit/memory-soul-read-gate.test.ts
@@ -64,7 +64,7 @@ const databasesMock = {
   },
 };
 
-mock.module("@harperfast/harper", () => ({ databases: databasesMock }));
+mock.module("@harperfast/harper", () => ({ databases: databasesMock, Resource: class {} }));
 
 const { Soul } = await import("../../resources/Soul.ts");
 

--- a/test/unit/relationship-read-gate.test.ts
+++ b/test/unit/relationship-read-gate.test.ts
@@ -63,7 +63,7 @@ const databasesMock = {
   },
 };
 
-mock.module("@harperfast/harper", () => ({ databases: databasesMock }));
+mock.module("@harperfast/harper", () => ({ databases: databasesMock, Resource: class {} }));
 
 const { Relationship } = await import("../../resources/Relationship.ts");
 

--- a/test/unit/relationship-read-gate.test.ts
+++ b/test/unit/relationship-read-gate.test.ts
@@ -1,0 +1,165 @@
+/**
+ * relationship-read-gate.test.ts — regression guard for the memory-soul-
+ * read-gate FAMILY fix (ops-oox7): Relationship.ts previously gated
+ * post()/put()/delete() (via search()'s own 401 and put()/delete()'s
+ * tpsAgent checks) but never defined `allowRead()` nor overrode `get()`.
+ * Harper routes `GET /Relationship/<id>` to get() and the collection-
+ * describe `GET /Relationship` outside search(), so both were ungated — an
+ * anonymous caller got a 200 with full record content.
+ *
+ * Same mocking technique as memory-integrity.test.ts / coordination-write-
+ * auth.test.ts: mock @harperfast/harper so the resource class loads outside
+ * a real Harper runtime, then exercise allowRead()/get() directly. No other
+ * test/unit/ file imports resources/Relationship.ts, so this file owns that
+ * mock+import with no collision risk (see memory-soul-read-gate.test.ts's
+ * doc comment for why that matters — bun runs test/unit/ in one process and
+ * dynamic imports are cached by resolved path).
+ */
+import { describe, it, expect, beforeEach, mock } from "bun:test";
+
+process.env.FLAIR_RATE_LIMIT_ENABLED = "false";
+
+let relationshipStore: Map<string, any>;
+
+function matchesCondition(record: any, cond: any): boolean {
+  if (cond.operator && Array.isArray(cond.conditions)) {
+    const results = cond.conditions.map((c: any) => matchesCondition(record, c));
+    return cond.operator === "or" ? results.some(Boolean) : results.every(Boolean);
+  }
+  const fieldVal = record[cond.attribute];
+  if (cond.comparator === "equals") return fieldVal === cond.value;
+  if (cond.comparator === "not_equal") return fieldVal !== cond.value;
+  return true;
+}
+
+class BaseRelationship {
+  async get(target?: any) {
+    const id = typeof target === "string" ? target : target?.id;
+    return relationshipStore.get(id) ?? null;
+  }
+  async put(content: any) {
+    relationshipStore.set(content.id, { ...content });
+    return { ...content };
+  }
+  async delete(id: any) {
+    relationshipStore.delete(id);
+    return { ok: true };
+  }
+  search(query?: any) {
+    const conditions = Array.isArray(query) ? query : Array.isArray(query?.conditions) ? query.conditions : [];
+    let records = Array.from(relationshipStore.values());
+    for (const cond of conditions) records = records.filter((r) => matchesCondition(r, cond));
+    async function* gen() {
+      for (const r of records) yield r;
+    }
+    return gen();
+  }
+}
+
+const databasesMock = {
+  flair: {
+    Relationship: BaseRelationship,
+    Agent: { get: async () => null, search: async () => [] },
+  },
+};
+
+mock.module("@harperfast/harper", () => ({ databases: databasesMock }));
+
+const { Relationship } = await import("../../resources/Relationship.ts");
+
+function makeRelationship(ctxRequest: any) {
+  const r: any = new (Relationship as any)();
+  r.getContext = () => ({ request: ctxRequest });
+  return r;
+}
+const agentCtx = (agentId: string, isAdmin = false) => ({ tpsAgent: agentId, tpsAgentIsAdmin: isAdmin });
+const anonCtx = () => ({ tpsAnonymous: true });
+
+beforeEach(() => {
+  relationshipStore = new Map();
+});
+
+describe("Relationship.allowRead — closes the anonymous GET /Relationship/<id> and describe leak", () => {
+  it("anonymous is denied", async () => {
+    const r = makeRelationship(anonCtx());
+    expect(await (r as any).allowRead()).toBe(false);
+  });
+
+  it("a verified non-admin agent is allowed (per-record scoping is in get())", async () => {
+    const r = makeRelationship(agentCtx("agent-1"));
+    expect(await (r as any).allowRead()).toBe(true);
+  });
+
+  it("an admin agent is allowed", async () => {
+    const r = makeRelationship(agentCtx("agent-admin", true));
+    expect(await (r as any).allowRead()).toBe(true);
+  });
+
+  it("an internal call (no request context) is allowed", async () => {
+    const r: any = new (Relationship as any)();
+    r.getContext = () => undefined;
+    expect(await r.allowRead()).toBe(true);
+  });
+});
+
+describe("Relationship.get() — anonymous denied, owner-scoped for non-admin, unfiltered for internal/admin", () => {
+  it("anonymous get(<id>) → 404, never leaks record content", async () => {
+    relationshipStore.set("rel-1", { id: "rel-1", agentId: "agent-owner", subject: "nathan", predicate: "manages", object: "flint" });
+    const r = makeRelationship(anonCtx());
+    const res = await (r as any).get("rel-1");
+    expect(res instanceof Response).toBe(true);
+    expect((res as Response).status).toBe(404);
+    const body = await (res as Response).json();
+    expect(JSON.stringify(body)).not.toContain("nathan");
+  });
+
+  it("verified non-admin get() of ANOTHER agent's id → 404 (not 403 — no existence confirmation)", async () => {
+    relationshipStore.set("rel-1", { id: "rel-1", agentId: "agent-owner", subject: "a", predicate: "b", object: "c" });
+    const r = makeRelationship(agentCtx("agent-attacker"));
+    const res = await (r as any).get("rel-1");
+    expect(res instanceof Response).toBe(true);
+    expect((res as Response).status).toBe(404);
+  });
+
+  it("verified non-admin get() of ITS OWN id → returns the real record", async () => {
+    relationshipStore.set("rel-1", { id: "rel-1", agentId: "agent-owner", subject: "a", predicate: "b", object: "c" });
+    const r = makeRelationship(agentCtx("agent-owner"));
+    const res = await (r as any).get("rel-1");
+    expect(res instanceof Response).toBe(false);
+    expect((res as any).subject).toBe("a");
+  });
+
+  it("a non-existent id for a non-admin agent → 404 (same as denied — no oracle for existence)", async () => {
+    const r = makeRelationship(agentCtx("agent-owner"));
+    const res = await (r as any).get("does-not-exist");
+    expect(res instanceof Response).toBe(true);
+    expect((res as Response).status).toBe(404);
+  });
+
+  it("internal call (no request context) → returns any id unchanged", async () => {
+    relationshipStore.set("rel-1", { id: "rel-1", agentId: "agent-owner", subject: "secret-subject", predicate: "b", object: "c" });
+    const r: any = new (Relationship as any)();
+    r.getContext = () => undefined;
+    const res = await r.get("rel-1");
+    expect(res instanceof Response).toBe(false);
+    expect((res as any).subject).toBe("secret-subject");
+  });
+
+  it("admin agent → returns any id unchanged, no ownership check", async () => {
+    relationshipStore.set("rel-1", { id: "rel-1", agentId: "agent-owner", subject: "secret-subject", predicate: "b", object: "c" });
+    const r = makeRelationship(agentCtx("agent-admin", true));
+    const res = await (r as any).get("rel-1");
+    expect(res instanceof Response).toBe(false);
+    expect((res as any).subject).toBe("secret-subject");
+  });
+
+  it("a collection/query target (isCollection: true) delegates to search(), scoped by agentId", async () => {
+    relationshipStore.set("rel-own", { id: "rel-own", agentId: "agent-1", subject: "a", predicate: "b", object: "c" });
+    relationshipStore.set("rel-other", { id: "rel-other", agentId: "agent-other", subject: "x", predicate: "y", object: "z" });
+    const r = makeRelationship(agentCtx("agent-1"));
+    const res: any = await (r as any).get({ isCollection: true, conditions: [] });
+    const results: any[] = [];
+    for await (const rec of res) results.push(rec);
+    expect(results.map((rec) => rec.id)).toEqual(["rel-own"]);
+  });
+});

--- a/test/unit/resolve-agent-auth.test.ts
+++ b/test/unit/resolve-agent-auth.test.ts
@@ -3,7 +3,7 @@ import { mock, describe, it, expect } from "bun:test";
 // agent-auth.ts imports `databases` from @harperfast/harper, whose module chain
 // throws when loaded outside a Harper runtime. Mock it — resolveAgentAuth's
 // internal/anonymous paths never touch databases (they return before Agent.get).
-mock.module("@harperfast/harper", () => ({ databases: {} }));
+mock.module("@harperfast/harper", () => ({ databases: {}, Resource: class {} }));
 
 const { resolveAgentAuth } = await import("../../resources/agent-auth.ts");
 


### PR DESCRIPTION
Two security read-gate fixes from the ops-ckrr family audit. The first is a **live-confirmed P0** and is the headline.

## 🔴 P0 — verified non-admin agents can read the entire admin console (LIVE-CONFIRMED)

**Live repro on rockit** (running the current released code): a verified **non-admin** agent — `flint`, whose cross-agent memory read correctly returns 404 — signs an ordinary TPS-Ed25519 request and receives:
- `GET /AdminMemory` → **200, 30KB** (all-agents memory browse + full provenance)
- `GET /AdminPrincipals` → **200** (every principal, trust tier, status)
- `GET /AdminDashboard` → **200** (instance-wide stats)

**Root cause:** `auth-middleware.ts`'s `/Admin` pathname gate only 401s in the `if (!m)` branch — i.e. when there's **no valid** Authorization header. A validly-signed non-admin Ed25519 agent passes verification, is de-elevated to the `flair-agent` role, and proceeds to `nextLayer` with **no admin check**. The seven `Admin*` resources are custom `Resource`s (not `@table`), so Harper's RBAC doesn't gate them and — with no `allowRead` — nothing does.

**Fix:** `allowRead()=allowAdmin` on all seven `Admin*` resources (mirrors `OAuthClient.ts`). The integration test asserts **both** halves: a non-admin agent → 403, and an admin agent → authorized (real admins keep access).

## 🟠 Family read-gate (ops-oox7) — same class as ops-ckrr

`WorkspaceState`, `Relationship`, `Integration`, `MemoryGrant`: `search()` + writes gated, but no `allowRead()` / `get()` — so anonymous by-id and collection-describe reads leaked (live-confirmed 200 anon on all four). Same fix as Memory/Soul:
- `allowRead()=allowVerified` + `get()` branching on `target.isCollection` (collection/query → scoped `search()`; by-id → ownership check, **404 never 403**).
- `MemoryGrant` scopes `ownerId` **OR** `granteeId` (mirrors its `search()`).
- `delete()` switched to `super.get()` on all four — same Response-truthiness fix as Memory (a scoped `get()` returning a truthy 404 would otherwise misroute the ownership pre-check).

## Verification (independent — I reviewed the diff and re-ran, not relaying the implementer)
- **Live-confirmed the Admin bypass** on rockit (non-admin `flint` → 200 admin HTML across three pages).
- **Full suite green, real Harper:** unit **1357/0**, integration **144/0** — including the Admin de-elevation test (non-admin 403 + admin authorized) and the four `@table` anonymous→403 / self-by-id→200 / cross-agent→404 invariants.
- Mutation-proof (implementer, spot-checked): reverting MemoryGrant's gate → 8/12 fail, restore → pass.

**@tps-sherlock — HARD GATE.** The `Admin*` change is access-control on the admin console. Confirm: (1) `allowAdmin` permits every legitimate admin path (Basic super_user **and** admin agents), (2) the non-admin bypass is fully closed, (3) no legitimate non-admin path to `Admin*` exists that this would break.

**Pre-existing bug, out of scope (flagged):** `Relationship.delete()` calls `super.get()` with no id argument — unrelated to this leak, filing separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
