### PR TITLE
fix(auth): gate resolveAgentAuth on credential evidence — authorizeLocal root-cause (#610)

### DIFF
--- a/resources/OAuth.ts
+++ b/resources/OAuth.ts
@@ -245,7 +245,14 @@ ${scope.split(" ").map((s: string) => `<div class="scope">${s}</div>`).join("")}
       });
     }
 
-    if (action === "deny") {
+    // flair#610 — mint an authorization code ONLY on an explicit approve. The
+    // consent form rendered by get() submits action=approve|deny and nothing
+    // else, so treating every non-"approve" value (deny, missing, empty, or
+    // garbage) as a denial is safe — and it closes the previous loose
+    // `action !== "deny"` check, which minted a code for a malformed or absent
+    // action. redirect_uri was already validated above, so this access_denied
+    // redirect can only target the allowed URI.
+    if (action !== "approve") {
       const params = new URLSearchParams({ error: "access_denied", state });
       return redirectTo(`${redirectUri}?${params}`);
     }

--- a/resources/agent-auth.ts
+++ b/resources/agent-auth.ts
@@ -153,6 +153,56 @@ export type AgentAuthVerdict =
  *   5. nothing at all → trusted internal call
  */
 /**
+ * Header names that can carry a CLIENT-PRESENTED credential. Today only the
+ * standard `authorization` header — it carries Basic, Bearer, AND our custom
+ * `TPS-Ed25519 …` scheme (all three ride the Authorization header; see
+ * doVerify() above and auth-middleware.ts, both of which read exactly this
+ * header to authenticate a caller). Kept as a LIST, read via every header-object
+ * shape below, so a future signed-header auth scheme is a one-line addition here
+ * — not a scatter of ad-hoc `req.headers.authorization` truthiness checks that
+ * would each have to be rediscovered and updated (Kern's review point).
+ *
+ * DELIBERATELY EXCLUDES the server-set trust markers `x-tps-agent` /
+ * `x-tps-anonymous`: auth-middleware.ts STAMPS those AFTER it has verified a
+ * caller — they are never presented by the client. Counting them as "credential
+ * evidence" would let an unauthenticated caller forge one and defeat this gate.
+ */
+const CREDENTIAL_HEADERS = ["authorization"] as const;
+
+/**
+ * Read a header off either header-object shape Harper hands us: the Web
+ * Headers-like `.get(name)` (populated for GET/search requests) or the plain
+ * `.asObject` bag (PUT/POST). Mirrors doVerify()'s own read exactly, so the
+ * evidence check can't miss a shape the verifier would have seen.
+ */
+function readRequestHeader(reqLike: any, name: string): string {
+  return (
+    reqLike?.headers?.get?.(name) ??
+    reqLike?.headers?.asObject?.[name] ??
+    ""
+  );
+}
+
+/**
+ * True iff the request carries ANY client-presented credential (CREDENTIAL_HEADERS).
+ *
+ * WHY THIS EXISTS (flair#610): Harper's `authorizeLocal: true` forges
+ * `request.user = super_user` (and can populate `.username`) for a credential-
+ * LESS loopback request — one with NO Authorization header at all. A genuine
+ * Basic/Bearer/TPS-Ed25519 header SUPPRESSES that forgery. So "is a credential
+ * present?" is precisely what separates a genuinely-authenticated caller from
+ * Harper's ambient forgery — the gate resolveAgentAuth applies before trusting a
+ * `context.user` identity. Handles BOTH context shapes (`getContext().request`
+ * for GET/search, context-only for PUT/POST) by resolving `request ?? self`
+ * first, then reads both header-object shapes.
+ */
+export function hasCredentialEvidence(context: any): boolean {
+  const reqLike = context?.request ?? context;
+  if (!reqLike) return false;
+  return CREDENTIAL_HEADERS.some((h) => readRequestHeader(reqLike, h) !== "");
+}
+
+/**
  * allow* for AGENT-FACING resources: permit verified agents, admins/super_user,
  * and trusted internal calls; deny anonymous HTTP. Pass getContext(). Per-record
  * scoping/ownership is still enforced in the handler. Replaces the
@@ -182,11 +232,23 @@ export async function resolveAgentAuth(context: any): Promise<AgentAuthVerdict> 
     return { kind: "agent", agentId: String(c.tpsAgent), isAdmin: c.tpsAgentIsAdmin === true };
   }
 
+  // flair#610 — CREDENTIAL-EVIDENCE GATE. Harper's `authorizeLocal: true` forges
+  // `context.user = super_user` (and can populate `.username`) for a credential-
+  // LESS loopback request. Trusting that ambient identity was the forgery
+  // vector: a bare local caller resolved to admin with no signature and no
+  // password. Only trust a `context.user` identity when the request actually
+  // carries a credential (real Basic/Bearer/TPS-Ed25519 header) — the one thing
+  // authorizeLocal's forgery cannot manufacture. Without evidence, FALL THROUGH
+  // to the verifyAgentRequest fallback below: a genuine signed request still
+  // authenticates; a credential-less HTTP request lands on `anonymous` (it has a
+  // headers object but no valid agent), and a true in-process call with no
+  // request object at all lands on `internal`.
+  const credentialed = hasCredentialEvidence(c);
   const user = context?.user ?? c.user;
-  if (user?.role?.permission?.super_user === true) {
+  if (credentialed && user?.role?.permission?.super_user === true) {
     return { kind: "agent", agentId: String(user.username ?? "admin"), isAdmin: true };
   }
-  if (user?.username && user.username !== FLAIR_AGENT_USERNAME) {
+  if (credentialed && user?.username && user.username !== FLAIR_AGENT_USERNAME) {
     return { kind: "agent", agentId: String(user.username), isAdmin: false };
   }
 

--- a/resources/auth-middleware.ts
+++ b/resources/auth-middleware.ts
@@ -127,12 +127,27 @@ server.http(async (request: any, nextLayer: any) => {
     (request.method === "GET" && url.pathname === "/Presence")
   ) return nextLayer(request);
 
+  // Read the Authorization header ONCE, up front — the super_user branch below
+  // needs it too (hoisted from its former position just after the branch as part
+  // of the flair#610 belt-and-suspenders check).
+  const header = request.headers.get("authorization") || request.headers?.asObject?.authorization || "";
+
   // If Harper has already authorized this request (e.g. Basic admin, or
   // authorizeLocal=true on localhost), trust Harper's auth decision and pass
   // through. Annotate the admin identity so resources' resolveAgentAuth recognizes
   // this as an ADMIN caller (not anonymous) — otherwise a Basic-admin request,
   // which carries no TPS-Ed25519 header, gets classified anonymous and denied.
-  if (request.user?.role?.permission?.super_user === true) {
+  //
+  // flair#610 BELT-AND-SUSPENDERS: require an Authorization header to be present
+  // before trusting a super_user `request.user`. Harper's `authorizeLocal: true`
+  // forges request.user=super_user for a credential-LESS loopback request; a
+  // genuine Basic/super_user caller always carries a header. This is defense-in-
+  // depth — the general middleware path below already marks a headerless request
+  // tpsAnonymous BEFORE Harper's ambient elevation lands, so this branch isn't a
+  // live vector today — but it keeps the trust decision from ever hinging on
+  // ambient elevation alone. (The root-cause gate lives in resolveAgentAuth; see
+  // agent-auth.ts hasCredentialEvidence.)
+  if (header && request.user?.role?.permission?.super_user === true) {
     request.tpsAgent = request.user.username ?? "admin";
     request.tpsAgentIsAdmin = true;
     try {
@@ -144,8 +159,6 @@ server.http(async (request: any, nextLayer: any) => {
 
   // Skip re-entry: if we already swapped auth to Basic, pass through
   if ((request as any)._tpsAuthVerified) return nextLayer(request);
-
-  const header = request.headers.get("authorization") || request.headers?.asObject?.authorization || "";
 
   // ── Basic admin / super_user auth ──────────────────────────────────────────
   // Allow Basic auth for CLI operations (backup, etc.). Two paths:

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -457,9 +457,13 @@ async function api(method: string, path: string, body?: any, options?: { baseUrl
   //
   // NOTE: this function is for the Harper HTTP/REST API only. The Harper
   // operations API (used by seedAgentViaOpsApi / seedFederationInstanceViaOpsApi)
-  // does NOT honor authorizeLocal — it always requires Basic admin auth, and
-  // those helpers send it unconditionally. authorizeLocal=true affects this
-  // path; it does not affect ops-API calls.
+  // ALSO honors authorizeLocal: a header-less loopback request to the ops port
+  // is auto-authorized as super_user (verified by live probe — flair#610). Those
+  // helpers nonetheless send Basic admin auth UNCONDITIONALLY, so they never
+  // depend on that ambient elevation and behave identically against a remote or
+  // hardened instance. Hardening the ops-API loopback posture itself (bind scope
+  // / disabling authorizeLocal there) is tracked separately in flair#654 and is
+  // out of scope for this HTTP/REST auth path.
   let authHeader: string | undefined;
   const token = process.env.FLAIR_TOKEN;
   if (token) {

--- a/test/unit/allow-helpers.test.ts
+++ b/test/unit/allow-helpers.test.ts
@@ -1,9 +1,14 @@
 import { mock, describe, it, expect } from "bun:test";
 
 // agent-auth.ts imports `databases` from @harperfast/harper (throws outside a
-// Harper runtime). Mock it — the annotation/internal/anonymous paths exercised
-// here never reach databases (they return before any Agent.get).
-mock.module("@harperfast/harper", () => ({ databases: {}, Resource: class {} }));
+// Harper runtime). Mock it. A thin flair.Agent (get→null) keeps the shared,
+// process-global module registry safe if this file's mock is the one bound when
+// another test's well-formed-TPS path reaches verifyAgentRequest — Agent.get
+// returns null rather than throwing on `databases.flair` being undefined.
+mock.module("@harperfast/harper", () => ({
+  databases: { flair: { Agent: { get: async () => null, search: async function* () {} } } },
+  Resource: class {},
+}));
 
 const { allowVerified, allowAdmin } = await import("../../resources/agent-auth.ts");
 
@@ -14,6 +19,11 @@ const { allowVerified, allowAdmin } = await import("../../resources/agent-auth.t
 // non-admin agent (privilege-escalation guard) and that BOTH deny anonymous.
 
 const reqNoAuth = { headers: { get: () => undefined } };
+// A Basic Authorization header — the credential evidence a genuine Basic
+// super_user / de-elevated user always carries (flair#610). The `user` contexts
+// below pair it with the user object because a REAL such request has BOTH; the
+// authorizeLocal forgery (no header) is exercised separately in FORGED below.
+const withBasic = (user: any) => ({ user, headers: { get: (n: string) => (n === "authorization" ? "Basic dXNlcjpwYXNz" : undefined) } });
 
 const CONTEXTS = {
   internal:          undefined,                                              // no request → trusted in-process
@@ -21,8 +31,12 @@ const CONTEXTS = {
   anonymousNoAuth:   reqNoAuth,                                              // raw request, no valid agent
   agentNonAdmin:     { tpsAgent: "agent-x", tpsAgentIsAdmin: false },        // verified non-admin agent
   agentAdmin:        { tpsAgent: "admin-x", tpsAgentIsAdmin: true },         // verified admin agent
-  superUser:         { user: { username: "admin", role: { permission: { super_user: true } } } }, // Basic super_user
-  perAgentUser:      { user: { username: "agent-y", role: { permission: {} } } }, // de-elevated per-agent user
+  superUser:         withBasic({ username: "admin", role: { permission: { super_user: true } } }), // Basic super_user (real header)
+  perAgentUser:      withBasic({ username: "agent-y", role: { permission: {} } }), // de-elevated per-agent user (real header)
+  // flair#610 forgeries: an ambient super_user / username on context.user with
+  // NO Authorization header — Harper's authorizeLocal shape. Must NOT be trusted.
+  forgedSuperUser:   { user: { username: "admin", role: { permission: { super_user: true } } }, headers: { get: () => undefined } },
+  forgedPerAgent:    { user: { username: "agent-y", role: { permission: {} } }, headers: { get: () => undefined } },
 } as const;
 
 describe("allowVerified — agent-facing gate (deny anonymous, permit verified/admin/internal)", () => {
@@ -47,6 +61,12 @@ describe("allowVerified — agent-facing gate (deny anonymous, permit verified/a
   it("permits a de-elevated per-agent user", async () => {
     expect(await allowVerified(CONTEXTS.perAgentUser)).toBe(true);
   });
+  it("DENIES a FORGED super_user (authorizeLocal shape: super_user context.user, NO Authorization header)", async () => {
+    expect(await allowVerified(CONTEXTS.forgedSuperUser)).toBe(false);
+  });
+  it("DENIES a FORGED per-agent username (context.user set, NO Authorization header)", async () => {
+    expect(await allowVerified(CONTEXTS.forgedPerAgent)).toBe(false);
+  });
 });
 
 describe("allowAdmin — admin-only gate (deny anonymous AND non-admin agents)", () => {
@@ -70,5 +90,8 @@ describe("allowAdmin — admin-only gate (deny anonymous AND non-admin agents)",
   });
   it("permits Basic super_user", async () => {
     expect(await allowAdmin(CONTEXTS.superUser)).toBe(true);
+  });
+  it("DENIES a FORGED super_user (no Authorization header) — the authorizeLocal escalation must not reach admin-only resources", async () => {
+    expect(await allowAdmin(CONTEXTS.forgedSuperUser)).toBe(false);
   });
 });

--- a/test/unit/cross-agent-isolation.test.ts
+++ b/test/unit/cross-agent-isolation.test.ts
@@ -287,4 +287,31 @@ describe("OAuthAuthorize.post() — resolved principal, not hardcoded admin (ide
     expect((res as Response).status).toBe(401);
     expect(authCodePut).toBeNull();
   });
+
+  // ── flair#610: mint ONLY on an explicit action="approve" ──────────────────
+  // Previously the code minted for anything `!== "deny"`, so a malformed or
+  // absent action produced a real authorization code. A genuinely-authenticated
+  // approver (super_user + real header) is used for every case so the ONLY
+  // variable is `action`.
+  const superUserApprover = () => {
+    const oa: any = new (OAuthAuthorize as any)();
+    oa.getContext = () => ({ user: { username: "admin", role: { permission: { super_user: true } } }, headers: mockAuthHeader });
+    return oa;
+  };
+
+  it('action="approve" (authenticated) → 302 with a minted code', async () => {
+    const res = await superUserApprover().post(approveBody({ action: "approve" }));
+    expect((res as Response).status).toBe(302);
+    expect((res as Response).headers.get("location")).toContain("code=");
+    expect(authCodePut?.principalId).toBe("admin");
+  });
+
+  for (const badAction of [undefined, "", "deny", "garbage", "APPROVE", "approve "] as const) {
+    it(`action=${JSON.stringify(badAction)} (authenticated) → 302 access_denied, NO code minted`, async () => {
+      const res = await superUserApprover().post(approveBody({ action: badAction }));
+      expect((res as Response).status).toBe(302);
+      expect((res as Response).headers.get("location")).toContain("error=access_denied");
+      expect(authCodePut).toBeNull();
+    });
+  }
 });

--- a/test/unit/resolve-agent-auth.test.ts
+++ b/test/unit/resolve-agent-auth.test.ts
@@ -1,20 +1,43 @@
 import { mock, describe, it, expect } from "bun:test";
 
 // agent-auth.ts imports `databases` from @harperfast/harper, whose module chain
-// throws when loaded outside a Harper runtime. Mock it — resolveAgentAuth's
-// internal/anonymous paths never touch databases (they return before Agent.get).
-mock.module("@harperfast/harper", () => ({ databases: {}, Resource: class {} }));
+// throws when loaded outside a Harper runtime. Mock it. Provide a thin
+// flair.Agent so the verifyAgentRequest fallback (reached by a well-formed
+// TPS-Ed25519 header with no forged user) looks up an unknown agent and returns
+// null WITHOUT throwing — proving the header ROUTED into verifyAgentRequest.
+// (The positive path — a VALID signature resolving to `agent` — is covered end-
+// to-end against real Harper in test/integration/oauth-authorize-authz.test.ts;
+// reproducing it here would depend on which sibling file's @harperfast/harper
+// mock wins bun's process-global module registry, so it's deliberately left to
+// the integration harness.)
+mock.module("@harperfast/harper", () => ({
+  databases: { flair: { Agent: { get: async () => null, search: async function* () {} } } },
+  Resource: class {},
+}));
 
-const { resolveAgentAuth } = await import("../../resources/agent-auth.ts");
+const { resolveAgentAuth, hasCredentialEvidence } = await import("../../resources/agent-auth.ts");
 
-// The internal-vs-anonymous distinction is the security-critical part: a missing
-// request = trusted in-process call; a request with no valid agent = anonymous
-// HTTP caller that MUST be denied. (The "agent" verdict needs a real Agent record
-// + signature, covered in the integration harness.)
+// ─── Request-shape helpers ────────────────────────────────────────────────────
 
-function reqWithAuth(header: string) {
-  return { headers: { get: (n: string) => (n === "authorization" ? header : undefined) } };
+// A request whose Authorization header is exposed via the Web Headers `.get()`
+// shape (GET/search). `header === undefined` = header absent.
+function getShape(header?: string): any {
+  return { headers: { get: (n: string) => (n === "authorization" ? header : undefined) }, url: "/x", method: "GET" };
 }
+// A request whose Authorization header is exposed via the `.asObject` bag
+// (PUT/POST). Omitting the key = header absent.
+function asObjectShape(header?: string): any {
+  const asObject: Record<string, string> = {};
+  if (header !== undefined) asObject.authorization = header;
+  return { headers: { asObject }, url: "/x", method: "POST" };
+}
+
+const BASIC = "Basic dXNlcjpwYXNz";
+const superUser = { username: "admin", role: { permission: { super_user: true } } };
+const superUserNamed = (username: string) => ({ username, role: { permission: { super_user: true } } });
+const perAgentUser = { username: "agent-3", role: { permission: {} } };
+
+// ─── internal vs anonymous (unchanged core distinction) ───────────────────────
 
 describe("resolveAgentAuth — internal vs anonymous", () => {
   it("no request context → internal (trusted in-process call)", async () => {
@@ -23,20 +46,32 @@ describe("resolveAgentAuth — internal vs anonymous", () => {
   });
 
   it("request with NO Authorization header → anonymous (deny)", async () => {
-    expect(await resolveAgentAuth(reqWithAuth(""))).toEqual({ kind: "anonymous" });
+    expect(await resolveAgentAuth(getShape())).toEqual({ kind: "anonymous" });
   });
 
-  it("request with a non-TPS scheme → anonymous (deny)", async () => {
-    expect(await resolveAgentAuth(reqWithAuth("Basic dXNlcjpwYXNz"))).toEqual({ kind: "anonymous" });
+  it("request with a non-TPS scheme + no user → anonymous (deny)", async () => {
+    expect(await resolveAgentAuth(getShape(BASIC))).toEqual({ kind: "anonymous" });
   });
 
   it("request with a malformed TPS-Ed25519 header → anonymous (deny)", async () => {
-    expect(await resolveAgentAuth(reqWithAuth("TPS-Ed25519 garbage-no-colons"))).toEqual({ kind: "anonymous" });
+    expect(await resolveAgentAuth(getShape("TPS-Ed25519 garbage-no-colons"))).toEqual({ kind: "anonymous" });
+  });
+
+  it("well-formed TPS-Ed25519 header for an unknown agent → anonymous, proving it ROUTED into verifyAgentRequest (not short-circuited)", async () => {
+    // No forged user present; the credential-evidence gate must NOT block the
+    // Ed25519 path — it has to reach verifyAgentRequest, which returns null for
+    // an unknown agent → anonymous. A short-circuit would instead have hit the
+    // final `internal` return (impossible here: headers ARE present).
+    const ts = Date.now();
+    const header = `TPS-Ed25519 unknown-agent:${ts}:nonce-abc:c2ln`;
+    expect(await resolveAgentAuth(getShape(header))).toEqual({ kind: "anonymous" });
   });
 });
 
-describe("resolveAgentAuth — gate annotations + context.user (handler phase)", () => {
-  it("gate tpsAgent annotation → agent (handler path; no header re-verify needed)", async () => {
+// ─── gate annotations (unchanged) ─────────────────────────────────────────────
+
+describe("resolveAgentAuth — gate annotations (handler phase)", () => {
+  it("gate tpsAgent annotation → agent (no header re-verify needed)", async () => {
     expect(await resolveAgentAuth({ tpsAgent: "agent-1", tpsAgentIsAdmin: false }))
       .toEqual({ kind: "agent", agentId: "agent-1", isAdmin: false });
     expect(await resolveAgentAuth({ tpsAgent: "admin-1", tpsAgentIsAdmin: true }))
@@ -51,20 +86,96 @@ describe("resolveAgentAuth — gate annotations + context.user (handler phase)",
   it("explicit tpsAnonymous marker → anonymous (set by the non-rejecting gate)", async () => {
     expect(await resolveAgentAuth({ tpsAnonymous: true })).toEqual({ kind: "anonymous" });
   });
+});
 
-  it("per-agent context.user (de-elevated) → agent via username", async () => {
-    expect(await resolveAgentAuth({ user: { username: "agent-3", role: { permission: {} } } }))
-      .toEqual({ kind: "agent", agentId: "agent-3", isAdmin: false });
+// ─── flair#610: context.user is trusted ONLY with credential evidence ─────────
+
+describe("resolveAgentAuth — context.user credential-evidence gate (flair#610)", () => {
+  it("super_user context.user WITH a Basic Authorization header (.get shape) → admin agent", async () => {
+    const v = await resolveAgentAuth({ user: superUser, ...getShape(BASIC) });
+    expect(v).toEqual({ kind: "agent", agentId: "admin", isAdmin: true });
   });
 
-  it("super_user context.user → admin agent", async () => {
-    const v = await resolveAgentAuth({ user: { username: "admin", role: { permission: { super_user: true } } } });
-    expect(v.kind).toBe("agent");
-    expect((v as any).isAdmin).toBe(true);
+  it("super_user context.user WITH a Basic Authorization header (.asObject shape) → admin agent", async () => {
+    const v = await resolveAgentAuth({ user: superUser, ...asObjectShape(BASIC) });
+    expect(v).toEqual({ kind: "agent", agentId: "admin", isAdmin: true });
+  });
+
+  it("super_user reachable via context.request wrapper (with header) → admin agent", async () => {
+    const v = await resolveAgentAuth({ request: { user: superUserNamed("nathan"), ...getShape(BASIC) } });
+    expect(v).toEqual({ kind: "agent", agentId: "nathan", isAdmin: true });
+  });
+
+  it("FORGED super_user context.user with NO Authorization header (.get shape) → anonymous — the authorizeLocal forgery is rejected", async () => {
+    const v = await resolveAgentAuth({ user: superUser, ...getShape(/* absent */) });
+    expect(v).toEqual({ kind: "anonymous" });
+  });
+
+  it("FORGED super_user context.user with NO Authorization header (.asObject shape) → anonymous", async () => {
+    const v = await resolveAgentAuth({ user: superUser, ...asObjectShape(/* absent */) });
+    expect(v).toEqual({ kind: "anonymous" });
+  });
+
+  it("per-agent (de-elevated) username WITH a Basic Authorization header → non-admin agent", async () => {
+    const v = await resolveAgentAuth({ user: perAgentUser, ...getShape(BASIC) });
+    expect(v).toEqual({ kind: "agent", agentId: "agent-3", isAdmin: false });
+  });
+
+  it("FORGED per-agent username with NO Authorization header → anonymous (identity claim without a credential is not trusted)", async () => {
+    const v = await resolveAgentAuth({ user: perAgentUser, ...getShape(/* absent */) });
+    expect(v).toEqual({ kind: "anonymous" });
   });
 
   it("shared flair-agent user with no other signal → internal (not mistaken for an agent)", async () => {
     expect(await resolveAgentAuth({ user: { username: "flair-agent", role: { permission: {} } } }))
       .toEqual({ kind: "internal" });
+  });
+
+  it("a bare context.user with NO request/headers object at all → internal (an in-process shape, never a loopback HTTP forgery, which always carries a headers object)", async () => {
+    // Documents the fall-through: a genuinely request-less call that merely
+    // carries a user object is a trusted in-process caller. A forged loopback
+    // request is distinguishable because it ALWAYS has a headers object (tested
+    // above → anonymous), so this internal path is unreachable by an attacker.
+    expect(await resolveAgentAuth({ user: superUser })).toEqual({ kind: "internal" });
+  });
+});
+
+// ─── hasCredentialEvidence — direct coverage of every shape ───────────────────
+
+describe("hasCredentialEvidence — recognizes every credential-bearing header shape", () => {
+  it("Basic on the .get() shape → true", () => {
+    expect(hasCredentialEvidence(getShape("Basic abc"))).toBe(true);
+  });
+  it("Bearer on the .get() shape → true", () => {
+    expect(hasCredentialEvidence(getShape("Bearer tok"))).toBe(true);
+  });
+  it("TPS-Ed25519 on the .get() shape → true (custom scheme still rides Authorization)", () => {
+    expect(hasCredentialEvidence(getShape("TPS-Ed25519 a:1:b:c"))).toBe(true);
+  });
+  it("TPS-Ed25519 on the .asObject shape → true", () => {
+    expect(hasCredentialEvidence(asObjectShape("TPS-Ed25519 a:1:b:c"))).toBe(true);
+  });
+  it("Basic on the .asObject shape → true", () => {
+    expect(hasCredentialEvidence(asObjectShape("Basic abc"))).toBe(true);
+  });
+  it("absent Authorization (.get returns undefined) → false", () => {
+    expect(hasCredentialEvidence(getShape())).toBe(false);
+  });
+  it("empty-string Authorization → false", () => {
+    expect(hasCredentialEvidence(getShape(""))).toBe(false);
+  });
+  it("absent Authorization (.asObject has no key) → false", () => {
+    expect(hasCredentialEvidence(asObjectShape())).toBe(false);
+  });
+  it("no headers object at all → false", () => {
+    expect(hasCredentialEvidence({ user: superUser })).toBe(false);
+    expect(hasCredentialEvidence(undefined)).toBe(false);
+    expect(hasCredentialEvidence(null)).toBe(false);
+  });
+  it("header carried on context.request (GET/search context shape) → true", () => {
+    expect(hasCredentialEvidence({ request: getShape("Basic abc") })).toBe(true);
+  });
+  it("header carried on the context object itself (PUT/POST context shape) → true", () => {
+    expect(hasCredentialEvidence(asObjectShape("Basic abc"))).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary

Root-cause fix for the `authorizeLocal` forgery class (#604/#609/#632 were per-resource; this closes it at the framework level). **K&S design-concurred** before implementation (both approved the approach 2026-07-08).

Harper's `authorizeLocal: true` forges `context.user = super_user` for a credential-**less** loopback request. `resolveAgentAuth` trusted that ambient `context.user` with no check that a credential was actually presented — the forgery vector. Fix: gate the `context.user` super_user/username branches on `hasCredentialEvidence()`.

- **`resources/agent-auth.ts`** — new `hasCredentialEvidence()` (reads the `authorization` header across both header-object shapes; TPS-Ed25519 rides the same header so it's covered; **deliberately excludes** the server-stamped `x-tps-*` trust markers — counting those would be a fresh forgery vector). Both `context.user` branches now require evidence; without it they fall through to the existing `verifyAgentRequest` path (signed request → agent; credential-less HTTP → anonymous; true in-process → internal). Per Kern's review, it's a header **list** read via both shapes, not a bare truthiness check, so a future signed-header scheme is a one-line add.
- **`resources/auth-middleware.ts`** — belt-and-suspenders: super_user branch gated on header-present (not a live vector today; keeps trust off ambient elevation for any future early-return resource).
- **`resources/OAuth.ts`** — `OAuthAuthorize.post()` mints only on explicit `action === "approve"` (was anything `!== "deny"`).
- **`src/cli.ts`** — corrected the false comment claiming the ops API doesn't honor authorizeLocal (it does for header-less loopback; the helpers send Basic unconditionally so they don't rely on it). Ops-API posture hardening tracked separately as #654.

## Test plan

- [x] `bun run build` && `bun run build:cli` clean
- [x] `bunx tsc --noEmit -p tsconfig.check.json` clean
- [x] `bun test test/unit/` — 1903/1903 pass (new `resolve-agent-auth`/`allow-helpers`/`cross-agent-isolation` cases; updated two assertions that had encoded the pre-fix vulnerable behavior — deliberate contract change)
- [x] `bun test test/integration/` — 237/237 pass. The #604 regression (`oauth-authorize-authz.test.ts`: credential-less loopback `POST /OAuthAuthorize` approve → 401, **no code minted**) runs against **real spawned Harper with `authorizeLocal:true`** and denies — Sherlock's required regression, already present from #604/#609, now defended at two layers.
- [ ] Kern (architecture) + Sherlock (security — auth surface, explicit approval)

Part of the 0.22.0 batch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
