### PR TITLE
ci: wire flair-mcp package tests into the merge gate (closes #491)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -60,6 +60,17 @@ jobs:
           mode: firewall-free
       - run: sfw bun install --frozen-lockfile
       - run: bun test test/unit/
+      # packages/flair-mcp/test/*.test.ts (mcp.test.ts, mcp-node-preflight.test.ts,
+      # session-start-hook.test.ts) weren't gated by CI — `bun test test/unit/`
+      # above only covers the repo root (closes #491, follow-up to #490 per Kern's
+      # review). All three files are hermetic: pure-logic assertions, an injected
+      # mock bootstrap client, and a local `node` spawn against the built shim —
+      # no live Flair daemon or network I/O, so they belong in this job rather
+      # than test-integration.
+      - name: "Build flair-client (workspace dep flair-mcp imports by its built dist/)"
+        run: cd packages/flair-client && bun run build
+      - name: "flair-mcp package tests"
+        run: cd packages/flair-mcp && bun test
 
   test-integration:
     name: Integration Tests


### PR DESCRIPTION
## What
Wires `packages/flair-mcp/test/*.test.ts` into the `test-unit` job in `test.yml`, closing #491 (follow-up to #490 per Kern's review — those tests existed but weren't gated by CI).

## Why
`bun test test/unit/` (the existing Unit Tests step) only covers the repo root. `packages/flair-mcp` has its own `test` script (added in #490) but nothing invoked it in CI, so a regression in `mcp.test.ts` or `session-start-hook.test.ts` couldn't block a merge.

## How
Two new steps appended to the existing `test-unit` job (not a new job — same runner, same 10-min timeout, adds under 2s):
1. `cd packages/flair-client && bun run build` — flair-mcp imports the `@tpsdev-ai/flair-client` workspace package by its **built** `dist/`; bun's workspace symlink points at source, not emitted JS, so the package needs building first (same requirement the `typecheck-strict` job already documents for the same reason).
2. `cd packages/flair-mcp && bun test` — runs all three test files (`mcp.test.ts`, `mcp-node-preflight.test.ts`, `session-start-hook.test.ts`).

## Hermeticity — nothing split out
All 34 tests across the 3 files are hermetic, so everything is gated (nothing deferred to `test-integration`):
- `mcp.test.ts` — pure-logic assertions, no I/O.
- `session-start-hook.test.ts` — injects a mock `bootstrap` client; never touches a real Flair daemon.
- `mcp-node-preflight.test.ts` — spawns local `node` against the built shim; self-builds `flair-mcp` via `npm run build` in `beforeAll` if `dist/` is missing. No network.

## Verification (local, in an isolated worktree — not the live `~/ops/flair` checkout)
Ran the exact commands CI will run, from a clean `dist/`-less state:
```
$ bun test test/unit/
 1648 pass
 0 fail
 Ran 1648 tests across 106 files. [12.6s]

$ (cd packages/flair-client && bun run build)
$ (cd packages/flair-mcp && bun test)
 34 pass
 0 fail
 Ran 34 tests across 3 files. [~250-750ms]
```
Workflow YAML validated with `js-yaml` (loads clean, `test-unit` job now has 12 steps in the expected order).

## Not merging
Per process, this PR is for review only — CI on the PR itself is the real proof the new step runs and passes in the actual GitHub Actions environment.