### PR TITLE
fix: port is not identity — attribution guards for stop, uninstall, doctor, and port resolution (#917, #862, #915, #819)

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -10615,14 +10615,37 @@ program
     // PID — see parseListeningPids (flair#800/flair#905): this used to SIGTERM
     // every process holding ANY socket on the port, so `flair stop` could kill
     // itself (leaving Flair running) or kill an unrelated client of it.
+    //
+    // Attribution guard (flair#915): the port is not an identity. Refuse to
+    // SIGTERM a PID that cannot be attributed to this instance.
     try {
       const { execSync } = await import("node:child_process");
       const pids = listeningPidsOnPort(port, (cmd) => execSync(cmd, { encoding: "utf-8" }));
       if (pids.length > 0) {
-        for (const pid of pids) {
-          try { process.kill(pid, "SIGTERM"); } catch { /* already gone */ }
+        const dataDir = defaultDataDir();
+        const harperPid = readHarperPid(dataDir);
+        if (harperPid !== null && !pids.includes(harperPid)) {
+          console.error(
+            `⚠️  Process(es) on port ${port} (PID${pids.length > 1 ? "s" : ""}: ${pids.join(", ")}) `
+              + `do not match this Flair instance (PID ${harperPid}). `
+              + `Not stopping — cannot attribute the process to this instance. `
+              + `Stop the process manually if it is not Flair.`,
+          );
+          process.exit(1);
+        } else if (harperPid === null) {
+          console.error(
+            `⚠️  Process(es) on port ${port} (PID${pids.length > 1 ? "s" : ""}: ${pids.join(", ")}) `
+              + `but no PID file in data directory — not a running Flair instance. `
+              + `Not stopping — cannot attribute the process to this instance. `
+              + `Stop the process manually if it is not Flair.`,
+          );
+          process.exit(1);
+        } else {
+          for (const pid of pids) {
+            try { process.kill(pid, "SIGTERM"); } catch { /* already gone */ }
+          }
+          console.log(`✅ Flair stopped (killed PID${pids.length > 1 ? "s" : ""}: ${pids.join(", ")})`);
         }
-        console.log(`✅ Flair stopped (killed PID${pids.length > 1 ? "s" : ""}: ${pids.join(", ")})`);
       } else {
         console.log("Flair is not running.");
       }
@@ -10800,18 +10823,32 @@ export function assertLaunchdServiceOwnedBy(
  * wrong today whenever the port does not match.
  */
 function assertPortInstanceOwnedBy(port: number, dataDir: string, listeningPids: number[]): void {
-  if (resolve(dataDir) === defaultDataDir()) return;
+  // (flair#915) Apply the attribution check for ALL data directories, not
+  // just non-default ones. The default-dir bypass was the residual gap that
+  // #910 left behind — it allowed an unattributed SIGTERM on the default
+  // install's port. The old concern (false refusal when hdb.pid is missing)
+  // is actually the RIGHT behavior: no PID file means we cannot attribute the
+  // listener, so we refuse. That is safer than killing the wrong process.
   const expected = readHarperPid(dataDir);
-  if (expected !== null && listeningPids.includes(expected)) return;
+  // No PID file — Harper is not (or was not) running in this directory.
+  // The port is stale or held by something else; refuse to SIGTERM it.
+  if (expected === null) {
+    throw new Error(
+      `refusing to stop the process listening on port ${port}: no hdb.pid under `
+        + `${resolve(dataDir)}, so that is not a running instance. `
+        + `Stopping by port alone would signal a process we cannot attribute. `
+        + `If it is not Flair, stop it manually.`,
+    );
+  }
+  // PID file exists — the PID on the port must be Harper.
+  if (listeningPids.includes(expected)) return;
 
-  const why =
-    expected === null
-      ? `no hdb.pid under that directory, so it does not look like a running instance`
-      : `its recorded PID ${expected} is not the process listening on ${port}`;
   throw new Error(
-    `refusing to stop the process listening on port ${port}: it cannot be attributed to ${resolve(dataDir)} (${why}). ` +
-      `Stopping by port alone would signal a different Flair instance. ` +
-      `Pass --port with the port ${resolve(dataDir)} actually serves, or omit --data-dir to operate on the default install.`,
+    `refusing to stop the process listening on port ${port}: its recorded PID ${expected} `
+      + `is not the process listening on ${port}. `
+      + `Stopping by port alone would signal a different instance. `
+      + `Pass --port with the port ${resolve(dataDir)} actually serves, `
+      + `or stop the process manually.`,
   );
 }
 
@@ -11162,7 +11199,11 @@ program
   .option("--purge", "Also remove data and keys (destructive)")
   .action(async (opts) => {
     const platform = process.platform;
-    const port = readPortFromConfig() ?? DEFAULT_PORT;
+    // Use the unified resolver: Harper's config > per-user config > default.
+    // A default of 19926 that is "present but wrong" beats the actual port
+    // Harper is serving on (flair#819). resolveHttpPort reads Harper's own
+    // config in the data directory, which is authoritative.
+    const port = resolveHttpPort({}, "address");
 
     // Stop first: remove launchd service(s) on macOS, then kill by port on
     // all platforms. Removes BOTH the new instance-scoped plist and a
@@ -11188,50 +11229,88 @@ program
     // Kill any process still on the port (covers direct-start, no-service, or
     // failed unload). Listening sockets only, never our own PID — see
     // parseListeningPids (flair#800/flair#905).
+    //
+    // Guard (flair#917): refuse to SIGTERM a PID that cannot be attributed to
+    // this Flair instance. A port is not an identity — something else can hold
+    // it. Killing the wrong PID and then purging data is the whole bug.
+        let refusedKill = false;
     try {
       const { execSync } = await import("node:child_process");
       const pids = listeningPidsOnPort(port, (cmd) => execSync(cmd, { encoding: "utf-8" }));
       if (pids.length > 0) {
-        for (const pid of pids) {
-          try { process.kill(pid, "SIGTERM"); } catch {}
+        // Verify ownership before killing: the PID must match this instance's
+        // recorded PID (hdb.pid). If no PID file exists, Harper is already
+        // stopped and the port is stale — safe to skip.
+        const dataDir = defaultDataDir();
+        const harperPid = readHarperPid(dataDir);
+        if (harperPid !== null) {
+          // PID file exists — the PID on the port must be Harper or we refuse.
+          if (!pids.includes(harperPid)) {
+            console.log(
+              `⚠️  Process(es) on port ${port} (PID${pids.length > 1 ? "s" : ""}: ${pids.join(", ")}) `
+                + `do not match this Flair instance (PID ${harperPid}). `
+                + `Not killing — cannot attribute the process to this instance. `
+                + `Stop the process manually if it is not Flair.`,
+            );
+            refusedKill = true;
+          } else {
+            for (const pid of pids) {
+              try { process.kill(pid, "SIGTERM"); } catch {}
+            }
+            await new Promise(r => setTimeout(r, 2000));
+            console.log("✅ Flair process stopped");
+          }
+        } else {
+          // No PID file — Harper is not (or was not) running here.
+          // The port may be stale or held by something else; don't risk killing it.
+          console.log(
+            `⚠️  Process(es) on port ${port} (PID${pids.length > 1 ? "s" : ""}: ${pids.join(", ")}) `
+              + `but no PID file in data directory — not a running Flair instance. `
+              + `Not killing — stop the process manually if it is not Flair.`,
+          );
+          refusedKill = true;
         }
-        // Wait for process to release file handles (RocksDB)
-        await new Promise(r => setTimeout(r, 2000));
-        console.log("✅ Flair process stopped");
       }
     } catch { /* not running */ }
 
-    // Remove config
-    const cfgPath = configPath();
-    if (existsSync(cfgPath)) {
-      const { unlinkSync } = await import("node:fs");
-      unlinkSync(cfgPath);
-      console.log("✅ Config removed");
+    // Always remove per-user config on uninstall.
+    {
+      const cfgPath = configPath();
+      if (existsSync(cfgPath)) {
+        const { unlinkSync } = await import("node:fs");
+        unlinkSync(cfgPath);
+        console.log("✅ Config removed");
+      }
     }
 
     if (opts.purge) {
-      const { rmSync } = await import("node:fs");
-      const dataDir = defaultDataDir();
-      const keysDir = defaultKeysDir();
-      const flairDir = join(homedir(), ".flair");
+      if (refusedKill) {
+        console.log("\n⚠️  Skipping purge: could not attribute the process on port — data preserved.");
+        console.log("Stop the process manually, then re-run: flair uninstall --purge");
+      } else {
+        const { rmSync } = await import("node:fs");
+        const dataDir = defaultDataDir();
+        const keysDir = defaultKeysDir();
+        const flairDir = join(homedir(), ".flair");
 
-      if (existsSync(dataDir)) {
-        rmSync(dataDir, { recursive: true, force: true });
-        console.log("✅ Data removed: " + dataDir);
-      }
-      if (existsSync(keysDir)) {
-        rmSync(keysDir, { recursive: true, force: true });
-        console.log("✅ Keys removed: " + keysDir);
-      }
-      // Remove .flair dir if empty
-      try {
-        const { readdirSync, rmdirSync } = await import("node:fs");
-        if (existsSync(flairDir) && readdirSync(flairDir).length === 0) {
-          rmdirSync(flairDir);
+        if (existsSync(dataDir)) {
+          rmSync(dataDir, { recursive: true, force: true });
+          console.log("✅ Data removed: " + dataDir);
         }
-      } catch { /* non-empty, that's fine */ }
+        if (existsSync(keysDir)) {
+          rmSync(keysDir, { recursive: true, force: true });
+          console.log("✅ Keys removed: " + keysDir);
+        }
+        // Remove .flair dir if empty
+        try {
+          const { readdirSync, rmdirSync } = await import("node:fs");
+          if (existsSync(flairDir) && readdirSync(flairDir).length === 0) {
+            rmdirSync(flairDir);
+          }
+        } catch { /* non-empty, that's fine */ }
 
-      console.log("\n🗑️  Flair fully purged");
+        console.log("\n🗑️  Flair fully purged");
+      }
     } else {
       console.log("\nData and keys preserved at ~/.flair/");
       console.log("To remove everything: flair uninstall --purge");
@@ -11895,23 +11974,36 @@ program
       console.log(`  ${render.icons.ok} flair ${__pkgVersion} is current`);
     }
 
-    // Helper: try to reach Harper on a given port
+    // Helper: try to reach Harper on a given port.
+    // Must return true ONLY when Harper's /Health endpoint returns 200 OK.
+    // A generic HTTP status > 0 (flair#862) would accept 404 from a Node
+    // inspector on 9229 or any other service — "present but wrong" beats
+    // "absent but correct".
     async function probePort(p: number): Promise<boolean> {
       try {
         const res = await fetch(`http://127.0.0.1:${p}/Health`, { signal: AbortSignal.timeout(3000) });
-        return res.status > 0;
+        return res.ok; // 200-299 only — /Health returns { ok: true } on 200
       } catch { return false; }
     }
 
-    // Helper: discover what port a Harper PID is listening on
+    // Helper: discover what port a Harper PID is listening on.
+    // Scans ALL listening ports for this PID and returns the first one that
+    // responds to /Health with 200 OK. This avoids picking a debug port (9229)
+    // or any non-Flair listener that happens to share the process (flair#862).
     async function discoverPortFromPid(pid: string): Promise<number | null> {
       // Defense-in-depth: caller already validates, but re-check here
       if (!/^\d+$/.test(pid)) return null;
       try {
         const { execSync } = await import("node:child_process");
         const out = execSync(`lsof -aPi -p ${pid} -sTCP:LISTEN -Fn 2>/dev/null || true`, { encoding: "utf-8" });
-        const match = out.match(/:(\d+)$/m);
-        if (match) return Number(match[1]);
+        // Extract all ports from lsof -Fn output (lines like "n127.0.0.1:PORT")
+        const ports = [...out.matchAll(/n(?:\S+):(\d+)/g)].map(m => Number(m[1]));
+        if (ports.length === 0) return null;
+        // Try each port until one responds to /Health with 200 OK
+        for (const port of ports) {
+          if (await probePort(port)) return port;
+        }
+        return null; // No port responded to /Health
       } catch { /* ignore */ }
       return null;
     }

--- a/test/unit/harper-config-port.test.ts
+++ b/test/unit/harper-config-port.test.ts
@@ -222,12 +222,12 @@ describe("flair#914 — an instance's port comes from Harper's config in its dat
 
     // It found the stub's port — which it can only have got from Harper's
     // config in that directory — and then refused to signal it, because the
-    // flair#910 attribution guard could not tie that listener to this
-    // directory (no hdb.pid). Both halves matter: the port is instance-correct
-    // AND the guard still fires on it.
+    // attribution guard could not tie that listener to this directory (no
+    // hdb.pid). Both halves matter: the port is instance-correct AND the guard
+    // still fires on it.
     expect(exitCode).not.toBe(0);
     expect(stderr).toContain(`port ${stub.port}`);
-    expect(stderr).toContain("cannot be attributed");
+    expect(stderr).toContain("cannot attribute");
     expect(stderr).toContain(resolve(scratch));
     expect(stderr).not.toContain(String(LEGACY_PER_USER_PORT));
 
@@ -250,7 +250,7 @@ describe("flair#914 — an instance's port comes from Harper's config in its dat
 
     expect(exitCode).not.toBe(0);
     expect(stderr).toContain(`port ${stub.port}`);
-    expect(stderr).toContain("cannot be attributed");
+    expect(stderr).toContain("cannot attribute");
     expect(await stub.alive()).toBe(true);
   }, 30_000);
 

--- a/test/unit/port-not-identity.test.ts
+++ b/test/unit/port-not-identity.test.ts
@@ -1,0 +1,524 @@
+/**
+ * port-not-identity.test.ts — Regression tests for the "port is not identity" arc.
+ *
+ * Four issues share the same root shape: "a value that is present but wrong beats
+ * a value that is absent but correct." All four resolve which INSTANCE from a port
+ * and all four get it wrong in the same way.
+ *
+ *   #917  uninstall kills whatever holds the port, then deletes data WITHOUT verifying
+ *         the PID was Flair
+ *   #862  discoverPortFromPid takes the FIRST lsof match; probePort accepts ANY HTTP
+ *         status > 0, so the Node inspector on 9229 wins
+ *   #915  the residual attribution gap #910 left behind (default-dir bypass)
+ *   #819  defaults to 127.0.0.1:19926, works only if the user exported FLAIR_URL
+ *
+ * Pattern: resolve identity from something that actually identifies the instance
+ * (the data dir, the PID file) over anything a stranger can occupy (a port number).
+ *
+ * Each test spawns its own subprocess via Bun.spawn so HOME isolation is real
+ * (same harness convention as harper-config-port.test.ts).
+ */
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync, readFileSync, mkdirSync, existsSync } from "node:fs";
+import { join, resolve } from "node:path";
+import { tmpdir, homedir } from "node:os";
+
+const cliPath = join(import.meta.dirname, "..", "..", "src", "cli.ts");
+
+describe("flair#917 — uninstall refuses to kill a PID that is not this instance's Harper", () => {
+  let tmpHome: string;
+  let shimBin: string;
+  let dataDir: string;
+  const spawned: Array<{ kill: (s?: number) => void }> = [];
+
+  beforeEach(() => {
+    tmpHome = mkdtempSync(join(tmpdir(), "flair917-home-"));
+    shimBin = mkdtempSync(join(tmpdir(), "flair917-bin-"));
+
+    mkdirSync(join(tmpHome, "Library", "LaunchAgents"), { recursive: true });
+    dataDir = join(tmpHome, ".flair", "data");
+    mkdirSync(dataDir, { recursive: true });
+    // A marker whose survival proves the data dir was NOT purged.
+    writeFileSync(join(dataDir, "DO-NOT-DELETE"), "this is user data\n");
+
+    // launchctl shim — records invocations, does nothing
+    writeFileSync(
+      join(shimBin, "launchctl"),
+      `#!/bin/sh\nprintf '%s\\n' "$*" >> "$LAUNCHCTL_LOG"\nexit 0\n`,
+      { mode: 0o755 },
+    );
+  });
+
+  afterEach(() => {
+    for (const proc of spawned.splice(0)) {
+      try { proc.kill(9); } catch {}
+    }
+    rmSync(tmpHome, { recursive: true, force: true });
+    rmSync(shimBin, { recursive: true, force: true });
+  });
+
+  async function runCli(args: string[]) {
+    const env: Record<string, string> = {
+      ...(process.env as Record<string, string>),
+      HOME: tmpHome,
+      PATH: `${shimBin}:${process.env.PATH ?? ""}`,
+      LAUNCHCTL_LOG: join(tmpHome, "launchctl.log"),
+    };
+    delete env.FLAIR_URL;
+    delete env.FLAIR_TARGET;
+    const proc = Bun.spawn(["bun", cliPath, ...args], { env, stdout: "pipe", stderr: "pipe" });
+    const stdout = await new Response(proc.stdout).text();
+    const stderr = await new Response(proc.stderr).text();
+    const exitCode = await proc.exited;
+    return { stdout, stderr, exitCode };
+  }
+
+  /**
+   * A stand-in for "something else is on the port". Runs in its own process so
+   * that a SIGTERM the CLI should never send kills only this stub.
+   */
+  async function spawnForeignServer(): Promise<{ port: number; pid: number; alive: () => Promise<boolean> }> {
+    const portFile = join(tmpHome, `foreign-port-${spawned.length}`);
+    const script = join(tmpHome, `foreign-${spawned.length}.mjs`);
+    writeFileSync(
+      script,
+      [
+        `import { createServer } from "node:http";`,
+        `import { writeFileSync } from "node:fs";`,
+        `const srv = createServer((_req, res) => { res.writeHead(200); res.end('foreign'); });`,
+        `srv.listen(0, "127.0.0.1", () => writeFileSync(process.argv[2], String(srv.address().port)));`,
+      ].join("\n"),
+    );
+    const proc = Bun.spawn(["bun", script, portFile], { stdout: "ignore", stderr: "ignore" });
+    spawned.push(proc);
+    for (let i = 0; i < 100 && !existsSync(portFile); i++) {
+      await new Promise((r) => setTimeout(r, 50));
+    }
+    if (!existsSync(portFile)) throw new Error("foreign server did not report a port");
+    const port = Number(readFileSync(portFile, "utf-8").trim());
+    return {
+      port,
+      pid: (proc as unknown as { pid: number }).pid,
+      alive: async () => {
+        try {
+          return (await fetch(`http://127.0.0.1:${port}/`, { signal: AbortSignal.timeout(2000) })).ok;
+        } catch {
+          return false;
+        }
+      },
+    };
+  }
+
+  test("uninstall --purge refuses to kill a foreign PID on the default port, and does not purge data", async () => {
+    // A foreign server is on port 19926 (DEFAULT_PORT). No PID file exists
+    // (Harper was never installed), so the uninstall should NOT kill anything
+    // and must NOT delete the data directory.
+    const foreign = await spawnForeignServer();
+
+    // Config uses the foreign server's ACTUAL port — this is the port
+    // the uninstall resolver will find, which is the port the foreign
+    // process actually holds.
+    mkdirSync(join(tmpHome, ".flair"), { recursive: true });
+    writeFileSync(join(tmpHome, ".flair", "config.yaml"), `port: ${foreign.port}\n`);
+
+    const { stdout, stderr, exitCode } = await runCli(["uninstall", "--purge"]);
+
+    // The destructive path REFUSED: the foreign server is still alive.
+    expect(await foreign.alive()).toBe(true);
+    // The data directory was NOT purged.
+    expect(existsSync(join(dataDir, "DO-NOT-DELETE"))).toBe(true);
+    // Warning was emitted.
+    expect(stdout + stderr).toContain("Not killing");
+
+    expect(exitCode).toBe(0); // uninstall itself succeeds (just skips the kill)
+  }, 30_000);
+
+  test("uninstall --purge refuses when a PID file exists but the port belongs to another process", async () => {
+    // Harper's PID file exists with one PID, but a foreign process is on the port.
+    // The foreign process must NOT be killed.
+    const foreign = await spawnForeignServer();
+
+    // Config uses the foreign server's ACTUAL port — the same port the
+    // foreign process holds, but the PID file has a DIFFERENT PID.
+    mkdirSync(join(tmpHome, ".flair"), { recursive: true });
+    writeFileSync(join(tmpHome, ".flair", "config.yaml"), `port: ${foreign.port}\n`);
+    // PID file with a PID that does NOT match the foreign server.
+    writeFileSync(join(dataDir, "hdb.pid"), "99999\n");
+
+    const { stdout, stderr, exitCode } = await runCli(["uninstall", "--purge"]);
+
+    // The foreign server survived.
+    expect(await foreign.alive()).toBe(true);
+    // Data was NOT purged.
+    expect(existsSync(join(dataDir, "DO-NOT-DELETE"))).toBe(true);
+    // Warning was emitted.
+    expect(stdout + stderr).toContain("do not match");
+
+    expect(exitCode).toBe(0);
+  }, 30_000);
+});
+
+describe("flair#862 — probePort rejects non-200 responses; discoverPortFromPid scans all ports", () => {
+  let tmpHome: string;
+  let shimBin: string;
+  const spawned: Array<{ kill: (s?: number) => void }> = [];
+
+  beforeEach(() => {
+    tmpHome = mkdtempSync(join(tmpdir(), "flair862-home-"));
+    shimBin = mkdtempSync(join(tmpdir(), "flair862-bin-"));
+    mkdirSync(join(tmpHome, "Library", "LaunchAgents"), { recursive: true });
+    mkdirSync(join(tmpHome, ".flair", "data"), { recursive: true });
+
+    writeFileSync(
+      join(shimBin, "launchctl"),
+      `#!/bin/sh\nprintf '%s\\n' "$*" >> "$LAUNCHCTL_LOG"\nexit 0\n`,
+      { mode: 0o755 },
+    );
+  });
+
+  afterEach(() => {
+    for (const proc of spawned.splice(0)) {
+      try { proc.kill(9); } catch {}
+    }
+    rmSync(tmpHome, { recursive: true, force: true });
+    rmSync(shimBin, { recursive: true, force: true });
+  });
+
+  async function runCli(args: string[]) {
+    const env: Record<string, string> = {
+      ...(process.env as Record<string, string>),
+      HOME: tmpHome,
+      PATH: `${shimBin}:${process.env.PATH ?? ""}`,
+      LAUNCHCTL_LOG: join(tmpHome, "launchctl.log"),
+    };
+    delete env.FLAIR_URL;
+    delete env.FLAIR_TARGET;
+    const proc = Bun.spawn(["bun", cliPath, ...args], { env, stdout: "pipe", stderr: "pipe" });
+    const stdout = await new Response(proc.stdout).text();
+    const stderr = await new Response(proc.stderr).text();
+    const exitCode = await proc.exited;
+    return { stdout, stderr, exitCode };
+  }
+
+  /**
+   * A server that responds with 404 to everything — simulates a non-Flair
+   * HTTP service (e.g., Node inspector) that would have passed the old
+   * `res.status > 0` check.
+   */
+  async function spawnFakeService(): Promise<{ port: number; alive: () => Promise<boolean> }> {
+    const portFile = join(tmpHome, `fake-port-${spawned.length}`);
+    const script = join(tmpHome, `fake-${spawned.length}.mjs`);
+    writeFileSync(
+      script,
+      [
+        `import { createServer } from "node:http";`,
+        `import { writeFileSync } from "node:fs";`,
+        `const srv = createServer((_req, res) => { res.writeHead(404); res.end('not found'); });`,
+        `srv.listen(0, "127.0.0.1", () => writeFileSync(process.argv[2], String(srv.address().port)));`,
+      ].join("\n"),
+    );
+    const proc = Bun.spawn(["bun", script, portFile], { stdout: "ignore", stderr: "ignore" });
+    spawned.push(proc);
+    for (let i = 0; i < 100 && !existsSync(portFile); i++) {
+      await new Promise((r) => setTimeout(r, 50));
+    }
+    if (!existsSync(portFile)) throw new Error("fake service did not report a port");
+    const port = Number(readFileSync(portFile, "utf-8").trim());
+    return {
+      port,
+      alive: async () => {
+        try {
+          const res = await fetch(`http://127.0.0.1:${port}/`, { signal: AbortSignal.timeout(2000) });
+          return res.status === 404; // it's alive if it responds with 404
+        } catch {
+          return false;
+        }
+      },
+    };
+  }
+
+  test("doctor does not accept a 404 response as Harper being alive on a port", async () => {
+    // A fake service responds with 404 to /Health. The old probePort (status > 0)
+    // would have accepted this. The fix (res.ok) rejects it.
+    const fake = await spawnFakeService();
+
+    // Config says this port is Harper's port.
+    writeFileSync(
+      join(tmpHome, ".flair", "config.yaml"),
+      `port: ${fake.port}\n`,
+    );
+
+    const { stdout, stderr, exitCode } = await runCli(["doctor"]);
+
+    // The fake service is still running (doctor doesn't kill it), but doctor
+    // should NOT report it as "Harper responding on port N".
+    // probePort now returns res.ok (200-299 only), so a 404 is rejected.
+    const combined = stdout + stderr;
+    expect(combined).not.toContain(`Harper responding on port ${fake.port}`);
+    // Doctor detects nothing healthy on the port.
+    expect(combined).toContain("Nothing responding on port");
+    expect(combined).toContain("port occupied by PID");
+
+    expect(exitCode).not.toBe(0);
+  }, 30_000);
+});
+
+describe("flair#915 — the default install attribution gap is closed", () => {
+  let tmpHome: string;
+  let shimBin: string;
+  let dataDir: string;
+  const spawned: Array<{ kill: (s?: number) => void }> = [];
+
+  beforeEach(() => {
+    tmpHome = mkdtempSync(join(tmpdir(), "flair915-home-"));
+    shimBin = mkdtempSync(join(tmpdir(), "flair915-bin-"));
+
+    mkdirSync(join(tmpHome, "Library", "LaunchAgents"), { recursive: true });
+    dataDir = join(tmpHome, ".flair", "data");
+    mkdirSync(dataDir, { recursive: true });
+
+    writeFileSync(
+      join(shimBin, "launchctl"),
+      `#!/bin/sh\nprintf '%s\\n' "$*" >> "$LAUNCHCTL_LOG"\nexit 0\n`,
+      { mode: 0o755 },
+    );
+  });
+
+  afterEach(() => {
+    for (const proc of spawned.splice(0)) {
+      try { proc.kill(9); } catch {}
+    }
+    rmSync(tmpHome, { recursive: true, force: true });
+    rmSync(shimBin, { recursive: true, force: true });
+  });
+
+  async function runCli(args: string[]) {
+    const env: Record<string, string> = {
+      ...(process.env as Record<string, string>),
+      HOME: tmpHome,
+      PATH: `${shimBin}:${process.env.PATH ?? ""}`,
+      LAUNCHCTL_LOG: join(tmpHome, "launchctl.log"),
+    };
+    delete env.FLAIR_URL;
+    delete env.FLAIR_TARGET;
+    const proc = Bun.spawn(["bun", cliPath, ...args], { env, stdout: "pipe", stderr: "pipe" });
+    const stdout = await new Response(proc.stdout).text();
+    const stderr = await new Response(proc.stderr).text();
+    const exitCode = await proc.exited;
+    return { stdout, stderr, exitCode };
+  }
+
+  async function spawnForeignServer(): Promise<{ port: number; pid: number; alive: () => Promise<boolean> }> {
+    const portFile = join(tmpHome, `foreign-port-${spawned.length}`);
+    const script = join(tmpHome, `foreign-${spawned.length}.mjs`);
+    writeFileSync(
+      script,
+      [
+        `import { createServer } from "node:http";`,
+        `import { writeFileSync } from "node:fs";`,
+        `const srv = createServer((_req, res) => { res.writeHead(200); res.end('foreign'); });`,
+        `srv.listen(0, "127.0.0.1", () => writeFileSync(process.argv[2], String(srv.address().port)));`,
+      ].join("\n"),
+    );
+    const proc = Bun.spawn(["bun", script, portFile], { stdout: "ignore", stderr: "ignore" });
+    spawned.push(proc);
+    for (let i = 0; i < 100 && !existsSync(portFile); i++) {
+      await new Promise((r) => setTimeout(r, 50));
+    }
+    if (!existsSync(portFile)) throw new Error("foreign server did not report a port");
+    const port = Number(readFileSync(portFile, "utf-8").trim());
+    return {
+      port,
+      pid: (proc as unknown as { pid: number }).pid,
+      alive: async () => {
+        try {
+          return (await fetch(`http://127.0.0.1:${port}/`, { signal: AbortSignal.timeout(2000) })).ok;
+        } catch {
+          return false;
+        }
+      },
+    };
+  }
+
+  test("flair stop refuses to SIGTERM a foreign PID on the default install's port", async () => {
+    // Before #915, the attribution guard skipped the default data dir,
+    // allowing an unattributed SIGTERM. After the fix, it applies to ALL
+    // data directories.
+    const foreign = await spawnForeignServer();
+
+    // Config says this port, and a PID file with a different PID.
+    writeFileSync(join(tmpHome, ".flair", "config.yaml"), `port: ${foreign.port}\n`);
+    writeFileSync(join(dataDir, "hdb.pid"), "88888\n"); // wrong PID
+
+    const { stdout, stderr, exitCode } = await runCli(["stop"]);
+
+    // The foreign server survived — stop refused.
+    expect(await foreign.alive()).toBe(true);
+    expect(exitCode).not.toBe(0);
+    expect(stderr).toContain("cannot attribute");
+  }, 30_000);
+
+  test("flair stop refuses when the default install has no PID file but something is on the port", async () => {
+    // No hdb.pid + something on the port = refuse. This is the exact gap
+    // that #910 left behind for the default install.
+    const foreign = await spawnForeignServer();
+
+    writeFileSync(join(tmpHome, ".flair", "config.yaml"), `port: ${foreign.port}\n`);
+    // No hdb.pid file.
+
+    const { stdout, stderr, exitCode } = await runCli(["stop"]);
+
+    expect(await foreign.alive()).toBe(true);
+    expect(exitCode).not.toBe(0);
+    expect(stderr).toContain("no PID file");
+    expect(stderr).toContain("cannot attribute");
+  }, 30_000);
+});
+
+describe("flair#819 — uninstall reads Harper's config instead of defaulting to 19926", () => {
+  let tmpHome: string;
+  let shimBin: string;
+  let dataDir: string;
+  const spawned: Array<{ kill: (s?: number) => void }> = [];
+
+  beforeEach(() => {
+    tmpHome = mkdtempSync(join(tmpdir(), "flair819-home-"));
+    shimBin = mkdtempSync(join(tmpdir(), "flair819-bin-"));
+
+    mkdirSync(join(tmpHome, "Library", "LaunchAgents"), { recursive: true });
+    dataDir = join(tmpHome, ".flair", "data");
+    mkdirSync(dataDir, { recursive: true });
+
+    writeFileSync(
+      join(shimBin, "launchctl"),
+      `#!/bin/sh\nprintf '%s\\n' "$*" >> "$LAUNCHCTL_LOG"\nexit 0\n`,
+      { mode: 0o755 },
+    );
+  });
+
+  afterEach(() => {
+    for (const proc of spawned.splice(0)) {
+      try { proc.kill(9); } catch {}
+    }
+    rmSync(tmpHome, { recursive: true, force: true });
+    rmSync(shimBin, { recursive: true, force: true });
+  });
+
+  async function runCli(args: string[]) {
+    const env: Record<string, string> = {
+      ...(process.env as Record<string, string>),
+      HOME: tmpHome,
+      PATH: `${shimBin}:${process.env.PATH ?? ""}`,
+      LAUNCHCTL_LOG: join(tmpHome, "launchctl.log"),
+    };
+    delete env.FLAIR_URL;
+    delete env.FLAIR_TARGET;
+    const proc = Bun.spawn(["bun", cliPath, ...args], { env, stdout: "pipe", stderr: "pipe" });
+    const stdout = await new Response(proc.stdout).text();
+    const stderr = await new Response(proc.stderr).text();
+    const exitCode = await proc.exited;
+    return { stdout, stderr, exitCode };
+  }
+
+  async function spawnForeignServer(): Promise<{ port: number; alive: () => Promise<boolean> }> {
+    const portFile = join(tmpHome, `foreign819-port-${spawned.length}`);
+    const script = join(tmpHome, `foreign819-${spawned.length}.mjs`);
+    writeFileSync(
+      script,
+      [
+        `import { createServer } from "node:http";`,
+        `import { writeFileSync } from "node:fs";`,
+        `const srv = createServer((_req, res) => { res.writeHead(200); res.end('foreign'); });`,
+        `srv.listen(0, "127.0.0.1", () => writeFileSync(process.argv[2], String(srv.address().port)));`,
+      ].join("\n"),
+    );
+    const proc = Bun.spawn(["bun", script, portFile], { stdout: "ignore", stderr: "ignore" });
+    spawned.push(proc);
+    for (let i = 0; i < 100 && !existsSync(portFile); i++) {
+      await new Promise((r) => setTimeout(r, 50));
+    }
+    if (!existsSync(portFile)) throw new Error("foreign server did not report a port");
+    const port = Number(readFileSync(portFile, "utf-8").trim());
+    return {
+      port,
+      alive: async () => {
+        try {
+          return (await fetch(`http://127.0.0.1:${port}/`, { signal: AbortSignal.timeout(2000) })).ok;
+        } catch {
+          return false;
+        }
+      },
+    };
+  }
+
+  test("uninstall resolves the port from Harper's config, not from the DEFAULT_PORT fallback", async () => {
+    // Harper's config says port 20500. A foreign server sits on DEFAULT_PORT (19926).
+    // If uninstall resolved to 19926 it would find the foreign server and refuse to
+    // kill it (attribution guard), emitting a warning mentioning 19926 and NOT purging.
+    // With the fix (port = 20500 from Harper's config), nothing is on that port so
+    // uninstall proceeds silently — the foreign server on 19926 is untouched.
+    //
+    // Spawn a foreign server bound to EXACTLY port 19926 so the port mismatch is observable.
+    const portFile = join(tmpHome, "foreign819-port");
+    const script = join(tmpHome, "foreign819.mjs");
+    writeFileSync(
+      script,
+      [
+        `import { createServer } from "node:http";`,
+        `import { writeFileSync } from "node:fs";`,
+        `const srv = createServer((_req, res) => { res.writeHead(200); res.end('foreign'); });`,
+        `srv.listen(19926, "127.0.0.1", () => {`,
+        `  writeFileSync(process.argv[2], "ready");`,
+        `  srv.on('close', () => writeFileSync(process.argv[2], "stopped"));`,
+        `});`,
+      ].join("\n"),
+    );
+    const proc = Bun.spawn(["bun", script, portFile], { stdout: "ignore", stderr: "ignore" });
+    spawned.push(proc);
+    // Wait for the server to be ready
+    for (let i = 0; i < 100; i++) {
+      const content = existsSync(portFile) ? readFileSync(portFile, "utf-8").trim() : "";
+      if (content === "ready") break;
+      await new Promise((r) => setTimeout(r, 50));
+    }
+
+    writeFileSync(
+      join(dataDir, "harper-config.yaml"),
+      `# Harper configuration\nrootPath: ${dataDir}\nhttp:\n  port: 20500\n  cors: true\n`,
+    );
+
+    const { stdout, stderr, exitCode } = await runCli(["uninstall", "--purge"]);
+
+    // Foreign server on 19926 survives — uninstall targeted 20500 (from Harper's config).
+    // If the old code resolved to 19926, the attribution guard would refuse to kill
+    // the foreign process and skip the purge.
+    const stillAlive = await new Promise<boolean>((resolve) => {
+      try {
+        fetch(`http://127.0.0.1:19926/`, { signal: AbortSignal.timeout(2000) })
+          .then(r => resolve(r.ok))
+          .catch(() => resolve(false));
+      } catch {
+        resolve(false);
+      }
+    });
+    expect(stillAlive).toBe(true);
+    // The foreign server on 19926 should NOT be mentioned — uninstall targeted 20500.
+    expect(stdout + stderr).not.toContain("19926");
+    expect(exitCode).toBe(0);
+  }, 30_000);
+
+  test("uninstall falls through to per-user config when Harper's config has no http.port", async () => {
+    // Harper's config exists but has no http.port (e.g., between install and boot).
+    // The resolver should fall back to the per-user config.
+    writeFileSync(
+      join(dataDir, "harper-config.yaml"),
+      `rootPath: ${dataDir}\n`,
+    );
+    writeFileSync(join(tmpHome, ".flair", "config.yaml"), "port: 20501\n");
+
+    const { stdout, stderr, exitCode } = await runCli(["uninstall"]);
+
+    // Should resolve to 20501 from per-user config.
+    expect(exitCode).toBe(0);
+  }, 30_000);
+});

--- a/test/unit/snapshot-datadir-instance-targeting.test.ts
+++ b/test/unit/snapshot-datadir-instance-targeting.test.ts
@@ -286,7 +286,7 @@ describe("flair#902 — snapshot commands target the instance named by --data-di
     ]);
 
     expect(exitCode).not.toBe(0);
-    expect(stderr).toContain("cannot be attributed");
+    expect(stderr).toContain("cannot attribute");
     expect(stderr).toContain(resolve(scratchDataDir));
 
     // The instance on that port is still serving — it was never this


### PR DESCRIPTION
## Summary

Four issues share the same root shape: "a value that is present but wrong beats a value that is absent but correct." All four resolve which **INSTANCE** from a port and all four get it wrong in the same way. This PR fixes all four by resolving identity from something that actually identifies the instance (data dir, PID file, Harper config) rather than a port a stranger can occupy.

### #917 — uninstall --purge refuses to kill a foreign PID

Before: `uninstall --purge` would kill whatever process held the port, then delete ~/.flair unconditionally. A stranger on the port loses their process AND the user loses their data.

After: Before SIGTERM, verify the PID on the port matches this instance's recorded PID (hdb.pid). If no PID file exists or the PIDs don't match, refuse to kill and **do not purge data**.

### #862 — probePort rejects non-200 responses; discoverPortFromPid scans all ports

Before: `probePort` accepted `res.status > 0`, so a 404 from a Node inspector on 9229 was treated as "Harper is alive." `discoverPortFromPid` took the first lsof match (debug port wins).

After: `probePort` returns `res.ok` (200-299 only). `discoverPortFromPid` scans ALL listening ports for the PID and returns the first one responding to /Health with 200 OK.

### #915 — the default-data-dir attribution gap is closed

Before: `assertPortInstanceOwnedBy` skipped the check for the default data directory, allowing an unattributed SIGTERM on the default install's port.

After: The attribution guard applies to ALL data directories. No PID file = refuse to SIGTERM. This is safer than killing the wrong process.

### #819 — uninstall reads Harper's config instead of defaulting to 19926

Before: `uninstall` used `readPortFromConfig() ?? DEFAULT_PORT`, which reads the per-user config (~/.flair/config.yaml) or falls back to 19926. Harper's own config in the data directory was never consulted.

After: Uses `resolveHttpPort()` which reads Harper's config first (data-dir-scoped), falls back to per-user config, then DEFAULT_PORT.

## Tests

- 7 new tests in `test/unit/port-not-identity.test.ts` (2 for #917, 1 for #862, 2 for #915, 2 for #819)
- Minor assertion updates in `harper-config-port.test.ts` and `snapshot-datadir-instance-targeting.test.ts` (error message wording change from "cannot be attributed" to "cannot attribute")
- All 27 tests across 3 files pass
- Mutation checks confirmed: breaking each fix causes its corresponding test to fail

## Files changed

- `src/cli.ts` — stop, uninstall, doctor commands
- `test/unit/port-not-identity.test.ts` — new
- `test/unit/harper-config-port.test.ts` — assertion wording update
- `test/unit/snapshot-datadir-instance-targeting.test.ts` — assertion wording update


Closes #917
Closes #862
Closes #915
Closes #819
