### PR TITLE
fix(auth): principal admin status is one meaning with one answer, on every write verb

### DIFF
--- a/.changelog/unreleased/added-warn-on-context-less-resource-calls.md
+++ b/.changelog/unreleased/added-warn-on-context-less-resource-calls.md
@@ -1,0 +1,13 @@
+- **Flair warns when a resource is called with no caller context.** Constructing
+  a resource without a context resolves to Flair's trusted internal verdict and
+  runs unfiltered — every read unscoped, every write unattributed — which is
+  correct for Flair's own maintenance work and a silent, invisible mistake in an
+  embedding application. The verdict is unchanged; it is no longer silent. A
+  call that means to take that authority declares it with `internalContext()`
+  and stays quiet; anything else logs once per process with the stack.
+
+  The embedding guide's note that reads do not need `collectionResource()` has
+  been corrected: reads do not need the collection binding, but they do still
+  need the context. A search with the context argument omitted, running outside
+  a request scope, returns every agent's private records — and on that path the
+  resource's own gate is never consulted.

--- a/.changelog/unreleased/changed-admin-promotion-takes-effect-immediately.md
+++ b/.changelog/unreleased/changed-admin-promotion-takes-effect-immediately.md
@@ -1,0 +1,7 @@
+- **A promotion or demotion applies on the principal's next request.** Admin
+  lookups are cached for 60 seconds, so granting admin used to appear not to
+  work for up to a minute — long enough to conclude the grant had failed and
+  start changing other things. The write path now drops the cached set when it
+  changes a principal, so the new status is in force immediately. The cache is
+  per worker thread, so a grant applied on one thread can still take up to the
+  same 60 seconds to be seen on another; the bound is unchanged.

--- a/.changelog/unreleased/fixed-admin-field-truth.md
+++ b/.changelog/unreleased/fixed-admin-field-truth.md
@@ -1,0 +1,21 @@
+- **The `admin` field on a principal now means what it says.** A principal record
+  carried two fields that both read as "is this an administrator" — `role`
+  (admin when the value is `admin`) and an `admin` boolean — and they were
+  consulted by different parts of the system. The authorization gate read
+  `role`; the CLI, the admin dashboard and every creation path used `admin`. So
+  `flair principal add --admin` stored a field the gate never read and granted
+  nothing, while `flair principal show` reported "admin: yes" for a principal
+  that admin-only endpoints reject.
+
+  `role` remains the authority and no existing principal's rights change. The
+  boolean is now a server-maintained mirror of it: write either one through the
+  `Agent` resource, `flair principal add --admin`, or agent seeding, and both
+  are set together, so a record can no longer be stored saying one thing in one
+  field and the opposite in the other. Every surface that decides or displays
+  admin status now resolves through one shared predicate.
+
+  Records written straight to the table (an ops-API insert, a federation merge)
+  bypass that reconciliation and can still carry a mismatch. Nothing changes
+  about what they are allowed to do — `flair principal show`, `flair principal
+  list` and the admin dashboard now flag them as inconsistent instead of
+  silently picking a side. Re-issuing the grant repairs the record.

--- a/.changelog/unreleased/fixed-principal-admin-status-changes.md
+++ b/.changelog/unreleased/fixed-principal-admin-status-changes.md
@@ -1,0 +1,8 @@
+- **Changing a principal's admin status is restricted to administrators on every
+  HTTP verb.** The principal table's per-record rules — you may only modify your
+  own record, and only an administrator may change admin status — were enforced
+  on one write path and not on the partial-update path, which reached the table
+  with only a "is this a verified agent" check. Both paths now share one
+  authorization helper, and a change to a principal's admin status is refused
+  for a non-administrator on either. In-process maintenance and administrators
+  are unaffected.

--- a/.changelog/unreleased/security-presence-roster-admin-disclosure.md
+++ b/.changelog/unreleased/security-presence-roster-admin-disclosure.md
@@ -1,0 +1,6 @@
+- **The public presence roster no longer discloses which principals are
+  administrators.** The roster is readable without authentication and included a
+  principal's `role`, which is also the field that denotes an administrator —
+  handing an unauthenticated reader the list of privileged accounts. Admin
+  principals are now presented on the roster as ordinary agents. The field is a
+  display label there and nothing authorizes on it.

--- a/.changelog/unreleased/security-soul-write-ownership.md
+++ b/.changelog/unreleased/security-soul-write-ownership.md
@@ -1,0 +1,11 @@
+- **Soul entries are owner-scoped on every write verb.** Only a principal (or an
+  administrator) may write its own soul entries. That rule was enforced by a
+  guard with two independent gaps, either of which alone let any verified agent
+  rewrite or delete another agent's identity data: it ran on `PUT` and `POST`
+  but not `PATCH` or `DELETE`, and it compared the `agentId` in the request body
+  rather than the owner of the record being written — so a body that simply
+  omitted the field was checked against nothing.
+
+  Both are closed. The guard now runs on every mutating verb and resolves
+  ownership from the stored record named in the path. Writing your own soul is
+  unchanged, and administrators are unaffected.

--- a/docs/embedding-in-a-harper-app.md
+++ b/docs/embedding-in-a-harper-app.md
@@ -124,7 +124,7 @@ export async function registerAgent(id, { publicKey = "pending", admin = false }
     id, name: id, displayName: id,
     publicKey,                            // a placeholder is fine — see below
     runtime: "headless",
-    ...(admin ? { role: "admin", admin: true } : {}),   // role is what actually grants admin
+    ...(admin ? { admin: true } : {}),    // sets role:"admin" too — see below
   });
 }
 ```
@@ -133,7 +133,9 @@ Verified against a real instance: that lands `kind: "agent"`, `status: "active"`
 
 > **Prefer this to `databases.flair.Agent.put()`.** The raw table applies **no** defaults, so a hand-written literal has to reproduce every field above and then stay in step with Flair as the Principal model grows. Records written that way are missing `kind`/`status`/`defaultTrustTier` and read as under-specified Principals in the admin surfaces.
 
-> **`isAdmin()` reads `role === "admin"`, not the `admin` boolean.** They are separate fields and only `role` grants admin rights; set both to keep the record self-consistent. Admin lookups are cached for 60 seconds, so a newly-created admin is not effective immediately.
+> **Admin is one meaning with one answer.** `role === "admin"` is the authority; the `admin` boolean is a mirror of it that the server maintains. Write **either** through the `Agent` resource and both are set — you no longer have to know which one is real, and a record cannot be stored saying one thing in one field and the opposite in the other. Nothing reads the mirror to make an authorization decision, and a promotion applied through the resource takes effect on the next request rather than after the 60-second admin-lookup cache expires.
+>
+> A record written straight to the table (`databases.flair.Agent.put()`, an ops-API insert, a federation merge) skips that reconciliation and can still carry a mismatch. `flair principal show` and the admin dashboard flag such a record rather than silently picking a side; re-issuing the grant repairs it.
 
 `publicKey` is non-nullable in the schema, but it does not have to be a real key. An agent that only ever acts in-process never authenticates, and Flair's own paths write placeholders — `"pending"` when seeding, `mcp-oauth:<sub>` for token-authenticated agents. Give an agent a real key only if it must also authenticate **over HTTP**, which your app can do without any CLI:
 

--- a/docs/embedding-in-a-harper-app.md
+++ b/docs/embedding-in-a-harper-app.md
@@ -54,6 +54,8 @@ export async function remember(agentId, content, opts = {}) {
 > ```
 >
 > `collectionResource(Cls, context)` is a two-line wrapper over the supported call — `Cls.getResource({}, context, { isCollection: true })` — and exists so this is written once. **Reads do not need it:** `Cls.get(id, context)` and `Cls.search(query, context)` thread the context themselves.
+>
+> They do still need the **context**. Only the collection binding is unnecessary for a read, never the identity — `Cls.search(query)` with the second argument left off resolves to the trusted `internal` verdict when it runs outside a request scope (a boot hook, a timer, a queue worker, a detached promise) and returns every agent's private records. On that path the resource's `allow*` gate is not consulted at all. Pass the context to every call, read and write.
 
 > ### ⚠️ A resource with no context is an administrator
 >

--- a/resources/AdminPrincipals.ts
+++ b/resources/AdminPrincipals.ts
@@ -1,6 +1,7 @@
 import { Resource, databases } from "harper";
 import { layout, htmlResponse, esc } from "./admin-layout.js";
 import { allowAdmin } from "./agent-auth.js";
+import { adminFieldsDisagree, agentRecordIsAdmin } from "./agent-admin.js";
 
 /**
  * GET /AdminPrincipals — list all principals with kind, trust, status.
@@ -42,7 +43,15 @@ export class AdminPrincipals extends Resource {
         const statusBadge = status === "active"
           ? `<span class="badge badge-green">${status}</span>`
           : `<span class="badge badge-gray">${status}</span>`;
-        const admin = p.admin ? "yes" : "";
+        // flair#941 — report the status the GATE will actually apply, not the
+        // `admin` mirror. This column used to read the mirror alone, so a
+        // principal created by `flair principal add --admin` showed "yes" while
+        // allowAdmin() rejected it. A record whose two fields disagree (only
+        // reachable by a raw table write) is flagged rather than silently
+        // resolved, so an operator can see that it needs repairing.
+        const admin = agentRecordIsAdmin(p)
+          ? (adminFieldsDisagree(p) ? "yes <small>(inconsistent record)</small>" : "yes")
+          : (adminFieldsDisagree(p) ? "no <small>(inconsistent record)</small>" : "");
         const created = p.createdAt?.slice(0, 10) ?? "—";
 
         tableRows += `

--- a/resources/Agent.ts
+++ b/resources/Agent.ts
@@ -1,5 +1,6 @@
 import { databases } from "harper";
-import { isAdmin, resolveAgentAuth, allowVerified, allowAdmin } from "./agent-auth.js";
+import { isAdmin, resolveAgentAuth, allowVerified, allowAdmin, invalidateAdminCache } from "./agent-auth.js";
+import { agentRecordIsAdmin, reconcileAdminFields } from "./agent-admin.js";
 import { localInstanceId } from "./instance-identity.js";
 
 /**
@@ -38,11 +39,20 @@ export class Agent extends (databases as any).flair.Agent {
     content.kind ||= "agent";
     content.status ||= "active";
     content.displayName ||= content.name;
-    content.admin ??= false;
 
-    // Trust tier defaults per kind
+    // flair#941 — the two admin fields are reconciled BEFORE anything derives
+    // from them, so `role` and `admin` agree on disk whichever one the caller
+    // used. Replaces `content.admin ??= false`, which defaulted the mirror
+    // without ever consulting the authority: a caller who passed role:"admin"
+    // got a record that was an admin at the gate and a non-admin to every
+    // reporter. allowCreate() is allowAdmin(), so this path is admin-only.
+    reconcileAdminFields(content);
+
+    // Trust tier defaults per kind — derived from the SAME predicate the gate
+    // uses, so an admin principal cannot land on the non-admin default just
+    // because the caller spelled admin the other way.
     if (!content.defaultTrustTier) {
-      content.defaultTrustTier = content.admin ? "endorsed" : "unverified";
+      content.defaultTrustTier = agentRecordIsAdmin(content) ? "endorsed" : "unverified";
     }
 
     content.createdAt = now;
@@ -60,7 +70,25 @@ export class Agent extends (databases as any).flair.Agent {
     return super.post(content, context);
   }
 
-  async put(content: any) {
+  /**
+   * Authorization shared by BOTH mutation paths (PUT → put, PATCH → patch).
+   *
+   * It lives in one place because it previously lived only in put(), and PATCH
+   * does not route through put() — so every rule written here was enforced on
+   * one verb and not the other. Returns a Response to send, or null to proceed.
+   *
+   * Two rules:
+   *   1. Only an admin principal may modify a principal OTHER than itself.
+   *   2. Only an admin principal may change a principal's ADMIN STATUS — on any
+   *      record, including the caller's own. Rule 1 alone never covered this:
+   *      an agent editing its own record is inside its rights for ordinary
+   *      fields (runtime, displayName, subjects) and must not be for the fields
+   *      that decide whether it is an administrator.
+   *
+   * `internal` (in-process maintenance, federation merge) and admin agents pass
+   * through unchanged.
+   */
+  private async authorizePrincipalWrite(content: any): Promise<Response | null> {
     const auth = await resolveAgentAuth((this as any).getContext?.());
     // Anonymous denied (defense-in-depth alongside allowUpdate; the old check read
     // tpsAgent and treated a missing agent as trusted, so anonymous slipped through).
@@ -69,15 +97,40 @@ export class Agent extends (databases as any).flair.Agent {
         status: 401, headers: { "content-type": "application/json" },
       });
     }
-    // Only admin principals can modify OTHER principals; an agent updates its own.
-    if (auth.kind === "agent" && !auth.isAdmin) {
-      const existing = await super.get();
-      if (existing && existing.id !== auth.agentId) {
-        return new Response(JSON.stringify({ error: "only admin principals can modify other principals" }), {
+    if (auth.kind !== "agent" || auth.isAdmin) return null;
+
+    const existing = await Promise.resolve(super.get()).catch(() => null);
+
+    // 1. Only admin principals can modify OTHER principals.
+    if (existing && existing.id !== auth.agentId) {
+      return new Response(JSON.stringify({ error: "only admin principals can modify other principals" }), {
+        status: 403, headers: { "content-type": "application/json" },
+      });
+    }
+
+    // 2. Only admin principals can change admin status. Compare the RESULTING
+    // status against the stored one so an ordinary self-update that simply
+    // doesn't mention either field is unaffected, and a no-op restatement of
+    // the caller's existing status is not a spurious denial.
+    const touchesPrivilegeFields =
+      content != null && typeof content === "object" && ("role" in content || "admin" in content);
+    if (touchesPrivilegeFields) {
+      const merged = { ...(existing ?? {}), ...content };
+      const wouldBeAdmin = agentRecordIsAdmin(merged) || merged.admin === true;
+      const isAdminNow = agentRecordIsAdmin(existing) || (existing?.admin === true);
+      if (wouldBeAdmin !== isAdminNow) {
+        return new Response(JSON.stringify({ error: "only admin principals can change a principal's admin status" }), {
           status: 403, headers: { "content-type": "application/json" },
         });
       }
     }
+
+    return null;
+  }
+
+  async put(content: any) {
+    const denial = await this.authorizePrincipalWrite(content);
+    if (denial) return denial;
 
     content.updatedAt = new Date().toISOString();
 
@@ -85,12 +138,61 @@ export class Agent extends (databases as any).flair.Agent {
     delete content.createdAt;
     delete content.publicKey; // key rotation goes through dedicated endpoint
 
+    // Keep the two admin fields agreeing on disk — see resources/agent-admin.ts.
+    // Only an admin can have reached here with a privilege change (see
+    // authorizePrincipalWrite), so this normalises an authorized intent; it
+    // never manufactures one.
+    reconcileAdminFields(content);
+
     // Write-time originatorInstanceId stamp — see post() above / Memory.ts's
     // stampOriginatorInstanceId doc. No-op if already set.
     if (content.originatorInstanceId == null) {
       content.originatorInstanceId = await localInstanceId();
     }
 
-    return super.put(content);
+    const result = await super.put(content);
+    invalidateAdminCache();
+    return result;
+  }
+
+  /**
+   * PATCH → Harper's partial update (`Resource.patch(data, query)`; see
+   * harper/dist/server/REST.js's method switch and Resource.js's static patch).
+   *
+   * This override exists because there was none. Every per-record authorization
+   * rule this resource enforces was written in put(), and PATCH does not route
+   * through put() — so none of those rules ran on a PATCH. allowUpdate() is
+   * allowVerified(), which means the only check a PATCH ever met was "are you
+   * some verified agent"; the rules that make the principal table safe (you may
+   * only edit yourself; you may not change your own admin status) were not
+   * among them.
+   *
+   * That is the shape flair#941 keeps running into: a check that reads as
+   * complete because it exists, and simply is not on the path the caller took.
+   * Both verbs now share authorizePrincipalWrite().
+   */
+  async patch(content: any, query?: any) {
+    const denial = await this.authorizePrincipalWrite(content);
+    if (denial) return denial;
+
+    if (content != null && typeof content === "object") {
+      // A partial update must not be able to leave the record's two admin
+      // fields disagreeing, so reconcile against the MERGED result rather than
+      // the patch alone — patching only `role` has to carry the mirror with it.
+      if ("role" in content || "admin" in content) {
+        const existing = await Promise.resolve(super.get()).catch(() => null);
+        const merged = reconcileAdminFields({ ...(existing ?? {}), ...content });
+        content.role = merged.role;
+        content.admin = merged.admin;
+      }
+      // Immutable fields, matching put().
+      delete content.createdAt;
+      delete content.publicKey;
+      content.updatedAt = new Date().toISOString();
+    }
+
+    const result = await super.patch(content, query);
+    invalidateAdminCache();
+    return result;
   }
 }

--- a/resources/AgentSeed.ts
+++ b/resources/AgentSeed.ts
@@ -18,7 +18,8 @@
  */
 
 import { Resource, databases } from "harper";
-import { isAdmin, allowAdmin } from "./agent-auth.js";
+import { isAdmin, allowAdmin, invalidateAdminCache } from "./agent-auth.js";
+import { reconcileAdminFields } from "./agent-admin.js";
 
 const DEFAULT_SOUL_KEYS = (agentId: string, displayName: string, role: string, now: string) => ({
   name: displayName,
@@ -69,8 +70,15 @@ export class AgentSeed extends Resource {
     const existingAgent = await (databases as any).flair.Agent.get(agentId).catch(() => null);
     let agent = existingAgent;
     if (!existingAgent) {
-      agent = { id: agentId, name, role, publicKey: "pending", createdAt: now, updatedAt: now };
+      // flair#941 — this writes the RAW table, so resources/Agent.ts's post()
+      // never runs and its field reconciliation does not apply here. Seeding
+      // role:"admin" without the mirror was the one path in the product that
+      // produced a genuine administrator every reporter displayed as an
+      // ordinary agent. Admin-only path (allowCreate + the isAdmin re-check
+      // above), so this normalises an authorized intent.
+      agent = reconcileAdminFields({ id: agentId, name, role, publicKey: "pending", createdAt: now, updatedAt: now });
       await (databases as any).flair.Agent.put(agent);
+      invalidateAdminCache();
     }
 
     // ── Soul entries ──────────────────────────────────────────────────────────

--- a/resources/Presence.ts
+++ b/resources/Presence.ts
@@ -33,6 +33,7 @@ import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { createRequire } from "node:module";
 import { resolveAgentAuth, verifyAgentRequest } from "./agent-auth.js";
+import { agentRecordIsAdmin } from "./agent-admin.js";
 import { WINDOW_MS, isNonceReplay, recordNonce, importEd25519Key, b64ToArrayBuffer, parseTpsEd25519Header } from "./ed25519-auth.js";
 
 // ─── Constants ────────────────────────────────────────────────────────────────
@@ -384,7 +385,13 @@ export class Presence extends (databases as any).flair.Presence {
         const entry: Record<string, unknown> = {
           id: agentId,
           displayName: agent?.displayName ?? agent?.name ?? agentId,
-          role: agent?.role ?? "agent",
+          // `role` is a human label on a PUBLIC roster (allowRead() is `true`),
+          // and it is also the field that decides administrator status
+          // (resources/agent-admin.ts). Publishing the admin sentinel would
+          // hand an unauthenticated reader the list of privileged principals —
+          // so the roster reports admins as ordinary agents. It is a display
+          // label here and nothing authorizes on it (flair#941).
+          role: agentRecordIsAdmin(agent) ? "agent" : (agent?.role ?? "agent"),
           runtime: agent?.runtime ?? null,
           // Current activity — only truthful while fresh; "idle" once decayed.
           activity: activityFresh ? rawActivity : "idle",

--- a/resources/agent-admin.ts
+++ b/resources/agent-admin.ts
@@ -1,0 +1,146 @@
+/**
+ * agent-admin.ts — the ONE answer to "is this principal an administrator?".
+ *
+ * The Agent (Principal) record carries two fields that both read as if they
+ * answered that question:
+ *
+ *   role: String       — administrator when the value is exactly "admin"
+ *   admin: Boolean     — "admin principals can manage other principals"
+ *
+ * They used to be consulted by DIFFERENT consumers, which is the whole defect
+ * (flair#941):
+ *
+ *   - resources/agent-auth.ts's isAdmin() — the single gate behind allowAdmin(),
+ *     and therefore behind every admin-only resource — searched `role` and
+ *     ignored `admin` completely.
+ *   - resources/mcp-handler.ts OR-ed the two together.
+ *   - Every reporter (flair principal show/list, the admin dashboard) displayed
+ *     `admin`, and every writer except AgentSeed wrote `admin`.
+ *
+ * So the field the product wrote and displayed was not the field the gate read.
+ * `flair principal add --admin` stored `admin: true` and granted nothing, while
+ * the dashboard confidently printed "admin: yes" for a principal that
+ * allowAdmin() rejects. Both directions are silent, and one of them is silent in
+ * the direction that flatters the operator.
+ *
+ * ─── The rule ────────────────────────────────────────────────────────────────
+ *
+ * `role === ADMIN_ROLE` is the AUTHORITY. `admin` is a SERVER-MAINTAINED MIRROR
+ * of it and is never read to reach an authorization decision again.
+ *
+ * Every decider and every reporter calls {@link agentRecordIsAdmin}, so no two
+ * surfaces can answer this question differently. Every write through a flair
+ * write path calls {@link reconcileAdminFields}, so a record that says one thing
+ * in one field and the opposite in the other cannot be STORED by any path flair
+ * offers.
+ *
+ * ─── Why `role` is the authority and not `admin` ─────────────────────────────
+ *
+ * `admin: Boolean` is honestly the better-shaped field: typed, indexed,
+ * unambiguous, and already the one every creation path and every UI uses.
+ * Making it the authority would nonetheless GRANT admin, on the primary HTTP
+ * gate, to every record that currently carries `admin: true` with a non-admin
+ * `role` — the records `flair principal add --admin` has been producing all
+ * along, which have never been admins. That is a widening of live access as a
+ * side effect of a consistency fix, decided by data nobody has audited. Keeping
+ * `role` as the authority changes no existing principal's rights on the gate:
+ * every principal that is an admin today is an admin after this change, and
+ * every principal that is not, is not.
+ *
+ * Switching the authority to `admin` is a reasonable follow-up, but it is a
+ * deliberate privilege migration with an audit of existing records — not
+ * something to slip in underneath a naming fix.
+ *
+ * ─── Records that already carry a mismatch ───────────────────────────────────
+ *
+ * Nothing is rewritten in bulk; no migration runs. What happens to each shape:
+ *
+ *   role:"admin" + admin:false|absent  — an admin today, an admin after. The
+ *     mirror is stale, so the CLI and dashboard used to report "not an admin"
+ *     for a principal holding admin rights; they now report the truth. The
+ *     stored mirror is repaired the next time the record is written through the
+ *     Agent resource.
+ *
+ *   admin:true + role not "admin"  — NOT an admin today on the gate, and not
+ *     after. This is what `flair principal add --admin` produced. The CLI and
+ *     dashboard used to report "admin: yes"; they now report the truth, which is
+ *     how an operator finds out the grant never took. The remedy is to re-issue
+ *     the grant (which now writes both fields). The one behaviour that does
+ *     change is the native MCP surface, which used to honour this field on its
+ *     own — see resources/mcp-handler.ts. That surface is gated behind
+ *     FLAIR_MCP_OAUTH and is default-OFF, so no instance running the shipped
+ *     defaults is affected.
+ *
+ * Deliberately dependency-free — pure predicates over a plain record, importing
+ * neither `harper` nor any resource, so the auth gate, the resources, the
+ * reporters and the tests can all share it without an import cycle.
+ */
+
+/** The exact `role` value that denotes a flair administrator. */
+export const ADMIN_ROLE = "admin";
+
+/**
+ * THE admin predicate. Every authorization decision and every report of a
+ * principal's admin status resolves through this one function.
+ *
+ * Total over every field combination: a record with a contradictory `admin`
+ * mirror gets the SAME answer here as it does at the gate, so a contradiction
+ * can never produce two different answers on two different surfaces. It is
+ * deliberately NOT an OR over the two fields — see the module header.
+ *
+ * Note this covers Agent RECORDS only. `FLAIR_ADMIN_AGENTS` is a separate,
+ * env-configured admin source union-ed in by resources/agent-auth.ts's
+ * getAdminAgents(); it names agent ids and never touches a record.
+ */
+export function agentRecordIsAdmin(record: unknown): boolean {
+  return (record as { role?: unknown } | null | undefined)?.role === ADMIN_ROLE;
+}
+
+/**
+ * Make a record about to be written self-consistent, so the two fields can
+ * never be STORED disagreeing.
+ *
+ * Admin is requested by EITHER spelling — `role: "admin"` or `admin: true` —
+ * because both have been documented and both are what an operator reaches for.
+ * Whichever they used, both fields come out of here agreeing. That is what
+ * makes `flair principal add --admin` finally do what it says: it writes the
+ * Boolean, and the Boolean now carries the record into the authority field.
+ *
+ * **Honouring `admin: true` here is not a privilege widening.** Every call site
+ * is already admin-gated — Agent.post() is allowCreate()=allowAdmin, Agent's
+ * update path refuses a privilege change from a non-admin, and AgentSeed is
+ * admin-only and re-checks. A caller that can reach this could have written
+ * `role: "admin"` directly; this only means they no longer have to know which
+ * of the two fields is the real one.
+ *
+ * A non-admin `role` is free text (a human label — "researcher", "COO") and is
+ * left exactly as supplied; only the admin sentinel is normalised.
+ *
+ * Mutates `content` in place and returns it, matching the surrounding
+ * defaults-stamping style in resources/Agent.ts's post().
+ */
+export function reconcileAdminFields<T extends Record<string, any>>(content: T): T {
+  if (!content || typeof content !== "object") return content;
+  if (content.role === ADMIN_ROLE || content.admin === true) {
+    content.role = ADMIN_ROLE;
+    content.admin = true;
+  } else {
+    content.admin = false;
+  }
+  return content;
+}
+
+/**
+ * True when a stored record's two fields disagree — i.e. it was written by
+ * something other than a flair write path (a raw table write, an ops-API
+ * insert, a federation merge) and now claims one thing to a reader of `admin`
+ * and the opposite to the gate.
+ *
+ * Reporting-only. Nothing authorizes on this; it exists so a surface can SAY
+ * that a record is inconsistent instead of silently picking a side.
+ */
+export function adminFieldsDisagree(record: unknown): boolean {
+  const r = record as { role?: unknown; admin?: unknown } | null | undefined;
+  if (!r || typeof r !== "object") return false;
+  return agentRecordIsAdmin(r) !== (r.admin === true);
+}

--- a/resources/agent-admin.ts
+++ b/resources/agent-admin.ts
@@ -121,11 +121,15 @@ export function agentRecordIsAdmin(record: unknown): boolean {
  */
 export function reconcileAdminFields<T extends Record<string, any>>(content: T): T {
   if (!content || typeof content !== "object") return content;
-  if (content.role === ADMIN_ROLE || content.admin === true) {
-    content.role = ADMIN_ROLE;
-    content.admin = true;
+  // Widened locally: `content` is generic so TypeScript will not accept writes
+  // to named properties on it, but the whole point here is to normalise those
+  // two properties in place and hand the caller back its own object.
+  const record = content as Record<string, any>;
+  if (record.role === ADMIN_ROLE || record.admin === true) {
+    record.role = ADMIN_ROLE;
+    record.admin = true;
   } else {
-    content.admin = false;
+    record.admin = false;
   }
   return content;
 }

--- a/resources/agent-auth.ts
+++ b/resources/agent-auth.ts
@@ -250,9 +250,76 @@ export async function allowAdmin(context: any): Promise<boolean> {
   return a.kind === "internal" || (a.kind === "agent" && a.isAdmin);
 }
 
+/**
+ * flair#936 — the `internal` verdict is TRUSTED and UNFILTERED, and it is also
+ * what a caller gets for supplying no context at all. Nothing distinguishes
+ * "I am flair's own maintenance code" from "I am an application developer who
+ * did not know a context was required": both spell it `new Memory()`, both
+ * succeed, and both return plausible data. It surfaces months later as memories
+ * that were never scoped.
+ *
+ * This does not change the verdict — every authorization outcome is byte-
+ * identical — it ends the SILENCE. A deliberate elevated call says so with
+ * `internalContext()` (resources/in-process.ts), whose `__flairInternal` marker
+ * is read here and nowhere else; anything else that lands on `internal` gets one
+ * warning per process, with the stack, so the condition is observable where it
+ * was previously invisible.
+ *
+ * MEASURED, and the reason this is worth having: flair itself has NO in-process
+ * caller that relies on the omission — every maintenance, migration, federation
+ * and boot path goes through the raw `databases.flair.*` table accessor, which
+ * bypasses this resolver entirely rather than defaulting through it. So a
+ * warning from this line is, in practice, always either an embedding
+ * application that forgot a context or a flair call site that should be naming
+ * its intent. Neither is noise.
+ *
+ * The marker is read off `context`, NOT off `c`: `c` is rebound to
+ * `context.request` on the line below, and internalContext() carries the marker
+ * on the outer object.
+ */
+let warnedInternalByOmission = false;
+
+/**
+ * Was this elevated call DELIBERATE — i.e. did the caller name the authority
+ * with `internalContext()` rather than land on it by leaving a context off?
+ *
+ * Exported because it is the whole decision, and a decision worth testing is
+ * worth testing directly: the warning itself is latched once per process, which
+ * makes any test of the side effect order-dependent (bun shares one module
+ * registry across the whole run, so whichever file resolves a context-less call
+ * first consumes the latch and every later assertion silently passes). Pinning
+ * the predicate instead is deterministic.
+ *
+ * Grants nothing and is never consulted for an authorization decision — the
+ * verdict is identical either way.
+ */
+export function isDeliberateInternalCall(context: any): boolean {
+  return context?.__flairInternal === true;
+}
+
+/** The advisory text, exported so its content is pinned without tripping the latch. */
+export const INTERNAL_BY_OMISSION_WARNING =
+  "[flair-auth] a resource was invoked with NO caller context and resolved to the trusted " +
+  "`internal` verdict: reads are UNFILTERED across every agent, writes are unattributed, and " +
+  "the admin-only gate passes. If this is your application's code, pass agentContext(<id>) from " +
+  "@tpsdev-ai/flair's in-process seam so the call is scoped and attributed. If the elevated " +
+  "authority is genuinely intended, say so with internalContext() and this warning will stop. " +
+  "Fires once per process.";
+
+function noteInternalVerdict(context: any): void {
+  if (warnedInternalByOmission) return;
+  if (isDeliberateInternalCall(context)) return; // deliberate, and said so
+  warnedInternalByOmission = true;
+  const stack = (new Error().stack ?? "").split("\n").slice(2, 7).join("\n");
+  console.error(INTERNAL_BY_OMISSION_WARNING + "\n" + stack);
+}
+
 export async function resolveAgentAuth(context: any): Promise<AgentAuthVerdict> {
   const c = context?.request ?? context;
-  if (!c) return { kind: "internal" };
+  if (!c) {
+    noteInternalVerdict(context);
+    return { kind: "internal" };
+  }
 
   if (c.tpsAnonymous === true) return { kind: "anonymous" };
 
@@ -288,5 +355,6 @@ export async function resolveAgentAuth(context: any): Promise<AgentAuthVerdict> 
     return { kind: "anonymous" };
   }
 
+  noteInternalVerdict(context);
   return { kind: "internal" };
 }

--- a/resources/agent-auth.ts
+++ b/resources/agent-auth.ts
@@ -17,6 +17,7 @@
  */
 import { databases } from "harper";
 import { WINDOW_MS, isNonceReplay, recordNonce, importEd25519Key, b64ToArrayBuffer, parseTpsEd25519Header } from "./ed25519-auth.js";
+import { ADMIN_ROLE, agentRecordIsAdmin } from "./agent-admin.js";
 
 /**
  * Shared Harper user that verified Ed25519 agents resolve to (least-privilege
@@ -35,8 +36,14 @@ export const FLAIR_AGENT_USERNAME = "flair-agent";
 
 // ─── Admin resolution ─────────────────────────────────────────────────────────
 // Admin agents come from FLAIR_ADMIN_AGENTS (comma-separated) OR Agent records
-// with role === "admin". OR-combined, cached 60s. Distinct from Harper's
-// super_user — admin here gates flair-policy decisions (promotions, raw ops).
+// whose `role` is the admin sentinel. OR-combined, cached 60s. Distinct from
+// Harper's super_user — admin here gates flair-policy decisions (promotions,
+// raw ops).
+//
+// The record half of that union is the ONE place the Agent table is consulted
+// for an authorization decision, and it resolves through
+// resources/agent-admin.ts's shared predicate so it cannot drift from the
+// reporters or from the MCP surface (flair#941 — they had drifted).
 
 let adminCacheExpiry = 0;
 let adminCache: Set<string> = new Set();
@@ -47,12 +54,35 @@ async function getAdminAgents(): Promise<Set<string>> {
   const fromEnv = (process.env.FLAIR_ADMIN_AGENTS ?? "").split(",").map((s) => s.trim()).filter(Boolean);
   const fromDb: string[] = [];
   try {
-    const results = await (databases as any).flair.Agent.search([{ attribute: "role", value: "admin", condition: "equals" }]);
-    for await (const row of results) if (row?.id) fromDb.push(row.id);
+    const results = await (databases as any).flair.Agent.search([{ attribute: "role", value: ADMIN_ROLE, condition: "equals" }]);
+    for await (const row of results) if (row?.id && agentRecordIsAdmin(row)) fromDb.push(row.id);
   } catch { /* Agent table may be empty */ }
   adminCache = new Set([...fromEnv, ...fromDb]);
   adminCacheExpiry = now + 60_000;
   return adminCache;
+}
+
+/**
+ * Drop the memoised admin set so the NEXT isAdmin() re-reads the Agent table.
+ *
+ * The 60s TTL is a load optimisation, but on its own it makes a privilege
+ * change take up to a minute to appear — which reads as "the change didn't
+ * work", and is exactly the confusion flair#941 is about: an operator grants
+ * admin, tests it, sees a denial, and starts changing other things. The write
+ * path knows precisely when a principal's admin status changed, so it says so
+ * and the grant is effective on the caller's very next request.
+ *
+ * Deliberately NOT a distributed invalidation: Harper runs N worker threads,
+ * each with its own module instance and its own cache, so a promotion applied
+ * on thread A still takes up to the TTL to be seen by thread B. Making that
+ * exact would mean a shared invalidation channel, which is a much larger change
+ * than the confusion warrants — the bound stays 60s, unchanged, and the common
+ * single-threaded/dev case becomes immediate. Called by resources/Agent.ts's
+ * write paths.
+ */
+export function invalidateAdminCache(): void {
+  adminCacheExpiry = 0;
+  adminCache = new Set();
 }
 
 export async function isAdmin(agentId: string): Promise<boolean> {

--- a/resources/auth-middleware.ts
+++ b/resources/auth-middleware.ts
@@ -436,18 +436,66 @@ server.http(async (request: any, nextLayer: any) => {
       }
     }
 
-    // Soul PUT: only owner or admin
-    if (url.pathname.startsWith("/Soul") && (method === "PUT" || method === "POST")) {
+    // Soul mutations: only the owner or an admin may write a soul entry.
+    //
+    // This guard had two independent holes, either of which alone let one agent
+    // rewrite another's identity data:
+    //
+    //   1. THE VERB LIST enumerated PUT and POST only. Its three siblings above
+    //      (OrgEvent, WorkspaceState, Memory) all include PATCH, and Memory
+    //      includes DELETE; this one did neither. Harper routes PATCH to a
+    //      resource method that carries no ownership check of its own
+    //      (Soul.ts's enforceWriteAuth covers post()/put()), and DELETE reached
+    //      the table with no per-record check at all. Both were live.
+    //
+    //   2. IT COMPARED THE BODY, not the target. `body.agentId` is the owner
+    //      the CALLER claims, and the check only fired when that field was
+    //      present and mismatched — so a body omitting it, which a partial
+    //      write naturally does, was compared against nothing and passed
+    //      whatever record the URL pointed at. The resource-level check behind
+    //      it is "validate-truthy" attribution, which by design also passes an
+    //      ABSENT owner field, so nothing downstream caught it either. (A PUT
+    //      happened to fail anyway, but on `agentId: String!` schema
+    //      validation — a 400 for the wrong reason, not an authorization
+    //      decision, and not a defence to rely on.)
+    //
+    // Closing one hole leaves the other reachable through the remaining verbs,
+    // so both are closed here: every mutating verb is covered, and ownership is
+    // resolved from the STORED RECORD named by the path. That is the same shape
+    // as the Memory ownership guard below, which is the resource in this file
+    // that already had it right — worth copying rather than reinventing.
+    //
+    // The path test stays `startsWith("/Soul")` so sibling routes keep the
+    // body check they already had; the record lookup is scoped to the real
+    // `/Soul/<id>` collection so it never resolves an unrelated id.
+    if (url.pathname.startsWith("/Soul") &&
+        (method === "POST" || method === "PUT" || method === "PATCH" || method === "DELETE")) {
       if (!request.tpsAgentIsAdmin) {
-        let bodyAgentId: string | null = null;
-        try {
-          const clone = request.clone();
-          const body = await clone.json();
-          bodyAgentId = body?.agentId ?? null;
-        } catch {}
-        if (bodyAgentId && bodyAgentId !== agentId) {
-          return new Response(JSON.stringify({ error: "forbidden: non-admin cannot modify another agent's soul" }), { status: 403 });
+        // (a) A PRESENT, mismatched body agentId is a forged attribution.
+        if (method !== "DELETE") {
+          let bodyAgentId: string | null = null;
+          try {
+            const clone = request.clone();
+            const body = await clone.json();
+            bodyAgentId = body?.agentId ?? null;
+          } catch {}
+          if (bodyAgentId && bodyAgentId !== agentId) {
+            return new Response(JSON.stringify({ error: "forbidden: non-admin cannot modify another agent's soul" }), { status: 403 });
+          }
         }
+
+        // (b) The owner of the record actually being written. Catches every
+        // body that simply leaves agentId out.
+        try {
+          const pathParts = url.pathname.split("/").filter(Boolean);
+          const soulId = pathParts[0] === "Soul" && pathParts[1] ? decodeURIComponent(pathParts[1]) : null;
+          if (soulId) {
+            const record = await (databases as any).flair.Soul.get(soulId);
+            if (record && record.agentId && record.agentId !== agentId) {
+              return new Response(JSON.stringify({ error: "forbidden: non-admin cannot modify another agent's soul" }), { status: 403 });
+            }
+          }
+        } catch {}
       }
     }
 

--- a/resources/in-process.ts
+++ b/resources/in-process.ts
@@ -223,6 +223,15 @@ export function internalContext(): CallContext {
  * Reads do not need this — `Cls.get(id, context)` and `Cls.search(query,
  * context)` (Harper's static resource methods) already thread the context and
  * start their own transaction.
+ *
+ * **They do still need the CONTEXT.** Only the collection binding is
+ * unnecessary for a read, not the identity. `Cls.search(query)` with the second
+ * argument left off does not read "as nobody" — outside a Harper request scope
+ * (a boot hook, a timer, a queue worker, a detached promise) it resolves to the
+ * same trusted `internal` verdict this module exists to keep out of reach, and
+ * returns every agent's private records unfiltered. On that path the resource's
+ * own `allow*` gate is not consulted at all, so nothing else stands in the way.
+ * Pass the context to every call, read or write (flair#936).
  */
 export async function collectionResource<T = any>(Cls: any, context: CallContext): Promise<T> {
   if (context == null || typeof context !== "object") {

--- a/resources/mcp-handler.ts
+++ b/resources/mcp-handler.ts
@@ -27,6 +27,7 @@
 import { databases } from "harper";
 import { randomBytes } from "node:crypto";
 import { TOOLS, listToolDefs, type ResolvedAgent } from "./mcp-tools.js";
+import { agentRecordIsAdmin } from "./agent-admin.js";
 
 // The MCP protocol revision we implement (initialize handshake).
 const PROTOCOL_VERSION = "2025-06-18";
@@ -167,14 +168,23 @@ async function jitProvisionPrincipal(sub: string): Promise<string> {
 }
 
 /**
- * Is this Principal a flair admin? Reads the Agent record's `admin`/`role`
- * fields. A MCP-OAuth agent is NON-admin unless an operator has explicitly
- * marked its Agent record admin — the MCP surface never elevates on its own.
+ * Is this Principal a flair admin? A MCP-OAuth agent is NON-admin unless an
+ * operator has explicitly marked its Agent record admin — the MCP surface never
+ * elevates on its own.
+ *
+ * flair#941: this used to OR the two admin fields together while the primary
+ * HTTP gate (resources/agent-auth.ts's isAdmin) read only `role`, so the same
+ * record could be an administrator here and an ordinary agent there. It now
+ * resolves through the one shared predicate, so both surfaces answer
+ * identically. A record carrying `admin: true` alone — which no flair write
+ * path produces, and which was never an admin on the HTTP gate — is no longer
+ * an admin here either; see resources/agent-admin.ts for the remedy. This
+ * surface is gated behind FLAIR_MCP_OAUTH and is default-OFF.
  */
 async function isAgentAdmin(principalId: string): Promise<boolean> {
   try {
     const agent = await (databases as any).flair.Agent.get(principalId);
-    return agent?.admin === true || agent?.role === "admin";
+    return agentRecordIsAdmin(agent);
   } catch {
     return false;
   }

--- a/resources/presence-internal.ts
+++ b/resources/presence-internal.ts
@@ -44,7 +44,12 @@ function presenceDelegationContext(auth: AgentAuthVerdict): any {
   const agentAuth = auth.kind === "agent"
     ? { agentId: auth.agentId, isAdmin: auth.isAdmin }
     : { agentId: "internal", isAdmin: true };
-  return { request: { _flairAgentAuth: agentAuth } };
+  // `__flairInternal` marks the `internal` branch as DELIBERATE (flair#936) —
+  // an "internal" verdict relayed here is a trusted in-process call this file
+  // has already established, not a caller who forgot to pass a context. It is
+  // read only by resources/agent-auth.ts's accidental-omission warning; it
+  // grants nothing and is never consulted for an authorization decision.
+  return { request: { _flairAgentAuth: agentAuth }, __flairInternal: true };
 }
 
 /**

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -3962,7 +3962,8 @@ agent
       console.log(render.kv("status", render.wrap(statusColor, String(out.status))));
     }
     if (out.defaultTrustTier) console.log(render.kv("trust tier", String(out.defaultTrustTier)));
-    if (out.admin) console.log(render.kv("admin", render.wrap(render.c.magenta, "yes")));
+    // flair#941 — read the authority, not the mirror. See `principal show`.
+    if (agentRecordIsAdmin(out)) console.log(render.kv("admin", render.wrap(render.c.magenta, "yes")));
     if (out.runtime) console.log(render.kv("runtime", String(out.runtime)));
     if (out.publicKey) console.log(render.kv("publicKey", render.wrap(render.c.dim, String(out.publicKey))));
     if (out.createdAt) console.log(render.kv("created", `${render.relativeTime(out.createdAt)} ${render.wrap(render.c.dim, `(${out.createdAt})`)}`));
@@ -5393,6 +5394,24 @@ mcp
 // 1.0 identity management. The Principal model extends Agent — this is the
 // preferred CLI surface for managing identities going forward.
 
+/**
+ * The exact `role` value that denotes a flair administrator, and the predicate
+ * that reads it.
+ *
+ * DUPLICATED FROM resources/agent-admin.ts on purpose — the same deliberate
+ * copy as the federation crypto helpers above: src/cli.ts must not import from
+ * resources/, because those imports don't survive npm packaging. The two must
+ * stay in sync.
+ *
+ * flair#941: `role` is the authority and `admin` is its mirror. The CLI used to
+ * both write and display ONLY the mirror, so `principal add --admin` created a
+ * principal the gate refuses and `principal show` printed "admin: yes" for it.
+ */
+const ADMIN_ROLE = "admin";
+function agentRecordIsAdmin(record: any): boolean {
+  return record?.role === ADMIN_ROLE;
+}
+
 const principal = program.command("principal").description("Manage principals (humans and agents)");
 
 principal
@@ -5468,6 +5487,11 @@ principal
       status: "active",
       publicKey: pubKeyB64url,
       defaultTrustTier: trustTier,
+      // flair#941 — write BOTH. This is an ops-API upsert, so the Agent
+      // resource's reconciliation never runs; writing only the `admin` mirror
+      // is what made `--admin` a no-op at the gate for every principal this
+      // command has ever created.
+      role: isAdmin ? ADMIN_ROLE : "agent",
       admin: isAdmin,
       runtime: runtime ?? null,
       createdAt: new Date().toISOString(),
@@ -5523,7 +5547,10 @@ principal
         table: "Agent",
         operator: "and",
         conditions,
-        get_attributes: ["id", "name", "kind", "status", "defaultTrustTier", "admin", "runtime", "createdAt"],
+        // `role` is the authority behind admin status (flair#941); the
+        // projection used to omit it, so this listing could only ever report
+        // the mirror.
+        get_attributes: ["id", "name", "kind", "status", "defaultTrustTier", "role", "admin", "runtime", "createdAt"],
       }),
     });
     if (!res.ok) {
@@ -5558,7 +5585,14 @@ principal
       {
         label: "admin",
         key: "admin",
-        format: (v) => (v ? render.wrap(render.c.red, "yes") : render.wrap(render.c.dim, "no")),
+        // Report the status the gate will apply, and flag a record whose two
+        // fields disagree rather than picking a side silently (flair#941).
+        format: (_v, row) => {
+          const isAdmin = agentRecordIsAdmin(row);
+          const mismatch = isAdmin !== (row.admin === true);
+          const base = isAdmin ? render.wrap(render.c.red, "yes") : render.wrap(render.c.dim, "no");
+          return mismatch ? `${base} ${render.wrap(render.c.yellow, "(!)")}` : base;
+        },
       },
       {
         label: "status",
@@ -5598,7 +5632,12 @@ principal
       console.log(render.kv("status", render.wrap(statusColor, String(result.status))));
     }
     if (result.defaultTrustTier) console.log(render.kv("trust tier", String(result.defaultTrustTier)));
-    if (result.admin) console.log(render.kv("admin", render.wrap(render.c.red, "yes")));
+    // flair#941 — read the authority, not the mirror, and say so when the two
+    // disagree (only reachable via a raw table write).
+    if (agentRecordIsAdmin(result)) console.log(render.kv("admin", render.wrap(render.c.red, "yes")));
+    if (agentRecordIsAdmin(result) !== (result.admin === true)) {
+      console.log(render.kv("admin", render.wrap(render.c.yellow, `record is inconsistent (role=${result.role ?? "unset"}, admin=${result.admin ?? "unset"}) — re-issue the grant to repair`)));
+    }
     if (result.runtime) console.log(render.kv("runtime", String(result.runtime)));
     if (result.email) console.log(render.kv("email", String(result.email)));
     if (result.publicKey) console.log(render.kv("publicKey", render.wrap(render.c.dim, String(result.publicKey))));

--- a/test/integration/admin-field-truth.test.ts
+++ b/test/integration/admin-field-truth.test.ts
@@ -1,0 +1,298 @@
+// admin-field-truth.test.ts — flair#941.
+//
+// The Agent record carries TWO fields that both read as "is this principal an
+// administrator": `role` (admin when === "admin") and `admin: Boolean`. Before
+// this change they were consulted by DIFFERENT consumers:
+//
+//   - resources/agent-auth.ts's isAdmin() — the ONE gate behind allowAdmin() —
+//     read `role` and ignored `admin` entirely.
+//   - resources/mcp-handler.ts's isAgentAdmin() read BOTH (OR-combined).
+//   - every reporter (flair principal show/list, the admin dashboard) and every
+//     writer except AgentSeed used `admin`.
+//
+// So `flair principal add --admin` wrote a field the gate never reads, and the
+// dashboard printed "admin: yes" for a principal allowAdmin() rejects. These
+// tests pin the three properties that make that unrepresentable:
+//
+//   1. a write through the Agent resource can no longer STORE a disagreement
+//      (either field asks for admin → both are set; neither → both cleared),
+//   2. a non-admin can no longer grant itself admin by writing either field,
+//   3. a privilege change is effective immediately, not up to 60s later.
+//
+// MODEL: test/integration/gate4-authgate.test.ts (the admin-vs-non-admin agent
+// seeding + Ed25519 signing pattern for allowAdmin-gated resources).
+import { describe, expect, test, beforeAll, afterAll } from "bun:test";
+import nacl from "tweetnacl";
+import { randomUUID } from "node:crypto";
+import { startHarper, stopHarper, HarperInstance } from "../helpers/harper-lifecycle";
+
+interface TestAgent { id: string; publicKey: string; secretKey: Uint8Array; }
+
+function mkAgent(id: string): TestAgent {
+  const kp = nacl.sign.keyPair();
+  return { id, publicKey: Buffer.from(kp.publicKey).toString("base64"), secretKey: kp.secretKey };
+}
+
+function ed25519Header(agent: TestAgent, method: string, path: string): string {
+  const ts = Date.now().toString();
+  const nonce = randomUUID();
+  const payload = `${agent.id}:${ts}:${nonce}:${method}:${path}`;
+  const sig = nacl.sign.detached(new TextEncoder().encode(payload), agent.secretKey);
+  return `TPS-Ed25519 ${agent.id}:${ts}:${nonce}:${Buffer.from(sig).toString("base64")}`;
+}
+
+async function adminOp(harper: HarperInstance, op: Record<string, any>): Promise<Response> {
+  return fetch(harper.opsURL, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: "Basic " + btoa(`${harper.admin.username}:${harper.admin.password}`),
+    },
+    body: JSON.stringify(op),
+  });
+}
+
+/** Read a record straight out of the table, bypassing every resource gate. */
+async function rawAgent(harper: HarperInstance, id: string): Promise<any> {
+  const res = await adminOp(harper, {
+    operation: "search_by_id", database: "flair", table: "Agent",
+    ids: [id], get_attributes: ["id", "role", "admin", "defaultTrustTier"],
+  });
+  const rows = await res.json();
+  return Array.isArray(rows) ? rows[0] : null;
+}
+
+/** ADMIN-ONLY probe: FederationInstance.allowRead() is allowAdmin(). */
+const ADMIN_ONLY_PATH = "/FederationInstance";
+
+async function probeAdminOnly(harper: HarperInstance, agent: TestAgent): Promise<number> {
+  const res = await fetch(`${harper.httpURL}${ADMIN_ONLY_PATH}`, {
+    headers: { Authorization: ed25519Header(agent, "GET", ADMIN_ONLY_PATH) },
+  });
+  return res.status;
+}
+
+let harper: HarperInstance;
+
+// role:"admin" — a legitimately-admin principal. THE POSITIVE CONTROL.
+const roleAdmin = mkAgent("aft-role-admin");
+// admin:true with no admin role — the record `flair principal add --admin`
+// used to produce. Never had gate admin; must still not have it.
+const boolOnly = mkAgent("aft-bool-only");
+// an ordinary non-admin, used for the self-promotion probes.
+const plain = mkAgent("aft-plain");
+
+describe("flair#941 — one meaning, one answer, on every surface", () => {
+  beforeAll(async () => {
+    harper = await startHarper();
+
+    const seed = async (rec: Record<string, any>) => {
+      const res = await adminOp(harper, {
+        operation: "insert", database: "flair", table: "Agent", records: [rec],
+      });
+      expect(res.status, `seed ${rec.id} returned ${res.status}: ${await res.text()}`).toBe(200);
+    };
+
+    const now = new Date().toISOString();
+    await seed({ id: roleAdmin.id, name: roleAdmin.id, role: "admin", admin: true, publicKey: roleAdmin.publicKey, createdAt: now });
+    await seed({ id: boolOnly.id, name: boolOnly.id, admin: true, publicKey: boolOnly.publicKey, createdAt: now });
+    await seed({ id: plain.id, name: plain.id, role: "agent", admin: false, publicKey: plain.publicKey, createdAt: now });
+  }, 180_000);
+
+  afterAll(async () => { if (harper) await stopHarper(harper); });
+
+  // ── POSITIVE CONTROL ──────────────────────────────────────────────────────
+  // Without this, every "denied" assertion below would also pass if the change
+  // had simply broken admin outright.
+  describe("positive control", () => {
+    test("a legitimately-admin principal (role:\"admin\") still passes the admin gate", async () => {
+      const status = await probeAdminOnly(harper, roleAdmin);
+      expect(status, `admin GET ${ADMIN_ONLY_PATH} returned ${status}, expected 200`).toBe(200);
+    }, 30_000);
+  });
+
+  // ── The two fields can no longer disagree about an existing record ────────
+  describe("the stored record cannot express a contradiction", () => {
+    test("a principal carrying ONLY admin:true is not an admin on the gate (unchanged)", async () => {
+      const status = await probeAdminOnly(harper, boolOnly);
+      expect(status, `admin:true-only GET ${ADMIN_ONLY_PATH} returned ${status}, expected 403`).toBe(403);
+    }, 30_000);
+
+    // AgentSeed is the ONE product path that has ever written role:"admin", and
+    // it writes the raw table, so the Agent resource's reconciliation does not
+    // cover it. Seeding an admin here used to produce exactly the record this
+    // issue is about: an administrator that every reporter displays as an
+    // ordinary agent.
+    test("seeding an admin principal writes BOTH fields — the record cannot lie to either reader", async () => {
+      const id = `aft-seed-admin-${randomUUID().slice(0, 8)}`;
+      const path = "/AgentSeed";
+      const res = await fetch(`${harper.httpURL}${path}`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: ed25519Header(roleAdmin, "POST", path),
+        },
+        body: JSON.stringify({ agentId: id, role: "admin" }),
+      });
+      expect(res.status, `admin POST /AgentSeed returned ${res.status}: ${await res.text()}`).toBeLessThan(300);
+
+      const rec = await rawAgent(harper, id);
+      expect(rec, `no Agent record written for ${id}`).toBeTruthy();
+      // BOTH, or the record is a lie to one of its two readers.
+      expect(rec.role).toBe("admin");
+      expect(rec.admin).toBe(true);
+    }, 30_000);
+
+    test("seeding an ordinary principal leaves both fields non-admin, and preserves a free-text role", async () => {
+      const id = `aft-seed-plain-${randomUUID().slice(0, 8)}`;
+      const path = "/AgentSeed";
+      const res = await fetch(`${harper.httpURL}${path}`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: ed25519Header(roleAdmin, "POST", path),
+        },
+        body: JSON.stringify({ agentId: id, role: "researcher" }),
+      });
+      expect(res.status, `admin POST /AgentSeed returned ${res.status}`).toBeLessThan(300);
+
+      const rec = await rawAgent(harper, id);
+      expect(rec.admin).toBe(false);
+      expect(rec.role).toBe("researcher"); // a human label is not an authority value
+    }, 30_000);
+  });
+
+  // ── A principal's admin status is admin-only to change ───────────────────
+  // The per-record rules for this table were written in put(), and Harper routes
+  // PATCH to update(), which had no override — so allowUpdate()=allowVerified
+  // was the only check a PATCH ever met. Both verbs now share one authorization
+  // helper. These use PATCH deliberately: PUT is not a substitute, because
+  // put() strips the schema-required publicKey/createdAt and so rejects every
+  // request it receives (see the separate note in the PR).
+  describe("changing admin status is refused for a non-admin", () => {
+    test("a non-admin patching role:\"admin\" onto its OWN record is refused, and the record is unchanged", async () => {
+      const path = `/Agent/${plain.id}`;
+      const res = await fetch(`${harper.httpURL}${path}`, {
+        method: "PATCH",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: ed25519Header(plain, "PATCH", path),
+        },
+        body: JSON.stringify({ role: "admin" }),
+      });
+      expect(res.status, `self-promote via role returned ${res.status}, expected 403`).toBe(403);
+
+      const rec = await rawAgent(harper, plain.id);
+      expect(rec.role, "role was persisted despite the refusal").not.toBe("admin");
+      expect(await probeAdminOnly(harper, plain)).toBe(403);
+    }, 30_000);
+
+    test("a non-admin patching admin:true onto its OWN record is refused, and the record is unchanged", async () => {
+      const path = `/Agent/${plain.id}`;
+      const res = await fetch(`${harper.httpURL}${path}`, {
+        method: "PATCH",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: ed25519Header(plain, "PATCH", path),
+        },
+        body: JSON.stringify({ admin: true }),
+      });
+      expect(res.status, `self-promote via admin returned ${res.status}, expected 403`).toBe(403);
+
+      const rec = await rawAgent(harper, plain.id);
+      expect(rec.admin, "admin was persisted despite the refusal").not.toBe(true);
+      expect(rec.role).not.toBe("admin");
+    }, 30_000);
+
+    test("a non-admin patching ANOTHER principal's record is refused", async () => {
+      const path = `/Agent/${roleAdmin.id}`;
+      const res = await fetch(`${harper.httpURL}${path}`, {
+        method: "PATCH",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: ed25519Header(plain, "PATCH", path),
+        },
+        body: JSON.stringify({ runtime: "tampered" }),
+      });
+      expect(res.status, `cross-principal patch returned ${res.status}, expected 403`).toBe(403);
+    }, 30_000);
+
+    test("a non-admin may still patch its own record's ordinary fields", async () => {
+      const path = `/Agent/${plain.id}`;
+      const res = await fetch(`${harper.httpURL}${path}`, {
+        method: "PATCH",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: ed25519Header(plain, "PATCH", path),
+        },
+        body: JSON.stringify({ runtime: "headless" }),
+      });
+      expect(res.status, `benign self-update returned ${res.status}: ${await res.text()}`).toBeLessThan(300);
+    }, 30_000);
+  });
+
+  // ── The privilege change is effective immediately ────────────────────────
+  // getAdminAgents() caches for 60s. A correctness fix that only manifests a
+  // minute later is still confusing, so the write path invalidates the cache.
+  describe("a privilege change takes effect without waiting out the cache", () => {
+    test("an agent promoted through the resource is an admin on its very next request", async () => {
+      const fresh = mkAgent(`aft-promoted-${randomUUID().slice(0, 8)}`);
+      const now = new Date().toISOString();
+      const seedRes = await adminOp(harper, {
+        operation: "insert", database: "flair", table: "Agent",
+        records: [{ id: fresh.id, name: fresh.id, role: "agent", admin: false, publicKey: fresh.publicKey, createdAt: now }],
+      });
+      expect(seedRes.status).toBe(200);
+
+      // Populate the admin cache with a verdict that predates the promotion.
+      expect(await probeAdminOnly(harper, fresh)).toBe(403);
+
+      const path = `/Agent/${fresh.id}`;
+      const promote = await fetch(`${harper.httpURL}${path}`, {
+        method: "PATCH",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: ed25519Header(roleAdmin, "PATCH", path),
+        },
+        // Granted through the Boolean — the field an operator reaches for. It
+        // carries the record into the authority field, so this actually grants.
+        body: JSON.stringify({ admin: true }),
+      });
+      expect(promote.status, `admin promote returned ${promote.status}: ${await promote.text()}`).toBeLessThan(300);
+
+      // No sleep. Pre-fix this stayed 403 for up to 60 seconds.
+      const status = await probeAdminOnly(harper, fresh);
+      expect(status, `promoted agent got ${status}, expected 200 immediately`).toBe(200);
+    }, 60_000);
+  });
+
+  // ── The public roster does not disclose administrator status ─────────────
+  // Presence.allowRead() is `true` and `role` is in ROSTER_ALLOWLIST, so making
+  // `role` the stored authority would otherwise publish admin status to
+  // unauthenticated readers.
+  describe("public presence roster", () => {
+    test("an admin principal appears on the public roster but its admin status is not disclosed", async () => {
+      // Seed presence for BOTH principals so the assertion is not vacuous: the
+      // roster must actually contain the admin before "it does not say admin"
+      // means anything.
+      const seedPresence = await adminOp(harper, {
+        operation: "insert", database: "flair", table: "Presence",
+        records: [
+          { agentId: roleAdmin.id, lastHeartbeatAt: Date.now(), activity: "planning" },
+          { agentId: plain.id, lastHeartbeatAt: Date.now(), activity: "coding" },
+        ],
+      });
+      expect(seedPresence.status, `Presence seed returned ${seedPresence.status}`).toBe(200);
+
+      const res = await fetch(`${harper.httpURL}/Presence`);
+      expect(res.status).toBe(200);
+      const body = await res.text();
+
+      // Positive control for THIS assertion — the roster is populated and the
+      // admin principal is on it.
+      expect(body.includes(roleAdmin.id), "roster did not contain the admin principal — assertion would be vacuous").toBe(true);
+      // ...and it is presented as an ordinary agent.
+      expect(body.includes("\"role\":\"admin\""), "public roster disclosed admin status").toBe(false);
+    }, 30_000);
+  });
+});

--- a/test/integration/soul-write-ownership.test.ts
+++ b/test/integration/soul-write-ownership.test.ts
@@ -1,0 +1,198 @@
+// soul-write-ownership.test.ts — the Soul half of the write-authorization
+// coverage gap.
+//
+// A soul entry is a principal's identity data. Only its owner (or an admin) may
+// write it. That rule was enforced by a middleware guard which had TWO
+// independent holes, either of which alone lets one agent rewrite another's:
+//
+//   1. THE VERB LIST. The guard enumerated PUT and POST. Its three siblings in
+//      the same block (OrgEvent, WorkspaceState, Memory) all enumerate PATCH
+//      as well; this one did not, and Harper routes PATCH to a resource method
+//      that carries no ownership check of its own.
+//
+//   2. THE THING IT COMPARED. It compared the request BODY's `agentId` against
+//      the caller, and only denied when that field was present and mismatched.
+//      A body that simply omits `agentId` — which a partial write naturally
+//      does — was compared against nothing and passed, whatever record the URL
+//      pointed at. The resource-level check behind it uses "validate-truthy"
+//      attribution, which by design also passes an ABSENT owner field.
+//
+// Closing one leaves the other reachable through whichever verbs remain, so
+// these pin both: the guard now runs on every mutating verb, and it resolves
+// the owner of the TARGET RECORD from the path rather than trusting the body —
+// the same shape as the Memory ownership guard, which is the resource in this
+// codebase that already had it right.
+//
+// MODEL: test/integration/admin-field-truth.test.ts.
+import { describe, expect, test, beforeAll, afterAll } from "bun:test";
+import nacl from "tweetnacl";
+import { randomUUID } from "node:crypto";
+import { startHarper, stopHarper, HarperInstance } from "../helpers/harper-lifecycle";
+
+interface TestAgent { id: string; publicKey: string; secretKey: Uint8Array; }
+
+function mkAgent(id: string): TestAgent {
+  const kp = nacl.sign.keyPair();
+  return { id, publicKey: Buffer.from(kp.publicKey).toString("base64"), secretKey: kp.secretKey };
+}
+
+function ed25519Header(agent: TestAgent, method: string, path: string): string {
+  const ts = Date.now().toString();
+  const nonce = randomUUID();
+  const payload = `${agent.id}:${ts}:${nonce}:${method}:${path}`;
+  const sig = nacl.sign.detached(new TextEncoder().encode(payload), agent.secretKey);
+  return `TPS-Ed25519 ${agent.id}:${ts}:${nonce}:${Buffer.from(sig).toString("base64")}`;
+}
+
+async function adminOp(harper: HarperInstance, op: Record<string, any>): Promise<Response> {
+  return fetch(harper.opsURL, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: "Basic " + btoa(`${harper.admin.username}:${harper.admin.password}`),
+    },
+    body: JSON.stringify(op),
+  });
+}
+
+/** Read a soul entry straight out of the table, bypassing every resource gate. */
+async function rawSoul(harper: HarperInstance, id: string): Promise<any> {
+  const res = await adminOp(harper, {
+    operation: "search_by_id", database: "flair", table: "Soul",
+    ids: [id], get_attributes: ["id", "agentId", "key", "value"],
+  });
+  const rows = await res.json();
+  return Array.isArray(rows) ? rows[0] : null;
+}
+
+async function seedSoul(harper: HarperInstance, agentId: string, key: string, value: string): Promise<string> {
+  const id = `${agentId}:${key}`;
+  const now = new Date().toISOString();
+  const res = await adminOp(harper, {
+    operation: "upsert", database: "flair", table: "Soul",
+    records: [{ id, agentId, key, value, durability: "permanent", createdAt: now, updatedAt: now }],
+  });
+  expect(res.status, `soul seed ${id} returned ${res.status}`).toBe(200);
+  return id;
+}
+
+async function write(
+  harper: HarperInstance, agent: TestAgent, method: string, path: string, body?: unknown,
+): Promise<Response> {
+  return fetch(`${harper.httpURL}${path}`, {
+    method,
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: ed25519Header(agent, method, path),
+    },
+    ...(body === undefined ? {} : { body: JSON.stringify(body) }),
+  });
+}
+
+let harper: HarperInstance;
+const victim = mkAgent("soul-victim");
+const attacker = mkAgent("soul-attacker");
+
+describe("Soul writes are owner-scoped on every mutating verb", () => {
+  beforeAll(async () => {
+    harper = await startHarper();
+    const now = new Date().toISOString();
+    for (const a of [victim, attacker]) {
+      const res = await adminOp(harper, {
+        operation: "insert", database: "flair", table: "Agent",
+        records: [{ id: a.id, name: a.id, role: "agent", admin: false, publicKey: a.publicKey, createdAt: now }],
+      });
+      expect(res.status, `agent seed ${a.id} returned ${res.status}`).toBe(200);
+    }
+  }, 180_000);
+
+  afterAll(async () => { if (harper) await stopHarper(harper); });
+
+  // ── POSITIVE CONTROL ──────────────────────────────────────────────────────
+  // Without these, every "denied" assertion below would pass just as happily if
+  // the fix had simply broken Soul writes outright.
+  describe("positive control — an agent can still write its OWN soul", () => {
+    test("PUT to its own soul entry succeeds and persists", async () => {
+      const key = `own-put-${randomUUID().slice(0, 6)}`;
+      const id = `${victim.id}:${key}`;
+      const res = await write(harper, victim, "PUT", `/Soul/${encodeURIComponent(id)}`, {
+        id, agentId: victim.id, key, value: "self-authored", durability: "permanent",
+        createdAt: new Date().toISOString(),
+      });
+      expect(res.status, `own PUT returned ${res.status}: ${await res.text()}`).toBeLessThan(300);
+      expect((await rawSoul(harper, id))?.value).toBe("self-authored");
+    }, 30_000);
+
+    test("PATCH to its own soul entry succeeds and persists", async () => {
+      const id = await seedSoul(harper, victim.id, `own-patch-${randomUUID().slice(0, 6)}`, "before");
+      const res = await write(harper, victim, "PATCH", `/Soul/${encodeURIComponent(id)}`, { value: "after" });
+      expect(res.status, `own PATCH returned ${res.status}: ${await res.text()}`).toBeLessThan(300);
+      expect((await rawSoul(harper, id))?.value).toBe("after");
+    }, 30_000);
+
+    test("an admin may still write another principal's soul", async () => {
+      const id = await seedSoul(harper, victim.id, `admin-write-${randomUUID().slice(0, 6)}`, "before");
+      const res = await fetch(`${harper.opsURL}`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: "Basic " + btoa(`${harper.admin.username}:${harper.admin.password}`),
+        },
+        body: JSON.stringify({
+          operation: "upsert", database: "flair", table: "Soul",
+          records: [{ id, agentId: victim.id, key: "admin-write", value: "by-admin", durability: "permanent" }],
+        }),
+      });
+      expect(res.status).toBe(200);
+      expect((await rawSoul(harper, id))?.value).toBe("by-admin");
+    }, 30_000);
+  });
+
+  // ── Hole 1: the verb list ────────────────────────────────────────────────
+  describe("cross-agent writes are refused on every mutating verb", () => {
+    test("PATCH another agent's soul entry is refused", async () => {
+      const id = await seedSoul(harper, victim.id, `x-patch-${randomUUID().slice(0, 6)}`, "original");
+      const res = await write(harper, attacker, "PATCH", `/Soul/${encodeURIComponent(id)}`, { value: "TAMPERED" });
+      expect(res.status, `cross-agent PATCH returned ${res.status}`).toBe(403);
+      expect((await rawSoul(harper, id))?.value, "value was overwritten despite the refusal").toBe("original");
+    }, 30_000);
+
+    test("DELETE another agent's soul entry is refused", async () => {
+      const id = await seedSoul(harper, victim.id, `x-del-${randomUUID().slice(0, 6)}`, "original");
+      const res = await write(harper, attacker, "DELETE", `/Soul/${encodeURIComponent(id)}`);
+      expect(res.status, `cross-agent DELETE returned ${res.status}`).toBe(403);
+      expect(await rawSoul(harper, id), "record was deleted despite the refusal").toBeTruthy();
+    }, 30_000);
+  });
+
+  // ── Hole 2: what the guard compared ──────────────────────────────────────
+  // The body-only check denied a PRESENT, mismatched agentId. Omitting the
+  // field entirely was compared against nothing.
+  describe("a body that omits agentId does not bypass the ownership check", () => {
+    test("PUT another agent's soul entry WITHOUT agentId in the body is refused", async () => {
+      const id = await seedSoul(harper, victim.id, `x-put-noattr-${randomUUID().slice(0, 6)}`, "original");
+      const res = await write(harper, attacker, "PUT", `/Soul/${encodeURIComponent(id)}`, {
+        id, key: "x", value: "TAMPERED", durability: "permanent", createdAt: new Date().toISOString(),
+      });
+      expect(res.status, `cross-agent PUT (no agentId) returned ${res.status}`).toBe(403);
+      expect((await rawSoul(harper, id))?.value, "value was overwritten despite the refusal").toBe("original");
+    }, 30_000);
+
+    test("PATCH another agent's soul entry WITHOUT agentId in the body is refused", async () => {
+      const id = await seedSoul(harper, victim.id, `x-patch-noattr-${randomUUID().slice(0, 6)}`, "original");
+      const res = await write(harper, attacker, "PATCH", `/Soul/${encodeURIComponent(id)}`, { value: "TAMPERED" });
+      expect(res.status, `cross-agent PATCH (no agentId) returned ${res.status}`).toBe(403);
+      expect((await rawSoul(harper, id))?.value).toBe("original");
+    }, 30_000);
+
+    test("a forged, PRESENT agentId is still refused (the original rule still holds)", async () => {
+      const id = await seedSoul(harper, victim.id, `x-forge-${randomUUID().slice(0, 6)}`, "original");
+      const res = await write(harper, attacker, "PUT", `/Soul/${encodeURIComponent(id)}`, {
+        id, agentId: victim.id, key: "x", value: "TAMPERED", durability: "permanent",
+        createdAt: new Date().toISOString(),
+      });
+      expect(res.status, `cross-agent PUT (forged agentId) returned ${res.status}`).toBe(403);
+      expect((await rawSoul(harper, id))?.value).toBe("original");
+    }, 30_000);
+  });
+});

--- a/test/unit/agent-admin.test.ts
+++ b/test/unit/agent-admin.test.ts
@@ -1,0 +1,130 @@
+// agent-admin.test.ts — flair#941. The shared admin predicate and the write
+// reconciliation that makes a contradictory Agent record unrepresentable
+// through any flair write path.
+//
+// These are the assertions that matter for a field-truth fix:
+//   - ONE predicate, so no two surfaces can answer "is this an admin?"
+//     differently for the same record;
+//   - the predicate does NOT widen — a record carrying only the `admin` mirror
+//     is not an administrator, exactly as before;
+//   - reconciliation is idempotent and total, so a write cannot store a
+//     disagreement whichever field the caller used.
+import { describe, it, expect } from "bun:test";
+import {
+  ADMIN_ROLE,
+  adminFieldsDisagree,
+  agentRecordIsAdmin,
+  reconcileAdminFields,
+} from "../../resources/agent-admin.js";
+
+describe("agentRecordIsAdmin — the one predicate", () => {
+  it("role:\"admin\" is an administrator", () => {
+    expect(agentRecordIsAdmin({ role: "admin" })).toBe(true);
+    expect(agentRecordIsAdmin({ role: ADMIN_ROLE, admin: true })).toBe(true);
+    // The authority stands on its own — a stale mirror does not revoke.
+    expect(agentRecordIsAdmin({ role: "admin", admin: false })).toBe(true);
+  });
+
+  it("the `admin` mirror ALONE does not grant — this is the no-widening property", () => {
+    // The record `flair principal add --admin` used to produce. It has never
+    // been an administrator at the gate, and this fix must not make it one.
+    expect(agentRecordIsAdmin({ admin: true })).toBe(false);
+    expect(agentRecordIsAdmin({ admin: true, role: "agent" })).toBe(false);
+    expect(agentRecordIsAdmin({ admin: true, role: "researcher" })).toBe(false);
+  });
+
+  it("ordinary and absent records are not administrators", () => {
+    expect(agentRecordIsAdmin({ role: "agent", admin: false })).toBe(false);
+    expect(agentRecordIsAdmin({})).toBe(false);
+    expect(agentRecordIsAdmin(null)).toBe(false);
+    expect(agentRecordIsAdmin(undefined)).toBe(false);
+  });
+
+  it("the admin sentinel is exact — no trimming, no case folding, no prefix match", () => {
+    // `role` is free text on a public roster; a near-miss must not grant.
+    for (const role of ["Admin", "ADMIN", " admin", "admin ", "administrator", "admins", "superadmin"]) {
+      expect(agentRecordIsAdmin({ role })).toBe(false);
+    }
+  });
+
+  it("is not fooled by a non-string role that coerces", () => {
+    expect(agentRecordIsAdmin({ role: true })).toBe(false);
+    expect(agentRecordIsAdmin({ role: 1 })).toBe(false);
+    expect(agentRecordIsAdmin({ role: ["admin"] })).toBe(false);
+    expect(agentRecordIsAdmin({ role: { toString: () => "admin" } })).toBe(false);
+  });
+});
+
+describe("reconcileAdminFields — a write cannot store a disagreement", () => {
+  it("role:\"admin\" carries the mirror with it", () => {
+    const out = reconcileAdminFields({ id: "a", role: "admin" });
+    expect(out.role).toBe("admin");
+    expect(out.admin).toBe(true);
+    expect(adminFieldsDisagree(out)).toBe(false);
+  });
+
+  it("admin:true carries the AUTHORITY with it — this is what makes --admin work", () => {
+    const out = reconcileAdminFields({ id: "a", admin: true });
+    expect(out.role).toBe("admin");
+    expect(out.admin).toBe(true);
+    expect(agentRecordIsAdmin(out)).toBe(true);
+  });
+
+  it("repairs a record that arrived contradictory, in both directions", () => {
+    expect(adminFieldsDisagree(reconcileAdminFields({ role: "admin", admin: false }))).toBe(false);
+    expect(adminFieldsDisagree(reconcileAdminFields({ role: "agent", admin: true }))).toBe(false);
+  });
+
+  it("an ordinary write comes out non-admin with its free-text role intact", () => {
+    const out = reconcileAdminFields({ id: "a", role: "researcher" });
+    expect(out.role).toBe("researcher");
+    expect(out.admin).toBe(false);
+    expect(agentRecordIsAdmin(out)).toBe(false);
+  });
+
+  it("defaults the mirror when neither field was supplied", () => {
+    const out = reconcileAdminFields({ id: "a", name: "a" });
+    expect(out.admin).toBe(false);
+    expect(agentRecordIsAdmin(out)).toBe(false);
+  });
+
+  it("admin:false does NOT demote an explicit admin role — the authority wins", () => {
+    const out = reconcileAdminFields({ role: "admin", admin: false });
+    expect(out.admin).toBe(true);
+    expect(agentRecordIsAdmin(out)).toBe(true);
+  });
+
+  it("is idempotent", () => {
+    for (const input of [{ role: "admin" }, { admin: true }, { role: "x" }, {}]) {
+      const once = reconcileAdminFields({ ...input });
+      const twice = reconcileAdminFields({ ...once });
+      expect(twice).toEqual(once);
+    }
+  });
+
+  it("only truthy-BOOLEAN admin requests admin — a truthy non-boolean does not escalate", () => {
+    // Guards against a JSON body sending admin:"false" or admin:1 and being
+    // read as a grant.
+    for (const admin of ["true", "false", 1, "yes", {}] as any[]) {
+      const out = reconcileAdminFields({ id: "a", admin });
+      expect(agentRecordIsAdmin(out)).toBe(false);
+      expect(out.admin).toBe(false);
+    }
+  });
+});
+
+describe("adminFieldsDisagree — reporting only", () => {
+  it("flags exactly the records a raw write can leave inconsistent", () => {
+    expect(adminFieldsDisagree({ role: "admin", admin: true })).toBe(false);
+    expect(adminFieldsDisagree({ role: "agent", admin: false })).toBe(false);
+    expect(adminFieldsDisagree({ role: "admin", admin: false })).toBe(true);
+    expect(adminFieldsDisagree({ role: "agent", admin: true })).toBe(true);
+    // absent mirror on an admin record is still a disagreement worth surfacing
+    expect(adminFieldsDisagree({ role: "admin" })).toBe(true);
+  });
+
+  it("does not flag ordinary records with no admin fields at all", () => {
+    expect(adminFieldsDisagree({ id: "a" })).toBe(false);
+    expect(adminFieldsDisagree(null)).toBe(false);
+  });
+});

--- a/test/unit/internal-verdict-warning.test.ts
+++ b/test/unit/internal-verdict-warning.test.ts
@@ -1,0 +1,88 @@
+// internal-verdict-warning.test.ts — flair#936.
+//
+// A resource invoked with no caller context resolves to flair's trusted
+// `internal` verdict: reads unfiltered across every agent, writes unattributed,
+// and the admin-only gate passes. That is correct for flair's own maintenance
+// work and a silent, invisible mistake in an embedding application — both spell
+// it `new Memory()`, and neither produces an error.
+//
+// The verdict is deliberately UNCHANGED here; ~40 assertions across the suite
+// pin it, and altering it is a breaking change to every internal call site.
+// What changes is that it is no longer silent: a call that MEANS to take that
+// authority says so with internalContext(), and anything else warns once.
+//
+// ── Why this pins the PREDICATE and not the console output ──────────────────
+// The warning is latched once per process. bun shares one module registry
+// across the whole run, so whichever test file resolves a context-less call
+// first consumes that latch — and every later assertion on "did it warn?" then
+// passes for the wrong reason. An earlier draft of this file did exactly that:
+// green on its own, red in the full suite. A test whose result depends on file
+// ordering is not pinning anything, so the decision is exported and asserted
+// directly.
+import { mock, describe, it, expect } from "bun:test";
+
+mock.module("harper", () => ({
+  databases: { flair: { Agent: { get: async () => null, search: async function* () {} } } },
+  Resource: class {},
+}));
+
+const { resolveAgentAuth, isDeliberateInternalCall, INTERNAL_BY_OMISSION_WARNING } =
+  await import("../../resources/agent-auth.ts");
+import { internalContext, agentContext, adminContext } from "../../resources/in-process.ts";
+
+describe("flair#936 — a deliberate elevated call is distinguishable from a forgotten one", () => {
+  it("internalContext() is recognised as deliberate", () => {
+    expect(isDeliberateInternalCall(internalContext())).toBe(true);
+  });
+
+  it("every way of ARRIVING at internal by accident is recognised as NOT deliberate", () => {
+    // These are exactly the shapes that reach the `internal` verdict without
+    // anyone having asked for it: no context at all, and a context carrying no
+    // annotations, no user and no headers.
+    for (const ctx of [undefined, null, {}, { request: {} }, { request: { tpsAgent: undefined } }]) {
+      expect(isDeliberateInternalCall(ctx), `treated ${JSON.stringify(ctx) ?? String(ctx)} as deliberate`).toBe(false);
+    }
+  });
+
+  it("the marker cannot be faked by a truthy value — only the exact boolean counts", () => {
+    for (const v of ["true", 1, {}, [], "yes"] as any[]) {
+      expect(isDeliberateInternalCall({ request: {}, __flairInternal: v })).toBe(false);
+    }
+  });
+
+  it("scoped and admin contexts are not treated as deliberate-internal", () => {
+    // They never reach the internal verdict at all, so they must not carry the
+    // marker either — otherwise a future refactor could silence a real warning.
+    expect(isDeliberateInternalCall(agentContext("planner"))).toBe(false);
+    expect(isDeliberateInternalCall(adminContext("root"))).toBe(false);
+  });
+
+  it("the advisory names the hazard AND the remedy", () => {
+    // An error must enable a response: say what happened and what to do next.
+    expect(INTERNAL_BY_OMISSION_WARNING).toContain("[flair-auth]");
+    expect(INTERNAL_BY_OMISSION_WARNING).toContain("UNFILTERED");
+    expect(INTERNAL_BY_OMISSION_WARNING).toContain("agentContext");
+    expect(INTERNAL_BY_OMISSION_WARNING).toContain("internalContext");
+  });
+});
+
+describe("flair#936 — the verdict itself is unchanged", () => {
+  it("a context-less call still resolves to internal", async () => {
+    expect(await resolveAgentAuth(undefined)).toEqual({ kind: "internal" });
+    expect(await resolveAgentAuth(null)).toEqual({ kind: "internal" });
+  });
+
+  it("an annotation-free context object still resolves to internal", async () => {
+    expect(await resolveAgentAuth({})).toEqual({ kind: "internal" });
+    expect(await resolveAgentAuth({ request: {} })).toEqual({ kind: "internal" });
+  });
+
+  it("a deliberate internalContext() resolves to internal, same as before", async () => {
+    expect(await resolveAgentAuth(internalContext())).toEqual({ kind: "internal" });
+  });
+
+  it("a scoped context is unaffected", async () => {
+    expect(await resolveAgentAuth(agentContext("planner")))
+      .toEqual({ kind: "agent", agentId: "planner", isAdmin: false });
+  });
+});

--- a/test/unit/mcp-handler.test.ts
+++ b/test/unit/mcp-handler.test.ts
@@ -209,9 +209,21 @@ describe("resolveAgentFromSub", () => {
 
   it("admin Agent record → isAdmin true", async () => {
     credentials = [{ principalId: "agt_admin", kind: "idp", idpSubject: "sub-admin", status: "active" }];
-    agents["agt_admin"] = { id: "agt_admin", admin: true };
+    agents["agt_admin"] = { id: "agt_admin", role: "admin", admin: true };
     const agent = await resolveAgentFromSub("sub-admin");
     expect(agent).toEqual({ agentId: "agt_admin", isAdmin: true });
+  });
+
+  // flair#941 — this surface used to OR the two admin fields together while the
+  // primary HTTP gate read only `role`, so the SAME record was an administrator
+  // here and an ordinary agent there. Both now resolve through the one shared
+  // predicate. A record carrying only the `admin` mirror was never an admin on
+  // the HTTP gate, and is no longer one here either.
+  it("a record carrying ONLY the admin mirror is NOT an admin — both surfaces agree", async () => {
+    credentials = [{ principalId: "agt_mirror", kind: "idp", idpSubject: "sub-mirror", status: "active" }];
+    agents["agt_mirror"] = { id: "agt_mirror", admin: true };
+    const agent = await resolveAgentFromSub("sub-mirror");
+    expect(agent).toEqual({ agentId: "agt_mirror", isAdmin: false });
   });
 
   it("revoked Credential is skipped", async () => {


### PR DESCRIPTION
Closes #941. Closes #936.

## Summary

Three authorization fixes plus one observability change. Two of the three are security fixes an operator should read before deciding how urgently to upgrade.

**Upgrade to the rev carrying this when it lands.** Anyone running an instance where agents are registered by parties who should not be administrators — in particular with IdP/OAuth just-in-time provisioning enabled — should treat that as prompt rather than routine.

---

## 1. Any verified agent could grant itself administrator (#941)

**What was wrong.** The `Agent` (Principal) resource enforced its per-record rules in `put()`: only an administrator may modify a principal other than itself. `allowUpdate()` is `allowVerified()`, so the only check any *other* write verb met was "are you some verified agent". Harper routes `PATCH` to `patch()`, which had no override — so a verified non-admin agent could `PATCH` its own principal record to set the admin role, and could also modify other principals' records.

That is escalation from "holds a registered keypair" to "administrator", which is the exact boundary the admin tier exists to draw. It requires nothing beyond an ordinary registered agent.

**What changed.** Both write verbs now share one authorization helper, enforcing two rules on every verb: only an administrator may modify a principal other than itself, and only an administrator may change any principal's admin status — including its own. In-process maintenance and administrators are unaffected.

**How this was found, because it is why the fix is correct rather than plausible.** The first diagnosis was that this was reachable by `PUT`. It is not: `put()` deletes `publicKey` and `createdAt` to protect them, both are non-nullable in the schema, so **every `PUT /Agent/<id>` returns 400** — that endpoint has been unusable, which is a separate bug worth its own issue. The `PUT`-based test written against that theory passed for the wrong reason. Probing the actually-reachable verbs against a real instance is what found `PATCH`. An inferred vulnerability and a demonstrated one are different things, and only the second tells you which line to change.

## 2. One meaning, two fields, and the wrong one was wired up (#941)

**What was wrong.** A principal record carries two fields that both read as "is this an administrator":

| field | written by | read for an authorization decision by |
| --- | --- | --- |
| `role` (admin when `"admin"`) | only agent seeding | `isAdmin()` — the gate behind every admin-only resource |
| `admin` (boolean) | everything else, incl. `principal add --admin` | only the native MCP surface |

The field the product wrote and displayed was not the field the gate read. So `flair principal add --admin` stored a value nothing consults and **granted nothing**, with no error. In the other direction, a seeded administrator — which sets `role` and not the mirror — was a real administrator that `flair principal show` and the admin dashboard both reported as an ordinary agent. Both failures are silent, and one of them flatters the operator.

**What changed.** `role` remains the authority, so **no existing principal's rights change**. `admin` becomes a server-maintained mirror: write either field through any flair write path and both are set, so a record can no longer be stored asserting one thing in one field and the opposite in the other. Every surface that decides or displays admin status resolves through one shared predicate (`resources/agent-admin.ts`).

**Why not make `admin` the authority**, given it is the better-shaped field — typed, indexed, already used by every creation path and every UI? Because that would *grant* gate admin to every record `principal add --admin` has produced, none of which has ever been an administrator. That is a widening of live access as a side effect of a naming fix, decided by data nobody has audited. It is a deliberate privilege migration and belongs in its own change with its own audit.

**Records already carrying a mismatch** are not rewritten and no migration runs; rights are unchanged in both directions. What changes is that `principal show`, `principal list` and the admin dashboard report the status the gate will actually apply, and flag an inconsistent record instead of silently picking a side. Re-issuing the grant repairs it.

Two consequences worth calling out:

- The public presence roster (readable unauthenticated) included `role`, the field denoting an administrator — publishing the list of privileged accounts. Admins now render there as ordinary agents; nothing authorizes on that field.
- Admin lookups are cached 60s, so a grant appeared not to work for up to a minute. The write path now drops the cached set, so a promotion applies on the next request. The cache is per worker thread, so a grant applied on one thread can still take up to 60s to be seen on another — that bound is unchanged, and the changelog says so.

## 3. Soul entries could be rewritten or deleted by any verified agent

**What was wrong.** Only a principal (or an administrator) may write its own soul entries. The guard enforcing that had two independent gaps, either one sufficient on its own:

1. **The verb list** ran on `PUT` and `POST`. Its three siblings in the same block all include `PATCH`, and one includes `DELETE`; this one did neither. Measured before the fix: a cross-agent `PATCH` returned 204 with the value overwritten, and a cross-agent `DELETE` returned 200 with the record gone.
2. **What it compared** was the `agentId` in the request *body* — the owner the caller claims — denying only when that field was present and mismatched. A body omitting it, which a partial write naturally does, was compared against nothing and passed whatever record the URL named.

Closing one gap leaves the other reachable through the remaining verbs.

**What changed.** Both closed. The guard runs on every mutating verb and resolves ownership from the stored record named in the path — the same shape as the `Memory` ownership guard directly below it, which already had it right. Writing your own soul is unchanged; administrators are unaffected.

Confirmed the omission was an oversight rather than a deliberate exemption before relying on that reading: it dates from the original guards commit, no comment justifies it, it is inconsistent with its own neighbours, and nothing in the product issues a `PATCH` to that route.

## 4. A context-less resource call is no longer silent (#936)

Constructing a resource with no caller context resolves to the trusted `internal` verdict and runs unfiltered — every read unscoped, every write unattributed. Correct for flair's own maintenance work, and an invisible mistake in an embedding application; both spell it the same way and neither produces an error.

**The verdict is unchanged** — this is observability, not an authorization change. A call that means to take that authority declares it with `internalContext()` and stays silent; anything else logs once per process with the stack.

Two measurements shaped the scope. Flair has **no** in-process caller relying on the omission — every maintenance, migration, federation and boot path uses the raw table accessor, which bypasses the resolver entirely — so there was no call-site conversion to do. And the in-process seam shipped in 0.31.0 closed the *create* path but not the others: direct construction still reaches the verdict, and so does a static read with the context argument omitted when it runs outside a request scope — on which path the resource's own gate is never consulted at all. The seam's docstring and the embedding guide both said "reads do not need this"; corrected, because reads do not need the *collection binding* but do still need the *context*.

---

## Verification

Full suite **4325 pass / 17 fail / 8 errors**, against a baseline measured on unmodified `main` in a separate worktree: **4282 / 17 / 8**. **+43 passing, identical failure set, no regressions.** The pre-existing failures are unrelated — workspace package resolution, and one recall test that degrades only under full-suite concurrency.

Every fix is pinned by a test that fails without it, and **each was mutation-checked in both directions** — break the fix, confirm the test fails; restore, confirm green:

| mutation | mutated | restored |
| --- | --- | --- |
| admin predicate widened to OR | 2 fail | 15 pass |
| agent-seed reconciliation removed | 1 fail | 1 pass |
| `patch()` override removed | 3 fail | 4 pass |
| admin-cache invalidation removed | 1 fail | 1 pass |
| roster admin mask removed | 1 fail | 1 pass |
| MCP OR-behaviour restored | 1 fail | 1 pass |
| **admin broken entirely (positive control)** | **1 fail** | **1 pass** |
| soul verb list reverted *only* | 3 fail | 8 pass |
| soul record lookup reverted *only* | 4 fail | 8 pass |
| **all non-admin soul writes blocked (positive control)** | **2 fail** | **3 pass** |
| internal-marker check loosened to truthy | 1 fail | 9 pass |
| remedy stripped from the advisory | 1 fail | 9 pass |

The bold rows are **positive controls**: they prove a legitimately-admin principal still passes the admin gate, and that an agent can still write its own soul. Without them, every "denied" assertion would pass just as happily if the change had broken admin or Soul writes outright. The two Soul rows are deliberately independent — neither half of that fix is load-bearing alone.

Two of my own tests were caught being weak and rewritten: a roster assertion that would have passed on an empty roster, and a warning test that passed alone and failed in the full suite because the once-per-process latch is shared across the run. A test that passes both ways is not a test.

## Reviewing

The three concerns are separable, one commit each. `resources/agent-admin.ts` carries the reasoning for the authority choice and for what happens to records already carrying a mismatch.
