### PR TITLE
cleanup(refs): strip internal ops-* tracker refs from shipping comments + tests (closes #585)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,34 +22,34 @@ Writer-controlled memory sharing (Kris flair#522/#550), a memory recall-correctn
 
 ### 🔧 Memory recall correctness
 
-- **Dedup signal on singleton results (#564, ops-ume4).** Harper omits `$distance` when a cosine-sort result set is a singleton → dedup silently scored 0. Fallback: point-lookup the candidate and compute cosine directly.
+- **Dedup signal on singleton results (#564).** Harper omits `$distance` when a cosine-sort result set is a singleton → dedup silently scored 0. Fallback: point-lookup the candidate and compute cosine directly.
 - **Superseded records no longer resurface in recall (#566 SemanticSearch/BM25, #567 bootstrap).** A server-superseded record (past `validTo`, not archived) not co-present with its successor could resurface; now excluded unconditionally in every recall path.
-- **openclaw-flair supersede: write-new-before-close-old + observable failure (#563, ops-mmh9).**
+- **openclaw-flair supersede: write-new-before-close-old + observable failure (#563).**
 
 ### 🔒 Security
 
 - **Cross-agent delete authz regression guards** for `Relationship.delete` (#569) and `Credential.delete` (#570) — both verified safe against real Harper (the target record is bound before the method runs), now guarded so a future refactor can't silently reintroduce a bypass.
-- **Consolidated 3 Ed25519 nonce caches + crypto helpers into one shared guard (#559, ops-c4op).**
+- **Consolidated 3 Ed25519 nonce caches + crypto helpers into one shared guard (#559).**
 
 ### 🧰 Tooling / CI
 
-- **`release.sh` aligns bun.lock leaf specifiers after bump** — stops the recurring `--frozen-lockfile` desync (#560, ops-i9w8).
-- **Fail-fast timeouts on the two timeout-less CI jobs** whose sfw (Socket firewall) install could hang and block merge indefinitely (#571, ops-fumh).
-- **Real-Harper dedup/supersede e2e** (#562, which found ops-ume4) + Memory.get RequestTarget routing coverage (#561).
+- **`release.sh` aligns bun.lock leaf specifiers after bump** — stops the recurring `--frozen-lockfile` desync (#560).
+- **Fail-fast timeouts on the two timeout-less CI jobs** whose sfw (Socket firewall) install could hang and block merge indefinitely (#571).
+- **Real-Harper dedup/supersede e2e** (#562, which found the singleton dedup-signal gap above) + Memory.get RequestTarget routing coverage (#561).
 
 ## [0.19.0] - 2026-07-03
 
 The read-gate security sweep: three distinct anonymous/cross-agent read exposures, all found from one Sherlock sweep RED and closed.
 
-### 🔒 SECURITY: Memory/Soul by-id reads were ungated — anonymous content leak (#556, ops-ckrr)
+### 🔒 SECURITY: Memory/Soul by-id reads were ungated — anonymous content leak (#556)
 
 Memory and Soul gated writes and `search()` but defined no `allowRead()` and no `get()` override, so Harper's direct by-id path (`GET /Memory/<id>`) and the collection-describe (`GET /Memory`) were ungated — an anonymous caller received full record content, and a verified non-admin agent could read another agent's memory by enumerable id (`search()` only guarded the query path). Fix: `allowRead()=allowVerified` on both; an owner/grant-scoped `get()` on Memory (**404 never 403**, no id enumeration) branching on `isCollection` so collection/query reads delegate to the already-scoped `search()`; `delete()` reads via `super.get()` to preserve the permanent-delete guard.
 
-### 🔒 SECURITY: admin console reachable by verified non-admin agents (#557, ops-2ty0)
+### 🔒 SECURITY: admin console reachable by verified non-admin agents (#557)
 
 **P0, live-confirmed.** The `/Admin` auth-middleware gate only 401s requests with **no** Authorization header; a validly-signed non-admin Ed25519 agent passed verification, de-elevated to `flair-agent`, and reached the seven custom `Admin*` resources — which had no `allowRead` — returning the full admin console (`/AdminMemory` all-agents memory browse + provenance, `/AdminPrincipals`, `/AdminDashboard`). Fix: `allowRead()=allowAdmin` on all seven (Basic super_user and admin agents retain access; non-admins → 403).
 
-### 🔒 SECURITY: family read-gate — WorkspaceState / Relationship / Integration / MemoryGrant (#557, ops-oox7)
+### 🔒 SECURITY: family read-gate — WorkspaceState / Relationship / Integration / MemoryGrant (#557)
 
 The same by-id/describe leak class as Memory: `search()` and writes gated, but no `allowRead()`/`get()`. Fix: `allowRead()=allowVerified` + `isCollection`-branched owner-scoped `get()` (**404 never 403**) on all four; MemoryGrant scopes `ownerId` **OR** `granteeId` (both parties to a grant); `delete()` uses `super.get()`.
 
@@ -71,7 +71,7 @@ An in-process cross-encoder re-scores query+candidate together and reorders the 
 
 ## [0.17.0] - 2026-07-02
 
-### 🔒 SECURITY: cross-agent isolation break — `getContext()` not `this.request` (#551, ops-sal4)
+### 🔒 SECURITY: cross-agent isolation break — `getContext()` not `this.request` (#551)
 
 **P0, live-confirmed.** Harper v5 never populates `this.request` on `Resource` subclasses; the #236/#487 `getContext()` sweep missed 8 handlers, so their per-agent ownership guards silently read `undefined` and became dead no-ops (fail-open). Any verified agent could read any other agent's **WorkspaceState** (`GET /WorkspaceLatest/{id}`) and **OrgEvent catch-up feed** (`GET /OrgEventCatchup/{id}`), and every approved **OAuth consent grant** was minted for the `admin` principal regardless of who approved it.
 
@@ -81,7 +81,7 @@ All 8 handlers now resolve identity via the canonical `resolveAgentAuth(getConte
 
 `BootstrapMemories` now emits a fixed-cost `## Team` section listing the other active agents in the office with a nudge to search their memories before deep-diving an unfamiliar problem — bootstrap previously only ever loaded the caller's own context, so agents never learned teammates' findings were one `memory_search` away. Agent IDs are wrapped via `wrapUntrusted` (registrant-chosen, untrusted). External contribution from @kriszyp.
 
-### 🔐 Native `/mcp` OAuth surface — Model 2 (custom `withMCPAuth`-guarded handler), default-OFF (ops-b6uk)
+### 🔐 Native `/mcp` OAuth surface — Model 2 (custom `withMCPAuth`-guarded handler), default-OFF
 
 Flair speaks MCP natively over a custom in-process `/mcp` JSON-RPC handler wrapped with `@harperfast/oauth`'s `withMCPAuth` — a per-agent OAuth identity replaces the local `flair-mcp` stdio proxy's key-holding. This is the **Model 2** path (Nathan approved 2026-07-01): a custom handler rather than Harper's native application-MCP profile, so it sidesteps the Harper native-MCP gating gaps and is curated **by construction** (the handler only implements the 9 flair tools — no raw CRUD surface).
 
@@ -98,7 +98,7 @@ Flair speaks MCP natively over a custom in-process `/mcp` JSON-RPC handler wrapp
 
 ### 🐛 `flair upgrade` — detect an installed-but-stale flair-mcp, drop openclaw noise, fix formatting (#543)
 
-The bin `--version` probe missed a globally-installed `flair-mcp` (older installs predate `--version`) → it now falls back to the lib probe (reads the installed `package.json` version, version-independent), so a stale-but-present flair-mcp is correctly detected. The `openclaw-flair` line is suppressed when openclaw isn't installed (still shown under `--all`), dropping noise on machines without openclaw. Fixed a double-space in the restart hint. Added a one-line scope note: `flair upgrade` covers the npm-global surface + openclaw plugins; `pi-flair` / `langgraph-flair` / `n8n-nodes-flair` / `hermes-flair` upgrade within their own ecosystems. Fixes ops-p42n (surfaced by Kyle's real-world use).
+The bin `--version` probe missed a globally-installed `flair-mcp` (older installs predate `--version`) → it now falls back to the lib probe (reads the installed `package.json` version, version-independent), so a stale-but-present flair-mcp is correctly detected. The `openclaw-flair` line is suppressed when openclaw isn't installed (still shown under `--all`), dropping noise on machines without openclaw. Fixed a double-space in the restart hint. Added a one-line scope note: `flair upgrade` covers the npm-global surface + openclaw plugins; `pi-flair` / `langgraph-flair` / `n8n-nodes-flair` / `hermes-flair` upgrade within their own ecosystems. Fixes the stale-flair-mcp detection gap (surfaced by Kyle's real-world use).
 
 ### 🤖 Auto-cut GitHub releases from the CHANGELOG on tag (#544)
 
@@ -106,7 +106,7 @@ Every `v*` tag now creates its GitHub release from the matching CHANGELOG sectio
 
 ## [0.16.0] - 2026-06-29
 
-### 🧪 CI clean-VM gate — exercise the REALISTIC user env so the #538 embeddings showstopper can't silently regress (ops-cd37)
+### 🧪 CI clean-VM gate — exercise the REALISTIC user env so the #538 embeddings showstopper can't silently regress
 
 The #538 fix (above) addressed a fresh `sudo npm install -g @tpsdev-ai/flair` leaving semantic search **dead** (model targeted the root-owned package dir; Harper-as-user couldn't write it). The uncomfortable part: **CI never caught it.** The existing `docker/Dockerfile.test` from-scratch job runs as **root** (no perms mismatch) *and* sets `FLAIR_MODELS_DIR=/opt/flair-models` (a writable override), so its "clean install" is not the user's environment — root + a pre-solved model path made the bug structurally invisible. The tarball smoke test (`test.yml`) also installs as root and its write/search round-trip uses a **keyword-matching** marker, so it passes even with embeddings dead.
 
@@ -116,17 +116,17 @@ This adds a gate that reproduces what a real user actually has:
 - **The assertion is genuine semantic recall, not keyword match.** The gate asserts `flair init` reports `Semantic search operational` (the #533 in-init check, which prints `DEGRADED` but does *not* exit non-zero), then runs `flair doctor` as the hard gate — `doctor` performs the same embed→**paraphrase** round-trip (`verifySemanticSearch`: query "a cat hunting a mouse in the evening" vs. content "feline predator stalked its rodent quarry at dusk", **zero keyword overlap**, real semantic score > 0.05) and `process.exit(1)` on degraded. Keyword-only fallback cannot satisfy it. Embeddings dead → the gate FAILS.
 - **Wired into `.github/workflows/docker-test.yml`** as a new `clean-vm-gate` job that runs on PRs, alongside (not replacing) the existing from-scratch job — the from-scratch coverage stays, the gate adds the realistic non-root / no-override variant. Each Docker build uses a distinct GHA cache scope. Validated locally: builds + runs green on current main (post-#538) with a real semantic score; the assertion is semantic, so it would catch a regression that the old root-+-override CI could not.
 
-### 🩺 Fix dead semantic search on a sudo/root-owned global install — model dir defaults to `~/.flair` (ops-am0v)
+### 🩺 Fix dead semantic search on a sudo/root-owned global install — model dir defaults to `~/.flair`
 
 A fresh `sudo npm install -g @tpsdev-ai/flair` left semantic search **dead**: the package landed root-owned (e.g. `/usr/lib/node_modules`), Harper runs as the *user*, so the embeddings model download hit `EACCES` and recall silently fell back to keyword-only. The `flair doctor` / `flair init` round-trip check (#533) caught it loud, but recall was still broken — this fixes the underlying cause.
 
-**Root cause (corrects the ops-9czl note).** The blocker was the **model path**, not the `node_modules/harper` symlink. Flair loads itself as a Harper component in-place (`harper run .`, cwd = the package dir), and Flair's own embeddings wrapper (`resources/embeddings-provider.ts`) hard-coded the model dir to `join(process.cwd(), "models")` — i.e. **inside the package dir**. On a root-owned install that's read-only to the user-run Harper, so the model can't download and `init()` fails. Verified end-to-end with a faithful repro (read-only `<packageDir>/models`, isolated HOME/data/free port): pre-fix → `✗ Semantic search DEGRADED`; the componentLoader's `node_modules/harper` symlink `EACCES` is caught-and-logged (componentLoader.js, no rethrow) and Flair imports nothing from `harperdb`, so it is **non-fatal** — the model path was the only real sink.
+**Root cause (corrects the "onboarding dogfood round 1" note below).** The blocker was the **model path**, not the `node_modules/harper` symlink. Flair loads itself as a Harper component in-place (`harper run .`, cwd = the package dir), and Flair's own embeddings wrapper (`resources/embeddings-provider.ts`) hard-coded the model dir to `join(process.cwd(), "models")` — i.e. **inside the package dir**. On a root-owned install that's read-only to the user-run Harper, so the model can't download and `init()` fails. Verified end-to-end with a faithful repro (read-only `<packageDir>/models`, isolated HOME/data/free port): pre-fix → `✗ Semantic search DEGRADED`; the componentLoader's `node_modules/harper` symlink `EACCES` is caught-and-logged (componentLoader.js, no rethrow) and Flair imports nothing from `harperdb`, so it is **non-fatal** — the model path was the only real sink.
 
 - **The embeddings model dir now defaults to a user-writable location, never the package dir (`resources/embeddings-provider.ts`).** New `resolveModelsDir()` resolves, in order: `FLAIR_MODELS_DIR` (explicit override) → `<ROOTPATH>/models` (Harper's data dir — Flair passes `ROOTPATH = ~/.flair/data` when it spawns Harper, so this is user-owned and writable even under a root-owned install) → `<cwd>/models` **only if a model is already cached there** (backward compat for existing writable installs — reuse, don't re-download) → `~/.flair/data/models` (last resort). Aligns with the principle that everything Flair writes lives under `~/.flair` and the package dir stays read-only. `FLAIR_MODELS_DIR` (already used by `docker/Dockerfile.test`) is now an actually-wired override on the production path, not just a dev/docker affordance. Under the read-only-install repro, embed→paraphrase-search now round-trips with a real semantic score (~0.74) and doctor's #533 check passes.
 - **Test harness reuses the pre-downloaded model via the override (`test/helpers/harper-lifecycle.ts`).** With the new `<ROOTPATH>/models` default, the integration harness (fresh temp `installDir` per `startHarper`) would otherwise re-download the ~80MB model every run (HuggingFace 429-prone, #463/#465). The harness now sets `FLAIR_MODELS_DIR` to the repo-root `models/` that CI/local pre-download into; a pre-existing parent `FLAIR_MODELS_DIR` still wins.
 - **New unit coverage (`test/unit/embeddings-models-dir.test.ts`)** asserts the resolution order, including the load-bearing invariant: a fresh install with no `ROOTPATH` and no cached model resolves to `~/.flair`, **never** the read-only package dir. Full unit suite (1155) green; HNSW / agent-journey / smoke / durability integration tests green (real-embeddings paths exercised).
 
-### 🛟 Loud Node-version preflight for `flair-mcp` — silent failure on old Node (ops-fomi)
+### 🛟 Loud Node-version preflight for `flair-mcp` — silent failure on old Node
 
 The `flair-mcp` bin (`dist/index.js`) is an ES module: top-level imports are hoisted and the whole module graph is linked + evaluated before the file body runs. flair-mcp's deps (`@modelcontextprotocol/sdk`, `@tpsdev-ai/flair-client` and its transitive deps) need a modern engine, so on an old Node the import graph crashes during linking — **before** any in-file version guard could run. Result: a user wiring `npx -y @tpsdev-ai/flair-mcp` on an unsupported Node gets zero output and a dead MCP server, with no actionable signal. This is the same exposure flair's CLI had, fixed in #524 — now mirrored for the MCP server.
 
@@ -136,7 +136,7 @@ The `flair-mcp` bin (`dist/index.js`) is an ES module: top-level imports are hoi
 - **`engines.node` bumped `>=18` → `>=22`** to match flair's CLI and the deps' real floor, so `npm install` also warns on an unsupported Node. Postinstall now `chmod +x` the shim.
 - New unit test (`test/mcp-node-preflight.test.ts`) proves: loud non-zero failure on a simulated old Node without loading the ESM server, no-op handoff to `runMcp()` on the supported Node the suite runs on, and parse-safety of the emitted shim. (packages/flair-mcp/*)
 
-### 🛟 Harper watchdog now recovers an UNLOADED launchd job + alerts on state transitions (ops-6nv7)
+### 🛟 Harper watchdog now recovers an UNLOADED launchd job + alerts on state transitions
 
 On 2026-06-27 ~04:20 prod Flair (`:9926`) was **down** — the `ai.tpsdev.flair` launchd job wasn't loaded (no Harper PID) — and it stayed down, undetected, until a memory write happened to fail. Two gaps: (1) `harper-watchdog.sh` only handled the *PID-alive-but-`/Health`-dead* zombie case (`kill -9` + `launchctl kickstart -k`); `kickstart`/`start` are **no-ops on an unloaded job**, so the job-unloaded failure mode went unrecovered. (2) There was **no alerting at all** — a Flair-down was invisible. Recovery was a manual `launchctl load ~/Library/LaunchAgents/ai.tpsdev.flair.plist`.
 
@@ -148,22 +148,22 @@ The watchdog now recovers **both** failure modes and makes the event **known**:
 
 `bash -n` clean; all three cases (health-OK silent, health-dead+job-loaded kickstart, health-dead+job-unloaded bootstrap) plus the recovered / sustained-down / self-healed / mail-fallback transitions were dry-run against a stubbed `launchctl`/`curl`/`pgrep` harness (never against live prod). The live `ai.tpsdev.flair-watchdog` picks up the new script on its next 60s run after merge — no plist change required. (scripts/harper-watchdog.sh)
 
-### 🔒 Exact-pin all runtime deps + Renovate with a supply-chain cooldown (ops-sz4n)
+### 🔒 Exact-pin all runtime deps + Renovate with a supply-chain cooldown
 
 Four root runtime deps were `^`-ranged install-defaults rather than deliberate choices — `jose` (`^6.2.2`, in the auth/JWT path), `tar` (`^7.5.13`, in packaging), `js-yaml` (`^4.1.1`), and `@types/js-yaml` (`^4.0.9`). A user's `npm install -g @tpsdev-ai/flair` resolves `^` ranges **fresh** — npm does not consume our committed `bun.lock` — so a fresh install could pull a newer, untested (or freshly-compromised) version than anything we shipped or tested. This is exactly the surface `docs/supply-chain-policy.md` §2 already mandated against ("exact-version pinning for production deps") but nothing enforced.
 
 - **All ranged production + dev deps are now exact-pinned to the lockfile-resolved versions** (pin to what we tested — no version bumps): root `jose` `6.2.2`, `tar` `7.5.13`, `js-yaml` `4.1.1`, `@types/js-yaml` `4.0.9`, plus devDeps `@playwright/test` `1.59.1`, `@types/tar` `7.0.87`; and `packages/pi-flair` devDeps `@types/node` `24.11.0`, `typescript` `5.9.3`. `peerDependencies` are intentionally left as ranges (host-provided, not installed). `bun.lock` is version-identical — the resolved `packages:` block is byte-for-byte unchanged; only package.json spec strings tightened (and a pre-existing stale `pi-flair → @tpsdev-ai/flair-client` lock entry corrected to `0.15.0`). This brings `jose`, `tar`, and `js-yaml` under the `check-dep-ages.mjs` bake-time guard, which previously **skipped them** because it only checks exact-pinned deps (the guard now covers 10 production deps, up from 8). (package.json, packages/pi-flair/package.json, bun.lock)
 - **Renovate config added (`.github/renovate.json`) for deliberate, test-gated updates with a supply-chain cooldown.** `minimumReleaseAge: "7 days"` matches the `FLAIR_DEP_MIN_AGE_DAYS` default (7) enforced by `scripts/check-dep-ages.mjs` and documented in the policy — Renovate only proposes versions past the bake-time, so a freshly-published (possibly compromised) version has to survive the detection window before it's even suggested. Updates are PRs only (`automerge: false`) — every bump flows through the full test suite + K&S review, never a surprise install. `rangeStrategy: "pin"` (pin-mode aware), grouped non-major / isolated major PRs, weekly schedule, and a keep-current allow-list (`@harperfast/harper`, `harper-fabric-embeddings`) mirroring the script's `DEFAULT_KEEP_CURRENT` so Renovate and the bake-time guard stay in lockstep. Vulnerability alerts bypass the cooldown (security fixes ship immediately). Validated against the latest `renovate-config-validator`. Policy doc §2 updated to reflect Renovate is now enabled (deliberate, cooldown-gated, never auto-merge). (.github/renovate.json, docs/supply-chain-policy.md)
 
-### ⬆️ Bump bundled Harper 5.0.21 → 5.1.14 (ops-xc0x)
+### ⬆️ Bump bundled Harper 5.0.21 → 5.1.14
 
-The bundled `@harperfast/harper` dependency moves from `5.0.21` to `5.1.14`, retiring the 5.0.21 pin that has been the source of recurring friction — the `packageComponent` empty-tarball bug under `node_modules` (#513) and the `flair upgrade --target` override dance that hard-coded a `>= 5.1.13` Harper pin to work around it. The Fabric already runs Flair on 5.1.14 (proven in production), so this brings the bundled dep to parity. This is step 0 of the native-MCP arc (ops-b6uk / #520): 5.1 unlocks Harper's native MCP support and the OAuth plugin.
+The bundled `@harperfast/harper` dependency moves from `5.0.21` to `5.1.14`, retiring the 5.0.21 pin that has been the source of recurring friction — the `packageComponent` empty-tarball bug under `node_modules` (#513) and the `flair upgrade --target` override dance that hard-coded a `>= 5.1.13` Harper pin to work around it. The Fabric already runs Flair on 5.1.14 (proven in production), so this brings the bundled dep to parity. This is step 0 of the native-MCP arc (#520): 5.1 unlocks Harper's native MCP support and the OAuth plugin.
 
 Full unit (1151) + integration (129) suites pass on 5.1.14, and `flair init` / `flair doctor` confirm embeddings load and semantic recall works (paraphrase round-trip, score ~0.74) in a writable environment. The 5.1.x dependency tree swaps the storage native bindings (`@harperfast/rocksdb-js` 1.3.0 → 2.3.0, `lmdb` 3.5.4 → 3.5.5) and pulls a new, **optional** `react-native-fs` subtree transitively via `alasql` 4.6.6 → 4.17.3 (never `require`d in a server/Node context). (package.json, bun.lock)
 
-**CI Docker image synced to match (ops-xc0x follow-up).** The E2E and smoke jobs spun up the `harperfast/harper:5.0.1` Docker image while the bundled npm dep was already 5.1.14 — validating a different Harper runtime than ships to users. Both pins (`.github/workflows/test.yml`, `.github/workflows/smoke.yml`) now use `harperfast/harper:5.1.14`. The native-spawn (integration) and `workers: 1` + retry (Playwright) HarperFast/harper#386 mitigations are **kept** — they're version-agnostic guards against the concurrent-write race; this PR's Docker E2E/smoke run is what validates whether 5.1.14 still trips it (a real finding if so, since users get 5.1.14 — not a reason to revert). Stale `5.0.1` references in CI/Playwright comments updated.
+**CI Docker image synced to match (Harper bump follow-up).** The E2E and smoke jobs spun up the `harperfast/harper:5.0.1` Docker image while the bundled npm dep was already 5.1.14 — validating a different Harper runtime than ships to users. Both pins (`.github/workflows/test.yml`, `.github/workflows/smoke.yml`) now use `harperfast/harper:5.1.14`. The native-spawn (integration) and `workers: 1` + retry (Playwright) HarperFast/harper#386 mitigations are **kept** — they're version-agnostic guards against the concurrent-write race; this PR's Docker E2E/smoke run is what validates whether 5.1.14 still trips it (a real finding if so, since users get 5.1.14 — not a reason to revert). Stale `5.0.1` references in CI/Playwright comments updated.
 
-### 🩺 Onboarding dogfood round 1 — loud failure for dead semantic search + install/UX fixes (ops-9czl)
+### 🩺 Onboarding dogfood round 1 — loud failure for dead semantic search + install/UX fixes
 
 A clean-VM dogfood (fresh Ubuntu, new Harper dev) found semantic search **dead out of the box** — a `sudo`/root-owned global install can't write the embeddings model symlink (`EACCES`), so `SemanticSearch` silently fell back to keyword-only — while `flair doctor` reported "no issues found" the entire time. This round makes that failure loud and fixes the surrounding install/UX friction.
 
@@ -179,7 +179,7 @@ The git mental model: `npm install -g @tpsdev-ai/flair`, then `flair init`. `fla
 
 - **`flair init` is now the full one-command setup.** It gained `install`'s flags — `--client <claude-code|codex|gemini|cursor|all|none>`, `--no-mcp`, `--skip-smoke` — alongside its existing instance/agent/remote/Fabric flags. With no MCP flag it detects and wires every installed client (Claude Code is auto-wired into `~/.claude.json`; others print copy-paste snippets) and runs an MCP smoke test, then degrades gracefully (warnings, never a hard failure). `--no-mcp` reduces it to the minimal instance + agent bootstrap, so existing callers like `flair init --agent-id X` keep working unchanged.
 - **Canonical agent flag is `--agent-id`** (init's existing flag, referenced in docs and callers); `--agent` (install's flag) is kept as a hidden alias so both forms work.
-- **Docs updated:** README Quick Start, `docs/integrations.md`, the cross-orchestrator demo cast, and `packages/flair-mcp/README.md` now lead with `flair init`. (ops-ogzp iteration 2.)
+- **Docs updated:** README Quick Start, `docs/integrations.md`, the cross-orchestrator demo cast, and `packages/flair-mcp/README.md` now lead with `flair init`. (second docs pass.)
 
 ### 📚 Onboarding consistency — one zero-install MCP-wiring pattern + `flair install` as the front door
 
@@ -194,8 +194,8 @@ Three contradictions in the onboarding story, fixed so the docs and the code agr
 
 Closes the two recurring papercuts from the v0.15.0 release:
 
-- **`release.sh` pushes authenticate via the gh token (ops-cb5o):** both git-push points (the Phase-1 release-branch push and the Phase-2 tag push) used plain `git push origin`, which fails auth on hosts without a working cred helper for the flair remote (rockit: `Password authentication is not supported`). They now push via the gh token embedded in the remote URL (`git push https://x-access-token:<token>@github.com/tpsdev-ai/flair.git <ref>`), the same PAT-in-URL pattern used everywhere else. The token is read once and never echoed; if no token is available the push fails loudly with recovery guidance. The `-u` upstream tracking on the branch push was dropped (it would persist the token into `.git/config`; the release flow pushes once and opens the PR via the API). The `gh pr create` → `gh api` change from #528 is untouched.
-- **Impl-term leak check runs on every PR, scanning the built package surface (ops-aksm):** the `check-impl-term-leaks` lint scans `packages/*/dist/`, but the per-PR "Doc/Code Lint" CI job didn't build the packages — so a bead-ref/internal label in a package's **source** comment (which `tsc` compiles verbatim into `dist/`) was invisible at PR time and only failed at release. This is exactly what blocked v0.15.0: a coordination-write-surface comment in `packages/flair-mcp/src/index.ts` carried an internal ref into `dist/index.js`, caught only by the release-time check (#528). The `doclint` job now builds all publishable packages before running the check, so a source leak fails CI on the PR that introduces it, not at release.
+- **`release.sh` pushes authenticate via the gh token:** both git-push points (the Phase-1 release-branch push and the Phase-2 tag push) used plain `git push origin`, which fails auth on hosts without a working cred helper for the flair remote (rockit: `Password authentication is not supported`). They now push via the gh token embedded in the remote URL (`git push https://x-access-token:<token>@github.com/tpsdev-ai/flair.git <ref>`), the same PAT-in-URL pattern used everywhere else. The token is read once and never echoed; if no token is available the push fails loudly with recovery guidance. The `-u` upstream tracking on the branch push was dropped (it would persist the token into `.git/config`; the release flow pushes once and opens the PR via the API). The `gh pr create` → `gh api` change from #528 is untouched.
+- **Impl-term leak check runs on every PR, scanning the built package surface:** the `check-impl-term-leaks` lint scans `packages/*/dist/`, but the per-PR "Doc/Code Lint" CI job didn't build the packages — so a bead-ref/internal label in a package's **source** comment (which `tsc` compiles verbatim into `dist/`) was invisible at PR time and only failed at release. This is exactly what blocked v0.15.0: a coordination-write-surface comment in `packages/flair-mcp/src/index.ts` carried an internal ref into `dist/index.js`, caught only by the release-time check (#528). The `doclint` job now builds all publishable packages before running the check, so a source leak fails CI on the PR that introduces it, not at release.
 
 ## 0.15.0 (2026-06-26)
 
@@ -207,25 +207,25 @@ Unblocks the release build and removes two recurring release-time papercuts:
 - **Gitignore disposable UI artifacts:** added `ui/_shoot*.mjs`, `ui/floor-*.png`, `ui/hero-*.png`, `ui/office-space*.html` (hero-mock screenshot scripts + pngs from prior sessions) to `.gitignore` so they stop dirtying the tree and tripping `release.sh`'s clean-tree check. None were tracked or shipped.
 - **`release.sh` PR-create via REST:** the release PR step used `gh pr create`, which 401s with the flint token (it routes through GraphQL). Switched to `gh api -X POST repos/tpsdev-ai/flair/pulls` (REST works) with the same title/body/head/base, so the PR step actually succeeds.
 
-### ✨ `flair upgrade --target <fabric>` — one-command Fabric upgrade — ops-e5bh
+### ✨ `flair upgrade --target <fabric>` — one-command Fabric upgrade
 
-Upgrading a Flair instance deployed to a Harper Fabric cluster used to require a manual deploy dance: stand up a fresh temp dir, hand-write a `package.json` that depends on `@tpsdev-ai/flair@<version>` **and** carries an `overrides` block pinning `@harperfast/harper` to a fixed version (because the published flair declares an old Harper — `@harperfast/harper@5.0.21` as of `flair@0.14.0` — whose component packager emits an empty tarball when the package root is under `node_modules`, flair#513), `npm install`, then run `flair deploy`. `flair upgrade --target <fabric-url>` now bakes that whole thing into one command: it resolves the target version (latest published `@tpsdev-ai/flair`, or `--version`), prepares a clean deployable in an isolated temp dir with the Harper pin (>= 5.1.13) applied automatically, **confirms the staged Harper is the fix version before deploying**, then **reuses `flair deploy`** to push to the Fabric and verifies the result. `--check` shows the version diff + plan without deploying; credentials mirror `flair deploy` (`--fabric-user`/`--fabric-password`, `FABRIC_USER`/`FABRIC_PASSWORD` env) and are never printed. The local-package `flair upgrade` (no `--target`) is unchanged. (ops-e5bh.)
+Upgrading a Flair instance deployed to a Harper Fabric cluster used to require a manual deploy dance: stand up a fresh temp dir, hand-write a `package.json` that depends on `@tpsdev-ai/flair@<version>` **and** carries an `overrides` block pinning `@harperfast/harper` to a fixed version (because the published flair declares an old Harper — `@harperfast/harper@5.0.21` as of `flair@0.14.0` — whose component packager emits an empty tarball when the package root is under `node_modules`, flair#513), `npm install`, then run `flair deploy`. `flair upgrade --target <fabric-url>` now bakes that whole thing into one command: it resolves the target version (latest published `@tpsdev-ai/flair`, or `--version`), prepares a clean deployable in an isolated temp dir with the Harper pin (>= 5.1.13) applied automatically, **confirms the staged Harper is the fix version before deploying**, then **reuses `flair deploy`** to push to the Fabric and verifies the result. `--check` shows the version diff + plan without deploying; credentials mirror `flair deploy` (`--fabric-user`/`--fabric-password`, `FABRIC_USER`/`FABRIC_PASSWORD` env) and are never printed. The local-package `flair upgrade` (no `--target`) is unchanged.
 
-### 🐛 Loud Node-version preflight — `flair init` was silently failing on unsupported Node — ops-3wz7
+### 🐛 Loud Node-version preflight — `flair init` was silently failing on unsupported Node
 
 `flair` (and so `flair init`) silently did nothing on an older/unsupported Node: no error, no output, no `~/.flair`. A Harper dev hit it live onboarding to a Flair office — zero output and no `~/.flair`, fixed only by upgrading Node. Every dev on an old Node hits the same silent wall.
 
 **Root cause:** the CLI bin (`dist/cli.js`) is an ES module. In ESM, every top-level `import` is hoisted and the whole module graph is linked + evaluated *before* the first statement in the file body runs. Flair's deps require a modern engine (`harper-fabric-embeddings` `>=22`, `@harperfast/harper` / `commander` `>=20`), so on an old Node the import graph crashes during linking — *before* any in-file version guard could ever run. The two pre-existing `process.version` checks lived deep inside command handlers, far past the imports, so they never executed; the failure surfaced as silence.
 
-**Fix:** the bin now points at a CommonJS preflight shim (`dist/cli-shim.cjs`, compiled from `src/cli-shim.cts`). CommonJS evaluates top-to-bottom with lazy `require()`/`import()`, so the shim's Node-version check runs and prints *before* anything tries to load the ESM CLI or any modern dependency. The check uses only ancient-safe syntax (`var`, plain functions, string ops, `console.error`, `process.exit`) so the guard itself can never become the thing that fails to parse — it is guaranteed to run and print on the oldest Node a dev could plausibly have. On an unsupported Node it prints a clear, actionable message ("Flair requires Node.js >= 22. You are running Node.js X. Please upgrade: https://nodejs.org/") and exits non-zero. On a supported Node it is a transparent no-op that hands off to the real CLI via `runCli()`. `engines.node` is unchanged at `>=22` (so `npm install` also warns). (ops-3wz7.)
+**Fix:** the bin now points at a CommonJS preflight shim (`dist/cli-shim.cjs`, compiled from `src/cli-shim.cts`). CommonJS evaluates top-to-bottom with lazy `require()`/`import()`, so the shim's Node-version check runs and prints *before* anything tries to load the ESM CLI or any modern dependency. The check uses only ancient-safe syntax (`var`, plain functions, string ops, `console.error`, `process.exit`) so the guard itself can never become the thing that fails to parse — it is guaranteed to run and print on the oldest Node a dev could plausibly have. On an unsupported Node it prints a clear, actionable message ("Flair requires Node.js >= 22. You are running Node.js X. Please upgrade: https://nodejs.org/") and exits non-zero. On a supported Node it is a transparent no-op that hands off to the real CLI via `runCli()`. `engines.node` is unchanged at `>=22` (so `npm install` also warns).
 
-### 🐛 `seedAgentViaOpsApi` seeded agents with `kind=null` / `status=null` (invisible to roster/presence) — ops-3b9i / #521
+### 🐛 `seedAgentViaOpsApi` seeded agents with `kind=null` / `status=null` (invisible to roster/presence) — #521
 
-Remote agent seeding (`flair agent add`, `flair import`, remote init) writes the `Agent` record through the Harper operations API (`operation: "insert"`), which **bypasses the `Agent` resource layer** — so `Agent.post()`'s 1.0 Principal defaults (`kind="agent"`, `status="active"`, `displayName`, `admin`, `defaultTrustTier`, `type`) never ran. The seed body only carried `{id, name, publicKey, createdAt}`, so remotely-seeded agents landed `kind=null, status=null` and were **invisible to roster / presence / Office-Space queries** that filter `status='active'` or `kind='agent'`. `seedAgentViaOpsApi` now writes those fields explicitly, mirroring `Agent.post()` exactly. (ops-3b9i / closes #521.)
+Remote agent seeding (`flair agent add`, `flair import`, remote init) writes the `Agent` record through the Harper operations API (`operation: "insert"`), which **bypasses the `Agent` resource layer** — so `Agent.post()`'s 1.0 Principal defaults (`kind="agent"`, `status="active"`, `displayName`, `admin`, `defaultTrustTier`, `type`) never ran. The seed body only carried `{id, name, publicKey, createdAt}`, so remotely-seeded agents landed `kind=null, status=null` and were **invisible to roster / presence / Office-Space queries** that filter `status='active'` or `kind='agent'`. `seedAgentViaOpsApi` now writes those fields explicitly, mirroring `Agent.post()` exactly. (closes #521.)
 
-### ✨ BM25 + union-RRF hybrid retrieval (feature-flagged) — ops-i39b
+### ✨ BM25 + union-RRF hybrid retrieval (feature-flagged)
 
-Flair semantic recall (HNSW over Q4-nomic embeddings) buries known-good **near-verbatim** memories past rank 100 — outside the HNSW candidate window — so `SemanticSearch` never returns them (confirmed by the recall-eval diagnosis, ops-ti82: 6 known-good memories missing in both raw and composite scoring; the misses are lexical exact-term cases the weak embedding cannot surface). This adds a **feature-flagged** BM25 + candidate-union Reciprocal Rank Fusion hybrid path in `resources/SemanticSearch.ts`, between the HNSW candidate fetch and the composite scoring.
+Flair semantic recall (HNSW over Q4-nomic embeddings) buries known-good **near-verbatim** memories past rank 100 — outside the HNSW candidate window — so `SemanticSearch` never returns them (confirmed by the recall-eval diagnosis: 6 known-good memories missing in both raw and composite scoring; the misses are lexical exact-term cases the weak embedding cannot surface). This adds a **feature-flagged** BM25 + candidate-union Reciprocal Rank Fusion hybrid path in `resources/SemanticSearch.ts`, between the HNSW candidate fetch and the composite scoring.
 
 - **In-memory per-query BM25** (`k1=1.2`, `b=0.75`, lowercased tokenize, trivial-stopword drop, standard +1-variant IDF) over the caller's scoped corpus — no persistent index, no schema change, no write-path coupling. Extracted to the Harper-free `resources/bm25.ts` so the scoring + fusion are unit-tested against the shipped code.
 - **Candidate-UNION RRF** (`rrf = 1/(K+rank_sem) + 1/(K+rank_bm25)`, `K=60`, absent-from-a-list = 0 contribution) over the dedup'd union of the semantic and BM25 (top-50) candidate pools → **normalized** to `[0,1]` (`rrf / max_rrf_in_union`) → fed as the `rawScore` input to the existing `compositeScore`, so durability/recency/`retrievalBoost` and the `RBOOST_RELEVANCE_FLOOR` / `minScore` thresholds all still apply. Naive whole-corpus RRF was rejected (pilot: 0/6 — the broken semantic top-50 floods the fusion and buries BM25's rank-1 hits); union-RRF is the production shape.
@@ -233,9 +233,9 @@ Flair semantic recall (HNSW over Q4-nomic embeddings) buries known-good **near-v
 - **Removes** the `+0.05` exact-substring keyword bump on the hybrid path (BM25 subsumes it). **No-embedding fallback** → BM25-only ranking (RRF degrades naturally as the semantic list is empty). `CANDIDATE_MULTIPLIER` (HNSW fetch size) unchanged; BM25 uses a fixed `SEM_LIMIT=50` candidate window.
 - **Feature flag `FLAIR_HYBRID_RETRIEVAL`** (`true` / `1` / `on`; default OFF). **Flag OFF is byte-identical to current behavior** — the legacy HNSW and no-embedding branches are untouched and only the flag-ON path runs the hybrid logic.
 
-Recall-eval (flag-ON vs flag-OFF, against the live flint corpus through the shipped modules): the NEW-8 within-cluster gate **p@3 holds 0.88** (no regression); the OLD-6 severe near-verbatim misses go from **0/6 → 4/6 into top-10** (1/6 into top-3). Sherlock-gated on the security boundary. (ops-i39b — spec `FLAIR-BM25-HYBRID-RETRIEVAL`.)
+Recall-eval (flag-ON vs flag-OFF, against the live flint corpus through the shipped modules): the NEW-8 within-cluster gate **p@3 holds 0.88** (no regression); the OLD-6 severe near-verbatim misses go from **0/6 → 4/6 into top-10** (1/6 into top-3). Sherlock-gated on the security boundary. (spec `FLAIR-BM25-HYBRID-RETRIEVAL`.)
 
-### ✨ Coordination write surface — `flair orgevent` + `flair workspace set` + MCP tools (ops-wmgx / Kris #510)
+### ✨ Coordination write surface — `flair orgevent` + `flair workspace set` + MCP tools (Kris #510)
 
 Completes the Office Space coordination layer so multi-agent coordination no longer requires hand-rolling signed HTTP (validated need from the Rivet collision dogfood). Adds two CLI commands and two MCP tools that write the coordination layer:
 
@@ -243,13 +243,13 @@ Completes the Office Space coordination layer so multi-agent coordination no lon
 - **`flair orgevent --kind <kind> --summary <text> [--detail --scope --target <agentId>…]`** → signed `POST /OrgEvent`. Publishes an org-wide event attributed to the calling agent; `--target` is repeatable for recipients.
 - MCP tools **`flair_workspace_set`** and **`flair_orgevent`** mirror the CLI, going through `FlairClient.request()` (Ed25519-signed).
 
-**Attribution is taken from the Ed25519 signature, NEVER the request body — an agent cannot forge another agent's records.** `WorkspaceState.post()` and `OrgEvent.post()` now overwrite the persisted `agentId` / `authorId` with the authenticated identity for non-admin agents (rather than 403'ing a mismatch), mirroring `Presence.post()`'s "agentId from signature, not from body" and A2A `message/send`'s "sender must match params.agentId" no-spoof guard. Anonymous writes stay rejected (401); admin agents may still write on behalf of another agent. The CLI/MCP clients deliberately omit `agentId`/`authorId` from the body. (ops-wmgx / Kris #510.)
+**Attribution is taken from the Ed25519 signature, NEVER the request body — an agent cannot forge another agent's records.** `WorkspaceState.post()` and `OrgEvent.post()` now overwrite the persisted `agentId` / `authorId` with the authenticated identity for non-admin agents (rather than 403'ing a mismatch), mirroring `Presence.post()`'s "agentId from signature, not from body" and A2A `message/send`'s "sender must match params.agentId" no-spoof guard. Anonymous writes stay rejected (401); admin agents may still write on behalf of another agent. The CLI/MCP clients deliberately omit `agentId`/`authorId` from the body. (Kris #510.)
 
-### 🐛 A2A `message/send` couldn't direct a handoff to a peer — ops-f1e3
+### 🐛 A2A `message/send` couldn't direct a handoff to a peer
 
 The A2A `message/send` handler published an OrgEvent with `targetIds = [agentId]` where `agentId` is the **sender**, so every message was a self-scoped broadcast — there was no way to hand off to a specific peer. (`OrgEventCatchup` returns events whose `targetIds` includes the requesting agent, so a recipient could never receive a message addressed to the sender.) Confirmed live in the Rivet × krais collision dogfood: rivet's `message/send` published an event targeting rivet, and krais never received it. `message/send` now accepts an additive `toAgentId` param — the recipient — and routes the OrgEvent with `scope = sender`, `targetIds = [toAgentId]`, so the recipient's catch-up picks it up. The recipient is validated to exist (`-32004` if not). The no-spoof guard is unchanged: `agentId` is still the sender and must equal the authenticated caller (or admin), so `toAgentId` only controls who *receives* a message, never who it's sent *as*. Back-compat: omit `toAgentId` and the legacy self-scoped behaviour (`targetIds = [sender]`) is preserved, so existing callers don't break. Found in the Rivet × krais collision dogfood.
 
-### 🐛 base64url Ed25519 pubkeys / signatures 401'd (cross-org interop) — ops-wjjx
+### 🐛 base64url Ed25519 pubkeys / signatures 401'd (cross-org interop)
 
 An Agent registered with a **base64url**-encoded public key (the `-` `_` alphabet, often unpadded — the JWK / `Buffer.toString('base64url')` form) failed Ed25519 signature verification with a 401. The `b64ToArrayBuffer` decoder was copy-pasted into three auth call sites (`resources/auth-middleware.ts`, `resources/agent-auth.ts`, `resources/Presence.ts`) and had drifted: at least one copy fed url-safe input straight to `atob`, which rejects `-`/`_` ("Invalid character"). The decoder now normalizes base64url → standard (`-`→`+`, `_`→`/`) **and** right-pads with `=` to a multiple of 4 before `atob`, so both standard base64 and (padded or unpadded) base64url decode correctly; standard input is unchanged. To stop the copies re-diverging, the single corrected decoder is extracted to `resources/b64.ts` and imported by all three (same "shared so it can't drift" rationale as HarperFast/harper#1466). Found in the Rivet × krais cross-org dogfood.
 
@@ -420,7 +420,7 @@ Caught 2026-05-19 after the Fabric cluster hit its 4.7G XFS quota with 5,899 Blo
 
 ### 📋 Smoke tests + supply-chain — #442 + #443
 
-- Smoke test scaffold + golden-path e2e scenario (#442) — closes ops-t0i3.
+- Smoke test scaffold + golden-path e2e scenario (#442).
 - CI wraps `bun install` with Socket Firewall (sfw) across all jobs (#443) — supply-chain defense.
 
 ### 📝 Docs
@@ -554,11 +554,11 @@ Per the pre-1.0 versioning policy, this minor bump is breaking on purpose.
 
 ### ✨ Features
 
-- **`@tpsdev-ai/openclaw-flair` now registers the `flair` context engine** for behavioral-anchor re-injection (ops-czop). On every turn, the engine reads `~/.openclaw/workspace-<agentId>/{IDENTITY,SOUL,AGENTS}.md` and returns their contents as a `systemPromptAddition` — pinning PERMANENT-tier rules at the top of the prompt so they don't drift across long sessions. Files are mtime-cached; missing files are skipped silently. Replaces the standalone `flair-context-engine` plugin (now retired) — anchor re-injection was the only feature that earned its slot per the audit; compaction-extract regex (0% retrieval), auto-ingest (dead path), and HEARTBEAT_OK filter (redundant with openclaw's built-in) were dropped.
+- **`@tpsdev-ai/openclaw-flair` now registers the `flair` context engine** for behavioral-anchor re-injection. On every turn, the engine reads `~/.openclaw/workspace-<agentId>/{IDENTITY,SOUL,AGENTS}.md` and returns their contents as a `systemPromptAddition` — pinning PERMANENT-tier rules at the top of the prompt so they don't drift across long sessions. Files are mtime-cached; missing files are skipped silently. Replaces the standalone `flair-context-engine` plugin (now retired) — anchor re-injection was the only feature that earned its slot per the audit; compaction-extract regex (0% retrieval), auto-ingest (dead path), and HEARTBEAT_OK filter (redundant with openclaw's built-in) were dropped.
 
 ### ✨ UX
 
-- **`flair init` and CLI fetches no longer require `--admin-pass` for local instances with `authorizeLocal: true`** (ops-vu31): when targeting localhost (no `--target`/`FLAIR_TARGET`), the CLI now skips Basic auth and lets Harper's `authorizeLocal` trust loopback requests. Remote targets still require `--admin-pass`. Sherlock-approved with a defense-in-depth follow-up noted on the auth-middleware locality guard.
+- **`flair init` and CLI fetches no longer require `--admin-pass` for local instances with `authorizeLocal: true`**: when targeting localhost (no `--target`/`FLAIR_TARGET`), the CLI now skips Basic auth and lets Harper's `authorizeLocal` trust loopback requests. Remote targets still require `--admin-pass`. Sherlock-approved with a defense-in-depth follow-up noted on the auth-middleware locality guard.
 
 ### ⚠️ Behavioral Change
 
@@ -586,9 +586,9 @@ Per the pre-1.0 versioning policy, this minor bump is breaking on purpose.
 
 ### 🔒 Security
 
-- **Localhost trust boundary for `flair agent list`:** IDs-only enumeration is allowed from localhost processes without per-agent Ed25519 auth. The response is filtered to public metadata (id, name, createdAt) — no secrets, no key material, no memory contents. Approved by Sherlock in ops-fqwh review.
+- **Localhost trust boundary for `flair agent list`:** IDs-only enumeration is allowed from localhost processes without per-agent Ed25519 auth. The response is filtered to public metadata (id, name, createdAt) — no secrets, no key material, no memory contents. Approved by Sherlock's security review.
 
-- **Reembed respects cross-agent isolation:** the `agentId` passed in the update payload matches the record being reembedded, not a wildcard. The 0.5.5 schema-validation gate remains intact. Approved by Sherlock in ops-fqwh review.
+- **Reembed respects cross-agent isolation:** the `agentId` passed in the update payload matches the record being reembedded, not a wildcard. The 0.5.5 schema-validation gate remains intact. Approved by Sherlock's security review.
 
 
 ### 📖 Docs

--- a/packages/flair-client/test/client.test.ts
+++ b/packages/flair-client/test/client.test.ts
@@ -193,7 +193,7 @@ describe("MemoryApi", () => {
     expect((result as any).written).toBe(true);
   });
 
-  test("write() forwards visibility ONLY when the caller sets it (ops-2dm3 Layer 1)", async () => {
+  test("write() forwards visibility ONLY when the caller sets it — opt-in, no forced default (Layer 1)", async () => {
     mockFetch = mock(() => Promise.resolve(new Response("{}", { status: 200 })));
     globalThis.fetch = mockFetch as any;
 

--- a/packages/flair-mcp/test/mcp.test.ts
+++ b/packages/flair-mcp/test/mcp.test.ts
@@ -116,11 +116,11 @@ describe("coordination write surface (flair_workspace_set / flair_orgevent)", ()
   }
 
   test("flair_workspace_set body never carries agentId (no forging — attribute from signature)", () => {
-    const body = buildWorkspaceBody("agent-alpha", { ref: "main", phase: "implement", task: "ops-wmgx" });
+    const body = buildWorkspaceBody("agent-alpha", { ref: "main", phase: "implement", task: "cp7-implement-task" });
     expect(body).not.toHaveProperty("agentId");
     expect(body.ref).toBe("main");
     expect(body.phase).toBe("implement");
-    expect(body.taskId).toBe("ops-wmgx");
+    expect(body.taskId).toBe("cp7-implement-task");
     expect(body.provider).toBe("mcp");
   });
 

--- a/packages/openclaw-flair/index.ts
+++ b/packages/openclaw-flair/index.ts
@@ -22,14 +22,14 @@ import { FlairClient } from "@tpsdev-ai/flair-client";
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
 import { resolveAgentId } from "./key-resolver.js";
 
-// ─── Defense-in-depth: agentId path-traversal guard (ops-pnwq) ───────────────
+// ─── Defense-in-depth: agentId path-traversal guard ──────────────────────────
 // agentId flows into resolve() to compose ~/.openclaw/workspace-<agentId>/...
 // resolve() normalizes "../" but doesn't reject — an attacker-controlled
 // agentId of "../../../etc" could traverse out of the workspace dir.
 // Today's threat surface is low (agentId comes from plugin config or session
 // context, both within the agent's host trust boundary), but a fail-closed
 // regex guard is cheap and surfaces invalid input rather than silently
-// mangling. Per Sherlock review of PR #317 (filed as ops-pnwq).
+// mangling. Per Sherlock review of PR #317.
 const AGENT_ID_PATTERN = /^[a-z0-9_-]{1,64}$/i;
 
 export function isValidAgentId(agentId: string | null | undefined): boolean {
@@ -267,8 +267,9 @@ function detectRelationships(text: string): DetectedRelationship[] {
 //
 // Replaces the standalone `flair-context-engine` plugin (retired 2026-05-03).
 // Anchor re-injection was the only feature that earned its slot per the
-// ops-czop audit; the rest was noise (compaction-extract regex, auto-ingest
-// dead path) or duplicates (HEARTBEAT_OK filter is built into openclaw).
+// plugin-consolidation audit done at retirement time; the rest was noise
+// (compaction-extract regex, auto-ingest dead path) or duplicates
+// (HEARTBEAT_OK filter is built into openclaw).
 
 const ANCHOR_FILES = ["IDENTITY.md", "SOUL.md", "AGENTS.md"];
 
@@ -307,7 +308,7 @@ class FlairBehavioralAnchorEngine {
     private logger: { info: Function; warn: Function },
   ) {
     // Defense-in-depth: agentId flows into resolve() to compose the workspace
-    // path. Reject malformed input at construction time (ops-pnwq).
+    // path. Reject malformed input at construction time.
     assertValidAgentId(agentId);
   }
 
@@ -420,7 +421,7 @@ export default {
       const id = agentId || (cfg.agentId && cfg.agentId !== "auto" ? cfg.agentId : null) || currentAgentId || fallbackAgentId;
       if (!id || id === "auto") throw new Error("no agentId available — set agentId in plugin config, FLAIR_AGENT_ID env var, or ensure OpenClaw provides it via session context (before_agent_start)");
       // Defense-in-depth: validate before flowing into FlairClient + workspace
-      // path composition (ops-pnwq).
+      // path composition.
       assertValidAgentId(id);
       let client = clientPool.get(id);
       if (!client) {
@@ -558,8 +559,8 @@ export default {
             const client = getCurrentClient();
             const memId = `${client.agentId}-${Date.now()}`;
 
-            // Write the NEW memory FIRST (ops-a4t5 discipline: write-new-
-            // BEFORE-close-old). Note: `client.memory.write()` does not
+            // Write the NEW memory FIRST (write-new-BEFORE-close-old
+            // discipline). Note: `client.memory.write()` does not
             // forward a `supersedes` field to the server (flair-client's
             // MemoryApi.write() opts have no such field — see client.ts),
             // so this can't be routed through the server's transactional

--- a/packages/openclaw-flair/test/plugin.test.ts
+++ b/packages/openclaw-flair/test/plugin.test.ts
@@ -493,14 +493,14 @@ describe("FlairBehavioralAnchorEngine — anchor re-injection", () => {
   });
 });
 
-// ─── isValidAgentId / assertValidAgentId — ops-pnwq defense-in-depth ─────────
+// ─── isValidAgentId / assertValidAgentId — path-traversal defense-in-depth ───
 // Sanitizer for agentId before path composition. Sherlock review of PR #317
 // flagged that agentId flows into resolve() unchecked; "../" segments would
 // compose into a workspace-dir escape. This is the fail-closed regex guard.
 
 import { isValidAgentId, assertValidAgentId } from "../index.ts";
 
-describe("isValidAgentId / assertValidAgentId (ops-pnwq)", () => {
+describe("isValidAgentId / assertValidAgentId (path-traversal defense-in-depth)", () => {
   test("accepts standard agent names", () => {
     for (const id of ["flint", "anvil", "kern", "sherlock", "ember"]) {
       expect(isValidAgentId(id)).toBe(true);
@@ -575,17 +575,17 @@ describe("isValidAgentId / assertValidAgentId (ops-pnwq)", () => {
   });
 });
 
-// ─── memory_store supersede — write-then-close ordering (ops-mmh9) ──────────
+// ─── memory_store supersede — write-then-close ordering ─────────────────────
 // The hand-rolled supersede used to archive the OLD record BEFORE writing the
 // NEW one — if the write then failed, the old fact was gone and the new one
-// never landed (silent loss; same class as ops-a4t5, fixed server-side in
-// resources/Memory.ts). These tests exercise the fixed ordering directly
-// against the real FlairClient class (flair-client's HTTP boundary,
+// never landed (silent loss; same class as the write-new-before-close-old bug,
+// fixed server-side in resources/Memory.ts). These tests exercise the fixed
+// ordering directly against the real FlairClient class (flair-client's HTTP boundary,
 // `FlairClient.prototype.request`, is monkey-patched per test so no network
 // call is made — everything above that boundary, including memory.write()/
 // memory.get()'s real logic, runs unmodified).
 
-describe("memory_store supersede — write-then-close ordering (ops-mmh9)", () => {
+describe("memory_store supersede — write-then-close ordering", () => {
   const originalRequest = FlairClient.prototype.request;
 
   afterEach(() => {

--- a/resources/Admin.ts
+++ b/resources/Admin.ts
@@ -8,7 +8,7 @@ import { allowAdmin } from "./agent-auth.js";
  * they hit a 404 and assume the admin UI is broken. The dashboard is the
  * canonical landing surface; redirect there.
  *
- * allowRead()=allowAdmin (ops-oox7 defense-in-depth): the /Admin* pathname
+ * allowRead()=allowAdmin (defense-in-depth): the /Admin* pathname
  * gate in auth-middleware.ts only 401s when there's NO Authorization header
  * at all (or Basic creds don't resolve to a real user) — a validly-verified
  * TPS-Ed25519 agent that is NOT an admin, or a valid-but-non-super_user Basic

--- a/resources/AdminConnectors.ts
+++ b/resources/AdminConnectors.ts
@@ -5,7 +5,7 @@ import { allowAdmin } from "./agent-auth.js";
 /**
  * GET /AdminConnectors — OAuth clients and active sessions.
  *
- * allowRead()=allowAdmin (ops-oox7 defense-in-depth): see Admin.ts.
+ * allowRead()=allowAdmin (defense-in-depth): see Admin.ts.
  */
 export class AdminConnectors extends Resource {
   async allowRead(): Promise<boolean> {

--- a/resources/AdminDashboard.ts
+++ b/resources/AdminDashboard.ts
@@ -5,7 +5,7 @@ import { allowAdmin } from "./agent-auth.js";
 /**
  * GET /AdminDashboard — admin home page with system overview.
  *
- * allowRead()=allowAdmin (ops-oox7 defense-in-depth): see Admin.ts for why
+ * allowRead()=allowAdmin (defense-in-depth): see Admin.ts for why
  * this closes a real gap, not just belt-and-suspenders — a verified
  * non-admin agent could otherwise read full instance stats (principal/agent/
  * memory/relationship counts) with no admin check at all.

--- a/resources/AdminIdp.ts
+++ b/resources/AdminIdp.ts
@@ -5,7 +5,7 @@ import { allowAdmin } from "./agent-auth.js";
 /**
  * GET /AdminIdp — enterprise IdP configuration management.
  *
- * allowRead()=allowAdmin (ops-oox7 defense-in-depth): see Admin.ts.
+ * allowRead()=allowAdmin (defense-in-depth): see Admin.ts.
  */
 export class AdminIdp extends Resource {
   async allowRead(): Promise<boolean> {

--- a/resources/AdminInstance.ts
+++ b/resources/AdminInstance.ts
@@ -88,7 +88,7 @@ function resolveVersion(): string {
 /**
  * GET /AdminInstance — instance info, public key, version.
  *
- * allowRead()=allowAdmin (ops-oox7 defense-in-depth): see Admin.ts.
+ * allowRead()=allowAdmin (defense-in-depth): see Admin.ts.
  */
 export class AdminInstance extends Resource {
   async allowRead(): Promise<boolean> {

--- a/resources/AdminMemory.ts
+++ b/resources/AdminMemory.ts
@@ -22,7 +22,7 @@ import { allowAdmin } from "./agent-auth.js";
  * makes that legible: every memory shows where it came from, what it derived
  * from, what it superseded, and which peer it synced from.
  *
- * allowRead()=allowAdmin (ops-oox7 defense-in-depth): see Admin.ts — this
+ * allowRead()=allowAdmin (defense-in-depth): see Admin.ts — this
  * page surfaces full memory content across ALL agents, so the gap it closes
  * matters more here than on the other Admin* pages.
  */
@@ -33,7 +33,7 @@ export class AdminMemory extends Resource {
 
   async get() {
     // Harper v5 does not populate this.request on Resource subclasses —
-    // getContext() is the only reliable path (ops-sal4: the previous
+    // getContext() is the only reliable path (the previous
     // `(this as any).request` read was always undefined, so query params
     // (?id=, ?q=, ?subject=, ?limit=) were always ignored).
     const ctx = (this as any).getContext?.();

--- a/resources/AdminPrincipals.ts
+++ b/resources/AdminPrincipals.ts
@@ -5,7 +5,7 @@ import { allowAdmin } from "./agent-auth.js";
 /**
  * GET /AdminPrincipals — list all principals with kind, trust, status.
  *
- * allowRead()=allowAdmin (ops-oox7 defense-in-depth): see Admin.ts.
+ * allowRead()=allowAdmin (defense-in-depth): see Admin.ts.
  */
 export class AdminPrincipals extends Resource {
   async allowRead(): Promise<boolean> {

--- a/resources/AgentCard.ts
+++ b/resources/AgentCard.ts
@@ -38,7 +38,7 @@ export class AgentCard extends Resource {
     return {
       name: String(agent.name ?? agent.id ?? agentId),
       // Only an explicit kind="description" soul publishes — no private-soul
-      // fallback (ops-vz6j). See agentcard-fields.ts for the security rationale.
+      // fallback. See agentcard-fields.ts for the security rationale.
       description: selectPublicDescription(souls),
       url: String(agent.url ?? ""),
       version: String(agent.version ?? "1.0.0"),

--- a/resources/AgentSeed.ts
+++ b/resources/AgentSeed.ts
@@ -45,7 +45,7 @@ export class AgentSeed extends Resource {
 
   async post(data: any) {
     // Harper v5 does not populate this.request on Resource subclasses —
-    // getContext() is the only reliable path (ops-sal4: the previous
+    // getContext() is the only reliable path (the previous
     // `(this as any).request` read was always undefined, so actorId was always
     // undefined and this belt-and-suspenders check fail-closed every request,
     // even from a real admin already verified by allowCreate()).

--- a/resources/IngestEvents.ts
+++ b/resources/IngestEvents.ts
@@ -98,7 +98,7 @@ export class IngestEvents extends Resource {
 
   async post(body: unknown, context?: unknown) {
     // Harper v5 does not populate this.request on Resource subclasses —
-    // getContext() is the only reliable path (ops-sal4: the previous
+    // getContext() is the only reliable path (the previous
     // `(this as any).request` read was always undefined, so authHeader was
     // always undefined and every request 401'd before reaching the office
     // Ed25519 signature check below).

--- a/resources/Integration.ts
+++ b/resources/Integration.ts
@@ -21,7 +21,7 @@ export class Integration extends (databases as any).flair.Integration {
 
   /**
    * Self-authorize now that the global gate is non-rejecting (memory-soul-
-   * read-gate family fix, ops-oox7 — same pattern as Memory.ts/Soul.ts/
+   * read-gate family fix — same pattern as Memory.ts/Soul.ts/
    * WorkspaceState.ts/Relationship.ts). Closes the same P0 leak: Harper
    * routes `GET /Integration/<id>` to get() and the collection describe
    * (`GET /Integration`) outside search(), so neither was gated before this

--- a/resources/Memory.ts
+++ b/resources/Memory.ts
@@ -29,7 +29,7 @@ const NOT_FOUND = () =>
  * live in ./memory-read-scope.ts — the ONE centralized helper every
  * cross-agent Memory read path (search()/get() here, SemanticSearch.ts,
  * MemoryBootstrap.ts, auth-middleware.ts's by-id guard) resolves its scope
- * through, so the scoping rule cannot drift per-path again (ops-nzxa: a
+ * through, so the scoping rule cannot drift per-path again (a
  * SemanticSearch inline `visibility === "office"` OR-clause leaked office
  * memories to any authenticated agent because the rule had scattered). See
  * that module's doc for the migration invariant (no-visibility-field reads
@@ -107,7 +107,7 @@ async function findConservativeDedupMatch(
     }
     if (!top) return null;
 
-    // ─── ops-ume4: Harper's cosine-sort query omits $distance for a SINGLETON
+    // ─── Harper's cosine-sort query omits $distance for a SINGLETON
     // result set ─────────────────────────────────────────────────────────────
     // Initial working theory was a per-agentId HNSW "cold-start" (first-ever
     // query cold, second query warm) and the initially-recommended fix was a
@@ -154,7 +154,7 @@ async function findConservativeDedupMatch(
       cosine = 1 - top.$distance;
     } else {
       console.error(
-        "Memory.findConservativeDedupMatch: $distance undefined on a singleton cosine result (ops-ume4) — " +
+        "Memory.findConservativeDedupMatch: $distance undefined on a singleton cosine result — " +
         "falling back to a manual cosine computation from the candidate's stored embedding",
         { agentId, candidateId: top.id },
       );
@@ -235,7 +235,7 @@ function buildWriteResponse(content: any, result: any, dedupMatch: DedupMatch | 
  * detachment discipline as findConservativeDedupMatch (each discrete Harper
  * call individually wrapped — see withDetachedTxn's doc for why a single
  * wrap around a multi-await async function would not protect the later
- * call). Does NOT swallow failures (ops-a4t5 fix) — throws so the caller can
+ * call). Does NOT swallow failures — throws so the caller can
  * log it. Never called before the new record is already written.
  */
 async function closeSupersededRecord(ctx: any, oldId: string, patch: Record<string, unknown>): Promise<void> {
@@ -300,7 +300,7 @@ async function validateAndAuthorizeSupersedes(content: any, auth: AgentAuthVerdi
 
 /**
  * Close the superseded record — called AFTER the new record has already been
- * written (write-new-BEFORE-close-old, ops-a4t5 fix). Safe failure state is
+ * written (write-new-BEFORE-close-old). Safe failure state is
  * two active records (recoverable), never a tombstoned-old-with-lost-new.
  * Failure is logged (observable), never silently swallowed. No-op if
  * `content.supersedes` is not set.
@@ -319,14 +319,14 @@ async function closeSupersededIfNeeded(ctx: any, content: any, methodLabel: "pos
     // (semgrep unsafe-formatstring). Keep all dynamic values in the data object.
     console.error(
       "Memory.closeSuperseded: failed to close superseded record after writing new record " +
-      "(ops-a4t5 — observable, not silent; new record is safely written, old record remains active until retried)",
+      "(observable, not silent; new record is safely written, old record remains active until retried)",
       { method: methodLabel, supersededId: content.supersedes, newRecordId: content.id, err },
     );
   }
 }
 
 /**
- * ─── Durability-keyed default visibility (ops-2dm3 Layer 1, part A) ─────────
+ * ─── Durability-keyed default visibility (Layer 1, part A) ─────────────────
  *
  * Writer intent: an explicit `visibility` on the write ALWAYS overrides this
  * (callers check `content.visibility == null` before calling this). When
@@ -484,8 +484,8 @@ export class Memory extends (databases as any).flair.Memory {
     }
 
     // Non-admin agent: only its own memories (any visibility), or a granted
-    // owner's SHARED memories — never that owner's private ones (ops-2dm3
-    // Layer 1 private-exclusion). Centralized in resolveReadScope() so this
+    // owner's SHARED memories — never that owner's private ones (Layer 1
+    // private-exclusion). Centralized in resolveReadScope() so this
     // and search() below cannot drift.
     const record = await super.get(target);
     if (!record) return NOT_FOUND();
@@ -525,7 +525,7 @@ export class Memory extends (databases as any).flair.Memory {
     }
 
     // Non-admin agent: scope to own (any visibility) + granted owners' SHARED
-    // memories only (ops-2dm3 Layer 1 private-exclusion). Centralized in
+    // memories only (Layer 1 private-exclusion). Centralized in
     // resolveReadScope() so get() above and search() here cannot drift.
     const authAgent = auth.agentId;
     const scope = await resolveReadScope(authAgent);
@@ -583,7 +583,7 @@ export class Memory extends (databases as any).flair.Memory {
     content.updatedAt = content.createdAt;
     content.archived = content.archived ?? false;
 
-    // ─── Default visibility (durability-keyed) — ops-2dm3 Layer 1, part A ────
+    // ─── Default visibility (durability-keyed) — Layer 1, part A ────────────
     // post() only ever creates a NEW record — patchRecord/supersede-close/
     // retrievalCount bumps all route through put() instead (see put()'s
     // pre-existing-record guard below), so there is no "don't overwrite an
@@ -624,7 +624,7 @@ export class Memory extends (databases as any).flair.Memory {
     }
 
     // Content safety scan — covers content + summary (defense-in-depth for
-    // agent-set summaries, ops-i2jb).
+    // agent-set summaries).
     if (content.content || content.summary) {
       const safety = scanFields(content, ["content", "summary"]);
       if (!safety.safe) {
@@ -673,7 +673,7 @@ export class Memory extends (databases as any).flair.Memory {
     // ── Write the new record FIRST ──────────────────────────────────────────
     const result = await super.post(content);
 
-    // ── THEN close the superseded record (ops-a4t5 fix) ─────────────────────
+    // ── THEN close the superseded record ────────────────────────────────────
     // Write-new-BEFORE-close-old: the previous order (close-old via a fire-
     // and-forget `.catch(()=>{})` BEFORE the new write) could tombstone the
     // old record and then lose the new one if the write failed afterward.
@@ -733,7 +733,7 @@ export class Memory extends (databases as any).flair.Memory {
     // visibility stamped) or an update/patch (dedup-bypassed, visibility left
     // untouched). See the dedup-gate block further down for why an existing
     // id skips the gate; the SAME "does a record already exist" check gates
-    // the visibility default (ops-2dm3 Layer 1 part A): patchRecord/supersede-
+    // the visibility default (Layer 1 part A): patchRecord/supersede-
     // close/retrievalCount bumps all route through put() with a MERGED
     // `{...existing, ...patch}` payload, and must never have their stored
     // visibility overwritten by a default recomputed from that merged content
@@ -742,7 +742,7 @@ export class Memory extends (databases as any).flair.Memory {
       ? await (databases as any).flair.Memory.get(content.id).catch(() => null)
       : null;
 
-    // ─── Default visibility (durability-keyed) — ops-2dm3 Layer 1, part A ────
+    // ─── Default visibility (durability-keyed) — Layer 1, part A ────────────
     // Explicit visibility on the write ALWAYS overrides; only stamp the
     // default when the caller left it unset AND this is a fresh record.
     // permanent|persistent → shared; standard|ephemeral|absent → private.
@@ -760,7 +760,7 @@ export class Memory extends (databases as any).flair.Memory {
       content.validFrom = content.createdAt;
     }
 
-    // Content safety scan on updated content + summary (ops-i2jb).
+    // Content safety scan on updated content + summary.
     if (content.content || content.summary) {
       const safety = scanFields(content, ["content", "summary"]);
       if (!safety.safe) {
@@ -845,7 +845,7 @@ export class Memory extends (databases as any).flair.Memory {
     // ── Write the new/updated record FIRST ──────────────────────────────────
     const result = await super.put(content);
 
-    // ── THEN close the superseded record (ops-a4t5 fix; see post()) ────────
+    // ── THEN close the superseded record (see post()) ───────────────────────
     await closeSupersededIfNeeded(ctx, content, "put");
 
     return buildWriteResponse(content, result, dedupMatch);

--- a/resources/MemoryBootstrap.ts
+++ b/resources/MemoryBootstrap.ts
@@ -18,13 +18,13 @@ import { resolveReadScope } from "./memory-read-scope.js";
  *      task-relevant set as #4, split by origin: a grant-visible teammate's
  *      SHARED memory that scores against currentTask lands here instead of
  *      #4, attributed via "[via <agentId>]". Presentation only — what's
- *      readable is entirely Layer 1's resolveReadScope()/ops-2dm3; this only
+ *      readable is entirely Layer 1's resolveReadScope(); this only
  *      changes how an already-read cross-agent record is formatted/sectioned)
  *   5. Relationship context (active relationships for mentioned entities)
  *   6. Predicted context (based on channel/surface/subject hints)
  *   7. Team roster (other active agents in this office + a search-first nudge —
  *      bootstrap loads the caller's own memories plus any granted owner's
- *      SHARED memories (ops-2dm3 Layer 1, never their private ones), so this
+ *      SHARED memories (Layer 1, never their private ones), so this
  *      section nudges toward memory_search for anything beyond that window)
  *
  * Prediction: when context signals (channel, surface, subjects) are provided,
@@ -220,8 +220,8 @@ export class BootstrapMemories extends Resource {
 
     // --- 1c. Team roster + cross-agent search nudge ---
     // Soul is still caller-own-only (unaffected here). Memory loading below
-    // (step 2) now also includes granted owners' SHARED memories (ops-2dm3
-    // Layer 1) — but this section stays: memory_search/SemanticSearch remains
+    // (step 2) now also includes granted owners' SHARED memories (Layer 1)
+    // — but this section stays: memory_search/SemanticSearch remains
     // the deliberate, query-driven way to find a teammate's finding, vs.
     // bootstrap's fixed recent/permanent window. This section is fixed-cost
     // (no query text to format per agent) so it's cheap enough to always
@@ -245,7 +245,7 @@ export class BootstrapMemories extends Resource {
 
     // --- 2. Permanent memories (always included, highest priority) ---
     // Read-scope: own (any visibility) + granted owners' SHARED memories only
-    // (ops-2dm3 Layer 1 — never a granted owner's private ones). Centralized
+    // (Layer 1 — never a granted owner's private ones). Centralized
     // in resolveReadScope(): the condition is pushed into the Harper query
     // (so the table itself never returns an out-of-scope row), and
     // `scope.isAllowed` re-checks in-process as defense-in-depth (same
@@ -257,10 +257,11 @@ export class BootstrapMemories extends Resource {
     for await (const record of (databases as any).flair.Memory.search({ conditions: [scope.condition] })) {
       if (!scope.isAllowed(record)) continue;
       if (record.expiresAt && Date.parse(record.expiresAt) < Date.now()) continue;
-      // ops-hesq: a past validTo ALWAYS means the record has been closed out
+      // A past validTo ALWAYS means the record has been closed out
       // (server supersede path — Memory.ts closeSupersededRecord — sets
       // validTo without necessarily setting `archived`), same root cause and
-      // fix as ops-9rc6's SemanticSearch/bm25-filter exclusion. Unconditional
+      // fix as SemanticSearch.ts's unconditional past-validTo/bm25-filter
+      // exclusion. Unconditional
       // so a server-superseded record can't resurface in bootstrap just
       // because its successor isn't co-present in this result set (the
       // supersededIds filter further down only catches co-presence). A

--- a/resources/MemoryGrant.ts
+++ b/resources/MemoryGrant.ts
@@ -25,7 +25,7 @@ export class MemoryGrant extends (databases as any).flair.MemoryGrant {
 
   /**
    * Self-authorize now that the global gate is non-rejecting (memory-soul-
-   * read-gate family fix, ops-oox7 — same pattern as Memory.ts/Soul.ts/
+   * read-gate family fix — same pattern as Memory.ts/Soul.ts/
    * WorkspaceState.ts/Relationship.ts/Integration.ts). Closes the same P0
    * leak: Harper routes `GET /MemoryGrant/<id>` to get() and the collection
    * describe (`GET /MemoryGrant`) outside search(), so neither was gated

--- a/resources/OAuth.ts
+++ b/resources/OAuth.ts
@@ -143,7 +143,7 @@ export class OAuthAuthorize extends Resource {
     // In 1.0, this returns a simple HTML consent page.
     // The user (Nathan) approves or denies, which POSTs back.
     // Harper v5 does not populate this.request on Resource subclasses —
-    // getContext() is the only reliable path (ops-sal4: the previous
+    // getContext() is the only reliable path (the previous
     // `(this as any).request` read was always undefined, so query params were
     // always empty).
     const ctx = (this as any).getContext?.();
@@ -232,7 +232,7 @@ ${scope.split(" ").map((s: string) => `<div class="scope">${s}</div>`).join("")}
     // this.request on Resource subclasses, so `(this as any).request?.tpsAgent`
     // was always undefined and this ALWAYS fell back to the hardcoded "admin" —
     // every approved consent grant was minted for the admin principal
-    // regardless of who actually approved it (ops-sal4 identity spoof).
+    // regardless of who actually approved it (identity spoof).
     // resolveAgentAuth(getContext()) resolves Basic super_user/admin auth to
     // { kind: "agent", agentId: username, isAdmin: true } (see agent-auth.ts).
     // We do NOT silently fall back to "admin" on an unresolved principal — if

--- a/resources/OrgEventCatchup.ts
+++ b/resources/OrgEventCatchup.ts
@@ -26,7 +26,7 @@ export class OrgEventCatchup extends Resource {
   async get(pathInfo?: any) {
     // Harper v5 does not populate this.request on Resource subclasses —
     // getContext() is the only reliable path to the gate's tpsAgent/
-    // tpsAgentIsAdmin annotations (ops-sal4: the previous `(this as
+    // tpsAgentIsAdmin annotations (the previous `(this as
     // any).request` read was always undefined, so the ownership check below
     // never ran — fail-open cross-agent read).
     const auth = await resolveAgentAuth((this as any).getContext?.());

--- a/resources/Presence.ts
+++ b/resources/Presence.ts
@@ -38,7 +38,7 @@ function offlineThresholdMs(): number {
 
 // ─── Nonce replay + crypto helpers ─────────────────────────────────────────────
 // WINDOW_MS, isNonceReplay/recordNonce (the ONE shared nonce store), and
-// importEd25519Key all live in ./ed25519-auth.ts (bd ops-c4op) — the single
+// importEd25519Key all live in ./ed25519-auth.ts — the single
 // shared implementation imported by auth-middleware.ts, agent-auth.ts, and
 // Presence.ts so a nonce recorded via any one of the three call sites is
 // visible to the other two, and the crypto/decoder logic can't drift.

--- a/resources/Relationship.ts
+++ b/resources/Relationship.ts
@@ -20,7 +20,7 @@ const NOT_FOUND = () =>
 export class Relationship extends (databases as any).flair.Relationship {
   /**
    * Self-authorize now that the global gate is non-rejecting (memory-soul-
-   * read-gate family fix, ops-oox7 — same pattern as Memory.ts/Soul.ts/
+   * read-gate family fix — same pattern as Memory.ts/Soul.ts/
    * WorkspaceState.ts). Closes the same P0 leak: Harper routes
    * `GET /Relationship/<id>` to get() and the collection describe
    * (`GET /Relationship`) outside search(), so neither was gated before this

--- a/resources/SemanticSearch.ts
+++ b/resources/SemanticSearch.ts
@@ -19,7 +19,7 @@ import {
 // unit-tested directly (see test/unit/temporal-scoring.test.ts).
 import { compositeScore } from "./scoring.js";
 
-// BM25 + union-RRF hybrid retrieval (ops-i39b / FLAIR-BM25-HYBRID-RETRIEVAL).
+// BM25 + union-RRF hybrid retrieval (FLAIR-BM25-HYBRID-RETRIEVAL).
 // Harper-free modules so the BM25 scoring, the candidate-union RRF, and the
 // SECURITY conditions-filter are unit-tested against the shipped code.
 import { buildBM25, fuseRrfNormalized, hybridEnabled, SEM_LIMIT } from "./bm25.js";
@@ -101,10 +101,10 @@ export class SemanticSearch extends Resource {
       : bodyAgentId;
 
     // Read-scope: own (any visibility) + granted owners' SHARED memories only
-    // (ops-2dm3 Layer 1). Centralized in resolveReadScope() — this used to be
+    // (Layer 1). Centralized in resolveReadScope() — this used to be
     // an inline grant-resolution loop here PLUS a `visibility === "office"`
     // global OR-clause below that leaked ANY authenticated agent's read of
-    // ANY other agent's office-visible memories (ops-nzxa). Both are gone;
+    // ANY other agent's office-visible memories. Both are gone;
     // this is the ONE scoping resolution for this endpoint now.
     const scope = agentId ? await resolveReadScope(agentId) : null;
 
@@ -179,14 +179,14 @@ export class SemanticSearch extends Resource {
     // from CANDIDATE_MULTIPLIER so composite re-ranking keeps its existing
     // headroom. Scoped to the legacy (non-hybrid) vector path below — the
     // hybrid path's candidate pool is already governed by CANDIDATE_MULTIPLIER
-    // (semantic leg) + SEM_LIMIT (BM25 leg) via RRF union (ops-i39b); the
+    // (semantic leg) + SEM_LIMIT (BM25 leg) via RRF union; the
     // reranker still applies to its output further down regardless of which
     // path produced `filteredResults`.
     const rerankOn = isRerankEnabled();
     const rerankTopN = getRerankTopN();
 
     if (hybrid) {
-      // ─── BM25 + union-RRF hybrid path (ops-i39b) ─────────────────────────
+      // ─── BM25 + union-RRF hybrid path ────────────────────────────────────
       // 1. Semantic candidates via HNSW (unchanged fetch). 2. BM25 lexical pass
       //    over the SCOPED corpus. 3. SECURITY: the BM25 candidate set is filtered
       //    by the SAME conditions[] + temporal filters BEFORE fusion (the corpus
@@ -220,7 +220,7 @@ export class SemanticSearch extends Resource {
           if (sinceDate && record.createdAt && new Date(record.createdAt) < sinceDate) continue;
           if (asOf && record.validFrom && record.validFrom > asOf) continue;
           if (asOf && record.validTo && record.validTo <= asOf) continue;
-          // ops-9rc6: unconditional past-validTo exclusion (see legacy HNSW
+          // Unconditional past-validTo exclusion (see legacy HNSW
           // loop below for the full rationale) — applies regardless of asOf.
           if (record.validTo && Date.parse(record.validTo) < Date.now()) continue;
           semRecords.push(record);
@@ -327,7 +327,7 @@ export class SemanticSearch extends Resource {
         // Temporal validity: if asOf is specified, only include memories valid at that point
         if (asOf && record.validFrom && record.validFrom > asOf) continue;
         if (asOf && record.validTo && record.validTo <= asOf) continue;
-        // ops-9rc6: a past validTo ALWAYS means the record has been closed out
+        // A past validTo ALWAYS means the record has been closed out
         // (server supersede path — Memory.ts closeSupersededRecord — sets
         // validTo without necessarily setting `archived`). Unconditional, not
         // gated on `asOf`, so a server-superseded record can't resurface in
@@ -341,9 +341,9 @@ export class SemanticSearch extends Resource {
         if (record.$distance !== undefined) {
           semanticScore = distanceToSimilarity(record.$distance);
         } else {
-          // ─── ops-syzm: Harper's cosine-sort query omits $distance for a
+          // ─── Harper's cosine-sort query omits $distance for a
           // SINGLETON post-filter result set — the SAME quirk root-caused and
-          // fixed for the dedup path in ops-ume4 (resources/Memory.ts
+          // fixed for the dedup path (resources/Memory.ts
           // findConservativeDedupMatch / resources/dedup.ts cosineSimilarity).
           // Sort ORDER is still correct; only the numeric `$distance`
           // annotation is missing on that one record, regardless of the
@@ -351,7 +351,7 @@ export class SemanticSearch extends Resource {
           // just limit=1 — the trigger is the post-filter MATCH COUNT, not the
           // requested limit).
           //
-          // ops-2dm3 Layer 1 made this common: the no-grants agent scope used
+          // Layer 1 made this common: the no-grants agent scope used
           // to ALWAYS be a compound `{operator:"or", conditions:[{agentId},
           // {visibility=="office"}]}` condition; resolveReadScope() now emits
           // a PLAIN single `{agentId==X}` condition for the common (no-grants)
@@ -365,8 +365,8 @@ export class SemanticSearch extends Resource {
           //
           // Fix: point-lookup the record by id (a plain get(), unaffected by
           // the sort-query quirk — selecting "embedding" directly on the SAME
-          // sort-by-embedding query comes back as a bare scalar per ops-ume4's
-          // findings) and compute cosine similarity ourselves in JS from its
+          // sort-by-embedding query comes back as a bare scalar, per the same
+          // investigation above) and compute cosine similarity ourselves in JS from its
           // real stored `embedding` vector against this query's `qEmb`, via
           // the same math as the ume4 fallback (dedup.ts's cosineSimilarity).
           // Only done on this (rare) undefined-$distance branch — never adds
@@ -412,7 +412,7 @@ export class SemanticSearch extends Resource {
         if (sinceDate && record.createdAt && new Date(record.createdAt) < sinceDate) continue;
         if (asOf && record.validFrom && record.validFrom > asOf) continue;
         if (asOf && record.validTo && record.validTo <= asOf) continue;
-        // ops-9rc6: unconditional past-validTo exclusion (see legacy HNSW
+        // Unconditional past-validTo exclusion (see legacy HNSW
         // loop above for the full rationale) — applies regardless of asOf.
         if (record.validTo && Date.parse(record.validTo) < Date.now()) continue;
 
@@ -458,7 +458,7 @@ export class SemanticSearch extends Resource {
     // Re-scores query+candidate TOGETHER (cross-attention the pooled embedding
     // can't do) and reorders before the final slice. Reorders whatever
     // `filteredResults` the retrieval stage above produced — legacy HNSW-only
-    // OR the BM25+union-RRF hybrid path (ops-i39b) — since both converge into
+    // OR the BM25+union-RRF hybrid path — since both converge into
     // the same `results`/`filteredResults` shape before this point; hybrid
     // retrieves+fuses, the reranker only reorders the fused set. Still gated
     // on `qEmb` (an embedding was actually generated); the pure keyword-only

--- a/resources/WorkspaceLatest.ts
+++ b/resources/WorkspaceLatest.ts
@@ -19,7 +19,7 @@ export class WorkspaceLatest extends Resource {
   async get(pathInfo?: any) {
     // Harper v5 does not populate this.context / this.request on Resource
     // subclasses — getContext() is the only reliable path to the gate's
-    // tpsAgent/tpsAgentIsAdmin annotations (ops-sal4: the previous
+    // tpsAgent/tpsAgentIsAdmin annotations (the previous
     // `(this as any).context?.request ?? (this as any).request` read was always
     // undefined, so the ownership check below never ran — fail-open cross-agent
     // read).

--- a/resources/WorkspaceState.ts
+++ b/resources/WorkspaceState.ts
@@ -27,7 +27,7 @@ export class WorkspaceState extends (databases as any).flair.WorkspaceState {
 
   /**
    * Self-authorize now that the global gate is non-rejecting (memory-soul-
-   * read-gate family fix, ops-oox7 — applying the Memory.ts/Soul.ts pattern
+   * read-gate family fix — applying the Memory.ts/Soul.ts pattern
    * to WorkspaceState/Relationship/Integration/MemoryGrant). Closes the same
    * P0 leak: Harper routes `GET /WorkspaceState/<id>` to get() and the
    * collection describe (`GET /WorkspaceState`) to a path outside search(),

--- a/resources/agent-auth.ts
+++ b/resources/agent-auth.ts
@@ -28,7 +28,7 @@ export const FLAIR_AGENT_USERNAME = "flair-agent";
 
 // ─── Crypto + replay-guard helpers ────────────────────────────────────────────
 // WINDOW_MS, isNonceReplay/recordNonce (the ONE shared nonce store), and
-// importEd25519Key all live in ./ed25519-auth.ts (bd ops-c4op) — the single
+// importEd25519Key all live in ./ed25519-auth.ts — the single
 // shared implementation imported by auth-middleware.ts, agent-auth.ts, and
 // Presence.ts so a nonce recorded via any one of the three call sites is
 // visible to the other two, and the crypto/decoder logic can't drift.

--- a/resources/agentcard-fields.ts
+++ b/resources/agentcard-fields.ts
@@ -9,7 +9,7 @@
 //
 // Kept free of any @harperfast/harper import so the real logic is unit-testable
 // without spinning up Harper (avoids the simulator-pattern that let the
-// description-fallback leak ship untested — ops-vz6j).
+// description-fallback leak ship untested).
 
 export type SoulLike = {
   key?: string;
@@ -30,7 +30,7 @@ export function readSoulContent(entry: SoulLike): string {
  * The public description is ONLY an explicit `kind="description"` soul.
  *
  * There is deliberately no fallback to "the first soul with any content": that
- * was the ops-vz6j leak — an agent with no description soul would publish an
+ * was the description-fallback leak — an agent with no description soul would publish an
  * arbitrary private soul on the unauthenticated card. Absent an explicit
  * description, publish nothing.
  */

--- a/resources/auth-middleware.ts
+++ b/resources/auth-middleware.ts
@@ -43,7 +43,7 @@ function getAdminPass(): string | null {
 
 // ─── Crypto + replay-guard helpers ────────────────────────────────────────────
 // WINDOW_MS, isNonceReplay/recordNonce (the ONE shared nonce store), and
-// importEd25519Key all live in ./ed25519-auth.ts (bd ops-c4op) — the single
+// importEd25519Key all live in ./ed25519-auth.ts — the single
 // shared implementation imported by auth-middleware.ts, agent-auth.ts, and
 // Presence.ts so a nonce recorded via any one of the three call sites is
 // visible to the other two, and the crypto/decoder logic can't drift.
@@ -496,7 +496,7 @@ server.http(async (request: any, nextLayer: any) => {
         if (memId) {
           const record = await (databases as any).flair.Memory.get(memId);
           if (record && record.agentId && record.agentId !== agentId) {
-            // Centralized read-scope (ops-2dm3 Layer 1): a grant only covers
+            // Centralized read-scope (Layer 1): a grant only covers
             // the owner's SHARED memories, never their private ones. This
             // used to be a `visibility === "office"` bypass (any authenticated
             // agent, no grant needed) — that's gone; the private-exclusion is

--- a/resources/bm25-filter.ts
+++ b/resources/bm25-filter.ts
@@ -91,7 +91,7 @@ export function passesRecordFilters(record: any, f: RecordTimeFilters = {}): boo
   if (f.sinceDate && record?.createdAt && new Date(record.createdAt) < f.sinceDate) return false;
   if (f.asOf && record?.validFrom && record.validFrom > f.asOf) return false;
   if (f.asOf && record?.validTo && record.validTo <= f.asOf) return false;
-  // ops-9rc6: a past validTo ALWAYS means the record has been closed out —
+  // A past validTo ALWAYS means the record has been closed out —
   // either by the server supersede path (Memory.ts closeSupersededRecord sets
   // validTo without necessarily setting `archived`) or any other writer. This
   // is unconditional (not gated on `f.asOf`) so a server-superseded record

--- a/resources/bm25.ts
+++ b/resources/bm25.ts
@@ -1,5 +1,5 @@
 // ─── BM25 + union-RRF hybrid retrieval (Harper-free, unit-testable) ──────────
-// Per spec FLAIR-BM25-HYBRID-RETRIEVAL (Kern-approved, ops-i39b). This module is
+// Per spec FLAIR-BM25-HYBRID-RETRIEVAL (Kern-approved). This module is
 // deliberately Harper-free — same rationale as ./scoring.ts — so the BM25
 // scoring, the candidate-union RRF fusion, and the security conditions-filter
 // can be unit-tested directly against the SHIPPED code without a live Harper.

--- a/resources/dedup.ts
+++ b/resources/dedup.ts
@@ -40,10 +40,10 @@ export interface DedupMatch {
  * Cosine similarity of two equal-length embedding vectors, computed directly
  * in JS. Used as a fallback for Harper's HNSW cosine-sort query omitting a
  * computed `$distance` on its top candidate when the query's post-filter
- * result set contains exactly ONE matching record (ops-ume4, found in
+ * result set contains exactly ONE matching record (found in
  * resources/Memory.ts's findConservativeDedupMatch; the identical quirk is
  * also fixed in resources/SemanticSearch.ts's scoring loop for the same
- * reason — see ops-syzm there). A mismatched length, empty vector, or
+ * reason). A mismatched length, empty vector, or
  * zero-magnitude side yields 0 (no signal, never treated as "identical" by a
  * degenerate computation).
  */

--- a/resources/ed25519-auth.ts
+++ b/resources/ed25519-auth.ts
@@ -11,8 +11,8 @@
  * `importEd25519Key`. Three independent replay windows meant a nonce
  * recorded as "seen" via one path was invisible to the other two — a
  * defense-in-depth gap, and a drift hazard (any future fix to one copy
- * silently didn't apply to the other two). bd ops-c4op consolidates all
- * three into this one module so there is exactly ONE replay guard and ONE
+ * silently didn't apply to the other two). Consolidating all three into
+ * this one module means there is exactly ONE replay guard and ONE
  * key-import implementation, imported by all 3 sites.
  *
  * `b64ToArrayBuffer` was already unified into resources/b64.ts in a prior

--- a/resources/embeddings-provider.ts
+++ b/resources/embeddings-provider.ts
@@ -71,7 +71,7 @@ async function ensureInit(): Promise<void> {
     // Not initialized — init with modelsDir pointing at a USER-WRITABLE
     // location. On a sudo/root-owned global install the Flair package dir
     // (process.cwd()) is root-owned, so a model download into <cwd>/models
-    // fails with EACCES and semantic search silently dies (ops-am0v). The
+    // fails with EACCES and semantic search silently dies. The
     // model — and everything else Flair writes — must live under ~/.flair.
     //
     // NOTE: import.meta.dirname and __dirname are both undefined in Harper v5's

--- a/resources/memory-visibility.ts
+++ b/resources/memory-visibility.ts
@@ -1,6 +1,6 @@
 /**
  * ─── The single "is this Memory private" predicate (federation-edge-hardening
- * slice 2 / ops-nzxa: one rule, one place) ───────────────────────────────────
+ * slice 2: one rule, one place) ───────────────────────────────────
  *
  * Shared by BOTH:
  *   - resources/memory-read-scope.ts's resolveReadScope() — the cross-agent

--- a/scripts/harper-watchdog.sh
+++ b/scripts/harper-watchdog.sh
@@ -5,7 +5,7 @@
 # and ALERTS on every state transition (down→recovered, or failure-to-recover) so a
 # Flair-down is KNOWN rather than found by accident.
 #
-# INCIDENT (2026-06-27 ~04:20, ops-6nv7): prod Flair was DOWN — the ai.tpsdev.flair
+# INCIDENT (2026-06-27 ~04:20): prod Flair was DOWN — the ai.tpsdev.flair
 # launchd job was not loaded (no Harper PID). The old watchdog only handled (a):
 # `launchctl kickstart -k` / `start` are NO-OPS on an unloaded job, so (b) silently
 # went unrecovered, AND there was no alert — the outage was found only when a memory
@@ -109,7 +109,7 @@ PREV_STATE=$(read_state)
 if curl -sf --max-time 5 "$HEALTH_URL" -o /dev/null 2>/dev/null; then
   if [ "$PREV_STATE" = "down" ]; then
     write_state "up"
-    alert "✅ **Flair (:${HARPER_PORT}) RECOVERED** — /Health responding again. (ops-6nv7 watchdog)"
+    alert "✅ **Flair (:${HARPER_PORT}) RECOVERED** — /Health responding again. (watchdog)"
   fi
   exit 0
 fi
@@ -170,19 +170,19 @@ if [ "$RECOVERED" -eq 0 ] && [ "$HEALTH_BACK" -eq 0 ]; then
   # Recovery action ran and /Health is back. Mark up so CASE 1 stays quiet.
   if [ "$PREV_STATE" != "up" ]; then
     write_state "up"
-    alert "✅ **Flair (:${HARPER_PORT}) RECOVERED by watchdog** — was down: ${RECOVERY_DESC}. /Health responding again. (ops-6nv7)"
+    alert "✅ **Flair (:${HARPER_PORT}) RECOVERED by watchdog** — was down: ${RECOVERY_DESC}. /Health responding again. (watchdog)"
   else
     # We were "up", briefly dipped, and self-healed within this tick. Announce the
     # blip once so it's not invisible, then stay up.
     write_state "up"
-    alert "⚠️ **Flair (:${HARPER_PORT}) self-healed** — transient outage recovered within one watchdog tick: ${RECOVERY_DESC}. (ops-6nv7)"
+    alert "⚠️ **Flair (:${HARPER_PORT}) self-healed** — transient outage recovered within one watchdog tick: ${RECOVERY_DESC}. (watchdog)"
   fi
 else
   # Either the recovery action failed, OR /Health is still dead after acting.
   # Alert ONLY on the up→down transition (first failure); suppress repeats while down.
   if [ "$PREV_STATE" != "down" ]; then
     write_state "down"
-    alert "🚨 **Flair (:${HARPER_PORT}) DOWN** — recovery attempted (${RECOVERY_DESC}) but /Health still failing. Manual intervention may be needed: launchctl bootstrap gui/\$(id -u) ~/Library/LaunchAgents/${LAUNCHD_LABEL}.plist. Check ${LOG}. (ops-6nv7)"
+    alert "🚨 **Flair (:${HARPER_PORT}) DOWN** — recovery attempted (${RECOVERY_DESC}) but /Health still failing. Manual intervention may be needed: launchctl bootstrap gui/\$(id -u) ~/Library/LaunchAgents/${LAUNCHD_LABEL}.plist. Check ${LOG}. (watchdog)"
   else
     log "still DOWN (${RECOVERY_DESC}) — already alerted on transition, suppressing repeat"
   fi

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -223,7 +223,7 @@ echo "🔒 Refreshing bun.lock..."
 (cd "$ROOT" && bun install) || { echo "❌ bun install failed"; exit 1; }
 
 # 3b. `bun install` does NOT rewrite the workspace internal-dep specifiers in
-# bun.lock's per-package sections (ops-i9w8): the leaf packages (langgraph/n8n/
+# bun.lock's per-package sections: the leaf packages (langgraph/n8n/
 # openclaw/pi-flair) keep the OLD @tpsdev-ai/flair-client version even though
 # their package.json now declares $VERSION. `bun install` above passes, so it
 # looks clean — but any downstream `--frozen-lockfile` install fails on the
@@ -234,10 +234,10 @@ echo "🔒 Refreshing bun.lock..."
 # untouched — the regex only matches the "x.y.z" version-string form), then
 # HARD-VERIFY with --frozen-lockfile so a residual desync fails the release loud
 # instead of silently shipping a broken lockfile.
-echo "🔗 Aligning bun.lock internal-dep specifiers (ops-i9w8)..."
+echo "🔗 Aligning bun.lock internal-dep specifiers..."
 perl -i -pe 's{("\@tpsdev-ai/flair-client":\s*")\d+\.\d+\.\d+(")}{${1}'"$VERSION"'${2}}g' "$ROOT/bun.lock"
 (cd "$ROOT" && bun install --frozen-lockfile) || {
-  echo "❌ bun.lock still desynced after specifier alignment (ops-i9w8) — investigate before releasing."; exit 1;
+  echo "❌ bun.lock still desynced after specifier alignment — investigate before releasing."; exit 1;
 }
 
 # 4. Build

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -782,7 +782,7 @@ export async function seedFederationInstanceViaOpsApi(
   }
 }
 
-// ─── Provision Flair on Harper Fabric (ops-2kyi) ───────────────────────────
+// ─── Provision Flair on Harper Fabric ──────────────────────────────────────
 //
 // Atomic provisioning for a fresh Harper Fabric cluster: builds a deploy
 // tarball with .env baked in, deploys via ops API, waits for restart, and
@@ -904,7 +904,7 @@ export async function provisionFabric(
   console.log("Flair is running ✓");
 
   // 3. Provision Harper super_user
-  // Since ops-lzmg is merged, the username doesn't have to be "admin".
+  // Since custom-admin-username support is merged, the username doesn't have to be "admin".
   // We can use the cluster-admin user directly if it's already a super_user.
   // Check if cluster admin is already a super_user first:
   let clusterAdminIsSuperUser = false;
@@ -1330,7 +1330,7 @@ export type UpgradeStatus = "current" | "outdated" | "missing" | "optional";
 /**
  * Whether a package's status line should be printed in the default `flair
  * upgrade` listing. Suppresses optional-because-openclaw-is-absent lines
- * (ops-p42n) — pure noise on machines without openclaw — unless `--all`
+ * — pure noise on machines without openclaw — unless `--all`
  * (showAll) is set. All other statuses always print.
  */
 export function shouldPrintUpgradeLine(status: UpgradeStatus, showAll: boolean): boolean {
@@ -4025,7 +4025,7 @@ export async function runFederationSyncOnce(opts: any): Promise<{ pushed: number
     }
 
     if (totalBatches === 0) {
-      // ops-c7t9: no-change syncs must still ping the hub so it updates the
+      // No-change syncs must still ping the hub so it updates the
       // spoke's lastSyncAt (liveness). Without this, idle-but-alive spokes
       // look indistinguishable from dead ones on the hub dashboard.
       try {
@@ -5316,7 +5316,7 @@ function oauthDetailLines(o: any): string[] {
 
 // Common localhost ports a running Flair daemon might be on. Used by
 // discoverLocalFlairPort when the configured URL is unreachable, to detect
-// config-vs-daemon port drift (ops-mbdi). Order is ad-hoc — first hit wins.
+// config-vs-daemon port drift. Order is ad-hoc — first hit wins.
 //
 // 9926: original default (long-running early installs predate the bump)
 // 19926: current default (DEFAULT_PORT)
@@ -5432,7 +5432,7 @@ const statusCmd = program
     const { healthy, baseUrl, healthData } = await fetchHealthDetail(opts);
 
     // When unreachable on a localhost URL, probe candidate ports to detect
-    // config-vs-daemon port drift (ops-mbdi). Surface the actually-listening
+    // config-vs-daemon port drift. Surface the actually-listening
     // port with a fix recipe — better UX than just "unreachable."
     let discoveredPort: number | null = null;
     if (!healthy && isLocalhostUrl(baseUrl)) {
@@ -6258,11 +6258,11 @@ program
     //
     // Default UI shows the npm-global packages (flair, flair-mcp) plus
     // openclaw-flair WHEN openclaw is installed. On machines without openclaw
-    // the openclaw-flair line is suppressed entirely (ops-p42n) rather than
+    // the openclaw-flair line is suppressed entirely rather than
     // nagging with an install hint for a plugin the user can't use. flair-client
     // is a transitive dep of flair-mcp and showing it as a top-level upgrade
     // item invites a misleading "❔ missing — install with npm install -g"
-    // suggestion for users who installed flair without flair-mcp (ops-h5cd).
+    // suggestion for users who installed flair without flair-mcp.
     // --all opts in to both flair-client and the suppressed openclaw line.
     type ProbeKind = "bin" | "lib" | "openclaw-plugin";
     const packages: Array<{
@@ -6281,7 +6281,7 @@ program
         kind: "bin",
         // Older flair-mcp installs (e.g. 0.10.0) either aren't on PATH or
         // don't support `--version`, so the bin probe returns null even when
-        // the package IS globally installed (ops-p42n). Fall back to the lib
+        // the package IS globally installed. Fall back to the lib
         // probe, which require.resolves the package.json from a sibling global
         // install regardless of PATH or --version support. kind stays "bin" so
         // it remains npm-upgradeable (npm install -g), not the openclaw path.
@@ -6326,7 +6326,7 @@ program
         findings.push({ name, installed, latest, status, kind });
 
         // Suppress the line for openclaw plugins that are optional-because-
-        // openclaw-is-absent (ops-p42n): on machines without openclaw the
+        // openclaw-is-absent: on machines without openclaw the
         // "○ … not installed (openclaw not detected) → … (install via …)"
         // line is pure noise. Still print it when openclaw IS installed
         // (current/outdated) or under --all.
@@ -6345,7 +6345,7 @@ program
       } catch { /* skip unavailable packages */ }
     }
 
-    // Scope footer (ops-p42n): make explicit what `flair upgrade` does and
+    // Scope footer: make explicit what `flair upgrade` does and
     // doesn't cover, so "were the others checked?" has a one-line answer.
     console.log("\nScope: npm-global packages (flair, flair-mcp) + openclaw plugins. Other integrations (pi-flair, langgraph-flair, n8n-nodes-flair, hermes-flair) upgrade in their own ecosystems (pi / pip / n8n).");
 
@@ -7380,7 +7380,7 @@ program
   });
 
 // ─── flair session snapshot ──────────────────────────────────────────────────
-// Slice 2 of FLAIR-AGENT-CONTEXT-TIERS-B (ops-9wji-B / ops-ojht). Snapshot a
+// Slice 2 of FLAIR-AGENT-CONTEXT-TIERS-B. Snapshot a
 // session jsonl + label metadata into a tar.gz under ~/.flair/snapshots/<agent>/sessions/.
 //
 // Three subcommands: create | list | restore. Mirrors FLAIR-NIGHTLY-REM's
@@ -7534,7 +7534,7 @@ const memory = program.command("memory").description("Manage agent memories");
 memory.command("add [content]").requiredOption("--agent <id>")
   .option("--content <text>", "memory content (alias for positional arg)")
   .option("--durability <d>", "standard").option("--tags <csv>")
-  .option("--summary <text>", "agent-set multi-sentence dense compression (3-tier chain: subject → summary → content; ops-wkoh)")
+  .option("--summary <text>", "agent-set multi-sentence dense compression (3-tier chain: subject → summary → content)")
   .option("--subject <text>", "one-line title / entity this memory is about")
   .option("--derived-from <csv>", "Comma-separated source Memory IDs this memory was distilled/reflected from (sets Memory.derivedFrom; used by the `rem rapid` reflection loop)")
   .option("--visibility <value>", "Writer-controlled sharing intent (sets Memory.visibility): 'private' (owner-only, never visible to any other agent) or 'shared' (visible to owner + every other agent on this instance — open within the org, not gated by a MemoryGrant). Omit to use the server's durability-keyed default: permanent/persistent -> shared, standard/ephemeral -> private (flair#509)")
@@ -7557,7 +7557,7 @@ memory.command("add [content]").requiredOption("--agent <id>")
     console.log(JSON.stringify(out, null, 2));
   });
 // ─── flair memory write-task-summary ────────────────────────────────────────
-// Slice 1 of FLAIR-AGENT-CONTEXT-TIERS-B (ops-9wji-B / ops-3xyd). Standalone
+// Slice 1 of FLAIR-AGENT-CONTEXT-TIERS-B. Standalone
 // helper that any agent harness (or a manual operator) can invoke at task
 // close to capture a structured task summary as a persistent Memory row
 // before resetting the session.
@@ -7575,7 +7575,7 @@ memory.command("add [content]").requiredOption("--agent <id>")
 memory.command("write-task-summary")
   .description("Capture a structured task summary as a persistent Memory row (used by session-reset harness; standalone-callable by operators)")
   .requiredOption("--agent <id>", "Agent the summary belongs to")
-  .requiredOption("--beads <ops-id>", "Bead/PR/task identifier this summary is about (e.g. ops-3xyd)")
+  .requiredOption("--beads <ops-id>", "Bead/PR/task identifier this summary is about")
   .requiredOption("--outcome <s>", "Outcome of the task: merged | rejected | abandoned")
   .option("--summary <text>", "Multi-sentence dense compression (populates Memory.summary; will be the agent's read-time view)")
   .option("--files-touched <csv>", "Comma-separated list of files touched during the task (becomes part of content)")
@@ -7774,7 +7774,7 @@ memory.command("list")
 
 // ─── flair memory hygiene ────────────────────────────────────────────────────
 // Detect + remove junk memory rows that accumulate over time. Surfaced from
-// the 2026-05-07 manual cleanup (ops-ucyy): an instance had 627 records, ~250 of
+// a 2026-05-07 manual cleanup: an instance had 627 records, ~250 of
 // them were noise — `*-compact-*` ID fragments from an old pipeline, pangram
 // test content ("the quick brown fox..." / "Flair 251 test ..."), and
 // near-empty rows (<25 chars). We did the cleanup ad-hoc with raw curl + jq;
@@ -7789,8 +7789,8 @@ memory.command("list")
 // Default is all three, dry-run. Flip --apply to actually delete. Always
 // requires admin pass to read across agent scopes (uses ops API).
 //
-// Federation note: this only deletes on the local instance. ops-esun
-// (federation distributed-delete via tombstones) is the systemic answer for
+// Federation note: this only deletes on the local instance. Federation
+// distributed-delete via tombstones is the systemic answer for
 // fan-out — until that lands, run `flair memory hygiene` on each peer.
 
 // Exported for unit testing — keeps the predicate logic separable from
@@ -7927,7 +7927,7 @@ memory.command("hygiene")
     console.log(`\n\n✅ Deleted ${deleted} rows.`);
     console.log("");
     console.log("Note: this is a local-instance delete. Federated peers will keep their copies until");
-    console.log("ops-esun (tombstone-based distributed delete) lands. Until then, run `flair memory");
+    console.log("tombstone-based distributed delete lands. Until then, run `flair memory");
     console.log("hygiene --apply` on each peer to fan out.");
   });
 
@@ -9728,7 +9728,7 @@ presence
 
 // ─── flair workspace ─────────────────────────────────────────────────────────
 //
-// Coordination write surface (ops-wmgx / Kris #510). `workspace set` writes the
+// Coordination write surface (Kris #510). `workspace set` writes the
 // agent's OWN WorkspaceState via a signed POST /WorkspaceState. Identity comes
 // from the Ed25519 signature — the body carries NO agentId, so an agent can only
 // write as itself (the WorkspaceState.post() handler overwrites agentId from the
@@ -9805,7 +9805,7 @@ workspace
 
 // ─── flair orgevent ──────────────────────────────────────────────────────────
 //
-// Coordination write surface (ops-wmgx / Kris #510). `orgevent` publishes an
+// Coordination write surface (Kris #510). `orgevent` publishes an
 // OrgEvent ATTRIBUTED to the authenticated agent via a signed POST /OrgEvent.
 // The event's authorId comes from the Ed25519 signature — the body carries NO
 // authorId, so an agent CANNOT forge another agent's events (the OrgEvent.post()

--- a/src/deploy.ts
+++ b/src/deploy.ts
@@ -29,7 +29,7 @@ export interface DeployOptions {
   verify?: boolean;
   verifyResources?: string[];
   verifyTimeoutMs?: number;
-  // ops-2i8x: flaky-peer-replication resilience. A real Fabric deploy hit
+  // Flaky-peer-replication resilience. A real Fabric deploy hit
   // "Component 'flair' was deployed on the origin node but failed to
   // replicate to 1 of 1 peer node(s): ... (Error: Connection closed 1006)"
   // and hard-exited 1 — a bare manual re-run cleared it with no other
@@ -74,7 +74,7 @@ export interface DeployResult {
   packageRoot: string;
   dryRun: boolean;
   // true iff the deploy only succeeded because a peer-replication failure
-  // was accepted via --ignore-replication-errors (ops-2i8x) — the origin
+  // was accepted via --ignore-replication-errors — the origin
   // node has the component, at least one peer does not (yet).
   replicationWarning?: boolean;
 }
@@ -285,7 +285,7 @@ export function buildHarperDeployArgs(
     `deployment_timeout=${deploymentTimeoutMs}`,
     `install_timeout=${installTimeoutMs}`,
   ];
-  // ops-2i8x: --ignore-replication-errors escape hatch. Only appended when
+  // --ignore-replication-errors escape hatch. Only appended when
   // set — omitted entirely otherwise, so this is a no-op for every existing
   // caller/test that doesn't pass it.
   if (opts.ignoreReplicationErrors) {
@@ -294,7 +294,7 @@ export function buildHarperDeployArgs(
   return args;
 }
 
-// ops-2i8x: flaky-peer-replication resilience defaults. See DeployOptions
+// Flaky-peer-replication resilience defaults. See DeployOptions
 // for the full incident writeup this closes.
 export const DEFAULT_DEPLOY_RETRIES = 2;
 export const DEPLOY_RETRY_BACKOFF_MS = [5_000, 10_000];

--- a/src/rem/restore.ts
+++ b/src/rem/restore.ts
@@ -273,7 +273,7 @@ export async function applySnapshot(opts: RestoreOpts): Promise<RestoreResult> {
   //    Catches silent failures: Harper schema coercion, 4xx responses the
   //    apiCall layer masked as ok, partial-DELETE leftovers. Per-ID diff,
   //    not just counts — count parity can hide simultaneous PUT+DELETE
-  //    failures that wash out numerically. See ops-90dq.
+  //    failures that wash out numerically.
   if (opts.verifyPostRestore !== false) {
     try {
       const verifyMem = asArray(await opts.apiCall("GET", `/Memory?agentId=${encodeURIComponent(opts.agentId)}`));

--- a/test/backup-restore.test.ts
+++ b/test/backup-restore.test.ts
@@ -378,7 +378,7 @@ describe("flair restore", () => {
   });
 });
 
-// ─── readAdminPassFileSecure — ops-smft ───────────────────────────────────────
+// ─── readAdminPassFileSecure — refuses world/group-readable admin-pass files ──
 
 describe("readAdminPassFileSecure", () => {
   let tmpDir: string;

--- a/test/helpers/harper-lifecycle.ts
+++ b/test/helpers/harper-lifecycle.ts
@@ -11,7 +11,7 @@ const MAX_SPAWN_ATTEMPTS = 3;
 // Harper logs exactly this ("Unable to bind to port NNNNN: Address already in
 // use") when its HTTP/ops listener can't bind, but it STILL prints "successfully
 // started" — so without detecting it, the health poll hammers a dead port for the
-// full 60s timeout and the test fails at ~64s (the ops-wumd flake: a random port
+// full 60s timeout and the test fails at ~64s (a random port
 // occasionally collided with an in-use one).
 //
 // Match ONLY Harper's specific bind-failure message — NOT a bare "address already
@@ -205,7 +205,7 @@ export async function startHarper(): Promise<HarperInstance> {
     ROOTPATH: installDir,
     HOME: installDir,               // isolate from system Harper install (~/.harperdb)
     // Point the embeddings model dir at the repo-root models/ that CI / local
-    // runs pre-download into (the FLAIR_MODELS_DIR override; see ops-am0v and
+    // runs pre-download into (the FLAIR_MODELS_DIR override; see
     // resources/embeddings-provider.ts:resolveModelsDir). Without this, the fix's
     // new default — <ROOTPATH>/models, i.e. the fresh temp installDir — would
     // re-download the ~80MB model on every startHarper (HuggingFace 429-prone,

--- a/test/integration/auth-middleware-e2e.test.ts
+++ b/test/integration/auth-middleware-e2e.test.ts
@@ -1,4 +1,4 @@
-// auth-middleware e2e — real-Harper integration tests (ops-ketv).
+// auth-middleware e2e — real-Harper integration tests.
 //
 // Replaces the simulator-based unit tests (simulateAuthMiddleware + super_user/
 // getUser mock blocks) with real HTTP requests against a live Harper instance.
@@ -84,12 +84,12 @@ async function adminOp(
 
 let harper: HarperInstance;
 const agent = mkAgent("auth-e2e-agent");
-// Second agent for the family read-gate cross-agent 404 checks (ops-oox7).
+// Second agent for the family read-gate cross-agent 404 checks.
 const agent2 = mkAgent("auth-e2e-agent-2");
 
-// ─── Family read-gate fixtures (ops-oox7) ────────────────────────────────────
+// ─── Family read-gate fixtures ────────────────────────────────────────────
 // WorkspaceState/Relationship/Integration/MemoryGrant — same P0 leak as
-// Memory.ts/Soul.ts (e1e3012, ops-ckrr): each gated write+search but had no
+// Memory.ts/Soul.ts (e1e3012): each gated write+search but had no
 // allowRead()/get() override, so anonymous GET /<Resource>/<id> and the
 // collection describe GET /<Resource> both returned 200 with full record
 // content. One record per table, owned by `agent`, seeded via direct DB
@@ -157,7 +157,7 @@ describe("auth-middleware e2e (real Harper)", () => {
     });
     expect(agentRes.status).toBe(200);
 
-    // 2b. Second agent (ops-oox7 family read-gate cross-agent checks).
+    // 2b. Second agent (family read-gate cross-agent checks).
     const agent2Res = await adminOp(harper, {
       operation: "insert",
       database: "flair",
@@ -249,14 +249,14 @@ describe("auth-middleware e2e (real Harper)", () => {
   // return resource-level errors (400 for missing body), not 401.
   // /FederationPair and /FederationSync remain excluded (public allowlist,
   // above). /Soul GET now DOES enforce auth via allowRead()=allowVerified
-  // (ops-ckrr read-gate fix) — it has its own invariant below.
+  // — it has its own invariant below.
   // ═══════════════════════════════════════════════════════════════════════════
 
   test("AUTH INVARIANT: no Authorization header on /Memory → 403 (allowRead gate denies anonymous table access, like /Agent)", async () => {
     const res = await fetch(
       `${harper.httpURL}/Memory/?agentId=${agent.id}`,
     );
-    // Post-ops-ckrr: Memory defines allowRead()=allowVerified to close the
+    // Post-fix: Memory defines allowRead()=allowVerified to close the
     // by-id / collection-describe anonymous-read leak that search()'s custom
     // 401 never covered (search() only guarded the query path). Anonymous
     // reads are now denied at Harper's allow-gate with 403 — the same
@@ -266,7 +266,7 @@ describe("auth-middleware e2e (real Harper)", () => {
 
   test("AUTH INVARIANT: no Authorization header on /Soul → 403 (allowRead gate denies anonymous table access)", async () => {
     const res = await fetch(`${harper.httpURL}/Soul`);
-    // Post-ops-ckrr: Soul defines allowRead()=allowVerified (previously GET
+    // Post-fix: Soul defines allowRead()=allowVerified (previously GET
     // enforced nothing — the anonymous-read leak Sherlock's sweep flagged).
     expect(res.status).toBe(403);
   }, 30_000);
@@ -475,7 +475,7 @@ describe("auth-middleware e2e (real Harper)", () => {
   }, 30_000);
 
   // ═══════════════════════════════════════════════════════════════════════════
-  // bd ops-c4op — shared nonce store consolidation (3 independent nonceSeen
+  // Shared nonce store consolidation (3 independent nonceSeen
   // Maps -> resources/ed25519-auth.ts, one singleton). Real HTTP replay
   // coverage for auth-middleware.ts's Ed25519 branch didn't previously exist
   // (only unit-level simulator logic did). Real-Harper is also the only place
@@ -544,9 +544,9 @@ describe("auth-middleware e2e (real Harper)", () => {
   }, 30_000);
 
   // ═══════════════════════════════════════════════════════════════════════════
-  // FAMILY READ-GATE (ops-oox7): WorkspaceState / Relationship / Integration /
+  // FAMILY READ-GATE: WorkspaceState / Relationship / Integration /
   // MemoryGrant — applying the Memory.ts/Soul.ts allowRead()+get() pattern
-  // (e1e3012, ops-ckrr) to the remaining agent-owned @table resources that had
+  // (e1e3012) to the remaining agent-owned @table resources that had
   // the identical anonymous by-id / collection-describe read leak. These are
   // REAL-Harper invariants exercising the actual RequestTarget routing
   // (isCollection branch) that a mocked unit test cannot — see get()'s doc

--- a/test/integration/bootstrap-supersede-resurface.test.ts
+++ b/test/integration/bootstrap-supersede-resurface.test.ts
@@ -1,8 +1,8 @@
-// ops-hesq — a server-superseded Memory record resurfaces in the DEFAULT
+// A server-superseded Memory record resurfaces in the DEFAULT
 // /BootstrapMemories recall path when its successor isn't co-present in
 // bootstrap's own candidate set.
 //
-// Root cause: identical to ops-9rc6 (PR #566), a different endpoint.
+// Root cause: identical to the fix in PR #566, a different endpoint.
 // resources/MemoryBootstrap.ts's Memory loop only ever excluded a record via
 // `expiresAt` — never via `validTo`. The server supersede path
 // (Memory.ts closeSupersededRecord, exercised via PUT /Memory/<id> with
@@ -21,11 +21,11 @@
 //
 // Fix: an unconditional per-record exclusion in the Memory loop —
 // `validTo` set AND in the past (relative to real `Date.now()`) — the SAME
-// idiom ops-9rc6 added to resources/SemanticSearch.ts / resources/bm25-filter.ts.
+// idiom PR #566 added to resources/SemanticSearch.ts / resources/bm25-filter.ts.
 // Applies regardless of co-presence. A record with no `validTo`, or a FUTURE
 // `validTo`, is unaffected — this test asserts that boundary too (controls C/D).
 //
-// Pattern: test/integration/supersede-recall-resurface.test.ts (ops-9rc6),
+// Pattern: test/integration/supersede-recall-resurface.test.ts (PR #566),
 // adapted for /BootstrapMemories — whose response has no per-record id list,
 // so assertions match on content substrings inside `body.context`.
 import { describe, expect, test, beforeAll, afterAll } from "bun:test";
@@ -94,19 +94,19 @@ async function bootstrap(harper: HarperInstance, agent: TestAgent, body: Record<
 }
 
 let harper: HarperInstance;
-const agent = mkAgent(`ops-hesq-${randomUUID()}`);
+const agent = mkAgent(`bootstrap-resurface-${randomUUID()}`);
 
 const ID_A = `${agent.id}-a`; // superseded (server path), successor later deleted — must NOT resurface
 const ID_B = `${agent.id}-b`; // successor — deleted after closing A, to force genuine non-co-presence
 const ID_C = `${agent.id}-c`; // control: never superseded, no validTo — must still surface
 const ID_D = `${agent.id}-d`; // control: FUTURE validTo, never superseded — must still surface
 
-const CONTENT_A = "ops-hesq marker: the Q2 vendor contract renewal was approved at the March review.";
-const CONTENT_B = "ops-hesq marker: transient successor record, deleted immediately after closing A.";
-const CONTENT_C = "ops-hesq marker: the office lease renewal was signed off by facilities in April.";
-const CONTENT_D = "ops-hesq marker: the annual compliance audit is scheduled for next winter.";
+const CONTENT_A = "bootstrap-resurface marker: the Q2 vendor contract renewal was approved at the March review.";
+const CONTENT_B = "bootstrap-resurface marker: transient successor record, deleted immediately after closing A.";
+const CONTENT_C = "bootstrap-resurface marker: the office lease renewal was signed off by facilities in April.";
+const CONTENT_D = "bootstrap-resurface marker: the annual compliance audit is scheduled for next winter.";
 
-describe("ops-hesq — server-superseded (validTo, not archived) Memory record must not resurface in bootstrap", () => {
+describe("server-superseded (validTo, not archived) Memory record must not resurface in bootstrap", () => {
   beforeAll(async () => {
     harper = await startHarper();
     await registerAgent(harper, agent);
@@ -127,7 +127,7 @@ describe("ops-hesq — server-superseded (validTo, not archived) Memory record m
     expect(bodyB.written).toBe(true);
 
     // Confirm the server actually closed A (validTo set) — the documented
-    // ops-9rc6/ops-hesq mechanism (Memory.ts closeSupersededRecord), NOT archived.
+    // closeSupersededRecord mechanism (Memory.ts), NOT archived.
     const getA = await getMemory(harper, agent, ID_A);
     expect(getA.status).toBe(200);
     const recA: any = await getA.json();

--- a/test/integration/bootstrap-teammate-findings-e2e.test.ts
+++ b/test/integration/bootstrap-teammate-findings-e2e.test.ts
@@ -1,8 +1,8 @@
-// flair#550 (ops-q6i5, Presentation Layer) — bootstrap's "Teammate findings
+// flair#550 (Presentation Layer) — bootstrap's "Teammate findings
 // relevant to your task" section: real-Harper, real-embedding end-to-end
 // coverage of the gap this feature closes.
 //
-// Layer 1 (ops-2dm3, already merged) made a grant-visible teammate's SHARED
+// Layer 1 (the resolveReadScope no-grants simplification, already merged) made a grant-visible teammate's SHARED
 // memory reachable through bootstrap's read scope and scored it against
 // currentTask alongside the caller's own memories — but it rendered
 // identically to the caller's own memory (no attribution) and landed in the

--- a/test/integration/credential-delete-authz.test.ts
+++ b/test/integration/credential-delete-authz.test.ts
@@ -1,5 +1,5 @@
 // Credential.delete() cross-agent authorization — real-Harper integration
-// test (follow-up to ops-sgjr / #569).
+// test (follow-up to the Relationship.delete() authz investigation, #569).
 //
 // Credential.ts's delete() (~line 112) has the byte-identical non-admin
 // ownership guard that Relationship.delete() had — it calls `super.get()` with
@@ -14,7 +14,7 @@
 //   }
 //   return super.delete(_);                            // _ is the real target
 //
-// INVESTIGATED: same conclusion as Relationship (ops-sgjr, #569) — this is NOT
+// INVESTIGATED: same conclusion as Relationship (#569) — this is NOT
 // a bypass, verified against a real Harper instance below. Harper's REST layer
 // resolves a Table resource instance to the URL's id via
 // getResource()->_loadRecord() (Table.ts) BEFORE calling ANY instance method
@@ -113,7 +113,7 @@ async function getCredentialAsAdmin(id: string): Promise<any> {
   return Array.isArray(body) && body.length > 0 ? body[0] : null;
 }
 
-describe("Credential.delete() cross-agent authorization (ops-sgjr follow-up)", () => {
+describe("Credential.delete() cross-agent authorization (follow-up to the Relationship.delete() authz investigation)", () => {
   beforeAll(async () => {
     harper = await startHarper();
 

--- a/test/integration/dedup-supersede-e2e.test.ts
+++ b/test/integration/dedup-supersede-e2e.test.ts
@@ -1,4 +1,4 @@
-// dedup / supersede / memory_update e2e — real-Harper integration tests (ops-2gby).
+// dedup / supersede / memory_update e2e — real-Harper integration tests.
 //
 // PR #553 fixed a memory-integrity bug (silent-write-loss on the dedup/
 // supersede path) with: a cosine+lexical co-gate for dedup, a memory_update
@@ -97,7 +97,8 @@ async function registerAgent(harper: HarperInstance, agent: TestAgent): Promise<
 /**
  * ═══════════════════════════════════════════════════════════════════════════
  * DISCOVERED BEHAVIORAL DIVERGENCE (real Harper vs. the mocked unit suite) —
- * ops-2gby's original reason for existing, RESOLVED by ops-ume4.
+ * this suite's original reason for existing, RESOLVED by the
+ * findConservativeDedupMatch singleton-candidate cosine fix described below.
  *
  * test/unit/memory-integrity.test.ts's in-memory mock computes the cosine
  * "$distance" synchronously in plain JS (a real, always-populated number) for
@@ -116,7 +117,7 @@ async function registerAgent(harper: HarperInstance, agent: TestAgent): Promise<
  * `$distance` silently resolved to `cosine = 0` — below any sane threshold —
  * meaning EVERY agent's very first near-duplicate comparison, ever, was
  * GUARANTEED to be flagged `deduplicated: false` regardless of true
- * similarity (ops-ume4).
+ * similarity.
  *
  * This was NOT the never-suppress write-safety invariant breaking — the
  * WRITE always landed. It was the `deduplicated` SIGNAL silently failing to
@@ -191,7 +192,7 @@ const FINDING_A_REWORDED =
 
 let harper: HarperInstance;
 
-describe("dedup / supersede / memory_update e2e (real Harper, ops-2gby)", () => {
+describe("dedup / supersede / memory_update e2e (real Harper)", () => {
   beforeAll(async () => {
     harper = await startHarper();
   }, 180_000);
@@ -248,12 +249,13 @@ describe("dedup / supersede / memory_update e2e (real Harper, ops-2gby)", () => 
   }, 60_000);
 
   // ═══════════════════════════════════════════════════════════════════════
-  // Scenario 2 — never-silent-loss AND ops-ume4 regression guard: a true
+  // Scenario 2 — never-silent-loss AND findConservativeDedupMatch singleton-
+  // candidate-cosine regression guard: a true
   // near-duplicate is FLAGGED (deduplicated:true + matchedId) but STILL
   // written as a brand-new record with the reworded content intact (never
   // swapped for the old record's content). This agent's near-dup write below
   // is its SECOND memory ever (compared against its first, idOrig) — exactly
-  // the singleton-candidate-set query ops-ume4 fixed (before the fix, this
+  // the singleton-candidate-set query findConservativeDedupMatch fixed (before the fix, this
   // exact shape was a GUARANTEED miss: `deduplicated:false` regardless of
   // true similarity, on every fresh agent's first near-dup comparison, with
   // no warm-up query able to change that). No warm-up write precedes this
@@ -269,7 +271,7 @@ describe("dedup / supersede / memory_update e2e (real Harper, ops-2gby)", () => 
   // + real HNSW cosine search + real jaccard) wired correctly, using the
   // exact knob production callers use to tune it.
   // ═══════════════════════════════════════════════════════════════════════
-  test("Scenario 2 (ops-ume4): a FRESH agent's FIRST-EVER near-duplicate write is flagged deduplicated:true + matchedId, AND still written as a new record with the reworded content", async () => {
+  test("Scenario 2 (singleton-candidate cosine fix): a FRESH agent's FIRST-EVER near-duplicate write is flagged deduplicated:true + matchedId, AND still written as a new record with the reworded content", async () => {
     const agent = mkAgent(`dedup-nearmatch-${randomUUID()}`);
     await registerAgent(harper, agent);
 
@@ -310,7 +312,7 @@ describe("dedup / supersede / memory_update e2e (real Harper, ops-2gby)", () => 
     expect(bodyReword.id).toBe(idReword);
 
     // The collision signal fired against the REAL top-cosine candidate. Per
-    // ops-ume4: this query's underlying result set is a SINGLETON (exactly
+    // Singleton-candidate cosine fix: this query's underlying result set is a SINGLETON (exactly
     // one candidate, idOrig) — the case where Harper's raw `$distance` field
     // itself is undefined BY DESIGN (that never changes; findConservativeDedupMatch's
     // fix doesn't make Harper populate it, it computes cosine itself from the

--- a/test/integration/ed25519-auth-hnsw.test.ts
+++ b/test/integration/ed25519-auth-hnsw.test.ts
@@ -77,7 +77,7 @@ describe("Ed25519 → HNSW auth path (flair#457 / regression guard for #456)", (
     const res = await fetch(`${harper.httpURL}/Memory/?agentId=${agent.id}`);
     // If this returns 200, the harness is authorizeLocal-bypassing and the
     // Ed25519 assertions below would be theater — fail loudly so we notice.
-    // Post-ops-ckrr: Memory's allowRead()=allowVerified denies anonymous reads
+    // Post-fix: Memory's allowRead()=allowVerified denies anonymous reads
     // at Harper's allow-gate with 403 (was search()'s 401 before the read-gate
     // fix, which only covered the query path). The invariant — anonymous is
     // DENIED, not bypassed — is unchanged; only the denial code moved 401→403,

--- a/test/integration/flair-agent-deelevation.test.ts
+++ b/test/integration/flair-agent-deelevation.test.ts
@@ -189,7 +189,7 @@ describe("flair_agent de-elevation (verified agents act as flair-agent, not admi
     expect([401, 403], `admin /MemoryReindex returned ${res.status} (expected authorized)`).not.toContain(res.status);
   }, 30_000);
 
-  // ops-oox7: Admin* custom (non-@table) Resources previously had NO
+  // Admin* custom (non-@table) Resources previously had NO
   // resource-level read gate at all — reachability depended entirely on the
   // auth-middleware's /Admin* pathname check, which only 401s when there's NO
   // Authorization header. A validly-verified NON-admin agent (real TPS-Ed25519

--- a/test/integration/init-remote-ops.test.ts
+++ b/test/integration/init-remote-ops.test.ts
@@ -1,6 +1,6 @@
 /**
- * init-remote-ops-2kyi.test.ts — Integration tests for the atomic
- * `flair init --remote` provisioning flow (ops-2kyi).
+ * init-remote-ops.test.ts — Integration tests for the atomic
+ * `flair init --remote` provisioning flow.
  *
  * Mocks fetch() to simulate the ops API and Flair REST endpoints.
  * Verifies operation ordering, idempotence, timeout handling, and

--- a/test/integration/relationship-delete-authz.test.ts
+++ b/test/integration/relationship-delete-authz.test.ts
@@ -1,5 +1,5 @@
 // Relationship.delete() cross-agent authorization — real-Harper integration
-// test (ops-sgjr).
+// test.
 //
 // Relationship.ts's delete() (~line 144) has a non-admin ownership guard that
 // calls `super.get()` with NO id argument before allowing the delete:
@@ -12,7 +12,7 @@
 //   }
 //   return super.delete(_);                            // _ is the real target
 //
-// INVESTIGATED (ops-sgjr): this LOOKS like an authz bypass (get() with no id
+// INVESTIGATED: this LOOKS like an authz bypass (get() with no id
 // vs. the correctly-threaded `super.get(target)` in get() at ~line 39-69),
 // but it is NOT — verified against a real Harper instance below. Harper's REST
 // layer resolves a Table resource instance to the URL's id via
@@ -101,7 +101,7 @@ async function getRelationshipAsAdmin(id: string): Promise<any> {
   return Array.isArray(body) && body.length > 0 ? body[0] : null;
 }
 
-describe("Relationship.delete() cross-agent authorization (ops-sgjr)", () => {
+describe("Relationship.delete() cross-agent authorization", () => {
   beforeAll(async () => {
     harper = await startHarper();
 
@@ -121,7 +121,7 @@ describe("Relationship.delete() cross-agent authorization (ops-sgjr)", () => {
 
   afterAll(async () => { if (harper) await stopHarper(harper); });
 
-  test("REPRO (ops-sgjr): non-admin cross-agent DELETE is rejected with 403 and the record survives", async () => {
+  test("REPRO: non-admin cross-agent DELETE is rejected with 403 and the record survives", async () => {
     const id = `repro-${randomUUID()}`;
     const putRes = await putRelationship(owner, id);
     expect([200, 204], `owner PUT returned ${putRes.status}: ${(await putRes.text()).slice(0, 200)}`).toContain(putRes.status);

--- a/test/integration/semantic-search-singleton-score.test.ts
+++ b/test/integration/semantic-search-singleton-score.test.ts
@@ -1,9 +1,9 @@
-// ops-syzm — SemanticSearch scores a SINGLETON semantic-search result as 0
+// SemanticSearch scores a SINGLETON semantic-search result as 0
 // ("DEGRADED") even though embeddings are loaded and the memory genuinely
 // matches its own paraphrase.
 //
 // This is the SAME Harper quirk already root-caused and fixed for the dedup
-// path (ops-ume4, resources/Memory.ts findConservativeDedupMatch /
+// path (resources/Memory.ts findConservativeDedupMatch /
 // resources/dedup.ts cosineSimilarity): a cosine-sort query's `$distance`
 // annotation comes back `undefined` when its post-filter result set contains
 // EXACTLY ONE matching record — sort ORDER is still correct, only the numeric
@@ -13,7 +13,7 @@
 // so a singleton hit fell through `?? 1` → similarity 0 → the memory reads as
 // totally dissimilar to a paraphrase of ITSELF.
 //
-// ops-2dm3 Layer 1 made this trigger easily: before, the no-grants agent scope
+// The read-scope Layer 1 change made this trigger easily: before, the no-grants agent scope
 // was ALWAYS a compound `{operator:"or", conditions:[{agentId},{visibility==
 // "office"}]}` condition; resolveReadScope() now emits a PLAIN single
 // `{agentId==X}` condition for the common (no-grants) case, so an agent with
@@ -63,11 +63,11 @@ const agent = mkAgent("syzm-singleton");
 const MEMORY_ID = "syzm-singleton-memory-1";
 // Genuinely-related content + paraphrase, worded differently enough that the
 // keyword-substring bump (`content.includes(q)`) never fires — the score we
-// assert on is semanticScore alone, exactly the quantity ops-syzm corrupts.
+// assert on is semanticScore alone, exactly the quantity this singleton-scoring bug corrupts.
 const CONTENT = "Our quarterly budget review meeting is scheduled for next Tuesday afternoon in the main conference room downtown.";
 const PARAPHRASE_QUERY = "When are we getting together to go over quarterly spending numbers?";
 
-describe("ops-syzm — SemanticSearch singleton-result scoring (real Harper, real embeddings)", () => {
+describe("SemanticSearch singleton-result scoring (real Harper, real embeddings)", () => {
   beforeAll(async () => {
     harper = await startHarper();
     const res = await adminOp(harper, {
@@ -92,7 +92,7 @@ describe("ops-syzm — SemanticSearch singleton-result scoring (real Harper, rea
 
   afterAll(async () => { if (harper) await stopHarper(harper); });
 
-  test("ops-syzm: a singleton semantic-search result scores as a real positive similarity, not 0/DEGRADED", async () => {
+  test("SemanticSearch singleton-result scoring: a singleton semantic-search result scores as a real positive similarity, not 0/DEGRADED", async () => {
     const path = "/SemanticSearch";
     const res = await fetch(`${harper.httpURL}${path}`, {
       method: "POST",
@@ -109,7 +109,7 @@ describe("ops-syzm — SemanticSearch singleton-result scoring (real Harper, rea
     expect(body.results[0].id).toBe(MEMORY_ID);
 
     const score = body.results[0]._score;
-    console.log(`[ops-syzm] singleton semantic score observed: ${score}`);
+    console.log(`[singleton-score] singleton semantic score observed: ${score}`);
     // Pre-fix this is EXACTLY 0 (distanceToSimilarity(1) via the `?? 1`
     // fallback on an undefined $distance). A real paraphrase of the memory's
     // own content must score as genuinely similar — well above 0, not just

--- a/test/integration/supersede-recall-resurface.test.ts
+++ b/test/integration/supersede-recall-resurface.test.ts
@@ -1,4 +1,4 @@
-// ops-9rc6 — a server-superseded memory resurfaces in the DEFAULT (no-asOf)
+// A server-superseded memory resurfaces in the DEFAULT (no-asOf)
 // recall path when its successor isn't semantically/conditions co-present in
 // the same search result set.
 //
@@ -100,10 +100,10 @@ async function search(harper: HarperInstance, agent: TestAgent, body: Record<str
 }
 
 let harper: HarperInstance;
-const agent = mkAgent(`ops-9rc6-${randomUUID()}`);
+const agent = mkAgent(`semantic-resurface-${randomUUID()}`);
 
-const SUBJECT = "ops-9rc6-budget-approval";
-const OTHER_SUBJECT = "ops-9rc6-unrelated-kitchen-topic";
+const SUBJECT = "semantic-resurface-budget-approval";
+const OTHER_SUBJECT = "semantic-resurface-unrelated-kitchen-topic";
 
 const ID_A = `${agent.id}-a`; // superseded (server path) — must NOT resurface
 const ID_B = `${agent.id}-b`; // successor — different subject, never co-present with A's search
@@ -116,7 +116,7 @@ const CONTENT_C = "The finance team's Q3 budget sign-off is expected in mid-Marc
 const CONTENT_D = "The annual budget planning retreat for department heads is confirmed for next spring.";
 const QUERY = "When is the marketing budget deadline approved?";
 
-describe("ops-9rc6 — server-superseded (validTo, not archived) memory must not resurface in default recall", () => {
+describe("server-superseded (validTo, not archived) memory must not resurface in default recall", () => {
   beforeAll(async () => {
     harper = await startHarper();
     await registerAgent(harper, agent);
@@ -141,7 +141,7 @@ describe("ops-9rc6 — server-superseded (validTo, not archived) memory must not
     expect(bodyB.written).toBe(true);
 
     // Confirm the server actually closed A (validTo set) — the documented
-    // ops-9rc6 mechanism (Memory.ts closeSupersededRecord), NOT archived.
+    // closeSupersededRecord mechanism (Memory.ts), NOT archived.
     const getA = await getMemory(harper, agent, ID_A);
     expect(getA.status).toBe(200);
     const recA: any = await getA.json();

--- a/test/rem-restore.test.ts
+++ b/test/rem-restore.test.ts
@@ -284,7 +284,7 @@ describe("applySnapshot — real restore", () => {
   });
 });
 
-describe("applySnapshot — post-restore verification (ops-90dq)", () => {
+describe("applySnapshot — post-restore verification (detects silent write drift)", () => {
   it("flags drift when Harper silently drops PUT rows", async () => {
     // Simulates the failure mode the verify pass is designed to catch:
     // Harper returns ok on PUT but doesn't actually persist the row

--- a/test/smoke/golden-path.test.ts
+++ b/test/smoke/golden-path.test.ts
@@ -1,6 +1,6 @@
 /**
  * golden-path.test.ts — Smoke test: golden path end-to-end
- * (ops-t0i3 — scaffold + scenario 1)
+ * (initial scaffold, covering scenario 1)
  *
  * Tests the full agent lifecycle against a real Flair instance:
  *   1. Create agent

--- a/test/unit/a2a-auth.test.ts
+++ b/test/unit/a2a-auth.test.ts
@@ -1,5 +1,5 @@
 /**
- * a2a-auth.test.ts — covers the P0 fix (ops-yhrr / similar): A2AAdapter
+ * a2a-auth.test.ts — covers the P0 fix (unauthenticated POST /a2a): A2AAdapter
  * POST /a2a was unauthenticated, allowing any caller to forge OrgEvents
  * impersonating any agent and read all Beads issues.
  *
@@ -13,7 +13,7 @@
  *    unset (no upstream auth) and not admin, reject with JSON-RPC -32001.
  *    For message/send, sender must match params.agentId unless admin.
  *
- * Note: these tests use the "simulator" pattern (per ops-ketv P1 backlog
+ * Note: these tests use the "simulator" pattern (a known P1 backlog item
  * to convert to real-module tests). They exercise the decision logic of
  * the two guards but do NOT exercise Harper's full request/auth pipeline.
  */
@@ -174,7 +174,7 @@ describe("A2AAdapter.post() — message/send sender-match", () => {
   });
 });
 
-// ─── message/send DIRECTED handoff routing (ops-f1e3) ─────────────────────
+// ─── message/send DIRECTED handoff routing (Rivet × krais collision fix) ──
 
 /**
  * Reproduces the message/send routing decision from A2AAdapter.post()
@@ -229,7 +229,7 @@ function catchupReceives(participant: string, targetIds: string[] | null | undef
   return !targetIds || targetIds.length === 0 || targetIds.includes(participant);
 }
 
-describe("message/send — directed handoff routing (ops-f1e3)", () => {
+describe("message/send — directed handoff routing (Rivet × krais collision fix)", () => {
   const agents = new Set(["rivet", "krais", "flint"]);
 
   test("(a) sender=rivet, toAgentId=krais → event scope=rivet, targetIds=[krais]; krais's catchup receives it", () => {

--- a/test/unit/admin-instance-resolve-url.test.ts
+++ b/test/unit/admin-instance-resolve-url.test.ts
@@ -3,7 +3,8 @@
  * 127.0.0.1 URLs on remote deployments).
  *
  * Tests the predicate logic of `resolvePublicUrl` from
- * resources/AdminInstance.ts. Simulator-pattern (per ops-ketv) — exercises
+ * resources/AdminInstance.ts. Simulator-pattern (a known P1 backlog item to
+ * convert to real-module tests) — exercises
  * the decision branches without importing the real Resource class (which
  * pulls Harper at import time).
  */

--- a/test/unit/agentcard-fields.test.ts
+++ b/test/unit/agentcard-fields.test.ts
@@ -7,7 +7,7 @@ import {
 } from "../../resources/agentcard-fields";
 
 /**
- * Tests for what the public (unauthenticated) AgentCard exposes — ops-vz6j.
+ * Tests for what the public (unauthenticated) AgentCard exposes.
  *
  * `GET /AgentCard/{id}` bypasses auth (A2A spec). The prior code fell back to
  * publishing the first soul with ANY content as the description when no
@@ -27,7 +27,7 @@ describe("selectPublicDescription", () => {
     expect(selectPublicDescription(souls)).toBe("Strategic cofounder agent.");
   });
 
-  test("SECURITY: no description soul → empty string, never a private soul (ops-vz6j)", () => {
+  test("SECURITY: no description soul → empty string, never a private soul", () => {
     const souls = [
       { kind: "note", content: "INTERNAL reminder: rotate the admin pass" },
       { kind: "prompt", content: "You have access to the production keys at..." },

--- a/test/unit/auth-middleware.test.ts
+++ b/test/unit/auth-middleware.test.ts
@@ -273,7 +273,7 @@ describe("auth header edge cases", () => {
   });
 });
 
-// ─── Basic auth: super_user support (ops-lzmg) ───────────────────────────────
+// ─── Basic auth: super_user support ───────────────────────────────
 // NOTE: The simulateAuthMiddleware block and super_user/getUser mock tests
 // were deleted — their real coverage now lives in the integration file
 // test/integration/auth-middleware-e2e.test.ts (real Harper, real HTTP).

--- a/test/unit/bm25.test.ts
+++ b/test/unit/bm25.test.ts
@@ -1,6 +1,6 @@
 import { describe, test, expect } from "bun:test";
 // Exercise the SHIPPED BM25 module (resources/bm25.ts) directly — Harper-free,
-// same convention as temporal-scoring.test.ts. ops-i39b / FLAIR-BM25-HYBRID.
+// same convention as temporal-scoring.test.ts. FLAIR-BM25-HYBRID.
 import {
   tokenize,
   buildBM25,

--- a/test/unit/cli-port-autodiscover.test.ts
+++ b/test/unit/cli-port-autodiscover.test.ts
@@ -1,6 +1,6 @@
 /**
  * cli-port-autodiscover.test.ts — Unit tests for the port-drift autodiscover
- * helpers (ops-mbdi).
+ * helpers.
  *
  * The discoverLocalFlairPort helper probes a small candidate-port set when the
  * configured Flair URL is unreachable. Tests cover:

--- a/test/unit/cli-target-flag.test.ts
+++ b/test/unit/cli-target-flag.test.ts
@@ -1,7 +1,7 @@
 /**
  * cli-target-flag.test.ts — Unit tests for --target flag / FLAIR_TARGET env var
  *
- * ops-n3ob: Add consistent --target <url> flag (env fallback: FLAIR_TARGET)
+ * Add consistent --target <url> flag (env fallback: FLAIR_TARGET)
  * to init, federation status/token/pair/sync, and status commands.
  *
  * Tests:

--- a/test/unit/client-wiring.test.ts
+++ b/test/unit/client-wiring.test.ts
@@ -6,7 +6,7 @@ import { join } from "node:path";
 import { wireGemini, wireCursor, wireCodex } from "../../src/install/clients.ts";
 
 /**
- * FIX 4 (onboarding dogfood round 1, ops-9czl):
+ * FIX 4 (onboarding dogfood round 1):
  * "wired" MUST mean a config file was actually written. The Codex/Gemini/Cursor
  * wire functions used to ALWAYS return "Manual wiring required" while the run
  * elsewhere claimed the client was wired. They now write the real client config

--- a/test/unit/coordination-write-auth.test.ts
+++ b/test/unit/coordination-write-auth.test.ts
@@ -1,6 +1,6 @@
 /**
  * coordination-write-auth.test.ts — Handler-level no-forge tests for the
- * coordination write surface (ops-wmgx / Kris #510).
+ * coordination write surface (Kris #510).
  *
  * Exercises WorkspaceState.post() and OrgEvent.post() directly, mocking
  * @harperfast/harper so the resource classes load + their writes are capturable
@@ -20,7 +20,7 @@
  * signature (see auth-middleware.ts) and what resolveAgentAuth() reads.
  *
  * ── WorkspaceState.allowRead() + get() ownership scoping (memory-soul-read-
- * gate family fix, ops-oox7) ─────────────────────────────────────────────────
+ * gate family fix) ─────────────────────────────────────────────────
  * These tests are ADDED HERE (not a separate file) deliberately: this file
  * already `mock.module("@harperfast/harper", ...)` + dynamically imports
  * "../../resources/WorkspaceState.ts". bun runs every test/unit/ file in ONE
@@ -196,7 +196,7 @@ describe("OrgEvent.post() — agent-self attribution (no forging)", () => {
   });
 });
 
-// ─── WorkspaceState.allowRead + get() ownership scoping (ops-oox7) ──────────
+// ─── WorkspaceState.allowRead + get() ownership scoping (read-gate family fix) ──
 //
 // Regression guard for the family read-gate fix: WorkspaceState.ts previously
 // gated post()/put()/delete() but never defined `allowRead()` nor overrode

--- a/test/unit/cross-agent-isolation.test.ts
+++ b/test/unit/cross-agent-isolation.test.ts
@@ -1,5 +1,5 @@
 /**
- * cross-agent-isolation.test.ts — NECESSITY tests for the ops-sal4 P0 fix.
+ * cross-agent-isolation.test.ts — NECESSITY tests for the cross-agent read-isolation P0 fix.
  *
  * flair-agent-deelevation.test.ts (integration) only asserts SUFFICIENCY: an
  * agent CAN read its own WorkspaceLatest / OrgEventCatchup (`not.toContain([401,403])`).
@@ -123,7 +123,7 @@ beforeEach(() => {
 
 // ─── WorkspaceLatest ────────────────────────────────────────────────────────
 
-describe("WorkspaceLatest.get() — cross-agent isolation (ops-sal4)", () => {
+describe("WorkspaceLatest.get() — cross-agent isolation (fail-open cross-agent-read fix)", () => {
   it("agent requesting OWN id → allowed (reaches the query, not 403)", async () => {
     const ws = makeInstance<any>(WorkspaceLatest, agentCtx("agent-alpha"));
     const res = await ws.get("agent-alpha");
@@ -162,7 +162,7 @@ describe("WorkspaceLatest.get() — cross-agent isolation (ops-sal4)", () => {
 
 // ─── OrgEventCatchup ────────────────────────────────────────────────────────
 
-describe("OrgEventCatchup.get() — cross-agent isolation (ops-sal4)", () => {
+describe("OrgEventCatchup.get() — cross-agent isolation (fail-open cross-agent-read fix)", () => {
   const pathFor = (participantId: string) => ({
     id: participantId,
     conditions: [{ attribute: "since", value: "2020-01-01T00:00:00.000Z", comparator: "equals" }],
@@ -206,7 +206,7 @@ describe("OrgEventCatchup.get() — cross-agent isolation (ops-sal4)", () => {
 
 // ─── OAuthAuthorize — resolved principal (identity spoof fix) ──────────────
 
-describe("OAuthAuthorize.post() — resolved principal, not hardcoded admin (ops-sal4)", () => {
+describe("OAuthAuthorize.post() — resolved principal, not hardcoded admin (identity spoof fix)", () => {
   const approveBody = (extra: Record<string, any> = {}) => ({
     action: "approve",
     client_id: "cl1",

--- a/test/unit/deploy.test.ts
+++ b/test/unit/deploy.test.ts
@@ -427,7 +427,7 @@ describe("flair deploy: deploy() gating — --no-verify and --dry-run both skip 
 });
 
 // ─────────────────────────────────────────────────────────────────────────
-// ops-2i8x: flaky-peer-replication resilience. A real Fabric deploy hit
+// Flaky-peer-replication resilience. A real Fabric deploy hit
 //   "Component 'flair' was deployed on the origin node but failed to
 //    replicate to 1 of 1 peer node(s): ... (Error: Connection closed 1006)"
 // and hard-exited 1 — a bare manual retry cleared it with no other change.

--- a/test/unit/doctor-embed-verify.test.ts
+++ b/test/unit/doctor-embed-verify.test.ts
@@ -7,7 +7,7 @@ import nacl from "tweetnacl";
 import { verifySemanticSearch } from "../../src/cli.ts";
 
 /**
- * FIX 1 (onboarding dogfood round 1, ops-9czl):
+ * FIX 1 (onboarding dogfood round 1):
  * `flair doctor` / `flair init` must run a REAL embed→paraphrase-search
  * round-trip and FAIL LOUDLY when embeddings are not loaded — never report
  * all-clear while recall-by-meaning is dead.

--- a/test/unit/dogfood-fixes.test.ts
+++ b/test/unit/dogfood-fixes.test.ts
@@ -32,7 +32,7 @@ function run(cmd: string, env?: Record<string, string>): string {
   }
 }
 
-describe("Dogfood fixes (ops-fqwh)", () => {
+describe("Dogfood fixes", () => {
   beforeAll(() => {
     setup();
   });

--- a/test/unit/ed25519-auth-cross-site.test.ts
+++ b/test/unit/ed25519-auth-cross-site.test.ts
@@ -1,6 +1,6 @@
 /**
- * ed25519-auth-cross-site.test.ts — REAL cross-module closure proof (bd
- * ops-c4op): agent-auth.ts's verifyAgentRequest() and Presence.ts's post()
+ * ed25519-auth-cross-site.test.ts — REAL cross-module closure proof (shared
+ * nonce-store consolidation): agent-auth.ts's verifyAgentRequest() and Presence.ts's post()
  * fallback verification are two of the three independent TPS-Ed25519 call
  * sites that used to carry their OWN nonceSeen Map. This test imports BOTH
  * real modules under one @harperfast/harper mock (bun's module cache is

--- a/test/unit/ed25519-auth.test.ts
+++ b/test/unit/ed25519-auth.test.ts
@@ -1,6 +1,6 @@
 /**
  * ed25519-auth.test.ts — unit tests for the shared Ed25519 auth primitives
- * module (bd ops-c4op consolidation).
+ * module (shared nonce-store consolidation).
  *
  * resources/ed25519-auth.ts has ZERO dependency on @harperfast/harper (it
  * only imports resources/b64.ts, which is also dependency-free), so these

--- a/test/unit/embeddings-models-dir.test.ts
+++ b/test/unit/embeddings-models-dir.test.ts
@@ -8,11 +8,11 @@ import { resolveModelsDir } from "../../resources/embeddings-provider";
 /**
  * resolveModelsDir() decides where the embeddings model lives / downloads.
  *
- * The whole point of ops-am0v: the chosen dir must ALWAYS be user-writable, so a
+ * The whole point of this resolution: the chosen dir must ALWAYS be user-writable, so a
  * sudo/root-owned global install (package dir owned by root) never targets the
  * read-only package dir and silently kills semantic search.
  */
-describe("resolveModelsDir (ops-am0v)", () => {
+describe("resolveModelsDir (user-writable dir enforcement)", () => {
   const SAVED = {
     FLAIR_MODELS_DIR: process.env.FLAIR_MODELS_DIR,
     ROOTPATH: process.env.ROOTPATH,

--- a/test/unit/federation-liveness-ping.test.ts
+++ b/test/unit/federation-liveness-ping.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, mock, beforeEach, afterEach } from "bun:test";
 import nacl from "tweetnacl";
 
 /**
- * ops-c7t9: no-change federation syncs must still ping the hub for liveness.
+ * No-change federation syncs must still ping the hub for liveness.
  *
  * Before the fix, when a spoke had no records to push, it returned early
  * without contacting the hub — so idle-but-alive spokes looked dead

--- a/test/unit/federation-sync-push-privacy.test.ts
+++ b/test/unit/federation-sync-push-privacy.test.ts
@@ -3,7 +3,7 @@ import nacl from "tweetnacl";
 import { isPrivateVisibility, PRIVATE_VISIBILITY } from "../../resources/memory-visibility";
 
 /**
- * federation-edge-hardening slice 2 (ops-nzxa: one rule, one place).
+ * federation-edge-hardening slice 2 (one rule, one place).
  *
  * The federation-sync PUSH (runFederationSyncOnce in src/cli.ts) pulls every
  * changed Memory row via the admin ops API with get_attributes:["*"] and,
@@ -47,7 +47,7 @@ function res(ok: boolean, status: number, body: any) {
 const testKp = nacl.sign.keyPair();
 const SINCE = "2025-01-01T00:00:00.000Z";
 
-describe("federation sync push — private-visibility filter (ops-nzxa)", () => {
+describe("federation sync push — private-visibility filter", () => {
   let capturedCalls: Array<{ url: string; body?: any; method?: string }> = [];
 
   beforeEach(() => {

--- a/test/unit/integration-read-gate.test.ts
+++ b/test/unit/integration-read-gate.test.ts
@@ -1,6 +1,6 @@
 /**
  * integration-read-gate.test.ts — regression guard for the memory-soul-
- * read-gate FAMILY fix (ops-oox7): Integration.ts previously gated
+ * read-gate FAMILY fix: Integration.ts previously gated
  * search()/post()/put()/delete() but never defined `allowRead()` nor
  * overrode `get()`. Harper routes `GET /Integration/<id>` to get() and the
  * collection-describe `GET /Integration` outside search(), so both were

--- a/test/unit/local-no-auth.test.ts
+++ b/test/unit/local-no-auth.test.ts
@@ -1,5 +1,5 @@
 /**
- * local-no-auth.test.ts — Unit tests for implicit local auth skip (ops-vu31)
+ * local-no-auth.test.ts — Unit tests for implicit local auth skip
  *
  * When targeting localhost with no admin pass, api() should send no
  * Authorization header. Auth-middleware should let the request through

--- a/test/unit/memory-grant-read-gate.test.ts
+++ b/test/unit/memory-grant-read-gate.test.ts
@@ -1,6 +1,6 @@
 /**
  * memory-grant-read-gate.test.ts — regression guard for the memory-soul-
- * read-gate FAMILY fix (ops-oox7): MemoryGrant.ts previously gated
+ * read-gate FAMILY fix: MemoryGrant.ts previously gated
  * search()/post()/put()/delete() but never defined `allowRead()` nor
  * overrode `get()`. Harper routes `GET /MemoryGrant/<id>` to get() and the
  * collection-describe `GET /MemoryGrant` outside search(), so both were

--- a/test/unit/orgevent-cli.test.ts
+++ b/test/unit/orgevent-cli.test.ts
@@ -1,6 +1,6 @@
 /**
  * orgevent-cli.test.ts — Unit tests for `flair orgevent` CLI command
- * (coordination write surface, ops-wmgx / Kris #510).
+ * (coordination write surface / Kris #510).
  *
  * Uses a mock HTTP server. No real Harper instance required. Mirrors
  * presence-set.test.ts. The security-critical assertion: the request carries an

--- a/test/unit/relationship-read-gate.test.ts
+++ b/test/unit/relationship-read-gate.test.ts
@@ -1,6 +1,6 @@
 /**
  * relationship-read-gate.test.ts — regression guard for the memory-soul-
- * read-gate FAMILY fix (ops-oox7): Relationship.ts previously gated
+ * read-gate FAMILY fix: Relationship.ts previously gated
  * post()/put()/delete() (via search()'s own 401 and put()/delete()'s
  * tpsAgent checks) but never defined `allowRead()` nor overrode `get()`.
  * Harper routes `GET /Relationship/<id>` to get() and the collection-

--- a/test/unit/semantic-search-scoping.test.ts
+++ b/test/unit/semantic-search-scoping.test.ts
@@ -201,7 +201,7 @@ describe("SemanticSearch.post() — centralized read-scoping", () => {
     expect(res.results.map((r: any) => r.id)).toEqual(["live"]);
   });
 
-  // ─── ops-syzm: singleton $distance-omission fallback ───────────────────────
+  // ─── singleton $distance-omission fallback ───────────────────────
   // This mock's Memory.search() never annotates `$distance` on returned
   // records (that's a Harper-computed sort-query field with no equivalent in
   // the in-memory mock) — so any test that takes the HNSW (qEmb-truthy)
@@ -210,7 +210,7 @@ describe("SemanticSearch.post() — centralized read-scoping", () => {
   // (see resources/SemanticSearch.ts's scoring block for the full writeup,
   // and test/integration/semantic-search-singleton-score.test.ts for the
   // real-Harper reproduction this was root-caused against).
-  it("ops-syzm: undefined $distance falls back to a point-lookup cosine computation instead of scoring 0", async () => {
+  it("undefined $distance falls back to a point-lookup cosine computation instead of scoring 0", async () => {
     reset();
     const qEmb = [1, 0, 0];
     // Orthogonal to qEmb — the pre-fix `?? 1` fallback and the fixed

--- a/test/unit/temporal-scoring.test.ts
+++ b/test/unit/temporal-scoring.test.ts
@@ -66,7 +66,7 @@ describe("composite scoring (OPS-AYGD: relevance-floor gate)", () => {
   });
 
   test("MAGNET FIX: a low-semantic popular doc cannot outrank a high-semantic fresh doc", () => {
-    // The ops-aygd bug: pre-fix the magnet's unbounded rBoost lifted it above relevant docs.
+    // Pre-fix the magnet's unbounded rBoost lifted it above relevant docs.
     const magnet = compositeScore(0.45, { durability: "standard", createdAt: now(), retrievalCount: 1000 }); // below floor → no lift
     const relevant = compositeScore(0.6, { durability: "standard", createdAt: now(), retrievalCount: 0 });
     expect(relevant).toBeGreaterThan(magnet);

--- a/test/unit/upgrade-probes.test.ts
+++ b/test/unit/upgrade-probes.test.ts
@@ -113,10 +113,10 @@ describe("probeOpenclawPluginVersion", () => {
 // The flair-mcp package entry in `flair upgrade` probes via
 //   probeBinVersion(execFileSync, "flair-mcp") ?? probeLibVersion("@tpsdev-ai/flair-mcp")
 // so an older install that's globally present but not on PATH / has no
-// `--version` (e.g. 0.10.0, ops-p42n) is still detected via the lib probe
+// `--version` (e.g. 0.10.0) is still detected via the lib probe
 // instead of falsely reporting "not detected". These tests pin that
 // bin→lib fallback composition and the resulting detected/outdated status.
-describe("flair-mcp bin→lib probe fallback (ops-p42n)", () => {
+describe("flair-mcp bin→lib probe fallback", () => {
   // Mirror the upgrade command's status mapping for the assertions below.
   const statusFor = (installed: string | null, latest: string) =>
     installed === null ? "missing" : installed === latest ? "current" : "outdated";
@@ -132,7 +132,7 @@ describe("flair-mcp bin→lib probe fallback (ops-p42n)", () => {
   });
 
   test("a globally-installed-but-binless flair-mcp is treated as outdated when < latest", () => {
-    // Real-world ops-p42n: 0.10.0 installed, bin probe null, lib probe finds it.
+    // Real-world case: 0.10.0 installed, bin probe null, lib probe finds it.
     const binNull = fake(() => { throw new Error("not on PATH"); });
     const libStub = (_pkg: string): string | null => "0.10.0"; // sibling global install
     const installed = probeBinVersion(binNull, "flair-mcp") ?? libStub("@tpsdev-ai/flair-mcp");
@@ -158,7 +158,7 @@ describe("flair-mcp bin→lib probe fallback (ops-p42n)", () => {
   });
 });
 
-// fix #2 (ops-p42n): the optional openclaw-flair line is suppressed in the
+// fix #2 (bin→lib probe fallback): the optional openclaw-flair line is suppressed in the
 // default listing on machines without openclaw, but still shown under --all.
 describe("shouldPrintUpgradeLine", () => {
   test("suppresses an optional (openclaw-absent) line by default", () => {

--- a/test/unit/workspace-set.test.ts
+++ b/test/unit/workspace-set.test.ts
@@ -1,6 +1,6 @@
 /**
  * workspace-set.test.ts — Unit tests for `flair workspace set` CLI subcommand
- * (coordination write surface, ops-wmgx / Kris #510).
+ * (coordination write surface / Kris #510).
  *
  * Uses a mock HTTP server. No real Harper instance required. Mirrors
  * presence-set.test.ts. The security-critical assertion: the request carries an
@@ -127,7 +127,7 @@ describe("flair workspace set", () => {
       const parsed = JSON.parse(body);
       expect(parsed.ref).toBe("cp7-coord");
       expect(parsed.phase).toBe("implement");
-      expect(parsed.taskId).toBe("ops-wmgx");
+      expect(parsed.taskId).toBe("cp7-implement-task");
       // SECURITY: the body must NOT carry agentId — identity is attributed
       // server-side from the Ed25519 signature.
       expect(parsed.agentId).toBeUndefined();
@@ -136,7 +136,7 @@ describe("flair workspace set", () => {
 
     try {
       const { stdout, code } = await runCli(
-        ["workspace", "set", "--ref", "cp7-coord", "--phase", "implement", "--task", "ops-wmgx"],
+        ["workspace", "set", "--ref", "cp7-coord", "--phase", "implement", "--task", "cp7-implement-task"],
         { FLAIR_AGENT_ID: agentId, FLAIR_KEY_DIR: keysDir, FLAIR_URL: url },
       );
       expect(code).toBe(0);


### PR DESCRIPTION
Sweeps internal DTRT tracker IDs (`ops-XXXX`) out of shipping code comments, docblocks, test descriptions, and user-facing CHANGELOG / log strings. They're an internal planning-tracker reference meaningless to Flair adopters reading the public repo. Follows #578, which cleaned only the within-org-read files it touched.

## What changed

- **82 files** touched (81 edits + 1 rename). Each `ops-XXXX` ref was replaced with the concept it pointed to — reasoning kept, tracker ID dropped.
- Breakdown: `src/` (26 refs: cli.ts, deploy.ts, rem/restore.ts) · `resources/` (65 refs across 32 files) · `test/` (~130 refs across unit + integration) · `scripts/` (harper-watchdog.sh, release.sh) · `packages/` (openclaw-flair, flair-mcp, flair-client) · `CHANGELOG.md` (43 refs).
- Renamed `test/integration/init-remote-ops-2kyi.test.ts` → `init-remote-ops.test.ts` (the bead ID was in the filename; verified no other file referenced it).
- **Public `flair#NNN` GitHub-issue references were left intact** — those are fine for consumers.

## Kept intentionally (false positives, not tracker IDs)

The `ops-[a-z0-9]{4}` pattern also matches real product terms, which were left untouched: `--ops-target` / `--ops-port` (real CLI flags), `ops-only.example.com` (example URL), `ops-insert` (operations-API insert), plus incidental substring matches in `devops-pipeline`, `stops-cycle`, `ops-anvil`.

## Test-string handling

No assertion-on-tracker-ID bugs were introduced. Two test files used a tracker ID (`ops-wmgx`) as arbitrary passthrough **fixture data** with a matching assertion (`test/unit/workspace-set.test.ts` and `packages/flair-mcp/test/mcp.test.ts`) — in each, the fixture value and its assertion were changed together to a neutral example (`cp7-implement-task`), so the tests stay green and the passthrough semantics are unchanged. The `ops-a4t5` case that #578's rework had to fix (an assertion checking a bead ID instead of the real log message) is not present in the current tree — it was already resolved upstream; the only remaining occurrences were the source `console.error` strings themselves, which had no test asserting on them, so they were cleaned directly.

## Out of scope

`specs/*.md` are internal design docs (not shipping code, not tests, excluded from the published npm `files` list) and use bead IDs as structured provenance (`**Bead:** ops-q3qf`, including in filenames) — left as-is, matching #578's precedent of cleaning only the consumer-facing root docs. `SECURITY.md` / `README.md` / `DESIGN.md` were already clean from #578.

## Zero behavior change — verification

Comment / description / log-string only. No logic touched.

- `npm run build` + `npm run build:cli` — clean
- `npx tsc --noEmit -p tsconfig.check.json` — clean
- Full unit suite `bun test test/unit/` — **1540 pass / 0 fail** (unchanged baseline)
- `packages/flair-mcp/test/mcp.test.ts` — 20 pass / 0 fail (edited fixture)
- Pre-commit `check-impl-term-leaks` hook — passed
- Final `grep -rnE "ops-[a-z0-9]{4}"` across `src resources test scripts packages` (minus the false-positive flags above) — **0 real tracker refs remaining**

Closes #585.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
