### PR TITLE
fix(security): gate FederationInstance/FederationPeers/HealthDetail/SkillScan (authorizeLocal class, #614 finding)

### DIFF
--- a/resources/Federation.ts
+++ b/resources/Federation.ts
@@ -1,6 +1,7 @@
 import { Resource, databases, server } from "@harperfast/harper";
 import { createHash, randomBytes } from "node:crypto";
 import nacl from "tweetnacl";
+import { allowAdmin } from "./agent-auth.js";
 import {
   canonicalize,
   signBody,
@@ -120,8 +121,22 @@ function mergeRecord(local: Record<string, any> | null, remote: SyncRecord): Rec
 /**
  * GET /FederationInstance — return this instance's identity.
  * Used by peers during pairing and by the admin UI.
+ *
+ * allowRead()=allowAdmin (defense-in-depth, authorizeLocal-escalation-class
+ * follow-up to #601/#604/#609/#612 — flair#614's backstop found this one had
+ * NO allow* at all, so Harper's own default — `user?.role.permission.
+ * super_user`, satisfiable only by a genuine admin OR authorizeLocal's forged
+ * loopback super_user — was silently standing in). Same idiom as
+ * AdminInstance.ts/AdminDashboard.ts: this is an admin-view endpoint (peers
+ * never call it during pairing — FederationPair.post() reads the Instance
+ * table directly server-side to hand a peer our identity; this HTTP GET is
+ * ObservationCenter/CLI tooling only).
  */
 export class FederationInstance extends Resource {
+  async allowRead(): Promise<boolean> {
+    return allowAdmin((this as any).getContext?.());
+  }
+
   async get() {
     // Find or create instance identity
     let instance: any = null;
@@ -560,8 +575,20 @@ export class FederationSync extends Resource {
 
 /**
  * GET /FederationPeers — list known peers (admin view).
+ *
+ * allowRead()=allowAdmin (defense-in-depth, authorizeLocal-escalation-class
+ * follow-up to #601/#604/#609/#612 — flair#614's backstop found this one had
+ * NO allow* at all). The docstring already called this "(admin view)" and
+ * ObservationCenter's own JS already prompts for admin-pass before hitting
+ * this endpoint (see auth-middleware.ts's ObservationCenter comment) — this
+ * closes the gap between the documented/intended access model and what was
+ * actually enforced (nothing).
  */
 export class FederationPeers extends Resource {
+  async allowRead(): Promise<boolean> {
+    return allowAdmin((this as any).getContext?.());
+  }
+
   async get() {
     const peers: any[] = [];
     try {

--- a/resources/SkillScan.ts
+++ b/resources/SkillScan.ts
@@ -1,4 +1,5 @@
 import { Resource } from "@harperfast/harper";
+import { allowVerified } from "./agent-auth.js";
 import { scanSkillContent } from "./scan/skill-scanner.js";
 
 /**
@@ -32,6 +33,21 @@ import { scanSkillContent } from "./scan/skill-scanner.js";
  */
 
 export class SkillScan extends Resource {
+  /**
+   * allowCreate()=allowVerified (authorizeLocal-escalation-class follow-up to
+   * #601/#604/#609/#612 — flair#614's backstop found this resource had NO
+   * allow* at all). The docstring above already says "Auth: any authenticated
+   * agent" — this was never actually enforced; Harper's own default
+   * (`user?.role.permission.super_user`, satisfiable only by a genuine admin
+   * OR authorizeLocal's forged loopback super_user) silently stood in
+   * instead. allowVerified matches the documented intent: any verified agent
+   * (not admin-only — this is a stateless text scanner, no agent/memory data
+   * touched), anonymous denied.
+   */
+  async allowCreate(): Promise<boolean> {
+    return allowVerified((this as any).getContext?.());
+  }
+
   async post(data: any, _context?: any) {
     const { content } = data || {};
 

--- a/resources/health.ts
+++ b/resources/health.ts
@@ -3,6 +3,7 @@ import { promises as fsp } from "node:fs";
 import { homedir, platform } from "node:os";
 import { join } from "node:path";
 import { getRerankStatus } from "./rerank-provider.js";
+import { allowVerified, resolveAgentAuth } from "./agent-auth.js";
 
 const db = databases as any;
 
@@ -51,19 +52,45 @@ export class Health extends Resource {
  * Authenticated health detail — returns memory/agent/soul stats + process info.
  * Requires Ed25519 agent auth or admin basic auth.
  *
+ * allowRead()=allowVerified (authorizeLocal-escalation-class follow-up to
+ * #601/#604/#609/#612 — flair#614's backstop found this resource had NO
+ * allow* at all, despite this docstring's stated intent). Harper's own
+ * default (`user?.role.permission.super_user`, satisfiable only by a genuine
+ * admin OR authorizeLocal's forged loopback super_user) was silently
+ * standing in instead. Any verified agent may read — get() below still
+ * filters sensitive fields (peer/OAuth-client lists, absolute paths, full
+ * agent roster) down to admin-only.
+ *
  * Every optional-subsystem lookup is wrapped so a missing table or absent
  * schema downgrades to "not configured" rather than failing the whole call.
  */
 export class HealthDetail extends Resource {
+  async allowRead(): Promise<boolean> {
+    return allowVerified((this as any).getContext?.());
+  }
+
   async get() {
     const stats: Record<string, any> = { ok: true };
     const nowMs = Date.now();
     const warnings: Array<{ level: "warn" | "info"; message: string }> = [];
 
     const ctx = (this as any).getContext?.();
-    const request = ctx?.request ?? ctx;
-    const callerAgent: string | undefined = request?.tpsAgent;
-    const isAdmin: boolean = request?.tpsAgentIsAdmin === true || !callerAgent;
+    // #614 fix: resolve identity via the shared three-way verdict
+    // (internal/agent/anonymous — agent-auth.ts) instead of reading
+    // tpsAgent/tpsAgentIsAdmin off the raw request directly. The OLD
+    // computation was `request?.tpsAgentIsAdmin === true || !callerAgent` —
+    // the `|| !callerAgent` half meant an UNRESOLVED caller (no tpsAgent at
+    // all — i.e. anonymous) defaulted to isAdmin=TRUE, backwards from every
+    // other resource in this codebase and the opposite of fail-safe.
+    // allowRead() above already denies a genuine anonymous HTTP caller
+    // before get() ever runs; this fixes the internal computation to match
+    // (defense-in-depth, and correct semantics if get() is ever reached
+    // another way). Only a true "internal" verdict (no HTTP request at all —
+    // a programmatic/in-process call) or a verified admin agent is isAdmin;
+    // an unresolved/anonymous HTTP caller is never treated as admin.
+    const auth = await resolveAgentAuth(ctx);
+    const callerAgent: string | undefined = auth.kind === "agent" ? auth.agentId : undefined;
+    const isAdmin: boolean = auth.kind === "internal" || (auth.kind === "agent" && auth.isAdmin);
     stats.caller = { agentId: callerAgent ?? null, isAdmin };
 
     let memoriesList: any[] = [];

--- a/test/integration/gate4-authgate.test.ts
+++ b/test/integration/gate4-authgate.test.ts
@@ -1,0 +1,245 @@
+// gate4-authgate.test.ts — Integration tests for the 4 resources surfaced by
+// the flair#614 CI-assertion backstop (test/unit/resource-allow-decision.test.ts's
+// NEEDS_HUMAN_REVIEW list): FederationInstance, FederationPeers, HealthDetail,
+// SkillScan. Same authorizeLocal-escalation class as #601/#604/#609/#612.
+//
+// Each of these four had NO allow* override at all, so Harper's own default
+// (`user?.role.permission.super_user`, satisfiable by a genuine admin OR by
+// authorizeLocal's forged loopback super_user for ANY credential-less
+// LOOPBACK request) silently stood in. Verified empirically pre-fix: a bare
+// credential-less `fetch(harper.httpURL + "/FederationInstance")` (no
+// Authorization header at all) returned 200 with full instance identity,
+// full peer list, full HealthDetail stats (with `caller.isAdmin: true` for
+// the unresolved caller — the sharpest of the four), and a working SkillScan
+// result — zero credentials required, from loopback.
+//
+// FederationInstance/FederationPeers → allowRead()=allowAdmin (admin views,
+// matching AdminInstance.ts/AdminDashboard.ts's idiom).
+// HealthDetail → allowRead()=allowVerified (matches its own docstring's
+// stated, previously-unenforced intent) + fixes the backwards internal
+// `isAdmin = tpsAgentIsAdmin === true || !callerAgent` default (an unresolved
+// caller no longer defaults to admin).
+// SkillScan → allowCreate()=allowVerified (matches its own docstring's
+// stated, previously-unenforced intent — stateless text scanner, no
+// agent/memory data touched, so any verified agent may call it).
+//
+// MODEL: test/integration/credential-allowread-authgate.test.ts (the
+// allowRead-gate proof pattern) + test/integration/flair-agent-deelevation.test.ts
+// (the admin-vs-non-admin agent seeding pattern for allowAdmin-gated
+// resources).
+import { describe, expect, test, beforeAll, afterAll } from "bun:test";
+import nacl from "tweetnacl";
+import { randomUUID } from "node:crypto";
+import { startHarper, stopHarper, HarperInstance } from "../helpers/harper-lifecycle";
+
+interface TestAgent { id: string; publicKey: string; secretKey: Uint8Array; }
+
+function mkAgent(id: string): TestAgent {
+  const kp = nacl.sign.keyPair();
+  return { id, publicKey: Buffer.from(kp.publicKey).toString("base64"), secretKey: kp.secretKey };
+}
+
+function ed25519Header(agent: TestAgent, method: string, path: string): string {
+  const ts = Date.now().toString();
+  const nonce = randomUUID();
+  const payload = `${agent.id}:${ts}:${nonce}:${method}:${path}`;
+  const sig = nacl.sign.detached(new TextEncoder().encode(payload), agent.secretKey);
+  return `TPS-Ed25519 ${agent.id}:${ts}:${nonce}:${Buffer.from(sig).toString("base64")}`;
+}
+
+async function adminOp(harper: HarperInstance, op: Record<string, any>): Promise<Response> {
+  return fetch(harper.opsURL, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: "Basic " + btoa(`${harper.admin.username}:${harper.admin.password}`),
+    },
+    body: JSON.stringify(op),
+  });
+}
+
+let harper: HarperInstance;
+const nonAdmin = mkAgent("gate4-nonadmin");
+const admin = mkAgent("gate4-admin");
+const seededPeerId = `gate4-peer-${randomUUID()}`;
+
+describe("flair#614 backstop follow-up: FederationInstance/FederationPeers/HealthDetail/SkillScan gates", () => {
+  beforeAll(async () => {
+    harper = await startHarper();
+
+    const nonAdminRes = await adminOp(harper, {
+      operation: "insert", database: "flair", table: "Agent",
+      records: [{ id: nonAdmin.id, name: nonAdmin.id, role: "agent", publicKey: nonAdmin.publicKey, createdAt: new Date().toISOString() }],
+    });
+    expect(nonAdminRes.status).toBe(200);
+
+    const adminRes = await adminOp(harper, {
+      operation: "insert", database: "flair", table: "Agent",
+      records: [{ id: admin.id, name: admin.id, role: "admin", publicKey: admin.publicKey, createdAt: new Date().toISOString() }],
+    });
+    expect(adminRes.status).toBe(200);
+
+    // Seed a Peer record so FederationPeers has something to (not) leak, and
+    // an Instance row so FederationInstance/HealthDetail's federation block
+    // has real data.
+    const peerKp = nacl.sign.keyPair();
+    const peerRes = await adminOp(harper, {
+      operation: "insert", database: "flair", table: "Peer",
+      records: [{
+        id: seededPeerId,
+        publicKey: Buffer.from(peerKp.publicKey).toString("base64url"),
+        role: "spoke", status: "connected", endpoint: "https://peer.example",
+        relayOnly: false, pairedAt: new Date().toISOString(), createdAt: new Date().toISOString(), updatedAt: new Date().toISOString(),
+      }],
+    });
+    expect(peerRes.status, `Peer insert returned ${peerRes.status}: ${await peerRes.text()}`).toBe(200);
+  }, 180_000);
+
+  afterAll(async () => { if (harper) await stopHarper(harper); });
+
+  // ── FederationInstance (allowRead → allowAdmin) ───────────────────────────
+
+  describe("FederationInstance", () => {
+    test("credential-less loopback GET → denied (was 200 pre-fix, forged-admin reachable)", async () => {
+      const res = await fetch(`${harper.httpURL}/FederationInstance`);
+      const text = await res.text();
+      expect(res.status, `anon GET /FederationInstance returned ${res.status}: ${text.slice(0, 200)}`).toBe(403);
+    }, 30_000);
+
+    test("non-admin verified agent GET → denied", async () => {
+      const path = "/FederationInstance";
+      const res = await fetch(`${harper.httpURL}${path}`, {
+        headers: { Authorization: ed25519Header(nonAdmin, "GET", path) },
+      });
+      expect(res.status, `non-admin GET ${path} returned ${res.status}`).toBe(403);
+    }, 30_000);
+
+    test("admin verified agent GET → authorized, returns instance identity", async () => {
+      const path = "/FederationInstance";
+      const res = await fetch(`${harper.httpURL}${path}`, {
+        headers: { Authorization: ed25519Header(admin, "GET", path) },
+      });
+      const text = await res.text();
+      expect(res.status, `admin GET ${path} returned ${res.status}: ${text.slice(0, 200)}`).toBe(200);
+      const body = JSON.parse(text);
+      expect(body.id).toBeTruthy();
+      expect(body.publicKey).toBeTruthy();
+    }, 30_000);
+  });
+
+  // ── FederationPeers (allowRead → allowAdmin) ──────────────────────────────
+
+  describe("FederationPeers", () => {
+    test("credential-less loopback GET → denied (was 200 pre-fix, leaked full peer list)", async () => {
+      const res = await fetch(`${harper.httpURL}/FederationPeers`);
+      const text = await res.text();
+      expect(res.status, `anon GET /FederationPeers returned ${res.status}: ${text.slice(0, 200)}`).toBe(403);
+      expect(text).not.toContain(seededPeerId);
+    }, 30_000);
+
+    test("non-admin verified agent GET → denied", async () => {
+      const path = "/FederationPeers";
+      const res = await fetch(`${harper.httpURL}${path}`, {
+        headers: { Authorization: ed25519Header(nonAdmin, "GET", path) },
+      });
+      const text = await res.text();
+      expect(res.status, `non-admin GET ${path} returned ${res.status}`).toBe(403);
+      expect(text).not.toContain(seededPeerId);
+    }, 30_000);
+
+    test("admin verified agent GET → authorized, returns the seeded peer", async () => {
+      const path = "/FederationPeers";
+      const res = await fetch(`${harper.httpURL}${path}`, {
+        headers: { Authorization: ed25519Header(admin, "GET", path) },
+      });
+      const text = await res.text();
+      expect(res.status, `admin GET ${path} returned ${res.status}: ${text.slice(0, 200)}`).toBe(200);
+      const body = JSON.parse(text);
+      expect(body.peers.some((p: any) => p.id === seededPeerId)).toBe(true);
+    }, 30_000);
+  });
+
+  // ── HealthDetail (allowRead → allowVerified; isAdmin default fix) ─────────
+
+  describe("HealthDetail", () => {
+    test("credential-less loopback GET → denied (was 200 pre-fix WITH caller.isAdmin:true — the backwards-default bug)", async () => {
+      const res = await fetch(`${harper.httpURL}/HealthDetail`);
+      const text = await res.text();
+      expect(res.status, `anon GET /HealthDetail returned ${res.status}: ${text.slice(0, 300)}`).toBe(403);
+      // Belt-and-suspenders: the pre-fix leak specifically included
+      // `"isAdmin":true` in the body for this exact unauthenticated request —
+      // confirm no body carrying that claim escapes even if the status check
+      // above regresses.
+      expect(text).not.toContain('"isAdmin":true');
+    }, 30_000);
+
+    test("non-admin verified agent GET → authorized, caller.isAdmin is false (NOT the old unresolved->true default)", async () => {
+      const path = "/HealthDetail";
+      const res = await fetch(`${harper.httpURL}${path}`, {
+        headers: { Authorization: ed25519Header(nonAdmin, "GET", path) },
+      });
+      const text = await res.text();
+      expect(res.status, `non-admin GET ${path} returned ${res.status}: ${text.slice(0, 300)}`).toBe(200);
+      const body = JSON.parse(text);
+      expect(body.caller.agentId).toBe(nonAdmin.id);
+      expect(body.caller.isAdmin).toBe(false);
+      // Admin-only fields must be redacted for a non-admin caller.
+      expect(body.agents.names).toBeUndefined();
+      expect(body.federation?.peerList).toBeUndefined();
+    }, 30_000);
+
+    test("admin verified agent GET → authorized, caller.isAdmin is true, full detail returned", async () => {
+      const path = "/HealthDetail";
+      const res = await fetch(`${harper.httpURL}${path}`, {
+        headers: { Authorization: ed25519Header(admin, "GET", path) },
+      });
+      const text = await res.text();
+      expect(res.status, `admin GET ${path} returned ${res.status}: ${text.slice(0, 300)}`).toBe(200);
+      const body = JSON.parse(text);
+      expect(body.caller.agentId).toBe(admin.id);
+      expect(body.caller.isAdmin).toBe(true);
+      expect(Array.isArray(body.agents.names)).toBe(true);
+      expect(body.federation?.peerList?.some((p: any) => p.id === seededPeerId)).toBe(true);
+    }, 30_000);
+  });
+
+  // ── SkillScan (allowCreate → allowVerified) ───────────────────────────────
+
+  describe("SkillScan", () => {
+    const scanBody = JSON.stringify({ content: "echo hi | rm -rf /tmp/x" });
+
+    test("credential-less loopback POST → denied (was 200 pre-fix)", async () => {
+      const res = await fetch(`${harper.httpURL}/SkillScan`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: scanBody,
+      });
+      const text = await res.text();
+      expect(res.status, `anon POST /SkillScan returned ${res.status}: ${text.slice(0, 200)}`).toBe(403);
+    }, 30_000);
+
+    test("non-admin verified agent POST → authorized (any verified agent, not admin-only)", async () => {
+      const path = "/SkillScan";
+      const res = await fetch(`${harper.httpURL}${path}`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json", Authorization: ed25519Header(nonAdmin, "POST", path) },
+        body: scanBody,
+      });
+      const text = await res.text();
+      expect(res.status, `non-admin POST ${path} returned ${res.status}: ${text.slice(0, 200)}`).toBe(200);
+      const body = JSON.parse(text);
+      expect(typeof body.safe).toBe("boolean");
+      expect(Array.isArray(body.violations)).toBe(true);
+    }, 30_000);
+
+    test("admin verified agent POST → authorized", async () => {
+      const path = "/SkillScan";
+      const res = await fetch(`${harper.httpURL}${path}`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json", Authorization: ed25519Header(admin, "POST", path) },
+        body: scanBody,
+      });
+      expect(res.status, `admin POST ${path} returned ${res.status}`).toBe(200);
+    }, 30_000);
+  });
+});

--- a/test/unit/resource-allow-decision.test.ts
+++ b/test/unit/resource-allow-decision.test.ts
@@ -61,25 +61,24 @@ const SRC = (f: string) => readFileSync(join(RESOURCES_DIR, f), "utf8");
  * NO allow* override of their own anywhere in the prototype chain — i.e.
  * fall through to Harper's default `user?.role.permission.super_user`.
  *
- * IMPORTANT — these are NOT a "these are fine, ship it" sign-off. Building
- * this test (2026-07-07) surfaced four resources with zero allow-decision
- * that were NOT in the previously-known list of 7 patched instances. Under
- * Harper's default, each is reachable by the authorizeLocal-forged loopback
- * super_user (same mechanism as #601/#604/#609/#612) but NOT by a genuine
- * remote unauthenticated caller (Harper's default denies non-super_user).
- * They are listed here — a conscious, cited entry — SPECIFICALLY so this
- * test passes today without silently blessing the gap, and so the next
- * person reads this comment instead of rediscovering the bug a 5th time.
- * Flagged to Flint in the flair#614 PR for a follow-up security fix; do not
- * add to this list without the same treatment (a citation + a plan to close
- * it), and remove an entry the moment its resource gets a real allow* gate.
+ * IMPORTANT — these are NOT a "these are fine, ship it" sign-off. Under
+ * Harper's default, each entry here is reachable by the authorizeLocal-forged
+ * loopback super_user (same mechanism as #601/#604/#609/#612) but NOT by a
+ * genuine remote unauthenticated caller (Harper's default denies
+ * non-super_user). Entries require a conscious, cited addition (a citation +
+ * a plan to close it) — SPECIFICALLY so the next person reads this comment
+ * instead of rediscovering the bug again — and must be removed the moment
+ * the resource gets a real allow* gate.
+ *
+ * 2026-07-07: the four resources first found here (FederationInstance,
+ * FederationPeers, HealthDetail, SkillScan) were gated (allowAdmin /
+ * allowVerified as fit each resource's sensitivity — see Federation.ts,
+ * health.ts, SkillScan.ts) and removed from this list; see the flair#614
+ * backstop follow-up PR. This list is currently empty — kept as a named,
+ * empty Record (rather than deleted) so the mechanism has an obvious home
+ * if a future resource genuinely needs this treatment.
  */
-const NEEDS_HUMAN_REVIEW: Record<string, string> = {
-  "FederationInstance": "Federation.ts — GET returns {id, publicKey, role, status}, no allow* at all. Low-sensitivity (peer-discovery identity, same shape as AgentCard) but not verified as a deliberate public decision anywhere in the code — just an absent gate. Loopback-forgery reachable.",
-  "FederationPeers": "Federation.ts — GET returns full peer list (id, role, status, endpoint, lastSyncAt, lastMergeAt, relayOnly, pairedAt), no allow* at all, and the docstring literally calls it '(admin view)' — reads like an intended admin gate that was never added. Loopback-forgery reachable.",
-  "HealthDetail": "health.ts — no allow* at all. get() computes `isAdmin = request?.tpsAgentIsAdmin === true || !callerAgent` — the `|| !callerAgent` means an UNRESOLVED caller (not just an authenticated non-admin) defaults to isAdmin=true internally. Harper's default allowRead still denies a genuine unauthenticated remote caller (no super_user), so this is loopback-forgery-reachable, not remotely exploitable — but the isAdmin fallback direction (missing-caller -> true) is backwards from every other resource's pattern in this codebase and deserves its own look.",
-  "SkillScan": "SkillScan.ts — POST content-safety scanner, no allow* at all. Doesn't touch agent/memory data (stateless text scan), so the blast radius of the same loopback-forgery gap is low, but it's still an unguarded default rather than a decision.",
-};
+const NEEDS_HUMAN_REVIEW: Record<string, string> = {};
 
 /**
  * True public-by-design resources go here ONLY if they do NOT already


### PR DESCRIPTION
## Summary

flair#614's CI backstop (`test/unit/resource-allow-decision.test.ts`) surfaced four resources with **zero** `allow*` override — silently falling through to Harper's own default (`user?.role.permission.super_user`), which is satisfiable by a genuine admin **or** by Harper's `authorizeLocal: true` forging `request.user` to a super_user identity for any credential-less **loopback** request. Same escalation class as #601/#604/#609/#612.

Verified empirically pre-fix (bare `fetch`, no `Authorization` header at all, from loopback):

- `GET /FederationInstance` → 200, full instance identity
- `GET /FederationPeers` → 200, full peer list (docstring already called this "(admin view)")
- `GET /HealthDetail` → 200, full stats **with `caller.isAdmin: true`** — the resource's own internal computation (`isAdmin = tpsAgentIsAdmin === true || !callerAgent`) treats an *unresolved* caller as admin, backwards from every other resource in this codebase
- `POST /SkillScan` → 200, working scan result

All four are **loopback-only reachable** — a genuine remote unauthenticated caller is still denied by Harper's own default. Not remotely exploitable, but a real gap between documented intent (HealthDetail's and SkillScan's own docstrings both claim auth is required) and what was actually enforced (nothing).

## Fix

- `FederationInstance` / `FederationPeers` → `allowRead()=allowAdmin` — matches `AdminInstance.ts`/`AdminDashboard.ts`'s idiom (admin-view endpoints; `ObservationCenter`'s own JS already prompts for admin-pass before hitting `/FederationPeers`).
- `HealthDetail` → `allowRead()=allowVerified` (matches its own docstring) **+ fixes the backwards `isAdmin` default**: replaced the ad hoc `tpsAgentIsAdmin === true || !callerAgent` with the shared three-way `resolveAgentAuth()` verdict (`internal`/`agent`/`anonymous`) — an unresolved/anonymous caller is never treated as admin.
- `SkillScan` → `allowCreate()=allowVerified` (matches its own docstring — stateless scanner, no agent/memory data touched, any verified agent may call it).
- Retired all four from `NEEDS_HUMAN_REVIEW` in `test/unit/resource-allow-decision.test.ts`.
- New `test/integration/gate4-authgate.test.ts` (real spawned Harper): credential-less/cross-agent reads denied, legitimate admin/verified access still works, for all four.

Closes #631.

## Flagged — not fixed here, needs its own decision

`src/cli.ts`'s `api()` helper deliberately skips sending *any* auth header for local targets, relying entirely on `authorizeLocal` so the CLI works out of the box against a local Flair. `flair federation status/pair/prune/reachability` and the periodic `runFederationSyncOnce` (`flair federation sync`) all call `GET /FederationInstance`/`GET /FederationPeers` through this helper. Once those two require `allowAdmin`, a local CLI invocation with no `FLAIR_AGENT_ID`+key or `FLAIR_ADMIN_PASS` in its environment now gets **403** instead of silently riding the forged-admin passthrough. Filed as a note on #631 — needs a coordinated CLI-side fix before/alongside broad rollout if any deployment relies on credential-less local federation CLI usage.

## Test plan

- [x] `bun run build && bun run build:cli` clean
- [x] `bunx tsc --noEmit -p tsconfig.check.json` clean
- [x] `bun test test/unit/` — 1720/1720 pass (incl. updated `resource-allow-decision.test.ts` — the 4 now pass without the allowlist)
- [x] `bun test test/integration/` — 221/221 pass across 26 files (incl. new `gate4-authgate.test.ts`, 12/12) against real spawned Harper
- [ ] Kern (architecture) + Sherlock (security) review

🤖 Generated with [Claude Code](https://claude.com/claude-code)
