### PR TITLE
perf(bootstrap): bounded queries replace org-wide memory scan

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ## [Unreleased]
 
+### ⚡ Bootstrap scale fix — bounded queries replace the org-wide memory scan
+
+`MemoryBootstrap.post()` loaded the entire org's non-private Memory corpus into RAM on every bootstrap call (an unbounded `Memory.search()` — no `limit`/`select`, every row's full 768-float embedding vector included) then ran a hand-rolled O(N·d) JS dot-product scan over all of it. Both scaled with the size of the whole org's memory corpus, not the caller's own — a liability on a hot, every-session path that got worse as collision surfacing (flair#681) and open-within-org reads (flair#578) widened the scanned set.
+
+- **Extracted a pure retrieval core** (`resources/semantic-retrieval-core.ts`, `retrieveCandidates()`) from `SemanticSearch.post()` — the HNSW/BM25 retrieval + all post-retrieval filtering (temporal/expiry/supersede exclusion, the `scope.isAllowed()` defense-in-depth re-check), taking primitives only, never a Resource instance. Auth, rate-limiting, the reranker, and the `retrievalCount`/`lastRetrieved` hit-tracking side effects stay in `SemanticSearch.post()`'s wrapper, so bootstrap's internal call never trips them. `SemanticSearch`'s own behavior is unchanged (full unit-test suite green; the isolated recall-harness returns byte-identical p@3/MRR before and after).
+- **Own-scoped pushdowns** for the permanent/recent/predicted lifecycle slices: `Memory.search` calls conditioned on `agentId==self` (+ durability/createdAt, all `@indexed`), explicit `select` (no raw embedding) — replacing the post-load JS filter over the full org corpus.
+- **Bounded HNSW candidate pool** for task-relevant/teammate/collision surfaces via the same `retrieveCandidates()` core — HNSW-leg pushdown only (no BM25 fusion, no reranker; a different, likely-worse cost profile for a one-shot session load — opt-in follow-on), sized `K = max(3 × expected fill, 5 × teammate count, 50)`, capped at 100.
+- Per-set supersede exclusion (own slices independently, candidate pool independently) — the unconditional past-`validTo` guard (the primary supersede defense) is preserved verbatim.
+- `memoriesAvailable` is now an own-scoped count (`agentId==self`, a cheap indexed seek) instead of the org-wide exact figure — computing that exactly was itself the scan being removed.
+
+No scope widening: own-scoped queries are strictly narrower than the previous load-then-filter; the candidate pool carries the identical `scope.condition` (own OR non-private). Measured on a synthetic 6,100-record corpus (6,000 org-wide + 100 own) against an ephemeral Harper instance: bootstrap latency dropped from 350ms (cold) / 309ms (warm mean) to 91ms / 48ms.
+
 ### 🎯 Usage-feedback signal — `usageCount` + `usageBoost` replaces `retrievalBoost` (flair#683)
 
 flair#623 found `compositeScore` measurably losing to raw relevance and flipped the default to `raw`. The root cause was the *signal*, not the model: the reinforcement term was `retrievalCount` — incremented on every search hit (`resources/SemanticSearch.ts`) — so a doc surfacing once got boosted, surfaced more, boosted more, independent of whether it was ever actually useful. This ships a stronger, distinct signal: verified *use*, captured explicitly.

--- a/resources/MemoryBootstrap.ts
+++ b/resources/MemoryBootstrap.ts
@@ -14,6 +14,13 @@ import {
   type EntityMatchInput,
   type SemanticMatchInput,
 } from "./collision-lib.js";
+// The bounded HNSW candidate-pool retrieval for the task-relevant/teammate/
+// collision surfaces (flair-bootstrap-scale-fix) — the SAME pure core
+// SemanticSearch.ts's post() wraps, called bare here so an internal
+// bootstrap call never trips SemanticSearch's rate-limit/reranker/
+// retrievalCount hit-tracking side effects (see resources/
+// semantic-retrieval-core.ts's module doc for the full boundary).
+import { retrieveCandidates } from "./semantic-retrieval-core.js";
 
 /**
  * POST /MemoryBootstrap
@@ -73,6 +80,39 @@ import {
 const COLLISION_WINDOW_DAYS = 7;
 const MAX_COLLISION_ENTRIES = 10;
 
+// ─── Bootstrap scale fix (flair-bootstrap-scale-fix) tunables ───────────────
+//
+// Own-scoped, non-permanent memories (the "recent" adaptive-window source,
+// ALSO reused as the "predicted" subject-match source — see the fetch below)
+// are pulled bounded + createdAt-desc instead of the full org corpus. 500 is
+// a generous ceiling: recent's own display is budget-limited (40% of
+// remaining tokenBudget, in practice a handful of lines) and predicted's
+// subject match is a narrow filter over the same set — an agent with more
+// than 500 non-permanent memories in total would only miss an
+// older-than-the-500th subject-tagged predicted candidate, a theoretical
+// edge case traded for turning an O(org) scan into an O(own) bounded seek.
+// If the recall harness ever shows this bound is too tight, widen it —
+// never reintroduce the unbounded org-wide load.
+const OWN_NONPERMANENT_FETCH_LIMIT = 500;
+
+// Candidate-pool K formula (Kern-approved, K&S verdict on
+// FLAIR-BOOTSTRAP-SCALE-FIX.md): K = max(3 × expected fill count,
+// 5 × teammate count, MIN_CANDIDATE_POOL), capped at MAX_CANDIDATE_POOL.
+// "Expected fill count" estimates how many formatted memory lines could fit
+// in the remaining token budget (AVG_LINE_TOKEN_ESTIMATE is deliberately
+// generous/low so the estimate — and thus K — errs LARGE, never small). The
+// greedy token-budget fill loop AND collision's "one top cross-agent hit per
+// teammate" (flair#681) both draw from this SAME pool, so it needs depth for
+// both. If the recall harness ever shows a delta, widen K — never add a
+// second scan (Kern's explicit instruction).
+const AVG_LINE_TOKEN_ESTIMATE = 60;
+const MIN_CANDIDATE_POOL = 50;
+const MAX_CANDIDATE_POOL = 100;
+// Bootstrap's own historical relevance floor (distinct from SemanticSearch's
+// `minScore` request param) — preserved verbatim from the original raw
+// JS dot-product scan's `.filter((s) => s.score > 0.3)`.
+const TASK_RELEVANCE_FLOOR = 0.3;
+
 // Rough token estimate: ~4 chars per token for English text
 function estimateTokens(text: string): number {
   return Math.ceil(text.length / 4);
@@ -81,10 +121,11 @@ function estimateTokens(text: string): number {
 // `agentId` is the BOOTSTRAPPING agent (the caller) — used only to decide
 // whether to annotate attribution, never to change what's read (that
 // boundary is resolveReadScope()'s job, upstream of this function). A
-// cross-agent record always carries `_source` (set once, above, when the
-// record's own agentId differs from the bootstrapping agent — see the
-// allMemories loop), so `m._source !== agentId` is the "is this a
-// teammate's finding" check; own memories never carry `_source` at all.
+// cross-agent record always carries `_source` (tagged by
+// retrieveCandidates() — see resources/semantic-retrieval-core.ts — when the
+// record's own agentId differs from the bootstrapping agent), so
+// `m._source !== agentId` is the "is this a teammate's finding" check; own
+// memories never carry `_source` at all.
 function formatMemory(m: any, agentId?: string): string {
   const tag = m.durability === "permanent" ? "🔒" : m.durability === "persistent" ? "📌" : "📝";
   const date = m.createdAt ? ` (${m.createdAt.slice(0, 10)})` : "";
@@ -268,8 +309,13 @@ export class BootstrapMemories extends Resource {
     // records missing either field are legacy agents/active — a strict
     // `!== "agent"` check would silently drop them. Assumes single-tenant
     // (one instance = one office); grant-filtered roster is the multi-tenant follow-up.
+    // Hoisted out of the try block below (not just team-roster-local) — the
+    // task-relevant candidate pool's K formula (flair-bootstrap-scale-fix)
+    // needs the teammate count too. Stays `[]` on an Agent.search() failure
+    // (older/standalone deployments without the table), which K's formula
+    // tolerates fine (falls back to its other terms).
+    let teammateIds: string[] = [];
     try {
-      const teammateIds: string[] = [];
       for await (const record of (databases as any).flair.Agent.search()) {
         if (isTeammate(record, agentId)) teammateIds.push(record.id);
       }
@@ -279,64 +325,99 @@ export class BootstrapMemories extends Resource {
       // Agent table may not exist in older / standalone deployments
     }
 
-    // --- 2. Permanent memories (always included, highest priority) ---
+    // ─── Read-scope (flair-bootstrap-scale-fix) ─────────────────────────────
     // Read-scope: own (any visibility) + every OTHER in-org agent's
     // non-private memory — open-within-org read (#578), no MemoryGrant
-    // consulted at all. Centralized in resolveReadScope(): the condition is
-    // pushed into the Harper query (so the table itself never returns an
-    // out-of-scope row), and `scope.isAllowed` re-checks in-process as
-    // defense-in-depth (same belt-and-suspenders discipline as
-    // SemanticSearch's BM25 pre-fusion filter) — this is the #550 foundation:
-    // bootstrap can now safely expand beyond own-only without a parallel
-    // scoping rule, and that rule tracks resolveReadScope()'s model
-    // automatically (grant-gated when #568 first built this, open-within-org
-    // now that #578 has landed — this file never re-implements the rule, so
-    // it never has to change when the rule does).
+    // consulted at all. Centralized in resolveReadScope(): `scope.condition`
+    // is pushed into every Harper query below (so the table itself never
+    // returns an out-of-scope row), and `scope.isAllowed` re-checks
+    // in-process as defense-in-depth on every candidate (Sherlock's
+    // non-negotiable — the pushdown condition is the primary gate, this is
+    // the belt) — this is the #550 foundation: bootstrap can now safely
+    // expand beyond own-only without a parallel scoping rule, and that rule
+    // tracks resolveReadScope()'s model automatically (this file never
+    // re-implements the rule, so it never has to change when the rule does).
+    //
+    // The org-wide "load everything, then filter/scan in JS" this section
+    // used to do (`Memory.search({conditions:[scope.condition]})`, no
+    // limit/select — every row's full embedding vector dragged into RAM on
+    // every bootstrap) is replaced by targeted, bounded queries per
+    // consumer: own-scoped pushdowns for the permanent/recent/predicted
+    // lifecycle slices below (agentId==self — strictly NARROWER than the
+    // full open-within-org scope, so no filter is dropped), a cheap
+    // own-scoped count for `memoriesAvailable`, and a bounded HNSW candidate
+    // pool (via retrieveCandidates(), further down) for the task-relevant/
+    // teammate/collision surfaces — the only consumer that legitimately
+    // spans the org. Each bounded query still re-checks `scope.isAllowed()`
+    // on every record even where it's provably a no-op (e.g. an
+    // agentId==self-only query) — uniform defense-in-depth, never skipped
+    // because "the filter already pushed down."
     const scope = await resolveReadScope(agentId);
-    const allMemories: any[] = [];
-    for await (const record of (databases as any).flair.Memory.search({ conditions: [scope.condition] })) {
+
+    // `memoriesAvailable`: dropped the org-wide exact count (computing it
+    // exactly WAS the scan being removed — `visibility != private` isn't
+    // index-seekable, so even a bare count would scan). Replaced with the
+    // own-scoped count (`agentId==self`, cheap indexed seek) — a more
+    // meaningful "how much do I actually have" figure, and O(own) not
+    // O(org). Cosmetic change, called out to K&S in the spec.
+    let ownMemoriesAvailable = 0;
+    const availabilityRows = withDetachedTxn(ctx, () => (databases as any).flair.Memory.search({
+      conditions: [{ attribute: "agentId", comparator: "equals", value: agentId }],
+      select: ["id", "expiresAt", "validTo"],
+    }));
+    for await (const record of availabilityRows as AsyncIterable<any>) {
       if (!scope.isAllowed(record)) continue;
       if (record.expiresAt && Date.parse(record.expiresAt) < Date.now()) continue;
-      // A past validTo ALWAYS means the record has been closed out
-      // (server supersede path — Memory.ts closeSupersededRecord — sets
-      // validTo without necessarily setting `archived`), same root cause and
-      // fix as SemanticSearch.ts's unconditional past-validTo/bm25-filter
-      // exclusion. Unconditional
-      // so a server-superseded record can't resurface in bootstrap just
-      // because its successor isn't co-present in this result set (the
-      // supersededIds filter further down only catches co-presence). A
-      // record with no validTo, or a future validTo, is unaffected.
       if (record.validTo && Date.parse(record.validTo) < Date.now()) continue;
-      // Attribution for cross-agent (any other in-org agent's) records — same
-      // convention SemanticSearch.ts already uses: formatMemory() below only USES this
-      // when the record also carries _safetyFlags (labels the untrusted-data
-      // wrapper with whose memory it is), it never forces wrapping on its own.
-      // Real Harper's search() results are non-extensible objects — mutating
-      // `record._source = ...` directly throws ("object is not extensible");
-      // shallow-copy instead of mutating in place.
-      allMemories.push(record.agentId !== agentId ? { ...record, _source: record.agentId } : record);
+      ownMemoriesAvailable++;
     }
-    memoriesAvailable = allMemories.length;
+    memoriesAvailable = ownMemoriesAvailable;
 
-    // Build superseded set: exclude memories that have been replaced by newer ones
-    const supersededIds = new Set<string>();
-    for (const m of allMemories) {
-      if (m.supersedes) supersededIds.add(m.supersedes);
+    // Fields every own-scoped lifecycle slice below needs — explicit (no raw
+    // `embedding`), matching the "select, no raw embedding" pushdown
+    // requirement.
+    const OWN_SELECT = ["id", "agentId", "content", "durability", "createdAt", "supersedes", "subject", "validTo", "expiresAt", "_safetyFlags"];
+
+    // --- 2. Permanent memories (always included, highest priority) ---
+    // Own-scoped pushdown: `agentId==self` + `durability==permanent`, both
+    // @indexed (a seek, not a scan) — strictly narrower than the prior
+    // load-then-filter (own records are always visible to their own agent
+    // regardless of visibility, so agentId==self alone is the correct,
+    // no-filter-dropped condition here; no other agent's data enters this
+    // query at all).
+    const permanentRows: any[] = [];
+    const permanentQuery = withDetachedTxn(ctx, () => (databases as any).flair.Memory.search({
+      conditions: [
+        { attribute: "agentId", comparator: "equals", value: agentId },
+        { attribute: "durability", comparator: "equals", value: "permanent" },
+      ],
+      select: OWN_SELECT,
+    }));
+    for await (const record of permanentQuery as AsyncIterable<any>) {
+      if (!scope.isAllowed(record)) continue;
+      if (record.expiresAt && Date.parse(record.expiresAt) < Date.now()) continue;
+      // A past validTo ALWAYS means the record has been closed out (server
+      // supersede path — Memory.ts closeSupersededRecord — sets validTo
+      // without necessarily setting `archived`), same root cause and fix as
+      // SemanticSearch.ts's unconditional past-validTo exclusion.
+      // Unconditional so a server-superseded record can't resurface just
+      // because its successor isn't co-present in THIS bounded set (the
+      // per-set supersededIds filter below only catches co-presence).
+      if (record.validTo && Date.parse(record.validTo) < Date.now()) continue;
+      permanentRows.push(record);
     }
-    const activeMemories = allMemories.filter((m) => !supersededIds.has(m.id));
-
-    // #550 design boundary: the permanent / recent / predicted sections are the
-    // agent's OWN working context — own-only, always. `activeMemories` also
-    // carries every other in-org agent's non-private records (`_source` set,
-    // open-within-org read — no grant involved), but that cross-agent
-    // visibility exists to feed the task-relevant "Teammate findings"
-    // surfacing (#550) below, NOT to blend a teammate's memories into the
-    // reader's recent/permanent/predicted view. So these three sections
-    // filter to own (`!m._source`); team knowledge surfaces only when
-    // task-relevant (the teammate section) or via an explicit memory_search.
-    const ownMemories = activeMemories.filter((m) => !m._source);
-
-    const permanent = ownMemories.filter((m) => m.durability === "permanent");
+    // Per-set supersededIds (flair-bootstrap-scale-fix, Kern-approved
+    // narrowing): computed from THIS bounded set alone, never cross-applied
+    // to the recent/predicted sets or the candidate pool below — each is
+    // independent. The uncovered case (predecessor and successor landing in
+    // DIFFERENT bounded sets) is a theoretical gap already covered by the
+    // unconditional past-validTo guard above (the primary supersede
+    // defense); this co-presence check is a secondary belt, same as before
+    // this refactor, just now scoped per-set instead of per the old
+    // org-wide load.
+    const permanentSupersededIds = new Set<string>();
+    for (const m of permanentRows) if (m.supersedes) permanentSupersededIds.add(m.supersedes);
+    const permanent = permanentRows.filter((m) => !permanentSupersededIds.has(m.id));
     for (const m of permanent) {
       const line = formatMemory(m, agentId);
       const cost = estimateTokens(line);
@@ -350,10 +431,39 @@ export class BootstrapMemories extends Resource {
     }
 
     // --- 3. Recent memories (adaptive window) ---
+    // Own-scoped, non-permanent, bounded + createdAt-desc pushdown (agentId
+    // and durability are both @indexed) — replaces the org-wide load's
+    // post-hoc JS filter. This SAME fetched set also feeds "predicted"
+    // (3b, below): both draw from "my own non-permanent memories" bounded to
+    // OWN_NONPERMANENT_FETCH_LIMIT (see that constant's doc for the bound's
+    // rationale) — same shared-source relationship the pre-refactor code
+    // had via `ownMemories`, just bounded now instead of org-wide.
+    const nonPermanentRows: any[] = [];
+    const nonPermanentQuery = withDetachedTxn(ctx, () => (databases as any).flair.Memory.search({
+      conditions: [
+        { attribute: "agentId", comparator: "equals", value: agentId },
+        { attribute: "durability", comparator: "not_equal", value: "permanent" },
+      ],
+      select: OWN_SELECT,
+      sort: { attribute: "createdAt", descending: true },
+      limit: OWN_NONPERMANENT_FETCH_LIMIT,
+    }));
+    for await (const record of nonPermanentQuery as AsyncIterable<any>) {
+      if (!scope.isAllowed(record)) continue;
+      if (record.expiresAt && Date.parse(record.expiresAt) < Date.now()) continue;
+      if (record.validTo && Date.parse(record.validTo) < Date.now()) continue;
+      nonPermanentRows.push(record);
+    }
+    // Per-set supersededIds — independent of `permanentSupersededIds` above
+    // (see that block's doc for the full per-set rationale).
+    const nonPermanentSupersededIds = new Set<string>();
+    for (const m of nonPermanentRows) if (m.supersedes) nonPermanentSupersededIds.add(m.supersedes);
+    const nonPermanentActive = nonPermanentRows.filter((m) => !nonPermanentSupersededIds.has(m.id));
+
     // Start with 48h. If nothing found, widen to 7d, then 30d.
     // This prevents empty recent sections for agents that were idle.
-    const nonPermanent = ownMemories
-      .filter((m) => m.durability !== "permanent" && m.createdAt)
+    const nonPermanent = nonPermanentActive
+      .filter((m) => m.createdAt)
       .sort((a: any, b: any) => (b.createdAt || "").localeCompare(a.createdAt || ""));
 
     let effectiveSince: Date;
@@ -402,7 +512,13 @@ export class BootstrapMemories extends Resource {
         ...recent.filter((_: any, i: number) => i < sections.recent.length).map((m: any) => m.id),
       ]);
 
-      const subjectMemories = ownMemories
+      // Draws from the SAME bounded own-scoped, non-permanent set "recent"
+      // uses (nonPermanentActive — see that fetch's doc above for the
+      // shared-source rationale and OWN_NONPERMANENT_FETCH_LIMIT's bound).
+      // `durability !== "permanent"` is now redundant with the source
+      // query's own condition but kept for parity/clarity with the
+      // pre-refactor filter shape.
+      const subjectMemories = nonPermanentActive
         .filter((m: any) =>
           !includedIds.has(m.id) &&
           m.subject &&
@@ -482,22 +598,69 @@ export class BootstrapMemories extends Resource {
           ...recent.filter((_, i) => i < sections.recent.length).map((m) => m.id),
         ]);
 
-        const scored = allMemories
-          .filter((m) => !includedIds.has(m.id) && !supersededIds.has(m.id) && m.embedding?.length > 100)
-          .map((m) => {
-            let dot = 0;
-            const len = Math.min(queryEmbedding!.length, m.embedding.length);
-            for (let i = 0; i < len; i++) dot += queryEmbedding![i] * m.embedding[i];
-            return { memory: m, score: dot };
-          })
-          .filter((s) => s.score > 0.3)
-          .sort((a, b) => b.score - a.score);
+        // Bounded HNSW candidate pool (flair-bootstrap-scale-fix) — replaces
+        // the full-corpus JS dot-product scan (`allMemories` × queryEmbedding,
+        // O(org corpus size) every bootstrap). K formula (Kern-approved):
+        // max(3 × expected fill, 5 × teammate count, MIN_CANDIDATE_POOL),
+        // capped at MAX_CANDIDATE_POOL — deep enough for BOTH the
+        // token-budget fill loop below AND collision's "one top cross-agent
+        // hit per teammate" (flair#681), which draws from the SAME pool. If
+        // the recall harness ever shows a delta, widen K — never add a
+        // second scan (Kern's explicit instruction).
+        const expectedFill = Math.max(1, Math.ceil(tokenBudget / AVG_LINE_TOKEN_ESTIMATE));
+        const candidatePoolK = Math.min(
+          MAX_CANDIDATE_POOL,
+          Math.max(3 * expectedFill, 5 * teammateIds.length, MIN_CANDIDATE_POOL),
+        );
+
+        const candidates = await retrieveCandidates({
+          queryEmbedding,
+          conditions: [scope.condition],
+          limit: candidatePoolK,
+          // HNSW-leg pushdown ONLY (K&S verdict): no BM25 fusion, no
+          // reranker for bootstrap — a different cost profile (BM25 over the
+          // org corpus for a one-shot session-load could be MORE expensive
+          // than HNSW-only unless cached across sessions; the reranker is a
+          // generative call per candidate). Both are explicit opt-in
+          // follow-ons, gated on their own harness runs.
+          hybrid: false,
+          // Per-set (this K-bounded pool only, never cross-applied to the
+          // permanent/recent/predicted sets above) — see this function's
+          // supersededIds docs above and resources/
+          // semantic-retrieval-core.ts's own doc for the full caveat. The
+          // unconditional past-validTo guard (inside retrieveCandidates)
+          // stays the primary supersede defense either way.
+          includeSuperseded: false,
+          // Matches the original raw JS dot product exactly — no
+          // composite/durability-recency weighting for bootstrap's own
+          // relevance ranking.
+          scoring: "raw",
+          agentId,
+          // Sherlock's non-negotiable belt: re-checked on every candidate
+          // even though `conditions` already scoped the query.
+          isAllowed: scope.isAllowed,
+          ctx,
+        });
+
+        // Preserve the ORIGINAL score > 0.3 floor exactly (bootstrap's own
+        // historical relevance floor — distinct from SemanticSearch's
+        // `minScore` request param — strict inequality, applied client-side;
+        // `candidates` are already `_score`-sorted best-first, so filtering
+        // preserves that order). `retrieveCandidates()`'s cosine similarity
+        // replaces the raw JS dot product as the ranking signal (HNSW-only,
+        // no BM25/rerank) — the K&S-ratified, closest-to-a-wash choice; the
+        // recall harness gates any regression from this ranking-signal
+        // change (magnitude-sensitive dot product → normalized cosine).
+        const scored = candidates
+          .filter((m: any) => !includedIds.has(m.id) && m._score > TASK_RELEVANCE_FLOOR)
+          .map((m: any) => ({ memory: m, score: m._score }));
 
         // flair#681: the collision block's semantic surface — one candidate
         // per teammate (the highest-scoring hit; `scored` is already sorted
         // desc, so the first occurrence of a given `_source` IS the best
         // one). `m._source` is only ever set for a cross-agent record (see
-        // the allMemories loop above) — an own memory never contributes here.
+        // retrieveCandidates()'s `_source` tagging) — an own memory never
+        // contributes here.
         const seenCollisionAgents = new Set<string>();
         for (const { memory: m, score } of scored) {
           if (!m._source || seenCollisionAgents.has(m._source)) continue;
@@ -508,12 +671,12 @@ export class BootstrapMemories extends Resource {
         // #550: split the scored, task-relevant set by origin. Own findings
         // go to `relevant` as before; any other in-org agent's non-private
         // record — already read-scoped by resolveReadScope(), no grant
-        // required (`m._source` is only ever set for a cross-agent record,
-        // see the allMemories loop above) — goes to the new `teammate`
-        // section so the agent can tell it apart at a glance. Both draw from
-        // the SAME `tokenBudget` in one score-ordered pass — highest-relevance
-        // memories win the remaining budget regardless of which section they
-        // land in, so neither section double-spends.
+        // required (`m._source` is only ever set for a cross-agent record) —
+        // goes to the new `teammate` section so the agent can tell it apart
+        // at a glance. Both draw from the SAME `tokenBudget` in one
+        // score-ordered pass — highest-relevance memories win the remaining
+        // budget regardless of which section they land in, so neither
+        // section double-spends.
         for (const { memory: m } of scored) {
           const line = formatMemory(m, agentId);
           const cost = estimateTokens(line);

--- a/resources/SemanticSearch.ts
+++ b/resources/SemanticSearch.ts
@@ -1,11 +1,9 @@
 import { Resource, databases } from "@harperfast/harper";
 import { resolveAgentAuth, allowVerified } from "./agent-auth.js";
 import { getEmbedding, getMode } from "./embeddings-provider.js";
-import { patchRecord, withDetachedTxn } from "./table-helpers.js";
+import { patchRecord } from "./table-helpers.js";
 import { checkRateLimit, rateLimitResponse } from "./rate-limiter.js";
-import { wrapUntrusted } from "./content-safety.js";
 import { resolveReadScope } from "./memory-read-scope.js";
-import { cosineSimilarity } from "./dedup.js";
 import {
   isRerankEnabled,
   getRerankTopN,
@@ -14,33 +12,24 @@ import {
   rerankCandidates,
 } from "./rerank-provider.js";
 
-// Temporal decay + relevance scoring (incl. the OPS-AYGD retrievalBoost cap +
-// relevance floor, and flair#683's usageBoost — which REPLACES retrievalBoost
-// as compositeScore's reinforcement term, see that function's own doc) lives
-// in ./scoring.ts — a Harper-free module so it can be unit-tested directly
-// (see test/unit/temporal-scoring.test.ts).
-import { compositeScore } from "./scoring.js";
-
-// BM25 + union-RRF hybrid retrieval (FLAIR-BM25-HYBRID-RETRIEVAL).
-// Harper-free modules so the BM25 scoring, the candidate-union RRF, and the
-// SECURITY conditions-filter are unit-tested against the shipped code.
-import { buildBM25, fuseRrfNormalized, hybridEnabled, SEM_LIMIT } from "./bm25.js";
-import { isAllowedBm25Candidate, type Condition } from "./bm25-filter.js";
-
-// Convert HNSW cosine distance (1 - similarity) to similarity score
-function distanceToSimilarity(distance: number): number {
-  return 1 - distance;
-}
-
-// Candidate multiplier: fetch more candidates than needed from the HNSW index
-// so composite re-ranking has enough headroom to reorder results.
-const CANDIDATE_MULTIPLIER = 5;
-
 // The BM25 + union-RRF hybrid path is feature-flagged via hybridEnabled()
 // (imported from ./bm25 — Harper-free so it's unit-testable). Default is ON as
 // of 2026-07-08 (see ./bm25.ts's hybridEnabled() doc); set
 // FLAIR_HYBRID_RETRIEVAL=false to revert to the legacy HNSW + +0.05
 // keyword-bump path, byte-identical to the original pre-hybrid behavior.
+import { hybridEnabled } from "./bm25.js";
+
+// The actual HNSW/BM25 retrieval + post-retrieval filtering (temporal/
+// supersede/isAllowed) now lives in the pure, side-effect-free
+// retrieveCandidates() core (flair-bootstrap-scale-fix, Kern-approved
+// extraction) — MemoryBootstrap.ts calls the SAME core bare, without
+// tripping this file's rate-limit/reranker/hit-tracking side effects. See
+// resources/semantic-retrieval-core.ts's module doc for the full boundary.
+import { retrieveCandidates } from "./semantic-retrieval-core.js";
+
+// Candidate multiplier: fetch more candidates than needed from the HNSW index
+// so composite re-ranking has enough headroom to reorder results.
+const CANDIDATE_MULTIPLIER = 5;
 
 export class SemanticSearch extends Resource {
   // Self-authorize via the Ed25519 agent verify instead of relying on the auth
@@ -202,7 +191,6 @@ export class SemanticSearch extends Resource {
       }
     }
 
-    const results: any[] = [];
     const hybrid = hybridEnabled();
 
     // When the reranker is on, widen the legacy HNSW fetch so it has a deeper
@@ -216,333 +204,58 @@ export class SemanticSearch extends Resource {
     const rerankOn = isRerankEnabled();
     const rerankTopN = getRerankTopN();
 
-    if (hybrid) {
-      // ─── BM25 + union-RRF hybrid path ────────────────────────────────────
-      // 1. Semantic candidates via HNSW (unchanged fetch). 2. BM25 lexical pass
-      //    over the SCOPED corpus. 3. SECURITY: the BM25 candidate set is filtered
-      //    by the SAME conditions[] + temporal filters BEFORE fusion (the corpus
-      //    is fetched with those conditions, AND re-checked in-process as
-      //    defense-in-depth) so no other agent's memory is ever scored or fused.
-      //    4. Candidate-union RRF → normalize → feed as rawScore to compositeScore.
-      const ctx = (this as any).getContext?.();
+    // The overfetch policy (how many raw candidates to pull from the
+    // HNSW/BM25 legs relative to what the caller ultimately wants) is THIS
+    // wrapper's decision — retrieveCandidates() never multiplies its `limit`
+    // param internally (see resources/semantic-retrieval-core.ts's doc), so
+    // every caller (this one, and MemoryBootstrap's own K formula) computes
+    // its own fetch depth. Hybrid's semantic leg is never rerank-widened
+    // (matches the pre-extraction behavior: only the legacy path widened for
+    // rerank).
+    const candidateLimit = hybrid
+      ? limit * CANDIDATE_MULTIPLIER
+      : (rerankOn ? Math.max(limit * CANDIDATE_MULTIPLIER, rerankTopN) : limit * CANDIDATE_MULTIPLIER);
 
-      // ── (a) Semantic candidate records (best-first) ──────────────────────
-      // Same HNSW query as the legacy path; we keep the raw records so the BM25
-      // pass + fusion can re-derive rawScore. No embedding → empty semantic list
-      // (RRF degrades naturally to BM25-only).
-      const semRecords: any[] = [];
-      const semIds: string[] = [];
-      if (qEmb) {
-        const candidateLimit = limit * CANDIDATE_MULTIPLIER;
-        const semQuery: any = {
-          sort: { attribute: "embedding", target: qEmb, distance: "cosine" },
-          select: ["id", "agentId", "content", "contentHash", "visibility", "tags", "durability",
-            "source", "createdAt", "updatedAt", "expiresAt", "retrievalCount", "usageCount", "lastRetrieved",
-            "promotionStatus", "promotedAt", "promotedBy", "archived", "archivedAt", "archivedBy",
-            "parentId", "derivedFrom", "sessionId", "lastReflected", "supersedes", "subject",
-            "validFrom", "validTo", "_safetyFlags", "$distance"],
-          limit: candidateLimit,
-        };
-        if (conditions.length > 0) semQuery.conditions = conditions;
-        const semResults = withDetachedTxn(ctx, () => (databases as any).flair.Memory.search(semQuery));
-        for await (const record of semResults) {
-          // Same per-record temporal gate as the legacy HNSW loop.
-          if (record.expiresAt && Date.parse(record.expiresAt) < Date.now()) continue;
-          if (sinceDate && record.createdAt && new Date(record.createdAt) < sinceDate) continue;
-          if (asOf && record.validFrom && record.validFrom > asOf) continue;
-          if (asOf && record.validTo && record.validTo <= asOf) continue;
-          // Unconditional past-validTo exclusion (see legacy HNSW
-          // loop below for the full rationale) — applies regardless of asOf.
-          if (record.validTo && Date.parse(record.validTo) < Date.now()) continue;
-          semRecords.push(record);
-          semIds.push(record.id);
-        }
-      }
+    const ctx = (this as any).getContext?.();
 
-      // ── (b) BM25 candidate records over the SCOPED corpus ────────────────
-      // SECURITY: fetch the corpus WITH the same conditions[] so Harper applies
-      // the agent boundary, then re-apply the identical predicate + temporal
-      // filters in-process (isAllowedBm25Candidate) BEFORE building/scoring the
-      // index. The BM25 index therefore only ever contains the caller's allowed
-      // memories — no other agent's content/term-frequency enters scoring or
-      // fusion. This is the conditions-filter-before-fusion gate.
-      // Explicit select (same fields as the HNSW path, no embedding / $distance)
-      // so the large embedding vector is never fetched into the BM25 corpus and
-      // never spread into a result payload.
-      const corpusSelect = ["id", "agentId", "content", "contentHash", "visibility", "tags", "durability",
-        "source", "createdAt", "updatedAt", "expiresAt", "retrievalCount", "usageCount", "lastRetrieved",
-        "promotionStatus", "promotedAt", "promotedBy", "archived", "archivedAt", "archivedBy",
-        "parentId", "derivedFrom", "sessionId", "lastReflected", "supersedes", "subject",
-        "validFrom", "validTo", "_safetyFlags"];
-      const corpusQuery: any = conditions.length > 0
-        ? { conditions, select: corpusSelect }
-        : { select: corpusSelect };
-      const corpusResults = withDetachedTxn(ctx, () => (databases as any).flair.Memory.search(corpusQuery));
-      const allowedById = new Map<string, any>();
-      const bm25Docs: { id: string; content?: string }[] = [];
-      for await (const record of corpusResults) {
-        // Defense-in-depth: re-check the SAME conditions[] + temporal filters
-        // in-process. Even if a Harper query change ever let an out-of-scope
-        // record through, it is dropped here BEFORE it can be BM25-scored/fused.
-        if (!isAllowedBm25Candidate(record, conditions as Condition[], { sinceDate, asOf })) continue;
-        allowedById.set(record.id, record);
-        bm25Docs.push({ id: record.id, content: record.content });
-      }
-
-      // Carry semantic candidates that survived their temporal gate into the
-      // allowed map too (so a fused id always resolves to a record). Semantic
-      // records were fetched with the SAME conditions[], so they're in-scope.
-      for (const r of semRecords) {
-        if (!allowedById.has(r.id)) {
-          const { $distance, ...rest } = r;
-          allowedById.set(r.id, rest);
-        }
-      }
-
-      // ── (c) BM25 lexical ranking → top SEM_LIMIT (only when q present) ────
-      let bm25Ids: string[] = [];
-      if (q) {
-        const bm25 = buildBM25(bm25Docs);
-        const ranked = bm25.rank(String(q));
-        // Drop zero-score docs (no query-term overlap → contribute nothing) and
-        // cap at SEM_LIMIT — the production BM25 candidate window.
-        bm25Ids = ranked.filter(r => r.score > 0).slice(0, SEM_LIMIT).map(r => r.id);
-      }
-
-      // ── (d) No retrieval signal at all → full scoped listing ────────────
-      // Neither `q` nor `qEmb`: semIds and bm25Ids are BOTH necessarily empty
-      // (semIds is only populated `if (qEmb)`; bm25Ids only `if (q)`), so
-      // fuseRrfNormalized([], []) returns an empty map and the union-RRF loop
-      // below would silently emit ZERO results — unlike the legacy path's
-      // final no-embedding branch, which full-scans and returns every
-      // scope-matching record (rawScore 0 when there's no keyword hit,
-      // included because `if (q && rawScore === 0) continue` only fires when
-      // `q` is truthy). This is the "list everything in my scope" call
-      // real callers rely on (e.g. SemanticSearch with only `agentId`/`tag`/
-      // `subject` — see test/integration/memory-visibility-scoping-e2e.test.ts),
-      // and it must behave identically whether the hybrid flag is on or off.
-      // `allowedById` already holds exactly the right candidate set (built
-      // from the SAME conditions[] + isAllowedBm25Candidate temporal/security
-      // filters as the BM25 pass), so emit it directly at rawScore 0 instead
-      // of routing through the (necessarily-empty) RRF fusion.
-      if (!q && !qEmb) {
-        for (const record of allowedById.values()) {
-          const rawScore = 0;
-          let finalScore = scoring === "raw" ? rawScore : compositeScore(rawScore, record);
-          if (temporalBoost > 1.0) finalScore *= temporalBoost;
-
-          const isFlagged = record._safetyFlags && Array.isArray(record._safetyFlags) && record._safetyFlags.length > 0;
-          const source = record.agentId !== agentId ? record.agentId : undefined;
-          results.push({
-            ...record,
-            content: isFlagged ? wrapUntrusted(record.content, source) : record.content,
-            _score: Math.round(finalScore * 1000) / 1000,
-            _rawScore: scoring !== "raw" ? Math.round(rawScore * 1000) / 1000 : undefined,
-            _source: source,
-          });
-        }
-      } else {
-        // ── Candidate-union RRF → normalized [0,1] rawScore ────────────────
-        // Union dedupes semantic ∪ bm25 ids; absent-from-a-list = 0 contribution.
-        const fused = fuseRrfNormalized(semIds, bm25Ids);
-
-        for (const [id, rrfRaw] of fused) {
-          const record = allowedById.get(id);
-          if (!record) continue; // should not happen — union ⊆ allowed
-          const rawScore = rrfRaw; // already normalized to [0,1]
-          let finalScore = scoring === "raw" ? rawScore : compositeScore(rawScore, record);
-          if (temporalBoost > 1.0) finalScore *= temporalBoost;
-
-          const isFlagged = record._safetyFlags && Array.isArray(record._safetyFlags) && record._safetyFlags.length > 0;
-          const source = record.agentId !== agentId ? record.agentId : undefined;
-          results.push({
-            ...record,
-            content: isFlagged ? wrapUntrusted(record.content, source) : record.content,
-            _score: Math.round(finalScore * 1000) / 1000,
-            _rawScore: scoring !== "raw" ? Math.round(rawScore * 1000) / 1000 : undefined,
-            _source: source,
-          });
-        }
-      }
-    } else if (qEmb) {
-      // ─── HNSW vector search path (legacy, hybrid flag OFF) ────────────────
-      const candidateLimit = rerankOn
-        ? Math.max(limit * CANDIDATE_MULTIPLIER, rerankTopN)
-        : limit * CANDIDATE_MULTIPLIER;
-      const query: any = {
-        sort: { attribute: "embedding", target: qEmb, distance: "cosine" },
-        select: ["id", "agentId", "content", "contentHash", "visibility", "tags", "durability",
-          "source", "createdAt", "updatedAt", "expiresAt", "retrievalCount", "usageCount", "lastRetrieved",
-          "promotionStatus", "promotedAt", "promotedBy", "archived", "archivedAt", "archivedBy",
-          "parentId", "derivedFrom", "sessionId", "lastReflected", "supersedes", "subject",
-          "validFrom", "validTo", "_safetyFlags", "$distance"],
-        limit: candidateLimit,
-      };
-      if (conditions.length > 0) {
-        query.conditions = conditions;
-      }
-
-      // MemoryGrant.search above left a closed transaction in ctx's chain —
-      // detach it so Harper builds a fresh transaction for this Memory read.
-      const ctx = (this as any).getContext?.();
-      const memoryResults = withDetachedTxn(ctx, () => (databases as any).flair.Memory.search(query));
-      for await (const record of memoryResults) {
-        if (record.expiresAt && Date.parse(record.expiresAt) < Date.now()) continue;
-        if (sinceDate && record.createdAt && new Date(record.createdAt) < sinceDate) continue;
-        // Temporal validity: if asOf is specified, only include memories valid at that point
-        if (asOf && record.validFrom && record.validFrom > asOf) continue;
-        if (asOf && record.validTo && record.validTo <= asOf) continue;
-        // A past validTo ALWAYS means the record has been closed out
-        // (server supersede path — Memory.ts closeSupersededRecord — sets
-        // validTo without necessarily setting `archived`). Unconditional, not
-        // gated on `asOf`, so a server-superseded record can't resurface in
-        // the DEFAULT recall path just because its successor isn't
-        // co-present in this result set (the supersededIds filter further
-        // down only catches co-presence). A record with no validTo, or a
-        // future validTo, is unaffected.
-        if (record.validTo && Date.parse(record.validTo) < Date.now()) continue;
-
-        let semanticScore: number;
-        if (record.$distance !== undefined) {
-          semanticScore = distanceToSimilarity(record.$distance);
-        } else {
-          // ─── Harper's cosine-sort query omits $distance for a
-          // SINGLETON post-filter result set — the SAME quirk root-caused and
-          // fixed for the dedup path (resources/Memory.ts
-          // findConservativeDedupMatch / resources/dedup.ts cosineSimilarity).
-          // Sort ORDER is still correct; only the numeric `$distance`
-          // annotation is missing on that one record, regardless of the
-          // query's own `limit` (reproduced here with candidateLimit=50, not
-          // just limit=1 — the trigger is the post-filter MATCH COUNT, not the
-          // requested limit).
-          //
-          // Layer 1 made this common: the no-grants agent scope used
-          // to ALWAYS be a compound `{operator:"or", conditions:[{agentId},
-          // {visibility=="office"}]}` condition; resolveReadScope() now emits
-          // a PLAIN single `{agentId==X}` condition for the common (no-grants)
-          // case, so a scoped search against an agent with exactly one
-          // matching memory hits this Harper quirk directly. Before, the OR
-          // wrap incidentally avoided the singleton shape. The old `?? 1`
-          // fallback silently collapsed this to similarity 0 — read by
-          // callers (including the clean-VM CI gate's single-memory init
-          // probe, #533) as "embeddings not loaded", which is WRONG:
-          // embeddings ARE loaded, only the score was computed incorrectly.
-          //
-          // Fix: point-lookup the record by id (a plain get(), unaffected by
-          // the sort-query quirk — selecting "embedding" directly on the SAME
-          // sort-by-embedding query comes back as a bare scalar, per the same
-          // investigation above) and compute cosine similarity ourselves in JS from its
-          // real stored `embedding` vector against this query's `qEmb`, via
-          // the same math as the ume4 fallback (dedup.ts's cosineSimilarity).
-          // Only done on this (rare) undefined-$distance branch — never adds
-          // a point-lookup to the normal per-record path. If the stored
-          // embedding is missing/empty (e.g. a legacy pre-embedding record),
-          // cosineSimilarity returns 0 — the same safe "no match" the old
-          // `?? 1` fallback produced, never a false-high score.
-          const full = await withDetachedTxn(ctx, () => (databases as any).flair.Memory.get(record.id));
-          const storedEmbedding = Array.isArray(full?.embedding) ? full.embedding : [];
-          semanticScore = cosineSimilarity(qEmb, storedEmbedding);
-        }
-        let keywordHit = false;
-        if (q && String(record.content || "").toLowerCase().includes(String(q).toLowerCase())) {
-          keywordHit = true;
-        }
-        const rawScore = semanticScore + (keywordHit ? 0.05 : 0);
-
-        let finalScore = scoring === "raw" ? rawScore : compositeScore(rawScore, record);
-        if (temporalBoost > 1.0) finalScore *= temporalBoost;
-
-        const { $distance, ...rest } = record;
-        const isFlagged = rest._safetyFlags && Array.isArray(rest._safetyFlags) && rest._safetyFlags.length > 0;
-        const source = record.agentId !== agentId ? record.agentId : undefined;
-        results.push({
-          ...rest,
-          content: isFlagged ? wrapUntrusted(rest.content, source) : rest.content,
-          _score: Math.round(finalScore * 1000) / 1000,
-          _rawScore: scoring !== "raw" ? Math.round(rawScore * 1000) / 1000 : undefined,
-          _source: source,
-        });
-      }
-    } else {
-      // ─── No embedding available — keyword-only fallback ──────────────────
-      // Full scan is only used when there's no query embedding (e.g. tag-only
-      // or subject-only searches, or when the embedding engine is unavailable).
-      const query: any = conditions.length > 0 ? { conditions } : {};
-      // MemoryGrant.search above left a closed transaction in ctx's chain —
-      // detach it so Harper builds a fresh transaction for this Memory read.
-      const ctx = (this as any).getContext?.();
-      const memoryResults = withDetachedTxn(ctx, () => (databases as any).flair.Memory.search(query));
-      for await (const record of memoryResults) {
-        if (record.expiresAt && Date.parse(record.expiresAt) < Date.now()) continue;
-        if (sinceDate && record.createdAt && new Date(record.createdAt) < sinceDate) continue;
-        if (asOf && record.validFrom && record.validFrom > asOf) continue;
-        if (asOf && record.validTo && record.validTo <= asOf) continue;
-        // Unconditional past-validTo exclusion (see legacy HNSW
-        // loop above for the full rationale) — applies regardless of asOf.
-        if (record.validTo && Date.parse(record.validTo) < Date.now()) continue;
-
-        let keywordHit = false;
-        if (q && String(record.content || "").toLowerCase().includes(String(q).toLowerCase())) {
-          keywordHit = true;
-        }
-        const rawScore = keywordHit ? 0.05 : 0;
-        if (q && rawScore === 0) continue;
-
-        const { embedding, ...rest } = record;
-        let finalScore = scoring === "raw" ? rawScore : compositeScore(rawScore, rest);
-        if (temporalBoost > 1.0) finalScore *= temporalBoost;
-
-        const isFlagged = rest._safetyFlags && Array.isArray(rest._safetyFlags) && rest._safetyFlags.length > 0;
-        const source = record.agentId !== agentId ? record.agentId : undefined;
-        results.push({
-          ...rest,
-          content: isFlagged ? wrapUntrusted(rest.content, source) : rest.content,
-          _score: Math.round(finalScore * 1000) / 1000,
-          _rawScore: scoring !== "raw" ? Math.round(rawScore * 1000) / 1000 : undefined,
-          _source: source,
-        });
-      }
-    }
-
-    // Build superseded set and filter (unless caller opts in to see full history)
-    let filteredResults = results;
-    if (!includeSuperseded) {
-      const supersededIds = new Set<string>();
-      for (const r of results) {
-        if (r.supersedes) supersededIds.add(r.supersedes);
-      }
-      filteredResults = results.filter((r: any) => !supersededIds.has(r.id));
-    }
-
-    // Apply minimum score filter
-    if (minScore > 0) {
-      filteredResults = filteredResults.filter((r: any) => r._score >= minScore);
-    }
+    let filteredResults = await retrieveCandidates({
+      queryEmbedding: qEmb,
+      q,
+      conditions,
+      limit: candidateLimit,
+      includeSuperseded,
+      scoring,
+      temporalBoost,
+      sinceDate,
+      asOf,
+      minScore,
+      agentId,
+      isAllowed: scope?.isAllowed,
+      hybrid,
+      ctx,
+    });
 
     // ─── Cross-encoder rerank (best-effort, fail-open to vector order) ───────
     // Re-scores query+candidate TOGETHER (cross-attention the pooled embedding
     // can't do) and reorders before the final slice. Reorders whatever
-    // `filteredResults` the retrieval stage above produced — legacy HNSW-only
-    // OR the BM25+union-RRF hybrid path — since both converge into
-    // the same `results`/`filteredResults` shape before this point; hybrid
-    // retrieves+fuses, the reranker only reorders the fused set. Still gated
-    // on `qEmb` (an embedding was actually generated); the pure keyword-only
-    // fallback (no qEmb at all) is untouched either way. The reranker
-    // overwrites `_score` with the rerank score (so margin measurement reads it)
-    // and preserves the semantic score as `_semScore`; `_rawScore` is left as-is
-    // so recall-bench's scoring:"raw" path stays reproducible. On init failure,
-    // timeout, or any throw, rerankCandidates returns the input UNCHANGED and we
-    // fall through to the existing vector-order sort — recall is never blocked.
+    // `filteredResults` retrieveCandidates() produced — legacy HNSW-only OR
+    // the BM25+union-RRF hybrid path — since both converge into the same
+    // shape (retrieveCandidates never exposes which leg produced a result).
+    // Still gated on `qEmb` (an embedding was actually generated); the pure
+    // keyword-only fallback (no qEmb at all) is untouched either way. The
+    // reranker overwrites `_score` with the rerank score (so margin
+    // measurement reads it) and preserves the semantic score as `_semScore`;
+    // `_rawScore` is left as-is so recall-bench's scoring:"raw" path stays
+    // reproducible. On init failure, timeout, or any throw, rerankCandidates
+    // returns the input UNCHANGED and we fall through to retrieveCandidates'
+    // own vector-order sort — recall is never blocked. retrieveCandidates
+    // already returns its output sorted best-first, so the non-rerank branch
+    // needs no additional sort here.
     if (rerankOn && qEmb && q && filteredResults.length >= getRerankMinCandidates()) {
-      // Pre-sort by vector order so the topN fed to the reranker is the most
-      // semantically-promising slice (filteredResults isn't sorted yet here).
-      filteredResults.sort((a: any, b: any) => b._score - a._score);
       filteredResults = await rerankCandidates(String(q), filteredResults, {
         topN: rerankTopN,
         budgetMs: getRerankBudgetMs(),
       });
-    } else {
-      filteredResults.sort((a: any, b: any) => b._score - a._score);
     }
     const topResults = filteredResults.slice(0, limit);
 

--- a/resources/collision-lib.ts
+++ b/resources/collision-lib.ts
@@ -9,10 +9,14 @@
  *   - entity-overlap candidates from WorkspaceState (internal server-side
  *     path, Sherlock Option 1 — the #678 AttentionQuery pattern) and OrgEvent
  *     (org-open read model, no per-agent scoping to respect),
- *   - semantic-match candidates from the SAME scored Memory list #550's
- *     existing code already computes during bootstrap (dot-product against
- *     the caller's embedded currentTask, `score > 0.3` relevance floor — no
- *     new embedding code here or anywhere in this feature),
+ *   - semantic-match candidates from the SAME scored candidate pool #550's
+ *     existing code already computes during bootstrap (HNSW cosine
+ *     similarity against the caller's embedded currentTask, via the bounded
+ *     retrieveCandidates() core — flair-bootstrap-scale-fix replaced the
+ *     original full-corpus JS dot-product scan with this bounded pushdown;
+ *     same `score > 0.3` relevance floor, same "no new embedding code"
+ *     property — see resources/MemoryBootstrap.ts and resources/
+ *     semantic-retrieval-core.ts),
  *   - the freshness gate from the Presence roster (resources/
  *     presence-internal.ts's getPresenceRoster(), the SAME internal path
  *     #678 established — never the raw table),
@@ -42,7 +46,7 @@ export interface EntityMatchInput {
 
 export interface SemanticMatchInput {
   agentId: string;
-  /** #550's existing dot-product score — already > 0.3 (the relevance floor) by construction. */
+  /** #550's existing candidate score (HNSW cosine similarity, flair-bootstrap-scale-fix) — already > 0.3 (the relevance floor) by construction. */
   score: number;
   /** Short display text for the matching memory (summary, falling back to content). */
   content: string;

--- a/resources/semantic-retrieval-core.ts
+++ b/resources/semantic-retrieval-core.ts
@@ -1,0 +1,395 @@
+// ─── retrieveCandidates() — the pure retrieval core (flair bootstrap-scale-fix) ──
+//
+// Extracted from resources/SemanticSearch.ts's post() (Kern-approved
+// refactor, ~/ops/FLAIR-BOOTSTRAP-SCALE-FIX.md). Before this module existed,
+// SemanticSearch.post() was one function entangling auth resolution,
+// rate-limiting, HNSW/BM25 retrieval, post-retrieval filtering, the
+// cross-encoder reranker, AND retrievalCount/lastRetrieved hit-tracking side
+// effects — so the ONLY way for MemoryBootstrap (resources/MemoryBootstrap.ts)
+// to get bounded, HNSW-pushed-down candidates was to duplicate the retrieval
+// logic or trip the side effects (an internal bootstrap call spuriously
+// bumping `retrievalCount` would pollute a ranking signal every other agent's
+// searches read).
+//
+// Boundary (Kern's review, folded into the implementation checklist): this
+// function owns SemanticSearch's retrieval + post-retrieval filtering layers —
+// the HNSW leg query construction (sort/select/conditions/limit), the BM25 +
+// union-RRF hybrid fusion, the per-record temporal/expiry/supersede filters,
+// and the scope.isAllowed() defense-in-depth re-check. It does NOT own: auth
+// resolution, rate-limiting, the reranker, or the retrievalCount/lastRetrieved
+// hit-tracking side effects — those stay in SemanticSearch.post()'s wrapper
+// (resources/SemanticSearch.ts) so an internal caller (bootstrap) never trips
+// them.
+//
+// PURE FUNCTION DISCIPLINE (Kern, non-negotiable): every param below is a
+// primitive/plain-value/function — never `this` or a SemanticSearch instance.
+// A core that took `this` would force mocking (or a later re-refactor) for
+// any second caller; this one is callable standalone, no Resource/HTTP
+// context required beyond the optional `ctx` param (only used for
+// withDetachedTxn's transaction-chain workaround — both SemanticSearch and
+// MemoryBootstrap are Harper Resources with their own `ctx`).
+//
+// Returns results AFTER all filters, sorted best-first by `_score` — bounded
+// ONLY by the `limit` the caller chose to push down (the core never
+// multiplies `limit` internally; any overfetch policy — SemanticSearch's
+// CANDIDATE_MULTIPLIER, rerank-topN widening — is the CALLER's decision, made
+// before calling in). Never exposes which internal leg (BM25+RRF hybrid vs.
+// legacy HNSW-only vs. keyword-only fallback) produced a given result — the
+// output shape is identical regardless of `hybrid`.
+import { databases } from "@harperfast/harper";
+import { withDetachedTxn } from "./table-helpers.js";
+import { wrapUntrusted } from "./content-safety.js";
+import { cosineSimilarity } from "./dedup.js";
+import { compositeScore } from "./scoring.js";
+import { buildBM25, fuseRrfNormalized, SEM_LIMIT } from "./bm25.js";
+import { isAllowedBm25Candidate, type Condition } from "./bm25-filter.js";
+
+// Convert HNSW cosine distance (1 - similarity) to similarity score.
+function distanceToSimilarity(distance: number): number {
+  return 1 - distance;
+}
+
+// Default field selection for every retrieval leg — explicit (no raw
+// `embedding`, so the large vector never enters a result payload or a
+// bootstrap-sized candidate pool) and shared between the HNSW leg and the
+// BM25 corpus fetch so a fused id always resolves to the same record shape
+// regardless of which leg produced it. Includes `summary` (agent-set dense
+// compression, resources/Memory.ts) even though SemanticSearch's own callers
+// don't read it — MemoryBootstrap's collision-surfacing block
+// (resources/collision-lib.ts's SemanticMatchInput) reads `m.summary ||
+// m.content`, so dropping it here would silently regress bootstrap's
+// "Others in the room" surface even though SemanticSearch never asserts on
+// its absence.
+const DEFAULT_SELECT = ["id", "agentId", "content", "contentHash", "visibility", "tags", "durability",
+  "source", "createdAt", "updatedAt", "expiresAt", "retrievalCount", "usageCount", "lastRetrieved",
+  "promotionStatus", "promotedAt", "promotedBy", "archived", "archivedAt", "archivedBy",
+  "parentId", "derivedFrom", "sessionId", "lastReflected", "supersedes", "subject", "summary",
+  "validFrom", "validTo", "_safetyFlags"];
+
+export interface RetrieveCandidatesParams {
+  /** Precomputed query embedding, or null/undefined when none is available
+   *  (e.g. the embedding engine failed/was never called). */
+  queryEmbedding?: number[] | null;
+  /** Raw query text — drives BM25 lexical ranking (hybrid leg) and the
+   *  legacy keyword bump (HNSW-only leg). Optional: MemoryBootstrap never
+   *  supplies this — it has no free-text query, only a precomputed
+   *  `queryEmbedding`, and per the K&S verdict bootstrap gets HNSW-leg
+   *  pushdown only, no keyword bump. */
+  q?: string;
+  /** Pre-built Harper conditions[] — the caller (SemanticSearch.post() /
+   *  MemoryBootstrap.post()) already resolved scope.condition (and, for
+   *  SemanticSearch, folded in archived/tag/subject conditions too) into
+   *  this array. The core never builds its own scoping condition — it only
+   *  pushes down whatever it's given. */
+  conditions: any[];
+  /** The literal Harper query `limit` for the HNSW/BM25 legs — the exact
+   *  candidate-pool depth fetched. The core does NOT multiply this
+   *  internally; SemanticSearch's overfetch policy (CANDIDATE_MULTIPLIER,
+   *  rerank-topN widening) and MemoryBootstrap's K formula are both computed
+   *  by the caller BEFORE calling in. */
+  limit: number;
+  /** Field selection override. Defaults to DEFAULT_SELECT (no raw
+   *  embedding). */
+  select?: string[];
+  /** Include supersede-chain predecessors that are co-present in THIS
+   *  bounded candidate set. Default false (exclude them) — matches both
+   *  SemanticSearch's and MemoryBootstrap's prior default. */
+  includeSuperseded?: boolean;
+  scoring?: "raw" | "composite";
+  temporalBoost?: number;
+  sinceDate?: Date | null;
+  asOf?: string;
+  minScore?: number;
+  /** The calling agent's own id — used ONLY to tag a result's `_source`
+   *  (cross-agent attribution). Never used to change what's fetched; that's
+   *  entirely `conditions`' job. */
+  agentId?: string;
+  /**
+   * scope.isAllowed() (resources/memory-read-scope.ts) — Sherlock's
+   * NON-NEGOTIABLE defense-in-depth re-check (flair-bootstrap-scale-fix K&S
+   * verdict). `conditions` is the PRIMARY gate — Harper's query engine
+   * should never return a row failing it — but the pushdown condition alone
+   * is not trusted as the only gate: Harper could in principle return a row
+   * matching `conditions` that still fails a stricter in-process
+   * `isAllowed` check (a visibility edge case). Re-checked on EVERY
+   * candidate in every branch below whenever provided — never skipped just
+   * because the caller already pushed a scoping condition down. This is the
+   * exact refactor mistake ("the filter pushes down now, so the re-check is
+   * redundant") that would turn a perf fix into a scope leak.
+   */
+  isAllowed?: (record: any) => boolean;
+  /**
+   * Whether to run the BM25 + union-RRF hybrid leg (true) or the legacy
+   * HNSW-only / keyword-fallback path (false). Explicit and REQUIRED — never
+   * read from hybridEnabled() internally, so a caller gets a deterministic
+   * mode regardless of the global FLAIR_HYBRID_RETRIEVAL env value.
+   * MemoryBootstrap ALWAYS passes false: the hybrid leg's BM25 corpus fetch
+   * (`corpusQuery` below) is an UNBOUNDED conditions-scoped scan (no
+   * `limit` — matches SemanticSearch's pre-existing, out-of-scope-for-this-PR
+   * behavior) run regardless of whether `q` is even supplied, which is
+   * exactly the kind of unbounded scan this PR removes bootstrap's need for.
+   * HNSW-leg-only for bootstrap is also the K&S-ratified default: BM25 for a
+   * one-shot session-load has a different (likely worse) cost profile than
+   * SemanticSearch's per-query BM25, and the reranker is a generative call
+   * per candidate — both are explicit opt-in follow-ons, not this PR.
+   */
+  hybrid: boolean;
+  /** Request context, for withDetachedTxn — both SemanticSearch and
+   *  MemoryBootstrap are Resources with their own ctx. */
+  ctx?: any;
+}
+
+export async function retrieveCandidates(params: RetrieveCandidatesParams): Promise<any[]> {
+  const {
+    queryEmbedding: qEmb, q, conditions, limit,
+    select = DEFAULT_SELECT,
+    includeSuperseded = false,
+    scoring = "raw",
+    temporalBoost = 1.0,
+    sinceDate = null,
+    asOf,
+    minScore = 0,
+    agentId,
+    isAllowed,
+    hybrid,
+    ctx,
+  } = params;
+
+  const passesAllowed = (record: any) => !isAllowed || isAllowed(record);
+  const hnswSelect = [...select, "$distance"];
+
+  const results: any[] = [];
+
+  if (hybrid) {
+    // ─── BM25 + union-RRF hybrid path ────────────────────────────────────
+    // 1. Semantic candidates via HNSW (unchanged fetch). 2. BM25 lexical pass
+    //    over the SCOPED corpus. 3. SECURITY: the BM25 candidate set is filtered
+    //    by the SAME conditions[] + temporal filters BEFORE fusion (the corpus
+    //    is fetched with those conditions, AND re-checked in-process as
+    //    defense-in-depth) so no other agent's memory is ever scored or fused.
+    //    4. Candidate-union RRF → normalize → feed as rawScore to compositeScore.
+
+    // ── (a) Semantic candidate records (best-first) ──────────────────────
+    const semRecords: any[] = [];
+    const semIds: string[] = [];
+    if (qEmb) {
+      const semQuery: any = {
+        sort: { attribute: "embedding", target: qEmb, distance: "cosine" },
+        select: hnswSelect,
+        limit,
+      };
+      if (conditions.length > 0) semQuery.conditions = conditions;
+      const semResults = withDetachedTxn(ctx, () => (databases as any).flair.Memory.search(semQuery));
+      for await (const record of semResults) {
+        if (record.expiresAt && Date.parse(record.expiresAt) < Date.now()) continue;
+        if (sinceDate && record.createdAt && new Date(record.createdAt) < sinceDate) continue;
+        if (asOf && record.validFrom && record.validFrom > asOf) continue;
+        if (asOf && record.validTo && record.validTo <= asOf) continue;
+        // A past validTo ALWAYS means the record has been closed out
+        // (server supersede path — Memory.ts closeSupersededRecord — sets
+        // validTo without necessarily setting `archived`). Unconditional, not
+        // gated on `asOf`, so a server-superseded record can't resurface just
+        // because its successor isn't co-present in this result set (the
+        // supersededIds filter further down only catches co-presence). A
+        // record with no validTo, or a future validTo, is unaffected.
+        if (record.validTo && Date.parse(record.validTo) < Date.now()) continue;
+        if (!passesAllowed(record)) continue;
+        semRecords.push(record);
+        semIds.push(record.id);
+      }
+    }
+
+    // ── (b) BM25 candidate records over the SCOPED corpus ────────────────
+    const corpusQuery: any = conditions.length > 0
+      ? { conditions, select }
+      : { select };
+    const corpusResults = withDetachedTxn(ctx, () => (databases as any).flair.Memory.search(corpusQuery));
+    const allowedById = new Map<string, any>();
+    const bm25Docs: { id: string; content?: string }[] = [];
+    for await (const record of corpusResults) {
+      // Defense-in-depth: re-check the SAME conditions[] + temporal filters
+      // in-process. Even if a Harper query change ever let an out-of-scope
+      // record through, it is dropped here BEFORE it can be BM25-scored/fused.
+      if (!isAllowedBm25Candidate(record, conditions as Condition[], { sinceDate, asOf })) continue;
+      if (!passesAllowed(record)) continue;
+      allowedById.set(record.id, record);
+      bm25Docs.push({ id: record.id, content: record.content });
+    }
+
+    // Carry semantic candidates that survived their temporal gate into the
+    // allowed map too (so a fused id always resolves to a record). Semantic
+    // records were fetched with the SAME conditions[], so they're in-scope.
+    for (const r of semRecords) {
+      if (!allowedById.has(r.id)) {
+        const { $distance, ...rest } = r;
+        allowedById.set(r.id, rest);
+      }
+    }
+
+    // ── (c) BM25 lexical ranking → top SEM_LIMIT (only when q present) ────
+    let bm25Ids: string[] = [];
+    if (q) {
+      const bm25 = buildBM25(bm25Docs);
+      const ranked = bm25.rank(String(q));
+      bm25Ids = ranked.filter(r => r.score > 0).slice(0, SEM_LIMIT).map(r => r.id);
+    }
+
+    // ── (d) No retrieval signal at all → full scoped listing ────────────
+    if (!q && !qEmb) {
+      for (const record of allowedById.values()) {
+        const rawScore = 0;
+        let finalScore = scoring === "raw" ? rawScore : compositeScore(rawScore, record);
+        if (temporalBoost > 1.0) finalScore *= temporalBoost;
+
+        const isFlagged = record._safetyFlags && Array.isArray(record._safetyFlags) && record._safetyFlags.length > 0;
+        const source = record.agentId !== agentId ? record.agentId : undefined;
+        results.push({
+          ...record,
+          content: isFlagged ? wrapUntrusted(record.content, source) : record.content,
+          _score: Math.round(finalScore * 1000) / 1000,
+          _rawScore: scoring !== "raw" ? Math.round(rawScore * 1000) / 1000 : undefined,
+          _source: source,
+        });
+      }
+    } else {
+      // ── Candidate-union RRF → normalized [0,1] rawScore ────────────────
+      const fused = fuseRrfNormalized(semIds, bm25Ids);
+
+      for (const [id, rrfRaw] of fused) {
+        const record = allowedById.get(id);
+        if (!record) continue; // should not happen — union ⊆ allowed
+        const rawScore = rrfRaw; // already normalized to [0,1]
+        let finalScore = scoring === "raw" ? rawScore : compositeScore(rawScore, record);
+        if (temporalBoost > 1.0) finalScore *= temporalBoost;
+
+        const isFlagged = record._safetyFlags && Array.isArray(record._safetyFlags) && record._safetyFlags.length > 0;
+        const source = record.agentId !== agentId ? record.agentId : undefined;
+        results.push({
+          ...record,
+          content: isFlagged ? wrapUntrusted(record.content, source) : record.content,
+          _score: Math.round(finalScore * 1000) / 1000,
+          _rawScore: scoring !== "raw" ? Math.round(rawScore * 1000) / 1000 : undefined,
+          _source: source,
+        });
+      }
+    }
+  } else if (qEmb) {
+    // ─── HNSW vector search path (legacy, hybrid flag OFF — or a caller
+    // like MemoryBootstrap forcing HNSW-leg-only regardless of the flag) ────
+    const query: any = {
+      sort: { attribute: "embedding", target: qEmb, distance: "cosine" },
+      select: hnswSelect,
+      limit,
+    };
+    if (conditions.length > 0) {
+      query.conditions = conditions;
+    }
+
+    const memoryResults = withDetachedTxn(ctx, () => (databases as any).flair.Memory.search(query));
+    for await (const record of memoryResults) {
+      if (record.expiresAt && Date.parse(record.expiresAt) < Date.now()) continue;
+      if (sinceDate && record.createdAt && new Date(record.createdAt) < sinceDate) continue;
+      if (asOf && record.validFrom && record.validFrom > asOf) continue;
+      if (asOf && record.validTo && record.validTo <= asOf) continue;
+      if (record.validTo && Date.parse(record.validTo) < Date.now()) continue;
+      if (!passesAllowed(record)) continue;
+
+      let semanticScore: number;
+      if (record.$distance !== undefined) {
+        semanticScore = distanceToSimilarity(record.$distance);
+      } else {
+        // ─── Harper's cosine-sort query omits $distance for a SINGLETON
+        // post-filter result set (see resources/SemanticSearch.ts's original
+        // writeup of this quirk, and test/integration/
+        // semantic-search-singleton-score.test.ts for the real-Harper
+        // reproduction). Fix: point-lookup the record by id and compute
+        // cosine similarity ourselves from its real stored `embedding`
+        // vector. If the stored embedding is missing/empty, cosineSimilarity
+        // returns 0 — the same safe "no match" the old `?? 1` fallback
+        // produced, never a false-high score.
+        const full = await withDetachedTxn(ctx, () => (databases as any).flair.Memory.get(record.id));
+        const storedEmbedding = Array.isArray(full?.embedding) ? full.embedding : [];
+        semanticScore = cosineSimilarity(qEmb, storedEmbedding);
+      }
+      let keywordHit = false;
+      if (q && String(record.content || "").toLowerCase().includes(String(q).toLowerCase())) {
+        keywordHit = true;
+      }
+      const rawScore = semanticScore + (keywordHit ? 0.05 : 0);
+
+      let finalScore = scoring === "raw" ? rawScore : compositeScore(rawScore, record);
+      if (temporalBoost > 1.0) finalScore *= temporalBoost;
+
+      const { $distance, ...rest } = record;
+      const isFlagged = rest._safetyFlags && Array.isArray(rest._safetyFlags) && rest._safetyFlags.length > 0;
+      const source = record.agentId !== agentId ? record.agentId : undefined;
+      results.push({
+        ...rest,
+        content: isFlagged ? wrapUntrusted(rest.content, source) : rest.content,
+        _score: Math.round(finalScore * 1000) / 1000,
+        _rawScore: scoring !== "raw" ? Math.round(rawScore * 1000) / 1000 : undefined,
+        _source: source,
+      });
+    }
+  } else {
+    // ─── No embedding available — keyword-only fallback ──────────────────
+    // Full scan is only used when there's no query embedding (e.g. tag-only
+    // or subject-only searches, or when the embedding engine is unavailable).
+    // Pre-existing, out-of-scope-for-this-PR behavior — MemoryBootstrap never
+    // reaches this branch (it only calls in when it already has a
+    // queryEmbedding).
+    const query: any = conditions.length > 0 ? { conditions } : {};
+    const memoryResults = withDetachedTxn(ctx, () => (databases as any).flair.Memory.search(query));
+    for await (const record of memoryResults) {
+      if (record.expiresAt && Date.parse(record.expiresAt) < Date.now()) continue;
+      if (sinceDate && record.createdAt && new Date(record.createdAt) < sinceDate) continue;
+      if (asOf && record.validFrom && record.validFrom > asOf) continue;
+      if (asOf && record.validTo && record.validTo <= asOf) continue;
+      if (record.validTo && Date.parse(record.validTo) < Date.now()) continue;
+      if (!passesAllowed(record)) continue;
+
+      let keywordHit = false;
+      if (q && String(record.content || "").toLowerCase().includes(String(q).toLowerCase())) {
+        keywordHit = true;
+      }
+      const rawScore = keywordHit ? 0.05 : 0;
+      if (q && rawScore === 0) continue;
+
+      const { embedding, ...rest } = record;
+      let finalScore = scoring === "raw" ? rawScore : compositeScore(rawScore, rest);
+      if (temporalBoost > 1.0) finalScore *= temporalBoost;
+
+      const isFlagged = rest._safetyFlags && Array.isArray(rest._safetyFlags) && rest._safetyFlags.length > 0;
+      const source = record.agentId !== agentId ? record.agentId : undefined;
+      results.push({
+        ...rest,
+        content: isFlagged ? wrapUntrusted(rest.content, source) : rest.content,
+        _score: Math.round(finalScore * 1000) / 1000,
+        _rawScore: scoring !== "raw" ? Math.round(rawScore * 1000) / 1000 : undefined,
+        _source: source,
+      });
+    }
+  }
+
+  // Build superseded set and filter (unless caller opts in to see full
+  // history) — computed from THIS bounded result set alone (per-set, never
+  // cross-applied — see this PR's supersededIds doc in MemoryBootstrap.ts for
+  // the full caveat: the unconditional past-validTo exclusion above is the
+  // primary supersede guard; this co-presence check is a secondary belt).
+  let filteredResults = results;
+  if (!includeSuperseded) {
+    const supersededIds = new Set<string>();
+    for (const r of results) {
+      if (r.supersedes) supersededIds.add(r.supersedes);
+    }
+    filteredResults = results.filter((r: any) => !supersededIds.has(r.id));
+  }
+
+  // Apply minimum score filter
+  if (minScore > 0) {
+    filteredResults = filteredResults.filter((r: any) => r._score >= minScore);
+  }
+
+  filteredResults.sort((a: any, b: any) => b._score - a._score);
+  return filteredResults;
+}

--- a/test/integration/memory-visibility-scoping-e2e.test.ts
+++ b/test/integration/memory-visibility-scoping-e2e.test.ts
@@ -199,11 +199,15 @@ describe("within-org-read-open — private/shared visibility + centralized read-
       const bodyText = await res.text();
       expect(res.status, `bootstrap → ${res.status}: ${bodyText.slice(0, 2000)}`).toBe(200);
       const body: any = JSON.parse(bodyText);
-      // Layer 1's read boundary (what this file owns): the legacy (no-visibility
-      // → reads as shared) + explicitly-shared records are in the grantee's
-      // read-scope; the owner's PRIVATE record is not. `memoriesAvailable` is
-      // the read-scope signal (allMemories.length), independent of rendering.
-      expect(body.memoriesAvailable, `grantee read-scope should be exactly legacy+shared=2 — got ${body.memoriesAvailable}`).toBe(2);
+      // `memoriesAvailable` (flair-bootstrap-scale-fix) is now the OWN-scoped
+      // count (agentId==self, a cheap indexed seek) — no longer a read-scope
+      // signal. The grantee owns ZERO memories in this fixture (only `owner`
+      // does), so it's 0 regardless of what's readable. The actual read-scope
+      // proof (legacy + shared readable, private excluded) is Path 1/2's job
+      // above (Memory GET/collection, SemanticSearch) — this assertion is
+      // just confirming the new count reflects "mine", not "everything I can
+      // read".
+      expect(body.memoriesAvailable, `grantee's OWN memory count should be 0 (fixture seeds none for grantee) — got ${body.memoriesAvailable}`).toBe(0);
       // #550 design boundary: these owner records are grant-visible TEAMMATE
       // memories, and they were raw-inserted (no embeddings) so they can't
       // surface via the task-relevant "Teammate findings" path either. With
@@ -220,9 +224,12 @@ describe("within-org-read-open — private/shared visibility + centralized read-
       const res = await authFetch(harper, stranger, "POST", "/BootstrapMemories", { agentId: stranger.id, maxTokens: 4000 });
       expect(res.status).toBe(200);
       const body: any = await res.json();
-      // Same read-scope as the grantee above — proving the grant was never
-      // what gated this.
-      expect(body.memoriesAvailable, `stranger read-scope should be exactly legacy+shared=2 — got ${body.memoriesAvailable}`).toBe(2);
+      // Same reasoning as the grantee above: `memoriesAvailable` is now
+      // own-scoped, and the stranger owns zero memories in this fixture too
+      // — proving the grant was never what gated read-scope (Path 1/2 above
+      // are the read-scope proof) and that this cosmetic count doesn't
+      // secretly reintroduce a scope-wide computation either.
+      expect(body.memoriesAvailable, `stranger's OWN memory count should be 0 (fixture seeds none for stranger) — got ${body.memoriesAvailable}`).toBe(0);
       expect(body.context ?? "").not.toContain("pre-migration finding");
       expect(body.context ?? "").not.toContain("explicitly shared finding");
       expect(body.context ?? "").not.toContain("explicitly private note");

--- a/test/unit/memory-bootstrap-scoping.test.ts
+++ b/test/unit/memory-bootstrap-scoping.test.ts
@@ -25,13 +25,15 @@ delete (process.env as any).FLAIR_PUBLIC;
 
 // Deterministic task-relevance scoring without a real embedding model — same
 // technique as test/unit/memory-integrity.test.ts (constant vector → cosine
-// 1.0 between any two records using it), sized to clear MemoryBootstrap.ts's
-// OWN scored-path candidate filter (`m.embedding?.length > 100` — a record
-// with a short/absent embedding is never even considered "task-relevant").
-// MemoryBootstrap.ts's task-relevant path calls getEmbedding(currentTask) for
-// the query vector and reads `record.embedding` directly off whatever's in
-// the mock store, so the SAME 128-length vector on both sides deterministically
-// clears both the length gate and the `score > 0.3` threshold (dot product
+// 1.0 between any two records using it). MemoryBootstrap.ts's task-relevant
+// path (flair-bootstrap-scale-fix: now routed through the shared
+// retrieveCandidates() core, resources/semantic-retrieval-core.ts) calls
+// getEmbedding(currentTask) for the query vector; this mock's Memory.search()
+// never annotates $distance (no real HNSW sort), so retrieveCandidates()
+// falls back to its point-lookup cosine path (Memory.get(), also mocked
+// above), reading `record.embedding` directly off whatever's in the mock
+// store. The SAME 128-length vector on both sides deterministically clears
+// the `_score > 0.3` (TASK_RELEVANCE_FLOOR) threshold (cosine similarity
 // with itself = 1). memory-integrity.test.ts's own mock of this module only
 // needs "a constant vector returned every call" (never compares its literal
 // values against anything) — length differing between the two files' mocks
@@ -74,7 +76,18 @@ function emptyGen() {
 
 const databasesMock = {
   flair: {
-    Memory: { search: (query: any) => memorySearchGen(query) },
+    // `get` added for the flair-bootstrap-scale-fix refactor: bootstrap's
+    // task-relevant candidate pool now goes through the SAME
+    // retrieveCandidates() core SemanticSearch.ts uses (resources/
+    // semantic-retrieval-core.ts), which point-looks-up a record by id via
+    // Memory.get() whenever a search result's $distance is undefined — this
+    // mock's memorySearchGen() never annotates $distance (no real HNSW sort),
+    // so every task-relevant test below exercises that fallback. Same
+    // pattern as test/unit/semantic-search-scoping.test.ts's mock.
+    Memory: {
+      search: (query: any) => memorySearchGen(query),
+      get: async (id: any) => memoryStore.get(typeof id === "string" ? id : id?.id) ?? null,
+    },
     MemoryGrant: {
       search: (query: any) => {
         const conditions = Array.isArray(query?.conditions) ? query.conditions : [];
@@ -116,10 +129,19 @@ function reset() {
 // proxy for "was this memory actually surfaced" without reaching into internal
 // state. NOTE (#550 design boundary): for a TEAMMATE (grant-visible) record
 // that proxy holds ONLY when the record is task-relevant — the permanent /
-// recent / predicted sections are own-only, so a teammate record entering
-// read-scope (`memoriesAvailable`) is decoupled from whether it renders. The
-// read-scope tests below therefore assert `memoriesAvailable` for teammate
-// records, and rendering is covered by the #550 describe block further down.
+// recent / predicted sections are own-only, so a teammate record being
+// READABLE is decoupled from whether it renders (own-context sections never
+// blend in a teammate's record regardless of read-scope). Rendering is
+// covered by the #550 describe block further down.
+//
+// `memoriesAvailable` (flair-bootstrap-scale-fix): no longer a read-scope
+// proxy — it's now the OWN-scoped count (agentId==self, a cheap indexed
+// seek), replacing the org-wide "own + every readable cross-agent record"
+// exact count (computing that exactly WAS the scan this PR removes). The
+// tests below assert it as "how many of MY OWN records are available",
+// not as a stand-in for whether a cross-agent record is in read-scope —
+// that read-scope proof lives in the dedicated e2e coverage
+// (test/integration/memory-visibility-scoping-e2e.test.ts).
 
 describe("MemoryBootstrap.post() — centralized read-scoping", () => {
   it("read-scope includes the caller's own memories PLUS any other agent's non-private memory — no grant required (within-org-read-open)", async () => {
@@ -138,7 +160,12 @@ describe("MemoryBootstrap.post() — centralized read-scoping", () => {
     // scope at all.
     expect(res.context).not.toContain("NOT-MINE-BUT-ORG-OPEN-FINDING");
     expect(res.context).not.toContain("NOT-MINE-PRIVATE-FINDING");
-    expect(res.memoriesAvailable).toBe(2);
+    // flair-bootstrap-scale-fix: `memoriesAvailable` is now the OWN-scoped
+    // count (agentId==self, a cheap indexed seek), not the org-wide
+    // scope-wide count — computing the scope-wide figure exactly WAS the
+    // scan this PR removes. Only m1 (own) counts; m2 (cross-agent, in
+    // read-scope but not own) no longer inflates this number.
+    expect(res.memoriesAvailable).toBe(1);
   });
 
   it("a grant-holder's read-scope now includes the owner's SHARED memory (the flair#550 gap this closes) — but it does NOT bleed into own-context sections", async () => {
@@ -148,9 +175,11 @@ describe("MemoryBootstrap.post() — centralized read-scoping", () => {
 
     const b = makeBootstrap(agentCtx("agent-grantee"));
     const res: any = await b.post({ agentId: "agent-grantee", includeSoul: false }); // no currentTask
-    // The grant-gated model: the SHARED memory is in the reader's read-scope ...
-    expect(res.memoriesAvailable).toBe(1);
-    // ... but the #550 design boundary keeps it out of the reader's OWN
+    // The SHARED memory is readable (open-within-org) but it's the OWNER's,
+    // not the reader's — `memoriesAvailable` is now own-scoped
+    // (flair-bootstrap-scale-fix), and the reader owns zero records here.
+    expect(res.memoriesAvailable).toBe(0);
+    // ... and the #550 design boundary ALSO keeps it out of the reader's OWN
     // permanent/recent/predicted view — with no currentTask, its only surface
     // (the task-relevant "Teammate findings" section) is inactive, so it
     // renders nowhere. This is the non-bleed guarantee.
@@ -175,23 +204,31 @@ describe("MemoryBootstrap.post() — centralized read-scoping", () => {
 
     const b = makeBootstrap(agentCtx("agent-grantee"));
     const res: any = await b.post({ agentId: "agent-grantee", includeSoul: false });
-    // The no-visibility-field invariant lives at the READ-SCOPE layer: an absent visibility
-    // field reads as shared, so the legacy record enters the grantee's scope
-    // (vs. a private record, which would not — see the private-exclusion test's
-    // memoriesAvailable === 0). Rendering is still own-only, so with no
-    // currentTask it doesn't bleed into the reader's own-context view.
-    expect(res.memoriesAvailable).toBe(1);
+    // The no-visibility-field invariant lives at the READ-SCOPE layer: an absent
+    // visibility field reads as shared, so the legacy record is READABLE by
+    // the grantee (see the dedicated read-scope e2e coverage in
+    // test/integration/memory-visibility-scoping-e2e.test.ts for the
+    // read-path proof). `memoriesAvailable` (flair-bootstrap-scale-fix) is
+    // now own-scoped, though, and the reader owns zero records here — the
+    // legacy record is the OWNER's, not the reader's, so it doesn't count.
+    // Rendering is still own-only, so with no currentTask it doesn't bleed
+    // into the reader's own-context view either.
+    expect(res.memoriesAvailable).toBe(0);
     expect(res.context).not.toContain("LEGACY-PRE-MIGRATION-FINDING");
   });
 
-  it("within-org-read-open: an ungranted owner's SHARED memory IS now in read-scope (memoriesAvailable), though it still doesn't bleed into own-context sections without a currentTask", async () => {
+  it("within-org-read-open: an ungranted owner's SHARED memory is readable, though it still doesn't bleed into own-context sections without a currentTask", async () => {
     reset();
     memoryStore.set("shared-no-grant", { id: "shared-no-grant", agentId: "agent-owner", content: "SHARED-BUT-UNGRANTED", visibility: "shared", durability: "permanent", createdAt: "2026-01-01T00:00:00Z" });
 
     const b = makeBootstrap(agentCtx("agent-stranger"));
     const res: any = await b.post({ agentId: "agent-stranger", includeSoul: false });
     expect(res.context).not.toContain("SHARED-BUT-UNGRANTED");
-    expect(res.memoriesAvailable).toBe(1);
+    // `memoriesAvailable` is own-scoped (flair-bootstrap-scale-fix) — the
+    // reader (agent-stranger) owns zero records; the shared record is the
+    // OWNER's. The read-scope proof itself (that this record is reachable
+    // at all) lives in the dedicated e2e coverage, not this cosmetic count.
+    expect(res.memoriesAvailable).toBe(0);
   });
 
   it("private-exclusion still holds without a grant: a stranger's read-scope never includes another agent's PRIVATE memory", async () => {
@@ -469,7 +506,9 @@ describe("MemoryBootstrap.post() — flair#550 teammate-findings attribution + s
     expect(res.context).toContain("## Core Principles");
     expect(res.context).toContain("MY-OWN-PERMANENT-RULE");         // own → renders
     expect(res.context).not.toContain("TEAMMATE-PERMANENT-RULE");   // teammate → no bleed
-    expect(res.memoriesAvailable).toBe(2);                          // both in read-scope
+    // `memoriesAvailable` is own-scoped (flair-bootstrap-scale-fix) — only
+    // own-perm counts; teammate-perm is the OWNER's, readable but not owned.
+    expect(res.memoriesAvailable).toBe(1);
   });
 
   it("a teammate's grant-visible RECENT memory does NOT appear in the reader's Recent Context section", async () => {


### PR DESCRIPTION
## Summary

`MemoryBootstrap.post()` loaded the entire org's non-private Memory corpus into RAM on every bootstrap call (`Memory.search({conditions:[scope.condition]})` with no `limit`/`select` — every row's full 768-float embedding vector included), then ran a hand-rolled O(N·d) JS dot-product scan over all of it. Both scale with the size of the whole org's memory corpus, not the caller's own — a liability on a hot, every-session path.

This PR replaces that with bounded, pushed-down queries, in two logical commits:

**1. Extract a pure retrieval core from `SemanticSearch`**

`resources/semantic-retrieval-core.ts` — a side-effect-free `retrieveCandidates()` function extracted from `SemanticSearch.post()`. It owns the HNSW/BM25 retrieval + all post-retrieval filtering (temporal/expiry/supersede exclusion, the `scope.isAllowed()` defense-in-depth re-check) and takes only primitives (no `this`/Resource instance). Auth, rate-limiting, the reranker, and the `retrievalCount`/`lastRetrieved` hit-tracking side effects stay in `SemanticSearch.post()`'s wrapper, so an internal bootstrap call never trips them. `SemanticSearch`'s own behavior is unchanged — proven by its full unit-test suite staying green and by the isolated recall-harness returning byte-identical numbers before/after (see below).

**2. Rewire `MemoryBootstrap` onto bounded queries**

- Own-scoped lifecycle slices (permanent / recent / predicted) now come from `Memory.search` calls conditioned on `agentId==self` (+ durability/createdAt, all `@indexed`), with an explicit `select` (no raw embedding) — replacing the post-load JS filter over the full org corpus.
- Task-relevant / teammate / collision surfaces now draw from a bounded HNSW candidate pool via the same `retrieveCandidates()` core, HNSW-leg only (no BM25 fusion, no reranker — a different cost profile for a one-shot session load; opt-in follow-on). Pool size `K = max(3 × expected fill, 5 × teammate count, 50)`, capped at 100.
- `scope.isAllowed()` is re-checked on every candidate from every bounded query (the pushdown condition is the primary gate; this is the belt).
- Supersede exclusion is computed per-set (own slices independently, candidate pool independently) — the unconditional past-`validTo` guard (the primary supersede defense) is preserved verbatim.
- The org-wide exact `memoriesAvailable` count is replaced with an own-scoped count (`agentId==self`, a cheap indexed seek) — computing the old exact figure was itself the scan being removed.

No scope widening: own-scoped queries are strictly narrower than the previous load-then-filter; the candidate pool carries the identical `scope.condition` (own OR non-private).

## Test plan

- [x] `bun test test/unit/` — 1988 pass, 0 fail (includes SemanticSearch's own scoping/singleton-score unit tests, proving the core extraction is behavior-neutral)
- [x] `bun test test/integration/` — 267 pass, 0 fail, real Harper + real embeddings (includes `bootstrap-collision-e2e`, `bootstrap-teammate-findings-e2e`, `bootstrap-supersede-resurface`, `memory-visibility-scoping-e2e`)
- [x] Isolated recall-harness (`test/bench/recall-harness/run.ts --hybrid on`), same repo/hardware, main vs. branch: byte-identical p@3/MRR on both — no recall regression
- [x] Measured scale win: seeded a synthetic org corpus into an ephemeral Harper instance and called `/BootstrapMemories` before/after — latency and RSS reported below

### Recall harness (main vs. branch, same 87-record corpus, hybrid=true, single run each)

| | p@3 | MRR |
|---|---|---|
| main (before) | 0.967 | 0.892 |
| branch (after) | 0.967 | 0.892 |

Byte-identical — proves the `SemanticSearch` extraction is behavior-neutral.

### Scale measurement (synthetic org corpus: 80 teammate agents × 75 records = 6,000 org-wide records + 100 own records = 6,100 total, ephemeral Harper, same seeding script both runs, 6 reps)

| | cold call | warm mean (5 reps) |
|---|---|---|
| main (before) | 350ms | 309ms |
| branch (after) | 91ms | 48ms |

**~3.9x faster cold, ~6.5x faster warm.** `memoriesAvailable` also changed as designed: main reported 568 (the org-wide scope count), branch reports 100 (exactly the seeded own-record count — the own-scoped count is now precise and cheap by construction).

Process RSS (sampled via `ps` during each call) didn't cleanly discriminate at this corpus size — both runs sit at ~880-900MB, dominated by the embedding model + Harper server baseline footprint that's already resident regardless of the request; a per-request difference on the order of single-digit MB doesn't reliably surface in whole-process RSS at 15ms sampling granularity. The eliminated per-request array (6,100 records × a 768-float embedding each ≈ 21MB of live JS heap under the old code, scaling linearly with org corpus size going forward) is real but not independently visible against that baseline in this harness — latency is the clean, measured signal here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
