### PR TITLE
feat(cli): flair keys prune — recoverable cleanup of stale/unregistered keys (flair#734)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ## [Unreleased]
 
+### ✨ `flair keys prune` — recoverable cleanup of stale/unregistered keys (flair#734)
+
+Follow-up to #731's doctor agent-iteration, which made previously-invisible stale keys visible (each renders as a "not registered" gate finding) but shipped no command to act on it — every `flair doctor` run just re-reported the same noise, and a long-lived dogfood host's key dir kept accreting e2e-test leftovers. `agent remove <id>` already handles the registered case (agent + key together); `flair keys prune` fills the gap for keys with no agent behind them at all.
+
+- **`flair keys prune`** classifies every file in the key dir (`FLAIR_KEY_DIR` / `~/.flair/keys` / `--keys-dir`) into one of four classes: `keep` (registered on the configured instance — never touched, under any flag), `stale` (a valid Ed25519 seed for an agent that is NOT registered), `invalid` (a `.key` file that doesn't parse as an Ed25519 seed at all — reported as its own class, never lumped in with "unregistered"), or `ignored` (non-`.key` files, directories, and its own `.pruned` archive).
+- **Dry-run by default** — prints what would move and why, moves nothing. `--apply` actually moves.
+- **Never deletes.** Prunable files are MOVED to `<keysDir>/.pruned/<YYYY-MM-DD>/` (UTC date), preserving the original filename; a same-day collision (e.g. two prune runs) gets a numeric suffix (`agentId.key.2`) rather than overwriting the earlier archive.
+- **Conservative on reachability**: registration is checked only against the configured default instance (`--instance <url>` to target a different one); if that instance can't be confirmed reachable, the WHOLE run aborts immediately with a non-zero exit — nothing is classified or moved. Never guesses offline.
+- Registration checking reuses `checkAgentRegistered` (`src/cli.ts`) — the exact same signed `GET /Agent/:id` doctor's registration gate already uses, not a reimplementation.
+- **Doctor integration**: the existing "not registered" gate finding's fix hint (`src/doctor-client.ts` `describeAgentGateFinding`) now points at both remedies — `flair agent add <id>` if the key should be registered, or `flair keys prune` if it's a stale/leftover key. `flair doctor` itself stays read-only; no behavior change beyond the hint text.
+- New `test/unit/keys-prune.test.ts` (classification + move + CLI wiring, mocked-fetch + temp dirs, plus two subprocess acceptance checks for the process-exit-code bullets) and new `classifyKeyFile`/`resolveCollisionSafeName`/`pruneDateStamp` pure-logic tests in `test/unit/doctor-client.test.ts`.
+
 ### 🧪 Structural guard: `provenance.claimed.*` can never enter an authority decision (flair#735, follow-up to #718)
 
 flair#718's design review (Sherlock) noted that `claimed.model`/`claimed.client` grant zero authority by CONTRACT — never read for read-scope, attribution, dedup, or usage-count decisions — but that contract was enforced only by field naming and code review, not structurally. This is a pure test slice; no runtime code changed.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -61,7 +61,12 @@ import {
   resolveWireFlairUrl,
   planAgentIterations,
   describeAgentGateFinding,
+  classifyKeyFile,
+  resolveCollisionSafeName,
+  pruneDateStamp,
+  PRUNED_DIR_NAME,
   type AgentGateState,
+  type KeyPruneClass,
 } from "./doctor-client.js";
 
 // Federation crypto helpers — inlined to avoid cross-boundary imports from
@@ -3071,6 +3076,219 @@ agent
     }
 
     console.log(`\n✅ Agent '${id}' removed successfully`);
+  });
+
+// ─── flair keys ────────────────────────────────────────────────────────────────
+// flair#734 — recoverable cleanup of stale/unregistered/invalid key files in
+// the key dir. Follow-up to #731's doctor agent-iteration, which made this
+// state visible (every stale key renders as a "not registered" gate finding,
+// src/doctor-client.ts describeAgentGateFinding) but shipped no way to act on
+// it — every doctor run just re-reported the same noise, and the dir kept
+// accreting e2e-test leftovers. `agent remove <id>` already handles the
+// REGISTERED case (agent + key together); this fills the gap for keys with no
+// agent behind them at all: test leftovers, renamed-agent leftovers, and
+// files that were never valid Ed25519 seeds to begin with.
+//
+// classifyKeysDir/applyKeyPrune are exported (not inlined in the action) so
+// they're directly unit-testable with a mocked fetch + a temp keys dir, same
+// pattern as checkAgentRegistered/probeFlairReachable above (see
+// test/unit/doctor-client-network.test.ts) — no subprocess, no real ~/.flair.
+
+export interface KeysPruneEntry {
+  name: string;
+  class: KeyPruneClass;
+  reason: string;
+  agentId?: string;
+}
+
+export interface KeysPruneResult {
+  /** True when the configured instance could not be confirmed reachable —
+   *  the WHOLE run stops the moment this happens, before classifying
+   *  anything else (never classify offline). `entries` is always empty here. */
+  aborted: boolean;
+  abortReason?: string;
+  entries: KeysPruneEntry[];
+}
+
+/** Best-effort seed-validity check for a `.key` file: does it parse via any
+ *  of the formats loadEd25519PrivateKeyFromFile (src/mcp-client-assertion.ts
+ *  — the same loader `flair mcp token` uses) accepts? Never throws — used
+ *  only to decide "invalid" vs. "worth a registration check", not to
+ *  actually sign anything. */
+function isValidPrivateKeySeedFile(keyPath: string): boolean {
+  try {
+    loadEd25519PrivateKeyFromFile(keyPath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Classify every entry in `keysDir` for `flair keys prune`. Pure READ —
+ * never writes or moves anything; see applyKeyPrune below for the actual
+ * move. Directories (including keysDir's own `.pruned` archive, PRUNED_DIR_NAME)
+ * and files not ending in `.key` are "ignored" without any network call.
+ * `.key` files with an unparseable seed are "invalid" without a network call
+ * either — only a `.key` file that DOES parse triggers a signed
+ * `GET /Agent/:id` against `baseUrl` (checkAgentRegistered above, the exact
+ * same check doctor's registration gate uses).
+ *
+ * If that check EVER reports "unreachable" — the instance couldn't be
+ * confirmed up for that key — the WHOLE run aborts immediately
+ * (`aborted: true`, `entries: []`, short-circuiting the loop): never
+ * classify anything, prunable or not, while registration state can't be
+ * verified. A missing keysDir is treated as "nothing to classify" (fresh
+ * install), not an error — matches `flair doctor`'s own "Keys directory
+ * missing" being a separate, non-fatal finding.
+ */
+export async function classifyKeysDir(keysDir: string, baseUrl: string): Promise<KeysPruneResult> {
+  if (!existsSync(keysDir)) return { aborted: false, entries: [] };
+
+  const dirents = readdirSync(keysDir, { withFileTypes: true });
+  const entries: KeysPruneEntry[] = [];
+  const candidates: Array<{ name: string; agentId: string }> = [];
+
+  for (const d of dirents) {
+    if (d.isDirectory()) {
+      entries.push({
+        name: d.name,
+        class: "ignored",
+        reason: d.name === PRUNED_DIR_NAME ? "prune archive directory" : "directory (not a key file)",
+      });
+      continue;
+    }
+    if (!d.name.endsWith(".key")) {
+      entries.push({ name: d.name, class: "ignored", reason: "not a .key file" });
+      continue;
+    }
+    candidates.push({ name: d.name, agentId: d.name.slice(0, -".key".length) });
+  }
+
+  for (const c of candidates) {
+    const keyPath = join(keysDir, c.name);
+    if (!isValidPrivateKeySeedFile(keyPath)) {
+      const decision = classifyKeyFile(c.agentId, false, null, baseUrl);
+      entries.push({ name: c.name, class: decision.class, reason: decision.reason, agentId: c.agentId });
+      continue;
+    }
+
+    const reg = await checkAgentRegistered(baseUrl, c.agentId, keysDir);
+    if (reg.state === "unreachable") {
+      return {
+        aborted: true,
+        abortReason:
+          `could not reach ${baseUrl} to verify agent '${c.agentId}' is registered` +
+          `${reg.detail ? ` (${reg.detail})` : ""} — aborting; nothing was classified or moved. ` +
+          `Pass --instance <url> to target a different instance.`,
+        entries: [],
+      };
+    }
+    const decision = classifyKeyFile(c.agentId, true, { state: reg.state, detail: reg.detail }, baseUrl);
+    entries.push({ name: c.name, class: decision.class, reason: decision.reason, agentId: c.agentId });
+  }
+
+  return { aborted: false, entries };
+}
+
+/**
+ * Move every "stale" or "invalid" entry from `keysDir` into
+ * `<keysDir>/.pruned/<dateStamp>/`, creating the archive dir as needed —
+ * MOVE, never delete, so a bad classification is always recoverable. Only
+ * ever called with entries classifyKeysDir already decided are prunable; a
+ * "keep" or "ignored" entry passed in here is simply skipped (defense in
+ * depth — a registered agent's key must never move, even if a caller bug
+ * fed it in). Collisions (same filename already archived from an earlier
+ * prune run today) get a numeric suffix (resolveCollisionSafeName) rather
+ * than silently overwriting the earlier archive.
+ */
+export function applyKeyPrune(
+  keysDir: string,
+  entries: KeysPruneEntry[],
+  dateStamp: string,
+): Array<{ name: string; movedTo: string }> {
+  const prunable = entries.filter((e) => e.class === "stale" || e.class === "invalid");
+  if (prunable.length === 0) return [];
+
+  const destDir = join(keysDir, PRUNED_DIR_NAME, dateStamp);
+  mkdirSync(destDir, { recursive: true });
+  const existing = new Set(readdirSync(destDir));
+
+  const moved: Array<{ name: string; movedTo: string }> = [];
+  for (const e of prunable) {
+    const destName = resolveCollisionSafeName(existing, e.name);
+    existing.add(destName);
+    const from = join(keysDir, e.name);
+    const to = join(destDir, destName);
+    renameSync(from, to);
+    moved.push({ name: e.name, movedTo: to });
+  }
+  return moved;
+}
+
+const keys = program.command("keys").description("Manage Ed25519 key files in the key directory");
+
+keys
+  .command("prune")
+  .description("Move stale/unregistered/invalid keys to <keysDir>/.pruned/<date>/ — dry-run by default")
+  .option("--apply", "Actually move prunable keys (default: dry-run, prints what would move and why)")
+  .option("--keys-dir <dir>", "Directory to scan for key files (else FLAIR_KEY_DIR, ~/.flair/keys)")
+  .option("--instance <url>", "Flair instance to check registration against (else FLAIR_TARGET/FLAIR_URL/config)")
+  .option("--port <port>", "Harper HTTP port (used when --instance/FLAIR_URL/FLAIR_TARGET are not set)")
+  .action(async (opts) => {
+    const keysDir: string = opts.keysDir ?? process.env.FLAIR_KEY_DIR ?? defaultKeysDir();
+    const baseUrl = resolveBaseUrl({ target: opts.instance, port: opts.port });
+    const apply = !!opts.apply;
+
+    console.log(`\n${render.wrap(render.c.bold, "🔑 Flair Keys Prune")}${apply ? "" : render.wrap(render.c.dim, " (dry run)")}\n`);
+    console.log(`  Keys directory: ${render.wrap(render.c.dim, keysDir)}`);
+    console.log(`  Instance:       ${render.wrap(render.c.dim, baseUrl)}\n`);
+
+    const result = await classifyKeysDir(keysDir, baseUrl);
+    if (result.aborted) {
+      console.error(`  ${render.icons.error} ${result.abortReason}`);
+      console.log("");
+      process.exit(1);
+    }
+
+    const stale = result.entries.filter((e) => e.class === "stale");
+    const invalid = result.entries.filter((e) => e.class === "invalid");
+    const kept = result.entries.filter((e) => e.class === "keep");
+    const ignored = result.entries.filter((e) => e.class === "ignored");
+    const prunable = [...stale, ...invalid];
+
+    if (stale.length + invalid.length + kept.length === 0) {
+      console.log(`  ${render.icons.ok} No key files found in ${render.wrap(render.c.dim, keysDir)} — nothing to prune.`);
+      console.log("");
+      return;
+    }
+
+    for (const e of prunable) {
+      const icon = e.class === "invalid" ? render.icons.error : render.icons.warn;
+      console.log(`  ${icon} ${render.wrap(render.c.bold, e.name)} — ${e.class}: ${e.reason}`);
+    }
+    for (const e of kept) {
+      console.log(`  ${render.icons.ok} ${e.name} — registered, keeping`);
+    }
+
+    if (!apply) {
+      console.log("");
+      console.log(
+        `  ${render.wrap(render.c.dim, `${prunable.length} prunable (${stale.length} stale, ${invalid.length} invalid), ${kept.length} kept, ${ignored.length} ignored`)}`,
+      );
+      if (prunable.length > 0) {
+        console.log(`  ${render.wrap(render.c.dim, "Run with --apply to move prunable keys to")} ${join(keysDir, PRUNED_DIR_NAME, pruneDateStamp())}`);
+      }
+      console.log("");
+      return;
+    }
+
+    const moved = applyKeyPrune(keysDir, result.entries, pruneDateStamp());
+    console.log("");
+    for (const m of moved) {
+      console.log(`  ${render.icons.ok} moved ${m.name} -> ${m.movedTo}`);
+    }
+    console.log(`\n  ${render.wrap(render.c.bold, String(moved.length))} moved, ${kept.length} kept, ${ignored.length} ignored\n`);
   });
 
 // ─── flair mcp ───────────────────────────────────────────────────────────────

--- a/src/doctor-client.ts
+++ b/src/doctor-client.ts
@@ -450,16 +450,24 @@ export function planAgentIterations(keyAgentIds: string[], agentFlag: string | u
  *  type only (no import) to keep this module network/crypto-free. */
 export type AgentGateState = "registered" | "not-registered" | "unreachable" | "no-key";
 
+/** AgentGateState minus "unreachable", for the parts of the surface (like
+ *  classifyKeyFile below) that only ever see it once instance reachability
+ *  is already settled — a caller that has confirmed the instance IS
+ *  reachable never has "unreachable" left to hand back here. */
+export type PruneRegistrationState = "registered" | "not-registered" | "no-key";
+
 export interface AgentGateFinding {
   icon: "warn" | "error";
   message: string;
   fixHint?: string;
   /** Whether this finding counts toward doctor's found/fixed/remaining
    *  summary (flair#721). True only for the actionable "not-registered"
-   *  state (fixable via `flair agent add <id>`) — a transient or missing-key
-   *  finding is surfaced but not counted, matching how doctor already treats
-   *  "could not verify agent registration" elsewhere (Client integration
-   *  section) — no --fix action exists for either non-issue case. */
+   *  state — fixable either by registering (`flair agent add <id>`) or, if
+   *  the key is a stale/leftover test artifact instead, by removing it
+   *  (`flair keys prune`, flair#734) — a transient or missing-key finding is
+   *  surfaced but not counted, matching how doctor already treats "could not
+   *  verify agent registration" elsewhere (Client integration section) — no
+   *  --fix action exists for either non-issue case. */
   isIssue: boolean;
 }
 
@@ -485,7 +493,11 @@ export function describeAgentGateFinding(agentId: string, state: AgentGateState,
       return {
         icon: "error",
         message: `agent '${agentId}' has a local key but is NOT registered on this Flair instance`,
-        fixHint: `flair agent add ${agentId}`,
+        // Two ways out, both actionable — register it if it should exist, or
+        // (flair#734) clean it up if it's a stale/leftover key. `flair keys
+        // prune` never touches a key that IS registered, so it's always a
+        // safe suggestion here even when the right fix is actually `agent add`.
+        fixHint: `flair agent add ${agentId} (if it should be registered) — or flair keys prune (if it's a stale/leftover key)`,
         isIssue: true,
       };
     case "unreachable":
@@ -495,4 +507,96 @@ export function describeAgentGateFinding(agentId: string, state: AgentGateState,
         isIssue: false,
       };
   }
+}
+
+// ── check 6: `flair keys prune` classification (flair#734) ─────────────────
+//
+// Follow-up to #731's doctor agent-iteration, which made previously-invisible
+// stale keys visible (each renders as a "not registered" gate finding, check
+// 5 above) but shipped no command to act on it — every doctor run just
+// re-reported the same noise. `flair keys prune` (src/cli.ts) walks the key
+// dir and moves anything it can positively classify as prunable into
+// `<keysDir>/.pruned/<date>/` — never deletes. The network-dependent half
+// (is this agentId actually registered?) reuses checkAgentRegistered
+// (src/cli.ts), the exact same signed GET /Agent/:id check 5's gate uses.
+// This module only owns the PURE decision — given a file's seed-validity and
+// (if checked) registration state, what class is it and why — plus two
+// path/naming helpers pure enough to live here (no crypto, no network).
+
+/** Name of the archive subdirectory prune moves prunable files into —
+ *  `<keysDir>/.pruned/<date>/`. Also the one directory name the scanner
+ *  itself must skip when walking the key dir (never re-classify prune's own
+ *  archive as a candidate). */
+export const PRUNED_DIR_NAME = ".pruned";
+
+/** `YYYY-MM-DD`, UTC — the `<date>` component of the archive path. UTC (not
+ *  local time) so a single prune run always lands in exactly one date
+ *  bucket regardless of the host's timezone. */
+export function pruneDateStamp(now: Date = new Date()): string {
+  return now.toISOString().slice(0, 10);
+}
+
+/**
+ * Pick a collision-free destination filename for a move into an archive
+ * directory that may already hold a file of the same name (e.g. two prune
+ * runs on the same UTC day). Preserves the original name whenever possible;
+ * on collision appends `.2`, `.3`, ... until free. Pure — the caller supplies
+ * the set of names already present (or about to be present, within the same
+ * run) at the destination; no fs access happens here.
+ */
+export function resolveCollisionSafeName(existingNames: Iterable<string>, filename: string): string {
+  const existing = existingNames instanceof Set ? existingNames : new Set(existingNames);
+  if (!existing.has(filename)) return filename;
+  let n = 2;
+  while (existing.has(`${filename}.${n}`)) n++;
+  return `${filename}.${n}`;
+}
+
+export type KeyPruneClass = "keep" | "stale" | "invalid" | "ignored";
+
+export interface KeyPruneDecision {
+  class: KeyPruneClass;
+  /** Human-readable reason — rendered next to the filename in prune's report. */
+  reason: string;
+}
+
+/**
+ * Classify one `.key` file given whether its seed parsed (`seedValid`) and,
+ * if it did, the registration-gate result checkAgentRegistered (src/cli.ts)
+ * returned for it — the SAME check doctor's "not registered" finding above
+ * is built from. Pure — no fs/crypto/network; the caller (classifyKeysDir,
+ * src/cli.ts) does the actual file read, seed parse, and signed registration
+ * check, and only calls this to decide what the result means.
+ *
+ * `registration` is ignored (pass null) when `seedValid` is false — an
+ * unparseable seed can't be signed with, so it was never checked against the
+ * instance, regardless of what agentId its filename implies.
+ *
+ * Deliberately has no case for "unreachable": classifyKeysDir aborts the
+ * WHOLE run before classifying anything once the instance is confirmed
+ * unreachable (never classify offline) — this function is only ever called
+ * once that's already been ruled out.
+ */
+export function classifyKeyFile(
+  agentId: string,
+  seedValid: boolean,
+  registration: { state: PruneRegistrationState; detail?: string } | null,
+  baseUrl: string,
+): KeyPruneDecision {
+  if (!seedValid) {
+    return { class: "invalid", reason: "not a parseable Ed25519 private key seed" };
+  }
+  if (registration?.state === "registered") {
+    return { class: "keep", reason: `agent '${agentId}' is registered on ${baseUrl} — never pruned` };
+  }
+  // "not-registered", "no-key", or (defensively) no registration result at
+  // all — every one of those means we could not confirm this agent is
+  // registered, so it's prunable. "no-key" is not expected in practice here
+  // (the file we just parsed a valid seed FROM is itself the key
+  // checkAgentRegistered would sign with), but is handled the same way
+  // rather than left as an unclassified gap.
+  return {
+    class: "stale",
+    reason: `agent '${agentId}' is not registered on ${baseUrl}${registration?.detail ? ` (${registration.detail})` : ""}`,
+  };
 }

--- a/test/unit/doctor-agent-iteration.test.ts
+++ b/test/unit/doctor-agent-iteration.test.ts
@@ -73,12 +73,17 @@ describe("describeAgentGateFinding", () => {
     expect(f!.message).toContain("no local key for 'ci-bot'");
   });
 
-  test("not-registered → error finding, IS an issue, carries the `flair agent add` fix hint", () => {
+  // flair#734: the fix hint now points at BOTH remedies — register it
+  // (`flair agent add`) if it should exist, or clean it up (`flair keys
+  // prune`) if it's a stale/leftover key. `.toContain` rather than an exact
+  // `.toBe` match so the wording can evolve without re-breaking this test.
+  test("not-registered → error finding, IS an issue, carries fix hints for both `flair agent add` and `flair keys prune` (flair#734)", () => {
     const f = describeAgentGateFinding("stray", "not-registered");
     expect(f).not.toBeNull();
     expect(f!.icon).toBe("error");
     expect(f!.isIssue).toBe(true);
-    expect(f!.fixHint).toBe("flair agent add stray");
+    expect(f!.fixHint).toContain("flair agent add stray");
+    expect(f!.fixHint).toContain("flair keys prune");
     expect(f!.message).toContain("stray");
     expect(f!.message).toContain("NOT registered");
   });

--- a/test/unit/doctor-client.test.ts
+++ b/test/unit/doctor-client.test.ts
@@ -11,6 +11,10 @@ import {
   fixSessionStartHook,
   CLAUDE_MD_BOOTSTRAP_MARKER,
   SESSION_START_HOOK_MARKER,
+  classifyKeyFile,
+  resolveCollisionSafeName,
+  pruneDateStamp,
+  PRUNED_DIR_NAME,
 } from "../../src/doctor-client.ts";
 
 /**
@@ -341,5 +345,99 @@ describe("fixSessionStartHook", () => {
     fixSessionStartHook(isoHome, "me");
     const res = checkSessionStartHook(isoHome);
     expect(res.present).toBe(true);
+  });
+});
+
+/**
+ * flair#734 — pure decision logic behind `flair keys prune`. No fs, no
+ * network, no crypto: the actual file reads, seed parsing, and signed
+ * registration checks live in src/cli.ts's classifyKeysDir (see
+ * test/unit/keys-prune.test.ts for those, mirroring how checkAgentRegistered
+ * is unit-tested with a mocked fetch rather than a real Harper).
+ */
+describe("classifyKeyFile", () => {
+  const BASE_URL = "http://127.0.0.1:19926";
+
+  it("invalid seed → class 'invalid', regardless of any registration result", () => {
+    const d = classifyKeyFile("stray", false, null, BASE_URL);
+    expect(d.class).toBe("invalid");
+    expect(d.reason).toContain("not a parseable Ed25519");
+  });
+
+  it("valid seed + registered → class 'keep'", () => {
+    const d = classifyKeyFile("local", true, { state: "registered" }, BASE_URL);
+    expect(d.class).toBe("keep");
+    expect(d.reason).toContain("local");
+    expect(d.reason).toContain(BASE_URL);
+  });
+
+  it("valid seed + not-registered → class 'stale', reason names the agent and instance", () => {
+    const d = classifyKeyFile("stray", true, { state: "not-registered" }, BASE_URL);
+    expect(d.class).toBe("stale");
+    expect(d.reason).toContain("stray");
+    expect(d.reason).toContain(BASE_URL);
+  });
+
+  it("valid seed + not-registered carries the detail string when given", () => {
+    const d = classifyKeyFile("stray", true, { state: "not-registered", detail: "HTTP 401 unknown_agent" }, BASE_URL);
+    expect(d.reason).toContain("HTTP 401 unknown_agent");
+  });
+
+  it("valid seed + no-key (defensive edge case) still classifies as 'stale', not a crash", () => {
+    const d = classifyKeyFile("stray", true, { state: "no-key" }, BASE_URL);
+    expect(d.class).toBe("stale");
+  });
+
+  it("valid seed + null registration (defensive edge case) still classifies as 'stale'", () => {
+    const d = classifyKeyFile("stray", true, null, BASE_URL);
+    expect(d.class).toBe("stale");
+  });
+
+  it("a registered agent's key is NEVER classified as prunable", () => {
+    const d = classifyKeyFile("local", true, { state: "registered" }, BASE_URL);
+    expect(d.class).not.toBe("stale");
+    expect(d.class).not.toBe("invalid");
+  });
+});
+
+describe("pruneDateStamp", () => {
+  it("formats as YYYY-MM-DD in UTC", () => {
+    const d = new Date("2026-07-18T23:45:00.000Z");
+    expect(pruneDateStamp(d)).toBe("2026-07-18");
+  });
+
+  it("uses UTC, not local time — a date that would roll over in a negative-offset zone stays UTC's day", () => {
+    // 2026-01-01T00:30:00Z is still Dec 31 in e.g. US Pacific, but the stamp
+    // must be the UTC day so prune's archive bucketing is host-timezone-independent.
+    const d = new Date("2026-01-01T00:30:00.000Z");
+    expect(pruneDateStamp(d)).toBe("2026-01-01");
+  });
+
+  it("defaults to now() when no date is given", () => {
+    const stamp = pruneDateStamp();
+    expect(stamp).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+  });
+});
+
+describe("resolveCollisionSafeName", () => {
+  it("returns the original filename when nothing exists yet", () => {
+    expect(resolveCollisionSafeName([], "stray.key")).toBe("stray.key");
+    expect(resolveCollisionSafeName(new Set(), "stray.key")).toBe("stray.key");
+  });
+
+  it("appends .2 on a single collision", () => {
+    expect(resolveCollisionSafeName(["stray.key"], "stray.key")).toBe("stray.key.2");
+  });
+
+  it("keeps incrementing past existing numbered collisions", () => {
+    expect(resolveCollisionSafeName(["stray.key", "stray.key.2", "stray.key.3"], "stray.key")).toBe("stray.key.4");
+  });
+
+  it("is unaffected by unrelated filenames in the existing set", () => {
+    expect(resolveCollisionSafeName(["other.key", "another.key"], "stray.key")).toBe("stray.key");
+  });
+
+  it("PRUNED_DIR_NAME is the literal '.pruned' the scanner must skip", () => {
+    expect(PRUNED_DIR_NAME).toBe(".pruned");
   });
 });

--- a/test/unit/keys-prune.test.ts
+++ b/test/unit/keys-prune.test.ts
@@ -1,0 +1,328 @@
+/**
+ * keys-prune.test.ts — Unit tests for `flair keys prune` (flair#734).
+ *
+ * Follow-up to #731's doctor agent-iteration, which made stale/unregistered
+ * keys in ~/.flair/keys visible (each renders as a "not registered" gate
+ * finding — see test/unit/doctor-agent-iteration.test.ts) but shipped no
+ * command to act on it. `flair keys prune` classifies every file in the key
+ * dir and, with --apply, MOVES (never deletes) anything prunable into
+ * <keysDir>/.pruned/<date>/.
+ *
+ * classifyKeysDir/applyKeyPrune (src/cli.ts) are the exported, directly
+ * testable orchestration — same pattern as checkAgentRegistered/
+ * probeFlairReachable (test/unit/doctor-client-network.test.ts): mock
+ * globalThis.fetch, write REAL Ed25519 keys via tweetnacl to a temp dir so
+ * the signing path runs for real, only the network response is mocked.
+ * classifyKeyFile/resolveCollisionSafeName/pruneDateStamp's own pure-decision
+ * tests live in test/unit/doctor-client.test.ts.
+ *
+ * The two acceptance bullets that need a REAL process exit code (fresh/empty
+ * dir exits 0; unreachable instance hard-aborts with a non-zero exit and
+ * moves nothing) are covered here by spawning the CLI as a subprocess —
+ * mirrors test/unit/cli-startup-errors.test.ts's technique, since an
+ * in-process call can't observe process.exit().
+ */
+
+import { describe, it, test, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, mkdirSync, rmSync, existsSync, readFileSync, writeFileSync, readdirSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import nacl from "tweetnacl";
+
+import { classifyKeysDir, applyKeyPrune, program } from "../../src/cli.ts";
+import { PRUNED_DIR_NAME } from "../../src/doctor-client.ts";
+
+const BASE_URL = "http://127.0.0.1:19926";
+const CLI_SOURCE = join(__dirname, "..", "..", "src", "cli.ts");
+const realFetch = globalThis.fetch;
+
+let keysDir: string;
+
+beforeEach(() => {
+  keysDir = mkdtempSync(join(tmpdir(), "flair-keys-prune-"));
+});
+
+afterEach(() => {
+  rmSync(keysDir, { recursive: true, force: true });
+  globalThis.fetch = realFetch;
+});
+
+// ─── helpers ────────────────────────────────────────────────────────────────
+
+/** Write a real, raw 32-byte Ed25519 seed at <keysDir>/<agentId>.key — the
+ *  same format `flair agent add` writes (src/cli.ts, agent add action). */
+function writeSeedKey(dir: string, agentId: string): void {
+  const kp = nacl.sign.keyPair();
+  writeFileSync(join(dir, `${agentId}.key`), Buffer.from(kp.secretKey.slice(0, 32)));
+}
+
+/** Mock fetch for checkAgentRegistered's signed GET /Agent/:id — 200 for any
+ *  agent id in `registeredIds`, the server's real "unknown_agent" 401 shape
+ *  otherwise (flair#602 — that's the live not-registered signal, not 404). */
+function mockRegistrationFetch(registeredIds: Set<string>): typeof fetch {
+  return (async (input: any) => {
+    const url = typeof input === "string" ? input : input.url;
+    const id = url.match(/\/Agent\/([^/]+)$/)?.[1];
+    if (id && registeredIds.has(id)) {
+      return new Response(JSON.stringify({ id }), { status: 200, headers: { "Content-Type": "application/json" } });
+    }
+    return new Response(JSON.stringify({ error: "unknown_agent" }), { status: 401, headers: { "Content-Type": "application/json" } });
+  }) as typeof fetch;
+}
+
+// ─── classifyKeysDir ────────────────────────────────────────────────────────
+
+describe("classifyKeysDir — fresh/empty key dir (acceptance: finds nothing)", () => {
+  it("a keysDir that does not exist on disk → not aborted, zero entries, no network call", async () => {
+    let called = false;
+    globalThis.fetch = (async () => { called = true; return new Response("{}", { status: 200 }); }) as typeof fetch;
+    const nonExistent = join(keysDir, "does-not-exist");
+    const res = await classifyKeysDir(nonExistent, BASE_URL);
+    expect(res.aborted).toBe(false);
+    expect(res.entries).toEqual([]);
+    expect(called).toBe(false);
+  });
+
+  it("an existing but empty keysDir → not aborted, zero entries, no network call", async () => {
+    let called = false;
+    globalThis.fetch = (async () => { called = true; return new Response("{}", { status: 200 }); }) as typeof fetch;
+    const res = await classifyKeysDir(keysDir, BASE_URL);
+    expect(res.aborted).toBe(false);
+    expect(res.entries).toEqual([]);
+    expect(called).toBe(false);
+  });
+
+  it("a keysDir containing only ignored files (README, no .key files) → zero candidates, no network call", async () => {
+    let called = false;
+    globalThis.fetch = (async () => { called = true; return new Response("{}", { status: 200 }); }) as typeof fetch;
+    writeFileSync(join(keysDir, "README.md"), "not a key\n");
+    mkdirSync(join(keysDir, "some-subdir"));
+    const res = await classifyKeysDir(keysDir, BASE_URL);
+    expect(res.aborted).toBe(false);
+    expect(res.entries.every((e) => e.class === "ignored")).toBe(true);
+    expect(called).toBe(false);
+  });
+
+  it("skips its own .pruned archive directory rather than treating it as a candidate", async () => {
+    mkdirSync(join(keysDir, PRUNED_DIR_NAME, "2026-01-01"), { recursive: true });
+    const res = await classifyKeysDir(keysDir, BASE_URL);
+    expect(res.entries).toHaveLength(1);
+    expect(res.entries[0].class).toBe("ignored");
+    expect(res.entries[0].name).toBe(PRUNED_DIR_NAME);
+  });
+});
+
+describe("classifyKeysDir — N unregistered + M registered", () => {
+  it("dry-run classification lists exactly N stale and M keep, with reasons, without touching disk", async () => {
+    writeSeedKey(keysDir, "agent-stale-1");
+    writeSeedKey(keysDir, "agent-stale-2");
+    writeSeedKey(keysDir, "agent-registered");
+    globalThis.fetch = mockRegistrationFetch(new Set(["agent-registered"]));
+
+    const res = await classifyKeysDir(keysDir, BASE_URL);
+    expect(res.aborted).toBe(false);
+
+    const stale = res.entries.filter((e) => e.class === "stale");
+    const keep = res.entries.filter((e) => e.class === "keep");
+    expect(stale.map((e) => e.agentId).sort()).toEqual(["agent-stale-1", "agent-stale-2"]);
+    expect(keep.map((e) => e.agentId)).toEqual(["agent-registered"]);
+    for (const e of stale) expect(e.reason.length).toBeGreaterThan(0);
+
+    // Dry classification never moves anything.
+    expect(existsSync(join(keysDir, "agent-stale-1.key"))).toBe(true);
+    expect(existsSync(join(keysDir, "agent-stale-2.key"))).toBe(true);
+    expect(existsSync(join(keysDir, "agent-registered.key"))).toBe(true);
+    expect(existsSync(join(keysDir, PRUNED_DIR_NAME))).toBe(false);
+  });
+});
+
+describe("classifyKeysDir — invalid files classified distinctly from unregistered", () => {
+  it("an unparseable .key file → class 'invalid', and never triggers a network call", async () => {
+    writeFileSync(join(keysDir, "garbage.key"), "not-a-real-ed25519-seed-at-all");
+    let called = false;
+    globalThis.fetch = (async () => { called = true; return new Response("{}", { status: 200 }); }) as typeof fetch;
+
+    const res = await classifyKeysDir(keysDir, BASE_URL);
+    expect(res.aborted).toBe(false);
+    expect(res.entries).toHaveLength(1);
+    expect(res.entries[0].class).toBe("invalid");
+    expect(res.entries[0].name).toBe("garbage.key");
+    expect(called).toBe(false);
+  });
+
+  it("invalid and stale are both prunable but reported as distinct classes side by side", async () => {
+    writeFileSync(join(keysDir, "garbage.key"), "not-a-real-ed25519-seed-at-all");
+    writeSeedKey(keysDir, "agent-stale");
+    globalThis.fetch = mockRegistrationFetch(new Set());
+
+    const res = await classifyKeysDir(keysDir, BASE_URL);
+    const byClass = Object.fromEntries(res.entries.map((e) => [e.name, e.class]));
+    expect(byClass["garbage.key"]).toBe("invalid");
+    expect(byClass["agent-stale.key"]).toBe("stale");
+  });
+});
+
+describe("classifyKeysDir — unreachable instance aborts the whole run", () => {
+  it("a network failure on the registration check aborts before classifying anything, nothing moved", async () => {
+    writeSeedKey(keysDir, "agent-a");
+    writeSeedKey(keysDir, "agent-b");
+    globalThis.fetch = (async () => { throw new Error("ECONNREFUSED"); }) as typeof fetch;
+
+    const res = await classifyKeysDir(keysDir, BASE_URL);
+    expect(res.aborted).toBe(true);
+    expect(res.entries).toEqual([]);
+    expect(res.abortReason).toBeDefined();
+    expect(res.abortReason).toContain(BASE_URL);
+
+    // Nothing was ever touched.
+    expect(existsSync(join(keysDir, "agent-a.key"))).toBe(true);
+    expect(existsSync(join(keysDir, "agent-b.key"))).toBe(true);
+    expect(existsSync(join(keysDir, PRUNED_DIR_NAME))).toBe(false);
+  });
+});
+
+// ─── applyKeyPrune ──────────────────────────────────────────────────────────
+
+describe("applyKeyPrune — --apply moves prunable keys, leaves registered ones untouched", () => {
+  it("moves exactly the stale + invalid entries into .pruned/<date>/, a registered agent's key is NEVER moved", async () => {
+    writeSeedKey(keysDir, "agent-stale-1");
+    writeSeedKey(keysDir, "agent-stale-2");
+    writeSeedKey(keysDir, "agent-registered");
+    writeFileSync(join(keysDir, "garbage.key"), "not-a-real-ed25519-seed-at-all");
+    globalThis.fetch = mockRegistrationFetch(new Set(["agent-registered"]));
+
+    const classified = await classifyKeysDir(keysDir, BASE_URL);
+    expect(classified.aborted).toBe(false);
+
+    const moved = applyKeyPrune(keysDir, classified.entries, "2026-07-18");
+    expect(moved).toHaveLength(3);
+    expect(moved.map((m) => m.name).sort()).toEqual(["agent-stale-1.key", "agent-stale-2.key", "garbage.key"]);
+
+    // Prunable files are gone from the original location...
+    expect(existsSync(join(keysDir, "agent-stale-1.key"))).toBe(false);
+    expect(existsSync(join(keysDir, "agent-stale-2.key"))).toBe(false);
+    expect(existsSync(join(keysDir, "garbage.key"))).toBe(false);
+    // ...and present in the archive.
+    const archiveDir = join(keysDir, PRUNED_DIR_NAME, "2026-07-18");
+    expect(existsSync(join(archiveDir, "agent-stale-1.key"))).toBe(true);
+    expect(existsSync(join(archiveDir, "agent-stale-2.key"))).toBe(true);
+    expect(existsSync(join(archiveDir, "garbage.key"))).toBe(true);
+
+    // The registered agent's key is untouched, at its original path.
+    expect(existsSync(join(keysDir, "agent-registered.key"))).toBe(true);
+    expect(existsSync(join(archiveDir, "agent-registered.key"))).toBe(false);
+  });
+
+  it("moving nothing (all keys registered) is a no-op — returns an empty list, no .pruned dir created", async () => {
+    writeSeedKey(keysDir, "agent-registered");
+    globalThis.fetch = mockRegistrationFetch(new Set(["agent-registered"]));
+    const classified = await classifyKeysDir(keysDir, BASE_URL);
+    const moved = applyKeyPrune(keysDir, classified.entries, "2026-07-18");
+    expect(moved).toEqual([]);
+    expect(existsSync(join(keysDir, PRUNED_DIR_NAME))).toBe(false);
+    expect(existsSync(join(keysDir, "agent-registered.key"))).toBe(true);
+  });
+
+  it("a second prune on a same-named leftover the same day gets a numeric-suffixed archive name, never overwrites", async () => {
+    writeSeedKey(keysDir, "agent-stray");
+    globalThis.fetch = mockRegistrationFetch(new Set());
+    const first = await classifyKeysDir(keysDir, BASE_URL);
+    const firstMoved = applyKeyPrune(keysDir, first.entries, "2026-07-18");
+    expect(firstMoved).toHaveLength(1);
+
+    // A fresh key happens to reuse the same agent id / filename (e.g. a
+    // second run after `flair agent add agent-stray` was retried).
+    writeSeedKey(keysDir, "agent-stray");
+    const second = await classifyKeysDir(keysDir, BASE_URL);
+    const secondMoved = applyKeyPrune(keysDir, second.entries, "2026-07-18");
+    expect(secondMoved).toHaveLength(1);
+    expect(secondMoved[0].movedTo).toContain("agent-stray.key.2");
+
+    const archiveDir = join(keysDir, PRUNED_DIR_NAME, "2026-07-18");
+    expect(readdirSync(archiveDir).sort()).toEqual(["agent-stray.key", "agent-stray.key.2"]);
+  });
+});
+
+// ─── CLI wiring ─────────────────────────────────────────────────────────────
+
+describe("`flair keys prune` command wiring", () => {
+  function findCommand(name: string) {
+    return program.commands.find((c) => c.name() === name);
+  }
+  function findSubcommand(parent: string, child: string) {
+    return findCommand(parent)?.commands.find((c) => c.name() === child);
+  }
+  function hasOption(cmd: any, flag: string): boolean {
+    return cmd.options.some((o: any) => o.flags.includes(flag));
+  }
+
+  it("registers `flair keys prune` with --apply, --keys-dir, --instance, --port", () => {
+    const prune = findSubcommand("keys", "prune");
+    expect(prune).toBeDefined();
+    expect(hasOption(prune, "--apply")).toBe(true);
+    expect(hasOption(prune, "--keys-dir")).toBe(true);
+    expect(hasOption(prune, "--instance")).toBe(true);
+    expect(hasOption(prune, "--port")).toBe(true);
+  });
+
+  it("is dry-run by default — --apply is not a required option", () => {
+    const prune = findSubcommand("keys", "prune");
+    const applyOpt = prune!.options.find((o: any) => o.flags.includes("--apply"));
+    expect(applyOpt?.required).toBeFalsy();
+  });
+});
+
+// ─── real subprocess acceptance checks (need an observable process.exit) ───
+
+interface RunResult { exitCode: number | null; stdout: string; stderr: string }
+
+function runCLI(args: string[], env: Record<string, string> = {}): RunResult {
+  const r = spawnSync("bun", [CLI_SOURCE, ...args], {
+    env: { ...process.env, ...env },
+    timeout: 10_000,
+    encoding: "utf8",
+  });
+  return { exitCode: r.status, stdout: r.stdout ?? "", stderr: r.stderr ?? "" };
+}
+
+describe("flair keys prune — subprocess acceptance checks", () => {
+  let isoHome: string;
+  let subKeysDir: string;
+
+  beforeEach(() => {
+    isoHome = mkdtempSync(join(tmpdir(), "flair-keys-prune-home-"));
+    subKeysDir = mkdtempSync(join(tmpdir(), "flair-keys-prune-cli-"));
+  });
+
+  afterEach(() => {
+    rmSync(isoHome, { recursive: true, force: true });
+    rmSync(subKeysDir, { recursive: true, force: true });
+  });
+
+  test("fresh/empty key dir: exits 0 without needing a reachable instance", () => {
+    // Deliberately point --instance at a bogus, unroutable-fast address —
+    // if this exits 0 it proves the empty-dir path never even tries to
+    // reach it (there are zero .key files to check registration for).
+    const r = runCLI(
+      ["keys", "prune", "--keys-dir", subKeysDir, "--instance", "http://127.0.0.1:1"],
+      { HOME: isoHome },
+    );
+    expect(r.exitCode).toBe(0);
+  });
+
+  test("unreachable instance: hard-aborts with a non-zero exit and moves nothing", () => {
+    const kp = nacl.sign.keyPair();
+    writeFileSync(join(subKeysDir, "agent-x.key"), Buffer.from(kp.secretKey.slice(0, 32)));
+
+    // Port 1 is a privileged port nothing listens on locally — a fast,
+    // reliable ECONNREFUSED without depending on any real Flair instance.
+    const r = runCLI(
+      ["keys", "prune", "--keys-dir", subKeysDir, "--instance", "http://127.0.0.1:1"],
+      { HOME: isoHome },
+    );
+    expect(r.exitCode).not.toBe(0);
+    expect(existsSync(join(subKeysDir, "agent-x.key"))).toBe(true);
+    expect(existsSync(join(subKeysDir, PRUNED_DIR_NAME))).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Follow-up to #731's doctor agent-iteration, which made previously-invisible stale keys visible (each renders as a "not registered" gate finding) but shipped no command to act on it — every `flair doctor` run just re-reported the same noise. `agent remove <id>` already handles the registered case (agent + key together); `flair keys prune` fills the gap for keys with no agent behind them at all.

- **`flair keys prune`** classifies every file in the key dir (`FLAIR_KEY_DIR` / `~/.flair/keys` / `--keys-dir`) into `keep` (registered — never touched, under any flag), `stale` (valid seed, agent not registered), `invalid` (unparseable seed — its own distinct class), or `ignored` (non-`.key` files, directories, its own `.pruned` archive).
- **Dry-run by default**; `--apply` actually moves.
- **Never deletes** — prunable files move to `<keysDir>/.pruned/<YYYY-MM-DD>/` (UTC), preserving filename; same-day collisions get a numeric suffix (`agentId.key.2`) rather than overwriting.
- **Conservative on reachability**: registration is checked only against the configured default instance (`--instance <url>` overrides); if unreachable, the whole run aborts immediately with a non-zero exit — nothing classified or moved.
- Reuses `checkAgentRegistered` (same signed `GET /Agent/:id` doctor's registration gate uses) — not a reimplementation.
- **Doctor integration**: the "not registered" gate finding's fix hint now points at both `flair agent add <id>` (if it should be registered) and `flair keys prune` (if it's stale/leftover). Doctor stays read-only.

## Acceptance evidence

- Fresh/empty key dir: exits 0, no network call made (verified both in-process and via a real subprocess run).
- N unregistered + M registered: dry-run lists exactly N with reasons, moves nothing; `--apply` moves N into `.pruned/<date>/`, leaves M untouched — covered directly and via a live local smoke test (stub Flair instance).
- Invalid/unparseable files are classified as their own `invalid` class, distinct from `stale`, and never trigger a network call.
- A registered agent's key is never moved under any flag (explicit assertion + smoke test).
- Unreachable instance hard-aborts with a non-zero exit and moves nothing — verified via mocked-fetch unit test and a real subprocess run against a closed port.

## Test plan

- [x] `bun test test/unit/` — 2443 pass, 0 fail (142 files)
- [x] `for f in test/unit-isolated/*.test.ts; do bun test "$f" || exit 1; done` — all green
- [x] `bunx tsc --noEmit -p tsconfig.cli.json` and `-p tsconfig.check.src.json` — clean
- [x] Manual smoke test against a local stub Flair instance (dry-run + `--apply`, registered/stale/invalid mix) — behaved exactly as classified
- [ ] `test/integration/` — has a pre-existing env failure on this host, unrelated to this change; skipped locally, CI is the integration gate

New tests: `test/unit/keys-prune.test.ts` (classification, move, CLI wiring, two subprocess acceptance checks), plus `classifyKeyFile`/`resolveCollisionSafeName`/`pruneDateStamp` pure-logic tests added to `test/unit/doctor-client.test.ts`, and an updated fix-hint assertion in `test/unit/doctor-agent-iteration.test.ts`.

Closes #734