### PR TITLE
ci: derive Docker Harper image tag from package.json (fix pin skew #625)

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -56,6 +56,21 @@ jobs:
             -o models/nomic-embed-text-v1.5.Q4_K_M.gguf
           echo "Model downloaded ($(du -sh models/*.gguf | cut -f1))"
 
+      # Single source of truth (#625): derive the Harper Docker image tag from the
+      # @harperfast/harper version declared in package.json, so the Docker-based
+      # validation can never drift behind the Harper that ships to npm users (the
+      # skew that bit v0.14.0: 5.0.1 image vs 5.1.14 dep).
+      - name: Resolve Harper image tag from package.json
+        id: harper-image
+        run: |
+          TAG=$(node -p "require('./package.json').dependencies['@harperfast/harper']")
+          case "$TAG" in
+            [0-9]*) : ;; # exact pin — usable directly as a Docker image tag
+            *) echo "::error::@harperfast/harper is '$TAG' in package.json — not an exact version pin, cannot derive a Docker image tag"; exit 1 ;;
+          esac
+          echo "Harper Docker image tracks the npm dep: harperfast/harper:$TAG"
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+
       - name: Start Flair (ephemeral Harper + Flair components)
         run: |
           docker run -d \
@@ -69,7 +84,7 @@ jobs:
             -e OPERATIONSAPI_NETWORK_PORT=9925 \
             -e HTTP_PORT=9926 \
             --entrypoint /bin/sh \
-            harperfast/harper:5.1.14 \
+            harperfast/harper:${{ steps.harper-image.outputs.tag }} \
             -c "harper install && harper dev /flair"
 
           # Wait for Harper to be healthy

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -115,8 +115,10 @@ jobs:
       # race that doesn't reproduce on native Node 22 spawns. The Harper
       # server code is byte-identical across artifacts — only the runtime
       # environment differs. The native-spawn choice is a version-agnostic
-      # mitigation; the E2E/smoke jobs run the Docker image (now 5.1.14, matching
-      # the bundled npm dep) and are where the race, if still present, surfaces.
+      # mitigation; the E2E/smoke jobs run the Docker image (its tag is derived
+      # from the @harperfast/harper npm dep at CI time — see the resolve step
+      # below, #625 — so it can't drift) and are where the race, if still
+      # present, surfaces.
       # Tracked upstream: https://github.com/HarperFast/harper/issues/386
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
@@ -147,7 +149,7 @@ jobs:
           echo "Model downloaded ($(du -sh models/*.gguf | cut -f1))"
       - name: Run integration tests (native Harper spawn)
         # No HARPER_HTTP_URL — harper-lifecycle spawns Harper from node_modules
-        # per the npm-installed @harperfast/harper (5.1.14). Avoids the Docker
+        # per the npm-installed @harperfast/harper. Avoids the Docker
         # runtime environment that has triggered HarperFast/harper#386.
         #
         # integration_repeats (workflow_dispatch input, default 1) runs the
@@ -167,6 +169,21 @@ jobs:
             bun test test/integration/
             echo "::endgroup::"
           done
+      # Single source of truth (#625): derive the Harper Docker image tag from the
+      # @harperfast/harper version declared in package.json, so the Docker-based
+      # E2E/Playwright validation can never drift behind the Harper that ships to
+      # npm users (the skew that bit v0.14.0: 5.0.1 image vs 5.1.14 dep).
+      - name: Resolve Harper image tag from package.json
+        id: harper-image
+        run: |
+          TAG=$(node -p "require('./package.json').dependencies['@harperfast/harper']")
+          case "$TAG" in
+            [0-9]*) : ;; # exact pin — usable directly as a Docker image tag
+            *) echo "::error::@harperfast/harper is '$TAG' in package.json — not an exact version pin, cannot derive a Docker image tag"; exit 1 ;;
+          esac
+          echo "Harper Docker image tracks the npm dep: harperfast/harper:$TAG"
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+
       - name: Start Harper with Flair component (for E2E / Playwright)
         run: |
           docker run -d \
@@ -180,7 +197,7 @@ jobs:
             -e OPERATIONSAPI_NETWORK_PORT=9925 \
             -e HTTP_PORT=9926 \
             --entrypoint /bin/sh \
-            harperfast/harper:5.1.14 \
+            harperfast/harper:${{ steps.harper-image.outputs.tag }} \
             -c "harper install && harper dev /flair"
           # Wait for Harper to be healthy (Basic auth required by Harper's authorizeLocal)
           for i in $(seq 1 60); do


### PR DESCRIPTION
## Summary

Closes #625. CI's Docker Harper image was hardcoded `harperfast/harper:5.1.14` in `smoke.yml` and `test.yml` while the npm `@harperfast/harper` dependency ships **5.1.17** — 3 patch versions of skew, so the Docker-based CI ran against a different Harper than production/npm uses (false confidence).

**Fix — single source of truth (not bump-and-check):** a CI step reads the declared `@harperfast/harper` version from `package.json` at run time and the `docker run` consumes it as the image tag. Divergence becomes *structurally impossible* rather than merely detectable. The resolve step guards against a non-exact pin (a `^`/`~` range can't be a Docker tag) with a clear error, matching the repo's existing exact-pin convention.

- `.github/workflows/smoke.yml` — resolve-tag step + derived tag on the Harper `docker run`.
- `.github/workflows/test.yml` — same in the `test-integration` E2E/Playwright Harper container; fixed two stale `5.1.14` comments.
- `docker/Dockerfile.*` + `docker-test.yml` npm-install Harper already, so they track the dep — correctly untouched.

**Verified:** Docker Hub registry API — `harperfast/harper:5.1.17` → 200 (and a fake `5.1.99` → 404, confirming the check discriminates). `bun test test/unit/` 1875/1875 pass; both workflow YAMLs parse; derivation yields 5.1.17 locally and passes the exact-pin guard.

Flag (not fixed, out of scope): `src/fabric-upgrade.ts`'s `DEFAULT_HARPER_PIN = "5.1.14"` is cosmetically stale but a dead-path fallback (only used below the 5.1.13 floor, which 5.1.17 clears) — bump in a follow-up if desired.

## Test plan
- [x] `bun test test/unit/` — 1875/1875 pass (no TS touched)
- [x] Both workflow YAMLs valid; derived tag present in both jobs
- [x] Target image tag existence verified via registry API
- [ ] Kern (CI) + Sherlock

Part of the 0.22.0 batch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
