### PR TITLE
feat(deploy): self-verifying flair deploy — timeout passthrough + served-API verification (ops-qj88)

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -6966,6 +6966,11 @@ program
   .option("--no-restart", "Do not restart the component after deploy (default: restart=true)")
   .option("--dry-run", "Resolve package, validate args, skip the deploy call")
   .option("--package-root <dir>", "Override package root (mainly for testing)")
+  .option("--deployment-timeout <ms>", "Milliseconds harper waits for cluster-wide peer replication (env: FABRIC_DEPLOYMENT_TIMEOUT; default: 600000 — harper's own 120s default is too short for Fabric)")
+  .option("--install-timeout <ms>", "Milliseconds harper waits for package install (env: FABRIC_INSTALL_TIMEOUT; default: 600000)")
+  .option("--no-verify", "Skip post-deploy served-API verification (default: verify — on by design, so the CLI can't report success on an empty/broken deploy)")
+  .option("--verify-timeout <ms>", "Milliseconds to wait for the served API to settle after harper's post-deploy restart before verifying (default: 300000)")
+  .option("--verify-resource <name>", "Resource to verify is serving after deploy (repeatable; default: derived from the deployed package's dist/resources)", (val: string, prev: string[]) => [...prev, val], [] as string[])
   .action(async (opts) => {
     const green = (s: string) => `\x1b[32m${s}\x1b[0m`;
     const red = (s: string) => `\x1b[31m${s}\x1b[0m`;
@@ -6984,6 +6989,12 @@ program
       restart: opts.restart !== false,
       dryRun: opts.dryRun ?? false,
       packageRoot: opts.packageRoot,
+      deploymentTimeoutMs: Number(opts.deploymentTimeout ?? process.env.FABRIC_DEPLOYMENT_TIMEOUT ?? 600_000),
+      installTimeoutMs: Number(opts.installTimeout ?? process.env.FABRIC_INSTALL_TIMEOUT ?? 600_000),
+      verify: opts.verify !== false,
+      verifyResources: (opts.verifyResource as string[] | undefined)?.length ? opts.verifyResource : undefined,
+      verifyTimeoutMs: Number(opts.verifyTimeout ?? 300_000),
+      onProgress: (msg: string) => console.log(dim(`  ${msg}`)),
     };
 
     const errors = validateDeployOptions(deployOpts);
@@ -7012,7 +7023,7 @@ program
         console.log(dim(`  package root: ${result.packageRoot}`));
         return;
       }
-      console.log(`\n${green("✓")} Flair ${result.version} deployed`);
+      console.log(`\n${green("✓")} Flair ${result.version} deployed${deployOpts.verify ? " and verified serving" : ""}`);
       console.log(`\n  URL:     ${result.url}`);
       console.log(`  Project: ${result.project}`);
       console.log(`\nNext steps:`);
@@ -7024,6 +7035,12 @@ program
       const hint = err.message?.toLowerCase();
       if (hint?.includes("401") || hint?.includes("unauthoriz")) {
         console.error(dim("  hint: check Fabric Studio → Cluster Settings → Admin for the admin password"));
+      }
+      if (hint?.includes("component is not serving")) {
+        console.error(dim("  hint: harper reported success but the served API disagrees — check the Fabric Studio component logs for the real deploy error, then retry"));
+      }
+      if (hint?.includes("did not settle")) {
+        console.error(dim("  hint: Harper may still be restarting — check Fabric Studio, or retry with a longer --verify-timeout"));
       }
       process.exit(1);
     }

--- a/src/deploy.ts
+++ b/src/deploy.ts
@@ -168,8 +168,11 @@ export function validatePackageLayout(packageRoot: string): void {
 // WorkspaceLatest, action-style endpoints) are deliberately excluded here —
 // they're action/command endpoints, not GET-able collections, and asserting
 // non-404 on them would be the wrong check.
-const TABLE_RESOURCE_RE = (name: string) =>
-  new RegExp(`export class ${name} extends databases\\.[A-Za-z_$][\\w$]*\\.${name}\\b`);
+// Literal regex (no interpolation — satisfies semgrep detect-non-literal-regexp):
+// matches `export class <Name> extends databases.<db>.<Name>` where the `\1`
+// backreference forces the class name and the table name to be identical.
+// Capture group 1 is the resource name; the caller matches it against the filename.
+const EXPORTED_TABLE_CLASS_RE = /export class (\w+) extends databases\.[A-Za-z_$][\w$]*\.\1\b/g;
 
 export function deriveVerifyResources(packageRoot: string): string[] {
   const resourcesDir = join(packageRoot, "dist", "resources");
@@ -191,7 +194,11 @@ export function deriveVerifyResources(packageRoot: string): string[] {
     } catch {
       continue;
     }
-    if (TABLE_RESOURCE_RE(base).test(src)) names.push(base);
+    // The file serves a table resource iff it exports a class whose name matches
+    // its filename (base) and extends databases.<db>.<sameName>.
+    for (const m of src.matchAll(EXPORTED_TABLE_CLASS_RE)) {
+      if (m[1] === base) { names.push(base); break; }
+    }
   }
   names.sort();
   return names.length ? names : [FALLBACK_VERIFY_RESOURCE];

--- a/src/deploy.ts
+++ b/src/deploy.ts
@@ -1,6 +1,6 @@
 import { spawn } from "node:child_process";
 import { dirname, join, resolve } from "node:path";
-import { existsSync, readFileSync } from "node:fs";
+import { existsSync, readFileSync, readdirSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { createRequire } from "node:module";
 
@@ -17,6 +17,23 @@ export interface DeployOptions {
   restart?: boolean;
   dryRun?: boolean;
   packageRoot?: string;
+  // How long harper's own deploy CLI will wait for cluster-wide peer
+  // replication / package install before giving up. Both default to
+  // DEFAULT_DEPLOYMENT_TIMEOUT_MS / DEFAULT_INSTALL_TIMEOUT_MS — the harper
+  // CLI's own default (120s) is too short for Fabric peer-replication and
+  // was the root cause of a real incident where the CLI aborted and forced
+  // a hand-rolled raw deploy.
+  deploymentTimeoutMs?: number;
+  installTimeoutMs?: number;
+  // Post-deploy served-API verification (on by default). See verifyDeployServing.
+  verify?: boolean;
+  verifyResources?: string[];
+  verifyTimeoutMs?: number;
+  // Optional progress sink so callers (the CLI) can surface what would
+  // otherwise be a silent multi-minute poll. Never required — deploy() and
+  // verifyDeployServing() work fine without it (e.g. fabric-upgrade.ts's
+  // reuse of deploy() doesn't pass one).
+  onProgress?: (msg: string) => void;
 }
 
 export interface DeployResult {
@@ -35,6 +52,26 @@ export const REQUIRED_PACKAGE_FILES = [
   "ui",
   "config.yaml",
 ] as const;
+
+// harper's own deploy CLI defaults to a 120s peer-replication timeout that's
+// too short for Fabric — the CLI aborts mid-replicate with no override,
+// which is exactly the incident this module now guards against. 10 minutes
+// gives cluster-wide replication + install room to actually finish.
+export const DEFAULT_DEPLOYMENT_TIMEOUT_MS = 600_000;
+export const DEFAULT_INSTALL_TIMEOUT_MS = 600_000;
+
+// Post-deploy verification: how long we'll wait for the served API to come
+// back up after harper's restart, how often we poll while waiting, and how
+// many consecutive reachable responses count as "settled" (a single
+// reachable probe right after restart can be a fluke mid-flap).
+export const DEFAULT_VERIFY_TIMEOUT_MS = 300_000;
+export const VERIFY_POLL_INTERVAL_MS = 15_000;
+export const VERIFY_SETTLE_STREAK = 3;
+
+// Fallback when dist/resources can't be scanned (e.g. an unusual package
+// layout via --package-root). Memory is Flair's original, always-present
+// resource — a reasonable single thing to check when derivation fails.
+export const FALLBACK_VERIFY_RESOURCE = "Memory";
 
 export function validateOptions(opts: DeployOptions): string[] {
   const errors: string[] = [];
@@ -112,6 +149,54 @@ export function validatePackageLayout(packageRoot: string): void {
   }
 }
 
+// Derive the list of served, table-backed REST resources from the compiled
+// package — no hardcoded resource list. Flair's jsResource files (dist/resources/*.js)
+// contain both real Resource classes (routable, GET-able) and plain helper
+// modules (embeddings, auth, scoring, etc). We only ship dist/ in the
+// published package (resources/*.ts source is not in package.json's `files`),
+// so this scans the COMPILED output, matching the convention every current
+// table-backed resource follows:
+//
+//   export class <Name> extends databases.<db>.<Name> { ... }
+//
+// i.e. the exported class name equals the filename equals the underlying
+// table name (Memory.js -> `export class Memory extends databases.flair.Memory`,
+// same for Agent, Soul, MemoryGrant, Credential, OrgEvent, etc). Helper
+// modules are lowercase-first (agent-auth.js, embeddings-provider.js, ...)
+// and never match, so they're skipped without needing a denylist. Files
+// that export a resource extending a *generic* `Resource` base (AgentCard,
+// WorkspaceLatest, action-style endpoints) are deliberately excluded here —
+// they're action/command endpoints, not GET-able collections, and asserting
+// non-404 on them would be the wrong check.
+const TABLE_RESOURCE_RE = (name: string) =>
+  new RegExp(`export class ${name} extends databases\\.[A-Za-z_$][\\w$]*\\.${name}\\b`);
+
+export function deriveVerifyResources(packageRoot: string): string[] {
+  const resourcesDir = join(packageRoot, "dist", "resources");
+  let entries: string[];
+  try {
+    entries = readdirSync(resourcesDir);
+  } catch {
+    return [FALLBACK_VERIFY_RESOURCE];
+  }
+
+  const names: string[] = [];
+  for (const entry of entries) {
+    if (!entry.endsWith(".js")) continue;
+    const base = entry.slice(0, -3);
+    if (!/^[A-Z]/.test(base)) continue; // helper modules are camelCase/lowercase
+    let src: string;
+    try {
+      src = readFileSync(join(resourcesDir, entry), "utf8");
+    } catch {
+      continue;
+    }
+    if (TABLE_RESOURCE_RE(base).test(src)) names.push(base);
+  }
+  names.sort();
+  return names.length ? names : [FALLBACK_VERIFY_RESOURCE];
+}
+
 function resolveHarperBin(packageRoot: string): string {
   const local = join(
     packageRoot,
@@ -139,6 +224,27 @@ function resolveHarperBin(packageRoot: string): string {
   );
 }
 
+// Pure arg-array builder — separated from spawnHarper so the timeout
+// passthrough (and the rest of the arg shape) is unit-testable without
+// mocking child_process / actually spawning harper.
+export function buildHarperDeployArgs(
+  opts: DeployOptions,
+  url: string,
+  project: string,
+): string[] {
+  const deploymentTimeoutMs = opts.deploymentTimeoutMs ?? DEFAULT_DEPLOYMENT_TIMEOUT_MS;
+  const installTimeoutMs = opts.installTimeoutMs ?? DEFAULT_INSTALL_TIMEOUT_MS;
+  return [
+    "deploy",
+    `target=${url}`,
+    `project=${project}`,
+    `restart=${opts.restart !== false}`,
+    `replicated=${opts.replicated !== false}`,
+    `deployment_timeout=${deploymentTimeoutMs}`,
+    `install_timeout=${installTimeoutMs}`,
+  ];
+}
+
 function spawnHarper(
   bin: string,
   args: string[],
@@ -157,6 +263,121 @@ function spawnHarper(
       else rejectP(new Error(`harper deploy exited with code ${code}`));
     });
   });
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+// A single reachability probe against the served (REST) base URL. Harper
+// restarts the process after every deploy, so the endpoint FLAPS for a bit —
+// connection refused / reset / DNS blips are all EXPECTED right after
+// restart, not a failure signal by themselves. Any HTTP response at all
+// (regardless of status code — a 404 on `/` is normal) proves the process
+// is back up and terminating TLS/HTTP again; that's all "reachable" means
+// here. Resource-level 404s are a separate, later check.
+async function probeReachable(baseUrl: string, fetchImpl: typeof fetch): Promise<boolean> {
+  try {
+    await fetchImpl(baseUrl, { method: "GET", signal: AbortSignal.timeout(10_000) });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export interface VerifyDeployOptions {
+  baseUrl: string;
+  resources: string[];
+  timeoutMs?: number;
+  pollIntervalMs?: number;
+  settleStreak?: number;
+  fetchImpl?: typeof fetch;
+  onProgress?: (msg: string) => void;
+}
+
+async function pollUntilSettled(
+  baseUrl: string,
+  timeoutMs: number,
+  pollIntervalMs: number,
+  settleStreak: number,
+  fetchImpl: typeof fetch,
+  onProgress?: (msg: string) => void,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  let streak = 0;
+  let attempt = 0;
+  for (;;) {
+    attempt++;
+    const reachable = await probeReachable(baseUrl, fetchImpl);
+    streak = reachable ? streak + 1 : 0;
+    if (!reachable) {
+      onProgress?.(`waiting for ${baseUrl} to come back up after restart (attempt ${attempt})...`);
+    }
+    if (streak >= settleStreak) return;
+    if (Date.now() >= deadline) {
+      throw new Error(
+        `deploy verification: ${baseUrl} did not settle within ${timeoutMs}ms after restart ` +
+          `(Harper never came back up, or is unusually slow to restart post-deploy)`,
+      );
+    }
+    await sleep(pollIntervalMs);
+  }
+}
+
+async function verifyResourcesServing(
+  baseUrl: string,
+  resources: string[],
+  fetchImpl: typeof fetch,
+): Promise<void> {
+  const base = baseUrl.replace(/\/+$/, "");
+  const notServing: string[] = [];
+  for (const name of resources) {
+    const path = `${base}/${name}`;
+    let status: number;
+    try {
+      const res = await fetchImpl(path, { method: "GET", signal: AbortSignal.timeout(10_000) });
+      status = res.status;
+    } catch (err: any) {
+      throw new Error(
+        `deploy verification: request to ${path} failed even after the endpoint settled: ${err?.message ?? err}`,
+      );
+    }
+    // 404 = the resource genuinely isn't being served (this is the incident:
+    // harper reported "Successfully deployed" while the component was empty).
+    // 401 = auth-gated, which means the resource IS being served correctly.
+    // 200 = served + accessible. Both count as pass.
+    if (status === 404) notServing.push(name);
+  }
+  if (notServing.length) {
+    const list = notServing.map((n) => `/${n}`).join(", ");
+    throw new Error(
+      `deploy reported success but ${list} return${notServing.length === 1 ? "s" : ""} 404 — ` +
+        `component is not serving; likely deployed the wrong package root`,
+    );
+  }
+}
+
+// The tool must not be able to lie. harper's deploy CLI can print
+// "Successfully deployed" for an empty component — the only way to know the
+// deploy actually worked is to curl the served API and check it isn't 404.
+// This polls the served base URL (443, NOT the :9925 ops API deploy talks
+// to) until it settles after harper's post-deploy restart, then asserts the
+// derived resource(s) respond non-404.
+export async function verifyDeployServing(o: VerifyDeployOptions): Promise<void> {
+  const {
+    baseUrl,
+    resources,
+    timeoutMs = DEFAULT_VERIFY_TIMEOUT_MS,
+    pollIntervalMs = VERIFY_POLL_INTERVAL_MS,
+    settleStreak = VERIFY_SETTLE_STREAK,
+    fetchImpl = fetch,
+    onProgress,
+  } = o;
+  onProgress?.(`verifying ${baseUrl} is actually serving (not just reported deployed)...`);
+  await pollUntilSettled(baseUrl, timeoutMs, pollIntervalMs, settleStreak, fetchImpl, onProgress);
+  onProgress?.(`settled — checking ${resources.map((r) => `/${r}`).join(", ")}...`);
+  await verifyResourcesServing(baseUrl, resources, fetchImpl);
+  onProgress?.(`served API verified non-404 for ${resources.length} resource(s)`);
 }
 
 export async function deploy(opts: DeployOptions): Promise<DeployResult> {
@@ -188,13 +409,7 @@ export async function deploy(opts: DeployOptions): Promise<DeployResult> {
   }
 
   const harperBin = resolveHarperBin(packageRoot);
-  const args = [
-    "deploy",
-    `target=${url}`,
-    `project=${project}`,
-    `restart=${opts.restart !== false}`,
-    `replicated=${opts.replicated !== false}`,
-  ];
+  const args = buildHarperDeployArgs(opts, url, project);
 
   // Credentials go via env, not argv, so they don't appear in `ps` output
   // for the lifetime of the Harper child process. Harper's cliOperations
@@ -206,6 +421,22 @@ export async function deploy(opts: DeployOptions): Promise<DeployResult> {
   };
 
   await spawnHarper(harperBin, args, packageRoot, childEnv);
+
+  // harper can print "Successfully deployed" for a component that isn't
+  // actually serving anything (the incident this closes: an empty deploy,
+  // reported success, /Memory 404ing in prod). Verify by curling the served
+  // API — on by default, escape hatch via --no-verify.
+  if (opts.verify !== false) {
+    const resources = opts.verifyResources?.length
+      ? opts.verifyResources
+      : deriveVerifyResources(packageRoot);
+    await verifyDeployServing({
+      baseUrl: url,
+      resources,
+      timeoutMs: opts.verifyTimeoutMs ?? DEFAULT_VERIFY_TIMEOUT_MS,
+      onProgress: opts.onProgress,
+    });
+  }
 
   return { url, project, version, packageRoot, dryRun: false };
 }

--- a/test/unit/deploy.test.ts
+++ b/test/unit/deploy.test.ts
@@ -16,6 +16,12 @@ import {
   validatePackageLayout,
   deploy,
   REQUIRED_PACKAGE_FILES,
+  buildHarperDeployArgs,
+  DEFAULT_DEPLOYMENT_TIMEOUT_MS,
+  DEFAULT_INSTALL_TIMEOUT_MS,
+  deriveVerifyResources,
+  FALLBACK_VERIFY_RESOURCE,
+  verifyDeployServing,
 } from "../../src/deploy.js";
 
 describe("flair deploy: validateOptions", () => {
@@ -163,5 +169,256 @@ describe("flair deploy: dry-run end-to-end", () => {
         // missing cluster + creds
       } as any),
     ).rejects.toThrow();
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────
+// Incident fix: harper's deploy CLI defaults to a 120s peer-replication
+// timeout with no override, which aborted a real Fabric deploy. These tests
+// cover the two closes: (A) timeout passthrough, (B) post-deploy verification
+// that the served API is actually serving (not just harper claiming success).
+// ─────────────────────────────────────────────────────────────────────────
+
+describe("flair deploy: buildHarperDeployArgs (timeout passthrough)", () => {
+  test("defaults deployment_timeout and install_timeout to 600000ms", () => {
+    expect(DEFAULT_DEPLOYMENT_TIMEOUT_MS).toBe(600_000);
+    expect(DEFAULT_INSTALL_TIMEOUT_MS).toBe(600_000);
+
+    const args = buildHarperDeployArgs(
+      { fabricOrg: "acme", fabricCluster: "prod", fabricUser: "a", fabricPassword: "b" },
+      "https://prod.acme.harperfabric.com",
+      "flair",
+    );
+    expect(args).toContain("deployment_timeout=600000");
+    expect(args).toContain("install_timeout=600000");
+  });
+
+  test("threads deploymentTimeoutMs / installTimeoutMs overrides through", () => {
+    const args = buildHarperDeployArgs(
+      { deploymentTimeoutMs: 900_000, installTimeoutMs: 45_000 },
+      "https://custom.host",
+      "flair",
+    );
+    expect(args).toContain("deployment_timeout=900000");
+    expect(args).toContain("install_timeout=45000");
+  });
+
+  test("still carries target/project/restart/replicated alongside the new timeout args", () => {
+    const args = buildHarperDeployArgs(
+      { restart: false, replicated: false },
+      "https://custom.host",
+      "myproject",
+    );
+    expect(args).toEqual([
+      "deploy",
+      "target=https://custom.host",
+      "project=myproject",
+      "restart=false",
+      "replicated=false",
+      "deployment_timeout=600000",
+      "install_timeout=600000",
+    ]);
+  });
+});
+
+describe("flair deploy: deriveVerifyResources", () => {
+  test("derives table-backed Resource classes, skips helpers and generic-Resource action endpoints", () => {
+    const dir = mkdtempSync(join(tmpdir(), "flair-deploy-derive-"));
+    const resourcesDir = join(dir, "dist", "resources");
+    mkdirSync(resourcesDir, { recursive: true });
+    try {
+      // Real table-backed resources (the kind curled in the incident).
+      writeFileSync(
+        join(resourcesDir, "Memory.js"),
+        "export class Memory extends databases.flair.Memory {}\n",
+      );
+      writeFileSync(
+        join(resourcesDir, "Soul.js"),
+        "export class Soul extends databases.flair.Soul {}\n",
+      );
+      // Action-style endpoint extending the generic Resource base — not a
+      // GET-able collection, must be excluded.
+      writeFileSync(
+        join(resourcesDir, "AgentCard.js"),
+        "export class AgentCard extends Resource {}\n",
+      );
+      // Lowercase helper module — never a route, must be excluded.
+      writeFileSync(
+        join(resourcesDir, "agent-auth.js"),
+        "export function allowAdmin() { return true; }\n",
+      );
+
+      const resources = deriveVerifyResources(dir);
+      expect(resources).toEqual(["Memory", "Soul"]);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("falls back to FALLBACK_VERIFY_RESOURCE when dist/resources can't be scanned", () => {
+    const dir = mkdtempSync(join(tmpdir(), "flair-deploy-derive-missing-"));
+    try {
+      expect(deriveVerifyResources(dir)).toEqual([FALLBACK_VERIFY_RESOURCE]);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("flair deploy: verifyDeployServing (served-API verification)", () => {
+  // Fast settling for tests: 1ms poll interval, 1-response streak unless a
+  // test needs to exercise the flap/retry path specifically.
+  const FAST = { pollIntervalMs: 1, settleStreak: 1, timeoutMs: 2000 };
+
+  test("404 on the resource fails loudly with a clear message (the incident: empty deploy, harper said success)", async () => {
+    const fetchImpl = (async (url: any) => {
+      const u = String(url);
+      return new Response("", { status: u.endsWith("/Memory") ? 404 : 200 });
+    }) as unknown as typeof fetch;
+
+    await expect(
+      verifyDeployServing({
+        baseUrl: "https://cluster.org.harperfabric.com",
+        resources: ["Memory"],
+        fetchImpl,
+        ...FAST,
+      }),
+    ).rejects.toThrow(/deploy reported success but \/Memory returns 404 — component is not serving/);
+  });
+
+  test("401 (auth-gated) and 200 both count as serving — no throw", async () => {
+    let call = 0;
+    const fetchImpl = (async () => {
+      call++;
+      // First call is the settle probe against baseUrl; alternate 401/200
+      // for the resource checks to prove both are accepted.
+      return new Response("", { status: call % 2 === 0 ? 401 : 200 });
+    }) as unknown as typeof fetch;
+
+    await expect(
+      verifyDeployServing({
+        baseUrl: "https://cluster.org.harperfabric.com",
+        resources: ["Memory", "Agent"],
+        fetchImpl,
+        ...FAST,
+      }),
+    ).resolves.toBeUndefined();
+  });
+
+  test("connection-flap (network failure, then reachable) retries the settle probe then passes", async () => {
+    let call = 0;
+    const fetchImpl = (async () => {
+      call++;
+      if (call <= 2) throw new Error("connect ECONNREFUSED (simulated post-restart flap)");
+      return new Response("", { status: 200 });
+    }) as unknown as typeof fetch;
+
+    await expect(
+      verifyDeployServing({
+        baseUrl: "https://cluster.org.harperfabric.com",
+        resources: ["Memory"],
+        fetchImpl,
+        pollIntervalMs: 1,
+        settleStreak: 3,
+        timeoutMs: 5000,
+      }),
+    ).resolves.toBeUndefined();
+    // 2 failures + 3-streak settle (3 more calls) + 1 resource check = 6
+    expect(call).toBeGreaterThanOrEqual(6);
+  });
+
+  test("endpoint never comes back (always unreachable) fails with a settle-timeout message", async () => {
+    const fetchImpl = (async () => {
+      throw new Error("connect ECONNREFUSED");
+    }) as unknown as typeof fetch;
+
+    await expect(
+      verifyDeployServing({
+        baseUrl: "https://cluster.org.harperfabric.com",
+        resources: ["Memory"],
+        fetchImpl,
+        pollIntervalMs: 5,
+        settleStreak: 3,
+        timeoutMs: 20,
+      }),
+    ).rejects.toThrow(/did not settle within 20ms after restart/);
+  });
+});
+
+describe("flair deploy: deploy() gating — --no-verify and --dry-run both skip verification", () => {
+  function synthPkgRootForGatingTests(): string {
+    const dir = mkdtempSync(join(tmpdir(), "flair-deploy-gating-"));
+    for (const f of REQUIRED_PACKAGE_FILES) {
+      const p = join(dir, f);
+      if (f.endsWith(".yaml")) writeFileSync(p, "port: 9926\n");
+      else mkdirSync(p, { recursive: true });
+    }
+    writeFileSync(
+      join(dir, "package.json"),
+      JSON.stringify({ name: "@tpsdev-ai/flair", version: "9.9.9-test" }),
+    );
+    return dir;
+  }
+
+  function addStubHarperBinary(packageRoot: string): void {
+    // Stands in for the real harper CLI so spawnHarper() succeeds without
+    // touching a real Fabric cluster — exits 0 immediately.
+    const binDir = join(packageRoot, "node_modules", "@harperfast", "harper", "dist", "bin");
+    mkdirSync(binDir, { recursive: true });
+    writeFileSync(join(binDir, "harper.js"), "process.exit(0);\n");
+  }
+
+  test("verify: false skips the served-API check entirely (--no-verify)", async () => {
+    const pkgRoot = synthPkgRootForGatingTests();
+    addStubHarperBinary(pkgRoot);
+    const origFetch = globalThis.fetch;
+    let fetchCalls = 0;
+    globalThis.fetch = (async () => {
+      fetchCalls++;
+      return new Response("", { status: 200 });
+    }) as any;
+    try {
+      const result = await deploy({
+        fabricOrg: "acme",
+        fabricCluster: "prod",
+        fabricUser: "admin",
+        fabricPassword: "pw",
+        packageRoot: pkgRoot,
+        verify: false,
+      });
+      expect(result.dryRun).toBe(false);
+      expect(fetchCalls).toBe(0);
+    } finally {
+      globalThis.fetch = origFetch;
+      rmSync(pkgRoot, { recursive: true, force: true });
+    }
+  });
+
+  test("--dry-run skips both the harper deploy call AND verification", async () => {
+    // Deliberately no stub harper binary present — if deploy() incorrectly
+    // tried to spawn harper, resolveHarperBin() would throw before we ever
+    // got here, failing this test.
+    const pkgRoot = synthPkgRootForGatingTests();
+    const origFetch = globalThis.fetch;
+    let fetchCalls = 0;
+    globalThis.fetch = (async () => {
+      fetchCalls++;
+      throw new Error("fetch must not be called during --dry-run");
+    }) as any;
+    try {
+      const result = await deploy({
+        fabricOrg: "acme",
+        fabricCluster: "prod",
+        fabricUser: "admin",
+        fabricPassword: "pw",
+        packageRoot: pkgRoot,
+        dryRun: true,
+      });
+      expect(result.dryRun).toBe(true);
+      expect(fetchCalls).toBe(0);
+    } finally {
+      globalThis.fetch = origFetch;
+      rmSync(pkgRoot, { recursive: true, force: true });
+    }
   });
 });


### PR DESCRIPTION
Makes `flair deploy` **unable to report false success** — the fix for tonight's incident (a hand-rolled deploy shipped an empty component while harper printed "Successfully deployed"; only curling the served API revealed `/Memory` 404s). Two changes, both in `src/deploy.ts` + `src/cli.ts`:

## A. Timeout passthrough (fixes the abort that forced the hand-roll)
`--deployment-timeout <ms>` / `--install-timeout <ms>` (env `FABRIC_DEPLOYMENT_TIMEOUT`/`FABRIC_INSTALL_TIMEOUT`), default **600000**, threaded into the harper deploy args (`deployment_timeout=` / `install_timeout=`). The CLI previously didn't expose these, so it aborted on the 120s peer-replication bug — forcing a raw hand-rolled deploy. Now it doesn't.

## B. Post-deploy served-API verification (the tool can't lie)
After harper reports success, the CLI polls the **served** base URL (443, not the `:9925` ops API) through the post-deploy restart flap (3 consecutive reachable = settled), then GETs each of the component's resources and **fails loudly on 404**:
> `deploy reported success but /Memory returns 404 — component is not serving; likely deployed the wrong package root`

- **Resources derived from the built package** (`dist/resources/*.js` → `export class <Name> extends databases.<db>.<Name>`), not hardcoded — yields 17 (Memory, Agent, Soul, MemoryGrant + 13 more). `--verify-resource <name>` overrides; falls back to `Memory` if `dist/resources` is unreadable.
- `401`/`200` = serving (401 = auth-gated, correct). `404` = empty deploy = fail.
- `--no-verify` escape hatch; `--verify-timeout <ms>` (default 300000) bounds the settle-poll. Node built-in `fetch`, no new deps. Valid LE cert → normal TLS (no `-k`).
- `flair upgrade` reuses `deploy()` → gets this protection free.

## Verified
Full unit suite **1453/1453** (baseline 1442 + 11 new: arg-building, resource-derivation incl. helper/action-endpoint exclusion, verify-serving 404-throws/401-passes/flap-retries/settle-timeout, and dry-run/`--no-verify` gating). `tsc` + `build:cli` clean; `--help` and dry-runs verified.

Plan: ship in v0.20.1, then dogfood by deploying 0.20.1 → Fabric *through this CLI*, then a tiny v0.20.2 to prove repeatability.

@tps-kern the verification design + resource derivation. @tps-sherlock this now gates deploys — any risk in the post-deploy curl, or the derivation missing/over-including a resource?
