### PR TITLE
fix(docs): quickstart imports server, handle owns nothing, admin cached

### DIFF
--- a/docs/embedding-in-a-harper-app.md
+++ b/docs/embedding-in-a-harper-app.md
@@ -21,6 +21,7 @@ Embedding *adds* the in-process path; `rest: true` keeps serving MCP clients and
 **2. Import the facade and write a memory.**
 
 ```javascript
+import { server } from "harper";
 import { Flair } from "@tpsdev-ai/flair";
 
 const flair = new Flair(server);
@@ -61,6 +62,8 @@ console.log([...server.resources.keys()].sort());   // what Flair registered
 
 One handle per Harper instance. Resolves resources lazily on first use — no lookup at construction time.
 
+**The handle owns nothing.** It holds a reference to the Harper server the caller already owns and acquires no timers, connections, or file handles. There is no `close()` or `dispose()` method. If a future version acquires something releasable, that is a breaking change and will be versioned as one.
+
 ### `flair.as(agentId)`
 
 Returns an `AgentHandle` scoped to that agent. The `agentId` is runtime-validated: missing, empty, blank, or non-string throws `InProcessContextError`.
@@ -84,6 +87,8 @@ planner.agentId;  // "planner"
 ### `flair.admin`
 
 Admin operations — unfiltered reads, cross-agent writes. Every call site is greppable via `git grep "flair.admin"`.
+
+**The handle is cached** — `flair.admin === flair.admin` is `true`. Access it once and reuse the reference, or access it inline; either is fine.
 
 | Method | Description |
 |---|---|
@@ -301,7 +306,7 @@ The facade wraps a lower-level API that is still available for callers who need 
 import { agentContext, adminContext, internalContext, collectionResource } from "@tpsdev-ai/flair/server";
 ```
 
-This is the same seam Flair's own MCP handler and internal tooling use. You should not need it for ordinary agent operations — the facade covers those. Use the primitives when you are building your own abstraction on top of Flair's resources.
+This is the same seam Flair's own MCP handler and internal tooling use. **You should not need it for ordinary agent operations** — the facade covers those. Reach for the primitives when you are building your own abstraction on top of Flair's resources, or when you need the context helpers (`agentContext`, `adminContext`, `internalContext`) to pass into a resource call directly.
 
 ### Resolving a resource
 

--- a/resources/in-process-api.ts
+++ b/resources/in-process-api.ts
@@ -427,6 +427,7 @@ class InternalAgentTable {
  */
 export class Flair {
   #server: FlairServer;
+  #adminHandle?: AdminHandle;
 
   constructor(server: FlairServer) {
     this.#server = server;
@@ -453,7 +454,10 @@ export class Flair {
     // AdminHandle requires an agentId for attribution. We use a sentinel
     // that makes the admin identity visible in audit logs. The caller
     // should use a real admin agent id when possible.
-    return new AdminHandle(this.#server, "_admin");
+    // Cached: the getter returns the same handle on every access so
+    // flair.admin === flair.admin is true (flair#981).
+    this.#adminHandle ??= new AdminHandle(this.#server, "_admin");
+    return this.#adminHandle;
   }
 
   /**

--- a/test/unit/in-process-api.test.ts
+++ b/test/unit/in-process-api.test.ts
@@ -110,6 +110,10 @@ describe("Flair (public in-process API)", () => {
     it("is a property, not a method", () => {
       expect(typeof flair.admin).toBe("object");
     });
+
+    it("returns the same handle on every access (flair#981)", () => {
+      expect(flair.admin).toBe(flair.admin);
+    });
   });
 
   describe("flair.internal", () => {


### PR DESCRIPTION
## What

Four fixes to the embedding doc and in-process API (#981):

### 1. Quickstart imports `server` from "harper"

The quickstart opened with `const flair = new Flair(server)` but never said where `server` comes from. Now imports it:

```javascript
import { server } from "harper";
import { Flair } from "@tpsdev-ai/flair";
const flair = new Flair(server);
```

### 2. Handle owns nothing

`new Flair(server)` holds a reference to the Harper server the caller already owns and acquires no timers, connections, or file handles. There is no `close()` or `dispose()` method. Forward promise: if a future version acquires something releasable, that is a breaking change and will be versioned as one.

### 3. Primitives layer: when to reach for it

The appendix now says explicitly: reach for `@tpsdev-ai/flair/server` when building your own abstraction on top of Flair's resources, or when you need the context helpers (`agentContext`, `adminContext`, `internalContext`) to pass into a resource call directly.

### 4. `flair.admin` cached

The getter now caches the `AdminHandle` in a private field (`#adminHandle`) so `flair.admin === flair.admin` is `true`. Previously every property access returned a new handle.

## Test results

- `test/unit/in-process-api.test.ts`: 19 pass, 0 fail (18→19, +1 caching test)
- `test/unit/in-process-seam.test.ts`: 28 pass, 0 fail
- Docs freshness: 7/7 checks pass

Closes #981.
