### PR TITLE
fix(upgrade): detect globally-installed flair when off PATH (require.resolve fallback) — Canary finding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- **`flair upgrade` couldn't detect a globally-installed flair when `flair` isn't on PATH.** For a custom npm prefix (mise/fnm/nvm/volta, or the sudo-less user-prefix install the README recommends), `flair upgrade` reported `not detected → run npm install -g` even though the package was installed, so the one-command upgrade never ran. The flair package probe now falls back to a `require.resolve`-based lookup — the same PATH-independent fallback `flair-mcp` already had. Found by the Canary dogfooder validating the 0.25.3 upgrade flow.
+
 ## [0.25.3] - 2026-07-22
 
 ### Fixed

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -8860,7 +8860,15 @@ program
       {
         name: "@tpsdev-ai/flair",
         kind: "bin",
-        probe: () => probeBinVersion(execFileSync,"flair"),
+        // Same PATH-independence fix as flair-mcp below: when `flair` isn't on
+        // PATH (a custom npm prefix — mise/fnm/nvm/volta, or the sudo-less
+        // user-prefix install the README recommends), the bin probe returns
+        // null even though the package IS globally installed, and `flair
+        // upgrade` mis-reports "not detected → run npm install -g". Fall back
+        // to the lib probe, which require.resolves the package.json regardless
+        // of PATH or `--version` support. (Canary's 0.25.3 dogfooding caught
+        // this — the fallback existed for flair-mcp but not for flair itself.)
+        probe: () => probeBinVersion(execFileSync, "flair") ?? probeLibVersion("@tpsdev-ai/flair"),
       },
       {
         name: "@tpsdev-ai/flair-mcp",


### PR DESCRIPTION
## `flair upgrade` couldn't find your install if `flair` isn't on PATH

Found by **Canary** validating the 0.25.3 upgrade flow on a clean box.

### Bug
The `@tpsdev-ai/flair` probe in `flair upgrade` used only `probeBinVersion` (a PATH-based `flair --version`). When `flair` isn't on PATH — a **custom npm prefix** (mise/fnm/nvm/volta, or **the sudo-less user-prefix install the README recommends**) — it returned null and upgrade printed:
```
❔ @tpsdev-ai/flair: not detected → 0.25.x (run: npm install -g)
```
…even though the package *was* globally installed. The documented one-command upgrade never ran; the user had to discover the manual `npm i -g` fallback.

### Fix
Fall back to `probeLibVersion` (a `require.resolve` of the package.json), the **same PATH-independent fallback `flair-mcp` already had** (cli.ts:8874). The fallback existed for flair-mcp but not for flair itself — a one-line composition change mirroring the proven pattern.

### Verified
The probe functions are unit-tested (`test/unit/upgrade-probes.test.ts`, 21/0). Full unit suite **2765/0**; typecheck clean. Verified against source before fixing (root cause: the missing `?? probeLibVersion(...)` on the flair entry).

Targeted as **0.25.4** — "your upgrade command can't find your install" is exactly the trust-eroding class, and it hits the README's own recommended setup.