### PR TITLE
ci: model fetch via first-party mirror with pinned sha256 (#715)

### DIFF
--- a/.github/workflows/docker-test.yml
+++ b/.github/workflows/docker-test.yml
@@ -92,14 +92,12 @@ jobs:
 
       - name: Download embeddings model into build context
         if: steps.model-cache.outputs.cache-hit != 'true'
-        run: |
-          mkdir -p models
-          # --retry-all-errors so 429/4xx/5xx (incl. the HF 503 that flaked the
-          # gate) are retried, not just connection-level failures.
-          curl -fSL --retry 5 --retry-delay 10 --retry-all-errors --connect-timeout 30 \
-            "https://huggingface.co/nomic-ai/nomic-embed-text-v1.5-GGUF/resolve/main/nomic-embed-text-v1.5.Q4_K_M.gguf" \
-            -o models/nomic-embed-text-v1.5.Q4_K_M.gguf
-          echo "Model downloaded ($(du -sh models/*.gguf | cut -f1))"
+        # Resolves first-party GitHub release mirror → HuggingFace (last),
+        # with sha256 verification regardless of source (flair#715 — an HF
+        # outage on 2026-07-13 took four other lanes red for hours with
+        # zero code at fault; the actions/cache step above is layer one —
+        # this only runs on a cache miss).
+        run: bash "$GITHUB_WORKSPACE/scripts/ci/fetch-model.sh" nomic-embed-text-v1.5.Q4_K_M.gguf "$GITHUB_WORKSPACE/models"
 
       - name: Build clean-VM gate image
         uses: docker/build-push-action@14487ce63c7a62a4a324b0bfb37086795e31c6c1 # v6

--- a/.github/workflows/migration-ci-lanes.yml
+++ b/.github/workflows/migration-ci-lanes.yml
@@ -88,13 +88,9 @@ jobs:
       # in-band HuggingFace download (the #463/#465 429-flake class) and any
       # re-download after the swap.
       - name: Pre-download embedding model (shared by baseline + PR build)
-        run: |
-          set -euo pipefail
-          mkdir -p models
-          curl -fSL --retry 5 --retry-delay 10 --retry-all-errors --connect-timeout 30 \
-            "https://huggingface.co/nomic-ai/nomic-embed-text-v1.5-GGUF/resolve/main/nomic-embed-text-v1.5.Q4_K_M.gguf" \
-            -o models/nomic-embed-text-v1.5.Q4_K_M.gguf
-          echo "Model downloaded ($(du -sh models/*.gguf | cut -f1))"
+        # Resolves cache → first-party GitHub release mirror → HuggingFace
+        # (last), with sha256 verification regardless of source (flair#715).
+        run: bash "$GITHUB_WORKSPACE/scripts/ci/fetch-model.sh" nomic-embed-text-v1.5.Q4_K_M.gguf "$GITHUB_WORKSPACE/models"
 
       - name: Pack HEAD (PR build)
         id: pack
@@ -374,12 +370,9 @@ jobs:
       - run: bun run build && bun run build:cli
 
       - name: Pre-download embedding model
-        run: |
-          set -euo pipefail
-          mkdir -p models
-          curl -fSL --retry 5 --retry-delay 10 --retry-all-errors --connect-timeout 30 \
-            "https://huggingface.co/nomic-ai/nomic-embed-text-v1.5-GGUF/resolve/main/nomic-embed-text-v1.5.Q4_K_M.gguf" \
-            -o models/nomic-embed-text-v1.5.Q4_K_M.gguf
+        # Resolves cache → first-party GitHub release mirror → HuggingFace
+        # (last), with sha256 verification regardless of source (flair#715).
+        run: bash "$GITHUB_WORKSPACE/scripts/ci/fetch-model.sh" nomic-embed-text-v1.5.Q4_K_M.gguf "$GITHUB_WORKSPACE/models"
 
       - name: Pack HEAD (PR build)
         id: pack

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -46,15 +46,12 @@ jobs:
         run: bun run build && bun run build:cli
 
       - name: Pre-download embedding model
-        run: |
-          mkdir -p models
-          # HuggingFace intermittently 429s the model download; retry with
-          # backoff (--retry-all-errors so 429/4xx are retried, not just 5xx).
-          # A bare curl here flaked the whole job and blocked merges (#463, #465).
-          curl -fSL --retry 5 --retry-delay 10 --retry-all-errors --connect-timeout 30 \
-            "https://huggingface.co/nomic-ai/nomic-embed-text-v1.5-GGUF/resolve/main/nomic-embed-text-v1.5.Q4_K_M.gguf" \
-            -o models/nomic-embed-text-v1.5.Q4_K_M.gguf
-          echo "Model downloaded ($(du -sh models/*.gguf | cut -f1))"
+        # Resolves cache → first-party GitHub release mirror → HuggingFace
+        # (last), with sha256 verification regardless of source (flair#715 —
+        # an HF outage on 2026-07-13 took five other lanes red for hours
+        # with zero code at fault; a bare HF curl had already flaked this
+        # job before that, #463/#465).
+        run: bash "$GITHUB_WORKSPACE/scripts/ci/fetch-model.sh" nomic-embed-text-v1.5.Q4_K_M.gguf "$GITHUB_WORKSPACE/models"
 
       # Single source of truth (#625): derive the Harper Docker image tag from the
       # @harperfast/harper version declared in package.json, so the Docker-based

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -191,15 +191,12 @@ jobs:
           grep -q "export.*function getMode" dist/resources/embeddings-provider.js || { echo "FATAL: getMode missing"; exit 1; }
           echo "All critical exports present ✅"
       - name: Pre-download embedding model
-        run: |
-          mkdir -p models
-          # HuggingFace intermittently 429s the model download; retry with
-          # backoff (--retry-all-errors so 429/4xx are retried, not just 5xx).
-          # A bare curl here flaked the whole job and blocked merges (#463, #465).
-          curl -fSL --retry 5 --retry-delay 10 --retry-all-errors --connect-timeout 30 \
-            "https://huggingface.co/nomic-ai/nomic-embed-text-v1.5-GGUF/resolve/main/nomic-embed-text-v1.5.Q4_K_M.gguf" \
-            -o models/nomic-embed-text-v1.5.Q4_K_M.gguf
-          echo "Model downloaded ($(du -sh models/*.gguf | cut -f1))"
+        # Resolves cache → first-party GitHub release mirror → HuggingFace
+        # (last), with sha256 verification regardless of source (flair#715 —
+        # an HF outage on 2026-07-13 took this lane and four others red for
+        # hours with zero code at fault; a bare HF curl had already flaked
+        # this job before that, #463/#465).
+        run: bash "$GITHUB_WORKSPACE/scripts/ci/fetch-model.sh" nomic-embed-text-v1.5.Q4_K_M.gguf "$GITHUB_WORKSPACE/models"
       - name: Run integration tests (native Harper spawn)
         # No HARPER_HTTP_URL — harper-lifecycle spawns Harper from node_modules
         # per the npm-installed @harperfast/harper. Avoids the Docker
@@ -501,12 +498,9 @@ jobs:
       # migration-assertion seeding added below. Same rationale as the new
       # migration-ci-lanes.yml downgrade-and-revert job.
       - name: Pre-download embedding model (shared by baseline + HEAD)
-        run: |
-          set -euo pipefail
-          mkdir -p models
-          curl -fSL --retry 5 --retry-delay 10 --retry-all-errors --connect-timeout 30 \
-            "https://huggingface.co/nomic-ai/nomic-embed-text-v1.5-GGUF/resolve/main/nomic-embed-text-v1.5.Q4_K_M.gguf" \
-            -o models/nomic-embed-text-v1.5.Q4_K_M.gguf
+        # Resolves cache → first-party GitHub release mirror → HuggingFace
+        # (last), with sha256 verification regardless of source (flair#715).
+        run: bash "$GITHUB_WORKSPACE/scripts/ci/fetch-model.sh" nomic-embed-text-v1.5.Q4_K_M.gguf "$GITHUB_WORKSPACE/models"
       - name: Install npm-stable, seed data, upgrade, verify
         run: |
           set -euo pipefail

--- a/docker/Dockerfile.test
+++ b/docker/Dockerfile.test
@@ -59,20 +59,21 @@ COPY --from=base /app/config.yaml ./config.yaml
 RUN bun add @node-llama-cpp/linux-x64@3 --no-save 2>/dev/null || \
     npm install --no-save @node-llama-cpp/linux-x64@3
 
-# Pre-download embeddings model (~80MB). Docker layer cache ensures this
-# only downloads once — subsequent builds reuse the cached layer.
+# Pre-download embeddings model (~80MB). Docker layer cache (this workflow
+# builds with the GHA cache backend, cache-from/cache-to type=gha) ensures
+# this only downloads once — subsequent builds reuse the cached layer.
 # Required because Harper blocks on model download during schema init,
 # causing the seed retry loop to time out.
 #
-# HuggingFace intermittently 429s/503s the model download; retry with backoff
-# (--retry-all-errors so 4xx/5xx are retried, not just connection failures). A
-# bare curl here flaked the from-scratch build on an HF 503 — same root cause
-# the clean-vm gate hit (#463/#465 429/503 issue).
+# fetch-model.sh resolves first-party GitHub release mirror → HuggingFace
+# (last), with sha256 verification regardless of source (flair#715 — an HF
+# outage on 2026-07-13 took this lane and four others red for hours with
+# zero code at fault; a bare curl here had already flaked the from-scratch
+# build on an HF 503 before that — same root cause the clean-vm gate hit,
+# #463/#465).
+COPY scripts/ci/fetch-model.sh scripts/ci/model-checksums.txt ./scripts/ci/
 ENV FLAIR_MODELS_DIR=/opt/flair-models
-RUN mkdir -p /opt/flair-models && \
-    curl -fSL --retry 5 --retry-delay 10 --retry-all-errors --connect-timeout 30 \
-      "https://huggingface.co/nomic-ai/nomic-embed-text-v1.5-GGUF/resolve/main/nomic-embed-text-v1.5.Q4_K_M.gguf" \
-      -o /opt/flair-models/nomic-embed-text-v1.5.Q4_K_M.gguf && \
+RUN bash ./scripts/ci/fetch-model.sh nomic-embed-text-v1.5.Q4_K_M.gguf /opt/flair-models && \
     echo "Embeddings model cached ($(du -sh /opt/flair-models/*.gguf | cut -f1))"
 
 # Copy test script

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -49,6 +49,19 @@ flair doctor                                  # should now report semantic searc
 
 **Other causes:** a missing native llama.cpp addon for your platform, or a corrupted/partial model download. `flair doctor` prints the underlying init error; `flair reembed` re-downloads the model and regenerates embeddings once the component loads.
 
+**HuggingFace outage:** the model normally resolves from HuggingFace (`nomic-ai/nomic-embed-text-v1.5-GGUF`). If HF is down or 403/429-ing, point `FLAIR_MODELS_DIR` at a directory containing your own copy of `nomic-embed-text-v1.5.Q4_K_M.gguf` instead of waiting it out:
+```bash
+mkdir -p ~/models
+curl -fSL -o ~/models/nomic-embed-text-v1.5.Q4_K_M.gguf \
+  https://github.com/tpsdev-ai/flair/releases/download/ci-models/nomic-embed-text-v1.5.Q4_K_M.gguf
+sha256sum ~/models/nomic-embed-text-v1.5.Q4_K_M.gguf
+# expect: d4e388894e09cf3816e8b0896d81d265b55e7a9fff9ab03fe8bf4ef5e11295ac
+
+export FLAIR_MODELS_DIR=~/models   # add to your shell rc to persist
+flair restart
+```
+The `ci-models` release above is a first-party mirror of the same file (public, no auth required) that flair's own CI falls back to for the same reason — same-origin with GitHub, no dependency on HF's availability. Always verify the sha256 against the value printed here (or in `scripts/ci/model-checksums.txt` in the repo) before pointing Harper at a manually-downloaded file.
+
 ### "Embeddings: hash-fallback (512-dim)"
 
 **Symptoms:** `flair status` shows hash-fallback instead of nomic. Search returns poor results.

--- a/scripts/ci/fetch-model.sh
+++ b/scripts/ci/fetch-model.sh
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+# fetch-model.sh — resolve a pinned embedding-model GGUF for CI lanes
+# (flair#715).
+#
+# An HF outage on 2026-07-13 (sustained 403s) took five CI lanes red for
+# hours with zero code at fault, and the same outage broke local
+# fresh-clone runs (the in-process fallback download hits the same URL).
+# actions/cache is not a guarantee either — 7-day/size-pressure eviction
+# plus an HF outage still means red lanes with no recovery path but
+# waiting. This script gives every lane (and, via the Dockerfile.test
+# build, the from-scratch Docker lane too) one shared resolution order:
+#
+#   1. Already present at <dest-dir>/<filename> with a matching sha256 —
+#      done. This is the actions/cache-hit path: point the cache step's
+#      `path:` at the same file this script writes and a cache hit makes
+#      this script a no-op.
+#   2. First-party GitHub release asset on this repo's `ci-models` tag —
+#      same-origin with the runner's existing GitHub access, no external
+#      availability dependency, no new secret (public repo — plain curl
+#      works unauthenticated).
+#   3. HuggingFace — last resort.
+#
+# The sha256 is ALWAYS verified after download, regardless of source
+# (today's raw HF curl has no integrity check at all — flair#715 calls
+# that out as a supply-chain gap to close at the same time).
+#
+# Usage: fetch-model.sh <model-filename> <dest-dir> [expected-sha256]
+#
+# The expected sha256 is looked up by filename from model-checksums.txt
+# (next to this script) when the third argument is omitted. That file is
+# the single pinned source of truth — callers should not hardcode the hash
+# per workflow; pass it explicitly only to override for a one-off (e.g.
+# local testing of a checksum-mismatch path).
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CHECKSUMS_FILE="${SCRIPT_DIR}/model-checksums.txt"
+
+if [[ $# -lt 2 ]]; then
+  echo "usage: fetch-model.sh <model-filename> <dest-dir> [expected-sha256]" >&2
+  exit 1
+fi
+
+MODEL_FILENAME="$1"
+DEST_DIR="$2"
+EXPECTED_SHA256="${3:-}"
+
+if [[ -z "$EXPECTED_SHA256" ]]; then
+  EXPECTED_SHA256="$(awk -v f="$MODEL_FILENAME" '$1 == f { print $2 }' "$CHECKSUMS_FILE")"
+  if [[ -z "$EXPECTED_SHA256" ]]; then
+    echo "::error::fetch-model.sh: no pinned sha256 for '${MODEL_FILENAME}' in ${CHECKSUMS_FILE} (and none passed as \$3)" >&2
+    exit 1
+  fi
+fi
+
+# Overridable for testing; real callers should rely on the defaults.
+GITHUB_MIRROR_REPO="${FETCH_MODEL_MIRROR_REPO:-tpsdev-ai/flair}"
+GITHUB_MIRROR_TAG="${FETCH_MODEL_MIRROR_TAG:-ci-models}"
+HF_REPO="${FETCH_MODEL_HF_REPO:-nomic-ai/nomic-embed-text-v1.5-GGUF}"
+
+DEST_PATH="${DEST_DIR}/${MODEL_FILENAME}"
+
+sha256_of() {
+  sha256sum "$1" | awk '{ print $1 }'
+}
+
+verify() {
+  local path="$1" actual
+  actual="$(sha256_of "$path")"
+  if [[ "$actual" != "$EXPECTED_SHA256" ]]; then
+    echo "::error::fetch-model.sh: sha256 mismatch for ${path} — expected ${EXPECTED_SHA256}, got ${actual}" >&2
+    return 1
+  fi
+  echo "fetch-model.sh: sha256 verified for ${path} (${EXPECTED_SHA256})"
+}
+
+download() {
+  local url="$1" label="$2"
+  echo "fetch-model.sh: attempting ${label}: ${url}"
+  if curl -fSL --retry 5 --retry-delay 10 --retry-all-errors --connect-timeout 30 \
+      "$url" -o "${DEST_PATH}.partial"; then
+    mv "${DEST_PATH}.partial" "$DEST_PATH"
+    return 0
+  fi
+  rm -f "${DEST_PATH}.partial"
+  echo "fetch-model.sh: ${label} download failed" >&2
+  return 1
+}
+
+mkdir -p "$DEST_DIR"
+
+# 1. Already present (the actions/cache-hit path).
+if [[ -f "$DEST_PATH" ]]; then
+  if verify "$DEST_PATH"; then
+    echo "fetch-model.sh: ${DEST_PATH} already present and verified — skipping download"
+    exit 0
+  fi
+  echo "fetch-model.sh: ${DEST_PATH} present but checksum mismatch — re-downloading" >&2
+  rm -f "$DEST_PATH"
+fi
+
+# 2. First-party GitHub release asset mirror.
+GITHUB_URL="https://github.com/${GITHUB_MIRROR_REPO}/releases/download/${GITHUB_MIRROR_TAG}/${MODEL_FILENAME}"
+if download "$GITHUB_URL" "GitHub release mirror"; then
+  if verify "$DEST_PATH"; then
+    echo "fetch-model.sh: ${MODEL_FILENAME} ready at ${DEST_PATH} ($(du -sh "$DEST_PATH" | cut -f1), via GitHub release mirror)"
+    exit 0
+  fi
+  rm -f "$DEST_PATH"
+  echo "fetch-model.sh: GitHub mirror asset failed checksum verification — falling back to HuggingFace" >&2
+fi
+
+# 3. HuggingFace (last resort).
+HF_URL="https://huggingface.co/${HF_REPO}/resolve/main/${MODEL_FILENAME}"
+if download "$HF_URL" "HuggingFace"; then
+  if verify "$DEST_PATH"; then
+    echo "fetch-model.sh: ${MODEL_FILENAME} ready at ${DEST_PATH} ($(du -sh "$DEST_PATH" | cut -f1), via HuggingFace)"
+    exit 0
+  fi
+  rm -f "$DEST_PATH"
+  echo "::error::fetch-model.sh: HuggingFace asset failed checksum verification" >&2
+  exit 1
+fi
+
+echo "::error::fetch-model.sh: failed to fetch ${MODEL_FILENAME} from both the GitHub release mirror (${GITHUB_URL}) and HuggingFace (${HF_URL})" >&2
+exit 1

--- a/scripts/ci/model-checksums.txt
+++ b/scripts/ci/model-checksums.txt
@@ -1,0 +1,13 @@
+# model-checksums.txt — pinned sha256 checksums for CI-fetched embedding
+# model GGUFs (flair#715). Single source of truth for
+# scripts/ci/fetch-model.sh — do not duplicate these hashes inline in any
+# workflow or Dockerfile; add a line here and reference it by filename
+# instead.
+#
+# Format: <filename> <sha256> [# comment]
+#
+# Mirrored as first-party release assets on the `ci-models` tag of this repo
+# (https://github.com/tpsdev-ai/flair/releases/tag/ci-models), sourced
+# originally from nomic-ai/nomic-embed-text-v1.5-GGUF on HuggingFace.
+nomic-embed-text-v1.5.Q4_K_M.gguf d4e388894e09cf3816e8b0896d81d265b55e7a9fff9ab03fe8bf4ef5e11295ac # 84106624 bytes
+nomic-embed-text-v1.5.Q8_0.gguf 3e24342164b3d94991ba9692fdc0dd08e3fd7362e0aacc396a9a5c54a544c3b7 # 146146432 bytes


### PR DESCRIPTION
Closes #715. Every CI lane that fetches the embedding model now resolves cache → first-party `ci-models` release asset → HuggingFace last, with the SHA-256 verified after every download regardless of source (closing the integrity gap the issue calls out) and fail-closed on mismatch (bad file removed, nonzero exit).

One shared helper (`scripts/ci/fetch-model.sh`) with checksums pinned once in `scripts/ci/model-checksums.txt`; six lanes updated including the Docker from-scratch build (helper COPY'd into the build context); `docs/troubleshooting.md` gains the self-hoster mirror recipe. Helper verified live against the real mirror: success path, cache-hit no-op path, and a deliberate wrong-checksum run where BOTH sources downloaded successfully and were both correctly rejected.

Honest caveat: the Dockerfile.test change is inspection-verified only (no Docker in the build sandbox) — this PR's own 'CLI from-scratch validation' lane is its real test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
