### PR TITLE
docs(cli): name the real storage engine — Harper 5.x is RocksDB, not LMDB

### DIFF
--- a/docs/upgrade.md
+++ b/docs/upgrade.md
@@ -83,8 +83,9 @@ Snapshotting data before upgrade...
   each successful snapshot.
 - **Consistency:** Flair is briefly stopped, snapshotted, and immediately restarted on
   the OLD version before the package swap even begins — a plain file copy of a
-  *running* Harper's data directory isn't guaranteed point-in-time consistent (LMDB
-  writes can be mid-flight), so the snapshot always happens against a quiesced
+  *running* Harper's data directory isn't guaranteed point-in-time consistent (Harper
+  5.x stores tables in RocksDB — an LSM engine whose WAL, MANIFEST, and SST files can
+  be mid-write/mid-compaction), so the snapshot always happens against a quiesced
   directory. This means a short stop/start blip happens even with `--no-restart` — the
   snapshot's correctness doesn't depend on whether you want a restart *after* the
   upgrade, those are separate questions. (A native Harper backup operation,

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -6591,7 +6591,9 @@ function upgradeSnapshotFileName(): string {
  *
  * Consistency: the caller is expected to have stopped Flair first (a
  * running Harper's data dir can be mid-write, and a plain file copy of a
- * live LMDB environment isn't guaranteed point-in-time consistent) — this
+ * live database directory isn't guaranteed point-in-time consistent —
+ * Harper 5.x's engine is RocksDB, verified from the .sst/WAL/MANIFEST
+ * layout under database/*, and a torn WAL/SST set won't open) — this
  * function itself doesn't stop anything, it just archives whatever is on
  * disk right now.
  *
@@ -6908,8 +6910,9 @@ program
       } else {
         console.log("\nSnapshotting data before upgrade...");
         // Consistency: a running Harper's data dir can be mid-write, and a
-        // plain file copy of a live LMDB environment isn't guaranteed
-        // point-in-time consistent. Stopping first — then immediately
+        // plain file copy of a live database directory isn't guaranteed
+        // point-in-time consistent (Harper 5.x = RocksDB: WAL/SST/MANIFEST
+        // can tear under a live copy). Stopping first — then immediately
         // restarting the OLD version, before any package changes — gives a
         // quiesced, safe-to-copy directory with only a brief blip, even for
         // --no-restart (the snapshot's correctness doesn't depend on


### PR DESCRIPTION
## Summary

Nathan asked "why do we care about LMDB?" — and the honest answer was that we shouldn't: **Harper 5.x stores tables in RocksDB, not LMDB.** Verified from the live data layout (`~/.flair/data/database/*` is `.sst` / WAL `.log` / `MANIFEST` / `CURRENT` on harper 5.1.17). Harper ≤4 was LMDB-based and `lmdb@3.5.6` remains in Harper's dependency tree — the likely source of the mislabel, which #647's rationale (agent-written, K&S-reviewed, my merge) carried into comments and docs.

Comment/docs-only change: three passages now name RocksDB with the evidence, and the snapshot doc explains the tear mode (WAL/SST/MANIFEST mid-write/mid-compaction). **The quiesce design is unchanged** — an LSM store mid-compaction is exactly what a plain file copy tears, so stop→snapshot→restart remains right; only the stated reason was wrong.

## Test plan

- [x] `bun run build:cli` clean (comments only in code paths)
- [x] Docs render change reviewed by eye
- [ ] Kern + Sherlock (comment/docs-only, but the no-exceptions rule is the rule)
