### PR TITLE
fix(config): downgrade-safe models.embedding config (#694)

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -14,25 +14,27 @@ jsResource:
 
 # Phase 1 (flair#504): embeddings now run through Harper's native
 # models.embed() facade, backed by harper-fabric-embeddings registered as the
-# `embedding` backend. That registration is NOT configured here: Harper's
-# `bootstrapModels()` only reads the `models:` block from the Harper
-# INSTANCE-ROOT config (harper-config.yaml, generated in ROOTPATH) — the
-# `.` application this file configures always loads with `isRoot: false`
-# (components/componentLoader.ts), so a `models:` block in THIS file is
-# silently never read (verified: bootstrapModels is gated on `isRoot`, and
-# RUN_HDB_APP — what `.` becomes — always loads isRoot:false). The real
-# registration is delivered via the HARPER_CONFIG env var (Harper's merge-layer
-# config mechanism — reasserts only the keys it names, yields to Fabric-managed
-# HARPER_SET_CONFIG, no force-override or drift-lock) from src/cli.ts
-# (buildEmbeddingsHarperConfigEnv, on every Harper spawn) and
-# test/helpers/harper-lifecycle.ts for tests. This ALSO replaces the prior
-# `package:`-style sub-component entry that used to sit here
-# (`'harper-fabric-embeddings': { package: ... }`, which drove
-# `handleApplication`) — keeping both would double-init the engine (two
-# separate EmbeddingEngine instances: one unused, one backing models.embed),
-# since `register` (the models-backend path) and `handleApplication` (the old
-# sub-component path) are independent code paths in harper-fabric-embeddings,
-# not the same init.
+# `embedding` backend. That registration is NOT configured here, and (as of
+# flair#694) is no longer config-driven anywhere: a `models:` block in THIS
+# file would silently never be read (this application always loads with
+# `isRoot: false` — components/componentLoader.ts gates `bootstrapModels()`
+# on `isRoot`), and the earlier fix for that — reasserting the block into the
+# Harper INSTANCE-ROOT config via the HARPER_CONFIG env var on every spawn —
+# turned out to PERSIST that block into harper-config.yaml, which an
+# older/downgraded build's boot (never having set the env var) would tear
+# down to an invalid empty shell and refuse to boot against (flair#694; see
+# flair#695 for the invariant this violated). The registration now happens
+# in-process instead: `dist/resources/embeddings-boot.js` (built from
+# resources/embeddings-boot.ts, loaded by the `jsResource` glob below like
+# every other file under resources/) calls harper-fabric-embeddings'
+# `register()` factory directly on every boot — nothing is ever written to
+# the config file, so there is nothing for a downgrade to trip over. This
+# also means a `package:`-style sub-component entry
+# (`'harper-fabric-embeddings': { package: ... }`, which used to sit here and
+# drove `handleApplication`) still must not be reintroduced alongside it —
+# that hook populates a SEPARATE raw-API engine, not `models.embed()`, and
+# running both would double-init (two separate EmbeddingEngine instances:
+# one unused, one backing models.embed).
 
 authentication:
   # Default secure (flair#654): a credential-less loopback request to the

--- a/resources/embeddings-boot.ts
+++ b/resources/embeddings-boot.ts
@@ -1,0 +1,125 @@
+/**
+ * embeddings-boot.ts — registers harper-fabric-embeddings as Harper's
+ * `embedding`/`default` model backend DIRECTLY, in-process, on every boot
+ * (flair#694 fix; invariants at flair#695).
+ *
+ * ─── Why this file exists (flair#694) ──────────────────────────────────────
+ * The previous mechanism (removed by this change) delivered the registration
+ * as a `models.embedding.default` block via the `HARPER_CONFIG` env var
+ * (src/cli.ts's old `buildEmbeddingsHarperConfigEnv`) — a "merge layer" that
+ * Harper's environment-manager (`@harperfast/harper`'s
+ * `config/harperConfigEnvVars.js`) reasserts on every boot AND PERSISTS into
+ * the instance-root `harper-config.yaml`. That file proved to be config-as-
+ * STATE, not config-as-intent: `flair#694`'s downgrade-and-revert CI lane
+ * (flair#692) caught a real bricking sequence —
+ *
+ *   1. A build with this feature boots and HARPER_CONFIG reasserts
+ *      `models.embedding.default.{backend,modelName,modelsDir}`, which
+ *      Harper's env-var layer persists to `harper-config.yaml` AND records
+ *      each of those THREE flattened leaf paths as `sources[path] =
+ *      'HARPER_CONFIG'` in `.harper-config-state.json` (no "original value"
+ *      stored, because the key didn't exist before this boot introduced it).
+ *   2. On ANY later boot that does not reassert `HARPER_CONFIG` for those
+ *      paths (a downgrade to a build that predates this feature; equally, a
+ *      transient resolution failure on the current build) — Harper's own
+ *      `applyRuntimeEnvConfig` treats the env var's absence as "the operator
+ *      removed this config" and calls `cleanupRemovedEnvVar`, which deletes
+ *      each of the three leaves INDIVIDUALLY (no stored original to restore
+ *      to), leaving `models.embedding.default: {}` — an empty shell —
+ *      persisted to disk.
+ *   3. The next boot's config schema validator
+ *      (`@harperfast/harper`'s `validation/configValidator.js`) resolves the
+ *      entry's backend via `Joi.alternatives().conditional('.backend', {...,
+ *      otherwise: unknownBackendEntrySchema})`; with `backend` absent, that
+ *      falls through to `unknownBackendEntrySchema = Joi.object({backend:
+ *      string.required()})`, which throws exactly: "Harper config file
+ *      validation error: 'models.embedding.default.backend' is required" —
+ *      Harper refuses to boot. Confirmed byte-identical in both @harperfast/
+ *      harper 5.1.15 and 5.1.17 (this is upstream env-var-config behavior,
+ *      not a schema difference between versions), and reproduced locally by
+ *      replaying the exact downgrade-and-revert sequence.
+ *
+ * No shape flair could put IN HARPER_CONFIG fixes this: the deletion is
+ * triggered by an OLDER build never setting the env var in the first place,
+ * which is unfixable from the newer build's side. Config that gets torn
+ * down whenever a boot doesn't reassert it is fundamentally unsafe for
+ * anything a downgrade must survive (flair#695 invariant I: "config files
+ * are state too").
+ *
+ * ─── The fix ────────────────────────────────────────────────────────────
+ * Skip Harper's config-file-driven bootstrap path ENTIRELY. Call
+ * harper-fabric-embeddings' own `register({logicalName, kind, config})`
+ * factory DIRECTLY — the same factory Harper's `bootstrapModels()` would
+ * have invoked, and (per that package's own source) the "public path for
+ * components and apps to add in-process ... backends":
+ * `models.registerBackend(kind, id, backend)` on Harper's process-wide
+ * `models` singleton. This is genuinely reassert-only: every boot calls this
+ * function again (module-scope side effect, same convention as
+ * `migration-boot.ts`), NOTHING is ever written to `harper-config.yaml`, so
+ * there is no persisted state for a downgrade to trip over — the class of
+ * bug this file fixes cannot recur by construction, not by a shape
+ * contract that has to keep being honored.
+ *
+ * Bonus: this also drops the old absolute-path workaround
+ * (`resolveEmbeddingBackendModule`'s `require.resolve` + `pathToFileURL`
+ * dance) that HARPER_CONFIG's `backend:` needed because
+ * `resolveBackendSpecifier` resolves a bare package name from the Harper
+ * INSTANCE ROOT's `node_modules`, not flair's own package dir. Importing
+ * harper-fabric-embeddings directly from flair's own code needs no such
+ * workaround — plain Node module resolution from flair's own `node_modules`
+ * always finds it, uniformly across a local install, Docker, AND a Fabric
+ * deploy (where flair runs as a non-root cluster component and
+ * `bootstrapModels()` — gated on `isRoot` — was never reachable at all; see
+ * the removed comment this replaces in `config.yaml`).
+ *
+ * ─── Loading mechanism ──────────────────────────────────────────────────
+ * Plain (non-Resource) module — same shape as `migration-boot.ts` /
+ * `embeddings-provider.ts` / `table-helpers.ts` — so Harper's `jsResource:
+ * files: dist/resources/*.js` loader (config.yaml) imports it at boot like
+ * every other flat file under `resources/`, running its top-level side
+ * effect exactly once per process. No config.yaml wiring needed.
+ *
+ * Graceful degrade preserved: if harper-fabric-embeddings isn't installed,
+ * or `globalThis.models` isn't available (this module loaded outside a real
+ * Harper boot), registration is skipped and logged — Harper falls back to
+ * keyword-only search, matching the pre-existing degrade contract.
+ */
+import { resolveModelsDir } from "./embeddings-provider.js";
+
+const LOGICAL_NAME = "default";
+const MODEL_NAME = "nomic-embed-text";
+
+let registered = false;
+
+/**
+ * Register the embedding backend. Idempotent within a process (mirrors
+ * `migration-boot.ts`'s `scheduled` guard) — safe to call more than once,
+ * only the first call does anything.
+ */
+export async function registerEmbeddingsBackend(): Promise<void> {
+  if (registered) return;
+  registered = true;
+  try {
+    const { register } = await import("harper-fabric-embeddings");
+    await register({
+      logicalName: LOGICAL_NAME,
+      kind: "embedding",
+      config: { modelName: MODEL_NAME, modelsDir: resolveModelsDir() },
+    });
+  } catch (err) {
+    // Not installed, or globalThis.models isn't ready (module loaded outside
+    // a real Harper boot, e.g. some future non-Harper import path) — degrade
+    // to Harper's keyword-only fallback, the same contract the old
+    // HARPER_CONFIG-omitted path preserved.
+    console.error(
+      `[embeddings] backend registration skipped: ${(err as Error)?.message ?? String(err)}`
+    );
+  }
+}
+
+/** Test-only reset — never used in production (a real process boots once). */
+export function _resetEmbeddingsBackendRegistrationForTests(): void {
+  registered = false;
+}
+
+void registerEmbeddingsBackend();

--- a/resources/embeddings-provider.ts
+++ b/resources/embeddings-provider.ts
@@ -7,15 +7,21 @@
  * through Harper's process-wide `models` singleton instead of this file
  * dynamic-importing `harper-fabric-embeddings` and initializing it itself.
  * The engine is the SAME one, registered as the `embedding`/`default`
- * backend by harper-fabric-embeddings@0.3.0's own `register()` factory
- * (invoked by Harper's `bootstrapModels` off the Harper INSTANCE-ROOT
- * config's `models.embedding.default` block — NOT this package's own
- * config.yaml, which is loaded as a non-root application and never reaches
- * bootstrapModels; see config.yaml's own comment, and src/cli.ts's
- * `buildEmbeddingsHarperConfigEnv` / `buildModelsConfig`, which write that
- * root-config block via HARPER_CONFIG — Harper's merge-layer env that reasserts
- * only the keys it names and yields to Fabric-managed config, never
- * HARPER_SET_CONFIG's force-override). Phase 1 passed no `inputType`, so no
+ * backend by harper-fabric-embeddings@0.3.0's own `register()` factory —
+ * called DIRECTLY, in-process, by `resources/embeddings-boot.ts` on every
+ * boot (flair#694; see that file's header for why: the original mechanism
+ * drove `register()` off a `models.embedding.default` block Harper's
+ * `bootstrapModels()` read from the INSTANCE-ROOT config, delivered via the
+ * `HARPER_CONFIG` env var — but that env var's value got PERSISTED into
+ * `harper-config.yaml`, and a boot that didn't reassert it (any
+ * older/downgraded build) tore the persisted block down to an invalid empty
+ * shell that the next boot's config validator rejected outright, bricking
+ * the instance). Registering directly means nothing is ever written to the
+ * config file, so there is no downgrade-unsafe state — and it works
+ * uniformly whether this package's own `config.yaml` loads root or non-root
+ * (e.g. a Harper Fabric deploy, where it's always non-root and
+ * `bootstrapModels()` was never reachable at all). Phase 1 passed no
+ * `inputType`, so no
  * `search_document:`/`search_query:` prefix was applied — output was
  * byte-identical to the pre-migration direct-import path. That's what made
  * that swap a dead-flat wash: same model, same weights, same input, same
@@ -228,15 +234,13 @@ async function getModelsApi(): Promise<HarperModelsApi> {
  * The chosen dir is always writable, so the embeddings engine can download the
  * model on first use without hitting EACCES on a root-owned package dir.
  *
- * Not called by this file anymore (Phase 1 moved model-directory resolution
- * to src/cli.ts, which computes the SAME <ROOTPATH>/models default and bakes
- * it directly into the `models.embedding.default.modelsDir` value it writes
- * via HARPER_CONFIG — a plain env-var default, not this function, since
- * cli.ts runs in a separate process from the one that would import this
- * file). Kept — and still exported and tested
- * (test/unit/embeddings-models-dir.test.ts) — as the single documented
- * source of truth for that default, and for any external caller that still
- * depends on it.
+ * Called by `resources/embeddings-boot.ts` (flair#694) to build the
+ * `modelsDir` it passes to harper-fabric-embeddings' `register()` — both run
+ * in the SAME process now (unlike the retired src/cli.ts-side computation,
+ * which duplicated this exact default because it ran in a separate process
+ * that set the resulting value via an env var). Still exported and tested
+ * independently (test/unit/embeddings-models-dir.test.ts) as the single
+ * documented source of truth for this default.
  */
 export function resolveModelsDir(): string {
   const override = process.env.FLAIR_MODELS_DIR;

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -413,80 +413,6 @@ function harperBin(): string | null {
   return null;
 }
 
-/**
- * Resolve harper-fabric-embeddings' entry file as an ABSOLUTE path, for use as
- * Harper's `models.embedding.default.backend` value (flair#504 Phase 1).
- *
- * Harper's non-built-in `backend:` resolution (bootstrap.ts's
- * resolveBackendSpecifier) treats a BARE package name as resolvable from the
- * Harper INSTANCE ROOT's node_modules (ROOTPATH — "where the operator installs
- * the backend", per that file's own doc comment) — NOT from flair's own
- * package directory. Flair's ROOTPATH (~/.flair/data by default) is a data
- * dir, not an npm install root, so a bare `backend: 'harper-fabric-embeddings'`
- * fails with "Cannot find module" (verified). An absolute path specifier
- * sidesteps that resolution entirely — resolveBackendSpecifier() passes it
- * straight to `import()`.
- *
- * Uses the top-level ESM-imported `createRequire` anchored at THIS file's own
- * location (`dist/cli.js`, inside flair's package dir — the same directory
- * harper-fabric-embeddings is installed into as a flair dependency), and
- * respects its package.json `exports`/`main`, so this doesn't hardcode an
- * internal `dist/index.js` path that could drift. NOTE: `createRequire` MUST be
- * the module-scope ESM import — `require('node:module')` throws "require is not
- * defined" here because the built `dist/cli.js` is a pure ES module (the CJS
- * bin shim `import()`s it). That exact bug silently returned null on a real
- * install → no `models` block → the clean-VM embed→search gate reported
- * "Semantic search DEGRADED" (flair#504 review).
- */
-function resolveEmbeddingBackendModule(): string | null {
-  try {
-    const req = createRequire(import.meta.url);
-    return req.resolve("harper-fabric-embeddings");
-  } catch {
-    return null; // harper-fabric-embeddings not installed — models.embedding.default is simply omitted below
-  }
-}
-
-/**
- * Build the `models.embedding.default` registration config (flair#504 Phase 1),
- * or `undefined` if harper-fabric-embeddings can't be resolved (degrades to
- * Harper's keyword-only fallback, matching the pre-migration behavior when the
- * embeddings engine was unavailable). Delivered to Harper via HARPER_CONFIG
- * (see buildEmbeddingsHarperConfigEnv) — a merge layer, NOT HARPER_SET_CONFIG's
- * force-override (which would fight Fabric-managed config and drift-lock).
- */
-function buildModelsConfig(modelsDir: string): Record<string, unknown> | undefined {
-  const backend = resolveEmbeddingBackendModule();
-  if (!backend) return undefined;
-  return {
-    embedding: {
-      default: { backend, modelName: "nomic-embed-text", modelsDir },
-    },
-  };
-}
-
-/**
- * The HARPER_CONFIG env value that registers the local embedding backend
- * (flair#504 Phase 1), or `undefined` when the engine can't be resolved.
- *
- * HARPER_CONFIG (not HARPER_SET_CONFIG) on purpose, per Nathan: HARPER_SET_CONFIG
- * is a force-override that also LOCKS against drift — it would clobber
- * Fabric-managed config and, because it reverts any key a later boot omits,
- * forced the earlier authentication-readback complexity. HARPER_CONFIG is a
- * merge layer: it reasserts ONLY the keys it names (here just
- * `models.embedding.default`) on every boot, yields to Fabric's own
- * HARPER_SET_CONFIG, and never touches unrelated config. Set it on EVERY Harper
- * spawn path (install, run, launchd plist, and both restart fallbacks) so it's
- * always present — an omitted boot would revert `models` the same way, but
- * since we always assert it, `models` stays registered and nothing else moves.
- * Reaches bootstrapModels() the same way HARPER_SET_CONFIG did (both merge into
- * the instance-root config getConfigObj() reads).
- */
-function buildEmbeddingsHarperConfigEnv(modelsDir: string): string | undefined {
-  const modelsConfig = buildModelsConfig(modelsDir);
-  return modelsConfig ? JSON.stringify({ models: modelsConfig }) : undefined;
-}
-
 // ─── Helpers ─────────────────────────────────────────────────────────────────
 
 function b64(bytes: Uint8Array): string {
@@ -2265,17 +2191,14 @@ program
           OPERATIONSAPI_NETWORK_PORT: String(opsPort),
           LOCAL_STUDIO: "false",
         };
-        // models (flair#504 Phase 1): register harper-fabric-embeddings as
-        // Harper's `embedding`/`default` backend via HARPER_CONFIG (merge
-        // layer, Fabric-safe) — NOT HARPER_SET_CONFIG and NOT config.yaml.
-        // bootstrapModels() only reads the `models:` block from the
-        // INSTANCE-ROOT config (never a per-application config.yaml); HARPER_CONFIG
-        // and HARPER_SET_CONFIG both merge into that instance-root config, but
-        // HARPER_CONFIG doesn't force-override Fabric's config or drift-lock
-        // sibling keys. See buildEmbeddingsHarperConfigEnv. Present on install AND
-        // run (same env) so it persists and is reasserted each boot.
-        const embeddingsHarperConfig = buildEmbeddingsHarperConfigEnv(modelsDir);
-        if (embeddingsHarperConfig) env.HARPER_CONFIG = embeddingsHarperConfig;
+        // models (flair#504 Phase 1): the embedding backend registers itself
+        // in-process at boot (resources/embeddings-boot.ts, loaded by
+        // config.yaml's `jsResource` glob) — NOT via a config env var. See
+        // that file's header for why (flair#694: HARPER_CONFIG persisted a
+        // `models.embedding.default` block into harper-config.yaml that an
+        // older/downgraded build's boot would tear down to an invalid empty
+        // shell). FLAIR_MODELS_DIR above is still the channel that tells the
+        // registration where to find/download the model.
 
         if (alreadyInstalled) {
           console.log("Existing Harper installation found — skipping install.");
@@ -2344,14 +2267,13 @@ program
             localStudio: { enabled: false },
             authentication: { authorizeLocal: false, enableSessions: true },
           });
-          // models (flair#504 Phase 1) via HARPER_CONFIG — see the initial spawn's
-          // comment. The launchd-managed process must carry it too, so every
-          // KeepAlive restart re-registers the embedding backend.
+          // models (flair#504 Phase 1): no env var needed here — the
+          // launchd-managed process loads the SAME dist/resources/*.js as any
+          // other spawn, so resources/embeddings-boot.ts self-registers the
+          // backend on every KeepAlive restart in-process. See that file's
+          // header (flair#694) for why this replaced the old HARPER_CONFIG
+          // plist line.
           const escapeXml = (s: string) => s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/"/g, "&quot;");
-          const plistEmbeddingsConfig = buildEmbeddingsHarperConfigEnv(modelsDir);
-          const harperConfigPlistLine = plistEmbeddingsConfig
-            ? `\n    <key>HARPER_CONFIG</key><string>${escapeXml(plistEmbeddingsConfig)}</string>`
-            : "";
           const plist = `<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
@@ -2369,7 +2291,7 @@ program
   <dict>
     <key>ROOTPATH</key><string>${dataDir}</string>
     <key>FLAIR_MODELS_DIR</key><string>${modelsDir}</string>
-    <key>HARPER_SET_CONFIG</key><string>${escapeXml(setConfig)}</string>${harperConfigPlistLine}
+    <key>HARPER_SET_CONFIG</key><string>${escapeXml(setConfig)}</string>
     <key>DEFAULTS_MODE</key><string>dev</string>
     <key>HDB_ADMIN_USERNAME</key><string>${adminUser}</string>
     <key>HDB_ADMIN_PASSWORD</key><string>${adminPass}</string>
@@ -7706,13 +7628,8 @@ program
     if (adminPass) {
       env.HDB_ADMIN_PASSWORD = adminPass;
     }
-    // models (flair#504 Phase 1) via HARPER_CONFIG — merge layer, so registering
-    // the embedding backend here does NOT disturb the authentication/port config
-    // the install-time HARPER_SET_CONFIG set (that's exactly why HARPER_CONFIG,
-    // not HARPER_SET_CONFIG — no force-override, no drift-lock, no read-back
-    // needed). See buildEmbeddingsHarperConfigEnv.
-    const embeddingsHarperConfig = buildEmbeddingsHarperConfigEnv(modelsDir);
-    if (embeddingsHarperConfig) env.HARPER_CONFIG = embeddingsHarperConfig;
+    // models (flair#504 Phase 1): no env var needed — resources/embeddings-boot.ts
+    // self-registers the backend in-process on every boot (flair#694).
 
     const proc = spawn(process.execPath, [bin, "run", "."], {
       cwd: flairPackageDir(), env, detached: true, stdio: "ignore",
@@ -7828,12 +7745,8 @@ async function startFlairProcess(port: number): Promise<void> {
   if (adminPass) {
     env.HDB_ADMIN_PASSWORD = adminPass;
   }
-  // models (flair#504 Phase 1) via HARPER_CONFIG — merge layer, so registering
-  // the embedding backend here does NOT disturb the authentication/port config
-  // the install-time HARPER_SET_CONFIG set (no force-override, no drift-lock, no
-  // read-back needed). See buildEmbeddingsHarperConfigEnv.
-  const embeddingsHarperConfig = buildEmbeddingsHarperConfigEnv(modelsDir);
-  if (embeddingsHarperConfig) env.HARPER_CONFIG = embeddingsHarperConfig;
+  // models (flair#504 Phase 1): no env var needed — resources/embeddings-boot.ts
+  // self-registers the backend in-process on every boot (flair#694).
 
   const proc = spawn(process.execPath, [bin, "run", "."], {
     cwd: flairPackageDir(), env, detached: true, stdio: "ignore",

--- a/test/helpers/harper-lifecycle.ts
+++ b/test/helpers/harper-lifecycle.ts
@@ -4,34 +4,9 @@ import type { AddressInfo, Server } from "node:net";
 import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { createRequire } from "node:module";
-import { pathToFileURL } from "node:url";
 
 const STARTUP_TIMEOUT_MS = 45_000;
 const MAX_SPAWN_ATTEMPTS = 3;
-
-/**
- * Resolve harper-fabric-embeddings' entry file as an ABSOLUTE path, for
- * Harper's `models.embedding.default.backend` (flair#504 Phase 1).
- *
- * Harper's non-built-in `backend:` resolution (bootstrap.ts) treats a bare
- * package name as resolvable from the Harper INSTANCE ROOT's node_modules
- * (ROOTPATH — an ephemeral mkdtemp dir here, with no node_modules at all),
- * not from `cwd` where harper-fabric-embeddings is actually installed as a
- * flair dependency — a bare name fails with "Cannot find module" (verified).
- * An absolute path sidesteps that resolution; anchoring `createRequire` at a
- * synthetic `<cwd>/index.js` (mirrors bootstrap.ts's own
- * `resolveBackendSpecifier` pattern) resolves via `cwd`'s node_modules
- * without hardcoding harper-fabric-embeddings' internal dist/ layout.
- */
-function resolveEmbeddingBackendModule(cwd: string): string | null {
-  try {
-    const req = createRequire(pathToFileURL(join(cwd, "index.js")).href);
-    return req.resolve("harper-fabric-embeddings");
-  } catch {
-    return null; // not installed — models.embedding.default is simply omitted
-  }
-}
 
 // Harper logs exactly this ("Unable to bind to port NNNNN: Address already in
 // use") when its HTTP/ops listener can't bind, but it STILL prints "successfully
@@ -305,24 +280,15 @@ export async function startHarper(opts: StartHarperOptions = {}): Promise<Harper
     NODE_HOSTNAME: "127.0.0.1",     // IPv4 only — avoids bun uv_ip6_addr panic
   };
 
-  // models (flair#504 Phase 1): registers harper-fabric-embeddings as Harper's
-  // `embedding`/`default` backend via HARPER_CONFIG (the merge-layer mechanism
-  // flair's CLI uses in production — buildEmbeddingsHarperConfigEnv), NOT
-  // HARPER_SET_CONFIG. Harper's bootstrapModels() only reads `models:` from the
-  // INSTANCE-ROOT config (isRoot:true), never a per-application config.yaml, so
-  // this can't live in flair's own config.yaml (see that file's comment).
-  // Present on both the install spawn below AND the dev spawn (env =
-  // {...baseEnv, ...}), so there's no cross-spawn gap.
-  const embeddingBackend = resolveEmbeddingBackendModule(cwd);
-  if (embeddingBackend) {
-    baseEnv.HARPER_CONFIG = JSON.stringify({
-      models: {
-        embedding: {
-          default: { backend: embeddingBackend, modelName: "nomic-embed-text", modelsDir: baseEnv.FLAIR_MODELS_DIR },
-        },
-      },
-    });
-  }
+  // models (flair#504 Phase 1): no env var needed here anymore — the spawned
+  // build's own dist/resources/embeddings-boot.js self-registers the backend
+  // in-process at boot (flair#694 fixed the old HARPER_CONFIG mechanism,
+  // which persisted a `models.embedding.default` block that an
+  // older/downgraded build's boot would tear down to an invalid empty shell;
+  // see that file's header). FLAIR_MODELS_DIR above still tells the
+  // registration where to find/download the model. A baseline build that
+  // predates flair#504 simply has no such file and skips registration —
+  // exactly the pre-#504 degrade behavior.
 
   const install = spawn(NODE_BIN, [HARPER_BIN, "install"], { cwd, env: baseEnv });
   await new Promise<void>((resolve, reject) => {


### PR DESCRIPTION
## The bug (flair#694)

The composer for Harper's local embedding backend registered `harper-fabric-embeddings` via the `HARPER_CONFIG` env var — a `models.embedding.default` block that Harper's environment-manager both **reasserts** on every boot AND **persists** into the instance-root `harper-config.yaml`.

That persistence is what bricked a downgrade. Reproduced locally (isolated fake-`$HOME`, never touching this host's real Flair) by replaying the exact downgrade-and-revert CI lane sequence (published `@tpsdev-ai/flair@0.21.0` → this worktree's build → `0.21.0` again, same data dir):

1. **Boot 1 (published baseline):** boots fine — `0.21.0` predates this feature entirely (`grep -c resolveEmbeddingBackendModule dist/cli.js` on the published tarball → `0`). No `models:` block, no `HARPER_CONFIG`.
2. **Boot 2 (this worktree's build):** boots, composes `HARPER_CONFIG` with `models.embedding.default.{backend,modelName,modelsDir}`, which Harper's env-config layer (`@harperfast/harper`'s `config/harperConfigEnvVars.js`) **flattens into three independent leaf paths** and persists to `harper-config.yaml`, recording each as `sources[path] = 'HARPER_CONFIG'` in `.harper-config-state.json` — with **no stored original value**, because the key didn't exist before this boot introduced it.
3. **Boot 3 (published baseline again — the downgrade):** baseline never sets `HARPER_CONFIG` (it doesn't know the feature exists). Harper's `applyRuntimeEnvConfig` treats the env var's *absence* as "the operator removed this config" and calls `cleanupRemovedEnvVar`, which deletes each of the three leaves **individually** (no original to restore to), leaving:
   ```yaml
   models:
     embedding:
       default: {}
   ```
   persisted to disk. The *next* boot's config schema validator (`validation/configValidator.js`) resolves the entry's backend via `Joi.alternatives().conditional('.backend', {switch:[...], otherwise: unknownBackendEntrySchema})`; with `backend` absent it falls to `unknownBackendEntrySchema = Joi.object({backend: string.required()})`, which throws exactly:

   ```
   Harper config file validation error: 'models.embedding.default.backend' is required
   ```

   Reproduced verbatim in `hdb.log`, ~28s after "Harper successfully started" (worker-thread env-manager re-init, not the main-thread boot). Confirmed **byte-identical** `harperConfigEnvVars.js`/`configValidator.js` between `@harperfast/harper` 5.1.15 (baseline) and 5.1.17 (this worktree) — this is upstream env-var-config *behavior*, not a schema difference between versions. No shape flair could put in `HARPER_CONFIG` fixes it: the deletion is triggered by the OLDER build never setting the env var at all, which is unfixable from the newer build's side.

## The fix

`resources/embeddings-boot.ts` calls harper-fabric-embeddings' own `register({logicalName, kind, config})` factory **directly, in-process, on every boot** — the same factory Harper's `bootstrapModels()` would have invoked off the config file, and (per that package's own source) the *"public path for components and apps to add in-process ... backends"*: `models.registerBackend(kind, id, backend)` on Harper's process-wide `models` singleton. Loaded automatically by `config.yaml`'s existing `jsResource: files: dist/resources/*.js` glob — same convention as `resources/migration-boot.ts`.

**Nothing is ever written to `harper-config.yaml`.** This is genuinely reassert-only/never-persist: every boot re-registers, no persisted state exists for any future downgrade to trip over — the bug class is closed by construction, not by a shape contract that has to keep being honored release after release.

**Bonus:** this also retires the absolute-path workaround `HARPER_CONFIG`'s `backend:` needed (Harper's non-built-in `backend:` resolution reads from the *instance root's* `node_modules`, not flair's own package dir — `resolveEmbeddingBackendModule`'s `require.resolve` + `pathToFileURL` dance existed only to route around that). A direct import from flair's own code needs no such workaround, and works uniformly across a local install, Docker, **and a Harper Fabric deploy** — where `bootstrapModels()` was never reachable at all, since flair always loads as a non-root component there (see `config.yaml`'s own long-standing comment on this).

### Alternatives considered and rejected
- **Compat union / always-emit-all-fields shape in `HARPER_CONFIG`:** doesn't work — the deletion is triggered by the *older* build never setting the env var in the first place; no shape on the newer build's side can prevent that.
- **Strip the `models:` block on clean shutdown:** only covers a graceful `flair stop`, not the kill-mid-flight scenario the downgrade-and-revert CI lane (and invariant I) specifically tests. Strictly weaker than reassert-only.

## Files changed
- `resources/embeddings-boot.ts` (new) — the in-process registration, with full mechanism writeup in its header.
- `src/cli.ts` — removed `buildEmbeddingsHarperConfigEnv`/`buildModelsConfig`/`resolveEmbeddingBackendModule` and all four `HARPER_CONFIG` call sites (install, launchd plist, `start`, `startFlairProcess`).
- `resources/embeddings-provider.ts` — updated header/doc comments to describe the new mechanism.
- `config.yaml` — updated the comment explaining why `models:` isn't configured there.
- `test/helpers/harper-lifecycle.ts` — removed the test harness's own duplicate `HARPER_CONFIG` composition (no longer needed; the real dist build self-registers).

## Proof

**Manual three-boot repro (isolated fake-`$HOME`, mirrors the CI lane exactly), with the fix:**
- Boot 1 (published `0.21.0`): boots clean, no `models:` block.
- Boot 2 (this branch's build): boots, embed→search round-trip verified live — `memory add "The quick brown fox jumps over the lazy dog"` then `memory search "a fast auburn fox leaping over a sleepy canine"` → matches with `_score: 1` (zero shared keywords — genuine semantic vector recall, not keyword matching). `harper-config.yaml` has **no `models:` key at all** after this boot; `.harper-config-state.json` has zero `models.*` entries.
- Boot 3 (published `0.21.0` again — the actual downgrade): **boots successfully** (`Health` → 200), the seeded memory row reads back byte-identical via the old binary's own ops-API. `hdb.log` has zero errors.

**Suites:**
- `bun test test/unit` — 2147 pass. 14 pre-existing failures in `test/unit/migrations-runner.test.ts`, confirmed byte-identical on unmodified `origin/main` (this sandbox's disk is at 92% capacity, tripping the migration-safety disk-headroom check — unrelated code path, not touched by this change).
- `npx tsc --noEmit -p tsconfig.check.json` / `tsconfig.check.src.json` / `tsconfig.cli.json` — all clean.
- `bun test test/integration/version-handshake-e2e.test.ts` — 4/4 pass.
- `bun test test/compat/downgrade-boot.test.ts` — **3/3 pass** (the existing official downgrade-compat suite: boots this branch's build, writes data, boots published `0.21.0` against the same data dir — green with the fix).
- `bun test test/compat/federation-mixed-version.test.ts` — 6/6 pass (additional regression coverage for the `harper-lifecycle.ts` simplification).
- `bun test test/integration/migrations-synthetic-e2e.test.ts` — blocked by the same pre-existing disk-headroom constraint as above (confirmed identical failure on unmodified `origin/main`; this test doesn't touch embeddings/config registration at all).

## Deviations
- Could not get a clean run of `migrations-synthetic-e2e.test.ts` in this sandbox due to a pre-existing, unrelated disk-space constraint (confirmed identical on `origin/main`); substituted `downgrade-boot.test.ts` + the manual three-boot repro as the targeted proof for this specific bug, which is a closer match to the actual scenario anyway (it exercises two real, different Harper/flair builds against the same data dir; the migrations e2e test only ever boots one build).

Extends the config-is-state clause flair#694 taught (flair#695): persisted config keys need the same downgrade discipline as data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
