### PR TITLE
bench(recall-harness): --model-file GGUF override + per-kind MRR and seed-latency reporting

### DIFF
--- a/resources/embeddings-boot.ts
+++ b/resources/embeddings-boot.ts
@@ -89,6 +89,35 @@ import { resolveModelsDir } from "./embeddings-provider.js";
 const LOGICAL_NAME = "default";
 const MODEL_NAME = "nomic-embed-text";
 
+/**
+ * BENCH-ONLY escape hatch — NOT a production feature flag, never documented
+ * as an operator setting, and never read anywhere else in this codebase.
+ * Mirrors `embeddings-provider.ts`'s `FLAIR_RECALL_HARNESS_FORCE_PREFIX`
+ * hatch (see that file's header for the pattern this follows): a bench-only
+ * env var, read lazily, that lets `test/bench/recall-harness/run.ts`'s
+ * `--model-file <path>` flag override model SELECTION the same way that
+ * hatch overrides prefix behavior — without editing this file's hardcoded
+ * `MODEL_NAME`/`resolveModelsDir()` call every time a bakeoff needs a
+ * different GGUF (e.g. a Q8_0 quant of the same base model).
+ *
+ * This is not a new capability grafted on — `harper-fabric-embeddings`'
+ * `register()` factory already accepts `config.modelPath` as an alternative
+ * to `modelName`+`modelsDir` (see `engineOptionsFromConfig()` in
+ * `harper-fabric-embeddings`' `dist/index.js`): an absolute path bypasses its
+ * built-in model registry and HuggingFace-download resolution entirely. This
+ * hatch is the one line that lets a caller reach that existing parameter.
+ * `EmbeddingEngine`'s `modelIdentity` (used for nomic-prefix detection, see
+ * `engine.js`'s `#applyPrefix`) becomes the file's basename in this path, so
+ * prefix behavior is unaffected as long as the GGUF's filename still
+ * contains "nomic-embed-text".
+ *
+ * No production deploy sets this env var, so the unset (overwhelmingly
+ * common) case is byte-identical to before this hatch existed.
+ */
+function benchModelPathOverride(): string | undefined {
+  return process.env.FLAIR_RECALL_HARNESS_MODEL_PATH || undefined;
+}
+
 let registered = false;
 
 /**
@@ -101,10 +130,11 @@ export async function registerEmbeddingsBackend(): Promise<void> {
   registered = true;
   try {
     const { register } = await import("harper-fabric-embeddings");
+    const modelPath = benchModelPathOverride();
     await register({
       logicalName: LOGICAL_NAME,
       kind: "embedding",
-      config: { modelName: MODEL_NAME, modelsDir: resolveModelsDir() },
+      config: modelPath ? { modelPath } : { modelName: MODEL_NAME, modelsDir: resolveModelsDir() },
     });
   } catch (err) {
     // Not installed, or globalThis.models isn't ready (module loaded outside

--- a/test/bench/recall-harness/README.md
+++ b/test/bench/recall-harness/README.md
@@ -98,6 +98,7 @@ export FLAIR_MODELS_DIR=/path/to/an/existing/flair/checkout/models
 | `--verbose`       | off     | Print every query's rank (hit/miss, kind, marker) under `--runs`. |
 | `--keep-on-fail`  | off     | On a fatal error, print a reminder to inspect (the ephemeral installDir itself is NOT preserved automatically — see caveat below). |
 | `--corpus v1\|v2` | `v1`    | Which eval instrument to run against — see "Eval instrument v2" below. `v1` (`corpus.ts`) is the default so a bare invocation with no flag reproduces every number already published in this file, byte-for-byte, forever. `v2` (`corpus-v2.ts`) is the larger, harder standing gate for future embedding/scoring changes. |
+| `--model-file <path>` | unset | Bench-only GGUF override for A/B'ing a different quant/model of the same family (e.g. a Q8_0 requant) without a code change. Sets `FLAIR_RECALL_HARNESS_MODEL_PATH`, forwarded to the spawned Harper process; `resources/embeddings-boot.ts`'s `benchModelPathOverride()` passes it straight through to `harper-fabric-embeddings`' `register()` as `config.modelPath`, which that package already supports as an alternative to `modelName`+`modelsDir` (bypasses its registry + HuggingFace-download resolution entirely). One value per invocation, not swept per-config — compare two GGUFs by running the harness twice and comparing the aggregate reports, the same way you'd compare against `BASELINE.json`. Unset (the default) is byte-identical to before this flag existed. |
 
 ## Interpreting the output
 

--- a/test/bench/recall-harness/run.ts
+++ b/test/bench/recall-harness/run.ts
@@ -132,6 +132,27 @@ if (CORPUS_ARG !== "v1" && CORPUS_ARG !== "v2") {
   process.exit(2);
 }
 const { CORPUS, QUERIES } = CORPUS_ARG === "v2" ? CorpusV2 : CorpusV1;
+// bench-only model-file override (Q4/Q8 GGUF A/B — see
+// resources/embeddings-boot.ts's `benchModelPathOverride()` for the mechanism
+// this flag drives): an absolute or cwd-relative path to a GGUF file,
+// forwarded to the spawned Harper process as FLAIR_RECALL_HARNESS_MODEL_PATH
+// so harper-fabric-embeddings' `register()` loads THAT file directly
+// (bypassing its modelName/modelsDir registry+download resolution) for every
+// config this invocation runs. Unset (the default) keeps the existing
+// resolveModelsDir()+modelName path — byte-identical to before this flag
+// existed. One value per invocation, not swept per-config like
+// hybrid/prefixes/rerank: comparing two GGUF files means comparing two
+// separate harness invocations' aggregate numbers, not two arms measured
+// against the same seeded corpus.
+const MODEL_FILE_ARG = argVal("--model-file", "");
+if (MODEL_FILE_ARG) {
+  const resolvedModelFile = path.resolve(MODEL_FILE_ARG);
+  if (!existsSync(resolvedModelFile)) {
+    console.error(`FATAL: --model-file ${resolvedModelFile} does not exist.`);
+    process.exit(2);
+  }
+  process.env.FLAIR_RECALL_HARNESS_MODEL_PATH = resolvedModelFile;
+}
 // Every topic cluster present in whichever corpus got selected — drives the
 // per-cluster reporting breakdown below. Computed once at module load since
 // CORPUS is fixed for the whole process (selected by --corpus above).
@@ -296,7 +317,19 @@ async function runOnce(hybrid: boolean, rerank: boolean, prefixesOn: boolean, ru
     const agent = mkAgent(AGENT_ID);
     await registerAgent(harper, agent);
     console.log(`${label} seeding ${CORPUS.length} records...`);
+    // Wall-clock the seed pass — a simple, comparable embed-latency proxy for
+    // A/B'ing model files (--model-file): each seedRecord's PUT awaits
+    // embedding generation before responding (Memory.put()'s contract, see
+    // waitSearchable's comment below), and the native engine serializes embed
+    // calls on its own internal queue (engine.js's `#queue`) even though
+    // seedCorpus fires BATCH=6 concurrent HTTP requests — so total elapsed
+    // divided by record count is a cleaner per-embed estimate than timing any
+    // single concurrent PUT in isolation (which would include queueing wait
+    // behind its batch-mates, not pure compute).
+    const seedStart = performance.now();
     await seedCorpus(harper, agent);
+    const seedMs = performance.now() - seedStart;
+    console.log(`${label} seeded ${CORPUS.length} records in ${seedMs.toFixed(0)}ms (${(seedMs / CORPUS.length).toFixed(1)}ms/record avg)`);
     await waitSearchable(harper, agent);
     console.log(`${label} corpus searchable, measuring ${QUERIES.length} queries × 2 scoring modes...`);
 
@@ -377,6 +410,7 @@ async function main() {
   console.log(`recall-harness — ISOLATED recall eval (corpus=${CORPUS_ARG}: ${CORPUS.length} records / ${CLUSTERS.length} clusters, queries=${QUERIES.length})`);
   console.log(`config: runs=${RUNS} hybrid=${hybridValues.join(",")} prefixes=${prefixValues.map(p => p ? "on" : "off").join(",")} rerank=${WITH_RERANK ? "on(hybrid=true,prefixes=true only)+off" : "off"}\n`);
   if (process.env.FLAIR_MODELS_DIR) console.log(`FLAIR_MODELS_DIR=${process.env.FLAIR_MODELS_DIR} (reusing pre-downloaded models)\n`);
+  if (MODEL_FILE_ARG) console.log(`--model-file ${process.env.FLAIR_RECALL_HARNESS_MODEL_PATH} (overriding model selection for this invocation)\n`);
 
   // Build the (hybrid, rerank, prefixesOn) config list. rerank is opt-in and
   // only ever tested alongside hybrid=true, prefixes=true (the
@@ -435,6 +469,20 @@ async function main() {
       const agg = results[key][scoring];
       const p3 = aggStats(agg.p3), mrr = aggStats(agg.mrr);
       console.log(`  scoring=${scoring.padEnd(9)} p@3=${fmtAgg(p3)}   MRR=${fmtAgg(mrr)}`);
+    }
+    // Per-kind MRR for scoring=raw — same shape as BASELINE.json's `perKind`
+    // block (n + mrr per kind), so a model/quant A/B's per-kind numbers are
+    // directly diffable against that file without re-deriving them from the
+    // p@3-only composite-vs-raw breakdown printed below. Collected in the same
+    // loop as everything else above (agg.byKind[k].mrr) — this just prints
+    // data that already existed but had no standalone print site.
+    {
+      const rawAgg = results[key].raw;
+      const parts = (["stress", "trap", "hard", "clean"] as QueryKind[]).map(k => {
+        const n = QUERIES.filter(q => q.kind === k).length;
+        return `${k}(n=${n})=${fmtAgg(aggStats(rawAgg.byKind[k].mrr))}`;
+      });
+      console.log(`  scoring=raw per-kind MRR: ${parts.join("  ")}`);
     }
     const rawP3 = aggStats(results[key].raw.p3), compP3 = aggStats(results[key].composite.p3);
     const rawMrr = aggStats(results[key].raw.mrr), compMrr = aggStats(results[key].composite.mrr);


### PR DESCRIPTION
Bench-only tooling from the Q8 requant A/B (flair#504 model strategy): a `--model-file <path>` flag on the recall harness (forwarded via a bench-only env hatch to the embeddings boot, same double-guard pattern as the existing force-prefix hatch — unset means byte-identical production behavior), per-kind MRR printed in BASELINE.json shape, and seed-pass wall-clock (ms/record) for embed-latency comparisons. This is the instrument extension that makes model bakeoffs one-command: measured Q8_0 vs Q4_K_M with it (Q8: +0.008 p@3, +0.004 MRR, zero per-kind regressions, ~38% faster per embed on M4, +62MB disk). Typechecks + embeddings unit tests green; hooks green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)