### PR TITLE
feat(recall): citation-on-write — usedMemoryIds on the write path (flair#744 slice A)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ## [Unreleased]
 
+### Trust-graded recall — citation-on-write (flair#744 slice A)
+
+Memory usage feedback (`record_usage`, flair#683) required a separate call after the fact. Now a write can cite the memories that informed it inline: an optional `usedMemoryIds?: string[]` on the memory write surfaces (`Memory.post`/`Memory.put`, the `memory_store` MCP tool, `flair-client.mjs write --used <csv>`) credits each cited memory through the exact SAME deduped, principal-bound usage ledger `record_usage` writes to — no separate call, no duplicated ledger logic (`resources/usage-recording.ts` extracts the shared ledger-write core so RecordUsage and citation-on-write share one implementation).
+
+- **Post-commit, non-blocking.** Citation recording runs strictly AFTER the memory write commits. A recording failure is logged server-side and swallowed — it never changes the write's response, never rolls back or retries the write.
+- **Silent drop for anything outside read scope.** Reusing `record_usage`'s existing ledger path means a cited id that doesn't exist (or isn't visible to the writer) is a quiet no-op, exactly like `record_usage` — no error, no observable difference between "not found" and "already credited".
+- **agentId always from the resolved auth context.** The ledger key is `{writerAgentId}:{citedMemoryId}`, where `writerAgentId` comes from the same auth resolution `Memory.post`/`put` already perform — never from the request body. A caller cannot credit a contribution on behalf of another identity.
+- **Opt-in, additive, clean migration.** `usedMemoryIds` is consumed-and-stripped from the write body before the row is persisted (same discipline as `claimedClient`) — it is never stored on the Memory record itself. Omitted entirely ⇒ zero new calls, byte-identical to before.
+- **Trust-block absent-vs-0 fix.** The trust block's `usageCount` field is now `number | null`: `null` when no usage has ever been recorded, a real `0`/`3`/etc. when it has — so a reader can tell "no usage signal yet" apart from "recorded, zero uses" instead of both reading as a false `0`.
+- New pure unit coverage in `test/unit/usage-recording.test.ts` (auth gating, cap/dedup, per-id failure isolation, agentId provenance) and `test/unit/trust-block.test.ts` (the absent-vs-0 cases); new integration coverage in `test/integration/citation-on-write-e2e.test.ts` (ledger-sharing dedup parity with `record_usage`, cross-agent isolation, out-of-scope/nonexistent-id silent drop, post-commit write-success isolation).
+- Consumer wiring (openclaw-flair / flair-mcp actually passing `usedMemoryIds` on real writes) is a follow-up slice, out of scope here.
+
 ### Trust-graded recall — `matchQuality` confidence bands on the trust block ("breadcrumbs, labeled") (flair#744)
 
 Recall shouldn't be binary confident-match / nothing. A weak, fuzzy match is *valuable* if the agent knows it's weak — a breadcrumb taken for what it is. The hallucination risk isn't returning weak matches; it's returning them **undifferentiated** from strong ones. Abstention (slice 2) already returns breadcrumbs (it only abstains at a near-zero floor); this adds the **label** that says "this is a breadcrumb, not a fact." Each recall result's trust block now carries a **`matchQuality: "strong" | "moderate" | "breadcrumb" | null`** field, derived purely from the result's absolute semantic similarity.

--- a/resources/Memory.ts
+++ b/resources/Memory.ts
@@ -28,6 +28,7 @@ import {
 } from "./record-type-kit.js";
 import { RECORD_TYPES } from "./record-types.js";
 import { attachTrust } from "./trust-block.js";
+import { recordCitations } from "./usage-recording.js";
 
 /**
  * flair#744 slice 1 — read the opt-in `includeTrust` flag for a by-id get.
@@ -611,6 +612,16 @@ export class Memory extends (databases as any).flair.Memory {
       if (attr.denied) return attr.denied;
     }
 
+    // flair#744 slice A: citation-on-write — consume-and-strip, same
+    // discipline as `claimedClient` below. Pull the optional
+    // `usedMemoryIds` off the write body now, BEFORE anything else touches
+    // `content`, so it is NEVER persisted on the Memory record itself.
+    // Recording happens POST-COMMIT, only when this was present (see the
+    // failure-isolated recordCitations() call near the return below) —
+    // omitted ⇒ `undefined` ⇒ zero new calls, byte-identical behavior.
+    const usedMemoryIds = content?.usedMemoryIds;
+    if (content && typeof content === "object") delete content.usedMemoryIds;
+
     content.durability ||= "standard";
     content.createdAt = new Date().toISOString();
     content.updatedAt = content.createdAt;
@@ -729,6 +740,20 @@ export class Memory extends (databases as any).flair.Memory {
     // a lost write — and the failure is logged, never silently swallowed.
     await closeSupersededIfNeeded(ctx, content, "post");
 
+    // flair#744 slice A: citation-on-write — POST-COMMIT, fully
+    // failure-isolated. The write above already succeeded and `result` is
+    // final; crediting each cited memory through the shared usage ledger
+    // (same path as POST /RecordUsage) must never affect this response —
+    // any failure here is logged server-side and swallowed, never surfaced
+    // to the caller, never rolls back or retries the write.
+    if (usedMemoryIds !== undefined) {
+      try {
+        await recordCitations(ctx, auth, usedMemoryIds, new Date().toISOString());
+      } catch (err) {
+        console.error("Memory.post: citation recording failed (write already committed)", err);
+      }
+    }
+
     return buildWriteResponse(content, result, dedupMatch);
   }
 
@@ -771,6 +796,13 @@ export class Memory extends (databases as any).flair.Memory {
       const attr = stampAttribution(auth, content, RECORD_TYPES.Memory.ownerField, RECORD_TYPES.Memory.attribution.put, "forbidden: cannot write memory owned by another agent");
       if (attr.denied) return attr.denied;
     }
+
+    // flair#744 slice A: citation-on-write — same consume-and-strip
+    // discipline as post() above. Strip BEFORE anything else touches
+    // `content` so it is never persisted on the row; recorded post-commit
+    // below only when present.
+    const usedMemoryIds = content?.usedMemoryIds;
+    if (content && typeof content === "object") delete content.usedMemoryIds;
 
     const now = new Date().toISOString();
     content.updatedAt = now;
@@ -908,6 +940,16 @@ export class Memory extends (databases as any).flair.Memory {
 
     // ── THEN close the superseded record (see post()) ───────────────────────
     await closeSupersededIfNeeded(ctx, content, "put");
+
+    // flair#744 slice A: citation-on-write — POST-COMMIT, fully
+    // failure-isolated (see post()'s identical comment above).
+    if (usedMemoryIds !== undefined) {
+      try {
+        await recordCitations(ctx, auth, usedMemoryIds, new Date().toISOString());
+      } catch (err) {
+        console.error("Memory.put: citation recording failed (write already committed)", err);
+      }
+    }
 
     return buildWriteResponse(content, result, dedupMatch);
   }

--- a/resources/RecordUsage.ts
+++ b/resources/RecordUsage.ts
@@ -11,6 +11,14 @@
  * REPLACES `retrievalBoost` in `compositeScore` outright (see that
  * function's doc).
  *
+ * flair#744 slice A: the actual ledger-write core below (formerly this
+ * class's private `_recordOne()`) has moved to ./usage-recording.ts's
+ * `recordUsageContribution()` — a shared, single-implementation extraction
+ * also used by citation-on-write (resources/Memory.ts's post()/put()) so
+ * there is exactly ONE place the (agentId, memoryId) ledger logic lives.
+ * This endpoint's own request handling (auth, rate limit, batch validation,
+ * the no-enumeration response) is unchanged.
+ *
  * WHY THIS IS ITS OWN ENDPOINT, NOT `Memory.put()` (Sherlock, K&S verdict —
  * FLAIR-USAGE-FEEDBACK-SIGNAL.md): usage feedback is fundamentally a
  * CROSS-AGENT write — agent B reports using agent A's memory, so the write
@@ -21,10 +29,10 @@
  * memory through this surface — not just the count. So this endpoint does
  * the narrowest possible thing instead: a TARGETED `usageCount`-only
  * bump (read-full-record, merge just this one field, write — see
- * _recordOne() below) against the RAW `Memory` table object, entirely
- * bypassing the `Memory` RESOURCE class (and its ownership gate) — its own
- * auth model is verified-agent + within-org + explicitly NO ownership
- * requirement.
+ * ./usage-recording.ts's recordUsageContribution()) against the RAW
+ * `Memory` table object, entirely bypassing the `Memory` RESOURCE class
+ * (and its ownership gate) — its own auth model is verified-agent +
+ * within-org + explicitly NO ownership requirement.
  *
  * WHY THIS ISN'T A @table-BACKED RESOURCE: the actual dedup ledger (one row
  * per (agentId, memoryId) contribution) lives in the `MemoryUsage` table
@@ -37,13 +45,14 @@
  * SAME class of gotcha resources/Memory.ts documents for a raw HTTP POST to
  * `/Memory`, but here it bites even an in-process call). So the ledger row
  * itself is written via `.put()` (upsert with the deterministic composite
- * id — see _recordOne()), and this endpoint's OWN HTTP surface lives on a
- * plain action `Resource` (same shape as resources/MemoryReflect.ts /
- * resources/SemanticSearch.ts) rather than extending a @table class, so POST
- * actually routes here. It talks to BOTH `Memory` and `MemoryUsage` via
- * their raw table objects (bypassing each resource class's own auth
- * wrapper — the same "call the other table directly" pattern
- * resources/Memory.ts already uses for `MemoryGrant` in hasWriteGrant()).
+ * id — see ./usage-recording.ts's recordUsageContribution()), and this
+ * endpoint's OWN HTTP surface lives on a plain action `Resource` (same shape
+ * as resources/MemoryReflect.ts / resources/SemanticSearch.ts) rather than
+ * extending a @table class, so POST actually routes here. It talks to BOTH
+ * `Memory` and `MemoryUsage` via their raw table objects (bypassing each
+ * resource class's own auth wrapper — the same "call the other table
+ * directly" pattern resources/Memory.ts already uses for `MemoryGrant` in
+ * hasWriteGrant()).
  *
  * ANTI-GAMING (Sherlock): usage feedback is a write that affects RANKING —
  * an abuse surface (inflate usageCount to boost a memory). Three-layer
@@ -73,17 +82,20 @@
  * sanitized (control-character-stripped, length-capped) and stored as-is,
  * for audit/analytics only. Treat it as untrusted data, always.
  */
-import { Resource, databases } from "@harperfast/harper";
+import { Resource } from "@harperfast/harper";
 import { resolveAgentAuth } from "./agent-auth.js";
 import { checkRateLimit, rateLimitResponse } from "./rate-limiter.js";
-import { withDetachedTxn } from "./table-helpers.js";
+import { recordUsageContribution, MAX_USAGE_IDS_PER_CALL } from "./usage-recording.js";
 
 const UNAUTH = () =>
   new Response(JSON.stringify({ error: "authentication required" }), { status: 401, headers: { "Content-Type": "application/json" } });
 const BAD_REQUEST = (msg: string) =>
   new Response(JSON.stringify({ error: msg }), { status: 400, headers: { "Content-Type": "application/json" } });
 
-const MAX_IDS_PER_CALL = 20;
+// flair#744 slice A: sourced from the shared module (./usage-recording.ts)
+// so RecordUsage.post()'s validated-batch cap and citation-on-write's
+// advisory-batch cap can never drift apart.
+const MAX_IDS_PER_CALL = MAX_USAGE_IDS_PER_CALL;
 const MAX_ATTRIBUTION_LENGTH = 500;
 
 /**
@@ -157,7 +169,12 @@ export class RecordUsage extends Resource {
 
     for (const memoryId of memoryIds) {
       try {
-        await this._recordOne(ctx, agentId, memoryId, attribution, now);
+        // flair#744 slice A: the ledger-write core now lives in
+        // ./usage-recording.ts's recordUsageContribution() — a shared,
+        // single-implementation extraction (also used by citation-on-write,
+        // resources/Memory.ts's post()/put()). Byte-identical behavior to
+        // the former private _recordOne() this replaced.
+        await recordUsageContribution(ctx, agentId, memoryId, attribution, now);
       } catch (err) {
         // Never let one bad id fail the whole batch, and never let an
         // internal error leak existence information either — log
@@ -170,81 +187,5 @@ export class RecordUsage extends Resource {
     // Deliberately does NOT report which ids succeeded / were already
     // counted / were not found — see RECORDED_RESPONSE's doc.
     return RECORDED_RESPONSE;
-  }
-
-  /**
-   * One (agentId, memoryId) contribution.
-   *
-   * Ledger-row-create FIRST, THEN the Memory.usageCount bump — so a crash
-   * between the two leaves the SAFE failure state (ledger row exists, count
-   * not yet bumped: a later retry just re-checks and no-ops) rather than the
-   * reverse (count bumped, no ledger row → a retry would double-count).
-   *
-   * Every discrete Harper call is wrapped INDIVIDUALLY in its own
-   * withDetachedTxn — never one wrap around a multi-step helper. A request
-   * that reads/writes MULTIPLE tables (or the same table twice) in sequence
-   * can otherwise inherit a closed transaction from a prior call's drained
-   * chain (table-helpers.ts's withDetachedTxn doc); resources/Memory.ts's
-   * closeSupersededRecord documents exactly why a single wrap around a
-   * multi-await async function does NOT protect a later call inside it —
-   * this mirrors that function's literal shape (get wrapped, then a
-   * SEPARATE put wrapped) rather than delegating to the generic
-   * patchRecord() helper, which would combine both into one un-safe wrap.
-   *
-   * The final get-then-put for the increment is a best-effort (non-atomic)
-   * read-modify-write, same class of race already accepted elsewhere in
-   * this codebase for count fields (e.g. retrievalCount's bump in
-   * SemanticSearch.ts) — a concurrent contribution from a DIFFERENT agent
-   * landing between this call's read and write could lose one increment.
-   * Re-fetching immediately before the write (rather than reusing the
-   * earlier existence-check read) narrows, without eliminating, that
-   * window. Not solved here: bounded, low-severity (an undercount, never an
-   * inflation), and orthogonal to the anti-gaming properties the cap/floor
-   * and dedup ledger actually defend.
-   */
-  private async _recordOne(
-    ctx: any,
-    agentId: string,
-    memoryId: string,
-    attribution: string | undefined,
-    now: string,
-  ): Promise<void> {
-    const ledgerId = `${agentId}:${memoryId}`;
-
-    // Bypasses resources/MemoryUsage.ts's own auth wrapper by design — this
-    // IS the trusted internal caller that resource's module doc describes
-    // (same "raw table object" pattern resources/Memory.ts uses for
-    // MemoryGrant).
-    const existingContribution = await withDetachedTxn(ctx, () =>
-      (databases as any).flair.MemoryUsage.get(ledgerId),
-    ).catch(() => null);
-    if (existingContribution) return; // already counted by this agent — silent no-op
-
-    const memoryExists = await withDetachedTxn(ctx, () => (databases as any).flair.Memory.get(memoryId)).catch(() => null);
-    if (!memoryExists) return; // no such memory — silent no-op (no enumeration)
-
-    const ledgerRecord: Record<string, unknown> = { id: ledgerId, agentId, memoryId, createdAt: now };
-    if (attribution) ledgerRecord.attribution = attribution;
-    // .put(), not .post(): Harper's raw TableResource has no default post()
-    // implementation for a static-style (non-`isCollection`-instantiated)
-    // call — confirmed live ("The MemoryUsage does not have a post method
-    // implemented", statusCode 405) — the SAME class of gotcha
-    // resources/Memory.ts documents for HTTP POST, but here it bites even
-    // this in-process call. Irrelevant anyway: ledgerId is already a
-    // deterministic composite key, so this is a create-with-explicit-id —
-    // exactly what PUT (upsert) is for, not an auto-generated-id insert.
-    await withDetachedTxn(ctx, () => (databases as any).flair.MemoryUsage.put(ledgerRecord));
-
-    // Targeted usageCount-ONLY bump: read-full-record, merge just this one
-    // field, write — against the RAW Memory table, NEVER Memory.put() (the
-    // resource class): that would 403 this cross-agent write via its
-    // ownership check, and bypassing that check directly would risk letting
-    // this endpoint smuggle OTHER field changes through instead of just the
-    // count (module doc's "WHY THIS IS ITS OWN ENDPOINT").
-    const fresh = await withDetachedTxn(ctx, () => (databases as any).flair.Memory.get(memoryId)).catch(() => null);
-    if (!fresh) return; // deleted between the checks above and now — no-op
-    await withDetachedTxn(ctx, () =>
-      (databases as any).flair.Memory.put({ ...fresh, usageCount: (fresh.usageCount ?? 0) + 1 }),
-    );
   }
 }

--- a/resources/mcp-tools.ts
+++ b/resources/mcp-tools.ts
@@ -191,6 +191,12 @@ async function memoryStore(agent: ResolvedAgent, args: any) {
   // folds it into provenance.claimed.client and strips it from the row.
   // Omitted entirely when the token carried no client_id.
   if (agent.clientId) body.claimedClient = agent.clientId;
+  // flair#744 slice A: citation-on-write — forward the optional
+  // usedMemoryIds array only when the caller actually supplied it, so an
+  // omitted citation list delegates a byte-identical body (Memory.post()
+  // consumes-and-strips this before the row is written, then credits each
+  // id post-commit through the shared usage ledger).
+  if (Array.isArray(args?.usedMemoryIds)) body.usedMemoryIds = args.usedMemoryIds;
   return unwrap(await h.post(body));
 }
 
@@ -456,6 +462,7 @@ export const TOOLS: Record<string, ToolEntry> = {
           type: { type: "string", enum: ["session", "lesson", "decision", "preference", "fact", "goal"], description: "Memory type (default session)" },
           durability: { type: "string", enum: ["permanent", "persistent", "standard", "ephemeral"], description: "permanent > persistent > standard > ephemeral (default standard)" },
           tags: { type: "array", items: { type: "string" }, description: "Tag strings" },
+          usedMemoryIds: { type: "array", items: { type: "string" }, description: "IDs of memories that informed this write (citation-on-write). Credited via the same deduped usage ledger as record_usage. Optional." },
         },
         required: ["content"],
       },

--- a/resources/trust-block.ts
+++ b/resources/trust-block.ts
@@ -137,8 +137,12 @@ export interface TrustBlock {
    */
   hasClaimedProvenance: boolean;
 
-  /** Verified-USE signal (flair#683 `usageCount`). Absent reads as 0. */
-  usageCount: number;
+  /**
+   * Verified-USE signal (flair#683 `usageCount`). `null` when no usage has
+   * been recorded — never a false `0`, so a reader can tell "no usage
+   * signal" apart from "recorded, zero uses".
+   */
+  usageCount: number | null;
 
   /**
    * Freshness / validity from the record's temporal window:
@@ -254,7 +258,7 @@ export function buildTrustBlock(record: TrustableRecord, now: number = Date.now(
     verifiedAuthor,
     verifiedAt,
     hasClaimedProvenance,
-    usageCount: typeof record.usageCount === "number" ? record.usageCount : 0,
+    usageCount: typeof record.usageCount === "number" ? record.usageCount : null,
     validityStatus,
     validFrom,
     validTo,

--- a/resources/usage-recording.ts
+++ b/resources/usage-recording.ts
@@ -1,0 +1,183 @@
+/**
+ * usage-recording.ts — shared usage-ledger recording core (flair#744 slice A,
+ * "citation-on-write"; extracted from RecordUsage.ts's flair#683 signal so
+ * there is exactly ONE implementation of the ledger logic, not two that can
+ * drift).
+ *
+ * Two callers share this core, both crediting the SAME deduped,
+ * principal-bound `MemoryUsage` ledger + the targeted `Memory.usageCount`
+ * bump:
+ *   - `POST /RecordUsage` (resources/RecordUsage.ts) — an agent explicitly
+ *     reports "I used this memory" as a standalone call.
+ *   - Citation-on-write (resources/Memory.ts's post()/put(), via
+ *     `recordCitations()` below) — an agent cites `usedMemoryIds` inline on a
+ *     memory WRITE; each cited id is credited the same way, post-commit and
+ *     failure-isolated from the write itself.
+ *
+ * `recordUsageContribution()` is an EXACT extraction of what was
+ * RecordUsage.ts's private `_recordOne()` — see its doc below for the
+ * ledger-then-count ordering, the individually-wrapped `withDetachedTxn`
+ * discipline, and the accepted best-effort race on the final
+ * read-modify-write. This move changes WHERE the logic lives, not what it
+ * does — behavior is byte-identical for RecordUsage.ts's existing callers.
+ *
+ * `recordCitations()` is the NEW batch helper citation-on-write uses: the
+ * same agent-required / cap / dedup / per-id failure-isolation shape as
+ * RecordUsage.post()'s loop, parameterized so Memory.ts can drive it from a
+ * write body instead of a dedicated POST body. It NEVER reads the ledger for
+ * authority — it only writes contributions; `usedMemoryIds` must never enter
+ * an access/scope/attribution/dedup decision (flair#744 slice A invariant 3).
+ */
+import { databases } from "@harperfast/harper";
+import { withDetachedTxn } from "./table-helpers.js";
+import type { AgentAuthVerdict } from "./agent-auth.js";
+
+/**
+ * Per-call cap on ids credited in one batch — shared by RecordUsage.post()'s
+ * validated `memoryIds` body (rejects a batch over the cap with a 400) and
+ * recordCitations()'s advisory `usedMemoryIds` (silently slices instead —
+ * see that function's doc for why the two differ here).
+ */
+export const MAX_USAGE_IDS_PER_CALL = 20;
+
+/**
+ * One (agentId, memoryId) contribution — the shared ledger-write core.
+ *
+ * Ledger-row-create FIRST, THEN the Memory.usageCount bump — so a crash
+ * between the two leaves the SAFE failure state (ledger row exists, count
+ * not yet bumped: a later retry just re-checks and no-ops) rather than the
+ * reverse (count bumped, no ledger row → a retry would double-count).
+ *
+ * Every discrete Harper call is wrapped INDIVIDUALLY in its own
+ * withDetachedTxn — never one wrap around a multi-step helper. A request
+ * that reads/writes MULTIPLE tables (or the same table twice) in sequence
+ * can otherwise inherit a closed transaction from a prior call's drained
+ * chain (table-helpers.ts's withDetachedTxn doc); resources/Memory.ts's
+ * closeSupersededRecord documents exactly why a single wrap around a
+ * multi-await async function does NOT protect a later call inside it —
+ * this mirrors that function's literal shape (get wrapped, then a
+ * SEPARATE put wrapped) rather than delegating to the generic
+ * patchRecord() helper, which would combine both into one un-safe wrap.
+ *
+ * The final get-then-put for the increment is a best-effort (non-atomic)
+ * read-modify-write, same class of race already accepted elsewhere in
+ * this codebase for count fields (e.g. retrievalCount's bump in
+ * SemanticSearch.ts) — a concurrent contribution from a DIFFERENT agent
+ * landing between this call's read and write could lose one increment.
+ * Re-fetching immediately before the write (rather than reusing the
+ * earlier existence-check read) narrows, without eliminating, that
+ * window. Not solved here: bounded, low-severity (an undercount, never an
+ * inflation), and orthogonal to the anti-gaming properties the cap/floor
+ * and dedup ledger actually defend.
+ *
+ * Called by RecordUsage.post() (explicit usage feedback) and by
+ * recordCitations() below (citation-on-write) — identical ledger semantics
+ * regardless of which surface triggered the contribution.
+ */
+export async function recordUsageContribution(
+  ctx: any,
+  agentId: string,
+  memoryId: string,
+  attribution: string | undefined,
+  now: string,
+): Promise<void> {
+  const ledgerId = `${agentId}:${memoryId}`;
+
+  // Bypasses resources/MemoryUsage.ts's own auth wrapper by design — this
+  // IS the trusted internal caller that resource's module doc describes
+  // (same "raw table object" pattern resources/Memory.ts uses for
+  // MemoryGrant).
+  const existingContribution = await withDetachedTxn(ctx, () =>
+    (databases as any).flair.MemoryUsage.get(ledgerId),
+  ).catch(() => null);
+  if (existingContribution) return; // already counted by this agent — silent no-op
+
+  const memoryExists = await withDetachedTxn(ctx, () => (databases as any).flair.Memory.get(memoryId)).catch(() => null);
+  if (!memoryExists) return; // no such memory — silent no-op (no enumeration)
+
+  const ledgerRecord: Record<string, unknown> = { id: ledgerId, agentId, memoryId, createdAt: now };
+  if (attribution) ledgerRecord.attribution = attribution;
+  // .put(), not .post(): Harper's raw TableResource has no default post()
+  // implementation for a static-style (non-`isCollection`-instantiated)
+  // call — confirmed live ("The MemoryUsage does not have a post method
+  // implemented", statusCode 405) — the SAME class of gotcha
+  // resources/Memory.ts documents for HTTP POST, but here it bites even
+  // this in-process call. Irrelevant anyway: ledgerId is already a
+  // deterministic composite key, so this is a create-with-explicit-id —
+  // exactly what PUT (upsert) is for, not an auto-generated-id insert.
+  await withDetachedTxn(ctx, () => (databases as any).flair.MemoryUsage.put(ledgerRecord));
+
+  // Targeted usageCount-ONLY bump: read-full-record, merge just this one
+  // field, write — against the RAW Memory table, NEVER Memory.put() (the
+  // resource class): that would 403 this cross-agent write via its
+  // ownership check, and bypassing that check directly would risk letting
+  // this write path smuggle OTHER field changes through instead of just the
+  // count (RecordUsage.ts module doc's "WHY THIS IS ITS OWN ENDPOINT").
+  const fresh = await withDetachedTxn(ctx, () => (databases as any).flair.Memory.get(memoryId)).catch(() => null);
+  if (!fresh) return; // deleted between the checks above and now — no-op
+  await withDetachedTxn(ctx, () =>
+    (databases as any).flair.Memory.put({ ...fresh, usageCount: (fresh.usageCount ?? 0) + 1 }),
+  );
+}
+
+/**
+ * Batch citation helper — credits every id in `usedMemoryIds` through
+ * `recordFn` (the real `recordUsageContribution` by default), one contribution
+ * per unique id, capped at `MAX_USAGE_IDS_PER_CALL`.
+ *
+ * Called by Memory.ts's post()/put() POST-COMMIT, wrapped in its own
+ * try/catch at the call site — this function itself never throws (every
+ * per-id failure is caught and logged below), but callers still isolate the
+ * call as a second line of defense so a write can never be affected by
+ * citation recording (flair#744 slice A invariant 1).
+ *
+ *   - `auth.kind !== "agent"` ⇒ return immediately, no-op. Internal/admin/
+ *     anonymous writes have no agent identity to attribute a contribution
+ *     TO — same rule RecordUsage.post() applies ("usage feedback requires a
+ *     verified agent identity").
+ *   - `usedMemoryIds` not a non-empty array of non-empty strings ⇒ no-op
+ *     (advisory field, never a validated request body — a malformed value
+ *     is silently ignored, never a 400).
+ *   - Deduped within the call (`[...new Set(...)]`), THEN capped at
+ *     MAX_USAGE_IDS_PER_CALL by slicing — a citation list is advisory, not a
+ *     validated request body, so an oversized list is trimmed rather than
+ *     rejected (unlike RecordUsage.post()'s validated `memoryIds`, which
+ *     400s over the same cap).
+ *   - Each id is credited independently: one id throwing never stops the
+ *     rest, and the failure is logged server-side, never surfaced to the
+ *     caller (the write already committed by the time this runs).
+ *
+ * `agentId` passed to `recordFn` is ALWAYS `auth.agentId` — the resolved
+ * auth context, never anything derived from `usedMemoryIds` or any other
+ * caller-supplied input (flair#744 slice A invariant 4: no forging on
+ * behalf of another identity).
+ */
+export async function recordCitations(
+  ctx: any,
+  auth: AgentAuthVerdict,
+  usedMemoryIds: unknown,
+  now: string,
+  recordFn: typeof recordUsageContribution = recordUsageContribution,
+): Promise<void> {
+  if (auth.kind !== "agent") return;
+
+  if (
+    !Array.isArray(usedMemoryIds) ||
+    usedMemoryIds.length === 0 ||
+    !usedMemoryIds.every((id) => typeof id === "string" && id.length > 0)
+  ) {
+    return;
+  }
+
+  const ids = [...new Set(usedMemoryIds as string[])].slice(0, MAX_USAGE_IDS_PER_CALL);
+
+  for (const id of ids) {
+    try {
+      await recordFn(ctx, auth.agentId, id, undefined, now);
+    } catch (err) {
+      // Never let one bad id stop the batch — same no-op-on-error discipline
+      // as RecordUsage.post()'s loop, log server-side only.
+      console.error("recordCitations: failed to credit (no-op)", { memoryId: id, err });
+    }
+  }
+}

--- a/scripts/flair-client.mjs
+++ b/scripts/flair-client.mjs
@@ -47,19 +47,24 @@ try {
       result = await flairFetch('GET', `/${table}/${rest[0]}`);
       break;
     case 'write': {
-      // Support --durability <level> and --supersedes <id> flags
+      // Support --durability <level>, --supersedes <id>, and --used <csv> flags
       const filteredRest = [];
       let durability = 'standard';
       let supersedes;
+      let usedMemoryIds;
       for (let i = 0; i < rest.length; i++) {
         if (rest[i] === '--durability' && rest[i + 1]) { durability = rest[++i]; }
         else if (rest[i] === '--supersedes' && rest[i + 1]) { supersedes = rest[++i]; }
+        else if (rest[i] === '--used' && rest[i + 1]) { usedMemoryIds = rest[++i].split(',').map(s => s.trim()).filter(Boolean); }
         else filteredRest.push(rest[i]);
       }
       const content = filteredRest.join(' ');
       const id = `${AGENT_ID}-${Date.now()}`;
       const body = { id, agentId: AGENT_ID, content, durability, createdAt: new Date().toISOString() };
       if (supersedes) body.supersedes = supersedes;
+      // flair#744 slice A: citation-on-write — only set when --used was
+      // given, so omitting the flag is byte-identical to before.
+      if (usedMemoryIds) body.usedMemoryIds = usedMemoryIds;
       result = await flairFetch('PUT', `/${table}/${id}`, body);
       break;
     }

--- a/test/integration/citation-on-write-e2e.test.ts
+++ b/test/integration/citation-on-write-e2e.test.ts
@@ -1,0 +1,270 @@
+// Citation-on-write (flair#744 slice A) e2e — real-Harper integration tests.
+//
+// WHY THIS FILE EXISTS: mirrors test/integration/record-usage-e2e.test.ts
+// (same real-Harper spawn / signed TPS-Ed25519 request pattern) for the NEW
+// `usedMemoryIds` write-time surface. citation-on-write is a thin, post-commit
+// wrapper around the SAME shared ledger core RecordUsage.ts uses
+// (resources/usage-recording.ts), so this file focuses on the properties that
+// are SPECIFIC to the write-surface integration — the ledger-sharing/dedup
+// parity itself, cross-agent isolation, out-of-scope/nonexistent-id silent
+// drop, post-commit write-success isolation, and that `usedMemoryIds` is
+// never persisted on the row — rather than re-proving every RecordUsage
+// property (auth/no-enumeration/attribution-sanitization) already covered
+// there against the identical underlying ledger.
+import { describe, expect, test, beforeAll, afterAll } from "bun:test";
+import nacl from "tweetnacl";
+import { randomUUID } from "node:crypto";
+import { startHarper, stopHarper, HarperInstance } from "../helpers/harper-lifecycle";
+
+interface TestAgent { id: string; publicKey: string; secretKey: Uint8Array; }
+
+function mkAgent(id: string): TestAgent {
+  const kp = nacl.sign.keyPair();
+  return { id, publicKey: Buffer.from(kp.publicKey).toString("base64"), secretKey: kp.secretKey };
+}
+
+function ed25519Header(agent: TestAgent, method: string, path: string): string {
+  const ts = Date.now().toString();
+  const nonce = randomUUID();
+  const payload = `${agent.id}:${ts}:${nonce}:${method}:${path}`;
+  const sig = nacl.sign.detached(new TextEncoder().encode(payload), agent.secretKey);
+  const sigB64 = Buffer.from(sig).toString("base64");
+  return `TPS-Ed25519 ${agent.id}:${ts}:${nonce}:${sigB64}`;
+}
+
+async function adminOp(harper: HarperInstance, op: Record<string, any>): Promise<Response> {
+  return fetch(harper.opsURL, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: "Basic " + btoa(`${harper.admin.username}:${harper.admin.password}`),
+    },
+    body: JSON.stringify(op),
+  });
+}
+
+async function registerAgent(harper: HarperInstance, agent: TestAgent): Promise<void> {
+  const res = await adminOp(harper, {
+    operation: "insert", database: "flair", table: "Agent",
+    records: [{ id: agent.id, name: agent.id, role: "agent", publicKey: agent.publicKey, createdAt: new Date().toISOString() }],
+  });
+  expect(res.status, `Agent insert for ${agent.id} returned ${res.status}`).toBe(200);
+}
+
+/** Signed PUT to /Memory/<id> — the only HTTP-reachable Memory create/update
+ *  path, and one of the two write surfaces citation-on-write hooks (put()). */
+async function putMemory(harper: HarperInstance, agent: TestAgent, id: string, body: Record<string, any>): Promise<Response> {
+  const path = `/Memory/${id}`;
+  return fetch(`${harper.httpURL}${path}`, {
+    method: "PUT",
+    headers: { Authorization: ed25519Header(agent, "PUT", path), "Content-Type": "application/json" },
+    body: JSON.stringify({ id, ...body }),
+  });
+}
+
+/** Signed GET /Memory/<id>. */
+async function getMemory(harper: HarperInstance, agent: TestAgent, id: string): Promise<Response> {
+  const path = `/Memory/${id}`;
+  return fetch(`${harper.httpURL}${path}`, {
+    headers: { Authorization: ed25519Header(agent, "GET", path) },
+  });
+}
+
+/** Signed POST /RecordUsage — used to prove dedup PARITY with citation-on-write
+ *  (same shared ledger, so a citation and a RecordUsage call on the same
+ *  (agent, memory) pair must contribute at most 1, not 2). */
+async function recordUsage(harper: HarperInstance, agent: TestAgent, body: Record<string, any>): Promise<{ status: number; body: any }> {
+  const path = "/RecordUsage";
+  const res = await fetch(`${harper.httpURL}${path}`, {
+    method: "POST",
+    headers: { Authorization: ed25519Header(agent, "POST", path), "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  const text = await res.text();
+  let parsed: any; try { parsed = JSON.parse(text); } catch { parsed = text; }
+  return { status: res.status, body: parsed };
+}
+
+let harper: HarperInstance;
+
+describe("citation-on-write e2e (real Harper) — flair#744 slice A", () => {
+  beforeAll(async () => {
+    harper = await startHarper();
+  }, 180_000);
+
+  afterAll(async () => {
+    if (harper) await stopHarper(harper);
+  });
+
+  test("citing a memory on write bumps its usageCount through the SAME shared ledger as POST /RecordUsage", async () => {
+    const owner = mkAgent(`cow-owner-${randomUUID()}`);
+    const citer = mkAgent(`cow-citer-${randomUUID()}`);
+    await registerAgent(harper, owner);
+    await registerAgent(harper, citer);
+
+    const citedId = `${owner.id}-cited`;
+    const putCited = await putMemory(harper, owner, citedId, { agentId: owner.id, content: "The cited memory, long enough for the dedup gate to consider.", durability: "standard" });
+    expect(putCited.status).toBe(200);
+
+    const newId = `${citer.id}-citing-write`;
+    const putCiting = await putMemory(harper, citer, newId, {
+      agentId: citer.id,
+      content: "A new memory that cites the earlier one above.",
+      durability: "standard",
+      usedMemoryIds: [citedId],
+    });
+    expect(putCiting.status, `citing write returned ${putCiting.status}: ${JSON.stringify(await putCiting.clone().json().catch(() => null))}`).toBe(200);
+
+    const check = await getMemory(harper, owner, citedId);
+    const rec: any = await check.json();
+    expect(rec.usageCount).toBe(1);
+  }, 60_000);
+
+  test("usedMemoryIds is stripped — NEVER persisted on the writing memory's own row", async () => {
+    const owner = mkAgent(`cow-strip-owner-${randomUUID()}`);
+    const citer = mkAgent(`cow-strip-citer-${randomUUID()}`);
+    await registerAgent(harper, owner);
+    await registerAgent(harper, citer);
+
+    const citedId = `${owner.id}-cited`;
+    await putMemory(harper, owner, citedId, { agentId: owner.id, content: "Cited memory for the strip test, long enough for the gate.", durability: "standard" });
+
+    const newId = `${citer.id}-citing`;
+    const putRes = await putMemory(harper, citer, newId, {
+      agentId: citer.id,
+      content: "This write carries usedMemoryIds, which must never land on its own row.",
+      durability: "standard",
+      usedMemoryIds: [citedId],
+    });
+    expect(putRes.status).toBe(200);
+
+    const check = await getMemory(harper, citer, newId);
+    const rec: any = await check.json();
+    expect(rec.usedMemoryIds).toBeUndefined();
+  }, 60_000);
+
+  test("dedup PARITY: citing the same memory via citation-on-write AND POST /RecordUsage contributes AT MOST 1 (same ledger key)", async () => {
+    const owner = mkAgent(`cow-parity-owner-${randomUUID()}`);
+    const citer = mkAgent(`cow-parity-citer-${randomUUID()}`);
+    await registerAgent(harper, owner);
+    await registerAgent(harper, citer);
+
+    const citedId = `${owner.id}-cited`;
+    await putMemory(harper, owner, citedId, { agentId: owner.id, content: "Dedup-parity cited memory, long enough for the gate.", durability: "standard" });
+
+    // First contribution via citation-on-write.
+    const citingId = `${citer.id}-citing`;
+    const putRes = await putMemory(harper, citer, citingId, {
+      agentId: citer.id, content: "First contribution via citation-on-write.", durability: "standard",
+      usedMemoryIds: [citedId],
+    });
+    expect(putRes.status).toBe(200);
+
+    const afterCitation = await getMemory(harper, owner, citedId);
+    expect((await afterCitation.json()).usageCount).toBe(1);
+
+    // SAME (citer, citedId) pair reported again via the standalone endpoint —
+    // shares the identical ledger key `${agentId}:${memoryId}`, so this must
+    // be a no-op, not a second increment.
+    const ru = await recordUsage(harper, citer, { memoryIds: [citedId] });
+    expect(ru.status).toBe(200);
+
+    const afterRecordUsage = await getMemory(harper, owner, citedId);
+    expect((await afterRecordUsage.json()).usageCount).toBe(1); // still 1 — NOT 2
+  }, 60_000);
+
+  test("cross-agent isolation: agent B citing agent A's memory credits it under B's ledger key; A's own later citation is an INDEPENDENT contribution", async () => {
+    const owner = mkAgent(`cow-cross-owner-${randomUUID()}`);
+    const agentB = mkAgent(`cow-cross-b-${randomUUID()}`);
+    await registerAgent(harper, owner);
+    await registerAgent(harper, agentB);
+
+    const citedId = `${owner.id}-cited`;
+    await putMemory(harper, owner, citedId, { agentId: owner.id, content: "Cross-agent-isolation cited memory, long enough for the gate.", durability: "standard" });
+
+    // Agent B cites owner's memory on a write of B's own.
+    const bWriteId = `${agentB.id}-citing`;
+    const bPut = await putMemory(harper, agentB, bWriteId, {
+      agentId: agentB.id, content: "B's write citing owner's memory.", durability: "standard",
+      usedMemoryIds: [citedId],
+    });
+    expect(bPut.status).toBe(200);
+
+    const afterB = await getMemory(harper, owner, citedId);
+    expect((await afterB.json()).usageCount).toBe(1);
+
+    // Owner (A) later cites their OWN memory on a separate write — a
+    // DIFFERENT ledger key (`${owner.id}:${citedId}` vs `${agentB.id}:${citedId}`),
+    // so it must independently add a second contribution, not collide with B's.
+    const aWriteId = `${owner.id}-self-citing`;
+    const aPut = await putMemory(harper, owner, aWriteId, {
+      agentId: owner.id, content: "Owner's own later write, self-citing the earlier memory.", durability: "standard",
+      usedMemoryIds: [citedId],
+    });
+    expect(aPut.status).toBe(200);
+
+    const afterA = await getMemory(harper, owner, citedId);
+    expect((await afterA.json()).usageCount).toBe(2); // two DISTINCT ledger keys = 2
+  }, 60_000);
+
+  test("out-of-scope / nonexistent cited id is silently dropped — the write still succeeds (200) with no error surfaced", async () => {
+    const citer = mkAgent(`cow-oos-citer-${randomUUID()}`);
+    await registerAgent(harper, citer);
+
+    const nonexistentId = `does-not-exist-${randomUUID()}`;
+    const newId = `${citer.id}-citing-nonexistent`;
+    const putRes = await putMemory(harper, citer, newId, {
+      agentId: citer.id,
+      content: "This write cites an id that does not exist.",
+      durability: "standard",
+      usedMemoryIds: [nonexistentId],
+    });
+    expect(putRes.status, `write returned ${putRes.status}: ${JSON.stringify(await putRes.clone().json().catch(() => null))}`).toBe(200);
+    const body: any = await putRes.json();
+    expect(body.written).toBe(true);
+    expect(body.error).toBeUndefined();
+  }, 60_000);
+
+  test("post-commit isolation: the write's response shape is IDENTICAL whether or not usedMemoryIds is present (citation recording never leaks into the write response)", async () => {
+    const owner = mkAgent(`cow-shape-owner-${randomUUID()}`);
+    const citer = mkAgent(`cow-shape-citer-${randomUUID()}`);
+    await registerAgent(harper, owner);
+    await registerAgent(harper, citer);
+
+    const citedId = `${owner.id}-cited`;
+    await putMemory(harper, owner, citedId, { agentId: owner.id, content: "Shape-parity cited memory, long enough for the gate.", durability: "standard" });
+
+    const plainId = `${citer.id}-plain`;
+    const plainRes = await putMemory(harper, citer, plainId, { agentId: citer.id, content: "A plain write with no citations.", durability: "standard" });
+    expect(plainRes.status).toBe(200);
+    const plainBody: any = await plainRes.json();
+
+    const citingId = `${citer.id}-citing`;
+    const citingRes = await putMemory(harper, citer, citingId, {
+      agentId: citer.id, content: "A write that cites a memory, mixed with one nonexistent id too.", durability: "standard",
+      usedMemoryIds: [citedId, `nonexistent-${randomUUID()}`],
+    });
+    expect(citingRes.status).toBe(200);
+    const citingBody: any = await citingRes.json();
+
+    // Same top-level response shape — citation recording (success, partial
+    // no-op, or an internal failure) never adds/removes/changes fields on
+    // the write response itself.
+    expect(Object.keys(citingBody).sort()).toEqual(Object.keys(plainBody).sort());
+    expect(citingBody.written).toBe(true);
+    expect(citingBody.deduplicated).toBe(false);
+  }, 60_000);
+
+  test("omitted usedMemoryIds ⇒ no ledger side effect at all (byte-identical to a pre-slice-A write)", async () => {
+    const owner = mkAgent(`cow-omit-owner-${randomUUID()}`);
+    await registerAgent(harper, owner);
+    const id = `${owner.id}-plain`;
+    const putRes = await putMemory(harper, owner, id, { agentId: owner.id, content: "A completely ordinary write with no usedMemoryIds field at all.", durability: "standard" });
+    expect(putRes.status).toBe(200);
+
+    const check = await getMemory(harper, owner, id);
+    const rec: any = await check.json();
+    expect(rec.usageCount ?? 0).toBe(0);
+    expect(rec.usedMemoryIds).toBeUndefined();
+  }, 30_000);
+});

--- a/test/unit/trust-block.test.ts
+++ b/test/unit/trust-block.test.ts
@@ -98,12 +98,15 @@ describe("buildTrustBlock — provenance status (verified vs claimed)", () => {
   });
 });
 
-describe("buildTrustBlock — usage signal", () => {
-  it("maps usageCount", () => {
-    expect(buildTrustBlock({ agentId: "a", usageCount: 7 }, NOW).usageCount).toBe(7);
+describe("buildTrustBlock — usage signal (flair#744 slice A: absent-vs-0 fix)", () => {
+  it("maps a positive usageCount", () => {
+    expect(buildTrustBlock({ agentId: "a", usageCount: 3 }, NOW).usageCount).toBe(3);
   });
-  it("absent usageCount reads as 0", () => {
-    expect(buildTrustBlock({ agentId: "a" }, NOW).usageCount).toBe(0);
+  it("maps an explicit usageCount: 0 (recorded, zero uses) as 0, NOT null", () => {
+    expect(buildTrustBlock({ agentId: "a", usageCount: 0 }, NOW).usageCount).toBe(0);
+  });
+  it("absent usageCount reads as null — never a false 0 — so a reader can tell 'no usage signal' apart from 'recorded, zero uses'", () => {
+    expect(buildTrustBlock({ agentId: "a" }, NOW).usageCount).toBeNull();
   });
 });
 

--- a/test/unit/usage-recording.test.ts
+++ b/test/unit/usage-recording.test.ts
@@ -1,0 +1,158 @@
+/**
+ * usage-recording.test.ts — resources/usage-recording.ts's recordCitations()
+ * (flair#744 slice A: citation-on-write).
+ *
+ * Pure unit coverage via the `recordFn` injection seam — no Harper.
+ * `recordUsageContribution()` itself (the real ledger-write core, moved
+ * unchanged from RecordUsage.ts's former private `_recordOne()`) already has
+ * end-to-end coverage via test/integration/record-usage-e2e.test.ts (real
+ * Harper); this file covers ONLY recordCitations()'s batch-orchestration
+ * contract in isolation: auth gating, validation, dedup+cap, per-id failure
+ * isolation, and that the agentId credited is always the resolved auth
+ * context's — never anything derived from the ids/args (flair#744 slice A
+ * invariant 4).
+ */
+import { mock, describe, it, expect } from "bun:test";
+import type { AgentAuthVerdict } from "../../resources/agent-auth.ts";
+
+// resources/usage-recording.ts imports `databases` from @harperfast/harper,
+// whose module chain throws when loaded outside a Harper runtime (the same
+// gotcha test/unit/resolve-agent-auth.test.ts documents for agent-auth.ts).
+// Mock it — every test below drives recordCitations() exclusively through
+// the injected `recordFn` seam, so this stub is never actually touched; it
+// exists purely so importing the module under test doesn't throw.
+mock.module("@harperfast/harper", () => ({
+  databases: { flair: { Memory: { get: async () => null }, MemoryUsage: { get: async () => null, put: async () => {} } } },
+  Resource: class {},
+}));
+
+const { recordCitations, MAX_USAGE_IDS_PER_CALL } = await import("../../resources/usage-recording.ts");
+
+const AGENT: AgentAuthVerdict = { kind: "agent", agentId: "agt_citer", isAdmin: false };
+const NOW = "2026-07-21T00:00:00.000Z";
+
+interface Call {
+  agentId: string;
+  memoryId: string;
+  attribution: string | undefined;
+  now: string;
+}
+
+/** A recorder double that records every call it receives — never throws. */
+function trackingRecorder(): {
+  fn: (ctx: any, agentId: string, memoryId: string, attribution: string | undefined, now: string) => Promise<void>;
+  calls: Call[];
+} {
+  const calls: Call[] = [];
+  const fn = async (_ctx: any, agentId: string, memoryId: string, attribution: string | undefined, now: string) => {
+    calls.push({ agentId, memoryId, attribution, now });
+  };
+  return { fn, calls };
+}
+
+describe("recordCitations — non-agent auth is a silent no-op", () => {
+  // AgentAuthVerdict's non-"agent" kinds are "internal" (trusted in-process
+  // call, no per-agent identity) and "anonymous" (HTTP request, no verified
+  // agent) — same "requires a verified agent identity" rule RecordUsage.post()
+  // applies. Neither has an agentId to credit a contribution TO.
+  it("kind: internal ⇒ recorder never called", async () => {
+    const { fn, calls } = trackingRecorder();
+    await recordCitations({}, { kind: "internal" }, ["m1", "m2"], NOW, fn);
+    expect(calls).toEqual([]);
+  });
+
+  it("kind: anonymous ⇒ recorder never called", async () => {
+    const { fn, calls } = trackingRecorder();
+    await recordCitations({}, { kind: "anonymous" }, ["m1", "m2"], NOW, fn);
+    expect(calls).toEqual([]);
+  });
+});
+
+describe("recordCitations — usedMemoryIds validation (advisory field, no-op never throws)", () => {
+  it("empty array ⇒ recorder never called", async () => {
+    const { fn, calls } = trackingRecorder();
+    await recordCitations({}, AGENT, [], NOW, fn);
+    expect(calls).toEqual([]);
+  });
+
+  it("missing (undefined) ⇒ recorder never called", async () => {
+    const { fn, calls } = trackingRecorder();
+    await recordCitations({}, AGENT, undefined, NOW, fn);
+    expect(calls).toEqual([]);
+  });
+
+  it("non-array ⇒ recorder never called", async () => {
+    const { fn, calls } = trackingRecorder();
+    await recordCitations({}, AGENT, "m1" as any, NOW, fn);
+    expect(calls).toEqual([]);
+  });
+
+  it("array containing an empty-string entry ⇒ the whole call is a no-op", async () => {
+    const { fn, calls } = trackingRecorder();
+    await recordCitations({}, AGENT, ["m1", "", "m2"], NOW, fn);
+    expect(calls).toEqual([]);
+  });
+
+  it("array containing a non-string entry ⇒ the whole call is a no-op", async () => {
+    const { fn, calls } = trackingRecorder();
+    await recordCitations({}, AGENT, ["m1", 42 as any], NOW, fn);
+    expect(calls).toEqual([]);
+  });
+});
+
+describe("recordCitations — dedup + cap", () => {
+  it("duplicate ids are deduped within the call — each unique id credited once", async () => {
+    const { fn, calls } = trackingRecorder();
+    await recordCitations({}, AGENT, ["m1", "m2", "m1", "m2", "m1"], NOW, fn);
+    expect(calls.length).toBe(2);
+    expect(new Set(calls.map((c: Call) => c.memoryId))).toEqual(new Set(["m1", "m2"]));
+  });
+
+  it("more than MAX_USAGE_IDS_PER_CALL unique ids ⇒ recorder called exactly the cap — sliced, not rejected", async () => {
+    const ids = Array.from({ length: MAX_USAGE_IDS_PER_CALL + 15 }, (_, i) => `m${i}`);
+    const { fn, calls } = trackingRecorder();
+    await recordCitations({}, AGENT, ids, NOW, fn);
+    expect(calls.length).toBe(MAX_USAGE_IDS_PER_CALL);
+  });
+});
+
+describe("recordCitations — per-id failure isolation (post-commit safety)", () => {
+  it("a recorder that throws on one id still attempts every OTHER id, and recordCitations itself never throws", async () => {
+    const seen: string[] = [];
+    const throwingFn = async (_ctx: any, _agentId: string, memoryId: string) => {
+      seen.push(memoryId);
+      if (memoryId === "bad") throw new Error("simulated ledger failure");
+    };
+    await expect(recordCitations({}, AGENT, ["m1", "bad", "m2"], NOW, throwingFn as any)).resolves.toBeUndefined();
+    expect(seen).toEqual(["m1", "bad", "m2"]);
+  });
+
+  it("every id throwing still resolves cleanly (no unhandled rejection)", async () => {
+    const alwaysThrows = async () => {
+      throw new Error("simulated ledger failure");
+    };
+    await expect(recordCitations({}, AGENT, ["m1", "m2", "m3"], NOW, alwaysThrows as any)).resolves.toBeUndefined();
+  });
+});
+
+describe("recordCitations — agentId/attribution provenance (invariant 4: from auth context only)", () => {
+  it("agentId credited to every recorded id is auth.agentId, never derived from the cited ids or any other input", async () => {
+    const { fn, calls } = trackingRecorder();
+    const auth: AgentAuthVerdict = { kind: "agent", agentId: "agt_the_real_citer", isAdmin: false };
+    await recordCitations({}, auth, ["some-other-agent-mem-1", "some-other-agent-mem-2"], NOW, fn);
+    expect(calls.length).toBe(2);
+    expect(calls.every((c: Call) => c.agentId === "agt_the_real_citer")).toBe(true);
+  });
+
+  it("attribution passed to the recorder is always undefined for citation-on-write (Slice A)", async () => {
+    const { fn, calls } = trackingRecorder();
+    await recordCitations({}, AGENT, ["m1"], NOW, fn);
+    expect(calls[0].attribution).toBeUndefined();
+  });
+
+  it("`now` is threaded through to the recorder unchanged", async () => {
+    const { fn, calls } = trackingRecorder();
+    await recordCitations({}, AGENT, ["m1"], NOW, fn);
+    expect(calls[0].now).toBe(NOW);
+  });
+});


### PR DESCRIPTION
## Citation-on-write (flair#744 slice A, closes part of #775)

Optional `usedMemoryIds?: string[]` on the memory **write** surfaces. After a write succeeds, each cited id is credited through the **same** deduped, principal-bound usage ledger as `POST /RecordUsage` (flair#683). The ledger-write core is extracted to `resources/usage-recording.ts` so there is exactly **one** implementation shared by both surfaces — no duplicated dedup/anti-gaming logic.

### Surfaces
- REST write (`Memory.post`/`put`) — accepts `usedMemoryIds`, consumes-and-strips it before the row is written.
- MCP `memory_store` — new optional `usedMemoryIds` arg.
- `flair-client write --used <csv>`.

### Invariants
1. **Post-commit / non-blocking** — the memory write succeeds and returns its normal response even if crediting fails; failures log server-side, never surface.
2. **Read-scope validated, silent drop** — cited ids that don't exist / aren't readable are silently dropped (no enumeration); uniform handling, not timing-distinguishable. Reuses RecordUsage's existing existence check.
3. **Zero-authority untouched** — the citation path only *writes* the ledger, never *reads* it for authority; `usedMemoryIds` never enters an access/scope/attribution/dedup decision.
4. **agentId from auth context, never caller-supplied** — ledger key `{writerAgentId}:{citedMemoryId}`; a caller cannot credit on behalf of another identity.
5. **Omitted param ⇒ byte-identical behavior.**

### Trust-block absent-vs-0 fix
`buildTrustBlock` now emits `usageCount: null` (not a false `0`) when no usage has been recorded, so a reader can tell "no usage signal" from "recorded, zero uses".

### Tests
- Pure unit (`test/unit/usage-recording.test.ts`): citation batch helper — agent-only, cap, dedup, per-id failure isolation, agentId provenance; trust-block absent→null.
- Real-Harper e2e (`test/integration/citation-on-write-e2e.test.ts`): ledger dedup parity with `POST /RecordUsage`, cross-agent isolation, out-of-scope silent drop, post-commit response-shape parity, non-persistence, omitted byte-identity.
- Full unit suite **2757/0**; the zero-authority and no-per-principal tripwires stay green (no authority coupling added).

### Not in this slice
Slice B (client act-on affordances) and consumer adoption (first-party clients citing on write) are follow-ups. Note: `record_usage` / the usage signal isn't documented outside code comments + CHANGELOG today, and the README MCP tool table is already incomplete — left as a separate pre-existing docs gap rather than an unrelated docs-architecture call here.