### PR TITLE
fix(test): de-flake E2E CLI smoke test — poll store→read race + remove SIGPIPE

### DIFF
--- a/test/e2e-cli.sh
+++ b/test/e2e-cli.sh
@@ -4,15 +4,62 @@ set -euo pipefail
 
 FLAIR_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 if command -v bun > /dev/null 2>&1; then
-  FLAIR="bun ${FLAIR_DIR}/dist/cli.js"
+  FLAIR=(bun "${FLAIR_DIR}/dist/cli.js")
 else
-  FLAIR="node ${FLAIR_DIR}/dist/cli.js"
+  FLAIR=(node "${FLAIR_DIR}/dist/cli.js")
 fi
 
 AGENT_ID="e2e-test-$$"
 PORT="${FLAIR_PORT:-9926}"
 ADMIN_PASS="${FLAIR_ADMIN_PASS:-admin123}"
 export FLAIR_URL="http://localhost:${PORT}"
+
+# retry_until <description> <check_fn> <cmd...>
+#
+# Runs <cmd...> and hands its captured output to <check_fn> as $1, retrying
+# on failure. This absorbs eventual-consistency lag between a write and its
+# read-visibility in live Harper (indexing/commit lag) — a single immediate
+# read after a write is a race, not a guarantee, no matter how long a fixed
+# `sleep` before it is. Passes as soon as check_fn succeeds; only fails once
+# every attempt is exhausted, dumping the last output for debugging.
+#
+# Output is captured into a variable rather than piped into the checker
+# (e.g. `echo "$out" | grep -q ...`) on purpose: grep -q exits the instant it
+# finds a match, closing its end of the pipe while the producer may still be
+# writing — the shell then delivers SIGPIPE to the writer ("write error:
+# Broken pipe"). Capturing to a variable first and testing that removes the
+# concurrent pipe entirely.
+#
+# Tunable via RETRY_ATTEMPTS (default 10) / RETRY_DELAY seconds (default 1).
+retry_until() {
+  local description="$1"; shift
+  local check_fn="$1"; shift
+  local attempts="${RETRY_ATTEMPTS:-10}"
+  local delay="${RETRY_DELAY:-1}"
+  local output="" attempt
+  for ((attempt = 1; attempt <= attempts; attempt++)); do
+    output="$("$@" 2>&1)" || true
+    if "$check_fn" "$output"; then
+      echo "$output"
+      echo "PASS: ${description} (attempt ${attempt}/${attempts})"
+      return 0
+    fi
+    [ "$attempt" -lt "$attempts" ] && sleep "$delay"
+  done
+  echo "FAIL: ${description} — condition not met after ${attempts} attempts (${delay}s apart)"
+  echo "--- last output ---"
+  echo "$output"
+  echo "--- end output ---"
+  return 1
+}
+
+contains_quick_brown_fox() {
+  grep -q "quick brown fox" <<< "$1"
+}
+
+has_search_results() {
+  ! grep -q '"results":\[\]' <<< "$1"
+}
 
 echo "=== E2E CLI Test ==="
 
@@ -27,37 +74,23 @@ for i in $(seq 1 60); do
 done
 
 echo "--- status ---"
-$FLAIR status
+"${FLAIR[@]}" status
 echo "PASS: status"
 
 echo "--- agent add ---"
-$FLAIR agent add "$AGENT_ID" --name "E2E Bot" --admin-pass "$ADMIN_PASS" --port "$PORT"
+"${FLAIR[@]}" agent add "$AGENT_ID" --name "E2E Bot" --admin-pass "$ADMIN_PASS" --port "$PORT"
 echo "PASS: agent add"
 
 echo "--- memory add ---"
-$FLAIR memory add --agent "$AGENT_ID" --content "The quick brown fox jumps over the lazy dog"
+"${FLAIR[@]}" memory add --agent "$AGENT_ID" --content "The quick brown fox jumps over the lazy dog"
 echo "PASS: memory add"
 
-sleep 2
-
 echo "--- memory list ---"
-LIST_OUTPUT=$($FLAIR memory list --agent "$AGENT_ID")
-echo "$LIST_OUTPUT"
-if echo "$LIST_OUTPUT" | grep -q "quick brown fox"; then
-  echo "PASS: memory list (content found)"
-else
-  echo "FAIL: memory list — stored content not found"
-  exit 1
-fi
+retry_until "memory list (content found)" contains_quick_brown_fox \
+  "${FLAIR[@]}" memory list --agent "$AGENT_ID"
 
 echo "--- memory search ---"
-SEARCH_OUTPUT=$($FLAIR memory search --agent "$AGENT_ID" --q "animals jumping")
-echo "$SEARCH_OUTPUT"
-if echo "$SEARCH_OUTPUT" | grep -q '"results":\[\]'; then
-  echo "FAIL: memory search — empty results (embeddings not generated on write)"
-  exit 1
-else
-  echo "PASS: memory search (results returned)"
-fi
+retry_until "memory search (results returned; empty ⇒ embeddings not generated on write)" has_search_results \
+  "${FLAIR[@]}" memory search --agent "$AGENT_ID" --q "animals jumping"
 
 echo "=== E2E CLI Test PASSED ==="


### PR DESCRIPTION
**Fixes the flaky E2E CLI smoke test** (ops-17ln) — intermittently reds Integration Tests and spuriously blocks merges (just hit it on #583, a workflows-only change). Same self-healing-CI class as ops-fumh.

## Two races (found both — the second had no guard)
- `memory list` → assert stored content present (was guarded by a guessy `sleep 2`).
- `memory search` → assert results non-empty (embedding-generation lag, no wait at all).
Both are "store then immediately read" against live Harper — the read races ahead of write visibility.

## Fix — structural, not tuning
- **`retry_until` poll:** re-checks up to `RETRY_ATTEMPTS` (10) × `RETRY_DELAY` (1s), passes the instant the content appears, **fails after N with the last output dumped** — still genuinely verifies store→read (not weakened to always-pass; unit-tested that it fails when content never appears).
- **Broken pipe removed by construction:** `memory list`'s payload embeds a ~768-dim vector (~20KB JSON); `echo "$OUT" | grep -q` matched early, `grep -q` exited, and the still-writing `echo` got SIGPIPE. Switched to a here-string (`grep -q … <<< "$OUT"`) — bash spools to a temp file, so there's no concurrent writer to SIGPIPE. Not a narrowed window, a removed one.
- `FLAIR` command converted to an array for safe retried composition.

## Verified
bash -n clean; shellcheck 0 (new + pre-existing); ran the E2E live against a natively-spawned isolated Harper 3/3 pass (first attempt, faster — no unconditional 2s tax). Honest caveat: the original flake is CI-load/scheduling-dependent and could NOT be force-reproduced locally (20 iterations, 0 repros), so there's no literal before/after transcript — the fix is structural (eliminates the race by construction), verified by logic + the retry_until unit test. Scoped to test/e2e-cli.sh.

@tps-kern the test-infra fix (retry_until poll + here-string pipe removal) — sound, and does the poll still genuinely verify (not mask a real store→read break)? Prose, no code spans.
