### PR TITLE
feat(bootstrap): surface grant-visible teammate findings for currentTask, own-context stays own (#550)

### DIFF
--- a/resources/MemoryBootstrap.ts
+++ b/resources/MemoryBootstrap.ts
@@ -14,6 +14,12 @@ import { resolveReadScope } from "./memory-read-scope.js";
  *   2. Permanent memories (safety rules, core principles)
  *   3. Recent memories (adaptive window)
  *   4. Task-relevant memories (semantic search if currentTask provided)
+ *   4b. Teammate findings relevant to your task (flair#550 — the SAME scored
+ *      task-relevant set as #4, split by origin: a grant-visible teammate's
+ *      SHARED memory that scores against currentTask lands here instead of
+ *      #4, attributed via "[via <agentId>]". Presentation only — what's
+ *      readable is entirely Layer 1's resolveReadScope()/ops-2dm3; this only
+ *      changes how an already-read cross-agent record is formatted/sectioned)
  *   5. Relationship context (active relationships for mentioned entities)
  *   6. Predicted context (based on channel/surface/subject hints)
  *   7. Team roster (other active agents in this office + a search-first nudge —
@@ -38,13 +44,24 @@ function estimateTokens(text: string): number {
   return Math.ceil(text.length / 4);
 }
 
-function formatMemory(m: any, supersedes?: boolean): string {
+// `agentId` is the BOOTSTRAPPING agent (the caller) — used only to decide
+// whether to annotate attribution, never to change what's read (that
+// boundary is resolveReadScope()'s job, upstream of this function). A
+// cross-agent record always carries `_source` (set once, above, when the
+// record's own agentId differs from the bootstrapping agent — see the
+// allMemories loop), so `m._source !== agentId` is the "is this a
+// teammate's finding" check; own memories never carry `_source` at all.
+function formatMemory(m: any, agentId?: string): string {
   const tag = m.durability === "permanent" ? "🔒" : m.durability === "persistent" ? "📌" : "📝";
   const date = m.createdAt ? ` (${m.createdAt.slice(0, 10)})` : "";
   const chain = m.supersedes ? " [supersedes earlier decision]" : "";
-  const base = `${tag} ${m.content}${date}${chain}`;
+  const attribution = m._source && m._source !== agentId ? `[via ${m._source}] ` : "";
+  const base = `${tag} ${attribution}${m.content}${date}${chain}`;
 
-  // Wrap flagged memories in safety delimiters
+  // Wrap flagged memories in safety delimiters — composes with attribution
+  // above (attribution is baked into `base` before wrapping, so a flagged
+  // teammate memory renders with BOTH the "[via <agent>]" tag and the
+  // untrusted-content wrapper).
   if (m._safetyFlags && Array.isArray(m._safetyFlags) && m._safetyFlags.length > 0) {
     return wrapUntrusted(base, m._source);
   }
@@ -110,6 +127,7 @@ export class BootstrapMemories extends Resource {
       predicted: [],
       relationships: [],
       relevant: [],
+      teammate: [],
       events: [],
     };
     let tokenBudget = maxTokens;
@@ -268,7 +286,7 @@ export class BootstrapMemories extends Resource {
 
     const permanent = activeMemories.filter((m) => m.durability === "permanent");
     for (const m of permanent) {
-      const line = formatMemory(m);
+      const line = formatMemory(m, agentId);
       const cost = estimateTokens(line);
       if (cost <= tokenBudget) {
         sections.permanent.push(line);
@@ -305,7 +323,7 @@ export class BootstrapMemories extends Resource {
     const recentBudget = Math.floor(tokenBudget * 0.4);
     let recentSpent = 0;
     for (const m of recent) {
-      const line = formatMemory(m);
+      const line = formatMemory(m, agentId);
       const cost = estimateTokens(line);
       if (recentSpent + cost > recentBudget) {
         memoriesTruncated++;
@@ -344,7 +362,7 @@ export class BootstrapMemories extends Resource {
       const predictedBudget = Math.floor(tokenBudget * 0.3);
       let predictedSpent = 0;
       for (const m of subjectMemories) {
-        const line = formatMemory(m);
+        const line = formatMemory(m, agentId);
         const cost = estimateTokens(line);
         if (predictedSpent + cost > predictedBudget) {
           memoriesTruncated++;
@@ -414,11 +432,23 @@ export class BootstrapMemories extends Resource {
           .filter((s) => s.score > 0.3)
           .sort((a, b) => b.score - a.score);
 
+        // #550: split the scored, task-relevant set by origin. Own findings
+        // go to `relevant` as before; a teammate's (grant-visible, already
+        // read-scoped by Layer 1 — `m._source` is only ever set for a
+        // cross-agent record, see the allMemories loop above) go to the new
+        // `teammate` section so the agent can tell it apart at a glance.
+        // Both draw from the SAME `tokenBudget` in one score-ordered pass —
+        // highest-relevance memories win the remaining budget regardless of
+        // which section they land in, so neither section double-spends.
         for (const { memory: m } of scored) {
-          const line = formatMemory(m);
+          const line = formatMemory(m, agentId);
           const cost = estimateTokens(line);
           if (cost > tokenBudget) continue;
-          sections.relevant.push(line);
+          if (m._source) {
+            sections.teammate.push(line);
+          } else {
+            sections.relevant.push(line);
+          }
           tokenBudget -= cost;
           memoriesIncluded++;
         }
@@ -480,6 +510,13 @@ export class BootstrapMemories extends Resource {
     if (sections.relevant.length > 0) {
       parts.push("## Relevant Knowledge\n" + sections.relevant.join("\n"));
     }
+    // #550: teammate findings relevant to the current task — right after the
+    // agent's own task-relevant knowledge. Empty section renders nothing
+    // (no header) so a bootstrap with no grant-visible teammate findings for
+    // this task looks exactly as it did before this feature.
+    if (sections.teammate.length > 0) {
+      parts.push("## Teammate findings relevant to your task\n" + sections.teammate.join("\n"));
+    }
     if (sections.events.length > 0) {
       parts.push("## Recent Org Events\n" + sections.events.join("\n"));
     }
@@ -499,6 +536,7 @@ export class BootstrapMemories extends Resource {
         predicted: sections.predicted.length,
         relationships: sections.relationships.length,
         relevant: sections.relevant.length,
+        teammate: sections.teammate.length,
         events: sections.events.length,
       },
       tokenEstimate: soulTokens + memoryTokens,

--- a/resources/MemoryBootstrap.ts
+++ b/resources/MemoryBootstrap.ts
@@ -284,7 +284,17 @@ export class BootstrapMemories extends Resource {
     }
     const activeMemories = allMemories.filter((m) => !supersededIds.has(m.id));
 
-    const permanent = activeMemories.filter((m) => m.durability === "permanent");
+    // #550 design boundary: the permanent / recent / predicted sections are the
+    // agent's OWN working context — own-only, always. Post-Layer-1
+    // `activeMemories` also carries grant-visible teammate records (`_source`
+    // set), but grant-visibility exists to feed the task-relevant "Teammate
+    // findings" surfacing (#550) below, NOT to blend a teammate's memories into
+    // the reader's recent/permanent/predicted view. So these three sections
+    // filter to own (`!m._source`); team knowledge surfaces only when
+    // task-relevant (the teammate section) or via an explicit memory_search.
+    const ownMemories = activeMemories.filter((m) => !m._source);
+
+    const permanent = ownMemories.filter((m) => m.durability === "permanent");
     for (const m of permanent) {
       const line = formatMemory(m, agentId);
       const cost = estimateTokens(line);
@@ -300,7 +310,7 @@ export class BootstrapMemories extends Resource {
     // --- 3. Recent memories (adaptive window) ---
     // Start with 48h. If nothing found, widen to 7d, then 30d.
     // This prevents empty recent sections for agents that were idle.
-    const nonPermanent = activeMemories
+    const nonPermanent = ownMemories
       .filter((m) => m.durability !== "permanent" && m.createdAt)
       .sort((a: any, b: any) => (b.createdAt || "").localeCompare(a.createdAt || ""));
 
@@ -350,7 +360,7 @@ export class BootstrapMemories extends Resource {
         ...recent.filter((_: any, i: number) => i < sections.recent.length).map((m: any) => m.id),
       ]);
 
-      const subjectMemories = activeMemories
+      const subjectMemories = ownMemories
         .filter((m: any) =>
           !includedIds.has(m.id) &&
           m.subject &&

--- a/test/integration/bootstrap-teammate-findings-e2e.test.ts
+++ b/test/integration/bootstrap-teammate-findings-e2e.test.ts
@@ -1,0 +1,195 @@
+// flair#550 (ops-q6i5, Presentation Layer) — bootstrap's "Teammate findings
+// relevant to your task" section: real-Harper, real-embedding end-to-end
+// coverage of the gap this feature closes.
+//
+// Layer 1 (ops-2dm3, already merged) made a grant-visible teammate's SHARED
+// memory reachable through bootstrap's read scope and scored it against
+// currentTask alongside the caller's own memories — but it rendered
+// identically to the caller's own memory (no attribution) and landed in the
+// SAME "Relevant Knowledge" section (not surfaced distinctly). This test
+// proves the fix: a grant-visible teammate's task-relevant SHARED memory now
+// appears attributed ("[via <ownerId>]") in its OWN "Teammate findings
+// relevant to your task" section — never mixed into "Relevant Knowledge",
+// which stays the caller's own findings only — while the SAME owner's
+// PRIVATE memory (equally task-relevant by content) never surfaces at all,
+// proving Layer 1's read-exclusion still holds under this presentation-only
+// split (this test does NOT touch, and is not testing, resolveReadScope()
+// itself — see test/integration/memory-visibility-scoping-e2e.test.ts for
+// that boundary's own dedicated coverage; the private-exclusion assertion
+// here is a guard against a regression in the NEW scored-path split code).
+//
+// Pattern: test/integration/memory-visibility-scoping-e2e.test.ts (Ed25519
+// signing, grant seeding via adminOp) + test/integration/semantic-search-
+// singleton-score.test.ts / bootstrap-supersede-resurface.test.ts (real
+// embeddings generated through the signed PUT write path, real currentTask
+// scoring against them).
+//
+// `createdAt` is explicitly backdated ~40 days on every write — Memory.ts's
+// put() honors a caller-supplied createdAt (`content.createdAt =
+// content.createdAt ?? now`) — so none of these records get swept into
+// bootstrap's separate "Recent Context" window (48h/7d/30d, which widens up
+// to 30d when fewer than 3 recent memories are found) instead of the
+// currentTask-scored path this test targets: the scoring/section-split
+// behavior under test only ever runs on candidates NOT already claimed by
+// the permanent/recent sections.
+import { describe, expect, test, beforeAll, afterAll } from "bun:test";
+import nacl from "tweetnacl";
+import { randomUUID } from "node:crypto";
+import { startHarper, stopHarper, HarperInstance } from "../helpers/harper-lifecycle";
+
+interface TestAgent { id: string; publicKey: string; secretKey: Uint8Array; }
+
+function mkAgent(id: string): TestAgent {
+  const kp = nacl.sign.keyPair();
+  return { id, publicKey: Buffer.from(kp.publicKey).toString("base64"), secretKey: kp.secretKey };
+}
+
+function ed25519Header(agent: TestAgent, method: string, path: string): string {
+  const ts = Date.now().toString();
+  const nonce = randomUUID();
+  const payload = `${agent.id}:${ts}:${nonce}:${method}:${path}`;
+  const sig = nacl.sign.detached(new TextEncoder().encode(payload), agent.secretKey);
+  return `TPS-Ed25519 ${agent.id}:${ts}:${nonce}:${Buffer.from(sig).toString("base64")}`;
+}
+
+async function adminOp(harper: HarperInstance, op: Record<string, any>): Promise<Response> {
+  return fetch(harper.opsURL, {
+    method: "POST",
+    headers: { "Content-Type": "application/json", Authorization: "Basic " + btoa(`${harper.admin.username}:${harper.admin.password}`) },
+    body: JSON.stringify(op),
+  });
+}
+
+async function registerAgent(harper: HarperInstance, agent: TestAgent): Promise<void> {
+  const res = await adminOp(harper, {
+    operation: "insert", database: "flair", table: "Agent",
+    records: [{ id: agent.id, name: agent.id, role: "agent", publicKey: agent.publicKey, createdAt: new Date().toISOString() }],
+  });
+  expect(res.status, `Agent insert for ${agent.id} returned ${res.status}`).toBe(200);
+}
+
+async function insertGrant(harper: HarperInstance, ownerId: string, granteeId: string, scope: string): Promise<void> {
+  const res = await adminOp(harper, {
+    operation: "insert", database: "flair", table: "MemoryGrant",
+    records: [{ id: `${ownerId}:${granteeId}:${scope}`, ownerId, granteeId, scope, createdAt: new Date().toISOString() }],
+  });
+  expect(res.status, `MemoryGrant insert ${ownerId}->${granteeId} returned ${res.status}`).toBe(200);
+}
+
+/** Signed PUT to /Memory/<id> — the only HTTP-reachable create path, so the
+ *  embedding is generated for real (Memory.ts put() → getEmbedding()), not
+ *  synthesized. */
+async function putMemory(harper: HarperInstance, agent: TestAgent, id: string, body: Record<string, any>): Promise<void> {
+  const path = `/Memory/${id}`;
+  const res = await fetch(`${harper.httpURL}${path}`, {
+    method: "PUT",
+    headers: { Authorization: ed25519Header(agent, "PUT", path), "Content-Type": "application/json" },
+    body: JSON.stringify({ id, ...body }),
+  });
+  if (![200, 204].includes(res.status)) {
+    throw new Error(`seed PUT ${id} → ${res.status}: ${await res.text()}`);
+  }
+}
+
+async function bootstrap(harper: HarperInstance, agent: TestAgent, body: Record<string, any>): Promise<any> {
+  const path = "/BootstrapMemories";
+  const res = await fetch(`${harper.httpURL}${path}`, {
+    method: "POST",
+    headers: { Authorization: ed25519Header(agent, "POST", path), "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  const text = await res.text();
+  expect(res.status, `BootstrapMemories → ${res.status}: ${text.slice(0, 500)}`).toBe(200);
+  return JSON.parse(text);
+}
+
+/** Slice out the body of one "## <header>" section from bootstrap's `context`
+ *  string, up to (not including) the next "## " header — lets assertions
+ *  target which SECTION a piece of content landed in, not just whether it
+ *  appears anywhere in the full context. */
+function extractSection(context: string, header: string): string {
+  const marker = `## ${header}`;
+  const idx = context.indexOf(marker);
+  if (idx === -1) return "";
+  const rest = context.slice(idx + marker.length);
+  const nextIdx = rest.indexOf("\n## ");
+  return nextIdx === -1 ? rest : rest.slice(0, nextIdx);
+}
+
+let harper: HarperInstance;
+const owner = mkAgent(`t550-owner-${randomUUID()}`);
+const grantee = mkAgent(`t550-grantee-${randomUUID()}`);
+
+const ID_SHARED = `${owner.id}-shared`;
+const ID_PRIVATE = `${owner.id}-private`;
+const ID_OWN = `${grantee.id}-own`;
+
+// Tightly-aligned domain (shared distinctive entity + subject phrase across
+// currentTask and all three memories) to clear MemoryBootstrap.ts's
+// `score > 0.3` raw-cosine threshold deterministically against the REAL
+// nomic embedding model, while keeping each memory's actual informational
+// content genuinely distinct (so Memory.ts's dedup co-gate — cosine >= 0.95
+// AND lexical Jaccard >= 0.5 — never conflates them into one record).
+const CURRENT_TASK = "Prepare talking points for the Acme Corp vendor contract renegotiation meeting this week.";
+const CONTENT_SHARED = "flair-550 marker: for the Acme Corp vendor contract renegotiation, lead with a volume discount ask and a 12-month price lock.";
+const CONTENT_PRIVATE = "flair-550 marker: for the Acme Corp vendor contract renegotiation, our internal walk-away margin floor is 18 percent — never disclose this to Acme.";
+const CONTENT_OWN = "flair-550 marker: for the Acme Corp vendor contract renegotiation, legal flagged the indemnification clause as the first blocker to resolve.";
+
+const BACKDATED = new Date(Date.now() - 40 * 24 * 3600_000).toISOString();
+
+describe("flair#550 — MemoryBootstrap 'Teammate findings relevant to your task' (real Harper, real embeddings)", () => {
+  beforeAll(async () => {
+    harper = await startHarper();
+    await registerAgent(harper, owner);
+    await registerAgent(harper, grantee);
+    await insertGrant(harper, owner.id, grantee.id, "read");
+
+    await putMemory(harper, owner, ID_SHARED, {
+      agentId: owner.id, content: CONTENT_SHARED, durability: "standard", visibility: "shared", createdAt: BACKDATED,
+    });
+    await putMemory(harper, owner, ID_PRIVATE, {
+      agentId: owner.id, content: CONTENT_PRIVATE, durability: "standard", visibility: "private", createdAt: BACKDATED,
+    });
+    await putMemory(harper, grantee, ID_OWN, {
+      agentId: grantee.id, content: CONTENT_OWN, durability: "standard", createdAt: BACKDATED,
+    });
+  }, 180_000);
+
+  afterAll(async () => { if (harper) await stopHarper(harper); });
+
+  test("grantee's bootstrap surfaces the teammate's SHARED finding attributed in 'Teammate findings', keeps own finding in 'Relevant Knowledge', excludes the teammate's PRIVATE finding entirely", async () => {
+    const body = await bootstrap(harper, grantee, { agentId: grantee.id, maxTokens: 8000, currentTask: CURRENT_TASK });
+    const context: string = body.context ?? "";
+
+    // Guard first: Layer 1's private-exclusion must hold under the new
+    // scored-path split — the private memory (equally task-relevant by
+    // content) must never appear anywhere in the response.
+    expect(context, "owner's PRIVATE memory must never appear in grantee's bootstrap").not.toContain(CONTENT_PRIVATE);
+
+    // Section-count structure: exactly one own task-relevant finding, exactly
+    // one teammate task-relevant finding.
+    expect(body.sections?.relevant, `sections.relevant — full response: ${JSON.stringify(body.sections)}`).toBe(1);
+    expect(body.sections?.teammate, `sections.teammate — full response: ${JSON.stringify(body.sections)}`).toBe(1);
+
+    const relevantSection = extractSection(context, "Relevant Knowledge");
+    const teammateSection = extractSection(context, "Teammate findings relevant to your task");
+
+    // The teammate's SHARED finding: present, attributed, in its OWN section.
+    expect(teammateSection, `"Teammate findings" section missing or empty — full context:\n${context}`).toContain(CONTENT_SHARED);
+    expect(teammateSection).toContain(`[via ${owner.id}]`);
+    expect(teammateSection).not.toContain(CONTENT_OWN);
+
+    // The grantee's own finding: present, UNattributed, in "Relevant
+    // Knowledge" — never in the teammate section.
+    expect(relevantSection, `"Relevant Knowledge" section missing or empty — full context:\n${context}`).toContain(CONTENT_OWN);
+    expect(relevantSection).not.toContain("[via");
+    expect(relevantSection).not.toContain(CONTENT_SHARED);
+  }, 60_000);
+
+  test("no currentTask → no 'Teammate findings' section at all (empty section renders no header)", async () => {
+    const body = await bootstrap(harper, grantee, { agentId: grantee.id, maxTokens: 8000 });
+    const context: string = body.context ?? "";
+    expect(context).not.toContain("Teammate findings relevant to your task");
+    expect(body.sections?.teammate).toBe(0);
+  }, 60_000);
+});

--- a/test/integration/bootstrap-teammate-findings-e2e.test.ts
+++ b/test/integration/bootstrap-teammate-findings-e2e.test.ts
@@ -135,6 +135,17 @@ const CONTENT_SHARED = "flair-550 marker: for the Acme Corp vendor contract rene
 const CONTENT_PRIVATE = "flair-550 marker: for the Acme Corp vendor contract renegotiation, our internal walk-away margin floor is 18 percent — never disclose this to Acme.";
 const CONTENT_OWN = "flair-550 marker: for the Acme Corp vendor contract renegotiation, legal flagged the indemnification clause as the first blocker to resolve.";
 
+// Two PERMANENT memories (own + teammate) — permanent records ALWAYS render in
+// bootstrap's "Core Principles" section regardless of recency/currentTask, so
+// they're the sharpest real-Harper probe of the own-only design boundary: an
+// own permanent renders there, a grant-visible TEAMMATE permanent must NOT
+// bleed into it (pre-fix it did, because that section filtered the reader's
+// full Layer-1 read-scope with no own-agent gate).
+const ID_OWN_PERM = `${grantee.id}-own-perm`;
+const ID_SHARED_PERM = `${owner.id}-shared-perm`;
+const CONTENT_OWN_PERM = "flair-550 marker: standing rule — I always double-check indemnification caps before signing any vendor agreement.";
+const CONTENT_SHARED_PERM = "flair-550 marker: standing rule — the procurement team requires two competing quotes on file before any renewal above fifty thousand dollars.";
+
 const BACKDATED = new Date(Date.now() - 40 * 24 * 3600_000).toISOString();
 
 describe("flair#550 — MemoryBootstrap 'Teammate findings relevant to your task' (real Harper, real embeddings)", () => {
@@ -153,6 +164,13 @@ describe("flair#550 — MemoryBootstrap 'Teammate findings relevant to your task
     await putMemory(harper, grantee, ID_OWN, {
       agentId: grantee.id, content: CONTENT_OWN, durability: "standard", createdAt: BACKDATED,
     });
+    // Permanent pair for the own-only non-bleed probe (see constants above).
+    await putMemory(harper, grantee, ID_OWN_PERM, {
+      agentId: grantee.id, content: CONTENT_OWN_PERM, durability: "permanent", createdAt: BACKDATED,
+    });
+    await putMemory(harper, owner, ID_SHARED_PERM, {
+      agentId: owner.id, content: CONTENT_SHARED_PERM, durability: "permanent", visibility: "shared", createdAt: BACKDATED,
+    });
   }, 180_000);
 
   afterAll(async () => { if (harper) await stopHarper(harper); });
@@ -166,10 +184,15 @@ describe("flair#550 — MemoryBootstrap 'Teammate findings relevant to your task
     // content) must never appear anywhere in the response.
     expect(context, "owner's PRIVATE memory must never appear in grantee's bootstrap").not.toContain(CONTENT_PRIVATE);
 
-    // Section-count structure: exactly one own task-relevant finding, exactly
-    // one teammate task-relevant finding.
+    // Section-count structure: exactly one own task-relevant finding
+    // (CONTENT_OWN — the own PERMANENT memory is excluded from the scored path
+    // via includedIds, so it can't inflate this), and at least one teammate
+    // task-relevant finding. `teammate` is `>= 1` rather than exactly 1 because
+    // the seed's teammate PERMANENT rule (CONTENT_SHARED_PERM, about vendor
+    // renewals) is legitimately task-relevant too and correctly lands here —
+    // proving the split by ORIGIN, not that only one teammate memory can show.
     expect(body.sections?.relevant, `sections.relevant — full response: ${JSON.stringify(body.sections)}`).toBe(1);
-    expect(body.sections?.teammate, `sections.teammate — full response: ${JSON.stringify(body.sections)}`).toBe(1);
+    expect(body.sections?.teammate, `sections.teammate — full response: ${JSON.stringify(body.sections)}`).toBeGreaterThanOrEqual(1);
 
     const relevantSection = extractSection(context, "Relevant Knowledge");
     const teammateSection = extractSection(context, "Teammate findings relevant to your task");
@@ -186,10 +209,23 @@ describe("flair#550 — MemoryBootstrap 'Teammate findings relevant to your task
     expect(relevantSection).not.toContain(CONTENT_SHARED);
   }, 60_000);
 
-  test("no currentTask → no 'Teammate findings' section at all (empty section renders no header)", async () => {
+  test("no currentTask → no 'Teammate findings' section, AND a grant-visible teammate PERMANENT memory does NOT bleed into the reader's own Core Principles", async () => {
     const body = await bootstrap(harper, grantee, { agentId: grantee.id, maxTokens: 8000 });
     const context: string = body.context ?? "";
+
+    // No currentTask → the task-relevant teammate surface is inactive.
     expect(context).not.toContain("Teammate findings relevant to your task");
     expect(body.sections?.teammate).toBe(0);
+
+    // Own-only design boundary, real-Harper proof: the reader's OWN permanent
+    // memory renders in Core Principles ...
+    const principles = extractSection(context, "Core Principles");
+    expect(principles, `own permanent memory missing from Core Principles — full context:\n${context}`).toContain(CONTENT_OWN_PERM);
+    // ... while the grant-visible TEAMMATE permanent memory (in read-scope,
+    // but a teammate's) must NOT appear anywhere — no bleed into own context.
+    expect(context, "teammate PERMANENT memory bled into the reader's own-context view").not.toContain(CONTENT_SHARED_PERM);
+    // The standard-durability teammate SHARED memory likewise stays out with
+    // no currentTask (backdated beyond the recent window AND own-only).
+    expect(context).not.toContain(CONTENT_SHARED);
   }, 60_000);
 });

--- a/test/integration/memory-visibility-scoping-e2e.test.ts
+++ b/test/integration/memory-visibility-scoping-e2e.test.ts
@@ -186,14 +186,26 @@ describe("ops-2dm3 Layer 1 — private/shared visibility + centralized read-scop
 
   // ─── Path 3: MemoryBootstrap ────────────────────────────────────────────────
   describe("POST /BootstrapMemories (path 3 — flair#550 foundation)", () => {
-    test("grantee's bootstrap context includes owner's legacy + shared findings, not the private one", async () => {
+    test("grantee's bootstrap READ-SCOPE includes owner's legacy + shared findings (not the private one); post-#550 those teammate records don't bleed into own-context sections", async () => {
       const res = await authFetch(harper, grantee, "POST", "/BootstrapMemories", { agentId: grantee.id, maxTokens: 4000 });
       const bodyText = await res.text();
       expect(res.status, `bootstrap → ${res.status}: ${bodyText.slice(0, 2000)}`).toBe(200);
       const body: any = JSON.parse(bodyText);
-      expect(body.context ?? "").toContain("pre-migration finding");
-      expect(body.context ?? "").toContain("explicitly shared finding");
+      // Layer 1's read boundary (what this file owns): the legacy (no-visibility
+      // → reads as shared) + explicitly-shared records are in the grantee's
+      // read-scope; the owner's PRIVATE record is not. `memoriesAvailable` is
+      // the read-scope signal (allMemories.length), independent of rendering.
+      expect(body.memoriesAvailable, `grantee read-scope should be exactly legacy+shared=2 — got ${body.memoriesAvailable}`).toBe(2);
+      // #550 design boundary: these owner records are grant-visible TEAMMATE
+      // memories, and they were raw-inserted (no embeddings) so they can't
+      // surface via the task-relevant "Teammate findings" path either. With
+      // own-context sections now own-only, none of them render in this
+      // no-currentTask bootstrap — critically, the private note never leaks.
+      // (The rendered teammate-findings surfacing is covered end-to-end, with
+      // real embeddings, in bootstrap-teammate-findings-e2e.test.ts.)
       expect(body.context ?? "").not.toContain("explicitly private note");
+      expect(body.context ?? "").not.toContain("pre-migration finding");
+      expect(body.context ?? "").not.toContain("explicitly shared finding");
     }, 60_000);
 
     test("stranger's bootstrap context contains none of owner's memories", async () => {

--- a/test/unit/memory-bootstrap-scoping.test.ts
+++ b/test/unit/memory-bootstrap-scoping.test.ts
@@ -109,9 +109,14 @@ function reset() {
 }
 
 // formatMemory() (resources/MemoryBootstrap.ts) renders each memory's content
-// verbatim into the "## Recent Context" / "## Core Principles" sections, so
-// asserting on `result.context` is a reasonable proxy for "was this memory
-// actually surfaced" without reaching into internal state.
+// verbatim into its section, so asserting on `result.context` is a reasonable
+// proxy for "was this memory actually surfaced" without reaching into internal
+// state. NOTE (#550 design boundary): for a TEAMMATE (grant-visible) record
+// that proxy holds ONLY when the record is task-relevant — the permanent /
+// recent / predicted sections are own-only, so a teammate record entering
+// read-scope (`memoriesAvailable`) is decoupled from whether it renders. The
+// read-scope tests below therefore assert `memoriesAvailable` for teammate
+// records, and rendering is covered by the #550 describe block further down.
 
 describe("MemoryBootstrap.post() — ops-2dm3 Layer 1 centralized read-scoping", () => {
   it("includes only the caller's own memories when no grants are held", async () => {
@@ -126,15 +131,20 @@ describe("MemoryBootstrap.post() — ops-2dm3 Layer 1 centralized read-scoping",
     expect(res.memoriesAvailable).toBe(1);
   });
 
-  it("a grant-holder now ALSO sees the owner's SHARED memory (the flair#550 gap this closes)", async () => {
+  it("a grant-holder's read-scope now includes the owner's SHARED memory (the flair#550 gap this closes) — but it does NOT bleed into own-context sections", async () => {
     reset();
     memoryStore.set("shared-1", { id: "shared-1", agentId: "agent-owner", content: "TEAMMATE-SHARED-FINDING", visibility: "shared", durability: "permanent", createdAt: "2026-01-01T00:00:00Z" });
     memoryGrants.push({ granteeId: "agent-grantee", ownerId: "agent-owner", scope: "read" });
 
     const b = makeBootstrap(agentCtx("agent-grantee"));
-    const res: any = await b.post({ agentId: "agent-grantee", includeSoul: false });
-    expect(res.context).toContain("TEAMMATE-SHARED-FINDING");
+    const res: any = await b.post({ agentId: "agent-grantee", includeSoul: false }); // no currentTask
+    // Layer 1: the SHARED memory is in the reader's read-scope ...
     expect(res.memoriesAvailable).toBe(1);
+    // ... but the #550 design boundary keeps it out of the reader's OWN
+    // permanent/recent/predicted view — with no currentTask, its only surface
+    // (the task-relevant "Teammate findings" section) is inactive, so it
+    // renders nowhere. This is the non-bleed guarantee.
+    expect(res.context).not.toContain("TEAMMATE-SHARED-FINDING");
   });
 
   it("private-exclusion: a grant-holder does NOT see the owner's PRIVATE memory", async () => {
@@ -148,14 +158,20 @@ describe("MemoryBootstrap.post() — ops-2dm3 Layer 1 centralized read-scoping",
     expect(res.memoriesAvailable).toBe(0);
   });
 
-  it("migration invariant: a grant-holder sees a NO-visibility-field owner record (absent reads as shared)", async () => {
+  it("migration invariant: a grant-holder's read-scope includes a NO-visibility-field owner record (absent reads as shared) — but it too stays out of own-context sections", async () => {
     reset();
     memoryStore.set("legacy-1", { id: "legacy-1", agentId: "agent-owner", content: "LEGACY-PRE-MIGRATION-FINDING", durability: "permanent", createdAt: "2026-01-01T00:00:00Z" }); // no visibility field
     memoryGrants.push({ granteeId: "agent-grantee", ownerId: "agent-owner", scope: "search" });
 
     const b = makeBootstrap(agentCtx("agent-grantee"));
     const res: any = await b.post({ agentId: "agent-grantee", includeSoul: false });
-    expect(res.context).toContain("LEGACY-PRE-MIGRATION-FINDING");
+    // Migration invariant lives at the READ-SCOPE layer: an absent visibility
+    // field reads as shared, so the legacy record enters the grantee's scope
+    // (vs. a private record, which would not — see the private-exclusion test's
+    // memoriesAvailable === 0). Rendering is still own-only, so with no
+    // currentTask it doesn't bleed into the reader's own-context view.
+    expect(res.memoriesAvailable).toBe(1);
+    expect(res.context).not.toContain("LEGACY-PRE-MIGRATION-FINDING");
   });
 
   it("without any grant, an ungranted owner's SHARED memory is still invisible (no bypass)", async () => {
@@ -200,14 +216,19 @@ const OLD_DATE = "2020-01-01T00:00:00Z";
 describe("MemoryBootstrap.post() — flair#550 teammate-findings attribution + section", () => {
   it("formatMemory attributes a grant-visible teammate SHARED memory with [via <ownerId>]", async () => {
     reset();
+    // A teammate record only RENDERS via the task-relevant teammate section
+    // (own-context sections are own-only), so make it task-relevant: embedding
+    // + currentTask (mocked getEmbedding → cosine 1.0 clears score > 0.3).
     memoryStore.set("shared-attr", {
       id: "shared-attr", agentId: "agent-owner", content: "TEAMMATE-ATTR-FINDING",
-      visibility: "shared", durability: "permanent", createdAt: "2026-01-01T00:00:00Z",
+      visibility: "shared", durability: "standard", createdAt: OLD_DATE, embedding: FAKE_EMBEDDING,
     });
     memoryGrants.push({ granteeId: "agent-grantee", ownerId: "agent-owner", scope: "read" });
 
     const b = makeBootstrap(agentCtx("agent-grantee"));
-    const res: any = await b.post({ agentId: "agent-grantee", includeSoul: false });
+    const res: any = await b.post({
+      agentId: "agent-grantee", includeSoul: false, currentTask: "investigate the thing",
+    });
     expect(res.context).toContain("[via agent-owner] TEAMMATE-ATTR-FINDING");
   });
 
@@ -227,15 +248,19 @@ describe("MemoryBootstrap.post() — flair#550 teammate-findings attribution + s
 
   it("attribution composes with the safety wrap — a flagged teammate memory shows BOTH", async () => {
     reset();
+    // Task-relevant (embedding + currentTask) so the flagged teammate record
+    // reaches the teammate section where it renders — see the note above.
     memoryStore.set("shared-flagged", {
       id: "shared-flagged", agentId: "agent-owner", content: "TEAMMATE-FLAGGED-FINDING",
-      visibility: "shared", durability: "permanent", createdAt: "2026-01-01T00:00:00Z",
+      visibility: "shared", durability: "standard", createdAt: OLD_DATE, embedding: FAKE_EMBEDDING,
       _safetyFlags: ["prompt_injection"],
     });
     memoryGrants.push({ granteeId: "agent-grantee", ownerId: "agent-owner", scope: "read" });
 
     const b = makeBootstrap(agentCtx("agent-grantee"));
-    const res: any = await b.post({ agentId: "agent-grantee", includeSoul: false });
+    const res: any = await b.post({
+      agentId: "agent-grantee", includeSoul: false, currentTask: "investigate the thing",
+    });
     // Both markers present ...
     expect(res.context).toContain("[⚠️ SAFETY:");
     expect(res.context).toContain("[via agent-owner]");
@@ -336,5 +361,98 @@ describe("MemoryBootstrap.post() — flair#550 teammate-findings attribution + s
     const res: any = await b.post({ agentId: "agent-grantee", includeSoul: false }); // no currentTask
     expect(res.context).not.toContain("## Teammate findings relevant to your task");
     expect(res.sections.teammate).toBe(0);
+  });
+
+  // ─── Own-context sections are OWN-ONLY (the design-correction boundary) ─────
+  // Post-Layer-1 `activeMemories` carries grant-visible teammate records; the
+  // permanent / recent / predicted sections must NOT blend them into the
+  // reader's own working context. Grant-visibility feeds ONLY the
+  // task-relevant "Teammate findings" surface (or an explicit memory_search).
+
+  it("a teammate's grant-visible PERMANENT memory does NOT appear in the reader's Core Principles (permanent) section", async () => {
+    reset();
+    // Give the reader an OWN permanent memory too, so the section renders and
+    // we're asserting the teammate one is absent from a LIVE section (not just
+    // that the section is empty).
+    memoryStore.set("own-perm", {
+      id: "own-perm", agentId: "agent-grantee", content: "MY-OWN-PERMANENT-RULE",
+      durability: "permanent", createdAt: "2026-01-01T00:00:00Z",
+    });
+    memoryStore.set("teammate-perm", {
+      id: "teammate-perm", agentId: "agent-owner", content: "TEAMMATE-PERMANENT-RULE",
+      visibility: "shared", durability: "permanent", createdAt: "2026-01-01T00:00:00Z",
+    });
+    memoryGrants.push({ granteeId: "agent-grantee", ownerId: "agent-owner", scope: "read" });
+
+    const b = makeBootstrap(agentCtx("agent-grantee"));
+    const res: any = await b.post({ agentId: "agent-grantee", includeSoul: false }); // no currentTask
+    expect(res.context).toContain("## Core Principles");
+    expect(res.context).toContain("MY-OWN-PERMANENT-RULE");         // own → renders
+    expect(res.context).not.toContain("TEAMMATE-PERMANENT-RULE");   // teammate → no bleed
+    expect(res.memoriesAvailable).toBe(2);                          // both in read-scope
+  });
+
+  it("a teammate's grant-visible RECENT memory does NOT appear in the reader's Recent Context section", async () => {
+    reset();
+    const recentDate = new Date(Date.now() - 3600_000).toISOString(); // 1h ago — inside the 48h window
+    memoryStore.set("own-recent", {
+      id: "own-recent", agentId: "agent-grantee", content: "MY-OWN-RECENT-NOTE",
+      durability: "standard", createdAt: recentDate,
+    });
+    memoryStore.set("teammate-recent", {
+      id: "teammate-recent", agentId: "agent-owner", content: "TEAMMATE-RECENT-NOTE",
+      visibility: "shared", durability: "standard", createdAt: recentDate,
+    });
+    memoryGrants.push({ granteeId: "agent-grantee", ownerId: "agent-owner", scope: "read" });
+
+    const b = makeBootstrap(agentCtx("agent-grantee"));
+    const res: any = await b.post({ agentId: "agent-grantee", includeSoul: false }); // no currentTask
+    expect(res.context).toContain("## Recent Context");
+    expect(res.context).toContain("MY-OWN-RECENT-NOTE");        // own → renders
+    expect(res.context).not.toContain("TEAMMATE-RECENT-NOTE");  // teammate → no bleed
+  });
+
+  it("a teammate's grant-visible subject-tagged memory does NOT appear in the reader's Predicted Context section", async () => {
+    reset();
+    memoryStore.set("own-subj", {
+      id: "own-subj", agentId: "agent-grantee", content: "MY-OWN-SUBJECT-NOTE",
+      durability: "standard", subject: "billing", createdAt: "2026-01-01T00:00:00Z",
+    });
+    memoryStore.set("teammate-subj", {
+      id: "teammate-subj", agentId: "agent-owner", content: "TEAMMATE-SUBJECT-NOTE",
+      visibility: "shared", durability: "standard", subject: "billing", createdAt: "2026-01-01T00:00:00Z",
+    });
+    memoryGrants.push({ granteeId: "agent-grantee", ownerId: "agent-owner", scope: "read" });
+
+    const b = makeBootstrap(agentCtx("agent-grantee"));
+    const res: any = await b.post({ agentId: "agent-grantee", includeSoul: false, subjects: ["billing"] });
+    expect(res.context).toContain("## Predicted Context");
+    expect(res.context).toContain("MY-OWN-SUBJECT-NOTE");       // own → renders
+    expect(res.context).not.toContain("TEAMMATE-SUBJECT-NOTE"); // teammate → no bleed
+  });
+
+  it("a teammate's grant-visible PERMANENT memory that IS task-relevant surfaces in 'Teammate findings' (not 'Core Principles')", async () => {
+    reset();
+    // durability: "permanent" — proves the teammate surface is by ORIGIN, not
+    // durability: a permanent-durability teammate record is excluded from the
+    // (own-only) permanent section yet still reaches the scored teammate path.
+    memoryStore.set("teammate-perm-task", {
+      id: "teammate-perm-task", agentId: "agent-owner", content: "TEAMMATE-PERMANENT-TASK-FINDING",
+      visibility: "shared", durability: "permanent", createdAt: OLD_DATE, embedding: FAKE_EMBEDDING,
+    });
+    memoryGrants.push({ granteeId: "agent-grantee", ownerId: "agent-owner", scope: "read" });
+
+    const b = makeBootstrap(agentCtx("agent-grantee"));
+    const res: any = await b.post({
+      agentId: "agent-grantee", includeSoul: false, currentTask: "investigate the thing",
+    });
+    // Surfaces in the teammate section, attributed ...
+    expect(res.context).toContain("## Teammate findings relevant to your task");
+    expect(res.context).toContain("[via agent-owner] TEAMMATE-PERMANENT-TASK-FINDING");
+    expect(res.sections.teammate).toBe(1);
+    // ... and never in Core Principles (the permanent section stayed own-only,
+    // which here is empty → no header at all).
+    expect(res.context).not.toContain("## Core Principles");
+    expect(res.sections.permanent).toBe(0);
   });
 });

--- a/test/unit/memory-bootstrap-scoping.test.ts
+++ b/test/unit/memory-bootstrap-scoping.test.ts
@@ -20,6 +20,26 @@ import { describe, it, expect, mock } from "bun:test";
 process.env.FLAIR_RATE_LIMIT_ENABLED = "false";
 delete (process.env as any).FLAIR_PUBLIC;
 
+// Deterministic task-relevance scoring without a real embedding model — same
+// technique as test/unit/memory-integrity.test.ts (constant vector → cosine
+// 1.0 between any two records using it), sized to clear MemoryBootstrap.ts's
+// OWN scored-path candidate filter (`m.embedding?.length > 100` — a record
+// with a short/absent embedding is never even considered "task-relevant").
+// MemoryBootstrap.ts's task-relevant path calls getEmbedding(currentTask) for
+// the query vector and reads `record.embedding` directly off whatever's in
+// the mock store, so the SAME 128-length vector on both sides deterministically
+// clears both the length gate and the `score > 0.3` threshold (dot product
+// with itself = 1). memory-integrity.test.ts's own mock of this module only
+// needs "a constant vector returned every call" (never compares its literal
+// values against anything) — length differing between the two files' mocks
+// doesn't matter to either.
+const FAKE_EMBEDDING = [1, ...Array(127).fill(0)];
+mock.module("../../resources/embeddings-provider.ts", () => ({
+  getEmbedding: async (_text: string) => FAKE_EMBEDDING,
+  getModelId: () => "mock-embedding-model",
+  getMode: () => "local",
+}));
+
 function matchesCondition(record: any, cond: any): boolean {
   if (cond.operator && Array.isArray(cond.conditions)) {
     const results = cond.conditions.map((c: any) => matchesCondition(record, c));
@@ -155,5 +175,166 @@ describe("MemoryBootstrap.post() — ops-2dm3 Layer 1 centralized read-scoping",
     const b = makeBootstrap(agentCtx("agent-1"));
     const res: any = await b.post({ agentId: "agent-1", includeSoul: false });
     expect(res.context).toContain("MY-OWN-PRIVATE-NOTE");
+  });
+});
+
+// ─── flair#550 — teammate findings attribution + "Teammate findings" section ─
+//
+// Layer 1 (above) already made grant-visible teammate SHARED memories
+// reachable through bootstrap's read scope; these tests cover the
+// PRESENTATION gap: (1) formatMemory() attributes a cross-agent record with
+// "[via <ownerId>]" and composes with the safety wrap, and (2) the
+// currentTask-scored path splits by origin into sections.relevant (own) vs
+// the new sections.teammate (grant-visible teammate), never mixing them, and
+// never letting a teammate's PRIVATE memory reach the scored path at all
+// (Layer 1's exclusion, re-asserted here as a guard on the NEW split code).
+//
+// All records below carry embedding: FAKE_EMBEDDING so they clear the
+// `score > 0.3` deterministic-cosine-1.0 threshold against any currentTask
+// (mocked getEmbedding returns the same vector, see top of file). createdAt
+// is pinned far in the past so nothing here is ever swept into the
+// recent/permanent sections instead — the point is to isolate the
+// task-relevant scored path exclusively.
+const OLD_DATE = "2020-01-01T00:00:00Z";
+
+describe("MemoryBootstrap.post() — flair#550 teammate-findings attribution + section", () => {
+  it("formatMemory attributes a grant-visible teammate SHARED memory with [via <ownerId>]", async () => {
+    reset();
+    memoryStore.set("shared-attr", {
+      id: "shared-attr", agentId: "agent-owner", content: "TEAMMATE-ATTR-FINDING",
+      visibility: "shared", durability: "permanent", createdAt: "2026-01-01T00:00:00Z",
+    });
+    memoryGrants.push({ granteeId: "agent-grantee", ownerId: "agent-owner", scope: "read" });
+
+    const b = makeBootstrap(agentCtx("agent-grantee"));
+    const res: any = await b.post({ agentId: "agent-grantee", includeSoul: false });
+    expect(res.context).toContain("[via agent-owner] TEAMMATE-ATTR-FINDING");
+  });
+
+  it("the caller's own memory renders WITHOUT any [via ...] attribution (unchanged)", async () => {
+    reset();
+    memoryStore.set("own-attr", {
+      id: "own-attr", agentId: "agent-1", content: "MY-OWN-UNATTRIBUTED-FINDING",
+      durability: "permanent", createdAt: "2026-01-01T00:00:00Z",
+    });
+
+    const b = makeBootstrap(agentCtx("agent-1"));
+    const res: any = await b.post({ agentId: "agent-1", includeSoul: false });
+    // durability: "permanent" → 🔒 tag (see formatMemory's tag selection).
+    expect(res.context).toContain("🔒 MY-OWN-UNATTRIBUTED-FINDING");
+    expect(res.context).not.toContain("[via");
+  });
+
+  it("attribution composes with the safety wrap — a flagged teammate memory shows BOTH", async () => {
+    reset();
+    memoryStore.set("shared-flagged", {
+      id: "shared-flagged", agentId: "agent-owner", content: "TEAMMATE-FLAGGED-FINDING",
+      visibility: "shared", durability: "permanent", createdAt: "2026-01-01T00:00:00Z",
+      _safetyFlags: ["prompt_injection"],
+    });
+    memoryGrants.push({ granteeId: "agent-grantee", ownerId: "agent-owner", scope: "read" });
+
+    const b = makeBootstrap(agentCtx("agent-grantee"));
+    const res: any = await b.post({ agentId: "agent-grantee", includeSoul: false });
+    // Both markers present ...
+    expect(res.context).toContain("[⚠️ SAFETY:");
+    expect(res.context).toContain("[via agent-owner]");
+    expect(res.context).toContain("TEAMMATE-FLAGGED-FINDING");
+    // ... and the attribution is INSIDE the safety wrapper (attribution is
+    // baked into `base` before wrapUntrusted() wraps it), not appended after.
+    const safetyStart = res.context.indexOf("[⚠️ SAFETY:");
+    const safetyEnd = res.context.indexOf("[/SAFETY]");
+    const viaIdx = res.context.indexOf("[via agent-owner]");
+    expect(viaIdx).toBeGreaterThan(safetyStart);
+    expect(viaIdx).toBeLessThan(safetyEnd);
+  });
+
+  it("a task-relevant teammate SHARED memory lands in the new 'Teammate findings' section, attributed", async () => {
+    reset();
+    memoryStore.set("teammate-task", {
+      id: "teammate-task", agentId: "agent-owner", content: "TEAMMATE-TASK-RELEVANT-FINDING",
+      visibility: "shared", durability: "standard", createdAt: OLD_DATE, embedding: FAKE_EMBEDDING,
+    });
+    memoryGrants.push({ granteeId: "agent-grantee", ownerId: "agent-owner", scope: "read" });
+
+    const b = makeBootstrap(agentCtx("agent-grantee"));
+    const res: any = await b.post({
+      agentId: "agent-grantee", includeSoul: false, currentTask: "investigate the thing",
+    });
+    expect(res.context).toContain("## Teammate findings relevant to your task");
+    expect(res.context).toContain("[via agent-owner] TEAMMATE-TASK-RELEVANT-FINDING");
+    expect(res.sections.teammate).toBe(1);
+    expect(res.sections.relevant).toBe(0);
+  });
+
+  it("the agent's OWN task-relevant memory lands in 'relevant', never 'teammate'", async () => {
+    reset();
+    memoryStore.set("own-task", {
+      id: "own-task", agentId: "agent-grantee", content: "MY-OWN-TASK-RELEVANT-FINDING",
+      durability: "standard", createdAt: OLD_DATE, embedding: FAKE_EMBEDDING,
+    });
+
+    const b = makeBootstrap(agentCtx("agent-grantee"));
+    const res: any = await b.post({
+      agentId: "agent-grantee", includeSoul: false, currentTask: "investigate the thing",
+    });
+    expect(res.context).toContain("## Relevant Knowledge");
+    expect(res.context).toContain("📝 MY-OWN-TASK-RELEVANT-FINDING");
+    expect(res.context).not.toContain("## Teammate findings relevant to your task");
+    expect(res.sections.relevant).toBe(1);
+    expect(res.sections.teammate).toBe(0);
+  });
+
+  it("own + teammate task-relevant findings both surface, correctly split, in one bootstrap", async () => {
+    reset();
+    memoryStore.set("own-task-2", {
+      id: "own-task-2", agentId: "agent-grantee", content: "MIXED-OWN-FINDING",
+      durability: "standard", createdAt: OLD_DATE, embedding: FAKE_EMBEDDING,
+    });
+    memoryStore.set("teammate-task-2", {
+      id: "teammate-task-2", agentId: "agent-owner", content: "MIXED-TEAMMATE-FINDING",
+      visibility: "shared", durability: "standard", createdAt: OLD_DATE, embedding: FAKE_EMBEDDING,
+    });
+    memoryGrants.push({ granteeId: "agent-grantee", ownerId: "agent-owner", scope: "read" });
+
+    const b = makeBootstrap(agentCtx("agent-grantee"));
+    const res: any = await b.post({
+      agentId: "agent-grantee", includeSoul: false, currentTask: "investigate the thing",
+    });
+    expect(res.context).toContain("📝 MIXED-OWN-FINDING");
+    expect(res.context).toContain("[via agent-owner] MIXED-TEAMMATE-FINDING");
+    expect(res.sections.relevant).toBe(1);
+    expect(res.sections.teammate).toBe(1);
+  });
+
+  it("guard: a teammate's PRIVATE memory never reaches the task-relevant scored path (Layer 1 exclusion holds under the new split)", async () => {
+    reset();
+    memoryStore.set("teammate-private-task", {
+      id: "teammate-private-task", agentId: "agent-owner", content: "TEAMMATE-PRIVATE-TASK-FINDING",
+      visibility: "private", durability: "standard", createdAt: OLD_DATE, embedding: FAKE_EMBEDDING,
+    });
+    memoryGrants.push({ granteeId: "agent-grantee", ownerId: "agent-owner", scope: "read" });
+
+    const b = makeBootstrap(agentCtx("agent-grantee"));
+    const res: any = await b.post({
+      agentId: "agent-grantee", includeSoul: false, currentTask: "investigate the thing",
+    });
+    expect(res.context).not.toContain("TEAMMATE-PRIVATE-TASK-FINDING");
+    expect(res.context).not.toContain("## Teammate findings relevant to your task");
+    expect(res.sections.teammate).toBe(0);
+  });
+
+  it("no currentTask, no teammate matches → the 'Teammate findings' header never renders (empty section renders nothing)", async () => {
+    reset();
+    memoryStore.set("shared-no-task", {
+      id: "shared-no-task", agentId: "agent-owner", content: "SHARED-NO-TASK-QUERY",
+      visibility: "shared", durability: "permanent", createdAt: "2026-01-01T00:00:00Z",
+    });
+    memoryGrants.push({ granteeId: "agent-grantee", ownerId: "agent-owner", scope: "read" });
+
+    const b = makeBootstrap(agentCtx("agent-grantee"));
+    const res: any = await b.post({ agentId: "agent-grantee", includeSoul: false }); // no currentTask
+    expect(res.context).not.toContain("## Teammate findings relevant to your task");
+    expect(res.sections.teammate).toBe(0);
   });
 });


### PR DESCRIPTION
Implements **#550 (ops-q6i5)** — proactively surface grant-visible teammate findings for the current task. Completes Kris's #522/#550 arc (Layer 1 was the prerequisite). **Presentation-only; the read boundary is Layer 1's `resolveReadScope`, untouched.**

## What
1. **Attribution** — `formatMemory` annotates cross-agent records `📝 [via <sourceAgent>] …` (uses the `_source` tag Layer 1 already sets on grant-visible records). Composes with the existing safety-wrap (attribution inside the wrapper).
2. **Distinct "Teammate findings" section** — the task-relevant scoring block splits scored candidates by `_source`: teammate → a new `## Teammate findings relevant to your task` section (attributed); own → `## Relevant Knowledge` as before. Same token budget, one pass. Empty section renders nothing.
3. **Own-context sections stay own-only (design correction)** — Layer 1 made bootstrap grant-aware, which had a side-effect: teammate memories bled into the agent's own `permanent`/`recent`/`predicted` sections. Fixed: those three now source from `ownMemories = activeMemories.filter(m => !m._source)`. Teammate knowledge surfaces ONLY via the task-relevant teammate section (or explicit memory_search) — the agent's own-context view stays *theirs*. (Flint product call.)

## Security-test reconciliation (flag for Sherlock)
Three pre-existing tests asserted the OLD bleed (a granted teammate permanent memory rendering in a no-task bootstrap). Reconciled to assert **read-scope + non-bleed** while PRESERVING private-exclusion:
- The Layer-1 integration test now asserts `memoriesAvailable === 2` (grantee's scope = legacy+shared, private NOT in scope — a *stronger* check than content-absence: private isn't even readable) + the teammate records don't bleed into no-task context. **Private-exclusion is still asserted independently** in the same file via the by-id GET (`not.toContain("explicitly private note")`) and search (`ids.has(idPrivate) === false`) blocks — untouched.

## Verified (real Harper + real embeddings)
- Teammate SHARED task-relevant → teammate section, attributed. Teammate PRIVATE → excluded everywhere. Own task-relevant → `relevant`, not `teammate`. Teammate permanent/recent → NOT in own-context sections. No currentTask → no teammate section.
- Full suite: **unit 1442/0, integration 172/0** (I re-ran on the branch, base 5f36e2d).

@tps-sherlock — please re-verify the security-test reconciliation preserves private-exclusion (the boundary itself is Layer 1's, unchanged; this only changes bootstrap presentation). @tps-kern — the own-only section split + the teammate-section wiring.
