### PR TITLE
feat(bootstrap): teammate findings follow open-within-org read scope (completes #550)

### DIFF
--- a/resources/MemoryBootstrap.ts
+++ b/resources/MemoryBootstrap.ts
@@ -15,17 +15,19 @@ import { resolveReadScope } from "./memory-read-scope.js";
  *   3. Recent memories (adaptive window)
  *   4. Task-relevant memories (semantic search if currentTask provided)
  *   4b. Teammate findings relevant to your task (flair#550 — the SAME scored
- *      task-relevant set as #4, split by origin: a grant-visible teammate's
- *      SHARED memory that scores against currentTask lands here instead of
- *      #4, attributed via "[via <agentId>]". Presentation only — what's
- *      readable is entirely Layer 1's resolveReadScope(); this only
- *      changes how an already-read cross-agent record is formatted/sectioned)
+ *      task-relevant set as #4, split by origin: any other in-org agent's
+ *      NON-PRIVATE memory that scores against currentTask lands here instead
+ *      of #4, attributed via "[via <agentId>]" — no MemoryGrant required
+ *      (open-within-org read, per #578). Presentation only — what's readable
+ *      is entirely resolveReadScope()'s job; this only changes how an
+ *      already-read cross-agent record is formatted/sectioned)
  *   5. Relationship context (active relationships for mentioned entities)
  *   6. Predicted context (based on channel/surface/subject hints)
  *   7. Team roster (other active agents in this office + a search-first nudge —
- *      bootstrap loads the caller's own memories plus any granted owner's
- *      SHARED memories (Layer 1, never their private ones), so this
- *      section nudges toward memory_search for anything beyond that window)
+ *      bootstrap loads the caller's own memories plus every other in-org
+ *      agent's non-private memories (open-within-org read, never anyone's
+ *      private ones), so this section nudges toward memory_search for
+ *      anything beyond that window)
  *
  * Prediction: when context signals (channel, surface, subjects) are provided,
  * the bootstrap loads more aggressively — Flair is fast enough that the
@@ -220,9 +222,10 @@ export class BootstrapMemories extends Resource {
 
     // --- 1c. Team roster + cross-agent search nudge ---
     // Soul is still caller-own-only (unaffected here). Memory loading below
-    // (step 2) now also includes granted owners' SHARED memories (Layer 1)
-    // — but this section stays: memory_search/SemanticSearch remains
-    // the deliberate, query-driven way to find a teammate's finding, vs.
+    // (step 2) now also includes every other in-org agent's non-private
+    // memories (open-within-org read, no MemoryGrant needed — #578) — but
+    // this section stays: memory_search/SemanticSearch remains the
+    // deliberate, query-driven way to find a teammate's finding, vs.
     // bootstrap's fixed recent/permanent window. This section is fixed-cost
     // (no query text to format per agent) so it's cheap enough to always
     // include, not budgeted.
@@ -244,14 +247,18 @@ export class BootstrapMemories extends Resource {
     }
 
     // --- 2. Permanent memories (always included, highest priority) ---
-    // Read-scope: own (any visibility) + granted owners' SHARED memories only
-    // (Layer 1 — never a granted owner's private ones). Centralized
-    // in resolveReadScope(): the condition is pushed into the Harper query
-    // (so the table itself never returns an out-of-scope row), and
-    // `scope.isAllowed` re-checks in-process as defense-in-depth (same
-    // belt-and-suspenders discipline as SemanticSearch's BM25 pre-fusion
-    // filter) — this is the #550 foundation: bootstrap can now safely expand
-    // beyond own-only without a parallel scoping rule.
+    // Read-scope: own (any visibility) + every OTHER in-org agent's
+    // non-private memory — open-within-org read (#578), no MemoryGrant
+    // consulted at all. Centralized in resolveReadScope(): the condition is
+    // pushed into the Harper query (so the table itself never returns an
+    // out-of-scope row), and `scope.isAllowed` re-checks in-process as
+    // defense-in-depth (same belt-and-suspenders discipline as
+    // SemanticSearch's BM25 pre-fusion filter) — this is the #550 foundation:
+    // bootstrap can now safely expand beyond own-only without a parallel
+    // scoping rule, and that rule tracks resolveReadScope()'s model
+    // automatically (grant-gated when #568 first built this, open-within-org
+    // now that #578 has landed — this file never re-implements the rule, so
+    // it never has to change when the rule does).
     const scope = await resolveReadScope(agentId);
     const allMemories: any[] = [];
     for await (const record of (databases as any).flair.Memory.search({ conditions: [scope.condition] })) {
@@ -267,8 +274,8 @@ export class BootstrapMemories extends Resource {
       // supersededIds filter further down only catches co-presence). A
       // record with no validTo, or a future validTo, is unaffected.
       if (record.validTo && Date.parse(record.validTo) < Date.now()) continue;
-      // Attribution for cross-agent (granted-owner) records — same convention
-      // SemanticSearch.ts already uses: formatMemory() below only USES this
+      // Attribution for cross-agent (any other in-org agent's) records — same
+      // convention SemanticSearch.ts already uses: formatMemory() below only USES this
       // when the record also carries _safetyFlags (labels the untrusted-data
       // wrapper with whose memory it is), it never forces wrapping on its own.
       // Real Harper's search() results are non-extensible objects — mutating
@@ -286,11 +293,12 @@ export class BootstrapMemories extends Resource {
     const activeMemories = allMemories.filter((m) => !supersededIds.has(m.id));
 
     // #550 design boundary: the permanent / recent / predicted sections are the
-    // agent's OWN working context — own-only, always. Post-Layer-1
-    // `activeMemories` also carries grant-visible teammate records (`_source`
-    // set), but grant-visibility exists to feed the task-relevant "Teammate
-    // findings" surfacing (#550) below, NOT to blend a teammate's memories into
-    // the reader's recent/permanent/predicted view. So these three sections
+    // agent's OWN working context — own-only, always. `activeMemories` also
+    // carries every other in-org agent's non-private records (`_source` set,
+    // open-within-org read — no grant involved), but that cross-agent
+    // visibility exists to feed the task-relevant "Teammate findings"
+    // surfacing (#550) below, NOT to blend a teammate's memories into the
+    // reader's recent/permanent/predicted view. So these three sections
     // filter to own (`!m._source`); team knowledge surfaces only when
     // task-relevant (the teammate section) or via an explicit memory_search.
     const ownMemories = activeMemories.filter((m) => !m._source);
@@ -444,13 +452,14 @@ export class BootstrapMemories extends Resource {
           .sort((a, b) => b.score - a.score);
 
         // #550: split the scored, task-relevant set by origin. Own findings
-        // go to `relevant` as before; a teammate's (grant-visible, already
-        // read-scoped by Layer 1 — `m._source` is only ever set for a
-        // cross-agent record, see the allMemories loop above) go to the new
-        // `teammate` section so the agent can tell it apart at a glance.
-        // Both draw from the SAME `tokenBudget` in one score-ordered pass —
-        // highest-relevance memories win the remaining budget regardless of
-        // which section they land in, so neither section double-spends.
+        // go to `relevant` as before; any other in-org agent's non-private
+        // record — already read-scoped by resolveReadScope(), no grant
+        // required (`m._source` is only ever set for a cross-agent record,
+        // see the allMemories loop above) — goes to the new `teammate`
+        // section so the agent can tell it apart at a glance. Both draw from
+        // the SAME `tokenBudget` in one score-ordered pass — highest-relevance
+        // memories win the remaining budget regardless of which section they
+        // land in, so neither section double-spends.
         for (const { memory: m } of scored) {
           const line = formatMemory(m, agentId);
           const cost = estimateTokens(line);
@@ -523,7 +532,7 @@ export class BootstrapMemories extends Resource {
     }
     // #550: teammate findings relevant to the current task — right after the
     // agent's own task-relevant knowledge. Empty section renders nothing
-    // (no header) so a bootstrap with no grant-visible teammate findings for
+    // (no header) so a bootstrap with no task-relevant teammate findings for
     // this task looks exactly as it did before this feature.
     if (sections.teammate.length > 0) {
       parts.push("## Teammate findings relevant to your task\n" + sections.teammate.join("\n"));

--- a/resources/memory-bootstrap-lib.ts
+++ b/resources/memory-bootstrap-lib.ts
@@ -38,6 +38,6 @@ export function formatTeamLine(teammateIds: string[]): string | null {
   return (
     `${teammateIds.length} other ${plural} this Flair office (${wrapUntrusted(teammateIds.join(", "))}). ` +
     `Before deep-diving an unfamiliar problem, search their memories for related work — ` +
-    `\`memory_search\` covers any agent you hold a search grant from.`
+    `\`memory_search\` covers any agent's non-private memories on this instance (open-within-org read; no grant required).`
   );
 }

--- a/test/integration/bootstrap-teammate-findings-e2e.test.ts
+++ b/test/integration/bootstrap-teammate-findings-e2e.test.ts
@@ -2,21 +2,32 @@
 // relevant to your task" section: real-Harper, real-embedding end-to-end
 // coverage of the gap this feature closes.
 //
-// Layer 1 (the resolveReadScope no-grants simplification, already merged) made a grant-visible teammate's SHARED
-// memory reachable through bootstrap's read scope and scored it against
-// currentTask alongside the caller's own memories — but it rendered
-// identically to the caller's own memory (no attribution) and landed in the
-// SAME "Relevant Knowledge" section (not surfaced distinctly). This test
-// proves the fix: a grant-visible teammate's task-relevant SHARED memory now
-// appears attributed ("[via <ownerId>]") in its OWN "Teammate findings
-// relevant to your task" section — never mixed into "Relevant Knowledge",
-// which stays the caller's own findings only — while the SAME owner's
-// PRIVATE memory (equally task-relevant by content) never surfaces at all,
-// proving Layer 1's read-exclusion still holds under this presentation-only
-// split (this test does NOT touch, and is not testing, resolveReadScope()
-// itself — see test/integration/memory-visibility-scoping-e2e.test.ts for
-// that boundary's own dedicated coverage; the private-exclusion assertion
-// here is a guard against a regression in the NEW scored-path split code).
+// resolveReadScope() (resources/memory-read-scope.ts) made any other in-org
+// agent's non-private memory reachable through bootstrap's read scope and
+// scored it against currentTask alongside the caller's own memories — but it
+// rendered identically to the caller's own memory (no attribution) and
+// landed in the SAME "Relevant Knowledge" section (not surfaced distinctly).
+// This test proves the presentation fix: a task-relevant non-private
+// cross-agent memory now appears attributed ("[via <ownerId>]") in its OWN
+// "Teammate findings relevant to your task" section — never mixed into
+// "Relevant Knowledge", which stays the caller's own findings only — while
+// that same owner's PRIVATE memory (equally task-relevant by content) never
+// surfaces at all, proving resolveReadScope()'s read-exclusion still holds
+// under this presentation-only split (this test does NOT touch, and is not
+// testing, resolveReadScope() itself — see test/integration/memory-
+// visibility-scoping-e2e.test.ts for that boundary's own dedicated coverage;
+// the private-exclusion assertion here is a guard against a regression in
+// the scored-path split code).
+//
+// Two fixtures probe this: `owner`, who DOES hold a MemoryGrant with
+// `grantee` (kept from this test's original pre-#578 authoring — see the
+// `owner` tests), and `stranger`, who has NO grant relationship with
+// `grantee` whatsoever (see the `stranger` doc comment below and the
+// dedicated "open-within-org" test). Both must behave identically — a
+// grant's presence or absence must not change whether a non-private record
+// surfaces or a private one stays hidden. That equivalence, not the grant
+// itself, is what open-within-org read means, and the `stranger` fixture is
+// the direct completion of flair#550 against the model that shipped in #578.
 //
 // Pattern: test/integration/memory-visibility-scoping-e2e.test.ts (Ed25519
 // signing, grant seeding via adminOp) + test/integration/semantic-search-
@@ -119,6 +130,15 @@ function extractSection(context: string, header: string): string {
 let harper: HarperInstance;
 const owner = mkAgent(`t550-owner-${randomUUID()}`);
 const grantee = mkAgent(`t550-grantee-${randomUUID()}`);
+// A THIRD agent with NO MemoryGrant relationship to grantee at all (no
+// insertGrant call for this agent anywhere in beforeAll below) — the
+// load-bearing proof that teammate-findings surfacing is open-within-org,
+// not grant-gated. Under the pre-#578 grant-gated model this agent's records
+// would never have entered grantee's read-scope; under open-within-org its
+// non-private record must surface exactly like the grant-holding owner's
+// does, and its private record must never surface, regardless of the
+// absent grant.
+const stranger = mkAgent(`t550-stranger-${randomUUID()}`);
 
 const ID_SHARED = `${owner.id}-shared`;
 const ID_PRIVATE = `${owner.id}-private`;
@@ -146,6 +166,13 @@ const ID_SHARED_PERM = `${owner.id}-shared-perm`;
 const CONTENT_OWN_PERM = "flair-550 marker: standing rule — I always double-check indemnification caps before signing any vendor agreement.";
 const CONTENT_SHARED_PERM = "flair-550 marker: standing rule — the procurement team requires two competing quotes on file before any renewal above fifty thousand dollars.";
 
+// stranger's records — NO grant to grantee exists for these at all (see the
+// `stranger` doc comment above).
+const ID_STRANGER_SHARED = `${stranger.id}-shared`;
+const ID_STRANGER_PRIVATE = `${stranger.id}-private`;
+const CONTENT_STRANGER_SHARED = "flair-550 marker: for the Acme Corp vendor contract renegotiation, procurement flagged that Acme's incumbent competitor already undercut list price by 8 percent last cycle.";
+const CONTENT_STRANGER_PRIVATE = "flair-550 marker: for the Acme Corp vendor contract renegotiation, our CFO's absolute hard floor (never shared outside finance) is a 22 percent minimum margin.";
+
 const BACKDATED = new Date(Date.now() - 40 * 24 * 3600_000).toISOString();
 
 describe("flair#550 — MemoryBootstrap 'Teammate findings relevant to your task' (real Harper, real embeddings)", () => {
@@ -153,7 +180,10 @@ describe("flair#550 — MemoryBootstrap 'Teammate findings relevant to your task
     harper = await startHarper();
     await registerAgent(harper, owner);
     await registerAgent(harper, grantee);
+    await registerAgent(harper, stranger);
     await insertGrant(harper, owner.id, grantee.id, "read");
+    // Deliberately NO insertGrant call involving `stranger` — grantee and
+    // stranger have never had any grant relationship whatsoever.
 
     await putMemory(harper, owner, ID_SHARED, {
       agentId: owner.id, content: CONTENT_SHARED, durability: "standard", visibility: "shared", createdAt: BACKDATED,
@@ -171,6 +201,13 @@ describe("flair#550 — MemoryBootstrap 'Teammate findings relevant to your task
     await putMemory(harper, owner, ID_SHARED_PERM, {
       agentId: owner.id, content: CONTENT_SHARED_PERM, durability: "permanent", visibility: "shared", createdAt: BACKDATED,
     });
+    // Ungranted stranger's pair — the open-within-org proof.
+    await putMemory(harper, stranger, ID_STRANGER_SHARED, {
+      agentId: stranger.id, content: CONTENT_STRANGER_SHARED, durability: "standard", visibility: "shared", createdAt: BACKDATED,
+    });
+    await putMemory(harper, stranger, ID_STRANGER_PRIVATE, {
+      agentId: stranger.id, content: CONTENT_STRANGER_PRIVATE, durability: "standard", visibility: "private", createdAt: BACKDATED,
+    });
   }, 180_000);
 
   afterAll(async () => { if (harper) await stopHarper(harper); });
@@ -187,10 +224,12 @@ describe("flair#550 — MemoryBootstrap 'Teammate findings relevant to your task
     // Section-count structure: exactly one own task-relevant finding
     // (CONTENT_OWN — the own PERMANENT memory is excluded from the scored path
     // via includedIds, so it can't inflate this), and at least one teammate
-    // task-relevant finding. `teammate` is `>= 1` rather than exactly 1 because
-    // the seed's teammate PERMANENT rule (CONTENT_SHARED_PERM, about vendor
-    // renewals) is legitimately task-relevant too and correctly lands here —
-    // proving the split by ORIGIN, not that only one teammate memory can show.
+    // task-relevant finding. `teammate` is `>= 1` rather than an exact count
+    // because several other seeded records (owner's CONTENT_SHARED_PERM,
+    // stranger's CONTENT_STRANGER_SHARED — see the dedicated open-within-org
+    // test below) are also legitimately task-relevant and correctly land
+    // here — proving the split by ORIGIN, not that only one teammate memory
+    // can show.
     expect(body.sections?.relevant, `sections.relevant — full response: ${JSON.stringify(body.sections)}`).toBe(1);
     expect(body.sections?.teammate, `sections.teammate — full response: ${JSON.stringify(body.sections)}`).toBeGreaterThanOrEqual(1);
 
@@ -207,6 +246,22 @@ describe("flair#550 — MemoryBootstrap 'Teammate findings relevant to your task
     expect(relevantSection, `"Relevant Knowledge" section missing or empty — full context:\n${context}`).toContain(CONTENT_OWN);
     expect(relevantSection).not.toContain("[via");
     expect(relevantSection).not.toContain(CONTENT_SHARED);
+  }, 60_000);
+
+  test("open-within-org, the flair#550 gap this PR closes: a NON-GRANTED stranger's non-private finding surfaces attributed in 'Teammate findings'; the same stranger's PRIVATE finding never surfaces", async () => {
+    // `stranger` has no MemoryGrant with `grantee` at all (see beforeAll) —
+    // this is the load-bearing real-Harper proof that teammate-findings
+    // surfacing no longer depends on MemoryGrant, only on visibility.
+    const body = await bootstrap(harper, grantee, { agentId: grantee.id, maxTokens: 8000, currentTask: CURRENT_TASK });
+    const context: string = body.context ?? "";
+
+    // Security invariant first: the stranger's PRIVATE finding — equally
+    // task-relevant by content — must never appear anywhere, grant or no grant.
+    expect(context, "ungranted stranger's PRIVATE memory must never appear in grantee's bootstrap").not.toContain(CONTENT_STRANGER_PRIVATE);
+
+    const teammateSection = extractSection(context, "Teammate findings relevant to your task");
+    expect(teammateSection, `"Teammate findings" section missing or empty — full context:\n${context}`).toContain(CONTENT_STRANGER_SHARED);
+    expect(teammateSection).toContain(`[via ${stranger.id}]`);
   }, 60_000);
 
   test("no currentTask → no 'Teammate findings' section, AND a grant-visible teammate PERMANENT memory does NOT bleed into the reader's own Core Principles", async () => {

--- a/test/unit/memory-bootstrap-scoping.test.ts
+++ b/test/unit/memory-bootstrap-scoping.test.ts
@@ -216,14 +216,24 @@ describe("MemoryBootstrap.post() — centralized read-scoping", () => {
 
 // ─── flair#550 — teammate findings attribution + "Teammate findings" section ─
 //
-// The read-scoping above already made grant-visible teammate SHARED memories
-// reachable through bootstrap's read scope; these tests cover the
-// PRESENTATION gap: (1) formatMemory() attributes a cross-agent record with
-// "[via <ownerId>]" and composes with the safety wrap, and (2) the
-// currentTask-scored path splits by origin into sections.relevant (own) vs
-// the new sections.teammate (grant-visible teammate), never mixing them, and
-// never letting a teammate's PRIVATE memory reach the scored path at all
-// (that exclusion, re-asserted here as a guard on the NEW split code).
+// The read-scoping above already made any other in-org agent's non-private
+// memory reachable through bootstrap's read scope (open-within-org — no
+// MemoryGrant required); these tests cover the PRESENTATION gap: (1)
+// formatMemory() attributes a cross-agent record with "[via <ownerId>]" and
+// composes with the safety wrap, and (2) the currentTask-scored path splits
+// by origin into sections.relevant (own) vs the new sections.teammate (any
+// other in-org agent's non-private record), never mixing them, and never
+// letting a teammate's PRIVATE memory reach the scored path at all (that
+// exclusion, re-asserted here as a guard on the NEW split code).
+//
+// Most tests below still seed a MemoryGrant alongside the memories — that's
+// incidental (this file was written before #578 moved reads from grant-gated
+// to open-within-org) and no longer load-bearing: resolveReadScope() never
+// consults MemoryGrant for reads anymore. The dedicated "no grant at all"
+// tests further down (search for "NO MemoryGrant") are the ones that actually
+// prove the open-within-org model — a grant's presence or absence must not
+// change whether a non-private record surfaces, or whether a private one
+// stays hidden.
 //
 // All records below carry embedding: FAKE_EMBEDDING so they clear the
 // `score > 0.3` deterministic-cosine-1.0 threshold against any currentTask
@@ -367,6 +377,56 @@ describe("MemoryBootstrap.post() — flair#550 teammate-findings attribution + s
     expect(res.context).not.toContain("TEAMMATE-PRIVATE-TASK-FINDING");
     expect(res.context).not.toContain("## Teammate findings relevant to your task");
     expect(res.sections.teammate).toBe(0);
+  });
+
+  // ─── Open-within-org: the actual flair#550 gap this PR closes ─────────────
+  // The tests above all seed a MemoryGrant alongside the memories, which is
+  // incidental (pre-#578 authoring) — resolveReadScope() never consults
+  // MemoryGrant for reads anymore. These two tests are the load-bearing
+  // proof: a non-private teammate finding surfaces with ZERO grant records
+  // in the store at all (`memoryGrants` stays empty — `reset()` sets it to
+  // `[]` and nothing here pushes to it), and a private one still never does.
+
+  it("a non-private teammate memory surfaces in 'Teammate findings' when task-relevant — NO MemoryGrant exists at all (open-within-org, the flair#550 gap)", async () => {
+    reset();
+    // No memoryGrants.push() anywhere in this test — agent-owner and
+    // agent-grantee have never had any grant relationship. Under the old
+    // grant-gated model this record would never have entered read-scope;
+    // under open-within-org it's non-private, so it's readable by any
+    // verified in-org agent regardless.
+    memoryStore.set("ungranted-shared-task", {
+      id: "ungranted-shared-task", agentId: "agent-owner", content: "UNGRANTED-TEAMMATE-TASK-FINDING",
+      visibility: "shared", durability: "standard", createdAt: OLD_DATE, embedding: FAKE_EMBEDDING,
+    });
+
+    const b = makeBootstrap(agentCtx("agent-grantee"));
+    const res: any = await b.post({
+      agentId: "agent-grantee", includeSoul: false, currentTask: "investigate the thing",
+    });
+    expect(res.context).toContain("## Teammate findings relevant to your task");
+    expect(res.context).toContain("[via agent-owner] UNGRANTED-TEAMMATE-TASK-FINDING");
+    expect(res.sections.teammate).toBe(1);
+  });
+
+  it("a teammate's PRIVATE memory NEVER surfaces even with NO MemoryGrant and no relationship at all (the security invariant: private stays owner-only, unconditionally)", async () => {
+    reset();
+    // Same "no grant ever existed" setup as above, but this record is
+    // private — the ONE exception open-within-org carves out. This is the
+    // explicit security-invariant test: a caller must never see a private
+    // memory that isn't theirs, regardless of any grant history.
+    memoryStore.set("ungranted-private-task", {
+      id: "ungranted-private-task", agentId: "agent-owner", content: "UNGRANTED-TEAMMATE-PRIVATE-FINDING",
+      visibility: "private", durability: "standard", createdAt: OLD_DATE, embedding: FAKE_EMBEDDING,
+    });
+
+    const b = makeBootstrap(agentCtx("agent-grantee"));
+    const res: any = await b.post({
+      agentId: "agent-grantee", includeSoul: false, currentTask: "investigate the thing",
+    });
+    expect(res.context).not.toContain("UNGRANTED-TEAMMATE-PRIVATE-FINDING");
+    expect(res.context).not.toContain("## Teammate findings relevant to your task");
+    expect(res.sections.teammate).toBe(0);
+    expect(res.memoriesAvailable).toBe(0);
   });
 
   it("no currentTask, no teammate matches → the 'Teammate findings' header never renders (empty section renders nothing)", async () => {


### PR DESCRIPTION
## Summary

Closes flair#550 against the model that actually shipped: #578 moved `resolveReadScope()` from grant-gated to open-within-org read (own records + every other in-org agent's non-private records; `private` stays owner-only, no `MemoryGrant` consulted). #568 (the original #550 implementation) already built the "Teammate findings relevant to your task" section entirely on top of `resolveReadScope()` — it never had its own `MemoryGrant` traversal — so when #578 landed, the teammate-findings surfacing picked up the open-within-org model automatically, with **zero production behavior change needed**.

What was actually stale:
- Comments throughout `resources/MemoryBootstrap.ts` (header doc, sections 1c/2/4) and the agent-facing team-roster nudge text in `resources/memory-bootstrap-lib.ts` still described the section as "grant-visible" — misleading, since the underlying rule no longer consults `MemoryGrant` at all. Corrected all of it to describe the shipped open-within-org model. The roster nudge (`## Team` section, read by the bootstrapping agent) previously told agents `memory_search` "covers any agent you hold a search grant from" — factually wrong post-#578; now says it covers "any agent's non-private memories on this instance (open-within-org read; no grant required)".
- **Test coverage was the real gap.** Every existing test exercising the teammate section (`test/unit/memory-bootstrap-scoping.test.ts`, `test/integration/bootstrap-teammate-findings-e2e.test.ts`) seeded a `MemoryGrant` alongside the memories — harmless leftover from pre-#578 authoring, but nothing proved the grant is *not* required. That's the acceptance criterion this PR actually closes.

## What changed

- `resources/MemoryBootstrap.ts` — comments only, no logic changes. Updated every stale "grant-visible" / "granted owner" reference to describe open-within-org read.
- `resources/memory-bootstrap-lib.ts` — corrected the agent-facing `## Team` nudge text (was actively wrong about grants being required for `memory_search`).
- `test/unit/memory-bootstrap-scoping.test.ts` — added two tests with **zero MemoryGrant records in the store**: a non-private teammate memory surfaces in "Teammate findings" when task-relevant, and a private teammate memory never does (explicit security-invariant test).
- `test/integration/bootstrap-teammate-findings-e2e.test.ts` — added a third `stranger` agent fixture with **no grant relationship to the reader at all**, real Harper + real embeddings: the stranger's shared memory surfaces attributed (`[via <strangerId>]`), the stranger's private memory never surfaces.

## Why no MemoryBootstrap.ts logic changed

Traced the full path: section 2 builds `allMemories` via `resolveReadScope(agentId)`'s `condition` (pushed into the Harper query) + `isAllowed` (in-process re-check) — no `MemoryGrant.search()` anywhere in this file. Section 4 splits the scored, task-relevant set by `m._source` (set whenever a record's `agentId !== agentId`, regardless of any grant). Since `resolveReadScope()` itself changed internals in #578 (grant-gated → open-within-org) and every caller only ever consumes its output, `MemoryBootstrap.ts` inherited the new model automatically. `resources/Memory.ts`'s `MemoryGrant` usage is unrelated — that's the **write**-grant path (posting a memory on someone else's behalf), untouched by this change.

## Security invariant

A caller must never see a private memory that isn't theirs. Tested explicitly at both layers, with no grant in play at all:
- Unit: `"a teammate's PRIVATE memory NEVER surfaces even with NO MemoryGrant and no relationship at all"` — asserts `memoriesAvailable: 0` and the content never appears.
- Integration (real Harper): `stranger`'s private memory (equally task-relevant by content to its shared counterpart) never appears in `grantee`'s bootstrap context, grant or no grant.

## Verify

- `bun run build` — clean
- `bun run build:cli` — clean
- `bunx tsc -p tsconfig.check.json --noEmit` (strict, touched configs) — clean
- `bun test test/unit/` — **1650/1650 pass**
- `bun test test/integration/bootstrap-teammate-findings-e2e.test.ts` — 3/3 pass (real Harper, real embeddings)

## Test plan
- [x] Non-private teammate memory (no grant) surfaces in "Teammate findings" when task-relevant
- [x] Private teammate memory never surfaces (no grant, no relationship) — security invariant
- [x] Attribution (`[via <agentId>]`) intact
- [x] No-`currentTask` → no "Teammate findings" section (unchanged)
- [x] Budget: single relevance-ordered pool for own + teammate findings (unchanged from #568 — not a percentage-slice design; own never starved by a lower-relevance teammate record)

Worktree: `~/agents/flint/work/flair-550` (isolated, not the live `~/ops/flair` checkout). Not merging — Flint merges after CI + Kern/Sherlock sign-off.