### PR TITLE
docs: README refresh — trust-graded recall section + accuracy fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+### Docs — README refresh (trust-graded recall + accuracy fixes)
+
+- Added a **Trust-Graded Recall** feature section documenting the 0.25.0 arc — the trust-evidence block, `matchQuality` confidence bands, first-class `abstain` verdict, and citation-on-write / `record_usage` — with an honest note on which surfaces expose it today (authenticated HTTP API + native `/mcp`) versus what's follow-up (`flair` CLI, `@tpsdev-ai/flair-client`, the `flair-mcp` bridge).
+- Corrected the advertised MCP tool list (7 → the 11 the bridge actually exposes), the n8n node count (2 → 3, incl. Flair Write), moved the shipped first-run soul wizard out of "What's next", and reconciled the MCP client list.
+
 ### Fixed — `flair upgrade` no longer rolls back a healthy instance it just can't authenticate to
 
 `flair upgrade`'s post-restart verification treated "the server responded but the verifier couldn't authenticate" (a 401/403 on the authenticated `/HealthDetail`) the same as "the upgrade broke the instance" — it triggered a rollback, whose own re-verify hit the identical missing-credential wall, leaving the operator with a false `ROLLBACK ALSO FAILED VERIFICATION — instance state is UNKNOWN` for an instance that was healthy the entire time. This bit a real `0.22.1 → 0.25.0` upgrade on a machine with no admin-pass/agent key: `/HealthDetail` became a *verified-read* (flair#747), so the verifier authenticated fine against the pre-upgrade version but not post-restart, and the pre-flight credential check can't anticipate a version that changes `/HealthDetail`'s auth requirement.

--- a/README.md
+++ b/README.md
@@ -134,6 +134,15 @@ flair memory search "native addon loading in sandboxed runtimes"
 # → [0.67] Harper v5 sandbox blocks node:module but process.dlopen works
 ```
 
+### Trust-Graded Recall
+Recall can carry an opt-in **trust-evidence block** per result — provenance (verified vs claimed author), usage signal, freshness/validity, supersession — so an agent weighs *what to trust*, not just *what matched*. On top of it:
+
+- **Confidence bands** (`matchQuality`): each result is labeled `strong` / `moderate` / `breadcrumb` from its absolute similarity — a weak-but-relevant hit is taken for what it is, not mistaken for a confident one.
+- **First-class abstention** (`abstain`): when nothing clears a confidence floor, recall returns an honest "no memory covers this" verdict instead of the N weakest matches.
+- **Citation-on-write** (`usedMemoryIds`) + **`record_usage`**: report which memories actually grounded an answer — a deduped, principal-bound usage signal (honest evidence, never retrieval-popularity) that strengthens future recall.
+
+Opt-in and additive (`includeTrust` / `abstain` on the recall path) — off by default, byte-identical when unused. Reachable today via the authenticated HTTP API and the native `/mcp` tools; first-class exposure in the `flair` CLI, `@tpsdev-ai/flair-client`, and the `flair-mcp` bridge is a follow-up. Full arc in the [CHANGELOG](CHANGELOG.md) (flair#744).
+
 ### Tiered Durability
 Not all memories are equal:
 
@@ -340,7 +349,7 @@ Add to your `CLAUDE.md`:
 
     At the start of every session, run mcp__flair__bootstrap before responding.
 
-Your agent's memory **follows it across CLIs** — same Flair instance, same agent identity, switch from Claude Code to Gemini CLI to Codex CLI without losing state. The MCP server exposes `memory_store`, `memory_search`, `memory_get`, `memory_delete`, `bootstrap`, `soul_set`, `soul_get`.
+Your agent's memory **follows it across CLIs** — same Flair instance, same agent identity, switch from Claude Code to Gemini CLI to Codex CLI without losing state. The MCP server exposes `memory_store`, `memory_search`, `memory_update`, `memory_get`, `memory_delete`, `relationship_store`, `bootstrap`, `soul_set`, `soul_get`, `flair_workspace_set`, and `flair_orgevent`.
 
 For per-CLI config snippets (Gemini CLI's `~/.gemini/settings.json`, Codex CLI's `~/.codex/config.toml`, etc.), see **[docs/mcp-clients.md](docs/mcp-clients.md)**. For a deeper Claude Code walk-through with `CLAUDE.md` patterns, see [docs/claude-code.md](docs/claude-code.md).
 
@@ -353,7 +362,7 @@ Use Flair as the memory backend for n8n's AI Agent. Same memories readable from 
 @tpsdev-ai/n8n-nodes-flair
 ```
 
-Two nodes ship: **Flair Chat Memory** (Memory port, conversation buffer) and **Flair Search** (Tool port, semantic search + get-by-subject). Setup walkthrough, subject/sessionId patterns, and security guidance in **[docs/n8n.md](docs/n8n.md)**.
+Three nodes ship: **Flair Chat Memory** (Memory port, conversation buffer), **Flair Search** (Tool port, semantic search + get-by-subject), and **Flair Write** (Tool port, store memories). Setup walkthrough, subject/sessionId patterns, and security guidance in **[docs/n8n.md](docs/n8n.md)**.
 
 ### JavaScript / TypeScript (Client Library)
 
@@ -541,13 +550,13 @@ Flair is in active development and daily use. We dogfood it — the agents that 
 - ✅ Web admin UI (principals, connectors, IdPs, instance config)
 - ✅ Federation (hub-and-spoke sync with signed requests and pairing tokens)
 - ✅ OpenClaw memory plugin
-- ✅ MCP server for Claude Code / Cursor / Windsurf
+- ✅ MCP server for Claude Code / Cursor / Codex / Gemini CLI
 - ✅ Lightweight client library (`@tpsdev-ai/flair-client`)
 - ✅ Portable agent identity (export/import between instances)
 - ✅ `flair --version`, `flair upgrade`
+- ✅ First-run soul wizard (interactive personality setup)
 
 **What's next:**
-- [ ] First-run soul wizard (interactive personality setup)
 - [ ] Git-backed memory sync
 - [ ] Encryption at rest (opt-in AES-256-GCM per memory)
 - [ ] Harper Fabric deployment (managed multi-office)

--- a/README.md
+++ b/README.md
@@ -349,7 +349,7 @@ Add to your `CLAUDE.md`:
 
     At the start of every session, run mcp__flair__bootstrap before responding.
 
-Your agent's memory **follows it across CLIs** — same Flair instance, same agent identity, switch from Claude Code to Gemini CLI to Codex CLI without losing state. The MCP server exposes `memory_store`, `memory_search`, `memory_update`, `memory_get`, `memory_delete`, `relationship_store`, `bootstrap`, `soul_set`, `soul_get`, `flair_workspace_set`, and `flair_orgevent`.
+Your agent's memory **follows it across CLIs** — same Flair instance, same agent identity, switch from Claude Code to Gemini CLI to Codex CLI without losing state. The `flair-mcp` server — the bridge these CLIs connect to — exposes `memory_store`, `memory_search`, `memory_update`, `memory_get`, `memory_delete`, `relationship_store`, `bootstrap`, `soul_set`, `soul_get`, `flair_workspace_set`, and `flair_orgevent`. (Flair's in-Harper native `/mcp` surface is a separate, still-experimental tool set with `attention` + `record_usage` — see Trust-Graded Recall above.)
 
 For per-CLI config snippets (Gemini CLI's `~/.gemini/settings.json`, Codex CLI's `~/.codex/config.toml`, etc.), see **[docs/mcp-clients.md](docs/mcp-clients.md)**. For a deeper Claude Code walk-through with `CLAUDE.md` patterns, see [docs/claude-code.md](docs/claude-code.md).
 


### PR DESCRIPTION
## README refresh — document the 0.25.0 trust-recall arc + fix drift

Bundles into **0.25.1** so the npmjs README reflects it (npmjs renders the README in the published tarball). Driven by a full docs audit.

### Added
- **Trust-Graded Recall** feature section — documents the 0.25.0 arc that previously lived only in the CHANGELOG + code comments: the trust-evidence block, `matchQuality` confidence bands, first-class `abstain` verdict, and citation-on-write / `record_usage`. **Honest about reachability**: exposed today via the authenticated HTTP API + native `/mcp`; first-class CLI / `flair-client` / `flair-mcp` wiring is a follow-up (so users aren't sent looking for a surface that doesn't exist yet).

### Fixed (accuracy)
- MCP tool list: **7 → 11** (the bridge actually exposes memory_update, relationship_store, flair_workspace_set, flair_orgevent on top of the 7 listed).
- n8n node count: **2 → 3** (adds Flair Write).
- Moved the shipped **first-run soul wizard** out of "What's next".
- Reconciled the MCP client list (dropped the undocumented "Windsurf" → Codex / Gemini CLI).

### Not here
`docs/` tree fixes (system-requirements embedding model, claude-code TTL, integrations Codex/Gemini config formats) are a **separate PR** — they improve GitHub docs but don't affect the npmjs page, so they don't need a release. Wiring trust-recall into the mainstream client surfaces is tracked as the priority follow-up.

Docs-only, no code change.