### PR TITLE
fix(ci): drop Playwright --with-deps — the timeout was 21 MB of fonts from a stalled apt mirror, not the browser download

### DIFF
--- a/.changelog/unreleased/fixed-ci-playwright-with-deps-timeout.md
+++ b/.changelog/unreleased/fixed-ci-playwright-with-deps-timeout.md
@@ -1,0 +1,10 @@
+- **CI: the Integration Tests lane no longer depends on the Ubuntu apt mirror to
+  run browser tests.** `playwright install` was being invoked with
+  `--with-deps`, which on `ubuntu-latest` installed nothing Chromium needs — every
+  required library is already on the image — and instead pulled 21.1 MB of
+  CJK/Thai/Cyrillic and X11 bitmap font packages the E2E suite never renders. When
+  that mirror degraded on 2026-07-28 the step stalled past the job's 20-minute
+  timeout and discarded integration and E2E CLI results that had already passed,
+  reporting `cancelled` rather than `failure`. The flag is gone, Playwright's
+  browser downloads are now cached on the resolved Playwright version, and the
+  job's timeout has headroom. No effect on shipped code.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -369,6 +369,9 @@ jobs:
       # runner image ever does drop a Chromium library, Playwright fails here
       # with an explicit "missing dependencies … install-deps" message in
       # seconds, which is a better signal than a multi-minute mirror stall.
+      # Cache-effectiveness note: on a cold key this downloads Chrome for
+      # Testing, FFmpeg and the headless shell (~10s from cdn.playwright.dev);
+      # on a warm key it verifies the existing install and downloads nothing.
       - name: Install Playwright browsers
         run: bunx playwright install chromium
       - name: Playwright E2E tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -175,7 +175,15 @@ jobs:
   test-integration:
     name: Integration Tests
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    # 30, not 20 (#948). This is headroom, NOT the fix — the fix is dropping
+    # `--with-deps` from the Playwright step below, which removed this job's
+    # dependency on the Ubuntu apt mirror. Kept deliberately generous because
+    # the dominant cost here is `Run integration tests` at ~12 min (measured
+    # over four runs on 2026-07-28: 11m39s / 11m46s / 12m08s / 12m19s), which
+    # left only ~6 min of slack against the old ceiling. If total job time
+    # starts creeping toward this number, the integration suite is what to
+    # look at — raising this again would just hide the trend.
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - uses: oven-sh/setup-bun@735343b667d3e6f658f44d0eca948eb6282f2b76 # v2
@@ -306,8 +314,63 @@ jobs:
         env:
           FLAIR_PORT: "9926"
           FLAIR_ADMIN_PASS: admin123
+      # Cache key must track the resolved Playwright version, because a given
+      # Playwright release pins specific browser builds (1.59.1 → chromium
+      # v1217). Derived from package.json rather than hardcoded, so it cannot
+      # go stale silently on a version bump — same single-source-of-truth
+      # pattern as `Resolve Harper image tag` above (#625).
+      - name: Resolve Playwright version (browser cache key)
+        id: playwright-version
+        run: |
+          VER=$(node -p "require('./package.json').devDependencies['@playwright/test']")
+          case "$VER" in
+            [0-9]*) : ;; # exact pin — safe to key a browser cache on
+            *) echo "::error::@playwright/test is '$VER' in package.json — not an exact version pin, so a browser cache keyed on it could serve builds from a different Playwright"; exit 1 ;;
+          esac
+          echo "Playwright $VER — caching browsers under that key"
+          echo "version=$VER" >> "$GITHUB_OUTPUT"
+
+      # NO `restore-keys` on purpose. A prefix fallback would let browsers
+      # downloaded for an older Playwright satisfy a newer one, which is
+      # exactly the browser/version mismatch this cache must not create —
+      # Playwright resolves browsers by build number and fails obscurely when
+      # the expected build is absent. Exact key or cold miss, nothing between.
+      - name: Cache Playwright browsers
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-browsers-${{ runner.os }}-${{ steps.playwright-version.outputs.version }}
+
+      # `--with-deps` REMOVED (#948) — it was the actual cause of the 20-minute
+      # timeout that read as `cancelled` on flair#946, and no browser cache
+      # would have prevented it.
+      #
+      # Measured from that job's own log: every library Chromium needs was
+      # already present on ubuntu-latest — apt reported libnss3, libgbm1,
+      # libcairo2, libpango-1.0-0, libatk*, libx*, libasound2t64, libcups2t64,
+      # xvfb, fonts-liberation and fonts-noto-color-emoji all "already the
+      # newest version". The only 9 packages `--with-deps` actually installed
+      # were 21.1 MB of CJK/Thai/Cyrillic and X11 bitmap FONTS
+      # (fonts-ipafont-gothic, fonts-wqy-zenhei, fonts-unifont, xfonts-*),
+      # which Chromium does not need to launch and which our E2E suite — six
+      # English-language admin pages — never renders a glyph from.
+      #
+      # On a good run that apt fetch took ~1.5s (17.2 MB/s). On the failing run
+      # the Azure Ubuntu mirror degraded to ~45 kB/s and it was still fetching
+      # fonts 7 minutes later when the job timeout killed it, discarding
+      # integration and E2E CLI results that had ALREADY passed. Dropping the
+      # flag removes an unbounded dependency on a mirror we don't control;
+      # the browser download itself (~10s from cdn.playwright.dev) is what the
+      # cache above covers.
+      #
+      # Run unconditionally rather than gating on a cache hit: with the cache
+      # warm this is a fast no-op verification, and a partial or corrupted
+      # cache entry repairs itself instead of failing the E2E step. If a future
+      # runner image ever does drop a Chromium library, Playwright fails here
+      # with an explicit "missing dependencies … install-deps" message in
+      # seconds, which is a better signal than a multi-minute mirror stall.
       - name: Install Playwright browsers
-        run: bunx playwright install --with-deps chromium
+        run: bunx playwright install chromium
       - name: Playwright E2E tests
         run: bunx playwright test
         env:


### PR DESCRIPTION
Closes #948 — but **not with the fix #948 proposed**, because the measurement does not support it.

## The diagnosis in #948 is wrong

#948 says the job died on an uncached Chromium download and that caching `~/.cache/ms-playwright` is the fix. I pulled the failing job's log (run `30402694592`, job `90421008435`). The step never got as far as downloading a browser. It spent all 7 minutes inside `apt-get`, and every one of those minutes was fonts.

Here is the tail of the step as it was killed:

```
22:10:11  Need to get 21.1 MB of archives.
22:10:12  Get:2 fonts-ipafont-gothic  [3513 kB]
22:11:53  Get:3 fonts-freefont-ttf    [5641 kB]
22:14:35  Get:4 fonts-tlwg-loma-otf   [107 kB]
22:14:39  Get:5 fonts-unifont         [2993 kB]
22:16:05  Get:6 fonts-wqy-zenhei      [7472 kB]
22:17:10  ##[error]The operation was canceled.
```

Six of ten packages in seven minutes — roughly **45 kB/s**. The same fetch on a healthy run takes **1.5 seconds at 17.2 MB/s**. `azure.archive.ubuntu.com` degraded; nothing in this repo changed.

### `--with-deps` was installing nothing Chromium needs

apt's own output in that log reports every actual Chromium runtime library as **"already the newest version"** on `ubuntu-latest`:

> libnss3, libnspr4, libgbm1, libdrm2, libcairo2, libpango-1.0-0, libglib2.0-0t64, libatk1.0-0t64, libatk-bridge2.0-0t64, libatspi2.0-0t64, libasound2t64, libcups2t64, libdbus-1-3, libfontconfig1, libfreetype6, libx11-6, libxcb1, libxcomposite1, libxdamage1, libxext6, libxfixes3, libxkbcommon0, libxrandr2, xvfb, fonts-liberation, fonts-noto-color-emoji

The **only 9 packages** it actually installed were fonts:

> fonts-freefont-ttf, fonts-ipafont-gothic, fonts-tlwg-loma-otf, fonts-unifont, fonts-wqy-zenhei, xfonts-cyrillic, xfonts-encodings, xfonts-scalable, xfonts-utils

That is 21.1 MB of Japanese, Thai, Chinese, Cyrillic and X11 bitmap fonts. Our entire browser E2E suite is `test/e2e/admin-ui.spec.ts` — six admin pages asserting the strings "Dashboard", "Memory", "Principals", "Connectors", "IdP", "Instance" and "Flair". Not one glyph comes from those packages.

### The proposed cache would have saved ~10 seconds

Measured on a healthy run, the step splits as:

| phase | duration |
|---|---|
| `apt-get update` (index metadata) | 8.6s |
| apt fetch + unpack 21.1 MB of fonts | 4.3s |
| **Chromium + FFmpeg + headless shell download** | **10.3s** |

The browser download — the only thing a `ms-playwright` cache covers — is under a third of the step and was never the problem. Caching it and keeping `--with-deps` would have left the failure mode fully intact.

## What this PR does

1. **Removes `--with-deps`.** This is the fix. It deletes an unbounded dependency on an apt mirror we do not control, from a step that was gaining nothing by it.
2. **Caches `~/.cache/ms-playwright` anyway** — not for the ~10s, but because it removes the *second* uncontrolled network fetch (`cdn.playwright.dev`) from the lane. Same failure shape, different host.
   - Key is the Playwright version **resolved from `package.json`**, never hardcoded. If the pin ever stops being exact the step hard-fails rather than silently keying on a range. Mirrors the existing `Resolve Harper image tag` pattern.
   - **No `restore-keys`, deliberately.** A prefix fallback could serve browsers built for a different Playwright and produce exactly the build-number mismatch a browser cache must never create. Exact key or cold miss.
   - The install still runs **unconditionally**, so a cold or partially-written cache self-heals instead of breaking the E2E step.
3. **Raises `timeout-minutes` 20 → 30** as headroom, explicitly commented as *not* the fix.

## Measurements

**Before** (four runs, 2026-07-28) — job total against a 20-minute ceiling:

| run | job total | `Run integration tests` | Playwright install |
|---|---|---|---|
| 30400673360 | 13m27s | 11m39s | 19s |
| 30401722063 | 14m06s | 12m08s | 22s |
| 30402731310 | 14m24s | 12m19s | 25s |
| 30402694592 | **20m17s → cancelled** | 11m46s | **7m05s, killed** |

Note the real shape of this lane: **the integration suite is ~85% of it.** The 20-minute budget left only ~6 minutes of slack, which is why a single degraded mirror was enough.

**After** — I will post the observed timing and the cache-hit proof from this PR's own runs as follow-up comments. The first run is necessarily a cache *miss*; the second run is what proves the cache works, and I will confirm it with `Cache restored from key:` in the log rather than asserting it from the YAML.

## On splitting the browser E2E into its own job

#948 raises this and the brief asked for a judgement rather than compliance. **I recommend against it**, for three reasons:

1. **It would silently weaken the gate.** Branch protection on this repo pins exact check contexts by name — that is not a guess, it is why `test-unit-gate` exists in this same file, re-emitting a fixed `Unit Tests` context because a matrixed job could no longer produce it. A new job creates a new context that branch protection does not require, so browser E2E failures would stop blocking merges until protection is updated. Trading a *misleading* `cancelled` for a check that genuinely does not gate is a strictly worse outcome. (I could not verify the protection config directly — our PAT gets 403 on the branch-protection endpoint — but the in-repo evidence is explicit.)
2. **The duplication is real.** A split job still needs checkout, bun install, the native embeddings binary, both builds, *and* the Docker Harper container. That is several minutes re-run, to move a step that is about to cost ~10 seconds.
3. **The motivating harm disappears with the actual fix.** The split was proposed to stop a browser download from invalidating signal that had already passed. Once the apt path is gone the step is ~10s of cached, first-party CDN work. There is no longer a multi-minute setup at the end of the job for anything to die on.

If the integration suite's ~12 minutes becomes the next problem, splitting *that* is the higher-value move — and it needs a branch-protection change made deliberately, not as a side effect of a CI reliability fix.

## Also worth flagging (not fixed here)

`docs-freshness-check.mjs` reports `cli-command-descriptions` as **`✓ pass`** when `dist/cli.js` is not built — it prints a "skipping" note and then passes. That is an unrun check that looks like a passing one. Out of scope for this PR; happy to file it separately.

## Verification

- `actionlint` on the changed workflow: **no new findings**. The two `SC2086:info` results are pre-existing on `origin/main` and appear at the identical positions, shifted by exactly the 63 lines this PR adds.
- `node scripts/changelog-fragments.mjs check` → 34 fragments, clean.
- `node scripts/docs-freshness-check.mjs` → all checks pass.
- Diff touches exactly two files. `release-publish.yml`, `README.md`, `docs/quickstart.md`, `scripts/release.sh` and `CHANGELOG.md` are confirmed untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
