### PR TITLE
fix(launchd): stop uses unload, plist re-read on restart, migration validates

### DIFF
--- a/.changelog/unreleased/fixed-launchd-plist-reread-on-restart.md
+++ b/.changelog/unreleased/fixed-launchd-plist-reread-on-restart.md
@@ -1,0 +1,1 @@
+- **A rewritten launchd plist is now re-read on restart.** `ensureLaunchdServiceLoaded` now unloads the service before loading it, so launchd picks up changes to the plist on disk. Previously a config change followed by `flair restart` could silently keep the old environment.

--- a/.changelog/unreleased/fixed-launchd-stop-keepalive-respawn.md
+++ b/.changelog/unreleased/fixed-launchd-stop-keepalive-respawn.md
@@ -1,0 +1,1 @@
+- **`flair stop` no longer reports success while a KeepAlive job respawns.** The launchd stop path now uses `launchctl unload` instead of `launchctl stop`, which both stops the process and prevents launchd from immediately restarting it. This also fixes `flair restart`, `flair upgrade`, and `flair snapshot` — all of which compose stop-then-start through the same helper.

--- a/.changelog/unreleased/fixed-migration-plist-validation.md
+++ b/.changelog/unreleased/fixed-migration-plist-validation.md
@@ -1,0 +1,1 @@
+- **Legacy launchd plist migration now validates the plist before rewriting it.** If the legacy plist does not contain the expected Label key, migration refuses with a named remedy instead of silently propagating a malformed document. The Label replacement also uses a `$`-safe function replacer, closing a latent bug that could fire if the label format ever changes.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -396,10 +396,21 @@ function migrateLegacyLaunchdLabel(
   try { runLaunchctl(`launchctl unload "${resolved.plistPath}"`); } catch { /* best effort */ }
 
   const legacyContent = readFileSync(resolved.plistPath, "utf-8");
-  const newContent = legacyContent.replace(
-    `<key>Label</key><string>${LEGACY_LAUNCHD_LABEL}</string>`,
-    `<key>Label</key><string>${newLabel}</string>`,
-  );
+  // Use a function replacer to avoid $-sensitivity in the replacement
+  // string (flair#919). String.prototype.replace interprets $&, $', $`
+  // etc. in the replacement even when the search value is a plain string.
+  const labelSearch = `<key>Label</key><string>${LEGACY_LAUNCHD_LABEL}</string>`;
+  const labelReplacement = `<key>Label</key><string>${newLabel}</string>`;
+  const newContent = legacyContent.replace(labelSearch, () => labelReplacement);
+  // Refuse to propagate a malformed plist: if the Label wasn't found,
+  // the plist is not what we expect and migration must not write it.
+  if (newContent === legacyContent) {
+    throw new Error(
+      `Legacy plist at ${resolved.plistPath} does not contain the expected ` +
+      `Label key — it may be malformed or from an unknown Flair version. ` +
+      `Remove it manually and re-run 'flair init'.`,
+    );
+  }
   writeFileSync(newPlistPath, newContent);
   try { unlinkSync(resolved.plistPath); } catch { /* best effort */ }
 
@@ -499,6 +510,10 @@ function ensureLaunchdServiceLoaded(
   launchAgentsDir: string = defaultLaunchAgentsDir(),
 ): { label: string; plistPath: string; migrated: boolean } {
   const migration = migrateLegacyLaunchdLabel(dataDir, runLaunchctl, launchAgentsDir);
+  // Unload first so a rewritten plist is re-read (flair#872).
+  // launchd caches the environment of an already-loaded job; load
+  // alone does not pick up changes to the plist on disk.
+  try { runLaunchctl(`launchctl unload "${migration.plistPath}"`); } catch { /* not loaded, etc. — best effort */ }
   try { runLaunchctl(`launchctl load "${migration.plistPath}"`); } catch { /* already loaded, etc. — best effort */ }
   runLaunchctl(`launchctl start ${migration.label}`);
   return migration;
@@ -10853,14 +10868,14 @@ async function stopFlairProcess(port: number, dataDir: string): Promise<void> {
       assertLaunchdServiceOwnedBy(dataDir, label, plistPath, "stop");
       try {
         const { execSync } = await import("node:child_process");
-        // Ensure the service is loaded (init writes the plist but doesn't load it)
-        try { execSync(`launchctl load "${plistPath}"`, { stdio: "pipe" }); } catch {}
-        // Capture the current PID *before* stopping so callers that
+        // Capture the current PID *before* unloading so callers that
         // immediately restart can verify exit. Without this, waitForHealth
         // can race against the still-shutting-down old process and return
-        // success before KeepAlive brings the new one up.
+        // success before the new one comes up.
         const oldPid = readHarperPid(dataDir);
-        try { execSync(`launchctl stop ${label}`, { stdio: "pipe" }); } catch {}
+        // unload stops the job AND prevents KeepAlive from respawning it.
+        // launchctl stop alone is insufficient for a KeepAlive job (flair#874).
+        try { execSync(`launchctl unload "${plistPath}"`, { stdio: "pipe" }); } catch {}
         if (oldPid) await waitForProcessExit(oldPid, STARTUP_TIMEOUT_MS);
         return;
       } catch (err: any) {

--- a/test/unit/launchd-label.test.ts
+++ b/test/unit/launchd-label.test.ts
@@ -189,13 +189,15 @@ describe("resolveLaunchdLabel / migrateLegacyLaunchdLabel / ensureLaunchdService
     expect(result.migrated).toBe(true);
     expect(result.label).toBe(newLabel);
 
-    // Exactly 3 launchctl calls, in this order: unload legacy, load new, start new.
-    expect(calls.length).toBe(3);
+    // Exactly 4 launchctl calls, in this order: unload legacy, unload new, load new, start new.
+    expect(calls.length).toBe(4);
     expect(calls[0]).toContain("launchctl unload");
     expect(calls[0]).toContain(legacyPath);
-    expect(calls[1]).toContain("launchctl load");
+    expect(calls[1]).toContain("launchctl unload");
     expect(calls[1]).toContain(launchdPlistPath(newLabel, launchAgentsDir));
-    expect(calls[2]).toBe(`launchctl start ${newLabel}`);
+    expect(calls[2]).toContain("launchctl load");
+    expect(calls[2]).toContain(launchdPlistPath(newLabel, launchAgentsDir));
+    expect(calls[3]).toBe(`launchctl start ${newLabel}`);
 
     // There is never a moment with both registered: legacy file is gone,
     // new one exists, by the time this returns.
@@ -211,9 +213,11 @@ describe("resolveLaunchdLabel / migrateLegacyLaunchdLabel / ensureLaunchdService
     const result = ensureLaunchdServiceLoaded(dataDir, (cmd) => calls.push(cmd), launchAgentsDir);
 
     expect(result.migrated).toBe(false);
-    expect(calls.length).toBe(2);
-    expect(calls[0]).toContain("launchctl load");
-    expect(calls[1]).toBe(`launchctl start ${newLabel}`);
+    // flair#872: unload before load so a rewritten plist is re-read.
+    expect(calls.length).toBe(3);
+    expect(calls[0]).toContain("launchctl unload");
+    expect(calls[1]).toContain("launchctl load");
+    expect(calls[2]).toBe(`launchctl start ${newLabel}`);
   });
 
   test("ensureLaunchdServiceLoaded tolerates a load failure but propagates a start failure", () => {
@@ -228,8 +232,8 @@ describe("resolveLaunchdLabel / migrateLegacyLaunchdLabel / ensureLaunchdService
     };
 
     expect(() => ensureLaunchdServiceLoaded(dataDir, runLaunchctl, launchAgentsDir)).toThrow("could not find service");
-    // Both were attempted (load's failure didn't block the start attempt)
-    expect(calls.length).toBe(2);
+    // All three were attempted (unload + load failures didn't block the start attempt)
+    expect(calls.length).toBe(3);
   });
 
   test("no bare 'ai.tpsdev.flair' string literals remain in operational label call sites (structural)", async () => {
@@ -416,5 +420,65 @@ describe("resolveLaunchdLabel / migrateLegacyLaunchdLabel / ensureLaunchdService
 
     expect(result.action).toBe("none");
     expect(launchctlCalls.length).toBe(0);
+  });
+
+  // ── flair#919: migration must not propagate a malformed plist ──────
+
+  test("migrateLegacyLaunchdLabel: throws on a plist that does not contain the expected Label key", () => {
+    // A plist that is valid XML but has a different label — the replace
+    // won't match, and migration must refuse rather than write it unchanged.
+    const wrongLabel = "com.example.something-else";
+    const legacyPath = launchdPlistPath(LEGACY_LAUNCHD_LABEL, launchAgentsDir);
+    writeFileSync(legacyPath, fakePlist(wrongLabel));
+
+    const calls: string[] = [];
+    expect(() => migrateLegacyLaunchdLabel(dataDir, (cmd) => calls.push(cmd), launchAgentsDir))
+      .toThrow(/does not contain the expected Label key/);
+
+    // The legacy plist must still exist — we did NOT delete it on failure.
+    expect(existsSync(legacyPath)).toBe(true);
+    // No new plist was written.
+    const newLabel = launchdLabel(dataDir);
+    expect(existsSync(launchdPlistPath(newLabel, launchAgentsDir))).toBe(false);
+  });
+
+  // ── flair#874 / flair#872 structural guards ────────────────────────
+
+  test("stopFlairProcess uses launchctl unload, not launchctl stop, on the launchd path (flair#874)", async () => {
+    const src = await Bun.file(join(import.meta.dirname, "..", "..", "src", "cli.ts")).text();
+    // Find the stopFlairProcess function body.
+    const fnStart = src.indexOf("async function stopFlairProcess");
+    expect(fnStart).not.toBe(-1);
+    // The next function after stopFlairProcess is startFlairProcess.
+    const nextFn = src.indexOf("async function startFlairProcess", fnStart);
+    expect(nextFn).not.toBe(-1);
+    const fnBody = src.slice(fnStart, nextFn);
+
+    // Must contain launchctl unload (the fix).
+    expect(fnBody).toContain("launchctl unload");
+    // Must NOT contain launchctl stop as a shell command (the old, broken
+    // behaviour). The comment explaining the fix mentions "launchctl stop"
+    // but no execSync/runLaunchctl call should invoke it.
+    const cmdCalls = fnBody.match(/`launchctl \w+/g) ?? [];
+    const stopCalls = cmdCalls.filter((c: string) => c.includes("stop"));
+    expect(stopCalls.length).toBe(0);
+  });
+
+  test("migrateLegacyLaunchdLabel uses a function replacer, not a $-sensitive string replacement (flair#919)", async () => {
+    const src = await Bun.file(join(import.meta.dirname, "..", "..", "src", "cli.ts")).text();
+    // Find the migrateLegacyLaunchdLabel function body.
+    const fnStart = src.indexOf("function migrateLegacyLaunchdLabel");
+    expect(fnStart).not.toBe(-1);
+    // The next function after migrateLegacyLaunchdLabel is cleanupLegacyLaunchdPlist.
+    const nextFn = src.indexOf("function cleanupLegacyLaunchdPlist", fnStart);
+    expect(nextFn).not.toBe(-1);
+    const fnBody = src.slice(fnStart, nextFn);
+
+    // Must use a function replacer (() => ...) to avoid $-sensitivity.
+    expect(fnBody).toMatch(/\.replace\([^)]*,\s*\(\)\s*=>/);
+    // Must NOT use a bare string as the second argument to .replace().
+    // The only .replace call in this function should use the function form.
+    const replaceCalls = fnBody.match(/\.replace\(/g) ?? [];
+    expect(replaceCalls.length).toBe(1);
   });
 });


### PR DESCRIPTION
## What

Three related launchd service-control fixes in one region of `src/cli.ts`:

### #874: `flair stop` reports success while the service respawns

`stopFlairProcess` used `launchctl stop` against a KeepAlive job — launchd immediately respawned it. Changed to `launchctl unload`, which stops the process AND prevents KeepAlive from restarting it. The PID capture and `waitForProcessExit` check are preserved so callers that immediately restart can verify the old process is gone.

### #872: A rewritten plist is never re-read on restart

`ensureLaunchdServiceLoaded` did `launchctl load` + `launchctl start` without ever unloading first. launchd caches an already-loaded job's environment, so a rewritten plist was silently never picked up. Added an `unload` before `load` so config changes take effect on restart.

### #919: Migration copies plist verbatim, preserving writer bugs

`migrateLegacyLaunchdLabel` copied the plist verbatim with a `$`-sensitive `String.replace()` on the Label only. Two changes:

1. **`$`-safe replace**: Uses a function replacer (`() => replacement`) instead of a bare string, closing a latent bug that would fire if the label format ever contained `$`.
2. **Validation**: Refuses migration when the plist does not contain the expected Label key, with a named remedy ("remove it manually and re-run `flair init`"), rather than silently propagating a malformed document.

**Why validate rather than re-render**: Re-rendering from current inputs (calling `buildLaunchdPlist`) would require threading the port and other options through `migrateLegacyLaunchdLabel` → `ensureLaunchdServiceLoaded` → `startFlairProcess` and the `flair start` command handler. That is a larger refactor. Validation closes the immediate hazard (propagating a broken plist) and the `$`-safe replace closes the latent one. Re-rendering can follow in a separate change.

### #973: Deliberately not included

`init` performing migration cleanup as a side effect is architectural and needs its own PR. The direction is agreed but the change is larger than the other three combined.

## Mutation checks

Every new test was verified by breaking the fix and confirming the test fails:

| Fix | Mutation | Test result |
|-----|----------|-------------|
| #874 | `unload` → `stop` in `stopFlairProcess` | Structural test fails: finds `launchctl stop` in command calls |
| #872 | Remove `unload` from `ensureLaunchdServiceLoaded` | 3 call-count tests fail (legacy path expects 4 calls, current path expects 3) |
| #919a | Revert to `$`-sensitive `String.replace()` | Structural test fails: no function replacer found |
| #919b | Remove malformed-plist validation | Throws test fails: migration no longer throws on bad plist |

## Test results

Launchd unit tests: **56 pass, 0 fail** (up from 53 on baseline — 3 new tests added).

Full test suite baseline (on `origin/main`): 2864 pass, 135 fail, 113 errors. The failures are pre-existing integration tests requiring a live Harper instance. No regressions introduced.
