### PR TITLE
ci: upgrade-smoke exercises the real upgrade path on every PR (#620)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -368,12 +368,25 @@ jobs:
           HEAD_VERSION=$(node -p "require('$GITHUB_WORKSPACE/package.json').version")
           echo "Baseline: $BASELINE — HEAD: $HEAD_VERSION"
 
-          # Same-version runs (e.g. a PR that hasn't bumped) are a no-op test;
-          # we still assert the install worked, but skip the upgrade assertion
-          # because there's no "previous" to upgrade from.
+          # flair#620: this used to skip the entire upgrade-verify path whenever
+          # $BASELINE == $HEAD_VERSION (true on every ordinary feature PR that
+          # hasn't bumped package.json — the vast majority of PRs), so the real
+          # cross-version data-survival path only ever ran at release-bump PRs.
+          # That's backwards: the code under test on a feature PR differs from
+          # published-latest regardless of whether the *semver string* moved —
+          # a feature PR can still change the daemon start/stop sequence, the
+          # reembed migration, storage schema, etc. The invariant we care about
+          # (HEAD's binary must start cleanly against baseline's on-disk data
+          # and not lose or corrupt memories) has nothing to do with whether
+          # someone remembered to bump the version. So: no early exit — always
+          # install published-latest as baseline, pack+install HEAD's actual
+          # built tarball as the upgrade target, and run the full sequence.
+          # The one no-op case left (baseline tag == this exact HEAD commit,
+          # e.g. a re-run against an unchanged tree) still exercises install +
+          # start + reembed + round-trip; it just isn't testing a *content*
+          # diff, and that's an acceptable, rare edge rather than the default.
           if [ "$BASELINE" = "$HEAD_VERSION" ]; then
-            echo "Baseline == HEAD; nothing to upgrade. Passing trivially."
-            exit 0
+            echo "Note: BASELINE version string ($BASELINE) == HEAD package.json version. This PR hasn't bumped semver, but HEAD's packed tarball is still this PR's actual code — running the full upgrade-verify path against it, not skipping."
           fi
 
           BASE_FLAIR="node $BASE_DIR/node_modules/@tpsdev-ai/flair/dist/cli.js"


### PR DESCRIPTION
## Root cause

`upgrade-smoke` (`.github/workflows/test.yml`) always runs as a job on every PR (no job-level `if:` gate) — but the shell script inside it gated the entire install→seed→upgrade→verify sequence on a version-string comparison:

```sh
BASELINE=$(node -p "require('@tpsdev-ai/flair/package.json').version")   # npm-latest
HEAD_VERSION=$(node -p "require('$GITHUB_WORKSPACE/package.json').version")  # this PR
if [ "$BASELINE" = "$HEAD_VERSION" ]; then
  echo "Baseline == HEAD; nothing to upgrade. Passing trivially."
  exit 0
fi
```

Ordinary feature PRs don't bump `package.json`, so `BASELINE == HEAD_VERSION` on the vast majority of merges — meaning the real cross-version data-survival path (seed data at baseline → stop → install HEAD → start against baseline's data → reembed → verify nothing was lost) only ever ran at version-bump/release PRs. That's exactly backwards: upgrade data-loss is the highest-blast-radius failure mode in the system, and it was being tested at release cadence (every few weeks) instead of every PR. This is precisely how the npm-arborist/`flair-stop`-SIGTERM race (flair#611, npm/cli#4907) went undetected until the 0.21.0 release cut — it was the first time in a while `BASELINE != HEAD_VERSION` was true.

## Fix

Removed the early `exit 0`. The invariant under test — HEAD's binary must start cleanly against baseline's on-disk data without losing or corrupting memories — has nothing to do with whether someone remembered to bump semver; a feature PR's packed tarball is genuinely different code regardless of the version string. Now:

- Baseline is always installed from published npm-latest (unchanged).
- HEAD is always packed from the PR's actual tree and installed fresh (unchanged fresh-directory-install pattern from the earlier flair#611 fix, avoiding the arborist in-place-reify race).
- The full seed → stop → upgrade → start → reembed → verify sequence always runs, on every PR.
- When `BASELINE == HEAD_VERSION` (no semver bump — the common case), a note is logged instead of skipping, since the tarball being installed is still this PR's real code.

## Validation

This host (rockit) runs the live production Flair server, whose default data directory (`~/.flair`, via `os.homedir()`) is this same machine's `$HOME` — so I deliberately did **not** spin up a real `flair init/start/stop` here (there's also a known Bun-ignores-`HOME`-mutation gotcha that's burned an admin-pass rotation before; env-based isolation isn't reliable for this binary).

Instead:
- `.github/workflows/test.yml` validated as well-formed YAML and passed `actionlint` (the only findings — 2 pre-existing shellcheck SC2086 nits elsewhere in the file — are unchanged from `main`, confirmed by diffing actionlint output before/after this change).
- Built a control-flow harness that mirrors the exact updated script but swaps every real `flair` binary call for a harmless stub (no real Harper daemon, no real `~/.flair` writes, no registry writes) and ran it against the **actual current real-world state of this repo right now**: published npm-latest is `0.21.0` and this branch's `package.json` is also `0.21.0` (no bump) — i.e. exactly the scenario flair#620 describes as silently skipped. Result: all 6 steps (init, seed marker, stop, "upgrade", start, reembed, verify pre-marker survives, verify new write round-trips) executed to completion with no early exit.
- Reproduced the counterfactual: running the *old* early-exit logic against the same real `BASELINE`/`HEAD_VERSION` values does short-circuit at `exit 0` before touching init/seed/upgrade/verify at all — confirming the bug was real and is now fixed.
- The actual functional install-upgrade-verify (real Harper daemon, real reembed, real semantic search round-trip) will run for real once this PR's CI executes `upgrade-smoke` on GitHub's ephemeral `ubuntu-latest` runner — the safe, isolated place this check is designed to run, and now it'll do so on *this* PR instead of no-op'ing.

## Acceptance criteria (flair#620)

- [x] `upgrade-smoke` runs its full real (non-no-op) path on a normal feature PR, using published-latest as the baseline — verified structurally above; will additionally self-verify when this PR's own CI runs.
- [x] The arborist/flair-stop SIGTERM class of bug (or an equivalent regression) would now be caught on a feature PR, not only at a version-bump PR — the full sequence, including the stop→fresh-install→start choreography that surfaced flair#611, now always executes.

Not merging — opening for review per the K&S gate.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>