### PR TITLE
chore: public-repo hygiene — private spec-path refs → public tracking issue #695

### DIFF
--- a/resources/collision-lib.ts
+++ b/resources/collision-lib.ts
@@ -1,7 +1,7 @@
 /**
  * collision-lib.ts — pure join/rank/format logic for MemoryBootstrap's
  * "Others in the room" collision-surfacing block (flair#681, the attention-
- * plane flagship — spec: ~/ops/FLAIR-ATTENTION-PLANE.md "Phase 2 — collision
+ * plane flagship — spec: flair#695 "Phase 2 — collision
  * surfacing in bootstrap").
  *
  * This module does NO Harper reads of its own. resources/MemoryBootstrap.ts's

--- a/resources/health.ts
+++ b/resources/health.ts
@@ -74,7 +74,7 @@ export class Health extends Resource {
     return true;
   }
   async get() {
-    // `version` (ops-1l18, the CLI↔server handshake — src/version-handshake.ts):
+    // `version` (flair#695, the CLI↔server handshake — src/version-handshake.ts):
     // exposed on the PUBLIC endpoint deliberately, so the check works even
     // before an agent identity/key exists (fresh install, pre-`flair init`).
     // Sherlock verdict: fine while locally bound; if /Health is ever fronted
@@ -443,9 +443,9 @@ export class HealthDetail extends Resource {
       }
     } catch { stats.rem = null; }
 
-    // ── Migrations (ops-1l18: zero-touch boot-keyed auto-migration) ──
+    // ── Migrations (flair#695: zero-touch boot-keyed auto-migration) ──
     // `{ id, rowsDone, rowsRemaining, state }` per registered migration, per
-    // ~/ops/FLAIR-ZERO-TOUCH-UPGRADE.md §A. `cyclePhase: "pre-hash"` is the
+    // flair#695 §A. `cyclePhase: "pre-hash"` is the
     // "pre-flight integrity check in progress" state the K&S verdict calls
     // for; a halted migration surfaces here (with `reason`) AND as a
     // warning below so it's visible without a separate lookup.

--- a/resources/migration-boot.ts
+++ b/resources/migration-boot.ts
@@ -1,5 +1,5 @@
 /**
- * migration-boot.ts — the boot-keyed trigger (~/ops/FLAIR-ZERO-TOUCH-UPGRADE.md
+ * migration-boot.ts — the boot-keyed trigger (flair#695
  * §A, Kern verdict): "Envelope ASYNC after ready — boot serves immediately
  * on the old shape; pre-hash runs async; migration deferred until it
  * completes; health shows 'pre-flight integrity check in progress'."

--- a/resources/migrations/envelope.ts
+++ b/resources/migrations/envelope.ts
@@ -1,7 +1,7 @@
 /**
  * envelope.ts — the corpus-wide integrity envelope: "full-corpus
  * hash-of-source-field-hashes computed before first write and after
- * completion; must match" (~/ops/FLAIR-MIGRATION-SAFETY.md invariant IV /
+ * completion; must match" (flair#695 invariant IV /
  * Kern verdict), computed ONCE per boot cycle (K&S: "Envelope ASYNC after
  * ready — boot serves immediately on the old shape; pre-hash runs async;
  * migration deferred until it completes").

--- a/resources/migrations/export.ts
+++ b/resources/migrations/export.ts
@@ -4,7 +4,7 @@
  * data-dir size; the irreplaceable part (memory content + provenance)
  * exports far smaller. If the physical snapshot doesn't fit but the content
  * export does → export content, proceed (derived is recomputable by
- * definition)." (~/ops/FLAIR-MIGRATION-SAFETY.md, space-pressure step 4)
+ * definition)." (flair#695, space-pressure step 4)
  *
  * Exports SOURCE_FIELDS ONLY (+id) — never derived fields (embedding is the
  * dominant size driver this exists to skip) — as JSONL, one row per line,

--- a/resources/migrations/risk-policy.ts
+++ b/resources/migrations/risk-policy.ts
@@ -7,7 +7,7 @@
  * full envelope; content-transform: envelope over OLD rows' SOURCE_FIELDS +
  * new-row presence — strictest)."
  *
- * Snapshot scope (~/ops/FLAIR-MIGRATION-SAFETY.md invariant III, space
+ * Snapshot scope (flair#695 invariant III, space
  * pressure step 3): derived-only → metadata-only (no corpus snapshot
  * needed — recomputable by definition); schema-additive → schema+metadata
  * (no row rewrites); content-transform → pointers+metadata (old rows are

--- a/resources/migrations/runner.ts
+++ b/resources/migrations/runner.ts
@@ -6,7 +6,7 @@
  * risk-scoped completion gate → post-hash comparison → ledger OrgEvent →
  * state-file update → snapshot prune.
  *
- * Halt-don't-brick everywhere (~/ops/FLAIR-MIGRATION-SAFETY.md invariant
+ * Halt-don't-brick everywhere (flair#695 invariant
  * II): this function NEVER throws — every failure mode (space-blocked,
  * snapshot-failed, pre-hash-failed, gate-failed, an unexpected exception)
  * resolves to a halted/failed progress entry + (where applicable) a ledger

--- a/resources/migrations/snapshot.ts
+++ b/resources/migrations/snapshot.ts
@@ -14,7 +14,7 @@
  * files, stat-verified — see dir-safety.ts) as the rest of Flair's snapshot
  * machinery.
  *
- * Scope per risk class (~/ops/FLAIR-MIGRATION-SAFETY.md, space-pressure
+ * Scope per risk class (flair#695, space-pressure
  * step 3 / resources/migrations/risk-policy.ts):
  *   - metadata-only:      manifest only (row counts, versions) — no corpus
  *                          snapshot needed; derived data is recomputable by

--- a/resources/migrations/source-fields.ts
+++ b/resources/migrations/source-fields.ts
@@ -1,6 +1,6 @@
 /**
  * source-fields.ts — SOURCE_FIELDS enumerations + the integrity envelope
- * hash (~/ops/FLAIR-MIGRATION-SAFETY.md invariant I + Kern verdict).
+ * hash (flair#695 invariant I + Kern verdict).
  *
  * "SOURCE_FIELDS constant per resource — enumerate source vs derived per
  * table, mechanically checked by the hash gate." The exact enumerations

--- a/resources/migrations/space.ts
+++ b/resources/migrations/space.ts
@@ -1,6 +1,6 @@
 /**
  * space.ts — pre-flight space check, step 1 of the ladder
- * (~/ops/FLAIR-MIGRATION-SAFETY.md, "Space pressure"):
+ * (flair#695, "Space pressure"):
  *
  * "Pre-flight space check before any write — estimate snapshot size AND the
  * migration's own working set (supersession transforms temporarily hold

--- a/resources/migrations/types.ts
+++ b/resources/migrations/types.ts
@@ -1,8 +1,8 @@
 /**
- * types.ts — shared shapes for the zero-touch migration runner (ops-1l18).
+ * types.ts — shared shapes for the zero-touch migration runner (flair#695).
  *
- * Governed by ~/ops/FLAIR-MIGRATION-SAFETY.md (the four invariants) and
- * ~/ops/FLAIR-ZERO-TOUCH-UPGRADE.md (the runner design + K&S verdict
+ * Governed by flair#695 (the four invariants) and
+ * flair#695 (the runner design + K&S verdict
  * refinements). Every migration registered in resources/migrations/registry.ts
  * implements the `Migration` interface below.
  */

--- a/resources/semantic-retrieval-core.ts
+++ b/resources/semantic-retrieval-core.ts
@@ -1,7 +1,7 @@
 // ─── retrieveCandidates() — the pure retrieval core (flair bootstrap-scale-fix) ──
 //
 // Extracted from resources/SemanticSearch.ts's post() (Kern-approved
-// refactor, ~/ops/FLAIR-BOOTSTRAP-SCALE-FIX.md). Before this module existed,
+// refactor, flair#695). Before this module existed,
 // SemanticSearch.post() was one function entangling auth resolution,
 // rate-limiting, HNSW/BM25 retrieval, post-retrieval filtering, the
 // cross-encoder reranker, AND retrievalCount/lastRetrieved hit-tracking side

--- a/scripts/migrate-memories.mjs
+++ b/scripts/migrate-memories.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 /**
  * Migrate flat-file daily memories into Flair.
- * Usage: FLAIR_AGENT_ID=flint node scripts/migrate-memories.mjs ~/ops/agents/flint/memory/
+ * Usage: FLAIR_AGENT_ID=flint node scripts/migrate-memories.mjs <memory-dir>/
  */
 import { readFileSync, readdirSync } from 'node:fs';
 import { webcrypto } from 'node:crypto';

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1869,7 +1869,7 @@ const __pkgVersion = (() => {
 const program = new Command();
 program.name("flair").version(__pkgVersion, "-v, --version");
 
-// ─── CLI↔server version handshake (ops-1l18 §B) ────────────────────────────
+// ─── CLI↔server version handshake (flair#695 §B) ────────────────────────────
 // Every command invocation gets a cheap, cached (~60s), short-timeout check
 // of the running server's version against this CLI's own — catches the
 // bare-npm-upgrade trap where `npm i -g @tpsdev-ai/flair@latest` swaps the
@@ -3886,7 +3886,7 @@ federation
   });
 
 // `flair federation reachability` — probe local instance + all paired peers.
-// Productizes ~/ops/scripts/flair-boot-probe.sh: a single command that tells
+// Productizes flair#695: a single command that tells
 // you whether memories CAN flow across the federation right now. Read-only;
 // no mutations, no side effects beyond a single tagged status read per peer.
 federation
@@ -4597,7 +4597,7 @@ federation
   });
 
 // `flair federation prune` — remove stale spoke peers (never the hub).
-// Productizes ~/ops/scripts/cleanup-stale-fed-peers.sh into a real CLI
+// Productizes flair#695 into a real CLI
 // subcommand with safety: dry-run is the default, --apply required to delete.
 function parseDuration(spec: string): number | null {
   // Accept forms like "30d", "12h", "90m". Returns milliseconds.
@@ -4704,7 +4704,7 @@ federation
 
 // `flair federation verify` — end-to-end roundtrip: write a tagged memory
 // locally, wait for federation push, probe peers for the tag. Productizes
-// ~/ops/scripts/verify-fed-sync.sh. Cleans up the test memory at the end.
+// flair#695 Cleans up the test memory at the end.
 federation
   .command("verify")
   .description("End-to-end check: write a tagged memory locally and verify it shows up on each peer")
@@ -8631,7 +8631,7 @@ program
       }
     }
 
-    // 1a. CLI ↔ running-server version handshake (ops-1l18 §B) — the
+    // 1a. CLI ↔ running-server version handshake (flair#695 §B) — the
     // version TRIPLE: this CLI's own version (__pkgVersion, checked against
     // npm-latest in step 0 above), and the RUNNING server's reported
     // version (GET /Health — public, no auth needed). A mismatch means the
@@ -8999,7 +8999,7 @@ program
       }
     }
 
-    // 9. Migration state (ops-1l18) — pending/in-progress/blocked + last
+    // 9. Migration state (flair#695) — pending/in-progress/blocked + last
     // ledger-derived outcome per registered migration, read off the same
     // authenticated /HealthDetail the "Fleet presence" section above
     // already fetches. `--fix` here means the SAME restart offered in step

--- a/src/version-handshake.ts
+++ b/src/version-handshake.ts
@@ -1,5 +1,5 @@
 /**
- * version-handshake.ts — CLI↔server version handshake (ops-1l18 §B, the
+ * version-handshake.ts — CLI↔server version handshake (flair#695 §B, the
  * bare-npm rescue): "Every CLI invocation (cheap, cached ~60s) compares:
  * CLI version, installed-package version, running-server version. Mismatch
  * → one-line nudge on stderr: `flair 0.23.0 installed but server is running

--- a/test/bench/recall-harness/README.md
+++ b/test/bench/recall-harness/README.md
@@ -2,7 +2,7 @@
 
 Measures Flair's recall precision (p@3, MRR) against a **harder, representative
 synthetic corpus**, on a **fully ephemeral Harper instance**. It never touches
-`~/ops/flair`, the live `:9926` service, or any production memory.
+any live checkout, the live `:9926` service, or any production memory.
 
 ## Why this exists
 

--- a/test/bench/recall-harness/run.ts
+++ b/test/bench/recall-harness/run.ts
@@ -15,7 +15,7 @@
  *
  * This harness is isolated (spawns an EPHEMERAL Harper via
  * test/helpers/harper-lifecycle.ts — zero contact with the live :9926
- * service or ~/ops/flair) AND uses a harder, representative corpus
+ * service or flair#695) AND uses a harder, representative corpus
  * (./corpus.ts — near-duplicate clusters, lexical-overlap traps, varied
  * durability/recency) that can actually discriminate. It reproduces, in
  * isolation, the exact finding that flair#623 (commit 624299c, 2026-07-08)
@@ -37,7 +37,7 @@
  * SAFETY: every Harper instance is a fresh `mkdtemp` ROOTPATH/HOME
  * (test/helpers/harper-lifecycle.ts), bound to OS-assigned free ports, and
  * killed + removed at the end of each run. This script never imports, reads
- * from, or writes to ~/ops/flair or any live Flair service. FLAIR_MODELS_DIR
+ * from, or writes to flair#695 or any live Flair service. FLAIR_MODELS_DIR
  * may be pointed at an EXISTING flair install's models/ directory (read-only
  * — just the GGUF weight files) to skip re-downloading the embedding model;
  * see README.md.

--- a/test/integration/attention-query-e2e.test.ts
+++ b/test/integration/attention-query-e2e.test.ts
@@ -1,6 +1,6 @@
 /**
  * attention-query-e2e.test.ts — real-Harper integration coverage for
- * POST /AttentionQuery (flair#677, spec: ~/ops/FLAIR-ATTENTION-PLANE.md).
+ * POST /AttentionQuery (flair#677, spec: flair#695).
  *
  * The unit suite (test/unit/attention-query.test.ts) exercises
  * resources/AttentionQuery.ts against a HAND-WRITTEN mock of Harper's

--- a/test/integration/bootstrap-collision-e2e.test.ts
+++ b/test/integration/bootstrap-collision-e2e.test.ts
@@ -1,7 +1,7 @@
 // bootstrap-collision-e2e.test.ts — real-Harper, real-embedding end-to-end
 // coverage for MemoryBootstrap's "Others in the room" collision-surfacing
 // block (flair#681, the attention-plane flagship — spec:
-// ~/ops/FLAIR-ATTENTION-PLANE.md "Phase 2 — collision surfacing in
+// flair#695 "Phase 2 — collision surfacing in
 // bootstrap"). Builds on #676 (entity vocab + entities[] fields), #678
 // (AttentionQuery's internal WorkspaceState read + Presence-via-resource
 // pattern, reused here), and #550 (Memory semantic scoring during bootstrap,

--- a/test/integration/migrations-halt-space.test.ts
+++ b/test/integration/migrations-halt-space.test.ts
@@ -1,6 +1,6 @@
 /**
  * migrations-halt-space.test.ts — halt-don't-brick under a blocked disk
- * (~/ops/FLAIR-MIGRATION-SAFETY.md invariant III space-pressure steps 1/5):
+ * (flair#695 invariant III space-pressure steps 1/5):
  * "No safe path → halt-don't-brick: serve old shape, health + doctor state
  * exactly what's needed."
  *

--- a/test/integration/migrations-resume-after-kill.test.ts
+++ b/test/integration/migrations-resume-after-kill.test.ts
@@ -1,7 +1,7 @@
 /**
  * migrations-resume-after-kill.test.ts — proves crash-resume (invariant IV:
  * "Idempotent, resumable, observable... crash-resume free" /
- * ~/ops/FLAIR-ZERO-TOUCH-UPGRADE.md: "ENOSPC/crash mid-run = clean halt,
+ * flair#695: "ENOSPC/crash mid-run = clean halt,
  * auto-resume next boot").
  *
  * Seeds rows spanning multiple batches, starts Harper, waits for the

--- a/test/integration/migrations-synthetic-e2e.test.ts
+++ b/test/integration/migrations-synthetic-e2e.test.ts
@@ -1,6 +1,6 @@
 /**
  * migrations-synthetic-e2e.test.ts — end-to-end coverage of the zero-touch
- * migration runner against a REAL ephemeral Harper (ops-1l18). Exercises the
+ * migration runner against a REAL ephemeral Harper (flair#695). Exercises the
  * FULL boot-keyed path: process boot → resources/migration-boot.ts's
  * setImmediate trigger → shared async pre-hash → the synthetic CI-only
  * migration's own pre-flight ladder → risk-scoped snapshot → throttled

--- a/test/integration/version-handshake-e2e.test.ts
+++ b/test/integration/version-handshake-e2e.test.ts
@@ -1,5 +1,5 @@
 /**
- * version-handshake-e2e.test.ts — ops-1l18 §B, the CLI↔server version
+ * version-handshake-e2e.test.ts — flair#695 §B, the CLI↔server version
  * handshake, against a REAL Harper instance. Unit coverage
  * (test/unit/version-handshake.test.ts) already exhaustively covers
  * caching/TTL/offline-tolerance with a fake fetch; this file proves the

--- a/test/unit/attention-query.test.ts
+++ b/test/unit/attention-query.test.ts
@@ -1,6 +1,6 @@
 /**
  * attention-query.test.ts — unit coverage for resources/AttentionQuery.ts
- * (flair#677, spec: ~/ops/FLAIR-ATTENTION-PLANE.md "Phase 1 — the query").
+ * (flair#677, spec: flair#695 "Phase 1 — the query").
  *
  * Exercises the SHIPPED AttentionQuery.post() directly against a mocked
  * @harperfast/harper, using the same in-memory-store mocking technique as

--- a/test/unit/collision-lib.test.ts
+++ b/test/unit/collision-lib.test.ts
@@ -1,6 +1,6 @@
 // Unit tests for resources/collision-lib.ts — the pure join/rank/format
 // logic behind MemoryBootstrap's "Others in the room" collision-surfacing
-// block (flair#681, spec: ~/ops/FLAIR-ATTENTION-PLANE.md "Phase 2").
+// block (flair#681, spec: flair#695 "Phase 2").
 //
 // These exercise the real shipped logic directly (no Harper dependency —
 // same reason test/unit/bootstrap-team.test.ts imports memory-bootstrap-lib.ts

--- a/test/unit/version-handshake.test.ts
+++ b/test/unit/version-handshake.test.ts
@@ -1,6 +1,6 @@
 /**
  * version-handshake.test.ts — src/version-handshake.ts, the CLI↔server
- * version handshake (ops-1l18 §B). Mirrors test/unit/version-check.test.ts's
+ * version handshake (flair#695 §B). Mirrors test/unit/version-check.test.ts's
  * technique (injected fetch/cache/clock) for the sibling "installed vs
  * latest-published" checker.
  */


### PR DESCRIPTION
Comment/doc-only sweep (26 files, 36 lines): every reference to private ops spec paths and internal tracker ids in the public repo now points at the public tracking issue #695 (which carries the distilled migration-safety invariants + CI-lane rationale). One README sentence rephrased where the old text named a private checkout path. No code behavior touched — verified by diff inspection (all changed lines are comments/docs) and clean typecheck; the unit suite shows 14 environment-local failures on this machine that reproduce identically on the un-modified base (CI was green on the same base SHA, facdfcb).

Rule going forward (also applied to PR #692's files and body): public artifacts — code comments, commit messages, PR bodies — reference public issues, never private paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)