### PR TITLE
feat(federation): edge slice 2 — push-side private-visibility filter

### DIFF
--- a/resources/memory-read-scope.ts
+++ b/resources/memory-read-scope.ts
@@ -1,4 +1,5 @@
 import { databases } from "@harperfast/harper";
+import { PRIVATE_VISIBILITY, isPrivateVisibility } from "./memory-visibility.js";
 
 /**
  * ─── Centralized Memory read-scoping (ops-2dm3 Layer 1) ─────────────────────
@@ -93,8 +94,6 @@ export interface ReadScope {
   isAllowed: (record: ScopableRecord | null | undefined) => boolean;
 }
 
-const PRIVATE = "private";
-
 /**
  * Resolve the full read-scope (owner set + condition + in-process predicate)
  * for a reader. This is the ONE function every cross-agent Memory read path
@@ -130,7 +129,7 @@ export async function resolveReadScope(authAgentId: string): Promise<ReadScope> 
             // NO visibility field must still read as shared. This is the
             // migration-equivalence invariant, enforced in the condition
             // itself so every path that uses it gets it for free.
-            { attribute: "visibility", comparator: "not_equal", value: PRIVATE },
+            { attribute: "visibility", comparator: "not_equal", value: PRIVATE_VISIBILITY },
           ],
         },
       ],
@@ -142,7 +141,7 @@ export async function resolveReadScope(authAgentId: string): Promise<ReadScope> 
     if (!record) return false;
     if (record.agentId === authAgentId) return true;
     if (!record.agentId || !grantedSet.has(record.agentId)) return false;
-    return record.visibility !== PRIVATE;
+    return !isPrivateVisibility(record.visibility);
   };
 
   return { allowedOwners, condition, isAllowed };

--- a/resources/memory-visibility.ts
+++ b/resources/memory-visibility.ts
@@ -1,0 +1,39 @@
+/**
+ * ─── The single "is this Memory private" predicate (federation-edge-hardening
+ * slice 2 / ops-nzxa: one rule, one place) ───────────────────────────────────
+ *
+ * Shared by BOTH:
+ *   - resources/memory-read-scope.ts's resolveReadScope() — the cross-agent
+ *     READ scope every read path (Memory.search/get, SemanticSearch,
+ *     MemoryBootstrap, the by-id auth-middleware guard) resolves through.
+ *   - src/cli.ts's runFederationSyncOnce() — the federation-sync PUSH filter
+ *     that must not replicate `private` memories to peer instances.
+ *
+ * Deliberately has ZERO imports — not even "@harperfast/harper". That is
+ * intentional and load-bearing: src/cli.ts is a standalone CLI entrypoint
+ * that runs OUTSIDE any running Harper instance (e.g. `flair federation
+ * sync` invoked from a cron/launchd job). resources/memory-read-scope.ts
+ * imports `databases` from "@harperfast/harper", and that package's
+ * top-level init eagerly resolves storage paths and THROWS when there is no
+ * live Harper runtime backing it (confirmed empirically — it takes down
+ * even `flair --help`). So src/cli.ts must never import
+ * resources/memory-read-scope.ts (or anything else that drags that
+ * side-effecting import in) directly. This module is the safe seam: a pure
+ * function + constant that both sides can import without dragging in
+ * "@harperfast/harper".
+ *
+ * ── The migration invariant (non-negotiable, mirrors memory-read-scope.ts) ──
+ * A record with NO `visibility` field (written before the field existed) is
+ * NOT private — it must keep syncing/reading exactly as before. This is why
+ * the predicate is "is this exactly 'private'", never "is this not 'shared'":
+ * missing/null/anything-other-than-'private' all count as non-private.
+ */
+
+export const PRIVATE_VISIBILITY = "private";
+
+/** True only when visibility is the literal string "private". Null, undefined,
+ *  "shared", or any other value are all non-private (see migration invariant
+ *  above) — never invert this to an allowlist of "shared". */
+export function isPrivateVisibility(visibility: string | null | undefined): boolean {
+  return visibility === PRIVATE_VISIBILITY;
+}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -47,6 +47,22 @@ function signBody(body: Record<string, any>, secretKey: Uint8Array): string {
   return Buffer.from(sig).toString("base64url");
 }
 
+// Federation push private-visibility filter — inlined for the SAME reason as
+// the crypto helpers above (see comment there; also resources/memory-
+// visibility.ts, the canonical definition; the two must stay in sync).
+//
+// federation-edge-hardening slice 2 (ops-nzxa: one rule, one place): the
+// push side of federation sync (runFederationSyncOnce below) must exclude
+// `private` Memory rows from what gets sent to peers, using the EXACT same
+// "not private" semantics as resources/memory-read-scope.ts's resolveReadScope()
+// — a record with NO visibility field (legacy, pre-dates the field) is NOT
+// private and must keep syncing exactly as before. Only `visibility ===
+// "private"` is excluded; null/undefined/"shared"/anything else is included.
+const FEDERATION_PRIVATE_VISIBILITY = "private";
+function isFederationPrivateVisibility(visibility: string | null | undefined): boolean {
+  return visibility === FEDERATION_PRIVATE_VISIBILITY;
+}
+
 // ─── Secret detection helpers ────────────────────────
 
 /**
@@ -3881,8 +3897,17 @@ export async function runFederationSyncOnce(opts: any): Promise<{ pushed: number
         }
         const batch = await res.json() as any[];
         // For null-updatedAt rows, use createdAt as the effective timestamp.
-        // Skip rows created before the last sync cursor.
-        rows = rows.concat(batch.filter((r: any) => r.updatedAt !== null || r.createdAt > since));
+        // Skip rows created before the last sync cursor. Only Memory carries
+        // a `visibility` field (Soul/Agent/Relationship don't — see
+        // schemas/memory.graphql vs agent.graphql), so the private-exclusion
+        // filter only applies there; on the other 3 tables `row.visibility`
+        // is always undefined, which isFederationPrivateVisibility() treats
+        // as non-private (included) — a no-op for them.
+        rows = rows.concat(
+          batch
+            .filter((r: any) => r.updatedAt !== null || r.createdAt > since)
+            .filter((r: any) => table !== "Memory" || !isFederationPrivateVisibility(r.visibility)),
+        );
       }
       if (rows.length === 0) continue;
 

--- a/test/unit/federation-sync-push-privacy.test.ts
+++ b/test/unit/federation-sync-push-privacy.test.ts
@@ -1,0 +1,228 @@
+import { describe, it, expect, mock, beforeEach, afterEach } from "bun:test";
+import nacl from "tweetnacl";
+import { isPrivateVisibility, PRIVATE_VISIBILITY } from "../../resources/memory-visibility";
+
+/**
+ * federation-edge-hardening slice 2 (ops-nzxa: one rule, one place).
+ *
+ * The federation-sync PUSH (runFederationSyncOnce in src/cli.ts) pulls every
+ * changed Memory row via the admin ops API with get_attributes:["*"] and,
+ * before this slice, applied NO visibility filter — so `private` memories
+ * were pushed to peer instances. This slice filters them out on the push
+ * side, using the SAME "not private" rule as resources/memory-read-scope.ts's
+ * resolveReadScope(): exclude ONLY visibility === "private"; a `shared` or
+ * null/absent visibility (legacy, pre-dates the field) row must still sync
+ * — that migration invariant is the critical regression this file guards.
+ *
+ * src/cli.ts cannot import resources/memory-visibility.ts directly (proven
+ * packaging constraint — see the "Federation crypto helpers" / "Federation
+ * push private-visibility filter" comments in src/cli.ts, and the 0.5.3
+ * ERR_MODULE_NOT_FOUND postmortem: a relative `../resources/...` import from
+ * dist/cli.js resolves OUTSIDE the published dist/ tree, since dist/cli.js
+ * ships without a sibling top-level resources/ folder). So cli.ts inlines an
+ * identical one-liner predicate. This file cross-checks the two: the
+ * canonical resources/memory-visibility.ts predicate is imported directly,
+ * and its verdicts are asserted against what actually happens when the same
+ * visibility values flow through the real runFederationSyncOnce() push path
+ * — the anti-drift check the two independent copies can't silently diverge
+ * on.
+ */
+
+const origFetch = globalThis.fetch;
+
+/** Build a minimal Response mock with proper headers.get(). */
+function res(ok: boolean, status: number, body: any) {
+  return {
+    ok,
+    status,
+    headers: {
+      get: (name: string) =>
+        name === "content-length" ? String(JSON.stringify(body).length) : null,
+    },
+    json: async () => body,
+    text: async () => JSON.stringify(body),
+  } as unknown as Response;
+}
+
+const testKp = nacl.sign.keyPair();
+const SINCE = "2025-01-01T00:00:00.000Z";
+
+describe("federation sync push — private-visibility filter (ops-nzxa)", () => {
+  let capturedCalls: Array<{ url: string; body?: any; method?: string }> = [];
+
+  beforeEach(() => {
+    capturedCalls = [];
+  });
+
+  afterEach(() => {
+    globalThis.fetch = origFetch;
+  });
+
+  /**
+   * Install a content-dispatched fetch mock (NOT a fixed call-index array —
+   * whether a table's sendBatch/loadInstanceSecretKey calls happen at all
+   * depends on whether that table has any rows left AFTER the privacy
+   * filter, so the exact call count/order varies per test case). Only the
+   * Memory table's `updatedAt > since` query returns `memoryRows`; every
+   * other query (Memory's null-updatedAt query, and all of Soul/Agent/
+   * Relationship) is empty.
+   */
+  function installMock(memoryRows: any[]) {
+    globalThis.fetch = mock(async (urlInput: string | URL | Request, init?: RequestInit) => {
+      const url = typeof urlInput === "string" ? urlInput : urlInput.toString();
+      const method = init?.method ?? "GET";
+      const body = init?.body ? JSON.parse(String(init.body)) : undefined;
+      capturedCalls.push({ url, body, method });
+
+      if (method === "GET" && url.includes("/FederationPeers")) {
+        return res(true, 200, { peers: [{ id: "hub-1", role: "hub", status: "connected", endpoint: "http://hub:9926", lastSyncAt: SINCE }] });
+      }
+      if (method === "GET" && url.includes("/FederationInstance")) {
+        return res(true, 200, { id: "spoke-alpha", publicKey: Buffer.from(testKp.publicKey).toString("base64url"), role: "spoke" });
+      }
+      if (body?.operation === "search_by_conditions") {
+        const isMemoryUpdatedAtQuery = body.table === "Memory" && body.conditions?.[0]?.search_type === "greater_than";
+        return res(true, 200, isMemoryUpdatedAtQuery ? memoryRows : []);
+      }
+      if (body?.operation === "search_by_value") {
+        // loadInstanceSecretKey DB fallback (keystore is empty in test env)
+        return res(true, 200, [{ id: "spoke-alpha", _keySeed: Buffer.from(testKp.secretKey.slice(0, 32)).toString("base64url") }]);
+      }
+      if (body?.operation === "update") {
+        // local hub.lastSyncAt advance
+        return res(true, 200, { ok: true });
+      }
+      if (method === "POST" && url.includes("/FederationSync")) {
+        // sendBatch (has records) or the no-change liveness ping (empty records)
+        const records = body?.records ?? [];
+        return res(true, 200, { merged: records.length, skipped: 0 });
+      }
+      throw new Error(`Unexpected fetch call: ${method} ${url} body=${JSON.stringify(body)}`);
+    }) as any;
+  }
+
+  function hubSyncCalls() {
+    return capturedCalls.filter((c) => c.url.includes("/FederationSync") && c.method === "POST");
+  }
+
+  /** The batch actually POSTed with non-empty records (excludes the liveness ping, if any). */
+  function pushedRecordIds(): string[] {
+    const ids: string[] = [];
+    for (const call of hubSyncCalls()) {
+      for (const r of call.body?.records ?? []) ids.push(r.id);
+    }
+    return ids;
+  }
+
+  it("excludes a private Memory row from the push batch entirely", async () => {
+    installMock([
+      { id: "mem-private", agentId: "a1", content: "secret stuff", visibility: "private", updatedAt: "2025-06-01T00:00:00.000Z", createdAt: "2025-06-01T00:00:00.000Z" },
+    ]);
+
+    const { runFederationSyncOnce } = await import("../../src/cli");
+    const result = await runFederationSyncOnce({ adminPass: "test-admin-pass", opsPort: "9925" });
+
+    expect(result.error).toBeUndefined();
+    expect(pushedRecordIds()).toEqual([]);
+  });
+
+  it("pushes a shared Memory row", async () => {
+    installMock([
+      { id: "mem-shared", agentId: "a1", content: "team update", visibility: "shared", updatedAt: "2025-06-01T00:00:00.000Z", createdAt: "2025-06-01T00:00:00.000Z" },
+    ]);
+
+    const { runFederationSyncOnce } = await import("../../src/cli");
+    const result = await runFederationSyncOnce({ adminPass: "test-admin-pass", opsPort: "9925" });
+
+    expect(result.error).toBeUndefined();
+    expect(pushedRecordIds()).toEqual(["mem-shared"]);
+  });
+
+  it("pushes a null/absent-visibility (legacy) Memory row — migration-safety invariant", async () => {
+    // No `visibility` key at all — mirrors a pre-visibility-field row exactly
+    // as it comes back from Harper's ops API (field simply absent, not null).
+    installMock([
+      { id: "mem-legacy", agentId: "a1", content: "old memory, no visibility field", updatedAt: "2025-06-01T00:00:00.000Z", createdAt: "2025-06-01T00:00:00.000Z" },
+    ]);
+
+    const { runFederationSyncOnce } = await import("../../src/cli");
+    const result = await runFederationSyncOnce({ adminPass: "test-admin-pass", opsPort: "9925" });
+
+    expect(result.error).toBeUndefined();
+    expect(pushedRecordIds()).toEqual(["mem-legacy"]);
+  });
+
+  it("pushes an explicit-null visibility Memory row the same as absent", async () => {
+    installMock([
+      { id: "mem-null", agentId: "a1", content: "explicit null visibility", visibility: null, updatedAt: "2025-06-01T00:00:00.000Z", createdAt: "2025-06-01T00:00:00.000Z" },
+    ]);
+
+    const { runFederationSyncOnce } = await import("../../src/cli");
+    const result = await runFederationSyncOnce({ adminPass: "test-admin-pass", opsPort: "9925" });
+
+    expect(result.error).toBeUndefined();
+    expect(pushedRecordIds()).toEqual(["mem-null"]);
+  });
+
+  it("mixed batch: excludes only the private row, keeps shared + legacy-null", async () => {
+    installMock([
+      { id: "mem-private", agentId: "a1", content: "secret", visibility: "private", updatedAt: "2025-06-01T00:00:00.000Z", createdAt: "2025-06-01T00:00:00.000Z" },
+      { id: "mem-shared", agentId: "a1", content: "shared", visibility: "shared", updatedAt: "2025-06-01T00:00:00.000Z", createdAt: "2025-06-01T00:00:00.000Z" },
+      { id: "mem-legacy", agentId: "a1", content: "legacy", updatedAt: "2025-06-01T00:00:00.000Z", createdAt: "2025-06-01T00:00:00.000Z" },
+    ]);
+
+    const { runFederationSyncOnce } = await import("../../src/cli");
+    const result = await runFederationSyncOnce({ adminPass: "test-admin-pass", opsPort: "9925" });
+
+    expect(result.error).toBeUndefined();
+    expect(pushedRecordIds().sort()).toEqual(["mem-legacy", "mem-shared"]);
+  });
+
+  /**
+   * Anti-drift cross-check: cli.ts inlines its own copy of the "is this
+   * private" predicate (isFederationPrivateVisibility, not exported — see
+   * the packaging-constraint comment in src/cli.ts). It cannot be imported
+   * directly here. Instead, run the SAME table of visibility values through
+   * both the canonical resources/memory-visibility.ts predicate (imported
+   * directly) and through the real push path (one Memory row per value),
+   * and assert the include/exclude decision agrees for every value. If the
+   * two copies ever drift, this test — not just the individual cases above
+   * — catches it.
+   */
+  it("push-path inclusion agrees with resources/memory-visibility.ts's isPrivateVisibility for every value", async () => {
+    const cases: Array<{ visibility: string | null | undefined; label: string }> = [
+      { visibility: "private", label: "private" },
+      { visibility: "shared", label: "shared" },
+      { visibility: null, label: "null" },
+      { visibility: undefined, label: "undefined" },
+      { visibility: "office", label: "office-legacy-value" },
+    ];
+
+    const memoryRows = cases.map((c, i) => {
+      const row: any = { id: `mem-${i}-${c.label}`, agentId: "a1", content: c.label, updatedAt: "2025-06-01T00:00:00.000Z", createdAt: "2025-06-01T00:00:00.000Z" };
+      if (c.visibility !== undefined) row.visibility = c.visibility;
+      return row;
+    });
+
+    installMock(memoryRows);
+    const { runFederationSyncOnce } = await import("../../src/cli");
+    await runFederationSyncOnce({ adminPass: "test-admin-pass", opsPort: "9925" });
+
+    const pushedIds = new Set(pushedRecordIds());
+
+    for (let i = 0; i < cases.length; i++) {
+      const c = cases[i];
+      const id = `mem-${i}-${c.label}`;
+      const expectedPushed = !isPrivateVisibility(c.visibility);
+      expect(pushedIds.has(id)).toBe(expectedPushed);
+    }
+  });
+
+  it("PRIVATE_VISIBILITY constant is the literal string 'private' (matches resources/memory-read-scope.ts)", () => {
+    expect(PRIVATE_VISIBILITY).toBe("private");
+    expect(isPrivateVisibility("private")).toBe(true);
+    expect(isPrivateVisibility("shared")).toBe(false);
+    expect(isPrivateVisibility(null)).toBe(false);
+    expect(isPrivateVisibility(undefined)).toBe(false);
+  });
+});


### PR DESCRIPTION
Federation-edge-hardening **slice 2** — the push-side private-visibility filter (K&S-validated design). `private` memories no longer replicate to peer instances. Foundation prereq for opening within-org read (Kern: lands with/before it).

## What
- `runFederationSyncOnce` (`src/cli.ts`) now filters `private` Memory rows out of the federation push (previously `get_attributes:["*"]` with no filter → private memories were pushed).
- **Scoped to Memory only** — Soul/Agent/Relationship have no `visibility` field.

## Null-safe (the migration invariant)
Only `visibility === "private"` is excluded. **Legacy null/absent-visibility rows keep syncing** (they're shared), exactly matching `resolveReadScope`'s `!== PRIVATE` semantics. This is the critical correctness point — a regression here would silently stop pre-visibility memories from replicating.

## One rule, one place — with a real constraint
- Canonical predicate extracted to **`resources/memory-visibility.ts`** (zero imports); `resolveReadScope` now uses it.
- `src/cli.ts` does **NOT** import it — it inlines an identical copy. Reason: the CLI can't import from `resources/` — that path resolves in the published `dist/cli.js` to a folder not in npm's `files` manifest → `ERR_MODULE_NOT_FOUND` on clean install (the exact v0.5.0–0.5.2 incident, #232/`5696283`; guarded by `scripts/check-imports.mjs`). Inlining matches the existing `canonicalize`/`signBody` precedent. `check-imports dist` → 0 failures.
- Since the two copies can't be unified at import level, `federation-sync-push-privacy.test.ts` runs the same visibility table (`private`/`shared`/`null`/`undefined`/legacy `office`) through **both** the canonical predicate and the real push path, asserting they agree — drift can't slip through.
- Implemented as a **JS post-filter** on fetched rows (not a Harper `not_equal` query condition) — deliberately avoids relying on unverified ops-API NULL semantics; same idiom the push already uses.

## Verified
Full suite **1501/1501** (+7). `tsc` + `build:cli` + `check-imports` clean.

@tps-kern the shared-predicate + inline-vs-import decision (is inlining + a drift test the right call vs the CLI-import crash?). @tps-sherlock the null-visibility correctness — do legacy rows still sync, and is only `private` filtered? + migration-safety. Prose, no code spans.
