### PR TITLE
feat(recall): activate BM25 hybrid retrieval by default (ops-i39b, follow-up to #519)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+### 🔎 BM25 + union-RRF hybrid retrieval — ACTIVATED (ops-i39b, follow-up to #519)
+
+`FLAIR_HYBRID_RETRIEVAL` now defaults **ON** (was default-OFF since #519 shipped the feature). Recall-eval at build time validated the intended gain: the NEW-8 within-cluster gate held p@3=0.88 (no regression); the OLD-6 severe near-verbatim misses recovered 0/6 → 4/6 into top-10 (1/6 into top-3). A fresh isolated-Harper measurement at activation time (ephemeral spawned instance, zero production contact) confirmed zero regression on a synthetic severe-miss/within-cluster-gate corpus and a small latency delta (~+4ms/query, ~27ms absolute at n≈90 records). Revert lever unchanged: set `FLAIR_HYBRID_RETRIEVAL=false` (also `"0"`/`"off"`) to fall back to the byte-identical legacy HNSW + keyword-bump path — no code rollback needed.
+
+- **Fixed a blocking regression found during activation testing:** the hybrid path's candidate-union RRF fusion silently returned **zero results** for a `SemanticSearch` call with neither `q` nor `queryEmbedding` — the "list everything in my scope" shape (`agentId`/`tag`/`subject`-only calls; see `test/integration/memory-visibility-scoping-e2e.test.ts`), which the legacy path answers with a full scoped listing. `resources/SemanticSearch.ts`'s hybrid branch now falls back to emitting the already-security-filtered `allowedById` candidate set directly at `rawScore 0` when neither retrieval signal is present, matching the legacy contract exactly. Regression-guarded by `test/integration/bm25-hybrid-noquery-listing.test.ts`.
+
 The upgrade path becomes one tested transaction — install, restart, verify, and roll back automatically on failure — backed by a pre-upgrade data snapshot, a nightly-checked downgrade path, and a post-deploy fleet-convergence sweep. Also closes out the remaining `authorizeLocal`-class security gaps from the 0.21.0 state review.
 
 ### 🔁 `flair upgrade` restarts by default, verifies, and rolls back (#635, #641)

--- a/resources/SemanticSearch.ts
+++ b/resources/SemanticSearch.ts
@@ -35,8 +35,10 @@ function distanceToSimilarity(distance: number): number {
 const CANDIDATE_MULTIPLIER = 5;
 
 // The BM25 + union-RRF hybrid path is feature-flagged via hybridEnabled()
-// (imported from ./bm25 — Harper-free so it's unit-testable). Flag OFF (default)
-// → byte-identical to the pre-hybrid HNSW + +0.05 keyword-bump behavior.
+// (imported from ./bm25 — Harper-free so it's unit-testable). Default is ON as
+// of 2026-07-08 (see ./bm25.ts's hybridEnabled() doc); set
+// FLAIR_HYBRID_RETRIEVAL=false to revert to the legacy HNSW + +0.05
+// keyword-bump path, byte-identical to the original pre-hybrid behavior.
 
 export class SemanticSearch extends Resource {
   // Self-authorize via the Ed25519 agent verify instead of relying on the auth
@@ -278,26 +280,60 @@ export class SemanticSearch extends Resource {
         bm25Ids = ranked.filter(r => r.score > 0).slice(0, SEM_LIMIT).map(r => r.id);
       }
 
-      // ── (d) Candidate-union RRF → normalized [0,1] rawScore ──────────────
-      // Union dedupes semantic ∪ bm25 ids; absent-from-a-list = 0 contribution.
-      const fused = fuseRrfNormalized(semIds, bm25Ids);
+      // ── (d) No retrieval signal at all → full scoped listing ────────────
+      // Neither `q` nor `qEmb`: semIds and bm25Ids are BOTH necessarily empty
+      // (semIds is only populated `if (qEmb)`; bm25Ids only `if (q)`), so
+      // fuseRrfNormalized([], []) returns an empty map and the union-RRF loop
+      // below would silently emit ZERO results — unlike the legacy path's
+      // final no-embedding branch, which full-scans and returns every
+      // scope-matching record (rawScore 0 when there's no keyword hit,
+      // included because `if (q && rawScore === 0) continue` only fires when
+      // `q` is truthy). This is the "list everything in my scope" call
+      // real callers rely on (e.g. SemanticSearch with only `agentId`/`tag`/
+      // `subject` — see test/integration/memory-visibility-scoping-e2e.test.ts),
+      // and it must behave identically whether the hybrid flag is on or off.
+      // `allowedById` already holds exactly the right candidate set (built
+      // from the SAME conditions[] + isAllowedBm25Candidate temporal/security
+      // filters as the BM25 pass), so emit it directly at rawScore 0 instead
+      // of routing through the (necessarily-empty) RRF fusion.
+      if (!q && !qEmb) {
+        for (const record of allowedById.values()) {
+          const rawScore = 0;
+          let finalScore = scoring === "raw" ? rawScore : compositeScore(rawScore, record);
+          if (temporalBoost > 1.0) finalScore *= temporalBoost;
 
-      for (const [id, rrfRaw] of fused) {
-        const record = allowedById.get(id);
-        if (!record) continue; // should not happen — union ⊆ allowed
-        const rawScore = rrfRaw; // already normalized to [0,1]
-        let finalScore = scoring === "raw" ? rawScore : compositeScore(rawScore, record);
-        if (temporalBoost > 1.0) finalScore *= temporalBoost;
+          const isFlagged = record._safetyFlags && Array.isArray(record._safetyFlags) && record._safetyFlags.length > 0;
+          const source = record.agentId !== agentId ? record.agentId : undefined;
+          results.push({
+            ...record,
+            content: isFlagged ? wrapUntrusted(record.content, source) : record.content,
+            _score: Math.round(finalScore * 1000) / 1000,
+            _rawScore: scoring !== "raw" ? Math.round(rawScore * 1000) / 1000 : undefined,
+            _source: source,
+          });
+        }
+      } else {
+        // ── Candidate-union RRF → normalized [0,1] rawScore ────────────────
+        // Union dedupes semantic ∪ bm25 ids; absent-from-a-list = 0 contribution.
+        const fused = fuseRrfNormalized(semIds, bm25Ids);
 
-        const isFlagged = record._safetyFlags && Array.isArray(record._safetyFlags) && record._safetyFlags.length > 0;
-        const source = record.agentId !== agentId ? record.agentId : undefined;
-        results.push({
-          ...record,
-          content: isFlagged ? wrapUntrusted(record.content, source) : record.content,
-          _score: Math.round(finalScore * 1000) / 1000,
-          _rawScore: scoring !== "raw" ? Math.round(rawScore * 1000) / 1000 : undefined,
-          _source: source,
-        });
+        for (const [id, rrfRaw] of fused) {
+          const record = allowedById.get(id);
+          if (!record) continue; // should not happen — union ⊆ allowed
+          const rawScore = rrfRaw; // already normalized to [0,1]
+          let finalScore = scoring === "raw" ? rawScore : compositeScore(rawScore, record);
+          if (temporalBoost > 1.0) finalScore *= temporalBoost;
+
+          const isFlagged = record._safetyFlags && Array.isArray(record._safetyFlags) && record._safetyFlags.length > 0;
+          const source = record.agentId !== agentId ? record.agentId : undefined;
+          results.push({
+            ...record,
+            content: isFlagged ? wrapUntrusted(record.content, source) : record.content,
+            _score: Math.round(finalScore * 1000) / 1000,
+            _rawScore: scoring !== "raw" ? Math.round(rawScore * 1000) / 1000 : undefined,
+            _source: source,
+          });
+        }
       }
     } else if (qEmb) {
       // ─── HNSW vector search path (legacy, hybrid flag OFF) ────────────────

--- a/resources/bm25.ts
+++ b/resources/bm25.ts
@@ -10,13 +10,19 @@
 // no regression on the within-cluster gate (p@3 holds 0.88).
 
 // ─── Feature flag: BM25 + union-RRF hybrid retrieval ────────────────────────
-// Flag OFF (default) → SemanticSearch behavior is byte-identical to the
-// pre-hybrid path (HNSW + the +0.05 exact-substring keyword bump). Flag ON → the
-// hybrid path. Toggle with FLAIR_HYBRID_RETRIEVAL=true (also "1" / "on"). Read
-// per-call so it can be flipped without a rebuild and set per-case in tests.
-// Lives here (Harper-free) so it's unit-testable.
+// ACTIVATED 2026-07-08 (ops-i39b activation follow-up to #519): default is now
+// ON. Recall-eval validated at build time (CHANGELOG 0.20.x): NEW-8
+// within-cluster gate p@3 holds 0.88 (no regression), OLD-6 severe
+// near-verbatim misses recover 0/6 → 4/6 into top-10. A fresh isolated-Harper
+// measurement at activation time (no prod contact) confirmed zero regression
+// on both severe- and within-cluster-style synthetic queries and a small
+// (~+4ms/query) latency delta. Set FLAIR_HYBRID_RETRIEVAL=false (also "0" /
+// "off") to REVERT to the pre-hybrid legacy path — byte-identical to the
+// original default-OFF behavior, no code rollback needed. Read per-call so it
+// can be flipped without a rebuild and set per-case in tests. Lives here
+// (Harper-free) so it's unit-testable.
 export function hybridEnabled(): boolean {
-  const v = (process.env.FLAIR_HYBRID_RETRIEVAL ?? "").toLowerCase();
+  const v = (process.env.FLAIR_HYBRID_RETRIEVAL ?? "true").toLowerCase();
   return v === "true" || v === "1" || v === "on";
 }
 

--- a/test/integration/bm25-hybrid-noquery-listing.test.ts
+++ b/test/integration/bm25-hybrid-noquery-listing.test.ts
@@ -1,0 +1,99 @@
+// Regression guard: SemanticSearch with NEITHER `q` NOR `queryEmbedding` (the
+// "list everything in my scope" call — e.g. browse-by-agentId/tag/subject with
+// no search text) must return the full scoped listing REGARDLESS of the
+// FLAIR_HYBRID_RETRIEVAL flag.
+//
+// Found while preparing to activate the BM25 + union-RRF hybrid path
+// (FLAIR-BM25-HYBRID-RETRIEVAL): resources/SemanticSearch.ts's hybrid branch
+// only ever populates `semIds` when `qEmb` is present and `bm25Ids` when `q`
+// is present. With neither, `fuseRrfNormalized([], [])` returns an empty map,
+// so the union-RRF loop silently emitted ZERO results — while the legacy
+// (hybrid flag OFF) path's final no-embedding branch full-scans and returns
+// every scope-matching record. Confirmed by forcing FLAIR_HYBRID_RETRIEVAL=true
+// against test/integration/memory-visibility-scoping-e2e.test.ts, which relies
+// on exactly this no-q listing shape and failed 2/16 before the fix.
+//
+// Fixed in resources/SemanticSearch.ts's hybrid branch: when `!q && !qEmb`,
+// emit every record already collected in `allowedById` (the SAME
+// conditions[]-filtered, isAllowedBm25Candidate-gated candidate set the BM25
+// pass would have scored) directly at rawScore 0, instead of routing through
+// the (necessarily-empty) RRF fusion. This test pins that fix so it can never
+// silently regress again.
+import { describe, expect, test, beforeAll, afterAll } from "bun:test";
+import nacl from "tweetnacl";
+import { randomUUID } from "node:crypto";
+import { startHarper, stopHarper, HarperInstance } from "../helpers/harper-lifecycle";
+
+interface TestAgent { id: string; publicKey: string; secretKey: Uint8Array; }
+function mkAgent(id: string): TestAgent {
+  const kp = nacl.sign.keyPair();
+  return { id, publicKey: Buffer.from(kp.publicKey).toString("base64"), secretKey: kp.secretKey };
+}
+function ed25519Header(agent: TestAgent, method: string, path: string): string {
+  const ts = Date.now().toString();
+  const nonce = randomUUID();
+  const payload = `${agent.id}:${ts}:${nonce}:${method}:${path}`;
+  const sig = nacl.sign.detached(new TextEncoder().encode(payload), agent.secretKey);
+  return `TPS-Ed25519 ${agent.id}:${ts}:${nonce}:${Buffer.from(sig).toString("base64")}`;
+}
+async function adminOp(harper: HarperInstance, op: Record<string, any>): Promise<Response> {
+  return fetch(harper.opsURL, {
+    method: "POST",
+    headers: { "Content-Type": "application/json", Authorization: "Basic " + btoa(`${harper.admin.username}:${harper.admin.password}`) },
+    body: JSON.stringify(op),
+  });
+}
+
+let harper: HarperInstance;
+const agent = mkAgent("hybrid-noq-listing");
+const LIVE_ID = "hybrid-noq-live";
+const ARCHIVED_ID = "hybrid-noq-archived";
+
+describe("SemanticSearch no-q/no-embedding listing (hybrid flag ON — regression guard)", () => {
+  beforeAll(async () => {
+    // Spawn with the flag ON from the start — startHarper() inherits
+    // process.env at spawn time, so this must be set before the call.
+    const prev = process.env.FLAIR_HYBRID_RETRIEVAL;
+    process.env.FLAIR_HYBRID_RETRIEVAL = "true";
+    try {
+      harper = await startHarper();
+    } finally {
+      if (prev === undefined) delete process.env.FLAIR_HYBRID_RETRIEVAL; else process.env.FLAIR_HYBRID_RETRIEVAL = prev;
+    }
+
+    const res = await adminOp(harper, {
+      operation: "insert", database: "flair", table: "Agent",
+      records: [{ id: agent.id, name: agent.id, role: "agent", publicKey: agent.publicKey, createdAt: new Date().toISOString() }],
+    });
+    expect(res.status).toBe(200);
+
+    for (const [id, archived] of [[LIVE_ID, false], [ARCHIVED_ID, true]] as const) {
+      const path = `/Memory/${id}`;
+      const r = await fetch(`${harper.httpURL}${path}`, {
+        method: "PUT",
+        headers: { Authorization: ed25519Header(agent, "PUT", path), "Content-Type": "application/json" },
+        body: JSON.stringify({ id, agentId: agent.id, content: `record ${id}`, durability: "standard", archived, createdAt: new Date().toISOString() }),
+      });
+      if (![200, 204].includes(r.status)) throw new Error(`seed PUT ${id} → ${r.status}: ${await r.text()}`);
+    }
+  }, 180_000);
+
+  afterAll(async () => { if (harper) await stopHarper(harper); });
+
+  test("no q, no queryEmbedding → full scoped listing (not empty), archived still excluded", async () => {
+    const path = "/SemanticSearch";
+    const res = await fetch(`${harper.httpURL}${path}`, {
+      method: "POST",
+      headers: { Authorization: ed25519Header(agent, "POST", path), "Content-Type": "application/json" },
+      body: JSON.stringify({ agentId: agent.id, limit: 100 }),
+    });
+    const text = await res.text();
+    expect(res.status, `SemanticSearch → ${res.status}: ${text.slice(0, 300)}`).toBe(200);
+    const body: any = JSON.parse(text);
+    const ids = new Set((body.results ?? []).map((r: any) => r.id));
+
+    // Pre-fix: this was an empty array (0 results) under hybrid ON.
+    expect(ids.has(LIVE_ID), `expected the live record in a no-q listing under hybrid ON, got ${JSON.stringify([...ids])}`).toBe(true);
+    expect(ids.has(ARCHIVED_ID)).toBe(false);
+  }, 60_000);
+});

--- a/test/integration/semantic-search-singleton-score.test.ts
+++ b/test/integration/semantic-search-singleton-score.test.ts
@@ -7,11 +7,18 @@
 // resources/dedup.ts cosineSimilarity): a cosine-sort query's `$distance`
 // annotation comes back `undefined` when its post-filter result set contains
 // EXACTLY ONE matching record — sort ORDER is still correct, only the numeric
-// distance is missing. resources/SemanticSearch.ts's legacy HNSW path (hybrid
-// flag OFF, the default) computed
+// distance is missing. resources/SemanticSearch.ts's legacy HNSW path
+// computed
 //   distanceToSimilarity(record.$distance ?? 1)
 // so a singleton hit fell through `?? 1` → similarity 0 → the memory reads as
 // totally dissimilar to a paraphrase of ITSELF.
+//
+// This is a LEGACY-path-specific regression test: the hybrid path (default ON
+// since the 2026-07-08 BM25 hybrid activation) doesn't compute
+// distanceToSimilarity/$distance at all — it derives rawScore from
+// union-RRF rank fusion instead. This file pins FLAIR_HYBRID_RETRIEVAL=false
+// before spawning Harper so it keeps exercising the exact branch it
+// documents, regardless of the global default.
 //
 // The read-scope Layer 1 change made this trigger easily: before, the no-grants agent scope
 // was ALWAYS a compound `{operator:"or", conditions:[{agentId},{visibility==
@@ -69,7 +76,16 @@ const PARAPHRASE_QUERY = "When are we getting together to go over quarterly spen
 
 describe("SemanticSearch singleton-result scoring (real Harper, real embeddings)", () => {
   beforeAll(async () => {
-    harper = await startHarper();
+    // Pin the legacy path: startHarper() inherits process.env at spawn time,
+    // so this must be set before the call, not just before the request.
+    const prevHybrid = process.env.FLAIR_HYBRID_RETRIEVAL;
+    process.env.FLAIR_HYBRID_RETRIEVAL = "false";
+    try {
+      harper = await startHarper();
+    } finally {
+      if (prevHybrid === undefined) delete process.env.FLAIR_HYBRID_RETRIEVAL;
+      else process.env.FLAIR_HYBRID_RETRIEVAL = prevHybrid;
+    }
     const res = await adminOp(harper, {
       operation: "insert", database: "flair", table: "Agent",
       records: [{ id: agent.id, name: agent.id, role: "agent", publicKey: agent.publicKey, createdAt: new Date().toISOString() }],

--- a/test/unit/bm25.test.ts
+++ b/test/unit/bm25.test.ts
@@ -13,23 +13,28 @@ import {
   SEM_LIMIT,
 } from "../../resources/bm25.ts";
 
-describe("feature flag — FLAIR_HYBRID_RETRIEVAL (default OFF = unchanged behavior)", () => {
+describe("feature flag — FLAIR_HYBRID_RETRIEVAL (ACTIVATED 2026-07-08: default ON)", () => {
   const orig = process.env.FLAIR_HYBRID_RETRIEVAL;
   const restore = () => {
     if (orig === undefined) delete process.env.FLAIR_HYBRID_RETRIEVAL;
     else process.env.FLAIR_HYBRID_RETRIEVAL = orig;
   };
 
-  test("unset → OFF (legacy path, byte-identical behavior)", () => {
+  test("unset → ON (hybrid is now the default retrieval path)", () => {
     delete process.env.FLAIR_HYBRID_RETRIEVAL;
-    expect(hybridEnabled()).toBe(false);
+    expect(hybridEnabled()).toBe(true);
     restore();
   });
-  test("'false' / 'off' / '0' / '' → OFF", () => {
-    for (const v of ["false", "off", "0", "", "FALSE", "no"]) {
+  test("'false' / 'off' / '0' → OFF (the revert lever: legacy HNSW path, byte-identical to pre-hybrid behavior)", () => {
+    for (const v of ["false", "off", "0", "FALSE", "no"]) {
       process.env.FLAIR_HYBRID_RETRIEVAL = v;
       expect(hybridEnabled()).toBe(false);
     }
+    restore();
+  });
+  test("'' (explicitly set to empty string) → OFF — `??` only falls back on null/undefined, not '', so an explicit empty value does NOT inherit the ON default", () => {
+    process.env.FLAIR_HYBRID_RETRIEVAL = "";
+    expect(hybridEnabled()).toBe(false);
     restore();
   });
   test("'true' / '1' / 'on' (any case) → ON", () => {

--- a/test/unit/semantic-search-scoping.test.ts
+++ b/test/unit/semantic-search-scoping.test.ts
@@ -212,21 +212,35 @@ describe("SemanticSearch.post() — centralized read-scoping", () => {
   // real-Harper reproduction this was root-caused against).
   it("undefined $distance falls back to a point-lookup cosine computation instead of scoring 0", async () => {
     reset();
-    const qEmb = [1, 0, 0];
-    // Orthogonal to qEmb — the pre-fix `?? 1` fallback and the fixed
-    // point-lookup cosine computation would BOTH read as "not similar" here,
-    // so this record is a control: it must never be mistaken for a match.
-    memoryStore.set("m-orthogonal", { id: "m-orthogonal", agentId: "agent-1", content: "unrelated", visibility: "private", embedding: [0, 1, 0] });
-    // Identical to qEmb — cosineSimilarity == 1 exactly. Pre-fix this record
-    // would score 0 (distanceToSimilarity(undefined ?? 1) === 0); post-fix it
-    // must score a real positive similarity via the embedding point-lookup.
-    memoryStore.set("m-identical", { id: "m-identical", agentId: "agent-1", content: "matches the query", visibility: "private", embedding: [1, 0, 0] });
+    // This is a LEGACY (hybrid-flag-OFF) path-specific regression test — the
+    // undefined-$distance fallback (distanceToSimilarity / point-lookup cosine)
+    // lives only in resources/SemanticSearch.ts's `else if (qEmb)` branch, not
+    // in the hybrid path's RRF-fusion scoring. Since FLAIR_HYBRID_RETRIEVAL now
+    // defaults ON (BM25 hybrid activation, 2026-07-08), pin it OFF explicitly
+    // so this test keeps exercising the exact branch it documents, regardless
+    // of the global default.
+    const prevHybrid = process.env.FLAIR_HYBRID_RETRIEVAL;
+    process.env.FLAIR_HYBRID_RETRIEVAL = "false";
+    try {
+      const qEmb = [1, 0, 0];
+      // Orthogonal to qEmb — the pre-fix `?? 1` fallback and the fixed
+      // point-lookup cosine computation would BOTH read as "not similar" here,
+      // so this record is a control: it must never be mistaken for a match.
+      memoryStore.set("m-orthogonal", { id: "m-orthogonal", agentId: "agent-1", content: "unrelated", visibility: "private", embedding: [0, 1, 0] });
+      // Identical to qEmb — cosineSimilarity == 1 exactly. Pre-fix this record
+      // would score 0 (distanceToSimilarity(undefined ?? 1) === 0); post-fix it
+      // must score a real positive similarity via the embedding point-lookup.
+      memoryStore.set("m-identical", { id: "m-identical", agentId: "agent-1", content: "matches the query", visibility: "private", embedding: [1, 0, 0] });
 
-    const s = makeSearch(agentCtx("agent-1"));
-    const res: any = await s.post({ queryEmbedding: qEmb, scoring: "raw", limit: 10 });
+      const s = makeSearch(agentCtx("agent-1"));
+      const res: any = await s.post({ queryEmbedding: qEmb, scoring: "raw", limit: 10 });
 
-    const byId = new Map(res.results.map((r: any) => [r.id, r]));
-    expect(byId.get("m-identical")?._score).toBe(1);
-    expect(byId.get("m-orthogonal")?._score).toBe(0);
+      const byId = new Map(res.results.map((r: any) => [r.id, r]));
+      expect(byId.get("m-identical")?._score).toBe(1);
+      expect(byId.get("m-orthogonal")?._score).toBe(0);
+    } finally {
+      if (prevHybrid === undefined) delete (process.env as any).FLAIR_HYBRID_RETRIEVAL;
+      else process.env.FLAIR_HYBRID_RETRIEVAL = prevHybrid;
+    }
   });
 });


### PR DESCRIPTION
## Summary

Activates the BM25 + union-RRF hybrid retrieval lever (`FLAIR_HYBRID_RETRIEVAL`), which has been fully implemented, tested, and merged since #519 but shipped **default-OFF**. This flips the default to **ON**, with the env var remaining as the reversible revert path.

**This PR does NOT merge itself** — opening for Flint review + Kern/Sherlock gate per the standard handoff loop.

## What changed

1. **`resources/bm25.ts`** — `hybridEnabled()` now defaults to `true` when `FLAIR_HYBRID_RETRIEVAL` is unset. Set it to `false` / `"0"` / `"off"` to revert to the byte-identical legacy HNSW + keyword-bump path — no code rollback needed.
2. **A blocking regression found and fixed during activation testing** (see below) in `resources/SemanticSearch.ts`.
3. Test updates so flag-default-dependent tests keep pinning the exact branch they document (see "Test changes" below).
4. `CHANGELOG.md` entry.

## Important finding: a real bug in the already-shipped hybrid path

While verifying it was safe to flip the default, I found that `SemanticSearch` calls with **neither `q` nor `queryEmbedding`** — the "list everything in my scope" shape (`agentId`/`tag`/`subject`-only calls; this is a real, tested pattern — see `test/integration/memory-visibility-scoping-e2e.test.ts`) — silently returned **zero results** under the hybrid path, instead of the full scoped listing the legacy path returns.

Root cause: the hybrid branch only populates `semIds` when `qEmb` is present and `bm25Ids` when `q` is present. With neither, `fuseRrfNormalized([], [])` returns an empty map, so the union-RRF loop emits nothing.

I confirmed this empirically: forcing `FLAIR_HYBRID_RETRIEVAL=true` against `memory-visibility-scoping-e2e.test.ts` failed 2/16 tests before the fix, 0/16 after.

**Fix** (commit `9f8bb05`): when neither `q` nor `qEmb` is present, emit every record already collected in `allowedById` (the same conditions-filtered, security-gated candidate set the BM25 pass would have scored) directly at `rawScore 0`, matching the legacy contract. Added a dedicated regression test: `test/integration/bm25-hybrid-noquery-listing.test.ts`.

This was a genuine prerequisite — flipping the default without this fix would have shipped a real, silent data-loss regression for any "browse without a query" caller the moment the flag went live.

## Recall measurement (before/after)

**Historical validation (from #519, at original implementation time, against the real ~673-record flint corpus, through the shipped modules — see CHANGELOG "0.20.x"):**
- NEW-8 within-cluster gate: **p@3 holds 0.88** (no regression)
- OLD-6 severe near-verbatim misses: **0/6 → 4/6 recovered into top-10** (1/6 into top-3)

**Fresh measurement (this session, isolated & reproducible):** I built a synthetic 90-record corpus (6 topical clusters, each with 1 near-verbatim "target" + 2 near-duplicate siblings + 12 topically-adjacent filler records) and ran it against an **ephemeral, throwaway Harper instance** spawned via `test/helpers/harper-lifecycle.ts` — the same mechanism the integration test suite uses. Zero production contact; the live flint Flair service was never touched.

| | BEFORE (flag off) | AFTER (flag on) |
|---|---|---|
| p@3 | 1.000 | 1.000 |
| MRR | 0.875 | 0.875 |
| severe-miss queries in top-3 | 6/6 | 6/6 |
| within-cluster-hard queries in top-3 | 6/6 | 6/6 |
| mean query latency (30-call probe) | 21.5ms | 26.7ms |

**Delta: p@3/MRR identical (zero regression); latency +5.2ms/query (+24.4% relative, ~27ms absolute).**

**Honest caveat:** at this corpus scale (~90 records) and with real nomic-embed-text-v1.5 embeddings, I could **not** reproduce a genuine "severe miss" (target buried outside top-10) even with a denser 46-record adversarial variant targeting one cluster specifically — the embedding model handled distinctive rare tokens well at this scale. The original severe-miss phenomenon documented in #519 was observed against the real, organically-grown, much larger flint corpus over months — that scale/organic-growth condition isn't practical to reproduce synthetically in this session. So this fresh measurement's contribution is: **confirms zero regression + quantifies latency** on real shipped code via real Harper instances; the recall-*improvement* evidence rests on the historical #519 validation, not on anything fabricated here.

## Latency

+5.2ms mean/query (+24.4% relative) at n=90 records, absolute latency still low (~27ms). This is the BM25 lexical pass + corpus fetch overhead; expected to scale with corpus size (in-memory per-query BM25 — see the spec's "Index lifecycle" section on when a persistent inverted index would become necessary, not before ~3–20K records).

## How to revert

Set `FLAIR_HYBRID_RETRIEVAL=false` (or `"0"`/`"off"`) in the deployment environment. No code change or rollback needed — `hybridEnabled()` reads the env var per-call.

## Test suite

Full `bun test` (177 files) after this change: **2613 pass / 5 fail / 2 errors** — identical to the pre-existing baseline failures measured before any change in this PR (3 `smoke.test.ts` "Golden path" HTTP-401 flakes + 2 `test/e2e` Playwright version-collision config errors, both unrelated to BM25/SemanticSearch and present before this branch existed). **Zero new failures.**

## Spec / tracking

`FLAIR-BM25-HYBRID-RETRIEVAL` (Kern-approved design, ops-i39b). Sherlock gate: the conditions-filter-before-fusion security boundary is unchanged by this PR (no code touched in `resources/bm25-filter.ts`); please re-verify the no-query-listing fix doesn't introduce a new security surface — it reuses the exact same `allowedById` map the BM25 pass already builds under the existing conditions[] + `isAllowedBm25Candidate` filter, no new query/filter logic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
