### PR TITLE
feat(presence): liveness beacon — decay stale activity/task instead of freezing

### DIFF
--- a/packages/flair-mcp/src/presence.ts
+++ b/packages/flair-mcp/src/presence.ts
@@ -139,6 +139,14 @@ function withTimeout<T>(promise: Promise<T>, ms: number): Promise<T> {
  * omitted (not sent as null/empty) when absent, so callers that don't know a
  * task can still heartbeat without explicitly clearing one that was set
  * earlier — see postPresenceSafe()'s doc comment for why that matters.
+ *
+ * Natural-presence: this body always carries `activity`, and the server stamps
+ * `activityUpdatedAt` (resources/Presence.ts, buildPresenceRecord) on any beat
+ * that asserts activity/task — so a working agent keeps activity fresh, and one
+ * that stops lets it decay to last-known automatically (no manual clear). A
+ * future liveness-only beat (this body without `activity`) would refresh
+ * lastHeartbeatAt without re-stamping activity — the server treats the two
+ * independently.
  */
 export function buildPresenceBody(activity: PresenceActivity, currentTask?: string): Record<string, unknown> {
   const body: Record<string, unknown> = { activity };

--- a/resources/Presence.ts
+++ b/resources/Presence.ts
@@ -124,14 +124,24 @@ export function buildPresenceRecord(
   currentTask: unknown,
   activity: string | undefined,
   existingActivity: string | undefined,
+  existingActivityUpdatedAt: number | null | undefined,
   flairVersion: string,
   harperVersion: string | null,
 ): Record<string, unknown> {
+  // A heartbeat "asserts" what the agent is doing when it carries an activity
+  // and/or a (non-empty) currentTask. Only such a beat re-stamps
+  // activityUpdatedAt to `now`; a pure liveness beat (neither field) refreshes
+  // lastHeartbeatAt but PRESERVES the prior stamp — so activity ages on its own
+  // and lapses to last-known once the agent stops asserting it, with no manual
+  // clear (natural-presence). Backward compatible: today every real heartbeat
+  // carries activity, so this simply keeps activity fresh while an agent works.
+  const asserted = activity !== undefined || sanitizeCurrentTask(currentTask) !== null;
   return {
     agentId,
     lastHeartbeatAt: now,
     currentTask: sanitizeCurrentTask(currentTask),
     activity: activity ?? (existingActivity ?? "idle"),
+    activityUpdatedAt: asserted ? now : (existingActivityUpdatedAt ?? null),
     flairVersion,
     harperVersion,
   };
@@ -164,6 +174,60 @@ export function derivePresenceStatus(
   return "offline";
 }
 
+// ─── Activity decay (natural-presence) ─────────────────────────────────────────
+//
+// Presence is a LIVENESS BEACON, not a sticky status board: an offline agent
+// has, by definition, no *current* activity, so returning its last `activity`
+// / `currentTask` as if live is a lie (an agent offline 13 days still read as
+// `activity: "debugging"`; another showed a finished-task `currentTask` 20h
+// after going dark). These two pure functions decide "is this record's
+// activity still CURRENT, or has it lapsed into last-known?" — same offline
+// threshold, and the SAME graceful-degradation-on-old-records discipline, as
+// derivePresenceStatus() above and flair#639's version staleness.
+
+/**
+ * Resolve the timestamp used to judge activity freshness. Prefer the per-field
+ * `activityUpdatedAt` stamp (additive/nullable, mirrors flair#639); fall back
+ * to `lastHeartbeatAt` for records written before this feature existed — so an
+ * old row degrades to "activity is exactly as fresh as its heartbeat" (never
+ * claiming activity is FRESHER than the beat that carried it) rather than
+ * reading as permanently stale or throwing. Returns null only when NEITHER is
+ * a finite number (nothing to judge against → treated as stale by callers).
+ */
+export function activityFreshnessAt(
+  activityUpdatedAt: number | null | undefined,
+  lastHeartbeatAt: number | null | undefined,
+): number | null {
+  if (typeof activityUpdatedAt === "number" && Number.isFinite(activityUpdatedAt)) return activityUpdatedAt;
+  if (typeof lastHeartbeatAt === "number" && Number.isFinite(lastHeartbeatAt)) return lastHeartbeatAt;
+  return null;
+}
+
+/**
+ * Pure decay rule: is a record's activity/currentTask still CURRENT? Activity
+ * is fresh while its freshness stamp is younger than the SAME offline
+ * threshold that flips presenceStatus to "offline" — so an offline agent can
+ * never present a live-looking activity label. Because the stamp only moves
+ * forward when a heartbeat actually carries activity (see buildPresenceRecord),
+ * activity also lapses INDEPENDENTLY of raw liveness: an agent that keeps
+ * heartbeating liveness but stops asserting what it's doing decays to
+ * last-known on its own, no manual "clear" call needed. Clock skew (a stamp in
+ * the future) is treated as fresh, matching derivePresenceStatus().
+ */
+export function isActivityFresh(
+  now: number,
+  activityUpdatedAt: number | null | undefined,
+  lastHeartbeatAt: number | null | undefined,
+  offlineMs?: number,
+): boolean {
+  const offline = offlineMs ?? offlineThresholdMs();
+  const at = activityFreshnessAt(activityUpdatedAt, lastHeartbeatAt);
+  if (at == null) return false;
+  const elapsed = now - at;
+  if (elapsed < 0) return true;
+  return elapsed < offline;
+}
+
 // ─── Public-safe field allowlist ──────────────────────────────────────────────
 
 // flairVersion/harperVersion (flair#639) are content-gated the SAME way as
@@ -172,12 +236,22 @@ export function derivePresenceStatus(
 // endpoint (resources/health.ts): version info is deliberately withheld from
 // anonymous callers to avoid fingerprinting a publicly exposed instance for
 // known-CVE targeting. Anonymous readers get null for both, same as currentTask.
+// activity/lastActivity/activityUpdatedAt/activityAgeMs/activityFresh
+// (natural-presence) are all public-safe: `activity` and `lastActivity` are a
+// fixed vocabulary label (coding|reviewing|planning|idle), the two timestamps
+// and the boolean are liveness metadata of the same class as the already-public
+// lastHeartbeatAt. Only `currentTask` (free text) stays content-gated to
+// verified readers — see get()'s includeVerifiedFields.
 const ROSTER_ALLOWLIST = new Set([
   "id",
   "displayName",
   "role",
   "runtime",
   "activity",
+  "lastActivity",
+  "activityUpdatedAt",
+  "activityAgeMs",
+  "activityFresh",
   "presenceStatus",
   "currentTask",
   "lastHeartbeatAt",
@@ -285,27 +359,59 @@ export class Presence extends (databases as any).flair.Presence {
           agent = await (databases as any).flair.Agent.get(agentId);
         } catch { /* agent may not exist or be deactivated */ }
 
+        const lastHeartbeatAt = typeof row?.lastHeartbeatAt === "number"
+          ? row.lastHeartbeatAt
+          : Number(row?.lastHeartbeatAt ?? 0);
+        // activityUpdatedAt is BigInt in the schema (Harper may hand it back as
+        // number|string|bigint) and absent on pre-feature records — normalize
+        // to a finite number or null so activityFreshnessAt() can fall back.
+        const activityUpdatedAt = row?.activityUpdatedAt == null
+          ? null
+          : (typeof row.activityUpdatedAt === "number" ? row.activityUpdatedAt : Number(row.activityUpdatedAt));
+
+        // NATURAL PRESENCE: bind activity/currentTask to freshness. A stale
+        // record has no *current* activity — present the last-known label under
+        // dedicated fields, never as the live `activity`. `activity` is the
+        // CURRENT truth (falls to "idle" — the "nothing right now" vocabulary
+        // value — once stale); `lastActivity` preserves the raw last-known
+        // label so a reader can render "offline (was: coding)".
+        const rawActivity = (typeof row?.activity === "string" && row.activity.length > 0)
+          ? row.activity
+          : "idle";
+        const activityFresh = isActivityFresh(now, activityUpdatedAt, lastHeartbeatAt, offlineThreshold);
+        const freshnessAt = activityFreshnessAt(activityUpdatedAt, lastHeartbeatAt);
+
         const entry: Record<string, unknown> = {
           id: agentId,
           displayName: agent?.displayName ?? agent?.name ?? agentId,
           role: agent?.role ?? "agent",
           runtime: agent?.runtime ?? null,
-          activity: row?.activity ?? "idle",
+          // Current activity — only truthful while fresh; "idle" once decayed.
+          activity: activityFresh ? rawActivity : "idle",
+          // Last-known activity label regardless of freshness (public-safe, same
+          // vocabulary as activity) → enables "was: <activity>" rendering.
+          lastActivity: rawActivity,
+          // When activity was last asserted (resolved; falls back to
+          // lastHeartbeatAt for pre-feature records — see activityFreshnessAt).
+          activityUpdatedAt: freshnessAt,
+          // How stale that assertion is, so a reader can show "was active Xh
+          // ago" without needing the server's clock or the threshold.
+          activityAgeMs: freshnessAt != null ? Math.max(0, now - freshnessAt) : null,
+          // The server's verdict — makes staleness impossible to misread.
+          activityFresh,
           presenceStatus: derivePresenceStatus(
             now,
-            typeof row?.lastHeartbeatAt === "number"
-              ? row.lastHeartbeatAt
-              : Number(row?.lastHeartbeatAt ?? 0),
+            lastHeartbeatAt,
             idleThreshold,
             offlineThreshold,
           ),
-          // Anonymous/unverified readers get `null` here (key stays present,
-          // schema-stable) instead of the sanitized task text — see the
-          // currentTask CONTENT gate doc above get().
-          currentTask: includeVerifiedFields ? sanitizeCurrentTask(row?.currentTask) : null,
-          lastHeartbeatAt: typeof row?.lastHeartbeatAt === "number"
-            ? row.lastHeartbeatAt
-            : Number(row?.lastHeartbeatAt ?? 0),
+          // currentTask is current only when the reader is verified AND the
+          // record is fresh. A stale record's task (a finished-task string it
+          // never cleared) is NOT current → null, same as the anonymous case.
+          // Anonymous/unverified readers always get null (key stays present,
+          // schema-stable) — see the currentTask CONTENT gate doc above get().
+          currentTask: (includeVerifiedFields && activityFresh) ? sanitizeCurrentTask(row?.currentTask) : null,
+          lastHeartbeatAt,
           // flair#639: absent on records written before this feature (older
           // instance, never re-heartbeated since upgrading) — `row?.field ??
           // null` tolerates that directly, same as every other optional field
@@ -449,6 +555,10 @@ export class Presence extends (databases as any).flair.Presence {
         currentTask,
         activity,
         existing?.activity,
+        // Preserve the prior activity-freshness stamp when THIS beat asserts no
+        // activity/task (pure liveness) — normalize the BigInt-ish stored value
+        // to a number so buildPresenceRecord's `?? null` fallback behaves.
+        existing?.activityUpdatedAt == null ? null : Number(existing.activityUpdatedAt),
         resolveVersion(),
         resolveHarperVersion(),
       );

--- a/schemas/schema.graphql
+++ b/schemas/schema.graphql
@@ -3,9 +3,10 @@
 
 type Presence @table(database: "flair") @export {
   agentId: ID @primaryKey
-  lastHeartbeatAt: BigInt        # unix ms timestamp
+  lastHeartbeatAt: BigInt        # unix ms timestamp — pure liveness beacon; every heartbeat refreshes it
   currentTask: String            # short human string, e.g. "Reviewing flair#467"
   activity: String @indexed      # "coding" | "reviewing" | "planning" | "idle"
+  activityUpdatedAt: BigInt      # unix ms — when activity/currentTask were last ASSERTED (natural-presence); nullable/additive, absent on records written before this feature (readers fall back to lastHeartbeatAt)
   flairVersion: String           # @tpsdev-ai/flair version serving this heartbeat (flair#639); absent on pre-#639 records
   harperVersion: String          # @harperfast/harper version serving this heartbeat (flair#639); absent on pre-#639 records
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -8729,7 +8729,21 @@ program
                 : "";
               const icon = row.stale ? render.icons.warn : render.icons.ok;
               const statusSuffix = row.presenceStatus ? ` (${row.presenceStatus})` : "";
-              console.log(`  ${icon} ${row.id} — ${versionLabel} — last seen ${lastSeen}${statusSuffix}${staleNote}`);
+              // Natural-presence: same staleness principle as the version
+              // column — a live activity is shown as current, a decayed one as
+              // "last-known". `activityFresh === false` (server verdict) plus a
+              // known lastActivity → "(was: X)"; a fresh, non-idle activity →
+              // "(X)". Skip entirely when there's nothing informative to say
+              // (no signal, or idle) so the line stays quiet for the common case.
+              const lastActivity = row.lastActivity ?? row.activity;
+              const activityNote = row.activityFresh === false
+                ? (lastActivity && lastActivity !== "idle"
+                    ? " " + render.wrap(render.c.dim, `(was: ${lastActivity})`)
+                    : "")
+                : (row.activity && row.activity !== "idle"
+                    ? " " + render.wrap(render.c.dim, `(${row.activity})`)
+                    : "");
+              console.log(`  ${icon} ${row.id} — ${versionLabel} — last seen ${lastSeen}${statusSuffix}${activityNote}${staleNote}`);
             }
             if (!canSign) {
               console.log(`     ${render.wrap(render.c.dim, "Pass --agent <id> (with a matching key in ~/.flair/keys) to reveal versions — flairVersion/harperVersion require a verified signature, same as currentTask.")}`);

--- a/src/fleet-presence.ts
+++ b/src/fleet-presence.ts
@@ -37,6 +37,13 @@ export interface FleetPresenceRow {
   harperVersion?: string | null;
   lastHeartbeatAt?: number | null;
   presenceStatus?: string;
+  // Natural-presence activity fields (roster GET). `activity` is the CURRENT
+  // activity ("idle" once decayed); `lastActivity` is the raw last-known label;
+  // `activityFresh` is the server's freshness verdict. All optional — a
+  // pre-feature roster omits them, and the doctor renderer tolerates absence.
+  activity?: string | null;
+  lastActivity?: string | null;
+  activityFresh?: boolean;
 }
 
 export interface FleetInstanceRow extends FleetPresenceRow {

--- a/test/integration/doctor-fleet-presence.test.ts
+++ b/test/integration/doctor-fleet-presence.test.ts
@@ -166,4 +166,41 @@ describe("flair doctor — fleet presence (flair#639, real CLI + real spawned Ha
     expect(currentIdx).toBeGreaterThan(-1);
     expect(oldIdx).toBeLessThan(currentIdx);
   }, 40_000);
+
+  test("natural-presence: a stale-activity instance renders 'offline' with its last-known activity, not a live label", async () => {
+    // Seed a row with a CURRENT version (not version-stale) but a long-stale
+    // heartbeat + activity stamp, so the only signal is activity decay — the
+    // fleet section must read it as offline + last-known, same staleness
+    // principle as the version column.
+    const STALE_ACT_ID = "fleet-doctor-agent-stale-activity";
+    const staleAt = Date.now() - 13 * 24 * 60 * 60 * 1000;
+    const auth = "Basic " + Buffer.from(`admin:${ADMIN_PASS}`).toString("base64");
+    const seedRes = await fetch(harper.opsURL, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Authorization: auth },
+      body: JSON.stringify({
+        operation: "insert",
+        database: "flair",
+        table: "Presence",
+        records: [{
+          agentId: STALE_ACT_ID,
+          lastHeartbeatAt: staleAt,
+          activityUpdatedAt: staleAt,
+          activity: "debugging",
+          currentTask: "on-call investigation complete",
+          flairVersion: REAL_FLAIR_VERSION,
+          harperVersion: "5.1.17",
+        }],
+      }),
+    });
+    expect(seedRes.ok).toBe(true);
+
+    const doctor = await runCli(["doctor", "--port", httpPort(), "--agent", AGENT_A]);
+    const out = `${doctor.stdout}${doctor.stderr}`;
+    const sectionStart = out.indexOf("Fleet presence");
+    const line = out.slice(sectionStart).split("\n").find((l) => l.includes(STALE_ACT_ID)) ?? "";
+    expect(line).toContain("offline");
+    // Last-known activity is shown as "(was: debugging)", never a live label.
+    expect(line).toContain("was: debugging");
+  }, 40_000);
 });

--- a/test/integration/presence-api.test.ts
+++ b/test/integration/presence-api.test.ts
@@ -235,6 +235,10 @@ describe("Presence API integration", () => {
       "role",
       "runtime",
       "activity",
+      "lastActivity",
+      "activityUpdatedAt",
+      "activityAgeMs",
+      "activityFresh",
       "presenceStatus",
       "currentTask",
       "lastHeartbeatAt",
@@ -378,6 +382,184 @@ describe("Presence API integration", () => {
     // The rest of the row is served normally — tolerance doesn't break the
     // entry, it just leaves the two new fields null.
     expect(typeof legacy.presenceStatus).toBe("string");
+  });
+
+  // ── 4d. Natural presence: activity/currentTask decay with liveness ─────────
+  // Presence is a liveness beacon, not a sticky status board. A fresh heartbeat
+  // presents activity/currentTask as CURRENT; a stale record must NOT — it
+  // presents the last-known label under lastActivity, nulls the current
+  // activity to "idle" and currentTask to null, and flags activityFresh=false.
+  // Staleness is simulated by inserting a Presence row directly via the ops API
+  // with old timestamps (same technique as the legacy-record test above) — the
+  // only way to produce a stale row without waiting out the real threshold.
+
+  const STALE_MS = 13 * 24 * 60 * 60 * 1000; // 13 days — the real-world frozen-"debugging" case
+
+  test("fresh heartbeat: activity is presented as CURRENT (activityFresh=true, stamp set)", async () => {
+    const auth = buildAuthHeader(agent1.id, "POST", "/Presence", agent1.privateKey);
+    await fetch(`${harper.httpURL}/Presence`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Authorization: auth },
+      body: JSON.stringify({ currentTask: "shipping natural presence", activity: "reviewing" }),
+    });
+
+    const getAuth = buildAuthHeader(agent1.id, "GET", "/Presence", agent1.privateKey);
+    const res = await fetch(`${harper.httpURL}/Presence`, { headers: { Authorization: getAuth } });
+    const roster = await res.json();
+    const a1 = roster.find((r: any) => r.id === agent1.id);
+    expect(a1.activityFresh).toBe(true);
+    expect(a1.activity).toBe("reviewing");
+    expect(a1.lastActivity).toBe("reviewing");
+    expect(a1.currentTask).toBe("shipping natural presence");
+    expect(typeof a1.activityUpdatedAt).toBe("number");
+    expect(a1.activityAgeMs).toBeGreaterThanOrEqual(0);
+    expect(a1.activityAgeMs).toBeLessThan(60_000); // just set
+  });
+
+  test("stale record: activity decays to 'idle', currentTask nulls, lastActivity keeps the last-known label", async () => {
+    const staleId = "presence-natural-stale";
+    const staleAt = Date.now() - STALE_MS;
+    await fetch(harper.opsURL, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Authorization: adminAuth() },
+      body: JSON.stringify({
+        operation: "insert",
+        database: "flair",
+        table: "Presence",
+        records: [{
+          agentId: staleId,
+          lastHeartbeatAt: staleAt,
+          activityUpdatedAt: staleAt,
+          activity: "debugging",
+          currentTask: "on-call investigation complete — preprod-db-3",
+        }],
+      }),
+    });
+
+    // Read as a VERIFIED agent — proves the decay is not merely the anon gate:
+    // even a verified reader does NOT get a stale record's currentTask, because
+    // it isn't CURRENT.
+    const getAuth = buildAuthHeader(agent1.id, "GET", "/Presence", agent1.privateKey);
+    const res = await fetch(`${harper.httpURL}/Presence`, { headers: { Authorization: getAuth } });
+    const roster = await res.json();
+    const stale = roster.find((r: any) => r.id === staleId);
+    expect(stale).toBeDefined();
+    expect(stale.presenceStatus).toBe("offline");
+    expect(stale.activityFresh).toBe(false);
+    // Current activity is NOT the frozen "debugging" label.
+    expect(stale.activity).toBe("idle");
+    // Last-known label is preserved for "was: debugging" rendering.
+    expect(stale.lastActivity).toBe("debugging");
+    // A verified reader still gets null — the task is not current.
+    expect(stale.currentTask).toBeNull();
+    // Age reflects how long ago it lapsed.
+    expect(stale.activityAgeMs).toBeGreaterThan(STALE_MS - 60_000);
+  });
+
+  test("independent decay: fresh heartbeat but stale activity stamp → online yet activity decayed", async () => {
+    const id = "presence-natural-independent";
+    const now = Date.now();
+    await fetch(harper.opsURL, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Authorization: adminAuth() },
+      body: JSON.stringify({
+        operation: "insert",
+        database: "flair",
+        table: "Presence",
+        records: [{
+          agentId: id,
+          lastHeartbeatAt: now,               // fresh liveness
+          activityUpdatedAt: now - 700_000,   // 11.6min — past the 10min offline threshold
+          activity: "coding",
+          currentTask: "started this a while ago",
+        }],
+      }),
+    });
+
+    const getAuth = buildAuthHeader(agent1.id, "GET", "/Presence", agent1.privateKey);
+    const res = await fetch(`${harper.httpURL}/Presence`, { headers: { Authorization: getAuth } });
+    const roster = await res.json();
+    const row = roster.find((r: any) => r.id === id);
+    expect(row).toBeDefined();
+    // Liveness is fresh → still active/idle, NOT offline.
+    expect(row.presenceStatus).not.toBe("offline");
+    // But activity lapsed on its own — this is the independent decay.
+    expect(row.activityFresh).toBe(false);
+    expect(row.activity).toBe("idle");
+    expect(row.lastActivity).toBe("coding");
+    expect(row.currentTask).toBeNull();
+  });
+
+  test("old record (no activityUpdatedAt) + stale heartbeat: falls back to lastHeartbeatAt, decays, no throw", async () => {
+    const id = "presence-natural-legacy-stale";
+    const staleAt = Date.now() - STALE_MS;
+    await fetch(harper.opsURL, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Authorization: adminAuth() },
+      body: JSON.stringify({
+        operation: "insert",
+        database: "flair",
+        table: "Presence",
+        // NO activityUpdatedAt — a record written before natural-presence.
+        records: [{ agentId: id, lastHeartbeatAt: staleAt, activity: "planning" }],
+      }),
+    });
+
+    const getAuth = buildAuthHeader(agent1.id, "GET", "/Presence", agent1.privateKey);
+    const res = await fetch(`${harper.httpURL}/Presence`, { headers: { Authorization: getAuth } });
+    expect(res.status).toBe(200);
+    const roster = await res.json();
+    const row = roster.find((r: any) => r.id === id);
+    expect(row).toBeDefined();
+    // Freshness falls back to lastHeartbeatAt → stale → decayed, no crash.
+    expect(row.activityFresh).toBe(false);
+    expect(row.activity).toBe("idle");
+    expect(row.lastActivity).toBe("planning");
+    expect(typeof row.activityUpdatedAt).toBe("number"); // resolved to lastHeartbeatAt
+  });
+
+  test("old record (no activityUpdatedAt) + FRESH heartbeat: activity is as fresh as the beat", async () => {
+    const id = "presence-natural-legacy-fresh";
+    await fetch(harper.opsURL, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Authorization: adminAuth() },
+      body: JSON.stringify({
+        operation: "insert",
+        database: "flair",
+        table: "Presence",
+        records: [{ agentId: id, lastHeartbeatAt: Date.now(), activity: "reviewing" }],
+      }),
+    });
+
+    const getAuth = buildAuthHeader(agent1.id, "GET", "/Presence", agent1.privateKey);
+    const res = await fetch(`${harper.httpURL}/Presence`, { headers: { Authorization: getAuth } });
+    const roster = await res.json();
+    const row = roster.find((r: any) => r.id === id);
+    expect(row.activityFresh).toBe(true);
+    expect(row.activity).toBe("reviewing");
+  });
+
+  test("stale record: anonymous reader also gets currentTask=null, and lastActivity stays public", async () => {
+    const id = "presence-natural-stale-anon";
+    const staleAt = Date.now() - STALE_MS;
+    await fetch(harper.opsURL, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Authorization: adminAuth() },
+      body: JSON.stringify({
+        operation: "insert",
+        database: "flair",
+        table: "Presence",
+        records: [{ agentId: id, lastHeartbeatAt: staleAt, activityUpdatedAt: staleAt, activity: "coding", currentTask: "secret preprod host" }],
+      }),
+    });
+
+    const res = await fetch(`${harper.httpURL}/Presence`); // anonymous
+    const roster = await res.json();
+    const row = roster.find((r: any) => r.id === id);
+    expect(row.currentTask).toBeNull();     // gated AND stale
+    expect(row.lastActivity).toBe("coding"); // public-safe label survives
+    expect(row.activity).toBe("idle");
+    expect(row.activityFresh).toBe(false);
   });
 
   // ── 5. currentTask length cap ──────────────────────────────────────────────
@@ -556,10 +738,17 @@ describe("Presence API integration", () => {
   test("genuine Ed25519-signed PUT /Presence/<id> (own record) still succeeds", async () => {
     const path = `/Presence/${agent1.id}`;
     const auth = buildAuthHeader(agent1.id, "PUT", path, agent1.privateKey);
+    // PUT is a full record replace (super.put()), NOT the heartbeat merge — so
+    // it must carry its own liveness (lastHeartbeatAt) and activity freshness
+    // (activityUpdatedAt) for the record to read as CURRENT. Natural-presence
+    // gates currentTask on freshness: a record with no/stale heartbeat is
+    // offline and its task is (correctly) not current. This writes a fresh
+    // record so we assert the signed PUT landed AND reads back as current.
+    const now = Date.now();
     const res = await fetch(`${harper.httpURL}${path}`, {
       method: "PUT",
       headers: { "Content-Type": "application/json", Authorization: auth },
-      body: JSON.stringify({ agentId: agent1.id, currentTask: "signed PUT still works", activity: "coding" }),
+      body: JSON.stringify({ agentId: agent1.id, currentTask: "signed PUT still works", activity: "coding", lastHeartbeatAt: now, activityUpdatedAt: now }),
     });
     expect([200, 204]).toContain(res.status);
 
@@ -568,6 +757,7 @@ describe("Presence API integration", () => {
     const roster = await check.json();
     const a1 = roster.find((r: any) => r.id === agent1.id);
     expect(a1.currentTask).toBe("signed PUT still works");
+    expect(a1.activityFresh).toBe(true);
   }, 30_000);
 
   test("genuine Ed25519-signed PUT /Presence for ANOTHER agent's record → 403", async () => {

--- a/test/unit/presence-activity-decay.test.ts
+++ b/test/unit/presence-activity-decay.test.ts
@@ -1,0 +1,148 @@
+/**
+ * presence-activity-decay.test.ts — Unit tests for the natural-presence
+ * activity-decay logic: is a record's activity/currentTask still CURRENT, or
+ * has it lapsed into last-known?
+ *
+ * These tests exercise INLINE COPIES of activityFreshnessAt()/isActivityFresh()
+ * from resources/Presence.ts — same technique (and same reason) as
+ * presence-status-derivation.test.ts / presence-version-record.test.ts:
+ * resources/Presence.ts extends `databases.flair.Presence` at module load,
+ * which throws outside a running Harper. Live coverage of the decay applied to
+ * a real GET /Presence lives in test/integration/presence-api.test.ts.
+ */
+
+import { describe, test, expect } from "bun:test";
+
+// ─── Inline copies (mirror resources/Presence.ts) ──────────────────────────────
+
+const OFFLINE_THRESHOLD = 600_000; // 600s — the same boundary as presenceStatus offline
+
+function activityFreshnessAt(
+  activityUpdatedAt: number | null | undefined,
+  lastHeartbeatAt: number | null | undefined,
+): number | null {
+  if (typeof activityUpdatedAt === "number" && Number.isFinite(activityUpdatedAt)) return activityUpdatedAt;
+  if (typeof lastHeartbeatAt === "number" && Number.isFinite(lastHeartbeatAt)) return lastHeartbeatAt;
+  return null;
+}
+
+function isActivityFresh(
+  now: number,
+  activityUpdatedAt: number | null | undefined,
+  lastHeartbeatAt: number | null | undefined,
+  offlineMs: number = OFFLINE_THRESHOLD,
+): boolean {
+  const at = activityFreshnessAt(activityUpdatedAt, lastHeartbeatAt);
+  if (at == null) return false;
+  const elapsed = now - at;
+  if (elapsed < 0) return true;
+  return elapsed < offlineMs;
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+const NOW = 1_700_000_000_000;
+
+describe("activityFreshnessAt", () => {
+  test("prefers activityUpdatedAt when it is a finite number", () => {
+    expect(activityFreshnessAt(NOW - 1000, NOW - 999999)).toBe(NOW - 1000);
+  });
+
+  test("falls back to lastHeartbeatAt when activityUpdatedAt is null (old record)", () => {
+    expect(activityFreshnessAt(null, NOW - 5000)).toBe(NOW - 5000);
+  });
+
+  test("falls back to lastHeartbeatAt when activityUpdatedAt is undefined", () => {
+    expect(activityFreshnessAt(undefined, NOW - 5000)).toBe(NOW - 5000);
+  });
+
+  test("falls back to lastHeartbeatAt when activityUpdatedAt is NaN", () => {
+    expect(activityFreshnessAt(NaN, NOW - 5000)).toBe(NOW - 5000);
+  });
+
+  test("falls back to lastHeartbeatAt when activityUpdatedAt is Infinity", () => {
+    expect(activityFreshnessAt(Infinity, NOW - 5000)).toBe(NOW - 5000);
+  });
+
+  test("null when NEITHER is a finite number", () => {
+    expect(activityFreshnessAt(null, null)).toBeNull();
+    expect(activityFreshnessAt(undefined, undefined)).toBeNull();
+    expect(activityFreshnessAt(NaN, NaN)).toBeNull();
+  });
+});
+
+describe("isActivityFresh", () => {
+  describe("fresh: stamp younger than the offline threshold", () => {
+    test("just-stamped (0ms elapsed) → fresh", () => {
+      expect(isActivityFresh(NOW, NOW, NOW)).toBe(true);
+    });
+
+    test("30s old → fresh", () => {
+      expect(isActivityFresh(NOW, NOW - 30_000, NOW - 30_000)).toBe(true);
+    });
+
+    test("1ms before the offline boundary → fresh", () => {
+      expect(isActivityFresh(NOW, NOW - (OFFLINE_THRESHOLD - 1), NOW)).toBe(true);
+    });
+
+    test("idle-window heartbeat (5min old) → activity still fresh", () => {
+      // Matches derivePresenceStatus semantics: an idle (not offline) agent's
+      // activity is plausibly still current; only crossing offline decays it.
+      expect(isActivityFresh(NOW, NOW - 300_000, NOW - 300_000)).toBe(true);
+    });
+  });
+
+  describe("stale: stamp at or past the offline threshold", () => {
+    test("exactly at the offline threshold → stale (mirrors presenceStatus offline boundary)", () => {
+      expect(isActivityFresh(NOW, NOW - OFFLINE_THRESHOLD, NOW - OFFLINE_THRESHOLD)).toBe(false);
+    });
+
+    test("1ms past the offline threshold → stale", () => {
+      expect(isActivityFresh(NOW, NOW - OFFLINE_THRESHOLD - 1, NOW)).toBe(false);
+    });
+
+    test("13 days old (the real-world frozen-'debugging' case) → stale", () => {
+      const thirteenDays = 13 * 24 * 60 * 60 * 1000;
+      expect(isActivityFresh(NOW, NOW - thirteenDays, NOW - thirteenDays)).toBe(false);
+    });
+  });
+
+  describe("independent decay: activity older than liveness", () => {
+    test("fresh heartbeat but activity stamp past the threshold → activity stale", () => {
+      // Agent keeps heartbeating liveness (lastHeartbeatAt fresh) but stopped
+      // asserting activity 11min ago → activity decays even though it's online.
+      expect(isActivityFresh(NOW, NOW - 660_000, NOW - 1_000)).toBe(false);
+    });
+
+    test("fresh activity stamp but stale heartbeat → activity still fresh (stamp wins)", () => {
+      expect(isActivityFresh(NOW, NOW - 1_000, NOW - 660_000)).toBe(true);
+    });
+  });
+
+  describe("old records (no activityUpdatedAt): fall back to lastHeartbeatAt", () => {
+    test("fresh heartbeat, no stamp → fresh (as fresh as the beat)", () => {
+      expect(isActivityFresh(NOW, null, NOW - 1_000)).toBe(true);
+    });
+
+    test("stale heartbeat, no stamp → stale (never fresher than the beat)", () => {
+      expect(isActivityFresh(NOW, undefined, NOW - 700_000)).toBe(false);
+    });
+
+    test("no stamp AND no heartbeat → stale (nothing to judge)", () => {
+      expect(isActivityFresh(NOW, null, null)).toBe(false);
+    });
+  });
+
+  describe("clock skew", () => {
+    test("stamp in the future (negative elapsed) → fresh, matching derivePresenceStatus", () => {
+      expect(isActivityFresh(NOW, NOW + 5_000, NOW + 5_000)).toBe(true);
+    });
+  });
+
+  describe("custom threshold", () => {
+    test("respects a custom offline threshold", () => {
+      expect(isActivityFresh(NOW, NOW - 31_000, NOW, 30_000)).toBe(false);
+      expect(isActivityFresh(NOW, NOW - 29_000, NOW, 30_000)).toBe(true);
+    });
+  });
+});

--- a/test/unit/presence-version-record.test.ts
+++ b/test/unit/presence-version-record.test.ts
@@ -39,14 +39,17 @@ function buildPresenceRecord(
   currentTask: unknown,
   activity: string | undefined,
   existingActivity: string | undefined,
+  existingActivityUpdatedAt: number | null | undefined,
   flairVersion: string,
   harperVersion: string | null,
 ): Record<string, unknown> {
+  const asserted = activity !== undefined || sanitizeCurrentTask(currentTask) !== null;
   return {
     agentId,
     lastHeartbeatAt: now,
     currentTask: sanitizeCurrentTask(currentTask),
     activity: activity ?? (existingActivity ?? "idle"),
+    activityUpdatedAt: asserted ? now : (existingActivityUpdatedAt ?? null),
     flairVersion,
     harperVersion,
   };
@@ -58,13 +61,13 @@ const NOW = 1_700_000_000_000;
 
 describe("buildPresenceRecord", () => {
   test("stamps both flairVersion and harperVersion onto the record", () => {
-    const record = buildPresenceRecord("agent-1", NOW, "reviewing flair#639", "coding", undefined, "0.21.0", "5.1.17");
+    const record = buildPresenceRecord("agent-1", NOW, "reviewing flair#639", "coding", undefined, undefined, "0.21.0", "5.1.17");
     expect(record.flairVersion).toBe("0.21.0");
     expect(record.harperVersion).toBe("5.1.17");
   });
 
   test("harperVersion null passthrough when resolution failed", () => {
-    const record = buildPresenceRecord("agent-1", NOW, undefined, "idle", undefined, "0.21.0", null);
+    const record = buildPresenceRecord("agent-1", NOW, undefined, "idle", undefined, undefined, "0.21.0", null);
     expect(record.harperVersion).toBeNull();
     // flairVersion always resolves to a real string (falls back to "dev"),
     // never null — the two are intentionally different types.
@@ -72,46 +75,83 @@ describe("buildPresenceRecord", () => {
   });
 
   test("core fields (agentId, lastHeartbeatAt) always present", () => {
-    const record = buildPresenceRecord("agent-2", NOW, undefined, "idle", undefined, "0.1.0", null);
+    const record = buildPresenceRecord("agent-2", NOW, undefined, "idle", undefined, undefined, "0.1.0", null);
     expect(record.agentId).toBe("agent-2");
     expect(record.lastHeartbeatAt).toBe(NOW);
   });
 
   test("activity falls back to existingActivity when not provided", () => {
-    const record = buildPresenceRecord("a", NOW, undefined, undefined, "reviewing", "0.1.0", "5.0.0");
+    const record = buildPresenceRecord("a", NOW, undefined, undefined, "reviewing", undefined, "0.1.0", "5.0.0");
     expect(record.activity).toBe("reviewing");
   });
 
   test("activity falls back to 'idle' when neither activity nor existingActivity is set", () => {
-    const record = buildPresenceRecord("a", NOW, undefined, undefined, undefined, "0.1.0", "5.0.0");
+    const record = buildPresenceRecord("a", NOW, undefined, undefined, undefined, undefined, "0.1.0", "5.0.0");
     expect(record.activity).toBe("idle");
   });
 
   test("explicit activity wins over existingActivity", () => {
-    const record = buildPresenceRecord("a", NOW, undefined, "planning", "coding", "0.1.0", "5.0.0");
+    const record = buildPresenceRecord("a", NOW, undefined, "planning", "coding", undefined, "0.1.0", "5.0.0");
     expect(record.activity).toBe("planning");
   });
 
   test("currentTask is sanitized (trimmed) the same as before flair#639", () => {
-    const record = buildPresenceRecord("a", NOW, "  investigating flair#639  ", "coding", undefined, "0.1.0", "5.0.0");
+    const record = buildPresenceRecord("a", NOW, "  investigating flair#639  ", "coding", undefined, undefined, "0.1.0", "5.0.0");
     expect(record.currentTask).toBe("investigating flair#639");
   });
 
   test("currentTask capped at 200 chars", () => {
     const long = "x".repeat(500);
-    const record = buildPresenceRecord("a", NOW, long, "coding", undefined, "0.1.0", "5.0.0");
+    const record = buildPresenceRecord("a", NOW, long, "coding", undefined, undefined, "0.1.0", "5.0.0");
     expect((record.currentTask as string).length).toBe(200);
   });
 
   test("absent currentTask → null (explicit clear, unchanged from pre-#639 behavior)", () => {
-    const record = buildPresenceRecord("a", NOW, undefined, "coding", undefined, "0.1.0", "5.0.0");
+    const record = buildPresenceRecord("a", NOW, undefined, "coding", undefined, undefined, "0.1.0", "5.0.0");
     expect(record.currentTask).toBeNull();
   });
 
   test("record has exactly the expected key set (no accidental extra fields)", () => {
-    const record = buildPresenceRecord("a", NOW, "task", "coding", undefined, "0.1.0", "5.0.0");
+    const record = buildPresenceRecord("a", NOW, "task", "coding", undefined, undefined, "0.1.0", "5.0.0");
     expect(Object.keys(record).sort()).toEqual(
-      ["activity", "agentId", "currentTask", "flairVersion", "harperVersion", "lastHeartbeatAt"].sort(),
+      ["activity", "activityUpdatedAt", "agentId", "currentTask", "flairVersion", "harperVersion", "lastHeartbeatAt"].sort(),
     );
+  });
+});
+
+describe("buildPresenceRecord — activityUpdatedAt stamping (natural-presence)", () => {
+  const PRIOR = NOW - 5 * 60 * 1000; // 5 minutes before NOW
+
+  test("a beat that carries activity stamps activityUpdatedAt = now", () => {
+    const record = buildPresenceRecord("a", NOW, undefined, "coding", undefined, PRIOR, "0.1.0", null);
+    expect(record.activityUpdatedAt).toBe(NOW);
+  });
+
+  test("a beat that carries only currentTask (no activity) still stamps now", () => {
+    const record = buildPresenceRecord("a", NOW, "shipping the fix", undefined, "coding", PRIOR, "0.1.0", null);
+    expect(record.activityUpdatedAt).toBe(NOW);
+  });
+
+  test("a pure liveness beat (no activity, no task) PRESERVES the prior stamp", () => {
+    const record = buildPresenceRecord("a", NOW, undefined, undefined, "coding", PRIOR, "0.1.0", null);
+    // lastHeartbeatAt refreshes (liveness), but activityUpdatedAt does NOT —
+    // activity ages independently and lapses to last-known on its own.
+    expect(record.lastHeartbeatAt).toBe(NOW);
+    expect(record.activityUpdatedAt).toBe(PRIOR);
+  });
+
+  test("a liveness beat with a blank/whitespace task does NOT count as asserting (still preserves)", () => {
+    const record = buildPresenceRecord("a", NOW, "   ", undefined, "coding", PRIOR, "0.1.0", null);
+    expect(record.activityUpdatedAt).toBe(PRIOR);
+  });
+
+  test("first-ever beat with activity but no prior stamp → now", () => {
+    const record = buildPresenceRecord("a", NOW, undefined, "planning", undefined, undefined, "0.1.0", null);
+    expect(record.activityUpdatedAt).toBe(NOW);
+  });
+
+  test("first-ever pure liveness beat (no prior stamp) → null (nothing asserted yet)", () => {
+    const record = buildPresenceRecord("a", NOW, undefined, undefined, undefined, undefined, "0.1.0", null);
+    expect(record.activityUpdatedAt).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary

Makes Flair presence a **liveness beacon** instead of a sticky status board — fixes the class where an agent offline 13 days still shows `activity: "debugging"` (verified live on Kris's install: `presenceStatus` was correctly offline, but `activity`/`currentTask` were frozen at their last-set value).

- **Schema:** additive nullable `activityUpdatedAt: BigInt` on `Presence` (when activity/task were last *asserted*; absent on old records → readers fall back to `lastHeartbeatAt`).
- **Read model (`Presence.get()` roster):** activity/currentTask now bound to freshness. Fresh → current truth. Stale (heartbeat past the offline threshold, or activity stamp lapsed) → `activity` decays to `"idle"`, `currentTask` → `null`, and the last-known label moves to a new public `lastActivity` + `activityAgeMs` + `activityFresh` verdict → enables "offline (was: debugging)" without a client re-deriving staleness.
- **Heartbeat carries activity (self-updating):** `buildPresenceRecord` re-stamps `activityUpdatedAt` only on a beat that asserts activity/task; a pure liveness beat preserves the prior stamp → activity self-decays when an agent stops. `POST /Presence` contract unchanged.
- **Decay rule:** pure `isActivityFresh()`, same 600s threshold as `presenceStatus` offline. `flair doctor` fleet section renders `(was: X)` for decayed vs `(X)` for fresh.
- `includeVerifiedFields` gate on `currentTask` unchanged (not widened); `lastActivity` is a public vocabulary label like `activity`.

Ties #613 (activity enum), #639 (staleness), #608 (auto-presence).

## ⚠ Consumer behavior change (intended) — flag for review
An offline/stale agent now reports `activity: "idle"` + `currentTask: null` instead of the frozen last value; the last value moved to `lastActivity`. **The Office Space public renderer reads `activity`** — it should be updated to prefer `lastActivity`/`activityFresh` for a "was: X" display. Follow-up on the consumer side; flagging so it's not a surprise.

## Test plan
- [x] build + build:cli + tsc clean
- [x] `bun test test/unit/` — 1901/1901 (new `presence-activity-decay.test.ts` 20 tests; stamping + freshness)
- [x] `bun test test/integration/` — 244/244 (real Harper: fresh beat shows current; simulated staleness NOT presented as current; verified-reader gate holds)
- [ ] Kern + Sherlock

Part of the 0.22.0 batch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
