### PR TITLE
feat(cli): pre-upgrade data snapshot + tested downgrade path (#637)

### DIFF
--- a/.github/workflows/federation-compat.yml
+++ b/.github/workflows/federation-compat.yml
@@ -15,6 +15,12 @@
 # a re-run of the whole integration suite. No embedding model predownload —
 # the round-trip check reads back via the ops API rather than semantic
 # search, so it doesn't depend on embeddings being loaded.
+#
+# Also runs test/compat/downgrade-boot.test.ts (flair#637) — a second, related
+# but distinct compat check that joined this same `bun test test/compat/`
+# scope rather than getting its own workflow: does the last npm-published
+# `@tpsdev-ai/flair` boot against a data directory the CURRENT build already
+# wrote to? Backs the downgrade compatibility claim in docs/upgrade.md.
 name: Federation Mixed-Version Compat
 
 on:
@@ -46,8 +52,11 @@ on:
       - "src/cli.ts"
       # Ed25519 instance-identity keystore federation pair/sync sign with.
       - "src/keystore.ts"
-      # The compat suite itself + this workflow (standard self-trigger).
+      # The compat suites themselves, the shared Harper spawn/reuse harness
+      # both of them build on (test/helpers/harper-lifecycle.ts), and this
+      # workflow (standard self-trigger).
       - "test/compat/**"
+      - "test/helpers/**"
       - ".github/workflows/federation-compat.yml"
   workflow_dispatch:
 
@@ -98,5 +107,5 @@ jobs:
       - name: Build Flair resources and CLI
         run: bun run build && bun run build:cli
 
-      - name: Run mixed-version federation compat suite
+      - name: Run compat suite (federation mixed-version + downgrade boot)
         run: bun test test/compat/

--- a/docs/upgrade.md
+++ b/docs/upgrade.md
@@ -57,9 +57,47 @@ actually running:
 - **On verification failure**, `flair upgrade` automatically reinstalls the
   previously-running `@tpsdev-ai/flair` version, restarts again, and
   re-verifies — then exits nonzero with a clear report of what failed. If the
-  rollback itself fails verification, it says so loudly instead of retrying
-  in a loop; see the data-snapshot guidance tracked in flair#637 before
-  touching data in that state.
+  rollback itself fails verification, it says so loudly and points at the
+  concrete pre-upgrade snapshot path (see "Pre-upgrade snapshot" below)
+  instead of retrying in a loop — see [Downgrade](#downgrade) for the
+  restore procedure.
+
+### Pre-upgrade snapshot
+
+As of flair#637, `flair upgrade` snapshots `~/.flair/data` **before** touching any
+package, whenever `@tpsdev-ai/flair` itself is one of the packages being upgraded
+(an `flair-mcp`-only or `openclaw-flair`-only upgrade never runs different code
+against your data, so nothing is snapshotted for those):
+
+```
+Snapshotting data before upgrade...
+✅ Snapshot: ~/.flair/upgrade-snapshots/flair-data-2026-07-08T14-32-01-118Z.tar.gz (842.3 MB)
+   Restore: flair stop && rm -rf "~/.flair/data" && mkdir -p "~/.flair/data" && tar -xzf "<snapshot>" -C "~/.flair/data" && flair start
+   Pruned 1 older snapshot (keeping last 3)
+```
+
+- **Location:** `~/.flair/upgrade-snapshots/flair-data-<timestamp>.tar.gz` — owner-only
+  (`0600`), with every file inside it at its **original** mode (so a `0600` key or
+  `admin-pass` file stays `0600` after a restore, not whatever tar's default would be).
+- **Retention:** keeps the newest 3 snapshots, prunes older ones automatically after
+  each successful snapshot.
+- **Consistency:** Flair is briefly stopped, snapshotted, and immediately restarted on
+  the OLD version before the package swap even begins — a plain file copy of a
+  *running* Harper's data directory isn't guaranteed point-in-time consistent (LMDB
+  writes can be mid-flight), so the snapshot always happens against a quiesced
+  directory. This means a short stop/start blip happens even with `--no-restart` — the
+  snapshot's correctness doesn't depend on whether you want a restart *after* the
+  upgrade, those are separate questions. (A native Harper backup operation,
+  `get_backup`, was evaluated and rejected here — see the code comment above
+  `createDataSnapshot` in `src/cli.ts` for why: it backs up one table/schema at a time
+  over the running HTTP API, not the whole data directory, and would be strictly less
+  complete than a plain file copy.)
+- **Failure is a hard stop by default:** if the snapshot itself fails (disk full,
+  permissions, etc.), the upgrade aborts before any package changes — no packages are
+  swapped, Flair is restarted on the version it was already running. Pass
+  `--no-snapshot` to skip the snapshot entirely on hosts that can't spare the time or
+  disk for it (not recommended — it's the only thing standing between you and an
+  untested downgrade).
 
 If you'd rather upgrade by hand instead of `flair upgrade`:
 
@@ -140,7 +178,7 @@ if you want to see it scripted end-to-end.
 
 ## Rollback
 
-If an upgrade causes problems:
+If an upgrade causes problems immediately after upgrading (code-level, not data):
 
 ```bash
 # Install a specific previous version (substitute your last known-good)
@@ -151,8 +189,70 @@ flair restart
 flair restore < ~/flair-backup-<date>.json
 ```
 
-Downgrading more than a minor version back is not a supported, tested path — restoring
-from backup on the older version is the reliable route if you need to go back further.
+`flair upgrade` does this automatically on a failed post-restart verification — see
+"Upgrade is a transaction" above. This section is for doing it by hand, e.g. after
+`--no-verify`, or after problems surface later than the automatic check catches.
+
+## Downgrade
+
+Rolling back the **package** (above) assumes the data on disk is fine — only the new
+code was the problem. If the new version actually **wrote data in a way the old
+version can't read**, package rollback alone isn't enough. This is what the
+flair#637 pre-upgrade snapshot exists for.
+
+### Procedure
+
+```bash
+# 1. Stop Flair
+flair stop
+
+# 2. Restore the pre-upgrade snapshot (see the exact path/command flair upgrade
+#    printed when it ran — or list them yourself):
+ls -la ~/.flair/upgrade-snapshots/
+rm -rf ~/.flair/data
+mkdir -p ~/.flair/data
+tar -xzf ~/.flair/upgrade-snapshots/flair-data-<timestamp>.tar.gz -C ~/.flair/data
+
+# 3. Install the previous version
+npm install -g @tpsdev-ai/flair@<previous-version>
+
+# 4. Start it back up
+flair start
+
+# 5. Verify
+flair status
+flair doctor
+```
+
+If you don't have a snapshot (upgraded with `--no-snapshot`, or on a version from
+before flair#637 shipped it), there is no tested way back short of restoring from a
+`flair backup` JSON export on the older version — do not assume an untested downgrade
+boot will work.
+
+### Does the previous version actually boot against newer data? (tested, not assumed)
+
+This used to be aspirational — nobody had actually checked. `test/compat/downgrade-boot.test.ts`
+now checks it for real, nightly, alongside the mixed-version federation suite (both run
+from `.github/workflows/federation-compat.yml`'s `bun test test/compat/`): it boots the
+current build, writes a memory and a presence row, stops it *without* wiping the data
+directory, then boots the last **npm-published** `@tpsdev-ai/flair` against that exact
+same directory and confirms it comes up healthy and can read both rows back.
+
+**As observed when this suite was added (2026-07-08):** the npm-published baseline
+(0.21.0) boots cleanly against data written by a HEAD build roughly 14 commits ahead of
+it (several security-hardening and CLI-behavior changes, no Flair schema migration, and
+only a patch-level `@harperfast/harper` bump, 5.1.15 → 5.1.17) — both the memory and
+presence rows written by the newer build were readable through the older build's own
+HTTP surface after the downgrade boot. **No downgrade break has been found across that
+gap.**
+
+This is *not* a blanket "downgrade is always safe" guarantee for every future release —
+it's a live, continuously-checked claim. If `test/compat/downgrade-boot.test.ts` starts
+failing (a real schema-incompatible change landing without a documented break), this
+section and the test's own assertions get updated together to say so explicitly, the
+same way this paragraph does today. Check the suite's latest nightly run (or the
+CHANGELOG for an explicit "no downgrade past X" note) before relying on this for a jump
+you haven't personally tested.
 
 ## See also
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -6940,7 +6940,13 @@ program
           }
           process.exit(1);
         }
-        await startFlairProcess(upgradePort);
+        try {
+          await startFlairProcess(upgradePort);
+        } catch (err: any) {
+          console.error(`❌ failed to restart Flair after the pre-upgrade snapshot: ${err.message}`);
+          console.error(`   The snapshot itself succeeded (${snapshotPath}) — no packages were changed. Check: flair doctor`);
+          process.exit(1);
+        }
       }
     }
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -15,6 +15,8 @@ import {
   mkdtempSync,
   readdirSync,
   statSync,
+  lstatSync,
+  realpathSync,
 } from "node:fs";
 import { homedir, hostname, tmpdir } from "node:os";
 import { join, resolve, sep, dirname } from "node:path";
@@ -6551,6 +6553,159 @@ async function runFabricUpgrade(opts: any): Promise<void> {
   }
 }
 
+// ─── Pre-upgrade data snapshot (flair#637) ─────────────────────────────────
+// `flair upgrade` used to swap @tpsdev-ai/flair's own package with no backup
+// of ~/.flair/data — if an upgrade broke something past the package level
+// (schema/data, not just code), there was no tested way back. This is cheap
+// insurance: a timestamped tar.gz of the whole data directory taken right
+// before the package swap, with a keep-last-3 retention policy.
+//
+// Native-backup alternative considered and rejected: Harper ships a
+// `get_backup` operation (@harperfast/harper's dataLayer/getBackup.ts,
+// wired in server/serverHelpers/serverUtilities.ts, documented in
+// components/mcp/tools/schemas/operationDescriptions.ts) that streams a
+// live backup over the running HTTP operations API. It's available in this
+// OSS tier (no license/tier gate found in operation_authorization.ts — just
+// `requires_su`), but it backs up ONE database/table at a time
+// (GetBackupObject requires `schema`/`table`, or defaults to a single "data"
+// database) — not the whole `~/.flair/data` tree: no config, no
+// users/roles, no keys, no other schemas. Using it here would mean
+// enumerating every schema/table and making N authenticated HTTP calls
+// against a server this same command is about to take down — for a LESS
+// complete result than a plain recursive file copy, and one that can't run
+// at all once the server is stopped (it's an operations-API call, not a
+// standalone filesystem utility). Rejected in favor of the file-level
+// snapshot below. See docs/upgrade.md for the restore procedure this
+// produces.
+const UPGRADE_SNAPSHOT_ROOT = resolve(homedir(), ".flair", "upgrade-snapshots");
+const UPGRADE_SNAPSHOT_RETAIN = 3;
+
+function upgradeSnapshotFileName(): string {
+  const ts = new Date().toISOString().replace(/[:.]/g, "-");
+  return `flair-data-${ts}.tar.gz`;
+}
+
+/**
+ * Snapshot `dataDir` (normally ~/.flair/data) into a timestamped tar.gz
+ * under ~/.flair/upgrade-snapshots/.
+ *
+ * Consistency: the caller is expected to have stopped Flair first (a
+ * running Harper's data dir can be mid-write, and a plain file copy of a
+ * live LMDB environment isn't guaranteed point-in-time consistent) — this
+ * function itself doesn't stop anything, it just archives whatever is on
+ * disk right now.
+ *
+ * Preserves file modes exactly — deliberately NOT using tar's `portable`
+ * option (used elsewhere in this file for the deploy tarball and session
+ * snapshots), which flattens every entry's mode to a umask-based "reasonable
+ * default" and would turn 0600 key/admin-pass files into whatever that
+ * default is. Never follows symlinks out of `dataDir`: node-tar already
+ * archives symlinks as symlinks by default (no `follow` option set here),
+ * and the filter below additionally skips any symlink whose resolved target
+ * falls outside `dataDir`, plus any non-regular file (sockets, FIFOs, device
+ * nodes — e.g. a stale `operations-server` domain socket left behind by a
+ * prior run) that tar can't meaningfully archive anyway.
+ *
+ * Throws on any failure — `flair upgrade` treats a snapshot failure as
+ * abort-the-upgrade by default (safe default; --no-snapshot is the opt-out
+ * for hosts that can't spare the time/disk).
+ *
+ * `snapshotRoot` defaults to UPGRADE_SNAPSHOT_ROOT (~/.flair/upgrade-snapshots)
+ * but is an explicit parameter — not read from homedir() internally — so
+ * unit tests can point it at a throwaway temp dir instead of this machine's
+ * real ~/.flair (test/unit/upgrade-data-snapshot.test.ts).
+ */
+export async function createDataSnapshot(
+  dataDir: string,
+  snapshotRoot: string = UPGRADE_SNAPSHOT_ROOT,
+): Promise<{ path: string; bytes: number }> {
+  mkdirSync(snapshotRoot, { recursive: true, mode: 0o700 });
+  const snapshotPath = join(snapshotRoot, upgradeSnapshotFileName());
+  // realpath, not just resolve() — on macOS (and some Linux distros) the
+  // system temp dir itself sits behind a symlink (/tmp -> /private/tmp), so
+  // a plain lexical resolve() of `dataDir` would never equal the realpath()
+  // of a symlink target genuinely INSIDE it, misclassifying every in-bounds
+  // symlink as an escape.
+  const resolvedDataDir = realpathSync(resolve(dataDir));
+
+  const filter = (entryPath: string): boolean => {
+    // entryPath is relative to `cwd` (dataDir) per tar's create() contract.
+    const abs = resolve(resolvedDataDir, entryPath);
+    let st;
+    try {
+      st = lstatSync(abs);
+    } catch {
+      return false; // vanished between readdir and stat — skip, don't crash the snapshot
+    }
+    if (st.isSocket() || st.isFIFO() || st.isCharacterDevice() || st.isBlockDevice()) {
+      console.error(`  (skipping non-regular file in snapshot: ${entryPath})`);
+      return false;
+    }
+    if (st.isSymbolicLink()) {
+      let real: string;
+      try {
+        real = realpathSync(abs);
+      } catch {
+        console.error(`  (skipping broken symlink in snapshot: ${entryPath})`);
+        return false;
+      }
+      const withinDataDir = real === resolvedDataDir || real.startsWith(resolvedDataDir + sep);
+      if (!withinDataDir) {
+        console.error(`  (skipping symlink pointing outside the data dir: ${entryPath})`);
+        return false;
+      }
+    }
+    return true;
+  };
+
+  // preservePaths: true — WITHOUT it, node-tar strips the leading `/` off
+  // any absolute symlink target it archives (found the hard way: an
+  // in-bounds symlink pointing at an absolute path under `dataDir` came
+  // back on extraction as a nonsense RELATIVE path, silently broken). Every
+  // entry path here is already relative (fileList is `["."]`, cwd is
+  // `dataDir`) — this only affects symlink target text, restoring it
+  // verbatim, which is exactly what a same-host restore into the original
+  // ~/.flair/data path needs.
+  await tarCreate({ gzip: true, cwd: resolvedDataDir, file: snapshotPath, filter, preservePaths: true }, ["."]);
+  // Owner-only — the archive can contain 0600 key/admin-pass material.
+  chmodSync(snapshotPath, 0o600);
+  return { path: snapshotPath, bytes: statSync(snapshotPath).size };
+}
+
+/**
+ * Keep only the newest `retain` upgrade snapshots, deleting older ones.
+ * Best-effort: a pruning failure is logged, not thrown — it must never
+ * un-succeed an upgrade whose snapshot already landed safely on disk.
+ * Returns the paths removed.
+ *
+ * `snapshotRoot` is explicit for the same testability reason as
+ * `createDataSnapshot` above.
+ */
+export function pruneOldSnapshots(
+  retain: number = UPGRADE_SNAPSHOT_RETAIN,
+  snapshotRoot: string = UPGRADE_SNAPSHOT_ROOT,
+): string[] {
+  if (!existsSync(snapshotRoot)) return [];
+  const removed: string[] = [];
+  try {
+    const files = readdirSync(snapshotRoot)
+      .filter((f) => f.startsWith("flair-data-") && f.endsWith(".tar.gz"))
+      .map((f) => join(snapshotRoot, f))
+      .sort((a, b) => statSync(b).mtimeMs - statSync(a).mtimeMs);
+    for (const stale of files.slice(retain)) {
+      try {
+        rmSync(stale, { force: true });
+        removed.push(stale);
+      } catch (err: any) {
+        console.error(`  (could not prune old snapshot ${stale}: ${err.message})`);
+      }
+    }
+  } catch (err: any) {
+    console.error(`  (snapshot retention check failed: ${err.message})`);
+  }
+  return removed;
+}
+
 // ─── flair upgrade ────────────────────────────────────────────────────────────
 
 program
@@ -6560,6 +6715,7 @@ program
   .option("--restart", "[deprecated] no-op — restart now happens automatically after upgrade; use --no-restart to opt out")
   .option("--no-restart", "Skip the restart after upgrade (stage new packages now, restart later)")
   .option("--no-verify", "Skip post-restart health/version/auth verification (default: verify — so a broken upgrade can't report success; see flair#635)")
+  .option("--no-snapshot", "Skip the pre-upgrade ~/.flair/data snapshot (default: snapshot before the package swap, keep-last-3 retention; see flair#637)")
   .option("--all", "Show transitive packages (e.g. flair-client) in the listing — verbose mode for debugging dep versions")
   // ── Fabric upgrade (--target) ────────────────────────────────────────────
   // When --target is passed, upgrade the Flair component DEPLOYED to that
@@ -6728,6 +6884,66 @@ program
       return;
     }
 
+    // Hoisted here (was previously computed after install/restart) — the
+    // pre-upgrade snapshot below needs to know the target port AND whether a
+    // restart is coming, before any package is touched. Pure function of
+    // `opts` — safe to call this early.
+    const { restart: shouldRestart, verify: shouldVerify, deprecatedRestartFlagUsed } =
+      resolveUpgradeRestartVerify(opts);
+    const upgradePort = resolveHttpPort({});
+
+    // ── Pre-upgrade data snapshot (flair#637) ───────────────────────────────
+    // Only an @tpsdev-ai/flair package swap touches the code that reads/
+    // writes ~/.flair/data — an flair-mcp-only or openclaw-plugin-only
+    // upgrade never runs different Harper/Flair code against the data, so
+    // there's nothing at risk and nothing to snapshot.
+    const flairIsUpgrading = npmUpgrades.some((u) => u.pkg === "@tpsdev-ai/flair");
+    let snapshotPath: string | null = null;
+    if (flairIsUpgrading && opts.snapshot === false) {
+      console.log("\n⚠️  --no-snapshot: skipping the pre-upgrade data snapshot. If this upgrade breaks something past the package level, there is no tested way back.");
+    } else if (flairIsUpgrading) {
+      const snapshotDataDir = defaultDataDir();
+      if (!existsSync(snapshotDataDir)) {
+        console.log(`\n(no data directory at ${snapshotDataDir} yet — nothing to snapshot)`);
+      } else {
+        console.log("\nSnapshotting data before upgrade...");
+        // Consistency: a running Harper's data dir can be mid-write, and a
+        // plain file copy of a live LMDB environment isn't guaranteed
+        // point-in-time consistent. Stopping first — then immediately
+        // restarting the OLD version, before any package changes — gives a
+        // quiesced, safe-to-copy directory with only a brief blip, even for
+        // --no-restart (the snapshot's correctness doesn't depend on
+        // whether the caller wants a restart AFTER the upgrade — those are
+        // orthogonal). --no-snapshot is the escape hatch for hosts that
+        // can't tolerate even this blip. See docs/upgrade.md for the
+        // native-backup alternative considered and rejected (Harper's
+        // `get_backup` op backs up one table/schema at a time over the
+        // running HTTP API — not the whole data dir — and rejecting it here
+        // means this path never depends on the server being up).
+        let stoppedForSnapshot = false;
+        try {
+          await stopFlairProcess(upgradePort);
+          stoppedForSnapshot = true;
+          const snapshot = await createDataSnapshot(snapshotDataDir);
+          snapshotPath = snapshot.path;
+          const removed = pruneOldSnapshots();
+          console.log(`✅ Snapshot: ${snapshotPath} (${humanBytes(snapshot.bytes)})`);
+          console.log(`   Restore: flair stop && rm -rf "${snapshotDataDir}" && mkdir -p "${snapshotDataDir}" && tar -xzf "${snapshotPath}" -C "${snapshotDataDir}" && flair start`);
+          if (removed.length > 0) {
+            console.log(`   Pruned ${removed.length} older snapshot${removed.length > 1 ? "s" : ""} (keeping last ${UPGRADE_SNAPSHOT_RETAIN})`);
+          }
+        } catch (err: any) {
+          console.error(`❌ snapshot failed: ${err.message}`);
+          console.error("   Aborting upgrade — no packages were changed. Use --no-snapshot to skip (not recommended).");
+          if (stoppedForSnapshot) {
+            try { await startFlairProcess(upgradePort); } catch { /* best effort — surface the original snapshot error, not this */ }
+          }
+          process.exit(1);
+        }
+        await startFlairProcess(upgradePort);
+      }
+    }
+
     // Perform upgrade. `latest` comes from the npm registry's HTTP
     // response, so CodeQL (correctly) treats it as untrusted input.
     // Use execFileSync with argv — the spec `<name>@<version>` becomes a
@@ -6782,8 +6998,9 @@ program
         ? flairFinding.latest
         : flairFinding?.installed ?? null;
 
-    const { restart: shouldRestart, verify: shouldVerify, deprecatedRestartFlagUsed } =
-      resolveUpgradeRestartVerify(opts);
+    // shouldRestart/shouldVerify/deprecatedRestartFlagUsed were hoisted above
+    // the pre-upgrade snapshot block — it needs to know these before any
+    // package is touched.
     if (deprecatedRestartFlagUsed) {
       console.error("warning: --restart is deprecated and is now a no-op — flair upgrade restarts by default. Use --no-restart to skip it.");
     }
@@ -6794,7 +7011,7 @@ program
     }
 
     console.log("\nRestarting Flair...");
-    const port = resolveHttpPort({});
+    const port = upgradePort;
     const baseUrl = `http://127.0.0.1:${port}`;
     try {
       await restartFlair(port);
@@ -6864,7 +7081,15 @@ program
 
     console.error(`❌❌ ROLLBACK ALSO FAILED VERIFICATION: ${rollbackVerdict.reason}`);
     console.error("   Instance state is UNKNOWN — do not assume data integrity.");
-    console.error("   This double-failure isn't auto-recoverable yet — see flair#637 (data-snapshot) before touching data.");
+    // This double-failure isn't auto-recoverable yet (flair#637) — but if a
+    // pre-upgrade snapshot landed, point at the CONCRETE path instead of
+    // just the issue number, so recovery doesn't start with a GitHub search.
+    if (snapshotPath) {
+      console.error(`   A pre-upgrade snapshot is available: ${snapshotPath}`);
+      console.error(`   Restore procedure: docs/upgrade.md#downgrade — stop Flair, restore the snapshot, reinstall the previous version, start, verify.`);
+    } else {
+      console.error("   No pre-upgrade snapshot was taken for this run (--no-snapshot was used, or ~/.flair/data didn't exist yet) — do not touch data without one. See docs/upgrade.md#downgrade.");
+    }
     process.exit(1);
   });
 
@@ -6995,17 +7220,18 @@ program
 // ─── flair restart ────────────────────────────────────────────────────────────
 
 /**
- * The ONE restart mechanism for a local Flair install — launchd stop/start
- * on darwin when a plist is present (falling back on failure), otherwise a
- * manual SIGTERM + respawn. Shared by `flair restart` and `flair upgrade`'s
- * post-install restart step (flair#635) so the two never drift into two
- * different ways to bounce the same process.
+ * Stop the local Flair (Harper) process — launchd `stop` on darwin when a
+ * plist is present (falling back on failure), otherwise a manual SIGTERM by
+ * port. Split out of the old monolithic `restartFlair` (flair#637) so the
+ * pre-upgrade snapshot can quiesce the data directory between a stop and a
+ * start without duplicating this logic — `restartFlair` is now just
+ * `stopFlairProcess` followed by `startFlairProcess`.
  *
- * Throws on failure instead of calling process.exit — callers decide how to
- * react (`flair restart` exits 1; `flair upgrade` treats a failed restart as
- * an upgrade failure and may attempt a rollback).
+ * Idempotent-ish: stopping an already-stopped instance is a harmless no-op
+ * on both paths (launchctl stop on an unloaded/idle service, or an empty
+ * `lsof` match).
  */
-async function restartFlair(port: number): Promise<void> {
+async function stopFlairProcess(port: number): Promise<void> {
   if (process.platform === "darwin") {
     const label = "ai.tpsdev.flair";
     const plistPath = join(homedir(), "Library", "LaunchAgents", `${label}.plist`);
@@ -7014,21 +7240,21 @@ async function restartFlair(port: number): Promise<void> {
         const { execSync } = await import("node:child_process");
         // Ensure the service is loaded (init writes the plist but doesn't load it)
         try { execSync(`launchctl load "${plistPath}"`, { stdio: "pipe" }); } catch {}
-        // Capture the current PID *before* stopping so we can verify exit. Without
-        // this, waitForHealth can race against the still-shutting-down old process
-        // and return success before KeepAlive brings the new one up.
+        // Capture the current PID *before* stopping so callers that
+        // immediately restart can verify exit. Without this, waitForHealth
+        // can race against the still-shutting-down old process and return
+        // success before KeepAlive brings the new one up.
         const oldPid = readHarperPid(defaultDataDir());
         try { execSync(`launchctl stop ${label}`, { stdio: "pipe" }); } catch {}
         if (oldPid) await waitForProcessExit(oldPid, STARTUP_TIMEOUT_MS);
-        await waitForHealth(port, DEFAULT_ADMIN_USER, process.env.HDB_ADMIN_PASSWORD ?? "", STARTUP_TIMEOUT_MS);
         return;
       } catch (err: any) {
-        console.error(`launchd restart failed, falling back to port restart: ${err.message}`);
+        console.error(`launchd stop failed, falling back to port-based stop: ${err.message}`);
       }
     }
   }
 
-  // Port-based restart (Linux, or macOS fallback when no launchd plist)
+  // Port-based stop (Linux, or macOS fallback when no launchd plist)
   console.log("Stopping...");
   try {
     const { execSync } = await import("node:child_process");
@@ -7041,6 +7267,29 @@ async function restartFlair(port: number): Promise<void> {
       await new Promise(r => setTimeout(r, 2000));
     }
   } catch { /* not running */ }
+}
+
+/**
+ * Start the local Flair (Harper) process — launchd `start` on darwin when a
+ * plist is present (falling back on failure), otherwise a direct spawn.
+ * Counterpart to `stopFlairProcess`; see that function's doc comment.
+ */
+async function startFlairProcess(port: number): Promise<void> {
+  if (process.platform === "darwin") {
+    const label = "ai.tpsdev.flair";
+    const plistPath = join(homedir(), "Library", "LaunchAgents", `${label}.plist`);
+    if (existsSync(plistPath)) {
+      try {
+        const { execSync } = await import("node:child_process");
+        try { execSync(`launchctl load "${plistPath}"`, { stdio: "pipe" }); } catch {}
+        try { execSync(`launchctl start ${label}`, { stdio: "pipe" }); } catch {}
+        await waitForHealth(port, DEFAULT_ADMIN_USER, process.env.HDB_ADMIN_PASSWORD ?? "", STARTUP_TIMEOUT_MS);
+        return;
+      } catch (err: any) {
+        console.error(`launchd start failed, falling back to direct start: ${err.message}`);
+      }
+    }
+  }
 
   console.log("Starting...");
   const bin = harperBin();
@@ -7072,6 +7321,23 @@ async function restartFlair(port: number): Promise<void> {
   proc.unref();
 
   await waitForHealth(port, DEFAULT_ADMIN_USER, adminPass, STARTUP_TIMEOUT_MS);
+}
+
+/**
+ * The ONE restart mechanism for a local Flair install. Shared by `flair
+ * restart` and `flair upgrade`'s post-install restart step (flair#635) so
+ * the two never drift into two different ways to bounce the same process.
+ * Composed of `stopFlairProcess` + `startFlairProcess` (flair#637) — the
+ * pre-upgrade snapshot step calls those two directly with a snapshot taken
+ * in between, instead of going through this wrapper.
+ *
+ * Throws on failure instead of calling process.exit — callers decide how to
+ * react (`flair restart` exits 1; `flair upgrade` treats a failed restart as
+ * an upgrade failure and may attempt a rollback).
+ */
+async function restartFlair(port: number): Promise<void> {
+  await stopFlairProcess(port);
+  await startFlairProcess(port);
 }
 
 program

--- a/test/compat/downgrade-boot.test.ts
+++ b/test/compat/downgrade-boot.test.ts
@@ -1,0 +1,306 @@
+// Downgrade compat (flair#637): does the previously-published npm baseline
+// BOOT against a data directory the CURRENT build has already written to?
+//
+// This is the honesty check behind `flair upgrade`'s new pre-upgrade
+// snapshot (src/cli.ts, flair#637): the snapshot is only useful insurance if
+// restoring it and starting an OLDER Flair actually works. Nobody had ever
+// tested that before this suite — "downgrade" was aspirational, not verified.
+//
+// Scenario (mirrors a real operator downgrade exactly — no shortcuts):
+//   1. Boot the CURRENT BUILD (this worktree's own `dist/`, via
+//      `startHarper()` — same mechanism test/integration/*.test.ts and
+//      test/compat/federation-mixed-version.test.ts use) against a FRESH,
+//      throwaway data directory.
+//   2. Write real data through it: register an agent, add a permanent
+//      memory, set presence.
+//   3. Stop it WITHOUT deleting the data directory
+//      (`stopHarper(inst, { keepInstallDir: true })` — flair#637's harness
+//      addition to test/helpers/harper-lifecycle.ts).
+//   4. Boot the previously-published npm baseline (`@tpsdev-ai/flair@latest`
+//      on the public registry, installed fresh — same "baseline" concept as
+//      federation-mixed-version.test.ts) against THAT SAME data directory,
+//      via `startHarper({ installDir: <the current build's dir> })`. No
+//      re-init, no `--purge`, no touching the files by hand — exactly what a
+//      real `flair stop && npm install -g @tpsdev-ai/flair@<previous> &&
+//      flair start` downgrade does.
+//   5. If it boots: read the memory and presence rows back through the
+//      baseline's own HTTP surface — a clean boot that can't actually see
+//      its own data isn't "downgrade works", it's a different failure mode.
+//
+// ─── Either outcome is a valid, asserted result ────────────────────────────
+// Green here is a real claim ("downgrade to <baseline> is safe") that
+// docs/upgrade.md repeats — so this suite must actually observe reality, not
+// assume success. If a real incompatibility is found, this file documents
+// the EXACT failure (error string, which step) and asserts THAT specific
+// behavior, so the red/green state of this test always matches what
+// docs/upgrade.md claims. See the note at the bottom of this file recording
+// what was actually observed when this suite was written (2026-07-08).
+//
+// ─── HOME isolation ─────────────────────────────────────────────────────
+// Same hard rule as federation-mixed-version.test.ts: every `flair` CLI
+// invocation is spawned as its own subprocess with an explicit per-instance
+// `HOME` env var, never by mutating `process.env.HOME` in this test's own
+// process (Bun's `os.homedir()` ignores live mutation) — this test must
+// never read or write this machine's real `~/.flair`.
+//
+// ─── Why this doesn't reuse federation-mixed-version.test.ts's baseline
+// install code ────────────────────────────────────────────────────────────
+// Both files need an "install the npm-published baseline into a throwaway
+// dir" step, but that file is a `.test.ts` module — importing anything from
+// it at module scope would re-execute its top-level `describe()` block and
+// register its tests a second time under this file too. The npm-baseline
+// bootstrap below is intentionally a close copy of that file's `beforeAll`
+// (same rationale, same comments trimmed to what applies here); the actual
+// HARNESS reuse this issue asked for is `startHarper`/`stopHarper` from
+// test/helpers/harper-lifecycle.ts, which both files share for real.
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { spawn } from "node:child_process";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { startHarper, stopHarper, type HarperInstance } from "../helpers/harper-lifecycle";
+
+const NODE_BIN = process.env.NODE_BIN ?? "node";
+
+// Generous but bounded — a fresh `npm install` from the public registry plus
+// two real Harper installs/boots easily takes 1-3 minutes on a cold cache
+// (same figure federation-mixed-version.test.ts uses for the same reason).
+const SETUP_TIMEOUT_MS = 300_000;
+const CLI_TIMEOUT_MS = 45_000;
+const NPM_INSTALL_TIMEOUT_MS = 180_000;
+
+const AGENT_ID = "flair637-downgrade-agent";
+
+/** Strip CI secrets from the inherited env before handing it to a child
+ * process — same deny-list rationale as harper-lifecycle.ts's baseEnv
+ * (Sherlock review on #467).
+ */
+function sanitizedParentEnv(): Record<string, string> {
+  const env = { ...(process.env as Record<string, string>) };
+  delete env.GITHUB_TOKEN;
+  delete env.NPM_TOKEN;
+  return env;
+}
+
+/** Spawn `node <cliPath> ...args` and wait for it to exit. Rejects (with the
+ * full captured stdout/stderr in the error message) on a non-zero exit code
+ * or timeout.
+ */
+async function runFlairCli(
+  cliPath: string,
+  args: string[],
+  env: Record<string, string>,
+  timeoutMs = CLI_TIMEOUT_MS,
+): Promise<{ stdout: string; stderr: string }> {
+  return await new Promise((resolve, reject) => {
+    const proc = spawn(NODE_BIN, [cliPath, ...args], { env });
+    let stdout = "";
+    let stderr = "";
+    proc.stdout?.on("data", (d: Buffer) => { stdout += d.toString(); });
+    proc.stderr?.on("data", (d: Buffer) => { stderr += d.toString(); });
+    const timer = setTimeout(() => {
+      proc.kill("SIGKILL");
+      reject(new Error(
+        `flair CLI timed out after ${timeoutMs}ms: ${args.join(" ")}\n` +
+        `--- stdout ---\n${stdout}\n--- stderr ---\n${stderr}`,
+      ));
+    }, timeoutMs);
+    proc.on("exit", (code) => {
+      clearTimeout(timer);
+      if (code !== 0) {
+        reject(new Error(
+          `flair CLI exited ${code}: ${args.join(" ")}\n` +
+          `--- stdout ---\n${stdout}\n--- stderr ---\n${stderr}`,
+        ));
+      } else {
+        resolve({ stdout, stderr });
+      }
+    });
+    proc.on("error", (err) => { clearTimeout(timer); reject(err); });
+  });
+}
+
+function instanceEnv(inst: HarperInstance): Record<string, string> {
+  return {
+    ...sanitizedParentEnv(),
+    HOME: inst.installDir,
+    FLAIR_URL: inst.httpURL,
+    FLAIR_ADMIN_PASS: inst.admin.password,
+  };
+}
+
+/** Read an agent's Memory rows via the Harper OPERATIONS API directly (raw
+ * `search_by_value`, Basic admin auth) — the same version-stable read path
+ * federation-mixed-version.test.ts's fetchAgentMemories uses, for the same
+ * reason: it doesn't depend on either build's `flair memory search` CLI/REST
+ * auth resolution, which has genuinely differed across versions.
+ */
+async function fetchAgentMemories(inst: HarperInstance, agentId: string): Promise<any[]> {
+  const auth = "Basic " + Buffer.from(`admin:${inst.admin.password}`).toString("base64");
+  const res = await fetch(`${inst.opsURL}/`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json", Authorization: auth },
+    body: JSON.stringify({
+      operation: "search_by_value",
+      schema: "flair",
+      table: "Memory",
+      search_attribute: "agentId",
+      search_value: agentId,
+      get_attributes: ["*"],
+    }),
+    signal: AbortSignal.timeout(10_000),
+  });
+  if (!res.ok) {
+    throw new Error(`ops search_by_value(Memory, agentId=${agentId}) failed: ${res.status} ${await res.text().catch(() => "")}`);
+  }
+  return await res.json() as any[];
+}
+
+describe("downgrade compat (npm baseline boot vs current-build data) [flair#637]", () => {
+  let baselineDir: string;
+  let pkgDirBaseline: string;
+  let cliPathBaseline: string;
+  let cliPathCurrent: string;
+  let dataDir: string | undefined;
+  let current: HarperInstance | null = null;
+  let baseline: HarperInstance | null = null;
+  let memoryMarker: string;
+  /** Set when the baseline fails to boot — captured, not thrown, so the
+   * suite can assert on the DOCUMENTED failure mode instead of erroring out
+   * of every test via a failed beforeAll. */
+  let baselineBootError: Error | null = null;
+
+  beforeAll(async () => {
+    // ── 1. Install the previous published baseline from npm (same recipe as
+    // federation-mixed-version.test.ts's beforeAll) ─────────────────────────
+    baselineDir = await mkdtemp(join(tmpdir(), "flair-downgrade-baseline-"));
+    await new Promise<void>((resolve, reject) => {
+      const proc = spawn("npm", ["init", "-y"], { cwd: baselineDir, env: sanitizedParentEnv() });
+      let out = "";
+      proc.stdout?.on("data", (d) => out += d.toString());
+      proc.stderr?.on("data", (d) => out += d.toString());
+      proc.on("exit", (code) => code === 0 ? resolve() : reject(new Error(`npm init failed: ${out}`)));
+      proc.on("error", reject);
+    });
+    await new Promise<void>((resolve, reject) => {
+      const proc = spawn("npm", ["install", "@tpsdev-ai/flair@latest"], { cwd: baselineDir, env: sanitizedParentEnv() });
+      let out = "";
+      proc.stdout?.on("data", (d) => out += d.toString());
+      proc.stderr?.on("data", (d) => out += d.toString());
+      const timer = setTimeout(() => { proc.kill(); reject(new Error(`npm install timed out after ${NPM_INSTALL_TIMEOUT_MS}ms:\n${out}`)); }, NPM_INSTALL_TIMEOUT_MS);
+      proc.on("exit", (code) => { clearTimeout(timer); code === 0 ? resolve() : reject(new Error(`npm install @tpsdev-ai/flair@latest failed:\n${out}`)); });
+      proc.on("error", (err) => { clearTimeout(timer); reject(err); });
+    });
+    // Linux CI has no native embedding binary for the npm-published package's
+    // own optionalDependencies resolution — install it explicitly (same as
+    // federation-mixed-version.test.ts) so the baseline's embeddings
+    // component doesn't crash at boot.
+    if (process.platform === "linux") {
+      await new Promise<void>((resolve, reject) => {
+        const proc = spawn("npm", ["install", "--no-save", "@node-llama-cpp/linux-x64@3"], { cwd: baselineDir, env: sanitizedParentEnv() });
+        let out = "";
+        proc.stdout?.on("data", (d) => out += d.toString());
+        proc.stderr?.on("data", (d) => out += d.toString());
+        proc.on("exit", (code) => code === 0 ? resolve() : reject(new Error(`native embedding binary install failed:\n${out}`)));
+        proc.on("error", reject);
+      });
+    }
+    pkgDirBaseline = join(baselineDir, "node_modules", "@tpsdev-ai", "flair");
+    cliPathBaseline = join(pkgDirBaseline, "dist", "cli.js");
+    cliPathCurrent = join(process.cwd(), "dist", "cli.js");
+
+    // ── 2. Boot the CURRENT BUILD against a fresh data dir ─────────────────
+    current = await startHarper();
+    dataDir = current.installDir;
+    const currentEnv = instanceEnv(current);
+    const currentPort = String(new URL(current.httpURL).port);
+    const currentOpsPort = String(new URL(current.opsURL).port);
+
+    await runFlairCli(
+      cliPathCurrent,
+      ["agent", "add", AGENT_ID, "--admin-pass", current.admin.password, "--port", currentPort, "--ops-port", currentOpsPort],
+      currentEnv,
+    );
+
+    memoryMarker = `flair637-downgrade-marker-${Date.now()}`;
+    await runFlairCli(
+      cliPathCurrent,
+      ["memory", "add", `downgrade compat marker: ${memoryMarker}`, "--agent", AGENT_ID, "--durability", "permanent"],
+      currentEnv,
+    );
+
+    // Presence — cheap to add, per the issue ("write memories (and presence
+    // if cheap)"); also exercises a second table through the same boot.
+    await runFlairCli(
+      cliPathCurrent,
+      ["presence", "set", "--agent", AGENT_ID, "--activity", "coding", "--task", "flair#637 downgrade compat check", "--port", currentPort],
+      currentEnv,
+    );
+
+    // ── 3. Stop the current build WITHOUT deleting its data dir ────────────
+    await stopHarper(current, { keepInstallDir: true });
+
+    // ── 4. Boot the npm baseline against the SAME data dir ─────────────────
+    // Captured, not awaited-and-thrown: a boot failure here is one of the two
+    // valid outcomes this suite exists to distinguish, not a setup error.
+    try {
+      baseline = await startHarper({ cwd: pkgDirBaseline, harperBinDir: baselineDir, installDir: dataDir });
+    } catch (err) {
+      baselineBootError = err as Error;
+    }
+  }, SETUP_TIMEOUT_MS);
+
+  afterAll(async () => {
+    // baseline never owns dataDir (passed explicitly via `installDir`), so
+    // stopHarper(baseline) will not remove it — this suite owns and removes
+    // the shared dir itself, once, regardless of which side last touched it.
+    if (baseline) await stopHarper(baseline);
+    if (dataDir) await rm(dataDir, { recursive: true, force: true, maxRetries: 4 });
+    if (baselineDir) await rm(baselineDir, { recursive: true, force: true });
+  }, 120_000);
+
+  // ─── OBSERVED RESULT (recorded when this suite was written, 2026-07-08) ──
+  // The npm-published baseline (0.21.0) DOES boot successfully against a data
+  // directory written by this worktree's HEAD build (~14 commits ahead of
+  // 0.21.0, including several security/behavior changes but no Flair schema
+  // migration and only a patch-level @harperfast/harper bump, 5.1.15→5.1.17).
+  // Both the pre-existing memory and presence rows written by the CURRENT
+  // build are readable back through the BASELINE's own HTTP surface after the
+  // downgrade boot. This is the "green" branch below. If a future run of this
+  // suite starts failing, that is real signal — a schema-incompatible change
+  // landed without a documented downgrade break, and BOTH this test's
+  // assertions AND docs/upgrade.md's compatibility statement need updating
+  // together, not just the test loosened to pass again.
+  test("npm baseline boots against data written by the current build", async () => {
+    if (baselineBootError) {
+      throw new Error(
+        `npm baseline failed to boot against current-build data — this is a REAL downgrade break, ` +
+        `not a test bug. docs/upgrade.md's compatibility statement must be updated to say so.\n` +
+        `${baselineBootError.stack ?? baselineBootError.message}`,
+      );
+    }
+    expect(baseline).not.toBeNull();
+    const res = await fetch(`${baseline!.httpURL}/Health`);
+    expect(res.status).toBeGreaterThan(0);
+  }, CLI_TIMEOUT_MS);
+
+  test("memory written by the current build is readable via the npm baseline after downgrade", async () => {
+    if (baselineBootError) {
+      throw new Error("skipped: baseline never booted — see the boot test above for the documented failure");
+    }
+    const rows = await fetchAgentMemories(baseline!, AGENT_ID);
+    expect(rows.some((r) => String(r.content ?? "").includes(memoryMarker))).toBe(true);
+  }, CLI_TIMEOUT_MS);
+
+  test("presence written by the current build is readable via the npm baseline after downgrade", async () => {
+    if (baselineBootError) {
+      throw new Error("skipped: baseline never booted — see the boot test above for the documented failure");
+    }
+    const res = await fetch(`${baseline!.httpURL}/Presence`);
+    expect(res.status).toBe(200);
+    const roster = await res.json() as any[];
+    const entry = roster.find((r) => r.id === AGENT_ID);
+    expect(entry).toBeDefined();
+    expect(entry.presenceStatus).toBe("active");
+  }, CLI_TIMEOUT_MS);
+});

--- a/test/helpers/harper-lifecycle.ts
+++ b/test/helpers/harper-lifecycle.ts
@@ -42,6 +42,14 @@ export interface HarperInstance {
   process: ChildProcess | null;
   admin: { username: string; password: string };
   external: boolean;
+  /**
+   * True when `startHarper` created `installDir` itself (mkdtemp), false
+   * when the caller supplied it via `StartHarperOptions.installDir`.
+   * `stopHarper` only ever removes a directory it created — a caller-owned
+   * dir (e.g. one shared across two `startHarper()` calls for a downgrade
+   * test) is the caller's to clean up.
+   */
+  ownsInstallDir: boolean;
 }
 
 interface HarperExit { code: number | null; signal: NodeJS.Signals | null }
@@ -198,6 +206,27 @@ export interface StartHarperOptions {
    * install root here separately.
    */
   harperBinDir?: string;
+  /**
+   * Reuse this existing directory as ROOTPATH/HOME instead of `mkdtemp`-ing a
+   * fresh one. Used by the downgrade-compat test (flair#637) to boot a
+   * DIFFERENT Harper build against data a PRIOR `startHarper()` call already
+   * wrote — i.e. "does N-1 boot against data touched by N" — without this
+   * function silently handing back an empty temp dir instead.
+   *
+   * The `install` step still runs but is expected to no-op: Harper's own
+   * installer (utility/install/installer.ts) checks for an existing
+   * harperdb-config.yaml/hdb boot file in ROOTPATH and exits 0 immediately
+   * if found, without touching anything — exactly what a real downgrade
+   * does (start the old binary against existing data, no re-init). This
+   * mirrors production; do not add a `skipInstall` escape hatch that a real
+   * downgrade wouldn't have.
+   *
+   * When set, `startHarper` does NOT take ownership of the directory —
+   * `stopHarper` will never remove it (see `HarperInstance.ownsInstallDir`).
+   * The caller created it (directly or via a prior `startHarper()`) and is
+   * responsible for cleaning it up.
+   */
+  installDir?: string;
 }
 
 export async function startHarper(opts: StartHarperOptions = {}): Promise<HarperInstance> {
@@ -218,11 +247,13 @@ export async function startHarper(opts: StartHarperOptions = {}): Promise<Harper
       process: null,
       admin: { username: HARPER_ADMIN_USER, password: HARPER_ADMIN_PASS },
       external: true,
+      ownsInstallDir: false,
     };
   }
 
   // ── Local mode: spawn Harper from node_modules ────────────────────────────
-  const installDir = await mkdtemp(join(tmpdir(), "flair-test-"));
+  const ownsInstallDir = !opts.installDir;
+  const installDir = opts.installDir ?? await mkdtemp(join(tmpdir(), "flair-test-"));
 
   // Deny-list: strip CI secrets from the inherited env so Harper's child
   // process (and any log dump on failure) doesn't leak them onto a public
@@ -294,7 +325,7 @@ export async function startHarper(opts: StartHarperOptions = {}): Promise<Harper
         waitForHealth(httpURL, 60_000, () => exited, () => log),
         waitForHealth(opsURL, 60_000, () => exited, () => log),
       ]);
-      return { httpURL, opsURL, installDir, process: proc, admin: { username: "admin", password: "test123" }, external: false };
+      return { httpURL, opsURL, installDir, process: proc, admin: { username: "admin", password: "test123" }, external: false, ownsInstallDir };
     } catch (err) {
       await killProcess(proc);
       lastErr = err as Error;
@@ -308,11 +339,24 @@ export async function startHarper(opts: StartHarperOptions = {}): Promise<Harper
   throw lastErr ?? new Error("Harper failed to start");
 }
 
-export async function stopHarper(inst: HarperInstance): Promise<void> {
+export interface StopHarperOptions {
+  /**
+   * Kill the process but leave `installDir` on disk even if this instance
+   * owns it. Used by the downgrade-compat test (flair#637) to stop the
+   * CURRENT-build instance while preserving its data dir for a SECOND
+   * `startHarper({ installDir })` call against a different build.
+   */
+  keepInstallDir?: boolean;
+}
+
+export async function stopHarper(inst: HarperInstance, opts: StopHarperOptions = {}): Promise<void> {
   if (inst.external) return;
 
   if (inst.process) await killProcess(inst.process);
-  if (inst.installDir) {
+  // Never remove a directory this instance didn't create (ownsInstallDir
+  // false — the caller supplied it and owns its lifecycle), and never remove
+  // one the caller explicitly asked to keep.
+  if (inst.installDir && inst.ownsInstallDir && !opts.keepInstallDir) {
     await rm(inst.installDir, { recursive: true, force: true, maxRetries: 4 });
   }
 }

--- a/test/unit/upgrade-data-snapshot.test.ts
+++ b/test/unit/upgrade-data-snapshot.test.ts
@@ -1,0 +1,219 @@
+// upgrade-data-snapshot.test.ts — Unit tests for flair#637's pre-upgrade
+// data snapshot: createDataSnapshot() and pruneOldSnapshots(). Pure
+// filesystem behavior against throwaway temp dirs — never touches this
+// machine's real ~/.flair (both functions take an explicit `snapshotRoot`
+// param for exactly this reason; see their doc comments in src/cli.ts).
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import {
+  mkdtempSync, rmSync, writeFileSync, mkdirSync, symlinkSync,
+  chmodSync, statSync, existsSync, readdirSync, utimesSync,
+} from "node:fs";
+import { createServer, type Server } from "node:net";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { extract as tarExtract } from "tar";
+import { program, createDataSnapshot, pruneOldSnapshots } from "../../src/cli";
+
+function findCommand(root: any, path: string[]): any {
+  let node = root;
+  for (const name of path) {
+    node = node.commands.find((c: any) => c.name() === name);
+    if (!node) return null;
+  }
+  return node;
+}
+
+describe("flair upgrade — --no-snapshot flag wiring (flair#637)", () => {
+  test("upgrade command registers --no-snapshot", () => {
+    const upgrade = findCommand(program, ["upgrade"]);
+    expect(upgrade).not.toBeNull();
+    const optionNames = upgrade.options.map((o: any) => o.long);
+    expect(optionNames).toContain("--no-snapshot");
+  });
+});
+
+describe("createDataSnapshot", () => {
+  let dataDir: string;
+  let snapshotRoot: string;
+  let extractDir: string;
+
+  beforeEach(() => {
+    dataDir = mkdtempSync(join(tmpdir(), "flair637-data-"));
+    snapshotRoot = mkdtempSync(join(tmpdir(), "flair637-snaproot-"));
+    extractDir = mkdtempSync(join(tmpdir(), "flair637-extract-"));
+  });
+
+  afterEach(() => {
+    rmSync(dataDir, { recursive: true, force: true });
+    rmSync(snapshotRoot, { recursive: true, force: true });
+    rmSync(extractDir, { recursive: true, force: true });
+  });
+
+  test("archives a regular file and preserves its exact mode (0600 stays 0600)", async () => {
+    const secretPath = join(dataDir, "admin-pass");
+    writeFileSync(secretPath, "super-secret", { mode: 0o600 });
+
+    const { path: snapshotPath, bytes } = await createDataSnapshot(dataDir, snapshotRoot);
+    expect(existsSync(snapshotPath)).toBe(true);
+    expect(bytes).toBeGreaterThan(0);
+    // The archive file itself is owner-only.
+    expect(statSync(snapshotPath).mode & 0o777).toBe(0o600);
+
+    // preservePaths: true mirrors what a real restore's `tar -xzf` does —
+    // node-tar's own extract() would otherwise re-strip the leading `/`
+    // from an absolute symlink target on the way back out, even though the
+    // archive (created with preservePaths: true) already stored it intact.
+    await tarExtract({ file: snapshotPath, cwd: extractDir, preservePaths: true });
+    const restoredMode = statSync(join(extractDir, "admin-pass")).mode & 0o777;
+    expect(restoredMode).toBe(0o600);
+  });
+
+  test("preserves a nested directory structure", async () => {
+    mkdirSync(join(dataDir, "keys"), { recursive: true });
+    writeFileSync(join(dataDir, "keys", "agent.key"), "key-material", { mode: 0o600 });
+    writeFileSync(join(dataDir, "harper-config.yaml"), "some: config\n");
+
+    const { path: snapshotPath } = await createDataSnapshot(dataDir, snapshotRoot);
+    // preservePaths: true mirrors what a real restore's `tar -xzf` does —
+    // node-tar's own extract() would otherwise re-strip the leading `/`
+    // from an absolute symlink target on the way back out, even though the
+    // archive (created with preservePaths: true) already stored it intact.
+    await tarExtract({ file: snapshotPath, cwd: extractDir, preservePaths: true });
+
+    expect(existsSync(join(extractDir, "harper-config.yaml"))).toBe(true);
+    expect(existsSync(join(extractDir, "keys", "agent.key"))).toBe(true);
+    expect(statSync(join(extractDir, "keys", "agent.key")).mode & 0o777).toBe(0o600);
+  });
+
+  test("keeps a symlink that points WITHIN the data dir", async () => {
+    writeFileSync(join(dataDir, "real-file.txt"), "hello");
+    symlinkSync(join(dataDir, "real-file.txt"), join(dataDir, "link-inside.txt"));
+
+    const { path: snapshotPath } = await createDataSnapshot(dataDir, snapshotRoot);
+    // preservePaths: true mirrors what a real restore's `tar -xzf` does —
+    // node-tar's own extract() would otherwise re-strip the leading `/`
+    // from an absolute symlink target on the way back out, even though the
+    // archive (created with preservePaths: true) already stored it intact.
+    await tarExtract({ file: snapshotPath, cwd: extractDir, preservePaths: true });
+
+    expect(existsSync(join(extractDir, "link-inside.txt"))).toBe(true);
+    expect(statSync(join(extractDir, "link-inside.txt")).isFile()).toBe(true);
+  });
+
+  test("skips a symlink that points OUTSIDE the data dir — never follows it, never archives its target", async () => {
+    const outsideDir = mkdtempSync(join(tmpdir(), "flair637-outside-"));
+    try {
+      const outsideSecret = join(outsideDir, "outside-secret.txt");
+      writeFileSync(outsideSecret, "should never appear in the snapshot");
+      symlinkSync(outsideSecret, join(dataDir, "escape-link.txt"));
+      writeFileSync(join(dataDir, "normal-file.txt"), "normal");
+
+      const { path: snapshotPath } = await createDataSnapshot(dataDir, snapshotRoot);
+      // preservePaths: true mirrors what a real restore's `tar -xzf` does —
+    // node-tar's own extract() would otherwise re-strip the leading `/`
+    // from an absolute symlink target on the way back out, even though the
+    // archive (created with preservePaths: true) already stored it intact.
+    await tarExtract({ file: snapshotPath, cwd: extractDir, preservePaths: true });
+
+      expect(existsSync(join(extractDir, "normal-file.txt"))).toBe(true);
+      expect(existsSync(join(extractDir, "escape-link.txt"))).toBe(false);
+    } finally {
+      rmSync(outsideDir, { recursive: true, force: true });
+    }
+  });
+
+  test("skips a broken symlink without throwing", async () => {
+    symlinkSync(join(dataDir, "does-not-exist"), join(dataDir, "broken-link"));
+    writeFileSync(join(dataDir, "normal-file.txt"), "normal");
+
+    const { path: snapshotPath } = await createDataSnapshot(dataDir, snapshotRoot);
+    // preservePaths: true mirrors what a real restore's `tar -xzf` does —
+    // node-tar's own extract() would otherwise re-strip the leading `/`
+    // from an absolute symlink target on the way back out, even though the
+    // archive (created with preservePaths: true) already stored it intact.
+    await tarExtract({ file: snapshotPath, cwd: extractDir, preservePaths: true });
+
+    expect(existsSync(join(extractDir, "normal-file.txt"))).toBe(true);
+    expect(existsSync(join(extractDir, "broken-link"))).toBe(false);
+  });
+
+  test("skips a unix domain socket without crashing the snapshot", async () => {
+    const socketPath = join(dataDir, "operations-server");
+    const server: Server = createServer();
+    await new Promise<void>((resolve, reject) => {
+      server.once("error", reject);
+      server.listen(socketPath, () => resolve());
+    });
+    try {
+      writeFileSync(join(dataDir, "normal-file.txt"), "normal");
+
+      const { path: snapshotPath } = await createDataSnapshot(dataDir, snapshotRoot);
+      // preservePaths: true mirrors what a real restore's `tar -xzf` does —
+    // node-tar's own extract() would otherwise re-strip the leading `/`
+    // from an absolute symlink target on the way back out, even though the
+    // archive (created with preservePaths: true) already stored it intact.
+    await tarExtract({ file: snapshotPath, cwd: extractDir, preservePaths: true });
+
+      expect(existsSync(join(extractDir, "normal-file.txt"))).toBe(true);
+      expect(existsSync(join(extractDir, "operations-server"))).toBe(false);
+    } finally {
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    }
+  });
+});
+
+describe("pruneOldSnapshots", () => {
+  let snapshotRoot: string;
+
+  beforeEach(() => {
+    snapshotRoot = mkdtempSync(join(tmpdir(), "flair637-prune-"));
+  });
+
+  afterEach(() => {
+    rmSync(snapshotRoot, { recursive: true, force: true });
+  });
+
+  function makeSnapshotFile(name: string, mtimeOffsetSeconds: number) {
+    const p = join(snapshotRoot, name);
+    writeFileSync(p, "fake tarball");
+    const t = new Date(Date.now() + mtimeOffsetSeconds * 1000);
+    utimesSync(p, t, t);
+  }
+
+  test("keeps only the newest N (default 3), removes the rest", () => {
+    // Oldest to newest by mtime offset.
+    makeSnapshotFile("flair-data-a.tar.gz", -500);
+    makeSnapshotFile("flair-data-b.tar.gz", -400);
+    makeSnapshotFile("flair-data-c.tar.gz", -300);
+    makeSnapshotFile("flair-data-d.tar.gz", -200);
+    makeSnapshotFile("flair-data-e.tar.gz", -100);
+
+    const removed = pruneOldSnapshots(3, snapshotRoot);
+    expect(removed.length).toBe(2);
+    const remaining = readdirSync(snapshotRoot).sort();
+    expect(remaining).toEqual(["flair-data-c.tar.gz", "flair-data-d.tar.gz", "flair-data-e.tar.gz"]);
+  });
+
+  test("no-op when fewer snapshots than the retention count exist", () => {
+    makeSnapshotFile("flair-data-a.tar.gz", -100);
+    makeSnapshotFile("flair-data-b.tar.gz", -50);
+
+    const removed = pruneOldSnapshots(3, snapshotRoot);
+    expect(removed.length).toBe(0);
+    expect(readdirSync(snapshotRoot).length).toBe(2);
+  });
+
+  test("ignores files that don't match the flair-data-*.tar.gz naming convention", () => {
+    makeSnapshotFile("flair-data-a.tar.gz", -300);
+    makeSnapshotFile("flair-data-b.tar.gz", -200);
+    writeFileSync(join(snapshotRoot, "unrelated-file.txt"), "leave me alone");
+
+    pruneOldSnapshots(1, snapshotRoot);
+    expect(existsSync(join(snapshotRoot, "unrelated-file.txt"))).toBe(true);
+  });
+
+  test("returns an empty array when the snapshot root doesn't exist yet", () => {
+    rmSync(snapshotRoot, { recursive: true, force: true });
+    expect(pruneOldSnapshots(3, snapshotRoot)).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

Implements #637 — the last piece of the upgrade-hardening cluster. Upgrades now have a way back past the package level.

- **Pre-upgrade snapshot**: `flair upgrade` takes a timestamped `tar.gz` of the data directory into `~/.flair/upgrade-snapshots/` (mode 0700, keep-last-3 retention) before any package changes. Snapshot failure **aborts the upgrade** (safe default; `--no-snapshot` opts out). The #641 rollback-failure path now points at the concrete snapshot path.
- **⚠ Behavior change to weigh explicitly**: for point-in-time consistency the snapshot quiesces the DB — **stop → snapshot → restart old version → install → (#641's restart-to-new + verify)**. A live LMDB dir isn't safely copyable mid-write, and Harper's native `get_backup` was evaluated and rejected (streams one table at a time over the running ops API; misses config/keys/roles; unusable once stopped). Net: upgrades now always include a brief stop/start blip, even with `--no-restart`.
- **Tested downgrade, verdict GREEN**: `test/compat/downgrade-boot.test.ts` boots the npm-published baseline (0.21.0) against a data dir written by this HEAD — memory and presence rows read back cleanly through the older build's own HTTP surface. Reproduced 3×, ~44s/run, joins the nightly compat lane. `docs/upgrade.md` documents the restore + downgrade procedure with the compatibility claim framed as continuously-checked (tied to the nightly run), not a permanent guarantee.
- **Snapshot hygiene**: modes preserved exactly (0600-class files stay 0600 — deliberately not tar's `portable` mode), symlinks archived as symlinks (never followed), out-of-bounds symlinks skipped via `realpathSync` boundary check.

Three self-caught bugs fixed en route: `resolve()` vs `realpathSync()` misclassifying every in-bounds symlink on macOS (`/tmp → /private/tmp`); node-tar silently stripping the leading `/` from absolute symlink targets without `preservePaths` (verified restore against node-tar and system `tar`); missing error handling on the restart-to-old-version step.

## Test plan (post-rebase onto current main)

- [x] `bun run build` && `bun run build:cli` clean
- [x] `bunx tsc --noEmit -p tsconfig.check.json` clean
- [x] `bun test test/unit/` — 1841/1841 pass (incl. new snapshot/prune coverage with symlink-boundary cases)
- [x] `bun test test/integration/` — 237/237 pass
- [x] `bun test test/compat/downgrade-boot.test.ts` — 3/3 pass, 44s
- [ ] Kern (architecture) + Sherlock (security) review

Honest coverage note: `stopFlairProcess`/`startFlairProcess`/`restartFlair` are exercised by full-suite regression and diff review, not a live `flair upgrade` against this host's production instance (deliberately — that instance runs the session doing the work). Real-path exercise comes with the 0.21.1 rollout itself, per the release-is-the-dogfood plan.

Closes #637.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
