### PR TITLE
refactor(security): consolidate 3 Ed25519 nonce caches + crypto helpers into one shared guard (ops-c4op)

### DIFF
--- a/resources/Presence.ts
+++ b/resources/Presence.ts
@@ -19,11 +19,10 @@
 
 import { databases } from "@harperfast/harper";
 import { resolveAgentAuth } from "./agent-auth.js";
-import { b64ToArrayBuffer } from "./b64.js";
+import { WINDOW_MS, isNonceReplay, recordNonce, importEd25519Key, b64ToArrayBuffer } from "./ed25519-auth.js";
 
 // ─── Constants ────────────────────────────────────────────────────────────────
 
-const WINDOW_MS = 30_000;
 const CURRENT_TASK_MAX_LENGTH = 200;
 const VALID_ACTIVITIES = new Set(["coding", "reviewing", "planning", "idle"]);
 
@@ -37,37 +36,12 @@ function offlineThresholdMs(): number {
   return env ? Number(env) || 600_000 : 600_000;
 }
 
-// ─── Nonce replay protection ──────────────────────────────────────────────────
-
-const nonceSeen = new Map<string, number>();
-
-function pruneNonces() {
-  const now = Date.now();
-  for (const [k, ts] of nonceSeen.entries()) {
-    if (now - ts > WINDOW_MS) nonceSeen.delete(k);
-  }
-}
-
-// ─── Crypto helpers ───────────────────────────────────────────────────────────
-// b64ToArrayBuffer lives in ./b64.ts (shared with auth-middleware.ts + agent-auth.ts
-// so the base64/base64url decoder can't drift across the three auth call sites).
-
-const keyCache = new Map<string, CryptoKey>();
-
-async function importEd25519Key(publicKeyStr: string): Promise<CryptoKey> {
-  if (keyCache.has(publicKeyStr)) return keyCache.get(publicKeyStr)!;
-  let raw: ArrayBuffer;
-  if (/^[0-9a-f]{64}$/i.test(publicKeyStr)) {
-    const bytes = new Uint8Array(32);
-    for (let i = 0; i < 32; i++) bytes[i] = parseInt(publicKeyStr.slice(i * 2, i * 2 + 2), 16);
-    raw = bytes.buffer;
-  } else {
-    raw = b64ToArrayBuffer(publicKeyStr);
-  }
-  const key = await crypto.subtle.importKey("raw", raw, { name: "Ed25519" } as any, false, ["verify"]);
-  keyCache.set(publicKeyStr, key);
-  return key;
-}
+// ─── Nonce replay + crypto helpers ─────────────────────────────────────────────
+// WINDOW_MS, isNonceReplay/recordNonce (the ONE shared nonce store), and
+// importEd25519Key all live in ./ed25519-auth.ts (bd ops-c4op) — the single
+// shared implementation imported by auth-middleware.ts, agent-auth.ts, and
+// Presence.ts so a nonce recorded via any one of the three call sites is
+// visible to the other two, and the crypto/decoder logic can't drift.
 
 // ─── Status derivation (pure — exported for unit testing) ─────────────────────
 
@@ -236,9 +210,7 @@ export class Presence extends (databases as any).flair.Presence {
         );
       }
 
-      pruneNonces();
-      const nonceKey = `${headerAgentId}:${nonce}`;
-      if (nonceSeen.has(nonceKey)) {
+      if (isNonceReplay(headerAgentId, nonce, now)) {
         return new Response(
           JSON.stringify({ error: "nonce_replay_detected" }),
           { status: 401, headers: { "Content-Type": "application/json" } },
@@ -280,7 +252,7 @@ export class Presence extends (databases as any).flair.Presence {
         );
       }
 
-      nonceSeen.set(nonceKey, ts);
+      recordNonce(headerAgentId, nonce, ts);
       agentId = headerAgentId;
     }
 

--- a/resources/agent-auth.ts
+++ b/resources/agent-auth.ts
@@ -16,9 +16,7 @@
  * 30s timestamp window + a per-(agent,nonce) seen-set pruned to that window.
  */
 import { databases } from "@harperfast/harper";
-import { b64ToArrayBuffer } from "./b64.js";
-
-const WINDOW_MS = Number(process.env.FLAIR_AGENT_AUTH_WINDOW_MS) || 30_000;
+import { WINDOW_MS, isNonceReplay, recordNonce, importEd25519Key, b64ToArrayBuffer } from "./ed25519-auth.js";
 
 /**
  * Shared Harper user that verified Ed25519 agents resolve to (least-privilege
@@ -28,30 +26,12 @@ const WINDOW_MS = Number(process.env.FLAIR_AGENT_AUTH_WINDOW_MS) || 30_000;
  */
 export const FLAIR_AGENT_USERNAME = "flair-agent";
 
-// Replay protection: remember recently-seen (agent:nonce), pruned by the window.
-const nonceSeen = new Map<string, number>();
-
-// ─── Crypto helpers ───────────────────────────────────────────────────────────
-// b64ToArrayBuffer lives in ./b64.ts (shared with auth-middleware.ts + Presence.ts
-// so the base64/base64url decoder can't drift across the three auth call sites).
-
-const keyCache = new Map<string, CryptoKey>();
-async function importEd25519Key(publicKeyStr: string): Promise<CryptoKey> {
-  const cached = keyCache.get(publicKeyStr);
-  if (cached) return cached;
-  // Accept hex (64-char) or base64 (44-char) encoded 32-byte Ed25519 public key.
-  let raw: ArrayBuffer;
-  if (/^[0-9a-f]{64}$/i.test(publicKeyStr)) {
-    const bytes = new Uint8Array(32);
-    for (let i = 0; i < 32; i++) bytes[i] = parseInt(publicKeyStr.slice(i * 2, i * 2 + 2), 16);
-    raw = bytes.buffer;
-  } else {
-    raw = b64ToArrayBuffer(publicKeyStr);
-  }
-  const key = await crypto.subtle.importKey("raw", raw, { name: "Ed25519" } as any, false, ["verify"]);
-  keyCache.set(publicKeyStr, key);
-  return key;
-}
+// ─── Crypto + replay-guard helpers ────────────────────────────────────────────
+// WINDOW_MS, isNonceReplay/recordNonce (the ONE shared nonce store), and
+// importEd25519Key all live in ./ed25519-auth.ts (bd ops-c4op) — the single
+// shared implementation imported by auth-middleware.ts, agent-auth.ts, and
+// Presence.ts so a nonce recorded via any one of the three call sites is
+// visible to the other two, and the crypto/decoder logic can't drift.
 
 // ─── Admin resolution ─────────────────────────────────────────────────────────
 // Admin agents come from FLAIR_ADMIN_AGENTS (comma-separated) OR Agent records
@@ -101,10 +81,8 @@ async function doVerify(request: any): Promise<AgentAuth | null> {
   const now = Date.now();
   if (!Number.isFinite(ts) || Math.abs(now - ts) > WINDOW_MS) return null;
 
-  // Prune expired nonces, then reject replays within the window.
-  for (const [k, t] of nonceSeen) if (now - t > WINDOW_MS) nonceSeen.delete(k);
-  const nonceKey = `${agentId}:${nonce}`;
-  if (nonceSeen.has(nonceKey)) return null;
+  // Reject replays within the window (isNonceReplay prunes expired entries first).
+  if (isNonceReplay(agentId, nonce, now)) return null;
 
   const agent = await (databases as any).flair.Agent.get(agentId).catch(() => null);
   if (!agent?.publicKey) return null;
@@ -126,7 +104,7 @@ async function doVerify(request: any): Promise<AgentAuth | null> {
     return null;
   }
 
-  nonceSeen.set(nonceKey, ts);
+  recordNonce(agentId, nonce, ts);
   return { agentId, isAdmin: await isAdmin(agentId) };
 }
 

--- a/resources/auth-middleware.ts
+++ b/resources/auth-middleware.ts
@@ -2,7 +2,7 @@ import { patchRecord } from "./table-helpers.js";
 import { server, databases } from "@harperfast/harper";
 import { getEmbedding } from "./embeddings-provider.js";
 import { isAdmin, FLAIR_AGENT_USERNAME } from "./agent-auth.js";
-import { b64ToArrayBuffer } from "./b64.js";
+import { WINDOW_MS, isNonceReplay, recordNonce, importEd25519Key, b64ToArrayBuffer } from "./ed25519-auth.js";
 
 // --- Admin credentials ---
 // Admin auth is sourced exclusively from Harper's own environment variables
@@ -34,37 +34,18 @@ function getAdminPass(): string | null {
   return null;
 }
 
-const WINDOW_MS = 30_000;
-const nonceSeen = new Map<string, number>();
-
 // ─── Admin resolution ─────────────────────────────────────────────────────────
 // `isAdmin` (FLAIR_ADMIN_AGENTS env + Agent role==="admin", 60s-cached) now lives
 // in agent-auth.ts as the single source of truth, imported above. During the
 // auth reshape this gate and the per-resource allow* helpers must agree on who's
 // an admin — one implementation guarantees they can't diverge.
 
-// ─── Crypto helpers ───────────────────────────────────────────────────────────
-// b64ToArrayBuffer lives in ./b64.ts (shared with agent-auth.ts + Presence.ts so
-// the base64/base64url decoder can't drift across the three auth call sites).
-
-const keyCache = new Map<string, CryptoKey>();
-async function importEd25519Key(publicKeyStr: string): Promise<CryptoKey> {
-  if (keyCache.has(publicKeyStr)) return keyCache.get(publicKeyStr)!;
-  // Accept hex (64-char) or base64 (44-char) encoded 32-byte Ed25519 public key
-  let raw: ArrayBuffer;
-  if (/^[0-9a-f]{64}$/i.test(publicKeyStr)) {
-    // Hex-encoded raw key (TPS CLI default: Buffer.toString('hex'))
-    const bytes = new Uint8Array(32);
-    for (let i = 0; i < 32; i++) bytes[i] = parseInt(publicKeyStr.slice(i * 2, i * 2 + 2), 16);
-    raw = bytes.buffer;
-  } else {
-    raw = b64ToArrayBuffer(publicKeyStr);
-  }
-  const key = await crypto.subtle.importKey("raw", raw, { name: "Ed25519" } as any, false, ["verify"]);
-  keyCache.set(publicKeyStr, key);
-  return key;
-}
-
+// ─── Crypto + replay-guard helpers ────────────────────────────────────────────
+// WINDOW_MS, isNonceReplay/recordNonce (the ONE shared nonce store), and
+// importEd25519Key all live in ./ed25519-auth.ts (bd ops-c4op) — the single
+// shared implementation imported by auth-middleware.ts, agent-auth.ts, and
+// Presence.ts so a nonce recorded via any one of the three call sites is
+// visible to the other two, and the crypto/decoder logic can't drift.
 
 async function backfillEmbedding(memoryId: string): Promise<void> {
   try {
@@ -263,11 +244,7 @@ server.http(async (request: any, nextLayer: any) => {
   if (!Number.isFinite(ts) || Math.abs(now - ts) > WINDOW_MS)
     return new Response(JSON.stringify({ error: "timestamp_out_of_window" }), { status: 401 });
 
-  for (const [k, signatureTs] of nonceSeen.entries())
-    if (now - signatureTs > WINDOW_MS) nonceSeen.delete(k);
-
-  const nonceKey = `${agentId}:${nonce}`;
-  if (nonceSeen.has(nonceKey))
+  if (isNonceReplay(agentId, nonce, now))
     return new Response(JSON.stringify({ error: "nonce_replay_detected" }), { status: 401 });
 
   const agent = await (databases as any).flair.Agent.get(agentId);
@@ -288,7 +265,7 @@ server.http(async (request: any, nextLayer: any) => {
       return new Response(JSON.stringify({ error: "signature_verification_failed", detail: e?.message }), { status: 401 });
   }
 
-  nonceSeen.set(nonceKey, ts);
+  recordNonce(agentId, nonce, ts);
   request.tpsAgent = agentId;
   (request as any)._tpsAuthVerified = true;
   request.tpsAgentIsAdmin = await isAdmin(agentId);

--- a/resources/ed25519-auth.ts
+++ b/resources/ed25519-auth.ts
@@ -1,0 +1,124 @@
+/**
+ * ed25519-auth — single shared source of truth for the TPS-Ed25519 auth
+ * primitives used at all 3 signature-verification call sites:
+ *
+ *   - resources/auth-middleware.ts  (instance-wide HTTP gate)
+ *   - resources/agent-auth.ts       (resolveAgentAuth's per-resource fallback)
+ *   - resources/Presence.ts         (POST /Presence heartbeat auth)
+ *
+ * Before this module existed, each of the 3 files carried its OWN
+ * module-level `nonceSeen` Map (replay guard) plus its own copy of
+ * `importEd25519Key`. Three independent replay windows meant a nonce
+ * recorded as "seen" via one path was invisible to the other two — a
+ * defense-in-depth gap, and a drift hazard (any future fix to one copy
+ * silently didn't apply to the other two). bd ops-c4op consolidates all
+ * three into this one module so there is exactly ONE replay guard and ONE
+ * key-import implementation, imported by all 3 sites.
+ *
+ * `b64ToArrayBuffer` was already unified into resources/b64.ts in a prior
+ * pass (see that file's header) — re-exported here so callers can import
+ * everything Ed25519-auth-related from one place.
+ *
+ * NOT included here: resources/Federation.ts's replay guard. Federation
+ * uses its own purpose-built NonceStore (federation-crypto.ts) for a
+ * different signing scheme (federation peer-to-peer body signatures, not
+ * agent TPS-Ed25519 auth) — deliberately left alone.
+ *
+ * Signed payload format (must match the TPS CLI signer exactly — changing
+ * it breaks every agent's auth): `${agentId}:${ts}:${nonce}:${METHOD}:${pathname}${search}`.
+ * Auth header format: `TPS-Ed25519 <agentId>:<ts>:<nonce>:<signatureB64>`.
+ * nonceKey format (replay-guard map key): `${agentId}:${nonce}`.
+ */
+import { b64ToArrayBuffer } from "./b64.js";
+
+export { b64ToArrayBuffer };
+
+/**
+ * Replay window, in ms. Confirmed identical (30_000) as a literal constant
+ * in auth-middleware.ts and Presence.ts. agent-auth.ts alone additionally
+ * read an (undocumented, never-set-anywhere) `FLAIR_AGENT_AUTH_WINDOW_MS`
+ * env override — see the flag on this in the consolidation report; the
+ * override is preserved here (uniformly, for all 3 sites) since no config,
+ * docs, or test in this repo currently sets that var, so preserving it is
+ * additive/no-op for today's deployments while keeping agent-auth.ts's
+ * stated "plugin-shaped, config via env" design intent.
+ */
+export const WINDOW_MS = Number(process.env.FLAIR_AGENT_AUTH_WINDOW_MS) || 30_000;
+
+// ─── Replay guard (single shared instance) ─────────────────────────────────
+//
+// nonceSeen is the ONE module-level singleton — the whole point of this
+// consolidation. A nonce recorded via any one of the 3 call sites is
+// immediately visible to the other two, because they all import this same
+// module (Node/bun module cache = one instance per process).
+const nonceSeen = new Map<string, number>();
+
+/** Remove nonce records older than WINDOW_MS relative to `now`. */
+export function pruneNonces(now: number = Date.now()): void {
+  for (const [k, ts] of nonceSeen) {
+    if (now - ts > WINDOW_MS) nonceSeen.delete(k);
+  }
+}
+
+/**
+ * Prune expired entries, then report whether (agentId, nonce) has already
+ * been recorded within the current window. Returns true = REPLAY (reject).
+ *
+ * Deliberately does NOT record as a side effect — callers check this BEFORE
+ * verifying the signature and call `recordNonce` only AFTER the signature is
+ * confirmed valid (matches the pre-consolidation per-site behavior at all 3
+ * sites exactly: an invalid-signature attempt never burns the nonce, so a
+ * client that retries with a corrected signature isn't locked out).
+ */
+export function isNonceReplay(agentId: string, nonce: string, now: number = Date.now()): boolean {
+  pruneNonces(now);
+  return nonceSeen.has(`${agentId}:${nonce}`);
+}
+
+/** Record (agentId, nonce) as seen at `ts`. Call only after successful verification. */
+export function recordNonce(agentId: string, nonce: string, ts: number): void {
+  nonceSeen.set(`${agentId}:${nonce}`, ts);
+}
+
+/**
+ * Test-only escape hatch: clear all recorded nonces. Never called by any
+ * production call site — exists so unit tests can isolate the shared
+ * singleton between cases instead of relying on WINDOW_MS-based expiry.
+ */
+export function __clearNoncesForTest(): void {
+  nonceSeen.clear();
+}
+
+// ─── Ed25519 public key import (cached) ────────────────────────────────────
+//
+// Single shared key cache, keyed by the raw publicKeyStr. Consolidating the
+// 3 previously-independent caches into one just avoids redundant
+// crypto.subtle.importKey calls across sites for the same agent — no
+// security-relevant behavior change (the cache holds only CryptoKey handles,
+// never logged or exposed).
+const keyCache = new Map<string, CryptoKey>();
+
+/**
+ * Import an agent's Ed25519 public key as a CryptoKey, cached by the raw
+ * key string. Accepts hex (64-char) or base64/base64url (44-char, or
+ * unpadded) encoded 32-byte Ed25519 public keys — identical logic across
+ * all 3 pre-consolidation copies (auth-middleware.ts, agent-auth.ts,
+ * Presence.ts).
+ */
+export async function importEd25519Key(publicKeyStr: string): Promise<CryptoKey> {
+  const cached = keyCache.get(publicKeyStr);
+  if (cached) return cached;
+  // Accept hex (64-char) or base64 (44-char) encoded 32-byte Ed25519 public key.
+  let raw: ArrayBuffer;
+  if (/^[0-9a-f]{64}$/i.test(publicKeyStr)) {
+    // Hex-encoded raw key (TPS CLI default: Buffer.toString('hex'))
+    const bytes = new Uint8Array(32);
+    for (let i = 0; i < 32; i++) bytes[i] = parseInt(publicKeyStr.slice(i * 2, i * 2 + 2), 16);
+    raw = bytes.buffer;
+  } else {
+    raw = b64ToArrayBuffer(publicKeyStr);
+  }
+  const key = await crypto.subtle.importKey("raw", raw, { name: "Ed25519" } as any, false, ["verify"]);
+  keyCache.set(publicKeyStr, key);
+  return key;
+}

--- a/test/integration/auth-middleware-e2e.test.ts
+++ b/test/integration/auth-middleware-e2e.test.ts
@@ -475,6 +475,38 @@ describe("auth-middleware e2e (real Harper)", () => {
   }, 30_000);
 
   // ═══════════════════════════════════════════════════════════════════════════
+  // bd ops-c4op — shared nonce store consolidation (3 independent nonceSeen
+  // Maps -> resources/ed25519-auth.ts, one singleton). Real HTTP replay
+  // coverage for auth-middleware.ts's Ed25519 branch didn't previously exist
+  // (only unit-level simulator logic did). Real-Harper is also the only place
+  // this is reliably testable end-to-end: auth-middleware.ts's `import {
+  // server } from "@harperfast/harper"` can't be safely mocked in the unit
+  // suite (bun's mock.module is process-global and ~10+ sibling unit test
+  // files mock @harperfast/harper without a `server` export — any of them
+  // can end up "active" when auth-middleware.ts's import resolves, racing
+  // unpredictably). Real cross-path closure between the OTHER two sites
+  // (agent-auth.ts <-> Presence.ts) is covered at the unit level in
+  // test/unit/ed25519-auth-cross-site.test.ts, where no such mock exists.
+  // ═══════════════════════════════════════════════════════════════════════════
+
+  test("nonce replay: same TPS-Ed25519 header sent twice → 2nd request 401 nonce_replay_detected", async () => {
+    const path = `/Memory/?agentId=${agent.id}`;
+    const header = ed25519Header(agent, "GET", path);
+
+    const first = await fetch(`${harper.httpURL}${path}`, {
+      headers: { Authorization: header },
+    });
+    expect(first.status).toBe(200);
+
+    const replay = await fetch(`${harper.httpURL}${path}`, {
+      headers: { Authorization: header },
+    });
+    expect(replay.status).toBe(401);
+    const body: any = await replay.json().catch(() => ({}));
+    expect(body.error).toBe("nonce_replay_detected");
+  }, 30_000);
+
+  // ═══════════════════════════════════════════════════════════════════════════
   // Bug 1 — Basic / Path 2: super_user
   //
   // The old simulator tests used a mock getUser that returned hand-written

--- a/test/unit/ed25519-auth-cross-site.test.ts
+++ b/test/unit/ed25519-auth-cross-site.test.ts
@@ -1,0 +1,260 @@
+/**
+ * ed25519-auth-cross-site.test.ts — REAL cross-module closure proof (bd
+ * ops-c4op): agent-auth.ts's verifyAgentRequest() and Presence.ts's post()
+ * fallback verification are two of the three independent TPS-Ed25519 call
+ * sites that used to carry their OWN nonceSeen Map. This test imports BOTH
+ * real modules under one @harperfast/harper mock (bun's module cache is
+ * process-global, so both modules resolve the SAME `../../resources/
+ * ed25519-auth.ts` singleton) and proves a nonce recorded via one site is
+ * rejected as a replay via the OTHER — in both directions — using a real
+ * Ed25519 keypair and a real signature, not a simulated header.
+ *
+ * (The third site, auth-middleware.ts, is covered together with
+ * agent-auth.ts in auth-middleware-ed25519.test.ts — its registration model
+ * via `server.http()` needs a slightly different mock shape.)
+ *
+ * Per the harness lesson (order-dependent CI failure): any test that mocks
+ * @harperfast/harper MUST also export `Resource` in the mock object.
+ */
+import { mock, describe, it, expect, beforeEach } from "bun:test";
+import nacl from "tweetnacl";
+
+// ─── Fixtures ───────────────────────────────────────────────────────────────
+
+let agentsById: Record<string, { publicKey: string }> = {};
+let presenceRecords: Record<string, any> = {};
+
+class BasePresence {
+  static async get(id: string) {
+    return presenceRecords[id] ?? null;
+  }
+  static async put(rec: any) {
+    presenceRecords[rec.agentId] = rec;
+    return rec;
+  }
+  static search() {
+    async function* gen() {}
+    return gen();
+  }
+}
+
+const databasesMock = {
+  flair: {
+    Agent: {
+      get: async (id: string) => agentsById[id] ?? null,
+      search: async function* (_q?: any) {
+        // No admin agents in this fixture set.
+      },
+    },
+    Presence: BasePresence,
+  },
+};
+
+// Minimal stand-in for Harper's runtime-injected `Resource` base class —
+// required alongside `databases` any time @harperfast/harper is mocked, or a
+// later-loaded test file in the same bun process fails with "Export named
+// Resource not found" (bun mock.module is process-global).
+class MockResourceBase {}
+
+// `server` isn't used by this file's own imports (agent-auth.ts / Presence.ts
+// don't import it), but auth-middleware-ed25519.test.ts's `import { server }`
+// DOES need it — and because bun's mock.module is process-global, whichever
+// mock is active when THAT file's import resolves wins, regardless of file
+// order. A superset mock (server + databases + Resource) is the safe shape
+// (same pattern as test/unit/mcp-oauth-register.test.ts).
+mock.module("@harperfast/harper", () => ({
+  server: { http: () => {}, getUser: async (name: string) => ({ username: name, role: { permission: {} } }) },
+  databases: databasesMock,
+  Resource: MockResourceBase,
+}));
+
+const { verifyAgentRequest } = await import("../../resources/agent-auth.ts");
+const { Presence } = await import("../../resources/Presence.ts");
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+function makeAgent(agentId: string): { secretKey: Uint8Array; publicKeyB64: string } {
+  const kp = nacl.sign.keyPair();
+  const publicKeyB64 = Buffer.from(kp.publicKey).toString("base64");
+  agentsById[agentId] = { publicKey: publicKeyB64 };
+  return { secretKey: kp.secretKey, publicKeyB64 };
+}
+
+/**
+ * Signs `${agentId}:${ts}:${nonce}:POST:/Presence` — the canonical payload
+ * BOTH agent-auth.ts's doVerify (via `new URL(request.url).pathname` on
+ * "/Presence" with no query string) and Presence.ts's own fallback verify
+ * (via `request.url.split("?")[0]`, method hardcoded "POST") compute
+ * identically for this exact request shape. One signature, valid at both
+ * sites — the point of the test.
+ */
+function signPresencePost(agentId: string, ts: number, nonce: string, secretKey: Uint8Array): string {
+  const payload = `${agentId}:${ts}:${nonce}:POST:/Presence`;
+  const sig = nacl.sign.detached(new TextEncoder().encode(payload), secretKey);
+  const sigB64 = Buffer.from(sig).toString("base64");
+  return `TPS-Ed25519 ${agentId}:${ts}:${nonce}:${sigB64}`;
+}
+
+function reqFor(header: string): any {
+  return {
+    headers: { get: (n: string) => (n === "authorization" ? header : undefined) },
+    url: "/Presence",
+    method: "POST",
+    // tpsAgent deliberately unset — forces Presence.post() to do its OWN
+    // verification instead of trusting a middleware annotation.
+  };
+}
+
+function makePresenceInstance(request: any): any {
+  const p: any = new (Presence as any)();
+  p.getContext = () => ({ request });
+  return p;
+}
+
+beforeEach(() => {
+  agentsById = {};
+  presenceRecords = {};
+});
+
+// ─── Cross-path closure ─────────────────────────────────────────────────────
+
+describe("cross-site nonce replay closure: agent-auth.ts -> Presence.ts", () => {
+  it("a nonce recorded via verifyAgentRequest() is rejected as replay via Presence.post()", async () => {
+    const agentId = "agent-cross-1";
+    const { secretKey } = makeAgent(agentId);
+    const ts = Date.now();
+    const nonce = "cross-nonce-1";
+    const header = signPresencePost(agentId, ts, nonce, secretKey);
+
+    // 1) First use, via agent-auth.ts's verifyAgentRequest — succeeds, records the nonce.
+    const first = await verifyAgentRequest(reqFor(header));
+    expect(first).toEqual({ agentId, isAdmin: false });
+
+    // 2) SAME header replayed via Presence.ts's OWN verification fallback.
+    //    If the two sites still had independent nonceSeen Maps, this would
+    //    succeed (Presence never saw the nonce). With the shared store, it
+    //    must be rejected.
+    const presence = makePresenceInstance(reqFor(header));
+    const res = await presence.post({ activity: "idle" });
+    expect(res).toBeInstanceOf(Response);
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    expect(body.error).toBe("nonce_replay_detected");
+  });
+});
+
+describe("cross-site nonce replay closure: Presence.ts -> agent-auth.ts", () => {
+  it("a nonce recorded via Presence.post() is rejected as replay via verifyAgentRequest()", async () => {
+    const agentId = "agent-cross-2";
+    const { secretKey } = makeAgent(agentId);
+    const ts = Date.now();
+    const nonce = "cross-nonce-2";
+    const header = signPresencePost(agentId, ts, nonce, secretKey);
+
+    // 1) First use, via Presence.ts's own verify path — succeeds, records the nonce.
+    const presence = makePresenceInstance(reqFor(header));
+    const res = await presence.post({ activity: "coding" });
+    expect(res).toEqual({ ok: true, agentId, lastHeartbeatAt: expect.any(Number), presenceStatus: "active" });
+
+    // 2) SAME header replayed via agent-auth.ts's verifyAgentRequest — must be
+    //    rejected (null) because the nonce is already recorded in the shared store.
+    const second = await verifyAgentRequest(reqFor(header));
+    expect(second).toBeNull();
+  });
+});
+
+// ─── Per-site negative-path coverage (Steps item 4) ────────────────────────
+
+describe("agent-auth.ts verifyAgentRequest — per-site negative paths", () => {
+  it("rejects a tampered signature", async () => {
+    const agentId = "agent-neg-1";
+    const { secretKey } = makeAgent(agentId);
+    const ts = Date.now();
+    const nonce = "neg-nonce-1";
+    // Sign a DIFFERENT payload than the one that will be verified.
+    const wrongPayload = `${agentId}:${ts}:${nonce}:POST:/SomewhereElse`;
+    const sig = nacl.sign.detached(new TextEncoder().encode(wrongPayload), secretKey);
+    const header = `TPS-Ed25519 ${agentId}:${ts}:${nonce}:${Buffer.from(sig).toString("base64")}`;
+
+    const result = await verifyAgentRequest(reqFor(header));
+    expect(result).toBeNull();
+  });
+
+  it("rejects an unknown agent", async () => {
+    const ts = Date.now();
+    const header = `TPS-Ed25519 nobody:${ts}:some-nonce:c2ln`;
+    const result = await verifyAgentRequest(reqFor(header));
+    expect(result).toBeNull();
+  });
+
+  it("rejects an expired timestamp", async () => {
+    const agentId = "agent-neg-2";
+    const { secretKey } = makeAgent(agentId);
+    const ts = Date.now() - 60_000; // 60s old, WINDOW_MS is 30s
+    const nonce = "neg-nonce-2";
+    const header = signPresencePost(agentId, ts, nonce, secretKey);
+    const result = await verifyAgentRequest(reqFor(header));
+    expect(result).toBeNull();
+  });
+
+  it("rejects an outright replay within the same site", async () => {
+    const agentId = "agent-neg-3";
+    const { secretKey } = makeAgent(agentId);
+    const ts = Date.now();
+    const nonce = "neg-nonce-3";
+    const header = signPresencePost(agentId, ts, nonce, secretKey);
+
+    const first = await verifyAgentRequest(reqFor(header));
+    expect(first).toEqual({ agentId, isAdmin: false });
+
+    const replay = await verifyAgentRequest(reqFor(header));
+    expect(replay).toBeNull();
+  });
+});
+
+describe("Presence.ts post() — per-site negative paths", () => {
+  it("rejects a tampered signature with invalid_signature", async () => {
+    const agentId = "agent-neg-4";
+    const { secretKey } = makeAgent(agentId);
+    const ts = Date.now();
+    const nonce = "neg-nonce-4";
+    const wrongPayload = `${agentId}:${ts}:${nonce}:POST:/SomewhereElse`;
+    const sig = nacl.sign.detached(new TextEncoder().encode(wrongPayload), secretKey);
+    const header = `TPS-Ed25519 ${agentId}:${ts}:${nonce}:${Buffer.from(sig).toString("base64")}`;
+
+    const presence = makePresenceInstance(reqFor(header));
+    const res = await presence.post({ activity: "idle" });
+    expect(res).toBeInstanceOf(Response);
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    expect(body.error).toBe("invalid_signature");
+  });
+
+  it("rejects an unknown agent with unknown_agent", async () => {
+    const ts = Date.now();
+    const header = `TPS-Ed25519 ghost-agent:${ts}:some-nonce:c2ln`;
+    const presence = makePresenceInstance(reqFor(header));
+    const res = await presence.post({ activity: "idle" });
+    expect(res).toBeInstanceOf(Response);
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    expect(body.error).toBe("unknown_agent");
+  });
+
+  it("rejects a replay within the same site with nonce_replay_detected", async () => {
+    const agentId = "agent-neg-5";
+    const { secretKey } = makeAgent(agentId);
+    const ts = Date.now();
+    const nonce = "neg-nonce-5";
+    const header = signPresencePost(agentId, ts, nonce, secretKey);
+
+    const first = await makePresenceInstance(reqFor(header)).post({ activity: "idle" });
+    expect((first as any).ok).toBe(true);
+
+    const replay = await makePresenceInstance(reqFor(header)).post({ activity: "idle" });
+    expect(replay).toBeInstanceOf(Response);
+    expect(replay.status).toBe(401);
+    const body = await replay.json();
+    expect(body.error).toBe("nonce_replay_detected");
+  });
+});

--- a/test/unit/ed25519-auth.test.ts
+++ b/test/unit/ed25519-auth.test.ts
@@ -1,0 +1,157 @@
+/**
+ * ed25519-auth.test.ts — unit tests for the shared Ed25519 auth primitives
+ * module (bd ops-c4op consolidation).
+ *
+ * resources/ed25519-auth.ts has ZERO dependency on @harperfast/harper (it
+ * only imports resources/b64.ts, which is also dependency-free), so these
+ * tests import it directly — no mock.module needed.
+ *
+ * Covers the shared nonce store in isolation: pruning, replay rejection, and
+ * the cross-path closure property (a nonce recorded via the shared API is
+ * then rejected — proving there is exactly ONE store, not three). Real
+ * cross-MODULE closure (agent-auth.ts <-> Presence.ts <-> auth-middleware.ts
+ * all seeing the same recorded nonce) is covered in
+ * ed25519-auth-cross-site.test.ts and auth-middleware-ed25519.test.ts.
+ */
+import { describe, it, expect, beforeEach } from "bun:test";
+import nacl from "tweetnacl";
+import {
+  WINDOW_MS,
+  isNonceReplay,
+  recordNonce,
+  importEd25519Key,
+  b64ToArrayBuffer,
+  __clearNoncesForTest,
+} from "../../resources/ed25519-auth.ts";
+
+beforeEach(() => {
+  __clearNoncesForTest();
+});
+
+describe("WINDOW_MS", () => {
+  it("defaults to 30_000 (matches all 3 pre-consolidation sites)", () => {
+    expect(WINDOW_MS).toBe(30_000);
+  });
+});
+
+describe("isNonceReplay / recordNonce — the single shared store", () => {
+  it("a fresh (agentId, nonce) pair is not a replay", () => {
+    expect(isNonceReplay("agent-a", "nonce-1", Date.now())).toBe(false);
+  });
+
+  it("CORE CLOSURE PROPERTY: recording a nonce via the shared API makes the SAME key rejected", () => {
+    const ts = Date.now();
+    expect(isNonceReplay("agent-a", "nonce-2", ts)).toBe(false);
+    recordNonce("agent-a", "nonce-2", ts);
+    // Any caller checking the identical (agentId, nonce) — regardless of which
+    // "site" it represents — now sees a replay, because there is exactly one
+    // module-level nonceSeen Map backing both isNonceReplay and recordNonce.
+    expect(isNonceReplay("agent-a", "nonce-2", ts + 1000)).toBe(true);
+  });
+
+  it("nonceKey format is `${agentId}:${nonce}` — different agentId does not collide", () => {
+    const ts = Date.now();
+    recordNonce("agent-a", "shared-nonce", ts);
+    expect(isNonceReplay("agent-a", "shared-nonce", ts)).toBe(true);
+    expect(isNonceReplay("agent-b", "shared-nonce", ts)).toBe(false);
+  });
+
+  it("different nonce for the same agent does not collide", () => {
+    const ts = Date.now();
+    recordNonce("agent-a", "nonce-x", ts);
+    expect(isNonceReplay("agent-a", "nonce-y", ts)).toBe(false);
+  });
+
+  it("prunes entries older than WINDOW_MS — replay guard expires", () => {
+    const ts = 1_000_000;
+    recordNonce("agent-a", "nonce-3", ts);
+    expect(isNonceReplay("agent-a", "nonce-3", ts + WINDOW_MS - 1)).toBe(true);
+    // Strictly greater than WINDOW_MS is pruned (matches all 3 sites' `now - t > WINDOW_MS`).
+    expect(isNonceReplay("agent-a", "nonce-3", ts + WINDOW_MS + 1)).toBe(false);
+  });
+
+  it("pruning one expired nonce does not evict a still-fresh nonce", () => {
+    const t0 = 1_000_000;
+    recordNonce("agent-a", "old-nonce", t0);
+    const t1 = t0 + 10_000;
+    recordNonce("agent-a", "fresh-nonce", t1);
+    // Advance past old-nonce's window but within fresh-nonce's window.
+    const now = t0 + WINDOW_MS + 1;
+    expect(isNonceReplay("agent-a", "old-nonce", now)).toBe(false); // pruned
+    expect(isNonceReplay("agent-a", "fresh-nonce", now)).toBe(true); // still recorded
+  });
+});
+
+describe("importEd25519Key", () => {
+  it("imports a base64-encoded public key and verifies a real signature", async () => {
+    const kp = nacl.sign.keyPair();
+    const pubB64 = Buffer.from(kp.publicKey).toString("base64");
+    const key = await importEd25519Key(pubB64);
+
+    const message = new TextEncoder().encode("hello-ed25519-auth");
+    const sig = nacl.sign.detached(message, kp.secretKey);
+
+    const ok = await crypto.subtle.verify({ name: "Ed25519" } as any, key, sig, message);
+    expect(ok).toBe(true);
+  });
+
+  it("imports a hex-encoded public key identically", async () => {
+    const kp = nacl.sign.keyPair();
+    const pubHex = Buffer.from(kp.publicKey).toString("hex");
+    const key = await importEd25519Key(pubHex);
+
+    const message = new TextEncoder().encode("hex-key-message");
+    const sig = nacl.sign.detached(message, kp.secretKey);
+
+    const ok = await crypto.subtle.verify({ name: "Ed25519" } as any, key, sig, message);
+    expect(ok).toBe(true);
+  });
+
+  it("imports a base64url-encoded public key (unpadded) identically", async () => {
+    const kp = nacl.sign.keyPair();
+    const pubB64url = Buffer.from(kp.publicKey).toString("base64url");
+    const key = await importEd25519Key(pubB64url);
+
+    const message = new TextEncoder().encode("base64url-key-message");
+    const sig = nacl.sign.detached(message, kp.secretKey);
+
+    const ok = await crypto.subtle.verify({ name: "Ed25519" } as any, key, sig, message);
+    expect(ok).toBe(true);
+  });
+
+  it("caches by the raw key string (same CryptoKey instance on 2nd call)", async () => {
+    const kp = nacl.sign.keyPair();
+    const pubB64 = Buffer.from(kp.publicKey).toString("base64");
+    const key1 = await importEd25519Key(pubB64);
+    const key2 = await importEd25519Key(pubB64);
+    expect(key1).toBe(key2);
+  });
+
+  it("a signature from a DIFFERENT key does not verify (sanity: real crypto, not a stub)", async () => {
+    const kp1 = nacl.sign.keyPair();
+    const kp2 = nacl.sign.keyPair();
+    const key1 = await importEd25519Key(Buffer.from(kp1.publicKey).toString("base64"));
+
+    const message = new TextEncoder().encode("mismatched-key-message");
+    const sigFromKp2 = nacl.sign.detached(message, kp2.secretKey);
+
+    const ok = await crypto.subtle.verify({ name: "Ed25519" } as any, key1, sigFromKp2, message);
+    expect(ok).toBe(false);
+  });
+});
+
+describe("b64ToArrayBuffer (re-exported from b64.ts)", () => {
+  it("round-trips standard base64", () => {
+    const original = new Uint8Array([1, 2, 3, 255, 0, 128]);
+    const b64 = btoa(String.fromCharCode(...original));
+    const result = new Uint8Array(b64ToArrayBuffer(b64));
+    expect(result).toEqual(original);
+  });
+
+  it("round-trips unpadded base64url", () => {
+    const original = new Uint8Array([9, 8, 7, 6, 5, 4, 3, 2, 1, 0]);
+    const b64url = Buffer.from(original).toString("base64url");
+    const result = new Uint8Array(b64ToArrayBuffer(b64url));
+    expect(result).toEqual(original);
+  });
+});


### PR DESCRIPTION
Consolidates Flair's three independent TPS-Ed25519 replay guards + three `importEd25519Key` copies into one shared `resources/ed25519-auth.ts`. **bd ops-c4op.**

## The problem
The same signature scheme (`agentId:ts:nonce:METHOD:path`, keyed `agentId:nonce`, 30s window) was verified at three sites — `auth-middleware.ts`, `agent-auth.ts`, `Presence.ts` — each with its **own** module-level `nonceSeen` Map and its own crypto-helper copy. Three independent replay windows: a nonce recorded via one path is invisible to the other two (defense-in-depth gap), and any future fix to one copy silently skips the others (drift hazard). (`Federation.ts` keeps its own purpose-built `NonceStore` for a different signing scheme — deliberately untouched.)

## The fix
New `resources/ed25519-auth.ts` exports one module-level singleton nonce store (`isNonceReplay` / `recordNonce` / `pruneNonces`), one `importEd25519Key` (cached), one `WINDOW_MS`, re-exporting `b64ToArrayBuffer` (already unified in `b64.ts`). All three sites now import and use it; their local copies are deleted (verified: 0 remaining `new Map`/`importEd25519Key` at the 3 sites). One replay guard, no drift.

**Semantics preserved exactly** (this is a pure consolidation):
- `isNonceReplay` (check) and `recordNonce` (record) are **separate** — deliberately NOT an atomic check-and-record — because all three sites record only **after** a successful signature verify. An invalid signature never burns a nonce (no lock-out / DoS on a client that retries with a corrected sig). This matches pre-consolidation behavior at all three.
- Check order preserved at each site: timestamp-window → nonce-replay → agent lookup → verify → record.
- `nonceKey` format (`agentId:nonce`) confirmed identical across all three before merging.

## @tps-sherlock — SECURITY, this is the bead's core ask (hygiene vs. severity-bump)
The bead asks you to assess exploitability of the *pre-consolidation* three-cache state:
1. **Cross-cache replay.** In the normal HTTP path, `auth-middleware` verifies first and sets `tpsAgent`; `agent-auth` and `Presence` then *trust* it without re-verifying — so one cache is used and replays are caught. The gap is only reachable if a signed request can reach a **second** cache's own verification within 30s without the middleware. `Presence` is unconditionally allow-listed at the middleware (bypasses Ed25519 there), and `agent-auth`'s fallback is short-circuited by the middleware's `tpsAgent` annotation on every real HTTP request — so a live 3-way path may not be architecturally reachable. Your call: was it exploitable (→ bump + note for backport) or purely hygiene? Either way this PR closes it (one shared store).
2. **Concurrency TOCTOU (pre-existing, preserved).** `check → await verify → record` has an async gap: two concurrent requests with the same nonce could both pass `isNonceReplay` before either records. This existed at all three sites before and is unchanged here. Worth a follow-up bead, or acceptable given path-binding + 30s window? Your read.

## @tps-kern — architecture
- The shared-module shape (singleton store + separate check/record). 
- **WINDOW_MS env-override decision (flagged):** only `agent-auth.ts` previously read `FLAIR_AGENT_AUTH_WINDOW_MS` (undocumented, unset everywhere, unreferenced elsewhere — traces to #487's plugin-extraction intent). I kept it, applied **uniformly** to the shared window. Keep uniform / revert to agent-auth-only / drop entirely? It's a no-op today; I lean keep-uniform (one shared guard → one tunable window).

## Verification (Flint — read the diff + re-ran, not relaying the implementer)
- Read `ed25519-auth.ts` + all three sites: record-after-verify and check-order preserved, local copies gone.
- Full suite green, real Harper: **unit 1380/0, integration 145/0** (includes new `ed25519-auth.test.ts` (14), `ed25519-auth-cross-site.test.ts` (9 — real cross-module `agent-auth ↔ Presence` replay closure), and a real-Harper middleware replay test).
- Mutation-proof (implementer): `isNonceReplay`→always-false → 8 unit + 1 integration fail; reverted → green.
- Test-infra note: `auth-middleware.ts` can't be safely `mock.module`-unit-tested (its `import { server }` + bun's process-global mock collide with ~10 sibling mocks) — its replay coverage lives in the real-Harper integration suite instead (more faithful anyway). A wider sibling-mock cleanup is a separate item.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
