### PR TITLE
fix(cli): a bare init must not renumber a custom-port instance, and stop parent/subcommand option collisions

### DIFF
--- a/.changelog/unreleased/fixed-init-port-renumber.md
+++ b/.changelog/unreleased/fixed-init-port-renumber.md
@@ -1,0 +1,14 @@
+- **`flair init` no longer renumbers an instance that serves a custom port.** A
+  bare `flair init` used to rewrite the port to 19926, because `--port` carried a
+  commander default and commander cannot tell "the user passed the default" from
+  "the user passed nothing". It was the only one of ~50 `--port` declarations in
+  the CLI with a default, on the one command where a default is destructive:
+  `init` is `flair doctor`'s standing suggestion and is recommended as the remedy
+  in ten other places, so the command handed to an operator whose install was
+  already wrong was the one that quietly moved their port.
+
+  A bare `init` now resolves the port the way every other command does — explicit
+  `--port`, then `FLAIR_URL`, then the port Harper records for that data
+  directory, then the per-user config — and only reaches 19926 for a data
+  directory no instance has ever been served from. An explicit `--port` still
+  moves the instance, and a first-run `flair init` still lands on 19926.

--- a/.changelog/unreleased/fixed-parent-subcommand-option-collisions.md
+++ b/.changelog/unreleased/fixed-parent-subcommand-option-collisions.md
@@ -1,0 +1,11 @@
+- **Options a parent command owns now work on its subcommands as documented.**
+  Where a subcommand redeclared an option its parent already had — `--target`,
+  `--port` and `--admin-pass-file` on `flair federation sync enable|status` —
+  the duplicate never received a value; it only made the flag look local. The
+  duplicates are gone, the flags still work on those subcommands, and
+  subcommand `--help` now lists inherited flags under a **Global Options**
+  heading so nothing became less discoverable.
+
+  A test walks the whole command tree and fails on any subcommand that
+  redeclares an option name an ancestor already owns, so this class of silent
+  drop cannot return the next time a subcommand grows a flag.

--- a/.changelog/unreleased/fixed-upgrade-flair-version-flag.md
+++ b/.changelog/unreleased/fixed-upgrade-flair-version-flag.md
@@ -1,0 +1,7 @@
+- **`flair upgrade --target <url> --version <semver>` silently upgraded nothing.**
+  Commander matches an option against a parent command's own list before
+  dispatching to the subcommand, so `--version` was caught by the program's
+  global `-v, --version`: the CLI printed its own version and exited 0 without
+  ever running the Fabric upgrade. The flag is now **`--flair-version <semver>`**
+  (matching the existing `--harper-version`). `--version` keeps its usual
+  meaning of printing the CLI version.

--- a/docs/upgrade.md
+++ b/docs/upgrade.md
@@ -188,7 +188,7 @@ FABRIC_USER=<admin> FABRIC_PASSWORD=<pass> \
 
 (or `--fabric-password-file <path>` instead of the `FABRIC_PASSWORD` env var — reads the
 password from a file, chmod 600). This resolves the target version (latest published
-`@tpsdev-ai/flair`, or pin one with `--version`), stages a clean deployable with the
+`@tpsdev-ai/flair`, or pin one with `--flair-version`), stages a clean deployable with the
 required `harper` version pin applied (`--harper-version` to override),
 confirms the staged Harper build before deploying, then reuses `flair deploy` to push it
 and verifies the result. `--check` shows the version diff and plan without deploying

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2745,6 +2745,15 @@ export { mcpServerSpec };
 const program = new Command();
 program.name("flair").version(__pkgVersion, "-v, --version");
 
+// flair#926: an option declared on a parent is consumed by the PARENT even when
+// it appears after a subcommand name, so a subcommand must NOT redeclare one —
+// the duplicate never receives a value, it only makes the flag look local.
+// Removing those duplicates would have hidden working flags from the
+// subcommand's help, so the help is taught to show inherited options instead.
+// This is commander's own answer to the problem, and it applies to every
+// subcommand at once rather than one hand-maintained list of exceptions.
+program.configureHelp({ showGlobalOptions: true });
+
 // ─── CLI↔server version handshake (flair#695 §B) ────────────────────────────
 // Every command invocation gets a cheap, cached (~60s), short-timeout check
 // of the running server's version against this CLI's own — catches the
@@ -6954,23 +6963,32 @@ federationSync
   .command("enable")
   .description("Install the sync driver (launchd on macOS, systemd timer on Linux)")
   .option("--interval <seconds>", `Seconds between syncs (default ${FEDERATION_SYNC_DEFAULT_INTERVAL})`, String(FEDERATION_SYNC_DEFAULT_INTERVAL))
-  .option("--admin-pass-file <path>", "Path to a 0600 file holding the admin password (default ~/.flair/admin-pass when it exists). The PATH is stored in the unit — never the password.")
   // Deliberately NOT `--no-admin-pass-file`: commander treats a `--no-x` flag
   // as the negation of `--x`, and declaring both on one command makes the
   // POSITIVE option silently parse to undefined — `--admin-pass-file /path`
   // would be accepted and dropped, producing a driver that fails auth every
   // cycle with no error anywhere. Verified against commander 14.
   .option("--no-credentials", "Do not wire any credential file into the unit")
-  .option("--target <url>", "Remote Flair URL to sync (default: the local instance)")
+  // `--admin-pass-file` and `--target` are NOT redeclared here (flair#926).
+  // The parent `flair federation sync` owns both, and commander matches an
+  // option against the parent's list before dispatching — so a duplicate
+  // declaration here never receives a value, it only makes the option LOOK
+  // local. Both flags still work on this command; they arrive via
+  // optsWithGlobals() below and are listed under "Global Options" in --help.
+  .addHelpText(
+    "after",
+    "\nCredentials:\n"
+      + "  --admin-pass-file defaults to ~/.flair/admin-pass when that file exists.\n"
+      + "  The PATH is stored in the unit — never the password.\n",
+  )
   .action(async (_opts, cmd) => {
     // optsWithGlobals(), NOT the action's first argument: `--admin-pass-file`
-    // and `--target` are declared on BOTH this subcommand and its parent
-    // (`flair federation sync`), and when a parent declares the same option
-    // name commander binds the value to the PARENT — the subcommand's own
-    // opts come back undefined. Reading only the local opts silently dropped
-    // `--admin-pass-file <path>` here, which would have installed a driver
+    // and `--target` are declared on the PARENT (`flair federation sync`), and
+    // commander binds their values there. The subcommand's own opts() has no
+    // entry for them at all. Reading only the local opts silently dropped
+    // `--admin-pass-file <path>` here (flair#923), which installed a driver
     // that failed auth every cycle with no error anywhere. Verified against
-    // commander 14.
+    // commander 14; test/unit/cli-option-collisions.test.ts pins the rule.
     const opts = cmd.optsWithGlobals();
     const intervalSeconds = Number(opts.interval);
     if (!Number.isFinite(intervalSeconds)) {
@@ -7034,12 +7052,14 @@ federationSync
 federationSync
   .command("status")
   .description("Show whether a sync driver is installed and genuinely active")
-  .option("--port <port>", "Harper HTTP port")
-  .option("--target <url>", "Remote Flair URL (env: FLAIR_TARGET)")
+  // `--port` and `--target` are NOT redeclared here (flair#926) — the parent
+  // `flair federation sync` owns them and commander binds them there. They
+  // still work on this command, via optsWithGlobals() below.
   .option("--json", "Emit JSON")
   .action(async (_opts, cmd) => {
-    // See the comment on `enable` above: `--target`/`--port` are declared on
-    // the parent too, so commander binds them there.
+    // See the comment on `enable` above: `--target`/`--port` live on the
+    // parent, so commander binds them there and only optsWithGlobals() sees
+    // them.
     const opts = cmd.optsWithGlobals();
     const { schedulerStatus, formatStatusReport, assessDriver } = await import("./federation/scheduler.js");
     try {
@@ -9304,7 +9324,9 @@ async function runFabricUpgrade(opts: any): Promise<void> {
   const upgradeOpts = {
     target: opts.target as string,
     project: opts.project,
-    version: opts.version,
+    // flair#926: `--flair-version`, never `opts.version` — that attribute name
+    // belongs to the program's `-v, --version` and never reaches this action.
+    version: opts.flairVersion,
     harperVersion: opts.harperVersion,
     fabricUser,
     fabricPassword,
@@ -9873,7 +9895,14 @@ program
   .option("--fabric-user <user>", "Fabric admin username — for --target (env: FABRIC_USER preferred; inline leaks to shell history)")
   .option("--fabric-password <pass>", "Fabric admin password — for --target (prefer FABRIC_PASSWORD env or --fabric-password-file; inline leaks to shell history)")
   .option("--fabric-password-file <path>", "Read the Fabric admin password from a file (chmod 600) — for --target")
-  .option("--version <semver>", "Flair version to deploy with --target (default: latest published @tpsdev-ai/flair)")
+  // NOT `--version` (flair#926). The program declares `-v, --version`, and
+  // commander matches an option against the PARENT's list before dispatching to
+  // the subcommand — so `flair upgrade --target X --version 1.2.3` printed the
+  // CLI's own version and exited 0, never running the Fabric upgrade at all.
+  // A colliding name is normally recoverable via optsWithGlobals(); this one is
+  // not, because commander's version listener exits the process. The name had
+  // to change. `--harper-version` below is the symmetry this follows.
+  .option("--flair-version <semver>", "Flair version to deploy with --target (default: latest published @tpsdev-ai/flair)")
   .option("--harper-version <semver>", "Pin harper to this version for --target (default: registry latest, floored at the flair#513 fix)")
   .option("--project <name>", "Fabric component name for --target", "flair")
   .option("--no-replicated", "Disable cluster-wide replication for --target (default: replicated=true)")

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -629,15 +629,14 @@ function readOpsPortFromConfig(path: string = configPath()): number | null {
  *     a clean install has always done, instead of the refusal that would make
  *     `flair init --data-dir <new>` impossible.
  *
- * Note that `init`'s own `--port` option carries a commander default of
- * DEFAULT_PORT, so in practice `opts.port` is always set there and this
- * function returns on the first rung — including when re-initialising an
- * instance that already serves a different port, which is silently renumbered
- * to DEFAULT_PORT. That is pre-existing (it is equally true of the default
- * install on a custom port, where re-running init is `flair doctor`'s standing
- * remedy) and is tracked separately; the "create" rung is what this function
- * would answer if that default were removed, and is what keeps the mode
- * distinction honest rather than hypothetical.
+ * The "create" rung is load-bearing rather than hypothetical (flair#928).
+ * `init`'s `--port` used to carry a commander default of DEFAULT_PORT, so
+ * `opts.port` was ALWAYS set there and this function returned on the first rung
+ * — including when re-initialising an instance already serving a different
+ * port, which was silently renumbered to DEFAULT_PORT. Commander cannot tell
+ * "the user passed the default" from "the user passed nothing", so the default
+ * was the bug. It is gone; a bare `init` now falls through to the ladder, and
+ * only a directory no instance has ever been served from reaches DEFAULT_PORT.
  *
  * Nothing is copied, migrated or written here. Harper's config already IS the
  * per-instance record, so there is no second file to keep in step — which is
@@ -2792,7 +2791,12 @@ program
   .description("One-command Flair setup — bootstrap the instance, register an agent, and wire MCP clients")
   .option("--agent-id <id>", "Agent ID to register (omit to bootstrap instance without agent)")
   .option("--agent <id>", "Alias for --agent-id")
-  .option("--port <port>", "Harper HTTP port", String(DEFAULT_PORT))
+  // No commander default (flair#928). A default here is indistinguishable from
+  // the user typing it, so a BARE `flair init` used to state DEFAULT_PORT and
+  // renumber an instance already serving a custom one. Absent means absent, and
+  // resolveHttpPort's "create" ladder supplies DEFAULT_PORT for a genuinely new
+  // instance — which is the only case that ever wanted one.
+  .option("--port <port>", "Harper HTTP port (default: this instance's current port, or 19926 for a new one)")
   .option("--ops-port <port>", "Harper operations API port")
   .option("--ops-bind <addr>", "Harper ops API bind address (env: FLAIR_OPS_BIND; default: 127.0.0.1 loopback-only for single-host — pass e.g. 0.0.0.0 for multi-host/Fabric remote admin)")
   .option("--admin-pass <pass>", "Admin password (generated if omitted)")
@@ -3006,9 +3010,14 @@ program
     // directory with no recorded port is a new instance taking the default,
     // not the hard error every other caller gets — otherwise `flair init
     // --data-dir <new>` could never succeed. `dataDir` is resolved first so
-    // this is never asked before the instance is known. (`--port` carries a
-    // commander default, so this usually returns on the flag rung; see
-    // resolveHttpPort's doc comment.)
+    // this is never asked before the instance is known.
+    //
+    // flair#928: `--port` deliberately carries NO commander default, so a bare
+    // `init` reaches the ladder below instead of restating DEFAULT_PORT and
+    // renumbering an instance that already serves a custom port. `init` is
+    // `flair doctor`'s standing remedy and is recommended in ten places, so the
+    // command handed to an operator whose install is already wrong must not be
+    // the one that moves their port.
     const httpPort = resolveHttpPort(opts, "create");
     // The already-resolved port is handed to the ops resolver rather than
     // letting it re-resolve — its last rung is `resolveHttpPort(opts) - 1`,

--- a/test/unit/cli-option-collisions.test.ts
+++ b/test/unit/cli-option-collisions.test.ts
@@ -1,0 +1,299 @@
+// cli-option-collisions.test.ts — the structural guard for flair#926.
+//
+// Commander matches an option against a command's OWN option list while it is
+// still scanning for the subcommand to dispatch to, so a flag typed after a
+// subcommand name is consumed by the first ancestor that recognises it. When a
+// subcommand redeclares a name its parent already owns, the parent wins and the
+// subcommand's `opts()` has no entry for it at all.
+//
+// The failure is invisible in three ways at once: no type error, no runtime
+// error, and behaviour indistinguishable from the user simply not passing the
+// flag. flair#923 hit it with `--admin-pass-file` on `flair federation sync
+// enable`, which installed a scheduled driver that failed authentication every
+// cycle with nothing surfaced anywhere. Typecheck and unit tests were green;
+// only an end-to-end run caught it.
+//
+// So this file pins two different things, and both are needed:
+//
+//   1. THE RULE — a synthetic commander tree exercising the exact shape, with a
+//      positive control that has no collision. This is what stops the guard
+//      below from silently becoming vacuous if commander's binding changes: a
+//      test that only asserts "no collisions exist" passes just as happily when
+//      the walk is broken as when the tree is clean.
+//   2. THE TREE — the real `program`, asserted to contain no collisions at all.
+//      Zero tolerance rather than an allowlist: every entry on an allowlist is
+//      a trap for whoever adds the next subcommand, and the two mitigations
+//      (drop the duplicate declaration, or read `optsWithGlobals()`) are both
+//      cheap enough that no exception has to be carved out.
+//
+// Discoverability is not the cost it looks like. `program.configureHelp({
+// showGlobalOptions: true })` lists a parent's options under "Global Options"
+// in every subcommand's `--help`, so removing a duplicate declaration hides
+// nothing from the operator — the flag is still shown, and still works.
+import { describe, test, expect } from "bun:test";
+import { Command, Option } from "commander";
+import { program } from "../../src/cli";
+
+/** Every (command, option) pair whose name an ancestor already declares. */
+interface Collision {
+  /** Full command path, e.g. "federation sync enable". */
+  path: string;
+  /** The `opts()` key — what actually collides. `--admin-pass-file` → `adminPassFile`. */
+  attr: string;
+  flags: string;
+  ancestorPath: string;
+  ancestorFlags: string;
+}
+
+/**
+ * The options a command explicitly declares.
+ *
+ * This is `cmd.options`, which already includes the one added by `.version()`
+ * — the worst case in this class, because commander's version listener exits
+ * the process and no `optsWithGlobals()` can recover the value.
+ *
+ * It deliberately does NOT include commander's lazily-materialised `-h,
+ * --help`. Every command has one, so counting it would report a collision on
+ * all 125 of them, and it would be wrong: commander resolves help flags at the
+ * LEAF after dispatching, not during the ancestor's option scan, so `flair
+ * federation sync enable --help` prints `enable`'s help and not its parent's.
+ * The synthetic test below pins that rather than trusting the claim, so this
+ * exclusion fails loudly if commander ever changes it.
+ */
+function declaredOptions(cmd: Command): Option[] {
+  return [...((cmd as unknown as { options: Option[] }).options)];
+}
+
+function findCollisions(root: Command): Collision[] {
+  const found: Collision[] = [];
+
+  function walk(cmd: Command, path: string[], ancestors: Array<{ path: string; options: Option[] }>): void {
+    const here = [...path, cmd.name()];
+    const herePath = here.join(" ");
+    const mine = declaredOptions(cmd);
+
+    for (const opt of mine) {
+      const attr = opt.attributeName();
+      // Nearest ancestor first — that is the one that actually consumes it.
+      for (let i = ancestors.length - 1; i >= 0; i--) {
+        const clash = ancestors[i].options.find((a) => a.attributeName() === attr);
+        if (clash) {
+          found.push({
+            path: herePath,
+            attr,
+            flags: opt.flags,
+            ancestorPath: ancestors[i].path,
+            ancestorFlags: clash.flags,
+          });
+          break;
+        }
+      }
+    }
+
+    const next = [...ancestors, { path: herePath, options: mine }];
+    for (const sub of cmd.commands) walk(sub, here, next);
+  }
+
+  const rootName = root.name() || "flair";
+  for (const sub of root.commands) {
+    walk(sub, [], [{ path: rootName, options: declaredOptions(root) }]);
+  }
+  return found;
+}
+
+function describeCollisions(cs: Collision[]): string {
+  return cs
+    .map(
+      (c) =>
+        `  'flair ${c.path}' declares ${c.flags} (opts key: ${c.attr})\n`
+        + `      but 'flair ${c.ancestorPath}' already declares ${c.ancestorFlags}, and consumes it.`,
+    )
+    .join("\n");
+}
+
+describe("flair#926 — the rule, on a synthetic tree", () => {
+  test("a parent consumes a colliding option and the subcommand sees undefined", () => {
+    const root = new Command();
+    root.name("flair").exitOverride();
+    const parent = root
+      .command("parent")
+      .option("--shared <v>", "declared on the parent")
+      .action(() => {});
+
+    let childOpts: Record<string, unknown> | undefined;
+    let childWithGlobals: Record<string, unknown> | undefined;
+    let parentOpts: Record<string, unknown> | undefined;
+    parent
+      .command("child")
+      .option("--shared <v>", "redeclared on the child — this is the defect")
+      .option("--own <v>", "declared only here")
+      .action((opts, cmd) => {
+        childOpts = opts;
+        childWithGlobals = cmd.optsWithGlobals();
+        parentOpts = cmd.parent!.opts();
+      });
+
+    root.parse(["node", "flair", "parent", "child", "--shared", "SENTINEL", "--own", "mine"]);
+
+    // The child's own opts() has NO entry — not a wrong value, no entry. That
+    // is why the defect reads as "the user did not pass the flag".
+    expect(childOpts).toBeDefined();
+    expect(childOpts!.shared).toBeUndefined();
+    expect("shared" in childOpts!).toBe(false);
+    // The value is not lost, it is on the parent.
+    expect(parentOpts!.shared).toBe("SENTINEL");
+    // ...and optsWithGlobals() is what reaches it. This is the recovery the
+    // federation sync subcommands rely on.
+    expect(childWithGlobals!.shared).toBe("SENTINEL");
+    // A non-colliding option on the same command is unaffected, which is what
+    // makes the defect so quiet: everything else on the command works.
+    expect(childOpts!.own).toBe("mine");
+  });
+
+  test("positive control: with no collision the subcommand receives its own value", () => {
+    // Without this, the assertions above could pass because the option never
+    // arrived at all — a broken fixture rather than the binding rule.
+    const root = new Command();
+    root.name("flair").exitOverride();
+    const parent = root.command("parent").option("--other <v>", "").action(() => {});
+    let childOpts: Record<string, unknown> | undefined;
+    parent.command("child").option("--shared <v>", "").action((opts) => { childOpts = opts; });
+
+    root.parse(["node", "flair", "parent", "child", "--shared", "SENTINEL"]);
+    expect(childOpts!.shared).toBe("SENTINEL");
+  });
+
+  test("--help is NOT in this class: commander resolves it at the leaf", () => {
+    // Justifies `declaredOptions` skipping the auto-added help option. Every
+    // command has one, so if help behaved like an ordinary option the guard
+    // would have to report all 125 commands — and the exclusion that avoids
+    // that would be hiding real collisions. It does not: help flags are checked
+    // in the leaf subcommand after dispatch, so the deepest command wins.
+    const root = new Command();
+    root.name("flair").exitOverride();
+    let shown = "";
+    const parent = root.command("parent").action(() => {});
+    const child = parent.command("child").description("the leaf").action(() => {});
+    child.configureOutput({ writeOut: (s) => { shown += s; } });
+    parent.configureOutput({ writeOut: (s) => { shown += s; } });
+
+    expect(() => root.parse(["node", "flair", "parent", "child", "--help"]))
+      .toThrow(expect.objectContaining({ code: "commander.helpDisplayed" }));
+    expect(shown).toContain("flair parent child");
+    expect(shown).toContain("the leaf");
+  });
+
+  test("a collision with the program's --version is not recoverable at all", () => {
+    // The reason `flair upgrade` could not keep its `--version <semver>`.
+    // Every other collision leaves the value retrievable via optsWithGlobals();
+    // this one runs commander's version listener, which writes the version and
+    // exits the process before any action is reached. There is nothing to
+    // recover and nothing to read — the only fix is a different name.
+    const root = new Command();
+    root.name("flair").version("9.9.9", "-v, --version").exitOverride();
+    root.configureOutput({ writeOut: () => {} });
+    let ran = false;
+    root.command("upgrade").option("--version <semver>", "").action(() => { ran = true; });
+
+    expect(() => root.parse(["node", "flair", "upgrade", "--version", "1.2.3"]))
+      .toThrow(expect.objectContaining({ code: "commander.version" }));
+    expect(ran).toBe(false);
+  });
+});
+
+describe("flair#926 — the real CLI declares no colliding options", () => {
+  test("no subcommand redeclares an option name an ancestor already owns", () => {
+    const collisions = findCollisions(program as unknown as Command);
+
+    expect(
+      collisions.length === 0
+        ? ""
+        : "Subcommand options shadowed by an ancestor (flair#926):\n"
+          + describeCollisions(collisions)
+          + "\n\nCommander binds each of these to the ANCESTOR, so the subcommand's"
+          + "\nopts() returns undefined for it — silently, with no type or runtime error."
+          + "\n\nFix by one of:"
+          + "\n  - Drop the duplicate declaration. The parent's already parses the flag,"
+          + "\n    it still works on the subcommand, and `showGlobalOptions` keeps it"
+          + "\n    listed in the subcommand's --help. Preferred."
+          + "\n  - If the subcommand genuinely needs its own, rename it (see"
+          + "\n    `flair upgrade --flair-version`)."
+          + "\nEither way the action must read cmd.optsWithGlobals(), not its first argument.",
+    ).toBe("");
+  });
+
+  test("the walk actually traverses the CLI, and would see a collision if one existed", () => {
+    // Guards the guard. `findCollisions` returning [] is the pass condition
+    // above, and [] is also what a walk that visited nothing returns. So: prove
+    // it reaches depth, then prove it still detects a collision when one is
+    // planted in the real tree.
+    const root = program as unknown as Command;
+    let count = 0;
+    let maxDepth = 0;
+    (function count_(cmd: Command, depth: number): void {
+      count++;
+      maxDepth = Math.max(maxDepth, depth);
+      for (const sub of cmd.commands) count_(sub, depth + 1);
+    })(root, 0);
+    expect(count).toBeGreaterThan(100);
+    expect(maxDepth).toBeGreaterThanOrEqual(3); // e.g. flair federation sync enable
+
+    // Plant one, on a real command, and confirm it is reported.
+    const victim = root.commands.find((c) => c.commands.length > 0)!;
+    const sub = victim.commands[0];
+    const parentOwned = (victim as unknown as { options: Option[] }).options[0]
+      ?? (root as unknown as { options: Option[] }).options[0];
+    const planted = new Option(parentOwned.flags, "planted by the guard's own test");
+    (sub as unknown as { options: Option[] }).options.push(planted);
+    try {
+      const withPlant = findCollisions(root);
+      expect(withPlant.some((c) => c.attr === planted.attributeName())).toBe(true);
+    } finally {
+      const opts = (sub as unknown as { options: Option[] }).options;
+      opts.splice(opts.indexOf(planted), 1);
+    }
+    // ...and removing it returns the tree to clean.
+    expect(findCollisions(root)).toEqual([]);
+  });
+});
+
+describe("flair#926 — regressions on the two commands this came from", () => {
+  test("`flair upgrade` takes --flair-version and never declares --version", () => {
+    const upgrade = (program as unknown as Command).commands.find((c) => c.name() === "upgrade")!;
+    const names = (upgrade as unknown as { options: Option[] }).options.map((o) => o.attributeName());
+    // `--version` on this command was accepted by the shell, printed the CLI's
+    // own version, and exited 0 — so `flair upgrade --target X --version 1.2.3`
+    // reported success while upgrading nothing.
+    expect(names).not.toContain("version");
+    expect(names).toContain("flairVersion");
+  });
+
+  test("`federation sync` owns the shared flags and its subcommands do not restate them", () => {
+    const federation = (program as unknown as Command).commands.find((c) => c.name() === "federation")!;
+    const sync = federation.commands.find((c) => c.name() === "sync")!;
+    const own = (c: Command) => (c as unknown as { options: Option[] }).options.map((o) => o.attributeName());
+
+    // The parent is where they live, and where commander binds them.
+    expect(own(sync)).toEqual(expect.arrayContaining(["port", "adminPassFile", "target"]));
+
+    for (const name of ["enable", "status"]) {
+      const child = sync.commands.find((c) => c.name() === name)!;
+      expect(own(child)).not.toContain("adminPassFile");
+      expect(own(child)).not.toContain("target");
+      expect(own(child)).not.toContain("port");
+    }
+  });
+
+  test("the shared flags are still discoverable on the subcommands", () => {
+    // Removing a declaration must not remove the flag from the operator's view
+    // — it still works, so it still has to be documented where it is used.
+    const federation = (program as unknown as Command).commands.find((c) => c.name() === "federation")!;
+    const sync = federation.commands.find((c) => c.name() === "sync")!;
+    const status = sync.commands.find((c) => c.name() === "status")!;
+
+    const help = status.helpInformation();
+    expect(help).toContain("Global Options:");
+    expect(help).toContain("--target");
+    expect(help).toContain("--port");
+  });
+});

--- a/test/unit/harper-config-port.test.ts
+++ b/test/unit/harper-config-port.test.ts
@@ -422,6 +422,123 @@ describe("flair#914 — an instance's port comes from Harper's config in its dat
     expect(existsSync(join(defaultDataDir, "DEFAULT-INSTANCE-MARKER"))).toBe(true);
   }, 60_000);
 
+  // ─── 4b. flair#928 — a BARE init must not renumber an existing instance ──
+  //
+  // `init`'s `--port` carried a commander default of DEFAULT_PORT. Commander
+  // cannot distinguish "the user passed the default value" from "the user
+  // passed nothing", so `opts.port` was ALWAYS set and resolution returned on
+  // the flag rung — a bare `flair init` restated DEFAULT_PORT and moved an
+  // instance that was serving a custom one.
+  //
+  // It was the only one of ~50 `--port` declarations in the CLI with a default,
+  // and it was on the one command where a default is destructive rather than
+  // convenient: `init` is `flair doctor`'s standing remedy and is recommended
+  // in ten places, so the command handed to an operator whose install is
+  // already wrong was the one that quietly renumbered it.
+  //
+  // These run with `--skip-start`, so no Harper is spawned and Harper's own
+  // config is the fixture's. That is the right seam: the defect is in
+  // RESOLUTION, and what a real init does with the resolved number (force-set
+  // `http.port` via HARPER_SET_CONFIG, then persist the per-user coordinates)
+  // follows from it.
+
+  /**
+   * The port an existing instance is already serving. Distinct from BOTH
+   * DEFAULT_PORT and LEGACY_PER_USER_PORT on purpose: each of the three
+   * possible answers here — preserve, default, or read the wrong file — is a
+   * different number, so a single assertion says which one the code gave.
+   */
+  const CUSTOM_PORT = 20771;
+
+  test("a bare init does not renumber an existing custom-port default install", async () => {
+    // The install already serves a custom port, recorded where Harper records
+    // it and where the per-user file records it. Both agree; neither says
+    // DEFAULT_PORT.
+    writeLegacyPerUserConfig(CUSTOM_PORT);
+    writeHarperConfig(defaultDataDir, { httpPort: CUSTOM_PORT });
+    const harperBefore = readFileSync(join(defaultDataDir, "harper-config.yaml"), "utf-8");
+
+    // No --port. This is `flair doctor`'s standing remedy, typed verbatim.
+    const { stdout, exitCode } = await runCli(["init", "--skip-start", "--no-mcp"]);
+    expect(exitCode).toBe(0);
+
+    // The instance still serves the port it served. The assertion is on
+    // DEFAULT_PORT's ABSENCE as much as the custom port's presence: a renumber
+    // writes a specific wrong number, and naming it is what makes this fail
+    // loudly if the default ever comes back.
+    expect(perUserConfig()).toContain(`port: ${CUSTOM_PORT}`);
+    expect(perUserConfig()).not.toContain(String(DEFAULT_PORT));
+    // Harper's own record — the authority — was not rewritten.
+    expect(readFileSync(join(defaultDataDir, "harper-config.yaml"), "utf-8")).toBe(harperBefore);
+    // And what the operator is TOLD matches what is on disk. A correct file
+    // under a summary announcing DEFAULT_PORT would still send them to the
+    // wrong URL.
+    expect(stdout).toContain(`127.0.0.1:${CUSTOM_PORT}`);
+    expect(stdout).not.toContain(`127.0.0.1:${DEFAULT_PORT}`);
+
+    expect(existsSync(join(defaultDataDir, "DEFAULT-INSTANCE-MARKER"))).toBe(true);
+    expect(flairOwnedPortFiles(defaultDataDir)).toEqual([]);
+  }, 60_000);
+
+  test("a bare init does not renumber an existing custom-port NAMED instance", async () => {
+    // Same defect through `--data-dir`, which is the addressable form. The
+    // per-user file carries a different number again, so an answer of
+    // LEGACY_PER_USER_PORT would also be wrong and is distinguishable from
+    // both the right answer and the defaulted one.
+    writeLegacyPerUserConfig();
+    const before = perUserConfig();
+    const instance = newScratchDataDir();
+    writeHarperConfig(instance, { httpPort: CUSTOM_PORT });
+    const harperBefore = readFileSync(join(resolve(instance), "harper-config.yaml"), "utf-8");
+
+    const { stdout, exitCode } = await runCli(["init", "--skip-start", "--no-mcp", "--data-dir", instance]);
+    expect(exitCode).toBe(0);
+
+    expect(stdout).toContain(`127.0.0.1:${CUSTOM_PORT}`);
+    expect(stdout).not.toContain(`127.0.0.1:${DEFAULT_PORT}`);
+    expect(stdout).not.toContain(`127.0.0.1:${LEGACY_PER_USER_PORT}`);
+    expect(readFileSync(join(resolve(instance), "harper-config.yaml"), "utf-8")).toBe(harperBefore);
+    // flair#914 still holds: a named init leaves the per-user file alone.
+    expect(perUserConfig()).toBe(before);
+  }, 60_000);
+
+  test("an explicit --port still wins over the recorded port", async () => {
+    // The other half of the fix. Removing the default must not make `--port`
+    // advisory — an operator MOVING an instance deliberately is exactly what
+    // the flag is for, and a fix that only ever preserved would be as wrong as
+    // one that only ever defaulted.
+    writeLegacyPerUserConfig(CUSTOM_PORT);
+    writeHarperConfig(defaultDataDir, { httpPort: CUSTOM_PORT });
+
+    const { stdout, exitCode } = await runCli(["init", "--skip-start", "--no-mcp", "--port", "20993"]);
+    expect(exitCode).toBe(0);
+    expect(perUserConfig()).toContain("port: 20993");
+    expect(stdout).toContain("127.0.0.1:20993");
+  }, 60_000);
+
+  test("a bare init on a directory no instance has ever used still takes DEFAULT_PORT", async () => {
+    // What the commander default was actually for. A brand-new install has no
+    // port to preserve, and the "create" rung supplies one — so removing the
+    // default did not turn a first-run `flair init` into a refusal.
+    const fresh = newScratchDataDir();
+    rmSync(resolve(fresh), { recursive: true, force: true });
+
+    const { stdout, exitCode } = await runCli(["init", "--skip-start", "--no-mcp", "--data-dir", fresh]);
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain(`127.0.0.1:${DEFAULT_PORT}`);
+  }, 60_000);
+
+  test("`--port` carries no commander default", async () => {
+    // The mechanism, pinned directly rather than only through its consequence:
+    // a default printed in `init --help` is a default commander is substituting
+    // for absence, which is the defect. Help text is the one place the
+    // declaration is observable without running an init.
+    const { stdout } = await runCli(["init", "--help"]);
+    const portLine = stdout.split("\n").find((l) => l.trimStart().startsWith("--port"));
+    expect(portLine).toBeDefined();
+    expect(portLine).not.toContain(`(default: "${DEFAULT_PORT}")`);
+  }, 30_000);
+
   // ─── 5. flair#910's guard, on a port that now comes from Harper ─────────
 
   test("the flair#910 attribution guard passes when Harper's recorded port is the one this instance serves", async () => {


### PR DESCRIPTION
Fixes two related Commander defects. The commits are separable — one per issue.

## #928 — a bare `flair init` renumbered a custom-port instance

`init`'s `--port` was the only one of ~50 `--port` declarations in the CLI carrying a Commander default, and it was on the one command where a default is destructive rather than convenient. Commander cannot distinguish "the user passed the default value" from "the user passed nothing", so `opts.port` was always populated and resolution returned on the flag rung.

**Reproduced on v0.31.0 before changing anything**, in an isolated `HOME` on a throwaway data dir:

| | before | after a bare `flair init` |
|---|---|---|
| per-user `config.yaml` | `port: 20881` | `port: 19926` |
| announced URL | — | `http://127.0.0.1:19926` |
| operator's hand-edited comment | present | gone |

And with a **real Harper**: an instance that had bound `20881` came back up on `19926` after a bare `init` — the port move, observed rather than inferred. The `--skip-start` run proves the persistence half; the live run proves the bind half.

The fix removes the default, so a bare `init` falls through to the same ladder every other command uses (explicit `--port` → `FLAIR_URL` → the port Harper records for that data directory → the per-user config), reaching `DEFAULT_PORT` only via `resolveHttpPort`'s `"create"` rung — i.e. only for a directory no instance has ever been served from. `--ops-port` was checked and already carried no default.

This matters more than it sounds: `init` is `flair doctor`'s standing suggestion and is recommended as the remedy in ten other places, so the command handed to an operator whose install is already wrong was the one that quietly renumbered it.

## #926 — the general case

Commander matches an option against a command's own list *while it is still scanning for the subcommand to dispatch to*, so a flag typed after a subcommand name is consumed by the first ancestor that recognises it. The subcommand's `opts()` then has no entry at all — no type error, no runtime error, and behaviour indistinguishable from the user simply not passing the flag.

Swept all **125 commands** by walking the real Commander tree rather than grepping. **Five collisions, in two classes:**

| command | option | shadowed by | verdict |
|---|---|---|---|
| `upgrade` | `--version <semver>` | program's `-v, --version` | **live bug** |
| `federation sync enable` | `--admin-pass-file` | `federation sync` | benign today |
| `federation sync enable` | `--target` | `federation sync` | benign today |
| `federation sync status` | `--port` | `federation sync` | benign today |
| `federation sync status` | `--target` | `federation sync` | benign today |

### `flair upgrade --version` — a live bug, and the worse class

Every other collision leaves the value retrievable via `optsWithGlobals()`. This one does not: Commander's version listener writes the version and **exits the process**. Verified on v0.31.0:

```
$ flair upgrade --target http://example.invalid --version 9.9.9 --yes
0.31.0
$ echo $?
0
```

The Fabric upgrade never ran, and the exit code says success — so a script would treat it as done. `docs/upgrade.md` documented this unreachable spelling ("pin one with `--version`"). Renamed to **`--flair-version <semver>`**, matching the existing `--harper-version`; docs updated. After the fix the action is reached (it gets as far as the credentials check).

### The four benign ones

`federation sync enable` and `status` already read `cmd.optsWithGlobals()` (from #923), so the values do arrive and both commands work exactly as documented. The duplicate declarations never received a value — they only made the flags *look* local, which is the trap for whoever adds the next subcommand. Removed.

Verified end to end that the documented invocations still deliver their values, with a negative control proving the check is meaningful: `federation sync enable --interval 900 --admin-pass-file <path>` still writes that path into the unit, and the same command without the flag does not.

Removing a duplicate would normally hide a working flag from the subcommand's `--help`, so help now shows inherited options under a **Global Options** heading. That is Commander's own answer (`showGlobalOptions`), and it applies to every subcommand at once rather than a hand-maintained list of exceptions.

## The guard

`test/unit/cli-option-collisions.test.ts` walks the tree and fails on **any** such collision — zero tolerance rather than an allowlist, since every allowlist entry is a trap for exactly the person the guard exists to protect. It:

- pins the Commander binding rule on a synthetic tree, **with a positive control** — a zero-collision assertion passes just as happily when the walk is broken as when the tree is clean, so the rule is pinned independently;
- proves the walk reaches depth 3 or more and still reports a collision **planted in the real tree**;
- pins that `--help` is *not* in this class (Commander resolves it at the leaf), so the exclusion that keeps the guard from reporting all 125 commands is justified by evidence rather than assertion;
- names the command, the option, the ancestor and the remedy when it fails.

## Verification

- **#928 mutation-check** — restoring `String(DEFAULT_PORT)`: **3 fail** (both bare-init tests plus the mechanism test that reads `init --help`). The two control tests — explicit `--port` still wins, and a fresh install still lands on 19926 — correctly stay green, since they must be insensitive to the mutation. Removed: **16 pass**.
- **#926 mutation-check**, both directions. Re-adding `--target` to `federation sync status`: **3 fail**. Renaming `--flair-version` back to `--version`: **3 fail**. Restored: **9 pass**.
- Full unit suite: **3350 pass, 0 fail** (181 files). Typecheck, `check-imports`, `check-version-sync`, `check-workspace-deps`, `audit-gate`, impl-term-leaks and ASCII-box all pass.
- `docs-freshness-check` passes with `cli-command-descriptions` **actually running** — it skips silently unless `dist/cli.js` is built, so the CLI was built first rather than accepting a skip that reads as a pass.
- All `init` runs were against throwaway data dirs under an isolated `HOME` on non-default ports, with `launchctl` shimmed. Production was checked before and after and is unchanged: HTTP 200, v0.31.0, `http.port: 9926`, `operationsApi.port: 9925`. No stray listeners left behind.

Closes #928
Closes #926

🤖 Generated with [Claude Code](https://claude.com/claude-code)
