### PR TITLE
fix(cli): api() sends local credentials instead of riding authorizeLocal (#634)

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -186,6 +186,9 @@ function defaultAdminPassPath(): string {
 /**
  * Resolve an admin password for LOCAL-only CLI convenience (`agent add`,
  * `principal add`) without requiring `--admin-pass` on every call (#590).
+ * Also reused by `api()`'s local-target auth fallback (flair#634) — called
+ * there as `resolveLocalAdminPass(undefined, !isLocal)`, so only its file leg
+ * ever fires (the env leg is already handled by `api()` itself first).
  *
  * Resolution order: explicit value (the `--admin-pass` flag) → `FLAIR_ADMIN_PASS`
  * env → the secure `~/.flair/admin-pass` file `flair init` already writes with
@@ -416,12 +419,22 @@ async function api(method: string, path: string, body?: any, options?: { baseUrl
   const base = options?.baseUrl ?? (process.env.FLAIR_URL || defaultUrl);
   const isLocal = isLocalBase(base);
 
-  // Auth resolution order:
+  // Auth resolution order (flair#634 — local targets used to send NO auth at
+  // all here and ride Harper's authorizeLocal forged super_user; #632 gated
+  // FederationInstance/FederationPeers behind allowAdmin, so credential-less
+  // local calls to those now 403 instead of silently passing):
   // 1. FLAIR_TOKEN env → Bearer token (backward compat)
-  // 2. FLAIR_ADMIN_PASS / HDB_ADMIN_PASSWORD env → Basic admin auth (remote targets only).
-  //    For local targets with authorizeLocal=true, skip Basic auth and let Harper handle it.
+  // 2. FLAIR_ADMIN_PASS / HDB_ADMIN_PASSWORD env → Basic admin auth. Applies to
+  //    BOTH local and remote targets — an explicit env var always wins, local
+  //    included, so a caller that sets it never depends on authorizeLocal.
   // 3. FLAIR_AGENT_ID env + key file → Ed25519 signature (standard)
-  // 4. No auth (Harper authorizeLocal handles local; remote will 401)
+  // 4. LOCAL TARGETS ONLY: the secure ~/.flair/admin-pass file `flair init`
+  //    writes (#593) → Basic admin auth, via the same resolveLocalAdminPass
+  //    convenience `agent add`/`principal add` already use (#590). Guarded to
+  //    isLocal so a --target/FLAIR_URL request aimed elsewhere never rides
+  //    this machine's local admin secret.
+  // 5. No auth (remote will 401/403; local now also gets a real 403 from
+  //    #632-gated resources instead of the old forged-admin passthrough)
   //
   // NOTE: this function is for the Harper HTTP/REST API only. The Harper
   // operations API (used by seedAgentViaOpsApi / seedFederationInstanceViaOpsApi)
@@ -432,7 +445,7 @@ async function api(method: string, path: string, body?: any, options?: { baseUrl
   const token = process.env.FLAIR_TOKEN;
   if (token) {
     authHeader = `Bearer ${token}`;
-  } else if (!isLocal && (process.env.FLAIR_ADMIN_PASS || process.env.HDB_ADMIN_PASSWORD)) {
+  } else if (process.env.FLAIR_ADMIN_PASS || process.env.HDB_ADMIN_PASSWORD) {
     // Admin Basic auth — used by federation, backup, and other admin CLI commands
     const adminPass = process.env.FLAIR_ADMIN_PASS ?? process.env.HDB_ADMIN_PASSWORD!;
     authHeader = `Basic ${Buffer.from(`admin:${adminPass}`).toString("base64")}`;
@@ -457,6 +470,25 @@ async function api(method: string, path: string, body?: any, options?: { baseUrl
         }
       }
     }
+
+    // Local-only fallback (flair#634): no explicit env, no usable agent key.
+    // FLAIR_ADMIN_PASS/HDB_ADMIN_PASSWORD are already ruled out by this point
+    // (handled above), so resolveLocalAdminPass's env leg is a no-op here and
+    // this only ever resolves the ~/.flair/admin-pass file — isRemoteTarget
+    // is `!isLocal` so it's skipped entirely for --target/FLAIR_URL requests.
+    if (!authHeader) {
+      try {
+        const filePass = resolveLocalAdminPass(undefined, !isLocal);
+        if (filePass) {
+          authHeader = `Basic ${Buffer.from(`admin:${filePass}`).toString("base64")}`;
+        }
+      } catch (err: unknown) {
+        // File exists but has unsafe permissions — warn (never the secret
+        // itself) and fall through to no-auth.
+        const message = err instanceof Error ? err.message : String(err);
+        console.error(`Warning: ~/.flair/admin-pass unusable: ${message}`);
+      }
+    }
   }
 
   const res = await fetch(`${base}${path}`, {
@@ -473,7 +505,19 @@ async function api(method: string, path: string, body?: any, options?: { baseUrl
     return { ok: true };
   }
   const text = await res.text();
-  if (!res.ok) throw new Error(text || `HTTP ${res.status}`);
+  if (!res.ok) {
+    // 403 with no credentials sent at all is the flair#634 case: a gated
+    // resource (e.g. #632's FederationInstance/FederationPeers) rejected a
+    // credential-less call. Name the fix instead of surfacing the raw
+    // "forbidden" body — never a stack trace.
+    if (res.status === 403 && !authHeader) {
+      const hint = isLocal
+        ? "Set FLAIR_ADMIN_PASS, or run `flair init` to provision ~/.flair/admin-pass."
+        : "Set FLAIR_ADMIN_PASS (remote targets have no local admin-pass fallback).";
+      throw new Error(`HTTP 403: no credentials sent. ${hint}`);
+    }
+    throw new Error(text || `HTTP ${res.status}`);
+  }
   if (!text) return { ok: true };
   return JSON.parse(text);
 }

--- a/test/integration/cli-local-admin-pass-fallback.test.ts
+++ b/test/integration/cli-local-admin-pass-fallback.test.ts
@@ -1,0 +1,127 @@
+// cli-local-admin-pass-fallback.test.ts — Integration test for flair#634
+// (companion to #632 gate-4): the real `flair` CLI, spawned as a subprocess
+// against a REAL Harper instance, exercising the exact regression #634 fixes.
+//
+// BEFORE #634: `api()` in src/cli.ts sent NO Authorization header at all for
+// local targets, riding Harper's authorizeLocal forged super_user. #632 gated
+// FederationInstance/FederationPeers behind allowAdmin (a real permission
+// check — see resources/agent-auth.ts's allowAdmin/resolveAgentAuth), so a
+// credential-less `flair federation status` against a #632-gated instance
+// started getting a real 403 instead of the old forged-admin 200.
+//
+// AFTER #634: api() auto-loads credentials for local targets — FLAIR_ADMIN_PASS/
+// HDB_ADMIN_PASSWORD env, then FLAIR_AGENT_ID+key (Ed25519), then the secure
+// ~/.flair/admin-pass file `flair init` writes (#593) — so a properly
+// provisioned host works zero-config again.
+//
+// This file spawns the REAL CLI entrypoint (src/cli.ts under bun) against a
+// REAL spawned Harper instance (test/helpers/harper-lifecycle, same as
+// gate4-authgate.test.ts), with HOME pointed at an isolated tmpdir so the
+// admin-pass fixture file never touches this machine's real ~/.flair/admin-pass.
+// The "admin password" used below is the test harness's own ephemeral
+// generated Harper credential (harper.admin.password) — not a real secret.
+//
+// MODEL: test/integration/gate4-authgate.test.ts (the #632 gate this is the
+// companion to) + test/unit/agent-add-adminpass-fallback.test.ts's subprocess
+// CLI-spawn pattern (#590's precedent for the same admin-pass-file idiom).
+import { describe, expect, test, beforeAll, afterAll } from "bun:test";
+import { mkdirSync, rmSync, writeFileSync, chmodSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { startHarper, stopHarper, HarperInstance } from "../helpers/harper-lifecycle";
+
+function makeTmpDir(prefix: string): string {
+  const dir = join(tmpdir(), `${prefix}-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+  mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+async function runCli(
+  args: string[],
+  env: Record<string, string | undefined>,
+): Promise<{ stdout: string; stderr: string; exitCode: number }> {
+  const cliPath = join(import.meta.dirname, "..", "..", "src", "cli.ts");
+  // Merge onto a copy of the real env, but explicitly DELETE any key passed
+  // as undefined — guarantees isolation even if the host shell already has
+  // FLAIR_ADMIN_PASS/etc set (must not leak into the "no creds" case).
+  const merged: Record<string, string> = { ...process.env } as Record<string, string>;
+  for (const [k, v] of Object.entries(env)) {
+    if (v === undefined) delete merged[k];
+    else merged[k] = v;
+  }
+  const proc = Bun.spawn(["bun", cliPath, ...args], { env: merged, stdout: "pipe", stderr: "pipe" });
+  const stdout = await new Response(proc.stdout).text();
+  const stderr = await new Response(proc.stderr).text();
+  const exitCode = await proc.exited;
+  return { stdout, stderr, exitCode };
+}
+
+let harper: HarperInstance;
+
+describe("flair#634: CLI api() sends local credentials against a real #632-gated Harper instance", () => {
+  beforeAll(async () => {
+    harper = await startHarper();
+  }, 180_000);
+
+  afterAll(async () => { if (harper) await stopHarper(harper); });
+
+  test("credential-less `flair federation status` is denied (real 403 from #632's allowAdmin gate, not the old forged-admin passthrough)", async () => {
+    const tmpHome = makeTmpDir("flair-634-int-nocreds");
+    try {
+      const { exitCode, stderr, stdout } = await runCli(
+        ["federation", "status", "--target", harper.httpURL],
+        { HOME: tmpHome, FLAIR_ADMIN_PASS: undefined, HDB_ADMIN_PASSWORD: undefined, FLAIR_AGENT_ID: undefined, FLAIR_TOKEN: undefined },
+      );
+      expect(exitCode, `stdout: ${stdout}\nstderr: ${stderr}`).not.toBe(0);
+      // Clear, actionable message — not a stack trace.
+      expect(stderr).toMatch(/flair init|FLAIR_ADMIN_PASS/);
+      expect(stderr).not.toMatch(/\bat .*\.(ts|js):\d+/);
+    } finally {
+      rmSync(tmpHome, { recursive: true, force: true });
+    }
+  }, 30_000);
+
+  test("flair#634 FIX: `flair federation status` succeeds against the SAME gated instance using ONLY ~/.flair/admin-pass (no env, no key)", async () => {
+    const tmpHome = makeTmpDir("flair-634-int-filecreds");
+    try {
+      const flairDir = join(tmpHome, ".flair");
+      mkdirSync(flairDir, { recursive: true });
+      // The test harness's own ephemeral generated Harper admin password —
+      // not a developer secret. This is exactly what `flair init` (#593)
+      // would have written for a real deployment.
+      writeFileSync(join(flairDir, "admin-pass"), harper.admin.password, "utf-8");
+      chmodSync(join(flairDir, "admin-pass"), 0o600);
+
+      const { exitCode, stdout, stderr } = await runCli(
+        ["federation", "status", "--target", harper.httpURL],
+        { HOME: tmpHome, FLAIR_ADMIN_PASS: undefined, HDB_ADMIN_PASSWORD: undefined, FLAIR_AGENT_ID: undefined, FLAIR_TOKEN: undefined },
+      );
+      expect(exitCode, `stdout: ${stdout}\nstderr: ${stderr}`).toBe(0);
+      // Real instance identity was returned (FederationInstance.get() self-
+      // bootstraps on first call) — proves this actually authenticated as
+      // admin against the live #632 gate, not just "didn't crash". Output
+      // mode auto-detects JSON for a non-TTY pipe (render.resolveOutputMode),
+      // so parse rather than match against the human-readable text renderer.
+      const body = JSON.parse(stdout);
+      expect(body.instance?.id).toMatch(/^flair_/);
+      expect(Array.isArray(body.peers)).toBe(true);
+    } finally {
+      rmSync(tmpHome, { recursive: true, force: true });
+    }
+  }, 30_000);
+
+  test("explicit FLAIR_ADMIN_PASS env still works against the same gated instance (existing remote-target behavior, unaffected by #634)", async () => {
+    const tmpHome = makeTmpDir("flair-634-int-envcreds");
+    try {
+      const { exitCode, stdout, stderr } = await runCli(
+        ["federation", "status", "--target", harper.httpURL],
+        { HOME: tmpHome, FLAIR_ADMIN_PASS: harper.admin.password, HDB_ADMIN_PASSWORD: undefined, FLAIR_AGENT_ID: undefined, FLAIR_TOKEN: undefined },
+      );
+      expect(exitCode, `stdout: ${stdout}\nstderr: ${stderr}`).toBe(0);
+      const body = JSON.parse(stdout);
+      expect(body.instance?.id).toMatch(/^flair_/);
+    } finally {
+      rmSync(tmpHome, { recursive: true, force: true });
+    }
+  }, 30_000);
+});

--- a/test/unit/local-no-auth.test.ts
+++ b/test/unit/local-no-auth.test.ts
@@ -1,20 +1,65 @@
 /**
- * local-no-auth.test.ts — Unit tests for implicit local auth skip
+ * local-no-auth.test.ts — Unit tests for api()'s local-target auth behavior,
+ * including the flair#634 credential fallback.
  *
- * When targeting localhost with no admin pass, api() should send no
- * Authorization header. Auth-middleware should let the request through
- * if Harper's authorizeLocal has already set request.user.
+ * Historically, targeting localhost with no admin pass meant api() sent no
+ * Authorization header at all, relying on Harper's authorizeLocal to forge a
+ * super_user for credential-less loopback requests. flair#632 gated
+ * FederationInstance/FederationPeers behind allowAdmin (a real permission
+ * check, not the authorizeLocal escalation), so that forged passthrough no
+ * longer satisfies those resources — a credential-less local call now gets a
+ * real 403.
+ *
+ * flair#634 teaches api() to send real credentials for local targets too, in
+ * precedence order: FLAIR_TOKEN > FLAIR_ADMIN_PASS/HDB_ADMIN_PASSWORD env >
+ * FLAIR_AGENT_ID + key (Ed25519) > the secure ~/.flair/admin-pass file
+ * `flair init` writes (#593, via the same resolveLocalAdminPass convenience
+ * `agent add`/`principal add` use, #590) > no auth as a last resort.
+ *
+ * TWO TEST TECHNIQUES ARE USED HERE, DELIBERATELY:
+ *
+ *  1. In-process mocked-fetch, for env-var-only precedence (FLAIR_TOKEN,
+ *     FLAIR_ADMIN_PASS/HDB_ADMIN_PASSWORD, and the remote-target guard).
+ *     These never reach the ~/.flair/admin-pass file at all — an env var
+ *     wins before the file leg runs, and resolveLocalAdminPass's
+ *     `isRemoteTarget` check short-circuits BEFORE any existsSync/file-read
+ *     when the target isn't local — so home-directory isolation isn't
+ *     needed for these cases.
+ *
+ *  2. Subprocess spawn (matching agent-add-adminpass-fallback.test.ts's
+ *     established pattern), for every case that exercises the admin-pass
+ *     FILE leg. This is required, not stylistic: Bun's `os.homedir()` does
+ *     NOT re-read a live `process.env.HOME` mutation mid-process (verified
+ *     empirically while writing this file — unlike Node, a runtime
+ *     `process.env.HOME = ...` assignment has no effect on subsequent
+ *     `homedir()` calls in the SAME Bun process). An in-process test that
+ *     tries to isolate HOME by mutating the env var therefore silently
+ *     falls through to THIS machine's real `~/.flair/admin-pass` file —
+ *     exactly the file this task must never read. Spawning a subprocess
+ *     with HOME set in its OWN startup environment (via Bun.spawn's `env`
+ *     option) works correctly, because the child resolves `homedir()` from
+ *     its real process environment at its own startup, not from a live
+ *     mutation. All admin-pass fixture files used below live under a fresh
+ *     tmpdir HOME, never under the real one.
  */
 
 import { describe, test, expect, beforeEach, afterEach } from "bun:test";
-
-// We can't import api() directly because cli.ts starts a Commander program
-// on import. Instead we exercise the logic by mocking fetch and checking
-// that local calls omit the Authorization header when no admin pass is set.
-
+import { mkdirSync, rmSync, writeFileSync, chmodSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { createServer, IncomingMessage, ServerResponse, Server } from "node:http";
 import { api } from "../../src/cli.js";
 
-describe("api() local auth behavior", () => {
+function makeTmpDir(prefix: string): string {
+  const dir = join(tmpdir(), `${prefix}-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+  mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+// ─── In-process tests: env-var precedence + remote-target guard ───────────────
+// Safe without HOME isolation — see file header for why.
+
+describe("api() local auth behavior — env-var precedence (in-process)", () => {
   let origFetch: typeof globalThis.fetch;
   let capturedHeaders: Record<string, string> | undefined;
   let capturedUrl: string | undefined;
@@ -42,28 +87,6 @@ describe("api() local auth behavior", () => {
     delete process.env.FLAIR_AGENT_ID;
   });
 
-  test("local call with no admin pass sends no Authorization header", async () => {
-    delete process.env.FLAIR_ADMIN_PASS;
-    delete process.env.HDB_ADMIN_PASSWORD;
-    delete process.env.FLAIR_TOKEN;
-
-    await api("GET", "/Agent", undefined, { baseUrl: "http://127.0.0.1:19926" });
-
-    expect(capturedUrl).toBe("http://127.0.0.1:19926/Agent");
-    expect(capturedHeaders?.authorization).toBeUndefined();
-  });
-
-  test("local call with no admin pass (localhost hostname) sends no Authorization header", async () => {
-    delete process.env.FLAIR_ADMIN_PASS;
-    delete process.env.HDB_ADMIN_PASSWORD;
-    delete process.env.FLAIR_TOKEN;
-
-    await api("GET", "/Agent", undefined, { baseUrl: "http://localhost:19926" });
-
-    expect(capturedUrl).toBe("http://localhost:19926/Agent");
-    expect(capturedHeaders?.authorization).toBeUndefined();
-  });
-
   test("remote call with admin pass sends Basic auth header", async () => {
     process.env.FLAIR_ADMIN_PASS = "secret123";
 
@@ -73,13 +96,21 @@ describe("api() local auth behavior", () => {
     expect(capturedHeaders?.authorization).toStartWith("Basic ");
   });
 
-  test("local call with admin pass env set skips Basic auth (authorizes via authorizeLocal)", async () => {
+  test("flair#634: local call with FLAIR_ADMIN_PASS env set now sends Basic auth (explicit env wins on local too)", async () => {
     process.env.FLAIR_ADMIN_PASS = "secret123";
 
     await api("GET", "/Agent", undefined, { baseUrl: "http://127.0.0.1:19926" });
 
     expect(capturedUrl).toBe("http://127.0.0.1:19926/Agent");
-    expect(capturedHeaders?.authorization).toBeUndefined();
+    expect(capturedHeaders?.authorization).toBe(`Basic ${Buffer.from("admin:secret123").toString("base64")}`);
+  });
+
+  test("flair#634: local call with HDB_ADMIN_PASSWORD env set sends Basic auth", async () => {
+    process.env.HDB_ADMIN_PASSWORD = "secret456";
+
+    await api("GET", "/Agent", undefined, { baseUrl: "http://127.0.0.1:19926" });
+
+    expect(capturedHeaders?.authorization).toBe(`Basic ${Buffer.from("admin:secret456").toString("base64")}`);
   });
 
   test("Bearer token still sent on local when FLAIR_TOKEN is set", async () => {
@@ -90,16 +121,228 @@ describe("api() local auth behavior", () => {
     expect(capturedHeaders?.authorization).toBe("Bearer mytoken");
   });
 
-  test("Ed25519 agent auth still used on local when FLAIR_AGENT_ID and key exist", async () => {
-    // This test verifies the fallback to agent auth isn't broken.
-    // We don't have a real key file, so it falls through to no auth.
+  test("SECURITY GUARD: a remote target's request is never sent an Authorization header when no env auth is configured (structural — resolveLocalAdminPass's isRemoteTarget check short-circuits before any local file is ever consulted, on THIS real machine's actual HOME)", async () => {
     delete process.env.FLAIR_ADMIN_PASS;
     delete process.env.HDB_ADMIN_PASSWORD;
-    process.env.FLAIR_AGENT_ID = "test-agent";
+    delete process.env.FLAIR_TOKEN;
+    delete process.env.FLAIR_AGENT_ID;
 
-    await api("POST", "/Agent", { agentId: "test-agent" }, { baseUrl: "http://127.0.0.1:19926" });
+    await api("GET", "/FederationInstance", undefined, { baseUrl: "https://remote.example.com:19926" });
 
-    // No key file exists for test-agent, so no auth header is sent.
     expect(capturedHeaders?.authorization).toBeUndefined();
+  });
+});
+
+// ─── Subprocess tests: admin-pass FILE leg (requires real HOME isolation) ─────
+
+interface CapturedRequest { method: string; path: string; authorization: string | undefined }
+
+function startMockFederationServer(
+  opts: { instanceStatus?: number; peersStatus?: number } = {},
+): Promise<{ server: Server; url: string; requests: CapturedRequest[] }> {
+  const requests: CapturedRequest[] = [];
+  return new Promise((resolve) => {
+    const server = createServer((req: IncomingMessage, res: ServerResponse) => {
+      requests.push({ method: req.method ?? "", path: req.url ?? "", authorization: req.headers.authorization });
+      const status = req.url?.startsWith("/FederationPeers") ? (opts.peersStatus ?? 200) : (opts.instanceStatus ?? 200);
+      res.writeHead(status, { "Content-Type": "application/json" });
+      if (status !== 200) {
+        res.end(JSON.stringify({ error: "forbidden" }));
+      } else if (req.url?.startsWith("/FederationPeers")) {
+        res.end(JSON.stringify({ peers: [] }));
+      } else {
+        res.end(JSON.stringify({ id: "flair_test", publicKey: "test-pubkey", role: "spoke", status: "active" }));
+      }
+    });
+    server.listen(0, "127.0.0.1", () => {
+      const addr = server.address();
+      const port = typeof addr === "object" && addr ? addr.port : 0;
+      resolve({ server, url: `http://127.0.0.1:${port}`, requests });
+    });
+  });
+}
+
+function stopServer(server: Server): Promise<void> {
+  return new Promise((resolve, reject) => server.close((e) => (e ? reject(e) : resolve())));
+}
+
+async function runCli(
+  args: string[],
+  env: Record<string, string | undefined>,
+): Promise<{ stdout: string; stderr: string; exitCode: number }> {
+  const cliPath = join(import.meta.dirname ?? __dirname, "..", "..", "src", "cli.ts");
+  // Merge onto a copy of the real env, but explicitly DELETE any key passed
+  // as undefined — guarantees isolation even if the host shell already has
+  // FLAIR_ADMIN_PASS/etc set (must not leak into the "no creds" cases).
+  const merged: Record<string, string> = { ...process.env } as Record<string, string>;
+  for (const [k, v] of Object.entries(env)) {
+    if (v === undefined) delete merged[k];
+    else merged[k] = v;
+  }
+  const proc = Bun.spawn(["bun", cliPath, ...args], { env: merged, stdout: "pipe", stderr: "pipe" });
+  const stdout = await new Response(proc.stdout).text();
+  const stderr = await new Response(proc.stderr).text();
+  const exitCode = await proc.exited;
+  return { stdout, stderr, exitCode };
+}
+
+describe("api() local auth behavior — admin-pass file fallback (subprocess, isolated HOME)", () => {
+  let tmpHome: string;
+  let server: Server;
+  let serverUrl: string;
+  let requests: CapturedRequest[];
+
+  beforeEach(async () => {
+    tmpHome = makeTmpDir("flair-634-adminpass-home");
+    const started = await startMockFederationServer();
+    server = started.server;
+    serverUrl = started.url;
+    requests = started.requests;
+  });
+
+  afterEach(async () => {
+    await stopServer(server);
+    try { rmSync(tmpHome, { recursive: true, force: true }); } catch { /* best-effort cleanup */ }
+  });
+
+  function writeAdminPassFile(content: string, mode = 0o600): void {
+    const flairDir = join(tmpHome, ".flair");
+    mkdirSync(flairDir, { recursive: true });
+    const p = join(flairDir, "admin-pass");
+    writeFileSync(p, content, "utf-8");
+    chmodSync(p, mode);
+  }
+
+  async function writeAgentKey(agentId: string): Promise<void> {
+    const keysDir = join(tmpHome, ".flair", "keys");
+    mkdirSync(keysDir, { recursive: true });
+    const nacl = (await import("tweetnacl")).default;
+    const kp = nacl.sign.keyPair();
+    const seed = kp.secretKey.slice(0, 32);
+    writeFileSync(join(keysDir, `${agentId}.key`), Buffer.from(seed));
+    chmodSync(join(keysDir, `${agentId}.key`), 0o600);
+  }
+
+  test("no admin-pass file, no env: local call sends no Authorization header", async () => {
+    const { exitCode } = await runCli(
+      ["federation", "status", "--target", serverUrl],
+      { HOME: tmpHome, FLAIR_ADMIN_PASS: undefined, HDB_ADMIN_PASSWORD: undefined, FLAIR_AGENT_ID: undefined, FLAIR_TOKEN: undefined },
+    );
+
+    expect(exitCode).toBe(0);
+    expect(requests.length).toBeGreaterThan(0);
+    expect(requests[0].authorization).toBeUndefined();
+  });
+
+  test("flair#634: falls back to the ~/.flair/admin-pass file when no env/agent key is set", async () => {
+    writeAdminPassFile("file-secret-pass\n");
+
+    const { exitCode } = await runCli(
+      ["federation", "status", "--target", serverUrl],
+      { HOME: tmpHome, FLAIR_ADMIN_PASS: undefined, HDB_ADMIN_PASSWORD: undefined, FLAIR_AGENT_ID: undefined },
+    );
+
+    expect(exitCode).toBe(0);
+    expect(requests[0].authorization).toBe(`Basic ${Buffer.from("admin:file-secret-pass").toString("base64")}`);
+  });
+
+  test("precedence: FLAIR_ADMIN_PASS env wins over the admin-pass file", async () => {
+    writeAdminPassFile("file-secret-pass\n");
+
+    const { exitCode } = await runCli(
+      ["federation", "status", "--target", serverUrl],
+      { HOME: tmpHome, FLAIR_ADMIN_PASS: "env-secret-pass", HDB_ADMIN_PASSWORD: undefined, FLAIR_AGENT_ID: undefined },
+    );
+
+    expect(exitCode).toBe(0);
+    expect(requests[0].authorization).toBe(`Basic ${Buffer.from("admin:env-secret-pass").toString("base64")}`);
+  });
+
+  test("precedence: a resolved FLAIR_AGENT_ID + real key wins over the admin-pass file", async () => {
+    await writeAgentKey("test-agent-634");
+    writeAdminPassFile("file-secret-pass\n");
+
+    const { exitCode } = await runCli(
+      ["federation", "status", "--target", serverUrl],
+      { HOME: tmpHome, FLAIR_ADMIN_PASS: undefined, HDB_ADMIN_PASSWORD: undefined, FLAIR_AGENT_ID: "test-agent-634" },
+    );
+
+    expect(exitCode).toBe(0);
+    expect(requests[0].authorization).toStartWith("TPS-Ed25519 ");
+  });
+
+  test("precedence: file beats nothing — falls back to the file when Ed25519 resolution fails (no key on disk for the agent)", async () => {
+    writeAdminPassFile("file-secret-pass\n");
+
+    const { exitCode } = await runCli(
+      ["federation", "status", "--target", serverUrl],
+      { HOME: tmpHome, FLAIR_ADMIN_PASS: undefined, HDB_ADMIN_PASSWORD: undefined, FLAIR_AGENT_ID: "no-such-agent" },
+    );
+
+    expect(exitCode).toBe(0);
+    expect(requests[0].authorization).toBe(`Basic ${Buffer.from("admin:file-secret-pass").toString("base64")}`);
+  });
+
+  test("missing admin-pass file (no ~/.flair dir at all) falls through cleanly to no auth, no crash", async () => {
+    // tmpHome has no .flair dir — existsSync() guard inside resolveLocalAdminPass
+    // short-circuits before readAdminPassFileSecure would throw "does not exist".
+    const { exitCode, stderr } = await runCli(
+      ["federation", "status", "--target", serverUrl],
+      { HOME: tmpHome, FLAIR_ADMIN_PASS: undefined, HDB_ADMIN_PASSWORD: undefined, FLAIR_AGENT_ID: undefined },
+    );
+
+    expect(exitCode).toBe(0);
+    expect(stderr).not.toContain("does not exist");
+    expect(requests[0].authorization).toBeUndefined();
+  });
+
+  test("unreadable/unsafe-permission admin-pass file falls through to no auth (warns, never crashes, never echoes the secret)", async () => {
+    writeAdminPassFile("file-secret-pass\n", 0o644);
+
+    const { exitCode, stderr } = await runCli(
+      ["federation", "status", "--target", serverUrl],
+      { HOME: tmpHome, FLAIR_ADMIN_PASS: undefined, HDB_ADMIN_PASSWORD: undefined, FLAIR_AGENT_ID: undefined },
+    );
+
+    expect(exitCode).toBe(0);
+    expect(requests[0].authorization).toBeUndefined();
+    expect(stderr).toContain("permissions 644 are too open");
+    // Never echo the credential value itself, even in a warning.
+    expect(stderr).not.toContain("file-secret-pass");
+  });
+
+  test("flair#634: 403 with no credentials available prints a clear actionable message, not a stack trace", async () => {
+    await stopServer(server);
+    const started = await startMockFederationServer({ instanceStatus: 403 });
+    server = started.server;
+    serverUrl = started.url;
+    requests = started.requests;
+
+    const { exitCode, stderr } = await runCli(
+      ["federation", "status", "--target", serverUrl],
+      { HOME: tmpHome, FLAIR_ADMIN_PASS: undefined, HDB_ADMIN_PASSWORD: undefined, FLAIR_AGENT_ID: undefined },
+    );
+
+    expect(exitCode).toBe(1);
+    expect(stderr).toMatch(/flair init|FLAIR_ADMIN_PASS/);
+    // Not a raw stack trace: no "at <anonymous>" / source-file frame lines.
+    expect(stderr).not.toMatch(/\bat .*\.(ts|js):\d+/);
+  });
+
+  test("403 with credentials already sent (wrong password) surfaces the server's own error, not the no-creds hint", async () => {
+    await stopServer(server);
+    const started = await startMockFederationServer({ instanceStatus: 403 });
+    server = started.server;
+    serverUrl = started.url;
+    requests = started.requests;
+
+    const { exitCode, stderr } = await runCli(
+      ["federation", "status", "--target", serverUrl],
+      { HOME: tmpHome, FLAIR_ADMIN_PASS: "wrong-pass", HDB_ADMIN_PASSWORD: undefined, FLAIR_AGENT_ID: undefined },
+    );
+
+    expect(exitCode).toBe(1);
+    expect(stderr).toContain("forbidden");
+    expect(stderr).not.toContain("no credentials sent");
   });
 });


### PR DESCRIPTION
## Summary

Companion to #632. `api()` in `src/cli.ts` deliberately sent no auth header for local targets, riding Harper's `authorizeLocal` forged super_user. With `FederationInstance`/`FederationPeers` now gated `allowAdmin`, credential-less local invocations of `flair federation status/pair/prune/reachability/sync` got 403.

`api()` now resolves credentials for local targets, in precedence order:

1. Explicit env (`FLAIR_ADMIN_PASS` / `HDB_ADMIN_PASSWORD`) — the `!isLocal` guard on this branch is removed, so explicit env now wins locally too
2. Existing Ed25519 agent path (unchanged)
3. **Local targets only:** the `~/.flair/admin-pass` file `flair init` writes (#593), resolved via the existing `resolveLocalAdminPass()` (#590's idiom — already encodes the never-for-remote guard and is independently unit-tested)
4. No credentials → unchanged no-auth request; a 403 now surfaces an actionable message naming `flair init` / `FLAIR_ADMIN_PASS` instead of the raw server body

Credential values are never logged or echoed; an unusable admin-pass file warns (message only, no content) and falls through.

## Test plan

- [x] `bun run build` && `bun run build:cli` clean
- [x] `bunx tsc --noEmit -p tsconfig.check.json` clean
- [x] `bun test test/unit/` — 1728/1728 pass (incl. rewritten `local-no-auth.test.ts`: precedence, missing/unreadable file fallthrough, remote-never-gets-file-creds, 403 messaging)
- [x] `bun test test/integration/` — 224/224 pass (incl. new `cli-local-admin-pass-fallback.test.ts`: real spawned Harper, #632-gated FederationInstance/FederationPeers succeed with only an admin-pass fixture file, denied with none; fixture HOME isolation via subprocess spawn — never touches the host's real file)
- [ ] Kern (architecture) + Sherlock (security) review

Closes #634.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
