### PR TITLE
test: complete the embeddings-provider mock surface — fix latent bun module-cache poisoning (#691)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## [Unreleased]
 
+### 🧪 Test infra: complete the embeddings-provider mock surface — latent `bun test` module-cache poisoning (flair#691)
+
+Three unit files `mock.module("resources/embeddings-provider.ts", ...)` with PARTIAL stubs. `bun test test/unit` runs all files in one process and `mock.module` is process-global/unrestored, so whichever mocking file ran first won the module cache for every later file in that worker — and a stub omitting an export (`getModelId`/`buildEmbedOptions`/`resolveModelsDir`) made real importers (migrations-embedding-stamp et al.) die with `SyntaxError: Export named ... not found` as an unhandled error between tests. Latent until file scheduling shifted: adding the 140th unit test file (any new PR) armed it, turning every subsequent PR red on a bug in none of their diffs.
+
+- New shared `test/unit/helpers/embeddings-provider-mock.ts` returns the COMPLETE export surface; the three files override only what they assert on.
+- New `embeddings-provider-mock-completeness.test.ts` pins the helper to the real module's named exports so it fails loudly at the source if an export is added without updating the stub.
+
+
 ### 🐛 `flair doctor`'s Codex wiring printed a broken FLAIR_URL and needlessly forced manual mode on an existing config.toml (flair#727)
 
 Two defects in doctor's Codex client-integration fix path, found on a real 0.22.1 dogfood run against a second machine.

--- a/test/unit/embeddings-provider-mock-completeness.test.ts
+++ b/test/unit/embeddings-provider-mock-completeness.test.ts
@@ -1,0 +1,35 @@
+// Pins the shared embeddings-provider mock's export surface to the real
+// module's named exports. If someone adds an export to
+// resources/embeddings-provider.ts and a test file imports it by name, an
+// incomplete mock would poison that import in the shared `bun test` process
+// (SyntaxError: Export named 'x' not found) — latent until file scheduling
+// shifts. This test fails loudly at the source instead. See
+// helpers/embeddings-provider-mock.ts. (flair#691 flake-hardening.)
+import { describe, it, expect } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { embeddingsProviderMock } from "./helpers/embeddings-provider-mock";
+
+describe("embeddings-provider mock completeness (flair#691)", () => {
+  it("stubs every named export the real module declares", () => {
+    const src = readFileSync(
+      join(import.meta.dir, "../../resources/embeddings-provider.ts"),
+      "utf8",
+    );
+    // Match `export function|const NAME` and `export { NAME, ... }`; skip
+    // type-only exports (erased at runtime, never break a value import).
+    const named = new Set<string>();
+    for (const m of src.matchAll(/^export\s+(?:async\s+)?(?:function|const)\s+([A-Za-z0-9_]+)/gm)) {
+      named.add(m[1]);
+    }
+    for (const m of src.matchAll(/^export\s+\{([^}]+)\}/gm)) {
+      for (const part of m[1].split(",")) {
+        const name = part.trim().split(/\s+as\s+/)[0].trim();
+        if (name && !part.includes("type ")) named.add(name);
+      }
+    }
+    const stub = embeddingsProviderMock();
+    const missing = [...named].filter((n) => !(n in stub));
+    expect(missing).toEqual([]);
+  });
+});

--- a/test/unit/helpers/embeddings-provider-mock.ts
+++ b/test/unit/helpers/embeddings-provider-mock.ts
@@ -1,0 +1,36 @@
+// Complete stub surface for `mock.module("resources/embeddings-provider.ts")`.
+//
+// `bun test test/unit` runs every file in ONE process and `mock.module` is
+// process-global and unrestored — so whichever test file mocks
+// embeddings-provider first wins the module cache for every later file in
+// that worker, including files that import the REAL module. If a stub omits
+// any export a later consumer imports by name, that consumer dies with
+// `SyntaxError: Export named '<x>' not found in module 'embeddings-provider.ts'`
+// as an "unhandled error between tests" — and which files collide depends on
+// bun's file scheduling, so it stays latent until a new test file shifts the
+// order (adding the 140th unit file armed exactly this: getModelId /
+// buildEmbedOptions / resolveModelsDir went missing for migrations-embedding-
+// stamp et al.).
+//
+// The rule the memory-integrity stub already documented but wasn't applied
+// everywhere: a stub's export surface must be a SUPERSET of every consumer's
+// named imports, not just the mocking file's own. This helper makes that
+// structural — it returns the full surface; callers override only what they
+// assert on. Keep it in sync with embeddings-provider.ts's exports (the
+// mock-completeness test pins it).
+export function embeddingsProviderMock(
+  overrides: Record<string, unknown> = {},
+): Record<string, unknown> {
+  return {
+    getEmbedding: async (_text: string, _inputType?: string) => null,
+    getModelId: () => "mock-embedding-model",
+    getMode: () => "none",
+    getStatus: () => ({ mode: "none" as const }),
+    buildEmbedOptions: (inputType?: "document" | "query") => ({
+      model: "default" as const,
+      ...(inputType ? { inputType } : {}),
+    }),
+    resolveModelsDir: () => "/tmp/mock-models",
+    ...overrides,
+  };
+}

--- a/test/unit/memory-bootstrap-scoping.test.ts
+++ b/test/unit/memory-bootstrap-scoping.test.ts
@@ -19,6 +19,7 @@
  * mock+import exclusively (no other test/unit/ file imports it).
  */
 import { describe, it, expect, mock } from "bun:test";
+import { embeddingsProviderMock } from "./helpers/embeddings-provider-mock";
 
 process.env.FLAIR_RATE_LIMIT_ENABLED = "false";
 delete (process.env as any).FLAIR_PUBLIC;
@@ -44,14 +45,16 @@ const FAKE_EMBEDDING = [1, ...Array(127).fill(0)];
 // task-relevance query embed passes 'query' (currentTask is a search query
 // against stored memories, never stored content itself).
 let embedInputTypeCalls: (string | undefined)[] = [];
-mock.module("../../resources/embeddings-provider.ts", () => ({
-  getEmbedding: async (_text: string, inputType?: string) => {
-    embedInputTypeCalls.push(inputType);
-    return FAKE_EMBEDDING;
-  },
-  getModelId: () => "mock-embedding-model",
-  getMode: () => "local",
-}));
+mock.module("../../resources/embeddings-provider.ts", () =>
+  embeddingsProviderMock({
+    getEmbedding: async (_text: string, inputType?: string) => {
+      embedInputTypeCalls.push(inputType);
+      return FAKE_EMBEDDING;
+    },
+    getModelId: () => "mock-embedding-model",
+    getMode: () => "local",
+  }),
+);
 
 function matchesCondition(record: any, cond: any): boolean {
   if (cond.operator && Array.isArray(cond.conditions)) {

--- a/test/unit/memory-integrity.test.ts
+++ b/test/unit/memory-integrity.test.ts
@@ -20,6 +20,7 @@
  * jaccardSimilarity() implementations — nothing about that math is mocked.
  */
 import { describe, it, expect, beforeEach, mock, spyOn } from "bun:test";
+import { embeddingsProviderMock } from "./helpers/embeddings-provider-mock";
 
 // Defensive: `bun test <dir>` runs every file in one process, and
 // resources/rate-limiter.ts reads process.env LAZILY (not cached at import
@@ -40,23 +41,20 @@ const FAKE_EMBEDDING = [1, 0, 0, 0];
 // together; the dedup-gate embedding IS the stored vector).
 let embedInputTypeCalls: (string | undefined)[] = [];
 
-mock.module("../../resources/embeddings-provider.ts", () => ({
-  getEmbedding: async (_text: string, inputType?: string) => {
-    embedInputTypeCalls.push(inputType);
-    return FAKE_EMBEDDING;
-  },
-  getModelId: () => "mock-embedding-model",
-  // getMode is unused by this file's own tests, but MUST still be exported —
-  // `bun test test/unit` runs every file in one process, and another file's
-  // dynamic import of a module that (transitively) imports embeddings-
-  // provider.ts can resolve to whichever mock reached the module cache
-  // first. An incomplete mock here previously broke
-  // test/unit/semantic-search-scoping.test.ts (SemanticSearch.ts imports
-  // getMode too) with "Export named 'getMode' not found" when run in the
-  // same process — keep this mock's export surface a superset of every
-  // consumer's named imports, not just this file's own.
-  getMode: () => "local",
-}));
+// The complete export surface (getModelId/getMode/buildEmbedOptions/
+// resolveModelsDir/getStatus/getEmbedding) comes from the shared helper —
+// see its header for why a partial stub poisons other files' real imports.
+// This file overrides only what its own tests assert on.
+mock.module("../../resources/embeddings-provider.ts", () =>
+  embeddingsProviderMock({
+    getEmbedding: async (_text: string, inputType?: string) => {
+      embedInputTypeCalls.push(inputType);
+      return FAKE_EMBEDDING;
+    },
+    getModelId: () => "mock-embedding-model",
+    getMode: () => "local",
+  }),
+);
 
 // ─── In-memory Harper Memory / MemoryGrant / Agent mock ─────────────────────
 

--- a/test/unit/semantic-search-scoping.test.ts
+++ b/test/unit/semantic-search-scoping.test.ts
@@ -26,6 +26,7 @@
  * class-capture collision documented there.
  */
 import { describe, it, expect, mock } from "bun:test";
+import { embeddingsProviderMock } from "./helpers/embeddings-provider-mock";
 
 process.env.FLAIR_RATE_LIMIT_ENABLED = "false";
 delete (process.env as any).FLAIR_PUBLIC;
@@ -43,13 +44,15 @@ delete (process.env as any).FLAIR_HYBRID_RETRIEVAL;
 // 'document' (see embeddings-provider-input-type.test.ts for the value-
 // forwarding logic itself).
 let embedInputTypeCalls: (string | undefined)[] = [];
-mock.module("../../resources/embeddings-provider.ts", () => ({
-  getEmbedding: async (_text: string, inputType?: string) => {
-    embedInputTypeCalls.push(inputType);
-    return null;
-  },
-  getMode: () => "none",
-}));
+mock.module("../../resources/embeddings-provider.ts", () =>
+  embeddingsProviderMock({
+    getEmbedding: async (_text: string, inputType?: string) => {
+      embedInputTypeCalls.push(inputType);
+      return null;
+    },
+    getMode: () => "none",
+  }),
+);
 
 // ─── In-memory Harper Memory / MemoryGrant mock (search-only; SemanticSearch
 // never post()/put()s Memory directly, only patches retrievalCount via


### PR DESCRIPTION
Fixes the latent test-suite bug that is currently turning **every new PR red** (#730 and #731 both, on a bug in neither of their diffs) — the concrete recurrence of #691.

**Root cause:** three unit files `mock.module("resources/embeddings-provider.ts")` with PARTIAL stubs. `bun test test/unit` runs all files in one process; `mock.module` is process-global and unrestored, so the first-scheduled mocking file wins the module cache for every later file in that worker. A stub omitting an export (`getModelId`/`buildEmbedOptions`/`resolveModelsDir`) makes real importers (migrations-embedding-stamp, memory-integrity, …) die with `SyntaxError: Export named ... not found` — reported as an unhandled error between tests. It stayed latent until a 140th unit test file (any PR that adds one) reshuffled bun's scheduling and armed the collision.

**Fix:** a shared `embeddings-provider-mock.ts` helper returning the COMPLETE export surface (callers override only what they assert), plus a completeness tripwire test pinning the helper to the real module's named exports so a future added export fails loudly at the source instead of poisoning a random later file.

The `memory-integrity` stub already *documented* this exact hazard — the fix just makes completeness structural instead of per-file vigilance. Full unit suite green locally (2370/0); CI is the real gate for an order-dependent bug. Once this merges, #730/#731 rebase onto it and go green.

Refs #691.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
