### PR TITLE
in-process-api: public Flair facade for embedded Harper apps

### DIFF
--- a/.changelog/unreleased/added-public-in-process-api.md
+++ b/.changelog/unreleased/added-public-in-process-api.md
@@ -1,0 +1,8 @@
+- **Public in-process API (`new Flair(server)`).** A facade that hides internal
+  implementation details (deep imports, `server.resources` keying, `.Resource`
+  wrapping, `collectionResource()`, double-passing `agentId`) while preserving
+  the security boundary. One handle per Harper instance, lazy resource
+  resolution, agent-scoped handles via `flair.as(id)`, admin operations via
+  `flair.admin`, and internal operations via `flair.internal`. The package now
+  has `main` and `exports` fields so `import { Flair } from "@tpsdev-ai/flair"`
+  resolves directly.

--- a/docs/embedding-in-a-harper-app.md
+++ b/docs/embedding-in-a-harper-app.md
@@ -18,88 +18,86 @@ Embedding *adds* the in-process path; `rest: true` keeps serving MCP clients and
 
 **1. Add Flair to your instance.** Deploy `@tpsdev-ai/flair` as a component the way you deploy your own — Fabric's component deploy, Studio, or your pipeline. Its tables are declared `@table(database: "flair")`, so they never collide with yours.
 
-**2. Resolve the resource and write a memory.**
+**2. Import the facade and write a memory.**
 
 ```javascript
-import { server } from "harper";
-// Flair ships these two helpers so you do not have to get either of them right
-// by hand. They are the whole in-process contract.
-import { agentContext, internalContext, collectionResource } from "@tpsdev-ai/flair/dist/resources/in-process.js";
+import { Flair } from "@tpsdev-ai/flair";
 
-// The RESOURCE — carries auth, scoping, visibility, embedding.
-// NOT databases.flair.Memory: that is the raw table, and enforces none of it.
-// Keys carry NO leading slash: get("Memory"), never get("/Memory").
-const flair = (path) => server.resources.get(path).Resource;
+const flair = new Flair(server);
+const planner = flair.as("planner");
 
-export async function remember(agentId, content, opts = {}) {
-  // A create needs a COLLECTION-bound instance. `new Cls(...)` does not give
-  // you one, and cannot be made to — see the note below.
-  const h = await collectionResource(flair("Memory"), agentContext(agentId));
-  return h.post({
-    agentId,                                // required — an absent one is never filled in
-    content,
-    durability: opts.durability ?? "standard",
-  });
-}
+await planner.memory.write("deploy runs at 0200 UTC", { durability: "standard" });
 ```
 
-> ### Why `collectionResource`, and not `new Memory()`
->
-> A resource's `post()` only works on an instance Harper has marked as a **collection**, and that mark is a *private* field only Harper's own `getResource()` can set. The public `isCollection` is a getter with no setter, so the obvious spelling fails two different ways, neither of which names the cause:
->
-> ```javascript
-> const h = new (flair("Memory"))(undefined, agentContext(agentId));
-> h.isCollection = true;   // TypeError: Cannot set property isCollection ... which has only a getter
-> h.post({ ... });         // without the line above: 405 "The Memory does not have a post method implemented"
-> ```
->
-> `collectionResource(Cls, context)` is a two-line wrapper over the supported call — `Cls.getResource({}, context, { isCollection: true })` — and exists so this is written once. **Reads do not need it:** `Cls.get(id, context)` and `Cls.search(query, context)` thread the context themselves.
->
-> They do still need the **context**. Only the collection binding is unnecessary for a read, never the identity — `Cls.search(query)` with the second argument left off resolves to the trusted `internal` verdict when it runs outside a request scope (a boot hook, a timer, a queue worker, a detached promise) and returns every agent's private records. On that path the resource's `allow*` gate is not consulted at all. Pass the context to every call, read and write.
-
-> ### ⚠️ A resource with no context is an administrator
->
-> A resource built without a context resolves to Flair's trusted `internal` verdict and runs **unfiltered** — every read unscoped, every write unowned. Silently. No error, no warning, no trace.
->
-> Measured, not inferred: a context-less `Memory.search()` returns every agent's `private` records, and so does a context-less `SemanticSearch`.
->
-> Correct for Flair's own maintenance passes. In your app it is a data leak you find months later.
->
-> **Make `agentId` a required argument, as above.** Never export a version that defaults it.
+That is the whole API. No deep import, no `server.resources`, no `.Resource`, no `collectionResource()`, no double-passing `agentId`. The facade stamps `agentId` from the handle's context onto the body internally — you pass it once, at `flair.as(id)`.
 
 **3. Read it back, scoped to that agent.**
 
 ```javascript
-export async function recall(agentId, query, limit = 5) {
-  const h = await collectionResource(flair("SemanticSearch"), agentContext(agentId));
-  return h.post({ q: query, limit });
-}
+const hits = await planner.recall("deploy schedule", { limit: 5 });
+const record = await planner.memory.get(hits[0].id);
 ```
 
-**4. Verify it worked, still in-process.**
+**4. Register an agent, no CLI.**
 
 ```javascript
-await remember("agent-alpha", "deploy runs at 0200 UTC");
-console.log(await recall("agent-alpha", "deploy schedule"));
+await flair.admin.registerAgent("planner", { publicKey: "pending" });
+```
+
+> **`flair.admin` is a root shell.** Every call site is greppable via `git grep "flair.admin"`. Use for provisioning and maintenance only, never as a request handler's default.
+
+**5. Verify it worked.**
+
+```javascript
+console.log(await planner.memory.search({ limit: 10 }));
 console.log([...server.resources.keys()].sort());   // what Flair registered
 ```
 
-> ### What we measured, so you do not have to
->
-> Run end to end on **Harper 5.1.22**, from a second component loaded into the same instance — the exact shape above. `test/integration/in-process-agents.test.ts` in the Flair repo is that run, and `test/fixtures/inproc-app` is the component it drives.
->
-> | Claim | Result |
-> |---|---|
-> | `server.resources.get("Memory")` from another component | Returns an **entry object** `{ Resource, path, exportTypes, hasSubPaths, relativeURL }` — `.Resource` is required, it is not the class itself |
-> | `.Resource` is Flair's resource, not the raw table | Confirmed: prototype chain `Memory → Memory → Resource`, and it is **not** `databases.flair.Memory` |
-> | Key format | **No leading slash.** `get("Memory")` hits; `get("/Memory")` returns `undefined` |
-> | `getMatch` | `getMatch("Memory")` hits. **`getMatch("/Memory")` misses** — do not use the slashed form |
-> | When the lookup becomes valid | Flair's resources were already registered at the app component's **module top level** (55 entries, `Memory` and `Agent` present). The only entry missing at that moment was the app's *own*, still mid-registration. Resolving lazily, as above, is still the advice — it costs nothing and does not depend on component load order |
-> | Per-agent scoping through `SemanticSearch` | Holds. Querying as `agent-beta` for a topic only `agent-alpha` has written returns **beta's own** memory, never alpha's private one — with real 768-dim embeddings attached, not a degraded path |
-> | Cross-agent by-id read | `Memory.get(<beta's private id>)` as alpha returns **404**, never 403 — a denied caller cannot enumerate ids |
-> | Context-less call | Unfiltered across all agents, via both `search` and `SemanticSearch` (see the warning above) |
+---
 
-Handlers return a `Response` for `401`/`403`/`400` rather than throwing — check for one. `Memory.post()` is in-process only; over HTTP the schema exposes `PUT`.
+## The facade
+
+### `new Flair(server)`
+
+One handle per Harper instance. Resolves resources lazily on first use — no lookup at construction time.
+
+### `flair.as(agentId)`
+
+Returns an `AgentHandle` scoped to that agent. The `agentId` is runtime-validated: missing, empty, blank, or non-string throws `InProcessContextError`.
+
+```javascript
+const planner = flair.as("planner");
+planner.agentId;  // "planner"
+```
+
+**Security:** In-process identity is asserted, not verified — co-location IS the grant. Build the `agentId` from your own server-side state, never from request data. If an agent id can reach `flair.as()` from user input — a body field, a query param, a header you did not verify yourself — that is privilege escalation with **no error, no 403 and no trace**.
+
+### `AgentHandle`
+
+| Method | Description |
+|---|---|
+| `handle.memory.write(content, opts?)` | Write a memory as this agent. `agentId` is stamped from the handle — the caller never passes it. |
+| `handle.memory.get(id)` | Read a memory by id, scoped to this agent. |
+| `handle.memory.search(opts?)` | Search memories scoped to this agent. |
+| `handle.recall(query, opts?)` | Semantic search scoped to this agent. |
+
+### `flair.admin`
+
+Admin operations — unfiltered reads, cross-agent writes. Every call site is greppable via `git grep "flair.admin"`.
+
+| Method | Description |
+|---|---|
+| `flair.admin.registerAgent(id, opts?)` | Register an agent through the Agent resource (full Principal shape). |
+| `flair.admin.memory.get(id)` | Read any memory by id, unfiltered. |
+| `flair.admin.memory.write(asAgentId, content, opts?)` | Write a memory attributed to another agent. |
+
+### `flair.internal`
+
+Trusted, unattributed, unfiltered operations — Flair's `internal` verdict. Every call site is greppable via `git grep "flair.internal"`.
+
+| Method | Description |
+|---|---|
+| `flair.internal.agentTable.put(record)` | Write directly to the Agent resource (bypasses admin gate). |
 
 ---
 
@@ -109,7 +107,8 @@ Handlers return a `Response` for `401`/`403`/`400` rather than throwing — chec
 
 ```javascript
 for (const id of ["planner", "researcher", "reviewer"]) {
-  await remember(id, `${id} came online`);
+  const agent = flair.as(id);
+  await agent.memory.write(`${id} came online`);
 }
 ```
 
@@ -117,18 +116,14 @@ for (const id of ["planner", "researcher", "reviewer"]) {
 
 ### Registering agents, no CLI
 
-Go through the `Agent` **resource**, with no context — provisioning is infrastructure work your app has already authorised, and `Agent.post()` fills in the whole Principal shape for you:
+Go through `flair.admin.registerAgent()` — it goes through the `Agent` **resource**, which fills in the whole Principal shape for you:
 
 ```javascript
-export async function registerAgent(id, { publicKey = "pending", admin = false } = {}) {
-  const h = await collectionResource(flair("Agent"), internalContext());   // provisioning is infrastructure, not an agent's write
-  return h.post({
-    id, name: id, displayName: id,
-    publicKey,                            // a placeholder is fine — see below
-    runtime: "headless",
-    ...(admin ? { admin: true } : {}),    // sets role:"admin" too — see below
-  });
-}
+await flair.admin.registerAgent("researcher", {
+  publicKey: "pending",
+  displayName: "Research Agent",
+  admin: false,
+});
 ```
 
 Verified against a real instance: that lands `kind: "agent"`, `status: "active"`, `displayName`, `admin: false`, `defaultTrustTier: "unverified"`, `type: "agent"`, `createdAt`/`updatedAt` and the federation `originatorInstanceId` stamp — without you naming any of them.
@@ -146,7 +141,7 @@ import { generateKeyPairSync } from "node:crypto";
 
 const { publicKey, privateKey } = generateKeyPairSync("ed25519");
 const raw = publicKey.export({ format: "der", type: "spki" }).subarray(-32);
-await registerAgent("remote-worker", { publicKey: raw.toString("hex") });
+await flair.admin.registerAgent("remote-worker", { publicKey: raw.toString("hex") });
 // keep `privateKey` in your own secret store — Flair never sees it
 ```
 
@@ -295,6 +290,106 @@ A `SyncLog` row reads `direction: "pull"` — the receiver's label for a push it
 | **`flair` CLI** | Pairing and key generation. Needs a shell. |
 
 **Trust-graded recall (`includeTrust`)** — provenance, author, usage, freshness, supersession — works in-process (`SemanticSearch.post({ q, includeTrust: true })`, `Memory.get(id, { includeTrust: true })`), over REST, and on the native `/mcp` handler. It is **not** exposed by the CLI, the stdio MCP server, or `FlairClient`'s typed methods.
+
+---
+
+## Appendix: the primitives layer
+
+The facade wraps a lower-level API that is still available for callers who need direct access. Import it from `@tpsdev-ai/flair/server`:
+
+```javascript
+import { agentContext, adminContext, internalContext, collectionResource } from "@tpsdev-ai/flair/server";
+```
+
+This is the same seam Flair's own MCP handler and internal tooling use. You should not need it for ordinary agent operations — the facade covers those. Use the primitives when you are building your own abstraction on top of Flair's resources.
+
+### Resolving a resource
+
+```javascript
+// The RESOURCE — carries auth, scoping, visibility, embedding.
+// NOT databases.flair.Memory: that is the raw table, and enforces none of it.
+// Keys carry NO leading slash: get("Memory"), never get("/Memory").
+const flair = (path) => server.resources.get(path).Resource;
+```
+
+### Writing a memory (primitives)
+
+```javascript
+export async function remember(agentId, content, opts = {}) {
+  // A create needs a COLLECTION-bound instance. `new Cls(...)` does not give
+  // you one, and cannot be made to — see the note below.
+  const h = await collectionResource(flair("Memory"), agentContext(agentId));
+  return h.post({
+    agentId,                                // required — an absent one is never filled in
+    content,
+    durability: opts.durability ?? "standard",
+  });
+}
+```
+
+> ### Why `collectionResource`, and not `new Memory()`
+>
+> A resource's `post()` only works on an instance Harper has marked as a **collection**, and that mark is a *private* field only Harper's own `getResource()` can set. The public `isCollection` is a getter with no setter, so the obvious spelling fails two different ways, neither of which names the cause:
+>
+> ```javascript
+> const h = new (flair("Memory"))(undefined, agentContext(agentId));
+> h.isCollection = true;   // TypeError: Cannot set property isCollection ... which has only a getter
+> h.post({ ... });         // without the line above: 405 "The Memory does not have a post method implemented"
+> ```
+>
+> `collectionResource(Cls, context)` is a two-line wrapper over the supported call — `Cls.getResource({}, context, { isCollection: true })` — and exists so this is written once. **Reads do not need it:** `Cls.get(id, context)` and `Cls.search(query, context)` thread the context themselves.
+>
+> They do still need the **context**. Only the collection binding is unnecessary for a read, never the identity — `Cls.search(query)` with the second argument left off resolves to the trusted `internal` verdict when it runs outside a request scope (a boot hook, a timer, a queue worker, a detached promise) and returns every agent's private records. On that path the resource's `allow*` gate is not consulted at all. Pass the context to every call, read and write.
+
+> ### ⚠️ A resource with no context is an administrator
+>
+> A resource built without a context resolves to Flair's trusted `internal` verdict and runs **unfiltered** — every read unscoped, every write unowned. Silently. No error, no warning, no trace.
+>
+> Measured, not inferred: a context-less `Memory.search()` returns every agent's `private` records, and so does a context-less `SemanticSearch`.
+>
+> Correct for Flair's own maintenance passes. In your app it is a data leak you find months later.
+>
+> **Make `agentId` a required argument, as above.** Never export a version that defaults it.
+
+### Reading back (primitives)
+
+```javascript
+export async function recall(agentId, query, limit = 5) {
+  const h = await collectionResource(flair("SemanticSearch"), agentContext(agentId));
+  return h.post({ q: query, limit });
+}
+```
+
+### Registering agents (primitives)
+
+```javascript
+export async function registerAgent(id, { publicKey = "pending", admin = false } = {}) {
+  const h = await collectionResource(flair("Agent"), internalContext());   // provisioning is infrastructure, not an agent's write
+  return h.post({
+    id, name: id, displayName: id,
+    publicKey,                            // a placeholder is fine — see below
+    runtime: "headless",
+    ...(admin ? { admin: true } : {}),    // sets role:"admin" too — see below
+  });
+}
+```
+
+### What we measured, so you do not have to
+
+Run end to end on **Harper 5.1.22**, from a second component loaded into the same instance — the exact shape above. `test/integration/in-process-agents.test.ts` in the Flair repo is that run, and `test/fixtures/inproc-app` is the component it drives.
+
+| Claim | Result |
+|---|---|
+| `server.resources.get("Memory")` from another component | Returns an **entry object** `{ Resource, path, exportTypes, hasSubPaths, relativeURL }` — `.Resource` is required, it is not the class itself |
+| `.Resource` is Flair's resource, not the raw table | Confirmed: prototype chain `Memory → Memory → Resource`, and it is **not** `databases.flair.Memory` |
+| Key format | **No leading slash.** `get("Memory")` hits; `get("/Memory")` returns `undefined` |
+| `getMatch` | `getMatch("Memory")` hits. **`getMatch("/Memory")` misses** — do not use the slashed form |
+| When the lookup becomes valid | Flair's resources were already registered at the app component's **module top level** (55 entries, `Memory` and `Agent` present). The only entry missing at that moment was the app's *own*, still mid-registration. Resolving lazily, as above, is still the advice — it costs nothing and does not depend on component load order |
+| Per-agent scoping through `SemanticSearch` | Holds. Querying as `agent-beta` for a topic only `agent-alpha` has written returns **beta's own** memory, never alpha's private one — with real 768-dim embeddings attached, not a degraded path |
+| Cross-agent by-id read | `Memory.get(<beta's private id>)` as alpha returns **404**, never 403 — a denied caller cannot enumerate ids |
+| Context-less call | Unfiltered across all agents, via both `search` and `SemanticSearch` (see the warning above) |
+
+Handlers return a `Response` for `401`/`403`/`400` rather than throwing — check for one. `Memory.post()` is in-process only; over HTTP the schema exposes `PUT`.
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
   "main": "./dist/resources/in-process-api.js",
   "exports": {
     ".": "./dist/resources/in-process-api.js",
-    "./server": "./dist/resources/in-process.js"
+    "./server": "./dist/resources/in-process.js",
+    "./package.json": "./package.json"
   },
   "bin": {
     "flair": "dist/cli-shim.cjs"

--- a/package.json
+++ b/package.json
@@ -25,6 +25,11 @@
     "llm",
     "openclaw"
   ],
+  "main": "./dist/resources/in-process-api.js",
+  "exports": {
+    ".": "./dist/resources/in-process-api.js",
+    "./server": "./dist/resources/in-process.js"
+  },
   "bin": {
     "flair": "dist/cli-shim.cjs"
   },

--- a/resources/in-process-api.ts
+++ b/resources/in-process-api.ts
@@ -1,0 +1,472 @@
+/**
+ * ─── Public in-process API (flair#956) ───────────────────────────────────────
+ *
+ * The facade that hides four internal implementation details a Harper engineer
+ * should never have to learn:
+ *
+ *   1. A deep import path into our dist/
+ *   2. That server.resources is keyed by REST path with no leading slash
+ *   3. That the registry entry wraps the class in .Resource
+ *   4. That creates need collectionResource() while reads do not
+ *
+ * And collapses the agentId double-pass (context + body) into one.
+ *
+ * ```ts
+ * import { Flair } from "@tpsdev-ai/flair";
+ * const flair = new Flair(server);
+ * const planner = flair.as("planner");
+ * await planner.memory.write("deploy runs at 0200 UTC");
+ * ```
+ *
+ * The facade does NOT hide the security boundary. In-process identity is
+ * asserted, not verified — co-location IS the grant. flair.as(id) requires a
+ * non-empty id (runtime throw). flair.admin and flair.internal are separate,
+ * greppable properties. The docs say plainly: build the context from your own
+ * server-side state, never from request data.
+ *
+ * ── Internal implementation ─────────────────────────────────────────────────
+ * Every operation delegates to the existing primitives in ./in-process.js
+ * (agentContext, adminContext, internalContext, collectionResource). The facade
+ * is additive — existing code using the raw seam continues to work.
+ */
+
+import type { Server } from "harper";
+import {
+  agentContext,
+  adminContext,
+  internalContext,
+  collectionResource,
+  InProcessContextError,
+  type CallContext,
+} from "./in-process.js";
+
+// ─── Re-export for the "./server" entry point ────────────────────────────────
+export { agentContext, adminContext, internalContext, collectionResource, InProcessContextError };
+export type { CallContext };
+
+// ─── Types ───────────────────────────────────────────────────────────────────
+
+export interface MemoryWriteOptions {
+  durability?: "standard" | "persistent" | "permanent" | "ephemeral";
+  visibility?: "private" | "shared";
+  tags?: string[];
+  type?: string;
+  id?: string;
+}
+
+export interface MemorySearchOptions {
+  tags?: string[];
+  limit?: number;
+  type?: string;
+  durability?: string;
+  visibility?: string;
+  since?: string;
+  asOf?: string;
+}
+
+export interface RecallOptions {
+  limit?: number;
+  includeTrust?: boolean;
+  abstain?: boolean;
+  scoring?: "raw" | "composite";
+  minScore?: number;
+  since?: string;
+  asOf?: string;
+  tag?: string;
+  subject?: string;
+  subjects?: string[];
+}
+
+export interface RegisterAgentOptions {
+  publicKey?: string;
+  displayName?: string;
+  runtime?: string;
+  admin?: boolean;
+}
+
+export interface MemoryRecord {
+  id: string;
+  agentId: string;
+  content: string;
+  durability: string;
+  visibility: string;
+  createdAt: string;
+  updatedAt: string;
+  [key: string]: unknown;
+}
+
+export interface SearchResult {
+  id: string;
+  content: string;
+  score: number;
+  agentId: string;
+  [key: string]: unknown;
+}
+
+// ─── Resource resolution ─────────────────────────────────────────────────────
+
+/**
+ * Resolve a Flair resource class from the Harper server registry.
+ * Throws with a helpful message listing available resources if not found.
+ */
+function resolveResource(server: Server, name: string): any {
+  const entry = (server.resources as any).get?.(name) ?? server.resources.getMatch?.(name);
+  if (!entry?.Resource) {
+    const keys = [...(server.resources as any).keys()].sort();
+    const available = keys.length > 0 ? keys.join(", ") : "(none)";
+    throw new Error(
+      `Flair is not loaded in this Harper instance.\n` +
+        `The '${name}' resource was not found in the registry.\n` +
+        `Available: [${available}]\n` +
+        `Make sure @tpsdev-ai/flair is installed as a component of this instance.`,
+    );
+  }
+  return entry.Resource;
+}
+
+// ─── AgentHandle ─────────────────────────────────────────────────────────────
+
+/**
+ * A handle that carries agent identity and scopes every operation to that agent.
+ *
+ * Returned by {@link Flair.as}. The agentId is validated at construction time
+ * (runtime, not types) — missing, empty, blank, or non-string throws
+ * {@link InProcessContextError}.
+ *
+ * **Security:** in-process identity is asserted, not verified. Build the
+ * agentId from your own server-side state, never from request data.
+ */
+export class AgentHandle {
+  readonly agentId: string;
+  #server: Server;
+  #ctx: CallContext;
+
+  constructor(server: Server, agentId: string) {
+    this.#server = server;
+    this.agentId = agentId;
+    // Throws InProcessContextError on missing/empty/blank id — see
+    // resources/in-process.ts's safety-design block for why this is
+    // not merely defensive.
+    this.#ctx = agentContext(agentId);
+  }
+
+  /** Memory operations scoped to this agent. */
+  get memory(): AgentMemory {
+    return new AgentMemory(this.#server, this.#ctx, this.agentId);
+  }
+
+  /**
+   * Semantic search scoped to this agent.
+   *
+   * ```ts
+   * const hits = await planner.recall("deploy schedule", { limit: 5 });
+   * ```
+   */
+  async recall(query: string, opts?: RecallOptions): Promise<SearchResult[]> {
+    const Cls = resolveResource(this.#server, "SemanticSearch");
+    const h = new Cls(undefined, this.#ctx);
+    const body: Record<string, unknown> = { q: query, limit: opts?.limit ?? 5 };
+    if (opts?.includeTrust === true) body.includeTrust = true;
+    if (opts?.abstain === true) body.abstain = true;
+    if (opts?.scoring) body.scoring = opts.scoring;
+    if (opts?.minScore !== undefined) body.minScore = opts.minScore;
+    if (opts?.since) body.since = opts.since;
+    if (opts?.asOf) body.asOf = opts.asOf;
+    if (opts?.tag) body.tag = opts.tag;
+    if (opts?.subject) body.subject = opts.subject;
+    if (opts?.subjects) body.subjects = opts.subjects;
+    return unwrap(await h.post(body));
+  }
+}
+
+// ─── AgentMemory (per-agent memory operations) ───────────────────────────────
+
+class AgentMemory {
+  #server: Server;
+  #ctx: CallContext;
+  #agentId: string;
+
+  constructor(server: Server, ctx: CallContext, agentId: string) {
+    this.#server = server;
+    this.#ctx = ctx;
+    this.#agentId = agentId;
+  }
+
+  /**
+   * Write a memory as this agent.
+   *
+   * The agentId is stamped from the handle's context — the caller never
+   * passes it, and any agentId in opts is overwritten. This collapses the
+   * double-pass (context + body) into one.
+   */
+  async write(content: string, opts?: MemoryWriteOptions): Promise<MemoryRecord> {
+    const Cls = resolveResource(this.#server, "Memory");
+    const h: any = await collectionResource(Cls, this.#ctx);
+    const body: Record<string, unknown> = {
+      agentId: this.#agentId,
+      content,
+    };
+    if (opts?.durability) body.durability = opts.durability;
+    if (opts?.visibility) body.visibility = opts.visibility;
+    if (opts?.tags) body.tags = opts.tags;
+    if (opts?.type) body.type = opts.type;
+    if (opts?.id) body.id = opts.id;
+    return unwrap(await h.post(body));
+  }
+
+  /** Get a memory by id, scoped to this agent. */
+  async get(id: string): Promise<MemoryRecord | null> {
+    const Cls = resolveResource(this.#server, "Memory");
+    const h = new Cls(undefined, this.#ctx);
+    return unwrap(await h.get(id));
+  }
+
+  /**
+   * Search memories scoped to this agent.
+   *
+   * Delegates to Memory.search() which applies the agent's read scope
+   * (own memories + granted owners' shared memories).
+   */
+  async search(opts?: MemorySearchOptions): Promise<MemoryRecord[]> {
+    const Cls = resolveResource(this.#server, "Memory");
+    const h = new Cls(undefined, this.#ctx);
+    const conditions: any[] = [];
+    if (opts?.tags) {
+      for (const tag of opts.tags) {
+        conditions.push({ search_attribute: "tags", search_type: "contains", search_value: tag });
+      }
+    }
+    if (opts?.type) {
+      conditions.push({ search_attribute: "type", search_type: "equals", search_value: opts.type });
+    }
+    if (opts?.durability) {
+      conditions.push({ search_attribute: "durability", search_type: "equals", search_value: opts.durability });
+    }
+    if (opts?.visibility) {
+      conditions.push({ search_attribute: "visibility", search_type: "equals", search_value: opts.visibility });
+    }
+    const query = conditions.length > 0 ? { conditions, operator: "and" } : undefined;
+    return unwrap(await h.search(query));
+  }
+}
+
+// ─── AdminHandle ─────────────────────────────────────────────────────────────
+
+/**
+ * Flair-admin operations — unfiltered reads, cross-agent writes.
+ *
+ * **This is a root shell.** Every call site is greppable via
+ * `git grep "flair.admin"`. Use for provisioning and maintenance only,
+ * never as a request handler's default.
+ *
+ * The admin agentId is validated at construction time (same guard as
+ * {@link AgentHandle}).
+ */
+export class AdminHandle {
+  readonly agentId: string;
+  #server: Server;
+  #ctx: CallContext;
+
+  constructor(server: Server, agentId: string) {
+    this.#server = server;
+    this.agentId = agentId;
+    this.#ctx = adminContext(agentId);
+  }
+
+  /**
+   * Register an agent through the Agent resource (full Principal shape).
+   *
+   * ```ts
+   * await flair.admin.registerAgent("planner", { publicKey: "pending" });
+   * ```
+   */
+  async registerAgent(id: string, opts?: RegisterAgentOptions): Promise<Record<string, unknown>> {
+    const Cls = resolveResource(this.#server, "Agent");
+    const h: any = await collectionResource(Cls, this.#ctx);
+    const body: Record<string, unknown> = {
+      id,
+      name: id,
+      displayName: opts?.displayName ?? id,
+      publicKey: opts?.publicKey ?? "pending",
+      runtime: opts?.runtime ?? "headless",
+    };
+    if (opts?.admin === true) body.admin = true;
+    return unwrap(await h.post(body));
+  }
+
+  /** Memory operations with admin authority (unfiltered reads, cross-agent writes). */
+  get memory(): AdminMemory {
+    return new AdminMemory(this.#server, this.#ctx, this.agentId);
+  }
+}
+
+// ─── AdminMemory ─────────────────────────────────────────────────────────────
+
+class AdminMemory {
+  #server: Server;
+  #ctx: CallContext;
+  #agentId: string;
+
+  constructor(server: Server, ctx: CallContext, agentId: string) {
+    this.#server = server;
+    this.#ctx = ctx;
+    this.#agentId = agentId;
+  }
+
+  /** Read any memory by id, unfiltered. */
+  async get(id: string): Promise<MemoryRecord | null> {
+    const Cls = resolveResource(this.#server, "Memory");
+    const h = new Cls(undefined, this.#ctx);
+    return unwrap(await h.get(id));
+  }
+
+  /**
+   * Write a memory attributed to another agent.
+   *
+   * ```ts
+   * await flair.admin.memory.write("researcher", "provisioned memory", { visibility: "shared" });
+   * ```
+   */
+  async write(asAgentId: string, content: string, opts?: MemoryWriteOptions): Promise<MemoryRecord> {
+    const Cls = resolveResource(this.#server, "Memory");
+    // Use adminContext for the acting admin, but stamp the target agentId
+    // on the body so the memory is owned by the target agent.
+    const h: any = await collectionResource(Cls, this.#ctx);
+    const body: Record<string, unknown> = {
+      agentId: asAgentId,
+      content,
+    };
+    if (opts?.durability) body.durability = opts.durability;
+    if (opts?.visibility) body.visibility = opts.visibility;
+    if (opts?.tags) body.tags = opts.tags;
+    if (opts?.type) body.type = opts.type;
+    if (opts?.id) body.id = opts.id;
+    return unwrap(await h.post(body));
+  }
+}
+
+// ─── InternalHandle ──────────────────────────────────────────────────────────
+
+/**
+ * Trusted, unattributed, unfiltered operations — Flair's `internal` verdict.
+ *
+ * Reads see every agent's private records; writes are owned by nobody.
+ * This exists for work that is genuinely infrastructure: provisioning a
+ * principal, a migration, a maintenance sweep.
+ *
+ * Every call site is greppable via `git grep "flair.internal"`.
+ */
+export class InternalHandle {
+  #server: Server;
+  #ctx: CallContext;
+
+  constructor(server: Server) {
+    this.#server = server;
+    this.#ctx = internalContext();
+  }
+
+  /** Raw Agent table access for provisioning. */
+  get agentTable(): InternalAgentTable {
+    return new InternalAgentTable(this.#server, this.#ctx);
+  }
+}
+
+// ─── InternalAgentTable ──────────────────────────────────────────────────────
+
+class InternalAgentTable {
+  #server: Server;
+  #ctx: CallContext;
+
+  constructor(server: Server, ctx: CallContext) {
+    this.#server = server;
+    this.#ctx = ctx;
+  }
+
+  /** Write directly to the Agent resource (bypasses admin gate via internal context). */
+  async put(record: Record<string, unknown>): Promise<Record<string, unknown>> {
+    const Cls = resolveResource(this.#server, "Agent");
+    const h: any = await collectionResource(Cls, this.#ctx);
+    return unwrap(await h.post(record));
+  }
+}
+
+// ─── Flair (the facade) ──────────────────────────────────────────────────────
+
+/**
+ * The public in-process API for Flair embedded in a Harper app.
+ *
+ * One handle per Harper instance. Resolves resources lazily on first use.
+ *
+ * ```ts
+ * import { Flair } from "@tpsdev-ai/flair";
+ * const flair = new Flair(server);
+ * const planner = flair.as("planner");
+ * await planner.memory.write("deploy runs at 0200 UTC");
+ * ```
+ *
+ * **Security:** In-process identity is asserted, not verified — co-location
+ * IS the grant. Build the agentId from your own server-side state, never
+ * from request data. `flair.as(id)` requires a non-empty id (runtime throw).
+ * `flair.admin` and `flair.internal` are separate, greppable properties for
+ * deliberate escalation.
+ */
+export class Flair {
+  #server: Server;
+
+  constructor(server: Server) {
+    this.#server = server;
+  }
+
+  /**
+   * Return a handle that acts as the given agent.
+   *
+   * The agentId is runtime-validated: missing, empty, blank, or non-string
+   * throws {@link InProcessContextError}. Build it from your own server-side
+   * state, never from request data.
+   */
+  as(agentId: string): AgentHandle {
+    return new AgentHandle(this.#server, agentId);
+  }
+
+  /**
+   * Admin operations — unfiltered reads, cross-agent writes.
+   *
+   * **This is a root shell.** Every call site is greppable via
+   * `git grep "flair.admin"`. Use for provisioning and maintenance only.
+   */
+  get admin(): AdminHandle {
+    // AdminHandle requires an agentId for attribution. We use a sentinel
+    // that makes the admin identity visible in audit logs. The caller
+    // should use a real admin agent id when possible.
+    return new AdminHandle(this.#server, "_admin");
+  }
+
+  /**
+   * Internal operations — trusted, unattributed, unfiltered.
+   *
+   * Every call site is greppable via `git grep "flair.internal"`.
+   * Use for infrastructure work only: provisioning, migrations, maintenance.
+   */
+  get internal(): InternalHandle {
+    return new InternalHandle(this.#server);
+  }
+}
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+/**
+ * Unwrap a handler return value into a plain object.
+ * Handlers may return a `Response` (the 401/403/400 guards) — surface its
+ * JSON body so the caller sees the structured error rather than an opaque object.
+ */
+async function unwrap(value: any): Promise<any> {
+  if (value && typeof value === "object" && typeof value.json === "function" && "status" in value) {
+    try {
+      const body = await value.json();
+      return { error: body?.error ?? "request failed", status: (value as any).status, ...body };
+    } catch {
+      return { error: "request failed", status: (value as any).status };
+    }
+  }
+  return value;
+}

--- a/resources/in-process-api.ts
+++ b/resources/in-process-api.ts
@@ -30,7 +30,6 @@
  * is additive — existing code using the raw seam continues to work.
  */
 
-import type { Server } from "harper";
 import {
   agentContext,
   adminContext,
@@ -39,6 +38,22 @@ import {
   InProcessContextError,
   type CallContext,
 } from "./in-process.js";
+
+/**
+ * Minimal structural interface for a Harper server — only the members the
+ * facade actually touches. Structural rather than imported from "harper"
+ * because the package exports `server` as a value (not a type), and the
+ * `Server` interface in its internal typings is not part of the public API.
+ * A consumer passes the real `server` object and TypeScript structural
+ * compatibility accepts it.
+ */
+export interface FlairServer {
+  resources: {
+    get(name: string): { Resource: any } | undefined;
+    getMatch(name: string): { Resource: any } | undefined;
+    keys(): IterableIterator<string>;
+  };
+}
 
 // ─── Re-export for the "./server" entry point ────────────────────────────────
 export { agentContext, adminContext, internalContext, collectionResource, InProcessContextError };
@@ -109,7 +124,7 @@ export interface SearchResult {
  * Resolve a Flair resource class from the Harper server registry.
  * Throws with a helpful message listing available resources if not found.
  */
-function resolveResource(server: Server, name: string): any {
+function resolveResource(server: FlairServer, name: string): any {
   const entry = (server.resources as any).get?.(name) ?? server.resources.getMatch?.(name);
   if (!entry?.Resource) {
     const keys = [...(server.resources as any).keys()].sort();
@@ -138,10 +153,10 @@ function resolveResource(server: Server, name: string): any {
  */
 export class AgentHandle {
   readonly agentId: string;
-  #server: Server;
+  #server: FlairServer;
   #ctx: CallContext;
 
-  constructor(server: Server, agentId: string) {
+  constructor(server: FlairServer, agentId: string) {
     this.#server = server;
     this.agentId = agentId;
     // Throws InProcessContextError on missing/empty/blank id — see
@@ -182,11 +197,11 @@ export class AgentHandle {
 // ─── AgentMemory (per-agent memory operations) ───────────────────────────────
 
 class AgentMemory {
-  #server: Server;
+  #server: FlairServer;
   #ctx: CallContext;
   #agentId: string;
 
-  constructor(server: Server, ctx: CallContext, agentId: string) {
+  constructor(server: FlairServer, ctx: CallContext, agentId: string) {
     this.#server = server;
     this.#ctx = ctx;
     this.#agentId = agentId;
@@ -264,10 +279,10 @@ class AgentMemory {
  */
 export class AdminHandle {
   readonly agentId: string;
-  #server: Server;
+  #server: FlairServer;
   #ctx: CallContext;
 
-  constructor(server: Server, agentId: string) {
+  constructor(server: FlairServer, agentId: string) {
     this.#server = server;
     this.agentId = agentId;
     this.#ctx = adminContext(agentId);
@@ -303,11 +318,11 @@ export class AdminHandle {
 // ─── AdminMemory ─────────────────────────────────────────────────────────────
 
 class AdminMemory {
-  #server: Server;
+  #server: FlairServer;
   #ctx: CallContext;
   #agentId: string;
 
-  constructor(server: Server, ctx: CallContext, agentId: string) {
+  constructor(server: FlairServer, ctx: CallContext, agentId: string) {
     this.#server = server;
     this.#ctx = ctx;
     this.#agentId = agentId;
@@ -357,10 +372,10 @@ class AdminMemory {
  * Every call site is greppable via `git grep "flair.internal"`.
  */
 export class InternalHandle {
-  #server: Server;
+  #server: FlairServer;
   #ctx: CallContext;
 
-  constructor(server: Server) {
+  constructor(server: FlairServer) {
     this.#server = server;
     this.#ctx = internalContext();
   }
@@ -374,10 +389,10 @@ export class InternalHandle {
 // ─── InternalAgentTable ──────────────────────────────────────────────────────
 
 class InternalAgentTable {
-  #server: Server;
+  #server: FlairServer;
   #ctx: CallContext;
 
-  constructor(server: Server, ctx: CallContext) {
+  constructor(server: FlairServer, ctx: CallContext) {
     this.#server = server;
     this.#ctx = ctx;
   }
@@ -411,9 +426,9 @@ class InternalAgentTable {
  * deliberate escalation.
  */
 export class Flair {
-  #server: Server;
+  #server: FlairServer;
 
-  constructor(server: Server) {
+  constructor(server: FlairServer) {
     this.#server = server;
   }
 

--- a/test/fixtures/inproc-app/resources/AgentFleet.js
+++ b/test/fixtures/inproc-app/resources/AgentFleet.js
@@ -21,7 +21,7 @@ import { Resource, server } from "harper";
 // The in-process call seam. Deep-imported from the installed package the same
 // way an application would — Flair ships `dist/`, and this module has no
 // dependencies of its own.
-import { agentContext, adminContext, internalContext, collectionResource } from "@tpsdev-ai/flair/dist/resources/in-process.js";
+import { agentContext, adminContext, internalContext, collectionResource } from "@tpsdev-ai/flair/server";
 
 /**
  * Resolve a Flair RESOURCE by its REST path.

--- a/test/integration/in-process-api.test.ts
+++ b/test/integration/in-process-api.test.ts
@@ -1,0 +1,99 @@
+// in-process-api.test.ts — flair#956. Integration test that imports the Flair
+// facade the way a CONSUMER would: from the package name, not a relative path.
+// This is the test that proves the exports map in package.json resolves
+// correctly. If `main` or `exports` is wrong or absent, this test fails.
+//
+// Requires a build (`bun run build`) because the entry point is a compiled
+// artifact. The fast unit tests in test/unit/in-process-api.test.ts import
+// from TypeScript source and run without a build.
+
+import { describe, it, expect } from "bun:test";
+import { Flair, AgentHandle, AdminHandle, InternalHandle, InProcessContextError } from "@tpsdev-ai/flair";
+
+// A minimal fake server that looks enough like Harper's Server to satisfy
+// the facade's resource-resolution path.
+function fakeServer(resources?: Record<string, any>) {
+  const map = new Map(Object.entries(resources ?? {}));
+  return {
+    resources: {
+      get: (name: string) => map.get(name),
+      getMatch: (name: string) => map.get(name),
+      keys: () => map.keys(),
+    },
+  } as any;
+}
+
+function fakeResourceEntry(Resource: any) {
+  return { Resource, path: "Memory", exportTypes: {}, hasSubPaths: false, relativeURL: "" };
+}
+
+describe("Flair — package entry point (integration)", () => {
+  // ── The exports map resolves ──────────────────────────────────────────
+
+  it("Flair is importable from @tpsdev-ai/flair", () => {
+    expect(Flair).toBeDefined();
+    expect(typeof Flair).toBe("function");
+  });
+
+  it("AgentHandle, AdminHandle, InternalHandle are importable", () => {
+    expect(AgentHandle).toBeDefined();
+    expect(AdminHandle).toBeDefined();
+    expect(InternalHandle).toBeDefined();
+  });
+
+  it("InProcessContextError is importable", () => {
+    expect(InProcessContextError).toBeDefined();
+  });
+
+  // ── Construction ───────────────────────────────────────────────────────
+
+  it("new Flair(server) constructs", () => {
+    const server = fakeServer();
+    const flair = new Flair(server);
+    expect(flair).toBeInstanceOf(Flair);
+  });
+
+  // ── as() guards ────────────────────────────────────────────────────────
+
+  describe("flair.as() — identity guards", () => {
+    const server = fakeServer();
+    const flair = new Flair(server);
+
+    it('as("") throws InProcessContextError', () => {
+      expect(() => flair.as("")).toThrow(InProcessContextError);
+    });
+
+    it('as(" ") throws InProcessContextError (blank)', () => {
+      expect(() => flair.as(" ")).toThrow(InProcessContextError);
+    });
+
+    it('as("planner") returns an AgentHandle with the correct agentId', () => {
+      const handle = flair.as("planner");
+      expect(handle).toBeInstanceOf(AgentHandle);
+      expect(handle.agentId).toBe("planner");
+    });
+  });
+
+  // ── admin / internal properties ────────────────────────────────────────
+
+  it("flair.admin is an AdminHandle", () => {
+    const flair = new Flair(fakeServer());
+    expect(flair.admin).toBeInstanceOf(AdminHandle);
+  });
+
+  it("flair.internal is an InternalHandle", () => {
+    const flair = new Flair(fakeServer());
+    expect(flair.internal).toBeInstanceOf(InternalHandle);
+  });
+
+  // ── Resource-not-found error ───────────────────────────────────────────
+
+  it("throws with a helpful message when Flair is not loaded", async () => {
+    const server = fakeServer(); // empty — no resources registered
+    const flair = new Flair(server);
+    const handle = flair.as("test-agent");
+    await expect(handle.memory.write("hello")).rejects.toThrow(
+      /Flair is not loaded in this Harper instance/,
+    );
+  });
+});

--- a/test/unit/in-process-api.test.ts
+++ b/test/unit/in-process-api.test.ts
@@ -1,20 +1,18 @@
-// in-process-api.test.ts — flair#956. Tests the public Flair facade the way
-// a CONSUMER would import it: from the package entry point, not a relative
-// path into src. That is the only test that proves the thing this PR exists
-// to fix.
+// in-process-api.test.ts — flair#956. Fast unit tests for the Flair facade
+// that run without a build step (import from TypeScript source).
 //
 // The unit tests cover:
-//   1. Import shape — Flair is exported from the entry point
+//   1. Import shape — Flair is exported from the module
 //   2. as() guards — empty, blank, undefined, null, non-string all throw
 //   3. Construction — new Flair(server) stores the server
 //   4. Admin/Internal — separate, greppable properties exist
 //
-// Integration tests (test/integration/in-process-api.test.ts) cover the
-// full Harper round-trip: write, read, search, recall, admin register,
-// cross-agent scoping.
+// The EXPORTS MAP is tested in test/integration/in-process-api.test.ts,
+// which imports from "@tpsdev-ai/flair" (the package name) and therefore
+// proves that `main` and `exports` in package.json resolve correctly.
 
 import { describe, it, expect } from "bun:test";
-import { Flair, AgentHandle, AdminHandle, InternalHandle, InProcessContextError } from "../../dist/resources/in-process-api.js";
+import { Flair, AgentHandle, AdminHandle, InternalHandle, InProcessContextError } from "../../resources/in-process-api.ts";
 
 // A minimal fake server that looks enough like Harper's Server to satisfy
 // the facade's resource-resolution path.

--- a/test/unit/in-process-api.test.ts
+++ b/test/unit/in-process-api.test.ts
@@ -1,0 +1,160 @@
+// in-process-api.test.ts — flair#956. Tests the public Flair facade the way
+// a CONSUMER would import it: from the package entry point, not a relative
+// path into src. That is the only test that proves the thing this PR exists
+// to fix.
+//
+// The unit tests cover:
+//   1. Import shape — Flair is exported from the entry point
+//   2. as() guards — empty, blank, undefined, null, non-string all throw
+//   3. Construction — new Flair(server) stores the server
+//   4. Admin/Internal — separate, greppable properties exist
+//
+// Integration tests (test/integration/in-process-api.test.ts) cover the
+// full Harper round-trip: write, read, search, recall, admin register,
+// cross-agent scoping.
+
+import { describe, it, expect } from "bun:test";
+import { Flair, AgentHandle, AdminHandle, InternalHandle, InProcessContextError } from "../../dist/resources/in-process-api.js";
+
+// A minimal fake server that looks enough like Harper's Server to satisfy
+// the facade's resource-resolution path.
+function fakeServer(resources?: Record<string, any>) {
+  const map = new Map(Object.entries(resources ?? {}));
+  return {
+    resources: {
+      get: (name: string) => map.get(name),
+      getMatch: (name: string) => map.get(name),
+      keys: () => map.keys(),
+    },
+  } as any;
+}
+
+function fakeResourceEntry(Resource: any) {
+  return { Resource, path: "Memory", exportTypes: {}, hasSubPaths: false, relativeURL: "" };
+}
+
+describe("Flair (public in-process API)", () => {
+  // ── Import shape ───────────────────────────────────────────────────────
+
+  it("exports Flair as a named export", () => {
+    expect(Flair).toBeDefined();
+    expect(typeof Flair).toBe("function");
+  });
+
+  it("exports AgentHandle, AdminHandle, InternalHandle", () => {
+    expect(AgentHandle).toBeDefined();
+    expect(AdminHandle).toBeDefined();
+    expect(InternalHandle).toBeDefined();
+  });
+
+  it("re-exports InProcessContextError from the entry point", () => {
+    expect(InProcessContextError).toBeDefined();
+  });
+
+  // ── Construction ───────────────────────────────────────────────────────
+
+  it("new Flair(server) stores the server (lazy — no resource lookup at construction)", () => {
+    const server = fakeServer();
+    const flair = new Flair(server);
+    expect(flair).toBeInstanceOf(Flair);
+  });
+
+  // ── as() guards ────────────────────────────────────────────────────────
+
+  describe("flair.as() — identity guards", () => {
+    const server = fakeServer();
+    const flair = new Flair(server);
+
+    it("as(\"\") throws InProcessContextError", () => {
+      expect(() => flair.as("")).toThrow(InProcessContextError);
+    });
+
+    it("as(\" \") throws InProcessContextError (blank)", () => {
+      expect(() => flair.as(" ")).toThrow(InProcessContextError);
+    });
+
+    it("as(\"   \") throws InProcessContextError (whitespace-only)", () => {
+      expect(() => flair.as("   ")).toThrow(InProcessContextError);
+    });
+
+    it("as(undefined) throws — not a string", () => {
+      // @ts-expect-error — testing the JS guard, not the TS type
+      expect(() => flair.as(undefined)).toThrow(InProcessContextError);
+    });
+
+    it("as(null) throws — not a string", () => {
+      // @ts-expect-error — testing the JS guard, not the TS type
+      expect(() => flair.as(null)).toThrow(InProcessContextError);
+    });
+
+    it("as(123) throws — not a string", () => {
+      // @ts-expect-error — testing the JS guard, not the TS type
+      expect(() => flair.as(123)).toThrow(InProcessContextError);
+    });
+
+    it("as(\"planner\") returns an AgentHandle with the correct agentId", () => {
+      const handle = flair.as("planner");
+      expect(handle).toBeInstanceOf(AgentHandle);
+      expect(handle.agentId).toBe("planner");
+    });
+  });
+
+  // ── admin / internal properties ────────────────────────────────────────
+
+  describe("flair.admin", () => {
+    const server = fakeServer();
+    const flair = new Flair(server);
+
+    it("is an AdminHandle", () => {
+      expect(flair.admin).toBeInstanceOf(AdminHandle);
+    });
+
+    it("is a property, not a method", () => {
+      expect(typeof flair.admin).toBe("object");
+    });
+  });
+
+  describe("flair.internal", () => {
+    const server = fakeServer();
+    const flair = new Flair(server);
+
+    it("is an InternalHandle", () => {
+      expect(flair.internal).toBeInstanceOf(InternalHandle);
+    });
+
+    it("is a property, not a method", () => {
+      expect(typeof flair.internal).toBe("object");
+    });
+  });
+
+  // ── Resource-not-found error ───────────────────────────────────────────
+
+  describe("resource resolution error", () => {
+    it("throws with a helpful message when Flair is not loaded", async () => {
+      const server = fakeServer(); // empty — no resources registered
+      const flair = new Flair(server);
+      const handle = flair.as("test-agent");
+      await expect(handle.memory.write("hello")).rejects.toThrow(
+        /Flair is not loaded in this Harper instance/,
+      );
+    });
+
+    it("names the missing resource", async () => {
+      const server = fakeServer(); // empty
+      const flair = new Flair(server);
+      const handle = flair.as("test-agent");
+      await expect(handle.memory.write("hello")).rejects.toThrow(/Memory/);
+    });
+
+    it("lists available resources when some are registered", async () => {
+      // Register a non-Memory resource so the error lists what IS there
+      const server = fakeServer({
+        Agent: fakeResourceEntry(class {}),
+        Health: fakeResourceEntry(class {}),
+      });
+      const flair = new Flair(server);
+      const handle = flair.as("test-agent");
+      await expect(handle.memory.write("hello")).rejects.toThrow(/Agent, Health/);
+    });
+  });
+});


### PR DESCRIPTION
Adds a public in-process API (`new Flair(server)`) that hides four internal implementation details a Harper engineer should never have to learn:

1. The deep import path into `dist/`
2. That `server.resources` is keyed by REST path without a leading slash
3. That the registry entry wraps the class in `.Resource`
4. That creates need `collectionResource()` while reads do not

Also collapses the agentId double-pass (context + body) into one.

## Shape

```ts
import { Flair } from "@tpsdev-ai/flair";
const flair = new Flair(server);
const planner = flair.as("planner");
await planner.memory.write("deploy runs at 0200 UTC");
const hits = await planner.recall("deploy schedule", { limit: 5 });
const record = await planner.memory.get(hits[0].id);
await flair.admin.registerAgent("planner", { publicKey: "pending" });
```

## What's included

- `new Flair(server)` — one handle per Harper instance, lazy resource resolution
- `flair.as(agentId)` — `AgentHandle` with `memory.write/get/search` and `recall()`, agentId runtime-validated (empty/blank throws `InProcessContextError`)
- `flair.admin` — `AdminHandle` with `registerAgent()` and cross-agent memory operations
- `flair.internal` — `InternalHandle` with raw `agentTable` access
- `package.json`: `main` + `exports` fields so bare import resolves
- `docs/embedding-in-a-harper-app.md`: rewritten to lead with the facade; primitives moved to appendix
- 18 unit tests, mutation-checked (breaking the guard causes 6 failures)

## What the facade does NOT hide

The security boundary. In-process identity is asserted, not verified — co-location IS the grant. `flair.as(id)` requires a non-empty id (runtime throw). `flair.admin` and `flair.internal` are separate, greppable properties. The docs say plainly: build the context from your own server-side state, never from request data.

## Test results

Baseline (`origin/main`, 186 files): 3410 pass, 4 skip, 20 fail (3434 tests)
Branch (187 files): 3428 pass, 4 skip, 20 fail (3452 tests)
Delta: +18 pass, 0 regression. The 20 pre-existing failures are unchanged.

Closes #956
