### PR TITLE
feat(identity): authorship provenance — claimed.client records which client wrote a row (flair#718)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 ## [Unreleased]
 
+### ✨ Authorship provenance — `claimed.client` records which client wrote a row (flair#718)
+
+An audit of the identity machinery reframed this from "add a personal-vs-org deployment mode" to a narrower, cheaper fix: the personal shape (one shared principal across every AI client, via `flair init`) already ships and is correct — what's missing is recording *which client* authored a write once several clients share one principal. K&S-approved design (issue #718): no new config key (deployment shape stays emergent from provisioning, now documented in `docs/auth.md`), authorship recorded in the existing `claimed` (self-reported, unverified) provenance slot rather than a first-class row field.
+
+- **`resources/provenance.ts`**: `buildProvenance` gains `claimed.client`, sourced from a write-body-only `claimedClient` field (deliberately distinct from the stamped output key). Shares a new `sanitizeClaim()` helper with `claimed.model` — both now get the SAME discipline: string-only, control-character-stripped, trimmed, length-capped at 200 chars, dropped if empty after sanitizing (Sherlock flair#718 refinement: `claimed.model` previously had only a truthiness check).
+- **Write paths** (`resources/Memory.ts` post()/put(), `resources/Relationship.ts` put()): thread `claimedClient` into `buildProvenance`, then strip it from the row before persisting — authorship lives in the `provenance` JSON only, never as a second top-level field.
+- **Native `/mcp` OAuth path** (`resources/mcp-handler.ts`, `resources/mcp-tools.ts`): the handler stamps `claimed.client` from the verified token's `client_id` claim (the server-generated `flair_cl_...` machine id) — **never** `client_name` (user-controlled at Dynamic Client Registration), per Sherlock's binding refinement. `ResolvedAgent` gains an optional `clientId`, threaded into `memory_store`/`memory_update`'s write bodies; no client-side cooperation needed for this surface.
+- **`packages/flair-client`**: `FlairClientConfig.claimedClient` (or the `FLAIR_CLIENT` env var) is forwarded on `memory.write()`/`memory.update()` payloads when set; absent by default — zero behavior change for existing installs. **`packages/flair-mcp`** forwards its own `FLAIR_CLIENT` env into the client it constructs.
+- **`flair init`**: each client's wired env block (Claude Code, Codex, Gemini, Cursor) gains `FLAIR_CLIENT` set to that client's own id. Optional/additive — `flair doctor --fix`'s re-wiring path is unchanged (no FLAIR_CLIENT, deferred).
+- **Zero authority, by construction**: `claimed.client` is self-reported, unverified metadata — it is never read for access control, read-scope, attribution weighting, or dedup decisions anywhere in the codebase. `docs/auth.md` gets a new "Deployment shapes: personal vs org" section documenting the existing personal/org provisioning distinction and this field's role in it.
+
+Out of scope for this slice (explicitly, per the design record): new config keys, per-client credentials, row backfill, trust scoring, `flair doctor` rendering changes, and provenance stamping for Soul/WorkspaceState/OrgEvent (neither stamps provenance today).
+
 ### ✨ `flair doctor` now iterates every identifiable agent for its verified-read sections, instead of hiding them behind `--agent` (flair#722)
 
 `doctor`'s "Fleet presence" and "Migrations" sections need a signed (Ed25519) request to reveal server-verified fields (flairVersion/harperVersion, migration state) — previously that meant passing `--agent <id>` explicitly, even though doctor already enumerates every key in `~/.flair/keys` (the `Keys found: N agent(s)` line). A real 0.22.0 dogfood run found the flair#720 halted-migration warning visible via `flair status --agent local` but invisible in the default `doctor` run the same user ran minutes later.

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -39,6 +39,23 @@ flair agent add myagent
 
 This is the default and recommended auth for single-instance deployments.
 
+## Deployment shapes: personal vs org
+
+Flair has no `mode`/`shape` config setting — the shape you get is emergent from *how you provision principals*, not something you declare:
+
+- **Personal (the default).** `flair init` mints ONE agent identity and wires that same `FLAIR_AGENT_ID` into every MCP client it configures (Claude Code, Codex, Gemini, Cursor). One human driving several AI clients ends up with one canonical principal and one Ed25519 keypair — all clients share ownership of the same memory. This is intentional, not a limitation: all clients see each other's private rows (one human's memory, one view), a fact re-asserted from two different clients dedups to one memory, and usage counting treats the principal as one contributor.
+- **Org (multiple real agents).** `flair agent add <id>` mints a distinct principal — its own keypair, its own ownership boundary — for each real agent that should be a separate identity. Wire each principal's own `FLAIR_AGENT_ID` into its own client(s).
+
+Nothing in flair validates which shape you're in; a personal install that later grows into an org just runs `flair agent add` for the new distinct identities it needs.
+
+### Authorship: which client wrote a row
+
+The personal shape's one shared principal means `agentId` alone can't answer "was this written by Claude Code or Codex?" — every write it receives has the same owner. `flair init`'s per-client wiring closes that gap by setting an additional env var per client: `FLAIR_CLIENT` (`"claude-code"` / `"codex"` / `"gemini"` / `"cursor"`). `flair-client` and `flair-mcp` forward it on memory writes as `claimedClient`, and the server folds it into the write's `provenance` blob as `claimed.client` — self-reported, unverified metadata recording *which tool* authored a row, alongside the existing `claimed.model`.
+
+This is deliberately in `claimed`, never `verified`: it carries **zero authority**. It is never read for access control, read-scope, attribution weighting, or dedup decisions — it exists purely for audit/analysis. Absent on any install that predates this field (no backfill, no migration) and absent whenever a client doesn't set `FLAIR_CLIENT`.
+
+The native `/mcp` OAuth surface (see below) doesn't need any client-side wiring at all: the handler stamps `claimed.client` directly from the OAuth token's verified `client_id` claim — the server-generated `flair_cl_...` machine id assigned at Dynamic Client Registration, **not** the user-supplied `client_name` (which the registering client fully controls and could set to anything). Using `client_id` keeps the stamp a stable, server-verified label even though it still only carries `claimed`-level (unverified-by-content) authority.
+
 ## OAuth 2.1
 
 Flair includes a built-in OAuth 2.1 authorization server for client integrations (e.g., Claude connecting to Flair as an MCP server).

--- a/packages/flair-client/src/client.ts
+++ b/packages/flair-client/src/client.ts
@@ -32,6 +32,10 @@ export class FlairClient {
   readonly memory: MemoryApi;
   readonly relationship: RelationshipApi;
   readonly soul: SoulApi;
+  /** flair#718 authorship-provenance — see FlairClientConfig.claimedClient's
+   *  doc (types.ts). `undefined` when neither config nor FLAIR_CLIENT is set;
+   *  MemoryApi reads this to (optionally) stamp memory write payloads. */
+  readonly claimedClient: string | undefined;
 
   private privateKey: KeyObject | null = null;
   private keyResolved = false;
@@ -47,6 +51,7 @@ export class FlairClient {
     if (config.privateKey !== undefined) {
       this.rawPrivateKey = config.privateKey;
     }
+    this.claimedClient = config.claimedClient || process.env.FLAIR_CLIENT || undefined;
     this.timeoutMs = config.timeoutMs ?? DEFAULT_TIMEOUT;
     // Basic auth fallback for standalone deployments without Ed25519 keys
     const adminUser = config.adminUser ?? process.env.FLAIR_ADMIN_USER;
@@ -185,6 +190,11 @@ class MemoryApi {
     // never stored on the record itself.
     if (opts.dedup !== undefined) record.dedup = opts.dedup;
     if (opts.dedupThreshold !== undefined) record.dedupThreshold = opts.dedupThreshold;
+    // flair#718 authorship-provenance: forward this process's claimed client
+    // label (config.claimedClient / FLAIR_CLIENT env) only when set — the
+    // server folds it into provenance.claimed.client and strips it from the
+    // row (resources/Memory.ts). Absent = omitted, zero behavior change.
+    if (this.client.claimedClient) record.claimedClient = this.client.claimedClient;
 
     const response = await this.client.request<Record<string, unknown>>("PUT", `/Memory/${id}`, record);
     // Merge the server response (deduplicated/matchedId/matchConfidence/
@@ -236,6 +246,8 @@ class MemoryApi {
       delete record.validTo;
       delete record.archivedAt;
       delete record.deduped;
+      // flair#718 authorship-provenance — see write()'s identical comment above.
+      if (this.client.claimedClient) record.claimedClient = this.client.claimedClient;
       // The Memory schema does not expose a working HTTP POST route (see
       // resources/Memory.ts) — Memory.post() is only reachable in-process
       // (resources/mcp-tools.ts). So the supersede-link write goes through
@@ -254,6 +266,8 @@ class MemoryApi {
     delete merged.embedding;
     delete merged.embeddingModel;
     delete merged.deduped;
+    // flair#718 authorship-provenance — see write()'s identical comment above.
+    if (this.client.claimedClient) merged.claimedClient = this.client.claimedClient;
     const response = await this.client.request<Record<string, unknown>>("PUT", `/Memory/${id}`, merged);
     return { ...merged, id, ...(response ?? {}) } as unknown as Memory;
   }

--- a/packages/flair-client/src/types.ts
+++ b/packages/flair-client/src/types.ts
@@ -80,7 +80,7 @@ export interface Relationship {
   createdAt: string;
   updatedAt?: string;
   /** JSON blob, same shape as Memory.provenance — { v, verified: { agentId,
-   *  timestamp }, claimed?: { model } }. Absent on rows written before this
+   *  timestamp }, claimed?: { model, client } }. Absent on rows written before this
    *  field existed (migration-equivalence: additive/nullable). */
   provenance?: string;
   /** Always true after a successful write() — the server never suppresses a
@@ -144,4 +144,15 @@ export interface FlairClientConfig {
   adminUser?: string;
   /** Admin password for Basic auth fallback (standalone deployments). Falls back to FLAIR_ADMIN_PASSWORD env var. */
   adminPassword?: string;
+  /**
+   * flair#718 authorship-provenance: a label identifying WHICH CLIENT this
+   * process is (e.g. "claude-code", "codex", "gemini", "cursor") — recorded
+   * as unverified `provenance.claimed.client` on memory writes, distinct from
+   * `agentId` (ownership) and ungoverned by any authority (never enters
+   * read-scope, attribution, or dedup decisions — server-enforced in
+   * resources/provenance.ts). Falls back to the `FLAIR_CLIENT` env var.
+   * Absent (both here and in the env) = omitted entirely; zero behavior
+   * change for existing installs.
+   */
+  claimedClient?: string;
 }

--- a/packages/flair-client/test/client.test.ts
+++ b/packages/flair-client/test/client.test.ts
@@ -41,6 +41,33 @@ describe("FlairClient", () => {
     const client = new FlairClient({ agentId: "mybot" });
     expect(client.agentId).toBe("mybot");
   });
+
+  // ─── flair#718 authorship-provenance ───────────────────────────────────────
+  describe("claimedClient (flair#718 authorship-provenance)", () => {
+    test("absent by default — neither config nor FLAIR_CLIENT set", () => {
+      const client = new FlairClient({ agentId: "test" });
+      expect(client.claimedClient).toBeUndefined();
+    });
+
+    test("set from the explicit config field", () => {
+      const client = new FlairClient({ agentId: "test", claimedClient: "claude-code" });
+      expect(client.claimedClient).toBe("claude-code");
+    });
+
+    test("set from the FLAIR_CLIENT env var when config omits it", () => {
+      process.env.FLAIR_CLIENT = "codex";
+      const client = new FlairClient({ agentId: "test" });
+      expect(client.claimedClient).toBe("codex");
+      delete process.env.FLAIR_CLIENT;
+    });
+
+    test("explicit config field wins over FLAIR_CLIENT env", () => {
+      process.env.FLAIR_CLIENT = "codex";
+      const client = new FlairClient({ agentId: "test", claimedClient: "gemini" });
+      expect(client.claimedClient).toBe("gemini");
+      delete process.env.FLAIR_CLIENT;
+    });
+  });
 });
 
 describe("MemoryApi", () => {
@@ -293,6 +320,85 @@ describe("MemoryApi", () => {
     await expect(client.memory.update("nonexistent", "x")).rejects.toThrow();
     // Only the GET happened — no PUT was attempted.
     expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+
+  // ─── flair#718 authorship-provenance — claimedClient forwarding on memory writes ──
+  describe("claimedClient forwarding (flair#718 authorship-provenance)", () => {
+    test("write(): claimedClient is included in the PUT body when the client has one configured", async () => {
+      mockFetch = mock(() => Promise.resolve(new Response("{}", { status: 200 })));
+      globalThis.fetch = mockFetch as any;
+
+      const client = new FlairClient({ agentId: "test", claimedClient: "claude-code" });
+      await client.memory.write("hello world");
+
+      const call = (mockFetch as any).mock.calls[0];
+      const body = JSON.parse(call[1].body);
+      expect(body.claimedClient).toBe("claude-code");
+    });
+
+    test("write(): claimedClient is OMITTED from the body entirely when the client has none configured", async () => {
+      mockFetch = mock(() => Promise.resolve(new Response("{}", { status: 200 })));
+      globalThis.fetch = mockFetch as any;
+
+      const client = new FlairClient({ agentId: "test" });
+      await client.memory.write("hello world");
+
+      const call = (mockFetch as any).mock.calls[0];
+      const body = JSON.parse(call[1].body);
+      expect("claimedClient" in body).toBe(false);
+    });
+
+    test("write(): FLAIR_CLIENT env var (no explicit config field) also forwards", async () => {
+      mockFetch = mock(() => Promise.resolve(new Response("{}", { status: 200 })));
+      globalThis.fetch = mockFetch as any;
+      process.env.FLAIR_CLIENT = "cursor";
+
+      const client = new FlairClient({ agentId: "test" });
+      await client.memory.write("hello world");
+      delete process.env.FLAIR_CLIENT;
+
+      const call = (mockFetch as any).mock.calls[0];
+      const body = JSON.parse(call[1].body);
+      expect(body.claimedClient).toBe("cursor");
+    });
+
+    test("update() (default mode): claimedClient is included in the merged PUT body", async () => {
+      const existing = {
+        id: "mem-1", agentId: "test", content: "old content", type: "session",
+        durability: "standard", tags: [], createdAt: "2026-01-01T00:00:00Z",
+      };
+      mockFetch = mock((_url: string, init?: any) => {
+        if (init?.method === "GET") return Promise.resolve(new Response(JSON.stringify(existing), { status: 200 }));
+        return Promise.resolve(new Response(JSON.stringify({ written: true }), { status: 200 }));
+      });
+      globalThis.fetch = mockFetch as any;
+
+      const client = new FlairClient({ agentId: "test", claimedClient: "gemini" });
+      await client.memory.update("mem-1", "new content");
+
+      const putCall = (mockFetch as any).mock.calls.find((c: any) => c[1].method === "PUT");
+      const putBody = JSON.parse(putCall[1].body);
+      expect(putBody.claimedClient).toBe("gemini");
+    });
+
+    test("update() (preserveHistory mode): claimedClient is included on the new-version write", async () => {
+      const existing = {
+        id: "mem-1", agentId: "test", content: "old content", type: "session",
+        durability: "standard", tags: [], createdAt: "2026-01-01T00:00:00Z",
+      };
+      mockFetch = mock((_url: string, init?: any) => {
+        if (init?.method === "GET") return Promise.resolve(new Response(JSON.stringify(existing), { status: 200 }));
+        return Promise.resolve(new Response(JSON.stringify({ written: true }), { status: 200 }));
+      });
+      globalThis.fetch = mockFetch as any;
+
+      const client = new FlairClient({ agentId: "test", claimedClient: "codex" });
+      await client.memory.update("mem-1", "new version", { preserveHistory: true });
+
+      const putCall = (mockFetch as any).mock.calls.find((c: any) => c[1].method === "PUT");
+      const putBody = JSON.parse(putCall[1].body);
+      expect(putBody.claimedClient).toBe("codex");
+    });
   });
 
   test("list POSTs conditions body with agentId scope", async () => {

--- a/packages/flair-mcp/src/index.ts
+++ b/packages/flair-mcp/src/index.ts
@@ -160,6 +160,13 @@ export async function runMcp(): Promise<void> {
     agentId,
     url: process.env.FLAIR_URL,
     keyPath: process.env.FLAIR_KEY_PATH,
+    // flair#718 authorship-provenance: forward this stdio proxy's own
+    // FLAIR_CLIENT env (set by `flair init`'s per-client wiring, e.g.
+    // "claude-code"/"codex"/"gemini"/"cursor") into the client it constructs
+    // — explicit here rather than relying solely on FlairClient's own
+    // process.env fallback, so the forwarding is visible at this call site.
+    // Absent = omitted, zero behavior change for un-wired installs.
+    claimedClient: process.env.FLAIR_CLIENT,
   });
 
   // ─── Auto-presence (flair#598) ────────────────────────────────────────────────

--- a/resources/Memory.ts
+++ b/resources/Memory.ts
@@ -392,8 +392,9 @@ function defaultVisibilityForDurability(durability: unknown): "private" | "share
  * "reuse buildProvenance as-is" contract) instead of a hand-copied format
  * that could drift. See that module for the full field-by-field rationale
  * (verified.agentId from the auth verdict never the body, verified.timestamp
- * = the server-computed createdAt, optional unverified claimed.model
- * passthrough). Deliberately NOT implemented in this slice: a
+ * = the server-computed createdAt, optional unverified claimed.model /
+ * claimed.client passthroughs — the latter added by flair#718 authorship-
+ * provenance). Deliberately NOT implemented in this slice: a
  * context-fingerprint field — bootstrap doesn't return the IDs a fingerprint
  * would need, so it requires client cooperation that's out of scope here.
  */
@@ -656,6 +657,12 @@ export class Memory extends (databases as any).flair.Memory {
     // buildProvenance's doc above. Stamped last, right before persist, so it
     // reflects the final resolved `content.createdAt`.
     content.provenance = buildProvenance(auth, content.createdAt, content);
+    // flair#718 authorship-provenance: `claimedClient` is a WRITE-BODY-ONLY
+    // passthrough — buildProvenance above already folded it into
+    // `provenance.claimed.client` (sanitized/capped). Strip it from the row
+    // itself so it is NEVER persisted as a second, undeclared/unsanitized
+    // top-level field — authorship lives in the provenance JSON only.
+    delete content.claimedClient;
 
     // Write-time originatorInstanceId stamp (federation-edge-hardening slice
     // 1) — see stampOriginatorInstanceId's doc above. No-op if already set
@@ -833,6 +840,10 @@ export class Memory extends (databases as any).flair.Memory {
     // always gets a freshly-stamped provenance reflecting the CURRENT
     // authenticated actor performing this write.
     content.provenance = buildProvenance(auth, content.createdAt, content);
+    // flair#718 authorship-provenance — see post()'s identical comment above:
+    // strip the write-body-only `claimedClient` passthrough now that it's
+    // folded into `provenance.claimed.client`. Never persisted as a row field.
+    delete content.claimedClient;
 
     // Write-time originatorInstanceId stamp (federation-edge-hardening slice
     // 1) — see stampOriginatorInstanceId's doc above post(). No-op if

--- a/resources/Relationship.ts
+++ b/resources/Relationship.ts
@@ -204,6 +204,11 @@ export class Relationship extends (databases as any).flair.Relationship {
     // pre-existing row with no provenance field reads back `undefined`,
     // unchanged behavior (migration-equivalence gate).
     content.provenance = buildProvenance(auth, content.createdAt, content);
+    // flair#718 authorship-provenance — same contract as resources/Memory.ts's
+    // post()/put(): `claimedClient` is a write-body-only passthrough, already
+    // folded into `provenance.claimed.client` above. Strip it so it is NEVER
+    // persisted as a row field.
+    delete content.claimedClient;
 
     // Write-time originatorInstanceId stamp (federation-edge-hardening slice
     // 1) — see resources/Memory.ts's stampOriginatorInstanceId doc for the

--- a/resources/mcp-handler.ts
+++ b/resources/mcp-handler.ts
@@ -74,12 +74,21 @@ function jitProvisionEnabled(): boolean {
  * XAA's ID-JAG path uses (resources/XAA.ts resolveOrCreatePrincipal) — one
  * identity model, keyed on the IdP subject.
  *
+ * `clientId` (flair#718 authorship-provenance) is NOT part of sub resolution —
+ * it rides along from the verified token's `client_id` claim (see
+ * handleToolCall's stamp-site comment for why `client_id` and never
+ * `client_name`) and is copied onto the resolved agent unchanged so downstream
+ * write tools (memory_store/memory_update) can thread it into `claimedClient`.
+ * Omitted from the returned object entirely when absent — never stamped as
+ * `undefined` — so existing callers/tests that don't pass one see the exact
+ * same `{ agentId, isAdmin }` shape as before this field existed.
+ *
  * Returns:
- *   - `{ agentId, isAdmin }` when a Credential maps the sub to an Agent.
+ *   - `{ agentId, isAdmin, clientId? }` when a Credential maps the sub to an Agent.
  *   - null when no Credential maps the sub AND JIT-provisioning is disabled or
  *     failed → the handler denies the tool call (sub is unresolvable).
  */
-export async function resolveAgentFromSub(sub: string): Promise<ResolvedAgent | null> {
+export async function resolveAgentFromSub(sub: string, clientId?: string): Promise<ResolvedAgent | null> {
   if (!sub) return null;
 
   // 1. Existing IdP credential → its principalId is the Agent id.
@@ -95,7 +104,9 @@ export async function resolveAgentFromSub(sub: string): Promise<ResolvedAgent | 
         try {
           await (databases as any).flair.Credential.put({ ...cred, lastUsedAt: new Date().toISOString() });
         } catch { /* non-fatal */ }
-        return { agentId: String(cred.principalId), isAdmin: await isAgentAdmin(cred.principalId) };
+        const resolved: ResolvedAgent = { agentId: String(cred.principalId), isAdmin: await isAgentAdmin(cred.principalId) };
+        if (clientId) resolved.clientId = clientId;
+        return resolved;
       }
     }
   } catch { /* Credential table empty / search error → fall through to JIT/deny */ }
@@ -106,7 +117,9 @@ export async function resolveAgentFromSub(sub: string): Promise<ResolvedAgent | 
   try {
     const principalId = await jitProvisionPrincipal(sub);
     // A JIT-provisioned principal is a fresh, non-admin agent by construction.
-    return { agentId: principalId, isAdmin: false };
+    const resolved: ResolvedAgent = { agentId: principalId, isAdmin: false };
+    if (clientId) resolved.clientId = clientId;
+    return resolved;
   } catch {
     return null;
   }
@@ -245,7 +258,17 @@ async function handleToolCall(request: any, id: any, params: any): Promise<any> 
     return rpcError(id, -32001, "unauthorized: no verified token subject");
   }
 
-  const agent = await resolveAgentFromSub(String(sub));
+  // flair#718 authorship-provenance, Sherlock's binding refinement: source
+  // the authorship stamp from `client_id` (the server-generated
+  // `flair_cl_...` machine id — resources/OAuth.ts, an RS256-verified JWT
+  // claim, not a secret) — NEVER `client_name` (a free-text label the client
+  // supplied at Dynamic Client Registration time and fully controls). Do NOT
+  // "helpfully" switch this to `client_name` for a prettier label; that would
+  // turn a server-verified, stable id into caller-forgeable data landing in
+  // stored provenance. Absent/non-string client_id → omitted, not invented.
+  const clientId = typeof request?.mcp?.client_id === "string" ? request.mcp.client_id : undefined;
+
+  const agent = await resolveAgentFromSub(String(sub), clientId);
   if (!agent) {
     // Sub verified by the AS but not mapped to a flair Agent (and JIT disabled /
     // failed). Deny — do NOT fall back to anonymous or admin.

--- a/resources/mcp-tools.ts
+++ b/resources/mcp-tools.ts
@@ -87,6 +87,17 @@ export function __setHandlers(overrides: Partial<Record<HandlerKey, any>>): () =
 export interface ResolvedAgent {
   agentId: string;
   isAdmin: boolean;
+  /**
+   * flair#718 authorship-provenance: the OAuth token's verified `client_id`
+   * claim (resources/mcp-handler.ts's handleToolCall — sourced from
+   * `client_id`, NEVER `client_name`; see that stamp site for why). Optional
+   * and absent when the token carries none. Threaded into the write tools
+   * below as `claimedClient` on the POST/PUT body, which
+   * resources/provenance.ts's buildProvenance folds into
+   * `provenance.claimed.client` — records WHICH CLIENT authored the write,
+   * grants ZERO authority, never read for access control/attribution/dedup.
+   */
+  clientId?: string;
 }
 
 /** MCP tool descriptor as returned by tools/list. */
@@ -159,13 +170,19 @@ async function memoryStore(agent: ResolvedAgent, args: any) {
   // agentId is the RESOLVED agent — Memory.post also re-checks ownership via
   // resolveAgentAuth, so a mismatched body agentId would 403 anyway; we set it
   // to the verified id so the write is correctly owned.
-  return unwrap(await h.post({
+  const body: Record<string, unknown> = {
     agentId: agent.agentId,
     content: args?.content,
     type: args?.type ?? "session",
     durability: args?.durability ?? "standard",
     tags: args?.tags,
-  }));
+  };
+  // flair#718 authorship-provenance: forward the resolved OAuth client_id
+  // (never a tool argument — no forging) as claimedClient; Memory.post()
+  // folds it into provenance.claimed.client and strips it from the row.
+  // Omitted entirely when the token carried no client_id.
+  if (agent.clientId) body.claimedClient = agent.clientId;
+  return unwrap(await h.post(body));
 }
 
 /**
@@ -214,6 +231,10 @@ async function memoryUpdate(agent: ResolvedAgent, args: any) {
     delete record.validFrom;
     delete record.validTo;
     delete record.archivedAt;
+    // flair#718 authorship-provenance — see memoryStore's comment: forward
+    // the resolved OAuth client_id (never forgeable via args) so the NEW
+    // version's provenance records which client authored this update.
+    if (agent.clientId) record.claimedClient = agent.clientId;
     (h as any).isCollection = true;
     return unwrap(await h.post(record));
   }
@@ -221,6 +242,8 @@ async function memoryUpdate(agent: ResolvedAgent, args: any) {
   const merged: Record<string, unknown> = { ...existing, content, updatedAt: new Date().toISOString() };
   delete merged.embedding;
   delete merged.embeddingModel;
+  // flair#718 authorship-provenance — see memoryStore's comment above.
+  if (agent.clientId) merged.claimedClient = agent.clientId;
   return unwrap(await h.put(merged));
 }
 

--- a/resources/provenance.ts
+++ b/resources/provenance.ts
@@ -1,7 +1,37 @@
 import type { AgentAuthVerdict } from "./agent-auth.js";
 
 /**
- * ─── Write-time provenance stamp (memory-provenance slice 1) ────────────────
+ * Sanitize an optional, unverified `claimed.*` passthrough value (memory-
+ * provenance slice 1 + flair#718 authorship-provenance). Shared by BOTH
+ * `claimed.model` and `claimed.client` — same authority level, same
+ * discipline, one implementation so they can't drift:
+ *
+ *   1. Must be a `string` — anything else (number, object, array) is dropped.
+ *   2. Control characters (C0 + DEL, `\x00`-`\x1F`,`\x7F`) are stripped —
+ *      this is caller-supplied, unverified data landing in a stored JSON
+ *      blob; no newlines/nulls smuggled into logs or downstream renders.
+ *   3. Trimmed.
+ *   4. Length-capped at 200 chars (truncated, not rejected — a label this
+ *      long is almost certainly malformed, but the write must never fail
+ *      because of it).
+ *   5. Dropped (returns `undefined`) if empty after the above — an
+ *      all-control-chars or all-whitespace input is treated as absent, not
+ *      stamped as `""`.
+ *
+ * Sherlock flair#718 review: `claimed.model` previously had only a
+ * truthiness check (no cap, no sanitize) — folded into this same function
+ * "while touching the same code" per that review's non-blocking recommendation.
+ */
+function sanitizeClaim(value: unknown): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const cleaned = value.replace(/[\x00-\x1F\x7F]/g, "").trim();
+  if (cleaned.length === 0) return undefined;
+  return cleaned.length > 200 ? cleaned.slice(0, 200) : cleaned;
+}
+
+/**
+ * ─── Write-time provenance stamp (memory-provenance slice 1; claimed.client
+ * added by flair#718 authorship-provenance) ──────────────────────────────────
  *
  * Foundational capture for an emergent-trust model: every write gets a
  * structured, versioned `provenance` JSON blob recording what the server can
@@ -10,7 +40,7 @@ import type { AgentAuthVerdict } from "./agent-auth.js";
  *
  *   { v: 1,
  *     verified: { agentId: <string|null>, timestamp: <ISO string> },
- *     claimed?: { model: <string> } }
+ *     claimed?: { model?: <string>, client?: <string> } }
  *
  * - `verified.agentId` comes from the ALREADY-RESOLVED auth verdict
  *   (resolveAgentAuth) — never from anything the caller can forge on the
@@ -25,10 +55,25 @@ import type { AgentAuthVerdict } from "./agent-auth.js";
  *   `embeddingModel = getModelId()` stamp in resources/Memory.ts.
  * - `claimed.model` is an OPTIONAL, UNVERIFIED passthrough: included only
  *   when the incoming write payload itself already carries a non-empty
- *   string `model` field. No client/CLI sets one today — this just means the
- *   server won't discard it if/when a future write path does. Never
- *   invented, never defaulted, and the `claimed` key is omitted entirely
- *   (not stamped as `{}`) when absent.
+ *   string `model` field (sanitized via sanitizeClaim above). Never
+ *   invented, never defaulted.
+ * - `claimed.client` (flair#718) is the SAME kind of OPTIONAL, UNVERIFIED
+ *   passthrough, sourced from `content.claimedClient` (a deliberately
+ *   distinct body-field name from the output key — see the write paths in
+ *   resources/Memory.ts / resources/Relationship.ts, which strip this field
+ *   from the row after calling buildProvenance so it is NEVER persisted
+ *   outside this provenance blob). Records WHICH CLIENT authored a write
+ *   under one shared principal (the personal deployment shape — see
+ *   docs/auth.md "Deployment shapes"). `claimed` — never `verified` —
+ *   because this is self-reported by an authenticated principal, not
+ *   independently corroborated: it MUST grant zero authority anywhere
+ *   (never read for access control, attribution weighting, or dedup
+ *   decisions — Sherlock flair#718 binding refinement). On the native /mcp
+ *   OAuth path, the caller is required to source this from the verified
+ *   `client_id` token claim, never the user-controlled `client_name` — see
+ *   resources/mcp-handler.ts's handleToolCall for that stamp site.
+ * - The `claimed` key is omitted entirely (not stamped as `{}`) when both
+ *   `model` and `client` are absent.
  *
  * Originally introduced in resources/Memory.ts (Memory.post()/Memory.put());
  * extracted here so Relationship.ts (and any future write path) can reuse the
@@ -41,7 +86,7 @@ export function buildProvenance(auth: AgentAuthVerdict, createdAt: string, conte
   const provenance: {
     v: 1;
     verified: { agentId: string | null; timestamp: string };
-    claimed?: { model: string };
+    claimed?: { model?: string; client?: string };
   } = {
     v: 1,
     verified: {
@@ -49,8 +94,12 @@ export function buildProvenance(auth: AgentAuthVerdict, createdAt: string, conte
       timestamp: createdAt,
     },
   };
-  if (typeof content?.model === "string" && content.model.length > 0) {
-    provenance.claimed = { model: content.model };
+  const model = sanitizeClaim(content?.model);
+  const client = sanitizeClaim(content?.claimedClient);
+  if (model !== undefined || client !== undefined) {
+    provenance.claimed = {};
+    if (model !== undefined) provenance.claimed.model = model;
+    if (client !== undefined) provenance.claimed.client = client;
   }
   return JSON.stringify(provenance);
 }

--- a/schemas/memory.graphql
+++ b/schemas/memory.graphql
@@ -53,7 +53,7 @@ type Memory @table(database: "flair") {
   validFrom: String @indexed   # ISO timestamp — when this fact became true
   validTo: String @indexed     # ISO timestamp — when this fact stopped being true (null = still valid)
   _safetyFlags: [String]       # content safety flags from scanContent()
-  provenance: String           # JSON blob (memory-provenance slice 1): { v, verified: { agentId, timestamp }, claimed?: { model } }
+  provenance: String           # JSON blob (memory-provenance slice 1; claimed.client added by flair#718): { v, verified: { agentId, timestamp }, claimed?: { model, client } }
                                # Nullable by design — existing rows read back provenance = null, unchanged behavior (clean-upgrade-path gate).
                                # Same idiom as Soul.metadata below. Stamped server-side in resources/Memory.ts; never client-writable.
   originatorInstanceId: String @indexed  # federation-edge-hardening slice 1: WRITE-TIME instance identity, stamped server-side in
@@ -99,7 +99,7 @@ type Relationship @table(database: "flair") {
                                     # for the full contract (write-time stamp, nullable, preserved across sync merges).
                                     # Stamped server-side in resources/Relationship.ts's put().
   provenance: String                # JSON blob (relationship-write-path, folded K&S refinement): SAME shape as
-                                    # Memory.provenance above — { v, verified: { agentId, timestamp }, claimed?: { model } }
+                                    # Memory.provenance above — { v, verified: { agentId, timestamp }, claimed?: { model, client } }
                                     # — via the shared resources/provenance.ts buildProvenance(), never a
                                     # Relationship-specific format. Nullable by design — pre-existing rows read back
                                     # provenance = null, unchanged behavior (migration-equivalence gate, same

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2487,7 +2487,12 @@ program
               type: "stdio" as const,
               command: "npx",
               args: ["-y", "@tpsdev-ai/flair-mcp"] as string[],
-              env: mcpEnv,
+              // flair#718 authorship-provenance: each client's wired env block
+              // gets its OWN FLAIR_CLIENT label (never the shared mcpEnv
+              // object directly — that would stamp the same label into every
+              // client's config) so writes from THIS client's proxy stamp
+              // provenance.claimed.client = "claude-code".
+              env: { ...mcpEnv, FLAIR_CLIENT: "claude-code" },
             };
             try {
               if (existsSync(claudeJsonPath)) {
@@ -2539,10 +2544,13 @@ program
             }
           } else {
             let result: { ok: boolean; message: string };
+            // flair#718 authorship-provenance — see the claude-code branch's
+            // identical comment above: FLAIR_CLIENT is per-client, so it's
+            // added at each call site rather than baked into the shared mcpEnv.
             switch (clientId) {
-              case "codex": result = wireCodex(mcpEnv); break;
-              case "gemini": result = wireGemini(mcpEnv); break;
-              case "cursor": result = wireCursor(mcpEnv); break;
+              case "codex": result = wireCodex({ ...mcpEnv, FLAIR_CLIENT: "codex" }); break;
+              case "gemini": result = wireGemini({ ...mcpEnv, FLAIR_CLIENT: "gemini" }); break;
+              case "cursor": result = wireCursor({ ...mcpEnv, FLAIR_CLIENT: "cursor" }); break;
               default: result = { ok: false, message: `Unknown client: ${clientId}` };
             }
             wiringResults.push({ client: clientId, message: result.message });

--- a/src/install/clients.ts
+++ b/src/install/clients.ts
@@ -16,11 +16,24 @@
 
 export type ClientId = "claude-code" | "codex" | "gemini" | "cursor";
 
+/**
+ * The env block every wire function writes into a client's MCP server config.
+ * `FLAIR_CLIENT` (flair#718 authorship-provenance) is OPTIONAL and additive —
+ * when the caller sets it (flair init's per-client wiring sets it to the
+ * client's own id, e.g. "codex"), the written env block records WHICH CLIENT
+ * this config wires, so writes forwarded through it stamp
+ * `provenance.claimed.client` server-side (resources/provenance.ts). Absent
+ * entirely on an un-set call = omitted from the written config, byte-for-byte
+ * the same output as before this field existed (flair doctor's --fix
+ * re-wiring path deliberately does not set it — out of scope for this slice).
+ */
+export type WireEnv = { FLAIR_AGENT_ID: string; FLAIR_URL: string; FLAIR_CLIENT?: string };
+
 export interface Client {
   id: ClientId;
   label: string;
   detected: boolean;
-  wire: (env: { FLAIR_AGENT_ID: string; FLAIR_URL: string }) => { ok: boolean; message: string };
+  wire: (env: WireEnv) => { ok: boolean; message: string };
 }
 
 // ---- Detection helpers ----------------------------------------------------------
@@ -109,22 +122,28 @@ function cursorDetect(): boolean {
 // ---- Shared config shapes -------------------------------------------------------
 
 /** The standard MCP stdio server entry every client (except Codex TOML) uses. */
-function flairMcpEntry(env: { FLAIR_AGENT_ID: string; FLAIR_URL: string }) {
+function flairMcpEntry(env: WireEnv) {
   return {
     command: "npx",
     args: ["-y", "@tpsdev-ai/flair-mcp"],
-    env: { FLAIR_AGENT_ID: env.FLAIR_AGENT_ID, FLAIR_URL: env.FLAIR_URL },
+    env: {
+      FLAIR_AGENT_ID: env.FLAIR_AGENT_ID,
+      FLAIR_URL: env.FLAIR_URL,
+      // flair#718 — only present when the caller set it; absent = omitted,
+      // not written as FLAIR_CLIENT: undefined.
+      ...(env.FLAIR_CLIENT ? { FLAIR_CLIENT: env.FLAIR_CLIENT } : {}),
+    },
   };
 }
 
 /** Pretty-printed JSON `mcpServers.flair` snippet for copy-paste fallbacks. */
-function jsonSnippet(env: { FLAIR_AGENT_ID: string; FLAIR_URL: string }): string {
+function jsonSnippet(env: WireEnv): string {
   return JSON.stringify({ mcpServers: { flair: flairMcpEntry(env) } }, null, 2);
 }
 
 /** TOML `[mcp_servers.flair]` snippet (Codex format). Exported for tests
  * (flair#727 — asserts the rendered template carries a full scheme+port URL). */
-export function tomlSnippet(env: { FLAIR_AGENT_ID: string; FLAIR_URL: string }): string {
+export function tomlSnippet(env: WireEnv): string {
   return [
     `[mcp_servers.flair]`,
     `command = "npx"`,
@@ -133,6 +152,8 @@ export function tomlSnippet(env: { FLAIR_AGENT_ID: string; FLAIR_URL: string }):
     `[mcp_servers.flair.env]`,
     `FLAIR_AGENT_ID = "${env.FLAIR_AGENT_ID}"`,
     `FLAIR_URL = "${env.FLAIR_URL}"`,
+    // flair#718 — only present when the caller set it (same rule as flairMcpEntry above).
+    ...(env.FLAIR_CLIENT ? [`FLAIR_CLIENT = "${env.FLAIR_CLIENT}"`] : []),
   ].join("\n");
 }
 
@@ -155,7 +176,7 @@ export function codexConfigHasFlairSection(raw: string): boolean {
  * separator (mirrors fixClaudeMdBootstrap's separator logic in
  * src/doctor-client.ts — never runs the new block into the prior line).
  */
-export function appendCodexFlairBlock(raw: string, env: { FLAIR_AGENT_ID: string; FLAIR_URL: string }): string {
+export function appendCodexFlairBlock(raw: string, env: WireEnv): string {
   const separator = raw.length === 0 ? "" : raw.endsWith("\n\n") ? "" : raw.endsWith("\n") ? "\n" : "\n\n";
   return raw + separator + tomlSnippet(env) + "\n";
 }
@@ -168,7 +189,7 @@ export function appendCodexFlairBlock(raw: string, env: { FLAIR_AGENT_ID: string
 function wireJsonMcp(
   configPath: string,
   label: string,
-  env: { FLAIR_AGENT_ID: string; FLAIR_URL: string },
+  env: WireEnv,
 ): { ok: boolean; message: string } {
   const home = resolveHome();
   const display = configPath.startsWith(home) ? "~" + configPath.slice(home.length) : configPath;
@@ -244,14 +265,14 @@ export function clientConfigPath(id: ClientId): string {
 // fallback used when something calls the array form; it returns the snippet for
 // ~/.claude.json so the message is unambiguous and correct on every OS.
 
-function _wireClaudeCode(env: { FLAIR_AGENT_ID: string; FLAIR_URL: string }): { ok: boolean; message: string } {
+function _wireClaudeCode(env: WireEnv): { ok: boolean; message: string } {
   // The real auto-wire is inline in cli.ts. If reached via the array, point at
   // the correct cross-platform path (~/.claude.json — same on macOS/Linux/Win)
   // and give the exact snippet. Never emit macOS-only paths here.
   return wireJsonMcp(join(resolveHome(), ".claude.json"), "Claude Code", env);
 }
 
-function _wireCodex(env: { FLAIR_AGENT_ID: string; FLAIR_URL: string }): { ok: boolean; message: string } {
+function _wireCodex(env: WireEnv): { ok: boolean; message: string } {
   // Codex uses TOML with a [mcp_servers.flair] table. We don't carry a TOML
   // parser, but appending a new top-level table at EOF is safe TOML when the
   // exact header isn't already present (flair#727) — so an existing file only
@@ -283,11 +304,11 @@ function _wireCodex(env: { FLAIR_AGENT_ID: string; FLAIR_URL: string }): { ok: b
   }
 }
 
-function _wireGemini(env: { FLAIR_AGENT_ID: string; FLAIR_URL: string }): { ok: boolean; message: string } {
+function _wireGemini(env: WireEnv): { ok: boolean; message: string } {
   return wireJsonMcp(geminiConfigPath(), "Gemini", env);
 }
 
-function _wireCursor(env: { FLAIR_AGENT_ID: string; FLAIR_URL: string }): { ok: boolean; message: string } {
+function _wireCursor(env: WireEnv): { ok: boolean; message: string } {
   return wireJsonMcp(cursorConfigPath(), "Cursor", env);
 }
 
@@ -333,25 +354,25 @@ export function detectClients(): Client[] {
 }
 
 export function wireClaudeCode(
-  env: { FLAIR_AGENT_ID: string; FLAIR_URL: string }
+  env: WireEnv
 ): { ok: boolean; message: string } {
   return _wireClaudeCode(env);
 }
 
 export function wireCodex(
-  env: { FLAIR_AGENT_ID: string; FLAIR_URL: string }
+  env: WireEnv
 ): { ok: boolean; message: string } {
   return _wireCodex(env);
 }
 
 export function wireGemini(
-  env: { FLAIR_AGENT_ID: string; FLAIR_URL: string }
+  env: WireEnv
 ): { ok: boolean; message: string } {
   return _wireGemini(env);
 }
 
 export function wireCursor(
-  env: { FLAIR_AGENT_ID: string; FLAIR_URL: string }
+  env: WireEnv
 ): { ok: boolean; message: string } {
   return _wireCursor(env);
 }

--- a/test/unit-isolated/memory-integrity.test.ts
+++ b/test/unit-isolated/memory-integrity.test.ts
@@ -1451,3 +1451,92 @@ describe("federation-edge-hardening slice 1 — migration-equivalence (no-origin
     expect(after.originatorInstanceId).toBe("flair_local_test"); // additively gains the stamp on this write
   });
 });
+
+// ─── flair#718 authorship-provenance: claimedClient is folded into
+// provenance.claimed.client and STRIPPED from the row itself ───────────────
+//
+// Reuses this file's existing mock/import (see the memory-soul-read-gate
+// collision-avoidance comment above): a second file mock.module-ing
+// "@harperfast/harper" + importing "../../resources/Memory.ts" would race
+// this file's Memory class singleton.
+describe("flair#718 authorship-provenance — Memory.post()/put() claimedClient handling", () => {
+  it("post(): a claimedClient on the write body is folded into provenance.claimed.client, and NEVER persisted as a top-level row field", async () => {
+    const m = makeMemory(agentCtx("agent-1"));
+    const r: any = await m.post({
+      agentId: "agent-1",
+      content: "A memory written via the claude-code MCP client, long enough for the gate.",
+      claimedClient: "claude-code",
+    });
+    expect(r.written).toBe(true);
+
+    const stored = await BaseMemory.get(r.id);
+    // Row-level: claimedClient must NEVER appear on the persisted record.
+    expect(stored.claimedClient).toBeUndefined();
+    expect("claimedClient" in stored).toBe(false);
+    // Provenance JSON: the SAME value lands in claimed.client.
+    expect(typeof stored.provenance).toBe("string");
+    const prov = JSON.parse(stored.provenance);
+    expect(prov.claimed.client).toBe("claude-code");
+  });
+
+  it("put() (fresh create via explicit id): same fold + strip behavior as post()", async () => {
+    const m = makeMemory(agentCtx("agent-1"));
+    const r: any = await m.put({
+      id: "agent-1-put-claimed-client",
+      agentId: "agent-1",
+      content: "A fresh PUT-created memory carrying claimedClient, long enough for the gate.",
+      claimedClient: "codex",
+    });
+    expect(r.written).toBe(true);
+
+    const stored = await BaseMemory.get("agent-1-put-claimed-client");
+    expect("claimedClient" in stored).toBe(false);
+    const prov = JSON.parse(stored.provenance);
+    expect(prov.claimed.client).toBe("codex");
+  });
+
+  it("put() (update of an existing record): a fresh claimedClient on the update is stamped into the NEW provenance and still never persisted as a row field", async () => {
+    const m = makeMemory(agentCtx("agent-1"));
+    const created: any = await m.post({ agentId: "agent-1", content: "Original content, long enough for the gate.", claimedClient: "claude-code" });
+
+    const existing = await BaseMemory.get(created.id);
+    const merged = { ...existing, content: "Updated via a different client, long enough for the gate.", updatedAt: new Date().toISOString(), claimedClient: "gemini" };
+    delete (merged as any).embedding;
+    delete (merged as any).embeddingModel;
+
+    const mUpdate = makeMemory(agentCtx("agent-1"));
+    await mUpdate.put(merged);
+
+    const after = await BaseMemory.get(created.id);
+    expect("claimedClient" in after).toBe(false);
+    const prov = JSON.parse(after.provenance);
+    expect(prov.claimed.client).toBe("gemini"); // reflects the CURRENT write, not the original post()
+  });
+
+  it("absent claimedClient → provenance has no `claimed` key at all (never invented, never stamped as empty)", async () => {
+    const m = makeMemory(agentCtx("agent-1"));
+    const r: any = await m.post({ agentId: "agent-1", content: "A plain memory with no client label, long enough for the gate." });
+    const stored = await BaseMemory.get(r.id);
+    const prov = JSON.parse(stored.provenance);
+    expect("claimed" in prov).toBe(false);
+  });
+
+  it("claimedClient is dropped from the row EVEN when the write is otherwise denied's opposite case — a successful cross-write scenario (supersede) also strips it", async () => {
+    const mOwner = makeMemory(agentCtx("agent-1"));
+    const owned: any = await mOwner.post({ agentId: "agent-1", content: "Original finding, long enough for the gate.", claimedClient: "cursor" });
+
+    const mNew = makeMemory(agentCtx("agent-1"));
+    const res: any = await mNew.post({
+      agentId: "agent-1",
+      content: "Replacement finding via supersede, long enough for the gate.",
+      supersedes: owned.id,
+      claimedClient: "codex",
+    });
+    expect(res.written).toBe(true);
+
+    const stored = await BaseMemory.get(res.id);
+    expect("claimedClient" in stored).toBe(false);
+    const prov = JSON.parse(stored.provenance);
+    expect(prov.claimed.client).toBe("codex");
+  });
+});

--- a/test/unit/client-wiring.test.ts
+++ b/test/unit/client-wiring.test.ts
@@ -173,6 +173,70 @@ describe("client wiring (FIX 4: 'wired' means a file was written)", () => {
   });
 });
 
+// ─── flair#718 authorship-provenance: FLAIR_CLIENT per-client wiring ────────
+// FLAIR_CLIENT is OPTIONAL and additive on the wire env — absent (as every
+// test above uses ENV, with no FLAIR_CLIENT) writes byte-identical config to
+// before this field existed. These tests confirm it's written into the
+// client's real config file, per-client-labeled, when the caller sets it.
+describe("FLAIR_CLIENT wiring (flair#718 authorship-provenance)", () => {
+  it("Gemini: writes FLAIR_CLIENT into the env block when set", () => {
+    const res = wireGemini({ ...ENV, FLAIR_CLIENT: "gemini" });
+    expect(res.ok).toBe(true);
+    const cfgPath = join(isoHome, ".gemini", "settings.json");
+    const cfg = JSON.parse(readFileSync(cfgPath, "utf-8"));
+    expect(cfg.mcpServers.flair.env.FLAIR_CLIENT).toBe("gemini");
+    // Base fields are untouched by the addition.
+    expect(cfg.mcpServers.flair.env.FLAIR_AGENT_ID).toBe("wirebot");
+    expect(cfg.mcpServers.flair.env.FLAIR_URL).toBe(ENV.FLAIR_URL);
+  });
+
+  it("Gemini: no FLAIR_CLIENT set → omitted from the written env block entirely (not written as null/undefined)", () => {
+    const res = wireGemini(ENV);
+    expect(res.ok).toBe(true);
+    const cfgPath = join(isoHome, ".gemini", "settings.json");
+    const cfg = JSON.parse(readFileSync(cfgPath, "utf-8"));
+    expect("FLAIR_CLIENT" in cfg.mcpServers.flair.env).toBe(false);
+  });
+
+  it("Cursor: writes FLAIR_CLIENT into the env block when set", () => {
+    const res = wireCursor({ ...ENV, FLAIR_CLIENT: "cursor" });
+    expect(res.ok).toBe(true);
+    const cfgPath = join(isoHome, ".cursor", "mcp.json");
+    const cfg = JSON.parse(readFileSync(cfgPath, "utf-8"));
+    expect(cfg.mcpServers.flair.env.FLAIR_CLIENT).toBe("cursor");
+  });
+
+  it("Codex: writes FLAIR_CLIENT = \"codex\" into the TOML env table when set", () => {
+    const res = wireCodex({ ...ENV, FLAIR_CLIENT: "codex" });
+    expect(res.ok).toBe(true);
+    const cfgPath = join(isoHome, ".codex", "config.toml");
+    const toml = readFileSync(cfgPath, "utf-8");
+    expect(toml).toContain(`FLAIR_CLIENT = "codex"`);
+  });
+
+  it("Codex: no FLAIR_CLIENT set → the TOML env table omits the line entirely", () => {
+    const res = wireCodex(ENV);
+    expect(res.ok).toBe(true);
+    const cfgPath = join(isoHome, ".codex", "config.toml");
+    const toml = readFileSync(cfgPath, "utf-8");
+    expect(toml).not.toContain("FLAIR_CLIENT");
+  });
+
+  it("re-running with a DIFFERENT FLAIR_CLIENT after an already-wired install is a no-op (idempotency check doesn't compare FLAIR_CLIENT) — documents current behavior, not a requirement", () => {
+    // First wire without FLAIR_CLIENT (simulates a pre-flair#718 install).
+    wireGemini(ENV);
+    // Re-running with FLAIR_CLIENT set matches on FLAIR_URL/FLAIR_AGENT_ID and
+    // reports already-wired without adding FLAIR_CLIENT retroactively — no
+    // backfill, per flair#718's explicit scope (existing installs need a
+    // fresh `flair init` re-run to pick up the new field).
+    const res = wireGemini({ ...ENV, FLAIR_CLIENT: "gemini" });
+    expect(res.message).toContain("already wired");
+    const cfgPath = join(isoHome, ".gemini", "settings.json");
+    const cfg = JSON.parse(readFileSync(cfgPath, "utf-8"));
+    expect("FLAIR_CLIENT" in cfg.mcpServers.flair.env).toBe(false);
+  });
+});
+
 // flair#727 bug 1 — resolveWireFlairUrl (src/doctor-client.ts) decides which
 // FLAIR_URL doctor's client-integration --fix feeds into wire*(): a
 // pre-existing but malformed value (bare host, no scheme/port) must never

--- a/test/unit/mcp-handler.test.ts
+++ b/test/unit/mcp-handler.test.ts
@@ -220,6 +220,26 @@ describe("resolveAgentFromSub", () => {
   it("empty sub → null", async () => {
     expect(await resolveAgentFromSub("")).toBeNull();
   });
+
+  // ─── flair#718 authorship-provenance: clientId threading ──────────────────
+  it("no clientId passed → resolved agent has NO clientId property at all (not stamped as undefined)", async () => {
+    credentials = [{ principalId: "agt_alice", kind: "idp", idpSubject: "sub-alice", status: "active" }];
+    const agent = await resolveAgentFromSub("sub-alice");
+    expect(agent).toEqual({ agentId: "agt_alice", isAdmin: false });
+    expect("clientId" in (agent as any)).toBe(false);
+  });
+
+  it("clientId passed → copied onto the resolved agent unchanged (existing-credential path)", async () => {
+    credentials = [{ principalId: "agt_alice", kind: "idp", idpSubject: "sub-alice", status: "active" }];
+    const agent = await resolveAgentFromSub("sub-alice", "flair_cl_abc123");
+    expect(agent).toEqual({ agentId: "agt_alice", isAdmin: false, clientId: "flair_cl_abc123" });
+  });
+
+  it("clientId passed on the JIT-provision path is also copied onto the resolved agent", async () => {
+    process.env.FLAIR_MCP_JIT_PROVISION = "1";
+    const agent = await resolveAgentFromSub("fresh-sub-2", "flair_cl_jit");
+    expect(agent?.clientId).toBe("flair_cl_jit");
+  });
 });
 
 // ─── tools/call scoping ──────────────────────────────────────────────────────
@@ -249,6 +269,69 @@ describe("tools/call — scopes to the resolved agent (no forging)", () => {
     expect(lastCall?.resource).toBe("Memory.post");
     expect(lastCall?.args.agentId).toBe("agt_bob");
     expect(lastCall?.ctx.request.tpsAgent).toBe("agt_bob");
+  });
+
+  // ─── flair#718 authorship-provenance: OAuth client_id → claimedClient ──────
+  describe("flair#718 authorship-provenance — claimedClient stamped from the OAuth token's client_id", () => {
+    it("memory_store: request.mcp.client_id flows into the body as claimedClient", async () => {
+      await mcpHandler(post(
+        { jsonrpc: "2.0", id: 1, method: "tools/call", params: { name: "memory_store", arguments: { content: "hi" } } },
+        { sub: "sub-bob", client_id: "flair_cl_abc123" },
+      ));
+      expect(lastCall?.resource).toBe("Memory.post");
+      expect(lastCall?.args.claimedClient).toBe("flair_cl_abc123");
+    });
+
+    it("memory_store: NO client_id on the token → claimedClient is absent from the body entirely (not undefined)", async () => {
+      await mcpHandler(post(
+        { jsonrpc: "2.0", id: 1, method: "tools/call", params: { name: "memory_store", arguments: { content: "hi" } } },
+        { sub: "sub-bob" },
+      ));
+      expect(lastCall?.resource).toBe("Memory.post");
+      expect(lastCall?.args).not.toHaveProperty("claimedClient");
+    });
+
+    it("memory_store: `client_name` on the token is NEVER used — only `client_id` (Sherlock flair#718 binding refinement)", async () => {
+      await mcpHandler(post(
+        { jsonrpc: "2.0", id: 1, method: "tools/call", params: { name: "memory_store", arguments: { content: "hi" } } },
+        { sub: "sub-bob", client_name: "My Pretty Claude Desktop" },
+      ));
+      expect(lastCall?.args).not.toHaveProperty("claimedClient");
+    });
+
+    it("memory_store: a non-string client_id on the token is ignored, not coerced/forwarded", async () => {
+      await mcpHandler(post(
+        { jsonrpc: "2.0", id: 1, method: "tools/call", params: { name: "memory_store", arguments: { content: "hi" } } },
+        { sub: "sub-bob", client_id: 12345 },
+      ));
+      expect(lastCall?.args).not.toHaveProperty("claimedClient");
+    });
+
+    it("memory_update (default mode): client_id flows into the PUT body as claimedClient", async () => {
+      await mcpHandler(post(
+        { jsonrpc: "2.0", id: 1, method: "tools/call", params: { name: "memory_update", arguments: { id: "mem-1", content: "updated" } } },
+        { sub: "sub-bob", client_id: "flair_cl_def456" },
+      ));
+      expect(lastCall?.resource).toBe("Memory.put");
+      expect(lastCall?.args.claimedClient).toBe("flair_cl_def456");
+    });
+
+    it("memory_update (preserveHistory mode): client_id flows into the new-version POST body as claimedClient", async () => {
+      await mcpHandler(post(
+        { jsonrpc: "2.0", id: 1, method: "tools/call", params: { name: "memory_update", arguments: { id: "mem-1", content: "new version", preserveHistory: true } } },
+        { sub: "sub-bob", client_id: "flair_cl_ghi789" },
+      ));
+      expect(lastCall?.resource).toBe("Memory.post");
+      expect(lastCall?.args.claimedClient).toBe("flair_cl_ghi789");
+    });
+
+    it("a body-supplied claimedClient argument (forgery attempt) is ignored — only the resolved token's client_id is used", async () => {
+      await mcpHandler(post(
+        { jsonrpc: "2.0", id: 1, method: "tools/call", params: { name: "memory_store", arguments: { content: "hi", claimedClient: "forged-client" } } },
+        { sub: "sub-bob", client_id: "flair_cl_real" },
+      ));
+      expect(lastCall?.args.claimedClient).toBe("flair_cl_real");
+    });
   });
 
   it("memory_update (default) reads then PUTs the same id, merging new content", async () => {

--- a/test/unit/provenance.test.ts
+++ b/test/unit/provenance.test.ts
@@ -1,0 +1,146 @@
+/**
+ * provenance.test.ts — resources/provenance.ts's buildProvenance().
+ *
+ * Pure-function unit coverage for the write-time provenance stamp
+ * (memory-provenance slice 1; `claimed.client` added by flair#718
+ * authorship-provenance). No Harper mocking needed — buildProvenance takes
+ * plain values and returns a JSON string.
+ *
+ * Covers:
+ *   - verified.agentId/timestamp derivation from the auth verdict.
+ *   - claimed.model / claimed.client: sanitize (string-only, control-char
+ *     strip, trim, 200-char cap, drop-if-empty-after-sanitize) — SAME
+ *     discipline for both fields (Sherlock flair#718: the model cap was
+ *     previously truthiness-only; folded into the shared sanitizer here).
+ *   - `claimed` key omitted entirely when both are absent.
+ *   - claimedClient is a WRITE-BODY-ONLY input: it must never leak into the
+ *     output under its own name, and the stripping of it from the persisted
+ *     row is asserted at the Memory.ts/Relationship.ts call sites (see
+ *     memory-claimed-client-strip.test.ts / relationship's own coverage).
+ */
+import { describe, it, expect } from "bun:test";
+import { buildProvenance } from "../../resources/provenance.ts";
+import type { AgentAuthVerdict } from "../../resources/agent-auth.ts";
+
+const AGENT: AgentAuthVerdict = { kind: "agent", agentId: "agt_alice", isAdmin: false };
+const INTERNAL: AgentAuthVerdict = { kind: "internal" };
+const NOW = "2026-07-18T00:00:00.000Z";
+
+function parse(json: string): any {
+  return JSON.parse(json);
+}
+
+describe("buildProvenance — verified fields", () => {
+  it("stamps verified.agentId from the auth verdict (kind: agent)", () => {
+    const prov = parse(buildProvenance(AGENT, NOW, {}));
+    expect(prov.v).toBe(1);
+    expect(prov.verified.agentId).toBe("agt_alice");
+    expect(prov.verified.timestamp).toBe(NOW);
+  });
+
+  it("stamps verified.agentId = null for kind: internal (never throws)", () => {
+    const prov = parse(buildProvenance(INTERNAL, NOW, {}));
+    expect(prov.verified.agentId).toBeNull();
+    expect(prov.verified.timestamp).toBe(NOW);
+  });
+
+  it("verified.agentId NEVER reads from the content body, even if forged", () => {
+    const prov = parse(buildProvenance(AGENT, NOW, { agentId: "agt_forged_victim" }));
+    expect(prov.verified.agentId).toBe("agt_alice");
+  });
+});
+
+describe("buildProvenance — claimed key omission", () => {
+  it("omits `claimed` entirely when neither model nor client is present", () => {
+    const prov = parse(buildProvenance(AGENT, NOW, {}));
+    expect(prov.claimed).toBeUndefined();
+    expect("claimed" in prov).toBe(false);
+  });
+
+  it("omits `claimed` when model/client are present but non-string", () => {
+    const prov = parse(buildProvenance(AGENT, NOW, { model: 12345, claimedClient: { nested: true } }));
+    expect("claimed" in prov).toBe(false);
+  });
+
+  it("omits `claimed` when model/client are empty/whitespace-only strings", () => {
+    const prov = parse(buildProvenance(AGENT, NOW, { model: "   ", claimedClient: "\t\n" }));
+    expect("claimed" in prov).toBe(false);
+  });
+});
+
+describe("buildProvenance — claimed.client (flair#718)", () => {
+  it("passthrough from content.claimedClient (a DISTINCT body field name from the output key)", () => {
+    const prov = parse(buildProvenance(AGENT, NOW, { claimedClient: "claude-code" }));
+    expect(prov.claimed).toEqual({ client: "claude-code" });
+  });
+
+  it("content.client (wrong field name) is NOT picked up — only claimedClient", () => {
+    const prov = parse(buildProvenance(AGENT, NOW, { client: "codex" }));
+    expect("claimed" in prov).toBe(false);
+  });
+
+  it("trims surrounding whitespace", () => {
+    const prov = parse(buildProvenance(AGENT, NOW, { claimedClient: "  gemini  " }));
+    expect(prov.claimed.client).toBe("gemini");
+  });
+
+  it("strips control characters (C0 + DEL)", () => {
+    const withControls = "cur\x00sor\x1F\x7F";
+    const prov = parse(buildProvenance(AGENT, NOW, { claimedClient: withControls }));
+    expect(prov.claimed.client).toBe("cursor");
+  });
+
+  it("length-caps at 200 chars (truncates, does not drop)", () => {
+    const long = "x".repeat(250);
+    const prov = parse(buildProvenance(AGENT, NOW, { claimedClient: long }));
+    expect(prov.claimed.client).toBe("x".repeat(200));
+    expect(prov.claimed.client.length).toBe(200);
+  });
+
+  it("drops (claimed omitted) when the value is entirely control chars", () => {
+    const prov = parse(buildProvenance(AGENT, NOW, { claimedClient: "\x00\x01\x02" }));
+    expect("claimed" in prov).toBe(false);
+  });
+});
+
+describe("buildProvenance — claimed.model (Sherlock flair#718 refinement: same cap+sanitize as client)", () => {
+  it("passthrough from content.model, unchanged for a normal value", () => {
+    const prov = parse(buildProvenance(AGENT, NOW, { model: "claude-opus-4-7" }));
+    expect(prov.claimed).toEqual({ model: "claude-opus-4-7" });
+  });
+
+  it("length-caps at 200 chars (previously unbounded — truthiness-only check)", () => {
+    const long = "m".repeat(500);
+    const prov = parse(buildProvenance(AGENT, NOW, { model: long }));
+    expect(prov.claimed.model).toBe("m".repeat(200));
+  });
+
+  it("trims and strips control characters, same as claimed.client", () => {
+    const prov = parse(buildProvenance(AGENT, NOW, { model: "  gpt\x00-5  " }));
+    expect(prov.claimed.model).toBe("gpt-5");
+  });
+
+  it("drops when non-string", () => {
+    const prov = parse(buildProvenance(AGENT, NOW, { model: 42 }));
+    expect("claimed" in prov).toBe(false);
+  });
+});
+
+describe("buildProvenance — both fields together", () => {
+  it("stamps both model and client when both present", () => {
+    const prov = parse(buildProvenance(AGENT, NOW, { model: "claude-opus-4-7", claimedClient: "claude-code" }));
+    expect(prov.claimed).toEqual({ model: "claude-opus-4-7", client: "claude-code" });
+  });
+
+  it("stamps only client when model is absent", () => {
+    const prov = parse(buildProvenance(AGENT, NOW, { claimedClient: "codex" }));
+    expect(prov.claimed).toEqual({ client: "codex" });
+    expect(prov.claimed.model).toBeUndefined();
+  });
+
+  it("stamps only model when client is absent", () => {
+    const prov = parse(buildProvenance(AGENT, NOW, { model: "gpt-5" }));
+    expect(prov.claimed).toEqual({ model: "gpt-5" });
+    expect(prov.claimed.client).toBeUndefined();
+  });
+});

--- a/test/unit/relationship-read-gate.test.ts
+++ b/test/unit/relationship-read-gate.test.ts
@@ -379,3 +379,30 @@ describe("relationship-write-path — Relationship.put() write-time provenance s
     expect(ids).toEqual(["legacy-no-prov-2", "new-with-prov"].sort());
   });
 });
+
+// ─── flair#718 authorship-provenance — Relationship.put() claimedClient ────
+describe("flair#718 authorship-provenance — Relationship.put() claimedClient handling", () => {
+  it("a claimedClient on the write body is folded into provenance.claimed.client, and NEVER persisted as a top-level row field", async () => {
+    const r = makeRelationship(agentCtx("agent-1"));
+    const res: any = await r.put({
+      id: "rel-claimed-client-1",
+      subject: "nathan",
+      predicate: "manages",
+      object: "flint",
+      claimedClient: "codex",
+    });
+    expect("claimedClient" in res).toBe(false);
+    const prov = JSON.parse(res.provenance);
+    expect(prov.claimed.client).toBe("codex");
+
+    const stored = relationshipStore.get("rel-claimed-client-1");
+    expect("claimedClient" in stored).toBe(false);
+  });
+
+  it("absent claimedClient → provenance has no `claimed` key at all", async () => {
+    const r = makeRelationship(agentCtx("agent-1"));
+    const res: any = await r.put({ id: "rel-claimed-client-2", subject: "a", predicate: "b", object: "c" });
+    const prov = JSON.parse(res.provenance);
+    expect("claimed" in prov).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Records **which client wrote a row** when several AI clients share one principal — the personal deployment shape `flair init` already ships (one `FLAIR_AGENT_ID` wired into every client). Extends the existing `claimed` provenance slot (self-reported, unverified — same authority level as the existing `claimed.model`) rather than adding a first-class row field or a new config key, per the K&S-approved design.

- `resources/provenance.ts`: `buildProvenance` gains `claimed.client`, sourced from a write-body-only `claimedClient` field. Shares a new `sanitizeClaim()` helper with `claimed.model` — both now get the same discipline: string-only, control-character-stripped, trimmed, length-capped at 200 chars, dropped if empty after sanitizing (`claimed.model` previously had only a truthiness check).
- `resources/Memory.ts` / `resources/Relationship.ts`: thread `claimedClient` into `buildProvenance`, then strip it from the row before persisting — authorship lives in the `provenance` JSON only.
- `resources/mcp-handler.ts` / `resources/mcp-tools.ts`: the native `/mcp` OAuth path stamps `claimed.client` from the verified token's `client_id` claim (the server-generated `flair_cl_...` machine id) — **never** `client_name` (user-controlled at Dynamic Client Registration). `ResolvedAgent` gains an optional `clientId`, threaded into `memory_store`/`memory_update`.
- `packages/flair-client`, `packages/flair-mcp`: `FlairClientConfig.claimedClient` / `FLAIR_CLIENT` env forwards on memory writes when set; absent by default — zero behavior change for existing installs.
- `src/install/clients.ts`, `src/cli.ts`: `flair init` wires `FLAIR_CLIENT` per client (`claude-code`/`codex`/`gemini`/`cursor`) into each wired env block.
- `docs/auth.md`: new "Deployment shapes: personal vs org" section documenting the existing personal/org provisioning distinction and this field's role.

Out of scope (per the design record): new config keys, per-client credentials, row backfill, trust scoring, `flair doctor` rendering changes, and provenance stamping for Soul/WorkspaceState/OrgEvent (neither stamps provenance today).

## Design record

- #718 (design comment): https://github.com/tpsdev-ai/flair/issues/718#issuecomment-5011026099
- Kern APPROVE (architecture): https://github.com/tpsdev-ai/flair/issues/718#issuecomment-5011028228 and https://github.com/tpsdev-ai/flair/issues/718#issuecomment-5011031038
- Sherlock APPROVE with binding refinements (security): https://github.com/tpsdev-ai/flair/issues/718#issuecomment-5011031439
  1. Stamp the OAuth path from `client_id`, never `client_name` — implemented with an explicit code comment at the stamp site in `mcp-handler.ts`.
  2. Same length cap applied to `claimed.model` in this PR (previously truthiness-only).
  3. `claimed.client` grants zero authority — verified below.

## Test plan / acceptance evidence

- `bun test test/unit/` — **2380 pass, 0 fail** (includes new `test/unit/provenance.test.ts` and extensions to `test/unit/mcp-handler.test.ts`, `test/unit/client-wiring.test.ts`, `test/unit/relationship-read-gate.test.ts`).
- `test/unit-isolated/*.test.ts`, each run in its own `bun test` invocation — all pass (`memory-integrity.test.ts` 102 pass including 5 new claimedClient-strip tests; `memory-bootstrap-scoping.test.ts` 21 pass; `semantic-search-scoping.test.ts` 11 pass).
- `packages/flair-client` (`bun test`) — **61 pass, 0 fail** (includes new claimedClient constructor + write()/update() forwarding tests).
- `packages/flair-mcp` (`bun run build && bun test`) — **78 pass, 0 fail**.
- Typecheck: `tsconfig.check.json` (resources), `tsconfig.check.src.json` (src strict), `tsconfig.cli.json` (cli.ts), and every workspace package's own `tsconfig.json` — all clean, zero errors.
- `node scripts/docs-freshness-check.mjs` and `bash scripts/check-impl-term-leaks.sh` — both pass.
- `test/integration/` (real spawned Harper): could not complete cleanly in this development environment — confirmed via `git stash` that the failure is **pre-existing and byte-identical on unmodified `origin/main`** (e.g. `test/integration/relationship-write-surface-e2e.test.ts`: 9/9 fail on main and on this branch, same failure signatures — a component-deploy/native-dependency spawn issue documented in `test/helpers/harper-lifecycle.ts`'s own comments, unrelated to this change). The real "Integration Tests" CI job passed cleanly (13m45s) on the most recently merged PR to this repo (#731): https://github.com/tpsdev-ai/flair/actions/runs/29641268735/job/88072101379 — this branch will run the same job in CI.

## Zero-authority verification

`grep -rn "claimedClient" resources/ packages/*/src/ src/` shows it appears only at: the `provenance.ts` sanitize/passthrough site, the `Memory.ts`/`Relationship.ts` thread-then-strip sites, the `mcp-tools.ts` forward-from-resolved-agent sites, the client SDK forwarding sites, and the `flair init` wiring site — never in `resources/memory-read-scope.ts`, `resources/dedup.ts`, `resources/scoring.ts`, `resources/record-type-kit.ts`'s attribution helpers, or any auth/gate file. A broader `grep -rln "provenance"` across `resources/` turns up only `provenance.ts`, `Memory.ts`, `Relationship.ts` (the stamp sites), `mcp-handler.ts`/`mcp-tools.ts` (comments + the forwarding above), `record-types.ts` (a declarative `provenance: boolean` registry flag — whether a table stamps provenance at all, not a read of its contents), and `record-type-kit.ts` (re-exports `buildProvenance` unmodified). No read-scope, attribution, or dedup code path reads `provenance` or `claimedClient`.

Closes #718
