### PR TITLE
fix: a check that did not run must not look like a check that passed (#953)

### DIFF
--- a/.changelog/unreleased/fixed-docs-freshness-skip-is-not-a-pass.md
+++ b/.changelog/unreleased/fixed-docs-freshness-skip-is-not-a-pass.md
@@ -1,0 +1,29 @@
+- **A docs-freshness check that could not run no longer reports as passing
+  (flair#953).** `cli-command-descriptions` introspects the CLI's command tree
+  from the built `dist/cli.js`. On any machine where the CLI had not been built
+  it printed "skipping", returned no failures, and the runner rendered it as
+  `✓ pass` beneath a summary reading "All docs-freshness checks passed" — six
+  ticks, one of which had verified nothing. The defect was never in a check; it
+  was in what the runner does when a check cannot execute.
+
+  The gate now carries three states — `✓ pass`, `⊘ DID NOT RUN`, `✗ fail` —
+  through the per-check line, the summary tally and the exit code. A skip is
+  never counted toward the pass total, so the tally cannot read `6/6` while
+  something sat out, and the process exits `2` (distinct from `1` for real
+  findings, so a wrapper can tell "your docs are stale" from "your environment
+  is wrong"; both are non-zero, so CI treats them identically). Each skip names
+  the unmet prerequisite and its remedy, and is emitted as a CI annotation
+  rather than buried in the log.
+
+  Two silent variants are closed at the same time. A check that examined **zero
+  items** is now automatically a skip: passing checks report their corpus size
+  (`✓ port-drift (26 prose docs scanned)`), so a glob or `existsSync` filter
+  that empties after a rename shows up as `examined 0 prose docs` instead of
+  being indistinguishable from a clean scan. And the gate refuses to report at
+  all if a check fails to register, because a gate that runs zero checks
+  announces success exactly as loudly as one that runs six.
+
+  Nothing changes in CI, which builds the CLI and checks out full history before
+  invoking the gate — that is the point: the gate was already passing there for
+  real, and only ever went dark where nobody was looking. Running it locally
+  without building the CLI first will now tell you so.

--- a/.changelog/unreleased/fixed-gates-that-covered-nothing.md
+++ b/.changelog/unreleased/fixed-gates-that-covered-nothing.md
@@ -1,0 +1,51 @@
+- **Five gates that could report success without checking anything (flair#953,
+  sweep).** Auditing the class behind the docs-freshness skip — the absence of a
+  result rendering identically to a passing result — turned up these, each
+  verified against real CI logs or a reproduced failure rather than by reading
+  the code:
+
+  - **250 tests in `test/*.test.ts` were run by no CI job and no release gate.**
+    Every `bun test` invocation in every workflow is directory-scoped, and a
+    directory filter does not match root-level files, so twelve suites — six of
+    them security-scoping (auth scoping, data scoping, content safety, key
+    rotation, agent grants, backup/restore) — were never executed by CI. A bare
+    `bun test`, which `CONTRIBUTING.md` tells contributors to run, does pick them
+    up, so they passed locally and were enforced nowhere. Confirmed by grepping
+    28.6 MB of historical CI logs for each suite's `describe()` name: zero hits
+    each, against positive controls from `test/unit/` at 192 and 240 hits. They
+    are now in the unit lane and all 250 pass.
+
+  - **The implementation-term leak gate reported clean when its scan failed.**
+    `grep`'s exit status was discarded with `|| true`, collapsing "grep itself
+    failed" (unreadable file, argument-list overflow) into "no matches found";
+    the file list was word-split, so a path containing a space was silently never
+    scanned; and an empty corpus printed "No files to search." and exited 0. All
+    three now fail loudly, and the file count is reported so a shrinking corpus
+    is visible.
+
+  - **`release.sh` tagged a partial publish as a complete release.** Five of the
+    eight packages soft-fail on publish so a break-glass release of the core
+    three isn't blocked — but the script then tagged and printed "published and
+    tagged" regardless. Since the root package pins its internal dependencies at
+    the exact version, a missing package is a broken install rather than a
+    missing extra. The soft-fails are retained; they are now counted, named, and
+    block the tag.
+
+  - **A workspace package with no `tsconfig.json` was silently exempt from type
+    checking.** It printed one "Skipping" line into a folded log and left the job
+    green, so a package that lost its tsconfig in a refactor would have had zero
+    type coverage with the same signal as a clean check. Exclusions are now an
+    explicit allowlist, an unlisted skip fails, and a run that type-checks zero
+    packages fails.
+
+  - **`changelog-fragments check` skipped its stray-entry rule when the
+    `## [Unreleased]` header was missing**, making the PR-time check strictly
+    weaker than the release-time one, which refuses on the same condition. A
+    mangled header passed CI and detonated mid-release-cut instead. It now fails
+    where `promote` would.
+
+  `test/unit/ci-gate-coverage.test.ts` pins these as invariants rather than as
+  string matches: it enumerates every test file on disk and asserts CI reaches
+  all of them, and enumerates every workspace package and asserts each is
+  type-checked or explicitly excused. Adding a test directory no job runs, or a
+  package nobody type-checks, fails there.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -99,7 +99,15 @@ jobs:
           restore-keys: |
             bun-cache-${{ runner.os }}-
       - run: sfw bun install --frozen-lockfile
-      - run: bun test test/unit/
+      # test/*.test.ts — 12 files, 250 cases — were run by NO CI command
+      # (flair#953). Every `bun test` invocation in every workflow targets a
+      # subdirectory, and a subdirectory filter does not pick up root-level test
+      # files. They pass locally under a bare `bun test`, which is what
+      # CONTRIBUTING.md tells contributors to run, so they looked covered from
+      # both ends while being enforced from neither. They are pure-logic suites
+      # (auth scoping, data scoping, REM runner/scheduler/snapshot, content
+      # safety, key rotation) with no live-service reason to be excluded.
+      - run: bun test test/unit/ test/*.test.ts
       # test/unit-isolated/ holds files that `mock.module` a process-global
       # shared module (embeddings-provider). `mock.module` is first-wins and
       # unrestored, so these files poison not only the real-importer files in
@@ -1009,20 +1017,50 @@ jobs:
       # Workspace packages: check every package that has a tsconfig.json.
       # Collect all failures so the full picture is visible, then hard-fail
       # if any package had type errors.
+      #
+      # A package without a tsconfig.json used to print one "Skipping" line into
+      # a folded log and leave the job green — so a TS package that lost its
+      # tsconfig in a refactor got ZERO type coverage with the same signal as a
+      # clean check, and a `packages/*/` glob that matched nothing would have
+      # passed outright (flair#953). Skips are now enumerated against an explicit
+      # allowlist: an unlisted skip fails, and so does a zero-package run.
       - name: Type check workspace packages
         run: |
+          # Packages deliberately outside the TypeScript typecheck. Add a package
+          # here only with a reason; removing its tsconfig without saying so is
+          # the failure this list exists to catch.
+          #   hermes-flair — Python plugin, no TypeScript sources.
+          ALLOWED_UNTYPED="hermes-flair"
+
           FAIL=0
+          CHECKED=0
+          UNEXPECTED=""
           for pkg in packages/*/; do
+            name=$(basename "$pkg")
             if [ -f "$pkg/tsconfig.json" ]; then
               echo "::group::Type check: $pkg"
               (cd "$pkg" && npx tsc --noEmit) || FAIL=1
               echo "::endgroup::"
+              CHECKED=$((CHECKED + 1))
+            elif echo " $ALLOWED_UNTYPED " | grep -q " $name "; then
+              echo "Skipping $name (allowlisted: no TypeScript sources)"
             else
-              echo "Skipping $pkg (no tsconfig.json)"
+              echo "::error::$name has no tsconfig.json and is not allowlisted — it received NO type checking"
+              UNEXPECTED="$UNEXPECTED $name"
+              FAIL=1
             fi
           done
+
+          echo "Type-checked $CHECKED workspace package(s)."
+          if [ "$CHECKED" -eq 0 ]; then
+            echo "::error::Type-checked 0 workspace packages — the scan found nothing, so nothing was verified"
+            exit 1
+          fi
+          if [ -n "$UNEXPECTED" ]; then
+            echo "::error::Untypechecked package(s) outside the allowlist:$UNEXPECTED"
+          fi
           if [ "$FAIL" -ne 0 ]; then
-            echo "::error::One or more workspace packages have type errors"
+            echo "::error::One or more workspace packages have type errors or are untypechecked"
             exit 1
           fi
 

--- a/scripts/changelog-fragments.mjs
+++ b/scripts/changelog-fragments.mjs
@@ -275,8 +275,21 @@ if (isMain) {
             `top-level '- ' item. Split it into one file per entry.`,
         );
       }
+      // `loc ? ... : []` used to mean "no [Unreleased] header ⇒ no stray entries
+      // ⇒ ✓". That made the PR-time check strictly WEAKER than the release-time
+      // one, which throws on the same condition (see promote) — so a mangled
+      // header sailed through CI green and detonated mid-release-cut instead
+      // (flair#953). The stray-entry rule cannot be evaluated without the
+      // header, and a rule that could not be evaluated is not a rule that
+      // passed.
       const loc = locateUnreleased(readFileSync(CHANGELOG_PATH, "utf8").split("\n"));
-      const stray = loc ? strayUnreleasedEntries(loc.body) : [];
+      if (!loc) {
+        throw new FragmentError(
+          `CHANGELOG.md has no '## [Unreleased]' section, so the stray-entry check could not run — and ` +
+            `'promote' will refuse for the same reason at release time. Restore the header.`,
+        );
+      }
+      const stray = strayUnreleasedEntries(loc.body);
       if (stray.length > 0) {
         throw new FragmentError(
           `CHANGELOG.md '## [Unreleased]' has ${stray.length} hand-written entr${stray.length === 1 ? "y" : "ies"}; ` +

--- a/scripts/check-impl-term-leaks.sh
+++ b/scripts/check-impl-term-leaks.sh
@@ -13,7 +13,8 @@ PATTERNS='(^|[^-a-z0-9])ops-[a-z0-9]{4,}|(^|[^-a-z0-9])(post|pre)-[0-9]+\.[0-9]+
 
 # Temporary file for list of files
 TMPFILE=$(mktemp)
-trap "rm -f $TMPFILE" EXIT
+ERRFILE=$(mktemp)
+trap 'rm -f "$TMPFILE" "$ERRFILE"' EXIT
 
 # Find files to search:
 # 1. All files under packages/*/dist/
@@ -31,25 +32,59 @@ find docs -type f -not -path '*/.github/*' -not -path '*/specs/*' -not -path '*/
 sort -u "$TMPFILE" > "${TMPFILE}.sorted"
 mv "${TMPFILE}.sorted" "$TMPFILE"
 
-# If no files found, exit 0
+# An empty corpus is a broken scan, not a clean one (flair#953). This is a
+# REQUIRED status check, and the corpus depends on `packages/*/dist/` having been
+# built by the caller — so "no files to search" is the exact shape of this gate
+# silently going dark while still reporting green.
 if [[ ! -s "$TMPFILE" ]]; then
-  echo "No files to search."
-  exit 0
+  echo "✗ found 0 files to search — the corpus is empty, so NOTHING was checked."
+  echo "  This gate scans packages/*/dist/, packages/*/README.md, README.md and docs/."
+  echo "  If dist/ has not been built yet, build it first; if the layout moved, fix the"
+  echo "  find expressions above. An empty scan is not a passing scan."
+  exit 1
 fi
 
+FILE_COUNT=$(wc -l < "$TMPFILE" | tr -d ' ')
+
 # Search for patterns in the collected files
-echo "Searching for implementation term leaks in:"
+echo "Searching for implementation term leaks in $FILE_COUNT file(s):"
 cat "$TMPFILE"
 echo "---"
 
-# Use grep with line numbers and filename
-# We use command substitution to pass the list of files as arguments
-OUTPUT=$(grep -n -E "$PATTERNS" $(cat "$TMPFILE") 2>/dev/null || true)
+# grep's exit codes are three-valued and the distinction is load-bearing:
+#   0 = matches found (leaks — fail)
+#   1 = no matches (clean — pass)
+#  ≥2 = grep ITSELF failed (unreadable file, bad pattern, argv overflow)
+# The previous `... 2>/dev/null || true` collapsed 2 into 1: a grep that errored
+# out printed "No leaks found." and exited 0. Verified: grep on a chmod-000 file
+# returns 2, and the old line rendered that as clean.
+#
+# The file list goes through a quoted array rather than an unquoted `$(cat ...)`
+# so a path containing a space is scanned as one path instead of being split into
+# two nonexistent ones — which, under the old code, also read as "no leaks".
+# (Built with a read loop rather than mapfile: bash 3.2 still ships as /bin/bash
+# on macOS, where the pre-commit hook runs this. xargs is deliberately avoided —
+# it batches, and a batched run collapses grep's three exit codes into 123.)
+FILES=()
+while IFS= read -r line; do
+  [[ -n "$line" ]] && FILES+=("$line")
+done < "$TMPFILE"
+
+set +e
+OUTPUT=$(grep -n -E "$PATTERNS" "${FILES[@]}" 2>"$ERRFILE")
+GREP_RC=$?
+set -e
+
+if (( GREP_RC >= 2 )); then
+  echo "✗ grep exited $GREP_RC — the scan FAILED and verified nothing:"
+  cat "$ERRFILE"
+  exit 1
+fi
 
 if [[ -n "$OUTPUT" ]]; then
   echo "$OUTPUT"
   exit 1
 else
-  echo "No leaks found."
+  echo "No leaks found across $FILE_COUNT file(s)."
   exit 0
 fi

--- a/scripts/docs-freshness-check.mjs
+++ b/scripts/docs-freshness-check.mjs
@@ -16,6 +16,11 @@
 // Facts are derived from CODE, not hardcoded, so the gate tracks the source of
 // truth: current version + package name from package.json, default port from
 // src/cli.ts, the CLI command tree from the built dist/cli.js.
+//
+// Design note on SKIPS (flair#953): a check that could not run must never render
+// as a check that passed. See the "Check results" section below — `pass`,
+// `skipped` and `fail` are three distinct states in the output, in the tally and
+// in the exit code, and a check that examined zero items is automatically a skip.
 
 import { readFileSync, readdirSync, statSync, existsSync } from "node:fs";
 import { execFileSync } from "node:child_process";
@@ -102,20 +107,82 @@ function hasAllow(lines, idx) {
 const EXTERNAL_TOOL_RE = /\b(nvm|node|nodejs\.org|npmjs|homebrew|brew|harper|python|docker|semver)\b/i;
 const LEGACY_MARKER_RE = /(legacy|old default|\bold\b|changed from|changed to|predate|before the|before that|was on|migrat|used to|prior to|pre-bump|no longer|formerly|historic)/i;
 
+// ─── Check results: pass, SKIPPED, fail ───────────────────────────────────────
+//
+// A skip is not a pass (flair#953). This gate spent its whole life printing
+// `✓ cli-command-descriptions` on every machine where `dist/cli.js` had not been
+// built, under a summary line reading "All docs-freshness checks passed" —
+// nothing about the CLI's command descriptions had been verified. The defect was
+// never in the checking logic; it was in what the gate does when a check cannot
+// execute. Three states, carried through the per-check line, the summary tally
+// and the exit code:
+//
+//   ✓ pass     — the check ran over a non-empty corpus and found nothing
+//   ⊘ skipped  — the check could not run; NOTHING it covers has been verified
+//   ✗ N        — the check ran and found N problems
+//
+// Exit: 1 if anything failed, 2 if nothing failed but something did not run,
+// 0 only when every check ran and passed.
+//
+// A check returns either an array of failures (the terse form, still supported)
+// or `{ failures, skips, scanned }`:
+//   failures — [{ file, line, msg }]
+//   skips    — [{ reason, remedy }], each an unmet prerequisite
+//   scanned  — how many items the check actually examined, or null when the
+//              check has no item corpus. **scanned === 0 is promoted to a skip
+//              automatically**: a loop that never entered its body reports the
+//              same thing as a loop that examined four hundred files and found
+//              nothing, which is the silent variant of this same bug. Every
+//              glob, filter and `existsSync` filter in this file is one rename
+//              away from producing it.
+function skip(reason, remedy) {
+  return { reason, remedy };
+}
+
+function normalizeResult(r) {
+  if (Array.isArray(r)) return { failures: r, skips: [], scanned: null };
+  return {
+    failures: r?.failures ?? [],
+    skips: r?.skips ?? [],
+    scanned: r?.scanned ?? null,
+  };
+}
+
 // ─── Check runner ─────────────────────────────────────────────────────────────
 
 const checks = [];
-function defineCheck(name, fn) {
-  checks.push({ name, fn });
+// `unit` names what the check counts, for the "scanned N units" line and for the
+// zero-corpus skip message. Pass null when the check has no item corpus.
+function defineCheck(name, unit, fn) {
+  checks.push({ name, unit, fn });
 }
+
+// A gate that runs zero checks reports success just as loudly as a gate that runs
+// six — the same defect one level up. This manifest is the contract: if a check
+// stops registering (renamed, thrown out by a bad merge, lost to a refactor of
+// `defineCheck`), the gate fails instead of quietly shrinking. Removing a check
+// is a deliberate act; deleting its name from here is how you say so.
+const EXPECTED_CHECKS = [
+  "stale-install-pin",
+  "getting-started-version-placeholder",
+  "port-drift",
+  "package-name-drift",
+  "changelog-unreleased",
+  "cli-command-descriptions",
+];
 
 // ── Check 1: stale install pin of the root package ──────────────────────────────
 // FAILS on any `npm install`/`bun add`/etc. that pins `@tpsdev-ai/flair@<v>` to a
 // version other than the current one. (Sub-packages version independently, so
 // only the root package — validatable from this package.json — is checked.)
-defineCheck("stale-install-pin", () => {
+defineCheck("stale-install-pin", "prose doc", () => {
   const failures = [];
-  if (!PKG_NAME) return failures;
+  if (!PKG_NAME) {
+    return { failures, scanned: null, skips: [skip(
+      "package.json has no `name`, so there is no package spec to look for in install commands — no doc was checked for a stale pin.",
+      "restore `name` in package.json",
+    )] };
+  }
   const installRe = /\b(npm\s+(?:install|i|add)|pnpm\s+add|yarn\s+add|bun\s+add|bunx)\b/;
   const escName = PKG_NAME.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
   const pinRe = new RegExp(`${escName}@(\\d+\\.\\d+\\.\\d+)`, "g");
@@ -133,14 +200,14 @@ defineCheck("stale-install-pin", () => {
       }
     });
   }
-  return failures;
+  return { failures, scanned: PROSE_DOCS.length };
 });
 
 // ── Check 2: getting-started version placeholder discipline ─────────────────────
 // FAILS on any concrete Flair-style version (v0.0.0) in a getting-started doc.
 // These docs should use the `vX.Y.Z` placeholder so example output never rots.
 // External-tool version lines (node/nvm/brew/harper) are exempt.
-defineCheck("getting-started-version-placeholder", () => {
+defineCheck("getting-started-version-placeholder", "getting-started doc", () => {
   const failures = [];
   const verRe = /v(\d+)\.(\d+)\.(\d+)/g;
   for (const doc of GETTING_STARTED_DOCS) {
@@ -157,14 +224,17 @@ defineCheck("getting-started-version-placeholder", () => {
       }
     });
   }
-  return failures;
+  // GETTING_STARTED_DOCS is an existsSync filter over a hardcoded path list, so
+  // renaming docs/quickstart.md empties it — and before flair#953 that rendered
+  // as `✓ pass`, indistinguishable from a clean scan.
+  return { failures, scanned: GETTING_STARTED_DOCS.length };
 });
 
 // ── Check 3: port drift ─────────────────────────────────────────────────────────
 // FAILS when a doc references a retired legacy Flair port (9926/9925) as if it
 // were current. A reference inside an explicit legacy/historical context — the
 // same line, the 3 preceding lines, or the nearest preceding heading — is exempt.
-defineCheck("port-drift", () => {
+defineCheck("port-drift", "prose doc", () => {
   const failures = [];
   const legacyRe = new RegExp(`(?<!\\d)(${LEGACY_PORTS.join("|")})(?!\\d)`);
   for (const doc of PROSE_DOCS) {
@@ -186,15 +256,20 @@ defineCheck("port-drift", () => {
       });
     });
   }
-  return failures;
+  return { failures, scanned: PROSE_DOCS.length };
 });
 
 // ── Check 4: package-name / scope drift ─────────────────────────────────────────
 // FAILS on any scoped package whose name contains "flair" but whose scope is not
 // our scope (e.g. a typo'd `@tpsdev/flair` missing the `-ai`).
-defineCheck("package-name-drift", () => {
+defineCheck("package-name-drift", "prose doc", () => {
   const failures = [];
-  if (!PKG_SCOPE) return failures;
+  if (!PKG_SCOPE) {
+    return { failures, scanned: null, skips: [skip(
+      `the root package '${PKG_NAME}' is unscoped, so there is no expected scope to compare doc references against — no doc was checked for scope drift.`,
+      "publish the root package under a scope, or delete this check deliberately",
+    )] };
+  }
   // Placeholder scopes used in naming-convention docs ("publish under @scope/…").
   const PLACEHOLDER_SCOPES = new Set(["scope", "your-scope", "yourscope", "org", "myorg", "example"]);
   const scopedRe = /@([a-z0-9][a-z0-9-]*)\/([a-z0-9-]*flair[a-z0-9-]*)/gi;
@@ -218,7 +293,7 @@ defineCheck("package-name-drift", () => {
       }
     });
   }
-  return failures;
+  return { failures, scanned: PROSE_DOCS.length };
 });
 
 // ── Check 5: unreleased changelog entries exist when work has landed ────────────
@@ -233,9 +308,17 @@ defineCheck("package-name-drift", () => {
 // failure modes it could not previously have, both of them silent-loss vectors:
 // a fragment that cannot be parsed (fail rather than skip it), and a hand-written
 // entry left in [Unreleased] (the release step overwrites that body).
-defineCheck("changelog-unreleased", () => {
+// `scanned` is null: this check reads one file rather than a corpus, so a
+// zero-item guard says nothing useful about it. Its did-not-run condition is the
+// git skip below, which is stated explicitly.
+defineCheck("changelog-unreleased", null, () => {
   const changelogPath = join(ROOT, "CHANGELOG.md");
-  if (!existsSync(changelogPath)) return [];
+  if (!existsSync(changelogPath)) {
+    return { failures: [], scanned: null, skips: [skip(
+      "CHANGELOG.md does not exist, so no changelog discipline was verified at all.",
+      "restore CHANGELOG.md, or delete this check deliberately",
+    )] };
+  }
   const lines = readFileSync(changelogPath, "utf8").split("\n");
   const loc = locateUnreleased(lines);
   if (!loc) {
@@ -269,17 +352,26 @@ defineCheck("changelog-unreleased", () => {
   try {
     const tag = execFileSync("git", ["describe", "--tags", "--abbrev=0", "--match", "v*"],
       { cwd: ROOT, stdio: ["ignore", "pipe", "ignore"] }).toString().trim();
-    if (tag) {
-      const subjects = execFileSync("git", ["log", `${tag}..HEAD`, "--pretty=%s"],
-        { cwd: ROOT, stdio: ["ignore", "pipe", "ignore"] }).toString().trim();
-      commitsSinceTag = subjects
-        ? subjects.split("\n").filter((s) => /^(feat|fix)(\(|!|:)/.test(s)).length
-        : 0;
-    }
-  } catch {
-    // No tags, shallow clone, or not a git repo — can't compare; skip gracefully.
-    console.warn("  (changelog-unreleased: no v* tag / git history available — skipping commit comparison)");
-    return failures;
+    // `git describe --match v*` exits non-zero when nothing matches, so an empty
+    // string here means git succeeded and told us nothing. Treated as unmet, not
+    // as "zero commits since the tag" — the difference is a dark check.
+    if (!tag) throw new Error("git describe returned no v* tag");
+    const subjects = execFileSync("git", ["log", `${tag}..HEAD`, "--pretty=%s"],
+      { cwd: ROOT, stdio: ["ignore", "pipe", "ignore"] }).toString().trim();
+    commitsSinceTag = subjects
+      ? subjects.split("\n").filter((s) => /^(feat|fix)(\(|!|:)/.test(s)).length
+      : 0;
+  } catch (err) {
+    // No tags, shallow clone, or not a git repo. The stray-entry rule above DID
+    // run; the "work landed with nothing written down" rule did not — which is
+    // the whole point of this check. Report the partial coverage rather than
+    // absorbing it into the pass tally (flair#953). CI passes fetch-depth: 0
+    // specifically so this path is never taken there; if it is, the workflow has
+    // drifted away from the gate and that is worth failing over.
+    return { failures, scanned: null, skips: [skip(
+      `could not resolve the last v* tag (${err?.message ?? err}), so 'feat/fix commits landed since the release with no changelog fragment' was NOT checked.`,
+      "git fetch --tags --unshallow  (CI uses actions/checkout with fetch-depth: 0)",
+    )] };
   }
 
   // Release-PR exception: an empty fragment directory is correct when its content
@@ -299,7 +391,10 @@ defineCheck("changelog-unreleased", () => {
         { cwd: ROOT, stdio: ["ignore", "pipe", "ignore"] }).toString().trim().length > 0;
       if (hasVersionSection && !tagExists) return failures;
     } catch {
-      // package.json unreadable or git unavailable — fall through to the normal rule.
+      // package.json unreadable or git unavailable — fall through to the normal
+      // rule. This swallow is deliberately fail-CLOSED: losing the exception
+      // only costs us the release-PR amnesty, so the strict rule below still
+      // runs. Not a skip; the check's coverage is unreduced.
     }
   }
 
@@ -315,12 +410,17 @@ defineCheck("changelog-unreleased", () => {
 // ── Check 6: every CLI command has help text ────────────────────────────────────
 // FAILS on any command/subcommand with an empty .description(). Introspects the
 // real command tree from the built dist/cli.js (accurate, no source-regex guessing).
-// Requires a build; skips with a warning locally if dist/cli.js is absent.
-defineCheck("cli-command-descriptions", async () => {
+// Requires a build. THIS IS THE CHECK FROM flair#953: it used to print
+// "skipping" and return no failures when dist/cli.js was absent, which the
+// runner then rendered as `✓ pass` under an "All docs-freshness checks passed"
+// summary. It now reports a skip, which is not a pass and does not exit 0.
+defineCheck("cli-command-descriptions", "CLI command", async () => {
   const distCli = join(ROOT, "dist", "cli.js");
   if (!existsSync(distCli)) {
-    console.warn("  (cli-command-descriptions: dist/cli.js not built — run `bun run build:cli` to include this check; skipping)");
-    return [];
+    return { failures: [], scanned: null, skips: [skip(
+      "dist/cli.js is not built, so the command tree could not be introspected — no CLI command was checked for help text.",
+      "bun run build:cli",
+    )] };
   }
   const mod = await import(pathToFileURL(distCli).href);
   const program = mod.program;
@@ -328,11 +428,13 @@ defineCheck("cli-command-descriptions", async () => {
     return [{ file: "dist/cli.js", line: 1, msg: "dist/cli.js does not export `program` — cannot introspect commands." }];
   }
   const failures = [];
+  let scanned = 0;
   const walk = (cmd, path) => {
     for (const sub of cmd.commands ?? []) {
       const name = sub.name();
       if (name === "help") continue; // commander's auto-generated help command
       const full = [...path, name].join(" ");
+      scanned++;
       const desc = (typeof sub.description === "function" ? sub.description() : "") || "";
       if (desc.trim().length === 0) {
         failures.push({
@@ -344,7 +446,10 @@ defineCheck("cli-command-descriptions", async () => {
     }
   };
   walk(program, []);
-  return failures;
+  // A `program` that exports cleanly but registers no subcommands walks zero
+  // commands and finds zero problems — identical output to a healthy scan. The
+  // runner promotes scanned === 0 to a skip.
+  return { failures, scanned };
 });
 
 // ─── Run ────────────────────────────────────────────────────────────────────────
@@ -354,32 +459,98 @@ function emit(file, line, msg) {
   if (IN_CI) console.log(`::error file=${file},line=${line}::${msg}`);
 }
 
+// Skips get the same CI annotation weight as failures. A skip that only appears
+// in the raw log is a skip nobody reads. No comma in `title=` — GitHub parses
+// commas there as property separators.
+function emitSkip(name, s) {
+  console.log(`  ⊘ DID NOT RUN — ${s.reason}`);
+  console.log(`             remedy: ${s.remedy}`);
+  if (IN_CI) {
+    console.log(`::error title=docs-freshness check did not run::[${name}] ${s.reason} — remedy: ${s.remedy}`);
+  }
+}
+
+// Refuse to report on a gate that lost checks between edit and run.
+const registered = new Set(checks.map((c) => c.name));
+const unregistered = EXPECTED_CHECKS.filter((n) => !registered.has(n));
+if (unregistered.length > 0) {
+  console.error(`\n✗ docs-freshness gate is incomplete — expected check(s) never registered: ${unregistered.join(", ")}`);
+  console.error(`  Nothing below would have covered them. Restore them, or remove them from EXPECTED_CHECKS deliberately.`);
+  process.exit(1);
+}
+
 const summary = [];
 let totalFailures = 0;
-for (const { name, fn } of checks) {
+let totalSkips = 0;
+let passedChecks = 0;
+let skippedChecks = 0;
+let failedChecks = 0;
+
+for (const { name, unit, fn } of checks) {
   console.log(`\n▶ ${name}`);
-  let failures;
+  let failures, skips, scanned;
   try {
-    failures = await fn();
+    ({ failures, skips, scanned } = normalizeResult(await fn()));
   } catch (err) {
     console.error(`  ! check '${name}' crashed: ${err?.message ?? err}`);
     failures = [{ file: name, line: 0, msg: `check crashed: ${err?.message ?? err}` }];
+    skips = [];
+    scanned = null;
   }
-  if (failures.length === 0) {
-    console.log("  ✓ pass");
-    summary.push(`✓ ${name}`);
+
+  // Zero items examined is a skip, not a pass — see the "Check results" note.
+  if (skips.length === 0 && scanned === 0) {
+    skips = [skip(
+      `examined 0 ${unit ?? "item"}s — the input set was empty, so nothing was verified.`,
+      `check that the ${unit ?? "item"} corpus this check reads still exists at the path it expects`,
+    )];
+  }
+
+  for (const s of skips) emitSkip(name, s);
+  for (const f of failures) emit(f.file, f.line, f.msg);
+
+  totalFailures += failures.length;
+  totalSkips += skips.length;
+
+  const scannedNote = scanned !== null && unit ? ` (${scanned} ${unit}${scanned === 1 ? "" : "s"} scanned)` : "";
+  if (failures.length === 0 && skips.length === 0) {
+    console.log(`  ✓ pass${scannedNote}`);
+    summary.push(`✓ ${name}${scannedNote}`);
+    passedChecks++;
+  } else if (failures.length === 0) {
+    summary.push(`⊘ ${name} — DID NOT RUN`);
+    skippedChecks++;
   } else {
-    for (const f of failures) emit(f.file, f.line, f.msg);
-    summary.push(`✗ ${name} (${failures.length})`);
-    totalFailures += failures.length;
+    summary.push(`✗ ${name} (${failures.length})${skips.length > 0 ? ` + ${skips.length} did not run` : ""}`);
+    failedChecks++;
   }
 }
 
 console.log(`\n─── docs-freshness summary ───`);
 for (const s of summary) console.log(`  ${s}`);
+
+// The tally can never read "all passed" while something did not run: the counts
+// are computed from disjoint buckets and the skip bucket is printed whenever it
+// is non-empty. This line is the one flair#953 was actually about.
 console.log(
-  totalFailures === 0
-    ? `\nAll docs-freshness checks passed.`
-    : `\n${totalFailures} docs-freshness issue(s) found. Fix the files above, or annotate intentional cases with a '${ALLOW_MARKER}' comment.`,
+  `\n  ${passedChecks}/${checks.length} checks passed` +
+  (skippedChecks > 0 ? ` · ${skippedChecks} DID NOT RUN` : "") +
+  (failedChecks > 0 ? ` · ${failedChecks} failed (${totalFailures} issue${totalFailures === 1 ? "" : "s"})` : ""),
 );
-process.exit(totalFailures > 0 ? 1 : 0);
+
+if (totalFailures > 0) {
+  console.log(`\n${totalFailures} docs-freshness issue(s) found. Fix the files above, or annotate intentional cases with a '${ALLOW_MARKER}' comment.`);
+}
+if (totalSkips > 0) {
+  console.log(
+    `\n${skippedChecks} check(s) could not run. A check that did not run is not a check that passed —` +
+    ` nothing they cover has been verified. Resolve the prerequisites above and re-run.`,
+  );
+}
+if (totalFailures === 0 && totalSkips === 0) {
+  console.log(`\nAll ${checks.length} docs-freshness checks ran and passed.`);
+}
+
+// Distinct exit codes so a wrapper can tell "your docs are stale" (1) from "your
+// environment is wrong" (2). Both are non-zero, so CI treats them identically.
+process.exit(totalFailures > 0 ? 1 : totalSkips > 0 ? 2 : 0);

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -136,32 +136,54 @@ if [[ "$MODE" == "--publish" ]]; then
   echo "  Publishing @tpsdev-ai/flair..."
   (cd "$ROOT" && npm publish) || { echo "❌ flair publish failed"; exit 1; }
 
-  echo "  Publishing @tpsdev-ai/openclaw-flair..."
-  (cd "$ROOT/packages/openclaw-flair" && npm publish) || { echo "⚠️  openclaw-flair publish failed (may need build step)"; }
+  # The five leaf packages below soft-fail so a break-glass publish of the core
+  # three isn't blocked by, say, flair-bench's one-time Trusted Publisher
+  # bootstrap (docs/releasing.md). That is a reasonable trade — but it used to
+  # end with `git tag` and `✅ published and tagged` regardless, which is not
+  # (flair#953). A partial publish rendered identically to a complete one, and
+  # the tag then said a release shipped that a consumer cannot install: the root
+  # package pins its internal deps at the exact version, so a missing leaf is a
+  # broken install, not a missing extra.
+  #
+  # They still soft-fail individually. What changed is that the failures are
+  # counted, named at the end, and block the tag.
+  SOFT_FAILED=()
+  soft_publish() {
+    local dir="$1" name="$2" hint="${3:-}"
+    echo "  Publishing ${name}..."
+    if ! (cd "$ROOT/$dir" && npm publish); then
+      echo "⚠️  ${name} publish failed${hint:+ ($hint)}"
+      SOFT_FAILED+=("$name")
+    fi
+  }
 
-  echo "  Publishing @tpsdev-ai/pi-flair..."
-  (cd "$ROOT/packages/pi-flair" && npm publish) || { echo "⚠️  pi-flair publish failed (may need build step)"; }
+  soft_publish "packages/openclaw-flair"  "@tpsdev-ai/openclaw-flair"  "may need build step"
+  soft_publish "packages/pi-flair"        "@tpsdev-ai/pi-flair"        "may need build step"
+  soft_publish "packages/n8n-nodes-flair" "@tpsdev-ai/n8n-nodes-flair"
+  soft_publish "packages/langgraph-flair" "@tpsdev-ai/langgraph-flair" "may need build step"
+  # Until the one-time bootstrap in docs/releasing.md is done (first manual
+  # publish + npm Trusted Publisher registration), this is expected to fail on a
+  # brand-new install of the package.
+  soft_publish "packages/flair-bench"     "@tpsdev-ai/flair-bench"     "may need build step, or first-publish bootstrap — see docs/releasing.md"
 
-  echo "  Publishing @tpsdev-ai/n8n-nodes-flair..."
-  (cd "$ROOT/packages/n8n-nodes-flair" && npm publish) || { echo "⚠️  n8n-nodes-flair publish failed"; }
-
-  echo "  Publishing @tpsdev-ai/langgraph-flair..."
-  (cd "$ROOT/packages/langgraph-flair" && npm publish) || { echo "⚠️  langgraph-flair publish failed (may need build step)"; }
-
-  echo "  Publishing @tpsdev-ai/flair-bench..."
-  # NOTE: until the one-time bootstrap in docs/releasing.md is done (first
-  # manual publish + npm Trusted Publisher registration for this package),
-  # this is expected to fail on brand-new installs of the package — see PR
-  # that added this line for context. Soft-fail like the other prepublishOnly
-  # leaf packages above so a break-glass publish of the other 7 isn't blocked.
-  (cd "$ROOT/packages/flair-bench" && npm publish) || { echo "⚠️  flair-bench publish failed (may need build step, or first-publish bootstrap — see docs/releasing.md)"; }
+  if (( ${#SOFT_FAILED[@]} > 0 )); then
+    echo ""
+    echo "❌ ${#SOFT_FAILED[@]} package(s) did NOT publish:"
+    for p in "${SOFT_FAILED[@]}"; do echo "     - $p"; done
+    echo ""
+    echo "   NOT tagging v${VERSION}. A tag asserts that this version shipped; it did not."
+    echo "   The core packages above ARE published — this is a partial release."
+    echo "   Publish the packages listed above, then re-run to tag, or tag by hand"
+    echo "   once you have decided the partial release is what you want."
+    exit 1
+  fi
 
   echo "🏷️  Tagging v${VERSION} on main..."
   git -C "$ROOT" tag -a "v${VERSION}" -m "Release v${VERSION}"
   git_push_auth "v${VERSION}"
 
   echo ""
-  echo "✅ Flair v${VERSION} published and tagged."
+  echo "✅ Flair v${VERSION} published and tagged (all 8 packages)."
   exit 0
 fi
 

--- a/test/unit/ci-gate-coverage.test.ts
+++ b/test/unit/ci-gate-coverage.test.ts
@@ -1,0 +1,174 @@
+// Gates that cover nothing (flair#953, sweep half).
+//
+// The defect this PR is about — an absent result rendering as a passing one —
+// has a quiet cousin: a gate whose *corpus* silently shrinks. Nothing goes red,
+// nothing prints "skipping"; the check simply examines fewer things than anyone
+// believes it does, and reports the same tick either way.
+//
+// Two live instances, both found by asking "what does this gate actually scan?"
+// rather than by reading its logic:
+//
+//   - `test/*.test.ts` — 12 files, 250 cases — were run by NO CI command. Every
+//     `bun test` in every workflow targets a subdirectory, and a subdirectory
+//     filter does not pick up root-level files. A bare `bun test` (what
+//     CONTRIBUTING.md tells contributors to run) DOES run them, so they passed
+//     locally and were enforced nowhere.
+//   - `packages/hermes-flair/` has no tsconfig.json, so the typecheck job
+//     printed one "Skipping" line into a folded log and stayed green.
+//
+// These are invariant tests, not source-string tests: they enumerate what exists
+// on disk and assert CI reaches all of it. Adding a test directory that no job
+// runs, or a package nobody typechecks, fails here.
+
+import { describe, expect, test } from "bun:test";
+import { readFileSync, readdirSync, existsSync } from "node:fs";
+import { join, relative } from "node:path";
+
+const REPO_ROOT = join(import.meta.dir, "..", "..");
+const WORKFLOW_DIR = join(REPO_ROOT, ".github", "workflows");
+
+function workflowText(): string {
+  return readdirSync(WORKFLOW_DIR)
+    .filter((f) => f.endsWith(".yml") || f.endsWith(".yaml"))
+    .map((f) => readFileSync(join(WORKFLOW_DIR, f), "utf8"))
+    .join("\n");
+}
+
+/** Every *.test.ts under test/, as a repo-relative path. */
+function allTestFiles(dir = join(REPO_ROOT, "test")): string[] {
+  const out: string[] = [];
+  for (const name of readdirSync(dir, { withFileTypes: true })) {
+    const full = join(dir, name.name);
+    if (name.isDirectory()) out.push(...allTestFiles(full));
+    else if (name.name.endsWith(".test.ts")) out.push(relative(REPO_ROOT, full));
+  }
+  return out.sort();
+}
+
+/**
+ * The directory prefixes CI actually hands to `bun test`, plus whether the
+ * root-level glob is present. Derived from the workflow text so it cannot drift
+ * from what CI runs.
+ */
+function ciTestTargets(): { dirs: string[]; rootGlob: boolean } {
+  const text = workflowText();
+  const dirs = new Set<string>();
+  let rootGlob = false;
+  for (const m of text.matchAll(/bun test ((?:[^\s|&;`\n]+\s*)+)/g)) {
+    for (const target of m[1].trim().split(/\s+/)) {
+      if (target === "test/*.test.ts") rootGlob = true;
+      else if (target.startsWith("test/")) dirs.add(target.replace(/\/$/, ""));
+    }
+  }
+  return { dirs: [...dirs], rootGlob };
+}
+
+describe("every test file is reachable from a CI command", () => {
+  const files = allTestFiles();
+  const { dirs, rootGlob } = ciTestTargets();
+
+  test("the enumeration itself found tests (positive control)", () => {
+    // A zero-length list would make every assertion below vacuously true — the
+    // exact failure mode this file exists to catch.
+    expect(files.length).toBeGreaterThan(100);
+  });
+
+  test("CI runs the root-level test/*.test.ts files", () => {
+    // These were invisible to CI entirely. `bun test test/unit/` does not match
+    // test/foo.test.ts, and nothing else targeted them.
+    const rootLevel = files.filter((f) => f.split("/").length === 2);
+    if (rootLevel.length > 0) {
+      expect(rootGlob).toBe(true);
+    }
+  });
+
+  test("no test file sits in a directory CI never runs", () => {
+    // unit-isolated/ is run file-by-file in a loop (`bun test "$f"`), which the
+    // target parser sees as neither a dir nor the root glob — enumerate it here
+    // rather than teaching the parser about shell loops.
+    const loopRun = ["test/unit-isolated"];
+    const covered = (f: string) =>
+      (f.split("/").length === 2 && rootGlob) ||
+      [...dirs, ...loopRun].some((d) => f.startsWith(`${d}/`));
+
+    const orphans = files.filter((f) => !covered(f));
+    expect(orphans).toEqual([]);
+  });
+});
+
+describe("every workspace package is typechecked or explicitly excused", () => {
+  const packagesDir = join(REPO_ROOT, "packages");
+  const pkgs = readdirSync(packagesDir, { withFileTypes: true })
+    .filter((d) => d.isDirectory())
+    .map((d) => d.name)
+    .sort();
+
+  test("the enumeration found packages (positive control)", () => {
+    expect(pkgs.length).toBeGreaterThan(0);
+  });
+
+  test("a package with no tsconfig.json is named in the workflow's allowlist", () => {
+    // Before this, an unlisted package without a tsconfig got zero type coverage
+    // and one line in a folded log. The allowlist makes the exclusion a decision
+    // somebody wrote down rather than an accident nobody can see.
+    const text = workflowText();
+    const m = text.match(/ALLOWED_UNTYPED="([^"]*)"/);
+    expect(m).not.toBeNull();
+    const allowed = (m?.[1] ?? "").split(/\s+/).filter(Boolean);
+
+    const untyped = pkgs.filter((p) => !existsSync(join(packagesDir, p, "tsconfig.json")));
+    for (const p of untyped) {
+      expect(allowed).toContain(p);
+    }
+  });
+});
+
+describe("the impl-term-leak gate cannot report clean without scanning", () => {
+  const src = readFileSync(join(REPO_ROOT, "scripts", "check-impl-term-leaks.sh"), "utf8");
+
+  test("grep's exit status is inspected rather than discarded with || true", () => {
+    // `grep ... || true` collapses grep's error status (>=2: unreadable file,
+    // argv overflow) into its "no matches" status (1). Verified empirically: a
+    // grep over a chmod-000 file returns 2, and the old line printed
+    // "No leaks found." and exited 0.
+    const grepLine = src.split("\n").find((l) => l.includes("grep -n -E \"$PATTERNS\"")) ?? "";
+    expect(grepLine.length).toBeGreaterThan(0);
+    expect(grepLine).not.toMatch(/\|\|\s*(true|:)/);
+    expect(src).toContain("GREP_RC");
+  });
+
+  test("an empty corpus is a failure, not a pass", () => {
+    expect(src).not.toContain('echo "No files to search."');
+    expect(src).toMatch(/found 0 files to search[\s\S]*?exit 1/);
+  });
+
+  test("the file list is not word-split", () => {
+    // `$(cat "$TMPFILE")` unquoted splits `docs/name with space.md` into three
+    // nonexistent paths — which the old code then reported as clean.
+    expect(src).not.toMatch(/grep[^\n]*\$\(cat "\$TMPFILE"\)/);
+  });
+});
+
+describe("the release script does not tag a partial publish", () => {
+  const src = readFileSync(join(REPO_ROOT, "scripts", "release.sh"), "utf8");
+
+  test("soft-failed publishes are collected", () => {
+    expect(src).toContain("SOFT_FAILED");
+  });
+
+  test("the failure count is checked before the tag is created", () => {
+    const guardAt = src.indexOf("${#SOFT_FAILED[@]} > 0");
+    const tagAt = src.indexOf('git -C "$ROOT" tag -a "v${VERSION}"');
+    expect(guardAt).toBeGreaterThan(-1);
+    expect(tagAt).toBeGreaterThan(-1);
+    // Order is the whole point: a check after the tag is not a check.
+    expect(guardAt).toBeLessThan(tagAt);
+  });
+
+  test("no publish is soft-failed with a bare warning that returns success", () => {
+    const bare = src
+      .split("\n")
+      .filter((l) => /npm publish\)\s*\|\|\s*\{\s*echo\s+"⚠/.test(l));
+    expect(bare).toEqual([]);
+  });
+});

--- a/test/unit/docs-freshness-skips.test.ts
+++ b/test/unit/docs-freshness-skips.test.ts
@@ -1,0 +1,279 @@
+// A skipped docs-freshness check must not render as a passing one (flair#953).
+//
+// The original defect was not in any check's logic. `cli-command-descriptions`
+// printed "dist/cli.js not built — skipping", returned no failures, and the
+// runner rendered `✓ pass` under a summary reading "All docs-freshness checks
+// passed". Six checks, six ticks, one of them a lie — and the lie is invisible
+// from the source of the check that told it, because it lives in the runner.
+//
+// So these tests are BEHAVIOUR tests: they build a throwaway repo, run the real
+// script as a subprocess, and assert on stdout and the exit code — the two
+// things a human or a CI step actually consumes. Asserting on the shape of the
+// return value would have passed happily against the broken version, which
+// returned a perfectly well-formed empty failure list.
+
+import { describe, expect, test, beforeAll } from "bun:test";
+import { execFileSync, spawnSync } from "node:child_process";
+import { cpSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const REPO_ROOT = join(import.meta.dir, "..", "..");
+const SCRIPT_REL = join("scripts", "docs-freshness-check.mjs");
+
+/**
+ * A minimal repo the gate can run against end to end: a package.json to read the
+ * name/version from, a src/cli.ts carrying DEFAULT_PORT, one prose doc, one
+ * getting-started doc, a CHANGELOG with an [Unreleased] section, and a git
+ * history with a v-tag so the changelog check has something to compare against.
+ */
+function makeFixture(opts: {
+  quickstart?: boolean;
+  git?: boolean;
+  distCli?: string | null;
+} = {}): string {
+  const { quickstart = true, git = true, distCli = null } = opts;
+  const dir = mkdtempSync(join(tmpdir(), "flair-docs-freshness-"));
+
+  mkdirSync(join(dir, "scripts"), { recursive: true });
+  for (const f of ["docs-freshness-check.mjs", "changelog-fragments.mjs"]) {
+    cpSync(join(REPO_ROOT, "scripts", f), join(dir, "scripts", f));
+  }
+
+  writeFileSync(
+    join(dir, "package.json"),
+    JSON.stringify({ name: "@tpsdev-ai/flair", version: "0.1.0", private: true }, null, 2) + "\n",
+  );
+
+  mkdirSync(join(dir, "src"), { recursive: true });
+  writeFileSync(join(dir, "src", "cli.ts"), "const DEFAULT_PORT = 9927;\nexport { DEFAULT_PORT };\n");
+
+  writeFileSync(join(dir, "README.md"), "# Fixture\n\nNothing stale in here.\n");
+
+  mkdirSync(join(dir, "docs"), { recursive: true });
+  if (quickstart) {
+    writeFileSync(join(dir, "docs", "quickstart.md"), "# Quickstart\n\nInstall vX.Y.Z and go.\n");
+  } else {
+    // The corpus is an existsSync filter over a hardcoded path list. Renaming
+    // the file empties it — the "examined zero items" variant of the same bug.
+    writeFileSync(join(dir, "docs", "getting-started.md"), "# Renamed\n\nInstall vX.Y.Z and go.\n");
+  }
+
+  writeFileSync(
+    join(dir, "CHANGELOG.md"),
+    "# Changelog\n\n## [Unreleased]\n\n## [0.1.0] - 2020-01-01\n\n### Added\n\n- Initial.\n",
+  );
+  mkdirSync(join(dir, ".changelog", "unreleased"), { recursive: true });
+
+  if (distCli !== null) {
+    mkdirSync(join(dir, "dist"), { recursive: true });
+    writeFileSync(join(dir, "dist", "cli.js"), distCli);
+  }
+
+  if (git) {
+    const g = (...args: string[]) =>
+      execFileSync("git", args, { cwd: dir, stdio: ["ignore", "ignore", "ignore"] });
+    g("init", "-q");
+    g("config", "user.email", "fixture@example.invalid");
+    g("config", "user.name", "Fixture");
+    g("config", "commit.gpgsign", "false");
+    g("add", "-A");
+    g("commit", "-qm", "chore: fixture");
+    g("tag", "v0.1.0");
+  }
+
+  return dir;
+}
+
+/** A dist/cli.js exporting a commander-shaped tree with `n` described commands. */
+function fakeCli(n: number): string {
+  const cmds = Array.from({ length: n }, (_, i) =>
+    `{ name: () => "cmd${i}", description: () => "does thing ${i}", commands: [] }`,
+  ).join(", ");
+  return `export const program = { commands: [${cmds}] };\n`;
+}
+
+function runGate(dir: string) {
+  const r = spawnSync(process.execPath, [join(dir, SCRIPT_REL)], {
+    cwd: dir,
+    encoding: "utf8",
+    env: { ...process.env, GITHUB_ACTIONS: "" },
+  });
+  return { status: r.status, out: `${r.stdout}${r.stderr}` };
+}
+
+const created: string[] = [];
+function fixture(opts: Parameters<typeof makeFixture>[0] = {}): string {
+  const d = makeFixture(opts);
+  created.push(d);
+  return d;
+}
+
+// ─── The control: the gate still works ────────────────────────────────────────
+
+describe("docs-freshness gate, everything present", () => {
+  let res: { status: number | null; out: string };
+  beforeAll(() => {
+    res = runGate(fixture({ distCli: fakeCli(3) }));
+  });
+
+  test("exits 0", () => {
+    expect(res.status).toBe(0);
+  });
+
+  test("reports every check as passed", () => {
+    expect(res.out).toContain("6/6 checks passed");
+    expect(res.out).toContain("All 6 docs-freshness checks ran and passed.");
+  });
+
+  test("reports nothing as skipped", () => {
+    expect(res.out).not.toContain("DID NOT RUN");
+  });
+
+  test("says how many items each corpus check examined", () => {
+    // A pass with a count is falsifiable; a bare `✓ pass` is not. If a corpus
+    // silently empties, this number is where it shows up.
+    expect(res.out).toMatch(/prose docs scanned/);
+    expect(res.out).toContain("3 CLI commands scanned");
+  });
+});
+
+// ─── flair#953 itself ─────────────────────────────────────────────────────────
+
+describe("cli-command-descriptions with dist/cli.js absent", () => {
+  let res: { status: number | null; out: string };
+  beforeAll(() => {
+    res = runGate(fixture({ distCli: null }));
+  });
+
+  test("does not exit 0", () => {
+    // The whole bug in one assertion: the gate used to exit 0 here.
+    expect(res.status).not.toBe(0);
+  });
+
+  test("uses the did-not-run exit code, not the failure exit code", () => {
+    expect(res.status).toBe(2);
+  });
+
+  test("marks the check as not having run", () => {
+    expect(res.out).toContain("cli-command-descriptions");
+    expect(res.out).toContain("DID NOT RUN");
+  });
+
+  test("names the remedy, which is not 'go fix your docs'", () => {
+    expect(res.out).toContain("bun run build:cli");
+  });
+
+  test("never claims all checks passed", () => {
+    expect(res.out).not.toContain("All 6 docs-freshness checks ran and passed.");
+    expect(res.out).not.toMatch(/6\/6 checks passed/);
+  });
+
+  test("the tally excludes it from the pass count and names it separately", () => {
+    expect(res.out).toContain("5/6 checks passed");
+    expect(res.out).toContain("1 DID NOT RUN");
+  });
+});
+
+// ─── The silent variant: a corpus that emptied ────────────────────────────────
+
+describe("a check whose corpus is empty", () => {
+  let res: { status: number | null; out: string };
+  beforeAll(() => {
+    // docs/quickstart.md renamed: GETTING_STARTED_DOCS filters down to [], the
+    // loop body never runs, zero problems are found. Before flair#953 this was
+    // byte-identical to a healthy scan.
+    res = runGate(fixture({ quickstart: false, distCli: fakeCli(3) }));
+  });
+
+  test("does not exit 0", () => {
+    expect(res.status).not.toBe(0);
+  });
+
+  test("reports the getting-started check as not having run", () => {
+    expect(res.out).toMatch(/getting-started-version-placeholder[\s\S]*?DID NOT RUN/);
+  });
+
+  test("says the input set was empty rather than implying a clean scan", () => {
+    expect(res.out).toContain("examined 0 getting-started docs");
+  });
+});
+
+describe("a CLI that registers no commands", () => {
+  let res: { status: number | null; out: string };
+  beforeAll(() => {
+    // dist/cli.js builds and exports `program`, but the command tree is empty:
+    // zero commands walked, zero missing descriptions found.
+    res = runGate(fixture({ distCli: "export const program = { commands: [] };\n" }));
+  });
+
+  test("does not exit 0", () => {
+    expect(res.status).not.toBe(0);
+  });
+
+  test("reports that it examined nothing", () => {
+    expect(res.out).toContain("examined 0 CLI commands");
+  });
+});
+
+// ─── The other swallow in the same file ───────────────────────────────────────
+
+describe("changelog-unreleased with no git history", () => {
+  let res: { status: number | null; out: string };
+  beforeAll(() => {
+    res = runGate(fixture({ git: false, distCli: fakeCli(3) }));
+  });
+
+  test("does not exit 0", () => {
+    expect(res.status).not.toBe(0);
+  });
+
+  test("reports the check as not having run rather than warning and passing", () => {
+    expect(res.out).toMatch(/changelog-unreleased[\s\S]*?DID NOT RUN/);
+  });
+
+  test("names what specifically went unchecked", () => {
+    expect(res.out).toContain("NOT checked");
+  });
+});
+
+// ─── The gate itself must not be able to shrink silently ──────────────────────
+
+describe("the check manifest", () => {
+  test("every expected check is registered, and the count is asserted", () => {
+    // A gate that registers zero checks reports success exactly as loudly as one
+    // that registers six. EXPECTED_CHECKS is the contract that makes losing a
+    // check an error rather than a quiet reduction in coverage.
+    const src = Bun.file(join(REPO_ROOT, SCRIPT_REL));
+    return src.text().then((text) => {
+      const block = text.slice(text.indexOf("const EXPECTED_CHECKS"), text.indexOf("];", text.indexOf("const EXPECTED_CHECKS")));
+      const expected = [...block.matchAll(/"([a-z-]+)"/g)].map((m) => m[1]);
+      const defined = [...text.matchAll(/defineCheck\(\s*"([a-z-]+)"/g)].map((m) => m[1]);
+      expect(expected.length).toBeGreaterThan(0);
+      expect(defined.sort()).toEqual(expected.sort());
+    });
+  });
+
+  test("the runner refuses to report when a check failed to register", () => {
+    const dir = fixture({ distCli: fakeCli(3) });
+    const path = join(dir, SCRIPT_REL);
+    const src = Bun.file(path);
+    return src.text().then(async (text) => {
+      // Disable one check's registration the way a bad merge would.
+      const broken = text.replace('defineCheck("port-drift"', 'const _dropped = ((...a) => a)(\n  "port-drift"');
+      expect(broken).not.toBe(text);
+      writeFileSync(path, broken);
+      const res = runGate(dir);
+      expect(res.status).not.toBe(0);
+      expect(res.out).toContain("gate is incomplete");
+      expect(res.out).toContain("port-drift");
+    });
+  });
+});
+
+describe("cleanup", () => {
+  test("removes fixtures", () => {
+    for (const d of created) rmSync(d, { recursive: true, force: true });
+    expect(true).toBe(true);
+  });
+});


### PR DESCRIPTION
Closes #953.

`scripts/docs-freshness-check.mjs` reported `cli-command-descriptions` as `✓ pass` on any machine where `dist/cli.js` had not been built. It printed "skipping", returned an empty failure list, and the runner rendered that identically to a clean scan — under a summary reading **"All docs-freshness checks passed."** Six ticks, one of which had verified nothing.

The bug was never in a check. It was in what the runner does when a check cannot execute: **the absence of a result rendered identically to a passing result.**

Before, with the CLI unbuilt:

```
▶ cli-command-descriptions
  (cli-command-descriptions: dist/cli.js not built — run `bun run build:cli` to include this check; skipping)
  ✓ pass
...
All docs-freshness checks passed.
$ echo $?
0
```

After:

```
▶ cli-command-descriptions
  ⊘ DID NOT RUN — dist/cli.js is not built, so the command tree could not be
    introspected — no CLI command was checked for help text.
             remedy: bun run build:cli

─── docs-freshness summary ───
  ✓ stale-install-pin (26 prose docs scanned)
  ✓ getting-started-version-placeholder (1 getting-started doc scanned)
  ✓ port-drift (26 prose docs scanned)
  ✓ package-name-drift (26 prose docs scanned)
  ✓ changelog-unreleased
  ⊘ cli-command-descriptions — DID NOT RUN

  5/6 checks passed · 1 DID NOT RUN

1 check(s) could not run. A check that did not run is not a check that passed —
nothing they cover has been verified. Resolve the prerequisites above and re-run.
$ echo $?
2
```

## Why a third state rather than a plain failure

The issue offers two options: fail on a missing prerequisite, or add a `skipped` state that the tally and exit code both respect. I took the second, with the first's teeth — a skip is **non-zero exit**, so operationally it *is* a failure. The reason to keep it distinct is that a skip and a finding have different remedies, and collapsing them tells a contributor to go fix their docs when what they actually need to do is run `bun run build:cli`. An error that does not enable a response is most of the way back to no error at all.

Exit is `2` for skips and `1` for findings. Both are non-zero, so CI behaviour is identical, but a wrapper can distinguish "your docs are stale" from "your environment is wrong". Nothing currently reads the specific code — `.github/workflows/test.yml` invokes the script bare — so this costs nothing and is available if anything ever does.

The one thing I would not accept is a state that exits 0. The header of this file carries a design note reading *"this gate must never block a legitimate PR."* That note is about false positives on doc **content**, and it was being quietly stretched to cover a missing **input**. A gate invoked without its inputs is a misconfiguration, not a legitimate state, and treating it as one is exactly how a gate goes dark.

## Two silent variants closed alongside it

**A check that examined zero items is now a skip, not a pass.** This is the same defect with no `if` statement to point at: a loop that never enters its body finds no problems, and reports what a loop over four hundred files that found no problems reports. Passing checks now print their corpus size, so it is visible:

```
  ✓ port-drift (26 prose docs scanned)
```

This was live, not hypothetical. `GETTING_STARTED_DOCS` is an `existsSync` filter over a hardcoded path list — renaming `docs/quickstart.md` empties it, and `getting-started-version-placeholder` would have gone dark with a tick beside it. It now reports `examined 0 getting-started docs`.

**A gate that registers zero checks must not report success** — the same defect one level up. `EXPECTED_CHECKS` is a manifest; a check that stops registering fails the gate rather than quietly shrinking its coverage. Removing a check stays possible, but you have to say so.

**The other swallow in the same file.** `changelog-unreleased` caught any git failure, warned "skipping commit comparison", and returned — disabling the "work landed since the release with nothing written down" rule on a shallow clone or a tagless checkout, while still printing a tick. It is now a skip that names what specifically went unchecked. Also: `git describe` returning an empty string was being treated as "zero commits since the tag" rather than as an unmet prerequisite.

One swallow in that check is **left in place and annotated**, deliberately: the release-PR amnesty's `catch` falls through to the *stricter* rule, so losing it can only produce a false failure, never a false pass. Fail-closed swallows are not this bug.

## Tests

Behaviour tests, not source tests. They build a throwaway repo in a tmpdir — `package.json`, `src/cli.ts`, a prose doc, a getting-started doc, a `CHANGELOG.md`, a git history with a v-tag — run the real script as a subprocess, and assert on **stdout and the exit code**, which are the two things a human or a CI step actually consumes.

That distinction is load-bearing here. Asserting on the return value would have passed happily against the broken version: it returned a perfectly well-formed empty failure list. The lie was not in the value, it was in the rendering.

Covered: the control (everything present, `6/6`, exit 0, corpus counts printed); `dist/cli.js` absent; `docs/quickstart.md` renamed; a `program` that exports cleanly but registers no commands; no git history; and a check that fails to register.

## Mutation checks

Every guard added here was removed, watched fail, and restored. A guard nobody has watched fail is not known to work — which is the entire subject of this PR.

| Mutation | Result |
|---|---|
| M1 — `cli-command-descriptions` skip → old silent pass | 15 pass / **6 fail** |
| M2 — zero-corpus promotion removed from the runner | 16 pass / **5 fail** |
| M3 — `EXPECTED_CHECKS` manifest guard removed | 20 pass / **1 fail** |
| M4 — changelog git skip → old warn-and-pass | 18 pass / **3 fail** |
| M5 — exit code ignores skips (old behaviour) | 16 pass / **5 fail** |
| M6 — summary tally counts a skip as a pass | 19 pass / **2 fail** |

Baseline 21 pass / 0 fail, restored to 21 pass / 0 fail after each.

## Verification

- `node scripts/docs-freshness-check.mjs` with the CLI unbuilt → exit **2**, `5/6 checks passed · 1 DID NOT RUN`.
- Same after `bun run build:cli` → exit **0**, `6/6 checks passed`, `125 CLI commands scanned`. That count is the result this check was supposed to have been producing all along.
- CI is unaffected and still green: the `docs-freshness` job runs `bun run build:cli` and checks out with `fetch-depth: 0` before invoking the gate, so neither skip path is reachable there. That is the point — the gate was passing in CI for real, and only went dark where nobody was looking.
- CI-mode annotation verified: skips emit `::error title=docs-freshness check did not run::…` (no comma in `title=`, which GitHub would parse as a property separator).
- Full unit suite, the exact command CI runs: **3336 pass / 0 fail** on unmodified `origin/main` → **3618 pass / 0 fail** on this branch. The delta is +21 (`docs-freshness-skips`), +11 (`ci-gate-coverage`) and +250 (the orphaned root-level suites this PR puts back under CI).

  One measurement note, because it nearly became a false finding: my first baseline used `bun test test/unit` without the trailing slash. Bun treats that as a **substring filter**, not a directory, so it also pulled in `test/unit-isolated/` — the three files CI deliberately runs one-per-process because they `mock.module` a process-global. That produced 2 module-resolution failures on both sides. With the real CI command (`test/unit/`) both sides are clean. The comparison was valid either way, but the absolute numbers in my first pass were measuring something CI never runs.

---

# The sweep

Second commit. Separately reviewable — nothing in it is needed for #953.

**Audited by evidence, not by reading code**, as the issue asks: 51 CI run-log archives (28.6 MB, 438 job logs) across every workflow, grepped per section for a check that has never once printed a real result. A check that has never produced a finding is either perfect or dead, and dead is more likely. Reading the source tells you what a gate intends; the output tells you what it does.

Five fixed:

**1. 250 tests in `test/*.test.ts` were run by no CI job and no release gate.** Every `bun test` invocation in every workflow is directory-scoped, and a directory filter does not match root-level files. Twelve suites — six of them security-scoping (auth scoping, data scoping, content safety, key rotation, agent grants, backup/restore) — executed nowhere. Evidence: grepping the log corpus for each suite's `describe()` name returns **0 hits each**, against positive controls from `test/unit/` at 192 and 240 hits. A bare `bun test`, which `CONTRIBUTING.md` tells contributors to run, *does* pick them up — so they passed locally and were enforced nowhere, green from both directions. All 250 pass. Verified first that they carry no live-service dependency: every `fetch` target is a stub server on an ephemeral port, and no `9926` occurrence in them is a call target.

**2. `check-impl-term-leaks.sh` — a required status check — reported clean when its scan failed.** Three defects, one shape:

- `grep ... || true` collapsed grep's *error* status (≥2: unreadable file, argv overflow) into its *no-matches* status (1). Measured: grep over a `chmod 000` file returns 2, and the old line printed `No leaks found.` and exited 0.
- `$(cat "$TMPFILE")` unquoted word-split the file list, so a path containing a space was never scanned — which also read as clean. Measured with a real leak in `docs/name with space.md`: old code exit 0, leak missed.
- An empty corpus printed `No files to search.` and exited 0 — though the corpus depends on `packages/*/dist/` having been built by the caller.

Now grep's status is inspected three-valued, the list goes through a quoted array, an empty corpus fails, and the file count is printed. (Deliberately not `xargs`: it batches, and a batched run collapses grep's three exit codes into 123. Deliberately a read loop rather than `mapfile`: bash 3.2 still ships as `/bin/bash` on macOS, where the pre-commit hook runs this. Syntax-checked on both.)

**3. `release.sh` tagged a partial publish as a complete release.** Five of the eight packages soft-fail on publish so a break-glass release of the core three isn't blocked — a reasonable trade — but it then tagged and printed `✅ published and tagged` regardless. The root package pins its internal deps at the exact version, so a missing leaf is a **broken install**, not a missing extra. The soft-fails are retained; they are now counted, named, and block the tag.

**4. A workspace package with no `tsconfig.json` was silently exempt from type checking** — one `Skipping` line in a folded log, job green, in 8 of 8 runs. Live today for `packages/hermes-flair/`. Exclusions are now an explicit allowlist; an unlisted skip fails, and a run that type-checks zero packages fails.

**5. `changelog-fragments check` skipped its stray-entry rule when the `## [Unreleased]` header was missing**, making the PR-time check strictly weaker than `promote`, which refuses on the same condition — so a mangled header passed CI green and detonated mid-release-cut instead.

`test/unit/ci-gate-coverage.test.ts` pins these as **invariants rather than string matches**: it enumerates every test file on disk and asserts CI reaches all of them, and every workspace package and asserts each is type-checked or explicitly excused. Each carries a positive control on the enumeration, so a zero-length list cannot make the assertions vacuously true — which would be this very bug, in the test for this bug.

### Sweep mutation checks

Each guard removed, the pre-fix condition constructed, and **both halves observed** — the new code failing loudly, and the old code reproducing the silent pass:

| | new | old |
|---|---|---|
| S1 empty corpus | exit 1 | exit 0 — silent pass reproduced |
| S2 grep errors (`chmod 000`) | exit 1 | exit 0 — silent pass reproduced |
| S3 leak in a path with a space | exit 1 | exit 0 — leak missed, reported clean |
| S4 partial publish | exit 1 | exit 0 — tagged and declared success |
| S5 no `[Unreleased]` header | exit 1 | exit 0 — printed OK |
| S6 unlisted package, no tsconfig | exit 1 | exit 0 — skipped silently |
| S6 zero packages | exit 1 | exit 0 — passed on empty |

And against the regression tests, each fix reverted to its pre-PR form: N1 2 fail, N2 1 fail, N3 2 fail, N4 1 fail, N5 1 fail, N6 1 fail. Baseline 11 pass / 0 fail, restored after each.

S4 is the one indirect check: it exercises the extracted publish/tally block with `npm publish` stubbed, not a live release run. Everything else runs the real script.

## Found and deliberately NOT fixed

The sweep turned up further instances of this class that this PR does not change — some because the remedy is a repository-settings change that has to be sequenced rather than shipped in a diff, some because the fix needs a runtime measurement before it goes near a required gate, and some because they change a user-facing CLI's exit semantics and deserve a PR whose title tells a reviewer that is what they are reviewing.

That list is being routed privately rather than posted here: several entries describe gates that are currently weaker than they appear, and this repository is public. Enumerating those in a public artifact is a target list, not a changelog. Ask me for it directly.

## Premise check

The class is real but **narrower than "everything is broken"**. Of roughly 25 gate scripts and workflow validators, the majority already fail closed, and several carry purpose-built positive controls — `check-version-sync.mjs` has an explicit zero-hit control ("the scan is broken, not the tree"), `check-imports.mjs` fails on an empty file list, `audit-gate.mjs` says in as many words that *an audit that cannot run is not an audit that passed*, and the three matrix gate jobs correctly fail on `cancelled`/`skipped`. `bun test <path>` with no matching files exits 1, verified with a positive control, which retires a whole family of suspects.

The live residual is concentrated in a handful of places, enumerated in the private list. The biggest single finding — 250 uncounted tests — has no skip syntax anywhere in it and would not have been found by grepping for skip constructs. That is the argument for auditing gates by their output rather than their source.
