### PR TITLE
feat(federation): supervised sync driver + status that says what is driving sync

### DIFF
--- a/.changelog/unreleased/added-federation-sync-admin-pass-file.md
+++ b/.changelog/unreleased/added-federation-sync-admin-pass-file.md
@@ -1,0 +1,3 @@
+- **`flair federation sync --admin-pass-file <path>`.** Reads the admin password from a file
+  instead of an inline flag, matching `flair backup`, so an unattended sync keeps the secret out of
+  `ps` and shell history. The file must be owner-only (`chmod 600`) or the CLI refuses it.

--- a/.changelog/unreleased/added-federation-sync-driver.md
+++ b/.changelog/unreleased/added-federation-sync-driver.md
@@ -1,0 +1,12 @@
+- **`flair federation sync enable` — federation finally has an automatic driver.** Until now
+  `flair federation sync` was one-shot and `flair federation watch` was a foreground loop that
+  died with its terminal, so a freshly paired spoke synced exactly once and then silently stopped
+  — which reads as a broken pairing rather than as a missing scheduler. `enable` installs a
+  periodic one-shot on the platform scheduler (launchd `StartInterval` on macOS, a systemd user
+  timer on Linux), with `disable` and `status` to match, mirroring `flair rem nightly`. Default
+  interval 300s, `--interval` to change it, first sync runs immediately. `federation watch` is
+  unchanged and remains the right tool for interactive debugging.
+
+  The scheduler never writes a password into a unit file: it stores the *path* passed to
+  `--admin-pass-file` (defaulting to `~/.flair/admin-pass` when present) and the CLI reads it at
+  run time, refusing any file that is not owner-only.

--- a/.changelog/unreleased/changed-federation-status-reports-driver.md
+++ b/.changelog/unreleased/changed-federation-status-reports-driver.md
@@ -1,0 +1,9 @@
+- **`flair federation status` now says whether anything is driving sync.** It previously warned
+  "one or more peers haven't merged a record in >24h" identically whether sync was running and the
+  peer was unreachable, or nothing had run sync since the day you paired — two problems needing
+  opposite fixes, reported the same way. Status now combines the service manager's view of the
+  driver with peer contact times and names which one you actually have: driver active and healthy,
+  driver active but not reaching the peer, unit files present but never loaded, no driver at all,
+  or an unmanaged driver (a cron entry, a hand-written unit) that is working fine. The driver check
+  is local to the machine running the CLI, so it is omitted for remote `--target`s rather than
+  making a claim about a host it cannot see.

--- a/docs/federation.md
+++ b/docs/federation.md
@@ -83,12 +83,61 @@ Replace `<fabric-node>`, `<instance-name>`, and `<hub-admin-password>` with your
 
 ## Sync
 
-Push local changes to the hub:
+Push local changes to the hub, once:
 
 ```bash
 flair federation sync --admin-pass <password>
 # Output: ✅ Synced 12 records (0 skipped) in 145ms
 ```
+
+### Keeping it synced
+
+`flair federation sync` is one-shot and `flair federation watch` only runs
+while its terminal is open. Neither survives a logout, so a spoke that is only
+ever synced by hand looks paired but stops replicating — enable the scheduled
+driver instead:
+
+```bash
+flair federation sync enable                  # every 300s by default
+flair federation sync enable --interval 900   # or pick your own cadence
+flair federation sync status                  # is anything actually driving sync?
+flair federation sync disable
+```
+
+This installs a **periodic one-shot**: a launchd job (`StartInterval`) on
+macOS, a systemd user timer (`OnUnitActiveSec`) on Linux, each invoking
+`flair federation sync` on the interval. It is deliberately not a supervised
+long-lived watcher — the sync holds no state between runs, so a resident
+process would buy nothing, and a supervisor cannot restart a process that
+hangs rather than exits. The trade-off is latency, and `--interval` is the
+knob. The first sync runs immediately on enable.
+
+`flair federation watch` is unchanged and still the right tool for an
+interactive "watch it sync while I debug" session.
+
+**Credentials.** The scheduler never writes a password into a unit file. It
+stores the *path* given to `--admin-pass-file` (defaulting to
+`~/.flair/admin-pass` when that exists) and the CLI reads the file at run time,
+refusing it unless it is owner-only (`chmod 600`). Pass `--no-credentials` to
+wire none at all.
+
+### Is anything driving sync?
+
+`flair federation status` reports the driver alongside the peer table, because
+"no peer has merged in 24h" has two completely different causes:
+
+| What you see | What it means | What to do |
+|---|---|---|
+| `Sync driver: active` | A managed driver is loaded and syncs are landing | Nothing |
+| `Sync driver: active … but no peer contact in <window>` | Sync **is** running; the runs are not reaching the peer | `flair federation reachability`, then the driver log |
+| `Sync driver: NONE` | Nothing has run sync since you paired | `flair federation sync enable` |
+| `Sync driver: INSTALLED BUT NOT LOADED` | Unit files exist, the service manager never loaded them | `flair federation sync enable` |
+| `Sync driver: none managed by Flair — but syncs are landing` | A cron entry / hand-written unit is driving it | Nothing |
+
+The check is local to the machine running the CLI, so it is omitted when
+`--target` points at a remote instance.
+
+Driver logs: `~/.flair/logs/federation-sync.{stdout,stderr}.log`.
 
 ## Security
 
@@ -125,10 +174,13 @@ Records with `updatedAt` more than 5 minutes in the future are rejected. This pr
 
 | Command | Description |
 |---------|-------------|
-| `flair federation status` | Show instance identity and peer connections |
+| `flair federation status` | Show instance identity, peer connections, and whether anything is driving sync |
 | `flair federation pair <hub-url> --token-from <file>` | Pair this spoke with a hub using a token triple file (or `-` for stdin) |
 | `flair federation sync` | Push local changes to the hub (one-shot) |
-| `flair federation watch [--interval <s>]` | Run sync in a foreground daemon loop (default 30s) |
+| `flair federation sync enable [--interval <s>] [--admin-pass-file <path>]` | Install the scheduled sync driver (launchd on macOS, systemd timer on Linux) |
+| `flair federation sync disable [--remove-shim]` | Remove the scheduled sync driver |
+| `flair federation sync status` | Show whether the driver is installed and genuinely active |
+| `flair federation watch [--interval <s>]` | Run sync in a foreground loop for an interactive session (default 30s) |
 | `flair federation reachability` | Probe local instance + each paired peer (read-only) |
 | `flair federation token [--ttl <min>]` | Generate a one-time pairing token triple (hub only) |
 
@@ -174,6 +226,6 @@ flair federation unpin <instanceId>
 ## Limitations (1.0)
 
 - **HTTP push only** — no persistent WebSocket connections or real-time sync
-- **Manual or watch-loop sync** — `flair federation sync` is one-shot; `flair federation watch --interval 30` runs it on a loop in a foreground daemon (wrap in launchd / systemd for production)
+- **Polled sync** — `flair federation sync enable` schedules a periodic one-shot (launchd / systemd, default 300s); there is no write-path trigger, so a new memory replicates on the next tick rather than immediately
 - **Single hub** — spoke-to-spoke sync goes through the hub
 - **Record-level LWW** — not field-level; concurrent edits to different fields of the same record may lose data

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -106,6 +106,11 @@ import {
 } from "./lib/auth-resolve.js";
 import { validateSnapshotArchive, extractSnapshotSafely } from "./lib/safe-snapshot-extract.js";
 import { escapeXml, unescapeXml } from "./lib/xml-escape.js";
+// Value-only static import so `--interval`'s advertised default cannot drift
+// from the one the scheduler actually validates against. The module itself is
+// still loaded lazily at call time (the `await import()`s below) for the
+// functions — this pulls in nothing but node builtins.
+import { DEFAULT_INTERVAL_SECONDS as FEDERATION_SYNC_DEFAULT_INTERVAL } from "./federation/scheduler.js";
 
 // Federation crypto helpers — inlined to avoid cross-boundary imports from
 // src/ into resources/, which don't survive npm packaging (see also
@@ -5777,13 +5782,55 @@ const signBodyFresh = signRequestBody;
 
 const federation = program.command("federation").description("Manage federation (hub-and-spoke sync)");
 
+/**
+ * The most recent CONTACT with any peer (max of peer.lastSyncAt), or null.
+ *
+ * Contact, not merge: a sync that reaches the peer and legitimately has
+ * nothing to send still proves the driver ran. This is half of what lets
+ * `federation status` tell "nothing is driving sync" apart from "sync is
+ * running, the peer is unreachable" (flair#922) — the other half is whether
+ * the service manager has a driver loaded.
+ *
+ * Returns null on ANY failure. A driver verdict is a diagnostic aid; it must
+ * never be the reason `federation status` fails.
+ */
+async function latestPeerContact(opts: { target?: string }): Promise<string | null> {
+  try {
+    const target = resolveTarget(opts);
+    const baseUrl = target ? target.replace(/\/$/, "") : undefined;
+    const { peers } = await api("GET", "/FederationPeers", undefined, baseUrl ? { baseUrl } : undefined);
+    let best: number | null = null;
+    for (const p of peers ?? []) {
+      if (!p?.lastSyncAt) continue;
+      const t = Date.parse(p.lastSyncAt);
+      if (Number.isFinite(t) && (best === null || t > best)) best = t;
+    }
+    return best === null ? null : new Date(best).toISOString();
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * True when the CLI is pointed at the instance running on THIS machine.
+ *
+ * The scheduler check is inherently local — launchctl/systemctl only know
+ * about jobs on the host the CLI is running on. Reporting "no driver" while
+ * `--target` points at someone else's hub would be a confident claim about a
+ * machine we cannot see, so the driver block is suppressed for remote targets.
+ */
+function driverCheckAppliesTo(opts: { target?: string }): boolean {
+  const target = resolveTarget(opts);
+  return !target || isLocalBase(target.replace(/\/$/, ""));
+}
+
 federation
   .command("status")
   .description("Show federation status and peer connections")
   .option("--port <port>", "Harper HTTP port")
   .option("--target <url>", "Remote Flair URL (env: FLAIR_TARGET)")
   .option("--ops-target <url>", "Explicit ops API URL (env: FLAIR_OPS_TARGET; bypasses port derivation)")
-  .option("--json", "Emit JSON {instance, peers} (also: pipe + FLAIR_OUTPUT=json)")
+  .option("--json", "Emit JSON {instance, peers, driver} (also: pipe + FLAIR_OUTPUT=json)")
   .action(async (opts) => {
     const target = resolveTarget(opts);
     const baseUrl = target ? target.replace(/\/$/, "") : undefined;
@@ -5792,8 +5839,40 @@ federation
       const instance = await api("GET", "/FederationInstance", undefined, baseUrl ? { baseUrl } : undefined);
       const { peers } = await api("GET", "/FederationPeers", undefined, baseUrl ? { baseUrl } : undefined);
 
+      // Driver state (flair#922). Computed from the LOCAL service manager, so
+      // it is only meaningful when the CLI is pointed at the local instance.
+      let driver: import("./federation/scheduler.js").SchedulerStatus | null = null;
+      let assessment: import("./federation/scheduler.js").DriverAssessment | null = null;
+      if (driverCheckAppliesTo(opts)) {
+        try {
+          const { schedulerStatus, assessDriver } = await import("./federation/scheduler.js");
+          driver = schedulerStatus();
+          let lastSyncAt: string | null = null;
+          for (const p of peers ?? []) {
+            if (!p?.lastSyncAt) continue;
+            const t = Date.parse(p.lastSyncAt);
+            if (Number.isFinite(t) && (lastSyncAt === null || t > Date.parse(lastSyncAt))) {
+              lastSyncAt = new Date(t).toISOString();
+            }
+          }
+          assessment = assessDriver({
+            installed: driver.installed,
+            active: driver.active,
+            intervalSeconds: driver.intervalSeconds,
+            lastSyncAt,
+            now: Date.now(),
+          });
+        } catch {
+          // An unsupported platform (neither darwin nor linux) or an
+          // unreadable unit must not take down `federation status` — the peer
+          // table is still the primary output.
+          driver = null;
+          assessment = null;
+        }
+      }
+
       if (mode === "json") {
-        console.log(render.asJSON({ instance, peers }));
+        console.log(render.asJSON({ instance, peers, driver, driverAssessment: assessment }));
         return;
       }
 
@@ -5806,6 +5885,26 @@ federation
       if (peers.length === 0) {
         console.log(`\n${render.icons.info} ${render.wrap(render.c.dim, "No peers configured. Use 'flair federation pair' to connect to a hub.")}`);
         return;
+      }
+
+      // Print the driver line BEFORE the per-peer table: "is anything running
+      // sync at all" is the question that decides how to read everything
+      // below it.
+      if (assessment) {
+        const icon = assessment.verdict === "driving" || assessment.verdict === "external-driver"
+          ? render.icons.ok
+          : assessment.verdict === "unknown"
+            ? render.icons.info
+            : render.icons.warn;
+        const color = assessment.verdict === "driving" || assessment.verdict === "external-driver"
+          ? render.c.green
+          : assessment.verdict === "unknown"
+            ? render.c.dim
+            : render.c.yellow;
+        console.log();
+        console.log(`${icon} ${render.wrap(color, assessment.headline)}`);
+        console.log(`  ${render.wrap(render.c.dim, assessment.detail)}`);
+        if (assessment.remedy) console.log(`  ${render.wrap(render.c.cyan, assessment.remedy)}`);
       }
 
       const now = Date.now();
@@ -5867,7 +5966,16 @@ federation
       });
       if (haveStale) {
         console.log();
-        console.log(`${render.icons.warn} ${render.wrap(render.c.yellow, "One or more peers haven't merged a record in >24h.")} ${render.wrap(render.c.dim, "Check skippedReasons in SyncLog or run 'flair federation sync'.")}`);
+        // The staleness warning used to fire identically whether sync was
+        // running and the peer was unreachable, or nothing had run sync since
+        // the day the spoke was paired (flair#922). Those need opposite
+        // actions, so the remedy is now chosen by the driver verdict instead
+        // of always pointing at SyncLog.
+        const noDriver = assessment?.verdict === "no-driver" || assessment?.verdict === "driver-inactive";
+        const remedy = noDriver
+          ? "Nothing is driving sync — see the driver line above. Run 'flair federation sync enable'."
+          : "Check skippedReasons in SyncLog or run 'flair federation sync'.";
+        console.log(`${render.icons.warn} ${render.wrap(render.c.yellow, "One or more peers haven't merged a record in >24h.")} ${render.wrap(render.c.dim, remedy)}`);
       }
 
       const haveContactButNoMerge = peers.some((p: any) => {
@@ -6548,18 +6656,156 @@ export async function runFederationSyncOnce(opts: any): Promise<{ pushed: number
   }
 }
 
-federation
+const federationSync = federation
   .command("sync")
-  .description("Push local changes to the hub")
+  .description("Push local changes to the hub (one-shot). Subcommands manage the scheduled driver.")
   .option("--port <port>", "Harper HTTP port")
   .option("--admin-pass <pass>", "Admin password")
+  .option("--admin-pass-file <path>", "Read the admin password from a file (e.g. ~/.flair/admin-pass). Preferred for launchd/cron — keeps the secret out of ps and shell history.")
   .option("--ops-port <port>", "Harper operations API port")
   .option("--target <url>", "Remote Flair URL (env: FLAIR_TARGET)")
   .option("--ops-target <url>", "Explicit ops API URL (env: FLAIR_OPS_TARGET; bypasses port derivation)")
   .action(async (opts) => {
+    // --admin-pass-file resolves into the same `adminPass` slot the inline
+    // flag uses, so the scheduler never has to embed a secret in a unit file.
+    // readAdminPassFileSecure() refuses a file that is not owner-only.
+    if (!opts.adminPass && opts.adminPassFile) {
+      try {
+        opts.adminPass = readAdminPassFileSecure(opts.adminPassFile);
+      } catch (err: any) {
+        console.error(`Error reading --admin-pass-file ${opts.adminPassFile}: ${err.message}`);
+        process.exit(1);
+      }
+    }
     const r = await runFederationSyncOnce(opts);
     if (r.error) {
       console.error(`Error: ${r.error.message}`);
+      process.exit(1);
+    }
+  });
+
+// ─── flair federation sync enable | disable | status ────────────────────────
+// The supervised driver (flair#922). Federation had no automatic driver at
+// all: `sync` is one-shot and `watch` is a foreground loop that dies with its
+// terminal, so every operator paired a spoke, saw one successful sync, and
+// then silently stopped syncing.
+//
+// Shape deliberately mirrors `flair rem nightly enable|disable|status` —
+// same verbs, same platform coverage (launchd on macOS, systemd --user timer
+// on Linux), same "never claim success before activation succeeded" rule.
+// Strategy is a PERIODIC ONE-SHOT rather than a supervised long-lived
+// watcher; the reasoning is in src/federation/scheduler.ts's header.
+
+federationSync
+  .command("enable")
+  .description("Install the sync driver (launchd on macOS, systemd timer on Linux)")
+  .option("--interval <seconds>", `Seconds between syncs (default ${FEDERATION_SYNC_DEFAULT_INTERVAL})`, String(FEDERATION_SYNC_DEFAULT_INTERVAL))
+  .option("--admin-pass-file <path>", "Path to a 0600 file holding the admin password (default ~/.flair/admin-pass when it exists). The PATH is stored in the unit — never the password.")
+  // Deliberately NOT `--no-admin-pass-file`: commander treats a `--no-x` flag
+  // as the negation of `--x`, and declaring both on one command makes the
+  // POSITIVE option silently parse to undefined — `--admin-pass-file /path`
+  // would be accepted and dropped, producing a driver that fails auth every
+  // cycle with no error anywhere. Verified against commander 14.
+  .option("--no-credentials", "Do not wire any credential file into the unit")
+  .option("--target <url>", "Remote Flair URL to sync (default: the local instance)")
+  .action(async (_opts, cmd) => {
+    // optsWithGlobals(), NOT the action's first argument: `--admin-pass-file`
+    // and `--target` are declared on BOTH this subcommand and its parent
+    // (`flair federation sync`), and when a parent declares the same option
+    // name commander binds the value to the PARENT — the subcommand's own
+    // opts come back undefined. Reading only the local opts silently dropped
+    // `--admin-pass-file <path>` here, which would have installed a driver
+    // that failed auth every cycle with no error anywhere. Verified against
+    // commander 14.
+    const opts = cmd.optsWithGlobals();
+    const intervalSeconds = Number(opts.interval);
+    if (!Number.isFinite(intervalSeconds)) {
+      console.error(`Error: --interval must be a number of seconds (got: ${opts.interval})`);
+      process.exit(1);
+    }
+
+    // Default to the canonical admin-pass file when it is actually there.
+    // Silently wiring a path that does not exist would produce a driver that
+    // runs and fails auth every interval — the failure mode this whole issue
+    // is about, in a new costume.
+    let adminPassFile: string | undefined;
+    if (opts.credentials === false) {
+      adminPassFile = undefined;
+    } else if (typeof opts.adminPassFile === "string" && opts.adminPassFile) {
+      adminPassFile = opts.adminPassFile;
+    } else {
+      const fallback = defaultAdminPassPath();
+      adminPassFile = existsSync(fallback) ? fallback : undefined;
+    }
+
+    const { enableScheduler, formatEnableReport } = await import("./federation/scheduler.js");
+    try {
+      const r = enableScheduler({ intervalSeconds, adminPassFile, target: opts.target });
+      const { lines, ok } = formatEnableReport(r, { adminPassFile, target: opts.target });
+      for (const line of lines) console.log(line);
+      if (!ok) process.exit(1);
+    } catch (err: any) {
+      console.error(`Error: ${err.message}`);
+      process.exit(1);
+    }
+  });
+
+federationSync
+  .command("disable")
+  .description("Remove the sync driver (peers and sync history are preserved)")
+  .option("--remove-shim", "Also delete the ~/.flair/bin/flair-federation-sync shim")
+  .action(async (opts) => {
+    const { disableScheduler } = await import("./federation/scheduler.js");
+    try {
+      const r = disableScheduler({ removeShim: !!opts.removeShim });
+      if (r.removed.length === 0) {
+        console.log(`(Federation sync driver was not installed on ${r.platform})`);
+        return;
+      }
+      console.log(`✅ Federation sync driver disabled (${r.platform})`);
+      console.log(`   Removed:`);
+      for (const p of r.removed) console.log(`     ${p}`);
+      if (r.unloadResult && r.unloadResult.code !== 0) {
+        console.log(`   Unload:      ${r.unloadCommand.join(" ")} → code ${r.unloadResult.code}`);
+        if (r.unloadResult.stderr) console.log(`     stderr: ${r.unloadResult.stderr.trim()}`);
+      }
+      console.log(`\nPeers, keys and sync history are untouched. Nothing will sync until you`);
+      console.log(`re-enable the driver or run \`flair federation sync\` by hand.`);
+    } catch (err: any) {
+      console.error(`Error: ${err.message}`);
+      process.exit(1);
+    }
+  });
+
+federationSync
+  .command("status")
+  .description("Show whether a sync driver is installed and genuinely active")
+  .option("--port <port>", "Harper HTTP port")
+  .option("--target <url>", "Remote Flair URL (env: FLAIR_TARGET)")
+  .option("--json", "Emit JSON")
+  .action(async (_opts, cmd) => {
+    // See the comment on `enable` above: `--target`/`--port` are declared on
+    // the parent too, so commander binds them there.
+    const opts = cmd.optsWithGlobals();
+    const { schedulerStatus, formatStatusReport, assessDriver } = await import("./federation/scheduler.js");
+    try {
+      const s = schedulerStatus();
+      const lastSyncAt = await latestPeerContact(opts);
+      const a = assessDriver({
+        installed: s.installed,
+        active: s.active,
+        intervalSeconds: s.intervalSeconds,
+        lastSyncAt,
+        now: Date.now(),
+      });
+      if (render.resolveOutputMode(opts) === "json") {
+        console.log(render.asJSON({ driver: s, assessment: a, lastSyncAt }));
+        return;
+      }
+      const { lines } = formatStatusReport(s, a);
+      for (const line of lines) console.log(line);
+    } catch (err: any) {
+      console.error(`Error: ${err.message}`);
       process.exit(1);
     }
   });

--- a/src/federation/scheduler.ts
+++ b/src/federation/scheduler.ts
@@ -1,0 +1,716 @@
+/**
+ * Federation sync driver — platform-native scheduler install/uninstall.
+ *
+ * Backs `flair federation sync enable|disable|status`. Mirrors
+ * src/rem/scheduler.ts (`flair rem nightly enable`) in structure, verbs and
+ * platform handling; the shared launchd/systemd primitives live in
+ * src/lib/scheduler-platform.ts so flair#850's active-state lesson has one
+ * implementation.
+ *
+ * ── Why this exists ────────────────────────────────────────────────────────
+ * Federation had no automatic driver. `flair federation sync` is one-shot and
+ * `flair federation watch` is a foreground loop that dies with its terminal,
+ * so a freshly paired spoke syncs exactly once and then never again — which
+ * presents as a broken pairing rather than as a missing scheduler.
+ *
+ * ── Why a periodic one-shot, not a supervised watcher ──────────────────────
+ * Both shapes were built by hand on our own hub (one launchd job wrapping the
+ * watch loop with KeepAlive/SuccessfulExit=false, one running one-shot sync on
+ * StartInterval=900) and neither was ever shipped. This module ships exactly
+ * one of them: the periodic one-shot. The argument is not aesthetic:
+ *
+ *   1. The watch loop carries NO state across iterations. It is literally
+ *      `while (!stopped) { await runFederationSyncOnce(opts); sleep(interval) }`
+ *      — every cycle re-reads the peer list, re-loads the instance key and
+ *      opens fresh HTTP connections. A long-lived process is worth its cost
+ *      when it holds warm state or a persistent connection. This one holds
+ *      neither, so supervision buys only the ~300ms of process startup a
+ *      one-shot pays per cycle — at a 300s interval, a 0.1% duty cycle.
+ *
+ *   2. A supervised watcher's worst failure is invisible. KeepAlive restarts a
+ *      process that EXITS; it does nothing for one that HANGS. A hung watcher
+ *      stops syncing forever while `launchctl list` still shows it happily
+ *      running — the exact "looks fine, is dead" shape supervision was
+ *      supposed to remove. Every network call inside runFederationSyncOnce is
+ *      bounded by an AbortSignal.timeout (10s ops, 15s query, 45s per batch),
+ *      so a one-shot always terminates and the scheduler always gets to start
+ *      the next one.
+ *
+ *   3. Crash safety is free. The sync cursor (peer.lastSyncAt) only advances
+ *      after a successful push, and the hub merges by id, so an interrupted
+ *      run re-sends rather than losing records. There is no partial-failure
+ *      state for a supervisor to reason about.
+ *
+ * The cost is latency, and latency is the knob: --interval, default 300s.
+ * (Not 30s like `federation watch`: a scheduler-spawned process per cycle
+ * makes very short intervals mostly process startup. Not 900s like the
+ * hand-built job either — five minutes is a defensible upper bound on how
+ * stale a spoke should look on the hub dashboard.)
+ *
+ * `federation watch` is NOT removed — it is still the right tool for an
+ * interactive "watch it sync while I debug this" session. It is simply no
+ * longer the answer to "how do I keep this synced".
+ *
+ * ── Secrets ────────────────────────────────────────────────────────────────
+ * The scheduler unit NEVER contains a password. It carries
+ * FLAIR_ADMIN_PASS_FILE — a PATH — and the shim passes that path to
+ * `flair federation sync --admin-pass-file`, which reads it through
+ * readAdminPassFileSecure() and refuses a file that is not owner-only.
+ */
+import { existsSync, chmodSync, rmSync, readFileSync } from "node:fs";
+import { resolve, dirname } from "node:path";
+import { homedir } from "node:os";
+import { fileURLToPath } from "node:url";
+import { escapeXml } from "../lib/xml-escape.js";
+import {
+  type SchedulerPlatform,
+  detectPlatform as detectPlatformFor,
+  spawnReport,
+  readTemplate,
+  renderTemplateWith,
+  writeFileWithDir,
+  interpretActiveResult,
+  describeLoadFailure as describeLoadFailureFor,
+  STATUS_CHECK_TIMEOUT_MS,
+} from "../lib/scheduler-platform.js";
+
+export type { SchedulerPlatform };
+
+export const LAUNCHD_LABEL = "dev.flair.federation.sync";
+export const SYSTEMD_TIMER_UNIT = "flair-federation-sync.timer";
+export const SYSTEMD_SERVICE_UNIT = "flair-federation-sync.service";
+
+export const SHIM_PATH_DEFAULT = resolve(homedir(), ".flair", "bin", "flair-federation-sync");
+export const LAUNCHD_PLIST_PATH = resolve(homedir(), "Library", "LaunchAgents", `${LAUNCHD_LABEL}.plist`);
+export const SYSTEMD_USER_DIR = resolve(homedir(), ".config", "systemd", "user");
+export const SYSTEMD_TIMER_PATH = resolve(SYSTEMD_USER_DIR, SYSTEMD_TIMER_UNIT);
+export const SYSTEMD_SERVICE_PATH = resolve(SYSTEMD_USER_DIR, SYSTEMD_SERVICE_UNIT);
+
+/** Default seconds between one-shot syncs. See the module header for why 300. */
+export const DEFAULT_INTERVAL_SECONDS = 300;
+
+/**
+ * Floor on --interval. Below a minute the per-cycle process startup starts to
+ * dominate the actual work, and systemd's default timer accuracy is a minute
+ * anyway — a smaller number would be a promise the scheduler cannot keep.
+ * Sub-minute latency is what `flair federation watch` is for.
+ */
+export const MIN_INTERVAL_SECONDS = 60;
+/** Ceiling on --interval: a day. Past this, use `flair rem nightly`'s shape. */
+export const MAX_INTERVAL_SECONDS = 86_400;
+
+export interface FederationSchedulerSubstitutions {
+  /** Absolute path to the flair binary the shim should invoke. */
+  FLAIR_BIN: string;
+  /** Absolute path to the shim script the scheduler should call. */
+  SHIM_PATH: string;
+  /** Operator's home directory (HOME env var value). */
+  HOME: string;
+  /** Seconds between one-shot syncs. */
+  INTERVAL_SECONDS: string;
+  /**
+   * Path to the admin-password FILE (never the password). Empty string when
+   * no credential file was configured — the shim then invokes plain
+   * `flair federation sync` and the CLI's own auth ladder applies.
+   */
+  ADMIN_PASS_FILE: string;
+  /**
+   * Remote Flair URL to sync from, as FLAIR_TARGET. Empty for the normal
+   * case (the local instance).
+   */
+  FLAIR_TARGET: string;
+}
+
+export interface EnableOpts {
+  /** Seconds between one-shot syncs. */
+  intervalSeconds: number;
+  /** Path to a 0600 file holding the admin password. Never the password. */
+  adminPassFile?: string;
+  /** Remote Flair URL (FLAIR_TARGET). Omit for the local instance. */
+  target?: string;
+  /** Absolute path to the flair binary. Defaults to argv[1]. */
+  flairBin?: string;
+  /** Override platform for testing. */
+  platformOverride?: SchedulerPlatform;
+  /** Override target paths for testing. */
+  shimPathOverride?: string;
+  launchdPlistOverride?: string;
+  systemdTimerOverride?: string;
+  systemdServiceOverride?: string;
+  /** Override HOME written into the units (testing). */
+  homeOverride?: string;
+  /** Override the template root for testing. */
+  templateRootOverride?: string;
+  /** Skip the launchctl/systemctl invocation (testing). */
+  skipLoad?: boolean;
+}
+
+export interface EnableResult {
+  platform: SchedulerPlatform;
+  shimPath: string;
+  schedulerPath: string;
+  intervalSeconds: number;
+  loadCommand: string[];
+  loadResult?: { code: number | null; stdout: string; stderr: string };
+}
+
+export interface DisableOpts {
+  platformOverride?: SchedulerPlatform;
+  shimPathOverride?: string;
+  launchdPlistOverride?: string;
+  systemdTimerOverride?: string;
+  systemdServiceOverride?: string;
+  skipUnload?: boolean;
+  /** When true, remove the shim too. Default false to keep state minimal. */
+  removeShim?: boolean;
+}
+
+export interface DisableResult {
+  platform: SchedulerPlatform;
+  removed: string[];
+  unloadCommand: string[];
+  unloadResult?: { code: number | null; stdout: string; stderr: string };
+}
+
+function detectPlatform(override?: SchedulerPlatform): SchedulerPlatform {
+  return detectPlatformFor("federation sync scheduler", override);
+}
+
+function defaultTemplateRoot(): string {
+  // Templates live alongside dist/ in the published package and alongside
+  // src/federation/ in the source tree. Walk up from this file until we find
+  // a directory containing templates/.
+  const here = dirname(fileURLToPath(import.meta.url));
+  const candidates = [
+    resolve(here, "..", "..", "templates"),
+    resolve(here, "..", "..", "..", "templates"),
+    resolve(here, "..", "templates"),
+  ];
+  for (const c of candidates) {
+    if (existsSync(c)) return c;
+  }
+  throw new Error(`unable to locate templates directory (looked in: ${candidates.join(", ")})`);
+}
+
+export function renderTemplate(text: string, subs: FederationSchedulerSubstitutions): string {
+  return renderTemplateWith(text, { ...subs }, (v) => v);
+}
+
+/**
+ * renderTemplate() for the launchd plist specifically: substituted values are
+ * XML-escaped (#918). A plist is XML, so a value carrying `&`, `<`, `>`, `"`
+ * or `'` makes it malformed and `launchctl bootstrap` rejects it — the job
+ * silently never registers. HOME, SHIM_PATH, ADMIN_PASS_FILE and FLAIR_TARGET
+ * are all arbitrary operator-supplied strings and every one of them can carry
+ * an ampersand.
+ *
+ * Deliberately NOT folded into renderTemplate(): the same substitutions are
+ * rendered into the systemd units and the shell shim, where XML escaping
+ * would be corruption rather than a fix.
+ */
+export function renderPlistTemplate(text: string, subs: FederationSchedulerSubstitutions): string {
+  return renderTemplateWith(text, { ...subs }, escapeXml);
+}
+
+/**
+ * Validates the interval. Throws rather than silently coercing — surface bad
+ * input at the install boundary, where the operator is still watching.
+ */
+export function validateInterval(intervalSeconds: number): void {
+  if (!Number.isInteger(intervalSeconds)) {
+    throw new Error(`interval must be a whole number of seconds, got ${intervalSeconds}`);
+  }
+  if (intervalSeconds < MIN_INTERVAL_SECONDS || intervalSeconds > MAX_INTERVAL_SECONDS) {
+    throw new Error(
+      `interval must be ${MIN_INTERVAL_SECONDS}-${MAX_INTERVAL_SECONDS} seconds, got ${intervalSeconds}. ` +
+        `For sub-minute latency use \`flair federation watch --interval <s>\` in a foreground session instead.`,
+    );
+  }
+}
+
+function buildSubstitutions(opts: EnableOpts, shimPath: string, flairBin: string): FederationSchedulerSubstitutions {
+  validateInterval(opts.intervalSeconds);
+  const adminPassFile = opts.adminPassFile ?? "";
+  if (adminPassFile && !existsSync(adminPassFile)) {
+    throw new Error(
+      `--admin-pass-file path does not exist: ${adminPassFile}. ` +
+        `The scheduler stores the PATH, not the password, so the file must exist before enabling.`,
+    );
+  }
+  return {
+    FLAIR_BIN: flairBin,
+    SHIM_PATH: shimPath,
+    HOME: opts.homeOverride ?? homedir(),
+    INTERVAL_SECONDS: String(opts.intervalSeconds),
+    ADMIN_PASS_FILE: adminPassFile,
+    FLAIR_TARGET: opts.target ?? "",
+  };
+}
+
+function launchdDomain(): string {
+  return `gui/${process.getuid?.() ?? ""}`;
+}
+
+/**
+ * Installs the platform-native scheduler entry and the shim script.
+ *
+ * macOS: writes ~/Library/LaunchAgents/dev.flair.federation.sync.plist and
+ *   bootstraps it (StartInterval + RunAtLoad).
+ * Linux: writes ~/.config/systemd/user/flair-federation-sync.{timer,service}
+ *   and enables the timer (OnActiveSec + OnUnitActiveSec).
+ *
+ * Idempotent: re-running overwrites the unit in place and re-bootstraps, so
+ * `enable --interval 600` after `enable` is how you change the interval.
+ */
+export function enableScheduler(opts: EnableOpts): EnableResult {
+  const plat = detectPlatform(opts.platformOverride);
+  const flairBin = opts.flairBin ?? process.argv[1] ?? "flair";
+  const shimPath = opts.shimPathOverride ?? SHIM_PATH_DEFAULT;
+  const templateRoot = opts.templateRootOverride ?? defaultTemplateRoot();
+  const subs = buildSubstitutions(opts, shimPath, flairBin);
+
+  // 1. Deploy the shim (always — both platforms invoke it).
+  const shimContents = renderTemplate(readTemplate(templateRoot, "bin/flair-federation-sync.sh.tmpl"), subs);
+  writeFileWithDir(shimPath, shimContents, 0o700);
+  chmodSync(shimPath, 0o700);
+
+  // 2. Write the scheduler entry.
+  if (plat === "darwin") {
+    const plistPath = opts.launchdPlistOverride ?? LAUNCHD_PLIST_PATH;
+    const plistContents = renderPlistTemplate(
+      readTemplate(templateRoot, `launchd/${LAUNCHD_LABEL}.plist.tmpl`),
+      subs,
+    );
+    writeFileWithDir(plistPath, plistContents, 0o600);
+
+    const loadCommand = ["launchctl", "bootstrap", launchdDomain(), plistPath];
+    let loadResult: EnableResult["loadResult"];
+    if (!opts.skipLoad) {
+      // Bootout first in case a prior install left the job loaded — this is
+      // what makes re-running enable (e.g. to change --interval) idempotent
+      // rather than a "service already loaded" failure.
+      spawnReport(["launchctl", "bootout", launchdDomain(), plistPath]);
+      loadResult = spawnReport(loadCommand);
+    }
+    return { platform: plat, shimPath, schedulerPath: plistPath, intervalSeconds: opts.intervalSeconds, loadCommand, loadResult };
+  }
+
+  // Linux: systemd user units.
+  const timerPath = opts.systemdTimerOverride ?? SYSTEMD_TIMER_PATH;
+  const servicePath = opts.systemdServiceOverride ?? SYSTEMD_SERVICE_PATH;
+
+  const serviceContents = renderTemplate(readTemplate(templateRoot, `systemd/${SYSTEMD_SERVICE_UNIT}.tmpl`), subs);
+  const timerContents = renderTemplate(readTemplate(templateRoot, `systemd/${SYSTEMD_TIMER_UNIT}.tmpl`), subs);
+  writeFileWithDir(servicePath, serviceContents, 0o600);
+  writeFileWithDir(timerPath, timerContents, 0o600);
+
+  const loadCommand = ["systemctl", "--user", "enable", "--now", SYSTEMD_TIMER_UNIT];
+  let loadResult: EnableResult["loadResult"];
+  if (!opts.skipLoad) {
+    spawnReport(["systemctl", "--user", "daemon-reload"]);
+    // Restart so a changed --interval takes effect on re-enable; `enable
+    // --now` alone leaves an already-running timer on its old schedule.
+    loadResult = spawnReport(loadCommand);
+    if (loadResult.code === 0) spawnReport(["systemctl", "--user", "restart", SYSTEMD_TIMER_UNIT]);
+  }
+  return { platform: plat, shimPath, schedulerPath: timerPath, intervalSeconds: opts.intervalSeconds, loadCommand, loadResult };
+}
+
+/** Removes the scheduler entry. Peer records and sync history are untouched. */
+export function disableScheduler(opts: DisableOpts = {}): DisableResult {
+  const plat = detectPlatform(opts.platformOverride);
+  const removed: string[] = [];
+
+  if (plat === "darwin") {
+    const plistPath = opts.launchdPlistOverride ?? LAUNCHD_PLIST_PATH;
+    const unloadCommand = ["launchctl", "bootout", launchdDomain(), plistPath];
+    let unloadResult: DisableResult["unloadResult"];
+    if (existsSync(plistPath)) {
+      if (!opts.skipUnload) {
+        unloadResult = spawnReport(unloadCommand);
+      }
+      rmSync(plistPath, { force: true });
+      removed.push(plistPath);
+    }
+    if (opts.removeShim) {
+      const shim = opts.shimPathOverride ?? SHIM_PATH_DEFAULT;
+      if (existsSync(shim)) {
+        rmSync(shim, { force: true });
+        removed.push(shim);
+      }
+    }
+    return { platform: plat, removed, unloadCommand, unloadResult };
+  }
+
+  const timerPath = opts.systemdTimerOverride ?? SYSTEMD_TIMER_PATH;
+  const servicePath = opts.systemdServiceOverride ?? SYSTEMD_SERVICE_PATH;
+  const unloadCommand = ["systemctl", "--user", "disable", "--now", SYSTEMD_TIMER_UNIT];
+  let unloadResult: DisableResult["unloadResult"];
+  if (existsSync(timerPath) || existsSync(servicePath)) {
+    if (!opts.skipUnload) {
+      unloadResult = spawnReport(unloadCommand);
+      spawnReport(["systemctl", "--user", "daemon-reload"]);
+    }
+    if (existsSync(timerPath)) { rmSync(timerPath, { force: true }); removed.push(timerPath); }
+    if (existsSync(servicePath)) { rmSync(servicePath, { force: true }); removed.push(servicePath); }
+  }
+  if (opts.removeShim) {
+    const shim = opts.shimPathOverride ?? SHIM_PATH_DEFAULT;
+    if (existsSync(shim)) {
+      rmSync(shim, { force: true });
+      removed.push(shim);
+    }
+  }
+  return { platform: plat, removed, unloadCommand, unloadResult };
+}
+
+// ─── Status ─────────────────────────────────────────────────────────────────
+
+export interface SchedulerStatus {
+  platform: SchedulerPlatform;
+  /** Whether the scheduler entry files were written to disk. */
+  installed: boolean;
+  /**
+   * Whether the service manager genuinely has the job loaded/active — NOT
+   * inferred from file presence (flair#850). `null` when the query itself was
+   * inconclusive or was explicitly skipped.
+   */
+  active: boolean | null;
+  /**
+   * The interval read back OUT of the installed unit, not out of the caller's
+   * flags — status must describe what is installed, not what someone meant to
+   * install. `null` when nothing is installed or the value can't be parsed.
+   */
+  intervalSeconds: number | null;
+  schedulerPath: string;
+  shimPath: string;
+  shimExists: boolean;
+}
+
+export interface SchedulerStatusOpts {
+  platformOverride?: SchedulerPlatform;
+  shimPathOverride?: string;
+  launchdPlistOverride?: string;
+  systemdTimerOverride?: string;
+  systemdServiceOverride?: string;
+  /** Skip the launchctl/systemctl active-state query (testing). */
+  skipActiveCheck?: boolean;
+}
+
+function activeCheckCommand(plat: SchedulerPlatform): string[] {
+  if (plat === "darwin") {
+    return ["launchctl", "print", `${launchdDomain()}/${LAUNCHD_LABEL}`];
+  }
+  return ["systemctl", "--user", "is-active", SYSTEMD_TIMER_UNIT];
+}
+
+function queryActiveState(plat: SchedulerPlatform): boolean | null {
+  const [cmd, ...args] = activeCheckCommand(plat);
+  const r = spawnReport([cmd, ...args], STATUS_CHECK_TIMEOUT_MS);
+  return interpretActiveResult(plat, r.code, r.stdout, r.stderr);
+}
+
+/**
+ * Reads the configured interval back out of an installed unit file.
+ *
+ * Exported for testing, and deliberately parses the file rather than trusting
+ * a remembered value: an operator who hand-edits the plist has changed the
+ * real schedule, and status should say what is actually installed.
+ */
+export function parseInstalledInterval(plat: SchedulerPlatform, unitText: string): number | null {
+  const m = plat === "darwin"
+    ? /<key>\s*StartInterval\s*<\/key>\s*<integer>\s*(\d+)\s*<\/integer>/.exec(unitText)
+    : /^\s*OnUnitActiveSec\s*=\s*(\d+)s\s*$/m.exec(unitText);
+  if (!m) return null;
+  const n = Number(m[1]);
+  return Number.isFinite(n) && n > 0 ? n : null;
+}
+
+export function schedulerStatus(opts: SchedulerStatusOpts = {}): SchedulerStatus {
+  const plat = detectPlatform(opts.platformOverride);
+  const shimPath = opts.shimPathOverride ?? SHIM_PATH_DEFAULT;
+
+  let schedulerPath: string;
+  let installed: boolean;
+  if (plat === "darwin") {
+    schedulerPath = opts.launchdPlistOverride ?? LAUNCHD_PLIST_PATH;
+    installed = existsSync(schedulerPath);
+  } else {
+    schedulerPath = opts.systemdTimerOverride ?? SYSTEMD_TIMER_PATH;
+    const servicePath = opts.systemdServiceOverride ?? SYSTEMD_SERVICE_PATH;
+    installed = existsSync(schedulerPath) && existsSync(servicePath);
+  }
+
+  let intervalSeconds: number | null = null;
+  if (installed) {
+    try {
+      intervalSeconds = parseInstalledInterval(plat, readFileSync(schedulerPath, "utf-8"));
+    } catch {
+      intervalSeconds = null;
+    }
+  }
+
+  let active: boolean | null;
+  if (!installed) {
+    active = false; // nothing written — definitely nothing active
+  } else if (opts.skipActiveCheck) {
+    active = null; // caller opted out — unknown, not a claim either way
+  } else {
+    active = queryActiveState(plat);
+  }
+
+  return {
+    platform: plat,
+    installed,
+    active,
+    intervalSeconds,
+    schedulerPath,
+    shimPath,
+    shimExists: existsSync(shimPath),
+  };
+}
+
+// ─── Driver assessment ──────────────────────────────────────────────────────
+// The point of the whole feature. `flair federation status` used to warn "no
+// peer has merged in >24h" whether the cause was an unreachable peer or the
+// complete absence of anything running sync. Those need opposite actions, so
+// the warning named the wrong problem roughly half the time it fired.
+//
+// Two INDEPENDENT signals disambiguate them:
+//   - the service manager     → is a Flair-managed driver loaded?
+//   - peer.lastSyncAt         → has ANY sync contacted a peer recently?
+// Neither alone is sufficient. The driver check alone would call a hand-rolled
+// cron "no driver"; the timestamp alone cannot tell "never started" from
+// "started, can't reach the peer".
+
+export type DriverVerdict =
+  /** Managed driver loaded, and syncs are landing. */
+  | "driving"
+  /** Managed driver loaded, but nothing has reached a peer in the window. */
+  | "driver-stalled"
+  /** Unit files on disk, but the service manager does not have them loaded. */
+  | "driver-inactive"
+  /** No managed driver — but syncs ARE landing, so something else drives it. */
+  | "external-driver"
+  /** No managed driver and nothing has synced. THE bug this issue is about. */
+  | "no-driver"
+  /** The service-manager query itself was inconclusive. */
+  | "unknown";
+
+export interface DriverAssessmentInput {
+  installed: boolean;
+  active: boolean | null;
+  intervalSeconds: number | null;
+  /**
+   * The most recent peer CONTACT across all peers (max of peer.lastSyncAt).
+   * Contact, not merge: a sync that reaches the peer and legitimately has
+   * nothing to send still proves the driver ran. Gating on lastMergeAt here
+   * would re-create the original bug in a new place — an idle-but-healthy
+   * federation would read as "nothing is driving sync".
+   */
+  lastSyncAt: string | null;
+  now: number;
+}
+
+export interface DriverAssessment {
+  verdict: DriverVerdict;
+  /** A Flair-managed driver is loaded in the service manager. */
+  driverActive: boolean;
+  /** At least one peer was contacted inside the freshness window. */
+  contactFresh: boolean;
+  freshnessWindowMs: number;
+  headline: string;
+  detail: string;
+  /** What to run to fix it, or null when nothing needs fixing. */
+  remedy: string | null;
+}
+
+/** Freshness window when no managed interval is known (nothing installed). */
+export const DEFAULT_FRESHNESS_MS = 3_600_000;
+
+/**
+ * How long peer silence has to last before it counts as "not syncing".
+ *
+ * Three consecutive missed cycles — one miss is a blip, three is a pattern —
+ * with a five-minute floor so a tight interval doesn't produce a hair trigger
+ * that fires on a single slow run.
+ */
+export function freshnessWindowMs(intervalSeconds: number | null): number {
+  if (intervalSeconds == null) return DEFAULT_FRESHNESS_MS;
+  return Math.max(intervalSeconds * 3 * 1000, 300_000);
+}
+
+function humanAge(ms: number): string {
+  if (ms < 60_000) return "<1m";
+  if (ms < 3_600_000) return `${Math.floor(ms / 60_000)}m`;
+  if (ms < 86_400_000) return `${Math.floor(ms / 3_600_000)}h`;
+  return `${Math.floor(ms / 86_400_000)}d`;
+}
+
+const LOG_HINT = "~/.flair/logs/federation-sync.stderr.log";
+
+export function assessDriver(input: DriverAssessmentInput): DriverAssessment {
+  const windowMs = freshnessWindowMs(input.intervalSeconds);
+  const t = input.lastSyncAt ? Date.parse(input.lastSyncAt) : NaN;
+  const haveContact = Number.isFinite(t);
+  const contactAgeMs = haveContact ? input.now - t : Number.POSITIVE_INFINITY;
+  const contactFresh = haveContact && contactAgeMs <= windowMs;
+  const driverActive = input.installed && input.active === true;
+  const agoText = haveContact ? `${humanAge(contactAgeMs)} ago` : "never";
+  const everyText = input.intervalSeconds ? `every ${input.intervalSeconds}s` : "on its installed schedule";
+
+  const base = { driverActive, contactFresh, freshnessWindowMs: windowMs };
+
+  // Inconclusive service-manager query — say so rather than guessing. Note
+  // this is checked BEFORE driverActive: `active === null` can never satisfy
+  // `active === true`, so without this branch an inconclusive query would be
+  // silently reported as "no driver".
+  if (input.installed && input.active === null) {
+    return {
+      ...base,
+      verdict: "unknown",
+      headline: "Sync driver: installed, but its state could not be read",
+      detail:
+        `The scheduler unit is on disk, but querying the service manager was inconclusive, ` +
+        `so whether it is actually loaded is unknown. Last peer contact: ${agoText}.`,
+      remedy: "flair federation sync status",
+    };
+  }
+
+  if (driverActive) {
+    if (contactFresh) {
+      return {
+        ...base,
+        verdict: "driving",
+        headline: `Sync driver: active (${everyText})`,
+        detail: `Last peer contact ${agoText}.`,
+        remedy: null,
+      };
+    }
+    return {
+      ...base,
+      verdict: "driver-stalled",
+      headline: `Sync driver: active (${everyText}) — but no peer contact in ${humanAge(windowMs)}`,
+      detail:
+        `Sync IS scheduled and the service manager has it loaded, so this is not a missing driver — ` +
+        `the runs themselves are failing to reach a peer (unreachable endpoint, expired credential, ` +
+        `or a revoked pairing). Last peer contact: ${agoText}.`,
+      remedy: `flair federation reachability   # then check ${LOG_HINT}`,
+    };
+  }
+
+  // No managed driver from here down.
+  if (contactFresh) {
+    return {
+      ...base,
+      verdict: "external-driver",
+      headline: "Sync driver: none managed by Flair — but syncs are landing",
+      detail:
+        `No Flair-managed scheduler is loaded, yet a peer was contacted ${agoText}. Something else is ` +
+        `driving sync — a cron entry, a hand-written unit, or a \`flair federation watch\` session. ` +
+        `Nothing is broken; enable the managed driver only if you want Flair to own it.`,
+      remedy: null,
+    };
+  }
+
+  if (input.installed) {
+    return {
+      ...base,
+      verdict: "driver-inactive",
+      headline: "Sync driver: INSTALLED BUT NOT LOADED — nothing is running federation sync",
+      detail:
+        `The scheduler unit is on disk but the service manager does not have it loaded, so it never ` +
+        `fires. Last peer contact: ${agoText}.`,
+      remedy: "flair federation sync enable",
+    };
+  }
+
+  return {
+    ...base,
+    verdict: "no-driver",
+    headline: "Sync driver: NONE — nothing is running federation sync",
+    detail:
+      `\`flair federation sync\` is one-shot and \`flair federation watch\` only runs while its terminal ` +
+      `is open, so a paired spoke syncs once and then stops. Last peer contact: ${agoText}.`,
+    remedy: "flair federation sync enable",
+  };
+}
+
+// ─── Report formatting ──────────────────────────────────────────────────────
+
+export interface FormattedReport {
+  lines: string[];
+  /** false means the caller should signal failure (nonzero exit). */
+  ok: boolean;
+}
+
+/**
+ * Formats the `flair federation sync enable` report. Owns the
+ * success-vs-failure decision (flair#850: never print a success headline
+ * before activation is known to have succeeded), extracted from the CLI
+ * action so it is unit-testable without spawning launchctl/systemctl.
+ */
+export function formatEnableReport(r: EnableResult, input: { adminPassFile?: string; target?: string }): FormattedReport {
+  const activationFailed = !!r.loadResult && r.loadResult.code !== 0;
+  const credLine = input.adminPassFile
+    ? `   Credential:  ${input.adminPassFile} ${"(path only — the password is never written into the unit)"}`
+    : `   Credential:  none configured — sync will use the CLI's default auth resolution`;
+
+  if (activationFailed) {
+    const lr = r.loadResult!;
+    const lines = [
+      `⚠️  Federation sync driver files written but NOT activated (${r.platform})`,
+      `   Interval:    every ${r.intervalSeconds}s — NOT scheduled (see below)`,
+      `   Scheduler:   ${r.schedulerPath}`,
+      `   Shim:        ${r.shimPath}`,
+      credLine,
+    ];
+    if (input.target) lines.push(`   Target:      ${input.target}`);
+    lines.push(`   Activation:  ${r.loadCommand.join(" ")} → code ${lr.code}`);
+    if (lr.stderr) lines.push(`     stderr: ${lr.stderr.trim()}`);
+    const remedy = describeLoadFailureFor(r.platform, lr, "flair federation sync enable");
+    lines.push("");
+    lines.push(remedy ? `   ${remedy}` : `   Re-run the activation command above manually to see the full diagnostic.`);
+    lines.push("");
+    lines.push(`   Nothing is scheduled until activation succeeds. Check anytime with: flair federation sync status`);
+    return { lines, ok: false };
+  }
+
+  const lines = [
+    `✅ Federation sync driver enabled (${r.platform})`,
+    `   Interval:    every ${r.intervalSeconds}s`,
+    `   Scheduler:   ${r.schedulerPath}`,
+    `   Shim:        ${r.shimPath}`,
+    credLine,
+  ];
+  if (input.target) lines.push(`   Target:      ${input.target}`);
+  if (r.loadResult) lines.push(`   Load:        ${r.loadCommand.join(" ")} → ok`);
+  lines.push("");
+  lines.push(`The first sync runs immediately. Confirm with \`flair federation status\`,`);
+  lines.push(`which now reports whether anything is actually driving sync.`);
+  lines.push(`Disable with \`flair federation sync disable\`.`);
+  return { lines, ok: true };
+}
+
+/** Formats the `flair federation sync status` report. */
+export function formatStatusReport(s: SchedulerStatus, a: DriverAssessment): FormattedReport {
+  const activeTxt = s.active === true ? "yes" : s.active === false ? "no" : "unknown";
+  const lines = [
+    `Federation sync driver (${s.platform}):`,
+    `  Active:      ${activeTxt}`,
+    `  Installed:   ${s.installed ? "yes" : "no"}`,
+    `  Interval:    ${s.intervalSeconds ? `every ${s.intervalSeconds}s` : "—"}`,
+    `  Scheduler:   ${s.schedulerPath}`,
+    `  Shim:        ${s.shimPath}${s.shimExists ? "" : " (missing)"}`,
+    "",
+    `  ${a.headline}`,
+    `  ${a.detail}`,
+  ];
+  if (a.remedy) {
+    lines.push("");
+    lines.push(`  Run: ${a.remedy}`);
+  }
+  // Status is informational — it does not itself signal process failure.
+  // `ok` reflects only whether the headline claims a working driver.
+  return { lines, ok: a.verdict !== "driver-stalled" && a.verdict !== "driver-inactive" && a.verdict !== "no-driver" };
+}

--- a/src/lib/scheduler-platform.ts
+++ b/src/lib/scheduler-platform.ts
@@ -1,0 +1,150 @@
+/**
+ * Platform-scheduler primitives shared by every Flair-managed background job.
+ *
+ * Two modules install user-session scheduler entries today:
+ *   - src/rem/scheduler.ts        (`flair rem nightly enable`)
+ *   - src/federation/scheduler.ts (`flair federation sync enable`)
+ *
+ * They differ in what they schedule and how often; they do NOT differ in how
+ * you ask launchd/systemd whether a job is really loaded, how you read the
+ * answer, or how you render a template into a unit file. This module exists so
+ * there is exactly ONE implementation of those — same reason src/lib/xml-escape.ts
+ * exists (#918): the second copy of a subtle rule is where it goes wrong.
+ *
+ * `interpretActiveResult()` in particular encodes a production lesson
+ * (flair#850) that took a real outage to learn. It must not be re-derived.
+ */
+import { existsSync, mkdirSync, writeFileSync, readFileSync } from "node:fs";
+import { resolve, dirname } from "node:path";
+import { platform } from "node:os";
+import { spawnSync, type SpawnSyncReturns } from "node:child_process";
+
+export type SchedulerPlatform = "darwin" | "linux";
+
+/**
+ * 30s ceiling on launchctl/systemctl invocations so a hung service manager
+ * can't block the CLI indefinitely. Sherlock #415 follow-up.
+ */
+export const SPAWN_TIMEOUT_MS = 30_000;
+
+/**
+ * Status-check spawns (launchctl print / systemctl is-active) return
+ * near-instantly when the service manager is reachable, and fail fast (no
+ * hang) when it isn't (e.g. "Failed to connect to bus"). A short ceiling
+ * keeps status commands and the Health endpoint responsive even when the
+ * query is inconclusive.
+ */
+export const STATUS_CHECK_TIMEOUT_MS = 5_000;
+
+export interface SpawnReport {
+  code: number | null;
+  stdout: string;
+  stderr: string;
+}
+
+export function detectPlatform(label: string, override?: SchedulerPlatform): SchedulerPlatform {
+  if (override) return override;
+  const p = platform();
+  if (p === "darwin") return "darwin";
+  if (p === "linux") return "linux";
+  throw new Error(`unsupported platform for ${label}: ${p} (only darwin and linux)`);
+}
+
+export function spawnReport(cmd: string[], timeoutMs: number = SPAWN_TIMEOUT_MS): SpawnReport {
+  const r: SpawnSyncReturns<Buffer> = spawnSync(cmd[0], cmd.slice(1), {
+    encoding: "buffer",
+    timeout: timeoutMs,
+  });
+  return {
+    code: r.status,
+    stdout: r.stdout?.toString("utf-8") ?? "",
+    stderr: r.stderr?.toString("utf-8") ?? "",
+  };
+}
+
+/**
+ * Interprets the result of a `launchctl print` / `systemctl --user is-active`
+ * probe. Shared by the sync (CLI) and async (server) callers of both
+ * schedulers.
+ *
+ * - true  — the service manager confirms the job is loaded/active.
+ * - false — confirmed NOT active. This includes the "no session bus" case
+ *   (flair#850): when `systemctl --user` can't reach a bus, it fails
+ *   before printing a status word ("Failed to connect to bus: No medium
+ *   found") — but nothing CAN be running without a bus, so `false` is the
+ *   honest answer, not "unknown".
+ * - null  — genuinely inconclusive (the command itself couldn't run at
+ *   all — e.g. the binary is missing — with no output to interpret).
+ */
+export function interpretActiveResult(
+  plat: SchedulerPlatform,
+  code: number | null,
+  stdout: string,
+  stderr: string,
+): boolean | null {
+  const noOutput = !stdout.trim() && !stderr.trim();
+  if (plat === "darwin") {
+    if (code === 0) return true;
+    if (code === null && noOutput) return null; // spawn itself failed — inconclusive
+    return false; // launchctl ran and reported not-loaded
+  }
+  const out = stdout.trim();
+  if (out === "active" || out === "activating") return true;
+  if (out === "inactive" || out === "failed" || out === "unknown") return false;
+  if (code === null && noOutput) return null; // spawn itself failed — inconclusive
+  return false; // covers the no-bus case: empty stdout, nonzero/failed exit
+}
+
+/**
+ * Human remedy text for a failed scheduler-load attempt (flair#850). Covers
+ * the one root cause traced so far: a missing systemd user session bus,
+ * which blocks `systemctl --user` entirely in ssh-without-lingering,
+ * container, and CI contexts. Returns null when the failure doesn't match a
+ * known pattern — the caller already prints the raw stderr, so the operator
+ * still has something to go on.
+ *
+ * `enableCommand` is the caller's own enable invocation, named in the remedy
+ * so the operator is told to re-run the command they actually ran.
+ */
+export function describeLoadFailure(
+  plat: SchedulerPlatform,
+  loadResult: { code: number | null; stderr: string },
+  enableCommand: string,
+): string | null {
+  const stderr = loadResult.stderr || "";
+  if (plat === "linux" && /failed to connect to bus/i.test(stderr)) {
+    return (
+      "No systemd user session bus is available in this session (common over ssh without lingering, " +
+      "in containers, or under CI). Fix: enable lingering for this user — `loginctl enable-linger <user>` " +
+      `— then re-run \`${enableCommand}\`.`
+    );
+  }
+  return null;
+}
+
+/** Single-pass `{{KEY}}` substitution, with a per-value escape hook. */
+export function renderTemplateWith(
+  text: string,
+  subs: Record<string, string>,
+  escape: (value: string) => string,
+): string {
+  return text.replace(/\{\{([A-Z_]+)\}\}/g, (_, key) => {
+    const value = subs[key];
+    if (value === undefined) throw new Error(`unknown template placeholder: ${key}`);
+    return escape(String(value));
+  });
+}
+
+export function readTemplate(rootDir: string, relativePath: string): string {
+  const full = resolve(rootDir, relativePath);
+  if (!existsSync(full)) {
+    throw new Error(`template not found: ${full}`);
+  }
+  return readFileSync(full, "utf-8");
+}
+
+export function writeFileWithDir(path: string, contents: string, mode: number = 0o600): void {
+  const dir = dirname(path);
+  if (!existsSync(dir)) mkdirSync(dir, { recursive: true, mode: 0o700 });
+  writeFileSync(path, contents, { mode });
+}

--- a/src/rem/scheduler.ts
+++ b/src/rem/scheduler.ts
@@ -15,18 +15,35 @@
  */
 import { existsSync, mkdirSync, writeFileSync, readFileSync, chmodSync, rmSync, statSync } from "node:fs";
 import { resolve, dirname, join } from "node:path";
-import { homedir, platform } from "node:os";
-import { spawn, spawnSync, type SpawnSyncReturns } from "node:child_process";
+import { homedir } from "node:os";
+import { spawn } from "node:child_process";
 import { fileURLToPath } from "node:url";
 import { escapeXml } from "../lib/xml-escape.js";
+import {
+  type SchedulerPlatform,
+  detectPlatform as detectPlatformFor,
+  spawnReport,
+  readTemplate as readTemplateFrom,
+  renderTemplateWith,
+  writeFileWithDir,
+  interpretActiveResult,
+  describeLoadFailure as describeLoadFailureFor,
+  SPAWN_TIMEOUT_MS,
+  STATUS_CHECK_TIMEOUT_MS,
+} from "../lib/scheduler-platform.js";
+
+// Re-exported so this module's public surface is unchanged by the extraction
+// into src/lib/scheduler-platform.ts (a second scheduler — `flair federation
+// sync enable` — needs the identical launchctl/systemctl interpretation, and
+// flair#850's lesson must have exactly one implementation).
+export { interpretActiveResult };
+export type { SchedulerPlatform };
 
 export const SHIM_PATH_DEFAULT = resolve(homedir(), ".flair", "bin", "flair-rem-nightly");
 export const LAUNCHD_PLIST_PATH = resolve(homedir(), "Library", "LaunchAgents", "dev.flair.rem.nightly.plist");
 export const SYSTEMD_USER_DIR = resolve(homedir(), ".config", "systemd", "user");
 export const SYSTEMD_TIMER_PATH = resolve(SYSTEMD_USER_DIR, "flair-rem-nightly.timer");
 export const SYSTEMD_SERVICE_PATH = resolve(SYSTEMD_USER_DIR, "flair-rem-nightly.service");
-
-export type SchedulerPlatform = "darwin" | "linux";
 
 export interface SchedulerSubstitutions {
   /** Absolute path to the flair binary the shim should invoke. */
@@ -98,11 +115,7 @@ export interface DisableResult {
 }
 
 function detectPlatform(override?: SchedulerPlatform): SchedulerPlatform {
-  if (override) return override;
-  const p = platform();
-  if (p === "darwin") return "darwin";
-  if (p === "linux") return "linux";
-  throw new Error(`unsupported platform for REM nightly scheduler: ${p} (only darwin and linux)`);
+  return detectPlatformFor("REM nightly scheduler", override);
 }
 
 function defaultTemplateRoot(): string {
@@ -122,7 +135,7 @@ function defaultTemplateRoot(): string {
 }
 
 export function renderTemplate(text: string, subs: SchedulerSubstitutions): string {
-  return renderTemplateWith(text, subs, (v) => v);
+  return renderTemplateWith(text, { ...subs }, (v) => v);
 }
 
 /**
@@ -143,27 +156,11 @@ export function renderTemplate(text: string, subs: SchedulerSubstitutions): stri
  * escaping would be corruption rather than a fix.
  */
 export function renderPlistTemplate(text: string, subs: SchedulerSubstitutions): string {
-  return renderTemplateWith(text, subs, escapeXml);
-}
-
-function renderTemplateWith(
-  text: string,
-  subs: SchedulerSubstitutions,
-  escape: (value: string) => string,
-): string {
-  return text.replace(/\{\{([A-Z_]+)\}\}/g, (_, key) => {
-    const value = (subs as any)[key];
-    if (value === undefined) throw new Error(`unknown template placeholder: ${key}`);
-    return escape(String(value));
-  });
+  return renderTemplateWith(text, { ...subs }, escapeXml);
 }
 
 export function readTemplate(rootDir: string, relativePath: string): string {
-  const full = resolve(rootDir, relativePath);
-  if (!existsSync(full)) {
-    throw new Error(`template not found: ${full}`);
-  }
-  return readFileSync(full, "utf-8");
+  return readTemplateFrom(rootDir, relativePath);
 }
 
 /**
@@ -197,35 +194,6 @@ function buildSubstitutions(opts: EnableOpts, shimPath: string, flairBin: string
   };
 }
 
-function writeFileWithDir(path: string, contents: string, mode: number = 0o600): void {
-  const dir = dirname(path);
-  if (!existsSync(dir)) mkdirSync(dir, { recursive: true, mode: 0o700 });
-  writeFileSync(path, contents, { mode });
-}
-
-// 30s ceiling on launchctl/systemctl invocations so a hung service manager
-// can't block the CLI indefinitely. Sherlock #415 follow-up.
-const SPAWN_TIMEOUT_MS = 30_000;
-
-// Status-check spawns (launchctl print / systemctl is-active) return
-// near-instantly when the service manager is reachable, and fail fast (no
-// hang) when it isn't (e.g. "Failed to connect to bus"). A short ceiling
-// keeps `flair rem nightly status` and the Health endpoint responsive even
-// when the query is inconclusive.
-const STATUS_CHECK_TIMEOUT_MS = 5_000;
-
-function spawnReport(cmd: string[], timeoutMs: number = SPAWN_TIMEOUT_MS): { code: number | null; stdout: string; stderr: string } {
-  const r: SpawnSyncReturns<Buffer> = spawnSync(cmd[0], cmd.slice(1), {
-    encoding: "buffer",
-    timeout: timeoutMs,
-  });
-  return {
-    code: r.status,
-    stdout: r.stdout?.toString("utf-8") ?? "",
-    stderr: r.stderr?.toString("utf-8") ?? "",
-  };
-}
-
 /**
  * Command to genuinely query the platform scheduler's active/loaded state
  * for a given install (as opposed to the shape of `loadCommand`, which
@@ -237,33 +205,6 @@ function activeCheckCommand(plat: SchedulerPlatform): string[] {
     return ["launchctl", "print", `gui/${process.getuid?.() ?? ""}/dev.flair.rem.nightly`];
   }
   return ["systemctl", "--user", "is-active", "flair-rem-nightly.timer"];
-}
-
-/**
- * Interprets the result of `activeCheckCommand()`. Shared by the sync
- * (CLI) and async (server) callers.
- *
- * - true  — the service manager confirms the job is loaded/active.
- * - false — confirmed NOT active. This includes the "no session bus" case
- *   (flair#850): when `systemctl --user` can't reach a bus, it fails
- *   before printing a status word ("Failed to connect to bus: No medium
- *   found") — but nothing CAN be running without a bus, so `false` is the
- *   honest answer, not "unknown".
- * - null  — genuinely inconclusive (the command itself couldn't run at
- *   all — e.g. the binary is missing — with no output to interpret).
- */
-export function interpretActiveResult(plat: SchedulerPlatform, code: number | null, stdout: string, stderr: string): boolean | null {
-  const noOutput = !stdout.trim() && !stderr.trim();
-  if (plat === "darwin") {
-    if (code === 0) return true;
-    if (code === null && noOutput) return null; // spawn itself failed — inconclusive
-    return false; // launchctl ran and reported not-loaded
-  }
-  const out = stdout.trim();
-  if (out === "active" || out === "activating") return true;
-  if (out === "inactive" || out === "failed" || out === "unknown") return false;
-  if (code === null && noOutput) return null; // spawn itself failed — inconclusive
-  return false; // covers the no-bus case: empty stdout, nonzero/failed exit
 }
 
 /**
@@ -321,15 +262,7 @@ export async function queryActiveStateAsync(plat: SchedulerPlatform, timeoutMs: 
  * still has something to go on.
  */
 export function describeLoadFailure(plat: SchedulerPlatform, loadResult: { code: number | null; stderr: string }): string | null {
-  const stderr = loadResult.stderr || "";
-  if (plat === "linux" && /failed to connect to bus/i.test(stderr)) {
-    return (
-      "No systemd user session bus is available in this session (common over ssh without lingering, " +
-      "in containers, or under CI). Fix: enable lingering for this user — `loginctl enable-linger <user>` " +
-      "— then re-run `flair rem nightly enable`."
-    );
-  }
-  return null;
+  return describeLoadFailureFor(plat, loadResult, "flair rem nightly enable");
 }
 
 export interface EnableReportInput {

--- a/templates/bin/flair-federation-sync.sh.tmpl
+++ b/templates/bin/flair-federation-sync.sh.tmpl
@@ -1,0 +1,28 @@
+#!/bin/sh
+# Flair federation sync driver shim.
+# Deployed by `flair federation sync enable` to {{SHIM_PATH}}.
+# Invoked by launchd (macOS) or systemd (Linux) every {{INTERVAL_SECONDS}}s.
+#
+# One-shot by design: every run is a fresh, fully bounded process. See
+# src/federation/scheduler.ts for why this is a periodic one-shot rather than
+# a supervised long-lived watcher.
+#
+# The admin password is NEVER written into the scheduler unit. The unit
+# carries FLAIR_ADMIN_PASS_FILE — a PATH — and the CLI reads the file itself
+# through readAdminPassFileSecure(), which refuses anything not owner-only.
+# Passing the path (not the value) also keeps it out of `ps`.
+#
+# Logs land in {{HOME}}/.flair/logs/federation-sync.{stdout,stderr}.log.
+set -e
+
+if [ -n "${FLAIR_TARGET:-}" ]; then
+  set -- --target "${FLAIR_TARGET}"
+else
+  set --
+fi
+
+if [ -n "${FLAIR_ADMIN_PASS_FILE:-}" ] && [ -f "${FLAIR_ADMIN_PASS_FILE}" ]; then
+  set -- "$@" --admin-pass-file "${FLAIR_ADMIN_PASS_FILE}"
+fi
+
+exec "{{FLAIR_BIN}}" federation sync "$@"

--- a/templates/launchd/dev.flair.federation.sync.plist.tmpl
+++ b/templates/launchd/dev.flair.federation.sync.plist.tmpl
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+  "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>dev.flair.federation.sync</string>
+
+  <key>ProgramArguments</key>
+  <array>
+    <string>{{SHIM_PATH}}</string>
+  </array>
+
+  <!-- Periodic one-shot. NOT KeepAlive: the sync carries no state between
+       runs, and KeepAlive restarts a process that exits while doing nothing
+       for one that hangs. See src/federation/scheduler.ts. -->
+  <key>StartInterval</key>
+  <integer>{{INTERVAL_SECONDS}}</integer>
+
+  <!-- Sync once as soon as the job is loaded, so `enable` visibly works
+       instead of leaving the operator waiting out a whole interval. -->
+  <key>RunAtLoad</key>
+  <true/>
+
+  <key>StandardOutPath</key>
+  <string>{{HOME}}/.flair/logs/federation-sync.stdout.log</string>
+
+  <key>StandardErrorPath</key>
+  <string>{{HOME}}/.flair/logs/federation-sync.stderr.log</string>
+
+  <key>WorkingDirectory</key>
+  <string>{{HOME}}</string>
+
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>HOME</key>
+    <string>{{HOME}}</string>
+    <key>PATH</key>
+    <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
+    <!-- A PATH to the password file, never the password. -->
+    <key>FLAIR_ADMIN_PASS_FILE</key>
+    <string>{{ADMIN_PASS_FILE}}</string>
+    <key>FLAIR_TARGET</key>
+    <string>{{FLAIR_TARGET}}</string>
+  </dict>
+</dict>
+</plist>

--- a/templates/systemd/flair-federation-sync.service.tmpl
+++ b/templates/systemd/flair-federation-sync.service.tmpl
@@ -1,0 +1,21 @@
+[Unit]
+Description=Flair federation sync (one-shot, driven by flair-federation-sync.timer)
+After=network-online.target
+
+[Service]
+# Type=oneshot, not a Restart=always long-lived watcher: the sync carries no
+# state between runs, and every network call inside it is bounded by its own
+# timeout, so a run always terminates and the timer always gets to fire the
+# next one. See src/federation/scheduler.ts.
+Type=oneshot
+ExecStart={{SHIM_PATH}}
+# A PATH to the password file, never the password.
+Environment=FLAIR_ADMIN_PASS_FILE={{ADMIN_PASS_FILE}}
+Environment=FLAIR_TARGET={{FLAIR_TARGET}}
+StandardOutput=append:{{HOME}}/.flair/logs/federation-sync.stdout.log
+StandardError=append:{{HOME}}/.flair/logs/federation-sync.stderr.log
+
+# No [Install] section: this unit is started by flair-federation-sync.timer,
+# which is what `flair federation sync enable` enables. A WantedBy here would
+# only invite someone to enable the service directly and get exactly one sync
+# per boot.

--- a/templates/systemd/flair-federation-sync.timer.tmpl
+++ b/templates/systemd/flair-federation-sync.timer.tmpl
@@ -1,0 +1,16 @@
+[Unit]
+Description=Flair federation sync timer (every {{INTERVAL_SECONDS}}s)
+
+[Timer]
+# Sync shortly after the timer starts (enable, and every boot thereafter), so
+# `enable` visibly works instead of leaving the operator waiting out a whole
+# interval. The launchd side gets this from RunAtLoad.
+OnActiveSec=10s
+# Then repeat, measured from the END of the previous run — a slow sync delays
+# the next one rather than overlapping with it.
+OnUnitActiveSec={{INTERVAL_SECONDS}}s
+AccuracySec=30s
+Unit=flair-federation-sync.service
+
+[Install]
+WantedBy=timers.target

--- a/test/unit/federation-scheduler.test.ts
+++ b/test/unit/federation-scheduler.test.ts
@@ -1,0 +1,646 @@
+/**
+ * federation-scheduler.test.ts — unit tests for src/federation/scheduler.ts
+ * (`flair federation sync enable|disable|status`, flair#922).
+ *
+ * SAFETY: every test writes into a fresh temp dir passed through the
+ * *Override options, and every enable/disable passes skipLoad/skipUnload. No
+ * test touches ~/Library/LaunchAgents, ~/.config/systemd, ~/.flair, or runs
+ * launchctl/systemctl against the real user domain. Credential fixtures are
+ * PATHS to placeholder files — never a real secret.
+ *
+ * Deliberately placed in test/unit/ rather than beside test/rem-scheduler.test.ts:
+ * CI's unit lane runs `bun test test/unit/`, so the repo-root test files are
+ * not gated by it (see the report on this PR).
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, rmSync, readFileSync, writeFileSync, existsSync, statSync, mkdirSync } from "node:fs";
+import { join, resolve } from "node:path";
+import { tmpdir } from "node:os";
+import { execFileSync } from "node:child_process";
+import {
+  renderTemplate,
+  renderPlistTemplate,
+  enableScheduler,
+  disableScheduler,
+  schedulerStatus,
+  parseInstalledInterval,
+  validateInterval,
+  assessDriver,
+  freshnessWindowMs,
+  formatEnableReport,
+  formatStatusReport,
+  DEFAULT_INTERVAL_SECONDS,
+  MIN_INTERVAL_SECONDS,
+  MAX_INTERVAL_SECONDS,
+  type FederationSchedulerSubstitutions,
+  type EnableOpts,
+  type EnableResult,
+  type SchedulerStatus,
+  type DriverAssessmentInput,
+} from "../../src/federation/scheduler.ts";
+
+let testRoot: string;
+let home: string;
+let shimPath: string;
+let plistPath: string;
+let timerPath: string;
+let servicePath: string;
+let passFile: string;
+let templateRoot: string;
+
+beforeEach(() => {
+  testRoot = mkdtempSync(join(tmpdir(), "flair-fed-scheduler-test-"));
+  home = join(testRoot, "home");
+  mkdirSync(home, { recursive: true });
+  shimPath = join(testRoot, "bin", "flair-federation-sync");
+  plistPath = join(testRoot, "LaunchAgents", "dev.flair.federation.sync.plist");
+  timerPath = join(testRoot, "systemd", "flair-federation-sync.timer");
+  servicePath = join(testRoot, "systemd", "flair-federation-sync.service");
+  // A PATH fixture only. The scheduler must never read or copy the contents.
+  passFile = join(testRoot, "admin-pass");
+  writeFileSync(passFile, "PLACEHOLDER-not-a-real-password\n", { mode: 0o600 });
+  templateRoot = resolve(import.meta.dir, "..", "..", "templates");
+});
+
+afterEach(() => {
+  rmSync(testRoot, { recursive: true, force: true });
+});
+
+function baseOpts(overrides: Partial<EnableOpts> = {}): EnableOpts {
+  return {
+    intervalSeconds: 300,
+    flairBin: "/usr/local/bin/flair",
+    shimPathOverride: shimPath,
+    launchdPlistOverride: plistPath,
+    systemdTimerOverride: timerPath,
+    systemdServiceOverride: servicePath,
+    homeOverride: home,
+    templateRootOverride: templateRoot,
+    skipLoad: true,
+    ...overrides,
+  };
+}
+
+const sampleSubs: FederationSchedulerSubstitutions = {
+  FLAIR_BIN: "/usr/local/bin/flair",
+  SHIM_PATH: "/Users/test/.flair/bin/flair-federation-sync",
+  HOME: "/Users/test",
+  INTERVAL_SECONDS: "300",
+  ADMIN_PASS_FILE: "/Users/test/.flair/admin-pass",
+  FLAIR_TARGET: "",
+};
+
+// ─── plist parsing (a malformed plist is silently never registered) ──────────
+
+function have(cmd: string): boolean {
+  try {
+    execFileSync(cmd, ["--version"], { stdio: "pipe" });
+    return true;
+  } catch (e: any) {
+    return e?.code !== "ENOENT";
+  }
+}
+const HAS_PLUTIL = have("plutil");
+const HAS_PYTHON = have("python3");
+const PY_DUMP = "import plistlib,json,sys;json.dump(plistlib.load(open(sys.argv[1],'rb')),sys.stdout)";
+
+/** Key-order-independent canonical form — plutil and plistlib disagree on order. */
+function canonical(v: any): any {
+  if (Array.isArray(v)) return v.map(canonical);
+  if (v && typeof v === "object") {
+    const out: Record<string, any> = {};
+    for (const k of Object.keys(v).sort()) out[k] = canonical(v[k]);
+    return out;
+  }
+  return v;
+}
+
+/**
+ * Parse the plist with every real parser available and return the decoded
+ * document. Throws if none is available rather than skipping — a parse check
+ * that silently degrades into nothing still reads green.
+ */
+function parsePlist(plistText: string): any {
+  const path = join(testRoot, "probe.plist");
+  writeFileSync(path, plistText);
+  const seen: any[] = [];
+  if (HAS_PLUTIL) {
+    execFileSync("plutil", ["-lint", path], { stdio: "pipe" });
+    seen.push(JSON.parse(execFileSync("plutil", ["-convert", "json", "-o", "-", path], { encoding: "utf-8" })));
+  }
+  if (HAS_PYTHON) {
+    seen.push(JSON.parse(execFileSync("python3", ["-c", PY_DUMP, path], { encoding: "utf-8", stdio: "pipe" })));
+  }
+  if (seen.length === 0) {
+    throw new Error("no plist parser available (need plutil or python3) — refusing to skip a parse check");
+  }
+  for (const doc of seen) {
+    expect(JSON.stringify(canonical(doc))).toBe(JSON.stringify(canonical(seen[0])));
+  }
+  return seen[0];
+}
+
+/** Unit-file directives only — assertions about shape must not match prose in comments. */
+function directives(unitText: string): string {
+  return unitText
+    .split("\n")
+    .filter((l) => !l.trimStart().startsWith("#"))
+    .join("\n");
+}
+
+describe("renderTemplate / renderPlistTemplate", () => {
+  it("substitutes placeholders", () => {
+    expect(renderTemplate("every {{INTERVAL_SECONDS}}s", sampleSubs)).toBe("every 300s");
+  });
+
+  it("throws on an unknown placeholder", () => {
+    expect(() => renderTemplate("{{NOPE}}", sampleSubs)).toThrow(/unknown template placeholder: NOPE/);
+  });
+
+  it("XML-escapes into the plist but NOT into systemd/shim renders (#918)", () => {
+    const subs = { ...sampleSubs, HOME: "/Users/a&b" };
+    expect(renderPlistTemplate("{{HOME}}", subs)).toBe("/Users/a&amp;b");
+    expect(renderTemplate("{{HOME}}", subs)).toBe("/Users/a&b");
+  });
+});
+
+// ─── enable ─────────────────────────────────────────────────────────────────
+
+describe("enableScheduler (darwin)", () => {
+  it("writes a shim and a plist that PARSES, with the periodic-one-shot shape", () => {
+    const r = enableScheduler(baseOpts({ platformOverride: "darwin", adminPassFile: passFile }));
+    expect(r.platform).toBe("darwin");
+    expect(r.schedulerPath).toBe(plistPath);
+    expect(r.intervalSeconds).toBe(300);
+    expect(existsSync(shimPath)).toBe(true);
+    expect(existsSync(plistPath)).toBe(true);
+    expect(statSync(shimPath).mode & 0o777).toBe(0o700);
+
+    const doc = parsePlist(readFileSync(plistPath, "utf-8"));
+    expect(doc.Label).toBe("dev.flair.federation.sync");
+    expect(doc.ProgramArguments).toEqual([shimPath]);
+    // The strategy decision, asserted: periodic one-shot, not a supervised
+    // long-lived watcher.
+    expect(doc.StartInterval).toBe(300);
+    expect(doc.KeepAlive).toBeUndefined();
+    // Sync immediately on enable so the operator sees it work.
+    expect(doc.RunAtLoad).toBe(true);
+    expect(doc.EnvironmentVariables.FLAIR_ADMIN_PASS_FILE).toBe(passFile);
+    expect(readFileSync(plistPath, "utf-8")).not.toContain("{{");
+  });
+
+  it("puts the PASSWORD FILE PATH in the unit and never the password", () => {
+    enableScheduler(baseOpts({ platformOverride: "darwin", adminPassFile: passFile }));
+    const secret = readFileSync(passFile, "utf-8").trim();
+    for (const p of [plistPath, shimPath]) {
+      expect(readFileSync(p, "utf-8")).not.toContain(secret);
+    }
+    expect(readFileSync(plistPath, "utf-8")).toContain(passFile);
+  });
+
+  it("produces a plist that still parses when HOME contains XML metacharacters", () => {
+    const weird = join(testRoot, "R&D<home>");
+    mkdirSync(weird, { recursive: true });
+    enableScheduler(baseOpts({ platformOverride: "darwin", homeOverride: weird }));
+    const doc = parsePlist(readFileSync(plistPath, "utf-8"));
+    expect(doc.EnvironmentVariables.HOME).toBe(weird);
+  });
+
+  it("is idempotent — re-enabling overwrites in place and changes the interval", () => {
+    enableScheduler(baseOpts({ platformOverride: "darwin", intervalSeconds: 300 }));
+    const first = readFileSync(plistPath, "utf-8");
+    const r2 = enableScheduler(baseOpts({ platformOverride: "darwin", intervalSeconds: 900 }));
+    const second = readFileSync(plistPath, "utf-8");
+
+    expect(r2.intervalSeconds).toBe(900);
+    expect(parsePlist(second).StartInterval).toBe(900);
+    expect(second).not.toBe(first);
+    // Re-enabling at the SAME interval must be byte-identical — no drift, no
+    // accumulated duplication.
+    enableScheduler(baseOpts({ platformOverride: "darwin", intervalSeconds: 900 }));
+    expect(readFileSync(plistPath, "utf-8")).toBe(second);
+    // Still exactly one plist and one shim.
+    expect(existsSync(plistPath)).toBe(true);
+    expect(existsSync(shimPath)).toBe(true);
+  });
+
+  it("does not invoke launchctl when skipLoad=true", () => {
+    const r = enableScheduler(baseOpts({ platformOverride: "darwin" }));
+    expect(r.loadResult).toBeUndefined();
+    expect(r.loadCommand[0]).toBe("launchctl");
+    expect(r.loadCommand).toContain("bootstrap");
+  });
+});
+
+describe("enableScheduler (linux)", () => {
+  it("writes a timer + service with the periodic-one-shot shape", () => {
+    const r = enableScheduler(baseOpts({ platformOverride: "linux", adminPassFile: passFile }));
+    expect(r.platform).toBe("linux");
+    expect(r.schedulerPath).toBe(timerPath);
+    expect(existsSync(timerPath)).toBe(true);
+    expect(existsSync(servicePath)).toBe(true);
+
+    const timer = readFileSync(timerPath, "utf-8");
+    expect(timer).toContain("OnUnitActiveSec=300s");
+    expect(timer).toContain("Unit=flair-federation-sync.service");
+    expect(timer).toContain("WantedBy=timers.target");
+    expect(timer).not.toContain("{{");
+
+    const service = directives(readFileSync(servicePath, "utf-8"));
+    expect(service).toContain("Type=oneshot");
+    // The strategy decision, asserted: no supervised long-lived process.
+    expect(service).not.toContain("Restart=");
+    expect(service).toContain(`ExecStart=${shimPath}`);
+    expect(service).toContain(`Environment=FLAIR_ADMIN_PASS_FILE=${passFile}`);
+    // The timer carries [Install], not the service.
+    expect(service).not.toContain("[Install]");
+    // systemd units must NOT be XML-escaped — escaping there is corruption.
+    expect(service).not.toContain("&amp;");
+    expect(service).not.toContain("{{");
+  });
+
+  it("puts the PASSWORD FILE PATH in the unit and never the password", () => {
+    enableScheduler(baseOpts({ platformOverride: "linux", adminPassFile: passFile }));
+    const secret = readFileSync(passFile, "utf-8").trim();
+    for (const p of [timerPath, servicePath, shimPath]) {
+      expect(readFileSync(p, "utf-8")).not.toContain(secret);
+    }
+  });
+
+  it("is idempotent — re-enabling overwrites in place and changes the interval", () => {
+    enableScheduler(baseOpts({ platformOverride: "linux", intervalSeconds: 300 }));
+    enableScheduler(baseOpts({ platformOverride: "linux", intervalSeconds: 600 }));
+    const timer = readFileSync(timerPath, "utf-8");
+    expect(timer).toContain("OnUnitActiveSec=600s");
+    expect(timer).not.toContain("OnUnitActiveSec=300s");
+    const again = enableScheduler(baseOpts({ platformOverride: "linux", intervalSeconds: 600 }));
+    expect(readFileSync(timerPath, "utf-8")).toBe(timer);
+    expect(again.intervalSeconds).toBe(600);
+  });
+
+  it("does not XML-escape a systemd unit even when a value carries an ampersand", () => {
+    const weird = join(testRoot, "a&b");
+    mkdirSync(weird, { recursive: true });
+    enableScheduler(baseOpts({ platformOverride: "linux", homeOverride: weird }));
+    expect(readFileSync(servicePath, "utf-8")).toContain(`${weird}/.flair/logs/federation-sync.stdout.log`);
+  });
+});
+
+describe("enableScheduler validation", () => {
+  it("rejects an interval below the floor, naming the alternative", () => {
+    expect(() => enableScheduler(baseOpts({ intervalSeconds: 30 }))).toThrow(/interval must be 60-86400 seconds/);
+    expect(() => enableScheduler(baseOpts({ intervalSeconds: 30 }))).toThrow(/federation watch/);
+  });
+
+  it("rejects an interval above the ceiling and a non-integer", () => {
+    expect(() => enableScheduler(baseOpts({ intervalSeconds: MAX_INTERVAL_SECONDS + 1 }))).toThrow(/interval must be/);
+    expect(() => enableScheduler(baseOpts({ intervalSeconds: 300.5 }))).toThrow(/whole number of seconds/);
+  });
+
+  it("accepts the boundaries", () => {
+    expect(() => validateInterval(MIN_INTERVAL_SECONDS)).not.toThrow();
+    expect(() => validateInterval(MAX_INTERVAL_SECONDS)).not.toThrow();
+    expect(DEFAULT_INTERVAL_SECONDS).toBe(300);
+  });
+
+  it("refuses a credential path that does not exist rather than installing a driver that fails every cycle", () => {
+    expect(() => enableScheduler(baseOpts({ adminPassFile: join(testRoot, "nope") }))).toThrow(/does not exist/);
+  });
+});
+
+// ─── the shim ───────────────────────────────────────────────────────────────
+
+describe("shim", () => {
+  it("invokes the one-shot sync and passes the credential FILE PATH, not its contents", () => {
+    enableScheduler(baseOpts({ platformOverride: "darwin", adminPassFile: passFile }));
+    const shim = readFileSync(shimPath, "utf-8");
+    expect(shim).toStartWith("#!/bin/sh");
+    expect(shim).toContain(`exec "/usr/local/bin/flair" federation sync`);
+    expect(shim).toContain("--admin-pass-file");
+    // Never the value.
+    expect(shim).not.toContain("PLACEHOLDER-not-a-real-password");
+    expect(shim).not.toContain("{{");
+  });
+
+  it("is syntactically valid /bin/sh", () => {
+    enableScheduler(baseOpts({ platformOverride: "linux" }));
+    // -n parses without executing. Throws on a syntax error.
+    execFileSync("/bin/sh", ["-n", shimPath], { stdio: "pipe" });
+  });
+});
+
+// ─── disable ────────────────────────────────────────────────────────────────
+
+describe("disableScheduler", () => {
+  it("darwin: removes the plist, preserves the shim by default", () => {
+    enableScheduler(baseOpts({ platformOverride: "darwin" }));
+    const r = disableScheduler({
+      platformOverride: "darwin",
+      launchdPlistOverride: plistPath,
+      shimPathOverride: shimPath,
+      skipUnload: true,
+    });
+    expect(r.removed).toContain(plistPath);
+    expect(existsSync(plistPath)).toBe(false);
+    expect(existsSync(shimPath)).toBe(true);
+  });
+
+  it("darwin: removes the shim with removeShim", () => {
+    enableScheduler(baseOpts({ platformOverride: "darwin" }));
+    const r = disableScheduler({
+      platformOverride: "darwin",
+      launchdPlistOverride: plistPath,
+      shimPathOverride: shimPath,
+      skipUnload: true,
+      removeShim: true,
+    });
+    expect(r.removed).toContain(shimPath);
+    expect(existsSync(shimPath)).toBe(false);
+  });
+
+  it("linux: removes timer AND service", () => {
+    enableScheduler(baseOpts({ platformOverride: "linux" }));
+    const r = disableScheduler({
+      platformOverride: "linux",
+      systemdTimerOverride: timerPath,
+      systemdServiceOverride: servicePath,
+      shimPathOverride: shimPath,
+      skipUnload: true,
+    });
+    expect(r.removed.sort()).toEqual([servicePath, timerPath].sort());
+    expect(existsSync(timerPath)).toBe(false);
+    expect(existsSync(servicePath)).toBe(false);
+  });
+
+  it("is idempotent — disabling twice is a no-op the second time", () => {
+    enableScheduler(baseOpts({ platformOverride: "darwin" }));
+    const opts = {
+      platformOverride: "darwin" as const,
+      launchdPlistOverride: plistPath,
+      shimPathOverride: shimPath,
+      skipUnload: true,
+    };
+    expect(disableScheduler(opts).removed).toContain(plistPath);
+    expect(disableScheduler(opts).removed).toEqual([]);
+  });
+
+  it("enable → disable → status returns to a clean not-installed state", () => {
+    const statusOpts = {
+      platformOverride: "darwin" as const,
+      launchdPlistOverride: plistPath,
+      shimPathOverride: shimPath,
+      skipActiveCheck: true,
+    };
+    enableScheduler(baseOpts({ platformOverride: "darwin" }));
+    expect(schedulerStatus(statusOpts).installed).toBe(true);
+    disableScheduler({ ...statusOpts, skipUnload: true });
+    const after = schedulerStatus(statusOpts);
+    expect(after.installed).toBe(false);
+    expect(after.active).toBe(false);
+    expect(after.intervalSeconds).toBeNull();
+  });
+});
+
+// ─── status: interval readback + no activation-by-file-presence ─────────────
+
+describe("schedulerStatus", () => {
+  it("reads the interval back OUT of the installed unit (darwin)", () => {
+    enableScheduler(baseOpts({ platformOverride: "darwin", intervalSeconds: 420 }));
+    const s = schedulerStatus({
+      platformOverride: "darwin",
+      launchdPlistOverride: plistPath,
+      shimPathOverride: shimPath,
+      skipActiveCheck: true,
+    });
+    expect(s.installed).toBe(true);
+    expect(s.intervalSeconds).toBe(420);
+  });
+
+  it("reads the interval back OUT of the installed unit (linux)", () => {
+    enableScheduler(baseOpts({ platformOverride: "linux", intervalSeconds: 720 }));
+    const s = schedulerStatus({
+      platformOverride: "linux",
+      systemdTimerOverride: timerPath,
+      systemdServiceOverride: servicePath,
+      shimPathOverride: shimPath,
+      skipActiveCheck: true,
+    });
+    expect(s.intervalSeconds).toBe(720);
+  });
+
+  it("does NOT claim active purely because the unit file exists (flair#850)", () => {
+    enableScheduler(baseOpts({ platformOverride: "linux" }));
+    const s = schedulerStatus({
+      platformOverride: "linux",
+      systemdTimerOverride: timerPath,
+      systemdServiceOverride: servicePath,
+      shimPathOverride: shimPath,
+      skipActiveCheck: true,
+    });
+    expect(s.installed).toBe(true);
+    expect(s.active).not.toBe(true);
+    expect(s.active).toBeNull();
+  });
+
+  it("parseInstalledInterval returns null on a unit with no interval", () => {
+    expect(parseInstalledInterval("darwin", "<plist><dict></dict></plist>")).toBeNull();
+    expect(parseInstalledInterval("linux", "[Timer]\nOnCalendar=daily\n")).toBeNull();
+    // Must not accept the OTHER platform's syntax.
+    expect(parseInstalledInterval("linux", "<key>StartInterval</key><integer>300</integer>")).toBeNull();
+  });
+});
+
+// ─── THE core behaviour: telling the three cases apart ───────────────────────
+
+describe("assessDriver — driver present vs absent vs present-but-peer-unreachable", () => {
+  const NOW = Date.parse("2026-07-28T12:00:00.000Z");
+  const ago = (ms: number) => new Date(NOW - ms).toISOString();
+
+  function input(over: Partial<DriverAssessmentInput> = {}): DriverAssessmentInput {
+    return { installed: true, active: true, intervalSeconds: 300, lastSyncAt: ago(60_000), now: NOW, ...over };
+  }
+
+  it("CASE 1 — driver ABSENT and nothing syncing: says nothing is driving sync", () => {
+    const a = assessDriver(input({ installed: false, active: false, intervalSeconds: null, lastSyncAt: ago(5 * 86_400_000) }));
+    expect(a.verdict).toBe("no-driver");
+    expect(a.driverActive).toBe(false);
+    expect(a.headline).toMatch(/nothing is running federation sync/i);
+    expect(a.remedy).toBe("flair federation sync enable");
+    // Must NOT send the operator after the peer.
+    expect(a.remedy).not.toMatch(/reachability/);
+  });
+
+  it("CASE 1b — never synced at all (the freshly-paired spoke) is also no-driver", () => {
+    const a = assessDriver(input({ installed: false, active: false, intervalSeconds: null, lastSyncAt: null }));
+    expect(a.verdict).toBe("no-driver");
+    expect(a.detail).toMatch(/never/);
+  });
+
+  it("CASE 2 — driver PRESENT and syncs landing: healthy, no remedy", () => {
+    const a = assessDriver(input({ lastSyncAt: ago(60_000) }));
+    expect(a.verdict).toBe("driving");
+    expect(a.driverActive).toBe(true);
+    expect(a.contactFresh).toBe(true);
+    expect(a.remedy).toBeNull();
+    expect(a.headline).toMatch(/every 300s/);
+  });
+
+  it("CASE 3 — driver PRESENT but peer unreachable: blames the peer, NOT a missing scheduler", () => {
+    const a = assessDriver(input({ lastSyncAt: ago(3 * 86_400_000) }));
+    expect(a.verdict).toBe("driver-stalled");
+    expect(a.driverActive).toBe(true);
+    expect(a.contactFresh).toBe(false);
+    expect(a.remedy).toMatch(/reachability/);
+    // The distinction the whole issue is about: never tell someone whose
+    // driver IS running to go enable a driver.
+    expect(a.remedy).not.toMatch(/sync enable/);
+    expect(a.detail).toMatch(/not a missing driver/i);
+  });
+
+  it("CASES 1 and 3 have the SAME peer staleness and DIFFERENT verdicts", () => {
+    const stale = ago(3 * 86_400_000);
+    const absent = assessDriver(input({ installed: false, active: false, intervalSeconds: null, lastSyncAt: stale }));
+    const present = assessDriver(input({ lastSyncAt: stale }));
+    expect(absent.verdict).not.toBe(present.verdict);
+    expect(absent.remedy).not.toBe(present.remedy);
+  });
+
+  it("unit files on disk but the service manager has not loaded them", () => {
+    const a = assessDriver(input({ installed: true, active: false, lastSyncAt: ago(3 * 86_400_000) }));
+    expect(a.verdict).toBe("driver-inactive");
+    expect(a.remedy).toBe("flair federation sync enable");
+    expect(a.headline).toMatch(/INSTALLED BUT NOT LOADED/);
+  });
+
+  it("no managed driver but syncs ARE landing: reports an external driver, does not cry wolf", () => {
+    const a = assessDriver(input({ installed: false, active: false, intervalSeconds: null, lastSyncAt: ago(60_000) }));
+    expect(a.verdict).toBe("external-driver");
+    expect(a.remedy).toBeNull();
+    expect(a.detail).toMatch(/cron|watch/i);
+  });
+
+  it("an inconclusive service-manager query is reported as unknown, never as no-driver", () => {
+    const a = assessDriver(input({ installed: true, active: null, lastSyncAt: ago(3 * 86_400_000) }));
+    expect(a.verdict).toBe("unknown");
+    expect(a.headline).not.toMatch(/NONE/);
+  });
+
+  it("freshness is three intervals with a five-minute floor", () => {
+    expect(freshnessWindowMs(300)).toBe(900_000);
+    expect(freshnessWindowMs(60)).toBe(300_000); // floor, not 180_000
+    expect(freshnessWindowMs(null)).toBe(3_600_000);
+  });
+
+  it("a single missed cycle does not trip the stalled verdict; three do", () => {
+    expect(assessDriver(input({ lastSyncAt: ago(310_000) })).verdict).toBe("driving");
+    expect(assessDriver(input({ lastSyncAt: ago(1_000_000) })).verdict).toBe("driver-stalled");
+  });
+
+  it("an idle-but-healthy federation (contact fresh, nothing to merge) still reads as driving", () => {
+    // Gating on lastMergeAt instead of lastSyncAt would re-create the original
+    // bug here: a spoke with no new memories would report as not-driven.
+    const a = assessDriver(input({ lastSyncAt: ago(30_000) }));
+    expect(a.verdict).toBe("driving");
+  });
+
+  it("an unparseable lastSyncAt is treated as no contact, not as fresh contact", () => {
+    const a = assessDriver(input({ installed: false, active: false, intervalSeconds: null, lastSyncAt: "not-a-date" }));
+    expect(a.contactFresh).toBe(false);
+    expect(a.verdict).toBe("no-driver");
+  });
+});
+
+// ─── report formatting ──────────────────────────────────────────────────────
+
+describe("formatEnableReport (flair#850 — no success headline before activation succeeded)", () => {
+  function result(over: Partial<EnableResult> = {}): EnableResult {
+    return {
+      platform: "linux",
+      shimPath: "/home/test/.flair/bin/flair-federation-sync",
+      schedulerPath: "/home/test/.config/systemd/user/flair-federation-sync.timer",
+      intervalSeconds: 300,
+      loadCommand: ["systemctl", "--user", "enable", "--now", "flair-federation-sync.timer"],
+      ...over,
+    };
+  }
+
+  it("reports success when the load succeeded", () => {
+    const { lines, ok } = formatEnableReport(result({ loadResult: { code: 0, stdout: "", stderr: "" } }), {});
+    expect(ok).toBe(true);
+    expect(lines.join("\n")).toContain("✅ Federation sync driver enabled");
+  });
+
+  it("does NOT print a success headline when activation failed", () => {
+    const { lines, ok } = formatEnableReport(
+      result({ loadResult: { code: 1, stdout: "", stderr: "Failed to connect to bus: No medium found\n" } }),
+      {},
+    );
+    const text = lines.join("\n");
+    expect(ok).toBe(false);
+    expect(text).not.toMatch(/^✅/m);
+    expect(text).toMatch(/NOT activated/);
+    // The remedy names THIS command, not the REM one.
+    expect(text).toContain("loginctl enable-linger");
+    expect(text).toContain("flair federation sync enable");
+    expect(text).not.toContain("rem nightly");
+  });
+
+  it("treats a null exit code (timeout/killed) as failure", () => {
+    expect(formatEnableReport(result({ loadResult: { code: null, stdout: "", stderr: "" } }), {}).ok).toBe(false);
+  });
+
+  it("names the credential file as a path and never claims a password was stored", () => {
+    const { lines } = formatEnableReport(result({ loadResult: { code: 0, stdout: "", stderr: "" } }), {
+      adminPassFile: "/home/test/.flair/admin-pass",
+    });
+    const text = lines.join("\n");
+    expect(text).toContain("/home/test/.flair/admin-pass");
+    expect(text).toContain("path only");
+  });
+});
+
+describe("formatStatusReport", () => {
+  const NOW = Date.parse("2026-07-28T12:00:00.000Z");
+  function status(over: Partial<SchedulerStatus> = {}): SchedulerStatus {
+    return {
+      platform: "linux",
+      installed: true,
+      active: true,
+      intervalSeconds: 300,
+      schedulerPath: "/home/test/.config/systemd/user/flair-federation-sync.timer",
+      shimPath: "/home/test/.flair/bin/flair-federation-sync",
+      shimExists: true,
+      ...over,
+    };
+  }
+
+  it("a healthy driver reports Active: yes and ok", () => {
+    const s = status();
+    const a = assessDriver({ installed: true, active: true, intervalSeconds: 300, lastSyncAt: new Date(NOW - 60_000).toISOString(), now: NOW });
+    const { lines, ok } = formatStatusReport(s, a);
+    expect(ok).toBe(true);
+    expect(lines.join("\n")).toContain("Active:      yes");
+    expect(lines.join("\n")).toContain("Interval:    every 300s");
+  });
+
+  it("no driver reports Active: no, ok=false, and the enable remedy", () => {
+    const s = status({ installed: false, active: false, intervalSeconds: null });
+    const a = assessDriver({ installed: false, active: false, intervalSeconds: null, lastSyncAt: null, now: NOW });
+    const { lines, ok } = formatStatusReport(s, a);
+    const text = lines.join("\n");
+    expect(ok).toBe(false);
+    expect(text).toContain("Active:      no");
+    expect(text).toContain("Run: flair federation sync enable");
+  });
+
+  it("a stalled driver reports Active: yes but is still not ok, and points at the peer", () => {
+    const s = status();
+    const a = assessDriver({ installed: true, active: true, intervalSeconds: 300, lastSyncAt: new Date(NOW - 3 * 86_400_000).toISOString(), now: NOW });
+    const { lines, ok } = formatStatusReport(s, a);
+    const text = lines.join("\n");
+    expect(ok).toBe(false);
+    expect(text).toContain("Active:      yes");
+    expect(text).toMatch(/reachability/);
+  });
+});


### PR DESCRIPTION
Closes #922.

Federation had no automatic driver. `flair federation sync` is one-shot and `flair federation watch` is a foreground loop that dies with its terminal, so a freshly paired spoke synced exactly once and then silently stopped — which presents as a broken pairing rather than as a missing scheduler.

This adds `flair federation sync enable | disable | status`, mirroring `flair rem nightly` in verbs, platform coverage, and reporting rules.

## Strategy: periodic one-shot, not a supervised watcher

Both shapes existed as hand-built, never-shipped scaffolding. This ships exactly one of them, and the argument is not aesthetic:

1. **The watch loop carries no state across iterations.** It is `while (!stopped) { await runFederationSyncOnce(opts); sleep(interval) }` — every cycle re-reads the peer list, re-loads the instance key, and opens fresh connections. A resident process earns its cost when it holds warm state or a persistent connection; this one holds neither. Supervision would buy only the ~300ms of process startup a one-shot pays per cycle — a 0.1% duty cycle at the 300s default.
2. **A supervised watcher's worst failure is invisible.** `KeepAlive` restarts a process that *exits*; it does nothing for one that *hangs*. A hung watcher stops syncing forever while `launchctl list` still shows it running — the exact "looks fine, is dead" shape supervision was supposed to remove. Every network call inside `runFederationSyncOnce` is already bounded by its own `AbortSignal.timeout` (10s ops, 15s query, 45s per batch), so a one-shot always terminates and the scheduler always gets to start the next one.
3. **Crash safety is free.** The sync cursor only advances after a successful push and the hub merges by id, so an interrupted run re-sends rather than losing records. There is no partial-failure state for a supervisor to reason about.

The cost is latency, and `--interval` is the knob (default 300s; floor 60s, below which process startup starts to dominate and systemd's default timer accuracy is a minute anyway). The first sync runs immediately on enable, so the command visibly works.

`flair federation watch` is **not** removed — it is still the right tool for an interactive "watch it sync while I debug this" session. It is simply no longer the answer to "how do I keep this synced".

## `federation status` now says whether anything is driving sync

This is the highest-value part. The old warning — "one or more peers haven't merged a record in >24h" — fired identically whether sync was running and the peer was unreachable, or nothing had run sync since the day you paired. Those need opposite actions.

Two **independent** signals disambiguate them, and neither alone is sufficient: the service manager's view of the driver (timestamps alone cannot tell "never started" from "started, can't reach the peer") and peer contact times (the driver check alone would call a hand-rolled cron "no driver").

| Verdict | Means | Remedy |
|---|---|---|
| `driving` | Managed driver loaded, syncs landing | none |
| `driver-stalled` | Driver **is** running; runs are not reaching the peer | `flair federation reachability`, then the driver log |
| `driver-inactive` | Unit files on disk, service manager never loaded them | `flair federation sync enable` |
| `no-driver` | Nothing has run sync since pairing | `flair federation sync enable` |
| `external-driver` | No managed driver, but syncs **are** landing (cron, hand-written unit) | none — don't cry wolf |
| `unknown` | Service-manager query inconclusive | say so, don't guess |

Freshness is three consecutive missed cycles (one miss is a blip) with a five-minute floor, derived from the interval **read back out of the installed unit** rather than from a remembered value — status should describe what is installed, including after a hand-edit.

Deliberately gated on `lastSyncAt` (contact), not `lastMergeAt` (progress): a sync that reaches the peer and legitimately has nothing to send still proves the driver ran. Gating on merges would re-create the original bug in a new place — an idle-but-healthy federation would read as "nothing is driving sync".

The check is local to the machine running the CLI, so it is **omitted for remote `--target`s** rather than making a confident claim about a host it cannot see.

## Secrets

The scheduler never writes a password into a unit file. It stores the **path** passed to `--admin-pass-file` (defaulting to `~/.flair/admin-pass` when present); the CLI reads it at run time through `readAdminPassFileSecure()`, which refuses any file that is not owner-only. Passing a path rather than a value also keeps it out of `ps`. `--no-credentials` wires none at all. Enable refuses a credential path that does not exist, rather than installing a driver that fails auth every cycle in silence.

This also adds `--admin-pass-file` to `flair federation sync` itself, matching `flair backup`.

## Platform coverage

Both, matching `rem nightly`:

- **macOS** — `~/Library/LaunchAgents/dev.flair.federation.sync.plist`, `StartInterval` + `RunAtLoad`, bootstrapped via `launchctl`. Written through `renderPlistTemplate` so every interpolated value is XML-escaped (#918) — `HOME`, `SHIM_PATH`, `ADMIN_PASS_FILE` and `FLAIR_TARGET` are all arbitrary strings and every one can carry an ampersand.
- **Linux** — `~/.config/systemd/user/flair-federation-sync.{timer,service}`, `OnActiveSec` + `OnUnitActiveSec`, enabled via `systemctl --user`. Deliberately **not** XML-escaped — escaping there is corruption, not a fix.

The systemd service carries no `[Install]` section: the timer is what gets enabled, and an inert `WantedBy` on the service only invites someone to enable it directly and get one sync per boot.

## Shared scheduler primitives

`src/lib/scheduler-platform.ts` now holds the launchd/systemd machinery both schedulers need — most importantly `interpretActiveResult()`, which encodes #850's lesson (a `systemctl --user` that cannot reach a session bus is *not active*, not *unknown*). Duplicating that into a second scheduler is how it would have gone wrong, so this follows the `src/lib/xml-escape.ts` precedent of extracting when a second writer appears. `src/rem/scheduler.ts`'s public API and behaviour are unchanged — its full suite passes untouched.

## Verification

- **Unit lane** (`bun test test/unit/`, what CI runs): **3230 → 3276 pass, 0 fail** — measured against a baseline run on unmodified `origin/main`. The +46 is exactly this PR's new file; no other counts moved.
- `test/unit-isolated/` one process each: 139 pass, 0 fail.
- Repo-root `test/*.test.ts` (includes `rem-scheduler.test.ts`): 250 pass, 0 fail.
- `bunx tsc --noEmit -p tsconfig.check.json`: clean.
- **Exercised for real** against a throwaway `HOME` with a PATH-shimmed `launchctl`: enable → status → disable → status, plus re-enable at a new interval. Verified the emitted plist passes `plutil -lint`, that the credential **path** (never the value) reaches the unit, and that all three driver states report distinctly. Also ran read-only `federation status` against a live paired instance, which correctly reported `external-driver` rather than crying "no driver".
- **Nine mutation checks**, each broken → confirmed failing → restored → confirmed green: invalid unit (3 tests fail), idempotence on both platforms (1 each), disable-removes (3), driver present-vs-absent (6), peer-unreachable-vs-healthy (9), absent-vs-stalled (4), interval readback (2), password-in-unit (4). All caught.

Not run locally: `test/integration/`, e2e, smoke and Docker lanes — they spawn Harper or Docker. CI covers them.

## Notes for review

- The new tests live in `test/unit/` rather than beside `test/rem-scheduler.test.ts`, because CI's unit lane is `bun test test/unit/` — the twelve repo-root `test/*.test.ts` files are not gated by any lane. Worth a follow-up.
- `flair federation sync enable`'s action reads `cmd.optsWithGlobals()`, not the action's own options object. `--admin-pass-file` and `--target` are declared on both the subcommand and its parent, and when a parent declares the same option name commander binds the value to the **parent** — the subcommand's own opts come back `undefined`. Reading only the local opts silently dropped `--admin-pass-file <path>`, which would have installed a driver that failed auth every cycle with no error anywhere. Caught by exercising the CLI for real; a typecheck would never have found it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
