### PR TITLE
feat(federation): edge slice 1 — write-time originatorInstanceId tag on synced tables

### DIFF
--- a/resources/Agent.ts
+++ b/resources/Agent.ts
@@ -1,5 +1,6 @@
 import { databases } from "@harperfast/harper";
 import { isAdmin, resolveAgentAuth, allowVerified, allowAdmin } from "./agent-auth.js";
+import { localInstanceId } from "./instance-identity.js";
 
 /**
  * Agent resource — serves as the Principal table in 1.0.
@@ -47,6 +48,15 @@ export class Agent extends (databases as any).flair.Agent {
     content.createdAt = now;
     content.updatedAt = now;
 
+    // Write-time originatorInstanceId stamp (federation-edge-hardening slice
+    // 1) — see resources/Memory.ts's stampOriginatorInstanceId doc for the
+    // full contract. No-op if already set (never fires for a genuine local
+    // write; a federation-synced record never reaches this method — the
+    // merge path writes via the raw table object, bypassing this class).
+    if (content.originatorInstanceId == null) {
+      content.originatorInstanceId = await localInstanceId();
+    }
+
     return super.post(content, context);
   }
 
@@ -74,6 +84,12 @@ export class Agent extends (databases as any).flair.Agent {
     // Protect immutable fields
     delete content.createdAt;
     delete content.publicKey; // key rotation goes through dedicated endpoint
+
+    // Write-time originatorInstanceId stamp — see post() above / Memory.ts's
+    // stampOriginatorInstanceId doc. No-op if already set.
+    if (content.originatorInstanceId == null) {
+      content.originatorInstanceId = await localInstanceId();
+    }
 
     return super.put(content);
   }

--- a/resources/Memory.ts
+++ b/resources/Memory.ts
@@ -1,6 +1,7 @@
 import { databases } from "@harperfast/harper";
 import { patchRecord, withDetachedTxn } from "./table-helpers.js";
 import { isAdmin, resolveAgentAuth, allowVerified, type AgentAuthVerdict } from "./agent-auth.js";
+import { localInstanceId } from "./instance-identity.js";
 import { getEmbedding, getModelId } from "./embeddings-provider.js";
 import { scanFields, isStrictMode } from "./content-safety.js";
 import { checkRateLimit, rateLimitResponse } from "./rate-limiter.js";
@@ -396,6 +397,38 @@ function buildProvenance(auth: AgentAuthVerdict, createdAt: string, content: any
   return JSON.stringify(provenance);
 }
 
+/**
+ * ─── Write-time originatorInstanceId stamp (federation-edge-hardening slice 1) ──
+ *
+ * Stamps this instance's own federation identity (resources/instance-
+ * identity.ts's localInstanceId(), cached — never a DB read per write) onto
+ * every LOCAL write. Deliberately a no-op when `content.originatorInstanceId`
+ * already carries a non-null value: this is the anti-clobber rule that keeps
+ * a federation-synced record's true origin intact.
+ *
+ * Why this can never clobber a synced record: FederationSync.post()
+ * (resources/Federation.ts) merges incoming records via the RAW table object
+ * (`(databases as any).flair.Memory.put(mergedData)`) — Harper's static
+ * table-level put, not this Resource subclass's instance put() below. The
+ * merge path never runs this function at all, so a record arriving from
+ * instance B keeps whatever `originatorInstanceId` it already carried in
+ * `mergedData` (that instance's own write-time stamp, carried through in the
+ * synced row) with no risk of this instance overwriting it with its own id.
+ * The `content.originatorInstanceId == null` guard below is still applied —
+ * defense-in-depth for any future path that might route a synced payload
+ * through this class's post()/put() — so the invariant holds even if that
+ * assumption ever changes.
+ *
+ * `localInstanceId()` resolves to null on an instance that has never been
+ * federation-bootstrapped (no Instance row yet) — the field is nullable by
+ * design, so this stamps null rather than inventing an id.
+ */
+async function stampOriginatorInstanceId(content: any): Promise<void> {
+  if (content.originatorInstanceId == null) {
+    content.originatorInstanceId = await localInstanceId();
+  }
+}
+
 export class Memory extends (databases as any).flair.Memory {
   /**
    * Self-authorize now that the global gate is non-rejecting. Closes the P0
@@ -632,6 +665,11 @@ export class Memory extends (databases as any).flair.Memory {
     // reflects the final resolved `content.createdAt`.
     content.provenance = buildProvenance(auth, content.createdAt, content);
 
+    // Write-time originatorInstanceId stamp (federation-edge-hardening slice
+    // 1) — see stampOriginatorInstanceId's doc above. No-op if already set
+    // (never fires for a genuine local write — no client sets this field).
+    await stampOriginatorInstanceId(content);
+
     // ── Write the new record FIRST ──────────────────────────────────────────
     const result = await super.post(content);
 
@@ -794,6 +832,15 @@ export class Memory extends (databases as any).flair.Memory {
     // always gets a freshly-stamped provenance reflecting the CURRENT
     // authenticated actor performing this write.
     content.provenance = buildProvenance(auth, content.createdAt, content);
+
+    // Write-time originatorInstanceId stamp (federation-edge-hardening slice
+    // 1) — see stampOriginatorInstanceId's doc above post(). No-op if
+    // already set: an update/patch of an existing local record carries its
+    // own already-stamped originatorInstanceId forward unchanged (the
+    // `{...existing, ...patch}` merge pattern every put() caller uses), and a
+    // federation-synced record never reaches this method at all (see that
+    // function's doc for why the merge path can't clobber it here either).
+    await stampOriginatorInstanceId(content);
 
     // ── Write the new/updated record FIRST ──────────────────────────────────
     const result = await super.put(content);

--- a/resources/Relationship.ts
+++ b/resources/Relationship.ts
@@ -1,6 +1,7 @@
 import { databases } from "@harperfast/harper";
 import { resolveAgentAuth, allowVerified } from "./agent-auth.js";
 import { checkRateLimit, rateLimitResponse } from "./rate-limiter.js";
+import { localInstanceId } from "./instance-identity.js";
 
 const NOT_FOUND = () =>
   new Response(JSON.stringify({ error: "not found" }), { status: 404, headers: { "Content-Type": "application/json" } });
@@ -137,6 +138,15 @@ export class Relationship extends (databases as any).flair.Relationship {
     content.validFrom = content.validFrom || now;
     // validTo left as null/undefined for active relationships
     content.confidence = content.confidence ?? 1.0;
+
+    // Write-time originatorInstanceId stamp (federation-edge-hardening slice
+    // 1) — see resources/Memory.ts's stampOriginatorInstanceId doc for the
+    // full contract. No-op if already set (never fires for a genuine local
+    // write; a federation-synced record never reaches this method — the
+    // merge path writes via the raw table object, bypassing this class).
+    if (content.originatorInstanceId == null) {
+      content.originatorInstanceId = await localInstanceId();
+    }
 
     return super.put(content);
   }

--- a/resources/Soul.ts
+++ b/resources/Soul.ts
@@ -1,5 +1,6 @@
 import { databases } from "@harperfast/harper";
 import { resolveAgentAuth, allowVerified } from "./agent-auth.js";
+import { localInstanceId } from "./instance-identity.js";
 
 const FORBIDDEN = (msg: string) =>
   new Response(JSON.stringify({ error: msg }), { status: 403, headers: { "Content-Type": "application/json" } });
@@ -41,6 +42,14 @@ export class Soul extends (databases as any).flair.Soul {
     content.durability ||= "permanent";
     content.createdAt = new Date().toISOString();
     content.updatedAt = content.createdAt;
+    // Write-time originatorInstanceId stamp (federation-edge-hardening slice
+    // 1) — see resources/Memory.ts's stampOriginatorInstanceId doc for the
+    // full contract. No-op if already set (never fires for a genuine local
+    // write; a federation-synced record never reaches this method — the
+    // merge path writes via the raw table object, bypassing this class).
+    if (content.originatorInstanceId == null) {
+      content.originatorInstanceId = await localInstanceId();
+    }
     return super.post(content, context);
   }
 
@@ -48,6 +57,11 @@ export class Soul extends (databases as any).flair.Soul {
     const denied = await enforceWriteAuth(this, content);
     if (denied) return denied;
     content.updatedAt = new Date().toISOString();
+    // Write-time originatorInstanceId stamp — see post() above / Memory.ts's
+    // stampOriginatorInstanceId doc. No-op if already set.
+    if (content.originatorInstanceId == null) {
+      content.originatorInstanceId = await localInstanceId();
+    }
     return super.put(content, context);
   }
 }

--- a/resources/instance-identity.ts
+++ b/resources/instance-identity.ts
@@ -1,0 +1,54 @@
+import { databases } from "@harperfast/harper";
+
+/**
+ * ─── Local instance identity (federation-edge-hardening slice 1) ────────────
+ *
+ * The write-time `originatorInstanceId` stamp (Memory.ts/Soul.ts/Agent.ts/
+ * Relationship.ts post()/put()) needs to know THIS instance's own federation
+ * identity — the same `id` FederationInstance.get() (resources/Federation.ts)
+ * finds-or-creates on first boot and persists in the `Instance` table
+ * (schemas/federation.graphql). Exactly one row is expected in a given
+ * instance's own Instance table — that row IS this instance; other instances
+ * it has paired with live in the separate `Peer` table, never here.
+ *
+ * Deliberately READ-ONLY: this module never creates an Instance row — that
+ * first-boot bootstrap (keypair generation + keystore write) stays
+ * FederationInstance.get()'s job (resources/Federation.ts). If no Instance
+ * row exists yet (a fresh, never-federated instance, or a unit-test
+ * environment with no Instance table at all), localInstanceId() resolves to
+ * null and callers stamp nothing — originatorInstanceId is nullable by
+ * design (schemas/memory.graphql), and a null tag reads as "pre-tag /
+ * local-origin by default" per the federation-edge-hardening design.
+ *
+ * Cached at module scope after the FIRST successful resolution — a write
+ * must not pay a DB lookup every call. An unresolved (null) result is NOT
+ * cached, since that state can legitimately change later (federation gets
+ * bootstrapped after this process already started serving writes) and the
+ * cost of re-checking only applies to instances that have never federated.
+ */
+let cachedInstanceId: string | null = null;
+
+export async function localInstanceId(): Promise<string | null> {
+  if (cachedInstanceId) return cachedInstanceId;
+  try {
+    for await (const row of (databases as any).flair.Instance.search()) {
+      if (row?.id) {
+        cachedInstanceId = row.id;
+      }
+      break; // exactly one row expected — this instance's own identity
+    }
+  } catch {
+    // Instance table not present (test env / not yet migrated) — no local id.
+  }
+  return cachedInstanceId;
+}
+
+/**
+ * Test-only: force re-resolution on the next localInstanceId() call. The
+ * module-level cache otherwise persists across test files that share the
+ * same `bun test` process (same collision class documented in
+ * memory-integrity.test.ts re: the Memory class singleton).
+ */
+export function _resetLocalInstanceIdCacheForTests(): void {
+  cachedInstanceId = null;
+}

--- a/schemas/agent.graphql
+++ b/schemas/agent.graphql
@@ -22,6 +22,13 @@ type Agent @table(database: "flair") @export {
 
   createdAt: String!
   updatedAt: String
+  originatorInstanceId: String @indexed  # federation-edge-hardening slice 1 — write-time instance identity,
+                                   # stamped server-side in resources/Agent.ts's post()/put() from
+                                   # resources/instance-identity.ts's localInstanceId(). Nullable (existing rows
+                                   # read null = clean upgrade); preserved (never re-stamped) as the record flows
+                                   # through federation sync merges. See schemas/memory.graphql's Memory.
+                                   # originatorInstanceId for the full contract — same field, same idiom, this is
+                                   # one of the 4 synced tables (Memory/Soul/Agent/Relationship).
 }
 
 # Credential table — auth surfaces for Principals.

--- a/schemas/memory.graphql
+++ b/schemas/memory.graphql
@@ -34,6 +34,13 @@ type Memory @table(database: "flair") {
   provenance: String           # JSON blob (memory-provenance slice 1): { v, verified: { agentId, timestamp }, claimed?: { model } }
                                # Nullable by design — existing rows read back provenance = null, unchanged behavior (clean-upgrade-path gate).
                                # Same idiom as Soul.metadata below. Stamped server-side in resources/Memory.ts; never client-writable.
+  originatorInstanceId: String @indexed  # federation-edge-hardening slice 1: WRITE-TIME instance identity, stamped server-side in
+                               # resources/Memory.ts from resources/instance-identity.ts's localInstanceId() — never client-writable.
+                               # Nullable (existing rows read null = clean upgrade). Distinct from the legacy _originatorInstanceId
+                               # (Federation.ts's mergeRecord — stamped by the RECEIVER at merge time, forgeable/lossy); this field is
+                               # stamped by the ORIGINATING instance itself and preserved (never re-stamped) as the record flows through
+                               # sync merges. @indexed for the later sync push-query filter (per-record signature verification and the
+                               # classifier org-gate are separate, later slices — not built here).
 }
 
 # Explicit entity-to-entity relationships with temporal validity.
@@ -51,6 +58,9 @@ type Relationship @table(database: "flair") {
   source: String                   # where this was learned (memory ID, conversation, etc.)
   createdAt: String! @indexed
   updatedAt: String
+  originatorInstanceId: String @indexed  # federation-edge-hardening slice 1 — see Memory.originatorInstanceId's doc above
+                                    # for the full contract (write-time stamp, nullable, preserved across sync merges).
+                                    # Stamped server-side in resources/Relationship.ts's put().
 }
 
 type Soul @table(database: "flair") {
@@ -63,6 +73,9 @@ type Soul @table(database: "flair") {
   durability: String @indexed
   createdAt: String!
   updatedAt: String
+  originatorInstanceId: String @indexed  # federation-edge-hardening slice 1 — see Memory.originatorInstanceId's doc above
+                                    # for the full contract (write-time stamp, nullable, preserved across sync merges).
+                                    # Stamped server-side in resources/Soul.ts's post()/put().
 }
 
 type MemoryGrant @table(database: "flair") @export {

--- a/test/unit/agent-originator-instance.test.ts
+++ b/test/unit/agent-originator-instance.test.ts
@@ -1,0 +1,126 @@
+/**
+ * agent-originator-instance.test.ts — federation-edge-hardening slice 1:
+ * write-time originatorInstanceId stamp on resources/Agent.ts.
+ *
+ * See resources/Memory.ts's stampOriginatorInstanceId doc for the full
+ * contract (write-time, cached local instance id via resources/instance-
+ * identity.ts's localInstanceId(), anti-clobber for federation-synced
+ * records). Agent.ts stamps in both post() and put().
+ *
+ * Same mocking technique as memory-integrity.test.ts / relationship-read-
+ * gate.test.ts: mock @harperfast/harper so the resource class loads outside
+ * a real Harper runtime. No other test/unit/ file imports resources/Agent.ts,
+ * so this file owns that mock+import with no collision risk (bun runs
+ * test/unit/ in one process and dynamic imports are cached by resolved path).
+ */
+import { describe, it, expect, beforeEach, mock } from "bun:test";
+
+process.env.FLAIR_RATE_LIMIT_ENABLED = "false";
+
+let agentStore: Map<string, any>;
+// resources/instance-identity.ts's localInstanceId() reads this via
+// databases.flair.Instance.search().
+let instanceRow: any = null;
+
+class BaseAgent {
+  async post(content: any) {
+    const id = content.id ?? `agent-${Math.random().toString(36).slice(2)}`;
+    content.id = id;
+    const rec = { ...content };
+    agentStore.set(id, rec);
+    return rec;
+  }
+  async put(content: any) {
+    const rec = { ...content };
+    agentStore.set(content.id, rec);
+    return rec;
+  }
+  async get(target?: any) {
+    const id = typeof target === "string" ? target : target?.id;
+    return agentStore.get(id) ?? null;
+  }
+}
+
+const databasesMock = {
+  flair: {
+    Agent: BaseAgent,
+    Instance: {
+      search: () => {
+        async function* gen() {
+          if (instanceRow) yield instanceRow;
+        }
+        return gen();
+      },
+    },
+  },
+};
+
+mock.module("@harperfast/harper", () => ({ databases: databasesMock, Resource: class {} }));
+
+const { Agent } = await import("../../resources/Agent.ts");
+const { _resetLocalInstanceIdCacheForTests } = await import("../../resources/instance-identity.ts");
+
+function makeAgent(ctxRequest: any) {
+  const a: any = new (Agent as any)();
+  a.getContext = () => ({ request: ctxRequest });
+  return a;
+}
+const agentCtx = (agentId: string, isAdmin = false) => ({ tpsAgent: agentId, tpsAgentIsAdmin: isAdmin });
+
+beforeEach(() => {
+  agentStore = new Map();
+  instanceRow = null;
+  _resetLocalInstanceIdCacheForTests();
+});
+
+describe("federation-edge-hardening slice 1 — Agent.post() write-time originatorInstanceId stamp", () => {
+  it("stamps the local instance id on a fresh local write", async () => {
+    instanceRow = { id: "flair_local_test" };
+    const a = makeAgent(agentCtx("agent-admin", true));
+    const res: any = await a.post({ name: "New Principal" }, undefined);
+    expect(res.originatorInstanceId).toBe("flair_local_test");
+  });
+
+  it("stamps null when this instance has no Instance row yet — never invents one", async () => {
+    instanceRow = null;
+    const a = makeAgent(agentCtx("agent-admin", true));
+    const res: any = await a.post({ name: "New Principal" }, undefined);
+    expect(res.originatorInstanceId).toBeNull();
+  });
+
+  it("THE KEY TEST — an Agent record already carrying another instance's originatorInstanceId is NEVER clobbered with the local id", async () => {
+    instanceRow = { id: "flair_local_test" };
+    const a = makeAgent(agentCtx("agent-admin", true));
+    const res: any = await a.post({ name: "Synced Principal", originatorInstanceId: "instance-B" }, undefined);
+    expect(res.originatorInstanceId).toBe("instance-B");
+    expect(res.originatorInstanceId).not.toBe("flair_local_test");
+  });
+});
+
+describe("federation-edge-hardening slice 1 — Agent.put() write-time originatorInstanceId stamp", () => {
+  it("stamps the local instance id on an update to one's own record", async () => {
+    instanceRow = { id: "flair_local_test" };
+    agentStore.set("agent-1", { id: "agent-1", name: "Agent One" });
+    const a = makeAgent(agentCtx("agent-1"));
+    const res: any = await a.put({ id: "agent-1", name: "Agent One Updated" });
+    expect(res.originatorInstanceId).toBe("flair_local_test");
+  });
+
+  it("THE KEY TEST via put() — an update already carrying instance B's originatorInstanceId retains it, never re-stamped to the local id", async () => {
+    instanceRow = { id: "flair_local_test" };
+    agentStore.set("agent-1", { id: "agent-1", name: "Agent One", originatorInstanceId: "instance-B" });
+    const a = makeAgent(agentCtx("agent-1"));
+    const res: any = await a.put({ id: "agent-1", name: "Agent One Updated", originatorInstanceId: "instance-B" });
+    expect(res.originatorInstanceId).toBe("instance-B");
+  });
+});
+
+describe("federation-edge-hardening slice 1 — migration-equivalence (no-originatorInstanceId-field Agent rows)", () => {
+  it("an existing/old Agent row with no originatorInstanceId field reads back fine", async () => {
+    agentStore.set("legacy-agent", { id: "legacy-agent", name: "Legacy Principal" });
+    const a = makeAgent(agentCtx("agent-admin", true));
+    const res: any = await a.get("legacy-agent");
+    expect(res.name).toBe("Legacy Principal");
+    expect(res.originatorInstanceId).toBeUndefined();
+  });
+});

--- a/test/unit/instance-identity.test.ts
+++ b/test/unit/instance-identity.test.ts
@@ -1,0 +1,110 @@
+/**
+ * instance-identity.test.ts — resources/instance-identity.ts's localInstanceId()
+ * accessor (federation-edge-hardening slice 1).
+ *
+ * The write-time originatorInstanceId stamp (Memory.ts/Soul.ts/Agent.ts/
+ * Relationship.ts) needs this instance's own federation identity WITHOUT
+ * paying a DB lookup on every write — this file proves the module-level
+ * cache actually caches (a spy counts calls to the mocked
+ * databases.flair.Instance.search()), and that an unresolved (null) result
+ * is NOT permanently cached (a never-federated instance that later pairs
+ * must pick up its new identity on the next write, not stay null forever).
+ */
+import { describe, it, expect, beforeEach, mock } from "bun:test";
+
+let instanceRow: any = null;
+let searchCallCount = 0;
+let throwOnSearch = false;
+
+const databasesMock = {
+  flair: {
+    Instance: {
+      search: () => {
+        searchCallCount++;
+        if (throwOnSearch) throw new Error("Instance table not present");
+        async function* gen() {
+          if (instanceRow) yield instanceRow;
+        }
+        return gen();
+      },
+    },
+  },
+};
+
+mock.module("@harperfast/harper", () => ({ databases: databasesMock, Resource: class {} }));
+
+const { localInstanceId, _resetLocalInstanceIdCacheForTests } = await import("../../resources/instance-identity.ts");
+
+beforeEach(() => {
+  instanceRow = null;
+  searchCallCount = 0;
+  throwOnSearch = false;
+  _resetLocalInstanceIdCacheForTests();
+});
+
+describe("localInstanceId() — resolution", () => {
+  it("resolves the instance id from the Instance table's single row", async () => {
+    instanceRow = { id: "flair_abc123" };
+    expect(await localInstanceId()).toBe("flair_abc123");
+  });
+
+  it("resolves to null when no Instance row exists yet (never federation-bootstrapped)", async () => {
+    instanceRow = null;
+    expect(await localInstanceId()).toBeNull();
+  });
+
+  it("resolves to null (never throws) when the Instance table isn't present at all", async () => {
+    throwOnSearch = true;
+    expect(await localInstanceId()).toBeNull();
+  });
+});
+
+describe("localInstanceId() — caching (a write must not pay a DB lookup every call)", () => {
+  it("a successful resolution is cached — a second call does NOT hit the DB again", async () => {
+    instanceRow = { id: "flair_abc123" };
+    const first = await localInstanceId();
+    const callsAfterFirst = searchCallCount;
+    expect(first).toBe("flair_abc123");
+    expect(callsAfterFirst).toBe(1);
+
+    const second = await localInstanceId();
+    expect(second).toBe("flair_abc123");
+    expect(searchCallCount).toBe(callsAfterFirst); // no new DB call
+  });
+
+  it("caching survives even if the underlying row later changes — the cached value wins (by design: resolved once)", async () => {
+    instanceRow = { id: "flair_first" };
+    await localInstanceId();
+    instanceRow = { id: "flair_second" }; // simulate the row somehow changing
+    const stillCached = await localInstanceId();
+    expect(stillCached).toBe("flair_first");
+    expect(searchCallCount).toBe(1); // proves no re-fetch happened
+  });
+
+  it("an UNRESOLVED (null) result is NOT cached — the next call retries against the DB", async () => {
+    instanceRow = null;
+    const first = await localInstanceId();
+    expect(first).toBeNull();
+    expect(searchCallCount).toBe(1);
+
+    // Instance becomes available (e.g. this process's first-ever federation
+    // pairing just completed) — the very next write must pick it up, not
+    // stay permanently null from the earlier miss.
+    instanceRow = { id: "flair_newly_paired" };
+    const second = await localInstanceId();
+    expect(second).toBe("flair_newly_paired");
+    expect(searchCallCount).toBe(2); // retried — proves null wasn't cached
+  });
+
+  it("_resetLocalInstanceIdCacheForTests() forces re-resolution on the next call", async () => {
+    instanceRow = { id: "flair_before_reset" };
+    await localInstanceId();
+    expect(searchCallCount).toBe(1);
+
+    _resetLocalInstanceIdCacheForTests();
+    instanceRow = { id: "flair_after_reset" };
+    const afterReset = await localInstanceId();
+    expect(afterReset).toBe("flair_after_reset");
+    expect(searchCallCount).toBe(2);
+  });
+});

--- a/test/unit/memory-integrity.test.ts
+++ b/test/unit/memory-integrity.test.ts
@@ -76,6 +76,12 @@ let memoryStore: Map<string, any>;
 let memoryGrants: any[];
 let callOrder: string[];
 let idCounter: number;
+// federation-edge-hardening slice 1: the local instance's own identity row
+// (resources/instance-identity.ts's localInstanceId() reads this). null by
+// default in most describe blocks above (no Instance table row — matches a
+// never-federated instance); the originatorInstanceId describe block below
+// sets this to a fixed test id.
+let instanceRow: any = null;
 // ops-ume4 simulation switch: when true, memorySearchGen's cosine-sort branch
 // omits `$distance` from every candidate (real Harper's observed behavior for
 // a SINGLETON cosine-query result set) instead of computing a real one —
@@ -174,12 +180,23 @@ const databasesMock = {
       },
     },
     Agent: { get: async () => null, search: async () => [] },
+    // federation-edge-hardening slice 1: resources/instance-identity.ts's
+    // localInstanceId() reads this table to find THIS instance's own row.
+    Instance: {
+      search: () => {
+        async function* gen() {
+          if (instanceRow) yield instanceRow;
+        }
+        return gen();
+      },
+    },
   },
 };
 
 mock.module("@harperfast/harper", () => ({ databases: databasesMock, Resource: class {} }));
 
 const { Memory } = await import("../../resources/Memory.ts");
+const { _resetLocalInstanceIdCacheForTests } = await import("../../resources/instance-identity.ts");
 const { jaccardSimilarity, isConservativeMatch, computeMatchConfidence, cosineSimilarity } = await import("../../resources/dedup.ts");
 const { tokenize } = await import("../../resources/bm25.ts");
 // Dynamic (not static) import — MUST run after mock.module() above, same
@@ -202,6 +219,8 @@ beforeEach(() => {
   callOrder = [];
   idCounter = 0;
   forceUndefinedDistance = false;
+  instanceRow = null;
+  _resetLocalInstanceIdCacheForTests();
 });
 
 // ─── Fixture text for the #526 replay ────────────────────────────────────────
@@ -1238,5 +1257,136 @@ describe("memory-provenance slice 1 — migration-equivalence (no-provenance-fie
     expect(typeof after.provenance).toBe("string"); // additively gains provenance on this write
     const prov = JSON.parse(after.provenance);
     expect(prov.v).toBe(1);
+  });
+});
+
+// ─── federation-edge-hardening slice 1: write-time originatorInstanceId stamp ──
+//
+// New nullable field on the 4 synced tables (Memory/Soul/Agent/Relationship),
+// stamped server-side from resources/instance-identity.ts's localInstanceId()
+// on every LOCAL write. Distinct from the legacy `_originatorInstanceId`
+// (Federation.ts's mergeRecord — receiver-stamped at merge time, forgeable);
+// this field is stamped by the ORIGINATING instance and must survive a
+// federation sync unchanged. These tests live in THIS file for the same
+// mock+import-collision reason as the memory-provenance slice 1 block above
+// (this file already owns the Memory mock+import).
+describe("federation-edge-hardening slice 1 — Memory.post() write-time originatorInstanceId stamp", () => {
+  it("stamps the local instance id on a fresh local write", async () => {
+    instanceRow = { id: "flair_local_test" };
+    const m = makeMemory(agentCtx("agent-1"));
+    const r = await m.post({ agentId: "agent-1", content: "A note long enough for the dedup gate to inspect." });
+    const stored = await BaseMemory.get(r.id);
+    expect(stored.originatorInstanceId).toBe("flair_local_test");
+  });
+
+  it("stamps null when this instance has no Instance row yet (never federation-bootstrapped) — never invents one", async () => {
+    instanceRow = null;
+    const m = makeMemory(agentCtx("agent-1"));
+    const r = await m.post({ agentId: "agent-1", content: "Written before this instance ever paired." });
+    const stored = await BaseMemory.get(r.id);
+    expect(stored.originatorInstanceId).toBeNull();
+  });
+
+  it("THE KEY TEST — a record already carrying another instance's originatorInstanceId is NEVER clobbered with the local id", async () => {
+    // Simulates the shape a federation-synced record would carry (this
+    // instance's own local id is "flair_local_test", but the write itself
+    // already carries instance B's origin — e.g. a caller re-writing synced
+    // data through this class rather than the raw table object). The stamp
+    // must be a no-op here: the record's TRUE author (instance B) must never
+    // be overwritten by whichever instance happens to run this write.
+    instanceRow = { id: "flair_local_test" };
+    const m = makeMemory(agentCtx("agent-1"));
+    const r = await m.post({
+      agentId: "agent-1",
+      content: "This record was authored on instance B, long enough for the gate.",
+      originatorInstanceId: "instance-B",
+    });
+    const stored = await BaseMemory.get(r.id);
+    expect(stored.originatorInstanceId).toBe("instance-B");
+    expect(stored.originatorInstanceId).not.toBe("flair_local_test");
+  });
+});
+
+describe("federation-edge-hardening slice 1 — Memory.put() stamps the identical shape (shared helper)", () => {
+  it("a fresh PUT (not-yet-existing id) stamps the local instance id the same as post()", async () => {
+    instanceRow = { id: "flair_local_test" };
+    const m = makeMemory(agentCtx("agent-1"));
+    const r = await m.put({ id: "agent-1-fresh-origin", agentId: "agent-1", content: "Fresh PUT create, long enough for the gate." });
+    const stored = await BaseMemory.get(r.id);
+    expect(stored.originatorInstanceId).toBe("flair_local_test");
+  });
+
+  it("THE KEY TEST via put() — an update carrying instance B's originatorInstanceId retains it, never re-stamped to the local id", async () => {
+    instanceRow = { id: "flair_local_test" };
+    const m = makeMemory(agentCtx("agent-1"));
+    const r = await m.put({
+      id: "agent-1-synced-origin",
+      agentId: "agent-1",
+      content: "Synced-shaped record authored on instance B, long enough for the gate.",
+      originatorInstanceId: "instance-B",
+    });
+    const stored = await BaseMemory.get(r.id);
+    expect(stored.originatorInstanceId).toBe("instance-B");
+
+    // A SUBSEQUENT update (e.g. memory_update's read-merge-PUT pattern) that
+    // carries the existing record forward must ALSO preserve instance B's
+    // origin — this is the realistic shape of an update to an already-synced
+    // record (the merged payload spreads the existing stored fields).
+    const existing = await BaseMemory.get(r.id);
+    const merged = { ...existing, content: "Edited locally after sync, long enough for the gate.", updatedAt: new Date().toISOString() };
+    const mUpdate = makeMemory(agentCtx("agent-1"));
+    await mUpdate.put(merged);
+    const after = await BaseMemory.get(r.id);
+    expect(after.originatorInstanceId).toBe("instance-B");
+    expect(after.content).toBe("Edited locally after sync, long enough for the gate.");
+  });
+
+  it("no authenticated agent (internal call) via put() still stamps the local instance id — never throws", async () => {
+    instanceRow = { id: "flair_local_test" };
+    const r: any = new (Memory as any)();
+    r.getContext = () => undefined;
+    const result = await r.put({ id: "internal-put-origin", agentId: "agent-1", content: "Internal in-process PUT, long enough for the gate." });
+    expect(result.written).toBe(true);
+    const stored = await BaseMemory.get(result.id);
+    expect(stored.originatorInstanceId).toBe("flair_local_test");
+  });
+});
+
+describe("federation-edge-hardening slice 1 — migration-equivalence (no-originatorInstanceId-field memories)", () => {
+  it("an existing/old row with no originatorInstanceId field reads back fine — the field is purely additive, not required for reads", async () => {
+    memoryStore.set("legacy-no-origin", { id: "legacy-no-origin", agentId: "agent-owner", content: "pre-migration content, no originatorInstanceId field at all." });
+    const m = makeMemory(agentCtx("agent-owner"));
+    const res = await (m as any).get("legacy-no-origin");
+    expect(res instanceof Response).toBe(false);
+    expect((res as any).content).toBe("pre-migration content, no originatorInstanceId field at all.");
+    expect((res as any).originatorInstanceId).toBeUndefined();
+  });
+
+  it("search() over a mix of legacy (no originatorInstanceId) and new (stamped) records returns both, unaffected by the new field", async () => {
+    instanceRow = { id: "flair_local_test" };
+    memoryStore.set("legacy-no-origin", { id: "legacy-no-origin", agentId: "agent-1", content: "legacy record, no originatorInstanceId" });
+    const m = makeMemory(agentCtx("agent-1"));
+    await m.post({ agentId: "agent-1", content: "new record, gets originatorInstanceId stamped, long enough for the gate." });
+
+    const results: any[] = [];
+    for await (const r of await (m as any).search({ conditions: [] })) results.push(r);
+    const ids = results.map((r) => r.id).sort();
+    expect(ids).toContain("legacy-no-origin");
+    expect(results.length).toBe(2);
+  });
+
+  it("updating a legacy (no-originatorInstanceId) record via put() adds the field additively without disturbing any other field", async () => {
+    instanceRow = { id: "flair_local_test" };
+    memoryStore.set("legacy-origin-2", { id: "legacy-origin-2", agentId: "agent-1", content: "legacy content", durability: "standard", archived: false });
+    const existing = await BaseMemory.get("legacy-origin-2");
+    expect(existing.originatorInstanceId).toBeUndefined();
+
+    const merged = { ...existing, content: "patched legacy content", updatedAt: new Date().toISOString() };
+    const m = makeMemory(agentCtx("agent-1"));
+    await m.put(merged);
+
+    const after = await BaseMemory.get("legacy-origin-2");
+    expect(after.content).toBe("patched legacy content"); // untouched aside from the intended patch
+    expect(after.originatorInstanceId).toBe("flair_local_test"); // additively gains the stamp on this write
   });
 });

--- a/test/unit/memory-soul-read-gate.test.ts
+++ b/test/unit/memory-soul-read-gate.test.ts
@@ -32,6 +32,9 @@ delete (process.env as any).FLAIR_PUBLIC;
 // ─── In-memory Harper Soul mock ─────────────────────────────────────────────
 
 let soulStore: Map<string, any>;
+// federation-edge-hardening slice 1: resources/instance-identity.ts's
+// localInstanceId() reads this via databases.flair.Instance.search().
+let instanceRow: any = null;
 
 class BaseSoul {
   async post(content: any) {
@@ -61,12 +64,21 @@ class BaseSoul {
 const databasesMock = {
   flair: {
     Soul: BaseSoul,
+    Instance: {
+      search: () => {
+        async function* gen() {
+          if (instanceRow) yield instanceRow;
+        }
+        return gen();
+      },
+    },
   },
 };
 
 mock.module("@harperfast/harper", () => ({ databases: databasesMock, Resource: class {} }));
 
 const { Soul } = await import("../../resources/Soul.ts");
+const { _resetLocalInstanceIdCacheForTests } = await import("../../resources/instance-identity.ts");
 
 function makeSoul(ctxRequest: any) {
   const r: any = new (Soul as any)();
@@ -78,6 +90,8 @@ const anonCtx = () => ({ tpsAnonymous: true });
 
 beforeEach(() => {
   soulStore = new Map();
+  instanceRow = null;
+  _resetLocalInstanceIdCacheForTests();
 });
 
 // ─── Soul.allowRead — anonymous denied, any verified agent allowed (no per-agent scoping) ──
@@ -134,5 +148,49 @@ describe("Soul write gates — unaffected by the read-gate fix", () => {
     const s = makeSoul(agentCtx("agent-1"));
     const res: any = await s.post({ agentId: "agent-1", identity: "my identity" });
     expect(res.identity).toBe("my identity");
+  });
+});
+
+// ─── federation-edge-hardening slice 1: write-time originatorInstanceId stamp ──
+// See resources/Memory.ts's stampOriginatorInstanceId doc for the full
+// contract (write-time, cached local instance id, anti-clobber for
+// federation-synced records). Soul.ts stamps in both post() and put().
+describe("federation-edge-hardening slice 1 — Soul.post()/put() write-time originatorInstanceId stamp", () => {
+  it("post() stamps the local instance id on a fresh local write", async () => {
+    instanceRow = { id: "flair_local_test" };
+    const s = makeSoul(agentCtx("agent-1"));
+    const res: any = await s.post({ agentId: "agent-1", key: "identity", value: "my soul" });
+    expect(res.originatorInstanceId).toBe("flair_local_test");
+  });
+
+  it("stamps null when this instance has no Instance row yet — never invents one", async () => {
+    instanceRow = null;
+    const s = makeSoul(agentCtx("agent-1"));
+    const res: any = await s.post({ agentId: "agent-1", key: "identity", value: "my soul" });
+    expect(res.originatorInstanceId).toBeNull();
+  });
+
+  it("THE KEY TEST — a soul record already carrying another instance's originatorInstanceId is NEVER clobbered with the local id", async () => {
+    instanceRow = { id: "flair_local_test" };
+    const s = makeSoul(agentCtx("agent-1"));
+    const res: any = await s.post({
+      agentId: "agent-1",
+      key: "identity",
+      value: "authored on instance B",
+      originatorInstanceId: "instance-B",
+    });
+    expect(res.originatorInstanceId).toBe("instance-B");
+    expect(res.originatorInstanceId).not.toBe("flair_local_test");
+  });
+
+  it("put() also stamps the local instance id, and also never clobbers an already-set origin", async () => {
+    instanceRow = { id: "flair_local_test" };
+    const s1 = makeSoul(agentCtx("agent-1"));
+    const fresh: any = await s1.put({ id: "soul-1", agentId: "agent-1", key: "identity", value: "fresh put" });
+    expect(fresh.originatorInstanceId).toBe("flair_local_test");
+
+    const s2 = makeSoul(agentCtx("agent-1"));
+    const synced: any = await s2.put({ id: "soul-2", agentId: "agent-1", key: "identity", value: "synced put", originatorInstanceId: "instance-B" });
+    expect(synced.originatorInstanceId).toBe("instance-B");
   });
 });

--- a/test/unit/relationship-read-gate.test.ts
+++ b/test/unit/relationship-read-gate.test.ts
@@ -20,6 +20,9 @@ import { describe, it, expect, beforeEach, mock } from "bun:test";
 process.env.FLAIR_RATE_LIMIT_ENABLED = "false";
 
 let relationshipStore: Map<string, any>;
+// federation-edge-hardening slice 1: resources/instance-identity.ts's
+// localInstanceId() reads this via databases.flair.Instance.search().
+let instanceRow: any = null;
 
 function matchesCondition(record: any, cond: any): boolean {
   if (cond.operator && Array.isArray(cond.conditions)) {
@@ -60,12 +63,21 @@ const databasesMock = {
   flair: {
     Relationship: BaseRelationship,
     Agent: { get: async () => null, search: async () => [] },
+    Instance: {
+      search: () => {
+        async function* gen() {
+          if (instanceRow) yield instanceRow;
+        }
+        return gen();
+      },
+    },
   },
 };
 
 mock.module("@harperfast/harper", () => ({ databases: databasesMock, Resource: class {} }));
 
 const { Relationship } = await import("../../resources/Relationship.ts");
+const { _resetLocalInstanceIdCacheForTests } = await import("../../resources/instance-identity.ts");
 
 function makeRelationship(ctxRequest: any) {
   const r: any = new (Relationship as any)();
@@ -77,6 +89,8 @@ const anonCtx = () => ({ tpsAnonymous: true });
 
 beforeEach(() => {
   relationshipStore = new Map();
+  instanceRow = null;
+  _resetLocalInstanceIdCacheForTests();
 });
 
 describe("Relationship.allowRead — closes the anonymous GET /Relationship/<id> and describe leak", () => {
@@ -161,5 +175,39 @@ describe("Relationship.get() — anonymous denied, owner-scoped for non-admin, u
     const results: any[] = [];
     for await (const rec of res) results.push(rec);
     expect(results.map((rec) => rec.id)).toEqual(["rel-own"]);
+  });
+});
+
+// ─── federation-edge-hardening slice 1: write-time originatorInstanceId stamp ──
+// See resources/Memory.ts's stampOriginatorInstanceId doc for the full
+// contract. Relationship.ts only exposes put() as a write path (no post()
+// override — same idiom as Memory.ts's HTTP-reachable-only-via-PUT note).
+describe("federation-edge-hardening slice 1 — Relationship.put() write-time originatorInstanceId stamp", () => {
+  it("stamps the local instance id on a fresh local write", async () => {
+    instanceRow = { id: "flair_local_test" };
+    const r = makeRelationship(agentCtx("agent-1"));
+    const res: any = await r.put({ id: "rel-fresh", subject: "nathan", predicate: "manages", object: "flint" });
+    expect(res.originatorInstanceId).toBe("flair_local_test");
+  });
+
+  it("stamps null when this instance has no Instance row yet — never invents one", async () => {
+    instanceRow = null;
+    const r = makeRelationship(agentCtx("agent-1"));
+    const res: any = await r.put({ id: "rel-no-instance", subject: "nathan", predicate: "manages", object: "flint" });
+    expect(res.originatorInstanceId).toBeNull();
+  });
+
+  it("THE KEY TEST — a relationship already carrying another instance's originatorInstanceId is NEVER clobbered with the local id", async () => {
+    instanceRow = { id: "flair_local_test" };
+    const r = makeRelationship(agentCtx("agent-1"));
+    const res: any = await r.put({
+      id: "rel-synced",
+      subject: "nathan",
+      predicate: "manages",
+      object: "flint",
+      originatorInstanceId: "instance-B",
+    });
+    expect(res.originatorInstanceId).toBe("instance-B");
+    expect(res.originatorInstanceId).not.toBe("flair_local_test");
   });
 });


### PR DESCRIPTION
Federation-edge-hardening **slice 1** — the write-time origin tag (K&S-validated design, `FLAIR-FEDERATION-EDGE-HARDENING.md`). Foundation for org-boundedness; **no** signature/gate/filter in this slice (those are slices 3/4/2).

## What
- **New nullable `originatorInstanceId: String @indexed`** on the 4 synced tables (Memory, Soul, Relationship in `memory.graphql`; Agent in `agent.graphql`). Migration-safe: existing rows read `null` (= pre-tag / local-origin), no backfill — purely additive.
- **Stamped at write time** from the local instance identity: new `resources/instance-identity.ts` `localInstanceId()` reads this instance's own row from the **self-only `Instance` table** (peers live in the separate `Peer` table), caching a successful resolution and retrying on a null miss (so a not-yet-federated instance picks up its id when it pairs).
- Stamped in `post()`/`put()` of Memory/Soul/Agent/Relationship via a shared `== null` guard.

## The critical property — synced records keep their AUTHOR's id
A record arriving via federation sync must retain `originatorInstanceId = <author>`, not get restamped local. Two independent protections:
1. The merge path (`FederationSync.post` → `mergeRecord`) writes via the **raw `databases.flair.<Table>.put()` CRUD surface**, which does NOT run the Resource subclass's `post`/`put` — so the stamp code never fires on merges (the same raw-table-vs-resource-method split documented in `deploy.ts`'s `deriveVerifyResources`).
2. The `== null` guard never overwrites a non-null incoming value.
Tested directly: "instance B stays B" on post + put + update, across all 4 tables.

## Verified
Full suite **1494/1494** (+29: stamp-on-write, the anti-clobber key test ×4 tables, migration-equivalence for legacy null rows, `localInstanceId` caching). `tsc` + `build:cli` clean.

@tps-kern the tag-as-foundation + the merge-path-bypass architecture (does the raw-CRUD-vs-resource-method split hold everywhere sync writes?). @tps-sherlock the anti-clobber correctness — can a synced/forged record get restamped to the local id, or its own id preserved? + migration-safety. Prose replies, no code spans.
