### PR TITLE
chore: declare packageManager (bun@1.3.10) — enable Renovate on bun.lock

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,8 @@
 {
   "name": "@tpsdev-ai/flair",
   "version": "0.24.0",
-  "description": "Identity, memory, and soul for AI agents. Cryptographic identity (Ed25519), semantic memory with local embeddings, and persistent personality — all in a single process.",
+  "packageManager": "bun@1.3.10",
+  "description": "Identity, memory, and soul for AI agents. Cryptographic identity (Ed25519), semantic memory with local embeddings, and persistent personality \u2014 all in a single process.",
   "type": "module",
   "license": "Apache-2.0",
   "repository": {


### PR DESCRIPTION
Adds `"packageManager": "bun@1.3.10"` to package.json.

**Why:** Renovate (now installed on the org) keys its bun/`bun.lock` dependency-update support off package-manager detection. Without this field its scheduled runs produce zero dependency PRs on this repo — the root cause behind falling ~5 patches behind on @harperfast/harper (see #770). Also correct toolchain-declaration hygiene; matches CI's `setup-bun` 1.3.10.

**Risk:** minimal — additive metadata field, `bun install` clean with no lockfile change. Closes the Renovate-can't-see-us gap for #770.