### PR TITLE
fix(deploy): ship FLAIR_PUBLIC_URL in the deployed component, and prove it took effect (#1005)

### DIFF
--- a/.changelog/unreleased/fixed-deploy-ships-public-url-env.md
+++ b/.changelog/unreleased/fixed-deploy-ships-public-url-env.md
@@ -1,0 +1,18 @@
+- **A deploy now supplies `FLAIR_PUBLIC_URL`, and proves it took effect.** A publicly-reachable
+  instance served an OAuth discovery document whose issuer and every endpoint were
+  `http://127.0.0.1:9980`, so remote clients followed discovery to their own loopback and no
+  authorization flow could complete (#1000). `flair deploy` and `flair init --remote` now ship a
+  `.env` in the component payload carrying `FLAIR_PUBLIC_URL`, taken from the target the deploy
+  already resolves and verifies against; after deploying, `flair deploy` reads
+  `GET <target>/OAuthMetadata` and fails if the advertised issuer is still loopback — an
+  unreadable document is reported as a check that did not run, never as a pass. `flair doctor`
+  reports the same misconfiguration locally, naming the file, the key and the `loadEnv`
+  requirement. An existing `.env` is merged and a value you set is never overwritten; the deploy
+  prints the disagreement and keeps yours, and your file on disk is never written to. The
+  `flair init --remote` tarball builder had written a `.env` since April and packed an entries
+  list that never contained it, so its output was discarded on every call — `.env` is now in that
+  list, and the tests assert against the packed payload rather than against a file on disk. That
+  builder's admin-password parameter is **removed** rather than validated: the deploy payload is
+  ingested into Harper's replicated deployment record, so it must carry no credential, and
+  `HDB_ADMIN_PASSWORD` could not configure Harper from a component `.env` in any case — Harper
+  composes its own configuration before component env files load (#1005, #1011).

--- a/.env.example
+++ b/.env.example
@@ -32,3 +32,13 @@
 # See flair#824 and flair#1005 for details.
 
 FLAIR_ADMIN_AGENTS=
+
+# The URL clients reach this instance on. OAuth metadata and A2A discovery
+# advertise it verbatim; unset, they advertise the bind address, so every URL a
+# remote client is handed points at its own loopback (flair#1000).
+#
+# `flair deploy` writes this into the component payload's .env from the target it
+# deploys to, and fails the deploy if the instance does not then advertise it.
+# Set it here only to advertise a DIFFERENT host — a CDN, a reverse proxy, a
+# vanity domain. A value you set is never overwritten by a deploy.
+FLAIR_PUBLIC_URL=

--- a/docs/deploying-on-fabric.md
+++ b/docs/deploying-on-fabric.md
@@ -78,8 +78,41 @@ export FLAIR_URL=https://<cluster>.<org>.harperfabric.com
 flair agent add mybot --target "$FLAIR_URL" --ops-target <ops-url>
 ```
 
-Also set `FLAIR_PUBLIC_URL` to that URL in the component's environment — OAuth metadata
-and A2A discovery advertise it, or clients see a loopback address.
+### `FLAIR_PUBLIC_URL` — set for you, and how to override it
+
+OAuth metadata and A2A discovery advertise `FLAIR_PUBLIC_URL`; with it unset, every
+URL a client is handed points at loopback and no remote client can authorize.
+
+`flair deploy` ships it. The deploy already knows the URL — it is the target it
+verifies the served API against immediately afterwards — so it writes
+`FLAIR_PUBLIC_URL=<target>` into a `.env` in the component payload, and then checks
+`GET <target>/OAuthMetadata` really does advertise a non-loopback issuer. That check
+fails the deploy if it does not.
+
+To advertise something other than the deploy target — a CDN, a reverse proxy, a
+vanity domain — put your own `.env` in the package root:
+
+```
+FLAIR_PUBLIC_URL=https://flair.example.com
+```
+
+A value you set is never overwritten; the deploy prints the disagreement and keeps
+yours. Any other keys in that file are carried through untouched.
+
+Three things worth knowing about that file:
+
+- Harper reads a component's `.env` **only** because flair's `config.yaml` declares
+  its `loadEnv` plugin, above `jsResource`. Without that declaration the file is
+  present and inert.
+- A variable already set in the instance's **process environment** outranks the
+  file. Harper's `loadEnv` skips any key already present in `process.env` (and logs
+  an "Environment variable conflict" warning) unless `override` is declared, which
+  flair does not declare. So a value you set through Fabric's own environment
+  mechanism is what the instance uses, and a deploy cannot replace it.
+- The deploy payload is stored in Harper's deployment record and replicated to every
+  node, so anything in `.env` is persisted cluster-wide. flair puts no credential
+  there. `HDB_ADMIN_PASSWORD` in particular cannot work from a component `.env` at
+  all — Harper composes its own configuration before component env files load.
 
 ---
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -180,7 +180,7 @@ Set these in the Flair process environment (`~/Library/LaunchAgents/ai.tpsdev.fl
 
 | Variable | What it does | When to set it |
 |----------|--------------|----------------|
-| `FLAIR_PUBLIC_URL` | The URL operators reach this Flair on (e.g. `https://flair.example.com`). Surfaced in the AdminInstance pane's Endpoints table and used by OAuth metadata + A2A discovery so external clients see a reachable URL. | **Always set on remote / Fabric / VPS deployments.** Local-only installs can leave it unset. |
+| `FLAIR_PUBLIC_URL` | The URL operators reach this Flair on (e.g. `https://flair.example.com`). Surfaced in the AdminInstance pane's Endpoints table and used by OAuth metadata + A2A discovery so external clients see a reachable URL. | **Always set on remote / VPS deployments** — unset means every URL a client is handed points at loopback. On Fabric, `flair deploy` sets it from the deploy target and verifies the result; see [deploying-on-fabric.md](deploying-on-fabric.md). Local-only installs can leave it unset. |
 | `HDB_ADMIN_PASSWORD` | Bootstrap password for the embedded Harper. After first start, the persisted user record is the source of truth; rotate via the Harper ops API, not by changing this env var. | Set at install time. See [secrets-and-keys.md](secrets-and-keys.md) for rotation. |
 | `FLAIR_KEY_PASSPHRASE` | Passphrase used to derive the AES-256-GCM key that wraps federation private-key seeds at rest. Auto-generated to `~/.flair/keys/.passphrase` if unset. | Set explicitly for production federation deployments so the passphrase isn't auto-generated and lost on disk wipe. |
 | `HTTP_PORT` | Override the Harper HTTP port. Useful for sandboxes; production deployments should configure the port in `config.yaml` instead. | Rare. |

--- a/docs/hosted-on-fabric.md
+++ b/docs/hosted-on-fabric.md
@@ -53,7 +53,7 @@ On Fabric, configuration goes through the component's environment, not a local `
 
 | Variable | What it does | When to set it |
 |----------|--------------|----------------|
-| `FLAIR_PUBLIC_URL` | The URL operators reach this Flair on. Surfaced in OAuth metadata and A2A discovery. | **Always set** — or clients see a loopback address. |
+| `FLAIR_PUBLIC_URL` | The URL operators reach this Flair on. Surfaced in OAuth metadata and A2A discovery. | **`flair deploy` sets it** to the deploy target, in the component's `.env`. Set it yourself only to advertise a different host (CDN / proxy / vanity domain) — a value you set is never overwritten. |
 | `HDB_ADMIN_PASSWORD` | Bootstrap password for the embedded Harper. | Set at install time. |
 | `FLAIR_KEY_PASSPHRASE` | Passphrase for federation key encryption. | Set for production federation deployments. |
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -27,7 +27,15 @@ import { createRequire } from "node:module";
 import { createHash, randomUUID, randomBytes } from "node:crypto";
 import { create as tarCreate, extract as tarExtract, list as tarList } from "tar";
 import { keystore } from "./keystore.js";
-import { deploy as deployToFabric, validateOptions as validateDeployOptions, buildTargetUrl as buildDeployUrl } from "./deploy.js";
+import { deploy as deployToFabric, validateOptions as validateDeployOptions, buildTargetUrl as buildDeployUrl, resolveDeployPublicUrl } from "./deploy.js";
+import {
+  COMPONENT_ENV_FILENAME,
+  PUBLIC_URL_KEY,
+  assertNoSecretKeysAdded,
+  describePublicUrlFinding,
+  planComponentEnv,
+  readEnvValue,
+} from "./component-env.js";
 import { fabricUpgrade } from "./fabric-upgrade.js";
 import { checkVersion, formatVersionNudge, primeVersionCheckCache, FLAIR_PKG_NAME } from "./version-check.js";
 import { checkServerHandshake, formatHandshakeNudge, invalidateHandshakeCache } from "./version-handshake.js";
@@ -2032,9 +2040,37 @@ export async function callOpsApi(
   return res.json();
 }
 
+/**
+ * Build the component tarball `flair init --remote` uploads via the ops API.
+ *
+ * ── What was wrong here (flair#1005 item 2) ─────────────────────────────────
+ * This function wrote a `.env` into its temp directory and then packed an
+ * EXPLICIT entries list that did not contain it, so the file was discarded with
+ * the temp directory on every call. It had been that way since the writer landed:
+ * a writer whose output nothing consumed. `.env` is now in the list, which is the
+ * whole of the fix — and `init-remote-ops.test.ts` asserts the entry is present
+ * in a real tarball, because "the file was written" was never evidence of
+ * anything.
+ *
+ * ── Why `publicUrl` replaced the password parameter (flair#1011) ────────────
+ * The discarded file assigned `HDB_ADMIN_PASSWORD` and `FLAIR_ADMIN_PASSWORD`.
+ * Shipping it as-is would have made a latent hazard live, for two independent
+ * reasons: Harper composes its own configuration before a component's `.env`
+ * loads, so `HDB_ADMIN_PASSWORD` set this way is a credential Harper is
+ * structurally unable to honour while flair reads it — two sources, one name,
+ * nothing comparing them; and the payload is ingested into Harper's
+ * `hdb_deployment` record, which is replicated to every node and retained for
+ * rollback, so anything in it is persisted cluster-wide.
+ *
+ * The parameter is REMOVED rather than validated. A caller cannot pass a password
+ * to a function that has nowhere to put one, and no future edit can reintroduce
+ * one without also reintroducing the parameter. The admin credential still
+ * reaches the instance the way it always actually did — `add_user`/`alter_user`
+ * over the ops API in `provisionFabric`.
+ */
 export async function buildDeployTarball(
   projectRoot: string,
-  flairAdminPass: string,
+  publicUrl: string | null,
 ): Promise<{ tarballB64: string }> {
   const tmpDir = mkdtempSync(join(tmpdir(), "flair-deploy-"));
   try {
@@ -2050,13 +2086,21 @@ export async function buildDeployTarball(
       }
     }
 
-    // Write .env with 600 permissions
-    const envContent = [
-      `HDB_ADMIN_PASSWORD=${flairAdminPass}`,
-      `FLAIR_ADMIN_PASSWORD=${flairAdminPass}`,
-      "",
-    ].join("\n");
-    writeFileSync(join(tmpDir, ".env"), envContent, { mode: 0o600 });
+    // The component's environment. Harper reads this file only because
+    // config.yaml declares its `loadEnv` plugin (flair#1010) — without that
+    // declaration the file is present and inert, which is what made flair#1000
+    // hard to see. An existing `.env` in the project root is merged, never
+    // replaced; planComponentEnv keeps an operator's own value for the key.
+    const existingEnvPath = join(projectRoot, COMPONENT_ENV_FILENAME);
+    const existingEnv = existsSync(existingEnvPath) ? readFileSync(existingEnvPath, "utf8") : null;
+    const plan = planComponentEnv(existingEnv, publicUrl);
+    for (const notice of plan.notices) console.warn(`⚠ flair init --remote: ${notice}`);
+    const envText = plan.text ?? existingEnv;
+    if (envText !== null) {
+      assertNoSecretKeysAdded(existingEnv, envText);
+      writeFileSync(join(tmpDir, COMPONENT_ENV_FILENAME), envText, { mode: 0o600 });
+      entries.push(COMPONENT_ENV_FILENAME);
+    }
 
     // Build compressed tarball
     const tarballPath = join(tmpDir, "deploy.tar.gz");
@@ -2109,9 +2153,12 @@ export async function provisionFabric(
 ): Promise<void> {
   const projectRoot = process.cwd();
 
-  // 1. Build and deploy component tarball
+  // 1. Build and deploy component tarball. `target` is the served URL this
+  // function verifies against in step 2 — the same value the component must
+  // advertise in OAuth/A2A discovery, so it is what FLAIR_PUBLIC_URL is set from
+  // (flair#1005). A loopback target supplies nothing: see resolveDeployPublicUrl.
   console.log("Building deploy tarball...");
-  const { tarballB64 } = await buildDeployTarball(projectRoot, flairAdminPass);
+  const { tarballB64 } = await buildDeployTarball(projectRoot, resolveDeployPublicUrl(target));
 
   console.log("Deploying via ops API...");
   await callOpsApi(opsTarget, {
@@ -12228,6 +12275,53 @@ program
         }
       }
     } catch { /* best-effort — a stat failure shouldn't fail doctor */ }
+
+    // 3d. The URL this instance tells the world to use (flair#1005, flair#1000).
+    //
+    // Asks the instance for its OWN discovery document rather than inferring
+    // anything from config: /OAuthMetadata's `issuer` is the exact field that was
+    // wrong in flair#1000, and it is the only thing that proves what a client
+    // will actually be handed. describePublicUrlFinding (src/component-env.ts) is
+    // pure decision logic, unit-tested, and documents in its own header why the
+    // detectable condition is DRIFT rather than "unset on a public instance" —
+    // doctor reaches this instance over loopback and cannot observe whether it is
+    // also reachable at a public address.
+    if (harperResponding) {
+      let advertisedIssuer: string | null = null;
+      try {
+        const res = await fetch(`${baseUrl}/OAuthMetadata`, { signal: AbortSignal.timeout(5000) });
+        if (res.ok) {
+          const doc = (await res.json()) as { issuer?: unknown };
+          if (typeof doc?.issuer === "string" && doc.issuer !== "") advertisedIssuer = doc.issuer;
+        }
+      } catch { /* unreachable/unparseable → null → the finding is skipped, not passed */ }
+
+      // The component directory for a local install is the flair package itself:
+      // `flair start` spawns `harper run .` with cwd = flairPackageDir().
+      const componentEnvPath = join(flairPackageDir(), COMPONENT_ENV_FILENAME);
+      let componentEnvValue: string | null = null;
+      try {
+        if (existsSync(componentEnvPath)) {
+          componentEnvValue = readEnvValue(readFileSync(componentEnvPath, "utf-8"), PUBLIC_URL_KEY);
+        }
+      } catch { /* unreadable → treat as absent */ }
+
+      const finding = describePublicUrlFinding({
+        advertisedIssuer,
+        componentEnvValue,
+        processEnvValue: process.env.FLAIR_PUBLIC_URL ?? null,
+        componentEnvPath,
+      });
+      if (finding) {
+        const icon =
+          finding.icon === "ok" ? render.icons.ok
+          : finding.icon === "warn" ? render.icons.warn
+          : render.icons.error;
+        console.log(`  ${icon} ${finding.message}`);
+        if (finding.fixHint) console.log(`     ${render.wrap(render.c.dim, "Fix:")} ${finding.fixHint}`);
+        if (finding.isIssue) issues++;
+      }
+    }
 
     // 4. Embeddings check — REAL semantic round-trip (only if Harper is responding).
     //

--- a/src/component-env.ts
+++ b/src/component-env.ts
@@ -1,0 +1,354 @@
+// ─── The deployed component's `.env` (flair#1005 item 2, flair#1000, flair#1011) ──
+//
+// A publicly-reachable Flair served an OAuth discovery document whose issuer and
+// every endpoint were `http://127.0.0.1:9980`, so no remote client could complete
+// an authorization flow (flair#1000). The cause was `FLAIR_PUBLIC_URL` being unset
+// on the instance: `resources/OAuth.ts` and `resources/AdminInstance.ts` fall back
+// to the bind address when it is absent.
+//
+// The value has to arrive as an ENVIRONMENT VARIABLE in the component's process.
+// The only channel a deploying client controls is a `.env` file inside the
+// component payload, and Harper reads that file only because flair#1010 added
+//
+//     loadEnv:
+//       files: '.env'
+//
+// to the shipped config.yaml, declared above `jsResource`. Without that block the
+// file is inert — present on disk, never in `process.env`. Read config.yaml's own
+// comment for the ordering constraint and for why `loadEnv` supplies APPLICATION
+// variables only: it runs after Harper has already composed its own configuration.
+//
+// ── Why exactly one key ships, and no secret ever does ──────────────────────────
+//
+// The deploy payload is not transient. Harper's `deploy_component` ingests the
+// whole tarball into an `hdb_deployment` row's `payload_blob`, and that row is the
+// channel peers read the component from and the source for rollback
+// (harper/dist/components/operations.js — "The row also holds the payload in a Blob
+// attribute, which doubles as the source for peer replication and (later)
+// rollback"). So anything in the payload is persisted on every node for as long as
+// the deployment record lives. A public URL is fine there. A password is not.
+//
+// `HDB_ADMIN_PASSWORD` additionally cannot work from here even if that were
+// acceptable: Harper composes its own configuration before component `.env` files
+// load, so the name Harper itself consumes at startup is already resolved by the
+// time `loadEnv` fires. Shipping it would put a credential in a component directory
+// that only flair reads, fed from a different source than Harper's own copy, with
+// nothing detecting divergence (flair#1011). `FLAIR_ADMIN_PASSWORD` is flair's own
+// name for flair's own need and does reach its reader in time — but it is still a
+// password, and the payload-persistence argument above applies to it unchanged.
+//
+// Hence: the file this module generates carries `FLAIR_PUBLIC_URL` and nothing
+// else, and `assertNoSecretKeys` is a runtime guard, not a comment.
+
+/** The file Harper's `loadEnv` plugin is pointed at by flair's config.yaml. */
+export const COMPONENT_ENV_FILENAME = ".env";
+
+/** The one key `flair deploy` supplies. */
+export const PUBLIC_URL_KEY = "FLAIR_PUBLIC_URL";
+
+/**
+ * Key names that must never appear in a `.env` flair GENERATES.
+ *
+ * An operator's own file is a different matter — see `planComponentEnv`, which
+ * preserves whatever they wrote and warns by key NAME (never value) rather than
+ * silently dropping or shipping it.
+ */
+export const NEVER_GENERATED_SECRET_KEYS = [
+  "HDB_ADMIN_PASSWORD",
+  "FLAIR_ADMIN_PASSWORD",
+  "FLAIR_ADMIN_PASS",
+  "FABRIC_PASSWORD",
+  "FLAIR_CLUSTER_ADMIN_PASS",
+  "CLI_TARGET_PASSWORD",
+] as const;
+
+/**
+ * A key name that looks like it carries a credential. Used for the operator-facing
+ * notice only — matching is on the NAME, and the value is never read, printed, or
+ * compared.
+ */
+export function looksLikeSecretKey(name: string): boolean {
+  return /(PASSWORD|PASSWD|SECRET|TOKEN|_KEY|APIKEY|CREDENTIAL)/i.test(name);
+}
+
+/**
+ * Is this URL one only the machine serving it can reach?
+ *
+ * Deliberately a TEXT test, not a DNS lookup: this decides what gets baked into a
+ * deployed artifact, and a resolver answer at deploy time is not a property of the
+ * artifact. The IPv4 pattern is anchored end-to-end on purpose — a prefix test
+ * (`startsWith("127.")`) also matches hostnames like `127.0.0.1.example.com`, which
+ * are ordinary DNS names that merely happen to begin with those digits.
+ */
+export function isLoopbackUrl(raw: string | null | undefined): boolean {
+  if (!raw) return false;
+  let host: string;
+  try {
+    host = new URL(raw).hostname;
+  } catch {
+    return false;
+  }
+  return isLoopbackHost(host);
+}
+
+export function isLoopbackHost(host: string): boolean {
+  const h = host.replace(/^\[|\]$/g, "").toLowerCase();
+  if (h === "localhost" || h.endsWith(".localhost")) return true;
+  if (h === "::1" || h === "0:0:0:0:0:0:0:1") return true;
+  return /^127\.\d{1,3}\.\d{1,3}\.\d{1,3}$/.test(h);
+}
+
+// A `.env` assignment line. `export ` is accepted because dotenv-style files
+// commonly carry it and an operator who wrote `export FLAIR_PUBLIC_URL=...` has
+// unambiguously set the key — treating that as "absent" and appending a second
+// assignment would be the clobber this module exists to avoid.
+const ASSIGNMENT_RE = /^[ \t]*(?:export[ \t]+)?([A-Za-z_][A-Za-z0-9_]*)[ \t]*=/;
+
+/** Key NAMES present in a `.env`, in file order. Never returns values. */
+export function envKeyNames(text: string | null | undefined): string[] {
+  if (!text) return [];
+  const names: string[] = [];
+  for (const line of text.split(/\r?\n/)) {
+    const m = ASSIGNMENT_RE.exec(line);
+    if (m && !names.includes(m[1])) names.push(m[1]);
+  }
+  return names;
+}
+
+/**
+ * The value assigned to `key`, or null. The single value this module reads is
+ * `FLAIR_PUBLIC_URL`, which is not a secret; nothing here reads any other value.
+ */
+export function readEnvValue(text: string | null | undefined, key: string): string | null {
+  if (!text) return null;
+  for (const line of text.split(/\r?\n/)) {
+    const m = ASSIGNMENT_RE.exec(line);
+    if (!m || m[1] !== key) continue;
+    let v = line.slice(line.indexOf("=") + 1).trim();
+    if ((v.startsWith('"') && v.endsWith('"') && v.length >= 2) ||
+        (v.startsWith("'") && v.endsWith("'") && v.length >= 2)) {
+      v = v.slice(1, -1);
+    }
+    return v;
+  }
+  return null;
+}
+
+/**
+ * Throws if the transition from `existing` to `generated` INTRODUCES any key flair
+ * must never generate.
+ *
+ * Deliberately a diff and not "does the output contain a password": an operator's
+ * own `.env` may legitimately assign one, and refusing to deploy their file would
+ * break a deploy that works today. What must never happen is flair adding one. A
+ * runtime guard rather than a review convention, because the generator and this
+ * check are one edit apart forever — and `git grep NEVER_GENERATED_SECRET_KEYS`
+ * finds both ends of it.
+ */
+export function assertNoSecretKeysAdded(existing: string | null, generated: string): void {
+  const before = new Set(envKeyNames(existing));
+  const added = envKeyNames(generated).filter(
+    (n) => !before.has(n) && (NEVER_GENERATED_SECRET_KEYS as readonly string[]).includes(n),
+  );
+  if (added.length) {
+    throw new Error(
+      `refusing to generate a component ${COMPONENT_ENV_FILENAME} that adds ${added.join(", ")}: ` +
+        `the deploy payload is persisted in Harper's hdb_deployment record and replicated to ` +
+        `every node, so flair must add no credential to it (flair#1011)`,
+    );
+  }
+}
+
+export type ComponentEnvAction =
+  /** No `.env` needs to be supplied — deploy the package root as-is. */
+  | "unchanged"
+  /** flair adds the key to a payload that did not have it. */
+  | "added"
+  /** The operator already set the key; their value is kept verbatim. */
+  | "operator-value-kept";
+
+export interface ComponentEnvPlan {
+  action: ComponentEnvAction;
+  /**
+   * The `.env` contents to ship, or null when `action === "unchanged"` (nothing
+   * is written and the operator's tree is not touched).
+   */
+  text: string | null;
+  /** The value that will be in effect for `FLAIR_PUBLIC_URL`, if any. */
+  effectiveValue: string | null;
+  /** Operator-facing lines. Key names only — never a value from a secret-shaped key. */
+  notices: string[];
+}
+
+/**
+ * Decide what `.env` a deploy should ship.
+ *
+ * `existing` is the CONTENT of a `.env` already in the package root, or null. It is
+ * never modified in place and never overwritten on disk — the caller stages a copy.
+ * That is the answer to "do not silently clobber an operator's existing `.env`":
+ * flair MERGES, and merging here means "append the one key when it is absent, and
+ * change nothing at all when it is present".
+ *
+ * Why merge rather than refuse: a `.env` in the package root already ships today
+ * (Harper's packer includes every non-`node_modules` file under the deploy root), so
+ * an operator can legitimately be relying on one, and refusing would break a deploy
+ * that works. Why the operator's value wins rather than the deploy target: an
+ * instance is routinely fronted by a hostname that is not the URL the deploy is
+ * addressed to — a CDN, a reverse proxy, a vanity domain — and that hostname is
+ * exactly what OAuth clients must be told. Overwriting it with the Fabric URL would
+ * break the deployment the value exists to fix. The disagreement is printed, so the
+ * choice is visible rather than silent.
+ *
+ * `publicUrl` is null when the deploy has no non-loopback target to advertise; the
+ * plan is then "unchanged" — writing `http://127.0.0.1:...` into a shipped `.env` is
+ * the precise misconfiguration flair#1000 is about, so it is never generated.
+ */
+export function planComponentEnv(
+  existing: string | null,
+  publicUrl: string | null,
+): ComponentEnvPlan {
+  const notices: string[] = [];
+
+  // Whatever the operator wrote, say out loud which credential-shaped KEYS are
+  // about to be persisted in the replicated deployment record. Names only.
+  const secretish = envKeyNames(existing).filter(looksLikeSecretKey);
+  if (secretish.length) {
+    notices.push(
+      `${COMPONENT_ENV_FILENAME} in the deploy root assigns ${secretish.join(", ")} — a deploy ` +
+        `payload is stored in Harper's deployment record and replicated to every node, so ` +
+        `those values travel with it. flair adds no credential of its own.`,
+    );
+  }
+
+  const operatorValue = readEnvValue(existing, PUBLIC_URL_KEY);
+  if (operatorValue !== null) {
+    if (publicUrl && operatorValue !== publicUrl) {
+      notices.push(
+        `${PUBLIC_URL_KEY} is already set in ${COMPONENT_ENV_FILENAME} to ${operatorValue} — ` +
+          `keeping it. The deploy target is ${publicUrl}; if the instance is fronted by a ` +
+          `proxy or CDN the existing value is the correct one, otherwise edit that file.`,
+      );
+    }
+    if (isLoopbackUrl(operatorValue)) {
+      notices.push(
+        `${PUBLIC_URL_KEY} in ${COMPONENT_ENV_FILENAME} is a loopback address ` +
+          `(${operatorValue}). OAuth discovery and A2A discovery advertise it verbatim, so ` +
+          `remote clients will be told to connect to their own machine (flair#1000).`,
+      );
+    }
+    return { action: "operator-value-kept", text: null, effectiveValue: operatorValue, notices };
+  }
+
+  if (!publicUrl) {
+    return { action: "unchanged", text: null, effectiveValue: null, notices };
+  }
+
+  const base = existing ?? "";
+  const separator = base.length === 0 || base.endsWith("\n") ? "" : "\n";
+  const text = `${base}${separator}${PUBLIC_URL_KEY}=${publicUrl}\n`;
+  assertNoSecretKeysAdded(existing, text);
+
+  return { action: "added", text, effectiveValue: publicUrl, notices };
+}
+
+/**
+ * The remedy string for a missing/loopback `FLAIR_PUBLIC_URL`. One definition so
+ * `flair deploy` and `flair doctor` cannot drift into naming different files.
+ *
+ * It names all three things an operator needs: the FILE, the KEY, and the fact that
+ * the file is only read because config.yaml declares Harper's `loadEnv` plugin —
+ * without which the file is present and inert, which is what made flair#1000 hard
+ * to see.
+ */
+export function publicUrlRemedy(envPath: string, exampleUrl = "https://flair.example.com"): string {
+  return (
+    `set ${PUBLIC_URL_KEY}=${exampleUrl} in ${envPath} (Harper reads a component's ` +
+    `${COMPONENT_ENV_FILENAME} only because flair's config.yaml declares the loadEnv plugin, ` +
+    `above jsResource), then restart the instance`
+  );
+}
+
+// ─── flair doctor ─────────────────────────────────────────────────────────────
+
+export interface PublicUrlDoctorInput {
+  /** `issuer` from the instance's own /OAuthMetadata, or null if it could not be read. */
+  advertisedIssuer: string | null;
+  /** `FLAIR_PUBLIC_URL` assigned in the component's `.env`, or null. */
+  componentEnvValue: string | null;
+  /** `FLAIR_PUBLIC_URL` visible to the CLI process, or null. */
+  processEnvValue: string | null;
+  /** Absolute path of the component `.env` the remedy should name. */
+  componentEnvPath: string;
+}
+
+export interface PublicUrlDoctorFinding {
+  isIssue: boolean;
+  icon: "ok" | "warn" | "error";
+  message: string;
+  fixHint?: string;
+}
+
+/**
+ * What `flair doctor` should say about the instance's advertised public URL.
+ *
+ * Scope, stated rather than implied: doctor diagnoses the instance on THIS machine,
+ * reached over loopback. It cannot observe whether that instance is also reachable
+ * at a public address, so "unset, and the instance is public" is not a state it can
+ * detect — an unconditional finding there would fire on every laptop install, and a
+ * check that always fires is noise, not a gate. What it CAN detect without guessing
+ * is DRIFT: the value exists somewhere, and the running instance is still advertising
+ * loopback anyway. That is the exact shape of flair#1000 (a `.env` was placed and the
+ * issuer never changed, because no `loadEnv` declaration existed to read it), and it
+ * has no false positives.
+ *
+ * The unset-everywhere case is reported as information, not a finding, with the full
+ * remedy — so an operator who IS running this publicly is told precisely what to do.
+ */
+export function describePublicUrlFinding(input: PublicUrlDoctorInput): PublicUrlDoctorFinding | null {
+  const { advertisedIssuer, componentEnvValue, processEnvValue, componentEnvPath } = input;
+
+  // Nothing to say if the instance could not be asked.
+  if (advertisedIssuer === null) return null;
+
+  if (!isLoopbackUrl(advertisedIssuer)) {
+    return {
+      isIssue: false,
+      icon: "ok",
+      message: `OAuth/A2A discovery advertises ${advertisedIssuer}`,
+    };
+  }
+
+  if (componentEnvValue !== null && !isLoopbackUrl(componentEnvValue)) {
+    return {
+      isIssue: true,
+      icon: "error",
+      message:
+        `${PUBLIC_URL_KEY} is set in ${componentEnvPath} but discovery still advertises ` +
+        `${advertisedIssuer} — the file is not reaching process.env, so every URL this ` +
+        `instance publishes points at its own loopback (flair#1000)`,
+      fixHint:
+        `confirm config.yaml declares "loadEnv: files: '${COMPONENT_ENV_FILENAME}'" ABOVE ` +
+        `jsResource, then restart — a component .env is inert without that declaration`,
+    };
+  }
+
+  if (componentEnvValue === null && processEnvValue !== null && !isLoopbackUrl(processEnvValue)) {
+    return {
+      isIssue: true,
+      icon: "error",
+      message:
+        `${PUBLIC_URL_KEY} is set in this shell but discovery advertises ${advertisedIssuer} — ` +
+        `the server reads its own environment, not yours`,
+      fixHint: publicUrlRemedy(componentEnvPath, processEnvValue),
+    };
+  }
+
+  return {
+    isIssue: false,
+    icon: "warn",
+    message:
+      `${PUBLIC_URL_KEY} is not set — OAuth and A2A discovery advertise ${advertisedIssuer}, ` +
+      `which is correct for a local-only install and unusable for any remote client`,
+    fixHint: `if this instance is reachable at a public URL, ${publicUrlRemedy(componentEnvPath)}`,
+  };
+}

--- a/src/deploy.ts
+++ b/src/deploy.ts
@@ -1,8 +1,17 @@
 import { spawn } from "node:child_process";
-import { dirname, join, resolve } from "node:path";
-import { existsSync, readFileSync, readdirSync } from "node:fs";
+import { dirname, join, relative, resolve, sep } from "node:path";
+import { cpSync, existsSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
 import { fileURLToPath } from "node:url";
 import { createRequire } from "node:module";
+import {
+  COMPONENT_ENV_FILENAME,
+  PUBLIC_URL_KEY,
+  isLoopbackUrl,
+  planComponentEnv,
+  publicUrlRemedy,
+  type ComponentEnvPlan,
+} from "./component-env.js";
 import {
   awaitOriginQuiescent,
   awaitReplicationConvergence,
@@ -789,6 +798,202 @@ async function verifyResourcesServing(
   }
 }
 
+// ─── The component `.env` the deploy ships (flair#1005 item 2) ────────────────
+//
+// `harper deploy` packs its own CWD — every file under it except `node_modules`
+// (harper/dist/bin/cliOperations.js sets `skip_node_modules` unless explicitly
+// disabled, and harper/dist/components/packageComponent.js's `isExcluded` is the
+// only other filter). So a `.env` sitting in the deploy root ships; there is no
+// entries list to add it to, and no `.env` is special-cased away. Verified by
+// running harper's own packer over a directory containing one.
+//
+// What this must NOT do is write into `packageRoot`. That directory is an
+// npm-installed package — frequently not writable by the deploying user, shared by
+// every deploy from this machine, and, when the operator has put their own `.env`
+// there, theirs. So when flair has a key to add, it copies the deploy root to a
+// temp directory, writes the merged file THERE, and points harper at the copy. The
+// operator's tree is read and never written.
+//
+// The copy skips `node_modules` for the obvious reason (it can be gigabytes) and
+// for the correctness one: harper excludes it at pack time regardless, so the
+// resulting payload is identical. `deploy-staging.test.ts` asserts that identity
+// with harper's real packer rather than trusting this paragraph.
+
+const STAGING_PREFIX = "flair-deploy-";
+
+export interface StagedDeployRoot {
+  /** Directory harper should pack — either the staged copy or `packageRoot` itself. */
+  dir: string;
+  plan: ComponentEnvPlan;
+  /** Removes the staged copy. A no-op when nothing was staged. */
+  cleanup: () => void;
+}
+
+/** True for any path inside a `node_modules` directory under `root`. */
+function isNodeModulesPath(root: string, path: string): boolean {
+  const rel = relative(root, path);
+  return rel !== "" && rel.split(sep).includes("node_modules");
+}
+
+/**
+ * Resolve the value `FLAIR_PUBLIC_URL` should carry for this deploy, or null.
+ *
+ * The deploy already knows this: `url` is the target it hands to harper AND the
+ * base URL it verifies the served API against immediately afterwards. A loopback
+ * target yields null — baking `http://127.0.0.1:...` into a shipped `.env` is
+ * precisely the misconfiguration flair#1000 is about, so it is never generated.
+ *
+ * Anything that is not an absolute http(s) URL also yields null. `--target` is
+ * operator-supplied and reaches here before harper has had a chance to reject it,
+ * and a value that is not a URL cannot be the base of a discovery document — so
+ * "cannot be determined" is answered by supplying nothing rather than by baking in
+ * a string that would make every advertised endpoint malformed.
+ */
+export function resolveDeployPublicUrl(url: string): string | null {
+  const trimmed = String(url ?? "").replace(/\/+$/, "");
+  let parsed: URL;
+  try {
+    parsed = new URL(trimmed);
+  } catch {
+    return null;
+  }
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") return null;
+  return isLoopbackUrl(trimmed) ? null : trimmed;
+}
+
+/**
+ * Prepare the directory harper will pack, supplying `FLAIR_PUBLIC_URL` when the
+ * payload does not already carry it. Returns `packageRoot` unchanged (and a no-op
+ * cleanup) whenever there is nothing to add — the common cases being a loopback
+ * target and an operator who has already set the key.
+ */
+export function stageDeployRoot(packageRoot: string, publicUrl: string | null): StagedDeployRoot {
+  const envPath = join(packageRoot, COMPONENT_ENV_FILENAME);
+  const existing = existsSync(envPath) ? readFileSync(envPath, "utf8") : null;
+  const plan = planComponentEnv(existing, publicUrl);
+
+  if (plan.text === null) {
+    return { dir: packageRoot, plan, cleanup: () => {} };
+  }
+
+  const dir = mkdtempSync(join(tmpdir(), STAGING_PREFIX));
+  try {
+    cpSync(packageRoot, dir, {
+      recursive: true,
+      dereference: false,
+      verbatimSymlinks: true,
+      filter: (src) => !isNodeModulesPath(packageRoot, src),
+    });
+    // 0600 even though the generated content is a public URL: an operator's own
+    // keys may have been merged through, and the file's permissions should not
+    // depend on what happens to be in it.
+    writeFileSync(join(dir, COMPONENT_ENV_FILENAME), plan.text, { mode: 0o600 });
+  } catch (err) {
+    rmSync(dir, { recursive: true, force: true });
+    throw err;
+  }
+  return { dir, plan, cleanup: () => rmSync(dir, { recursive: true, force: true }) };
+}
+
+// ─── Post-deploy: is the instance advertising a URL a client can reach? ───────
+//
+// This is the check that makes the writer above testable in production rather than
+// merely present. flair#1000 was a deploy that reported success while the served
+// OAuth discovery document named `http://127.0.0.1:9980` for every endpoint, so a
+// remote client followed discovery to its own loopback. Nothing in the deploy
+// noticed, because nothing looked.
+//
+// A failure here fails the command even though the component IS deployed — the same
+// contract as verifyResourcesServing above ("the tool must not be able to lie"). A
+// deploy that leaves an instance no client can authorize against is not a success,
+// and the operator needs to hear that at deploy time rather than from a user.
+//
+// An unreadable document is NOT treated as a pass: it is reported as a check that
+// did not run, with the reason.
+//
+// It POLLS rather than reading once. A Fabric restart is rolling, so for a while
+// after `harper deploy` returns, a request to the cluster can be answered by a node
+// that has not restarted yet and is still running the previous environment. Reading
+// once would turn that race into a failed deploy for a change that was fine. The
+// poll only ever converts a "not yet" into a wait — a genuinely misconfigured
+// instance still fails, at the deadline.
+
+export const OAUTH_METADATA_PATH = "/OAuthMetadata";
+export const DEFAULT_ISSUER_CHECK_TIMEOUT_MS = 60_000;
+export const ISSUER_CHECK_POLL_INTERVAL_MS = 5_000;
+
+export interface VerifyPublicIssuerOptions {
+  baseUrl: string;
+  timeoutMs?: number;
+  pollIntervalMs?: number;
+  fetchImpl?: typeof fetch;
+  onProgress?: (msg: string) => void;
+}
+
+export interface PublicIssuerResult {
+  /** false when the document could not be read — never rendered as a pass. */
+  checked: boolean;
+  issuer: string | null;
+  detail: string;
+}
+
+/** One read of the discovery document. `issuer: null` means "could not be read". */
+async function readAdvertisedIssuer(
+  url: string,
+  fetchImpl: typeof fetch,
+): Promise<{ issuer: string | null; detail: string }> {
+  try {
+    const res = await fetchImpl(url, { method: "GET", signal: AbortSignal.timeout(10_000) });
+    if (!res.ok) return { issuer: null, detail: `HTTP ${res.status} from ${url}` };
+    const doc = (await res.json()) as { issuer?: unknown };
+    if (typeof doc?.issuer !== "string" || doc.issuer === "") {
+      return { issuer: null, detail: `${url} returned no issuer` };
+    }
+    return { issuer: doc.issuer, detail: `issuer ${doc.issuer}` };
+  } catch (err: any) {
+    return { issuer: null, detail: `${url} could not be read: ${err?.message ?? err}` };
+  }
+}
+
+export async function verifyPublicIssuer(o: VerifyPublicIssuerOptions): Promise<PublicIssuerResult> {
+  const {
+    baseUrl,
+    timeoutMs = DEFAULT_ISSUER_CHECK_TIMEOUT_MS,
+    pollIntervalMs = ISSUER_CHECK_POLL_INTERVAL_MS,
+    fetchImpl = fetch,
+    onProgress,
+  } = o;
+  const base = baseUrl.replace(/\/+$/, "");
+  const url = `${base}${OAUTH_METADATA_PATH}`;
+  onProgress?.(`checking ${OAUTH_METADATA_PATH} advertises a reachable issuer...`);
+
+  const deadline = Date.now() + timeoutMs;
+  let last = await readAdvertisedIssuer(url, fetchImpl);
+  for (;;) {
+    if (last.issuer !== null && !isLoopbackUrl(last.issuer)) {
+      return { checked: true, issuer: last.issuer, detail: last.detail };
+    }
+    if (Date.now() >= deadline) break;
+    onProgress?.(
+      last.issuer === null
+        ? `${OAUTH_METADATA_PATH} not readable yet (${last.detail}) — retrying...`
+        : `${OAUTH_METADATA_PATH} still advertises ${last.issuer} — the restart may not have reached every node yet, retrying...`,
+    );
+    await sleep(Math.min(pollIntervalMs, Math.max(0, deadline - Date.now())));
+    last = await readAdvertisedIssuer(url, fetchImpl);
+  }
+
+  if (last.issuer !== null) {
+    throw new Error(
+      `deploy verification: ${url} advertises issuer ${last.issuer} — a loopback address, which ` +
+        `every remote client will follow to its own machine (flair#1000). ${PUBLIC_URL_KEY} is ` +
+        `not reaching the deployed component's process.env. Fix: ` +
+        `${publicUrlRemedy(`${COMPONENT_ENV_FILENAME} in the deploy root`, base)}, then re-deploy.`,
+    );
+  }
+  return { checked: false, issuer: null, detail: last.detail };
+}
+
 // The tool must not be able to lie. harper's deploy CLI can print
 // "Successfully deployed" for an empty component — the only way to know the
 // deploy actually worked is to curl the served API and check it isn't 404.
@@ -852,15 +1057,35 @@ export async function deploy(opts: DeployOptions): Promise<DeployResult> {
     CLI_TARGET_PASSWORD: opts.fabricPassword,
   };
 
-  const { replicationWarning, convergedAfterReplicationError } = await runHarperDeploy(
-    harperBin,
-    args,
-    packageRoot,
-    childEnv,
-    opts,
-    url,
-    project,
-  );
+  // flair#1005 item 2: supply FLAIR_PUBLIC_URL to the component being deployed.
+  // `deployRoot` is packageRoot itself whenever there is nothing to add.
+  const publicUrl = resolveDeployPublicUrl(url);
+  const staged = stageDeployRoot(packageRoot, publicUrl);
+  for (const notice of staged.plan.notices) {
+    console.warn(`⚠ flair deploy: ${notice}`);
+    opts.onProgress?.(notice);
+  }
+  if (staged.plan.action === "added") {
+    opts.onProgress?.(
+      `shipping ${COMPONENT_ENV_FILENAME} with ${PUBLIC_URL_KEY}=${staged.plan.effectiveValue}`,
+    );
+  }
+
+  let replicationWarning: boolean;
+  let convergedAfterReplicationError: boolean;
+  try {
+    ({ replicationWarning, convergedAfterReplicationError } = await runHarperDeploy(
+      harperBin,
+      args,
+      staged.dir,
+      childEnv,
+      opts,
+      url,
+      project,
+    ));
+  } finally {
+    staged.cleanup();
+  }
 
   // harper can print "Successfully deployed" for a component that isn't
   // actually serving anything (the incident this closes: an empty deploy,
@@ -876,6 +1101,22 @@ export async function deploy(opts: DeployOptions): Promise<DeployResult> {
       timeoutMs: opts.verifyTimeoutMs ?? DEFAULT_VERIFY_TIMEOUT_MS,
       onProgress: opts.onProgress,
     });
+
+    // Only meaningful for a target that is not loopback: a local Harper SHOULD
+    // advertise loopback, and asserting otherwise there would be wrong.
+    if (publicUrl) {
+      const issuerCheck = await verifyPublicIssuer({ baseUrl: url, onProgress: opts.onProgress });
+      if (issuerCheck.checked) {
+        opts.onProgress?.(`discovery advertises ${issuerCheck.issuer}`);
+      } else {
+        // Not a pass. Say which check did not run, and why.
+        console.warn(
+          `⚠ flair deploy: could not verify the advertised OAuth issuer — ${issuerCheck.detail}. ` +
+            `This check did NOT run; ${PUBLIC_URL_KEY} may or may not have taken effect.`,
+        );
+        opts.onProgress?.(`issuer check did not run — ${issuerCheck.detail}`);
+      }
+    }
   }
 
   return {

--- a/test/integration/deploy-public-url.test.ts
+++ b/test/integration/deploy-public-url.test.ts
@@ -1,0 +1,182 @@
+// deploy-public-url.test.ts — does the value a deploy ships actually change what
+// the instance tells the world? (flair#1005 item 2, flair#1000)
+//
+// flair#1000: a publicly-reachable instance served an OAuth discovery document
+// whose issuer and every endpoint were `http://127.0.0.1:9980`, so a remote client
+// followed discovery to its own loopback. The fix is `FLAIR_PUBLIC_URL` reaching
+// the component's `process.env` — which requires a `.env` inside the deployed
+// component AND the `loadEnv` declaration in config.yaml that makes Harper read it
+// (flair#1010). Either half missing produces the same silent failure.
+//
+// This walks the whole chain with production code at every step:
+//
+//   stageDeployRoot()            the thing `flair deploy` runs
+//     → harper's own packer      the code `harper deploy` uploads with
+//       → tar extract            what Harper's deployComponent does server-side
+//         → a REAL spawned Harper booting that directory as its component
+//           → GET /OAuthMetADATA over HTTP
+//
+// What it does not cover: the HTTPS upload to a Fabric cluster and Harper's
+// server-side `npm install`. Nothing about either is specific to this change.
+//
+// The second test is the positive control. Without it, a green first test proves
+// only that /OAuthMetadata returned a string — not that the `.env` is what put it
+// there. So the identical tree, built for a target that supplies no public URL,
+// must advertise loopback.
+
+import { describe, test, expect, afterAll } from "bun:test";
+import { createRequire } from "node:module";
+import { cpSync, existsSync, mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { startHarper, stopHarper, type HarperInstance } from "../helpers/harper-lifecycle.js";
+import { resolveDeployPublicUrl, stageDeployRoot } from "../../src/deploy.js";
+
+const REPO_ROOT = join(import.meta.dir, "..", "..");
+const PUBLIC_URL = "https://flair-1005.example.com";
+
+const require_ = createRequire(import.meta.url);
+function harperPackagerPath(): string {
+  for (const pkg of ["harper", join("@harperfast", "harper")]) {
+    const p = join(REPO_ROOT, "node_modules", pkg, "dist", "components", "packageComponent.js");
+    if (existsSync(p)) return p;
+  }
+  throw new Error("harper's packageComponent.js not found under node_modules");
+}
+const { packageDirectory } = require_(harperPackagerPath()) as {
+  packageDirectory: (dir: string, opts: { skip_node_modules: boolean; skip_symlinks: boolean }) => Promise<string>;
+};
+
+const tmpDirs: string[] = [];
+const instances: HarperInstance[] = [];
+
+function tempDir(prefix: string): string {
+  const d = mkdtempSync(join(tmpdir(), prefix));
+  tmpDirs.push(d);
+  return d;
+}
+
+afterAll(async () => {
+  for (const h of instances) {
+    try { await stopHarper(h); } catch { /* best effort */ }
+  }
+  for (const d of tmpDirs) {
+    try { rmSync(d, { recursive: true, force: true }); } catch { /* best effort */ }
+  }
+});
+
+/**
+ * A package root shaped like the PUBLISHED flair package — the layout
+ * `resolvePackageRoot()` hands to a deploy. Deliberately not the repo root: that
+ * carries an 80MB pre-downloaded embedding model which a real deploy never packs.
+ */
+function publishedLikePackageRoot(): string {
+  const root = tempDir("flair-pkgroot-");
+  for (const entry of ["dist", "schemas", "templates", "docs", "config.yaml", "package.json", "LICENSE", "README.md", "SECURITY.md"]) {
+    const src = join(REPO_ROOT, entry);
+    if (existsSync(src)) cpSync(src, join(root, entry), { recursive: true });
+  }
+  return root;
+}
+
+/**
+ * Run the real deploy path as far as a directory Harper can boot: stage, pack
+ * with harper's packer, extract the way Harper's deployComponent does, then
+ * provide node_modules (which Harper installs server-side and the packer always
+ * excludes).
+ */
+async function deployedComponentDir(publicUrl: string | null): Promise<string> {
+  const packageRoot = publishedLikePackageRoot();
+  const staged = stageDeployRoot(packageRoot, publicUrl);
+  try {
+    const b64 = await packageDirectory(staged.dir, { skip_node_modules: true, skip_symlinks: false });
+    const work = tempDir("flair-payload-");
+    const tarPath = join(work, "payload.tar.gz");
+    writeFileSync(tarPath, Buffer.from(b64, "base64"));
+
+    const componentDir = join(work, "component");
+    mkdirSync(componentDir, { recursive: true });
+    const { extract } = await import("tar");
+    await extract({ file: tarPath, cwd: componentDir });
+
+    symlinkSync(join(REPO_ROOT, "node_modules"), join(componentDir, "node_modules"));
+    return componentDir;
+  } finally {
+    staged.cleanup();
+  }
+}
+
+async function fetchOAuthMetadata(httpURL: string): Promise<Record<string, unknown>> {
+  const res = await fetch(`${httpURL}/OAuthMetadata`, { signal: AbortSignal.timeout(15_000) });
+  expect(res.status).toBe(200);
+  return (await res.json()) as Record<string, unknown>;
+}
+
+describe("a deployed component advertises the deploy's public URL (flair#1005)", () => {
+  test(
+    "every discovery URL is on the public host, not 127.0.0.1",
+    async () => {
+      const componentDir = await deployedComponentDir(PUBLIC_URL);
+      const harper = await startHarper({ cwd: componentDir, harperBinDir: REPO_ROOT });
+      instances.push(harper);
+
+      const doc = await fetchOAuthMetadata(harper.httpURL);
+
+      expect(doc.issuer).toBe(PUBLIC_URL);
+      for (const key of Object.keys(doc)) {
+        if (!key.endsWith("_endpoint")) continue;
+        const value = doc[key];
+        expect({ key, value }).toEqual({ key, value: expect.stringContaining(PUBLIC_URL) });
+      }
+      // The literal symptom from flair#1000, asserted against the whole document.
+      expect(JSON.stringify(doc)).not.toContain("127.0.0.1");
+    },
+    240_000,
+  );
+
+  test(
+    "a value already in the instance's process environment WINS over the shipped file",
+    async () => {
+      // Harper's loadEnv plugin skips (and warns about) any key already present in
+      // process.env unless `override` is declared, and flair's config.yaml declares
+      // only `files`. So a Fabric-level environment setting outranks the payload:
+      // a deploy cannot silently replace configuration the operator set on the
+      // instance itself. That is a claim the docs make, so it is measured here
+      // rather than read off harper's source.
+      const OPERATOR_URL = "https://operator-set.example.com";
+      const componentDir = await deployedComponentDir(PUBLIC_URL);
+      const prev = process.env.FLAIR_PUBLIC_URL;
+      process.env.FLAIR_PUBLIC_URL = OPERATOR_URL;
+      let harper;
+      try {
+        harper = await startHarper({ cwd: componentDir, harperBinDir: REPO_ROOT });
+      } finally {
+        if (prev === undefined) delete process.env.FLAIR_PUBLIC_URL;
+        else process.env.FLAIR_PUBLIC_URL = prev;
+      }
+      instances.push(harper);
+
+      const doc = await fetchOAuthMetadata(harper.httpURL);
+      expect(doc.issuer).toBe(OPERATOR_URL);
+    },
+    240_000,
+  );
+
+  test(
+    "POSITIVE CONTROL: the same tree with no shipped .env advertises loopback",
+    async () => {
+      // resolveDeployPublicUrl returns null for a loopback target, so stageDeployRoot
+      // generates nothing — the pre-flair#1005 payload. If this ALSO advertised the
+      // public URL, the test above would be measuring something other than the file.
+      const componentDir = await deployedComponentDir(resolveDeployPublicUrl("http://127.0.0.1:9925"));
+      expect(existsSync(join(componentDir, ".env"))).toBe(false);
+
+      const harper = await startHarper({ cwd: componentDir, harperBinDir: REPO_ROOT });
+      instances.push(harper);
+
+      const doc = await fetchOAuthMetadata(harper.httpURL);
+      expect(String(doc.issuer)).toContain("127.0.0.1");
+    },
+    240_000,
+  );
+});

--- a/test/integration/init-remote-ops.test.ts
+++ b/test/integration/init-remote-ops.test.ts
@@ -79,9 +79,43 @@ afterAll(() => {
 
 // ── Tests ────────────────────────────────────────────────────────────────────
 
+const PUBLIC_URL = "https://flair.example.com";
+
+/** Entry names inside a base64 tarball, sorted. */
+async function tarballEntries(tarballB64: string): Promise<string[]> {
+  const dir = mkdtempSync(join(tmpdir(), "flair-tarball-"));
+  try {
+    const p = join(dir, "payload.tar.gz");
+    writeFileSync(p, Buffer.from(tarballB64, "base64"));
+    const { list } = await import("tar");
+    const names: string[] = [];
+    await list({ file: p, onReadEntry: (e: any) => names.push(String(e.path).replace(/^\.\//, "")) });
+    return names.filter((n) => n !== "" && n !== ".").sort();
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+/** The `.env` inside a base64 tarball, or null when it carries none. */
+async function tarballEnvText(tarballB64: string): Promise<string | null> {
+  const dir = mkdtempSync(join(tmpdir(), "flair-tarball-"));
+  try {
+    const p = join(dir, "payload.tar.gz");
+    writeFileSync(p, Buffer.from(tarballB64, "base64"));
+    const out = join(dir, "x");
+    mkdirSync(out, { recursive: true });
+    const { extract } = await import("tar");
+    await extract({ file: p, cwd: out });
+    const envPath = join(out, ".env");
+    return existsSync(envPath) ? readFileSync(envPath, "utf8") : null;
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
 describe("buildDeployTarball", () => {
-  test("builds a gzip tarball with .env baked in", async () => {
-    const { tarballB64 } = await buildDeployTarball(tmpDir, TEST_OPTS.flairAdminPass);
+  test("builds a gzip tarball", async () => {
+    const { tarballB64 } = await buildDeployTarball(tmpDir, PUBLIC_URL);
     expect(typeof tarballB64).toBe("string");
     expect(tarballB64.length).toBeGreaterThan(100);
 
@@ -92,21 +126,67 @@ describe("buildDeployTarball", () => {
     expect(buf[1]).toBe(0x8b);
   });
 
+  // ── flair#1005 item 2 ───────────────────────────────────────────────────────
+  // The test above used to be titled "…with .env baked in" and asserted two
+  // gzip magic bytes. It passed for the entire period during which this function
+  // wrote a `.env` into a temp directory and then packed an entries list that did
+  // not contain it — the file was discarded on every call. These assert the
+  // PACKED payload, because that is the only thing a deployed instance ever sees.
+  test("THE DEFECT: .env is actually IN the tarball", async () => {
+    const { tarballB64 } = await buildDeployTarball(tmpDir, PUBLIC_URL);
+    expect(await tarballEntries(tarballB64)).toContain(".env");
+  });
+
+  test("the packed .env carries FLAIR_PUBLIC_URL from the deploy target", async () => {
+    const { tarballB64 } = await buildDeployTarball(tmpDir, PUBLIC_URL);
+    expect(await tarballEnvText(tarballB64)).toBe(`FLAIR_PUBLIC_URL=${PUBLIC_URL}\n`);
+  });
+
+  test("no credential is ever packed (flair#1011)", async () => {
+    // The deploy payload is ingested into Harper's hdb_deployment record and
+    // replicated to every node, so a password in it is persisted cluster-wide —
+    // and `loadEnv` runs after Harper has composed its own configuration, so
+    // HDB_ADMIN_PASSWORD could not configure Harper from there even if that were
+    // acceptable. buildDeployTarball has no password parameter at all now; this
+    // asserts the outcome rather than the signature.
+    const { tarballB64 } = await buildDeployTarball(tmpDir, PUBLIC_URL);
+    const env = (await tarballEnvText(tarballB64)) ?? "";
+    for (const key of ["HDB_ADMIN_PASSWORD", "FLAIR_ADMIN_PASSWORD", "FLAIR_ADMIN_PASS"]) {
+      expect(env).not.toContain(key);
+    }
+  });
+
+  test("packs no .env when there is no public URL to advertise", async () => {
+    const { tarballB64 } = await buildDeployTarball(tmpDir, null);
+    expect(await tarballEntries(tarballB64)).not.toContain(".env");
+  });
+
+  test("keeps an operator's own .env value and does not rewrite their file", async () => {
+    const operatorFile = join(tmpDir, ".env");
+    const original = "# operator\nFLAIR_PUBLIC_URL=https://cdn.example.com\n";
+    writeFileSync(operatorFile, original);
+
+    const { tarballB64 } = await buildDeployTarball(tmpDir, PUBLIC_URL);
+    expect(readFileSync(operatorFile, "utf8")).toBe(original);
+    expect(await tarballEnvText(tarballB64)).toBe(original);
+  });
+
+  test("merges the key into an operator's .env that does not set it", async () => {
+    writeFileSync(join(tmpDir, ".env"), "FLAIR_MCP_OAUTH=1\n");
+    const { tarballB64 } = await buildDeployTarball(tmpDir, PUBLIC_URL);
+    expect(await tarballEnvText(tarballB64)).toBe(`FLAIR_MCP_OAUTH=1\nFLAIR_PUBLIC_URL=${PUBLIC_URL}\n`);
+  });
+
   test("excludes ui/ directory when absent", async () => {
-    const { tarballB64 } = await buildDeployTarball(tmpDir, TEST_OPTS.flairAdminPass);
-    const buf = Buffer.from(tarballB64, "base64");
-    // Should still produce valid gzip without ui/
-    expect(buf[0]).toBe(0x1f);
-    expect(buf[1]).toBe(0x8b);
+    const { tarballB64 } = await buildDeployTarball(tmpDir, PUBLIC_URL);
+    expect(await tarballEntries(tarballB64)).not.toContain("ui");
   });
 
   test("includes ui/ directory when present", async () => {
     mkdirSync(join(tmpDir, "ui"), { recursive: true });
     writeFileSync(join(tmpDir, "ui/index.html"), "<html></html>");
-    const { tarballB64 } = await buildDeployTarball(tmpDir, TEST_OPTS.flairAdminPass);
-    const buf = Buffer.from(tarballB64, "base64");
-    expect(buf[0]).toBe(0x1f);
-    expect(buf[1]).toBe(0x8b);
+    const { tarballB64 } = await buildDeployTarball(tmpDir, PUBLIC_URL);
+    expect(await tarballEntries(tarballB64)).toContain("ui/index.html");
   });
 });
 

--- a/test/unit/component-env.test.ts
+++ b/test/unit/component-env.test.ts
@@ -1,0 +1,248 @@
+// component-env.test.ts — the `.env` a deploy ships to a Flair component
+// (flair#1005 item 2, flair#1000, flair#1011).
+//
+// These are the decisions the deploy makes BEFORE any file or tarball exists:
+// what value to advertise, whether to touch an operator's file at all, and what
+// must never be generated into a payload that Harper persists and replicates.
+// deploy-staging.test.ts covers the file/tarball half — the two halves are split
+// because "a file was written" was never evidence that anything reads it.
+
+import { describe, test, expect } from "bun:test";
+import {
+  COMPONENT_ENV_FILENAME,
+  NEVER_GENERATED_SECRET_KEYS,
+  PUBLIC_URL_KEY,
+  assertNoSecretKeysAdded,
+  describePublicUrlFinding,
+  envKeyNames,
+  isLoopbackUrl,
+  looksLikeSecretKey,
+  planComponentEnv,
+  publicUrlRemedy,
+  readEnvValue,
+} from "../../src/component-env.js";
+
+describe("isLoopbackUrl", () => {
+  test("recognises the addresses only the serving machine can reach", () => {
+    for (const url of [
+      "http://127.0.0.1:9926",
+      "http://127.0.0.1:9980/OAuthAuthorize",
+      "http://127.1.2.3:80",
+      "http://localhost:19926",
+      "https://localhost",
+      "http://sub.localhost:3000",
+      "http://[::1]:9926",
+    ]) {
+      expect({ url, loopback: isLoopbackUrl(url) }).toEqual({ url, loopback: true });
+    }
+  });
+
+  test("does not treat a public host as loopback", () => {
+    for (const url of [
+      "https://flair.example.com",
+      "https://cluster.org.harperfabric.com",
+      "http://10.0.0.4:9926",
+      "https://192.168.1.10",
+    ]) {
+      expect({ url, loopback: isLoopbackUrl(url) }).toEqual({ url, loopback: false });
+    }
+  });
+
+  test("a DNS name that merely STARTS with 127. is not loopback", () => {
+    // The regression guard for the obvious implementation. `startsWith("127.")`
+    // would classify these as loopback and silently refuse to advertise a
+    // perfectly reachable host — and it is exactly the host shape used to prove
+    // this feature end to end against a locally spawned Harper.
+    expect(isLoopbackUrl("http://127.0.0.1.nip.io:9926")).toBe(false);
+    expect(isLoopbackUrl("https://127.0.0.1.example.com")).toBe(false);
+  });
+
+  test("a non-URL is not loopback (and must not throw)", () => {
+    expect(isLoopbackUrl("")).toBe(false);
+    expect(isLoopbackUrl(null)).toBe(false);
+    expect(isLoopbackUrl("not a url")).toBe(false);
+  });
+});
+
+describe("env parsing", () => {
+  test("reports key names in file order, ignoring comments and blanks", () => {
+    const text = "# comment\nFOO=1\n\n  BAR = 2\nexport BAZ=3\nnot an assignment\n";
+    expect(envKeyNames(text)).toEqual(["FOO", "BAR", "BAZ"]);
+  });
+
+  test("reads a value, including the export and quoted forms", () => {
+    expect(readEnvValue("FLAIR_PUBLIC_URL=https://a.example\n", PUBLIC_URL_KEY)).toBe("https://a.example");
+    expect(readEnvValue('export FLAIR_PUBLIC_URL="https://b.example"\n', PUBLIC_URL_KEY)).toBe("https://b.example");
+    expect(readEnvValue("OTHER=x\n", PUBLIC_URL_KEY)).toBeNull();
+    expect(readEnvValue(null, PUBLIC_URL_KEY)).toBeNull();
+  });
+
+  test("looksLikeSecretKey flags credential-shaped NAMES", () => {
+    expect(looksLikeSecretKey("HDB_ADMIN_PASSWORD")).toBe(true);
+    expect(looksLikeSecretKey("FABRIC_TOKEN")).toBe(true);
+    expect(looksLikeSecretKey("SOME_API_KEY")).toBe(true);
+    expect(looksLikeSecretKey("FLAIR_PUBLIC_URL")).toBe(false);
+    expect(looksLikeSecretKey("HTTP_PORT")).toBe(false);
+  });
+});
+
+describe("planComponentEnv", () => {
+  test("adds FLAIR_PUBLIC_URL when the payload has no .env at all", () => {
+    const plan = planComponentEnv(null, "https://flair.example.com");
+    expect(plan.action).toBe("added");
+    expect(plan.effectiveValue).toBe("https://flair.example.com");
+    expect(plan.text).toBe("FLAIR_PUBLIC_URL=https://flair.example.com\n");
+  });
+
+  test("appends to an operator's file without disturbing what is already there", () => {
+    const existing = "# my settings\nFLAIR_MCP_OAUTH=1\nHTTP_PORT=9926\n";
+    const plan = planComponentEnv(existing, "https://flair.example.com");
+    expect(plan.action).toBe("added");
+    expect(plan.text!.startsWith(existing)).toBe(true);
+    expect(envKeyNames(plan.text)).toEqual(["FLAIR_MCP_OAUTH", "HTTP_PORT", PUBLIC_URL_KEY]);
+  });
+
+  test("does not weld two assignments together when the file has no trailing newline", () => {
+    const plan = planComponentEnv("FLAIR_MCP_OAUTH=1", "https://flair.example.com");
+    expect(plan.text).toBe("FLAIR_MCP_OAUTH=1\nFLAIR_PUBLIC_URL=https://flair.example.com\n");
+  });
+
+  test("NEVER overwrites a value the operator set — that is the no-clobber rule", () => {
+    const existing = "FLAIR_PUBLIC_URL=https://cdn.example.com\n";
+    const plan = planComponentEnv(existing, "https://cluster.org.harperfabric.com");
+    expect(plan.action).toBe("operator-value-kept");
+    expect(plan.text).toBeNull(); // nothing is written, so nothing is staged
+    expect(plan.effectiveValue).toBe("https://cdn.example.com");
+    expect(plan.notices.join(" ")).toContain("https://cdn.example.com");
+    expect(plan.notices.join(" ")).toContain("keeping it");
+  });
+
+  test("an operator's `export`-prefixed assignment counts as set", () => {
+    // Otherwise the merge appends a SECOND assignment for the same key, and which
+    // one wins is left to the env loader — a clobber by another route.
+    const plan = planComponentEnv("export FLAIR_PUBLIC_URL=https://cdn.example.com\n", "https://x.example");
+    expect(plan.action).toBe("operator-value-kept");
+  });
+
+  test("says so out loud when the operator's own value is a loopback address", () => {
+    const plan = planComponentEnv("FLAIR_PUBLIC_URL=http://127.0.0.1:9926\n", "https://flair.example.com");
+    expect(plan.action).toBe("operator-value-kept");
+    expect(plan.notices.join(" ")).toContain("loopback");
+  });
+
+  test("supplies nothing when there is no public URL to advertise", () => {
+    const plan = planComponentEnv(null, null);
+    expect(plan.action).toBe("unchanged");
+    expect(plan.text).toBeNull();
+    expect(plan.effectiveValue).toBeNull();
+  });
+
+  test("names the credential-shaped KEYS an operator's file will carry into the payload", () => {
+    const plan = planComponentEnv("HDB_ADMIN_PASSWORD=whatever\n", "https://flair.example.com");
+    const notice = plan.notices.join(" ");
+    expect(notice).toContain("HDB_ADMIN_PASSWORD");
+    expect(notice).toContain("replicated");
+    // The NAME is reported; the value is not read, compared, or echoed.
+    expect(notice).not.toContain("whatever");
+  });
+
+  test("generates FLAIR_PUBLIC_URL and nothing else", () => {
+    const plan = planComponentEnv(null, "https://flair.example.com");
+    expect(envKeyNames(plan.text)).toEqual([PUBLIC_URL_KEY]);
+    for (const key of NEVER_GENERATED_SECRET_KEYS) {
+      expect(plan.text).not.toContain(key);
+    }
+  });
+});
+
+describe("assertNoSecretKeysAdded", () => {
+  test("accepts the file flair actually generates", () => {
+    expect(() => assertNoSecretKeysAdded(null, "FLAIR_PUBLIC_URL=https://a.example\n")).not.toThrow();
+  });
+
+  test("throws when a generator introduces a credential (flair#1011)", () => {
+    // The positive control for the test above: the guard is capable of failing.
+    expect(() =>
+      assertNoSecretKeysAdded(null, "FLAIR_PUBLIC_URL=https://a.example\nHDB_ADMIN_PASSWORD=x\n"),
+    ).toThrow(/HDB_ADMIN_PASSWORD/);
+    expect(() => assertNoSecretKeysAdded(null, "FLAIR_ADMIN_PASSWORD=x\n")).toThrow(/FLAIR_ADMIN_PASSWORD/);
+  });
+
+  test("does not punish an operator for their OWN pre-existing key", () => {
+    // A `.env` in the deploy root already ships today. Refusing to deploy one
+    // that was working would be a regression; the notice covers it instead.
+    const existing = "HDB_ADMIN_PASSWORD=x\n";
+    expect(() =>
+      assertNoSecretKeysAdded(existing, `${existing}FLAIR_PUBLIC_URL=https://a.example\n`),
+    ).not.toThrow();
+  });
+});
+
+describe("publicUrlRemedy", () => {
+  test("names the file, the key and the loadEnv requirement", () => {
+    const remedy = publicUrlRemedy("/opt/flair/.env");
+    expect(remedy).toContain("/opt/flair/.env");
+    expect(remedy).toContain(PUBLIC_URL_KEY);
+    expect(remedy).toContain("loadEnv");
+    expect(remedy).toContain(COMPONENT_ENV_FILENAME);
+  });
+});
+
+describe("describePublicUrlFinding (flair doctor)", () => {
+  const ENV_PATH = "/opt/flair/.env";
+  const base = { componentEnvValue: null, processEnvValue: null, componentEnvPath: ENV_PATH };
+
+  test("says nothing when the instance could not be asked — a skipped check is not a pass", () => {
+    expect(describePublicUrlFinding({ ...base, advertisedIssuer: null })).toBeNull();
+  });
+
+  test("clean when discovery already advertises a reachable issuer", () => {
+    const f = describePublicUrlFinding({ ...base, advertisedIssuer: "https://flair.example.com" })!;
+    expect(f.isIssue).toBe(false);
+    expect(f.icon).toBe("ok");
+    expect(f.message).toContain("https://flair.example.com");
+  });
+
+  test("ISSUE: the component .env sets the key and the instance still advertises loopback", () => {
+    // This is flair#1000's exact shape — the file was placed, the issuer never
+    // moved, because no loadEnv declaration existed to read it.
+    const f = describePublicUrlFinding({
+      ...base,
+      advertisedIssuer: "http://127.0.0.1:9980",
+      componentEnvValue: "https://flair.example.com",
+    })!;
+    expect(f.isIssue).toBe(true);
+    expect(f.icon).toBe("error");
+    expect(f.message).toContain(ENV_PATH);
+    expect(f.fixHint).toContain("loadEnv");
+  });
+
+  test("ISSUE: the value is in the operator's shell, not where the server reads it", () => {
+    const f = describePublicUrlFinding({
+      ...base,
+      advertisedIssuer: "http://127.0.0.1:9980",
+      processEnvValue: "https://flair.example.com",
+    })!;
+    expect(f.isIssue).toBe(true);
+    expect(f.fixHint).toContain(ENV_PATH);
+    expect(f.fixHint).toContain("https://flair.example.com");
+  });
+
+  test("unset everywhere is INFORMATION, not a finding — a check that always fires is noise", () => {
+    const f = describePublicUrlFinding({ ...base, advertisedIssuer: "http://127.0.0.1:19926" })!;
+    expect(f.isIssue).toBe(false);
+    expect(f.icon).toBe("warn");
+    expect(f.fixHint).toContain(PUBLIC_URL_KEY);
+    expect(f.fixHint).toContain("loadEnv");
+  });
+
+  test("a loopback value in the component .env is not mistaken for a working one", () => {
+    const f = describePublicUrlFinding({
+      ...base,
+      advertisedIssuer: "http://127.0.0.1:19926",
+      componentEnvValue: "http://127.0.0.1:19926",
+    })!;
+    expect(f.isIssue).toBe(false);
+    expect(f.icon).toBe("warn");
+  });
+});

--- a/test/unit/deploy-staging.test.ts
+++ b/test/unit/deploy-staging.test.ts
@@ -1,0 +1,339 @@
+// deploy-staging.test.ts — does the `.env` actually reach the deployed payload?
+// (flair#1005 item 2)
+//
+// The defect this pins is not "the writer did not run". It is that a writer ran
+// and its output went nowhere: `buildDeployTarball` wrote a `.env` into a temp
+// directory and then packed an explicit entries list that never contained it, so
+// the file was discarded with the directory on every single call since it was
+// written. Asserting "the file exists on disk" would have passed throughout.
+//
+// So every assertion here is made against a PACKED payload, produced by the same
+// packer that runs in production:
+//
+//   - `flair deploy` shells out to `harper deploy`, which packs its own CWD via
+//     harper/dist/components/packageComponent.js. That module is imported here
+//     directly, so the entry list under test is the entry list harper would send.
+//   - `flair init --remote` builds its own tarball via `tar` — covered in
+//     test/integration/init-remote-ops.test.ts against a real tarball.
+//
+// The other half of the proof — that a packed `.env` reaches `process.env` and
+// changes what the instance advertises — is test/integration/deploy-public-url.test.ts,
+// against a real spawned Harper. Neither half is sufficient alone.
+
+import { describe, test, expect, afterEach } from "bun:test";
+import { createRequire } from "node:module";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, statSync, symlinkSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { COMPONENT_ENV_FILENAME, PUBLIC_URL_KEY, envKeyNames, readEnvValue } from "../../src/component-env.js";
+import { OAUTH_METADATA_PATH, resolveDeployPublicUrl, stageDeployRoot, verifyPublicIssuer } from "../../src/deploy.js";
+
+const require_ = createRequire(import.meta.url);
+
+// harper's real packer — the code that decides what a `harper deploy` uploads.
+// Addressed by PATH, not by package specifier: harper's `exports` map does not
+// expose its internals, and the same direct-path convention is what
+// test/helpers/harper-lifecycle.ts uses to reach `dist/bin/harper.js`.
+const REPO_ROOT = join(import.meta.dir, "..", "..");
+function harperPackagerPath(): string {
+  for (const pkg of ["harper", join("@harperfast", "harper")]) {
+    const p = join(REPO_ROOT, "node_modules", pkg, "dist", "components", "packageComponent.js");
+    if (existsSync(p)) return p;
+  }
+  throw new Error("harper's packageComponent.js not found under node_modules — cannot test what a deploy uploads");
+}
+const { packageDirectory } = require_(harperPackagerPath()) as {
+  packageDirectory: (dir: string, opts: { skip_node_modules: boolean; skip_symlinks: boolean }) => Promise<string>;
+};
+
+// The options harper's CLI applies to a `deploy` (cliOperations.js: skip_node_modules
+// defaults on, skip_symlinks defaults off).
+const HARPER_DEPLOY_PACK_OPTS = { skip_node_modules: true, skip_symlinks: false };
+
+const cleanups: Array<() => void> = [];
+afterEach(() => {
+  while (cleanups.length) cleanups.pop()!();
+});
+
+function tempDir(): string {
+  const dir = mkdtempSync(join(tmpdir(), "flair-stagetest-"));
+  cleanups.push(() => rmSync(dir, { recursive: true, force: true }));
+  return dir;
+}
+
+/** A package root shaped like the published flair package. */
+function makePackageRoot(): string {
+  const root = tempDir();
+  mkdirSync(join(root, "dist", "resources"), { recursive: true });
+  mkdirSync(join(root, "schemas"), { recursive: true });
+  mkdirSync(join(root, "node_modules", "harper"), { recursive: true });
+  writeFileSync(join(root, "package.json"), JSON.stringify({ name: "@tpsdev-ai/flair", version: "0.0.0-test" }));
+  writeFileSync(join(root, "config.yaml"), "name: flair\nloadEnv:\n  files: '.env'\n");
+  writeFileSync(join(root, "dist", "resources", "Memory.js"), "// resource\n");
+  writeFileSync(join(root, "schemas", "schema.graphql"), "type Q { a: String }\n");
+  writeFileSync(join(root, "node_modules", "harper", "big.bin"), "x".repeat(1024));
+  return root;
+}
+
+/** Entry names harper would upload for `dir`, sorted. */
+async function packedEntries(dir: string): Promise<string[]> {
+  const b64 = await packageDirectory(dir, HARPER_DEPLOY_PACK_OPTS);
+  const tarPath = join(tempDir(), "payload.tar.gz");
+  writeFileSync(tarPath, Buffer.from(b64, "base64"));
+  const { list } = await import("tar");
+  const names: string[] = [];
+  await list({ file: tarPath, onReadEntry: (e: any) => names.push(String(e.path).replace(/^\.\//, "")) });
+  return names.filter((n) => n !== "." && n !== "").sort();
+}
+
+/** The `.env` content of a packed payload, or null when the payload has none. */
+async function packedEnvText(dir: string): Promise<string | null> {
+  const b64 = await packageDirectory(dir, HARPER_DEPLOY_PACK_OPTS);
+  const out = tempDir();
+  const tarPath = join(out, "payload.tar.gz");
+  writeFileSync(tarPath, Buffer.from(b64, "base64"));
+  const { extract } = await import("tar");
+  const dest = join(out, "x");
+  mkdirSync(dest, { recursive: true });
+  await extract({ file: tarPath, cwd: dest });
+  const p = join(dest, COMPONENT_ENV_FILENAME);
+  return existsSync(p) ? readFileSync(p, "utf8") : null;
+}
+
+describe("resolveDeployPublicUrl", () => {
+  test("a Fabric target is the value to advertise", () => {
+    expect(resolveDeployPublicUrl("https://cluster.org.harperfabric.com")).toBe("https://cluster.org.harperfabric.com");
+    expect(resolveDeployPublicUrl("https://flair.example.com/")).toBe("https://flair.example.com");
+  });
+
+  test("a loopback target supplies nothing", () => {
+    expect(resolveDeployPublicUrl("http://127.0.0.1:9925")).toBeNull();
+    expect(resolveDeployPublicUrl("http://localhost:9925")).toBeNull();
+  });
+
+  test("a value that is not an http(s) URL supplies nothing", () => {
+    expect(resolveDeployPublicUrl("not a url")).toBeNull();
+    expect(resolveDeployPublicUrl("ftp://example.com")).toBeNull();
+    expect(resolveDeployPublicUrl("")).toBeNull();
+  });
+});
+
+describe("stageDeployRoot — what harper actually uploads", () => {
+  test("THE DEFECT: .env is in the packed payload", async () => {
+    // Fails on any implementation where the file is written but not packed.
+    const root = makePackageRoot();
+    const staged = stageDeployRoot(root, "https://flair.example.com");
+    cleanups.push(staged.cleanup);
+
+    const entries = await packedEntries(staged.dir);
+    expect(entries).toContain(COMPONENT_ENV_FILENAME);
+  });
+
+  test("the packed .env carries FLAIR_PUBLIC_URL and nothing else", async () => {
+    const root = makePackageRoot();
+    const staged = stageDeployRoot(root, "https://flair.example.com");
+    cleanups.push(staged.cleanup);
+
+    const text = await packedEnvText(staged.dir);
+    expect(text).not.toBeNull();
+    expect(envKeyNames(text)).toEqual([PUBLIC_URL_KEY]);
+    expect(readEnvValue(text, PUBLIC_URL_KEY)).toBe("https://flair.example.com");
+  });
+
+  test("the payload is otherwise byte-for-byte the same set of entries", async () => {
+    // The staged copy must not quietly drop or add anything else. Compared against
+    // harper packing the ORIGINAL root, so a mistake in the copy filter shows up
+    // here rather than as a component that is missing a file in production.
+    const root = makePackageRoot();
+    const staged = stageDeployRoot(root, "https://flair.example.com");
+    cleanups.push(staged.cleanup);
+
+    const before = await packedEntries(root);
+    const after = await packedEntries(staged.dir);
+    expect(after).toEqual([...before, COMPONENT_ENV_FILENAME].sort());
+    // node_modules is excluded by harper itself, so it is absent from both.
+    expect(before.some((e) => e.startsWith("node_modules"))).toBe(false);
+    expect(after.some((e) => e.startsWith("node_modules"))).toBe(false);
+  });
+
+  test("symlinked content survives the staging copy", async () => {
+    // harper packs with dereference on, so a symlinked directory contributes its
+    // CONTENT to the payload. If staging turned that into a broken link the
+    // deployed component would be missing files.
+    const root = makePackageRoot();
+    const external = tempDir();
+    mkdirSync(join(external, "inner"), { recursive: true });
+    writeFileSync(join(external, "inner", "linked.txt"), "linked\n");
+    symlinkSync(join(external, "inner"), join(root, "templates"));
+
+    const staged = stageDeployRoot(root, "https://flair.example.com");
+    cleanups.push(staged.cleanup);
+
+    const after = await packedEntries(staged.dir);
+    expect(after).toContain("templates/linked.txt");
+  });
+
+  test("does not write into the operator's package root", () => {
+    const root = makePackageRoot();
+    const staged = stageDeployRoot(root, "https://flair.example.com");
+    cleanups.push(staged.cleanup);
+
+    expect(staged.dir).not.toBe(root);
+    expect(existsSync(join(root, COMPONENT_ENV_FILENAME))).toBe(false);
+  });
+
+  test("an operator's existing .env is merged, and their file on disk is untouched", async () => {
+    const root = makePackageRoot();
+    const operatorFile = join(root, COMPONENT_ENV_FILENAME);
+    const original = "# operator settings\nFLAIR_MCP_OAUTH=1\n";
+    writeFileSync(operatorFile, original);
+
+    const staged = stageDeployRoot(root, "https://flair.example.com");
+    cleanups.push(staged.cleanup);
+
+    expect(readFileSync(operatorFile, "utf8")).toBe(original);
+    const packed = await packedEnvText(staged.dir);
+    expect(envKeyNames(packed)).toEqual(["FLAIR_MCP_OAUTH", PUBLIC_URL_KEY]);
+  });
+
+  test("an operator's own FLAIR_PUBLIC_URL is deployed unchanged, with nothing staged", async () => {
+    const root = makePackageRoot();
+    writeFileSync(join(root, COMPONENT_ENV_FILENAME), "FLAIR_PUBLIC_URL=https://cdn.example.com\n");
+
+    const staged = stageDeployRoot(root, "https://cluster.org.harperfabric.com");
+    cleanups.push(staged.cleanup);
+
+    expect(staged.dir).toBe(root); // nothing copied at all
+    expect(staged.plan.action).toBe("operator-value-kept");
+    expect(readEnvValue(await packedEnvText(root), PUBLIC_URL_KEY)).toBe("https://cdn.example.com");
+  });
+
+  test("a loopback target stages nothing and ships no generated .env", async () => {
+    const root = makePackageRoot();
+    const staged = stageDeployRoot(root, resolveDeployPublicUrl("http://127.0.0.1:9925"));
+    cleanups.push(staged.cleanup);
+
+    expect(staged.dir).toBe(root);
+    expect(staged.plan.action).toBe("unchanged");
+    expect(await packedEnvText(root)).toBeNull();
+  });
+
+  test("the staged .env is written 0600", () => {
+    const root = makePackageRoot();
+    const staged = stageDeployRoot(root, "https://flair.example.com");
+    cleanups.push(staged.cleanup);
+    const mode = statSync(join(staged.dir, COMPONENT_ENV_FILENAME)).mode & 0o777;
+    expect(mode).toBe(0o600);
+  });
+
+  test("cleanup removes the staged copy", () => {
+    const root = makePackageRoot();
+    const staged = stageDeployRoot(root, "https://flair.example.com");
+    const dir = staged.dir;
+    expect(existsSync(dir)).toBe(true);
+    staged.cleanup();
+    expect(existsSync(dir)).toBe(false);
+  });
+});
+
+// ─── The post-deploy check that the value actually took effect ───────────────
+//
+// This one can FAIL a deploy, so its branches are pinned individually. The
+// distinction that matters is the last two tests: a document that cannot be read
+// must not be reported as a pass, and must not fail the deploy either — it is a
+// check that did not run, and it says so.
+
+describe("verifyPublicIssuer", () => {
+  const BASE = "https://flair.example.com";
+
+  function fakeFetch(handler: (url: string) => Response | Promise<Response>): typeof fetch {
+    return (async (input: any) => handler(String(input))) as unknown as typeof fetch;
+  }
+  const json = (body: unknown, status = 200) =>
+    new Response(JSON.stringify(body), { status, headers: { "content-type": "application/json" } });
+
+  test("passes when the advertised issuer is on the public host", async () => {
+    let asked = "";
+    const result = await verifyPublicIssuer({
+      baseUrl: BASE,
+      fetchImpl: fakeFetch((url) => { asked = url; return json({ issuer: BASE }); }),
+    });
+    expect(asked).toBe(`${BASE}${OAUTH_METADATA_PATH}`);
+    expect(result).toEqual({ checked: true, issuer: BASE, detail: `issuer ${BASE}` });
+  });
+
+  test("THROWS on a loopback issuer — the flair#1000 symptom, at deploy time", async () => {
+    const opts = {
+      baseUrl: BASE,
+      timeoutMs: 0, // no rolling restart to wait out in a unit test
+      fetchImpl: fakeFetch(() => json({ issuer: "http://127.0.0.1:9980" })),
+    };
+    await expect(verifyPublicIssuer(opts)).rejects.toThrow(/127\.0\.0\.1/);
+    // The error has to enable a response: the key, the file, and loadEnv.
+    await expect(verifyPublicIssuer(opts)).rejects.toThrow(/FLAIR_PUBLIC_URL/);
+    await expect(verifyPublicIssuer(opts)).rejects.toThrow(/loadEnv/);
+  });
+
+  test("waits out a rolling restart rather than failing a good deploy", async () => {
+    // On a multi-node cluster the request can be answered by a node that has not
+    // restarted yet, so the first read can legitimately still be the OLD value.
+    // Reading once would fail a deploy that was fine.
+    let call = 0;
+    const result = await verifyPublicIssuer({
+      baseUrl: BASE,
+      timeoutMs: 5_000,
+      pollIntervalMs: 1,
+      fetchImpl: fakeFetch(() => {
+        call++;
+        return json({ issuer: call < 3 ? "http://127.0.0.1:9980" : BASE });
+      }),
+    });
+    expect(result).toEqual({ checked: true, issuer: BASE, detail: `issuer ${BASE}` });
+    expect(call).toBe(3);
+  });
+
+  test("still fails when the issuer never stops being loopback", async () => {
+    // The positive control for the test above: waiting must not become "never fails".
+    let call = 0;
+    await expect(
+      verifyPublicIssuer({
+        baseUrl: BASE,
+        timeoutMs: 30,
+        pollIntervalMs: 1,
+        fetchImpl: fakeFetch(() => { call++; return json({ issuer: "http://127.0.0.1:9980" }); }),
+      }),
+    ).rejects.toThrow(/127\.0\.0\.1/);
+    expect(call).toBeGreaterThan(1);
+  });
+
+  test("a 404 is 'did not run', not a pass and not a failure", async () => {
+    const result = await verifyPublicIssuer({
+      baseUrl: BASE,
+      timeoutMs: 0,
+      fetchImpl: fakeFetch(() => new Response("nope", { status: 404 })),
+    });
+    expect(result.checked).toBe(false);
+    expect(result.issuer).toBeNull();
+    expect(result.detail).toContain("404");
+  });
+
+  test("a document with no issuer is 'did not run'", async () => {
+    const result = await verifyPublicIssuer({
+      baseUrl: BASE,
+      timeoutMs: 0,
+      fetchImpl: fakeFetch(() => json({ token_endpoint: `${BASE}/OAuthToken` })),
+    });
+    expect(result.checked).toBe(false);
+    expect(result.detail).toContain("no issuer");
+  });
+
+  test("an unreachable endpoint is 'did not run'", async () => {
+    const result = await verifyPublicIssuer({
+      baseUrl: BASE,
+      timeoutMs: 0,
+      fetchImpl: fakeFetch(() => { throw new Error("connect ECONNREFUSED"); }),
+    });
+    expect(result.checked).toBe(false);
+    expect(result.detail).toContain("ECONNREFUSED");
+  });
+});


### PR DESCRIPTION
A publicly-reachable instance served an OAuth discovery document whose issuer and every
endpoint were `http://127.0.0.1:9980`, so remote clients followed discovery to their own
loopback and no authorization flow could complete (#1000). The cause was `FLAIR_PUBLIC_URL`
being unset, and the only thing holding it right on a live instance was a hand-placed file
that any redeploy would destroy.

`Refs #1005` — this is item 2 (and the doctor half of item 4). Item 3 of #1000 and the
`.well-known` paths are untouched.

## What I found that the issue got wrong

**There are two deploy paths, not one, and the issue's description matched the other one.**

- `flair deploy` (`src/deploy.ts`) shells out to `harper deploy`, which packs its own CWD.
  There is no entries list here at all — harper includes every file under the deploy root
  except `node_modules`. I confirmed that by running harper's own packer over a directory
  containing a `.env`: the file is packed. So `flair deploy` did not need an entries fix; it
  needed a `.env` to exist in the root it packs.
- `flair init --remote` (`buildDeployTarball`) is the one with the entries list, and the
  issue's diagnosis of it is exactly right: it wrote a `.env` at mode 600 into a temp
  directory and then packed a list that never contained it. Dead code since April.

Both are fixed, because both deploy a component that needs the value.

**A deploy destroys the component directory regardless.** Harper's `extractApplication`
renames the existing component directory aside and creates a fresh one before extracting. So
a hand-placed `.env` on a deployed instance does not survive *any* deploy, with or without
this change. That reframes "don't clobber the operator's file": the only file this can
preserve is the one in the local deploy root, and the remote one was never survivable.

## What changed

- **`src/component-env.ts`** (new) — the decisions, as pure functions: what to advertise,
  whether to touch an operator's file, what must never be generated, and what `doctor` should
  say. Unit-tested without a filesystem.
- **`flair deploy`** stages the deploy root to a temp copy, writes the merged `.env` there,
  and points harper at the copy. The operator's tree is read and never written — which also
  makes this work when the package root is a read-only global install.
- **`flair deploy` verifies its own writer.** After the existing served-API check it reads
  `GET <target>/OAuthMetadata` and **fails the deploy** if the advertised issuer is loopback.
  Same contract as the existing "the tool must not be able to lie" check: a deploy that
  leaves an instance no client can authorize against is not a success. It polls for up to 60s
  rather than reading once — a Fabric restart is rolling, so a request can be answered by a
  node that has not restarted yet, and reading once would turn that race into a failed deploy
  for a change that was fine. An unreadable document is reported as a check that **did not
  run**, with the reason — never as a pass, and never as a failure.
- **`flair init --remote`** packs `.env`, and its admin-password parameter is **removed**.
- **`flair doctor`** asks the running instance for its own discovery document and reports on
  the issuer, with a remedy naming the file, the key and the `loadEnv` requirement.

## Decisions you asked me to make and defend

**`HDB_ADMIN_PASSWORD` is gone — and so is `FLAIR_ADMIN_PASSWORD`.** #1011's argument holds:
`loadEnv` runs after Harper has composed its own configuration, so Harper cannot honour a
component `.env`. There is a second, independent reason that also rules out flair's own name:
harper's `deployComponent` ingests the whole payload into an `hdb_deployment` row's
`payload_blob`, and harper's own comment says that row "doubles as the source for peer
replication and (later) rollback". **Anything in a deploy payload is persisted on every node
for the life of the deployment record.** A public URL is fine there; a password is not,
whatever name it goes by. So the generated file carries exactly one key.

`buildDeployTarball`'s password parameter is removed rather than validated — a caller cannot
pass a credential to a function with nowhere to put one. `assertNoSecretKeysAdded` is a
runtime guard on the diff (not on the output), so an operator's own pre-existing key is not
punished while a future generator that adds one throws. It has a positive control in the
tests.

**Clobbering: merge, and the operator's value always wins.** A `.env` in the deploy root
already ships today, so an operator can be relying on one and refusing would break a working
deploy. flair appends `FLAIR_PUBLIC_URL` only when the key is absent; when it is present the
file is passed through untouched and nothing is staged at all. The operator's value wins
rather than the deploy target because an instance is routinely fronted by a hostname that is
*not* the URL the deploy is addressed to — a CDN, a proxy, a vanity domain — and that
hostname is exactly what clients must be told. Overwriting it would break the deployment the
value exists to fix. The disagreement is printed, so the choice is visible rather than silent,
and an `export`-prefixed assignment counts as set (otherwise the merge appends a second
assignment for the same key, which is a clobber by another route).

There is a third layer of no-clobber that came out of reading harper's `loadEnv`: it skips any
key already present in `process.env` (logging an "Environment variable conflict" warning)
unless `override` is declared, and flair declares only `files`. So a value set through the
instance's own environment outranks the shipped file and a deploy cannot replace it. That is
now a documented claim, so there is a test that measures it against a real Harper rather than
asserting it from harper's source.

**Refusing the deploy when the target is public and the value cannot be determined: not
implemented, deliberately.** `buildTargetUrl` always yields a URL — either `--target` or the
Fabric template — so on a public target the value can always be determined. A refusal branch
there could never fire, and an unrunnable check that reads as a passing one is the failure
mode this issue is about. The reachable version of "refuse" is the post-deploy issuer check,
which fails on the condition that actually matters: the value was supplied and *did not take
effect*. A `--target` that is not an absolute http(s) URL supplies nothing rather than baking
a malformed base into every advertised endpoint.

## How this was verified — read this part

**Verified end to end locally, against a real spawned Harper. NOT against a real Fabric
cluster** — that target is live and I did not deploy to it.

`test/integration/deploy-public-url.test.ts` runs production code at every step:
`stageDeployRoot()` → harper's own packer → tar extract (what Harper does server-side) → a
real spawned Harper booting that directory as its component → `GET /OAuthMetadata` over HTTP.

    issuer:  https://flair-1005.example.com
    every *_endpoint on that host
    the whole document contains no "127.0.0.1"

Its second test is the positive control: the identical tree built for a target that supplies
no public URL advertises loopback. Without that, a green first test would only prove the
endpoint returned a string.

Not covered locally: the HTTPS upload to a Fabric cluster and harper's server-side
`npm install`. Nothing about either is specific to this change.

**Mutation checks** (each break restored and re-verified green):

1. Made `stageDeployRoot` write the `.env` into a different temp directory than the one it
   returns — i.e. the original defect. 5 of 18 unit tests fail, including "THE DEFECT: .env is
   in the packed payload", **and the end-to-end test fails** while its positive control still
   passes.
2. Removed `.env` from `buildDeployTarball`'s entries list. 4 tests fail, including "THE
   DEFECT: .env is actually IN the tarball".
3. Removed the `loadEnv` declaration from `config.yaml`. The end-to-end test fails — the whole
   chain is load-bearing in the test, not just the file write.

The test this replaces was titled "builds a gzip tarball with .env baked in" and asserted two
gzip magic bytes. It passed for the entire period during which the `.env` was discarded.

**Full suite**, measured the same way on both sides (fresh worktree, `bun install`,
`npm run build && npm run build:cli`, `packages/flair-client` built, then `bun test`):

| | tests | files | pass | fail | errors |
|---|---|---|---|---|---|
| unmodified `main` | 4632 | 283 | 4622 | 10 | 4 |
| this branch | 4687 | 286 | 4677 | 10 | 4 |

+55 tests, +3 files, and the failure and error counts are **identical** — the same six named
failures in both runs, all real-Harper integration lanes that are already red on `main` on this
machine.

Docs freshness: 7/7 checks **ran** and passed, with the CLI built first. `tsconfig.json`
reports the one pre-existing error in `resources/auth-middleware.ts`; that file is
byte-identical to `main`.

## Scope limit worth stating

`flair doctor` diagnoses the instance on the machine it runs on, over loopback. It cannot
observe whether that instance is *also* reachable at a public address, so "unset, and the
instance is public" is not a state it can detect — an unconditional finding there would fire
on every laptop install, and a check that always fires is noise rather than a gate. What it
detects instead is **drift**, with no false positives: the value exists somewhere and the
instance is still advertising loopback anyway. That is #1000's exact shape. The
unset-everywhere case is reported as information with the full remedy. Both branches were
exercised against a real spawned Harper.

Refs #1005
Refs #1000
Refs #1011
