### PR TITLE
test: wait for the migration state postcondition, not for the file to exist

### DIFF
--- a/test/integration/migrations-provisioned-datadir.test.ts
+++ b/test/integration/migrations-provisioned-datadir.test.ts
@@ -138,12 +138,33 @@ describe("zero-touch migrations — provisioned shape whose ~/.flair/data is unu
   test("the boot cycle still runs: migration state is written under ROOTPATH", async () => {
     const statePath = join(harper.installDir, ".migrations", "state.json");
     const deadline = Date.now() + 60_000;
-    while (Date.now() < deadline && !existsSync(statePath)) {
+    // Poll for the POSTCONDITION, not a proxy for it. The runner creates
+    // state.json before writing into it, so `existsSync` can be true while the
+    // file is still empty or a partial object — JSON.parse then throws and the
+    // test fails intermittently on a migration that actually succeeded
+    // (flair#890). Waiting until it parses AND carries the entry removes the
+    // race without weakening the assertions below.
+    let state: Record<string, any> | null = null;
+    while (Date.now() < deadline) {
+      if (existsSync(statePath)) {
+        try {
+          const parsed = JSON.parse(readFileSync(statePath, "utf-8"));
+          if (parsed?.["visibility-backfill"]) {
+            state = parsed;
+            break;
+          }
+        } catch {
+          // partially-written file — keep waiting rather than failing
+        }
+      }
       await new Promise((r) => setTimeout(r, 500));
     }
 
-    expect(existsSync(statePath)).toBe(true);
-    const state = JSON.parse(readFileSync(statePath, "utf-8"));
+    if (state === null) {
+      throw new Error(
+        `no parseable .migrations/state.json carrying a visibility-backfill entry at ${statePath} within 60s`,
+      );
+    }
     expect(state["visibility-backfill"]?.lastOutcome).toBe("success");
     expect(state["visibility-backfill"]?.rowsProcessed).toBe(SEED_IDS.length);
   }, 90_000);


### PR DESCRIPTION
Closes #890.

## The race

```js
while (Date.now() < deadline && !existsSync(statePath)) { … }   // poll for EXISTENCE
expect(existsSync(statePath)).toBe(true);
const state = JSON.parse(readFileSync(statePath, "utf-8"));      // then parse CONTENTS
```

The migration runner creates `.migrations/state.json` before writing into it. So `existsSync` can be true while the file is still empty or a partial object — `JSON.parse` throws, and the test fails on a migration that **actually succeeded**.

Observed exactly that way: one CI failure, passing on a re-run of the identical commit, with the two following assertions passing in both runs — which is itself evidence the migration had completed.

## The fix

Poll for the **postcondition** rather than a proxy for it: wait until the file parses *and* carries the `visibility-backfill` entry, tolerating a partial read while waiting. On timeout, fail with a message naming the path and the window instead of a bare `JSON.parse` stack.

The two assertions below are untouched, so the test is no weaker — it just no longer races the writer.

## Why it matters beyond this test

This is the same shape as the status-code assertion fixed in #861: **the check was a proxy for the condition rather than the condition itself**. A file existing is not the same as a file being readable; a substring appearing is not the same as a status code being returned. Both fail intermittently, both look like infrastructure flakiness, and both cost a re-run and some confidence every time they fire.

Worth a sweep for other `existsSync`-then-read polls in the integration suite — this is unlikely to be the only one.

## Verification

- `tsc --noEmit -p tsconfig.json`: zero errors in this file; only the pre-existing unrelated `resources/auth-middleware.ts(69,1)` remains, confirmed present on unmodified `main`.
- `docs-freshness-check` passes.
- Test-only change; no source, no dependencies, no CHANGELOG entry (nothing user-observable).
