### PR TITLE
ci: wire the remaining 5 packages' tests into CI (generalize #605)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -71,6 +71,33 @@ jobs:
         run: cd packages/flair-client && bun run build
       - name: "flair-mcp package tests"
         run: cd packages/flair-mcp && bun test
+      # The other 5 packages (flair-client, langgraph-flair, n8n-nodes-flair,
+      # openclaw-flair, pi-flair) also have real test suites CI only typechecked
+      # (#619, generalizing #605/#491's fix for flair-mcp). flair-client's own
+      # tests import its source directly, so the build above isn't required for
+      # it — but langgraph-flair, n8n-nodes-flair, openclaw-flair, and pi-flair
+      # all depend on the WORKSPACE package @tpsdev-ai/flair-client, which
+      # resolves via its package.json main → dist/index.js (bun workspace
+      # symlinks point at source, not emitted JS): confirmed by temporarily
+      # unbuilding flair-client, which broke openclaw-flair's test with
+      # "Cannot find module '@tpsdev-ai/flair-client'". The build step above
+      # already covers all four. All five suites are hermetic (pure-logic
+      # assertions / mocked fetch, no live Flair daemon or network I/O) and
+      # were verified green on main before wiring here.
+      - name: "flair-client package tests"
+        run: cd packages/flair-client && bun test
+      - name: "Remaining workspace package tests (flair-client dep already built above)"
+        run: |
+          FAIL=0
+          for pkg in langgraph-flair n8n-nodes-flair openclaw-flair pi-flair; do
+            echo "::group::test $pkg"
+            (cd "packages/$pkg" && bun test) || FAIL=1
+            echo "::endgroup::"
+          done
+          if [ "$FAIL" -ne 0 ]; then
+            echo "::error::One or more workspace packages have failing tests"
+            exit 1
+          fi
 
   test-integration:
     name: Integration Tests


### PR DESCRIPTION
## Summary
- `flair-mcp` got wired into `test-unit` by #605 (closing #491); the other 5 workspace packages (`flair-client`, `langgraph-flair`, `n8n-nodes-flair`, `openclaw-flair`, `pi-flair`) had real `bun test` suites CI only typechecked, so a regression in any of their test files couldn't block a merge.
- Adds two steps to the existing `test-unit` job: `flair-client package tests` (runs directly against source, no build needed) and a loop over the other four (`langgraph-flair`, `n8n-nodes-flair`, `openclaw-flair`, `pi-flair`), which all depend on the workspace `@tpsdev-ai/flair-client` package — resolved via its `package.json` `main` → `dist/index.js`, already built by the pre-existing flair-mcp step above it, so no extra build step was needed.
- Confirmed the build-dependency by temporarily unbuilding `flair-client` locally: `openclaw-flair`'s test failed with `Cannot find module '@tpsdev-ai/flair-client'`, proving the ordering matters.

## Test plan
- [x] All 5 suites run green locally on `main` before wiring: `flair-client` 40/40, `langgraph-flair` 40/40 (2 files), `n8n-nodes-flair` 31/31 (4 files), `openclaw-flair` 40/40, `pi-flair` 27/27.
- [x] Simulated the new `test-unit` steps end-to-end locally in sequence (build flair-client → flair-mcp tests → flair-client tests → loop over remaining 4) — all green.
- [x] Deliberate break-and-revert proof (#619 acceptance criteria): added a failing assertion to `pi-flair`'s suite, confirmed the loop step's `FAIL=1` / `exit 1` catches it, then reverted and re-confirmed green.
- [x] Validated `.github/workflows/test.yml` parses as valid YAML (`js-yaml`).

Closes #619

🤖 Generated with [Claude Code](https://claude.com/claude-code)