### PR TITLE
fix(openclaw-flair): capture memories in persistent sessions — agent_end never fires (#798)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- **`openclaw-flair`'s `autoCapture` never fired in long-lived persistent gateway sessions.** It only hooked `agent_end`, which fires at the true end of a discrete agent run — a persistent session's "run" never ends, so `agent_end` never fired and auto-capture was dead code in that deployment shape. Real-world: an agent ran May→July with the plugin registered on every boot and zero auto-captures, ever (#798). Auto-capture now also evaluates the same trigger regex live, per turn, on the `llm_input`/`llm_output` hooks (the user-facing prompt and the model's response) — these fire on every model call regardless of how the host bounds a "run", so persistent sessions capture in real time instead of waiting on an event that never comes. The existing `agent_end` path is unchanged for discrete runs. Both paths share one per-session cap (still 3 by default, now tunable via `autoCaptureMaxPerSession`) and dedup by content hash, so a phrase captured live isn't captured again when `agent_end` later rescans the same run's full history.
+
 ## [0.26.0] - 2026-07-22
 
 ### Added

--- a/packages/openclaw-flair/README.md
+++ b/packages/openclaw-flair/README.md
@@ -10,7 +10,7 @@ Uses Flair's native Harper vector embeddings — no OpenAI API key required.
 - **Persistent storage** via `memory_store` → Ed25519-authenticated writes
 - **Memory retrieval** via `memory_get` → fetch by ID
 - **Auto-bootstrap** — injects relevant memories into context at session start
-- **Auto-capture** — automatically stores important information from conversations
+- **Auto-capture** — automatically stores important information from conversations, live, on every turn — works in both discrete runs and long-lived persistent gateway sessions (#798)
 - **Multi-agent** — `agentId: "auto"` resolves per-session for shared gateways
 - **Durability levels** — permanent, persistent, standard, ephemeral
 - **Memory versioning** — `supersedes` field creates version chains
@@ -70,6 +70,16 @@ In your OpenClaw config (`openclaw.json`):
 | `autoCapture` | boolean | `true` | Auto-capture important info from conversations |
 | `autoRecall` | boolean | `true` | Inject relevant memories at session start |
 | `maxRecallResults` | number | `5` | Max results for `memory_search` |
+| `autoCaptureMaxPerSession` | number | `3` | Cap on trigger-based auto-captures per session (see below) |
+
+### Auto-capture
+
+Auto-capture scans conversation text for a small set of conservative trigger phrases (e.g. "remember this", "we decided", "my name is") and writes a matching excerpt to Flair. It runs on two hooks:
+
+- **`agent_end`** — scans the full conversation once, at the true end of a discrete run. Also detects entities/relationships from the same pass.
+- **`llm_input`/`llm_output`** — scans the live prompt/response on every model call. This is what makes auto-capture work in a long-lived, persistent gateway session, where `agent_end` never fires because the "run" never ends (#798).
+
+Both hooks share one capture budget per agent session (`autoCaptureMaxPerSession`, default 3) and dedup by content hash, so a phrase captured live during a run isn't captured again when `agent_end` rescans that same run's history at the end. For a persistent session that never fires `agent_end`, the budget is never reset — it's a cap for the session's whole lifetime, not per calendar day. Raise `autoCaptureMaxPerSession` if a long-lived deployment needs more than 3 auto-captures over its life.
 
 ## Tool naming
 

--- a/packages/openclaw-flair/index.ts
+++ b/packages/openclaw-flair/index.ts
@@ -10,7 +10,9 @@
  *   - memory_store   → PUT  /Memory/<id>  (write + embed)
  *   - memory_get     → GET  /Memory/<id>  (fetch by id)
  *   - before_agent_start hook → inject recent/relevant memories
- *   - agent_end hook → auto-capture from conversation
+ *   - agent_end hook → auto-capture from conversation (discrete runs)
+ *   - llm_input/llm_output hooks → auto-capture from live turns
+ *     (long-lived/persistent sessions — see "Auto-capture" below, #798)
  */
 
 import { createHash } from "node:crypto";
@@ -54,11 +56,21 @@ interface FlairMemoryConfig {
   autoRecall?: boolean;
   maxRecallResults?: number;
   maxBootstrapTokens?: number;
+  /**
+   * Cap on trigger-based auto-captures per "session" — where a session is
+   * bounded by before_agent_start (start) / agent_end (end). For discrete
+   * runs that's one run; for a long-lived persistent session that never
+   * fires agent_end (#798), it's the whole life of the session, since there
+   * is no other reliable reset signal. Raise this for persistent deployments
+   * that want more than the discrete-run default over their lifetime.
+   */
+  autoCaptureMaxPerSession?: number;
 }
 
 const DEFAULT_URL = "http://127.0.0.1:19926";
 const DEFAULT_MAX_RECALL = 5;
 const DEFAULT_MAX_BOOTSTRAP_TOKENS = 4000;
+const DEFAULT_AUTO_CAPTURE_MAX_PER_SESSION = 3;
 
 // ─── Workspace sync helpers ───────────────────────────────────────────────────
 
@@ -128,6 +140,54 @@ function shouldCapture(text: string): boolean {
 
 function excerptForCapture(text: string, maxChars = 500): string {
   return text.length > maxChars ? `${text.slice(0, maxChars)}…` : text;
+}
+
+// ─── Auto-capture: shared trigger evaluation + cap/dedup state ───────────────
+// Two independent paths feed the same capture logic:
+//   1. agent_end     — full-session message scan (discrete runs; fires once
+//                       at the true end of a run).
+//   2. llm_input/llm_output — per-call live-turn scan (fires on every model
+//                       request/response, so it also covers persistent
+//                       sessions where agent_end never fires — #798).
+// Both paths share one CaptureState per agentId so the "N per session" cap
+// and the duplicate-content guard apply across paths, not per-path — a
+// phrase captured live during a run isn't re-captured when agent_end
+// rescans the same run's full history at the end.
+
+interface CaptureState {
+  count: number;
+  hashes: Set<string>;
+}
+
+function createCaptureState(): CaptureState {
+  return { count: 0, hashes: new Set() };
+}
+
+/**
+ * Pure decision: given a candidate text and the current per-session capture
+ * state, decide whether it should be captured. Returns the excerpt + content
+ * hash to write, or null if the text doesn't match a trigger, the session
+ * cap is already spent, or this exact excerpt was already captured (via
+ * either path). Does not mutate state or perform I/O — callers apply the
+ * decision (write the memory, then call recordCapture).
+ */
+export function evaluateAutoCapture(
+  text: string,
+  state: Pick<CaptureState, "count" | "hashes">,
+  maxPerSession: number = DEFAULT_AUTO_CAPTURE_MAX_PER_SESSION,
+): { excerpt: string; hash: string } | null {
+  if (!shouldCapture(text)) return null;
+  if (state.count >= maxPerSession) return null;
+  const excerpt = excerptForCapture(text);
+  const hash = hashContent(excerpt);
+  if (state.hashes.has(hash)) return null;
+  return { excerpt, hash };
+}
+
+/** Records a capture decision against state — call after the write succeeds. */
+function recordCapture(state: CaptureState, hash: string): void {
+  state.count++;
+  state.hashes.add(hash);
 }
 
 // ─── Entity detection ────────────────────────────────────────────────────────
@@ -449,6 +509,47 @@ export default {
     const maxRecall = cfg.maxRecallResults ?? DEFAULT_MAX_RECALL;
     const autoCapture = cfg.autoCapture ?? false; // opt-in — trust the LLM to use memory_store
     const autoRecall = cfg.autoRecall ?? true;
+    const autoCaptureMaxPerSession = Math.max(1, cfg.autoCaptureMaxPerSession ?? DEFAULT_AUTO_CAPTURE_MAX_PER_SESSION);
+
+    // Auto-capture state, one per agentId — shared across the agent_end path
+    // and the live-turn (llm_input/llm_output) path so the cap and the
+    // duplicate-content guard apply across both (see evaluateAutoCapture).
+    const captureStatePool = new Map<string, CaptureState>();
+    function getCaptureState(agentId: string): CaptureState {
+      let state = captureStatePool.get(agentId);
+      if (!state) {
+        state = createCaptureState();
+        captureStatePool.set(agentId, state);
+      }
+      return state;
+    }
+    // Fresh budget for the next run. Only ever called from agent_end, which
+    // is the one reliable "this run/session is over" signal we have — for a
+    // persistent session that never fires agent_end (#798), this simply
+    // never runs, so the cap holds for the session's whole lifetime.
+    function resetCaptureState(agentId: string): void {
+      captureStatePool.delete(agentId);
+    }
+
+    /**
+     * Evaluate + (if triggered) write a single auto-captured memory. Shared
+     * by the agent_end path and the live-turn path — same regex gate, same
+     * per-session cap, same dedup-by-content-hash guard.
+     */
+    async function tryAutoCapture(client: FlairClient, agentId: string, text: string): Promise<boolean> {
+      const state = getCaptureState(agentId);
+      const decision = evaluateAutoCapture(text, state, autoCaptureMaxPerSession);
+      if (!decision) return false;
+      const entities = detectEntities(text);
+      const subject = entities.length > 0 ? entities[0].name.toLowerCase() : undefined;
+      await client.memory.write(decision.excerpt, {
+        type: "session",
+        tags: ["auto-captured"],
+        subject,
+      });
+      recordCapture(state, decision.hash);
+      return true;
+    }
 
     // Per-session agentId — resolved from session context at runtime.
     // In auto mode, each session gets its own agentId from before_agent_start.
@@ -692,12 +793,33 @@ export default {
       });
     }
 
-    // ── Lifecycle: auto-capture on session end ────────────────────────────
+    // ── Lifecycle: auto-capture ─────────────────────────────────────────────
+    // Two paths, same trigger regex + cap + dedup (see tryAutoCapture above):
+    //
+    //  1. agent_end — full-session message scan + entity/relationship
+    //     detection. Reliable for discrete runs (agent_end fires at the true
+    //     end of each run). Also resets the per-agentId capture budget for
+    //     the next run.
+    //
+    //  2. llm_input/llm_output — live, per-call scan. agent_end never fires
+    //     in a long-lived persistent gateway session (the "run" never ends,
+    //     so autoCapture was dead code there — #798). llm_input/llm_output
+    //     fire on every model request/response regardless of how the host
+    //     bounds a "run" or "session", so they cover that deployment shape
+    //     without needing a session-end signal at all. Entity/relationship
+    //     detection stays exclusive to agent_end (full-history pass is a
+    //     better fit for that than re-running it on every single call).
+    //
+    // Both paths write through the same getClient()/getCaptureState(agentId)
+    // pool, so a phrase captured live isn't re-captured when agent_end
+    // rescans the same run's history at the end (hash-deduped).
 
     if (autoCapture) {
-      api.on("agent_end", async (event) => {
+      api.on("agent_end", async (event, ctx: any) => {
+        const agentId = ctx?.agentId || currentAgentId || fallbackAgentId || undefined;
+        if (!agentId) return;
         try {
-          const client = getCurrentClient();
+          const client = getClient(agentId);
           const messages = (event.messages ?? []) as Array<{ role: string; content?: string }>;
           let stored = 0;
           const allEntities = new Map<string, DetectedEntity>();
@@ -708,19 +830,10 @@ export default {
             const text = typeof msg.content === "string" ? msg.content : "";
             if (!text || text.length < MIN_CAPTURE_LENGTH) continue;
 
-            // Traditional trigger-based capture
-            if (shouldCapture(text) && stored < 3) {
-              const excerpt = excerptForCapture(text);
-              // Tag with detected subject if available
-              const entities = detectEntities(text);
-              const subject = entities.length > 0 ? entities[0].name.toLowerCase() : undefined;
-              await client.memory.write(excerpt, {
-                type: "session",
-                tags: ["auto-captured"],
-                subject,
-              });
-              stored++;
-            }
+            // Traditional trigger-based capture (dedup guards against
+            // re-capturing something the live llm_input/llm_output path
+            // already wrote earlier in this same run).
+            if (await tryAutoCapture(client, agentId, text)) stored++;
 
             // Entity detection — accumulate across all messages
             for (const entity of detectEntities(text)) {
@@ -763,6 +876,45 @@ export default {
           }
         } catch (err: any) {
           api.logger.warn(`openclaw-flair: auto-capture failed: ${err.message}`);
+        } finally {
+          // Run is over — fresh capture budget for the next one. Never
+          // reached for a persistent session (that's the whole bug), so the
+          // budget correctly holds for that session's entire lifetime.
+          resetCaptureState(agentId);
+        }
+      });
+
+      // Live-turn capture: fires on every LLM call/response, independent of
+      // whatever the host considers a "run" or "session" boundary — the
+      // fix for #798. Evaluates the exact same shouldCapture() regex against
+      // each side of the exchange as it happens, instead of waiting for a
+      // session-end event that a persistent session never produces.
+      api.on("llm_input", async (event: any, ctx: any) => {
+        const agentId = ctx?.agentId || currentAgentId || fallbackAgentId || undefined;
+        if (!agentId) return;
+        const text = typeof event?.prompt === "string" ? event.prompt : "";
+        if (!text) return;
+        try {
+          const client = getClient(agentId);
+          const captured = await tryAutoCapture(client, agentId, text);
+          if (captured) api.logger.info("openclaw-flair: auto-captured 1 memory from live turn (llm_input)");
+        } catch (err: any) {
+          api.logger.warn(`openclaw-flair: live auto-capture (llm_input) failed: ${err.message}`);
+        }
+      });
+
+      api.on("llm_output", async (event: any, ctx: any) => {
+        const agentId = ctx?.agentId || currentAgentId || fallbackAgentId || undefined;
+        if (!agentId) return;
+        const texts = Array.isArray(event?.assistantTexts) ? event.assistantTexts : [];
+        const text = texts.filter((t: unknown) => typeof t === "string").join("\n");
+        if (!text) return;
+        try {
+          const client = getClient(agentId);
+          const captured = await tryAutoCapture(client, agentId, text);
+          if (captured) api.logger.info("openclaw-flair: auto-captured 1 memory from live turn (llm_output)");
+        } catch (err: any) {
+          api.logger.warn(`openclaw-flair: live auto-capture (llm_output) failed: ${err.message}`);
         }
       });
     }

--- a/packages/openclaw-flair/openclaw.plugin.json
+++ b/packages/openclaw-flair/openclaw.plugin.json
@@ -29,6 +29,11 @@
     "autoRecall": {
       "label": "Auto-Recall",
       "help": "Automatically inject relevant memories into context at session start"
+    },
+    "autoCaptureMaxPerSession": {
+      "label": "Auto-Capture Max Per Session",
+      "help": "Cap on trigger-based auto-captures per session (default 3). For a long-lived persistent session, this is the cap for the session's whole lifetime, not per calendar day.",
+      "advanced": true
     }
   },
   "configSchema": {
@@ -41,7 +46,8 @@
       "autoCapture": { "type": "boolean" },
       "autoRecall": { "type": "boolean" },
       "maxRecallResults": { "type": "number", "minimum": 1, "maximum": 20 },
-      "maxBootstrapTokens": { "type": "number", "minimum": 500, "maximum": 8000 }
+      "maxBootstrapTokens": { "type": "number", "minimum": 500, "maximum": 8000 },
+      "autoCaptureMaxPerSession": { "type": "number", "minimum": 1, "maximum": 50 }
     },
     "required": []
   },

--- a/packages/openclaw-flair/test/plugin.test.ts
+++ b/packages/openclaw-flair/test/plugin.test.ts
@@ -707,3 +707,281 @@ describe("memory_store supersede — write-then-close ordering", () => {
     expect(writePut!.body.dedup).toBe(true);
   });
 });
+
+// ─── evaluateAutoCapture — pure trigger/cap/dedup decision logic (#798) ──────
+// Pure function: no I/O, no plugin registration. Mirrors shouldCapture's
+// regex gate + MIN_CAPTURE_LENGTH, plus the per-session cap and the
+// hash-based dedup guard that lets the agent_end path and the new live-turn
+// (llm_input/llm_output) path share one capture budget without double-
+// writing the same content.
+
+import { evaluateAutoCapture } from "../index.ts";
+
+function freshCaptureState() {
+  return { count: 0, hashes: new Set<string>() };
+}
+
+describe("evaluateAutoCapture — pure trigger/cap/dedup logic", () => {
+  test("returns null for text with no trigger phrase", () => {
+    const state = freshCaptureState();
+    const text = "just a normal message with nothing special about it at all, really";
+    expect(evaluateAutoCapture(text, state)).toBeNull();
+  });
+
+  test("returns null for a trigger phrase shorter than MIN_CAPTURE_LENGTH (30 chars)", () => {
+    const state = freshCaptureState();
+    expect(evaluateAutoCapture("call me Bob", state)).toBeNull(); // 11 chars
+  });
+
+  test("returns an excerpt + hash for text matching a trigger", () => {
+    const state = freshCaptureState();
+    const text = "remember this: the deploy window is Tuesdays only, no exceptions";
+    const decision = evaluateAutoCapture(text, state);
+    expect(decision).not.toBeNull();
+    expect(decision!.excerpt).toBe(text);
+    expect(typeof decision!.hash).toBe("string");
+    expect(decision!.hash.length).toBe(16);
+  });
+
+  test("matches each trigger category (name, decision, note-for-record)", () => {
+    const state = freshCaptureState();
+    expect(evaluateAutoCapture("my name is Nathan and I run this company", state)).not.toBeNull();
+    expect(evaluateAutoCapture("we decided to ship the fix today instead of waiting", freshCaptureState())).not.toBeNull();
+    expect(evaluateAutoCapture("note for future: always check the CHANGELOG first", freshCaptureState())).not.toBeNull();
+  });
+
+  test("does not mutate state — caller must call recordCapture-equivalent separately", () => {
+    const state = freshCaptureState();
+    const text = "key decision: we are migrating off the old queue by Friday";
+    evaluateAutoCapture(text, state);
+    expect(state.count).toBe(0);
+    expect(state.hashes.size).toBe(0);
+  });
+
+  test("returns null once the per-session cap is reached", () => {
+    const state = freshCaptureState();
+    state.count = 3; // default cap
+    const text = "remember this: the cap should block further captures this session";
+    expect(evaluateAutoCapture(text, state)).toBeNull();
+  });
+
+  test("respects a custom maxPerSession", () => {
+    const state = freshCaptureState();
+    state.count = 1;
+    const text = "remember this: a lower cap should also block at count 1";
+    expect(evaluateAutoCapture(text, state, 1)).toBeNull();
+    expect(evaluateAutoCapture(text, state, 2)).not.toBeNull();
+  });
+
+  test("dedup: returns null for content whose hash was already captured", () => {
+    const state = freshCaptureState();
+    const text = "remember this: identical content should only ever be captured once";
+    const first = evaluateAutoCapture(text, state);
+    expect(first).not.toBeNull();
+    state.hashes.add(first!.hash);
+    state.count++;
+    // Same text seen again (e.g. live turn already captured it, agent_end
+    // rescans the same run's history at the end) — must be skipped.
+    expect(evaluateAutoCapture(text, state)).toBeNull();
+  });
+
+  test("distinct content is still capturable after a prior capture", () => {
+    const state = freshCaptureState();
+    const first = evaluateAutoCapture("remember this: first distinct fact worth keeping around", state);
+    state.hashes.add(first!.hash);
+    state.count++;
+    const second = evaluateAutoCapture("remember this: second distinct fact, unrelated to the first", state);
+    expect(second).not.toBeNull();
+    expect(second!.hash).not.toBe(first!.hash);
+  });
+
+  test("excerpt is truncated for very long text (matches excerptForCapture behavior)", () => {
+    const state = freshCaptureState();
+    const longText = "remember this: " + "x".repeat(600);
+    const decision = evaluateAutoCapture(longText, state);
+    expect(decision).not.toBeNull();
+    expect(decision!.excerpt.length).toBeLessThan(longText.length);
+    expect(decision!.excerpt.endsWith("…")).toBe(true);
+  });
+});
+
+// ─── Live-turn auto-capture (#798) — llm_input/llm_output hooks ─────────────
+// agent_end never fires in a long-lived persistent gateway session (the
+// "run" never ends), so autoCapture was dead code in that deployment shape.
+// These hooks fire on every model request/response instead, independent of
+// how the host bounds a run — proving capture now works without ever
+// firing agent_end at all.
+
+describe("live-turn auto-capture (#798) — llm_input/llm_output hooks", () => {
+  const originalRequest = FlairClient.prototype.request;
+
+  afterEach(() => {
+    FlairClient.prototype.request = originalRequest;
+  });
+
+  test("registers llm_input and llm_output hooks when autoCapture is enabled", async () => {
+    const plugin = (await import("../index.ts")).default;
+    const api = createMockApi({ autoCapture: true });
+    plugin.register(api as any);
+
+    expect((api._hooks.get("llm_input") ?? []).length).toBeGreaterThanOrEqual(1);
+    expect((api._hooks.get("llm_output") ?? []).length).toBeGreaterThanOrEqual(1);
+    expect((api._hooks.get("agent_end") ?? []).length).toBeGreaterThanOrEqual(1);
+  });
+
+  test("does NOT register llm_input/llm_output/agent_end hooks when autoCapture is disabled", async () => {
+    const plugin = (await import("../index.ts")).default;
+    const api = createMockApi({ autoCapture: false });
+    plugin.register(api as any);
+
+    expect(api._hooks.get("llm_input") ?? []).toHaveLength(0);
+    expect(api._hooks.get("llm_output") ?? []).toHaveLength(0);
+    expect(api._hooks.get("agent_end") ?? []).toHaveLength(0);
+  });
+
+  test("captures a memory from llm_output alone — agent_end is never fired (persistent-session simulation)", async () => {
+    const calls: Array<{ method: string; path: string; body?: any }> = [];
+    (FlairClient.prototype as any).request = async function (method: string, path: string, body?: any) {
+      calls.push({ method, path, body });
+      return { written: true };
+    };
+
+    const plugin = (await import("../index.ts")).default;
+    const api = createMockApi({ autoCapture: true });
+    plugin.register(api as any);
+
+    const [llmOutputHook] = api._hooks.get("llm_output") ?? [];
+    expect(llmOutputHook).toBeDefined();
+
+    await llmOutputHook(
+      { assistantTexts: ["note for future: always deploy behind the feature flag first"] },
+      { agentId: "test-agent" },
+    );
+
+    const writes = calls.filter((c) => c.method === "PUT" && c.path.startsWith("/Memory/"));
+    expect(writes.length).toBe(1);
+    expect(writes[0].body.content).toContain("note for future");
+    expect(writes[0].body.tags).toContain("auto-captured");
+  });
+
+  test("captures a memory from llm_input (user-side trigger text)", async () => {
+    const calls: Array<{ method: string; path: string; body?: any }> = [];
+    (FlairClient.prototype as any).request = async function (method: string, path: string, body?: any) {
+      calls.push({ method, path, body });
+      return { written: true };
+    };
+
+    const plugin = (await import("../index.ts")).default;
+    const api = createMockApi({ autoCapture: true });
+    plugin.register(api as any);
+
+    const [llmInputHook] = api._hooks.get("llm_input") ?? [];
+    expect(llmInputHook).toBeDefined();
+
+    await llmInputHook(
+      { prompt: "by the way, my name is Nathan — please use that going forward" },
+      { agentId: "test-agent" },
+    );
+
+    const writes = calls.filter((c) => c.method === "PUT" && c.path.startsWith("/Memory/"));
+    expect(writes.length).toBe(1);
+    expect(writes[0].body.content).toContain("my name is Nathan");
+  });
+
+  test("caps live captures at the per-session default of 3", async () => {
+    const calls: Array<{ method: string; path: string; body?: any }> = [];
+    (FlairClient.prototype as any).request = async function (method: string, path: string, body?: any) {
+      calls.push({ method, path, body });
+      return { written: true };
+    };
+
+    const plugin = (await import("../index.ts")).default;
+    const api = createMockApi({ autoCapture: true });
+    plugin.register(api as any);
+
+    const [llmOutputHook] = api._hooks.get("llm_output") ?? [];
+    for (let i = 0; i < 6; i++) {
+      await llmOutputHook(
+        { assistantTexts: [`key decision: distinct fact number ${i} worth remembering forever`] },
+        { agentId: "test-agent" },
+      );
+    }
+
+    const writes = calls.filter((c) => c.method === "PUT" && c.path.startsWith("/Memory/"));
+    expect(writes.length).toBe(3);
+  });
+
+  test("does not double-capture identical content seen via both llm_output and agent_end", async () => {
+    const calls: Array<{ method: string; path: string; body?: any }> = [];
+    (FlairClient.prototype as any).request = async function (method: string, path: string, body?: any) {
+      calls.push({ method, path, body });
+      return { written: true };
+    };
+
+    const plugin = (await import("../index.ts")).default;
+    const api = createMockApi({ autoCapture: true });
+    plugin.register(api as any);
+
+    const [llmOutputHook] = api._hooks.get("llm_output") ?? [];
+    const [agentEndHook] = api._hooks.get("agent_end") ?? [];
+    const text = "final decision: we are keeping the current pricing model as-is";
+
+    // Captured live, mid-run.
+    await llmOutputHook({ assistantTexts: [text] }, { agentId: "test-agent" });
+    // agent_end rescans the FULL run history at the end, including the same
+    // message already captured live — must be deduped, not written twice.
+    await agentEndHook(
+      { messages: [{ role: "assistant", content: text }] },
+      { agentId: "test-agent" },
+    );
+
+    const writes = calls.filter((c) => c.method === "PUT" && c.path.startsWith("/Memory/"));
+    expect(writes.length).toBe(1);
+  });
+
+  test("agent_end resets the capture budget for the next run", async () => {
+    const calls: Array<{ method: string; path: string; body?: any }> = [];
+    (FlairClient.prototype as any).request = async function (method: string, path: string, body?: any) {
+      calls.push({ method, path, body });
+      return { written: true };
+    };
+
+    const plugin = (await import("../index.ts")).default;
+    const api = createMockApi({ autoCapture: true });
+    plugin.register(api as any);
+
+    const [llmOutputHook] = api._hooks.get("llm_output") ?? [];
+    const [agentEndHook] = api._hooks.get("agent_end") ?? [];
+
+    // Run 1: spend the whole budget live, then the run ends.
+    for (let i = 0; i < 3; i++) {
+      await llmOutputHook(
+        { assistantTexts: [`we decided: run-one fact number ${i} for the record`] },
+        { agentId: "test-agent" },
+      );
+    }
+    await agentEndHook({ messages: [] }, { agentId: "test-agent" });
+
+    // Run 2: a fresh persistent-session-style run — budget should be reset.
+    await llmOutputHook(
+      { assistantTexts: ["we decided: run-two fact, budget should be fresh again"] },
+      { agentId: "test-agent" },
+    );
+
+    const writes = calls.filter((c) => c.method === "PUT" && c.path.startsWith("/Memory/"));
+    expect(writes.length).toBe(4); // 3 from run 1 + 1 from run 2
+  });
+
+  test("live capture is silently skipped (no throw) when agentId cannot be resolved", async () => {
+    const plugin = (await import("../index.ts")).default;
+    const api = createMockApi({ agentId: "auto", autoCapture: true });
+    delete process.env.FLAIR_AGENT_ID;
+    plugin.register(api as any);
+
+    const [llmOutputHook] = api._hooks.get("llm_output") ?? [];
+    // No before_agent_start ever fired, so currentAgentId is unresolved.
+    await expect(
+      llmOutputHook({ assistantTexts: ["note for future: this should not crash the host"] }, {}),
+    ).resolves.toBeUndefined();
+  });
+});


### PR DESCRIPTION
Fixes #798 — `openclaw-flair`'s `autoCapture` was dead code in persistent gateway sessions.

## Root cause
`autoCapture` hooked only `agent_end`, which fires at the true end of a discrete agent run. A long-lived persistent gateway session never "ends" → the hook never fires → zero captures ever (observed in production: plugin registered May→July, zero captures).

## Fix
Hook **`llm_input`** (`prompt`) and **`llm_output`** (`assistantTexts`) — these fire on *every model call*, by construction, independent of how the host bounds a "run"/"session" — so capture works in any deployment shape. `agent_end` stays wired for discrete runs (full-history scan + entity/relationship detection).

**No-spam guarantees:** the trigger regex + per-session cap logic is refactored into a shared pure `evaluateAutoCapture(text, state, maxPerSession)` with one `CaptureState` per agentId used by *all three* hooks — a content-hash `Set` prevents double-capture across paths (live-turn capture + agent_end rescan), and the cap (default 3, now tunable via `autoCaptureMaxPerSession`, unchanged default) is shared and only resets on `agent_end` — so a persistent session gets "N per session lifetime," not N per turn.

## Tests
18 new tests (58 total pass / 0 fail): pure trigger logic (regex/length/cap/dedup/truncation), and the core regression — **capture works via `llm_output`/`llm_input` with `agent_end` never fired** — plus cap enforcement, cross-path dedup, and budget reset on `agent_end`. Typecheck clean; docs-freshness green (CHANGELOG `[Unreleased]` included). README + plugin manifest document the new behavior/config.
