### PR TITLE
chore(release): 0.21.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -312,8 +312,8 @@ jobs:
       - name: Install npm-stable, seed data, upgrade, verify
         run: |
           set -euo pipefail
-          TMPDIR=$(mktemp -d)
-          cd "$TMPDIR"
+          BASE_DIR=$(mktemp -d)
+          cd "$BASE_DIR"
           npm init -y > /dev/null
 
           # 1. Install current npm-stable
@@ -332,25 +332,61 @@ jobs:
             exit 0
           fi
 
-          FLAIR="node $(pwd)/node_modules/@tpsdev-ai/flair/dist/cli.js"
+          BASE_FLAIR="node $BASE_DIR/node_modules/@tpsdev-ai/flair/dist/cli.js"
           PORT=19998
           export FLAIR_ADMIN_PASS=upgrade-smoke-admin
           export FLAIR_URL=http://127.0.0.1:$PORT
 
           # 2. Init at baseline + write marker memory
-          $FLAIR init --agent-id upgrade --port $PORT --admin-pass "$FLAIR_ADMIN_PASS" --skip-soul
-          $FLAIR memory add --agent upgrade --content "upgrade-smoke-pre-marker"
+          $BASE_FLAIR init --agent-id upgrade --port $PORT --admin-pass "$FLAIR_ADMIN_PASS" --skip-soul
+          $BASE_FLAIR memory add --agent upgrade --content "upgrade-smoke-pre-marker"
 
-          PRE=$($FLAIR memory search --agent upgrade --q "upgrade-smoke-pre-marker")
+          PRE=$($BASE_FLAIR memory search --agent upgrade --q "upgrade-smoke-pre-marker")
           echo "$PRE" | grep -q "upgrade-smoke-pre-marker" || {
             echo "FAIL: baseline write/search didn't work — setup broken, not an upgrade regression"
             exit 1
           }
 
-          # 3. Stop baseline, overinstall HEAD tarball
-          $FLAIR stop --port $PORT || true
+          # 3. Stop baseline. Install HEAD into a FRESH project dir rather than
+          # reifying the tarball on top of baseline's node_modules in place.
+          #
+          # `flair stop` (cli.ts) sends SIGTERM and returns immediately — it
+          # does not wait for the Harper child process to actually exit. The
+          # very next command used to be `npm install <tarball>` run in the
+          # SAME directory the just-killed process was serving out of, which
+          # overwrites an existing registry-resolved @tpsdev-ai/flair with a
+          # same-named local-tarball-resolved one. That combination (possible
+          # file contention from the not-yet-exited process, plus npm's
+          # arborist reifying a same-name registry→tarball swap in place) can
+          # throw during reify's commit phase. npm's own rollback path for a
+          # failed reify has a long-standing upstream bug (npm/cli#4907:
+          # `rollbackMoveBackRetiredUnchanged` in @npmcli/arborist) that
+          # itself crashes with `ERR_INVALID_ARG_TYPE: The "from" argument
+          # must be of type string` — masking whatever the real error was.
+          # This hit flair#611 deterministically across two separate CI runs
+          # (2026-07-07): baseline install, HEAD tarball install, Ed25519
+          # auth, and semantic search all verified clean beforehand, so this
+          # was never a 0.21.0 content regression — it's an npm-internals /
+          # process-teardown race in the test's own in-place-overwrite
+          # choreography, exercised for the first time here because prior
+          # release PRs were same-version (BASELINE == HEAD) no-ops.
+          #
+          # Fix: install HEAD fresh, in its own directory, instead of
+          # overwriting baseline's tree. Flair's data lives in ~/.flair
+          # (home-dir scoped, independent of node_modules location), so this
+          # still exercises the real invariant under test — HEAD starting
+          # against baseline's on-disk data — without ever asking npm to
+          # reconcile/rename an existing differently-sourced package or race
+          # a still-terminating daemon.
+          $BASE_FLAIR stop --port $PORT || true
+
+          HEAD_DIR=$(mktemp -d)
+          cd "$HEAD_DIR"
+          npm init -y > /dev/null
           npm install "${{ steps.pack.outputs.TGZ_PATH }}"
           npm install --no-save @node-llama-cpp/linux-x64@3
+
+          FLAIR="node $HEAD_DIR/node_modules/@tpsdev-ai/flair/dist/cli.js"
 
           NEW=$(node -p "require('@tpsdev-ai/flair/package.json').version")
           [ "$NEW" = "$HEAD_VERSION" ] || { echo "FAIL: expected $HEAD_VERSION in node_modules, got $NEW"; exit 1; }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,51 @@
 
 ## [Unreleased]
 
+## [0.21.0] - 2026-07-07
+
+Federation edge-hardening, open-within-org memory read, an adopter-adoptability sweep (now including automatic MCP presence), and a security closure on Presence/OAuthAuthorize auth-bypass gaps — on harper 5.1.15.
+
+### 🧠 Open-within-org memory read (#578)
+
+Cross-agent read opens up within an org: a verified in-org agent can read another agent's non-private memories (`resolveReadScope` returns non-private OR own), while `private` stays owner-only on every path. Replaces the prior grant-gated model — knowledge is org-readable by default, access-gated only at the federation edge. Live + verified on both rockit and Fabric.
+
+- **Bootstrap teammate-findings aligned to the open model (#606, completes #550)** — the "teammate findings" surfacing already rode on `resolveReadScope()` (never its own `MemoryGrant` traversal), so it picked up #578's behavior with zero code changes needed. Corrected stale comments/nudge copy that still described the retired grant-gated model, and added the missing test proving a `MemoryGrant` is NOT required to see a teammate's memory — every prior test seeded one as harmless leftover from pre-#578 authoring, masking the gap.
+
+### 🔒 Federation edge-hardening (slices 1–4)
+
+Hardens what crosses the federation boundary:
+- **Server-stamped verified provenance on writes (#575)** — provenance captured server-side (verified identity + timestamp), not client-claimed.
+- **Write-time originator tagging (#576)** — synced tables carry an `originatorInstanceId` stamped at write.
+- **Push-side private-visibility filter (#577)** — private memories are filtered before they leave the instance.
+- **Per-record signing + verification (#580)** — each synced record is signed over its canonical form and verified on receipt, closing a hub-forgery hole where a relay could forge records for another originator.
+- **Persistent anti-replay nonce store (#581)** — the nonce store survives restarts, so replay protection holds across process boundaries.
+
+### 🧰 Adopter adoptability
+
+Making Flair actually work for a fresh adopter instead of silently half-working:
+- **`flair doctor` verifies client integration (#599)** — a new "Client integration" section answers "is Flair working for my agent?": per detected MCP client, the MCP block + `FLAIR_URL` reachability + agent registration; for Claude Code, the CLAUDE.md bootstrap line + `SessionStart` hook. `--fix` wires missing pieces (idempotent, merge-safe).
+- **`flair doctor` reports not-registered on 401/403, not just 404 (#603, closes #602)** — the auth middleware rejects an unregistered agent's *signed* request before the resource handler runs (401 `unknown_agent`), so the 404-only branch was dead code and a missing agent showed "⚠ couldn't-verify" instead of "✗ not-registered." Now 401/403 with the `unknown_agent` marker and a resolved local key correctly reports not-registered, with the fix hint.
+- **`flair init` wires all three legs (#600)** — init now installs the `SessionStart` hook + CLAUDE.md line alongside the MCP block, instead of leaving them manual (silent partial setups). `--skip-hook` / `--skip-claude-md` opt-outs; prints the exact missing snippet when skipped.
+- **`flair-mcp` auto-sets presence on session-start + rate-limited heartbeat (#608, closes #598)** — the session-start hook and bootstrap seed `activity`/`currentTask`; every other MCP tool call refreshes `lastHeartbeatAt` (rate-limited, 3min default). Fire-and-forget + fail-open — never blocks a tool call or startup. Complements #601's read-side gating below.
+- **Version-behind nudge (#594)** — `flair status` / `doctor` surface when the installed version is behind the published latest (cached, offline-tolerant, never blocks).
+- **`agent add` / `principal add` admin-pass fallback (#593)** — fall back to the local `~/.flair/admin-pass` file instead of hard-requiring `--admin-pass`.
+
+### 🔒 Security
+
+- **OAuthAuthorize consent required real auth; Presence PUT/DELETE scoped correctly (#609, closes #604)** — closes the `authorizeLocal` escalation class: a credential-less loopback POST (which Harper's `authorizeLocal` forges as `super_user`) could mint an admin OAuth code without a real `Authorization` header. Loopback-only, HIGH severity — verified **not** remotely exploitable (Fabric rejects the unauthed remote request with 401). Also scopes the `/Presence` early-return to GET-only so PUT/DELETE correctly transit the auth middleware, and fixes a pre-existing bug where `Response.redirect`'s immutable Headers 500'd every `POST /OAuthAuthorize` on main.
+- **`Presence.currentTask` gated to verified readers (#601, closes #592)** — anonymous `GET /Presence` returned agents' freeform `currentTask` (which can hold customer/host/incident strings) verbatim on a public endpoint. Now gated behind a verified Ed25519 signature (not just `resolveAgentAuth`, which Harper's `authorizeLocal` can spoof for a loopback caller) — anonymous, loopback, and Basic-admin callers get the low-risk roster with `currentTask` nulled; the rest of the roster stays public.
+
+### 📦 Dependencies
+
+- **harper 5.1.14 → 5.1.15 (#595)** — pins the models extension API (`registerBackend`, unblocks sovereign local embeddings), replication/deploy reliability fixes, and the MCP row-level RBAC fix. Also fixes the Fabric deploy abort.
+
+### 🧹 Tooling / CI / hygiene
+
+- **Wire `flair-mcp` package tests into the merge gate (#605, closes #491)** — the 34 `packages/flair-mcp/test/*` tests weren't gated by CI (root `test.yml` only ran `test/unit/`); now builds `flair-client` first (flair-mcp imports its built `dist/`), then runs the package's own suite.
+- **Self-healing CI/deploy**: timeout+retry the flaky sfw (Socket-firewall) install (#583), retry peer-replication with `--ignore-replication-errors` on deploy (#582), de-flake the E2E CLI smoke test (#584).
+- **Strip internal ops-* tracker refs from shipping comments/tests (#586)** — consumer-facing code references public flair# issues only.
+- **DESIGN.md in-repo (#579)** — design invariants documented adopter-facing.
+
 ## [0.20.1] - 2026-07-05
 
 ### 🛠 Self-verifying `flair deploy` (#573)

--- a/bun.lock
+++ b/bun.lock
@@ -35,21 +35,21 @@
     },
     "packages/flair-client": {
       "name": "@tpsdev-ai/flair-client",
-      "version": "0.20.1",
+      "version": "0.21.0",
       "devDependencies": {
         "typescript": "5.9.3",
       },
     },
     "packages/flair-mcp": {
       "name": "@tpsdev-ai/flair-mcp",
-      "version": "0.20.1",
+      "version": "0.21.0",
       "bin": {
         "flair-mcp": "dist/mcp-shim.cjs",
         "flair-session-start": "dist/session-start-hook.js",
       },
       "dependencies": {
         "@modelcontextprotocol/sdk": "1.27.1",
-        "@tpsdev-ai/flair-client": "0.20.1",
+        "@tpsdev-ai/flair-client": "0.21.0",
         "zod": "4.3.6",
       },
       "devDependencies": {
@@ -58,9 +58,9 @@
     },
     "packages/langgraph-flair": {
       "name": "@tpsdev-ai/langgraph-flair",
-      "version": "0.20.1",
+      "version": "0.21.0",
       "dependencies": {
-        "@tpsdev-ai/flair-client": "0.20.1",
+        "@tpsdev-ai/flair-client": "0.21.0",
       },
       "peerDependencies": {
         "@langchain/langgraph-checkpoint": ">=0.0.10",
@@ -68,9 +68,9 @@
     },
     "packages/n8n-nodes-flair": {
       "name": "@tpsdev-ai/n8n-nodes-flair",
-      "version": "0.20.1",
+      "version": "0.21.0",
       "dependencies": {
-        "@tpsdev-ai/flair-client": "0.20.1",
+        "@tpsdev-ai/flair-client": "0.21.0",
         "zod": "3.25.76",
       },
       "devDependencies": {
@@ -87,10 +87,10 @@
     },
     "packages/openclaw-flair": {
       "name": "@tpsdev-ai/openclaw-flair",
-      "version": "0.20.1",
+      "version": "0.21.0",
       "dependencies": {
         "@sinclair/typebox": "0.34.48",
-        "@tpsdev-ai/flair-client": "0.20.1",
+        "@tpsdev-ai/flair-client": "0.21.0",
       },
       "devDependencies": {
         "typescript": "5.9.3",
@@ -101,10 +101,10 @@
     },
     "packages/pi-flair": {
       "name": "@tpsdev-ai/pi-flair",
-      "version": "0.20.1",
+      "version": "0.21.0",
       "dependencies": {
         "@sinclair/typebox": "0.34.48",
-        "@tpsdev-ai/flair-client": "0.20.1",
+        "@tpsdev-ai/flair-client": "0.21.0",
       },
       "devDependencies": {
         "@mariozechner/pi-coding-agent": "0.73.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tpsdev-ai/flair",
-  "version": "0.20.1",
+  "version": "0.21.0",
   "description": "Identity, memory, and soul for AI agents. Cryptographic identity (Ed25519), semantic memory with local embeddings, and persistent personality — all in a single process.",
   "type": "module",
   "license": "Apache-2.0",

--- a/packages/flair-client/package.json
+++ b/packages/flair-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tpsdev-ai/flair-client",
-  "version": "0.20.1",
+  "version": "0.21.0",
   "description": "Lightweight client for Flair — identity, memory, and soul for AI agents. Zero heavy dependencies.",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/flair-mcp/package.json
+++ b/packages/flair-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tpsdev-ai/flair-mcp",
-  "version": "0.20.1",
+  "version": "0.21.0",
   "description": "MCP server for Flair — persistent memory for Claude Code, Cursor, and any MCP client.",
   "type": "module",
   "main": "dist/index.js",
@@ -27,7 +27,7 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "1.27.1",
-    "@tpsdev-ai/flair-client": "0.20.1",
+    "@tpsdev-ai/flair-client": "0.21.0",
     "zod": "4.3.6"
   },
   "license": "Apache-2.0",

--- a/packages/langgraph-flair/package.json
+++ b/packages/langgraph-flair/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tpsdev-ai/langgraph-flair",
-  "version": "0.20.1",
+  "version": "0.21.0",
   "description": "LangGraph BaseStore adapter backed by Flair — durable agent memory with crypto-pinned identity, federation, and cross-orchestrator portability.",
   "type": "module",
   "main": "dist/index.js",
@@ -36,7 +36,7 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
-    "@tpsdev-ai/flair-client": "0.20.1"
+    "@tpsdev-ai/flair-client": "0.21.0"
   },
   "peerDependencies": {
     "@langchain/langgraph-checkpoint": ">=0.0.10"

--- a/packages/n8n-nodes-flair/package.json
+++ b/packages/n8n-nodes-flair/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tpsdev-ai/n8n-nodes-flair",
-  "version": "0.20.1",
+  "version": "0.21.0",
   "description": "n8n community node — use Flair as your AI Agent's memory backend. Includes FlairChatMemory (Memory port) and FlairSearch (Tool port).",
   "type": "commonjs",
   "main": "dist/index.js",
@@ -48,7 +48,7 @@
     "langchain"
   ],
   "dependencies": {
-    "@tpsdev-ai/flair-client": "0.20.1",
+    "@tpsdev-ai/flair-client": "0.21.0",
     "zod": "3.25.76"
   },
   "peerDependencies": {

--- a/packages/openclaw-flair/package.json
+++ b/packages/openclaw-flair/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tpsdev-ai/openclaw-flair",
-  "version": "0.20.1",
+  "version": "0.21.0",
   "description": "OpenClaw memory plugin for Flair — agent identity and semantic memory",
   "type": "module",
   "main": "./dist/index.js",
@@ -58,7 +58,7 @@
   },
   "dependencies": {
     "@sinclair/typebox": "0.34.48",
-    "@tpsdev-ai/flair-client": "0.20.1"
+    "@tpsdev-ai/flair-client": "0.21.0"
   },
   "devDependencies": {
     "typescript": "5.9.3"

--- a/packages/pi-flair/package.json
+++ b/packages/pi-flair/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tpsdev-ai/pi-flair",
-  "version": "0.20.1",
+  "version": "0.21.0",
   "description": "Flair memory extension for pi — persistent memory access from within pi sessions",
   "type": "module",
   "main": "dist/index.js",
@@ -21,7 +21,7 @@
     "node": ">=18"
   },
   "dependencies": {
-    "@tpsdev-ai/flair-client": "0.20.1",
+    "@tpsdev-ai/flair-client": "0.21.0",
     "@sinclair/typebox": "0.34.48"
   },
   "license": "Apache-2.0",


### PR DESCRIPTION
## [0.21.0] - 2026-07-07

Federation edge-hardening, open-within-org memory read, an adopter-adoptability sweep (now including automatic MCP presence), and a security closure on Presence/OAuthAuthorize auth-bypass gaps — on harper 5.1.15.

### 🧠 Open-within-org memory read (#578)

Cross-agent read opens up within an org: a verified in-org agent can read another agent's non-private memories (`resolveReadScope` returns non-private OR own), while `private` stays owner-only on every path. Replaces the prior grant-gated model — knowledge is org-readable by default, access-gated only at the federation edge. Live + verified on both rockit and Fabric.

- **Bootstrap teammate-findings aligned to the open model (#606, completes #550)** — the "teammate findings" surfacing already rode on `resolveReadScope()` (never its own `MemoryGrant` traversal), so it picked up #578's behavior with zero code changes needed. Corrected stale comments/nudge copy that still described the retired grant-gated model, and added the missing test proving a `MemoryGrant` is NOT required to see a teammate's memory — every prior test seeded one as harmless leftover from pre-#578 authoring, masking the gap.

### 🔒 Federation edge-hardening (slices 1–4)

Hardens what crosses the federation boundary:
- **Server-stamped verified provenance on writes (#575)** — provenance captured server-side (verified identity + timestamp), not client-claimed.
- **Write-time originator tagging (#576)** — synced tables carry an `originatorInstanceId` stamped at write.
- **Push-side private-visibility filter (#577)** — private memories are filtered before they leave the instance.
- **Per-record signing + verification (#580)** — each synced record is signed over its canonical form and verified on receipt, closing a hub-forgery hole where a relay could forge records for another originator.
- **Persistent anti-replay nonce store (#581)** — the nonce store survives restarts, so replay protection holds across process boundaries.

### 🧰 Adopter adoptability

Making Flair actually work for a fresh adopter instead of silently half-working:
- **`flair doctor` verifies client integration (#599)** — a new "Client integration" section answers "is Flair working for my agent?": per detected MCP client, the MCP block + `FLAIR_URL` reachability + agent registration; for Claude Code, the CLAUDE.md bootstrap line + `SessionStart` hook. `--fix` wires missing pieces (idempotent, merge-safe).
- **`flair doctor` reports not-registered on 401/403, not just 404 (#603, closes #602)** — the auth middleware rejects an unregistered agent's *signed* request before the resource handler runs (401 `unknown_agent`), so the 404-only branch was dead code and a missing agent showed "⚠ couldn't-verify" instead of "✗ not-registered." Now 401/403 with the `unknown_agent` marker and a resolved local key correctly reports not-registered, with the fix hint.
- **`flair init` wires all three legs (#600)** — init now installs the `SessionStart` hook + CLAUDE.md line alongside the MCP block, instead of leaving them manual (silent partial setups). `--skip-hook` / `--skip-claude-md` opt-outs; prints the exact missing snippet when skipped.
- **`flair-mcp` auto-sets presence on session-start + rate-limited heartbeat (#608, closes #598)** — the session-start hook and bootstrap seed `activity`/`currentTask`; every other MCP tool call refreshes `lastHeartbeatAt` (rate-limited, 3min default). Fire-and-forget + fail-open — never blocks a tool call or startup. Complements #601's read-side gating below.
- **Version-behind nudge (#594)** — `flair status` / `doctor` surface when the installed version is behind the published latest (cached, offline-tolerant, never blocks).
- **`agent add` / `principal add` admin-pass fallback (#593)** — fall back to the local `~/.flair/admin-pass` file instead of hard-requiring `--admin-pass`.

### 🔒 Security

- **OAuthAuthorize consent required real auth; Presence PUT/DELETE scoped correctly (#609, closes #604)** — closes the `authorizeLocal` escalation class: a credential-less loopback POST (which Harper's `authorizeLocal` forges as `super_user`) could mint an admin OAuth code without a real `Authorization` header. Loopback-only, HIGH severity — verified **not** remotely exploitable (Fabric rejects the unauthed remote request with 401). Also scopes the `/Presence` early-return to GET-only so PUT/DELETE correctly transit the auth middleware, and fixes a pre-existing bug where `Response.redirect`'s immutable Headers 500'd every `POST /OAuthAuthorize` on main.
- **`Presence.currentTask` gated to verified readers (#601, closes #592)** — anonymous `GET /Presence` returned agents' freeform `currentTask` (which can hold customer/host/incident strings) verbatim on a public endpoint. Now gated behind a verified Ed25519 signature (not just `resolveAgentAuth`, which Harper's `authorizeLocal` can spoof for a loopback caller) — anonymous, loopback, and Basic-admin callers get the low-risk roster with `currentTask` nulled; the rest of the roster stays public.

### 📦 Dependencies

- **harper 5.1.14 → 5.1.15 (#595)** — pins the models extension API (`registerBackend`, unblocks sovereign local embeddings), replication/deploy reliability fixes, and the MCP row-level RBAC fix. Also fixes the Fabric deploy abort.

### 🧹 Tooling / CI / hygiene

- **Wire `flair-mcp` package tests into the merge gate (#605, closes #491)** — the 34 `packages/flair-mcp/test/*` tests weren't gated by CI (root `test.yml` only ran `test/unit/`); now builds `flair-client` first (flair-mcp imports its built `dist/`), then runs the package's own suite.
- **Self-healing CI/deploy**: timeout+retry the flaky sfw (Socket-firewall) install (#583), retry peer-replication with `--ignore-replication-errors` on deploy (#582), de-flake the E2E CLI smoke test (#584).
- **Strip internal ops-* tracker refs from shipping comments/tests (#586)** — consumer-facing code references public flair# issues only.
- **DESIGN.md in-repo (#579)** — design invariants documented adopter-facing.

