### PR TITLE
fix: correct broken README quickstart command + flair no-args exit 0 (Canary findings)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- **README's quickstart used a command that doesn't exist.** The "Semantic Memory" example wrote memories with `flair memory write "..."` — but the CLI command is `flair memory add` (`write` was never a subcommand). Corrected to `flair memory add --agent <id> "..."` / `flair memory search --agent <id> "..."` (the actual, working forms). Every new user following the quickstart hit "unknown command 'write'" on their first write. Found by the Canary DevEx dogfooder on a clean-box run.
+- **`flair` with no command now exits 0.** A bare `flair` prints help and exits 0 (it was exit 1 — a bare invocation is a help request, not a usage error). `-h`/`--help`/`-v` are unaffected.
+
 ## [0.25.2] - 2026-07-22
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -126,11 +126,11 @@ Every agent has an Ed25519 key pair. Requests are signed with `agentId:timestamp
 Memories are automatically embedded on write using [nomic-embed-text](https://huggingface.co/nomic-ai/nomic-embed-text-v1.5-GGUF) (768 dimensions). Search by meaning:
 
 ```bash
-# Write a memory
-flair memory write "Harper v5 sandbox blocks node:module but process.dlopen works"
+# Write a memory (--agent is your registered agent id)
+flair memory add --agent myagent "Harper v5 sandbox blocks node:module but process.dlopen works"
 
 # Find it later by concept, not exact words
-flair memory search "native addon loading in sandboxed runtimes"
+flair memory search --agent myagent "native addon loading in sandboxed runtimes"
 # → [0.67] Harper v5 sandbox blocks node:module but process.dlopen works
 ```
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -13701,6 +13701,14 @@ program
 // its Node-version check passes. The shim imports this module, so import.meta.main
 // is false there — without this explicit entry point the CLI would load but never run.
 async function runCli(): Promise<void> {
+  // A bare `flair` (no command) is a help request, not a usage error — show
+  // help and exit 0, rather than commander's default (help + exit 1). Flags
+  // like -h/--help/-v have argv beyond the binary and fall through to
+  // commander, which already exits 0 for them.
+  if (process.argv.length <= 2) {
+    program.outputHelp();
+    process.exit(0);
+  }
   await program.parseAsync();
 }
 


### PR DESCRIPTION
## Fix two DevEx bugs Canary found on a clean-box run

The **Canary** DevEx dogfooder's first mission (fresh install on a clean box) turned these up. Verified against source before fixing.

### 1. [MAJOR] README quickstart used a command that doesn't exist
The "Semantic Memory" example wrote memories with `flair memory write "..."` — but the CLI command is `flair memory add` (`write` was never a subcommand). **Every new user following the quickstart hit `unknown command 'write'` on their first write.** Corrected to the actual working forms: `flair memory add --agent <id> "..."` and `flair memory search --agent <id> "..."`.

Verified: `memory add` requires `--agent` and takes positional content; the sibling examples (README L305/L308) were already correct — including `--q`, which is a real alias for the positional query, so I left them untouched (didn't "fix" a working example).

### 2. [MINOR] `flair` with no command exited 1
A bare `flair` now prints help and exits **0** — a bare invocation is a help request, not a usage error. `-h`/`--help`/`-v` unaffected.

### Verified
- Bare `flair` → help + exit 0; `flair --help` → exit 0 (functional check).
- Full unit suite **2765/0**; typecheck clean (one pre-existing unrelated error).

### Not in this patch
Canary also found a real `flair init` re-run 401 (admin-pass overwrite) and an `init` oversell — those touch the sensitive auth/init path and get careful separate treatment (I'm confirming the interactive path first). Targeted as **0.25.3**.