### PR TITLE
fix(config): declare Harper's loadEnv plugin so a component .env is read (#1005)

### DIFF
--- a/.changelog/unreleased/fixed-component-env-file-inert.md
+++ b/.changelog/unreleased/fixed-component-env-file-inert.md
@@ -1,0 +1,24 @@
+- **A `.env` in a deployed Flair component is now actually read.** Harper does
+  not load a component's `.env` implicitly — it loads env files only for
+  components that declare its `loadEnv` plugin, and Flair's `config.yaml` never
+  did. So a `.env` sitting next to `config.yaml` on a deployed instance was
+  inert: the file arrived intact and its values never reached `process.env`. The
+  visible symptom was a public deployment whose OAuth discovery document (and
+  A2A agent card) kept advertising a `127.0.0.1` issuer and endpoints even
+  though `FLAIR_PUBLIC_URL` was set in the component's `.env`, so no external
+  client could complete an authorization flow against it (#1000, #1005).
+
+  Nothing to do on an existing install, and nothing changes for one. A `.env` is
+  optional: when the file is absent — which is the normal case for a local
+  install driven by a launchd plist or a systemd unit — the plugin never fires
+  and boot is line-for-line identical to before. Deployments that want to set
+  `FLAIR_PUBLIC_URL` (or any other `FLAIR_*` variable) this way can now do so by
+  putting a `.env` in the app root.
+
+  Application variables only. Harper composes its own configuration before
+  component `.env` files load, so Harper's own settings — `HDB_ADMIN_PASSWORD`,
+  `HTTP_PORT` — must still come from the process environment, and
+  `HARPER_CONFIG` / `HARPER_DEFAULT_CONFIG` / `HARPER_SET_CONFIG` are refused
+  outright by Harper with a warning at boot. `.env.example` said Flair never
+  read a `.env` at all; it now describes which process reads what, and where
+  the boundary is.

--- a/.env.example
+++ b/.env.example
@@ -1,18 +1,34 @@
 # Environment configuration template.
 #
-# NAME REFERENCE ONLY: this file lists the FLAIR_* variables that exist. Copying
-# it to .env does NOT make them take effect. The flair CLI and the Harper server
-# both run under Node, which does not read .env files, and Flair loads no dotenv
-# of its own. Set variables in the environment itself: the launchd plist
-# (EnvironmentVariables) and the systemd unit (Environment=) set them directly;
-# for a local run, export them in your shell or prefix the command, e.g.
+# NAME REFERENCE: this file lists the FLAIR_* variables that exist. Where you
+# put them depends on which process has to read them.
+#
+# The flair CLI does NOT read a .env. It runs under Node, which has no .env
+# support, and Flair ships no dotenv loader of its own. Export the variable in
+# your shell, or prefix the command:
+#
 #   FLAIR_ADMIN_AGENTS=agent-a,agent-b flair start
 #
-# One caveat, and it is not a mechanism to rely on: the Bun runtime loads a
-# repo-root .env by itself, so bun-executed scripts (e.g. `bun test`) DO see one.
-# That is Bun's behaviour, not Flair config — and it is why a real .env must
-# never be committed (flair#913).
+# The Harper SERVER does read one — but only the `.env` sitting in flair's own
+# component directory, next to config.yaml, and only because config.yaml
+# declares Harper's `loadEnv` plugin (flair#1005). Harper does not read a
+# component's .env implicitly; without that declaration the file is inert. A
+# local install typically has no .env at all: launchd (`EnvironmentVariables`)
+# and systemd (`Environment=`) set variables directly, which is unaffected by
+# any of this.
 #
-# See flair#824 for details.
+# APPLICATION VARIABLES ONLY. Harper composes its OWN configuration before
+# component .env files are loaded, so Harper's settings cannot be set this way
+# — `HDB_ADMIN_PASSWORD`, `HTTP_PORT` and friends are read by Harper's
+# installer/config layer from the process environment and must stay there.
+# `HARPER_CONFIG` / `HARPER_DEFAULT_CONFIG` / `HARPER_SET_CONFIG` are refused
+# outright at the injection point and warned about at boot.
+#
+# A .env is where secrets end up, so it stays gitignored and must never be
+# committed (flair#913). Separately, the Bun runtime loads a repo-root .env by
+# itself, so bun-executed scripts (e.g. `bun test`) DO see one — that is Bun's
+# behaviour, not Flair config.
+#
+# See flair#824 and flair#1005 for details.
 
 FLAIR_ADMIN_AGENTS=

--- a/config.yaml
+++ b/config.yaml
@@ -6,6 +6,40 @@ rest: true
 # http:
 #   port: 19926
 
+# Harper does not read a component's `.env` implicitly — it only loads env
+# files a component ASKS for, via this plugin. Without this block a `.env`
+# sitting next to config.yaml is inert: the file is present and its values
+# never reach `process.env`. That is exactly what a deployed instance hit —
+# `FLAIR_PUBLIC_URL` was set in the deployed component's `.env` and OAuth
+# discovery kept advertising a loopback issuer (flair#1005, #1000).
+#
+# MUST STAY FIRST. Config keys are iterated in file order by Harper's
+# component loader, and each plugin's initial entry load is awaited before
+# the next key is processed — so declaring this above `jsResource` is what
+# guarantees `process.env` is populated before `dist/resources/*.js` are
+# imported. Most consumers read `process.env` per request and would not care
+# (resources/OAuth.ts, resources/AdminInstance.ts, resources/XAA.ts,
+# resources/a2a-url.ts), but `resources/mcp-oauth.ts` decides at MODULE LOAD
+# whether to mount `/mcp`; move this below `jsResource` and that decision is
+# made against an env that has not been loaded yet.
+#
+# No `.env` is required, which is the case for essentially every local
+# install: when the glob matches nothing the plugin never fires and emits
+# nothing. Measured — a boot log with this block and no `.env` differs from
+# one without the block only in the PID and in non-deterministic table-init
+# ordering. (A MALFORMED declaration is loud, not silent: a pattern
+# containing '..' produced both an `Ignoring invalid loadEnv files pattern`
+# warning and a `Could not load component 'loadEnv'` error, which is the
+# positive control for that silence.)
+#
+# Application variables only. Harper composes its OWN configuration before
+# component `.env` files load, so Harper-level settings cannot be set this
+# way; `HARPER_CONFIG` / `HARPER_DEFAULT_CONFIG` / `HARPER_SET_CONFIG` are
+# refused at the injection point and warned about (harper#1513). Those
+# belong in the process environment or harper-config.yaml.
+loadEnv:
+  files: '.env'
+
 graphqlSchema:
   files: schemas/*.graphql
 

--- a/test/unit/component-load-env.test.ts
+++ b/test/unit/component-load-env.test.ts
@@ -1,0 +1,84 @@
+// component-load-env.test.ts — pins the `loadEnv` declaration in the shipped
+// config.yaml (flair#1005).
+//
+// Harper does NOT read a component's `.env` implicitly. It loads env files only
+// for components that ask, via the built-in `loadEnv` plugin, declared in the
+// component's own config.yaml. flair shipped without that block, so a `.env`
+// deployed alongside config.yaml was inert: the file arrived, and its values
+// never reached `process.env`. The visible symptom was a public deployment
+// whose OAuth discovery document advertised a loopback issuer even though
+// `FLAIR_PUBLIC_URL` was set in the deployed component's `.env` (flair#1000).
+//
+// Two things are asserted here, and the second is the one that is easy to lose:
+//
+//   1. The block exists and points at `.env`.
+//   2. It is declared BEFORE `jsResource`. Harper's component loader iterates
+//      config keys in file order and awaits each plugin's initial entry load
+//      before processing the next key, so declaration order decides whether
+//      `process.env` is populated before `dist/resources/*.js` are imported.
+//      Most read sites evaluate per request and would not notice
+//      (resources/OAuth.ts, resources/AdminInstance.ts, resources/XAA.ts,
+//      resources/a2a-url.ts), but resources/mcp-oauth.ts decides at MODULE LOAD
+//      whether to mount `/mcp`. Measured against a real spawned Harper: with
+//      `loadEnv` first, a `.env` carrying `FLAIR_MCP_OAUTH` mounts `/mcp`; with
+//      the identical `.env` and `loadEnv` moved below `jsResource`, `/mcp` is
+//      never mounted while the per-request issuer still resolves. Ordering is
+//      behaviour, not tidiness — hence a test rather than only a comment.
+//
+// Deliberately NOT asserted: that a `.env` exists. Practically every install
+// has none, and the plugin simply never fires when the glob matches nothing —
+// a boot with the block and no `.env` is line-for-line identical to a boot
+// without the block.
+//
+// This reads the real config.yaml rather than a fixture: a fixture would keep
+// passing while the shipped file drifted, which is the exact failure mode
+// (a declaration nothing consumes) that flair#1005 exists to fix.
+
+import { describe, test, expect } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import yaml from "js-yaml";
+
+const CONFIG_PATH = join(import.meta.dir, "..", "..", "config.yaml");
+const raw = readFileSync(CONFIG_PATH, "utf8");
+const config = yaml.load(raw) as Record<string, unknown>;
+
+describe("config.yaml loadEnv declaration (flair#1005)", () => {
+  test("declares the loadEnv plugin against .env", () => {
+    const loadEnv = config.loadEnv as { files?: unknown } | undefined;
+    expect(loadEnv).toBeDefined();
+    expect(loadEnv?.files).toBe(".env");
+  });
+
+  test("declares loadEnv before jsResource so env is set before resources import", () => {
+    const keys = Object.keys(config);
+    expect(keys).toContain("loadEnv");
+    expect(keys).toContain("jsResource");
+    expect(keys.indexOf("loadEnv")).toBeLessThan(keys.indexOf("jsResource"));
+  });
+
+  test("loadEnv pattern stays inside the component directory", () => {
+    // Harper's Component throws ComponentInvalidPatternError on a pattern
+    // containing '..' or starting with '/', and the boot-time pre-pass warns
+    // and skips it — the component fails to load rather than degrading
+    // quietly. Observed: an invalid pattern produced both a
+    // `Ignoring invalid loadEnv files pattern` warning and a
+    // `Could not load component 'loadEnv'` error at boot.
+    const files = (config.loadEnv as { files?: unknown } | undefined)?.files;
+    // Assert the value is there FIRST: with no declaration at all, `""` would
+    // satisfy both checks below and this test would report a pass for a
+    // configuration it never examined.
+    expect(typeof files).toBe("string");
+    expect(String(files).includes("..")).toBe(false);
+    expect(String(files).startsWith("/")).toBe(false);
+  });
+
+  test("does not try to shape Harper's own configuration from a component .env", () => {
+    // Harper composes its instance configuration BEFORE component .env files
+    // load, and refuses these three at the injection point (harper#1513).
+    // Nothing in the shipped config may imply otherwise.
+    for (const key of ["HARPER_CONFIG", "HARPER_DEFAULT_CONFIG", "HARPER_SET_CONFIG"]) {
+      expect(raw.includes(`${key}=`)).toBe(false);
+    }
+  });
+});


### PR DESCRIPTION
Declares Harper's `loadEnv` plugin in flair's `config.yaml`, so a `.env` in a
deployed component's app root is actually read.

Item 1 of #1005. The `flair deploy` writer and the `flair doctor` check are
separate items in that issue and depend on this landing first — deliberately
not here.

## The bug

Harper does not read a component's `.env` implicitly. It loads env files only
for components that declare its built-in `loadEnv` plugin in their own
`config.yaml`. flair shipped without that block, so a `.env` sitting next to
`config.yaml` was inert: the file was present and its values never reached
`process.env`.

The visible symptom (#1000) was a public deployment whose OAuth discovery
document advertised a loopback address for `issuer` and every endpoint, even
though `FLAIR_PUBLIC_URL` was set in the deployed component's `.env`. No
external client can complete an authorization flow against that.

## Evidence

Four boots of a real spawned Harper against this component tree — each an
ephemeral instance on OS-assigned ports — probing `GET /OAuthMetadata`. The
`.env` fixture is a single line setting `FLAIR_PUBLIC_URL`.

| # | config.yaml | `.env` | resulting `issuer` |
|---|---|---|---|
| 1 | main, no `loadEnv` | absent | `http://127.0.0.1:<port>` |
| 2 | main, no `loadEnv` | **present** | `http://127.0.0.1:<port>` — **bug reproduced** |
| 3 | this PR | **present** | `https://loadenv-probe.example` — **fixed** |
| 4 | this PR | absent | `http://127.0.0.1:<port>` — unchanged |

Boot 2 is the local reproduction of the deployment failure: the file is right
there and nothing reads it. Boot 3 is the fix end to end — `issuer`,
`authorization_endpoint`, `token_endpoint` and `registration_endpoint` all
resolve to the value from the `.env`.

## Blocking question 1 — does a missing `.env` break or pollute a normal install?

No. Practically every install has no `.env`, so this had to be answered with an
observed boot rather than by reading the plugin.

Boot 4 above, diffed against boot 1 (the same tree without the block), after
normalising the temp path, ports and timings:

- Both logs: **223 lines**.
- Only differences: the Harper PID, the order of five `Initialized table` lines
  (non-deterministic run to run), and one `ggml_metal_library_init` timing.
- **Zero** occurrences of `loadEnv`, and no new warning or error of any kind.

When the glob matches nothing, the plugin never fires. Nothing is logged,
nothing degrades.

That silence is a real negative, not a blind probe. Positive control: the same
harness with the pattern changed to one containing `..` produced both

```
[warn]: Ignoring invalid loadEnv files pattern '../.env' ... while composing config
[error]: ComponentInvalidPatternError: Could not load component 'loadEnv' ...
```

so a `loadEnv` complaint would have been captured had there been one.

## Blocking question 2 — is auto-loading a component-directory `.env` a security regression?

**Conclusion: it does not widen the threat model, but it adds a second,
lower-effort path for an actor who already holds the decisive capability. On
the record here to be attacked rather than taken on trust.**

**What the capability is.** Anything that can write `.env` into flair's
component directory can now set environment variables in the running server
process. In flair specifically the sharpest of those is `FLAIR_ADMIN_AGENTS`
(read in `resources/agent-auth.ts`), which names agent ids treated as flair
admins — so this is a privilege-escalation primitive, not merely a cosmetic
config knob. `FLAIR_PUBLIC_URL`, `FLAIR_MCP_ISSUER` and `FLAIR_KEY_PASSPHRASE`
are similarly interesting.

**Why it does not widen the model.** The same `config.yaml` already declares
`jsResource: dist/resources/*.js`. Anyone who can write a file into the
component directory can therefore already write **executable JavaScript that
Harper imports into the server process** — arbitrary code execution, strictly
stronger than setting an environment variable. That holds for both deployment
shapes:

- A deployed component's directory is written by the deploy operation, which
  requires Harper admin credentials. That actor can already deploy arbitrary
  component code.
- A local install's component directory is the installed package (or the
  checkout), owned by the user the server runs as. Same actor, same reasoning.

So the write capability required to exploit `.env` is one that already grants
more. What genuinely changes is **discoverability and effort**: a plain text
file is a lower bar than a compiled resource, and the component directory's
write permissions are now load-bearing for a second reason.

**Mitigations already in the mechanism — properties of Harper's plugin, not
things this PR adds:**

- **An already-set variable wins.** The plugin skips any key already present in
  `process.env` unless its `override` option is enabled, and this declaration
  does not enable it. A `.env` therefore **cannot** hijack a value set by the
  launchd plist, the systemd unit, or a managed secrets mechanism. The
  higher-trust channel takes precedence, and an existing correctly-configured
  deployment cannot be silently changed by dropping a file in.
- **Harper's own configuration is out of reach.** `HARPER_CONFIG`,
  `HARPER_DEFAULT_CONFIG` and `HARPER_SET_CONFIG` are refused at the injection
  point — not merely ignored — and warned about at boot. Harper composes its
  instance configuration before component `.env` files load, so Harper-level
  settings such as `HDB_ADMIN_PASSWORD` and `HTTP_PORT` cannot be set this way
  and must stay in the process environment. Nothing here says or implies
  otherwise; `.env.example` states the boundary explicitly.
- **The pattern cannot escape the component directory.** A `files` pattern
  containing `..` or starting with `/` is rejected by Harper (see the positive
  control above), so this cannot be aimed at a file outside the component.
- **We ship no `.env`.** It is gitignored, and `package.json`'s `files` list
  does not include it, so it is absent from the published tarball. There is no
  default file to inherit or forget about.

**Residual, named rather than hidden:**

1. The entry handler processes an `add` event at runtime, not only during the
   initial scan, so creating a `.env` in a live component directory injects its
   variables **without a restart**. Measured, not inferred: on a running
   instance serving a loopback issuer, writing a `.env` and waiting six seconds
   flipped `GET /OAuthMetadata` to the injected value — same PID, zero restart
   events in the log. Modifying or deleting an existing `.env` requests a
   restart instead. An operator using "did the service restart?" as the signal
   that configuration changed will not see one on first creation.
2. `.env` is by convention where secrets go. Making it functional in the
   component directory raises the chance one lands there — a directory whose
   contents are enumerable through the components API to an admin-credentialed
   caller. That caller is already privileged, but "the value sits in a file in
   the app root" is a different exposure shape from "the value exists only in
   the process environment".

Neither is introduced by this declaration — both follow from Harper's plugin —
but both are the shape of thing worth arguing with now rather than finding
later.

## Ordering is load-bearing, and is tested

The block is declared **before** `jsResource`, and that is not cosmetic.
Harper's component loader iterates `config.yaml` keys in file order and awaits
each plugin's initial entry load before moving to the next key, so declaration
order decides whether `process.env` is populated before `dist/resources/*.js`
are imported.

Measured both ways, with an identical `.env` setting `FLAIR_PUBLIC_URL` and
`FLAIR_MCP_OAUTH`:

- `loadEnv` **before** `jsResource` → `[mcp-oauth] /mcp mounted (OAuth-guarded);
  issuer=https://loadenv-probe.example`
- `loadEnv` **after** `jsResource` → **no `[mcp-oauth]` output at all**, `/mcp`
  never mounted — while `GET /OAuthMetadata` still resolved the public issuer
  correctly.

That asymmetry answers "which consumers benefit". Read sites that evaluate
`process.env` **per request** are unaffected by ordering and all work:

- `resources/OAuth.ts` — the discovery document
- `resources/AdminInstance.ts` — the Endpoints table
- `resources/XAA.ts` — the jwt-bearer grant's base URL
- `resources/a2a-url.ts`, via `resources/A2AAdapter.ts` — the agent card

The one consumer that reads at **module load** is `resources/mcp-oauth.ts`,
which decides at import time whether to mount `/mcp` (`mcpIssuer()` falls back
to `FLAIR_PUBLIC_URL`). It benefits **only** because `loadEnv` is declared
first. A unit test pins the ordering so it cannot be lost to a tidy-up.

## Tests

`test/unit/component-load-env.test.ts` reads the real `config.yaml`, not a
fixture — a fixture would keep passing while the shipped file drifted, which is
precisely the failure mode this issue is about. Four assertions: the
declaration exists and targets `.env`; it precedes `jsResource`; the pattern
stays inside the component directory; and the file does not try to set
Harper-level config vars.

Mutation-checked, each assertion individually:

| Mutation | Result |
|---|---|
| `config.yaml` reverted to main's (no block) | 3 fail / 1 pass |
| `loadEnv` moved below `jsResource` | 1 fail — the ordering assertion |
| `files` changed to `'../.env'` | 2 fail |
| `HARPER_CONFIG=` added to the file | 1 fail — the Harper-config assertion |
| restored | **4 pass / 0 fail** |

The first draft of the pattern assertion passed **vacuously** with no `loadEnv`
block at all (an empty string contains no `..` and starts with no `/`); the
mutation run is what caught it. It now asserts the value is a string first, so
an absent declaration cannot render as a pass.

## Verification

Measured on this branch against a baseline measured on unmodified `origin/main`
on the same machine.

| Lane | Baseline (`origin/main`) | This branch |
|---|---|---|
| `bun test test/unit/ test/*.test.ts` | 3724 pass / 2 fail | 3728 pass / 2 fail |
| `bun test test/integration/` | 390 pass / 0 fail (51 files) | 390 pass / 0 fail (51 files) |
| `test/unit-isolated/`, one process each | — | 139 pass / 0 fail |
| workspace package suites (7) | — | 344 pass / 0 fail |
| `scripts/docs-freshness-check.mjs` | 7/7 checks | 7/7 checks |
| `tsc -p tsconfig.json --noEmit` | 1 error | 1 error, identical |

The 2 unit failures are pre-existing on `origin/main` and untouched — both in
`test/unit/snapshot-datadir-instance-targeting.test.ts` (launchd label
targeting), identical before and after. The typecheck error is the known
pre-existing one in `resources/auth-middleware.ts`, byte for byte the same on
both. The CLI was built before the docs-freshness run so
`cli-command-descriptions` genuinely ran (125 commands scanned) rather than
reporting a skip.

## Found, not fixed here

- **`.env.example` was made accurate**, since leaving it would ship a document
  that contradicts shipped behaviour. It claimed "The flair CLI and the Harper
  server both run under Node, which does not read .env files" — true before this
  change, false after. It now separates the CLI (still does not read one) from
  the server (does, from the component directory, application variables only).
- **Embedded deployments put the `.env` somewhere non-obvious.** When a host
  application loads flair as a sub-component, Harper resolves flair's
  `config.yaml` from flair's own package directory, so the `.env` this glob
  matches must sit **next to that** — inside the installed flair package — not
  in the host application's root. Whoever builds the `flair deploy` writer
  (item 2) needs to resolve that path rather than assuming the app root.
- **Operator-facing documentation of the `.env` mechanism** in the deployment
  guides is left to the PR that adds the writer. Those pages currently say "set
  it in the component's environment", which remains true. A note for whoever
  takes that on: the same tables list `HDB_ADMIN_PASSWORD` and `HTTP_PORT`,
  which are Harper-level and must **not** be documented as settable via `.env`.

Refs #1005, #1000.
