### PR TITLE
test(recall): isolated recall-eval harness + harder synthetic corpus

### DIFF
--- a/test/bench/recall-harness/README.md
+++ b/test/bench/recall-harness/README.md
@@ -1,0 +1,238 @@
+# recall-harness — isolated recall-eval harness
+
+Measures Flair's recall precision (p@3, MRR) against a **harder, representative
+synthetic corpus**, on a **fully ephemeral Harper instance**. It never touches
+`~/ops/flair`, the live `:9926` service, or any production memory.
+
+## Why this exists
+
+Two recall tools already live in `ops/tools/agent-fabric/`:
+
+- **`recall-eval.mjs`** measures against flint's LIVE production memory
+  corpus over the network. It's the only tool that's ever caught a real
+  regression (it's what found flair#623 — see below) but it can only run
+  *on* the live server, it mutates the corpus it measures
+  (`retrievalCount` bumps on every query), and its ground truth rots as
+  real memories get added/superseded. There was no safe way to try a
+  scoring/retrieval change without measuring against production.
+- **`recall-bench.mjs`** IS isolated — it seeds a synthetic corpus, measures,
+  tears down — but that corpus is 4 maximally-distant topic clusters
+  (consensus / coffee / index funds / houseplants). Every distractor is
+  topically miles from the query, so precision@3 caps at 1.00 almost
+  regardless of embedding/scoring quality — it's a "flattering upper bound"
+  documented in its own header, and it can't discriminate between a config
+  that helps and one that hurts.
+
+This harness closes that gap: isolated (ephemeral Harper, spawned fresh per
+run, killed + wiped after) **and** hard enough to discriminate (a corpus
+with near-duplicate clusters, cross-cluster lexical traps, and varied
+durability/recency — see `corpus.ts`'s header for the full design rationale).
+
+### It reproduces a real, already-shipped finding
+
+On 2026-07-08, `recall-eval.mjs` run against the **live** corpus found that
+`scoring: "composite"` (then the default) was net-harmful to precision once
+BM25 hybrid retrieval went live — Δp@3 (composite − raw) ran **-0.38 to
+-0.50**. That shipped as commit `624299c` ("default SemanticSearch scoring to
+raw, not composite", flair#623), which flipped the default and added one
+hand-written unit-test pair (`test/unit/semantic-search-scoping.test.ts`)
+pinning the mechanism with mocked Harper.
+
+This harness reproduces the same finding **in isolation**, on a full
+embeddings+BM25+RRF pipeline, across 30 queries and 87 records instead of one
+mocked pair — see "Measured results" below. Going forward, it's the tool to
+run *before* trusting the next scoring/retrieval/rerank config change,
+instead of measuring against production again.
+
+## Usage
+
+Requires the repo to be **built** first — Harper loads compiled resources
+from `dist/resources/*.js` (see `config.yaml`'s `jsResource.files`), not the
+TypeScript source, so a fresh clone/worktree needs a build:
+
+```bash
+npm run build   # or: bun run build
+```
+
+Then, from the repo root:
+
+```bash
+# Full sweep: hybrid on AND off, 3 runs each (~10-15 min)
+bun run test/bench/recall-harness/run.ts
+
+# Quick single-run pass (faster, noisier — don't trust a lone run's delta)
+bun run test/bench/recall-harness/run.ts --runs 1
+
+# Only the production-default config (hybrid=true)
+bun run test/bench/recall-harness/run.ts --hybrid on
+
+# Also spawn one hybrid+rerank config (needs the rerank GGUF present — see below)
+bun run test/bench/recall-harness/run.ts --hybrid on --rerank
+
+# Print every query's rank, not just the aggregates
+bun run test/bench/recall-harness/run.ts --verbose
+```
+
+### Skip re-downloading the embedding/rerank models
+
+Every ephemeral Harper instance needs the embedding model (and, with
+`--rerank`, the reranker GGUF). By default `test/helpers/harper-lifecycle.ts`
+points `FLAIR_MODELS_DIR` at `<repo>/models`, which is empty in a fresh
+worktree — set it to an **existing** Flair install's `models/` directory to
+reuse the already-downloaded weights (read-only; the harness never writes
+there):
+
+```bash
+export FLAIR_MODELS_DIR=/path/to/an/existing/flair/checkout/models
+```
+
+### Flags
+
+| Flag              | Default | Meaning |
+|-------------------|---------|---------|
+| `--runs N`        | `3`     | Independent seed→measure→teardown cycles per config, aggregated as mean ± standard error. |
+| `--hybrid on\|off\|both` | `both` | Which `FLAIR_HYBRID_RETRIEVAL` value(s) to spawn instances for. |
+| `--rerank`        | off     | Additionally spawn one `hybrid=true, rerank=true` config. Opt-in — see "On the rerank knob" below. |
+| `--verbose`       | off     | Print every query's rank (hit/miss, kind, marker) under `--runs`. |
+| `--keep-on-fail`  | off     | On a fatal error, print a reminder to inspect (the ephemeral installDir itself is NOT preserved automatically — see caveat below). |
+
+## Interpreting the output
+
+For each `(hybrid, rerank)` config, the harness prints p@3 and MRR for
+`scoring=raw` and `scoring=composite` against the **same seeded corpus** (no
+reseed between the two — matches `recall-eval.mjs`'s own convention), then:
+
+- **Δ (composite − raw)** — negative means composite underperforms raw on
+  this corpus/config. This is the number that matters for "should X be the
+  default."
+- **by kind** — the same delta broken out by query kind (`stress` / `trap`
+  / `hard` / `clean`, see `corpus.ts`). `stress` queries are the deliberate
+  durability/recency adversarial pairs; a large negative delta there
+  specifically (vs. a flat delta on `clean`) is the signature of the
+  `compositeScore` durability-weight × recency-decay mechanism, not some
+  other regression.
+- **HEADLINE** — the `hybrid=true` (production-default) composite-vs-raw
+  comparison, called out explicitly with a discriminates/does-not-discriminate
+  verdict.
+
+### If it does NOT discriminate
+
+If a future run shows composite ≈ raw (no meaningful gap) on this corpus,
+that's a real signal `compositeScore` changed (e.g. a relevance-gated
+durability/recency multiplier, mirroring `retrievalBoost`'s existing
+`RBOOST_RELEVANCE_FLOOR` in `resources/scoring.ts`) — re-validate against
+`recall-eval.mjs` on the live corpus before reconsidering the default, per
+that file's own header. It is NOT a sign this harness's corpus needs to be
+made harder — see the numbers below; it already discriminates hard.
+
+## Measured results (2026-07-08, isolated — zero production contact)
+
+`--runs 3`, `FLAIR_HYBRID_RETRIEVAL` swept `true`/`false`, `--rerank` not
+exercised (see caveat below). Real numbers from an ephemeral instance on this
+corpus — not simulated, and reproducible by re-running the command above
+(variance was ±0.000 across all 3 runs in both configs — this corpus's
+collapse is not a fluke of one HNSW build):
+
+```
+── hybrid=true rerank=false ──
+  scoring=raw       p@3=0.967 ± 0.000   MRR=0.892 ± 0.000
+  scoring=composite p@3=0.067 ± 0.000   MRR=0.123 ± 0.000
+  Δ (composite − raw)   p@3=-0.900   MRR=-0.769
+  by kind (composite − raw p@3):
+    stress raw=1.000  composite=0.000  Δ=-1.000
+    trap   raw=1.000  composite=0.000  Δ=-1.000
+    hard   raw=1.000  composite=0.333  Δ=-0.667
+    clean  raw=0.929  composite=0.000  Δ=-0.929
+
+── hybrid=false rerank=false ──
+  scoring=raw       p@3=0.967 ± 0.000   MRR=0.892 ± 0.000
+  scoring=composite p@3=0.067 ± 0.000   MRR=0.120 ± 0.000
+  Δ (composite − raw)   p@3=-0.900   MRR=-0.772
+  by kind (composite − raw p@3):
+    stress raw=1.000  composite=0.000  Δ=-1.000
+    trap   raw=1.000  composite=0.000  Δ=-1.000
+    hard   raw=1.000  composite=0.167  Δ=-0.833
+    clean  raw=0.929  composite=0.071  Δ=-0.857
+
+HEADLINE (hybrid=true, the production default): composite p@3=0.067 vs raw
+p@3=0.967; composite MRR=0.123 vs raw MRR=0.892 → corpus DISCRIMINATES,
+reproducing flair#623 in isolation.
+```
+
+**raw is an excellent scorer on this corpus** (p@3=0.967 — only one query,
+a `clean` RATE::1 case, misses top-3, landing rank 4) — the corpus is hard
+enough to be meaningful but not so adversarial that a good scorer can't
+still nearly ace it. **composite collapses almost everywhere**, not just on
+the 7 deliberately-engineered `stress` pairs: `trap` and `clean` queries
+(zero durability/recency adversarial design) crater just as hard.
+
+**Why it's worse here than the live corpus's -0.38/-0.50**: inspecting the
+actual top results (`_score`/`_rawScore`/durability/age per candidate)
+confirms this is the real mechanism, not a harness artifact — for the query
+"How does a cluster pick which single node gets to lead for a while?"
+(expects `CONSENSUS::1`), raw correctly ranks `CONSENSUS::1` #2 (a
+`CONSENSUS::4` rank-1/rank-2 near-tie, both genuinely on-topic). Under
+composite, the top 4 results are **`CONSENSUS::8`, `DEPLOY::2`, `FIN::4`,
+`PLANT::3`** — four totally unrelated-cluster records that all happen to
+share `durability: permanent, ageDays: 2` — before either real consensus
+record appears at all. Each carries `dWeight=1.0 × rFactor=1.0` (no
+discount), while the correct, standard/persistent-durability, 65-95-day-old
+answers get discounted 30-95% by `compositeScore`'s **unconditional**
+multiplier (no relevance floor, unlike `retrievalBoost`'s
+`RBOOST_RELEVANCE_FLOOR`). This corpus deliberately spreads durability/age
+across nearly every record (not just 7 hand-paired queries), and the
+Q4/Q8-nomic embedding's known weak tail separation (already flagged
+elsewhere as flair's #2 moat risk) is enough that even a topically-unrelated
+record clears the semantic-candidate bar — so **any** `permanent`/fresh
+record in the corpus acts as a magnet across many queries, not only its
+"intended" one. That's a broader, more systemic characterization of
+flair#623's root cause than the single-pair unit test shows, and it holds
+**identically under `hybrid=false`** (the legacy path) — so the effect is
+not specific to BM25/RRF score-banding as the commit's narrative framed it;
+it's `compositeScore`'s unconditional multiplier, full stop.
+
+## Caveats
+
+- **retrievalCount drift within a run**: `SemanticSearch` bumps
+  `retrievalCount` on every returned doc regardless of `scoring`. Since raw
+  is measured first and composite second against the same seeded instance,
+  composite's `retrievalBoost` is very slightly influenced by docs the raw
+  pass already surfaced. Bounded to +10% (`RBOOST_CAP`) and gated on
+  `RBOOST_RELEVANCE_FLOOR` — small next to the durability/recency effect this
+  harness targets, and it's the same convention `recall-eval.mjs` already
+  uses (see that file's own header caveat).
+- **HNSW/embedding run-to-run noise**: a single run can wobble; that's why
+  the default is `--runs 3` and results are reported as mean ± SE, mirroring
+  `recall-bench.mjs`'s convention.
+- **The rerank knob is implemented but not the main validation target.**
+  `--rerank` spawns one additional `hybrid=true, rerank=true` config using
+  `FLAIR_RERANK_ENABLED=true`. It needs the actual reranker GGUF
+  (`Qwen3-Reranker-0.6B-q8_0.gguf` by default) reachable via
+  `FLAIR_MODELS_DIR`; if the model is missing, `rerankCandidates()` fails
+  open (returns candidates unchanged — see `resources/rerank-provider.ts`)
+  and the run silently measures the *non-reranked* config instead of
+  erroring. It's slower (generative token-probability scoring per candidate)
+  and not this PR's ask (the ask was specifically the composite-vs-raw
+  discrimination under hybrid) — treat it as an available lever for whoever
+  next needs to validate a reranker change, not a number this PR reports.
+- **`--keep-on-fail`** only prints a reminder; it does not currently change
+  `stopHarper`'s cleanup behavior. If you need to inspect a failed run's
+  Harper installDir, comment out the `stopHarper` call in `runOnce()`
+  temporarily — left as a manual step rather than adding an
+  installDir-leaking code path that's easy to forget to remove.
+
+## Files
+
+- `corpus.ts` — the 87-record synthetic corpus + 30 ground-truth queries.
+  Read its header first; it documents exactly how relevance was assigned and
+  why each "stress"/"trap"/"hard" pair exists.
+- `run.ts` — the harness: spawns ephemeral Harper via
+  `test/helpers/harper-lifecycle.ts`, seeds the corpus via signed
+  `TPS-Ed25519` requests (same pattern as
+  `test/integration/bm25-hybrid-noquery-listing.test.ts`), measures, tears
+  down, aggregates.
+
+Neither file is swept into CI (`bun test test/unit/`,
+`test/integration/`, etc. — see `.github/workflows/*.yml` — only ever glob
+those specific directories, never `test/bench/`). This is a manually-invoked
+benchmark, not a gating test.

--- a/test/bench/recall-harness/corpus.ts
+++ b/test/bench/recall-harness/corpus.ts
@@ -1,0 +1,429 @@
+/**
+ * corpus.ts — synthetic corpus + ground-truth queries for the isolated
+ * recall-eval harness (test/bench/recall-harness/run.ts).
+ *
+ * WHY THIS CORPUS EXISTS (vs. the 4-cluster one in ops/tools/agent-fabric/recall-bench.mjs):
+ * recall-bench's CORPUS is 4 maximally-distant topic clusters (distributed
+ * consensus / coffee / index funds / houseplants), 4 memories each, one
+ * unambiguous correct answer per query. That's a "flattering upper bound":
+ * every distractor is topically miles away, so almost any embedding gets
+ * p@3 = 1.00 — it CANNOT discriminate between a scoring/retrieval config that
+ * genuinely helps and one that hurts, because there's no headroom to lose.
+ * (See recall-bench.mjs's own header, "KNOWN BIASES".)
+ *
+ * This corpus is deliberately harder along three axes a real agent memory
+ * corpus actually has:
+ *
+ *   1. NEAR-DUPLICATE / ADJACENT DENSITY — most clusters below hold several
+ *      records about the SAME narrow topic from different angles (e.g. four
+ *      separate facts about Raft, or three JWT/token-lifecycle facts that all
+ *      share vocabulary). A query's correct answer often has to beat a close
+ *      paraphrase or an adjacent-but-wrong fact in the SAME cluster, not just
+ *      four unrelated topics.
+ *   2. CROSS-CLUSTER "TRAP" CLUSTERS — a few clusters exist ONLY to share
+ *      surface vocabulary with a real-target cluster while answering a
+ *      different domain: ENG-TEAM-PROCESS shares "consensus"/"leader" with
+ *      CONSENSUS; TEA shares brewing vocabulary with COFFEE; GARDEN shares
+ *      "branch"/plant-care vocabulary with GIT and PLANT; DB-INDEXING shares
+ *      the word "index" with FINANCE's index funds. These test whether a
+ *      config (especially BM25/hybrid) confuses lexical overlap for
+ *      relevance.
+ *   3. VARIED DURABILITY + createdAt (recency) — records are spread across
+ *      all four durability levels (permanent/persistent/standard/ephemeral)
+ *      and ages from ~2 days to ~110 days old. This is what lets the harness
+ *      actually MEASURE compositeScore's durability-weight × recency-decay
+ *      effect (resources/scoring.ts) instead of assuming it.
+ *
+ * THE "STRESS PAIRS" — the deliberate composite-vs-raw discriminator:
+ * Seven records are marked STRESS CORRECT below; each has a same-cluster
+ * "STRESS DISTRACTOR" sibling that is semantically adjacent (same topic,
+ * different specific fact) but assigned `permanent` durability and a
+ * ~2-3-day createdAt, while the correct answer is `standard`/`persistent`
+ * and 50-90 days old. Under scoring="raw" (semantic + keyword only, no
+ * durability/recency weighting — see resources/SemanticSearch.ts) the
+ * correct, better-matching record should win. Under scoring="composite",
+ * compositeScore's dWeight × rFactor multiplier (0.4-1.0 × ~0-1, UNCONDITIONAL,
+ * no relevance floor — resources/scoring.ts) can be large enough to invert
+ * that ranking in favor of the fresher/more-durable-but-wrong sibling. This
+ * is the exact mechanism flair#623 (fixed in commit 624299c, 2026-07-08:
+ * "default SemanticSearch scoring to raw, not composite") found on the LIVE
+ * corpus — this harness reproduces it in isolation, on a purpose-built
+ * corpus, without ever touching production. See run.ts's REPORT for the
+ * measured composite-vs-raw delta this corpus produces.
+ *
+ * GROUND TRUTH — how relevance was assigned: every query below was written
+ * by hand against ONE specific corpus record, then checked that no OTHER
+ * record answers the query's literal question as directly. Four query
+ * "kinds" are tagged (see QueryKind) so a reader can see WHY each pair is in
+ * the set instead of taking p@3 on faith:
+ *   stress — targets one of the 7 durability/recency stress pairs above.
+ *   trap   — targets a record in a "real" cluster whose query wording shares
+ *            strong surface vocabulary with a same-corpus TRAP cluster.
+ *   hard   — targets one of two-or-more genuine near-duplicate records in the
+ *            SAME cluster; the correct id is the one that answers the
+ *            query's specific question, but a close sibling is a plausible
+ *            rank-2/3 confusion (this is what keeps p@3 from trivially
+ *            capping at 1.0 the way recall-bench's does).
+ *   clean  — an unambiguous, single-best-answer query, kept as a sanity
+ *            floor so the corpus isn't ADVERSARIAL everywhere (a corpus that
+ *            is 100% stress cases would itself be an unrepresentative
+ *            upper-bound-on-difficulty, same failure mode as recall-bench's
+ *            4-cluster corpus but inverted).
+ *
+ * ageDays is relative to seed time (computed fresh by run.ts on every seed),
+ * not an absolute date — so the corpus's relative recency shape is identical
+ * on every run regardless of when it's run.
+ */
+
+export type Durability = "permanent" | "persistent" | "standard" | "ephemeral";
+
+export interface CorpusRecord {
+  /** Unique marker, e.g. "CONSENSUS::1". Also used to derive the record's id. */
+  marker: string;
+  cluster: string;
+  text: string;
+  durability: Durability;
+  /** Age in days at seed time (createdAt = now - ageDays). */
+  ageDays: number;
+  /** Free-form note on why this record's durability/age was chosen. */
+  note?: string;
+}
+
+export type QueryKind = "stress" | "trap" | "hard" | "clean";
+
+export interface GroundTruthQuery {
+  q: string;
+  expectMarker: string;
+  kind: QueryKind;
+  /** What this query is specifically testing, and against which distractor. */
+  note: string;
+}
+
+// ─── Corpus: 12 clusters, 87 records ────────────────────────────────────────
+export const CORPUS: CorpusRecord[] = [
+  // ── CONSENSUS: distributed-systems consensus (8) ──────────────────────────
+  { marker: "CONSENSUS::1", cluster: "CONSENSUS", durability: "standard", ageDays: 75,
+    text: "Raft elects a single leader per term: each follower grants its vote to the first candidate whose log is at least as up to date as its own, and a candidate must collect votes from a majority of the cluster to become leader.",
+    note: "STRESS CORRECT (vs CONSENSUS::8): older + standard durability." },
+  { marker: "CONSENSUS::2", cluster: "CONSENSUS", durability: "standard", ageDays: 40,
+    text: "A Raft log entry counts as committed only once a majority of nodes have replicated it; the leader then applies it to its own state machine and includes the new commit index in the next heartbeat to followers." },
+  { marker: "CONSENSUS::3", cluster: "CONSENSUS", durability: "persistent", ageDays: 110,
+    text: "Paxos splits the work across three roles — proposer, acceptor, and learner — and reaches agreement in two rounds: a prepare phase that carries a proposal number, followed by an accept phase that carries the value tied to that number." },
+  { marker: "CONSENSUS::4", cluster: "CONSENSUS", durability: "persistent", ageDays: 95,
+    text: "When a network partition splits a consensus cluster so neither side can reach a majority, the cluster halts new writes on both sides rather than risk two histories diverging — availability is sacrificed to preserve a single truth." },
+  { marker: "CONSENSUS::5", cluster: "CONSENSUS", durability: "standard", ageDays: 30,
+    text: "In Raft, a candidate starts an election after its heartbeat timeout expires, bumps the term number, and requests votes from every peer; if it wins a majority before another leader emerges it starts sending heartbeats of its own.",
+    note: "Near-dup of CONSENSUS::1 (election-timeout mechanics vs the vote-granting rule)." },
+  { marker: "CONSENSUS::6", cluster: "CONSENSUS", durability: "standard", ageDays: 60,
+    text: "ZooKeeper's Zab protocol totally orders writes through a single elected leader much like Raft, but recovery after a leader crash replays a synchronization phase that reconciles each follower's history before normal broadcast resumes." },
+  { marker: "CONSENSUS::7", cluster: "CONSENSUS", durability: "standard", ageDays: 25,
+    text: "A quorum read or write only needs to touch a majority of replicas, not all of them, so a consensus system stays available even when a minority of nodes are slow or unreachable, at the cost of an extra round trip to reconcile stale replicas.",
+    note: "Near-dup facet of CONSENSUS::4 (quorum read/write path vs partition-halt)." },
+  { marker: "CONSENSUS::8", cluster: "CONSENSUS", durability: "permanent", ageDays: 2,
+    text: "Once elected, a Raft leader proves it is still alive by sending periodic heartbeats before its lease expires; if followers stop hearing them in time they assume the leader is gone and start a new election.",
+    note: "STRESS DISTRACTOR for CONSENSUS::1: fresh + permanent, adjacent topic (staying leader, not becoming leader)." },
+
+  // ── ENG: engineering team process (6) — adjacent-vocab trap for CONSENSUS ─
+  { marker: "ENG::1", cluster: "ENG", durability: "standard", ageDays: 20,
+    text: "Daily standups work best kept to fifteen minutes and three questions per person: what you did, what you're doing next, and anything blocking you — anything longer becomes a status meeting, not a sync." },
+  { marker: "ENG::2", cluster: "ENG", durability: "standard", ageDays: 45,
+    text: "When an engineering team can't reach consensus on a design in one sitting, write the disagreement down as an RFC with the options and tradeoffs spelled out, then time-box the discussion instead of letting the thread run forever." },
+  { marker: "ENG::3", cluster: "ENG", durability: "persistent", ageDays: 85,
+    text: "A tech lead is not automatically the most senior engineer; the role is about unblocking the team, owning technical direction, and making the tie-breaking call when consensus stalls — not writing the most code." },
+  { marker: "ENG::4", cluster: "ENG", durability: "standard", ageDays: 10,
+    text: "Sprint retros work better when you pick one or two concrete changes to try next sprint instead of relitigating every complaint — a long list of action items is really a list of things that won't get done." },
+  { marker: "ENG::5", cluster: "ENG", durability: "ephemeral", ageDays: 4,
+    text: "On-call rotations should rotate the pager, not the accountability — whoever owns the service should still triage the postmortem even if a different engineer was holding the pager when it paged." },
+  { marker: "ENG::6", cluster: "ENG", durability: "standard", ageDays: 33,
+    text: "Reaching team agreement on a contentious technical choice usually goes faster with a short doc and an explicit decision deadline than with an open-ended meeting where the loudest voice tends to win by default." },
+
+  // ── COFFEE: brewing methods (8) ──────────────────────────────────────────
+  { marker: "COFFEE::1", cluster: "COFFEE", durability: "persistent", ageDays: 80,
+    text: "A pour-over drips hot water in slow concentric circles over a paper-filtered bed of grounds, giving a clean, bright cup with the fines held back by the filter.",
+    note: "STRESS CORRECT (vs COFFEE::6): older + persistent durability." },
+  { marker: "COFFEE::2", cluster: "COFFEE", durability: "standard", ageDays: 45,
+    text: "A French press steeps coarse grounds in water for about four minutes, then a metal mesh plunger separates the liquid, leaving a fuller, heavier body in the cup." },
+  { marker: "COFFEE::3", cluster: "COFFEE", durability: "standard", ageDays: 20,
+    text: "An espresso shot forces near-boiling water through finely tamped grounds at roughly nine bars of pressure, pulling a concentrated ounce topped with golden crema." },
+  { marker: "COFFEE::4", cluster: "COFFEE", durability: "standard", ageDays: 35,
+    text: "Cold brew soaks coarse grounds in room-temperature or chilled water for twelve to twenty-four hours, yielding a smooth, low-acidity concentrate you dilute before serving." },
+  { marker: "COFFEE::5", cluster: "COFFEE", durability: "standard", ageDays: 15,
+    text: "A moka pot forces steam pressure up through grounds and into the upper chamber, producing a strong, espresso-adjacent cup without needing an actual espresso machine." },
+  { marker: "COFFEE::6", cluster: "COFFEE", durability: "permanent", ageDays: 2,
+    text: "An AeroPress presses hot water through fine grounds and a small paper filter in under a minute, splitting the difference between a pour-over's clarity and an espresso's short brew time.",
+    note: "STRESS DISTRACTOR for COFFEE::1: fresh + permanent, also paper-filtered (plausible confusion)." },
+  { marker: "COFFEE::7", cluster: "COFFEE", durability: "standard", ageDays: 50,
+    text: "Letting a pour-over 'bloom' first — a short pre-soak that lets trapped CO2 escape before the main pour — keeps the extraction even instead of channeling water around dry pockets of grounds.",
+    note: "Near-dup facet of COFFEE::1 (bloom technique vs basic method)." },
+  { marker: "COFFEE::8", cluster: "COFFEE", durability: "standard", ageDays: 28,
+    text: "Cold brew concentrate keeps well refrigerated for up to two weeks because the low-temperature steep extracts far less of the acid and oil that make hot-brewed coffee turn stale and bitter quickly.",
+    note: "Near-dup facet of COFFEE::4 (shelf life vs method)." },
+
+  // ── TEA: brewing methods (5) — adjacent-domain trap for COFFEE ───────────
+  { marker: "TEA::1", cluster: "TEA", durability: "standard", ageDays: 18,
+    text: "Green tea turns bitter and grassy if steeped in boiling water — aim for around 175°F and two minutes, not the near-boil and five minutes that black tea wants." },
+  { marker: "TEA::2", cluster: "TEA", durability: "standard", ageDays: 40,
+    text: "Black tea can take a full rolling boil and three to five minutes of steeping without turning harsh, which is why it stands up to milk better than green or white tea." },
+  { marker: "TEA::3", cluster: "TEA", durability: "standard", ageDays: 60,
+    text: "Oolong sits between green and black in oxidation, and a good oolong can be steeped multiple short infusions in a row, each one drawing out a slightly different flavor note." },
+  { marker: "TEA::4", cluster: "TEA", durability: "persistent", ageDays: 75,
+    text: "Matcha isn't steeped at all — the whole powdered leaf is whisked directly into hot water, which is why its caffeine and antioxidant content per cup runs higher than steeped tea." },
+  { marker: "TEA::5", cluster: "TEA", durability: "ephemeral", ageDays: 6,
+    text: "Iced tea gets cloudy when hot-brewed tea is poured directly over ice because the rapid cooling precipitates tannins; cold-brewing the tea overnight instead avoids the cloudiness entirely." },
+
+  // ── FIN: personal finance / investing (8) ────────────────────────────────
+  { marker: "FIN::1", cluster: "FIN", durability: "persistent", ageDays: 70,
+    text: "A low-cost broad-market index fund tracks the whole market instead of picking stocks, and its tiny expense ratio compounds into a large advantage over decades.",
+    note: "STRESS CORRECT (vs FIN::4): older + persistent durability." },
+  { marker: "FIN::2", cluster: "FIN", durability: "standard", ageDays: 40,
+    text: "Dollar-cost averaging means investing a fixed amount on a regular schedule regardless of price, smoothing out the cost of entry and removing the urge to time the market." },
+  { marker: "FIN::3", cluster: "FIN", durability: "standard", ageDays: 55,
+    text: "A tax-advantaged retirement account lets contributions grow without yearly taxes on gains; a Roth variant is funded with after-tax money so qualified withdrawals come out tax-free." },
+  { marker: "FIN::4", cluster: "FIN", durability: "permanent", ageDays: 2,
+    text: "Rebalancing periodically sells whatever asset class has grown beyond its target weight and buys the laggards, keeping your portfolio risk near the allocation you originally chose.",
+    note: "STRESS DISTRACTOR for FIN::1: fresh + permanent, same cluster, different specific fact." },
+  { marker: "FIN::5", cluster: "FIN", durability: "standard", ageDays: 25,
+    text: "An emergency fund of three to six months of expenses sitting in something boring and liquid — not invested — is what keeps a market downturn from forcing you to sell stocks at the worst possible time." },
+  { marker: "FIN::6", cluster: "FIN", durability: "standard", ageDays: 60,
+    text: "A total-market index fund and an S&P 500 index fund overlap heavily, but the total-market version also owns the small- and mid-cap names the S&P 500 excludes by definition.",
+    note: "Near-dup facet of FIN::1 (index-fund variants)." },
+  { marker: "FIN::7", cluster: "FIN", durability: "standard", ageDays: 18,
+    text: "An HSA is the rare triple-tax-advantaged account — contributions are pre-tax, growth is untaxed, and withdrawals for qualified medical expenses are never taxed either, which is why it's worth maxing before a Roth in many cases." },
+  { marker: "FIN::8", cluster: "FIN", durability: "standard", ageDays: 32,
+    text: "Automating a fixed monthly transfer into a broad index fund the same day your paycheck lands removes the decision point entirely — the money is invested before you've had a chance to talk yourself out of it.",
+    note: "Near-dup facet of FIN::2 (automating DCA)." },
+
+  // ── DBIDX: database indexing (8) — lexical "index" trap for FIN ─────────
+  { marker: "DBIDX::1", cluster: "DBIDX", durability: "standard", ageDays: 50,
+    text: "A B-tree index keeps keys sorted across a balanced tree so a database can find a row, or the start of a range, in logarithmic time instead of scanning every row." },
+  { marker: "DBIDX::2", cluster: "DBIDX", durability: "standard", ageDays: 35,
+    text: "A hash index maps a key straight to a bucket via a hash function, which makes an exact-match lookup very fast but can't help at all with a range query — the tree ordering that a B-tree has just isn't there." },
+  { marker: "DBIDX::3", cluster: "DBIDX", durability: "standard", ageDays: 20,
+    text: "A covering index includes every column a query needs directly in the index itself, so the database never has to jump back to the base table row — a much faster path than a normal index-then-lookup." },
+  { marker: "DBIDX::4", cluster: "DBIDX", durability: "standard", ageDays: 42,
+    text: "A partial index only covers rows matching a filter condition, which keeps it far smaller and cheaper to maintain than indexing the whole table when most queries only ever care about one subset of rows." },
+  { marker: "DBIDX::5", cluster: "DBIDX", durability: "persistent", ageDays: 65,
+    text: "A composite index over several columns only helps a query that filters on a left-to-right prefix of those columns — an index on (a, b, c) speeds up a query on a or (a, b), but not a query on b alone." },
+  { marker: "DBIDX::6", cluster: "DBIDX", durability: "standard", ageDays: 15,
+    text: "Every index you add speeds up reads but slows down every write, because the database has to keep that extra structure updated in lockstep with the table — indexing is a read/write tradeoff, not a free win." },
+  { marker: "DBIDX::7", cluster: "DBIDX", durability: "standard", ageDays: 28,
+    text: "An index-only scan answers a query straight from the index's own pages without ever touching the table, which is only possible when every selected column is already present in that index.",
+    note: "Near-dup facet of DBIDX::3 (covering index vs the scan it enables)." },
+  { marker: "DBIDX::8", cluster: "DBIDX", durability: "standard", ageDays: 8,
+    text: "A B-tree index degrades over time as rows are deleted and inserted unevenly across the tree, leaving half-empty pages — periodic reindexing rebuilds it back to a dense, balanced structure." },
+
+  // ── PLANT: houseplant care (9) ────────────────────────────────────────────
+  { marker: "PLANT::1", cluster: "PLANT", durability: "persistent", ageDays: 65,
+    text: "A snake plant tolerates low light and infrequent watering; let the soil dry out completely between waterings or its thick rhizomes will rot.",
+    note: "STRESS CORRECT (vs PLANT::3): older + persistent durability." },
+  { marker: "PLANT::2", cluster: "PLANT", durability: "standard", ageDays: 38,
+    text: "A fiddle-leaf fig wants bright indirect light and hates being moved or sitting in soggy roots, so drainage and a consistent spot matter more than frequent watering." },
+  { marker: "PLANT::3", cluster: "PLANT", durability: "permanent", ageDays: 2,
+    text: "A pothos vine grows fast in almost any light and roots easily from cuttings placed in a glass of water, making it the classic beginner trailing plant.",
+    note: "STRESS DISTRACTOR for PLANT::1: fresh + permanent, also 'easy/low-maintenance houseplant'." },
+  { marker: "PLANT::4", cluster: "PLANT", durability: "standard", ageDays: 22,
+    text: "Overwatering kills more houseplants than drought; yellowing lower leaves and gnats hovering over the soil usually mean the roots are staying wet too long." },
+  { marker: "PLANT::5", cluster: "PLANT", durability: "standard", ageDays: 30,
+    text: "Underwatering shows up as crispy brown leaf edges and a pot that feels suspiciously light when you lift it, quite different from overwatering's soft yellow leaves and heavy, waterlogged soil.",
+    note: "Near-dup/contrast of PLANT::4 (underwatering vs overwatering signs)." },
+  { marker: "PLANT::6", cluster: "PLANT", durability: "standard", ageDays: 48,
+    text: "Most houseplants actually want more humidity than a heated indoor room provides in winter — a pebble tray or a small humidifier does more for a fussy tropical plant than adjusting the watering schedule." },
+  { marker: "PLANT::7", cluster: "PLANT", durability: "standard", ageDays: 55,
+    text: "Feeding houseplants a diluted liquid fertilizer roughly monthly during spring and summer growth is plenty — feeding through winter dormancy just builds up salts in soil that isn't actively using the nutrients." },
+  { marker: "PLANT::8", cluster: "PLANT", durability: "standard", ageDays: 12,
+    text: "Roots circling tightly at the bottom of the pot, or growing out of the drainage holes, mean a plant is rootbound and overdue for a repot into a container one size up." },
+  { marker: "PLANT::9", cluster: "PLANT", durability: "ephemeral", ageDays: 5,
+    text: "Gnats hovering just above the soil surface are almost always a sign the top inch is staying wet too long between waterings, not a sign of the plant itself being unhealthy.",
+    note: "Near-dup facet of PLANT::4 (the gnat detail specifically, vs the general overwatering picture)." },
+
+  // ── GARDEN: outdoor gardening (5) — adjacent-domain trap for PLANT + GIT ─
+  { marker: "GARDEN::1", cluster: "GARDEN", durability: "standard", ageDays: 25,
+    text: "Pruning the suckers off a tomato plant — the small shoots that grow in the joint between the main stem and a branch — redirects the plant's energy into fewer, larger fruit instead of a tangle of foliage.",
+    note: "Shares 'branch' vocabulary with the GIT cluster — trap target for a git query." },
+  { marker: "GARDEN::2", cluster: "GARDEN", durability: "standard", ageDays: 50,
+    text: "A good compost pile wants roughly equal parts 'browns' like dry leaves or cardboard and 'greens' like vegetable scraps or grass clippings, turned every week or two so it doesn't go anaerobic and start to smell." },
+  { marker: "GARDEN::3", cluster: "GARDEN", durability: "standard", ageDays: 15,
+    text: "A few inches of mulch over garden soil suppresses weeds, holds moisture so you water less often, and breaks down slowly to add organic matter — straw and wood chips both work, just don't pile it against stems." },
+  { marker: "GARDEN::4", cluster: "GARDEN", durability: "ephemeral", ageDays: 5,
+    text: "Outdoor beds generally want a deep, infrequent soak rather than a light daily sprinkle, because shallow watering trains roots to stay near the surface where they dry out fastest." },
+  { marker: "GARDEN::5", cluster: "GARDEN", durability: "standard", ageDays: 35,
+    text: "Aphids cluster on new growth and the undersides of leaves; a strong blast of water or a diluted insecticidal soap knocks most of them off without reaching for a broad-spectrum pesticide." },
+
+  // ── AUTH: API authentication (8) ──────────────────────────────────────────
+  { marker: "AUTH::1", cluster: "AUTH", durability: "standard", ageDays: 55,
+    text: "OAuth2's authorization code flow redirects the user to the provider to log in and approve access, then exchanges a short-lived code for tokens server-side, so the access token never has to pass through the browser.",
+    note: "STRESS CORRECT (vs AUTH::3): older + standard durability." },
+  { marker: "AUTH::2", cluster: "AUTH", durability: "standard", ageDays: 30,
+    text: "A static API key is simple to issue and simple to check, but it carries no built-in expiry or scope narrowing — anyone who has it can do everything it's allowed to do until you revoke it entirely." },
+  { marker: "AUTH::3", cluster: "AUTH", durability: "permanent", ageDays: 3,
+    text: "A JWT bundles claims like the subject, issuer, and expiry into a signed payload the recipient can verify without a database round trip, but a leaked one is valid until it expires — there's no revoke button.",
+    note: "STRESS DISTRACTOR for AUTH::1: fresh + permanent, adjacent auth topic." },
+  { marker: "AUTH::4", cluster: "AUTH", durability: "standard", ageDays: 45,
+    text: "Mutual TLS has both sides present a certificate during the handshake, not just the server, so the connection itself proves both parties' identity before a single request is sent." },
+  { marker: "AUTH::5", cluster: "AUTH", durability: "standard", ageDays: 20,
+    text: "HMAC request signing hashes the request body and a shared secret together into a signature header, so a receiver can confirm the request wasn't tampered with in transit without ever sending the secret itself." },
+  { marker: "AUTH::6", cluster: "AUTH", durability: "standard", ageDays: 15,
+    text: "A refresh token lets a client mint a new short-lived access token without forcing the user to log in again, and rotating the refresh token on each use limits the damage if one ever leaks.",
+    note: "Near-dup/adjacent facet of AUTH::3 (token lifecycle)." },
+  { marker: "AUTH::7", cluster: "AUTH", durability: "standard", ageDays: 8,
+    text: "Storing an API key as a hash instead of the plaintext value means a database leak doesn't hand out working keys — the check works the same way a password hash check does, comparing hashes not the raw secret.",
+    note: "Near-dup facet of AUTH::2." },
+  { marker: "AUTH::8", cluster: "AUTH", durability: "standard", ageDays: 25,
+    text: "A JWT's expiry claim only limits how long it's valid for — it says nothing about whether the token has been revoked early, which is why short expiries plus refresh tokens matter more than the signature algorithm chosen.",
+    note: "Near-dup facet of AUTH::3/AUTH::6 (revocation vs expiry)." },
+
+  // ── RATE: API rate limiting (6) — adjacent-domain trap for AUTH ─────────
+  { marker: "RATE::1", cluster: "RATE", durability: "standard", ageDays: 20,
+    text: "A token bucket refills at a fixed rate and lets a request through as long as there's a token in the bucket, which allows short bursts above the average rate as long as the bucket has tokens saved up." },
+  { marker: "RATE::2", cluster: "RATE", durability: "standard", ageDays: 45,
+    text: "A leaky bucket processes requests at a strictly constant rate regardless of how bursty the incoming traffic is, smoothing bursts out instead of allowing them the way a token bucket does." },
+  { marker: "RATE::3", cluster: "RATE", durability: "standard", ageDays: 30,
+    text: "A sliding window log tracks the exact timestamp of every request in the recent window, giving an accurate count at the cost of more memory than a simple fixed counter." },
+  { marker: "RATE::4", cluster: "RATE", durability: "persistent", ageDays: 80,
+    text: "A client hitting a 429 should back off exponentially with jitter rather than retrying immediately, and should honor a Retry-After header if the server sends one instead of guessing its own delay." },
+  { marker: "RATE::5", cluster: "RATE", durability: "standard", ageDays: 12,
+    text: "A fixed window counter resets to zero at a clock boundary, which lets a client send double the intended limit by timing requests around the reset instant — a sliding window avoids that edge effect." },
+  { marker: "RATE::6", cluster: "RATE", durability: "ephemeral", ageDays: 7,
+    text: "Rate limiting by API key rather than by IP address is what actually protects a shared endpoint, since a legitimate high-traffic customer and an abusive one can share the same NAT'd IP address." },
+
+  // ── DEPLOY: container/k8s deployment strategies (8) ───────────────────────
+  { marker: "DEPLOY::1", cluster: "DEPLOY", durability: "persistent", ageDays: 90,
+    text: "A canary deployment shifts a small percentage of live traffic to the new version first, watches its error rate and latency against the baseline, and only then ramps the rest of the traffic over.",
+    note: "STRESS CORRECT (vs DEPLOY::2): older + persistent durability." },
+  { marker: "DEPLOY::2", cluster: "DEPLOY", durability: "permanent", ageDays: 2,
+    text: "A blue-green deployment keeps two full environments running and switches all traffic over at once by flipping a router or load balancer, making rollback as fast as flipping it back.",
+    note: "STRESS DISTRACTOR for DEPLOY::1: fresh + permanent, adjacent deployment strategy." },
+  { marker: "DEPLOY::3", cluster: "DEPLOY", durability: "standard", ageDays: 35,
+    text: "A rolling update replaces old pods with new ones a few at a time, so the service never has zero capacity, but it does mean old and new versions briefly serve traffic side by side." },
+  { marker: "DEPLOY::4", cluster: "DEPLOY", durability: "standard", ageDays: 20,
+    text: "A recreate strategy tears down every old instance before starting any new one, guaranteeing no version overlap at the cost of real downtime during the switch — fine for a maintenance window, not for a live service." },
+  { marker: "DEPLOY::5", cluster: "DEPLOY", durability: "standard", ageDays: 48,
+    text: "A readiness probe that fails keeps a pod out of the load balancer's rotation without restarting it, which is exactly what should gate a rolling update — a pod isn't 'up' until it says it can actually serve traffic." },
+  { marker: "DEPLOY::6", cluster: "DEPLOY", durability: "standard", ageDays: 12,
+    text: "Rolling back a Kubernetes deployment to the previous revision is usually one command because Kubernetes keeps a revision history by default — the fast path assumes you kept that history around instead of pruning it." },
+  { marker: "DEPLOY::7", cluster: "DEPLOY", durability: "standard", ageDays: 28,
+    text: "A canary's traffic split is only useful if the metrics you're watching are sliced by version — an aggregate error rate across both old and new pods can hide a canary regression in the noise.",
+    note: "Near-dup facet of DEPLOY::1 (canary observability detail)." },
+  { marker: "DEPLOY::8", cluster: "DEPLOY", durability: "standard", ageDays: 18,
+    text: "Blue-green needs double the infrastructure capacity during the cutover window, which is the tradeoff for being able to roll back instantly by just flipping the router back to the old environment.",
+    note: "Near-dup facet of DEPLOY::2." },
+
+  // ── GIT: git branching workflows (8) ──────────────────────────────────────
+  { marker: "GIT::1", cluster: "GIT", durability: "standard", ageDays: 50,
+    text: "Trunk-based development keeps everyone committing small changes directly to main (or short-lived branches merged within a day), leaning on feature flags instead of long-lived branches to hide unfinished work.",
+    note: "STRESS CORRECT (vs GIT::2): older + standard durability." },
+  { marker: "GIT::2", cluster: "GIT", durability: "permanent", ageDays: 3,
+    text: "Gitflow keeps separate long-lived develop and main branches plus dedicated release and hotfix branches, which gives more process ceremony than most teams need for a service that ships continuously.",
+    note: "STRESS DISTRACTOR for GIT::1: fresh + permanent, adjacent workflow." },
+  { marker: "GIT::3", cluster: "GIT", durability: "standard", ageDays: 25,
+    text: "A feature-branch workflow cuts a new branch per unit of work and merges it back via pull request once reviewed, which is lighter than Gitflow but still means work-in-progress lives off of main until it lands." },
+  { marker: "GIT::4", cluster: "GIT", durability: "standard", ageDays: 40,
+    text: "Rebasing a feature branch onto main rewrites its commits on top of the latest main, producing a clean linear history, while merging main into the branch instead preserves the true chronological history but adds merge commits." },
+  { marker: "GIT::5", cluster: "GIT", durability: "standard", ageDays: 15,
+    text: "Cherry-picking takes one specific commit from another branch and replays just that change onto the current branch, which is the right tool for backporting a single fix without pulling in everything else that branch has." },
+  { marker: "GIT::6", cluster: "GIT", durability: "standard", ageDays: 22,
+    text: "Squash-merging collapses an entire branch's commits into one on main, trading away the fine-grained commit history for a clean, one-line-per-feature main log that's much easier to skim or revert.",
+    note: "Near-dup facet of GIT::4 (history-shape tradeoff)." },
+  { marker: "GIT::7", cluster: "GIT", durability: "standard", ageDays: 8,
+    text: "Git bisect binary-searches your commit history by checking out a midpoint, having you mark it good or bad, and narrowing the range each time — it finds the exact commit that introduced a regression in log2(n) steps." },
+  { marker: "GIT::8", cluster: "GIT", durability: "standard", ageDays: 32,
+    text: "A rebase rewrites commit hashes, so rebasing a branch anyone else has already pulled forces them into a painful history reconciliation — the rule of thumb is never rebase a branch other people are also working on.",
+    note: "Near-dup facet of GIT::4 (rebase caveat)." },
+];
+
+// ─── Ground-truth queries (30) ──────────────────────────────────────────────
+export const QUERIES: GroundTruthQuery[] = [
+  // ── stress (7): durability/recency composite-vs-raw discriminators ───────
+  { kind: "stress", expectMarker: "CONSENSUS::1",
+    q: "How does a cluster pick which single node gets to lead for a while?",
+    note: "vs CONSENSUS::8 (fresh/permanent 'staying leader' fact)." },
+  { kind: "stress", expectMarker: "COFFEE::1",
+    q: "What's the classic manual method for a clean, bright cup using a paper filter and a slow, careful pour?",
+    note: "vs COFFEE::6 (fresh/permanent AeroPress, also paper-filtered)." },
+  { kind: "stress", expectMarker: "FIN::1",
+    q: "What's the cheapest hands-off way to own a slice of the entire stock market?",
+    note: "vs FIN::4 (fresh/permanent rebalancing fact, same cluster)." },
+  { kind: "stress", expectMarker: "PLANT::1",
+    q: "What's a good hard-to-kill houseplant for someone who always forgets to water?",
+    note: "vs PLANT::3 (fresh/permanent pothos, also 'easy plant')." },
+  { kind: "stress", expectMarker: "AUTH::1",
+    q: "How does a web app hand off a user's login to a third-party identity provider without the app ever seeing the password?",
+    note: "vs AUTH::3 (fresh/permanent JWT fact, adjacent auth topic)." },
+  { kind: "stress", expectMarker: "DEPLOY::1",
+    q: "What deployment approach tests a new version on a small slice of real traffic before rolling it out to everyone?",
+    note: "vs DEPLOY::2 (fresh/permanent blue-green, adjacent strategy)." },
+  { kind: "stress", expectMarker: "GIT::1",
+    q: "What git workflow has everyone committing small changes straight to main behind feature flags instead of long-lived branches?",
+    note: "vs GIT::2 (fresh/permanent Gitflow, adjacent workflow)." },
+
+  // ── trap (3): lexical-overlap-but-wrong-domain (BM25/hybrid stress) ──────
+  { kind: "trap", expectMarker: "FIN::1",
+    q: "What's the cheapest way to track the whole stock market instead of trying to pick individual winners?",
+    note: "shares 'index'/'market' vocab with the DBIDX cluster." },
+  { kind: "trap", expectMarker: "DBIDX::1",
+    q: "What data structure lets a database find a row in logarithmic time instead of scanning the whole table?",
+    note: "shares 'index' vocab with the FIN cluster." },
+  { kind: "trap", expectMarker: "GIT::3",
+    q: "What's a common workflow for isolating one unit of work per branch before merging it back to main?",
+    note: "shares 'branch' vocab with GARDEN::1 (tomato pruning)." },
+
+  // ── hard (6): genuine near-duplicate disambiguation, non-adversarial age ─
+  { kind: "hard", expectMarker: "PLANT::4",
+    q: "What are the telltale signs my plant is dying from too much water rather than too little?",
+    note: "vs PLANT::9 (gnat-specific facet) and PLANT::5 (underwatering contrast)." },
+  { kind: "hard", expectMarker: "DBIDX::5",
+    q: "Why would the same two columns need a different index shape depending on which query is running?",
+    note: "vs DBIDX::3 (covering index — both about index-shape-per-query)." },
+  { kind: "hard", expectMarker: "AUTH::3",
+    q: "What's the real risk if someone steals my signed access token before it expires?",
+    note: "vs AUTH::8 (expiry-vs-revocation near-dup facet)." },
+  { kind: "hard", expectMarker: "GIT::6",
+    q: "What do I give up by squashing a branch's commits down to one before merging?",
+    note: "vs GIT::4 (rebase/merge history-shape near-dup)." },
+  { kind: "hard", expectMarker: "DEPLOY::5",
+    q: "How do I stop a rollout from sending traffic to a pod before it's actually ready to serve?",
+    note: "vs DEPLOY::3 (rolling update — both gate rollout traffic)." },
+  { kind: "hard", expectMarker: "COFFEE::7",
+    q: "What's a quick technique for getting a more even extraction out of a manual drip brew?",
+    note: "vs COFFEE::1 (pour-over basics — bloom is a facet of the same method)." },
+
+  // ── clean (14): unambiguous single-best-answer sanity floor ──────────────
+  { kind: "clean", expectMarker: "CONSENSUS::2",
+    q: "When is it actually safe to say a replicated write has taken effect across the cluster?", note: "" },
+  { kind: "clean", expectMarker: "CONSENSUS::3",
+    q: "How does Paxos structure its two rounds of agreement?", note: "" },
+  { kind: "clean", expectMarker: "CONSENSUS::4",
+    q: "Why does a consensus cluster stop accepting writes entirely during a bad network split instead of picking a side?", note: "" },
+  { kind: "clean", expectMarker: "CONSENSUS::6",
+    q: "How is ZooKeeper's atomic broadcast protocol similar to Raft?", note: "" },
+  { kind: "clean", expectMarker: "ENG::2",
+    q: "How do you keep a long meeting-based disagreement from dragging on forever on an engineering team?", note: "" },
+  { kind: "clean", expectMarker: "ENG::3",
+    q: "What actually distinguishes a tech lead's job from just being the most senior engineer?", note: "" },
+  { kind: "clean", expectMarker: "TEA::1",
+    q: "Why does green tea turn bitter if you steep it like you would black tea?", note: "" },
+  { kind: "clean", expectMarker: "FIN::5",
+    q: "Why is an emergency fund supposed to sit in cash instead of being invested?", note: "" },
+  { kind: "clean", expectMarker: "FIN::7",
+    q: "What's the actual tax advantage that makes an HSA worth maxing out?", note: "" },
+  { kind: "clean", expectMarker: "DBIDX::6",
+    q: "Why does adding a database index make writes slower even though it speeds up reads?", note: "" },
+  { kind: "clean", expectMarker: "GARDEN::4",
+    q: "Why should outdoor garden beds get watered deeply and rarely instead of a light daily sprinkle?", note: "" },
+  { kind: "clean", expectMarker: "RATE::1",
+    q: "What lets a client send occasional bursts above its average allowed rate without getting throttled?", note: "" },
+  { kind: "clean", expectMarker: "RATE::4",
+    q: "What should a client do differently when a server responds with a 429 rather than just retrying immediately?", note: "" },
+  { kind: "clean", expectMarker: "GIT::7",
+    q: "What's the fast way to find exactly which commit introduced a regression out of hundreds of candidates?", note: "" },
+];
+
+// Sanity: every expectMarker must resolve to a real corpus record (checked at
+// harness startup too, but cheap to assert here for anyone importing this
+// module directly).
+const MARKERS = new Set(CORPUS.map(c => c.marker));
+for (const { expectMarker, q } of QUERIES) {
+  if (!MARKERS.has(expectMarker)) {
+    throw new Error(`corpus.ts: query "${q}" expects unknown marker ${expectMarker}`);
+  }
+}

--- a/test/bench/recall-harness/run.ts
+++ b/test/bench/recall-harness/run.ts
@@ -1,0 +1,331 @@
+#!/usr/bin/env bun
+/**
+ * recall-harness/run.ts — ISOLATED recall-eval harness.
+ *
+ * WHY: the two existing recall tools both have a gap this closes.
+ *   - ops/tools/agent-fabric/recall-eval.mjs measures against flint's LIVE
+ *     production memory corpus over the network. It only runs ON the live
+ *     server, mutates it (retrievalCount bumps on every query), and its
+ *     ground truth rots as that corpus changes day to day — there is no way
+ *     to safely try a scoring/retrieval change without touching production.
+ *   - ops/tools/agent-fabric/recall-bench.mjs IS isolated (seeds a synthetic
+ *     corpus, measures, tears down) but its corpus is 4 maximally-distant
+ *     topic clusters — a "flattering upper bound" that caps p@3 at 1.0 and
+ *     can't discriminate between a config that helps and one that hurts.
+ *
+ * This harness is isolated (spawns an EPHEMERAL Harper via
+ * test/helpers/harper-lifecycle.ts — zero contact with the live :9926
+ * service or ~/ops/flair) AND uses a harder, representative corpus
+ * (./corpus.ts — near-duplicate clusters, lexical-overlap traps, varied
+ * durability/recency) that can actually discriminate. It reproduces, in
+ * isolation, the exact finding that flair#623 (commit 624299c, 2026-07-08)
+ * made by measuring the LIVE corpus: scoring="composite" measurably
+ * underperforms scoring="raw" once BM25 hybrid retrieval is active, because
+ * compositeScore's durability-weight × recency-decay multiplier
+ * (resources/scoring.ts) applies unconditionally and can invert a ranking
+ * the raw semantic/BM25 score got right.
+ *
+ * WHAT IT MEASURES: for each (hybrid, rerank) config it spawns ONE ephemeral
+ * Harper, seeds ./corpus.ts's CORPUS, and against that SAME seeded instance
+ * runs every query in QUERIES under BOTH scoring="raw" and
+ * scoring="composite" — reporting precision@3 and MRR for each, overall and
+ * broken out by query "kind" (stress/trap/hard/clean — see corpus.ts). This
+ * repeats `--runs` times (fresh spawn+seed+teardown each time, for
+ * independence — HNSW graph construction and embedding-engine warmup both
+ * introduce run-to-run noise) and aggregates as mean ± standard error.
+ *
+ * SAFETY: every Harper instance is a fresh `mkdtemp` ROOTPATH/HOME
+ * (test/helpers/harper-lifecycle.ts), bound to OS-assigned free ports, and
+ * killed + removed at the end of each run. This script never imports, reads
+ * from, or writes to ~/ops/flair or any live Flair service. FLAIR_MODELS_DIR
+ * may be pointed at an EXISTING flair install's models/ directory (read-only
+ * — just the GGUF weight files) to skip re-downloading the embedding model;
+ * see README.md.
+ *
+ * USAGE:
+ *   bun run test/bench/recall-harness/run.ts                  # full sweep: hybrid on+off, 3 runs each
+ *   bun run test/bench/recall-harness/run.ts --runs 1          # quick single-run pass (less trustworthy)
+ *   bun run test/bench/recall-harness/run.ts --hybrid on        # only the production-default config
+ *   bun run test/bench/recall-harness/run.ts --hybrid on --rerank  # also spawn a hybrid+rerank config
+ *   bun run test/bench/recall-harness/run.ts --verbose          # print every query's rank, not just aggregates
+ *   bun run test/bench/recall-harness/run.ts --keep-on-fail     # leave a failed run's Harper installDir on disk
+ *
+ * Reads nothing from the network except what Harper itself needs (model
+ * files from FLAIR_MODELS_DIR or a HuggingFace download on first use).
+ */
+import nacl from "tweetnacl";
+import { randomUUID } from "node:crypto";
+import { existsSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+import { startHarper, stopHarper, type HarperInstance } from "../../helpers/harper-lifecycle";
+import { CORPUS, QUERIES, type QueryKind, type CorpusRecord } from "./corpus";
+
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../../..");
+const AGENT_ID = "recall-harness-corpus";
+
+// Harper loads compiled resources per config.yaml's `jsResource: files:
+// dist/resources/*.js` — NOT the TypeScript source directly. dist/ is
+// gitignored build output, so a fresh worktree/clone has none until built.
+// Without this check, every request 404s with a bare "Not found" body and
+// the real cause (stale or missing build) is easy to misread as an auth or
+// routing bug.
+function assertBuilt(): void {
+  const marker = path.join(REPO_ROOT, "dist", "resources", "SemanticSearch.js");
+  if (!existsSync(marker)) {
+    console.error(`FATAL: ${marker} not found. Harper serves resources from dist/, not TypeScript source.`);
+    console.error(`Run \`npm run build\` (or \`bun run build\`) in ${REPO_ROOT} first, then re-run this harness.`);
+    process.exit(2);
+  }
+}
+
+// ─── CLI args ────────────────────────────────────────────────────────────────
+function argVal(flag: string, dflt: string): string {
+  const i = process.argv.indexOf(flag);
+  return i >= 0 && process.argv[i + 1] ? process.argv[i + 1] : dflt;
+}
+const RUNS = Math.max(1, parseInt(argVal("--runs", "3"), 10) || 3);
+const HYBRID_ARG = argVal("--hybrid", "both"); // "both" | "on" | "off"
+const WITH_RERANK = process.argv.includes("--rerank");
+const VERBOSE = process.argv.includes("--verbose");
+const KEEP_ON_FAIL = process.argv.includes("--keep-on-fail");
+const SEARCH_LIMIT = 20; // candidateLimit = limit*5 = 100 > CORPUS.length(87) → full HNSW coverage
+
+const hybridValues: boolean[] = HYBRID_ARG === "on" ? [true] : HYBRID_ARG === "off" ? [false] : [true, false];
+
+// ─── Ed25519 TPS-signed fetch (same pattern as test/integration's own suite) ─
+interface TestAgent { id: string; publicKey: string; secretKey: Uint8Array }
+function mkAgent(id: string): TestAgent {
+  const kp = nacl.sign.keyPair();
+  return { id, publicKey: Buffer.from(kp.publicKey).toString("base64"), secretKey: kp.secretKey };
+}
+function ed25519Header(agent: TestAgent, method: string, p: string): string {
+  const ts = Date.now().toString();
+  const nonce = randomUUID();
+  const payload = `${agent.id}:${ts}:${nonce}:${method}:${p}`;
+  const sig = nacl.sign.detached(new TextEncoder().encode(payload), agent.secretKey);
+  return `TPS-Ed25519 ${agent.id}:${ts}:${nonce}:${Buffer.from(sig).toString("base64")}`;
+}
+async function signedFetch(harper: HarperInstance, agent: TestAgent, method: string, p: string, body?: unknown): Promise<{ ok: boolean; status: number; body: any }> {
+  const res = await fetch(`${harper.httpURL}${p}`, {
+    method,
+    headers: { Authorization: ed25519Header(agent, method, p), "Content-Type": "application/json" },
+    body: body !== undefined ? JSON.stringify(body) : undefined,
+  });
+  const text = await res.text();
+  let parsed: any; try { parsed = JSON.parse(text); } catch { parsed = text; }
+  return { ok: res.ok, status: res.status, body: parsed };
+}
+async function adminOp(harper: HarperInstance, op: Record<string, any>): Promise<Response> {
+  return fetch(harper.opsURL, {
+    method: "POST",
+    headers: { "Content-Type": "application/json", Authorization: "Basic " + Buffer.from(`${harper.admin.username}:${harper.admin.password}`).toString("base64") },
+    body: JSON.stringify(op),
+  });
+}
+
+// ─── Seeding ─────────────────────────────────────────────────────────────────
+const idFor = (marker: string) => `${AGENT_ID}-${marker.replace(/::/g, "-")}`;
+
+async function registerAgent(harper: HarperInstance, agent: TestAgent): Promise<void> {
+  const res = await adminOp(harper, {
+    operation: "insert", database: "flair", table: "Agent",
+    records: [{ id: agent.id, name: agent.id, kind: "agent", publicKey: agent.publicKey, createdAt: new Date().toISOString() }],
+  });
+  if (!res.ok) throw new Error(`registerAgent: HTTP ${res.status} ${await res.text().catch(() => "")}`);
+}
+
+async function seedRecord(harper: HarperInstance, agent: TestAgent, rec: CorpusRecord): Promise<void> {
+  const id = idFor(rec.marker);
+  const createdAt = new Date(Date.now() - rec.ageDays * 24 * 3600_000).toISOString();
+  const path = `/Memory/${id}`;
+  const res = await signedFetch(harper, agent, "PUT", path, {
+    id, agentId: agent.id, content: rec.text, durability: rec.durability, createdAt,
+  });
+  if (!res.ok) throw new Error(`seed ${rec.marker} (${id}) failed: HTTP ${res.status} ${JSON.stringify(res.body ?? null).slice(0, 500)}`);
+}
+
+// Batched concurrency — enough to cut wall time without hammering a
+// THREADS_COUNT=1 ephemeral instance.
+async function seedCorpus(harper: HarperInstance, agent: TestAgent): Promise<void> {
+  const BATCH = 6;
+  for (let i = 0; i < CORPUS.length; i += BATCH) {
+    await Promise.all(CORPUS.slice(i, i + BATCH).map(rec => seedRecord(harper, agent, rec)));
+  }
+}
+
+// Canary poll: confirm the corpus is actually semantically searchable (not
+// just written) before measuring. Memory.put() awaits embedding generation
+// before responding, but poll anyway — HNSW index visibility has a
+// documented async lag in this codebase (see recall-bench.mjs's own
+// waitUntilSearchable). Uses one real ground-truth pair as the canary.
+async function waitSearchable(harper: HarperInstance, agent: TestAgent, timeoutMs = 45_000): Promise<void> {
+  const canary = QUERIES[0];
+  const expectId = idFor(canary.expectMarker);
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const res = await signedFetch(harper, agent, "POST", "/SemanticSearch", { agentId: agent.id, q: canary.q, limit: 10, scoring: "raw" });
+    if (res.ok && Array.isArray(res.body?.results) && res.body.results.some((r: any) => r.id === expectId)) return;
+    await new Promise(r => setTimeout(r, 1500));
+  }
+  throw new Error(`waitSearchable: canary query never surfaced ${expectId} within ${timeoutMs}ms (embedding engine slow/down?)`);
+}
+
+// ─── Measurement ─────────────────────────────────────────────────────────────
+interface QueryRow { q: string; kind: QueryKind; expectMarker: string; rank: number /* 0-based, -1 = not found */ }
+interface KindStats { p3: number; mrr: number; n: number }
+interface ScoringResult { scoring: "raw" | "composite"; p3: number; mrr: number; n: number; byKind: Record<QueryKind, KindStats>; rows: QueryRow[] }
+
+function statsFor(rows: QueryRow[]): { p3: number; mrr: number; n: number } {
+  if (!rows.length) return { p3: 0, mrr: 0, n: 0 };
+  const hits3 = rows.filter(r => r.rank >= 0 && r.rank < 3).length;
+  const rr = rows.reduce((s, r) => s + (r.rank >= 0 ? 1 / (r.rank + 1) : 0), 0);
+  return { p3: hits3 / rows.length, mrr: rr / rows.length, n: rows.length };
+}
+
+async function runQueries(harper: HarperInstance, agent: TestAgent, scoring: "raw" | "composite"): Promise<ScoringResult> {
+  const rows: QueryRow[] = [];
+  for (const { q, expectMarker, kind } of QUERIES) {
+    const expectId = idFor(expectMarker);
+    const res = await signedFetch(harper, agent, "POST", "/SemanticSearch", { agentId: agent.id, q, limit: SEARCH_LIMIT, scoring });
+    if (!res.ok) throw new Error(`search failed (scoring=${scoring}) for "${q}": HTTP ${res.status} ${JSON.stringify(res.body).slice(0, 200)}`);
+    const ids: string[] = (res.body.results || []).map((r: any) => r.id);
+    const rank = ids.indexOf(expectId);
+    rows.push({ q, kind, expectMarker, rank });
+  }
+  const overall = statsFor(rows);
+  const kinds: QueryKind[] = ["stress", "trap", "hard", "clean"];
+  const byKind = Object.fromEntries(kinds.map(k => [k, statsFor(rows.filter(r => r.kind === k))])) as Record<QueryKind, KindStats>;
+  return { scoring, ...overall, byKind, rows };
+}
+
+// One independent (spawn → register → seed → wait → measure[raw,composite] →
+// teardown) cycle for a given (hybrid, rerank) config.
+async function runOnce(hybrid: boolean, rerank: boolean, runIdx: number, totalRuns: number): Promise<{ raw: ScoringResult; composite: ScoringResult }> {
+  const label = `[hybrid=${hybrid} rerank=${rerank} run ${runIdx}/${totalRuns}]`;
+  const prevHybrid = process.env.FLAIR_HYBRID_RETRIEVAL;
+  const prevRerank = process.env.FLAIR_RERANK_ENABLED;
+  process.env.FLAIR_HYBRID_RETRIEVAL = hybrid ? "true" : "false";
+  if (rerank) process.env.FLAIR_RERANK_ENABLED = "true"; else delete process.env.FLAIR_RERANK_ENABLED;
+
+  let harper: HarperInstance | undefined;
+  try {
+    console.log(`${label} spawning ephemeral Harper...`);
+    harper = await startHarper({ cwd: REPO_ROOT, harperBinDir: REPO_ROOT });
+    console.log(`${label} up at ${harper.httpURL} (installDir=${harper.installDir})`);
+
+    const agent = mkAgent(AGENT_ID);
+    await registerAgent(harper, agent);
+    console.log(`${label} seeding ${CORPUS.length} records...`);
+    await seedCorpus(harper, agent);
+    await waitSearchable(harper, agent);
+    console.log(`${label} corpus searchable, measuring ${QUERIES.length} queries × 2 scoring modes...`);
+
+    // raw FIRST, then composite, against the SAME seeded instance — matches
+    // recall-eval.mjs's own convention. CAVEAT (same as recall-eval.mjs):
+    // SemanticSearch bumps retrievalCount on every returned doc regardless of
+    // scoring mode, so the composite pass's retrievalBoost is very slightly
+    // influenced by docs the raw pass already surfaced. Bounded to +10%
+    // (RBOOST_CAP) and gated by RBOOST_RELEVANCE_FLOOR — small next to the
+    // durability/recency effect this harness targets, but worth naming.
+    const raw = await runQueries(harper, agent, "raw");
+    const composite = await runQueries(harper, agent, "composite");
+    return { raw, composite };
+  } finally {
+    if (harper) await stopHarper(harper, { keepInstallDir: false });
+    if (prevHybrid === undefined) delete process.env.FLAIR_HYBRID_RETRIEVAL; else process.env.FLAIR_HYBRID_RETRIEVAL = prevHybrid;
+    if (prevRerank === undefined) delete process.env.FLAIR_RERANK_ENABLED; else process.env.FLAIR_RERANK_ENABLED = prevRerank;
+  }
+}
+
+// ─── Aggregation: mean ± standard error over repeated runs ──────────────────
+function aggStats(vals: number[]): { mean: number; se: number | null } {
+  const mean = vals.reduce((s, x) => s + x, 0) / vals.length;
+  if (vals.length < 2) return { mean, se: null };
+  const variance = vals.reduce((s, x) => s + (x - mean) ** 2, 0) / (vals.length - 1);
+  return { mean, se: Math.sqrt(variance) / Math.sqrt(vals.length) };
+}
+const fmt = (x: number, d = 3) => x.toFixed(d);
+const fmtAgg = (a: { mean: number; se: number | null }, d = 3) => a.se != null ? `${fmt(a.mean, d)} ± ${fmt(a.se, d)}` : fmt(a.mean, d);
+
+async function main() {
+  assertBuilt();
+  console.log(`recall-harness — ISOLATED recall eval (corpus=${CORPUS.length} records, queries=${QUERIES.length})`);
+  console.log(`config: runs=${RUNS} hybrid=${hybridValues.join(",")} rerank=${WITH_RERANK ? "on(hybrid=true only)+off" : "off"}\n`);
+  if (process.env.FLAIR_MODELS_DIR) console.log(`FLAIR_MODELS_DIR=${process.env.FLAIR_MODELS_DIR} (reusing pre-downloaded models)\n`);
+
+  // Build the (hybrid, rerank) config list. rerank is opt-in and only ever
+  // tested alongside hybrid=true (the production-default combination) — a
+  // full 2×2×2 sweep triples runtime for a knob this PR's validation doesn't
+  // depend on; see README for how to run a fuller sweep manually.
+  const configs: { hybrid: boolean; rerank: boolean }[] = hybridValues.map(h => ({ hybrid: h, rerank: false }));
+  if (WITH_RERANK && hybridValues.includes(true)) configs.push({ hybrid: true, rerank: true });
+
+  type Agg = { p3: number[]; mrr: number[]; byKind: Record<QueryKind, { p3: number[]; mrr: number[] }> };
+  const emptyAgg = (): Agg => ({ p3: [], mrr: [], byKind: { stress: { p3: [], mrr: [] }, trap: { p3: [], mrr: [] }, hard: { p3: [], mrr: [] }, clean: { p3: [], mrr: [] } } });
+
+  const results: Record<string, { raw: Agg; composite: Agg }> = {};
+
+  for (const cfg of configs) {
+    const key = `hybrid=${cfg.hybrid} rerank=${cfg.rerank}`;
+    results[key] = { raw: emptyAgg(), composite: emptyAgg() };
+    for (let i = 1; i <= RUNS; i++) {
+      const { raw, composite } = await runOnce(cfg.hybrid, cfg.rerank, i, RUNS);
+      for (const [scoring, res] of [["raw", raw], ["composite", composite]] as const) {
+        const agg = results[key][scoring];
+        agg.p3.push(res.p3); agg.mrr.push(res.mrr);
+        for (const k of Object.keys(res.byKind) as QueryKind[]) {
+          agg.byKind[k].p3.push(res.byKind[k].p3);
+          agg.byKind[k].mrr.push(res.byKind[k].mrr);
+        }
+        console.log(`  run ${i}/${RUNS} [${key}] scoring=${scoring}: p@3=${fmt(res.p3, 3)} MRR=${fmt(res.mrr, 3)}`);
+        if (VERBOSE) {
+          for (const row of res.rows) {
+            const status = row.rank < 0 ? "MISS" : row.rank < 3 ? "HIT " : "meh ";
+            console.log(`      ${status} rank=${row.rank < 0 ? ">k" : row.rank + 1}  [${row.kind}]  expect=${row.expectMarker}  q="${row.q.slice(0, 60)}"`);
+          }
+        }
+      }
+    }
+  }
+
+  // ── Report ──────────────────────────────────────────────────────────────
+  console.log(`\n══ AGGREGATE (mean ± SE over ${RUNS} run${RUNS > 1 ? "s" : ""}) ══\n`);
+  for (const cfg of configs) {
+    const key = `hybrid=${cfg.hybrid} rerank=${cfg.rerank}`;
+    console.log(`── ${key} ──`);
+    for (const scoring of ["raw", "composite"] as const) {
+      const agg = results[key][scoring];
+      const p3 = aggStats(agg.p3), mrr = aggStats(agg.mrr);
+      console.log(`  scoring=${scoring.padEnd(9)} p@3=${fmtAgg(p3)}   MRR=${fmtAgg(mrr)}`);
+    }
+    const rawP3 = aggStats(results[key].raw.p3), compP3 = aggStats(results[key].composite.p3);
+    const rawMrr = aggStats(results[key].raw.mrr), compMrr = aggStats(results[key].composite.mrr);
+    const dP3 = compP3.mean - rawP3.mean, dMrr = compMrr.mean - rawMrr.mean;
+    console.log(`  Δ (composite − raw)   p@3=${dP3 >= 0 ? "+" : ""}${fmt(dP3)}   MRR=${dMrr >= 0 ? "+" : ""}${fmt(dMrr)}`);
+    console.log(`  by kind (composite − raw p@3):`);
+    for (const k of ["stress", "trap", "hard", "clean"] as QueryKind[]) {
+      const r = aggStats(results[key].raw.byKind[k].p3), c = aggStats(results[key].composite.byKind[k].p3);
+      console.log(`    ${k.padEnd(6)} raw=${fmt(r.mean)}  composite=${fmt(c.mean)}  Δ=${(c.mean - r.mean) >= 0 ? "+" : ""}${fmt(c.mean - r.mean)}`);
+    }
+    console.log();
+  }
+
+  // ── Headline discrimination check (the ask this PR validates) ───────────
+  const primaryKey = `hybrid=true rerank=false`;
+  if (results[primaryKey]) {
+    const rawP3 = aggStats(results[primaryKey].raw.p3).mean, compP3 = aggStats(results[primaryKey].composite.p3).mean;
+    const rawMrr = aggStats(results[primaryKey].raw.mrr).mean, compMrr = aggStats(results[primaryKey].composite.mrr).mean;
+    const discriminates = compP3 < rawP3 || compMrr < rawMrr;
+    console.log(`HEADLINE (hybrid=true, the production default): composite p@3=${fmt(compP3)} vs raw p@3=${fmt(rawP3)}; composite MRR=${fmt(compMrr)} vs raw MRR=${fmt(rawMrr)}.`);
+    console.log(discriminates
+      ? "  → Corpus DISCRIMINATES: composite measurably underperforms raw, reproducing flair#623 in isolation."
+      : "  → Corpus did NOT discriminate this run — see README's 'if it doesn't discriminate' notes before trusting this config as safe.");
+  }
+}
+
+main().catch(e => {
+  console.error("FATAL:", e?.stack || e?.message || e);
+  if (!KEEP_ON_FAIL) console.error("(pass --keep-on-fail to leave a failed run's Harper installDir on disk for inspection)");
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

Adds `test/bench/recall-harness/` — an **isolated** recall-eval harness for Flair, closing a gap flagged by Flint: there was no safe way to measure a recall scoring/retrieval config change without either (a) hitting flint's LIVE production memory corpus (`recall-eval.mjs`, mutates `retrievalCount` on every query, ground truth rots) or (b) using a synthetic corpus so easy (4 maximally-distant clusters) that it caps p@3 at 1.0 and can't discriminate between configs (`recall-bench.mjs`).

**Never touches `~/ops/flair` or the live `:9926` service.** Built and validated entirely in a git worktree (`~/agents/flint/work/flair-evalharness`, now removed). Every measurement run spawns a fresh, fully ephemeral Harper instance (`test/helpers/harper-lifecycle.ts` — `mkdtemp` ROOTPATH/HOME, OS-assigned free ports), seeds it, measures, and tears it down.

**This PR is NOT to be merged** — it's a reviewable deliverable per the tasking. Opening as a normal PR (not draft) since CI should still run over it; will hold for explicit merge approval.

## What's in it

- **`corpus.ts`** — 87 records across 12 clusters, deliberately harder than `recall-bench.mjs`'s corpus along 3 axes: near-duplicate/adjacent record density within clusters, cross-cluster *lexical-overlap* trap clusters (e.g. `DBIDX` shares the word "index" with `FIN`'s index funds; `GARDEN` shares "branch" with `GIT`), and durability + `createdAt` spread across all 4 durability levels and ~2-110 days old. 30 ground-truth queries, each tagged `stress` / `trap` / `hard` / `clean` so the reasoning behind every pair is legible, not just asserted. Full design rationale is in the file's header.
- **`run.ts`** — the harness. Spawns ephemeral Harper, registers a synthetic agent, seeds the corpus via signed `TPS-Ed25519` requests (same pattern as `test/integration/bm25-hybrid-noquery-listing.test.ts`), measures p@3 + MRR for `scoring=raw` and `scoring=composite` against the same seeded instance, configurable via `--hybrid on|off|both` (`FLAIR_HYBRID_RETRIEVAL`) and `--rerank` (`FLAIR_RERANK_ENABLED`), repeated `--runs` times (default 3) for mean ± SE. Guards on `dist/resources/*.js` existing first (Harper loads compiled resources, not TS source — a fresh worktree/clone needs `npm run build` first; this cost me a debugging cycle, now a clear preflight error instead).
- **`README.md`** — usage, flags, how to interpret the output, and the measured numbers below.

Not swept into CI — `bun test` only globs `test/unit/`, `test/integration/`, `test/compat/`, `test/smoke/` (checked every `.github/workflows/*.yml`); this is a manually-invoked tool.

## Measured: does it discriminate? Yes — and it reproduces flair#623 in isolation

`--runs 3`, hybrid swept `true`/`false`. Zero variance across all 3 runs in both configs:

```
── hybrid=true rerank=false ──  (production default)
  scoring=raw       p@3=0.967 ± 0.000   MRR=0.892 ± 0.000
  scoring=composite p@3=0.067 ± 0.000   MRR=0.123 ± 0.000
  Δ (composite − raw)   p@3=-0.900   MRR=-0.769
  by kind: stress Δ=-1.000  trap Δ=-1.000  hard Δ=-0.667  clean Δ=-0.929

── hybrid=false rerank=false ──  (legacy path)
  scoring=raw       p@3=0.967 ± 0.000   MRR=0.892 ± 0.000
  scoring=composite p@3=0.067 ± 0.000   MRR=0.120 ± 0.000
  Δ (composite − raw)   p@3=-0.900   MRR=-0.772
  by kind: stress Δ=-1.000  trap Δ=-1.000  hard Δ=-0.833  clean Δ=-0.857
```

raw is a strong scorer on this corpus (only 1/30 queries misses top-3). composite collapses almost everywhere — not just the 7 deliberately-engineered `stress` pairs, but `trap` and `clean` queries too, which have zero adversarial design.

This is the same finding `624299c` ("default SemanticSearch scoring to raw, not composite", flair#623) shipped from a **live-corpus** measurement (Δp@3 -0.38 to -0.50) — reproduced here in isolation, on a harder purpose-built corpus, with a full embeddings+BM25+RRF pipeline instead of one mocked pair.

**Two things worth flagging beyond the original ask:**

1. **The magnitude here (-0.90) is larger than the live corpus's (-0.38 to -0.50).** I inspected the actual `_score`/`_rawScore` per candidate to confirm this is real, not a harness bug: for one query (expects `CONSENSUS::1`), composite's top 4 results are `CONSENSUS::8`, `DEPLOY::2`, `FIN::4`, `PLANT::3` — four *unrelated-cluster* records that all happen to share `durability: permanent, ageDays: 2` (no discount), ranked above the actually-correct, older/lower-durability answers. Because this corpus spreads durability/age across nearly every record (not just isolated pairs) and the embedding's known weak tail separation lets even off-topic records clear the semantic-candidate bar, *any* `permanent`/fresh record acts as a magnet across many queries, not just its "intended" one. Broader and more systemic than the single mocked-pair unit test shows.
2. **The effect is identical under `hybrid=false`** (legacy path) — p@3 0.067 both ways. `compositeScore`'s unconditional `dWeight × rFactor` multiplier is harmful on its own; it doesn't depend on BM25/RRF score-banding the way the commit's narrative framed it.

Full table, methodology, and caveats (retrievalCount drift within a run, HNSW run-to-run noise, the rerank knob's status) are in `README.md`.

## Test plan

- [x] Built in an isolated git worktree off `origin/main` — never touched `~/ops/flair` (the live server's cwd) or ran anything against the live `:9926` service.
- [x] `npm run build` + `npx tsc -p tsconfig.json --noEmit` clean on the new files (one pre-existing unrelated error in `resources/auth-middleware.ts`, not touched by this PR).
- [x] `bun run test/bench/recall-harness/run.ts --runs 1 --hybrid on` — verified wiring end-to-end against a real ephemeral Harper.
- [x] `bun run test/bench/recall-harness/run.ts --runs 3` (full sweep, hybrid true+false) — numbers above.
- [x] `--verbose` spot-check + a targeted raw-score/durability dump to confirm the composite collapse is the documented mechanism, not a bug in the harness's id/scoring wiring.
- [ ] Not merging per the tasking — open for review (Kern/Sherlock/Flint) only.

Co-authored by Flint (Claude Fable 5) via Claude Code.