### PR TITLE
feat(cli): doctor verifies client integration — is Flair working for my agent? (closes #596)

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -25,7 +25,14 @@ import { keystore } from "./keystore.js";
 import { deploy as deployToFabric, validateOptions as validateDeployOptions, buildTargetUrl as buildDeployUrl } from "./deploy.js";
 import { fabricUpgrade } from "./fabric-upgrade.js";
 import { checkVersion, formatVersionNudge } from "./version-check.js";
-import { detectClients, wireCodex, wireGemini, wireCursor, type ClientId } from "./install/clients.js";
+import { detectClients, wireClaudeCode, wireCodex, wireGemini, wireCursor, type ClientId } from "./install/clients.js";
+import {
+  readClientMcpBlock,
+  checkClaudeMdBootstrap,
+  checkSessionStartHook,
+  fixClaudeMdBootstrap,
+  fixSessionStartHook,
+} from "./doctor-client.js";
 
 // Federation crypto helpers — inlined to avoid cross-boundary imports from
 // src/ into resources/, which don't survive npm packaging (see also
@@ -673,6 +680,68 @@ export async function verifySemanticSearch(
         await authFetch(baseUrl, agentId, keyPath, "DELETE", `/Memory/${id}`);
       } catch { /* leave the ephemeral row; it'll age out */ }
     }
+  }
+}
+
+// ─── Doctor: client-integration network checks (flair#588) ────────────────────
+//
+// The pure filesystem checks (MCP block parsing, CLAUDE.md, SessionStart hook)
+// live in src/doctor-client.ts. These two are network-dependent and live here
+// because they reuse authFetch/resolveKeyPath, which are private to this file.
+
+/**
+ * Quick, offline-tolerant reachability probe for a Flair instance's HTTP
+ * endpoint — GETs /Health with a short timeout. Never hangs, never throws:
+ * any failure (timeout, DNS, connection refused, bad URL) is "unreachable".
+ * Mirrors the doctor action's own probePort helper (3000ms AbortSignal.timeout
+ * style), but takes a full URL since client configs point at arbitrary hosts.
+ */
+export async function probeFlairReachable(url: string, timeoutMs = 2000): Promise<boolean> {
+  try {
+    const res = await fetch(`${url.replace(/\/+$/, "")}/Health`, { signal: AbortSignal.timeout(timeoutMs) });
+    return res.status > 0;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Is `agentId` actually registered on the Flair instance at `baseUrl`? Signs
+ * GET /Agent/:id with the agent's own key (same pattern as the `flair init`
+ * verification at line ~2043 and `flair agent rotate` at line ~2596) —
+ * reuses authFetch/resolveKeyPath rather than duplicating the signing logic.
+ *
+ *   200            -> "registered"
+ *   404             -> "not-registered" (a clear, unambiguous "no such agent")
+ *   any other status, or a network error/timeout -> "unreachable" (could not
+ *     verify one way or the other — e.g. a 401/500 doesn't tell us whether
+ *     the agent exists, so we don't claim NOT registered on those)
+ *   no local key found for agentId (checked resolveKeyPath, then keysDir) -> "no-key"
+ *     (can't sign the request at all — distinct from "unreachable" so the
+ *     caller can print an accurate reason)
+ */
+export async function checkAgentRegistered(
+  baseUrl: string,
+  agentId: string,
+  keysDir: string,
+): Promise<{ state: "registered" | "not-registered" | "unreachable" | "no-key"; detail?: string }> {
+  let keyPath = resolveKeyPath(agentId);
+  if (!keyPath) {
+    const candidate = join(keysDir, `${agentId}.key`);
+    if (existsSync(candidate)) keyPath = candidate;
+  }
+  if (!keyPath) {
+    return { state: "no-key", detail: `no local key for agent '${agentId}' to sign the check` };
+  }
+  try {
+    const res = await authFetch(baseUrl, agentId, keyPath, "GET", `/Agent/${agentId}`);
+    if (res.ok) return { state: "registered" };
+    if (res.status === 404) return { state: "not-registered" };
+    const text = await res.text().catch(() => "");
+    return { state: "unreachable", detail: `HTTP ${res.status} ${text.slice(0, 80)}` };
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : String(err);
+    return { state: "unreachable", detail: `instance unreachable: ${message.slice(0, 100)}` };
   }
 }
 
@@ -7466,6 +7535,145 @@ program
         console.log(`  ${render.icons.error} No data directory found`);
         console.log(`     ${render.wrap(render.c.dim, "Fix:")} flair init --agent-id <your-agent>`);
         issues++;
+      }
+    }
+
+    // 7. Client integration (flair#588) — the first 6 checks diagnose the
+    // SERVER side. This diagnoses whether Flair is actually wired to a real
+    // MCP client (Claude Code, Codex, Gemini, Cursor): the MCP block present
+    // + reachable + the configured agent genuinely registered (every detected
+    // client), plus CLAUDE.md + the SessionStart hook (Claude Code only,
+    // since only Claude Code has those mechanisms). Reuses detectClients()
+    // rather than reimplementing client detection.
+    console.log(`\n  ${render.wrap(render.c.bold, "Client integration")}`);
+
+    // Prompt y/N before a content-editing fix, but only when interactive —
+    // in a non-TTY context (CI, scripts) --fix itself is the consent signal,
+    // matching how doctor's other --fix branches already behave unprompted.
+    // Mirrors the confirm pattern at `flair fabric upgrade` (~line 6258).
+    async function confirmFix(question: string): Promise<boolean> {
+      if (!process.stdin.isTTY) return true;
+      const { createInterface } = await import("node:readline");
+      const rl = createInterface({ input: process.stdin, output: process.stdout });
+      const answer: string = await new Promise((res) =>
+        rl.question(question, (a) => { rl.close(); res(a); }),
+      );
+      return /^y(es)?$/i.test(answer.trim());
+    }
+
+    const detectedClients = detectClients().filter((c) => c.detected);
+    if (detectedClients.length === 0) {
+      console.log(`  ${render.icons.info} No MCP client detected — skipping client-integration checks`);
+    } else {
+      let claudeCodeAgentId: string | undefined;
+      let anyKnownAgentId: string | undefined;
+
+      for (const client of detectedClients) {
+        const block = readClientMcpBlock(client.id, homedir());
+        if (client.id === "claude-code" && block.agentId) claudeCodeAgentId = block.agentId;
+        if (block.agentId) anyKnownAgentId = anyKnownAgentId ?? block.agentId;
+
+        if (!block.present) {
+          console.log(`  ${render.icons.error} ${client.label}: no Flair MCP server configured in ${render.wrap(render.c.dim, block.configPath)}`);
+          if (autoFix) {
+            if (dryRun) {
+              console.log(`     ${render.wrap(render.c.dim, "Would wire")} ${client.label} (writes ${block.configPath})`);
+            } else {
+              const proceed = await confirmFix(`  Wire ${client.label} now? [y/N] `);
+              if (!proceed) {
+                console.log(`     Skipped.`);
+              } else {
+                const fixAgentId = opts.agent || process.env.FLAIR_AGENT_ID || anyKnownAgentId;
+                if (!fixAgentId) {
+                  console.log(`     ${render.icons.warn} Cannot auto-wire ${client.label}: no agent id known — pass --agent <id>`);
+                } else {
+                  const wireEnv = { FLAIR_AGENT_ID: fixAgentId, FLAIR_URL: block.flairUrl || baseUrl };
+                  const wireResult =
+                    client.id === "claude-code" ? wireClaudeCode(wireEnv) :
+                    client.id === "codex" ? wireCodex(wireEnv) :
+                    client.id === "gemini" ? wireGemini(wireEnv) :
+                    wireCursor(wireEnv);
+                  console.log(`     ${wireResult.ok ? render.icons.ok : render.icons.warn} ${wireResult.message}`);
+                }
+              }
+            }
+          } else {
+            console.log(`     ${render.wrap(render.c.dim, "Fix:")} flair doctor --fix ${render.wrap(render.c.dim, `(wires ${client.label} automatically)`)}`);
+          }
+          issues++;
+          continue;
+        }
+
+        console.log(`  ${render.icons.ok} ${client.label}: MCP server configured (${render.wrap(render.c.dim, block.configPath)})`);
+
+        const reachable = await probeFlairReachable(block.flairUrl!);
+        if (!reachable) {
+          console.log(`     ${render.icons.warn} FLAIR_URL ${render.wrap(render.c.dim, block.flairUrl!)} not reachable — cannot verify agent registration`);
+          continue;
+        }
+        console.log(`     ${render.icons.ok} FLAIR_URL ${render.wrap(render.c.dim, block.flairUrl!)} reachable`);
+
+        const reg = await checkAgentRegistered(block.flairUrl!, block.agentId!, defaultKeysDir());
+        if (reg.state === "registered") {
+          console.log(`     ${render.icons.ok} agent '${block.agentId}' registered`);
+        } else if (reg.state === "not-registered") {
+          console.log(`     ${render.icons.error} agent '${block.agentId}' is NOT registered on this Flair instance`);
+          console.log(`        ${render.wrap(render.c.dim, "Fix:")} flair agent add ${block.agentId}`);
+          issues++;
+        } else {
+          console.log(`     ${render.icons.warn} could not verify agent registration ${render.wrap(render.c.dim, `(${reg.detail})`)}`);
+        }
+      }
+
+      // Claude-Code-specific: CLAUDE.md + SessionStart hook. Only Claude Code
+      // has these mechanisms, so only run them when claude-code was detected.
+      if (detectedClients.some((c) => c.id === "claude-code")) {
+        const claudeMd = checkClaudeMdBootstrap(process.cwd(), homedir());
+        if (claudeMd.present) {
+          console.log(`  ${render.icons.ok} CLAUDE.md: bootstrap instruction present (${render.wrap(render.c.dim, claudeMd.path!)})`);
+        } else {
+          console.log(`  ${render.icons.error} CLAUDE.md: bootstrap instruction not found (checked ${render.wrap(render.c.dim, join(process.cwd(), "CLAUDE.md"))} and ${render.wrap(render.c.dim, join(homedir(), ".claude", "CLAUDE.md"))})`);
+          if (autoFix) {
+            if (dryRun) {
+              console.log(`     ${render.wrap(render.c.dim, "Would append bootstrap instruction to")} ${join(process.cwd(), "CLAUDE.md")}`);
+            } else {
+              const proceed = await confirmFix(`  Add the Flair bootstrap line to ./CLAUDE.md? [y/N] `);
+              if (!proceed) {
+                console.log(`     Skipped.`);
+              } else {
+                const fixRes = fixClaudeMdBootstrap(process.cwd());
+                console.log(`     ${fixRes.ok ? render.icons.ok : render.icons.warn} ${fixRes.message}`);
+              }
+            }
+          } else {
+            console.log(`     ${render.wrap(render.c.dim, "Fix:")} flair doctor --fix ${render.wrap(render.c.dim, "(adds the mcp__flair__bootstrap line to ./CLAUDE.md)")}`);
+          }
+          issues++;
+        }
+
+        const hook = checkSessionStartHook(homedir());
+        if (hook.present) {
+          console.log(`  ${render.icons.ok} SessionStart hook: flair-session-start wired in ${render.wrap(render.c.dim, hook.path)}`);
+        } else {
+          console.log(`  ${render.icons.error} SessionStart hook: not found in ${render.wrap(render.c.dim, hook.path)}`);
+          if (autoFix) {
+            if (dryRun) {
+              console.log(`     ${render.wrap(render.c.dim, "Would add SessionStart hook to")} ${hook.path}`);
+            } else {
+              const proceed = await confirmFix(`  Add the flair-session-start SessionStart hook to ${hook.path}? [y/N] `);
+              if (!proceed) {
+                console.log(`     Skipped.`);
+              } else {
+                const fixAgentId = claudeCodeAgentId || opts.agent || process.env.FLAIR_AGENT_ID;
+                const fixRes = fixSessionStartHook(homedir(), fixAgentId);
+                console.log(`     ${fixRes.ok ? render.icons.ok : render.icons.warn} ${fixRes.message}`);
+              }
+            }
+          } else {
+            console.log(`     ${render.wrap(render.c.dim, "Fix:")} flair doctor --fix ${render.wrap(render.c.dim, "(adds the flair-session-start SessionStart hook)")}`);
+          }
+          issues++;
+        }
       }
     }
 

--- a/src/doctor-client.ts
+++ b/src/doctor-client.ts
@@ -1,0 +1,285 @@
+// ─── Doctor: client integration checks (flair#588) ──────────────────────────────
+//
+// `flair doctor` diagnosed the SERVER side only (Harper port, keys, config,
+// embeddings, data dir). It had zero visibility into whether the CLIENT
+// integration — the MCP wiring an agent like Claude Code actually uses — is
+// working. A real incident found users with partial setups (MCP block wired
+// but no CLAUDE.md line; or no SessionStart hook) that silently no-op, with
+// no way to tell "is Flair working for my agent?" short of an incident.
+//
+// This module is pure filesystem logic (no network, no crypto) so it's fast
+// and fully unit-testable in isolation — mirrors test/unit/client-wiring.test.ts's
+// technique of overriding process.env.HOME to a temp dir. The two
+// network-dependent checks (reachability + agent registration) live in
+// src/cli.ts alongside authFetch/resolveKeyPath, which they reuse.
+//
+// Every read here is try/catch-wrapped: a missing or malformed config file is
+// "not present", never a thrown error — doctor must never crash or hang on a
+// broken client config.
+
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { clientConfigPath, type ClientId } from "./install/clients.js";
+
+// The exact substring `flair init` writes into CLAUDE.md (src/cli.ts, the
+// `init` action) and that the doctor check + fix both key off of.
+export const CLAUDE_MD_BOOTSTRAP_MARKER = "mcp__flair__bootstrap";
+const CLAUDE_MD_BOOTSTRAP_LINE = "At the start of every session, run mcp__flair__bootstrap before responding.";
+
+// The exact substring identifying a Flair SessionStart hook command (see
+// docs/mcp-clients.md "Auto-recall on session start").
+export const SESSION_START_HOOK_MARKER = "flair-session-start";
+
+// ── shared helpers ──────────────────────────────────────────────────────────
+
+/**
+ * Run `fn` with process.env.HOME temporarily pointed at `homeDir`, then
+ * restore it. clientConfigPath() (src/install/clients.ts) resolves the home
+ * dir via HOME/USERPROFILE at call time (not cached), so this lets us reuse
+ * that single source of truth for per-client config paths while keeping
+ * doctor-client's own functions parameterized by an explicit homeDir for
+ * tests — no test ever touches the real ~/.claude.json etc. The override is
+ * synchronous and restored before this function returns, so it's safe even
+ * though process.env is process-global.
+ */
+function withHome<T>(homeDir: string, fn: () => T): T {
+  const prev = process.env.HOME;
+  process.env.HOME = homeDir;
+  try {
+    return fn();
+  } finally {
+    if (prev === undefined) delete process.env.HOME;
+    else process.env.HOME = prev;
+  }
+}
+
+function readTextFile(path: string): string | null {
+  try {
+    if (!existsSync(path)) return null;
+    return readFileSync(path, "utf-8");
+  } catch {
+    return null;
+  }
+}
+
+// ── check 1: MCP server block present + configured ─────────────────────────
+
+export interface ClientMcpBlockResult {
+  present: boolean;
+  configPath: string;
+  agentId?: string;
+  flairUrl?: string;
+}
+
+/**
+ * Read the Flair MCP server block from `clientId`'s config file. `present`
+ * is true only when the block exists AND both FLAIR_AGENT_ID and FLAIR_URL
+ * are set (non-empty) — a half-wired block (e.g. block present, env missing)
+ * counts as absent for the pass/fail check, but agentId/flairUrl are still
+ * returned when partially found so callers can use whatever is known.
+ */
+export function readClientMcpBlock(clientId: ClientId, homeDir: string): ClientMcpBlockResult {
+  const configPath = withHome(homeDir, () => clientConfigPath(clientId));
+  return clientId === "codex" ? readCodexFlairBlock(configPath) : readJsonFlairBlock(configPath);
+}
+
+function readJsonFlairBlock(configPath: string): ClientMcpBlockResult {
+  const raw = readTextFile(configPath);
+  if (!raw || !raw.trim()) return { present: false, configPath };
+  try {
+    const config = JSON.parse(raw);
+    const flair = config?.mcpServers?.flair;
+    if (!flair || typeof flair !== "object") return { present: false, configPath };
+    const agentId: string | undefined = typeof flair.env?.FLAIR_AGENT_ID === "string" && flair.env.FLAIR_AGENT_ID ? flair.env.FLAIR_AGENT_ID : undefined;
+    const flairUrl: string | undefined = typeof flair.env?.FLAIR_URL === "string" && flair.env.FLAIR_URL ? flair.env.FLAIR_URL : undefined;
+    return { present: !!agentId && !!flairUrl, configPath, agentId, flairUrl };
+  } catch {
+    // Malformed JSON — treat as "not present", never throw.
+    return { present: false, configPath };
+  }
+}
+
+/**
+ * Codex's config is TOML, and this repo carries no TOML parser (see the
+ * comment on _wireCodex in src/install/clients.ts) — so this is a lightweight
+ * string scan, matching the exact shape _wireCodex/tomlSnippet() produce:
+ *
+ *   [mcp_servers.flair]
+ *   command = "npx"
+ *   args = ["-y", "@tpsdev-ai/flair-mcp"]
+ *
+ *   [mcp_servers.flair.env]
+ *   FLAIR_AGENT_ID = "..."
+ *   FLAIR_URL = "..."
+ *
+ * We locate the `[mcp_servers.flair]` header, then collect lines until a
+ * header that is NOT part of this table (i.e. doesn't start with
+ * "[mcp_servers.flair") — deliberately does NOT stop at the nested
+ * `[mcp_servers.flair.env]` sub-table, since that's where the two env keys
+ * actually live.
+ */
+function readCodexFlairBlock(configPath: string): ClientMcpBlockResult {
+  const raw = readTextFile(configPath);
+  if (!raw) return { present: false, configPath };
+  const scanned = scanCodexFlairBlock(raw);
+  return { present: scanned.present, configPath, agentId: scanned.agentId, flairUrl: scanned.flairUrl };
+}
+
+function scanCodexFlairBlock(raw: string): { present: boolean; agentId?: string; flairUrl?: string } {
+  const startMatch = raw.match(/^\[mcp_servers\.flair\]\s*$/m);
+  if (!startMatch || startMatch.index === undefined) return { present: false };
+
+  const rest = raw.slice(startMatch.index);
+  const lines = rest.split("\n");
+  const blockLines: string[] = [lines[0]];
+  for (let i = 1; i < lines.length; i++) {
+    const trimmed = lines[i].trim();
+    if (trimmed.startsWith("[") && !trimmed.startsWith("[mcp_servers.flair")) break;
+    blockLines.push(lines[i]);
+  }
+  const block = blockLines.join("\n");
+
+  const agentMatch = block.match(/^\s*FLAIR_AGENT_ID\s*=\s*"([^"]*)"/m);
+  const urlMatch = block.match(/^\s*FLAIR_URL\s*=\s*"([^"]*)"/m);
+  const agentId = agentMatch?.[1] || undefined;
+  const flairUrl = urlMatch?.[1] || undefined;
+  return { present: !!agentId && !!flairUrl, agentId, flairUrl };
+}
+
+// ── check 3: CLAUDE.md bootstrap instruction (claude-code only) ────────────
+
+export interface ClaudeMdCheckResult {
+  present: boolean;
+  path: string | null;
+}
+
+/**
+ * Pass when EITHER the project-scoped `${cwd}/CLAUDE.md` or the user-level
+ * `~/.claude/CLAUDE.md` contains the bootstrap marker — Claude Code loads
+ * both. Checks cwd first (the convention docs/claude-code.md documents and
+ * what `flair init` tells users to edit).
+ */
+export function checkClaudeMdBootstrap(cwd: string, homeDir: string): ClaudeMdCheckResult {
+  const cwdPath = join(cwd, "CLAUDE.md");
+  const cwdContent = readTextFile(cwdPath);
+  if (cwdContent && cwdContent.includes(CLAUDE_MD_BOOTSTRAP_MARKER)) {
+    return { present: true, path: cwdPath };
+  }
+
+  const homePath = join(homeDir, ".claude", "CLAUDE.md");
+  const homeContent = readTextFile(homePath);
+  if (homeContent && homeContent.includes(CLAUDE_MD_BOOTSTRAP_MARKER)) {
+    return { present: true, path: homePath };
+  }
+
+  return { present: false, path: null };
+}
+
+/**
+ * Append the bootstrap instruction to `${cwd}/CLAUDE.md` (creating it if
+ * absent). Idempotent — safe to call twice; a second call is a no-op that
+ * still reports ok:true.
+ */
+export function fixClaudeMdBootstrap(cwd: string): { ok: boolean; path: string; message: string } {
+  const path = join(cwd, "CLAUDE.md");
+  try {
+    const existing = readTextFile(path) ?? "";
+    if (existing.includes(CLAUDE_MD_BOOTSTRAP_MARKER)) {
+      return { ok: true, path, message: `already present in ${path}` };
+    }
+    const separator = existing.length === 0 ? "" : existing.endsWith("\n\n") ? "" : existing.endsWith("\n") ? "\n" : "\n\n";
+    const block = `${separator}## Flair memory\n\n${CLAUDE_MD_BOOTSTRAP_LINE}\n`;
+    writeFileSync(path, existing + block);
+    return { ok: true, path, message: `added bootstrap instruction to ${path}` };
+  } catch (err: unknown) {
+    const reason = err instanceof Error ? err.message : String(err);
+    return { ok: false, path, message: `could not write ${path}: ${reason}` };
+  }
+}
+
+// ── check 4: settings.json SessionStart hook (claude-code only) ────────────
+
+export interface SessionStartHookCheckResult {
+  present: boolean;
+  path: string;
+}
+
+/**
+ * Pass when ~/.claude/settings.json exists, parses as JSON, and ANY hook
+ * command anywhere under hooks.SessionStart[*].hooks[*].command contains the
+ * flair-session-start marker (see docs/mcp-clients.md for the exact shape).
+ */
+export function checkSessionStartHook(homeDir: string): SessionStartHookCheckResult {
+  const path = join(homeDir, ".claude", "settings.json");
+  const raw = readTextFile(path);
+  if (!raw || !raw.trim()) return { present: false, path };
+  try {
+    const config = JSON.parse(raw);
+    const groups = config?.hooks?.SessionStart;
+    if (!Array.isArray(groups)) return { present: false, path };
+    for (const group of groups) {
+      const hooks = group?.hooks;
+      if (!Array.isArray(hooks)) continue;
+      for (const hook of hooks) {
+        if (typeof hook?.command === "string" && hook.command.includes(SESSION_START_HOOK_MARKER)) {
+          return { present: true, path };
+        }
+      }
+    }
+    return { present: false, path };
+  } catch {
+    return { present: false, path };
+  }
+}
+
+/**
+ * Merge-safe insert of a Flair SessionStart hook group into
+ * ~/.claude/settings.json — creates the file/array if absent, preserves any
+ * other existing hooks/keys (read-parse-merge-write, mirroring wireJsonMcp's
+ * merge safety in src/install/clients.ts; never a blind overwrite). Dedupes:
+ * a no-op (ok:true) if a matching hook is already present, so it's safe to
+ * call twice.
+ */
+export function fixSessionStartHook(homeDir: string, agentId: string | undefined): { ok: boolean; path: string; message: string } {
+  const path = join(homeDir, ".claude", "settings.json");
+  if (!agentId) {
+    return {
+      ok: false,
+      path,
+      message: "no agent id known — pass --agent <id> (or set FLAIR_AGENT_ID) so doctor knows which agent to wire the hook to",
+    };
+  }
+  try {
+    let config: any = {};
+    const raw = readTextFile(path);
+    if (raw && raw.trim()) config = JSON.parse(raw);
+
+    config.hooks = config.hooks && typeof config.hooks === "object" ? config.hooks : {};
+    config.hooks.SessionStart = Array.isArray(config.hooks.SessionStart) ? config.hooks.SessionStart : [];
+
+    const alreadyPresent = config.hooks.SessionStart.some(
+      (group: any) =>
+        Array.isArray(group?.hooks) &&
+        group.hooks.some((h: any) => typeof h?.command === "string" && h.command.includes(SESSION_START_HOOK_MARKER)),
+    );
+    if (alreadyPresent) {
+      return { ok: true, path, message: `already present in ${path}` };
+    }
+
+    config.hooks.SessionStart.push({
+      hooks: [
+        {
+          type: "command",
+          command: `FLAIR_AGENT_ID=${agentId} npx -y @tpsdev-ai/flair-mcp flair-session-start`,
+        },
+      ],
+    });
+
+    mkdirSync(dirname(path), { recursive: true });
+    writeFileSync(path, JSON.stringify(config, null, 2) + "\n");
+    return { ok: true, path, message: `added SessionStart hook to ${path} (agent '${agentId}')` };
+  } catch (err: unknown) {
+    const reason = err instanceof Error ? err.message : String(err);
+    return { ok: false, path, message: `could not write ${path}: ${reason}` };
+  }
+}

--- a/src/install/clients.ts
+++ b/src/install/clients.ts
@@ -193,6 +193,25 @@ function codexConfigPath(): string {
   return join(resolveHome(), ".codex", "config.toml");
 }
 
+/**
+ * Single dispatcher for "where does this client's MCP config live" — used by
+ * `flair doctor`'s client-integration checks (flair#588) to read the config
+ * without duplicating the per-client path logic that already lives here.
+ * Additive only: does not change existing wire/detect behavior.
+ */
+export function clientConfigPath(id: ClientId): string {
+  switch (id) {
+    case "claude-code":
+      return join(resolveHome(), ".claude.json");
+    case "codex":
+      return codexConfigPath();
+    case "gemini":
+      return geminiConfigPath();
+    case "cursor":
+      return cursorConfigPath();
+  }
+}
+
 // ---- Internal wiring functions --------------------------------------------------
 //
 // Claude Code wiring lives inline in src/cli.ts (it writes ~/.claude.json, the

--- a/test/unit/doctor-client-network.test.ts
+++ b/test/unit/doctor-client-network.test.ts
@@ -1,0 +1,130 @@
+import { describe, it, expect, beforeAll, afterAll, afterEach } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import nacl from "tweetnacl";
+
+import { probeFlairReachable, checkAgentRegistered } from "../../src/cli.ts";
+
+/**
+ * flair#588 — the two NETWORK-dependent doctor client-integration checks.
+ * Mirrors test/unit/doctor-embed-verify.test.ts: mock globalThis.fetch, and
+ * write a real Ed25519 key via tweetnacl to a temp keys dir so
+ * checkAgentRegistered's authFetch/buildEd25519Auth signing path runs for
+ * real — only the network response is mocked.
+ */
+
+const AGENT_ID = "doctor-client-test-agent";
+const BASE_URL = "http://127.0.0.1:19926";
+let keysDir: string;
+const realFetch = globalThis.fetch;
+
+beforeAll(() => {
+  keysDir = mkdtempSync(join(tmpdir(), "flair-doctor-client-keys-"));
+  const kp = nacl.sign.keyPair();
+  writeFileSync(join(keysDir, `${AGENT_ID}.key`), Buffer.from(kp.secretKey.slice(0, 32)));
+});
+
+afterAll(() => {
+  rmSync(keysDir, { recursive: true, force: true });
+});
+
+afterEach(() => {
+  globalThis.fetch = realFetch;
+});
+
+function jsonResponse(status: number, body: unknown): Response {
+  return new Response(JSON.stringify(body), { status, headers: { "Content-Type": "application/json" } });
+}
+
+describe("probeFlairReachable", () => {
+  it("returns true when /Health responds", async () => {
+    globalThis.fetch = (async (input: any) => {
+      const url = typeof input === "string" ? input : input.url;
+      expect(url).toBe(`${BASE_URL}/Health`);
+      return jsonResponse(200, { ok: true });
+    }) as typeof fetch;
+    const reachable = await probeFlairReachable(BASE_URL);
+    expect(reachable).toBe(true);
+  });
+
+  it("returns true even on a non-2xx status — reachability just means something answered", async () => {
+    globalThis.fetch = (async () => jsonResponse(401, { error: "unauthorized" })) as typeof fetch;
+    const reachable = await probeFlairReachable(BASE_URL);
+    expect(reachable).toBe(true);
+  });
+
+  it("returns false when fetch throws (connection refused)", async () => {
+    globalThis.fetch = (async () => { throw new Error("ECONNREFUSED"); }) as typeof fetch;
+    const reachable = await probeFlairReachable(BASE_URL);
+    expect(reachable).toBe(false);
+  });
+
+  it("returns false on timeout and never hangs past the configured timeout", async () => {
+    globalThis.fetch = (async (_input: any, init?: any) => {
+      return new Promise((_resolve, reject) => {
+        init?.signal?.addEventListener("abort", () => reject(new Error("aborted")));
+      });
+    }) as typeof fetch;
+    const start = Date.now();
+    const reachable = await probeFlairReachable(BASE_URL, 200);
+    const elapsed = Date.now() - start;
+    expect(reachable).toBe(false);
+    expect(elapsed).toBeLessThan(2000);
+  });
+
+  it("strips a trailing slash before appending /Health", async () => {
+    globalThis.fetch = (async (input: any) => {
+      const url = typeof input === "string" ? input : input.url;
+      expect(url).toBe(`${BASE_URL}/Health`);
+      return jsonResponse(200, {});
+    }) as typeof fetch;
+    const reachable = await probeFlairReachable(`${BASE_URL}/`);
+    expect(reachable).toBe(true);
+  });
+});
+
+describe("checkAgentRegistered", () => {
+  it("returns 'registered' on HTTP 200", async () => {
+    globalThis.fetch = (async (input: any) => {
+      const url = typeof input === "string" ? input : input.url;
+      expect(url).toBe(`${BASE_URL}/Agent/${AGENT_ID}`);
+      return jsonResponse(200, { id: AGENT_ID });
+    }) as typeof fetch;
+    const res = await checkAgentRegistered(BASE_URL, AGENT_ID, keysDir);
+    expect(res.state).toBe("registered");
+  });
+
+  it("returns 'not-registered' on HTTP 404", async () => {
+    globalThis.fetch = (async () => jsonResponse(404, { error: "not found" })) as typeof fetch;
+    const res = await checkAgentRegistered(BASE_URL, AGENT_ID, keysDir);
+    expect(res.state).toBe("not-registered");
+  });
+
+  it("returns 'unreachable' on a network error", async () => {
+    globalThis.fetch = (async () => { throw new Error("ECONNREFUSED"); }) as typeof fetch;
+    const res = await checkAgentRegistered(BASE_URL, AGENT_ID, keysDir);
+    expect(res.state).toBe("unreachable");
+    expect(res.detail).toBeDefined();
+  });
+
+  it("returns 'unreachable' (not 'not-registered') on an ambiguous non-404 error status like 401", async () => {
+    globalThis.fetch = (async () => jsonResponse(401, { error: "bad signature" })) as typeof fetch;
+    const res = await checkAgentRegistered(BASE_URL, AGENT_ID, keysDir);
+    expect(res.state).toBe("unreachable");
+  });
+
+  it("returns 'no-key' when no local key exists for the agent id", async () => {
+    const emptyKeysDir = mkdtempSync(join(tmpdir(), "flair-doctor-client-empty-"));
+    try {
+      // fetch should never even be called — no key to sign with.
+      let called = false;
+      globalThis.fetch = (async () => { called = true; return jsonResponse(200, {}); }) as typeof fetch;
+      const res = await checkAgentRegistered(BASE_URL, "no-such-agent", emptyKeysDir);
+      expect(res.state).toBe("no-key");
+      expect(called).toBe(false);
+    } finally {
+      rmSync(emptyKeysDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/test/unit/doctor-client.test.ts
+++ b/test/unit/doctor-client.test.ts
@@ -1,0 +1,345 @@
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, rmSync, existsSync, readFileSync, writeFileSync, mkdirSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  readClientMcpBlock,
+  checkClaudeMdBootstrap,
+  checkSessionStartHook,
+  fixClaudeMdBootstrap,
+  fixSessionStartHook,
+  CLAUDE_MD_BOOTSTRAP_MARKER,
+  SESSION_START_HOOK_MARKER,
+} from "../../src/doctor-client.ts";
+
+/**
+ * flair#588 — `flair doctor` client-integration checks. Pure filesystem
+ * logic (no network, no crypto), so this mirrors client-wiring.test.ts's
+ * isolation technique: a temp dir stands in for both HOME and cwd, and is
+ * torn down after every test. Never touches the real ~/.claude.json,
+ * ~/.claude/settings.json, ~/.claude/CLAUDE.md, etc.
+ */
+
+let isoHome: string;
+let isoCwd: string;
+
+beforeEach(() => {
+  isoHome = mkdtempSync(join(tmpdir(), "flair-doctor-home-"));
+  isoCwd = mkdtempSync(join(tmpdir(), "flair-doctor-cwd-"));
+});
+
+afterEach(() => {
+  rmSync(isoHome, { recursive: true, force: true });
+  rmSync(isoCwd, { recursive: true, force: true });
+});
+
+describe("readClientMcpBlock", () => {
+  it("claude-code: absent when ~/.claude.json doesn't exist", () => {
+    const res = readClientMcpBlock("claude-code", isoHome);
+    expect(res.present).toBe(false);
+    expect(res.configPath).toBe(join(isoHome, ".claude.json"));
+  });
+
+  it("claude-code: present when ~/.claude.json has mcpServers.flair with both env vars", () => {
+    writeFileSync(
+      join(isoHome, ".claude.json"),
+      JSON.stringify({
+        mcpServers: {
+          flair: {
+            command: "npx",
+            args: ["-y", "@tpsdev-ai/flair-mcp"],
+            env: { FLAIR_AGENT_ID: "me", FLAIR_URL: "http://127.0.0.1:9926" },
+          },
+        },
+      }),
+    );
+    const res = readClientMcpBlock("claude-code", isoHome);
+    expect(res.present).toBe(true);
+    expect(res.agentId).toBe("me");
+    expect(res.flairUrl).toBe("http://127.0.0.1:9926");
+  });
+
+  it("claude-code: not present when the block exists but is missing FLAIR_URL", () => {
+    writeFileSync(
+      join(isoHome, ".claude.json"),
+      JSON.stringify({ mcpServers: { flair: { command: "npx", env: { FLAIR_AGENT_ID: "me" } } } }),
+    );
+    const res = readClientMcpBlock("claude-code", isoHome);
+    expect(res.present).toBe(false);
+    // Partial info still surfaced.
+    expect(res.agentId).toBe("me");
+    expect(res.flairUrl).toBeUndefined();
+  });
+
+  it("claude-code: not present (never throws) on malformed JSON", () => {
+    writeFileSync(join(isoHome, ".claude.json"), "{ not valid json");
+    const res = readClientMcpBlock("claude-code", isoHome);
+    expect(res.present).toBe(false);
+  });
+
+  it("gemini: absent when ~/.gemini/settings.json doesn't exist", () => {
+    const res = readClientMcpBlock("gemini", isoHome);
+    expect(res.present).toBe(false);
+    expect(res.configPath).toBe(join(isoHome, ".gemini", "settings.json"));
+  });
+
+  it("gemini: present when ~/.gemini/settings.json has mcpServers.flair with both env vars", () => {
+    mkdirSync(join(isoHome, ".gemini"), { recursive: true });
+    writeFileSync(
+      join(isoHome, ".gemini", "settings.json"),
+      JSON.stringify({ mcpServers: { flair: { env: { FLAIR_AGENT_ID: "geminibot", FLAIR_URL: "http://127.0.0.1:9926" } } } }),
+    );
+    const res = readClientMcpBlock("gemini", isoHome);
+    expect(res.present).toBe(true);
+    expect(res.agentId).toBe("geminibot");
+    expect(res.flairUrl).toBe("http://127.0.0.1:9926");
+  });
+
+  it("codex: absent when ~/.codex/config.toml doesn't exist", () => {
+    const res = readClientMcpBlock("codex", isoHome);
+    expect(res.present).toBe(false);
+    expect(res.configPath).toBe(join(isoHome, ".codex", "config.toml"));
+  });
+
+  it("codex: present when config.toml has the exact [mcp_servers.flair] + [mcp_servers.flair.env] shape _wireCodex writes", () => {
+    mkdirSync(join(isoHome, ".codex"), { recursive: true });
+    const toml = [
+      "[mcp_servers.flair]",
+      'command = "npx"',
+      'args = ["-y", "@tpsdev-ai/flair-mcp"]',
+      "",
+      "[mcp_servers.flair.env]",
+      'FLAIR_AGENT_ID = "codexbot"',
+      'FLAIR_URL = "http://127.0.0.1:9926"',
+      "",
+    ].join("\n");
+    writeFileSync(join(isoHome, ".codex", "config.toml"), toml);
+    const res = readClientMcpBlock("codex", isoHome);
+    expect(res.present).toBe(true);
+    expect(res.agentId).toBe("codexbot");
+    expect(res.flairUrl).toBe("http://127.0.0.1:9926");
+  });
+
+  it("codex: absent when config.toml has an unrelated table only", () => {
+    mkdirSync(join(isoHome, ".codex"), { recursive: true });
+    writeFileSync(join(isoHome, ".codex", "config.toml"), '[some_other_table]\nkey = 1\n');
+    const res = readClientMcpBlock("codex", isoHome);
+    expect(res.present).toBe(false);
+  });
+
+  it("codex: scan stops at the next unrelated table (doesn't leak keys from a sibling section)", () => {
+    mkdirSync(join(isoHome, ".codex"), { recursive: true });
+    const toml = [
+      "[mcp_servers.flair]",
+      'command = "npx"',
+      "",
+      "[mcp_servers.flair.env]",
+      'FLAIR_AGENT_ID = "codexbot"',
+      'FLAIR_URL = "http://127.0.0.1:9926"',
+      "",
+      "[some_other_table]",
+      'FLAIR_AGENT_ID = "decoy"',
+      "",
+    ].join("\n");
+    writeFileSync(join(isoHome, ".codex", "config.toml"), toml);
+    const res = readClientMcpBlock("codex", isoHome);
+    expect(res.present).toBe(true);
+    expect(res.agentId).toBe("codexbot");
+  });
+
+  it("does not mutate process.env.HOME as an observable side effect", () => {
+    const prevHome = process.env.HOME;
+    readClientMcpBlock("claude-code", isoHome);
+    expect(process.env.HOME).toBe(prevHome);
+  });
+});
+
+describe("checkClaudeMdBootstrap", () => {
+  it("absent when neither cwd/CLAUDE.md nor ~/.claude/CLAUDE.md exist", () => {
+    const res = checkClaudeMdBootstrap(isoCwd, isoHome);
+    expect(res.present).toBe(false);
+    expect(res.path).toBeNull();
+  });
+
+  it("present when cwd/CLAUDE.md contains the marker", () => {
+    writeFileSync(join(isoCwd, "CLAUDE.md"), `# Project\n\nAt the start of every session, run ${CLAUDE_MD_BOOTSTRAP_MARKER} before responding.\n`);
+    const res = checkClaudeMdBootstrap(isoCwd, isoHome);
+    expect(res.present).toBe(true);
+    expect(res.path).toBe(join(isoCwd, "CLAUDE.md"));
+  });
+
+  it("falls back to ~/.claude/CLAUDE.md when cwd/CLAUDE.md is absent", () => {
+    mkdirSync(join(isoHome, ".claude"), { recursive: true });
+    writeFileSync(join(isoHome, ".claude", "CLAUDE.md"), `run ${CLAUDE_MD_BOOTSTRAP_MARKER} before responding.\n`);
+    const res = checkClaudeMdBootstrap(isoCwd, isoHome);
+    expect(res.present).toBe(true);
+    expect(res.path).toBe(join(isoHome, ".claude", "CLAUDE.md"));
+  });
+
+  it("falls back to ~/.claude/CLAUDE.md when cwd/CLAUDE.md exists but lacks the marker", () => {
+    writeFileSync(join(isoCwd, "CLAUDE.md"), "# Project\n\nSome other instructions.\n");
+    mkdirSync(join(isoHome, ".claude"), { recursive: true });
+    writeFileSync(join(isoHome, ".claude", "CLAUDE.md"), `run ${CLAUDE_MD_BOOTSTRAP_MARKER} before responding.\n`);
+    const res = checkClaudeMdBootstrap(isoCwd, isoHome);
+    expect(res.present).toBe(true);
+    expect(res.path).toBe(join(isoHome, ".claude", "CLAUDE.md"));
+  });
+
+  it("absent when both files exist but neither contains the marker", () => {
+    writeFileSync(join(isoCwd, "CLAUDE.md"), "# Project\n");
+    mkdirSync(join(isoHome, ".claude"), { recursive: true });
+    writeFileSync(join(isoHome, ".claude", "CLAUDE.md"), "# Global\n");
+    const res = checkClaudeMdBootstrap(isoCwd, isoHome);
+    expect(res.present).toBe(false);
+  });
+});
+
+describe("fixClaudeMdBootstrap", () => {
+  it("creates CLAUDE.md when absent and appends the bootstrap line", () => {
+    const res = fixClaudeMdBootstrap(isoCwd);
+    expect(res.ok).toBe(true);
+    expect(res.path).toBe(join(isoCwd, "CLAUDE.md"));
+    const content = readFileSync(res.path, "utf-8");
+    expect(content).toContain(CLAUDE_MD_BOOTSTRAP_MARKER);
+    expect(content).toContain("At the start of every session, run mcp__flair__bootstrap before responding.");
+  });
+
+  it("appends to an existing CLAUDE.md, preserving prior content", () => {
+    writeFileSync(join(isoCwd, "CLAUDE.md"), "# My Project\n\nSome existing instructions.\n");
+    const res = fixClaudeMdBootstrap(isoCwd);
+    expect(res.ok).toBe(true);
+    const content = readFileSync(res.path, "utf-8");
+    expect(content).toContain("# My Project");
+    expect(content).toContain("Some existing instructions.");
+    expect(content).toContain(CLAUDE_MD_BOOTSTRAP_MARKER);
+  });
+
+  it("is idempotent — a second call does not double-append", () => {
+    fixClaudeMdBootstrap(isoCwd);
+    const firstContent = readFileSync(join(isoCwd, "CLAUDE.md"), "utf-8");
+    const res2 = fixClaudeMdBootstrap(isoCwd);
+    expect(res2.ok).toBe(true);
+    const secondContent = readFileSync(join(isoCwd, "CLAUDE.md"), "utf-8");
+    expect(secondContent).toBe(firstContent);
+    const occurrences = secondContent.split(CLAUDE_MD_BOOTSTRAP_MARKER).length - 1;
+    expect(occurrences).toBe(1);
+  });
+
+  it("checkClaudeMdBootstrap sees the fix's output as present", () => {
+    fixClaudeMdBootstrap(isoCwd);
+    const res = checkClaudeMdBootstrap(isoCwd, isoHome);
+    expect(res.present).toBe(true);
+    expect(res.path).toBe(join(isoCwd, "CLAUDE.md"));
+  });
+});
+
+describe("checkSessionStartHook", () => {
+  it("absent when ~/.claude/settings.json doesn't exist", () => {
+    const res = checkSessionStartHook(isoHome);
+    expect(res.present).toBe(false);
+    expect(res.path).toBe(join(isoHome, ".claude", "settings.json"));
+  });
+
+  it("present when a SessionStart hook command contains the flair-session-start marker", () => {
+    mkdirSync(join(isoHome, ".claude"), { recursive: true });
+    writeFileSync(
+      join(isoHome, ".claude", "settings.json"),
+      JSON.stringify({
+        hooks: {
+          SessionStart: [
+            { hooks: [{ type: "command", command: `FLAIR_AGENT_ID=me npx -y @tpsdev-ai/flair-mcp ${SESSION_START_HOOK_MARKER}` }] },
+          ],
+        },
+      }),
+    );
+    const res = checkSessionStartHook(isoHome);
+    expect(res.present).toBe(true);
+  });
+
+  it("absent when settings.json exists but has other hooks / no SessionStart", () => {
+    mkdirSync(join(isoHome, ".claude"), { recursive: true });
+    writeFileSync(
+      join(isoHome, ".claude", "settings.json"),
+      JSON.stringify({ hooks: { PreToolUse: [{ hooks: [{ type: "command", command: "some-other-hook" }] }] } }),
+    );
+    const res = checkSessionStartHook(isoHome);
+    expect(res.present).toBe(false);
+  });
+
+  it("absent when a SessionStart hook exists but none of the commands match", () => {
+    mkdirSync(join(isoHome, ".claude"), { recursive: true });
+    writeFileSync(
+      join(isoHome, ".claude", "settings.json"),
+      JSON.stringify({ hooks: { SessionStart: [{ hooks: [{ type: "command", command: "some-other-thing" }] }] } }),
+    );
+    const res = checkSessionStartHook(isoHome);
+    expect(res.present).toBe(false);
+  });
+
+  it("never throws on malformed JSON", () => {
+    mkdirSync(join(isoHome, ".claude"), { recursive: true });
+    writeFileSync(join(isoHome, ".claude", "settings.json"), "{ not valid json");
+    const res = checkSessionStartHook(isoHome);
+    expect(res.present).toBe(false);
+  });
+});
+
+describe("fixSessionStartHook", () => {
+  it("creates settings.json and the SessionStart hook when absent", () => {
+    const res = fixSessionStartHook(isoHome, "me");
+    expect(res.ok).toBe(true);
+    expect(existsSync(res.path)).toBe(true);
+    const config = JSON.parse(readFileSync(res.path, "utf-8"));
+    const commands = config.hooks.SessionStart.flatMap((g: any) => g.hooks.map((h: any) => h.command));
+    expect(commands.some((c: string) => c.includes(SESSION_START_HOOK_MARKER) && c.includes("FLAIR_AGENT_ID=me"))).toBe(true);
+  });
+
+  it("merge-safe: preserves other top-level keys and other hook types", () => {
+    mkdirSync(join(isoHome, ".claude"), { recursive: true });
+    writeFileSync(
+      join(isoHome, ".claude", "settings.json"),
+      JSON.stringify({
+        theme: "dark",
+        hooks: {
+          PreToolUse: [{ hooks: [{ type: "command", command: "some-other-hook" }] }],
+          SessionStart: [{ hooks: [{ type: "command", command: "unrelated-session-hook" }] }],
+        },
+      }),
+    );
+    const res = fixSessionStartHook(isoHome, "me");
+    expect(res.ok).toBe(true);
+    const config = JSON.parse(readFileSync(res.path, "utf-8"));
+    expect(config.theme).toBe("dark"); // preserved
+    expect(config.hooks.PreToolUse[0].hooks[0].command).toBe("some-other-hook"); // preserved
+    const sessionStartCommands = config.hooks.SessionStart.flatMap((g: any) => g.hooks.map((h: any) => h.command));
+    expect(sessionStartCommands).toContain("unrelated-session-hook"); // preserved, not clobbered
+    expect(sessionStartCommands.some((c: string) => c.includes(SESSION_START_HOOK_MARKER))).toBe(true); // added
+  });
+
+  it("is idempotent / dedupes — a second call does not add a duplicate hook group", () => {
+    fixSessionStartHook(isoHome, "me");
+    const path = join(isoHome, ".claude", "settings.json");
+    const firstConfig = JSON.parse(readFileSync(path, "utf-8"));
+    const firstCount = firstConfig.hooks.SessionStart.length;
+
+    const res2 = fixSessionStartHook(isoHome, "me");
+    expect(res2.ok).toBe(true);
+    expect(res2.message).toContain("already present");
+    const secondConfig = JSON.parse(readFileSync(path, "utf-8"));
+    expect(secondConfig.hooks.SessionStart.length).toBe(firstCount);
+  });
+
+  it("returns ok:false and a clear message (never crashes) when agentId is unknown", () => {
+    const res = fixSessionStartHook(isoHome, undefined);
+    expect(res.ok).toBe(false);
+    expect(res.message.length).toBeGreaterThan(0);
+    expect(existsSync(res.path)).toBe(false);
+  });
+
+  it("checkSessionStartHook sees the fix's output as present", () => {
+    fixSessionStartHook(isoHome, "me");
+    const res = checkSessionStartHook(isoHome);
+    expect(res.present).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

`flair doctor` diagnosed only the SERVER side (Harper port/PID, keys dir, config, embeddings round-trip, data dir). It had no visibility into whether the CLIENT integration — the MCP wiring an agent like Claude Code actually uses — was working. A real incident found users with partial setups (MCP block wired but no CLAUDE.md line; or no SessionStart hook) that silently no-op, with no way to tell "is Flair working for my agent?" short of an incident.

This adds a new "Client integration" section to `flair doctor`, run after the existing 6 server-side checks:

- **Checks 1+2 (every detected MCP client — reuses `detectClients()`):**
  - MCP server block present in the client's config, with `FLAIR_AGENT_ID`+`FLAIR_URL` set, and `FLAIR_URL` reachable (short-timeout `/Health` probe, never hangs).
  - The configured agent id is actually registered on that Flair instance (signed `GET /Agent/:id`, reusing `authFetch`/`resolveKeyPath`).
- **Checks 3+4 (Claude Code only — CLAUDE.md and SessionStart hook are Claude-Code-specific mechanisms):**
  - `CLAUDE.md` (project cwd, falling back to `~/.claude/CLAUDE.md`) contains the `mcp__flair__bootstrap` instruction.
  - `~/.claude/settings.json` has a `flair-session-start` `SessionStart` hook.
- If no MCP client is detected at all, prints one info line and skips the section (not counted as an issue).

Severity matches the existing doctor pattern: hard failures (missing block/line/hook, or agent confirmed NOT registered) are `✗` + `issues++` with an exact `Fix:` line; things that genuinely can't be verified (unreachable instance, no local key, timeout) are `⚠` and don't count as issues.

## `--fix` behavior

Extends the doctor command's existing `--fix`/`--dry-run` flags (no new flags added):

- `--dry-run` with `--fix`: prints what would be written, writes nothing.
- `--fix` in a TTY: prompts `y/N` before each content-editing fix (mirrors the existing confirm pattern in `flair fabric upgrade`).
- `--fix` non-TTY (CI/scripts): applies directly, no prompt — `--fix` itself is the consent signal, matching doctor's other existing `--fix` branches.
- Fixes: append the bootstrap line to `./CLAUDE.md` (creates it if absent); merge-safe insert of the SessionStart hook group into `~/.claude/settings.json` (preserves other hooks/keys, dedupes); and — a deliberate small scope extension beyond the issue's literal wording, worth a second look — for a missing MCP block, offers to wire it via the existing, already-tested `wireClaudeCode`/`wireCodex`/`wireGemini`/`wireCursor` functions from `src/install/clients.ts`.

## New / changed files

- `src/install/clients.ts`: adds `export function clientConfigPath(id: ClientId)` — additive only, existing exports/behavior unchanged, `test/unit/client-wiring.test.ts` passes unmodified.
- `src/doctor-client.ts` (new): pure filesystem logic — `readClientMcpBlock`, `checkClaudeMdBootstrap`, `checkSessionStartHook`, `fixClaudeMdBootstrap`, `fixSessionStartHook`. No network, no crypto — fully unit-testable by overriding `HOME`.
- `src/cli.ts`: adds `probeFlairReachable` and `checkAgentRegistered` (network-dependent, reuse `authFetch`/`resolveKeyPath`), and wires the new "7. Client integration" section into the `doctor` action between the existing "6. Data directory" and "Summary" blocks.

## Test coverage

- `test/unit/doctor-client.test.ts` (30 tests): MCP block present/absent for claude-code, gemini (JSON) and codex (TOML regex scan, including a sibling-table boundary case); CLAUDE.md present in cwd / present only in `~/.claude/CLAUDE.md` / absent in both; SessionStart hook present / absent / merge-safety with unrelated hooks preserved; both fix functions writing correctly and idempotent on a second call; dedup.
- `test/unit/doctor-client-network.test.ts` (10 tests): `probeFlairReachable` (reachable, non-2xx-but-reachable, connection error, timeout, trailing-slash handling) and `checkAgentRegistered` (200→registered, 404→not-registered, network error→unreachable, ambiguous 401→unreachable not not-registered, no local key→no-key) — mocks `globalThis.fetch`, signs with a real `tweetnacl` Ed25519 key on disk.
- Full suite: 1584/1584 before → 1624/1624 after (all new tests passing, zero regressions).

## Verification

- `bun run build && bun run build:cli` — clean.
- `npx tsc --noEmit -p tsconfig.cli.json` — zero diagnostics.
- `bun test test/unit/` — 1624 pass / 0 fail.
- Manually smoke-tested `flair doctor` (read-only) and `flair doctor --fix --dry-run` against an isolated `HOME`/cwd — correct output, correct gating of Claude-Code-specific checks on `detectClients()`, no side effects on the real environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
