### PR TITLE
fix(release): bump every version declaration, not just package.json

### DIFF
--- a/.changelog/unreleased/fixed-release-version-sync.md
+++ b/.changelog/unreleased/fixed-release-version-sync.md
@@ -1,0 +1,30 @@
+- **Every release went red in CI on a version the release script itself failed to
+  bump.** `scripts/release.sh` bumped the eight `package.json` files and nothing
+  else, but the version is also declared in `packages/flair-bench/src/version.ts`
+  as a plain `TOOL_VERSION` constant — deliberately, since a runtime JSON import
+  of `package.json` trips NodeNext import-attribute edges in the published
+  `dist/`. A flair-bench test asserts the two are equal, so it failed on every
+  release until an operator remembered to hand-edit the constant. It looked like
+  a flake. It was not: a documented manual step that a script could perform is a
+  gap in the script, and the operator was standing in for a missing line of code.
+
+  The reason it reached CI at all is that `release.sh`'s own test step runs only
+  `test/unit/`, `test/integration/` and `test/unit-isolated/`; the flair-bench
+  package tests are a separate CI job. The release therefore bumped, built and
+  tested green locally and only failed *after* the release branch existed, the
+  changelog fragments had been consumed, and the PR was open — which is the
+  expensive place to fail.
+
+  `release.sh` now bumps that constant and stages it in the version-bump commit
+  (its `git add` list is deliberately explicit rather than `-A`, so a new path
+  that is not named there is silently left out of the release). A new
+  `scripts/check-version-sync.mjs` backs it from both ends: `release.sh`
+  **preflights** it before creating the branch or touching the changelog, so an
+  out-of-sync tree costs nothing to recover from, and re-runs it after the bump
+  so a missed site cannot be committed. It also runs in CI, where it does the
+  part that stops this recurring — a scan that fails when *any* file outside the
+  known set declares the release version, so the next version-bearing file
+  someone adds is caught on the PR that adds it rather than at a release weeks
+  later. The check refuses to pass when it cannot actually run: a scan that finds
+  no declaration of the current version anywhere, not even in `package.json`, is
+  a broken scan, and it reports that instead of a green tick.

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -163,6 +163,26 @@ jobs:
             echo "  ok $name @ $pv"
           done
 
+      - name: Verify version declarations outside package.json match the tag
+        # The loop above reads package.json files only. The version is also
+        # declared in source -- packages/flair-bench/src/version.ts holds it as
+        # a TOOL_VERSION constant -- and nothing here could see that.
+        #
+        # This is the LAST gate before npm staging. Everything upstream of a tag
+        # is recoverable; a staged tarball and a pushed tag are not, and the only
+        # thing after this is a human 2FA approval that cannot be expected to
+        # catch a wrong version constant. Relying on the release PR's CI to have
+        # caught it assumes no one ever merges past a red check, which is not an
+        # assumption this repo has earned.
+        #
+        # Same script release.sh preflights with, deliberately: a fourth call
+        # site is correct, a fourth implementation would be the bug this whole
+        # change exists to prevent. Needs only node + the git checkout, both
+        # already set up above.
+        env:
+          VERSION: ${{ steps.ver.outputs.version }}
+        run: node scripts/check-version-sync.mjs "$VERSION"
+
       - name: Build
         run: |
           set -euo pipefail

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -72,6 +72,13 @@ jobs:
         # that workspace package ships. Local dev hides it (bun symlinks);
         # only consumers of the published tarball see the staleness.
         run: node scripts/check-workspace-deps.mjs
+      - name: "Check version declarations in sync"
+        # The release version is declared outside package.json too (e.g.
+        # flair-bench's TOOL_VERSION constant). release.sh preflights this, but
+        # running it here catches a NEW declaration site on the PR that adds it,
+        # while the author still has the context — rather than at a release
+        # weeks later, after the release branch and PR already exist.
+        run: node scripts/check-version-sync.mjs
       - name: "Check production dep bake time (≥7 days)"
         # Supply-chain bake-time guard. Fails if any external pinned production
         # dep was published <7 days ago — catches the "compromise published,

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -36,6 +36,17 @@ This assembles the changelog, bumps every workspace package to the version, alig
 internal deps, refreshes `bun.lock`, builds, tests, and opens a `release: v0.11.0` PR.
 Review and merge it (CI green + K&S approval) the same as any other PR.
 
+**Nothing about the version is bumped by hand.** The version is declared outside
+`package.json` too — `packages/flair-bench/src/version.ts` holds it as a `TOOL_VERSION`
+constant — and `release.sh` bumps every such site. It checks them *before* creating the
+branch, so an out-of-sync tree aborts while nothing has been touched, and again after the
+bump so a missed site can't be committed. The same check runs in CI
+(`node scripts/check-version-sync.mjs`) and fails on any file outside the known set that
+declares the release version, so a new version-bearing file is caught on the PR that adds
+it. If you ever find yourself editing a version constant by hand during a release, that is
+a bug in the script — add the file to `SOURCE_VERSION_FILES` in
+`scripts/check-version-sync.mjs` and to the `git add` list in `scripts/release.sh`.
+
 **The changelog is assembled, not hand-promoted.** Entries land during development as one
 file per change under `.changelog/unreleased/` (flair#835 — a shared `[Unreleased]` block
 conflicted on every concurrent PR, and resolving a conflict dismisses approvals). The

--- a/scripts/check-version-sync.mjs
+++ b/scripts/check-version-sync.mjs
@@ -137,12 +137,19 @@ function trackedFiles() {
   return out.split("\0").filter(Boolean);
 }
 
+/**
+ * Decode as UTF-8 unconditionally. There is deliberately NO binary sniff: the
+ * obvious one — "contains a NUL byte" — excluded `src/mcp-client-assertion.ts`,
+ * a real TypeScript file that embeds literal NULs as a cache-key delimiter.
+ * A source file quietly dropped from the scan is precisely the failure this
+ * script exists to prevent. Binary files are harmless to scan: a GIF cannot
+ * accidentally contain the ASCII text of a version declaration. Only the size
+ * cap skips anything, and skips are reported.
+ */
 function readTextOrNull(abs) {
   try {
     if (statSync(abs).size > MAX_SCAN_BYTES) return null;
-    const buf = readFileSync(abs);
-    if (buf.includes(0)) return null; // binary
-    return buf.toString("utf8");
+    return readFileSync(abs).toString("utf8");
   } catch {
     return null;
   }
@@ -222,10 +229,17 @@ function verify(expected) {
 
   const pattern = declarationPattern(expected);
   const hits = [];
+  const skipped = [];
   for (const path of files) {
     if (isExcluded(path)) continue;
     const text = readTextOrNull(join(REPO_ROOT, path));
-    if (text === null) continue;
+    // Binary or oversized. Report rather than skip silently — a file the scan
+    // could not read is not a file the scan cleared. No tracked file hits this
+    // today; if one starts to, it should be visible, not absorbed.
+    if (text === null) {
+      skipped.push(path);
+      continue;
+    }
     if (pattern.test(text)) hits.push(path);
   }
 
@@ -259,6 +273,10 @@ function verify(expected) {
     process.exit(1);
   }
 
+  if (skipped.length > 0) {
+    console.log(`  note: ${skipped.length} unreadable (binary/oversized) file(s) not scanned:`);
+    for (const p of skipped.slice(0, 10)) console.log(`    ${p}`);
+  }
   console.log(
     `✓ Version ${expected} consistent across ${INVENTORY.size} declaration sites; ` +
       `no unknown sites in ${files.length} tracked files.`,

--- a/scripts/check-version-sync.mjs
+++ b/scripts/check-version-sync.mjs
@@ -1,0 +1,262 @@
+#!/usr/bin/env node
+/**
+ * check-version-sync.mjs — the release version is declared in more than one
+ * place. Keep every one of them in lockstep, and make it impossible to add a
+ * new one without the release script learning about it.
+ *
+ * PROBLEM. `scripts/release.sh` bumped the eight `package.json` files and
+ * nothing else. `packages/flair-bench/src/version.ts` also declares the
+ * version — deliberately, as a plain constant rather than a runtime JSON
+ * import — and a test asserts it equals its package.json. So every release
+ * went red in CI until an operator remembered to hand-edit that constant.
+ * Worse, release.sh's own local test step runs only `test/unit/`,
+ * `test/integration/` and `test/unit-isolated/`; the flair-bench package
+ * tests are a separate CI job. The release therefore built, tested and pushed
+ * green locally and only failed after the branch, the changelog assembly and
+ * the PR already existed. Recovering from a half-run release is the expensive
+ * part.
+ *
+ * FIX, two halves:
+ *
+ *   1. INVENTORY — an explicit list of every file that must carry the release
+ *      version, and the ability to both verify and rewrite it. release.sh
+ *      calls `--write` to bump, and this same module owns the pattern used to
+ *      do it, so the bumping regex and the checking regex cannot drift apart.
+ *
+ *   2. DISCOVERY — a scan for anything OUTSIDE the inventory that declares the
+ *      reference version. Half 1 alone fixes today's file; half 2 is what
+ *      stops the class, because the next version-bearing file someone adds
+ *      fails this check at the PR that adds it rather than at a release
+ *      months later.
+ *
+ * Discovery matches a version *declaration* (`version: "X.Y.Z"`,
+ * `SOME_VERSION = "X.Y.Z"`), not a mention. That distinction is load-bearing:
+ * `src/cli.ts` carries the current version in prose comments about a past
+ * upgrade, and a naive substring scan flags it on every release.
+ *
+ * Discovery is also pinned to the reference version, not to "any semver".
+ * Several files legitimately declare unrelated versions — an MCP `serverInfo`,
+ * a scaffold template's default, `MIN_HARPER_VERSION`, the Hermes plugin
+ * manifest at its own 0.1.0 — and an any-semver scan would need an allowlist
+ * for all of them, which is one more thing to rot. A file that does not carry
+ * the monorepo version is a file the release must not touch.
+ *
+ * Usage:
+ *   node scripts/check-version-sync.mjs             verify against root package.json
+ *   node scripts/check-version-sync.mjs 0.31.0      verify everything is at 0.31.0
+ *   node scripts/check-version-sync.mjs --write 0.31.0
+ *                                                   rewrite the non-package.json
+ *                                                   inventory files to 0.31.0
+ *
+ * Exit codes:
+ *   0 — every declaration agrees, and nothing declares it off-inventory
+ *   1 — a mismatch, an unknown declaration site, or the check could not run
+ */
+
+import { readFileSync, writeFileSync, statSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { execFileSync } from "node:child_process";
+
+const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), "..");
+
+// --- Inventory ---------------------------------------------------------------
+
+// The eight workspace package.json files release.sh bumps. Their `version`
+// field is read and written by release.sh itself; listed here so discovery
+// knows they are accounted for.
+const PACKAGE_JSONS = [
+  "package.json",
+  "packages/flair-client/package.json",
+  "packages/flair-mcp/package.json",
+  "packages/openclaw-flair/package.json",
+  "packages/pi-flair/package.json",
+  "packages/n8n-nodes-flair/package.json",
+  "packages/langgraph-flair/package.json",
+  "packages/flair-bench/package.json",
+];
+
+// Version declarations that live in source rather than a package.json.
+// `--write` rewrites these; release.sh has no separate copy of the pattern.
+const SOURCE_VERSION_FILES = [
+  {
+    path: "packages/flair-bench/src/version.ts",
+    label: "TOOL_VERSION",
+    // Matches: export const TOOL_VERSION = "X.Y.Z";
+    // Illustrative comments use a placeholder deliberately — a real version
+    // here would be a declaration site, and discovery below would flag it.
+    pattern: /(\bTOOL_VERSION\s*=\s*")([^"]*)(")/,
+  },
+];
+
+const INVENTORY = new Set([...PACKAGE_JSONS, ...SOURCE_VERSION_FILES.map((f) => f.path)]);
+
+// --- Discovery scope ---------------------------------------------------------
+
+// Excluded from the scan, with the reason each is not a declaration site:
+//   lockfiles      resolved dependency versions, not our declaration
+//   CHANGELOG      the historical record; rewriting it would destroy history
+//   .changelog/    unreleased fragments, prose about shipped versions
+//   test fixtures  deliberately pin literal versions to reproduce past bugs
+const isExcluded = (p) =>
+  p === "bun.lock" ||
+  p === "package-lock.json" ||
+  p === "yarn.lock" ||
+  p === "CHANGELOG.md" ||
+  p.startsWith(".changelog/") ||
+  p.startsWith("test/") ||
+  p.includes("/test/") ||
+  p.includes("node_modules/");
+
+const MAX_SCAN_BYTES = 2 * 1024 * 1024;
+
+function escapeRegExp(s) {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+/**
+ * A version *declaration* carrying `version`: an identifier ending in
+ * "version" (case-insensitive, so both `version` and `TOOL_VERSION` match),
+ * optionally quoted, then `:` or `=`, then the version. The trailing
+ * lookahead stops "0.30.0" from matching inside "0.30.01".
+ */
+function declarationPattern(version) {
+  return new RegExp(
+    String.raw`(?:^|\W)['"]?[\w$]*version[\w$]*['"]?\s*[:=]\s*['"]?` +
+      escapeRegExp(version) +
+      String.raw`(?![\d.])`,
+    "i",
+  );
+}
+
+function trackedFiles() {
+  const out = execFileSync("git", ["-C", REPO_ROOT, "ls-files", "-z"], {
+    encoding: "utf8",
+    maxBuffer: 64 * 1024 * 1024,
+  });
+  return out.split("\0").filter(Boolean);
+}
+
+function readTextOrNull(abs) {
+  try {
+    if (statSync(abs).size > MAX_SCAN_BYTES) return null;
+    const buf = readFileSync(abs);
+    if (buf.includes(0)) return null; // binary
+    return buf.toString("utf8");
+  } catch {
+    return null;
+  }
+}
+
+// --- Modes -------------------------------------------------------------------
+
+function readDeclared(file) {
+  const abs = join(REPO_ROOT, file.path);
+  const src = readFileSync(abs, "utf8");
+  const m = src.match(file.pattern);
+  if (!m) {
+    return { ok: false, reason: `no ${file.label} declaration matched in ${file.path}` };
+  }
+  return { ok: true, version: m[2] };
+}
+
+function write(version) {
+  for (const file of SOURCE_VERSION_FILES) {
+    const abs = join(REPO_ROOT, file.path);
+    const src = readFileSync(abs, "utf8");
+    if (!file.pattern.test(src)) {
+      console.error(`❌ ${file.path}: no ${file.label} declaration to rewrite.`);
+      console.error(`   The pattern in scripts/check-version-sync.mjs no longer matches this file.`);
+      process.exit(1);
+    }
+    writeFileSync(abs, src.replace(file.pattern, `$1${version}$3`));
+    console.log(`  ✓ ${file.path} ${file.label} → ${version}`);
+  }
+}
+
+function verify(expected) {
+  const problems = [];
+
+  // 1. Inventory: every listed declaration must be at `expected`.
+  for (const path of PACKAGE_JSONS) {
+    const pkg = JSON.parse(readFileSync(join(REPO_ROOT, path), "utf8"));
+    if (pkg.version !== expected) {
+      problems.push(`${path}: "version" is ${pkg.version}, expected ${expected}`);
+    }
+  }
+  for (const file of SOURCE_VERSION_FILES) {
+    const got = readDeclared(file);
+    if (!got.ok) {
+      problems.push(got.reason);
+    } else if (got.version !== expected) {
+      problems.push(`${file.path}: ${file.label} is ${got.version}, expected ${expected}`);
+    }
+  }
+
+  // 2. Discovery: nothing off-inventory may declare `expected`.
+  const files = trackedFiles();
+  if (files.length === 0) {
+    console.error("❌ git ls-files returned nothing — this check cannot run, and must not pass silently.");
+    process.exit(1);
+  }
+
+  const pattern = declarationPattern(expected);
+  const hits = [];
+  for (const path of files) {
+    if (isExcluded(path)) continue;
+    const text = readTextOrNull(join(REPO_ROOT, path));
+    if (text === null) continue;
+    if (pattern.test(text)) hits.push(path);
+  }
+
+  // Positive control. The inventory files themselves declare `expected`, so a
+  // scan that finds nothing at all did not run correctly — an unrun check must
+  // not look like a pass.
+  if (hits.length === 0) {
+    console.error(`❌ Scanned ${files.length} tracked files and found no declaration of ${expected} anywhere,`);
+    console.error(`   not even in package.json. The scan is broken, not the tree.`);
+    process.exit(1);
+  }
+
+  const unknown = hits.filter((p) => !INVENTORY.has(p));
+  if (unknown.length > 0) {
+    problems.push(
+      `these files declare version ${expected} but the release script does not bump them:\n` +
+        unknown.map((p) => `      ${p}`).join("\n"),
+    );
+  }
+
+  if (problems.length > 0) {
+    console.error("");
+    console.error(`❌ Version declarations are not in sync (expected ${expected}):`);
+    console.error("");
+    for (const p of problems) console.error(`  - ${p}`);
+    console.error("");
+    console.error("  Fix: bump the file to match, or — if it is a new declaration site — add it to");
+    console.error("  SOURCE_VERSION_FILES in scripts/check-version-sync.mjs so release.sh bumps it,");
+    console.error("  and to the `git add` list in scripts/release.sh so the bump is committed.");
+    console.error("");
+    process.exit(1);
+  }
+
+  console.log(
+    `✓ Version ${expected} consistent across ${INVENTORY.size} declaration sites; ` +
+      `no unknown sites in ${files.length} tracked files.`,
+  );
+}
+
+// --- Entry -------------------------------------------------------------------
+
+const argv = process.argv.slice(2);
+
+if (argv[0] === "--write") {
+  const version = argv[1];
+  if (!version) {
+    console.error("Usage: check-version-sync.mjs --write <version>");
+    process.exit(1);
+  }
+  write(version);
+} else {
+  const expected = argv[0] ?? JSON.parse(readFileSync(join(REPO_ROOT, "package.json"), "utf8")).version;
+  verify(expected);
+}

--- a/scripts/check-version-sync.mjs
+++ b/scripts/check-version-sync.mjs
@@ -85,7 +85,8 @@ const SOURCE_VERSION_FILES = [
     // Matches: export const TOOL_VERSION = "X.Y.Z";
     // Illustrative comments use a placeholder deliberately — a real version
     // here would be a declaration site, and discovery below would flag it.
-    pattern: /(\bTOOL_VERSION\s*=\s*")([^"]*)(")/,
+    // Global so occurrences can be counted; see readDeclared.
+    pattern: /(\bTOOL_VERSION\s*=\s*")([^"]*)(")/g,
   },
 ];
 
@@ -110,23 +111,26 @@ const isExcluded = (p) =>
 
 const MAX_SCAN_BYTES = 2 * 1024 * 1024;
 
-function escapeRegExp(s) {
-  return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-}
-
 /**
- * A version *declaration* carrying `version`: an identifier ending in
- * "version" (case-insensitive, so both `version` and `TOOL_VERSION` match),
- * optionally quoted, then `:` or `=`, then the version. The trailing
- * lookahead stops "0.30.0" from matching inside "0.30.01".
+ * A version *declaration*: an identifier ending in "version" (case-insensitive,
+ * so both `version` and `TOOL_VERSION` match), optionally quoted, then `:` or
+ * `=`, then a semver. Capture group 1 is the declared version.
+ *
+ * This is a fixed literal rather than a pattern built around the version we are
+ * looking for. Interpolating the version would mean escaping it, and would
+ * build a RegExp from a non-literal — which Semgrep blocks, correctly. Matching
+ * every declaration and comparing the captured value with `===` is both safer
+ * and more exact: no escaping, no regex metacharacter surface, and no chance of
+ * "0.30.0" matching inside "0.30.01".
  */
-function declarationPattern(version) {
-  return new RegExp(
-    String.raw`(?:^|\W)['"]?[\w$]*version[\w$]*['"]?\s*[:=]\s*['"]?` +
-      escapeRegExp(version) +
-      String.raw`(?![\d.])`,
-    "i",
-  );
+const VERSION_DECLARATION =
+  /(?:^|\W)['"]?[\w$]*version[\w$]*['"]?\s*[:=]\s*['"]?(\d+\.\d+\.\d+(?:-[A-Za-z0-9.]+)?)(?![\d.])/gi;
+
+function declaresVersion(text, expected) {
+  for (const m of text.matchAll(VERSION_DECLARATION)) {
+    if (m[1] === expected) return true;
+  }
+  return false;
 }
 
 function trackedFiles() {
@@ -165,41 +169,42 @@ function readTextOrNull(abs) {
 // --- Modes -------------------------------------------------------------------
 
 /**
- * `--write` rewrites the FIRST match only, so a file carrying two declarations
- * would be half-bumped and the second left stale — invisible to the discovery
- * scan, which only asks whether a file is in the inventory, not whether every
- * declaration in it agrees. Require exactly one.
+ * Both callers require EXACTLY ONE declaration per listed file. A file carrying
+ * two is ambiguous: `readDeclared` would have to pick one to report, and the
+ * discovery scan would not catch a disagreement between them — it only asks
+ * whether a file is in the inventory, not whether every declaration inside it
+ * agrees. Refusing beats guessing.
  */
-function countMatches(src, pattern) {
-  return (src.match(new RegExp(pattern.source, pattern.flags + "g")) ?? []).length;
+function matchesIn(src, pattern) {
+  return [...src.matchAll(pattern)];
 }
 
 function readDeclared(file) {
   const abs = join(REPO_ROOT, file.path);
   const src = readFileSync(abs, "utf8");
-  const n = countMatches(src, file.pattern);
-  if (n === 0) {
+  const m = matchesIn(src, file.pattern);
+  if (m.length === 0) {
     return { ok: false, reason: `no ${file.label} declaration matched in ${file.path}` };
   }
-  if (n > 1) {
+  if (m.length > 1) {
     return {
       ok: false,
-      reason: `${file.path} has ${n} ${file.label} declarations; --write rewrites only the first. Reduce it to one.`,
+      reason: `${file.path} has ${m.length} ${file.label} declarations; expected exactly 1.`,
     };
   }
-  return { ok: true, version: src.match(file.pattern)[2] };
+  return { ok: true, version: m[0][2] };
 }
 
 function write(version) {
   for (const file of SOURCE_VERSION_FILES) {
     const abs = join(REPO_ROOT, file.path);
     const src = readFileSync(abs, "utf8");
-    const n = countMatches(src, file.pattern);
+    const n = matchesIn(src, file.pattern).length;
     if (n !== 1) {
       console.error(
         n === 0
           ? `❌ ${file.path}: no ${file.label} declaration to rewrite. The pattern in scripts/check-version-sync.mjs no longer matches this file.`
-          : `❌ ${file.path}: ${n} ${file.label} declarations, expected exactly 1. Rewriting would leave ${n - 1} stale.`,
+          : `❌ ${file.path}: ${n} ${file.label} declarations, expected exactly 1. Refusing to rewrite an ambiguous file.`,
       );
       process.exit(1);
     }
@@ -234,7 +239,6 @@ function verify(expected) {
     process.exit(1);
   }
 
-  const pattern = declarationPattern(expected);
   const hits = [];
   const skipped = [];
   for (const path of files) {
@@ -247,7 +251,7 @@ function verify(expected) {
       skipped.push(path);
       continue;
     }
-    if (pattern.test(text)) hits.push(path);
+    if (declaresVersion(text, expected)) hits.push(path);
   }
 
   // Positive control. The inventory files themselves declare `expected`, so a

--- a/scripts/check-version-sync.mjs
+++ b/scripts/check-version-sync.mjs
@@ -130,10 +130,17 @@ function declarationPattern(version) {
 }
 
 function trackedFiles() {
-  const out = execFileSync("git", ["-C", REPO_ROOT, "ls-files", "-z"], {
-    encoding: "utf8",
-    maxBuffer: 64 * 1024 * 1024,
-  });
+  let out;
+  try {
+    out = execFileSync("git", ["-C", REPO_ROOT, "ls-files", "-z"], {
+      encoding: "utf8",
+      maxBuffer: 64 * 1024 * 1024,
+    });
+  } catch (err) {
+    console.error(`❌ Could not list tracked files (git ls-files failed: ${err.message.trim()}).`);
+    console.error("   The discovery scan cannot run, and must not pass silently.");
+    process.exit(1);
+  }
   return out.split("\0").filter(Boolean);
 }
 
@@ -233,9 +240,9 @@ function verify(expected) {
   for (const path of files) {
     if (isExcluded(path)) continue;
     const text = readTextOrNull(join(REPO_ROOT, path));
-    // Binary or oversized. Report rather than skip silently — a file the scan
-    // could not read is not a file the scan cleared. No tracked file hits this
-    // today; if one starts to, it should be visible, not absorbed.
+    // Over the size cap, or unreadable. Report rather than skip silently — a
+    // file the scan could not read is not a file the scan cleared. No tracked
+    // file hits this today; if one starts to, it should be visible.
     if (text === null) {
       skipped.push(path);
       continue;

--- a/scripts/check-version-sync.mjs
+++ b/scripts/check-version-sync.mjs
@@ -257,9 +257,18 @@ function verify(expected) {
   // Positive control. The inventory files themselves declare `expected`, so a
   // scan that finds nothing at all did not run correctly — an unrun check must
   // not look like a pass.
-  if (hits.length === 0) {
+  //
+  // Conditioned on the inventory being clean, and that condition is load-bearing.
+  // When `expected` comes from an argument rather than from package.json — the
+  // tag-time gate, `--publish`, the post-bump re-check — a tree that simply is
+  // not at that version ALSO produces zero hits. Reporting "the scan is broken"
+  // there would send the operator after the instrument instead of the tag.
+  // Tagging v0.99.0 against a 0.31.0 tree hit exactly that. If the inventory
+  // check already found problems, those explain the zero hits; report them.
+  if (hits.length === 0 && problems.length === 0) {
     console.error(`❌ Scanned ${files.length} tracked files and found no declaration of ${expected} anywhere,`);
-    console.error(`   not even in package.json. The scan is broken, not the tree.`);
+    console.error(`   not even in package.json, yet every known site reported the right version.`);
+    console.error(`   Those cannot both be true: the scan is broken, not the tree.`);
     process.exit(1);
   }
 

--- a/scripts/check-version-sync.mjs
+++ b/scripts/check-version-sync.mjs
@@ -150,23 +150,43 @@ function readTextOrNull(abs) {
 
 // --- Modes -------------------------------------------------------------------
 
+/**
+ * `--write` rewrites the FIRST match only, so a file carrying two declarations
+ * would be half-bumped and the second left stale — invisible to the discovery
+ * scan, which only asks whether a file is in the inventory, not whether every
+ * declaration in it agrees. Require exactly one.
+ */
+function countMatches(src, pattern) {
+  return (src.match(new RegExp(pattern.source, pattern.flags + "g")) ?? []).length;
+}
+
 function readDeclared(file) {
   const abs = join(REPO_ROOT, file.path);
   const src = readFileSync(abs, "utf8");
-  const m = src.match(file.pattern);
-  if (!m) {
+  const n = countMatches(src, file.pattern);
+  if (n === 0) {
     return { ok: false, reason: `no ${file.label} declaration matched in ${file.path}` };
   }
-  return { ok: true, version: m[2] };
+  if (n > 1) {
+    return {
+      ok: false,
+      reason: `${file.path} has ${n} ${file.label} declarations; --write rewrites only the first. Reduce it to one.`,
+    };
+  }
+  return { ok: true, version: src.match(file.pattern)[2] };
 }
 
 function write(version) {
   for (const file of SOURCE_VERSION_FILES) {
     const abs = join(REPO_ROOT, file.path);
     const src = readFileSync(abs, "utf8");
-    if (!file.pattern.test(src)) {
-      console.error(`❌ ${file.path}: no ${file.label} declaration to rewrite.`);
-      console.error(`   The pattern in scripts/check-version-sync.mjs no longer matches this file.`);
+    const n = countMatches(src, file.pattern);
+    if (n !== 1) {
+      console.error(
+        n === 0
+          ? `❌ ${file.path}: no ${file.label} declaration to rewrite. The pattern in scripts/check-version-sync.mjs no longer matches this file.`
+          : `❌ ${file.path}: ${n} ${file.label} declarations, expected exactly 1. Rewriting would leave ${n - 1} stale.`,
+      );
       process.exit(1);
     }
     writeFileSync(abs, src.replace(file.pattern, `$1${version}$3`));

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -111,6 +111,10 @@ if [[ "$MODE" == "--publish" ]]; then
     fi
   done
 
+  # Same check the PR-prep path runs — covers the version declarations that are
+  # not package.json files, which the loop above cannot see.
+  (cd "$ROOT" && node scripts/check-version-sync.mjs "$VERSION") || exit 1
+
   if git -C "$ROOT" rev-parse "v${VERSION}" >/dev/null 2>&1; then
     echo "❌ Tag v${VERSION} already exists. Did you already publish?"
     exit 1
@@ -183,6 +187,18 @@ fi
 echo "🔄 Pulling latest main..."
 git -C "$ROOT" pull --ff-only origin main
 
+# 1b. Preflight the version declarations BEFORE anything destructive happens.
+# The version lives in more than just the package.json files, and a site this
+# script does not bump fails CI on the release PR — after the branch exists, the
+# changelog fragments have been consumed and deleted, and the PR is open.
+# Recovering from a half-run release is the expensive part, so this runs while
+# the tree is still untouched. It verifies the CURRENT version is consistent
+# everywhere and that no file outside the known set declares it.
+echo "🔍 Preflighting version declarations..."
+(cd "$ROOT" && node scripts/check-version-sync.mjs) || {
+  echo "❌ Version declarations are out of sync on main — fix before releasing. Nothing was changed."; exit 1;
+}
+
 RELEASE_BRANCH="release/v${VERSION}"
 if git -C "$ROOT" show-ref --verify --quiet "refs/heads/$RELEASE_BRANCH"; then
   echo "❌ Branch $RELEASE_BRANCH already exists locally. Delete it first if re-running."
@@ -218,6 +234,20 @@ for pkg in "${PACKAGES[@]}"; do
   echo "  ✓ $name → $VERSION"
 done
 
+# 2a. Bump the version declarations that are NOT package.json files.
+# packages/flair-bench/src/version.ts holds TOOL_VERSION as a plain constant
+# (a runtime JSON import of package.json trips NodeNext import-attribute edges
+# in the published dist/), and a flair-bench package test asserts the two are
+# equal. Step 5 below runs only test/unit, test/integration and
+# test/unit-isolated — the flair-bench package tests are a separate CI job — so
+# skipping this bumped cleanly, tested green locally, and went red in CI every
+# single release. The rewrite lives in check-version-sync.mjs alongside the
+# pattern that verifies it, so the two cannot drift.
+echo "📌 Bumping source version declarations..."
+(cd "$ROOT" && node scripts/check-version-sync.mjs --write "$VERSION") || {
+  echo "❌ Source version bump failed"; exit 1;
+}
+
 # 3. Update internal dependencies (flair-mcp + pi-flair + n8n-nodes-flair all
 #    depend on flair-client)
 echo "🔗 Aligning internal dependencies..."
@@ -238,6 +268,15 @@ for INTERNAL_DEPENDENT in \
     }
   "
 done
+
+# Re-run the same check, now asserting the NEW version. The preflight above
+# proves the tree was consistent; this proves the bump covered every site it
+# knew about. It runs before the slow install/build/test so a miss costs seconds,
+# and still before the commit, so nothing half-bumped can be pushed.
+echo "🔍 Verifying every version declaration is at v${VERSION}..."
+(cd "$ROOT" && node scripts/check-version-sync.mjs "$VERSION") || {
+  echo "❌ Post-bump version check failed — do not push this branch."; exit 1;
+}
 
 # 3a. Refresh bun.lock so CI's --frozen-lockfile passes post-bump.
 # Omitting this was the 0.5.6 release failure: version bumps desynced the
@@ -296,6 +335,7 @@ git -C "$ROOT" add \
   "$ROOT/packages/n8n-nodes-flair/package.json" \
   "$ROOT/packages/langgraph-flair/package.json" \
   "$ROOT/packages/flair-bench/package.json" \
+  "$ROOT/packages/flair-bench/src/version.ts" \
   "$ROOT/bun.lock"
 
 # The fragment files consumed by step 1a are DELETED, so this needs -A to stage
@@ -306,7 +346,7 @@ git -C "$ROOT" add -A -- "$ROOT/.changelog"
 # CHANGELOG.md is always modified by the fragment assembly in step 1a, and script
 # bugfixes (like the missing langgraph-flair stage line, 2026-05-14) need to ride
 # along with the release that surfaces them.
-for extra in "$ROOT/CHANGELOG.md" "$ROOT/scripts/release.sh"; do
+for extra in "$ROOT/CHANGELOG.md" "$ROOT/scripts/release.sh" "$ROOT/scripts/check-version-sync.mjs"; do
   if ! git -C "$ROOT" diff --quiet -- "$extra"; then
     git -C "$ROOT" add "$extra"
   fi


### PR DESCRIPTION
## The defect

`scripts/release.sh` bumped the eight `package.json` files and nothing else. The
version is *also* declared in `packages/flair-bench/src/version.ts` as a plain
`TOOL_VERSION` constant (deliberately — a runtime JSON import of `package.json`
trips NodeNext import-attribute edges in the published `dist/`), and
`packages/flair-bench/test/version-sync.test.ts` asserts the two are equal.

So every release went red in CI until an operator remembered to hand-edit the
constant. It read like a flake. It was not — a documented manual step that a
script could perform is a gap in the script, and the operator was standing in
for a missing line of code.

**Why it reached CI instead of failing locally:** `release.sh`'s test step (step 5)
runs only `test/unit/`, `test/integration/` and `test/unit-isolated/`. The
flair-bench package tests are a separate CI job (`.github/workflows/test.yml`,
the `for pkg in ... flair-bench` loop). The release therefore bumped, built and
tested green locally, and failed only *after* the release branch existed, the
changelog fragments had been consumed and deleted, and the PR was open.

## The fix

1. `release.sh` bumps `packages/flair-bench/src/version.ts` and **stages it** in
   the version-bump commit. That `git add` list is deliberately enumerated rather
   than `-A`, so a path not named there is silently left out of the release.

2. New `scripts/check-version-sync.mjs`, in two halves:
   - **Inventory** — the explicit set of files that must carry the release
     version, with the ability to both verify and rewrite them. `release.sh`
     calls `--write` to bump, so the bumping pattern and the checking pattern
     are one definition and cannot drift.
   - **Discovery** — a scan that fails when any file *outside* the inventory
     declares the release version. Half 1 fixes today's file; half 2 is what
     stops the class.

3. Wired at three points, one mechanism:
   - **Preflight** in `release.sh`, before the branch is created or the changelog
     is touched. An out-of-sync tree aborts while nothing has been modified.
   - **Post-bump re-check**, before the slow install/build/test and before the
     commit, so a missed site can never be pushed.
   - **CI** (`test-unit`), which is the part that stops recurrence: a new
     version-bearing file fails on the PR that adds it, while the author still
     has context, rather than at a release weeks later.

## Design notes

**Preflight over a test, per the brief** — but note a preflight over a *static
list* could not have prevented recurrence on its own. Before the bump every file
is consistently at the old version, so a list-based preflight passes even when
the script's bump list is missing a file. Only the discovery scan catches a
declaration site nobody wired in. The preflight controls *when* it fails; discovery
controls *whether* it can fail at all.

**Discovery matches a declaration, not a mention.** `version: "X.Y.Z"` /
`SOME_VERSION = "X.Y.Z"`, not a substring. This is load-bearing: `src/cli.ts`
carries the current version in prose comments about a past upgrade, and a naive
substring scan flags it on every release.

**Discovery is pinned to the reference version, not "any semver".** Several files
legitimately declare unrelated versions — an MCP `serverInfo`, a scaffold
template default, `MIN_HARPER_VERSION`, `packages/hermes-flair/plugin.yaml` at its
own `0.1.0`. An any-semver scan needs an allowlist for all of them, which is one
more thing to rot. A file that does not carry the monorepo version is a file the
release must not touch.

**An unrun check must not look like a pass.** The inventory files themselves
declare the reference version, so a scan returning zero hits *anywhere* — not
even in `package.json` — is a broken scan, and it hard-errors rather than
reporting green. Same for `git ls-files` returning nothing.

## Survey: is anything else unbumped?

Grepped the current version across the whole repo and checked every
version-declaration shape. **`packages/flair-bench/src/version.ts` was the only
unbumped declaration site.** Everything else carrying the string is a historical
reference that must *not* be bumped: `CHANGELOG.md`, `.changelog/` fragments,
`docs/upgrade.md`, prose comments in `src/cli.ts`, and test fixtures that pin
literal versions to reproduce past bugs.

Also checked and found clean: no version badges in `README.md`;
`packages/openclaw-flair/openclaw.plugin.json` has no version field;
`resources/version.ts` resolves at runtime from `package.json` rather than
hardcoding. **`packages/hermes-flair/plugin.yaml` declares `version: 0.1.0`** —
independently versioned, has no `package.json`, is not in the npm release set,
and is correctly left alone.

## Verification

No release was cut, no tag created, nothing published. The bump path was
exercised against a throwaway clone in a scratch directory, with only the
network/build/test steps stubbed (`git pull`, `bun install`, `npm run build`,
`bun test`) — every line changed in this PR ran for real.

| Check | Result |
|---|---|
| `release.sh 0.31.0 --dry` on the scratch clone | version.ts bumped `0.30.0` to `0.31.0` **and present in the release commit** alongside the 8 package.json files |
| `packages/flair-bench/test/version-sync.test.ts` on that simulated release commit | **1 pass** — the exact test that went red today |
| Guard on clean `main` | passes, 9 declaration sites, 674 tracked files scanned |
| `node scripts/docs-freshness-check.mjs` | all checks pass |
| `node scripts/changelog-fragments.mjs check` | 34 fragments, no stray `[Unreleased]` entries |

**Mutation checks — every one confirmed to fire, then confirmed to pass on restore:**

| Mutation | Result |
|---|---|
| version.ts left stale at `0.29.0` | fails, names the file and expected version |
| New off-inventory file declaring the version | fails, names the unknown declaration site |
| Bump sabotaged to skip version.ts (reproduces the original defect exactly) | **post-bump check aborts with 0 commits on the release branch**, before build/test |
| Scan sabotaged so it can match nothing | hard-errors "the scan is broken, not the tree" rather than passing green |
| All restored | passes |

The guard also caught a genuine mistake of mine on its first real run: I had
written a live version into an illustrative comment inside
`check-version-sync.mjs` itself, and the preflight aborted the dry run before
touching anything. Fixed by using a placeholder — which is the correct outcome,
and is now noted in the file.

**Honest limitation.** The preflight fires before *any* modification. The
post-bump check fires after the changelog fragments have been assembled and
deleted, but before the commit, push and PR. Recovery from that point is
`git checkout main && git checkout -- . && git branch -D release/vX.Y.Z` — verified
in the scratch clone to restore all 34 fragments with no data loss. Fully
preventing fragment consumption would mean reordering assembly after the bump,
which is a larger change than this defect justifies.

**Not verified:** the full unit/integration suite was not run locally — this PR
touches no `src/` code. CI covers it.

## Documentation

`docs/releasing.md` did **not** contain a "bump TOOL_VERSION by hand" line to
remove — the manual step was carried in operator procedure, not in the repo. The
phase-1 section now states explicitly that nothing about the version is bumped by
hand, and that hand-editing a version constant during a release is a bug in the
script, with the two files to update.

---

Reviewers: the release path is the risk surface here. Worth a hard look at the
preflight placement (before branch creation, after `git pull`) and at whether
the discovery scan's exclusion list could hide a real declaration site.


---

## Two follow-up commits: holes found in my own guard

Both are the same defect class the script exists to catch, found by turning the
check on itself. Reviewers may want to look hardest here.

**1. `--write` rewrites the first match only** (`59b1e5a`). A listed file carrying
two declarations would be half-bumped, with the second left stale — and discovery
would *not* catch it, because discovery only asks whether a file is in the
inventory, not whether every declaration inside it agrees. Both `verify` and
`--write` now fail unless a listed file has exactly one declaration. Mutation-checked:
appending a second `TOOL_VERSION` line makes both modes fail with an explicit count;
removing it restores green.

**2. The scan was silently skipping a real source file** (`80a7ccc`). The scan had
a size cap and a binary sniff, neither of which reported what it skipped. Adding
the report immediately surfaced the bug: the sniff was "Buffer contains a NUL
byte", and `src/mcp-client-assertion.ts` embeds literal NULs as a cache-key
delimiter inside a template literal —

```ts
return `${clientId}\0${tokenEndpoint}\0${resource ?? ""}`;
```

— so that file was classified binary and dropped from every scan. **Verified by
planting a version declaration in it: caught now, silently missed before.** The
sniff is gone; files decode as UTF-8 unconditionally, since a binary file cannot
accidentally contain the ASCII text of a version declaration. Only the size cap
skips anything now (no tracked file currently hits it), and skips are printed
rather than absorbed.

This is why the check hard-errors when it finds no declaration anywhere rather
than reporting a green tick — a check you have never seen fail, or never seen
report what it could not read, is not known to work.


**3. Semgrep blocking finding — fixed properly, not suppressed** (`c400d6e`).
`detect-non-literal-regexp` fired twice: the discovery pattern was built around
the version being searched for, and the occurrence counter rebuilt a caller's
regex with an added `g` flag. Semgrep was **green on `main`** and red here, so
this was mine, not inherited.

Suppressing the rule would have been the wrong fix. Removing the construction is
also the better design: discovery is now a fixed literal regex that *captures*
whatever version a declaration carries, and the comparison is string equality.
That deletes the escaping step, the regex-metacharacter surface, and the
lookahead that previously stopped `0.30.0` matching inside `0.30.01` — none of
which are load-bearing once you compare strings.

Verified by running the exact CI rule
(`r/javascript.lang.security.audit.detect-non-literal-regexp`) over the pre-fix
and post-fix files in one scan: **2 findings on pre-fix, 0 on fixed.**

> **Caveat for whoever next verifies a Semgrep fix locally.** My first attempt
> scanned both files with `p/javascript` and reported **0 findings for each** —
> which reads exactly like a fix confirmed. It was not: `p/javascript` does not
> contain `detect-non-literal-regexp`, so the scan came back clean because the
> rule was never loaded. CI runs `semgrep scan --config=auto` (~1074 rules), so
> a local `p/*` pack is not a substitute for it.
>
> A clean scan from the wrong ruleset is indistinguishable from a clean scan
> from the right one. Both print zero. The generalisable rule: **when verifying
> a rule-specific fix, pin the rule by id, and prove the scan can find the thing
> before trusting that it found nothing.** Keeping the pre-fix file in the same
> scan is the cheapest positive control — if it does not light up, the scan is
> not measuring what you think it is.
>
> This is the same defect class as the rest of this PR: an absent result and a
> passing result rendering identically. It is why the check hard-errors when it
> finds no version declaration anywhere rather than reporting green.

Full mutation battery and the end-to-end release simulation were re-run after the
refactor; all behaviour unchanged.




---

## ⚠️ Added after review started — please re-look

**`a123b88` landed after Sherlock began reviewing.** It touches the release
path, so it wants eyes rather than a rubber stamp on the earlier diff.

### 4. The tag-time gate had the same blind spot

`release-publish.yml` fires on a tag push and is the **last gate before npm
staging** — everything upstream of a tag is recoverable, a staged tarball and a
pushed tag are not, and the only thing after it is a human 2FA approval that
cannot reasonably be expected to notice a wrong version constant. Its version
check read the eight `package.json` files and nothing else.

I had originally left this alone, reasoning that the release PR's CI would catch
a stale constant before merge. That reasoning was wrong: it assumes nobody merges
past a red check, and flair#927 was merged in this repo with a gate red. **A gate
that only holds when nobody makes a mistake is not a gate.**

**Mutation-checked against a simulated tag** — a full clone, detached HEAD, no
`node_modules`, `VERSION` supplied exactly as the workflow supplies it, and the
command extracted programmatically from the YAML rather than retyped:

| Tagged commit state | Existing package.json check | New step |
|---|---|---|
| Healthy (all at 0.31.0) | pass | **exit 0** |
| `package.json`s 0.31.0, `version.ts` 0.30.0 | **exit 0** — prints `ok @tpsdev-ai/flair-bench @ 0.31.0` | **exit 1**, names the file and both versions |
| Restored | pass | **exit 0** |

The middle row is the point: the existing gate waves the bad tag through and
reports the flair-bench package as OK while its shipped constant says otherwise.
This is a fourth *call site* of `check-version-sync.mjs`, deliberately not a
fourth implementation — the bump and every verification stay one definition.
Availability was checked rather than assumed: the step needs only `node` and the
git checkout, both set up earlier in that job (`fetch-depth: 0`), and the script
imports only node builtins.

### A diagnostic bug this exercise exposed

Testing a *wrong* tag (`v0.99.0` against a `0.31.0` tree) made the check report
**"the scan is broken, not the tree"** — sending the operator after the
instrument instead of the tag. The positive control assumed `expected` was the
tree's own version, which is true in preflight mode but false in every mode that
takes the version as an argument: the tag gate, `--publish`, and the post-bump
re-check.

It is now conditioned on the inventory being clean, so a version mismatch reports
as a version mismatch and a genuinely broken scan still reports as a broken scan.
Both branches mutation-checked, exit codes verified directly rather than through
a pipe.
