### PR TITLE
ci(migrations): downgrade-and-revert + restore-drill lanes + upgrade-lane migration assertions

### DIFF
--- a/.github/workflows/migration-ci-lanes.yml
+++ b/.github/workflows/migration-ci-lanes.yml
@@ -1,0 +1,464 @@
+# Migration CI lanes (ops-1l18 enforcement arm) — the K&S-ratified, per-PR
+# proof of the migration safety invariants (~/ops/FLAIR-MIGRATION-SAFETY.md)
+# for the zero-touch boot-keyed auto-migration runner (~/ops/FLAIR-ZERO-TOUCH-UPGRADE.md,
+# resources/migrations/*, PR #690). Extends ~/ops/FLAIR-CI-FOUNDATION.md §2's
+# upgrade-path CI with the two lanes Kern's design-review verdict called
+# non-negotiable:
+#
+#   - downgrade-and-revert: "the proof of invariant I" — a PR build that goes
+#     bad mid-migration must not brick the fleet; reinstalling the previously
+#     published release must boot cleanly against the partially-migrated
+#     store. Runs PER MIGRATION PR, not nightly-only.
+#   - snapshot-restore drill: invariant III ("a backup that has never been
+#     restored is a prayer") — proves the restore path actually recovers
+#     corrupted content, not just that a snapshot file gets written.
+#
+# The third ratified lane (upgrade-lane migration assertions: auto-migration
+# ran, content-hash envelope match=true, recall parity) extends the EXISTING
+# `upgrade-smoke` job in test.yml instead of duplicating it here — see that
+# file's comment block on the extension.
+#
+# Sherlock §4 compliance (FLAIR-CI-FOUNDATION.md): pull_request trigger only
+# (never pull_request_target with PR-code checkout); no secrets exposed to
+# either job (public npm install + public GITHUB_TOKEN-default only — no
+# NPM_TOKEN, no deploy credentials); every third-party action below is
+# pinned to a full commit SHA, not a tag; no `${{ }}` interpolation of
+# PR-controlled metadata (title/body/branch) into any `run:` block — the only
+# `${{ }}` uses here are `github.workspace` (runner-controlled, not
+# PR-controlled) and this workflow's own step outputs.
+name: Migration CI Lanes
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  # ── Downgrade-and-revert (Kern: "non-negotiable per migration PR") ───────
+  # Scenario (mirrors a real bad-PR-build incident exactly):
+  #   1. Install the previously-published release, init, seed a corpus AS the
+  #      reserved synthetic-migration test agent via the real CLI write path.
+  #   2. Swap in the PR build, restart (boot-keyed — this is the boot that
+  #      discovers the seeded rows as pending), with the test-migration gate
+  #      on and the batch delay widened so the synthetic migration runs slow
+  #      enough to catch genuinely mid-flight.
+  #   3. Kill Harper while it's mid-migration (a real SIGTERM, not simulated).
+  #   4. Reinstall (start) the previously-published release again against
+  #      that SAME, now partially-migrated data directory.
+  #   5. Assert: it boots (health OK) and serves the seeded corpus correctly
+  #      — byte-identical content, exact count — through BOTH a version-stable
+  #      raw ops-API read (same rationale as
+  #      test/compat/downgrade-boot.test.ts's fetchAgentMemories: doesn't
+  #      depend on either build's CLI/REST auth resolution, which has
+  #      genuinely differed across versions) AND a real `flair memory search`
+  #      CLI round-trip.
+  downgrade-and-revert:
+    name: Migration downgrade-and-revert (invariant I proof)
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+
+      - uses: oven-sh/setup-bun@735343b667d3e6f658f44d0eca948eb6282f2b76 # v2
+        with:
+          bun-version: "1.3.10"
+
+      # Node 22 — same native-Harper-spawn stability rationale test.yml's
+      # "Integration Tests" job documents (avoids a known HNSW race present
+      # only under the Docker image's bundled Node 24, not native spawns).
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: "22"
+
+      - uses: socketdev/action@ba6de6cc0565af1f42295590380973573297e31f # v1.3.2
+        with:
+          mode: firewall-free
+
+      - run: sfw bun install --frozen-lockfile
+
+      - name: Install linux-x64 native binary for embeddings (HEAD build)
+        run: bun add --no-save @node-llama-cpp/linux-x64@3
+
+      - run: bun run build && bun run build:cli
+
+      # Pre-downloaded ONCE and pointed at by FLAIR_MODELS_DIR (below) for
+      # BOTH the baseline and PR-build boots. Deliberate: it keeps
+      # `getModelId()`'s embeddingModel stamp identical across the swap
+      # (embedding-stamp — the always-on derived-only migration that runs
+      # BEFORE the synthetic one in registry order — would otherwise see the
+      # freshly-seeded rows as stale the moment the model becomes ready and
+      # contend with the synthetic migration for the mid-flight window this
+      # lane depends on catching deterministically; the resume-after-kill
+      # integration test hit exactly this class of flake and pins
+      # FLAIR_EMBEDDING_MODEL for the same reason — this lane's CLI-seeded
+      # rows sidestep it a different way: a real, synchronous, correctly-
+      # stamped embed at write time on both sides of the swap).
+      - name: Pre-download embedding model (shared by baseline + PR build)
+        run: |
+          set -euo pipefail
+          mkdir -p models
+          curl -fSL --retry 5 --retry-delay 10 --retry-all-errors --connect-timeout 30 \
+            "https://huggingface.co/nomic-ai/nomic-embed-text-v1.5-GGUF/resolve/main/nomic-embed-text-v1.5.Q4_K_M.gguf" \
+            -o models/nomic-embed-text-v1.5.Q4_K_M.gguf
+          echo "Model downloaded ($(du -sh models/*.gguf | cut -f1))"
+
+      - name: Pack HEAD (PR build)
+        id: pack
+        run: |
+          set -euo pipefail
+          npm pack
+          echo "TGZ_PATH=$(pwd)/$(ls tpsdev-ai-flair-*.tgz)" >> "$GITHUB_OUTPUT"
+
+      - name: Downgrade-and-revert drill
+        env:
+          TGZ_PATH: ${{ steps.pack.outputs.TGZ_PATH }}
+        run: |
+          set -euo pipefail
+          source "$GITHUB_WORKSPACE/scripts/ci/migration-lane-lib.sh"
+
+          PORT=19995
+          OPS_PORT=$((PORT - 1))
+          BASE_URL="http://127.0.0.1:${PORT}"
+          OPS_URL="http://127.0.0.1:${OPS_PORT}"
+          DATA_DIR="$HOME/.flair/data"
+          DIAG_DIR="$GITHUB_WORKSPACE/diagnostics/downgrade-and-revert"
+          mkdir -p "$DIAG_DIR"
+          export FLAIR_ADMIN_PASS="downgrade-lane-admin-$$"
+          export FLAIR_MODELS_DIR="$GITHUB_WORKSPACE/models"
+          # Self-diagnosing (deliverable #4): ANY failing command in this
+          # script dumps HealthDetail + the migrations state file + Harper's
+          # own hdb.log tail (see the module doc on why that file, not the
+          # spawned process's stdout, carries Harper-internal diagnostics on
+          # Linux) before the step fails — no separate evidence-gathering
+          # cycle needed to triage a red run.
+          trap 'dump_migration_diagnostics "$DATA_DIR" "$BASE_URL" "$FLAIR_ADMIN_PASS" "$DIAG_DIR"' ERR
+
+          ROW_COUNT=140            # 3 batches at the schema-additive batch size (50) —
+          DELAY_MS=2500            # matches migrations-resume-after-kill.test.ts's proven
+                                    # constants for reliably catching a genuine mid-flight window.
+          RUN_ID="dg-${GITHUB_RUN_ID:-local}-$$"
+
+          # ── 1. Install the previously-published baseline ──────────────────
+          BASE_DIR=$(mktemp -d)
+          ( cd "$BASE_DIR" && npm init -y > /dev/null )
+          ( cd "$BASE_DIR" && npm install @tpsdev-ai/flair@latest )
+          ( cd "$BASE_DIR" && npm install --no-save @node-llama-cpp/linux-x64@3 )
+          BASE_FLAIR="node $BASE_DIR/node_modules/@tpsdev-ai/flair/dist/cli.js"
+          BASELINE_VERSION=$(node -p "require('$BASE_DIR/node_modules/@tpsdev-ai/flair/package.json').version")
+          HEAD_VERSION=$(node -p "require('$GITHUB_WORKSPACE/package.json').version")
+          echo "Baseline (previously published): ${BASELINE_VERSION} — HEAD (PR build): ${HEAD_VERSION}"
+
+          # ── 2. Init baseline, seed the corpus AS the reserved synthetic-
+          # migration test agent, via the real CLI write path (flair memory
+          # add -> HTTP PUT /Memory/:id -> Memory.post(), the SAME path a
+          # real user's writes take — never the raw ops API bypass the
+          # resume-after-kill integration test needs for a different reason). ──
+          $BASE_FLAIR init --agent-id downgrade-lane --port $PORT --admin-pass "$FLAIR_ADMIN_PASS" --skip-soul
+
+          echo "Seeding ${ROW_COUNT} rows as the reserved synthetic-migration test agent..."
+          EXPECTED_CONTENT_FILE="$DIAG_DIR/expected-content.txt"
+          : > "$EXPECTED_CONTENT_FILE"
+          for i in $(seq 1 "$ROW_COUNT"); do
+            CONTENT="downgrade-drill-row-${i}-${RUN_ID}"
+            echo "$CONTENT" >> "$EXPECTED_CONTENT_FILE"
+            $BASE_FLAIR memory add --agent "$RESERVED_TEST_AGENT_ID" --content "$CONTENT" > /dev/null
+            if (( i % 20 == 0 )); then echo "  seeded ${i}/${ROW_COUNT}"; fi
+          done
+          echo "Seed complete."
+
+          fetch_agent_memories_json "$OPS_URL" "$FLAIR_ADMIN_PASS" "$RESERVED_TEST_AGENT_ID" > "$DIAG_DIR/seeded-rows-pre-swap.json"
+          SEEDED_COUNT=$(node -e "console.log(JSON.parse(require('fs').readFileSync('$DIAG_DIR/seeded-rows-pre-swap.json','utf8')).length)")
+          [[ "$SEEDED_COUNT" == "$ROW_COUNT" ]] || { echo "::error::seeded ${SEEDED_COUNT} rows, expected ${ROW_COUNT} — setup broken, not a downgrade regression"; exit 1; }
+          echo "Confirmed ${SEEDED_COUNT} seeded rows readable on baseline before the swap."
+
+          # ── 3. Stop baseline. Confirm it actually exited (flair stop sends
+          # SIGTERM and returns immediately — see src/cli.ts's own comment on
+          # this race) before touching the data dir with a different binary. ──
+          $BASE_FLAIR stop --port $PORT || true
+          wait_for_http_down "${BASE_URL}/Health" 30 "baseline Harper (post-stop)"
+
+          # ── 4. Install the PR build fresh, in its own directory (never
+          # overwrite baseline's node_modules in place — the exact npm
+          # arborist/teardown race upgrade-smoke's own comment documents,
+          # flair#611). ──
+          HEAD_DIR=$(mktemp -d)
+          ( cd "$HEAD_DIR" && npm init -y > /dev/null )
+          ( cd "$HEAD_DIR" && npm install "$TGZ_PATH" )
+          ( cd "$HEAD_DIR" && npm install --no-save @node-llama-cpp/linux-x64@3 )
+          HEAD_FLAIR="node $HEAD_DIR/node_modules/@tpsdev-ai/flair/dist/cli.js"
+          NEW=$(node -p "require('$HEAD_DIR/node_modules/@tpsdev-ai/flair/package.json').version")
+          [[ "$NEW" == "$HEAD_VERSION" ]] || { echo "::error::expected ${HEAD_VERSION} in node_modules, got ${NEW}"; exit 1; }
+
+          # ── 5. Swap in the PR build against baseline's SAME data dir
+          # (default ~/.flair/data — neither install overrides HOME), with
+          # the synthetic-migration gate on and the batch delay widened. This
+          # boot is the one that discovers the seeded rows as pending. ──
+          export FLAIR_ENABLE_TEST_MIGRATIONS=1
+          export FLAIR_MIGRATION_TEST_BATCH_DELAY_MS=$DELAY_MS
+          $HEAD_FLAIR start --port $PORT
+          wait_for_http_ok "${BASE_URL}/Health" 90 "PR-build Harper (post-restart)"
+
+          # ── 6. Wait until the synthetic migration is GENUINELY mid-flight
+          # (not just "running" — rowsDone>0 AND rowsRemaining>0), bounded
+          # retry throughout (never a single-shot probe — the flair#691 class
+          # of bug this PR also fixes in the tarball-smoke lane). ──
+          wait_for_migration_mid_flight "$BASE_URL" "$FLAIR_ADMIN_PASS" "$SYNTHETIC_MIGRATION_ID" 150 90
+
+          # ── 7. The real kill — SIGTERM mid-migration, confirmed exited. ──
+          $HEAD_FLAIR stop --port $PORT || true
+          wait_for_http_down "${BASE_URL}/Health" 30 "PR-build Harper (post-kill)"
+
+          # ── 8. Reinstall the previously-published release: start the SAME
+          # already-installed baseline binary again against the now
+          # partially-migrated data directory — exactly what a real operator
+          # downgrade is (`flair stop && npm install -g @tpsdev-ai/flair@<prev>
+          # && flair restart`), no re-init, no touching the files by hand. ──
+          unset FLAIR_ENABLE_TEST_MIGRATIONS FLAIR_MIGRATION_TEST_BATCH_DELAY_MS
+          $BASE_FLAIR start --port $PORT
+          wait_for_http_ok "${BASE_URL}/Health" 90 "baseline Harper (post-downgrade)"
+          wait_for_flair_status_running "$BASE_FLAIR" "$PORT" 60
+
+          # ── 9. Assert the old binary serves the corpus CORRECTLY, not just
+          # that it boots — the honest bar per FLAIR-MIGRATION-SAFETY.md
+          # invariant II ("still serving on the pre-migration shape"). ──
+          fetch_agent_memories_json "$OPS_URL" "$FLAIR_ADMIN_PASS" "$RESERVED_TEST_AGENT_ID" > "$DIAG_DIR/post-downgrade-rows.json"
+          ACTUAL_COUNT=$(node -e "console.log(JSON.parse(require('fs').readFileSync('$DIAG_DIR/post-downgrade-rows.json','utf8')).length)")
+          [[ "$ACTUAL_COUNT" == "$ROW_COUNT" ]] || { echo "::error::post-downgrade row count ${ACTUAL_COUNT} != expected ${ROW_COUNT} — DATA LOSS across the downgrade"; exit 1; }
+
+          node -e "
+            const fs = require('fs');
+            const rows = JSON.parse(fs.readFileSync('$DIAG_DIR/post-downgrade-rows.json', 'utf8'));
+            const actual = rows.map((r) => r.content).sort();
+            const expected = fs.readFileSync('$EXPECTED_CONTENT_FILE', 'utf8').trim().split('\n').sort();
+            if (JSON.stringify(actual) !== JSON.stringify(expected)) {
+              console.error('content mismatch after downgrade — some seeded rows changed or were lost');
+              process.exit(1);
+            }
+            console.log('all ${ROW_COUNT} seeded rows byte-identical after downgrade against the partially-migrated store (raw ops-API read)');
+          "
+
+          # Real CLI round-trip too (not just the version-stable raw read) —
+          # picks the first seeded row's exact content as the query.
+          ANCHOR_CONTENT="downgrade-drill-row-1-${RUN_ID}"
+          SEARCH_OUT=$(FLAIR_URL="$BASE_URL" FLAIR_ADMIN_PASS="$FLAIR_ADMIN_PASS" $BASE_FLAIR memory search --agent "$RESERVED_TEST_AGENT_ID" --q "$ANCHOR_CONTENT")
+          echo "$SEARCH_OUT" | grep -q "$ANCHOR_CONTENT" || { echo "::error::baseline 'flair memory search' round-trip did not find the seeded marker after downgrade"; exit 1; }
+
+          echo "✅ downgrade-and-revert: old binary (${BASELINE_VERSION}) boots and serves ${ROW_COUNT} seeded rows correctly against the store PR build ${HEAD_VERSION} left partially migrated."
+
+          $BASE_FLAIR stop --port $PORT || true
+
+      - name: Upload diagnostics (failure only)
+        if: failure()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: downgrade-and-revert-diagnostics
+          path: diagnostics/downgrade-and-revert/
+          retention-days: 7
+          if-no-files-found: ignore
+
+  # ── Snapshot-restore drill (invariant III: "a backup that has never been
+  # restored is a prayer") ───────────────────────────────────────────────────
+  # Finding, not a bug (documented here + in the PR body): the auto-migration
+  # runner's OWN pre-flight snapshot (resources/migrations/snapshot.ts) is
+  # deliberately risk-class-scoped — metadata-only for derived-only migrations,
+  # schema+metadata for schema-additive ones (see that file's module doc for
+  # why: it's a logical in-process manifest, not `flair snapshot create`'s
+  # byte-exact tar.gz, because the runner executes inside the ALREADY-serving
+  # process and stopping Harper to snapshot would undo the #687 boot-win).
+  # Neither of the two migrations registered today (embedding-stamp,
+  # derived-only; the synthetic CI variant, schema-additive) writes row
+  # CONTENT into that internal snapshot — there is nothing there to restore
+  # FROM for a content-corruption drill. This lane therefore exercises the
+  # invariant III "floor beneath everything" mechanism instead: `flair
+  # snapshot create` / `flair snapshot restore` — the shipped, byte-exact
+  # physical mechanism, and the one the migration-safety doc's "rides the
+  # existing `flair snapshot` machinery" language actually describes for
+  # content recovery. It ALSO asserts the migration's own internal pre-flight
+  # snapshot exists (proving that mechanism fired), as a complementary,
+  # cheaper check. See the PR description for the full reasoning — this is a
+  # design-fit observation for K&S, not a runtime change (out of scope here).
+  snapshot-restore-drill:
+    name: Migration snapshot-restore drill (invariant III proof)
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+
+      - uses: oven-sh/setup-bun@735343b667d3e6f658f44d0eca948eb6282f2b76 # v2
+        with:
+          bun-version: "1.3.10"
+
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: "22"
+
+      - uses: socketdev/action@ba6de6cc0565af1f42295590380973573297e31f # v1.3.2
+        with:
+          mode: firewall-free
+
+      - run: sfw bun install --frozen-lockfile
+
+      - name: Install linux-x64 native binary for embeddings
+        run: bun add --no-save @node-llama-cpp/linux-x64@3
+
+      - run: bun run build && bun run build:cli
+
+      - name: Pre-download embedding model
+        run: |
+          set -euo pipefail
+          mkdir -p models
+          curl -fSL --retry 5 --retry-delay 10 --retry-all-errors --connect-timeout 30 \
+            "https://huggingface.co/nomic-ai/nomic-embed-text-v1.5-GGUF/resolve/main/nomic-embed-text-v1.5.Q4_K_M.gguf" \
+            -o models/nomic-embed-text-v1.5.Q4_K_M.gguf
+
+      - name: Pack HEAD (PR build)
+        id: pack
+        run: |
+          set -euo pipefail
+          npm pack
+          echo "TGZ_PATH=$(pwd)/$(ls tpsdev-ai-flair-*.tgz)" >> "$GITHUB_OUTPUT"
+
+      - name: Snapshot-restore drill
+        env:
+          TGZ_PATH: ${{ steps.pack.outputs.TGZ_PATH }}
+        run: |
+          set -euo pipefail
+          source "$GITHUB_WORKSPACE/scripts/ci/migration-lane-lib.sh"
+
+          PORT=19994
+          OPS_PORT=$((PORT - 1))
+          BASE_URL="http://127.0.0.1:${PORT}"
+          OPS_URL="http://127.0.0.1:${OPS_PORT}"
+          DATA_DIR="$HOME/.flair/data"
+          DIAG_DIR="$GITHUB_WORKSPACE/diagnostics/snapshot-restore-drill"
+          mkdir -p "$DIAG_DIR"
+          export FLAIR_ADMIN_PASS="snapshot-drill-admin-$$"
+          export FLAIR_MODELS_DIR="$GITHUB_WORKSPACE/models"
+          trap 'dump_migration_diagnostics "$DATA_DIR" "$BASE_URL" "$FLAIR_ADMIN_PASS" "$DIAG_DIR"' ERR
+
+          ROW_COUNT=60
+          RUN_ID="sr-${GITHUB_RUN_ID:-local}-$$"
+
+          HEAD_DIR=$(mktemp -d)
+          ( cd "$HEAD_DIR" && npm init -y > /dev/null )
+          ( cd "$HEAD_DIR" && npm install "$TGZ_PATH" )
+          ( cd "$HEAD_DIR" && npm install --no-save @node-llama-cpp/linux-x64@3 )
+          FLAIR="node $HEAD_DIR/node_modules/@tpsdev-ai/flair/dist/cli.js"
+
+          # ── 1. First boot (empty corpus — its migration cycle finds nothing
+          # pending), then seed AS the reserved synthetic-migration test
+          # agent via the real CLI write path. Boot-keyed means a cycle only
+          # runs at boot time — restarting AFTER seeding is what makes the
+          # NEXT boot's cycle discover the pending rows (same two-boot shape
+          # test/integration/migrations-synthetic-e2e.test.ts uses). ──
+          export FLAIR_ENABLE_TEST_MIGRATIONS=1
+          $FLAIR init --agent-id snapshot-drill --port $PORT --admin-pass "$FLAIR_ADMIN_PASS" --skip-soul
+
+          echo "Seeding ${ROW_COUNT} rows as the reserved synthetic-migration test agent..."
+          EXPECTED_CONTENT_FILE="$DIAG_DIR/expected-content.txt"
+          : > "$EXPECTED_CONTENT_FILE"
+          for i in $(seq 1 "$ROW_COUNT"); do
+            CONTENT="snapshot-drill-row-${i}-${RUN_ID}"
+            echo "$CONTENT" >> "$EXPECTED_CONTENT_FILE"
+            $FLAIR memory add --agent "$RESERVED_TEST_AGENT_ID" --content "$CONTENT" > /dev/null
+          done
+          echo "Seed complete."
+
+          # ── 2. Restart so THIS boot's cycle discovers the seeded rows, and
+          # let the auto-migration run to completion (bounded retry). ──
+          $FLAIR restart --port $PORT
+          wait_for_http_ok "${BASE_URL}/Health" 90 "Harper (post-restart, pre-migration-wait)"
+          wait_for_migration_state "$BASE_URL" "$FLAIR_ADMIN_PASS" "$SYNTHETIC_MIGRATION_ID" "completed" 150
+
+          # ── 3. Complementary check: the migration's OWN pre-flight snapshot
+          # fired (invariant III's boot-keyed mechanism), even though — per
+          # this job's header comment — it's metadata/schema-scoped, not a
+          # content-restorable snapshot for this risk class. ──
+          SNAPSHOT_COUNT=0
+          for entry in "${DATA_DIR}/.migrations/snapshots/${SYNTHETIC_MIGRATION_ID}"-*; do
+            [[ -d "$entry" ]] && SNAPSHOT_COUNT=$((SNAPSHOT_COUNT + 1))
+          done
+          [[ "$SNAPSHOT_COUNT" -ge 1 ]] || { echo "::error::no internal pre-flight snapshot found under .migrations/snapshots/ for ${SYNTHETIC_MIGRATION_ID} — invariant III's boot-keyed snapshot step did not fire"; exit 1; }
+          echo "Confirmed the migration's own pre-flight snapshot fired (${SNAPSHOT_COUNT} entr$([ "$SNAPSHOT_COUNT" = 1 ] && echo y || echo ies))."
+
+          # ── 4. Take the shipped, byte-exact PHYSICAL snapshot (the
+          # invariant III 'floor beneath everything' mechanism, and the one
+          # that can actually restore row content) — AFTER the migration has
+          # completed, so this is the restore point we drill against. ──
+          $FLAIR snapshot create --port $PORT
+          SNAPSHOT_PATH=$(node -e "
+            const {execFileSync} = require('child_process');
+            const out = JSON.parse(execFileSync('node', ['$HEAD_DIR/node_modules/@tpsdev-ai/flair/dist/cli.js', 'snapshot', 'list', '--json'], {env: process.env}).toString());
+            if (!out.length) { console.error('no snapshots listed'); process.exit(1); }
+            out.sort((a, b) => new Date(b.mtime) - new Date(a.mtime));
+            console.log(out[0].path);
+          ")
+          echo "Restore point: ${SNAPSHOT_PATH}"
+
+          # ── 5. Record pre-corruption ground truth, then deliberately mangle
+          # the rows the migration touched (every seeded row now carries the
+          # migration's marker in `source`) via a raw ops-API partial update —
+          # simulates real corruption (bit-rot / bad write / operator
+          # mistake), not a synthetic marker the restore path could special-case. ──
+          fetch_agent_memories_json "$OPS_URL" "$FLAIR_ADMIN_PASS" "$RESERVED_TEST_AGENT_ID" > "$DIAG_DIR/pre-corrupt-rows.json"
+          PRE_COUNT=$(node -e "console.log(JSON.parse(require('fs').readFileSync('$DIAG_DIR/pre-corrupt-rows.json','utf8')).length)")
+          [[ "$PRE_COUNT" == "$ROW_COUNT" ]] || { echo "::error::expected ${ROW_COUNT} seeded rows before corruption, found ${PRE_COUNT}"; exit 1; }
+
+          CORRUPT_BODY=$(node -e "
+            const fs = require('fs');
+            const rows = JSON.parse(fs.readFileSync('$DIAG_DIR/pre-corrupt-rows.json', 'utf8'));
+            const records = rows.map((r) => ({ id: r.id, content: 'CORRUPTED-BY-CI-RESTORE-DRILL' }));
+            process.stdout.write(JSON.stringify({ operation: 'update', database: 'flair', table: 'Memory', records }));
+          ")
+          curl -sf -u "admin:${FLAIR_ADMIN_PASS}" -X POST -H "Content-Type: application/json" -d "$CORRUPT_BODY" --max-time 15 "${OPS_URL}/" > /dev/null
+          echo "Corrupted ${ROW_COUNT} rows' content in place."
+
+          POST_CORRUPT=$(fetch_agent_memories_json "$OPS_URL" "$FLAIR_ADMIN_PASS" "$RESERVED_TEST_AGENT_ID")
+          echo "$POST_CORRUPT" | node -e "
+            let d = ''; process.stdin.on('data', c => d += c); process.stdin.on('end', () => {
+              const rows = JSON.parse(d);
+              const stillGood = rows.filter((r) => r.content !== 'CORRUPTED-BY-CI-RESTORE-DRILL').length;
+              if (stillGood > 0) { console.error(stillGood + ' rows were NOT corrupted — corruption step itself is broken, drill proves nothing'); process.exit(1); }
+              console.log('confirmed all ' + rows.length + ' rows corrupted in place');
+            });
+          "
+
+          # ── 6. Restore from the pre-corruption snapshot via the shipped
+          # mechanism (stops Flair, replaces the data dir, restarts — all
+          # handled internally by `flair snapshot restore`). ──
+          $FLAIR snapshot restore "$SNAPSHOT_PATH" --port $PORT --yes
+          wait_for_http_ok "${BASE_URL}/Health" 90 "Harper (post-restore)"
+          wait_for_flair_status_running "$FLAIR" "$PORT" 60
+
+          # ── 7. Verify integrity: seeded content reads back correct, counts
+          # match — the honest bar invariant III sets for a restore drill. ──
+          fetch_agent_memories_json "$OPS_URL" "$FLAIR_ADMIN_PASS" "$RESERVED_TEST_AGENT_ID" > "$DIAG_DIR/post-restore-rows.json"
+          POST_COUNT=$(node -e "console.log(JSON.parse(require('fs').readFileSync('$DIAG_DIR/post-restore-rows.json','utf8')).length)")
+          [[ "$POST_COUNT" == "$ROW_COUNT" ]] || { echo "::error::post-restore row count ${POST_COUNT} != expected ${ROW_COUNT}"; exit 1; }
+
+          node -e "
+            const fs = require('fs');
+            const rows = JSON.parse(fs.readFileSync('$DIAG_DIR/post-restore-rows.json', 'utf8'));
+            const actual = rows.map((r) => r.content).sort();
+            const expected = fs.readFileSync('$EXPECTED_CONTENT_FILE', 'utf8').trim().split('\n').sort();
+            if (JSON.stringify(actual) !== JSON.stringify(expected)) {
+              console.error('content mismatch after restore — corruption was not fully reverted');
+              process.exit(1);
+            }
+            console.log('all ${ROW_COUNT} seeded rows byte-identical after restore — corruption fully reverted');
+          "
+
+          echo "✅ snapshot-restore-drill: corrupted ${ROW_COUNT} migration-touched rows, restored via the shipped snapshot mechanism, integrity verified."
+
+          $FLAIR stop --port $PORT || true
+
+      - name: Upload diagnostics (failure only)
+        if: failure()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: snapshot-restore-drill-diagnostics
+          path: diagnostics/snapshot-restore-drill/
+          retention-days: 7
+          if-no-files-found: ignore

--- a/.github/workflows/migration-ci-lanes.yml
+++ b/.github/workflows/migration-ci-lanes.yml
@@ -84,17 +84,9 @@ jobs:
       - run: bun run build && bun run build:cli
 
       # Pre-downloaded ONCE and pointed at by FLAIR_MODELS_DIR (below) for
-      # BOTH the baseline and PR-build boots. Deliberate: it keeps
-      # `getModelId()`'s embeddingModel stamp identical across the swap
-      # (embedding-stamp — the always-on derived-only migration that runs
-      # BEFORE the synthetic one in registry order — would otherwise see the
-      # freshly-seeded rows as stale the moment the model becomes ready and
-      # contend with the synthetic migration for the mid-flight window this
-      # lane depends on catching deterministically; the resume-after-kill
-      # integration test hit exactly this class of flake and pins
-      # FLAIR_EMBEDDING_MODEL for the same reason — this lane's CLI-seeded
-      # rows sidestep it a different way: a real, synchronous, correctly-
-      # stamped embed at write time on both sides of the swap).
+      # BOTH the baseline and PR-build boots — avoids the baseline init's own
+      # in-band HuggingFace download (the #463/#465 429-flake class) and any
+      # re-download after the swap.
       - name: Pre-download embedding model (shared by baseline + PR build)
         run: |
           set -euo pipefail
@@ -139,6 +131,15 @@ jobs:
           DELAY_MS=2500            # matches migrations-resume-after-kill.test.ts's proven
                                     # constants for reliably catching a genuine mid-flight window.
           RUN_ID="dg-${GITHUB_RUN_ID:-local}-$$"
+          # Pinned embeddingModel stamp — the resume-after-kill isolation
+          # pattern: seeded rows carry this exact stamp AND the PR-build boot
+          # runs with FLAIR_EMBEDDING_MODEL pinned to it (only consumed by
+          # getModelId(), the stamp string — never model loading), so the
+          # always-on embedding-stamp migration (first in registry order)
+          # detects NO pending work on the seeded corpus and the synthetic
+          # migration — the one whose mid-flight window this lane must catch
+          # deterministically — starts right after the shared pre-hash.
+          PINNED_EMBEDDING_MODEL="downgrade-lane-pinned-model"
 
           # ── 1. Install the previously-published baseline ──────────────────
           BASE_DIR=$(mktemp -d)
@@ -150,21 +151,33 @@ jobs:
           HEAD_VERSION=$(node -p "require('$GITHUB_WORKSPACE/package.json').version")
           echo "Baseline (previously published): ${BASELINE_VERSION} — HEAD (PR build): ${HEAD_VERSION}"
 
-          # ── 2. Init baseline, seed the corpus AS the reserved synthetic-
-          # migration test agent, via the real CLI write path (flair memory
-          # add -> HTTP PUT /Memory/:id -> Memory.post(), the SAME path a
-          # real user's writes take — never the raw ops API bypass the
-          # resume-after-kill integration test needs for a different reason). ──
+          # ── 2. Init baseline, then seed the corpus AS the reserved
+          # synthetic-migration test agent via the OPS API with Basic admin
+          # auth — the version-stable authenticated write channel (see
+          # ops_seed_stub_memory_rows's doc in migration-lane-lib.sh).
+          # NOT `flair memory add`: the published baseline's REST auth chain
+          # differs from HEAD's — 0.21.0 only honors FLAIR_ADMIN_PASS for
+          # remote targets and falls through to a per-agent Ed25519 key the
+          # reserved agent doesn't have, so the CLI path 401s on the baseline
+          # half of this lane (hit live in CI run 29180826116).
+          #
+          # cwd = $BASE_DIR for every baseline CLI call (same convention as
+          # upgrade-smoke's `cd "$BASE_DIR"`): harperBin() falls back to
+          # process.cwd()/node_modules when @harperfast/harper isn't nested
+          # inside the flair package (npm hoists it to the install root), so
+          # running from the workspace would silently make the BASELINE spawn
+          # the WORKSPACE'S Harper instead of its own — wrong binary for the
+          # downgrade claim this lane makes. ──
+          cd "$BASE_DIR"
           $BASE_FLAIR init --agent-id downgrade-lane --port $PORT --admin-pass "$FLAIR_ADMIN_PASS" --skip-soul
 
-          echo "Seeding ${ROW_COUNT} rows as the reserved synthetic-migration test agent..."
+          echo "Seeding ${ROW_COUNT} rows as the reserved synthetic-migration test agent (ops API, stub embedding, pinned stamp)..."
+          ops_seed_stub_memory_rows "$OPS_URL" "$FLAIR_ADMIN_PASS" "$RESERVED_TEST_AGENT_ID" \
+            "downgrade-seed-${RUN_ID}" "downgrade-drill-row-${RUN_ID}" "$ROW_COUNT" "$PINNED_EMBEDDING_MODEL"
           EXPECTED_CONTENT_FILE="$DIAG_DIR/expected-content.txt"
           : > "$EXPECTED_CONTENT_FILE"
-          for i in $(seq 1 "$ROW_COUNT"); do
-            CONTENT="downgrade-drill-row-${i}-${RUN_ID}"
-            echo "$CONTENT" >> "$EXPECTED_CONTENT_FILE"
-            $BASE_FLAIR memory add --agent "$RESERVED_TEST_AGENT_ID" --content "$CONTENT" > /dev/null
-            if (( i % 20 == 0 )); then echo "  seeded ${i}/${ROW_COUNT}"; fi
+          for i in $(seq 0 $((ROW_COUNT - 1))); do
+            echo "downgrade-drill-row-${RUN_ID}-${i}" >> "$EXPECTED_CONTENT_FILE"
           done
           echo "Seed complete."
 
@@ -193,10 +206,16 @@ jobs:
 
           # ── 5. Swap in the PR build against baseline's SAME data dir
           # (default ~/.flair/data — neither install overrides HOME), with
-          # the synthetic-migration gate on and the batch delay widened. This
-          # boot is the one that discovers the seeded rows as pending. ──
+          # the synthetic-migration gate on, the batch delay widened, and the
+          # embeddingModel stamp pinned (embedding-stamp isolation — see the
+          # PINNED_EMBEDDING_MODEL comment above). This boot is the one that
+          # discovers the seeded rows as pending. cwd = $HEAD_DIR so
+          # harperBin() resolves the PR install's own Harper (see step 2's
+          # cwd comment). ──
+          cd "$HEAD_DIR"
           export FLAIR_ENABLE_TEST_MIGRATIONS=1
           export FLAIR_MIGRATION_TEST_BATCH_DELAY_MS=$DELAY_MS
+          export FLAIR_EMBEDDING_MODEL="$PINNED_EMBEDDING_MODEL"
           $HEAD_FLAIR start --port $PORT
           wait_for_http_ok "${BASE_URL}/Health" 90 "PR-build Harper (post-restart)"
 
@@ -214,36 +233,71 @@ jobs:
           # already-installed baseline binary again against the now
           # partially-migrated data directory — exactly what a real operator
           # downgrade is (`flair stop && npm install -g @tpsdev-ai/flair@<prev>
-          # && flair restart`), no re-init, no touching the files by hand. ──
-          unset FLAIR_ENABLE_TEST_MIGRATIONS FLAIR_MIGRATION_TEST_BATCH_DELAY_MS
+          # && flair restart`), no re-init, no touching the files by hand.
+          # Back to $BASE_DIR so the baseline spawns ITS OWN Harper. ──
+          cd "$BASE_DIR"
+          unset FLAIR_ENABLE_TEST_MIGRATIONS FLAIR_MIGRATION_TEST_BATCH_DELAY_MS FLAIR_EMBEDDING_MODEL
           $BASE_FLAIR start --port $PORT
           wait_for_http_ok "${BASE_URL}/Health" 90 "baseline Harper (post-downgrade)"
+          # Version-safe on the baseline: 0.21.0's `flair status` probes the
+          # PUBLIC /Health (with a Basic fallback on 401) — no per-agent
+          # auth in the loop (verified by reading the published dist).
           wait_for_flair_status_running "$BASE_FLAIR" "$PORT" 60
 
           # ── 9. Assert the old binary serves the corpus CORRECTLY, not just
           # that it boots — the honest bar per FLAIR-MIGRATION-SAFETY.md
-          # invariant II ("still serving on the pre-migration shape"). ──
+          # invariant II ("still serving on the pre-migration shape"). All
+          # reads go through the version-stable ops API with Basic auth —
+          # deliberately NOT the baseline's `flair memory search`/REST
+          # surface, whose auth chain for a keyless agent differs across
+          # published versions (the same class of bug that broke the CLI
+          # seeding path in CI run 29180826116; the ops read IS the old
+          # binary's own serving surface, so readability is genuinely
+          # exercised). ──
           fetch_agent_memories_json "$OPS_URL" "$FLAIR_ADMIN_PASS" "$RESERVED_TEST_AGENT_ID" > "$DIAG_DIR/post-downgrade-rows.json"
           ACTUAL_COUNT=$(node -e "console.log(JSON.parse(require('fs').readFileSync('$DIAG_DIR/post-downgrade-rows.json','utf8')).length)")
           [[ "$ACTUAL_COUNT" == "$ROW_COUNT" ]] || { echo "::error::post-downgrade row count ${ACTUAL_COUNT} != expected ${ROW_COUNT} — DATA LOSS across the downgrade"; exit 1; }
 
-          node -e "
-            const fs = require('fs');
-            const rows = JSON.parse(fs.readFileSync('$DIAG_DIR/post-downgrade-rows.json', 'utf8'));
+          MARKER="$SYNTHETIC_TARGET_MARKER" PINNED="$PINNED_EMBEDDING_MODEL" ROWS_FILE="$DIAG_DIR/post-downgrade-rows.json" EXPECTED_FILE="$EXPECTED_CONTENT_FILE" TOTAL="$ROW_COUNT" node -e '
+            const fs = require("fs");
+            const rows = JSON.parse(fs.readFileSync(process.env.ROWS_FILE, "utf8"));
+            const total = Number(process.env.TOTAL);
+
+            // (a) Byte-identical content — no row lost, none corrupted.
             const actual = rows.map((r) => r.content).sort();
-            const expected = fs.readFileSync('$EXPECTED_CONTENT_FILE', 'utf8').trim().split('\n').sort();
+            const expected = fs.readFileSync(process.env.EXPECTED_FILE, "utf8").trim().split("\n").sort();
             if (JSON.stringify(actual) !== JSON.stringify(expected)) {
-              console.error('content mismatch after downgrade — some seeded rows changed or were lost');
+              console.error("content mismatch after downgrade — some seeded rows changed or were lost");
               process.exit(1);
             }
-            console.log('all ${ROW_COUNT} seeded rows byte-identical after downgrade against the partially-migrated store (raw ops-API read)');
-          "
 
-          # Real CLI round-trip too (not just the version-stable raw read) —
-          # picks the first seeded row's exact content as the query.
-          ANCHOR_CONTENT="downgrade-drill-row-1-${RUN_ID}"
-          SEARCH_OUT=$(FLAIR_URL="$BASE_URL" FLAIR_ADMIN_PASS="$FLAIR_ADMIN_PASS" $BASE_FLAIR memory search --agent "$RESERVED_TEST_AGENT_ID" --q "$ANCHOR_CONTENT")
-          echo "$SEARCH_OUT" | grep -q "$ANCHOR_CONTENT" || { echo "::error::baseline 'flair memory search' round-trip did not find the seeded marker after downgrade"; exit 1; }
+            // (b) Isolation held: every row still carries the pinned stamp —
+            // embedding-stamp never touched the seeded corpus on the PR boot.
+            const notPinned = rows.filter((r) => r.embeddingModel !== process.env.PINNED).length;
+            if (notPinned > 0) {
+              console.error(notPinned + " rows lost the pinned embeddingModel stamp — embedding-stamp contended with the synthetic migration (isolation broken)");
+              process.exit(1);
+            }
+
+            // (c) The store is GENUINELY partially migrated — the scenario
+            // invariant I must survive. Some rows stamped (rowsDone>0 was
+            // observed pre-kill and those writes persist), some not (the
+            // kill landed mid-flight). Fully-stamped means the kill landed
+            // too late (widen FLAIR_MIGRATION_TEST_BATCH_DELAY_MS / raise
+            // ROW_COUNT); zero-stamped means no migration write ever
+            // persisted — both fail loud, same philosophy as the resume
+            // tests too-fast guard.
+            const stamped = rows.filter((r) => r.source === process.env.MARKER).length;
+            if (stamped === 0) {
+              console.error("0 rows carry the migration marker post-kill — no migration write persisted before the kill (mid-flight observation was hollow)");
+              process.exit(1);
+            }
+            if (stamped === total) {
+              console.error("ALL " + total + " rows are migrated — the kill landed after completion, the store is not partially migrated; widen FLAIR_MIGRATION_TEST_BATCH_DELAY_MS or raise ROW_COUNT");
+              process.exit(1);
+            }
+            console.log("all " + total + " seeded rows byte-identical after downgrade; store genuinely partial (" + stamped + "/" + total + " migrated); pinned-stamp isolation held (raw ops-API read through the old binary)");
+          '
 
           echo "✅ downgrade-and-revert: old binary (${BASELINE_VERSION}) boots and serves ${ROW_COUNT} seeded rows correctly against the store PR build ${HEAD_VERSION} left partially migrated."
 
@@ -346,13 +400,23 @@ jobs:
           ( cd "$HEAD_DIR" && npm install "$TGZ_PATH" )
           ( cd "$HEAD_DIR" && npm install --no-save @node-llama-cpp/linux-x64@3 )
           FLAIR="node $HEAD_DIR/node_modules/@tpsdev-ai/flair/dist/cli.js"
+          # cwd = $HEAD_DIR for every CLI call: harperBin() falls back to
+          # process.cwd()/node_modules for the npm-hoisted @harperfast/harper,
+          # so this install must run ITS OWN Harper, not the workspace's
+          # (same convention as upgrade-smoke's `cd`; see the downgrade
+          # lane's step-2 comment for the full rationale).
+          cd "$HEAD_DIR"
 
           # ── 1. First boot (empty corpus — its migration cycle finds nothing
           # pending), then seed AS the reserved synthetic-migration test
-          # agent via the real CLI write path. Boot-keyed means a cycle only
-          # runs at boot time — restarting AFTER seeding is what makes the
-          # NEXT boot's cycle discover the pending rows (same two-boot shape
-          # test/integration/migrations-synthetic-e2e.test.ts uses). ──
+          # agent via the real CLI write path — fine HERE because this lane
+          # only ever drives the PR build, whose api() honors
+          # FLAIR_ADMIN_PASS for local targets (the published-baseline auth
+          # skew that forced the downgrade lane onto the ops API doesn't
+          # apply; validated live against a real ephemeral Harper). Boot-keyed
+          # means a cycle only runs at boot time — restarting AFTER seeding
+          # is what makes the NEXT boot's cycle discover the pending rows
+          # (same two-boot shape migrations-synthetic-e2e.test.ts uses). ──
           export FLAIR_ENABLE_TEST_MIGRATIONS=1
           $FLAIR init --agent-id snapshot-drill --port $PORT --admin-pass "$FLAIR_ADMIN_PASS" --skip-soul
 

--- a/.github/workflows/migration-ci-lanes.yml
+++ b/.github/workflows/migration-ci-lanes.yml
@@ -1,7 +1,7 @@
-# Migration CI lanes (ops-1l18 enforcement arm) — the K&S-ratified, per-PR
-# proof of the migration safety invariants (~/ops/FLAIR-MIGRATION-SAFETY.md)
-# for the zero-touch boot-keyed auto-migration runner (~/ops/FLAIR-ZERO-TOUCH-UPGRADE.md,
-# resources/migrations/*, PR #690). Extends ~/ops/FLAIR-CI-FOUNDATION.md §2's
+# Migration CI lanes (#695 enforcement arm) — the K&S-ratified, per-PR
+# proof of the migration safety invariants (flair#695)
+# for the zero-touch boot-keyed auto-migration runner (flair#695,
+# resources/migrations/*, PR #690). Extends flair#695's
 # upgrade-path CI with the two lanes Kern's design-review verdict called
 # non-negotiable:
 #
@@ -18,7 +18,7 @@
 # `upgrade-smoke` job in test.yml instead of duplicating it here — see that
 # file's comment block on the extension.
 #
-# Sherlock §4 compliance (FLAIR-CI-FOUNDATION.md): pull_request trigger only
+# Sherlock §4 compliance (flair#695): pull_request trigger only
 # (never pull_request_target with PR-code checkout); no secrets exposed to
 # either job (public npm install + public GITHUB_TOKEN-default only — no
 # NPM_TOKEN, no deploy credentials); every third-party action below is
@@ -245,7 +245,7 @@ jobs:
           wait_for_flair_status_running "$BASE_FLAIR" "$PORT" 60
 
           # ── 9. Assert the old binary serves the corpus CORRECTLY, not just
-          # that it boots — the honest bar per FLAIR-MIGRATION-SAFETY.md
+          # that it boots — the honest bar per flair#695
           # invariant II ("still serving on the pre-migration shape"). All
           # reads go through the version-stable ops API with Basic auth —
           # deliberately NOT the baseline's `flair memory search`/REST

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -488,7 +488,7 @@ jobs:
           npm pack
           echo "TGZ_PATH=$(pwd)/$(ls tpsdev-ai-flair-*.tgz)" >> $GITHUB_OUTPUT
       # Pre-downloaded and pointed at by FLAIR_MODELS_DIR (below) for BOTH the
-      # baseline and HEAD boots — ci(migrations) extension (#504/ops-1l18
+      # baseline and HEAD boots — ci(migrations) extension (#504/#695
       # enforcement): keeps `getModelId()`'s embeddingModel stamp identical
       # across the swap, so embedding-stamp (always-on, runs before the
       # synthetic migration in registry order) doesn't contend with the
@@ -554,8 +554,8 @@ jobs:
             exit 1
           }
 
-          # 2a. ci(migrations) extension (#504/ops-1l18 enforcement arm — see
-          # ~/ops/FLAIR-CI-FOUNDATION.md §2): seed STUB-STAMPED rows via the
+          # 2a. ci(migrations) extension (#504/#695 enforcement arm — see
+          # flair#695): seed STUB-STAMPED rows via the
           # version-stable ops-API bulk insert (ops_seed_stub_memory_rows —
           # see its doc in migration-lane-lib.sh for why a CLI/REST seed
           # can't be trusted against the published baseline: its api() auth
@@ -636,7 +636,7 @@ jobs:
 
           # 4a. ci(migrations) extension — the zero-touch boot-keyed
           # auto-migration assertions this lane exists to enforce
-          # (~/ops/FLAIR-CI-FOUNDATION.md §2 / ~/ops/FLAIR-ZERO-TOUCH-UPGRADE.md):
+          # (flair#695 / flair#695):
           #   (a) the auto-migration actually RAN (not just "boot didn't crash")
           #   (b) its content-hash envelope matched (invariant IV's completion gate)
           #   (c) recall parity — the migration-touched ground truth is still

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -555,34 +555,25 @@ jobs:
           }
 
           # 2a. ci(migrations) extension (#504/ops-1l18 enforcement arm — see
-          # ~/ops/FLAIR-CI-FOUNDATION.md §2): seed STUB-STAMPED rows (a raw
-          # ops-API bulk insert, same pattern
-          # test/integration/migrations-synthetic-e2e.test.ts uses — bypasses
-          # Memory.post()'s own regen branch on purpose, so these rows carry a
-          # deliberately-stale embeddingModel regardless of the embeddings
-          # pipeline's readiness) as the reserved synthetic-migration test
-          # agent, so there is REAL pending work for the auto-migration to do
-          # once HEAD boots below. `flair reembed` (step 4a) already proves
+          # ~/ops/FLAIR-CI-FOUNDATION.md §2): seed STUB-STAMPED rows via the
+          # version-stable ops-API bulk insert (ops_seed_stub_memory_rows —
+          # see its doc in migration-lane-lib.sh for why a CLI/REST seed
+          # can't be trusted against the published baseline: its api() auth
+          # chain differs from HEAD's and 401s for a keyless agent). The
+          # deliberately-stale 'upgrade-lane-stub-stamp' (and NO
+          # FLAIR_EMBEDDING_MODEL pinning in this job — the opposite choice
+          # from the downgrade lane, on purpose) means the always-on
+          # embedding-stamp migration has REAL pending work on the HEAD
+          # boot: it re-embeds these rows with genuine vectors via its
+          # production regen path, and the synthetic migration then stamps
+          # them — so the recall-parity search below exercises real
+          # embeddings, not stubs. `flair reembed` (step 4b) already proves
           # the OLD manual re-embed path; this proves the NEW boot-keyed
           # runner actually ran, independent of it.
           MIGRATION_SEED_COUNT=20
-          MIGRATION_SEED_BODY=$(MIGRATION_SEED_COUNT="$MIGRATION_SEED_COUNT" AGENT_ID="$RESERVED_TEST_AGENT_ID" node -e '
-            const n = Number(process.env.MIGRATION_SEED_COUNT);
-            const agentId = process.env.AGENT_ID;
-            const records = Array.from({ length: n }, (_, i) => ({
-              id: "upgrade-lane-migration-seed-" + i,
-              agentId: agentId,
-              content: "upgrade-lane-migration-seed-row-" + i,
-              source: "not-yet",
-              embedding: [0.1, 0.2, 0.3],
-              embeddingModel: "upgrade-lane-stub-stamp",
-              createdAt: new Date().toISOString(),
-            }));
-            process.stdout.write(JSON.stringify({ operation: "insert", database: "flair", table: "Memory", records }));
-          ')
           BASE_OPS_PORT=$((PORT - 1))
-          curl -sf -u "admin:${FLAIR_ADMIN_PASS}" -X POST -H "Content-Type: application/json" \
-            -d "$MIGRATION_SEED_BODY" --max-time 15 "http://127.0.0.1:${BASE_OPS_PORT}/" > /dev/null
+          ops_seed_stub_memory_rows "http://127.0.0.1:${BASE_OPS_PORT}" "$FLAIR_ADMIN_PASS" "$RESERVED_TEST_AGENT_ID" \
+            "upgrade-lane-migration-seed" "upgrade-lane-migration-seed-row" "$MIGRATION_SEED_COUNT" "upgrade-lane-stub-stamp"
           echo "Seeded ${MIGRATION_SEED_COUNT} stub-stamped rows as ${RESERVED_TEST_AGENT_ID} for the upgrade lane's migration assertions."
 
           # 3. Stop baseline. Install HEAD into a FRESH project dir rather than

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -408,15 +408,21 @@ jobs:
           # ── end flair#654 hard gate ─────────────────────────────────────────────
 
           # Restart race guard (0.5.4 regression): `flair restart` must block until
-          # Harper is actually reachable, so an immediately following `flair status`
-          # must not report unreachable.
+          # Harper is actually reachable, so a following `flair status` must
+          # eventually report running, not unreachable.
+          #
+          # flair#691: this used to be a SINGLE-SHOT check immediately after
+          # `flair restart` returned — on a slow CI runner that races the
+          # daemon's own post-restart boot (deferred migration-boot readiness
+          # poll, embeddings-settle window, etc.) and flakes on "unreachable"
+          # even though the restart is genuinely still in flight, not broken.
+          # Bounded-retry instead (never a fixed `sleep N` guess either) —
+          # see scripts/ci/migration-lane-lib.sh's wait_for_flair_status_running,
+          # the same primitive the migration CI lanes use for every
+          # post-boot/post-restart verification (ci(migrations) PR, #691).
+          source "$GITHUB_WORKSPACE/scripts/ci/migration-lane-lib.sh"
           $FLAIR restart --port $PORT
-          STATUS=$($FLAIR status --port $PORT); echo "$STATUS"
-          if echo "$STATUS" | grep -q "unreachable"; then
-            echo "FAIL: unreachable immediately after restart (0.5.4 regression)"
-            exit 1
-          fi
-          echo "$STATUS" | grep -q "running" || { echo "FAIL: not running after restart"; exit 1; }
+          wait_for_flair_status_running "$FLAIR" "$PORT" 90
 
           # Write/search round-trip (0.5.2-class regression guard): write a
           # memory as the smoke agent, then search for it. Exercises the
@@ -481,9 +487,25 @@ jobs:
         run: |
           npm pack
           echo "TGZ_PATH=$(pwd)/$(ls tpsdev-ai-flair-*.tgz)" >> $GITHUB_OUTPUT
+      # Pre-downloaded and pointed at by FLAIR_MODELS_DIR (below) for BOTH the
+      # baseline and HEAD boots — ci(migrations) extension (#504/ops-1l18
+      # enforcement): keeps `getModelId()`'s embeddingModel stamp identical
+      # across the swap, so embedding-stamp (always-on, runs before the
+      # synthetic migration in registry order) doesn't contend with the
+      # migration-assertion seeding added below. Same rationale as the new
+      # migration-ci-lanes.yml downgrade-and-revert job.
+      - name: Pre-download embedding model (shared by baseline + HEAD)
+        run: |
+          set -euo pipefail
+          mkdir -p models
+          curl -fSL --retry 5 --retry-delay 10 --retry-all-errors --connect-timeout 30 \
+            "https://huggingface.co/nomic-ai/nomic-embed-text-v1.5-GGUF/resolve/main/nomic-embed-text-v1.5.Q4_K_M.gguf" \
+            -o models/nomic-embed-text-v1.5.Q4_K_M.gguf
       - name: Install npm-stable, seed data, upgrade, verify
         run: |
           set -euo pipefail
+          source "$GITHUB_WORKSPACE/scripts/ci/migration-lane-lib.sh"
+          export FLAIR_MODELS_DIR="$GITHUB_WORKSPACE/models"
           BASE_DIR=$(mktemp -d)
           cd "$BASE_DIR"
           npm init -y > /dev/null
@@ -532,6 +554,37 @@ jobs:
             exit 1
           }
 
+          # 2a. ci(migrations) extension (#504/ops-1l18 enforcement arm — see
+          # ~/ops/FLAIR-CI-FOUNDATION.md §2): seed STUB-STAMPED rows (a raw
+          # ops-API bulk insert, same pattern
+          # test/integration/migrations-synthetic-e2e.test.ts uses — bypasses
+          # Memory.post()'s own regen branch on purpose, so these rows carry a
+          # deliberately-stale embeddingModel regardless of the embeddings
+          # pipeline's readiness) as the reserved synthetic-migration test
+          # agent, so there is REAL pending work for the auto-migration to do
+          # once HEAD boots below. `flair reembed` (step 4a) already proves
+          # the OLD manual re-embed path; this proves the NEW boot-keyed
+          # runner actually ran, independent of it.
+          MIGRATION_SEED_COUNT=20
+          MIGRATION_SEED_BODY=$(MIGRATION_SEED_COUNT="$MIGRATION_SEED_COUNT" AGENT_ID="$RESERVED_TEST_AGENT_ID" node -e '
+            const n = Number(process.env.MIGRATION_SEED_COUNT);
+            const agentId = process.env.AGENT_ID;
+            const records = Array.from({ length: n }, (_, i) => ({
+              id: "upgrade-lane-migration-seed-" + i,
+              agentId: agentId,
+              content: "upgrade-lane-migration-seed-row-" + i,
+              source: "not-yet",
+              embedding: [0.1, 0.2, 0.3],
+              embeddingModel: "upgrade-lane-stub-stamp",
+              createdAt: new Date().toISOString(),
+            }));
+            process.stdout.write(JSON.stringify({ operation: "insert", database: "flair", table: "Memory", records }));
+          ')
+          BASE_OPS_PORT=$((PORT - 1))
+          curl -sf -u "admin:${FLAIR_ADMIN_PASS}" -X POST -H "Content-Type: application/json" \
+            -d "$MIGRATION_SEED_BODY" --max-time 15 "http://127.0.0.1:${BASE_OPS_PORT}/" > /dev/null
+          echo "Seeded ${MIGRATION_SEED_COUNT} stub-stamped rows as ${RESERVED_TEST_AGENT_ID} for the upgrade lane's migration assertions."
+
           # 3. Stop baseline. Install HEAD into a FRESH project dir rather than
           # reifying the tarball on top of baseline's node_modules in place.
           #
@@ -577,13 +630,51 @@ jobs:
           [ "$NEW" = "$HEAD_VERSION" ] || { echo "FAIL: expected $HEAD_VERSION in node_modules, got $NEW"; exit 1; }
           echo "Upgraded $BASELINE → $NEW"
 
-          # 4. Start HEAD against baseline's data dir (~/.flair by default)
+          # 4. Start HEAD against baseline's data dir (~/.flair by default).
+          # FLAIR_ENABLE_TEST_MIGRATIONS=1 registers the CI-only synthetic
+          # migration (never ships — registration is conditional on this
+          # exact-match env var, see resources/migrations/synthetic-test-migration.ts)
+          # so this boot has the stub-stamped rows seeded in 2a above as real
+          # pending work.
+          export FLAIR_ENABLE_TEST_MIGRATIONS=1
           $FLAIR start --port $PORT
 
-          STATUS=$($FLAIR status --port $PORT); echo "$STATUS"
-          echo "$STATUS" | grep -q "running" || { echo "FAIL: HEAD didn't start after upgrade from $BASELINE"; exit 1; }
+          # Bounded-retry, not a single-shot check (flair#691's lesson,
+          # generalized — see scripts/ci/migration-lane-lib.sh).
+          wait_for_flair_status_running "$FLAIR" "$PORT" 90
 
-          # 4a. Run the documented post-upgrade migration: re-embed all memories
+          # 4a. ci(migrations) extension — the zero-touch boot-keyed
+          # auto-migration assertions this lane exists to enforce
+          # (~/ops/FLAIR-CI-FOUNDATION.md §2 / ~/ops/FLAIR-ZERO-TOUCH-UPGRADE.md):
+          #   (a) the auto-migration actually RAN (not just "boot didn't crash")
+          #   (b) its content-hash envelope matched (invariant IV's completion gate)
+          #   (c) recall parity — the migration-touched ground truth is still
+          #       retrievable by search post-migration, not just present in storage
+          # Deliberately BEFORE the manual `flair reembed` below (4b): the
+          # always-on embedding-stamp migration (runs ahead of the synthetic
+          # one in registry order) already gives these stub-stamped rows real
+          # embeddings as part of THIS SAME auto-migration cycle — waiting for
+          # the cycle to finish here, before reembed's own writes touch the
+          # same rows, avoids two independent writers racing on them.
+          BASE_URL="http://127.0.0.1:${PORT}"
+          OPS_URL="http://127.0.0.1:$((PORT - 1))"
+
+          wait_for_migration_state "$BASE_URL" "$FLAIR_ADMIN_PASS" "$SYNTHETIC_MIGRATION_ID" "completed" 120
+
+          echo "Ledger content-hash envelope for ${SYNTHETIC_MIGRATION_ID}:"
+          check_ledger_hash_envelope "$OPS_URL" "$FLAIR_ADMIN_PASS" "$SYNTHETIC_MIGRATION_ID" || {
+            echo "FAIL: content-hash envelope did not match=true after the upgrade-lane migration run"
+            exit 1
+          }
+
+          MIGRATION_RECALL=$($FLAIR memory search --agent "$RESERVED_TEST_AGENT_ID" --q "upgrade-lane-migration-seed-row-0")
+          echo "$MIGRATION_RECALL" | grep -q "upgrade-lane-migration-seed-row-0" || {
+            echo "FAIL: migration-seeded ground truth not retrievable by search post-migration (recall parity broken)"
+            exit 1
+          }
+          echo "Migration ran, envelope matched, migration-seeded ground truth recalls correctly."
+
+          # 4b. Run the documented post-upgrade migration: re-embed all memories
           # so their stored vectors match the running Harper version's expected
           # shape. Required when bumping @harperfast/harper across versions where
           # HNSW storage internals changed (e.g. 5.0.1 → 5.0.9). See CHANGELOG.

--- a/scripts/ci/migration-lane-lib.sh
+++ b/scripts/ci/migration-lane-lib.sh
@@ -3,8 +3,8 @@
 # (downgrade-and-revert, snapshot-restore-drill, and the upgrade-lane
 # migration assertions bolted onto `upgrade-smoke` in test.yml).
 #
-# Governed by ~/ops/FLAIR-CI-FOUNDATION.md §2 / ~/ops/FLAIR-MIGRATION-SAFETY.md
-# / ~/ops/FLAIR-ZERO-TOUCH-UPGRADE.md. Meant to be `source`d, not executed —
+# Governed by flair#695 / flair#695
+# / flair#695. Meant to be `source`d, not executed —
 # every function below is a bounded-retry (never single-shot) verification
 # primitive, per flair#691's lesson (a single post-restart status check races
 # boot on a slow CI runner) generalized to every lane that polls Harper after

--- a/scripts/ci/migration-lane-lib.sh
+++ b/scripts/ci/migration-lane-lib.sh
@@ -235,6 +235,52 @@ check_ledger_hash_envelope() {
   ' <<< "$resp"
 }
 
+# ─── ops API: bulk-insert stub-stamped Memory rows (version-stable seeding) ─
+# Seeds `count` rows as `agent_id` via the Harper OPERATIONS API with Basic
+# admin auth — the one write channel authenticated identically on EVERY
+# published flair version. The REST path's auth chain has genuinely differed
+# across releases: published 0.21.0's api() only honors FLAIR_ADMIN_PASS for
+# REMOTE (!isLocal) targets and falls through to per-agent Ed25519 keys
+# locally — the reserved synthetic-migration test agent has no key (init only
+# creates the init agent's), so a published-baseline `flair memory add
+# --agent <reserved>` goes out with NO auth header and 401s
+# ("authentication required" — hit live in CI run 29180826116; root cause
+# confirmed by reading the published dist's api()). The ops API, by that same
+# release's own comment, "always requires Basic admin auth, and those helpers
+# send it unconditionally" — version-stable by design.
+#
+# Rows carry a STUB embedding + the given embeddingModel stamp: raw ops
+# inserts bypass resources/Memory.ts's regen branch entirely, so without a
+# stub stamp the rows would land embedding-less and the always-on
+# embedding-stamp migration would contend with the migration under test on
+# the next boot (the migrations-resume-after-kill.test.ts isolation lesson).
+# Callers that need embedding-stamp to see NO pending work pin
+# FLAIR_EMBEDDING_MODEL to the same stamp for the swapped-in build's boot;
+# callers that WANT embedding-stamp to have real pending work (the upgrade
+# lane) pass a deliberately-stale stamp and don't pin.
+#
+# Args: ops_url admin_pass agent_id id_prefix content_prefix count stamp
+# Row shape: id="<id_prefix>-<i>", content="<content_prefix>-<i>", i in 0..count-1.
+ops_seed_stub_memory_rows() {
+  local ops_url="$1" admin_pass="$2" agent_id="$3" id_prefix="$4" content_prefix="$5" count="$6" stamp="$7"
+  local body
+  body=$(AGENT_ID="$agent_id" ID_PREFIX="$id_prefix" CONTENT_PREFIX="$content_prefix" COUNT="$count" STAMP="$stamp" node -e '
+    const n = Number(process.env.COUNT);
+    const records = Array.from({ length: n }, (_, i) => ({
+      id: process.env.ID_PREFIX + "-" + i,
+      agentId: process.env.AGENT_ID,
+      content: process.env.CONTENT_PREFIX + "-" + i,
+      source: "not-yet",
+      embedding: [0.1, 0.2, 0.3],
+      embeddingModel: process.env.STAMP,
+      createdAt: new Date().toISOString(),
+    }));
+    process.stdout.write(JSON.stringify({ operation: "insert", database: "flair", table: "Memory", records }));
+  ')
+  curl -sf -u "admin:${admin_pass}" -X POST -H "Content-Type: application/json" \
+    -d "$body" --max-time 30 "${ops_url}/" > /dev/null
+}
+
 # ─── ops API: exact row read-back for an agent (version-stable path) ───────
 # Same rationale as test/compat/downgrade-boot.test.ts's fetchAgentMemories:
 # a raw ops search_by_value doesn't depend on either build's `flair memory

--- a/scripts/ci/migration-lane-lib.sh
+++ b/scripts/ci/migration-lane-lib.sh
@@ -1,0 +1,277 @@
+#!/usr/bin/env bash
+# migration-lane-lib.sh — shared bash helpers for the migration CI lanes
+# (downgrade-and-revert, snapshot-restore-drill, and the upgrade-lane
+# migration assertions bolted onto `upgrade-smoke` in test.yml).
+#
+# Governed by ~/ops/FLAIR-CI-FOUNDATION.md §2 / ~/ops/FLAIR-MIGRATION-SAFETY.md
+# / ~/ops/FLAIR-ZERO-TOUCH-UPGRADE.md. Meant to be `source`d, not executed —
+# every function below is a bounded-retry (never single-shot) verification
+# primitive, per flair#691's lesson (a single post-restart status check races
+# boot on a slow CI runner) generalized to every lane that polls Harper after
+# a boot/restart/kill.
+#
+# All functions read simple positional args (no associative arrays, for
+# `bash -n`/portability) and print progress to stdout so a CI log is
+# self-explanatory without a second evidence-gathering pass. On a genuine
+# timeout, each polling function prints the last-observed state/response
+# itself — callers additionally call `dump_migration_diagnostics` (below) in
+# an `if: failure()` step so the *files* survive as an uploaded artifact too.
+#
+# These constants MUST match resources/migrations/synthetic-test-migration.ts
+# exactly — CI shell can't `import` a TS module, so this is a deliberate,
+# documented duplication (same idiom test/integration/migrations-*.test.ts
+# uses for the same reason).
+SYNTHETIC_MIGRATION_ID="synthetic-ci-schema-stamp"
+RESERVED_TEST_AGENT_ID="__flair_migration_synthetic_test_agent__"
+SYNTHETIC_TARGET_MARKER="${SYNTHETIC_MIGRATION_ID}-done"
+
+# ─── Generic bounded-retry HTTP reachability check ─────────────────────────
+# Replaces every "curl once right after restart" pattern (the flair#691
+# class of bug). Polls every 2s until `curl -sf` against `$1` succeeds or
+# `$2` seconds elapse.
+wait_for_http_ok() {
+  local url="$1" timeout_s="${2:-60}" label="${3:-$url}"
+  local deadline=$((SECONDS + timeout_s))
+  local attempt=0
+  while (( SECONDS < deadline )); do
+    attempt=$((attempt + 1))
+    if curl -sf -o /dev/null --max-time 5 "$url"; then
+      echo "[wait_for_http_ok] ${label} reachable after ${attempt} attempt(s) (~$((SECONDS - (deadline - timeout_s)))s)"
+      return 0
+    fi
+    sleep 2
+  done
+  echo "::error::[wait_for_http_ok] ${label} did not become reachable within ${timeout_s}s (${url})"
+  return 1
+}
+
+# ─── Inverse: bounded-retry wait for a URL to stop answering ───────────────
+# Used after `flair stop`/a SIGTERM kill (which return/land asynchronously —
+# see startFlairProcess's own comment on this in src/cli.ts) to confirm the
+# OLD process has genuinely exited before a caller starts a new one against
+# the same port/data dir. Bounded, not a fixed `sleep N` guess.
+wait_for_http_down() {
+  local url="$1" timeout_s="${2:-30}" label="${3:-$url}"
+  local deadline=$((SECONDS + timeout_s))
+  local attempt=0
+  while (( SECONDS < deadline )); do
+    attempt=$((attempt + 1))
+    if ! curl -sf -o /dev/null --max-time 3 "$url" 2>/dev/null; then
+      echo "[wait_for_http_down] ${label} stopped answering after ${attempt} attempt(s)"
+      return 0
+    fi
+    sleep 1
+  done
+  echo "::error::[wait_for_http_down] ${label} was still answering after ${timeout_s}s — process may not have exited"
+  return 1
+}
+
+# ─── Bounded-retry `flair status` check ────────────────────────────────────
+# THE #691 FIX SHAPE: `$1` is the flair invocation (e.g. "node dist/cli.js"),
+# `$2` the port, `$3` the timeout in seconds. Polls until `status` reports
+# "running" and never treats a transient "unreachable" as final until the
+# deadline — exactly the bounded-retry / waitForHealth pattern
+# test/helpers/harper-lifecycle.ts uses for the bun-test harness, ported to
+# the real installed CLI's own `status` subcommand for these npm-install-path
+# lanes.
+wait_for_flair_status_running() {
+  local flair_cmd="$1" port="$2" timeout_s="${3:-90}"
+  local deadline=$((SECONDS + timeout_s))
+  local attempt=0
+  local status_out=""
+  while (( SECONDS < deadline )); do
+    attempt=$((attempt + 1))
+    status_out=$($flair_cmd status --port "$port" 2>&1 || true)
+    if echo "$status_out" | grep -qi "unreachable"; then
+      : # still coming up — keep polling
+    elif echo "$status_out" | grep -qi "running"; then
+      echo "[wait_for_flair_status_running] running after ${attempt} attempt(s)"
+      echo "$status_out"
+      return 0
+    fi
+    sleep 2
+  done
+  echo "::error::[wait_for_flair_status_running] never reported 'running' within ${timeout_s}s — last output:"
+  echo "$status_out"
+  return 1
+}
+
+# ─── HealthDetail fetch (admin Basic auth) ─────────────────────────────────
+fetch_health_detail() {
+  local base_url="$1" admin_pass="$2"
+  curl -sf -u "admin:${admin_pass}" --max-time 10 "${base_url}/HealthDetail"
+}
+
+# ─── Bounded-retry: wait for a named migration to reach an exact state ─────
+# `$4` is one of the resources/migrations/types.ts MigrationState values
+# ("running" | "completed" | ...). Treats "halted"/"failed" as an immediate
+# terminal failure (never silently keeps polling past a real halt) UNLESS
+# that IS the target state.
+wait_for_migration_state() {
+  local base_url="$1" admin_pass="$2" migration_id="$3" target_state="$4" timeout_s="${5:-120}"
+  local deadline=$((SECONDS + timeout_s))
+  local attempt=0
+  local detail_json="" state=""
+  while (( SECONDS < deadline )); do
+    attempt=$((attempt + 1))
+    detail_json=$(fetch_health_detail "$base_url" "$admin_pass" 2>/dev/null || echo "")
+    state=$(MIG_ID="$migration_id" node -e '
+      let d = "";
+      process.stdin.on("data", c => d += c);
+      process.stdin.on("end", () => {
+        try {
+          const j = JSON.parse(d);
+          const m = (j.migrations && j.migrations.migrations || []).find(x => x.id === process.env.MIG_ID);
+          process.stdout.write(m ? m.state : "");
+        } catch { process.stdout.write(""); }
+      });
+    ' <<< "$detail_json" 2>/dev/null || echo "")
+    if [[ "$state" == "$target_state" ]]; then
+      echo "[wait_for_migration_state] '${migration_id}' reached '${target_state}' after ${attempt} attempt(s)"
+      return 0
+    fi
+    if [[ "$state" == "halted" || "$state" == "failed" ]]; then
+      echo "::error::[wait_for_migration_state] '${migration_id}' entered terminal state '${state}' while waiting for '${target_state}'"
+      echo "$detail_json"
+      return 1
+    fi
+    sleep 2
+  done
+  echo "::error::[wait_for_migration_state] '${migration_id}' never reached '${target_state}' within ${timeout_s}s (last observed state: '${state:-<none>}')"
+  echo "$detail_json"
+  return 1
+}
+
+# ─── Bounded-retry, two-phase: wait for a migration to be genuinely
+# mid-flight (state=running AND rowsDone>0 AND rowsRemaining>0) ────────────
+# Mirrors test/integration/migrations-resume-after-kill.test.ts's proven
+# two-phase pattern: first wait for "running" (a generous deadline — the
+# deferred boot-keyed start can take tens of seconds), THEN catch a
+# mid-flight sample inside a second, tighter deadline. FAILS LOUD (not a
+# silent pass) if "completed" is observed before mid-flight was ever caught
+# — that means the batch delay/row count is mistuned for this runner, which
+# is a real signal to widen it, not something to swallow.
+wait_for_migration_mid_flight() {
+  local base_url="$1" admin_pass="$2" migration_id="$3" running_timeout_s="${4:-150}" midflight_timeout_s="${5:-90}"
+
+  if ! wait_for_migration_state "$base_url" "$admin_pass" "$migration_id" "running" "$running_timeout_s"; then
+    return 1
+  fi
+
+  local deadline=$((SECONDS + midflight_timeout_s))
+  local attempt=0
+  local detail_json="" result=""
+  while (( SECONDS < deadline )); do
+    attempt=$((attempt + 1))
+    detail_json=$(fetch_health_detail "$base_url" "$admin_pass" 2>/dev/null || echo "")
+    result=$(MIG_ID="$migration_id" node -e '
+      let d = "";
+      process.stdin.on("data", c => d += c);
+      process.stdin.on("end", () => {
+        try {
+          const j = JSON.parse(d);
+          const m = (j.migrations && j.migrations.migrations || []).find(x => x.id === process.env.MIG_ID);
+          if (!m) { process.stdout.write("missing"); return; }
+          if (m.state === "completed") { process.stdout.write("completed"); return; }
+          if ((m.state === "halted" || m.state === "failed")) { process.stdout.write("terminal:" + m.state + ":" + (m.reason || "")); return; }
+          if (m.state === "running" && m.rowsDone > 0 && m.rowsRemaining > 0) {
+            process.stdout.write("midflight:" + m.rowsDone + ":" + m.rowsRemaining);
+            return;
+          }
+          process.stdout.write("waiting:" + m.state);
+        } catch { process.stdout.write("parse-error"); }
+      });
+    ' <<< "$detail_json" 2>/dev/null || echo "")
+    case "$result" in
+      midflight:*)
+        echo "[wait_for_migration_mid_flight] caught '${migration_id}' mid-flight after ${attempt} attempt(s): ${result#midflight:}"
+        return 0
+        ;;
+      completed)
+        echo "::error::[wait_for_migration_mid_flight] '${migration_id}' completed before a mid-flight state was ever observed — the batch delay / row count is mistuned for this runner (widen FLAIR_MIGRATION_TEST_BATCH_DELAY_MS or increase the seeded row count)"
+        return 1
+        ;;
+      terminal:*)
+        echo "::error::[wait_for_migration_mid_flight] '${migration_id}' ${result#terminal:} while waiting to catch it mid-flight"
+        echo "$detail_json"
+        return 1
+        ;;
+    esac
+    sleep 0.5
+  done
+  echo "::error::[wait_for_migration_mid_flight] never observed a mid-flight state for '${migration_id}' within ${midflight_timeout_s}s of reaching 'running' (last: ${result:-<none>})"
+  echo "$detail_json"
+  return 1
+}
+
+# ─── Ledger (OrgEvent) content-hash envelope check ─────────────────────────
+# Reads the migration's ledger row via the ops API (search_by_value on
+# OrgEvent.refId — same raw-ops read path downgrade-boot.test.ts /
+# federation-mixed-version.test.ts use, version-stable and independent of
+# either build's CLI/REST auth resolution). Prints the parsed `detail` blob
+# (structural-only per the Sherlock-ratified ledger shape) and returns 0 only
+# when `hashEnvelopeMatch === true` (invariant IV's completion-gate proof).
+check_ledger_hash_envelope() {
+  local ops_url="$1" admin_pass="$2" migration_id="$3"
+  local body resp
+  body=$(MIG_ID="$migration_id" node -e 'process.stdout.write(JSON.stringify({operation:"search_by_value",database:"flair",table:"OrgEvent",search_attribute:"refId",search_value:process.env.MIG_ID,get_attributes:["*"]}))')
+  resp=$(curl -sf -u "admin:${admin_pass}" -X POST -H "Content-Type: application/json" -d "$body" --max-time 10 "${ops_url}/")
+  MIG_ID="$migration_id" node -e '
+    let d = "";
+    process.stdin.on("data", c => d += c);
+    process.stdin.on("end", () => {
+      let rows;
+      try { rows = JSON.parse(d); } catch (e) { console.error("could not parse ledger search response: " + e.message); process.exit(2); }
+      if (!Array.isArray(rows)) rows = [rows];
+      if (rows.length === 0) { console.error("no ledger OrgEvent found for migration " + process.env.MIG_ID); process.exit(2); }
+      const evt = rows[rows.length - 1];
+      let detail;
+      try { detail = JSON.parse(evt.detail); } catch (e) { console.error("could not parse ledger detail JSON: " + e.message); process.exit(2); }
+      console.log(JSON.stringify(detail, null, 2));
+      if (detail.hashEnvelopeMatch === true) process.exit(0);
+      console.error("hashEnvelopeMatch !== true (got: " + JSON.stringify(detail.hashEnvelopeMatch) + ")");
+      process.exit(1);
+    });
+  ' <<< "$resp"
+}
+
+# ─── ops API: exact row read-back for an agent (version-stable path) ───────
+# Same rationale as test/compat/downgrade-boot.test.ts's fetchAgentMemories:
+# a raw ops search_by_value doesn't depend on either build's `flair memory
+# search` CLI/REST auth resolution (which has genuinely differed across
+# versions) — the honest "did the bytes survive" check.
+fetch_agent_memories_json() {
+  local ops_url="$1" admin_pass="$2" agent_id="$3"
+  local body
+  body=$(AGENT_ID="$agent_id" node -e 'process.stdout.write(JSON.stringify({operation:"search_by_value",database:"flair",table:"Memory",search_attribute:"agentId",search_value:process.env.AGENT_ID,get_attributes:["*"]}))')
+  curl -sf -u "admin:${admin_pass}" -X POST -H "Content-Type: application/json" -d "$body" --max-time 15 "${ops_url}/"
+}
+
+# ─── Self-diagnosing failure dump ───────────────────────────────────────────
+# Writes everything a maintainer would otherwise have to re-derive by hand
+# into `$4/diagnostics.txt` (+ a copy of Harper's own on-disk log, which
+# `flair start`/`restart` spawns with stdio:"ignore" on Linux — Harper still
+# writes its OWN internal log to <dataDir>/log/hdb.log regardless, per
+# docs/troubleshooting.md, so that file — not the CLI wrapper's stdout — is
+# the real source of Harper-internal diagnostics). Best-effort: never throws,
+# so a diagnostics failure can't mask the real test failure that triggered it.
+dump_migration_diagnostics() {
+  local data_dir="$1" base_url="$2" admin_pass="$3" out_dir="$4"
+  mkdir -p "$out_dir"
+  {
+    echo "== HealthDetail (${base_url}/HealthDetail) =="
+    fetch_health_detail "$base_url" "$admin_pass" 2>&1 || echo "(HealthDetail unreachable)"
+    echo
+    echo "== migrations state file (${data_dir}/.migrations/state.json) =="
+    cat "${data_dir}/.migrations/state.json" 2>&1 || echo "(state.json absent)"
+    echo
+    echo "== migrations snapshot dir listing (${data_dir}/.migrations/snapshots/) =="
+    ls -la "${data_dir}/.migrations/snapshots/" 2>&1 || echo "(snapshots dir absent)"
+    echo
+    echo "== hdb.log tail (last 400 lines of ${data_dir}/log/hdb.log) =="
+    tail -n 400 "${data_dir}/log/hdb.log" 2>&1 || echo "(hdb.log absent)"
+  } > "${out_dir}/diagnostics.txt" 2>&1 || true
+  cp "${data_dir}/log/hdb.log" "${out_dir}/hdb.log" 2>/dev/null || true
+  cp "${data_dir}/.migrations/state.json" "${out_dir}/migrations-state.json" 2>/dev/null || true
+  echo "[dump_migration_diagnostics] wrote diagnostics to ${out_dir}"
+}


### PR DESCRIPTION
## What this proves (maps to the ratified safety-doc invariants)

Enforcement arm of the CI-enforcement standards (#695) and the migration-safety invariants (#695) for the zero-touch boot-keyed auto-migration runner (#690). References #695 throughout.

### New: `.github/workflows/migration-ci-lanes.yml`

- **`downgrade-and-revert`** — Kern: *"the proof of invariant I"*. Installs the latest published release → seeds a 140-row corpus via the real CLI write path as the reserved synthetic-migration test agent → swaps in the PR build with `FLAIR_ENABLE_TEST_MIGRATIONS=1` + a widened batch delay → catches the synthetic migration genuinely mid-flight via a bounded two-phase poll (mirrors `migrations-resume-after-kill.test.ts`'s proven pattern) → kills Harper → reinstalls the previously-published release against the SAME, now partially-migrated store → asserts it boots and serves the corpus byte-identically (raw ops-API read + a real `flair memory search` round-trip). Non-negotiable per migration PR per Kern's verdict.

- **`snapshot-restore-drill`** — invariant III: *"a backup that has never been restored is a prayer."* Seeds → lets the auto-migration run to completion → deliberately corrupts the migration-touched rows via a raw ops-API partial update → restores via the shipped `flair snapshot create`/`flair snapshot restore` mechanism → verifies byte-identical integrity and matching counts.

  **Design-fit finding for K&S** (not a runtime bug, no runtime touched): the auto-migration runner's own internal pre-flight snapshot (`resources/migrations/snapshot.ts`) is deliberately risk-class-scoped — metadata-only for `embedding-stamp` (derived-only), schema+metadata for the synthetic migration (schema-additive). Neither writes row *content*, so there's nothing there to restore FROM for a content-corruption drill; it's a logical in-process manifest, not a byte-exact snapshot, by design (stopping Harper to snapshot inside its own live-serving process would undo the #687 boot win). This lane therefore drills the invariant III "floor beneath everything" mechanism instead — `flair snapshot create`/`restore`, the shipped byte-exact mechanism actually capable of content recovery — while separately asserting the migration's own internal snapshot fired (a complementary, cheaper check). Flagging in case #695's "rides the existing `flair snapshot` machinery" language should be reconciled with the as-implemented architecture.

### Extended: `upgrade-smoke` in `test.yml`

Seeds stub-stamped rows (raw ops-API bulk insert, same pattern `migrations-synthetic-e2e.test.ts` uses) as the reserved synthetic-migration test agent before the swap, enables `FLAIR_ENABLE_TEST_MIGRATIONS=1` on the HEAD boot, and asserts: (a) the auto-migration ran to completion, (b) its content-hash envelope `hashEnvelopeMatch === true` (read from the ledger `OrgEvent`), (c) recall parity — the migration-touched ground truth is still retrievable by `flair memory search` post-migration. Placed *before* the existing manual `flair reembed` step so the two writers never race the same rows.

### `scripts/ci/migration-lane-lib.sh`

Shared bounded-retry primitives (bash, sourced by all three lanes): `wait_for_http_ok`/`wait_for_http_down`, `wait_for_flair_status_running`, `wait_for_migration_state`, `wait_for_migration_mid_flight` (two-phase), `check_ledger_hash_envelope`, `fetch_agent_memories_json`, `dump_migration_diagnostics`. Every post-boot/post-restart check in all three lanes goes through one of these — never a single-shot probe.

### flair#691 fix (included, small + contained per the dispatch)

`pack-smoke`'s post-restart verify was a single-shot `flair status` check immediately after `flair restart` returned — races boot on a slow runner. Replaced with `wait_for_flair_status_running` (the same bounded-retry primitive the new lanes use). Same fix applied to `upgrade-smoke`'s post-start check while touching that job for the migration assertions above.

## Sherlock §4 compliance

- `pull_request`-trigger only on the new workflow (never `pull_request_target` with PR-code checkout) — matches every existing lane's pattern.
- Zero secrets exposed to either new job (public npm installs + default `GITHUB_TOKEN` only — no `NPM_TOKEN`, no deploy credentials).
- Every third-party action pinned to a full commit SHA (`actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2`, looked up live via the GitHub API rather than guessed; all other actions reuse SHAs already pinned elsewhere in this repo).
- No `${{ }}` interpolation of PR-controlled metadata (title/body/branch) into any `run:` block — the only `${{ }}` uses are step outputs this workflow itself produces and `github.workspace`.
- No new cache keys added (no `actions/cache` introduced by this PR) — N/A for the ref-scoping requirement.

## Local validation performed

- `actionlint` (locally installed via Homebrew) against both touched workflow files: clean except two pre-existing `SC2086` info-level notes verified present identically on `origin/main` (unrelated to this diff — confirmed via a direct `actionlint` run against `origin/main`'s copy).
- Every `run:` block in both files (63 total) extracted programmatically and individually passed `bash -n`.
- `scripts/ci/migration-lane-lib.sh` passes `bash -n`.
- Both workflow files parse cleanly via `js-yaml` (repo dependency).
- **Live validation against a real ephemeral Harper** (this worktree's own build, on the local dev host): confirmed CLI-seeded Memory rows get a real, synchronous `embeddingModel` stamp at write time (so `embedding-stamp` — always-on, runs ahead of the synthetic migration in registry order — doesn't contend with it across a baseline→PR-build swap, without needing the `FLAIR_EMBEDDING_MODEL` pinning trick `migrations-resume-after-kill.test.ts` needs for its raw-ops-API seeding path); ran the synthetic migration to completion and read back `hashEnvelopeMatch: true` from the ledger via `check_ledger_hash_envelope`; confirmed the internal snapshot directory naming/shape; confirmed the raw ops-API `update` operation does a genuine partial-field merge (validates the corruption step's semantics); ran a full `flair snapshot create` → corrupt → `flair snapshot restore --yes` round trip and verified byte-identical content recovery; unit-tested the mid-flight JSON-extraction logic against a synthetic `HealthDetail` payload.
- Full existing unit suite: **2161 pass / 0 fail** (no runtime files touched by this PR).

## Deviations

- Used `flair snapshot create`/`restore` (not the migration runner's own internal snapshot) as the restore mechanism for the snapshot-restore-drill lane — see the design-fit finding above.
- Row counts/delays for `downgrade-and-revert` (140 rows, 2500ms batch delay) reuse `migrations-resume-after-kill.test.ts`'s exact proven constants rather than inventing new ones, to avoid re-deriving a timing tune that's already validated in this codebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
