### PR TITLE
docs(rem): non-thinking model requirement for the ollama backend

### DIFF
--- a/docs/rem.md
+++ b/docs/rem.md
@@ -22,6 +22,9 @@ models:
 
 No credentials, nothing leaves the box (see the warning below).
 
+> **⚠️ Pick a non-thinking model for the Ollama backend.**
+> Thinking/reasoning models (`qwen3-next`, `deepseek-r1`, and similar) currently return **empty generations** through Harper's Ollama backend: Ollama routes their output into the response's `thinking` field, which the backend doesn't read, so every REM execute run fails closed with `distillation_failed` (no candidates are ever staged — the failure is availability, not correctness). Use a non-thinking model (`llama3.1`, `qwen3-coder-next`, `gemma3`, …) until the upstream backend behavior changes. Tracked in #712.
+
 **Hosted provider** (OpenAI / Anthropic / Bedrock also supported — `backend: openai|anthropic|bedrock`):
 
 ```yaml


### PR DESCRIPTION
Docs-only follow-up from the slice-2 dogfood run (14/14 checks green against a live model — full stage → review → promote loop on an ephemeral instance).

**Finding (#712):** thinking/reasoning models return empty generations through Harper's Ollama backend (output lands in the response's `thinking` field, which the backend never reads), so every REM execute run fails closed with `distillation_failed`. REM's posture held — fail-closed, zero partial candidates, no leakage — but the availability failure needs a loud docs warning since the natural first model choice on many boxes is a thinking model. Non-thinking models work perfectly (`qwen3-coder-next` staged 7 quality candidates in ~7s, dedup held on a second run, promoted candidate landed with `derivedFrom` intact).

One boxed warning added to the Ollama recipe in `docs/rem.md`. Upstream fix direction is drafted for filing on the Harper side.

Refs #712, #707.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
