### PR TITLE
fix(docs): repair semantic garbles from the #696 sweep

### DIFF
--- a/resources/collision-lib.ts
+++ b/resources/collision-lib.ts
@@ -1,7 +1,7 @@
 /**
  * collision-lib.ts — pure join/rank/format logic for MemoryBootstrap's
  * "Others in the room" collision-surfacing block (flair#681, the attention-
- * plane flagship — spec: flair#695 "Phase 2 — collision
+ * plane flagship — spec: flair#681 "Phase 2 — collision
  * surfacing in bootstrap").
  *
  * This module does NO Harper reads of its own. resources/MemoryBootstrap.ts's

--- a/test/bench/recall-harness/run.ts
+++ b/test/bench/recall-harness/run.ts
@@ -15,7 +15,7 @@
  *
  * This harness is isolated (spawns an EPHEMERAL Harper via
  * test/helpers/harper-lifecycle.ts — zero contact with the live :9926
- * service or flair#695) AND uses a harder, representative corpus
+ * service or any live checkout) AND uses a harder, representative corpus
  * (./corpus.ts — near-duplicate clusters, lexical-overlap traps, varied
  * durability/recency) that can actually discriminate. It reproduces, in
  * isolation, the exact finding that flair#623 (commit 624299c, 2026-07-08)
@@ -37,7 +37,7 @@
  * SAFETY: every Harper instance is a fresh `mkdtemp` ROOTPATH/HOME
  * (test/helpers/harper-lifecycle.ts), bound to OS-assigned free ports, and
  * killed + removed at the end of each run. This script never imports, reads
- * from, or writes to flair#695 or any live Flair service. FLAIR_MODELS_DIR
+ * from, or writes to any live checkout or any live Flair service. FLAIR_MODELS_DIR
  * may be pointed at an EXISTING flair install's models/ directory (read-only
  * — just the GGUF weight files) to skip re-downloading the embedding model;
  * see README.md.

--- a/test/integration/attention-query-e2e.test.ts
+++ b/test/integration/attention-query-e2e.test.ts
@@ -1,6 +1,6 @@
 /**
  * attention-query-e2e.test.ts — real-Harper integration coverage for
- * POST /AttentionQuery (flair#677, spec: flair#695).
+ * POST /AttentionQuery (flair#677).
  *
  * The unit suite (test/unit/attention-query.test.ts) exercises
  * resources/AttentionQuery.ts against a HAND-WRITTEN mock of Harper's

--- a/test/integration/bootstrap-collision-e2e.test.ts
+++ b/test/integration/bootstrap-collision-e2e.test.ts
@@ -1,7 +1,7 @@
 // bootstrap-collision-e2e.test.ts — real-Harper, real-embedding end-to-end
 // coverage for MemoryBootstrap's "Others in the room" collision-surfacing
 // block (flair#681, the attention-plane flagship — spec:
-// flair#695 "Phase 2 — collision surfacing in
+// flair#681 "Phase 2 — collision surfacing in
 // bootstrap"). Builds on #676 (entity vocab + entities[] fields), #678
 // (AttentionQuery's internal WorkspaceState read + Presence-via-resource
 // pattern, reused here), and #550 (Memory semantic scoring during bootstrap,

--- a/test/unit/attention-query.test.ts
+++ b/test/unit/attention-query.test.ts
@@ -1,6 +1,6 @@
 /**
  * attention-query.test.ts — unit coverage for resources/AttentionQuery.ts
- * (flair#677, spec: flair#695 "Phase 1 — the query").
+ * (flair#677, "Phase 1 — the query").
  *
  * Exercises the SHIPPED AttentionQuery.post() directly against a mocked
  * @harperfast/harper, using the same in-memory-store mocking technique as

--- a/test/unit/collision-lib.test.ts
+++ b/test/unit/collision-lib.test.ts
@@ -1,6 +1,6 @@
 // Unit tests for resources/collision-lib.ts — the pure join/rank/format
 // logic behind MemoryBootstrap's "Others in the room" collision-surfacing
-// block (flair#681, spec: flair#695 "Phase 2").
+// block (flair#681, "Phase 2").
 //
 // These exercise the real shipped logic directly (no Harper dependency —
 // same reason test/unit/bootstrap-team.test.ts imports memory-bootstrap-lib.ts


### PR DESCRIPTION
Seven comment lines from the #696 mechanical sweep replaced text the regex should never have touched. Two classes, both caught by review of the merged diff (credit: the founder spotted the first):

1. **Filesystem-path prose garbled** (2 lines, `test/bench/recall-harness/run.ts`): "never …writes to `~/ops/flair`…" became "never …writes to flair#695…" — an issue reference substituted into a sentence about a directory. Restored as "any live checkout".
2. **Wrong-anchor citations** (5 lines): attention-plane spec references in `collision-lib.ts` and the attention/collision tests were pointed at #695 (the *migration-safety* anchor). Re-anchored to the correct public issues that were already cited alongside — #677 (attention query) and #681 (collision surfacing) — or the redundant spec ref dropped.

Issue #695 was also extended (§A runner design, §B version handshake, the space-pressure ladder) so the remaining section-style citations ("#695 §B" etc.) resolve to real content.

Process fix applied on our side: mechanical sweeps get a semantic line-by-line read of the final diff, not just a comments-only structural check — three reviewers pattern-matched "comment-only, safe" and all missed line 40.

🤖 Generated with [Claude Code](https://claude.com/claude-code)