### PR TITLE
feat(presence): version-stamped heartbeats + fleet staleness in doctor (#639)

### DIFF
--- a/resources/Presence.ts
+++ b/resources/Presence.ts
@@ -28,6 +28,10 @@
  */
 
 import { databases } from "@harperfast/harper";
+import { existsSync, readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { createRequire } from "node:module";
 import { resolveAgentAuth, verifyAgentRequest } from "./agent-auth.js";
 import { WINDOW_MS, isNonceReplay, recordNonce, importEd25519Key, b64ToArrayBuffer } from "./ed25519-auth.js";
 
@@ -44,6 +48,93 @@ function idleThresholdMs(): number {
 function offlineThresholdMs(): number {
   const env = process.env.PRESENCE_OFFLINE_THRESHOLD_MS;
   return env ? Number(env) || 600_000 : 600_000;
+}
+
+// ─── Version stamping (flair#639) ──────────────────────────────────────────────
+//
+// Auto-presence (packages/flair-mcp/src/presence.ts, flair#608) gives agents a
+// heartbeat, but the record never said which Flair *instance* served it —
+// fleet skew across hosts was only discoverable by probing each one by hand.
+// Every heartbeat now stamps the RUNNING server's own flair + harper versions,
+// so `flair doctor`'s fleet-presence section (src/cli.ts + src/fleet-presence.ts)
+// can flag stale instances org-relatively, no per-host probing required.
+
+/**
+ * Resolve the running @tpsdev-ai/flair version from package.json (duplicated
+ * from resources/health.ts / admin-layout.ts / AdminInstance.ts — same "keep
+ * in sync" idiom noted in those files: each resource module keeps its own
+ * copy for dependency isolation rather than importing a shared helper).
+ * `process.env.npm_package_version` is only populated inside `npm run`, so
+ * reading package.json relative to THIS running module is the only way to
+ * report the version of the code that's actually executing.
+ */
+function resolveVersion(): string {
+  try {
+    const here = dirname(fileURLToPath(import.meta.url));
+    const candidates = [
+      join(here, "..", "..", "package.json"),
+      join(here, "..", "package.json"),
+    ];
+    for (const p of candidates) {
+      if (existsSync(p)) {
+        const pkg = JSON.parse(readFileSync(p, "utf-8"));
+        if (pkg.version) return pkg.version;
+      }
+    }
+  } catch { /* fall through */ }
+  return process.env.npm_package_version ?? "dev";
+}
+
+/**
+ * Resolve the running @harperfast/harper version. Unlike flair's own
+ * package.json (readable via a plain relative path above), Harper's package
+ * only exports "." → dist/index.js — there's no "./package.json" subpath, so
+ * requiring it directly throws (Node's exports-map enforcement). Resolve the
+ * main entry via createRequire instead, then walk up from dist/index.js to
+ * the package root's package.json. Returns null (not a placeholder string)
+ * on failure so callers/readers can tell "genuinely unknown" apart from a
+ * real version — same tri-state as fabric-upgrade.ts's last-resort Harper
+ * version lookup.
+ */
+function resolveHarperVersion(): string | null {
+  try {
+    const req = createRequire(import.meta.url);
+    const mainPath = req.resolve("@harperfast/harper");
+    const pkgPath = join(dirname(mainPath), "..", "package.json");
+    if (existsSync(pkgPath)) {
+      const pkg = JSON.parse(readFileSync(pkgPath, "utf-8"));
+      if (typeof pkg.version === "string") return pkg.version;
+    }
+  } catch { /* fall through */ }
+  return null;
+}
+
+/**
+ * Build the record to persist for a presence heartbeat. Pure — no Harper
+ * calls, no version resolution of its own — so the record SHAPE (and post()'s
+ * merge-vs-insert plumbing around it) can be unit-tested without a live
+ * Harper or the real filesystem. Callers pass already-resolved versions
+ * (resolveVersion()/resolveHarperVersion() above), so tests can pin them
+ * directly. Mirrors buildPresenceBody() in packages/flair-mcp/src/presence.ts
+ * — same "exported pure builder, exported for tests" idiom, server side.
+ */
+export function buildPresenceRecord(
+  agentId: string,
+  now: number,
+  currentTask: unknown,
+  activity: string | undefined,
+  existingActivity: string | undefined,
+  flairVersion: string,
+  harperVersion: string | null,
+): Record<string, unknown> {
+  return {
+    agentId,
+    lastHeartbeatAt: now,
+    currentTask: sanitizeCurrentTask(currentTask),
+    activity: activity ?? (existingActivity ?? "idle"),
+    flairVersion,
+    harperVersion,
+  };
 }
 
 // ─── Nonce replay + crypto helpers ─────────────────────────────────────────────
@@ -75,6 +166,12 @@ export function derivePresenceStatus(
 
 // ─── Public-safe field allowlist ──────────────────────────────────────────────
 
+// flairVersion/harperVersion (flair#639) are content-gated the SAME way as
+// currentTask (see get()'s includeVerifiedFields) even though version
+// numbers aren't free text — precedent is HealthDetail vs the public /Health
+// endpoint (resources/health.ts): version info is deliberately withheld from
+// anonymous callers to avoid fingerprinting a publicly exposed instance for
+// known-CVE targeting. Anonymous readers get null for both, same as currentTask.
 const ROSTER_ALLOWLIST = new Set([
   "id",
   "displayName",
@@ -84,6 +181,8 @@ const ROSTER_ALLOWLIST = new Set([
   "presenceStatus",
   "currentTask",
   "lastHeartbeatAt",
+  "flairVersion",
+  "harperVersion",
 ]);
 
 function sanitizeCurrentTask(task: unknown): string | null {
@@ -154,6 +253,10 @@ export class Presence extends (databases as any).flair.Presence {
    * super_user, Basic-admin, internal in-process) gets currentTask=null.
    * allowRead() is UNCHANGED (still `true`) — the roster itself stays public;
    * only the free-text field is gated, per the issue's field-level option.
+   *
+   * flairVersion/harperVersion (flair#639) ride the SAME gate, renamed to
+   * includeVerifiedFields since it now covers more than currentTask — see the
+   * ROSTER_ALLOWLIST comment above for why version numbers are gated too.
    */
   async get() {
     // Extract the raw request the same way post() does (getContext().request
@@ -164,7 +267,7 @@ export class Presence extends (databases as any).flair.Presence {
     const ctx = (this as any).getContext?.();
     const request = ctx?.request ?? ctx;
     const agentAuth = request ? await verifyAgentRequest(request) : null;
-    const includeCurrentTask = agentAuth !== null;
+    const includeVerifiedFields = agentAuth !== null;
 
     const now = Date.now();
     const idleThreshold = idleThresholdMs();
@@ -199,10 +302,16 @@ export class Presence extends (databases as any).flair.Presence {
           // Anonymous/unverified readers get `null` here (key stays present,
           // schema-stable) instead of the sanitized task text — see the
           // currentTask CONTENT gate doc above get().
-          currentTask: includeCurrentTask ? sanitizeCurrentTask(row?.currentTask) : null,
+          currentTask: includeVerifiedFields ? sanitizeCurrentTask(row?.currentTask) : null,
           lastHeartbeatAt: typeof row?.lastHeartbeatAt === "number"
             ? row.lastHeartbeatAt
             : Number(row?.lastHeartbeatAt ?? 0),
+          // flair#639: absent on records written before this feature (older
+          // instance, never re-heartbeated since upgrading) — `row?.field ??
+          // null` tolerates that directly, same as every other optional field
+          // here. Gated to verified readers; see ROSTER_ALLOWLIST comment.
+          flairVersion: includeVerifiedFields ? (row?.flairVersion ?? null) : null,
+          harperVersion: includeVerifiedFields ? (row?.harperVersion ?? null) : null,
         };
 
         results.push(pickAllowlisted(entry));
@@ -331,12 +440,18 @@ export class Presence extends (databases as any).flair.Presence {
         existing = await (databases as any).flair.Presence.get(agentId);
       } catch { /* first heartbeat */ }
 
-      const record: Record<string, unknown> = {
+      // flair#639: stamp THIS server's own running versions on every
+      // heartbeat — an upgrade takes effect on the instance's very next
+      // heartbeat, no separate migration needed.
+      const record = buildPresenceRecord(
         agentId,
-        lastHeartbeatAt: now,
-        currentTask: sanitizeCurrentTask(currentTask),
-        activity: activity ?? (existing?.activity ?? "idle"),
-      };
+        now,
+        currentTask,
+        activity,
+        existing?.activity,
+        resolveVersion(),
+        resolveHarperVersion(),
+      );
 
       if (existing) {
         const merged = { ...existing, ...record };

--- a/schemas/schema.graphql
+++ b/schemas/schema.graphql
@@ -6,6 +6,8 @@ type Presence @table(database: "flair") @export {
   lastHeartbeatAt: BigInt        # unix ms timestamp
   currentTask: String            # short human string, e.g. "Reviewing flair#467"
   activity: String @indexed      # "coding" | "reviewing" | "planning" | "idle"
+  flairVersion: String           # @tpsdev-ai/flair version serving this heartbeat (flair#639); absent on pre-#639 records
+  harperVersion: String          # @harperfast/harper version serving this heartbeat (flair#639); absent on pre-#639 records
 }
 
 # ─── Observatory tables ───────────────────────────────────────────────────────

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -32,6 +32,7 @@ import {
   FLEET_EXIT_OK,
   type FleetSweepResult,
 } from "./fleet-verify.js";
+import { markStale, sortOldestVersionFirst, type FleetPresenceRow } from "./fleet-presence.js";
 import { detectClients, wireClaudeCode, wireCodex, wireGemini, wireCursor, type ClientId } from "./install/clients.js";
 import {
   readClientMcpBlock,
@@ -8056,6 +8057,76 @@ program
           }
           issues++;
         }
+      }
+    }
+
+    // 8. Fleet presence (flair#639) — known instances via /Presence heartbeats.
+    //
+    // "Instance" here means each AGENT's heartbeat row — Presence is keyed by
+    // agentId (schemas/schema.graphql), not by Flair server — so several rows
+    // can (and typically will) share one flairVersion/harperVersion whenever
+    // several agents heartbeat through the same Flair. That's still the
+    // useful fleet signal: an outlier version on one row means THAT agent's
+    // serving instance is behind the rest.
+    //
+    // SCOPE, verified against runFederationSyncOnce's own table list a few
+    // hundred lines up (`const tables = ["Memory", "Soul", "Agent",
+    // "Relationship"]`): Presence is NOT one of the tables federation sync
+    // replicates. So this section reports only what THIS instance's own
+    // Presence table has recorded — every agent whose FLAIR_URL points
+    // directly at the Flair `doctor` is talking to. On a hub+spokes
+    // deployment where each spoke runs its own separate Flair database, a
+    // spoke's locally-recorded heartbeats are invisible from the hub's
+    // `doctor` unless those agents also heartbeat straight to the hub. Not
+    // fixed here — flair#639's fix list is version-stamping + a doctor
+    // listing, not widening federation sync scope.
+    if (harperResponding) {
+      console.log(`\n  ${render.wrap(render.c.bold, "Fleet presence")}`);
+      try {
+        // flairVersion/harperVersion are gated to verified readers on the
+        // server (resources/Presence.ts, same boundary as currentTask) — sign
+        // the GET when we have an agent + key so the fields aren't silently
+        // nulled out from under us.
+        const fleetAgentId: string | undefined = opts.agent || process.env.FLAIR_AGENT_ID;
+        const fleetKeyPath = fleetAgentId ? join(defaultKeysDir(), `${fleetAgentId}.key`) : undefined;
+        const canSign = !!(fleetAgentId && fleetKeyPath && existsSync(fleetKeyPath));
+        const headers: Record<string, string> = canSign
+          ? { Authorization: buildEd25519Auth(fleetAgentId!, "GET", "/Presence", fleetKeyPath!) }
+          : {};
+
+        const presRes = await fetch(`${baseUrl}/Presence`, { headers, signal: AbortSignal.timeout(5000) });
+        if (!presRes.ok) {
+          console.log(`  ${render.icons.warn} Could not fetch presence roster (HTTP ${presRes.status})`);
+        } else {
+          const roster = (await presRes.json()) as FleetPresenceRow[];
+          if (!Array.isArray(roster) || roster.length === 0) {
+            console.log(`  ${render.icons.info} No known instances yet — no /Presence heartbeats recorded on this instance`);
+          } else {
+            const rows = sortOldestVersionFirst(markStale(roster));
+            for (const row of rows) {
+              const lastSeen = typeof row.lastHeartbeatAt === "number"
+                ? render.relativeTime(new Date(row.lastHeartbeatAt).toISOString())
+                : "—";
+              const versionLabel = !canSign
+                ? render.wrap(render.c.dim, "hidden")
+                : row.flairVersion
+                  ? `v${row.flairVersion}`
+                  : render.wrap(render.c.dim, "no version reported");
+              const staleNote = row.stale && row.newestVersion
+                ? " " + render.wrap(render.c.yellow, `(stale — fleet newest is v${row.newestVersion})`)
+                : "";
+              const icon = row.stale ? render.icons.warn : render.icons.ok;
+              const statusSuffix = row.presenceStatus ? ` (${row.presenceStatus})` : "";
+              console.log(`  ${icon} ${row.id} — ${versionLabel} — last seen ${lastSeen}${statusSuffix}${staleNote}`);
+            }
+            if (!canSign) {
+              console.log(`     ${render.wrap(render.c.dim, "Pass --agent <id> (with a matching key in ~/.flair/keys) to reveal versions — flairVersion/harperVersion require a verified signature, same as currentTask.")}`);
+            }
+            console.log(`     ${render.wrap(render.c.dim, "Staleness above is fleet-relative (newest version seen among these instances) — comparing against the latest PUBLISHED flair is the version check at the top of this report, not this section.")}`);
+          }
+        }
+      } catch (err: any) {
+        console.log(`  ${render.icons.warn} Fleet presence check failed: ${err?.message ?? err}`);
       }
     }
 

--- a/src/fleet-presence.ts
+++ b/src/fleet-presence.ts
@@ -1,0 +1,119 @@
+// ─── Doctor: fleet presence / instance staleness (flair#639) ────────────────────
+//
+// `flair doctor` diagnosed a single instance only. Auto-presence (flair#608)
+// gives every agent a heartbeat, and each heartbeat now carries the SERVING
+// instance's own flair + harper version (resources/Presence.ts,
+// buildPresenceRecord()) — so the /Presence roster doubles as an org-level
+// fleet-version report, IF something reads it that way. This module is that
+// reading: pure classification over an already-fetched roster, no network,
+// no crypto, so it's fast and fully unit-testable in isolation — same split
+// as doctor-client.ts (pure logic here; the network fetch + Ed25519 signing
+// stay in src/cli.ts alongside authFetch/buildEd25519Auth, which they reuse).
+//
+// Deliberately NOT npm-latest aware: comparing against the newest version
+// PUBLISHED is version-nudge's job (src/version-check.ts, flair#587/#594).
+// This is comparing instances against EACH OTHER — "is anyone behind the
+// rest of the fleet" — which stays meaningful even fully offline, and is the
+// question flair#639 actually asks: an org-level answer without probing
+// every host by hand.
+//
+// Semver comparison reuses fabric-upgrade.ts's parseSemverCore/semverGte
+// (major.minor.patch only, pre-release/build suffixes ignored) — the one
+// semver implementation in this codebase; duplicating it here would risk the
+// two drifting on an edge case.
+
+import { parseSemverCore, semverGte } from "./fabric-upgrade.js";
+
+/**
+ * One row of the /Presence roster relevant to fleet-version classification.
+ * Deliberately a subset (not the full roster shape) — callers pass whatever
+ * they fetched; extra fields are ignored, missing optional fields are
+ * tolerated (an older, pre-flair#639 instance never wrote flairVersion at
+ * all — that's the fleet-skew reality this feature exists to surface).
+ */
+export interface FleetPresenceRow {
+  id: string;
+  flairVersion?: string | null;
+  harperVersion?: string | null;
+  lastHeartbeatAt?: number | null;
+  presenceStatus?: string;
+}
+
+export interface FleetInstanceRow extends FleetPresenceRow {
+  /** True when this row is behind the newest version seen across the roster. */
+  stale: boolean;
+  /** Newest flairVersion seen across the WHOLE roster, or null if none reported one. */
+  newestVersion: string | null;
+}
+
+/** True only for a non-empty, parseable semver string — the one predicate every
+ *  function below needs, so it lives in exactly one place. */
+function hasParsableVersion(v: string | null | undefined): v is string {
+  return typeof v === "string" && parseSemverCore(v) !== null;
+}
+
+/**
+ * Newest flairVersion seen across the roster. Entries with no (or an
+ * unparseable) version are excluded from the computation — an unversioned
+ * record can't be compared, so it can't set the bar. Returns null when NO
+ * entry in the roster reports a parseable version (nothing to compare
+ * against — e.g. a fleet that's entirely pre-flair#639, or a roster with a
+ * single unversioned instance).
+ */
+export function newestVersionSeen(rows: FleetPresenceRow[]): string | null {
+  let newest: string | null = null;
+  for (const row of rows) {
+    if (!hasParsableVersion(row.flairVersion)) continue;
+    if (newest === null || semverGte(row.flairVersion, newest)) newest = row.flairVersion;
+  }
+  return newest;
+}
+
+/**
+ * Flag each roster row as stale relative to the newest flairVersion seen
+ * ACROSS THE WHOLE ROSTER (never against npm-latest — see module doc). A row
+ * is stale when:
+ *   - the roster has SOME newest version to compare against (newest !== null)
+ *     AND
+ *   - this row has no parseable version of its own (an older, pre-flair#639
+ *     instance — the loudest possible skew signal), OR its version is older
+ *     than the newest seen.
+ *
+ * A single-instance roster, or a roster where every instance reports the
+ * IDENTICAL version, has nothing to compare against → newest equals every
+ * row's own version (or is null) → nothing is flagged stale. A roster where
+ * NO instance has ever reported a version (newest === null) similarly flags
+ * nothing — there's no fleet-relative signal yet, only an org-wide gap this
+ * function can't see (that's what the "pass --agent to reveal versions" /
+ * "no versions reported yet" doctor messaging is for, not staleness).
+ */
+export function markStale(rows: FleetPresenceRow[]): FleetInstanceRow[] {
+  const newest = newestVersionSeen(rows);
+  return rows.map((row) => {
+    const stale = newest !== null && (!hasParsableVersion(row.flairVersion) || !semverGte(row.flairVersion, newest));
+    return { ...row, stale, newestVersion: newest };
+  });
+}
+
+/**
+ * Sort oldest-version-first so problems top the listing (flair#639's stated
+ * requirement). Rows with no parseable version sort FIRST — an unversioned
+ * instance is the biggest unknown in the fleet, not a middling one, and
+ * markStale() always flags it stale whenever the roster has any signal at
+ * all, so surfacing it first keeps the "problems on top" contract even when
+ * mixed with real-but-old versions. Ties (equal versions) preserve roster
+ * order (stable sort).
+ */
+export function sortOldestVersionFirst<T extends { flairVersion?: string | null }>(rows: T[]): T[] {
+  return [...rows].sort((a, b) => {
+    const pa = hasParsableVersion(a.flairVersion) ? parseSemverCore(a.flairVersion) : null;
+    const pb = hasParsableVersion(b.flairVersion) ? parseSemverCore(b.flairVersion) : null;
+    if (!pa && !pb) return 0;
+    if (!pa) return -1;
+    if (!pb) return 1;
+    for (let i = 0; i < 3; i++) {
+      if (pa[i] !== pb[i]) return pa[i] - pb[i];
+    }
+    return 0;
+  });
+}

--- a/test/integration/doctor-fleet-presence.test.ts
+++ b/test/integration/doctor-fleet-presence.test.ts
@@ -1,0 +1,169 @@
+/**
+ * doctor-fleet-presence.test.ts — Integration tests for `flair doctor`'s
+ * "Fleet presence" section (flair#639): known instances via /Presence
+ * heartbeats, version stamping, and org-relative staleness.
+ *
+ * Drives the REAL built CLI (dist/cli.js) as subprocesses against a
+ * throwaway Harper, same pattern as onboarding-smoke.test.ts:
+ *   - startHarper() spins Harper from a mkdtemp install dir on OS-assigned
+ *     free ports — NEVER ~/.flair, NEVER port 9926.
+ *   - The CLI subprocesses run with HOME pointed at a separate mktemp dir,
+ *     so the CLI's own ~/.flair (keys, config, admin-pass) is fully
+ *     isolated too — never reads the host's real ~/.flair files.
+ *
+ * Build prerequisite: dist/cli.js and dist/resources/*.js must exist
+ * (`bun run build && bun run build:cli`).
+ */
+
+import { describe, expect, test, beforeAll, afterAll } from "bun:test";
+import { spawn } from "node:child_process";
+import { mkdtemp, rm } from "node:fs/promises";
+import { readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { startHarper, stopHarper, type HarperInstance } from "../helpers/harper-lifecycle";
+
+const CLI = join(process.cwd(), "dist", "cli.js");
+const ADMIN_PASS = "test123"; // matches harper-lifecycle's seeded admin pass
+const AGENT_A = "fleet-doctor-agent-a";
+const LEGACY_STALE_ID = "fleet-doctor-agent-old";
+
+let harper: HarperInstance;
+let cliHome: string; // isolated HOME for the CLI's own ~/.flair
+
+interface RunResult {
+  code: number | null;
+  stdout: string;
+  stderr: string;
+}
+
+function runCli(args: string[], extraEnv: Record<string, string> = {}): Promise<RunResult> {
+  const opsPort = new URL(harper.opsURL).port;
+  return new Promise((resolve, reject) => {
+    const child = spawn(process.execPath, [CLI, ...args], {
+      env: {
+        ...process.env,
+        HOME: cliHome,
+        FLAIR_URL: harper.httpURL,
+        FLAIR_OPS_PORT: opsPort,
+        FLAIR_TOKEN: "",
+        FLAIR_ADMIN_PASS: "",
+        ...extraEnv,
+      },
+    });
+    let stdout = "";
+    let stderr = "";
+    child.stdout?.on("data", (d: Buffer) => { stdout += d.toString(); });
+    child.stderr?.on("data", (d: Buffer) => { stderr += d.toString(); });
+    child.on("error", reject);
+    child.on("exit", (code) => resolve({ code, stdout, stderr }));
+    setTimeout(() => { child.kill(); reject(new Error(`CLI timed out: ${args.join(" ")}\n${stdout}\n${stderr}`)); }, 30_000);
+  });
+}
+
+beforeAll(async () => {
+  harper = await startHarper();
+  cliHome = await mkdtemp(join(tmpdir(), "flair-fleet-doctor-home-"));
+}, 120_000);
+
+afterAll(async () => {
+  if (harper) await stopHarper(harper);
+  if (cliHome) await rm(cliHome, { recursive: true, force: true, maxRetries: 4 });
+});
+
+const httpPort = () => new URL(harper.httpURL).port;
+const opsPort = () => new URL(harper.opsURL).port;
+
+// The exact package.json this repo's resolveVersion() (resources/Presence.ts)
+// reads at runtime — Harper is spawned with cwd: process.cwd() (this
+// worktree root), so this is the SAME file the running server resolves.
+const REAL_FLAIR_VERSION: string = JSON.parse(
+  readFileSync(join(process.cwd(), "package.json"), "utf-8"),
+).version;
+
+describe("flair doctor — fleet presence (flair#639, real CLI + real spawned Harper)", () => {
+  test("agent add + presence heartbeat + doctor renders fleet presence with the real version", async () => {
+    const add = await runCli([
+      "agent", "add", AGENT_A,
+      "--admin-pass", ADMIN_PASS,
+      "--port", httpPort(),
+      "--ops-port", opsPort(),
+    ]);
+    if (add.code !== 0) console.error(`agent add failed:\n${add.stdout}\n${add.stderr}`);
+    expect(add.code).toBe(0);
+
+    const set = await runCli([
+      "presence", "set",
+      "--agent", AGENT_A,
+      "--activity", "coding",
+      "--task", "flair#639 doctor integration test",
+      "--port", httpPort(),
+    ]);
+    if (set.code !== 0) console.error(`presence set failed:\n${set.stdout}\n${set.stderr}`);
+    expect(set.code).toBe(0);
+
+    const doctor = await runCli(["doctor", "--port", httpPort(), "--agent", AGENT_A]);
+    const out = `${doctor.stdout}${doctor.stderr}`;
+    expect(out).toContain("Fleet presence");
+    expect(out).toContain(AGENT_A);
+    // The real bundled package.json version shows up unmodified — proves
+    // resolveVersion()'s "keep in sync" copy resolves correctly against the
+    // ACTUAL running package, not a stub.
+    expect(out).toContain(`v${REAL_FLAIR_VERSION}`);
+    // A single, freshly-heartbeated instance has nothing to compare
+    // against — never flagged stale.
+    expect(out).not.toContain("stale");
+    // We passed --agent with a real key → versions must NOT be hidden.
+    expect(out).not.toContain("hidden");
+  }, 40_000);
+
+  test("doctor without --agent: fleet identities still show, but versions are hidden (verified-reader gate)", async () => {
+    const doctor = await runCli(["doctor", "--port", httpPort()]);
+    const out = `${doctor.stdout}${doctor.stderr}`;
+    expect(out).toContain("Fleet presence");
+    // Roster identity (agentId) is public regardless of the gate.
+    expect(out).toContain(AGENT_A);
+    expect(out).toContain("hidden");
+    expect(out).toContain("Pass --agent");
+  }, 40_000);
+
+  test("an older-version instance is flagged stale and sorted ahead of the current one", async () => {
+    // Seed a second, artificially OLD presence row directly via the ops API
+    // (bypassing POST /Presence, which always stamps the CURRENT running
+    // version by design — there's no way to make a live heartbeat report an
+    // old version other than actually running an old build).
+    const auth = "Basic " + Buffer.from(`admin:${ADMIN_PASS}`).toString("base64");
+    const seedRes = await fetch(harper.opsURL, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Authorization: auth },
+      body: JSON.stringify({
+        operation: "insert",
+        database: "flair",
+        table: "Presence",
+        records: [{
+          agentId: LEGACY_STALE_ID,
+          lastHeartbeatAt: Date.now(),
+          activity: "idle",
+          flairVersion: "0.0.1",
+          harperVersion: "0.0.1",
+        }],
+      }),
+    });
+    expect(seedRes.ok).toBe(true);
+
+    const doctor = await runCli(["doctor", "--port", httpPort(), "--agent", AGENT_A]);
+    const out = `${doctor.stdout}${doctor.stderr}`;
+    expect(out).toContain(LEGACY_STALE_ID);
+    expect(out).toContain("stale");
+    expect(out).toContain(`fleet newest is v${REAL_FLAIR_VERSION}`);
+
+    // Sort oldest-version-first: the 0.0.1 row's line precedes the current
+    // (real-version) agent's line within the Fleet presence section.
+    const sectionStart = out.indexOf("Fleet presence");
+    const oldIdx = out.indexOf(LEGACY_STALE_ID, sectionStart);
+    const currentIdx = out.indexOf(AGENT_A, sectionStart);
+    expect(oldIdx).toBeGreaterThan(-1);
+    expect(currentIdx).toBeGreaterThan(-1);
+    expect(oldIdx).toBeLessThan(currentIdx);
+  }, 40_000);
+});

--- a/test/integration/presence-api.test.ts
+++ b/test/integration/presence-api.test.ts
@@ -17,7 +17,7 @@
 
 import { describe, expect, test, beforeAll, afterAll } from "bun:test";
 import { startHarper, stopHarper, HarperInstance } from "../helpers/harper-lifecycle";
-import { writeFileSync, mkdirSync, rmSync } from "node:fs";
+import { writeFileSync, mkdirSync, rmSync, readFileSync } from "node:fs";
 import { join } from "node:os";
 import { randomBytes } from "node:crypto";
 import nacl from "tweetnacl";
@@ -238,6 +238,8 @@ describe("Presence API integration", () => {
       "presenceStatus",
       "currentTask",
       "lastHeartbeatAt",
+      "flairVersion",
+      "harperVersion",
     ]);
 
     for (const entry of roster) {
@@ -294,6 +296,88 @@ describe("Presence API integration", () => {
 
     const a1 = roster.find((r: any) => r.id === agent1.id);
     expect(a1.currentTask).toBe("investigating preprod-db-3: replication lag");
+  });
+
+  // ── 4c. flair#639: version stamping ────────────────────────────────────────
+  // Every heartbeat stamps the SERVING instance's own flair + harper versions
+  // (resources/Presence.ts, buildPresenceRecord()/resolveVersion()/
+  // resolveHarperVersion()). Rides the SAME content gate as currentTask
+  // (#592) — verified readers only, anonymous gets null for both.
+  //
+  // Expected values are read directly from THIS repo's own package.json /
+  // node_modules — the exact files resolveVersion()/resolveHarperVersion()
+  // read at runtime, since harper-lifecycle.ts spawns Harper with
+  // cwd: process.cwd(), i.e. this worktree root.
+
+  const expectedFlairVersion: string = JSON.parse(
+    readFileSync(`${process.cwd()}/package.json`, "utf-8"),
+  ).version;
+  const expectedHarperVersion: string = JSON.parse(
+    readFileSync(`${process.cwd()}/node_modules/@harperfast/harper/package.json`, "utf-8"),
+  ).version;
+
+  test("POST /Presence stamps the real running flairVersion + harperVersion", async () => {
+    const auth = buildAuthHeader(agent1.id, "POST", "/Presence", agent1.privateKey);
+    await fetch(`${harper.httpURL}/Presence`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Authorization: auth },
+      body: JSON.stringify({ activity: "coding" }),
+    });
+
+    const getAuth = buildAuthHeader(agent1.id, "GET", "/Presence", agent1.privateKey);
+    const res = await fetch(`${harper.httpURL}/Presence`, { headers: { Authorization: getAuth } });
+    expect(res.status).toBe(200);
+    const roster = await res.json();
+    const a1 = roster.find((r: any) => r.id === agent1.id);
+    expect(a1.flairVersion).toBe(expectedFlairVersion);
+    expect(a1.harperVersion).toBe(expectedHarperVersion);
+  });
+
+  test("GET /Presence WITHOUT auth: flairVersion/harperVersion are null (same gate as currentTask)", async () => {
+    const auth = buildAuthHeader(agent1.id, "POST", "/Presence", agent1.privateKey);
+    await fetch(`${harper.httpURL}/Presence`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Authorization: auth },
+      body: JSON.stringify({ activity: "coding" }),
+    });
+
+    const res = await fetch(`${harper.httpURL}/Presence`);
+    expect(res.status).toBe(200);
+    const roster = await res.json();
+    const a1 = roster.find((r: any) => r.id === agent1.id);
+    expect(a1.flairVersion).toBeNull();
+    expect(a1.harperVersion).toBeNull();
+    // roster metadata is unaffected by the gate, same as the currentTask case
+    expect(typeof a1.presenceStatus).toBe("string");
+  });
+
+  test("reader tolerance: a legacy presence record with no flairVersion/harperVersion doesn't crash GET", async () => {
+    // Simulate a pre-flair#639 instance's record: insert directly via the ops
+    // API (bypassing POST /Presence, which always stamps versions now) — same
+    // technique seedAgent() uses for Agent rows.
+    const legacyId = "presence-639-legacy-instance";
+    await fetch(harper.opsURL, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Authorization: adminAuth() },
+      body: JSON.stringify({
+        operation: "insert",
+        database: "flair",
+        table: "Presence",
+        records: [{ agentId: legacyId, lastHeartbeatAt: Date.now(), activity: "idle" }],
+      }),
+    });
+
+    const auth = buildAuthHeader(agent1.id, "GET", "/Presence", agent1.privateKey);
+    const res = await fetch(`${harper.httpURL}/Presence`, { headers: { Authorization: auth } });
+    expect(res.status).toBe(200);
+    const roster = await res.json();
+    const legacy = roster.find((r: any) => r.id === legacyId);
+    expect(legacy).toBeDefined();
+    expect(legacy.flairVersion).toBeNull();
+    expect(legacy.harperVersion).toBeNull();
+    // The rest of the row is served normally — tolerance doesn't break the
+    // entry, it just leaves the two new fields null.
+    expect(typeof legacy.presenceStatus).toBe("string");
   });
 
   // ── 5. currentTask length cap ──────────────────────────────────────────────

--- a/test/unit/fleet-presence.test.ts
+++ b/test/unit/fleet-presence.test.ts
@@ -1,0 +1,168 @@
+/**
+ * fleet-presence.test.ts — Unit tests for the pure fleet-version staleness
+ * classification behind `flair doctor`'s "Fleet presence" section (flair#639).
+ *
+ * No Harper, no network — newestVersionSeen()/markStale()/sortOldestVersionFirst()
+ * are pure functions over an already-fetched /Presence roster shape.
+ */
+
+import { describe, test, expect } from "bun:test";
+import {
+  newestVersionSeen,
+  markStale,
+  sortOldestVersionFirst,
+  type FleetPresenceRow,
+} from "../../src/fleet-presence.ts";
+
+function row(id: string, flairVersion: string | null | undefined, lastHeartbeatAt = 1_700_000_000_000): FleetPresenceRow {
+  return { id, flairVersion, lastHeartbeatAt };
+}
+
+describe("newestVersionSeen", () => {
+  test("single instance with a version → that version is newest", () => {
+    expect(newestVersionSeen([row("a", "0.20.0")])).toBe("0.20.0");
+  });
+
+  test("single instance with NO version → null (nothing to compare)", () => {
+    expect(newestVersionSeen([row("a", null)])).toBeNull();
+  });
+
+  test("empty roster → null", () => {
+    expect(newestVersionSeen([])).toBeNull();
+  });
+
+  test("all instances report the SAME version → that version is newest", () => {
+    const rows = [row("a", "0.21.0"), row("b", "0.21.0"), row("c", "0.21.0")];
+    expect(newestVersionSeen(rows)).toBe("0.21.0");
+  });
+
+  test("mixed versions → the highest wins regardless of roster order", () => {
+    const rows = [row("a", "0.19.0"), row("b", "0.21.0"), row("c", "0.20.5")];
+    expect(newestVersionSeen(rows)).toBe("0.21.0");
+  });
+
+  test("versionless entries are excluded from the computation", () => {
+    const rows = [row("a", null), row("b", "0.18.0"), row("c", undefined)];
+    expect(newestVersionSeen(rows)).toBe("0.18.0");
+  });
+
+  test("all versionless → null", () => {
+    const rows = [row("a", null), row("b", undefined)];
+    expect(newestVersionSeen(rows)).toBeNull();
+  });
+
+  test("unparseable version strings are treated as absent", () => {
+    const rows = [row("a", "not-a-version"), row("b", "0.5.0")];
+    expect(newestVersionSeen(rows)).toBe("0.5.0");
+  });
+
+  test("major version differences resolved correctly", () => {
+    const rows = [row("a", "0.99.0"), row("b", "1.0.0")];
+    expect(newestVersionSeen(rows)).toBe("1.0.0");
+  });
+
+  test("pre-release/build suffixes ignored (numeric core only, per semverGte)", () => {
+    const rows = [row("a", "0.21.0-beta.1"), row("b", "0.21.0")];
+    // Equal numeric cores — either is an acceptable "newest"; must not throw
+    // and must resolve to the shared 0.21.0 core.
+    const newest = newestVersionSeen(rows);
+    expect(newest === "0.21.0-beta.1" || newest === "0.21.0").toBe(true);
+  });
+});
+
+describe("markStale", () => {
+  test("single instance with a version → not stale", () => {
+    const [a] = markStale([row("a", "0.20.0")]);
+    expect(a.stale).toBe(false);
+    expect(a.newestVersion).toBe("0.20.0");
+  });
+
+  test("single instance with NO version → not stale (nothing to compare against)", () => {
+    const [a] = markStale([row("a", null)]);
+    expect(a.stale).toBe(false);
+    expect(a.newestVersion).toBeNull();
+  });
+
+  test("all instances on the identical version → none flagged stale", () => {
+    const rows = markStale([row("a", "0.21.0"), row("b", "0.21.0"), row("c", "0.21.0")]);
+    for (const r of rows) expect(r.stale).toBe(false);
+  });
+
+  test("mixed versions → older ones stale, the newest is not", () => {
+    const [a, b, c] = markStale([row("a", "0.19.0"), row("b", "0.21.0"), row("c", "0.20.0")]);
+    expect(a.stale).toBe(true);
+    expect(b.stale).toBe(false);
+    expect(c.stale).toBe(true);
+    expect(a.newestVersion).toBe("0.21.0");
+  });
+
+  test("a versionless row is stale whenever ANY other row reports a version", () => {
+    const [a, b] = markStale([row("a", null), row("b", "0.10.0")]);
+    expect(a.stale).toBe(true); // no version at all — loudest skew signal
+    expect(b.stale).toBe(false);
+  });
+
+  test("all rows versionless → none stale (no fleet-relative signal exists yet)", () => {
+    const rows = markStale([row("a", null), row("b", undefined)]);
+    for (const r of rows) expect(r.stale).toBe(false);
+  });
+
+  test("every row carries the same newestVersion value", () => {
+    const rows = markStale([row("a", "0.18.0"), row("b", "0.21.0"), row("c", null)]);
+    expect(rows.every((r) => r.newestVersion === "0.21.0")).toBe(true);
+  });
+
+  test("unparseable version is treated the same as absent (stale, like versionless)", () => {
+    const [a, b] = markStale([row("a", "garbage"), row("b", "0.5.0")]);
+    expect(a.stale).toBe(true);
+    expect(b.stale).toBe(false);
+  });
+
+  test("does not mutate the input rows", () => {
+    const input = [row("a", "0.1.0"), row("b", "0.2.0")];
+    const snapshot = JSON.parse(JSON.stringify(input));
+    markStale(input);
+    expect(input).toEqual(snapshot);
+  });
+});
+
+describe("sortOldestVersionFirst", () => {
+  test("ascending version order", () => {
+    const rows = [row("c", "0.20.0"), row("a", "0.5.0"), row("b", "0.10.0")];
+    const sorted = sortOldestVersionFirst(rows).map((r) => r.id);
+    expect(sorted).toEqual(["a", "b", "c"]);
+  });
+
+  test("versionless rows sort FIRST — biggest unknown, not a middling one", () => {
+    const rows = [row("a", "0.5.0"), row("b", null), row("c", "0.1.0")];
+    const sorted = sortOldestVersionFirst(rows).map((r) => r.id);
+    expect(sorted[0]).toBe("b");
+  });
+
+  test("multiple versionless rows all sort ahead of every versioned row", () => {
+    const rows = [row("a", "0.5.0"), row("b", null), row("c", undefined), row("d", "0.1.0")];
+    const sorted = sortOldestVersionFirst(rows).map((r) => r.id);
+    expect(sorted.slice(0, 2).sort()).toEqual(["b", "c"]);
+    expect(sorted.slice(2)).toEqual(["d", "a"]);
+  });
+
+  test("single-instance roster is trivially sorted", () => {
+    const rows = [row("solo", "0.9.9")];
+    expect(sortOldestVersionFirst(rows).map((r) => r.id)).toEqual(["solo"]);
+  });
+
+  test("does not mutate the input array", () => {
+    const input = [row("b", "0.2.0"), row("a", "0.1.0")];
+    const result = sortOldestVersionFirst(input);
+    expect(input.map((r) => r.id)).toEqual(["b", "a"]); // original order preserved
+    expect(result.map((r) => r.id)).toEqual(["a", "b"]);
+  });
+
+  test("composes with markStale: problems top the list", () => {
+    const rows = markStale([row("newest", "0.21.0"), row("oldest", "0.1.0"), row("mid", "0.10.0")]);
+    const sorted = sortOldestVersionFirst(rows);
+    expect(sorted.map((r) => r.id)).toEqual(["oldest", "mid", "newest"]);
+    expect(sorted[0].stale).toBe(true);
+    expect(sorted[sorted.length - 1].stale).toBe(false);
+  });
+});

--- a/test/unit/presence-version-record.test.ts
+++ b/test/unit/presence-version-record.test.ts
@@ -1,0 +1,117 @@
+/**
+ * presence-version-record.test.ts — Unit tests for the presence-heartbeat
+ * record-shape builder behind POST /Presence's version stamping (flair#639).
+ *
+ * These tests exercise a pure INLINE COPY of buildPresenceRecord()/
+ * sanitizeCurrentTask() from resources/Presence.ts — mirrors
+ * presence-status-derivation.test.ts's technique for the exact same reason
+ * stated there: resources/Presence.ts extends `databases.flair.Presence` at
+ * class-definition time (module load), which resolves a live Harper database
+ * path and throws immediately outside a running Harper (verified: importing
+ * the module directly in a bare `bun run` fails with "Unable to determine
+ * database storage path"). Real Harper coverage of the write path — that
+ * resolveVersion()/resolveHarperVersion() actually resolve correctly and the
+ * live POST persists them — lives in test/integration/presence-api.test.ts.
+ *
+ * Versions are passed in already-resolved here — this IS "mocking the write
+ * path": the two version-resolution functions do real filesystem lookups
+ * and are exercised for real (not mocked) in the integration test; here we
+ * pin arbitrary values to test the record SHAPE and merge-relevant fields in
+ * isolation, with no Harper and no filesystem.
+ */
+
+import { describe, test, expect } from "bun:test";
+
+// ─── Inline copies (mirror resources/Presence.ts) ──────────────────────────────
+
+const CURRENT_TASK_MAX_LENGTH = 200;
+
+function sanitizeCurrentTask(task: unknown): string | null {
+  if (typeof task !== "string") return null;
+  const trimmed = task.trim();
+  if (trimmed.length === 0) return null;
+  return trimmed.slice(0, CURRENT_TASK_MAX_LENGTH);
+}
+
+function buildPresenceRecord(
+  agentId: string,
+  now: number,
+  currentTask: unknown,
+  activity: string | undefined,
+  existingActivity: string | undefined,
+  flairVersion: string,
+  harperVersion: string | null,
+): Record<string, unknown> {
+  return {
+    agentId,
+    lastHeartbeatAt: now,
+    currentTask: sanitizeCurrentTask(currentTask),
+    activity: activity ?? (existingActivity ?? "idle"),
+    flairVersion,
+    harperVersion,
+  };
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+const NOW = 1_700_000_000_000;
+
+describe("buildPresenceRecord", () => {
+  test("stamps both flairVersion and harperVersion onto the record", () => {
+    const record = buildPresenceRecord("agent-1", NOW, "reviewing flair#639", "coding", undefined, "0.21.0", "5.1.17");
+    expect(record.flairVersion).toBe("0.21.0");
+    expect(record.harperVersion).toBe("5.1.17");
+  });
+
+  test("harperVersion null passthrough when resolution failed", () => {
+    const record = buildPresenceRecord("agent-1", NOW, undefined, "idle", undefined, "0.21.0", null);
+    expect(record.harperVersion).toBeNull();
+    // flairVersion always resolves to a real string (falls back to "dev"),
+    // never null — the two are intentionally different types.
+    expect(record.flairVersion).toBe("0.21.0");
+  });
+
+  test("core fields (agentId, lastHeartbeatAt) always present", () => {
+    const record = buildPresenceRecord("agent-2", NOW, undefined, "idle", undefined, "0.1.0", null);
+    expect(record.agentId).toBe("agent-2");
+    expect(record.lastHeartbeatAt).toBe(NOW);
+  });
+
+  test("activity falls back to existingActivity when not provided", () => {
+    const record = buildPresenceRecord("a", NOW, undefined, undefined, "reviewing", "0.1.0", "5.0.0");
+    expect(record.activity).toBe("reviewing");
+  });
+
+  test("activity falls back to 'idle' when neither activity nor existingActivity is set", () => {
+    const record = buildPresenceRecord("a", NOW, undefined, undefined, undefined, "0.1.0", "5.0.0");
+    expect(record.activity).toBe("idle");
+  });
+
+  test("explicit activity wins over existingActivity", () => {
+    const record = buildPresenceRecord("a", NOW, undefined, "planning", "coding", "0.1.0", "5.0.0");
+    expect(record.activity).toBe("planning");
+  });
+
+  test("currentTask is sanitized (trimmed) the same as before flair#639", () => {
+    const record = buildPresenceRecord("a", NOW, "  investigating flair#639  ", "coding", undefined, "0.1.0", "5.0.0");
+    expect(record.currentTask).toBe("investigating flair#639");
+  });
+
+  test("currentTask capped at 200 chars", () => {
+    const long = "x".repeat(500);
+    const record = buildPresenceRecord("a", NOW, long, "coding", undefined, "0.1.0", "5.0.0");
+    expect((record.currentTask as string).length).toBe(200);
+  });
+
+  test("absent currentTask → null (explicit clear, unchanged from pre-#639 behavior)", () => {
+    const record = buildPresenceRecord("a", NOW, undefined, "coding", undefined, "0.1.0", "5.0.0");
+    expect(record.currentTask).toBeNull();
+  });
+
+  test("record has exactly the expected key set (no accidental extra fields)", () => {
+    const record = buildPresenceRecord("a", NOW, "task", "coding", undefined, "0.1.0", "5.0.0");
+    expect(Object.keys(record).sort()).toEqual(
+      ["activity", "agentId", "currentTask", "flairVersion", "harperVersion", "lastHeartbeatAt"].sort(),
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Implements #639: presence records now carry the running versions, and `flair doctor` surfaces fleet staleness.

- **`Presence` records gain `flairVersion` / `harperVersion`** (nullable) — stamped server-side on heartbeat via the same running-module `resolveVersion()` idiom as `HealthDetail` (#641). Readers tolerate versionless records from older instances — that skew is exactly what this feature surfaces.
- **`flair doctor` gains a "Fleet presence" section**: known agents with version(s) + last-seen, stale rows flagged and sorted oldest-version-first. Staleness is **org-relative** (behind the newest version seen) — npm-latest comparison stays version-nudge's job (#594). Informational, not a doctor failure, matching the yellow-nudge precedent.
- **Version fields are gated to verified Ed25519 readers** exactly like `currentTask` — anonymous callers get `null`. Deliberate security-consistency call mirroring `Health` vs `HealthDetail` (no version fingerprinting for anonymous callers); flagged for Sherlock.
- Staleness logic lives in pure `src/fleet-presence.ts` (the `doctor-client.ts` pattern), fully unit-tested.

## Honest scope note

**Presence does not federate** — `runFederationSyncOnce` syncs only `Memory/Soul/Agent/Relationship`. On hub+spokes, each instance's doctor sees only agents heartbeating directly to it; a spoke's local heartbeats are invisible from the hub. This is documented inline rather than papered over (the dispatch's rosier assumption was checked and corrected). Whether Presence *should* federate is a separate design question — filed as its own issue.

## Test plan (post-rebase onto current main, incl. #642)

- [x] `bun run build` && `bun run build:cli` clean
- [x] `bunx tsc --noEmit -p tsconfig.check.json` clean
- [x] `bun test test/unit/` — 1830/1830 pass (35 new: version emission, versionless-record tolerance, staleness computation incl. all-same-version and single-instance)
- [x] `bun test test/integration/` — 237/237 pass (real spawned Harper: heartbeat carries correct version; doctor renders the fleet section)
- [ ] Kern (architecture) + Sherlock (security) review

Closes #639.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
