### PR TITLE
feat(cli): flair quality — read-only memory-quality report (Slice 1a)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- **`flair quality` — a read-only memory-quality report.** New command (`flair quality [--agent <id>] [--json]`) that answers "is my agent's memory healthy, or silting up with noise and stale entries?" It mirrors `flair status`/`doctor` — fetches `/HealthDetail` and computes CLI-side — reporting instance health, embedding coverage (% real vs hash-fallback), staleness (% expired), per-agent signal density (write volume + last-active, framed as a usage pattern), and quiet-agent detection. Read-only and downstream of all authority — it never influences access, ranking, or trust. Unavailable metrics degrade gracefully to a noted `gaps` entry rather than crashing. First slice of the memory-quality observability arc.
+
 ## [0.25.4] - 2026-07-22
 
 ### Fixed

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -10978,6 +10978,350 @@ program
     if (summary.exitCode !== 0) process.exit(summary.exitCode);
   });
 
+// ─── flair quality — pure metric computation ─────────────────────────────────
+// Slice 1a of the memory-quality-observability arc (ops/proposals/
+// flair-quality-slice1-spec.md, K&S design-approved). Same "extract the pure
+// decision logic" idiom as summarizeDoctorRun above (flair#721) and
+// derivePresenceStatus (resources/Presence.ts): the CLI action spawns a
+// network fetch + a long console.log sequence, which is high-effort/
+// low-value to drive directly in a test — this is the actual metric math,
+// fed a fixture-shaped /HealthDetail body.
+//
+// ZERO new server surface. Every field this reads already exists in
+// resources/health.ts's response (the same one `flair status`/`flair doctor`
+// consume) — no new query pattern, no new endpoint. That's what makes the
+// Sherlock "read-scope holds by construction" argument hold: quality can
+// never see anything status/doctor couldn't already see, because it reads
+// the identical payload.
+//
+// Two metrics from the design doc are deliberately NOT computed at full
+// fidelity here — both degrade gracefully into `gaps` entries instead of
+// failing:
+//   - staleness: /HealthDetail's `memories.expired` count is instance-wide
+//     only (resources/health.ts never buckets it per agent), so --agent
+//     does not scope this metric. The "old + never-recalled" variant isn't
+//     computed at all — no read API exposes per-memory last-recalled data.
+//   - signal density: the design doc named `usageCount` (citation rate) as
+//     the signal, but /HealthDetail's per-agent rows carry only
+//     memoryCount/hashFallback/writes24h/lastWriteAt — no usage/citation
+//     aggregate. Memory.usageCount DOES exist (resources/scoring.ts,
+//     resources/RecordUsage.ts) and IS returned by `GET /Memory?agentId=`
+//     (what `flair memory list` calls), but pulling it in here would add a
+//     query pattern doctor/status never use, widening quality's read
+//     footprint past the payload K&S actually reviewed. Ships write-volume
+//     + last-active only (still real, still useful — "writes exploratory
+//     content" is a legitimate usage pattern) and notes the gap rather than
+//     quietly relabeling write-count as a citation signal.
+//
+// Naming (Sherlock security finding on the design round): "signal density" /
+// "citation rate" describes a USAGE PATTERN, never a trust/quality verdict.
+// A low citation rate means "writes exploratory content", not "noisy" or
+// "untrustworthy" — same for "quiet agents": an ops fact (days since last
+// write), not a trust signal. Keep that framing in any copy touching this
+// code.
+
+/** First-pass default, same "documented heuristic, not derived from data we
+ *  don't have" spirit as health.ts's own 10%-hash-fallback threshold below.
+ *  Tunable later if a real fleet shows this is too loud/quiet. */
+export const QUALITY_QUIET_THRESHOLD_DAYS = 7;
+
+/** Mirrors resources/health.ts's own hash-fallback warning threshold (kept as
+ *  a literal constant here rather than imported — health.ts computes its
+ *  warning string server-side, this recomputes the same judgment CLI-side
+ *  from the raw counts so quality doesn't depend on parsing warning text). */
+export const QUALITY_HASH_FALLBACK_DEGRADED_PCT = 10;
+
+export interface QualityMetricGap {
+  metric: string;
+  reason: string;
+}
+
+export interface QualityAgentActivity {
+  id: string;
+  memoryCount: number;
+  writes24h: number;
+  lastWriteAt: string | null;
+  /** null when the agent has never written (nothing to measure "days since" from). */
+  daysSinceLastWrite: number | null;
+  /** true if daysSinceLastWrite >= QUALITY_QUIET_THRESHOLD_DAYS, or the agent has never written. */
+  quiet: boolean;
+}
+
+export interface QualityReport {
+  agentFilter: string | null;
+  instance: {
+    up: boolean;
+    /** null when /HealthDetail returned no migrations block at all. */
+    migrationsClean: boolean | null;
+    haltedMigrations: Array<{ id: string; state: string; reason?: string }>;
+    embeddingsStatus: "ok" | "degraded" | "unknown";
+    embeddingsDetail: string;
+  };
+  embeddingCoverage: {
+    total: number;
+    withEmbeddings: number;
+    hashFallback: number;
+    coveragePct: number;
+  } | null;
+  staleness: {
+    scope: "instance";
+    total: number;
+    expired: number;
+    stalePct: number;
+  } | null;
+  signalDensity: {
+    scope: "write-volume";
+    perAgent: Array<{ id: string; memoryCount: number; writes24h: number; lastWriteAt: string | null }>;
+  } | null;
+  quietAgents: {
+    thresholdDays: number;
+    perAgent: QualityAgentActivity[];
+    quietCount: number;
+  } | null;
+  gaps: QualityMetricGap[];
+}
+
+/**
+ * Pure computation: /HealthDetail response (+ reachability) → quality report.
+ * Never throws — every missing data source degrades to a null section + a
+ * `gaps` entry (same graceful-degradation contract as `flair doctor`), so a
+ * partially-populated instance still gets a partial, honest report instead
+ * of a crash.
+ */
+export function computeQualityReport(
+  healthy: boolean,
+  healthData: any,
+  opts: { agentId?: string | null; now?: number } = {},
+): QualityReport {
+  const now = opts.now ?? Date.now();
+  const agentFilter = opts.agentId ?? null;
+  const gaps: QualityMetricGap[] = [];
+
+  // ── Instance health: migrations ──
+  let migrationsClean: boolean | null = null;
+  let haltedMigrations: Array<{ id: string; state: string; reason?: string }> = [];
+  const migList = healthData?.migrations?.migrations;
+  if (Array.isArray(migList)) {
+    haltedMigrations = migList
+      .filter((m: any) => m?.state === "halted" || m?.state === "failed")
+      .map((m: any) => ({ id: m.id, state: m.state, reason: m.reason }));
+    migrationsClean = haltedMigrations.length === 0;
+  } else {
+    gaps.push({ metric: "instance.migrationsClean", reason: "no migrations block in /HealthDetail response" });
+  }
+
+  // ── Instance health: embeddings operational ──
+  // Inferred from stored coverage stats (hash-fallback %, mixed embedding
+  // models) — NOT a live semantic round-trip like `flair doctor` runs
+  // (verifySemanticSearch writes a probe memory to verify recall-by-meaning,
+  // which this read-only command must not do).
+  let embeddingsStatus: "ok" | "degraded" | "unknown" = "unknown";
+  let embeddingsDetail = "no memory stats available";
+  const memories = healthData?.memories;
+  if (memories && typeof memories.total === "number") {
+    if (memories.total === 0) {
+      embeddingsDetail = "no memories written yet";
+    } else {
+      const hashFallback = memories.hashFallback ?? 0;
+      const pct = Math.round((hashFallback / memories.total) * 100);
+      const modelCounts = (memories.modelCounts ?? {}) as Record<string, number>;
+      const realModels = Object.keys(modelCounts).filter((k) => k !== "hash-512d" && modelCounts[k] > 0);
+      if (pct >= QUALITY_HASH_FALLBACK_DEGRADED_PCT) {
+        embeddingsStatus = "degraded";
+        embeddingsDetail = `${hashFallback}/${memories.total} (${pct}%) memories are hash-fallback`;
+      } else if (realModels.length > 1) {
+        embeddingsStatus = "degraded";
+        embeddingsDetail = `multiple embedding models in use (${realModels.join(", ")}) — cross-model search unreliable`;
+      } else {
+        embeddingsStatus = "ok";
+        embeddingsDetail = `${memories.total - hashFallback}/${memories.total} memories have real embeddings`;
+      }
+    }
+  }
+
+  // ── Embedding coverage ──
+  let embeddingCoverage: QualityReport["embeddingCoverage"] = null;
+  if (memories && typeof memories.total === "number") {
+    const total = memories.total;
+    const hashFallback = memories.hashFallback ?? 0;
+    const withEmbeddings = typeof memories.withEmbeddings === "number" ? memories.withEmbeddings : Math.max(0, total - hashFallback);
+    const coveragePct = total > 0 ? Math.round((withEmbeddings / total) * 100) : 0;
+    embeddingCoverage = { total, withEmbeddings, hashFallback, coveragePct };
+  } else {
+    gaps.push({ metric: "embeddingCoverage", reason: "no memory stats available in /HealthDetail response" });
+  }
+
+  // ── Staleness (instance-wide only — see module doc above) ──
+  let staleness: QualityReport["staleness"] = null;
+  if (memories && typeof memories.total === "number" && typeof memories.expired === "number") {
+    const total = memories.total;
+    const expired = memories.expired;
+    const stalePct = total > 0 ? Math.round((expired / total) * 100) : 0;
+    staleness = { scope: "instance", total, expired, stalePct };
+    gaps.push({
+      metric: "staleness",
+      reason: "instance-wide only — /HealthDetail's `expired` count isn't broken down per agent, so --agent doesn't scope this metric; the \"old + never-recalled\" dead-weight variant also isn't computed (no read API exposes per-memory last-recalled data)",
+    });
+  } else {
+    gaps.push({ metric: "staleness", reason: "no expired-memory count available in /HealthDetail response" });
+  }
+
+  // ── Per-agent rows (shared source for signal density + quiet agents) ──
+  const perAgentAll: Array<{ id: string; memoryCount: number; hashFallback: number; writes24h: number; lastWriteAt: string | null }> =
+    Array.isArray(healthData?.agents?.perAgent) ? healthData.agents.perAgent : [];
+  const havePerAgent = Array.isArray(healthData?.agents?.perAgent);
+  const scopedAgents = agentFilter ? perAgentAll.filter((r) => r.id === agentFilter) : perAgentAll;
+
+  // ── Signal density (write-volume only — see module doc above) ──
+  let signalDensity: QualityReport["signalDensity"] = null;
+  if (havePerAgent) {
+    signalDensity = {
+      scope: "write-volume",
+      perAgent: scopedAgents.map((r) => ({ id: r.id, memoryCount: r.memoryCount, writes24h: r.writes24h, lastWriteAt: r.lastWriteAt })),
+    };
+    gaps.push({
+      metric: "signalDensity",
+      reason: "citation rate not computed — /HealthDetail's per-agent stats carry no usage/citation aggregate (Memory.usageCount exists but isn't exposed there); shipped write-volume + last-active only",
+    });
+  } else {
+    gaps.push({ metric: "signalDensity", reason: "no per-agent stats available in /HealthDetail response" });
+  }
+
+  // ── Quiet agents (ops fact — not a trust signal) ──
+  let quietAgents: QualityReport["quietAgents"] = null;
+  if (havePerAgent) {
+    const rows: QualityAgentActivity[] = scopedAgents.map((r) => {
+      const daysSinceLastWrite = r.lastWriteAt ? Math.floor((now - new Date(r.lastWriteAt).getTime()) / 86_400_000) : null;
+      const quiet = daysSinceLastWrite === null ? true : daysSinceLastWrite >= QUALITY_QUIET_THRESHOLD_DAYS;
+      return { id: r.id, memoryCount: r.memoryCount, writes24h: r.writes24h, lastWriteAt: r.lastWriteAt, daysSinceLastWrite, quiet };
+    });
+    quietAgents = { thresholdDays: QUALITY_QUIET_THRESHOLD_DAYS, perAgent: rows, quietCount: rows.filter((r) => r.quiet).length };
+  } else {
+    gaps.push({ metric: "quietAgents", reason: "no per-agent stats available in /HealthDetail response" });
+  }
+
+  return {
+    agentFilter,
+    instance: { up: healthy, migrationsClean, haltedMigrations, embeddingsStatus, embeddingsDetail },
+    embeddingCoverage,
+    staleness,
+    signalDensity,
+    quietAgents,
+    gaps,
+  };
+}
+
+// ─── flair quality ────────────────────────────────────────────────────────────
+program
+  .command("quality")
+  .description("Memory-quality report: embedding coverage, staleness, signal density, quiet agents (read-only)")
+  .option("--port <port>", "Harper HTTP port")
+  .option("--url <url>", "Flair base URL (overrides --port)")
+  .option("--target <url>", "Remote Flair URL (env: FLAIR_TARGET; alias for --url)")
+  .option("--json", "Output as JSON")
+  .option("--agent <id>", "Scope per-agent metrics to one agent id (or set FLAIR_AGENT_ID); default = all agents")
+  .action(async (opts) => {
+    const { healthy, baseUrl, healthData } = await fetchHealthDetail(opts);
+    const agentId: string | null = opts.agent || process.env.FLAIR_AGENT_ID || null;
+    const report = computeQualityReport(healthy, healthData, { agentId });
+    const mode = render.resolveOutputMode(opts);
+
+    if (mode === "json") {
+      const out: any = { healthy, url: baseUrl, flairVersion: __pkgVersion, ...report };
+      console.log(render.asJSON(out));
+      if (!healthy) process.exit(1);
+      return;
+    }
+
+    if (!healthy) {
+      console.log(`Flair v${__pkgVersion} — 🔴 unreachable`);
+      console.log(`  URL:  ${baseUrl}`);
+      console.log(`\n  Run: flair start  or  flair doctor`);
+      process.exit(1);
+    }
+
+    const scopeLabel = agentId ? ` ${render.wrap(render.c.dim, `(agent: ${agentId})`)}` : "";
+    console.log(`${render.wrap(render.c.bold, "Flair quality report")}${scopeLabel}`);
+    console.log(render.kv("URL", baseUrl));
+
+    // Instance health
+    console.log(`\n${render.wrap(render.c.bold, "Instance health")}`);
+    console.log(render.kv("Up", report.instance.up ? `${render.icons.ok} yes` : `${render.icons.error} no`));
+    if (report.instance.migrationsClean === null) {
+      console.log(render.kv("Migrations", `${render.icons.info} unknown ${render.wrap(render.c.dim, "(no data)")}`));
+    } else if (report.instance.migrationsClean) {
+      console.log(render.kv("Migrations", `${render.icons.ok} clean`));
+    } else {
+      console.log(render.kv("Migrations", `${render.icons.error} ${report.instance.haltedMigrations.length} halted/failed`));
+      for (const m of report.instance.haltedMigrations) {
+        console.log(`    ${render.icons.error} ${m.id}: ${m.state}${m.reason ? ` — ${m.reason}` : ""}`);
+      }
+    }
+    const embIcon =
+      report.instance.embeddingsStatus === "ok" ? render.icons.ok :
+      report.instance.embeddingsStatus === "degraded" ? render.icons.error :
+      render.icons.info;
+    console.log(render.kv("Embeddings", `${embIcon} ${report.instance.embeddingsStatus} ${render.wrap(render.c.dim, `(${report.instance.embeddingsDetail})`)}`));
+
+    // Embedding coverage
+    if (report.embeddingCoverage) {
+      const ec = report.embeddingCoverage;
+      console.log(`\n${render.wrap(render.c.bold, "Embedding coverage")}`);
+      console.log(render.kv("Coverage", `${render.wrap(render.c.bold, `${ec.coveragePct}%`)} ${render.wrap(render.c.dim, `(${ec.withEmbeddings}/${ec.total} real, ${ec.hashFallback} hash-fallback)`)}`));
+    }
+
+    // Staleness
+    if (report.staleness) {
+      const st = report.staleness;
+      console.log(`\n${render.wrap(render.c.bold, "Staleness")}`);
+      console.log(render.kv("Past validTo", `${render.wrap(render.c.bold, `${st.stalePct}%`)} ${render.wrap(render.c.dim, `(${st.expired}/${st.total}, instance-wide)`)}`));
+    }
+
+    // Signal density
+    if (report.signalDensity) {
+      console.log(`\n${render.wrap(render.c.bold, "Signal density")} ${render.wrap(render.c.dim, "(write activity — a usage pattern, not a trust signal)")}`);
+      if (agentId && report.signalDensity.perAgent.length === 0) {
+        console.log(`  ${render.icons.info} no data for agent '${agentId}'`);
+      } else {
+        const cols: render.TableColumn[] = [
+          { label: "id", key: "id" },
+          { label: "memories", key: "memoryCount", align: "right" },
+          { label: "writes_24h", key: "writes24h", align: "right" },
+          { label: "last_write", key: "lastWriteAt", format: (v) => render.relativeTime(v as string | null) },
+        ];
+        console.log(render.table(cols, report.signalDensity.perAgent as unknown as Array<Record<string, unknown>>));
+        console.log(`  ${render.wrap(render.c.dim, "citation rate not shown — usage/citation counts aren't exposed by /HealthDetail; low write volume means \"writes exploratory content\", not \"noisy\"")}`);
+      }
+    }
+
+    // Quiet agents
+    if (report.quietAgents) {
+      console.log(`\n${render.wrap(render.c.bold, "Quiet agents")} ${render.wrap(render.c.dim, `(no write in ${report.quietAgents.thresholdDays}+ days — an ops fact, not a trust signal)`)}`);
+      if (agentId && report.quietAgents.perAgent.length === 0) {
+        console.log(`  ${render.icons.info} no data for agent '${agentId}'`);
+      } else {
+        const quiet = report.quietAgents.perAgent.filter((r) => r.quiet);
+        if (quiet.length === 0) {
+          console.log(`  ${render.icons.ok} none`);
+        } else {
+          for (const r of quiet) {
+            const label = r.daysSinceLastWrite == null ? "never written" : `quiet for ${r.daysSinceLastWrite}d`;
+            console.log(`  ${render.icons.warn} ${r.id} — ${label}`);
+          }
+        }
+      }
+    }
+
+    // Gaps
+    if (report.gaps.length > 0) {
+      console.log(`\n${render.wrap(render.c.bold, "Gaps")} ${render.wrap(render.c.dim, "(degraded or unavailable from existing read APIs)")}`);
+      for (const g of report.gaps) {
+        console.log(`  ${render.icons.info} ${g.metric}: ${g.reason}`);
+      }
+    }
+    console.log("");
+  });
+
 // ─── flair session snapshot ──────────────────────────────────────────────────
 // Slice 2 of FLAIR-AGENT-CONTEXT-TIERS-B. Snapshot a
 // session jsonl + label metadata into a tar.gz under ~/.flair/snapshots/<agent>/sessions/.

--- a/test/unit/quality-report.test.ts
+++ b/test/unit/quality-report.test.ts
@@ -1,0 +1,283 @@
+/**
+ * quality-report.test.ts — Unit tests for `computeQualityReport`, the pure
+ * metric-computation core behind `flair quality` (Slice 1a of the
+ * memory-quality-observability arc, ops/proposals/flair-quality-slice1-spec.md).
+ *
+ * Same pattern as doctor-summary.test.ts / doctor-agent-iteration.test.ts:
+ * the CLI action drives a network fetch + a long console.log sequence
+ * (high-effort/low-value to exercise directly), so the actual metric math is
+ * extracted into a pure function and tested here against fixture
+ * /HealthDetail-shaped payloads. No fetch, no fs, no Harper.
+ */
+
+import { describe, test, expect } from "bun:test";
+import {
+  computeQualityReport,
+  QUALITY_QUIET_THRESHOLD_DAYS,
+  QUALITY_HASH_FALLBACK_DEGRADED_PCT,
+} from "../../src/cli.ts";
+
+const NOW = new Date("2026-07-21T12:00:00.000Z").getTime();
+const daysAgo = (n: number) => new Date(NOW - n * 86_400_000).toISOString();
+
+// A realistic /HealthDetail fixture — field names match resources/health.ts's
+// actual get() output (memories.{total,withEmbeddings,hashFallback,
+// modelCounts,expired}, agents.perAgent[].{id,memoryCount,hashFallback,
+// writes24h,lastWriteAt}, migrations.migrations[].{id,state,reason}) — NOT
+// the design doc's originally-named fields (verified against the resolver,
+// not trusted from memory).
+function fixture(overrides: Record<string, any> = {}) {
+  return {
+    ok: true,
+    caller: { agentId: "flint", isAdmin: true },
+    memories: {
+      total: 100,
+      withEmbeddings: 95,
+      hashFallback: 5,
+      modelCounts: { "nomic-embed-text": 95, "hash-512d": 5 },
+      byDurability: { permanent: 5, persistent: 20, standard: 70, ephemeral: 5 },
+      archived: 2,
+      expired: 8,
+    },
+    lastWrite: daysAgo(0),
+    agents: {
+      count: 3,
+      names: ["flint", "anvil", "pulse"],
+      perAgent: [
+        { id: "flint", memoryCount: 60, hashFallback: 2, writes24h: 5, lastWriteAt: daysAgo(0) },
+        { id: "anvil", memoryCount: 30, hashFallback: 5, writes24h: 0, lastWriteAt: daysAgo(3) },
+        { id: "pulse", memoryCount: 10, hashFallback: 3, writes24h: 0, lastWriteAt: daysAgo(30) },
+      ],
+    },
+    migrations: {
+      cyclePhase: "idle",
+      lastCycleAt: daysAgo(1),
+      migrations: [{ id: "embedding-backfill", rowsDone: 100, rowsRemaining: 0, state: "completed" }],
+    },
+    version: "0.25.4",
+    pid: 12345,
+    uptimeSeconds: 3600,
+    warnings: [],
+    ...overrides,
+  };
+}
+
+describe("computeQualityReport", () => {
+  describe("instance health", () => {
+    test("healthy + clean migrations + coverage under threshold → ok/clean/ok", () => {
+      const r = computeQualityReport(true, fixture(), { now: NOW });
+      expect(r.instance.up).toBe(true);
+      expect(r.instance.migrationsClean).toBe(true);
+      expect(r.instance.haltedMigrations).toEqual([]);
+      expect(r.instance.embeddingsStatus).toBe("ok");
+    });
+
+    test("unreachable instance → up: false, everything else degrades gracefully (no crash)", () => {
+      const r = computeQualityReport(false, null, { now: NOW });
+      expect(r.instance.up).toBe(false);
+      expect(r.instance.migrationsClean).toBeNull();
+      expect(r.instance.embeddingsStatus).toBe("unknown");
+      expect(r.embeddingCoverage).toBeNull();
+      expect(r.staleness).toBeNull();
+      expect(r.signalDensity).toBeNull();
+      expect(r.quietAgents).toBeNull();
+      expect(r.gaps.length).toBeGreaterThan(0);
+    });
+
+    test("halted migration → migrationsClean: false, surfaced in haltedMigrations", () => {
+      const data = fixture({
+        migrations: {
+          cyclePhase: "idle",
+          migrations: [
+            { id: "embedding-backfill", rowsDone: 50, rowsRemaining: 50, state: "halted", reason: "disk full" },
+            { id: "other", rowsDone: 10, rowsRemaining: 0, state: "completed" },
+          ],
+        },
+      });
+      const r = computeQualityReport(true, data, { now: NOW });
+      expect(r.instance.migrationsClean).toBe(false);
+      expect(r.instance.haltedMigrations).toEqual([{ id: "embedding-backfill", state: "halted", reason: "disk full" }]);
+    });
+
+    test("no migrations block at all → migrationsClean: null + a gap entry (not a false 'clean')", () => {
+      const data = fixture();
+      delete (data as any).migrations;
+      const r = computeQualityReport(true, data, { now: NOW });
+      expect(r.instance.migrationsClean).toBeNull();
+      expect(r.gaps.some((g) => g.metric === "instance.migrationsClean")).toBe(true);
+    });
+
+    test("hash-fallback at/above the degraded threshold → embeddings degraded", () => {
+      const data = fixture({
+        memories: { total: 100, withEmbeddings: 89, hashFallback: 11, modelCounts: { x: 89, "hash-512d": 11 }, expired: 0 },
+      });
+      const r = computeQualityReport(true, data, { now: NOW });
+      expect(r.instance.embeddingsStatus).toBe("degraded");
+      expect(r.instance.embeddingsDetail).toContain("11/100");
+    });
+
+    test("hash-fallback exactly at the threshold boundary counts as degraded (>=, not >)", () => {
+      const data = fixture({
+        memories: { total: 100, withEmbeddings: 90, hashFallback: QUALITY_HASH_FALLBACK_DEGRADED_PCT, modelCounts: {}, expired: 0 },
+      });
+      const r = computeQualityReport(true, data, { now: NOW });
+      expect(r.instance.embeddingsStatus).toBe("degraded");
+    });
+
+    test("mixed real embedding models (multiple non-hash-fallback models) → degraded even under the % threshold", () => {
+      const data = fixture({
+        memories: { total: 100, withEmbeddings: 98, hashFallback: 2, modelCounts: { "model-a": 60, "model-b": 38, "hash-512d": 2 }, expired: 0 },
+      });
+      const r = computeQualityReport(true, data, { now: NOW });
+      expect(r.instance.embeddingsStatus).toBe("degraded");
+      expect(r.instance.embeddingsDetail).toContain("multiple embedding models");
+    });
+
+    test("zero memories → embeddings status unknown, not a false 'ok'", () => {
+      const data = fixture({ memories: { total: 0, withEmbeddings: 0, hashFallback: 0, modelCounts: {}, expired: 0 } });
+      const r = computeQualityReport(true, data, { now: NOW });
+      expect(r.instance.embeddingsStatus).toBe("unknown");
+    });
+  });
+
+  describe("embedding coverage", () => {
+    test("computes coverage % from withEmbeddings/total", () => {
+      const r = computeQualityReport(true, fixture(), { now: NOW });
+      expect(r.embeddingCoverage).toEqual({ total: 100, withEmbeddings: 95, hashFallback: 5, coveragePct: 95 });
+    });
+
+    test("missing memories block → null + gap", () => {
+      const data = fixture();
+      delete (data as any).memories;
+      const r = computeQualityReport(true, data, { now: NOW });
+      expect(r.embeddingCoverage).toBeNull();
+      expect(r.gaps.some((g) => g.metric === "embeddingCoverage")).toBe(true);
+    });
+  });
+
+  describe("staleness", () => {
+    test("computes % past validTo (expired/total) from the instance-wide `expired` count", () => {
+      const r = computeQualityReport(true, fixture(), { now: NOW });
+      expect(r.staleness).toEqual({ scope: "instance", total: 100, expired: 8, stalePct: 8 });
+    });
+
+    test("always notes the instance-wide-only + never-recalled gap, even when the metric ships", () => {
+      const r = computeQualityReport(true, fixture(), { now: NOW });
+      expect(r.gaps.some((g) => g.metric === "staleness" && g.reason.includes("instance-wide"))).toBe(true);
+    });
+
+    test("zero total memories → 0% staleness, not NaN/division-by-zero", () => {
+      const data = fixture({ memories: { total: 0, withEmbeddings: 0, hashFallback: 0, modelCounts: {}, expired: 0 } });
+      const r = computeQualityReport(true, data, { now: NOW });
+      expect(r.staleness).toEqual({ scope: "instance", total: 0, expired: 0, stalePct: 0 });
+    });
+
+    test("no expired count in the payload → null + gap", () => {
+      const data = fixture({ memories: { total: 100, withEmbeddings: 90, hashFallback: 10, modelCounts: {} } });
+      const r = computeQualityReport(true, data, { now: NOW });
+      expect(r.staleness).toBeNull();
+      expect(r.gaps.some((g) => g.metric === "staleness" && g.reason.includes("no expired"))).toBe(true);
+    });
+  });
+
+  describe("signal density (write-volume, per agent)", () => {
+    test("all agents by default", () => {
+      const r = computeQualityReport(true, fixture(), { now: NOW });
+      expect(r.signalDensity?.scope).toBe("write-volume");
+      expect(r.signalDensity?.perAgent).toEqual([
+        { id: "flint", memoryCount: 60, writes24h: 5, lastWriteAt: daysAgo(0) },
+        { id: "anvil", memoryCount: 30, writes24h: 0, lastWriteAt: daysAgo(3) },
+        { id: "pulse", memoryCount: 10, writes24h: 0, lastWriteAt: daysAgo(30) },
+      ]);
+      // Citation-rate gap always noted (usageCount isn't in /HealthDetail's perAgent rows).
+      expect(r.gaps.some((g) => g.metric === "signalDensity" && g.reason.includes("citation rate"))).toBe(true);
+    });
+
+    test("--agent scopes to exactly that agent's row", () => {
+      const r = computeQualityReport(true, fixture(), { now: NOW, agentId: "anvil" });
+      expect(r.signalDensity?.perAgent).toEqual([{ id: "anvil", memoryCount: 30, writes24h: 0, lastWriteAt: daysAgo(3) }]);
+    });
+
+    test("--agent for an id not present in perAgent → empty array, not a crash", () => {
+      const r = computeQualityReport(true, fixture(), { now: NOW, agentId: "nonexistent" });
+      expect(r.signalDensity?.perAgent).toEqual([]);
+    });
+
+    test("no per-agent stats → null + gap", () => {
+      const data = fixture();
+      delete (data as any).agents;
+      const r = computeQualityReport(true, data, { now: NOW });
+      expect(r.signalDensity).toBeNull();
+      expect(r.gaps.some((g) => g.metric === "signalDensity" && g.reason.includes("no per-agent stats"))).toBe(true);
+    });
+  });
+
+  describe("quiet agents", () => {
+    test("flags agents at/over the threshold, not under it", () => {
+      const r = computeQualityReport(true, fixture(), { now: NOW });
+      const byId = Object.fromEntries((r.quietAgents?.perAgent ?? []).map((a) => [a.id, a]));
+      expect(byId.flint.quiet).toBe(false); // 0 days
+      expect(byId.anvil.quiet).toBe(false); // 3 days < 7
+      expect(byId.pulse.quiet).toBe(true); // 30 days >= 7
+      expect(r.quietAgents?.thresholdDays).toBe(QUALITY_QUIET_THRESHOLD_DAYS);
+      expect(r.quietAgents?.quietCount).toBe(1);
+    });
+
+    test("exactly at the threshold boundary counts as quiet (>=, not >)", () => {
+      const data = fixture({
+        agents: {
+          count: 1,
+          perAgent: [{ id: "solo", memoryCount: 5, hashFallback: 0, writes24h: 0, lastWriteAt: daysAgo(QUALITY_QUIET_THRESHOLD_DAYS) }],
+        },
+      });
+      const r = computeQualityReport(true, data, { now: NOW });
+      expect(r.quietAgents?.perAgent[0].quiet).toBe(true);
+      expect(r.quietAgents?.perAgent[0].daysSinceLastWrite).toBe(QUALITY_QUIET_THRESHOLD_DAYS);
+    });
+
+    test("agent with no lastWriteAt at all → quiet: true, daysSinceLastWrite: null ('never written', not a crash)", () => {
+      const data = fixture({
+        agents: {
+          count: 1,
+          perAgent: [{ id: "fresh", memoryCount: 0, hashFallback: 0, writes24h: 0, lastWriteAt: null }],
+        },
+      });
+      const r = computeQualityReport(true, data, { now: NOW });
+      expect(r.quietAgents?.perAgent[0]).toEqual({
+        id: "fresh",
+        memoryCount: 0,
+        writes24h: 0,
+        lastWriteAt: null,
+        daysSinceLastWrite: null,
+        quiet: true,
+      });
+    });
+
+    test("--agent scopes quiet-agent detection to one agent", () => {
+      const r = computeQualityReport(true, fixture(), { now: NOW, agentId: "pulse" });
+      expect(r.quietAgents?.perAgent.map((a) => a.id)).toEqual(["pulse"]);
+      expect(r.quietAgents?.quietCount).toBe(1);
+    });
+  });
+
+  describe("--json output shape (the full report object)", () => {
+    test("top-level keys are stable — agentFilter, instance, embeddingCoverage, staleness, signalDensity, quietAgents, gaps", () => {
+      const r = computeQualityReport(true, fixture(), { now: NOW });
+      expect(Object.keys(r).sort()).toEqual(
+        ["agentFilter", "embeddingCoverage", "gaps", "instance", "quietAgents", "signalDensity", "staleness"].sort(),
+      );
+    });
+
+    test("agentFilter reflects the --agent value, or null for the fleet-wide default", () => {
+      expect(computeQualityReport(true, fixture(), { now: NOW }).agentFilter).toBeNull();
+      expect(computeQualityReport(true, fixture(), { now: NOW, agentId: "flint" }).agentFilter).toBe("flint");
+    });
+
+    test("report is JSON-serializable with no undefined/function leakage", () => {
+      const r = computeQualityReport(true, fixture(), { now: NOW });
+      expect(() => JSON.stringify(r)).not.toThrow();
+      const round = JSON.parse(JSON.stringify(r));
+      expect(round.instance.up).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
Slice 1a of the memory-quality observability arc (K&S design-approved). Spec: the `flair quality` core read-only report.

## What this adds
`flair quality [--agent <id>] [--json]` — mirrors `status`/`doctor`: fetches `/HealthDetail` via the **existing shared `fetchHealthDetail` helper** (the same fetch status/doctor use — so Sherlock's read-scope invariant holds *by construction*) and computes metrics **CLI-side**. Zero new server surface, no new endpoint/resource, no writes. Downstream of all authority — never referenced by any access/scope/attribution/dedup/ranking path (#735 zero-authority spine).

## Metrics (from `/HealthDetail` only)
| Metric | Fidelity |
|---|---|
| **Instance health** (up, migrations clean, embeddings operational) | Full |
| **Embedding coverage** (% real, non-hash-fallback) | Full |
| **Staleness** (% expired) | Instance-wide only — see gap note |
| **Signal density** per agent (write volume + last-active) | Write-volume only — see gap note |
| **Quiet agents** (days since last write, 7-day default) | Full |

Every degraded/unavailable metric emits a `gaps[]` entry (and `--json` nulls the section) — graceful degradation, never a crash.

## Two deliberate scope-downs (flagging for K&S)
1. **Embeddings status is *inferred* from stored coverage stats, not a live semantic round-trip.** `doctor`'s `verifySemanticSearch()` **writes a probe memory** to test recall-by-meaning; a read-only command must not write, so this infers status from hash-fallback % + model spread. A real but weaker signal than doctor's live check — intentional.
2. **Signal density ships write-volume only; citation rate is deferred.** Kern's design wanted `writes vs usageCount` (citation rate), but **`usageCount` isn't in `/HealthDetail`** — it's only reachable via `GET /Memory?agentId=`, a read pattern status/doctor never use. Adding it would weaken the "reads exactly what status/doctor read" invariant. So this ships write-volume + last-active (labeled a *usage pattern*, never a trust judgment per Sherlock) and notes the gap.
   - **Proposed Slice 1b fork for your input:** rather than adding a `GET /Memory` loop CLI-side, extend the `/HealthDetail` resolver (`resources/health.ts`, flair-side) to aggregate per-agent `usageCount` — then citation rate computes CLI-side from `/HealthDetail` *and* the invariant still holds. Cleaner than the CLI-side join. Worth a nod before I spec 1b.

## Naming (Sherlock)
"Signal density / citation rate" is framed everywhere as a **usage pattern** — a low citation rate reads as "writes exploratory content," never "noisy/untrustworthy." Quiet-agent detection is an **ops fact**, not a trust signal.

## Tests
`test/unit/quality-report.test.ts` — 25 unit tests against fixture `/HealthDetail` payloads (coverage %, staleness %, signal density, quiet detection, gap emission, JSON shape), mirroring the `doctor-summary`/`doctor-agent-iteration` "extract the pure decision logic" convention. `computeQualityReport()` is pure (injectable `now`).

- `flair quality` suite: **25 pass / 0 fail**.
- Typecheck (`tsconfig.cli.json`): **clean**.
- Full `test/unit`: 2 pre-existing failures in `usage-recording.test.ts` (untouched here; passes 14/14 in isolation — cross-file test-ordering flake, identical count on clean `origin/main`).

## Out of scope (later slices, already designed)
1b: dedup-cluster count + citation-rate (via the `/HealthDetail` extension above). 1c: recall spot-check (inline canned queries). Slice 2: OrgEvents. Slice 3: Canary watcher (snapshots as Flair memories).
