### PR TITLE
fix(cli): DevEx batch — stale version reporting after upgrade/restart + n8n label

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- `flair restart`/`flair upgrade` now invalidate the version-handshake cache on a successful restart, so `flair status`'s preAction nudge doesn't falsely report the pre-restart server version for up to 60s after an upgrade+restart.
+- `flair upgrade` now primes the version-check cache with the latest version it just fetched fresh from the registry, so `flair status`/`doctor` immediately reflect it instead of a stale (up to 12h) cached value.
+- n8n `FlairWrite` node's ephemeral-durability option label corrected from "auto-expires 72h" to "auto-expires 24h" to match the actual default TTL.
+
 ### Docs
 
 - Fixed stale values found in a docs audit: `claude-code.md`'s ephemeral-durability TTL (72h → the actual 24h default), `system-requirements.md`'s embedding model (`Xenova/all-MiniLM-L6-v2`/384-dim/~85MB → the actual `nomic-embed-text-v1.5`/768-dim/~270MB), and `integrations.md`'s Codex/Gemini MCP config snippets (wrong file paths/formats → `~/.codex/config.toml` in TOML, `~/.gemini/settings.json`, matching `mcp-clients.md`). Also corrected `n8n.md`'s node count (two → the three actually shipped, adding Flair Write) and `mcp-clients.md`'s bridge tool count (seven → the eleven `flair-mcp` actually exposes). Added a known-issue note to `upgrade.md` documenting that the 0.25.1 post-restart-verify fix is forward-only: an upgrade *from* an older version is still verified by the old, unfixed CLI, so a credential-less verifier can report a false rollback on an instance that was healthy the whole time.

--- a/packages/n8n-nodes-flair/src/nodes/FlairWrite/FlairWrite.node.ts
+++ b/packages/n8n-nodes-flair/src/nodes/FlairWrite/FlairWrite.node.ts
@@ -140,7 +140,7 @@ export class FlairWrite implements INodeType {
           { name: "Standard (default)", value: "standard" },
           { name: "Persistent (key decisions)", value: "persistent" },
           { name: "Permanent (inviolable)", value: "permanent" },
-          { name: "Ephemeral (auto-expires 72h)", value: "ephemeral" },
+          { name: "Ephemeral (auto-expires 24h)", value: "ephemeral" },
         ],
         default: "standard",
         description:

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -29,8 +29,8 @@ import { create as tarCreate, extract as tarExtract, list as tarList } from "tar
 import { keystore } from "./keystore.js";
 import { deploy as deployToFabric, validateOptions as validateDeployOptions, buildTargetUrl as buildDeployUrl } from "./deploy.js";
 import { fabricUpgrade } from "./fabric-upgrade.js";
-import { checkVersion, formatVersionNudge } from "./version-check.js";
-import { checkServerHandshake, formatHandshakeNudge } from "./version-handshake.js";
+import { checkVersion, formatVersionNudge, primeVersionCheckCache, FLAIR_PKG_NAME } from "./version-check.js";
+import { checkServerHandshake, formatHandshakeNudge, invalidateHandshakeCache } from "./version-handshake.js";
 import { probeInstance, type ProbeResult } from "./probe.js";
 import {
   sweepFleet,
@@ -8897,6 +8897,9 @@ program
         if (!res.ok) continue;
         const data = await res.json() as { version?: string };
         const latest = data.version ?? "unknown";
+        if (name === FLAIR_PKG_NAME && latest !== "unknown") {
+          try { primeVersionCheckCache(latest); } catch { /* best-effort */ }
+        }
 
         const installed = probe();
         let status: Status;
@@ -9578,6 +9581,14 @@ async function startFlairProcess(port: number): Promise<void> {
 async function restartFlair(port: number): Promise<void> {
   await stopFlairProcess(port);
   await startFlairProcess(port);
+  // Bust the version-handshake cache so the next preAction nudge re-fetches
+  // the LIVE version instead of the pre-restart cached one (the false
+  // "server is running <old>" users hit for up to 60s post-upgrade+restart).
+  // Same (rootPath, serverUrl) key the preAction hook computes (~line 2189)
+  // — must match exactly, or this busts the wrong cache file.
+  try {
+    invalidateHandshakeCache(process.env.ROOTPATH ?? defaultDataDir(), `http://127.0.0.1:${port}`);
+  } catch { /* best-effort — never fail a restart over cache cleanup */ }
 }
 
 program

--- a/src/version-check.ts
+++ b/src/version-check.ts
@@ -155,6 +155,23 @@ export async function checkVersion(
   return { installed, latest: null, source: "unavailable" };
 }
 
+/**
+ * Primes the version-check cache with an already-known `latest` — e.g. right
+ * after `flair upgrade` fetches the true latest fresh via its own direct
+ * registry call, so the NEXT `checkVersion` (from `flair status`/`doctor`)
+ * reflects it immediately instead of serving a stale cached value for up to
+ * `DEFAULT_TTL_MS`. Reuses `writeCacheFile`, which is already best-effort/
+ * never-throws — a failed cache write must never surface as a command error.
+ */
+export function primeVersionCheckCache(
+  latest: string,
+  injected: Partial<Pick<VersionCheckDeps, "cachePath" | "now">> = {},
+): void {
+  const cachePath = injected.cachePath ?? DEFAULT_CACHE_PATH;
+  const now = injected.now ?? (() => Date.now());
+  writeCacheFile(cachePath, { latest, checkedAt: now() });
+}
+
 // ─── Severity heuristic (no advisory data — gap-based, see module doc) ──────
 
 export type VersionGapSeverity = "none" | "yellow" | "red";

--- a/src/version-handshake.ts
+++ b/src/version-handshake.ts
@@ -14,7 +14,7 @@
  * ROOTPATH, or a --target-switched remote), and a mismatch cached for one
  * must never bleed into a nudge about a different one.
  */
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { createHash } from "node:crypto";
 import { dirname, join } from "node:path";
 import { homedir } from "node:os";
@@ -144,6 +144,28 @@ export async function checkServerHandshake(
     };
   }
   return { cliVersion, runningVersion: null, mismatch: false, source: "unavailable" };
+}
+
+/**
+ * Deletes the cached running-version entry for a given (rootPath, serverUrl)
+ * pair — e.g. after `flair restart`/`flair upgrade` bounces the server, so
+ * the NEXT `checkServerHandshake` call re-fetches the live version instead
+ * of returning the pre-restart one for up to `DEFAULT_HANDSHAKE_TTL_MS`.
+ * Best-effort, like the rest of this module: a failed cache delete (missing
+ * file, permissions, read-only $HOME) must never surface as an error.
+ */
+export function invalidateHandshakeCache(
+  rootPath: string,
+  serverUrl: string,
+  injected: Partial<Pick<HandshakeDeps, "cacheDir">> = {},
+): void {
+  const cacheDir = injected.cacheDir ?? DEFAULT_HANDSHAKE_CACHE_DIR;
+  try {
+    const path = cacheFilePath(cacheDir, rootPath, serverUrl);
+    if (existsSync(path)) rmSync(path);
+  } catch {
+    // Best-effort — a failed cache delete must never surface as an error.
+  }
 }
 
 /**

--- a/test/unit/version-check.test.ts
+++ b/test/unit/version-check.test.ts
@@ -17,6 +17,7 @@ import {
   checkVersion,
   classifyGap,
   formatVersionNudge,
+  primeVersionCheckCache,
   defaultVersionCheckDeps,
   FLAIR_PKG_NAME,
   type VersionCheckDeps,
@@ -263,5 +264,47 @@ describe("checkVersion", () => {
     });
     expect(result.source).toBe("network");
     expect(existsSync(cachePath)).toBe(true);
+  }));
+});
+
+// ─── primeVersionCheckCache — `flair upgrade` writing the freshly-fetched
+// latest into the SAME cache `checkVersion` (status/doctor) reads from ─────
+
+describe("primeVersionCheckCache", () => {
+  let dir: string;
+  const cachePathFor = (d: string) => join(d, ".version-check-cache.json");
+
+  function withTmpDir<T>(fn: () => T): T {
+    dir = mkdtempSync(join(tmpdir(), "flair-version-check-prime-"));
+    try {
+      return fn();
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  }
+
+  test("writes the cache such that a subsequent checkVersion returns the primed latest without a network fetch", async () => withTmpDir(async () => {
+    const cachePath = cachePathFor(dir);
+    primeVersionCheckCache("0.25.2", { cachePath, now: () => 1000 });
+
+    let fetchCalls = 0;
+    const { readCache, writeCache } = defaultVersionCheckDeps();
+    const result = await checkVersion("0.25.1", {
+      cachePath, readCache, writeCache,
+      fetchLatest: async () => { fetchCalls++; return "0.99.0"; },
+      now: () => 1000 + 60_000, // shortly after — well within the 12h TTL
+      ttlMs: 12 * 60 * 60 * 1000,
+    });
+
+    expect(fetchCalls).toBe(0);
+    expect(result).toEqual({ installed: "0.25.1", latest: "0.25.2", source: "cache" });
+  }));
+
+  test("writes real JSON at the module default cache-file shape (latest + checkedAt)", async () => withTmpDir(async () => {
+    const cachePath = cachePathFor(dir);
+    primeVersionCheckCache("0.25.2", { cachePath, now: () => 1234 });
+
+    expect(existsSync(cachePath)).toBe(true);
+    expect(JSON.parse(readFileSync(cachePath, "utf-8"))).toEqual({ latest: "0.25.2", checkedAt: 1234 });
   }));
 });

--- a/test/unit/version-handshake.test.ts
+++ b/test/unit/version-handshake.test.ts
@@ -11,6 +11,7 @@ import { tmpdir } from "node:os";
 import {
   checkServerHandshake,
   formatHandshakeNudge,
+  invalidateHandshakeCache,
   DEFAULT_HANDSHAKE_TTL_MS,
   type HandshakeDeps,
 } from "../../src/version-handshake.ts";
@@ -148,6 +149,42 @@ describe("checkServerHandshake — cache isolation per (rootPath, serverUrl)", (
     await checkServerHandshake("1.2.3", "/root-a", "http://x", d);
     await checkServerHandshake("1.2.3", "/root-a", "http://x", d);
     expect(calls).toBe(1);
+  });
+});
+
+describe("invalidateHandshakeCache", () => {
+  it("deletes the cache file for a (rootPath, serverUrl) pair, forcing the next check back to the network (flair restart/upgrade cache-bust)", async () => {
+    let calls = 0;
+    const countingFetch: typeof fetch = (async () => {
+      calls++;
+      return { ok: true, status: 200, json: async () => ({ version: "0.22.1" }) } as unknown as Response;
+    }) as unknown as typeof fetch;
+
+    const d = deps({ fetchImpl: countingFetch, now: () => 1_000_000 });
+    const first = await checkServerHandshake("0.25.1", "/root", "http://x", d);
+    expect(first.source).toBe("network");
+    expect(calls).toBe(1);
+
+    // Still well within the TTL — without invalidation this would be a cache hit.
+    const stillCached = await checkServerHandshake("0.25.1", "/root", "http://x", d);
+    expect(stillCached.source).toBe("cache");
+    expect(calls).toBe(1);
+
+    invalidateHandshakeCache("/root", "http://x", { cacheDir });
+
+    const afterInvalidate = await checkServerHandshake("0.25.1", "/root", "http://x", d);
+    expect(afterInvalidate.source).toBe("network");
+    expect(calls).toBe(2);
+  });
+
+  it("is a silent no-op when there's no cache file for that key (never throws)", () => {
+    expect(() => invalidateHandshakeCache("/never-cached", "http://x", { cacheDir })).not.toThrow();
+  });
+
+  it("never throws even when the cache directory itself doesn't exist", () => {
+    expect(() =>
+      invalidateHandshakeCache("/root", "http://x", { cacheDir: join(cacheDir, "does-not-exist") }),
+    ).not.toThrow();
   });
 });
 


### PR DESCRIPTION
## DevEx batch — stale version reporting after upgrade/restart (+ n8n label)

Three real bugs Nathan surfaced dogfooding the 0.25.0→0.25.1 upgrade on a stock machine.

### 1. `flair status` falsely reports the pre-restart server version (up to 60s)
The preAction version-nudge reads a TTL-cached (`DEFAULT_HANDSHAKE_TTL_MS = 60s`) running-version from `~/.flair/.version-handshake-cache`, and it wasn't busted on restart — so after `flair upgrade`/`flair restart` it kept warning **"flair 0.25.1 installed but server is running 0.22.1 — run: flair restart"** even though the server WAS restarted. (`doctor` reads `/Health` live, which is why the two disagreed.)
**Fix:** `restartFlair` now calls a new best-effort `invalidateHandshakeCache(rootPath, serverUrl)` after starting — same `(rootPath, serverUrl)` key the preAction hook computes — so the next check re-fetches live. Covers `flair restart`, `flair upgrade` (success + rollback).

### 2. `flair status`/`doctor` show a stale "latest" after a release
`checkVersion` caches "latest" with a **12h** TTL; `flair upgrade` fetches latest **fresh** via its own registry call but never wrote it to that cache — so status showed **"latest is 0.24.0"** while upgrade correctly saw 0.25.1.
**Fix:** the upgrade loop now primes the version-check cache with the true latest it fetches (new best-effort `primeVersionCheckCache`), so status/doctor immediately reflect it.

### 3. n8n FlairWrite ephemeral label 72h → 24h
The actual TTL default is 24h (docs were fixed in #783; this is the code label).

### Invariants
Both helpers are **best-effort / never-throw**, matching the modules' existing discipline — a cache op can never affect a restart or upgrade outcome. The restart cache-bust key matches the preAction hook's format exactly (verified against `src/cli.ts:~2189`).

### Tests
Pure unit coverage (injectable seams, no network/$HOME): cache-bust forces a re-fetch (`source: cache` → `network`); prime makes `checkVersion` serve the primed latest with `fetchLatest` never called. Full unit suite **2765/0**; typecheck clean (one pre-existing unrelated error).

Targeted as patch **0.25.2**.