### PR TITLE
feat(memory): private/shared visibility + centralized cross-agent read-scoping (ops-2dm3 Layer 1)

### DIFF
--- a/packages/flair-client/src/client.ts
+++ b/packages/flair-client/src/client.ts
@@ -16,6 +16,7 @@ import type {
   Memory,
   MemoryType,
   Durability,
+  Visibility,
   SoulEntry,
   SearchResult,
   BootstrapResult,
@@ -145,6 +146,12 @@ class MemoryApi {
     durability?: Durability;
     tags?: string[];
     subject?: string;
+    /** Writer-controlled sharing intent. Omit to let the
+     *  server apply its durability-keyed default (permanent/persistent →
+     *  shared, standard/ephemeral → private) — only forwarded when the
+     *  caller explicitly sets it, so omitting this is a no-op change from
+     *  today's behavior. */
+    visibility?: Visibility;
     /** Ask the server to run its conservative near-duplicate check for this
      *  write and report a collision signal if found. Does NOT suppress the
      *  write either way. Default: false (server still applies its own
@@ -166,6 +173,11 @@ class MemoryApi {
       subject: opts.subject,
       createdAt: new Date().toISOString(),
     };
+    // Forward visibility ONLY when the caller set it — an unset visibility
+    // must reach the server as "absent" (not e.g. defaulted client-side) so
+    // the server's durability-keyed default (Memory.post/put) is the one
+    // source of truth for the default, never duplicated here.
+    if (opts.visibility !== undefined) record.visibility = opts.visibility;
     // Passthrough hints — the server strips these before persisting; they are
     // never stored on the record itself.
     if (opts.dedup !== undefined) record.dedup = opts.dedup;

--- a/packages/flair-client/src/index.ts
+++ b/packages/flair-client/src/index.ts
@@ -5,6 +5,7 @@ export type {
   Memory,
   MemoryType,
   Durability,
+  Visibility,
   SoulEntry,
   SearchResult,
   BootstrapResult,

--- a/packages/flair-client/src/types.ts
+++ b/packages/flair-client/src/types.ts
@@ -8,6 +8,16 @@ export type Durability = "permanent" | "persistent" | "standard" | "ephemeral";
 /** Memory type classification. */
 export type MemoryType = "session" | "lesson" | "decision" | "preference" | "fact" | "goal";
 
+/**
+ * Writer-controlled sharing intent. "private" — owner only,
+ * never returned to another agent even if that agent holds a MemoryGrant.
+ * "shared" — visible to owner + any grant-holder (subject to the grant's
+ * scope). When unset on write, the server defaults it from `durability`:
+ * permanent/persistent → shared, standard/ephemeral/absent → private. An
+ * explicit value here always overrides the server default.
+ */
+export type Visibility = "private" | "shared";
+
 /** A memory record. */
 export interface Memory {
   id: string;
@@ -17,6 +27,11 @@ export interface Memory {
   durability: Durability;
   tags: string[];
   subject?: string;
+  /** Writer-controlled sharing intent. Absent on records written before this
+   *  field existed — the server treats absence as "shared" (migration-
+   *  invariant: an existing memory keeps reading to exactly whoever holds a
+   *  grant today), never as "private". */
+  visibility?: Visibility;
   createdAt: string;
   updatedAt?: string;
   /** Always true after a successful write()/update() — the server never

--- a/packages/flair-client/test/client.test.ts
+++ b/packages/flair-client/test/client.test.ts
@@ -193,6 +193,42 @@ describe("MemoryApi", () => {
     expect((result as any).written).toBe(true);
   });
 
+  test("write() forwards visibility ONLY when the caller sets it (ops-2dm3 Layer 1)", async () => {
+    mockFetch = mock(() => Promise.resolve(new Response("{}", { status: 200 })));
+    globalThis.fetch = mockFetch as any;
+
+    const client = new FlairClient({ agentId: "test" });
+    await client.memory.write("content long enough to matter", { visibility: "private" });
+
+    const call = (mockFetch as any).mock.calls[0];
+    const body = JSON.parse(call[1].body);
+    expect(body.visibility).toBe("private");
+  });
+
+  test("write() omits visibility entirely when the caller doesn't set it — no client-side default duplicated", async () => {
+    mockFetch = mock(() => Promise.resolve(new Response("{}", { status: 200 })));
+    globalThis.fetch = mockFetch as any;
+
+    const client = new FlairClient({ agentId: "test" });
+    await client.memory.write("content long enough to matter");
+
+    const call = (mockFetch as any).mock.calls[0];
+    const body = JSON.parse(call[1].body);
+    expect("visibility" in body).toBe(false);
+  });
+
+  test("write() forwards visibility:'shared' too (not just a falsy-check bug)", async () => {
+    mockFetch = mock(() => Promise.resolve(new Response("{}", { status: 200 })));
+    globalThis.fetch = mockFetch as any;
+
+    const client = new FlairClient({ agentId: "test" });
+    await client.memory.write("content long enough to matter", { visibility: "shared" });
+
+    const call = (mockFetch as any).mock.calls[0];
+    const body = JSON.parse(call[1].body);
+    expect(body.visibility).toBe("shared");
+  });
+
   test("update() default mode: reads existing, PUTs merged content to the SAME id, clears stale embedding", async () => {
     const existing = {
       id: "mem-1", agentId: "test", content: "old content", type: "session",

--- a/packages/flair-mcp/src/index.ts
+++ b/packages/flair-mcp/src/index.ts
@@ -197,13 +197,20 @@ server.tool(
         "ephemeral — scratch state, auto-expires 72h (e.g., 'currently debugging issue #42')",
       ),
     tags: z.array(z.string()).optional().describe("Array of tag strings"),
+    visibility: z.enum(["private", "shared"]).optional().describe(
+      "Writer-controlled sharing intent (omit to use the server's durability-keyed default: " +
+      "permanent/persistent -> shared, standard/ephemeral -> private). " +
+      "private -- never visible to another agent, even one with a memory grant. " +
+      "shared -- visible to the owner and any agent holding a read/search grant.",
+    ),
   },
-  async ({ content, type, durability, tags }) => {
+  async ({ content, type, durability, tags, visibility }) => {
     try {
       const result = await flair.memory.write(content, {
         type: type as any,
         durability: durability as any,
         tags,
+        visibility: visibility as any,
         dedup: true,
         dedupThreshold: 0.95,
       });
@@ -219,6 +226,7 @@ server.tool(
       // data-loss bug. The gate is server-side now and never suppresses.)
       const deduplicated = (result as any).deduplicated === true;
       const matchedId = (result as any).matchedId as string | undefined;
+      const effectiveVisibility = (result as any).visibility as string | undefined;
       const preview = content.length > 120 ? content.slice(0, 120) + "..." : content;
       const tagStr = tags && tags.length > 0 ? tags.join(", ") : "none";
       const lines = [
@@ -226,7 +234,7 @@ server.tool(
         `Preview: ${preview}`,
         `Size: ${content.length} chars`,
         `Tags: ${tagStr}`,
-        `Type: ${type}, Durability: ${durability}`,
+        `Type: ${type}, Durability: ${durability}, Visibility: ${effectiveVisibility ?? "(server default)"}`,
       ];
       if (deduplicated && matchedId) {
         lines.push(

--- a/resources/AdminMemory.ts
+++ b/resources/AdminMemory.ts
@@ -369,7 +369,7 @@ export class AdminMemory extends Resource {
         <dl style="display:grid;grid-template-columns:200px 1fr;gap:6px;margin-top:8px;font-family:ui-monospace,SF Mono,monospace;font-size:0.85em">
           <dt style="color:#666">id</dt><dd>${esc(m.id)}</dd>
           <dt style="color:#666">contentHash</dt><dd>${esc(m.contentHash ?? "—")}</dd>
-          <dt style="color:#666">visibility</dt><dd>${esc(m.visibility ?? "private")}</dd>
+          <dt style="color:#666">visibility</dt><dd>${esc(m.visibility ?? "shared (no field — pre-migration default)")}</dd>
         </dl>
       </div>
     `;

--- a/resources/Memory.ts
+++ b/resources/Memory.ts
@@ -4,6 +4,7 @@ import { isAdmin, resolveAgentAuth, allowVerified, type AgentAuthVerdict } from 
 import { getEmbedding, getModelId } from "./embeddings-provider.js";
 import { scanFields, isStrictMode } from "./content-safety.js";
 import { checkRateLimit, rateLimitResponse } from "./rate-limiter.js";
+import { resolveAllowedOwners, resolveReadScope } from "./memory-read-scope.js";
 import {
   DEDUP_COSINE_THRESHOLD_DEFAULT,
   DEDUP_LEXICAL_THRESHOLD_DEFAULT,
@@ -22,25 +23,17 @@ const NOT_FOUND = () =>
   new Response(JSON.stringify({ error: "not found" }), { status: 404, headers: { "Content-Type": "application/json" } });
 
 /**
- * Owner ids a non-admin agent may READ: itself, plus any owner who has
- * granted it a "read" or "search" scoped MemoryGrant. Shared by search()
- * (collection scoping) and get() (per-id ownership check, memory-soul-read-
- * gate fix) so the two paths cannot drift apart — this was previously
- * computed inline only inside search().
+ * Owner ids a non-admin agent may READ (resolveAllowedOwners) and the full
+ * read-scope condition + private-exclusion predicate (resolveReadScope) now
+ * live in ./memory-read-scope.ts — the ONE centralized helper every
+ * cross-agent Memory read path (search()/get() here, SemanticSearch.ts,
+ * MemoryBootstrap.ts, auth-middleware.ts's by-id guard) resolves its scope
+ * through, so the scoping rule cannot drift per-path again (ops-nzxa: a
+ * SemanticSearch inline `visibility === "office"` OR-clause leaked office
+ * memories to any authenticated agent because the rule had scattered). See
+ * that module's doc for the migration invariant (no-visibility-field reads
+ * as "shared", never "private").
  */
-async function resolveAllowedOwners(authAgentId: string): Promise<string[]> {
-  const allowedOwners: string[] = [authAgentId];
-  try {
-    for await (const grant of (databases as any).flair.MemoryGrant.search({
-      conditions: [{ attribute: "granteeId", comparator: "equals", value: authAgentId }],
-    })) {
-      if (grant.ownerId && (grant.scope === "read" || grant.scope === "search")) {
-        allowedOwners.push(grant.ownerId);
-      }
-    }
-  } catch { /* MemoryGrant table not yet populated — ignore */ }
-  return allowedOwners;
-}
 
 /**
  * ─── Server-side conservative-duplicate gate (memory-integrity fix) ──────────
@@ -331,6 +324,21 @@ async function closeSupersededIfNeeded(ctx: any, content: any, methodLabel: "pos
   }
 }
 
+/**
+ * ─── Durability-keyed default visibility (ops-2dm3 Layer 1, part A) ─────────
+ *
+ * Writer intent: an explicit `visibility` on the write ALWAYS overrides this
+ * (callers check `content.visibility == null` before calling this). When
+ * unset, the default is keyed off durability — a durable write (the agent
+ * chose to make this stick around) defaults to shared; anything else
+ * defaults to private. "absent" durability (not yet defaulted by the caller)
+ * falls into the private branch, matching the spec's
+ * "standard|ephemeral|absent → private".
+ */
+function defaultVisibilityForDurability(durability: unknown): "private" | "shared" {
+  return durability === "permanent" || durability === "persistent" ? "shared" : "private";
+}
+
 export class Memory extends (databases as any).flair.Memory {
   /**
    * Self-authorize now that the global gate is non-rejecting. Closes the P0
@@ -385,14 +393,15 @@ export class Memory extends (databases as any).flair.Memory {
       return super.get(target);
     }
 
-    // Non-admin agent: only its own memories, or an owner's memories it holds
-    // a read/search MemoryGrant for (same owner-set as search() — shared
-    // resolveAllowedOwners helper so the two paths cannot drift).
+    // Non-admin agent: only its own memories (any visibility), or a granted
+    // owner's SHARED memories — never that owner's private ones (ops-2dm3
+    // Layer 1 private-exclusion). Centralized in resolveReadScope() so this
+    // and search() below cannot drift.
     const record = await super.get(target);
     if (!record) return NOT_FOUND();
 
-    const allowedOwners = await resolveAllowedOwners(auth.agentId);
-    if (!allowedOwners.includes(record.agentId)) return NOT_FOUND();
+    const scope = await resolveReadScope(auth.agentId);
+    if (!scope.isAllowed(record)) return NOT_FOUND();
 
     return record;
   }
@@ -425,14 +434,12 @@ export class Memory extends (databases as any).flair.Memory {
       return super.search(query);
     }
 
-    // Non-admin agent: scope to own + granted owners.
+    // Non-admin agent: scope to own (any visibility) + granted owners' SHARED
+    // memories only (ops-2dm3 Layer 1 private-exclusion). Centralized in
+    // resolveReadScope() so get() above and search() here cannot drift.
     const authAgent = auth.agentId;
-    const allowedOwners = await resolveAllowedOwners(authAgent);
-
-    // Build the agentId scope condition
-    const agentIdCondition: any = allowedOwners.length === 1
-      ? { attribute: "agentId", comparator: "equals", value: allowedOwners[0] }
-      : { conditions: allowedOwners.map(id => ({ attribute: "agentId", comparator: "equals", value: id })), operator: "or" };
+    const scope = await resolveReadScope(authAgent);
+    const agentIdCondition: any = scope.condition;
 
     // Harper passes `query` as a RequestTarget (extends URLSearchParams) or a
     // conditions array. For URL-based GET /Memory?... calls, URL params are no
@@ -485,6 +492,17 @@ export class Memory extends (databases as any).flair.Memory {
     content.createdAt = new Date().toISOString();
     content.updatedAt = content.createdAt;
     content.archived = content.archived ?? false;
+
+    // ─── Default visibility (durability-keyed) — ops-2dm3 Layer 1, part A ────
+    // post() only ever creates a NEW record — patchRecord/supersede-close/
+    // retrievalCount bumps all route through put() instead (see put()'s
+    // pre-existing-record guard below), so there is no "don't overwrite an
+    // existing record's visibility" concern here. Explicit visibility on the
+    // write ALWAYS overrides; only stamp the default when the caller left it
+    // unset. permanent|persistent → shared; standard|ephemeral|absent → private.
+    if (content.visibility === undefined || content.visibility === null) {
+      content.visibility = defaultVisibilityForDurability(content.durability);
+    }
 
     // Validate derivedFrom source IDs exist (best-effort, non-blocking)
     if (Array.isArray(content.derivedFrom) && content.derivedFrom.length > 0) {
@@ -610,6 +628,28 @@ export class Memory extends (databases as any).flair.Memory {
     content.archived = content.archived ?? false;
     content.createdAt = content.createdAt ?? now;
 
+    // Fetch the pre-existing record (if any) ONCE — reused below both to
+    // decide whether this PUT is a fresh create (dedup gate applies, default
+    // visibility stamped) or an update/patch (dedup-bypassed, visibility left
+    // untouched). See the dedup-gate block further down for why an existing
+    // id skips the gate; the SAME "does a record already exist" check gates
+    // the visibility default (ops-2dm3 Layer 1 part A): patchRecord/supersede-
+    // close/retrievalCount bumps all route through put() with a MERGED
+    // `{...existing, ...patch}` payload, and must never have their stored
+    // visibility overwritten by a default recomputed from that merged content
+    // — only a genuinely NEW id gets the default stamped.
+    const preExisting = content.id
+      ? await (databases as any).flair.Memory.get(content.id).catch(() => null)
+      : null;
+
+    // ─── Default visibility (durability-keyed) — ops-2dm3 Layer 1, part A ────
+    // Explicit visibility on the write ALWAYS overrides; only stamp the
+    // default when the caller left it unset AND this is a fresh record.
+    // permanent|persistent → shared; standard|ephemeral|absent → private.
+    if (!preExisting && (content.visibility === undefined || content.visibility === null)) {
+      content.visibility = defaultVisibilityForDurability(content.durability);
+    }
+
     // supersedes: optional reference to the ID of the memory this one
     // replaces. Validates shape + cross-agent-write authorization (shared
     // with post() — see validateAndAuthorizeSupersedes doc for why PUT needs
@@ -652,7 +692,6 @@ export class Memory extends (databases as any).flair.Memory {
       delete content.dedupThreshold;
       delete content.lexicalThreshold;
     } else if (content.id) {
-      const preExisting = await (databases as any).flair.Memory.get(content.id).catch(() => null);
       if (!preExisting) {
         dedupMatch = await runDedupGate(ctx, content);
       } else {

--- a/resources/MemoryBootstrap.ts
+++ b/resources/MemoryBootstrap.ts
@@ -3,6 +3,7 @@ import { allowVerified } from "./agent-auth.js";
 import { getEmbedding } from "./embeddings-provider.js";
 import { wrapUntrusted } from "./content-safety.js";
 import { isTeammate, formatTeamLine } from "./memory-bootstrap-lib.js";
+import { resolveReadScope } from "./memory-read-scope.js";
 
 /**
  * POST /MemoryBootstrap
@@ -16,8 +17,9 @@ import { isTeammate, formatTeamLine } from "./memory-bootstrap-lib.js";
  *   5. Relationship context (active relationships for mentioned entities)
  *   6. Predicted context (based on channel/surface/subject hints)
  *   7. Team roster (other active agents in this office + a search-first nudge —
- *      bootstrap only ever loads the caller's own memories, so this is the one
- *      place agents learn teammates' findings exist without a separate call)
+ *      bootstrap loads the caller's own memories plus any granted owner's
+ *      SHARED memories (ops-2dm3 Layer 1, never their private ones), so this
+ *      section nudges toward memory_search for anything beyond that window)
  *
  * Prediction: when context signals (channel, surface, subjects) are provided,
  * the bootstrap loads more aggressively — Flair is fast enough that the
@@ -199,12 +201,13 @@ export class BootstrapMemories extends Resource {
     }
 
     // --- 1c. Team roster + cross-agent search nudge ---
-    // Bootstrap only ever loads the caller's OWN soul/memories (every query
-    // below filters record.agentId === agentId). Nothing here tells the agent
-    // that teammates exist or that their findings are one memory_search away
-    // — so agents never think to check before re-investigating something a
-    // teammate already solved. This section is fixed-cost (no query text to
-    // format per agent) so it's cheap enough to always include, not budgeted.
+    // Soul is still caller-own-only (unaffected here). Memory loading below
+    // (step 2) now also includes granted owners' SHARED memories (ops-2dm3
+    // Layer 1) — but this section stays: memory_search/SemanticSearch remains
+    // the deliberate, query-driven way to find a teammate's finding, vs.
+    // bootstrap's fixed recent/permanent window. This section is fixed-cost
+    // (no query text to format per agent) so it's cheap enough to always
+    // include, not budgeted.
     //
     // Permissive kind/status checks are DELIBERATE: Agent.ts registration
     // defaults both (`kind ||= "agent"`, `status ||= "active"`), so pre-1.0
@@ -223,11 +226,27 @@ export class BootstrapMemories extends Resource {
     }
 
     // --- 2. Permanent memories (always included, highest priority) ---
+    // Read-scope: own (any visibility) + granted owners' SHARED memories only
+    // (ops-2dm3 Layer 1 — never a granted owner's private ones). Centralized
+    // in resolveReadScope(): the condition is pushed into the Harper query
+    // (so the table itself never returns an out-of-scope row), and
+    // `scope.isAllowed` re-checks in-process as defense-in-depth (same
+    // belt-and-suspenders discipline as SemanticSearch's BM25 pre-fusion
+    // filter) — this is the #550 foundation: bootstrap can now safely expand
+    // beyond own-only without a parallel scoping rule.
+    const scope = await resolveReadScope(agentId);
     const allMemories: any[] = [];
-    for await (const record of (databases as any).flair.Memory.search()) {
-      if (record.agentId !== agentId) continue;
+    for await (const record of (databases as any).flair.Memory.search({ conditions: [scope.condition] })) {
+      if (!scope.isAllowed(record)) continue;
       if (record.expiresAt && Date.parse(record.expiresAt) < Date.now()) continue;
-      allMemories.push(record);
+      // Attribution for cross-agent (granted-owner) records — same convention
+      // SemanticSearch.ts already uses: formatMemory() below only USES this
+      // when the record also carries _safetyFlags (labels the untrusted-data
+      // wrapper with whose memory it is), it never forces wrapping on its own.
+      // Real Harper's search() results are non-extensible objects — mutating
+      // `record._source = ...` directly throws ("object is not extensible");
+      // shallow-copy instead of mutating in place.
+      allMemories.push(record.agentId !== agentId ? { ...record, _source: record.agentId } : record);
     }
     memoriesAvailable = allMemories.length;
 

--- a/resources/SemanticSearch.ts
+++ b/resources/SemanticSearch.ts
@@ -5,6 +5,7 @@ import { patchRecord, withDetachedTxn } from "./table-helpers.js";
 import { checkRateLimit, rateLimitResponse } from "./rate-limiter.js";
 import { wrapUntrusted } from "./content-safety.js";
 import { resolveReadScope } from "./memory-read-scope.js";
+import { cosineSimilarity } from "./dedup.js";
 import {
   isRerankEnabled,
   getRerankTopN,
@@ -324,7 +325,47 @@ export class SemanticSearch extends Resource {
         if (asOf && record.validFrom && record.validFrom > asOf) continue;
         if (asOf && record.validTo && record.validTo <= asOf) continue;
 
-        const semanticScore = distanceToSimilarity(record.$distance ?? 1);
+        let semanticScore: number;
+        if (record.$distance !== undefined) {
+          semanticScore = distanceToSimilarity(record.$distance);
+        } else {
+          // ─── ops-syzm: Harper's cosine-sort query omits $distance for a
+          // SINGLETON post-filter result set — the SAME quirk root-caused and
+          // fixed for the dedup path in ops-ume4 (resources/Memory.ts
+          // findConservativeDedupMatch / resources/dedup.ts cosineSimilarity).
+          // Sort ORDER is still correct; only the numeric `$distance`
+          // annotation is missing on that one record, regardless of the
+          // query's own `limit` (reproduced here with candidateLimit=50, not
+          // just limit=1 — the trigger is the post-filter MATCH COUNT, not the
+          // requested limit).
+          //
+          // ops-2dm3 Layer 1 made this common: the no-grants agent scope used
+          // to ALWAYS be a compound `{operator:"or", conditions:[{agentId},
+          // {visibility=="office"}]}` condition; resolveReadScope() now emits
+          // a PLAIN single `{agentId==X}` condition for the common (no-grants)
+          // case, so a scoped search against an agent with exactly one
+          // matching memory hits this Harper quirk directly. Before, the OR
+          // wrap incidentally avoided the singleton shape. The old `?? 1`
+          // fallback silently collapsed this to similarity 0 — read by
+          // callers (including the clean-VM CI gate's single-memory init
+          // probe, #533) as "embeddings not loaded", which is WRONG:
+          // embeddings ARE loaded, only the score was computed incorrectly.
+          //
+          // Fix: point-lookup the record by id (a plain get(), unaffected by
+          // the sort-query quirk — selecting "embedding" directly on the SAME
+          // sort-by-embedding query comes back as a bare scalar per ops-ume4's
+          // findings) and compute cosine similarity ourselves in JS from its
+          // real stored `embedding` vector against this query's `qEmb`, via
+          // the same math as the ume4 fallback (dedup.ts's cosineSimilarity).
+          // Only done on this (rare) undefined-$distance branch — never adds
+          // a point-lookup to the normal per-record path. If the stored
+          // embedding is missing/empty (e.g. a legacy pre-embedding record),
+          // cosineSimilarity returns 0 — the same safe "no match" the old
+          // `?? 1` fallback produced, never a false-high score.
+          const full = await withDetachedTxn(ctx, () => (databases as any).flair.Memory.get(record.id));
+          const storedEmbedding = Array.isArray(full?.embedding) ? full.embedding : [];
+          semanticScore = cosineSimilarity(qEmb, storedEmbedding);
+        }
         let keywordHit = false;
         if (q && String(record.content || "").toLowerCase().includes(String(q).toLowerCase())) {
           keywordHit = true;

--- a/resources/SemanticSearch.ts
+++ b/resources/SemanticSearch.ts
@@ -4,6 +4,7 @@ import { getEmbedding, getMode } from "./embeddings-provider.js";
 import { patchRecord, withDetachedTxn } from "./table-helpers.js";
 import { checkRateLimit, rateLimitResponse } from "./rate-limiter.js";
 import { wrapUntrusted } from "./content-safety.js";
+import { resolveReadScope } from "./memory-read-scope.js";
 import {
   isRerankEnabled,
   getRerankTopN,
@@ -40,8 +41,9 @@ export class SemanticSearch extends Resource {
   // Self-authorize via the Ed25519 agent verify instead of relying on the auth
   // gate's admin super_user elevation (removed in the auth reshape). Any
   // cryptographically-verified agent may search; per-agent RESULT scoping is
-  // enforced in post() below (an agent only sees its own + office-visible +
-  // granted memories). Without this, Harper's default denies the POST for the
+  // enforced in post() below (an agent only sees its own memories, any
+  // visibility, plus granted owners' SHARED memories — never their private
+  // ones). Without this, Harper's default denies the POST for the
   // least-privilege flair_agent role (AccessViolation 403).
   async allowCreate(): Promise<boolean> {
     return allowVerified((this as any).getContext?.());
@@ -97,20 +99,13 @@ export class SemanticSearch extends Resource {
       ? authenticatedAgent
       : bodyAgentId;
 
-    const searchAgentIds = new Set<string>();
-    if (agentId) searchAgentIds.add(agentId);
-
-    if (agentId) {
-      try {
-        for await (const grant of (databases as any).flair.MemoryGrant.search({
-          conditions: [{ attribute: "granteeId", comparator: "equals", value: agentId }],
-        })) {
-          if (grant.scope === "search" || grant.scope === "read") {
-            searchAgentIds.add(grant.ownerId);
-          }
-        }
-      } catch { /* MemoryGrant may not exist */ }
-    }
+    // Read-scope: own (any visibility) + granted owners' SHARED memories only
+    // (ops-2dm3 Layer 1). Centralized in resolveReadScope() — this used to be
+    // an inline grant-resolution loop here PLUS a `visibility === "office"`
+    // global OR-clause below that leaked ANY authenticated agent's read of
+    // ANY other agent's office-visible memories (ops-nzxa). Both are gone;
+    // this is the ONE scoping resolution for this endpoint now.
+    const scope = agentId ? await resolveReadScope(agentId) : null;
 
     // Generate query embedding
     let qEmb = queryEmbedding;
@@ -148,22 +143,12 @@ export class SemanticSearch extends Resource {
     // ─── Build conditions for Harper query ──────────────────────────────────
     const conditions: any[] = [];
 
-    // Agent scoping: filter to allowed agent IDs or office-visible memories
-    if (searchAgentIds.size === 1) {
-      const [id] = searchAgentIds;
-      conditions.push({
-        operator: "or",
-        conditions: [
-          { attribute: "agentId", comparator: "equals", value: id },
-          { attribute: "visibility", comparator: "equals", value: "office" },
-        ],
-      });
-    } else if (searchAgentIds.size > 1) {
-      const agentConditions = [...searchAgentIds].map(id => (
-        { attribute: "agentId", comparator: "equals", value: id }
-      ));
-      agentConditions.push({ attribute: "visibility", comparator: "equals", value: "office" } as any);
-      conditions.push({ operator: "or", conditions: agentConditions });
+    // Agent scoping: own (any visibility) OR granted-owner's SHARED memories
+    // (private-exclusion) — the centralized read-scope condition. No agentId
+    // → no scoping condition pushed (trusted internal call / admin without a
+    // target agentId — matches the pre-existing unscoped fallback).
+    if (scope) {
+      conditions.push(scope.condition);
     }
 
     // Exclude archived records. Use "not_equal" (Harper v5 comparator) instead of

--- a/resources/auth-middleware.ts
+++ b/resources/auth-middleware.ts
@@ -3,6 +3,7 @@ import { server, databases } from "@harperfast/harper";
 import { getEmbedding } from "./embeddings-provider.js";
 import { isAdmin, FLAIR_AGENT_USERNAME } from "./agent-auth.js";
 import { WINDOW_MS, isNonceReplay, recordNonce, importEd25519Key, b64ToArrayBuffer } from "./ed25519-auth.js";
+import { resolveReadScope } from "./memory-read-scope.js";
 
 // --- Admin credentials ---
 // Admin auth is sourced exclusively from Harper's own environment variables
@@ -495,26 +496,16 @@ server.http(async (request: any, nextLayer: any) => {
         if (memId) {
           const record = await (databases as any).flair.Memory.get(memId);
           if (record && record.agentId && record.agentId !== agentId) {
-            // Allow office-wide memories
-            if (record.visibility !== "office") {
-              // Check MemoryGrant
-              let hasGrant = false;
-              try {
-                for await (const grant of (databases as any).flair.MemoryGrant.search({
-                  conditions: [{ attribute: "granteeId", comparator: "equals", value: agentId }],
-                })) {
-                  if (grant.ownerId === record.agentId &&
-                      (grant.scope === "read" || grant.scope === "search")) {
-                    hasGrant = true;
-                    break;
-                  }
-                }
-              } catch {}
-              if (!hasGrant) {
-                return new Response(JSON.stringify({
-                  error: `forbidden: cannot read memory owned by ${record.agentId}`,
-                }), { status: 403, headers: { "Content-Type": "application/json" } });
-              }
+            // Centralized read-scope (ops-2dm3 Layer 1): a grant only covers
+            // the owner's SHARED memories, never their private ones. This
+            // used to be a `visibility === "office"` bypass (any authenticated
+            // agent, no grant needed) — that's gone; the private-exclusion is
+            // now enforced the same way every other read path enforces it.
+            const scope = await resolveReadScope(agentId);
+            if (!scope.isAllowed(record)) {
+              return new Response(JSON.stringify({
+                error: `forbidden: cannot read memory owned by ${record.agentId}`,
+              }), { status: 403, headers: { "Content-Type": "application/json" } });
             }
           }
         }

--- a/resources/dedup.ts
+++ b/resources/dedup.ts
@@ -38,11 +38,14 @@ export interface DedupMatch {
 
 /**
  * Cosine similarity of two equal-length embedding vectors, computed directly
- * in JS. Used as a fallback (ops-ume4) when Harper's HNSW cosine-sort query
- * doesn't attach a computed `$distance` to its top candidate — see
- * findConservativeDedupMatch in ./Memory.ts for when/why. A mismatched
- * length, empty vector, or zero-magnitude side yields 0 (no signal, never
- * treated as "identical" by a degenerate computation).
+ * in JS. Used as a fallback for Harper's HNSW cosine-sort query omitting a
+ * computed `$distance` on its top candidate when the query's post-filter
+ * result set contains exactly ONE matching record (ops-ume4, found in
+ * resources/Memory.ts's findConservativeDedupMatch; the identical quirk is
+ * also fixed in resources/SemanticSearch.ts's scoring loop for the same
+ * reason — see ops-syzm there). A mismatched length, empty vector, or
+ * zero-magnitude side yields 0 (no signal, never treated as "identical" by a
+ * degenerate computation).
  */
 export function cosineSimilarity(a: number[], b: number[]): number {
   if (!Array.isArray(a) || !Array.isArray(b) || a.length === 0 || a.length !== b.length) return 0;

--- a/resources/memory-read-scope.ts
+++ b/resources/memory-read-scope.ts
@@ -1,0 +1,149 @@
+import { databases } from "@harperfast/harper";
+
+/**
+ * ─── Centralized Memory read-scoping (ops-2dm3 Layer 1) ─────────────────────
+ *
+ * The SINGLE source every cross-agent Memory read path resolves its scope
+ * through: Memory.search()/Memory.get() (resources/Memory.ts), SemanticSearch
+ * (resources/SemanticSearch.ts), MemoryBootstrap (resources/MemoryBootstrap.ts),
+ * and the by-id GET guard in resources/auth-middleware.ts. Before this module
+ * existed, SemanticSearch had its OWN inline grant-resolution + a
+ * `visibility === "office"` global OR-clause that leaked ANY authenticated
+ * agent's read of ANY other agent's memories once that memory happened to
+ * carry `visibility: "office"` (ops-nzxa). Scattering the scoping rule per
+ * path is exactly how that leak happened — this module exists so it can't
+ * happen again: one rule, one place, every path imports it.
+ *
+ * This is a plain-function module (no `class X extends databases.flair.X`) —
+ * deliberately, so it can be safely imported + exercised under DIFFERENT
+ * `@harperfast/harper` mocks from multiple test/unit/ files in the same bun
+ * process without the class-capture collision documented in
+ * test/unit/memory-soul-read-gate.test.ts (that collision is specific to a
+ * class whose `extends` clause evaluates `databases.flair.X` at module-eval
+ * time; a plain function that reads `databases` inside its body at CALL time
+ * does not have that problem).
+ *
+ * ── The model (private | shared) ─────────────────────────────────────────────
+ * `Memory.visibility` is writer intent: "private" (owner-only) or "shared"
+ * (visible to anyone holding a read/search MemoryGrant on the owner). A
+ * reader's full read-scope is:
+ *   - ALL of the reader's own records, any visibility, unrestricted.
+ *   - A GRANTED owner's records EXCEPT that owner's `private` ones.
+ *
+ * ── The migration invariant (non-negotiable) ─────────────────────────────────
+ * Existing memories (written before this field existed) have NO `visibility`
+ * field. They must read EXACTLY as before: to whoever holds a grant today.
+ * So a record with no `visibility` field is treated as "shared" — this is why
+ * the exclusion condition is `visibility != 'private'` (`not_equal`, which
+ * INCLUDES records missing the field entirely), never `visibility == 'shared'`
+ * (`equals`, which would EXCLUDE them and silently break every existing grant
+ * relationship — nothing is retroactively made private, nothing broadened).
+ */
+
+/**
+ * Owner ids a non-admin agent may READ: itself, plus any owner who has
+ * granted it a "read" or "search" scoped MemoryGrant. This is the pre-existing
+ * owner-set resolution (unchanged in shape/behavior) — resolveReadScope()
+ * below builds the full private-exclusion-aware scope on top of it.
+ */
+export async function resolveAllowedOwners(authAgentId: string): Promise<string[]> {
+  const allowedOwners: string[] = [authAgentId];
+  try {
+    for await (const grant of (databases as any).flair.MemoryGrant.search({
+      conditions: [{ attribute: "granteeId", comparator: "equals", value: authAgentId }],
+    })) {
+      if (grant.ownerId && (grant.scope === "read" || grant.scope === "search")) {
+        allowedOwners.push(grant.ownerId);
+      }
+    }
+  } catch { /* MemoryGrant table not yet populated — ignore */ }
+  return allowedOwners;
+}
+
+/** A record shape narrow enough for the in-process `isAllowed` re-check —
+ *  callers pass whatever partial record they have (select-projected search
+ *  results, a full Memory row, etc.). */
+export interface ScopableRecord {
+  agentId?: string | null;
+  visibility?: string | null;
+}
+
+export interface ReadScope {
+  /** Owner ids the reader may see records from (self + granted). Same value
+   *  resolveAllowedOwners() returns — kept for callers that only need the
+   *  owner set (not the private-exclusion), e.g. a "who can I see" listing. */
+  allowedOwners: string[];
+  /**
+   * The Harper condition object encoding the FULL read-scope, including the
+   * private-exclusion:
+   *   (agentId == reader) OR (agentId IN grantedOwners AND visibility != 'private')
+   * Injection-safe: this is always a SINGLE condition object meant to be
+   * wrapped as the OUTERMOST element a caller ANDs with the rest of its
+   * query — the same discipline Memory.search() already applies to the
+   * plain agentId-only condition this replaces (a user-supplied query can
+   * never escape this outer scope via boolean injection).
+   */
+  condition: any;
+  /**
+   * In-process re-check of the IDENTICAL rule, for defense-in-depth on paths
+   * that either can't push the condition down into a Harper query (e.g.
+   * MemoryBootstrap's in-memory candidate lists) or want a second check after
+   * the fact (BM25's pre-fusion filter). Always agrees with `condition`.
+   */
+  isAllowed: (record: ScopableRecord | null | undefined) => boolean;
+}
+
+const PRIVATE = "private";
+
+/**
+ * Resolve the full read-scope (owner set + condition + in-process predicate)
+ * for a reader. This is the ONE function every cross-agent Memory read path
+ * must call — see the module doc above.
+ */
+export async function resolveReadScope(authAgentId: string): Promise<ReadScope> {
+  const allowedOwners = await resolveAllowedOwners(authAgentId);
+  const grantedOwners = allowedOwners.filter((id) => id !== authAgentId);
+
+  const selfCondition = { attribute: "agentId", comparator: "equals", value: authAgentId };
+
+  let condition: any;
+  if (grantedOwners.length === 0) {
+    // No grants held — the reader's scope is just its own records. Emitting
+    // the plain leaf condition here (rather than an `or` with a single
+    // branch) keeps the common case's query shape identical to what
+    // Memory.search() emitted before this change.
+    condition = selfCondition;
+  } else {
+    const grantedOwnerCondition = grantedOwners.length === 1
+      ? { attribute: "agentId", comparator: "equals", value: grantedOwners[0] }
+      : { operator: "or", conditions: grantedOwners.map((id) => ({ attribute: "agentId", comparator: "equals", value: id })) };
+
+    condition = {
+      operator: "or",
+      conditions: [
+        selfCondition,
+        {
+          operator: "and",
+          conditions: [
+            grantedOwnerCondition,
+            // not_equal (NOT equals 'shared') — see module doc: a record with
+            // NO visibility field must still read as shared. This is the
+            // migration-equivalence invariant, enforced in the condition
+            // itself so every path that uses it gets it for free.
+            { attribute: "visibility", comparator: "not_equal", value: PRIVATE },
+          ],
+        },
+      ],
+    };
+  }
+
+  const grantedSet = new Set(grantedOwners);
+  const isAllowed = (record: ScopableRecord | null | undefined): boolean => {
+    if (!record) return false;
+    if (record.agentId === authAgentId) return true;
+    if (!record.agentId || !grantedSet.has(record.agentId)) return false;
+    return record.visibility !== PRIVATE;
+  };
+
+  return { allowedOwners, condition, isAllowed };
+}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -7428,7 +7428,7 @@ memory.command("add [content]").requiredOption("--agent <id>")
   .option("--summary <text>", "agent-set multi-sentence dense compression (3-tier chain: subject → summary → content; ops-wkoh)")
   .option("--subject <text>", "one-line title / entity this memory is about")
   .option("--derived-from <csv>", "Comma-separated source Memory IDs this memory was distilled/reflected from (sets Memory.derivedFrom; used by the `rem rapid` reflection loop)")
-  .option("--visibility <value>", "Memory visibility (sets Memory.visibility). Use 'office' to share office-wide with every team agent; omit (default) to keep it private to this agent (flair#509)")
+  .option("--visibility <value>", "Writer-controlled sharing intent (sets Memory.visibility): 'private' (owner-only, never visible to a grant-holder) or 'shared' (visible to owner + any agent holding a read/search MemoryGrant). Omit to use the server's durability-keyed default: permanent/persistent -> shared, standard/ephemeral -> private (flair#509, ops-2dm3)")
   .action(async (contentArg, opts) => {
     const content = contentArg ?? opts.content;
     if (!content) { console.error("error: content required (positional arg or --content)"); process.exit(1); }

--- a/test/data-scoping.test.ts
+++ b/test/data-scoping.test.ts
@@ -20,7 +20,15 @@ function checkAgentScope(
   return "forbidden: agentId must match authenticated agent";
 }
 
-/** Returns 403 message if agent tries to read another agent's memory without grant */
+/**
+ * Returns 403 message if agent tries to read another agent's memory without
+ * a grant, or if the memory is private (ops-2dm3 Layer 1 — mirrors
+ * resources/memory-read-scope.ts's resolveReadScope().isAllowed()). The
+ * pre-2dm3 `visibility === "office"` global bypass (any authenticated agent,
+ * no grant needed) is GONE — that was the ops-nzxa leak. A grant only ever
+ * covers an owner's SHARED memories (or ones with no visibility field at
+ * all — the migration invariant: absent reads as shared, never private).
+ */
 function checkMemoryReadScope(
   authenticatedAgent: string,
   memoryOwner: string,
@@ -30,9 +38,9 @@ function checkMemoryReadScope(
 ): string | null {
   if (isAdmin) return null;
   if (memoryOwner === authenticatedAgent) return null;
-  if (memoryVisibility === "office") return null;
-  if (hasGrant) return null;
-  return `forbidden: cannot read memory owned by ${memoryOwner}`;
+  if (!hasGrant) return `forbidden: cannot read memory owned by ${memoryOwner}`;
+  if (memoryVisibility === "private") return `forbidden: cannot read memory owned by ${memoryOwner}`;
+  return null;
 }
 
 /** Soul reads are open to authenticated agents for cross-team coordination */
@@ -74,16 +82,29 @@ describe("checkAgentScope (SemanticSearch / BootstrapMemories / Memory POST)", (
 });
 
 describe("checkMemoryReadScope (Memory GET by ID)", () => {
-  it("allows reading own memory", () => {
+  it("allows reading own memory, any visibility (even private)", () => {
     expect(checkMemoryReadScope("anvil", "anvil", "standard", false, false)).toBeNull();
+    expect(checkMemoryReadScope("anvil", "anvil", "private", false, false)).toBeNull();
   });
 
-  it("allows reading office-wide memory", () => {
-    expect(checkMemoryReadScope("anvil", "flint", "office", false, false)).toBeNull();
+  it("no grant at all → blocked regardless of the owner's visibility choice (ops-nzxa: no more global bypass)", () => {
+    const err = checkMemoryReadScope("anvil", "flint", "shared", false, false);
+    expect(err).not.toBeNull();
+    expect(err).toContain("flint");
   });
 
-  it("allows reading with MemoryGrant", () => {
-    expect(checkMemoryReadScope("anvil", "flint", "standard", true, false)).toBeNull();
+  it("allows reading a granted owner's SHARED memory", () => {
+    expect(checkMemoryReadScope("anvil", "flint", "shared", true, false)).toBeNull();
+  });
+
+  it("allows reading a granted owner's memory with NO visibility field (migration invariant: absent == shared)", () => {
+    expect(checkMemoryReadScope("anvil", "flint", undefined, true, false)).toBeNull();
+  });
+
+  it("blocks reading a granted owner's PRIVATE memory — the private-exclusion invariant", () => {
+    const err = checkMemoryReadScope("anvil", "flint", "private", true, false);
+    expect(err).not.toBeNull();
+    expect(err).toContain("flint");
   });
 
   it("blocks reading another agent's standard memory without grant", () => {
@@ -92,11 +113,12 @@ describe("checkMemoryReadScope (Memory GET by ID)", () => {
     expect(err).toContain("flint");
   });
 
-  it("allows admin to read any memory", () => {
+  it("allows admin to read any memory, including another agent's private one", () => {
     expect(checkMemoryReadScope("admin", "flint", "standard", false, true)).toBeNull();
+    expect(checkMemoryReadScope("admin", "flint", "private", false, true)).toBeNull();
   });
 
-  it("blocks kern reading sherlock's private memory", () => {
+  it("blocks kern reading sherlock's memory with no grant held", () => {
     const err = checkMemoryReadScope("kern", "sherlock", undefined, false, false);
     expect(err).not.toBeNull();
     expect(err).toContain("sherlock");
@@ -128,9 +150,18 @@ describe("cross-agent scoping scenarios", () => {
     expect(checkAgentScope("pulse", "pulse", false)).toBeNull();
   });
 
-  it("office memory is public to all agents", () => {
+  it("shared memory is NEVER public without a grant (ops-nzxa: the old office-wide bypass is gone)", () => {
     for (const reader of ["anvil", "flint", "kern", "pulse", "sherlock"]) {
-      expect(checkMemoryReadScope(reader, "flint", "office", false, false)).toBeNull();
+      if (reader === "flint") continue; // owner reading its own — not a cross-agent case
+      const err = checkMemoryReadScope(reader, "flint", "shared", false, false);
+      expect(err).not.toBeNull();
+    }
+  });
+
+  it("a grant makes a SHARED memory visible, but never a PRIVATE one", () => {
+    for (const reader of ["anvil", "kern", "pulse", "sherlock"]) {
+      expect(checkMemoryReadScope(reader, "flint", "shared", true, false)).toBeNull();
+      expect(checkMemoryReadScope(reader, "flint", "private", true, false)).not.toBeNull();
     }
   });
 

--- a/test/integration/agent-journey.test.ts
+++ b/test/integration/agent-journey.test.ts
@@ -115,6 +115,13 @@ describe("Authenticated agent journey", () => {
         content: memoryContent(i),
         subject: SUBJECT,
         durability: "standard",
+        // ops-2dm3 Layer 1: durability:"standard" with no explicit visibility
+        // now defaults SERVER-SIDE to "private" — which would make the grant
+        // test below (bob sees alice's rows via a MemoryGrant) fail, since a
+        // private memory is never returned to a grant-holder. Explicit
+        // "shared" here is alice's writer-intent opt-in, preserving this
+        // suite's original grant-mechanics coverage under the new default.
+        visibility: "shared",
       });
       if (![200, 204].includes(res.status)) {
         const text = await res.text();

--- a/test/integration/memory-visibility-scoping-e2e.test.ts
+++ b/test/integration/memory-visibility-scoping-e2e.test.ts
@@ -1,0 +1,266 @@
+// ops-2dm3 Layer 1 — private/shared visibility + centralized read-scoping.
+// Real-Harper end-to-end coverage of the security boundary: a memory written
+// `private` must NEVER cross to a non-owner, a grant only ever covers an
+// owner's SHARED memories, and a pre-existing (no-visibility-field) memory
+// must keep reading to EXACTLY whoever holds a grant today (migration-
+// equivalence — nothing retroactively private, nothing broadened). All four
+// read paths the design doc calls out are exercised against a real spawned
+// Harper: Memory.get() (by-id), Memory.search() (collection), SemanticSearch,
+// and MemoryBootstrap — plus the auth-middleware.ts by-id guard, which is the
+// pre-check `GET /Memory/<id>` passes through before ever reaching Memory.get().
+//
+// Pattern: test/integration/agent-journey.test.ts (Ed25519 signing helpers,
+// admin-op seeding) + test/integration/durability-guard.test.ts (raw `insert`
+// via the ops API to seed records that BYPASS resources/Memory.ts's write
+// path entirely — needed to simulate a genuine pre-migration record with NO
+// visibility field, since a signed PUT through Memory.put() would have the
+// new durability-keyed default stamped onto it).
+import { describe, expect, test, beforeAll, afterAll } from "bun:test";
+import nacl from "tweetnacl";
+import { randomUUID } from "node:crypto";
+import { startHarper, stopHarper, HarperInstance } from "../helpers/harper-lifecycle";
+
+interface TestAgent { id: string; publicKey: string; secretKey: Uint8Array; }
+
+function mkAgent(id: string): TestAgent {
+  const kp = nacl.sign.keyPair();
+  return { id, publicKey: Buffer.from(kp.publicKey).toString("base64"), secretKey: kp.secretKey };
+}
+
+function ed25519Header(agent: TestAgent, method: string, path: string): string {
+  const ts = Date.now().toString();
+  const nonce = randomUUID();
+  const payload = `${agent.id}:${ts}:${nonce}:${method}:${path}`;
+  const sig = nacl.sign.detached(new TextEncoder().encode(payload), agent.secretKey);
+  return `TPS-Ed25519 ${agent.id}:${ts}:${nonce}:${Buffer.from(sig).toString("base64")}`;
+}
+
+async function authFetch(harper: HarperInstance, agent: TestAgent, method: string, path: string, body?: unknown): Promise<Response> {
+  const headers: Record<string, string> = { Authorization: ed25519Header(agent, method, path) };
+  if (body !== undefined) headers["Content-Type"] = "application/json";
+  return fetch(`${harper.httpURL}${path}`, { method, headers, body: body !== undefined ? JSON.stringify(body) : undefined });
+}
+
+async function adminOp(harper: HarperInstance, op: Record<string, any>): Promise<Response> {
+  return fetch(harper.opsURL, {
+    method: "POST",
+    headers: { "Content-Type": "application/json", Authorization: "Basic " + btoa(`${harper.admin.username}:${harper.admin.password}`) },
+    body: JSON.stringify(op),
+  });
+}
+
+async function seedAgent(harper: HarperInstance, agent: TestAgent): Promise<void> {
+  const res = await adminOp(harper, {
+    operation: "insert", database: "flair", table: "Agent",
+    records: [{ id: agent.id, name: agent.id, role: "agent", publicKey: agent.publicKey, createdAt: new Date().toISOString() }],
+  });
+  expect(res.status).toBe(200);
+}
+
+/** Raw insert — bypasses resources/Memory.ts's post()/put() ENTIRELY (no
+ *  durability-keyed default stamped). Used to simulate records exactly as
+ *  they exist pre-migration. */
+async function insertMemoryRaw(harper: HarperInstance, record: Record<string, any>): Promise<void> {
+  const res = await adminOp(harper, { operation: "insert", database: "flair", table: "Memory", records: [record] });
+  expect(res.status, `raw insert of ${record.id} returned ${res.status}`).toBe(200);
+}
+
+async function insertGrant(harper: HarperInstance, ownerId: string, granteeId: string, scope: string): Promise<void> {
+  const res = await adminOp(harper, {
+    operation: "insert", database: "flair", table: "MemoryGrant",
+    records: [{ id: `${ownerId}:${granteeId}:${scope}`, ownerId, granteeId, scope, createdAt: new Date().toISOString() }],
+  });
+  expect(res.status).toBe(200);
+}
+
+let harper: HarperInstance;
+const owner = mkAgent("vis-owner");
+const grantee = mkAgent("vis-grantee");
+const stranger = mkAgent("vis-stranger");
+
+const idLegacy = "vis-owner-legacy-no-field";     // no visibility field at all — migration invariant
+const idShared = "vis-owner-explicit-shared";     // visibility: "shared"
+const idPrivate = "vis-owner-explicit-private";   // visibility: "private"
+
+describe("ops-2dm3 Layer 1 — private/shared visibility + centralized read-scoping (real Harper)", () => {
+  beforeAll(async () => {
+    harper = await startHarper();
+    await seedAgent(harper, owner);
+    await seedAgent(harper, grantee);
+    await seedAgent(harper, stranger);
+
+    const now = new Date().toISOString();
+    await insertMemoryRaw(harper, { id: idLegacy, agentId: owner.id, content: "pre-migration finding, no visibility field", durability: "permanent", createdAt: now });
+    await insertMemoryRaw(harper, { id: idShared, agentId: owner.id, content: "explicitly shared finding", visibility: "shared", durability: "permanent", createdAt: now });
+    await insertMemoryRaw(harper, { id: idPrivate, agentId: owner.id, content: "explicitly private note", visibility: "private", durability: "permanent", createdAt: now });
+
+    // grantee holds a read grant on owner; stranger holds NONE.
+    await insertGrant(harper, owner.id, grantee.id, "read");
+  }, 180_000);
+
+  afterAll(async () => {
+    if (harper) await stopHarper(harper);
+  });
+
+  // ─── Path 1a: Memory.get() (by-id) + the auth-middleware by-id guard ───────
+  describe("Memory GET by id (Memory.get() + auth-middleware's guard, path 1 + 4)", () => {
+    test("owner sees all three of its own memories, any visibility", async () => {
+      for (const id of [idLegacy, idShared, idPrivate]) {
+        const res = await authFetch(harper, owner, "GET", `/Memory/${id}`);
+        expect(res.status, `owner GET ${id} → ${res.status}`).toBe(200);
+      }
+    }, 30_000);
+
+    test("migration invariant: grantee GETs the legacy (no-visibility-field) memory — reads as shared", async () => {
+      const res = await authFetch(harper, grantee, "GET", `/Memory/${idLegacy}`);
+      expect(res.status, `grantee GET legacy → ${res.status}: ${await res.text()}`).toBe(200);
+    }, 30_000);
+
+    test("grantee GETs the explicitly-shared memory", async () => {
+      const res = await authFetch(harper, grantee, "GET", `/Memory/${idShared}`);
+      expect(res.status).toBe(200);
+    }, 30_000);
+
+    test("private-exclusion: grantee's GET of the PRIVATE memory is denied (never 200)", async () => {
+      const res = await authFetch(harper, grantee, "GET", `/Memory/${idPrivate}`);
+      expect([403, 404], `grantee GET private → ${res.status} (expected denied)`).toContain(res.status);
+      const text = await res.text();
+      expect(text).not.toContain("explicitly private note");
+    }, 30_000);
+
+    test("office-leak-closed: stranger (no grant at all) cannot GET any of owner's memories, shared or not", async () => {
+      for (const id of [idLegacy, idShared, idPrivate]) {
+        const res = await authFetch(harper, stranger, "GET", `/Memory/${id}`);
+        expect([403, 404], `stranger GET ${id} → ${res.status} (expected denied)`).toContain(res.status);
+      }
+    }, 30_000);
+  });
+
+  // ─── Path 1b: Memory.search() (collection GET) ─────────────────────────────
+  describe("Memory GET collection (Memory.search(), path 1)", () => {
+    test("grantee's collection GET includes owner's legacy + shared memories, not the private one", async () => {
+      const res = await authFetch(harper, grantee, "GET", "/Memory/");
+      const body: any = await res.json();
+      expect(res.status, `grantee collection GET → ${res.status}: ${JSON.stringify(body).slice(0, 300)}`).toBe(200);
+      const rows: any[] = Array.isArray(body) ? body : (body.results ?? body);
+      const ids = new Set(rows.map((r: any) => r.id));
+      expect(ids.has(idLegacy)).toBe(true);
+      expect(ids.has(idShared)).toBe(true);
+      expect(ids.has(idPrivate)).toBe(false);
+    }, 30_000);
+
+    test("stranger's collection GET contains none of owner's memories", async () => {
+      const res = await authFetch(harper, stranger, "GET", "/Memory/");
+      expect(res.status).toBe(200);
+      const body: any = await res.json();
+      const rows: any[] = Array.isArray(body) ? body : (body.results ?? body);
+      const ids = new Set(rows.map((r: any) => r.id));
+      expect(ids.has(idLegacy)).toBe(false);
+      expect(ids.has(idShared)).toBe(false);
+      expect(ids.has(idPrivate)).toBe(false);
+    }, 30_000);
+  });
+
+  // ─── Path 2: SemanticSearch ─────────────────────────────────────────────────
+  describe("POST /SemanticSearch (path 2 — office-OR leak closed)", () => {
+    test("grantee sees the legacy + shared memories via SemanticSearch, never the private one", async () => {
+      const res = await authFetch(harper, grantee, "POST", "/SemanticSearch", { agentId: grantee.id, limit: 100 });
+      expect(res.status).toBe(200);
+      const body: any = await res.json();
+      const ids = new Set((body.results ?? []).map((r: any) => r.id));
+      expect(ids.has(idLegacy)).toBe(true);
+      expect(ids.has(idShared)).toBe(true);
+      expect(ids.has(idPrivate)).toBe(false);
+    }, 60_000);
+
+    test("stranger's SemanticSearch never surfaces owner's SHARED memory without a grant (ops-nzxa office-OR leak closed)", async () => {
+      const res = await authFetch(harper, stranger, "POST", "/SemanticSearch", { agentId: stranger.id, limit: 100 });
+      expect(res.status).toBe(200);
+      const body: any = await res.json();
+      const ids = new Set((body.results ?? []).map((r: any) => r.id));
+      expect(ids.has(idShared)).toBe(false);
+      expect(ids.has(idLegacy)).toBe(false);
+      expect(ids.has(idPrivate)).toBe(false);
+    }, 60_000);
+  });
+
+  // ─── Path 3: MemoryBootstrap ────────────────────────────────────────────────
+  describe("POST /BootstrapMemories (path 3 — flair#550 foundation)", () => {
+    test("grantee's bootstrap context includes owner's legacy + shared findings, not the private one", async () => {
+      const res = await authFetch(harper, grantee, "POST", "/BootstrapMemories", { agentId: grantee.id, maxTokens: 4000 });
+      const bodyText = await res.text();
+      expect(res.status, `bootstrap → ${res.status}: ${bodyText.slice(0, 2000)}`).toBe(200);
+      const body: any = JSON.parse(bodyText);
+      expect(body.context ?? "").toContain("pre-migration finding");
+      expect(body.context ?? "").toContain("explicitly shared finding");
+      expect(body.context ?? "").not.toContain("explicitly private note");
+    }, 60_000);
+
+    test("stranger's bootstrap context contains none of owner's memories", async () => {
+      const res = await authFetch(harper, stranger, "POST", "/BootstrapMemories", { agentId: stranger.id, maxTokens: 4000 });
+      expect(res.status).toBe(200);
+      const body: any = await res.json();
+      expect(body.context ?? "").not.toContain("pre-migration finding");
+      expect(body.context ?? "").not.toContain("explicitly shared finding");
+      expect(body.context ?? "").not.toContain("explicitly private note");
+    }, 60_000);
+  });
+
+  // ─── Durability-keyed default (write path, part A) ─────────────────────────
+  describe("durability-keyed default visibility (real write path)", () => {
+    test("a persistent write with no visibility is stored as shared", async () => {
+      const id = "vis-owner-write-persistent";
+      const put = await authFetch(harper, owner, "PUT", `/Memory/${id}`, { id, agentId: owner.id, content: "a persistent decision, long enough for the safety scan", durability: "persistent" });
+      expect(put.status, `PUT ${id} → ${put.status}: ${await put.text()}`).toBe(200);
+      const get = await authFetch(harper, owner, "GET", `/Memory/${id}`);
+      const body: any = await get.json();
+      expect(body.visibility).toBe("shared");
+    }, 30_000);
+
+    test("an ephemeral write with no visibility is stored as private", async () => {
+      const id = "vis-owner-write-ephemeral";
+      const put = await authFetch(harper, owner, "PUT", `/Memory/${id}`, { id, agentId: owner.id, content: "scratch state, long enough for the safety scan", durability: "ephemeral" });
+      expect(put.status).toBe(200);
+      const get = await authFetch(harper, owner, "GET", `/Memory/${id}`);
+      const body: any = await get.json();
+      expect(body.visibility).toBe("private");
+    }, 30_000);
+
+    test("an explicit visibility always overrides the durability default", async () => {
+      const id = "vis-owner-write-explicit-override";
+      const put = await authFetch(harper, owner, "PUT", `/Memory/${id}`, {
+        id, agentId: owner.id, content: "explicitly private despite being permanent, long enough for the scan",
+        durability: "permanent", visibility: "private",
+      });
+      expect(put.status).toBe(200);
+      const get = await authFetch(harper, owner, "GET", `/Memory/${id}`);
+      const body: any = await get.json();
+      expect(body.visibility).toBe("private");
+    }, 30_000);
+
+    test("a granted owner's freshly-written shared memory is immediately visible to the grantee", async () => {
+      const id = "vis-owner-write-fresh-shared";
+      const put = await authFetch(harper, owner, "PUT", `/Memory/${id}`, {
+        id, agentId: owner.id, content: "fresh shared finding, long enough for the safety scan", durability: "permanent", visibility: "shared",
+      });
+      expect(put.status).toBe(200);
+      const res = await authFetch(harper, grantee, "GET", `/Memory/${id}`);
+      expect(res.status).toBe(200);
+    }, 30_000);
+  });
+
+  // ─── Injection ──────────────────────────────────────────────────────────────
+  describe("injection: a reader cannot craft a query to surface a granted owner's private record", () => {
+    test("grantee's collection GET with extra (attacker-controlled-shaped) query params never leaks the private id", async () => {
+      // Memory.search() no longer translates URL params into conditions at
+      // all (see resources/Memory.ts's own doc comment) — any attacker-
+      // supplied query string is inert; the resolved scope condition is the
+      // only thing that determines the result set.
+      const res = await authFetch(harper, grantee, "GET", `/Memory/?visibility=private&agentId=${owner.id}`);
+      expect(res.status).toBe(200);
+      const body: any = await res.json();
+      const rows: any[] = Array.isArray(body) ? body : (body.results ?? body);
+      expect(rows.map((r: any) => r.id)).not.toContain(idPrivate);
+    }, 30_000);
+  });
+});

--- a/test/integration/semantic-search-singleton-score.test.ts
+++ b/test/integration/semantic-search-singleton-score.test.ts
@@ -1,0 +1,119 @@
+// ops-syzm — SemanticSearch scores a SINGLETON semantic-search result as 0
+// ("DEGRADED") even though embeddings are loaded and the memory genuinely
+// matches its own paraphrase.
+//
+// This is the SAME Harper quirk already root-caused and fixed for the dedup
+// path (ops-ume4, resources/Memory.ts findConservativeDedupMatch /
+// resources/dedup.ts cosineSimilarity): a cosine-sort query's `$distance`
+// annotation comes back `undefined` when its post-filter result set contains
+// EXACTLY ONE matching record — sort ORDER is still correct, only the numeric
+// distance is missing. resources/SemanticSearch.ts's legacy HNSW path (hybrid
+// flag OFF, the default) computed
+//   distanceToSimilarity(record.$distance ?? 1)
+// so a singleton hit fell through `?? 1` → similarity 0 → the memory reads as
+// totally dissimilar to a paraphrase of ITSELF.
+//
+// ops-2dm3 Layer 1 made this trigger easily: before, the no-grants agent scope
+// was ALWAYS a compound `{operator:"or", conditions:[{agentId},{visibility==
+// "office"}]}` condition; resolveReadScope() now emits a PLAIN single
+// `{agentId==X}` condition for the common (no-grants) case, so an agent with
+// exactly one matching memory hits the singleton-$distance quirk directly.
+// This is exactly the shape of the clean-VM CI gate's single-memory init
+// probe (#533), which as a result misreports "Semantic search DEGRADED —
+// embeddings not loaded" — a MISLEADING message; embeddings are fine, only
+// the score computation is wrong.
+//
+// Pattern: test/integration/ed25519-auth-hnsw.test.ts (real Ed25519-signed
+// PUT so the embedding is generated through the real write path) +
+// test/integration/memory-visibility-scoping-e2e.test.ts (adminOp agent
+// seeding). Each test file gets its own freshly-spawned Harper (see
+// test/helpers/harper-lifecycle.ts) with an empty Memory table, so writing
+// exactly ONE memory for this agent guarantees the scoped search below sees a
+// true singleton result set — no other test's records can leak in.
+import { describe, expect, test, beforeAll, afterAll } from "bun:test";
+import nacl from "tweetnacl";
+import { randomUUID } from "node:crypto";
+import { startHarper, stopHarper, HarperInstance } from "../helpers/harper-lifecycle";
+
+interface TestAgent { id: string; publicKey: string; secretKey: Uint8Array; }
+
+function mkAgent(id: string): TestAgent {
+  const kp = nacl.sign.keyPair();
+  return { id, publicKey: Buffer.from(kp.publicKey).toString("base64"), secretKey: kp.secretKey };
+}
+
+function ed25519Header(agent: TestAgent, method: string, path: string): string {
+  const ts = Date.now().toString();
+  const nonce = randomUUID();
+  const payload = `${agent.id}:${ts}:${nonce}:${method}:${path}`;
+  const sig = nacl.sign.detached(new TextEncoder().encode(payload), agent.secretKey);
+  return `TPS-Ed25519 ${agent.id}:${ts}:${nonce}:${Buffer.from(sig).toString("base64")}`;
+}
+
+async function adminOp(harper: HarperInstance, op: Record<string, any>): Promise<Response> {
+  return fetch(harper.opsURL, {
+    method: "POST",
+    headers: { "Content-Type": "application/json", Authorization: "Basic " + btoa(`${harper.admin.username}:${harper.admin.password}`) },
+    body: JSON.stringify(op),
+  });
+}
+
+let harper: HarperInstance;
+const agent = mkAgent("syzm-singleton");
+const MEMORY_ID = "syzm-singleton-memory-1";
+// Genuinely-related content + paraphrase, worded differently enough that the
+// keyword-substring bump (`content.includes(q)`) never fires — the score we
+// assert on is semanticScore alone, exactly the quantity ops-syzm corrupts.
+const CONTENT = "Our quarterly budget review meeting is scheduled for next Tuesday afternoon in the main conference room downtown.";
+const PARAPHRASE_QUERY = "When are we getting together to go over quarterly spending numbers?";
+
+describe("ops-syzm — SemanticSearch singleton-result scoring (real Harper, real embeddings)", () => {
+  beforeAll(async () => {
+    harper = await startHarper();
+    const res = await adminOp(harper, {
+      operation: "insert", database: "flair", table: "Agent",
+      records: [{ id: agent.id, name: agent.id, role: "agent", publicKey: agent.publicKey, createdAt: new Date().toISOString() }],
+    });
+    expect(res.status).toBe(200);
+
+    // Exactly ONE memory for this agent — and this Harper instance's Memory
+    // table is otherwise empty (fresh spawn) — guarantees the scoped search
+    // below is a true singleton post-filter result set. Real Ed25519-signed
+    // PUT so the embedding is generated through the actual write path
+    // (resources/Memory.ts put() → getEmbedding()), not synthesized.
+    const path = `/Memory/${MEMORY_ID}`;
+    const put = await fetch(`${harper.httpURL}${path}`, {
+      method: "PUT",
+      headers: { Authorization: ed25519Header(agent, "PUT", path), "Content-Type": "application/json" },
+      body: JSON.stringify({ id: MEMORY_ID, agentId: agent.id, content: CONTENT, durability: "permanent" }),
+    });
+    if (![200, 204].includes(put.status)) throw new Error(`seed PUT ${MEMORY_ID} → ${put.status}: ${await put.text()}`);
+  }, 180_000);
+
+  afterAll(async () => { if (harper) await stopHarper(harper); });
+
+  test("ops-syzm: a singleton semantic-search result scores as a real positive similarity, not 0/DEGRADED", async () => {
+    const path = "/SemanticSearch";
+    const res = await fetch(`${harper.httpURL}${path}`, {
+      method: "POST",
+      headers: { Authorization: ed25519Header(agent, "POST", path), "Content-Type": "application/json" },
+      body: JSON.stringify({ agentId: agent.id, q: PARAPHRASE_QUERY, limit: 10, scoring: "raw" }),
+    });
+    const text = await res.text();
+    expect(res.status, `SemanticSearch → ${res.status}: ${text.slice(0, 300)}`).toBe(200);
+    const body: any = JSON.parse(text);
+
+    // Confirm this really was the singleton case the bug depends on: exactly
+    // one result, and it's our seeded memory.
+    expect(body.results.length, `expected exactly 1 singleton result, got ${JSON.stringify(body.results).slice(0, 300)}`).toBe(1);
+    expect(body.results[0].id).toBe(MEMORY_ID);
+
+    const score = body.results[0]._score;
+    console.log(`[ops-syzm] singleton semantic score observed: ${score}`);
+    // Pre-fix this is EXACTLY 0 (distanceToSimilarity(1) via the `?? 1`
+    // fallback on an undefined $distance). A real paraphrase of the memory's
+    // own content must score as genuinely similar — well above 0, not just
+    // "not exactly zero" (guards against a trivial epsilon regression).
+    expect(score, `singleton semantic score was ${score} — expected a real positive similarity for a paraphrase of the memory's own content`).toBeGreaterThan(0.2);
+  }, 60_000);
+});

--- a/test/unit/bm25-security.test.ts
+++ b/test/unit/bm25-security.test.ts
@@ -13,18 +13,43 @@ import {
 } from "../../resources/bm25-filter.ts";
 
 // Reconstruct the EXACT conditions[] SemanticSearch.ts builds for a single-agent
-// scope: (agentId == me OR visibility == office) AND archived != true.
+// scope (ops-2dm3 Layer 1, resources/memory-read-scope.ts resolveReadScope()):
+//   (agentId == me) AND archived != true
+// (no grants held → the condition is just the plain self leaf — see the
+// multi-agent-scope test below for the granted-owner + private-exclusion shape).
 function conditionsForAgent(me: string, extra: Condition[] = []): Condition[] {
+  return [
+    { attribute: "agentId", comparator: "equals", value: me },
+    { attribute: "archived", comparator: "not_equal", value: true },
+    ...extra,
+  ];
+}
+
+// The granted-owner shape: (agentId == me) OR (agentId IN grantedOwners AND
+// visibility != 'private'). This is resolveReadScope()'s `condition` when the
+// reader holds at least one grant — reconstructed here rather than imported so
+// this file stays a pure Harper-free predicate test (matches the existing
+// pattern: bm25-filter.ts's shipped predicate is Harper-free and exercised
+// directly, with the condition SHAPE hand-built to mirror the real caller).
+function conditionsForAgentWithGrants(me: string, grantedOwners: string[]): Condition[] {
+  const grantedOwnerCondition: Condition = grantedOwners.length === 1
+    ? { attribute: "agentId", comparator: "equals", value: grantedOwners[0] }
+    : { operator: "or", conditions: grantedOwners.map((id) => ({ attribute: "agentId", comparator: "equals", value: id })) };
   return [
     {
       operator: "or",
       conditions: [
         { attribute: "agentId", comparator: "equals", value: me },
-        { attribute: "visibility", comparator: "equals", value: "office" },
+        {
+          operator: "and",
+          conditions: [
+            grantedOwnerCondition,
+            { attribute: "visibility", comparator: "not_equal", value: "private" },
+          ],
+        },
       ],
     },
     { attribute: "archived", comparator: "not_equal", value: true },
-    ...extra,
   ];
 }
 
@@ -32,36 +57,57 @@ describe("conditions-filter-before-fusion (cross-agent leak gate)", () => {
   const me = "flint";
   const conditions = conditionsForAgent(me);
 
-  test("a BM25 candidate belonging to ANOTHER agent is excluded BEFORE fusion", () => {
+  test("a BM25 candidate belonging to ANOTHER agent (no grant) is excluded BEFORE fusion", () => {
     const mine = { id: "m1", agentId: "flint", content: "Harper getUser phantom user", visibility: "private" };
-    const theirs = { id: "t1", agentId: "anvil", content: "Harper getUser phantom user", visibility: "private" };
+    const theirs = { id: "t1", agentId: "anvil", content: "Harper getUser phantom user", visibility: "shared" };
 
     expect(isAllowedBm25Candidate(mine, conditions)).toBe(true);
-    // The leak case: identical content owned by anvil — MUST be excluded so its
-    // term-frequency never enters the BM25 index / union / fusion.
+    // The leak case: identical content owned by anvil — MUST be excluded (no
+    // grant held for anvil at all, regardless of anvil's own visibility
+    // choice) so its term-frequency never enters the BM25 index/union/fusion.
     expect(isAllowedBm25Candidate(theirs, conditions)).toBe(false);
   });
 
-  test("simulated full pre-fusion filter: only the caller's docs survive", () => {
+  test("simulated full pre-fusion filter: only the caller's docs survive (no grants held)", () => {
     const corpus = [
       { id: "m1", agentId: "flint", content: "secret flint plan alpha", visibility: "private" },
       { id: "m2", agentId: "flint", content: "flint roadmap beta", visibility: "private" },
       { id: "t1", agentId: "anvil", content: "secret anvil plan alpha", visibility: "private" },
       { id: "t2", agentId: "kern", content: "kern review notes", visibility: "private" },
-      { id: "o1", agentId: "anvil", content: "shared office doc", visibility: "office" }, // office-visible → allowed
+      // ops-nzxa regression: this used to be `visibility: "office"`, which the
+      // OLD global OR-clause exposed to ANY authenticated agent with no grant
+      // at all. That clause is gone — a `shared` memory from an UNGRANTED
+      // owner must be excluded exactly like a private one.
+      { id: "o1", agentId: "anvil", content: "shared doc, no grant held for anvil", visibility: "shared" },
     ];
     const allowed = corpus.filter(r => isAllowedBm25Candidate(r, conditions));
     const allowedIds = allowed.map(r => r.id).sort();
-    // flint's own (m1, m2) + the office-visible doc (o1). NEVER anvil/kern private.
-    expect(allowedIds).toEqual(["m1", "m2", "o1"]);
-    // Explicitly assert no other-agent PRIVATE doc leaked into the candidate set.
+    // ONLY flint's own (m1, m2) — nothing from anvil or kern, grant or not.
+    expect(allowedIds).toEqual(["m1", "m2"]);
     expect(allowed.some(r => r.id === "t1")).toBe(false);
     expect(allowed.some(r => r.id === "t2")).toBe(false);
+    expect(allowed.some(r => r.id === "o1")).toBe(false);
   });
 
-  test("office-visible memories from other agents ARE allowed (matches HNSW scope)", () => {
-    const officeDoc = { id: "o1", agentId: "anvil", content: "office wide note", visibility: "office" };
-    expect(isAllowedBm25Candidate(officeDoc, conditions)).toBe(true);
+  test("office-OR leak closed: an ungranted owner's SHARED memory is never allowed (ops-nzxa)", () => {
+    const sharedNoGrant = { id: "o1", agentId: "anvil", content: "office wide note", visibility: "shared" };
+    expect(isAllowedBm25Candidate(sharedNoGrant, conditions)).toBe(false);
+  });
+
+  test("private-exclusion: a GRANTED owner's private memory is excluded, shared/no-field is allowed", () => {
+    const grantConditions = conditionsForAgentWithGrants("flint", ["anvil"]);
+    const anvilPrivate = { id: "p1", agentId: "anvil", content: "anvil's private note", visibility: "private" };
+    const anvilShared = { id: "s1", agentId: "anvil", content: "anvil's shared note", visibility: "shared" };
+    const anvilNoField = { id: "n1", agentId: "anvil", content: "anvil's pre-migration note" }; // no visibility field
+    expect(isAllowedBm25Candidate(anvilPrivate, grantConditions)).toBe(false);
+    expect(isAllowedBm25Candidate(anvilShared, grantConditions)).toBe(true);
+    // Migration invariant: absent visibility reads as shared, not private.
+    expect(isAllowedBm25Candidate(anvilNoField, grantConditions)).toBe(true);
+  });
+
+  test("own records are NEVER private-excluded, regardless of visibility", () => {
+    const myPrivate = { id: "mp1", agentId: "flint", content: "my private note", visibility: "private" };
+    expect(isAllowedBm25Candidate(myPrivate, conditions)).toBe(true);
   });
 
   test("archived records are excluded (archived == true fails not_equal)", () => {
@@ -74,24 +120,16 @@ describe("conditions-filter-before-fusion (cross-agent leak gate)", () => {
     expect(isAllowedBm25Candidate(noField, conditions)).toBe(true);
   });
 
-  test("multi-agent scope (grants): each granted owner + office, never ungranted", () => {
-    // searchAgentIds = {flint, anvil} (anvil granted flint a search scope).
-    const grantConditions: Condition[] = [
-      {
-        operator: "or",
-        conditions: [
-          { attribute: "agentId", comparator: "equals", value: "flint" },
-          { attribute: "agentId", comparator: "equals", value: "anvil" },
-          { attribute: "visibility", comparator: "equals", value: "office" },
-        ],
-      },
-      { attribute: "archived", comparator: "not_equal", value: true },
-    ];
-    const flintDoc = { id: "f", agentId: "flint", visibility: "private" };
-    const anvilGranted = { id: "g", agentId: "anvil", visibility: "private" };
-    const kernUngranted = { id: "k", agentId: "kern", visibility: "private" };
+  test("multi-agent scope (grants): each granted owner's SHARED docs, never ungranted, never a granted owner's private", () => {
+    // flint holds a grant on anvil (but not kern).
+    const grantConditions = conditionsForAgentWithGrants("flint", ["anvil"]);
+    const flintDoc = { id: "f", agentId: "flint", visibility: "private" }; // own — unrestricted
+    const anvilSharedGranted = { id: "g", agentId: "anvil", visibility: "shared" }; // granted + shared — allowed
+    const anvilPrivateGranted = { id: "gp", agentId: "anvil", visibility: "private" }; // granted but PRIVATE — excluded
+    const kernUngranted = { id: "k", agentId: "kern", visibility: "shared" }; // no grant at all — excluded regardless of visibility
     expect(isAllowedBm25Candidate(flintDoc, grantConditions)).toBe(true);
-    expect(isAllowedBm25Candidate(anvilGranted, grantConditions)).toBe(true);
+    expect(isAllowedBm25Candidate(anvilSharedGranted, grantConditions)).toBe(true);
+    expect(isAllowedBm25Candidate(anvilPrivateGranted, grantConditions)).toBe(false);
     expect(isAllowedBm25Candidate(kernUngranted, grantConditions)).toBe(false);
   });
 

--- a/test/unit/memory-bootstrap-scoping.test.ts
+++ b/test/unit/memory-bootstrap-scoping.test.ts
@@ -1,0 +1,159 @@
+/**
+ * memory-bootstrap-scoping.test.ts — ops-2dm3 Layer 1 unit coverage for
+ * resources/MemoryBootstrap.ts's read-scoping.
+ *
+ * Before this change, bootstrap only ever loaded the caller's OWN memories
+ * (`record.agentId !== agentId → continue`) — no grant traversal at all, so
+ * an agent holding a MemoryGrant on a teammate never saw that teammate's
+ * memories through bootstrap (the gap flair#550 was filed against). Bootstrap
+ * now resolves its scope through the SAME centralized helper every other read
+ * path uses (resources/memory-read-scope.ts resolveReadScope()): own (any
+ * visibility) + granted owners' SHARED memories, never a granted owner's
+ * private ones.
+ *
+ * Same in-memory-store mocking technique as memory-integrity.test.ts /
+ * semantic-search-scoping.test.ts. This file owns MemoryBootstrap.ts's
+ * mock+import exclusively (no other test/unit/ file imports it).
+ */
+import { describe, it, expect, mock } from "bun:test";
+
+process.env.FLAIR_RATE_LIMIT_ENABLED = "false";
+delete (process.env as any).FLAIR_PUBLIC;
+
+function matchesCondition(record: any, cond: any): boolean {
+  if (cond.operator && Array.isArray(cond.conditions)) {
+    const results = cond.conditions.map((c: any) => matchesCondition(record, c));
+    return cond.operator === "or" ? results.some(Boolean) : results.every(Boolean);
+  }
+  const fieldVal = record[cond.attribute];
+  if (cond.comparator === "equals") return fieldVal === cond.value;
+  if (cond.comparator === "not_equal") return fieldVal !== cond.value;
+  return true;
+}
+
+let memoryStore: Map<string, any>;
+let memoryGrants: any[];
+
+function memorySearchGen(query: any) {
+  const conditions = Array.isArray(query) ? query : Array.isArray(query?.conditions) ? query.conditions : [];
+  let records = Array.from(memoryStore.values());
+  for (const cond of conditions) records = records.filter((r) => matchesCondition(r, cond));
+  async function* gen() {
+    for (const r of records) yield r;
+  }
+  return gen();
+}
+
+function emptyGen() {
+  async function* gen() {}
+  return gen();
+}
+
+const databasesMock = {
+  flair: {
+    Memory: { search: (query: any) => memorySearchGen(query) },
+    MemoryGrant: {
+      search: (query: any) => {
+        const conditions = Array.isArray(query?.conditions) ? query.conditions : [];
+        let grants = memoryGrants.slice();
+        for (const cond of conditions) grants = grants.filter((g) => matchesCondition(g, cond));
+        async function* gen() {
+          for (const g of grants) yield g;
+        }
+        return gen();
+      },
+    },
+    Soul: { search: () => emptyGen() },
+    Agent: { search: () => emptyGen(), get: async () => null },
+    Relationship: { search: () => emptyGen() },
+    OrgEvent: { search: () => emptyGen() },
+  },
+};
+
+class ResourceBase {}
+
+mock.module("@harperfast/harper", () => ({ databases: databasesMock, Resource: ResourceBase }));
+
+const { BootstrapMemories } = await import("../../resources/MemoryBootstrap.ts");
+
+function makeBootstrap(ctxRequest: any) {
+  const r: any = new (BootstrapMemories as any)();
+  r.getContext = () => ({ request: ctxRequest });
+  return r;
+}
+const agentCtx = (agentId: string, isAdmin = false) => ({ tpsAgent: agentId, tpsAgentIsAdmin: isAdmin });
+
+function reset() {
+  memoryStore = new Map();
+  memoryGrants = [];
+}
+
+// formatMemory() (resources/MemoryBootstrap.ts) renders each memory's content
+// verbatim into the "## Recent Context" / "## Core Principles" sections, so
+// asserting on `result.context` is a reasonable proxy for "was this memory
+// actually surfaced" without reaching into internal state.
+
+describe("MemoryBootstrap.post() — ops-2dm3 Layer 1 centralized read-scoping", () => {
+  it("includes only the caller's own memories when no grants are held", async () => {
+    reset();
+    memoryStore.set("m1", { id: "m1", agentId: "agent-1", content: "MY-OWN-FINDING", durability: "permanent", createdAt: "2026-01-01T00:00:00Z" });
+    memoryStore.set("m2", { id: "m2", agentId: "agent-other", content: "NOT-MINE-FINDING", durability: "permanent", createdAt: "2026-01-01T00:00:00Z" });
+
+    const b = makeBootstrap(agentCtx("agent-1"));
+    const res: any = await b.post({ agentId: "agent-1", includeSoul: false });
+    expect(res.context).toContain("MY-OWN-FINDING");
+    expect(res.context).not.toContain("NOT-MINE-FINDING");
+    expect(res.memoriesAvailable).toBe(1);
+  });
+
+  it("a grant-holder now ALSO sees the owner's SHARED memory (the flair#550 gap this closes)", async () => {
+    reset();
+    memoryStore.set("shared-1", { id: "shared-1", agentId: "agent-owner", content: "TEAMMATE-SHARED-FINDING", visibility: "shared", durability: "permanent", createdAt: "2026-01-01T00:00:00Z" });
+    memoryGrants.push({ granteeId: "agent-grantee", ownerId: "agent-owner", scope: "read" });
+
+    const b = makeBootstrap(agentCtx("agent-grantee"));
+    const res: any = await b.post({ agentId: "agent-grantee", includeSoul: false });
+    expect(res.context).toContain("TEAMMATE-SHARED-FINDING");
+    expect(res.memoriesAvailable).toBe(1);
+  });
+
+  it("private-exclusion: a grant-holder does NOT see the owner's PRIVATE memory", async () => {
+    reset();
+    memoryStore.set("private-1", { id: "private-1", agentId: "agent-owner", content: "TEAMMATE-PRIVATE-NOTE", visibility: "private", durability: "permanent", createdAt: "2026-01-01T00:00:00Z" });
+    memoryGrants.push({ granteeId: "agent-grantee", ownerId: "agent-owner", scope: "read" });
+
+    const b = makeBootstrap(agentCtx("agent-grantee"));
+    const res: any = await b.post({ agentId: "agent-grantee", includeSoul: false });
+    expect(res.context).not.toContain("TEAMMATE-PRIVATE-NOTE");
+    expect(res.memoriesAvailable).toBe(0);
+  });
+
+  it("migration invariant: a grant-holder sees a NO-visibility-field owner record (absent reads as shared)", async () => {
+    reset();
+    memoryStore.set("legacy-1", { id: "legacy-1", agentId: "agent-owner", content: "LEGACY-PRE-MIGRATION-FINDING", durability: "permanent", createdAt: "2026-01-01T00:00:00Z" }); // no visibility field
+    memoryGrants.push({ granteeId: "agent-grantee", ownerId: "agent-owner", scope: "search" });
+
+    const b = makeBootstrap(agentCtx("agent-grantee"));
+    const res: any = await b.post({ agentId: "agent-grantee", includeSoul: false });
+    expect(res.context).toContain("LEGACY-PRE-MIGRATION-FINDING");
+  });
+
+  it("without any grant, an ungranted owner's SHARED memory is still invisible (no bypass)", async () => {
+    reset();
+    memoryStore.set("shared-no-grant", { id: "shared-no-grant", agentId: "agent-owner", content: "SHARED-BUT-UNGRANTED", visibility: "shared", durability: "permanent", createdAt: "2026-01-01T00:00:00Z" });
+
+    const b = makeBootstrap(agentCtx("agent-stranger"));
+    const res: any = await b.post({ agentId: "agent-stranger", includeSoul: false });
+    expect(res.context).not.toContain("SHARED-BUT-UNGRANTED");
+    expect(res.memoriesAvailable).toBe(0);
+  });
+
+  it("the caller always sees its own private memory through bootstrap", async () => {
+    reset();
+    memoryStore.set("mine-private", { id: "mine-private", agentId: "agent-1", content: "MY-OWN-PRIVATE-NOTE", visibility: "private", durability: "permanent", createdAt: "2026-01-01T00:00:00Z" });
+
+    const b = makeBootstrap(agentCtx("agent-1"));
+    const res: any = await b.post({ agentId: "agent-1", includeSoul: false });
+    expect(res.context).toContain("MY-OWN-PRIVATE-NOTE");
+  });
+});

--- a/test/unit/memory-integrity.test.ts
+++ b/test/unit/memory-integrity.test.ts
@@ -36,6 +36,16 @@ const FAKE_EMBEDDING = [1, 0, 0, 0];
 mock.module("../../resources/embeddings-provider.ts", () => ({
   getEmbedding: async (_text: string) => FAKE_EMBEDDING,
   getModelId: () => "mock-embedding-model",
+  // getMode is unused by this file's own tests, but MUST still be exported —
+  // `bun test test/unit` runs every file in one process, and another file's
+  // dynamic import of a module that (transitively) imports embeddings-
+  // provider.ts can resolve to whichever mock reached the module cache
+  // first. An incomplete mock here previously broke
+  // test/unit/semantic-search-scoping.test.ts (SemanticSearch.ts imports
+  // getMode too) with "Export named 'getMode' not found" when run in the
+  // same process — keep this mock's export surface a superset of every
+  // consumer's named imports, not just this file's own.
+  getMode: () => "local",
 }));
 
 // ─── In-memory Harper Memory / MemoryGrant / Agent mock ─────────────────────
@@ -172,6 +182,11 @@ mock.module("@harperfast/harper", () => ({ databases: databasesMock, Resource: c
 const { Memory } = await import("../../resources/Memory.ts");
 const { jaccardSimilarity, isConservativeMatch, computeMatchConfidence, cosineSimilarity } = await import("../../resources/dedup.ts");
 const { tokenize } = await import("../../resources/bm25.ts");
+// Dynamic (not static) import — MUST run after mock.module() above, same
+// reason as the three imports directly above: a static `import ... from`
+// here would be hoisted and evaluate before the @harperfast/harper mock is
+// registered, binding this module's `databases` to the REAL package instead.
+const { resolveAllowedOwners: scopeAllowedOwners, resolveReadScope } = await import("../../resources/memory-read-scope.ts");
 
 function makeMemory(ctxRequest: any) {
   const r: any = new (Memory as any)();
@@ -794,6 +809,261 @@ describe("Memory.search() — grant scoping parity with get() (shared resolveAll
     for await (const r of await (m as any).search({ conditions: [] })) results.push(r);
     const ids = results.map((r) => r.id).sort();
     expect(ids).toEqual(["mem-granted", "mem-own"]);
+  });
+});
+
+// ─── ops-2dm3 Layer 1: private/shared visibility + centralized read-scoping ──
+//
+// Security boundary tests. resources/memory-read-scope.ts's resolveReadScope()
+// is the ONE centralized helper Memory.search()/Memory.get() (this file),
+// SemanticSearch.ts, MemoryBootstrap.ts, and auth-middleware.ts's by-id guard
+// all resolve their scope through — see that module's doc for the full
+// rationale (closes ops-nzxa, the SemanticSearch office-OR global leak).
+// scopeAllowedOwners/resolveReadScope are imported dynamically near the top
+// of this file (after mock.module) alongside Memory/dedup/bm25.
+
+describe("ops-2dm3 Layer 1 — durability-keyed default visibility (write path)", () => {
+  it("Memory.post: persistent write with no visibility → stored shared", async () => {
+    const m = makeMemory(agentCtx("agent-1"));
+    const r = await m.post({ agentId: "agent-1", content: "A persistent lesson, long enough for the gate.", durability: "persistent" });
+    expect((await BaseMemory.get(r.id)).visibility).toBe("shared");
+  });
+
+  it("Memory.post: permanent write with no visibility → stored shared", async () => {
+    const m = makeMemory(agentCtx("agent-1"));
+    const r = await m.post({ agentId: "agent-1", content: "A permanent principle, long enough for the gate.", durability: "permanent" });
+    expect((await BaseMemory.get(r.id)).visibility).toBe("shared");
+  });
+
+  it("Memory.post: ephemeral write with no visibility → stored private", async () => {
+    const m = makeMemory(agentCtx("agent-1"));
+    const r = await m.post({ agentId: "agent-1", content: "Scratch state, long enough for the gate.", durability: "ephemeral" });
+    expect((await BaseMemory.get(r.id)).visibility).toBe("private");
+  });
+
+  it("Memory.post: standard (or absent) durability with no visibility → stored private", async () => {
+    const m = makeMemory(agentCtx("agent-1"));
+    const r1 = await m.post({ agentId: "agent-1", content: "Working memory, long enough for the gate.", durability: "standard" });
+    expect((await BaseMemory.get(r1.id)).visibility).toBe("private");
+
+    const m2 = makeMemory(agentCtx("agent-1"));
+    const r2 = await m2.post({ agentId: "agent-1", content: "No durability set at all, long enough for the gate." });
+    expect((await BaseMemory.get(r2.id)).visibility).toBe("private");
+  });
+
+  it("Memory.post: an explicit visibility ALWAYS overrides the durability default", async () => {
+    const m = makeMemory(agentCtx("agent-1"));
+    const r = await m.post({ agentId: "agent-1", content: "Explicitly private despite being permanent.", durability: "permanent", visibility: "private" });
+    expect((await BaseMemory.get(r.id)).visibility).toBe("private");
+
+    const m2 = makeMemory(agentCtx("agent-1"));
+    const r2 = await m2.post({ agentId: "agent-1", content: "Explicitly shared despite being ephemeral.", durability: "ephemeral", visibility: "shared" });
+    expect((await BaseMemory.get(r2.id)).visibility).toBe("shared");
+  });
+
+  it("Memory.put (fresh id, not yet existing): same durability-keyed default applies", async () => {
+    const m = makeMemory(agentCtx("agent-1"));
+    const r = await m.put({ id: "agent-1-fresh-visibility", agentId: "agent-1", content: "Fresh PUT create, long enough for the gate.", durability: "persistent" });
+    expect((await BaseMemory.get(r.id)).visibility).toBe("shared");
+  });
+
+  it("Memory.put on an EXISTING id (update/patch) NEVER stamps a default — visibility is left exactly as merged in", async () => {
+    // Simulate memory_update's default same-id overwrite: read existing
+    // (already has a stored visibility from its post()), merge new content on
+    // top, PUT back. The merged payload carries the EXISTING visibility
+    // forward — put() must not recompute/overwrite it from durability.
+    const m = makeMemory(agentCtx("agent-1"));
+    const initial = await m.post({ agentId: "agent-1", content: "Original note, long enough for the gate.", durability: "standard", visibility: "shared" });
+    expect((await BaseMemory.get(initial.id)).visibility).toBe("shared"); // explicit override honored
+
+    const existing = await BaseMemory.get(initial.id);
+    const merged = { ...existing, content: "Updated note, long enough for the gate.", updatedAt: new Date().toISOString() };
+    delete (merged as any).embedding;
+    delete (merged as any).embeddingModel;
+
+    const mUpdate = makeMemory(agentCtx("agent-1"));
+    await mUpdate.put(merged);
+    // Still "shared" — untouched by the update, NOT recomputed to "private"
+    // (which is what durability:"standard"'s default would incorrectly stamp
+    // if the fresh-record guard were broken).
+    expect((await BaseMemory.get(initial.id)).visibility).toBe("shared");
+  });
+
+  it("Memory.put on an EXISTING id with NO stored visibility (pre-migration record) stays absent — never stamped", async () => {
+    // A pre-migration record has no visibility field at all (simulates data
+    // written before this field existed).
+    memoryStore.set("legacy-1", { id: "legacy-1", agentId: "agent-1", content: "Pre-migration content.", durability: "standard" });
+    const existing = await BaseMemory.get("legacy-1");
+    expect(existing.visibility).toBeUndefined();
+
+    const merged = { ...existing, content: "Patched pre-migration content.", updatedAt: new Date().toISOString() };
+    const m = makeMemory(agentCtx("agent-1"));
+    await m.put(merged);
+
+    const after = await BaseMemory.get("legacy-1");
+    expect(after.visibility).toBeUndefined(); // NOT stamped to "private" (standard's default)
+  });
+});
+
+describe("ops-2dm3 Layer 1 — migration-equivalence (no-visibility-field memories)", () => {
+  it("Memory.search: a grant-holder sees a no-visibility-field owner record exactly as before (absent reads as shared)", async () => {
+    memoryStore.set("legacy-owned", { id: "legacy-owned", agentId: "agent-owner", content: "pre-migration finding" }); // no visibility field at all
+    memoryGrants.push({ granteeId: "agent-grantee", ownerId: "agent-owner", scope: "read" });
+
+    const m = makeMemory(agentCtx("agent-grantee"));
+    const results: any[] = [];
+    for await (const r of await (m as any).search({ conditions: [] })) results.push(r);
+    expect(results.map((r) => r.id)).toEqual(["legacy-owned"]);
+  });
+
+  it("Memory.get: a grant-holder can get() a no-visibility-field owner record by id (absent reads as shared)", async () => {
+    memoryStore.set("legacy-1", { id: "legacy-1", agentId: "agent-owner", content: "pre-migration finding" });
+    memoryGrants.push({ granteeId: "agent-grantee", ownerId: "agent-owner", scope: "read" });
+
+    const m = makeMemory(agentCtx("agent-grantee"));
+    const res = await (m as any).get("legacy-1");
+    expect(res instanceof Response).toBe(false);
+    expect((res as any).content).toBe("pre-migration finding");
+  });
+
+  it("without a grant, a no-visibility-field record is STILL invisible (absence of a grant, not the field, is what gates access)", async () => {
+    memoryStore.set("legacy-ungranted", { id: "legacy-ungranted", agentId: "agent-owner", content: "pre-migration finding" });
+    // No grant pushed at all.
+    const m = makeMemory(agentCtx("agent-stranger"));
+    const res = await (m as any).get("legacy-ungranted");
+    expect(res instanceof Response).toBe(true);
+    expect((res as Response).status).toBe(404);
+  });
+});
+
+describe("ops-2dm3 Layer 1 — private-exclusion invariant (the K&S acceptance criterion)", () => {
+  it("Memory.search: a granted owner's PRIVATE memory is never returned to the grant-holder", async () => {
+    memoryStore.set("mem-shared", { id: "mem-shared", agentId: "agent-owner", content: "shared finding", visibility: "shared" });
+    memoryStore.set("mem-private", { id: "mem-private", agentId: "agent-owner", content: "private note", visibility: "private" });
+    memoryGrants.push({ granteeId: "agent-grantee", ownerId: "agent-owner", scope: "read" });
+
+    const m = makeMemory(agentCtx("agent-grantee"));
+    const results: any[] = [];
+    for await (const r of await (m as any).search({ conditions: [] })) results.push(r);
+    const ids = results.map((r) => r.id).sort();
+    expect(ids).toEqual(["mem-shared"]);
+    expect(ids).not.toContain("mem-private");
+  });
+
+  it("Memory.get: a granted owner's PRIVATE memory 404s for the grant-holder (non-enumerating — same shape as no-grant)", async () => {
+    memoryStore.set("mem-private", { id: "mem-private", agentId: "agent-owner", content: "private note", visibility: "private" });
+    memoryGrants.push({ granteeId: "agent-grantee", ownerId: "agent-owner", scope: "read" });
+
+    const m = makeMemory(agentCtx("agent-grantee"));
+    const res = await (m as any).get("mem-private");
+    expect(res instanceof Response).toBe(true);
+    expect((res as Response).status).toBe(404);
+  });
+
+  it("the OWNER still sees its own private memory via both search() and get()", async () => {
+    memoryStore.set("mem-private", { id: "mem-private", agentId: "agent-owner", content: "my private note", visibility: "private" });
+
+    const m = makeMemory(agentCtx("agent-owner"));
+    const getRes = await (m as any).get("mem-private");
+    expect(getRes instanceof Response).toBe(false);
+    expect((getRes as any).content).toBe("my private note");
+
+    const m2 = makeMemory(agentCtx("agent-owner"));
+    const results: any[] = [];
+    for await (const r of await (m2 as any).search({ conditions: [] })) results.push(r);
+    expect(results.map((r) => r.id)).toEqual(["mem-private"]);
+  });
+
+  it("admin sees a private memory unfiltered (internal/admin bypass unaffected)", async () => {
+    memoryStore.set("mem-private", { id: "mem-private", agentId: "agent-owner", content: "private note", visibility: "private" });
+    const m = makeMemory(agentCtx("agent-admin", true));
+    const res = await (m as any).get("mem-private");
+    expect(res instanceof Response).toBe(false);
+    expect((res as any).content).toBe("private note");
+  });
+
+  it("a stranger with NO grant at all cannot see a SHARED memory either (grant is still required — private-exclusion narrows, never replaces, the grant gate)", async () => {
+    memoryStore.set("mem-shared", { id: "mem-shared", agentId: "agent-owner", content: "shared finding", visibility: "shared" });
+    const m = makeMemory(agentCtx("agent-stranger"));
+    const res = await (m as any).get("mem-shared");
+    expect(res instanceof Response).toBe(true);
+    expect((res as Response).status).toBe(404);
+  });
+});
+
+describe("ops-2dm3 Layer 1 — resolveReadScope() condition shape + injection safety", () => {
+  it("no grants held → condition is the plain self leaf (unchanged shape from pre-2dm3)", async () => {
+    const scope = await resolveReadScope("agent-1");
+    expect(scope.allowedOwners).toEqual(["agent-1"]);
+    expect(scope.condition).toEqual({ attribute: "agentId", comparator: "equals", value: "agent-1" });
+  });
+
+  it("one grant held → condition is (self) OR (owner AND visibility != 'private')", async () => {
+    memoryGrants.push({ granteeId: "agent-1", ownerId: "agent-owner", scope: "read" });
+    const scope = await resolveReadScope("agent-1");
+    expect(scope.condition).toEqual({
+      operator: "or",
+      conditions: [
+        { attribute: "agentId", comparator: "equals", value: "agent-1" },
+        {
+          operator: "and",
+          conditions: [
+            { attribute: "agentId", comparator: "equals", value: "agent-owner" },
+            { attribute: "visibility", comparator: "not_equal", value: "private" },
+          ],
+        },
+      ],
+    });
+  });
+
+  it("uses not_equal 'private' — NEVER equals 'shared' (the migration-invariant is baked into the condition itself)", async () => {
+    memoryGrants.push({ granteeId: "agent-1", ownerId: "agent-owner", scope: "search" });
+    const scope = await resolveReadScope("agent-1");
+    const json = JSON.stringify(scope.condition);
+    expect(json).toContain("not_equal");
+    expect(json).not.toContain('"equals","value":"shared"');
+  });
+
+  it("isAllowed() agrees with the condition shape for every combination", async () => {
+    memoryGrants.push({ granteeId: "agent-1", ownerId: "agent-owner", scope: "read" });
+    const scope = await resolveReadScope("agent-1");
+    expect(scope.isAllowed({ agentId: "agent-1", visibility: "private" })).toBe(true); // own private
+    expect(scope.isAllowed({ agentId: "agent-owner", visibility: "shared" })).toBe(true); // granted + shared
+    expect(scope.isAllowed({ agentId: "agent-owner" })).toBe(true); // granted + no field (migration invariant)
+    expect(scope.isAllowed({ agentId: "agent-owner", visibility: "private" })).toBe(false); // granted + PRIVATE
+    expect(scope.isAllowed({ agentId: "agent-stranger", visibility: "shared" })).toBe(false); // ungranted
+    expect(scope.isAllowed(null)).toBe(false);
+    expect(scope.isAllowed(undefined)).toBe(false);
+  });
+
+  it("injection: a reader cannot craft a search query to surface a granted owner's private record", async () => {
+    memoryStore.set("mem-private", { id: "mem-private", agentId: "agent-owner", content: "private note", visibility: "private" });
+    memoryGrants.push({ granteeId: "agent-grantee", ownerId: "agent-owner", scope: "read" });
+
+    // Attacker-supplied conditions try to OR their way around the scope, or
+    // directly assert visibility equals "private" to force a match — Memory.
+    // search() always wraps the resolved scope condition as the OUTERMOST
+    // element of an implicit-AND conditions[] array, so a user-supplied
+    // "or"/wildcard condition can only ever narrow the result set further,
+    // never broaden past the scope.
+    const attackerQuery = {
+      conditions: [
+        { attribute: "visibility", comparator: "equals", value: "private" },
+        "or",
+        { attribute: "id", comparator: "starts_with", value: "" },
+      ],
+    };
+    const m = makeMemory(agentCtx("agent-grantee"));
+    const results: any[] = [];
+    for await (const r of await (m as any).search(attackerQuery)) results.push(r);
+    expect(results.map((r: any) => r.id)).not.toContain("mem-private");
+  });
+
+  it("resolveAllowedOwners() (the owner-set-only helper) is unchanged in shape — still self + granted owner ids", async () => {
+    memoryGrants.push({ granteeId: "agent-1", ownerId: "agent-owner-a", scope: "read" });
+    memoryGrants.push({ granteeId: "agent-1", ownerId: "agent-owner-b", scope: "search" });
+    const owners = await scopeAllowedOwners("agent-1");
+    expect(owners.sort()).toEqual(["agent-1", "agent-owner-a", "agent-owner-b"]);
   });
 });
 

--- a/test/unit/semantic-search-scoping.test.ts
+++ b/test/unit/semantic-search-scoping.test.ts
@@ -182,4 +182,33 @@ describe("SemanticSearch.post() — ops-2dm3 Layer 1 centralized read-scoping", 
     const res: any = await s.post({});
     expect(res.results.map((r: any) => r.id)).toEqual(["live"]);
   });
+
+  // ─── ops-syzm: singleton $distance-omission fallback ───────────────────────
+  // This mock's Memory.search() never annotates `$distance` on returned
+  // records (that's a Harper-computed sort-query field with no equivalent in
+  // the in-memory mock) — so any test that takes the HNSW (qEmb-truthy)
+  // branch below exercises the undefined-$distance fallback path by
+  // construction, standing in for Harper's real singleton-result-set quirk
+  // (see resources/SemanticSearch.ts's scoring block for the full writeup,
+  // and test/integration/semantic-search-singleton-score.test.ts for the
+  // real-Harper reproduction this was root-caused against).
+  it("ops-syzm: undefined $distance falls back to a point-lookup cosine computation instead of scoring 0", async () => {
+    reset();
+    const qEmb = [1, 0, 0];
+    // Orthogonal to qEmb — the pre-fix `?? 1` fallback and the fixed
+    // point-lookup cosine computation would BOTH read as "not similar" here,
+    // so this record is a control: it must never be mistaken for a match.
+    memoryStore.set("m-orthogonal", { id: "m-orthogonal", agentId: "agent-1", content: "unrelated", visibility: "private", embedding: [0, 1, 0] });
+    // Identical to qEmb — cosineSimilarity == 1 exactly. Pre-fix this record
+    // would score 0 (distanceToSimilarity(undefined ?? 1) === 0); post-fix it
+    // must score a real positive similarity via the embedding point-lookup.
+    memoryStore.set("m-identical", { id: "m-identical", agentId: "agent-1", content: "matches the query", visibility: "private", embedding: [1, 0, 0] });
+
+    const s = makeSearch(agentCtx("agent-1"));
+    const res: any = await s.post({ queryEmbedding: qEmb, scoring: "raw", limit: 10 });
+
+    const byId = new Map(res.results.map((r: any) => [r.id, r]));
+    expect(byId.get("m-identical")?._score).toBe(1);
+    expect(byId.get("m-orthogonal")?._score).toBe(0);
+  });
 });

--- a/test/unit/semantic-search-scoping.test.ts
+++ b/test/unit/semantic-search-scoping.test.ts
@@ -1,0 +1,185 @@
+/**
+ * semantic-search-scoping.test.ts — ops-2dm3 Layer 1 unit coverage for
+ * resources/SemanticSearch.ts's read-scoping.
+ *
+ * Before this change, SemanticSearch had its OWN inline grant-resolution loop
+ * PLUS a `visibility === "office"` global OR-clause: ANY authenticated agent
+ * could read ANY other agent's memory once it happened to carry
+ * `visibility: "office"` — no grant required at all (ops-nzxa). Both are
+ * gone; SemanticSearch now resolves its scope through the ONE centralized
+ * helper (resources/memory-read-scope.ts resolveReadScope()), the same one
+ * Memory.search()/Memory.get() use.
+ *
+ * These tests exercise the SHIPPED SemanticSearch.post() directly against a
+ * mocked @harperfast/harper, using the "no embedding, no q" keyword-fallback
+ * path (resources/SemanticSearch.ts's final `else` branch) so the scoping
+ * conditions[] alone determine what comes back — no embeddings-provider
+ * dependency, deterministic. Same in-memory-store mocking technique as
+ * test/unit/memory-integrity.test.ts; this file owns SemanticSearch.ts's
+ * mock+import exclusively (no other test/unit/ file imports it), avoiding the
+ * class-capture collision documented there.
+ */
+import { describe, it, expect, mock } from "bun:test";
+
+process.env.FLAIR_RATE_LIMIT_ENABLED = "false";
+delete (process.env as any).FLAIR_PUBLIC;
+delete (process.env as any).FLAIR_HYBRID_RETRIEVAL;
+
+// None of this file's tests set `q`/`queryEmbedding`, so SemanticSearch.ts
+// never actually CALLS getEmbedding/getMode — but `bun test test/unit` runs
+// every file in one process, and another file's `mock.module` for this same
+// specifier can win the module cache race. Mock it explicitly here too (a
+// superset of SemanticSearch.ts's named imports) so this file never depends
+// on another file's mock being complete.
+mock.module("../../resources/embeddings-provider.ts", () => ({
+  getEmbedding: async () => null,
+  getMode: () => "none",
+}));
+
+// ─── In-memory Harper Memory / MemoryGrant mock (search-only; SemanticSearch
+// never post()/put()s Memory directly, only patches retrievalCount via
+// patchRecord — a fire-and-forget best-effort call we don't need to assert) ──
+
+function matchesCondition(record: any, cond: any): boolean {
+  if (cond.operator && Array.isArray(cond.conditions)) {
+    const results = cond.conditions.map((c: any) => matchesCondition(record, c));
+    return cond.operator === "or" ? results.some(Boolean) : results.every(Boolean);
+  }
+  const fieldVal = record[cond.attribute];
+  if (cond.comparator === "equals") return fieldVal === cond.value;
+  if (cond.comparator === "not_equal") return fieldVal !== cond.value;
+  return true;
+}
+
+let memoryStore: Map<string, any>;
+let memoryGrants: any[];
+
+function memorySearchGen(query: any) {
+  const conditions = Array.isArray(query) ? query : Array.isArray(query?.conditions) ? query.conditions : [];
+  let records = Array.from(memoryStore.values());
+  for (const cond of conditions) records = records.filter((r) => matchesCondition(r, cond));
+  async function* gen() {
+    for (const r of records) yield r;
+  }
+  return gen();
+}
+
+const databasesMock = {
+  flair: {
+    Memory: {
+      search: (query: any) => memorySearchGen(query),
+      get: async (id: any) => memoryStore.get(typeof id === "string" ? id : id?.id) ?? null,
+      put: async (content: any) => { memoryStore.set(content.id, { ...content }); return { ...content }; },
+    },
+    MemoryGrant: {
+      search: (query: any) => {
+        const conditions = Array.isArray(query?.conditions) ? query.conditions : [];
+        let grants = memoryGrants.slice();
+        for (const cond of conditions) grants = grants.filter((g) => matchesCondition(g, cond));
+        async function* gen() {
+          for (const g of grants) yield g;
+        }
+        return gen();
+      },
+    },
+    Agent: { get: async () => null, search: async () => [] },
+  },
+};
+
+class ResourceBase {}
+
+mock.module("@harperfast/harper", () => ({ databases: databasesMock, Resource: ResourceBase }));
+
+const { SemanticSearch } = await import("../../resources/SemanticSearch.ts");
+
+function makeSearch(ctxRequest: any) {
+  const r: any = new (SemanticSearch as any)();
+  r.getContext = () => ({ request: ctxRequest });
+  return r;
+}
+const agentCtx = (agentId: string, isAdmin = false) => ({ tpsAgent: agentId, tpsAgentIsAdmin: isAdmin });
+const anonCtx = () => ({ tpsAnonymous: true });
+
+function reset() {
+  memoryStore = new Map();
+  memoryGrants = [];
+}
+
+describe("SemanticSearch.post() — ops-2dm3 Layer 1 centralized read-scoping", () => {
+  it("anonymous is denied (401)", async () => {
+    reset();
+    const s = makeSearch(anonCtx());
+    const res = await s.post({});
+    expect(res instanceof Response).toBe(true);
+    expect((res as Response).status).toBe(401);
+  });
+
+  it("sees only its own records when no grants are held", async () => {
+    reset();
+    memoryStore.set("m1", { id: "m1", agentId: "agent-1", content: "mine", visibility: "private" });
+    memoryStore.set("m2", { id: "m2", agentId: "agent-other", content: "not mine", visibility: "shared" });
+    const s = makeSearch(agentCtx("agent-1"));
+    const res: any = await s.post({});
+    const ids = res.results.map((r: any) => r.id).sort();
+    expect(ids).toEqual(["m1"]);
+  });
+
+  it("office-OR leak CLOSED: an ungranted owner's SHARED memory is never returned (ops-nzxa)", async () => {
+    reset();
+    memoryStore.set("shared-no-grant", { id: "shared-no-grant", agentId: "agent-owner", content: "shared but no grant held", visibility: "shared" });
+    const s = makeSearch(agentCtx("agent-stranger"));
+    const res: any = await s.post({});
+    expect(res.results.map((r: any) => r.id)).not.toContain("shared-no-grant");
+    expect(res.results.length).toBe(0);
+  });
+
+  it("a grant-holder sees the owner's SHARED memory, never the owner's PRIVATE one", async () => {
+    reset();
+    memoryStore.set("shared-1", { id: "shared-1", agentId: "agent-owner", content: "shared finding", visibility: "shared" });
+    memoryStore.set("private-1", { id: "private-1", agentId: "agent-owner", content: "private note", visibility: "private" });
+    memoryGrants.push({ granteeId: "agent-grantee", ownerId: "agent-owner", scope: "read" });
+
+    const s = makeSearch(agentCtx("agent-grantee"));
+    const res: any = await s.post({});
+    const ids = res.results.map((r: any) => r.id).sort();
+    expect(ids).toEqual(["shared-1"]);
+    expect(ids).not.toContain("private-1");
+  });
+
+  it("migration invariant: a grant-holder sees a NO-visibility-field owner record (absent reads as shared)", async () => {
+    reset();
+    memoryStore.set("legacy-1", { id: "legacy-1", agentId: "agent-owner", content: "pre-migration finding" }); // no visibility field
+    memoryGrants.push({ granteeId: "agent-grantee", ownerId: "agent-owner", scope: "search" });
+
+    const s = makeSearch(agentCtx("agent-grantee"));
+    const res: any = await s.post({});
+    expect(res.results.map((r: any) => r.id)).toEqual(["legacy-1"]);
+  });
+
+  it("the owner always sees its own private memory via this endpoint too", async () => {
+    reset();
+    memoryStore.set("mine-private", { id: "mine-private", agentId: "agent-1", content: "my private note", visibility: "private" });
+    const s = makeSearch(agentCtx("agent-1"));
+    const res: any = await s.post({});
+    expect(res.results.map((r: any) => r.id)).toEqual(["mine-private"]);
+  });
+
+  it("admin (no bodyAgentId) is unfiltered — sees everything regardless of visibility/grant", async () => {
+    reset();
+    memoryStore.set("a", { id: "a", agentId: "agent-x", visibility: "private" });
+    memoryStore.set("b", { id: "b", agentId: "agent-y", visibility: "shared" });
+    const s = makeSearch(agentCtx("agent-admin", true));
+    const res: any = await s.post({});
+    const ids = res.results.map((r: any) => r.id).sort();
+    expect(ids).toEqual(["a", "b"]);
+  });
+
+  it("archived records stay excluded regardless of the scoping change", async () => {
+    reset();
+    memoryStore.set("live", { id: "live", agentId: "agent-1", visibility: "private", archived: false });
+    memoryStore.set("gone", { id: "gone", agentId: "agent-1", visibility: "private", archived: true });
+    const s = makeSearch(agentCtx("agent-1"));
+    const res: any = await s.post({});
+    expect(res.results.map((r: any) => r.id)).toEqual(["live"]);
+  });
+});


### PR DESCRIPTION
Implements **ops-2dm3 Layer 1** — the private/shared write boundary + **centralized** cross-agent read-scoping. Design doc `FLAIR-KNOWLEDGE-SHARING-MODEL.md` (both K&S APPROVED it). This is the cross-agent read gate — **same class as the recent P0s (ops-ckrr, ops-sal4)**; Sherlock hard-gates.

## What
- **`Memory.visibility` = `private` | `shared`** (writer intent). Server-side durability-keyed default on FRESH records only (permanent/persistent→shared, else→private); explicit always wins; updates never over-stamp. Forwarded through flair-client `MemoryApi.write()`, flair-mcp `memory_store`, CLI `--visibility`.
- **ONE centralized helper — new `resources/memory-read-scope.ts` (`resolveReadScope`)** — the single source every cross-agent read path resolves through. Kills the scattered per-path enforcement that caused ops-nzxa.
- **All 4 read paths routed through it:** `Memory.search`/`get`, `SemanticSearch` (its inline grant loop **and the `visibility==='office'` global OR-leak DELETED**), `MemoryBootstrap` (was own-only → now grant-aware, the #550 foundation), `auth-middleware` by-id guard (office-bypass deleted).

## The read-scope condition (Sherlock's target)
No grants → plain `agentId == reader` (identical shape to before). With grants:
```
(agentId == reader) OR (agentId IN grantedOwners AND visibility != 'private')
```
`isAllowed(record)`: own → true; else `grantedSet.has(agentId) && visibility !== 'private'`. Injection-safe: always the OUTERMOST condition a caller ANDs with its query.

## Migration safety (the governing invariant)
Existing memories have no `visibility` field. The exclusion is **`not_equal 'private'`** (NOT `equals 'shared'`) — so a record with no field reads as **shared**, exactly to whoever holds a grant today. Access-invariant: nothing retroactively private, nothing broadened. Enforced in the condition itself, so every path gets it for free.

## Verification (real Harper)
- **Migration-equivalence:** a no-visibility memory is visible to a grant-holder exactly as before.
- **Private-invariant (Kern's acceptance criterion):** a `private` memory is NEVER returned to a non-owner via Memory.get/search, SemanticSearch, or MemoryBootstrap — tested per path.
- **office-leak-closed:** a no-grant authenticated agent gets zero rows from a shared/legacy memory via every path.
- **Mutation-proof:** neutralizing the private clause fails 8 tests across 3 files; restored.
- **Durability default + injection** covered.
- **Full suite (I re-ran on the clean branch): unit 1424/0, integration 167/0**; flair-client 40/40, flair-mcp 34/34.

## Notes
- `resolveReadScope` is a plain-function module (not `class extends databases.flair.X`) — deliberately, to dodge the documented bun-test class-mock collision; verified.
- auth-middleware by-id guard still returns 403 on denial (unchanged shape); Memory.get's own 404 provides the non-enumerating defense downstream. Flagging for your call.

@tps-sherlock — **hard-gate the read boundary**: is the centralized condition + isAllowed airtight, office-OR fully gone, private never crossing to a non-owner on ANY path, migration access-invariant? @tps-kern — the centralization architecture + that this is the strict foundation you described (resolveReadScope internals swap for Layer 2, callers unchanged).
