### PR TITLE
fix(rerank): respect FLAIR_MODELS_DIR + fail-loud harness rerank arm (#815)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- **The reranker ignored `FLAIR_MODELS_DIR` (GGUF resolved from a hardcoded `<cwd>/models`), silently failing open to vector order in any deployment where Harper's cwd wasn't the models location — and the recall harness's `--rerank` arm could measure a NON-reranked run while labeling it reranked.** `resources/rerank-provider.ts`'s `ensureInit()` now resolves the reranker GGUF through the same `resolveModelsDir()` the embedding engine uses (`FLAIR_MODELS_DIR` → `<ROOTPATH>/models` → `<cwd>/models` backward compat → `~/.flair/data/models`; extracted unchanged to a shared `resources/models-dir.ts`, re-exported from `embeddings-provider.ts` for existing consumers), so the "provisioned alongside the embedding GGUF" contract from `docs/rerank-provisioning.md` actually holds by construction, and the not-found error now reports the full resolved path instead of a bare `models/<file>`. Production fail-open behavior is unchanged (a rerank error still never blocks recall) — what changed is that the recall harness (`test/bench/recall-harness/run.ts`) no longer *inherits* it as fictitious measurement: the `--rerank` arm now pins `FLAIR_RERANK_MODEL=jina-reranker-v2` (the rank-pooling model that actually serves inside Harper; caller override respected) and, after measuring, asserts engagement against the same spawned Harper's `/HealthDetail` rerank diagnostics — failing loud (nonzero exit, with state/model/counts/error in the message) if the reranker was enabled but never engaged (`state≠ready` or `rerankCount=0`), instead of publishing vector-order numbers under a "rerank" label (#815).
+
 ## [0.28.0] - 2026-07-24
 
 ### Fixed

--- a/resources/embeddings-provider.ts
+++ b/resources/embeddings-provider.ts
@@ -108,10 +108,6 @@
  * description for that distinction.
  */
 
-import { join } from "node:path";
-import { existsSync } from "node:fs";
-import { homedir } from "node:os";
-
 /**
  * The nomic search-prefix `inputType` — closed union, not `string`. See the
  * file header: the VALUES `'document'`/`'query'` are what HFE 0.3.0's engine
@@ -258,42 +254,15 @@ async function getModelsApi(): Promise<HarperModelsApi> {
 /**
  * Resolve the directory the embeddings model lives in / downloads into.
  *
- * Resolution order (everything writable, never the read-only package dir):
- *   1. FLAIR_MODELS_DIR        — explicit operator/docker override.
- *   2. <ROOTPATH>/models       — Harper's data dir (Flair passes ROOTPATH =
- *                                ~/.flair/data when it spawns Harper). User-
- *                                owned and writable even on sudo-global installs.
- *   3. <cwd>/models            — ONLY if a model already lives there. Backward
- *                                compat for existing writable installs that
- *                                downloaded into the package dir before this fix;
- *                                never used as a download target on fresh installs.
- *   4. ~/.flair/data/models    — last-resort default when ROOTPATH is unset.
- *
- * The chosen dir is always writable, so the embeddings engine can download the
- * model on first use without hitting EACCES on a root-owned package dir.
- *
- * Called by `resources/embeddings-boot.ts` (flair#694) to build the
- * `modelsDir` it passes to harper-fabric-embeddings' `register()` — both run
- * in the SAME process now (unlike the retired src/cli.ts-side computation,
- * which duplicated this exact default because it ran in a separate process
- * that set the resulting value via an env var). Still exported and tested
- * independently (test/unit/embeddings-models-dir.test.ts) as the single
- * documented source of truth for this default.
+ * Implementation moved to `resources/models-dir.ts` (flair#815) so the
+ * reranker can share the exact same resolution without importing this module
+ * (several unit-isolated tests `mock.module()` this file wholesale — see
+ * models-dir.ts's header). Re-exported here so existing consumers keep their
+ * import site: `resources/embeddings-boot.ts` (flair#694), which builds the
+ * `modelsDir` it passes to harper-fabric-embeddings' `register()`, and
+ * test/unit/embeddings-models-dir.test.ts, which pins the resolution order.
  */
-export function resolveModelsDir(): string {
-  const override = process.env.FLAIR_MODELS_DIR;
-  if (override) return override;
-
-  const rootPath = process.env.ROOTPATH;
-  if (rootPath) return join(rootPath, "models");
-
-  // Backward compat: a prior (writable) install may have the model cached in
-  // the package dir. Reuse it rather than re-downloading — but only if present.
-  const cwdModels = join(process.cwd(), "models");
-  if (existsSync(cwdModels)) return cwdModels;
-
-  return join(homedir(), ".flair", "data", "models");
-}
+export { resolveModelsDir } from "./models-dir.js";
 
 // ─── Health translation (Design §3 / Kern's hardening) ──────────────────────
 // `models.embed()` THROWS (ModelBackendNotFoundError / ModelCapabilityError)

--- a/resources/models-dir.ts
+++ b/resources/models-dir.ts
@@ -1,0 +1,57 @@
+/**
+ * models-dir.ts — the ONE place that decides where model GGUFs live.
+ *
+ * Extracted from embeddings-provider.ts (flair#815) so the reranker
+ * (rerank-provider.ts) can share the exact same resolution WITHOUT importing
+ * embeddings-provider: several unit-isolated tests `mock.module()` the whole
+ * embeddings-provider module (with only the named exports THEY consume), and
+ * bun's module cache is process-wide — so any new cross-module import of
+ * embeddings-provider from another resource makes those mocks incomplete and
+ * kills unrelated test files at module load. This module is tiny, pure
+ * node-stdlib, and never mocked, so both providers (and any future model
+ * consumer) can depend on it safely.
+ */
+
+import { existsSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+/**
+ * Resolve the directory model GGUFs live in / download into — shared by the
+ * embedding engine (embeddings-boot.ts's `register()` options) and the
+ * cross-encoder reranker (rerank-provider.ts, flair#815 — it used to hardcode
+ * `<cwd>/models`, silently failing open wherever Harper's cwd wasn't the
+ * models location).
+ *
+ * Resolution order (everything writable, never the read-only package dir):
+ *   1. FLAIR_MODELS_DIR        — explicit operator/docker override.
+ *   2. <ROOTPATH>/models       — Harper's data dir (Flair passes ROOTPATH =
+ *                                ~/.flair/data when it spawns Harper). User-
+ *                                owned and writable even on sudo-global installs.
+ *   3. <cwd>/models            — ONLY if a model already lives there. Backward
+ *                                compat for existing writable installs that
+ *                                downloaded into the package dir before this fix;
+ *                                never used as a download target on fresh installs.
+ *   4. ~/.flair/data/models    — last-resort default when ROOTPATH is unset.
+ *
+ * The chosen dir is always writable, so the embeddings engine can download the
+ * model on first use without hitting EACCES on a root-owned package dir.
+ *
+ * Tested independently (test/unit/embeddings-models-dir.test.ts, via
+ * embeddings-provider's re-export) as the single documented source of truth
+ * for this default.
+ */
+export function resolveModelsDir(): string {
+  const override = process.env.FLAIR_MODELS_DIR;
+  if (override) return override;
+
+  const rootPath = process.env.ROOTPATH;
+  if (rootPath) return join(rootPath, "models");
+
+  // Backward compat: a prior (writable) install may have the model cached in
+  // the package dir. Reuse it rather than re-downloading — but only if present.
+  const cwdModels = join(process.cwd(), "models");
+  if (existsSync(cwdModels)) return cwdModels;
+
+  return join(homedir(), ".flair", "data", "models");
+}

--- a/resources/rerank-provider.ts
+++ b/resources/rerank-provider.ts
@@ -70,11 +70,18 @@
  * No Ollama (no logprobs, no rerank endpoint — verified), no network hop, no
  * new auth boundary.
  *
- * GGUF files are NOT committed; they are provisioned into models/ alongside the
- * embedding GGUF. See docs/rerank-provisioning.md for download sources.
+ * GGUF files are NOT committed; they are provisioned into the models dir
+ * alongside the embedding GGUF — resolved via the SAME `resolveModelsDir()`
+ * the embedding engine uses (FLAIR_MODELS_DIR → <ROOTPATH>/models →
+ * <cwd>/models → ~/.flair/data/models; flair#815 — this file used to hardcode
+ * <cwd>/models, so any deployment whose cwd wasn't the models location failed
+ * init and silently fell open to vector order). See docs/rerank-provisioning.md
+ * for download sources.
  */
 
 import { join } from "node:path";
+
+import { resolveModelsDir } from "./models-dir.js";
 
 type InitState = "uninitialized" | "ready" | "failed";
 
@@ -209,6 +216,21 @@ function resolveModelKey(): string {
 }
 
 /**
+ * Absolute path the reranker GGUF is expected at: `<models dir>/<file>`,
+ * where the models dir is the shared `resolveModelsDir()` (models-dir.ts,
+ * same resolution the embedding engine uses) — the single documented source
+ * of truth (FLAIR_MODELS_DIR override, ROOTPATH/models, cwd/models backward
+ * compat, ~/.flair/data/models default).
+ * flair#815: this used to be a hardcoded `<cwd>/models/<file>`, which broke
+ * (fail-open, silently) in any deployment where Harper's cwd wasn't the
+ * models location — including the recall harness's ephemeral Harpers.
+ * Exported for unit testing (see test/unit/rerank-provider.test.ts).
+ */
+export function resolveRerankModelPath(file: string): string {
+  return join(resolveModelsDir(), file);
+}
+
+/**
  * Decide whether `ensureInit()` needs to (re)run the engine init sequence —
  * the flair#811 point-3 fix. Pure so the decision matrix is directly
  * unit-testable without touching the native engine.
@@ -269,10 +291,10 @@ async function ensureInit(): Promise<void> {
     _mode = spec.mode;
 
     const { existsSync } = await import("node:fs");
-    const modelPath = join(process.cwd(), "models", spec.file);
+    const modelPath = resolveRerankModelPath(spec.file);
     if (!existsSync(modelPath)) {
       throw new Error(
-        `reranker GGUF not found: models/${spec.file} (provision per docs/rerank-provisioning.md)`,
+        `reranker GGUF not found: ${modelPath} (provision per docs/rerank-provisioning.md; set FLAIR_MODELS_DIR to override the models dir)`,
       );
     }
 

--- a/test/bench/recall-harness/run.ts
+++ b/test/bench/recall-harness/run.ts
@@ -291,6 +291,41 @@ async function runQueries(harper: HarperInstance, agent: TestAgent, scoring: "ra
   return { scoring, ...overall, byKind, byCluster, rows };
 }
 
+// flair#815: a rerank arm whose reranker fails open (GGUF not found, engine
+// init failure, per-call fallback) measures a NON-reranked run while labeling
+// it reranked — the two arms of a rerank A/B come back byte-identical and the
+// "rerank" numbers are fiction. The provider's fail-open is correct behavior
+// for production recall (never block a search); what's NOT acceptable is a
+// measurement run silently inheriting it. So after measuring, read the
+// provider's own diagnostics (getRerankStatus() via the authenticated
+// /HealthDetail `rerank` block — resources/health.ts) from the SAME spawned
+// Harper that served the queries, and fail loud unless the reranker actually
+// engaged (state=ready AND rerankCount > 0).
+async function assertRerankEngaged(harper: HarperInstance, agent: TestAgent, label: string): Promise<void> {
+  // failLoud: print the full diagnosis on stderr BEFORE throwing — the FATAL
+  // handlers at the bottom of this file print `e.stack`, and the message line
+  // is not reliably part of it under bun (observed live: a throw from here
+  // surfaced as a bare "FATAL: Error" + frames, diagnosis lost), so the
+  // message must not depend on stack formatting to reach the operator.
+  const failLoud = (msg: string): never => {
+    console.error(msg);
+    throw new Error(msg);
+  };
+  const res = await signedFetch(harper, agent, "GET", "/HealthDetail");
+  if (!res.ok) failLoud(`${label} rerank engagement check: /HealthDetail failed: HTTP ${res.status} ${JSON.stringify(res.body ?? null).slice(0, 300)}`);
+  const rr = res.body?.rerank;
+  if (!rr || typeof rr !== "object") failLoud(`${label} rerank engagement check: /HealthDetail returned no rerank status block`);
+  if (rr.state !== "ready" || !(rr.rerankCount > 0)) {
+    const detail = `state=${rr.state} model=${rr.model} rerankCount=${rr.rerankCount} fallbackCount=${rr.fallbackCount}` + (rr.error ? ` error="${rr.error}"` : "");
+    failLoud(
+      `${label} rerank arm NEVER ENGAGED: ${detail} — the reranker fell open and this arm measured a ` +
+      `NON-reranked run (flair#815). Provision the reranker GGUF per docs/rerank-provisioning.md ` +
+      `(FLAIR_MODELS_DIR may point at an existing install's models/ dir, same as for the embedding model).`,
+    );
+  }
+  console.log(`${label} rerank engaged: model=${rr.model} rerankCount=${rr.rerankCount} fallbackCount=${rr.fallbackCount} lastLatencyMs=${rr.lastLatencyMs}`);
+}
+
 // One independent (spawn → register → seed → wait → measure[raw,composite] →
 // teardown) cycle for a given (hybrid, rerank, prefixesOn) config.
 // prefixesOn=false forces the harness-only prefix override to "false" (see
@@ -303,9 +338,19 @@ async function runOnce(hybrid: boolean, rerank: boolean, prefixesOn: boolean, ru
   const label = `[hybrid=${hybrid} rerank=${rerank} prefixes=${prefixesOn ? "on" : "off"} run ${runIdx}/${totalRuns}]`;
   const prevHybrid = process.env.FLAIR_HYBRID_RETRIEVAL;
   const prevRerank = process.env.FLAIR_RERANK_ENABLED;
+  const prevRerankModel = process.env.FLAIR_RERANK_MODEL;
   const prevPrefix = process.env.FLAIR_RECALL_HARNESS_FORCE_PREFIX;
   process.env.FLAIR_HYBRID_RETRIEVAL = hybrid ? "true" : "false";
-  if (rerank) process.env.FLAIR_RERANK_ENABLED = "true"; else delete process.env.FLAIR_RERANK_ENABLED;
+  if (rerank) {
+    process.env.FLAIR_RERANK_ENABLED = "true";
+    // flair#815: pin the model this arm measures to the rank-pooling
+    // cross-encoder that actually serves inside Harper's runtime (see
+    // resources/rerank-provider.ts's file header — the generative qwen3 path
+    // reliably fails open in-Harper), unless the caller explicitly chose one.
+    // Belt-and-suspenders with assertRerankEngaged() below: pinning makes the
+    // arm measure a known model; the assertion proves it actually ran.
+    if (!process.env.FLAIR_RERANK_MODEL) process.env.FLAIR_RERANK_MODEL = "jina-reranker-v2";
+  } else delete process.env.FLAIR_RERANK_ENABLED;
   if (prefixesOn) delete process.env.FLAIR_RECALL_HARNESS_FORCE_PREFIX; else process.env.FLAIR_RECALL_HARNESS_FORCE_PREFIX = "false";
 
   let harper: HarperInstance | undefined;
@@ -342,11 +387,15 @@ async function runOnce(hybrid: boolean, rerank: boolean, prefixesOn: boolean, ru
     // durability/recency effect this harness targets, but worth naming.
     const raw = await runQueries(harper, agent, "raw");
     const composite = await runQueries(harper, agent, "composite");
+    // flair#815: measurement integrity gate — fail loud (nonzero exit via
+    // main()'s catch) if this arm's reranker never actually engaged.
+    if (rerank) await assertRerankEngaged(harper, agent, label);
     return { raw, composite };
   } finally {
     if (harper) await stopHarper(harper, { keepInstallDir: false });
     if (prevHybrid === undefined) delete process.env.FLAIR_HYBRID_RETRIEVAL; else process.env.FLAIR_HYBRID_RETRIEVAL = prevHybrid;
     if (prevRerank === undefined) delete process.env.FLAIR_RERANK_ENABLED; else process.env.FLAIR_RERANK_ENABLED = prevRerank;
+    if (prevRerankModel === undefined) delete process.env.FLAIR_RERANK_MODEL; else process.env.FLAIR_RERANK_MODEL = prevRerankModel;
     if (prevPrefix === undefined) delete process.env.FLAIR_RECALL_HARNESS_FORCE_PREFIX; else process.env.FLAIR_RECALL_HARNESS_FORCE_PREFIX = prevPrefix;
   }
 }

--- a/test/unit/rerank-provider.test.ts
+++ b/test/unit/rerank-provider.test.ts
@@ -1,4 +1,7 @@
 import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, mkdirSync, rmSync, realpathSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import {
   yesNoScore,
   applyRerank,
@@ -11,6 +14,7 @@ import {
   truncateChars,
   truncateTokenBudget,
   needsReinit,
+  resolveRerankModelPath,
 } from "../../resources/rerank-provider";
 
 // These tests exercise the DETERMINISTIC scoring + reorder + config paths
@@ -176,6 +180,68 @@ describe("config readers (FLAIR_RERANK_* env, default OFF)", () => {
   test("qwen3 is still selectable explicitly (kept available, EXPERIMENTAL)", () => {
     process.env.FLAIR_RERANK_MODEL = "qwen3-reranker-0.6b-q8";
     expect(getRerankStatus().model).toBe("qwen3-reranker-0.6b-q8");
+  });
+});
+
+describe("resolveRerankModelPath (models-dir resolution, flair#815)", () => {
+  // The bug: ensureInit() hardcoded join(process.cwd(), "models", file),
+  // ignoring FLAIR_MODELS_DIR — so any deployment whose cwd wasn't the models
+  // location (e.g. the recall harness's ephemeral Harpers) failed init and
+  // silently fell open to vector order. The fix routes through the shared
+  // resolveModelsDir() (resources/models-dir.ts — the same resolution the
+  // embedding engine uses; its full 4-step priority chain is covered by
+  // test/unit/embeddings-models-dir.test.ts; these tests pin the two ends
+  // the reranker cares about).
+  const SAVED = {
+    FLAIR_MODELS_DIR: process.env.FLAIR_MODELS_DIR,
+    ROOTPATH: process.env.ROOTPATH,
+  };
+  let originalCwd: string;
+  let scratch: string;
+
+  beforeEach(() => {
+    originalCwd = process.cwd();
+    // realpath so comparisons against process.cwd() hold on macOS, where
+    // /var and /tmp are symlinks to /private/* (cwd reports the resolved path).
+    scratch = realpathSync(mkdtempSync(join(tmpdir(), "flair-rerank-models-dir-")));
+    delete process.env.FLAIR_MODELS_DIR;
+    delete process.env.ROOTPATH;
+  });
+
+  afterEach(() => {
+    process.chdir(originalCwd);
+    if (SAVED.FLAIR_MODELS_DIR === undefined) delete process.env.FLAIR_MODELS_DIR;
+    else process.env.FLAIR_MODELS_DIR = SAVED.FLAIR_MODELS_DIR;
+    if (SAVED.ROOTPATH === undefined) delete process.env.ROOTPATH;
+    else process.env.ROOTPATH = SAVED.ROOTPATH;
+    rmSync(scratch, { recursive: true, force: true });
+  });
+
+  test("FLAIR_MODELS_DIR set → GGUF path resolves under it (not cwd)", () => {
+    process.env.FLAIR_MODELS_DIR = "/opt/flair-models";
+    expect(resolveRerankModelPath("jina-reranker-v2-base.Q8_0.gguf")).toBe(
+      join("/opt/flair-models", "jina-reranker-v2-base.Q8_0.gguf"),
+    );
+  });
+
+  test("unset, cwd has a models/ dir → falls back to <cwd>/models (backward compat)", () => {
+    process.chdir(scratch);
+    mkdirSync(join(scratch, "models"), { recursive: true });
+    expect(resolveRerankModelPath("jina-reranker-v2-base.Q8_0.gguf")).toBe(
+      join(scratch, "models", "jina-reranker-v2-base.Q8_0.gguf"),
+    );
+  });
+
+  test("resolves the SAME dir as the embedding engine (alongside guarantee)", () => {
+    // docs/rerank-provisioning.md: the reranker GGUF lives alongside the
+    // embedding GGUF. That only holds if both read the same resolution —
+    // ROOTPATH (Harper's data dir) beats a cwd models/ dir, same as embeddings.
+    process.env.ROOTPATH = join(scratch, "data");
+    process.chdir(scratch);
+    mkdirSync(join(scratch, "models"), { recursive: true });
+    expect(resolveRerankModelPath("jina-reranker-v2-base.Q8_0.gguf")).toBe(
+      join(scratch, "data", "models", "jina-reranker-v2-base.Q8_0.gguf"),
+    );
   });
 });
 


### PR DESCRIPTION
Fixes #815.

Two halves, per the issue's diagnosis:

## 1. `rerank-provider.ts` respects `FLAIR_MODELS_DIR`

`ensureInit()` resolved the reranker GGUF from a hardcoded `join(process.cwd(), "models", spec.file)` — ignoring `FLAIR_MODELS_DIR` and inconsistent with `embeddings-provider.ts`. In any deployment where Harper's cwd wasn't the models location (including every ephemeral Harper the recall harness spawns), init threw `reranker GGUF not found`, `rerankCandidates` caught it, and reranking silently no-op'd to vector order.

It now resolves through the same `resolveModelsDir()` the embedding engine uses (`FLAIR_MODELS_DIR` → `<ROOTPATH>/models` → `<cwd>/models` backward compat → `~/.flair/data/models`), so the "provisioned alongside the embedding GGUF" contract in `docs/rerank-provisioning.md` holds by construction. The not-found error now reports the full resolved path. Production fail-open behavior is unchanged — a rerank error still never blocks recall.

**Extraction note:** `resolveModelsDir()` moved verbatim to a new shared `resources/models-dir.ts`, re-exported from `embeddings-provider.ts` so existing consumers (`embeddings-boot.ts`, `test/unit/embeddings-models-dir.test.ts`) are untouched. A direct `rerank-provider → embeddings-provider` import was tried first and empirically broke `test/unit-isolated/semantic-search-scoping.test.ts` (collapsed to 0 collected tests) and made `test/unit/rerank-provider.test.ts` order-dependent: several unit-isolated files `mock.module()` the whole embeddings-provider module with only the named exports they consume, and bun's module cache is process-wide — the new import made those mocks incomplete and killed unrelated files at module load. The tiny, never-mocked, stdlib-only shared module sidesteps that hazard class for good (documented in its header).

## 2. Harness `--rerank` arm can no longer measure a fiction

`test/bench/recall-harness/run.ts` set `FLAIR_RERANK_ENABLED=true`, but combined with (1) its rerank arm silently measured a **non-reranked** run while labeling it reranked — exactly how the issue was found (a rerank on/off A/B came back byte-identical). Now:

- The `--rerank` arm pins `FLAIR_RERANK_MODEL=jina-reranker-v2` (the rank-pooling model that actually serves inside Harper's runtime — see the provider's file header; a caller-provided value is respected), saved/restored like the arm's other env knobs.
- After measuring, `assertRerankEngaged()` reads the provider's own diagnostics (`getRerankStatus()` via the authenticated `/HealthDetail` `rerank` block) from the same spawned Harper that served the queries, and **fails loud** — full diagnosis (state/model/rerankCount/fallbackCount/error + remediation) and nonzero exit — unless `state=ready` and `rerankCount > 0`. The diagnosis is printed to stderr before the throw because the harness's `FATAL:` handlers print `e.stack`, which does not reliably carry the message line under bun (observed live: the throw surfaced as a bare `FATAL: Error` + frames).

## Tests

- New unit coverage in `test/unit/rerank-provider.test.ts`: `resolveRerankModelPath` honors `FLAIR_MODELS_DIR`; falls back to `<cwd>/models` when unset; resolves the same dir as the embedding engine (`ROOTPATH` beats cwd — the "alongside" guarantee). `test/unit/embeddings-models-dir.test.ts` still pins the full resolution order through the re-export, unchanged.
- Full unit suite locally: 3035 pass — same 2 pre-existing full-suite-only flakes as clean `main` (`usage-recording.test.ts`'s intentional-throw tests; both files pass standalone).
- **End-to-end, both directions**, real harness, worktree with no `models/` dir (the previously-broken shape):
  - `FLAIR_MODELS_DIR=<provisioned models dir>` + `--runs 1 --hybrid on --prefixes on --rerank` → `rerank engaged: model=jina-reranker-v2 rerankCount=61 fallbackCount=0 lastLatencyMs=441`, exit 0. Pre-fix, this arm failed open.
  - Same invocation with a models dir containing only the embedding GGUFs (rerank GGUF absent) → `rerank arm NEVER ENGAGED: state=failed ... rerankCount=0 fallbackCount=61 error="reranker GGUF not found: <full resolved path> ..."`, exit 1.

CHANGELOG entry in the same commit; `node scripts/docs-freshness-check.mjs` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
