### PR TITLE
docs: fix port drift + stale security-model docs + upgrade.md (state-review quick-wins)

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ An agent that can't remember what it learned yesterday, can't prove who it is to
 
 Flair fixes that with three primitives:
 
-- **Identity** — Ed25519 key pairs. Agents sign every request. No passwords, no API keys, no shared secrets. Cross-agent reads are refused at the server, not by client convention.
+- **Identity** — Ed25519 key pairs. Agents sign every request. No passwords, no API keys, no shared secrets. Write isolation (no agent can write as another) is enforced at the server, not by client convention; reads are open within the org for non-private memories by design (see [SECURITY.md](SECURITY.md)).
 - **Memory** — Persistent knowledge with semantic search (in-process [nomic-embed-text](https://huggingface.co/nomic-ai/nomic-embed-text-v1.5-GGUF), 768-dim, no API calls). Tiered durability (`permanent` / `persistent` / `standard` / `ephemeral`). Temporal validity. Decay-and-retrieval-aware composite scoring.
 - **Soul** — Personality, values, procedures. The stuff that makes an agent *that agent*. Re-injected every turn via the context-engine plugin so it doesn't drift across long sessions.
 
@@ -409,9 +409,9 @@ Auth is Ed25519 — sign `agentId:timestamp:nonce:METHOD:/path` with your privat
 
 ### Auth across surfaces
 
-The default, secure path everywhere is **Ed25519 per-agent**: each agent holds its own key (`~/.flair/keys/<agent>.key`), signs every request, and the server refuses cross-agent reads. The CLI, the `flair-mcp` server, and the OpenClaw / pi / Hermes plugins all use it.
+The default, secure path everywhere is **Ed25519 per-agent**: each agent holds its own key (`~/.flair/keys/<agent>.key`) and signs every request. That guarantees write isolation (no agent can write as another) and identity-verified reads — it does **not** mean cross-agent reads are refused: within one Flair instance, any verified agent can read any other agent's non-private memory by design (open-within-org read; the hard boundary is the federation edge, not intra-instance reads — see [SECURITY.md](SECURITY.md)). The CLI, the `flair-mcp` server, and the OpenClaw / pi / Hermes plugins all use this model.
 
-One exception: the **`n8n-nodes-flair`** community node authenticates with the Harper **admin password** (Basic auth), which grants **whole-instance read/write** access — not per-agent isolation. That's acceptable only on a single-tenant, operator-controlled n8n with trusted workflow inputs; otherwise prefer the CLI/SDK Ed25519 path. Full breakdown in **[docs/auth.md](docs/auth.md#auth-across-surfaces-read-this-first)**.
+One exception: the **`n8n-nodes-flair`** community node authenticates with the Harper **admin password** (Basic auth), which bypasses agent scoping entirely — including read of other agents' `visibility: private` memories and write-as-anyone, not just the org-wide non-private reads an Ed25519 identity already gets. That's acceptable only on a single-tenant, operator-controlled n8n with trusted workflow inputs; otherwise prefer the CLI/SDK Ed25519 path. Full breakdown in **[docs/auth.md](docs/auth.md#auth-across-surfaces-read-this-first)**.
 
 ## Architecture
 

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -8,20 +8,20 @@ Different surfaces authenticate differently. The model in one place:
 
 | Surface | Auth | Scope | Notes |
 |---------|------|-------|-------|
-| **CLI / SDK clients** (`flair`, `flair-client`) | **Ed25519 per-agent** | This agent only | Default, recommended. Signs every request; cross-agent reads refused server-side. |
-| **MCP server** (`@tpsdev-ai/flair-mcp`) | **Ed25519 per-agent** | This agent only | Same per-agent identity as the CLI — key auto-resolved from `~/.flair/keys/<agent>.key`. |
-| **OpenClaw / pi / Hermes plugins** | **Ed25519 per-agent** | This agent only | Same secure path; auto-detect agent identity. |
-| **`n8n-nodes-flair`** | **Harper admin-password Basic auth** | ⚠️ **Whole instance, read + write** | The admin credential grants every workflow read/write to the *entire* memory store, not just the configured Agent ID. |
+| **CLI / SDK clients** (`flair`, `flair-client`) | **Ed25519 per-agent** | Own writes; org-wide non-private reads | Default, recommended. Signs every request; an agent can never write as another, and reads are scoped to its own memories (any visibility) plus every other agent's **non-private** memories on the instance. |
+| **MCP server** (`@tpsdev-ai/flair-mcp`) | **Ed25519 per-agent** | Own writes; org-wide non-private reads | Same per-agent identity as the CLI — key auto-resolved from `~/.flair/keys/<agent>.key`. |
+| **OpenClaw / pi / Hermes plugins** | **Ed25519 per-agent** | Own writes; org-wide non-private reads | Same secure path; auto-detect agent identity. |
+| **`n8n-nodes-flair`** | **Harper admin-password Basic auth** | ⚠️ **Whole instance, read + write, including `private`** | The admin credential bypasses agent scoping entirely — every workflow gets read/write on the *entire* memory store, including other agents' `private`-marked memories, not just the org-wide non-private pool an Ed25519 identity would see. |
 
-**The default, secure path is Ed25519 per-agent** (see below): each agent holds its own key, signs every request, and the server refuses cross-agent reads. Use this everywhere you can.
+**The default, secure path is Ed25519 per-agent** (see below): each agent holds its own key and signs every request. That guarantees **write isolation** — no agent can write as another — and identity-verified reads. It does **not** mean cross-agent reads are refused: within one Flair instance (one org), any verified agent can read any other agent's memory unless that memory is explicitly marked `visibility: private` (owner-only). The hard access boundary is the **federation edge** (a separate Flair instance / org), not reads within an instance. See [SECURITY.md](../SECURITY.md) for the full model. Use Ed25519 per-agent everywhere you can regardless — it's still what makes writes and identity trustworthy.
 
 ### Known limitation — n8n uses admin-password Basic auth
 
-The `n8n-nodes-flair` community node authenticates with the Harper **admin password** (Basic auth), which grants **whole-instance read/write access**, not per-agent isolation. The blast radius is the entire memory store. This is acceptable only when **all** of the following hold:
+The `n8n-nodes-flair` community node authenticates with the Harper **admin password** (Basic auth), which bypasses agent scoping entirely — not just the org-wide non-private reads an Ed25519 identity already gets. Concretely, an n8n workflow using the admin credential can write memories under *any* agent's identity (no per-agent write isolation) and can read *every* memory including ones marked `visibility: private` (which stay owner-only under normal Ed25519 auth). This is acceptable only when **all** of the following hold:
 
 - The n8n instance is single-tenant and operator-controlled.
 - Workflow inputs are trusted (your own CRM, your own webhook source).
-- Memory leakage between agents is acceptable for the use case.
+- Write-forgery and full read access (including `private` memories) are acceptable for the use case.
 
 If any of those don't hold, use Flair's CLI / SDK clients (which support per-agent Ed25519 today) and wait for the n8n credential to gain Ed25519 per-agent auth (planned). Full guidance in [docs/n8n.md](n8n.md#security).
 

--- a/docs/claude-code.md
+++ b/docs/claude-code.md
@@ -115,7 +115,7 @@ Instead of passing `--agent` every time, set environment variables:
 ```bash
 # In your shell profile or .envrc
 export FLAIR_AGENT_ID=my-project
-export FLAIR_URL=http://localhost:9926  # default, only needed if custom
+export FLAIR_URL=http://localhost:19926  # default, only needed if custom
 ```
 
 Then the CLAUDE.md simplifies to:
@@ -157,7 +157,7 @@ flair agent add my-project
 
 # On client machines
 npm install -g @tpsdev-ai/flair  # for the CLI
-export FLAIR_URL=http://your-server:9926
+export FLAIR_URL=http://your-server:19926
 export FLAIR_AGENT_ID=my-project
 # Copy the key from the server:
 scp server:~/.flair/keys/my-project.key ~/.flair/keys/
@@ -166,8 +166,8 @@ scp server:~/.flair/keys/my-project.key ~/.flair/keys/
 Or use an SSH tunnel:
 
 ```bash
-ssh -f -N -L 9926:localhost:9926 your-server
-# Now FLAIR_URL=http://localhost:9926 works
+ssh -f -N -L 19926:localhost:19926 your-server
+# Now FLAIR_URL=http://localhost:19926 works
 ```
 
 ## Programmatic Access

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -41,7 +41,7 @@ flair restart
 Default port is `19926`. Override during init:
 
 ```bash
-flair init --port 9926
+flair init --port 8000
 ```
 
 Or edit `~/.flair/config.yaml` and restart.

--- a/docs/federation.md
+++ b/docs/federation.md
@@ -76,7 +76,7 @@ flair federation token --admin-pass <hub-admin-password> > /tmp/pair-triple.json
 scp hub-host:/tmp/pair-triple.json ./pair-triple.json
 
 # 3. Spoke admin pairs using the Fabric URL
-flair federation pair https://<fabric-node>:9926/<instance-name> --token-from ./pair-triple.json
+flair federation pair https://<fabric-node>:19926/<instance-name> --token-from ./pair-triple.json
 ```
 
 Replace `<fabric-node>`, `<instance-name>`, and `<hub-admin-password>` with your actual values.

--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -155,7 +155,7 @@ Walkthrough including a worked example flow: [`docs/n8n.md`](n8n.md).
 hermes plugins install path:/path/to/flair/packages/hermes-flair
 ```
 
-Auth: TPS-Ed25519 with per-agent isolation enforced server-side (the same model the rest of Flair uses).
+Auth: TPS-Ed25519 (the same model the rest of Flair uses) — writes are isolated per agent identity server-side; reads are open within the org for non-private memories, with `visibility: private` staying owner-only. See [SECURITY.md](../SECURITY.md).
 
 ---
 

--- a/docs/mcp-clients.md
+++ b/docs/mcp-clients.md
@@ -30,7 +30,7 @@ flair agent add my-project
 flair status
 ```
 
-Flair runs as a local server at `http://127.0.0.1:9926` by default. The MCP server connects to it on demand via Ed25519-signed requests; nothing leaves your machine unless you explicitly route to a remote Flair instance.
+Flair runs as a local server at `http://127.0.0.1:19926` by default. The MCP server connects to it on demand via Ed25519-signed requests; nothing leaves your machine unless you explicitly route to a remote Flair instance.
 
 ---
 
@@ -184,7 +184,7 @@ Seven tools, kept deliberately small:
 | `soul_set` | Set a personality/project/standards entry — included in every bootstrap |
 | `soul_get` | Get a soul entry |
 
-All scoped per-agent (your `FLAIR_AGENT_ID`). Cross-agent reads are refused by Flair's server, not by client convention — different agents on the same Flair instance can't see each other's memories.
+Writes are scoped per-agent (your `FLAIR_AGENT_ID`) and enforced by Flair's server, not by client convention — you can't write as another agent. Reads are more open by design: any agent on the same Flair instance can read any other agent's non-private memories (open-within-org read; see [SECURITY.md](../SECURITY.md)). Mark a memory `visibility: private` to keep it owner-only.
 
 ---
 
@@ -193,7 +193,7 @@ All scoped per-agent (your `FLAIR_AGENT_ID`). Cross-agent reads are refused by F
 | Env var | Default | Notes |
 |---|---|---|
 | `FLAIR_AGENT_ID` | (none — required) | Must match `flair agent add <id>` |
-| `FLAIR_URL` | `http://127.0.0.1:9926` | Override for remote Flair instances |
+| `FLAIR_URL` | `http://127.0.0.1:19926` | Override for remote Flair instances |
 | `FLAIR_KEY_PATH` | `~/.flair/keys/<agent>.key` | Ed25519 PKCS8 key — created by `flair agent add` |
 
 The MCP server has no client-side flags beyond these env vars; everything else (timeouts, dedup thresholds, error classification) is opinionated defaults from the underlying [`@tpsdev-ai/flair-client`](../packages/flair-client) package.
@@ -212,7 +212,7 @@ Future MCP-capable agent CLIs (and there are more landing every month) will work
 
 **"FLAIR_AGENT_ID is required" on startup.** Set it in the MCP server's `env` block (per snippets above). The CLI's own env doesn't propagate to the spawned MCP subprocess unless declared.
 
-**"connection_error: could not reach Flair at http://127.0.0.1:9926".** The Flair server isn't running. Run `flair status` to check; `flair start` to bring it up.
+**"connection_error: could not reach Flair at http://127.0.0.1:19926".** The Flair server isn't running. Run `flair status` to check; `flair start` to bring it up.
 
 **"auth_error: …" on every call.** The agent identity doesn't match a registered key. Re-run `flair agent add <id>` (idempotent on re-add — won't lose existing memories).
 

--- a/docs/n8n.md
+++ b/docs/n8n.md
@@ -26,7 +26,7 @@ npm install -g @tpsdev-ai/flair
 flair init
 ```
 
-This starts a local Flair server on `http://localhost:9926`. For shared/team setups, see [Deployment](./deployment.md).
+This starts a local Flair server on `http://localhost:19926`. For shared/team setups, see [Deployment](./deployment.md).
 
 ### 2. Install the n8n community node
 
@@ -38,7 +38,7 @@ In n8n: **Credentials → New → Flair API**. Fill in:
 
 | Field | Value |
 |---|---|
-| **Base URL** | `http://localhost:9926` (or your team's Flair URL) |
+| **Base URL** | `http://localhost:19926` (or your team's Flair URL) |
 | **Agent ID** | Logical identity that will own memories from this n8n workspace. Workflows that share an Agent ID share memory ownership. Use distinct IDs when isolation matters. |
 | **Admin Password** | Your Flair admin password (in `~/.flair/admin-pass` for local installs). **Sensitive** — see [Security](#security). |
 

--- a/docs/secrets-and-keys.md
+++ b/docs/secrets-and-keys.md
@@ -153,16 +153,18 @@ If you find yourself wanting one anyway, your agent can call `security find-gene
 
 | Asset | Owned by | If compromised → |
 |---|---|---|
-| Flair agent private key (`~/.flair/keys/<agent>.key`) | Flair (you, on the host) | Attacker can read/write that agent's memories until you rotate. Use `flair agent rotate <id>`. Other agents unaffected. |
+| Flair agent private key (`~/.flair/keys/<agent>.key`) | Flair (you, on the host) | Attacker can **write** memories under that agent's identity and read that agent's **`private`**-marked memories until you rotate. Use `flair agent rotate <id>`. Other agents' write identity is unaffected — they can't be impersonated with this key. |
 | LLM provider API keys (Anthropic, OpenAI, etc.) | OS keyring / 1Password | Standard provider revocation: rotate the key in the provider's console, update keyring entry. |
 | Cross-host secrets (1Password vault, age-sops) | The secret manager itself | Trust falls back to that manager's MFA / key handling. Document recovery in your team's ops runbook. |
-| Memory contents | Flair (server-side) | Read access via signed request → see "Per-agent isolation" below. |
+| Memory contents | Flair (server-side) | Write access requires the owning agent's key → see "Per-agent write isolation, org-wide non-private read" below. |
 
-### Per-agent isolation
+### Per-agent write isolation, org-wide non-private read
 
-Memories are scoped per `agentId` and isolation is enforced **server-side** by Ed25519 signature verification — not by client convention. An attacker with another agent's key cannot read your agent's memories even on the same Flair instance. Cross-agent sharing requires an explicit grant.
+Writes are scoped per `agentId` and isolation is enforced **server-side** by Ed25519 signature verification — not by client convention. An attacker with another agent's key can write memories as that agent, but cannot forge writes under *your* agent's identity without *your* key.
 
-This is a different threat model from password-based or API-key-based memory services where a leaked key gives access to the full namespace.
+Reads are a different, and intentionally more open, story: within one Flair instance (one org), **any** verified agent — not just an attacker with a stolen key — can already read **any other agent's non-private memory**. That's the shipped access model (open-within-org read; see [SECURITY.md](../SECURITY.md)), not a consequence of key compromise. A key leak's actual *incremental* exposure is narrower than "read your agent's memories": it's (1) the ability to write under that agent's identity, and (2) the ability to read that agent's `visibility: private` memories, which stay owner-only under normal operation. Non-private memories were already org-readable before the leak.
+
+The hard boundary in this model is the **federation edge** — a separate Flair instance / org. That's a different threat model from password-based or API-key-based memory services where a leaked key gives access to the full namespace across every trust boundary, not just one org.
 
 ## See also
 

--- a/docs/spoke-bringup.md
+++ b/docs/spoke-bringup.md
@@ -67,10 +67,10 @@ The admin password is passed via env (`FLAIR_ADMIN_PASS` / `HDB_ADMIN_PASSWORD`)
 
 ### 3c. Custom port
 
-Default is **9926** for REST / **9925** for ops. If you need to override (port conflict, multiple instances):
+Default is **19926** for REST / **19925** for ops. If you need to override (port conflict, multiple instances):
 
 ```bash
-flair init --agent-id <id> --port 19926
+flair init --agent-id <id> --port 8000
 ```
 
 Port is persisted to `~/.flair/config.yaml`. The ops port is always REST port − 1 (derived automatically).
@@ -247,35 +247,35 @@ rm -rf /data/flair
 flair init --data-dir /data/flair --agent-id <id>
 ```
 
-### 🔸 CLI config port 9926 vs 19926 drift
+### 🔸 Legacy hub on the old default (9926) vs a fresh spoke (19926)
 
-The CLI's `DEFAULT_PORT` constant is `19926`, but the real Harper instance listens on **9926** (with ops on **9925**). The port-resolution chain resolves this at runtime (`FLAIR_URL` env → `~/.flair/config.yaml` → default 9926), but if neither env nor config is set, the CLI falls through to `19926` and gets ECONNREFUSED.
+Flair's default REST port changed from 9926 to 19926 (ops: 9925 → 19925) to avoid Harper port collisions (see CHANGELOG.md). `flair init` today always resolves and persists the CLI's real `DEFAULT_PORT` — **19926** — to `~/.flair/config.yaml`, and that's what a fresh spoke gets. But a hub that was provisioned before that bump may still be running on the old 9926/9925 pair — nothing auto-migrates an existing instance's config. Don't assume the hub is on the current default; confirm its actual port with the hub admin, or check `~/.flair/config.yaml` on the hub host.
 
-**Fix:** Always set `FLAIR_URL` or write port to `~/.flair/config.yaml`. `flair init` writes `port: 9926` to config automatically. If you ran `flair init --port 19926`, the config gets 19926 and everything aligns — the mismatch only bites when init uses one port and subsequent commands expect the other without config.
+**Fix:** Pass the hub's actual URL (with its real port) to `flair federation pair` — never assume 19926. On the spoke side, confirm your own config matches what `flair init` actually wrote:
 
 ```bash
-# Verify config has the right port:
+# Verify the spoke's own config:
 grep port ~/.flair/config.yaml
-# → port: 9926
+# → port: 19926   (fresh install, or whatever you passed via --port)
 
-# Or set explicitly:
+# Or set explicitly if pairing to a hub still on the legacy default:
 export FLAIR_URL=http://127.0.0.1:9926
 ```
 
-### 🔸 rockit serves REST on 9926, ops on 9925
+### 🔸 Fabric hosts split REST and ops ports
 
-Fabric/rockit deployments split the REST API (port 9926) and the Harper operations API (port 9925). The derivation rule is **ops = REST − 1**. When pointing a CLI at a remote Fabric instance, pass `--target` for REST and the ops URL is derived automatically:
+Fabric deployments split the REST API and the Harper operations API onto adjacent ports. The derivation rule is **ops = REST − 1**. When pointing a CLI at a remote Fabric instance, pass the REST URL and the ops URL is derived automatically — substitute the hub's actual REST port (19926 for a fresh deployment, or whatever it was provisioned with):
 
 ```bash
-flair federation pair https://fabric-node.example.com:9926/<instance> --token-from triple.json
+flair federation pair https://fabric-node.example.com:19926/<instance> --token-from triple.json
 ```
 
 For explicit ops control:
 
 ```bash
-flair federation pair https://fabric-node.example.com:9926/<instance> \
+flair federation pair https://fabric-node.example.com:19926/<instance> \
   --token-from triple.json \
-  --ops-target https://fabric-node.example.com:9925
+  --ops-target https://fabric-node.example.com:19925
 ```
 
 ---

--- a/docs/the-team.md
+++ b/docs/the-team.md
@@ -15,7 +15,7 @@ If you're trying to run your own multi-agent team using Flair as the memory laye
 | **Pulse** | EA / intel scanning / coordination | OpenClaw | Claude API | cloud VM |
 | **Nathan** | Founder / product owner / human-in-the-loop | (human) | (human) | wherever |
 
-Every agent has its own Ed25519 identity in Flair. They sign every memory write and every read. **Cross-agent reads are refused at the Flair API layer**, not by client convention — Sherlock can't accidentally read Pulse's memories even on a shared Flair instance, because the signature won't verify.
+Every agent has its own Ed25519 identity in Flair. They sign every memory write and every read. **Writes are isolated at the Flair API layer** — Sherlock can't accidentally (or maliciously) write into Pulse's memory, because the signature won't verify for anyone but Pulse. Reads are a different story: within one Flair instance, any verified agent can read any other agent's **non-private** memory — that's the shipped model (open-within-org read, no grant needed), not a gap. An agent keeps something genuinely sensitive owner-only by writing it with `visibility: private`. The hard access boundary is the **federation edge** (a separate Flair instance), not reads within one.
 
 ## How memory flows
 
@@ -23,7 +23,8 @@ Every agent has its own Ed25519 identity in Flair. They sign every memory write 
                                 ┌────────────────────────┐                  
                                 │  Flair (self-hosted)   │                  
                                 │                        │                  
-                                │  Per-agent isolation   │                  
+                                │  Write isolation +     │                  
+                                │  open-within-org read, │                  
                                 │  enforced server-side  │                  
                                 │  via Ed25519 signing   │                  
                                 └─────────▲──────────────┘                  
@@ -33,18 +34,19 @@ Every agent has its own Ed25519 identity in Flair. They sign every memory write 
    Flint               Anvil           Kern          Sherlock           Pulse
    (local)           (cloud VM)    (inference box) (inference box)    (cloud VM)
         │                 │               │              │                 │
-   reads/writes      reads/writes    reads/writes   reads/writes      reads/writes
-   own memories      own memories    own memories   own memories      own memories
+   writes own          writes own      writes own     writes own       writes own
+   memories only        memories only   memories only  memories only   memories only
         │                 │               │              │                 │
         └─────────────────┴────────┬──────┴──────────────┴─────────────────┘
                                    │
-                            (no cross-agent reads
-                             without explicit grant)
+                       (every agent can read every other
+                        agent's non-private memories —
+                        `visibility: private` stays owner-only)
 ```
 
-Each agent's memory is independent. When Flint commits a piece of strategy, only Flint sees it on `memory_search`. When Sherlock writes a security finding, only Sherlock sees it. **By design.** Memory leaks between agents are how multi-agent teams break — different roles need different perspectives, and a security reviewer that's been told all of marketing's speculative ideas is no longer a credible reviewer.
+No agent can write into another agent's memory — that's enforced server-side by signature verification, no exceptions. Reads are intentionally open within the org: when Flint commits a piece of strategy, any agent can find it on `memory_search` unless Flint marked it `private`. **By design** — the goal is relevance and findability across the team, not secrecy between roles. An agent that genuinely needs something to stay owner-only (a draft not ready for the team, a sensitive finding pre-disclosure) marks it `visibility: private`; everything else is fair game for any teammate to search.
 
-When agents need to *coordinate*, they don't share memory — they pass **explicit messages** through TPS mail (a separate signed delivery channel; see [tpsdev-ai/cli](https://github.com/tpsdev-ai/cli)). The handoff is intentional and traceable. Memory is private; messages are interpersonal.
+When agents need to *coordinate* — a direct, targeted handoff rather than ambient searchable memory — they pass **explicit messages** through TPS mail (a separate signed delivery channel; see [tpsdev-ai/cli](https://github.com/tpsdev-ai/cli)). That's a different concern from memory visibility: TPS mail is for "I need you, specifically, to see this now"; Flair memory is the shared, searchable record everyone (except where `private`) can draw on later.
 
 ## Why these splits
 
@@ -100,19 +102,19 @@ Flair is the connective tissue:
 - **Soul:** each agent has a permanent personality block — role, voice, constraints. Loaded on every bootstrap so the agent stays *themselves* across sessions.
 - **Bridges:** when an agent needs context from a foreign system (e.g., Anvil needs to import lessons from another repo), bridges import them into Flair without a custom integration per source.
 
-The MCP server (`@tpsdev-ai/flair-mcp`) is what makes this orchestrator-agnostic — Flint's Claude Code, Anvil/Kern/Sherlock/Pulse's OpenClaw all hit the same Flair server with the same per-agent isolation guarantees.
+The MCP server (`@tpsdev-ai/flair-mcp`) is what makes this orchestrator-agnostic — Flint's Claude Code, Anvil/Kern/Sherlock/Pulse's OpenClaw all hit the same Flair server with the same write-isolation-plus-open-read guarantees.
 
 ## What we deliberately don't do
 
-- **No shared "team memory."** Agents pass explicit messages via TPS mail. Memory is private by default. Sharing requires an intentional grant.
+- **No shared write identity.** Every memory is written and owned by exactly one agent's Ed25519 key — there's no merged "team" identity that can write on another agent's behalf. Reads are a separate story: within the org, any agent can search any other's non-private memory by default (see [SECURITY.md](../SECURITY.md)) — that's intentional, not a leak. TPS mail is still how agents route a message to a *specific* teammate; it's for targeted delivery, not for gating ambient visibility.
 - **No silent LLM-driven memory extraction.** Each agent decides what it remembers. No background "summarize and persist" on every turn — that's how memory drifts away from intent.
-- **No multiple agents on one identity.** "Anvil" and "Anvil-2" would be two separate agentIds with two separate keys. Same workload, different identities, isolated memories.
+- **No multiple agents on one identity.** "Anvil" and "Anvil-2" would be two separate agentIds with two separate keys. Same workload, different identities, separately-owned memories.
 - **No replay-safe-but-otherwise-unsigned reads.** Every Flair request is Ed25519-signed and verified, including reads. Even on a private network we don't trust the network.
 - **No password-based access to memory.** A leaked Flair admin password lets you read the database via Harper directly, but doesn't let you impersonate an agent — you can't write under their identity without their key. We treat that as the right asymmetric defense.
 
 ## What we're still figuring out
 
-- **Cross-agent visibility for collaborative work.** Sometimes Flint needs Sherlock's recent security findings to write a spec. Today Flint asks via TPS mail; Sherlock answers. We're considering an explicit `flair memory share` mechanism with audit trails. Not in 1.0.
+- **Trust-weighting the open read pool.** Open-within-org read (#578, shipped in 0.21.0) means Flint no longer has to round-trip TPS mail to see Sherlock's recent security findings — `memory_search` already surfaces them directly. What's still unbuilt is any consolidation or trust-discounting of that shared pool: today it's a bigger unfiltered pile, not a ranked or corroborated one. That's the next arc (org-identity, emergent trust from provenance/corroboration/supersession) — it needs a founder-engaged design pass before we build it, not a solo build.
 - **Rhythm agent v1.** Today's v0 is a shell-cron polling for state changes and posting to Discord. v1 moves to a dedicated low-power device, uses a small local model to summarize, and escalates only when truly stuck. Post-1.0 polish.
 
 ## Try this with your own team
@@ -122,6 +124,6 @@ Pick a starting point that matches your scale:
 - **Solo, want continuity across sessions:** install Flair, give Claude Code an MCP-wired identity (see [`docs/mcp-clients.md`](mcp-clients.md)). One agent. Done.
 - **Pair, want explicit handoffs without losing context:** add a second agent identity, each with their own MCP config + Flair agentId. Pass work via TPS mail or your own coordination channel.
 - **Small team, want to see this rig work end-to-end:** clone our setup. Use our Beads issue tracker, our TPS mail, our agent role-splits. Replace Nathan with whoever's playing founder/product-owner.
-- **Bigger team:** federate Flair instances (per [`docs/federation.md`](federation.md)). Each office has its own Flair, signed cross-instance memory sharing. Same per-agent isolation guarantees scale across nodes.
+- **Bigger team:** federate Flair instances (per [`docs/federation.md`](federation.md)). Each office has its own Flair — that org boundary (the federation edge) is what stays hard across nodes; reads are already open within each office's own instance.
 
 Read the rest of the docs from there.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -137,7 +137,7 @@ flair agent list
 **Possible causes:**
 1. **Hash-fallback embeddings:** Check `flair status` — if embeddings are in hash mode, semantic search won't work properly. Fix with `flair reembed`.
 2. **Content safety flags:** The memory might have been flagged. Search for it directly: `flair memory list --agent <id>`.
-3. **Agent isolation:** Memories are scoped to the agent that wrote them. Ensure you're searching with the correct agent ID.
+3. **`visibility: private`:** Reads are open within the org by default — any agent can find any other agent's non-private memories. If the memory was written with `visibility: private`, only its author can find it; search as that agent instead.
 4. **Dedup threshold:** If the content is very similar to an existing memory, it may have been deduplicated. Check with `flair memory list`.
 
 ### High memory usage

--- a/docs/upgrade.md
+++ b/docs/upgrade.md
@@ -1,43 +1,87 @@
 # Upgrade Guide
 
-## Upgrading to 0.6.0 (from 0.5.x)
+This page covers the mechanics of upgrading Flair — the general path, valid across
+versions. For **what changed in a specific release** (behavior changes, new surfaces,
+breaking changes), see [`CHANGELOG.md`](../CHANGELOG.md) — each version has its own
+`## [X.Y.Z]` section. Check the CHANGELOG entries between your current version and the
+target version before upgrading anything you depend on in production.
 
-### Behavior changes to know about
+There are two things you might be upgrading:
 
-- **`flair init --skip-soul` and non-TTY init no longer seed placeholder soul entries.** Pre-0.6.0 those paths inserted generic `role` / `personality` / `constraints` strings (e.g. `"AI assistant [default — customize with 'flair soul set']"`). Those entries leaked into `flair bootstrap` output and confused users, so 0.6.0 leaves the soul empty for non-interactive installs. `flair doctor` and `flair soul set` are the nudge/workflow for populating real entries. **If you're upgrading an existing agent**: your previously-seeded placeholder entries are still there and won't be auto-removed. Run `flair soul list --agent <id>` to check; `flair soul delete` if you want them gone.
+1. **A local npm install** — the common case: `flair` running on your own machine or a
+   VPS, installed via `npm install -g @tpsdev-ai/flair`.
+2. **A Flair component deployed to a Harper Fabric cluster** — a different mechanism
+   (`flair deploy` / `flair upgrade --target`), covered separately below.
 
-- **`flair status` header now tiers health.** 🟢 means healthy; 🟡 means the process is running but something's worth looking at (e.g. >10% of your memories are hash-fallback); 🔴 still means unreachable. The state word stays `"running"` for 🟢 and 🟡 — only the icon changes. Any `grep -q "running"` scripts you have against `flair status` output continue to work; scripts that checked for 🟢 specifically should switch to `grep -q "🟢"` or treat 🟡 as also healthy.
-
-### New surfaces in 0.6.0
-
-- **`flair status`** now shows an `Embeddings:` line breaking down memories by embedding model — useful for catching mixed vector spaces after an upstream model change.
-- **`flair memory list --hash-fallback`** lists memories that lack a real embedding. Feeds a cleaner triage workflow when paired with `flair reembed --stale-only`.
-- **Per-agent columns in `flair status`** — new `hash_fb` and `24h` columns show which agents are carrying the embedding-coverage burden and which are actively writing.
-- **`flair bridge list` / `flair bridge scaffold`** — slice 1 of the memory-bridges plugin system. Runtime (`import`/`export`/`test`) lands in the next release. See [bridges.md](bridges.md).
-- **Revamped `flair init` first-run wizard** — template picker with (1) Solo developer / (2) Team agent / (3) Research assistant / (4) Draft from Claude / (5) Custom / (s) Skip. Only affects fresh installs.
-
-## Standard Upgrade
+## Standard upgrade (local install)
 
 ```bash
-# 1. Backup (always)
+# 1. Back up first, always
 flair backup > ~/flair-backup-$(date +%Y%m%d).json
 
-# 2. Upgrade the package
-npm install -g @tpsdev-ai/flair@latest
+# 2. Check what's outdated (doesn't install anything)
+flair upgrade --check
 
-# 3. Restart
-flair restart
+# 3. Upgrade
+flair upgrade
+# — or, to upgrade and restart in one step:
+flair upgrade --restart
 
 # 4. Verify
 flair status
 flair doctor
 ```
 
-`flair doctor` will flag any issues that need attention after an upgrade (stale embeddings, schema changes, etc.).
+`flair upgrade` checks and upgrades the npm-global packages (`@tpsdev-ai/flair`,
+`@tpsdev-ai/flair-mcp`) and, if present, the `openclaw-flair` plugin (via
+`openclaw plugins install --force --pin`, not `npm install -g` — it needs OpenClaw's
+own plugin loader). Pass `--all` to also see `flair-client` (normally hidden as a
+transitive dependency). **Other integrations upgrade in their own ecosystem, not via
+`flair upgrade`:** `pi-flair` (pi's plugin manager), `langgraph-flair` / `hermes-flair`
+(pip / your Python package manager), `n8n-nodes-flair` (n8n's Community Nodes UI).
 
-## Re-embedding
+If you'd rather upgrade by hand instead of `flair upgrade`:
 
-If the embedding model changes between versions, old memories may use a different embedding dimension. `flair doctor` will detect this:
+```bash
+npm install -g @tpsdev-ai/flair@latest
+npm install -g @tpsdev-ai/flair-mcp@latest   # if installed
+flair restart
+```
+
+`flair doctor` flags issues after an upgrade (stale embeddings, hash-fallback rows,
+connectivity problems) and can auto-remediate some of them with `flair doctor --fix`
+(`--dry-run` to preview first).
+
+## Upgrading a Fabric-deployed instance
+
+A Flair instance deployed to a Harper Fabric cluster isn't a local npm package — it's a
+component pushed via `flair deploy`. Upgrade it in place with:
+
+```bash
+flair upgrade --target https://<fabric-node>/<instance-name> \
+  --fabric-user <admin> --fabric-password <pass>
+```
+
+This resolves the target version (latest published `@tpsdev-ai/flair`, or pin one with
+`--version`), stages a clean deployable with the required `@harperfast/harper` version
+pin applied (`--harper-version` to override), confirms the staged Harper build before
+deploying, then reuses `flair deploy` to push it and verifies the result. `--check`
+shows the version diff and plan without deploying anything; `--yes` skips the
+confirmation prompt for scripted use. Credentials can come from `FABRIC_USER` /
+`FABRIC_PASSWORD` env vars instead of flags.
+
+## Re-embedding after an upgrade
+
+Two situations require a re-embed pass, and `flair doctor` will flag both:
+
+- **The embedding model changed** between versions — old memories carry vectors from
+  the previous model and won't compare correctly against new ones.
+- **Harper's internal vector storage changed across a version bump** (this has
+  happened between Harper point releases, e.g. HNSW-index-internal changes) — even
+  with the same embedding model, stored vectors may need to be regenerated to match
+  what the new Harper build expects.
+
+`flair doctor` reports the counts:
 
 ```
 ⚠️  49 memories have hash-fallback embeddings (512-dim)
@@ -48,40 +92,52 @@ If the embedding model changes between versions, old memories may use a differen
 Fix with:
 
 ```bash
-flair reembed
+flair reembed                 # all agents, all stale rows
+flair reembed --stale-only    # only mismatched-model-tag rows
+flair reembed --agent <id>    # scope to one agent
+flair reembed --dry-run       # show the count without writing
 ```
 
-This re-generates embeddings for all memories using the current model. Runs in the background — the server stays available during re-embedding.
+This runs in the background — the server stays available while it re-embeds. This is
+also the step CI's `upgrade-smoke` job exercises directly: it upgrades a running
+instance from the latest published version to the candidate build, then runs
+`flair reembed` before asserting old memories are still searchable and new writes
+round-trip. See the `upgrade-smoke` job in
+[`.github/workflows/test.yml`](../.github/workflows/test.yml) for the exact sequence
+if you want to see it scripted end-to-end.
 
-## Version Compatibility
+## Version compatibility
 
-- **Data format:** Flair stores data in Harper's native format. Harper v5 beta releases maintain backward compatibility within the v5 line.
-- **Keys:** Ed25519 keypairs are version-independent. No key migration needed between Flair versions.
-- **Config:** `~/.flair/config.yaml` format is stable. New options use defaults if not present.
-
-## MCP Server Upgrade
-
-The recommended wiring runs the MCP server via `npx -y @tpsdev-ai/flair-mcp`, which fetches the latest published version on demand. To pick up a new release, just **restart your MCP client** (Claude Code, Cursor, etc.) — `npx` will resolve the newest version on next launch (clear the npx cache with `npx clear-npx-cache` if it pins an old one). No config changes needed — the MCP server reads `FLAIR_URL` and `FLAIR_AGENT_ID` from environment.
-
-If you pinned a version (e.g. `["-y", "@tpsdev-ai/flair-mcp@0.6.0"]`) or installed globally, bump it explicitly:
-
-```bash
-npm install -g @tpsdev-ai/flair-mcp@latest   # only if you opted into a global install
-```
+- **Data format:** Flair stores data in Harper's native format; Harper maintains
+  backward compatibility within a major line. Cross-Harper-version data compatibility
+  is exactly what `upgrade-smoke` exists to catch regressions in — check the CHANGELOG
+  for any called-out breaking change before a major jump.
+- **Keys:** Ed25519 keypairs are version-independent. No key migration is ever needed
+  between Flair versions.
+- **Config:** `~/.flair/config.yaml` format is additive — new options fall back to
+  defaults when absent, old options aren't removed out from under you.
 
 ## Rollback
 
-If an upgrade causes issues:
+If an upgrade causes problems:
 
 ```bash
 # Install a specific previous version (substitute your last known-good)
-npm install -g @tpsdev-ai/flair@0.5.6
-
-# Restart
+npm install -g @tpsdev-ai/flair@<previous-version>
 flair restart
 
-# If data is corrupted, restore from backup
-flair restore < ~/flair-backup-20260405.json
+# If data looks wrong, restore from your pre-upgrade backup
+flair restore < ~/flair-backup-<date>.json
 ```
 
-Data written by a newer Flair is readable by the immediate predecessor — there are no schema breaks within the 0.5.x → 0.6.x window. Downgrading further back than one minor version is unsupported; use the backup path instead.
+Downgrading more than a minor version back is not a supported, tested path — restoring
+from backup on the older version is the reliable route if you need to go back further.
+
+## See also
+
+- [`CHANGELOG.md`](../CHANGELOG.md) — what actually changed, version by version.
+- [`docs/releasing.md`](releasing.md) — how a release gets published in the first
+  place (staged npm publish with 2FA approval), if you're curious why a new version
+  shows up when it does.
+- [`docs/deployment.md`](deployment.md) — initial install / deployment, as opposed to
+  upgrading an existing one.

--- a/packages/flair-client/README.md
+++ b/packages/flair-client/README.md
@@ -16,7 +16,7 @@ npm install @tpsdev-ai/flair-client
 import { FlairClient } from '@tpsdev-ai/flair-client'
 
 const flair = new FlairClient({
-  url: 'http://localhost:9926',   // or remote: https://flair.example.com
+  url: 'http://localhost:19926',   // or remote: https://flair.example.com
   agentId: 'my-agent',
   // keyPath auto-resolved from ~/.flair/keys/my-agent.key
 })
@@ -108,7 +108,7 @@ Or use the Flair CLI directly:
 
 | Option | Env | Default | Description |
 |--------|-----|---------|-------------|
-| `url` | `FLAIR_URL` | `http://localhost:9926` | Flair server URL |
+| `url` | `FLAIR_URL` | `http://localhost:19926` | Flair server URL |
 | `agentId` | `FLAIR_AGENT_ID` | — | Agent identifier |
 | `keyPath` | `FLAIR_KEY_DIR` | auto-resolved | Private key path |
 | `timeoutMs` | — | `10000` | Request timeout |

--- a/packages/hermes-flair/README.md
+++ b/packages/hermes-flair/README.md
@@ -6,7 +6,7 @@
 
 Hermes already ships great built-in memory (MEMORY.md / USER.md). Flair extends it with:
 
-- **Per-agent isolation enforced server-side.** Each Hermes agent identity gets its own Ed25519 keypair; cross-agent reads are refused at the API layer, not by client convention.
+- **Per-agent write isolation enforced server-side.** Each Hermes agent identity gets its own Ed25519 keypair; no agent can write memories as another, verified at the API layer, not by client convention. Reads are open within the org for non-private memories by design (see [SECURITY.md](https://github.com/tpsdev-ai/flair/blob/main/SECURITY.md)) — mark something `visibility: private` to keep it owner-only.
 - **Agent-authored, no LLM-extraction-on-every-turn.** The agent decides what's worth remembering via the `flair_store` tool. No silent server-side fact extraction, no surprise persistence.
 - **Self-hosted, no SaaS dependency.** Runs on a Mac Mini, a Raspberry Pi, or a cloud VM. Single Harper-backed binary.
 - **Same backend for memory + identity.** Soul (who I am), agent registry (who else exists), and memories all live in one place — so the plugin can answer "who am I and what do I know" from a single source.
@@ -33,7 +33,7 @@ Provide via environment variables, or `$HERMES_HOME/flair.json`:
 
 | Setting          | Env var          | Default                             | Notes                                           |
 |------------------|------------------|-------------------------------------|-------------------------------------------------|
-| Server URL       | `FLAIR_URL`      | `http://127.0.0.1:9926`              | Override for remote Flair deployments           |
+| Server URL       | `FLAIR_URL`      | `http://127.0.0.1:19926`             | Override for remote Flair deployments           |
 | Agent ID         | `FLAIR_AGENT_ID` | `hermes`                            | Must match `flair agent add <id>`               |
 | Private key path | `FLAIR_KEY_PATH` | `~/.flair/keys/<agent>.key`         | PKCS8 base64 Ed25519 key created above          |
 
@@ -41,7 +41,7 @@ Example `flair.json`:
 
 ```json
 {
-  "url": "http://127.0.0.1:9926",
+  "url": "http://127.0.0.1:19926",
   "agent_id": "hermes",
   "bootstrap_limit": 10,
   "recall_limit": 5

--- a/packages/n8n-nodes-flair/README.md
+++ b/packages/n8n-nodes-flair/README.md
@@ -22,7 +22,7 @@ Full setup walkthrough, subject/sessionId patterns, and security guidance are in
 
 ## Credential setup
 
-1. **Base URL** — your Flair instance, e.g. `http://localhost:9926`
+1. **Base URL** — your Flair instance, e.g. `http://localhost:19926`
 2. **Agent ID** — the logical identity that will own memories written from this n8n workspace. Workflows that share an Agent ID share memory ownership.
 3. **Admin Password** — your Flair (Harper) admin password. **This grants read/write access to the entire instance.** For production with untrusted workflow inputs, wait for Ed25519 per-agent auth (planned).
 

--- a/packages/n8n-nodes-flair/examples/ks-review-capture/README.md
+++ b/packages/n8n-nodes-flair/examples/ks-review-capture/README.md
@@ -54,7 +54,7 @@ Notes on each step:
 
 2. **Configure the Flair credential**:
    - Settings → Credentials → New → Flair API
-   - Base URL: `http://127.0.0.1:9926` (or your Flair host)
+   - Base URL: `http://127.0.0.1:19926` (or your Flair host)
    - Agent ID: any agent who should *own* the imported memories (e.g., `flint`, `pulse`, `archive`)
    - Admin Password: contents of `~/.flair/admin-pass`
 
@@ -68,11 +68,11 @@ Notes on each step:
 5. **Verify in Flair**:
    ```sh
    # search by tag
-   FLAIR_URL=http://127.0.0.1:9926 flair memory search "" \
+   FLAIR_URL=http://127.0.0.1:19926 flair memory search "" \
      --agent flint --tags kind:review --limit 5
 
    # search by PR
-   FLAIR_URL=http://127.0.0.1:9926 flair memory search "" \
+   FLAIR_URL=http://127.0.0.1:19926 flair memory search "" \
      --subject pr-380 --limit 10
    ```
 

--- a/packages/openclaw-flair/README.md
+++ b/packages/openclaw-flair/README.md
@@ -64,7 +64,7 @@ In your OpenClaw config (`openclaw.json`):
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
-| `url` | string | `http://127.0.0.1:9926` | Flair server URL |
+| `url` | string | `http://127.0.0.1:19926` | Flair server URL |
 | `agentId` | string | *required* | Agent ID for memory namespacing. Use `"auto"` for multi-agent gateways. |
 | `keyPath` | string | auto-resolved | Path to Ed25519 private key |
 | `autoCapture` | boolean | `true` | Auto-capture important info from conversations |

--- a/packages/pi-flair/README.md
+++ b/packages/pi-flair/README.md
@@ -56,7 +56,7 @@ Or use environment variables:
 
 ```bash
 export FLAIR_AGENT_ID=my-agent
-export FLAIR_URL=http://127.0.0.1:9926
+export FLAIR_URL=http://127.0.0.1:19926
 pi
 ```
 
@@ -73,7 +73,7 @@ pi
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `FLAIR_AGENT_ID` | *(required)* | Agent identity for memory scoping |
-| `FLAIR_URL` | `http://127.0.0.1:9926` | Flair server URL |
+| `FLAIR_URL` | `http://127.0.0.1:19926` | Flair server URL |
 | `FLAIR_KEY_PATH` | auto-resolved | Path to Ed25519 private key |
 | `FLAIR_MAX_RECALL_RESULTS` | `5` | Max results for memory_search |
 | `FLAIR_MAX_BOOTSTRAP_TOKENS` | `4000` | Max tokens in bootstrap output |


### PR DESCRIPTION
## Summary

Doc-only quick-wins from the 2026-07-07 state review (`FLAIR-STATE-REVIEW-2026-07-07.md`), all adopter-facing correctness bugs:

- **Port drift (19926 vs 9926).** Ground truth confirmed in code: `src/cli.ts`'s `DEFAULT_PORT` and `flair-client`'s own `client.ts`/`types.ts` both default to **19926**. Aligned every doc and package README that still said 9926 (`docs/mcp-clients.md`, `docs/claude-code.md`, `docs/n8n.md`, `docs/federation.md`, `packages/flair-client/README.md`, `packages/pi-flair/README.md`, `packages/hermes-flair/README.md`, `packages/n8n-nodes-flair/README.md` + its example, `packages/openclaw-flair/README.md`), and fixed a couple of misleading "override" examples in `docs/deployment.md` / `docs/spoke-bringup.md` that used the *old* default as the override target. `docs/spoke-bringup.md`'s port-drift gotcha section is rewritten to be factually correct (fresh installs default to 19926) while preserving the real nuance that pre-bump hub deployments may still run 9926 — and drops an adjacent internal hostname reference while I was already touching that paragraph.

- **Stale security-model docs.** `docs/auth.md`, `docs/the-team.md`, and `docs/secrets-and-keys.md` still described the retired grant-gated per-agent-isolation model ("cross-agent reads refused server-side," "sharing requires an explicit grant," "an attacker with another agent's key cannot read your agent's memories even on the same instance"). Corrected all three (plus the same stale claim found in `README.md`, `docs/mcp-clients.md`, `docs/integrations.md`, `packages/hermes-flair/README.md`, and one troubleshooting entry) to describe the model actually shipped in #578 / 0.21.0: writes are isolated per agent (Ed25519, no impersonation possible), reads are **open within the org** for non-private memories with no grant required, `visibility: private` stays strictly owner-only, and the hard access boundary is the **federation edge** — matching `SECURITY.md`/`DESIGN.md`, which were already accurate and served as source of truth.

- **`docs/upgrade.md` unfrozen.** Was stuck describing "Upgrading to 0.6.0" (current is 0.21.0). Replaced with general, version-agnostic upgrade guidance: the real `flair upgrade` / `flair upgrade --target <fabric-url>` mechanics (read straight from `src/cli.ts`), when/why `flair reembed` is needed (embedding-model changes or Harper internals changing across a version bump, per the `upgrade-smoke` CI job's own comments), and pointers to `CHANGELOG.md` for per-version specifics instead of duplicating (and re-staling) them here.

Docs only — no code, schema, or test changes (`bun run build` passes clean; pre-commit hooks green).

**Not merged.** Flint reviews and merges per team process.

## Test plan

- [x] `bun run build` — clean, no errors
- [x] Grepped the full docs tree for `9926`/`19926` and for the retired-model phrases (`cross-agent reads refused`, `requires an explicit grant`, etc.) post-edit — none remain outside `CHANGELOG.md` (historical) and `specs/` (point-in-time planning docs), which were deliberately left untouched
- [x] Verified all new/changed relative links resolve (`SECURITY.md`, `DESIGN.md`, `CHANGELOG.md`, `docs/releasing.md`, `.github/workflows/test.yml`)
- [ ] K&S review

🤖 Generated with [Claude Code](https://claude.com/claude-code)