### PR TITLE
feat(memory): provenance-capture slice 1 — server-stamped verified provenance on writes (§6a)

### DIFF
--- a/resources/Memory.ts
+++ b/resources/Memory.ts
@@ -339,6 +339,63 @@ function defaultVisibilityForDurability(durability: unknown): "private" | "share
   return durability === "permanent" || durability === "persistent" ? "shared" : "private";
 }
 
+/**
+ * ─── Write-time provenance stamp (memory-provenance slice 1) ────────────────
+ *
+ * Foundational capture for an emergent-trust model: every Memory write gets a
+ * structured, versioned `provenance` JSON blob recording what the server can
+ * actually VERIFY about the write, plus (optionally) what the caller merely
+ * CLAIMS. Deliberately minimal — verified fields only:
+ *
+ *   { v: 1,
+ *     verified: { agentId: <string|null>, timestamp: <ISO string> },
+ *     claimed?: { model: <string> } }
+ *
+ * - `verified.agentId` comes from the ALREADY-RESOLVED auth verdict
+ *   (resolveAgentAuth) — never from anything the caller can forge on the
+ *   request body. `kind: "agent"` → the Ed25519-verified agentId. Any other
+ *   verdict (in practice only `kind: "internal"` — a trusted in-process call
+ *   with no per-agent identity to attribute) stamps `null` rather than
+ *   throwing; `kind: "anonymous"` never reaches here — both post()/put()
+ *   already 401 it before this point.
+ * - `verified.timestamp` reuses the server-clock `createdAt` the caller has
+ *   already computed by this point (never client-suppliable) — the same
+ *   "stamp a dynamic attribute the server controls" mechanism as the existing
+ *   `embeddingModel = getModelId()` stamp elsewhere in this file. NOTE: the
+ *   *signed* Ed25519 request timestamp is also available (it's verified in
+ *   auth-middleware) but currently discarded there rather than threaded
+ *   through to resource methods — a future slice can carry it alongside (or
+ *   instead of) this server-clock timestamp without changing this shape's
+ *   `v: 1` contract. Not done here to keep auth-middleware untouched.
+ * - `claimed.model` is an OPTIONAL, UNVERIFIED passthrough: included only
+ *   when the incoming write payload itself already carries a non-empty
+ *   string `model` field. No client/CLI sets one today — this just means the
+ *   server won't discard it if/when a future write path does. Never
+ *   invented, never defaulted, and the `claimed` key is omitted entirely
+ *   (not stamped as `{}`) when absent.
+ *
+ * Deliberately NOT implemented in this slice: a context-fingerprint field —
+ * bootstrap doesn't return the IDs a fingerprint would need, so it requires
+ * client cooperation that's out of scope here.
+ */
+function buildProvenance(auth: AgentAuthVerdict, createdAt: string, content: any): string {
+  const provenance: {
+    v: 1;
+    verified: { agentId: string | null; timestamp: string };
+    claimed?: { model: string };
+  } = {
+    v: 1,
+    verified: {
+      agentId: auth.kind === "agent" ? auth.agentId : null,
+      timestamp: createdAt,
+    },
+  };
+  if (typeof content?.model === "string" && content.model.length > 0) {
+    provenance.claimed = { model: content.model };
+  }
+  return JSON.stringify(provenance);
+}
+
 export class Memory extends (databases as any).flair.Memory {
   /**
    * Self-authorize now that the global gate is non-rejecting. Closes the P0
@@ -570,6 +627,11 @@ export class Memory extends (databases as any).flair.Memory {
       if (vec) { content.embedding = vec; content.embeddingModel = getModelId(); }
     }
 
+    // Write-time provenance stamp (memory-provenance slice 1) — see
+    // buildProvenance's doc above. Stamped last, right before persist, so it
+    // reflects the final resolved `content.createdAt`.
+    content.provenance = buildProvenance(auth, content.createdAt, content);
+
     // ── Write the new record FIRST ──────────────────────────────────────────
     const result = await super.post(content);
 
@@ -725,6 +787,13 @@ export class Memory extends (databases as any).flair.Memory {
     if (content.promotionStatus === "approved") {
       content.durability = "permanent";
     }
+
+    // Write-time provenance stamp (memory-provenance slice 1) — see
+    // buildProvenance's doc above post(). Applies to every put() (fresh
+    // create AND update/patch) — never gated on preExisting, so an update
+    // always gets a freshly-stamped provenance reflecting the CURRENT
+    // authenticated actor performing this write.
+    content.provenance = buildProvenance(auth, content.createdAt, content);
 
     // ── Write the new/updated record FIRST ──────────────────────────────────
     const result = await super.put(content);

--- a/schemas/memory.graphql
+++ b/schemas/memory.graphql
@@ -31,6 +31,9 @@ type Memory @table(database: "flair") {
   validFrom: String @indexed   # ISO timestamp — when this fact became true
   validTo: String @indexed     # ISO timestamp — when this fact stopped being true (null = still valid)
   _safetyFlags: [String]       # content safety flags from scanContent()
+  provenance: String           # JSON blob (memory-provenance slice 1): { v, verified: { agentId, timestamp }, claimed?: { model } }
+                               # Nullable by design — existing rows read back provenance = null, unchanged behavior (clean-upgrade-path gate).
+                               # Same idiom as Soul.metadata below. Stamped server-side in resources/Memory.ts; never client-writable.
 }
 
 # Explicit entity-to-entity relationships with temporal validity.

--- a/test/unit/memory-integrity.test.ts
+++ b/test/unit/memory-integrity.test.ts
@@ -1084,3 +1084,159 @@ describe("Memory.delete() — durability/ownership check uses the raw record (su
     expect(await BaseMemory.get("mem-1")).not.toBeNull(); // untouched
   });
 });
+
+// ─── memory-provenance slice 1: write-time provenance stamp ─────────────────
+//
+// Foundational capture for an emergent-trust model (see resources/Memory.ts's
+// buildProvenance() doc). Deliberately minimal — verified fields only:
+//   { v: 1, verified: { agentId, timestamp }, claimed?: { model } }
+//
+// These tests live in THIS file (rather than a new one) for the same reason
+// the ops-2dm3 migration-equivalence block above does: bun runs every
+// test/unit/ file in one process, and resources/Memory.ts's `class Memory
+// extends (databases as any).flair.Memory` superclass reference is captured
+// ONCE at whichever file's mock.module("@harperfast/harper", ...) + dynamic
+// import wins first — a second file doing the same thing would silently
+// collide instead of getting its own isolated Memory/mock pairing. This
+// file's existing mock/import is reused instead.
+describe("memory-provenance slice 1 — Memory.post() write-time stamp", () => {
+  it("stamps valid, parseable JSON with v:1 and the authed agent's id", async () => {
+    const m = makeMemory(agentCtx("agent-1"));
+    const r = await m.post({ agentId: "agent-1", content: "A note long enough for the dedup gate to inspect." });
+    const stored = await BaseMemory.get(r.id);
+    expect(typeof stored.provenance).toBe("string");
+    const prov = JSON.parse(stored.provenance);
+    expect(prov.v).toBe(1);
+    expect(prov.verified.agentId).toBe("agent-1");
+    expect(typeof prov.verified.timestamp).toBe("string");
+    // Reuses the same server-clock createdAt the method computed for this write.
+    expect(prov.verified.timestamp).toBe(stored.createdAt);
+  });
+
+  it("omits claimed.model when the write payload has no model field", async () => {
+    const m = makeMemory(agentCtx("agent-1"));
+    const r = await m.post({ agentId: "agent-1", content: "No model field on this write at all." });
+    const prov = JSON.parse((await BaseMemory.get(r.id)).provenance);
+    expect(prov.claimed).toBeUndefined();
+  });
+
+  it("includes claimed.model ONLY when the payload carries one — never invented", async () => {
+    const m = makeMemory(agentCtx("agent-1"));
+    const r = await m.post({ agentId: "agent-1", content: "This write claims a model, unverified.", model: "claude-opus-4-7" });
+    const prov = JSON.parse((await BaseMemory.get(r.id)).provenance);
+    expect(prov.claimed).toEqual({ model: "claude-opus-4-7" });
+    // claimed.model is UNVERIFIED passthrough — verified.agentId is still the
+    // authenticated identity, entirely independent of the claimed model.
+    expect(prov.verified.agentId).toBe("agent-1");
+  });
+
+  it("an empty-string model is treated as absent (not a real claim)", async () => {
+    const m = makeMemory(agentCtx("agent-1"));
+    const r = await m.post({ agentId: "agent-1", content: "Empty-string model field on this write.", model: "" });
+    const prov = JSON.parse((await BaseMemory.get(r.id)).provenance);
+    expect(prov.claimed).toBeUndefined();
+  });
+
+  it("no authenticated agent (internal call) stamps verified.agentId: null — never throws", async () => {
+    const r: any = new (Memory as any)();
+    r.getContext = () => undefined; // no request at all → resolveAgentAuth() → { kind: "internal" }
+    const result = await r.post({ agentId: "agent-1", content: "Internal in-process write, long enough for the gate." });
+    expect(result.written).toBe(true);
+    const stored = await BaseMemory.get(result.id);
+    const prov = JSON.parse(stored.provenance);
+    expect(prov.v).toBe(1);
+    expect(prov.verified.agentId).toBeNull();
+    expect(typeof prov.verified.timestamp).toBe("string");
+  });
+});
+
+describe("memory-provenance slice 1 — Memory.put() stamps the identical shape (shared helper)", () => {
+  it("a fresh PUT (not-yet-existing id) stamps provenance the same as post()", async () => {
+    const m = makeMemory(agentCtx("agent-1"));
+    const r = await m.put({ id: "agent-1-fresh-prov", agentId: "agent-1", content: "Fresh PUT create, long enough for the gate." });
+    const stored = await BaseMemory.get(r.id);
+    const prov = JSON.parse(stored.provenance);
+    expect(prov.v).toBe(1);
+    expect(prov.verified.agentId).toBe("agent-1");
+    expect(typeof prov.verified.timestamp).toBe("string");
+  });
+
+  it("an update (same-id overwrite) re-stamps provenance reflecting the CURRENT authenticated actor", async () => {
+    const owner = agentCtx("agent-1");
+    const m = makeMemory(owner);
+    const initial = await m.post({ agentId: "agent-1", content: "Original note, long enough for the gate." });
+
+    const existing = await BaseMemory.get(initial.id);
+    const merged = { ...existing, content: "Updated note, long enough for the gate.", updatedAt: new Date().toISOString() };
+    delete (merged as any).embedding;
+    delete (merged as any).embeddingModel;
+
+    const mUpdate = makeMemory(owner);
+    await mUpdate.put(merged);
+
+    const after = await BaseMemory.get(initial.id);
+    const prov = JSON.parse(after.provenance);
+    expect(prov.v).toBe(1);
+    expect(prov.verified.agentId).toBe("agent-1");
+  });
+
+  it("claimed.model passthrough on put() is gated identically to post()", async () => {
+    const m = makeMemory(agentCtx("agent-1"));
+    const r = await m.put({ id: "agent-1-put-model", agentId: "agent-1", content: "PUT with a claimed model field.", model: "gpt-5" });
+    const prov = JSON.parse((await BaseMemory.get(r.id)).provenance);
+    expect(prov.claimed).toEqual({ model: "gpt-5" });
+
+    const m2 = makeMemory(agentCtx("agent-1"));
+    const r2 = await m2.put({ id: "agent-1-put-no-model", agentId: "agent-1", content: "PUT with no claimed model field." });
+    const prov2 = JSON.parse((await BaseMemory.get(r2.id)).provenance);
+    expect(prov2.claimed).toBeUndefined();
+  });
+
+  it("no authenticated agent (internal call) via put() also stamps verified.agentId: null — never throws", async () => {
+    const r: any = new (Memory as any)();
+    r.getContext = () => undefined;
+    const result = await r.put({ id: "internal-put-prov", agentId: "agent-1", content: "Internal in-process PUT, long enough for the gate." });
+    expect(result.written).toBe(true);
+    const prov = JSON.parse((await BaseMemory.get(result.id)).provenance);
+    expect(prov.verified.agentId).toBeNull();
+  });
+});
+
+describe("memory-provenance slice 1 — migration-equivalence (no-provenance-field memories)", () => {
+  it("an existing/old row with no provenance field reads back fine — provenance is purely additive, not required for reads", async () => {
+    memoryStore.set("legacy-no-prov", { id: "legacy-no-prov", agentId: "agent-owner", content: "pre-migration content, no provenance field at all." });
+    const m = makeMemory(agentCtx("agent-owner"));
+    const res = await (m as any).get("legacy-no-prov");
+    expect(res instanceof Response).toBe(false);
+    expect((res as any).content).toBe("pre-migration content, no provenance field at all.");
+    expect((res as any).provenance).toBeUndefined();
+  });
+
+  it("search() over a mix of legacy (no provenance) and new (stamped) records returns both, unaffected by the new field", async () => {
+    memoryStore.set("legacy-no-prov", { id: "legacy-no-prov", agentId: "agent-1", content: "legacy record, no provenance" });
+    const m = makeMemory(agentCtx("agent-1"));
+    await m.post({ agentId: "agent-1", content: "new record, gets provenance stamped, long enough for the gate." });
+
+    const results: any[] = [];
+    for await (const r of await (m as any).search({ conditions: [] })) results.push(r);
+    const ids = results.map((r) => r.id).sort();
+    expect(ids).toContain("legacy-no-prov");
+    expect(results.length).toBe(2);
+  });
+
+  it("updating a legacy (no-provenance) record via put() adds provenance additively without disturbing any other field", async () => {
+    memoryStore.set("legacy-2", { id: "legacy-2", agentId: "agent-1", content: "legacy content", durability: "standard", archived: false });
+    const existing = await BaseMemory.get("legacy-2");
+    expect(existing.provenance).toBeUndefined();
+
+    const merged = { ...existing, content: "patched legacy content", updatedAt: new Date().toISOString() };
+    const m = makeMemory(agentCtx("agent-1"));
+    await m.put(merged);
+
+    const after = await BaseMemory.get("legacy-2");
+    expect(after.content).toBe("patched legacy content"); // untouched aside from the intended patch
+    expect(typeof after.provenance).toBe("string"); // additively gains provenance on this write
+    const prov = JSON.parse(after.provenance);
+    expect(prov.v).toBe(1);
+  });
+});


### PR DESCRIPTION
Provenance-capture **slice 1** — the foundational write-time capture for the emergent-trust model (`FLAIR-MEMORY-MODEL.md` §6a). Stamps structured provenance on every `Memory` write, server-side.

## What
- **New nullable `provenance: String`** (JSON blob, `Soul.metadata` idiom) on the Memory type. **Migration-safe / clean-upgrade** (Nathan's gate): existing rows read `null` → "unknown provenance" = low-prior, not untrusted. Migration-equivalence tests included.
- Shape: `{ v:1, verified: { agentId, timestamp }, claimed?: { model } }`.
  - **`verified.agentId`** — from `resolveAgentAuth(ctx)` (Ed25519-unforgeable); `verified.timestamp` — server `createdAt`.
  - **`claimed.model`** — optional passthrough, stamped ONLY if the caller sends `model` (omitted otherwise); no client/CLI field added yet (separate follow-up).
- Stamped **last, right before persist** in both `post()` and `put()` via a shared helper — so the server value **overwrites any client-sent `provenance`**: the verified fields cannot be forged.

## Deliberately NOT in this slice
- **`context-fingerprint` deferred** — the design assumed "MemoryBootstrap already has the IDs," but bootstrap returns only counts/prose and nothing links a bootstrap read to a later write. It needs client-echo or a bootstrap→write association — its own slice.
- `generatedBy` (on `MemoryCandidate`) untouched.

## Verified
Full suite **1465/1465** (+12 new: post/put stamping, model-passthrough gating, no-auth→null, and migration-equivalence for legacy no-provenance rows). `tsc` + `build:cli` clean. Fork-independent of the federation-edge work.

@tps-kern the provenance shape + the shared-helper write-path hook (post + put). @tps-sherlock the anti-forgery property (server stamp overwrites client value, stamped last) + the verified-vs-claimed split + migration-safety. Prose replies please, no code spans.
