### PR TITLE
fix(mcp): pin the wired flair-mcp version instead of resolving latest every session

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Security
+
+- **The MCP server reference written into client configs is now pinned to the installed version.** `flair init` previously wired `npx -y @tpsdev-ai/flair-mcp`, which re-resolves to whatever is currently published on *every* agent session — so a single bad publish would reach every wired user silently, with no lockfile and no review in the path, and a yank would not help because unpinned clients keep resolving latest. Clients are now wired to `@tpsdev-ai/flair-mcp@<version>` (the running CLI's own version; the two ship in lockstep), so a wired client keeps running the version that was current when it was wired and moving forward is a deliberate act. The `init` MCP smoke test now exercises that same pinned spec rather than resolving latest independently. Falls back to the unpinned form only when the version cannot be read — the same condition under which `--version` reports `unknown`.
+
 ### Changed
 
 - **Removed the `specs/` directory** (12 planning docs — `FLAIR-1.0-SPEC.md`, `FLAIR-BRIDGES.md`, `FLAIR-CONTENT-SAFETY.md`, `FLAIR-DEPLOY.md`, `FLAIR-NIGHTLY-REM.md` + its two slice docs, `FLAIR-REEMBEDDING.md`, `FLAIR-XAA.md`, `AGENT-CONTEXT-TIERS-B-task-reset.md`, `N8N-NODE-q3qf.md`, `N8N-ED25519-q3qf-followup.md`). Planning docs now live as GitHub issues; reference docs live in `docs/`, `DESIGN.md`, and `CONTRIBUTING.md`. Every in-tree reference to a deleted spec path was repointed: bridge contract references now point at `docs/bridges.md` (now the authoritative contract, which now carries the full contract and states its own authority); REM references now point at `docs/rem.md` and `docs/notes/rem-ux.md`; n8n spec links (which pointed at absolute GitHub URLs that would 404) became plain prose; comments citing a slice spec + section for deferred/in-flight work (e.g. `§3A`, `§3B`, `§3C`) kept the section and issue number (#707) and dropped the dead file path. Historical `CHANGELOG.md` entries were left untouched — they correctly describe files that existed at the time.

--- a/docs/mcp-clients.md
+++ b/docs/mcp-clients.md
@@ -38,6 +38,8 @@ Flair runs as a local server at `http://127.0.0.1:19926` by default. The MCP ser
 
 Pick whichever you use. The MCP server is the same package; only the config syntax differs.
 
+> **Pin the version.** The snippets below use the bare package name for readability. `flair init` wires clients to a **pinned** spec (`@tpsdev-ai/flair-mcp@<version>`) on purpose: an unpinned reference re-resolves to whatever is currently published on every agent session, so any future publish reaches your machine silently. If you wire by hand, append the version you intend to run — `@tpsdev-ai/flair-mcp@0.28.0` — and bump it deliberately. `flair init` is the easier path and does this for you.
+
 ### Claude Code
 
 The canonical approach is the `claude mcp add` CLI (writes to `~/.claude.json`):

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2185,6 +2185,40 @@ const __pkgVersion = (() => {
   catch { return "unknown"; }
 })();
 
+/**
+ * The `@tpsdev-ai/flair-mcp` spec written into a client's MCP config.
+ *
+ * PINNED, deliberately. A bare `npx -y @tpsdev-ai/flair-mcp` re-resolves to
+ * whatever is currently published on EVERY agent session — so a single bad
+ * publish (stolen credentials, a malicious commit that clears review, or a
+ * compromised dependency of the MCP package) reaches every wired user
+ * silently, with no lockfile and no review step in the path. The postmark-mcp
+ * incident was exactly this shape: a legitimate publish by the legitimate
+ * owner, propagating for 16 days before anyone noticed. Worse, a yank does
+ * not help — unpinned clients keep resolving latest.
+ *
+ * Our publish side is already hardened (OIDC staged publish, human 2FA at the
+ * release gate), but that defends against credential theft, not against a bad
+ * version being published legitimately. The consumer side is where that gap
+ * closes, and pinning is what closes it: a wired client keeps running the
+ * exact version that was current when it was wired, and moving forward
+ * becomes a deliberate act.
+ *
+ * flair and flair-mcp ship in version lockstep from this monorepo, so the
+ * running CLI's own version is the correct pin. `flair init` re-run rewires
+ * to the then-current version; see the upgrade-rewire follow-up issue for
+ * making `flair upgrade` do the same.
+ *
+ * Falls back to the unpinned spec only when the version can't be read, which
+ * is the same condition under which `--version` reports "unknown" — a broken
+ * install, where a working MCP wiring matters more than a precise pin.
+ */
+export function mcpServerSpec(version: string = __pkgVersion): string {
+  return version && version !== "unknown"
+    ? `@tpsdev-ai/flair-mcp@${version}`
+    : "@tpsdev-ai/flair-mcp";
+}
+
 const program = new Command();
 program.name("flair").version(__pkgVersion, "-v, --version");
 
@@ -2890,7 +2924,8 @@ program
 
       // ── MCP client wiring ────────────────────────────────────────────────
       // The full one-command front door: detect installed MCP clients and wire
-      // each to the zero-install `npx -y @tpsdev-ai/flair-mcp` server. Claude
+      // each to the zero-install `npx -y @tpsdev-ai/flair-mcp@<version>` server
+      // (pinned — see mcpServerSpec()). Claude
       // Code is auto-wired into ~/.claude.json (the only client the CLI can
       // safely modify); other clients get copy-paste snippets. `--no-mcp`
       // skips wiring entirely; `--client <name>` targets one client; the
@@ -2929,7 +2964,7 @@ program
             const flairMcpConfig = {
               type: "stdio" as const,
               command: "npx",
-              args: ["-y", "@tpsdev-ai/flair-mcp"] as string[],
+              args: ["-y", mcpServerSpec()] as string[],
               // flair#718 authorship-provenance: each client's wired env block
               // gets its OWN FLAIR_CLIENT label (never the shared mcpEnv
               // object directly — that would stamp the same label into every
@@ -3009,7 +3044,9 @@ program
       if (!opts.skipSmoke && !noMcp && clientOpt !== "none" && wiringResults.length > 0) {
         console.log("\n   Smoke-testing MCP server...");
         try {
-          const mcpProc = spawn("npx", ["-y", "@tpsdev-ai/flair-mcp"], {
+          // Same spec that gets WIRED above — the smoke test must exercise the
+          // exact version the user will run, not whatever npm resolves latest to.
+          const mcpProc = spawn("npx", ["-y", mcpServerSpec()], {
             env: { ...process.env, FLAIR_AGENT_ID: agentId, FLAIR_URL: httpUrl },
             stdio: ["pipe", "pipe", "pipe"],
           });

--- a/test/unit/mcp-server-spec.test.ts
+++ b/test/unit/mcp-server-spec.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, test } from "bun:test";
+import { mcpServerSpec } from "../../src/cli.js";
+
+// The MCP server spec is what gets written into a user's client config and
+// re-resolved by npx on every agent session. An unpinned spec means any future
+// publish reaches every wired user silently — the postmark-mcp shape. These
+// tests pin that property, not the formatting.
+describe("mcpServerSpec — the wired MCP server reference", () => {
+  test("pins to the given version so a later publish cannot silently propagate", () => {
+    expect(mcpServerSpec("0.28.0")).toBe("@tpsdev-ai/flair-mcp@0.28.0");
+  });
+
+  test("is never the bare unpinned package when a version is known", () => {
+    // The regression that matters: reverting to `@tpsdev-ai/flair-mcp` with no
+    // version restores silent auto-update for everyone already wired.
+    expect(mcpServerSpec("1.2.3")).not.toBe("@tpsdev-ai/flair-mcp");
+    expect(mcpServerSpec("1.2.3")).toContain("@1.2.3");
+  });
+
+  test("falls back to unpinned only when the version is unreadable", () => {
+    // Same condition under which `--version` reports "unknown" — a broken
+    // install, where a working wiring beats a precise pin.
+    expect(mcpServerSpec("unknown")).toBe("@tpsdev-ai/flair-mcp");
+    expect(mcpServerSpec("")).toBe("@tpsdev-ai/flair-mcp");
+  });
+});


### PR DESCRIPTION
## The problem

`flair init` wired every detected client to:

```
npx -y @tpsdev-ai/flair-mcp
```

Unpinned. The bare package name re-resolves to whatever is currently published **on every agent session**. So a single bad publish — stolen credentials, a malicious commit that clears review, or a compromised dependency of the MCP package — reaches every wired user silently. There's no lockfile and no review step anywhere in that path, and **yanking doesn't help**: unpinned clients keep resolving latest.

The postmark-mcp incident was precisely this shape. Not stolen credentials — a legitimate publish by the legitimate owner, one line added in v16, every outgoing email BCC'd for 16 days before anyone noticed.

And because we *auto-wire* this during `init`, it isn't a documentation choice a user opted into. It's our default.

## What this doesn't fix, stated plainly

Our publish side is already reasonably hardened: OIDC staged publish with a human 2FA gate at release. That defends against **credential theft**. It does nothing about a bad version being published legitimately, which is the postmark case. This PR closes the consumer-side gap, which is the one we control on behalf of users.

## The change

Clients are wired to `@tpsdev-ai/flair-mcp@<version>`, using the running CLI's own version. `flair` and `flair-mcp` ship in lockstep from this monorepo, so the CLI's version is the correct pin.

A wired client therefore keeps running the version that was current when it was wired, and moving forward becomes a deliberate act rather than an automatic one.

Two smaller things came with it:

- **The `init` MCP smoke test now exercises the same pinned spec.** It previously spawned its own unpinned `npx`, meaning the smoke test could validate a *different version* than the one being wired into the user's config.
- **`docs/mcp-clients.md` now explains the pinning** and tells hand-wirers to append a version. The snippets keep the bare name for readability, with the rationale stated once at the top rather than repeated.

Falls back to the unpinned form only when the version can't be read — the same condition under which `--version` reports `unknown`, i.e. a broken install, where a working wiring matters more than a precise pin.

## Verification

- 3 new unit tests covering the pinned case, the never-bare-when-known case, and the unreadable-version fallback.
- **Mutation-checked**: reverting the implementation to return the bare package name fails 2 of the 3 tests. The test catches the regression it was written for.
- `tsc --noEmit -p tsconfig.cli.json` clean; `docs-freshness-check` passes.

## Follow-up, not in this PR

`flair upgrade` should re-wire the pin so upgrading doesn't leave clients on an old MCP server. Worth its own change — this one is deliberately scoped to closing the silent-propagation hole.
