### PR TITLE
docs: lead the README with the quick start, move Harper below it, and make the comparison honest

### DIFF
--- a/.changelog/unreleased/changed-readme-comparison-honest.md
+++ b/.changelog/unreleased/changed-readme-comparison-honest.md
@@ -1,0 +1,11 @@
+- **`How Flair compares` states positions instead of scoring them.** The old
+  table won every row and then admitted it omitted the rows it would not have
+  won; the three concessions under it each gave with the first clause and took it
+  back with the second. The table now covers the dimensions products actually
+  differ on — where memories live, what memory is scoped to, orchestrator reach,
+  instance-to-instance sync, in-person capture and per-agent character — with no
+  qualifying clauses and no emphasis on our own column.
+
+  SageOx is included, and it holds the row Flair loses: Ox Dot captures in-person
+  meetings, standups and whiteboard sessions, and Flair has no ambient capture of
+  anything that is not already text in a tool.

--- a/.changelog/unreleased/changed-readme-quick-start-first.md
+++ b/.changelog/unreleased/changed-readme-quick-start-first.md
@@ -1,0 +1,12 @@
+- **The README leads with a quick start you can copy-paste.** The lede is now two
+  sentences on identity, memory and soul, and the first runnable command sits on
+  line 17 instead of line 61. The quick start is a single path — install the CLI,
+  init, write a memory, search it back — rather than a fork the reader has to
+  choose between before they have run anything.
+
+  Nothing was dropped. The harness diagram moved below the quick start into its
+  own section, Harper moved from the opening pitch into `How it works`, and the
+  Harper-component path is now a clearly-labelled second door under
+  `Integration → Embedded in a Harper app (in-process)`, where it carries the
+  full in-process contract it used to share with the top of the file. The
+  `sudo` caveat now follows the working install command instead of preceding it.

--- a/.changelog/unreleased/fixed-readme-one-install-claim.md
+++ b/.changelog/unreleased/fixed-readme-one-install-claim.md
@@ -1,0 +1,6 @@
+- **`docs/quickstart.md` no longer claims one install gives you three things.**
+  It said `npm install -g @tpsdev-ai/flair` provides `flair`, `flair-mcp` and the
+  client library; the package declares one binary and neither of the other two as
+  a dependency. Both the quickstart and the README now say what is true: one
+  install, one command, and the MCP adapter is fetched on demand by each client
+  via `npx` rather than installed globally — which is the design, not a gap.

--- a/.changelog/unreleased/fixed-readme-one-install-claim.md
+++ b/.changelog/unreleased/fixed-readme-one-install-claim.md
@@ -1,6 +1,10 @@
 - **`docs/quickstart.md` no longer claims one install gives you three things.**
   It said `npm install -g @tpsdev-ai/flair` provides `flair`, `flair-mcp` and the
   client library; the package declares one binary and neither of the other two as
-  a dependency. Both the quickstart and the README now say what is true: one
-  install, one command, and the MCP adapter is fetched on demand by each client
-  via `npx` rather than installed globally — which is the design, not a gap.
+  a dependency.
+
+  Both the quickstart and the README now separate the two things called "MCP":
+  the server's own `/mcp` endpoint, which ships inside the package but registers
+  no route unless `FLAIR_MCP_OAUTH` and a public issuer are set, and the stdio
+  adapter `@tpsdev-ai/flair-mcp`, which is what MCP clients are actually wired to
+  and is fetched on demand via `npx` rather than installed globally.

--- a/README.md
+++ b/README.md
@@ -6,55 +6,11 @@
 
 > **The identity and memory substrate for AI agents. Crypto-pinned. Federated. Self-hosted.**
 
-Every agent framework gives you chat history. None give you *identity*. Flair gives an agent three things that survive a restart and follow it between orchestrators:
-
-- **Identity** — an Ed25519 keypair. The agent signs every request. No shared secrets.
-- **Memory** — persistent knowledge with semantic search, embedded in-process. No API calls.
-- **Soul** — the personality, values and procedures that make it *that* agent.
-
-Self-hosted on [Harper](https://harper.fast) as a single process. No sidecars, no vector database, no embedding API.
-
-```
-┌──────────────────────────────────────────────────────────────────┐
-│  same agent, same memory, every harness                          │
-│                                                                  │
-│  Claude Code  ─┐                                                 │
-│  Cursor       ─┤                                                 │
-│  Codex CLI    ─┼─[ flair-mcp ]─┐                                 │
-│  Gemini CLI   ─┤               │                                 │
-│  Continue.dev ─┤               │   ┌──────────────────────┐      │
-│  Goose        ─┘               ├─▶ │  Flair (self-hosted) │      │
-│  LangGraph   ─[ langgraph-flair ]──│  Ed25519 / HNSW /    │      │
-│  OpenClaw    ─[ openclaw-flair  ]──│  Soul + Memory       │      │
-│  n8n         ─[ n8n-nodes-flair ]──└──────────┬───────────┘      │
-│  Hermes      ─[ hermes-flair    ]─┘           │ federation       │
-│  Pi agent    ─[ pi-flair        ]─┘           │ (hub/spoke)      │
-│                                               ▼                  │
-│                                    ┌──────────────────────┐      │
-│                                    │  Flair (Fabric hub)  │      │
-│                                    └──────────────────────┘      │
-└──────────────────────────────────────────────────────────────────┘
-```
-
-11 harness surfaces today. Pick whichever you're shipping in; the memory layer doesn't care. **[Full integrations catalog →](docs/integrations.md)**
+Every agent framework gives you chat history. None give you *identity*. Flair gives an agent three things that survive a restart and follow it between orchestrators: an **identity** it proves with an Ed25519 keypair, **memory** it searches by meaning rather than by keyword, and a **soul** — the personality, values and procedures that make it *that* agent.
 
 ## Quick start
 
-Two front doors. Pick by where your code already runs.
-
-### Already on Harper? Load Flair as a component
-
-Flair *is* a Harper component. Deploy it into the instance your application already runs in and call its resources directly — `await h.post({ agentId, content })` is a **method call**, not a network call. No second service to operate, no HTTP round trip, and no key to distribute: a caller in the same process is already inside the trust boundary and names the agent it is acting as, per call.
-
-Adding it takes nothing away. The HTTP surface keeps serving MCP clients and remote agents exactly as before.
-
-**→ [Embedding Flair in a Harper app](docs/embedding-in-a-harper-app.md)** — the whole in-process contract, measured against a real instance: resolving the resource, the table-vs-resource distinction that decides whether your memories are scoped at all, N agents in one process, and registering agents with no shell on the node.
-
-### Everywhere else — install the CLI
-
-A laptop, a VPS, an MCP client, or any language over HTTP. Needs **Node.js 22+** and a **user-writable npm global prefix**.
-
-> ⚠️ **Never `sudo npm install -g @tpsdev-ai/flair`.** A root-owned install can't write the embedding model into its own package directory, so semantic search silently degrades to keyword-only. `flair init` and `flair doctor` will warn you loudly. Use `nvm`, or point npm at your home directory: `npm config set prefix ~/.npm-global` and add `~/.npm-global/bin` to `PATH`.
+Runs on a laptop, a VPS, or anywhere Node does. Needs **Node.js 22+**.
 
 ```bash
 # 1. Install the CLI (no sudo)
@@ -79,11 +35,19 @@ Step 4 finds the memory you never keyword-matched:
 
 That trailing figure is a rank score, normalized so the top hit is always near 100% — ordering, not confidence.
 
-`flair init` installs and starts Harper, creates the agent's Ed25519 keypair, verifies semantic search actually works, wires every MCP client it detects (Claude Code, Cursor, Codex CLI, Gemini CLI) to `npx -y @tpsdev-ai/flair-mcp`, and runs a smoke test. Restart your MCP client afterwards, then ask the agent *"what do you remember about me?"*
+`flair init` installs and starts Harper, creates the agent's Ed25519 keypair, verifies semantic search actually works, wires every MCP client it detects (Claude Code, Cursor, Codex CLI, Gemini CLI), and runs a smoke test. Restart your MCP client afterwards, then ask the agent *"what do you remember about me?"*
 
 > **Pass `--agent`.** A bare `flair init` bootstraps the instance and stops there — no agent, no keypair, no MCP wiring.
 
 Full walkthrough with expected output at every step: **[docs/quickstart.md](docs/quickstart.md)**.
+
+### One install, one binary
+
+`npm install -g @tpsdev-ai/flair` puts a single command on your `PATH`: `flair`. Nothing else is installed, and nothing else needs to be.
+
+The MCP adapter is deliberately *not* a second install. `flair init` writes `npx -y @tpsdev-ai/flair-mcp@<version>` into each client's config — pinned to the CLI's own version — so the client fetches the adapter on demand and there is no second global package to keep in step. `@tpsdev-ai/flair-client` is likewise its own package: add it to a project when you want to call Flair from your own code ([JavaScript / TypeScript](#javascript--typescript)).
+
+It needs a **user-writable npm global prefix**, which is why step 1 says *no sudo*. A root-owned install can't write the embedding model into its own package directory, so semantic search silently degrades to keyword-only. Use `nvm`, or point npm at your home directory — `npm config set prefix ~/.npm-global`, then add `~/.npm-global/bin` to `PATH`. `flair init` and `flair doctor` both check for this and say so loudly.
 
 ### Where the agent's key lives
 
@@ -91,7 +55,7 @@ Full walkthrough with expected output at every step: **[docs/quickstart.md](docs
 
 **Back that file up — it is the agent's identity, and there is one copy.** Memories are not encrypted with it, so losing it costs the identity, not the data: the agent can no longer sign, and every HTTP call it makes fails. Recovery is `flair agent rotate-key mybot`, which mints a new pair and re-registers the public half — it needs the admin password `flair init` wrote to `~/.flair/admin-pass`, so back that up too. Otherwise treat the key like an SSH key: one per agent per host, never copied between machines ([docs/secrets-and-keys.md](docs/secrets-and-keys.md)).
 
-**The in-process path needs no key at all.** Keys are how an agent *outside* the process proves who it is. Code running inside the same Harper instance asserts identity through the call context instead — `agentContext("mybot")` — which Flair reads and acts on with no signature, no `Agent`-table lookup and no registration. That is deliberate: same-process code could write the storage tables directly, so demanding a signature from it would be theatre. It is also why that id must come from your own server-side state and never from request data.
+Keys are how an agent *outside* the process proves who it is. Code running inside the same Harper instance needs no key at all — see [Embedded in a Harper app](#embedded-in-a-harper-app-in-process).
 
 ### Useful flags
 
@@ -138,9 +102,35 @@ Write a memory, then find it by meaning. The same memory is visible to every har
 
 One Ed25519 identity, one memory store, three MCP-capable CLIs. A memory written from Claude Code is retrievable from Codex CLI and Gemini CLI a moment later. Identity and history aren't bound to one orchestrator's runtime.
 
+## One agent, every harness
+
+```
+┌──────────────────────────────────────────────────────────────────┐
+│  same agent, same memory, every harness                          │
+│                                                                  │
+│  Claude Code  ─┐                                                 │
+│  Cursor       ─┤                                                 │
+│  Codex CLI    ─┼─[ flair-mcp ]─┐                                 │
+│  Gemini CLI   ─┤               │                                 │
+│  Continue.dev ─┤               │   ┌──────────────────────┐      │
+│  Goose        ─┘               ├─▶ │  Flair (self-hosted) │      │
+│  LangGraph   ─[ langgraph-flair ]──│  Ed25519 / HNSW /    │      │
+│  OpenClaw    ─[ openclaw-flair  ]──│  Soul + Memory       │      │
+│  n8n         ─[ n8n-nodes-flair ]──└──────────┬───────────┘      │
+│  Hermes      ─[ hermes-flair    ]─┘           │ federation       │
+│  Pi agent    ─[ pi-flair        ]─┘           │ (hub/spoke)      │
+│                                               ▼                  │
+│                                    ┌──────────────────────┐      │
+│                                    │  Flair (Fabric hub)  │      │
+│                                    └──────────────────────┘      │
+└──────────────────────────────────────────────────────────────────┘
+```
+
+11 harness surfaces today. Pick whichever you're shipping in; the memory layer doesn't care. **[Full integrations catalog →](docs/integrations.md)**
+
 ## How it works
 
-Flair is a native [Harper v5](https://harper.fast) application. Harper handles HTTP, persistence (RocksDB), and application logic in one process.
+Flair is a native [Harper v5](https://harper.fast) application. Harper handles HTTP, persistence (RocksDB), and application logic in one process — self-hosted, with no sidecars, no vector database and no embedding API.
 
 ```
 Agent ──[Ed25519-signed request]──▶ Flair (Harper)
@@ -182,20 +172,18 @@ Trust-graded recall reaches the authenticated HTTP API and the native `/mcp` too
 
 ## How Flair compares
 
-| | Flair | Mem0 | Honcho | Letta (MemGPT) | Built-ins (OAI/Anthropic/Google) |
-|---|---|---|---|---|---|
-| **Identity model** | **Ed25519 per agent (crypto-pinned)** | tenant-isolation | per-user soft tenant | runtime-bound | account-scoped |
-| **Federation (peer-to-peer)** | **yes — hub/spoke validated** | no | no | no | no |
-| **Cross-orchestrator** | **11+ harnesses, same memory** | several | several | runtime-bound | vendor-locked |
-| **Soul / persistent character** | **first-class** | optional | persona-shaped | optional | no |
+Every product here does semantic recall over stored memories. These are the dimensions they actually differ on.
 
-Parity rows are omitted: Mem0, Honcho and Letta are all open-source, self-hostable, and do semantic search. Those are table stakes here.
+| | Flair | Mem0 | Honcho | Letta (MemGPT) | [SageOx](https://sageox.ai) | Built-ins (OAI/Anthropic/Google) |
+|---|---|---|---|---|---|---|
+| **Where memories live** | infrastructure you run | self-host or Mem0 Cloud | self-host or hosted API | self-host or Letta Cloud | SageOx cloud | vendor cloud |
+| **Memory is scoped to** | the agent, via an Ed25519 keypair | tenant / user | per-user tenant | the runtime | the team | the account |
+| **Reaches other orchestrators** | 11 harnesses | several | several | Letta's runtime | MCP assistants and its own CLI | no |
+| **Sync between instances you run** | hub/spoke federation | no | no | no | one hosted service | one hosted service |
+| **Captures in-person conversation** | no | no | no | no | yes — Ox Dot | no |
+| **Per-agent persistent character** | first-class (Soul) | optional | persona-shaped | optional | team context, not per-agent | no |
 
-The honest gaps — if you need one of these specifically, use that tool:
-
-- Mem0's **cloud sync UX** is more polished, if you're happy with their hosting.
-- Honcho's **persona model** is more developed, if rich personality modeling is the priority.
-- Letta's **runtime integration** is tighter, if you're building on their agent loop.
+**Where Flair loses.** [SageOx's Ox Dot](https://sageox.ai) records in-person meetings, standups and whiteboard sessions and pipes them into shared context; Flair has no ambient capture of anything that isn't already text in a tool. Mem0's hosted sync is more polished. Honcho's persona model is more developed. Letta's integration with its own agent loop is tighter than anything Flair offers. And there is no Flair-operated cloud — running it is your job.
 
 ## Integration
 
@@ -298,7 +286,11 @@ Sign `agentId:timestamp:nonce:METHOD:/path` with the agent's private key. Protoc
 
 ### Embedded in a Harper app (in-process)
 
-Flair *is* a Harper component. If your application already runs on Harper, load Flair into the same instance and call its resources directly — a method call instead of an HTTP round trip, and no key anywhere.
+The second front door, and the one to take if your code already runs on Harper.
+
+Flair *is* a Harper component. Deploy it into the instance your application already runs in and call its resources directly — `await h.post({ agentId, content })` is a **method call**, not a network call. No second service to operate, no HTTP round trip, and no key to distribute: a caller in the same process is already inside the trust boundary and names the agent it is acting as, per call.
+
+Adding it takes nothing away. The HTTP surface keeps serving MCP clients and remote agents exactly as before.
 
 ```javascript
 import { server } from "harper";
@@ -312,7 +304,11 @@ const h = await collectionResource(Memory, agentContext("mybot"));
 await h.post({ agentId: "mybot", content: "...", durability: "standard" });
 ```
 
-`databases.flair.Memory` is the **table** (raw storage); the exported `Memory` class is the **resource**, where auth, read-scoping, visibility and embedding live. `new Memory(...)` is not a substitute for `collectionResource` — a create needs a collection-bound instance only Harper can produce. Both helpers refuse a missing agent id rather than defaulting it, because a resource invoked with no context resolves to Flair's trusted `internal` verdict and runs unfiltered across every agent. Full guide: **[docs/embedding-in-a-harper-app.md](docs/embedding-in-a-harper-app.md)**.
+`databases.flair.Memory` is the **table** (raw storage); the exported `Memory` class is the **resource**, where auth, read-scoping, visibility and embedding live. `new Memory(...)` is not a substitute for `collectionResource` — a create needs a collection-bound instance only Harper can produce. Both helpers refuse a missing agent id rather than defaulting it, because a resource invoked with no context resolves to Flair's trusted `internal` verdict and runs unfiltered across every agent.
+
+**This path needs no key at all.** Keys are how an agent *outside* the process proves who it is. Code running inside the same Harper instance asserts identity through the call context instead — `agentContext("mybot")` — which Flair reads and acts on with no signature, no `Agent`-table lookup and no registration. That is deliberate: same-process code could write the storage tables directly, so demanding a signature from it would be theatre. It is also why that id must come from your own server-side state and never from request data.
+
+**→ [Embedding Flair in a Harper app](docs/embedding-in-a-harper-app.md)** — the whole in-process contract, measured against a real instance: resolving the resource, the table-vs-resource distinction that decides whether your memories are scoped at all, N agents in one process, and registering agents with no shell on the node.
 
 ### Auth across surfaces
 

--- a/README.md
+++ b/README.md
@@ -43,11 +43,14 @@ Full walkthrough with expected output at every step: **[docs/quickstart.md](docs
 
 ### One install, one binary
 
-`npm install -g @tpsdev-ai/flair` puts a single command on your `PATH`: `flair`. Nothing else is installed, and nothing else needs to be.
+`npm install -g @tpsdev-ai/flair` puts a single command on your `PATH`: `flair`. That is the whole install, and it needs a **user-writable npm global prefix** — which is why step 1 says *no sudo*. A root-owned install can't write the embedding model into its own package directory, so semantic search silently degrades to keyword-only. Use `nvm`, or point npm at your home directory — `npm config set prefix ~/.npm-global`, then add `~/.npm-global/bin` to `PATH`. `flair init` and `flair doctor` both check for this and say so loudly.
 
-The MCP adapter is deliberately *not* a second install. `flair init` writes `npx -y @tpsdev-ai/flair-mcp@<version>` into each client's config — pinned to the CLI's own version — so the client fetches the adapter on demand and there is no second global package to keep in step. `@tpsdev-ai/flair-client` is likewise its own package: add it to a project when you want to call Flair from your own code ([JavaScript / TypeScript](#javascript--typescript)).
+Two different things get called "MCP" here, and you get them differently:
 
-It needs a **user-writable npm global prefix**, which is why step 1 says *no sudo*. A root-owned install can't write the embedding model into its own package directory, so semantic search silently degrades to keyword-only. Use `nvm`, or point npm at your home directory — `npm config set prefix ~/.npm-global`, then add `~/.npm-global/bin` to `PATH`. `flair init` and `flair doctor` both check for this and say so loudly.
+- **The server has an MCP surface built in.** `/mcp` is a JSON-RPC endpoint exposing 12 curated tools, guarded by OAuth bearer tokens. It ships inside the package — and it is **off by default**: until you set `FLAIR_MCP_OAUTH` *and* a public issuer (`FLAIR_MCP_ISSUER`, falling back to `FLAIR_PUBLIC_URL`), no `/mcp` route is registered and the path returns 404. No documented client setup uses it today.
+- **What your MCP client actually talks to is a separate package** — `@tpsdev-ai/flair-mcp`, a stdio adapter — and that one is deliberately not installed globally. `flair init` writes `npx -y @tpsdev-ai/flair-mcp@<version>` into each client's config, pinned to the CLI's own version, so the client fetches it on demand and there is no second global package to keep in step.
+
+`@tpsdev-ai/flair-client` is likewise its own package: add it to a project when you want to call Flair from your own code ([JavaScript / TypeScript](#javascript--typescript)).
 
 ### Where the agent's key lives
 
@@ -168,7 +171,7 @@ See **[DESIGN.md](DESIGN.md)** for the invariants behind the three primitives �
 | **Web admin** | Server-rendered UI for principals, connectors, IdPs and instance config. No separate dashboard service. |
 | **Benchmarks** | [`flair-bench`](packages/flair-bench/README.md) scores candidate embedding models against the same recall corpus Flair's CI gates on. Runs standalone — no Flair install, no server. |
 
-Trust-graded recall reaches the authenticated HTTP API and the native `/mcp` tools today; CLI, `@tpsdev-ai/flair-client` and `flair-mcp` exposure is a follow-up. REM needs a configured generative backend (Ollama, OpenAI, Anthropic, …) — without one, `flair rem rapid` fails with `Reflection error: No generative backend configured`.
+Trust-graded recall reaches the authenticated HTTP API and the built-in `/mcp` tools today — the latter being off by default, see [One install, one binary](#one-install-one-binary). CLI, `@tpsdev-ai/flair-client` and `flair-mcp` exposure is a follow-up. REM needs a configured generative backend (Ollama, OpenAI, Anthropic, …) — without one, `flair rem rapid` fails with `Reflection error: No generative backend configured`.
 
 ## How Flair compares
 
@@ -178,7 +181,7 @@ Every product here does semantic recall over stored memories. These are the dime
 |---|---|---|---|---|---|---|
 | **Where memories live** | infrastructure you run | self-host or Mem0 Cloud | self-host or hosted API | self-host or Letta Cloud | SageOx cloud | vendor cloud |
 | **Memory is scoped to** | the agent, via an Ed25519 keypair | tenant / user | per-user tenant | the runtime | the team | the account |
-| **Reaches other orchestrators** | 11 harnesses | several | several | Letta's runtime | MCP assistants and its own CLI | no |
+| **Reaches other orchestrators** | 11 harnesses, incl. workflow and agent frameworks | several | several | Letta's runtime | 14+ coding agents and editors, via hooks, plugins and instruction files | no |
 | **Sync between instances you run** | hub/spoke federation | no | no | no | one hosted service | one hosted service |
 | **Captures in-person conversation** | no | no | no | no | yes — Ox Dot | no |
 | **Per-agent persistent character** | first-class (Soul) | optional | persona-shaped | optional | team context, not per-agent | no |

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -26,7 +26,7 @@ export PATH="$HOME/.npm-global/bin:$PATH"   # add this to ~/.zshrc or ~/.bashrc
 npm install -g @tpsdev-ai/flair
 ```
 
-One install gives you `flair`, `flair-mcp` and the client library.
+One install gives you one command: `flair`. The MCP server is *not* installed — `flair init` wires each client to fetch it on demand with `npx -y @tpsdev-ai/flair-mcp@<version>`, so there is no second global package to keep in step. `@tpsdev-ai/flair-client` is a separate package you add to your own project when you want to call Flair from code.
 
 ## 2. Bootstrap Flair and register an agent
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -26,7 +26,9 @@ export PATH="$HOME/.npm-global/bin:$PATH"   # add this to ~/.zshrc or ~/.bashrc
 npm install -g @tpsdev-ai/flair
 ```
 
-One install gives you one command: `flair`. The MCP server is *not* installed — `flair init` wires each client to fetch it on demand with `npx -y @tpsdev-ai/flair-mcp@<version>`, so there is no second global package to keep in step. `@tpsdev-ai/flair-client` is a separate package you add to your own project when you want to call Flair from code.
+One install gives you one command: `flair`.
+
+The stdio adapter your MCP client talks to is a separate package, `@tpsdev-ai/flair-mcp`, and it is deliberately not installed globally — `flair init` wires each client to fetch it on demand with `npx -y @tpsdev-ai/flair-mcp@<version>`, so there is no second global package to keep in step. (The server also has its own `/mcp` endpoint built in, but it is off by default — it registers no route unless `FLAIR_MCP_OAUTH` and a public issuer are set — and no client setup in this guide uses it.) `@tpsdev-ai/flair-client` is a separate package you add to your own project when you want to call Flair from code.
 
 ## 2. Bootstrap Flair and register an agent
 


### PR DESCRIPTION
## The problem

A reader who has never heard of Flair hit ~40 lines of badges, a three-bullet pitch and a 20-line harness diagram before reaching "Quick start". The quick start then opened with a fork ("Two front doors. Pick by where your code already runs"), a paragraph about in-process trust boundaries, a docs link, and a bolded `sudo` warning — before any command.

**The first runnable command was on line 61. It is now on line 17.**

Harper also led the pitch, and the *first* item under Quick start was "Already on Harper? Load Flair as a component" — the narrowest audience in front of the widest section.

## Structure, before → after

| Before | After |
|---|---|
| Title + badges | Title + badges |
| Tagline | Tagline |
| 3-bullet Identity/Memory/Soul pitch | Lede — one paragraph, Identity/Memory/Soul |
| "Self-hosted on Harper as a single process" | **`## Quick start`** — one path, first command line 17 |
| 20-line harness ASCII diagram | `### One install, one binary` |
| "11 harness surfaces today" | `### Where the agent's key lives` |
| **`## Quick start`** ("Two front doors") | `### Useful flags` / `### Lifecycle` / `### Upgrading` |
| `### Already on Harper? Load Flair as a component` | `## What it looks like` |
| `### Everywhere else — install the CLI` | `## One agent, every harness` ← diagram lives here |
| ⚠️ sudo warning | `## How it works` ← Harper lives here |
| first command (line 61) | `## Features` / `## How Flair compares` |
| … | `## Integration` → `### Embedded in a Harper app (in-process)` ← second door |

## What moved where

- **Harper is out of the lede.** The single-process claim — no sidecars, no vector database, no embedding API — is intact, in `How it works`, which is where it was always going to be read. Nobody chooses a memory layer because of its host.
- **The Harper-component path is a clearly-labelled second door** under `Integration → Embedded in a Harper app (in-process)`. It is not reduced: it now carries the whole in-process contract that used to be split between the top of the file and that section, including "adding it takes nothing away", the method-call-not-network-call framing, and the "this path needs no key at all" paragraph that was stranded under `Where the agent's key lives`.
- **The harness diagram** moved below the quick start into its own section, with its caption and catalog link.
- **The `sudo` caveat now follows the working command.** Step 1 keeps the inline `# 1. Install the CLI (no sudo)` comment so a copy-paste is still safe; the full explanation sits below, under `One install, one binary`.

No content was deleted to shorten. Every existing link target is preserved — `#integration` and `#remote-server` are the only README anchors linked from elsewhere in the repo, and both are unchanged.

## Packaging, stated truthfully

Closes #990.

Verified against the published package before writing a word of it:

```
$ npm view @tpsdev-ai/flair@0.32.0 bin dependencies
bin: { flair: 'dist/cli-shim.cjs' }
```

One binary. Neither `@tpsdev-ai/flair-mcp` nor `@tpsdev-ai/flair-client` is a dependency. `docs/quickstart.md:29` said *"One install gives you `flair`, `flair-mcp` and the client library"* — two thirds false.

Both files now say what is true. **Review correction:** my first pass wrote "the MCP server is *not* installed", which was misleading in the other direction — the server does have an MCP surface built in. The text now separates the two things called "MCP", and overstates neither:

- **The built-in surface.** `resources/mcp-handler.ts` is a custom in-process `/mcp` JSON-RPC endpoint exposing 12 curated tools (`listToolDefs()`), wrapped by `@harperfast/oauth`'s `withMCPAuth`. It ships in the package — and it is **default-off**. `registerMcpOAuthRoute()` opens with `if (!mcpOAuthEnabled()) return false; // OFF → no route, no import, no side effects.` Enabling `FLAIR_MCP_OAUTH` alone is not enough either: with no issuer set it logs and bails without mounting.
- **The stdio adapter**, `@tpsdev-ai/flair-mcp` — what clients are actually wired to, and what genuinely is not installed by `npm i -g`.

Verified on a default install, probed with the correct method since `/mcp` is POST JSON-RPC:

```
POST /mcp             -> 404
POST /OAuthToken      -> 400   (control: a route that IS registered)
POST /zzz-not-a-route -> 404   (control: a route that is NOT registered)
```

`/mcp` is indistinguishable from a nonexistent path; a registered POST route on the same instance answers 400.

The Features note that said trust-graded recall reaches "the native `/mcp` tools today" is qualified for the same reason — left alone it contradicted the new text three sections below it. That line is pre-existing and outside the original brief; flagging it explicitly so it can be reverted if you'd rather keep the diff tight.

So the packaging direction is true today, stated precisely: `flair` is the one install, and MCP is an optional adapter rather than a second mandatory thing.

## `How Flair compares` — rebuilt

Two problems with the old section:

1. Four rows, and we won all four — then the text admitted it: *"Parity rows are omitted."* That is a scorecard, not a comparison.
2. Each of the three "honest gaps" gave with the first clause and took it back with the second — *"more polished, **if you're happy with their hosting**"*, *"more developed, **if rich personality modeling is the priority**"*, *"tighter, **if you're building on their agent loop**"*. Labelling that "honest" made it worse.

The new table covers dimensions a reader actually chooses on, states each product's position flatly, drops the bolding of our own column, and drops the qualifying clauses. It now contains a row where we are **not** ahead (where memories live — the others offer a hosted option and we don't) and a row we **lose** outright.

**SageOx is added**, and it holds the losing row. Everything asserted about them is from public sources:

- Store is theirs — the quickstart in `github.com/sageox/ox` is `ox login  # authenticate with sageox.ai`, and no self-hosting path is documented anywhere public. The table says "SageOx cloud", not "closed" — the CLI is MIT-licensed (confirmed via the GitHub API), so an open-source-vs-closed framing would have been both wrong and a jab.
- Memory is scoped to the team — their own copy: `ox init` "ties the repo to your team", context is "agent-agnostic", primed into whichever agent the team uses.
- **Ox Dot captures in-person discussions — "meetings, standups, whiteboard sessions"** (sageox.ai). Flair has nothing comparable: `grep` across the repo finds no audio, transcription or meeting capture; Flair's "ambient memory" is a harness SessionStart hook over text that is already in a tool.
- **Reach.** *(Review correction — the first pass undersold them.)* The cell said "MCP assistants and its own CLI". Their published compatibility table lists **14 named coding agents and editors** — Claude Code, Codex CLI, Gemini CLI, Droid, OpenCode, Amp, Pi, Aider and Goose wired via hooks, plugins or `AGENTS.md`/`CONVENTIONS.md`, plus Cursor, Windsurf, Cline, Copilot and Kiro via instruction file — with separate orchestrator integrations beyond that. The cell now reads "14+ coding agents and editors, via hooks, plugins and instruction files", and the Flair cell names its own kind of reach ("11 harnesses, incl. workflow and agent frameworks") so the real distinction — Flair reaches non-coding surfaces, SageOx is coding-agent centric — is drawn accurately rather than by omission. On raw coding-tool count they beat us, and the table now shows that.

That last one is the row we lose, and it is the best evidence a reader has that the other rows are trustworthy.

The closing paragraph is now four flat concessions with no take-backs, including "there is no Flair-operated cloud — running it is your job."

I left funding, headcount and headquarters out. They are not dimensions anyone chooses a memory layer on, and they go stale.

## Gates

- `node scripts/docs-freshness-check.mjs` — **7/7 ran and passed** (CLI built first, so `cli-command-descriptions` genuinely ran rather than reporting `⊘ DID NOT RUN`).
- `scripts/check-impl-term-leaks.sh` — clean across 45 files, non-empty corpus.
- Pre-commit hooks — including **ASCII box alignment**, which is the check that the diagram survived being moved.
- `tsc -p tsconfig.json --noEmit` — one error, `resources/auth-middleware.ts(70,1) TS2722`, pre-existing and unrelated. This branch is documentation only.
- Three changelog fragments, validated with `node scripts/changelog-fragments.mjs check`.

## Found while verifying, filed separately

- **#1001** — `resources/AdminInstance.ts` renders `MCP → <publicUrl>/mcp` in its Endpoints table unconditionally, with no reference to `FLAIR_MCP_OAUTH` anywhere in the file. So a default install's own admin dashboard advertises an endpoint that 404s. A disabled capability rendering as an available one. Filed with the probe evidence and both controls; not fixed here, since this branch is documentation only.
- `resources/mcp-oauth-flag.ts` says "The curated 9 tools" and points at a `docs/mcp-oauth.md` that does not exist in the tree. `listToolDefs()` returns **12**. Stale comment plus a dangling doc reference — not touched by a docs-only branch, noted for whoever picks up #998.

## Not changed, deliberately

- The rest of `docs/quickstart.md`. Only the false install claim was in scope.
- Claims about Mem0, Honcho and Letta that already existed in the table. I reframed presentation and added the "where memories live" row from their own published docs, but did not invent new assertions about them.
- Any SageOx cell I could not source publicly. Their federation and per-agent-character positions are stated only as far as their own material goes.
