### PR TITLE
fix(ci): timeout+retry the flaky sfw install (ops-fumh — intermittent merge blocker)

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -111,8 +111,16 @@ jobs:
         with:
           mode: firewall-free
 
-      - name: Install
-        run: sfw bun install --frozen-lockfile
+      - name: Install (sfw — retry on intermittent Socket-firewall hang, ops-fumh)
+        run: |
+          for attempt in 1 2 3; do
+            echo "::group::sfw bun install (attempt $attempt/3)"
+            if timeout 300 sfw bun install --frozen-lockfile; then echo "::endgroup::"; exit 0; fi
+            echo "::endgroup::"
+            echo "sfw install attempt $attempt failed or timed out (5m) — the sfw hang is intermittent; retrying in 10s"
+            sleep 10
+          done
+          echo "sfw bun install failed after 3 attempts"; exit 1
 
       - name: Verify all workspace versions match the tag
         # All values flow through env, never ${{ }} interpolation inside the

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -28,7 +28,16 @@ jobs:
 
           mode: firewall-free
 
-      - run: sfw bun install --frozen-lockfile
+      - name: Install (sfw — retry on intermittent Socket-firewall hang, ops-fumh)
+        run: |
+          for attempt in 1 2 3; do
+            echo "::group::sfw bun install (attempt $attempt/3)"
+            if timeout 300 sfw bun install --frozen-lockfile; then echo "::endgroup::"; exit 0; fi
+            echo "::endgroup::"
+            echo "sfw install attempt $attempt failed or timed out (5m) — the sfw hang is intermittent; retrying in 10s"
+            sleep 10
+          done
+          echo "sfw bun install failed after 3 attempts"; exit 1
 
       - name: Install linux-x64 native binary for embeddings
         run: bun add --no-save @node-llama-cpp/linux-x64@3


### PR DESCRIPTION
**Self-heals the intermittent Socket-firewall (`sfw`) install hang** (ops-fumh) — an intermittent merge blocker. `sfw bun install --frozen-lockfile` (in `smoke.yml` + `release-publish.yml`) has no timeout, so when the Socket firewall intermittently hangs, the job blocks indefinitely and the PR can't merge.

## What
Wrap the sfw install in a **`timeout 300` (5min) + retry (3×, 10s backoff)** loop. An intermittent hang now times out at 5min and retries — since the hang is transient, a retry succeeds, and the job self-heals instead of blocking. If all 3 attempts fail, the job fails clearly (not a silent hang). Same install, just resilient. Matches the "self-healing over keepalive" invariant.

## Scope
- Only the sfw *install step* is wrapped — the Socket firewall setup (`socketdev/action`, `mode: firewall-free`) and the supply-chain check itself are unchanged; this doesn't weaken the security posture, it just stops a transient hang from blocking merges.
- `release-publish.yml` is the OIDC release path — the change wraps ONLY its Install step; the OIDC auth + stage-publish steps are untouched.
- Workflows-only changeset; both YAML files validated.

@tps-kern the retry approach (timeout+retry loop) for the flaky install. @tps-sherlock light: confirm this doesn't weaken the sfw supply-chain check — it only retries the install on a hang, the firewall + Socket App PR analysis are unchanged. Prose, no code spans.
