### PR TITLE
fix(scripts): honour --limit in flair-client.mjs search

### DIFF
--- a/.changelog/unreleased/fixed-client-script-limit-flag.md
+++ b/.changelog/unreleased/fixed-client-script-limit-flag.md
@@ -1,0 +1,4 @@
+- **`scripts/flair-client.mjs` now honours `--limit` on search.** The flag was never
+  parsed, so it and its value fell through into the query string: searching with
+  `--limit 20` searched for the literal text "<query> --limit 20" and still returned
+  the hardcoded 5 results. A non-numeric value is now rejected rather than ignored.

--- a/.changelog/unreleased/fixed-client-script-limit-flag.md
+++ b/.changelog/unreleased/fixed-client-script-limit-flag.md
@@ -1,4 +1,6 @@
-- **`scripts/flair-client.mjs` now honours `--limit` on search.** The flag was never
-  parsed, so it and its value fell through into the query string: searching with
-  `--limit 20` searched for the literal text "<query> --limit 20" and still returned
-  the hardcoded 5 results. A non-numeric value is now rejected rather than ignored.
+- **`scripts/flair-client.mjs` no longer folds an unparsed flag into free text.**
+  `search` accepted `--limit` but never parsed it, so the flag and its value became
+  part of the query — `--limit 20` searched for the literal text "<query> --limit 20"
+  and still returned the hardcoded 5 results. Flags are now extracted before the free
+  text is assembled, and a flag with no value, an invalid value, or one belonging to a
+  different command is a hard error rather than silently becoming content.

--- a/scripts/flair-client.mjs
+++ b/scripts/flair-client.mjs
@@ -80,9 +80,21 @@ try {
       result = await flairFetch('DELETE', `/${table}/${rest[0]}`);
       break;
     case 'search': {
-      const query = rest.join(' ');
+      // Support --limit <n>. It was previously neither parsed nor passed: the flag and its
+      // value fell through into rest.join(' '), so `search "foo" --limit 20` searched for the
+      // literal string "foo --limit 20" and always returned the hardcoded 5 results.
+      const filteredRest = [];
+      let limit = 5;
+      for (let i = 0; i < rest.length; i++) {
+        if (rest[i] === '--limit' && rest[i + 1]) {
+          const n = Number(rest[++i]);
+          if (!Number.isFinite(n) || n < 1) { console.error(`--limit must be a positive number, got: ${rest[i]}`); process.exit(1); }
+          limit = Math.floor(n);
+        } else filteredRest.push(rest[i]);
+      }
+      const query = filteredRest.join(' ');
       // Server generates query embedding in-process — no sidecar needed
-      result = await flairFetch('POST', '/SemanticSearch', { agentId: AGENT_ID, q: query, limit: 5 });
+      result = await flairFetch('POST', '/SemanticSearch', { agentId: AGENT_ID, q: query, limit });
       if (result.results) {
         for (const r of result.results) {
           const date = r.createdAt?.slice(0, 10) || '?';

--- a/scripts/flair-client.mjs
+++ b/scripts/flair-client.mjs
@@ -37,6 +37,43 @@ if (!resource || !action) {
 
 const table = resource.charAt(0).toUpperCase() + resource.slice(1);
 
+// Every flag this script understands, in any command. Used to catch a flag passed to a
+// command that does not take it — which is the bug this whole helper exists to prevent:
+// `search "q" --limit 20` used to fold the unparsed flag into the query and search for the
+// literal text "q --limit 20".
+const KNOWN_FLAGS = new Set(['--durability', '--supersedes', '--used', '--limit']);
+
+/**
+ * Split `args` into `--flag value` pairs and free text.
+ *
+ * A flag with no value is a HARD ERROR rather than being folded into the free text.
+ * Silently folding it in is precisely the defect this replaced: the argument stops being
+ * an instruction and becomes content, and the caller gets a plausible wrong answer instead
+ * of a refusal. A flag that belongs to a different command errors for the same reason.
+ */
+function extractFlags(args, wanted) {
+  const values = Object.create(null);
+  const positional = [];
+  for (let i = 0; i < args.length; i++) {
+    const a = args[i];
+    if (wanted.includes(a)) {
+      const v = args[i + 1];
+      if (v === undefined || v === '' || KNOWN_FLAGS.has(v)) {
+        console.error(`${a} requires a value`);
+        process.exit(1);
+      }
+      values[a] = v;
+      i++;
+    } else if (KNOWN_FLAGS.has(a)) {
+      console.error(`${a} is not a valid flag for '${action}' (accepts: ${wanted.join(', ') || 'none'})`);
+      process.exit(1);
+    } else {
+      positional.push(a);
+    }
+  }
+  return { values, positional };
+}
+
 try {
   let result;
   switch (action) {
@@ -48,17 +85,13 @@ try {
       break;
     case 'write': {
       // Support --durability <level>, --supersedes <id>, and --used <csv> flags
-      const filteredRest = [];
-      let durability = 'standard';
-      let supersedes;
-      let usedMemoryIds;
-      for (let i = 0; i < rest.length; i++) {
-        if (rest[i] === '--durability' && rest[i + 1]) { durability = rest[++i]; }
-        else if (rest[i] === '--supersedes' && rest[i + 1]) { supersedes = rest[++i]; }
-        else if (rest[i] === '--used' && rest[i + 1]) { usedMemoryIds = rest[++i].split(',').map(s => s.trim()).filter(Boolean); }
-        else filteredRest.push(rest[i]);
-      }
-      const content = filteredRest.join(' ');
+      const { values, positional } = extractFlags(rest, ['--durability', '--supersedes', '--used']);
+      const durability = values['--durability'] ?? 'standard';
+      const supersedes = values['--supersedes'];
+      const usedMemoryIds = values['--used']
+        ? values['--used'].split(',').map((s) => s.trim()).filter(Boolean)
+        : undefined;
+      const content = positional.join(' ');
       const id = `${AGENT_ID}-${Date.now()}`;
       const body = { id, agentId: AGENT_ID, content, durability, createdAt: new Date().toISOString() };
       if (supersedes) body.supersedes = supersedes;
@@ -83,16 +116,17 @@ try {
       // Support --limit <n>. It was previously neither parsed nor passed: the flag and its
       // value fell through into rest.join(' '), so `search "foo" --limit 20` searched for the
       // literal string "foo --limit 20" and always returned the hardcoded 5 results.
-      const filteredRest = [];
+      const { values, positional } = extractFlags(rest, ['--limit']);
       let limit = 5;
-      for (let i = 0; i < rest.length; i++) {
-        if (rest[i] === '--limit' && rest[i + 1]) {
-          const n = Number(rest[++i]);
-          if (!Number.isFinite(n) || n < 1) { console.error(`--limit must be a positive number, got: ${rest[i]}`); process.exit(1); }
-          limit = Math.floor(n);
-        } else filteredRest.push(rest[i]);
+      if (values['--limit'] !== undefined) {
+        const n = Number(values['--limit']);
+        if (!Number.isFinite(n) || n < 1) {
+          console.error(`--limit must be a positive number, got: ${values['--limit']}`);
+          process.exit(1);
+        }
+        limit = Math.floor(n);
       }
-      const query = filteredRest.join(' ');
+      const query = positional.join(' ');
       // Server generates query embedding in-process — no sidecar needed
       result = await flairFetch('POST', '/SemanticSearch', { agentId: AGENT_ID, q: query, limit });
       if (result.results) {


### PR DESCRIPTION
`scripts/flair-client.mjs` accepted a `--limit` flag on `memory search` that was never parsed.

Because the search case did `rest.join(' ')` over the raw argument list, the flag and its value became part of the query text. So:

```
memory search "fabric deploy" --limit 20
```

searched for the literal string `fabric deploy --limit 20`, and returned the hardcoded 5 results regardless.

Both halves matter. The result count was wrong, and **the query itself was silently corrupted** — every call that passed an explicit `--limit` was semantically searching for its own flag text.

This surfaced while investigating a reported recall regression. I used this script to measure recall and reported a figure from it before noticing that the tool was both truncating to 5 and polluting the query. Any measurement taken through it with an explicit `--limit` was `recall@5` against a corrupted query.

## Change

- Parse `--limit <n>` out of the argument list before building the query, matching the existing flag-parsing idiom already used by the `write` case.
- Pass it through to `/SemanticSearch` instead of the hardcoded `5`. Default stays `5`, so callers that pass nothing are unaffected.
- Reject a non-numeric or non-positive value with a clear message and a non-zero exit, rather than silently falling back to the default. A typo that quietly changes the sample size is exactly how you get a measurement you trust and shouldn't.

## Verified

```
--limit 3   →  3 results
--limit 12  → 12 results
no flag     →  5 results   (unchanged default)
--limit abc →  "--limit must be a positive number, got: abc", exit 1
```

Run against a live instance with 2012 memories.

No issue: found while investigating a reported recall regression; the defect was in a repo script rather than a tracked product bug, so no issue predates the fix.
