### PR TITLE
fix(security): require real auth for OAuthAuthorize consent + scope Presence early-return to GET (closes #604)

### DIFF
--- a/resources/OAuth.ts
+++ b/resources/OAuth.ts
@@ -42,6 +42,28 @@ function futureISO(ms: number): string {
   return new Date(Date.now() + ms).toISOString();
 }
 
+/**
+ * 302 redirect — deliberately NOT `Response.redirect()`.
+ *
+ * FOUND while writing the real-Harper integration test for #604 (this exact
+ * gap is why the coverage doc above calls OAuthAuthorize.post() untestable
+ * without a running Harper instance — no test had ever hit this path over
+ * real HTTP before). Pre-existing on main, unrelated to the #604 auth fix:
+ * per the Fetch spec, `Response.redirect(url, status)` constructs a Response
+ * whose Headers guard is set to "immutable". Harper's own HTTP response
+ * pipeline mutates the handler's returned Response's headers afterward (e.g.
+ * CORS/instrumentation headers) — against an immutable-guarded Headers this
+ * throws `TypeError: immutable`, turning EVERY real POST /OAuthAuthorize
+ * (both "deny" and "approve") into a 500, verified via curl against a built
+ * origin/main with no other changes. A manually-constructed Response with
+ * the same status/Location header has the default (mutable) "response"
+ * guard, so Harper's later mutation succeeds — identical bytes on the wire,
+ * no behavior change, just a mutable Headers object underneath.
+ */
+function redirectTo(url: string, status: 302 | 303 = 302): Response {
+  return new Response(null, { status, headers: { Location: url } });
+}
+
 // ─── Discovery metadata ──────────────────────────────────────────────────────
 
 export class OAuthMetadata extends Resource {
@@ -225,7 +247,7 @@ ${scope.split(" ").map((s: string) => `<div class="scope">${s}</div>`).join("")}
 
     if (action === "deny") {
       const params = new URLSearchParams({ error: "access_denied", state });
-      return Response.redirect(`${redirectUri}?${params}`, 302);
+      return redirectTo(`${redirectUri}?${params}`);
     }
 
     // Determine authenticated principal. Harper v5 does not populate
@@ -244,6 +266,44 @@ ${scope.split(" ").map((s: string) => `<div class="scope">${s}</div>`).join("")}
     // admin, or should any verified (non-admin) agent be able to approve its
     // own consent grant? The previous code always resolved to "admin" for
     // every caller, so this is a genuine policy decision, not just a bug fix.
+    //
+    // SECURITY FIX (#604 — authorizeLocal escalation): resolveAgentAuth's
+    // `context.user` fallback (agent-auth.ts, the super_user / username
+    // branches) ALSO matches Harper's `authorizeLocal` (config true) ambient
+    // super_user injection for ANY credential-less LOOPBACK request.
+    // /OAuthAuthorize sits on auth-middleware.ts's public early-return
+    // passthrough (any method), so a bare local POST never gets OUR
+    // middleware's tpsAgent/tpsAnonymous annotation either — resolveAgentAuth
+    // falls straight through to Harper's raw `context.user`, which
+    // authorizeLocal can forge with NO signature and NO password. A
+    // credential-less loopback POST therefore resolved to
+    // { kind: "agent", agentId: "admin", isAdmin: true } and minted a REAL
+    // admin authorization code, exchangeable at OAuthToken for a Bearer
+    // token — full local privilege escalation with zero credentials.
+    // authorizeLocal injects request.user=super_user ONLY when there is NO
+    // Authorization header present (see Presence.ts's get() doc for the
+    // fuller writeup of this exact mechanism) — a genuinely
+    // password-verified Basic admin/super_user, or a genuinely
+    // Ed25519-signed agent request, both carry a real header. Requiring one
+    // be present before trusting resolveAgentAuth's verdict closes the
+    // forged-approver path without touching resolveAgentAuth itself (the
+    // root-cause fix is a separate, larger follow-up — see #604): a
+    // credential-less local caller now gets 401 and no code is minted; a
+    // genuinely-authenticated approver (real Basic password, or a real
+    // TPS-Ed25519 signature verified by resolveAgentAuth's own fallback) is
+    // unaffected.
+    const ctx = (this as any).getContext?.();
+    const request = ctx?.request ?? ctx;
+    const authHeader: string =
+      request?.headers?.get?.("authorization") ??
+      request?.headers?.asObject?.authorization ??
+      "";
+    if (!authHeader) {
+      return new Response(JSON.stringify({ error: "authentication required" }), {
+        status: 401, headers: { "content-type": "application/json" },
+      });
+    }
+
     const auth = await resolveAgentAuth((this as any).getContext?.());
     if (auth.kind !== "agent") {
       return new Response(JSON.stringify({ error: "authentication required" }), {
@@ -270,7 +330,7 @@ ${scope.split(" ").map((s: string) => `<div class="scope">${s}</div>`).join("")}
     });
 
     const params = new URLSearchParams({ code, state });
-    return Response.redirect(`${redirectUri}?${params}`, 302);
+    return redirectTo(`${redirectUri}?${params}`);
   }
 }
 

--- a/resources/auth-middleware.ts
+++ b/resources/auth-middleware.ts
@@ -103,9 +103,28 @@ server.http(async (request: any, nextLayer: any) => {
     // instances (rockit-local works only because authorizeLocal=true).
     url.pathname === "/ObservationCenter" ||
     // Presence roster is public-safe (field-allowlisted); GET serves the
-    // Office Space renderer without auth. POST handles Ed25519 auth internally
-    // (allowCreate=true on the Resource).
-    url.pathname === "/Presence"
+    // Office Space renderer without auth. Scoped to GET only (#604): the
+    // exact-path match used to match ANY method, so a bare `PUT /Presence`
+    // (collection-level, no id — Harper routes it to the same .put() as
+    // by-id PUT) early-returned here too, skipping this middleware entirely.
+    // A credential-less loopback PUT then reached Presence.put()'s
+    // resolveAgentAuth() call with NO tpsAnonymous/tpsAgent annotation, which
+    // fell through to raw `context.user` — populated by Harper's
+    // `authorizeLocal` (config true) ambient super_user injection for ANY
+    // credential-less loopback request — so the ownership check saw an
+    // "admin" caller (isAdmin=true) and let the write through unauthenticated
+    // (`super.put()`, no signature, no password). Mirrors the A2A GET-only
+    // pattern above: POST/PUT/DELETE now always transit the general
+    // middleware path below, which marks a genuinely headerless request
+    // tpsAnonymous BEFORE Harper's ambient elevation lands (resolveAgentAuth
+    // checks tpsAnonymous first — see agent-auth.ts's resolution order), so
+    // the ownership check in Presence.put()/delete() correctly denies it.
+    // POST (the heartbeat) is unaffected in practice: it already prefers
+    // request.tpsAgent when the middleware set it, and falls back to its own
+    // Ed25519 header parse otherwise — transiting the general path now just
+    // means a genuinely headerless POST gets marked anonymous (still 401)
+    // instead of skipping straight to that fallback parse.
+    (request.method === "GET" && url.pathname === "/Presence")
   ) return nextLayer(request);
 
   // If Harper has already authorized this request (e.g. Basic admin, or

--- a/test/integration/oauth-authorize-authz.test.ts
+++ b/test/integration/oauth-authorize-authz.test.ts
@@ -1,0 +1,285 @@
+// oauth-authorize-authz.test.ts — Integration tests for flair#604 (the
+// authorizeLocal escalation class), OAuthAuthorize.post() half.
+//
+// Harper's `authorizeLocal` (config.yaml: true) injects request.user =
+// super_user for ANY credential-less LOOPBACK request (only suppressed when a
+// real Authorization header is present). /OAuthAuthorize sits on
+// auth-middleware.ts's public early-return passthrough (any method), so a
+// bare local POST never gets OUR middleware's tpsAgent/tpsAnonymous
+// annotation either — resolveAgentAuth() used to fall straight through to
+// Harper's raw `context.user`, which authorizeLocal had already forged with
+// NO signature and NO password, and mint a REAL admin authorization code —
+// full local privilege escalation with zero credentials, exchangeable at
+// /OAuthToken for a Bearer token.
+//
+// This is a REAL Harper spawn (config.yaml's authorizeLocal: true applies,
+// same as every other integration test in this repo) — a mocked unit test
+// cannot reproduce the ambient-elevation path at all (that's the #601
+// lesson referenced throughout this PR).
+//
+// MODEL: test/integration/presence-api.test.ts + auth-middleware-e2e.test.ts.
+import { describe, expect, test, beforeAll, afterAll } from "bun:test";
+import nacl from "tweetnacl";
+import { createHash, randomBytes, randomUUID } from "node:crypto";
+import { startHarper, stopHarper, HarperInstance } from "../helpers/harper-lifecycle";
+
+const ALLOWED_REDIRECT_URI = "https://claude.com/api/mcp/auth_callback";
+
+// ─── Crypto / header helpers (same pattern as auth-middleware-e2e.test.ts) ───
+
+interface TestAgent { id: string; publicKey: string; secretKey: Uint8Array; }
+
+function mkAgent(id: string): TestAgent {
+  const kp = nacl.sign.keyPair();
+  return { id, publicKey: Buffer.from(kp.publicKey).toString("base64"), secretKey: kp.secretKey };
+}
+
+function ed25519Header(agent: TestAgent, method: string, path: string): string {
+  const ts = Date.now().toString();
+  const nonce = randomUUID();
+  const payload = `${agent.id}:${ts}:${nonce}:${method}:${path}`;
+  const sig = nacl.sign.detached(new TextEncoder().encode(payload), agent.secretKey);
+  const sigB64 = Buffer.from(sig).toString("base64");
+  return `TPS-Ed25519 ${agent.id}:${ts}:${nonce}:${sigB64}`;
+}
+
+function pkcePair(): { verifier: string; challenge: string } {
+  const verifier = randomBytes(32).toString("base64url");
+  const challenge = createHash("sha256").update(verifier).digest("base64url");
+  return { verifier, challenge };
+}
+
+async function adminOp(harper: HarperInstance, op: Record<string, any>): Promise<Response> {
+  return fetch(harper.opsURL, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: "Basic " + btoa(`${harper.admin.username}:${harper.admin.password}`),
+    },
+    body: JSON.stringify(op),
+  });
+}
+
+function codeFromRedirect(location: string | null): string | null {
+  if (!location) return null;
+  const url = new URL(location);
+  return url.searchParams.get("code");
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+let harper: HarperInstance;
+const agent = mkAgent("oauth-authz-e2e-agent");
+let clientId: string;
+
+describe("OAuthAuthorize.post() authz (flair#604 authorizeLocal escalation)", () => {
+  beforeAll(async () => {
+    harper = await startHarper();
+
+    const agentRes = await adminOp(harper, {
+      operation: "insert",
+      database: "flair",
+      table: "Agent",
+      records: [{
+        id: agent.id,
+        name: agent.id,
+        role: "agent",
+        publicKey: agent.publicKey,
+        createdAt: new Date().toISOString(),
+      }],
+    });
+    expect(agentRes.status).toBe(200);
+
+    clientId = `flair_cl_test_${randomUUID()}`;
+    const clientRes = await adminOp(harper, {
+      operation: "insert",
+      database: "flair",
+      table: "OAuthClient",
+      records: [{
+        id: clientId,
+        name: "604 test client",
+        redirectUris: [ALLOWED_REDIRECT_URI],
+        grantTypes: ["authorization_code", "refresh_token"],
+        scope: "memory:read",
+        registeredBy: "test",
+        createdAt: new Date().toISOString(),
+      }],
+    });
+    expect(clientRes.status).toBe(200);
+  }, 180_000);
+
+  afterAll(async () => {
+    if (harper) await stopHarper(harper);
+  });
+
+  // ── THE ESCALATION: credential-less loopback POST must NOT mint a code ────
+
+  test("#604: credential-less loopback POST /OAuthAuthorize (approve) → 401, mints NO code", async () => {
+    const { challenge } = pkcePair();
+    const state = randomUUID();
+
+    const res = await fetch(`${harper.httpURL}/OAuthAuthorize`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        action: "approve",
+        client_id: clientId,
+        redirect_uri: ALLOWED_REDIRECT_URI,
+        scope: "memory:read",
+        state,
+        code_challenge: challenge,
+        code_challenge_method: "S256",
+      }),
+    });
+
+    // Must NOT be a 302 redirect carrying a minted code — that would be the
+    // ambient-super_user escalation. Must be a 401 auth rejection instead.
+    expect(res.status).toBe(401);
+    const body: any = await res.json().catch(() => ({}));
+    expect(body.error).toBe("authentication required");
+
+    // Belt-and-suspenders: confirm no OAuthAuthCode record exists for this
+    // client at all (nothing was minted under the hood).
+    const search = await adminOp(harper, {
+      operation: "search_by_value",
+      database: "flair",
+      table: "OAuthAuthCode",
+      search_attribute: "clientId",
+      search_value: clientId,
+      get_attributes: ["id", "principalId"],
+    });
+    expect(search.status).toBe(200);
+    const rows: any[] = await search.json();
+    expect(rows.length).toBe(0);
+  }, 30_000);
+
+  test("#604: credential-less loopback POST /OAuthAuthorize (deny) is unaffected — still redirects with access_denied", async () => {
+    // Deny never mints anything, so it's fine for it to remain
+    // unauthenticated (nothing sensitive happens on this path) — this pins
+    // that the fix didn't accidentally block deny too.
+    const state = randomUUID();
+    const res = await fetch(`${harper.httpURL}/OAuthAuthorize`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      redirect: "manual",
+      body: JSON.stringify({
+        action: "deny",
+        client_id: clientId,
+        redirect_uri: ALLOWED_REDIRECT_URI,
+        state,
+      }),
+    });
+    expect(res.status).toBe(302);
+    const location = res.headers.get("location");
+    expect(location).toContain("error=access_denied");
+  }, 30_000);
+
+  // ── LEGITIMATE FLOWS: must still work ──────────────────────────────────────
+
+  test("genuine Basic admin approval still mints a real code, exchangeable for a token", async () => {
+    const { verifier, challenge } = pkcePair();
+    const state = randomUUID();
+
+    const approveRes = await fetch(`${harper.httpURL}/OAuthAuthorize`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: "Basic " + btoa(`${harper.admin.username}:${harper.admin.password}`),
+      },
+      redirect: "manual",
+      body: JSON.stringify({
+        action: "approve",
+        client_id: clientId,
+        redirect_uri: ALLOWED_REDIRECT_URI,
+        scope: "memory:read",
+        state,
+        code_challenge: challenge,
+        code_challenge_method: "S256",
+      }),
+    });
+    expect(approveRes.status).toBe(302);
+    const code = codeFromRedirect(approveRes.headers.get("location"));
+    expect(code).toBeTruthy();
+
+    // Exchange the code — proves the full genuine flow, not just the mint.
+    const tokenRes = await fetch(`${harper.httpURL}/OAuthToken`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        grant_type: "authorization_code",
+        code,
+        client_id: clientId,
+        redirect_uri: ALLOWED_REDIRECT_URI,
+        code_verifier: verifier,
+      }),
+    });
+    expect(tokenRes.status).toBe(200);
+    const tokenBody: any = await tokenRes.json();
+    expect(tokenBody.access_token).toBeTruthy();
+    expect(tokenBody.token_type).toBe("Bearer");
+  }, 30_000);
+
+  test("genuine Ed25519-signed agent approval still mints a code for that agent", async () => {
+    const { challenge } = pkcePair();
+    const state = randomUUID();
+    const path = "/OAuthAuthorize";
+
+    const res = await fetch(`${harper.httpURL}${path}`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: ed25519Header(agent, "POST", path),
+      },
+      redirect: "manual",
+      body: JSON.stringify({
+        action: "approve",
+        client_id: clientId,
+        redirect_uri: ALLOWED_REDIRECT_URI,
+        scope: "memory:read",
+        state,
+        code_challenge: challenge,
+        code_challenge_method: "S256",
+      }),
+    });
+    expect(res.status).toBe(302);
+    const code = codeFromRedirect(res.headers.get("location"));
+    expect(code).toBeTruthy();
+
+    // Confirm the minted code's principalId is the SIGNING agent, not admin —
+    // proves the approver identity, not just "something" got minted.
+    const search = await adminOp(harper, {
+      operation: "search_by_value",
+      database: "flair",
+      table: "OAuthAuthCode",
+      search_attribute: "id",
+      search_value: code,
+      get_attributes: ["id", "principalId", "clientId"],
+    });
+    expect(search.status).toBe(200);
+    const rows: any[] = await search.json();
+    expect(rows.length).toBe(1);
+    expect(rows[0].principalId).toBe(agent.id);
+  }, 30_000);
+
+  test("wrong-password Basic auth on POST /OAuthAuthorize → 401, mints NO code", async () => {
+    const { challenge } = pkcePair();
+    const state = randomUUID();
+    const res = await fetch(`${harper.httpURL}/OAuthAuthorize`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: "Basic " + btoa(`${harper.admin.username}:wrong-password-entirely`),
+      },
+      body: JSON.stringify({
+        action: "approve",
+        client_id: clientId,
+        redirect_uri: ALLOWED_REDIRECT_URI,
+        scope: "memory:read",
+        state,
+        code_challenge: challenge,
+        code_challenge_method: "S256",
+      }),
+    });
+    expect(res.status).toBe(401);
+  }, 30_000);
+});

--- a/test/integration/presence-api.test.ts
+++ b/test/integration/presence-api.test.ts
@@ -382,4 +382,119 @@ describe("Presence API integration", () => {
     // This should fail with unknown_agent
     expect([401, 403]).toContain(res.status);
   });
+
+  // ── 8. authorizeLocal escalation (#604) — bare PUT /Presence ───────────────
+  // The auth-middleware's public early-return used to match /Presence on
+  // ANY method (exact path, no method guard), so a bare `PUT /Presence`
+  // (collection-level, no id — Harper routes it to the same .put() as
+  // by-id PUT) skipped the middleware entirely. A credential-less loopback
+  // PUT then reached Presence.put()'s resolveAgentAuth() call with no
+  // tpsAnonymous/tpsAgent annotation, which fell through to Harper's raw
+  // `context.user` — populated by `authorizeLocal` (config.yaml: true) for
+  // ANY credential-less loopback request, with no signature and no
+  // password — so the ownership check saw an "admin" caller (isAdmin=true)
+  // and let it PAST the ownership guard unauthenticated (`super.put()` would
+  // then separately 400 on the missing primary key for a bare collection PUT
+  // — but the auth bypass itself, reaching super.put() as forged-admin with
+  // zero credentials, is the hole being closed; a by-id PUT, the real write
+  // path, has no such structural block and WOULD have written). Fixed by
+  // scoping the early-return to GET only, so PUT now always transits the
+  // general middleware path, which marks a genuinely headerless request
+  // tpsAnonymous BEFORE Harper's ambient elevation lands.
+
+  test("#604: credential-less loopback PUT /Presence (no id, no auth) → rejected before reaching the write path", async () => {
+    const victimId = "presence-604-victim";
+    // Seed a baseline record via a real signed write so we can prove the
+    // unauthenticated PUT below did not alter it.
+    const victimKp = makeKeypair();
+    await seedAgent(harper.opsURL, adminAuth(), victimId, victimKp.publicKey, "Victim Agent");
+    const seedAuth = buildAuthHeader(victimId, "POST", "/Presence", victimKp.privateKey);
+    await fetch(`${harper.httpURL}/Presence`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Authorization: seedAuth },
+      body: JSON.stringify({ currentTask: "baseline before 604 PUT attempt", activity: "coding" }),
+    });
+
+    // The escalation attempt: bare, unauthenticated, collection-level PUT.
+    const res = await fetch(`${harper.httpURL}/Presence`, {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ agentId: victimId, currentTask: "PWNED — authorizeLocal escalation", activity: "coding" }),
+    });
+    // Must NOT be a successful write. resolveAgentAuth's anonymous verdict
+    // → Presence.put() returns 401; Harper's own table gate could also
+    // intervene first with 403 depending on routing — either is an
+    // acceptable "not authorized," 200 is the only unacceptable outcome.
+    expect(res.status).not.toBe(200);
+    expect([401, 403]).toContain(res.status);
+
+    // Confirm the victim's record was NOT overwritten.
+    const getAuth = buildAuthHeader(victimId, "GET", "/Presence", victimKp.privateKey);
+    const check = await fetch(`${harper.httpURL}/Presence`, { headers: { Authorization: getAuth } });
+    const roster = await check.json();
+    const victim = roster.find((r: any) => r.id === victimId);
+    expect(victim).toBeDefined();
+    expect(victim.currentTask).toBe("baseline before 604 PUT attempt");
+  }, 30_000);
+
+  test("credential-less loopback PUT /Presence/<id> (the real write path) → also rejected, does NOT write", async () => {
+    // By-id PUT was never on the early-return allowlist (exact-path match
+    // only), so this was already safe pre-fix — this is a regression guard
+    // proving the ACTUAL exploitable write path (super.put() with a real
+    // primary key) stays protected, not just the structurally-inert bare
+    // collection PUT above.
+    const victimId = "presence-604-victim-byid";
+    const victimKp = makeKeypair();
+    await seedAgent(harper.opsURL, adminAuth(), victimId, victimKp.publicKey, "Victim Agent 2");
+    const seedAuth = buildAuthHeader(victimId, "POST", "/Presence", victimKp.privateKey);
+    await fetch(`${harper.httpURL}/Presence`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Authorization: seedAuth },
+      body: JSON.stringify({ currentTask: "baseline before 604 by-id PUT attempt", activity: "coding" }),
+    });
+
+    const res = await fetch(`${harper.httpURL}/Presence/${victimId}`, {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ agentId: victimId, currentTask: "PWNED via by-id PUT", activity: "coding" }),
+    });
+    expect(res.status).not.toBe(200);
+    expect([401, 403]).toContain(res.status);
+
+    const getAuth = buildAuthHeader(victimId, "GET", "/Presence", victimKp.privateKey);
+    const check = await fetch(`${harper.httpURL}/Presence`, { headers: { Authorization: getAuth } });
+    const roster = await check.json();
+    const victim = roster.find((r: any) => r.id === victimId);
+    expect(victim).toBeDefined();
+    expect(victim.currentTask).toBe("baseline before 604 by-id PUT attempt");
+  }, 30_000);
+
+  test("genuine Ed25519-signed PUT /Presence/<id> (own record) still succeeds", async () => {
+    const path = `/Presence/${agent1.id}`;
+    const auth = buildAuthHeader(agent1.id, "PUT", path, agent1.privateKey);
+    const res = await fetch(`${harper.httpURL}${path}`, {
+      method: "PUT",
+      headers: { "Content-Type": "application/json", Authorization: auth },
+      body: JSON.stringify({ agentId: agent1.id, currentTask: "signed PUT still works", activity: "coding" }),
+    });
+    expect([200, 204]).toContain(res.status);
+
+    const getAuth = buildAuthHeader(agent1.id, "GET", "/Presence", agent1.privateKey);
+    const check = await fetch(`${harper.httpURL}/Presence`, { headers: { Authorization: getAuth } });
+    const roster = await check.json();
+    const a1 = roster.find((r: any) => r.id === agent1.id);
+    expect(a1.currentTask).toBe("signed PUT still works");
+  }, 30_000);
+
+  test("genuine Ed25519-signed PUT /Presence for ANOTHER agent's record → 403", async () => {
+    const path = "/Presence";
+    // agent2 signs the request but targets agent1's record in the body.
+    const auth = buildAuthHeader(agent2.id, "PUT", path, agent2.privateKey);
+    const res = await fetch(`${harper.httpURL}${path}`, {
+      method: "PUT",
+      headers: { "Content-Type": "application/json", Authorization: auth },
+      body: JSON.stringify({ agentId: agent1.id, currentTask: "cross-agent PUT attempt", activity: "coding" }),
+    });
+    expect(res.status).toBe(403);
+  }, 30_000);
 });

--- a/test/unit/cross-agent-isolation.test.ts
+++ b/test/unit/cross-agent-isolation.test.ts
@@ -218,8 +218,23 @@ describe("OAuthAuthorize.post() — resolved principal, not hardcoded admin (ide
     ...extra,
   });
 
+  // #604: OAuthAuthorize.post() now additionally requires a real
+  // Authorization header be present before it trusts resolveAgentAuth's
+  // verdict — Harper's `authorizeLocal` can populate `context.user` with a
+  // forged super_user for a credential-less loopback request with NO
+  // header at all, and /OAuthAuthorize permanently bypasses the auth
+  // middleware (public early-return, any method) so tpsAgent/tpsAnonymous
+  // is never annotated either. Every "genuinely authenticated" fixture
+  // below carries a mock header for that reason — it isn't cryptographically
+  // verified here (that's what the real-Harper integration test in
+  // test/integration/oauth-authorize-authz.test.ts proves), it's just the
+  // minimum realistic shape: a real request that resolves to an
+  // authenticated principal HAS a header; the forged-loopback case (last
+  // test below) does not.
+  const mockAuthHeader = { get: (name: string) => (name === "authorization" ? "Basic bW9ja2Vk" : undefined) };
+
   it("approving principal is the authenticated agent (from the gate annotation, not a hardcoded 'admin')", async () => {
-    const oa = makeInstance<any>(OAuthAuthorize, agentCtx("agent-alpha", false));
+    const oa = makeInstance<any>(OAuthAuthorize, { ...agentCtx("agent-alpha", false), headers: mockAuthHeader });
     const res = await oa.post(approveBody());
     expect(res).toBeInstanceOf(Response);
     expect((res as Response).status).toBe(302);
@@ -229,7 +244,10 @@ describe("OAuthAuthorize.post() — resolved principal, not hardcoded admin (ide
 
   it("Basic super_user resolves via resolveAgentAuth to agentId=username (not the hardcoded literal)", async () => {
     const oa: any = new (OAuthAuthorize as any)();
-    oa.getContext = () => ({ user: { username: "admin", role: { permission: { super_user: true } } } });
+    oa.getContext = () => ({
+      user: { username: "admin", role: { permission: { super_user: true } } },
+      headers: mockAuthHeader,
+    });
     const res = await oa.post(approveBody());
     expect(res).toBeInstanceOf(Response);
     expect((res as Response).status).toBe(302);
@@ -241,13 +259,29 @@ describe("OAuthAuthorize.post() — resolved principal, not hardcoded admin (ide
 
   it("a different super_user username is preserved (proves it's not a hardcoded literal)", async () => {
     const oa: any = new (OAuthAuthorize as any)();
-    oa.getContext = () => ({ user: { username: "nathan-basic", role: { permission: { super_user: true } } } });
+    oa.getContext = () => ({
+      user: { username: "nathan-basic", role: { permission: { super_user: true } } },
+      headers: mockAuthHeader,
+    });
     await oa.post(approveBody());
     expect(authCodePut?.principalId).toBe("nathan-basic");
   });
 
   it("no resolvable principal (anonymous) → 401, no auth code minted (fail closed, not admin grant)", async () => {
     const oa = makeInstance<any>(OAuthAuthorize, anonCtx());
+    const res = await oa.post(approveBody());
+    expect(res).toBeInstanceOf(Response);
+    expect((res as Response).status).toBe(401);
+    expect(authCodePut).toBeNull();
+  });
+
+  it("#604: credential-less loopback (super_user context.user, but NO Authorization header at all) → 401, no auth code minted", async () => {
+    // The exact shape authorizeLocal forges: Harper's core has already
+    // populated context.user as super_user (ambient loopback elevation),
+    // but there is no header on the request at all — the tell that this is
+    // authorizeLocal's ambient injection, not a genuine credential.
+    const oa: any = new (OAuthAuthorize as any)();
+    oa.getContext = () => ({ user: { username: "admin", role: { permission: { super_user: true } } } });
     const res = await oa.post(approveBody());
     expect(res).toBeInstanceOf(Response);
     expect((res as Response).status).toBe(401);


### PR DESCRIPTION
## Summary

Closes the two confirmed **LOOPBACK-ONLY** exploits from #604 (Harper's `authorizeLocal` ambient super_user escalation). Scope is intentionally narrow — the root-cause (`resolveAgentAuth`'s super_user branch / `authorizeLocal` itself) is a separate follow-up per the dispatch spec, not touched here.

### Fix 1 — `OAuthAuthorize.post()` (the actual escalation)

`resolveAgentAuth(getContext())` resolved a credential-less loopback POST (ambiently elevated to `super_user` by Harper's `authorizeLocal`, config `true`) as an authenticated admin approver, minting a **real admin OAuth authorization code** — exchangeable at `/OAuthToken` for a Bearer token. Zero credentials required.

`/OAuthAuthorize` sits on `auth-middleware.ts`'s public early-return passthrough (any method, unchanged spec-wise per RFC 8414), so it never gets our middleware's `tpsAgent`/`tpsAnonymous` annotation — `resolveAgentAuth` fell straight through to Harper's raw `context.user`.

**Fix:** require a real `Authorization` header be present before trusting `resolveAgentAuth`'s verdict:

```ts
const ctx = (this as any).getContext?.();
const request = ctx?.request ?? ctx;
const authHeader: string =
  request?.headers?.get?.("authorization") ??
  request?.headers?.asObject?.authorization ??
  "";
if (!authHeader) {
  return new Response(JSON.stringify({ error: "authentication required" }), {
    status: 401, headers: { "content-type": "application/json" },
  });
}

const auth = await resolveAgentAuth((this as any).getContext?.());
if (auth.kind !== "agent") {
  return new Response(JSON.stringify({ error: "authentication required" }), {
    status: 401, headers: { "content-type": "application/json" },
  });
}
const principalId: string = auth.agentId;
```

`authorizeLocal` injects the ambient `super_user` **only when there is no `Authorization` header** (same mechanism #601/#592 already established for `Presence.get()`). A genuine Basic admin (real password, validated by Harper core) or a genuine `TPS-Ed25519` signature (verified independently by `resolveAgentAuth`'s own fallback) both carry a real header — neither is affected. `action: "deny"` is intentionally left ungated (mints nothing, nothing sensitive).

### Fix 2 — Presence early-return scope (auth-middleware.ts)

The public early-return matched `/Presence` on **any method** (exact path, no method guard), so a bare `PUT /Presence` (collection-level, no id) skipped the middleware entirely, reaching `Presence.put()`'s ownership check with the same forged-admin identity. Scoped to `GET` only, mirroring the existing A2A `GET`-only pattern:

```ts
(request.method === "GET" && url.pathname === "/Presence")
```

PUT/DELETE now always transit the general middleware path, which marks a genuinely headerless request `tpsAnonymous` **before** Harper's ambient elevation lands (verified: `resolveAgentAuth` checks `tpsAnonymous` first).

### Bonus fix — pre-existing, unrelated `Response.redirect()` bug

Found while writing the **first-ever real-Harper integration test** for `OAuthAuthorize.post()` (previously untestable per the file's own coverage-gap comment). `Response.redirect()` sets an immutable Headers guard per the Fetch spec; Harper's own response pipeline mutates headers afterward, which threw `TypeError: immutable` — **500ing every real POST /OAuthAuthorize, approve or deny, on unmodified `origin/main`** (verified via curl against a clean build, unrelated to this PR's changes). Replaced with a manually-constructed `new Response(null, {status:302, headers:{Location:url}})` — identical bytes on the wire, mutable Headers underneath. Flagging prominently since it's outside the stated fix scope but was blocking verification of Fix 1's "legitimate approver still works" requirement.

## Test plan

- [x] `bun run build` clean
- [x] `bun run build:cli` clean
- [x] `bunx tsc --noEmit -p tsconfig.check.json` clean
- [x] Full unit suite: **1651/1651 pass** (`bun test test/unit/`)
- [x] **Integration (real Harper, the load-bearing gate)**:
  - `test/integration/oauth-authorize-authz.test.ts` (new): 5/5 pass — credential-less loopback POST rejected + mints no code; deny unaffected; genuine Basic admin approval mints a real code exchangeable for a token; genuine Ed25519-signed agent approval mints a code for that agent (principalId verified); wrong-password Basic → 401
  - `test/integration/presence-api.test.ts` (extended): 21/21 pass — bare credential-less PUT rejected before reaching the write path; by-id credential-less PUT also rejected (regression guard, was already safe); genuine Ed25519 PUT (own + by-id) still succeeds; cross-agent PUT still 403
  - `test/integration/auth-middleware-e2e.test.ts` (regression check, untouched by this PR): 30/30 pass

Do NOT merge — Flint merges after CI + Kern/Sherlock sign-off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)