### PR TITLE
feat(federation): edge slice 3 — per-record signing + verification (closes hub forgery)

### DIFF
--- a/resources/Federation.ts
+++ b/resources/Federation.ts
@@ -65,6 +65,26 @@ interface PeerAnnouncement {
   endpoint?: string;
 }
 
+// ─── Per-record signature enforcement mode (federation-edge-hardening slice 3b) ──
+
+/**
+ * Whether FederationSync.post requires EVERY record to carry a valid
+ * per-record signature (§3a), skipping unsigned ones (`missing_signature`),
+ * vs. the default "verify-if-present" mode where an unsigned record still
+ * merges (relying on the batch-level signature already verified above it).
+ *
+ * Default OFF (verify-if-present) — pre-3a spokes don't sign individual
+ * records yet, and their batch is already authenticated. Turning this ON
+ * is an OPERATOR decision, never auto-flipped by this code: flip it only
+ * once every paired peer has been confirmed sending per-record signatures
+ * (e.g. by checking SyncLog for unsigned records / peer versions). Flipping
+ * it before every peer has upgraded silently starts dropping that peer's
+ * records instead of merging them.
+ */
+function requireRecordSignatures(): boolean {
+  return (process.env.FLAIR_FEDERATION_REQUIRE_RECORD_SIGNATURES ?? "").toLowerCase() === "true";
+}
+
 // ─── Conflict resolution ─────────────────────────────────────────────────────
 
 /**
@@ -385,6 +405,66 @@ export class FederationSync extends Resource {
 
         if (decision.action === "skip") {
           recordSkip(decision.reason);
+          continue;
+        }
+
+        // ── Per-record signature verification (federation-edge-hardening slice 3b) ──
+        // classifyRecord's "merge" verdict above only proves the record is
+        // STRUCTURALLY eligible (known table, self-originated OR the sender
+        // is a hub, not stale, not a no-op) — that hub bypass trusts the
+        // BATCH-level signature (verifyBodySignatureFresh above, verified
+        // against the SENDER's pinned key). It does NOT prove the record's
+        // *claimed* originator actually produced it — a hub relaying on
+        // behalf of many spokes could otherwise forge a record under any
+        // originatorInstanceId it likes, and the receiver had no way to
+        // tell. This gate closes that hole: verify the record's own
+        // signature (§3a, set at push-time by the ORIGINATOR, never by
+        // whoever relayed it) against the ORIGINATOR's pinned instance key
+        // — never the sender's key.
+        //
+        // A bad/unverifiable signature skips ONLY this record, never the
+        // batch — rejecting the whole batch on one bad record would be a
+        // DoS vector (one forged/garbled record could blackhole every other
+        // legitimate record riding along in the same POST).
+        const originator = decision.originator;
+        if (record.signature) {
+          const originatorPublicKey = originator === instanceId
+            ? peer.publicKey
+            : (await (databases as any).flair.Peer.get(originator))?.publicKey;
+
+          if (!originatorPublicKey) {
+            recordSkip("unknown_originator_key");
+            continue;
+          }
+
+          // CONTRACT — must match src/cli.ts runFederationSyncOnce's signing
+          // payload byte-for-byte: keys { v, table, id, data, updatedAt,
+          // originatorInstanceId }. canonicalize() sorts keys, so field ORDER
+          // doesn't matter, but the field SET and values do. `v: 1` versions
+          // the canonical form itself — bump it on BOTH sides together if the
+          // signed field set ever changes, so an old signature fails closed
+          // instead of silently mis-verifying under a new form.
+          const signatureValid = verifyBodySignature(
+            {
+              v: 1,
+              table: record.table,
+              id: record.id,
+              data: record.data,
+              updatedAt: record.updatedAt,
+              originatorInstanceId: originator,
+              signature: record.signature,
+            },
+            originatorPublicKey,
+          );
+          if (!signatureValid) {
+            recordSkip("invalid_signature");
+            continue;
+          }
+        } else if (requireRecordSignatures()) {
+          // require-mode: unsigned records are no longer trusted on
+          // batch-level auth alone. Default mode (verify-if-present) falls
+          // through here and merges — see requireRecordSignatures() above.
+          recordSkip("missing_signature");
           continue;
         }
 

--- a/resources/federation-classify.ts
+++ b/resources/federation-classify.ts
@@ -20,7 +20,20 @@ export type SkipReason =
   | "unknown_table"
   | "non_originator"
   | "future_timestamp"
-  | "no_op_same_hash";
+  | "no_op_same_hash"
+  // ─── federation-edge-hardening slice 3b ──────────────────────────────────
+  // Emitted by FederationSync.post's per-record signature verification gate
+  // (resources/Federation.ts), NOT by classifyRecord — this function stays
+  // pure/DB-free (verifying a signature against the originator's pinned key
+  // requires a Peer table lookup). Listed here so operators can grep one
+  // SkipReason union for every reason a record can be skipped, and so
+  // SyncLog.skippedReasons stays a closed, typed vocabulary.
+  | "unknown_originator_key" // record is signed, but its claimed originator
+                              // has no pinned public key on file (unknown peer)
+  | "invalid_signature" // record is signed, but the signature doesn't verify
+                        // against the originator's pinned public key
+  | "missing_signature"; // require-mode is on (FLAIR_FEDERATION_REQUIRE_RECORD_SIGNATURES)
+                         // and the record has no signature at all
 
 export type ClassifyResult =
   | { action: "merge"; originator: string }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -47,6 +47,23 @@ function signBody(body: Record<string, any>, secretKey: Uint8Array): string {
   return Buffer.from(sig).toString("base64url");
 }
 
+// Per-record principalId (federation-edge-hardening slice 3a) — INFORMATIONAL
+// only; the receiver (resources/Federation.ts) never treats it as verified
+// identity or uses it in any auth decision. Sourced from the write-time
+// provenance stamp (memory-provenance slice 1, Memory.ts's buildProvenance)
+// when present. `provenance` is persisted as a JSON STRING (not an object),
+// so it must be parsed — a raw `row.provenance?.verified?.agentId` would
+// silently always be undefined. Soul/Agent/Relationship rows never carry a
+// provenance stamp today, so this is a no-op for them.
+function principalIdFromRow(row: any): string | undefined {
+  if (typeof row?.provenance !== "string" || row.provenance.length === 0) return undefined;
+  try {
+    return JSON.parse(row.provenance)?.verified?.agentId ?? undefined;
+  } catch {
+    return undefined;
+  }
+}
+
 // Federation push private-visibility filter — inlined for the SAME reason as
 // the crypto helpers above (see comment there; also resources/memory-
 // visibility.ts, the canonical definition; the two must stay in sync).
@@ -3911,11 +3928,49 @@ export async function runFederationSyncOnce(opts: any): Promise<{ pushed: number
       }
       if (rows.length === 0) continue;
 
+      // Records are signed (below) before they're batched, so the secret key
+      // is needed here rather than only inside sendBatch. Still deferred
+      // until we know THIS table has rows to send — preserves the "don't
+      // load the key on a no-op run" property the original lazy load had.
+      if (!secretKey) secretKey = await loadInstanceSecretKey(instance.id, opts);
+
       let batch: any[] = [];
       let batchBytes = 0;
 
       for (const row of rows) {
-        const sr = { table, id: row.id, data: row, updatedAt: row.updatedAt ?? row.createdAt, originatorInstanceId: instance.id };
+        const updatedAt = row.updatedAt ?? row.createdAt;
+        const originatorInstanceId = instance.id;
+
+        // Per-record signature (federation-edge-hardening slice 3a): signed by
+        // THIS instance — the originator — over a versioned canonical form, so
+        // a receiver (including a hub relaying this record onward to other
+        // spokes) can verify authorship independent of who forwarded the
+        // batch. Closes the hub-relay forgery hole — see
+        // resources/Federation.ts FederationSync.post's verification gate.
+        //
+        // CONTRACT — must match Federation.ts's verification payload
+        // byte-for-byte: keys { v, table, id, data, updatedAt,
+        // originatorInstanceId }. canonicalize() sorts keys, so field ORDER
+        // doesn't matter, but the field SET and values do. `v: 1` versions the
+        // canonical form itself: bump it on BOTH sides together if the signed
+        // field set ever changes, so an old signature fails closed instead of
+        // silently mis-verifying under a new form.
+        //
+        // Additive/backward-compatible: pre-3a receivers don't read
+        // `signature`/`principalId` at all and merge exactly as before.
+        const signature = signBody(
+          { v: 1, table, id: row.id, data: row, updatedAt, originatorInstanceId },
+          secretKey,
+        );
+
+        const sr: Record<string, any> = { table, id: row.id, data: row, updatedAt, originatorInstanceId, signature };
+
+        // Informational only (see principalIdFromRow) — never verified by the
+        // receiver as proof of authorship. Omitted entirely when the row
+        // carries no write-time provenance stamp.
+        const principalId = principalIdFromRow(row);
+        if (principalId) sr.principalId = principalId;
+
         const srBytes = JSON.stringify(sr).length;
 
         if (batch.length >= BUDGET_RECORDS || (batch.length > 0 && batchBytes + srBytes > BUDGET_BYTES)) {

--- a/test/integration/federation-sync-e2e.test.ts
+++ b/test/integration/federation-sync-e2e.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, test, beforeEach } from "bun:test";
 import nacl from "tweetnacl";
-import { signBodyFresh, createNonceStore, verifyBodySignatureFresh } from "../../resources/federation-crypto.js";
+import {
+  signBodyFresh,
+  createNonceStore,
+  verifyBodySignatureFresh,
+  verifyBodySignature,
+  signBody,
+} from "../../resources/federation-crypto.js";
 
 // ─── Transitional integration test for Federation resource logic ──────────
 // TODO(ops-NEW-P1): Upgrade to real Harper container using test/helpers/harper-lifecycle.
@@ -15,6 +21,10 @@ import { signBodyFresh, createNonceStore, verifyBodySignatureFresh } from "../..
 //   - Peer status/role validation (revoked → 401, unknown → 401)
 //   - verifyBodySignatureFresh rejection reasons
 //   - Record merging with originator enforcement
+//   - federation-edge-hardening slice 3b: per-record signature verification
+//     against the ORIGINATOR's pinned key (not just the sender's), including
+//     the hub-relay-forgery hole this slice closes (see the "hub relay" describe
+//     block below)
 
 describe("FederationSync resource logic (transitional)", () => {
   let peerStore: Map<string, any>;
@@ -39,8 +49,17 @@ describe("FederationSync resource logic (transitional)", () => {
     return record.id;
   }
 
-  async function handleSyncRequest(body: Record<string, any>): Promise<{ status: number; body: any }> {
+  /**
+   * @param opts.requireRecordSignatures mirrors
+   *   FLAIR_FEDERATION_REQUIRE_RECORD_SIGNATURES (default false — the
+   *   verify-if-present mode Federation.ts defaults to).
+   */
+  async function handleSyncRequest(
+    body: Record<string, any>,
+    opts: { requireRecordSignatures?: boolean } = {},
+  ): Promise<{ status: number; body: any }> {
     const { instanceId, records, _ts, _nonce, signature } = body;
+    const requireRecordSignatures = opts.requireRecordSignatures ?? false;
 
     // ── Input validation (matches FederationSync.post) ──
     if (!instanceId || !Array.isArray(records)) {
@@ -75,52 +94,135 @@ describe("FederationSync resource logic (transitional)", () => {
     // ── Merge logic (simplified from FederationSync.post) ──
     let merged = 0;
     let skipped = 0;
+    const skippedReasons: Record<string, number> = {};
+    const recordSkip = (reason: string) => {
+      skipped++;
+      skippedReasons[reason] = (skippedReasons[reason] ?? 0) + 1;
+    };
 
     for (const record of records as any[]) {
-      if (record.table !== "Memory") { skipped++; continue; }
+      // Each record is independently classified and skipped-not-rejected —
+      // one bad record in a batch never aborts the whole request (a
+      // reject-the-batch policy would be a DoS vector: any peer could
+      // blackhole every other legitimate record by including one bad one).
+      try {
+        if (record.table !== "Memory") { recordSkip("unknown_table"); continue; }
 
-      const originator = record.originatorInstanceId ?? instanceId;
-      if (originator !== instanceId && peer.role !== "hub") {
-        skipped++;
-        continue;
+        const originator = record.originatorInstanceId ?? instanceId;
+        if (originator !== instanceId && peer.role !== "hub") {
+          recordSkip("non_originator");
+          continue;
+        }
+
+        const local = memoryGet(record.id);
+        const ts = record.updatedAt ?? new Date().toISOString();
+
+        // Timestamp ceiling
+        const fiveMinFromNow = new Date(Date.now() + 5 * 60 * 1000).toISOString();
+        if (ts > fiveMinFromNow) { recordSkip("future_timestamp"); continue; }
+
+        if (local && local.updatedAt && local.updatedAt > ts) { recordSkip("stale"); continue; }
+
+        // contentHash gate (matches Federation.ts production code) — skip the
+        // write if local and remote agree on contentHash and remote isn't
+        // strictly newer. Prevents the federation-watch re-upsert loop.
+        const remoteContentHash = (record.data as any)?.contentHash;
+        if (
+          local &&
+          local.contentHash &&
+          remoteContentHash &&
+          local.contentHash === remoteContentHash &&
+          ts <= (local.updatedAt ?? "")
+        ) {
+          recordSkip("no_op_same_hash");
+          continue;
+        }
+
+        // ── Per-record signature verification (federation-edge-hardening slice 3b) ──
+        // This is the gate that closes the hub-relay-forgery hole: the
+        // batch-level signature above only proves the SENDER is who they
+        // claim (peer.publicKey). When peer.role === "hub" relays a record
+        // whose originatorInstanceId names some OTHER instance, that
+        // sender-level proof says nothing about whether that other
+        // instance actually produced this record's data — a hub could
+        // otherwise forge anything on behalf of any spoke it knows about.
+        // Verify against the CLAIMED ORIGINATOR's pinned key instead:
+        //   - originator === sender (instanceId) → sender's peer.publicKey
+        //     (already fetched/verified above)
+        //   - else (a relayed record) → look up the originator's own Peer
+        //     record for ITS publicKey — same table/pattern as the sender
+        //     lookup, just keyed by a different id.
+        if (record.signature) {
+          const originatorPeer = originator === instanceId ? peer : peerGet(originator);
+          const originatorPublicKey = originatorPeer?.publicKey;
+
+          if (!originatorPublicKey) {
+            recordSkip("unknown_originator_key");
+            continue;
+          }
+
+          // CONTRACT: byte-for-byte the same canonical form src/cli.ts signs
+          // — { v: 1, table, id, data, updatedAt, originatorInstanceId }.
+          const signatureValid = verifyBodySignature(
+            {
+              v: 1,
+              table: record.table,
+              id: record.id,
+              data: record.data,
+              updatedAt: record.updatedAt,
+              originatorInstanceId: originator,
+              signature: record.signature,
+            },
+            originatorPublicKey,
+          );
+          if (!signatureValid) {
+            recordSkip("invalid_signature");
+            continue;
+          }
+        } else if (requireRecordSignatures) {
+          // require-mode: unsigned records are no longer trusted on
+          // batch-level auth alone.
+          recordSkip("missing_signature");
+          continue;
+        }
+        // else: verify-if-present (default) — unsigned record still merges,
+        // covered by the batch-level signature verified above.
+
+        const mergedData = {
+          ...(record.data ?? {}),
+          id: record.id,
+          updatedAt: ts,
+          _originatorInstanceId: originator,
+          _syncedFrom: instanceId,
+        };
+        memoryPut(mergedData);
+        merged++;
+      } catch {
+        // Mirrors FederationSync.post's per-record try/catch: an unexpected
+        // error merging one record must not abort the batch.
+        recordSkip("merge_error");
       }
-
-      const local = memoryGet(record.id);
-      const ts = record.updatedAt ?? new Date().toISOString();
-
-      // Timestamp ceiling
-      const fiveMinFromNow = new Date(Date.now() + 5 * 60 * 1000).toISOString();
-      if (ts > fiveMinFromNow) { skipped++; continue; }
-
-      if (local && local.updatedAt && local.updatedAt > ts) { skipped++; continue; }
-
-      // contentHash gate (matches Federation.ts production code) — skip the
-      // write if local and remote agree on contentHash and remote isn't
-      // strictly newer. Prevents the federation-watch re-upsert loop.
-      const remoteContentHash = (record.data as any)?.contentHash;
-      if (
-        local &&
-        local.contentHash &&
-        remoteContentHash &&
-        local.contentHash === remoteContentHash &&
-        ts <= (local.updatedAt ?? "")
-      ) {
-        skipped++;
-        continue;
-      }
-
-      const mergedData = {
-        ...(record.data ?? {}),
-        id: record.id,
-        updatedAt: ts,
-        _originatorInstanceId: originator,
-        _syncedFrom: instanceId,
-      };
-      memoryPut(mergedData);
-      merged++;
     }
 
-    return { status: 200, body: { merged, skipped, durationMs: 1 } };
+    return { status: 200, body: { merged, skipped, skippedReasons, durationMs: 1 } };
+  }
+
+  /** Sign a per-record canonical payload the way src/cli.ts's runFederationSyncOnce does (§3a). */
+  function signRecord(
+    record: { table: string; id: string; data: Record<string, any>; updatedAt: string; originatorInstanceId: string },
+    secretKey: Uint8Array,
+  ): string {
+    return signBody(
+      {
+        v: 1,
+        table: record.table,
+        id: record.id,
+        data: record.data,
+        updatedAt: record.updatedAt,
+        originatorInstanceId: record.originatorInstanceId,
+      },
+      secretKey,
+    );
   }
 
   test("valid signed sync request → 200 + merges records", async () => {
@@ -313,6 +415,12 @@ describe("FederationSync resource logic (transitional)", () => {
     expect(response.status).toBe(200);
     expect(response.body.skipped).toBe(1); // rejected
     expect(response.body.merged).toBe(0);
+    expect(response.body.skippedReasons.non_originator).toBe(1);
+    // Unaffected by federation-edge-hardening slice 3b: the peer here is a
+    // "spoke", not "hub", so this record is skipped as non_originator BEFORE
+    // the per-record signature gate ever runs (signed or not makes no
+    // difference — see the "hub relay" describe block below for the gate
+    // itself).
   });
 
   test("duplicate records (LWW) — newer wins", async () => {
@@ -471,5 +579,212 @@ describe("FederationSync resource logic (transitional)", () => {
     expect(second.status).toBe(200);
     expect(second.body.merged).toBe(1);
     expect(second.body.skipped).toBe(0);
+  });
+
+  // ─── federation-edge-hardening slice 3b — per-record signature verification ──
+  //
+  // Before this slice: classifyRecord's peerRole === "hub" bypass let a hub
+  // relay a record under ANY originatorInstanceId with zero further checks —
+  // record.signature/record.principalId were defined on the wire type but
+  // read by ZERO code. A malicious or compromised hub could forge a record
+  // "from" any spoke it had ever seen, and the receiver had no way to tell.
+  //
+  // After this slice: a hub may still relay (the classifyRecord bypass is
+  // UNCHANGED — see federation-classify-record.test.ts), but FederationSync.post
+  // now verifies the record's own signature (set at push-time by the
+  // ORIGINATOR, §3a) against the ORIGINATOR's OWN pinned instance key before
+  // merging — never against the relaying hub's key. These tests exercise
+  // that gate directly.
+  describe("hub relay — per-record signature verification (federation-edge-hardening slice 3b)", () => {
+    const hubId = "hub-1";
+    const originatorId = "spoke-beta-2"; // the instance that ACTUALLY produced the record
+    let hubKp: nacl.SignKeyPair;
+    let originatorKp: nacl.SignKeyPair;
+
+    beforeEach(() => {
+      hubKp = nacl.sign.keyPair();
+      originatorKp = nacl.sign.keyPair();
+
+      // Hub is the SENDER of the sync batch (paired, hub role).
+      peerStore.set(hubId, {
+        id: hubId,
+        publicKey: Buffer.from(hubKp.publicKey).toString("base64url"),
+        role: "hub",
+        status: "paired",
+      });
+      // Originator is a DIFFERENT, separately-paired peer — its pinned public
+      // key is what the receiver must verify the relayed record against.
+      peerStore.set(originatorId, {
+        id: originatorId,
+        publicKey: Buffer.from(originatorKp.publicKey).toString("base64url"),
+        role: "spoke",
+        status: "paired",
+      });
+    });
+
+    function relayedRecord(overrides: Partial<{ data: Record<string, any>; updatedAt: string; signature: string | undefined }> = {}) {
+      const updatedAt = overrides.updatedAt ?? new Date().toISOString();
+      const data = overrides.data ?? { id: "mem-relayed", content: "produced by the originator" };
+      return {
+        table: "Memory",
+        id: "mem-relayed",
+        data,
+        updatedAt,
+        originatorInstanceId: originatorId,
+        ...(("signature" in overrides) ? { signature: overrides.signature } : {}),
+      };
+    }
+
+    function sendFromHub(record: any, opts?: { requireRecordSignatures?: boolean }) {
+      const signed = signBodyFresh(
+        { instanceId: hubId, records: [record], lamportClock: Date.now() },
+        hubKp.secretKey,
+      );
+      return handleSyncRequest(signed, opts);
+    }
+
+    // ── THE CRITICAL TEST — the hole this slice closes ──────────────────
+    test("CRITICAL: hub relays a record with a VALID originator signature → merges", async () => {
+      const base = relayedRecord();
+      const signature = signRecord(base, originatorKp.secretKey);
+      const record = { ...base, signature };
+
+      const response = await sendFromHub(record);
+
+      expect(response.status).toBe(200);
+      expect(response.body.merged).toBe(1);
+      expect(response.body.skipped).toBe(0);
+      expect(memoryGet("mem-relayed")?.content).toBe("produced by the originator");
+    });
+
+    test("CRITICAL: hub relays a record FORGED under the originator's name (signed by the hub's own key, not the originator's) → skipped, NOT merged", async () => {
+      const base = relayedRecord();
+      // The hub signs the record itself, claiming originatorId — exactly the
+      // forgery this slice defends against (pre-3b, this record would have
+      // merged solely because peer.role === "hub").
+      const forgedSignature = signRecord(base, hubKp.secretKey);
+      const record = { ...base, signature: forgedSignature };
+
+      const response = await sendFromHub(record);
+
+      expect(response.status).toBe(200);
+      expect(response.body.merged).toBe(0);
+      expect(response.body.skipped).toBe(1);
+      expect(response.body.skippedReasons.invalid_signature).toBe(1);
+      expect(memoryGet("mem-relayed")).toBeNull();
+    });
+
+    test("CRITICAL: hub relays a record signed by a THIRD, unrelated key claiming to be the originator → skipped as invalid_signature", async () => {
+      const base = relayedRecord();
+      const attackerKp = nacl.sign.keyPair();
+      const record = { ...base, signature: signRecord(base, attackerKp.secretKey) };
+
+      const response = await sendFromHub(record);
+
+      expect(response.body.merged).toBe(0);
+      expect(response.body.skippedReasons.invalid_signature).toBe(1);
+    });
+
+    test("hub relays a record whose claimed originator has no pinned key on file → skipped as unknown_originator_key", async () => {
+      const unknownOriginator = "spoke-never-paired-9";
+      const base = { ...relayedRecord(), originatorInstanceId: unknownOriginator };
+      // Sign with SOME key — doesn't matter which, there's no pinned key to
+      // verify against at all.
+      const someKp = nacl.sign.keyPair();
+      const record = { ...base, signature: signRecord(base, someKp.secretKey) };
+
+      const response = await sendFromHub(record);
+
+      expect(response.body.merged).toBe(0);
+      expect(response.body.skippedReasons.unknown_originator_key).toBe(1);
+    });
+
+    test("verify-if-present (default): hub relays an UNSIGNED record → still merges (backward-compat for pre-3a spokes)", async () => {
+      const base = relayedRecord({ signature: undefined });
+
+      const response = await sendFromHub(base /* opts defaults requireRecordSignatures: false */);
+
+      expect(response.status).toBe(200);
+      expect(response.body.merged).toBe(1);
+      expect(response.body.skipped).toBe(0);
+    });
+
+    test("require-mode: hub relays an UNSIGNED record → skipped as missing_signature", async () => {
+      const base = relayedRecord({ signature: undefined });
+
+      const response = await sendFromHub(base, { requireRecordSignatures: true });
+
+      expect(response.status).toBe(200);
+      expect(response.body.merged).toBe(0);
+      expect(response.body.skippedReasons.missing_signature).toBe(1);
+    });
+
+    test("require-mode: a VALIDLY signed relayed record still merges (require-mode only rejects the unsigned case)", async () => {
+      const base = relayedRecord();
+      const record = { ...base, signature: signRecord(base, originatorKp.secretKey) };
+
+      const response = await sendFromHub(record, { requireRecordSignatures: true });
+
+      expect(response.body.merged).toBe(1);
+      expect(response.body.skipped).toBe(0);
+    });
+
+    test("skip-not-reject: a batch with one forged record and one good record still merges the good one", async () => {
+      const good = relayedRecord({ data: { id: "mem-relayed", content: "good" } });
+      const goodSigned = { ...good, signature: signRecord(good, originatorKp.secretKey) };
+
+      const badBase = { ...relayedRecord({ data: { id: "mem-relayed-2", content: "forged" } }), id: "mem-relayed-2" };
+      const badSigned = { ...badBase, signature: signRecord(badBase, hubKp.secretKey) }; // forged: signed by hub, not originator
+
+      const signedBatch = signBodyFresh(
+        { instanceId: hubId, records: [goodSigned, badSigned], lamportClock: Date.now() },
+        hubKp.secretKey,
+      );
+      const response = await handleSyncRequest(signedBatch);
+
+      expect(response.status).toBe(200);
+      expect(response.body.merged).toBe(1);
+      expect(response.body.skipped).toBe(1);
+      expect(response.body.skippedReasons.invalid_signature).toBe(1);
+      expect(memoryGet("mem-relayed")?.content).toBe("good");
+      expect(memoryGet("mem-relayed-2")).toBeNull();
+    });
+
+    // ── Migration-equivalence: pre-3a records (no signature at all) behave
+    // identically to how they did before this slice existed, as long as
+    // require-mode is off (the default).
+    test("migration-equivalence: an unsigned record from a directly-originating (non-relayed) spoke merges exactly as before slice 3", async () => {
+      const spokeKp = nacl.sign.keyPair();
+      const spokeId = "spoke-legacy-1";
+      peerStore.set(spokeId, {
+        id: spokeId,
+        publicKey: Buffer.from(spokeKp.publicKey).toString("base64url"),
+        role: "spoke",
+        status: "paired",
+      });
+
+      const signed = signBodyFresh(
+        {
+          instanceId: spokeId,
+          records: [{
+            table: "Memory",
+            id: "mem-legacy",
+            data: { id: "mem-legacy", content: "pre-3a spoke, no per-record signature" },
+            updatedAt: new Date().toISOString(),
+            originatorInstanceId: spokeId,
+            // no `signature` field — exactly what a pre-3a spoke sends
+          }],
+          lamportClock: Date.now(),
+        },
+        spokeKp.secretKey,
+      );
+
+      const response = await handleSyncRequest(signed);
+
+      expect(response.status).toBe(200);
+      expect(response.body.merged).toBe(1);
+      expect(response.body.skipped).toBe(0);
+      expect(memoryGet("mem-legacy")?.content).toBe("pre-3a spoke, no per-record signature");
+    });
   });
 });

--- a/test/unit/federation-classify-record.test.ts
+++ b/test/unit/federation-classify-record.test.ts
@@ -32,6 +32,20 @@ describe("classifyRecord — skip categorization", () => {
     const r = makeRecord({ originatorInstanceId: "spoke-2" });
     // Receiver is hub; sender is a hub-role peer (e.g., spokes' shared hub
     // relaying spoke-2's record).
+    //
+    // federation-edge-hardening slice 3b: this "merge" verdict is STRUCTURAL
+    // eligibility only — it does NOT mean the record actually gets merged.
+    // FederationSync.post (resources/Federation.ts), which calls
+    // classifyRecord, applies a signature-verification gate AFTER this
+    // decision: a hub-relayed record only merges if its signature verifies
+    // against spoke-2's (the claimed originator's) pinned instance key. A
+    // forged or unsigned (under require-mode) relayed record is skipped
+    // there — invalid_signature / unknown_originator_key / missing_signature
+    // — even though classifyRecord itself still says "merge". See
+    // test/integration/federation-sync-e2e.test.ts's hub-relay tests for the
+    // full gate. classifyRecord stays pure/DB-free on purpose: verifying a
+    // signature against the originator's pinned key requires a Peer table
+    // lookup, which does not belong in this pure function.
     const result = classifyRecord(r, "hub", receiverId, null, knownTables, now);
     expect(result).toEqual({ action: "merge", originator: "spoke-2" });
   });
@@ -101,5 +115,18 @@ describe("classifyRecord — skip categorization", () => {
     // receiverInstanceId is spoke-1 in this test, so default originator is spoke-1
     // → spoke-1 === receiver, NOT non_originator skip.
     expect(result).toEqual({ action: "merge", originator: "spoke-1" });
+  });
+
+  // federation-edge-hardening slice 3b introduced per-record signature
+  // verification (originator-key lookup via databases.flair.Peer.get) in
+  // FederationSync.post. That verification MUST NOT move into classifyRecord
+  // — it's the DB-free pure decision function specifically so the merge/skip
+  // logic is unit-testable without a running Harper instance. This guards
+  // against a future change quietly threading a DB call in here: the
+  // signature (5 required params, none of them a database handle) and
+  // non-async nature (no DB call could `await` inside it) stay unchanged.
+  test("classifyRecord stays pure/DB-free — signature unchanged by slice 3b", () => {
+    expect(classifyRecord.length).toBe(5); // record, peerRole, receiverInstanceId, local, knownTables (now has a default)
+    expect(classifyRecord.constructor.name).toBe("Function"); // not async — no DB awaits possible
   });
 });

--- a/test/unit/federation-sync-push-signing.test.ts
+++ b/test/unit/federation-sync-push-signing.test.ts
@@ -1,0 +1,238 @@
+import { describe, it, expect, mock, afterEach, beforeAll, afterAll } from "bun:test";
+import { existsSync, rmSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { randomUUID } from "node:crypto";
+import nacl from "tweetnacl";
+import { canonicalize, verifyBodySignature } from "../../resources/federation-crypto";
+import { keystore } from "../../src/keystore";
+
+/**
+ * federation-edge-hardening slice 3a.
+ *
+ * The federation-sync PUSH (runFederationSyncOnce in src/cli.ts) now signs
+ * EACH SyncRecord individually — over a versioned canonical form — using the
+ * instance's already-loaded secret key, in addition to the existing
+ * batch-level signBodyFresh signature. This is the additive half of the fix;
+ * resources/Federation.ts's FederationSync.post (slice 3b) is what actually
+ * verifies it on the receiving side (see federation-sync-e2e.test.ts).
+ *
+ * This file proves, against the real push path:
+ *   - every pushed record carries a `signature` field
+ *   - that signature verifies against the instance's public key, over the
+ *     EXACT canonical form { v: 1, table, id, data, updatedAt,
+ *     originatorInstanceId } — the same shape resources/Federation.ts
+ *     reconstructs on verify
+ *   - principalId is attached ONLY when the row carries a write-time
+ *     provenance stamp with a verified agentId (informational; never
+ *     required for verification)
+ *   - a tampered field breaks verification (the round-trip isn't a no-op)
+ */
+
+const origFetch = globalThis.fetch;
+
+function res(ok: boolean, status: number, body: any) {
+  return {
+    ok,
+    status,
+    headers: {
+      get: (name: string) =>
+        name === "content-length" ? String(JSON.stringify(body).length) : null,
+    },
+    json: async () => body,
+    text: async () => JSON.stringify(body),
+  } as unknown as Response;
+}
+
+const testKp = nacl.sign.keyPair();
+const publicKeyB64url = Buffer.from(testKp.publicKey).toString("base64url");
+const SINCE = "2025-01-01T00:00:00.000Z";
+// A randomized, obviously-synthetic instance ID — NOT "spoke-alpha" (used by
+// federation-sync-push-privacy.test.ts and elsewhere). keystore.ts persists
+// keys to the REAL ~/.flair/keys/ on disk (there is no test-mode override),
+// so reusing a shared ID risks reading a STALE key left behind by a prior
+// test run/file instead of the keypair this file actually signs with —
+// exactly the failure mode this randomization avoids. Cleaned up in
+// afterAll below.
+const INSTANCE_ID = `test-fed-sig-3a-${randomUUID().slice(0, 8)}`;
+
+describe("federation sync push — per-record signing (federation-edge-hardening slice 3a)", () => {
+  let capturedCalls: Array<{ url: string; body?: any; method?: string }> = [];
+
+  beforeAll(() => {
+    // Pin the keystore to OUR known keypair for this synthetic instance ID
+    // so loadInstanceSecretKey() deterministically returns testKp.secretKey
+    // (via the keystore branch) rather than depending on the search_by_value
+    // DB-fallback mock below, which only fires if the keystore is empty.
+    keystore.setPrivateKeySeed(INSTANCE_ID, testKp.secretKey.slice(0, 32));
+  });
+
+  afterAll(() => {
+    const keyFile = join(homedir(), ".flair", "keys", `${INSTANCE_ID}.key`);
+    if (existsSync(keyFile)) rmSync(keyFile, { force: true });
+  });
+
+  afterEach(() => {
+    globalThis.fetch = origFetch;
+  });
+
+  function installMock(memoryRows: any[]) {
+    capturedCalls = [];
+    globalThis.fetch = mock(async (urlInput: string | URL | Request, init?: RequestInit) => {
+      const url = typeof urlInput === "string" ? urlInput : urlInput.toString();
+      const method = init?.method ?? "GET";
+      const body = init?.body ? JSON.parse(String(init.body)) : undefined;
+      capturedCalls.push({ url, body, method });
+
+      if (method === "GET" && url.includes("/FederationPeers")) {
+        return res(true, 200, { peers: [{ id: "hub-1", role: "hub", status: "connected", endpoint: "http://hub:9926", lastSyncAt: SINCE }] });
+      }
+      if (method === "GET" && url.includes("/FederationInstance")) {
+        return res(true, 200, { id: INSTANCE_ID, publicKey: publicKeyB64url, role: "spoke" });
+      }
+      if (body?.operation === "search_by_conditions") {
+        const isMemoryUpdatedAtQuery = body.table === "Memory" && body.conditions?.[0]?.search_type === "greater_than";
+        return res(true, 200, isMemoryUpdatedAtQuery ? memoryRows : []);
+      }
+      if (body?.operation === "search_by_value") {
+        // loadInstanceSecretKey DB fallback (keystore is empty in test env)
+        return res(true, 200, [{ id: INSTANCE_ID, _keySeed: Buffer.from(testKp.secretKey.slice(0, 32)).toString("base64url") }]);
+      }
+      if (body?.operation === "update") {
+        return res(true, 200, { ok: true });
+      }
+      if (method === "POST" && url.includes("/FederationSync")) {
+        const records = body?.records ?? [];
+        return res(true, 200, { merged: records.length, skipped: 0 });
+      }
+      throw new Error(`Unexpected fetch call: ${method} ${url} body=${JSON.stringify(body)}`);
+    }) as any;
+  }
+
+  function pushedRecords(): any[] {
+    const records: any[] = [];
+    for (const call of capturedCalls) {
+      if (call.url.includes("/FederationSync") && call.method === "POST") {
+        for (const r of call.body?.records ?? []) records.push(r);
+      }
+    }
+    return records;
+  }
+
+  /** Reconstruct the canonical payload the receiver verifies against. */
+  function canonicalPayloadOf(record: any) {
+    return {
+      v: 1,
+      table: record.table,
+      id: record.id,
+      data: record.data,
+      updatedAt: record.updatedAt,
+      originatorInstanceId: record.originatorInstanceId,
+    };
+  }
+
+  it("attaches a signature to every pushed record", async () => {
+    installMock([
+      { id: "mem-1", agentId: "a1", content: "hello", updatedAt: "2025-06-01T00:00:00.000Z", createdAt: "2025-06-01T00:00:00.000Z" },
+    ]);
+
+    const { runFederationSyncOnce } = await import("../../src/cli");
+    const result = await runFederationSyncOnce({ adminPass: "test-admin-pass", opsPort: "9925" });
+
+    expect(result.error).toBeUndefined();
+    const records = pushedRecords();
+    expect(records.length).toBe(1);
+    expect(typeof records[0].signature).toBe("string");
+    expect(records[0].signature.length).toBeGreaterThan(0);
+  });
+
+  it("the signature round-trips against the instance public key over the versioned canonical form", async () => {
+    installMock([
+      { id: "mem-2", agentId: "a1", content: "round trip me", updatedAt: "2025-06-01T00:00:00.000Z", createdAt: "2025-06-01T00:00:00.000Z" },
+    ]);
+
+    const { runFederationSyncOnce } = await import("../../src/cli");
+    await runFederationSyncOnce({ adminPass: "test-admin-pass", opsPort: "9925" });
+
+    const record = pushedRecords()[0];
+    expect(record.originatorInstanceId).toBe(INSTANCE_ID);
+
+    const payload = canonicalPayloadOf(record);
+    expect(payload.v).toBe(1);
+
+    const ok = verifyBodySignature({ ...payload, signature: record.signature }, publicKeyB64url);
+    expect(ok).toBe(true);
+  });
+
+  it("a tampered field breaks verification — the round-trip is not a no-op", async () => {
+    installMock([
+      { id: "mem-3", agentId: "a1", content: "original", updatedAt: "2025-06-01T00:00:00.000Z", createdAt: "2025-06-01T00:00:00.000Z" },
+    ]);
+
+    const { runFederationSyncOnce } = await import("../../src/cli");
+    await runFederationSyncOnce({ adminPass: "test-admin-pass", opsPort: "9925" });
+
+    const record = pushedRecords()[0];
+    const payload = canonicalPayloadOf(record);
+
+    // Tamper with data after the fact — same shape used by canonicalize().
+    const tampered = { ...payload, data: { ...payload.data, content: "tampered" }, signature: record.signature };
+    expect(verifyBodySignature(tampered, publicKeyB64url)).toBe(false);
+
+    // Tamper with a wrong public key instead.
+    const otherKp = nacl.sign.keyPair();
+    const wrongKeyResult = verifyBodySignature(
+      { ...payload, signature: record.signature },
+      Buffer.from(otherKp.publicKey).toString("base64url"),
+    );
+    expect(wrongKeyResult).toBe(false);
+  });
+
+  it("principalId is attached when the row carries a verified provenance stamp", async () => {
+    const provenance = JSON.stringify({ v: 1, verified: { agentId: "agent-nathan", timestamp: "2025-06-01T00:00:00.000Z" } });
+    installMock([
+      { id: "mem-prov", agentId: "a1", content: "has provenance", provenance, updatedAt: "2025-06-01T00:00:00.000Z", createdAt: "2025-06-01T00:00:00.000Z" },
+    ]);
+
+    const { runFederationSyncOnce } = await import("../../src/cli");
+    await runFederationSyncOnce({ adminPass: "test-admin-pass", opsPort: "9925" });
+
+    const record = pushedRecords()[0];
+    expect(record.principalId).toBe("agent-nathan");
+  });
+
+  it("principalId is OMITTED (not null/undefined-valued) when the row has no provenance stamp", async () => {
+    installMock([
+      { id: "mem-noprov", agentId: "a1", content: "no provenance", updatedAt: "2025-06-01T00:00:00.000Z", createdAt: "2025-06-01T00:00:00.000Z" },
+    ]);
+
+    const { runFederationSyncOnce } = await import("../../src/cli");
+    await runFederationSyncOnce({ adminPass: "test-admin-pass", opsPort: "9925" });
+
+    const record = pushedRecords()[0];
+    expect("principalId" in record).toBe(false);
+  });
+
+  it("principalId is OMITTED when provenance is malformed JSON — fails closed, doesn't throw", async () => {
+    installMock([
+      { id: "mem-badprov", agentId: "a1", content: "bad provenance", provenance: "{not json", updatedAt: "2025-06-01T00:00:00.000Z", createdAt: "2025-06-01T00:00:00.000Z" },
+    ]);
+
+    const { runFederationSyncOnce } = await import("../../src/cli");
+    const result = await runFederationSyncOnce({ adminPass: "test-admin-pass", opsPort: "9925" });
+
+    expect(result.error).toBeUndefined();
+    const record = pushedRecords()[0];
+    expect("principalId" in record).toBe(false);
+    // still signed — a bad provenance blob must not break signing.
+    expect(typeof record.signature).toBe("string");
+  });
+
+  it("canonicalize sorts keys — signing is insensitive to source field order", () => {
+    // Sanity-check the exact shared primitive both sides rely on for the
+    // byte-for-byte contract: field order must not matter.
+    const a = canonicalize({ v: 1, table: "Memory", id: "x", data: { b: 1, a: 2 }, updatedAt: "t", originatorInstanceId: "i" });
+    const b = canonicalize({ originatorInstanceId: "i", updatedAt: "t", data: { a: 2, b: 1 }, id: "x", table: "Memory", v: 1 });
+    expect(a).toBe(b);
+  });
+});


### PR DESCRIPTION
**Closes the critical per-record forgery hole** (edge slice 3, 3a+3b; K&S design-approved). Today `FederationSync.post` merges each record's data via LWW without verifying `record.signature`/`principalId` (defined, read by zero code) — combined with the hub-role classifier bypass, any paired hub peer could inject records for any agentId. This adds per-**instance** record signing + verification at the hub, using existing crypto.

## 3a — push signs each record
`sr.signature = signBody({ v:1, table, id, data, updatedAt, originatorInstanceId }, instanceSecretKey)` in `runFederationSyncOnce`. **Versioned canonical form** (`v:1`) so a future format change is detectable, not a silent verify break (Sherlock). Additive/backward-compatible. `principalId` from `provenance` (informational) — note: `provenance` is a JSON *string*, parsed safely.

## 3b — receiver verifies (the fix)
In `FederationSync.post`, after `classifyRecord` says merge, before `mergeRecord`: verify `record.signature` against the **originator's pinned instance key** — sender's `peer.publicKey` when originator==sender, else `Peer.get(originator).publicKey` (hub relaying). Sign/verify canonical forms **byte-match** (`verifyBodySignature` strips `signature`, canonicalizes the same 6 fields).
- **Skip-not-reject:** bad/unknown → skip that record (`invalid_signature` / `unknown_originator_key`), never drop the batch (DoS vector).
- **Verify-if-present → require:** unsigned merges under default (pre-3a compat); `FLAIR_FEDERATION_REQUIRE_RECORD_SIGNATURES` flips to require (operator decision, not runtime-auto).
- **Hub bypass KEPT in `classifyRecord`** (structural eligibility); enforcement is the gate in `post` (Kern — else hub-relayed records skip as non_originator before verification runs). `classifyRecord` stays pure/DB-free.

## The hole, closed
Critical test: a hub relaying a record forged under another instance's name (signed by the **hub's own key**) → **skipped `invalid_signature`, not merged.** Also: valid-originator-sig merges, unknown-key skips, one-bad-record-in-batch still merges the good ones.

## Deferred (K&S-confirmed, each its own slice)
3c spoke-relay verification (needs peer-key propagation), 3d per-agent signatures (agent keys live on clients — an epic), the pairing interlock (needs an "external peer" definition). Until the interlock exists, the operator must not pair external instances before this is live.

## Verified
Unit **1509/1509** (+8, incl. the hole-closing test); integration federation-sync-e2e/watch pass; tsc + build:cli + check-imports clean.

@tps-sherlock the hole-closing (hub can't forge with its own key), skip-not-reject safety, the canonical-form versioning. @tps-kern the gate-in-post + classifier purity + the originator-key lookup for relayed records. Prose, no code spans.
