### PR TITLE
fix(cli): doctor reports not-registered on 401/403 unknown-agent, not just 404 (closes #602)

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -714,13 +714,34 @@ export async function probeFlairReachable(url: string, timeoutMs = 2000): Promis
  * reuses authFetch/resolveKeyPath rather than duplicating the signing logic.
  *
  *   200            -> "registered"
- *   404             -> "not-registered" (a clear, unambiguous "no such agent")
+ *   401/403 carrying the server's "unknown_agent" signal -> "not-registered"
+ *     (see below — this is the actual live behavior for a missing agent, NOT
+ *     404)
  *   any other status, or a network error/timeout -> "unreachable" (could not
- *     verify one way or the other — e.g. a 401/500 doesn't tell us whether
- *     the agent exists, so we don't claim NOT registered on those)
+ *     verify one way or the other — e.g. a bare 401/403/500 doesn't tell us
+ *     whether the agent exists, so we don't claim NOT registered on those)
  *   no local key found for agentId (checked resolveKeyPath, then keysDir) -> "no-key"
  *     (can't sign the request at all — distinct from "unreachable" so the
  *     caller can print an accurate reason)
+ *
+ * Why not 404: an unregistered agent never actually reaches the /Agent/:id
+ * resource handler (which is where a 404 would come from) — Flair's own
+ * signed-auth middleware (resources/auth-middleware.ts) rejects the request
+ * first, once it can't find an Agent record matching the signing identity.
+ * On current main that's an explicit `401 {"error":"unknown_agent"}` — Live-
+ * verified 2026-07-07 against a local Flair instance with a resolvable-but-
+ * unregistered signing key: `401 Unauthorized`, body `{"error":"unknown_agent"}`.
+ * Some server versions/paths may instead surface Harper's native
+ * AccessViolation as a 403 for the same condition, so both codes are checked
+ * — but ONLY when the response also carries the unknown-agent marker; a bare
+ * 401/403 without it (e.g. a real AccessViolation for an agent that exists
+ * but fails a resource-level authorization check) stays "unreachable", since
+ * the server can't always distinguish "agent doesn't exist" from "signing key
+ * doesn't match a known agent" and we don't want to falsely claim
+ * not-registered on that ambiguity. We only make the not-registered call
+ * because we ALREADY have a local signing key that resolved for this
+ * agentId (checked above) — so this isn't a client-side key problem, and the
+ * server naming the agent unknown is a reliable, actionable signal.
  */
 export async function checkAgentRegistered(
   baseUrl: string,
@@ -740,6 +761,9 @@ export async function checkAgentRegistered(
     if (res.ok) return { state: "registered" };
     if (res.status === 404) return { state: "not-registered" };
     const text = await res.text().catch(() => "");
+    if ((res.status === 401 || res.status === 403) && /unknown_agent/i.test(text)) {
+      return { state: "not-registered", detail: `HTTP ${res.status} ${text.slice(0, 80)}` };
+    }
     return { state: "unreachable", detail: `HTTP ${res.status} ${text.slice(0, 80)}` };
   } catch (err: unknown) {
     const message = err instanceof Error ? err.message : String(err);

--- a/test/unit/doctor-client-network.test.ts
+++ b/test/unit/doctor-client-network.test.ts
@@ -114,6 +114,41 @@ describe("checkAgentRegistered", () => {
     expect(res.state).toBe("unreachable");
   });
 
+  // flair#602 — an unregistered agent never actually returns 404: Flair's
+  // signed-auth middleware (resources/auth-middleware.ts) rejects the request
+  // before the /Agent/:id resource handler runs. Live-verified against a
+  // local Flair instance: a signed GET with a resolvable-but-unregistered
+  // key returns 401 with body {"error":"unknown_agent"}. Since we already
+  // have a LOCAL key that resolved (not a client-side key problem), that
+  // specific signal is treated as a reliable "not registered".
+  it("returns 'not-registered' on HTTP 401 with the server's unknown_agent signal", async () => {
+    globalThis.fetch = (async () => jsonResponse(401, { error: "unknown_agent" })) as typeof fetch;
+    const res = await checkAgentRegistered(BASE_URL, AGENT_ID, keysDir);
+    expect(res.state).toBe("not-registered");
+    expect(res.detail).toContain("401");
+  });
+
+  // Some server versions/paths may surface the same "no such agent" condition
+  // as Harper's native AccessViolation (403) instead of the custom
+  // middleware's 401 — handle both, per Sherlock's live-verification note on
+  // #599 that two reviewers saw two different codes.
+  it("returns 'not-registered' on HTTP 403 with the server's unknown_agent signal", async () => {
+    globalThis.fetch = (async () => jsonResponse(403, { error: "unknown_agent" })) as typeof fetch;
+    const res = await checkAgentRegistered(BASE_URL, AGENT_ID, keysDir);
+    expect(res.state).toBe("not-registered");
+    expect(res.detail).toContain("403");
+  });
+
+  it("returns 'unreachable' (not 'not-registered') on a bare 403 AccessViolation without the unknown_agent marker", async () => {
+    // A 403 for an agent that IS known but fails a resource-level
+    // authorization check (e.g. Harper's native AccessViolation) is a
+    // genuinely different, ambiguous case — stay conservative and don't
+    // claim not-registered just because the status code matches.
+    globalThis.fetch = (async () => new Response("Unauthorized access to resource", { status: 403 })) as typeof fetch;
+    const res = await checkAgentRegistered(BASE_URL, AGENT_ID, keysDir);
+    expect(res.state).toBe("unreachable");
+  });
+
   it("returns 'no-key' when no local key exists for the agent id", async () => {
     const emptyKeysDir = mkdtempSync(join(tmpdir(), "flair-doctor-client-empty-"));
     try {


### PR DESCRIPTION
## Problem

`checkAgentRegistered` (added in #599) only ever treated a `404` on the signed `GET /Agent/:id` as "not-registered". But an unregistered agent never actually returns 404 — Flair's signed-auth middleware (`resources/auth-middleware.ts`) rejects the request before the `/Agent/:id` resource handler runs, once it can't find an `Agent` record matching the signing identity. So the 404 branch was dead, and a genuinely-missing agent surfaced as ⚠ "couldn't verify" instead of ✗ "not registered — run `flair agent add`", defeating the point of the check.

## What I actually observed (live)

Signed a `GET /Agent/<id>` against a live local Flair instance (rockit, `http://localhost:9926`) using a resolvable-but-unregistered local key (same signing path `checkAgentRegistered`/`authFetch` use — `resolveKeyPath` + `buildEd25519Auth`):

```
status=401 statusText=Unauthorized
body={"error":"unknown_agent"}
```

This lines up exactly with `resources/auth-middleware.ts` line 252:
```ts
const agent = await (databases as any).flair.Agent.get(agentId);
if (!agent) return new Response(JSON.stringify({ error: "unknown_agent" }), { status: 401 });
```
This check runs *before* `Agent.ts`'s own `allowRead()`, so for a signed request with an agent that has no matching record, 401 `unknown_agent` is the only reachable code path on current main. The `403 AccessViolation` one reviewer on #599 saw is Harper's own native RBAC violation (`AccessViolation` class — 403 when a `user` is present, 401 when absent) — a different failure mode, most likely a *known* agent that fails a resource-level authorization check, not an unregistered one.

## The fix

In `checkAgentRegistered` (`src/cli.ts`):
- Keep 200 → `registered`, keep the (dead but harmless) 404 → `not-registered` branch for defense-in-depth.
- **New:** when the response is `401` or `403` **and** the body contains the server's `unknown_agent` marker → `not-registered` (✗, with the `flair agent add <id>` fix — same as the existing ✗ path).
- Everything else (bare 401/403 without the marker, other statuses like 500, network errors/timeouts, no local key) stays `unreachable` (⚠ "couldn't verify").

This is conservative but actionable, per Sherlock's point on #599: the server can't always distinguish "agent doesn't exist" from "signing key doesn't match a known agent" in general. But `checkAgentRegistered` only reaches this branch after it has *already* resolved a local signing key for this exact `agentId` (checked earlier in the function — if no key resolves, we return `no-key` before ever sending the request). So a 401/403 that explicitly names the agent unknown, on a request signed with a key that DOES resolve locally, is a strong, actionable signal that the agent isn't registered on this instance — not a client-side key problem. A bare 403 `AccessViolation` (no `unknown_agent` marker) is left ambiguous on purpose, since that's a different, more uncertain failure mode.

## Tests

Added to `test/unit/doctor-client-network.test.ts`:
- `401` + `{"error":"unknown_agent"}` → `not-registered`
- `403` + `{"error":"unknown_agent"}` → `not-registered`
- bare `403` "Unauthorized access to resource" (no marker) → stays `unreachable` (regression guard against over-claiming)

Existing bare-`401` "bad signature" test (no marker) still asserts `unreachable` — validates the conservative branch is unchanged for that case.

## Verification

- `bun run build && bun run build:cli` — clean
- `npx tsc --noEmit -p tsconfig.cli.json` — clean
- `bun test test/unit/` — **1641 pass, 0 fail** (106 files)
- `bun test test/unit/doctor-client-network.test.ts` — **13 pass, 0 fail**

Closes #602.