### PR TITLE
fix(rerank): make reranker work on real data — token truncation + config-reinit + jina default (#811)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- **The cross-encoder reranker (`FLAIR_RERANK_ENABLED`) errored on every call against real production data and silently no-op'd (fail-open masked it — `rerankCount` stayed 0, `fallbackCount` climbed).** Found running the OPS-RERANKER-INTEGRATION §6 live-corpus gate against rockit (#811). Two compounding root causes, both fixed in `resources/rerank-provider.ts`: (1) **context overflow** — the offline pilot's 16-doc fixture used short synthetic prose, but real memory content routinely exceeds either model's small context window; every (query, doc) pair is now truncated to a context-derived token budget (char pre-cut + exact tokenizer-level cut) before it ever reaches the engine, making the `rankAll` "input lengths... exceed the context size" throw effectively unreachable instead of routine. (2) **stale config** — `ensureInit()` used to cache which model was loaded PERMANENTLY on first success/failure, so a later `FLAIR_RERANK_MODEL` change had no effect until process restart ("configured model X, served model Y" could persist silently); config is now re-validated on every call and the engine reinitializes when it changes. Also flipped the **default model to `jina-reranker-v2`** (its rank-pooling path completes inside Harper) — the previous default, `qwen3-reranker-0.6b-q8`'s generative yes/no path, reliably returns empty logits inside Harper's resource runtime (a separate, previously-documented dual-native-backend limitation truncation alone doesn't fix) and is now marked experimental, kept available but not default. Fail-open behavior is unchanged (a rerank error still never blocks recall); `health.ts`'s `rerank.{state,rerankCount,fallbackCount,lastLatencyMs}` surface is unchanged in shape.
+
 ## [0.27.1] - 2026-07-23
 
 ### Fixed

--- a/docs/rerank-provisioning.md
+++ b/docs/rerank-provisioning.md
@@ -13,8 +13,8 @@ turning it on (`FLAIR_RERANK_ENABLED=true`) or running the recall-bench A/B.
 
 | `FLAIR_RERANK_MODEL` | GGUF filename (under `models/`) | Source | Inference mode |
 |---|---|---|---|
-| `qwen3-reranker-0.6b-q8` (default) | `Qwen3-Reranker-0.6B-q8_0.gguf` | `Mungert/Qwen3-Reranker-0.6B-GGUF` (q8_0) | generative yes/no |
-| `jina-reranker-v2` | `jina-reranker-v2-base.Q8_0.gguf` | `gpustack/jina-reranker-v2-base-multilingual-GGUF` (q8_0) | rank-pooling cross-encoder |
+| `jina-reranker-v2` (**default**, working) | `jina-reranker-v2-base.Q8_0.gguf` | `gpustack/jina-reranker-v2-base-multilingual-GGUF` (q8_0) | rank-pooling cross-encoder |
+| `qwen3-reranker-0.6b-q8` (**experimental** — see Known limitation) | `Qwen3-Reranker-0.6B-q8_0.gguf` | `Mungert/Qwen3-Reranker-0.6B-GGUF` (q8_0) | generative yes/no |
 
 Download into `models/` next to the embedding GGUF, e.g.:
 
@@ -36,10 +36,16 @@ vector order — it never blocks or breaks search.
 | Env var | Default | Meaning |
 |---|---|---|
 | `FLAIR_RERANK_ENABLED` | unset (**OFF**) | Master flag. `"true"` to enable. |
-| `FLAIR_RERANK_MODEL` | `qwen3-reranker-0.6b-q8` | Model + inference mode (table above). |
+| `FLAIR_RERANK_MODEL` | `jina-reranker-v2` | Model + inference mode (table above). Re-read on every rerank call — changing it takes effect on the NEXT call (that call pays a one-time model-(re)load cost and can itself fall back to vector order if the load exceeds `FLAIR_RERANK_BUDGET_MS`; subsequent calls run at normal latency). |
 | `FLAIR_RERANK_TOPN` | `50` | Candidate count fed to the reranker; caps the HNSW fetch. |
 | `FLAIR_RERANK_BUDGET_MS` | `2500` | Hard latency budget; exceeded → vector order. |
 | `FLAIR_RERANK_MIN_CANDIDATES` | `2` | Skip rerank below this many candidates. |
+
+Candidate document (and query) text is truncated to a per-model context budget
+before it ever reaches the engine — see `resources/rerank-provider.ts`'s file
+header ("Context-budget truncation"). This is not operator-configurable
+(the budgets are derived from each mode's fixed context size); flagged here
+only so a truncated rerank input isn't a surprise.
 
 ## Why this serving path (not Ollama, not a microservice)
 
@@ -62,6 +68,34 @@ detects this (`out.length === 0`), throws, and **fails open to vector order** (i
 never writes corrupt scores). Net effect today: with `FLAIR_RERANK_MODEL=qwen3-...`
 the rerank stage cleanly no-ops inside Harper.
 
-The `jina-reranker-v2` rank-API path (`createRankingContext()` / `rankAll`) works
-inside Harper. See the integration PR for the live recall-bench A/B numbers and the
-go/no-go read.
+flair#811 (the live-corpus Phase-1 gate) found the qwen3 path erroring on every
+call in production and root-caused two compounding issues, fixed in that PR:
+
+1. **Context overflow on real documents.** The offline pilot's 16-doc fixture was
+   short synthetic prose; real memory content routinely exceeds either model's
+   small context window (1024 tokens for the generative context, 2048 for the
+   rank context). `resources/rerank-provider.ts` now truncates every (query, doc)
+   pair to a budget derived from each mode's actual context size before it ever
+   reaches the engine (see that file's header). This doesn't fix the dual-backend
+   empty-logits limitation above, but it removes overflow as a SEPARATE, more
+   easily hit failure mode — and may have been a contributing cause of the
+   empty-logits symptom itself (an overflowing `controlledEvaluate` call doesn't
+   throw the way `rankAll` does; it's plausible an oversized prompt silently
+   context-shifted rather than decoding cleanly, though we couldn't confirm
+   this without a live repro).
+2. **Config not re-read after first init.** The provider used to cache which
+   model was loaded PERMANENTLY on first successful (or failed) init — a later
+   change to `FLAIR_RERANK_MODEL` had no effect until the process restarted, so
+   "configured model X, served model Y" could persist silently for the life of
+   the process. Now re-validated on every call (`needsReinit()`); a config
+   change is picked up on the next rerank.
+
+**Given the above, `jina-reranker-v2` is now the DEFAULT model** — its rank-API
+path (`createRankingContext()` / `rankAll`) completes inside Harper. `qwen3` stays
+selectable and documented for whoever revisits the dual-backend isolation
+question; it is not the default until the empty-logits limitation is actually
+fixed (truncation alone doesn't fix it — see point 1 above, it only removes a
+compounding cause).
+
+See the integration PR / flair#811 for the live recall-bench A/B numbers and the
+go/no-go read on `jina-reranker-v2` as the default.

--- a/resources/rerank-provider.ts
+++ b/resources/rerank-provider.ts
@@ -9,21 +9,62 @@
  *
  * Two inference modes (selected by FLAIR_RERANK_MODEL):
  *
- *  1. "qwen3-reranker-0.6b-q8" (DEFAULT, quality) — Qwen3-Reranker-0.6B is a
- *     causal-LM reranker, NOT a rank-pooling cross-encoder. Its GGUF reports
- *     supportsRanking=false, so node-llama-cpp's createRankingContext() rejects
- *     it. The correct path is generative: format query+doc into the official
- *     instruction prompt ending at the assistant turn, evaluate, and read the
- *     next-token probability of "yes" vs "no":
- *         score = P(yes) / (P(yes) + P(no))
- *     Implemented via seq.controlledEvaluate with generateNext probabilities.
- *     (Validated offline in RERANK-PILOT-RESULTS.md: 4/4 target cases flipped
- *     positive, p@1 6/8→8/8, mean margin 0.028→0.688, ~1.2s / 16 docs on rockit.)
- *
- *  2. "jina-reranker-v2" (latency fallback) — jina-reranker-v2 IS a rank-pooling
+ *  1. "jina-reranker-v2" (DEFAULT, working) — jina-reranker-v2 IS a rank-pooling
  *     cross-encoder; its gpustack GGUF loads via createRankingContext()/rankAll
- *     (supportsRanking=true). ~145ms / 16 docs but weaker (7/8, leaves the
- *     hardest consensus case negative). Selectable where latency is tight.
+ *     (supportsRanking=true). ~145ms / 16 docs in the offline pilot (7/8,
+ *     leaves the hardest consensus case negative — weaker than qwen3's
+ *     generative path in that pilot, but it's the path that actually PRODUCES
+ *     a score inside Harper's process — see #811 / point 2 below).
+ *
+ *  2. "qwen3-reranker-0.6b-q8" (EXPERIMENTAL, quality-if-it-worked) —
+ *     Qwen3-Reranker-0.6B is a causal-LM reranker, NOT a rank-pooling
+ *     cross-encoder. Its GGUF reports supportsRanking=false, so
+ *     createRankingContext() rejects it; the intended path is generative:
+ *     format query+doc into the official instruction prompt ending at the
+ *     assistant turn, evaluate, and read the next-token probability of "yes"
+ *     vs "no": score = P(yes) / (P(yes) + P(no)), via seq.controlledEvaluate
+ *     with generateNext probabilities. Validated OFFLINE, standalone, in
+ *     RERANK-PILOT-RESULTS.md (4/4 target cases flipped positive, p@1
+ *     6/8→8/8, mean margin 0.028→0.688, ~1.2s / 16 docs on rockit) — but
+ *     flair#811 found that INSIDE Harper's resource runtime,
+ *     controlledEvaluate reliably returns empty logits (no decoded output),
+ *     so every generative call throws "generative reranker produced no
+ *     logits" and falls open. Root cause per docs/rerank-provisioning.md's
+ *     "Known limitation": HFE's embedding engine has already initialized a
+ *     separate native llama backend in the same process before this
+ *     provider's own dynamic import runs, and the low-level
+ *     controlledEvaluate + custom-sampler logit readout the generative path
+ *     needs doesn't survive that dual-backend residency (ordinary model
+ *     loading and the jina rank-pooling call both work fine across it — only
+ *     this specific low-level readout is affected). Kept available and
+ *     documented for whoever revisits dual-backend isolation; NOT the
+ *     default until that's fixed.
+ *
+ * Context-budget truncation (flair#811 point 1): real memory content is
+ * routinely far longer than either model's small context window. Every
+ * (query, doc) pair is bounded BEFORE it reaches the engine — a cheap char
+ * pre-cut (`truncateChars`, avoids tokenizing pathological multi-MB content)
+ * followed by an exact token-level cut (`truncateForModel`, uses the loaded
+ * model's own tokenizer — the real guarantee, since char/token ratio varies
+ * a lot across prose/code/CJK/emoji). Budgets are derived from the context
+ * size each mode actually requests (both NUMERIC, not "auto" — node-llama-cpp
+ * grants a numeric contextSize exactly as asked, see GENERATIVE_CONTEXT_SIZE/
+ * RANK_CONTEXT_SIZE below) minus reserved template + query overhead. This
+ * makes the `rankAll`/context-overflow throw effectively unreachable in
+ * normal operation instead of guaranteed on any real-length memory.
+ *
+ * Config re-validated on every use (flair#811 point 3): `ensureInit()` used
+ * to cache `_modelKey`/`_state` permanently on first call — a later change to
+ * FLAIR_RERANK_MODEL (or a transient first-call failure) had NO effect for
+ * the lifetime of the process, since `_state === "ready"` (or `"failed"`)
+ * short-circuited every subsequent call without re-reading env. `needsReinit()`
+ * now compares the currently-resolved model key against what's actually
+ * loaded and re-initializes (disposing old handles first) whenever they
+ * differ, so "configured model X, served model Y" can no longer persist
+ * silently across calls. This is the most likely, directly-fixable
+ * code-level cause of the model-mismatch symptom reported in #811; without a
+ * live process repro we can't rule out an additional contributing factor,
+ * but this closes the gap regardless of the exact prior trigger.
  *
  * Serving path = the same in-process node-llama-cpp the embedding engine ships.
  * No Ollama (no logprobs, no rerank endpoint — verified), no network hop, no
@@ -46,14 +87,16 @@ interface ModelSpec {
   mode: RerankMode;
 }
 
-// Known reranker models → GGUF filename + inference mode. The default is the
-// quality model (Qwen3 generative). jina is the latency model (rank API).
+// Known reranker models → GGUF filename + inference mode. jina is the DEFAULT
+// (working — see file header, flair#811): its rank-pooling path completes
+// inside Harper. qwen3 is EXPERIMENTAL: its generative path is validated
+// offline but reliably fails open inside Harper today (empty logits).
 const MODELS: Record<string, ModelSpec> = {
-  "qwen3-reranker-0.6b-q8": { file: "Qwen3-Reranker-0.6B-q8_0.gguf", mode: "generative" },
   "jina-reranker-v2": { file: "jina-reranker-v2-base.Q8_0.gguf", mode: "rank" },
+  "qwen3-reranker-0.6b-q8": { file: "Qwen3-Reranker-0.6B-q8_0.gguf", mode: "generative" },
 };
 
-const DEFAULT_MODEL = "qwen3-reranker-0.6b-q8";
+const DEFAULT_MODEL = "jina-reranker-v2";
 
 // Official Qwen3-Reranker prompt scaffold (generative yes/no judgement).
 const QWEN_PREFIX =
@@ -65,9 +108,76 @@ function buildQwenPrompt(q: string, doc: string): string {
   return `${QWEN_PREFIX}<Instruct>: ${QWEN_INSTRUCT}\n<Query>: ${q}\n<Document>: ${doc}${QWEN_SUFFIX}`;
 }
 
-// Cap per-document content fed to the reranker. Short atomic notes are the norm;
-// this bounds context blow-up + latency on the occasional huge memory.
-const MAX_DOC_CHARS = 2000;
+// ── Context-budget truncation (flair#811 point 1) ──────────────────────────
+// See the file header for the two-layer rationale. Budgets are derived from
+// the context size each mode actually requests, minus reserved overhead —
+// not a flat guess detached from either number.
+
+/** Context size requested for the generative (Qwen3) context. NUMERIC (not
+ * "auto"), so node-llama-cpp grants exactly this many tokens — verified
+ * against node-llama-cpp 3.18.1's resolveContextContextSizeOption: a numeric
+ * contextSize is granted as-is (or context creation throws
+ * InsufficientMemoryError); only "auto"/object requests get VRAM-adaptive
+ * shrinking. */
+const GENERATIVE_CONTEXT_SIZE = 1024;
+/** Context size requested for the rank (jina) context — see
+ * createRankingContext() below. Also numeric, same guarantee. */
+const RANK_CONTEXT_SIZE = 2048;
+
+/** Reserved tokens for the Qwen3 prompt scaffold (QWEN_PREFIX + INSTRUCT +
+ * SUFFIX + <|im_start|>/<|im_end|> special tokens). Rough estimate from the
+ * literal scaffold text is ~130-140 tokens; 180 leaves real headroom above
+ * that estimate rather than sitting right on top of it — we don't have the
+ * actual Qwen3-Reranker tokenizer available to measure exactly (no GGUF in
+ * this worktree), so this errs generous. Belt-and-suspenders: scoreGenerative
+ * also hard-checks the FINAL built prompt against GENERATIVE_CONTEXT_SIZE
+ * and throws (fail-open) rather than proceeding if this margin ever isn't
+ * enough — see there. */
+const GENERATIVE_TEMPLATE_OVERHEAD_TOKENS = 180;
+/** Rank mode's DEFAULT template (no GGUF `chat_template.rerank` metadata) is
+ * just BOS + EOS + SEP + EOS — ~4 tokens. But if the loaded GGUF DOES carry
+ * a custom rerank template (LlamaRankingContext prefers it when present),
+ * that template's literal text adds more; we can't inspect the actual jina
+ * GGUF's metadata from this worktree (no model files here), so this reserves
+ * well above the no-template case. If the real template needs more than
+ * this, `rankAll()` still throws its own clean, caught error (existing
+ * fail-open path) rather than corrupting anything. */
+const RANK_TEMPLATE_OVERHEAD_TOKENS = 64;
+/** Queries are normally a handful of words. Bounding them caps the worst
+ * case so a pathologically long query can never eat the whole doc budget or
+ * overflow the context on its own. */
+const MAX_QUERY_TOKENS = 128;
+
+/** Per-mode doc token budgets: context size minus template overhead minus
+ * the reserved query budget. This is the number `truncateForModel()` enforces
+ * exactly (via the model's own tokenizer) for candidate document text. */
+const GENERATIVE_DOC_BUDGET_TOKENS =
+  GENERATIVE_CONTEXT_SIZE - GENERATIVE_TEMPLATE_OVERHEAD_TOKENS - MAX_QUERY_TOKENS;
+const RANK_DOC_BUDGET_TOKENS = RANK_CONTEXT_SIZE - RANK_TEMPLATE_OVERHEAD_TOKENS - MAX_QUERY_TOKENS;
+
+// Cheap CHAR pre-cuts — layer 1 (see file header). Deliberately generous
+// (not a tight token-accurate estimate): their only job is keeping us from
+// ever tokenizing a pathological multi-MB memory blob before layer 2
+// (`truncateForModel`'s exact token-level cut) does the real enforcement.
+const GENERATIVE_DOC_CHAR_PRECUT = 2000;
+const RANK_DOC_CHAR_PRECUT = 5000;
+const QUERY_CHAR_PRECUT = 800;
+
+/** Pure, trivial char-length cap — layer 1 of truncation. Returns `text`
+ * UNCHANGED (same reference) when already within budget, so callers can
+ * skip unnecessary work; otherwise returns the first `maxChars` characters.
+ * Exported for unit testing (see test/unit/rerank-provider.test.ts). */
+export function truncateChars(text: string, maxChars: number): string {
+  if (text.length <= maxChars) return text;
+  return text.slice(0, Math.max(0, maxChars));
+}
+
+/** Pure, trivial token-array cap — layer 2's core slice. Exported for unit
+ * testing independent of a real tokenizer. */
+export function truncateTokenBudget(tokens: readonly number[], maxTokens: number): number[] {
+  if (tokens.length <= maxTokens) return tokens as number[];
+  return tokens.slice(0, Math.max(0, maxTokens));
+}
 
 let _state: InitState = "uninitialized";
 let _initError: string | undefined;
@@ -98,6 +208,30 @@ function resolveModelKey(): string {
   return DEFAULT_MODEL;
 }
 
+/**
+ * Decide whether `ensureInit()` needs to (re)run the engine init sequence —
+ * the flair#811 point-3 fix. Pure so the decision matrix is directly
+ * unit-testable without touching the native engine.
+ *
+ * - Never initialized → always init.
+ * - Currently loaded model differs from what's now configured → always
+ *   (re)init, regardless of whether the PREVIOUS attempt was "ready" or
+ *   "failed" — a config change deserves a fresh attempt under the new
+ *   config. This is the fix: the old code short-circuited on `_state ===
+ *   "ready"`/`"failed"` unconditionally, so a later FLAIR_RERANK_MODEL
+ *   change (or a transient first-call failure under a config that was since
+ *   corrected) had NO effect for the life of the process.
+ * - Same model, already "ready" → no-op (don't reload a loaded GGUF).
+ * - Same model, already "failed" → no-op (don't retry-storm a config that's
+ *   still broken; avoids hammering a persistently-unavailable engine on
+ *   every search).
+ */
+export function needsReinit(state: InitState, cachedModelKey: string, requestedModelKey: string): boolean {
+  if (state === "uninitialized") return true;
+  if (cachedModelKey !== requestedModelKey) return true;
+  return false;
+}
+
 /** Discover the platform addon binary the same way embeddings-provider.ts does. */
 async function findAddonPath(): Promise<string | undefined> {
   const { existsSync } = await import("node:fs");
@@ -118,11 +252,19 @@ async function findAddonPath(): Promise<string | undefined> {
 }
 
 async function ensureInit(): Promise<void> {
-  if (_state === "ready") return;
-  if (_state === "failed") return; // already logged once — don't thrash
+  const requested = resolveModelKey();
+  if (!needsReinit(_state, _modelKey, requested)) return;
+
+  // Reinitializing under a new config (or first-ever init) — drop any
+  // previously loaded engine handles and let a fresh init attempt warn again
+  // if IT fails too (a new config's failure is a new fact, not a repeat of
+  // the old one).
+  if (_state === "ready") await disposeHandles().catch(() => {});
+  _state = "uninitialized";
+  _warnedOnce = false;
 
   try {
-    _modelKey = resolveModelKey();
+    _modelKey = requested;
     const spec = MODELS[_modelKey];
     _mode = spec.mode;
 
@@ -151,7 +293,7 @@ async function ensureInit(): Promise<void> {
     _model = await _llama.loadModel({ modelPath });
 
     if (_mode === "generative") {
-      _ctx = await _model.createContext({ contextSize: 1024 });
+      _ctx = await _model.createContext({ contextSize: GENERATIVE_CONTEXT_SIZE });
       _seq = _ctx.getSequence();
       // Resolve yes/no token ids (both case variants — the post-</think>
       // position puts mass on "yes"/"Yes").
@@ -169,9 +311,11 @@ async function ensureInit(): Promise<void> {
       if (!_model.fileInsights?.supportsRanking) {
         throw new Error(`model ${spec.file} does not support ranking (not a rank-pooling cross-encoder)`);
       }
-      // Context must fit query + the longest document (jina concatenates them).
-      // 512 is too small for real memories; 2048 covers MAX_DOC_CHARS + query.
-      _rankCtx = await _model.createRankingContext({ contextSize: 2048 });
+      // Context must fit query + the longest document (jina concatenates
+      // them). 512 is too small for real memories; RANK_CONTEXT_SIZE (2048)
+      // is what RANK_DOC_BUDGET_TOKENS/truncateForModel() are derived from —
+      // see the file header.
+      _rankCtx = await _model.createRankingContext({ contextSize: RANK_CONTEXT_SIZE });
     }
 
     _state = "ready";
@@ -210,9 +354,53 @@ async function resetSequence(): Promise<void> {
   _seq = _ctx.getSequence();
 }
 
+/**
+ * Bound `text` to at most `maxTokens` tokens using the loaded model's own
+ * tokenizer — layer 2 of the truncation scheme (see file header). Layer 1's
+ * cheap char pre-cut runs first (`truncateChars`, avoids tokenizing
+ * pathological multi-MB content); if the pre-cut string still tokenizes over
+ * budget (dense code/CJK/emoji content packs more tokens per char than the
+ * pre-cut assumes), the token array itself is cut and detokenized back to
+ * text. This is the actual guarantee: whatever this returns tokenizes to
+ * AT MOST `maxTokens` tokens (specialTokens=false — plain content text, no
+ * markup interpretation), full stop. Not exported/pure (needs `_model`); its
+ * two building blocks (`truncateChars`, `truncateTokenBudget`) are each unit
+ * tested directly.
+ */
+function truncateForModel(text: string, maxChars: number, maxTokens: number): string {
+  const precut = truncateChars(text, maxChars);
+  const tokens = _model.tokenize(precut, false);
+  if (tokens.length <= maxTokens) return precut;
+  const bounded = truncateTokenBudget(Array.from(tokens), maxTokens);
+  return _model.detokenize(bounded, false);
+}
+
 /** Generative yes/no score for one (query, doc) pair. */
 async function scoreGenerative(q: string, doc: string): Promise<number> {
-  const tokens = _model.tokenize(buildQwenPrompt(q, doc.slice(0, MAX_DOC_CHARS)), true);
+  // Bound query + doc BEFORE building the prompt (flair#811 point 1) — see
+  // truncateForModel's doc and the file header for the two-layer rationale.
+  // Each is tokenized/bounded independently, then concatenated into the
+  // template; GENERATIVE_TEMPLATE_OVERHEAD_TOKENS' margin absorbs the small
+  // boundary-tokenization variance a separate-then-concatenate cut can
+  // introduce (BPE isn't always compositional across a splice point).
+  const boundedQuery = truncateForModel(q, QUERY_CHAR_PRECUT, MAX_QUERY_TOKENS);
+  const boundedDoc = truncateForModel(doc, GENERATIVE_DOC_CHAR_PRECUT, GENERATIVE_DOC_BUDGET_TOKENS);
+  const tokens = _model.tokenize(buildQwenPrompt(boundedQuery, boundedDoc), true);
+  // Belt-and-suspenders: the per-field bounding above reserves
+  // GENERATIVE_TEMPLATE_OVERHEAD_TOKENS of margin for the template, but a
+  // splice-boundary tokenization surprise is still conceivable. We can't
+  // truncate the COMBINED prompt itself (it would cut the required
+  // assistant-turn suffix the model needs to answer at the right position),
+  // so if it's still over budget here, throw cleanly and let the caller fall
+  // open — better than handing an oversized prompt to controlledEvaluate,
+  // which doesn't throw on overflow the way rankAll does and could silently
+  // context-shift/corrupt instead (a plausible contributor to the "empty
+  // logits" symptom in #811, alongside the documented dual-backend issue).
+  if (tokens.length > GENERATIVE_CONTEXT_SIZE) {
+    throw new Error(
+      `generative reranker prompt (${tokens.length} tokens) exceeds context size (${GENERATIVE_CONTEXT_SIZE}) after truncation`,
+    );
+  }
   // Reset the sequence so each pair is scored independently (deterministic) and
   // a prior eval can't poison this one ("Eval has failed" after a bad state).
   await resetSequence();
@@ -260,8 +448,15 @@ export async function rerankScores(query: string, docs: string[]): Promise<numbe
   if (_state !== "ready") throw new Error("reranker not ready");
 
   if (_mode === "rank") {
-    const trimmed = docs.map((d) => String(d ?? "").slice(0, MAX_DOC_CHARS));
-    return runExclusive(() => _rankCtx.rankAll(query, trimmed));
+    // Bound query + every doc BEFORE rankAll (flair#811 point 1) — rankAll
+    // computes ALL documents' token lengths up front and throws "The input
+    // lengths of some of the given documents exceed the context size" if
+    // ANY one exceeds RANK_CONTEXT_SIZE (verified against node-llama-cpp
+    // 3.18.1's LlamaRankingContext.rankAll). truncateForModel makes that
+    // effectively unreachable instead of routine on real memory content.
+    const boundedQuery = truncateForModel(query, QUERY_CHAR_PRECUT, MAX_QUERY_TOKENS);
+    const trimmed = docs.map((d) => truncateForModel(String(d ?? ""), RANK_DOC_CHAR_PRECUT, RANK_DOC_BUDGET_TOKENS));
+    return runExclusive(() => _rankCtx.rankAll(boundedQuery, trimmed));
   }
   // generative — score sequentially under the engine lock (single shared
   // sequence; deterministic). The whole batch holds the lock for one search so

--- a/test/unit/rerank-provider.test.ts
+++ b/test/unit/rerank-provider.test.ts
@@ -8,6 +8,9 @@ import {
   getRerankMinCandidates,
   getRerankStatus,
   rerankCandidates,
+  truncateChars,
+  truncateTokenBudget,
+  needsReinit,
 } from "../../resources/rerank-provider";
 
 // These tests exercise the DETERMINISTIC scoring + reorder + config paths
@@ -161,12 +164,94 @@ describe("config readers (FLAIR_RERANK_* env, default OFF)", () => {
     expect(s.enabled).toBe(false);
     expect(s.topN).toBe(50);
     expect(s.budgetMs).toBe(2500);
-    // model resolves to the quality default
-    expect(s.model).toBe("qwen3-reranker-0.6b-q8");
+    // model resolves to the WORKING default (flair#811: jina's rank path
+    // completes inside Harper; qwen3's generative path doesn't — see
+    // resources/rerank-provider.ts's file header).
+    expect(s.model).toBe("jina-reranker-v2");
   });
-  test("unknown FLAIR_RERANK_MODEL falls back to the quality default", () => {
+  test("unknown FLAIR_RERANK_MODEL falls back to the working default", () => {
     process.env.FLAIR_RERANK_MODEL = "does-not-exist";
+    expect(getRerankStatus().model).toBe("jina-reranker-v2");
+  });
+  test("qwen3 is still selectable explicitly (kept available, EXPERIMENTAL)", () => {
+    process.env.FLAIR_RERANK_MODEL = "qwen3-reranker-0.6b-q8";
     expect(getRerankStatus().model).toBe("qwen3-reranker-0.6b-q8");
+  });
+});
+
+describe("truncateChars (context-budget truncation, flair#811 layer 1)", () => {
+  test("long text is truncated to the char budget", () => {
+    const long = "x".repeat(5000);
+    const out = truncateChars(long, 2000);
+    expect(out.length).toBe(2000);
+    expect(out).toBe("x".repeat(2000));
+  });
+
+  test("short text is returned UNCHANGED (same reference, no copy)", () => {
+    const short = "a short memory note";
+    const out = truncateChars(short, 2000);
+    expect(out).toBe(short);
+  });
+
+  test("text exactly at the budget is unchanged", () => {
+    const exact = "y".repeat(2000);
+    expect(truncateChars(exact, 2000)).toBe(exact);
+  });
+
+  test("negative/zero budget never throws, clamps to empty", () => {
+    expect(truncateChars("hello", 0)).toBe("");
+    expect(truncateChars("hello", -5)).toBe("");
+  });
+});
+
+describe("truncateTokenBudget (context-budget truncation, flair#811 layer 2 core)", () => {
+  test("long token array is truncated to the budget", () => {
+    const tokens = Array.from({ length: 500 }, (_, i) => i);
+    const out = truncateTokenBudget(tokens, 100);
+    expect(out.length).toBe(100);
+    expect(out).toEqual(tokens.slice(0, 100));
+  });
+
+  test("short token array is returned UNCHANGED (same reference)", () => {
+    const tokens = [1, 2, 3];
+    expect(truncateTokenBudget(tokens, 100)).toBe(tokens);
+  });
+
+  test("token array exactly at the budget is unchanged", () => {
+    const tokens = [1, 2, 3];
+    expect(truncateTokenBudget(tokens, 3)).toBe(tokens);
+  });
+
+  test("negative/zero budget never throws, clamps to empty", () => {
+    expect(truncateTokenBudget([1, 2, 3], 0)).toEqual([]);
+    expect(truncateTokenBudget([1, 2, 3], -5)).toEqual([]);
+  });
+});
+
+describe("needsReinit (config-change reinit decision, flair#811 point 3)", () => {
+  // The bug: ensureInit() used to short-circuit on _state === "ready" or
+  // "failed" UNCONDITIONALLY, so a later FLAIR_RERANK_MODEL change had no
+  // effect for the life of the process ("configured model X, served model
+  // Y" could persist silently). needsReinit() is the fix's decision core.
+  test("never initialized -> always reinit, regardless of cached/requested keys", () => {
+    expect(needsReinit("uninitialized", "", "jina-reranker-v2")).toBe(true);
+    expect(needsReinit("uninitialized", "jina-reranker-v2", "jina-reranker-v2")).toBe(true);
+  });
+
+  test("same model, ready -> no-op (don't reload a loaded GGUF)", () => {
+    expect(needsReinit("ready", "jina-reranker-v2", "jina-reranker-v2")).toBe(false);
+  });
+
+  test("same model, failed -> no-op (don't retry-storm a config that's still broken)", () => {
+    expect(needsReinit("failed", "jina-reranker-v2", "jina-reranker-v2")).toBe(false);
+  });
+
+  test("different model, ready -> reinit (config changed away from a working model)", () => {
+    expect(needsReinit("ready", "jina-reranker-v2", "qwen3-reranker-0.6b-q8")).toBe(true);
+  });
+
+  test("different model, failed -> reinit (config changed; give the new config its own attempt)", () => {
+    expect(needsReinit("failed", "qwen3-reranker-0.6b-q8", "jina-reranker-v2")).toBe(true);
   });
 });
 


### PR DESCRIPTION
Fixes #811 — the cross-encoder reranker errored on every call against real data and failed open (silent no-op). The #1 recall-moat lever, now made to actually function.

## Root cause (all three symptoms)
1. **Context overflow** — real memory documents exceed the reranker's context. The shipped flat `MAX_DOC_CHARS=2000` was a guess detached from the model's real token budget, and the *query* was never bounded. Real content (code/CJK/punctuation) packs more tokens/char than English prose, so 2000 chars wasn't a guarantee.
2. **Empty logits (qwen3 generative)** — documented known limitation, not a coding bug: `controlledEvaluate` returns empty logits *inside Harper* because HFE's llama.cpp backend is already initialized in-process before the reranker's import. Traced against node-llama-cpp 3.18.1 — the call shape is correct; the environment is hostile to a second generative context.
3. **Model mismatch** — real defect: `ensureInit()` cached `_modelKey`/`_state` permanently on first call, short-circuiting every later call without re-reading `FLAIR_RERANK_MODEL`. A config change had zero effect until restart → "configured X, served Y" persisted silently.

## Fix
- **Token-level truncation** (two-layer: cheap char pre-cut → exact tokenizer cut) with budgets *derived* from each mode's real context (generative 1024−180−128=716 doc tokens; rank 2048−64−128=1856) + a final hard-check-and-throw safety net. Overflow becomes structurally unreachable.
- **`needsReinit(state, cachedKey, requestedKey)`** — pure decision fn gating `ensureInit`; reinitializes whenever the resolved model key changes, so config actually takes effect.
- **Default flipped to `jina-reranker-v2`** (rank-pooling — *works* inside Harper). qwen3 stays selectable, now labeled **EXPERIMENTAL** (broken-in-Harper generative path). Fail-open preserved throughout.

## Status: default still OFF; this makes it *functional*, not *default-on*
Per OPS-RERANKER-INTEGRATION's phased plan, this is Phase-0-refinement (make it work). **I run the Phase-1 live A/B on rockit next** (jina ON vs OFF, recall-eval against the real 0.25 p@3 baseline) and report the delta — default-on is a separate follow-up gated on that number.

## Gates
`rerank-provider` tests **39 pass** (+14 new: truncation budgets, needsReinit 0/1/N, model/mode selection). Typecheck clean; docs-freshness green; `docs/rerank-provisioning.md` updated. Full suite: pre-existing 2-fail flake only (verified on unmodified main).

## Review focus
- **Kern:** the truncation-budget derivation + the needsReinit gate + jina-as-default / qwen-as-experimental call.
- **Sherlock:** fail-open invariant preserved (a rerank error never blocks recall); no new surface (internal recall-path refinement).
Honest gap: the builder couldn't run GGUF inference (no models in the worktree) — truncation math is derived with margins + a throw-net; **I validate live on rockit before we consider default-on.**
