### PR TITLE
fix(openclaw-flair): write-new-before-close-old on supersede + observable failure (ops-mmh9)

### DIFF
--- a/packages/openclaw-flair/index.ts
+++ b/packages/openclaw-flair/index.ts
@@ -557,7 +557,39 @@ export default {
           try {
             const client = getCurrentClient();
             const memId = `${client.agentId}-${Date.now()}`;
-            // If superseding an old memory, archive it
+
+            // Write the NEW memory FIRST (ops-a4t5 discipline: write-new-
+            // BEFORE-close-old). Note: `client.memory.write()` does not
+            // forward a `supersedes` field to the server (flair-client's
+            // MemoryApi.write() opts have no such field — see client.ts),
+            // so this can't be routed through the server's transactional
+            // `Memory.put()` supersede path (closeSupersededIfNeeded) the
+            // way `client.memory.update(id, content, {preserveHistory:true})`
+            // is. Separately, that server path closes the old record via
+            // `validTo` (temporal-validity), not `archived` — and default
+            // semantic search (SemanticSearch.ts) only filters `validTo`
+            // when the caller passes `asOf` (which memory_search here does
+            // not), but unconditionally filters `archived:true`. Routing
+            // through the server would therefore leave superseded content
+            // resurfacing in ordinary recall — a regression, not a fix.
+            // So: keep the archived/supersededBy close mechanism (it's
+            // load-bearing for recall correctness — SemanticSearch.ts,
+            // MemoryConsolidate.ts, MemoryReflect.ts, AdminMemory.ts, and
+            // health.ts all key off `archived`), but apply the same
+            // write-then-close ORDERING discipline as the server fix, with
+            // a non-swallowing catch below.
+            const result = await client.memory.write(text, {
+              id: memId,
+              tags,
+              durability: durability as any,
+              type: type as any,
+              dedup: !supersedes, // skip dedup when explicitly superseding
+              dedupThreshold: 0.7,
+            });
+
+            // THEN close the superseded record, if any. Safe failure state
+            // is two active records (recoverable), never a lost write — and
+            // any failure is logged (observable), never silently swallowed.
             if (supersedes) {
               try {
                 const old = await client.memory.get(supersedes);
@@ -568,20 +600,18 @@ export default {
                     archivedAt: new Date().toISOString(),
                     supersededBy: memId,
                   });
+                } else {
+                  api.logger.warn(
+                    `openclaw-flair: supersede target ${supersedes} not found — new memory ${memId} written; nothing to close`,
+                  );
                 }
-              } catch {
-                // Old memory not found — continue with the write
+              } catch (closeErr: any) {
+                api.logger.warn(
+                  `openclaw-flair: failed to close superseded memory ${supersedes} after writing ${memId}: ${closeErr.message} ` +
+                  `(not lost — new record is safely written; old record remains active until retried)`,
+                );
               }
             }
-
-            const result = await client.memory.write(text, {
-              id: memId,
-              tags,
-              durability: durability as any,
-              type: type as any,
-              dedup: !supersedes, // skip dedup when explicitly superseding
-              dedupThreshold: 0.7,
-            });
             // The server's conservative dedup gate NEVER suppresses a write
             // (memory-integrity fix, flair#526) — `result.deduplicated` is a
             // collision SIGNAL, not a "was this dropped" flag; the content at

--- a/packages/openclaw-flair/test/plugin.test.ts
+++ b/packages/openclaw-flair/test/plugin.test.ts
@@ -2,6 +2,7 @@ import { describe, test, expect, mock, beforeEach, afterEach } from "bun:test";
 import { mkdtempSync, rmSync, writeFileSync, mkdirSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
+import { FlairClient } from "@tpsdev-ai/flair-client";
 
 // Minimal mock of OpenClawPluginApi
 function createMockApi(config: Record<string, unknown> = {}) {
@@ -571,5 +572,138 @@ describe("isValidAgentId / assertValidAgentId (ops-pnwq)", () => {
     }
     // Simpler: directly call assertValidAgentId on what would flow through.
     expect(() => assertValidAgentId("../escape")).toThrow();
+  });
+});
+
+// ─── memory_store supersede — write-then-close ordering (ops-mmh9) ──────────
+// The hand-rolled supersede used to archive the OLD record BEFORE writing the
+// NEW one — if the write then failed, the old fact was gone and the new one
+// never landed (silent loss; same class as ops-a4t5, fixed server-side in
+// resources/Memory.ts). These tests exercise the fixed ordering directly
+// against the real FlairClient class (flair-client's HTTP boundary,
+// `FlairClient.prototype.request`, is monkey-patched per test so no network
+// call is made — everything above that boundary, including memory.write()/
+// memory.get()'s real logic, runs unmodified).
+
+describe("memory_store supersede — write-then-close ordering (ops-mmh9)", () => {
+  const originalRequest = FlairClient.prototype.request;
+
+  afterEach(() => {
+    FlairClient.prototype.request = originalRequest;
+  });
+
+  test("new memory is written even when closing the superseded record fails (no data loss)", async () => {
+    const calls: Array<{ method: string; path: string; body?: any }> = [];
+    (FlairClient.prototype as any).request = async function (method: string, path: string, body?: any) {
+      calls.push({ method, path, body });
+      if (method === "GET" && path === "/Memory/old-mem-1") {
+        return { id: "old-mem-1", content: "old fact", agentId: "test-agent" };
+      }
+      if (method === "PUT" && path === "/Memory/old-mem-1") {
+        throw new Error("simulated close failure");
+      }
+      // Any other PUT is the new-memory write — let it succeed.
+      return { written: true };
+    };
+
+    const plugin = (await import("../index.ts")).default;
+    const api = createMockApi();
+    plugin.register(api as any);
+
+    const tool = api._tools.get("memory_store")!;
+    const result = await tool.execute("test", { text: "new fact", supersedes: "old-mem-1" });
+
+    // The new memory must still be reported as written — the close failure
+    // must not propagate into the tool's error branch.
+    expect(result.details.written).toBe(true);
+    expect(result.content[0].text).toContain("Memory stored");
+    expect(result.content[0].text).not.toContain("unavailable");
+
+    // Ordering: the new-memory PUT happened BEFORE the close attempt
+    // (get-old, then put-old) — write-new-BEFORE-close-old.
+    const newWriteIdx = calls.findIndex((c) => c.method === "PUT" && c.path !== "/Memory/old-mem-1");
+    const closeGetIdx = calls.findIndex((c) => c.method === "GET" && c.path === "/Memory/old-mem-1");
+    const closePutIdx = calls.findIndex((c) => c.method === "PUT" && c.path === "/Memory/old-mem-1");
+    expect(newWriteIdx).toBeGreaterThanOrEqual(0);
+    expect(closeGetIdx).toBeGreaterThan(newWriteIdx);
+    expect(closePutIdx).toBeGreaterThan(closeGetIdx);
+
+    // The close failure must be observable (logged), never silently swallowed.
+    const warnCalls = (api.logger.warn as any).mock.calls;
+    const sawCloseFailureWarning = warnCalls.some((args: any[]) =>
+      String(args[0]).includes("failed to close superseded memory"),
+    );
+    expect(sawCloseFailureWarning).toBe(true);
+  });
+
+  test("happy path: supersede writes the new memory AND closes the old one", async () => {
+    const calls: Array<{ method: string; path: string; body?: any }> = [];
+    (FlairClient.prototype as any).request = async function (method: string, path: string, body?: any) {
+      calls.push({ method, path, body });
+      if (method === "GET" && path === "/Memory/old-mem-2") {
+        return { id: "old-mem-2", content: "old fact", agentId: "test-agent" };
+      }
+      return { written: true };
+    };
+
+    const plugin = (await import("../index.ts")).default;
+    const api = createMockApi();
+    plugin.register(api as any);
+
+    const tool = api._tools.get("memory_store")!;
+    const result = await tool.execute("test", { text: "new fact v2", supersedes: "old-mem-2" });
+
+    expect(result.details.written).toBe(true);
+
+    const newWriteIdx = calls.findIndex((c) => c.method === "PUT" && c.path !== "/Memory/old-mem-2");
+    const closePutIdx = calls.findIndex((c) => c.method === "PUT" && c.path === "/Memory/old-mem-2");
+    expect(newWriteIdx).toBeGreaterThanOrEqual(0);
+    expect(closePutIdx).toBeGreaterThan(newWriteIdx);
+
+    const closingPut = calls[closePutIdx];
+    expect(closingPut.body.archived).toBe(true);
+    expect(typeof closingPut.body.archivedAt).toBe("string");
+    expect(closingPut.body.supersededBy).toBeDefined();
+  });
+
+  test("supersede write bypasses dedup (dedup hint is false when supersedes is set)", async () => {
+    const calls: Array<{ method: string; path: string; body?: any }> = [];
+    (FlairClient.prototype as any).request = async function (method: string, path: string, body?: any) {
+      calls.push({ method, path, body });
+      if (method === "GET" && path === "/Memory/old-mem-3") {
+        return { id: "old-mem-3", content: "old fact", agentId: "test-agent" };
+      }
+      return { written: true };
+    };
+
+    const plugin = (await import("../index.ts")).default;
+    const api = createMockApi();
+    plugin.register(api as any);
+
+    const tool = api._tools.get("memory_store")!;
+    await tool.execute("test", { text: "new fact v3", supersedes: "old-mem-3" });
+
+    const newWritePut = calls.find((c) => c.method === "PUT" && c.path !== "/Memory/old-mem-3");
+    expect(newWritePut).toBeDefined();
+    expect(newWritePut!.body.dedup).toBe(false);
+  });
+
+  test("non-supersede write still requests dedup (dedup hint is true when supersedes is absent)", async () => {
+    const calls: Array<{ method: string; path: string; body?: any }> = [];
+    (FlairClient.prototype as any).request = async function (method: string, path: string, body?: any) {
+      calls.push({ method, path, body });
+      return { written: true };
+    };
+
+    const plugin = (await import("../index.ts")).default;
+    const api = createMockApi();
+    plugin.register(api as any);
+
+    const tool = api._tools.get("memory_store")!;
+    await tool.execute("test", { text: "plain fact, no supersede" });
+
+    const writePut = calls.find((c) => c.method === "PUT");
+    expect(writePut).toBeDefined();
+    expect(writePut!.body.dedup).toBe(true);
   });
 });


### PR DESCRIPTION
Fixes the openclaw-flair supersede close-before-write anti-pattern (**ops-mmh9**) — the same non-transactional loss class as ops-a4t5, on the client-side path the server fix didn't cover.

## The bug
`packages/openclaw-flair/index.ts`'s `memory_store` tool, when `supersedes` was set, **closed the old record first** (PUT `archived:true`) and only then wrote the new memory — with the close wrapped in an empty `catch {}`. If the new write failed after the archive succeeded: old archived, new lost, failure swallowed.

## The fix (write-new-before-close-old + observable failure)
Flipped the order: `client.memory.write()` (new) runs **first, unconditionally**; the archive-old block runs **after**, in a catch that `logger.warn`s on failure. Safe failure state is now two active records (recoverable), never a lost write. Mirrors ops-a4t5's server-side discipline on the client call site. `dedup: !supersedes` intent preserved.

## Why local write-before-close, not routing through the server's supersede
Two reasons, both run to ground (not assumed):
1. `client.memory.write()` does **not** forward a `supersedes` field (flair-client's `MemoryApi.write()` has no such opt) — the prerequisite gap the bead anticipated.
2. Deeper: the server closes supersedes via `validTo`, and recall (`SemanticSearch`) excludes `archived` **unconditionally** but only drops `validTo`/superseded records when the *superseding record is co-present in the results* (or an `asOf` is passed). openclaw's `archived` mechanism is strictly more reliable at keeping stale out of recall. Routing to the server would have *weakened* stale-exclusion — a real regression, not cosmetic.

## Field-semantics check
- `supersededBy` (set on old): read by **nothing** (grepped repo — dead data, safe).
- `archived` (set on old): **load-bearing** — `SemanticSearch` recall filter, `MemoryConsolidate`/`Reflect` candidate skip, `AdminMemory` list, `health.ts` counts. Kept it; switching to `validTo` would be a user-visible recall regression.

## Tests (4 new, `test/plugin.test.ts`)
Monkey-patch `FlairClient.prototype.request` (real client logic, no network): new memory written even when close throws + correct ordering + `logger.warn` fired (observable); happy-path both writes + archived PUT body; dedup false with supersedes; dedup true without. **40/0** in openclaw-flair; full monorepo delta is +4 passing (the 5 pre-existing fails / 2 errors confirmed on baseline `main`).

**Spun off ops-9rc6 (P2):** the co-presence-dependent server-supersede recall behavior this surfaced — worth Kern confirming whether server-superseded records can resurface in recall.

@tps-sherlock — data-integrity/supersede. @tps-kern — the approach decision + ops-9rc6.
