### PR TITLE
release: include flair-bench in the publish set

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -18,6 +18,11 @@ name: Release — stage-publish (OIDC) + GitHub release
 #   org=tpsdev-ai, repo=flair, workflow=release-publish.yml, environment=release
 # and allow ONLY "npm stage publish". The `release` GitHub environment must permit
 # `v*` tag deploys.
+#
+# flair-bench is version-bumped/tagged with the other 7 but stages in its own
+# continue-on-error step below — it needs a one-time first manual publish +
+# Trusted Publisher registration before `npm stage publish` will work for it
+# (see docs/releasing.md's "flair-bench bootstrap" section).
 
 on:
   push:
@@ -137,6 +142,7 @@ jobs:
             packages/pi-flair/package.json
             packages/n8n-nodes-flair/package.json
             packages/langgraph-flair/package.json
+            packages/flair-bench/package.json
           )
           for pj in "${PKG_JSONS[@]}"; do
             name="$(node -p "require('./$pj').name")"
@@ -178,6 +184,25 @@ jobs:
             echo "::endgroup::"
           done
 
+      - name: Stage-publish flair-bench (bootstrap-pending — isolated on purpose)
+        # `npm stage publish` requires the package already exist on the npm
+        # registry (npm-stage(1): "Package must exist"), and a Trusted Publisher
+        # can only be registered for a package that already exists — so this
+        # step WILL fail until a maintainer does the one-time bootstrap in
+        # docs/releasing.md (first manual `npm publish` of @tpsdev-ai/flair-bench,
+        # then register its Trusted Publisher). `continue-on-error: true` keeps
+        # that expected failure from aborting the other 7 packages' staging (the
+        # loop above runs under `set -euo pipefail` with no per-package
+        # isolation — a hard failure here would kill the whole job). Remove
+        # continue-on-error once the bootstrap is confirmed done and this step
+        # has staged flair-bench successfully at least once.
+        continue-on-error: true
+        run: |
+          set -euo pipefail
+          echo "::group::npm stage publish — @tpsdev-ai/flair-bench (packages/flair-bench)"
+          ( cd packages/flair-bench && npm stage publish )
+          echo "::endgroup::"
+
       - name: Summary
         env:
           VERSION: ${{ steps.ver.outputs.version }}
@@ -185,8 +210,13 @@ jobs:
           {
             echo "### 🚀 v$VERSION staged for release"
             echo ""
-            echo "All 7 workspace packages submitted to npm **staging** with provenance."
-            echo "They are **not live yet**."
+            echo "All 7 lockstep-versioned workspace packages submitted to npm **staging**"
+            echo "with provenance. They are **not live yet**."
+            echo ""
+            echo "flair-bench is included in the version bump/tag but stages in its own"
+            echo "step, which is allowed to fail until the one-time first-publish +"
+            echo "Trusted Publisher bootstrap in docs/releasing.md is done (check the"
+            echo "'Stage-publish flair-bench' step above for its actual result)."
             echo ""
             echo "**To release:** open [npmjs.com → Staged Packages](https://www.npmjs.com/settings/tpsdev-ai/staging),"
             echo "review each tarball, and approve with 2FA. Or: \`npm stage list\` then \`npm stage approve <id>\`."

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -1,9 +1,13 @@
 # Releasing Flair
 
-Flair publishes seven workspace packages to npm under `@tpsdev-ai/*`. Releases are
+Flair publishes eight workspace packages to npm under `@tpsdev-ai/*`. Releases are
 **tokenless** and **staged**: CI authenticates to npm with a short-lived OIDC token
 (no `NPM_TOKEN` lives anywhere) and submits each package to npm's **staging** area.
 A maintainer then approves the staged tarballs on npmjs.com with 2FA to make them live.
+
+> `flair-bench` is version-bumped and tagged in lockstep with the other 7, but stages
+> in its own step in CI (allowed to fail) until its one-time bootstrap is done — see
+> [flair-bench bootstrap](#flair-bench-bootstrap-one-time) below.
 
 ```
  merge release PR ──▶ push tag v0.11.0 ──▶ CI stages all packages ──▶ npm staging
@@ -78,9 +82,10 @@ npm stage view <stage-id> # inspect one
 npm stage approve <stage-id>   # 2FA prompt; package goes live
 ```
 
-There are seven packages, so there are seven approvals (the web UI lists them on one
-page). Approve in dependency order if installing immediately — flair-client before its
-dependents — though staging does not itself resolve dependencies.
+There are seven lockstep-staged packages, so seven approvals (the web UI lists them on
+one page). Approve in dependency order if installing immediately — flair-client before
+its dependents — though staging does not itself resolve dependencies. `flair-bench`
+stages separately and only appears here once its bootstrap (below) is done.
 
 Verify when done:
 
@@ -115,6 +120,28 @@ Packages: `flair-client`, `flair-mcp`, `flair`, `openclaw-flair`, `pi-flair`,
 
 > A package must already exist on npm before a trusted publisher can be added — all
 > seven already do. This account-level config can only be done by an npm org owner.
+> `flair-bench` doesn't exist on npm yet (verified via `npm view @tpsdev-ai/flair-bench`
+> → 404 as of 2026-07-13) so it can't have a Trusted Publisher yet either — see below.
+
+### `flair-bench` bootstrap (one-time)
+
+`flair-bench` (added 2026-07-12, flair#702) is wired into the version-bump/tag flow
+(`scripts/release.sh`, `release-publish.yml`'s version-check) alongside the other 7, but
+`npm stage publish` categorically requires the package already exist on the npm registry
+(`npm help stage`: "Package must exist"), and a Trusted Publisher can only be registered
+for a package that already exists — chicken-and-egg for a brand-new package. Until an npm
+org owner does this once, the workflow's dedicated "Stage-publish flair-bench" step is
+expected to fail (it's `continue-on-error: true` so it doesn't block the other 7):
+
+1. From a machine logged into npm with 2FA: `cd packages/flair-bench && npm run build &&
+   npm publish --access public` — one normal (non-staged) publish to create the package
+   on the registry. Any valid semver works; the very next lockstep release will bump it
+   to match the other 7 automatically (it's in `scripts/release.sh`'s `PACKAGES` array).
+2. Add the Trusted Publisher for `@tpsdev-ai/flair-bench` using the same table as the
+   other 7 above (org=`tpsdev-ai`, repo=`flair`, workflow=`release-publish.yml`,
+   environment=`release`, allowed=`npm stage publish` only).
+3. Remove `continue-on-error: true` from the "Stage-publish flair-bench" step in
+   `release-publish.yml` once a tag push has staged it successfully.
 
 ### GitHub `release` environment
 

--- a/packages/flair-bench/LICENSE
+++ b/packages/flair-bench/LICENSE
@@ -1,0 +1,19 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   Copyright 2026 TPS Dev AI
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -38,6 +38,7 @@ PACKAGES=(
   "$ROOT/packages/pi-flair"
   "$ROOT/packages/n8n-nodes-flair"
   "$ROOT/packages/langgraph-flair"
+  "$ROOT/packages/flair-bench"
   "$ROOT"
 )
 
@@ -48,6 +49,7 @@ PACKAGE_JSONS=(
   "$ROOT/packages/pi-flair/package.json"
   "$ROOT/packages/n8n-nodes-flair/package.json"
   "$ROOT/packages/langgraph-flair/package.json"
+  "$ROOT/packages/flair-bench/package.json"
   "$ROOT/package.json"
 )
 
@@ -140,6 +142,14 @@ if [[ "$MODE" == "--publish" ]]; then
 
   echo "  Publishing @tpsdev-ai/langgraph-flair..."
   (cd "$ROOT/packages/langgraph-flair" && npm publish) || { echo "⚠️  langgraph-flair publish failed (may need build step)"; }
+
+  echo "  Publishing @tpsdev-ai/flair-bench..."
+  # NOTE: until the one-time bootstrap in docs/releasing.md is done (first
+  # manual publish + npm Trusted Publisher registration for this package),
+  # this is expected to fail on brand-new installs of the package — see PR
+  # that added this line for context. Soft-fail like the other prepublishOnly
+  # leaf packages above so a break-glass publish of the other 7 isn't blocked.
+  (cd "$ROOT/packages/flair-bench" && npm publish) || { echo "⚠️  flair-bench publish failed (may need build step, or first-publish bootstrap — see docs/releasing.md)"; }
 
   echo "🏷️  Tagging v${VERSION} on main..."
   git -C "$ROOT" tag -a "v${VERSION}" -m "Release v${VERSION}"
@@ -266,6 +276,7 @@ git -C "$ROOT" add \
   "$ROOT/packages/pi-flair/package.json" \
   "$ROOT/packages/n8n-nodes-flair/package.json" \
   "$ROOT/packages/langgraph-flair/package.json" \
+  "$ROOT/packages/flair-bench/package.json" \
   "$ROOT/bun.lock"
 
 # Also stage CHANGELOG.md and scripts/release.sh if they have pre-staged changes —


### PR DESCRIPTION
## Evidence chain

**Release mechanism found:** scripts/release.sh (local two-phase bump-PR / publish) and .github/workflows/release-publish.yml (tag-triggered OIDC staged-publish, tokenless, npm stage publish + 2FA approval — see docs/releasing.md).

**Enumeration checked:** both scripts hardcode which workspace packages get bumped/verified/published. flair-bench (packages/flair-bench, added 2026-07-12 in flair#702) was in neither list:
- scripts/release.sh: absent from PACKAGES and PACKAGE_JSONS arrays, and from the Phase-2 npm publish steps.
- release-publish.yml: absent from PKG_JSONS (version-verify) and DIRS (npm stage publish loop).

Both files were last touched 2026-07-06 — before flair-bench existed. This is an oversight, not an intentional exclusion (docs/releasing.md says "seven" packages throughout).

**Verdict: would NOT publish on the next v* tag**, confirmed by:
- `node scripts/check-workspace-deps.mjs` counts 8 workspace packages, but neither release list matched.
- `npm pack --dry-run` in packages/flair-bench produced a sane 31-file, ~69kB tarball (bin present, corpus data compiled in via tsc, no junk) — the package itself is fine, it just never gets invoked by the release flow.
- `npm view @tpsdev-ai/flair-bench` returns 404. The package does not exist on the npm registry yet at all.
- `npm help stage`: "Package must exist" is a hard prerequisite for `npm stage publish`. So even after wiring flair-bench into the enumeration, its stage-publish will fail until a maintainer does a one-time bootstrap (first manual `npm publish` + Trusted Publisher registration) — documented in the new docs/releasing.md section.

## Fix

- **scripts/release.sh** — flair-bench added to the version-bump/verify arrays and the git-add list; Phase 2 publishes it with the same soft-fail pattern (warn "may need build step") already used for the other prepublishOnly leaf packages (openclaw-flair/pi-flair/langgraph-flair) — flair-bench has no internal @tpsdev-ai/* dependency to align, matching that same shape.
- **release-publish.yml** — flair-bench added to the version-check array (PKG_JSONS). Its `npm stage publish` runs in a separate `continue-on-error: true` step, not the shared hard loop — the existing loop has zero per-package error isolation under `set -euo pipefail`, so appending a package guaranteed to fail pre-bootstrap would have aborted staging for the other 7 on every tag push until the bootstrap happens. Isolating it avoids that regression.
- **docs/releasing.md** — 7 to 8 packages; new "flair-bench bootstrap (one-time)" section with the exact steps a maintainer (npm org owner, 2FA) needs to run once.
- **packages/flair-bench/LICENSE** — `files` listed "LICENSE" and package.json set `"license": "Apache-2.0"`, but the physical file was missing from the package directory, so it silently dropped out of every tarball. Copied from root LICENSE. (Found the same gap in pi-flair and langgraph-flair — pre-existing, left alone, out of scope here.)

## Validation

```
$ npm pack --dry-run   (packages/flair-bench, after LICENSE fix)
...
npm notice 804B LICENSE
...
npm notice total files: 31
npm notice package size: 69.3 kB
npm notice unpacked size: 221.0 kB
```

Installed the real packed tarball (`npm pack`, not dry-run) into an isolated directory via `npm install <tarball>` and ran the CLI from `node_modules/.bin/flair-bench --help` — prints full usage correctly.

`bash -n scripts/release.sh` (syntax), a js-yaml parse of the workflow (structure), `node scripts/check-workspace-deps.mjs` (still green, now counts 8), and `scripts/check-impl-term-leaks.sh` (no leaks) all pass.

## What this PR does NOT do

Does not make flair-bench publishable live on the next tag by itself — the one-time bootstrap (manual first publish + Trusted Publisher setup, both requiring npm org-owner access + 2FA) is a human action documented in docs/releasing.md, not something this PR can do. Until that happens, the "Stage-publish flair-bench" step will show a red/failed-but-ignored status in the Actions run — expected, and called out in the workflow's own Summary step.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
