### PR TITLE
fix(cli): honour search --explain when stdout is not a TTY (#992)

### DIFF
--- a/.changelog/unreleased/fixed-search-explain-non-tty.md
+++ b/.changelog/unreleased/fixed-search-explain-non-tty.md
@@ -1,0 +1,13 @@
+- **`flair search --explain` now works when stdout is not a terminal.** Previously
+  the flag was accepted and silently did nothing for every script, agent, CI job
+  or `| less` — a non-TTY stdout selects JSON output, and the JSON path returned
+  before the breakdown was ever rendered. The breakdown now rides along the JSON
+  as an `_explain` object on each hit, so non-interactive callers get it too.
+  Output without `--explain` is unchanged.
+
+  The breakdown itself is also more truthful: it no longer labels a raw score
+  `composite=` under the default `--scoring raw`, and it no longer reports
+  `retrievalCount`, which stopped participating in the composite formula when
+  usage replaced retrieval as the reinforcement signal. It now reports the
+  ranking inputs the server actually returned — raw score, composite score under
+  `--scoring composite`, durability, age and usage count.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -131,7 +131,7 @@ You searched for a concept, not the keywords. The line under each hit is its cre
 
 > The percentage is a **rank-fusion score, not a similarity**. It is normalized so the top result is always near 100%. Read it as ordering within these results, never as confidence that the match is good.
 
-Add `--explain` to see the ranking inputs, or `--limit`, `--tag`, `--since 7d` to narrow the search. `flair memory search` runs the same query but always prints raw JSON — use it when piping to a script.
+Add `--explain` to see the ranking inputs per hit — the raw score, the composite score under `--scoring composite`, and the record's durability, age and usage count. When output is JSON (`--json`, or any time stdout is not a terminal) the same breakdown arrives as an `_explain` object on each hit, so scripts get it too. Use `--limit`, `--tag`, `--since 7d` to narrow the search. `flair memory search` runs the same query but always prints raw JSON — use it when piping to a script.
 
 ## 6. Give your agent context on boot
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -14408,6 +14408,94 @@ function parseRelativeOrIso(input: string | undefined): string | null {
   return new Date(Date.now() - n * (multMs[unit] ?? 0)).toISOString();
 }
 
+// ─── --explain score breakdown (flair#992) ───────────────────────────────────
+//
+// One builder feeds BOTH output modes. Before #992 the breakdown was assembled
+// inline inside the human-rendering branch, which sits after an early `return`
+// on json mode — and non-TTY stdout resolves to json mode (render.ts
+// resolveOutputMode). So `--explain` was inert for every script, agent, CI job
+// and pipe, with no error. Sharing one builder is what keeps the two modes from
+// drifting apart again.
+//
+// What this can and cannot report:
+//
+//   - It reports what the SERVER sent. `--explain` is client-side: the
+//     /SemanticSearch request carries no `explain` key and the resource has no
+//     such parameter, so the durability WEIGHT, recency DECAY and usage BOOST
+//     that compositeScore() multiplies are not available here.
+//   - It deliberately does NOT recompute those weights client-side. They depend
+//     on floors read from the SERVER's environment
+//     (FLAIR_COMPOSITE_RELEVANCE_FLOOR / FLAIR_COMPOSITE_DISCOUNT_FLOOR), so a
+//     client-side recomputation would print confident numbers the ranking never
+//     used. Reporting the ranking INPUTS the server returned on the record is
+//     honest; inventing the weights is not.
+//   - Under `--scoring raw` the server puts the raw score in `_score` and omits
+//     `_rawScore`. Labelling `_score` "composite" in that mode — as the pre-#992
+//     block did — mislabels a raw score.
+//   - retrievalCount is NOT reported. flair#683 replaced retrievalBoost with
+//     usageBoost outright; retrievalCount no longer participates in the score,
+//     and a breakdown must not name a term the ranking stopped using.
+export type SearchScoringMode = "raw" | "composite";
+
+export type SearchExplain = {
+  scoring: SearchScoringMode;
+  formula: string;
+  raw?: number;
+  composite?: number;
+  durability: string;
+  ageDays?: number;
+  usageCount: number;
+};
+
+export function searchScoringFormula(scoring: SearchScoringMode): string {
+  return scoring === "composite"
+    ? "semantic × durability-weight × recency-decay × usage-boost"
+    : "cosine similarity only";
+}
+
+export function buildSearchExplain(record: any, scoring: SearchScoringMode, now: number = Date.now()): SearchExplain {
+  const score = typeof record?._score === "number" ? record._score : undefined;
+  const rawScore = typeof record?._rawScore === "number" ? record._rawScore : undefined;
+
+  // composite mode: server sends both (_rawScore = pre-composite semantic).
+  // raw mode: server sends only _score, and that IS the raw score.
+  const raw = scoring === "composite" ? rawScore : score;
+  const composite = scoring === "composite" ? score : undefined;
+
+  let ageDays: number | undefined;
+  if (record?.createdAt) {
+    const created = new Date(String(record.createdAt)).getTime();
+    if (Number.isFinite(created)) ageDays = Math.max(0, Math.floor((now - created) / 86_400_000));
+  }
+
+  const explain: SearchExplain = {
+    scoring,
+    formula: searchScoringFormula(scoring),
+    durability: record?.durability ?? "standard",
+    usageCount: typeof record?.usageCount === "number" ? record.usageCount : 0,
+  };
+  if (typeof raw === "number") explain.raw = raw;
+  if (typeof composite === "number") explain.composite = composite;
+  if (typeof ageDays === "number") explain.ageDays = ageDays;
+  return explain;
+}
+
+// Human one-liner for a hit's breakdown. Scoring terms come from the shared
+// builder; the trailing tags/subject/supersedes are record context that json
+// mode already carries at top level, so they're appended here only.
+export function formatSearchExplain(explain: SearchExplain, record: any): string {
+  const parts: string[] = [];
+  if (typeof explain.raw === "number") parts.push(`raw=${explain.raw.toFixed(3)}`);
+  if (typeof explain.composite === "number") parts.push(`composite=${explain.composite.toFixed(3)}`);
+  parts.push(`durability=${explain.durability}`);
+  if (typeof explain.ageDays === "number") parts.push(`age=${explain.ageDays}d`);
+  parts.push(`usage=${explain.usageCount}`);
+  if (Array.isArray(record?.tags) && record.tags.length > 0) parts.push(`tags=[${record.tags.join(",")}]`);
+  if (record?.subject) parts.push(`subject=${record.subject}`);
+  if (record?.supersedes) parts.push(`supersedes=${record.supersedes}`);
+  return parts.join(" · ");
+}
+
 program
   .command("search <query>")
   .description("Search memories by meaning (shortcut for memory search) — filterable, with --explain ranking")
@@ -14430,7 +14518,7 @@ program
   .option("--durability <level>", "Filter to permanent|persistent|standard|ephemeral (client-side)")
   .option("--source <name>", "Filter by source/agentId (client-side)")
   // Output modes
-  .option("--explain", "Show score breakdown (composite, raw, durability, age, retrieval) per hit")
+  .option("--explain", "Show score breakdown (raw, composite, durability, age, usage) per hit — also added to --json output as _explain")
   .option("--json", "Output raw JSON array")
   .action(async (query, opts) => {
     try {
@@ -14485,8 +14573,17 @@ program
       }
 
       const mode = render.resolveOutputMode(opts);
+      const scoringMode: SearchScoringMode = payload.scoring === "composite" ? "composite" : "raw";
       if (mode === "json") {
-        console.log(render.asJSON(results));
+        // flair#992: --explain must be honoured here, not silently dropped.
+        // This branch is what every non-TTY caller lands in. The breakdown
+        // rides ALONG the json contract as an opt-in `_explain` key — present
+        // only when the caller typed --explain, so default output is unchanged
+        // — rather than switching output mode behind the caller's back.
+        const out = opts.explain
+          ? results.map((r) => ({ ...r, _explain: buildSearchExplain(r, scoringMode) }))
+          : results;
+        console.log(render.asJSON(out));
         return;
       }
 
@@ -14530,29 +14627,17 @@ program
         console.log(`  ${r.content}`);
         if (meta) console.log(`  ${render.wrap(render.c.dim, "(")} ${meta} ${render.wrap(render.c.dim, ")")}`);
         if (opts.explain) {
-          const parts: string[] = [];
-          if (typeof r._rawScore === "number") parts.push(`raw=${r._rawScore.toFixed(3)}`);
-          if (typeof r._score === "number") parts.push(`composite=${r._score.toFixed(3)}`);
-          if (typeof r.retrievalCount === "number" && r.retrievalCount > 0) parts.push(`retrievals=${r.retrievalCount}`);
-          if (r.tags && Array.isArray(r.tags) && r.tags.length > 0) parts.push(`tags=[${r.tags.join(",")}]`);
-          if (r.subject) parts.push(`subject=${r.subject}`);
-          if (r.supersedes) parts.push(`supersedes=${r.supersedes}`);
-          if (parts.length > 0) {
-            console.log(
-              `    ${render.wrap(render.c.gray, "└─")} ${render.wrap(render.c.dim, parts.join(" · "))}`,
-            );
+          const line = formatSearchExplain(buildSearchExplain(r, scoringMode), r);
+          if (line) {
+            console.log(`    ${render.wrap(render.c.gray, "└─")} ${render.wrap(render.c.dim, line)}`);
           }
         }
         console.log();
       }
 
       if (opts.explain) {
-        const formula =
-          payload.scoring === "composite"
-            ? "semantic × durability-weight × recency-decay × retrieval-boost"
-            : "cosine similarity only";
         console.log(
-          `${render.wrap(render.c.dim, "Scoring:")} ${render.wrap(render.c.bold, payload.scoring)}  ${render.wrap(render.c.dim, `(${formula})`)}`,
+          `${render.wrap(render.c.dim, "Scoring:")} ${render.wrap(render.c.bold, scoringMode)}  ${render.wrap(render.c.dim, `(${searchScoringFormula(scoringMode)})`)}`,
         );
       }
     } catch (err: any) {

--- a/test/unit/cli-search-explain.test.ts
+++ b/test/unit/cli-search-explain.test.ts
@@ -1,0 +1,193 @@
+// cli-search-explain.test.ts — Flair #992
+//
+// `flair search --explain` was a silent no-op for every non-TTY caller.
+// render.resolveOutputMode() maps non-TTY stdout to json mode, and the search
+// action returns early on json mode — before the explain block ever runs. So
+// every script, agent, CI job and `| less` got no breakdown and no error:
+// absence rendering as success.
+//
+// These tests spawn the real CLI against a mock HTTP server. `spawn` gives the
+// child a PIPE for stdout, so process.stdout.isTTY is false — that is the exact
+// broken path, and it is the only path these tests exercise. A test that forced
+// FLAIR_OUTPUT=human would pass with the defect still in place.
+//
+// Also covers the second half of #992: the breakdown must not mislabel a raw
+// score as "composite", and must not report retrievalCount, which flair#683
+// removed from the scoring formula outright.
+
+import { describe, it, expect } from "bun:test";
+import { spawn } from "node:child_process";
+import { createServer, Server } from "node:http";
+import { buildSearchExplain, formatSearchExplain, searchScoringFormula } from "../../src/cli.js";
+
+const HIT = {
+  id: "m1",
+  content: "Harper v5 sandbox blocks node:module but process.dlopen works",
+  agentId: "a",
+  durability: "permanent",
+  createdAt: "2026-05-01T00:00:00.000Z",
+  usageCount: 3,
+  retrievalCount: 11,
+  tags: ["sandbox"],
+  subject: "runtime",
+  _score: 0.812,
+  _rawScore: 0.744,
+};
+
+function startMockServer(payload: unknown): Promise<{ server: Server; url: string }> {
+  return new Promise((resolve) => {
+    const server = createServer((req, res) => {
+      let body = "";
+      req.on("data", (c) => (body += c));
+      req.on("end", () => {
+        res.writeHead(200, { "Content-Type": "application/json" });
+        res.end(JSON.stringify(payload));
+      });
+    });
+    server.listen(0, "127.0.0.1", () => {
+      const port = (server.address() as any).port;
+      resolve({ server, url: `http://127.0.0.1:${port}` });
+    });
+  });
+}
+
+// stdout is a pipe here, never a TTY — that is the point of this harness.
+function runCli(args: string[], env: NodeJS.ProcessEnv): Promise<{ code: number | null; stdout: string; stderr: string }> {
+  return new Promise((resolve) => {
+    const child = spawn("bun", ["src/cli.ts", ...args], { cwd: ".", env });
+    let out = "";
+    let err = "";
+    child.stdout?.on("data", (d) => (out += d.toString()));
+    child.stderr?.on("data", (d) => (err += d.toString()));
+    child.on("close", (code) => resolve({ code, stdout: out, stderr: err }));
+  });
+}
+
+async function searchWith(args: string[], results: unknown[]) {
+  const { server, url } = await startMockServer({ results });
+  try {
+    const r = await runCli(args, {
+      ...process.env,
+      FLAIR_URL: url,
+      FLAIR_AGENT_ID: "",
+      // Deliberately NOT setting FLAIR_OUTPUT: the resolved mode must come
+      // from TTY detection, which is what the bug hinged on.
+      FLAIR_OUTPUT: "",
+    });
+    return r;
+  } finally {
+    await new Promise<void>((res) => server.close(() => res()));
+  }
+}
+
+describe("flair search --explain over a non-TTY stdout (flair#992)", () => {
+  it("emits a per-hit _explain block when piped, instead of silently dropping the flag", async () => {
+    const { code, stdout } = await searchWith(
+      ["search", "sandbox", "--agent", "a", "--explain"],
+      [HIT],
+    );
+    expect(code).toBe(0);
+
+    const parsed = JSON.parse(stdout);
+    expect(Array.isArray(parsed)).toBe(true);
+    expect(parsed).toHaveLength(1);
+
+    // The whole bug: before the fix this key did not exist on any non-TTY run.
+    expect(parsed[0]._explain).toBeDefined();
+    expect(parsed[0]._explain.scoring).toBe("raw");
+    expect(parsed[0]._explain.durability).toBe("permanent");
+    expect(parsed[0]._explain.usageCount).toBe(3);
+    expect(typeof parsed[0]._explain.ageDays).toBe("number");
+  });
+
+  it("emits _explain under --explain --json too", async () => {
+    const { code, stdout } = await searchWith(
+      ["search", "sandbox", "--agent", "a", "--explain", "--json"],
+      [HIT],
+    );
+    expect(code).toBe(0);
+    const parsed = JSON.parse(stdout);
+    expect(parsed[0]._explain).toBeDefined();
+    expect(parsed[0]._explain.formula).toBe("cosine similarity only");
+  });
+
+  it("reports composite and raw as separate terms under --scoring composite", async () => {
+    const { code, stdout } = await searchWith(
+      ["search", "sandbox", "--agent", "a", "--explain", "--scoring", "composite"],
+      [HIT],
+    );
+    expect(code).toBe(0);
+    const ex = JSON.parse(stdout)[0]._explain;
+    expect(ex.scoring).toBe("composite");
+    expect(ex.raw).toBe(0.744); // _rawScore — the pre-composite semantic score
+    expect(ex.composite).toBe(0.812); // _score
+  });
+
+  it("never labels a raw score 'composite' under the default raw scoring", async () => {
+    // Under --scoring raw the server puts the raw score in _score and omits
+    // _rawScore. The pre-#992 renderer printed that as `composite=`.
+    const rawHit = { ...HIT, _score: 0.744, _rawScore: undefined };
+    const { stdout } = await searchWith(
+      ["search", "sandbox", "--agent", "a", "--explain"],
+      [rawHit],
+    );
+    const ex = JSON.parse(stdout)[0]._explain;
+    expect(ex.raw).toBe(0.744);
+    expect(ex.composite).toBeUndefined();
+  });
+
+  it("does not report retrievalCount as a scoring term (flair#683 removed it)", async () => {
+    const { stdout } = await searchWith(
+      ["search", "sandbox", "--agent", "a", "--explain"],
+      [HIT],
+    );
+    const ex = JSON.parse(stdout)[0]._explain;
+    expect(ex.retrievalCount).toBeUndefined();
+    expect(ex.retrievals).toBeUndefined();
+    expect(JSON.stringify(ex)).not.toContain("retrieval");
+  });
+
+  it("leaves JSON output byte-identical when --explain is absent", async () => {
+    // Positive control for the opt-in claim: the widened shape must appear
+    // ONLY when the caller typed the flag.
+    const { stdout } = await searchWith(["search", "sandbox", "--agent", "a"], [HIT]);
+    const parsed = JSON.parse(stdout);
+    expect(parsed[0]._explain).toBeUndefined();
+    expect(parsed[0]).toEqual(HIT as any);
+  });
+});
+
+describe("buildSearchExplain / formatSearchExplain (flair#992)", () => {
+  const NOW = Date.parse("2026-05-11T00:00:00.000Z"); // 10 days after HIT.createdAt
+
+  it("derives ageDays from createdAt", () => {
+    expect(buildSearchExplain(HIT, "raw", NOW).ageDays).toBe(10);
+  });
+
+  it("omits ageDays when createdAt is absent or unparseable", () => {
+    expect(buildSearchExplain({ ...HIT, createdAt: undefined }, "raw", NOW).ageDays).toBeUndefined();
+    expect(buildSearchExplain({ ...HIT, createdAt: "not-a-date" }, "raw", NOW).ageDays).toBeUndefined();
+  });
+
+  it("defaults durability and usageCount rather than emitting undefined terms", () => {
+    const ex = buildSearchExplain({ _score: 0.5 }, "raw", NOW);
+    expect(ex.durability).toBe("standard");
+    expect(ex.usageCount).toBe(0);
+  });
+
+  it("names the usage boost, not the retrieval boost, in the composite formula", () => {
+    expect(searchScoringFormula("composite")).toContain("usage-boost");
+    expect(searchScoringFormula("composite")).not.toContain("retrieval");
+    expect(searchScoringFormula("raw")).toBe("cosine similarity only");
+  });
+
+  it("renders the same terms in the human one-liner", () => {
+    const line = formatSearchExplain(buildSearchExplain(HIT, "composite", NOW), HIT);
+    expect(line).toContain("raw=0.744");
+    expect(line).toContain("composite=0.812");
+    expect(line).toContain("durability=permanent");
+    expect(line).toContain("age=10d");
+    expect(line).toContain("usage=3");
+    expect(line).not.toContain("retrievals=");
+  });
+});


### PR DESCRIPTION
## The bug

`flair search --explain` was accepted and did nothing for every non-interactive caller.

`resolveOutputMode()` in `src/render.ts` maps a non-TTY stdout to json mode, and the search action returns early on json mode — before the explain block. So every script, agent, CI job and `| less` got no breakdown and no error. `--explain --json` was ignored for the same reason. The nightly dogfood run that filed this hit exactly that path, saw the bare server payload, and reported "`--explain` shows no breakdown".

That is the defect class worth naming: **absence rendering as success.** A flag that cannot be honoured must say so; it must not return quietly as though it worked.

Reproduced before the fix against a mock server, with stdout piped:

```
$ flair search anything --agent a --explain | cat
[ { "id": "m1", ..., "_score": 0.812, "_rawScore": 0.744 } ]      # byte-identical to no flag
$ echo $?
0                                                                  # and nothing on stderr
```

## The design choice, and why

Three defensible options for what `--explain` should do in JSON mode: fold the breakdown into the JSON, error out, or warn on stderr and continue.

**Chosen: fold it into the JSON**, as an `_explain` object per hit.

- A script is exactly the caller that wants machine-readable scoring. Erroring out would tell agents — the primary consumers of this CLI — that a documented flag is unavailable to them, and the only workaround (`FLAIR_OUTPUT=human`) is undiscoverable from the flag that is failing.
- I checked whether the JSON shape is contractual before widening it. Nothing consumes this output against a strict schema: the n8n node and the client script both call the REST API directly rather than shelling out to the CLI, and no doc specifies a field set for `search --json`. Searched for shell-outs to the command and found none.
- The widening is opt-in. `_explain` appears **only** when the caller typed `--explain`, so output without the flag is byte-identical to before. There is a test asserting that specifically, as a positive control for the claim.
- `_explain` follows the existing `_score` / `_rawScore` / `_source` convention for computed annotations.
- Warning on stderr and continuing was the runner-up. It keeps stdout untouched, but it leaves the flag unable to do its job for the callers who most need it — a quieter version of the same failure.

## Second half of the issue

The breakdown was also inaccurate on a TTY, and that is fixed here:

- **A raw score was labelled `composite=`.** Under the default `--scoring raw` the server puts the raw score in `_score` and omits `_rawScore`, so the old renderer printed `composite=0.812` directly above a footer reading `Scoring: raw`. Now raw and composite are distinct terms and composite only appears under `--scoring composite`.
- **`retrievalCount` was reported as a scoring input.** It stopped participating when usage replaced retrieval as the reinforcement signal; the composite formula takes `{durability, createdAt, usageCount, supersedes}`. A breakdown must not name a term the ranking no longer uses. Dropped, and `usageCount` — which does participate — is now reported. The footer's formula string said `retrieval-boost`; it now says `usage-boost`.
- **`durability` and `age` were promised and never emitted.** Both now appear.

One deliberate limit, stated rather than papered over: this reports the ranking **inputs** the server returned, not the computed weights. `--explain` is client-side — the `/SemanticSearch` request carries no `explain` key and the resource has no such parameter. The durability weight, recency decay and usage boost that the composite score multiplies depend on floors read from the **server's** environment, so recomputing them in the client would print confident numbers the ranking never actually used. Surfacing the true weights needs a server-side explain payload threaded through the retrieval path; that is a larger change than this fix and is **not** done here. The help string and quickstart now describe what is actually shown, so the promise matches the behaviour either way.

One shared builder feeds both output modes — that is what keeps them from drifting apart again, which is how the flag came to work in one mode and not the other.

## Testing

New `test/unit/cli-search-explain.test.ts` — 11 tests. The behavioural ones spawn the real CLI against a mock HTTP server; `spawn` gives the child a pipe for stdout, so `isTTY` is false. **That is the broken path, and it is the only path they exercise** — a test that forced `FLAIR_OUTPUT=human` would have passed with the defect fully in place.

**Mutation check.** Reverting just the JSON-branch fix to the pre-fix line, leaving the helpers in place to isolate the defect: **5 fail / 6 pass** — all five failures are the non-TTY spawn tests, and the six that survive are the pure-function tests plus the without-`--explain` control, which is correct. Restored: **11 pass / 0 fail**. Against the unmodified source from `main` the file fails outright (0 pass / 1 fail). The test fails before and passes after, in both directions.

**Full suite**, measured on unmodified `main` in this same worktree as the baseline:

| | pass | fail |
|---|---|---|
| baseline (`main`) | 3713 | 2 |
| this branch | 3724 | 2 |

+11 pass, exactly the new tests. The 2 failures are the same pre-existing ones in `snapshot-datadir-instance-targeting.test.ts`, unrelated to this change and failing identically on the baseline.

`docs-freshness-check.mjs`: 7/7 checks **ran** and passed after building the CLI (`cli-command-descriptions` reports 125 commands scanned, not a skip). `tsc -p tsconfig.check.json` (what CI runs) is clean. `tsc -p tsconfig.json` reports the one pre-existing unrelated error in `resources/auth-middleware.ts`, confirmed identical on unmodified `main`.

Closes #992
