### PR TITLE
fix(doctor): track fixed-vs-remaining so the --fix summary and exit code tell the truth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@
 - **`headroomFloor`** (the old fraction-of-total DI knob on `checkSpace`/`runMigrationCycle`) is removed — it was never wired from production config, only ever exercised by the fraction-based tests this fix rewrites, and the new rule has no fraction to override (the env var above is the operator-facing lever now).
 - **Failure message rewritten to be truthful and actionable**: no longer suggests pruning snapshots or `FLAIR_SNAPSHOT_DIR` (neither changes the `dataDir` volume's fraction and never could have helped this class of halt) — now states the human-readable bytes needed vs. available vs. the reserve, and names `FLAIR_MIGRATION_RESERVE_BYTES` as the remedy for constrained setups. All byte quantities in the message are formatted human-readable (e.g. `220.0 KB`, `17.37 GB`, `2.00 GB`) via a new `humanBytes()` export, never raw byte counts — structured fields (`SpaceCheckResult`) still carry raw numbers for machine consumers.
 
+### 🐛 `flair doctor --fix` reported issues found and exited 1 even after fixing everything (flair#721)
+
+`doctor --fix` tracked a single `issues` counter — every detected problem incremented it, and the summary/exit code read only that counter, with no record of which of those issues `--fix` actually resolved during the same run. A run that interactively fixed every issue it found (e.g. wiring an MCP client, adding the Claude Code SessionStart hook) still printed `N issues found — see fixes above` and exited 1, indistinguishable from a run that fixed nothing — breaking scripted use (`flair doctor --fix && ...`).
+
+`doctor` now tracks fixed-vs-remaining explicitly: each check that offers an in-run fix (port-drift config rewrite, dead-Harper restart, version-mismatch restart, stale PID-file removal, MCP client wiring, CLAUDE.md bootstrap line, SessionStart hook) counts toward a separate `fixed` total only when that fix actually succeeds, not merely attempted or declined. The summary now reads: all fixed → `N issues found, N fixed ✓` and exit 0; some remaining (declined prompts, unfixable checks, `--dry-run`) → `N issues found, M fixed, K remaining` and exit 1; zero issues → unchanged `No issues found` / exit 0. Without `--fix`, behavior is unchanged: `N issues found — see fixes above` / exit 1. The decision logic is extracted into a pure `summarizeDoctorRun(found, fixed, autoFix)` helper, unit-tested directly (`test/unit/doctor-summary.test.ts`).
+
 ## [0.22.0] - 2026-07-13
 
 ### ⬆️ Upgrade notes

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -8625,6 +8625,51 @@ see src/fleet-verify.ts's file header for the full caveat.`)
     process.exit(result.exitCode);
   });
 
+// ─── flair doctor — pure summary/exit helper ─────────────────────────────────
+// Extracted for testability (flair#721), same pattern as formatCandidateLine /
+// describeReflectError above: the action callback spawns process.exit and a
+// long sequence of console.log side effects, which makes it high-effort/
+// low-value to drive directly — this is the actual decision logic. Before
+// #721, doctor tracked only a single `issues` counter: every detected
+// problem incremented it, and the final summary/exit-code read that counter
+// alone, with no separate record of which of those issues `--fix` actually
+// resolved during the same run. So a `--fix` run that interactively fixed
+// every issue it found still printed "N issues found — see fixes above" and
+// exited 1 — indistinguishable from a run that fixed nothing. This helper
+// takes the accumulated found/fixed counts plus whether `--fix` was passed
+// at all, and decides the summary line + exit code:
+//   - 0 found                       → "No issues found", exit 0 (unchanged)
+//   - found, no --fix               → "N issues found — see fixes above", exit 1 (unchanged)
+//   - found, --fix, all fixed       → "N issues found, N fixed ✓", exit 0
+//   - found, --fix, some remaining  → "N issues found, M fixed, K remaining", exit 1
+export function summarizeDoctorRun(
+  found: number,
+  fixed: number,
+  autoFix: boolean,
+): { line: string; exitCode: number } {
+  const plural = (n: number) => `issue${n === 1 ? "" : "s"}`;
+  if (found === 0) {
+    return { line: `  ${render.icons.ok} ${render.wrap(render.c.green, "No issues found")}`, exitCode: 0 };
+  }
+  if (!autoFix) {
+    return {
+      line: `  ${render.icons.error} ${render.wrap(render.c.red, `${found} ${plural(found)} found`)} ${render.wrap(render.c.dim, "— see fixes above")}`,
+      exitCode: 1,
+    };
+  }
+  if (fixed >= found) {
+    return {
+      line: `  ${render.icons.ok} ${render.wrap(render.c.green, `${found} ${plural(found)} found, ${fixed} fixed ✓`)}`,
+      exitCode: 0,
+    };
+  }
+  const remaining = found - fixed;
+  return {
+    line: `  ${render.icons.error} ${render.wrap(render.c.red, `${found} ${plural(found)} found, ${fixed} fixed, ${remaining} remaining`)}`,
+    exitCode: 1,
+  };
+}
+
 // ─── flair doctor ─────────────────────────────────────────────────────────────
 
 program
@@ -8644,6 +8689,7 @@ program
     let effectivePort = port;
     let baseUrl = `http://127.0.0.1:${port}`;
     let issues = 0;
+    let fixed = 0; // issues that --fix successfully resolved during this run (flair#721)
     let harperResponding = false;
 
     console.log(`\n${render.wrap(render.c.bold, "🩺 Flair Doctor")}\n`);
@@ -8720,6 +8766,7 @@ program
             } else {
               writeConfig(discoveredPort);
               console.log(`     ${render.icons.ok} Updated config to port ${discoveredPort}`);
+              fixed++;
             }
           } else {
             console.log(`     ${render.wrap(render.c.dim, "Fix:")} flair doctor --fix ${render.wrap(render.c.dim, "(updates config to match running port)")}`);
@@ -8757,6 +8804,7 @@ program
                 const { execSync } = await import("node:child_process");
                 execSync(`${process.argv[0]} ${process.argv[1]} restart --port ${port}`, { stdio: "inherit" });
                 console.log(`     ${render.icons.ok} Restart attempted`);
+                fixed++;
               } catch {
                 console.log(`     ${render.icons.error} Restart failed — try: flair init --agent-id <your-agent>`);
               }
@@ -8797,6 +8845,7 @@ program
               const { execSync } = await import("node:child_process");
               execSync(`${process.argv[0]} ${process.argv[1]} restart --port ${effectivePort}`, { stdio: "inherit" });
               console.log(`     ${render.icons.ok} Restarted onto ${__pkgVersion}`);
+              fixed++;
             } catch {
               console.log(`     ${render.icons.error} Restart failed — try: flair restart`);
             }
@@ -8891,6 +8940,7 @@ program
           } else {
             (await import("node:fs")).unlinkSync(pidFile);
             console.log(`     ${render.icons.ok} Removed stale PID file`);
+            fixed++;
           }
         } else {
           console.log(`     ${render.wrap(render.c.dim, "Fix:")} rm ${pidFile} && flair restart`);
@@ -8970,6 +9020,7 @@ program
                     client.id === "gemini" ? wireGemini(wireEnv) :
                     wireCursor(wireEnv);
                   console.log(`     ${wireResult.ok ? render.icons.ok : render.icons.warn} ${wireResult.message}`);
+                  if (wireResult.ok) fixed++;
                 }
               }
             }
@@ -9019,6 +9070,7 @@ program
               } else {
                 const fixRes = fixClaudeMdBootstrap(process.cwd());
                 console.log(`     ${fixRes.ok ? render.icons.ok : render.icons.warn} ${fixRes.message}`);
+                if (fixRes.ok) fixed++;
               }
             }
           } else {
@@ -9043,6 +9095,7 @@ program
                 const fixAgentId = claudeCodeAgentId || opts.agent || process.env.FLAIR_AGENT_ID;
                 const fixRes = fixSessionStartHook(homedir(), fixAgentId);
                 console.log(`     ${fixRes.ok ? render.icons.ok : render.icons.warn} ${fixRes.message}`);
+                if (fixRes.ok) fixed++;
               }
             }
           } else {
@@ -9186,16 +9239,14 @@ program
       }
     }
 
-    // Summary
+    // Summary — see summarizeDoctorRun above (flair#721): distinguishes
+    // issues --fix actually resolved this run from ones still outstanding.
     console.log("");
-    if (issues === 0) {
-      console.log(`  ${render.icons.ok} ${render.wrap(render.c.green, "No issues found")}`);
-    } else {
-      console.log(`  ${render.icons.error} ${render.wrap(render.c.red, `${issues} issue${issues > 1 ? "s" : ""} found`)} ${render.wrap(render.c.dim, "— see fixes above")}`);
-    }
+    const summary = summarizeDoctorRun(issues, fixed, autoFix);
+    console.log(summary.line);
     console.log("");
 
-    if (issues > 0) process.exit(1);
+    if (summary.exitCode !== 0) process.exit(summary.exitCode);
   });
 
 // ─── flair session snapshot ──────────────────────────────────────────────────

--- a/test/unit/doctor-summary.test.ts
+++ b/test/unit/doctor-summary.test.ts
@@ -1,0 +1,92 @@
+/**
+ * doctor-summary.test.ts — Unit tests for summarizeDoctorRun (flair#721).
+ *
+ * `flair doctor --fix` used to track a single `issues` counter: every
+ * detected problem incremented it, with no record of which of those issues
+ * `--fix` actually resolved during the same run. A run that interactively
+ * fixed everything it found still printed "N issues found — see fixes
+ * above" and exited 1 — indistinguishable from a run that fixed nothing.
+ *
+ * Same pattern as cli-rem-rapid.test.ts (#707): the `doctor` action
+ * callback drives Harper probes, filesystem checks, interactive prompts,
+ * and process.exit, which makes it high-effort/low-value to drive
+ * directly (no CLI harness that mocks fetch/TTY/commander exists for this
+ * repo's convention — pure decision logic gets extracted instead). This is
+ * that extracted logic: given the found/fixed counts and whether --fix was
+ * requested, decide the summary line + exit code.
+ */
+
+import { describe, test, expect } from "bun:test";
+import { summarizeDoctorRun } from "../../src/cli.ts";
+
+describe("summarizeDoctorRun", () => {
+  test("no issues found → exit 0, regardless of --fix", () => {
+    for (const autoFix of [false, true]) {
+      const r = summarizeDoctorRun(0, 0, autoFix);
+      expect(r.exitCode).toBe(0);
+      expect(r.line).toContain("No issues found");
+    }
+  });
+
+  describe("without --fix (unchanged pre-#721 behavior)", () => {
+    test("issues found → exit 1, plain 'found' message, no fixed/remaining language", () => {
+      const r = summarizeDoctorRun(2, 0, false);
+      expect(r.exitCode).toBe(1);
+      expect(r.line).toContain("2 issues found");
+      expect(r.line).toContain("see fixes above");
+      expect(r.line).not.toContain("fixed");
+      expect(r.line).not.toContain("remaining");
+    });
+
+    test("singular pluralization for a single issue", () => {
+      const r = summarizeDoctorRun(1, 0, false);
+      expect(r.line).toContain("1 issue found");
+      expect(r.line).not.toContain("1 issues");
+    });
+
+    test("a nonzero `fixed` count is ignored when --fix wasn't passed", () => {
+      // Shouldn't happen in practice (fixed only increments inside --fix
+      // branches) but the summary must still key off `autoFix`, not `fixed`.
+      const r = summarizeDoctorRun(2, 2, false);
+      expect(r.exitCode).toBe(1);
+      expect(r.line).toContain("see fixes above");
+      expect(r.line).not.toContain("fixed");
+    });
+  });
+
+  describe("with --fix, everything resolved", () => {
+    test("all issues fixed → exit 0, 'N issues found, N fixed' message", () => {
+      const r = summarizeDoctorRun(2, 2, true);
+      expect(r.exitCode).toBe(0);
+      expect(r.line).toContain("2 issues found, 2 fixed");
+      expect(r.line).toContain("✓");
+    });
+
+    test("singular pluralization when the one issue found was fixed", () => {
+      const r = summarizeDoctorRun(1, 1, true);
+      expect(r.exitCode).toBe(0);
+      expect(r.line).toContain("1 issue found, 1 fixed");
+      expect(r.line).not.toContain("1 issues");
+    });
+  });
+
+  describe("with --fix, some remaining", () => {
+    test("partial fix → exit 1, 'found, fixed, remaining' breakdown", () => {
+      const r = summarizeDoctorRun(3, 1, true);
+      expect(r.exitCode).toBe(1);
+      expect(r.line).toContain("3 issues found, 1 fixed, 2 remaining");
+    });
+
+    test("nothing fixed (all declined/unfixable) → exit 1, 0 fixed reported explicitly", () => {
+      const r = summarizeDoctorRun(2, 0, true);
+      expect(r.exitCode).toBe(1);
+      expect(r.line).toContain("2 issues found, 0 fixed, 2 remaining");
+    });
+
+    test("singular 'remaining' count still reads correctly (no special-cased grammar needed)", () => {
+      const r = summarizeDoctorRun(2, 1, true);
+      expect(r.exitCode).toBe(1);
+      expect(r.line).toContain("2 issues found, 1 fixed, 1 remaining");
+    });
+  });
+});


### PR DESCRIPTION
Closes #721. `doctor --fix` tracked one counter — every problem incremented it and the summary read only that, with no record of what `--fix` actually resolved. A run that healed everything still ended `✗ N issues found` and exited 1, breaking scripted use.

Now fixed-vs-remaining is explicit: the 7 in-run fix sites count toward `fixed` only on genuine success. Contract: all fixed → `N issues found, N fixed ✓`, exit 0; some remaining → `N found, M fixed, K remaining`, exit 1; no `--fix` → byte-identical old behavior. Decision logic extracted to a pure `summarizeDoctorRun(found, fixed, autoFix)` helper (repo's CLI-testing precedent), 9 new unit tests. Rebased onto #723's merge with both CHANGELOG entries kept.

Second of the two 0.22.1 fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
