### PR TITLE
fix(deploy): self-heal flaky peer-replication — retry + --ignore-replication-errors (ops-2i8x)

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -7051,9 +7051,12 @@ program
   .option("--no-verify", "Skip post-deploy served-API verification (default: verify — on by design, so the CLI can't report success on an empty/broken deploy)")
   .option("--verify-timeout <ms>", "Milliseconds to wait for the served API to settle after harper's post-deploy restart before verifying (default: 300000)")
   .option("--verify-resource <name>", "Resource to verify is serving after deploy (repeatable; default: derived from the deployed package's dist/resources)", (val: string, prev: string[]) => [...prev, val], [] as string[])
+  .option("--deploy-retries <n>", "Retry the full harper deploy this many times on a detected flaky peer-replication failure ONLY — a normal deploy failure (auth, bad package, ...) never retries (default: 2; 0 disables)", "2")
+  .option("--ignore-replication-errors", "If peer replication is still failing once retries are exhausted, treat it as a non-fatal warning and succeed with an origin-only deploy (the peer catches up via federation sync or a later deploy)")
   .action(async (opts) => {
     const green = (s: string) => `\x1b[32m${s}\x1b[0m`;
     const red = (s: string) => `\x1b[31m${s}\x1b[0m`;
+    const yellow = (s: string) => `\x1b[33m${s}\x1b[0m`;
     const dim = (s: string) => `\x1b[2m${s}\x1b[0m`;
 
     const deployOpts = {
@@ -7074,6 +7077,8 @@ program
       verify: opts.verify !== false,
       verifyResources: (opts.verifyResource as string[] | undefined)?.length ? opts.verifyResource : undefined,
       verifyTimeoutMs: Number(opts.verifyTimeout ?? 300_000),
+      deployRetries: Number(opts.deployRetries ?? 2),
+      ignoreReplicationErrors: opts.ignoreReplicationErrors ?? false,
       onProgress: (msg: string) => console.log(dim(`  ${msg}`)),
     };
 
@@ -7103,7 +7108,11 @@ program
         console.log(dim(`  package root: ${result.packageRoot}`));
         return;
       }
-      console.log(`\n${green("✓")} Flair ${result.version} deployed${deployOpts.verify ? " and verified serving" : ""}`);
+      if (result.replicationWarning) {
+        console.log(`\n${yellow("⚠")} Flair ${result.version} deployed to the ORIGIN NODE ONLY — peer replication did not complete (see warning above). The peer will catch up via federation sync or a later deploy.`);
+      } else {
+        console.log(`\n${green("✓")} Flair ${result.version} deployed${deployOpts.verify ? " and verified serving" : ""}`);
+      }
       console.log(`\n  URL:     ${result.url}`);
       console.log(`  Project: ${result.project}`);
       console.log(`\nNext steps:`);
@@ -7121,6 +7130,9 @@ program
       }
       if (hint?.includes("did not settle")) {
         console.error(dim("  hint: Harper may still be restarting — check Fabric Studio, or retry with a longer --verify-timeout"));
+      }
+      if (hint?.includes("peer replication failed after")) {
+        console.error(dim("  hint: pass --ignore-replication-errors to accept an origin-only deploy, or re-run once the peer link recovers"));
       }
       process.exit(1);
     }

--- a/src/deploy.ts
+++ b/src/deploy.ts
@@ -29,6 +29,37 @@ export interface DeployOptions {
   verify?: boolean;
   verifyResources?: string[];
   verifyTimeoutMs?: number;
+  // ops-2i8x: flaky-peer-replication resilience. A real Fabric deploy hit
+  // "Component 'flair' was deployed on the origin node but failed to
+  // replicate to 1 of 1 peer node(s): ... (Error: Connection closed 1006)"
+  // and hard-exited 1 — a bare manual re-run cleared it with no other
+  // change. That's a flake, not a deterministic failure, so it should
+  // self-heal rather than force a human to notice and re-run (see the
+  // CLI's own "self-healing over keepalive" invariant). See
+  // REPLICATION_FAILURE_RE for how a replication failure is distinguished
+  // from any other deploy failure (auth, bad package, missing files — those
+  // must still fail fast, never retry).
+  //
+  // How many times to retry the FULL `harper deploy` (not just the peer
+  // push) after a detected replication-signature failure. Default 2, i.e.
+  // up to 3 total attempts. 0 disables retry entirely (first replication
+  // failure fails immediately, same as any other failure).
+  deployRetries?: number;
+  // Internal/testing knob: override the retry backoff schedule (ms per
+  // attempt; last value repeats if retries exceed the array length).
+  // Not exposed as a CLI flag — the default (5s, 10s) is deliberate for
+  // real deploys; tests override it to avoid real sleeps.
+  deployRetryBackoffMs?: number[];
+  // Escape hatch: pass ignore_replication_errors=true to harper's own
+  // deploy CLI (deploys to origin, treats peer-replication failure as
+  // non-fatal there). Also a JS-level fallback: if a replication-signature
+  // failure still reaches us after retries are exhausted (e.g. harper
+  // itself didn't fully suppress it), the deploy is reported as a WARNED
+  // success instead of failing — the peer catches up via normal federation
+  // sync or a later deploy. Mutually sensible with deployRetries: retry
+  // first (transient flakes usually clear on their own), fall back to
+  // "accept origin-only" only once retries are exhausted.
+  ignoreReplicationErrors?: boolean;
   // Optional progress sink so callers (the CLI) can surface what would
   // otherwise be a silent multi-minute poll. Never required — deploy() and
   // verifyDeployServing() work fine without it (e.g. fabric-upgrade.ts's
@@ -42,6 +73,10 @@ export interface DeployResult {
   version: string;
   packageRoot: string;
   dryRun: boolean;
+  // true iff the deploy only succeeded because a peer-replication failure
+  // was accepted via --ignore-replication-errors (ops-2i8x) — the origin
+  // node has the component, at least one peer does not (yet).
+  replicationWarning?: boolean;
 }
 
 // Files that must be present in a Flair package for deployment.
@@ -241,7 +276,7 @@ export function buildHarperDeployArgs(
 ): string[] {
   const deploymentTimeoutMs = opts.deploymentTimeoutMs ?? DEFAULT_DEPLOYMENT_TIMEOUT_MS;
   const installTimeoutMs = opts.installTimeoutMs ?? DEFAULT_INSTALL_TIMEOUT_MS;
-  return [
+  const args = [
     "deploy",
     `target=${url}`,
     `project=${project}`,
@@ -250,30 +285,145 @@ export function buildHarperDeployArgs(
     `deployment_timeout=${deploymentTimeoutMs}`,
     `install_timeout=${installTimeoutMs}`,
   ];
+  // ops-2i8x: --ignore-replication-errors escape hatch. Only appended when
+  // set — omitted entirely otherwise, so this is a no-op for every existing
+  // caller/test that doesn't pass it.
+  if (opts.ignoreReplicationErrors) {
+    args.push("ignore_replication_errors=true");
+  }
+  return args;
 }
 
-function spawnHarper(
+// ops-2i8x: flaky-peer-replication resilience defaults. See DeployOptions
+// for the full incident writeup this closes.
+export const DEFAULT_DEPLOY_RETRIES = 2;
+export const DEPLOY_RETRY_BACKOFF_MS = [5_000, 10_000];
+
+// The signature of a Fabric PEER-REPLICATION failure specifically — harper
+// deploys fine to the origin node, but pushing the component to a peer
+// fails, e.g.:
+//   "Component 'flair' was deployed on the origin node but failed to
+//    replicate to 1 of 1 peer node(s): ... (Error: Connection closed 1006)"
+// This is the CORRECTNESS-CRITICAL part of the fix: matching this pattern
+// (and ONLY this pattern) is what lets us retry a known flake while still
+// failing fast on a real deploy failure (bad package, auth, missing files —
+// none of which mention peer replication and must never be retried).
+// Literal regex, no interpolation.
+export const REPLICATION_FAILURE_RE =
+  /failed to replicate to \d+ (of \d+ )?peer|connection closed\s+1006|ignore_replication_errors/i;
+
+interface HarperSpawnResult {
+  code: number | null;
+  output: string;
+}
+
+// Tee-style capture: streams harper's stdout/stderr to the user in real time
+// (unchanged UX — a multi-minute deploy needs live progress, not a black
+// box) while ALSO buffering the combined text so the caller can
+// pattern-match REPLICATION_FAILURE_RE against it after exit. This replaces
+// the previous stdio:"inherit" passthrough, which gave no way to inspect
+// harper's output. stdin stays "inherit" — harper's deploy never reads
+// from it, so there's nothing to tee there.
+function spawnHarperCaptured(
   bin: string,
   args: string[],
   cwd: string,
   env: NodeJS.ProcessEnv,
-): Promise<void> {
+): Promise<HarperSpawnResult> {
   return new Promise((resolveP, rejectP) => {
     const p = spawn(process.execPath, [bin, ...args], {
       cwd,
-      stdio: "inherit",
+      stdio: ["inherit", "pipe", "pipe"],
       env,
     });
-    p.on("error", rejectP);
-    p.on("exit", (code) => {
-      if (code === 0) resolveP();
-      else rejectP(new Error(`harper deploy exited with code ${code}`));
+    const chunks: string[] = [];
+    p.stdout?.on("data", (d: Buffer) => {
+      process.stdout.write(d);
+      chunks.push(d.toString("utf8"));
     });
+    p.stderr?.on("data", (d: Buffer) => {
+      process.stderr.write(d);
+      chunks.push(d.toString("utf8"));
+    });
+    p.on("error", rejectP);
+    p.on("exit", (code) => resolveP({ code, output: chunks.join("") }));
   });
 }
 
 function sleep(ms: number): Promise<void> {
   return new Promise((r) => setTimeout(r, ms));
+}
+
+// Runs `harper deploy`, retrying ONLY on the flaky peer-replication failure
+// signature (REPLICATION_FAILURE_RE) — the real incident this closes: the
+// origin deployed fine, replication to a peer failed with a transient
+// "Connection closed 1006", and a bare manual retry cleared it with no
+// other change. This re-runs the FULL harper deploy (prepare/install/
+// replicate), not just a peer-only re-push — wasteful, but it's exactly
+// what worked by hand, and harper's CLI has no "retry replication only"
+// entry point. Any other failure (bad package, auth, missing files, ...)
+// is never retried — it fails fast, same as before this change.
+async function runHarperDeploy(
+  bin: string,
+  args: string[],
+  cwd: string,
+  env: NodeJS.ProcessEnv,
+  opts: DeployOptions,
+): Promise<{ replicationWarning: boolean }> {
+  const maxRetries = opts.deployRetries ?? DEFAULT_DEPLOY_RETRIES;
+  const backoff = opts.deployRetryBackoffMs ?? DEPLOY_RETRY_BACKOFF_MS;
+  const totalAttempts = Math.max(1, maxRetries + 1);
+
+  for (let attempt = 1; attempt <= totalAttempts; attempt++) {
+    const { code, output } = await spawnHarperCaptured(bin, args, cwd, env);
+    if (code === 0) return { replicationWarning: false };
+
+    const isReplicationFailure = REPLICATION_FAILURE_RE.test(output);
+    const isLastAttempt = attempt === totalAttempts;
+
+    if (isReplicationFailure && !isLastAttempt) {
+      const waitMs = backoff[Math.min(attempt - 1, backoff.length - 1)];
+      // Self-healing must be visible, never silent — console.warn directly
+      // (not gated behind onProgress, which some callers like
+      // fabric-upgrade.ts don't wire up) so this is loud regardless of caller.
+      console.warn(
+        `⚠ flair deploy: replication flake on attempt ${attempt}/${totalAttempts} ` +
+          `(harper deploy exited ${code}, peer-replication signature matched) — ` +
+          `retrying in ${Math.round(waitMs / 1000)}s...`,
+      );
+      opts.onProgress?.(
+        `replication flake on attempt ${attempt}/${totalAttempts} — retrying in ${Math.round(waitMs / 1000)}s...`,
+      );
+      await sleep(waitMs);
+      continue;
+    }
+
+    if (isReplicationFailure && opts.ignoreReplicationErrors) {
+      console.warn(
+        `⚠ flair deploy: peer replication still failing after ${attempt} attempt(s), ` +
+          `but --ignore-replication-errors is set — treating this as a WARNED SUCCESS ` +
+          `(deployed to the origin node only; the peer will need to catch up via normal ` +
+          `federation sync or a later deploy).`,
+      );
+      opts.onProgress?.(
+        `WARNING: proceeding origin-only — peer replication did not complete after ${attempt} attempt(s)`,
+      );
+      return { replicationWarning: true };
+    }
+
+    if (isReplicationFailure) {
+      throw new Error(
+        `harper deploy exited with code ${code}: peer replication failed after ${attempt} attempt(s) ` +
+          `(retries exhausted). Pass --ignore-replication-errors to accept an origin-only deploy, ` +
+          `or re-run once the peer link recovers.`,
+      );
+    }
+
+    throw new Error(`harper deploy exited with code ${code}`);
+  }
+
+  // Unreachable — the loop always returns or throws — but keeps TS happy.
+  throw new Error("harper deploy: exhausted retry loop without resolving");
 }
 
 // A single reachability probe against the served (REST) base URL. Harper
@@ -427,7 +577,7 @@ export async function deploy(opts: DeployOptions): Promise<DeployResult> {
     CLI_TARGET_PASSWORD: opts.fabricPassword,
   };
 
-  await spawnHarper(harperBin, args, packageRoot, childEnv);
+  const { replicationWarning } = await runHarperDeploy(harperBin, args, packageRoot, childEnv, opts);
 
   // harper can print "Successfully deployed" for a component that isn't
   // actually serving anything (the incident this closes: an empty deploy,
@@ -445,5 +595,5 @@ export async function deploy(opts: DeployOptions): Promise<DeployResult> {
     });
   }
 
-  return { url, project, version, packageRoot, dryRun: false };
+  return { url, project, version, packageRoot, dryRun: false, replicationWarning };
 }

--- a/test/unit/deploy.test.ts
+++ b/test/unit/deploy.test.ts
@@ -22,6 +22,9 @@ import {
   deriveVerifyResources,
   FALLBACK_VERIFY_RESOURCE,
   verifyDeployServing,
+  REPLICATION_FAILURE_RE,
+  DEFAULT_DEPLOY_RETRIES,
+  DEPLOY_RETRY_BACKOFF_MS,
 } from "../../src/deploy.js";
 
 describe("flair deploy: validateOptions", () => {
@@ -418,6 +421,254 @@ describe("flair deploy: deploy() gating — --no-verify and --dry-run both skip 
       expect(fetchCalls).toBe(0);
     } finally {
       globalThis.fetch = origFetch;
+      rmSync(pkgRoot, { recursive: true, force: true });
+    }
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────
+// ops-2i8x: flaky-peer-replication resilience. A real Fabric deploy hit
+//   "Component 'flair' was deployed on the origin node but failed to
+//    replicate to 1 of 1 peer node(s): ... (Error: Connection closed 1006)"
+// and hard-exited 1 — a bare manual retry cleared it with no other change.
+// These tests cover: (A) the replication-signature detector itself, (B) the
+// retry loop firing ONLY on that signature, (C) --deploy-retries 0 disabling
+// retry, (D) --ignore-replication-errors turning a still-failing replication
+// error into a warned success.
+// ─────────────────────────────────────────────────────────────────────────
+
+describe("flair deploy: REPLICATION_FAILURE_RE (signature detection)", () => {
+  test("matches the real incident message", () => {
+    expect(
+      "Component 'flair' was deployed on the origin node but failed to replicate to 1 of 1 peer node(s): timeout (Error: Connection closed 1006)",
+    ).toMatch(REPLICATION_FAILURE_RE);
+  });
+
+  test("matches a bare 'Connection closed 1006'", () => {
+    expect("socket error: Connection closed 1006").toMatch(REPLICATION_FAILURE_RE);
+  });
+
+  test("matches a 'failed to replicate to N peer(s)' without 'of M'", () => {
+    expect("failed to replicate to 2 peer nodes").toMatch(REPLICATION_FAILURE_RE);
+  });
+
+  test("does NOT match an unrelated deploy failure", () => {
+    expect("Error: ENOENT: no such file or directory, package tarball not found").not.toMatch(
+      REPLICATION_FAILURE_RE,
+    );
+  });
+
+  test("does NOT match a plain auth failure", () => {
+    expect("Error: 401 Unauthorized").not.toMatch(REPLICATION_FAILURE_RE);
+  });
+
+  test("does NOT match benign mentions of 'peer' with no failure", () => {
+    expect("Fabric cluster has 3 peer nodes, all healthy").not.toMatch(REPLICATION_FAILURE_RE);
+  });
+});
+
+describe("flair deploy: buildHarperDeployArgs (--ignore-replication-errors passthrough)", () => {
+  test("omits ignore_replication_errors by default", () => {
+    const args = buildHarperDeployArgs(
+      { fabricOrg: "acme", fabricCluster: "prod", fabricUser: "a", fabricPassword: "b" },
+      "https://prod.acme.harperfabric.com",
+      "flair",
+    );
+    expect(args.some((a) => a.startsWith("ignore_replication_errors"))).toBe(false);
+  });
+
+  test("appends ignore_replication_errors=true when set", () => {
+    const args = buildHarperDeployArgs(
+      { ignoreReplicationErrors: true },
+      "https://custom.host",
+      "flair",
+    );
+    expect(args).toContain("ignore_replication_errors=true");
+  });
+});
+
+describe("flair deploy: deploy() replication-flake retry + --ignore-replication-errors", () => {
+  function synthPkgRootForReplicationTests(): string {
+    const dir = mkdtempSync(join(tmpdir(), "flair-deploy-replication-"));
+    for (const f of REQUIRED_PACKAGE_FILES) {
+      const p = join(dir, f);
+      if (f.endsWith(".yaml")) writeFileSync(p, "port: 9926\n");
+      else mkdirSync(p, { recursive: true });
+    }
+    writeFileSync(
+      join(dir, "package.json"),
+      JSON.stringify({ name: "@tpsdev-ai/flair", version: "9.9.9-test" }),
+    );
+    return dir;
+  }
+
+  // Scripted stub harper binary: on each invocation, consults `behaviors`
+  // (indexed by attempt number, clamped to the last entry) and either exits
+  // 0 ("success"), exits 1 with the real replication-failure message
+  // ("replication-fail"), or exits 1 with an unrelated message ("other-fail").
+  // Attempt count is persisted to a counter file on disk so it survives
+  // across separate process spawns (one spawn per retry attempt).
+  function addScriptedHarperBinary(packageRoot: string, behaviors: string[]): string {
+    const binDir = join(packageRoot, "node_modules", "@harperfast", "harper", "dist", "bin");
+    mkdirSync(binDir, { recursive: true });
+    const counterPath = join(packageRoot, ".attempt-count");
+    writeFileSync(counterPath, "0");
+    const script = `
+const fs = require('fs');
+const counterPath = ${JSON.stringify(counterPath)};
+const behaviors = ${JSON.stringify(behaviors)};
+let n = parseInt(fs.readFileSync(counterPath, 'utf8'), 10) || 0;
+n += 1;
+fs.writeFileSync(counterPath, String(n));
+const behavior = behaviors[Math.min(n - 1, behaviors.length - 1)];
+if (behavior === 'success') {
+  console.log('Successfully deployed');
+  process.exit(0);
+} else if (behavior === 'replication-fail') {
+  console.error("Component 'flair' was deployed on the origin node but failed to replicate to 1 of 1 peer node(s): timeout waiting for ack (Error: Connection closed 1006)");
+  process.exit(1);
+} else {
+  console.error('Error: ENOENT: package tarball not found');
+  process.exit(1);
+}
+`;
+    writeFileSync(join(binDir, "harper.js"), script);
+    return counterPath;
+  }
+
+  function attemptCount(counterPath: string): number {
+    return parseInt(readFileSync(counterPath, "utf8"), 10) || 0;
+  }
+
+  test("defaults: DEFAULT_DEPLOY_RETRIES=2, DEPLOY_RETRY_BACKOFF_MS=[5000,10000]", () => {
+    expect(DEFAULT_DEPLOY_RETRIES).toBe(2);
+    expect(DEPLOY_RETRY_BACKOFF_MS).toEqual([5_000, 10_000]);
+  });
+
+  test("non-replication failure fails immediately — no retry, even with retries available", async () => {
+    const pkgRoot = synthPkgRootForReplicationTests();
+    // If a retry incorrectly fired, attempt 2 would succeed — proves the
+    // assertion is about retry behavior, not just eventual failure.
+    const counterPath = addScriptedHarperBinary(pkgRoot, ["other-fail", "success"]);
+    try {
+      await expect(
+        deploy({
+          fabricOrg: "acme",
+          fabricCluster: "prod",
+          fabricUser: "admin",
+          fabricPassword: "pw",
+          packageRoot: pkgRoot,
+          verify: false,
+          deployRetries: 2,
+          deployRetryBackoffMs: [1, 1],
+        }),
+      ).rejects.toThrow(/harper deploy exited with code 1/);
+      expect(attemptCount(counterPath)).toBe(1);
+    } finally {
+      rmSync(pkgRoot, { recursive: true, force: true });
+    }
+  });
+
+  test("succeeds on attempt 2 after a replication flake on attempt 1 (loud retry log)", async () => {
+    const pkgRoot = synthPkgRootForReplicationTests();
+    const counterPath = addScriptedHarperBinary(pkgRoot, ["replication-fail", "success"]);
+    const origWarn = console.warn;
+    const warnings: string[] = [];
+    console.warn = (msg: any) => { warnings.push(String(msg)); };
+    try {
+      const result = await deploy({
+        fabricOrg: "acme",
+        fabricCluster: "prod",
+        fabricUser: "admin",
+        fabricPassword: "pw",
+        packageRoot: pkgRoot,
+        verify: false,
+        deployRetries: 2,
+        deployRetryBackoffMs: [1, 1],
+      });
+      expect(result.dryRun).toBe(false);
+      expect(result.replicationWarning).toBe(false);
+      expect(attemptCount(counterPath)).toBe(2);
+      expect(warnings.some((w) => /replication flake on attempt 1\/3/.test(w))).toBe(true);
+    } finally {
+      console.warn = origWarn;
+      rmSync(pkgRoot, { recursive: true, force: true });
+    }
+  });
+
+  test("--deploy-retries 0 disables retry — first replication flake fails immediately", async () => {
+    const pkgRoot = synthPkgRootForReplicationTests();
+    const counterPath = addScriptedHarperBinary(pkgRoot, ["replication-fail", "success"]);
+    try {
+      await expect(
+        deploy({
+          fabricOrg: "acme",
+          fabricCluster: "prod",
+          fabricUser: "admin",
+          fabricPassword: "pw",
+          packageRoot: pkgRoot,
+          verify: false,
+          deployRetries: 0,
+        }),
+      ).rejects.toThrow(/peer replication failed after 1 attempt/);
+      expect(attemptCount(counterPath)).toBe(1);
+    } finally {
+      rmSync(pkgRoot, { recursive: true, force: true });
+    }
+  });
+
+  test("--ignore-replication-errors: still-failing replication after retries exhausted becomes a warned success", async () => {
+    const pkgRoot = synthPkgRootForReplicationTests();
+    // Always fails with the replication signature — simulates harper's own
+    // ignore_replication_errors not fully suppressing the non-zero exit.
+    const counterPath = addScriptedHarperBinary(pkgRoot, ["replication-fail"]);
+    const origWarn = console.warn;
+    const warnings: string[] = [];
+    console.warn = (msg: any) => { warnings.push(String(msg)); };
+    try {
+      const result = await deploy({
+        fabricOrg: "acme",
+        fabricCluster: "prod",
+        fabricUser: "admin",
+        fabricPassword: "pw",
+        packageRoot: pkgRoot,
+        verify: false,
+        deployRetries: 0,
+        ignoreReplicationErrors: true,
+      });
+      expect(result.dryRun).toBe(false);
+      expect(result.replicationWarning).toBe(true);
+      expect(attemptCount(counterPath)).toBe(1);
+      expect(warnings.some((w) => /WARNED SUCCESS/.test(w))).toBe(true);
+    } finally {
+      console.warn = origWarn;
+      rmSync(pkgRoot, { recursive: true, force: true });
+    }
+  });
+
+  test("--ignore-replication-errors composes with retry: retries first, then falls back to warned success", async () => {
+    const pkgRoot = synthPkgRootForReplicationTests();
+    const counterPath = addScriptedHarperBinary(pkgRoot, [
+      "replication-fail",
+      "replication-fail",
+      "replication-fail",
+    ]);
+    try {
+      const result = await deploy({
+        fabricOrg: "acme",
+        fabricCluster: "prod",
+        fabricUser: "admin",
+        fabricPassword: "pw",
+        packageRoot: pkgRoot,
+        verify: false,
+        deployRetries: 2,
+        deployRetryBackoffMs: [1, 1],
+        ignoreReplicationErrors: true,
+      });
+      expect(result.replicationWarning).toBe(true);
+      // 1 initial attempt + 2 retries = 3 total attempts before falling back.
+      expect(attemptCount(counterPath)).toBe(3);
+    } finally {
       rmSync(pkgRoot, { recursive: true, force: true });
     }
   });


### PR DESCRIPTION
**Deploy CLI self-heals flaky peer-replication** (ops-2i8x). Real dogfood finding: deploying flair to Fabric intermittently fails when the origin deploys fine but a peer replication drops ("failed to replicate to 1 of 1 peer node(s) ... Connection closed 1006") — a plain retry cleared it. Now the CLI self-heals instead of hard-failing + needing a human re-run (the "self-healing over keepalive" invariant applied to the deploy path).

## What
- **Auto-retry on a REPLICATION-specific failure only** (correctness-critical): `REPLICATION_FAILURE_RE = /failed to replicate to \d+ (of \d+ )?peer|connection closed\s+1006|ignore_replication_errors/i`. Retries up to `--deploy-retries <n>` (default 2, so 3 attempts; 0 disables), **loud** warn per retry, 5s/10s backoff, re-runs the full harper deploy (documented cost — matches the manual retry). A **non-replication** failure (bad package, auth, ENOENT) throws immediately — no retry. 6 dedicated tests confirm the regex matches the incident + variants but NOT unrelated failures or benign "peer" mentions.
- **`--ignore-replication-errors`** escape hatch: passes `ignore_replication_errors=true` to harper; a persisting replication failure becomes a *warned success* (origin deployed; peer catches up via normal sync). Retries run first; the flag is "I accept origin-only now."
- Output capture: `spawnHarper` switched from `stdio:"inherit"` to piped-and-re-emit (byte-for-byte to stdout/stderr as chunks arrive) so the output can be pattern-matched after exit. Post-deploy verification untouched.

## Verified
Unit **1536/1536** (+14). tsc (check + cli configs + strict on deploy.ts) + build:cli clean.

## ⚠ Flag for review
The output-capture change means the harper subprocess's fds are piped, not inherited — so `isTTY` reads false, and if harper's CLI does TTY-detection for color/spinners, those may not render (the output content + real-time streaming are preserved). Worth eyeballing one real deploy. The alternative (no capture) means no way to detect the replication signature for the retry.

@tps-kern the retry design (retry-only-on-signature, the full-deploy-retry cost, the output-capture-for-pattern-match) + is the isTTY/color tradeoff acceptable? @tps-sherlock light: does retry-only-on-`REPLICATION_FAILURE_RE` risk masking a real failure, or is the fail-fast-on-non-match correct? Prose, no code spans.
