### PR TITLE
fix(recall): relevance-gate compositeScore (flair#623 follow-up)

### DIFF
--- a/resources/SemanticSearch.ts
+++ b/resources/SemanticSearch.ts
@@ -55,21 +55,31 @@ export class SemanticSearch extends Resource {
   async post(data: any) {
     // Default scoring is "raw", not "composite" (flair#623 follow-up, measured
     // 2026-07-08). recall-eval on the live corpus with BM25 hybrid retrieval
-    // active (default since eb26890) showed composite is net-HARMFUL: Δp@3
-    // (composite − raw) = -0.38 to -0.50 across repeated runs, MRR 0.44→0.06-0.44.
-    // Root cause: compositeScore's durability-weight × recency-decay multiplier
-    // applies UNCONDITIONALLY (no relevance gate, unlike retrievalBoost's
-    // RBOOST_RELEVANCE_FLOOR — see ./scoring.ts), so a `permanent`-durability or
-    // freshly-created LOW-relevance record routinely outranks the objectively
-    // best-matching `persistent`/older record. This used to be a smaller effect
-    // when raw scores were more spread out; now that BM25+RRF fusion normalizes
-    // rawScore into a tight [0,1] band, the ±10-30% durability/recency multiplier
-    // is often bigger than the actual relevance gap between candidates, so it
-    // dominates the final ranking instead of nudging it. `scoring: "composite"`
-    // is still available (durability/recency/retrieval-aware re-ranking) for
-    // callers who explicitly opt in — it is no longer the default because it
-    // measurably hurts precision today. Re-run `recall-eval.mjs` before
-    // reconsidering this default if the compositeScore formula changes.
+    // active (default since eb26890) showed composite was net-HARMFUL at the
+    // time: Δp@3 (composite − raw) = -0.38 to -0.50 across repeated runs, MRR
+    // 0.44→0.06-0.44. Root cause: compositeScore's durability-weight ×
+    // recency-decay multiplier applied UNCONDITIONALLY (no relevance gate,
+    // unlike retrievalBoost's RBOOST_RELEVANCE_FLOOR), so a `permanent`
+    // -durability or freshly-created LOW-relevance record could outrank the
+    // objectively best-matching `persistent`/older record. Now that BM25+RRF
+    // fusion normalizes rawScore into a tight [0,1] band, an unbounded
+    // durability/recency multiplier is often bigger than the actual relevance
+    // gap between candidates.
+    //
+    // FIXED (flair#623 follow-up, 2026-07-08, see ./scoring.ts's
+    // COMPOSITE_DISCOUNT_FLOOR / COMPOSITE_RELEVANCE_FLOOR): compositeScore's
+    // durability/recency multiplier is now bounded to a small (~2%) nudge and
+    // relevance-gated, the same way RBOOST_CAP/RBOOST_RELEVANCE_FLOOR already
+    // bound the retrieval-popularity boost — `scoring: "composite"` no longer
+    // reproduces the magnet/inversion bug (recall-harness: p@3 and MRR both
+    // now match raw exactly on its 87-record corpus). The default REMAINS
+    // "raw" anyway: on that same corpus, a relevance-gated composite only
+    // MATCHES raw's precision, it doesn't beat it, so there is no measured
+    // upside to switching the default, only the (now-closed) downside risk
+    // for anyone who explicitly opts into "composite". Re-run
+    // recall-harness (test/bench/recall-harness/run.ts) and `recall-eval.mjs`
+    // before reconsidering this default if the compositeScore formula or
+    // corpus changes.
     const { agentId: bodyAgentId, q, queryEmbedding, tag, subject, subjects, limit = 10, includeSuperseded = false, scoring = "raw", minScore = 0, since, asOf } = data || {};
 
     // Authenticated identity lives on the Harper Resource context (getContext().request).

--- a/resources/scoring.ts
+++ b/resources/scoring.ts
@@ -46,13 +46,74 @@ export function retrievalBoost(retrievalCount: number): number {
 
 // flair#623 (2026-07-08): SemanticSearch.ts's `scoring` param now DEFAULTS to
 // "raw" — compositeScore measurably HURTS recall-eval precision on the live
-// corpus (Δp@3 -0.38 to -0.50 vs raw). Unlike rBoost above, dWeight and rFactor
-// apply UNCONDITIONALLY — no relevance-floor gate — so they can (and do) sink a
-// clearly-best semantic/BM25 match below a `permanent`/fresh but weaker match.
-// compositeScore itself is UNCHANGED here; it's still opt-in via scoring:
-// "composite" for callers who want durability/recency-aware re-ranking. If this
-// formula ever gets a relevance-gated dWeight/rFactor (the rBoost-style fix),
-// re-run recall-eval.mjs before reconsidering the default.
+// corpus (Δp@3 -0.38 to -0.50 vs raw). recall-harness's harder 87-record
+// corpus (test/bench/recall-harness) reproduced this in isolation at Δp@3
+// -0.900: dWeight and rFactor applied UNCONDITIONALLY — no relevance-floor
+// gate, unlike rBoost above — so an unrelated-but-`permanent`/fresh record
+// (dWeight=1.0 × rFactor=1.0, no discount at all) routinely outranked the
+// objectively best match once its `standard`/`persistent`, weeks-old
+// durability/recency discount cut 30-95% off its score.
+//
+// FIRST ATTEMPT (kept here as a documented dead end — do not re-introduce):
+// gate dWeight×rFactor by ramping it from neutral-at-floor to
+// full-strength-at-rawScore=1.0, mirroring rBoost's floor gate. Measured
+// WORSE than the original bug (p@3 0.033 vs 0.067) on recall-harness. Root
+// cause: the records compositeScore actually needs to protect are the
+// GENUINELY relevant ones, and a genuine match has a HIGH rawScore (0.9+ on
+// this corpus, not near the 0.5 floor) — so ramping the gate open as
+// rawScore rises means the *correct* answer gets the discount at nearly full
+// strength (gate≈1), while the discount was already a no-op for the
+// magnet distractors (permanent/fresh ⇒ dWeight×rFactor=1.0 regardless of any
+// gate). Ramping-by-relevance is backwards for a DISCOUNT-only multiplier: it
+// protects weak/borderline matches that were never the problem, and does
+// nothing for the strong matches that were.
+//
+// THE ACTUAL FIX: treat dWeight×rFactor the same way RBOOST_CAP treats
+// retrievalBoost — bound it to a small band around 1.0 (a gentle nudge, not
+// an override) via COMPOSITE_DISCOUNT_FLOOR, so durability/recency can never
+// cost a record more than a fixed, small percentage regardless of how stale
+// or low-durability it is. The RBOOST_RELEVANCE_FLOOR-style gate is layered
+// on top per its original intent (no adjustment at all for records that
+// don't even clear a basic relevance bar) but the CAP is what actually stops
+// the magnet: even a `standard`/95-day-old correct answer now loses at most
+// (1 - COMPOSITE_DISCOUNT_FLOOR) of its score, never the 30-95% the
+// unconditional formula could take.
+//
+// COMPOSITE_DISCOUNT_FLOOR (env: FLAIR_COMPOSITE_DISCOUNT_FLOOR) and
+// COMPOSITE_RELEVANCE_FLOOR (env: FLAIR_COMPOSITE_RELEVANCE_FLOOR, default
+// 0.5, same value as RBOOST_RELEVANCE_FLOOR): below the relevance floor the
+// durability/recency multiplier is fully neutral (1.0); at/above it, the
+// multiplier is dWeight×rFactor linearly remapped from its native [0,1] range
+// into [COMPOSITE_DISCOUNT_FLOOR, 1.0] — so a `permanent`+fresh record still
+// scores strictly higher than a `standard`+stale one among relevant
+// candidates (durability/recency remains a real, monotonic signal), but
+// never by more than the bounded amount.
+//
+// DISCOUNT_FLOOR_DEFAULT = 0.98 (max -2%) was tuned empirically against
+// recall-harness's 87-record corpus (test/bench/recall-harness/run.ts,
+// hybrid=true, 3 runs, deterministic/±0.000 SE on this corpus): 0.9 (max
+// -10%, symmetric with RBOOST_CAP's +10%) recovered p@3 to match raw exactly
+// (0.967) but MRR still trailed raw by -0.150 (0.742 vs 0.892) — the bounded
+// discount was still large enough to occasionally reorder within the top-3,
+// just not enough to push the right answer OUT of it. 0.95 narrowed the MRR
+// gap to -0.078. 0.98 closed it to +0.000 on both metrics across all 3 runs
+// — this corpus's RRF-normalized rawScore band is tight enough that even a
+// 5-10% durability/recency swing is bigger than the real relevance gap
+// between candidates. Re-run recall-harness (and recall-eval.mjs on the live
+// corpus) before changing this default or reconsidering scoring defaults.
+export const COMPOSITE_RELEVANCE_FLOOR_DEFAULT = 0.5;
+export const COMPOSITE_DISCOUNT_FLOOR_DEFAULT = 0.98; // max -2% — tuned to fully close the gap to raw on recall-harness
+
+export function getCompositeRelevanceFloor(): number {
+  const v = Number(process.env.FLAIR_COMPOSITE_RELEVANCE_FLOOR);
+  return Number.isFinite(v) && v >= 0 && v <= 1 ? v : COMPOSITE_RELEVANCE_FLOOR_DEFAULT;
+}
+
+export function getCompositeDiscountFloor(): number {
+  const v = Number(process.env.FLAIR_COMPOSITE_DISCOUNT_FLOOR);
+  return Number.isFinite(v) && v >= 0 && v <= 1 ? v : COMPOSITE_DISCOUNT_FLOOR_DEFAULT;
+}
+
 export function compositeScore(
   semanticScore: number,
   record: { durability?: string; createdAt?: string; retrievalCount?: number; supersedes?: string },
@@ -64,5 +125,15 @@ export function compositeScore(
   // this query (semanticScore clears the floor). Below the floor, a popular doc gets
   // no lift — kills the cross-query magnet while preserving boosts for relevant docs.
   const rBoost = semanticScore >= RBOOST_RELEVANCE_FLOOR ? retrievalBoost(record.retrievalCount ?? 0) : 1.0;
-  return semanticScore * dWeight * rFactor * rBoost;
+
+  // Bound dWeight×rFactor into [discountFloor, 1.0] (a gentle nudge, mirroring
+  // RBOOST_CAP), then relevance-gate it (mirroring RBOOST_RELEVANCE_FLOOR): no
+  // adjustment at all below the floor, the bounded nudge at/above it.
+  const discountFloor = getCompositeDiscountFloor();
+  const dWeightRecency = dWeight * rFactor; // native range ~[0, 1]
+  const boundedDWeightRecency = discountFloor + (1 - discountFloor) * dWeightRecency; // remapped to [discountFloor, 1]
+  const relevanceFloor = getCompositeRelevanceFloor();
+  const gatedDWeightRecency = semanticScore >= relevanceFloor ? boundedDWeightRecency : 1.0;
+
+  return semanticScore * gatedDWeightRecency * rBoost;
 }

--- a/test/unit/semantic-search-scoping.test.ts
+++ b/test/unit/semantic-search-scoping.test.ts
@@ -275,10 +275,14 @@ describe("SemanticSearch.post() — centralized read-scoping", () => {
 
     const s = makeSearch(agentCtx("agent-1"));
 
-    // Sanity check: scoring="composite" still reproduces the known bug
-    // (available as an explicit opt-in) — the weaker match wins.
+    // flair#623 follow-up (2026-07-08): compositeScore's durability/recency
+    // multiplier is now bounded + relevance-gated (resources/scoring.ts,
+    // COMPOSITE_DISCOUNT_FLOOR), so scoring="composite" no longer reproduces
+    // the bug either — the objectively-best match wins under BOTH modes now.
+    // raw remains the default (below); composite is merely no longer
+    // catastrophic for anyone who opts in.
     const composite: any = await s.post({ agentId: "agent-1", q: "widget", scoring: "composite", limit: 10 });
-    expect(composite.results[0]?.id).toBe("m-weak-raw-match-permanent");
+    expect(composite.results[0]?.id).toBe("m-best-raw-match");
 
     // scoring="raw" ranks by actual relevance — the strong match wins.
     const raw: any = await s.post({ agentId: "agent-1", q: "widget", scoring: "raw", limit: 10 });

--- a/test/unit/temporal-scoring.test.ts
+++ b/test/unit/temporal-scoring.test.ts
@@ -3,7 +3,7 @@ import { describe, test, expect } from "bun:test";
 // previously re-declared them ("they're not exported, so we test the logic
 // independently") — a simulator that could not catch changes to the real module.
 // The functions are now exported so these tests exercise the shipped code.
-import { recencyFactor, retrievalBoost, compositeScore } from "../../resources/scoring.ts";
+import { recencyFactor, retrievalBoost, compositeScore, getCompositeDiscountFloor } from "../../resources/scoring.ts";
 
 const now = () => new Date().toISOString();
 
@@ -90,5 +90,42 @@ describe("composite scoring (OPS-AYGD: relevance-floor gate)", () => {
     const score = compositeScore(0.8, { createdAt: now() });
     const explicit = compositeScore(0.8, { durability: "standard", createdAt: now() });
     expect(Math.abs(score - explicit)).toBeLessThan(0.01);
+  });
+});
+
+describe("composite scoring (flair#623 follow-up: bounded + relevance-gated dWeight/rFactor)", () => {
+  // recall-harness's stress-pair shape (test/bench/recall-harness/corpus.ts):
+  // a `standard`/weeks-old CORRECT match vs a `permanent`/2-day-old, adjacent
+  // -but-wrong DISTRACTOR, both clearing the relevance floor. This is the
+  // exact mechanism that collapsed composite p@3 to 0.067 pre-fix.
+  test("REGRESSION GUARD: a high-relevance stale/standard match still outranks a lower-relevance permanent/fresh distractor", () => {
+    const oldStandardDaysAgo = new Date(Date.now() - 75 * 24 * 3600_000).toISOString();
+    const freshPermanent = new Date(Date.now() - 2 * 24 * 3600_000).toISOString();
+    const correct = compositeScore(0.984, { durability: "standard", createdAt: oldStandardDaysAgo });
+    const distractor = compositeScore(0.871, { durability: "permanent", createdAt: freshPermanent });
+    expect(correct).toBeGreaterThan(distractor);
+  });
+
+  test("the durability/recency discount is bounded — it can never exceed (1 - discountFloor) of rawScore", () => {
+    const floor = getCompositeDiscountFloor();
+    // Worst case: ephemeral (lowest dWeight) and maximally decayed (rFactor -> 0).
+    const ancient = new Date(Date.now() - 10_000 * 24 * 3600_000).toISOString();
+    const worstCase = compositeScore(0.9, { durability: "ephemeral", createdAt: ancient });
+    expect(worstCase).toBeGreaterThanOrEqual(0.9 * floor - 1e-9);
+  });
+
+  test("durability/recency remains a monotonic (if bounded) signal among relevant candidates", () => {
+    const n = now();
+    const perm = compositeScore(0.8, { durability: "permanent", createdAt: n });
+    const std = compositeScore(0.8, { durability: "standard", createdAt: n });
+    const eph = compositeScore(0.8, { durability: "ephemeral", createdAt: n });
+    expect(perm).toBeGreaterThanOrEqual(std);
+    expect(std).toBeGreaterThanOrEqual(eph);
+  });
+
+  test("below the relevance floor, the durability/recency multiplier is fully neutral (no discount at all)", () => {
+    const oldEphemeral = new Date(Date.now() - 1000 * 24 * 3600_000).toISOString();
+    const belowFloor = compositeScore(0.2, { durability: "ephemeral", createdAt: oldEphemeral });
+    expect(belowFloor).toBeCloseTo(0.2, 5); // multiplier === 1.0, unlike a naive floor-less discount
   });
 });


### PR DESCRIPTION
## Summary

`compositeScore` (`resources/scoring.ts`) applied its durability-weight x
recency-decay multiplier **unconditionally** — no relevance floor, unlike
`retrievalBoost`'s existing `RBOOST_RELEVANCE_FLOOR`. On recall-harness's
harder 87-record corpus (`test/bench/recall-harness`, added in #661) this
was catastrophic: a `permanent`/fresh but topically-unrelated record
(`dWeight=1.0 x rFactor=1.0`, no discount at all) routinely outranked the
objectively best match once its `standard`/`persistent`, weeks-old
durability/recency discount cut 30-95% off its score.

**DO NOT MERGE** — opening for review/numbers first per Nathan's request.
`raw` remains the recommended default; this PR does not change
`SemanticSearch.ts`'s default `scoring` param.

## What was tried

**First attempt (documented as a dead end in the code, not re-added):** gate
`dWeight x rFactor` by ramping it from neutral-at-the-floor to
full-strength-at-`rawScore=1.0`, literally mirroring `rBoost`'s floor gate.
Measured **worse** than the original bug (p@3 0.033 vs 0.067). Root cause:
a genuine match on this corpus has a HIGH rawScore (0.9+, not near the 0.5
floor), so ramping the gate open as rawScore rises applies the discount at
nearly full strength exactly to the records that most need protecting,
while doing nothing for the magnet distractors (already undiscounted
because `permanent`+fresh -> `dWeight x rFactor = 1.0` regardless of any
gate). Ramping-by-relevance is backwards for a discount-only multiplier.

**The actual fix:** bound `dWeight x rFactor` into a small band around 1.0
(`COMPOSITE_DISCOUNT_FLOOR`), the same way `RBOOST_CAP` bounds the
retrieval-popularity boost, then relevance-gate it
(`COMPOSITE_RELEVANCE_FLOOR`, default 0.5, same value as
`RBOOST_RELEVANCE_FLOOR`): no adjustment below the floor, the bounded nudge
at/above it. Both are env-overridable
(`FLAIR_COMPOSITE_DISCOUNT_FLOOR` / `FLAIR_COMPOSITE_RELEVANCE_FLOOR`).

`COMPOSITE_DISCOUNT_FLOOR` default was tuned empirically against
recall-harness (hybrid=true, 3 runs, deterministic/±0.000 SE on this
corpus):

| discount floor | p@3 (composite) | MRR (composite) | Δp@3 vs raw | ΔMRR vs raw |
|---|---|---|---|---|
| unbounded (pre-fix) | 0.067 | 0.123 | -0.900 | -0.769 |
| 0.90 (max -10%, symmetric w/ RBOOST_CAP) | 0.967 | 0.742 | +0.000 | -0.150 |
| 0.95 (max -5%) | 0.967 | 0.814 | +0.000 | -0.078 |
| **0.98 (max -2%, chosen default)** | **0.967** | **0.892** | **+0.000** | **+0.000** |

This corpus's RRF-normalized rawScore band is tight enough that even a
5-10% durability/recency swing is bigger than the real relevance gap
between candidates — only a ~2% ceiling fully closes the gap.

## Measured results (recall-harness, full sweep: hybrid on+off, 3 runs each, deterministic)

```
── hybrid=true rerank=false ── (the production default)
  scoring=raw       p@3=0.967 ± 0.000   MRR=0.892 ± 0.000
  scoring=composite p@3=0.967 ± 0.000   MRR=0.892 ± 0.000
  Δ (composite − raw)   p@3=+0.000   MRR=+0.000
  by kind: stress/trap/hard/clean all Δ=+0.000

── hybrid=false rerank=false ── (legacy path)
  scoring=raw       p@3=0.967 ± 0.000   MRR=0.892 ± 0.000
  scoring=composite p@3=0.967 ± 0.000   MRR=0.897 ± 0.000
  Δ (composite − raw)   p@3=+0.000   MRR=+0.006
  by kind: stress/trap/hard/clean all Δ=+0.000

HEADLINE (hybrid=true): composite p@3=0.967 vs raw p@3=0.967;
composite MRR=0.892 vs raw MRR=0.892 — corpus did NOT discriminate
(matches raw exactly).
```

Before this fix, the same harness (see #661's README) measured composite
p@3=0.067 vs raw=0.967 (Δ-0.900) under hybrid=true.

## Recommendation

Gated composite **matches** raw — no measured upside to flipping the
default, only the (now-closed) downside for anyone who explicitly opts
into `scoring: "composite"`. Recommend:
- Keep `raw` as the default (unchanged from #660).
- Merge this so `scoring: "composite"` is safe rather than catastrophic
  for any caller who sets it.

## What changed

- `resources/scoring.ts`: `compositeScore` now bounds+gates the
  durability/recency multiplier (`COMPOSITE_DISCOUNT_FLOOR` /
  `COMPOSITE_RELEVANCE_FLOOR`, both env-overridable). Full reasoning and
  the documented dead-end are in the code comment.
- `resources/SemanticSearch.ts`: updated the header comment above `post()`
  to reflect the fix (no behavior change — default is still `raw`).
- `test/unit/temporal-scoring.test.ts`: new regression-guard tests for the
  bounded/gated behavior (stress-pair magnet scenario, bound invariant,
  monotonicity, below-floor neutrality). All pre-existing tests pass
  unchanged (verified by hand before editing — the bound/gate doesn't
  perturb any of them).
- `test/unit/semantic-search-scoping.test.ts`: updated one assertion that
  had explicitly locked in the old bug as a "sanity check" — composite no
  longer reproduces it, so the test now asserts composite gets it right
  too (while the actual regression test for the *default* being `raw`,
  not `composite`, is unchanged and still passes).

## Test plan

- [x] `bun test test/unit/` — 1935 pass, 0 fail (full unit suite, incl.
      updated scoring tests)
- [x] `bun test test/integration/semantic-search-singleton-score.test.ts
      test/integration/supersede-recall-resurface.test.ts` — 2 pass (the
      only integration tests touching the `scoring` param; both use
      `scoring: "raw"` explicitly, unaffected either way, run for safety)
- [x] `test/bench/recall-harness/run.ts` full sweep (hybrid on+off, 3 runs
      each) — see numbers above
- [ ] Kern/Sherlock review (not yet requested — opening for numbers review
      first per the task; DO NOT MERGE until asked)

🤖 Generated with [Claude Code](https://claude.com/claude-code)