### PR TITLE
feat(mcp): auto-set presence — bootstrap sets, tool activity heartbeats (closes #598)

### DIFF
--- a/packages/flair-mcp/src/index.ts
+++ b/packages/flair-mcp/src/index.ts
@@ -15,6 +15,13 @@
  *   - flair_workspace_set — write own WorkspaceState (Office Space coordination)
  *   - flair_orgevent      — publish an OrgEvent attributed to self (no forging)
  *
+ * Auto-presence (flair#598): every tool call above triggers a fire-and-forget,
+ * rate-limited `POST /Presence` heartbeat for the calling agent (see
+ * ./presence.ts + the `heartbeat()` closure in runMcp()) — presence is now a
+ * side effect of normal activity instead of the manual `flair presence set`
+ * CLI command nobody ran. `bootstrap` additionally seeds the activity/task
+ * from its own arguments (session start signal).
+ *
  * Usage:
  *   npx -y @tpsdev-ai/flair-mcp
  *
@@ -36,6 +43,14 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { FlairClient, FlairError } from "@tpsdev-ai/flair-client";
 import { z } from "zod";
+import {
+  deriveActivity,
+  postPresenceSafe,
+  resolveHeartbeatIntervalMs,
+  resolvePresenceTimeoutMs,
+  shouldSendHeartbeat,
+  type PresenceActivity,
+} from "./presence.js";
 
 // ─── Error helpers ──────────────────────────────────────────────────────────
 
@@ -146,6 +161,58 @@ export async function runMcp(): Promise<void> {
     keyPath: process.env.FLAIR_KEY_PATH,
   });
 
+  // ─── Auto-presence (flair#598) ────────────────────────────────────────────────
+  //
+  // Presence used to be manual-only (`flair presence set`, which in practice
+  // nobody runs) — so the roster was permanently stale and the collision-
+  // detection it exists for never worked. This makes presence a SIDE EFFECT of
+  // normal agent activity instead: `bootstrap` (session start) always attempts
+  // a heartbeat, and every other tool call attempts one too, both routed
+  // through the SAME rate-limited, fire-and-forget `heartbeat()` below so
+  // repeated bootstrap calls in a short window don't spam any more than
+  // repeated tool calls would.
+  //
+  // A SEPARATE FlairClient instance, not the main `flair` above — its own
+  // short `timeoutMs` (resolvePresenceTimeoutMs(), default 3s vs the main
+  // client's general-purpose 30s default) means a dead/slow daemon can never
+  // make a presence write outlive the tool call it rode in on, independent of
+  // whatever timeout the main client is configured with.
+  const presenceFlair = new FlairClient({
+    agentId,
+    url: process.env.FLAIR_URL,
+    keyPath: process.env.FLAIR_KEY_PATH,
+    timeoutMs: resolvePresenceTimeoutMs(),
+  });
+
+  // Rate-limit clock + last-known task, in-process only (no persistence —
+  // resets on restart, which is fine; the next tool call re-establishes it).
+  // Owned here, not in presence.ts, so the pure rate-limit/body-building logic
+  // stays testable without any shared mutable state.
+  let lastPresenceSentAt: number | null = null;
+  // currentTask is the caller's responsibility to preserve (see
+  // postPresenceSafe's doc comment): Presence.post() treats an ABSENT
+  // currentTask as an explicit clear, so a heartbeat that doesn't know about
+  // an in-flight task must keep resending the last one bootstrap() told us
+  // about, or it would silently erase it every ~3 minutes.
+  let lastKnownTask: string | undefined;
+
+  /**
+   * Fire-and-forget, rate-limited presence heartbeat. Safe to call from every
+   * tool handler unconditionally — the rate limit + postPresenceSafe's
+   * internal catch-everything mean this NEVER throws, NEVER awaits network
+   * I/O in the caller's path, and NEVER delays the tool response. The
+   * `.catch(() => {})` below is belt-and-suspenders (postPresenceSafe already
+   * never rejects) purely so a future change to that function can't
+   * accidentally reintroduce an unhandled rejection here.
+   */
+  function heartbeat(activity: PresenceActivity = "coding"): void {
+    const now = Date.now();
+    if (!shouldSendHeartbeat(now, lastPresenceSentAt, resolveHeartbeatIntervalMs())) return;
+    lastPresenceSentAt = now; // set synchronously, before the async write, so a burst of
+    // tool calls in the same tick can't all slip past the rate limit together
+    postPresenceSafe(presenceFlair, activity, lastKnownTask, resolvePresenceTimeoutMs()).catch(() => {});
+  }
+
   // ─── MCP Server ──────────────────────────────────────────────────────────────
 
   const server = new McpServer({
@@ -163,6 +230,7 @@ export async function runMcp(): Promise<void> {
     limit: z.coerce.number().optional().default(5).describe("Max results (default 5)"),
   },
   async ({ query, limit }) => {
+    heartbeat(); // auto-presence (flair#598) — fire-and-forget, rate-limited
     try {
       const results = await flair.memory.search(query, { limit });
       if (results.length === 0) {
@@ -205,6 +273,7 @@ server.tool(
     ),
   },
   async ({ content, type, durability, tags, visibility }) => {
+    heartbeat(); // auto-presence (flair#598) — fire-and-forget, rate-limited
     try {
       const result = await flair.memory.write(content, {
         type: type as any,
@@ -265,6 +334,7 @@ server.tool(
       .describe("Write a new supersedes-linked version instead of overwriting in place (default false)"),
   },
   async ({ id, content, preserveHistory }) => {
+    heartbeat(); // auto-presence (flair#598) — fire-and-forget, rate-limited
     try {
       const result = await flair.memory.update(id, content, { preserveHistory });
       const text = preserveHistory
@@ -287,6 +357,7 @@ server.tool(
     id: z.string().describe("Memory ID"),
   },
   async ({ id }) => {
+    heartbeat(); // auto-presence (flair#598) — fire-and-forget, rate-limited
     try {
       const mem = await flair.memory.get(id);
       if (!mem) return { content: [{ type: "text", text: `Memory ${id} not found.` }] };
@@ -304,6 +375,7 @@ server.tool(
     id: z.string().describe("Memory ID to delete"),
   },
   async ({ id }) => {
+    heartbeat(); // auto-presence (flair#598) — fire-and-forget, rate-limited
     try {
       await flair.memory.delete(id);
       return { content: [{ type: "text", text: `Memory ${id} deleted.` }] };
@@ -324,6 +396,15 @@ server.tool(
     subjects: z.array(z.string()).optional().describe("Entity names to preload context for (e.g., ['flair', 'auth'])"),
   },
   async ({ maxTokens, currentTask, channel, surface, subjects }) => {
+    // auto-presence (flair#598) — SESSION START. bootstrap() already receives
+    // exactly the payload Presence wants: currentTask is what the agent is
+    // about to work on, channel/surface are what deriveActivity() uses to
+    // pick something more specific than the "coding" default. Routed through
+    // the SAME rate-limited heartbeat() as every other tool, so calling
+    // bootstrap twice in quick succession (session resume/compact) doesn't
+    // double-send — it's still "sets presence once" per session in practice.
+    if (currentTask) lastKnownTask = currentTask;
+    heartbeat(deriveActivity({ channel, surface }));
     try {
       const result = await flair.bootstrap({ maxTokens, currentTask, channel, surface, subjects });
       if (!result.context) {
@@ -344,6 +425,7 @@ server.tool(
     value: z.string().describe("Entry value — personality trait, project context, coding standards, etc."),
   },
   async ({ key, value }) => {
+    heartbeat(); // auto-presence (flair#598) — fire-and-forget, rate-limited
     try {
       await flair.soul.set(key, value);
       return { content: [{ type: "text", text: `Soul entry '${key}' set.` }] };
@@ -360,6 +442,7 @@ server.tool(
     key: z.string().describe("Entry key"),
   },
   async ({ key }) => {
+    heartbeat(); // auto-presence (flair#598) — fire-and-forget, rate-limited
     try {
       const entry = await flair.soul.get(key);
       if (!entry) return { content: [{ type: "text", text: `No soul entry for '${key}'.` }] };
@@ -392,6 +475,7 @@ server.tool(
     summary: z.string().optional().describe("Short summary of current workspace state"),
   },
   async ({ ref, label, provider, task, phase, summary }) => {
+    heartbeat(); // auto-presence (flair#598) — fire-and-forget, rate-limited
     try {
       // No agentId in body — the server attributes from the signed identity.
       const body: Record<string, unknown> = {
@@ -423,6 +507,7 @@ server.tool(
     targets: z.array(z.string()).optional().describe("Recipient agent ids"),
   },
   async ({ kind, summary, detail, scope, targets }) => {
+    heartbeat(); // auto-presence (flair#598) — fire-and-forget, rate-limited
     try {
       // No authorId in body — the server attributes from the signed identity.
       const body: Record<string, unknown> = { kind, summary };

--- a/packages/flair-mcp/src/presence.ts
+++ b/packages/flair-mcp/src/presence.ts
@@ -1,0 +1,192 @@
+/**
+ * Auto-presence — shared, pure/testable logic behind flair#598.
+ *
+ * Presence (`POST /Presence`, resources/Presence.ts) only ever updated via the
+ * manual `flair presence set` CLI command, which in practice nobody runs — so
+ * the roster is permanently stale and the active/idle/offline derivation it
+ * powers (Office Space collision detection) never means anything. This module
+ * makes presence a SIDE EFFECT of normal agent activity instead: every flair-mcp
+ * tool call (and the flair-session-start hook) can call `postPresenceSafe()`
+ * to refresh the calling agent's own `lastHeartbeatAt`, rate-limited so it
+ * doesn't turn into a write storm.
+ *
+ * Everything here is a pure function or a single fire-and-forget async
+ * wrapper — no module-level mutable state lives in this file. The rate-limit
+ * clock (`lastSentAt`) and the "last known task" text are owned by each
+ * CALLER (flair-mcp/src/index.ts's runMcp() closure, session-start-hook.ts's
+ * per-invocation scope) — this file only decides "is it time yet" and "what
+ * does the POST body look like", so both call sites share ONE implementation
+ * of those decisions without sharing any actual state.
+ */
+
+// ─── Activity derivation ────────────────────────────────────────────────────
+
+/** Mirrors VALID_ACTIVITIES in resources/Presence.ts — keep in sync. */
+export type PresenceActivity = "coding" | "reviewing" | "planning" | "idle";
+
+/**
+ * Derive a presence `activity` from the SAME context signals the `bootstrap`
+ * tool and the SessionStart hook already receive (channel/surface) — no new
+ * inputs, no separate classifier call. Two narrow, name-based overrides for
+ * the surfaces that are unambiguous on their own; everything else (including
+ * no surface at all, e.g. the session-start hook) falls through to "coding",
+ * since an MCP tool call is, definitionally, an agent doing something — never
+ * "idle" (idle/offline are purely functions of elapsed time since the last
+ * heartbeat; see derivePresenceStatus() in resources/Presence.ts).
+ */
+export function deriveActivity(ctx: { surface?: string; channel?: string } = {}): PresenceActivity {
+  const surface = (ctx.surface ?? "").toLowerCase();
+  if (surface.includes("review")) return "reviewing";
+  if (surface.includes("plan") || surface.includes("spec") || surface.includes("design")) return "planning";
+  return "coding";
+}
+
+// ─── Rate limiting ──────────────────────────────────────────────────────────
+
+/**
+ * Pure "is it time to send another heartbeat" check. The caller owns the
+ * clock (`lastSentAt`) — this function has no memory of its own, which is
+ * what makes it trivially unit-testable (no fake timers, no module reset
+ * between tests).
+ */
+export function shouldSendHeartbeat(now: number, lastSentAt: number | null, minIntervalMs: number): boolean {
+  if (lastSentAt == null) return true;
+  return now - lastSentAt >= minIntervalMs;
+}
+
+/**
+ * Minimum gap between auto-presence POSTs triggered by MCP tool activity.
+ *
+ * 3 minutes: the issue's proposal asks for "once per few minutes" (2-5min).
+ * 3min sits in the middle of that range —
+ *   - frequent enough that an actively-used agent survives at least one
+ *     missed beat before crossing the 10-minute OFFLINE threshold
+ *     (offlineThresholdMs() in resources/Presence.ts, default 600_000ms) —
+ *     a dropped/delayed write doesn't flip the roster to offline;
+ *   - infrequent enough that a hot loop (e.g. memory_search called several
+ *     times a minute while an agent works through a task) doesn't turn every
+ *     tool call into a presence write — this is the rate limiter's whole job.
+ * Not tuned to the 90s ACTIVE threshold (idleThresholdMs(), default 90_000ms)
+ * — matching that would mean heartbeating roughly every other tool call,
+ * defeating the point of rate limiting. An agent that's genuinely active but
+ * calls flair-mcp tools less than once every ~3min will read as "idle" (not
+ * "offline") between heartbeats, which is the correct signal: idle already
+ * means "present but no recent activity", exactly this case.
+ */
+export const DEFAULT_HEARTBEAT_INTERVAL_MS = 3 * 60 * 1000;
+const HEARTBEAT_INTERVAL_FLOOR_MS = 30_000;
+const HEARTBEAT_INTERVAL_CEILING_MS = 15 * 60 * 1000;
+
+/** Resolve the heartbeat rate-limit interval from env, clamped to a sane range
+ *  (same validate-don't-trust-`??` pattern as FLAIR_MCP_PARENT_POLL_MS /
+ *  FLAIR_HOOK_TIMEOUT_MS elsewhere in this package — an empty-string override
+ *  must not silently become `0` and defeat the rate limit). */
+export function resolveHeartbeatIntervalMs(): number {
+  const raw = process.env.FLAIR_PRESENCE_HEARTBEAT_MS;
+  const parsed = raw != null ? Number(raw) : NaN;
+  return Number.isFinite(parsed) && parsed >= HEARTBEAT_INTERVAL_FLOOR_MS && parsed <= HEARTBEAT_INTERVAL_CEILING_MS
+    ? parsed
+    : DEFAULT_HEARTBEAT_INTERVAL_MS;
+}
+
+// ─── Timeout ────────────────────────────────────────────────────────────────
+
+/**
+ * Per-write timeout for auto-presence POSTs. Deliberately much shorter than
+ * FlairClient's general-purpose default (30s, client.ts DEFAULT_TIMEOUT) —
+ * auto-presence is a side effect, never the reason a tool call or a session
+ * hook waits. A dead/slow Flair daemon must not hold anything open.
+ */
+export const DEFAULT_PRESENCE_TIMEOUT_MS = 3_000;
+const PRESENCE_TIMEOUT_FLOOR_MS = 500;
+const PRESENCE_TIMEOUT_CEILING_MS = 10_000;
+
+export function resolvePresenceTimeoutMs(): number {
+  const raw = process.env.FLAIR_PRESENCE_TIMEOUT_MS;
+  const parsed = raw != null ? Number(raw) : NaN;
+  return Number.isFinite(parsed) && parsed >= PRESENCE_TIMEOUT_FLOOR_MS && parsed <= PRESENCE_TIMEOUT_CEILING_MS
+    ? parsed
+    : DEFAULT_PRESENCE_TIMEOUT_MS;
+}
+
+/** Race a promise against a timeout. Rejects with a timeout error if exceeded.
+ *  (Same idiom as session-start-hook.ts's withTimeout — duplicated rather than
+ *  imported to keep this module dependency-free of that one; it's four lines.) */
+function withTimeout<T>(promise: Promise<T>, ms: number): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error("presence_post_timeout")), ms);
+    (timer as unknown as { unref?: () => void }).unref?.();
+    promise.then(
+      (value) => {
+        clearTimeout(timer);
+        resolve(value);
+      },
+      (err) => {
+        clearTimeout(timer);
+        reject(err);
+      },
+    );
+  });
+}
+
+// ─── POST body ──────────────────────────────────────────────────────────────
+
+/**
+ * Build the POST /Presence body. Exported so tests can pin the exact shape.
+ * Never includes agentId — identity is attributed server-side from the
+ * Ed25519 signature on the request (Presence.post(), agent-auth.ts), exactly
+ * like flair_workspace_set / flair_orgevent in index.ts. currentTask is
+ * omitted (not sent as null/empty) when absent, so callers that don't know a
+ * task can still heartbeat without explicitly clearing one that was set
+ * earlier — see postPresenceSafe()'s doc comment for why that matters.
+ */
+export function buildPresenceBody(activity: PresenceActivity, currentTask?: string): Record<string, unknown> {
+  const body: Record<string, unknown> = { activity };
+  if (currentTask) body.currentTask = currentTask;
+  return body;
+}
+
+// ─── Fire-and-forget POST ───────────────────────────────────────────────────
+
+/** Minimal surface a presence write needs from a Flair client — matches
+ *  FlairClient.request()'s shape exactly, so the real client satisfies this
+ *  with zero adapter code, and tests can inject a stub without a live server
+ *  or a real FlairClient instance. */
+export interface PresencePoster {
+  request<T = unknown>(method: string, path: string, body?: unknown): Promise<T>;
+}
+
+/**
+ * POST /Presence and NEVER throw or reject — every failure mode (timeout,
+ * network error, 401/403/500 from the server, a malformed response) is
+ * caught and swallowed here, in this one place, so every call site gets the
+ * guarantee for free instead of re-implementing it. Not awaiting the
+ * returned promise is what makes a call site "fire and forget"; the promise
+ * itself resolving-never-rejecting is what makes doing that safe (no
+ * unhandled rejection even if a caller forgets the `.catch()` belt-and-
+ * suspenders).
+ *
+ * currentTask is intentionally the caller's responsibility, not derived here:
+ * Presence.post() (resources/Presence.ts) treats an ABSENT currentTask as an
+ * explicit clear — `sanitizeCurrentTask(undefined)` returns `null`, which then
+ * overwrites any previously-set task on every merge. That's correct for the
+ * CLI (`flair presence set --activity X` with no `--task` IS an explicit "no
+ * task" statement) but wrong for an automatic heartbeat, which should never
+ * silently erase a task a human or bootstrap() set minutes earlier. Callers
+ * that want tasks preserved across heartbeats must track and re-pass the last
+ * known task themselves (see index.ts's `lastKnownTask` / session-start-hook's
+ * per-invocation scope) — this function just forwards whatever it's given.
+ */
+export async function postPresenceSafe(
+  poster: PresencePoster,
+  activity: PresenceActivity,
+  currentTask: string | undefined,
+  timeoutMs: number,
+): Promise<void> {
+  try {
+    await withTimeout(poster.request("POST", "/Presence", buildPresenceBody(activity, currentTask)), timeoutMs);
+  } catch {
+    // Silent by design — see doc comment above. A flair instance that's down
+    // or slow must never slow down or break the caller.
+  }
+}

--- a/packages/flair-mcp/src/session-start-hook.ts
+++ b/packages/flair-mcp/src/session-start-hook.ts
@@ -27,12 +27,23 @@
  * A hard timeout (FLAIR_HOOK_TIMEOUT_MS, default 8s) wraps the bootstrap call
  * so a stalled Flair daemon can't hang session startup; on timeout we no-op.
  *
+ * AUTO-PRESENCE (flair#598)
+ * -------------------------
+ * A session starting is the clearest "this agent is alive" signal flair-mcp
+ * gets, so this hook also fires a best-effort `POST /Presence` heartbeat
+ * alongside bootstrap — see ./presence.ts. It runs CONCURRENTLY with the
+ * bootstrap call (not serially after it), reuses the SAME signed request
+ * path (Ed25519, no new auth mechanism), and is bounded by its own short
+ * timeout so it can never add meaningful latency or turn a working bootstrap
+ * into a no-op. Manual `flair presence set` keeps working unchanged.
+ *
  * CONFIG (env, read identically to the MCP server)
  * ------------------------------------------------
  *   FLAIR_AGENT_ID   (required — absent → no-op)  agent identity
  *   FLAIR_URL        (default http://localhost:19926 via flair-client)
  *   FLAIR_KEY_PATH   (default ~/.flair/keys/<agent>.key via flair-client)
  *   FLAIR_HOOK_TIMEOUT_MS (default 8000; clamped 500..30000)
+ *   FLAIR_PRESENCE_TIMEOUT_MS (default 3000; clamped 500..10000 — see ./presence.ts)
  *
  * USAGE — register in ~/.claude/settings.json:
  *   {
@@ -47,6 +58,7 @@
 
 import { FlairClient } from "@tpsdev-ai/flair-client";
 import { basename } from "node:path";
+import { deriveActivity, postPresenceSafe, resolvePresenceTimeoutMs, type PresencePoster } from "./presence.js";
 
 /** Claude Code SessionStart additionalContext hard limit (chars). */
 const MAX_CHARS = 10_000;
@@ -70,8 +82,13 @@ interface SessionStartInput {
   [key: string]: unknown;
 }
 
-/** Minimal surface of FlairClient this hook depends on (eases testing). */
-interface BootstrapClient {
+/** Minimal surface of FlairClient this hook depends on (eases testing).
+ *  `request` is optional and structurally matches PresencePoster (presence.ts)
+ *  — the real FlairClient always has it. When present, this hook also fires a
+ *  best-effort presence heartbeat (flair#598) alongside bootstrap; when
+ *  absent (e.g. a lightweight test stub that only implements bootstrap()),
+ *  the heartbeat is silently skipped — no behavior change for those tests. */
+interface BootstrapClient extends Partial<PresencePoster> {
   bootstrap(opts: {
     maxTokens?: number;
     channel?: string;
@@ -155,9 +172,31 @@ export async function runHook(
   const cwd = typeof input.cwd === "string" && input.cwd ? input.cwd : process.cwd();
   const project = basename(cwd) || undefined;
 
+  const client = makeClient(agentId);
+
+  // Auto-presence (flair#598): a session starting is the clearest "this
+  // agent is alive" signal available. Fired CONCURRENTLY with the bootstrap
+  // call below (not serially after it) and bounded by its own short timeout
+  // (resolvePresenceTimeoutMs(), default 3s) — postPresenceSafe() never
+  // throws (see presence.ts's fail-open contract), so this can never turn a
+  // working bootstrap into a no-op, and awaiting `presenceDone` below can
+  // never add meaningful latency beyond what bootstrap already budgets
+  // (resolveTimeoutMs(), default 8s). No currentTask here: the SessionStart
+  // payload doesn't carry a task description (unlike the MCP `bootstrap`
+  // tool call — see index.ts), so this only ever sets `activity`, leaving
+  // currentTask exactly whatever it already was.
+  const presenceDone: Promise<void> =
+    typeof client.request === "function"
+      ? postPresenceSafe(
+          client as PresencePoster,
+          deriveActivity({ channel: "claude-code" }),
+          undefined,
+          resolvePresenceTimeoutMs(),
+        )
+      : Promise.resolve();
+
   let context = "";
   try {
-    const client = makeClient(agentId);
     const res = await withTimeout(
       Promise.resolve(
         client.bootstrap({
@@ -170,8 +209,11 @@ export async function runHook(
     );
     context = res && res.context ? String(res.context) : "";
   } catch {
+    await presenceDone;
     return NOOP_OUTPUT; // flair unreachable / auth error / timeout → no-op
   }
+
+  await presenceDone;
 
   if (!context.trim()) return NOOP_OUTPUT;
   if (context.length > MAX_CHARS) context = context.slice(0, MAX_CHARS);

--- a/packages/flair-mcp/test/mcp.test.ts
+++ b/packages/flair-mcp/test/mcp.test.ts
@@ -139,6 +139,50 @@ describe("coordination write surface (flair_workspace_set / flair_orgevent)", ()
   });
 });
 
+describe("auto-presence (flair#598) — bootstrap wiring in index.ts", () => {
+  // index.ts's `bootstrap` tool handler does two things before calling
+  // flair.bootstrap(): `if (currentTask) lastKnownTask = currentTask;` then
+  // `heartbeat(deriveActivity({ channel, surface }))`. runMcp() has
+  // module-level side effects (FLAIR_AGENT_ID check, process.exit, stdio
+  // connect) so it isn't imported directly here — same reason the rest of
+  // this file tests logic snippets rather than the wired server. This pins
+  // the lastKnownTask truthy-check specifically (presence.ts's own unit
+  // tests, packages/flair-mcp/test/presence.test.ts, cover deriveActivity/
+  // shouldSendHeartbeat/postPresenceSafe directly against the real module).
+
+  test("lastKnownTask is set when bootstrap is called with a currentTask", () => {
+    let lastKnownTask: string | undefined;
+    function onBootstrapCall(currentTask?: string) {
+      if (currentTask) lastKnownTask = currentTask;
+    }
+    onBootstrapCall("flair#598");
+    expect(lastKnownTask).toBe("flair#598");
+  });
+
+  test("a LATER bootstrap call with no currentTask does not clear a previously-known task", () => {
+    let lastKnownTask: string | undefined = "flair#598";
+    function onBootstrapCall(currentTask?: string) {
+      if (currentTask) lastKnownTask = currentTask;
+    }
+    onBootstrapCall(undefined);
+    expect(lastKnownTask).toBe("flair#598");
+  });
+
+  test("an empty-string currentTask does not overwrite a previously-known task (truthy check, not undefined check)", () => {
+    let lastKnownTask: string | undefined = "flair#598";
+    function onBootstrapCall(currentTask?: string) {
+      if (currentTask) lastKnownTask = currentTask;
+    }
+    onBootstrapCall("");
+    expect(lastKnownTask).toBe("flair#598");
+  });
+
+  test("lastKnownTask starts undefined — no task is invented before bootstrap ever supplies one", () => {
+    let lastKnownTask: string | undefined;
+    expect(lastKnownTask).toBeUndefined();
+  });
+});
+
 describe("temporal intent patterns", () => {
   // These patterns should be recognized by SemanticSearch
   const temporalPatterns = [

--- a/packages/flair-mcp/test/presence.test.ts
+++ b/packages/flair-mcp/test/presence.test.ts
@@ -1,0 +1,303 @@
+import { describe, test, expect, afterEach } from "bun:test";
+import {
+  deriveActivity,
+  shouldSendHeartbeat,
+  buildPresenceBody,
+  postPresenceSafe,
+  resolveHeartbeatIntervalMs,
+  resolvePresenceTimeoutMs,
+  DEFAULT_HEARTBEAT_INTERVAL_MS,
+  DEFAULT_PRESENCE_TIMEOUT_MS,
+  type PresencePoster,
+} from "../src/presence.ts";
+
+/**
+ * flair#598 — auto-presence unit tests.
+ *
+ * Covers the three things the issue explicitly asks for:
+ *   - a session-defining event (first heartbeat) POSTs presence
+ *   - a rate-limited heartbeat: a second rapid call does NOT POST again
+ *   - a failing presence POST never throws / never breaks the caller
+ *
+ * Plus the supporting pure functions (deriveActivity, buildPresenceBody) and
+ * the env-clamped config resolvers, tested the same way the rest of this
+ * package validates its clamped-env helpers (FLAIR_MCP_PARENT_POLL_MS /
+ * FLAIR_HOOK_TIMEOUT_MS elsewhere).
+ */
+
+const ORIGINAL_HEARTBEAT_ENV = process.env.FLAIR_PRESENCE_HEARTBEAT_MS;
+const ORIGINAL_TIMEOUT_ENV = process.env.FLAIR_PRESENCE_TIMEOUT_MS;
+
+afterEach(() => {
+  if (ORIGINAL_HEARTBEAT_ENV === undefined) delete process.env.FLAIR_PRESENCE_HEARTBEAT_MS;
+  else process.env.FLAIR_PRESENCE_HEARTBEAT_MS = ORIGINAL_HEARTBEAT_ENV;
+  if (ORIGINAL_TIMEOUT_ENV === undefined) delete process.env.FLAIR_PRESENCE_TIMEOUT_MS;
+  else process.env.FLAIR_PRESENCE_TIMEOUT_MS = ORIGINAL_TIMEOUT_ENV;
+});
+
+// ─── deriveActivity ───────────────────────────────────────────────────────────
+
+describe("deriveActivity", () => {
+  test("defaults to 'coding' with no context", () => {
+    expect(deriveActivity()).toBe("coding");
+    expect(deriveActivity({})).toBe("coding");
+  });
+
+  test("defaults to 'coding' when surface doesn't match a known pattern", () => {
+    expect(deriveActivity({ surface: "cli-session" })).toBe("coding");
+    expect(deriveActivity({ channel: "claude-code" })).toBe("coding");
+  });
+
+  test("surface containing 'review' -> reviewing", () => {
+    expect(deriveActivity({ surface: "tps-review" })).toBe("reviewing");
+  });
+
+  test("surface containing 'plan'/'spec'/'design' -> planning", () => {
+    expect(deriveActivity({ surface: "tps-planning" })).toBe("planning");
+    expect(deriveActivity({ surface: "spec-writing" })).toBe("planning");
+    expect(deriveActivity({ surface: "design-doc" })).toBe("planning");
+  });
+
+  test("'review' takes precedence over 'plan'/'spec'/'design' when both match", () => {
+    // deriveActivity checks "review" first — see its doc comment (two narrow
+    // overrides, "review" wins ties since a review surface is unambiguous).
+    expect(deriveActivity({ surface: "spec-review-x" })).toBe("reviewing");
+  });
+
+  test("is case-insensitive", () => {
+    expect(deriveActivity({ surface: "TPS-REVIEW" })).toBe("reviewing");
+    expect(deriveActivity({ surface: "Design-Doc" })).toBe("planning");
+  });
+});
+
+// ─── shouldSendHeartbeat (pure rate-limit check) ─────────────────────────────
+
+describe("shouldSendHeartbeat", () => {
+  test("no prior send (lastSentAt null) -> always true", () => {
+    expect(shouldSendHeartbeat(1_000_000, null, 60_000)).toBe(true);
+  });
+
+  test("elapsed >= interval -> true", () => {
+    expect(shouldSendHeartbeat(100_000, 40_000, 60_000)).toBe(true); // exactly 60_000 elapsed
+    expect(shouldSendHeartbeat(200_000, 40_000, 60_000)).toBe(true); // well past
+  });
+
+  test("elapsed < interval -> false", () => {
+    expect(shouldSendHeartbeat(50_000, 40_000, 60_000)).toBe(false); // only 10_000 elapsed
+  });
+});
+
+// ─── buildPresenceBody ────────────────────────────────────────────────────────
+
+describe("buildPresenceBody", () => {
+  test("always includes activity", () => {
+    expect(buildPresenceBody("idle")).toEqual({ activity: "idle" });
+  });
+
+  test("includes currentTask when present and non-empty", () => {
+    expect(buildPresenceBody("coding", "flair#598")).toEqual({ activity: "coding", currentTask: "flair#598" });
+  });
+
+  test("omits currentTask when undefined (does not send null / clear it)", () => {
+    const body = buildPresenceBody("coding", undefined);
+    expect(body).not.toHaveProperty("currentTask");
+  });
+
+  test("omits currentTask when empty string", () => {
+    const body = buildPresenceBody("coding", "");
+    expect(body).not.toHaveProperty("currentTask");
+  });
+
+  test("never includes agentId — identity comes from the signed request, not the body", () => {
+    const body = buildPresenceBody("coding", "task");
+    expect(body).not.toHaveProperty("agentId");
+  });
+});
+
+// ─── resolveHeartbeatIntervalMs / resolvePresenceTimeoutMs (clamped env) ─────
+
+describe("resolveHeartbeatIntervalMs", () => {
+  test("defaults when unset", () => {
+    delete process.env.FLAIR_PRESENCE_HEARTBEAT_MS;
+    expect(resolveHeartbeatIntervalMs()).toBe(DEFAULT_HEARTBEAT_INTERVAL_MS);
+  });
+
+  test("defaults on empty string (does not coerce to 0 and hammer the endpoint)", () => {
+    process.env.FLAIR_PRESENCE_HEARTBEAT_MS = "";
+    expect(resolveHeartbeatIntervalMs()).toBe(DEFAULT_HEARTBEAT_INTERVAL_MS);
+  });
+
+  test("defaults when out of range (too low or too high)", () => {
+    process.env.FLAIR_PRESENCE_HEARTBEAT_MS = "1"; // below floor
+    expect(resolveHeartbeatIntervalMs()).toBe(DEFAULT_HEARTBEAT_INTERVAL_MS);
+    process.env.FLAIR_PRESENCE_HEARTBEAT_MS = String(24 * 60 * 60 * 1000); // above ceiling
+    expect(resolveHeartbeatIntervalMs()).toBe(DEFAULT_HEARTBEAT_INTERVAL_MS);
+  });
+
+  test("respects a valid in-range override", () => {
+    process.env.FLAIR_PRESENCE_HEARTBEAT_MS = "45000";
+    expect(resolveHeartbeatIntervalMs()).toBe(45_000);
+  });
+});
+
+describe("resolvePresenceTimeoutMs", () => {
+  test("defaults when unset", () => {
+    delete process.env.FLAIR_PRESENCE_TIMEOUT_MS;
+    expect(resolvePresenceTimeoutMs()).toBe(DEFAULT_PRESENCE_TIMEOUT_MS);
+  });
+
+  test("defaults on empty string", () => {
+    process.env.FLAIR_PRESENCE_TIMEOUT_MS = "";
+    expect(resolvePresenceTimeoutMs()).toBe(DEFAULT_PRESENCE_TIMEOUT_MS);
+  });
+
+  test("respects a valid in-range override", () => {
+    process.env.FLAIR_PRESENCE_TIMEOUT_MS = "1500";
+    expect(resolvePresenceTimeoutMs()).toBe(1500);
+  });
+});
+
+// ─── postPresenceSafe — fail-open contract ───────────────────────────────────
+
+describe("postPresenceSafe", () => {
+  test("posts to /Presence with the expected body", async () => {
+    const calls: Array<{ method: string; path: string; body: unknown }> = [];
+    const poster: PresencePoster = {
+      async request(method, path, body) {
+        calls.push({ method, path, body });
+        return { ok: true };
+      },
+    };
+
+    await postPresenceSafe(poster, "coding", "flair#598", 1000);
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0].method).toBe("POST");
+    expect(calls[0].path).toBe("/Presence");
+    expect(calls[0].body).toEqual({ activity: "coding", currentTask: "flair#598" });
+  });
+
+  test("a rejecting request() does NOT throw — resolves normally", async () => {
+    const poster: PresencePoster = {
+      async request() {
+        throw new Error("network error: ECONNREFUSED");
+      },
+    };
+
+    // The whole point: awaiting this must not reject.
+    await expect(postPresenceSafe(poster, "coding", undefined, 1000)).resolves.toBeUndefined();
+  });
+
+  test("a hanging request() does not hang the caller — bounded by timeoutMs", async () => {
+    const poster: PresencePoster = {
+      request() {
+        return new Promise(() => {}); // never resolves/rejects
+      },
+    };
+
+    const start = Date.now();
+    await postPresenceSafe(poster, "idle", undefined, 100); // tight timeout
+    const elapsed = Date.now() - start;
+
+    // Resolved (didn't throw) and did so close to the timeout, not instantly
+    // and not hung indefinitely.
+    expect(elapsed).toBeLessThan(2000);
+  });
+
+  test("a 401/403-shaped rejection (auth error) does NOT throw", async () => {
+    const poster: PresencePoster = {
+      async request() {
+        const err = new Error("Flair POST /Presence -> 401: invalid_signature");
+        throw err;
+      },
+    };
+
+    await expect(postPresenceSafe(poster, "coding", "task", 1000)).resolves.toBeUndefined();
+  });
+});
+
+// ─── End-to-end rate-limit contract (mirrors index.ts's heartbeat() closure) ─
+//
+// index.ts's runMcp() wires shouldSendHeartbeat + postPresenceSafe together
+// in a small closure (`heartbeat()`) that owns its own `lastPresenceSentAt`
+// clock — that closure isn't exported (runMcp() has module-level side
+// effects, same reason mcp.test.ts tests tool logic in isolation rather than
+// importing the wired server). This test reproduces the EXACT same wiring
+// using the real exported functions, with an injectable clock, so the
+// rate-limit contract is verified against real code, not a re-implementation.
+
+describe("heartbeat wiring (rate limit contract)", () => {
+  function makeHeartbeat(poster: PresencePoster, intervalMs: number, clock: { now: number }) {
+    let lastSentAt: number | null = null;
+    return (activity: Parameters<typeof buildPresenceBody>[0] = "coding", currentTask?: string) => {
+      if (!shouldSendHeartbeat(clock.now, lastSentAt, intervalMs)) return;
+      lastSentAt = clock.now;
+      void postPresenceSafe(poster, activity, currentTask, 1000);
+    };
+  }
+
+  test("first call always sends (session start)", async () => {
+    const calls: unknown[] = [];
+    const poster: PresencePoster = { async request(_m, _p, body) { calls.push(body); return {}; } };
+    const clock = { now: 1_000_000 };
+    const heartbeat = makeHeartbeat(poster, 60_000, clock);
+
+    heartbeat("coding", "flair#598");
+    await Promise.resolve(); // let the fire-and-forget microtask run
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(calls).toHaveLength(1);
+  });
+
+  test("a second rapid call within the interval does NOT POST again", async () => {
+    const calls: unknown[] = [];
+    const poster: PresencePoster = { async request(_m, _p, body) { calls.push(body); return {}; } };
+    const clock = { now: 1_000_000 };
+    const heartbeat = makeHeartbeat(poster, 60_000, clock);
+
+    heartbeat("coding");
+    await new Promise((r) => setTimeout(r, 0));
+    expect(calls).toHaveLength(1);
+
+    clock.now += 1_000; // 1s later — well within the 60s interval
+    heartbeat("coding");
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(calls).toHaveLength(1); // still just the one send — rate-limited
+  });
+
+  test("a call after the interval elapses sends again", async () => {
+    const calls: unknown[] = [];
+    const poster: PresencePoster = { async request(_m, _p, body) { calls.push(body); return {}; } };
+    const clock = { now: 1_000_000 };
+    const heartbeat = makeHeartbeat(poster, 60_000, clock);
+
+    heartbeat("coding");
+    await new Promise((r) => setTimeout(r, 0));
+    expect(calls).toHaveLength(1);
+
+    clock.now += 61_000; // past the interval
+    heartbeat("reviewing");
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(calls).toHaveLength(2);
+    expect(calls[1]).toEqual({ activity: "reviewing" });
+  });
+
+  test("a failing poster never surfaces through the heartbeat wiring (fire-and-forget is safe)", async () => {
+    const poster: PresencePoster = {
+      async request() {
+        throw new Error("Flair down");
+      },
+    };
+    const clock = { now: 1_000_000 };
+    const heartbeat = makeHeartbeat(poster, 60_000, clock);
+
+    // Calling this must not throw synchronously, and must not produce an
+    // unhandled rejection (postPresenceSafe's own catch guarantees the
+    // returned promise never rejects, so `void postPresenceSafe(...)` above
+    // is safe even without a `.catch()`).
+    expect(() => heartbeat("coding")).not.toThrow();
+    await new Promise((r) => setTimeout(r, 0));
+  });
+});

--- a/packages/flair-mcp/test/session-start-hook.test.ts
+++ b/packages/flair-mcp/test/session-start-hook.test.ts
@@ -136,4 +136,86 @@ describe("session-start hook", () => {
       expect(parsed.hookSpecificOutput.additionalContext).toContain("quotes");
     });
   });
+
+  describe("auto-presence (flair#598)", () => {
+    // Session start is the clearest "this agent is alive" signal flair-mcp
+    // gets — the hook fires a best-effort POST /Presence alongside bootstrap
+    // when the injected client exposes `request()` (the real FlairClient
+    // always does). These tests use a client stub with BOTH bootstrap() and
+    // request() so the presence side effect is observable.
+
+    test("session start POSTs presence when the client supports request()", async () => {
+      process.env.FLAIR_AGENT_ID = "test-agent";
+      const presenceCalls: Array<{ method: string; path: string; body: unknown }> = [];
+      const out = await runHook(SAMPLE_INPUT, () => ({
+        bootstrap: async () => ({ context: "## Identity\nrole: test" }),
+        request: async (method: string, path: string, body?: unknown) => {
+          presenceCalls.push({ method, path, body });
+          return { ok: true };
+        },
+      }));
+
+      expect(presenceCalls).toHaveLength(1);
+      expect(presenceCalls[0].method).toBe("POST");
+      expect(presenceCalls[0].path).toBe("/Presence");
+      expect(presenceCalls[0].body).toEqual({ activity: "coding" }); // no currentTask in the hook payload
+      // The presence side effect never changes the hook's own output contract.
+      const parsed = JSON.parse(out);
+      expect(parsed.hookSpecificOutput.additionalContext).toBe("## Identity\nrole: test");
+    });
+
+    test("client without request() — presence step is silently skipped, no error", async () => {
+      process.env.FLAIR_AGENT_ID = "test-agent";
+      // No `request` on this stub at all — matches every OTHER test in this
+      // file, confirming the new code path doesn't change their behavior.
+      const out = await runHook(SAMPLE_INPUT, () => ({
+        bootstrap: async () => ({ context: "ctx" }),
+      }));
+      const parsed = JSON.parse(out);
+      expect(parsed.hookSpecificOutput.additionalContext).toBe("ctx");
+    });
+
+    test("a failing presence POST does NOT throw and does NOT affect the hook's output", async () => {
+      process.env.FLAIR_AGENT_ID = "test-agent";
+      const out = await runHook(SAMPLE_INPUT, () => ({
+        bootstrap: async () => ({ context: "## Identity\nrole: test" }),
+        request: async () => {
+          throw new Error("network error: ECONNREFUSED");
+        },
+      }));
+      // Bootstrap succeeded; the presence failure must be invisible here.
+      const parsed = JSON.parse(out);
+      expect(parsed.hookSpecificOutput.additionalContext).toBe("## Identity\nrole: test");
+    });
+
+    test("a failing presence POST does not prevent the NOOP path either (bootstrap also fails)", async () => {
+      process.env.FLAIR_AGENT_ID = "test-agent";
+      const out = await runHook(SAMPLE_INPUT, () => ({
+        bootstrap: async () => {
+          throw new Error("bootstrap unreachable");
+        },
+        request: async () => {
+          throw new Error("presence also unreachable");
+        },
+      }));
+      expect(out).toBe(NOOP);
+    });
+
+    test("a hanging presence POST does not delay the hook beyond its own timeout budget", async () => {
+      process.env.FLAIR_AGENT_ID = "test-agent";
+      // Uses presence.ts's own default timeout (3s, resolvePresenceTimeoutMs)
+      // — runs CONCURRENTLY with bootstrap, so total wall time stays bounded
+      // by that ~3s, well under the 8s bootstrap timeout default.
+      const start = Date.now();
+      const out = await runHook(SAMPLE_INPUT, () => ({
+        bootstrap: async () => ({ context: "ctx" }),
+        request: () => new Promise(() => {}), // never resolves
+      }));
+      const elapsed = Date.now() - start;
+
+      const parsed = JSON.parse(out);
+      expect(parsed.hookSpecificOutput.additionalContext).toBe("ctx");
+      expect(elapsed).toBeLessThan(5000);
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Presence was manual-only (`flair presence set`), which in practice nobody ran — so the roster was permanently stale and the collision-detection it exists for never worked (#598). This makes presence a **side effect of normal flair-mcp activity**, reusing the existing SIGNED `POST /Presence` path (Ed25519, the same auth flair_workspace_set/flair_orgevent already use — no new auth mechanism):

- **Session start**: the `flair-session-start` hook and the MCP `bootstrap` tool call both fire a presence heartbeat. `bootstrap` additionally seeds `activity` (derived from its `channel`/`surface` args via `deriveActivity()`) and `currentTask` from its own arguments — exactly the payload the issue described.
- **Heartbeat**: every other MCP tool call (`memory_*`, `soul_*`, `flair_workspace_set`, `flair_orgevent`) refreshes `lastHeartbeatAt` too, through a shared, rate-limited (default 3min, env-clamped via `FLAIR_PRESENCE_HEARTBEAT_MS`) `heartbeat()` closure in `runMcp()` — so `presenceStatus` derivation (active/idle/offline, `resources/Presence.ts`) reflects real activity instead of a 12-day-old heartbeat.
- **Idle/offline**: no new writes — the existing threshold-based derivation handles decay once heartbeats are real.

Manual `flair presence set` is completely unaffected — this is purely additive.

New `packages/flair-mcp/src/presence.ts` holds the pure, directly-testable logic shared by both call sites: `deriveActivity`, `shouldSendHeartbeat`, `buildPresenceBody`, `postPresenceSafe`, plus env-clamped `resolveHeartbeatIntervalMs`/`resolvePresenceTimeoutMs`.

## Fail-open (never breaks the agent)

`postPresenceSafe()` NEVER throws — network errors, auth failures, a down daemon, or a hanging request (bounded by its own short timeout, default 3s — separate from `heartbeat()`'s rate-limit interval, and separate from the MCP client's general-purpose 30s default) are all swallowed. A Presence write failing can never break `bootstrap`, a tool call, or Claude Code session start. The MCP server's heartbeats are also fire-and-forget (not awaited in the tool handler's response path), so a slow Presence write adds zero latency to any tool call. The session-start hook awaits its own heartbeat, but runs it CONCURRENTLY with the bootstrap call (not serially after), bounded by the same short timeout, so it can't meaningfully extend the hook's existing timeout budget.

## currentTask stickiness (named tradeoff)

`resources/Presence.ts`'s `POST /Presence` handler treats an ABSENT `currentTask` as an explicit clear (`sanitizeCurrentTask(undefined)` → `null`, then unconditionally merged over the existing record) — true of `flair presence set --activity X` with no `--task` today. To keep the new rate-limited heartbeats from silently nulling out a task set at session start, `index.ts`'s `heartbeat()` closure remembers the last `currentTask` it was given (`lastKnownTask`) and re-sends it on every heartbeat. This is a client-side, single-process patch, not a source-of-truth fix: a manual `flair presence set --task` from a DIFFERENT process mid-session can still be overwritten by this tracker's next heartbeat, since neither process reads-before-writing. Acceptable for now — the core goal (a live, non-stale `presenceStatus`) only depends on `lastHeartbeatAt` being real, not on `currentTask` fidelity across processes.

## Verify

- `cd packages/flair-mcp && bun test` — 72/72 pass
- `bun test test/unit/` (repo root) — 1648/1648 pass
- `tsc --noEmit` on `packages/flair-mcp` — clean
- `packages/flair-mcp/test/presence.test.ts` (new) — unit tests for `deriveActivity`, `shouldSendHeartbeat` (rate-limit contract, including a second-rapid-call-doesn't-POST case), `buildPresenceBody`, `postPresenceSafe` (fail-open: rejecting/hanging `request()` never throws), and an end-to-end heartbeat-wiring contract test mirroring `index.ts`'s closure.
- `packages/flair-mcp/test/session-start-hook.test.ts` — new cases: session start POSTs presence when the client supports `request()`; a client without `request()` is unaffected (backward compatible); a failing/hanging presence POST doesn't affect the hook's output or exceed its timeout budget.
- `packages/flair-mcp/test/mcp.test.ts` — pins the `lastKnownTask` truthy-check wiring used by `bootstrap`'s handler.

## Test plan

- [x] `packages/flair-mcp` test suite passes (72/72)
- [x] root `test/unit/` suite passes (1648/1648)
- [x] typecheck clean
- [ ] Kern (architecture) + Sherlock (security) review

🤖 Generated with [Claude Code](https://claude.com/claude-code)