### PR TITLE
fix(test): deterministic deploy replication-retry output capture — kill the #699 CI flake

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,16 @@ Found the hard way during CI-lane validation on a shared host: `flair init`/`sta
 
 Closes #693.
 
+### 🐛 Deterministic deploy child-process output capture — kills the #699 CI flake
+
+`deploy.test.ts`'s "--deploy-retries 0 disables retry" (and the rest of the replication-flake suite) intermittently failed under loaded CI runners with the generic `"harper deploy exited with code 1"` instead of the parsed `/peer replication failed after 1 attempt/` signature — a real output-capture race in production code, not a test-only artifact.
+
+- **Root cause** (`src/deploy.ts`'s `spawnHarperCaptured`): the promise resolved on the child process's `"exit"` event, which Node's own docs warn can fire while the piped stdout/stderr streams are still delivering buffered `data` events. Under scheduler pressure, `exit` could win the race against the final stderr chunk — often exactly the line carrying the replication-failure signature, since it's written immediately before `process.exit()` — so `REPLICATION_FAILURE_RE` silently missed a match it should have made, and `runHarperDeploy` fell through to the generic exit-code error. This affects real `harper deploy` invocations too, not just the test's scripted fake binary.
+- **Fix**: resolve on `"close"` instead — the event Node guarantees fires only after all stdio streams have ended, i.e. every `data` chunk has already been delivered to the listeners before the promise resolves. No retry, no sleep, no skip — the deploy code now waits on the correct completion signal.
+- **Verify**: `deploy.test.ts`'s "disables retry" test looped 50x clean (0 failures), then 50x again under genuine concurrent load (8 CPU-bound hogs at ~97% each on a 10-core box, plus 6-way concurrent `bun test` invocations racing for CPU/pipe I/O) — 0 failures. Full `deploy.test.ts` looped 30x in isolation — 0 failures. Full `test/unit/` suite green (2614 pass). The exact race window is narrow enough that it could not be forced locally even under heavy synthetic load or a standalone spawn-concurrency probe (consistent with the issue's own report that all 37 deploy tests passed locally and it only manifested on loaded CI runners) — the fix is a structural guarantee from Node's documented `close`-vs-`exit` API contract, not a probabilistic mitigation.
+
+Closes #699.
+
 ### ✨ Ed25519 agent key as the universal CLI auth floor (flair#747)
 
 Generalizes flair#741/#742's upgrade-only agent-key fallback into ONE shared resolver adopted across every auth-requiring CLI surface. Before this, CLI auth resolved through per-command admin-pass chains that mostly ignored `~/.flair/keys/<agentId>.key` — the credential a headless/agent machine actually has — unless an agentId was already known some other way. That mismatch is exactly what produced flair#741's false "instance state UNKNOWN" terror on `flair upgrade`; this closes the same gap everywhere else it existed.

--- a/src/deploy.ts
+++ b/src/deploy.ts
@@ -323,6 +323,21 @@ interface HarperSpawnResult {
 // the previous stdio:"inherit" passthrough, which gave no way to inspect
 // harper's output. stdin stays "inherit" — harper's deploy never reads
 // from it, so there's nothing to tee there.
+//
+// Resolves on "close", NOT "exit" (flair#699). Node's child_process fires
+// "exit" as soon as the process terminates, but the piped stdout/stderr
+// streams can still have buffered `data` events in flight at that instant —
+// "exit" makes no promise that every chunk already written by the child has
+// been delivered to our listeners yet. "close" is the event Node guarantees
+// fires only after all stdio streams have ended, i.e. every `data` chunk has
+// already been pushed into `chunks`. Resolving on "exit" was a real
+// output-capture race, not just a test artifact: under scheduler pressure
+// (e.g. loaded CI runners) the process could exit and this promise could
+// resolve before the final stderr chunk — often exactly the line carrying
+// the replication-failure signature, since callers naturally console.error
+// their last message immediately before process.exit() — had been received,
+// so REPLICATION_FAILURE_RE silently missed a match it should have made and
+// runHarperDeploy fell through to the generic "exited with code N" error.
 function spawnHarperCaptured(
   bin: string,
   args: string[],
@@ -345,7 +360,7 @@ function spawnHarperCaptured(
       chunks.push(d.toString("utf8"));
     });
     p.on("error", rejectP);
-    p.on("exit", (code) => resolveP({ code, output: chunks.join("") }));
+    p.on("close", (code) => resolveP({ code, output: chunks.join("") }));
   });
 }
 


### PR DESCRIPTION
## Root cause

Production output-capture race in `src/deploy.ts`'s `spawnHarperCaptured` (`src/deploy.ts:326-363`). The promise resolved on the child process's `"exit"` event:

```ts
p.on("exit", (code) => resolveP({ code, output: chunks.join("") }));
```

Node's own child_process docs warn that `"exit"` can fire while the piped stdout/stderr streams are still delivering buffered `"data"` events — it makes no guarantee that every chunk the child already wrote has reached our listeners yet. Under CI runner scheduler pressure (the node-26 lane especially), `"exit"` could win the race against the final stderr chunk — in the flaky test's fake harper binary, that's the exact line carrying the replication-failure signature, written via `console.error(...)` immediately before `process.exit(1)`. When that chunk hadn't landed in `chunks` yet, `REPLICATION_FAILURE_RE` had nothing to match against, and `runHarperDeploy` (`src/deploy.ts:413-421`) fell through to the generic `"harper deploy exited with code N"` error instead of the parsed `"peer replication failed after N attempt(s)"` message.

This is a **real production-code race**, not a test-harness artifact — it affects real `harper deploy` invocations the same way, since `spawnHarperCaptured` is the one code path both the test and real deploys go through.

## Fix

Resolve on `"close"` instead of `"exit"`:

```ts
p.on("close", (code) => resolveP({ code, output: chunks.join("") }));
```

`"close"` is the event Node guarantees fires only after all stdio streams have ended — i.e. every `"data"` chunk has already been delivered to the listeners before the promise resolves. This is a structural fix (an API-contract guarantee), not a probabilistic mitigation: no retry, no sleep, no skip, no bumped `--deploy-retries`. This matches the issue's own hypothesis almost verbatim.

## Classification

**Production code fix** (not test-harness-only), per the dispatch's own framing — the race lives in `deploy()`'s child-process output capture, which every real deploy also goes through.

## Verify

- `deploy.test.ts`'s "--deploy-retries 0 disables retry" test looped 50x clean — 0 failures.
- Same test looped 50x again under genuine concurrent load: 8 CPU-bound busy-loop hogs pinned at ~97-98% each on a 10-core machine, plus 6-way concurrent `bun test` invocations racing each other for CPU and pipe I/O — 0 failures.
- Full `deploy.test.ts` (all 41 tests in the file) looped 30x in isolation — 0 failures.
- Full `test/unit/` suite green: 2630 pass, 0 fail, across 150 files.
- Additionally verified the theoretical mechanism directly with a standalone spawn-concurrency probe (not committed) comparing `"exit"`- vs `"close"`-based capture across ~4000 combined trials at up to 80-way concurrent spawn oversubscription plus CPU load: the race window turned out to be extremely narrow locally on this machine/runtime (near-zero reproduction rate either way), consistent with the issue's own report that all 37 deploy tests passed locally and it only manifested on loaded CI runners. I could not force a live before/after reproduction of the exact flake locally — the confidence in the fix rests on Node's documented `"close"`-vs-`"exit"` API contract (a structural guarantee, not luck) plus the fact that it directly targets the mechanism the issue itself identified, not on having caught the race red-handed on this machine.

Closes #699.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>