### PR TITLE
ci(migration-lanes): fix downgrade-and-revert flake — keep embedding-model pin across baseline restart

### DIFF
--- a/.github/workflows/migration-ci-lanes.yml
+++ b/.github/workflows/migration-ci-lanes.yml
@@ -246,7 +246,21 @@ jobs:
           # && flair restart`), no re-init, no touching the files by hand.
           # Back to $BASE_DIR so the baseline spawns ITS OWN Harper. ──
           cd "$BASE_DIR"
-          unset FLAIR_ENABLE_TEST_MIGRATIONS FLAIR_MIGRATION_TEST_BATCH_DELAY_MS FLAIR_EMBEDDING_MODEL
+          # Keep FLAIR_EMBEDDING_MODEL pinned across the baseline restart too
+          # (do NOT unset it here). The always-registered embedding-stamp
+          # migration runs on every boot and flags any row whose embeddingModel
+          # != getModelId(); getModelId() reads FLAIR_EMBEDDING_MODEL live. If we
+          # unset it, the baseline's getModelId() returns the real default, so
+          # all seeded rows (carrying the PINNED stamp) look stale — the baseline
+          # then genuinely re-embeds them, racing this script's post-downgrade
+          # read and rewriting embeddingModel on a nondeterministic few rows
+          # (the "N rows lost the pinned embeddingModel stamp — isolation broken"
+          # flake). Keeping the pin means the baseline's embedding-stamp finds
+          # nothing pending, so no re-embed runs. Zero effect on invariant I
+          # (byte-identical content, real partial-migration state, clean old-binary
+          # boot). The other two vars stay unset — the baseline doesn't know the
+          # synthetic-migration gate anyway.
+          unset FLAIR_ENABLE_TEST_MIGRATIONS FLAIR_MIGRATION_TEST_BATCH_DELAY_MS
           $BASE_FLAIR start --port $PORT
           wait_for_http_ok "${BASE_URL}/Health" 90 "baseline Harper (post-downgrade)"
           # Version-safe on the baseline: 0.21.0's `flair status` probes the


### PR DESCRIPTION
Fixes the flaky **Migration downgrade-and-revert (invariant I proof)** CI lane — a **test-harness bug, not a product bug** (the invariant it proves is sound).

## Root cause (proven from CI artifacts, two independent failing runs)
The downgrade step unsets `FLAIR_EMBEDDING_MODEL` right before restarting the **baseline** (previously-published) binary (`.github/workflows/migration-ci-lanes.yml` line 249). But:
- `embedding-stamp` (`resources/migrations/embedding-stamp.ts`) is unconditionally registered and runs on **every** boot; its `staleCondition` flags any row whose `embeddingModel != getModelId()`.
- `getModelId()` (`resources/embeddings-provider.ts`) reads `FLAIR_EMBEDDING_MODEL` **live**.

With the var unset, the baseline's `getModelId()` returns the real default (`nomic-embed-text-v1.5-Q4_K_M+searchprefix`) instead of the pinned test stamp, so all 140 seeded rows look **stale** → the baseline genuinely re-embeds them → that races the script's post-downgrade read ~3s later and rewrites `embeddingModel` on a nondeterministic few rows → `N rows lost the pinned embeddingModel stamp — isolation broken`.

**Evidence:** across two independent runs, the "bad" rows carry the *exact* real default model id (not corruption), `source` = the synthetic marker (so the synthetic migration had preserved their stamp correctly), and `updatedAt` squarely inside the baseline's post-restart window — matching an `embedding-stamp-*` snapshot dir created on that restart.

**Ruled out:** cross-migration concurrency (migrations run sequentially, single-flight-locked, `THREADS_COUNT=1`); a synthetic-migration write bug (`synthetic-test-migration.ts` round-trips `embeddingModel` unchanged).

## Fix
Drop `FLAIR_EMBEDDING_MODEL` from the `unset` so the pin carries through the baseline restart too (it stays exported from line 228). Then the baseline's embedding-stamp sees `getModelId()` == the pinned stamp, finds nothing stale, and never re-embeds — eliminating the race. **Zero effect on invariant I** (byte-identical content, real partial-migration state, clean old-binary boot). A comment is added so the `unset` isn't reintroduced.

## Validation
This PR's own **Migration downgrade-and-revert** lane runs with the fix — it should pass deterministically (that's the proof). The check is now a required status check, so this also unblocks merges on `main`.
