### PR TITLE
test: pin which launchd INSTANCE is targeted, not which verb (#1012)

### DIFF
--- a/test/unit/snapshot-datadir-instance-targeting.test.ts
+++ b/test/unit/snapshot-datadir-instance-targeting.test.ts
@@ -15,12 +15,23 @@
 //     Bun's `os.homedir()` ignores an in-process `process.env.HOME`
 //     mutation (same rule as upgrade-data-snapshot.test.ts).
 //   - `launchctl` is a recording shim on PATH. Nothing is loaded, started or
-//     stopped for real; the assertions are on the LABEL the CLI resolved,
+//     stopped for real; the assertions are on the INSTANCE the CLI resolved,
 //     never on an actual stop.
 //   - The one test that lets the CLI reach a port-based SIGTERM points it at
 //     a listener this test spawned and then asserts that listener is STILL
 //     SERVING — a killed listener fails the test instead of taking anything
 //     else down.
+//
+// The launchd assertions deliberately say nothing about which VERB the CLI
+// uses. They used to pin `stop <label>`/`start <label>`, and then failed when
+// quiescing moved to `unload`/`load` (flair#874: `launchctl stop` alone does
+// not hold a KeepAlive job down; flair#872: launchd caches a loaded job's
+// environment, so a rewritten plist needs an unload before the load). That
+// change preserved the targeting these tests exist to protect and broke them
+// anyway — a test asserting mechanism where the safety property is "which
+// instance". What is pinned instead is that property, via
+// expectLaunchctlNamedOnly below: every invocation names the instance
+// `--data-dir` pointed at, and none names the default install.
 //
 // The launchd tests are darwin-only because `stopFlairProcess`'s launchd
 // branch is itself gated on `process.platform === "darwin"`. CI runs on
@@ -111,6 +122,44 @@ describe("flair#902 — snapshot commands target the instance named by --data-di
     return existsSync(launchctlLog) ? readFileSync(launchctlLog, "utf-8") : "";
   }
 
+  /** Each launchctl invocation the CLI issued, one per element, blanks dropped. */
+  function launchctlLines(): string[] {
+    return launchctlInvocations()
+      .split("\n")
+      .map((line) => line.trim())
+      .filter((line) => line.length > 0);
+  }
+
+  /**
+   * The flair#902 property, asserted on WHICH INSTANCE each launchctl
+   * invocation names rather than on the verb it uses:
+   *
+   *   1. it issued some launchd traffic at all — a universal quantifier over
+   *      an empty log is vacuously true, so an implementation that stopped
+   *      quiescing entirely must fail here rather than pass by doing nothing;
+   *   2. every invocation names the target instance's label (the plist path
+   *      embeds it, so `unload <path>` satisfies this the same way
+   *      `start <label>` does);
+   *   3. none names the `forbiddenLabel` — the load-bearing half. This is the
+   *      assertion that fails if snapshot commands go back to acting on the
+   *      default install while claiming to honour `--data-dir`;
+   *   4. every `.plist` argument is EXACTLY the target's plist path. Stronger
+   *      than a substring check on the forbidden path: it also rejects the
+   *      real ~/Library/LaunchAgents, the legacy global plist, and any other
+   *      instance's, rather than only the one this test thought to name.
+   */
+  function expectLaunchctlNamedOnly(
+    target: { label: string; plistPath: string },
+    forbiddenLabel: string,
+  ): void {
+    const lines = launchctlLines();
+    expect(lines.length).toBeGreaterThan(0);
+    expect(lines.filter((line) => !line.includes(target.label))).toEqual([]);
+    expect(lines.filter((line) => line.includes(forbiddenLabel))).toEqual([]);
+    const plistArgs = lines.flatMap((line) => line.split(/\s+/).filter((arg) => arg.endsWith(".plist")));
+    expect(plistArgs.filter((arg) => arg !== target.plistPath)).toEqual([]);
+  }
+
   /**
    * A stand-in for "an instance is listening on this port". Runs in its own
    * process so that a SIGTERM the CLI should never have sent kills only this
@@ -158,10 +207,11 @@ describe("flair#902 — snapshot commands target the instance named by --data-di
       const scratchLabel = launchdLabel(scratchDataDir);
       const defaultLabel = launchdLabel(defaultDataDir);
       expect(scratchLabel).not.toBe(defaultLabel);
+      const scratchPlistPath = launchdPlistPath(scratchLabel, launchAgentsDir);
 
       // Both instances are registered with launchd, which is what makes the
       // resolution a real choice rather than a lucky miss.
-      writeFileSync(launchdPlistPath(scratchLabel, launchAgentsDir), plistFor(scratchLabel, scratchDataDir));
+      writeFileSync(scratchPlistPath, plistFor(scratchLabel, scratchDataDir));
       writeFileSync(launchdPlistPath(defaultLabel, launchAgentsDir), plistFor(defaultLabel, defaultDataDir));
 
       // A real snapshot, taken from a third directory, so the restore has
@@ -182,12 +232,9 @@ describe("flair#902 — snapshot commands target the instance named by --data-di
       expect(exitCode).toBe(0);
       expect(stdout).toContain("Restored");
 
-      // The whole point: every launchd verb the CLI issued names the scratch
-      // instance. The default install's label never appears at all.
-      const invocations = launchctlInvocations();
-      expect(invocations).toContain(`stop ${scratchLabel}`);
-      expect(invocations).toContain(`start ${scratchLabel}`);
-      expect(invocations).not.toContain(defaultLabel);
+      // The whole point: every launchd invocation the CLI issued names the
+      // scratch instance. The default install never appears at all.
+      expectLaunchctlNamedOnly({ label: scratchLabel, plistPath: scratchPlistPath }, defaultLabel);
 
       // And the default data directory is untouched — restore replaced the
       // directory it was pointed at, not ~/.flair/data.
@@ -201,7 +248,8 @@ describe("flair#902 — snapshot commands target the instance named by --data-di
     async () => {
       const scratchLabel = launchdLabel(scratchDataDir);
       const defaultLabel = launchdLabel(defaultDataDir);
-      writeFileSync(launchdPlistPath(scratchLabel, launchAgentsDir), plistFor(scratchLabel, scratchDataDir));
+      const scratchPlistPath = launchdPlistPath(scratchLabel, launchAgentsDir);
+      writeFileSync(scratchPlistPath, plistFor(scratchLabel, scratchDataDir));
       writeFileSync(launchdPlistPath(defaultLabel, launchAgentsDir), plistFor(defaultLabel, defaultDataDir));
       writeFileSync(join(scratchDataDir, "harper-config.yaml"), "some: config\n");
 
@@ -215,10 +263,7 @@ describe("flair#902 — snapshot commands target the instance named by --data-di
       expect(exitCode).toBe(0);
       expect(stdout).toContain("✅ Snapshot:");
 
-      const invocations = launchctlInvocations();
-      expect(invocations).toContain(`stop ${scratchLabel}`);
-      expect(invocations).toContain(`start ${scratchLabel}`);
-      expect(invocations).not.toContain(defaultLabel);
+      expectLaunchctlNamedOnly({ label: scratchLabel, plistPath: scratchPlistPath }, defaultLabel);
     },
   );
 


### PR DESCRIPTION
## What

`test/unit/snapshot-datadir-instance-targeting.test.ts` has four tests. Two are darwin-gated and have been failing on macOS. They pinned the launchd **verb**:

```js
expect(invocations).toContain(`stop ${scratchLabel}`);
expect(invocations).toContain(`start ${scratchLabel}`);
```

Quiescing has since moved from `stop`/`start` to `unload`/`load` — #874 (`launchctl stop` alone does not hold a KeepAlive job down) and #872 (launchd caches a loaded job's environment, so a rewritten plist needs an unload before the load), both landed in #982. Each change preserved the targeting these tests exist to protect, and broke the assertions anyway.

No CI lane executes them: `stopFlairProcess`'s launchd branch is gated on `process.platform === "darwin"` and CI runs on Linux. `scripts/release.sh` runs the same suite on macOS, so they surface there — as a release blocker.

## The safety property is intact

Confirmed from source *before* the tests were touched, because if the targeting were actually wrong this would be a live hazard rather than a stale assertion:

- `snapshot create` and `snapshot restore` resolve `dataDir` from `--data-dir` and pass it explicitly to `stopFlairProcess(port, dataDir)` / `startFlairProcess(port, dataDir)`.
- Both resolve the service via `resolveLaunchdLabel(dataDir)` — label `ai.tpsdev.flair.<8 hex of sha256(resolve(dataDir))>`, plist under `homedir()/Library/LaunchAgents`.
- Both then call `assertLaunchdServiceOwnedBy(dataDir, …)`, which refuses on a positive `ROOTPATH` contradiction and sits *outside* the try so a refusal cannot degrade into the port-based fallback.

Every launchctl invocation in the failing output named the scratch instance, and its plist sat under the scratch `HOME`. Nothing reached the default install. Stale assertion, not a regression of #902.

## The change

`expectLaunchctlNamedOnly()` replaces the verb assertions with the property that matters:

1. some launchd traffic was issued at all — a universal quantifier over an empty log is vacuously true, so "stopped quiescing entirely" must fail here rather than pass by doing nothing;
2. every invocation names the target instance's label;
3. **no** invocation names the default install's label — the load-bearing half;
4. every `.plist` argument is *exactly* the target's plist path, which also rejects the real `~/Library/LaunchAgents`, the legacy global plist, and any other instance's — not only the one this test thought to name.

Written this way the tests would have passed through the `stop` to `unload` change and still caught the regression they were written for.

## Mutation check

Each assertion was verified to fail against a deliberately broken implementation, then restored. `src/cli.ts` on this branch is byte-identical to `main`; the diff is test-only.

| Mutation | Result |
| --- | --- |
| Invocation targets the default install's plist/label, ownership guard still passing on the correct data dir | both tests **FAIL**, output naming the offending invocations |
| Positive assertion temporarily removed under that same mutation | negative assertion **FAILS alone** — the load-bearing half is not being carried by the positive one |
| `stopFlairProcess`/`startFlairProcess` resolve from `defaultDataDir()` (the literal #902 regression) | **3 FAIL** — both rewritten tests plus the legacy-label guard |
| Restored | 4 pass / 0 fail |

## Testing

macOS, `bun test test/unit/ test/integration/` after `npm run build && npm run build:cli` — matching `scripts/release.sh`'s order. Building first is load-bearing: without it the real-Harper integration tests never come up and the run is unusable as a baseline.

| | result |
| --- | --- |
| `main`, unmodified | **3885 pass / 2 fail** — the only two failures in the whole run are the two rewritten here |
| this branch | **3887 pass / 0 fail** (exit 0) |

The target file alone: 2 pass / 2 fail on `main`, 4 pass / 0 fail here.

`tsc -p tsconfig.json --noEmit` reports the same single pre-existing `resources/auth-middleware.ts(70,1): error TS2722` on this branch as on `main`, unchanged. (That project excludes `test/`, so it does not cover the changed file; `tsconfig.check.json` is clean on both.) `node scripts/docs-freshness-check.mjs` — 7/7 checks ran and passed, none skipped.

## Deliberately not changed

- **No changelog fragment.** Test-only change, and test-only commits here do not carry one (checked the last six `test:` commits — none touched `.changelog/`). The `changelog-unreleased` gate passes.
- **The coverage gap #1012 also describes** — that no lane runs the darwin-gated tests at all, and that a skipped darwin test on Linux reports nothing rather than a skip count — is untouched. Hence `Refs`, not `Closes`.

Refs #1012
