### PR TITLE
docs(security): document ops-API auth surfaces + owner-only socket admin channel (#654)

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -41,6 +41,17 @@ explicitly via `--admin-pass-file`, `FLAIR_ADMIN_PASS`, or
 [docs/secrets-and-keys.md](docs/secrets-and-keys.md) for the full
 precedence and rotation model.
 
+The Harper **operations API** is the admin/management surface. Network
+requests to it require admin Basic auth: Flair ships with
+`authorizeLocal: false`, so an unauthenticated loopback request is
+rejected (`401`) instead of being auto-elevated to super_user. The same
+API is also reachable over a Unix **domain socket**
+(`~/.flair/data/operations-server`, owner-write-only), which Harper
+treats as an inherent local-admin channel — a request over the socket is
+authorized as super_user **without** credentials. This is by design (the
+admin-password rotation flow relies on it) and is constrained to the box
+owner; see Threats NOT Mitigated below.
+
 ## Data Scoping
 
 ### Memory Read/Write Model
@@ -119,6 +130,13 @@ public key in Flair, and backs up the old key as `<agentId>.key.bak`.
   process could extract them.
 - **Network sniffing:** Flair uses HTTP by default. Use HTTPS in
   production or restrict to localhost.
+- **Same-OS-user ops-API socket access:** the operations-API domain
+  socket (`operations-server`, owner-write-only) is an unauthenticated
+  super_user channel by Harper design — any process running as the box
+  owner can perform admin operations through it (the admin-password
+  rotation flow uses this path). Owner-write permissions keep it
+  unreachable by other OS users, co-tenants, and the network; isolate
+  untrusted workloads to separate OS users.
 
 ## Recommendations
 


### PR DESCRIPTION
Documents the operations-API security posture, per the #654 accept+document resolution (the domain-socket residual is accepted, not hardened — locking it would break the admin-password rotation flow).

## What's added
- **Admin Authentication:** the Harper operations API requires admin Basic auth for network requests (Flair ships `authorizeLocal: false`, so an unauthenticated loopback request returns `401`), while the operations-API domain socket (`operations-server`, owner-write-only) is an inherent local-admin channel that authorizes as super_user *without* credentials — by design, and relied upon by admin-password rotation.
- **Threats NOT Mitigated:** a same-OS-user bullet — any process running as the box owner can perform admin operations through the socket; owner-write permissions keep it unreachable by other OS users, co-tenants, and the network; isolate untrusted workloads to separate OS users.

Docs-only. No port numbers cited (they're on the legacy-port list) — the note is port-agnostic. `docs-freshness-check` passes locally.
