### PR TITLE
fix(upgrade): never roll back a healthy instance on a credentials-only verify failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## [Unreleased]
 
+### Fixed — `flair upgrade` no longer rolls back a healthy instance it just can't authenticate to
+
+`flair upgrade`'s post-restart verification treated "the server responded but the verifier couldn't authenticate" (a 401/403 on the authenticated `/HealthDetail`) the same as "the upgrade broke the instance" — it triggered a rollback, whose own re-verify hit the identical missing-credential wall, leaving the operator with a false `ROLLBACK ALSO FAILED VERIFICATION — instance state is UNKNOWN` for an instance that was healthy the entire time. This bit a real `0.22.1 → 0.25.0` upgrade on a machine with no admin-pass/agent key: `/HealthDetail` became a *verified-read* (flair#747), so the verifier authenticated fine against the pre-upgrade version but not post-restart, and the pre-flight credential check can't anticipate a version that changes `/HealthDetail`'s auth requirement.
+
+- A credentials-only failure (`isCredentialOnlyFailure`: healthy instance, authenticated-leg rejected with 401/403) on the post-restart verification now resolves to a new **`healthy-unverified`** outcome — the upgrade is reported **complete**, with a clear note that the version couldn't be verified and how to enable full verification (`FLAIR_ADMIN_PASS` / `flair init`). It **never rolls back**: the public `/Health` already proved the server is up, and a version we can't *read* is not grounds to roll back a *running* instance. This supersedes flair#741 fix #3's "prefer the known-good version" default, which the incident proved wrong for a healthy instance.
+- Scoped strictly to credentials: a genuine server-side failure (unhealthy `/Health`, a 5xx, or a network error on the authenticated leg) still rolls back exactly as before.
+
 ## [0.25.0] - 2026-07-21
 
 ### Trust-graded recall — citation-on-write (flair#744 slice A)

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1934,12 +1934,29 @@ export function shouldRunFleetVerify(opts: { fleetVerify?: boolean }): boolean {
  */
 export type UpgradeVerifyAction =
   | { kind: "ok" }
+  | { kind: "healthy-unverified"; reason: string }
   | { kind: "rollback"; reason: string; toVersion: string }
   | { kind: "cannot-rollback"; reason: string };
 
 export function decideAfterVerify(result: ProbeResult, previousVersion: string | null): UpgradeVerifyAction {
   if (result.ok) return { kind: "ok" };
   const reason = result.error ?? "post-restart verification failed";
+  // A HEALTHY instance whose ONLY failure was that the verifier couldn't
+  // authenticate (401/403) is demonstrably UP: the public /Health answered
+  // 2xx AND the server responded to the authenticated probe — it rejected our
+  // credentials, it did not fail to respond. A version we couldn't READ is not
+  // grounds to roll back a RUNNING instance. Rolling back here is destructive
+  // AND self-defeating — the rollback's own re-verify hits the identical
+  // missing-credential wall, producing the false "ROLLBACK ALSO FAILED / state
+  // UNKNOWN" for an instance that was healthy the whole time. (The real
+  // incident: /HealthDetail became a verified-read in flair#747, so a machine
+  // with no admin-pass/agent key authenticates fine against the pre-upgrade
+  // version but not post-restart — the pre-flight credential check can't
+  // anticipate a version that changes /HealthDetail's auth requirement.)
+  // Report it as up-but-unverified and NEVER roll back. This supersedes
+  // flair#741 fix #3's "prefer the known-good version" default, which the
+  // incident proved wrong for a healthy instance.
+  if (isCredentialOnlyFailure(result)) return { kind: "healthy-unverified", reason };
   if (!previousVersion) return { kind: "cannot-rollback", reason };
   return { kind: "rollback", reason, toVersion: previousVersion };
 }
@@ -9205,18 +9222,23 @@ program
       return;
     }
 
-    console.error(`❌ post-restart verification failed: ${verdict.reason}`);
-    if (isCredentialOnlyFailure(verify)) {
-      // flair#741 fix #3: a responding server that rejects the verifier's
-      // credentials proves the instance is UP — it is not evidence the
-      // upgrade itself broke anything. Say so explicitly instead of leaving
-      // the reader to infer it from the raw error text. Rollback still
-      // proceeds below (a credential check that worked pre-upgrade — see
-      // the pre-flight above — and stopped working mid-run is an edge case
-      // ambiguous enough that "prefer the known-good version" is still the
-      // safer default), but the reason for it is now honest.
-      console.error("   The instance is up and responded — the verifier could not authenticate. This is not a sign the upgrade broke anything.");
+    // flair#741 follow-through: a healthy instance the verifier just couldn't
+    // authenticate against. The upgrade SUCCEEDED — the new version's server is
+    // up (public /Health passed); we simply couldn't read its version over the
+    // authenticated /HealthDetail. Report the caveat and STOP — never roll back
+    // a running instance over a credentials gap. (decideAfterVerify only
+    // returns this for isCredentialOnlyFailure(verify), so the old
+    // "print an honest note but roll back anyway" branch that used to sit below
+    // is gone — that credentials case can no longer reach the rollback path.)
+    if (verdict.kind === "healthy-unverified") {
+      console.log(`✅ upgrade complete: the instance is up and healthy${expectedFlairVersion ? ` on @tpsdev-ai/flair@${expectedFlairVersion}` : ""}.`);
+      console.log(`   The version could not be verified — the checker couldn't authenticate to /HealthDetail (${verdict.reason}).`);
+      console.log("   The server is confirmed running (public /Health passed); this is a verification gap, not an upgrade failure — nothing was rolled back.");
+      console.log("   To enable full post-upgrade verification: set FLAIR_ADMIN_PASS, or run `flair init` to provision ~/.flair/admin-pass or an agent key.");
+      return;
     }
+
+    console.error(`❌ post-restart verification failed: ${verdict.reason}`);
 
     if (verdict.kind === "cannot-rollback") {
       console.error("   Cannot roll back automatically: the previously-installed @tpsdev-ai/flair version is unknown.");

--- a/test/unit/upgrade-verify-rollback.test.ts
+++ b/test/unit/upgrade-verify-rollback.test.ts
@@ -132,6 +132,30 @@ describe("decideAfterVerify", () => {
     expect(decision.kind).toBe("rollback");
   });
 
+  // flair#741 follow-through: a healthy instance whose ONLY failure is that the
+  // verifier couldn't authenticate (credentials-only) must NOT roll back — the
+  // server is provably up (public /Health passed AND it responded to the authed
+  // probe), and rolling it back is exactly the destructive false-alarm the
+  // incident report described (rollback re-verify fails identically → false
+  // "state UNKNOWN").
+  test("credentials-only failure on a healthy instance → healthy-unverified, NEVER rollback", () => {
+    const decision = decideAfterVerify(credentialOnlyFailure, "1.2.2");
+    expect(decision.kind).toBe("healthy-unverified");
+    if (decision.kind === "healthy-unverified") {
+      expect(decision.reason).toContain("no credentials sent");
+    }
+  });
+
+  test("credentials-only failure → healthy-unverified even when previous version is unknown (a running instance is never rolled back)", () => {
+    const decision = decideAfterVerify(credentialOnlyFailure, null);
+    expect(decision.kind).toBe("healthy-unverified");
+  });
+
+  test("server-side auth-leg failure (5xx/network, not credentials) still rolls back — the fix is scoped to credentials only", () => {
+    const decision = decideAfterVerify(serverAuthFailure, "1.2.2");
+    expect(decision.kind).toBe("rollback");
+  });
+
   test("failing ProbeResult but previous version is unknown (null) → cannot-rollback, never guesses a target", () => {
     const decision = decideAfterVerify(mismatch, null);
     expect(decision.kind).toBe("cannot-rollback");


### PR DESCRIPTION
## `flair upgrade` no longer rolls back a healthy instance it just can't authenticate to

### The bug (real incident, 0.22.1 → 0.25.0)
`flair upgrade`'s post-restart verification treated **"the server responded but the verifier couldn't authenticate"** (a 401/403 on the authenticated `/HealthDetail`) the same as **"the upgrade broke the instance"** — it triggered a rollback, whose own re-verify hit the identical missing-credential wall, ending in a false:

```
❌❌ ROLLBACK ALSO FAILED VERIFICATION: ... HTTP 403: no credentials sent
   Instance state is UNKNOWN — do not assume data integrity.
```

…for an instance that was **healthy the entire time** (`flair status` → `✓ running, ✓ all checks passing`).

### Root cause
`/HealthDetail` became a **verified-read** in flair#747. A machine with no admin-pass/agent key authenticates fine against the *pre-upgrade* version but not *post-restart* — and the pre-flight credential check (flair#741 fix #1) can't anticipate a version that changes `/HealthDetail`'s auth requirement. flair#741 fix #3 deliberately chose to "prefer the known-good version" and roll back anyway; this incident proved that default wrong for a **healthy** instance.

### The fix
`decideAfterVerify` returns a new **`healthy-unverified`** outcome for a credentials-only failure (`isCredentialOnlyFailure`: healthy instance + authed leg rejected 401/403). The upgrade is reported **complete**, with a clear note that the version couldn't be verified and how to enable full verification (`FLAIR_ADMIN_PASS` / `flair init`) — and it **never rolls back**. The public `/Health` already proved the server is up; a version we can't *read* is not grounds to roll back a *running* instance.

- **Scoped strictly to credentials.** Unhealthy `/Health`, a 5xx, or a network error on the authenticated leg still roll back exactly as before.
- The now-dead honest-messaging-then-rollback branch (flair#741 fix #3) is removed.

### Tests
`test/unit/upgrade-verify-rollback.test.ts`: credentials-only failure → `healthy-unverified` (incl. previous-version-unknown — a running instance is never rolled back); server-side auth failure → still `rollback` (scoping proof). Full unit suite **2760/0**; typecheck clean (one pre-existing unrelated `auth-middleware.ts` error).

Targeted as patch **0.25.1**.