### PR TITLE
fix(migrations): pending-count false positive perpetually halted the gate on 0.10-era stores (#807)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- **The `embedding-stamp` migration's completion gate could halt forever on stores where every row already carried the current embedding-model stamp.** On a store whose rows were written under an older flair/Harper release and later rewritten via `PUT /Memory` (crossing a Harper minor-version boundary at boot), the migration's in-process pending-count query could report every row as still pending even though a direct record read showed each one already correctly stamped — root-caused to `embeddingModel` being an `@indexed` attribute: Harper's non-negated `not_equal` leaf condition reconstructs its match target from the (on such stores, stale) secondary index key rather than the live record, while the equivalent ops-API query reads the live record and returns the correct count. Fixed at the root by switching the query to the `not_equals` negated-comparator form, which Harper resolves to bypass the secondary index and scan primary-store records directly — immune to any index/record divergence, and behaviorally identical for genuinely-stale rows. Added a completion-gate safety net (opt-in via a new optional `Migration.recheckPending()` hook): before halting on a nonzero pending count small enough to check exhaustively, the runner re-verifies every claimed-pending row by a direct per-id read and, if all are already correct, logs a loud WARN and passes the gate instead of halting on what was really a counting artifact (#807).
+
 ## [0.27.0] - 2026-07-23
 
 ### Added

--- a/resources/migrations/embedding-stamp.ts
+++ b/resources/migrations/embedding-stamp.ts
@@ -60,6 +60,47 @@
  * known, narrow gap this bounded query cannot see;
  * resources/migration-boot.ts mitigates the common case by waiting for the
  * embeddings engine to settle before running migrations at all.
+ *
+ * flair#807 — completion-gate false-negative on 0.10-era / cross-version
+ * stores, root-caused against the installed `@harperfast/harper@5.1.22`
+ * source (node_modules/@harperfast/harper/resources/search.ts): for an
+ * INDEXED attribute (`embeddingModel` IS `@indexed` — schemas/memory.graphql),
+ * a non-negated `not_equal`/`ne` leaf condition takes `searchByIndex`'s
+ * `index && !skipIndex` branch, which reconstructs a SYNTHETIC partial record
+ * from the SECONDARY INDEX KEY alone (`recordMatcher = { [attribute_name]:
+ * key }`, resources/search.ts ~L418) and filters against THAT — never reading
+ * the live record. On a store whose rows were written under flair 0.10.0 /
+ * Harper 5.0.x and later rewritten via `PUT /Memory` (crossing a Harper
+ * 5.0.21→5.1.22 boot), the secondary index for `embeddingModel` can lag the
+ * live, on-disk value — the filter then evaluates a STALE key that never
+ * equals `getCurrentModelId()`, matching every row regardless of its true
+ * (already-current) stamp.
+ *
+ * The fix: use `comparator: "not_equals"` (the `not_` PREFIX form, distinct
+ * from the legacy `not_equal`/`ne` ALIAS — see search.ts's
+ * `resolveComparator`/`NEGATABLE_BASE_COMPARATORS`) for the not-current leg.
+ * `prepareConditions` resolves this to `{comparator: "equals", negated:
+ * true}`, which flips `searchByIndex`'s `skipIndex` flag
+ * (`searchCondition.negated && index && !isPrimaryKey`) — this is Harper's
+ * OWN documented mechanism for "bypass the secondary index, iterate the
+ * primary store directly" (see that file's comment: "we need to consider
+ * records whose attribute value is missing from the index... so we bypass
+ * the secondary index"). That path reads the LIVE record unconditionally,
+ * immune to any index/record divergence regardless of cause (this migration,
+ * a future one, or a Harper-internal index-rebuild timing issue). Strictly
+ * MORE reliable than the index-assisted path in every case — a genuinely
+ * stale row still matches (full scan over live values), so this changes
+ * nothing about the "3/3 success" happy path, only closes the false-positive
+ * gap on migrated stores. The `equals: null` leg is unaffected (not a
+ * negated comparator — no analogous bypass exists or is needed; its
+ * behavior was already verified against real Harper per the doc above).
+ *
+ * `recheckPending()` below is a SEPARATE, generic defense-in-depth layer
+ * (wired into resources/migrations/runner.ts's completion gate) — even a
+ * migration whose countPending() query is airtight can be defeated by some
+ * OTHER, not-yet-understood counting artifact; this lets the runner PROVE
+ * (via `.get()`, a primary-key lookup — always live, never index-assisted)
+ * that a nonzero countPending() result is real before halting on it.
  */
 import { databases } from "@harperfast/harper";
 import { getModelId } from "../embeddings-provider.js";
@@ -134,16 +175,24 @@ export function createEmbeddingStampMigration(
     regenViaHttpPut(id, existing, fetch),
 ): Migration {
   function staleCondition() {
-    // OR-combined: `not_equal <current>` catches a stale non-null model
+    // OR-combined: `not_equals <current>` catches a stale non-null model
     // string; `equals null` catches the explicit-null state this
     // migration's own writes leave behind on a failed regen (see the
     // module doc above — Harper's index never sees a TRULY ABSENT
     // property, only an explicit null).
+    //
+    // "not_equals" (NOT the legacy "not_equal" alias — see the flair#807
+    // addendum in the module doc) is load-bearing: it's the `not_` PREFIX
+    // form Harper's query engine resolves to a `negated: true` leaf, which
+    // bypasses the (on some stores, stale/desynced) secondary index and
+    // reads the live record directly. Reverting this to "not_equal" would
+    // reopen #807 on any store where the embeddingModel index lags the
+    // on-disk value.
     return [
       {
         operator: "or",
         conditions: [
-          { attribute: "embeddingModel", comparator: "not_equal", value: getCurrentModelId() },
+          { attribute: "embeddingModel", comparator: "not_equals", value: getCurrentModelId() },
           { attribute: "embeddingModel", comparator: "equals", value: null },
         ],
       },
@@ -195,6 +244,40 @@ export function createEmbeddingStampMigration(
       }
 
       return { processed: touchedIds.length, touchedIds };
+    },
+
+    /**
+     * flair#807 completion-gate safety net (resources/migrations/runner.ts
+     * calls this ONLY when a nonzero countPending() would otherwise halt the
+     * migration). Re-derives up to `limit` currently-"pending" ids via the
+     * SAME staleCondition() search countPending() uses, then re-checks each
+     * one by a DIRECT `.get()` — a primary-key lookup, never index-assisted,
+     * so it can't be fooled by the same secondary-index divergence that can
+     * make the search-based count wrong. Returns counts only (never ids —
+     * matches this codebase's structural-only-disclosure discipline, e.g.
+     * resources/migrations/ledger.ts's module doc), so the runner can log a
+     * loud, actionable WARN without ever needing to know which rows.
+     */
+    async recheckPending(limit: number): Promise<{ sampled: number; falsePositives: number }> {
+      const table = getTable();
+      const current = getCurrentModelId();
+
+      const ids: string[] = [];
+      for await (const row of table.search({ conditions: staleCondition(), limit })) {
+        const id = String((row as { id?: unknown }).id ?? "");
+        if (id) ids.push(id);
+      }
+
+      let falsePositives = 0;
+      for (const id of ids) {
+        const existing = await table.get(id);
+        // A row that vanished since the search, OR whose live embeddingModel
+        // still doesn't match current, is a GENUINE pending row (or a
+        // concurrent delete) — never counted as a false positive.
+        if (existing && existing.embeddingModel === current) falsePositives++;
+      }
+
+      return { sampled: ids.length, falsePositives };
     },
   };
 }

--- a/resources/migrations/runner.ts
+++ b/resources/migrations/runner.ts
@@ -48,6 +48,18 @@ import { join } from "node:path";
  */
 export const TEST_BATCH_DELAY_ENV = "FLAIR_MIGRATION_TEST_BATCH_DELAY_MS";
 
+/**
+ * flair#807 completion-gate safety net: the maximum `finalRemaining` count
+ * the gate will EXHAUSTIVELY re-verify (every claimed-pending row, never a
+ * probabilistic subset) via `migration.recheckPending()` before declaring a
+ * halt. Bounded so this stays "cheap" (a per-boot gate check, not a bulk
+ * job) and so the net can only ever flip a gate from fail→pass when it has
+ * proven — not sampled — that the WHOLE remaining set is a counting
+ * artifact. A `finalRemaining` above this threshold skips the net entirely
+ * and halts exactly as before (a partial recheck is not proof for the rest).
+ */
+const GATE_SAFETY_NET_MAX_RECHECK = 50;
+
 function resolveTestBatchDelayMs(env: NodeJS.ProcessEnv = process.env): number | undefined {
   if (!shouldRegisterSyntheticMigration(env)) return undefined;
   const raw = env[TEST_BATCH_DELAY_ENV];
@@ -423,6 +435,45 @@ async function runOneMigration(
 
   let hashEnvelopeMatch: boolean | null = null;
   let gateOk = finalRemaining === 0;
+
+  // ── flair#807 safety net: a nonzero finalRemaining can itself be a
+  // COUNTING ARTIFACT (e.g. countPending()'s search-based query reading a
+  // stale/desynced secondary index on a migrated store — see
+  // resources/migrations/embedding-stamp.ts's flair#807 doc for the
+  // concrete mechanism that motivated this) rather than real pending work.
+  // Only engages when finalRemaining is small enough to verify
+  // EXHAUSTIVELY — every claimed-pending row, not a subset — via a DIRECT
+  // per-row read (migration.recheckPending(), opt-in per Migration type).
+  // If every single one comes back already correct on direct read, the
+  // gate's nonzero count was the bug: log loudly and PASS with a WARN
+  // instead of halting forever on an artifact a real re-run can never
+  // clear (countPending() would report the same wrong number next boot).
+  if (
+    !gateOk &&
+    finalRemaining > 0 &&
+    finalRemaining <= GATE_SAFETY_NET_MAX_RECHECK &&
+    typeof migration.recheckPending === "function"
+  ) {
+    try {
+      const recheck = await migration.recheckPending(finalRemaining);
+      if (recheck.sampled === finalRemaining && recheck.falsePositives === recheck.sampled) {
+        console.warn(
+          `[migrations] ${migration.id}: completion gate countPending() reported ${finalRemaining} pending, ` +
+            `but a direct per-record read of ALL ${recheck.sampled} claimed-pending rows found every one already ` +
+            `correct. Treating this as a counting artifact (search/index divergence), NOT real pending work — ` +
+            `passing the gate with this WARN instead of halting.`,
+        );
+        gateOk = true;
+      }
+    } catch (err) {
+      // The safety net itself must never crash or worsen the gate outcome —
+      // a failure here just leaves gateOk as countPending() computed it.
+      console.warn(
+        `[migrations] ${migration.id}: completion-gate safety net recheckPending() threw (` +
+          `${(err as Error)?.message ?? String(err)}) — proceeding with the original gate result.`,
+      );
+    }
+  }
 
   if (gateOk && posture.gate === "count+full-envelope") {
     try {

--- a/resources/migrations/types.ts
+++ b/resources/migrations/types.ts
@@ -98,4 +98,22 @@ export interface Migration {
    * marker) — no separate journal/checkpoint file.
    */
   run(batchSize: number): Promise<RunBatchResult>;
+  /**
+   * OPTIONAL completion-gate safety net (flair#807). If countPending()
+   * reports a nonzero, would-otherwise-halt count, the runner calls this
+   * (bounded by GATE_SAFETY_NET_MAX_RECHECK — see runner.ts) to re-verify up
+   * to `limit` of those "pending" rows by a DIRECT per-row read, bypassing
+   * whatever query mechanism countPending() itself used. Root cause this
+   * exists for: countPending()'s search-based query can be misled by a
+   * stale/desynced secondary index on a migrated store (see
+   * resources/migrations/embedding-stamp.ts's flair#807 doc for the
+   * concrete mechanism); a `.get()`-by-id primary-key lookup is immune to
+   * that class of bug. Returns COUNTS ONLY — never row ids — so the runner
+   * can log a loud, actionable WARN without exposing which records.
+   *
+   * A migration that omits this gets exactly the prior behavior: a nonzero
+   * countPending() at the gate always halts. Implementing it is a purely
+   * additive opt-in, never required for correctness of the base gate.
+   */
+  recheckPending?(limit: number): Promise<{ sampled: number; falsePositives: number }>;
 }

--- a/test/integration/migrations-embedding-stamp-e2e.test.ts
+++ b/test/integration/migrations-embedding-stamp-e2e.test.ts
@@ -25,9 +25,16 @@
 import { describe, expect, test, beforeAll, afterAll } from "bun:test";
 import { rm } from "node:fs/promises";
 import { startHarper, stopHarper, type HarperInstance } from "../helpers/harper-lifecycle";
+import { getModelId } from "../../resources/embeddings-provider.ts";
 
 const EMBEDDING_STAMP_ID = "embedding-stamp";
 const AGENT_ID = "__flair_embedding_stamp_e2e_test_agent__";
+// getModelId() is a pure function of process.env (FLAIR_EMBEDDING_MODEL +
+// the prefix gate) — the spawned Harper child inherits this SAME process.env
+// (harper-lifecycle.ts's startHarper() spreads process.env as the child's
+// base env), so calling it here in the test process yields the IDENTICAL
+// value embedding-stamp.ts's getCurrentModelId() computes inside Harper.
+const CURRENT_MODEL_ID = getModelId();
 
 let harper: HarperInstance;
 let installDir: string;
@@ -61,6 +68,14 @@ describe("zero-touch migrations — embedding-stamp end-to-end (real Harper, alw
     // Row B: EXPLICIT null (a prior regen attempt failed, or a write raced
     // the embeddings engine's boot probe) — the queryable state
     // embedding-stamp's own writes now guarantee, per the module doc above.
+    // Row C (flair#807 regression): ALREADY carries the current model stamp
+    // — the exact shape a false positive would wrongly re-touch. Inserted
+    // via the ops-API `insert` operation (a fresh write, so its secondary
+    // index entry is genuinely in sync — this is the "3/3 success on a
+    // healthy store" reference case, not a reproduction of the actual
+    // stale-index bug, which requires a cross-version index desync this
+    // black-box test can't inject). Proves the fixed `not_equals`-based
+    // query has no false positives on real Harper for the common case.
     await opsCall({
       operation: "insert",
       database: "flair",
@@ -80,6 +95,14 @@ describe("zero-touch migrations — embedding-stamp end-to-end (real Harper, alw
           content: "embedding-stamp-e2e-marker-beta",
           embedding: null,
           embeddingModel: null,
+          createdAt: new Date().toISOString(),
+        },
+        {
+          id: "stamp-already-current",
+          agentId: AGENT_ID,
+          content: "embedding-stamp-e2e-marker-gamma",
+          embedding: [0.42, 0.42, 0.42],
+          embeddingModel: CURRENT_MODEL_ID,
           createdAt: new Date().toISOString(),
         },
       ],
@@ -131,5 +154,36 @@ describe("zero-touch migrations — embedding-stamp end-to-end (real Harper, alw
       // Content untouched — proves the migration is genuinely derived-only.
       expect(record.content).toContain("embedding-stamp-e2e-marker");
     }
+  }, 120_000);
+
+  test("flair#807: a row that ALREADY carries the current model stamp is never re-touched (no false positive on real Harper)", async () => {
+    // Reuses the SAME completed cycle the test above waits for — this just
+    // asserts on the row that was never supposed to be pending in the first
+    // place. A false positive on this row would have re-run it through
+    // Memory.put()'s regen branch, producing a NEW (different) embedding
+    // vector — the byte-for-byte-unchanged assertion below is exactly what
+    // would fail if staleCondition()'s not-current leg falsely matched it.
+    const deadline = Date.now() + 90_000;
+    let mig: any = null;
+    while (Date.now() < deadline) {
+      const detail = await healthDetail();
+      mig = detail?.migrations?.migrations?.find((m: any) => m.id === EMBEDDING_STAMP_ID);
+      if (mig?.state === "completed" || mig?.state === "halted" || mig?.state === "failed") break;
+      await new Promise((r) => setTimeout(r, 300));
+    }
+    expect(mig?.state).toBe("completed");
+
+    const row = await opsCall({
+      operation: "search_by_value",
+      database: "flair",
+      table: "Memory",
+      search_attribute: "id",
+      search_value: "stamp-already-current",
+      get_attributes: ["*"],
+    });
+    const record = Array.isArray(row) ? row[0] : row;
+    expect(record.embeddingModel).toBe(CURRENT_MODEL_ID);
+    expect(record.embedding).toEqual([0.42, 0.42, 0.42]); // byte-identical — never regenerated
+    expect(record.content).toBe("embedding-stamp-e2e-marker-gamma");
   }, 120_000);
 });

--- a/test/unit/migrations-embedding-stamp.test.ts
+++ b/test/unit/migrations-embedding-stamp.test.ts
@@ -42,6 +42,15 @@ function matchesCondition(row: Row, cond: any): boolean {
   const value = row[cond.attribute];
   switch (cond.comparator) {
     case "not_equal":
+    // flair#807: staleCondition()'s not-current leg now uses "not_equals"
+    // (the `not_` prefix form real Harper resolves to a negated-equals leaf
+    // — see embedding-stamp.ts's module doc) instead of the legacy
+    // "not_equal" alias. Same value-level semantics either way; this fake
+    // table doesn't model Harper's index-vs-live-record execution split
+    // (that's exercised for real in test/integration/
+    // migrations-embedding-stamp-e2e.test.ts), so both comparator spellings
+    // are handled identically here.
+    case "not_equals":
       return value !== cond.value;
     case "equals":
       return value === cond.value;
@@ -251,5 +260,109 @@ describe("embedding-stamp migration — a FAILED regen leaves the row pending, n
     const result = await m.run(50);
     expect(result.processed).toBe(0);
     expect(await m.countPending()).toBe(1);
+  });
+});
+
+describe("embedding-stamp migration — flair#807: staleCondition() comparator shape", () => {
+  it("uses \"not_equals\" (the negated-form comparator), never the legacy \"not_equal\" alias, for the not-current leg", async () => {
+    // Locks in the flair#807 fix: real Harper resolves "not_equals" (the
+    // `not_` PREFIX form) to a `negated: true` leaf, which bypasses a
+    // potentially stale/desynced secondary index and reads the live record
+    // directly (see embedding-stamp.ts's module doc for the full mechanism,
+    // root-caused against the installed @harperfast/harper source). The
+    // legacy "not_equal" alias does NOT get this bypass — reverting to it
+    // would silently reopen #807.
+    const queries: any[] = [];
+    const { table } = makeFakeMemoryTable([{ id: "m1", content: "a", embeddingModel: "old" }]);
+    const spyTable = {
+      ...table,
+      search(query: any) {
+        queries.push(query);
+        return table.search(query);
+      },
+    };
+    const m = createEmbeddingStampMigration(() => spyTable, () => CURRENT_MODEL, async () => true);
+    await m.detect();
+
+    expect(queries).toHaveLength(1);
+    const orGroup = queries[0].conditions[0];
+    expect(orGroup.operator).toBe("or");
+    const notCurrentLeg = orGroup.conditions.find((c: any) => c.attribute === "embeddingModel" && c.value === CURRENT_MODEL);
+    expect(notCurrentLeg.comparator).toBe("not_equals");
+    expect(notCurrentLeg.comparator).not.toBe("not_equal");
+  });
+});
+
+describe("embedding-stamp migration — flair#807: recheckPending() safety-net hook", () => {
+  /**
+   * A fake table whose search() and get() paths are DECOUPLED — search()
+   * reports whatever `searchIds` says is "pending" regardless of the
+   * store's real content, while get() always reads the store's true,
+   * current value. This mirrors the production divergence this safety net
+   * exists for: countPending()'s search-based query (index-assisted, can be
+   * stale) vs. a direct per-id record read (always live) disagreeing about
+   * the SAME row.
+   */
+  function makeDivergentTable(store: Map<string, Row>, searchIds: string[]) {
+    return {
+      async get(id: string) {
+        return store.has(id) ? { ...store.get(id)! } : null;
+      },
+      search(query: any): AsyncIterable<Row> {
+        const limit = typeof query?.limit === "number" ? query.limit : Infinity;
+        const ids = searchIds.slice(0, limit);
+        async function* gen() {
+          for (const id of ids) yield { ...(store.get(id) ?? { id }) } as Row;
+        }
+        return gen();
+      },
+    };
+  }
+
+  it("flags a row as a false positive when the search claims it pending but a direct get() shows it already current", async () => {
+    const store = new Map<string, Row>([
+      ["m1", { id: "m1", content: "a", embeddingModel: CURRENT_MODEL }], // TRUE state: already current
+    ]);
+    const table = makeDivergentTable(store, ["m1"]); // search() WRONGLY claims m1 is pending
+    const m = createEmbeddingStampMigration(() => table, () => CURRENT_MODEL, async () => true);
+
+    const recheck = await m.recheckPending!(10);
+    expect(recheck.sampled).toBe(1);
+    expect(recheck.falsePositives).toBe(1);
+  });
+
+  it("does NOT flag a genuinely stale row as a false positive (direct get() agrees it's still pending)", async () => {
+    const store = new Map<string, Row>([
+      ["m1", { id: "m1", content: "a", embeddingModel: "genuinely-old" }], // TRUE state: still stale
+    ]);
+    const table = makeDivergentTable(store, ["m1"]);
+    const m = createEmbeddingStampMigration(() => table, () => CURRENT_MODEL, async () => true);
+
+    const recheck = await m.recheckPending!(10);
+    expect(recheck.sampled).toBe(1);
+    expect(recheck.falsePositives).toBe(0);
+  });
+
+  it("a mix of real-stale and false-positive rows reports both counts correctly", async () => {
+    const store = new Map<string, Row>([
+      ["m1", { id: "m1", content: "a", embeddingModel: CURRENT_MODEL }], // false positive
+      ["m2", { id: "m2", content: "b", embeddingModel: "genuinely-old" }], // real
+    ]);
+    const table = makeDivergentTable(store, ["m1", "m2"]);
+    const m = createEmbeddingStampMigration(() => table, () => CURRENT_MODEL, async () => true);
+
+    const recheck = await m.recheckPending!(10);
+    expect(recheck.sampled).toBe(2);
+    expect(recheck.falsePositives).toBe(1);
+  });
+
+  it("a row deleted between search and the direct get() is never counted as a false positive", async () => {
+    const store = new Map<string, Row>(); // empty — "m1" was deleted
+    const table = makeDivergentTable(store, ["m1"]);
+    const m = createEmbeddingStampMigration(() => table, () => CURRENT_MODEL, async () => true);
+
+    const recheck = await m.recheckPending!(10);
+    expect(recheck.sampled).toBe(1);
+    expect(recheck.falsePositives).toBe(0);
   });
 });

--- a/test/unit/migrations-runner.test.ts
+++ b/test/unit/migrations-runner.test.ts
@@ -7,7 +7,7 @@
  * real-Harper end-to-end coverage: boot wiring, process-kill/resume,
  * version handshake).
  */
-import { describe, it, expect, beforeEach, afterEach, mock } from "bun:test";
+import { describe, it, expect, beforeEach, afterEach, mock, spyOn } from "bun:test";
 import { mkdtempSync, rmSync, writeFileSync, mkdirSync, existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
@@ -548,6 +548,187 @@ describe("runMigrationCycle — completion gate: row count still nonzero", () =>
     const detail = JSON.parse((ledgerEvents[0] as any).detail);
     expect(detail.outcome).toBe("halted");
     expect(detail.error).toContain("rowsRemaining=1");
+  });
+});
+
+describe("runMigrationCycle — flair#807 completion-gate safety net (migration.recheckPending)", () => {
+  /**
+   * A migration whose countPending() is a COUNTING ARTIFACT — it always
+   * reports `stuckCount` regardless of what run() actually did (mirrors the
+   * production bug: a search-based count reading a stale/desynced secondary
+   * index). `recheckFalsePositives` controls how many of the "pending" rows
+   * recheckPending() reports as already-correct on a direct read.
+   */
+  function makeArtifactMigration(opts: {
+    id: string;
+    stuckCount: number;
+    recheckFalsePositives: number;
+    recheckThrows?: boolean;
+  }): Migration & { recheckCalls: number[] } {
+    const recheckCalls: number[] = [];
+    return {
+      id: opts.id,
+      riskClass: "derived-only",
+      affectsTables: ["Memory"],
+      recheckCalls,
+      async detect() { return true; },
+      async countPending() { return opts.stuckCount; },
+      async run() { return { processed: 0, touchedIds: [] }; }, // 0 signals loop-end immediately
+      async recheckPending(limit: number) {
+        recheckCalls.push(limit);
+        if (opts.recheckThrows) throw new Error("recheckPending boom");
+        return { sampled: opts.stuckCount, falsePositives: opts.recheckFalsePositives };
+      },
+    };
+  }
+
+  it("PASSES the gate with a WARN when recheckPending proves every claimed-pending row is already correct", async () => {
+    const memory = makeStore([{ id: "m1", content: "a", agentId: "a1" }]);
+    const relationship = makeStore([]);
+    const migration = makeArtifactMigration({ id: "artifact-all-fp", stuckCount: 3, recheckFalsePositives: 3 });
+    const registry = buildRegistryWith(migration);
+
+    const warnSpy = spyOn(console, "warn").mockImplementation(() => {});
+    let result;
+    try {
+      const ledgerEvents: unknown[] = [];
+      result = await runMigrationCycle({
+        registry,
+        getTable: (t) => (t === "Memory" ? memory.accessor : relationship.accessor),
+        dataDir,
+        runningVersion: "0.1.0",
+        sleep: fastSleep,
+        ledgerDeps: { orgEventTable: { put: async (c: unknown) => { ledgerEvents.push(c); return c; } } },
+      });
+
+      expect(result.ran).toBe(true);
+      const detail = JSON.parse((ledgerEvents[0] as any).detail);
+      expect(detail.outcome).toBe("success");
+      expect(detail.rowsRemaining).toBe(0);
+      expect(migration.recheckCalls).toEqual([3]); // called once, with finalRemaining as the limit
+
+      const progress = listMigrationProgress().find((p) => p.id === "artifact-all-fp");
+      expect(progress?.state).toBe("completed");
+
+      expect(warnSpy).toHaveBeenCalled();
+      const warnedText = warnSpy.mock.calls.map((c) => String(c[0])).join(" ");
+      expect(warnedText).toContain("artifact-all-fp");
+      expect(warnedText).toContain("counting artifact");
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
+  it("still HALTS when recheckPending finds at least one row genuinely still pending (no false-pass on real work)", async () => {
+    const memory = makeStore([{ id: "m1", content: "a", agentId: "a1" }]);
+    const relationship = makeStore([]);
+    // 2 claimed pending, only 1 is a false positive — the OTHER is real.
+    const migration = makeArtifactMigration({ id: "artifact-partial-fp", stuckCount: 2, recheckFalsePositives: 1 });
+    const registry = buildRegistryWith(migration);
+
+    const ledgerEvents: unknown[] = [];
+    const result = await runMigrationCycle({
+      registry,
+      getTable: (t) => (t === "Memory" ? memory.accessor : relationship.accessor),
+      dataDir,
+      runningVersion: "0.1.0",
+      sleep: fastSleep,
+      ledgerDeps: { orgEventTable: { put: async (c: unknown) => { ledgerEvents.push(c); return c; } } },
+    });
+
+    expect(result.ran).toBe(true);
+    const detail = JSON.parse((ledgerEvents[0] as any).detail);
+    expect(detail.outcome).toBe("halted");
+    expect(detail.error).toContain("rowsRemaining=2");
+  });
+
+  it("skips the safety net (halts as before) when finalRemaining exceeds the exhaustive-recheck ceiling", async () => {
+    const memory = makeStore([{ id: "m1", content: "a", agentId: "a1" }]);
+    const relationship = makeStore([]);
+    // Even though recheckPending WOULD report every row as a false positive,
+    // a count this large can't be cheaply verified exhaustively — the net
+    // must not engage at all (recheckPending never even gets called).
+    const migration = makeArtifactMigration({ id: "artifact-too-big", stuckCount: 51, recheckFalsePositives: 51 });
+    const registry = buildRegistryWith(migration);
+
+    const ledgerEvents: unknown[] = [];
+    const result = await runMigrationCycle({
+      registry,
+      getTable: (t) => (t === "Memory" ? memory.accessor : relationship.accessor),
+      dataDir,
+      runningVersion: "0.1.0",
+      sleep: fastSleep,
+      ledgerDeps: { orgEventTable: { put: async (c: unknown) => { ledgerEvents.push(c); return c; } } },
+    });
+
+    expect(result.ran).toBe(true);
+    const detail = JSON.parse((ledgerEvents[0] as any).detail);
+    expect(detail.outcome).toBe("halted");
+    expect(detail.error).toContain("rowsRemaining=51");
+    expect(migration.recheckCalls).toEqual([]); // never called — over the ceiling
+  });
+
+  it("a throwing recheckPending never crashes the cycle — falls back to the original halt", async () => {
+    const memory = makeStore([{ id: "m1", content: "a", agentId: "a1" }]);
+    const relationship = makeStore([]);
+    const migration = makeArtifactMigration({
+      id: "artifact-throws",
+      stuckCount: 3,
+      recheckFalsePositives: 3,
+      recheckThrows: true,
+    });
+    const registry = buildRegistryWith(migration);
+
+    const warnSpy = spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      const ledgerEvents: unknown[] = [];
+      const result = await runMigrationCycle({
+        registry,
+        getTable: (t) => (t === "Memory" ? memory.accessor : relationship.accessor),
+        dataDir,
+        runningVersion: "0.1.0",
+        sleep: fastSleep,
+        ledgerDeps: { orgEventTable: { put: async (c: unknown) => { ledgerEvents.push(c); return c; } } },
+      });
+
+      expect(result.ran).toBe(true);
+      const detail = JSON.parse((ledgerEvents[0] as any).detail);
+      expect(detail.outcome).toBe("halted");
+      expect(detail.error).toContain("rowsRemaining=3");
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
+  it("a migration that doesn't implement recheckPending behaves exactly as before (plain halt, no net)", async () => {
+    // Covered structurally by the pre-existing "broken migration" test above
+    // (no recheckPending on that Migration literal at all) — this test just
+    // makes the flair#807 non-regression explicit for future readers.
+    const memory = makeStore([{ id: "m1", content: "a", agentId: "a1" }]);
+    const relationship = makeStore([]);
+    const noNetMigration: Migration = {
+      id: "no-safety-net",
+      riskClass: "derived-only",
+      affectsTables: ["Memory"],
+      async detect() { return true; },
+      async countPending() { return 1; },
+      async run() { return { processed: 0, touchedIds: [] }; },
+    };
+    const registry = buildRegistryWith(noNetMigration);
+
+    const ledgerEvents: unknown[] = [];
+    const result = await runMigrationCycle({
+      registry,
+      getTable: (t) => (t === "Memory" ? memory.accessor : relationship.accessor),
+      dataDir,
+      runningVersion: "0.1.0",
+      sleep: fastSleep,
+      ledgerDeps: { orgEventTable: { put: async (c: unknown) => { ledgerEvents.push(c); return c; } } },
+    });
+
+    expect(result.ran).toBe(true);
+    const detail = JSON.parse((ledgerEvents[0] as any).detail);
+    expect(detail.outcome).toBe("halted");
   });
 });
 


### PR DESCRIPTION
Fixes #807 — the migration completion-gate false-negative that leaves 0.10-era stores perpetually `halted`.

## Root cause (traced in Harper 5.1.22's installed source, `resources/search.ts`)
`embeddingModel` is `@indexed`. A non-negated `not_equal` leaf takes `searchByIndex`'s index-assisted branch, which filters against a **synthetic partial record reconstructed from the secondary-index key alone** — never reading the live record. On stores whose rows were written under Harper 5.0.x and rewritten after the 5.1 crossing, that index key can lag the live value → the filter compares a stale key → **every row matches "not current"** even when its true stamp is current. The ops-API path reads live records, hence the 31-vs-0 contradiction measured on the production spoke.

## Fix (two parts)
1. **`staleCondition()` uses `comparator: "not_equals"`** — the `not_` *prefix* form, which Harper resolves to `{comparator:"equals", negated:true}`, flipping the documented `skipIndex` gate ("bypass the secondary index and iterate over the primary store"). Live-record reads, unconditionally. Strictly more reliable; genuinely-stale rows still match (the 3/3 happy path is unaffected).
2. **Bounded gate safety-net**: new opt-in `Migration.recheckPending(limit)` hook. If the gate would halt with a claimed-pending count ≤50, the runner re-verifies every claimed row via primary-key `.get()` (immune to index staleness); if *all* are actually current, it logs a loud WARN and passes instead of halting forever on a counting artifact. Partial-real-pending, over-ceiling, throwing recheck, or no hook → original halt behavior, unchanged.

## Tests
- Unit: comparator-shape lock-in; `recheckPending` false-positive/genuine-stale/mixed/deleted-row; 6 runner-level safety-net cases (pass-with-warn, still-halts-on-partial, ceiling skip, throwing recheck, no-hook). Full `test/unit`: **2889 pass / 0 fail**.
- Integration: e2e gains a pre-stamped-current seeded row + regression assert it's never re-touched. **Honest flag:** the e2e suite doesn't run in the local sandbox (pre-existing `/HealthDetail` 404 there — verified identical on unmodified main via stash), so CI is the arbiter for that file; unit coverage of both fix parts is complete regardless.
- Typecheck (`tsconfig.check.json`) clean; docs-freshness green (CHANGELOG included).

## Live validation path
The production spoke that exhibits #807 (31-row 0.10-lineage store) upgrades to the next tagged release as part of normal fleet deploy — its `.migrations/state.json` flipping `halted → success` on first boot is the real-world confirmation.
