### PR TITLE
fix(init): detect MCP clients by PATH only, never by shelling out to npm

### DIFF
--- a/.changelog/unreleased/fixed-client-detection-never-shells-out.md
+++ b/.changelog/unreleased/fixed-client-detection-never-shells-out.md
@@ -1,0 +1,21 @@
+- **`flair init` no longer stalls for seconds detecting MCP clients, and no longer
+  reports a client that is not installed.** Detection asked `npm list -g <pkg>`
+  whenever a client's binary was not on PATH. That call walks the entire global
+  package tree — around 0.8 s each on a warm machine, with no timeout — and
+  `flair init` made up to three of them, so anyone without Claude Code, Codex and
+  Gemini installed waited on a silent multi-second probe during first-run setup.
+
+  It was also answering the wrong question. `npm list -g <pkg>` exits 0 when the
+  package appears anywhere in the global tree, including as a transitive
+  dependency of an unrelated global tool, and Gemini was probed with
+  `@google/generative-ai` — a library, not the CLI. Flair could therefore report
+  Gemini "detected" and write `~/.gemini/settings.json` on a machine with no
+  `gemini` binary. In the other direction it assumed npm's default global prefix,
+  so it reported "not installed" for mise / fnm / nvm / volta users.
+
+  All four clients are now detected the same way, by looking for their executable
+  on PATH, with no subprocess at all. Nothing installed is missed: `npm install
+  -g` links a package's binary into the prefix's bin directory, which is on PATH
+  by construction. A client whose binary is not on PATH could not be launched
+  anyway, and `flair init --client <name>` still wires one explicitly without
+  consulting detection.

--- a/src/install/clients.ts
+++ b/src/install/clients.ts
@@ -32,13 +32,14 @@ export type WireEnv = { FLAIR_AGENT_ID: string; FLAIR_URL: string; FLAIR_CLIENT?
 export interface Client {
   id: ClientId;
   label: string;
+  /** The executable that has to be on PATH for this client to be usable. */
+  bin: string;
   detected: boolean;
   wire: (env: WireEnv) => { ok: boolean; message: string };
 }
 
 // ---- Detection helpers ----------------------------------------------------------
 
-import { spawnSync } from "node:child_process";
 import { accessSync, constants, existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { dirname, join } from "node:path";
@@ -78,52 +79,42 @@ function binInPath(name: string): boolean {
 }
 
 /**
- * Claude Code is INSTALLED when its binary is on PATH — the same test every
- * other client here uses, and the one that matches how Claude Code is actually
- * distributed. The npm-global lookup below is only a fallback: Claude Code's
- * native installer puts `claude` on PATH without registering an npm global, so
- * `npm list -g @anthropic-ai/claude-code` alone reports "not installed" for a
- * large share of real users (flair#906).
+ * A client is INSTALLED when its executable is on PATH. One rule for all four,
+ * evaluated with filesystem calls only — detection never starts a subprocess.
+ *
+ * Claude Code, Codex and Gemini used to fall back to `npm list -g <pkg>` when
+ * the binary was absent. That fallback was removed (flair#906 follow-up); it
+ * was wrong in three separate directions and bought nothing:
+ *
+ *   1. UNBOUNDED AND SLOW ON AN INTERACTIVE PATH. `npm list -g <pkg>` walks the
+ *      whole global tree, measured at ~0.8 s per call on a warm developer
+ *      machine, with no `timeout` set. `flair init` calls detectClients(), so a
+ *      user with none of these clients paid up to three of those walks — seconds
+ *      of silent stall on first run — and on a loaded CI runner the same three
+ *      calls blew past a 5 s test timeout.
+ *
+ *   2. FALSE POSITIVES. `npm list -g <pkg>` exits 0 when the package appears
+ *      ANYWHERE in the global tree, including as a transitive dependency of an
+ *      unrelated global package. Gemini was probed with `@google/generative-ai`
+ *      — a library, not the CLI — so any globally installed tool that depended
+ *      on it made Flair report Gemini "detected" and write ~/.gemini/settings.json
+ *      for a CLI that was not on the machine.
+ *
+ *   3. FALSE NEGATIVES. It assumes npm's default global prefix, so it reports
+ *      "not installed" for mise / fnm / nvm / volta users whose prefix lives
+ *      elsewhere — the same defect already fixed for `flair upgrade`'s presence
+ *      probes (see "Upgrade presence probes" in src/cli.ts).
+ *
+ * Nothing is lost by dropping it: an `npm install -g` links the package's bin
+ * into the prefix's bin directory, which is on PATH by construction (it is where
+ * `npm` itself is found from). A client whose binary is NOT on PATH is a client
+ * the user cannot launch, and wiring an MCP config for it is at best a no-op.
+ * `flair init --client <name>` still wires a client explicitly, bypassing
+ * detection entirely, so an exotic install is never locked out.
  */
-function claudeCodeDetect(): boolean {
+function detectBin(bin: string): boolean {
   try {
-    if (binInPath("claude")) return true;
-    const result = spawnSync("npm", ["list", "-g", "@anthropic-ai/claude-code"], {
-      stdio: ["ignore", "ignore", "ignore"],
-    });
-    return result.status === 0;
-  } catch (_e: unknown) {
-    return false;
-  }
-}
-
-function codexDetect(): boolean {
-  try {
-    if (binInPath("codex")) return true;
-    const npmResult = spawnSync("npm", ["list", "-g", "@openai/codex"], {
-      stdio: ["ignore", "ignore", "ignore"],
-    });
-    return npmResult.status === 0;
-  } catch (_e: unknown) {
-    return false;
-  }
-}
-
-function geminiDetect(): boolean {
-  try {
-    if (binInPath("gemini")) return true;
-    const npmResult = spawnSync("npm", ["list", "-g", "@google/generative-ai"], {
-      stdio: ["ignore", "ignore", "ignore"],
-    });
-    return npmResult.status === 0;
-  } catch (_e: unknown) {
-    return false;
-  }
-}
-
-function cursorDetect(): boolean {
-  try {
-    return binInPath("cursor");
+    return binInPath(bin);
   } catch (_e: unknown) {
     return false;
   }
@@ -336,21 +327,25 @@ export const ALL_CLIENTS: Omit<Client, "detected">[] = [
   {
     id: "claude-code",
     label: "Claude Code",
+    bin: "claude",
     wire: _wireClaudeCode,
   },
   {
     id: "codex",
     label: "Codex",
+    bin: "codex",
     wire: _wireCodex,
   },
   {
     id: "gemini",
     label: "Gemini",
+    bin: "gemini",
     wire: _wireGemini,
   },
   {
     id: "cursor",
     label: "Cursor",
+    bin: "cursor",
     wire: _wireCursor,
   },
 ];
@@ -436,19 +431,15 @@ export function renderWiringSummary(
   return lines;
 }
 
+/**
+ * Detect every known client. One rule (`bin` on PATH) applied uniformly, so a
+ * client added to ALL_CLIENTS is detected by declaring its executable — there is
+ * no per-client branch here to forget to extend.
+ */
 export function detectClients(): Client[] {
   return ALL_CLIENTS.map((client) => ({
     ...client,
-    detected:
-      client.id === "claude-code"
-        ? claudeCodeDetect()
-        : client.id === "codex"
-          ? codexDetect()
-          : client.id === "gemini"
-            ? geminiDetect()
-            : client.id === "cursor"
-              ? cursorDetect()
-              : false,
+    detected: detectBin(client.bin),
   }));
 }
 

--- a/test/unit/init-wiring-summary.test.ts
+++ b/test/unit/init-wiring-summary.test.ts
@@ -152,12 +152,69 @@ describe("Claude Code detection is by binary on PATH, not by its config (flair#9
   });
 
   it("does not detect Claude Code when the binary is absent", () => {
-    // Empty-ish PATH: no `claude`, and the npm-global fallback cannot run
-    // either, so this exercises the negative case end to end.
+    // Empty PATH: no `claude` anywhere, so this exercises the negative case
+    // end to end.
     process.env.PATH = isoHome;
     const claudeCode = detectClients().find(c => c.id === "claude-code")!;
     expect(claudeCode.detected).toBe(false);
   });
+
+  it("reports NO client detected when PATH holds none of their binaries", () => {
+    // The Gemini false positive: detection used to fall back to
+    // `npm list -g @google/generative-ai`, which exits 0 when that package is
+    // anywhere in the global tree — including as a transitive dependency of an
+    // unrelated global tool. Gemini was then reported installed, and
+    // ~/.gemini/settings.json written, on a machine with no `gemini` binary.
+    // PATH is the only question detection asks now, so the answer cannot
+    // depend on what else happens to be installed globally.
+    process.env.PATH = isoHome;
+    for (const client of detectClients()) {
+      expect(`${client.id}=${client.detected}`).toBe(`${client.id}=false`);
+    }
+  });
+
+  it("detects a client purely from its own binary, never a sibling's", () => {
+    fakeBinOnPath(isoHome, "gemini");
+    const byId = new Map(detectClients().map(c => [c.id, c.detected]));
+    expect(byId.get("gemini")).toBe(true);
+    expect(byId.get("claude-code")).toBe(false);
+    expect(byId.get("codex")).toBe(false);
+    expect(byId.get("cursor")).toBe(false);
+  });
+});
+
+describe("client detection is bounded — it never shells out (flair#906 follow-up)", () => {
+  /**
+   * Detection runs on `flair init`, an interactive first-run path, so its cost
+   * has to be bounded by construction rather than by luck.
+   *
+   * It used to fall back to `npm list -g <pkg>` for three of the four clients
+   * whenever their binary was absent — an unbounded subprocess that walks the
+   * entire global package tree, measured at ~800 ms per call on a warm
+   * developer machine. A user with none of these clients installed paid up to
+   * three of those in silence, and on a loaded CI runner the same calls pushed
+   * a sibling test past its 5 s timeout.
+   *
+   * PATH here contains no client binary at all, which is precisely the case
+   * that triggered every fallback — the most expensive path detection has.
+   * Filesystem-only detection measures ~0.04 ms per call, so the budget below
+   * sits several hundred times above real cost while remaining far under what
+   * even a single npm spawn per iteration would need (~9 s at the fastest
+   * spawn time we have observed on CI). Restoring any subprocess to the
+   * detection path fails this test rather than merely making it flaky.
+   */
+  const ITERATIONS = 40;
+  const BUDGET_MS = 1000;
+
+  it(`runs ${ITERATIONS} full detection passes well inside ${BUDGET_MS}ms`, () => {
+    process.env.PATH = isoHome;
+
+    const started = performance.now();
+    for (let i = 0; i < ITERATIONS; i++) detectClients();
+    const elapsed = performance.now() - started;
+
+    expect({ overBudget: elapsed > BUDGET_MS }).toEqual({ overBudget: false });
+  }, 60_000);
 });
 
 describe("wiring Claude Code creates ~/.claude.json when it does not exist", () => {


### PR DESCRIPTION
## Summary

`Unit Tests (node 24)` timed out on the v0.31.0 release PR. It is not a flake — it is a real, measurable stall on the `flair init` first-run path, and the same call site produces wrong answers as well as slow ones.

Client detection fell back to `npm list -g <pkg>` for Claude Code, Codex and Gemini whenever the client's binary was not on PATH. That subprocess had **no `timeout` set** and walks the entire global package tree.

## Measured

| | |
|---|---|
| `npm list -g <pkg>`, warm, 10-package global tree | **0.78–0.96 s** per call (`--depth=0`: 0.50 s) |
| `detectClients()` before | up to **3** such calls = ~2.4 s, unbounded |
| `detectClients()` after | **0.038 ms** per pass |
| `test/unit/init-wiring-summary.test.ts` | **4.02 s to 18 ms** |
| Full `bun test test/unit/` lane | **26.45 s to 22.16 s** (3295 pass to 3298 pass, 0 fail) |

Per-test timing before the fix showed the two detection tests at **2.40 s and 1.60 s** while every sibling in the file was under 1.4 ms — ~800 ms per npm spawn, 2 or 3 spawns each. On a loaded runner that clears 5 s.

Why the test's PATH isolation did not prevent it: **Bun's `spawnSync` resolves the command from the PATH captured at process start**, so setting `process.env.PATH` to a temp dir does not stop `npm` from being found and run. The test believed it had isolated detection; it had not.

## The fallback was wrong in both directions

**False positives (the reported Gemini bug).** `npm list -g <pkg>` exits 0 when the package is anywhere in the global tree, including as a transitive dependency of an unrelated global package. Verified locally: `npm list -g @ai-sdk/google` and `npm list -g @aws-sdk/client-bedrock` both exit 0 although neither is a globally installed CLI. Gemini was additionally probed with `@google/generative-ai` — a library, not the CLI — so Flair could report Gemini detected and write `~/.gemini/settings.json` on a machine with no `gemini` binary.

**False negatives.** It assumes npm's default global prefix, so it reports "not installed" under mise / fnm / nvm / volta. This repo already fixed exactly that defect for `flair upgrade`'s presence probes (see "Upgrade presence probes" in `src/cli.ts`).

## The fix

All four clients are now detected the same way — executable on PATH — with **no subprocess at all**. The per-client `if/else` dispatch is replaced by a `bin` field on each entry, so a new client is detected by declaring its executable rather than by extending a branch.

**Nothing installed is missed.** `npm install -g` links a package's bin into the prefix's bin directory, which is on PATH by construction — it is where `npm` itself is found from. Verified on this machine: `@openai/codex` is npm-global-installed and `codex` resolves through the prefix's bin symlink. A client whose binary is not on PATH is one the user cannot launch, and `flair init --client <name>` still wires a client explicitly without consulting detection.

## On the timeout semantics

The brief asked what a detection timeout should mean. Removing the subprocess removes the question: a PATH scan is total — it finds an executable or it does not, and there is no "could not determine" state to misreport as "not installed". That is a stronger resolution than bounding the spawn and then having to choose a policy for the ambiguous answer.

## Regression guard and mutation check

A new test runs 40 full detection passes against a 1000 ms budget, with PATH holding no client binary — the exact case that triggered every fallback.

- **Green:** 40 passes in ~1.5 ms (~660x headroom).
- **Mutated** (npm fallback restored): 40 passes take **96.7 s**, the assertion reports `overBudget: true`, and it also blows the 60 s guard. Both signals fire.
- **Restored:** 15 pass, 16 ms.

The budget sits several hundred times above real cost and far below what even one npm spawn per iteration would need, so it cannot degrade into a flaky timeout the way the original did.

Two further tests cover the correctness half: no client is reported detected when PATH holds none of their binaries, and a client is detected only from its own binary and never a sibling's.

## Found but deliberately not fixed

- `binInPath` calls `accessSync` per PATH entry. A PATH entry on a hung network mount could block. This is pre-existing, applies equally to the Cursor path that never had a fallback, and is orders of magnitude less likely than spawning npm. Out of scope here.
- `resources/auth-middleware.ts:69` has a pre-existing `tsc --noEmit` error (TS2722), unrelated to this change. The build runs `--noCheck`, so CI is unaffected.
- The header comment in `src/install/clients.ts` still describes a per-client `detect()`; the shape is now uniform. Left alone to keep the diff to the defect.

## Verification

- Lane: `bun test test/unit/` — the exact command from `.github/workflows/test.yml`.
- Baseline measured on unmodified `origin/main` in the same worktree: 3295 pass, 0 fail, 26.45 s.
- With the fix: 3298 pass (3 new), 0 fail, 22.16 s.
- `node scripts/docs-freshness-check.mjs`: all 6 checks pass.
- `node scripts/changelog-fragments.mjs check`: 34 fragments, no stray `[Unreleased]` entries.
- Production Flair untouched and healthy throughout (`/Health` 200); no ephemeral Harper orphans.

CHANGELOG entry is a fragment file (`.changelog/unreleased/fixed-client-detection-never-shells-out.md`) in the same commit as the fix.
