### PR TITLE
feat(cli): init wires the SessionStart hook + CLAUDE.md line (closes #597)

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -32,6 +32,8 @@ import {
   checkSessionStartHook,
   fixClaudeMdBootstrap,
   fixSessionStartHook,
+  applyOrReportClaudeMdBootstrap,
+  applyOrReportSessionStartHook,
 } from "./doctor-client.js";
 
 // Federation crypto helpers — inlined to avoid cross-boundary imports from
@@ -1645,6 +1647,8 @@ program
   .option("--client <client>", "MCP client(s) to wire: claude-code, codex, gemini, cursor, all, or none")
   .option("--no-mcp", "Skip MCP client wiring (instance + agent only)")
   .option("--skip-smoke", "Skip the MCP smoke test")
+  .option("--skip-claude-md", "Skip appending the Flair bootstrap line to CLAUDE.md (claude-code only)")
+  .option("--skip-hook", "Skip installing the flair-session-start SessionStart hook (claude-code only)")
   .option("--target <url>", "Remote Flair URL (env: FLAIR_TARGET)")
   .option("--remote", "When used with --target, init as hub for remote federation")
   .option("--ops-target <url>", "Explicit ops API URL (env: FLAIR_OPS_TARGET; bypasses port derivation)")
@@ -2190,9 +2194,6 @@ program
         console.log(`     flair soul set --agent ${agentId} --key role --value "..."`);
       }
 
-      console.log(`\n   Claude Code: Add to your CLAUDE.md:`);
-      console.log(`     At the start of every session, run mcp__flair__bootstrap before responding.`);
-
       // ── MCP client wiring ────────────────────────────────────────────────
       // The full one-command front door: detect installed MCP clients and wire
       // each to the zero-install `npx -y @tpsdev-ai/flair-mcp` server. Claude
@@ -2260,6 +2261,30 @@ program
               console.log(`   MCP config (add manually to ~/.claude.json):`);
               console.log(`     { "mcpServers": { "flair": ${JSON.stringify(flairMcpConfig)} } }`);
               wiringResults.push({ client: "claude-code", message: "snippet printed" });
+            }
+
+            // ── CLAUDE.md bootstrap line (flair#597) ──────────────────────────
+            // The MCP block alone isn't a working setup — Claude Code also needs
+            // the bootstrap instruction in CLAUDE.md, or it never calls
+            // mcp__flair__bootstrap and memory silently does nothing. Applied
+            // automatically here (same "just do it" shape as the MCP block
+            // above); --skip-claude-md opts out and prints the exact line to
+            // add by hand instead.
+            const claudeMdResult = applyOrReportClaudeMdBootstrap(process.cwd(), homedir(), !!opts.skipClaudeMd);
+            console.log(`   ${claudeMdResult.ok ? "✓" : "•"} ${claudeMdResult.message}`);
+            if (claudeMdResult.hint) {
+              for (const line of claudeMdResult.hint.split("\n")) console.log(`   ${line}`);
+            }
+
+            // ── SessionStart hook (flair#597) ─────────────────────────────────
+            // Auto-recall on session start needs this hook wired into
+            // ~/.claude/settings.json — without it, mcp__flair__bootstrap only
+            // ever runs if the agent remembers to call it itself.
+            // --skip-hook opts out and prints the exact JSON to add by hand.
+            const hookResult = applyOrReportSessionStartHook(homedir(), agentId, !!opts.skipHook);
+            console.log(`   ${hookResult.ok ? "✓" : "•"} ${hookResult.message}`);
+            if (hookResult.hint) {
+              for (const line of hookResult.hint.split("\n")) console.log(`   ${line}`);
             }
           } else {
             let result: { ok: boolean; message: string };

--- a/src/doctor-client.ts
+++ b/src/doctor-client.ts
@@ -283,3 +283,101 @@ export function fixSessionStartHook(homeDir: string, agentId: string | undefined
     return { ok: false, path, message: `could not write ${path}: ${reason}` };
   }
 }
+
+// ── init integration: apply-or-report (flair#597) ──────────────────────────
+//
+// `flair init`'s claude-code wiring wrote the MCP server block into the
+// client config but left the other two legs manual: the CLAUDE.md bootstrap
+// line was only ever printed as a copy-paste hint, and the SessionStart hook
+// wasn't mentioned by init at all. A field incident (2026-07-02 adopter
+// retro) found real users with exactly those partial setups — MCP wired but
+// no CLAUDE.md line, or no SessionStart hook — discovered only during an
+// incident retrospective.
+//
+// These two functions are the shared "apply the fix, or (if skipped/failed)
+// report exactly what's missing" logic `flair init` (src/cli.ts) calls for
+// each leg, one call per leg, right after it wires the MCP block. Pure fs
+// logic, parameterized by cwd/homeDir so it's unit-testable the same way as
+// the rest of this module — no test ever touches the real environment.
+//
+// This mirrors init's existing MCP-block wiring shape: apply automatically
+// by default (init already writes ~/.claude.json unprompted), with a
+// --skip-<leg> flag as the opt-out — not doctor's TTY-gated confirmFix
+// prompt, which is a different, appropriately heavier flow for "you already
+// have a broken/partial setup, want me to fix it now" run after the fact.
+
+export interface ApplyOrReportResult {
+  /** True only when this call actually wrote a file (not "already present"). */
+  applied: boolean;
+  /** True when the leg ends in a good state — already present, or freshly fixed. */
+  ok: boolean;
+  /** Human-readable status line, e.g. for console.log. */
+  message: string;
+  /** Present only when skipped or the fix failed — exact copy-paste instructions. */
+  hint?: string;
+}
+
+function indentLines(s: string): string {
+  return s
+    .split("\n")
+    .map((l) => `     ${l}`)
+    .join("\n");
+}
+
+/**
+ * Apply-or-report for the CLAUDE.md bootstrap leg. Idempotent: a second call
+ * after the line is present (whether from a prior call or already there)
+ * reports ok:true, applied:false — safe to call on every `flair init`.
+ */
+export function applyOrReportClaudeMdBootstrap(cwd: string, homeDir: string, skip: boolean): ApplyOrReportResult {
+  const existing = checkClaudeMdBootstrap(cwd, homeDir);
+  if (existing.present) {
+    return { applied: false, ok: true, message: `CLAUDE.md already has the bootstrap instruction (${existing.path})` };
+  }
+
+  const hint = `Add to your CLAUDE.md:\n${indentLines(CLAUDE_MD_BOOTSTRAP_LINE)}`;
+  if (skip) {
+    return { applied: false, ok: false, message: "CLAUDE.md bootstrap instruction skipped (--skip-claude-md)", hint };
+  }
+
+  const fix = fixClaudeMdBootstrap(cwd);
+  return { applied: fix.ok, ok: fix.ok, message: fix.message, hint: fix.ok ? undefined : hint };
+}
+
+function sessionStartHookHint(agentId: string, path: string): string {
+  const snippet = {
+    hooks: {
+      SessionStart: [
+        {
+          hooks: [
+            {
+              type: "command",
+              command: `FLAIR_AGENT_ID=${agentId} npx -y @tpsdev-ai/flair-mcp flair-session-start`,
+            },
+          ],
+        },
+      ],
+    },
+  };
+  return `Add this to ${path}:\n${indentLines(JSON.stringify(snippet, null, 2))}`;
+}
+
+/**
+ * Apply-or-report for the SessionStart hook leg. Idempotent: a second call
+ * after the hook is present (whether from a prior call or already there)
+ * reports ok:true, applied:false — safe to call on every `flair init`.
+ */
+export function applyOrReportSessionStartHook(homeDir: string, agentId: string, skip: boolean): ApplyOrReportResult {
+  const existing = checkSessionStartHook(homeDir);
+  if (existing.present) {
+    return { applied: false, ok: true, message: `SessionStart hook already wired in ${existing.path}` };
+  }
+
+  const hint = sessionStartHookHint(agentId, existing.path);
+  if (skip) {
+    return { applied: false, ok: false, message: "SessionStart hook skipped (--skip-hook)", hint };
+  }
+
+  const fix = fixSessionStartHook(homeDir, agentId);
+  return { applied: fix.ok, ok: fix.ok, message: fix.message, hint: fix.ok ? undefined : hint };
+}

--- a/test/unit/init-client-wiring.test.ts
+++ b/test/unit/init-client-wiring.test.ts
@@ -1,0 +1,217 @@
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, rmSync, existsSync, readFileSync, writeFileSync, mkdirSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  applyOrReportClaudeMdBootstrap,
+  applyOrReportSessionStartHook,
+  checkClaudeMdBootstrap,
+  checkSessionStartHook,
+  CLAUDE_MD_BOOTSTRAP_MARKER,
+  SESSION_START_HOOK_MARKER,
+} from "../../src/doctor-client.ts";
+
+/**
+ * flair#597 — `flair init`'s claude-code wiring used to write the MCP block
+ * into ~/.claude.json but leave the other two legs manual: the CLAUDE.md
+ * bootstrap line was only ever printed as a copy-paste hint, and the
+ * SessionStart hook wasn't mentioned by init at all. This tests the
+ * apply-or-report orchestration (src/doctor-client.ts) that init now calls
+ * for both legs, right after it wires the MCP block — same isolation
+ * technique as doctor-client.test.ts: a temp dir stands in for both HOME and
+ * cwd, torn down after every test, never touching the real filesystem.
+ */
+
+let isoHome: string;
+let isoCwd: string;
+
+beforeEach(() => {
+  isoHome = mkdtempSync(join(tmpdir(), "flair-init-home-"));
+  isoCwd = mkdtempSync(join(tmpdir(), "flair-init-cwd-"));
+});
+
+afterEach(() => {
+  rmSync(isoHome, { recursive: true, force: true });
+  rmSync(isoCwd, { recursive: true, force: true });
+});
+
+describe("applyOrReportClaudeMdBootstrap", () => {
+  it("applies the fix when CLAUDE.md is absent and skip=false", () => {
+    const res = applyOrReportClaudeMdBootstrap(isoCwd, isoHome, false);
+    expect(res.applied).toBe(true);
+    expect(res.ok).toBe(true);
+    expect(res.hint).toBeUndefined();
+    const content = readFileSync(join(isoCwd, "CLAUDE.md"), "utf-8");
+    expect(content).toContain(CLAUDE_MD_BOOTSTRAP_MARKER);
+  });
+
+  it("reports already-present without writing when the marker already exists", () => {
+    writeFileSync(join(isoCwd, "CLAUDE.md"), `# Project\n\nrun ${CLAUDE_MD_BOOTSTRAP_MARKER} first.\n`);
+    const before = readFileSync(join(isoCwd, "CLAUDE.md"), "utf-8");
+    const res = applyOrReportClaudeMdBootstrap(isoCwd, isoHome, false);
+    expect(res.applied).toBe(false);
+    expect(res.ok).toBe(true);
+    expect(res.message).toContain("already has the bootstrap instruction");
+    expect(res.hint).toBeUndefined();
+    expect(readFileSync(join(isoCwd, "CLAUDE.md"), "utf-8")).toBe(before);
+  });
+
+  it("does not write and reports the exact missing line when skip=true", () => {
+    const res = applyOrReportClaudeMdBootstrap(isoCwd, isoHome, true);
+    expect(res.applied).toBe(false);
+    expect(res.ok).toBe(false);
+    expect(existsSync(join(isoCwd, "CLAUDE.md"))).toBe(false);
+    expect(res.hint).toBeDefined();
+    expect(res.hint).toContain(CLAUDE_MD_BOOTSTRAP_MARKER);
+    expect(res.message).toContain("--skip-claude-md");
+  });
+
+  it("also honors a marker already present in ~/.claude/CLAUDE.md (checkClaudeMdBootstrap's fallback)", () => {
+    mkdirSync(join(isoHome, ".claude"), { recursive: true });
+    writeFileSync(join(isoHome, ".claude", "CLAUDE.md"), `run ${CLAUDE_MD_BOOTSTRAP_MARKER} first.\n`);
+    const res = applyOrReportClaudeMdBootstrap(isoCwd, isoHome, false);
+    expect(res.applied).toBe(false);
+    expect(res.ok).toBe(true);
+    expect(existsSync(join(isoCwd, "CLAUDE.md"))).toBe(false); // no redundant write
+  });
+
+  it("is idempotent — calling twice with skip=false does not double-append", () => {
+    applyOrReportClaudeMdBootstrap(isoCwd, isoHome, false);
+    const firstContent = readFileSync(join(isoCwd, "CLAUDE.md"), "utf-8");
+    const res2 = applyOrReportClaudeMdBootstrap(isoCwd, isoHome, false);
+    expect(res2.applied).toBe(false);
+    expect(res2.ok).toBe(true);
+    const secondContent = readFileSync(join(isoCwd, "CLAUDE.md"), "utf-8");
+    expect(secondContent).toBe(firstContent);
+    const occurrences = secondContent.split(CLAUDE_MD_BOOTSTRAP_MARKER).length - 1;
+    expect(occurrences).toBe(1);
+  });
+
+  it("preserves existing CLAUDE.md content (merge-safe append, not overwrite)", () => {
+    writeFileSync(join(isoCwd, "CLAUDE.md"), "# My Project\n\nExisting project instructions.\n");
+    const res = applyOrReportClaudeMdBootstrap(isoCwd, isoHome, false);
+    expect(res.applied).toBe(true);
+    const content = readFileSync(join(isoCwd, "CLAUDE.md"), "utf-8");
+    expect(content).toContain("# My Project");
+    expect(content).toContain("Existing project instructions.");
+    expect(content).toContain(CLAUDE_MD_BOOTSTRAP_MARKER);
+  });
+
+  it("simulated re-run of init (apply, then apply again) matches checkClaudeMdBootstrap's view", () => {
+    applyOrReportClaudeMdBootstrap(isoCwd, isoHome, false);
+    applyOrReportClaudeMdBootstrap(isoCwd, isoHome, false);
+    const check = checkClaudeMdBootstrap(isoCwd, isoHome);
+    expect(check.present).toBe(true);
+    expect(check.path).toBe(join(isoCwd, "CLAUDE.md"));
+  });
+});
+
+describe("applyOrReportSessionStartHook", () => {
+  it("applies the fix when the hook is absent and skip=false", () => {
+    const res = applyOrReportSessionStartHook(isoHome, "my-agent", false);
+    expect(res.applied).toBe(true);
+    expect(res.ok).toBe(true);
+    expect(res.hint).toBeUndefined();
+    const config = JSON.parse(readFileSync(join(isoHome, ".claude", "settings.json"), "utf-8"));
+    const commands = config.hooks.SessionStart.flatMap((g: any) => g.hooks.map((h: any) => h.command));
+    expect(commands.some((c: string) => c.includes(SESSION_START_HOOK_MARKER) && c.includes("FLAIR_AGENT_ID=my-agent"))).toBe(true);
+  });
+
+  it("reports already-present without writing when the hook already exists", () => {
+    mkdirSync(join(isoHome, ".claude"), { recursive: true });
+    const settingsPath = join(isoHome, ".claude", "settings.json");
+    writeFileSync(
+      settingsPath,
+      JSON.stringify({
+        hooks: { SessionStart: [{ hooks: [{ type: "command", command: `FLAIR_AGENT_ID=my-agent npx -y @tpsdev-ai/flair-mcp ${SESSION_START_HOOK_MARKER}` }] }] },
+      }),
+    );
+    const before = readFileSync(settingsPath, "utf-8");
+    const res = applyOrReportSessionStartHook(isoHome, "my-agent", false);
+    expect(res.applied).toBe(false);
+    expect(res.ok).toBe(true);
+    expect(res.message).toContain("already wired");
+    expect(readFileSync(settingsPath, "utf-8")).toBe(before);
+  });
+
+  it("does not write and reports the exact missing JSON when skip=true", () => {
+    const res = applyOrReportSessionStartHook(isoHome, "my-agent", true);
+    expect(res.applied).toBe(false);
+    expect(res.ok).toBe(false);
+    expect(existsSync(join(isoHome, ".claude", "settings.json"))).toBe(false);
+    expect(res.hint).toBeDefined();
+    expect(res.hint).toContain(SESSION_START_HOOK_MARKER);
+    expect(res.hint).toContain("my-agent");
+    expect(res.message).toContain("--skip-hook");
+  });
+
+  it("is idempotent — calling twice with skip=false does not duplicate the hook group", () => {
+    applyOrReportSessionStartHook(isoHome, "my-agent", false);
+    const path = join(isoHome, ".claude", "settings.json");
+    const firstConfig = JSON.parse(readFileSync(path, "utf-8"));
+    const firstCount = firstConfig.hooks.SessionStart.length;
+
+    const res2 = applyOrReportSessionStartHook(isoHome, "my-agent", false);
+    expect(res2.applied).toBe(false);
+    expect(res2.ok).toBe(true);
+    const secondConfig = JSON.parse(readFileSync(path, "utf-8"));
+    expect(secondConfig.hooks.SessionStart.length).toBe(firstCount);
+  });
+
+  it("merge-safe: preserves other top-level keys and other hook types in settings.json", () => {
+    mkdirSync(join(isoHome, ".claude"), { recursive: true });
+    const settingsPath = join(isoHome, ".claude", "settings.json");
+    writeFileSync(
+      settingsPath,
+      JSON.stringify({
+        theme: "dark",
+        hooks: {
+          PreToolUse: [{ hooks: [{ type: "command", command: "some-other-hook" }] }],
+          SessionStart: [{ hooks: [{ type: "command", command: "unrelated-session-hook" }] }],
+        },
+      }),
+    );
+    const res = applyOrReportSessionStartHook(isoHome, "my-agent", false);
+    expect(res.applied).toBe(true);
+    const config = JSON.parse(readFileSync(settingsPath, "utf-8"));
+    expect(config.theme).toBe("dark");
+    expect(config.hooks.PreToolUse[0].hooks[0].command).toBe("some-other-hook");
+    const sessionStartCommands = config.hooks.SessionStart.flatMap((g: any) => g.hooks.map((h: any) => h.command));
+    expect(sessionStartCommands).toContain("unrelated-session-hook");
+    expect(sessionStartCommands.some((c: string) => c.includes(SESSION_START_HOOK_MARKER))).toBe(true);
+  });
+
+  it("simulated re-run of init (apply, then apply again) matches checkSessionStartHook's view", () => {
+    applyOrReportSessionStartHook(isoHome, "my-agent", false);
+    applyOrReportSessionStartHook(isoHome, "my-agent", false);
+    const check = checkSessionStartHook(isoHome);
+    expect(check.present).toBe(true);
+  });
+});
+
+describe("init re-run simulation (both legs together)", () => {
+  it("running init-shaped wiring twice in a row is a fully idempotent no-op the second time", () => {
+    const first = {
+      claudeMd: applyOrReportClaudeMdBootstrap(isoCwd, isoHome, false),
+      hook: applyOrReportSessionStartHook(isoHome, "my-agent", false),
+    };
+    expect(first.claudeMd.applied).toBe(true);
+    expect(first.hook.applied).toBe(true);
+
+    const claudeMdSnapshot = readFileSync(join(isoCwd, "CLAUDE.md"), "utf-8");
+    const settingsSnapshot = readFileSync(join(isoHome, ".claude", "settings.json"), "utf-8");
+
+    const second = {
+      claudeMd: applyOrReportClaudeMdBootstrap(isoCwd, isoHome, false),
+      hook: applyOrReportSessionStartHook(isoHome, "my-agent", false),
+    };
+    expect(second.claudeMd.applied).toBe(false);
+    expect(second.claudeMd.ok).toBe(true);
+    expect(second.hook.applied).toBe(false);
+    expect(second.hook.ok).toBe(true);
+
+    expect(readFileSync(join(isoCwd, "CLAUDE.md"), "utf-8")).toBe(claudeMdSnapshot);
+    expect(readFileSync(join(isoHome, ".claude", "settings.json"), "utf-8")).toBe(settingsSnapshot);
+  });
+});


### PR DESCRIPTION
## Summary

`flair init`'s claude-code wiring wrote the MCP server block into `~/.claude.json` but left the other two legs of a working setup manual: the CLAUDE.md bootstrap line was only ever printed as a copy-paste hint, and the `flair-session-start` SessionStart hook wasn't mentioned by init at all. A field incident (2026-07-02 adopter retro) found real users with exactly those partial setups — MCP wired but no CLAUDE.md line, or the hook skipped — discovered only during an incident retrospective, one after delegating the setup to the agent itself.

This wires both remaining legs into `flair init`'s claude-code branch, right after it wires the MCP block:

- **CLAUDE.md bootstrap line** — appends the `mcp__flair__bootstrap` instruction to `./CLAUDE.md` (creating it if absent), merge-safe (preserves existing content), idempotent.
- **SessionStart hook** — merge-safe insert of the `flair-session-start` hook into `~/.claude/settings.json` (preserves other hook groups/keys, dedupes on repeat).

Both apply **automatically by default** — the same "just do it" shape as init's existing MCP-block wiring (which already writes `~/.claude.json` unprompted, no y/N confirm). Two new flags opt out per leg:

- `--skip-claude-md` — skip the CLAUDE.md append; prints the exact line to add by hand instead.
- `--skip-hook` — skip the SessionStart hook install; prints the exact JSON to add by hand instead.

Also removes the old blanket `"Claude Code: Add to your CLAUDE.md: ..."` print, which fired unconditionally even when Claude Code wasn't the client actually being wired (e.g. `--client codex`) — now the message is scoped to the claude-code branch and reflects what actually happened.

## Reuse of #599

PR #599 (doctor client-checks, merged just ahead of this branch) added `fixClaudeMdBootstrap` + `fixSessionStartHook` in `src/doctor-client.ts` — merge-safe, idempotent, already unit-tested (30 tests). This PR reuses those functions directly rather than reimplementing them, and adds two small orchestration wrappers alongside them:

- `applyOrReportClaudeMdBootstrap(cwd, homeDir, skip)`
- `applyOrReportSessionStartHook(homeDir, agentId, skip)`

Both are pure fs logic (no network, no crypto), parameterized by cwd/homeDir so they're unit-testable in isolation — same technique as the rest of `doctor-client.ts`. `flair init` (`src/cli.ts`) calls them and prints the returned `message`/`hint`; `flair doctor --fix`'s existing TTY-confirm flow is untouched (different, appropriately heavier shape for "you already have a broken setup" vs init's "apply as part of first-run setup").

## Test coverage

`test/unit/init-client-wiring.test.ts` (14 tests, isolated temp-dir HOME/cwd, mirrors `doctor-client.test.ts`'s technique):
- apply-when-absent for both legs
- already-present → no-op, no write
- skip=true → no write, exact copy-paste hint returned
- idempotency — calling twice produces a byte-identical file the second time
- merge-safety — preserves unrelated CLAUDE.md content / settings.json keys and other hook groups
- combined "run init twice" simulation across both legs together

## Verification

- `bun run build && bun run build:cli` — clean.
- `npx tsc --noEmit -p tsconfig.cli.json` — zero diagnostics.
- `bun test test/unit/` — 1638/1638 pass (1624/1624 baseline off `main` post-#599, +14 new tests, 0 regressions).
- `node dist/cli.js init --help` — confirms `--skip-claude-md` / `--skip-hook` render correctly alongside the existing flags.

🤖 Generated with [Claude Code](https://claude.com/claude-code)