### PR TITLE
fix(test): remove process-global mcp-handler mock that flaked Unit Tests

### DIFF
--- a/resources/mcp-oauth.ts
+++ b/resources/mcp-oauth.ts
@@ -20,7 +20,15 @@
 
 import * as harper from "@harperfast/harper";
 import { mcpOAuthEnabled, mcpAuthConfig } from "./mcp-oauth-flag.js";
-import { mcpHandler } from "./mcp-handler.js";
+// NOTE: mcpHandler is intentionally NOT statically imported here — it's resolved
+// lazily (deps.mcpHandler ?? dynamic import) inside registerMcpOAuthRoute, same
+// as loadWithMCPAuth below. A static `import { mcpHandler } from "./mcp-handler.js"`
+// forced any test that wanted to mock this module to `mock.module(...)` it — a
+// process-global, unrestored bun mock (bun test runs all files in one process)
+// that raced mcp-handler.test.ts's own real `await import("./mcp-handler.js")`
+// and intermittently poisoned it (undefined resolveAgentFromSub → 35 tests fail
+// together). See resources/mcp-tools.ts's LOADERS/__setHandlers doc for the same
+// "inject, don't mock.module shared resources/*.ts" rationale.
 
 /**
  * Register the guarded /mcp route iff the flag is on. Called once at module load
@@ -38,6 +46,9 @@ export interface RegisterDeps {
   server?: { http: (handler: any, options: any) => void };
   /** Loader for withMCPAuth (injectable for tests; defaults to the real plugin). */
   loadWithMCPAuth?: () => Promise<(handler: any, options?: any) => any>;
+  /** The /mcp request handler (injectable for tests; defaults to a lazy import
+   *  of ./mcp-handler.js — never statically imported, see the note at the top). */
+  mcpHandler?: any;
 }
 
 async function defaultLoadWithMCPAuth(): Promise<(handler: any, options?: any) => any> {
@@ -76,6 +87,10 @@ export async function registerMcpOAuthRoute(deps: RegisterDeps = {}): Promise<bo
     return false;
   }
 
+  // Resolve the handler lazily (injected in tests; real module otherwise) — see
+  // the top-of-file note on why it isn't a static import.
+  const handler = deps.mcpHandler ?? (await import("./mcp-handler.js")).mcpHandler;
+
   // Read `server` lazily off the namespace (it's a runtime global on the Harper
   // module, not a static named export) so this module links cleanly even where a
   // stub build of @harperfast/harper lacks the export.
@@ -87,7 +102,7 @@ export async function registerMcpOAuthRoute(deps: RegisterDeps = {}): Promise<bo
   // resolves a different node_modules copy of the plugin (docs/mcp-oauth.md
   // §"Using withMCPAuth from a different component").
   srv.http(
-    withMCPAuth(mcpHandler, {
+    withMCPAuth(handler, {
       getConfig: () => mcpAuthConfig(),
     }),
     { urlPath: "/mcp" },

--- a/test/unit/mcp-oauth-register.test.ts
+++ b/test/unit/mcp-oauth-register.test.ts
@@ -32,9 +32,13 @@ mock.module("@harperfast/harper", () => ({
   Resource: NoopBase,
   databases: { flair: dbStub },
 }));
-// mcp-handler.ts (imported by mcp-oauth.ts) pulls in the resource handlers +
-// databases; stub so the import graph loads outside a Harper runtime.
-mock.module("../../resources/mcp-handler.ts", () => ({ mcpHandler: () => ({ status: 200 }) }));
+// NO mock.module for ./mcp-handler.ts: mcp-oauth.ts no longer statically imports
+// it (it's resolved lazily / via deps.mcpHandler), so loading mcp-oauth.ts here
+// doesn't pull in the resource graph and there's nothing to stub for link-time.
+// The handler is injected via deps.mcpHandler in makeDeps() below. Crucially,
+// this file must NOT process-globally mock a module that mcp-handler.test.ts
+// legitimately `await import(...)`s for real — that was the source of the
+// intermittent "35 tests failed" flake in mcp-handler.test.ts.
 
 const { registerMcpOAuthRoute } = await import("../../resources/mcp-oauth.ts");
 
@@ -58,6 +62,9 @@ function makeDeps() {
         return { __wrapped: true, handler, options };
       };
     },
+    // Inject the /mcp handler directly (replaces the old process-global
+    // mock.module of ./mcp-handler.ts) — same shape the mock used to return.
+    mcpHandler: () => ({ status: 200 }),
   };
 }
 


### PR DESCRIPTION
Fixes the flaky **Unit Tests** required check — a **test-infra flake** (process-global module-mock leak), not a product bug.

## Root cause (proven from #793's own CI logs)
The whole `tools/call` block in `test/unit/mcp-handler.test.ts` (~35 tests) intermittently failed *together* with `TypeError: resolveAgentFromSub is not a function` and `Expected 405, Received 200`. Cause: `test/unit/mcp-oauth-register.test.ts` did `mock.module("../../resources/mcp-handler.ts", () => ({ mcpHandler: () => ({ status: 200 }) }))` — a **process-global, never-restored** bun mock (`bun test test/unit/` runs every file in one process). `mcp-handler.test.ts` does its own real `await import("../../resources/mcp-handler.ts")`; when the mock registration won the race, that file captured the **stub** (dummy `mcpHandler`, no `resolveAgentFromSub`) → every test in the file failed. All 35-at-once, node-24/26-and-run-specific — the timing-dependent load-order race.

Confirmed against PR #793 (a `.yml`-only change, zero test code) failing on node 24/26 at SHA `5d76dd5`, with `Received: 200` matching the stub's hardcoded status.

## Fix (root-cause, minimal)
That `mock.module` only existed because `resources/mcp-oauth.ts` **statically imported** `mcp-handler.ts` (pulling the resource graph, which needed stubbing to load outside Harper). So:
- `resources/mcp-oauth.ts`: drop the static `import { mcpHandler }`; resolve it lazily — `deps.mcpHandler ?? (await import("./mcp-handler.js")).mcpHandler` — the **same DI pattern** the file already uses for `loadWithMCPAuth`. Loading `mcp-oauth.ts` no longer pulls in the resource graph.
- `test/unit/mcp-oauth-register.test.ts`: delete the `mock.module` of `mcp-handler.ts`; inject the fake handler via the new `deps.mcpHandler` instead.

This removes the *only* `mock.module` anywhere targeting `mcp-handler.ts` — nothing left to race against `mcp-handler.test.ts`'s real import. Follows the codebase's own documented "inject, don't `mock.module` shared resources/*.ts" rationale (`resources/mcp-tools.ts` LOADERS/`__setHandlers`).

## Validation
- The two previously-racing files: **40 pass / 0 fail across 3 repeated runs + reverse order** (was intermittently dropping ~35).
- Full `test/unit`: **2815 pass / 0 fail** (159 files).
- Typecheck (`tsconfig.check.json`) clean; docs-freshness green.

## Review focus
- **Sherlock:** `mcp-oauth.ts` is the OAuth-guarded `/mcp` route. This is a pure wiring refactor — the *same* handler is wrapped by `withMCPAuth` and mounted; only the import timing changed (static → lazy, injectable in tests). Confirm no change to the guard's fail-closed behavior or what gets mounted.
- **Kern:** the DI shape matches the existing `loadWithMCPAuth`; the lazy import is gated behind the flag/issuer checks (only resolved when actually mounting).
