### PR TITLE
feat(cli): flair fleet verify — post-deploy fleet convergence sweep (#636)

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -26,6 +26,12 @@ import { deploy as deployToFabric, validateOptions as validateDeployOptions, bui
 import { fabricUpgrade } from "./fabric-upgrade.js";
 import { checkVersion, formatVersionNudge } from "./version-check.js";
 import { probeInstance, type ProbeResult } from "./probe.js";
+import {
+  sweepFleet,
+  renderFleetSweepTable,
+  FLEET_EXIT_OK,
+  type FleetSweepResult,
+} from "./fleet-verify.js";
 import { detectClients, wireClaudeCode, wireCodex, wireGemini, wireCursor, type ClientId } from "./install/clients.js";
 import {
   readClientMcpBlock,
@@ -1537,6 +1543,17 @@ export function resolveUpgradeRestartVerify(opts: { restart?: boolean; verify?: 
     verify: opts.verify !== false,
     deprecatedRestartFlagUsed: opts.restart === true,
   };
+}
+
+/**
+ * Whether `flair deploy` / `flair upgrade --target` should run the
+ * post-deploy fleet convergence sweep (flair#636). Registering
+ * `--no-fleet-verify` via commander leaves `opts.fleetVerify` undefined when
+ * unset, `false` when the flag is passed — mirrors resolveUpgradeRestartVerify's
+ * `!== false` default-true idiom above.
+ */
+export function shouldRunFleetVerify(opts: { fleetVerify?: boolean }): boolean {
+  return opts.fleetVerify !== false;
 }
 
 /**
@@ -6500,6 +6517,29 @@ async function runFabricUpgrade(opts: any): Promise<void> {
       return;
     }
     console.log(`\n${green("✓")} Fabric upgrade complete.`);
+
+    // ── Post-upgrade fleet sweep (flair#636) ────────────────────────────────
+    // "deploy complete" from harper's own CLI means "origin took it" — this
+    // confirms every known federation peer actually converged on the version
+    // we just deployed, instead of trusting a single boolean. Skippable with
+    // --no-fleet-verify. fabricUser/fabricPassword are guaranteed set here —
+    // the !check branch above already required both.
+    if (!shouldRunFleetVerify(opts)) {
+      console.log(dim("(--no-fleet-verify: skipping post-upgrade fleet sweep)"));
+    } else {
+      console.log(`\n${green("→")} Fleet verify`);
+      const sweep = await sweepFleet({
+        target: upgradeOpts.target,
+        fabricUser: fabricUser as string,
+        fabricPassword: fabricPassword as string,
+        expectVersion: result.plan.targetVersion,
+      });
+      console.log(renderFleetSweepTable(sweep));
+      if (sweep.exitCode !== FLEET_EXIT_OK) {
+        console.error(red(`\n✗ fleet verify failed (exit ${sweep.exitCode}) — upgrade is NOT fully converged.`));
+        process.exit(sweep.exitCode);
+      }
+    }
   } catch (err: any) {
     console.error(red(`\n✗ fabric upgrade failed: ${err.message}`));
     const hint = err.message?.toLowerCase() ?? "";
@@ -6532,6 +6572,7 @@ program
   .option("--project <name>", "Fabric component name for --target", "flair")
   .option("--no-replicated", "Disable cluster-wide replication for --target (default: replicated=true)")
   .option("--yes", "Skip the confirmation prompt for --target")
+  .option("--no-fleet-verify", "Skip the automatic post-upgrade fleet convergence sweep for --target (default: sweep runs — see flair#636)")
   .action(async (opts) => {
     // ── Fabric-upgrade branch ───────────────────────────────────────────────
     if (opts.target) {
@@ -7453,6 +7494,7 @@ program
   .option("--verify-resource <name>", "Resource to verify is serving after deploy (repeatable; default: derived from the deployed package's dist/resources)", (val: string, prev: string[]) => [...prev, val], [] as string[])
   .option("--deploy-retries <n>", "Retry the full harper deploy this many times on a detected flaky peer-replication failure ONLY — a normal deploy failure (auth, bad package, ...) never retries (default: 2; 0 disables)", "2")
   .option("--ignore-replication-errors", "If peer replication is still failing once retries are exhausted, treat it as a non-fatal warning and succeed with an origin-only deploy (the peer catches up via federation sync or a later deploy)")
+  .option("--no-fleet-verify", "Skip the automatic post-deploy fleet convergence sweep (default: sweep runs — see flair#636)")
   .action(async (opts) => {
     const green = (s: string) => `\x1b[32m${s}\x1b[0m`;
     const red = (s: string) => `\x1b[31m${s}\x1b[0m`;
@@ -7515,6 +7557,35 @@ program
       }
       console.log(`\n  URL:     ${result.url}`);
       console.log(`  Project: ${result.project}`);
+
+      // ── Post-deploy fleet sweep (flair#636) ─────────────────────────────
+      // Harper's own "Successfully deployed" (and the served-API verify
+      // above) only confirm the ORIGIN. This sweeps the origin + every known
+      // federation peer for actual version/health convergence — the gap that
+      // let the 0.21.0 deploy report success while a peer was still throwing
+      // 1006s. Skippable with --no-fleet-verify. Needs Basic-auth creds
+      // (fabricUser+fabricPassword) — a --fabric-token-only deploy has no way
+      // to authenticate the sweep, so it's skipped with a note instead of a
+      // silent no-op.
+      if (!shouldRunFleetVerify(opts)) {
+        console.log(dim("\n(--no-fleet-verify: skipping post-deploy fleet sweep)"));
+      } else if (!deployOpts.fabricUser || !deployOpts.fabricPassword) {
+        console.log(dim("\n(skipping fleet verify — no --fabric-user/--fabric-password to authenticate the sweep; only --fabric-token was provided)"));
+      } else {
+        console.log(`\n${green("→")} Fleet verify`);
+        const sweep = await sweepFleet({
+          target: result.url,
+          fabricUser: deployOpts.fabricUser,
+          fabricPassword: deployOpts.fabricPassword,
+          expectVersion: result.version,
+        });
+        console.log(renderFleetSweepTable(sweep));
+        if (sweep.exitCode !== FLEET_EXIT_OK) {
+          console.error(red(`\n✗ fleet verify failed (exit ${sweep.exitCode}) — deploy is NOT fully converged.`));
+          process.exit(sweep.exitCode);
+        }
+      }
+
       console.log(`\nNext steps:`);
       console.log(dim(`  1. Set an admin password in Fabric Studio (Cluster Settings → Admin)`));
       console.log(dim(`  2. Seed your first agent:`));
@@ -7536,6 +7607,71 @@ program
       }
       process.exit(1);
     }
+  });
+
+// ─── flair fleet ──────────────────────────────────────────────────────────────
+//
+// Fabric fleet operations (flair#636). `flair deploy` / `flair upgrade
+// --target` already run this sweep automatically post-deploy (skippable
+// with --no-fleet-verify) — this is the standalone entry point for running
+// it independently, e.g. as a periodic health check or before a rolling
+// restart step (see the flair#636 decision comment: this sweep is the gate
+// between peers during a rolling restart, not the restart mechanism itself).
+const fleet = program.command("fleet").description("Fabric fleet operations (post-deploy convergence verification)");
+
+fleet
+  .command("verify")
+  .description("Sweep a Fabric origin + its known federation peers for version/health convergence")
+  .requiredOption("--target <url>", "Fabric URL to verify (the origin node)")
+  .option("--fabric-user <user>", "Fabric admin username (env: FABRIC_USER)")
+  .option("--fabric-password <pass>", "Fabric admin password (env: FABRIC_PASSWORD)")
+  .option("--expect-version <semver>", "Version every node must report (default: the origin's own reported version — a self-consistency check)")
+  .option("--timeout <ms>", "Per-node /Health poll timeout in ms", "60000")
+  .option("--json", "Emit JSON (also: pipe + FLAIR_OUTPUT=json)")
+  .addHelpText("after", `
+Exit codes:
+  0  all nodes verified: healthy, authenticated, and version-matched
+  1  origin failed (unreachable, unauthenticated, or wrong version)
+  2  origin OK, but a reachable peer is running a DIFFERENT version (skew)
+  3  origin OK, no skew among reachable peers, but a peer could not be
+     verified at all (unreachable, auth rejected, or no endpoint on file)
+
+"peer" here means a Flair federation peer (GET /FederationPeers on the
+origin) — NOT Harper's own cluster-replication nodes, which the OSS
+@harperfast/harper build this CLI ships does not expose (cluster_status is
+a harper-pro-only operation). A Fabric replica that was never
+federation-paired (\`flair federation pair\`) is invisible to this sweep —
+see src/fleet-verify.ts's file header for the full caveat.`)
+  .action(async (opts) => {
+    const fabricUser = opts.fabricUser ?? process.env.FABRIC_USER;
+    const fabricPassword = opts.fabricPassword ?? process.env.FABRIC_PASSWORD;
+
+    if (!fabricUser || !fabricPassword) {
+      console.error(render.wrap(render.c.red, "flair fleet verify: credentials required"));
+      console.error("  pass --fabric-user + --fabric-password (or FABRIC_USER / FABRIC_PASSWORD env)");
+      process.exit(1);
+    }
+    // Warn on password-via-flag (leaks to shell history). Env is preferred.
+    if (opts.fabricPassword && !process.env.FABRIC_PASSWORD) {
+      console.error(render.wrap(render.c.dim, "warning: --fabric-password leaks to shell history. Prefer FABRIC_PASSWORD env."));
+    }
+
+    const result: FleetSweepResult = await sweepFleet({
+      target: opts.target,
+      fabricUser,
+      fabricPassword,
+      expectVersion: opts.expectVersion,
+      timeoutMs: Number(opts.timeout ?? 60_000),
+    });
+
+    const mode = render.resolveOutputMode(opts);
+    if (mode === "json") {
+      console.log(render.asJSON(result));
+    } else {
+      console.log(render.wrap(render.c.bold, `Fleet verify — ${result.target}`));
+      console.log(renderFleetSweepTable(result));
+    }
+    process.exit(result.exitCode);
   });
 
 // ─── flair doctor ─────────────────────────────────────────────────────────────

--- a/src/fleet-verify.ts
+++ b/src/fleet-verify.ts
@@ -1,0 +1,410 @@
+/**
+ * fleet-verify.ts — `flair fleet verify` (flair#636)
+ *
+ * Fabric deploys tolerate replication errors by design (origin-first, see
+ * src/deploy.ts's REPLICATION_FAILURE_RE / --ignore-replication-errors) —
+ * but nothing upstream of this module confirms a replicated node actually
+ * converged. Harper's own "Successfully deployed" means "origin took it."
+ * This sweeps the origin + every known peer and reports a per-node table
+ * instead of a single boolean, reusing src/probe.ts's `probeInstance`
+ * verbatim (flair#635/#641 — same shape, Fabric admin Basic auth swapped in
+ * for the injected `authedGet`, exactly per that module's own docstring).
+ *
+ * ── What "peer" means here — read before trusting a green sweep ──────────
+ * Harper Fabric's OWN cluster-replication peers (the physical nodes a
+ * component gets replicated to by `harper deploy`) are NOT enumerable
+ * through any operation in the OSS @harperfast/harper build this repo
+ * depends on. `cluster_status` — the operation that would answer "what
+ * nodes are in this cluster and are they in sync" — is explicitly called
+ * out as harper-pro-only in Harper's own source (node_modules/@harperfast/
+ * harper/components/mcp/tools/schemas/operationDescriptions.ts: "Out-of-core
+ * operations (e.g. harper-pro's cluster_status) cannot have entries here").
+ * There is no "list this cluster's replication nodes" call available to this
+ * CLI, on the origin or anywhere else — direct AND via-origin cluster
+ * topology discovery are both unavailable in this Harper tier.
+ *
+ * The only node registry this module CAN reach is Flair's OWN federation
+ * peer table (resources/Federation.ts's Peer records, via GET
+ * /FederationPeers) — a distinct, higher-level concept (cross-instance
+ * memory-sync pairing, hub-and-spoke) that happens to double as a fleet
+ * registry ONLY where an operator has ALSO paired each Fabric replica as a
+ * federation peer of the origin. A replica that was never paired is
+ * invisible to this sweep — `0 peers known` means "0 peers ON FILE", never
+ * "0 peers exist." renderFleetSweepTable() prints this caveat inline
+ * whenever the peer list comes back empty, so it can't be missed by reading
+ * a green summary line.
+ *
+ * Every peer that DOES carry a direct `endpoint` gets a REAL probe (health +
+ * authenticated version check, same Fabric admin Basic-auth credentials as
+ * the origin — a Fabric cluster shares one admin realm). A peer with no
+ * usable endpoint is reported "unverifiable" — never silently dropped, never
+ * printed green. See classifyNode()'s "method" field: "direct" (we actually
+ * hit it) vs "none" (we could not attempt a check at all, and say why).
+ */
+
+import { probeInstance, type ProbeResult, type ProbeInstanceOptions } from "./probe.js";
+import * as render from "./render.js";
+
+// ─── Result shape ────────────────────────────────────────────────────────────
+
+export type FleetNodeRole = "origin" | "peer";
+
+/** "direct" = we actually made an HTTP request to this node. "none" = we had no usable way to reach it at all. */
+export type FleetCheckMethod = "direct" | "none";
+
+export type FleetNodeStatus =
+  | "ok"            // healthy, authenticated, version matches (or no baseline to compare against)
+  | "unreachable"   // /Health never answered within the timeout
+  | "auth-failed"   // healthy, but the authenticated check was rejected
+  | "skew"          // healthy + authenticated, but running a different version than expected
+  | "unverifiable"; // no way to check this node at all (no endpoint, bad URL, or peer enumeration itself failed)
+
+export interface FleetNodeResult {
+  id: string;
+  role: FleetNodeRole;
+  url: string | null;
+  method: FleetCheckMethod;
+  healthy: boolean | null;
+  authenticated: boolean | null;
+  version: string | null;
+  versionMatch: boolean | null;
+  status: FleetNodeStatus;
+  /** Always present — human-readable reason, especially load-bearing when !ok. */
+  detail: string;
+}
+
+// ─── Exit codes (documented in `flair fleet verify --help`) ─────────────────
+
+/** All nodes verified: healthy, authenticated, and version-matched. */
+export const FLEET_EXIT_OK = 0;
+/** Origin failed — unreachable, unauthenticated, or running the wrong version. Worst case: the cluster's entrypoint itself is broken. */
+export const FLEET_EXIT_ORIGIN_FAILED = 1;
+/** Origin is fine, but at least one reachable peer is running a DIFFERENT version — a mixed-version fleet (the #638 scenario). */
+export const FLEET_EXIT_PEER_SKEW = 2;
+/** Origin is fine, no version skew among reachable peers, but at least one peer could not be verified at all (unreachable, auth rejected, or no endpoint on file). */
+export const FLEET_EXIT_PEER_UNREACHABLE = 3;
+
+export const FLEET_EXIT_DESCRIPTIONS: Record<number, string> = {
+  [FLEET_EXIT_OK]: "all nodes verified: healthy, authenticated, version-matched",
+  [FLEET_EXIT_ORIGIN_FAILED]: "origin failed (unreachable, unauthenticated, or wrong version)",
+  [FLEET_EXIT_PEER_SKEW]: "origin OK, but a reachable peer is running a DIFFERENT version (skew)",
+  [FLEET_EXIT_PEER_UNREACHABLE]: "origin OK, no skew among reachable peers, but a peer could not be verified at all (unreachable, auth rejected, or no endpoint on file)",
+};
+
+/**
+ * Priority order when multiple problems exist at once: an origin failure
+ * always wins (nothing downstream matters if the entrypoint is broken), then
+ * skew (a real mixed-version fleet), then unreachable/unverifiable (we
+ * genuinely don't know that node's state).
+ */
+export function decideFleetExitCode(origin: FleetNodeResult, peers: FleetNodeResult[]): number {
+  if (origin.status !== "ok") return FLEET_EXIT_ORIGIN_FAILED;
+  if (peers.some((p) => p.status === "skew")) return FLEET_EXIT_PEER_SKEW;
+  if (peers.some((p) => p.status !== "ok")) return FLEET_EXIT_PEER_UNREACHABLE;
+  return FLEET_EXIT_OK;
+}
+
+// ─── Pure decision logic: ProbeResult → FleetNodeResult ─────────────────────
+
+/**
+ * Turn a probe attempt (or the absence of one) into a table row. Pure —
+ * no I/O. `expectVersion` is the baseline this node should be running;
+ * pass null when there is nothing to compare against (skew can't be
+ * evaluated, but health/auth still can).
+ */
+export function classifyNode(
+  role: FleetNodeRole,
+  id: string,
+  url: string | null,
+  method: FleetCheckMethod,
+  probe: ProbeResult | null,
+  expectVersion: string | null,
+  unverifiableReason?: string,
+): FleetNodeResult {
+  if (method === "none" || probe === null) {
+    return {
+      id, role, url, method: "none",
+      healthy: null, authenticated: null, version: null, versionMatch: null,
+      status: "unverifiable",
+      detail: unverifiableReason ?? "no way to verify this node",
+    };
+  }
+
+  if (!probe.healthy) {
+    return {
+      id, role, url, method,
+      healthy: false, authenticated: null, version: null, versionMatch: null,
+      status: "unreachable",
+      detail: probe.error ?? `${url ?? id} did not answer /Health`,
+    };
+  }
+
+  if (probe.authenticated === false) {
+    return {
+      id, role, url, method,
+      healthy: true, authenticated: false, version: null, versionMatch: null,
+      status: "auth-failed",
+      detail: probe.error ?? "authenticated request rejected",
+    };
+  }
+
+  if (expectVersion !== null && probe.versionMatch === false) {
+    return {
+      id, role, url, method,
+      healthy: true, authenticated: probe.authenticated, version: probe.version, versionMatch: false,
+      status: "skew",
+      detail: probe.error ?? `version mismatch: expected ${expectVersion}, reports ${probe.version ?? "unknown"}`,
+    };
+  }
+
+  return {
+    id, role, url, method,
+    healthy: true, authenticated: probe.authenticated, version: probe.version, versionMatch: probe.versionMatch,
+    status: "ok",
+    detail: probe.version ? `healthy, running ${probe.version}` : "healthy",
+  };
+}
+
+// ─── Peer endpoint validation ────────────────────────────────────────────────
+
+/**
+ * A federation Peer record may have no `endpoint` at all (tunnel-paired —
+ * see src/cli.ts's existing `flair federation ping` handling of the same
+ * shape) or an endpoint that isn't a plain http(s) URL. Reject non-http(s)
+ * schemes rather than attempting to fetch them (same protocol allowlist as
+ * the existing federation-ping probe — Sherlock review on #314).
+ */
+export function validatePeerEndpoint(endpoint: string | null | undefined): { url: string } | { error: string } {
+  if (!endpoint) {
+    return { error: "no endpoint on file (never federation-paired with a direct endpoint, or tunnel-paired)" };
+  }
+  let parsed: URL;
+  try {
+    parsed = new URL(endpoint);
+  } catch {
+    return { error: `invalid endpoint URL on file: ${endpoint}` };
+  }
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+    return { error: `unsupported endpoint protocol on file: ${parsed.protocol}` };
+  }
+  return { url: endpoint };
+}
+
+// ─── Fabric admin Basic-auth authedGet (injected into probeInstance) ────────
+
+/**
+ * Builds the authedGet probeInstance needs, using Fabric admin Basic auth —
+ * the exact credential shape src/deploy.ts and src/fabric-upgrade.ts already
+ * use for the whole cluster (FABRIC_USER/FABRIC_PASSWORD). Assumes a single
+ * Fabric cluster shares one admin realm across its nodes; a peer that
+ * rejects these credentials (a genuinely separate Harper instance with its
+ * own admin) surfaces as "auth-failed" — itself a real, informative finding,
+ * not a bug in this probe.
+ *
+ * NEVER logs the credential — only the Authorization header carries it, and
+ * probeInstance/callers only ever see/report the HTTP outcome.
+ */
+export function buildFabricAuthedGet(
+  baseUrl: string,
+  fabricUser: string,
+  fabricPassword: string,
+): (path: string) => Promise<any> {
+  const base = baseUrl.replace(/\/+$/, "");
+  const auth = Buffer.from(`${fabricUser}:${fabricPassword}`).toString("base64");
+  return async (path: string) => {
+    const res = await fetch(`${base}${path}`, {
+      headers: { Authorization: `Basic ${auth}` },
+      signal: AbortSignal.timeout(15_000),
+    });
+    const text = await res.text();
+    if (!res.ok) throw new Error(text || `HTTP ${res.status}`);
+    return text ? JSON.parse(text) : {};
+  };
+}
+
+// ─── Peer enumeration ────────────────────────────────────────────────────────
+
+export interface FleetPeerRecord {
+  id: string;
+  role?: string;
+  status?: string;
+  endpoint?: string | null;
+}
+
+async function defaultFetchPeers(authedGet: (path: string) => Promise<any>): Promise<FleetPeerRecord[]> {
+  const body = await authedGet("/FederationPeers");
+  return Array.isArray(body?.peers) ? body.peers : [];
+}
+
+// ─── Injectable seams (tests mock these — no real network/probing) ─────────
+
+export interface FleetVerifyDeps {
+  probe: (baseUrl: string, opts: ProbeInstanceOptions) => Promise<ProbeResult>;
+  fetchPeers: (authedGet: (path: string) => Promise<any>) => Promise<FleetPeerRecord[]>;
+  buildAuthedGet: (baseUrl: string, fabricUser: string, fabricPassword: string) => (path: string) => Promise<any>;
+  log?: (msg: string) => void;
+}
+
+function defaultDeps(): FleetVerifyDeps {
+  return {
+    probe: probeInstance,
+    fetchPeers: defaultFetchPeers,
+    buildAuthedGet: buildFabricAuthedGet,
+  };
+}
+
+export interface FleetVerifyOptions {
+  target: string;
+  fabricUser: string;
+  fabricPassword: string;
+  /** Version every node must report. Omit to compare peers against the origin's OWN reported version instead (self-consistency check). */
+  expectVersion?: string;
+  /** Per-node /Health poll timeout (probeInstance default: 60s). */
+  timeoutMs?: number;
+}
+
+export interface FleetSweepResult {
+  target: string;
+  /** The version baseline actually used for skew comparisons, or null when there was none available. */
+  expectVersion: string | null;
+  /** "explicit" = --expect-version was given. "origin" = derived from the origin's own reported version. "none" = no baseline available. */
+  expectVersionSource: "explicit" | "origin" | "none";
+  origin: FleetNodeResult;
+  peers: FleetNodeResult[];
+  /** Set when GET /FederationPeers on the origin itself failed — peer coverage is unknown, not necessarily zero. */
+  peerEnumerationError: string | null;
+  exitCode: number;
+}
+
+// ─── Orchestrator ───────────────────────────────────────────────────────────
+
+export async function sweepFleet(
+  opts: FleetVerifyOptions,
+  injected?: Partial<FleetVerifyDeps>,
+): Promise<FleetSweepResult> {
+  const deps: FleetVerifyDeps = { ...defaultDeps(), ...injected };
+  const log = deps.log ?? (() => {});
+
+  const originAuthedGet = deps.buildAuthedGet(opts.target, opts.fabricUser, opts.fabricPassword);
+
+  log(`Probing origin ${opts.target} ...`);
+  const originProbe = await deps.probe(opts.target, {
+    expectVersion: opts.expectVersion,
+    timeoutMs: opts.timeoutMs,
+    authedGet: originAuthedGet,
+  });
+
+  const explicitExpect = opts.expectVersion ?? null;
+  const expectVersion = explicitExpect ?? originProbe.version ?? null;
+  const expectVersionSource: "explicit" | "origin" | "none" =
+    explicitExpect !== null ? "explicit" : expectVersion !== null ? "origin" : "none";
+
+  // Origin is classified against the EXPLICIT expectation only — when none was
+  // given, the origin itself defines the baseline and can't be "skewed"
+  // relative to its own reading.
+  const origin = classifyNode("origin", "origin", opts.target, "direct", originProbe, explicitExpect);
+
+  let peerRecords: FleetPeerRecord[] = [];
+  let peerEnumerationError: string | null = null;
+  try {
+    log("Enumerating federation peers ...");
+    peerRecords = await deps.fetchPeers(originAuthedGet);
+  } catch (err: any) {
+    peerEnumerationError = err?.message ?? String(err);
+  }
+
+  // Revoked peers are intentionally decommissioned — reporting them
+  // unreachable would be noise, not signal.
+  const knownPeers = peerRecords.filter((p) => p.status !== "revoked");
+
+  const peers: FleetNodeResult[] = [];
+  for (const p of knownPeers) {
+    const check = validatePeerEndpoint(p.endpoint);
+    if ("error" in check) {
+      peers.push(classifyNode("peer", p.id, p.endpoint ?? null, "none", null, expectVersion, check.error));
+      continue;
+    }
+    log(`Probing peer ${p.id} (${check.url}) ...`);
+    const peerAuthedGet = deps.buildAuthedGet(check.url, opts.fabricUser, opts.fabricPassword);
+    const peerProbe = await deps.probe(check.url, {
+      expectVersion: expectVersion ?? undefined,
+      timeoutMs: opts.timeoutMs,
+      authedGet: peerAuthedGet,
+    });
+    peers.push(classifyNode("peer", p.id, check.url, "direct", peerProbe, expectVersion));
+  }
+
+  if (peerEnumerationError) {
+    // A failure to even LIST peers means fleet coverage is unknown — never
+    // let that read as "0 peers, all clear."
+    peers.push({
+      id: "(peer enumeration)",
+      role: "peer",
+      url: null,
+      method: "none",
+      healthy: null, authenticated: null, version: null, versionMatch: null,
+      status: "unverifiable",
+      detail: `GET /FederationPeers on the origin failed: ${peerEnumerationError} — fleet coverage unknown, cannot confirm every peer was even considered`,
+    });
+  }
+
+  const exitCode = decideFleetExitCode(origin, peers);
+
+  return { target: opts.target, expectVersion, expectVersionSource, origin, peers, peerEnumerationError, exitCode };
+}
+
+// ─── Rendering ───────────────────────────────────────────────────────────────
+
+const STATUS_COLOR: Record<FleetNodeStatus, string> = {
+  ok: render.c.green,
+  skew: render.c.red,
+  unreachable: render.c.red,
+  "auth-failed": render.c.yellow,
+  unverifiable: render.c.yellow,
+};
+
+/**
+ * Per-node table + the caveats an operator needs to trust it. An "ok" row
+ * always means a REAL probe answered; anything else names exactly how it's
+ * wrong (see FleetNodeResult.detail) instead of a bare pass/fail.
+ */
+export function renderFleetSweepTable(result: FleetSweepResult): string {
+  const rows = [result.origin, ...result.peers];
+  const cols: render.TableColumn[] = [
+    { label: "node", key: "id" },
+    { label: "role", key: "role" },
+    { label: "method", key: "method", format: (v) => (v === "direct" ? "direct" : render.wrap(render.c.dim, "none")) },
+    {
+      label: "status",
+      key: "status",
+      format: (v) => render.wrap(STATUS_COLOR[v as FleetNodeStatus] ?? render.c.dim, String(v)),
+    },
+    { label: "version", key: "version", format: (v) => (v ? String(v) : render.wrap(render.c.dim, "—")) },
+    { label: "detail", key: "detail" },
+  ];
+
+  const lines: string[] = [render.table(cols, rows as unknown as Array<Record<string, unknown>>)];
+
+  if (result.peers.length === 0 || (result.peers.length === 1 && result.peerEnumerationError)) {
+    lines.push("");
+    lines.push(render.wrap(
+      render.c.dim,
+      "0 federation peers known to the origin. This does NOT mean the Fabric cluster has no other " +
+      "replication nodes — Harper's own cluster peers aren't visible to this tool (cluster_status is a " +
+      "harper-pro-only operation, unavailable in the OSS build this CLI ships). It means no other node is " +
+      "paired as a Flair federation peer of this origin. If this cluster has replicas, pair them " +
+      "(`flair federation pair`) so fleet verify can actually see them.",
+    ));
+  }
+
+  const expectLine =
+    result.expectVersionSource === "explicit"
+      ? `compared against --expect-version ${result.expectVersion}`
+      : result.expectVersionSource === "origin"
+        ? `compared against the origin's own reported version (${result.expectVersion}) — no --expect-version given`
+        : "no version baseline available (origin unreachable/unauthenticated and no --expect-version given) — skew could not be checked";
+  lines.push("");
+  lines.push(render.wrap(render.c.dim, expectLine));
+
+  return lines.join("\n");
+}

--- a/test/integration/fleet-verify.test.ts
+++ b/test/integration/fleet-verify.test.ts
@@ -1,0 +1,104 @@
+// fleet-verify.test.ts — Integration tests for `flair fleet verify`
+// (src/fleet-verify.ts, flair#636) against a REAL spawned Harper instance.
+//
+// Confirms the whole real round trip for the case every Fabric fleet starts
+// as: a single origin node with zero federation peers on file. sweepFleet()
+// must report the origin row from a REAL /Health + /HealthDetail round trip
+// (not a mock), and a wrong --expect-version must be caught as a real skew,
+// not just something the unit tests assert about mocked probes.
+//
+// No two-instance federation-pairing test harness exists yet in this repo
+// (test/integration/federation-sync-e2e.test.ts's own header notes it's
+// still a "transitional" test against simulated Peer/Memory stores, not a
+// real second spawned Harper) — see flair#636's own report for what a
+// follow-up two-node harness would need. This file covers the single-origin
+// case for real; peer-classification logic (skew/unreachable/unverifiable)
+// is covered against mocked probes in test/unit/fleet-verify.test.ts.
+//
+// HOME isolation: startHarper() sets HOME only in the spawned Harper's OWN
+// child-process env (test/helpers/harper-lifecycle.ts) — this test process's
+// HOME is never touched, and no real ~/.flair file is ever read here.
+import { describe, expect, test, beforeAll, afterAll } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { startHarper, stopHarper, HarperInstance } from "../helpers/harper-lifecycle";
+import { sweepFleet, FLEET_EXIT_OK, FLEET_EXIT_PEER_SKEW } from "../../src/fleet-verify";
+
+let harper: HarperInstance;
+let realVersion: string;
+
+describe("sweepFleet against a real spawned Harper — single origin, zero peers (flair#636)", () => {
+  beforeAll(async () => {
+    harper = await startHarper();
+    // Read the SAME package.json resources/health.ts's resolveVersion() will
+    // find, instead of hardcoding a version string that drifts on release
+    // (same approach as test/integration/probe-instance.test.ts).
+    const pkg = JSON.parse(readFileSync(join(process.cwd(), "package.json"), "utf-8"));
+    realVersion = pkg.version;
+    expect(typeof realVersion).toBe("string");
+  }, 180_000);
+
+  afterAll(async () => {
+    if (harper) await stopHarper(harper);
+  });
+
+  test("reports the origin row correctly with the real running version, zero peers, exit OK", async () => {
+    const result = await sweepFleet({
+      target: harper.httpURL,
+      fabricUser: harper.admin.username,
+      fabricPassword: harper.admin.password,
+      timeoutMs: 15_000,
+    });
+
+    expect(result.origin.role).toBe("origin");
+    expect(result.origin.method).toBe("direct");
+    expect(result.origin.healthy).toBe(true);
+    expect(result.origin.authenticated).toBe(true);
+    expect(result.origin.version).toBe(realVersion);
+    expect(result.origin.status).toBe("ok");
+    expect(result.peers).toEqual([]);
+    expect(result.peerEnumerationError).toBeNull();
+    // No explicit --expect-version was given: the baseline is derived from
+    // the origin's own real reported version, not a mock.
+    expect(result.expectVersionSource).toBe("origin");
+    expect(result.expectVersion).toBe(realVersion);
+    expect(result.exitCode).toBe(FLEET_EXIT_OK);
+  }, 30_000);
+
+  test("a wrong --expect-version against the real origin yields the skew exit code", async () => {
+    const result = await sweepFleet({
+      target: harper.httpURL,
+      fabricUser: harper.admin.username,
+      fabricPassword: harper.admin.password,
+      expectVersion: "999.999.999-definitely-not-installed",
+      timeoutMs: 15_000,
+    });
+
+    expect(result.origin.healthy).toBe(true);
+    expect(result.origin.authenticated).toBe(true);
+    expect(result.origin.version).toBe(realVersion);
+    expect(result.origin.versionMatch).toBe(false);
+    expect(result.origin.status).toBe("skew");
+    expect(result.expectVersionSource).toBe("explicit");
+    // An ORIGIN mismatching an explicit expectation is ORIGIN_FAILED, not
+    // PEER_SKEW — ORIGIN_FAILED is asserted in the unit tests' priority-order
+    // coverage; ensure the real round trip agrees the origin itself is what's
+    // flagged (not silently swallowed as a peer concern with zero peers).
+    expect(result.exitCode).not.toBe(FLEET_EXIT_OK);
+    expect(result.exitCode).not.toBe(FLEET_EXIT_PEER_SKEW);
+  }, 30_000);
+
+  test("wrong Fabric credentials against the real origin are reported as auth-failed, not a false pass", async () => {
+    const result = await sweepFleet({
+      target: harper.httpURL,
+      fabricUser: harper.admin.username,
+      fabricPassword: "definitely-the-wrong-password",
+      timeoutMs: 15_000,
+    });
+
+    expect(result.origin.healthy).toBe(true); // /Health is public, unaffected by bad creds
+    expect(result.origin.authenticated).toBe(false);
+    expect(result.origin.status).toBe("auth-failed");
+    expect(result.exitCode).not.toBe(FLEET_EXIT_OK);
+  }, 30_000);
+});

--- a/test/unit/fleet-verify.test.ts
+++ b/test/unit/fleet-verify.test.ts
@@ -1,0 +1,412 @@
+// fleet-verify.test.ts — Unit tests for `flair fleet verify` (src/fleet-verify.ts, flair#636).
+//
+// Everything here mocks probe/fetchPeers/buildAuthedGet — no real network,
+// no spawned Harper. The real round trip against a spawned instance is
+// covered by test/integration/fleet-verify.test.ts.
+import { describe, test, expect } from "bun:test";
+import {
+  classifyNode,
+  decideFleetExitCode,
+  validatePeerEndpoint,
+  sweepFleet,
+  buildFabricAuthedGet,
+  FLEET_EXIT_OK,
+  FLEET_EXIT_ORIGIN_FAILED,
+  FLEET_EXIT_PEER_SKEW,
+  FLEET_EXIT_PEER_UNREACHABLE,
+  type FleetNodeResult,
+  type FleetPeerRecord,
+} from "../../src/fleet-verify";
+import type { ProbeResult } from "../../src/probe";
+import { shouldRunFleetVerify } from "../../src/cli";
+
+// ─── helpers ─────────────────────────────────────────────────────────────────
+
+function okProbe(version: string, versionMatch: boolean | null = null): ProbeResult {
+  return { healthy: true, authenticated: true, version, versionMatch, ok: versionMatch !== false };
+}
+function unhealthyProbe(error = "instance did not answer /Health"): ProbeResult {
+  return { healthy: false, authenticated: null, version: null, versionMatch: null, ok: false, error };
+}
+function authFailedProbe(error = "403 forbidden"): ProbeResult {
+  return { healthy: true, authenticated: false, version: null, versionMatch: null, ok: false, error };
+}
+function mismatchProbe(version: string, expected: string): ProbeResult {
+  return {
+    healthy: true, authenticated: true, version, versionMatch: false, ok: false,
+    error: `version mismatch: expected ${expected}, instance reports ${version}`,
+  };
+}
+
+function makeNode(overrides: Partial<FleetNodeResult> = {}): FleetNodeResult {
+  return {
+    id: "n", role: "peer", url: "https://n.example", method: "direct",
+    healthy: true, authenticated: true, version: "1.0.0", versionMatch: true,
+    status: "ok", detail: "healthy, running 1.0.0",
+    ...overrides,
+  };
+}
+
+// ─── classifyNode ────────────────────────────────────────────────────────────
+
+describe("classifyNode", () => {
+  test("method=none / probe=null → unverifiable, carries the given reason", () => {
+    const r = classifyNode("peer", "peer-a", null, "none", null, "1.0.0", "no endpoint on file");
+    expect(r.status).toBe("unverifiable");
+    expect(r.method).toBe("none");
+    expect(r.healthy).toBeNull();
+    expect(r.detail).toBe("no endpoint on file");
+  });
+
+  test("method=none without an explicit reason falls back to a generic message", () => {
+    const r = classifyNode("peer", "peer-a", null, "none", null, null);
+    expect(r.status).toBe("unverifiable");
+    expect(r.detail).toBeTruthy();
+  });
+
+  test("unhealthy probe → unreachable, no version/auth info leaked", () => {
+    const r = classifyNode("peer", "peer-a", "https://a", "direct", unhealthyProbe("ECONNREFUSED"), "1.0.0");
+    expect(r.status).toBe("unreachable");
+    expect(r.healthy).toBe(false);
+    expect(r.authenticated).toBeNull();
+    expect(r.version).toBeNull();
+    expect(r.detail).toBe("ECONNREFUSED");
+  });
+
+  test("healthy but authentication rejected → auth-failed, not unreachable", () => {
+    const r = classifyNode("peer", "peer-a", "https://a", "direct", authFailedProbe("401 unauthorized"), "1.0.0");
+    expect(r.status).toBe("auth-failed");
+    expect(r.healthy).toBe(true);
+    expect(r.authenticated).toBe(false);
+    expect(r.detail).toBe("401 unauthorized");
+  });
+
+  test("healthy + authenticated + wrong version → skew, names both versions via probe.error", () => {
+    const r = classifyNode("peer", "peer-a", "https://a", "direct", mismatchProbe("0.9.0", "1.0.0"), "1.0.0");
+    expect(r.status).toBe("skew");
+    expect(r.version).toBe("0.9.0");
+    expect(r.versionMatch).toBe(false);
+    expect(r.detail).toContain("0.9.0");
+    expect(r.detail).toContain("1.0.0");
+  });
+
+  test("healthy + authenticated + matching version → ok", () => {
+    const r = classifyNode("peer", "peer-a", "https://a", "direct", okProbe("1.0.0", true), "1.0.0");
+    expect(r.status).toBe("ok");
+    expect(r.version).toBe("1.0.0");
+  });
+
+  test("no expectVersion baseline (null) → health/auth-only ok, never falsely 'skew'", () => {
+    // probeInstance itself returns versionMatch=null when it wasn't given an
+    // expectVersion — classifyNode must not manufacture a skew verdict here.
+    const probe: ProbeResult = { healthy: true, authenticated: true, version: "1.0.0", versionMatch: null, ok: true };
+    const r = classifyNode("peer", "peer-a", "https://a", "direct", probe, null);
+    expect(r.status).toBe("ok");
+  });
+
+  test("origin role works the same as peer (role is just carried through)", () => {
+    const r = classifyNode("origin", "origin", "https://origin", "direct", okProbe("1.0.0", true), "1.0.0");
+    expect(r.role).toBe("origin");
+    expect(r.status).toBe("ok");
+  });
+});
+
+// ─── decideFleetExitCode ─────────────────────────────────────────────────────
+
+describe("decideFleetExitCode", () => {
+  test("origin ok, no peers → OK", () => {
+    const origin = makeNode({ role: "origin", id: "origin" });
+    expect(decideFleetExitCode(origin, [])).toBe(FLEET_EXIT_OK);
+  });
+
+  test("origin ok, all peers ok → OK", () => {
+    const origin = makeNode({ role: "origin", id: "origin" });
+    const peers = [makeNode({ id: "p1" }), makeNode({ id: "p2" })];
+    expect(decideFleetExitCode(origin, peers)).toBe(FLEET_EXIT_OK);
+  });
+
+  test("origin unreachable → ORIGIN_FAILED, regardless of peer states", () => {
+    const origin = makeNode({ role: "origin", id: "origin", status: "unreachable" });
+    const peers = [makeNode({ id: "p1", status: "ok" })];
+    expect(decideFleetExitCode(origin, peers)).toBe(FLEET_EXIT_ORIGIN_FAILED);
+  });
+
+  test("origin auth-failed → ORIGIN_FAILED", () => {
+    const origin = makeNode({ role: "origin", id: "origin", status: "auth-failed" });
+    expect(decideFleetExitCode(origin, [])).toBe(FLEET_EXIT_ORIGIN_FAILED);
+  });
+
+  test("origin skewed (wrong version vs --expect-version) → ORIGIN_FAILED", () => {
+    const origin = makeNode({ role: "origin", id: "origin", status: "skew" });
+    expect(decideFleetExitCode(origin, [])).toBe(FLEET_EXIT_ORIGIN_FAILED);
+  });
+
+  test("origin ok + one peer skewed → PEER_SKEW", () => {
+    const origin = makeNode({ role: "origin", id: "origin" });
+    const peers = [makeNode({ id: "p1", status: "ok" }), makeNode({ id: "p2", status: "skew" })];
+    expect(decideFleetExitCode(origin, peers)).toBe(FLEET_EXIT_PEER_SKEW);
+  });
+
+  test("origin ok + one peer unreachable (no skew anywhere) → PEER_UNREACHABLE", () => {
+    const origin = makeNode({ role: "origin", id: "origin" });
+    const peers = [makeNode({ id: "p1", status: "ok" }), makeNode({ id: "p2", status: "unreachable" })];
+    expect(decideFleetExitCode(origin, peers)).toBe(FLEET_EXIT_PEER_UNREACHABLE);
+  });
+
+  test("origin ok + one peer unverifiable → PEER_UNREACHABLE (unverifiable is never silently OK)", () => {
+    const origin = makeNode({ role: "origin", id: "origin" });
+    const peers = [makeNode({ id: "p1", status: "unverifiable" })];
+    expect(decideFleetExitCode(origin, peers)).toBe(FLEET_EXIT_PEER_UNREACHABLE);
+  });
+
+  test("origin ok + one peer auth-failed → PEER_UNREACHABLE", () => {
+    const origin = makeNode({ role: "origin", id: "origin" });
+    const peers = [makeNode({ id: "p1", status: "auth-failed" })];
+    expect(decideFleetExitCode(origin, peers)).toBe(FLEET_EXIT_PEER_UNREACHABLE);
+  });
+
+  test("skew AND unreachable both present → PEER_SKEW wins (worse signal first)", () => {
+    const origin = makeNode({ role: "origin", id: "origin" });
+    const peers = [
+      makeNode({ id: "p1", status: "unreachable" }),
+      makeNode({ id: "p2", status: "skew" }),
+    ];
+    expect(decideFleetExitCode(origin, peers)).toBe(FLEET_EXIT_PEER_SKEW);
+  });
+
+  test("priority order: ORIGIN_FAILED > PEER_SKEW > PEER_UNREACHABLE > OK", () => {
+    const failedOrigin = makeNode({ role: "origin", id: "origin", status: "unreachable" });
+    const peers = [makeNode({ id: "p1", status: "skew" }), makeNode({ id: "p2", status: "unreachable" })];
+    // Even with BOTH a skewed and an unreachable peer, an origin failure still wins.
+    expect(decideFleetExitCode(failedOrigin, peers)).toBe(FLEET_EXIT_ORIGIN_FAILED);
+  });
+});
+
+// ─── validatePeerEndpoint ────────────────────────────────────────────────────
+
+describe("validatePeerEndpoint", () => {
+  test("null/undefined/empty endpoint → error, names tunnel-pairing as a possibility", () => {
+    for (const v of [null, undefined, ""]) {
+      const r = validatePeerEndpoint(v);
+      expect("error" in r).toBe(true);
+      if ("error" in r) expect(r.error.toLowerCase()).toContain("endpoint");
+    }
+  });
+
+  test("malformed URL → error naming the bad value", () => {
+    const r = validatePeerEndpoint("not a url");
+    expect("error" in r).toBe(true);
+    if ("error" in r) expect(r.error).toContain("not a url");
+  });
+
+  test("non-http(s) scheme (e.g. file:) rejected — protocol allowlist", () => {
+    const r = validatePeerEndpoint("file:///etc/passwd");
+    expect("error" in r).toBe(true);
+    if ("error" in r) expect(r.error).toContain("file:");
+  });
+
+  test("valid http(s) URL passes through unchanged", () => {
+    const r = validatePeerEndpoint("https://peer.example.harperfabric.com");
+    expect("error" in r).toBe(false);
+    if (!("error" in r)) expect(r.url).toBe("https://peer.example.harperfabric.com");
+  });
+
+  test("plain http is accepted too (not just https)", () => {
+    const r = validatePeerEndpoint("http://10.0.0.5:9926");
+    expect("error" in r).toBe(false);
+  });
+});
+
+// ─── buildFabricAuthedGet ────────────────────────────────────────────────────
+
+describe("buildFabricAuthedGet", () => {
+  test("sends Basic auth built from user:password, never the raw password, on the wire as anything but the header", async () => {
+    let sawAuthHeader = "";
+    let sawUrl = "";
+    const originalFetch = globalThis.fetch;
+    (globalThis as any).fetch = async (url: any, init: any) => {
+      sawUrl = String(url);
+      sawAuthHeader = init.headers.Authorization;
+      return { ok: true, text: async () => JSON.stringify({ version: "1.0.0" }) } as any;
+    };
+    try {
+      const authedGet = buildFabricAuthedGet("https://fabric.example/", "flint-admin", "s3cr3t");
+      const body = await authedGet("/HealthDetail");
+      expect(body).toEqual({ version: "1.0.0" });
+      expect(sawUrl).toBe("https://fabric.example/HealthDetail"); // trailing slash on base collapsed
+      expect(sawAuthHeader).toBe(`Basic ${Buffer.from("flint-admin:s3cr3t").toString("base64")}`);
+    } finally {
+      (globalThis as any).fetch = originalFetch;
+    }
+  });
+
+  test("throws on a non-2xx response (matches probeInstance's authedGet contract)", async () => {
+    const originalFetch = globalThis.fetch;
+    (globalThis as any).fetch = async () => ({ ok: false, status: 401, text: async () => "unauthorized" }) as any;
+    try {
+      const authedGet = buildFabricAuthedGet("https://fabric.example", "u", "p");
+      await expect(authedGet("/HealthDetail")).rejects.toThrow("unauthorized");
+    } finally {
+      (globalThis as any).fetch = originalFetch;
+    }
+  });
+});
+
+// ─── sweepFleet (orchestration, fully mocked) ────────────────────────────────
+
+describe("sweepFleet", () => {
+  function deps(opts: {
+    originProbe: ProbeResult;
+    peerProbes?: Record<string, ProbeResult>;
+    peers?: FleetPeerRecord[];
+    peersError?: Error;
+  }) {
+    return {
+      probe: async (baseUrl: string) => {
+        if (baseUrl === "https://origin.example") return opts.originProbe;
+        const found = Object.entries(opts.peerProbes ?? {}).find(([url]) => url === baseUrl);
+        if (found) return found[1];
+        throw new Error(`unexpected probe target in test: ${baseUrl}`);
+      },
+      fetchPeers: async () => {
+        if (opts.peersError) throw opts.peersError;
+        return opts.peers ?? [];
+      },
+      buildAuthedGet: (baseUrl: string) => async (_path: string) => ({ baseUrl }),
+    };
+  }
+
+  test("origin ok, zero peers → exitCode OK, expectVersionSource=origin", async () => {
+    const result = await sweepFleet(
+      { target: "https://origin.example", fabricUser: "u", fabricPassword: "p" },
+      deps({ originProbe: okProbe("1.2.3", null) }),
+    );
+    expect(result.origin.status).toBe("ok");
+    expect(result.peers).toEqual([]);
+    expect(result.exitCode).toBe(FLEET_EXIT_OK);
+    expect(result.expectVersion).toBe("1.2.3");
+    expect(result.expectVersionSource).toBe("origin");
+  });
+
+  test("explicit --expect-version wins over the origin's own reported version", async () => {
+    const result = await sweepFleet(
+      { target: "https://origin.example", fabricUser: "u", fabricPassword: "p", expectVersion: "9.9.9" },
+      deps({ originProbe: okProbe("1.2.3", false) }), // origin itself doesn't match 9.9.9
+    );
+    expect(result.expectVersion).toBe("9.9.9");
+    expect(result.expectVersionSource).toBe("explicit");
+    // origin mismatching the EXPLICIT expectation is an origin failure, not a peer concern.
+    expect(result.exitCode).toBe(FLEET_EXIT_ORIGIN_FAILED);
+  });
+
+  test("origin unreachable → ORIGIN_FAILED, no baseline available for peers", async () => {
+    const result = await sweepFleet(
+      { target: "https://origin.example", fabricUser: "u", fabricPassword: "p" },
+      deps({ originProbe: unhealthyProbe() }),
+    );
+    expect(result.origin.status).toBe("unreachable");
+    expect(result.exitCode).toBe(FLEET_EXIT_ORIGIN_FAILED);
+    expect(result.expectVersionSource).toBe("none");
+  });
+
+  test("a reachable peer running a different version than the origin → PEER_SKEW", async () => {
+    const peers: FleetPeerRecord[] = [{ id: "peer-a", status: "paired", endpoint: "https://peer-a.example" }];
+    const result = await sweepFleet(
+      { target: "https://origin.example", fabricUser: "u", fabricPassword: "p" },
+      deps({
+        originProbe: okProbe("1.2.3", null),
+        peers,
+        peerProbes: { "https://peer-a.example": mismatchProbe("1.2.2", "1.2.3") },
+      }),
+    );
+    expect(result.peers).toHaveLength(1);
+    expect(result.peers[0].status).toBe("skew");
+    expect(result.exitCode).toBe(FLEET_EXIT_PEER_SKEW);
+  });
+
+  test("a peer with no endpoint on file → unverifiable, never probed, PEER_UNREACHABLE", async () => {
+    const peers: FleetPeerRecord[] = [{ id: "tunnel-peer", status: "paired", endpoint: null }];
+    const result = await sweepFleet(
+      { target: "https://origin.example", fabricUser: "u", fabricPassword: "p" },
+      deps({ originProbe: okProbe("1.2.3", null), peers }),
+    );
+    expect(result.peers).toHaveLength(1);
+    expect(result.peers[0].status).toBe("unverifiable");
+    expect(result.peers[0].method).toBe("none");
+    expect(result.peers[0].detail).toContain("no endpoint");
+    expect(result.exitCode).toBe(FLEET_EXIT_PEER_UNREACHABLE);
+  });
+
+  test("a peer that never answers /Health → unreachable (distinct from unverifiable), PEER_UNREACHABLE", async () => {
+    const peers: FleetPeerRecord[] = [{ id: "down-peer", status: "paired", endpoint: "https://down.example" }];
+    const result = await sweepFleet(
+      { target: "https://origin.example", fabricUser: "u", fabricPassword: "p" },
+      deps({
+        originProbe: okProbe("1.2.3", null),
+        peers,
+        peerProbes: { "https://down.example": unhealthyProbe("ECONNREFUSED") },
+      }),
+    );
+    expect(result.peers[0].status).toBe("unreachable");
+    expect(result.peers[0].method).toBe("direct"); // we DID attempt it — distinguishes from "no endpoint"
+    expect(result.exitCode).toBe(FLEET_EXIT_PEER_UNREACHABLE);
+  });
+
+  test("revoked peers are filtered out entirely (decommissioned, not noise)", async () => {
+    const peers: FleetPeerRecord[] = [{ id: "gone", status: "revoked", endpoint: "https://gone.example" }];
+    const result = await sweepFleet(
+      { target: "https://origin.example", fabricUser: "u", fabricPassword: "p" },
+      deps({ originProbe: okProbe("1.2.3", null), peers }),
+    );
+    expect(result.peers).toEqual([]);
+    expect(result.exitCode).toBe(FLEET_EXIT_OK);
+  });
+
+  test("peer enumeration itself failing → synthetic unverifiable row, never silently '0 peers = clean'", async () => {
+    const result = await sweepFleet(
+      { target: "https://origin.example", fabricUser: "u", fabricPassword: "p" },
+      deps({ originProbe: okProbe("1.2.3", null), peersError: new Error("403 forbidden") }),
+    );
+    expect(result.peerEnumerationError).toContain("403 forbidden");
+    expect(result.peers).toHaveLength(1);
+    expect(result.peers[0].status).toBe("unverifiable");
+    expect(result.peers[0].detail).toContain("FederationPeers");
+    expect(result.exitCode).toBe(FLEET_EXIT_PEER_UNREACHABLE);
+  });
+
+  test("multiple peers all ok, matching the origin's version → OK", async () => {
+    const peers: FleetPeerRecord[] = [
+      { id: "p1", status: "paired", endpoint: "https://p1.example" },
+      { id: "p2", status: "connected", endpoint: "https://p2.example" },
+    ];
+    const result = await sweepFleet(
+      { target: "https://origin.example", fabricUser: "u", fabricPassword: "p" },
+      deps({
+        originProbe: okProbe("1.2.3", null),
+        peers,
+        peerProbes: {
+          "https://p1.example": okProbe("1.2.3", true),
+          "https://p2.example": okProbe("1.2.3", true),
+        },
+      }),
+    );
+    expect(result.peers.every((p) => p.status === "ok")).toBe(true);
+    expect(result.exitCode).toBe(FLEET_EXIT_OK);
+  });
+});
+
+// ─── shouldRunFleetVerify (--no-fleet-verify plumbing, src/cli.ts) ──────────
+
+describe("shouldRunFleetVerify", () => {
+  test("defaults to true when the flag is never passed (opts.fleetVerify undefined)", () => {
+    expect(shouldRunFleetVerify({})).toBe(true);
+  });
+
+  test("--no-fleet-verify (commander sets fleetVerify=false) disables the sweep", () => {
+    expect(shouldRunFleetVerify({ fleetVerify: false })).toBe(false);
+  });
+
+  test("an explicit true (shouldn't normally happen, but must not disable) stays enabled", () => {
+    expect(shouldRunFleetVerify({ fleetVerify: true })).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Implements #636: nothing previously confirmed a Fabric deploy actually converged — "Successfully deployed" means "origin took it," and replication errors are tolerated by design. Now:

- **`flair fleet verify --target <url>`** — standalone sweep: enumerates origin + known peers, probes each with `probeInstance` (#641), prints a per-node table, and exits with a documented code: `0` all verified · `1` origin failed (always wins) · `2` reachable peer on a different version (skew) · `3` peer unverifiable (unreachable / auth rejected / no endpoint on file).
- **Wired into `flair deploy` and `flair upgrade --target`** post-success (opt-out `--no-fleet-verify`), expecting the just-deployed version.
- **Honest by construction:** a node the sweep couldn't actually check renders `unverifiable` — never green, never dropped. Zero-peers-on-file prints an explicit caveat ("0 peers ON FILE ≠ 0 peers exist").

## Findings that shape the follow-ups (documented in the module header)

- **Fabric cluster topology is not enumerable in this Harper tier.** `cluster_status` is harper-pro-only (per Harper's own `operationDescriptions.ts`); there is no "list this cluster's nodes" call, direct or via-origin. The sweep therefore rides Flair's own federation Peer table — which doubles as a fleet registry only where replicas are also paired as federation peers.
- **Rolling restart:** Harper's internal `restartService` with `replicated: true` already restarts peer-at-a-time (via `server.replication.sendOperationToNode`, polling each for completion) — but it operates on `server.nodes`, which is equally unexposed. Mechanism exists; external orchestration doesn't. The rolling-restart follow-up should lean on Harper's own replicated restart rather than CLI-side orchestration.

## Test plan

- [x] `bun run build` && `bun run build:cli` clean
- [x] `bunx tsc --noEmit -p tsconfig.check.json` clean (note: this config only covers `resources/**` — `src/**` isn't typechecked by it; pre-existing gap, see issue link below)
- [x] `bun test test/unit/` — 1795/1795 pass (incl. 38 new: classification, exit-code priority, endpoint validation, sweep orchestration, flag plumbing)
- [x] `bun test test/integration/` — 231/231 pass (incl. 3 new against real spawned Harper: clean sweep, version-skew detection, auth-failure classification)
- [ ] Kern (architecture) + Sherlock (security) review

Notes: `--fabric-token`-only deploys (bearer, no Basic creds) skip the sweep with an explicit console note — the sweep has no way to authenticate in that mode. Standalone `fleet verify` without `--expect-version` baselines on the origin's reported version (self-consistency).

Closes #636.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
