### PR TITLE
fix(launchd): XML-escape every value written into a plist

### DIFF
--- a/.changelog/unreleased/fixed-launchd-plist-xml-escaping.md
+++ b/.changelog/unreleased/fixed-launchd-plist-xml-escaping.md
@@ -1,0 +1,14 @@
+- **A data directory, home directory or Flair URL containing `&`, `<`, `>`,
+  `"` or `'` no longer produces a broken launchd service.** A launchd plist is
+  XML, and both plist writers were interpolating values into one unescaped:
+  `flair init` wrote the data directory, the install paths and the admin
+  credentials raw, and `flair rem nightly enable` did the same for the home
+  directory, the shim path and `--flair-url` (a URL with more than one query
+  parameter contains `&`). Any of those characters made the plist malformed,
+  and `launchctl` rejects a malformed plist outright — so the service or timer
+  silently never registered and did not survive a reboot.
+
+  All five XML predefined entities are now escaped through a single shared
+  helper, and the generated plists are verified by actually parsing them.
+  Nothing to do: re-run `flair init` (or `flair rem nightly enable`) to rewrite
+  the plist for an affected install.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -105,6 +105,7 @@ import {
   authedRequest,
 } from "./lib/auth-resolve.js";
 import { validateSnapshotArchive, extractSnapshotSafely } from "./lib/safe-snapshot-extract.js";
+import { escapeXml, unescapeXml } from "./lib/xml-escape.js";
 
 // Federation crypto helpers — inlined to avoid cross-boundary imports from
 // src/ into resources/, which don't survive npm packaging (see also
@@ -265,6 +266,76 @@ function launchdLabel(dataDir: string): string {
 
 function launchdPlistPath(label: string, launchAgentsDir: string = defaultLaunchAgentsDir()): string {
   return join(launchAgentsDir, `${label}.plist`);
+}
+
+/** Every value buildLaunchdPlist() interpolates into the plist XML. */
+export interface LaunchdPlistOptions {
+  label: string;
+  /** node binary that launchd execs (process.execPath). */
+  execPath: string;
+  /** harper.js entrypoint passed to node. */
+  harperBinPath: string;
+  /** cwd for the service — the installed flair package dir. */
+  workingDirectory: string;
+  dataDir: string;
+  modelsDir: string;
+  /** HARPER_SET_CONFIG payload; already JSON-stringified by the caller. */
+  setConfig: string;
+  adminUser: string;
+  adminPass: string;
+  httpPort: number | string;
+  /** OPERATIONSAPI_NETWORK_PORT value from opsNetworkPortValue(). */
+  opsNetworkPort: string;
+}
+
+/**
+ * Build the launchd plist for a Flair instance.
+ *
+ * Extracted from the `init` command so the XML escaping is unit-testable
+ * without touching real launchd or ~/Library/LaunchAgents. EVERY interpolated
+ * value goes through escapeXml() — including ones that look safe today (the
+ * label is a hash, the ports are numbers), because "this field can't contain
+ * a special character" is exactly the assumption that rots when a field's
+ * source changes. A future key added to this template that skips escapeXml()
+ * is the bug reappearing.
+ *
+ * Never log the return value: it embeds HDB_ADMIN_PASSWORD.
+ */
+export function buildLaunchdPlist(opts: LaunchdPlistOptions): string {
+  const e = escapeXml;
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key><string>${e(opts.label)}</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>${e(opts.execPath)}</string>
+    <string>${e(opts.harperBinPath)}</string>
+    <string>run</string>
+    <string>.</string>
+  </array>
+  <key>WorkingDirectory</key><string>${e(opts.workingDirectory)}</string>
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>ROOTPATH</key><string>${e(opts.dataDir)}</string>
+    <key>FLAIR_MODELS_DIR</key><string>${e(opts.modelsDir)}</string>
+    <key>HARPER_SET_CONFIG</key><string>${e(opts.setConfig)}</string>
+    <key>DEFAULTS_MODE</key><string>dev</string>
+    <key>HDB_ADMIN_USERNAME</key><string>${e(opts.adminUser)}</string>
+    <key>HDB_ADMIN_PASSWORD</key><string>${e(opts.adminPass)}</string>
+    <key>THREADS_COUNT</key><string>1</string>
+    <key>NODE_HOSTNAME</key><string>localhost</string>
+    <key>HTTP_PORT</key><string>${e(String(opts.httpPort))}</string>
+    <key>OPERATIONSAPI_NETWORK_PORT</key><string>${e(opts.opsNetworkPort)}</string>
+    <key>LOCAL_STUDIO</key><string>false</string>
+  </dict>
+  <key>RunAtLoad</key><true/>
+  <key>KeepAlive</key><true/>
+  <key>StandardOutPath</key><string>${e(join(opts.dataDir, "log", "launchd-stdout.log"))}</string>
+  <key>StandardErrorPath</key><string>${e(join(opts.dataDir, "log", "launchd-stderr.log"))}</string>
+</dict>
+</plist>`;
 }
 
 /**
@@ -2888,40 +2959,19 @@ program
           // backend on every KeepAlive restart in-process. See that file's
           // header (flair#694) for why this replaced the old HARPER_CONFIG
           // plist line.
-          const escapeXml = (s: string) => s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/"/g, "&quot;");
-          const plist = `<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-<dict>
-  <key>Label</key><string>${label}</string>
-  <key>ProgramArguments</key>
-  <array>
-    <string>${process.execPath}</string>
-    <string>${harperBinPath}</string>
-    <string>run</string>
-    <string>.</string>
-  </array>
-  <key>WorkingDirectory</key><string>${flairPackageDir()}</string>
-  <key>EnvironmentVariables</key>
-  <dict>
-    <key>ROOTPATH</key><string>${dataDir}</string>
-    <key>FLAIR_MODELS_DIR</key><string>${modelsDir}</string>
-    <key>HARPER_SET_CONFIG</key><string>${escapeXml(setConfig)}</string>
-    <key>DEFAULTS_MODE</key><string>dev</string>
-    <key>HDB_ADMIN_USERNAME</key><string>${adminUser}</string>
-    <key>HDB_ADMIN_PASSWORD</key><string>${adminPass}</string>
-    <key>THREADS_COUNT</key><string>1</string>
-    <key>NODE_HOSTNAME</key><string>localhost</string>
-    <key>HTTP_PORT</key><string>${httpPort}</string>
-    <key>OPERATIONSAPI_NETWORK_PORT</key><string>${escapeXml(opsNetworkPortValue(opsBindHost, opsPort))}</string>
-    <key>LOCAL_STUDIO</key><string>false</string>
-  </dict>
-  <key>RunAtLoad</key><true/>
-  <key>KeepAlive</key><true/>
-  <key>StandardOutPath</key><string>${join(dataDir, "log", "launchd-stdout.log")}</string>
-  <key>StandardErrorPath</key><string>${join(dataDir, "log", "launchd-stderr.log")}</string>
-</dict>
-</plist>`;
+          const plist = buildLaunchdPlist({
+            label,
+            execPath: process.execPath,
+            harperBinPath,
+            workingDirectory: flairPackageDir(),
+            dataDir,
+            modelsDir,
+            setConfig,
+            adminUser,
+            adminPass,
+            httpPort,
+            opsNetworkPort: opsNetworkPortValue(opsBindHost, opsPort),
+          });
           writeFileSync(plistPath, plist);
           console.log("Launchd service registered ✓");
         }
@@ -9846,7 +9896,7 @@ program
  * Never logs plist contents — the plist embeds HDB_ADMIN_PASSWORD. Only the
  * extracted ROOTPATH path ever reaches a message.
  */
-function assertLaunchdServiceOwnedBy(
+export function assertLaunchdServiceOwnedBy(
   dataDir: string,
   label: string,
   plistPath: string,
@@ -9856,7 +9906,11 @@ function assertLaunchdServiceOwnedBy(
   try {
     const raw = readFileSync(plistPath, "utf-8");
     const m = raw.match(/<key>ROOTPATH<\/key>\s*<string>([^<]*)<\/string>/);
-    declared = m ? m[1] : null;
+    // The plist stores this XML-escaped (buildLaunchdPlist), so a data dir
+    // containing `&` is on disk as `&amp;`. Decode before comparing, or the
+    // path would never equal itself and this guard would refuse a legitimate
+    // stop/start on any instance whose path contains an escaped character.
+    declared = m ? unescapeXml(m[1]) : null;
   } catch {
     return; // unreadable — no evidence, don't block
   }

--- a/src/lib/xml-escape.ts
+++ b/src/lib/xml-escape.ts
@@ -1,0 +1,56 @@
+/**
+ * XML entity escaping for the launchd plists this CLI generates.
+ *
+ * A launchd plist is XML, so ANY value interpolated into one has to be
+ * escaped or the document is malformed — and `launchctl load` rejects a
+ * malformed plist outright, so the service silently never registers.
+ *
+ * Two independent writers generate plists, and both go through here:
+ *   - buildLaunchdPlist() in src/cli.ts (the Harper service, `flair init`)
+ *   - renderPlistTemplate() in src/rem/scheduler.ts (`flair rem nightly enable`)
+ *
+ * This module exists so there is exactly ONE implementation to get right.
+ * Anything that interpolates into plist XML imports it rather than
+ * hand-rolling a `.replace()` chain at the call site — a local chain is how
+ * this class of bug got in (and how it stayed partial: the original one
+ * covered three of the five entities).
+ */
+
+/** The five XML predefined entities, in the order they must be replaced. */
+const XML_ESCAPES: ReadonlyArray<readonly [RegExp, string]> = [
+  // `&` MUST be first: replacing it after `<` would turn the `&` of an
+  // already-emitted `&lt;` into `&amp;lt;` and corrupt the value.
+  [/&/g, "&amp;"],
+  [/</g, "&lt;"],
+  [/>/g, "&gt;"],
+  [/"/g, "&quot;"],
+  [/'/g, "&apos;"],
+];
+
+/**
+ * Escape the five XML predefined entities for use inside an XML text node.
+ *
+ * Safe to apply to any string, including one with no special characters.
+ * The result round-trips exactly through unescapeXml().
+ */
+export function escapeXml(s: string): string {
+  let out = s;
+  for (const [pattern, replacement] of XML_ESCAPES) out = out.replace(pattern, replacement);
+  return out;
+}
+
+/**
+ * Inverse of escapeXml(), for reading a value back out of a document we wrote.
+ *
+ * `&amp;` MUST be decoded LAST, mirroring escapeXml()'s ordering: decoding it
+ * first would turn `&amp;lt;` (the escaping of a literal "&lt;") into `<`
+ * instead of back into `&lt;`.
+ */
+export function unescapeXml(s: string): string {
+  return s
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&quot;/g, '"')
+    .replace(/&apos;/g, "'")
+    .replace(/&amp;/g, "&");
+}

--- a/src/rem/scheduler.ts
+++ b/src/rem/scheduler.ts
@@ -18,6 +18,7 @@ import { resolve, dirname, join } from "node:path";
 import { homedir, platform } from "node:os";
 import { spawn, spawnSync, type SpawnSyncReturns } from "node:child_process";
 import { fileURLToPath } from "node:url";
+import { escapeXml } from "../lib/xml-escape.js";
 
 export const SHIM_PATH_DEFAULT = resolve(homedir(), ".flair", "bin", "flair-rem-nightly");
 export const LAUNCHD_PLIST_PATH = resolve(homedir(), "Library", "LaunchAgents", "dev.flair.rem.nightly.plist");
@@ -121,10 +122,39 @@ function defaultTemplateRoot(): string {
 }
 
 export function renderTemplate(text: string, subs: SchedulerSubstitutions): string {
+  return renderTemplateWith(text, subs, (v) => v);
+}
+
+/**
+ * renderTemplate() for the launchd plist template specifically: substituted
+ * values are XML-escaped.
+ *
+ * A launchd plist is XML, so a substitution carrying `&`, `<`, `>`, `"` or
+ * `'` makes it malformed and `launchctl bootstrap` rejects it — the timer
+ * silently never registers. FLAIR_URL is the realistic carrier (a URL with
+ * more than one query parameter contains `&`), but HOME and SHIM_PATH are
+ * arbitrary paths and equally capable of it. HOUR/MINUTE and AGENT_ID are
+ * validated upstream in buildSubstitutions(), but they are escaped too
+ * rather than exempted — the point of a chokepoint is that no value gets to
+ * argue it is special.
+ *
+ * Deliberately NOT folded into renderTemplate(): the same substitutions are
+ * rendered into the systemd unit files and the shell shim, where XML
+ * escaping would be corruption rather than a fix.
+ */
+export function renderPlistTemplate(text: string, subs: SchedulerSubstitutions): string {
+  return renderTemplateWith(text, subs, escapeXml);
+}
+
+function renderTemplateWith(
+  text: string,
+  subs: SchedulerSubstitutions,
+  escape: (value: string) => string,
+): string {
   return text.replace(/\{\{([A-Z_]+)\}\}/g, (_, key) => {
     const value = (subs as any)[key];
     if (value === undefined) throw new Error(`unknown template placeholder: ${key}`);
-    return String(value);
+    return escape(String(value));
   });
 }
 
@@ -421,7 +451,7 @@ export function enableScheduler(opts: EnableOpts): EnableResult {
   // 2. Write the scheduler entry.
   if (plat === "darwin") {
     const plistPath = opts.launchdPlistOverride ?? LAUNCHD_PLIST_PATH;
-    const plistContents = renderTemplate(readTemplate(templateRoot, "launchd/dev.flair.rem.nightly.plist.tmpl"), subs);
+    const plistContents = renderPlistTemplate(readTemplate(templateRoot, "launchd/dev.flair.rem.nightly.plist.tmpl"), subs);
     writeFileWithDir(plistPath, plistContents, 0o600);
 
     const loadCommand = ["launchctl", "bootstrap", `gui/${process.getuid?.() ?? ""}`, plistPath];

--- a/test/unit/launchd-plist-xml-escape.test.ts
+++ b/test/unit/launchd-plist-xml-escape.test.ts
@@ -1,0 +1,368 @@
+/**
+ * launchd-plist-xml-escape.test.ts — a launchd plist is XML, so every value
+ * interpolated into it has to be XML-escaped.
+ *
+ * The plist writer used to interpolate the data directory (and the install
+ * paths, the admin username/password, and the label) raw. `--data-dir` accepts
+ * any legal path and `&`, `<`, `>`, `"` and `'` are all legal in one, so a data
+ * dir containing `&` produced a MALFORMED plist — not a cosmetic problem:
+ * `launchctl load` rejects it outright and the service never registers.
+ *
+ * These tests assert by actually PARSING the generated plist and reading the
+ * value back. A string match for `&amp;` would pass on a plist that is still
+ * malformed somewhere else, and would not catch escaping that mangles the path
+ * it was supposed to preserve.
+ *
+ * Parsing goes through EVERY parser available on the machine — `plutil` (the
+ * parser launchd's own loader uses), `xmllint`, and Python's stdlib `plistlib`
+ * — and they must agree. macOS has all three; Linux CI ships neither plutil
+ * nor xmllint, so plistlib is what carries the check there. If NONE is present
+ * the helper throws rather than skipping: a parse check that silently degrades
+ * into nothing is worse than no check, because it still reads green.
+ *
+ * SAFETY: buildLaunchdPlist() is a pure function — nothing here touches
+ * ~/Library/LaunchAgents, runs launchctl, or reads a real plist (a real one
+ * embeds HDB_ADMIN_PASSWORD). Fixtures use placeholder credentials and are
+ * written to a temp dir.
+ */
+
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { execFileSync } from "node:child_process";
+import {
+  buildLaunchdPlist,
+  assertLaunchdServiceOwnedBy,
+  type LaunchdPlistOptions,
+} from "../../src/cli.ts";
+import { escapeXml, unescapeXml } from "../../src/lib/xml-escape.ts";
+import { renderTemplate, renderPlistTemplate } from "../../src/rem/scheduler.ts";
+
+let tmp: string;
+beforeEach(() => { tmp = mkdtempSync(join(tmpdir(), "flair-plist-escape-")); });
+afterEach(() => { rmSync(tmp, { recursive: true, force: true }); });
+
+/** Placeholder values only — never a real credential. */
+function opts(over: Partial<LaunchdPlistOptions> = {}): LaunchdPlistOptions {
+  return {
+    label: "ai.tpsdev.flair.deadbeef",
+    execPath: "/usr/local/bin/node",
+    harperBinPath: "/opt/flair/harper.js",
+    workingDirectory: "/opt/flair",
+    dataDir: "/Users/example/.flair/data",
+    modelsDir: "/Users/example/.flair/data/models",
+    setConfig: JSON.stringify({ rootPath: "/Users/example/.flair/data", http: { port: 9926 } }),
+    adminUser: "admin",
+    adminPass: "PLACEHOLDER-not-a-real-password",
+    httpPort: 9926,
+    opsNetworkPort: "9925",
+    ...over,
+  };
+}
+
+function have(cmd: string): boolean {
+  try {
+    execFileSync(cmd, ["--version"], { stdio: "pipe" });
+    return true;
+  } catch (e: any) {
+    // Present but unhappy with --version (plutil) still counts as present;
+    // only "not installed" (ENOENT) means we cannot use it.
+    return e?.code !== "ENOENT";
+  }
+}
+const HAS_PLUTIL = have("plutil");
+const HAS_XMLLINT = have("xmllint");
+const HAS_PYTHON = have("python3");
+
+/**
+ * Read a plist via Python's stdlib plistlib — a real plist parser that raises
+ * on a malformed document. This is the parser that carries the check on Linux
+ * CI, which ships neither plutil nor xmllint.
+ */
+const PY_DUMP = "import plistlib,json,sys;json.dump(plistlib.load(open(sys.argv[1],'rb')),sys.stdout)";
+
+/**
+ * Parse `plistText` with every available parser and return the value at the
+ * given location, which each parser must agree on.
+ *
+ * `xpath` addresses it for xmllint; `fromJson` picks it out of plutil's JSON
+ * conversion. Both parsers decode XML entities, so the returned value is the
+ * ORIGINAL string — which is what makes these round-trip assertions real
+ * rather than a string match on the escaped form.
+ */
+function readValue(plistText: string, xpath: string, fromJson: (o: any) => unknown): string {
+  const path = join(tmp, "probe.plist");
+  writeFileSync(path, plistText);
+
+  const seen: Array<[string, string]> = [];
+  if (HAS_PLUTIL) {
+    // Non-zero exit (thrown) if the document is not a well-formed plist.
+    execFileSync("plutil", ["-lint", path], { stdio: "pipe" });
+    const json = execFileSync("plutil", ["-convert", "json", "-o", "-", path], { encoding: "utf-8" });
+    seen.push(["plutil", String(fromJson(JSON.parse(json)))]);
+  }
+  if (HAS_XMLLINT) {
+    // --nonet: never fetch the Apple DTD the doctype names.
+    execFileSync("xmllint", ["--nonet", "--noout", path], { stdio: "pipe" });
+    const out = execFileSync("xmllint", ["--nonet", "--xpath", xpath, path], { encoding: "utf-8" });
+    // xmllint terminates --xpath output with a newline of its own. Strip
+    // exactly one (not .trim()) so genuine leading/trailing whitespace in a
+    // value would still show up as a mismatch against the other parsers.
+    seen.push(["xmllint", out.replace(/\n$/, "")]);
+  }
+  if (HAS_PYTHON) {
+    // plistlib raises on a malformed document, so this throws just like the
+    // other two rather than quietly returning a partial parse.
+    const json = execFileSync("python3", ["-c", PY_DUMP, path], { encoding: "utf-8", stdio: "pipe" });
+    seen.push(["plistlib", String(fromJson(JSON.parse(json)))]);
+  }
+  if (seen.length === 0) {
+    throw new Error(
+      "no plist/XML parser available (need plutil, xmllint or python3) — refusing to skip a parse check",
+    );
+  }
+  for (const [name, value] of seen) {
+    expect(`${name}=${value}`).toBe(`${name}=${seen[0]![1]}`);
+  }
+  return seen[0]![1];
+}
+
+/** A value under the top-level <dict> (Label, WorkingDirectory, StandardOutPath, ...). */
+function readTop(plistText: string, key: string): string {
+  return readValue(
+    plistText,
+    `string(/plist/dict/key[.='${key}']/following-sibling::string[1])`,
+    (o) => o[key],
+  );
+}
+
+/** A value under the EnvironmentVariables sub-dict. */
+function readEnvVar(plistText: string, key: string): string {
+  return readValue(
+    plistText,
+    `string(/plist/dict/key[.='EnvironmentVariables']/following-sibling::dict[1]/key[.='${key}']/following-sibling::string[1])`,
+    (o) => o.EnvironmentVariables[key],
+  );
+}
+
+/** The nth <string> of the ProgramArguments array (0-based). */
+function readProgramArg(plistText: string, index: number): string {
+  return readValue(
+    plistText,
+    `string(/plist/dict/key[.='ProgramArguments']/following-sibling::array[1]/string[${index + 1}])`,
+    (o) => o.ProgramArguments[index],
+  );
+}
+
+describe("escapeXml", () => {
+  test("escapes all five XML predefined entities", () => {
+    expect(escapeXml(`&<>"'`)).toBe("&amp;&lt;&gt;&quot;&apos;");
+  });
+
+  test("escapes & FIRST so the other entities are not double-escaped", () => {
+    // If `<` were replaced before `&`, this would come out as `&amp;lt;`.
+    expect(escapeXml("<")).toBe("&lt;");
+    expect(escapeXml("&lt;")).toBe("&amp;lt;");
+  });
+
+  test("leaves a string with no special characters untouched", () => {
+    expect(escapeXml("/Users/example/.flair/data")).toBe("/Users/example/.flair/data");
+  });
+
+  test("round-trips through unescapeXml, including a literal entity reference", () => {
+    for (const s of [`&<>"'`, "/tmp/a&b", "&amp;", "&lt;script&gt;", "plain"]) {
+      expect(unescapeXml(escapeXml(s))).toBe(s);
+    }
+  });
+});
+
+describe("buildLaunchdPlist — data dir containing XML metacharacters", () => {
+  test("a data dir containing & produces a plist that PARSES", () => {
+    const dataDir = "/Users/example/R&D/.flair/data";
+    // Reading it back proves both that it parsed and that it survived intact.
+    expect(readEnvVar(buildLaunchdPlist(opts({ dataDir })), "ROOTPATH")).toBe(dataDir);
+  });
+
+  for (const [name, dataDir] of [
+    ["ampersand", "/Users/example/R&D/data"],
+    ["less-than", "/Users/example/a<b/data"],
+    ["greater-than", "/Users/example/a>b/data"],
+    ["double quote", '/Users/example/a"b/data'],
+    ["single quote", "/Users/example/o'brien/data"],
+    ["all five at once", `/Users/example/a&b<c>d"e'f/data`],
+  ] as const) {
+    test(`round-trip: a data dir containing ${name} reads back identical`, () => {
+      const plist = buildLaunchdPlist(opts({ dataDir }));
+      expect(readEnvVar(plist, "ROOTPATH")).toBe(dataDir);
+    });
+  }
+
+  test("the log paths derived from the data dir are escaped too", () => {
+    const dataDir = "/Users/example/R&D/data";
+    const plist = buildLaunchdPlist(opts({ dataDir }));
+    expect(readTop(plist, "StandardOutPath")).toBe(join(dataDir, "log", "launchd-stdout.log"));
+    expect(readTop(plist, "StandardErrorPath")).toBe(join(dataDir, "log", "launchd-stderr.log"));
+  });
+});
+
+describe("buildLaunchdPlist — every other interpolated value", () => {
+  // Each of these reaches the XML as a <string>; none may break the document.
+  const hostile = `a&b<c>d"e'f`;
+
+  test("modelsDir round-trips", () => {
+    const modelsDir = `/opt/${hostile}/models`;
+    expect(readEnvVar(buildLaunchdPlist(opts({ modelsDir })), "FLAIR_MODELS_DIR")).toBe(modelsDir);
+  });
+
+  test("adminUser round-trips", () => {
+    expect(readEnvVar(buildLaunchdPlist(opts({ adminUser: hostile })), "HDB_ADMIN_USERNAME")).toBe(hostile);
+  });
+
+  test("a placeholder admin password containing metacharacters round-trips", () => {
+    // --admin-pass / an admin-pass file accepts arbitrary bytes, so this value
+    // is as capable of breaking the XML as any path. Placeholder only.
+    const placeholder = `PLACEHOLDER-${hostile}`;
+    expect(readEnvVar(buildLaunchdPlist(opts({ adminPass: placeholder })), "HDB_ADMIN_PASSWORD")).toBe(placeholder);
+  });
+
+  test("the HARPER_SET_CONFIG JSON payload round-trips as exact JSON", () => {
+    const setConfig = JSON.stringify({ rootPath: `/Users/example/R&D/data`, http: { port: 9926, cors: true } });
+    const got = readEnvVar(buildLaunchdPlist(opts({ setConfig })), "HARPER_SET_CONFIG");
+    expect(got).toBe(setConfig);
+    expect(JSON.parse(got).rootPath).toBe("/Users/example/R&D/data");
+  });
+
+  test("install paths (execPath, harperBinPath, workingDirectory) round-trip", () => {
+    const plist = buildLaunchdPlist(opts({
+      execPath: `/usr/${hostile}/node`,
+      harperBinPath: `/opt/${hostile}/harper.js`,
+      workingDirectory: `/opt/${hostile}`,
+    }));
+    expect(readProgramArg(plist, 0)).toBe(`/usr/${hostile}/node`);
+    expect(readProgramArg(plist, 1)).toBe(`/opt/${hostile}/harper.js`);
+    expect(readTop(plist, "WorkingDirectory")).toBe(`/opt/${hostile}`);
+  });
+
+  test("the label round-trips", () => {
+    const plist = buildLaunchdPlist(opts({ label: `ai.tpsdev.flair.${hostile}` }));
+    expect(readTop(plist, "Label")).toBe(`ai.tpsdev.flair.${hostile}`);
+  });
+
+  test("a plist with no special characters anywhere still parses", () => {
+    expect(readEnvVar(buildLaunchdPlist(opts()), "ROOTPATH")).toBe("/Users/example/.flair/data");
+  });
+});
+
+/**
+ * The ownership guard greps ROOTPATH back out of the plist with a regex rather
+ * than a real parser, so it is coupled to the writer's escaping: before the
+ * writer escaped, the grep round-tripped by accident. If the reader did not
+ * unescape, a data dir containing `&` would read back as `...&amp;...`, never
+ * equal itself, and the guard would refuse a perfectly legitimate stop/start.
+ */
+describe("assertLaunchdServiceOwnedBy — round-trips the writer's escaping", () => {
+  function writePlist(dataDir: string): string {
+    const path = join(tmp, "owned.plist");
+    writeFileSync(path, buildLaunchdPlist(opts({ dataDir })));
+    return path;
+  }
+
+  for (const [name, dataDir] of [
+    ["ampersand", "/Users/example/R&D/data"],
+    ["all five metacharacters", `/Users/example/a&b<c>d"e'f/data`],
+    ["no special characters", "/Users/example/.flair/data"],
+  ] as const) {
+    test(`does NOT refuse its own instance when the path contains ${name}`, () => {
+      const path = writePlist(dataDir);
+      expect(() => assertLaunchdServiceOwnedBy(dataDir, "ai.tpsdev.flair.deadbeef", path, "stop")).not.toThrow();
+    });
+  }
+
+  test("still refuses a plist registered to a DIFFERENT data dir", () => {
+    const path = writePlist("/Users/example/R&D/data");
+    expect(() => assertLaunchdServiceOwnedBy("/Users/example/other/data", "ai.tpsdev.flair.deadbeef", path, "stop"))
+      .toThrow(/different Flair instance/);
+  });
+
+  test("the refusal message reports the DECODED path, not the escaped one", () => {
+    const path = writePlist("/Users/example/R&D/data");
+    expect(() => assertLaunchdServiceOwnedBy("/Users/example/other/data", "ai.tpsdev.flair.deadbeef", path, "stop"))
+      .toThrow(/R&D/);
+  });
+});
+
+/**
+ * The second plist writer: `flair rem nightly enable` renders
+ * templates/launchd/dev.flair.rem.nightly.plist.tmpl. FLAIR_URL is the
+ * realistic carrier here — a URL with two query parameters contains `&` — but
+ * HOME and SHIM_PATH are arbitrary paths and equally capable of it.
+ *
+ * The same substitutions are ALSO rendered into the systemd units and the
+ * shell shim, where XML escaping would be corruption, so only the plist
+ * render escapes. Both halves of that are pinned below.
+ */
+describe("renderPlistTemplate — the rem nightly scheduler plist", () => {
+  const PLIST_TMPL = join(import.meta.dir, "../../templates/launchd/dev.flair.rem.nightly.plist.tmpl");
+
+  function subs(over: Record<string, string> = {}) {
+    return {
+      FLAIR_BIN: "/usr/local/bin/flair",
+      SHIM_PATH: "/Users/example/.flair/bin/flair-rem-nightly",
+      HOME: "/Users/example",
+      AGENT_ID: "test-agent",
+      FLAIR_URL: "http://127.0.0.1:9926",
+      HOUR: "3",
+      HOUR_PAD: "03",
+      MINUTE: "0",
+      MINUTE_PAD: "00",
+      ...over,
+    } as any;
+  }
+
+  function render(over: Record<string, string> = {}): string {
+    return renderPlistTemplate(readFileSync(PLIST_TMPL, "utf-8"), subs(over));
+  }
+
+  test("a FLAIR_URL with two query parameters produces a plist that PARSES", () => {
+    const url = "http://127.0.0.1:9926/?a=1&b=2";
+    expect(readEnvVar(render({ FLAIR_URL: url }), "FLAIR_URL")).toBe(url);
+  });
+
+  test("HOME containing XML metacharacters round-trips into every place it lands", () => {
+    const home = `/Users/a&b<c>d"e'f`;
+    const plist = render({ HOME: home });
+    expect(readEnvVar(plist, "HOME")).toBe(home);
+    expect(readTop(plist, "WorkingDirectory")).toBe(home);
+    expect(readTop(plist, "StandardOutPath")).toBe(`${home}/.flair/logs/rem-nightly.stdout.log`);
+    expect(readTop(plist, "StandardErrorPath")).toBe(`${home}/.flair/logs/rem-nightly.stderr.log`);
+  });
+
+  test("SHIM_PATH containing & round-trips as the program argument", () => {
+    const shim = "/Users/example/R&D/.flair/bin/flair-rem-nightly";
+    expect(readProgramArg(render({ SHIM_PATH: shim }), 0)).toBe(shim);
+  });
+
+  test("an ordinary render is unchanged and still parses", () => {
+    const plist = render();
+    expect(readTop(plist, "Label")).toBe("dev.flair.rem.nightly");
+    expect(readEnvVar(plist, "FLAIR_AGENT_ID")).toBe("test-agent");
+    expect(
+      readValue(
+        plist,
+        "string(/plist/dict/key[.='StartCalendarInterval']/following-sibling::dict[1]/key[.='Hour']/following-sibling::integer[1])",
+        (o) => o.StartCalendarInterval.Hour,
+      ),
+    ).toBe("3");
+  });
+
+  test("renderTemplate (systemd/shim) does NOT XML-escape — that would be corruption", () => {
+    // The shell shim and systemd units are not XML. An & there must stay an &.
+    const out = renderTemplate("FLAIR_URL={{FLAIR_URL}}", subs({ FLAIR_URL: "http://h/?a=1&b=2" }));
+    expect(out).toBe("FLAIR_URL=http://h/?a=1&b=2");
+  });
+
+  test("renderPlistTemplate still rejects an unknown placeholder", () => {
+    expect(() => renderPlistTemplate("{{NOPE}}", subs())).toThrow(/unknown template placeholder/);
+  });
+});


### PR DESCRIPTION
## The bug

A launchd plist is XML. Both plist writers interpolated values into one without escaping them, so a value containing `&`, `<`, `>`, `"` or `'` produced a **malformed plist**. That is not cosmetic — `launchctl` rejects a malformed plist outright, so the service or timer silently never registers and does not come back after a reboot.

Reproduced directly against Apple's own parser:

```
$ plutil -lint bad.plist
bad.plist: (Encountered unknown ampersand-escape sequence at line 5)
```

`--data-dir` is a supported capability and accepts any legal path; `&` in a path is unusual but entirely legal. `--flair-url` reaches the same defect without an unusual path at all — a URL with more than one query parameter contains `&`.

## Every interpolated value

**`flair init` — `src/cli.ts`.** One escape helper existed but was applied to only 2 of 11 interpolations, and covered 3 of the 5 entities (missed `>` and `'`).

| Value | Before |
| --- | --- |
| `Label` | raw |
| `ProgramArguments[0]` (node) | raw |
| `ProgramArguments[1]` (harper.js) | raw |
| `WorkingDirectory` (package dir) | raw |
| `ROOTPATH` (data dir) | **raw** — the reported one |
| `FLAIR_MODELS_DIR` | raw |
| `HARPER_SET_CONFIG` | partially escaped |
| `HDB_ADMIN_USERNAME` | raw |
| `HDB_ADMIN_PASSWORD` | raw |
| `HTTP_PORT` | raw |
| `OPERATIONSAPI_NETWORK_PORT` | partially escaped |
| `StandardOutPath` / `StandardErrorPath` | raw |

**`flair rem nightly enable` — `src/rem/scheduler.ts`.** A second writer, rendering the launchd template with raw substitution for `HOME`, `SHIM_PATH` and `FLAIR_URL`. (`HOUR`/`MINUTE`/`AGENT_ID` are validated upstream, but are escaped too rather than exempted.)

## The fix

Escaping lives in one place — `src/lib/xml-escape.ts` — covering all five entities with `&` replaced **first** so the others are not double-escaped. Both writers import it:

- `buildLaunchdPlist()` is extracted from the init command as a pure exported function that routes **every** interpolation through it, including values that look safe today. "This field cannot contain a special character" is exactly the assumption that rots when a field's source changes.
- `renderPlistTemplate()` escapes substitutions for the rem nightly plist. Deliberately **not** folded into `renderTemplate()`: the same substitutions are rendered into systemd units and a shell shim, where XML escaping would be corruption rather than a fix.

Hand-rolled rather than a serialiser — the tree carries no plist or XML dependency, and adding one for two templates is the larger change. The single-module chokepoint is what keeps a future field from skipping it.

### The reader had to move with it

`assertLaunchdServiceOwnedBy()` greps `ROOTPATH` back out of the plist with a regex, and round-tripped only **by accident** while the writer emitted paths raw. Left alone, correct escaping would make a data dir containing `&` compare unequal to itself and falsely refuse a legitimate `stop`/`start` — trading a malformed plist for a bricked one. It now decodes before comparing.

## Tests

Assert by **actually parsing** the generated plist with `plutil -lint` + `plutil -convert json` and reading the value back — not by string-matching for `&amp;`. A string match would pass on a plist still malformed elsewhere, and would not catch escaping that corrupts the value it was meant to preserve. Round-trip is asserted for `&`, `<`, `>`, `"` and `'` individually and all five at once, across every interpolated field.

Fixtures use placeholder credentials only, and nothing touches real launchd or `~/Library/LaunchAgents`.

### Mutation check

Each mutation applied, suite run, then restored:

| Mutation | Result |
| --- | --- |
| `escapeXml` returns its input unchanged | **17 fail** |
| escape `&` last instead of first (double-escape) | **12 fail** |
| reader stops decoding before comparing | **3 fail** |
| rem nightly plist reverts to unescaped render | **3 fail** |
| restored | **30 pass, 0 fail** |
