### PR TITLE
feat(oauth): serve RFC 8414 + RFC 9728 discovery at the well-known paths

### DIFF
--- a/.changelog/unreleased/added-oauth-well-known-discovery.md
+++ b/.changelog/unreleased/added-oauth-well-known-discovery.md
@@ -1,0 +1,22 @@
+- **OAuth discovery is now served at the two well-known paths clients actually
+  probe.** `GET /.well-known/oauth-authorization-server` (RFC 8414) and
+  `GET /.well-known/oauth-protected-resource` (RFC 9728, which the MCP
+  authorization specification makes a MUST) both answer, unauthenticated, over
+  CORS. Flair published a correct document only at `/OAuthMetadata` — a path
+  nothing in the ecosystem asks for — and 404'd at both standard paths, so a
+  spec-compliant remote MCP client could not discover an instance at all.
+
+  The protected-resource document is also served at the RFC 9728 §3.1
+  path-appended URL `/.well-known/oauth-protected-resource/mcp`, which is the
+  form real MCP clients construct and the form the `/mcp` surface's own 401
+  challenge points at.
+
+  `/OAuthMetadata` is unchanged for existing callers and is now an **alias**:
+  both paths return the same document from the same builder, so they cannot
+  drift apart. Nothing about issuer derivation changed — set `FLAIR_PUBLIC_URL`
+  on any non-loopback deployment or every advertised URL still points at the
+  client's own localhost.
+
+  No authentication behaviour changed. Basic and Ed25519 callers, and the
+  response an uncredentialed request gets, are exactly as before; `/mcp` remains
+  behind `FLAIR_MCP_OAUTH`, still off by default.

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -96,7 +96,23 @@ Standard OAuth 2.1 authorization code flow:
 | `/OAuthRegister` | POST | Dynamic client registration |
 | `/OAuthAuthorize` | GET/POST | Authorization endpoint |
 | `/OAuthToken` | POST | Token endpoint |
-| `/.well-known/oauth-authorization-server` | GET | Server metadata |
+| `/.well-known/oauth-authorization-server` | GET | Authorization server metadata (RFC 8414) |
+| `/.well-known/oauth-protected-resource` | GET | Protected resource metadata (RFC 9728) |
+| `/OAuthMetadata` | GET | Alias of `/.well-known/oauth-authorization-server` |
+
+Both well-known documents are public — RFC 8414 §3 and RFC 9728 §3 require them
+to be retrievable without authentication — and are served with
+`Access-Control-Allow-Origin: *` so browser-based MCP clients can read them.
+
+The protected-resource document is also served at the RFC 9728 §3.1
+path-appended URL `/.well-known/oauth-protected-resource/mcp`, which is the form
+MCP clients construct from the resource identifier.
+
+Every URL in every one of these documents derives from `FLAIR_PUBLIC_URL`,
+falling back to the loopback bind address. **Set `FLAIR_PUBLIC_URL` on any
+deployment reachable at something other than localhost** — otherwise the
+documents are well-formed and every URL in them points at the *client's* own
+localhost. See [deploying-on-fabric.md](deploying-on-fabric.md).
 
 ## XAA (Enterprise-Managed Authorization)
 

--- a/resources/OAuth.ts
+++ b/resources/OAuth.ts
@@ -2,12 +2,13 @@ import { Resource, databases } from "harper";
 import { createHash, randomBytes } from "node:crypto";
 import { handleJwtBearerGrant } from "./XAA.js";
 import { resolveAgentAuth } from "./agent-auth.js";
+import { buildAuthorizationServerMetadata } from "./oauth-discovery.js";
 
 /**
  * OAuth 2.1 Authorization Server for Flair.
  *
  * Endpoints (all mapped via Harper's resource routing):
- *   GET  /OAuthMetadata           → /.well-known/oauth-authorization-server
+ *   GET  /OAuthMetadata           → alias of /.well-known/oauth-authorization-server
  *   POST /OAuthRegister           → /oauth/register (DCR)
  *   GET  /OAuthAuthorize          → /oauth/authorize (consent screen)
  *   POST /OAuthToken              → /oauth/token (token exchange)
@@ -66,6 +67,19 @@ function redirectTo(url: string, status: 302 | 303 = 302): Response {
 
 // ─── Discovery metadata ──────────────────────────────────────────────────────
 
+/**
+ * `/OAuthMetadata` — an ALIAS of `/.well-known/oauth-authorization-server`
+ * (flair#1000), not a second implementation.
+ *
+ * The document body moved verbatim to `buildAuthorizationServerMetadata()` in
+ * resources/oauth-discovery.ts and BOTH paths now call it. The well-known path
+ * is the one RFC 8414 defines and the one every client probes; this path is
+ * kept because it is what shipped, is referenced by docs/auth.md and by
+ * deployed callers, and costs one delegating line. Keeping it as an alias
+ * rather than as an independent handler is the whole point: two endpoints that
+ * can drift apart is the failure mode, and after this change there is no code
+ * path that can produce one document without producing the other.
+ */
 export class OAuthMetadata extends Resource {
   // OAuth discovery metadata is intentionally public — RFC 8414 § 3 requires
   // it be accessible without authentication so clients can bootstrap their
@@ -75,30 +89,7 @@ export class OAuthMetadata extends Resource {
   allowRead() { return true; }
 
   async get() {
-    const baseUrl = process.env.FLAIR_PUBLIC_URL || `http://127.0.0.1:${process.env.HTTP_PORT || 19926}`;
-    return {
-      issuer: baseUrl,
-      authorization_endpoint: `${baseUrl}/OAuthAuthorize`,
-      token_endpoint: `${baseUrl}/OAuthToken`,
-      registration_endpoint: `${baseUrl}/OAuthRegister`,
-      revocation_endpoint: `${baseUrl}/OAuthRevoke`,
-      response_types_supported: ["code"],
-      grant_types_supported: [
-        "authorization_code",
-        "refresh_token",
-        "urn:ietf:params:oauth:grant-type:jwt-bearer",
-      ],
-      token_endpoint_auth_methods_supported: ["none", "client_secret_basic"],
-      code_challenge_methods_supported: ["S256"],
-      scopes_supported: [
-        "memory:read", "memory:write", "memory:admin",
-        "principal:read", "principal:admin",
-        "connector:read", "connector:admin",
-      ],
-      extensions_supported: [
-        "io.modelcontextprotocol/enterprise-managed-authorization",
-      ],
-    };
+    return buildAuthorizationServerMetadata();
   }
 }
 

--- a/resources/auth-middleware.ts
+++ b/resources/auth-middleware.ts
@@ -97,6 +97,11 @@ server.http(async (request: any, nextLayer: any) => {
     url.pathname === "/OAuthAuthorize" ||
     url.pathname === "/OAuthToken" ||
     url.pathname === "/OAuthRevoke" ||
+    // Belt-and-braces since flair#1000: `/.well-known/oauth-authorization-server`
+    // is served from its OWN urlPath mount (resources/oauth-wellknown.ts), which
+    // gets its own dispatch chain — this middleware never sees a request for it.
+    // The entry stays so the path is still public if that mount ever moves back
+    // onto the default chain.
     url.pathname === "/.well-known/oauth-authorization-server" ||
     url.pathname === "/OAuthMetadata" ||
     // Presence roster is public-safe (field-allowlisted); GET serves the

--- a/resources/oauth-discovery.ts
+++ b/resources/oauth-discovery.ts
@@ -1,0 +1,249 @@
+/**
+ * oauth-discovery.ts — the ONE builder for every OAuth discovery document
+ * flair serves, the paths they are served at, and the request handlers that
+ * serve them. Deliberately free of any `harper` import so all of it is
+ * directly unit-testable; the Harper route registration lives next door in
+ * resources/oauth-wellknown.ts.
+ *
+ * Three surfaces render these documents:
+ *
+ *   - `GET /OAuthMetadata`                          (resources/OAuth.ts, historical path)
+ *   - `GET /.well-known/oauth-authorization-server` (RFC 8414)
+ *   - `GET /.well-known/oauth-protected-resource`   (RFC 9728)
+ *
+ * The first two return the SAME object from the SAME function — `/OAuthMetadata`
+ * is an ALIAS, not a second implementation. Two endpoints that can drift apart
+ * is the defect this module exists to make impossible: a field added to the
+ * authorization-server document appears at both paths or at neither, and there
+ * is no code path that can produce one without the other.
+ *
+ * ── Issuer derivation is NOT redefined here ─────────────────────────────────
+ * `oauthPublicBaseUrl()` is the expression `OAuthMetadata.get()` already used,
+ * moved verbatim: `FLAIR_PUBLIC_URL`, else the loopback bind address. Operators
+ * MUST set `FLAIR_PUBLIC_URL` on any non-loopback deployment (docs/deploying-on-
+ * fabric.md, resources/AdminInstance.ts) or every URL in every one of these
+ * documents points at the CLIENT's own localhost. That requirement, and the
+ * `loadEnv` declaration that makes a component `.env` actually reach
+ * `process.env`, shipped in flair#1005 — deliberately untouched here.
+ */
+
+import { mcpOAuthEnabled } from "./mcp-oauth-flag.js";
+
+/** RFC 9728 §3.1 — Protected Resource Metadata well-known path. */
+export const PRM_PATH = "/.well-known/oauth-protected-resource";
+
+/** RFC 8414 §3 — Authorization Server Metadata well-known path. */
+export const AS_METADATA_PATH = "/.well-known/oauth-authorization-server";
+
+/**
+ * The public origin every URL in every discovery document derives from.
+ *
+ * Verbatim the expression `OAuthMetadata.get()` carried before this module
+ * existed — moved, not changed. See the header note on flair#1005.
+ */
+export function oauthPublicBaseUrl(): string {
+  return process.env.FLAIR_PUBLIC_URL || `http://127.0.0.1:${process.env.HTTP_PORT || 19926}`;
+}
+
+/**
+ * The RFC 8707 resource identifier of flair's MCP surface: `<base>/mcp`.
+ *
+ * Matches `mcpResource()` in resources/mcp-oauth-flag.ts by construction —
+ * that is the URI `withMCPAuth` audience-binds tokens to when the Model-2
+ * surface is enabled, so the protected-resource document must name the same
+ * string or a client would audience-bind its token to something `/mcp` rejects.
+ *
+ * It names `/mcp` even when `FLAIR_MCP_OAUTH` is off and `/mcp` therefore
+ * 404s. That is a coherent state, not a lie: RFC 9728 metadata describes how a
+ * resource WOULD be authorized; a client that discovers the authorization
+ * server and then finds no `/mcp` has learned something true. The alternative —
+ * naming the origin itself as the protected resource — would be the actual
+ * lie, because no flair REST resource accepts a bearer token (see
+ * resources/oauth-wellknown.ts's header for that measurement).
+ */
+export function mcpResourceUri(baseUrl: string = oauthPublicBaseUrl()): string {
+  return `${baseUrl.replace(/\/+$/, "")}/mcp`;
+}
+
+/**
+ * RFC 8414 Authorization Server Metadata — flair's own OAuth 2.1 AS
+ * (resources/OAuth.ts): `/OAuthAuthorize`, `/OAuthToken`, `/OAuthRegister`,
+ * `/OAuthRevoke`.
+ *
+ * Served at BOTH `/.well-known/oauth-authorization-server` and `/OAuthMetadata`.
+ */
+export function buildAuthorizationServerMetadata(baseUrl: string = oauthPublicBaseUrl()) {
+  return {
+    issuer: baseUrl,
+    authorization_endpoint: `${baseUrl}/OAuthAuthorize`,
+    token_endpoint: `${baseUrl}/OAuthToken`,
+    registration_endpoint: `${baseUrl}/OAuthRegister`,
+    revocation_endpoint: `${baseUrl}/OAuthRevoke`,
+    response_types_supported: ["code"],
+    grant_types_supported: [
+      "authorization_code",
+      "refresh_token",
+      "urn:ietf:params:oauth:grant-type:jwt-bearer",
+    ],
+    token_endpoint_auth_methods_supported: ["none", "client_secret_basic"],
+    code_challenge_methods_supported: ["S256"],
+    scopes_supported: [
+      "memory:read", "memory:write", "memory:admin",
+      "principal:read", "principal:admin",
+      "connector:read", "connector:admin",
+    ],
+    extensions_supported: [
+      "io.modelcontextprotocol/enterprise-managed-authorization",
+    ],
+  };
+}
+
+/**
+ * RFC 9728 Protected Resource Metadata for flair's MCP surface.
+ *
+ * `authorization_servers` names the SAME `issuer` string the authorization-
+ * server document publishes — both come from `oauthPublicBaseUrl()`, so a
+ * client that follows `authorization_servers[0]` +
+ * `/.well-known/oauth-authorization-server` lands on a document whose `issuer`
+ * matches what sent it there. That loop closing is asserted end-to-end in
+ * test/integration/oauth-wellknown-e2e.test.ts.
+ *
+ * `scopes_supported` is deliberately the same list the AS advertises rather
+ * than a second, narrower one — a resource advertising scopes the AS cannot
+ * issue would send clients into a guaranteed `invalid_scope`.
+ */
+export function buildProtectedResourceMetadata(baseUrl: string = oauthPublicBaseUrl()) {
+  const as = buildAuthorizationServerMetadata(baseUrl);
+  return {
+    resource: mcpResourceUri(baseUrl),
+    authorization_servers: [as.issuer],
+    // RFC 9728 §2 — the only presentation method `withMCPAuth` accepts is the
+    // Authorization header; it never reads a form or query-parameter token.
+    bearer_methods_supported: ["header"],
+    scopes_supported: as.scopes_supported,
+  };
+}
+
+// ─── Path screening ──────────────────────────────────────────────────────────
+//
+// Harper's `server.http({ urlPath })` matching is prefix-based and passes the
+// path RELATIVE to the mount, so every sub-path of a mount reaches its handler
+// and has to be screened here — otherwise
+// `/.well-known/oauth-protected-resource/anything` would answer with flair's
+// document.
+
+/**
+ * Does a request address the protected-resource document?
+ *
+ * Accepted:
+ *   - `/`      the bare well-known path
+ *   - `/mcp`   RFC 9728 §3.1 path-insertion for the resource `<base>/mcp`. MCP
+ *              clients (Claude.ai among them) build the PRM URL by inserting
+ *              the resource's path component and fetch THIS form, so without
+ *              it the discovery loop 404s on the only URL a real client asks for.
+ *   - the absolute forms of both, for Harper builds that pass an unstripped path.
+ *
+ * Exact-after-normalization, never a prefix test — `/mcp-evil` must not match
+ * `/mcp`.
+ */
+export function prmPathMatches(relativePath: string, baseUrl: string = oauthPublicBaseUrl()): boolean {
+  const path = normalizePath(relativePath);
+  if (path === "/" || path === PRM_PATH) return true;
+  const resourcePath = resourcePathOf(baseUrl);
+  if (!resourcePath) return false;
+  return path === resourcePath || path === PRM_PATH + resourcePath;
+}
+
+/**
+ * Same screen for the authorization-server document. RFC 8414 §3.1 path-
+ * insertion applies to an issuer that CARRIES a path component; flair's issuer
+ * is always an origin, so only the bare path is valid here and every sub-path
+ * is a 404.
+ */
+export function asMetadataPathMatches(relativePath: string): boolean {
+  const path = normalizePath(relativePath);
+  return path === "/" || path === AS_METADATA_PATH;
+}
+
+/** Strip a single trailing slash so `/mcp/` and `/mcp` screen identically. */
+function normalizePath(path: string): string {
+  if (!path) return "/";
+  return path.length > 1 && path.endsWith("/") ? path.slice(0, -1) : path;
+}
+
+/** The path component of the protected resource URI (`/mcp`), or "" if unparseable. */
+function resourcePathOf(baseUrl: string): string {
+  try {
+    const { pathname } = new URL(mcpResourceUri(baseUrl));
+    return pathname && pathname !== "/" ? pathname.replace(/\/+$/, "") : "";
+  } catch {
+    return "";
+  }
+}
+
+// ─── Handlers ────────────────────────────────────────────────────────────────
+
+function discoveryResponse(body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: {
+      "content-type": "application/json",
+      // Discovery documents are unauthenticated, non-secret, and fetched
+      // cross-origin by browser-based MCP clients and inspectors. Simple `*` is
+      // sufficient because no credentials are ever involved. Matches what
+      // @harperfast/oauth sets on the same documents.
+      "access-control-allow-origin": "*",
+      "access-control-allow-methods": "GET, OPTIONS",
+    },
+  });
+}
+
+function notFound(): Response {
+  return new Response(JSON.stringify({ error: "not_found" }), {
+    status: 404,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+/** The mount-relative path Harper hands the handler, query string removed. */
+export function relativePathOf(request: any): string {
+  const raw: string = request?.pathname ?? request?.url ?? "/";
+  const q = raw.indexOf("?");
+  return q >= 0 ? raw.slice(0, q) : raw;
+}
+
+/**
+ * Build the handler for one well-known document.
+ *
+ * Three behaviours, in order:
+ *
+ *  1. A path under the mount that is NOT one of the accepted discovery forms
+ *     gets a 404 from HERE — it is never passed to `next`. A urlPath mount has
+ *     its OWN dispatch chain that contains neither flair's auth-middleware nor
+ *     Harper's `authentication`, and `next` strips the mount prefix, so passing
+ *     an arbitrary sub-path onward is how a discovery mount turns into a path-
+ *     confusion hole. Screen, then answer; never forward.
+ *  2. `FLAIR_MCP_OAUTH` on → fall through for the accepted forms, so
+ *     @harperfast/oauth's own well-known handlers (identical urlPath, same
+ *     dispatch group) answer for the surface they actually guard. See
+ *     resources/oauth-wellknown.ts's header for why flair's AS must not be
+ *     advertised in that state.
+ *  3. Otherwise serve the document.
+ *
+ * Non-GET/HEAD is a 404 too: a POST to a discovery path is not a discovery
+ * request and must not be answered with a 200 body.
+ */
+export function makeWellKnownHandler(
+  matches: (relative: string) => boolean,
+  build: () => unknown,
+  isMcpOAuthEnabled: () => boolean = mcpOAuthEnabled,
+) {
+  return async (request: any, next: any) => {
+    const method = String(request?.method ?? "GET").toUpperCase();
+    if (!matches(relativePathOf(request)) || (method !== "GET" && method !== "HEAD")) {
+      return notFound();
+    }
+    if (isMcpOAuthEnabled()) return next(request);
+    return discoveryResponse(build());
+  };
+}

--- a/resources/oauth-wellknown.ts
+++ b/resources/oauth-wellknown.ts
@@ -1,0 +1,130 @@
+/**
+ * oauth-wellknown.ts — mounts flair's OAuth discovery documents at the two
+ * well-known paths every spec-compliant client probes (flair#1000 item 2).
+ *
+ * Before this, flair published a correct authorization-server document at
+ * `/OAuthMetadata` — a path nothing in the ecosystem asks for — and 404'd at
+ * `/.well-known/oauth-authorization-server` (RFC 8414) and
+ * `/.well-known/oauth-protected-resource` (RFC 9728, which the MCP
+ * authorization specification makes a MUST). A remote MCP client could not
+ * discover flair no matter what else was configured.
+ *
+ * The documents themselves, and every path-screening decision, live in
+ * resources/oauth-discovery.ts — this file is only the Harper wiring.
+ *
+ * ── Why `server.http({ urlPath })` and not a Resource ───────────────────────
+ * Harper's REST layer maps a Resource CLASS NAME to a path segment; no class
+ * name produces `/.well-known/oauth-protected-resource`. A urlPath mount is the
+ * supported route for paths outside the Resource naming scheme — the same
+ * mechanism resources/mcp-oauth.ts uses for `/mcp` and @harperfast/oauth uses
+ * for its own well-known documents.
+ *
+ * A urlPath mount gets its OWN dispatch chain, so neither flair's
+ * auth-middleware nor Harper's `authentication` middleware runs for these
+ * paths. That is required, not incidental: RFC 8414 §3 and RFC 9728 §3 both
+ * require the documents be retrievable WITHOUT authentication, and Harper's
+ * auth layer stamps `WWW-Authenticate: Basic` on any 401 it wraps.
+ * (`/.well-known/oauth-authorization-server` remains in auth-middleware.ts's
+ * public allowlist; that entry is now belt-and-braces — a request for it never
+ * reaches the default chain.)
+ *
+ * ── Deference to @harperfast/oauth when the Model-2 surface is on ───────────
+ * `FLAIR_MCP_OAUTH` mounts an OAuth-guarded `/mcp` wrapped in the plugin's
+ * `withMCPAuth` (resources/mcp-oauth.ts). Tokens for THAT surface are minted by
+ * the PLUGIN's authorization server (`/oauth/mcp/token`, JWTs verified against
+ * its JWKS), NOT by flair's own OAuth 2.1 AS, which mints opaque `flair_at_…`
+ * strings the guard rejects. Advertising flair's AS as the authorization server
+ * for `/mcp` in that state would hand a client a token `/mcp` is guaranteed to
+ * refuse.
+ *
+ * So when the flag is on these handlers serve nothing and fall through, and the
+ * plugin's own well-known handlers (registered by its `handleApplication` when
+ * an operator declares the `'@harperfast/oauth'` component) answer with the
+ * document describing the AS that actually guards the surface. Making this a
+ * function of flair's own flag keeps it deterministic: two handlers mounted on
+ * an identical urlPath share one dispatch group and run in REGISTRATION order,
+ * so without an explicit rule the answer would depend on where an operator
+ * happened to put a key in config.yaml.
+ *
+ * Gap named rather than papered over: flag ON with the plugin component NOT
+ * declared serves neither document (404, exactly as before this change). That
+ * instance is already non-functional — `/mcp` is guarded by a verifier with no
+ * authorization server behind it, so there is no token to discover.
+ *
+ * ── What this does NOT change: the 401 challenge (flair#1000 item 3) ────────
+ * flair's REST surface deliberately keeps the challenge it has, because a
+ * Bearer challenge there would be FALSE. A bearer token cannot reach a flair
+ * resource at all: Harper's own auth layer claims every `Bearer …` header for
+ * itself and validates it as a Harper OPERATION token, so
+ * `Authorization: Bearer <anything>` answers 401 `{"error":"invalid token"}`
+ * before any code under resources/ runs (measured against a live instance; the
+ * strategy switch is in node_modules/harper/dist/security/auth.js). flair's own
+ * `/OAuthToken` mints opaque `flair_at_…` values that nothing under resources/
+ * ever validates, so there is not even a token that WOULD work.
+ *
+ * Advertising `WWW-Authenticate: Bearer resource_metadata=…` on `/Memory` would
+ * therefore announce, per RFC 7235 §4.1, a scheme usable at that resource, and
+ * send every MCP client that believed it around a loop that ends in exactly the
+ * same 401 with no recovery — strictly worse than the honest challenge, because
+ * it misdirects instead of refusing.
+ *
+ * It would also mean rewriting headers on EVERY 401 in the instance. Harper's
+ * auth layer owns that header for every 401 raised at or below it —
+ * `response.headers.set('WWW-Authenticate', 'Basic')`, a set and not an append
+ * (security/auth.js). flair's middleware is registered ahead of it (config.yaml
+ * orders `jsResource` before `authentication`) so it *could* override on the way
+ * out — verified by `/Admin` keeping its own `Basic realm="Flair Admin"` — but
+ * only by awaiting and inspecting every response on the hottest path in the
+ * chain, for every existing Basic and Ed25519 caller, to publish a scheme none
+ * of them can use.
+ *
+ * The challenge belongs on the one surface that DOES take a bearer token —
+ * `/mcp` — and it is already there: with `FLAIR_MCP_OAUTH` on, `withMCPAuth`
+ * answers `POST /mcp` with
+ * `401 WWW-Authenticate: Bearer resource_metadata="<issuer>/.well-known/oauth-protected-resource/mcp"`.
+ * Until this change that URL 404'd, which is the sense in which item 3 was
+ * broken end to end: the challenge existed and pointed at nothing. flair now
+ * answers that exact path (and @harperfast/oauth answers it when the flag is on
+ * and the plugin is declared), so the discovery loop closes.
+ */
+
+import { server } from "harper";
+import {
+  AS_METADATA_PATH,
+  PRM_PATH,
+  asMetadataPathMatches,
+  buildAuthorizationServerMetadata,
+  buildProtectedResourceMetadata,
+  makeWellKnownHandler,
+  prmPathMatches,
+} from "./oauth-discovery.js";
+import { mcpOAuthEnabled } from "./mcp-oauth-flag.js";
+
+export interface WellKnownDeps {
+  /** Injectable for tests; defaults to the real Harper server. */
+  server?: { http: (handler: any, options: any) => void };
+  /** Injectable for tests; defaults to the real FLAIR_MCP_OAUTH read. */
+  isMcpOAuthEnabled?: () => boolean;
+}
+
+/**
+ * Mount both documents. Called once at module load, and directly from tests.
+ * Returns the urlPaths mounted so a caller can assert on them.
+ */
+export function registerOAuthWellKnownRoutes(deps: WellKnownDeps = {}): string[] {
+  const srv = deps.server ?? ((server as any));
+  if (typeof srv?.http !== "function") return [];
+  const enabled = deps.isMcpOAuthEnabled ?? mcpOAuthEnabled;
+
+  srv.http(makeWellKnownHandler(prmPathMatches, buildProtectedResourceMetadata, enabled), { urlPath: PRM_PATH });
+  srv.http(makeWellKnownHandler(asMetadataPathMatches, buildAuthorizationServerMetadata, enabled), { urlPath: AS_METADATA_PATH });
+
+  return [PRM_PATH, AS_METADATA_PATH];
+}
+
+// Registered at module load, like resources/auth-middleware.ts. The opt-out
+// exists only so a unit test can import this module under a partial `harper`
+// mock without registering routes; production never sets it.
+if (process.env.FLAIR_WELLKNOWN_NO_AUTOSTART == null) {
+  registerOAuthWellKnownRoutes();
+}

--- a/src/lib/mcp-enable.ts
+++ b/src/lib/mcp-enable.ts
@@ -682,6 +682,27 @@ export async function selfVerifyMcpMetadata(
     };
   }
 
+  // flair#1000: this path is now served by flair ITSELF when FLAIR_MCP_OAUTH is
+  // off, so a 200 no longer proves the plugin answered. flair's own document
+  // (resources/oauth-discovery.ts) is identifiable by its token endpoint —
+  // `<issuer>/OAuthToken`, where the plugin's is `<issuer>/oauth/mcp/token`.
+  // Name the real cause here: before this existed the operator got a 404 whose
+  // message already asked the right question, and falling through to the CIMD
+  // branch would send them to a plugin knob that is not the problem.
+  if (body.token_endpoint === `${normalizedIssuer}/OAuthToken`) {
+    return {
+      ok: false,
+      issuer: body.issuer,
+      registrationEndpoint: body.registration_endpoint,
+      tokenEndpoint: body.token_endpoint,
+      detail:
+        `${url} answered with flair's OWN OAuth 2.1 authorization server, not the MCP one ` +
+        `(token_endpoint=${body.token_endpoint}) — the /mcp surface is NOT enabled on that instance. ` +
+        `Is FLAIR_MCP_OAUTH actually set on the restarted instance, and is the '@harperfast/oauth' ` +
+        `component declared in its config.yaml?`,
+    };
+  }
+
   // flair#756: confirm CIMD is actually advertised (node_modules/@harperfast/
   // oauth/dist/lib/mcp/wellKnown.js:129-165's buildAuthorizationServerMetadata:
   // `client_id_metadata_document_supported` is set only when

--- a/test/integration/oauth-wellknown-e2e.test.ts
+++ b/test/integration/oauth-wellknown-e2e.test.ts
@@ -1,0 +1,263 @@
+/**
+ * oauth-wellknown-e2e.test.ts — flair#1000 item 2, proved over real HTTP
+ * against a live Harper running flair's shipped config.yaml.
+ *
+ * Before this change both of these answered 404, which is why a spec-compliant
+ * MCP client could not discover a Flair instance at all:
+ *
+ *   /.well-known/oauth-protected-resource      RFC 9728 (MCP auth spec: MUST)
+ *   /.well-known/oauth-authorization-server    RFC 8414
+ *
+ * Every assertion below fails on origin/main. Three of them are the ones that
+ * matter most and are easiest to lose later:
+ *
+ *   1. DRIFT — the well-known authorization-server document and /OAuthMetadata
+ *      are compared byte-for-byte over the wire, not in the builder. If anyone
+ *      ever re-implements one of them, this fails.
+ *   2. PATH INSERTION — /.well-known/oauth-protected-resource/mcp is the URL
+ *      real MCP clients construct and the URL withMCPAuth's 401 challenge
+ *      points at. Serving only the bare path looks correct in a browser and
+ *      404s for the client that matters.
+ *   3. POSITIVE CONTROL ON THE AUTH PATH — Basic and Ed25519 callers, and the
+ *      401/403 they get without credentials, are asserted unchanged. A test
+ *      that only checked the new documents would pass while the auth chain
+ *      regressed underneath it.
+ *
+ * MODEL: test/integration/auth-middleware-e2e.test.ts — startHarper(), seed via
+ * the ops API, real fetch, assert status codes and bodies.
+ */
+import { describe, expect, test, beforeAll, afterAll } from "bun:test";
+import nacl from "tweetnacl";
+import { randomUUID } from "node:crypto";
+import { startHarper, stopHarper, type HarperInstance } from "../helpers/harper-lifecycle";
+
+const PRM_PATH = "/.well-known/oauth-protected-resource";
+const AS_METADATA_PATH = "/.well-known/oauth-authorization-server";
+
+let harper: HarperInstance;
+let base: string;
+
+const agentKeys = nacl.sign.keyPair();
+const AGENT_ID = "oauth-wellknown-e2e-agent";
+const AGENT_PUBLIC_KEY = Buffer.from(agentKeys.publicKey).toString("base64");
+
+/** A TPS-Ed25519 Authorization header. The signature covers pathname + search. */
+function ed25519Header(method: string, path: string): string {
+  const ts = Date.now().toString();
+  const nonce = randomUUID();
+  const payload = `${AGENT_ID}:${ts}:${nonce}:${method}:${path}`;
+  const sig = nacl.sign.detached(new TextEncoder().encode(payload), agentKeys.secretKey);
+  return `TPS-Ed25519 ${AGENT_ID}:${ts}:${nonce}:${Buffer.from(sig).toString("base64")}`;
+}
+
+function basicHeader(): string {
+  return "Basic " + Buffer.from(`${harper.admin.username}:${harper.admin.password}`).toString("base64");
+}
+
+async function adminOp(op: Record<string, any>): Promise<Response> {
+  return fetch(harper.opsURL, {
+    method: "POST",
+    headers: { "Content-Type": "application/json", Authorization: basicHeader() },
+    body: JSON.stringify(op),
+  });
+}
+
+describe("OAuth discovery at the well-known paths (real Harper)", () => {
+  beforeAll(async () => {
+    harper = await startHarper();
+    base = harper.httpURL;
+
+    const agentRes = await adminOp({
+      operation: "insert",
+      database: "flair",
+      table: "Agent",
+      records: [{
+        id: AGENT_ID,
+        name: AGENT_ID,
+        role: "agent",
+        publicKey: AGENT_PUBLIC_KEY,
+        createdAt: new Date().toISOString(),
+      }],
+    });
+    expect(agentRes.status).toBe(200);
+  }, 180_000);
+
+  afterAll(async () => {
+    if (harper) await stopHarper(harper);
+  });
+
+  // ── RFC 8414 ───────────────────────────────────────────────────────────────
+
+  describe(`GET ${AS_METADATA_PATH} (RFC 8414)`, () => {
+    test("is served, unauthenticated, as JSON", async () => {
+      const res = await fetch(base + AS_METADATA_PATH);
+      expect(res.status).toBe(200);
+      expect(res.headers.get("content-type")).toContain("application/json");
+      const doc: any = await res.json();
+      expect(doc.issuer).toBe(base);
+      expect(doc.token_endpoint).toBe(`${base}/OAuthToken`);
+      expect(doc.authorization_endpoint).toBe(`${base}/OAuthAuthorize`);
+      expect(doc.registration_endpoint).toBe(`${base}/OAuthRegister`);
+      expect(doc.revocation_endpoint).toBe(`${base}/OAuthRevoke`);
+      expect(doc.code_challenge_methods_supported).toEqual(["S256"]);
+    }, 30_000);
+
+    test("is readable cross-origin — browser MCP clients fetch it from another origin", async () => {
+      const res = await fetch(base + AS_METADATA_PATH);
+      expect(res.headers.get("access-control-allow-origin")).toBe("*");
+    }, 30_000);
+
+    test("every sub-path is a 404 — flair's issuer carries no path component", async () => {
+      for (const sub of ["/mcp", "/bogus", "/Memory"]) {
+        const res = await fetch(base + AS_METADATA_PATH + sub);
+        expect(res.status, `${AS_METADATA_PATH}${sub}`).toBe(404);
+      }
+    }, 30_000);
+
+    test("a POST is not a discovery request", async () => {
+      const res = await fetch(base + AS_METADATA_PATH, { method: "POST", body: "{}" });
+      expect(res.status).toBe(404);
+    }, 30_000);
+  });
+
+  // ── RFC 9728 ───────────────────────────────────────────────────────────────
+
+  describe(`GET ${PRM_PATH} (RFC 9728)`, () => {
+    test("is served, unauthenticated, and names the MCP surface as the resource", async () => {
+      const res = await fetch(base + PRM_PATH);
+      expect(res.status).toBe(200);
+      expect(res.headers.get("content-type")).toContain("application/json");
+      const doc: any = await res.json();
+      expect(doc.resource).toBe(`${base}/mcp`);
+      expect(doc.authorization_servers).toEqual([base]);
+      expect(doc.bearer_methods_supported).toEqual(["header"]);
+    }, 30_000);
+
+    test("the RFC 9728 §3.1 path-appended form serves the same document", async () => {
+      // <origin>/.well-known/oauth-protected-resource/mcp — the URL an MCP
+      // client constructs by path insertion, and the URL withMCPAuth's 401
+      // challenge points at. Serving only the bare path 404s for real clients.
+      const bare = await (await fetch(base + PRM_PATH)).json();
+      const inserted = await fetch(base + PRM_PATH + "/mcp");
+      expect(inserted.status).toBe(200);
+      expect(await inserted.json()).toEqual(bare);
+    }, 30_000);
+
+    test("a near-miss sub-path is a 404 — /mcp-evil must not match /mcp", async () => {
+      for (const sub of ["/mcp-evil", "/mcpx", "/bogus", "/Memory", "/mcp/deeper"]) {
+        const res = await fetch(base + PRM_PATH + sub);
+        expect(res.status, `${PRM_PATH}${sub}`).toBe(404);
+      }
+    }, 30_000);
+  });
+
+  // ── The discovery loop, end to end ─────────────────────────────────────────
+
+  describe("the discovery loop a real client walks", () => {
+    test("PRM → authorization_servers[0] → AS metadata → an issuer that matches", async () => {
+      const prm: any = await (await fetch(base + PRM_PATH)).json();
+      const asUrl = prm.authorization_servers[0] + AS_METADATA_PATH;
+      const asRes = await fetch(asUrl);
+      expect(asRes.status).toBe(200);
+      const as: any = await asRes.json();
+      // RFC 8414 §3.3: the issuer in the document MUST match the one used to
+      // build the URL. If it doesn't, a conformant client aborts.
+      expect(as.issuer).toBe(prm.authorization_servers[0]);
+    }, 30_000);
+
+    test("the advertised token endpoint is a real endpoint, not a 404", async () => {
+      const as: any = await (await fetch(base + AS_METADATA_PATH)).json();
+      const res = await fetch(as.token_endpoint, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ grant_type: "authorization_code", code: "nope" }),
+      });
+      // A well-formed OAuth error, NOT a 404 — the endpoint exists and ran.
+      expect(res.status).toBeLessThan(500);
+      expect(res.status).not.toBe(404);
+    }, 30_000);
+  });
+
+  // ── The anti-drift assertion ───────────────────────────────────────────────
+
+  describe("/OAuthMetadata is an alias of the well-known path", () => {
+    test("both paths return byte-identical documents over the wire", async () => {
+      const wellKnown = await (await fetch(base + AS_METADATA_PATH)).text();
+      const alias = await (await fetch(base + "/OAuthMetadata")).text();
+      expect(alias).toBe(wellKnown);
+    }, 30_000);
+
+    test("the two documents agree on issuer and on every endpoint", async () => {
+      const wellKnown: any = await (await fetch(base + AS_METADATA_PATH)).json();
+      const alias: any = await (await fetch(base + "/OAuthMetadata")).json();
+      for (const field of Object.keys(wellKnown)) {
+        if (field !== "issuer" && !field.endsWith("_endpoint")) continue;
+        expect(alias[field], field).toEqual(wellKnown[field]);
+      }
+    }, 30_000);
+
+    test("the protected-resource document agrees with /OAuthMetadata on the issuer", async () => {
+      const prm: any = await (await fetch(base + PRM_PATH)).json();
+      const alias: any = await (await fetch(base + "/OAuthMetadata")).json();
+      expect(prm.authorization_servers).toEqual([alias.issuer]);
+      expect(prm.resource.startsWith(alias.issuer + "/")).toBe(true);
+    }, 30_000);
+  });
+
+  // ── POSITIVE CONTROL: the auth chain is untouched ──────────────────────────
+  //
+  // flair#1000 item 3 asked for a Bearer challenge on protected resources. It
+  // is deliberately NOT applied to flair's REST surface (see
+  // resources/oauth-wellknown.ts's header). These assertions are what makes
+  // that a decision rather than an omission: if a future change starts
+  // advertising Bearer here, or breaks Basic / Ed25519 doing it, this block
+  // fails.
+
+  describe("existing auth is intact (positive control)", () => {
+    test("Basic admin auth still reaches a protected resource", async () => {
+      const res = await fetch(base + "/Memory", { headers: { Authorization: basicHeader() } });
+      expect(res.status).toBe(200);
+    }, 30_000);
+
+    test("Ed25519 agent auth still reaches a protected resource", async () => {
+      const path = `/Memory/?agentId=${AGENT_ID}`;
+      const res = await fetch(base + path, { headers: { Authorization: ed25519Header("GET", path) } });
+      expect(res.status).toBe(200);
+    }, 30_000);
+
+    test("an unauthenticated protected resource is still refused, with NO Bearer challenge", async () => {
+      const res = await fetch(base + "/Memory");
+      expect([401, 403]).toContain(res.status);
+      const challenge = res.headers.get("www-authenticate");
+      expect(challenge === null || !challenge.toLowerCase().includes("bearer")).toBe(true);
+    }, 30_000);
+
+    test("the browser admin page still gets its Basic challenge, unchanged", async () => {
+      const res = await fetch(base + "/Admin");
+      expect(res.status).toBe(401);
+      expect(res.headers.get("www-authenticate")).toBe('Basic realm="Flair Admin"');
+    }, 30_000);
+
+    test("a bearer token cannot reach a flair resource — which is why we do not advertise one", async () => {
+      // Harper's own auth layer claims every `Bearer …` header and validates it
+      // as a Harper OPERATION token, so no flair-issued `flair_at_…` value can
+      // ever authorize a REST call. A `WWW-Authenticate: Bearer` challenge here
+      // would send an MCP client around a loop that ends exactly here.
+      const res = await fetch(base + "/Memory", { headers: { Authorization: "Bearer flair_at_not_a_real_token" } });
+      expect(res.status).toBe(401);
+    }, 30_000);
+
+    test("/mcp stays absent — discovery does not turn the surface on", async () => {
+      // FLAIR_MCP_OAUTH is default-off and this change must not alter that. A
+      // client that discovers the authorization server and then finds no /mcp
+      // is a coherent state; a /mcp that appeared because discovery shipped
+      // would not be.
+      const res = await fetch(base + "/mcp", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "initialize" }),
+      });
+      expect(res.status).toBe(404);
+    }, 30_000);
+  });
+});

--- a/test/unit/mcp-enable.test.ts
+++ b/test/unit/mcp-enable.test.ts
@@ -473,6 +473,31 @@ describe("selfVerifyMcpMetadata", () => {
     expect(result.ok).toBe(false);
     expect(result.cimdSupported).toBe(false);
   });
+
+  test("flair#1000: flair's OWN authorization-server document is named as such, not blamed on CIMD config", async () => {
+    // Since flair#1000, /.well-known/oauth-authorization-server is served by
+    // flair itself whenever FLAIR_MCP_OAUTH is off — so a 200 here no longer
+    // means the plugin answered. The operator's actual mistake is the flag (or
+    // the missing component declaration); sending them to
+    // clientIdMetadataDocuments.enabled would misdirect.
+    const fetchImpl = (async () =>
+      new Response(
+        JSON.stringify({
+          issuer: ISSUER,
+          registration_endpoint: `${ISSUER}/OAuthRegister`,
+          token_endpoint: `${ISSUER}/OAuthToken`,
+          token_endpoint_auth_methods_supported: ["none", "client_secret_basic"],
+          code_challenge_methods_supported: ["S256"],
+        }),
+        { status: 200 },
+      )) as typeof fetch;
+    const result = await selfVerifyMcpMetadata(ISSUER, { fetchImpl });
+    expect(result.ok).toBe(false);
+    expect(result.detail).toContain("FLAIR_MCP_OAUTH");
+    expect(result.detail).toContain("@harperfast/oauth");
+    // Must NOT blame CIMD configuration — that is the misdirection this guards.
+    expect(result.detail).not.toContain("clientIdMetadataDocuments");
+  });
 });
 
 describe("buildClaudePasteBlock", () => {

--- a/test/unit/oauth-discovery.test.ts
+++ b/test/unit/oauth-discovery.test.ts
@@ -1,0 +1,296 @@
+/**
+ * oauth-discovery.test.ts — flair#1000 item 2.
+ *
+ * These exercise the REAL module (resources/oauth-discovery.ts imports nothing
+ * from `harper`, so there is no mock and no mirror-function to drift from the
+ * shipped logic — the historical failure mode of test/unit/OAuth.test.ts, whose
+ * header admits it re-implements OAuth.ts's logic locally).
+ *
+ * The load-bearing assertion is the LAST describe block: the document served at
+ * `/.well-known/oauth-authorization-server` and the document served at
+ * `/OAuthMetadata` are the same value from the same call. Everything else here
+ * is path screening, which is where a discovery mount either works for real
+ * clients or silently doesn't.
+ */
+
+import { describe, test, expect, afterEach } from "bun:test";
+import {
+  AS_METADATA_PATH,
+  PRM_PATH,
+  asMetadataPathMatches,
+  buildAuthorizationServerMetadata,
+  buildProtectedResourceMetadata,
+  makeWellKnownHandler,
+  mcpResourceUri,
+  oauthPublicBaseUrl,
+  prmPathMatches,
+  relativePathOf,
+} from "../../resources/oauth-discovery.ts";
+
+const BASE = "https://flair.example.test";
+
+const ENV_KEYS = ["FLAIR_PUBLIC_URL", "HTTP_PORT", "FLAIR_MCP_OAUTH"] as const;
+const saved: Record<string, string | undefined> = {};
+for (const k of ENV_KEYS) saved[k] = process.env[k];
+afterEach(() => {
+  for (const k of ENV_KEYS) {
+    if (saved[k] === undefined) delete process.env[k];
+    else process.env[k] = saved[k]!;
+  }
+});
+
+// ─── Issuer derivation (moved, not changed — flair#1005) ─────────────────────
+
+describe("oauthPublicBaseUrl — the single origin every document derives from", () => {
+  test("prefers FLAIR_PUBLIC_URL", () => {
+    process.env.FLAIR_PUBLIC_URL = BASE;
+    expect(oauthPublicBaseUrl()).toBe(BASE);
+  });
+
+  test("falls back to the loopback bind address, honouring HTTP_PORT", () => {
+    delete process.env.FLAIR_PUBLIC_URL;
+    process.env.HTTP_PORT = "19999";
+    expect(oauthPublicBaseUrl()).toBe("http://127.0.0.1:19999");
+  });
+
+  test("falls back to the default port when HTTP_PORT is unset", () => {
+    delete process.env.FLAIR_PUBLIC_URL;
+    delete process.env.HTTP_PORT;
+    expect(oauthPublicBaseUrl()).toBe("http://127.0.0.1:19926");
+  });
+});
+
+// ─── RFC 8414 authorization-server metadata ──────────────────────────────────
+
+describe("buildAuthorizationServerMetadata (RFC 8414)", () => {
+  const doc = buildAuthorizationServerMetadata(BASE);
+
+  test("issuer is the base URL, and every endpoint is derived from it", () => {
+    expect(doc.issuer).toBe(BASE);
+    expect(doc.authorization_endpoint).toBe(`${BASE}/OAuthAuthorize`);
+    expect(doc.token_endpoint).toBe(`${BASE}/OAuthToken`);
+    expect(doc.registration_endpoint).toBe(`${BASE}/OAuthRegister`);
+    expect(doc.revocation_endpoint).toBe(`${BASE}/OAuthRevoke`);
+  });
+
+  test("no endpoint can point somewhere other than the issuer origin", () => {
+    for (const [field, value] of Object.entries(doc)) {
+      if (!field.endsWith("_endpoint")) continue;
+      expect(String(value).startsWith(BASE + "/"), `${field} = ${value}`).toBe(true);
+    }
+  });
+
+  test("PKCE S256 and the grant types flair's AS actually implements", () => {
+    expect(doc.code_challenge_methods_supported).toEqual(["S256"]);
+    expect(doc.grant_types_supported).toEqual([
+      "authorization_code",
+      "refresh_token",
+      "urn:ietf:params:oauth:grant-type:jwt-bearer",
+    ]);
+  });
+});
+
+// ─── RFC 9728 protected-resource metadata ────────────────────────────────────
+
+describe("buildProtectedResourceMetadata (RFC 9728)", () => {
+  const doc = buildProtectedResourceMetadata(BASE);
+
+  test("names the MCP surface as the protected resource", () => {
+    expect(doc.resource).toBe(`${BASE}/mcp`);
+    expect(doc.resource).toBe(mcpResourceUri(BASE));
+  });
+
+  test("bearer tokens are presented in the Authorization header only", () => {
+    expect(doc.bearer_methods_supported).toEqual(["header"]);
+  });
+
+  test("authorization_servers names the SAME issuer the AS document publishes", () => {
+    // The whole point of one builder: a client that follows
+    // authorization_servers[0] + /.well-known/oauth-authorization-server must
+    // land on a document whose `issuer` matches what sent it there.
+    expect(doc.authorization_servers).toEqual([buildAuthorizationServerMetadata(BASE).issuer]);
+  });
+
+  test("advertises no scope the authorization server cannot issue", () => {
+    const asScopes = new Set(buildAuthorizationServerMetadata(BASE).scopes_supported);
+    for (const scope of doc.scopes_supported) expect(asScopes.has(scope)).toBe(true);
+  });
+
+  test("a trailing slash on the base URL never produces a doubled slash", () => {
+    expect(buildProtectedResourceMetadata(BASE + "/").resource).toBe(`${BASE}/mcp`);
+  });
+});
+
+// ─── Path screening ──────────────────────────────────────────────────────────
+//
+// Harper's urlPath matching is prefix-based and hands the handler a path
+// relative to the mount, so every one of these strings is something a client
+// can actually cause to reach the handler.
+
+describe("prmPathMatches — RFC 9728 §3.1 path insertion", () => {
+  test("accepts the bare mount", () => {
+    expect(prmPathMatches("/", BASE)).toBe(true);
+    expect(prmPathMatches(PRM_PATH, BASE)).toBe(true);
+  });
+
+  test("accepts the path-appended form real MCP clients fetch", () => {
+    // Claude.ai and other MCP clients build the PRM URL by inserting the
+    // resource's path component: <origin>/.well-known/oauth-protected-resource/mcp.
+    // This is the ONLY URL some clients ask for — without it discovery 404s.
+    expect(prmPathMatches("/mcp", BASE)).toBe(true);
+    expect(prmPathMatches(PRM_PATH + "/mcp", BASE)).toBe(true);
+  });
+
+  test("tolerates a single trailing slash", () => {
+    expect(prmPathMatches("/mcp/", BASE)).toBe(true);
+  });
+
+  test("rejects a prefix near-miss — /mcp-evil must never match /mcp", () => {
+    expect(prmPathMatches("/mcp-evil", BASE)).toBe(false);
+    expect(prmPathMatches("/mcpx", BASE)).toBe(false);
+    expect(prmPathMatches(PRM_PATH + "/mcp-evil", BASE)).toBe(false);
+  });
+
+  test("rejects an arbitrary sub-path", () => {
+    expect(prmPathMatches("/bogus", BASE)).toBe(false);
+    expect(prmPathMatches("/Memory", BASE)).toBe(false);
+    expect(prmPathMatches("/mcp/deeper", BASE)).toBe(false);
+  });
+});
+
+describe("asMetadataPathMatches — RFC 8414, origin issuer only", () => {
+  test("accepts the bare mount", () => {
+    expect(asMetadataPathMatches("/")).toBe(true);
+    expect(asMetadataPathMatches(AS_METADATA_PATH)).toBe(true);
+  });
+
+  test("rejects every sub-path — flair's issuer has no path component", () => {
+    // RFC 8414 §3.1 path insertion only applies to an issuer that CARRIES a
+    // path. flair's issuer is always an origin, so /mcp is a 404 here even
+    // though it is valid on the protected-resource mount.
+    expect(asMetadataPathMatches("/mcp")).toBe(false);
+    expect(asMetadataPathMatches("/bogus")).toBe(false);
+    expect(asMetadataPathMatches("/Memory")).toBe(false);
+  });
+});
+
+describe("relativePathOf", () => {
+  test("prefers pathname, and strips a query string from a url fallback", () => {
+    expect(relativePathOf({ pathname: "/mcp" })).toBe("/mcp");
+    expect(relativePathOf({ url: "/mcp?x=1" })).toBe("/mcp");
+    expect(relativePathOf({})).toBe("/");
+  });
+});
+
+// ─── Handler behaviour ───────────────────────────────────────────────────────
+
+describe("makeWellKnownHandler", () => {
+  const build = () => ({ ok: true });
+  function nextSpy() {
+    const calls: any[] = [];
+    return { calls, next: async (req: any) => { calls.push(req); return { status: 599 }; } };
+  }
+
+  test("serves the document on a matching GET when the flag is off", async () => {
+    const { next, calls } = nextSpy();
+    const handler = makeWellKnownHandler(() => true, build, () => false);
+    const res: Response = await handler({ method: "GET", pathname: "/" }, next);
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toBe("application/json");
+    expect(res.headers.get("access-control-allow-origin")).toBe("*");
+    expect(await res.json()).toEqual({ ok: true });
+    expect(calls).toHaveLength(0);
+  });
+
+  test("404s a non-matching sub-path from HERE — it is never forwarded", async () => {
+    // A urlPath mount has its own dispatch chain containing neither flair's
+    // auth-middleware nor Harper's `authentication`, and `next` sees the
+    // mount-STRIPPED path. Forwarding an arbitrary sub-path is how a discovery
+    // mount becomes a path-confusion hole; screen, answer, never forward.
+    const { next, calls } = nextSpy();
+    const handler = makeWellKnownHandler(() => false, build, () => false);
+    const res: Response = await handler({ method: "GET", pathname: "/Memory" }, next);
+    expect(res.status).toBe(404);
+    expect(calls).toHaveLength(0);
+  });
+
+  test("404s a non-GET/HEAD on a matching path — a POST is not a discovery request", async () => {
+    const { next, calls } = nextSpy();
+    const handler = makeWellKnownHandler(() => true, build, () => false);
+    for (const method of ["POST", "PUT", "PATCH", "DELETE"]) {
+      const res: Response = await handler({ method, pathname: "/" }, next);
+      expect(res.status).toBe(404);
+    }
+    expect(calls).toHaveLength(0);
+  });
+
+  test("HEAD is served like GET", async () => {
+    const { next } = nextSpy();
+    const handler = makeWellKnownHandler(() => true, build, () => false);
+    const res: Response = await handler({ method: "HEAD", pathname: "/" }, next);
+    expect(res.status).toBe(200);
+  });
+
+  test("falls through when FLAIR_MCP_OAUTH is on, so @harperfast/oauth answers", async () => {
+    // Tokens for the flag-on `/mcp` surface are minted by the PLUGIN's
+    // authorization server, not flair's — advertising flair's AS there would
+    // hand a client a token `/mcp` is guaranteed to refuse.
+    const { next, calls } = nextSpy();
+    const handler = makeWellKnownHandler(() => true, build, () => true);
+    const res: any = await handler({ method: "GET", pathname: "/" }, next);
+    expect(res.status).toBe(599);
+    expect(calls).toHaveLength(1);
+  });
+
+  test("the flag-on fall-through still does not forward a non-matching sub-path", async () => {
+    const { next, calls } = nextSpy();
+    const handler = makeWellKnownHandler(() => false, build, () => true);
+    const res: Response = await handler({ method: "GET", pathname: "/Memory" }, next);
+    expect(res.status).toBe(404);
+    expect(calls).toHaveLength(0);
+  });
+
+  test("the default flag reader is the real FLAIR_MCP_OAUTH", async () => {
+    const { next, calls } = nextSpy();
+    const handler = makeWellKnownHandler(() => true, build);
+    process.env.FLAIR_MCP_OAUTH = "1";
+    expect((await handler({ method: "GET", pathname: "/" }, next)).status).toBe(599);
+    delete process.env.FLAIR_MCP_OAUTH;
+    expect((await handler({ method: "GET", pathname: "/" }, next)).status).toBe(200);
+    expect(calls).toHaveLength(1);
+  });
+});
+
+// ─── The anti-drift assertion ────────────────────────────────────────────────
+
+describe("/OAuthMetadata is an ALIAS, not a second implementation", () => {
+  test("the well-known document and the /OAuthMetadata document are byte-identical", () => {
+    process.env.FLAIR_PUBLIC_URL = BASE;
+    // resources/OAuth.ts's OAuthMetadata.get() body is exactly this call — it
+    // holds no fields of its own. The live proof that the SERVED bytes agree is
+    // test/integration/oauth-wellknown-e2e.test.ts; this pins the source.
+    const wellKnown = buildAuthorizationServerMetadata();
+    const alias = buildAuthorizationServerMetadata();
+    expect(JSON.stringify(alias)).toBe(JSON.stringify(wellKnown));
+    expect(wellKnown.issuer).toBe(BASE);
+  });
+
+  test("the protected-resource document points back at the authorization-server path", () => {
+    // The two constants must be the ones RFC 8414 / RFC 9728 define, or a
+    // spec-compliant client probes a path we do not serve.
+    expect(AS_METADATA_PATH).toBe("/.well-known/oauth-authorization-server");
+    expect(PRM_PATH).toBe("/.well-known/oauth-protected-resource");
+  });
+
+  test("the PRM path a withMCPAuth challenge points at is one this module serves", () => {
+    // @harperfast/oauth builds its 401 challenge as
+    //   Bearer resource_metadata="<origin><PRM_PATH><resource-path>"
+    // (dist/lib/mcp/wellKnown.js protectedResourceMetadataUrl). With our
+    // resource at <origin>/mcp that is <origin>/.well-known/oauth-protected-resource/mcp.
+    // Verified live: see the challenge assertion in the e2e file.
+    const resourcePath = new URL(mcpResourceUri(BASE)).pathname;
+    const challengeUrl = `${BASE}${PRM_PATH}${resourcePath}`;
+    const relative = challengeUrl.slice(`${BASE}${PRM_PATH}`.length) || "/";
+    expect(prmPathMatches(relative, BASE)).toBe(true);
+  });
+});


### PR DESCRIPTION
Refs #1000 — items 2 and 3. Item 1 (the loopback issuer) shipped separately and is not touched here.

A remote MCP client could not discover a Flair instance. We published a correct authorization-server document at `/OAuthMetadata` — a path nothing in the ecosystem probes — and 404'd at both paths everything probes.

## What changed

**`/.well-known/oauth-authorization-server` (RFC 8414)** and **`/.well-known/oauth-protected-resource` (RFC 9728, which the MCP authorization specification makes a MUST)** are now served, unauthenticated, with `Access-Control-Allow-Origin: *` so browser-based clients can read them.

The protected-resource document is also served at the **RFC 9728 §3.1 path-appended URL** `/.well-known/oauth-protected-resource/mcp`. That is the form MCP clients construct by inserting the resource's path component, and the form the `/mcp` surface's own 401 challenge points at. Serving only the bare path looks right in a browser and 404s for the client that matters.

Both documents, and `/OAuthMetadata`, derive every URL from one function in `resources/oauth-discovery.ts`. Issuer derivation itself is unchanged.

## `/OAuthMetadata`: alias, not independent

**Alias.** `OAuthMetadata.get()` is now one line delegating to the same builder the well-known path calls. It keeps its path because that is what shipped, what `docs/auth.md` documented, and what deployed callers use — and it costs a single line to keep.

The argument for keeping it independent would be that the two documents might legitimately diverge. They cannot: RFC 8414 defines exactly one authorization-server metadata document per issuer, and we have one authorization server. Two handlers that *could* diverge is the failure mode — the drift shows up months later as a client that authorizes against one document and is rejected by the server described in the other. After this change there is no code path that produces one document without producing the other, and the e2e test compares the two **byte-for-byte over the wire**, not in the builder, so a future re-implementation of either fails CI.

## The Bearer challenge: scoped to `/mcp`, and it was already there

**Not applied to Flair's REST surface. That is a decision, not an omission, and the tests assert it.**

The observation in the issue is right — a `Basic` challenge tells an MCP client nothing. But `Bearer` on `/Memory` would be *false*, and a false challenge is worse than an unhelpful one because it misdirects instead of refusing:

- **A bearer token cannot reach a Flair resource at all.** Harper's own auth layer claims every `Bearer ...` header and validates it as a Harper *operation* token, so `Authorization: Bearer <anything>` answers `401 {"error":"invalid token"}` before any Flair code runs. Measured against a live instance, and asserted in the e2e file.
- **There is no token that would work anyway.** `/OAuthToken` mints opaque `flair_at_...` values and nothing under `resources/` ever validates one.
- So a client that believed a `Bearer resource_metadata=...` challenge on `/Memory` would fetch the metadata, complete the flow, present the token, and land on exactly the same 401 with no recovery. RFC 7235 §4.1 is explicit that a challenge advertises schemes usable *at that resource*.

It would also mean rewriting headers on every 401 in the instance. Harper's auth layer owns that header for every 401 raised at or below it (`set`, not `append`). Flair's middleware is registered ahead of it and *could* override on the way out — verified by `/Admin` keeping its own `Basic realm="Flair Admin"` — but only by awaiting and inspecting every response on the hottest path in the chain, for every existing Basic and Ed25519 caller, to publish a scheme none of them can use.

**The challenge belongs on the one surface that does take a bearer token, and it is already correct there.** With `FLAIR_MCP_OAUTH` on, `POST /mcp` answers:

```
401 WWW-Authenticate: Bearer resource_metadata="<issuer>/.well-known/oauth-protected-resource/mcp"
```

Measured live on this branch. **Until this PR that URL 404'd** — which is the real sense in which item 3 was broken end to end: the challenge existed and pointed at nothing. It now resolves to a document we serve. Nothing about `FLAIR_MCP_OAUTH` or its default changed; `/mcp` is still absent unless an operator turns it on, and the e2e asserts that too.

## Deference when the MCP-OAuth surface is on

`@harperfast/oauth` serves these same two paths when an operator declares it as a component. Tokens for the flag-on `/mcp` surface are minted by *that* authorization server, not Flair's own — so advertising Flair's AS in that state would hand a client a token `/mcp` is guaranteed to refuse.

When `FLAIR_MCP_OAUTH` is on, these handlers therefore serve nothing and fall through, and the plugin's document wins. Making this a function of Flair's own flag keeps it deterministic: two handlers on an identical `urlPath` share one dispatch group and run in registration order, so without an explicit rule the answer would depend on where a key sat in `config.yaml`.

Named rather than papered over: **flag on with the plugin component not declared serves neither document** (404, exactly as before this change). That instance is already non-functional — `/mcp` is guarded by a verifier with no authorization server behind it.

## Two things found while doing this

- **Path confusion at a `urlPath` mount.** A `urlPath` mount gets its own dispatch chain containing neither Flair's auth-middleware nor Harper's `authentication`, and `next` sees the mount-*stripped* path. A handler that forwards an arbitrary sub-path is therefore forwarding an unauthenticated request with a rewritten path. These handlers screen first and answer 404 themselves — they never forward. Asserted for `/mcp-evil`, `/Memory` and friends at both mounts.
- **A diagnostic that would have started misdirecting.** `flair mcp enable`'s self-verify hits this exact well-known path and, before this change, read a 404 as "is `FLAIR_MCP_OAUTH` actually set?". Now that Flair answers there when the flag is off, that check would have fallen through to the CIMD branch and told the operator to go look at `clientIdMetadataDocuments.enabled` — a knob that is not the problem. It now recognises Flair's own document by its token endpoint and names the real cause.

## Testing

Both runs are `npm run build && npm run build:cli` first, so the integration lane actually comes up.

| | pass | fail | errors | tests | files |
|---|---|---|---|---|---|
| unmodified `origin/main` | 4507 | 15 | 8 | 4522 | 283 |
| this branch | **4555** | **15** | **8** | 4570 | 285 |

`+48 passing, +48 tests, +2 files` — exactly the 48 tests added here (29 unit, 18 e2e, 1 in the existing `mcp-enable` unit file). The 15 failures and 8 errors are the **same named tests** in both runs; they are pre-existing and untouched.

**Fail-before:** with only the source reverted and the new tests kept, the e2e run is `9 fail / 9 pass`. The 9 that pass are the auth positive controls — they are supposed to pass on both sides; that is what makes them a control. The new unit file cannot even resolve its import, which is its own kind of fail-before.

**Mutation check** — four breaks, each producing a targeted failure, all restored to green:

| mutation | result |
|---|---|
| drop RFC 9728 §3.1 path insertion | unit 3 fail, e2e 1 fail (the path-appended test) |
| make `/OAuthMetadata` drift by one endpoint | e2e 2 fail (both alias tests) |
| unmount the protected-resource route | e2e 4 fail |
| remove the `mcp enable` diagnostic branch | unit 1 fail |

**Positive control on the auth path.** A test that only checked the new documents would pass while breaking every current caller, so the e2e asserts, on the same live instance: Basic admin auth still reaches a protected resource (200); Ed25519 agent auth still reaches a protected resource (200); an uncredentialed request is still refused **and carries no Bearer challenge**; `/Admin` still returns its exact `Basic realm="Flair Admin"`; a `Bearer` token still cannot authorize a Flair resource; and `/mcp` is still 404.

The existing live-plugin e2e is the control for the deference rule — it stages the `@harperfast/oauth` component with the flag on and asserts the plugin's document is the one served.

`tsconfig.json` reports exactly one error, `resources/auth-middleware.ts(70,1) TS2722`, confirmed byte-identical on `origin/main`. `docs-freshness-check` runs all 7 checks and passes — none skipped.

## Not done, deliberately

- The `Basic` challenge on Flair's REST surface is unchanged, for the reasons above.
- Item 4 of the issue (making a misconfigured public instance fail loudly instead of serving a loopback issuer) is untouched and still open.
