### PR TITLE
fix(memory): dedup $distance fallback for Harper singleton-cosine-result gap (ops-ume4)

### DIFF
--- a/resources/Memory.ts
+++ b/resources/Memory.ts
@@ -9,6 +9,7 @@ import {
   DEDUP_LEXICAL_THRESHOLD_DEFAULT,
   DEDUP_MIN_CONTENT_LENGTH,
   computeMatchConfidence,
+  cosineSimilarity,
   isConservativeMatch,
   type DedupMatch,
 } from "./dedup.js";
@@ -111,7 +112,62 @@ async function findConservativeDedupMatch(
       break; // single top-cosine candidate only — never fall back further
     }
     if (!top) return null;
-    const cosine = 1 - (top.$distance ?? 1);
+
+    // ─── ops-ume4: Harper's cosine-sort query omits $distance for a SINGLETON
+    // result set ─────────────────────────────────────────────────────────────
+    // Initial working theory was a per-agentId HNSW "cold-start" (first-ever
+    // query cold, second query warm) and the initially-recommended fix was a
+    // same-query retry. Empirically FALSIFIED: a plain retry of the identical
+    // query, 8x with 300ms delays (2.4s total), never recovered a `$distance`
+    // for a genuinely singleton candidate set (exactly one record matching
+    // `agentId equals X AND archived not_equal true`). The actual trigger,
+    // confirmed by direct probing: when this query's post-filter result set
+    // has exactly ONE matching record, `$distance` comes back `undefined` for
+    // it — regardless of how many prior queries have run for that agentId,
+    // how long you wait, or how many other agentIds/records already exist in
+    // the table. The moment a SECOND matching record exists, `$distance` is
+    // populated correctly on the very first query ever issued for that
+    // agentId — no warm-up needed. In practice the singleton case is exactly
+    // an agent's SECOND-ever memory (compared against their first) — the most
+    // common real-world trigger for this bug, and why it looked "permanent
+    // per-agent for the first near-dup query."
+    //
+    // Also NOT a query-shape/conditions issue: the `{operator:"or"}` wrap
+    // SemanticSearch.ts uses elsewhere is unrelated, and neither raising
+    // `limit` past 1 nor changing the conditions shape changes the result —
+    // confirmed empirically. Harper's SORT ordering is correct even in the
+    // singleton case (the right record comes back as `top`); only the
+    // numeric `$distance` annotation is missing. Also confirmed: selecting
+    // "embedding" directly on THIS sort-by-embedding query does not help
+    // either — it comes back as a bare scalar (Harper appears to special-case
+    // the sort attribute in `select`), not the stored vector.
+    //
+    // Fix: when `$distance` is undefined, fetch the ONE candidate's full
+    // record by id (a plain point lookup — not a vector-sort query, so
+    // unaffected by the quirk above) and compute cosine similarity ourselves
+    // in JS from its real stored `embedding` vector against this write's own
+    // `embedding` (this function's parameter), via the same math Harper would
+    // have used (dedup.ts's cosineSimilarity, Harper-free and unit-tested).
+    // This sidesteps the underlying engine quirk entirely rather than
+    // depending on its timing, and works identically whether this is the
+    // agent's first query ever or its thousandth. Never suppresses the write
+    // either way: if the candidate's embedding is somehow also missing (e.g.
+    // a legacy record written before embeddings existed), `cosineSimilarity`
+    // returns 0 — the same safe "no match" signal the pre-fix `?? 1`
+    // fallback produced.
+    let cosine: number;
+    if (top.$distance !== undefined) {
+      cosine = 1 - top.$distance;
+    } else {
+      console.error(
+        "Memory.findConservativeDedupMatch: $distance undefined on a singleton cosine result (ops-ume4) — " +
+        "falling back to a manual cosine computation from the candidate's stored embedding",
+        { agentId, candidateId: top.id },
+      );
+      const fullCandidate = await withDetachedTxn(ctx, () => (databases as any).flair.Memory.get(top.id));
+      const candidateEmbedding = Array.isArray(fullCandidate?.embedding) ? fullCandidate.embedding : [];
+      cosine = cosineSimilarity(embedding, candidateEmbedding);
+    }
     const confidence = computeMatchConfidence(contentText, top.content, cosine);
     if (!isConservativeMatch(confidence.cosine, confidence.lexical, cosineThreshold, lexicalThreshold)) {
       return null;

--- a/resources/dedup.ts
+++ b/resources/dedup.ts
@@ -36,6 +36,26 @@ export interface DedupMatch {
   lexical: number;
 }
 
+/**
+ * Cosine similarity of two equal-length embedding vectors, computed directly
+ * in JS. Used as a fallback (ops-ume4) when Harper's HNSW cosine-sort query
+ * doesn't attach a computed `$distance` to its top candidate — see
+ * findConservativeDedupMatch in ./Memory.ts for when/why. A mismatched
+ * length, empty vector, or zero-magnitude side yields 0 (no signal, never
+ * treated as "identical" by a degenerate computation).
+ */
+export function cosineSimilarity(a: number[], b: number[]): number {
+  if (!Array.isArray(a) || !Array.isArray(b) || a.length === 0 || a.length !== b.length) return 0;
+  let dot = 0, normA = 0, normB = 0;
+  for (let i = 0; i < a.length; i++) {
+    dot += a[i] * b[i];
+    normA += a[i] * a[i];
+    normB += b[i] * b[i];
+  }
+  if (normA === 0 || normB === 0) return 0;
+  return dot / (Math.sqrt(normA) * Math.sqrt(normB));
+}
+
 /** Jaccard similarity of two token sets: |A∩B| / |A∪B|. An empty side yields 0
  *  (no signal — never treated as "fully similar" by vacuous set equality). */
 export function jaccardSimilarity(tokensA: string[], tokensB: string[]): number {

--- a/test/integration/dedup-supersede-e2e.test.ts
+++ b/test/integration/dedup-supersede-e2e.test.ts
@@ -97,65 +97,44 @@ async function registerAgent(harper: HarperInstance, agent: TestAgent): Promise<
 /**
  * ═══════════════════════════════════════════════════════════════════════════
  * DISCOVERED BEHAVIORAL DIVERGENCE (real Harper vs. the mocked unit suite) —
- * ops-2gby's whole reason for existing. Reported in full in the task
- * writeup; summarized here so the workaround below is self-explanatory.
+ * ops-2gby's original reason for existing, RESOLVED by ops-ume4.
  *
  * test/unit/memory-integrity.test.ts's in-memory mock computes the cosine
  * "$distance" synchronously in plain JS (a real, always-populated number) for
  * every query. Real Harper's HNSW-backed `sort: {attribute:"embedding",
  * distance:"cosine"}` query, when combined with a `conditions` filter (e.g.
  * `agentId equals X` — exactly findConservativeDedupMatch's shape in
- * resources/Memory.ts), does NOT behave this way: live probes against this
- * harness showed the FIRST such query issued for a GIVEN agentId value (per
- * Harper process — a fresh agentId is cold again even after OTHER agentIds
- * have already "warmed up" their own queries; confirmed with two
- * independently-fresh agents in the same running Harper instance, both cold
- * on their own first query and both fixed by their own second) returns a
- * candidate record whose `$distance` field is `undefined` (present as an
- * object key, but with no value) — even for a BYTE-IDENTICAL duplicate.
- * findConservativeDedupMatch computes `const cosine = 1 - (top.$distance ??
- * 1)`, so an undefined `$distance` silently resolves to `cosine = 0` — below
- * any sane threshold — meaning EVERY agent's very first near-duplicate
- * comparison, ever, is GUARANTEED to be flagged `deduplicated: false`
- * regardless of true similarity. That agent's SECOND and all subsequent
- * HNSW-cosine queries reliably return a real, correctly-populated
- * `$distance` (confirmed by re-running the same comparison shape repeatedly
- * — attempt 0 broken, attempt 1+ consistently working, across multiple
- * independent Harper instances AND multiple independent agentIds).
+ * resources/Memory.ts), does NOT behave this way: when that query's
+ * post-filter result set has exactly ONE matching record (a SINGLETON
+ * candidate set — in practice, an agent's SECOND-ever memory compared
+ * against its first), `$distance` comes back `undefined` for it — even for a
+ * BYTE-IDENTICAL duplicate — regardless of how many prior queries have run
+ * for that agentId or how long you wait. The moment a SECOND matching record
+ * exists, `$distance` is populated correctly, even on the very first query
+ * ever issued for that agentId. findConservativeDedupMatch previously
+ * computed `const cosine = 1 - (top.$distance ?? 1)`, so the undefined
+ * `$distance` silently resolved to `cosine = 0` — below any sane threshold —
+ * meaning EVERY agent's very first near-duplicate comparison, ever, was
+ * GUARANTEED to be flagged `deduplicated: false` regardless of true
+ * similarity (ops-ume4).
  *
- * This is NOT the never-suppress write-safety invariant breaking — the
- * WRITE always lands (confirmed in every probe). It is the `deduplicated`
- * SIGNAL silently failing to fire on literally the first opportunity it
- * ever gets for a given agent, which is exactly the shape of bug a
- * synchronous, always-correct mock can never surface. Production impact:
- * EVERY agent's very first near-duplicate write, following its very first
- * memory write ever, will never be flagged — not a one-time cold-start cost,
- * but a permanent per-agent miss on write #1's dedup check.
+ * This was NOT the never-suppress write-safety invariant breaking — the
+ * WRITE always landed. It was the `deduplicated` SIGNAL silently failing to
+ * fire on literally the first opportunity it ever gets for a given agent,
+ * which is exactly the shape of bug a synchronous, always-correct mock can
+ * never surface.
  *
- * warmUpAgentDedupGate() below deliberately BURNS that agent's first, broken
- * query on disposable scratch records under the SAME agentId that will be
- * used for the real assertion-bearing writes — a real write + real
- * comparison against real Harper, not a stub — so Scenario 2 asserts the
- * co-gate's STEADY-STATE (2nd-query-onward) behavior for that agent, rather
- * than the guaranteed-miss its actual first-ever query would hit. Reported
- * as the headline integration finding; the underlying fix belongs in
- * resources/Memory.ts (out of scope for this test-only change — see the
- * task report).
+ * FIXED in resources/Memory.ts's findConservativeDedupMatch: when
+ * `$distance` comes back undefined, it now fetches the one candidate's full
+ * record by id (a plain point lookup, unaffected by the sort-query quirk
+ * above) and computes cosine similarity itself in JS from the real stored
+ * embedding vectors (dedup.ts's cosineSimilarity). No warm-up write is
+ * needed any more — Scenario 2 below now asserts this directly on a
+ * completely fresh agent's first-ever near-dup comparison. (The formerly-used
+ * warmUpAgentDedupGate() workaround is removed — see git history for its
+ * implementation if you need the pre-fix reproduction shape.)
  * ═══════════════════════════════════════════════════════════════════════════
  */
-async function warmUpAgentDedupGate(harper: HarperInstance, agent: TestAgent): Promise<void> {
-  const WARM_TEXT = "Warm-up content for the dedup cosine gate, needs to be long enough to clear the length floor.";
-  await putMemory(harper, agent, `${agent.id}-warmup-seed`, { agentId: agent.id, content: WARM_TEXT, durability: "standard" });
-  for (let attempt = 0; attempt < 20; attempt++) {
-    const res = await putMemory(harper, agent, `${agent.id}-warmup-probe-${attempt}`, {
-      agentId: agent.id, content: WARM_TEXT, durability: "standard", dedupThreshold: 0.5, lexicalThreshold: 0.5,
-    });
-    const body: any = await res.json().catch(() => ({}));
-    if (body.deduplicated === true) return;
-    await new Promise((r) => setTimeout(r, 300));
-  }
-  throw new Error(`warmUpAgentDedupGate: agent ${agent.id} never observed a working $distance after 20 attempts`);
-}
 
 /**
  * Secondary, separate concern from the cold-start bug above: even once the
@@ -269,10 +248,17 @@ describe("dedup / supersede / memory_update e2e (real Harper, ops-2gby)", () => 
   }, 60_000);
 
   // ═══════════════════════════════════════════════════════════════════════
-  // Scenario 2 — never-silent-loss: a true near-duplicate is FLAGGED
-  // (deduplicated:true + matchedId) but STILL written as a brand-new record
-  // with the reworded content intact (never swapped for the old record's
-  // content). Jaccard/lexical overlap between FINDING_A and
+  // Scenario 2 — never-silent-loss AND ops-ume4 regression guard: a true
+  // near-duplicate is FLAGGED (deduplicated:true + matchedId) but STILL
+  // written as a brand-new record with the reworded content intact (never
+  // swapped for the old record's content). This agent's near-dup write below
+  // is its SECOND memory ever (compared against its first, idOrig) — exactly
+  // the singleton-candidate-set query ops-ume4 fixed (before the fix, this
+  // exact shape was a GUARANTEED miss: `deduplicated:false` regardless of
+  // true similarity, on every fresh agent's first near-dup comparison, with
+  // no warm-up query able to change that). No warm-up write precedes this
+  // one — that IS the regression proof: this test fails on pre-fix code.
+  // Jaccard/lexical overlap between FINDING_A and
   // FINDING_A_REWORDED is real and high (same math the unit test pins
   // >= 0.5). The cosine side is exercised against the REAL embedding model —
   // dedupThreshold is passed as an explicit, permissive per-write tuning
@@ -283,16 +269,9 @@ describe("dedup / supersede / memory_update e2e (real Harper, ops-2gby)", () => 
   // + real HNSW cosine search + real jaccard) wired correctly, using the
   // exact knob production callers use to tune it.
   // ═══════════════════════════════════════════════════════════════════════
-  test("Scenario 2: a true near-duplicate is flagged deduplicated:true + matchedId, AND still written as a new record with the reworded content", async () => {
+  test("Scenario 2 (ops-ume4): a FRESH agent's FIRST-EVER near-duplicate write is flagged deduplicated:true + matchedId, AND still written as a new record with the reworded content", async () => {
     const agent = mkAgent(`dedup-nearmatch-${randomUUID()}`);
     await registerAgent(harper, agent);
-
-    // See warmUpAgentDedupGate's doc comment: THIS agent's first-ever
-    // HNSW-cosine dedup query is a guaranteed miss (real Harper bug) — burn
-    // it on disposable scratch content before the real assertion-bearing
-    // writes below, so this test asserts the co-gate's steady-state
-    // behavior for this agent rather than its guaranteed-broken debut query.
-    await warmUpAgentDedupGate(harper, agent);
 
     const idOrig = `${agent.id}-orig`;
     const idReword = `${agent.id}-reword`;
@@ -330,10 +309,22 @@ describe("dedup / supersede / memory_update e2e (real Harper, ops-2gby)", () => 
     expect(bodyReword.written).toBe(true);
     expect(bodyReword.id).toBe(idReword);
 
-    // The collision signal fired against the REAL top-cosine candidate.
+    // The collision signal fired against the REAL top-cosine candidate. Per
+    // ops-ume4: this query's underlying result set is a SINGLETON (exactly
+    // one candidate, idOrig) — the case where Harper's raw `$distance` field
+    // itself is undefined BY DESIGN (that never changes; findConservativeDedupMatch's
+    // fix doesn't make Harper populate it, it computes cosine itself from the
+    // stored embedding vectors instead — see resources/Memory.ts's doc
+    // comment). So the correct regression assertion here is NOT "$distance is
+    // a real number" (it structurally isn't, for this exact query shape) —
+    // it's that the SIGNAL this function computes (matchConfidence.cosine)
+    // is a real, non-zero number reflecting genuine similarity (not the
+    // pre-fix sentinel of exactly 0, which a real-but-undefined-$distance
+    // forces via `1 - (undefined ?? 1)`).
     expect(bodyReword.deduplicated).toBe(true);
     expect(bodyReword.matchedId).toBe(idOrig);
     expect(typeof bodyReword.matchConfidence?.cosine).toBe("number");
+    expect(bodyReword.matchConfidence.cosine).not.toBe(0);
     expect(bodyReword.matchConfidence.cosine).toBeGreaterThanOrEqual(0.6);
     expect(bodyReword.matchConfidence.lexical).toBeGreaterThanOrEqual(0.5);
 

--- a/test/unit/memory-integrity.test.ts
+++ b/test/unit/memory-integrity.test.ts
@@ -66,6 +66,13 @@ let memoryStore: Map<string, any>;
 let memoryGrants: any[];
 let callOrder: string[];
 let idCounter: number;
+// ops-ume4 simulation switch: when true, memorySearchGen's cosine-sort branch
+// omits `$distance` from every candidate (real Harper's observed behavior for
+// a SINGLETON cosine-query result set) instead of computing a real one —
+// letting the "ops-ume4 fallback" describe block below exercise
+// findConservativeDedupMatch's manual-cosine fallback deterministically,
+// without needing a live Harper.
+let forceUndefinedDistance = false;
 
 function memorySearchGen(query: any) {
   let records = Array.from(memoryStore.values());
@@ -79,9 +86,13 @@ function memorySearchGen(query: any) {
   for (const cond of conditions) records = records.filter((r) => matchesCondition(r, cond));
   if (query?.sort?.attribute === "embedding" && query.sort.distance === "cosine") {
     const target = query.sort.target;
-    records = records
-      .map((r) => ({ ...r, $distance: Array.isArray(r.embedding) ? 1 - cosineSim(r.embedding, target) : 1 }))
-      .sort((a, b) => a.$distance - b.$distance);
+    if (forceUndefinedDistance) {
+      records = records.map((r) => ({ ...r, $distance: undefined }));
+    } else {
+      records = records
+        .map((r) => ({ ...r, $distance: Array.isArray(r.embedding) ? 1 - cosineSim(r.embedding, target) : 1 }))
+        .sort((a, b) => a.$distance - b.$distance);
+    }
   }
   const limit = typeof query?.limit === "number" ? query.limit : undefined;
   const sliced = limit !== undefined ? records.slice(0, limit) : records;
@@ -159,7 +170,7 @@ const databasesMock = {
 mock.module("@harperfast/harper", () => ({ databases: databasesMock, Resource: class {} }));
 
 const { Memory } = await import("../../resources/Memory.ts");
-const { jaccardSimilarity, isConservativeMatch, computeMatchConfidence } = await import("../../resources/dedup.ts");
+const { jaccardSimilarity, isConservativeMatch, computeMatchConfidence, cosineSimilarity } = await import("../../resources/dedup.ts");
 const { tokenize } = await import("../../resources/bm25.ts");
 
 function makeMemory(ctxRequest: any) {
@@ -175,6 +186,7 @@ beforeEach(() => {
   memoryGrants = [];
   callOrder = [];
   idCounter = 0;
+  forceUndefinedDistance = false;
 });
 
 // ─── Fixture text for the #526 replay ────────────────────────────────────────
@@ -216,6 +228,26 @@ describe("dedup co-gate — pure math (resources/dedup.ts)", () => {
   it("jaccardSimilarity of two empty/no-overlap sets is 0, never treated as a match", () => {
     expect(jaccardSimilarity([], [])).toBe(0);
     expect(jaccardSimilarity(["a", "b"], [])).toBe(0);
+  });
+
+  // cosineSimilarity backs the ops-ume4 fallback in findConservativeDedupMatch
+  // (resources/Memory.ts) — computed directly in JS when Harper's cosine-sort
+  // query doesn't attach a $distance (see that function's doc comment).
+  it("cosineSimilarity: identical vectors → 1, orthogonal vectors → 0", () => {
+    expect(cosineSimilarity([1, 0, 0, 0], [1, 0, 0, 0])).toBeCloseTo(1, 10);
+    expect(cosineSimilarity([1, 0, 0, 0], [0, 1, 0, 0])).toBe(0);
+  });
+
+  it("cosineSimilarity: a known non-trivial angle computes the exact expected value", () => {
+    const a = [1, 0, 0, 0];
+    const near = [0.9, Math.sqrt(1 - 0.81), 0, 0]; // unit vector
+    expect(cosineSimilarity(a, near)).toBeCloseTo(0.9, 10);
+  });
+
+  it("cosineSimilarity: mismatched length, empty, or zero-magnitude vectors safely yield 0 (never a false 'identical')", () => {
+    expect(cosineSimilarity([1, 2], [1, 2, 3])).toBe(0);
+    expect(cosineSimilarity([], [])).toBe(0);
+    expect(cosineSimilarity([0, 0, 0], [1, 2, 3])).toBe(0);
   });
 });
 
@@ -311,6 +343,54 @@ describe("Memory.post — server-side dedup gate never suppresses a write", () =
     expect(res instanceof Response).toBe(true);
     expect((res as Response).status).toBe(401);
     expect(memoryStore.size).toBe(0);
+  });
+});
+
+// ─── ops-ume4: findConservativeDedupMatch's manual-cosine fallback ───────────
+// Real Harper's cosine-sort query omits `$distance` (comes back `undefined`)
+// when its post-filter result set is a SINGLETON — in practice, an agent's
+// SECOND-ever memory compared against its first. That behavior can't be
+// reproduced by memorySearchGen's default mock, which always computes a
+// real $distance (see this file's top-of-file doc comment) — so this block
+// flips forceUndefinedDistance to simulate exactly that shape and proves
+// findConservativeDedupMatch's fallback (resources/Memory.ts: fetch the
+// candidate's full record and compute cosine manually via dedup.ts's
+// cosineSimilarity) fires correctly. See
+// test/integration/dedup-supersede-e2e.test.ts's Scenario 2 for the same
+// behavior proven against REAL Harper.
+describe("ops-ume4: findConservativeDedupMatch falls back to a manual cosine computation when $distance is undefined", () => {
+  it("a near-duplicate whose ONLY candidate has $distance undefined is still correctly flagged (real cosine, not the pre-fix 0 sentinel)", async () => {
+    const m1 = makeMemory(agentCtx("agent-1"));
+    const r1 = await m1.post({ agentId: "agent-1", content: FINDING_A });
+    expect(r1.written).toBe(true);
+
+    forceUndefinedDistance = true;
+    const m2 = makeMemory(agentCtx("agent-1"));
+    const r2 = await m2.post({ agentId: "agent-1", content: FINDING_A_REWORDED });
+    forceUndefinedDistance = false;
+
+    expect(r2.written).toBe(true); // never-suppress invariant
+    expect(r2.deduplicated).toBe(true);
+    expect(r2.matchedId).toBe(r1.id);
+    // This mock's getEmbedding() returns the SAME constant vector for every
+    // input (file-level FAKE_EMBEDDING), so a correctly-firing fallback
+    // computes cosine === 1 exactly. The pre-fix code (`1 - (undefined ?? 1)`)
+    // would have computed cosine === 0 here instead, forcing
+    // deduplicated:false regardless of true similarity — this is the
+    // regression the fallback closes.
+    expect(r2.matchConfidence.cosine).toBe(1);
+  });
+
+  it("if the candidate's stored embedding is ALSO missing (legacy record), the fallback safely yields cosine 0 — never suppresses the write", async () => {
+    memoryStore.set("legacy-1", { id: "legacy-1", agentId: "agent-1", content: FINDING_A, archived: false });
+
+    forceUndefinedDistance = true;
+    const m2 = makeMemory(agentCtx("agent-1"));
+    const r2 = await m2.post({ agentId: "agent-1", content: FINDING_A_REWORDED });
+    forceUndefinedDistance = false;
+
+    expect(r2.written).toBe(true); // never-suppress invariant, even in this double-degenerate case
+    expect(r2.deduplicated).toBe(false); // cosineSimilarity(embedding, []) === 0 — safe no-match signal
   });
 });
 


### PR DESCRIPTION
Fixes **ops-ume4** — the dedup `deduplicated` signal silently failing (found by the ops-2gby real-Harper e2e test).

## Empirical finding: the diagnosis changed
Kern's initial read was a per-agent HNSW **cold-start** (first query cold, retry to warm). The subagent implemented that retry exactly and **empirically falsified it**: a plain retry (8× / 2.4s) *never* recovers `$distance` for a genuinely singleton candidate set. Direct probing found the real trigger: **Harper omits `$distance` when the cosine-sort query's post-filter result set has exactly ONE matching record** — regardless of query count, elapsed time, or how many other records/agents exist. The moment a *second* matching record exists, `$distance` populates on the very first query. In practice the singleton case is an agent's **second-ever memory** (compared against its first) — which is exactly why it looked "permanent, first near-dup per agent." Sort ordering is correct even in the singleton case; only the numeric `$distance` annotation is missing. (Not a conditions-shape issue either — the `{operator:or}` wrap is unrelated; confirmed.)

## The fix (defensive — correct regardless of root cause)
In `findConservativeDedupMatch`: when `top.$distance` is `undefined`, point-lookup the candidate (`Memory.get`, unaffected by the sort-query quirk) and compute cosine directly via a new Harper-free `cosineSimilarity()` in `resources/dedup.ts`. Never suppresses the write; a missing candidate embedding safely yields 0 (same as the old `?? 1` sentinel).

## Verification (real Harper, mine + the subagent's)
- **Empirical proof:** 3/3 fresh agents' second-ever write — before: `deduplicated:false`, no match; after: `deduplicated:true`, `matchConfidence.cosine 0.974` (matches Harper's native value in the non-broken 2-candidate case).
- **Full suite (I re-ran on the clean branch):** unit **1391/0**, integration **151/0**.
- **`warmUpAgentDedupGate()` removed** from the e2e test — scenario 2 now directly asserts a fresh agent's first near-dup is flagged (fails pre-fix, passes post-fix, no workaround).

## Flagged (separate — ops-syzm, P2)
`SemanticSearch.ts` (~line 342) has the **identical** `record.$distance ?? 1` pattern — very likely the same singleton bug in recall *scoring* (a singleton/tiny result set gets mis-scored as maximally-distant). Out of scope here (dedup path only); same fix applies.

@tps-kern — your cold-start theory was empirically falsified; please confirm the corrected diagnosis (singleton-result-set). The fix is defensive so it's correct either way, but the root-cause writeup is in the code comment for your review. @tps-sherlock — correctness of the fallback (never suppresses, safe degenerate).
