### PR TITLE
feat(rem): nightly runner step 5 + CLI execute-mode flip + docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,13 +67,13 @@ If you need any of those specifically, use them. If you need crypto-pinned ident
 
 Anthropic shipped [Claude Dreams](https://platform.claude.com/docs/en/managed-agents/dreams) (research preview, April 2026) — async pipeline that reads a memory store + session transcripts and produces a curated output store: duplicates merged, stale entries replaced, insights surfaced. Validates the category: agent memory accumulates drift and needs cleanup.
 
-Flair ships both the on-demand curation surface (`flair rem rapid`) AND the scheduled nightly cycle in v0.9.0, per the [FLAIR-NIGHTLY-REM spec](specs/FLAIR-NIGHTLY-REM.md).
+Flair ships both the on-demand curation surface (`flair rem rapid`) AND the scheduled nightly cycle, per the [FLAIR-NIGHTLY-REM spec](specs/FLAIR-NIGHTLY-REM.md) and its [in-process distillation slice](specs/FLAIR-NIGHTLY-REM-SLICE-2-DISTILLATION.md). Config recipe (Ollama zero-key default, hosted-provider egress warning, clustered-deploy rules): [`docs/rem.md`](docs/rem.md).
 
-- **`flair rem rapid`** — on-demand reflection. `--focus {lessons_learned, patterns, decisions, errors}` mirrors Dreams' `instructions` parameter. Outputs *candidates*, not a wholesale store swap.
+- **`flair rem rapid`** — reflects and distills server-side by default, staging candidates in one bounded call. `--focus {lessons_learned, patterns, decisions, errors}` mirrors Dreams' `instructions` parameter. `--prompt-only` falls back to the bring-your-own-model handoff. Outputs *candidates*, not a wholesale store swap.
 - **`flair rem candidates` / `flair rem promote <id> --rationale "<why>"` / `flair rem reject <id>`** — review and promote distilled candidates with required rationale.
-- **`flair rem nightly enable [--at HH:MM]`** — scheduled automation via platform-native scheduler (launchd / systemd). Pre-cycle snapshot to `~/.flair/snapshots/<agent>/<iso>.tar.gz`. Maintenance step (soft-delete expired + soft-archive stale). Audit log to `~/.flair/logs/rem-nightly.jsonl`. `flair rem pause` / `resume` for emergency stop.
+- **`flair rem nightly enable [--at HH:MM]`** — scheduled automation via platform-native scheduler (launchd / systemd). Pre-cycle snapshot to `~/.flair/snapshots/<agent>/<iso>.tar.gz`. Maintenance (soft-delete expired + soft-archive stale) and distillation (staged candidates) both run each cycle. Audit log to `~/.flair/logs/rem-nightly.jsonl`. `flair rem pause` / `resume` for emergency stop.
 - **`flair rem restore <date> --apply`** — rewinds Harper state to a snapshot. Takes a pre-restore snapshot of current state first, so the rewind itself is reversible.
-- *Slice-3 (1.1)* — automated server-side distillation (requires pluggable LLM provider), trust-tier filter on REM input, cross-agent restore. Until then, distillation is operator-triggered via `flair rem rapid` followed by manual promote/reject.
+- *Next* — trust-tier filter on REM input, cross-agent restore. Until the trust-tier arc lands, the input filter stays scope-based (own agent, non-archived, non-permanent, scope window); the structural safety net is unchanged either way — candidates are staged, never auto-promoted.
 
 The substantive difference is the **promotion contract**:
 

--- a/docs/notes/rem-ux.md
+++ b/docs/notes/rem-ux.md
@@ -1,0 +1,39 @@
+# REM UX — trigger model, attach semantics, review loop
+
+> Design note accompanying REM slice 2 (#707). Describes the intended user experience of in-process distillation so the CLI/docs surfaces stay coherent as the feature grows. Parent spec: `specs/FLAIR-NIGHTLY-REM.md`; slice spec: `specs/FLAIR-NIGHTLY-REM-SLICE-2-DISTILLATION.md`.
+
+## Triggers — three, nothing implicit
+
+1. **Interactive:** an agent (or a human at the CLI) runs `flair rem rapid` — one bounded distillation of that agent's own recent memories. Non-admin actors can only reflect on themselves; an admin can run it for any agent.
+2. **Scheduled:** the nightly cycle, per agent, only where deliberately enabled (`flair rem nightly enable`). In a multi-node deploy, exactly one node gets the timer (see #709).
+3. **Admin-run:** same endpoint, another agent's corpus, admin credentials.
+
+REM never fires as a side effect of writes, searches, or boot. Distillation is always a deliberate act with an audit trail.
+
+## Locality — the model call runs next to the data
+
+The CLI is a thin HTTP trigger pointed at whatever Flair instance it is configured for (local or remote). Distillation executes **server-side** in the Flair component via Harper's model-access API. Consequences:
+
+- Memory content never transits the operator's machine on its way to a model.
+- Data egress is determined solely by the *server's* `models:` configuration — a local backend means nothing leaves the box; a hosted provider is an explicit, documented choice (keys ride Harper env-secret encryption on managed deploys).
+- The same trigger UX works identically against a laptop instance and a managed deployment.
+
+## Attach semantics — synchronous now, and the rule for when that changes
+
+**Interactive mode stays attached.** One request, one bounded generate call (gather cap 50 memories, bounded output tokens), a staged-candidate summary printed on return. Seconds, not minutes — request/response is the honest shape for it, and `--prompt-only` preserves the bring-your-own-model handoff.
+
+**Nightly mode is fully detached.** The scheduler fires the cycle; results land as pending candidates plus an audit row; the operator reviews next morning.
+
+**The rule for revisiting:** any run shape that exceeds a single bounded generate call — hierarchical/recursive consolidation, org-level REM across many agents — gets a real job model (run id, `flair rem status <id>`, resumability) *designed before that slice ships*. The failure mode to avoid is a timeout bug forcing an ad-hoc job system into existence.
+
+## The review loop — where REM's UX actually lives
+
+Distillation is the cheap half; the reviewable stream of candidates is the product surface:
+
+- **Today (CLI):** `flair rem candidates` lists pending rows; `flair rem promote <id> --rationale` / `flair rem reject <id> --reason` decide them. Every candidate carries its claim, source memory ids, generating model, and timestamp — enough to judge provenance at a glance.
+- **Direction:** a reviewable feed — candidates as a stream with one-glance provenance and one-action promote/reject, recurring rejected claims surfaced via their `supersedes` chains rather than appearing fresh each time. The nightly diff report should point at that surface, making morning review a two-minute ritual instead of a CLI expedition.
+- **Invariant either way:** nothing self-promotes. The feed can get faster and friendlier; the explicit-decision gate is load-bearing and stays.
+
+## Configuration UX — one decision, one knob
+
+Wanting REM should reduce to: *point the server's `models:` block at a backend.* Local Ollama works with zero credentials; a hosted provider takes an API key stored as an encrypted env secret. `FLAIR_REM_MODEL` selects a logical model name when the default routing isn't right. There is no REM-specific provider code, wiring, or plugin to install — if the server can `generate()`, REM works.

--- a/docs/rem.md
+++ b/docs/rem.md
@@ -1,0 +1,57 @@
+# REM — reflection, distillation, and review
+
+REM (Reflect · Extract · Merge) is Flair's memory-curation cycle: it reads an agent's recent memories, distills them into candidate insights, and stages those candidates for explicit human/agent review — nothing is ever auto-promoted. `flair rem rapid` runs it on demand; `flair rem nightly enable` runs it on a schedule. See [`docs/notes/rem-ux.md`](notes/rem-ux.md) for the full trigger model, locality guarantees, and the review-loop UX this page's commands feed into.
+
+## Configuration
+
+Distillation runs **server-side**, via Harper's model-access API (`models.generate()`). Flair ships zero provider code — which backend answers a REM call is entirely a Harper `models:` configuration decision.
+
+The `models:` block goes in **Harper's root instance config** (`harper-config.yaml` / `harperdb-config.yaml` at the Harper data directory) — **not** in flair's own `config.yaml` component config, which Harper only loads as a non-root component config and never reads a `models:` block from.
+
+**Local Ollama (zero-key default):**
+
+```yaml
+# harper-config.yaml
+models:
+  generative:
+    default:            # unset FLAIR_REM_MODEL resolves to this logical name
+      backend: ollama
+      host: localhost:11434   # optional — already the default
+      model: llama3.1         # required — Ollama has no built-in default model
+```
+
+No credentials, nothing leaves the box (see the warning below).
+
+**Hosted provider** (OpenAI / Anthropic / Bedrock also supported — `backend: openai|anthropic|bedrock`):
+
+```yaml
+# harper-config.yaml
+models:
+  generative:
+    hosted:
+      backend: openai
+      apiKey: ${OPENAI_API_KEY}   # env-var indirection — never a literal key in YAML
+      model: gpt-4o-mini
+```
+
+A literal (non-`${VAR}`) `apiKey` in the config file is flagged at Harper boot — keep it out of the YAML on disk. On Fabric / managed deploys, the env var itself is provisioned through Harper's Fabric secrets mechanism, which encrypts the value at rest (`enc:v1:` storage format) rather than holding it in plaintext; consult Harper's Fabric secrets documentation for provisioning that env var. Flair's own [`docs/secrets-and-keys.md`](secrets-and-keys.md) covers Flair's Ed25519 agent identity and general client-side credential patterns, but does not cover this Harper-side mechanism.
+
+> **⚠️ Data egress is a configuration decision.**
+> Pointing `models:` at a hosted provider (OpenAI, Anthropic, Bedrock, or any other network backend) sends the memory content being reflected on to that provider. A local Ollama backend keeps everything on the box — nothing transits the network. Default posture: local. Choose a hosted backend deliberately, and know what leaves when you do.
+
+### `FLAIR_REM_MODEL`
+
+Selects which `models.generative.<logicalName>` entry a REM call uses. Unset → Harper's default routing (the `default` logical name above). Set it to route to a different registered backend, e.g. `FLAIR_REM_MODEL=hosted`.
+
+### Clustered deploys — nightly enable is per-node, deliberately
+
+`flair rem nightly enable` installs a platform-native timer (launchd / systemd) **on the host it runs on**. In a multi-node or Fabric deploy, enabling it on every node would run the cycle N times and scatter N sets of pre-cycle snapshots. The v1 rule: **exactly one node gets the timer** — pick it deliberately, the same way you'd pick a cron owner for any single-writer job. This is a v1 constraint, not a permanent one; see #709 for the roadmap toward a coordinated multi-node story.
+
+Snapshot locality follows from this: a nightly cycle's pre-run snapshot (`~/.flair/snapshots/<agent>/`) lands on **the node that ran that cycle** — `flair rem restore <date>` and `flair rem snapshot list` only see local snapshots. If you move which node owns the timer, snapshot history doesn't move with it.
+
+## Interactive vs nightly
+
+- **Interactive (`flair rem rapid`):** one bounded, synchronous distillation call — gather cap 50 memories, bounded output tokens, seconds not minutes. Executes by default, staging candidates and printing a summary; `--prompt-only` returns the reflection prompt instead, for the bring-your-own-model handoff.
+- **Nightly (`flair rem nightly enable` / `run-once`):** fully detached — the scheduler runs the full cycle (snapshot → maintenance → distillation), candidates land as pending rows, and an audit row lands in `~/.flair/logs/rem-nightly.jsonl`. The operator reviews in the morning via `flair rem candidates`.
+
+Either path, the review loop is the same: `flair rem candidates` lists pending rows, `flair rem promote <id> --rationale "<why>"` / `flair rem reject <id> --reason "<why>"` decide them. Nothing self-promotes — see [`docs/notes/rem-ux.md`](notes/rem-ux.md) for why that gate is load-bearing and how the surface is expected to evolve.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -5006,13 +5006,64 @@ rem
     }
   });
 
+// ─── flair rem rapid — pure helpers ──────────────────────────────────────────
+// Extracted for testability, same pattern as validatePromoteOpts /
+// decideCandidateAction above: the action callback below spawns api() +
+// process.exit, which makes it high-effort/low-value to drive directly;
+// these two functions are the actual decision logic.
+
+/** One staged-candidate summary line: `[id] claim, truncated to ~80 chars`. */
+export function formatCandidateLine(candidate: { id?: string; claim?: string }, maxClaimLen = 80): string {
+  const claim = candidate.claim ?? "";
+  const truncated = claim.length > maxClaimLen ? `${claim.slice(0, maxClaimLen)}…` : claim;
+  return `  [${candidate.id ?? "?"}] ${truncated}`;
+}
+
+/**
+ * Classifies a thrown /ReflectMemories execute-mode error for CLI display.
+ * `api()` throws `Error(responseBodyText)` for non-2xx responses (see api()
+ * above) — the two execute-mode failure bodies are:
+ *   503 no-backend:        { error: "No generative backend configured..." }
+ *   502 distillation_failed: { error: "distillation_failed", detail: "..." }
+ * Any other shape (network errors, the 400/403 actor-resolution errors
+ * prompt mode shares) falls back to "other" — printed as a plain message,
+ * no docs pointer or retry hint attached since neither applies.
+ */
+export function describeReflectError(message: string): { kind: "no-backend" | "distillation-failed" | "other"; text: string } {
+  try {
+    const parsed = JSON.parse(message);
+    if (parsed && typeof parsed === "object") {
+      if (parsed.error === "distillation_failed") {
+        return { kind: "distillation-failed", text: String(parsed.detail ?? parsed.error) };
+      }
+      if (typeof parsed.error === "string" && parsed.error.startsWith("No generative backend configured")) {
+        return { kind: "no-backend", text: parsed.error };
+      }
+      if (typeof parsed.error === "string") {
+        return { kind: "other", text: parsed.error };
+      }
+    }
+  } catch {
+    // Not a JSON error body — network error, etc. Pass the raw message through.
+  }
+  return { kind: "other", text: message };
+}
+
+// ─── flair rem rapid ──────────────────────────────────────────────────────────
+// Executes by default (specs/FLAIR-NIGHTLY-REM-SLICE-2-DISTILLATION.md § 3C,
+// issue #707): distills server-side via /ReflectMemories execute:true and
+// stages MemoryCandidate rows, printing a staged-candidate summary. --prompt-only
+// preserves the pre-#710 handoff behavior byte-for-byte, for the bring-your-
+// own-model workflow.
+
 rem
   .command("rapid")
-  .description("REM — reflection/learning: generate a structured LLM reflection prompt")
+  .description("REM — reflection/learning: distill recent memories into staged candidates")
   .option("--port <port>", "Harper HTTP port")
   .option("--agent <id>", "Agent ID (or FLAIR_AGENT_ID env)")
   .option("--focus <type>", "lessons_learned | patterns | decisions | errors", "lessons_learned")
   .option("--since <date>", "ISO timestamp lower bound (default: 24h ago)")
+  .option("--prompt-only", "Return the reflection prompt instead of executing (pre-#710 handoff behavior)")
   .action(async (opts) => {
     const agentId = opts.agent || process.env.FLAIR_AGENT_ID;
     if (!agentId) {
@@ -5023,32 +5074,62 @@ rem
     console.log(`\n-- rem rapid --`);
     console.log(`Agent: ${agentId}  Focus: ${opts.focus}`);
 
-    try {
-      const body: Record<string, any> = {
-        agentId,
-        focus: opts.focus,
-      };
-      if (opts.since) body.since = opts.since;
+    const body: Record<string, any> = {
+      agentId,
+      focus: opts.focus,
+    };
+    if (opts.since) body.since = opts.since;
 
-      const result = await api("POST", "/ReflectMemories", body);
+    if (opts.promptOnly) {
+      // --prompt-only: EXACT pre-#710 behavior — prompt-return mode, unchanged.
+      try {
+        const result = await api("POST", "/ReflectMemories", body);
 
-      if (result.error) {
-        console.error(`Reflection error: ${result.error}`);
+        if (result.error) {
+          console.error(`Reflection error: ${result.error}`);
+          process.exit(1);
+        }
+
+        console.log(`\nSource memories: ${result.count ?? 0}`);
+        if (result.suggestedTags?.length) {
+          console.log(`Tags: ${result.suggestedTags.join(", ")}`);
+        }
+
+        console.log("\n--- Reflection Prompt ---");
+        console.log(result.prompt ?? "(no prompt returned)");
+        console.log("--- End Prompt ---\n");
+        console.log("Feed the prompt above to your LLM, then write insights back with:");
+        console.log("  flair memory add --agent <id> --content <insight> --durability persistent --derived-from <source-ids>");
+      } catch (err: any) {
+        console.error(`Error: ${err.message}`);
         process.exit(1);
       }
+      return;
+    }
 
-      console.log(`\nSource memories: ${result.count ?? 0}`);
-      if (result.suggestedTags?.length) {
-        console.log(`Tags: ${result.suggestedTags.join(", ")}`);
+    // Default: execute mode — distill server-side, stage candidates.
+    try {
+      const result = await api("POST", "/ReflectMemories", { ...body, execute: true });
+      const candidates: any[] = Array.isArray(result.candidates) ? result.candidates : [];
+
+      console.log(`\nModel:      ${result.model ?? "?"}`);
+      console.log(`Candidates: ${result.count ?? candidates.length}`);
+      if (candidates.length > 0) {
+        console.log();
+        for (const c of candidates) console.log(formatCandidateLine(c));
       }
-
-      console.log("\n--- Reflection Prompt ---");
-      console.log(result.prompt ?? "(no prompt returned)");
-      console.log("--- End Prompt ---\n");
-      console.log("Feed the prompt above to your LLM, then write insights back with:");
-      console.log("  flair memory add --agent <id> --content <insight> --durability persistent --derived-from <source-ids>");
+      console.log(`\nreview: flair rem candidates / flair rem promote <id>`);
     } catch (err: any) {
-      console.error(`Error: ${err.message}`);
+      const desc = describeReflectError(err.message ?? String(err));
+      if (desc.kind === "no-backend") {
+        console.error(`Reflection error: ${desc.text}`);
+        console.error(`See docs/rem.md#configuration for how to point Flair at a models: backend.`);
+      } else if (desc.kind === "distillation-failed") {
+        console.error(`Reflection error: distillation failed — ${desc.text}`);
+        console.error(`Retry, or run with --prompt-only for the manual handoff.`);
+      } else {
+        console.error(`Error: ${desc.text}`);
+      }
       process.exit(1);
     }
   });
@@ -5585,6 +5666,11 @@ remNightly
       if (typeof row.archived === "number" || typeof row.expired === "number") {
         console.log(`Archived:   ${row.archived ?? "—"}`);
         console.log(`Expired:    ${row.expired ?? "—"}`);
+      }
+      // row.candidates populates when step 5 (distillation) was attempted
+      // this cycle — see src/rem/runner.ts. Absent when dry-run skipped it.
+      if (row.candidates) {
+        console.log(`Staged:     ${row.candidates.length} candidate${row.candidates.length === 1 ? "" : "s"}`);
       }
       console.log(`Duration:   ${row.durationMs}ms`);
       if (row.errors.length > 0) {

--- a/src/rem/runner.ts
+++ b/src/rem/runner.ts
@@ -5,22 +5,32 @@
  *   1. Pre-flight: check pause sentinel / FLAIR_REM_PAUSE env. Exit clean if paused.
  *   2. Snapshot agent state (memory + soul) to ~/.flair/snapshots/<agent>/.
  *   3. Maintenance — delegate to /MemoryMaintenance (same code path `flair rem light` uses).
- *   4. (slice-2 next) trust-tier filter on input memories.
- *   5. (slice-2 next) distillation — call /ReflectMemories, persist candidates.
+ *   4. Trust-tier filter on input memories — permanently deferred (see below).
+ *   5. Distillation — call /ReflectMemories with execute:true, persist staged
+ *      candidate ids to the audit row.
  *   6. Append a row to ~/.flair/logs/rem-nightly.jsonl.
  *
  * Status today:
- *   - Steps 1, 2, 6 shipped in slice-1 PR-1 (#414).
- *   - Step 3 (maintenance) ships in this PR — fills `archived`/`expired` in
- *     the audit row.
- *   - Steps 4, 5 are slice-2 follow-ups; require an in-process distillation
- *     LLM path (today `/ReflectMemories` returns a prompt for human/agent
- *     consumption, not server-side candidate generation).
+ *   - Steps 1, 2 shipped in slice-1 PR-1 (#414).
+ *   - Step 3 (maintenance) shipped in a prior slice-2 PR — fills
+ *     `archived`/`expired` in the audit row.
+ *   - Step 4: per specs/FLAIR-NIGHTLY-REM-SLICE-2-DISTILLATION.md § 3B,
+ *     "Deferred from parent § 4 step 4" — trust tiers aren't derivable yet
+ *     (that's the emergent-trust arc). The input filter stays as today (own
+ *     agent, non-archived, non-permanent, scope window); the safety net for
+ *     un-tiered input is structural — candidates are staged, never
+ *     auto-promoted.
+ *   - Step 5 (distillation) ships in this PR: calls `/ReflectMemories` with
+ *     `execute: true` after maintenance succeeds. `dryRun` skips the call
+ *     entirely (staging rows + spending model tokens are side effects).
+ *   - Step 6 shipped in slice-1 PR-1.
  *
  * The audit row's `slice` field tells readers which steps populated which
  * counts: `slice: "1"` rows have `archived`/`expired` undefined; `slice:
- * "2-maintenance"` rows populate them; future slice-2 rows will populate
- * `consolidated` and `candidates`.
+ * "2-maintenance"` rows populate them but distillation didn't run this cycle
+ * (dry-run skip); `slice: "2"` rows had distillation attempted — check
+ * `candidates` for staged ids on success, `errors` for a `distillation:`
+ * entry on failure (maintenance results still stand either way).
  *
  * Pure dependency injection so the runner is unit-testable without Harper.
  * The CLI wires the real `apiCall` + `pkgVersion`; tests pass stubs.
@@ -61,8 +71,11 @@ export type RunnerStatus = "paused" | "completed" | "dry-run" | "failed";
  * from cycles with maintenance / distillation populated:
  *
  *   "1"             — snapshot + log only (slice-1, before #416)
- *   "2-maintenance" — snapshot + /MemoryMaintenance (this PR, slice-2 PR-3)
- *   "2"             — full slice-2 (adds /ReflectMemories distillation + replay)
+ *   "2-maintenance" — snapshot + /MemoryMaintenance, distillation not
+ *                     attempted this cycle (dry-run skip)
+ *   "2"             — distillation attempted (success or failure — see
+ *                     `candidates` / `errors`), per
+ *                     specs/FLAIR-NIGHTLY-REM-SLICE-2-DISTILLATION.md § 3B
  */
 export type RunnerSlice = "1" | "2-maintenance" | "2";
 
@@ -120,6 +133,29 @@ function asArray(raw: unknown): any[] {
     if (Array.isArray(obj.items)) return obj.items as any[];
   }
   return [];
+}
+
+/**
+ * Best-effort extraction of a readable message out of a thrown API error.
+ * `apiCall` implementations (see `api()` in src/cli.ts) throw
+ * `Error(responseBodyText)` for non-2xx HTTP responses — /ReflectMemories's
+ * 503 (no backend configured) and 502 (distillation_failed) bodies are JSON
+ * `{ error: string, detail?: string }`. Unwraps that shape into a single
+ * string so distinct failure modes read distinctly in the audit log instead
+ * of as a raw JSON blob; falls back to the raw input for network errors or
+ * any other shape.
+ */
+function describeApiError(err: unknown): string {
+  const message = typeof err === "string" ? err : (err as any)?.message ?? String(err);
+  try {
+    const parsed = JSON.parse(message);
+    if (parsed && typeof parsed === "object" && typeof parsed.error === "string") {
+      return parsed.detail ? `${parsed.error}: ${parsed.detail}` : parsed.error;
+    }
+  } catch {
+    // Not a JSON error body — network error, plain string, etc.
+  }
+  return message;
 }
 
 /**
@@ -266,6 +302,42 @@ export async function runNightlyCycle(opts: RunnerOpts): Promise<RunnerResult> {
     return { status: "failed", logRow: row, snapshotPath };
   }
 
+  // Step 5: distillation — call /ReflectMemories with execute:true, now that
+  // maintenance has succeeded. Per spec § 3B, dryRun skips the call entirely:
+  // staging MemoryCandidate rows and spending model tokens are side effects,
+  // the same way dryRun skips the snapshot write.
+  // When the call IS attempted (success or failure), the audit row's `slice`
+  // flips to "2" — "2-maintenance" is reserved for the dry-run skip case.
+  let candidates: string[] | undefined;
+
+  if (!opts.dryRun) {
+    sliceLabel = "2";
+    try {
+      const reflectRaw = await opts.apiCall("POST", "/ReflectMemories", {
+        agentId: opts.agentId,
+        execute: true,
+      });
+      const obj = (reflectRaw && typeof reflectRaw === "object") ? (reflectRaw as Record<string, unknown>) : {};
+      if (obj.error) {
+        // Defensive: a 200 response shouldn't carry { error }, since
+        // MemoryReflect signals failure via HTTP status (503/502) — apiCall
+        // implementations throw for those. Handled the same way regardless.
+        errors.push(`distillation: ${describeApiError(obj.error)}`);
+      } else {
+        const staged = asArray(obj.candidates);
+        candidates = staged
+          .map((c) => (c && typeof c === "object" ? (c as Record<string, unknown>).id : c))
+          .filter((id): id is string => typeof id === "string");
+      }
+    } catch (err: any) {
+      // Distillation failure is recorded, not fatal — maintenance already
+      // succeeded and the cycle's guaranteed steps are done (spec § 3B item
+      // 3). Zero partial candidates is guaranteed server-side (all-or-
+      // nothing staging in /ReflectMemories).
+      errors.push(`distillation: ${describeApiError(err?.message ?? err)}`);
+    }
+  }
+
   // Step 6: log
   const row: RunnerLogRow = {
     ...baseRow,
@@ -278,10 +350,11 @@ export async function runNightlyCycle(opts: RunnerOpts): Promise<RunnerResult> {
     pendingCandidates,
     archived,
     expired,
+    candidates,
     durationMs: Date.now() - startedMs,
     errors,
-    // `consolidated` and `candidates` populate when slice-2 PR-4 (distillation)
-    // lands; today they remain undefined so the row is honest about what ran.
+    // `consolidated` remains undefined — this runner has no consolidation
+    // step; it's reserved for a future slice that adds one.
   };
   appendLogRow(logPath, row);
   return { status: row.status, logRow: row, snapshotPath };

--- a/test/rem-runner.test.ts
+++ b/test/rem-runner.test.ts
@@ -4,8 +4,12 @@
  * Pure orchestration coverage. No Harper or filesystem state required
  * outside an isolated tmpdir. Tests pause sentinel, env-var pause, dry-run
  * (skip write but still log), happy path (writes snapshot + log row),
- * api failure (fail-stops-cycle + error in log row), and soul shape
- * coercion (single row vs multi row).
+ * api failure (fail-stops-cycle + error in log row), soul shape coercion
+ * (single row vs multi row), and step 5 distillation (specs/
+ * FLAIR-NIGHTLY-REM-SLICE-2-DISTILLATION.md § 3B): success populates
+ * `candidates` and flips `slice` to "2"; failure is recorded in `errors[]`
+ * without failing the cycle; dry-run skips the /ReflectMemories call
+ * entirely and `slice` stays "2-maintenance".
  */
 
 import { describe, it, expect, beforeEach, afterEach } from "bun:test";
@@ -62,6 +66,7 @@ function baseOpts(overrides: Partial<RunnerOpts> = {}): RunnerOpts {
       "GET:/Soul": () => [{ id: "soul-test-agent", agentId: "test-agent" }],
       "POST:/MemoryCandidate/search_by_conditions": () => [],
       "POST:/MemoryMaintenance": () => ({ expired: 0, archived: 0, total: 0, errors: 0 }),
+      "POST:/ReflectMemories": () => ({ candidates: [], count: 0, model: "default" }),
     }),
     snapshotRoot,
     logPath,
@@ -104,8 +109,10 @@ describe("happy path", () => {
     expect(r.logRow.soulCount).toBe(1);
     expect(r.logRow.pendingCandidates).toBe(0);
     expect(r.logRow.errors).toEqual([]);
-    // With maintenance wired in this PR, baseline cycles are now slice-2-maintenance.
-    expect(r.logRow.slice).toBe("2-maintenance");
+    // With distillation wired in this PR, baseline (non-dry-run) cycles are
+    // now full slice-2 — distillation was attempted (see rem-runner.test.ts
+    // "step 5: distillation" below for the populated-candidates case).
+    expect(r.logRow.slice).toBe("2");
 
     // Log file contains exactly one row.
     const rows = readLogRows();
@@ -123,6 +130,7 @@ describe("happy path", () => {
           { id: "c1" }, { id: "c2" }, { id: "c3" },
         ],
         "POST:/MemoryMaintenance": () => ({ expired: 0, archived: 0, total: 0, errors: 0 }),
+        "POST:/ReflectMemories": () => ({ candidates: [], count: 0, model: "default" }),
       }),
     }));
     expect(r.logRow.pendingCandidates).toBe(3);
@@ -135,6 +143,7 @@ describe("happy path", () => {
         "GET:/Soul": () => ({ items: [{ id: "s1" }] }),
         "POST:/MemoryCandidate/search_by_conditions": () => [],
         "POST:/MemoryMaintenance": () => ({ expired: 0, archived: 0, total: 0, errors: 0 }),
+        "POST:/ReflectMemories": () => ({ candidates: [], count: 0, model: "default" }),
       }),
     }));
     expect(r.status).toBe("completed");
@@ -149,12 +158,14 @@ describe("happy path", () => {
         "GET:/Soul": () => [sampleSoul],
         "POST:/MemoryCandidate/search_by_conditions": () => [],
         "POST:/MemoryMaintenance": () => ({ expired: 5, archived: 12, total: 200, errors: 0 }),
+        "POST:/ReflectMemories": () => ({ candidates: [], count: 0, model: "default" }),
       }),
     }));
     expect(r.status).toBe("completed");
     expect(r.logRow.archived).toBe(12);
     expect(r.logRow.expired).toBe(5);
-    expect(r.logRow.slice).toBe("2-maintenance");
+    // Distillation was attempted this cycle (not dry-run) — slice is "2".
+    expect(r.logRow.slice).toBe("2");
   });
 
   it("forwards dryRun to /MemoryMaintenance so counts are accurate without mutation", async () => {
@@ -179,6 +190,88 @@ describe("happy path", () => {
   });
 });
 
+describe("step 5: distillation", () => {
+  it("success — audit row slice is '2', candidates lists the staged ids", async () => {
+    const r = await runNightlyCycle(baseOpts({
+      apiCall: makeApi({
+        "GET:/Memory": () => sampleMemories,
+        "GET:/Soul": () => [sampleSoul],
+        "POST:/MemoryCandidate/search_by_conditions": () => [],
+        "POST:/MemoryMaintenance": () => ({ expired: 0, archived: 0, total: 0, errors: 0 }),
+        "POST:/ReflectMemories": () => ({
+          candidates: [
+            { id: "cand_aaa", claim: "first insight" },
+            { id: "cand_bbb", claim: "second insight" },
+          ],
+          count: 2,
+          model: "llama3",
+        }),
+      }),
+    }));
+    expect(r.status).toBe("completed");
+    expect(r.logRow.slice).toBe("2");
+    expect(r.logRow.candidates).toEqual(["cand_aaa", "cand_bbb"]);
+    expect(r.logRow.errors).toEqual([]);
+  });
+
+  it("distillation failure is recorded, not fatal — maintenance results stand, status completed", async () => {
+    const r = await runNightlyCycle(baseOpts({
+      apiCall: makeApi({
+        "GET:/Memory": () => sampleMemories,
+        "GET:/Soul": () => [sampleSoul],
+        "POST:/MemoryCandidate/search_by_conditions": () => [],
+        "POST:/MemoryMaintenance": () => ({ expired: 5, archived: 12, total: 200, errors: 0 }),
+        "POST:/ReflectMemories": () => { throw new Error("fetch failed: connection reset"); },
+      }),
+    }));
+    expect(r.status).toBe("completed");
+    expect(r.logRow.slice).toBe("2");
+    // Maintenance results from before the failed distillation call stand.
+    expect(r.logRow.archived).toBe(12);
+    expect(r.logRow.expired).toBe(5);
+    expect(r.logRow.candidates).toBeUndefined();
+    expect(r.logRow.errors.length).toBe(1);
+    expect(r.logRow.errors[0]).toContain("distillation:");
+    expect(r.logRow.errors[0]).toContain("fetch failed: connection reset");
+  });
+
+  it("no-backend (503) failure is recorded distinctly — structured message, not raw JSON", async () => {
+    const r = await runNightlyCycle(baseOpts({
+      apiCall: makeApi({
+        "GET:/Memory": () => sampleMemories,
+        "GET:/Soul": () => [sampleSoul],
+        "POST:/MemoryCandidate/search_by_conditions": () => [],
+        "POST:/MemoryMaintenance": () => ({ expired: 0, archived: 0, total: 0, errors: 0 }),
+        // Mirrors api()'s throw shape (src/cli.ts) for a 503 response body.
+        "POST:/ReflectMemories": () => {
+          throw new Error(JSON.stringify({ error: "No generative backend configured. See the models configuration docs." }));
+        },
+      }),
+    }));
+    expect(r.status).toBe("completed");
+    expect(r.logRow.errors.length).toBe(1);
+    expect(r.logRow.errors[0]).toBe("distillation: No generative backend configured. See the models configuration docs.");
+  });
+
+  it("distillation_failed (502) failure surfaces the detail, distinct from the no-backend case", async () => {
+    const r = await runNightlyCycle(baseOpts({
+      apiCall: makeApi({
+        "GET:/Memory": () => sampleMemories,
+        "GET:/Soul": () => [sampleSoul],
+        "POST:/MemoryCandidate/search_by_conditions": () => [],
+        "POST:/MemoryMaintenance": () => ({ expired: 0, archived: 0, total: 0, errors: 0 }),
+        // Mirrors api()'s throw shape (src/cli.ts) for a 502 response body.
+        "POST:/ReflectMemories": () => {
+          throw new Error(JSON.stringify({ error: "distillation_failed", detail: "model output did not validate after one retry" }));
+        },
+      }),
+    }));
+    expect(r.status).toBe("completed");
+    expect(r.logRow.errors.length).toBe(1);
+    expect(r.logRow.errors[0]).toBe("distillation: distillation_failed: model output did not validate after one retry");
+  });
+});
+
 describe("dry-run", () => {
   it("logs but does not write a snapshot tarball", async () => {
     const r = await runNightlyCycle(baseOpts({ dryRun: true }));
@@ -190,6 +283,32 @@ describe("dry-run", () => {
     expect(rows[0].status).toBe("dry-run");
     expect(rows[0].dryRun).toBe(true);
     expect(rows[0].memoryCount).toBe(2);
+  });
+
+  it("skips the /ReflectMemories execute call entirely — staging + token spend are side effects", async () => {
+    const calls: string[] = [];
+    const r = await runNightlyCycle(baseOpts({
+      dryRun: true,
+      apiCall: async (method, path, body) => {
+        calls.push(`${method}:${path.split("?")[0]}`);
+        if (method === "POST" && path === "/MemoryMaintenance") {
+          expect((body as any)?.dryRun).toBe(true);
+          return { expired: 0, archived: 0, total: 0, errors: 0 };
+        }
+        if (method === "GET" && path.startsWith("/Memory?")) return sampleMemories;
+        if (method === "GET" && path.startsWith("/Soul?")) return [sampleSoul];
+        if (method === "POST" && path === "/MemoryCandidate/search_by_conditions") return [];
+        if (method === "POST" && path === "/ReflectMemories") {
+          throw new Error("must not be called in dry-run mode");
+        }
+        throw new Error(`unexpected api: ${method}:${path}`);
+      },
+    }));
+    expect(r.status).toBe("dry-run");
+    expect(calls).not.toContain("POST:/ReflectMemories");
+    // Distillation was skipped (not attempted) — slice stays "2-maintenance".
+    expect(r.logRow.slice).toBe("2-maintenance");
+    expect(r.logRow.candidates).toBeUndefined();
   });
 });
 
@@ -231,6 +350,7 @@ describe("failure modes", () => {
         "GET:/Soul": () => [],
         "POST:/MemoryCandidate/search_by_conditions": () => { throw new Error("candidate table missing"); },
         "POST:/MemoryMaintenance": () => ({ expired: 0, archived: 0, total: 0, errors: 0 }),
+        "POST:/ReflectMemories": () => ({ candidates: [], count: 0, model: "default" }),
       }),
     }));
     // Candidate count is a non-fatal signal — the cycle still completes.

--- a/test/unit/cli-rem-rapid.test.ts
+++ b/test/unit/cli-rem-rapid.test.ts
@@ -1,0 +1,92 @@
+/**
+ * cli-rem-rapid.test.ts — Unit tests for the `flair rem rapid` execute-mode
+ * flip (specs/FLAIR-NIGHTLY-REM-SLICE-2-DISTILLATION.md § 3C, issue #707).
+ *
+ * Tests the pure helpers formatCandidateLine + describeReflectError. Same
+ * pattern as cli-rem-promote-reject.test.ts: the action callback itself
+ * spawns api() + process.exit, which makes it high-effort/low-value to
+ * drive directly (no CLI harness that mocks fetch/commander exists for the
+ * rem subcommands — this repo's convention is to extract the decision logic
+ * into pure, exported functions instead of inventing one). These two
+ * functions are the actual contract: formatCandidateLine is the
+ * staged-candidate summary line format (§ 3C item 1: "per-candidate claim
+ * first ~80 chars + id"); describeReflectError is the 503-vs-502 error UX
+ * classification (§ 3C item 3).
+ */
+
+import { describe, test, expect } from "bun:test";
+import { formatCandidateLine, describeReflectError } from "../../src/cli.ts";
+
+describe("formatCandidateLine", () => {
+  test("renders id + claim for a short claim", () => {
+    expect(formatCandidateLine({ id: "cand_abc", claim: "short claim" })).toBe("  [cand_abc] short claim");
+  });
+
+  test("truncates a claim longer than 80 chars with an ellipsis", () => {
+    const claim = "x".repeat(120);
+    const line = formatCandidateLine({ id: "cand_abc", claim });
+    expect(line).toBe(`  [cand_abc] ${"x".repeat(80)}…`);
+    expect(line.length).toBeLessThan(claim.length + 20);
+  });
+
+  test("does not truncate a claim exactly at the limit", () => {
+    const claim = "x".repeat(80);
+    const line = formatCandidateLine({ id: "cand_abc", claim });
+    expect(line).toBe(`  [cand_abc] ${claim}`);
+    expect(line).not.toContain("…");
+  });
+
+  test("respects a custom maxClaimLen", () => {
+    const line = formatCandidateLine({ id: "c1", claim: "0123456789" }, 5);
+    expect(line).toBe("  [c1] 01234…");
+  });
+
+  test("falls back to '?' for a missing id", () => {
+    expect(formatCandidateLine({ claim: "orphan" })).toBe("  [?] orphan");
+  });
+
+  test("handles a missing claim as an empty string", () => {
+    expect(formatCandidateLine({ id: "c1" })).toBe("  [c1] ");
+  });
+});
+
+describe("describeReflectError", () => {
+  test("classifies the 503 no-backend body", () => {
+    const body = JSON.stringify({ error: "No generative backend configured. See the models configuration docs." });
+    const r = describeReflectError(body);
+    expect(r.kind).toBe("no-backend");
+    expect(r.text).toBe("No generative backend configured. See the models configuration docs.");
+  });
+
+  test("classifies the 502 distillation_failed body, surfacing detail", () => {
+    const body = JSON.stringify({ error: "distillation_failed", detail: "model output did not validate after one retry" });
+    const r = describeReflectError(body);
+    expect(r.kind).toBe("distillation-failed");
+    expect(r.text).toBe("model output did not validate after one retry");
+  });
+
+  test("falls back to the error string when distillation_failed has no detail", () => {
+    const body = JSON.stringify({ error: "distillation_failed" });
+    const r = describeReflectError(body);
+    expect(r.kind).toBe("distillation-failed");
+    expect(r.text).toBe("distillation_failed");
+  });
+
+  test("treats an unrelated structured error (e.g. actor-resolution 400/403) as 'other'", () => {
+    const body = JSON.stringify({ error: "forbidden: can only reflect on own memories" });
+    const r = describeReflectError(body);
+    expect(r.kind).toBe("other");
+    expect(r.text).toBe("forbidden: can only reflect on own memories");
+  });
+
+  test("falls back to the raw message for a non-JSON error (network failure)", () => {
+    const r = describeReflectError("fetch failed: connection reset");
+    expect(r.kind).toBe("other");
+    expect(r.text).toBe("fetch failed: connection reset");
+  });
+
+  test("falls back to 'other' for a JSON body with no error field", () => {
+    const r = describeReflectError(JSON.stringify({ status: "weird" }));
+    expect(r.kind).toBe("other");
+  });
+});


### PR DESCRIPTION
Completes REM slice 2 (`specs/FLAIR-NIGHTLY-REM-SLICE-2-DISTILLATION.md` § 3B–C) on top of #710. With this, the paste-a-prompt handoff is gone end to end: `flair rem rapid` distills and stages by default, and the nightly cycle runs distillation unattended.

**What:**
- **Runner step 5:** after maintenance succeeds, the nightly cycle calls `/ReflectMemories` with `execute: true`. Audit row: `slice: "2"` whenever distillation was attempted (success or failure), `candidates` populated with staged ids on success, a `distillation:` entry in `errors[]` on failure — maintenance results stand either way. `dryRun` skips the call entirely (staging rows and spending model tokens are side effects).
- **CLI:** `flair rem rapid` executes by default and prints a staged-candidate summary with a review hint; `--prompt-only` preserves the pre-#710 prompt-return behavior byte-for-byte. Distinct error UX for 503 no-backend (docs pointer) vs 502 distillation-failed (retry / `--prompt-only` hint). `rem nightly run-once` surfaces the staged-candidate count.
- **Docs:** new `docs/rem.md` (linked from README) — config recipe, loud data-egress warning, `FLAIR_REM_MODEL`, and the clustered-deploy single-timer rule + snapshot-locality note (#709 v1). Plus `docs/notes/rem-ux.md` — the trigger model, locality guarantees, attach semantics, and review-loop direction.

**Load-bearing config finding (verified against the pinned `@harperfast/harper` 5.1.17 source, not assumed):** the `models:` block must live in **Harper's root instance config**, not flair's own `config.yaml` — Harper loads flair as a non-root component and never reads `models:` from component config. `docs/rem.md` documents this prominently since it's the first thing a deployer would get wrong. The Fabric `enc:v1:` secrets mechanism is documented hedged (it's a managed-deploy concern, not verifiable from the open-source package).

**Deviations, called out for review:**
1. Verification ran the hermetic scope CI's "Unit Tests" required check runs (`test/unit/` + root-level DI-based tests) rather than a bare `bun test` — the integration/smoke/compat lanes spawn live Harper + network and run as their own CI jobs on this PR.
2. `rem nightly run-once` gained one display line (staged-candidate count) — cosmetic surfacing of the newly populated audit field.
3. CLI coverage follows the repo's existing convention (pure helpers extracted and tested — `formatCandidateLine`, `describeReflectError`; no mocked-fetch harness invented).

**Tests:** hermetic suite 2348 → 2365 pass, 0 fail (143 files); all three typecheck configs clean. Independently re-run by the reviewer-of-record before push.

Refs #707, #709. Follows #708 (spec) and #710 (PR-1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
