### PR TITLE
feat(record-types): declare-and-enforce MCP surface — registry mcp backfill + bidirectional tripwire (flair#520 slice 3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 ## [Unreleased]
 
+### 🧹 MCP surface — declare-and-enforce, not runtime-derive; no behavior change (flair#520 slice 3)
+
+Slice 2 (#730) landed `resources/record-types.ts`'s `RECORD_TYPES` registry with an `mcp` field that was shape-only, consumed by nothing. Slice 3 backfills it and adds enforcement, per the design round on the #520 issue thread (Kern's DESIGN REVIEW — APPROVE all four asks; Sherlock's Security Review — APPROVE with one refinement, adopted).
+
+An audit of the 12 shipped `/mcp` tools (`resources/mcp-tools.ts`) found only 5 are simple table-verb wrappers (`memory_get/store/delete`, `soul_get/set`); the rest are composite or bespoke (`bootstrap`, `attention`, `memory_search`, `memory_update`, `record_usage`) and can't be generated from a registry entry without either losing schema/behavior specifics or duplicating the handler. So the registry does not generate tools — it DECLARES the reviewed MCP surface, and a new bidirectional test enforces that declaration and reality never drift:
+
+- `RECORD_TYPES.<Table>.mcp` backfilled on four of the five core entries, documenting the CURRENT shipped surface exactly (registration, not behavior change): Memory (`get`/`search` reads, `store`/`delete`/`update` writes), Soul (`get` read, `store` write), WorkspaceState (no reads, `store` write), OrgEvent (no reads, `store` write). Relationship stays `mcp`-absent — it has no MCP tool today.
+- `RecordTypeMcp.writeVerbs` gains `"update"` (additive), documenting `memory_update`'s already-shipped two-branch read-modify-write — not a new capability.
+- New top-level `COMPOSITE_MCP_TOOLS` export in `record-types.ts` (deep-frozen, `["bootstrap", "attention", "record_usage"]`) — the second and only other reviewed chokepoint, for tools that don't map to a single table + verb. Per Sherlock's refinement (Kern concurring): this lives in `record-types.ts`, not `mcp-tools.ts`, so the FULL MCP surface is reviewable in one file.
+- New `TOOL_NAME_OVERRIDES` in `resources/mcp-tools.ts` covers the three naming quirks where the shipped tool name isn't the default `${toolPrefix}_${verb}` shape: `(Soul, store)` → `soul_set`, `(WorkspaceState, store)` → `flair_workspace_set`, `(OrgEvent, store)` → `flair_orgevent`. Registry declares WHAT is exposed; `mcp-tools.ts` owns HOW (names, defaults, routing).
+- New `test/unit/mcp-surface-tripwire.test.ts`: bidirectional CI enforcement — every declared registry verb must resolve to a tool that exists in `TOOLS`, every tool in `TOOLS` must be either derived from a declared verb or listed in `COMPOSITE_MCP_TOOLS`, a table with no `mcp` field contributes zero tools carrying its prefix, and the full 12-tool `tools/list` surface is pinned as a golden value. Any future PR that adds or removes an MCP tool must now also touch one of the two reviewed chokepoints, or CI fails.
+- `test/unit/record-types-registry.test.ts`'s slice-2 "no entry sets mcp" assertion flips to golden-value pins of the four backfilled declarations plus a pin of `COMPOSITE_MCP_TOOLS`'s contents.
+- Fixed a stale comment in `mcp-tools.ts`'s `listToolDefs` ("exactly the 9 curated tools" — actual: 12, wrong since `attention`/`record_usage` were added).
+
+Zero runtime behavior change: `tools/list` output is byte-identical, `resources/mcp-tools.ts`'s `TOOLS` dispatch table is untouched apart from the name-override structure and the comment fix, and every existing `mcp-handler.test.ts` assertion passes unchanged. The diff is registry data + tests + two comment fixes.
+
 ### ✨ Authorship provenance — `claimed.client` records which client wrote a row (flair#718)
 
 An audit of the identity machinery reframed this from "add a personal-vs-org deployment mode" to a narrower, cheaper fix: the personal shape (one shared principal across every AI client, via `flair init`) already ships and is correct — what's missing is recording *which client* authored a write once several clients share one principal. K&S-approved design (issue #718): no new config key (deployment shape stays emergent from provisioning, now documented in `docs/auth.md`), authorship recorded in the existing `claimed` (self-reported, unverified) provenance slot rather than a first-class row field.

--- a/resources/mcp-tools.ts
+++ b/resources/mcp-tools.ts
@@ -51,6 +51,8 @@
  *
  * Prod: first tool call loads the real classes against a fully-real Harper.
  */
+import type { RecordTypeName } from "./record-types.js";
+
 type HandlerKey = "SemanticSearch" | "Memory" | "BootstrapMemories" | "Soul" | "WorkspaceState" | "OrgEvent" | "AttentionQuery" | "RecordUsage";
 const H: Partial<Record<HandlerKey, any>> = {};
 
@@ -366,6 +368,42 @@ interface ToolEntry {
   impl: ToolImpl;
 }
 
+/**
+ * Verb→tool-name overrides — the three naming quirks where the shipped tool
+ * name isn't record-types.ts's default `${toolPrefix}_${verb}` shape (see
+ * that module's `mcp` header doc, and RECORD_TYPES.<Table>.mcp itself,
+ * record-types slice 3, flair#520). Keyed by table name + verb; consumed by
+ * `mcpToolName()` below and by test/unit/mcp-surface-tripwire.test.ts to
+ * compute the expected tool name for every declared registry verb.
+ *
+ * Placement here (not in record-types.ts) is deliberate — per Kern/
+ * Sherlock's unanimous slice-3 verdict, the registry declares WHAT is
+ * exposed (capability: toolPrefix + verbs); this map declares HOW that
+ * capability's tool is actually named (presentation). Coupling names into
+ * the registry would mix the policy layer with the presentation layer,
+ * exactly what the registry's separation is meant to avoid.
+ */
+export const TOOL_NAME_OVERRIDES: Partial<
+  Record<RecordTypeName, Partial<Record<"get" | "search" | "store" | "delete" | "update", string>>>
+> = {
+  Soul: { store: "soul_set" },
+  WorkspaceState: { store: "flair_workspace_set" },
+  OrgEvent: { store: "flair_orgevent" },
+};
+
+/**
+ * Resolve the actual `TOOLS` key for a declared (table, verb) pair: the
+ * `TOOL_NAME_OVERRIDES` entry if one exists, else the default
+ * `${toolPrefix}_${verb}` shape. `toolPrefix` is passed in (rather than
+ * looked up from RECORD_TYPES here) so this stays a pure naming function —
+ * both this module and the tripwire test call it with the registry's own
+ * `toolPrefix` value, keeping the naming rule in exactly one place.
+ */
+export function mcpToolName(table: RecordTypeName, toolPrefix: string, verb: string): string {
+  const override = TOOL_NAME_OVERRIDES[table]?.[verb as "get" | "search" | "store" | "delete" | "update"];
+  return override ?? `${toolPrefix}_${verb}`;
+}
+
 export const TOOLS: Record<string, ToolEntry> = {
   memory_search: {
     def: {
@@ -578,7 +616,7 @@ export const TOOLS: Record<string, ToolEntry> = {
   },
 };
 
-/** The tool definitions for a tools/list response (exactly the 9 curated tools). */
+/** The tool definitions for a tools/list response (exactly the 12 curated tools). */
 export function listToolDefs(): McpToolDef[] {
   return Object.values(TOOLS).map((t) => t.def);
 }

--- a/resources/record-types.ts
+++ b/resources/record-types.ts
@@ -161,19 +161,65 @@
  * field yet — see above); it is a review-time invariant for whoever adds
  * the next entry.
  *
- * `mcp` — SHAPE ONLY, consumed by nothing in this slice. Per Kern's DESIGN
- * REVIEW refinement (Sherlock's Q5, Kern concurring): NOT a flat `verbs`
- * array. `readVerbs` (get/search — same review bar as adding the type
- * itself, since they exercise the same `readScope` the REST surface already
- * exposes) is structurally separate from `writeVerbs` (store/delete — a new
- * write/delete surface over MCP, requiring its own explicit line-item
- * sign-off). None of the five core entries below set `mcp` — flair's
- * existing hand-written `/mcp` surface (resources/mcp-tools.ts's 12-tool
- * `TOOLS` registry) remains the sole, unrelated, authoritative MCP wiring
- * for these five tables in this slice; whether/how to backfill `mcp`
- * declarations onto Memory/Soul/WorkspaceState/OrgEvent (Relationship has
- * no MCP tool today at all) so that surface derives from this registry
- * instead is explicitly slice 3's call, not decided here.
+ * `mcp` — DECLARED AND ENFORCED as of slice 3 (flair#520 design review
+ * round 2, issue comment 2026-07-13 — Kern APPROVE all four asks, Sherlock
+ * APPROVE with one refinement, both unanimous). This field is the reviewed
+ * DECLARATION of the MCP surface, not a runtime generator: resources/
+ * mcp-tools.ts's hand-written `TOOLS` map stays the actual dispatch table.
+ * The slice-3 design round audited all 12 shipped tools and found only 5
+ * are simple table-verb wrappers (memory_get/store/delete, soul_get/set —
+ * and even the soul pair does bespoke `agentId:key` id synthesis); the rest
+ * are composite or bespoke (bootstrap, attention, memory_search,
+ * memory_update, record_usage) and cannot be generated from a registry
+ * entry without either losing schema/behavior specifics or duplicating the
+ * handler. Generating the 5 simple tools would also touch the
+ * security-critical `/mcp` dispatch path for zero behavior change, and
+ * runtime derivation from a registry is structurally the same failure
+ * flair#541 closed for cause (Harper's native-MCP auto-exposing every
+ * resource as a tool) one layer up. What declare-and-enforce buys instead:
+ * any PR that adds or removes an MCP tool must now also touch a policy
+ * chokepoint — either a `RECORD_TYPES.<Table>.mcp` declaration (table-verb
+ * tools) or the `COMPOSITE_MCP_TOOLS` allowlist below (everything else) —
+ * enforced bidirectionally by test/unit/mcp-surface-tripwire.test.ts, or CI
+ * fails. Declaring a verb here does not create a tool; it documents (and,
+ * via the tripwire, locks in) a tool resources/mcp-tools.ts already
+ * implements.
+ *
+ * Per Kern's DESIGN REVIEW refinement (Sherlock's Q5, Kern concurring): NOT
+ * a flat `verbs` array. `readVerbs` (get/search — same review bar as adding
+ * the type itself, since they exercise the same `readScope` the REST
+ * surface already exposes) is structurally separate from `writeVerbs`
+ * (store/delete/update — a write/delete/update surface over MCP, requiring
+ * its own explicit line-item sign-off). `"update"` was added to the
+ * `writeVerbs` union in slice 3 — APPROVED by both Kern and Sherlock as
+ * documenting `memory_update`'s already-shipped two-branch
+ * read-modify-write (in-place overwrite, or a `supersedes`-linked new
+ * version), not a new capability.
+ *
+ * Backfilled on FOUR of the five core entries below, documenting the
+ * CURRENT shipped surface exactly (slice-2 discipline: registration, not
+ * behavior change) — Memory (`get`/`search` reads; `store`/`delete`/
+ * `update` writes), Soul (`get` read; `store` write), WorkspaceState (no
+ * reads; `store` write), OrgEvent (no reads; `store` write). Relationship
+ * stays `mcp`-absent: it has no MCP tool today, and absent means no
+ * exposure, exactly as slice 2 defined.
+ *
+ * Verb→tool-name mapping (default `${toolPrefix}_${verb}`, with three
+ * overrides — `(Soul, store)` → `soul_set`, `(WorkspaceState, store)` →
+ * `flair_workspace_set`, `(OrgEvent, store)` → `flair_orgevent`) lives in
+ * resources/mcp-tools.ts's `TOOL_NAME_OVERRIDES`, not here. Per Kern/
+ * Sherlock's unanimous verdict: the registry declares WHAT is exposed
+ * (capability); mcp-tools.ts owns HOW (names, defaults, routing, input
+ * schema). Keeping presentation out of this file is what keeps
+ * `RecordTypeMcp` a pure capability declaration.
+ *
+ * See `COMPOSITE_MCP_TOOLS` below for the second — and only other —
+ * reviewed chokepoint: tools that are cross-table, aggregate, or otherwise
+ * cannot map to a single table + verb (`bootstrap`, `attention`,
+ * `record_usage`). Sherlock's slice-3 refinement (Kern concurring on the
+ * relocation) put that allowlist HERE, in record-types.ts, rather than in
+ * mcp-tools.ts — so the FULL MCP surface (table-verb tools and composites
+ * alike) is reviewable in this one file, not split across two.
  *
  * Design lineage: flair#520 design draft (issue comment, 2026-07-13) §4;
  * Sherlock's Security Review (readScope narrowing, mandatory-vs-optional
@@ -262,14 +308,20 @@ export type RecordTypeFederation = "excluded" | "included";
  * MCP tool-surface shape — see header doc's `mcp` section. Structurally
  * separates read-only verbs (reviewed at the "add a type" bar) from
  * mutating verbs (their own explicit line-item sign-off), per Sherlock's
- * Q5 / Kern's concurrence. SHAPE ONLY: nothing in this slice generates a
- * tool from this field. Absent (the default for all five core entries) =
- * no MCP exposure derived from this registry for that type.
+ * Q5 / Kern's concurrence. DECLARE-AND-ENFORCE as of slice 3: nothing
+ * generates a tool from this field — resources/mcp-tools.ts's hand-written
+ * `TOOLS` map remains the actual dispatch — but every verb declared here
+ * MUST resolve (via mcp-tools.ts's default naming or its
+ * `TOOL_NAME_OVERRIDES`) to a tool that exists in `TOOLS`, and every
+ * table-verb-shaped tool in `TOOLS` MUST be declared here, enforced
+ * bidirectionally by test/unit/mcp-surface-tripwire.test.ts. Absent
+ * (Relationship only, in this slice) = no MCP exposure for that type — the
+ * tripwire proves zero tools carry its toolPrefix-style prefix.
  */
 export interface RecordTypeMcp {
   toolPrefix: string;
   readVerbs: Array<"get" | "search">;
-  writeVerbs: Array<"store" | "delete">;
+  writeVerbs: Array<"store" | "delete" | "update">;
 }
 
 export interface RecordTypePolicy {
@@ -320,6 +372,7 @@ export const RECORD_TYPES = {
     embedding: { field: "content", exposedSearch: true },
     remEligible: false,
     federation: "included",
+    mcp: { toolPrefix: "memory", readVerbs: ["get", "search"], writeVerbs: ["store", "delete", "update"] },
   },
 
   Relationship: {
@@ -344,6 +397,7 @@ export const RECORD_TYPES = {
     provenance: false,
     remEligible: false,
     federation: "excluded",
+    mcp: { toolPrefix: "flair_workspace", readVerbs: [], writeVerbs: ["store"] },
   },
 
   OrgEvent: {
@@ -357,6 +411,7 @@ export const RECORD_TYPES = {
     provenance: false,
     remEligible: false,
     federation: "excluded",
+    mcp: { toolPrefix: "flair_orgevent", readVerbs: [], writeVerbs: ["store"] },
   },
 
   Soul: {
@@ -370,10 +425,33 @@ export const RECORD_TYPES = {
     provenance: false,
     remEligible: false,
     federation: "included",
+    mcp: { toolPrefix: "soul", readVerbs: ["get"], writeVerbs: ["store"] },
   },
 } as const satisfies Record<string, RecordTypePolicy>;
 
 export type RecordTypeName = keyof typeof RECORD_TYPES;
+
+// ─── Composite MCP tools (the second, and only other, reviewed chokepoint) ─
+//
+// Tools that do not map to a single table + verb — cross-table aggregates,
+// bespoke resources, or multi-source composites. These cannot be expressed
+// via `RECORD_TYPES.<Table>.mcp` (there is no single `table` to attach them
+// to), so slice 3's design round (Sherlock's refinement, Kern concurring —
+// see the `mcp` header doc above) makes this array the SECOND reviewed
+// chokepoint for the MCP surface: test/unit/mcp-surface-tripwire.test.ts
+// requires every tool name in resources/mcp-tools.ts's `TOOLS` map to be
+// either derived from a declared `RECORD_TYPES.<Table>.mcp` verb OR listed
+// here. A PR adding a new composite MCP tool (or renaming/removing one of
+// these three) must touch this array — same review bar as touching a
+// table's `mcp` field.
+//
+//   bootstrap    — Soul + Memory + predicted-context composite (BootstrapMemories)
+//   attention    — cross-table aggregate query (AttentionQuery.ts), not a table verb
+//   record_usage — usage-signal resource (RecordUsage.ts), not a table verb
+//
+export const COMPOSITE_MCP_TOOLS = ["bootstrap", "attention", "record_usage"] as const;
+
+export type CompositeMcpTool = (typeof COMPOSITE_MCP_TOOLS)[number];
 
 // ─── Runtime immutability ───────────────────────────────────────────────────
 // Belt-and-suspenders backstop for the "static, compiled" invariant (see
@@ -386,7 +464,10 @@ export type RecordTypeName = keyof typeof RECORD_TYPES;
 // sub-object (attribution/embedding/mcp) makes an attempted mutation throw
 // (every .ts file in this repo compiles as an ES module, which is always
 // strict mode) instead of silently desyncing the registry from what a
-// resource file already composed at its own module-load time.
+// resource file already composed at its own module-load time. Same
+// treatment for `COMPOSITE_MCP_TOOLS` — it is the second reviewed MCP-surface
+// chokepoint (see its own doc above) and gets the same static-registry
+// guarantee as RECORD_TYPES itself.
 function deepFreeze<T>(value: T): T {
   if (value !== null && typeof value === "object" && !Object.isFrozen(value)) {
     for (const key of Object.getOwnPropertyNames(value)) {
@@ -397,3 +478,4 @@ function deepFreeze<T>(value: T): T {
   return value;
 }
 deepFreeze(RECORD_TYPES);
+deepFreeze(COMPOSITE_MCP_TOOLS);

--- a/resources/record-types.ts
+++ b/resources/record-types.ts
@@ -162,7 +162,7 @@
  * the next entry.
  *
  * `mcp` — DECLARED AND ENFORCED as of slice 3 (flair#520 design review
- * round 2, issue comment 2026-07-13 — Kern APPROVE all four asks, Sherlock
+ * round 2, issue comment 2026-07-18 — Kern APPROVE all four asks, Sherlock
  * APPROVE with one refinement, both unanimous). This field is the reviewed
  * DECLARATION of the MCP surface, not a runtime generator: resources/
  * mcp-tools.ts's hand-written `TOOLS` map stays the actual dispatch table.

--- a/test/unit/mcp-surface-tripwire.test.ts
+++ b/test/unit/mcp-surface-tripwire.test.ts
@@ -1,0 +1,151 @@
+/**
+ * mcp-surface-tripwire.test.ts — bidirectional enforcement that the MCP
+ * surface declared in resources/record-types.ts (`RECORD_TYPES.<Table>.mcp`
+ * + `COMPOSITE_MCP_TOOLS`) and resources/mcp-tools.ts's `TOOLS` dispatch
+ * table never drift (record-types slice 3, flair#520).
+ *
+ * Design record: https://github.com/tpsdev-ai/flair/issues/520 — Flint's
+ * slice-3 design comment, Kern's DESIGN REVIEW (APPROVE all four asks),
+ * Sherlock's Security Review (APPROVE with the COMPOSITE_MCP_TOOLS
+ * relocation-into-record-types.ts refinement, adopted by both).
+ *
+ * "Declare-and-enforce, not runtime-derive": resources/mcp-tools.ts's
+ * `TOOLS` map stays the hand-written dispatch table — nothing in this file
+ * generates a tool. What IS enforced is that the two reviewed chokepoints
+ * (a table's `mcp` verbs, and the `COMPOSITE_MCP_TOOLS` allowlist) and the
+ * actually-shipped `TOOLS` map describe the SAME SET, in both directions:
+ *
+ *   1. registry → tools: every verb declared on a `RECORD_TYPES.<Table>.mcp`
+ *      entry resolves (default naming, or a `TOOL_NAME_OVERRIDES` entry) to
+ *      a tool that exists in `TOOLS`. A declaration cannot outrun reality.
+ *   2. tools → registry: every tool name in `TOOLS` is either derived from
+ *      a declared verb or listed in `COMPOSITE_MCP_TOOLS`. A shipped tool
+ *      cannot exist undeclared — this is the check that makes "any PR
+ *      touching the MCP surface must also touch a policy chokepoint" an
+ *      enforced CI failure, not an aspiration.
+ *   3. absence means absence: a table with no `mcp` field (Relationship, in
+ *      this slice) contributes zero tools carrying its table-name-style
+ *      prefix.
+ *   4. the full 12-tool `tools/list` surface is pinned as a golden value —
+ *      belt-and-suspenders on the single highest-value invariant (an
+ *      undeclared tool silently reaching a client is exactly flair#541's
+ *      failure mode), independent of whether the bidirectional checks above
+ *      would also have caught a given drift.
+ *
+ * CRITICAL (CodeQL js/regex-injection — we've been burned twice on this
+ * class of finding): every "does this tool name carry this prefix" check
+ * below uses plain string methods (`startsWith`, `===`), never
+ * `new RegExp(...)` built from a runtime string.
+ */
+import { describe, it, expect } from "bun:test";
+import { RECORD_TYPES, COMPOSITE_MCP_TOOLS, type RecordTypeName } from "../../resources/record-types.ts";
+import { TOOLS, TOOL_NAME_OVERRIDES, mcpToolName } from "../../resources/mcp-tools.ts";
+
+const TABLE_NAMES = Object.keys(RECORD_TYPES) as RecordTypeName[];
+const SHIPPED_TOOL_NAMES = Object.keys(TOOLS).sort();
+
+/** Every (table, verb, toolPrefix) triple declared across RECORD_TYPES. */
+const DECLARED_VERBS: Array<[table: RecordTypeName, verb: string, toolPrefix: string]> = [];
+for (const table of TABLE_NAMES) {
+  const mcp = RECORD_TYPES[table].mcp;
+  if (!mcp) continue;
+  for (const verb of [...mcp.readVerbs, ...mcp.writeVerbs]) {
+    DECLARED_VERBS.push([table, verb, mcp.toolPrefix]);
+  }
+}
+
+/**
+ * The full set of tool names the registry + composite allowlist declare —
+ * computed the SAME way direction-1's per-verb check computes a single
+ * name, then unioned with COMPOSITE_MCP_TOOLS. Used by direction 2 to
+ * decide "declared vs. undeclared" for every shipped tool.
+ */
+function declaredToolNames(): Set<string> {
+  const names = new Set<string>();
+  for (const [table, verb, toolPrefix] of DECLARED_VERBS) names.add(mcpToolName(table, toolPrefix, verb));
+  for (const name of COMPOSITE_MCP_TOOLS) names.add(name);
+  return names;
+}
+
+describe("MCP surface tripwire — RECORD_TYPES.mcp + COMPOSITE_MCP_TOOLS vs. resources/mcp-tools.ts TOOLS", () => {
+  describe("direction 1: every declared registry verb resolves to an existing tool", () => {
+    it.each(DECLARED_VERBS)("%s.mcp verb \"%s\" (toolPrefix \"%s\") resolves to a tool present in TOOLS", (table, verb, toolPrefix) => {
+      const name = mcpToolName(table, toolPrefix, verb);
+      expect(
+        Object.prototype.hasOwnProperty.call(TOOLS, name),
+        `RECORD_TYPES.${table}.mcp declares write/read verb "${verb}" (resolved tool name "${name}"), ` +
+          `but resources/mcp-tools.ts's TOOLS map has no such entry. Either implement the tool in ` +
+          `resources/mcp-tools.ts, add/fix a TOOL_NAME_OVERRIDES entry there if the shipped name differs ` +
+          `from the default "\${toolPrefix}_\${verb}" shape, or remove the verb from ` +
+          `resources/record-types.ts's RECORD_TYPES.${table}.mcp.`,
+      ).toBe(true);
+    });
+  });
+
+  describe("direction 2: every shipped tool is declared (a registry verb, or a composite)", () => {
+    const declared = declaredToolNames();
+
+    it.each(SHIPPED_TOOL_NAMES)('TOOLS["%s"] is declared (registry verb or COMPOSITE_MCP_TOOLS)', (name) => {
+      expect(
+        declared.has(name),
+        `resources/mcp-tools.ts's TOOLS map has a tool named "${name}" that is neither derived from any ` +
+          `RECORD_TYPES.<Table>.mcp verb nor listed in COMPOSITE_MCP_TOOLS (both declared in ` +
+          `resources/record-types.ts). Declare it there: if it maps to a single table + verb, add the verb ` +
+          `to that table's \`mcp\` field (and a TOOL_NAME_OVERRIDES entry in resources/mcp-tools.ts if the ` +
+          `name isn't the default "\${toolPrefix}_\${verb}" shape); otherwise add "${name}" to ` +
+          `COMPOSITE_MCP_TOOLS in resources/record-types.ts.`,
+      ).toBe(true);
+    });
+  });
+
+  describe("absence means absence: a table with no `mcp` field contributes zero tools", () => {
+    const undeclaredTables = TABLE_NAMES.filter((t) => !RECORD_TYPES[t].mcp);
+
+    it("at least one table (Relationship) has no mcp field in this slice", () => {
+      expect(undeclaredTables).toContain("Relationship");
+    });
+
+    it.each(undeclaredTables)("%s: zero tools in TOOLS carry a table-name-style prefix for it", (table) => {
+      const prefix = table.toLowerCase();
+      const matches = SHIPPED_TOOL_NAMES.filter(
+        (name) => name === prefix || name.startsWith(`${prefix}_`),
+      );
+      expect(matches).toEqual([]);
+    });
+  });
+
+  describe("golden value: the complete 12-tool tools/list surface is pinned", () => {
+    it("sorted TOOLS keys deep-equal the pinned list (tools/list byte-identical)", () => {
+      expect(SHIPPED_TOOL_NAMES).toEqual([
+        "attention",
+        "bootstrap",
+        "flair_orgevent",
+        "flair_workspace_set",
+        "memory_delete",
+        "memory_get",
+        "memory_search",
+        "memory_store",
+        "memory_update",
+        "record_usage",
+        "soul_get",
+        "soul_set",
+      ]);
+    });
+
+    it("the declared surface (registry verbs ∪ composites) also totals exactly 12 unique names", () => {
+      expect(declaredToolNames().size).toBe(12);
+    });
+  });
+
+  describe("TOOL_NAME_OVERRIDES sanity", () => {
+    it("every override target is itself a real tool in TOOLS", () => {
+      for (const table of Object.keys(TOOL_NAME_OVERRIDES) as RecordTypeName[]) {
+        const verbs = TOOL_NAME_OVERRIDES[table] ?? {};
+        for (const verb of Object.keys(verbs)) {
+          const name = verbs[verb as keyof typeof verbs] as string;
+          expect(Object.prototype.hasOwnProperty.call(TOOLS, name)).toBe(true);
+        }
+      }
+    });
+  });
+});

--- a/test/unit/record-types-registry.test.ts
+++ b/test/unit/record-types-registry.test.ts
@@ -49,6 +49,7 @@ import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import {
   RECORD_TYPES,
+  COMPOSITE_MCP_TOOLS,
   type RecordTypePolicy,
   type RecordTypeReadScopeMode,
   type RecordTypeIdentityMode,
@@ -61,7 +62,7 @@ const VALID_READ_SCOPE: RecordTypeReadScopeMode[] = ["owner-only", "open-within-
 const VALID_ATTRIBUTION_MODES = ["validate-truthy", "validate-strict", "stamp-default", "stamp-strict"];
 const VALID_FEDERATION: RecordTypeFederation[] = ["excluded", "included"];
 const VALID_MCP_READ_VERBS = ["get", "search"];
-const VALID_MCP_WRITE_VERBS = ["store", "delete"];
+const VALID_MCP_WRITE_VERBS = ["store", "delete", "update"];
 
 // ─── 1. Shape / exhaustiveness ─────────────────────────────────────────────
 
@@ -125,8 +126,8 @@ describe("RECORD_TYPES — shape and exhaustiveness", () => {
     for (const v of policy.mcp.writeVerbs) expect(VALID_MCP_WRITE_VERBS).toContain(v);
   });
 
-  it("no entry sets mcp in this slice (MCP derivation is slice 3 — shape only)", () => {
-    for (const [, policy] of entries) expect(policy.mcp).toBeUndefined();
+  it("Relationship has no mcp field (no MCP tool today — absent means no exposure)", () => {
+    expect(RECORD_TYPES.Relationship.mcp).toBeUndefined();
   });
 });
 
@@ -167,6 +168,7 @@ describe("RECORD_TYPES — golden values (must match each table's current shippe
       embedding: { field: "content", exposedSearch: true },
       remEligible: false,
       federation: "included",
+      mcp: { toolPrefix: "memory", readVerbs: ["get", "search"], writeVerbs: ["store", "delete", "update"] },
     });
   });
 
@@ -193,6 +195,7 @@ describe("RECORD_TYPES — golden values (must match each table's current shippe
       provenance: false,
       remEligible: false,
       federation: "excluded",
+      mcp: { toolPrefix: "flair_workspace", readVerbs: [], writeVerbs: ["store"] },
     });
   });
 
@@ -206,6 +209,7 @@ describe("RECORD_TYPES — golden values (must match each table's current shippe
       provenance: false,
       remEligible: false,
       federation: "excluded",
+      mcp: { toolPrefix: "flair_orgevent", readVerbs: [], writeVerbs: ["store"] },
     });
   });
 
@@ -219,7 +223,67 @@ describe("RECORD_TYPES — golden values (must match each table's current shippe
       provenance: false,
       remEligible: false,
       federation: "included",
+      mcp: { toolPrefix: "soul", readVerbs: ["get"], writeVerbs: ["store"] },
     });
+  });
+});
+
+// ─── 3b. MCP surface — golden-value pins (slice 3, flair#520) ─────────────
+//
+// The "no entry sets mcp" shape-only assertion from slice 2 is gone — slice
+// 3's design round (Kern APPROVE all four asks, Sherlock APPROVE with the
+// COMPOSITE_MCP_TOOLS-relocation refinement) backfilled `mcp` on four of the
+// five entries and added the composite allowlist. These pins are the same
+// discipline as section 3 above: hardcoded independently of
+// resources/record-types.ts, so a registry edit that drifts from the
+// reviewed, shipped MCP surface fails here even though the bidirectional
+// enforcement lives in test/unit/mcp-surface-tripwire.test.ts, not this file.
+
+describe("RECORD_TYPES.<Table>.mcp — golden values (backfilled surface, slice 3)", () => {
+  it("Memory: get/search reads, store/delete/update writes", () => {
+    expect(RECORD_TYPES.Memory.mcp).toEqual({
+      toolPrefix: "memory",
+      readVerbs: ["get", "search"],
+      writeVerbs: ["store", "delete", "update"],
+    });
+  });
+
+  it("Soul: get read, store write", () => {
+    expect(RECORD_TYPES.Soul.mcp).toEqual({
+      toolPrefix: "soul",
+      readVerbs: ["get"],
+      writeVerbs: ["store"],
+    });
+  });
+
+  it("WorkspaceState: no reads, store write", () => {
+    expect(RECORD_TYPES.WorkspaceState.mcp).toEqual({
+      toolPrefix: "flair_workspace",
+      readVerbs: [],
+      writeVerbs: ["store"],
+    });
+  });
+
+  it("OrgEvent: no reads, store write", () => {
+    expect(RECORD_TYPES.OrgEvent.mcp).toEqual({
+      toolPrefix: "flair_orgevent",
+      readVerbs: [],
+      writeVerbs: ["store"],
+    });
+  });
+
+  it("Relationship: mcp absent (no MCP tool today)", () => {
+    expect(RECORD_TYPES.Relationship.mcp).toBeUndefined();
+  });
+});
+
+describe("COMPOSITE_MCP_TOOLS — golden-value pin (slice 3, flair#520)", () => {
+  it("pins the exact three composite tool names, in order", () => {
+    expect(COMPOSITE_MCP_TOOLS).toEqual(["bootstrap", "attention", "record_usage"]);
+  });
+
+  it("is deep-frozen (static-registry invariant, same as RECORD_TYPES)", () => {
+    expect(Object.isFrozen(COMPOSITE_MCP_TOOLS)).toBe(true);
   });
 });
 


### PR DESCRIPTION
## Summary

Record-types slice 3 (#520): the registry's `mcp` field goes from shape-only to **declared and enforced** — without generating anything at runtime.

- **`RECORD_TYPES.<Table>.mcp` backfilled** on Memory, Soul, WorkspaceState, OrgEvent, documenting the CURRENT shipped 12-tool `/mcp` surface exactly (registration, not behavior change). Relationship stays `mcp`-absent — it has no MCP tool, and absent = no exposure.
- **`RecordTypeMcp.writeVerbs` gains `"update"`** (additive) — documents `memory_update`'s already-shipped two-branch read-modify-write; K&S line-item approved.
- **New `COMPOSITE_MCP_TOOLS` export in `record-types.ts`** (deep-frozen: `bootstrap`, `attention`, `record_usage`) — the second and only other reviewed chokepoint, for tools that don't map to a single table + verb. Placed in `record-types.ts` per Sherlock's refinement (adopted): the FULL MCP surface is reviewable in one file.
- **`TOOL_NAME_OVERRIDES` + `mcpToolName()` in `mcp-tools.ts`** own the three naming quirks (`soul_set`, `flair_workspace_set`, `flair_orgevent`); default mapping is `${toolPrefix}_${verb}`. Registry declares WHAT is exposed; mcp-tools owns HOW.
- **New `test/unit/mcp-surface-tripwire.test.ts`** — bidirectional enforcement: every declared verb must resolve to a tool in `TOOLS`; every tool in `TOOLS` must be either derived from a declared verb or listed in `COMPOSITE_MCP_TOOLS` (failure message names the exact file to declare it in); `mcp`-absent tables have zero prefixed tools; the complete 12-name `tools/list` surface is pinned as a golden value. Plain string operations only — no dynamic `RegExp` construction.
- `record-types-registry.test.ts`'s slice-2 "no entry sets mcp" assertion flips to golden-value pins of the backfilled declarations + a `COMPOSITE_MCP_TOOLS` pin.
- Fixed the stale "exactly the 9 curated tools" comment in `listToolDefs` (actual: 12).

**Zero runtime behavior change**: `tools/list` output byte-identical, the `TOOLS` dispatch table untouched, every existing `mcp-handler.test.ts` assertion passes unchanged. The diff is registry data + types + tests + doc/comment fixes.

## Design record

- Slice-3 design: https://github.com/tpsdev-ai/flair/issues/520#issuecomment-5011012065
- Kern DESIGN REVIEW — APPROVE all four asks: https://github.com/tpsdev-ai/flair/issues/520#issuecomment-5011015354
- Sherlock Security Review — APPROVE with one refinement (COMPOSITE_MCP_TOOLS relocation into record-types.ts, adopted here): https://github.com/tpsdev-ai/flair/issues/520#issuecomment-5011018465

## Acceptance evidence

- `bun test test/unit/` — **2376 pass, 0 fail** (140 files), including the new tripwire (its golden pin matches `mcp-handler.test.ts`'s existing 12-tool `tools/list` pin exactly).
- `test/unit-isolated/` per-file in separate invocations — **21 + 97 + 11 pass, 0 fail**.
- Integration suite: the environment-dependent e2e failures observed locally reproduce **identically on an unmodified `origin/main` baseline** (verified by stash-and-rerun on the same subset — same failing tests, same counts), so they are unrelated to this diff; CI is the authoritative integration gate for this PR.
- TypeScript: `tsc --noEmit` introduces no new errors vs `origin/main`.

Closes nothing — #520 tracking continues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)