### PR TITLE
feat(cli): surface version-behind in status/doctor (closes #587)

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,6 +240,29 @@ flair uninstall     # Remove the service (keeps data)
 flair uninstall --purge  # Remove everything including data and keys
 ```
 
+### Upgrading
+
+`flair status` and `flair doctor` both check your installed version against the latest published release (cached, offline-tolerant — this never blocks or fails either command) and print a nudge when you're behind:
+
+```
+⚠ flair 0.16.1 is behind — latest is 0.20.1 (4 releases behind). Upgrade: npm i -g @tpsdev-ai/flair@latest
+```
+
+To upgrade:
+
+```bash
+npm install -g @tpsdev-ai/flair@latest
+
+# Or check what's outdated across the whole toolchain (flair, flair-mcp, the
+# openclaw-flair plugin) without installing anything:
+flair upgrade --check
+
+# Then apply:
+flair upgrade
+```
+
+`flair upgrade` also restarts the running instance for you with `--restart`. If you deployed Flair to a Harper Fabric cluster (rather than running it locally), use `flair upgrade --target <fabric-url>` instead — see `flair upgrade --help`.
+
 ### Advanced / manual setup
 
 Prefer to drive each step yourself, or scripting an unattended setup? Run `flair init --no-mcp` to bootstrap the instance + agent without wiring any MCP clients, then drive each step on its own:

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -24,6 +24,7 @@ import { create as tarCreate, extract as tarExtract, list as tarList } from "tar
 import { keystore } from "./keystore.js";
 import { deploy as deployToFabric, validateOptions as validateDeployOptions, buildTargetUrl as buildDeployUrl } from "./deploy.js";
 import { fabricUpgrade } from "./fabric-upgrade.js";
+import { checkVersion, formatVersionNudge } from "./version-check.js";
 import { detectClients, wireCodex, wireGemini, wireCursor, type ClientId } from "./install/clients.js";
 
 // Federation crypto helpers — inlined to avoid cross-boundary imports from
@@ -5439,9 +5440,16 @@ const statusCmd = program
       discoveredPort = await discoverLocalFlairPort(baseUrl);
     }
 
+    // Version-behind check (flair#587) — offline-tolerant + cached, so this
+    // never adds meaningful latency or fails `status` when the registry is
+    // unreachable. Independent of Harper health; runs either way.
+    const versionCheckResult = await checkVersion(__pkgVersion);
+    const versionNudge = formatVersionNudge(versionCheckResult);
+
     if (opts.json) {
       const out: any = { healthy, url: baseUrl, flairVersion: __pkgVersion, ...healthData };
       if (discoveredPort != null) out.discoveredPort = discoveredPort;
+      if (versionCheckResult.latest) out.latestVersion = versionCheckResult.latest;
       console.log(JSON.stringify(out, null, 2));
       if (!healthy) process.exit(1);
       return;
@@ -5459,6 +5467,10 @@ const statusCmd = program
         console.log(`  Or: flair doctor (when port-drift detection lands there)`);
       } else {
         console.log(`\n  Run: flair start  or  flair doctor`);
+      }
+      if (versionNudge) {
+        const color = versionNudge.severity === "red" ? render.c.red : render.c.yellow;
+        console.log(`\n  ${render.wrap(color, "⚠")} ${render.wrap(color, versionNudge.message)}`);
       }
       process.exit(1);
     }
@@ -5513,6 +5525,11 @@ const statusCmd = program
     const metaParts = [pidPart, uptimePart].filter(Boolean).join(render.wrap(render.c.dim, " · "));
     console.log(`${versionStr} ${render.wrap(render.c.dim, "—")} ${runStatus}${metaParts ? `  ${metaParts}` : ""}`);
     console.log(render.kv("URL", baseUrl));
+
+    if (versionNudge) {
+      const color = versionNudge.severity === "red" ? render.c.red : render.c.yellow;
+      console.log(`\n  ${render.wrap(color, "⚠")} ${render.wrap(color, versionNudge.message)}`);
+    }
 
     if (scopedWarnings.length > 0) {
       console.log(`\n${render.wrap(render.c.bold, "Warnings")}  ${render.wrap(render.c.dim, `(${scopedWarnings.length})`)}`);
@@ -7160,6 +7177,23 @@ program
     let harperResponding = false;
 
     console.log(`\n${render.wrap(render.c.bold, "🩺 Flair Doctor")}\n`);
+
+    // 0. Version check (flair#587) — offline-tolerant + cached, independent
+    // of Harper being up. A gap of ≥2 minor versions (or any major) is
+    // treated as loud/red — heuristic for "likely missed a security fix"
+    // since we don't have advisory data, only the version gap. A red gap
+    // counts as an issue (exit 1); a quieter yellow gap (one minor, or
+    // patch-only) is printed but doesn't fail doctor.
+    const versionCheckResult = await checkVersion(__pkgVersion);
+    const versionNudge = formatVersionNudge(versionCheckResult);
+    if (versionNudge) {
+      const color = versionNudge.severity === "red" ? render.c.red : render.c.yellow;
+      const icon = versionNudge.severity === "red" ? render.wrap(render.c.red, "✗") : render.icons.warn;
+      console.log(`  ${icon} ${render.wrap(color, versionNudge.message)}`);
+      if (versionNudge.severity === "red") issues++;
+    } else if (versionCheckResult.latest) {
+      console.log(`  ${render.icons.ok} flair ${__pkgVersion} is current`);
+    }
 
     // Helper: try to reach Harper on a given port
     async function probePort(p: number): Promise<boolean> {

--- a/src/version-check.ts
+++ b/src/version-check.ts
@@ -1,0 +1,229 @@
+/**
+ * version-check.ts — offline-tolerant, cached check of whether the installed
+ * @tpsdev-ai/flair is behind the latest published npm release.
+ *
+ * Motivation (flair#587): a laptop install sat on 0.16.1 through v0.17.0 and
+ * v0.19.0 (P0 security fixes) and v0.18.0 (memory-integrity fix) — `flair
+ * status` reported "✓ all checks passing" the whole time. Nothing anywhere
+ * in the CLI told the operator they were behind. `flair status` and `flair
+ * doctor` both wire this in.
+ *
+ * Non-negotiable design constraints — this must never make status/doctor
+ * WORSE:
+ *   - Offline-tolerant: a failed/timed-out registry fetch falls back to a
+ *     stale cache, or is skipped entirely. NEVER throws, NEVER hangs (short
+ *     fetch timeout).
+ *   - Cached with a TTL so a healthy network doesn't cost a registry round
+ *     trip on every single `flair status`/`flair doctor` invocation.
+ *   - No advisory data — we don't know which release fixed which CVE, so the
+ *     severity heuristic is purely the version GAP (major/minor count), not
+ *     "did this release carry a security fix". See classifyGap().
+ */
+
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { dirname, join } from "node:path";
+import { parseSemverCore } from "./fabric-upgrade.js";
+
+export const FLAIR_PKG_NAME = "@tpsdev-ai/flair";
+export const DEFAULT_CACHE_PATH = join(homedir(), ".flair", ".version-check-cache.json");
+/** How long a cached "latest" answer is trusted before we re-hit the registry. */
+export const DEFAULT_TTL_MS = 12 * 60 * 60 * 1000; // 12h
+/** Registry fetch timeout — this runs on every status/doctor call, so it must stay short. */
+export const DEFAULT_TIMEOUT_MS = 3000;
+
+interface CacheFile {
+  latest: string;
+  checkedAt: number; // epoch ms
+}
+
+function readCacheFile(path: string): CacheFile | null {
+  try {
+    if (!existsSync(path)) return null;
+    const raw = JSON.parse(readFileSync(path, "utf-8"));
+    if (typeof raw?.latest === "string" && typeof raw?.checkedAt === "number") {
+      return { latest: raw.latest, checkedAt: raw.checkedAt };
+    }
+    return null;
+  } catch {
+    // Corrupt/unreadable cache — treat as absent, never throw.
+    return null;
+  }
+}
+
+function writeCacheFile(path: string, entry: CacheFile): void {
+  try {
+    mkdirSync(dirname(path), { recursive: true });
+    writeFileSync(path, JSON.stringify(entry), "utf-8");
+  } catch {
+    // Best-effort — a cache-write failure must never surface as a
+    // status/doctor error (e.g. read-only $HOME).
+  }
+}
+
+async function defaultFetchLatest(timeoutMs: number): Promise<string | null> {
+  try {
+    const res = await fetch(`https://registry.npmjs.org/${FLAIR_PKG_NAME}/latest`, {
+      signal: AbortSignal.timeout(timeoutMs),
+    });
+    if (!res.ok) return null;
+    const data = (await res.json()) as { version?: string };
+    return typeof data?.version === "string" ? data.version : null;
+  } catch {
+    // Offline, DNS failure, timeout, registry 5xx, bad JSON — all the same:
+    // we couldn't determine "latest" over the network this time.
+    return null;
+  }
+}
+
+// ─── Injectable seams (so tests never hit the network or the real $HOME) ────
+
+export interface VersionCheckDeps {
+  /** Fetch the latest published version string, or null on any failure. */
+  fetchLatest: (timeoutMs: number) => Promise<string | null>;
+  /** Cache file path. */
+  cachePath: string;
+  /** Cache TTL in ms. */
+  ttlMs: number;
+  /** Registry fetch timeout in ms. */
+  timeoutMs: number;
+  /** Clock — injectable for TTL tests. */
+  now: () => number;
+  readCache: (path: string) => CacheFile | null;
+  writeCache: (path: string, entry: CacheFile) => void;
+}
+
+export function defaultVersionCheckDeps(): VersionCheckDeps {
+  return {
+    fetchLatest: defaultFetchLatest,
+    cachePath: DEFAULT_CACHE_PATH,
+    ttlMs: DEFAULT_TTL_MS,
+    timeoutMs: DEFAULT_TIMEOUT_MS,
+    now: () => Date.now(),
+    readCache: readCacheFile,
+    writeCache: writeCacheFile,
+  };
+}
+
+export type VersionCheckSource = "cache" | "network" | "unavailable";
+
+export interface VersionCheckResult {
+  installed: string;
+  /** Latest known published version, or null if we have neither a fresh fetch nor any cache. */
+  latest: string | null;
+  source: VersionCheckSource;
+}
+
+/**
+ * Resolve the latest published @tpsdev-ai/flair version, preferring a fresh
+ * cache hit over a network round trip, and falling back to a stale cache (or
+ * giving up quietly) when the registry is unreachable. NEVER throws.
+ */
+export async function checkVersion(
+  installed: string,
+  injected: Partial<VersionCheckDeps> = {},
+): Promise<VersionCheckResult> {
+  const deps: VersionCheckDeps = { ...defaultVersionCheckDeps(), ...injected };
+  const nowMs = deps.now();
+
+  const cached = deps.readCache(deps.cachePath);
+  if (cached && nowMs - cached.checkedAt < deps.ttlMs) {
+    return { installed, latest: cached.latest, source: "cache" };
+  }
+
+  // Defense-in-depth: the default fetchLatest already catches everything
+  // internally (network error, timeout, non-2xx, bad JSON) and resolves
+  // null rather than rejecting. This try/catch guards the contract even if
+  // a caller-injected fetchLatest misbehaves and throws/rejects instead —
+  // status/doctor must never crash or hang on a version check either way.
+  let fetched: string | null = null;
+  try {
+    fetched = await deps.fetchLatest(deps.timeoutMs);
+  } catch {
+    fetched = null;
+  }
+  if (fetched) {
+    deps.writeCache(deps.cachePath, { latest: fetched, checkedAt: nowMs });
+    return { installed, latest: fetched, source: "network" };
+  }
+
+  // Registry unreachable/timed out — fall back to a stale cache rather than
+  // reporting nothing, but never block or throw trying to get a fresh one.
+  if (cached) {
+    return { installed, latest: cached.latest, source: "cache" };
+  }
+  return { installed, latest: null, source: "unavailable" };
+}
+
+// ─── Severity heuristic (no advisory data — gap-based, see module doc) ──────
+
+export type VersionGapSeverity = "none" | "yellow" | "red";
+
+export interface VersionGap {
+  severity: VersionGapSeverity;
+  /** True when `latest` is a newer MAJOR than `installed`. */
+  majorBehind: boolean;
+  /**
+   * Count of minor versions behind (when majorBehind is false and minors
+   * differ), or patch versions behind (when only the patch differs). Not
+   * meaningful when majorBehind is true (minor numbering resets across a
+   * major bump) or severity is "none".
+   */
+  releasesBehind: number;
+}
+
+const NO_GAP: VersionGap = { severity: "none", majorBehind: false, releasesBehind: 0 };
+
+/**
+ * Classify how far `installed` is behind `latest` using major.minor.patch
+ * math only — we don't have advisory data, so:
+ *   - any major version behind, or ≥2 minor versions behind → "red" (loud;
+ *     heuristic for "you've likely missed a security fix")
+ *   - a single minor version behind, or a patch-only gap → "yellow"
+ *   - equal, ahead, or unparseable → "none"
+ */
+export function classifyGap(installed: string, latest: string): VersionGap {
+  const a = parseSemverCore(installed);
+  const b = parseSemverCore(latest);
+  if (!a || !b) return NO_GAP;
+
+  const [aMaj, aMin, aPatch] = a;
+  const [bMaj, bMin, bPatch] = b;
+
+  if (bMaj > aMaj) return { severity: "red", majorBehind: true, releasesBehind: 0 };
+  if (bMaj < aMaj) return NO_GAP; // installed is ahead (e.g. local/pre-release build)
+
+  if (bMin > aMin) {
+    const releasesBehind = bMin - aMin;
+    return { severity: releasesBehind >= 2 ? "red" : "yellow", majorBehind: false, releasesBehind };
+  }
+  if (bMin < aMin) return NO_GAP; // ahead on minor
+
+  if (bPatch > aPatch) return { severity: "yellow", majorBehind: false, releasesBehind: bPatch - aPatch };
+  return NO_GAP; // equal, or ahead on patch
+}
+
+export interface VersionNudge {
+  severity: "yellow" | "red";
+  message: string;
+}
+
+/**
+ * Build the human-readable nudge line for `flair status`/`flair doctor`, or
+ * null when there's nothing worth printing — current, ahead (local/dev
+ * build), or we couldn't determine latest at all (offline with no cache).
+ * Callers own icon/color; this returns plain text plus a severity to color by.
+ */
+export function formatVersionNudge(result: VersionCheckResult): VersionNudge | null {
+  if (!result.latest) return null;
+  const gap = classifyGap(result.installed, result.latest);
+  if (gap.severity === "none") return null;
+
+  const countHint = gap.majorBehind
+    ? "major version"
+    : `${gap.releasesBehind} release${gap.releasesBehind === 1 ? "" : "s"}`;
+  const message =
+    `flair ${result.installed} is behind — latest is ${result.latest} (${countHint} behind). ` +
+    `Upgrade: npm i -g ${FLAIR_PKG_NAME}@latest`;
+  return { severity: gap.severity, message };
+}

--- a/test/unit/version-check.test.ts
+++ b/test/unit/version-check.test.ts
@@ -1,0 +1,267 @@
+/**
+ * version-check.test.ts — Unit tests for the flair#587 version-behind check
+ * used by `flair status` and `flair doctor`.
+ *
+ * Covers: severity classification (gap-based, no advisory data), the cache
+ * (TTL respected / stale re-fetch / corrupt-cache tolerance), and the
+ * offline-tolerance contract (fetch failure never throws, falls back to
+ * cache or gives up quietly). The registry fetch and the cache file are both
+ * fully mocked — no real network, no real $HOME writes.
+ */
+
+import { describe, test, expect } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync, existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import {
+  checkVersion,
+  classifyGap,
+  formatVersionNudge,
+  defaultVersionCheckDeps,
+  FLAIR_PKG_NAME,
+  type VersionCheckDeps,
+} from "../../src/version-check.js";
+
+// ─── classifyGap / formatVersionNudge — pure severity heuristic ────────────
+
+describe("classifyGap", () => {
+  test("current (equal versions) → severity none", () => {
+    expect(classifyGap("0.20.1", "0.20.1").severity).toBe("none");
+  });
+
+  test("ahead of latest (local/dev build) → severity none", () => {
+    expect(classifyGap("0.21.0", "0.20.1").severity).toBe("none");
+    expect(classifyGap("1.0.0", "0.20.1").severity).toBe("none");
+  });
+
+  test("one minor version behind → yellow", () => {
+    const gap = classifyGap("0.19.0", "0.20.1");
+    expect(gap.severity).toBe("yellow");
+    expect(gap.majorBehind).toBe(false);
+    expect(gap.releasesBehind).toBe(1);
+  });
+
+  test("two or more minor versions behind → red", () => {
+    // The motivating flair#587 case: 0.16.1 → 0.20.1 (4 minor releases,
+    // spanning two P0 security fixes).
+    const gap = classifyGap("0.16.1", "0.20.1");
+    expect(gap.severity).toBe("red");
+    expect(gap.majorBehind).toBe(false);
+    expect(gap.releasesBehind).toBe(4);
+  });
+
+  test("exactly two minor versions behind is the red threshold", () => {
+    expect(classifyGap("0.18.0", "0.20.0").severity).toBe("red");
+  });
+
+  test("any major version behind → red, regardless of minor", () => {
+    const gap = classifyGap("0.20.1", "1.0.0");
+    expect(gap.severity).toBe("red");
+    expect(gap.majorBehind).toBe(true);
+  });
+
+  test("patch-only gap → yellow, not red", () => {
+    const gap = classifyGap("0.20.0", "0.20.5");
+    expect(gap.severity).toBe("yellow");
+    expect(gap.majorBehind).toBe(false);
+    expect(gap.releasesBehind).toBe(5);
+  });
+
+  test("unparseable versions → severity none (never throws)", () => {
+    expect(classifyGap("not-a-version", "0.20.1").severity).toBe("none");
+    expect(classifyGap("0.20.1", "").severity).toBe("none");
+  });
+});
+
+describe("formatVersionNudge", () => {
+  test("returns null when current", () => {
+    expect(formatVersionNudge({ installed: "0.20.1", latest: "0.20.1", source: "network" })).toBeNull();
+  });
+
+  test("returns null when latest is unknown (offline, no cache)", () => {
+    expect(formatVersionNudge({ installed: "0.16.1", latest: null, source: "unavailable" })).toBeNull();
+  });
+
+  test("red nudge names the installed/latest versions, the release count, and the upgrade command", () => {
+    const nudge = formatVersionNudge({ installed: "0.16.1", latest: "0.20.1", source: "network" });
+    expect(nudge).not.toBeNull();
+    expect(nudge!.severity).toBe("red");
+    expect(nudge!.message).toContain("0.16.1");
+    expect(nudge!.message).toContain("0.20.1");
+    expect(nudge!.message).toContain("4 releases");
+    expect(nudge!.message).toContain(`npm i -g ${FLAIR_PKG_NAME}@latest`);
+  });
+
+  test("yellow nudge for a single minor version behind", () => {
+    const nudge = formatVersionNudge({ installed: "0.19.0", latest: "0.20.0", source: "cache" });
+    expect(nudge!.severity).toBe("yellow");
+    expect(nudge!.message).toContain("1 release");
+  });
+
+  test("major-behind nudge says 'major version', not a release count", () => {
+    const nudge = formatVersionNudge({ installed: "0.20.1", latest: "1.0.0", source: "network" });
+    expect(nudge!.severity).toBe("red");
+    expect(nudge!.message).toContain("major version");
+  });
+});
+
+// ─── checkVersion — cache + offline-tolerance contract ──────────────────────
+
+describe("checkVersion", () => {
+  let dir: string;
+  const cachePathFor = (d: string) => join(d, ".version-check-cache.json");
+
+  function baseDeps(overrides: Partial<VersionCheckDeps> = {}): Partial<VersionCheckDeps> {
+    return {
+      cachePath: cachePathFor(dir),
+      ttlMs: 12 * 60 * 60 * 1000,
+      timeoutMs: 100,
+      ...overrides,
+    };
+  }
+
+  // beforeEach/afterEach aren't imported — each test creates/cleans its own
+  // tmpdir to avoid any cross-test cache bleed (cachePath is per-test anyway,
+  // but this keeps disk tidy).
+  function withTmpDir<T>(fn: () => T): T {
+    dir = mkdtempSync(join(tmpdir(), "flair-version-check-"));
+    try {
+      return fn();
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  }
+
+  test("network success writes the cache and reports source 'network'", async () => withTmpDir(async () => {
+    let fetchCalls = 0;
+    const cacheStore = new Map<string, { latest: string; checkedAt: number }>();
+    const result = await checkVersion("0.16.1", baseDeps({
+      fetchLatest: async () => { fetchCalls++; return "0.20.1"; },
+      readCache: (p) => cacheStore.get(p) ?? null,
+      writeCache: (p, entry) => { cacheStore.set(p, entry); },
+      now: () => 1000,
+    }));
+    expect(result).toEqual({ installed: "0.16.1", latest: "0.20.1", source: "network" });
+    expect(fetchCalls).toBe(1);
+    expect(cacheStore.get(cachePathFor(dir))).toEqual({ latest: "0.20.1", checkedAt: 1000 });
+  }));
+
+  test("a fresh cache within TTL is used without calling fetch", async () => withTmpDir(async () => {
+    let fetchCalls = 0;
+    const cached = { latest: "0.20.1", checkedAt: 1000 };
+    const result = await checkVersion("0.16.1", baseDeps({
+      fetchLatest: async () => { fetchCalls++; return "0.99.0"; },
+      readCache: () => cached,
+      writeCache: () => { throw new Error("should not write when cache is fresh"); },
+      now: () => 1000 + 60_000, // 1 minute later — well within a 12h TTL
+      ttlMs: 12 * 60 * 60 * 1000,
+    }));
+    expect(fetchCalls).toBe(0);
+    expect(result).toEqual({ installed: "0.16.1", latest: "0.20.1", source: "cache" });
+  }));
+
+  test("a stale cache (past TTL) triggers a re-fetch", async () => withTmpDir(async () => {
+    let fetchCalls = 0;
+    const cached = { latest: "0.20.1", checkedAt: 0 };
+    const result = await checkVersion("0.16.1", baseDeps({
+      fetchLatest: async () => { fetchCalls++; return "0.21.0"; },
+      readCache: () => cached,
+      writeCache: () => {},
+      now: () => 13 * 60 * 60 * 1000, // 13h later — past the 12h TTL
+      ttlMs: 12 * 60 * 60 * 1000,
+    }));
+    expect(fetchCalls).toBe(1);
+    expect(result.latest).toBe("0.21.0");
+    expect(result.source).toBe("network");
+  }));
+
+  test("fetch failure with no cache falls back to 'unavailable' — never throws", async () => withTmpDir(async () => {
+    const result = await checkVersion("0.16.1", baseDeps({
+      fetchLatest: async () => null, // simulates offline / timeout / non-2xx
+      readCache: () => null,
+      writeCache: () => {},
+      now: () => Date.now(),
+    }));
+    expect(result).toEqual({ installed: "0.16.1", latest: null, source: "unavailable" });
+  }));
+
+  test("fetch failure with a stale cache falls back to the stale cache instead of giving up", async () => withTmpDir(async () => {
+    const cached = { latest: "0.19.5", checkedAt: 0 };
+    const result = await checkVersion("0.16.1", baseDeps({
+      fetchLatest: async () => null,
+      readCache: () => cached,
+      writeCache: () => { throw new Error("should not write on fetch failure"); },
+      now: () => 13 * 60 * 60 * 1000, // past TTL, so it attempts a fetch first
+      ttlMs: 12 * 60 * 60 * 1000,
+    }));
+    expect(result).toEqual({ installed: "0.16.1", latest: "0.19.5", source: "cache" });
+  }));
+
+  test("never throws even if an injected fetchLatest itself throws (defense in depth)", async () => withTmpDir(async () => {
+    const result = await checkVersion("0.16.1", baseDeps({
+      fetchLatest: async () => { throw new Error("boom"); },
+      readCache: () => null,
+      writeCache: () => {},
+      now: () => Date.now(),
+    }));
+    expect(result).toEqual({ installed: "0.16.1", latest: null, source: "unavailable" });
+  }));
+
+  // ── Real cache FILE (not an in-memory map) — only fetchLatest is mocked,
+  // readCache/writeCache are the real fs-backed defaults, pointed at a tmp
+  // file. Exercises the actual JSON round-trip + corrupt-file tolerance.
+
+  test("real cache file: a network hit writes JSON that a subsequent real read TTL-hits", async () => withTmpDir(async () => {
+    const cachePath = cachePathFor(dir);
+    const { readCache, writeCache } = defaultVersionCheckDeps();
+    let fetchCalls = 0;
+
+    const first = await checkVersion("0.16.1", {
+      cachePath, readCache, writeCache,
+      fetchLatest: async () => { fetchCalls++; return "0.20.1"; },
+      now: () => 1000,
+      ttlMs: 12 * 60 * 60 * 1000,
+    });
+    expect(first).toEqual({ installed: "0.16.1", latest: "0.20.1", source: "network" });
+    expect(existsSync(cachePath)).toBe(true);
+    expect(JSON.parse(readFileSync(cachePath, "utf-8"))).toEqual({ latest: "0.20.1", checkedAt: 1000 });
+
+    // Second call, shortly after, real file read — must NOT re-fetch.
+    const second = await checkVersion("0.16.1", {
+      cachePath, readCache, writeCache,
+      fetchLatest: async () => { fetchCalls++; return "0.99.0"; },
+      now: () => 1000 + 60_000,
+      ttlMs: 12 * 60 * 60 * 1000,
+    });
+    expect(second).toEqual({ installed: "0.16.1", latest: "0.20.1", source: "cache" });
+    expect(fetchCalls).toBe(1);
+  }));
+
+  test("real cache file: corrupt/garbage JSON is treated as no cache — re-fetches instead of throwing", async () => withTmpDir(async () => {
+    const cachePath = cachePathFor(dir);
+    writeFileSync(cachePath, "{ not valid json", "utf-8");
+    const { readCache, writeCache } = defaultVersionCheckDeps();
+
+    const result = await checkVersion("0.16.1", {
+      cachePath, readCache, writeCache,
+      fetchLatest: async () => "0.20.1",
+      now: () => Date.now(),
+      ttlMs: 12 * 60 * 60 * 1000,
+    });
+    expect(result).toEqual({ installed: "0.16.1", latest: "0.20.1", source: "network" });
+  }));
+
+  test("real cache file: missing cache dir is created on write (fresh ~/.flair install)", async () => withTmpDir(async () => {
+    const cachePath = join(dir, "nested", "does-not-exist-yet", ".version-check-cache.json");
+    const { readCache, writeCache } = defaultVersionCheckDeps();
+
+    const result = await checkVersion("0.16.1", {
+      cachePath, readCache, writeCache,
+      fetchLatest: async () => "0.20.1",
+      now: () => Date.now(),
+      ttlMs: 12 * 60 * 60 * 1000,
+    });
+    expect(result.source).toBe("network");
+    expect(existsSync(cachePath)).toBe(true);
+  }));
+});


### PR DESCRIPTION
## Summary

`flair status`/`flair doctor` never told an operator they were on an old, possibly security-vulnerable version — the motivating case (flair#587) is a laptop install that sat on 0.16.1 through v0.17.0 and v0.19.0 (both P0 security fixes) and v0.18.0 (memory-integrity fix), with `flair status` reporting "✓ all checks passing" the whole time.

- **`src/version-check.ts`** — new util. Fetches the latest published `@tpsdev-ai/flair` from `https://registry.npmjs.org/@tpsdev-ai/flair/latest` (same endpoint `flair upgrade` already uses — `{ version }` response, not the dist-tags wrapper). Caches the result to `~/.flair/.version-check-cache.json` with a 12h TTL. Fully DI'd (`VersionCheckDeps`) so tests never touch the network or the real `$HOME`.
  - **Offline-tolerant**: a 3s fetch timeout; any failure (offline, DNS, timeout, non-2xx, bad JSON, or even a misbehaving injected dep) falls back to a stale cache or gives up quietly — `checkVersion()` never throws.
  - **Severity heuristic** (`classifyGap`) — no advisory data available, so it's pure version-gap math: any major version behind, or ≥2 minor versions behind → **red** (the flair#587 case — 0.16.1 → 0.20.1 is 4 minor releases, red); a single minor version behind, or a patch-only gap → **yellow**; equal, ahead (local/dev build), or unparseable → nothing.
- **Wired into `flair status`** (both human and `--json` output) and **`flair doctor`** (new step 0, runs before the Harper port check since it's independent of daemon health). A red gap counts as a `flair doctor` issue (non-zero exit); yellow doesn't. Current installs print nothing extra (`status`) or a quiet `✓ flair X is current` (`doctor`).
- **README** gets an "Upgrading" section — `flair upgrade --check`/`flair upgrade` previously only appeared as a feature-checklist bullet.

## Deferred (noted per issue, not built here)

The issue also proposes an optional **passive per-invocation notice** (npm `update-notifier` style, on every CLI command, opt-out via env). Intentionally **not** built in this PR to keep it focused and reviewable — status/doctor already cover the "operator explicitly checks" path, which is the higher-value fix for the motivating bug. Happy to spec that as a follow-up if wanted.

## Test plan

- [x] `npm run build` clean
- [x] `npm run build:cli` clean
- [x] `npx tsc --noEmit -p tsconfig.check.json` clean
- [x] `npx tsc --noEmit -p tsconfig.cli.json` clean (the config that actually typechecks `src/cli.ts`)
- [x] `bun test test/unit/` — 1562/1562 pass, 0 fail (22 new tests in `test/unit/version-check.test.ts`)
- [x] New tests cover: severity classification (yellow/red thresholds, major vs minor, patch-only), cache TTL respected / stale re-fetch, corrupt-cache-file tolerance, missing-cache-dir creation, and fetch-failure fallback (with and without a cache) — registry fetch and cache file both mocked (plus a few tests against the real fs-backed cache file in a tmp dir)