### PR TITLE
feat(security): ops-socket permission posture — 0600 default / 0660+group opt-in with dir gate (flair#763)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 ## [Unreleased]
 
+### 🔒 Ops-API domain-socket permission posture — 0600 default / 0660+group opt-in with a directory gate (flair#763)
+
+Split from flair#670 (the network-bind slice shipped in #762); same local-admin-surface axis as #654 (`authorizeLocal` off). Ground-truthing a live macOS install reshaped the original "socket is 0666" framing: Harper sets no mode, so the socket lands at `0777 & ~umask` (0755 here) — real, but umask-luck — and `~/.flair` was already `0700`, making the *directory* the effective gate by accident. Harper exposes no socket-permission knob (`operationsApi.network.domainSocket` is a path string only; no `chmod` in `dist/server`), so flair sets the posture itself around the socket the start path creates.
+
+- **Primary gate = the socket's immediate parent directory, made policy.** Resolved from the configured socket path — never a hardcoded `~/.flair`, so a custom `--data-dir` install is gated at its own root. The directory gate is the load-bearing control: race-free (checked on every `connect(2)` traversal — no create→chmod window), umask-independent (explicit `chmod`), and cross-platform (VFS-level, unlike socket-file permission enforcement on `connect(2)` which varies across BSD lineage). The socket file mode is defense-in-depth within it.
+- **Posture, kept in lockstep both directions:**
+  - `FLAIR_SOCKET_GROUP` unset → parent dir `0700`, socket `0600` (owner-only — the 99% single-user case; strictly tighter than `0660`+`staff`, which on macOS is shared by every human account on the box).
+  - `FLAIR_SOCKET_GROUP` set → parent dir `0750` (owner+group traverse — else the group grant is unreachable behind the dir gate), socket `0660` + `chgrp` to that group.
+  - A later **unset returns** the dir to `0700` and the socket to `0600` — the two layers widen and tighten together.
+- **Fail-closed group handling.** The group name is regex-validated (`^[a-zA-Z_][a-zA-Z0-9._-]*$`) **before** existence resolution; an invalid **or** missing group is a hard error — never a silent fallback to `0600`. A `chgrp` that fails because the user isn't a member gives a clear "requires membership" message (distinct from "does not exist"), and a broad system group (`staff`/`wheel`/`users`/`admin`/…) emits a warning (not a block).
+- **Applied in `init` and every start readiness path.** `init` puts the directory gate in place **before** Harper spawns (closing the create→chmod window) and applies the socket mode once the socket appears; `flair start` and the internal restart/upgrade start path re-assert the posture on the freshly-created socket. The default-posture path is non-fatal defense-in-depth (warn — the dir gate is the primary control); a broken `FLAIR_SOCKET_GROUP` opt-in fails loud.
+- **`flair doctor` finding (report-only, no `--fix`).** Re-tightening a live socket needs a restart, so the remedy is `flair init`/restart, not an auto-fix. Implements the exact six-row detection matrix: dir `0700`+socket `0600` → clean; dir `0755`+socket `0600` → flag (root gate breached); dir `0700`+socket `0755` → flag (socket mode breached); both open → flag; dir `0750`+socket `0660` with `FLAIR_SOCKET_GROUP` set → clean (deliberate multi-user); dir `0750`+socket `0660` without the opt-in → flag (unintended group access).
+- New `test/unit/ops-socket-posture.test.ts`: the posture helper in both postures, lockstep both directions, group-name validation (valid/invalid/missing + not-a-member + broad-group), and all six doctor matrix rows — in-memory fs and mocked group resolution, no real socket or `~/.flair` touched.
+
+Closes #763. References #670 (parent — network bind shipped in #762) and #654 (lineage — same local-admin-surface axis).
+
 ### 🔒 Bind the Harper ops API to loopback + domain socket for single-host installs (flair#670)
 
 Defense-in-depth follow-up to flair#654 (K&S concurrence 2026-07-09): #654 closed the unauthenticated-loopback-admin hole by disabling `authorizeLocal`; this shrinks the *network* surface. The ops API (`:9925`-equivalent) bound all interfaces unconditionally — single-host installs don't need remote admin, so an accidentally-exposed port (misconfigured firewall, container networking) could be reached off-box even with #654's auth fix in place.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -18,10 +18,11 @@ import {
   lstatSync,
   realpathSync,
   unlinkSync,
+  chownSync,
 } from "node:fs";
 import { homedir, hostname, tmpdir } from "node:os";
 import { join, resolve, sep, dirname } from "node:path";
-import { spawn } from "node:child_process";
+import { spawn, execFileSync } from "node:child_process";
 import { createRequire } from "node:module";
 import { createHash, randomUUID, randomBytes } from "node:crypto";
 import { create as tarCreate, extract as tarExtract, list as tarList } from "tar";
@@ -494,6 +495,283 @@ export function detectOpsApiAllInterfacesBind(
     return { allInterfaces: false, boundHost: str.slice(0, lastColon).replace(/[[\]]/g, "") };
   }
   return { allInterfaces: true, boundHost: null };
+}
+
+// ─── Ops-socket permission posture (flair#763) ─────────────────────────────────
+//
+// The ops API domain socket (dataDir/operations-server) is protected by a
+// two-layer posture, with the socket's IMMEDIATE PARENT DIRECTORY as the
+// primary, load-bearing gate (resolved from the socket path — never a
+// hardcoded ~/.flair, so custom --data-dir installs get the same gate):
+//
+//   FLAIR_SOCKET_GROUP unset → parent dir 0700, socket 0600 (owner-only).
+//   FLAIR_SOCKET_GROUP set    → parent dir 0750 (owner+group traverse — else
+//                               the group grant is unreachable behind the dir
+//                               gate), socket 0660 + chgrp to that group.
+//
+// The two layers move in lockstep BOTH directions: a later UNSET returns the
+// dir to 0700 and the socket to 0600. The directory gate is race-free
+// (checked on every connect(2) traversal), umask-independent (explicit
+// chmod), and cross-platform (VFS-level, unlike socket-file permission
+// enforcement on connect(2) which varies across BSD lineage); the socket-file
+// mode is defense-in-depth within it. Split from #670 (network bind shipped
+// in #762); same local-admin-surface axis as #654 (authorizeLocal off).
+
+/** Group names allowed for FLAIR_SOCKET_GROUP — validated BEFORE existence
+ *  resolution (Sherlock #763): rejects path-traversal / whitespace / any
+ *  weird-but-"valid" name before it reaches getgrnam/chgrp. */
+export const SOCKET_GROUP_NAME_RE = /^[a-zA-Z_][a-zA-Z0-9._-]*$/;
+
+export function isValidSocketGroupName(name: string): boolean {
+  return SOCKET_GROUP_NAME_RE.test(name);
+}
+
+/** System groups broad enough that opting the ops socket into them silently
+ *  grants access to a wide set of accounts (macOS `staff` = every human user
+ *  on the box). Not a gate — a warning (Sherlock #763). */
+const BROAD_SYSTEM_GROUPS = new Set(["staff", "wheel", "users", "admin", "everyone", "adm"]);
+
+/** The posture (parent-dir + socket file modes) for a given FLAIR_SOCKET_GROUP
+ *  value. Pure — the single source of truth for the two lockstep states. */
+export function resolveSocketPosture(group: string | undefined | null): {
+  dirMode: number;
+  socketMode: number;
+  group: string | null;
+} {
+  const g = (group ?? "").trim();
+  if (g.length > 0) return { dirMode: 0o750, socketMode: 0o660, group: g };
+  return { dirMode: 0o700, socketMode: 0o600, group: null };
+}
+
+export interface OpsSocketPostureFs {
+  chmodSync(path: string, mode: number): void;
+  statSync(path: string): { mode: number; uid: number; gid: number };
+  existsSync(path: string): boolean;
+  chownSync(path: string, uid: number, gid: number): void;
+}
+
+const NODE_SOCKET_FS: OpsSocketPostureFs = {
+  chmodSync,
+  statSync: (p) => {
+    const s = statSync(p);
+    return { mode: s.mode, uid: s.uid, gid: s.gid };
+  },
+  existsSync,
+  chownSync,
+};
+
+/** Resolve a group NAME to its numeric gid, cross-platform, or null if the
+ *  group does not exist. Uses execFileSync (arg vector — no shell) and the
+ *  name is regex-validated by the caller before it gets here. */
+function resolveGroupGid(name: string): number | null {
+  try {
+    if (process.platform === "darwin") {
+      // dscl reads Directory Services (macOS groups don't live in /etc/group).
+      const out = execFileSync("dscl", [".", "-read", `/Groups/${name}`, "PrimaryGroupID"], {
+        encoding: "utf-8",
+        stdio: ["ignore", "pipe", "ignore"],
+      });
+      const m = out.match(/PrimaryGroupID:\s*(\d+)/);
+      return m ? Number(m[1]) : null;
+    }
+    // Linux / other POSIX: getent resolves NSS (files, LDAP, …).
+    const out = execFileSync("getent", ["group", name], {
+      encoding: "utf-8",
+      stdio: ["ignore", "pipe", "ignore"],
+    });
+    const parts = out.trim().split(":");
+    return parts.length >= 3 && parts[2] !== "" ? Number(parts[2]) : null;
+  } catch {
+    return null; // command failed / group not found → treated as missing
+  }
+}
+
+export interface ApplyOpsSocketPostureOptions {
+  socketPath: string;
+  group?: string | null;
+  fs?: OpsSocketPostureFs;
+  resolveGid?: (name: string) => number | null;
+}
+
+export interface OpsSocketPostureResult {
+  dirMode: number;
+  socketMode: number;
+  group: string | null;
+  gid: number | null;
+  dirApplied: boolean;
+  socketApplied: boolean; // false when the socket didn't exist yet (pre-boot)
+  broadGroup: boolean;
+}
+
+/**
+ * Apply the ops-socket permission posture (flair#763). Idempotent: safe to
+ * call before Harper spawns (dir gate only — socket not present yet) and again
+ * after the socket appears (socket mode + optional chgrp). fs and resolveGid
+ * are injectable for unit tests (temp dirs / mocked group resolution).
+ *
+ * Fail-closed: an invalid OR missing FLAIR_SOCKET_GROUP is a hard error — NEVER
+ * a silent fallback to 0600. The group name is regex-validated BEFORE
+ * existence resolution.
+ */
+export function applyOpsSocketPosture(opts: ApplyOpsSocketPostureOptions): OpsSocketPostureResult {
+  const fs = opts.fs ?? NODE_SOCKET_FS;
+  const resolveGid = opts.resolveGid ?? resolveGroupGid;
+  const posture = resolveSocketPosture(opts.group);
+
+  let gid: number | null = null;
+  let broadGroup = false;
+  if (posture.group !== null) {
+    if (!isValidSocketGroupName(posture.group)) {
+      throw new Error(
+        `Invalid FLAIR_SOCKET_GROUP '${posture.group}': group names must match ${SOCKET_GROUP_NAME_RE.source}.`,
+      );
+    }
+    gid = resolveGid(posture.group);
+    if (gid === null) {
+      throw new Error(
+        `FLAIR_SOCKET_GROUP '${posture.group}' does not exist on this system. ` +
+          `Create the group first, or unset FLAIR_SOCKET_GROUP to use the owner-only default (dir 0700 / socket 0600).`,
+      );
+    }
+    broadGroup = BROAD_SYSTEM_GROUPS.has(posture.group);
+  }
+
+  const parentDir = dirname(opts.socketPath);
+  // Directory gate — the race-free primary control. Applied whether or not the
+  // socket exists yet, so it is in place BEFORE Harper creates the socket.
+  fs.chmodSync(parentDir, posture.dirMode);
+
+  // Socket file: defense-in-depth mode + optional chgrp — only once it exists.
+  let socketApplied = false;
+  if (fs.existsSync(opts.socketPath)) {
+    fs.chmodSync(opts.socketPath, posture.socketMode);
+    if (gid !== null) {
+      const st = fs.statSync(opts.socketPath);
+      try {
+        // uid unchanged (we own it); only the group moves.
+        fs.chownSync(opts.socketPath, st.uid, gid);
+      } catch (err: any) {
+        throw new Error(
+          `Failed to chgrp the ops socket to group '${posture.group}' (gid ${gid}): ${err?.code ?? err?.message ?? err}. ` +
+            `chgrp requires membership in the target group — join '${posture.group}' or pick a different FLAIR_SOCKET_GROUP.`,
+        );
+      }
+    }
+    socketApplied = true;
+  }
+
+  return {
+    dirMode: posture.dirMode,
+    socketMode: posture.socketMode,
+    group: posture.group,
+    gid,
+    dirApplied: true,
+    socketApplied,
+    broadGroup,
+  };
+}
+
+/**
+ * Resolve + apply the ops-socket posture for a data dir, with the right
+ * fatal-vs-warn handling. A broken FLAIR_SOCKET_GROUP opt-in is a hard error
+ * (fail closed, no silent fallback); a failure of the owner-only default is
+ * non-fatal defense-in-depth (warn — the dir gate remains the load-bearing
+ * control). Returns the applied posture, or null on a non-fatal default-path
+ * failure. The socket path is derived from dataDir so a --data-dir install is
+ * gated at its own root, never a hardcoded ~/.flair.
+ */
+function readyOpsSocketPosture(dataDir: string): OpsSocketPostureResult | null {
+  const socketPath = join(dataDir, "operations-server");
+  const group = process.env.FLAIR_SOCKET_GROUP;
+  const optedIn = !!(group && group.trim().length > 0);
+  try {
+    const res = applyOpsSocketPosture({ socketPath, group });
+    if (res.broadGroup) {
+      console.error(
+        `warning: FLAIR_SOCKET_GROUP='${res.group}' is a broad system group — every member gets ops-socket access. Prefer a dedicated group.`,
+      );
+    }
+    return res;
+  } catch (err: any) {
+    if (optedIn) throw err; // opt-in misconfiguration — fail closed
+    console.error(
+      `warning: could not tighten ops-socket permissions (${err?.message ?? err}); ` +
+        `the ${dataDir} directory gate remains the primary control.`,
+    );
+    return null;
+  }
+}
+
+/**
+ * The `flair doctor` detection matrix for the ops-socket posture (flair#763,
+ * Sherlock's exact six rows). Report-only — never auto-remediated (changing a
+ * live socket's mode needs a restart). Pure: takes the parent-dir mode, the
+ * socket mode, and whether FLAIR_SOCKET_GROUP is set (the opt-in signal).
+ */
+export function classifyOpsSocketPosture(
+  dirMode: number,
+  socketMode: number,
+  groupOptIn: boolean,
+): { flagged: boolean; row: string; reason: string } {
+  const dm = dirMode & 0o777;
+  const sm = socketMode & 0o777;
+  const dirWorld = (dm & 0o007) !== 0;
+  const sockWorld = (sm & 0o007) !== 0;
+  const dirGroup = (dm & 0o070) !== 0;
+  const sockGroup = (sm & 0o070) !== 0;
+
+  if (groupOptIn) {
+    // Deliberate multi-user posture (dir 0750 / socket 0660). Clean as long as
+    // no WORLD access leaked onto either — a world bit means a regressed mode.
+    if (!dirWorld && !sockWorld) {
+      return {
+        flagged: false,
+        row: "deliberate-group-clean",
+        reason: "deliberate FLAIR_SOCKET_GROUP posture (dir 0750 / socket 0660) — no world access",
+      };
+    }
+    return {
+      flagged: true,
+      row: "group-opt-in-world-open",
+      reason: "FLAIR_SOCKET_GROUP is set but the parent directory or socket is world-accessible",
+    };
+  }
+
+  // No opt-in. World access is the worst and takes precedence.
+  if (dirWorld && sockWorld) {
+    return {
+      flagged: true,
+      row: "both-open",
+      reason: "both the socket's parent directory and the socket itself are group/world-accessible",
+    };
+  }
+  if (dirWorld) {
+    return {
+      flagged: true,
+      row: "root-open",
+      reason: "the socket's parent directory is group/world-traversable — the primary access gate is breached",
+    };
+  }
+  if (sockWorld) {
+    return {
+      flagged: true,
+      row: "socket-open",
+      reason: "the ops socket is group/world-accessible",
+    };
+  }
+  // No world bits, but group bits present without the opt-in.
+  if (dirGroup || sockGroup) {
+    return {
+      flagged: true,
+      row: "group-mode-without-opt-in",
+      reason: "the socket carries group permissions but FLAIR_SOCKET_GROUP is not set (unintended group access)",
+    };
+  }
+  return {
+    flagged: false,
+    row: "default-clean",
+    reason: "owner-only posture (dir 0700 / socket 0600)",
+  };
 }
 
 // ─── Target resolution (remote Flair instance) ─────────────────────────────────
@@ -2211,6 +2489,14 @@ program
     // when Harper was already running and the fresh-spawn branch was skipped.
     const modelsDir = process.env.FLAIR_MODELS_DIR ?? join(dataDir, "models");
 
+    // flair#763: put the ops-socket directory gate in place BEFORE Harper
+    // spawns, so the socket is never reachable during the create→chmod window
+    // (the dir gate is the race-free primary control). This also validates
+    // FLAIR_SOCKET_GROUP early — a bad group fails fast, before a full boot.
+    // The socket doesn't exist yet, so only the parent-dir mode is applied here.
+    mkdirSync(dataDir, { recursive: true });
+    readyOpsSocketPosture(dataDir);
+
     if (!opts.skipStart) {
       // Check if already running
       try {
@@ -2317,6 +2603,10 @@ program
       console.log("Waiting for Harper health check...");
       await waitForHealth(httpPort, adminUser, adminPass, STARTUP_TIMEOUT_MS);
       console.log("Harper is healthy ✓");
+
+      // flair#763: the socket now exists — apply its file mode (+ chgrp for the
+      // FLAIR_SOCKET_GROUP opt-in). The dir gate above is re-asserted idempotently.
+      readyOpsSocketPosture(dataDir);
 
       // Register launchd service on macOS so Harper survives reboots
       // and `flair restart` / `flair stop` work via launchctl.
@@ -9073,6 +9363,7 @@ program
           const { label, migrated } = ensureLaunchdServiceLoaded(dataDir, (cmd) => execSync(cmd, { stdio: "pipe" }));
           if (migrated) console.log(`Migrated launchd service off the legacy label (${LEGACY_LAUNCHD_LABEL}) → ${label} ✓`);
           await waitForHealth(port, DEFAULT_ADMIN_USER, process.env.HDB_ADMIN_PASSWORD ?? "", STARTUP_TIMEOUT_MS);
+          readyOpsSocketPosture(dataDir); // flair#763: re-assert socket posture on the freshly-created socket
           console.log("✅ Flair started (launchd)");
           return;
         } catch (err: any) {
@@ -9125,6 +9416,7 @@ program
 
     try {
       await waitForHealth(port, DEFAULT_ADMIN_USER, adminPass, STARTUP_TIMEOUT_MS);
+      readyOpsSocketPosture(dataDir); // flair#763: re-assert socket posture on the freshly-created socket
       console.log(`✅ Flair started on port ${port}`);
     } catch {
       console.error("❌ Flair failed to start within timeout. Check logs in " + join(dataDir, "harper.log"));
@@ -9204,6 +9496,7 @@ async function startFlairProcess(port: number): Promise<void> {
         const { execSync } = await import("node:child_process");
         ensureLaunchdServiceLoaded(dataDir, (cmd) => execSync(cmd, { stdio: "pipe" }));
         await waitForHealth(port, DEFAULT_ADMIN_USER, process.env.HDB_ADMIN_PASSWORD ?? "", STARTUP_TIMEOUT_MS);
+        readyOpsSocketPosture(dataDir); // flair#763: re-assert socket posture across restart/upgrade
         return;
       } catch (err: any) {
         console.error(`launchd start failed, falling back to direct start: ${err.message}`);
@@ -9245,6 +9538,7 @@ async function startFlairProcess(port: number): Promise<void> {
   proc.unref();
 
   await waitForHealth(port, DEFAULT_ADMIN_USER, adminPass, STARTUP_TIMEOUT_MS);
+  readyOpsSocketPosture(dataDir); // flair#763: re-assert socket posture across restart/upgrade
 }
 
 /**
@@ -10180,6 +10474,25 @@ program
         }
       }
     } catch { /* best-effort — don't fail doctor over a malformed harper-config.yaml */ }
+
+    // 3c. Ops-socket permission posture (flair#763) — report-only, never
+    // auto-fixed. Re-tightening a live socket needs a restart, so the remedy is
+    // `flair init`/restart (which re-applies the posture), not a `doctor --fix`.
+    // Only assessed when the socket exists (Harper has booted at least once).
+    try {
+      const socketPath = join(defaultDataDir(), "operations-server");
+      if (existsSync(socketPath)) {
+        const dirMode = statSync(dirname(socketPath)).mode;
+        const socketMode = statSync(socketPath).mode;
+        const groupOptIn = !!(process.env.FLAIR_SOCKET_GROUP && process.env.FLAIR_SOCKET_GROUP.trim().length > 0);
+        const verdict = classifyOpsSocketPosture(dirMode, socketMode, groupOptIn);
+        if (verdict.flagged) {
+          console.log(`  ${render.icons.error} Ops socket permissions: ${verdict.reason}`);
+          console.log(`     ${render.wrap(render.c.dim, "Fix:")} flair init ${render.wrap(render.c.dim, "(re-applies the 0700 dir / 0600 socket posture on next start; set FLAIR_SOCKET_GROUP for deliberate multi-user access)")}`);
+          issues++;
+        }
+      }
+    } catch { /* best-effort — a stat failure shouldn't fail doctor */ }
 
     // 4. Embeddings check — REAL semantic round-trip (only if Harper is responding).
     //

--- a/test/unit/ops-socket-posture.test.ts
+++ b/test/unit/ops-socket-posture.test.ts
@@ -1,0 +1,273 @@
+/**
+ * ops-socket-posture.test.ts — Unit tests for the ops-API domain-socket
+ * permission posture added by flair#763 (split from #670; same local-admin
+ * surface axis as #654's authorizeLocal-off and #762's loopback bind).
+ *
+ * The socket (dataDir/operations-server) is gated primarily by its immediate
+ * parent directory — a race-free, umask-independent, cross-platform control —
+ * with the socket file mode as defense-in-depth:
+ *
+ *   FLAIR_SOCKET_GROUP unset → parent dir 0700, socket 0600.
+ *   FLAIR_SOCKET_GROUP set    → parent dir 0750, socket 0660 + chgrp to it.
+ *
+ * The two layers move in lockstep both directions (a later unset returns dir
+ * → 0700, socket → 0600). Same house pattern as ops-api-bind.test.ts: the pure
+ * decision + application logic is exported from cli.ts and exercised directly
+ * with an in-memory fs and a mocked group resolver — no real socket, no chmod
+ * of a real ~/.flair (the CLAUDE.md safety rail: tests touch temp/fake fs only).
+ */
+
+import { describe, test, expect } from "bun:test";
+import { dirname } from "node:path";
+import {
+  SOCKET_GROUP_NAME_RE,
+  isValidSocketGroupName,
+  resolveSocketPosture,
+  applyOpsSocketPosture,
+  classifyOpsSocketPosture,
+  type OpsSocketPostureFs,
+} from "../../src/cli.ts";
+
+// ─── In-memory fs double ────────────────────────────────────────────────────
+
+class FakeFs implements OpsSocketPostureFs {
+  chmods: Array<{ path: string; mode: number }> = [];
+  chowns: Array<{ path: string; uid: number; gid: number }> = [];
+  private modes = new Map<string, number>();
+  private uids = new Map<string, number>();
+  chownThrows?: Error;
+
+  /** `existing` seeds paths that "exist" (dirs never need seeding — chmod on a
+   *  dir is unconditional; only the socket's existence is gated on). */
+  constructor(existing: Record<string, { mode?: number; uid?: number }> = {}) {
+    for (const [p, v] of Object.entries(existing)) {
+      this.modes.set(p, v.mode ?? 0o755);
+      this.uids.set(p, v.uid ?? 501);
+    }
+  }
+  chmodSync(path: string, mode: number) {
+    this.chmods.push({ path, mode });
+    this.modes.set(path, mode);
+  }
+  chownSync(path: string, uid: number, gid: number) {
+    if (this.chownThrows) throw this.chownThrows;
+    this.chowns.push({ path, uid, gid });
+  }
+  existsSync(path: string) {
+    return this.modes.has(path);
+  }
+  statSync(path: string) {
+    return { mode: this.modes.get(path) ?? 0, uid: this.uids.get(path) ?? 501, gid: 0 };
+  }
+  modeOf(path: string) {
+    return this.modes.get(path);
+  }
+}
+
+const SOCK = "/data/inst/operations-server";
+const DIR = dirname(SOCK); // "/data/inst"
+
+// ─── resolveSocketPosture (pure two-state source of truth) ───────────────────
+
+describe("resolveSocketPosture", () => {
+  test("unset → owner-only: dir 0700, socket 0600", () => {
+    for (const g of [undefined, null, "", "   "]) {
+      const p = resolveSocketPosture(g as any);
+      expect(p.dirMode).toBe(0o700);
+      expect(p.socketMode).toBe(0o600);
+      expect(p.group).toBeNull();
+    }
+  });
+
+  test("set → owner+group: dir 0750, socket 0660, trimmed group name", () => {
+    const p = resolveSocketPosture("  flairadmin  ");
+    expect(p.dirMode).toBe(0o750);
+    expect(p.socketMode).toBe(0o660);
+    expect(p.group).toBe("flairadmin");
+  });
+});
+
+// ─── applyOpsSocketPosture — DEFAULT posture ─────────────────────────────────
+
+describe("applyOpsSocketPosture — default (no group)", () => {
+  test("socket present → dir 0700 + socket 0600, no chgrp", () => {
+    const fs = new FakeFs({ [SOCK]: { mode: 0o755, uid: 501 } });
+    const r = applyOpsSocketPosture({ socketPath: SOCK, group: undefined, fs });
+    expect(fs.modeOf(DIR)).toBe(0o700);
+    expect(fs.modeOf(SOCK)).toBe(0o600);
+    expect(fs.chowns).toHaveLength(0);
+    expect(r.socketApplied).toBe(true);
+    expect(r.group).toBeNull();
+    expect(r.gid).toBeNull();
+  });
+
+  test("socket absent (pre-boot) → dir gate only, socketApplied false", () => {
+    const fs = new FakeFs(); // socket not seeded → does not exist
+    const r = applyOpsSocketPosture({ socketPath: SOCK, group: undefined, fs });
+    expect(fs.modeOf(DIR)).toBe(0o700);
+    expect(fs.modeOf(SOCK)).toBeUndefined(); // never chmod'd
+    expect(fs.chowns).toHaveLength(0);
+    expect(r.socketApplied).toBe(false);
+    expect(r.dirApplied).toBe(true);
+  });
+});
+
+// ─── applyOpsSocketPosture — GROUP opt-in posture ────────────────────────────
+
+describe("applyOpsSocketPosture — FLAIR_SOCKET_GROUP opt-in", () => {
+  test("valid existing group → dir 0750 + socket 0660 + chgrp(uid unchanged, gid)", () => {
+    const fs = new FakeFs({ [SOCK]: { mode: 0o755, uid: 501 } });
+    const resolveGid = (name: string) => (name === "flairadmin" ? 2000 : null);
+    const r = applyOpsSocketPosture({ socketPath: SOCK, group: "flairadmin", fs, resolveGid });
+    expect(fs.modeOf(DIR)).toBe(0o750);
+    expect(fs.modeOf(SOCK)).toBe(0o660);
+    expect(fs.chowns).toEqual([{ path: SOCK, uid: 501, gid: 2000 }]);
+    expect(r.group).toBe("flairadmin");
+    expect(r.gid).toBe(2000);
+    expect(r.socketApplied).toBe(true);
+    expect(r.broadGroup).toBe(false);
+  });
+
+  test("group set but socket absent → dir 0750, group validated, no chgrp yet", () => {
+    const fs = new FakeFs();
+    const resolveGid = (name: string) => 2000;
+    const r = applyOpsSocketPosture({ socketPath: SOCK, group: "flairadmin", fs, resolveGid });
+    expect(fs.modeOf(DIR)).toBe(0o750);
+    expect(fs.chowns).toHaveLength(0);
+    expect(r.gid).toBe(2000);
+    expect(r.socketApplied).toBe(false);
+  });
+
+  test("broad system group (staff) → still applied, but flagged broadGroup", () => {
+    const fs = new FakeFs({ [SOCK]: { mode: 0o755, uid: 501 } });
+    const r = applyOpsSocketPosture({ socketPath: SOCK, group: "staff", fs, resolveGid: () => 20 });
+    expect(r.broadGroup).toBe(true);
+    expect(fs.modeOf(SOCK)).toBe(0o660);
+  });
+});
+
+// ─── Group-name validation (regex BEFORE existence resolution) ────────────────
+
+describe("applyOpsSocketPosture — group-name validation (fail-closed)", () => {
+  test("invalid group name → hard error, resolveGid NEVER called (regex first)", () => {
+    const fs = new FakeFs({ [SOCK]: { mode: 0o755, uid: 501 } });
+    let resolveCalls = 0;
+    const resolveGid = () => {
+      resolveCalls++;
+      return 2000;
+    };
+    for (const bad of ["../../etc/shadow", "bad group", "-leading", "5starts", "with/slash", "semi;colon"]) {
+      expect(() => applyOpsSocketPosture({ socketPath: SOCK, group: bad, fs, resolveGid })).toThrow(/Invalid FLAIR_SOCKET_GROUP/);
+    }
+    expect(resolveCalls).toBe(0); // regex rejected every one before existence resolution
+    // Fail-closed: validation throws BEFORE any chmod — no silent fallback, and
+    // not even the dir gate is touched (the socket keeps its original mode).
+    expect(fs.chmods).toHaveLength(0);
+    expect(fs.modeOf(SOCK)).toBe(0o755); // untouched
+    expect(fs.modeOf(DIR)).toBeUndefined();
+  });
+
+  test("valid-but-missing group → hard error (no silent 0600 fallback)", () => {
+    const fs = new FakeFs({ [SOCK]: { mode: 0o755, uid: 501 } });
+    const resolveGid = () => null; // getgrnam miss
+    expect(() => applyOpsSocketPosture({ socketPath: SOCK, group: "ghostgroup", fs, resolveGid })).toThrow(/does not exist/);
+    expect(fs.chmods).toHaveLength(0); // threw before any chmod — no fallback to 0600
+    expect(fs.modeOf(SOCK)).toBe(0o755); // untouched
+    expect(fs.chowns).toHaveLength(0);
+  });
+
+  test("chgrp failure (exists but not a member) → clear membership error", () => {
+    const fs = new FakeFs({ [SOCK]: { mode: 0o755, uid: 501 } });
+    fs.chownThrows = Object.assign(new Error("EPERM"), { code: "EPERM" });
+    expect(() => applyOpsSocketPosture({ socketPath: SOCK, group: "othergrp", fs, resolveGid: () => 3000 })).toThrow(/requires membership/);
+  });
+
+  test("SOCKET_GROUP_NAME_RE / isValidSocketGroupName accept & reject the right shapes", () => {
+    for (const ok of ["flair", "_flair", "flair-admin", "flair.grp", "a1_2.3-4", "staff"]) {
+      expect(isValidSocketGroupName(ok)).toBe(true);
+      expect(SOCKET_GROUP_NAME_RE.test(ok)).toBe(true);
+    }
+    for (const bad of ["1abc", "-abc", ".abc", "a b", "a/b", "a$b", "", "a;b"]) {
+      expect(isValidSocketGroupName(bad)).toBe(false);
+    }
+  });
+});
+
+// ─── Lockstep BOTH directions ────────────────────────────────────────────────
+
+describe("applyOpsSocketPosture — lockstep both directions", () => {
+  test("set-then-unset: 0700/0600 → 0750/0660 → back to 0700/0600", () => {
+    const fs = new FakeFs({ [SOCK]: { mode: 0o755, uid: 501 } });
+
+    // 1. Default posture.
+    applyOpsSocketPosture({ socketPath: SOCK, group: undefined, fs });
+    expect(fs.modeOf(DIR)).toBe(0o700);
+    expect(fs.modeOf(SOCK)).toBe(0o600);
+
+    // 2. Opt in → dir + socket widen together.
+    applyOpsSocketPosture({ socketPath: SOCK, group: "flairadmin", fs, resolveGid: () => 2000 });
+    expect(fs.modeOf(DIR)).toBe(0o750);
+    expect(fs.modeOf(SOCK)).toBe(0o660);
+    expect(fs.chowns).toHaveLength(1);
+
+    // 3. Unset → dir + socket tighten back together (lockstep the other way).
+    applyOpsSocketPosture({ socketPath: SOCK, group: undefined, fs });
+    expect(fs.modeOf(DIR)).toBe(0o700);
+    expect(fs.modeOf(SOCK)).toBe(0o600);
+    // No new chgrp on the way back — 0600 removes group access outright.
+    expect(fs.chowns).toHaveLength(1);
+  });
+});
+
+// ─── Doctor detection matrix — Sherlock's exact SIX rows ─────────────────────
+
+describe("classifyOpsSocketPosture — the six-row doctor matrix", () => {
+  test("row 1 — dir 0700 + socket 0600 (no opt-in) → CLEAN (default-clean)", () => {
+    const v = classifyOpsSocketPosture(0o700, 0o600, false);
+    expect(v.flagged).toBe(false);
+    expect(v.row).toBe("default-clean");
+  });
+
+  test("row 2 — dir 0755 + socket 0600 (no opt-in) → FLAG (root-open)", () => {
+    const v = classifyOpsSocketPosture(0o755, 0o600, false);
+    expect(v.flagged).toBe(true);
+    expect(v.row).toBe("root-open");
+  });
+
+  test("row 3 — dir 0700 + socket 0755 (no opt-in) → FLAG (socket-open)", () => {
+    const v = classifyOpsSocketPosture(0o700, 0o755, false);
+    expect(v.flagged).toBe(true);
+    expect(v.row).toBe("socket-open");
+  });
+
+  test("row 4 — dir 0755 + socket 0755 (no opt-in) → FLAG (both-open)", () => {
+    const v = classifyOpsSocketPosture(0o755, 0o755, false);
+    expect(v.flagged).toBe(true);
+    expect(v.row).toBe("both-open");
+  });
+
+  test("row 5 — dir 0750 + socket 0660 + FLAIR_SOCKET_GROUP set → CLEAN (deliberate-group-clean)", () => {
+    const v = classifyOpsSocketPosture(0o750, 0o660, true);
+    expect(v.flagged).toBe(false);
+    expect(v.row).toBe("deliberate-group-clean");
+  });
+
+  test("row 6 — dir 0750 + socket 0660 + NO FLAIR_SOCKET_GROUP → FLAG (group-mode-without-opt-in)", () => {
+    const v = classifyOpsSocketPosture(0o750, 0o660, false);
+    expect(v.flagged).toBe(true);
+    expect(v.row).toBe("group-mode-without-opt-in");
+  });
+
+  test("robustness — a world-open regression while opted-in is still flagged", () => {
+    const v = classifyOpsSocketPosture(0o750, 0o755, true);
+    expect(v.flagged).toBe(true);
+    expect(v.row).toBe("group-opt-in-world-open");
+  });
+
+  test("high mode bits (setuid/sticky) are ignored — only rwx bits classify", () => {
+    // 0o41700-style st.mode carries file-type bits; classifier masks to 0o777.
+    const v = classifyOpsSocketPosture(0o40700, 0o140600, false);
+    expect(v.flagged).toBe(false);
+    expect(v.row).toBe("default-clean");
+  });
+});


### PR DESCRIPTION
Split from #670 (the network-bind slice shipped in #762); same local-admin-surface axis as #654 (`authorizeLocal` off). Implements the K&S-approved design on #763.

**Ground truth (measured, folded into the design):** Harper sets no mode on the ops socket, so it lands at `0777 & ~umask` (0755 here) — real, but umask-luck, not a literal 0666. `~/.flair` was already `0700`, making the *directory* the effective gate by accident. Harper exposes no socket-permission knob (`operationsApi.network.domainSocket` is a path string only; no `chmod` in `dist/server`), so flair sets the posture itself around the socket the start path creates.

## Posture (lockstep both directions)

| `FLAIR_SOCKET_GROUP` | parent dir | socket | group |
|---|---|---|---|
| unset (default) | `0700` | `0600` | — |
| set | `0750` (owner+group traverse) | `0660` | `chgrp` to it |

The parent dir at `0750` (not `0700`) when a group is set is load-bearing: otherwise the group grant is silently unreachable behind the directory gate. A later **unset returns** the dir to `0700` and the socket to `0600` — the two layers widen and tighten together.

The **socket's immediate parent directory** is the primary, load-bearing gate — resolved from the configured socket path, **never a hardcoded `~/.flair`**, so a custom `--data-dir` install is gated at its own root. It's race-free (checked on every `connect(2)` traversal — no create→chmod window), umask-independent (explicit `chmod`), and cross-platform (VFS-level, unlike socket-file permission enforcement on `connect(2)` which varies across BSD lineage). The socket file mode is defense-in-depth within it.

## Fail-closed group validation

The group name is regex-validated (`^[a-zA-Z_][a-zA-Z0-9._-]*$`) **before** existence resolution; an invalid **or** missing group is a hard error — never a silent fallback to `0600`. A `chgrp` that fails because the user isn't a member gives a clear "requires membership" message (distinct from "does not exist"); a broad system group (`staff`/`wheel`/`users`/`admin`/…) emits a warning (not a block).

## Where it's applied

- **`init`** puts the directory gate in place **before** Harper spawns (closing the create→chmod window and failing fast on a bad `FLAIR_SOCKET_GROUP`), then applies the socket mode once the socket appears.
- **`flair start`** and the internal **restart/upgrade** start path re-assert the posture on the freshly-created socket.
- Default-posture failures are non-fatal defense-in-depth (warn — the dir gate is the primary control); a broken group opt-in fails loud.

## `flair doctor` — report-only six-row matrix (no `--fix`)

Re-tightening a live socket needs a restart, so the remedy is `flair init`/restart, mirroring #762's all-interfaces finding. Sherlock's exact matrix:

| parent dir | socket | opt-in | verdict |
|---|---|---|---|
| `0700` | `0600` | — | clean (default) |
| `0755` | `0600` | — | **flag** (root gate breached) |
| `0700` | `0755` | — | **flag** (socket mode breached) |
| `0755` | `0755` | — | **flag** (both open) |
| `0750` | `0660` | set | clean (deliberate multi-user) |
| `0750` | `0660` | unset | **flag** (unintended group access) |

## Acceptance evidence

- New `test/unit/ops-socket-posture.test.ts` — 20 tests: both postures, lockstep both directions, group-name validation (valid/invalid/missing/not-a-member/broad-group), and all six doctor matrix rows. In-memory fs + mocked group resolution; **no real socket or `~/.flair` touched**.
- `bun test test/unit/` green (2667 pass, 0 fail); the new file looped 5× isolated, 0 fail.
- Real-fs end-to-end spot-check on a temp dir (never `~/.flair`): default posture yields dir `0700`/socket `0600`; missing + invalid group both hard-error via the real `getgrnam`/`dscl` path; the `staff`-group opt-in yields dir `0750`/socket `0660`/gid resolved + `chgrp` applied + broad-group warning.
- `tsc` adds zero new errors (the one pre-existing `resources/auth-middleware.ts` error is unrelated and present on `main`).
- `test/integration/` skipped locally (pre-existing env failure unrelated to this change — CI is the gate).

Closes #763. References #670 (parent) and #654 (lineage).