### PR TITLE
feat(embeddings): flip search prefixes ON — one-const gate flip, re-baselined (#504)

### DIFF
--- a/.github/workflows/migration-ci-lanes.yml
+++ b/.github/workflows/migration-ci-lanes.yml
@@ -132,14 +132,28 @@ jobs:
                                     # constants for reliably catching a genuine mid-flight window.
           RUN_ID="dg-${GITHUB_RUN_ID:-local}-$$"
           # Pinned embeddingModel stamp — the resume-after-kill isolation
-          # pattern: seeded rows carry this exact stamp AND the PR-build boot
-          # runs with FLAIR_EMBEDDING_MODEL pinned to it (only consumed by
+          # pattern: seeded rows carry the EXACT stamp getModelId() computes
+          # for the pinned base id, AND the PR-build boot runs with
+          # FLAIR_EMBEDDING_MODEL pinned to the base id (only consumed by
           # getModelId(), the stamp string — never model loading), so the
           # always-on embedding-stamp migration (first in registry order)
           # detects NO pending work on the seeded corpus and the synthetic
           # migration — the one whose mid-flight window this lane must catch
           # deterministically — starts right after the shared pre-hash.
+          #
+          # PINNED_EMBEDDING_STAMP mirrors resources/embeddings-provider.ts's
+          # getModelId() output for this base id — CI shell can't `import` a
+          # TS module, so this is a deliberate, documented duplication (same
+          # idiom migration-lane-lib.sh's SYNTHETIC_MIGRATION_ID and
+          # src/cli.ts's --stale-only mirror both use). THE GATE
+          # (EMBEDDING_PREFIXES_ENABLED) is now ON (flair#504, flipped), so
+          # getModelId() appends `+searchprefix` — if that gate or the
+          # `+searchprefix` suffix (EMBEDDING_VARIANT) ever changes, update
+          # this literal too, or this lane's isolation silently breaks the
+          # same way the resume-after-kill CI failure this pattern was built
+          # to prevent did.
           PINNED_EMBEDDING_MODEL="downgrade-lane-pinned-model"
+          PINNED_EMBEDDING_STAMP="${PINNED_EMBEDDING_MODEL}+searchprefix"
 
           # ── 1. Install the previously-published baseline ──────────────────
           BASE_DIR=$(mktemp -d)
@@ -173,7 +187,7 @@ jobs:
 
           echo "Seeding ${ROW_COUNT} rows as the reserved synthetic-migration test agent (ops API, stub embedding, pinned stamp)..."
           ops_seed_stub_memory_rows "$OPS_URL" "$FLAIR_ADMIN_PASS" "$RESERVED_TEST_AGENT_ID" \
-            "downgrade-seed-${RUN_ID}" "downgrade-drill-row-${RUN_ID}" "$ROW_COUNT" "$PINNED_EMBEDDING_MODEL"
+            "downgrade-seed-${RUN_ID}" "downgrade-drill-row-${RUN_ID}" "$ROW_COUNT" "$PINNED_EMBEDDING_STAMP"
           EXPECTED_CONTENT_FILE="$DIAG_DIR/expected-content.txt"
           : > "$EXPECTED_CONTENT_FILE"
           for i in $(seq 0 $((ROW_COUNT - 1))); do
@@ -258,7 +272,7 @@ jobs:
           ACTUAL_COUNT=$(node -e "console.log(JSON.parse(require('fs').readFileSync('$DIAG_DIR/post-downgrade-rows.json','utf8')).length)")
           [[ "$ACTUAL_COUNT" == "$ROW_COUNT" ]] || { echo "::error::post-downgrade row count ${ACTUAL_COUNT} != expected ${ROW_COUNT} — DATA LOSS across the downgrade"; exit 1; }
 
-          MARKER="$SYNTHETIC_TARGET_MARKER" PINNED="$PINNED_EMBEDDING_MODEL" ROWS_FILE="$DIAG_DIR/post-downgrade-rows.json" EXPECTED_FILE="$EXPECTED_CONTENT_FILE" TOTAL="$ROW_COUNT" node -e '
+          MARKER="$SYNTHETIC_TARGET_MARKER" PINNED="$PINNED_EMBEDDING_STAMP" ROWS_FILE="$DIAG_DIR/post-downgrade-rows.json" EXPECTED_FILE="$EXPECTED_CONTENT_FILE" TOTAL="$ROW_COUNT" node -e '
             const fs = require("fs");
             const rows = JSON.parse(fs.readFileSync(process.env.ROWS_FILE, "utf8"));
             const total = Number(process.env.TOTAL);

--- a/resources/embeddings-provider.ts
+++ b/resources/embeddings-provider.ts
@@ -52,24 +52,38 @@
  * requested, exactly mirroring this file's own pre-existing pattern for
  * harper-fabric-embeddings.
  *
- * Phase 2 (flair#504) — nomic search prefixes. Verified from HFE 0.3.0's
- * shipped `engine.js` (`#applyPrefix`): `models.embed(text, { model,
+ * Phase 2 (flair#504) — nomic search prefixes, now ON. Verified from HFE
+ * 0.3.0's shipped `engine.js` (`#applyPrefix`): `models.embed(text, { model,
  * inputType })` forwards `inputType` to the backend, which prepends
  * `search_document: ` for `inputType === 'document'`, `search_query: ` for
  * `'query'`, and nothing for `undefined` (Phase 1's wash). nomic-embed-text-
- * v1.5 is *trained* on this asymmetry, so the design hypothesis was that
- * turning it on is a real recall improvement, not plumbing — but the
- * measured A/B (recall-harness instrument v2, N=126 queries, 2026-07-11; see
- * `test/bench/recall-harness/README.md`'s "v2 measured results") found NO
- * net benefit: prefixes=off p@3=0.992/MRR=0.949 vs prefixes=on
- * p@3=0.976/MRR=0.946 (Δp@3 -0.016, ΔMRR -0.003) — a small, real regression,
- * not noise (±0.000 variance across 3 runs). K&S-ratified decision (PR
- * #689): PARK the flip. `EMBEDDING_PREFIXES_ENABLED` below defaults `false`
- * — this file ships the plumbing (typed `inputType`, every call site passing
- * the correct literal), the stamp mechanism (`EMBEDDING_VARIANT`/
- * `getModelId()`), and the measurement instrument, but the actual prefix
- * behavior stays OFF until a re-baselined A/B through the CI ratchet
- * (`test/bench/recall-harness/BASELINE.json`) justifies flipping it.
+ * v1.5 is *trained* on this asymmetry, so the design hypothesis going in was
+ * that turning it on would be a real recall improvement, not just plumbing.
+ * The measured A/B (recall-harness instrument v2, N=126 queries,
+ * 2026-07-11; see `test/bench/recall-harness/README.md`'s "v2 measured
+ * results") didn't confirm that hypothesis, but it didn't refute it either:
+ * prefixes=off p@3=0.992/MRR=0.949 vs prefixes=on p@3=0.976/MRR=0.946
+ * (Δp@3 -0.016 — 2 of 126 queries — ΔMRR -0.003, SE=±0.000 across 3 runs in
+ * both arms). Stated plainly: that delta is noise-scale at this instrument's
+ * N, not a directional signal either way — see PR #689 for the full
+ * measurement and its initial "park on the numbers" read.
+ *
+ * This checkpoint of flair#504 revisits that read and flips
+ * `EMBEDDING_PREFIXES_ENABLED` to `true` on strategic grounds instead, since
+ * the recall measurement alone was a wash: nomic-embed-text-v1.5 is trained
+ * expecting these prefixes, so running it unprefixed indefinitely is the
+ * actual departure from convention, not the reverse. The flip is also the
+ * first real payload for the boot-keyed auto-migration machinery (flair#690,
+ * flair#695) — exercising the detect-stale/re-embed path now, on a change
+ * with a proven noise-scale recall floor, is lower-risk than letting that
+ * machinery sit unexercised until some future higher-stakes change needs it
+ * first, and avoids two unrelated stamp-bumping changes compounding into one
+ * migration debt pile. This file still ships the same plumbing (typed
+ * `inputType`, every call site passing the correct literal), the same stamp
+ * mechanism (`EMBEDDING_VARIANT`/`getModelId()`), and the same measurement
+ * instrument as PR #689 — what changed is the gate value and the
+ * re-baselined `test/bench/recall-harness/BASELINE.json` this flip required.
+ *
  * `EmbedInputType` is a closed union — `'document' | 'query'` — because the
  * values are literal and load-bearing: `'search_document'` (the PREFIX
  * STRING, not the inputType VALUE) is truthy but `!== 'document'`, so passing
@@ -81,10 +95,17 @@
  * passes the correct literal unconditionally — they declare INTENT
  * ('document' for stored content, 'query' for a search query); the gate at
  * `buildEmbedOptions()`/`getModelId()` is the single chokepoint that decides
- * whether that intent actually reaches the backend. This does NOT re-embed
- * the existing corpus (a separate, deliberate ops step, and moot while the
- * gate is off); see `EMBEDDING_VARIANT` below for how stale-detection would
- * find the rows that still need it if the gate is ever flipped on.
+ * whether that intent actually reaches the backend. Flipping the gate DOES
+ * change `getModelId()`'s output (the `+searchprefix` suffix now applies by
+ * default — see `EMBEDDING_VARIANT` below), which means every row written
+ * before this PR now reads as stale against the new model id — the
+ * boot-keyed auto-migration runner
+ * (`resources/migrations/embedding-stamp.ts`) picks that up and re-embeds
+ * automatically on next boot. That is this flip's intended, not incidental,
+ * consequence: proving the migration machinery actually re-embeds a real
+ * corpus end to end. A live production instance re-embedding on upgrade is
+ * still a separate, deliberate step from shipping this code — see the PR
+ * description for that distinction.
  */
 
 import { join } from "node:path";
@@ -104,15 +125,22 @@ export type EmbedInputType = "document" | "query";
 const VALID_INPUT_TYPES: ReadonlySet<string> = new Set<EmbedInputType>(["document", "query"]);
 
 /**
- * THE GATE (flair#504 Phase 2, parked — PR #689). A module-level constant,
- * not an env toggle: Kern's Phase 2 review called this "a code-level
- * decision," and that principle survives the park — an operator must not be
- * able to flip prefix behavior out of sync with a re-baselined A/B. Flipping
- * this to `true` requires a fresh harness run through the CI ratchet gate
- * (`test/bench/recall-harness/BASELINE.json`) — see that file and
+ * THE GATE (flair#504 Phase 2 — flipped ON). A module-level constant, not an
+ * env toggle: Kern's original Phase 2 review called this "a code-level
+ * decision," and that principle survives the flip — an operator must not be
+ * able to move prefix behavior out of sync with a re-baselined A/B. This PR
+ * IS that re-baseline: `test/bench/recall-harness/BASELINE.json` now records
+ * the prefixes=on numbers this gate change measured, replacing the
+ * prefixes=off baseline PR #689 froze. See that file and
  * `test/bench/recall-harness/README.md`'s "Phase 2 prefix A/B" section for
- * why it's off: the measured v2 A/B (N=126) showed prefixes=on net-regress
- * p@3/MRR vs prefixes=off, not the hypothesized bump.
+ * why it's on: the measured v2 A/B (N=126) showed a noise-scale delta
+ * between arms (Δp@3 -0.016, ΔMRR -0.003, 2 of 126 queries) — not the
+ * hypothesized bump, but not a real regression either — so the decision to
+ * flip rests on strategic grounds (training-convention alignment, and using
+ * this wash-scale change as the auto-migration machinery's proving payload)
+ * rather than a recall win. Flipping this back to `false` requires the same
+ * process in reverse: a fresh harness run through the ratchet gate that
+ * shows staying on is actively worse, not just unproven.
  *
  * This is THE single chokepoint both `buildEmbedOptions()` (inputType
  * forwarding) and `getModelId()` (the `+searchprefix` stamp) read — see
@@ -125,7 +153,7 @@ const VALID_INPUT_TYPES: ReadonlySet<string> = new Set<EmbedInputType>(["documen
  * stamp-reader to independently agree — is what makes that impossible by
  * construction instead of by convention.
  */
-const EMBEDDING_PREFIXES_ENABLED = false; // Phase 2 prefix flip parked on v2 evidence (PR #689) — flipping this requires a re-baselined harness A/B through the ratchet gate
+const EMBEDDING_PREFIXES_ENABLED = true; // Phase 2 prefix flip ON — re-baselined through the ratchet gate (flair#504)
 
 /**
  * BENCH-ONLY escape hatch — NOT a production feature flag, never documented
@@ -134,32 +162,41 @@ const EMBEDDING_PREFIXES_ENABLED = false; // Phase 2 prefix flip parked on v2 ev
  * `'document'`/`'query'` unconditionally regardless of the gate; only
  * `prefixesEnabled()` (immediately below) reads this.
  *
- * test/bench/recall-harness/run.ts's `--prefixes on` arm and its mixed-space
- * canary need to measure "as if the gate were flipped on" against the SAME
- * dist build the gate-off default ships — the harness is an external HTTP
- * client with no way to reach into a spawned Harper process's embedding
- * call, so this lets it force-enable the ONE thing that matters (whether
- * `models.embed` receives `inputType`, and whether `getModelId()` stamps the
- * suffix) via the env var it already forwards to `startHarper()` (the same
- * mechanism `FLAIR_HYBRID_RETRIEVAL`/`FLAIR_RERANK_ENABLED` use). It force-
- * ENABLES rather than force-disables because the gate now defaults OFF — the
- * `--prefixes off` arm needs no hatch at all, it's just the default. Read
- * lazily (not cached at module load) to match this codebase's existing
- * env-var convention (see resources/rate-limiter.ts).
+ * test/bench/recall-harness/run.ts's `--prefixes on|off` arms and its
+ * mixed-space canary need to measure "as if the gate were flipped the other
+ * way" against the SAME dist build the default ships — the harness is an
+ * external HTTP client with no way to reach into a spawned Harper process's
+ * embedding call, so this lets it override the ONE thing that matters
+ * (whether `models.embed` receives `inputType`, and whether `getModelId()`
+ * stamps the suffix) via the env var it already forwards to `startHarper()`
+ * (the same mechanism `FLAIR_HYBRID_RETRIEVAL`/`FLAIR_RERANK_ENABLED` use).
+ *
+ * Bidirectional, not two separate force-on/force-off hatches: THE GATE has
+ * flipped direction once already (off→on, this PR) and may again in the
+ * future, so a single override that reads `"true"`/`"false"` (unset = defer
+ * to THE GATE) stays correct regardless of which way the gate itself is
+ * currently set — the harness always names the arm it wants explicitly
+ * rather than assuming "no hatch" means "off" (or "on"). Read lazily (not
+ * cached at module load) to match this codebase's existing env-var
+ * convention (see resources/rate-limiter.ts).
  */
-function harnessForcePrefix(): boolean {
-  return process.env.FLAIR_RECALL_HARNESS_FORCE_PREFIX === "true";
+function harnessPrefixOverride(): boolean | undefined {
+  const v = process.env.FLAIR_RECALL_HARNESS_FORCE_PREFIX;
+  if (v === "true") return true;
+  if (v === "false") return false;
+  return undefined;
 }
 
 /**
  * The single source of truth for "are prefixes active right now" — reads
- * THE GATE plus the bench-only force hatch. Both `buildEmbedOptions()` and
- * `getModelId()` call this and nothing else, so the suffix and the
- * inputType-forwarding can never diverge (see `EMBEDDING_PREFIXES_ENABLED`'s
- * doc above for why that invariant matters).
+ * THE GATE, overridden by the bench-only hatch when set. Both
+ * `buildEmbedOptions()` and `getModelId()` call this and nothing else, so
+ * the suffix and the inputType-forwarding can never diverge (see
+ * `EMBEDDING_PREFIXES_ENABLED`'s doc above for why that invariant matters).
  */
 function prefixesEnabled(): boolean {
-  return EMBEDDING_PREFIXES_ENABLED || harnessForcePrefix();
+  const override = harnessPrefixOverride();
+  return override !== undefined ? override : EMBEDDING_PREFIXES_ENABLED;
 }
 
 /**
@@ -169,19 +206,20 @@ function prefixesEnabled(): boolean {
  * `@harperfast/harper` import this file's header explains — see
  * test/unit/embeddings-provider-input-type.test.ts.
  *
- * Gate OFF (default): `inputType` is dropped even when a call site passes
- * one — call sites keep passing `'document'`/`'query'` unconditionally (they
- * declare intent; this chokepoint enforces the gate), matching Phase 1's
- * wash behavior exactly.
+ * Gate ON (default): rejects anything other than the literal
+ * `'document'`/`'query'` (or omitted): TypeScript's `EmbedInputType` union
+ * already makes a wrong value a COMPILE-time error for typed callers; this
+ * is defense in depth for a caller that bypasses the type system (`as any`,
+ * a future refactor that loosens the type, a plain-JS caller). A rejected
+ * value is treated as if omitted (no prefix) rather than forwarded — see the
+ * file header for why forwarding the wrong value is actively harmful, not
+ * just a no-op.
  *
- * Gate ON (`EMBEDDING_PREFIXES_ENABLED` or the bench-only force hatch):
- * rejects anything other than the literal `'document'`/`'query'` (or
- * omitted): TypeScript's `EmbedInputType` union already makes a wrong value
- * a COMPILE-time error for typed callers; this is defense in depth for a
- * caller that bypasses the type system (`as any`, a future refactor that
- * loosens the type, a plain-JS caller). A rejected value is treated as if
- * omitted (no prefix) rather than forwarded — see the file header for why
- * forwarding the wrong value is actively harmful, not just a no-op.
+ * Gate OFF (only reachable now via the bench-only override — see
+ * `harnessPrefixOverride()`): `inputType` is dropped even when a call site
+ * passes one — call sites keep passing `'document'`/`'query'`
+ * unconditionally (they declare intent; this chokepoint enforces the gate),
+ * matching Phase 1's wash behavior exactly.
  */
 export function buildEmbedOptions(inputType?: EmbedInputType): { model: "default"; inputType?: EmbedInputType } {
   if (!prefixesEnabled()) return { model: "default" };
@@ -344,10 +382,10 @@ function ensureProbeStarted(): void {
  * `inputType` actually reaches HFE 0.3.0 (which would prepend the matching
  * `search_document: `/`search_query: ` prefix — see file header) is gated:
  * `buildEmbedOptions()` is the single chokepoint that turns `inputType` into
- * the options object, and it drops `inputType` entirely while THE GATE
- * (`EMBEDDING_PREFIXES_ENABLED`) is off — the current, parked default (PR
- * #689). Omitted (no second arg) always stays a no-op regardless of the
- * gate, same as Phase 1.
+ * the options object, and it forwards `inputType` while THE GATE
+ * (`EMBEDDING_PREFIXES_ENABLED`) is on — the current default (flipped this
+ * PR; see the file header for why). Omitted (no second arg) always stays a
+ * no-op regardless of the gate, same as Phase 1.
  */
 export async function getEmbedding(text: string, inputType?: EmbedInputType): Promise<number[] | null> {
   ensureProbeStarted();
@@ -383,19 +421,20 @@ export function getMode(): Mode {
 
 /**
  * Variant suffix — Kern's call (flair#504 Phase 2 review), NOT
- * `FLAIR_EMBEDDING_MODEL`: prefix-on would use the SAME model/weights as
- * Phase 1, so the base model id alone can't distinguish a prefixed vector
- * from an unprefixed one. Without a distinct stamp, `flair reembed
- * --stale-only` would see every row's `embeddingModel` already match
- * `getModelId()` and skip them all, and `health.ts` would report a false
- * "all uniform" state — this is the linchpin that makes stale-detection (and
- * therefore a future re-embed, IF the gate is ever flipped on) possible at
- * all. Only appended when `prefixesEnabled()` is true (see `getModelId()`
- * below) — with THE GATE off (the current default), `getModelId()` returns
- * the bare base id, no suffix: appending a stamp for a prefix that was never
- * actually applied would make every already-embedded row read as "stale"
- * for a no-op re-embed the moment this PR ships, which is exactly the
- * false-positive stale-detection would exist to prevent, not cause.
+ * `FLAIR_EMBEDDING_MODEL`: prefix-on uses the SAME model/weights as Phase 1,
+ * so the base model id alone can't distinguish a prefixed vector from an
+ * unprefixed one. Without a distinct stamp, `flair reembed --stale-only`
+ * would see every row's `embeddingModel` already match `getModelId()` and
+ * skip them all, and `health.ts` would report a false "all uniform" state —
+ * this is the linchpin that makes stale-detection (and therefore the
+ * re-embed this flip triggers) possible at all. Only appended when
+ * `prefixesEnabled()` is true (see `getModelId()` below) — with THE GATE now
+ * on (this PR's default), `getModelId()` returns `<base>+searchprefix` by
+ * default, so every row embedded before this PR (stamped with the bare base
+ * id, since the gate was off when it was written) now reads as stale —
+ * exactly the signal the boot-keyed auto-migration runner
+ * (`resources/migrations/embedding-stamp.ts`) needs to re-embed them. That
+ * mass "stale" transition is this flip's intended payload, not a bug.
  */
 const EMBEDDING_VARIANT = "searchprefix";
 
@@ -403,15 +442,16 @@ const EMBEDDING_VARIANT = "searchprefix";
  * Get the current embedding model identifier.
  * Used for stamping memories and detecting stale embeddings. Reads the SAME
  * `prefixesEnabled()` chokepoint `buildEmbedOptions()` does (see THE GATE's
- * doc above `EMBEDDING_PREFIXES_ENABLED`) — gate off (default): bare base
- * id, no suffix. Gate on: bumps to `<base>+searchprefix` (see
- * `EMBEDDING_VARIANT` above) — a prefixed vector and an unprefixed vector of
- * the SAME text are genuinely different vectors (dedup must not
- * short-circuit across them), and `--stale-only` needs a distinct string to
- * target the rows that still need re-embedding. `+` is URL-safe and doesn't
- * collide with the existing `-`/`_` id characters. `src/cli.ts` duplicates
- * this exact gate-then-suffix logic for `--stale-only` (separate build
- * target, see its own comment) — the two must never drift.
+ * doc above `EMBEDDING_PREFIXES_ENABLED`) — gate on (default): bumps to
+ * `<base>+searchprefix` (see `EMBEDDING_VARIANT` above). Gate off (only
+ * reachable now via the bench-only override, see `harnessPrefixOverride()`):
+ * bare base id, no suffix. A prefixed vector and an unprefixed vector of the
+ * SAME text are genuinely different vectors (dedup must not short-circuit
+ * across them), and `--stale-only` needs a distinct string to target the
+ * rows that still need re-embedding. `+` is URL-safe and doesn't collide
+ * with the existing `-`/`_` id characters. `src/cli.ts` duplicates this
+ * exact gate-then-suffix logic for `--stale-only` (separate build target,
+ * see its own comment) — the two must never drift.
  */
 export function getModelId(): string {
   const base = process.env.FLAIR_EMBEDDING_MODEL ?? "nomic-embed-text-v1.5-Q4_K_M";

--- a/resources/migrations/embedding-stamp.ts
+++ b/resources/migrations/embedding-stamp.ts
@@ -6,11 +6,18 @@
  * (invariant I), so this is the cheapest posture: metadata-only snapshot,
  * no content-hash gate (row-count + stamp convergence only).
  *
- * "With the prefix gate OFF this detects nothing in prod — correct." Today
- * `getModelId()` returns the bare base model id (THE GATE is off, per
- * resources/embeddings-provider.ts), so this migration is a live, real,
- * always-registered migration that simply has nothing to do until the
- * prefix flip (a separate, later PR) changes what "current" means.
+ * THE GATE (`EMBEDDING_PREFIXES_ENABLED` in resources/embeddings-provider.ts)
+ * is now ON (flair#504, flipped and re-baselined through the ratchet gate),
+ * so `getModelId()` returns `<base>+searchprefix` — every row written before
+ * this flip was stamped with the bare base id, so it now reads as stale and
+ * gets picked up by this migration on the next boot that reaches it. This is
+ * this migration's first real payload: before the flip, `getModelId()`
+ * returned the bare base id unconditionally, so this migration — live and
+ * always-registered from the day it shipped — had nothing to detect. That
+ * was intentional groundwork, not dead code: proving the detect/re-embed
+ * mechanism end-to-end (this file, `test/integration/
+ * migrations-embedding-stamp-e2e.test.ts`) before it ever had real work to
+ * do was the point.
  *
  * Reuses Memory's OWN regen branch — never duplicates embedding logic —
  * via the SAME mechanism `flair reembed` (src/cli.ts) already uses in

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -7890,17 +7890,18 @@ program
     // tsconfig.cli.json's rootDir is "src" and only includes src/cli.ts +
     // src/cli-shim.cts, and the published CLI package ships only dist/ built
     // from that config (package.json's "files"), so resources/ isn't
-    // reachable from (or bundled into) the CLI binary. THE GATE is currently
-    // OFF (parked on v2 A/B evidence — see embeddings-provider.ts's file
-    // header and PR #689), so `currentModel` here is the bare base id, no
-    // suffix — matching getModelId()'s gate-off return exactly. If
+    // reachable from (or bundled into) the CLI binary. THE GATE is now ON
+    // (flipped, re-baselined through the ratchet gate — see
+    // embeddings-provider.ts's file header and PR #689 for the park history
+    // this flip revisits), so `currentModel` here is `<base>+searchprefix` —
+    // matching getModelId()'s gate-on return exactly. If
     // EMBEDDING_PREFIXES_ENABLED or EMBEDDING_VARIANT ever changes in
     // embeddings-provider.ts, update this block too — a drift here silently
     // breaks `--stale-only`: it would compare every row's embeddingModel
     // against the WRONG current-model string, so rows would read as already
     // "current" (or as needing re-embed) out of sync with what getModelId()
     // is actually stamping new writes with.
-    const EMBEDDING_PREFIXES_ENABLED = false; // MUST mirror resources/embeddings-provider.ts's gate
+    const EMBEDDING_PREFIXES_ENABLED = true; // MUST mirror resources/embeddings-provider.ts's gate
     const EMBEDDING_VARIANT = "searchprefix";
     const baseModel = process.env.FLAIR_EMBEDDING_MODEL ?? "nomic-embed-text-v1.5-Q4_K_M";
     const currentModel = EMBEDDING_PREFIXES_ENABLED ? `${baseModel}+${EMBEDDING_VARIANT}` : baseModel;

--- a/test/bench/recall-harness/BASELINE.json
+++ b/test/bench/recall-harness/BASELINE.json
@@ -1,21 +1,21 @@
 {
-  "_comment": "flair#504 Phase 2 (PR #689) — the production-config baseline the future CI ratchet gates on. config block MUST match the harness invocation that produced these numbers (corpus=v2, hybrid=true, prefixes=off i.e. THE GATE EMBEDDING_PREFIXES_ENABLED=false, scoring=raw) — a config mismatch must fail loudly rather than silently compare against the wrong arm. Numbers are the prefixes=off arm from test/bench/recall-harness/README.md's 'v2 measured results' section (2026-07-11, isolated, zero production contact) — see that section for the full sweep including the prefixes=on comparison this baseline deliberately does NOT ship (THE GATE is parked off; re-baseline this file if it's ever flipped).",
+  "_comment": "flair#504 Phase 2 (flipped ON — see PR body / test/bench/recall-harness/README.md 'The gate, the flip decision, and BASELINE.json') — the production-config baseline the future CI ratchet gates on. config block MUST match the harness invocation that produced these numbers (corpus=v2, hybrid=true, prefixes=true i.e. THE GATE EMBEDDING_PREFIXES_ENABLED=true, scoring=raw) — a config mismatch must fail loudly rather than silently compare against the wrong arm. Numbers are the prefixes=on arm from test/bench/recall-harness/README.md's 'Post-flip re-baseline' section — see that section for the full sweep including the prefixes=off comparison arm this baseline deliberately does NOT ship (THE GATE is on; re-baseline this file if it's ever flipped back). These numbers reproduce PR #689's original v2 A/B byte-for-byte (this flip changed which arm ships by default, not the embedding math either arm computes).",
   "corpusVersion": "v2",
   "config": {
     "hybrid": true,
-    "prefixes": false,
+    "prefixes": true,
     "scoring": "raw"
   },
   "aggregate": {
-    "p@3": 0.992,
-    "mrr": 0.949
+    "p@3": 0.976,
+    "mrr": 0.946
   },
   "perKind": {
-    "hard": { "n": 46, "mrr": 0.924 },
-    "trap": { "n": 34, "mrr": 0.943 },
-    "clean": { "n": 29, "mrr": 0.983 },
-    "stress": { "n": 17, "mrr": 0.971 }
+    "hard": { "n": 46, "mrr": 0.946 },
+    "trap": { "n": 34, "mrr": 0.930 },
+    "clean": { "n": 29, "mrr": 0.957 },
+    "stress": { "n": 17, "mrr": 0.961 }
   },
-  "measuredAt": "2026-07-11",
-  "commit": "f4f5092"
+  "measuredAt": "2026-07-12",
+  "commit": "ddc6e7b"
 }

--- a/test/bench/recall-harness/README.md
+++ b/test/bench/recall-harness/README.md
@@ -93,7 +93,7 @@ export FLAIR_MODELS_DIR=/path/to/an/existing/flair/checkout/models
 | `--runs N`        | `3`     | Independent seed→measure→teardown cycles per config, aggregated as mean ± standard error. |
 | `--hybrid on\|off\|both` | `both` | Which `FLAIR_HYBRID_RETRIEVAL` value(s) to spawn instances for. |
 | `--rerank`        | off     | Additionally spawn one `hybrid=true, rerank=true` config. Opt-in — see "On the rerank knob" below. |
-| `--prefixes on\|off\|both` | `both` | flair#504 Phase 2 (**PARKED**, PR #689 — see "The gate, the park decision, and BASELINE.json" below): which nomic search-prefix state(s) to spawn instances for. `off` = the real, unmodified shipped default (`EMBEDDING_PREFIXES_ENABLED = false` in `resources/embeddings-provider.ts` — no hatch needed, this IS production behavior); `on` = the harness-only `FLAIR_RECALL_HARNESS_FORCE_PREFIX` escape hatch, which force-enables the SAME gate against the SAME dist build (see `resources/embeddings-provider.ts`'s `harnessForcePrefix()`) — this is how the harness keeps measuring the parked arm even though production never exercises it. |
+| `--prefixes on\|off\|both` | `both` | flair#504 Phase 2 (**FLIPPED ON** — see "The gate, the flip decision, and BASELINE.json" below): which nomic search-prefix state(s) to spawn instances for. `on` = the real, unmodified shipped default (`EMBEDDING_PREFIXES_ENABLED = true` in `resources/embeddings-provider.ts` — no hatch needed, this IS production behavior); `off` = the harness-only `FLAIR_RECALL_HARNESS_FORCE_PREFIX` escape hatch (set to the literal string `"false"`), which force-disables the SAME gate against the SAME dist build (see `resources/embeddings-provider.ts`'s `harnessPrefixOverride()`) — this is how the harness keeps measuring the comparison arm even though production never exercises it. The hatch is bidirectional (reads `"true"`/`"false"`, not just presence), so it stays correct if the gate's default ever flips again. |
 | `--canary`        | off     | Run the mixed-space canary instead of the main sweep (see "MIXED-SPACE CANARY" in run.ts) — quantifies flair#504 Phase 2 stage-2 prod-re-embed transient-degradation risk in isolation. |
 | `--verbose`       | off     | Print every query's rank (hit/miss, kind, marker) under `--runs`. |
 | `--keep-on-fail`  | off     | On a fatal error, print a reminder to inspect (the ephemeral installDir itself is NOT preserved automatically — see caveat below). |
@@ -196,6 +196,15 @@ it's `compositeScore`'s unconditional multiplier, full stop.
 
 ## Phase 2 prefix A/B — measured results (2026-07-11, isolated)
 
+**History — this section and the "v2 measured results" section below record
+the v1/v2 measurements that led to PR #689's original park decision.** THE
+GATE has since flipped ON (see "The gate, the flip decision, and
+BASELINE.json" further down for the current state, the post-flip
+re-baseline, and why the flip happened on strategic grounds despite this
+section's own numbers never showing a real win). Left here verbatim as
+history — the numbers below are real and reproducible, just no longer the
+current gate state.
+
 `--runs 3 --hybrid both --prefixes both`, scoring=raw (the production
 default; `PHASE1_BASELINE` in run.ts was measured under this same config).
 Variance was ±0.000 across all 3 runs in every arm — deterministic on this
@@ -238,14 +247,18 @@ large, diverse production corpus) specifically because an isolated
 synthetic-corpus result — in either direction — isn't the final word. See
 the PR for flair#504 Phase 2 for how this was resolved.
 
-**Resolved (PR #689)**: the v2 A/B below reproduced this same regression at
-4× the query count, and K&S ratified parking the flip — see "The gate, the
-park decision, and BASELINE.json" further down. `EMBEDDING_PREFIXES_ENABLED`
-now defaults `false`; this section's numbers and the `FLAIR_RECALL_HARNESS_NO_PREFIX`
-hatch they were measured with are preserved here as history — the harness's
-current mechanism is `FLAIR_RECALL_HARNESS_FORCE_PREFIX` (see "Flags" above),
-which force-enables prefixes rather than force-disabling them, matching the
-gate's new off-by-default shape.
+**Resolved, twice (PR #689, then this PR):** the v2 A/B below reproduced this
+same small delta at 4× the query count, and PR #689's K&S review ratified
+parking the flip on it. This PR (see "The gate, the flip decision, and
+BASELINE.json" further down) revisits that decision and flips
+`EMBEDDING_PREFIXES_ENABLED` to `true` — the delta itself never changed, only
+the read of what it means (noise-scale, not a real regression) and the
+strategic case for shipping anyway. This section's numbers and the
+`FLAIR_RECALL_HARNESS_NO_PREFIX` hatch they were originally measured with are
+preserved here as history — the harness's current mechanism is the
+bidirectional `FLAIR_RECALL_HARNESS_FORCE_PREFIX` (see "Flags" above), which
+now force-disables prefixes (the `off` comparison arm) rather than
+force-enabling them, matching the gate's new on-by-default shape.
 
 **Mixed-space canary** (`--canary`, hybrid=true, scoring=raw; 44 records
 seeded unprefixed then 43 more seeded prefixed after a same-installDir
@@ -423,42 +436,86 @@ below either endpoint**, tightening v1's earlier estimate (v1's canary had
 MRR dip 0.05 below the off-arm; at 4× the query count that dip does not
 reproduce).
 
-## The gate, the park decision, and BASELINE.json
+## The gate, the flip decision, and BASELINE.json
 
-The v2 A/B above (N=126, the largest and most reliable measurement this
-harness has produced) is what decided flair#504 Phase 2's outcome: prefixes
-regress both p@3 and MRR (off 0.992/0.949 vs on 0.976/0.946, Δ −0.016/−0.003)
-— small, but real (±0.000 variance across 3 runs, not noise), and the design
-hypothesis was that prefixes would *help*, not merely "not hurt." K&S
-reviewed this evidence and ratified the decision (PR #689): **park the flip**
-rather than ship it. `resources/embeddings-provider.ts` now has a single
-module-level constant, `EMBEDDING_PREFIXES_ENABLED = false`, that atomically
-gates BOTH `inputType` forwarding to `models.embed()` and the `+searchprefix`
-suffix `getModelId()` stamps — the two can never diverge, enforced at that
-one chokepoint (see the constant's own doc for why a stamp/behavior mismatch
-would silently corrupt dedup and stale-detection). `src/cli.ts`'s
+**History (PR #689):** the v2 A/B above (N=126, the largest and most
+reliable measurement this harness had produced at the time) is what decided
+flair#504 Phase 2's original outcome: prefixes=off p@3=0.992/MRR=0.949 vs
+prefixes=on p@3=0.976/MRR=0.946, Δ −0.016/−0.003 — small, reproducible
+(±0.000 variance across 3 runs), and the design hypothesis had been that
+prefixes would *help*, not merely "not hurt." K&S reviewed this evidence and
+ratified parking the flip rather than shipping it.
+
+**This PR flips it.** Read plainly, that Δ −0.016 p@3 / −0.003 MRR at N=126
+is 2 of 126 queries moving rank — noise-scale for this instrument, not a
+directional regression in either direction. The recall measurement alone was
+a wash either way, so this PR flips `EMBEDDING_PREFIXES_ENABLED` to `true` on
+strategic grounds instead: nomic-embed-text-v1.5 is trained expecting these
+prefixes (running it unprefixed indefinitely is the actual departure from
+convention), and the flip is the first real payload for the boot-keyed
+auto-migration machinery (flair#690, flair#695) — exercising the
+detect-stale/re-embed path now, on a change with a proven noise-scale recall
+floor, is lower-risk than letting that machinery sit unexercised until some
+future higher-stakes change needs it first, and avoids two unrelated
+stamp-bumping changes compounding into one migration debt pile. See the PR
+description for the full context.
+
+`resources/embeddings-provider.ts` still has a single module-level constant,
+`EMBEDDING_PREFIXES_ENABLED`, that atomically gates BOTH `inputType`
+forwarding to `models.embed()` and the `+searchprefix` suffix `getModelId()`
+stamps — the two can never diverge, enforced at that one chokepoint (see the
+constant's own doc for why a stamp/behavior mismatch would silently corrupt
+dedup and stale-detection). It now defaults `true`. `src/cli.ts`'s
 `--stale-only` duplicates the same gate-then-suffix logic (separate build
 target) and must be kept in sync manually — see its own comment.
 
-This PR ships the plumbing (typed `inputType`, every call site passing the
-correct literal), the stamp mechanism, and this measurement instrument — not
-the prefix behavior itself. The `--prefixes on\|off\|both` flag documented
-above still measures both arms: `off` needs no hatch (it's simply the real
-default), `on` uses the bench-only `FLAIR_RECALL_HARNESS_FORCE_PREFIX`
-escape hatch to force-enable the same gate against the same dist build — so
-this harness stays able to validate the parked mechanism without a second
-build config.
+The `--prefixes on\|off\|both` flag documented above still measures both
+arms: `on` needs no hatch (it's simply the real default now), `off` uses the
+bench-only `FLAIR_RECALL_HARNESS_FORCE_PREFIX` escape hatch (bidirectional —
+reads `"true"`/`"false"`, not just presence) to force-disable the same gate
+against the same dist build — so this harness stays able to validate the
+comparison arm without a second build config, in whichever direction the
+gate defaults.
 
-`BASELINE.json` (in this directory) freezes the production-config numbers —
-`corpus=v2, hybrid=true, prefixes=false, scoring=raw` — as the reference
-point a future CI ratchet gates on: `p@3=0.992, mrr=0.949` aggregate, with
-per-kind MRRs (`stress=0.971, trap=0.943, hard=0.924, clean=0.983`). It
-carries an explicit `config` block so a mismatched invocation (wrong corpus
-version, wrong hybrid/prefix/scoring combination) fails loudly instead of
-silently comparing against the wrong arm. Flipping `EMBEDDING_PREFIXES_ENABLED`
-back to `true` in the future requires a fresh, re-baselined A/B through that
-ratchet — not a unilateral code change — per the same K&S-ratified process
-that parked it.
+### Post-flip re-baseline (measured on this PR's build, isolated)
+
+`--corpus v2 --runs 3 --hybrid both --prefixes both`, scoring=raw for the
+prefix A/B (the production default). Variance was ±0.000 across all 3 runs
+in every arm — deterministic, same as every prior measurement in this file.
+Both hybrid modes produced byte-identical prefix deltas, same as every prior
+sweep:
+
+```
+── PREFIX A/B, hybrid=true (identical numbers under hybrid=false) ──
+  prefixes=off (comparison, via force-off hatch)  p@3=0.992 ± 0.000   MRR=0.949 ± 0.000
+  prefixes=on  (shipped default)                  p@3=0.976 ± 0.000   MRR=0.946 ± 0.000
+  Δ (on − off)   p@3=-0.016   MRR=-0.003
+  by kind (on − off, MRR):
+    stress (n=17) off=0.971  on=0.961  Δ=-0.010
+    trap   (n=34) off=0.943  on=0.930  Δ=-0.013
+    hard   (n=46) off=0.924  on=0.946  Δ=+0.022
+    clean  (n=29) off=0.983  on=0.957  Δ=-0.026
+  per-cluster MRR movers (on − off, 23 of 30 clusters flat):
+    gained: CERAMICS +0.250, PERFUMERY +0.250, FINOPS +0.017
+    lost:   WINEMAKING -0.375, AVIATION -0.250, MUSICPROD -0.017, GITWF -0.010
+```
+
+These numbers reproduce PR #689's original v2 A/B byte-for-byte (same Δ,
+same per-kind breakdown, same per-cluster movers) — expected and reassuring,
+not a coincidence: this flip changes which arm the production code path
+takes by default, not the embedding math either arm computes. The decision
+to flip rests on the strategic case in "This PR flips it" above, not on a
+changed recall number — there isn't one.
+
+`BASELINE.json` (in this directory) now freezes the production-config
+numbers — `corpus=v2, hybrid=true, prefixes=true, scoring=raw` — as the
+reference point a future CI ratchet gates on. It carries an explicit
+`config` block so a mismatched invocation (wrong corpus version, wrong
+hybrid/prefix/scoring combination) fails loudly instead of silently
+comparing against the wrong arm. Flipping `EMBEDDING_PREFIXES_ENABLED` back
+to `false` in the future requires the same process in reverse: a fresh,
+re-baselined A/B through that ratchet showing staying on is actively worse,
+not just unproven — not a unilateral code change.
 
 ## Caveats
 

--- a/test/bench/recall-harness/run.ts
+++ b/test/bench/recall-harness/run.ts
@@ -101,16 +101,19 @@ const KEEP_ON_FAIL = process.argv.includes("--keep-on-fail");
 // flair#683: run ONLY the usage-injection rematch (see "USAGE-FEEDBACK
 // REMATCH" section below) instead of the base composite-vs-raw sweep above.
 const USAGE_REMATCH = process.argv.includes("--usage-rematch");
-// flair#504 Phase 2 (nomic search prefixes, PARKED — PR #689): THE GATE
+// flair#504 Phase 2 (nomic search prefixes, FLIPPED ON): THE GATE
 // (EMBEDDING_PREFIXES_ENABLED in resources/embeddings-provider.ts) now
-// defaults OFF on measured v2 evidence, so "off" = the real, unmodified
-// default code path (no hatch needed at all) and "on" = the harness-only
-// FLAIR_RECALL_HARNESS_FORCE_PREFIX escape hatch, which force-enables the
+// defaults ON on strategic grounds (measured recall delta was noise-scale —
+// see that file's header), so "on" = the real, unmodified default code path
+// (no hatch needed at all) and "off" = the harness-only
+// FLAIR_RECALL_HARNESS_FORCE_PREFIX escape hatch, which force-disables the
 // SAME gate the production code checks — see that file's header for why a
 // real env toggle in PRODUCTION code was rejected but this harness-only one
 // is fine: the call sites never read it, only prefixesEnabled() does. This
-// is what lets the harness keep measuring BOTH arms (proving the parked
-// mechanism still works) even though production only ever exercises "off".
+// is what lets the harness keep measuring BOTH arms even though production
+// only ever exercises "on". The hatch is bidirectional
+// (`harnessPrefixOverride()` reads `"true"`/`"false"`, not just presence) so
+// it stays correct across any future re-flip without a second hatch.
 const PREFIXES_ARG = argVal("--prefixes", "both"); // "both" | "on" | "off"
 // Run ONLY the mixed-space canary (see "MIXED-SPACE CANARY" section below)
 // instead of the main sweep.
@@ -269,12 +272,12 @@ async function runQueries(harper: HarperInstance, agent: TestAgent, scoring: "ra
 
 // One independent (spawn → register → seed → wait → measure[raw,composite] →
 // teardown) cycle for a given (hybrid, rerank, prefixesOn) config.
-// prefixesOn=true forces the harness-only force-prefix escape hatch (see
-// resources/embeddings-provider.ts's `harnessForcePrefix` doc) so this arm's
-// writes/queries measure "as if THE GATE were flipped on" against the SAME
-// gate-off-by-default dist build the off-arm uses — isolating the prefix
+// prefixesOn=false forces the harness-only prefix override to "false" (see
+// resources/embeddings-provider.ts's `harnessPrefixOverride` doc) so this
+// arm's writes/queries measure "as if THE GATE were flipped off" against the
+// SAME gate-on-by-default dist build the on-arm uses — isolating the prefix
 // effect from every other variable (corpus, HNSW build, embedding-engine
-// warmup). prefixesOn=false needs no hatch — it IS the shipped default.
+// warmup). prefixesOn=true needs no hatch — it IS the shipped default.
 async function runOnce(hybrid: boolean, rerank: boolean, prefixesOn: boolean, runIdx: number, totalRuns: number): Promise<{ raw: ScoringResult; composite: ScoringResult }> {
   const label = `[hybrid=${hybrid} rerank=${rerank} prefixes=${prefixesOn ? "on" : "off"} run ${runIdx}/${totalRuns}]`;
   const prevHybrid = process.env.FLAIR_HYBRID_RETRIEVAL;
@@ -282,7 +285,7 @@ async function runOnce(hybrid: boolean, rerank: boolean, prefixesOn: boolean, ru
   const prevPrefix = process.env.FLAIR_RECALL_HARNESS_FORCE_PREFIX;
   process.env.FLAIR_HYBRID_RETRIEVAL = hybrid ? "true" : "false";
   if (rerank) process.env.FLAIR_RERANK_ENABLED = "true"; else delete process.env.FLAIR_RERANK_ENABLED;
-  if (prefixesOn) process.env.FLAIR_RECALL_HARNESS_FORCE_PREFIX = "true"; else delete process.env.FLAIR_RECALL_HARNESS_FORCE_PREFIX;
+  if (prefixesOn) delete process.env.FLAIR_RECALL_HARNESS_FORCE_PREFIX; else process.env.FLAIR_RECALL_HARNESS_FORCE_PREFIX = "false";
 
   let harper: HarperInstance | undefined;
   try {
@@ -447,17 +450,17 @@ async function main() {
   }
 
   // ── Headline discrimination check (composite vs raw, flair#623) ─────────
-  // Prefers prefixes=off — the shipped production default now that THE GATE
-  // (EMBEDDING_PREFIXES_ENABLED) is parked off per PR #689 — when that arm
-  // is present in this invocation; falls back to prefixes=on only if the
-  // invocation exclusively requested that (parked) arm.
-  const primaryPrefixOn = !prefixValues.includes(false) && prefixValues.includes(true);
+  // Prefers prefixes=on — the shipped production default now that THE GATE
+  // (EMBEDDING_PREFIXES_ENABLED) is flipped on — when that arm is present in
+  // this invocation; falls back to prefixes=off only if the invocation
+  // exclusively requested that (comparison) arm.
+  const primaryPrefixOn = prefixValues.includes(true);
   const primaryKey = keyFor({ hybrid: true, rerank: false, prefixesOn: primaryPrefixOn });
   if (results[primaryKey]) {
     const rawP3 = aggStats(results[primaryKey].raw.p3).mean, compP3 = aggStats(results[primaryKey].composite.p3).mean;
     const rawMrr = aggStats(results[primaryKey].raw.mrr).mean, compMrr = aggStats(results[primaryKey].composite.mrr).mean;
     const discriminates = compP3 < rawP3 || compMrr < rawMrr;
-    console.log(`HEADLINE (hybrid=true prefixes=${primaryPrefixOn ? "on (parked arm — this invocation didn't include the off/default arm)" : "off, the shipped production default"}): composite p@3=${fmt(compP3)} vs raw p@3=${fmt(rawP3)}; composite MRR=${fmt(compMrr)} vs raw MRR=${fmt(rawMrr)}.`);
+    console.log(`HEADLINE (hybrid=true prefixes=${primaryPrefixOn ? "on, the shipped production default" : "off (comparison arm — this invocation didn't include the on/default arm)"}): composite p@3=${fmt(compP3)} vs raw p@3=${fmt(rawP3)}; composite MRR=${fmt(compMrr)} vs raw MRR=${fmt(rawMrr)}.`);
     console.log(discriminates
       ? "  → Corpus DISCRIMINATES: composite measurably underperforms raw, reproducing flair#623 in isolation."
       : "  → Corpus did NOT discriminate this run — see README's 'if it doesn't discriminate' notes before trusting this config as safe.");
@@ -481,8 +484,8 @@ async function main() {
       const onMrr = aggStats(results[onKey].raw.mrr), offMrr = aggStats(results[offKey].raw.mrr);
       const dP3 = onP3.mean - offP3.mean, dMrr = onMrr.mean - offMrr.mean;
       console.log(`── hybrid=${h} ──`);
-      console.log(`  prefixes=off (shipped default)      p@3=${fmtAgg(offP3)}   MRR=${fmtAgg(offMrr)}`);
-      console.log(`  prefixes=on  (parked, via force hatch)  p@3=${fmtAgg(onP3)}   MRR=${fmtAgg(onMrr)}`);
+      console.log(`  prefixes=off (comparison, via force-off hatch)  p@3=${fmtAgg(offP3)}   MRR=${fmtAgg(offMrr)}`);
+      console.log(`  prefixes=on  (shipped default)                  p@3=${fmtAgg(onP3)}   MRR=${fmtAgg(onMrr)}`);
       console.log(`  Δ (on − off, live, same session)   p@3=${dP3 >= 0 ? "+" : ""}${fmt(dP3)}   MRR=${dMrr >= 0 ? "+" : ""}${fmt(dMrr)}`);
       // PHASE1_BASELINE was measured on v1's 87-record corpus — comparing a
       // v2 run against it would silently mix two different instruments'
@@ -506,8 +509,8 @@ async function main() {
       const bump = onP3 >= offP3 && onMrr >= offMrr;
       console.log(`PREFIX HEADLINE (hybrid=true, the production default): prefixes=on p@3=${fmt(onP3)} MRR=${fmt(onMrr)} vs prefixes=off p@3=${fmt(offP3)} MRR=${fmt(offMrr)}.`);
       console.log(bump
-        ? "  → Prefixes HELP (or at minimum don't regress) on THIS run — would be evidence toward re-flipping THE GATE, but a single run isn't a re-baseline (see BASELINE.json + README's ratchet-gate process)."
-        : "  → Prefixes REGRESS p@3 or MRR on this corpus — consistent with the parked decision (THE GATE stays off). Do NOT flip EMBEDDING_PREFIXES_ENABLED on this measurement alone.");
+        ? "  → Prefixes (the shipped default) match or beat the off comparison arm on THIS run — consistent with the flip decision, though a single run isn't the full re-baseline (see BASELINE.json + README's ratchet-gate process)."
+        : "  → Prefixes trail the off comparison arm on p@3 or MRR this run — a single run isn't grounds to revert THE GATE on its own; re-run the full sweep and compare against BASELINE.json before considering a revert.");
     }
   }
 }
@@ -752,39 +755,42 @@ async function runUsageRematch(): Promise<void> {
 
 // ═══════════════════════════════════════════════════════════════════════════
 // MIXED-SPACE CANARY (flair#504 Phase 2) — quantifies the transient risk a
-// FUTURE gate-on re-embed pass would carry, IF the parked prefix flip is
-// ever re-approved through a re-baselined A/B (see THE GATE,
-// `EMBEDDING_PREFIXES_ENABLED`, in resources/embeddings-provider.ts — off by
-// default as of PR #689 on measured v2 evidence). Does NOT touch prod;
-// ephemeral Harper only, and moot for as long as the gate stays off (no live
-// re-embed is planned while parked).
+// gate-flip re-embed pass carries while it's mid-flight (see THE GATE,
+// `EMBEDDING_PREFIXES_ENABLED`, in resources/embeddings-provider.ts — now ON
+// by default, re-baselined through this same measurement). Does NOT touch
+// prod; ephemeral Harper only. This scenario already played out for THIS
+// flip (the boot-keyed auto-migration runner re-embeds stale rows on next
+// boot — see resources/migrations/embedding-stamp.ts) — the canary stays as
+// a reusable tool for quantifying the same class of transient risk the NEXT
+// time a variant-stamp change (a different embedding model, a new
+// EMBEDDING_VARIANT bump) triggers a mass re-embed.
 //
-// The scenario this models: IF the gate is flipped on, a `flair reembed
-// --stale-only` pass against the LIVE corpus would transiently hold BOTH
-// prefixed and unprefixed document vectors in the SAME corpus while it runs
-// (batched, ~100ms apart) — a `search_query:`-prefixed query would then be
-// cross-space against whichever documents haven't been touched by the pass
-// yet.
+// The scenario this models: a re-embed pass against the LIVE corpus
+// transiently holds BOTH old-stamp and new-stamp document vectors in the
+// SAME corpus while it runs (batched, ~100ms apart) — a query embedded under
+// the NEW stamp would then be cross-space against whichever documents the
+// pass hasn't touched yet.
 //
 // This canary reproduces that mixed state in isolation: CORPUS is split by
 // ALTERNATING index (not a contiguous first/second half — that would
 // confound the measurement if a whole topic cluster or query kind happened
 // to land in only one half; alternating approximates a re-embed pass that
 // proceeds in id/insertion order, uncorrelated with topic). The even-index
-// half is written FIRST against the real gate-off default (no hatch needed —
-// simulating not-yet-re-embedded rows); Harper is then STOPPED but its
-// installDir is KEPT (mirrors flair#637's downgrade-boot restart pattern —
-// test/compat/downgrade-boot.test.ts — the on-disk Memory table + HNSW index
-// persist across the restart) and RESTARTED against the SAME installDir with
-// the harness-only force-prefix hatch ON (simulating the gate having been
-// flipped on for the re-embed), which writes the odd-index half WITH the
+// half is written FIRST with the harness-only hatch forced OFF (simulating
+// not-yet-re-embedded rows, i.e. rows still on the OLD stamp — reachable
+// now only via the hatch, since THE GATE itself defaults on); Harper is then
+// STOPPED but its installDir is KEPT (mirrors flair#637's downgrade-boot
+// restart pattern — test/compat/downgrade-boot.test.ts — the on-disk Memory
+// table + HNSW index persist across the restart) and RESTARTED against the
+// SAME installDir with no hatch (the real gate-on default, simulating the
+// re-embed having caught up), which writes the odd-index half WITH the
 // prefix. Queries run against this final instance, so they always get the
 // real 'query' prefix — only the STORED document vectors are mixed.
 //
 // Reports the mixed-corpus p@3/MRR; compare against this same invocation's
 // (or a prior `--hybrid on --prefixes on` run's) fully-consistent prefix-on
-// numbers — the delta IS the quantified transient-degradation risk a future
-// gate flip + re-embed would carry.
+// numbers — the delta IS the quantified transient-degradation risk a re-embed
+// pass carries while mid-flight.
 // ═══════════════════════════════════════════════════════════════════════════
 async function runMixedSpaceCanary(): Promise<void> {
   assertBuilt();
@@ -803,10 +809,11 @@ async function runMixedSpaceCanary(): Promise<void> {
   let installDir: string | undefined;
   try {
     // ── Phase A: unprefixed half, simulating pre-re-embed rows ────────────
-    // No hatch needed — THE GATE (EMBEDDING_PREFIXES_ENABLED) defaults off,
-    // so this IS the real shipped behavior, not a simulation.
-    delete process.env.FLAIR_RECALL_HARNESS_FORCE_PREFIX;
-    console.log(`[canary] spawning ephemeral Harper (phase A: prefix OFF, real gate-off default)...`);
+    // THE GATE (EMBEDDING_PREFIXES_ENABLED) now defaults ON, so this half
+    // needs the harness-only hatch forced to "false" to simulate the OLD,
+    // not-yet-re-embedded stamp.
+    process.env.FLAIR_RECALL_HARNESS_FORCE_PREFIX = "false";
+    console.log(`[canary] spawning ephemeral Harper (phase A: prefix OFF via force-off hatch, simulating not-yet-re-embedded rows)...`);
     inst1 = await startHarper({ cwd: REPO_ROOT, harperBinDir: REPO_ROOT });
     installDir = inst1.installDir;
     console.log(`[canary] up at ${inst1.httpURL} (installDir=${installDir})`);
@@ -829,10 +836,10 @@ async function runMixedSpaceCanary(): Promise<void> {
     await stopHarper(inst1, { keepInstallDir: true });
     inst1 = undefined;
 
-    // ── Phase B: SAME installDir, prefix ON via the bench-only force hatch —
-    // simulates the gate being flipped on for a future stage-2 re-embed ──
-    process.env.FLAIR_RECALL_HARNESS_FORCE_PREFIX = "true";
-    console.log(`[canary] restarting SAME installDir (phase B: prefix ON via force hatch, simulating a future gate-on re-embed)...`);
+    // ── Phase B: SAME installDir, prefix ON — the gate's real default now,
+    // no hatch needed. Simulates the re-embed pass having caught this half up.
+    delete process.env.FLAIR_RECALL_HARNESS_FORCE_PREFIX;
+    console.log(`[canary] restarting SAME installDir (phase B: prefix ON, real gate-on default, simulating the re-embed pass catching up)...`);
     inst2 = await startHarper({ cwd: REPO_ROOT, harperBinDir: REPO_ROOT, installDir });
     console.log(`[canary] up at ${inst2.httpURL}`);
     console.log(`[canary] seeding ${prefixedHalf.length} prefixed records...`);

--- a/test/integration/migrations-resume-after-kill.test.ts
+++ b/test/integration/migrations-resume-after-kill.test.ts
@@ -26,11 +26,14 @@
  * plus embedding-stamp's own knob-widened batch sleeps: past the deadline.
  * Local Metal-accelerated embeds (~10-30ms/row) masked this entirely.
  * Fix: pin FLAIR_EMBEDDING_MODEL (only consumed by getModelId() — the
- * stamp string, never model loading) and seed rows with that exact value,
- * so embedding-stamp detects NOTHING and the synthetic migration — the one
+ * stamp string, never model loading) and seed rows with the EXACT stamp
+ * getModelId() computes for that pinned base id (derived by calling the
+ * real function, below — not hardcoded, so this test can't silently drift
+ * from embeddings-provider.ts's actual gate state, see flair#504), so
+ * embedding-stamp detects NOTHING and the synthetic migration — the one
  * under test — starts immediately after the shared pre-hash. The ground
  * truth check asserts the isolation held (embeddingModel still the pinned
- * value at the end — embedding-stamp never touched the rows).
+ * stamp at the end — embedding-stamp never touched the rows).
  *
  * ── DETERMINISM (fix for CI failure #1) ──
  *   - FLAIR_MIGRATION_TEST_BATCH_DELAY_MS (runner.ts's test-only throttle
@@ -52,16 +55,37 @@ import { rm } from "node:fs/promises";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import { startHarper, stopHarper, type HarperInstance } from "../helpers/harper-lifecycle";
+import { getModelId } from "../../resources/embeddings-provider";
 
 const RESERVED_TEST_AGENT_ID = "__flair_migration_synthetic_test_agent__";
 const SYNTHETIC_TARGET_MARKER = "synthetic-ci-schema-stamp-done";
 const SYNTHETIC_MIGRATION_ID = "synthetic-ci-schema-stamp";
 const ROW_COUNT = 140; // 3 batches at the schema-additive batch size (50) — two observable mid-flight windows
 const TEST_BATCH_DELAY_MS = 2500; // widens each mid-flight window to ~2.5s (vs the 100ms prod default)
-// Pinned stamp — see "MIGRATION ISOLATION" above. getModelId() returns this
-// verbatim (gate off, no suffix) inside the spawned Harper, and every seeded
-// row carries it, so embedding-stamp's stale-detection finds nothing.
+// Pinned base id — see "MIGRATION ISOLATION" above. Set as FLAIR_EMBEDDING_MODEL
+// for the spawned Harper (beforeAll, below).
 const PINNED_EMBEDDING_MODEL = "resume-test-pinned-model";
+// The EXACT stamp getModelId() computes for PINNED_EMBEDDING_MODEL under
+// this build's THE GATE (flair#504) — derived by calling the real,
+// harper-free `getModelId()` (it only reads env vars + the module-level
+// gate constant, never triggers embeddings-provider.ts's deferred Harper
+// import), not hardcoded as a literal. This is what makes the isolation
+// hold regardless of which way THE GATE is currently set: whether
+// `getModelId()` returns the bare base id or `<base>+searchprefix`, this
+// constant always matches it, so the seeded rows below never read as stale
+// to embedding-stamp inside the spawned Harper (same build, same env var,
+// same gate — see the spawned process's own getModelId() for why this is a
+// faithful mirror, not a guess).
+const PINNED_EMBEDDING_STAMP = (() => {
+  const saved = process.env.FLAIR_EMBEDDING_MODEL;
+  process.env.FLAIR_EMBEDDING_MODEL = PINNED_EMBEDDING_MODEL;
+  try {
+    return getModelId();
+  } finally {
+    if (saved === undefined) delete process.env.FLAIR_EMBEDDING_MODEL;
+    else process.env.FLAIR_EMBEDDING_MODEL = saved;
+  }
+})();
 
 let harper: HarperInstance;
 let installDir: string;
@@ -139,7 +163,7 @@ describe("zero-touch migrations — resume after a mid-migration process kill (r
       content: `resume row ${i}`,
       source: "not-yet",
       embedding: [0.1, 0.2, 0.3],
-      embeddingModel: PINNED_EMBEDDING_MODEL, // matches getModelId() in the spawned server — invisible to embedding-stamp
+      embeddingModel: PINNED_EMBEDDING_STAMP, // matches getModelId() in the spawned server — invisible to embedding-stamp
       createdAt: new Date().toISOString(),
     }));
     // Single bulk insert — ops API accepts multiple records per call. (The
@@ -267,7 +291,7 @@ describe("zero-touch migrations — resume after a mid-migration process kill (r
     expect(list).toHaveLength(ROW_COUNT);
     for (const row of list) {
       expect(row.source).toBe(SYNTHETIC_TARGET_MARKER);
-      expect(row.embeddingModel).toBe(PINNED_EMBEDDING_MODEL);
+      expect(row.embeddingModel).toBe(PINNED_EMBEDDING_STAMP);
     }
   }, 400_000);
 });

--- a/test/unit/embeddings-provider-input-type.test.ts
+++ b/test/unit/embeddings-provider-input-type.test.ts
@@ -4,14 +4,17 @@ import { buildEmbedOptions, getModelId } from "../../resources/embeddings-provid
 
 /**
  * buildEmbedOptions() / getModelId() (flair#504 Phase 2, nomic search
- * prefixes — PARKED behind THE GATE as of PR #689) — the single chokepoint
- * (`prefixesEnabled()` inside embeddings-provider.ts) both functions read to
- * decide whether inputType-forwarding and the `+searchprefix` model-id
- * suffix are active. THE GATE (`EMBEDDING_PREFIXES_ENABLED`) defaults to
- * `false` on measured v2 evidence (see test/bench/recall-harness/README.md's
- * "v2 measured results" and BASELINE.json) — this file pins that default AND
- * the bench-only force hatch (`FLAIR_RECALL_HARNESS_FORCE_PREFIX`) that lets
- * the harness still measure the parked "on" arm against the SAME dist build.
+ * prefixes — FLIPPED ON, re-baselined through the ratchet gate) — the single
+ * chokepoint (`prefixesEnabled()` inside embeddings-provider.ts) both
+ * functions read to decide whether inputType-forwarding and the
+ * `+searchprefix` model-id suffix are active. THE GATE
+ * (`EMBEDDING_PREFIXES_ENABLED`) now defaults to `true` (see
+ * test/bench/recall-harness/README.md's "v2 measured results" and
+ * BASELINE.json — the measured recall delta between arms was noise-scale,
+ * not a regression) — this file pins that default AND the bidirectional
+ * bench-only override (`FLAIR_RECALL_HARNESS_FORCE_PREFIX`, reading
+ * `"true"`/`"false"`) that lets the harness measure BOTH arms against the
+ * SAME dist build.
  *
  * Deliberately does NOT go through `getEmbedding()` itself (which would
  * require mocking `@harperfast/harper`'s deferred dynamic import) — that
@@ -37,14 +40,14 @@ import { buildEmbedOptions, getModelId } from "../../resources/embeddings-provid
  * for anything that bypasses the type system (`as any`, a future refactor
  * that loosens the type, a plain-JS caller).
  */
-describe("buildEmbedOptions / getModelId (flair#504 Phase 2 — nomic search prefix gate, parked OFF)", () => {
+describe("buildEmbedOptions / getModelId (flair#504 Phase 2 — nomic search prefix gate, ON by default)", () => {
   const SAVED_HARNESS_FLAG = process.env.FLAIR_RECALL_HARNESS_FORCE_PREFIX;
   const SAVED_MODEL = process.env.FLAIR_EMBEDDING_MODEL;
 
   beforeEach(() => {
     // Belt-and-suspenders against env leak from another file/run — the
-    // bench-only force hatch and any operator model override must start
-    // clean so these tests exercise the real shipped default.
+    // bench-only override and any operator model override must start clean
+    // so these tests exercise the real shipped default.
     delete process.env.FLAIR_RECALL_HARNESS_FORCE_PREFIX;
     delete process.env.FLAIR_EMBEDDING_MODEL;
   });
@@ -56,33 +59,17 @@ describe("buildEmbedOptions / getModelId (flair#504 Phase 2 — nomic search pre
     else process.env.FLAIR_EMBEDDING_MODEL = SAVED_MODEL;
   });
 
-  describe("gate OFF (default — EMBEDDING_PREFIXES_ENABLED=false, no force hatch)", () => {
-    it("drops inputType even when a call site passes one", () => {
-      expect(buildEmbedOptions("document")).toEqual({ model: "default" });
-      expect(buildEmbedOptions("query")).toEqual({ model: "default" });
-    });
-
-    it("omits inputType when not provided", () => {
-      expect(buildEmbedOptions()).toEqual({ model: "default" });
-    });
-
-    it("getModelId() has no suffix — base id only (no stale-read false-positive on a no-op re-embed)", () => {
-      expect(getModelId()).toBe("nomic-embed-text-v1.5-Q4_K_M");
-      expect(getModelId()).not.toContain("+searchprefix");
-    });
-  });
-
-  describe("bench-only force hatch (FLAIR_RECALL_HARNESS_FORCE_PREFIX=true) — the recall-harness '--prefixes on' arm", () => {
-    beforeEach(() => {
-      process.env.FLAIR_RECALL_HARNESS_FORCE_PREFIX = "true";
-    });
-
+  describe("gate ON (default — EMBEDDING_PREFIXES_ENABLED=true, no override)", () => {
     it("forwards 'document' exactly", () => {
       expect(buildEmbedOptions("document")).toEqual({ model: "default", inputType: "document" });
     });
 
     it("forwards 'query' exactly", () => {
       expect(buildEmbedOptions("query")).toEqual({ model: "default", inputType: "query" });
+    });
+
+    it("omits inputType when not provided", () => {
+      expect(buildEmbedOptions()).toEqual({ model: "default" });
     });
 
     it("getModelId() carries the +searchprefix suffix", () => {
@@ -102,24 +89,70 @@ describe("buildEmbedOptions / getModelId (flair#504 Phase 2 — nomic search pre
     });
   });
 
+  describe("bench-only override (FLAIR_RECALL_HARNESS_FORCE_PREFIX=false) — the recall-harness '--prefixes off' arm", () => {
+    beforeEach(() => {
+      process.env.FLAIR_RECALL_HARNESS_FORCE_PREFIX = "false";
+    });
+
+    it("drops inputType even when a call site passes one", () => {
+      expect(buildEmbedOptions("document")).toEqual({ model: "default" });
+      expect(buildEmbedOptions("query")).toEqual({ model: "default" });
+    });
+
+    it("omits inputType when not provided", () => {
+      expect(buildEmbedOptions()).toEqual({ model: "default" });
+    });
+
+    it("getModelId() has no suffix — base id only (no stale-read false-positive on a no-op re-embed)", () => {
+      expect(getModelId()).toBe("nomic-embed-text-v1.5-Q4_K_M");
+      expect(getModelId()).not.toContain("+searchprefix");
+    });
+  });
+
+  describe("bench-only override (FLAIR_RECALL_HARNESS_FORCE_PREFIX=true) — explicit, redundant with the default, but must agree with it", () => {
+    beforeEach(() => {
+      process.env.FLAIR_RECALL_HARNESS_FORCE_PREFIX = "true";
+    });
+
+    it("forwards 'document' exactly", () => {
+      expect(buildEmbedOptions("document")).toEqual({ model: "default", inputType: "document" });
+    });
+
+    it("forwards 'query' exactly", () => {
+      expect(buildEmbedOptions("query")).toEqual({ model: "default", inputType: "query" });
+    });
+
+    it("getModelId() carries the +searchprefix suffix", () => {
+      expect(getModelId()).toBe("nomic-embed-text-v1.5-Q4_K_M+searchprefix");
+    });
+  });
+
   /**
-   * THE INVARIANT (Kern's ratified mechanism, PR #689): THE GATE atomically
-   * controls BOTH inputType-forwarding and the model-id suffix — they must
-   * NEVER diverge. A row stamped `+searchprefix` whose vector was actually
-   * computed WITHOUT the prefix (or vice versa) would silently corrupt
-   * dedup and stale-detection, which both key off `embeddingModel` matching
-   * what was actually forwarded to `models.embed()`. This sweeps every
-   * externally-reachable configuration — the bench-only force hatch is the
-   * only runtime lever; `EMBEDDING_PREFIXES_ENABLED` itself is a hardcoded
-   * module constant, not a runtime toggle, by design (see that constant's
-   * doc in resources/embeddings-provider.ts) — and asserts the two never
-   * disagree in either state.
+   * THE INVARIANT (Kern's ratified mechanism, PR #689, unchanged by the
+   * flip): THE GATE atomically controls BOTH inputType-forwarding and the
+   * model-id suffix — they must NEVER diverge. A row stamped `+searchprefix`
+   * whose vector was actually computed WITHOUT the prefix (or vice versa)
+   * would silently corrupt dedup and stale-detection, which both key off
+   * `embeddingModel` matching what was actually forwarded to
+   * `models.embed()`. This sweeps every externally-reachable configuration —
+   * the bench-only override is the only runtime lever (three states: unset
+   * defers to THE GATE, `"true"` forces on, `"false"` forces off);
+   * `EMBEDDING_PREFIXES_ENABLED` itself is a hardcoded module constant, not a
+   * runtime toggle, by design (see that constant's doc in
+   * resources/embeddings-provider.ts) — and asserts the two never disagree
+   * in any of the three reachable states, in either direction the gate might
+   * default to.
    */
   describe("invariant: suffix presence and inputType-forwarding never diverge", () => {
-    for (const forceOn of [false, true]) {
-      it(`force hatch=${forceOn}: it is impossible to observe suffix-without-inputType or inputType-without-suffix`, () => {
-        if (forceOn) process.env.FLAIR_RECALL_HARNESS_FORCE_PREFIX = "true";
-        else delete process.env.FLAIR_RECALL_HARNESS_FORCE_PREFIX;
+    const overrides: { label: string; value: string | undefined }[] = [
+      { label: "unset (defers to THE GATE, currently on)", value: undefined },
+      { label: 'override="true"', value: "true" },
+      { label: 'override="false"', value: "false" },
+    ];
+    for (const { label, value } of overrides) {
+      it(`${label}: it is impossible to observe suffix-without-inputType or inputType-without-suffix`, () => {
+        if (value === undefined) delete process.env.FLAIR_RECALL_HARNESS_FORCE_PREFIX;
+        else process.env.FLAIR_RECALL_HARNESS_FORCE_PREFIX = value;
 
         const hasSuffix = getModelId().endsWith("+searchprefix");
         const docForwards = "inputType" in buildEmbedOptions("document");


### PR DESCRIPTION
## Summary

flair#504 checkpoint: flips `EMBEDDING_PREFIXES_ENABLED` from `false` to `true` in `resources/embeddings-provider.ts` — one module-level constant — and re-baselines `test/bench/recall-harness/BASELINE.json` through the ratchet gate PR #689 established. Every other file this PR touches is a coupling-sweep consequence of that one flip, reasoned through individually below.

### Why flip it now, given #689 parked it on measured evidence

PR #689's v2 A/B (N=126 queries) found prefixes=off p@3=0.992/MRR=0.949 vs prefixes=on p@3=0.976/MRR=0.946 — Δp@3 -0.016 (2 of 126 queries), ΔMRR -0.003, SE=±0.000 across 3 runs both arms. Stated plainly: that delta is noise-scale at this instrument's N, not a directional signal. It never showed the hoped-for bump, but it also never showed a real regression either.

Given the recall measurement alone was a wash, this PR flips on strategic grounds instead:
- **Training-convention alignment** — nomic-embed-text-v1.5 is trained expecting `search_document:`/`search_query:` prefixes. Running it unprefixed indefinitely is the actual departure from convention, not the reverse.
- **Proving payload for the boot-keyed auto-migration machinery** (flair#690, flair#695) — this flip is the first real detect-stale/re-embed cycle that machinery has ever had to run for real (it shipped in #689 as live, always-registered plumbing with nothing to detect while the gate stayed off). Exercising it now, on a change with a proven noise-scale recall floor, is lower-risk than letting it sit unexercised until some future higher-stakes migration needs it first.
- **Avoiding compound migration debt** — landing this stamp bump alone, now, instead of letting it stack with a future unrelated embedding-model change.

### The auto-migration consequence (by design)

Flipping the gate changes `getModelId()`'s output (`<base>+searchprefix` now applies by default). Every row written before this PR was stamped with the bare base id, so it now reads as stale — the boot-keyed auto-migration runner (`resources/migrations/embedding-stamp.ts`, always-registered, previously a no-op because nothing was ever stale) picks these rows up and re-embeds them automatically on the next boot that reaches them. **This is intended, not incidental** — it's this migration's first real payload since it shipped.

A live production instance re-embedding on upgrade remains a separate, deliberate operational step from shipping this code — flipping this constant does not itself touch any running deployment; it changes what a future boot's auto-migration cycle will do.

## Coupling sweep

THE GATE is the single chokepoint both `buildEmbedOptions()` (inputType forwarding) and `getModelId()` (`+searchprefix` suffix) read — they can never diverge by construction. Flipping it ripples through every test/lane that pinned a stamp to the old gate-off value. Swept and reasoned through individually (not pattern-replaced):

- **`resources/embeddings-provider.ts`** — THE GATE flipped to `true`; doc block rewritten honestly (enablement rationale, noise-scale delta stated plainly); the bench-only harness hatch (`FLAIR_RECALL_HARNESS_FORCE_PREFIX`) made bidirectional (reads `"true"`/`"false"`, unset defers to the gate) so it stays correct regardless of which way the gate defaults, now or in the future.
- **`src/cli.ts`** (`flair reembed --stale-only`'s duplicated-literal mirror) — flipped identically; drift-warning comment kept accurate.
- **`resources/migrations/embedding-stamp.ts`** — doc block rewritten: this migration is no longer a no-op; it's now the mechanism actually re-embedding every pre-flip row.
- **`test/bench/recall-harness/run.ts`** — the `--prefixes on|off` harness hatch inverted (the `off` arm now needs the force-off hatch; `on` is the real default, no hatch); the mixed-space canary's two phases swapped which one needs the hatch; headline/PREFIX-A/B console wording updated to reflect on-as-default.
- **`test/unit/embeddings-provider-input-type.test.ts`** — default-state describe block inverted (gate-on: forwards + suffixed); the invariant sweep extended to cover all three reachable override states (unset/true/false), not just two.
- **`test/integration/migrations-resume-after-kill.test.ts`** — the pinned isolation stamp is now *derived* by calling the real `getModelId()` at test-file load time (not hardcoded), so it can't silently drift from whichever way the gate is set.
- **`.github/workflows/migration-ci-lanes.yml`** (downgrade-and-revert lane) — same isolation pattern, mirrored in bash (CI shell can't `import` a TS module): `PINNED_EMBEDDING_STAMP="${PINNED_EMBEDDING_MODEL}+searchprefix"`.
- **Reasoned through, no change needed** (each independently verified against the actual assertions, not assumed):
  - `test/integration/migrations-halt-space.test.ts` — the space-precheck halts the ENTIRE migration cycle before any migration (including embedding-stamp) writes anything; the seeded stub stamp's value is irrelevant to this test.
  - `test/integration/migrations-synthetic-e2e.test.ts` — its `"test-stub"` stamp never matched the real model id either before or after the flip; embedding-stamp already contended with it and the test already tolerated that (this is the exact 8-row/9.1s case migrations-resume-after-kill's own header cites).
  - `test/integration/migrations-embedding-stamp-e2e.test.ts` — asserts the stamp is `typeof string` and `!== "some-ancient-model-v0"`, never a hardcoded current value.
  - `.github/workflows/test.yml` (upgrade-smoke lane) — its `'upgrade-lane-stub-stamp'` is deliberately, permanently stale on purpose (opposite choice from the downgrade lane); its assertions check migration completion/ledger/recall, never a stamp equality.
  - `test/unit/migrations-embedding-stamp.test.ts`, `migrations-export.test.ts`, `migrations-source-fields.test.ts`, `memory-integrity.test.ts`, `memory-bootstrap-scoping.test.ts`, `dedup-supersede-e2e.test.ts` — all inject/mock their own `getCurrentModelId`/`getModelId`, fully decoupled from the real gate.

## Fresh A/B (post-flip, isolated recall-harness, v2 corpus)

`--corpus v2 --runs 3 --hybrid both --prefixes both`, scoring=raw. Variance ±0.000 across all 3 runs in every arm; both hybrid modes byte-identical:

```
── PREFIX A/B, hybrid=true (identical numbers under hybrid=false) ──
  prefixes=off (comparison, via force-off hatch)  p@3=0.992 ± 0.000   MRR=0.949 ± 0.000
  prefixes=on  (shipped default)                  p@3=0.976 ± 0.000   MRR=0.946 ± 0.000
  Δ (on − off)   p@3=-0.016   MRR=-0.003
  by kind (on − off, MRR):
    stress (n=17) off=0.971  on=0.961  Δ=-0.010
    trap   (n=34) off=0.943  on=0.930  Δ=-0.013
    hard   (n=46) off=0.924  on=0.946  Δ=+0.022
    clean  (n=29) off=0.983  on=0.957  Δ=-0.026
  per-cluster MRR movers (on − off, 23 of 30 clusters flat):
    gained: CERAMICS +0.250, PERFUMERY +0.250, FINOPS +0.017
    lost:   WINEMAKING -0.375, AVIATION -0.250, MUSICPROD -0.017, GITWF -0.010
```

These numbers reproduce PR #689's original v2 A/B byte-for-byte — expected: this flip changes which arm ships by default, not the embedding math either arm computes. Full writeup + composite-vs-raw context: `test/bench/recall-harness/README.md`'s "Post-flip re-baseline" section.

## New BASELINE.json

```json
{
  "corpusVersion": "v2",
  "config": { "hybrid": true, "prefixes": true, "scoring": "raw" },
  "aggregate": { "p@3": 0.976, "mrr": 0.946 },
  "perKind": {
    "hard": { "n": 46, "mrr": 0.946 },
    "trap": { "n": 34, "mrr": 0.930 },
    "clean": { "n": 29, "mrr": 0.957 },
    "stress": { "n": 17, "mrr": 0.961 }
  },
  "measuredAt": "2026-07-12",
  "commit": "ddc6e7b"
}
```

## Suites

- `bun test test/unit` — 2152 pass, 14 fail. All 14 failures are in `test/unit/migrations-runner.test.ts` and trace to `resources/migrations/space.ts`'s 90% disk-headroom pre-flight check tripping on this host's actual disk state — reproduces **byte-for-byte, same 14 tests, same error strings**, on a clean `origin/main` worktree with no changes applied. Confirmed environmental, not introduced by this PR.
- `bun test test/integration` — 281 pass, 6 fail, same root cause (all 6 trace to the identical "blocked on disk" halt from `space.ts`). Reproduced identically on a clean `origin/main` worktree (same 6 tests, same messages) before being classified environmental. This host's `$HOME` volume (`/System/Volumes/Data`) sits at ~91-95% capacity independent of `/`'s 42-54% — the exact condition the dispatch anticipated.
- `tsc --noEmit -p tsconfig.check.json` / `tsconfig.check.src.json` / `tsconfig.cli.json` — all three clean.

## Deviations

- Two commits instead of one: `ddc6e7b` (the gate flip + full coupling sweep) then `3784f7f` (BASELINE.json only). BASELINE.json's `commit` field needs a real SHA to point at (matching the existing convention — the prior baseline pointed at PR #689's `f4f5092`, an ancestor commit, not itself), which is only known after the first commit exists — avoids amending or a placeholder value.
- The mixed-space canary (`--canary`) was not re-run; the task's re-measure requirement was the 3-run/2-hybrid-mode/2-prefix-arm/raw-scoring sweep, which this PR ran in full. The existing canary numbers are marked historical in the README (same section note covering the v1/v2 measured-results sections).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
