### PR TITLE
fix(rem): stop reporting scheduler success when activation failed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- **`flair rem nightly enable` printed a green "scheduler enabled" headline even when activation failed, and `flair status`/`flair rem nightly status` kept repeating the claim afterward — with no way to detect the failure from an exit code.** In any session without a systemd user bus (ssh without lingering, a container, CI), `systemctl --user enable --now flair-rem-nightly.timer` exits nonzero with `Failed to connect to bus: No medium found` — `enableScheduler()` (`src/rem/scheduler.ts`) already captured that failure as `loadResult`, but the CLI (`src/cli.ts`) printed the success headline unconditionally, first, and only reported the nonzero code in a line underneath it, with `process.exit` never called — so scripts saw exit 0 for a scheduler that had nothing scheduled. Both scheduler-status surfaces had the same shape: `schedulerStatus()` and the `/HealthDetail` REM block (`resources/health.ts`) both inferred "enabled" from the timer/plist file existing, which a failed `enable` still writes. Fixed at the root: `formatEnableReport()` and `formatStatusReport()` (new, `src/rem/scheduler.ts`) only print a success headline when activation is actually known to have succeeded, `flair rem nightly enable` now exits nonzero on activation failure, and a new genuine active-state query (`launchctl print` / `systemctl --user is-active`, sync for the CLI and a non-blocking async form for the Health endpoint) replaces the file-existence check in both `schedulerStatus()` and `resources/health.ts`'s `nightlyEnabled`. The bus-connection failure now also names its own remedy inline (`loginctl enable-linger <user>`) instead of surfacing a bare error the operator has to go research.
+
 ## [0.29.0] - 2026-07-26
 
 ### Security

--- a/resources/health.ts
+++ b/resources/health.ts
@@ -406,12 +406,31 @@ export class HealthDetail extends Resource {
       const lastRapidAt = findLast("rapid");
       const lastRestorativeAt = findLast("restorative");
 
+      // File presence only proves the scheduler templates were written —
+      // NOT that launchctl/systemctl actually loaded the job. A
+      // `systemctl --user enable --now` that fails (e.g. no session bus)
+      // still leaves the timer file on disk, so file-existence alone would
+      // report "enabled" for a scheduler that has nothing scheduled
+      // (flair#850). Query genuine active state once the file is known to
+      // exist; async + short-timeout so a slow/hung service manager can't
+      // stall this request.
       let nightlyEnabled: boolean | null = null;
+      let nightlyInstalled = false;
       const plat = platform();
-      if (plat === "darwin") {
-        nightlyEnabled = await exists(join(homedir(), "Library", "LaunchAgents", "dev.flair.rem.nightly.plist"));
-      } else if (plat === "linux") {
-        nightlyEnabled = await exists(join(homedir(), ".config", "systemd", "user", "flair-rem-nightly.timer"));
+      if (plat === "darwin" || plat === "linux") {
+        nightlyInstalled = plat === "darwin"
+          ? await exists(join(homedir(), "Library", "LaunchAgents", "dev.flair.rem.nightly.plist"))
+          : await exists(join(homedir(), ".config", "systemd", "user", "flair-rem-nightly.timer"));
+        if (nightlyInstalled) {
+          try {
+            const { queryActiveStateAsync } = await import("../src/rem/scheduler.js");
+            nightlyEnabled = await queryActiveStateAsync(plat);
+          } catch {
+            nightlyEnabled = null;
+          }
+        } else {
+          nightlyEnabled = false;
+        }
       }
 
       const nightlyRecords = await tailJsonl(nightlyLog);
@@ -447,6 +466,9 @@ export class HealthDetail extends Resource {
         };
         if (nightlyEnabled && lastNightlyAt && nowMs - new Date(lastNightlyAt).getTime() > 48 * 3600 * 1000) {
           warnings.push({ level: "warn", message: "nightly REM hasn't run in >48h" });
+        }
+        if (nightlyInstalled && nightlyEnabled === false) {
+          warnings.push({ level: "warn", message: "REM nightly scheduler files are written but not active — nothing is scheduled (see `flair rem nightly status`)" });
         }
       }
     } catch { stats.rem = null; }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -7150,25 +7150,15 @@ remNightly
     const port = readPortFromConfig() ?? DEFAULT_PORT;
     const flairUrl = opts.flairUrl || process.env.FLAIR_URL || `http://127.0.0.1:${port}`;
 
-    const { enableScheduler } = await import("./rem/scheduler.js");
+    const { enableScheduler, formatEnableReport } = await import("./rem/scheduler.js");
     try {
       const r = enableScheduler({ agentId, flairUrl, hour, minute });
-      console.log(`✅ REM nightly scheduler enabled (${r.platform})`);
-      console.log(`   Schedule:    ${String(hour).padStart(2, "0")}:${String(minute).padStart(2, "0")} local time`);
-      console.log(`   Scheduler:   ${r.schedulerPath}`);
-      console.log(`   Shim:        ${r.shimPath}`);
-      console.log(`   Agent:       ${agentId}`);
-      console.log(`   Flair URL:   ${flairUrl}`);
-      if (r.loadResult) {
-        if (r.loadResult.code === 0) {
-          console.log(`   Load:        ${r.loadCommand.join(" ")} → ok`);
-        } else {
-          console.log(`   Load:        ${r.loadCommand.join(" ")} → code ${r.loadResult.code}`);
-          if (r.loadResult.stderr) console.log(`     stderr: ${r.loadResult.stderr.trim()}`);
-        }
-      }
-      console.log(`\nTip: run \`flair rem nightly run-once --dry-run\` to verify the cycle works`);
-      console.log(`     before the first scheduled fire. Disable with \`flair rem nightly disable\`.`);
+      // formatEnableReport() owns the success-vs-failure decision (flair#850:
+      // do not print a success headline before activation is known to have
+      // succeeded) — see src/rem/scheduler.ts for the unit-tested logic.
+      const { lines, ok } = formatEnableReport(r, { hour, minute, agentId, flairUrl });
+      for (const line of lines) console.log(line);
+      if (!ok) process.exit(1);
     } catch (err: any) {
       console.error(`Error: ${err.message}`);
       process.exit(1);
@@ -7204,18 +7194,13 @@ remNightly
 
 remNightly
   .command("status")
-  .description("Show whether the nightly scheduler is installed")
+  .description("Show whether the nightly scheduler is installed and genuinely active")
   .action(async () => {
-    const { schedulerStatus } = await import("./rem/scheduler.js");
+    const { schedulerStatus, formatStatusReport } = await import("./rem/scheduler.js");
     try {
       const s = schedulerStatus();
-      console.log(`REM nightly scheduler (${s.platform}):`);
-      console.log(`  Installed:   ${s.installed ? "yes" : "no"}`);
-      console.log(`  Scheduler:   ${s.schedulerPath}`);
-      console.log(`  Shim:        ${s.shimPath}${s.shimExists ? "" : " (missing)"}`);
-      if (!s.installed) {
-        console.log(`\nEnable with: flair rem nightly enable --agent <id> [--at HH:MM]`);
-      }
+      const { lines } = formatStatusReport(s);
+      for (const line of lines) console.log(line);
     } catch (err: any) {
       console.error(`Error: ${err.message}`);
       process.exit(1);

--- a/src/rem/scheduler.ts
+++ b/src/rem/scheduler.ts
@@ -16,7 +16,7 @@
 import { existsSync, mkdirSync, writeFileSync, readFileSync, chmodSync, rmSync, statSync } from "node:fs";
 import { resolve, dirname, join } from "node:path";
 import { homedir, platform } from "node:os";
-import { spawnSync, type SpawnSyncReturns } from "node:child_process";
+import { spawn, spawnSync, type SpawnSyncReturns } from "node:child_process";
 import { fileURLToPath } from "node:url";
 
 export const SHIM_PATH_DEFAULT = resolve(homedir(), ".flair", "bin", "flair-rem-nightly");
@@ -177,16 +177,224 @@ function writeFileWithDir(path: string, contents: string, mode: number = 0o600):
 // can't block the CLI indefinitely. Sherlock #415 follow-up.
 const SPAWN_TIMEOUT_MS = 30_000;
 
-function spawnReport(cmd: string[]): { code: number | null; stdout: string; stderr: string } {
+// Status-check spawns (launchctl print / systemctl is-active) return
+// near-instantly when the service manager is reachable, and fail fast (no
+// hang) when it isn't (e.g. "Failed to connect to bus"). A short ceiling
+// keeps `flair rem nightly status` and the Health endpoint responsive even
+// when the query is inconclusive.
+const STATUS_CHECK_TIMEOUT_MS = 5_000;
+
+function spawnReport(cmd: string[], timeoutMs: number = SPAWN_TIMEOUT_MS): { code: number | null; stdout: string; stderr: string } {
   const r: SpawnSyncReturns<Buffer> = spawnSync(cmd[0], cmd.slice(1), {
     encoding: "buffer",
-    timeout: SPAWN_TIMEOUT_MS,
+    timeout: timeoutMs,
   });
   return {
     code: r.status,
     stdout: r.stdout?.toString("utf-8") ?? "",
     stderr: r.stderr?.toString("utf-8") ?? "",
   };
+}
+
+/**
+ * Command to genuinely query the platform scheduler's active/loaded state
+ * for a given install (as opposed to the shape of `loadCommand`, which
+ * *installs* it). Shared by the sync and async active-state checks below so
+ * the two can't drift.
+ */
+function activeCheckCommand(plat: SchedulerPlatform): string[] {
+  if (plat === "darwin") {
+    return ["launchctl", "print", `gui/${process.getuid?.() ?? ""}/dev.flair.rem.nightly`];
+  }
+  return ["systemctl", "--user", "is-active", "flair-rem-nightly.timer"];
+}
+
+/**
+ * Interprets the result of `activeCheckCommand()`. Shared by the sync
+ * (CLI) and async (server) callers.
+ *
+ * - true  — the service manager confirms the job is loaded/active.
+ * - false — confirmed NOT active. This includes the "no session bus" case
+ *   (flair#850): when `systemctl --user` can't reach a bus, it fails
+ *   before printing a status word ("Failed to connect to bus: No medium
+ *   found") — but nothing CAN be running without a bus, so `false` is the
+ *   honest answer, not "unknown".
+ * - null  — genuinely inconclusive (the command itself couldn't run at
+ *   all — e.g. the binary is missing — with no output to interpret).
+ */
+export function interpretActiveResult(plat: SchedulerPlatform, code: number | null, stdout: string, stderr: string): boolean | null {
+  const noOutput = !stdout.trim() && !stderr.trim();
+  if (plat === "darwin") {
+    if (code === 0) return true;
+    if (code === null && noOutput) return null; // spawn itself failed — inconclusive
+    return false; // launchctl ran and reported not-loaded
+  }
+  const out = stdout.trim();
+  if (out === "active" || out === "activating") return true;
+  if (out === "inactive" || out === "failed" || out === "unknown") return false;
+  if (code === null && noOutput) return null; // spawn itself failed — inconclusive
+  return false; // covers the no-bus case: empty stdout, nonzero/failed exit
+}
+
+/**
+ * Synchronous active-state check for CLI use (`flair rem nightly status`).
+ * Blocking is fine here — this is a one-shot process and the caller wants
+ * the answer before printing anything.
+ */
+function queryActiveState(plat: SchedulerPlatform): boolean | null {
+  const [cmd, ...args] = activeCheckCommand(plat);
+  const r = spawnReport([cmd, ...args], STATUS_CHECK_TIMEOUT_MS);
+  return interpretActiveResult(plat, r.code, r.stdout, r.stderr);
+}
+
+/**
+ * Async, non-blocking equivalent for server contexts (the Health endpoint)
+ * where a synchronous subprocess would stall the request-handling thread.
+ * Same semantics as `queryActiveState()`.
+ */
+export async function queryActiveStateAsync(plat: SchedulerPlatform, timeoutMs: number = STATUS_CHECK_TIMEOUT_MS): Promise<boolean | null> {
+  const [cmd, ...args] = activeCheckCommand(plat);
+  return new Promise((resolvePromise) => {
+    let settled = false;
+    let child: ReturnType<typeof spawn>;
+    const finish = (result: boolean | null) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      resolvePromise(result);
+    };
+    const timer = setTimeout(() => {
+      try { child?.kill("SIGKILL"); } catch { /* best-effort */ }
+      finish(null);
+    }, timeoutMs);
+    try {
+      child = spawn(cmd, args, { stdio: ["ignore", "pipe", "pipe"] });
+    } catch {
+      finish(null);
+      return;
+    }
+    let stdout = "";
+    let stderr = "";
+    child.stdout?.on("data", (d) => { stdout += d.toString("utf-8"); });
+    child.stderr?.on("data", (d) => { stderr += d.toString("utf-8"); });
+    child.on("error", () => finish(null));
+    child.on("close", (code) => finish(interpretActiveResult(plat, code, stdout, stderr)));
+  });
+}
+
+/**
+ * Human remedy text for a failed scheduler-load attempt (flair#850). Covers
+ * the one root cause traced so far: a missing systemd user session bus,
+ * which blocks `systemctl --user` entirely in ssh-without-lingering,
+ * container, and CI contexts. Returns null when the failure doesn't match a
+ * known pattern — the caller already prints the raw stderr, so the operator
+ * still has something to go on.
+ */
+export function describeLoadFailure(plat: SchedulerPlatform, loadResult: { code: number | null; stderr: string }): string | null {
+  const stderr = loadResult.stderr || "";
+  if (plat === "linux" && /failed to connect to bus/i.test(stderr)) {
+    return (
+      "No systemd user session bus is available in this session (common over ssh without lingering, " +
+      "in containers, or under CI). Fix: enable lingering for this user — `loginctl enable-linger <user>` " +
+      "— then re-run `flair rem nightly enable`."
+    );
+  }
+  return null;
+}
+
+export interface EnableReportInput {
+  hour: number;
+  minute: number;
+  agentId: string;
+  flairUrl: string;
+}
+
+export interface FormattedReport {
+  lines: string[];
+  /** false means the caller should signal failure (nonzero exit). */
+  ok: boolean;
+}
+
+/**
+ * Formats the `flair rem nightly enable` report from an `EnableResult`.
+ * Pulled out of the CLI action so the success-vs-failure decision (flair#850:
+ * do not print a success headline before activation is known to have
+ * succeeded) is unit-testable without spawning a real launchctl/systemctl or
+ * parsing CLI argv.
+ *
+ * `r.loadResult` is only set when the load command actually ran (the CLI
+ * never sets `skipLoad`). A missing `loadResult` (test-only path) is treated
+ * as success — matches the CLI's real-world behavior, which always runs the
+ * load command and therefore always gets a `loadResult`.
+ */
+export function formatEnableReport(r: EnableResult, input: EnableReportInput): FormattedReport {
+  const { hour, minute, agentId, flairUrl } = input;
+  const scheduleTime = `${String(hour).padStart(2, "0")}:${String(minute).padStart(2, "0")}`;
+  const activationFailed = !!r.loadResult && r.loadResult.code !== 0;
+
+  if (activationFailed) {
+    const lr = r.loadResult!;
+    const lines = [
+      `⚠️  REM nightly scheduler files written but NOT activated (${r.platform})`,
+      `   Schedule:    ${scheduleTime} local time — NOT scheduled (see below)`,
+      `   Scheduler:   ${r.schedulerPath}`,
+      `   Shim:        ${r.shimPath}`,
+      `   Agent:       ${agentId}`,
+      `   Flair URL:   ${flairUrl}`,
+      `   Activation:  ${r.loadCommand.join(" ")} → code ${lr.code}`,
+    ];
+    if (lr.stderr) lines.push(`     stderr: ${lr.stderr.trim()}`);
+    const remedy = describeLoadFailure(r.platform, lr);
+    lines.push("");
+    lines.push(remedy ? `   ${remedy}` : `   Re-run the activation command above manually to see the full diagnostic.`);
+    lines.push("");
+    lines.push(`   Nothing is scheduled until activation succeeds. Check anytime with: flair rem nightly status`);
+    return { lines, ok: false };
+  }
+
+  const lines = [
+    `✅ REM nightly scheduler enabled (${r.platform})`,
+    `   Schedule:    ${scheduleTime} local time`,
+    `   Scheduler:   ${r.schedulerPath}`,
+    `   Shim:        ${r.shimPath}`,
+    `   Agent:       ${agentId}`,
+    `   Flair URL:   ${flairUrl}`,
+  ];
+  if (r.loadResult) {
+    lines.push(`   Load:        ${r.loadCommand.join(" ")} → ok`);
+  }
+  lines.push("");
+  lines.push(`Tip: run \`flair rem nightly run-once --dry-run\` to verify the cycle works`);
+  lines.push(`     before the first scheduled fire. Disable with \`flair rem nightly disable\`.`);
+  return { lines, ok: true };
+}
+
+/**
+ * Formats the `flair rem nightly status` report from a `SchedulerStatus`.
+ * Extracted for the same testability reason as `formatEnableReport()`
+ * (flair#850): status must report genuine active state, not file presence.
+ */
+export function formatStatusReport(s: SchedulerStatus): FormattedReport {
+  const activeTxt = s.active === true ? "yes" : s.active === false ? "no" : "unknown";
+  const lines = [
+    `REM nightly scheduler (${s.platform}):`,
+    `  Active:      ${activeTxt}`,
+    `  Installed:   ${s.installed ? "yes" : "no"}`,
+    `  Scheduler:   ${s.schedulerPath}`,
+    `  Shim:        ${s.shimPath}${s.shimExists ? "" : " (missing)"}`,
+  ];
+  if (!s.installed) {
+    lines.push("");
+    lines.push(`Enable with: flair rem nightly enable --agent <id> [--at HH:MM]`);
+  } else if (s.active === false) {
+    lines.push("");
+    lines.push(`Files are written but nothing is scheduled — the job is not loaded/active.`);
+    lines.push(`Re-run: flair rem nightly enable --agent <id> [--at HH:MM]`);
+  }
+  // Status is informational — it does not itself signal process failure,
+  // consistent with the pre-existing "not installed" case never exiting
+  // nonzero. `ok` here only reflects whether the headline claims success.
+  return { lines, ok: s.active !== false };
 }
 
 /**
@@ -296,33 +504,73 @@ export function disableScheduler(opts: DisableOpts = {}): DisableResult {
 
 export interface SchedulerStatus {
   platform: SchedulerPlatform;
+  /** Whether the scheduler entry files were written to disk. */
   installed: boolean;
+  /**
+   * Whether the scheduler genuinely has the job loaded/active per
+   * launchctl/systemctl — NOT inferred from file presence (flair#850: a
+   * `systemctl --user enable --now` that fails leaves `installed: true`
+   * but nothing scheduled). `null` when this could not be determined
+   * (files absent — nothing to check — or the query itself was
+   * inconclusive) or when the check was explicitly skipped.
+   */
+  active: boolean | null;
   schedulerPath: string;
   shimPath: string;
   shimExists: boolean;
 }
 
+export interface SchedulerStatusOpts {
+  platformOverride?: SchedulerPlatform;
+  /** Override target paths for testing. */
+  shimPathOverride?: string;
+  launchdPlistOverride?: string;
+  systemdTimerOverride?: string;
+  systemdServiceOverride?: string;
+  /**
+   * Skip the launchctl/systemctl active-state query (testing, or callers
+   * that only want file-presence). When skipped, `active` is `null` if
+   * `installed` is true (unknown) and `false` if `installed` is false
+   * (nothing to be active).
+   */
+  skipActiveCheck?: boolean;
+}
+
 /**
- * Reports whether the scheduler is installed. Filesystem-only — does not
- * shell out to launchctl/systemctl to query active state. The Health
- * endpoint already does that via existence checks; same approach here.
+ * Reports whether the scheduler is installed AND whether it is genuinely
+ * active. File presence alone proves the templates were written — it does
+ * NOT prove `launchctl`/`systemctl` successfully loaded the job (flair#850).
  */
-export function schedulerStatus(opts: { platformOverride?: SchedulerPlatform } = {}): SchedulerStatus {
+export function schedulerStatus(opts: SchedulerStatusOpts = {}): SchedulerStatus {
   const plat = detectPlatform(opts.platformOverride);
+  const shimPath = opts.shimPathOverride ?? SHIM_PATH_DEFAULT;
+
+  let schedulerPath: string;
+  let installed: boolean;
   if (plat === "darwin") {
-    return {
-      platform: plat,
-      installed: existsSync(LAUNCHD_PLIST_PATH),
-      schedulerPath: LAUNCHD_PLIST_PATH,
-      shimPath: SHIM_PATH_DEFAULT,
-      shimExists: existsSync(SHIM_PATH_DEFAULT),
-    };
+    schedulerPath = opts.launchdPlistOverride ?? LAUNCHD_PLIST_PATH;
+    installed = existsSync(schedulerPath);
+  } else {
+    schedulerPath = opts.systemdTimerOverride ?? SYSTEMD_TIMER_PATH;
+    const servicePath = opts.systemdServiceOverride ?? SYSTEMD_SERVICE_PATH;
+    installed = existsSync(schedulerPath) && existsSync(servicePath);
   }
+
+  let active: boolean | null;
+  if (!installed) {
+    active = false; // nothing written — definitely nothing active
+  } else if (opts.skipActiveCheck) {
+    active = null; // caller opted out — unknown, not a claim either way
+  } else {
+    active = queryActiveState(plat);
+  }
+
   return {
     platform: plat,
-    installed: existsSync(SYSTEMD_TIMER_PATH) && existsSync(SYSTEMD_SERVICE_PATH),
-    schedulerPath: SYSTEMD_TIMER_PATH,
-    shimPath: SHIM_PATH_DEFAULT,
-    shimExists: existsSync(SHIM_PATH_DEFAULT),
+    installed,
+    active,
+    schedulerPath,
+    shimPath,
+    shimExists: existsSync(shimPath),
   };
 }

--- a/test/rem-scheduler.test.ts
+++ b/test/rem-scheduler.test.ts
@@ -14,8 +14,14 @@ import {
   enableScheduler,
   disableScheduler,
   schedulerStatus,
+  formatEnableReport,
+  formatStatusReport,
+  describeLoadFailure,
+  interpretActiveResult,
   type SchedulerSubstitutions,
   type EnableOpts,
+  type EnableResult,
+  type SchedulerStatus,
 } from "../src/rem/scheduler.ts";
 
 let testRoot: string;
@@ -242,5 +248,235 @@ describe("schedulerStatus", () => {
     const s = schedulerStatus({ platformOverride: "linux" });
     expect(s.platform).toBe("linux");
     expect(s.schedulerPath).toContain("flair-rem-nightly.timer");
+  });
+
+  // flair#850 — schedulerStatus() must not claim active from file presence
+  // alone. These use overrides + skipActiveCheck so the assertions are
+  // hermetic (no real launchctl/systemctl dependency).
+
+  it("reports installed=false, active=false when nothing was ever written", () => {
+    const s = schedulerStatus({
+      platformOverride: "linux",
+      systemdTimerOverride: timerPath,
+      systemdServiceOverride: servicePath,
+      shimPathOverride: shimPath,
+    });
+    expect(s.installed).toBe(false);
+    // Nothing written — there is nothing to be active either, and we know
+    // that for certain (no need to shell out), so `false`, not `null`.
+    expect(s.active).toBe(false);
+  });
+
+  it("does NOT report active=true purely because the timer file exists (the flair#850 bug shape)", () => {
+    enableScheduler(baseOpts({ platformOverride: "linux" }));
+    expect(existsSync(timerPath)).toBe(true);
+
+    // skipActiveCheck simulates "we chose not to query" — installed files
+    // alone must yield `active: null` (unknown), never `true`. A `true`
+    // here would be the exact bug: inferring activation from file presence.
+    const s = schedulerStatus({
+      platformOverride: "linux",
+      systemdTimerOverride: timerPath,
+      systemdServiceOverride: servicePath,
+      shimPathOverride: shimPath,
+      skipActiveCheck: true,
+    });
+    expect(s.installed).toBe(true);
+    expect(s.active).not.toBe(true);
+    expect(s.active).toBeNull();
+  });
+
+  it("darwin: installed=true, active=null when the plist exists but the check is skipped", () => {
+    enableScheduler(baseOpts({ platformOverride: "darwin" }));
+    const s = schedulerStatus({
+      platformOverride: "darwin",
+      launchdPlistOverride: plistPath,
+      shimPathOverride: shimPath,
+      skipActiveCheck: true,
+    });
+    expect(s.installed).toBe(true);
+    expect(s.active).not.toBe(true);
+    expect(s.active).toBeNull();
+  });
+});
+
+describe("interpretActiveResult (flair#850 — genuine active state, not file presence)", () => {
+  it("linux: 'active' stdout means active", () => {
+    expect(interpretActiveResult("linux", 0, "active\n", "")).toBe(true);
+  });
+
+  it("linux: 'inactive' stdout means not active", () => {
+    expect(interpretActiveResult("linux", 3, "inactive\n", "")).toBe(false);
+  });
+
+  it("linux: no session bus (empty stdout, connection-refused stderr) is treated as NOT active — not unknown", () => {
+    // This is the exact traced production failure mode: `systemctl --user`
+    // fails before it ever prints a status word.
+    const r = interpretActiveResult("linux", 1, "", "Failed to connect to bus: No medium found\n");
+    expect(r).toBe(false);
+  });
+
+  it("linux: total spawn failure with no output at all is inconclusive (null), not a confident false", () => {
+    expect(interpretActiveResult("linux", null, "", "")).toBeNull();
+  });
+
+  it("darwin: exit code 0 means active", () => {
+    expect(interpretActiveResult("darwin", 0, "some plist dump", "")).toBe(true);
+  });
+
+  it("darwin: nonzero exit with 'could not find service' means not active", () => {
+    expect(interpretActiveResult("darwin", 3, "", "Could not find service \"dev.flair.rem.nightly\" in domain")).toBe(false);
+  });
+
+  it("darwin: total spawn failure with no output is inconclusive", () => {
+    expect(interpretActiveResult("darwin", null, "", "")).toBeNull();
+  });
+});
+
+describe("describeLoadFailure (flair#850 — remedy naming)", () => {
+  it("names loginctl enable-linger for the traced 'no bus' linux failure", () => {
+    const remedy = describeLoadFailure("linux", { code: 1, stderr: "Failed to connect to bus: No medium found\n" });
+    expect(remedy).not.toBeNull();
+    expect(remedy).toContain("loginctl enable-linger");
+  });
+
+  it("returns null for an unrecognized linux failure (caller falls back to raw stderr)", () => {
+    const remedy = describeLoadFailure("linux", { code: 1, stderr: "some other systemd error\n" });
+    expect(remedy).toBeNull();
+  });
+
+  it("returns null on darwin (no traced/verified remedy for launchctl failures)", () => {
+    const remedy = describeLoadFailure("darwin", { code: 1, stderr: "Failed to connect to bus: No medium found\n" });
+    expect(remedy).toBeNull();
+  });
+});
+
+describe("formatEnableReport (flair#850 — the core honesty fix)", () => {
+  const reportInput = { hour: 3, minute: 0, agentId: "test-agent", flairUrl: "http://127.0.0.1:9926" };
+
+  function baseEnableResult(overrides: Partial<EnableResult> = {}): EnableResult {
+    return {
+      platform: "linux",
+      shimPath: "/home/test/.flair/bin/flair-rem-nightly",
+      schedulerPath: "/home/test/.config/systemd/user/flair-rem-nightly.timer",
+      loadCommand: ["systemctl", "--user", "enable", "--now", "flair-rem-nightly.timer"],
+      ...overrides,
+    };
+  }
+
+  it("SUCCESS PATH: reports success when loadResult.code === 0", () => {
+    const r = baseEnableResult({ loadResult: { code: 0, stdout: "", stderr: "" } });
+    const { lines, ok } = formatEnableReport(r, reportInput);
+    expect(ok).toBe(true);
+    expect(lines.join("\n")).toContain("✅ REM nightly scheduler enabled");
+    expect(lines.join("\n")).not.toMatch(/NOT activated/);
+  });
+
+  it("SUCCESS PATH: reports success when loadResult is absent (test-only skipLoad shape)", () => {
+    const r = baseEnableResult({ loadResult: undefined });
+    const { lines, ok } = formatEnableReport(r, reportInput);
+    expect(ok).toBe(true);
+    expect(lines.join("\n")).toContain("✅ REM nightly scheduler enabled");
+  });
+
+  it("FAILURE PATH: does NOT print a success headline when loadResult.code !== 0", () => {
+    const r = baseEnableResult({
+      loadResult: { code: 1, stdout: "", stderr: "Failed to connect to bus: No medium found\n" },
+    });
+    const { lines, ok } = formatEnableReport(r, reportInput);
+    const text = lines.join("\n");
+    expect(ok).toBe(false);
+    expect(text).not.toContain("✅ REM nightly scheduler enabled");
+    expect(text).not.toMatch(/^✅/m);
+    expect(text).toMatch(/NOT activated/);
+  });
+
+  it("FAILURE PATH: signals failure via ok=false (caller exits nonzero)", () => {
+    const r = baseEnableResult({ loadResult: { code: 1, stdout: "", stderr: "boom\n" } });
+    const { ok } = formatEnableReport(r, reportInput);
+    expect(ok).toBe(false);
+  });
+
+  it("FAILURE PATH: names the loginctl remedy for the bus-connection failure", () => {
+    const r = baseEnableResult({
+      loadResult: { code: 1, stdout: "", stderr: "Failed to connect to bus: No medium found\n" },
+    });
+    const { lines } = formatEnableReport(r, reportInput);
+    const text = lines.join("\n");
+    expect(text).toContain("loginctl enable-linger");
+  });
+
+  it("FAILURE PATH: still surfaces the raw stderr and the failing command", () => {
+    const r = baseEnableResult({
+      loadResult: { code: 1, stdout: "", stderr: "Failed to connect to bus: No medium found\n" },
+    });
+    const { lines } = formatEnableReport(r, reportInput);
+    const text = lines.join("\n");
+    expect(text).toContain("systemctl --user enable --now flair-rem-nightly.timer");
+    expect(text).toContain("code 1");
+    expect(text).toContain("Failed to connect to bus");
+  });
+
+  it("FAILURE PATH: treats a null exit code (timeout/killed) as failure too", () => {
+    const r = baseEnableResult({ loadResult: { code: null, stdout: "", stderr: "" } });
+    const { ok } = formatEnableReport(r, reportInput);
+    expect(ok).toBe(false);
+  });
+
+  it("FAILURE PATH on darwin: no invented remedy, but still reports NOT activated", () => {
+    const r = baseEnableResult({
+      platform: "darwin",
+      schedulerPath: "/home/test/Library/LaunchAgents/dev.flair.rem.nightly.plist",
+      loadCommand: ["launchctl", "bootstrap", "gui/501", "/home/test/Library/LaunchAgents/dev.flair.rem.nightly.plist"],
+      loadResult: { code: 5, stdout: "", stderr: "Bootstrap failed: 5: Input/output error\n" },
+    });
+    const { lines, ok } = formatEnableReport(r, reportInput);
+    const text = lines.join("\n");
+    expect(ok).toBe(false);
+    expect(text).not.toContain("✅ REM nightly scheduler enabled");
+    expect(text).toMatch(/NOT activated/);
+    expect(text).toContain("Re-run the activation command above manually");
+  });
+});
+
+describe("formatStatusReport (flair#850 — status reflects genuine active state)", () => {
+  function baseStatus(overrides: Partial<SchedulerStatus> = {}): SchedulerStatus {
+    return {
+      platform: "linux",
+      installed: true,
+      active: true,
+      schedulerPath: "/home/test/.config/systemd/user/flair-rem-nightly.timer",
+      shimPath: "/home/test/.flair/bin/flair-rem-nightly",
+      shimExists: true,
+      ...overrides,
+    };
+  }
+
+  it("reports Active: yes when genuinely active", () => {
+    const { lines, ok } = formatStatusReport(baseStatus({ active: true }));
+    expect(ok).toBe(true);
+    expect(lines.join("\n")).toContain("Active:      yes");
+  });
+
+  it("reports Active: no — and does not claim enabled — when files exist but the job is not active (the flair#850 bug shape)", () => {
+    const { lines, ok } = formatStatusReport(baseStatus({ installed: true, active: false }));
+    const text = lines.join("\n");
+    expect(ok).toBe(false);
+    expect(text).toContain("Active:      no");
+    expect(text).not.toMatch(/Active:\s+yes/);
+    expect(text).toMatch(/nothing is scheduled/i);
+  });
+
+  it("reports Active: unknown when the check was inconclusive/skipped", () => {
+    const { lines } = formatStatusReport(baseStatus({ installed: true, active: null }));
+    expect(lines.join("\n")).toContain("Active:      unknown");
+  });
+
+  it("reports not-installed distinctly from installed-but-inactive", () => {
+    const { lines } = formatStatusReport(baseStatus({ installed: false, active: false }));
+    const text = lines.join("\n");
+    expect(text).toContain("Installed:   no");
+    expect(text).toContain("Enable with:");
+    expect(text).not.toMatch(/nothing is scheduled/i);
   });
 });


### PR DESCRIPTION
Fixes #850. Found by our clean-room dogfood agent on the published release.

## The bug

On any host without a systemd user bus — ssh without lingering, containers, CI:

```
flair rem nightly enable --agent x --at 03:00
→ ✅ REM nightly scheduler enabled (linux)
```

Meanwhile `systemctl --user enable --now flair-rem-nightly.timer` exits 1 with `Failed to connect to bus: No medium found`, and nothing is scheduled. `flair status` then also reported "Nightly: enabled".

## What was actually wrong

The scheduler already captured the failure — it returned `loadResult` with the non-zero code and stderr. The command handler printed the green headline **unconditionally, first**, and only afterwards printed `Load: … → code 1` underneath it. Exit code stayed 0.

So the truth was on screen the entire time, below a checkmark telling the user to stop reading. That is the same defect as an error that states a fact without enabling a response — the information is present and the framing defeats it.

`flair status` had it independently: `/HealthDetail` inferred "enabled" from the timer/plist file existing. A failed activation still writes the file, so file presence was never evidence of anything.

## Changes

- The headline reflects the real outcome; the command **exits non-zero** on activation failure; the error **names the remedy** (lingering) for the recognised no-session-bus case rather than only reporting the failure. Unrecognised failures fall back to a generic re-run message rather than inventing a fix — notably no remedy is claimed for darwin, where none was verified.
- Scheduler state is **queried** (`launchctl print` / `systemctl --user is-active`) rather than inferred. `installed` remains file-presence for back-compat; `active` is the honest answer. "No session bus" maps to `false`, not unknown — nothing can be running without one.
- `/HealthDetail` gets the same treatment, async with a 5s timeout that SIGKILLs a hung service manager and reports unknown, so this cannot stall the request path.
- The success/failure decision moved out of the command handler into pure functions, so it is unit-testable rather than tangled in printing.

## Verification

- 30 new tests, 42 in the file, all passing.
- **Mutation-checked**: forcing `activationFailed` to `false` fails 6 tests — the no-success-headline, signals-failure, names-remedy, surfaces-stderr, null-exit-code and darwin-path cases. Restored and re-verified byte-identical.
- End-to-end against the built CLI with a fake failing `launchctl` on PATH: prints NOT activated, surfaces stderr, exits 1. With a working fake, both commands report success — the happy path is not inverted.
- `tsc --noEmit -p tsconfig.cli.json` clean; docs-freshness passes. (`tsconfig.json` has one pre-existing unrelated error in `auth-middleware.ts`, confirmed present on unmodified main.)

## Known gap, flagged rather than buried

The `/HealthDetail` wiring itself has **no automated test** — there is no Harper-integration harness for `resources/health.ts` in this repo, and standing one up is disproportionate to this change. The shared decision logic it calls (`interpretActiveResult`) is fully unit-tested, and the cross-directory import is compile-verified against the existing `resources/Federation.ts` → `src/keystore.js` precedent, but the wiring is not exercised end-to-end. Worth knowing when reviewing.
