### PR TITLE
feat(in-process): call seam so a Harper app can run N agents with no CLI

### DIFF
--- a/.changelog/unreleased/added-in-process-call-seam.md
+++ b/.changelog/unreleased/added-in-process-call-seam.md
@@ -1,0 +1,26 @@
+- **Flair can now be driven entirely in-process, with per-agent scoping proven.** A Harper
+  application that loads Flair as a sub-component can register any number of agents and act as
+  each of them without a shell, a CLI or an HTTP hop — the shape a Fabric deployment has.
+  `resources/in-process.ts` is the seam: `agentContext(agentId)` builds the context that makes a
+  call act as one specific agent, and `collectionResource(Cls, context)` returns the
+  collection-bound instance Harper requires for a create. Registration goes through the `Agent`
+  resource, so a record gets the full Principal shape rather than a hand-copied literal, and
+  Ed25519 key material can be minted with `node:crypto` alone.
+
+  **The context object is a security boundary.** In-process identity is *asserted, not verified* —
+  there is no signature, no lookup against the `Agent` table and no registration requirement, and
+  `isAdmin` is asserted the same way. That is right for a caller already inside the trust boundary,
+  and it means the context must be built from the app's own server-side state and **never** from
+  request data: an agent id that reaches it from user input is privilege escalation with no error
+  and no trace. Prefer individual agent identities over one shared app identity — a per-agent
+  context costs nothing, while collapsing them loses per-agent attribution and turns N blast radii
+  into one.
+
+  `test/integration/in-process-agents.test.ts` boots a real second Harper application
+  (`test/fixtures/inproc-app`, a copyable reference implementation) and pins all of it: two agents
+  each write a private and a shared memory and neither can read the other's private one by search
+  or by id; claiming another agent's id, naming an unregistered one, or asserting `isAdmin` each
+  succeed exactly as documented; a context-**less** call resolves to Flair's trusted `internal`
+  verdict and reads every agent's private records; and a fresh Harper process over the same storage
+  resolves identical per-agent scope, so attribution is a property of the record rather than of the
+  process that wrote it.

--- a/.changelog/unreleased/fixed-embedding-guide-quickstart-incantation.md
+++ b/.changelog/unreleased/fixed-embedding-guide-quickstart-incantation.md
@@ -1,0 +1,17 @@
+- **Fixed: the Harper-embedding guide's first code sample did not run.** `docs/embedding-in-a-harper-app.md`
+  told readers to build a resource with `new (flair("Memory"))(undefined, ctx)` and then set
+  `h.isCollection = true`. On Harper 5.1.22 that property is a getter with no setter, so the assignment
+  raises `TypeError` under ESM strict mode, and omitting it yields `405 … does not have a post method
+  implemented`. The Quickstart now uses the shipped `collectionResource()` / `agentContext()` helpers, and
+  registration goes through the `Agent` resource rather than a hand-copied raw-table literal.
+
+  Every claim in that guide has now been run end to end against a real Harper with Flair loaded as a
+  **second component**, and the "confirm this yourself before building on it" disclaimer is replaced by
+  the measurements. Two of them were wrong: `getMatch("/Memory")` misses (the slashless form hits), and
+  the registry entry is an object wrapping the class, so `.Resource` is required. Per-agent scoping is
+  confirmed through `SemanticSearch` — not just table search — with real embeddings attached, and the
+  context-less superuser warning is confirmed on both read paths.
+
+  The guide also now states the thing an integrator most needs: **the context object is a security
+  boundary.** In-process identity is asserted, not verified, so it must be built from the app's own
+  server-side state and never from request data — with the cluster consequences spelled out.

--- a/.changelog/unreleased/fixed-in-process-byid-test-determinism.md
+++ b/.changelog/unreleased/fixed-in-process-byid-test-determinism.md
@@ -1,0 +1,9 @@
+- **Fixed: the in-process by-id scoping test picked its target by a coin flip.** It selected "the first
+  private record" from a `search_by_value` on the non-unique `agentId` index. Measured: that operation
+  returns rows in **primary-key order**, and Harper mints `Memory.id` as a random UUID — so once an
+  agent owned more than one private record, which one came back was re-decided on every run. It passed
+  locally and failed in CI on the owner *control*, meaning the cross-agent assertion it exists for
+  never executed in that run. An order-dependent security proof is not a proof. The test now names its
+  target explicitly (the id returned by the write), verifies against storage that the record really is
+  private and owned by the other agent, and then asserts the denial across **every** private record
+  that agent owns rather than one lucky pick.

--- a/.changelog/unreleased/fixed-mcp-tools-collection-binding.md
+++ b/.changelog/unreleased/fixed-mcp-tools-collection-binding.md
@@ -1,0 +1,10 @@
+- **Fixed: the native `/mcp` write tools threw instead of writing.** `memory_store`,
+  `memory_update` (with `preserveHistory`), `flair_workspace_set` and `flair_orgevent` bound their
+  delegated resource by assigning `h.isCollection = true`. On Harper 5.1.22 that property is a
+  getter with no setter, so under ESM's strict mode the assignment raised
+  `TypeError: Cannot set property isCollection … which has only a getter` before the write was
+  ever attempted. All four now go through `collectionResource()`. Read-only tools were unaffected.
+
+  The unit doubles carried a writable `isCollection` field, which accepted the assignment and kept
+  the suite green; they now reproduce Harper's getter-only accessor and private collection flag, so
+  the same mistake fails a test.

--- a/.changelog/unreleased/security-in-process-context-guards.md
+++ b/.changelog/unreleased/security-in-process-context-guards.md
@@ -1,0 +1,18 @@
+- **The in-process API refuses to grant administrator access by accident.** `resolveAgentAuth` tests
+  `tpsAgent` for truthiness, so a missing or empty agent id is indistinguishable from "no identity
+  supplied" — which is flair's trusted `internal` verdict. Measured: `resolveAgentAuth({ request: {
+  tpsAgent: undefined } })` returns `{ kind: "internal" }`, and `allowAdmin()` on that same context
+  returns `true`. An embedding app whose `session.agentId` came back undefined would therefore have
+  gained unfiltered cross-agent reads and writes, plus the admin-only gate, with no error and no log
+  line.
+
+  `resources/in-process.ts` is shaped so that cannot happen: `agentContext(id)` throws
+  `InProcessContextError` on a missing, empty or blank id and takes **no options** (so no
+  caller-influenced object spread into it can escalate); admin and the unfiltered verdict are separate
+  named exports, `adminContext(id)` and `internalContext()`; and `collectionResource(Cls, context)`
+  now requires its context rather than treating omission as `internal`. The privileged paths are the
+  longest ones to type and are greppable by name. These are runtime guards, not type annotations — a
+  plain-JavaScript embedder gets the same protection.
+
+  The hazard itself is pinned as a test alongside the guards, so the guards cannot be simplified away
+  without their justification failing in the same run.

--- a/docs/embedding-in-a-harper-app.md
+++ b/docs/embedding-in-a-harper-app.md
@@ -22,20 +22,19 @@ Embedding *adds* the in-process path; `rest: true` keeps serving MCP clients and
 
 ```javascript
 import { server } from "harper";
+// Flair ships these two helpers so you do not have to get either of them right
+// by hand. They are the whole in-process contract.
+import { agentContext, collectionResource } from "@tpsdev-ai/flair/dist/resources/in-process.js";
 
 // The RESOURCE — carries auth, scoping, visibility, embedding.
 // NOT databases.flair.Memory: that is the raw table, and enforces none of it.
-// Resolve lazily; Harper registers resources asynchronously.
+// Keys carry NO leading slash: get("Memory"), never get("/Memory").
 const flair = (path) => server.resources.get(path).Resource;
 
-// This context says WHICH agent is acting. Never omit it.
-const asAgent = (agentId, { isAdmin = false } = {}) => ({
-  request: { tpsAgent: agentId, tpsAgentIsAdmin: isAdmin },
-});
-
 export async function remember(agentId, content, opts = {}) {
-  const h = new (flair("Memory"))(undefined, asAgent(agentId));
-  h.isCollection = true;                    // collection POST
+  // A create needs a COLLECTION-bound instance. `new Cls(...)` does not give
+  // you one, and cannot be made to — see the note below.
+  const h = await collectionResource(flair("Memory"), agentContext(agentId));
   return h.post({
     agentId,                                // required — an absent one is never filled in
     content,
@@ -44,9 +43,23 @@ export async function remember(agentId, content, opts = {}) {
 }
 ```
 
-> ### ⚠️ `new Memory()` with no context is an administrator
+> ### Why `collectionResource`, and not `new Memory()`
+>
+> A resource's `post()` only works on an instance Harper has marked as a **collection**, and that mark is a *private* field only Harper's own `getResource()` can set. The public `isCollection` is a getter with no setter, so the obvious spelling fails two different ways, neither of which names the cause:
+>
+> ```javascript
+> const h = new (flair("Memory"))(undefined, agentContext(agentId));
+> h.isCollection = true;   // TypeError: Cannot set property isCollection ... which has only a getter
+> h.post({ ... });         // without the line above: 405 "The Memory does not have a post method implemented"
+> ```
+>
+> `collectionResource(Cls, context)` is a two-line wrapper over the supported call — `Cls.getResource({}, context, { isCollection: true })` — and exists so this is written once. **Reads do not need it:** `Cls.get(id, context)` and `Cls.search(query, context)` thread the context themselves.
+
+> ### ⚠️ A resource with no context is an administrator
 >
 > A resource built without a context resolves to Flair's trusted `internal` verdict and runs **unfiltered** — every read unscoped, every write unowned. Silently. No error, no warning, no trace.
+>
+> Measured, not inferred: a context-less `Memory.search()` returns every agent's `private` records, and so does a context-less `SemanticSearch`.
 >
 > Correct for Flair's own maintenance passes. In your app it is a data leak you find months later.
 >
@@ -56,7 +69,7 @@ export async function remember(agentId, content, opts = {}) {
 
 ```javascript
 export async function recall(agentId, query, limit = 5) {
-  const h = new (flair("SemanticSearch"))(undefined, asAgent(agentId));
+  const h = await collectionResource(flair("SemanticSearch"), agentContext(agentId));
   return h.post({ q: query, limit });
 }
 ```
@@ -69,7 +82,20 @@ console.log(await recall("agent-alpha", "deploy schedule"));
 console.log([...server.resources.keys()].sort());   // what Flair registered
 ```
 
-> **Confirm the step-2 lookup on your own instance before building on it.** `server.resources` is a process-global registry keyed by REST path, leading slash stripped. That is read from Harper 5.1.22's source — not from a two-component integration we have run end to end. If `get` returns `undefined`, print the keys as above, or try `server.resources.getMatch("/Memory")`.
+> ### What we measured, so you do not have to
+>
+> Run end to end on **Harper 5.1.22**, from a second component loaded into the same instance — the exact shape above. `test/integration/in-process-agents.test.ts` in the Flair repo is that run, and `test/fixtures/inproc-app` is the component it drives.
+>
+> | Claim | Result |
+> |---|---|
+> | `server.resources.get("Memory")` from another component | Returns an **entry object** `{ Resource, path, exportTypes, hasSubPaths, relativeURL }` — `.Resource` is required, it is not the class itself |
+> | `.Resource` is Flair's resource, not the raw table | Confirmed: prototype chain `Memory → Memory → Resource`, and it is **not** `databases.flair.Memory` |
+> | Key format | **No leading slash.** `get("Memory")` hits; `get("/Memory")` returns `undefined` |
+> | `getMatch` | `getMatch("Memory")` hits. **`getMatch("/Memory")` misses** — do not use the slashed form |
+> | When the lookup becomes valid | Flair's resources were already registered at the app component's **module top level** (55 entries, `Memory` and `Agent` present). The only entry missing at that moment was the app's *own*, still mid-registration. Resolving lazily, as above, is still the advice — it costs nothing and does not depend on component load order |
+> | Per-agent scoping through `SemanticSearch` | Holds. Querying as `agent-beta` for a topic only `agent-alpha` has written returns **beta's own** memory, never alpha's private one — with real 768-dim embeddings attached, not a degraded path |
+> | Cross-agent by-id read | `Memory.get(<beta's private id>)` as alpha returns **404**, never 403 — a denied caller cannot enumerate ids |
+> | Context-less call | Unfiltered across all agents, via both `search` and `SemanticSearch` (see the warning above) |
 
 Handlers return a `Response` for `401`/`403`/`400` rather than throwing — check for one. `Memory.post()` is in-process only; over HTTP the schema exposes `PUT`.
 
@@ -89,24 +115,23 @@ for (const id of ["planner", "researcher", "reviewer"]) {
 
 ### Registering agents, no CLI
 
-Provisioning is the one place you write the **table** rather than the resource. Agent records are infrastructure, not agent-scoped data, and Flair's own just-in-time provisioning does exactly this (`resources/mcp-handler.ts`). The table applies no defaults, so supply the whole shape:
+Go through the `Agent` **resource**, with no context — provisioning is infrastructure work your app has already authorised, and `Agent.post()` fills in the whole Principal shape for you:
 
 ```javascript
-import { databases } from "harper";
-
 export async function registerAgent(id, { publicKey = "pending", admin = false } = {}) {
-  const now = new Date().toISOString();
-  await databases.flair.Agent.put({
+  const h = await collectionResource(flair("Agent"));   // no context ⇒ trusted `internal`
+  return h.post({
     id, name: id, displayName: id,
-    kind: "agent", type: "agent", status: "active",
     publicKey,                            // a placeholder is fine — see below
-    defaultTrustTier: "unverified",
-    admin,
-    ...(admin ? { role: "admin" } : {}),  // role is what actually grants admin
-    createdAt: now, updatedAt: now,
+    runtime: "headless",
+    ...(admin ? { role: "admin", admin: true } : {}),   // role is what actually grants admin
   });
 }
 ```
+
+Verified against a real instance: that lands `kind: "agent"`, `status: "active"`, `displayName`, `admin: false`, `defaultTrustTier: "unverified"`, `type: "agent"`, `createdAt`/`updatedAt` and the federation `originatorInstanceId` stamp — without you naming any of them.
+
+> **Prefer this to `databases.flair.Agent.put()`.** The raw table applies **no** defaults, so a hand-written literal has to reproduce every field above and then stay in step with Flair as the Principal model grows. Records written that way are missing `kind`/`status`/`defaultTrustTier` and read as under-specified Principals in the admin surfaces.
 
 > **`isAdmin()` reads `role === "admin"`, not the `admin` boolean.** They are separate fields and only `role` grants admin rights; set both to keep the record self-consistent. Admin lookups are cached for 60 seconds, so a newly-created admin is not effective immediately.
 
@@ -123,7 +148,9 @@ await registerAgent("remote-worker", { publicKey: raw.toString("hex") });
 
 Flair accepts the public key as 64-char hex, or base64 of the raw 32 bytes.
 
-> **Two traps.** `Agent.put()` on the *resource* strips `publicKey` — key rotation goes through a dedicated path that today needs shell access, so set the key when you create the record. And do **not** call `AgentSeed` in-process: its `post()` requires `request.tpsAgent` to name a real admin, so a context-less internal call gets a 403.
+Both verified end to end: an agent registered this way, with a key its app minted, then authenticated over HTTP with a real `TPS-Ed25519` signature — and a request signed with the *wrong* key was rejected.
+
+> **Two traps.** `Agent.put()` on the *resource* silently strips `publicKey`, so set the key when you **create** the record; to rotate one later, write `databases.flair.Agent.put({ ...existing, publicKey })` on the raw table (which is what `flair agent rotate-key` does through the admin ops API — there is no dedicated endpoint today). And do **not** call `AgentSeed` in-process: although its `allowCreate()` explicitly permits the trusted `internal` verdict, its `post()` then re-checks for a named admin and returns `403 forbidden: admin only` — confirmed by running it.
 
 ---
 
@@ -149,7 +176,38 @@ Flair uses the raw table where it *wants* to bypass its own rules — the federa
 | `{ request: { tpsAgent: "mybot", tpsAgentIsAdmin: true } }` | admin | Unfiltered reads, cross-agent writes |
 | **Nothing** | `internal` | **Trusted. Unfiltered.** See the warning above. |
 
-**In-process callers are inside the trust boundary.** Ed25519 is how agents *outside* the process prove identity; a co-located component is trusted to declare it truthfully, so map your app's authenticated identity onto `tpsAgent` at the boundary. Treat `tpsAgentIsAdmin: true` as you would a root shell — reserve it for provisioning.
+### The context object is a security boundary
+
+**In-process identity is asserted, not verified.** Flair reads `request.tpsAgent` and acts as that agent. There is no signature check, no lookup against the `Agent` table, and no registration requirement — an id that has never been registered acts as an agent immediately. `tpsAgentIsAdmin: true` is asserted exactly the same way, and nothing checks that the named agent is really an admin.
+
+That is deliberate. A co-located caller is already inside the trust boundary and could write `databases.flair.Memory` directly, so demanding a signature from same-process code would be theatre. Ed25519 is how agents *outside* the process prove identity.
+
+The consequence is the single most important line in this guide:
+
+> **Build the context from your own server-side state. Never from request data.**
+>
+> If an agent id can reach `agentContext()` from user input — a body field, a query param, a header you did not verify yourself — that is privilege escalation with **no error, no 403 and no trace**. Authenticate the caller with your own mechanism first, then map the identity *you* established onto `tpsAgent`.
+
+There are exactly two ways to lose the model, from opposite ends. Both are pinned as tests in the Flair repo:
+
+| | |
+|---|---|
+| **By omission** | No context at all ⇒ `internal` ⇒ admin-equivalent, unfiltered. |
+| **By assertion** | An attacker-influenced `agentId`, or a stray `isAdmin: true`, is honoured verbatim. |
+
+### Individual identities, not one app identity
+
+Give every agent its own. A per-agent context costs nothing — no client to construct, no key to load, no per-agent setup, not even a registration. Collapsing N agents onto one shared identity buys you nothing and loses the two things that make the memory model work: **per-agent attribution**, which is what trust grading and provenance are computed from, and **N separate blast radii**, which become one.
+
+### In a cluster
+
+Harper replicates every table in a replicated database unless the table opts out with `@table(replicate: false)`. None of Flair's do. So:
+
+- **The registry replicates.** An agent registered on node A is visible on node B with no coordination. (Replication comes from the *database* being replicated — not from `@export`, which only controls REST exposure. `Memory` carries no `@export` and still replicates.)
+- **Authority is local.** The context is constructed per call, in whichever process handles it. No node asks another who a caller is.
+- **Attribution travels.** `agentId` is a field *on the record*, so a memory written on node A reads back correctly attributed — and correctly scoped — wherever it lands. Verified as far as this can be without a cluster: a fresh Harper process over the same storage resolves identical per-agent scope, so none of it lives in the process that did the writing.
+
+The consequence, stated plainly because someone will ask: **every node running the app is equally trusted**, since each one can assert any identity. That is fine for one application spread across regions — it is a single trust domain by construction. It is **not** fine for running this component beside untrusted co-tenants on the same instance. Co-location *is* the grant.
 
 ---
 

--- a/docs/embedding-in-a-harper-app.md
+++ b/docs/embedding-in-a-harper-app.md
@@ -24,7 +24,7 @@ Embedding *adds* the in-process path; `rest: true` keeps serving MCP clients and
 import { server } from "harper";
 // Flair ships these two helpers so you do not have to get either of them right
 // by hand. They are the whole in-process contract.
-import { agentContext, collectionResource } from "@tpsdev-ai/flair/dist/resources/in-process.js";
+import { agentContext, internalContext, collectionResource } from "@tpsdev-ai/flair/dist/resources/in-process.js";
 
 // The RESOURCE — carries auth, scoping, visibility, embedding.
 // NOT databases.flair.Memory: that is the raw table, and enforces none of it.
@@ -119,7 +119,7 @@ Go through the `Agent` **resource**, with no context — provisioning is infrast
 
 ```javascript
 export async function registerAgent(id, { publicKey = "pending", admin = false } = {}) {
-  const h = await collectionResource(flair("Agent"));   // no context ⇒ trusted `internal`
+  const h = await collectionResource(flair("Agent"), internalContext());   // provisioning is infrastructure, not an agent's write
   return h.post({
     id, name: id, displayName: id,
     publicKey,                            // a placeholder is fine — see below
@@ -174,7 +174,9 @@ Flair uses the raw table where it *wants* to bypass its own rules — the federa
 | `{ request: { tpsAnonymous: true } }` | `anonymous` | Denied everywhere |
 | `{ request: { tpsAgent: "mybot" } }` | `agent` | Scoped to that agent — **use this** |
 | `{ request: { tpsAgent: "mybot", tpsAgentIsAdmin: true } }` | admin | Unfiltered reads, cross-agent writes |
-| **Nothing** | `internal` | **Trusted. Unfiltered.** See the warning above. |
+| **Nothing**, or an empty/missing `tpsAgent` | `internal` | **Trusted. Unfiltered.** See the warning above. |
+
+Build these with `agentContext(id)`, `adminContext(id)` and `internalContext()` rather than by hand — see [below](#the-api-is-built-so-omission-cannot-happen-quietly) for why the hand-written form is a trap.
 
 ### The context object is a security boundary
 
@@ -192,8 +194,28 @@ There are exactly two ways to lose the model, from opposite ends. Both are pinne
 
 | | |
 |---|---|
-| **By omission** | No context at all ⇒ `internal` ⇒ admin-equivalent, unfiltered. |
-| **By assertion** | An attacker-influenced `agentId`, or a stray `isAdmin: true`, is honoured verbatim. |
+| **By omission** | No usable agent id ⇒ `internal` ⇒ admin-equivalent, unfiltered. |
+| **By assertion** | An attacker-influenced `agentId` is honoured verbatim. |
+
+### The API is built so omission cannot happen quietly
+
+`resolveAgentAuth` tests `tpsAgent` for *truthiness*, so a missing or empty id is indistinguishable from "no identity supplied" — which is the trusted, unfiltered verdict. Measured:
+
+```
+resolveAgentAuth({ request: { tpsAgent: undefined } })  ->  { kind: "internal" }
+allowAdmin({ request: { tpsAgent: undefined } })        ->  true
+```
+
+That would turn the most ordinary bug there is — `agentContext(session.agentId)` where the field came back undefined — into silent administrator access. So the helpers refuse rather than default:
+
+| | |
+|---|---|
+| `agentContext(id)` | **Throws** `InProcessContextError` on a missing, empty or blank id. Takes **no options**, so no object spread into it can escalate. |
+| `adminContext(id)` | The *only* way to get admin authority. Same id guard. |
+| `internalContext()` | The *only* way to get the unfiltered verdict. |
+| `collectionResource(Cls, context)` | Context is **required**; omitting it throws rather than granting `internal`. |
+
+The privileged paths are now the longest ones to type, and `git grep "adminContext\|internalContext"` enumerates every deliberate escalation in your codebase. These are runtime guards, not type annotations — a plain-JavaScript embedder gets exactly the same protection.
 
 ### Individual identities, not one app identity
 

--- a/resources/in-process.ts
+++ b/resources/in-process.ts
@@ -6,19 +6,22 @@
  * any co-located application component that loads flair as a sub-component and
  * calls it directly instead of over HTTP.
  *
- * Two things an in-process caller has to get right, both of which are invisible
- * from a resource's own source and neither of which fails in a way that points
- * at the cause:
+ * Three things an in-process caller has to get right, none of which is visible
+ * from a resource's own source and none of which used to fail in a way that
+ * points at the cause:
  *
  * 1. **Identity.** Every flair resource resolves its caller through
  *    resources/agent-auth.ts's `resolveAgentAuth()`, whose FIRST hop is the
  *    `tpsAgent` annotation the HTTP auth middleware stamps on a verified
  *    request. There is no HTTP request in-process, so the caller supplies that
- *    annotation itself — that is `agentContext()` below. A caller that supplies
- *    NOTHING resolves to the trusted `internal` verdict, which reads and writes
- *    UNFILTERED (see `agentContext`'s doc — this is the whole hazard).
+ *    annotation itself — {@link agentContext}.
  *
- * 2. **Collection binding.** A resource's `post()` — the create path — only
+ * 2. **Not accidentally becoming an administrator.** A context with no usable
+ *    agent id resolves to flair's trusted `internal` verdict, which is
+ *    UNFILTERED. See the safety-design block below: this module's API shape is
+ *    built around making that unreachable by accident.
+ *
+ * 3. **Collection binding.** A resource's `post()` — the create path — only
  *    works on a resource instance Harper has marked as a COLLECTION. That mark
  *    is a PRIVATE field (`#isCollection`) set inside Harper's own
  *    `getResource()`; the public `isCollection` is a GETTER WITH NO SETTER on
@@ -28,13 +31,50 @@
  *    `TypeError: Cannot set property isCollection ... which has only a getter`,
  *    and dropping the assignment instead yields
  *    `405 The <X> does not have a post method implemented` from Harper's base
- *    `Resource.post()`. `collectionResource()` below is the one supported way
- *    in: hand `getResource()` an `{ isCollection: true }` option and let Harper
- *    set its own private field.
+ *    `Resource.post()`. {@link collectionResource} is the one supported way in:
+ *    hand `getResource()` an `{ isCollection: true }` option and let Harper set
+ *    its own private field.
  *
- * This module exists so those two facts live in ONE place. flair itself got (2)
- * wrong in four MCP tool paths before this module existed — the same mistake a
- * consumer reading only the resource classes would make.
+ * flair itself got (3) wrong in four MCP tool paths before this module existed —
+ * the same mistake a consumer reading only the resource classes would make.
+ *
+ * ─── SAFETY DESIGN: the dangerous thing has to look dangerous ────────────────
+ *
+ * MEASURED, against the real resolver:
+ *
+ *   resolveAgentAuth({ request: { tpsAgent: undefined } })  ->  { kind: "internal" }
+ *   resolveAgentAuth({ request: { tpsAgent: ""        } })  ->  { kind: "internal" }
+ *   allowAdmin({ request: { tpsAgent: undefined } })        ->  true
+ *
+ * `resolveAgentAuth` tests `tpsAgent` for TRUTHINESS, so a missing or empty id
+ * is indistinguishable from "no identity was supplied at all" — and that is the
+ * trusted verdict. The consequence is that the most ordinary application bug
+ * there is — `agentContext(session.agentId)` where the field is undefined, a
+ * typo'd property, a lookup that found nothing — would not fail closed. It
+ * would silently grant unfiltered cross-agent reads and writes, and pass the
+ * admin-only gate on admin-only resources. No error, no 403, no log line.
+ *
+ * That is the same defect class as a check that cannot fail: **the failure mode
+ * of "I forgot the id" must never be "you are now an administrator."** So:
+ *
+ *   - {@link agentContext} THROWS on a missing, empty or blank id. It is always
+ *     a programming error, and an exception is the only outcome that cannot be
+ *     mistaken for success.
+ *   - {@link agentContext} takes NO options. It is structurally incapable of
+ *     producing an admin context, so spreading a caller-influenced object into
+ *     its arguments cannot escalate.
+ *   - Admin is a SEPARATE, NAMED export ({@link adminContext}), and so is the
+ *     unfiltered maintenance verdict ({@link internalContext}). Both are
+ *     greppable: `git grep -n "adminContext\|internalContext"` enumerates every
+ *     privileged call site in a codebase.
+ *   - {@link collectionResource} REQUIRES a context and throws without one, so
+ *     the privileged path can never be reached by leaving an argument off. The
+ *     dangerous path is now the LONGEST path, not the shortest.
+ *
+ * These guards are runtime, not types, on purpose: an embedding application may
+ * be plain JavaScript, where a `string` parameter annotation buys exactly
+ * nothing. test/integration/in-process-agents.test.ts pins both the guards and
+ * the hazard they exist for, against a real Harper.
  *
  * ── Deliberately dependency-free ─────────────────────────────────────────────
  * No `import { databases } from "harper"` (see resources/memory-visibility.ts
@@ -42,110 +82,131 @@
  * and an embedding app may want them before any table is resolved.
  */
 
-/**
- * ─── THE CONTEXT OBJECT IS A SECURITY BOUNDARY ───────────────────────────────
- *
- * In-process identity is **asserted, not verified**. `resolveAgentAuth()` reads
- * `context.request.tpsAgent` and returns that agent — there is no signature
- * check, no lookup against the `Agent` table, and no registration requirement.
- * `tpsAgentIsAdmin: true` is asserted the same way, and grants unfiltered
- * cross-agent reads and writes.
- *
- * That is the right design, not a gap: a co-located caller is already inside
- * the trust boundary and could write `databases.flair.Memory` directly, so
- * demanding a signature from same-process code would be theatre. Ed25519 exists
- * for callers OUTSIDE the process.
- *
- * The consequence is the single most important thing to get right in an
- * embedding app:
- *
- *   **Build the context from your own server-side state. NEVER from request
- *   data.** If an agent id can reach `agentContext()` from user input — a body
- *   field, a query param, a header your app did not itself verify — that is
- *   privilege escalation with no error, no 403 and no trace. Resolve the caller
- *   with your own authentication first, then map the identity YOU established
- *   onto `tpsAgent`.
- *
- * The two ways to lose the whole model, from opposite ends:
- *   - **By omission** — no context at all resolves to `internal`, which is
- *     admin-equivalent (see {@link agentContext}).
- *   - **By assertion** — an attacker-influenced `agentId`, or a stray
- *     `isAdmin: true`, is honoured verbatim.
- * Both are pinned as tests in test/integration/in-process-agents.test.ts.
- *
- * ── Prefer individual agent identities over one app identity ─────────────────
- * A per-agent context costs nothing: no client to construct, no key to load, no
- * per-agent setup, and (per the above) not even a registration. Collapsing N
- * agents onto one shared identity buys nothing and loses the two things that
- * make the memory model work — per-agent attribution, which is what trust
- * grading and provenance are computed from, and N separate blast radii, which
- * become one. Register the agents anyway: the admin surfaces, federation, and
- * the HTTP path all read those records.
- *
- * ── In a cluster ────────────────────────────────────────────────────────────
- * Harper replicates every table in a replicated database unless the table opts
- * out with `@table(replicate: false)`; none of flair's do. So:
- *   - **The registry replicates.** An agent registered on node A is visible on
- *     node B with no coordination. (Replication comes from the DATABASE being
- *     replicated — not from `@export`, which only controls REST exposure.
- *     `Memory` has no `@export` and still replicates.)
- *   - **Authority is local.** The context is constructed per call, in whichever
- *     process handles it. No node consults another to decide who a caller is.
- *   - **Attribution travels.** `agentId` is a field ON the record, so a memory
- *     written on node A reads back correctly attributed — and correctly scoped
- *     — anywhere the record lands.
- *
- * Therefore **every node running the app is equally trusted**, because each one
- * can assert any identity. That is fine for one application spread across
- * regions — it is a single trust domain by construction. It is NOT fine for
- * running this component beside untrusted co-tenants on the same instance:
- * co-location IS the grant.
- */
+/** The context shape flair resources resolve a caller's identity from. */
+export interface CallContext {
+  request: Record<string, unknown>;
+  [key: string]: unknown;
+}
 
-/** Options for {@link agentContext}. */
-export interface AgentContextOptions {
-  /**
-   * Grant flair-admin authority to this call: unfiltered cross-agent reads and
-   * writes attributed to other agents. Asserted, never checked — nothing
-   * validates that the named agent is actually an admin. Treat exactly as you
-   * would a root shell: provisioning and maintenance only, never a request
-   * handler's default, and never derived from anything a caller supplied.
-   */
-  isAdmin?: boolean;
+/**
+ * Thrown when an in-process call is built in a way that would have silently
+ * escalated. Its own type so a caller can distinguish "I wired this wrong" from
+ * a resource's business-logic refusal (which arrives as a `Response`, not a
+ * throw).
+ */
+export class InProcessContextError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "InProcessContextError";
+  }
+}
+
+/** Reject anything that would resolve to the trusted `internal` verdict, or to a nonsense id. */
+function requireAgentId(agentId: unknown, fnName: string): string {
+  if (typeof agentId !== "string" || agentId.trim() === "") {
+    const got =
+      agentId === undefined ? "undefined"
+      : agentId === null ? "null"
+      : typeof agentId !== "string" ? `a ${typeof agentId}`
+      : agentId === "" ? "an empty string"
+      : "a blank string";
+    throw new InProcessContextError(
+      `${fnName}() requires a non-empty agent id, but received ${got}. ` +
+      "This is refused rather than defaulted because flair resolves a missing or empty " +
+      "tpsAgent to its trusted `internal` verdict, which reads and writes UNFILTERED across " +
+      "every agent and passes the admin-only gate — so returning a context here would have " +
+      "turned a missing id into silent administrator access. Resolve the agent id from your " +
+      "own server-side state before calling, and never from request data.",
+    );
+  }
+  return agentId;
 }
 
 /**
  * The resource context that makes an in-process call act as ONE SPECIFIC agent.
+ * This is the call an application makes; the other two constructors below are
+ * privileged and deliberately harder to type.
  *
- * **`agentId` is asserted, not proven — see the security-boundary block above.
- * It must come from your own server-side state, never from request data.**
+ * **`agentId` is asserted, not proven.** flair reads it and acts as that agent:
+ * no signature, no lookup against the `Agent` table, no registration
+ * requirement. That is right for a caller already inside the trust boundary —
+ * it could write the raw table anyway — and it is exactly why the id must come
+ * from YOUR OWN server-side state (the session you authenticated, the job
+ * record you dequeued) and **never from request data**. An agent id that
+ * reaches here from a body field, a query param, or a header you did not verify
+ * yourself is privilege escalation with no error and no trace.
  *
- * Pass the result as the `context` argument of {@link collectionResource}, or as
- * the trailing `context` argument of a Harper static resource method
- * (`Cls.get(id, context)`, `Cls.put(id, record, context)`, …). Every flair
- * resource resolves it through `resolveAgentAuth()`, so the call is scoped,
- * attributed and rate-limited exactly as an Ed25519-signed REST call from that
- * agent would be — including the no-forge check that 403s a write whose
- * `agentId` names a different agent.
+ * Throws {@link InProcessContextError} on a missing, empty or blank id — see the
+ * safety-design block at the top of this file for why that is not merely
+ * defensive.
  *
- * ── OMITTING THE CONTEXT IS NOT A WEAKER CALL, IT IS AN ADMIN CALL ───────────
- * A resource built with no context at all resolves to `{ kind: "internal" }` —
- * flair's trusted in-process verdict — and runs UNFILTERED: every read sees
- * every agent's private records, every write is unattributed. That is correct
- * for flair's own maintenance passes (consolidation, migrations) and it is a
- * silent cross-agent data leak in an application. There is no error, no warning
- * and no log line to find it by.
+ * Takes no options, and in particular no way to ask for admin: use
+ * {@link adminContext} for that, so the escalation is a word you had to type.
  *
- * So in an embedding app: make the agent id a REQUIRED argument of whatever
- * wraps this, and never export a wrapper that defaults it.
+ * ```ts
+ * const Memory = server.resources.get("Memory").Resource;
+ * const h = await collectionResource(Memory, agentContext("planner"));
+ * const { id } = await h.post({ agentId: "planner", content: "…" });
+ * ```
  */
-export function agentContext(agentId: string, opts: AgentContextOptions = {}): any {
+export function agentContext(agentId: string): CallContext {
   return {
     request: {
-      tpsAgent: agentId,
-      tpsAgentIsAdmin: opts.isAdmin === true,
+      tpsAgent: requireAgentId(agentId, "agentContext"),
+      tpsAgentIsAdmin: false,
     },
   };
+}
+
+/**
+ * Like {@link agentContext}, but with flair-admin authority: unfiltered
+ * cross-agent reads, and writes attributed to agents other than this one.
+ *
+ * Asserted, never checked — nothing validates that the named agent is actually
+ * an admin principal. **Treat a call to this exactly as you would a root
+ * shell:** provisioning and maintenance only, never a request handler's
+ * default, and never with an id or a flag derived from anything a caller
+ * supplied.
+ *
+ * It is a separate export rather than an option so that (a) no options object
+ * spread into {@link agentContext} can escalate, and (b) every privileged call
+ * site in a codebase is findable by name.
+ *
+ * Throws {@link InProcessContextError} on a missing, empty or blank id.
+ */
+export function adminContext(agentId: string): CallContext {
+  return {
+    request: {
+      tpsAgent: requireAgentId(agentId, "adminContext"),
+      tpsAgentIsAdmin: true,
+    },
+  };
+}
+
+/**
+ * The TRUSTED, UNATTRIBUTED, UNFILTERED context — flair's `internal` verdict.
+ * Reads see every agent's private records; writes are owned by nobody.
+ *
+ * This exists for work that is genuinely infrastructure rather than an agent's:
+ * provisioning a principal, a migration, a maintenance sweep. It is the same
+ * verdict a context-less call used to fall into by accident; naming it means an
+ * application can no longer reach it by forgetting an argument, and means
+ * `git grep internalContext` enumerates every place flair or an embedder took
+ * that authority deliberately.
+ *
+ * There is no id to validate: the verdict comes precisely from the ABSENCE of
+ * an identity annotation, so the returned object carries none. The marker field
+ * is inert — it documents intent at a debugger breakpoint and is read by
+ * nothing.
+ *
+ * ```ts
+ * // Registering a principal — infrastructure, not an agent's own write.
+ * const h = await collectionResource(Agent, internalContext());
+ * await h.post({ id, name: id, publicKey });
+ * ```
+ */
+export function internalContext(): CallContext {
+  return { request: {}, __flairInternal: true };
 }
 
 /**
@@ -153,25 +214,29 @@ export function agentContext(agentId: string, opts: AgentContextOptions = {}): a
  * `post()` (the create path) works — see this module's header for why that mark
  * cannot be applied from outside Harper.
  *
- * Use it for every in-process CREATE:
- *
- * ```ts
- * const Memory = server.resources.get("Memory").Resource;
- * const h = await collectionResource(Memory, agentContext("planner"));
- * const { id } = await h.post({ agentId: "planner", content: "…" });
- * ```
- *
- * `context` is optional ONLY because flair's own maintenance paths legitimately
- * want the trusted `internal` verdict; omitting it in an application is the
- * admin hazard documented on {@link agentContext}.
+ * `context` is REQUIRED. Passing nothing used to yield the unfiltered
+ * `internal` verdict, which made the privileged path the shortest one to type;
+ * it now throws. Pass {@link agentContext} for an agent's own work,
+ * {@link adminContext} or {@link internalContext} when the authority is
+ * genuinely intended.
  *
  * Reads do not need this — `Cls.get(id, context)` and `Cls.search(query,
  * context)` (Harper's static resource methods) already thread the context and
  * start their own transaction.
  */
-export async function collectionResource<T = any>(Cls: any, context?: any): Promise<T> {
+export async function collectionResource<T = any>(Cls: any, context: CallContext): Promise<T> {
+  if (context == null || typeof context !== "object") {
+    throw new InProcessContextError(
+      "collectionResource() requires an explicit context, but received " +
+      (context === undefined ? "undefined" : context === null ? "null" : `a ${typeof context}`) +
+      ". Omitting it would resolve to flair's trusted `internal` verdict — unfiltered reads and " +
+      "unattributed writes across every agent — so the privileged path is never the one you get " +
+      "by leaving an argument off. Pass agentContext(id) to act as an agent, or internalContext() " +
+      "if this really is infrastructure work.",
+    );
+  }
   // `{}` is a sufficient RequestTarget here: getResource() reads only `.id` off
   // it (undefined ⇒ Harper mints the primary key), and takes the collection
   // mark from the options argument.
-  return (await Cls.getResource({}, context ?? {}, { isCollection: true })) as T;
+  return (await Cls.getResource({}, context, { isCollection: true })) as T;
 }

--- a/resources/in-process.ts
+++ b/resources/in-process.ts
@@ -1,0 +1,177 @@
+/**
+ * ─── The in-process call seam (one incantation, one place) ───────────────────
+ *
+ * How code running INSIDE the Harper process invokes a flair resource AS a
+ * specific agent — flair's own native MCP handler (resources/mcp-tools.ts), and
+ * any co-located application component that loads flair as a sub-component and
+ * calls it directly instead of over HTTP.
+ *
+ * Two things an in-process caller has to get right, both of which are invisible
+ * from a resource's own source and neither of which fails in a way that points
+ * at the cause:
+ *
+ * 1. **Identity.** Every flair resource resolves its caller through
+ *    resources/agent-auth.ts's `resolveAgentAuth()`, whose FIRST hop is the
+ *    `tpsAgent` annotation the HTTP auth middleware stamps on a verified
+ *    request. There is no HTTP request in-process, so the caller supplies that
+ *    annotation itself — that is `agentContext()` below. A caller that supplies
+ *    NOTHING resolves to the trusted `internal` verdict, which reads and writes
+ *    UNFILTERED (see `agentContext`'s doc — this is the whole hazard).
+ *
+ * 2. **Collection binding.** A resource's `post()` — the create path — only
+ *    works on a resource instance Harper has marked as a COLLECTION. That mark
+ *    is a PRIVATE field (`#isCollection`) set inside Harper's own
+ *    `getResource()`; the public `isCollection` is a GETTER WITH NO SETTER on
+ *    `Resource.prototype`. So the obvious `new Cls(undefined, ctx)` +
+ *    `h.isCollection = true` does not "not work" quietly — under ESM (always
+ *    strict mode) the assignment throws
+ *    `TypeError: Cannot set property isCollection ... which has only a getter`,
+ *    and dropping the assignment instead yields
+ *    `405 The <X> does not have a post method implemented` from Harper's base
+ *    `Resource.post()`. `collectionResource()` below is the one supported way
+ *    in: hand `getResource()` an `{ isCollection: true }` option and let Harper
+ *    set its own private field.
+ *
+ * This module exists so those two facts live in ONE place. flair itself got (2)
+ * wrong in four MCP tool paths before this module existed — the same mistake a
+ * consumer reading only the resource classes would make.
+ *
+ * ── Deliberately dependency-free ─────────────────────────────────────────────
+ * No `import { databases } from "harper"` (see resources/memory-visibility.ts
+ * for why that import is load-bearing to avoid): these helpers are pure shape,
+ * and an embedding app may want them before any table is resolved.
+ */
+
+/**
+ * ─── THE CONTEXT OBJECT IS A SECURITY BOUNDARY ───────────────────────────────
+ *
+ * In-process identity is **asserted, not verified**. `resolveAgentAuth()` reads
+ * `context.request.tpsAgent` and returns that agent — there is no signature
+ * check, no lookup against the `Agent` table, and no registration requirement.
+ * `tpsAgentIsAdmin: true` is asserted the same way, and grants unfiltered
+ * cross-agent reads and writes.
+ *
+ * That is the right design, not a gap: a co-located caller is already inside
+ * the trust boundary and could write `databases.flair.Memory` directly, so
+ * demanding a signature from same-process code would be theatre. Ed25519 exists
+ * for callers OUTSIDE the process.
+ *
+ * The consequence is the single most important thing to get right in an
+ * embedding app:
+ *
+ *   **Build the context from your own server-side state. NEVER from request
+ *   data.** If an agent id can reach `agentContext()` from user input — a body
+ *   field, a query param, a header your app did not itself verify — that is
+ *   privilege escalation with no error, no 403 and no trace. Resolve the caller
+ *   with your own authentication first, then map the identity YOU established
+ *   onto `tpsAgent`.
+ *
+ * The two ways to lose the whole model, from opposite ends:
+ *   - **By omission** — no context at all resolves to `internal`, which is
+ *     admin-equivalent (see {@link agentContext}).
+ *   - **By assertion** — an attacker-influenced `agentId`, or a stray
+ *     `isAdmin: true`, is honoured verbatim.
+ * Both are pinned as tests in test/integration/in-process-agents.test.ts.
+ *
+ * ── Prefer individual agent identities over one app identity ─────────────────
+ * A per-agent context costs nothing: no client to construct, no key to load, no
+ * per-agent setup, and (per the above) not even a registration. Collapsing N
+ * agents onto one shared identity buys nothing and loses the two things that
+ * make the memory model work — per-agent attribution, which is what trust
+ * grading and provenance are computed from, and N separate blast radii, which
+ * become one. Register the agents anyway: the admin surfaces, federation, and
+ * the HTTP path all read those records.
+ *
+ * ── In a cluster ────────────────────────────────────────────────────────────
+ * Harper replicates every table in a replicated database unless the table opts
+ * out with `@table(replicate: false)`; none of flair's do. So:
+ *   - **The registry replicates.** An agent registered on node A is visible on
+ *     node B with no coordination. (Replication comes from the DATABASE being
+ *     replicated — not from `@export`, which only controls REST exposure.
+ *     `Memory` has no `@export` and still replicates.)
+ *   - **Authority is local.** The context is constructed per call, in whichever
+ *     process handles it. No node consults another to decide who a caller is.
+ *   - **Attribution travels.** `agentId` is a field ON the record, so a memory
+ *     written on node A reads back correctly attributed — and correctly scoped
+ *     — anywhere the record lands.
+ *
+ * Therefore **every node running the app is equally trusted**, because each one
+ * can assert any identity. That is fine for one application spread across
+ * regions — it is a single trust domain by construction. It is NOT fine for
+ * running this component beside untrusted co-tenants on the same instance:
+ * co-location IS the grant.
+ */
+
+/** Options for {@link agentContext}. */
+export interface AgentContextOptions {
+  /**
+   * Grant flair-admin authority to this call: unfiltered cross-agent reads and
+   * writes attributed to other agents. Asserted, never checked — nothing
+   * validates that the named agent is actually an admin. Treat exactly as you
+   * would a root shell: provisioning and maintenance only, never a request
+   * handler's default, and never derived from anything a caller supplied.
+   */
+  isAdmin?: boolean;
+}
+
+/**
+ * The resource context that makes an in-process call act as ONE SPECIFIC agent.
+ *
+ * **`agentId` is asserted, not proven — see the security-boundary block above.
+ * It must come from your own server-side state, never from request data.**
+ *
+ * Pass the result as the `context` argument of {@link collectionResource}, or as
+ * the trailing `context` argument of a Harper static resource method
+ * (`Cls.get(id, context)`, `Cls.put(id, record, context)`, …). Every flair
+ * resource resolves it through `resolveAgentAuth()`, so the call is scoped,
+ * attributed and rate-limited exactly as an Ed25519-signed REST call from that
+ * agent would be — including the no-forge check that 403s a write whose
+ * `agentId` names a different agent.
+ *
+ * ── OMITTING THE CONTEXT IS NOT A WEAKER CALL, IT IS AN ADMIN CALL ───────────
+ * A resource built with no context at all resolves to `{ kind: "internal" }` —
+ * flair's trusted in-process verdict — and runs UNFILTERED: every read sees
+ * every agent's private records, every write is unattributed. That is correct
+ * for flair's own maintenance passes (consolidation, migrations) and it is a
+ * silent cross-agent data leak in an application. There is no error, no warning
+ * and no log line to find it by.
+ *
+ * So in an embedding app: make the agent id a REQUIRED argument of whatever
+ * wraps this, and never export a wrapper that defaults it.
+ */
+export function agentContext(agentId: string, opts: AgentContextOptions = {}): any {
+  return {
+    request: {
+      tpsAgent: agentId,
+      tpsAgentIsAdmin: opts.isAdmin === true,
+    },
+  };
+}
+
+/**
+ * A resource instance bound to `context` and marked as a COLLECTION, so its
+ * `post()` (the create path) works — see this module's header for why that mark
+ * cannot be applied from outside Harper.
+ *
+ * Use it for every in-process CREATE:
+ *
+ * ```ts
+ * const Memory = server.resources.get("Memory").Resource;
+ * const h = await collectionResource(Memory, agentContext("planner"));
+ * const { id } = await h.post({ agentId: "planner", content: "…" });
+ * ```
+ *
+ * `context` is optional ONLY because flair's own maintenance paths legitimately
+ * want the trusted `internal` verdict; omitting it in an application is the
+ * admin hazard documented on {@link agentContext}.
+ *
+ * Reads do not need this — `Cls.get(id, context)` and `Cls.search(query,
+ * context)` (Harper's static resource methods) already thread the context and
+ * start their own transaction.
+ */
+export async function collectionResource<T = any>(Cls: any, context?: any): Promise<T> {
+  // `{}` is a sufficient RequestTarget here: getResource() reads only `.id` off
+  // it (undefined ⇒ Harper mints the primary key), and takes the collection
+  // mark from the options argument.
+  return (await Cls.getResource({}, context ?? {}, { isCollection: true })) as T;
+}

--- a/resources/mcp-tools.ts
+++ b/resources/mcp-tools.ts
@@ -53,7 +53,7 @@
  */
 import type { RecordTypeName } from "./record-types.js";
 import { resolveVersion } from "./version.js";
-import { agentContext, collectionResource } from "./in-process.js";
+import { agentContext, adminContext, collectionResource } from "./in-process.js";
 
 type HandlerKey = "SemanticSearch" | "Memory" | "BootstrapMemories" | "Soul" | "WorkspaceState" | "OrgEvent" | "AttentionQuery" | "RecordUsage";
 const H: Partial<Record<HandlerKey, any>> = {};
@@ -125,11 +125,17 @@ export interface McpToolDef {
  * agent, never anonymous, never a header re-verify.
  */
 function delegationContext(agent: ResolvedAgent): any {
-  // Shape single-sourced from resources/in-process.ts's agentContext() — the
-  // same context an embedding Harper app builds to act as one of its agents —
-  // plus the `x-tps-agent` header shim the delegated handlers' own
-  // header-reading paths expect.
-  const ctx = agentContext(agent.agentId, { isAdmin: agent.isAdmin });
+  // Shape single-sourced from resources/in-process.ts — the same context an
+  // embedding Harper app builds to act as one of its agents — plus the
+  // `x-tps-agent` header shim the delegated handlers' own header-reading paths
+  // expect.
+  //
+  // The admin branch is spelled out rather than passed as a flag: adminContext()
+  // is the greppable name for "this call carries flair-admin authority". Both
+  // constructors THROW on an empty agent id, which is the outcome we want here —
+  // a token that resolved to no principal must fail the tool call, never fall
+  // through to flair's unfiltered `internal` verdict.
+  const ctx = agent.isAdmin ? adminContext(agent.agentId) : agentContext(agent.agentId);
   ctx.request.headers = {
     get: (k: string) => (k.toLowerCase() === "x-tps-agent" ? agent.agentId : undefined),
   };

--- a/resources/mcp-tools.ts
+++ b/resources/mcp-tools.ts
@@ -53,6 +53,7 @@
  */
 import type { RecordTypeName } from "./record-types.js";
 import { resolveVersion } from "./version.js";
+import { agentContext, collectionResource } from "./in-process.js";
 
 type HandlerKey = "SemanticSearch" | "Memory" | "BootstrapMemories" | "Soul" | "WorkspaceState" | "OrgEvent" | "AttentionQuery" | "RecordUsage";
 const H: Partial<Record<HandlerKey, any>> = {};
@@ -124,16 +125,16 @@ export interface McpToolDef {
  * agent, never anonymous, never a header re-verify.
  */
 function delegationContext(agent: ResolvedAgent): any {
-  return {
-    request: {
-      tpsAgent: agent.agentId,
-      tpsAgentIsAdmin: agent.isAdmin,
-      headers: {
-        get: (k: string) => (k.toLowerCase() === "x-tps-agent" ? agent.agentId : undefined),
-      },
-    },
-    user: undefined,
+  // Shape single-sourced from resources/in-process.ts's agentContext() — the
+  // same context an embedding Harper app builds to act as one of its agents —
+  // plus the `x-tps-agent` header shim the delegated handlers' own
+  // header-reading paths expect.
+  const ctx = agentContext(agent.agentId, { isAdmin: agent.isAdmin });
+  ctx.request.headers = {
+    get: (k: string) => (k.toLowerCase() === "x-tps-agent" ? agent.agentId : undefined),
   };
+  ctx.user = undefined;
+  return ctx;
 }
 
 /**
@@ -175,8 +176,7 @@ async function memorySearch(agent: ResolvedAgent, args: any) {
 
 async function memoryStore(agent: ResolvedAgent, args: any) {
   const Cls = await handler("Memory");
-  const h = new Cls(undefined, delegationContext(agent));
-  (h as any).isCollection = true;
+  const h: any = await collectionResource(Cls, delegationContext(agent));
   // agentId is the RESOLVED agent — Memory.post also re-checks ownership via
   // resolveAgentAuth, so a mismatched body agentId would 403 anyway; we set it
   // to the verified id so the write is correctly owned.
@@ -251,8 +251,10 @@ async function memoryUpdate(agent: ResolvedAgent, args: any) {
     // the resolved OAuth client_id (never forgeable via args) so the NEW
     // version's provenance records which client authored this update.
     if (agent.clientId) record.claimedClient = agent.clientId;
-    (h as any).isCollection = true;
-    return unwrap(await h.post(record));
+    // A create needs a COLLECTION-bound instance (see resources/in-process.ts);
+    // `h` above is the by-id handle the get()/put() branches use.
+    const coll: any = await collectionResource(Cls, delegationContext(agent));
+    return unwrap(await coll.post(record));
   }
 
   const merged: Record<string, unknown> = { ...existing, content, updatedAt: new Date().toISOString() };
@@ -334,8 +336,7 @@ async function soulGet(agent: ResolvedAgent, args: any) {
 
 async function workspaceSet(agent: ResolvedAgent, args: any) {
   const Cls = await handler("WorkspaceState");
-  const h = new Cls(undefined, delegationContext(agent));
-  (h as any).isCollection = true;
+  const h: any = await collectionResource(Cls, delegationContext(agent));
   // No agentId in the body — WorkspaceState.post attributes the record to the
   // authenticated identity (from the context), never the body. Same no-forge
   // contract as the flair-mcp stdio tool.
@@ -354,8 +355,7 @@ async function workspaceSet(agent: ResolvedAgent, args: any) {
 
 async function orgEvent(agent: ResolvedAgent, args: any) {
   const Cls = await handler("OrgEvent");
-  const h = new Cls(undefined, delegationContext(agent));
-  (h as any).isCollection = true;
+  const h: any = await collectionResource(Cls, delegationContext(agent));
   // No authorId in the body — OrgEvent.post attributes to the authenticated
   // identity, never the body (no forging as another agent).
   const body: Record<string, unknown> = { kind: args?.kind, summary: args?.summary };

--- a/test/fixtures/inproc-app/config.yaml
+++ b/test/fixtures/inproc-app/config.yaml
@@ -1,0 +1,16 @@
+# A Harper application that loads Flair as a sub-component and calls it
+# IN-PROCESS — the shape a Fabric deployment with no shell on the node has.
+#
+# The component name must match the directory under `node_modules/` that Harper
+# resolves it from (componentLoader.ts walks up from this directory looking for
+# `node_modules/<componentName>`); the `package:` identifier is only consulted
+# at deploy time. test/integration/in-process-agents.test.ts materialises that
+# symlink against the worktree before starting Harper.
+name: inproc-app
+rest: true
+
+'@tpsdev-ai/flair':
+  package: '@tpsdev-ai/flair'
+
+jsResource:
+  files: resources/*.js

--- a/test/fixtures/inproc-app/package.json
+++ b/test/fixtures/inproc-app/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "inproc-app",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "description": "Test fixture: a Harper application that loads Flair as a sub-component and calls it in-process."
+}

--- a/test/fixtures/inproc-app/resources/AgentFleet.js
+++ b/test/fixtures/inproc-app/resources/AgentFleet.js
@@ -1,0 +1,205 @@
+/**
+ * ─── Reference implementation: N agents, in-process, no CLI and no shell ──────
+ *
+ * This is a component of a SEPARATE Harper application that loads Flair as a
+ * sub-component (see ../config.yaml). Everything below runs inside the Harper
+ * process; nothing shells out, nothing goes over HTTP to Flair, and nothing
+ * touches the filesystem. It is the shape a Fabric deployment has, where there
+ * is no shell on the node at all.
+ *
+ * Copy the three helpers at the top — `flair()`, `registerAgent()`,
+ * `remember()`/`recall()` — into your own component and you have the whole
+ * integration. `test/integration/in-process-agents.test.ts` drives this file
+ * and asserts the properties that make it safe: registration lands a complete
+ * Principal record, every call is attributed to ONE agent, an agent cannot
+ * write as another, and an agent cannot read another's private memories.
+ *
+ * Kept as plain JS (no build step) so it loads through the `jsResource` glob
+ * exactly as a hand-written application component would.
+ */
+import { Resource, server } from "harper";
+// The in-process call seam. Deep-imported from the installed package the same
+// way an application would — Flair ships `dist/`, and this module has no
+// dependencies of its own.
+import { agentContext, collectionResource } from "@tpsdev-ai/flair/dist/resources/in-process.js";
+
+/**
+ * Resolve a Flair RESOURCE by its REST path.
+ *
+ * NOT `databases.flair.Memory` — that is the raw table, and enforces none of
+ * Flair's auth, read-scoping, attribution or embedding. Flair exports a
+ * SUBCLASS of each table as the resource, and Harper registers exported classes
+ * in the routing map only, never back into `databases`.
+ *
+ * Resolved lazily, per call. Measured on Harper 5.1.22: Flair's entries are in
+ * fact already present when THIS module's top level runs (the sub-component
+ * loads first; the only entry missing at that moment is this component's own).
+ * Lazy resolution is kept anyway — it costs one Map lookup and does not depend
+ * on component load order staying that way.
+ *
+ * Registry keys carry NO leading slash: get("Memory"), never get("/Memory").
+ * The same holds for getMatch — getMatch("Memory") hits, getMatch("/Memory")
+ * misses.
+ */
+const flair = (path) => {
+  const entry = server.resources.get(path);
+  if (!entry) throw new Error(`Flair resource '${path}' is not registered (loaded: ${[...server.resources.keys()].sort().join(", ")})`);
+  return entry.Resource;
+};
+
+/**
+ * Register an agent. No CLI, no keystore, no shell.
+ *
+ * Goes through Flair's `Agent` resource (not the raw table) so the record gets
+ * the full Principal shape — kind/status/displayName/admin/defaultTrustTier and
+ * the federation originator stamp — from one source instead of a hand-copied
+ * literal that drifts.
+ *
+ * `publicKey` is required by the schema. An agent that only ever acts
+ * in-process never authenticates, so a placeholder is honest there; supply a
+ * real Ed25519 public key (raw 32 bytes, base64 or hex) when the same agent
+ * must ALSO authenticate over HTTP. Generating that key needs nothing but
+ * `node:crypto` — see the test.
+ */
+async function registerAgent({ id, publicKey = "pending", displayName, runtime = "headless" }) {
+  // No context ⇒ Flair's trusted `internal` verdict. Correct for provisioning,
+  // which is infrastructure work your app has already authorised; never use a
+  // context-less call to read or write on an agent's behalf (see below).
+  const h = await collectionResource(flair("Agent"));
+  return h.post({ id, name: id, displayName: displayName ?? id, publicKey, runtime });
+}
+
+/**
+ * Write a memory AS a specific agent.
+ *
+ * ─── WHERE `agentId` COMES FROM IS THE SECURITY BOUNDARY ─────────────────────
+ * In-process identity is ASSERTED, not verified: Flair reads `tpsAgent` off the
+ * context and acts as that agent. No signature, no lookup, no registration
+ * required. So `agentId` must be resolved from YOUR OWN server-side state — the
+ * session your app authenticated, the job record it dequeued — and NEVER from
+ * request data. An agent id that reaches this function from a body field or a
+ * header your app did not itself verify is privilege escalation with no error
+ * and no trace.
+ *
+ * In THIS fixture it comes straight off the request body, because the test's
+ * whole job is to drive specific identities and prove what each one can and
+ * cannot do. That is the one context in which it is correct. Do not copy that
+ * part.
+ *
+ * `agentId` is also a required argument on purpose: a call with NO context
+ * resolves to `internal` and runs unfiltered — unscoped reads, unattributed
+ * writes. Never default it.
+ */
+async function remember(agentId, { content, durability = "standard", visibility, ownerAgentId, asAdmin }) {
+  // `asAdmin` exists only so the test can prove that admin, like identity, is
+  // ASSERTED — an app never sets it from anything a caller influenced.
+  const h = await collectionResource(flair("Memory"), agentContext(agentId, { isAdmin: asAdmin === true }));
+  // `ownerAgentId` exists only so the test can attempt a forgery — acting as
+  // one agent while claiming another owns the record. Flair 403s that; an
+  // application would simply pass `agentId` and never expose the distinction.
+  const body = { agentId: ownerAgentId ?? agentId, content, durability };
+  if (visibility) body.visibility = visibility;
+  return h.post(body);
+}
+
+/**
+ * Everything `agentId` is allowed to see: its own records, plus every other
+ * agent's non-private ones. Same boundary as `remember` — see its doc for where
+ * `agentId` may and may not come from.
+ */
+async function recall(agentId, { asAdmin } = {}) {
+  const rows = await flair("Memory").search({ conditions: [] }, agentContext(agentId, { isAdmin: asAdmin === true }));
+  return collect(rows);
+}
+
+/**
+ * Semantic recall, scoped to `agentId`. Same boundary as `remember`. This is the
+ * path a real agent loop actually reads through, so it is the one that matters:
+ * a vector index is global, and the scope has to be applied to the results.
+ */
+async function semanticRecall(agentId, q, limit = 20) {
+  const h = await collectionResource(flair("SemanticSearch"), agentContext(agentId));
+  const r = await h.post({ q, limit });
+  if (r instanceof Response) return { status: r.status };
+  const list = r?.results ?? r?.memories ?? r;
+  return Array.isArray(list) ? list.map(summarise) : list;
+}
+
+/** The same semantic read with NO context — see `recallUnscoped`. */
+async function semanticRecallUnscoped(q, limit = 20) {
+  const h = await collectionResource(flair("SemanticSearch"));
+  const r = await h.post({ q, limit });
+  if (r instanceof Response) return { status: r.status };
+  const list = r?.results ?? r?.memories ?? r;
+  return Array.isArray(list) ? list.map(summarise) : list;
+}
+
+/** A single record by id, scoped to `agentId` — another agent's private record reads as absent. */
+async function recallById(agentId, id) {
+  const record = await flair("Memory").get(id, agentContext(agentId));
+  return record && typeof record === "object" && !(record instanceof Response) ? summarise(record) : null;
+}
+
+/**
+ * The same read with NO context. Present so the test can PROVE what the
+ * omission costs — it returns every agent's private records. Never ship this.
+ */
+async function recallUnscoped() {
+  return collect(await flair("Memory").search({ conditions: [] }));
+}
+
+const summarise = (r) => ({ id: r?.id, agentId: r?.agentId, visibility: r?.visibility, content: r?.content });
+
+async function collect(rows) {
+  const out = [];
+  if (!rows) return out;
+  if (rows instanceof Response) return out;
+  if (typeof rows[Symbol.asyncIterator] === "function") { for await (const r of rows) out.push(summarise(r)); return out; }
+  if (typeof rows[Symbol.iterator] === "function") { for (const r of rows) out.push(summarise(r)); return out; }
+  return [summarise(rows)];
+}
+
+/**
+ * Flair handlers return a `Response` for 401/403/400 rather than throwing.
+ * Surface status + body so the caller sees the real refusal.
+ */
+async function run(fn) {
+  try {
+    const value = await fn();
+    if (value instanceof Response) {
+      return { ok: false, status: value.status, body: await value.text().catch(() => "") };
+    }
+    return { ok: true, value: value ?? null };
+  } catch (err) {
+    // Surfaced rather than thrown so a failing assertion in the test reads as
+    // the real cause instead of an opaque 500.
+    return { ok: false, error: String(err?.message ?? err), errorName: err?.name };
+  }
+}
+
+/** POST /AgentFleet {"op": …} — the test's remote control over the code above. */
+export class AgentFleet extends Resource {
+  async post(body) {
+    const op = body?.op;
+    switch (op) {
+      case "registered":
+        return run(() => [...server.resources.keys()].sort());
+      case "register":
+        return run(() => registerAgent(body));
+      case "remember":
+        return run(() => remember(body.agentId, body));
+      case "recall":
+        return run(() => recall(body.agentId, body));
+      case "recallById":
+        return run(() => recallById(body.agentId, body.id));
+      case "semanticRecall":
+        return run(() => semanticRecall(body.agentId, body.q, body.limit));
+      case "semanticRecallUnscoped":
+        return run(() => semanticRecallUnscoped(body.q, body.limit));
+      case "recallUnscoped":
+        return run(() => recallUnscoped());
+      default:
+        return new Response(JSON.stringify({ error: `unknown op '${op}'` }), { status: 400 });
+    }
+  }
+}

--- a/test/fixtures/inproc-app/resources/AgentFleet.js
+++ b/test/fixtures/inproc-app/resources/AgentFleet.js
@@ -21,7 +21,7 @@ import { Resource, server } from "harper";
 // The in-process call seam. Deep-imported from the installed package the same
 // way an application would — Flair ships `dist/`, and this module has no
 // dependencies of its own.
-import { agentContext, collectionResource } from "@tpsdev-ai/flair/dist/resources/in-process.js";
+import { agentContext, adminContext, internalContext, collectionResource } from "@tpsdev-ai/flair/dist/resources/in-process.js";
 
 /**
  * Resolve a Flair RESOURCE by its REST path.
@@ -65,9 +65,18 @@ async function registerAgent({ id, publicKey = "pending", displayName, runtime =
   // No context ⇒ Flair's trusted `internal` verdict. Correct for provisioning,
   // which is infrastructure work your app has already authorised; never use a
   // context-less call to read or write on an agent's behalf (see below).
-  const h = await collectionResource(flair("Agent"));
+  const h = await collectionResource(flair("Agent"), internalContext());
   return h.post({ id, name: id, displayName: displayName ?? id, publicKey, runtime });
 }
+
+/**
+ * Test-only: pick the identity constructor. An application writes
+ * `agentContext(id)` and nothing else — `adminContext()` is a separate, more
+ * alarming name precisely so a flag from elsewhere can never turn an agent call
+ * into an admin one. This fixture branches only so the test can prove that
+ * admin, like identity, is ASSERTED rather than checked.
+ */
+const actingAs = (agentId, asAdmin) => (asAdmin === true ? adminContext(agentId) : agentContext(agentId));
 
 /**
  * Write a memory AS a specific agent.
@@ -86,14 +95,13 @@ async function registerAgent({ id, publicKey = "pending", displayName, runtime =
  * cannot do. That is the one context in which it is correct. Do not copy that
  * part.
  *
- * `agentId` is also a required argument on purpose: a call with NO context
- * resolves to `internal` and runs unfiltered — unscoped reads, unattributed
- * writes. Never default it.
+ * `agentContext()` refuses a missing or empty id rather than defaulting, so
+ * "I forgot the id" fails loudly instead of resolving to Flair's unfiltered
+ * `internal` verdict. An application never has to remember that rule — but it
+ * should still resolve `agentId` before it gets here, not hope for the throw.
  */
 async function remember(agentId, { content, durability = "standard", visibility, ownerAgentId, asAdmin }) {
-  // `asAdmin` exists only so the test can prove that admin, like identity, is
-  // ASSERTED — an app never sets it from anything a caller influenced.
-  const h = await collectionResource(flair("Memory"), agentContext(agentId, { isAdmin: asAdmin === true }));
+  const h = await collectionResource(flair("Memory"), actingAs(agentId, asAdmin));
   // `ownerAgentId` exists only so the test can attempt a forgery — acting as
   // one agent while claiming another owns the record. Flair 403s that; an
   // application would simply pass `agentId` and never expose the distinction.
@@ -108,7 +116,7 @@ async function remember(agentId, { content, durability = "standard", visibility,
  * `agentId` may and may not come from.
  */
 async function recall(agentId, { asAdmin } = {}) {
-  const rows = await flair("Memory").search({ conditions: [] }, agentContext(agentId, { isAdmin: asAdmin === true }));
+  const rows = await flair("Memory").search({ conditions: [] }, actingAs(agentId, asAdmin));
   return collect(rows);
 }
 
@@ -127,7 +135,7 @@ async function semanticRecall(agentId, q, limit = 20) {
 
 /** The same semantic read with NO context — see `recallUnscoped`. */
 async function semanticRecallUnscoped(q, limit = 20) {
-  const h = await collectionResource(flair("SemanticSearch"));
+  const h = await collectionResource(flair("SemanticSearch"), internalContext());
   const r = await h.post({ q, limit });
   if (r instanceof Response) return { status: r.status };
   const list = r?.results ?? r?.memories ?? r;
@@ -141,11 +149,41 @@ async function recallById(agentId, id) {
 }
 
 /**
- * The same read with NO context. Present so the test can PROVE what the
- * omission costs — it returns every agent's private records. Never ship this.
+ * The DELIBERATELY unfiltered read — every agent's private records, by name.
+ * `internalContext()` is what an infrastructure sweep asks for on purpose; an
+ * application must never reach this verdict, and since it now has to type this
+ * function to get there, it cannot reach it by accident.
  */
 async function recallUnscoped() {
-  return collect(await flair("Memory").search({ conditions: [] }));
+  return collect(await flair("Memory").search({ conditions: [] }, internalContext()));
+}
+
+// ── Guard probes ────────────────────────────────────────────────────────────
+// Not things an application does — the test drives these to prove that the
+// forgot-the-argument paths fail closed, and to pin the hazard they exist for.
+
+/** `agentContext(<bad id>)` must throw rather than return a usable context. */
+function buildContextWith(agentId) {
+  const ctx = agentContext(agentId);           // expected to throw
+  return { threw: false, ctx };                // reached only if the guard is gone
+}
+
+/** `collectionResource(Cls)` with the context argument left off must throw. */
+async function createWithNoContext() {
+  const h = await collectionResource(flair("Memory"));   // expected to throw
+  return { threw: false, isCollection: h?.isCollection };
+}
+
+/**
+ * THE HAZARD THE GUARD EXISTS FOR — bypasses `agentContext()` and hands the
+ * resolver the raw shape a forgotten id used to produce. If this stops
+ * returning other agents' private records, the guard has become unnecessary and
+ * this fixture (and the warnings around it) should be revisited. Until then it
+ * is the evidence that "I forgot the id" really did mean "I am an administrator".
+ */
+async function recallWithRawMissingId() {
+  const forgotten = { request: { tpsAgent: undefined, tpsAgentIsAdmin: false } };
+  return collect(await flair("Memory").search({ conditions: [] }, forgotten));
 }
 
 const summarise = (r) => ({ id: r?.id, agentId: r?.agentId, visibility: r?.visibility, content: r?.content });
@@ -198,6 +236,12 @@ export class AgentFleet extends Resource {
         return run(() => semanticRecallUnscoped(body.q, body.limit));
       case "recallUnscoped":
         return run(() => recallUnscoped());
+      case "buildContextWith":
+        return run(() => buildContextWith(body.agentId));
+      case "createWithNoContext":
+        return run(() => createWithNoContext());
+      case "recallWithRawMissingId":
+        return run(() => recallWithRawMissingId());
       default:
         return new Response(JSON.stringify({ error: `unknown op '${op}'` }), { status: 400 });
     }

--- a/test/integration/in-process-agents.test.ts
+++ b/test/integration/in-process-agents.test.ts
@@ -1,0 +1,405 @@
+// ─── N agents, in-process, no CLI — proven against a real two-component Harper ─
+//
+// The consumer this exists for: a Harper application deployed to Fabric that
+// loads Flair as a sub-component and calls it IN-PROCESS. There is no shell on
+// that node, so every step here — registering agents, minting their key
+// material, writing and reading as each of them — has to be reachable from
+// application code alone.
+//
+// Every other in-process test in this repo runs against `mock.module("harper",
+// …)`, which cannot catch the two things that actually break an embedding: the
+// resource registry lookup across components, and Harper's collection binding
+// (see resources/in-process.ts). So this test boots a REAL second Harper
+// application (test/fixtures/inproc-app) with the worktree symlinked in as
+// `node_modules/@tpsdev-ai/flair`, and drives the fixture's in-process code via
+// its own HTTP endpoint. The HTTP hop is the TEST's remote control; the Flair
+// calls it triggers are all in-process method calls.
+//
+// The load-bearing assertion is the scoping proof: two agents registered by the
+// app, each writing a private and a shared memory, and NEITHER able to read the
+// other's private one. An integration where every agent is silently admin is
+// worse than no integration — so the admin-equivalence of a context-LESS call
+// is pinned here too, as a property, not a comment.
+import { describe, expect, test, beforeAll, afterAll } from "bun:test";
+import { generateKeyPairSync, createPrivateKey, sign as cryptoSign, randomUUID } from "node:crypto";
+import { mkdtemp, rm, mkdir, cp, symlink } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { startHarper, stopHarper, HarperInstance } from "../helpers/harper-lifecycle";
+
+const REPO_ROOT = process.cwd();
+const FIXTURE = join(REPO_ROOT, "test", "fixtures", "inproc-app");
+
+let harper: HarperInstance;
+let appDir: string;
+
+const sfx = Date.now().toString(36);
+const ALPHA = `inproc-alpha-${sfx}`;
+const BRAVO = `inproc-bravo-${sfx}`;
+
+/**
+ * An Ed25519 keypair minted with nothing but `node:crypto` — the point being
+ * that an app needs no CLI and no keystore to produce usable agent key
+ * material. The private key never leaves this process; only the raw 32-byte
+ * public key is handed to Flair.
+ */
+function mintKeypair() {
+  const { publicKey, privateKey } = generateKeyPairSync("ed25519");
+  const rawPublic = publicKey.export({ format: "der", type: "spki" }).subarray(-32);
+  return {
+    publicKeyB64: Buffer.from(rawPublic).toString("base64"),
+    privateKey: createPrivateKey(privateKey.export({ format: "pem", type: "pkcs8" }) as string),
+  };
+}
+
+const alphaKeys = mintKeypair();
+const bravoKeys = mintKeypair();
+
+/** The TPS-Ed25519 header an agent presents over HTTP (resources/agent-auth.ts). */
+function ed25519Header(agentId: string, privateKey: ReturnType<typeof createPrivateKey>, method: string, path: string): string {
+  const ts = Date.now().toString();
+  const nonce = randomUUID();
+  const payload = `${agentId}:${ts}:${nonce}:${method}:${path}`;
+  const sig = cryptoSign(null, Buffer.from(payload, "utf8"), privateKey);
+  return `TPS-Ed25519 ${agentId}:${ts}:${nonce}:${sig.toString("base64")}`;
+}
+
+/** Drive one in-process operation inside the fixture app. */
+async function fleet(op: string, body: Record<string, unknown> = {}): Promise<any> {
+  const res = await fetch(`${harper.httpURL}/AgentFleet/`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: "Basic " + btoa(`${harper.admin.username}:${harper.admin.password}`),
+    },
+    body: JSON.stringify({ op, ...body }),
+  });
+  const text = await res.text();
+  if (!res.ok) throw new Error(`AgentFleet ${op} → HTTP ${res.status}: ${text.slice(0, 400)}`);
+  return JSON.parse(text);
+}
+
+/** Read a record straight out of storage, bypassing every resource-level gate. */
+async function adminSearch(table: string, attribute: string, value: string): Promise<any[]> {
+  const res = await fetch(harper.opsURL, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: "Basic " + btoa(`${harper.admin.username}:${harper.admin.password}`),
+    },
+    body: JSON.stringify({
+      operation: "search_by_value",
+      database: "flair",
+      table,
+      search_attribute: attribute,
+      search_value: value,
+      get_attributes: ["*"],
+    }),
+  });
+  const body = await res.json().catch(() => []);
+  return Array.isArray(body) ? body : [];
+}
+
+const contents = (rows: any[]) => rows.map((r) => r.content).sort();
+
+beforeAll(async () => {
+  // Materialise the fixture app: its own config.yaml + resource, plus the
+  // worktree symlinked in as the Flair component. componentLoader.ts resolves a
+  // sub-component from `node_modules/<name>` walking up from the app directory,
+  // so this symlink is what makes `'@tpsdev-ai/flair'` in the fixture's
+  // config.yaml load THIS build.
+  appDir = await mkdtemp(join(tmpdir(), "flair-inproc-app-"));
+  await cp(FIXTURE, appDir, { recursive: true });
+  await mkdir(join(appDir, "node_modules", "@tpsdev-ai"), { recursive: true });
+  await symlink(REPO_ROOT, join(appDir, "node_modules", "@tpsdev-ai", "flair"), "dir");
+
+  // cwd = the APP (Harper's `dev "."` target); harperBinDir = the worktree,
+  // which is where node_modules/harper lives.
+  harper = await startHarper({ cwd: appDir, harperBinDir: REPO_ROOT });
+}, 300_000);
+
+afterAll(async () => {
+  // The restart test below hands `startHarper` an installDir it did not create,
+  // so that instance never owns it — clean it up here regardless of which
+  // instance is current.
+  const dataDir = harper?.installDir;
+  if (harper) await stopHarper(harper);
+  if (dataDir) await rm(dataDir, { recursive: true, force: true, maxRetries: 4 });
+  if (appDir) await rm(appDir, { recursive: true, force: true });
+});
+
+describe("in-process embedding — Flair loaded as a sub-component of another app", () => {
+  test("the app resolves Flair's RESOURCES (not just its tables) from the shared registry", async () => {
+    const { ok, value, error } = await fleet("registered");
+    expect(error).toBeUndefined();
+    expect(ok).toBe(true);
+    // The app's own resource and Flair's are in one process-global registry.
+    expect(value).toContain("AgentFleet");
+    expect(value).toContain("Memory");
+    expect(value).toContain("Agent");
+    expect(value).toContain("SemanticSearch");
+  });
+});
+
+describe("registering N agents with no CLI", () => {
+  test("the app registers two agents in-process, with key material it minted itself", async () => {
+    const a = await fleet("register", { id: ALPHA, publicKey: alphaKeys.publicKeyB64 });
+    const b = await fleet("register", { id: BRAVO, publicKey: bravoKeys.publicKeyB64 });
+    expect(a.error).toBeUndefined();
+    expect(b.error).toBeUndefined();
+    expect(a.ok).toBe(true);
+    expect(b.ok).toBe(true);
+  });
+
+  test("each record lands with the FULL Principal shape, not a hand-copied subset", async () => {
+    for (const [id, keys] of [[ALPHA, alphaKeys], [BRAVO, bravoKeys]] as const) {
+      const [record] = await adminSearch("Agent", "id", id);
+      expect(record, `Agent ${id} was not persisted`).toBeDefined();
+      // Defaults applied by resources/Agent.ts's post() — the reason to go
+      // through the resource rather than write databases.flair.Agent directly.
+      expect(record.kind).toBe("agent");
+      expect(record.status).toBe("active");
+      expect(record.displayName).toBe(id);
+      expect(record.admin).toBe(false);
+      expect(record.defaultTrustTier).toBe("unverified");
+      expect(record.type).toBe("agent");
+      expect(record.createdAt).toBeTruthy();
+      // The key the app minted, stored verbatim.
+      expect(record.publicKey).toBe(keys.publicKeyB64);
+    }
+  });
+
+  test("an agent registered in-process can then authenticate over HTTP with that key", async () => {
+    // Closes the loop: no CLI touched the keystore, yet the identity is a real
+    // one the Ed25519 gate accepts — so the same agent works for remote callers.
+    const path = `/Memory/?agentId=${ALPHA}`;
+    const res = await fetch(`${harper.httpURL}${path}`, {
+      headers: { Authorization: ed25519Header(ALPHA, alphaKeys.privateKey, "GET", path) },
+    });
+    expect(res.status).toBe(200);
+  });
+
+  test("a forged signature for the same agent is still rejected", async () => {
+    // Mutation guard on the test above: a 200 there must mean the SIGNATURE
+    // verified, not that the path is open to anyone naming a real agent.
+    const path = `/Memory/?agentId=${ALPHA}`;
+    const res = await fetch(`${harper.httpURL}${path}`, {
+      headers: { Authorization: ed25519Header(ALPHA, bravoKeys.privateKey, "GET", path) },
+    });
+    expect(res.status).not.toBe(200);
+  });
+});
+
+describe("acting as each agent, in-process", () => {
+  test("each agent writes its own private and shared memories", async () => {
+    for (const id of [ALPHA, BRAVO]) {
+      const priv = await fleet("remember", { agentId: id, content: `${id} PRIVATE`, durability: "standard", visibility: "private" });
+      const shared = await fleet("remember", { agentId: id, content: `${id} SHARED`, durability: "persistent", visibility: "shared" });
+      expect(priv.error, `private write for ${id}`).toBeUndefined();
+      expect(shared.error, `shared write for ${id}`).toBeUndefined();
+      expect(priv.ok).toBe(true);
+      expect(shared.ok).toBe(true);
+    }
+  });
+
+  test("writes are attributed to the acting agent in storage", async () => {
+    const rows = await adminSearch("Memory", "agentId", ALPHA);
+    expect(contents(rows)).toEqual([`${ALPHA} PRIVATE`, `${ALPHA} SHARED`]);
+  });
+
+  test("an agent CANNOT write a memory owned by another agent", async () => {
+    // Acting as ALPHA, claiming BRAVO owns the record. The context is the
+    // authority; the body is not.
+    const forged = await fleet("remember", { agentId: ALPHA, ownerAgentId: BRAVO, content: "forged by alpha" });
+    expect(forged.ok).toBe(false);
+    expect(forged.status).toBe(403);
+    expect(forged.body).toContain("cannot write memory owned by another agent");
+
+    // …and nothing landed under BRAVO.
+    const bravoRows = await adminSearch("Memory", "agentId", BRAVO);
+    expect(contents(bravoRows)).not.toContain("forged by alpha");
+  });
+});
+
+describe("SCOPING PROOF — agent A cannot read agent B's private memories", () => {
+  test("ALPHA sees its own private + both shared, and NOT BRAVO's private", async () => {
+    const { ok, value, error } = await fleet("recall", { agentId: ALPHA });
+    expect(error).toBeUndefined();
+    expect(ok).toBe(true);
+    const seen = contents(value);
+    expect(seen).toContain(`${ALPHA} PRIVATE`);
+    expect(seen).toContain(`${ALPHA} SHARED`);
+    expect(seen).toContain(`${BRAVO} SHARED`);
+    expect(seen).not.toContain(`${BRAVO} PRIVATE`);
+    // Nothing marked private by anyone else leaked in, whatever else is here.
+    expect(value.filter((r: any) => r.visibility === "private" && r.agentId !== ALPHA)).toEqual([]);
+  });
+
+  test("BRAVO sees its own private + both shared, and NOT ALPHA's private", async () => {
+    const { ok, value, error } = await fleet("recall", { agentId: BRAVO });
+    expect(error).toBeUndefined();
+    expect(ok).toBe(true);
+    const seen = contents(value);
+    expect(seen).toContain(`${BRAVO} PRIVATE`);
+    expect(seen).toContain(`${BRAVO} SHARED`);
+    expect(seen).toContain(`${ALPHA} SHARED`);
+    expect(seen).not.toContain(`${ALPHA} PRIVATE`);
+    expect(value.filter((r: any) => r.visibility === "private" && r.agentId !== BRAVO)).toEqual([]);
+  });
+
+  test("SEMANTIC recall is scoped too — the path an agent loop actually reads through", async () => {
+    // The one that matters most: the vector index is global, so the scope has to
+    // survive being applied to ranked results rather than to a table query. Each
+    // agent's private memory carries a distinctive topic the other never wrote
+    // about, so a leak would surface as a top hit rather than as a near-miss.
+    const alphaTopic = "quarterly billing reconciliation ledger";
+    const bravoTopic = "deploy key rotation schedule";
+    expect((await fleet("remember", { agentId: ALPHA, content: `${ALPHA} owns the ${alphaTopic}`, visibility: "private" })).ok).toBe(true);
+    expect((await fleet("remember", { agentId: BRAVO, content: `${BRAVO} owns the ${bravoTopic}`, visibility: "private" })).ok).toBe(true);
+
+    // Embeddings must actually have run, or this test proves nothing.
+    const alphaRows = await adminSearch("Memory", "agentId", ALPHA);
+    const embedded = alphaRows.find((r) => String(r.content).includes(alphaTopic));
+    expect(Array.isArray(embedded?.embedding) && embedded.embedding.length > 0).toBe(true);
+
+    // BRAVO searching for ALPHA's topic must not reach ALPHA's private record.
+    const bravoHits = await fleet("semanticRecall", { agentId: BRAVO, q: alphaTopic });
+    expect(bravoHits.ok).toBe(true);
+    expect(bravoHits.value.map((r: any) => r.content).join(" ")).not.toContain(`${ALPHA} owns the`);
+    expect(bravoHits.value.filter((r: any) => r.agentId === ALPHA && r.visibility === "private")).toEqual([]);
+
+    // …and symmetrically.
+    const alphaHits = await fleet("semanticRecall", { agentId: ALPHA, q: bravoTopic });
+    expect(alphaHits.ok).toBe(true);
+    expect(alphaHits.value.filter((r: any) => r.agentId === BRAVO && r.visibility === "private")).toEqual([]);
+
+    // Control: the owner CAN reach its own record, so the assertions above are
+    // not passing merely because semantic search returned nothing at all.
+    const ownHits = await fleet("semanticRecall", { agentId: ALPHA, q: alphaTopic });
+    expect(ownHits.value.map((r: any) => r.content).join(" ")).toContain(`${ALPHA} owns the`);
+  }, 120_000);
+
+  test("a by-id read of another agent's private record returns nothing", async () => {
+    const [bravoPrivate] = (await adminSearch("Memory", "agentId", BRAVO)).filter((r) => r.visibility === "private");
+    expect(bravoPrivate, "BRAVO's private record should exist in storage").toBeDefined();
+
+    // BRAVO can read it…
+    const owner = await fleet("recallById", { agentId: BRAVO, id: bravoPrivate.id });
+    expect(owner.ok).toBe(true);
+    expect(owner.value?.content).toBe(`${BRAVO} PRIVATE`);
+
+    // …ALPHA, holding the exact id, cannot.
+    const other = await fleet("recallById", { agentId: ALPHA, id: bravoPrivate.id });
+    expect(other.value ?? null).toBeNull();
+  });
+});
+
+// ─── The context object is a security boundary ───────────────────────────────
+//
+// The other half of the scoping proof. Showing that ALPHA cannot read BRAVO's
+// private memories is necessary but not sufficient: the honest answer to "what
+// if the app CLAIMS to be BRAVO?" is that it works, immediately and silently.
+// In-process identity is ASSERTED, not verified — there is no signature, no
+// lookup against the Agent table, and no registration requirement.
+//
+// That is correct design (a co-located caller could write the raw table anyway,
+// so demanding a signature from same-process code would be theatre), and it is
+// exactly why the context must be built from the app's own server-side state
+// and never from request data. Both escalation paths — by omission and by
+// assertion — are pinned here as properties, so neither can change quietly and
+// neither can be mistaken for something Flair will catch for you.
+describe("SECURITY BOUNDARY — in-process identity is asserted, not verified", () => {
+  test("BY ASSERTION: claiming another agent's id simply works — it reads that agent's private memories", async () => {
+    const { ok, value } = await fleet("recall", { agentId: BRAVO });
+    expect(ok).toBe(true);
+    // The caller never proved it is BRAVO. Nothing asked it to.
+    expect(contents(value)).toContain(`${BRAVO} PRIVATE`);
+  });
+
+  test("BY ASSERTION: an id with NO Agent record acts as that agent anyway (registration is not a gate)", async () => {
+    const ghost = `never-registered-${sfx}`;
+    expect(await adminSearch("Agent", "id", ghost)).toEqual([]);
+
+    const written = await fleet("remember", { agentId: ghost, content: `${ghost} GHOST`, visibility: "private" });
+    expect(written.ok).toBe(true);
+
+    const [row] = await adminSearch("Memory", "agentId", ghost);
+    expect(row?.content).toBe(`${ghost} GHOST`);
+
+    // …and it is scoped like any other agent: it cannot see ALPHA's private one.
+    const { value } = await fleet("recall", { agentId: ghost });
+    expect(contents(value)).not.toContain(`${ALPHA} PRIVATE`);
+  });
+
+  test("BY ASSERTION: tpsAgentIsAdmin is asserted too — it grants unfiltered reads and cross-agent writes", async () => {
+    // Nothing checks that ALPHA is actually an admin; the flag is taken at face
+    // value. This is why `isAdmin` must never be derived from caller input.
+    const [record] = await adminSearch("Agent", "id", ALPHA);
+    expect(record.admin).toBe(false); // ALPHA is NOT an admin principal…
+
+    const seen = contents((await fleet("recall", { agentId: ALPHA, asAdmin: true })).value);
+    expect(seen).toContain(`${BRAVO} PRIVATE`); // …yet it reads BRAVO's private record
+
+    const forged = await fleet("remember", { agentId: ALPHA, ownerAgentId: BRAVO, content: "admin-forged", asAdmin: true });
+    expect(forged.ok).toBe(true); // …and writes a record owned by BRAVO
+    expect(contents(await adminSearch("Memory", "agentId", BRAVO))).toContain("admin-forged");
+  });
+
+  test("BY OMISSION: a context-LESS SEMANTIC search is unfiltered too", async () => {
+    // The scary box in the guide claims this. It is true on both read paths.
+    const { ok, value } = await fleet("semanticRecallUnscoped", { q: "quarterly billing reconciliation ledger" });
+    expect(ok).toBe(true);
+    const owners = new Set(value.map((r: any) => r.agentId));
+    expect(value.some((r: any) => r.visibility === "private")).toBe(true);
+    expect(owners.size).toBeGreaterThan(1);
+  }, 120_000);
+
+  test("BY OMISSION: a context-LESS call is ADMIN-EQUIVALENT — it reads every agent's private records", async () => {
+    // The same escalation from the other end. If Flair's `internal` verdict ever
+    // stops being unfiltered, this test fails and the guidance changes with it;
+    // while it passes, it is the reason an embedding app must never let an agent
+    // id default.
+    const { ok, value } = await fleet("recallUnscoped");
+    expect(ok).toBe(true);
+    const seen = contents(value);
+    expect(seen).toContain(`${ALPHA} PRIVATE`);
+    expect(seen).toContain(`${BRAVO} PRIVATE`);
+  });
+});
+
+// ─── What survives a process boundary (the cluster question) ─────────────────
+//
+// A distributed app depends on attribution being a property of the RECORD, not
+// of the process that wrote it: Harper replicates every table in a replicated
+// database unless it opts out with `@table(replicate: false)`, and none of
+// Flair's do — so a memory written on node A lands on node B, and must read
+// back there correctly attributed AND correctly scoped.
+//
+// This harness runs one node, so what is proven here is the load-bearing half:
+// a SECOND Harper process, started fresh against the same storage with no
+// memory of the first, resolves the same identities and the same boundaries
+// from stored state alone. Nothing about who an agent is, or what it may see,
+// lives in the process that wrote the record. What is NOT proven here is
+// Harper's replication transport itself.
+describe("attribution and scoping are storage state, not process state", () => {
+  test("a fresh Harper process over the same data resolves identical per-agent scope", async () => {
+    await stopHarper(harper, { keepInstallDir: true });
+    harper = await startHarper({ cwd: appDir, harperBinDir: REPO_ROOT, installDir: harper.installDir });
+
+    const alphaSees = contents((await fleet("recall", { agentId: ALPHA })).value);
+    expect(alphaSees).toContain(`${ALPHA} PRIVATE`);
+    expect(alphaSees).toContain(`${BRAVO} SHARED`);
+    expect(alphaSees).not.toContain(`${BRAVO} PRIVATE`);
+
+    const bravoSees = contents((await fleet("recall", { agentId: BRAVO })).value);
+    expect(bravoSees).toContain(`${BRAVO} PRIVATE`);
+    expect(bravoSees).toContain(`${ALPHA} SHARED`);
+    expect(bravoSees).not.toContain(`${ALPHA} PRIVATE`);
+
+    // The registry survives too — the agents this app registered are still
+    // Principals, with the key material it minted.
+    const [alphaRecord] = await adminSearch("Agent", "id", ALPHA);
+    expect(alphaRecord.publicKey).toBe(alphaKeys.publicKeyB64);
+    expect(alphaRecord.kind).toBe("agent");
+  }, 300_000);
+});

--- a/test/integration/in-process-agents.test.ts
+++ b/test/integration/in-process-agents.test.ts
@@ -203,8 +203,17 @@ describe("acting as each agent, in-process", () => {
   });
 
   test("writes are attributed to the acting agent in storage", async () => {
+    // Asserted as a property, not as an exact snapshot: an exact `toEqual` here
+    // would silently become order- and count-dependent the moment any later
+    // test writes another ALPHA record (see the by-id test for what that class
+    // of coupling costs).
     const rows = await adminSearch("Memory", "agentId", ALPHA);
-    expect(contents(rows)).toEqual([`${ALPHA} PRIVATE`, `${ALPHA} SHARED`]);
+    expect(contents(rows)).toContain(`${ALPHA} PRIVATE`);
+    expect(contents(rows)).toContain(`${ALPHA} SHARED`);
+    expect(rows.every((r) => r.agentId === ALPHA)).toBe(true);
+    expect(await adminSearch("Memory", "agentId", BRAVO)).not.toContainEqual(
+      expect.objectContaining({ content: `${ALPHA} PRIVATE` }),
+    );
   });
 
   test("an agent CANNOT write a memory owned by another agent", async () => {
@@ -280,18 +289,56 @@ describe("SCOPING PROOF — agent A cannot read agent B's private memories", () 
   }, 120_000);
 
   test("a by-id read of another agent's private record returns nothing", async () => {
-    const [bravoPrivate] = (await adminSearch("Memory", "agentId", BRAVO)).filter((r) => r.visibility === "private");
-    expect(bravoPrivate, "BRAVO's private record should exist in storage").toBeDefined();
+    // The id comes from the WRITE, never from a search.
+    //
+    // This test previously picked its target with
+    // `[first] = adminSearch(...).filter(r => r.visibility === "private")`. Once
+    // BRAVO owned a second private record that selection became ambiguous, and
+    // it is not merely unordered — `search_by_value` on the non-unique `agentId`
+    // index returns matches in PRIMARY KEY order, and Harper mints Memory ids as
+    // random UUIDs. So "the first private record" is decided by a coin flip that
+    // is re-tossed on every run. It passed locally and failed in CI for exactly
+    // that reason, on the owner control rather than on the security assertion —
+    // meaning the cross-agent read below never actually executed in that run.
+    //
+    // An order-dependent security proof is not a proof. This one now names its
+    // target explicitly and verifies against storage before asserting anything.
+    const marker = `${BRAVO} BY-ID TARGET ${randomUUID()}`;
+    const written = await fleet("remember", { agentId: BRAVO, content: marker, visibility: "private" });
+    expect(written.ok).toBe(true);
+    const targetId = written.value?.id;
+    expect(typeof targetId, "the write must hand back the id it minted").toBe("string");
 
-    // BRAVO can read it…
-    const owner = await fleet("recallById", { agentId: BRAVO, id: bravoPrivate.id });
+    // Ground truth, straight out of storage past every resource-level gate:
+    // this exact id really is BRAVO's, really is private, really holds `marker`.
+    const [stored] = await adminSearch("Memory", "id", targetId);
+    expect(stored?.agentId).toBe(BRAVO);
+    expect(stored?.visibility).toBe("private");
+    expect(stored?.content).toBe(marker);
+
+    // BRAVO can read it — the control, so a null below cannot be explained by
+    // the record being unreadable to everyone.
+    const owner = await fleet("recallById", { agentId: BRAVO, id: targetId });
     expect(owner.ok).toBe(true);
-    expect(owner.value?.content).toBe(`${BRAVO} PRIVATE`);
+    expect(owner.value?.id).toBe(targetId);
+    expect(owner.value?.content).toBe(marker);
 
-    // …ALPHA, holding the exact id, cannot.
-    const other = await fleet("recallById", { agentId: ALPHA, id: bravoPrivate.id });
+    // …ALPHA, holding that exact id, cannot. THIS is the security assertion.
+    const other = await fleet("recallById", { agentId: ALPHA, id: targetId });
+    expect(other.ok).toBe(true);
     expect(other.value ?? null).toBeNull();
-  });
+
+    // And the same for every OTHER private record BRAVO owns, so the property is
+    // asserted over the whole set rather than over one lucky pick.
+    const allBravoPrivate = (await adminSearch("Memory", "agentId", BRAVO)).filter((r) => r.visibility === "private");
+    expect(allBravoPrivate.length).toBeGreaterThan(1); // there really are several by now
+    for (const row of allBravoPrivate) {
+      const denied = await fleet("recallById", { agentId: ALPHA, id: row.id });
+      expect(denied.value ?? null, `ALPHA must not read BRAVO's private record ${row.id}`).toBeNull();
+      const allowed = await fleet("recallById", { agentId: BRAVO, id: row.id });
+      expect(allowed.value?.id, `BRAVO must still read its own record ${row.id}`).toBe(row.id);
+    }
+  }, 120_000);
 });
 
 // ─── The context object is a security boundary ───────────────────────────────
@@ -343,6 +390,58 @@ describe("SECURITY BOUNDARY — in-process identity is asserted, not verified", 
     const forged = await fleet("remember", { agentId: ALPHA, ownerAgentId: BRAVO, content: "admin-forged", asAdmin: true });
     expect(forged.ok).toBe(true); // …and writes a record owned by BRAVO
     expect(contents(await adminSearch("Memory", "agentId", BRAVO))).toContain("admin-forged");
+  });
+
+  // ── The forgot-the-argument guards ────────────────────────────────────────
+  //
+  // `resolveAgentAuth` tests `tpsAgent` for TRUTHINESS, so a missing or empty id
+  // is indistinguishable from "no identity supplied" — which is the trusted,
+  // unfiltered `internal` verdict. That turns the most ordinary application bug
+  // there is (a field that came back undefined) into silent administrator
+  // access. The API refuses instead. These tests pin the refusal AND the hazard
+  // it exists for, so nobody can "simplify" the guard away without the reason
+  // failing loudly alongside it.
+  test("GUARD: agentContext(undefined) and agentContext('') THROW rather than returning an admin context", async () => {
+    for (const bad of [undefined, null, "", "   "]) {
+      const r = await fleet("buildContextWith", { agentId: bad });
+      expect(r.ok, `agentContext(${JSON.stringify(bad)}) must not return a context`).toBe(false);
+      expect(r.errorName).toBe("InProcessContextError");
+      // The message has to name the hazard, not just the argument — whoever
+      // hits this should understand what they narrowly avoided.
+      expect(r.error).toContain("non-empty agent id");
+      expect(r.error).toMatch(/internal|UNFILTERED/);
+    }
+  });
+
+  test("GUARD: collectionResource() with the context argument left off THROWS", async () => {
+    const r = await fleet("createWithNoContext");
+    expect(r.ok).toBe(false);
+    expect(r.errorName).toBe("InProcessContextError");
+    expect(r.error).toContain("explicit context");
+  });
+
+  test("GUARD: a valid id still works — the guards are not just refusing everything", async () => {
+    // Positive control. Without this, every assertion above would also pass if
+    // agentContext() had been broken into throwing unconditionally.
+    const r = await fleet("buildContextWith", { agentId: ALPHA });
+    expect(r.ok).toBe(true);
+    expect(r.value.threw).toBe(false);
+    expect(r.value.ctx.request.tpsAgent).toBe(ALPHA);
+    expect(r.value.ctx.request.tpsAgentIsAdmin).toBe(false);
+  });
+
+  test("WHY THE GUARD EXISTS: the raw shape a forgotten id used to produce reads every agent's private records", async () => {
+    // Bypasses agentContext() and hands resolveAgentAuth the exact object a
+    // missing id used to yield: { request: { tpsAgent: undefined } }. If this
+    // ever stops being unfiltered, the guard is no longer load-bearing and this
+    // whole section should be revisited — deliberately, not by accident.
+    const { ok, value } = await fleet("recallWithRawMissingId");
+    expect(ok).toBe(true);
+    const owners = new Set(value.map((r: any) => r.agentId));
+    expect(owners.has(ALPHA)).toBe(true);
+    expect(owners.has(BRAVO)).toBe(true);
+    expect(value.some((r: any) => r.agentId === ALPHA && r.visibility === "private")).toBe(true);
+    expect(value.some((r: any) => r.agentId === BRAVO && r.visibility === "private")).toBe(true);
   });
 
   test("BY OMISSION: a context-LESS SEMANTIC search is unfiltered too", async () => {

--- a/test/unit/in-process-seam.test.ts
+++ b/test/unit/in-process-seam.test.ts
@@ -1,0 +1,107 @@
+// resources/in-process.ts — the in-process call seam.
+//
+// The module under test has ZERO imports (deliberately — see its header), so
+// this file needs no `mock.module("harper", …)` and is safe in test/unit/.
+//
+// What matters here is that `collectionResource()` produces an instance a REAL
+// Harper `Resource` subclass would accept a `post()` on. Harper decides that
+// from a PRIVATE field (`#isCollection`) that only its own `getResource()` can
+// set; the public `isCollection` is a getter with no setter. `HarperShaped`
+// below reproduces both facts exactly, so the assertions here fail for the same
+// reason a real Harper would.
+//
+// The end-to-end proof against a real, two-component Harper is
+// test/integration/in-process-agents.test.ts — this file pins the mechanism.
+import { describe, it, expect } from "bun:test";
+import { agentContext, collectionResource } from "../../resources/in-process.ts";
+
+/**
+ * A stand-in for Harper's `Resource`, matching it on the only two points the
+ * seam depends on: a getter-only `isCollection` backed by a private field, and
+ * a `static getResource(target, context, options)` that is the sole way to set
+ * it. Verified against harper 5.1.22's resources/Resource.ts (`get
+ * isCollection()` at the prototype, `resource.#isCollection = true` inside
+ * `getResource`, and `post()` calling `missingMethod` when the flag is false).
+ */
+class HarperShaped {
+  #isCollection = false;
+  id: any;
+  context: any;
+  constructor(id: any, context: any) { this.id = id; this.context = context; }
+  get isCollection() { return this.#isCollection; }
+  static getResource(target: any, request: any, options?: any) {
+    const r = new (this as any)(target?.id, request ?? {}) as HarperShaped;
+    if (options?.isCollection) r.#isCollection = true;
+    return r;
+  }
+  /** Mirrors Harper's base Resource.post: refuses unless collection-bound. */
+  post(record: any) {
+    if (!this.#isCollection) throw new Error("The HarperShaped does not have a post method implemented");
+    return { id: record?.id ?? "generated", written: true };
+  }
+}
+
+describe("agentContext", () => {
+  it("carries the agent id the resolver reads, non-admin by default", () => {
+    expect(agentContext("planner")).toEqual({ request: { tpsAgent: "planner", tpsAgentIsAdmin: false } });
+  });
+
+  it("isAdmin is opt-in and strictly boolean (a truthy non-true never elevates)", () => {
+    expect(agentContext("p", { isAdmin: true }).request.tpsAgentIsAdmin).toBe(true);
+    expect(agentContext("p", { isAdmin: false }).request.tpsAgentIsAdmin).toBe(false);
+    expect(agentContext("p", {}).request.tpsAgentIsAdmin).toBe(false);
+    expect(agentContext("p", { isAdmin: 1 as any }).request.tpsAgentIsAdmin).toBe(false);
+    expect(agentContext("p", { isAdmin: "true" as any }).request.tpsAgentIsAdmin).toBe(false);
+  });
+
+  it("returns a fresh object per call (one agent's context can never be mutated into another's)", () => {
+    const a = agentContext("a");
+    const b = agentContext("b");
+    a.request.tpsAgent = "mutated";
+    expect(b.request.tpsAgent).toBe("b");
+  });
+});
+
+describe("collectionResource", () => {
+  it("returns an instance Harper accepts a create on", async () => {
+    const h = await collectionResource<HarperShaped>(HarperShaped, agentContext("planner"));
+    expect(h.isCollection).toBe(true);
+    expect(h.post({ content: "x" })).toEqual({ id: "generated", written: true });
+  });
+
+  it("threads the caller's context through to the instance", async () => {
+    const ctx = agentContext("researcher");
+    const h = await collectionResource<HarperShaped>(HarperShaped, ctx);
+    expect(h.context).toBe(ctx);
+  });
+
+  it("with no context still binds the collection (flair's own maintenance paths)", async () => {
+    const h = await collectionResource<HarperShaped>(HarperShaped);
+    expect(h.isCollection).toBe(true);
+    expect(h.context).toEqual({});
+  });
+
+  // ── The anti-pattern this module exists to replace ────────────────────────
+  //
+  // Before the seam, flair's MCP tool paths did `new Cls(undefined, ctx)` then
+  // `(h as any).isCollection = true`. Both halves of why that is wrong are
+  // pinned here, so reintroducing either fails a test instead of only failing
+  // in production:
+
+  it("MUTATION CHECK: assigning isCollection throws — it is a getter with no setter", () => {
+    const h = new HarperShaped(undefined, agentContext("planner"));
+    expect(() => { (h as any).isCollection = true; }).toThrow(TypeError);
+  });
+
+  it("MUTATION CHECK: a plain `new Cls(...)` instance refuses post()", () => {
+    const h = new HarperShaped(undefined, agentContext("planner"));
+    expect(h.isCollection).toBe(false);
+    expect(() => h.post({ content: "x" })).toThrow(/does not have a post method implemented/);
+  });
+
+  it("MUTATION CHECK: defineProperty on the instance does NOT satisfy Harper (private field)", () => {
+    const h = new HarperShaped(undefined, agentContext("planner"));
+    Object.defineProperty(h, "isCollection", { value: true, configurable: true });
+    expect(() => h.post({ content: "x" })).toThrow(/does not have a post method implemented/);
+  });
+});

--- a/test/unit/in-process-seam.test.ts
+++ b/test/unit/in-process-seam.test.ts
@@ -3,17 +3,33 @@
 // The module under test has ZERO imports (deliberately — see its header), so
 // this file needs no `mock.module("harper", …)` and is safe in test/unit/.
 //
-// What matters here is that `collectionResource()` produces an instance a REAL
-// Harper `Resource` subclass would accept a `post()` on. Harper decides that
-// from a PRIVATE field (`#isCollection`) that only its own `getResource()` can
-// set; the public `isCollection` is a getter with no setter. `HarperShaped`
-// below reproduces both facts exactly, so the assertions here fail for the same
-// reason a real Harper would.
+// Two things are pinned here:
 //
-// The end-to-end proof against a real, two-component Harper is
-// test/integration/in-process-agents.test.ts — this file pins the mechanism.
+//   1. The SAFETY SHAPE. A missing or empty agent id resolves, inside Flair, to
+//      the trusted `internal` verdict — unfiltered reads and writes across every
+//      agent. So the constructors refuse it rather than defaulting, and the
+//      privileged contexts are separate named exports that cannot be reached by
+//      leaving an argument off. These are runtime guards on purpose: an
+//      embedding app may be plain JavaScript, where the type annotations buy
+//      nothing at all.
+//   2. The COLLECTION BINDING. `collectionResource()` must produce an instance a
+//      real Harper `Resource` subclass accepts a `post()` on. Harper decides
+//      that from a PRIVATE field (`#isCollection`) only its own `getResource()`
+//      can set; the public `isCollection` is a getter with no setter.
+//      `HarperShaped` below reproduces both facts exactly, so the assertions
+//      fail for the same reason a real Harper would.
+//
+// The end-to-end proof against a real, two-component Harper — including the
+// escalation this API shape prevents — is
+// test/integration/in-process-agents.test.ts.
 import { describe, it, expect } from "bun:test";
-import { agentContext, collectionResource } from "../../resources/in-process.ts";
+import {
+  agentContext,
+  adminContext,
+  internalContext,
+  collectionResource,
+  InProcessContextError,
+} from "../../resources/in-process.ts";
 
 /**
  * A stand-in for Harper's `Resource`, matching it on the only two points the
@@ -41,17 +57,33 @@ class HarperShaped {
   }
 }
 
+// Everything a JS caller could plausibly pass by accident where an id belongs.
+// Each one resolves, inside Flair, to the unfiltered `internal` verdict (or to a
+// nonsense agent id, in the blank-string case) — so each one must be refused.
+const BAD_IDS: [string, unknown][] = [
+  ["undefined", undefined],
+  ["null", null],
+  ["empty string", ""],
+  ["blank string", "   "],
+  ["a number", 0],
+  ["a truthy number", 42],
+  ["an object", {}],
+  ["an array", []],
+  ["a boolean", false],
+];
+
 describe("agentContext", () => {
-  it("carries the agent id the resolver reads, non-admin by default", () => {
+  it("carries the agent id the resolver reads, and is never admin", () => {
     expect(agentContext("planner")).toEqual({ request: { tpsAgent: "planner", tpsAgentIsAdmin: false } });
   });
 
-  it("isAdmin is opt-in and strictly boolean (a truthy non-true never elevates)", () => {
-    expect(agentContext("p", { isAdmin: true }).request.tpsAgentIsAdmin).toBe(true);
-    expect(agentContext("p", { isAdmin: false }).request.tpsAgentIsAdmin).toBe(false);
-    expect(agentContext("p", {}).request.tpsAgentIsAdmin).toBe(false);
-    expect(agentContext("p", { isAdmin: 1 as any }).request.tpsAgentIsAdmin).toBe(false);
-    expect(agentContext("p", { isAdmin: "true" as any }).request.tpsAgentIsAdmin).toBe(false);
+  it("has no options parameter, so no spread object can escalate it", () => {
+    // The escalation shape this API removes: `agentContext(id, opts)` where
+    // `opts` came from somewhere a caller could influence. There is no second
+    // parameter to spread into, and extra arguments are inert.
+    expect(agentContext.length).toBe(1);
+    const attacker = { isAdmin: true, tpsAgentIsAdmin: true };
+    expect((agentContext as any)("planner", attacker).request.tpsAgentIsAdmin).toBe(false);
   });
 
   it("returns a fresh object per call (one agent's context can never be mutated into another's)", () => {
@@ -59,6 +91,63 @@ describe("agentContext", () => {
     const b = agentContext("b");
     a.request.tpsAgent = "mutated";
     expect(b.request.tpsAgent).toBe("b");
+  });
+
+  describe("refuses anything that would resolve to the unfiltered `internal` verdict", () => {
+    for (const [label, value] of BAD_IDS) {
+      it(`throws InProcessContextError for ${label}`, () => {
+        expect(() => (agentContext as any)(value)).toThrow(InProcessContextError);
+      });
+    }
+
+    it("names the HAZARD, not just the argument", () => {
+      // Whoever hits this should understand what they narrowly avoided, so the
+      // message has to say what would otherwise have happened.
+      let message = "";
+      try { (agentContext as any)(undefined); } catch (e: any) { message = e.message; }
+      expect(message).toContain("non-empty agent id");
+      expect(message).toContain("internal");
+      expect(message).toContain("UNFILTERED");
+      expect(message).toContain("never from request data");
+    });
+
+    it("reports what it actually received, so the bug is findable", () => {
+      const seen = (v: unknown) => { try { (agentContext as any)(v); return ""; } catch (e: any) { return e.message; } };
+      expect(seen(undefined)).toContain("undefined");
+      expect(seen(null)).toContain("null");
+      expect(seen("")).toContain("an empty string");
+      expect(seen("   ")).toContain("a blank string");
+      expect(seen(42)).toContain("a number");
+    });
+  });
+});
+
+describe("adminContext", () => {
+  it("is the only way to ask for admin, and says so by name", () => {
+    expect(adminContext("provisioner")).toEqual({
+      request: { tpsAgent: "provisioner", tpsAgentIsAdmin: true },
+    });
+  });
+
+  it("applies the same id guard — admin by accident is still accident", () => {
+    for (const [, value] of BAD_IDS) {
+      expect(() => (adminContext as any)(value)).toThrow(InProcessContextError);
+    }
+  });
+});
+
+describe("internalContext", () => {
+  it("carries NO identity annotation — that absence IS the internal verdict", () => {
+    const ctx = internalContext();
+    expect(ctx.request).toEqual({});
+    expect("tpsAgent" in ctx.request).toBe(false);
+  });
+
+  it("is a distinct, greppable name rather than an omitted argument", () => {
+    // The whole point: reaching the unfiltered verdict requires typing
+    // something that looks like what it is.
+    expect(typeof internalContext).toBe("function");
+    expect(internalContext.length).toBe(0);
   });
 });
 
@@ -75,10 +164,28 @@ describe("collectionResource", () => {
     expect(h.context).toBe(ctx);
   });
 
-  it("with no context still binds the collection (flair's own maintenance paths)", async () => {
-    const h = await collectionResource<HarperShaped>(HarperShaped);
-    expect(h.isCollection).toBe(true);
-    expect(h.context).toEqual({});
+  it("works with the explicitly-privileged contexts too", async () => {
+    for (const ctx of [adminContext("provisioner"), internalContext()]) {
+      const h = await collectionResource<HarperShaped>(HarperShaped, ctx);
+      expect(h.isCollection).toBe(true);
+    }
+  });
+
+  describe("refuses to grant `internal` by omission", () => {
+    const OMITTED: [string, unknown][] = [["nothing", undefined], ["null", null], ["a string", "planner"]];
+    for (const [label, value] of OMITTED) {
+      it(`throws when the context is ${label}`, async () => {
+        await expect(collectionResource(HarperShaped, value as any)).rejects.toThrow(InProcessContextError);
+      });
+    }
+
+    it("explains that omitting it would have been the privileged path", async () => {
+      let message = "";
+      try { await collectionResource(HarperShaped, undefined as any); } catch (e: any) { message = e.message; }
+      expect(message).toContain("explicit context");
+      expect(message).toContain("internal");
+      expect(message).toContain("agentContext(id)");
+    });
   });
 
   // ── The anti-pattern this module exists to replace ────────────────────────

--- a/test/unit/mcp-handler.test.ts
+++ b/test/unit/mcp-handler.test.ts
@@ -24,13 +24,41 @@ import { mock, describe, it, expect, beforeEach, afterEach, afterAll } from "bun
 // ─── Capture state for the mocked handlers ───────────────────────────────────
 let lastCall: { resource: string; ctx: any; args: any } | null = null;
 
+/**
+ * Base for every capture double, shaped like Harper's real `Resource` on the
+ * two points that decide whether an in-process delegation works at all:
+ *
+ *   - `isCollection` is a GETTER WITH NO SETTER on the prototype, backed by a
+ *     PRIVATE field. Assigning to it from outside throws under ESM's strict
+ *     mode — exactly what the real class does. The doubles previously carried a
+ *     public `isCollection = false` data field, which silently ACCEPTED the
+ *     assignment mcp-tools.ts used to make and let the whole suite pass green
+ *     while `memory_store`/`memory_update`/`workspace_set`/`orgevent` threw
+ *     `TypeError: Cannot set property isCollection …` against a real Harper.
+ *   - `static getResource(target, context, options)` is the only way to obtain
+ *     a collection-bound instance, mirroring Harper's own signature — which is
+ *     what resources/in-process.ts's collectionResource() calls.
+ *
+ * Keep both properties. A double that is easier to satisfy than the real class
+ * cannot catch this class of bug.
+ */
+class HarperShapedBase {
+  #collection = false;
+  _ctx: any;
+  constructor(_id: any, ctx: any) { this._ctx = ctx; }
+  get isCollection() { return this.#collection; }
+  static getResource(_target: any, ctx: any, options?: any) {
+    const r = new (this as any)(undefined, ctx) as HarperShapedBase;
+    if (options?.isCollection) r.#collection = true;
+    return r;
+  }
+}
+
 // Each mocked handler records the delegation context (getContext via ctor arg2)
 // and the args it was called with, then returns a marker so we can assert the
 // dispatch reached the right tool.
 function makeHandlerMock(resource: string, method: string) {
-  return class {
-    _ctx: any;
-    constructor(_id: any, ctx: any) { this._ctx = ctx; }
+  return class extends HarperShapedBase {
     async [method](args: any) {
       lastCall = { resource, ctx: this._ctx, args };
       return { ok: true, resource, agentId: this._ctx?.request?.tpsAgent };
@@ -39,11 +67,8 @@ function makeHandlerMock(resource: string, method: string) {
 }
 
 // Memory has post/get/delete on the same class.
-class MemoryMock {
-  _ctx: any;
-  isCollection = false;
-  constructor(_id: any, ctx: any) { this._ctx = ctx; }
-  async post(args: any) { lastCall = { resource: "Memory.post", ctx: this._ctx, args }; return { ok: true, resource: "Memory.post", agentId: this._ctx?.request?.tpsAgent }; }
+class MemoryMock extends HarperShapedBase {
+  async post(args: any) { lastCall = { resource: "Memory.post", ctx: this._ctx, args, isCollection: this.isCollection } as any; return { ok: true, resource: "Memory.post", agentId: this._ctx?.request?.tpsAgent }; }
   async put(args: any) { lastCall = { resource: "Memory.put", ctx: this._ctx, args }; return { ok: true, resource: "Memory.put", agentId: this._ctx?.request?.tpsAgent }; }
   async get(id: any) {
     lastCall = { resource: "Memory.get", ctx: this._ctx, args: id };
@@ -52,10 +77,7 @@ class MemoryMock {
   }
   async delete(id: any) { lastCall = { resource: "Memory.delete", ctx: this._ctx, args: id }; return { ok: true, resource: "Memory.delete", agentId: this._ctx?.request?.tpsAgent }; }
 }
-class SoulMock {
-  _ctx: any;
-  isCollection = false;
-  constructor(_id: any, ctx: any) { this._ctx = ctx; }
+class SoulMock extends HarperShapedBase {
   async put(args: any) { lastCall = { resource: "Soul.put", ctx: this._ctx, args }; return { ok: true, resource: "Soul.put", agentId: this._ctx?.request?.tpsAgent }; }
   async get(id: any) { lastCall = { resource: "Soul.get", ctx: this._ctx, args: id }; return { ok: true, resource: "Soul.get", agentId: this._ctx?.request?.tpsAgent }; }
 }

--- a/test/unit/resolve-agent-auth.test.ts
+++ b/test/unit/resolve-agent-auth.test.ts
@@ -15,9 +15,9 @@ mock.module("harper", () => ({
   Resource: class {},
 }));
 
-const { resolveAgentAuth, hasCredentialEvidence } = await import("../../resources/agent-auth.ts");
+const { resolveAgentAuth, hasCredentialEvidence, allowVerified, allowAdmin } = await import("../../resources/agent-auth.ts");
 // Zero-import module — safe to load statically alongside the mocked harper.
-import { agentContext } from "../../resources/in-process.ts";
+import { agentContext, adminContext, internalContext } from "../../resources/in-process.ts";
 
 // ─── Request-shape helpers ────────────────────────────────────────────────────
 
@@ -110,15 +110,57 @@ describe("resolveAgentAuth — resources/in-process.ts's agentContext()", () => 
       .toEqual({ kind: "agent", agentId: "no-such-principal-anywhere", isAdmin: false });
   });
 
-  it("agentContext(id, { isAdmin: true }) → admin, ASSERTED: nothing checks the agent really is one", async () => {
-    expect(await resolveAgentAuth(agentContext("provisioner", { isAdmin: true })))
+  it("adminContext(id) → admin, ASSERTED: nothing checks the agent really is one", async () => {
+    expect(await resolveAgentAuth(adminContext("provisioner")))
       .toEqual({ kind: "agent", agentId: "provisioner", isAdmin: true });
   });
 
+  it("internalContext() → internal, the deliberate unfiltered verdict", async () => {
+    expect(await resolveAgentAuth(internalContext())).toEqual({ kind: "internal" });
+  });
+
   it("NO context → internal, which is ADMIN-EQUIVALENT (the embedding hazard)", async () => {
-    // Not a weaker call — an unfiltered one. This is why agentContext() must be
-    // required, never defaulted, in an application wrapper.
+    // Not a weaker call — an unfiltered one.
     expect(await resolveAgentAuth(undefined)).toEqual({ kind: "internal" });
+  });
+});
+
+// ─── WHY agentContext() refuses a missing id ─────────────────────────────────
+//
+// This is the measurement the guard is built on, kept as a permanent test so the
+// guard can never be "simplified away" without its justification failing loudly
+// in the same run. `resolveAgentAuth` tests `tpsAgent` for TRUTHINESS, so an id
+// that came back undefined is indistinguishable from no identity at all — and
+// that is the trusted, unfiltered verdict. It even passes the ADMIN-only gate.
+//
+// If any of these ever stop holding, resources/in-process.ts's runtime guards
+// have become unnecessary and should be revisited deliberately, not by accident.
+
+describe("resolveAgentAuth — a missing/empty tpsAgent is INDISTINGUISHABLE from no identity", () => {
+  for (const [label, value] of [["undefined", undefined], ["null", null], ["empty string", ""]] as [string, unknown][]) {
+    it(`{ tpsAgent: ${label} } → internal (unfiltered), NOT anonymous`, async () => {
+      expect(await resolveAgentAuth({ request: { tpsAgent: value, tpsAgentIsAdmin: false } }))
+        .toEqual({ kind: "internal" });
+    });
+  }
+
+  it("and that verdict PASSES the admin-only gate — a forgotten id is a superuser", async () => {
+    const forgotten = { request: { tpsAgent: undefined, tpsAgentIsAdmin: false } };
+    expect(await allowVerified(forgotten)).toBe(true);
+    expect(await allowAdmin(forgotten)).toBe(true);
+  });
+
+  it("POSITIVE CONTROL: a real id resolves to that agent, so the above is not a broken harness", async () => {
+    expect(await resolveAgentAuth({ request: { tpsAgent: "planner" } }))
+      .toEqual({ kind: "agent", agentId: "planner", isAdmin: false });
+    expect(await allowAdmin({ request: { tpsAgent: "planner" } })).toBe(false);
+  });
+
+  it("a BLANK id is truthy, so it silently becomes a real agent id (misattribution, not escalation)", async () => {
+    // Also refused by agentContext(), for a different reason: memories written
+    // under an agent named three spaces are a bug either way.
+    expect(await resolveAgentAuth({ request: { tpsAgent: "   " } }))
+      .toEqual({ kind: "agent", agentId: "   ", isAdmin: false });
   });
 });
 

--- a/test/unit/resolve-agent-auth.test.ts
+++ b/test/unit/resolve-agent-auth.test.ts
@@ -16,6 +16,8 @@ mock.module("harper", () => ({
 }));
 
 const { resolveAgentAuth, hasCredentialEvidence } = await import("../../resources/agent-auth.ts");
+// Zero-import module — safe to load statically alongside the mocked harper.
+import { agentContext } from "../../resources/in-process.ts";
 
 // ─── Request-shape helpers ────────────────────────────────────────────────────
 
@@ -85,6 +87,38 @@ describe("resolveAgentAuth — gate annotations (handler phase)", () => {
 
   it("explicit tpsAnonymous marker → anonymous (set by the non-rejecting gate)", async () => {
     expect(await resolveAgentAuth({ tpsAnonymous: true })).toEqual({ kind: "anonymous" });
+  });
+});
+
+// ─── the in-process seam emits exactly the shape this resolver honours ────────
+//
+// resources/in-process.ts's agentContext() is what an embedding Harper app (and
+// flair's own MCP handler) builds to act as one specific agent. It is only
+// correct if THIS resolver reads it as that agent — so the link is pinned here,
+// against the real resolver, rather than restated as a literal in two files.
+
+describe("resolveAgentAuth — resources/in-process.ts's agentContext()", () => {
+  it("agentContext(id) → that agent, ASSERTED: no signature, and no Agent-table lookup", async () => {
+    // The harper mock at the top of this file resolves EVERY Agent.get to null,
+    // so a passing assertion here is itself the proof that identity is taken at
+    // face value — an id with no Principal record acts as that agent. Correct
+    // for a caller already inside the trust boundary; the reason the context
+    // must be built from the app's own state and never from request data.
+    expect(await resolveAgentAuth(agentContext("planner")))
+      .toEqual({ kind: "agent", agentId: "planner", isAdmin: false });
+    expect(await resolveAgentAuth(agentContext("no-such-principal-anywhere")))
+      .toEqual({ kind: "agent", agentId: "no-such-principal-anywhere", isAdmin: false });
+  });
+
+  it("agentContext(id, { isAdmin: true }) → admin, ASSERTED: nothing checks the agent really is one", async () => {
+    expect(await resolveAgentAuth(agentContext("provisioner", { isAdmin: true })))
+      .toEqual({ kind: "agent", agentId: "provisioner", isAdmin: true });
+  });
+
+  it("NO context → internal, which is ADMIN-EQUIVALENT (the embedding hazard)", async () => {
+    // Not a weaker call — an unfiltered one. This is why agentContext() must be
+    // required, never defaulted, in an application wrapper.
+    expect(await resolveAgentAuth(undefined)).toEqual({ kind: "internal" });
   });
 });
 


### PR DESCRIPTION
## Why

A Harper application that loads Flair as a sub-component should be able to register N agents and act as each of them **entirely in-process** — no shell, no CLI, no HTTP hop. That is the shape a Fabric deployment has, where there is no shell on the node at all.

Two things stood in the way, and neither fails in a way that points at the cause. This PR fixes both, and proves the result against a real two-component Harper.

## The security model, stated where it cannot be missed

**In-process identity is asserted, not verified.** `resolveAgentAuth()` reads `context.request.tpsAgent` and returns that agent — no signature, no lookup against the `Agent` table, no registration requirement. `tpsAgentIsAdmin: true` is asserted the same way and grants unfiltered cross-agent reads and writes.

That is correct design, not a gap: a co-located caller is already inside the trust boundary and could write the raw table directly, so demanding a signature from same-process code would be theatre. Ed25519 exists for callers *outside* the process.

The consequence is the most important thing in the integration:

> **Build the context from your own server-side state. Never from request data.** An agent id that reaches `agentContext()` from user input is privilege escalation with no error, no 403 and no trace.

Two ways to lose the model, from opposite ends — both now pinned as tests:

| | |
|---|---|
| **By omission** | No context resolves to Flair's trusted `internal` verdict, which is **admin-equivalent** (#936) — every read unscoped, every write unattributed. |
| **By assertion** | An attacker-influenced `agentId`, or a stray `isAdmin: true`, is honoured verbatim. |

**Prefer individual agent identities over one shared app identity.** A per-agent context costs nothing — no client to construct, no key to load, not even a registration. Collapsing N agents onto one identity loses per-agent attribution (what trust grading and provenance are computed from) and turns N blast radii into one.

**In a cluster.** Harper replicates every table in a replicated database unless the table opts out with `@table(replicate: false)`; none of Flair's do. So the registry replicates, authority is local (the context is built per call, in whichever process handles it), and attribution travels because `agentId` is a field on the record. The consequence: **every node running the app is equally trusted**, since each can assert any identity. Fine for one application across regions — a single trust domain by construction. Not fine beside untrusted co-tenants on the same instance: co-location *is* the grant.

> Worth correcting a natural misreading: replication comes from the **database** being replicated, not from `@export`, which only controls REST exposure. `Memory` carries no `@export` and still replicates.

## What is in here

**`resources/in-process.ts`** — the seam, and the one place these facts live:

- `agentContext(agentId, { isAdmin })` — the context that makes a call act as one specific agent.
- `collectionResource(Cls, context)` — the collection-bound instance Harper requires for a create.

The second one is not a convenience. A resource's `post()` only works on an instance Harper has marked as a collection, and that mark is a **private** field. The public `isCollection` is a getter with no setter on `Resource.prototype`, so the obvious `h.isCollection = true` throws `TypeError: Cannot set property isCollection … which has only a getter` under ESM strict mode; dropping the assignment instead yields `405 … does not have a post method implemented`.

**Flair itself had this wrong.** `memory_store`, `memory_update` (with `preserveHistory`), `flair_workspace_set` and `flair_orgevent` all assigned to `isCollection` and threw before writing anything. All four now go through the seam. Read-only tools were unaffected.

The unit doubles carried a *writable* `isCollection` field, which accepted the assignment and kept the suite green — a double easier to satisfy than the real class. They now reproduce Harper's getter-only accessor and private collection flag, so the same mistake fails a test.

**Registration** goes through the `Agent` resource rather than the raw table, so a record gets the full Principal shape (`kind`/`status`/`displayName`/`admin`/`defaultTrustTier`, plus the federation originator stamp) from one source instead of a hand-copied literal that drifts. Ed25519 key material needs nothing but `node:crypto`.

## The proof

Every other in-process test in this repo runs against a mocked `harper`, which cannot catch the cross-component registry lookup or the collection binding. So `test/integration/in-process-agents.test.ts` boots a **real second Harper application** — `test/fixtures/inproc-app`, a copyable reference implementation — with this build symlinked in as the Flair component, and asserts:

- The app resolves Flair's **resources** (not just its tables) from the shared registry.
- Two agents registered in-process, with keys the app minted, each landing a complete Principal record — and one of them then authenticating **over HTTP** with that key, with a forged signature rejected.
- **Scoping, both directions.** Each agent sees its own private + both shared, and never the other's private one, by search *or* by id. Neither can write a record the other owns.
- **The boundary.** Claiming another agent's id works. An id with no `Agent` record works. Asserting `isAdmin` on a non-admin principal grants unfiltered reads and cross-agent writes. A context-less call reads everything.
- **Attribution is storage state.** A fresh Harper process over the same storage resolves identical per-agent scope — nothing about who an agent is, or what it may see, lives in the process that wrote the record. (This harness runs one node; Harper's replication transport itself is not exercised.)

Every load-bearing assertion was mutation-checked: unscoped `recall` fails the scoping tests, an unscoped by-id read fails the by-id test, raw-table registration fails the Principal-shape test, a silently-admin context fails the no-forge test, and reintroducing `h.isCollection = true` fails four unit tests.

## Verification

Measured against unmodified `origin/main` (977ea4b) in a separate worktree, same machine:

| Lane | Baseline | This branch |
|---|---|---|
| `bun test test/unit/` | 3295 pass / 0 fail (179 files) | **3307 pass / 0 fail** (180 files) |
| `test/unit-isolated/` (per-file) | 21 / 107 / 11, 0 fail | **21 / 107 / 11, 0 fail** |
| `bun test test/integration/` | 314 pass / 0 fail | **330 pass / 0 fail** |

Deltas are exactly the new tests (+12 unit, +16 integration). Also clean: `tsc -p tsconfig.check.json`, `tsconfig.check.src.json`, `tsconfig.cli.json`; `semgrep --config=auto --error` over the changed files (0 findings); `changelog-fragments check`; `docs-freshness-check`.

## Found, deliberately not fixed

- **`AgentSeed` cannot be called in-process.** Its `allowCreate()` returns `allowAdmin(ctx)`, which explicitly permits the trusted `internal` verdict — but `post()` then re-checks with a hand-rolled `request?.tpsAgent` read and 403s when it is absent. So a context-less in-process call is rejected by the very gate that was written to allow it (verified: `403 forbidden: admin only`). Left alone because widening an admin gate is not something to slip into a PR about proving scoping. An app can register agents through the `Agent` resource, which is what this PR does; `AgentSeed` additionally seeds Soul entries and starter memories.
- **`Agent.put()` silently strips `publicKey`**, with a comment pointing at a "dedicated endpoint" for key rotation. There is no such endpoint — the CLI rotates by writing the raw table through the admin ops API, which an in-process app can also do. Worth either building the endpoint or correcting the comment.
- **`server.resources` is not in `types/harper.d.ts`**, so a TypeScript embedder needs a cast. Adding it there would only help Flair's own compilation (that file is not shipped), and Flair does not use the registry itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
