### PR TITLE
ci: extend strict typecheck to src/** (#643)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -510,6 +510,14 @@ jobs:
       # so harper's raw .ts internals don't pollute the output)
       - name: Type check root (resources)
         run: npx tsc --noEmit -p tsconfig.check.json
+      # Root src/ (CLI, probe, fleet-verify, deploy, bridges, etc. — everything
+      # under src/ EXCEPT cli.ts, which stays on tsconfig.cli.json's strict:false
+      # until #622 splits the monolith). Closes #643: src/** previously had zero
+      # strict coverage — tsconfig.check.json only ever covered resources/**, so a
+      # module like src/probe.ts or src/fleet-verify.ts could regress without CI
+      # noticing. Verified strict-clean with zero errors before wiring this in.
+      - name: Type check root src (strict, excl. cli.ts — #622)
+        run: npx tsc --noEmit -p tsconfig.check.src.json
       # Root CLI entry point (tsconfig.cli.json — strict: false, matches build:cli)
       - name: Type check root CLI
         run: npx tsc --noEmit -p tsconfig.cli.json

--- a/tsconfig.check.src.json
+++ b/tsconfig.check.src.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "outDir": "dist",
+    "rootDir": ".",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules", "dist", "test", "src/cli.ts"]
+}


### PR DESCRIPTION
## Summary

Closes #643. `tsconfig.check.json` only ever covered `resources/**`, so the CLI, probe, fleet-verify, deploy, and bridges modules under `src/` had zero strict type coverage in CI beyond what `build:cli` (`strict:false`) implied — a new strict-clean module under `src/` (e.g. `src/probe.ts`) could regress silently.

## What changed

- **New `tsconfig.check.src.json`**: `strict: true` over `src/**/*.ts`, excluding only `src/cli.ts` (kept on `tsconfig.cli.json`'s `strict:false` until #622 splits that monolith). `src/cli-shim.cts` is naturally out of scope too — same `*.ts`-only include pattern already used by `tsconfig.check.json` and `tsconfig.cli.json`, so no separate exclude was needed for it. (`cli-shim.cts` also dynamically imports `./cli.js`, so it can't be typechecked apart from `cli.ts` anyway.)
- **`.github/workflows/test.yml`**: added a `Type check root src (strict, excl. cli.ts — #622)` step to the existing `Type Check (strict)` job (`typecheck-strict`), right after the existing "Type check root (resources)" step. Same job, same gate — a strict-mode regression anywhere in `src/**` (minus `cli.ts`) now fails CI.

## Step-4 result (per spec): all-clean, no exclusions needed

Ran `npx tsc --noEmit -p tsconfig.check.src.json` locally against all 37 non-`cli.ts`/`cli-shim.cts` files under `src/` — **zero errors, exit 0**. This includes `src/probe.ts`, `src/fleet-verify.ts`, `src/deploy.ts`, `src/fabric-upgrade.ts`, `src/fleet-presence.ts`, `src/keystore.ts`, `src/observatory-sync.ts`, `src/render.ts`, `src/version-check.ts`, `src/doctor-client.ts`, `src/install/clients.ts`, all of `src/rem/**` (4 files), and all of `src/bridges/**` (21 files, including `builtins/` and `runtime/`).

No source changes were needed — the issue's premise held: these modules were already strict-clean, just never gated.

Also verified locally, unaffected by this change:
- `bun run build` / `bun run build:cli` — clean
- Existing `tsconfig.check.json` (resources) and `tsconfig.cli.json` (cli.ts) — still pass
- Workspace packages `tsc --noEmit` loop (flair-client, flair-mcp, langgraph-flair, n8n-nodes-flair, openclaw-flair, pi-flair) — all pass
- `bun test test/unit/` — 1935 pass, 0 fail (expected: no source changes)

## Test plan

- [x] `npx tsc --noEmit -p tsconfig.check.src.json` — 0 errors
- [x] `npx tsc --noEmit -p tsconfig.check.json` — 0 errors (unaffected)
- [x] `npx tsc --noEmit -p tsconfig.cli.json` — 0 errors (unaffected)
- [x] `bun run build && bun run build:cli` — clean
- [x] Workspace packages `tsc --noEmit` loop — clean
- [x] `bun test test/unit/` — 1935 pass, 0 fail
- [ ] CI green on this PR (not yet observed — PR just opened)

Not merging — flagged for review per team process (K&S + CI gate).

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>