### PR TITLE
docs(cli): correct stale ops-API authorizeLocal comments (flair#654)

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -866,10 +866,13 @@ function readHarperPid(dataDir: string): number | null {
  * Seed an agent record via the Harper operations API.
  * Accepts either a port number (localhost) or a full URL string (--target).
  *
- * `adminPass` is typed as optional but in practice the Harper operations API
- * always requires Basic admin auth — every existing call site passes one.
- * The optional signature leaves headroom for a future Harper that honors
- * `authorizeLocal` on its ops endpoint; until then, callers must pass it.
+ * `adminPass` is optional: a local caller may omit it and ride Harper's
+ * `authorizeLocal`, which auto-authorizes a header-less loopback request to
+ * the ops port as super_user (current behavior, verified by live probe —
+ * flair#610). When passed, the helper sends Basic admin auth so it never
+ * depends on that ambient elevation and behaves identically against a remote
+ * or hardened instance. Hardening the ops-API loopback posture is tracked in
+ * flair#654.
  */
 export async function seedAgentViaOpsApi(
   opsPortOrUrl: number | string,
@@ -933,10 +936,12 @@ export async function seedAgentViaOpsApi(
 // admin:admin-pass), not the REST API (which needs server-side HDB_ADMIN_PASSWORD
 // — unavailable on Fabric).  Same pattern as seedAgentViaOpsApi above.
 //
-// `adminPass` is optional in the signature for symmetry with seedAgentViaOpsApi
-// and to keep the door open for a future Harper that honors authorizeLocal on
-// its ops endpoint. Today the Harper operations API always requires Basic admin
-// auth; every current caller passes it.
+// `adminPass` is optional (symmetry with seedAgentViaOpsApi): a local caller may
+// omit it and ride authorizeLocal, which the Harper ops API honors today — a
+// header-less loopback request is auto-authorized as super_user (flair#610).
+// When passed, the helper sends Basic admin auth so it never depends on that
+// ambient elevation and behaves identically against a remote or hardened
+// instance. Hardening that posture is tracked in flair#654.
 
 export async function seedFederationInstanceViaOpsApi(
   opsPortOrUrl: number | string,


### PR DESCRIPTION
Corrects two stale, self-contradictory docstrings in src/cli.ts that claimed the Harper operations API "always requires Basic admin auth" and framed authorizeLocal support as a future Harper.

## Reality (verified live)

Unauth POST to the ops port (127.0.0.1:9925) with operation system_information and no auth header returns HTTP 200 — the current Harper already honors authorizeLocal for header-less loopback, auto-authorizing as super_user. So the "always requires Basic admin auth" / "future Harper" framing is wrong.

## What changed

- The seedAgentViaOpsApi docstring and the seedFederationInstanceViaOpsApi comment are rewritten to state that adminPass is optional precisely so a local caller can omit it and ride authorizeLocal (current behavior), and that when passed, the helpers send Basic admin auth so they never depend on that ambient elevation and behave identically against a remote or hardened instance.
- This resolves an internal contradiction: each function's own inline comment already says callers may omit adminPass on local targets with authorizeLocal, which the old docstrings denied.
- Aligns with the already-correct resolveAuthHeader note earlier in the file.

Comment-only. No behavior change. The ops-API loopback hardening arc (bind scope, disabling authorizeLocal) remains tracked in flair#654; this PR handles only the "correct the false comment now, independent of the config work" item from that issue.
