### PR TITLE
fix(doctor): validate scraped FLAIR_URL at the shared wiring site; append-if-missing for existing Codex config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## [Unreleased]
 
+### 🐛 `flair doctor`'s Codex wiring printed a broken FLAIR_URL and needlessly forced manual mode on an existing config.toml (flair#727)
+
+Two defects in doctor's Codex client-integration fix path, found on a real 0.22.1 dogfood run against a second machine.
+
+- **Broken `FLAIR_URL`.** When a stale/malformed value was scraped from an existing (partially-wired) `~/.codex/config.toml` — e.g. a bare host with no scheme or port, left over from an older Flair version or a hand-edited file — `doctor --fix` reused it verbatim in the freshly suggested block: `FLAIR_URL = "127.0.0.1"`, unusable if pasted. New `resolveWireFlairUrl()` (`src/doctor-client.ts`) only trusts an existing value when it parses as an absolute `http(s)://` URL; otherwise it falls back to the live, authoritative URL doctor already computed from the same port source as its `Config: ... (port: NNNNN)` line. This call site is shared by all four clients (Claude Code, Codex, Gemini, Cursor), so the fix applies uniformly — the other three clients' JSON templates were checked for the same class of bug and found clean (they always rendered the URL they were given; the bad value only ever originated at this one construction site).
+- **Existing `config.toml` no longer forces manual wiring unconditionally.** `_wireCodex` (`src/install/clients.ts`) used to refuse to touch any pre-existing file, regardless of content. Appending a `[mcp_servers.flair]` table at EOF is safe TOML when that exact header isn't already present, so it now greps for the header (`codexConfigHasFlairSection`) and appends (`appendCodexFlairBlock`, with the same blank-line separator convention as `fixClaudeMdBootstrap`) when missing, or reports `already wired` (idempotent, no write) when present — matching the JSON clients' existing idempotency contract. The manual-print fallback is now reserved for the genuinely unreadable/unwritable case (permissions, I/O error) — and that fallback's block renders the same corrected, always-authoritative URL.
+
 ## [0.22.1] - 2026-07-14
 
 ### 🐛 Migration disk-headroom pre-flight blocked trivially-small migrations on normally-full personal disks (flair#720)

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -58,6 +58,7 @@ import {
   fixSessionStartHook,
   applyOrReportClaudeMdBootstrap,
   applyOrReportSessionStartHook,
+  resolveWireFlairUrl,
 } from "./doctor-client.js";
 
 // Federation crypto helpers — inlined to avoid cross-boundary imports from
@@ -9013,7 +9014,7 @@ program
                 if (!fixAgentId) {
                   console.log(`     ${render.icons.warn} Cannot auto-wire ${client.label}: no agent id known — pass --agent <id>`);
                 } else {
-                  const wireEnv = { FLAIR_AGENT_ID: fixAgentId, FLAIR_URL: block.flairUrl || baseUrl };
+                  const wireEnv = { FLAIR_AGENT_ID: fixAgentId, FLAIR_URL: resolveWireFlairUrl(block.flairUrl, baseUrl) };
                   const wireResult =
                     client.id === "claude-code" ? wireClaudeCode(wireEnv) :
                     client.id === "codex" ? wireCodex(wireEnv) :

--- a/src/doctor-client.ts
+++ b/src/doctor-client.ts
@@ -146,6 +146,37 @@ function scanCodexFlairBlock(raw: string): { present: boolean; agentId?: string;
   return { present: !!agentId && !!flairUrl, agentId, flairUrl };
 }
 
+// ── check 2: FLAIR_URL to use when (re-)wiring a client (flair#727) ────────
+
+/**
+ * Pick the FLAIR_URL to feed a wire() call when `doctor --fix` re-wires a
+ * client whose block was judged "not present" (readClientMcpBlock — missing
+ * FLAIR_AGENT_ID and/or FLAIR_URL). A pre-existing config can still carry a
+ * `flairUrl` fragment (e.g. `present:false` because FLAIR_AGENT_ID is empty,
+ * but FLAIR_URL scanned fine) — and that fragment can itself be malformed: a
+ * bare host with no scheme/port (`"127.0.0.1"`), left over from an older
+ * Flair version or a hand-edited config. Blindly reusing it perpetuates the
+ * corruption into the freshly suggested block (flair#727 — a real dogfood
+ * run printed exactly `FLAIR_URL = "127.0.0.1"`, unusable if pasted).
+ *
+ * Only trust `existingFlairUrl` when it parses as an absolute http(s) URL;
+ * otherwise fall back to `baseUrl` — the live, authoritative URL `doctor`
+ * already computed from the same port source as its "Config: ... (port:
+ * NNNNN)" line (resolveHttpPort / readPortFromConfig, with live-port
+ * discovery layered on top).
+ */
+export function resolveWireFlairUrl(existingFlairUrl: string | undefined, baseUrl: string): string {
+  if (existingFlairUrl) {
+    try {
+      const parsed = new URL(existingFlairUrl);
+      if (parsed.protocol === "http:" || parsed.protocol === "https:") return existingFlairUrl;
+    } catch {
+      // Not an absolute URL (e.g. a bare host like "127.0.0.1") — fall through.
+    }
+  }
+  return baseUrl;
+}
+
 // ── check 3: CLAUDE.md bootstrap instruction (claude-code only) ────────────
 
 export interface ClaudeMdCheckResult {

--- a/src/install/clients.ts
+++ b/src/install/clients.ts
@@ -122,8 +122,9 @@ function jsonSnippet(env: { FLAIR_AGENT_ID: string; FLAIR_URL: string }): string
   return JSON.stringify({ mcpServers: { flair: flairMcpEntry(env) } }, null, 2);
 }
 
-/** TOML `[mcp_servers.flair]` snippet (Codex format). */
-function tomlSnippet(env: { FLAIR_AGENT_ID: string; FLAIR_URL: string }): string {
+/** TOML `[mcp_servers.flair]` snippet (Codex format). Exported for tests
+ * (flair#727 — asserts the rendered template carries a full scheme+port URL). */
+export function tomlSnippet(env: { FLAIR_AGENT_ID: string; FLAIR_URL: string }): string {
   return [
     `[mcp_servers.flair]`,
     `command = "npx"`,
@@ -133,6 +134,30 @@ function tomlSnippet(env: { FLAIR_AGENT_ID: string; FLAIR_URL: string }): string
     `FLAIR_AGENT_ID = "${env.FLAIR_AGENT_ID}"`,
     `FLAIR_URL = "${env.FLAIR_URL}"`,
   ].join("\n");
+}
+
+/**
+ * True when `raw` TOML content already has a `[mcp_servers.flair]` header —
+ * the same detection scanCodexFlairBlock (src/doctor-client.ts) uses to
+ * decide whether the block is present. Pure string scan; no TOML parser
+ * (see the comment on _wireCodex below for why).
+ */
+export function codexConfigHasFlairSection(raw: string): boolean {
+  return /^\[mcp_servers\.flair\]\s*$/m.test(raw);
+}
+
+/**
+ * Pure merge: append the Flair TOML snippet to existing raw config.toml
+ * content. Callers MUST first confirm codexConfigHasFlairSection(raw) is
+ * false — appending a second `[mcp_servers.flair]` table would shadow/
+ * duplicate the first (TOML doesn't merge repeated table headers), so this
+ * function does not re-check; it just appends safely with a newline
+ * separator (mirrors fixClaudeMdBootstrap's separator logic in
+ * src/doctor-client.ts — never runs the new block into the prior line).
+ */
+export function appendCodexFlairBlock(raw: string, env: { FLAIR_AGENT_ID: string; FLAIR_URL: string }): string {
+  const separator = raw.length === 0 ? "" : raw.endsWith("\n\n") ? "" : raw.endsWith("\n") ? "\n" : "\n\n";
+  return raw + separator + tomlSnippet(env) + "\n";
 }
 
 /**
@@ -228,18 +253,22 @@ function _wireClaudeCode(env: { FLAIR_AGENT_ID: string; FLAIR_URL: string }): { 
 
 function _wireCodex(env: { FLAIR_AGENT_ID: string; FLAIR_URL: string }): { ok: boolean; message: string } {
   // Codex uses TOML with a [mcp_servers.flair] table. We don't carry a TOML
-  // parser, and blind text-appending risks corrupting/duplicating an existing
-  // table — so we only auto-write when the file does NOT yet exist (clean
-  // create), otherwise emit the exact TOML block to paste.
+  // parser, but appending a new top-level table at EOF is safe TOML when the
+  // exact header isn't already present (flair#727) — so an existing file only
+  // forces the manual-print fallback when it's genuinely unreadable/
+  // unwritable (permissions, I/O error), never merely "exists". A file that
+  // already has the section is reported already-wired, matching the JSON
+  // clients' idempotency (wireJsonMcp above).
   const path = codexConfigPath();
   const display = "~/.codex/config.toml";
   try {
     if (existsSync(path)) {
-      return {
-        ok: false,
-        message: `Codex: manual wiring needed — ${display} already exists.\n` +
-          `   Add this block to ${display}:\n${indent(tomlSnippet(env))}`,
-      };
+      const raw = readFileSync(path, "utf-8");
+      if (codexConfigHasFlairSection(raw)) {
+        return { ok: true, message: `Codex: already wired in ${display}` };
+      }
+      writeFileSync(path, appendCodexFlairBlock(raw, env));
+      return { ok: true, message: `Codex: wired ${display} (restart Codex to pick it up)` };
     }
     mkdirSync(dirname(path), { recursive: true });
     writeFileSync(path, tomlSnippet(env) + "\n");

--- a/test/unit/client-wiring.test.ts
+++ b/test/unit/client-wiring.test.ts
@@ -3,7 +3,15 @@ import { mkdtempSync, rmSync, existsSync, readFileSync, writeFileSync, mkdirSync
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
-import { wireGemini, wireCursor, wireCodex } from "../../src/install/clients.ts";
+import {
+  wireGemini,
+  wireCursor,
+  wireCodex,
+  tomlSnippet,
+  codexConfigHasFlairSection,
+  appendCodexFlairBlock,
+} from "../../src/install/clients.ts";
+import { resolveWireFlairUrl } from "../../src/doctor-client.ts";
 
 /**
  * FIX 4 (onboarding dogfood round 1):
@@ -80,15 +88,114 @@ describe("client wiring (FIX 4: 'wired' means a file was written)", () => {
     expect(toml).toContain(`FLAIR_AGENT_ID = "wirebot"`);
   });
 
-  it("Codex: says 'manual wiring needed' (ok:false) with the snippet when config.toml already exists — never lies 'wired'", () => {
+  // flair#727 — an existing config.toml used to force manual mode
+  // unconditionally. Appending a `[mcp_servers.flair]` table at EOF is safe
+  // TOML when that exact header isn't already present, so this is now the
+  // same "append-if-missing, report already-wired if present" idempotency
+  // the JSON clients (wireGemini/wireCursor above) use — never a blind
+  // overwrite, never a lie that manual wiring is needed just because *some*
+  // file exists.
+  it("Codex: appends the block when config.toml exists but has no [mcp_servers.flair] section, preserving prior content", () => {
     const cfgPath = join(isoHome, ".codex", "config.toml");
     mkdirSync(join(isoHome, ".codex"), { recursive: true });
     writeFileSync(cfgPath, "[some_other_table]\nkey = 1\n");
     const res = wireCodex(ENV);
+    expect(res.ok).toBe(true);
+    expect(res.message).toContain("wired");
+    const toml = readFileSync(cfgPath, "utf-8");
+    expect(toml).toContain("[some_other_table]");   // preserved
+    expect(toml).toContain("key = 1");               // preserved
+    expect(toml).toContain("[mcp_servers.flair]");   // added
+    expect(toml).toContain(`FLAIR_AGENT_ID = "wirebot"`);
+    expect(toml).toContain(`FLAIR_URL = "${ENV.FLAIR_URL}"`);
+  });
+
+  it("Codex: skip-when-present — reports already-wired (ok:true, no write) when [mcp_servers.flair] already exists, and doesn't touch the file", () => {
+    const cfgPath = join(isoHome, ".codex", "config.toml");
+    mkdirSync(join(isoHome, ".codex"), { recursive: true });
+    const existingToml = tomlSnippet({ FLAIR_AGENT_ID: "someoneelse", FLAIR_URL: "http://127.0.0.1:1111" }) + "\n";
+    writeFileSync(cfgPath, existingToml);
+    const res = wireCodex(ENV);
+    expect(res.ok).toBe(true);
+    expect(res.message).toContain("already wired");
+    // File must be byte-for-byte untouched — no TOML parser, no safe rewrite.
+    expect(readFileSync(cfgPath, "utf-8")).toBe(existingToml);
+  });
+
+  it("Codex: manual-fallback only for the genuinely unreadable case — never for 'file exists'", () => {
+    // A directory in place of the config file makes readFileSync throw
+    // (EISDIR) regardless of process UID — a portable way to force the
+    // catch-block fallback without relying on chmod (which no-ops for root).
+    const cfgPath = join(isoHome, ".codex", "config.toml");
+    mkdirSync(cfgPath, { recursive: true });
+    const res = wireCodex(ENV);
     expect(res.ok).toBe(false);
     expect(res.message).toContain("manual wiring needed");
-    expect(res.message).toContain("[mcp_servers.flair]"); // the correct snippet to paste
-    // Must NOT have clobbered the existing file.
-    expect(readFileSync(cfgPath, "utf-8")).toContain("[some_other_table]");
+    expect(res.message).toContain("could not write");
+    expect(res.message).toContain("[mcp_servers.flair]"); // correct snippet still printed
+    expect(res.message).toContain(ENV.FLAIR_URL);          // and it's the real URL, not a bare host
+  });
+
+  // flair#727 bug 1 — the manual-print block (and the auto-write path, which
+  // shares the same template) rendered a bare host with no scheme/port. Cover
+  // the exact regression: a properly configured port renders a full URL.
+  it("tomlSnippet: renders the full scheme+port URL, never a bare host", () => {
+    const rendered = tomlSnippet({ FLAIR_AGENT_ID: "wirebot", FLAIR_URL: "http://127.0.0.1:19926" });
+    expect(rendered).toContain('FLAIR_URL = "http://127.0.0.1:19926"');
+    expect(rendered).not.toContain('FLAIR_URL = "127.0.0.1"');
+  });
+
+  describe("codexConfigHasFlairSection (append-decision, pure)", () => {
+    it("false on empty content", () => {
+      expect(codexConfigHasFlairSection("")).toBe(false);
+    });
+    it("false when only an unrelated table is present", () => {
+      expect(codexConfigHasFlairSection("[some_other_table]\nkey = 1\n")).toBe(false);
+    });
+    it("true when [mcp_servers.flair] header is present", () => {
+      expect(codexConfigHasFlairSection("[mcp_servers.flair]\ncommand = \"npx\"\n")).toBe(true);
+    });
+  });
+
+  describe("appendCodexFlairBlock (pure merge)", () => {
+    it("adds a blank-line separator when the existing content doesn't end in one", () => {
+      const merged = appendCodexFlairBlock("[some_other_table]\nkey = 1", ENV);
+      expect(merged).toBe("[some_other_table]\nkey = 1\n\n" + tomlSnippet(ENV) + "\n");
+    });
+    it("doesn't add a redundant blank line when content already ends in one", () => {
+      const merged = appendCodexFlairBlock("[some_other_table]\nkey = 1\n\n", ENV);
+      expect(merged).toBe("[some_other_table]\nkey = 1\n\n" + tomlSnippet(ENV) + "\n");
+    });
+    it("handles empty existing content (equivalent to a clean create)", () => {
+      const merged = appendCodexFlairBlock("", ENV);
+      expect(merged).toBe(tomlSnippet(ENV) + "\n");
+    });
+  });
+});
+
+// flair#727 bug 1 — resolveWireFlairUrl (src/doctor-client.ts) decides which
+// FLAIR_URL doctor's client-integration --fix feeds into wire*(): a
+// pre-existing but malformed value (bare host, no scheme/port) must never
+// flow through into a freshly suggested block.
+describe("resolveWireFlairUrl (flair#727 — never propagate a malformed existing URL)", () => {
+  it("URL rendering with a configured port: falls back to baseUrl when no existing value", () => {
+    expect(resolveWireFlairUrl(undefined, "http://127.0.0.1:19926")).toBe("http://127.0.0.1:19926");
+  });
+
+  it("rejects a bare host with no scheme/port — the exact flair#727 regression shape", () => {
+    expect(resolveWireFlairUrl("127.0.0.1", "http://127.0.0.1:19926")).toBe("http://127.0.0.1:19926");
+  });
+
+  it("rejects an empty string", () => {
+    expect(resolveWireFlairUrl("", "http://127.0.0.1:19926")).toBe("http://127.0.0.1:19926");
+  });
+
+  it("preserves a well-formed existing http(s) URL instead of overriding it with baseUrl", () => {
+    expect(resolveWireFlairUrl("http://127.0.0.1:9999", "http://127.0.0.1:19926")).toBe("http://127.0.0.1:9999");
+    expect(resolveWireFlairUrl("https://flair.example.com", "http://127.0.0.1:19926")).toBe("https://flair.example.com");
+  });
+
+  it("rejects a non-http(s) scheme", () => {
+    expect(resolveWireFlairUrl("ftp://127.0.0.1:19926", "http://127.0.0.1:19926")).toBe("http://127.0.0.1:19926");
   });
 });


### PR DESCRIPTION
Closes #727. Root cause was upstream of the printed block: doctor's shared wireEnv construction trusted a malformed `FLAIR_URL` scraped from a partially-wired existing config (`block.flairUrl || baseUrl`) — a bare host with no scheme/port survives that `||`. New `resolveWireFlairUrl` only accepts a scraped value that parses as absolute http(s), else uses doctor's live `baseUrl`; the single call site fixes all four clients uniformly.

Second facet: an existing `~/.codex/config.toml` no longer forces manual mode — `[mcp_servers.flair]` is appended when absent, reported already-wired when present, byte-untouched otherwise; the manual-print fallback survives only for genuinely unreadable/unwritable files (and now prints the correct URL).

Pure-helper tests per house convention, including the exact-bug assertion (`http://127.0.0.1:19926`, never `"127.0.0.1"`). Suite 2318/0 + root DI 221/0; all three typechecks clean.

Refs #727.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
