### PR TITLE
test: match HTTP status codes as tokens, not bare substrings

### DIFF
--- a/test/helpers/http-status.ts
+++ b/test/helpers/http-status.ts
@@ -1,0 +1,20 @@
+/**
+ * Matchers for asserting that CLI output does or does not carry a given HTTP
+ * status code.
+ *
+ * These exist because a bare `expect(output).not.toContain("405")` is unsound
+ * against CLI output: the CLI prints generated record ids, and a random UUID
+ * containing those three digits fails the assertion even though the command
+ * succeeded. That is not hypothetical — a run of the `flair orgevent` e2e test
+ * failed on the id `flair679-e2e-agent-49e40526-…`, whose UUID contains "4052".
+ *
+ * Requiring the code to stand alone as its own token keeps "HTTP 405",
+ * "status 405" and "405:" matching while ignoring digits embedded in an
+ * identifier, since every character inside a hex UUID segment is a word
+ * character and therefore yields no word boundary.
+ */
+
+/** Matches `code` only where it appears as a standalone token. */
+export function httpStatus(code: number): RegExp {
+  return new RegExp(`\\b${code}\\b`);
+}

--- a/test/integration/onboarding-smoke.test.ts
+++ b/test/integration/onboarding-smoke.test.ts
@@ -32,6 +32,7 @@ import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { startHarper, stopHarper, type HarperInstance } from "../helpers/harper-lifecycle";
+import { httpStatus } from "../helpers/http-status";
 
 const CLI = join(process.cwd(), "dist", "cli.js");
 const AGENT_ID = "krais-onboarding";
@@ -103,7 +104,7 @@ describe("first-run onboarding (real CLI, isolated temp Harper + home)", () => {
     expect(r.code).toBe(0);
     expect(r.stdout).toContain("registered");
     // The old bug surfaced as a REST 405; assert that error never appears.
-    expect(`${r.stdout}${r.stderr}`).not.toContain("405");
+    expect(`${r.stdout}${r.stderr}`).not.toMatch(httpStatus(405));
     expect(`${r.stdout}${r.stderr}`).not.toContain("does not have a post method");
   });
 
@@ -119,7 +120,7 @@ describe("first-run onboarding (real CLI, isolated temp Harper + home)", () => {
     ], { FLAIR_AGENT_ID: AGENT_ID });
     if (r.code !== 0) console.error(`soul set failed:\n${r.stdout}\n${r.stderr}`);
     expect(r.code).toBe(0);
-    expect(`${r.stdout}${r.stderr}`).not.toContain("405");
+    expect(`${r.stdout}${r.stderr}`).not.toMatch(httpStatus(405));
     expect(`${r.stdout}${r.stderr}`).not.toContain("does not have a post method");
 
     // Confirm the record actually landed: read it back via the server.
@@ -147,7 +148,7 @@ describe("first-run onboarding (real CLI, isolated temp Harper + home)", () => {
     expect(r.code).toBe(0);
     // The old bug surfaced as a 400 "id is not indexed for nulls".
     expect(`${r.stdout}${r.stderr}`).not.toContain("not indexed for nulls");
-    expect(`${r.stdout}${r.stderr}`).not.toContain("400");
+    expect(`${r.stdout}${r.stderr}`).not.toMatch(httpStatus(400));
     const agents = JSON.parse(r.stdout) as Array<{ id: string }>;
     expect(Array.isArray(agents)).toBe(true);
     expect(agents.some(a => a.id === AGENT_ID)).toBe(true);

--- a/test/integration/workspace-orgevent-cli-e2e.test.ts
+++ b/test/integration/workspace-orgevent-cli-e2e.test.ts
@@ -47,6 +47,7 @@ import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { startHarper, stopHarper, type HarperInstance } from "../helpers/harper-lifecycle";
+import { httpStatus } from "../helpers/http-status";
 
 const CLI = join(process.cwd(), "dist", "cli.js");
 const AGENT_ID = "flair679-e2e-agent";
@@ -139,7 +140,7 @@ describe("flair workspace set / flair orgevent — real Harper (#679)", () => {
     expect(r.code).toBe(0);
     expect(r.stdout).toContain("Workspace state updated");
     // The old bug surfaced as a REST 405; assert that error never appears.
-    expect(`${r.stdout}${r.stderr}`).not.toContain("405");
+    expect(`${r.stdout}${r.stderr}`).not.toMatch(httpStatus(405));
     expect(`${r.stdout}${r.stderr}`).not.toContain("does not have a post method");
 
     // MEASURED round-trip: read the record back over real HTTP (admin bypasses
@@ -202,7 +203,7 @@ describe("flair workspace set / flair orgevent — real Harper (#679)", () => {
     expect(r.code).toBe(0);
     expect(r.stdout).toContain("OrgEvent published");
     // The old bug surfaced as a REST 405; assert that error never appears.
-    expect(`${r.stdout}${r.stderr}`).not.toContain("405");
+    expect(`${r.stdout}${r.stderr}`).not.toMatch(httpStatus(405));
     expect(`${r.stdout}${r.stderr}`).not.toContain("does not have a post method");
 
     // The CLI prints the generated id (`  id: <id>`) — extract it so the

--- a/test/unit/http-status.test.ts
+++ b/test/unit/http-status.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, test } from "bun:test";
+import { httpStatus } from "../helpers/http-status";
+
+describe("httpStatus matcher", () => {
+  // The string below is the real CI failure: `flair orgevent` succeeded, but
+  // the generated id contains "4052", so a bare not.toContain("405") failed.
+  const successOutputWithUnluckyId =
+    "✓ OrgEvent published as 'flair679-e2e-agent': kind=status → flint\n" +
+    "  id: flair679-e2e-agent-49e40526-ea22-4fde-af83-db0ac1f2e3b4\n";
+
+  test("ignores the status digits when they are embedded in an identifier", () => {
+    expect(successOutputWithUnluckyId).not.toMatch(httpStatus(405));
+  });
+
+  test("still matches a real status code in the shapes the CLI emits", () => {
+    for (const output of [
+      "request failed: HTTP 405",
+      "status 405 Method Not Allowed",
+      "405: /Soul does not have a post method",
+      "server responded (405)",
+      "405",
+    ]) {
+      expect(output).toMatch(httpStatus(405));
+    }
+  });
+
+  test("does not match a longer number that merely contains the code", () => {
+    expect("listening on port 4050").not.toMatch(httpStatus(405));
+    expect("wrote 1405 bytes").not.toMatch(httpStatus(405));
+  });
+
+  test("distinguishes between codes", () => {
+    expect("HTTP 400").not.toMatch(httpStatus(405));
+    expect("HTTP 400").toMatch(httpStatus(400));
+  });
+});


### PR DESCRIPTION
## The failure

`Integration Tests` failed on #859 with:

```
error: expect(received).not.toContain(expected)
Expected to not contain: "405"
Received: "✓ OrgEvent published as 'flair679-e2e-agent': kind=status → flint
  id: flair679-e2e-agent-49e40526-ea22-4fde-af83-db0ac..."
```

The command **succeeded**. The assertion matched `4052` inside the random UUID of the printed record id.

## Why it is worth fixing rather than re-running

Five assertions have this shape — combined `stdout`+`stderr` checked for a bare status-code substring, against output that always contains a generated id:

| file | assertion |
| --- | --- |
| `onboarding-smoke.test.ts` | `not.toContain("405")` ×2, `not.toContain("400")` ×1 |
| `workspace-orgevent-cli-e2e.test.ts` | `not.toContain("405")` ×2 |

Each fails whenever the run's UUID happens to contain those three digits — sub-percent per assertion, but permanent and spread across five of them, on a required check. Re-running turns a real defect into intermittent noise that reads as infrastructure flakiness.

Worth noting these are the *belt-and-braces* half of each check. The assertion beside each one (`does not have a post method`, `not indexed for nulls`) is the semantic test and is untouched — so the diagnostic value here is preserved, not traded away.

## The change

A `httpStatus(code)` helper matching the code only as a standalone token, and the five assertions pointed at it. Every character inside a hex UUID segment is a word character, so digits embedded in an identifier produce no word boundary and no longer match, while `HTTP 405`, `status 405`, `405:` and `(405)` still do.

Test-only. No source change, and deliberately no CHANGELOG entry — nothing here is observable to a user of the published package. `docs-freshness-check` passes without one.

## Verification

- 4 new unit tests, including the **exact string from the CI failure** as a fixture.
- **Mutation-checked**: reverting the helper to substring semantics (`new RegExp(String(code))`) fails 2 of the 4 — the embedded-in-identifier case and the longer-number case. Restored and re-verified byte-identical, back to 4 pass.
- Both affected integration files run locally against real ephemeral Harper: `workspace-orgevent-cli-e2e` **6 pass / 0 fail**, `onboarding-smoke` **3 pass / 0 fail**. Ephemeral instances swept afterwards; no orphans.
- `tsc --noEmit` clean for `tsconfig.cli.json`; `tsconfig.json` reports only the pre-existing unrelated `resources/auth-middleware.ts(69,1)` error — this branch changes no source, so it cannot be from here.
