### PR TITLE
fix: admin Endpoints table must not advertise an unmounted /mcp

### DIFF
--- a/.changelog/unreleased/fixed-admin-instance-mcp-endpoint-row.md
+++ b/.changelog/unreleased/fixed-admin-instance-mcp-endpoint-row.md
@@ -1,0 +1,12 @@
+- **The admin Instance page no longer advertises an MCP endpoint that isn't there.** The
+  Endpoints table printed `<public-url>/mcp` on every install, but that route is off by
+  default — so a default install's own dashboard pointed operators at a URL that returns
+  404, which reads as a broken install rather than a disabled feature. The row now shows
+  "Not enabled" plus the environment variable that turns the surface on, and shows the URL
+  only when the route is genuinely mounted. Nothing to do — the other rows are unchanged
+  and were already accurate.
+
+  The row renders from the state the route registration records about its own decision,
+  not from a second read of the feature flag, so the page cannot drift from what is
+  actually served. That matters because the flag alone was never sufficient: with the flag
+  on but no issuer configured, the route still does not mount.

--- a/resources/AdminInstance.ts
+++ b/resources/AdminInstance.ts
@@ -1,5 +1,6 @@
 import { Resource } from "harper";
-import { layout, htmlResponse } from "./admin-layout.js";
+import { layout, htmlResponse, esc } from "./admin-layout.js";
+import { mcpRouteState } from "./mcp-oauth.js";
 import { existsSync, readFileSync } from "node:fs";
 import { join, dirname } from "node:path";
 import { homedir } from "node:os";
@@ -103,6 +104,24 @@ export class AdminInstance extends Resource {
     const request = ctx.request ?? ctx;
     const publicUrl = resolvePublicUrl(request);
 
+    // The MCP row (flair#1001). Every other row in the Endpoints table is a
+    // route this component always registers; `/mcp` is the one that may not be
+    // there — it is default-OFF, and even with FLAIR_MCP_OAUTH on it does not
+    // mount without an issuer. This page used to print the URL unconditionally,
+    // so a default install advertised an endpoint that 404s.
+    //
+    // The state comes from the router itself (mcp-oauth.ts records the outcome
+    // of its own mount decision) rather than from a second read of the flag
+    // here — a second read is a second source of truth, which is this bug one
+    // level up. The row is kept, not dropped: a missing row tells an operator
+    // nothing, while a named status and the variable that changes it is
+    // actionable and still teaches them the surface exists.
+    const mcp = mcpRouteState();
+    const mcpCell = mcp.mounted
+      ? `<code>${publicUrl}/mcp</code>`
+      : `<span class="badge badge-gray">${esc(mcp.status)}</span>` +
+        `<div style="margin-top:4px;color:#666;font-size:0.9em">${esc(mcp.reason)}</div>`;
+
     // Try to read instance public key
     let publicKey = "—";
     const keyDir = join(homedir(), ".flair", "keys");
@@ -144,7 +163,7 @@ export class AdminInstance extends Resource {
         <h3>Endpoints</h3>
         <table style="box-shadow:none">
           <tr><td>API</td><td><code>${publicUrl}/</code></td></tr>
-          <tr><td>MCP</td><td><code>${publicUrl}/mcp</code></td></tr>
+          <tr><td>MCP</td><td>${mcpCell}</td></tr>
           <tr><td>OAuth Discovery</td><td><code>${publicUrl}/OAuthMetadata</code></td></tr>
           <tr><td>OAuth Authorize</td><td><code>${publicUrl}/OAuthAuthorize</code></td></tr>
           <tr><td>OAuth Token</td><td><code>${publicUrl}/OAuthToken</code></td></tr>

--- a/resources/mcp-oauth.ts
+++ b/resources/mcp-oauth.ts
@@ -38,8 +38,10 @@ import { mcpOAuthEnabled, mcpAuthConfig } from "./mcp-oauth-flag.js";
  * "no /mcp route" (fail-safe: the surface simply doesn't mount) rather than
  * crashing flair.
  *
- * Returns true if the route was mounted, false otherwise — the return value is
- * for tests/observability; the load-time caller ignores it.
+ * Returns true if the route was mounted, false otherwise. The load-time caller
+ * ignores the return value, but the same decision is recorded in `routeState`
+ * and readable via `mcpRouteState()` — see the doc on `McpRouteState` for why
+ * consumers must read that rather than the flag.
  */
 export interface RegisterDeps {
   /** The Harper server to register the route on (injectable for tests). */
@@ -51,6 +53,63 @@ export interface RegisterDeps {
   mcpHandler?: any;
 }
 
+/**
+ * ── The recorded mount decision (flair#1001) ────────────────────────────────
+ *
+ * Whether `/mcp` is actually being served, as decided and recorded by
+ * `registerMcpOAuthRoute` itself. Anything that wants to *describe* the surface
+ * — the admin Endpoints table is the first such consumer — reads this instead of
+ * re-reading `FLAIR_MCP_OAUTH`.
+ *
+ * That distinction is the whole point. The admin Instance page used to render a
+ * literal `<publicUrl>/mcp` row on every install, so a default install's own
+ * dashboard advertised an endpoint that answers 404 exactly like a path that does
+ * not exist. A second, independent read of the flag would not have fixed that —
+ * it would have moved the disagreement one level up, and the flag alone is not
+ * even sufficient (flag on + no issuer → the route still does not mount). So the
+ * router publishes what it did, and there is deliberately NO exported setter:
+ * `decide()` below is module-private, which makes a second writer — and therefore
+ * a second source of truth — structurally impossible rather than merely
+ * discouraged.
+ */
+export type McpRouteState =
+  | { mounted: true }
+  | {
+      mounted: false;
+      /** Short operator-facing status, e.g. an admin table cell badge. */
+      status: string;
+      /** Why it is not mounted, and what would change that. */
+      reason: string;
+    };
+
+/**
+ * Initial value: no route has been registered yet, which is literally true until
+ * `registerMcpOAuthRoute` runs — a reader between module load and registration
+ * would get a 404 from `/mcp`, so reporting "not mounted" is accurate rather
+ * than merely safe. It also stays correct for an embedder that sets
+ * FLAIR_MCP_NO_AUTOSTART and never calls the registration function.
+ */
+let routeState: McpRouteState = {
+  mounted: false,
+  status: "Not mounted",
+  reason: "MCP route registration has not run.",
+};
+
+/** Read the mount decision the router recorded. */
+export function mcpRouteState(): McpRouteState {
+  return routeState;
+}
+
+/**
+ * Record a decision and return its `mounted` value. Every `return` in
+ * `registerMcpOAuthRoute` goes through here, so a branch cannot decide the
+ * route's fate without publishing that decision.
+ */
+function decide(state: McpRouteState): boolean {
+  routeState = state;
+  return state.mounted;
+}
+
 async function defaultLoadWithMCPAuth(): Promise<(handler: any, options?: any) => any> {
   // Dynamic import so the dep is only required when the surface is enabled.
   const mod = (await import("@harperfast/oauth")) as any;
@@ -58,7 +117,14 @@ async function defaultLoadWithMCPAuth(): Promise<(handler: any, options?: any) =
 }
 
 export async function registerMcpOAuthRoute(deps: RegisterDeps = {}): Promise<boolean> {
-  if (!mcpOAuthEnabled()) return false; // OFF → no route, no import, no side effects.
+  if (!mcpOAuthEnabled()) {
+    // OFF → no route, no import, no side effects.
+    return decide({
+      mounted: false,
+      status: "Not enabled",
+      reason: "Set FLAIR_MCP_OAUTH=1 (and an issuer) to serve MCP over HTTP.",
+    });
+  }
 
   const config = mcpAuthConfig();
   if (!config) {
@@ -69,7 +135,12 @@ export async function registerMcpOAuthRoute(deps: RegisterDeps = {}): Promise<bo
       "[mcp-oauth] FLAIR_MCP_OAUTH is on but no issuer configured " +
         "(set FLAIR_MCP_ISSUER or FLAIR_PUBLIC_URL) — /mcp NOT mounted.",
     );
-    return false;
+    return decide({
+      mounted: false,
+      status: "Not mounted",
+      reason:
+        "FLAIR_MCP_OAUTH is on but no issuer is configured — set FLAIR_MCP_ISSUER (or FLAIR_PUBLIC_URL).",
+    });
   }
 
   let withMCPAuth: (handler: any, options?: any) => any;
@@ -79,12 +150,23 @@ export async function registerMcpOAuthRoute(deps: RegisterDeps = {}): Promise<bo
     console.error(
       "[mcp-oauth] @harperfast/oauth not available — /mcp NOT mounted: " + (err?.message ?? err),
     );
-    return false;
+    // The underlying error text stays in the log rather than being carried into
+    // an operator-facing string: it is arbitrary text from a dependency, and the
+    // admin page is HTML.
+    return decide({
+      mounted: false,
+      status: "Not mounted",
+      reason: "The @harperfast/oauth plugin could not be loaded — see the server log.",
+    });
   }
 
   if (typeof withMCPAuth !== "function") {
     console.error("[mcp-oauth] @harperfast/oauth has no withMCPAuth export — /mcp NOT mounted.");
-    return false;
+    return decide({
+      mounted: false,
+      status: "Not mounted",
+      reason: "The @harperfast/oauth plugin has no withMCPAuth export — see the server log.",
+    });
   }
 
   // Resolve the handler lazily (injected in tests; real module otherwise) — see
@@ -109,7 +191,7 @@ export async function registerMcpOAuthRoute(deps: RegisterDeps = {}): Promise<bo
   );
 
   console.error(`[mcp-oauth] /mcp mounted (OAuth-guarded); issuer=${config.issuer}`);
-  return true;
+  return decide({ mounted: true });
 }
 
 // Fire-and-forget at module load. Any failure is contained inside
@@ -127,6 +209,14 @@ export async function registerMcpOAuthRoute(deps: RegisterDeps = {}): Promise<bo
 // deployment.)
 if (process.env.FLAIR_MCP_NO_AUTOSTART == null) {
   void registerMcpOAuthRoute().catch((err) => {
+    // A throw escaping registerMcpOAuthRoute means the mount never happened, so
+    // record that too — otherwise mcpRouteState() would keep reporting whatever
+    // the last completed decision was.
+    decide({
+      mounted: false,
+      status: "Not mounted",
+      reason: "MCP route registration failed — see the server log.",
+    });
     console.error("[mcp-oauth] route registration failed (surface not mounted): " + (err?.message ?? err));
   });
 }

--- a/test/unit/admin-instance-endpoints.test.ts
+++ b/test/unit/admin-instance-endpoints.test.ts
@@ -1,0 +1,127 @@
+/**
+ * admin-instance-endpoints.test.ts — flair#1001: the admin Endpoints table
+ * advertised `<publicUrl>/mcp` on every install, while `/mcp` is default-OFF
+ * and 404s on a default install (indistinguishable from a path that does not
+ * exist, while a registered POST route on the same instance answers 400).
+ *
+ * These tests render the REAL `AdminInstance.get()` HTML and drive the REAL
+ * `registerMcpOAuthRoute()` to establish each state — so they cover the whole
+ * path (router decision → recorded state → rendered row) rather than a
+ * re-implementation of it. That matters here specifically: the bug being fixed
+ * IS a second, independent description of the routing decision drifting from
+ * the router, so a test that re-derives the flag would reproduce the defect one
+ * level up.
+ *
+ * BOTH states are covered. A test that only asserted the flag-off row would
+ * pass while the flag-on row rendered wrongly.
+ *
+ * harper is mocked (a superset shape matching mcp-oauth-register.test.ts) because
+ * `resources/AdminInstance.ts` extends `Resource` and its `agent-auth` import
+ * reads `databases` — importing the real `harper` outside a Harper process throws
+ * ("Unable to determine database storage path"), which is the positive control
+ * for why the mock is needed rather than an alternative to it.
+ */
+import { mock, describe, it, expect, beforeEach, afterAll } from "bun:test";
+
+// Suppress mcp-oauth.ts's load-time fire-and-forget registration — each test
+// calls registerMcpOAuthRoute() directly with injected deps.
+process.env.FLAIR_MCP_NO_AUTOSTART = "1";
+
+class NoopBase { constructor(_id?: any, _ctx?: any) {} }
+const dbStub = new Proxy({}, { get: () => new Proxy({}, { get: () => NoopBase }) });
+mock.module("harper", () => ({
+  server: { http: () => {} },
+  Resource: NoopBase,
+  databases: { flair: dbStub },
+}));
+
+const { AdminInstance } = await import("../../resources/AdminInstance.ts");
+const { registerMcpOAuthRoute } = await import("../../resources/mcp-oauth.ts");
+
+const ENV = ["FLAIR_MCP_OAUTH", "FLAIR_MCP_ISSUER", "FLAIR_PUBLIC_URL"];
+function clearEnv() { for (const k of ENV) delete process.env[k]; }
+
+/** Injected deps so registration never touches the real plugin or Harper server. */
+function makeDeps() {
+  return {
+    server: { http: (_h: any, _o: any) => {} },
+    loadWithMCPAuth: async () => (handler: any, _options: any) => handler,
+    mcpHandler: () => ({ status: 200 }),
+  };
+}
+
+/**
+ * Render the real Instance page. No FLAIR_PUBLIC_URL is set, so the public URL
+ * is derived from the Host header → `https://flair.example.com`.
+ */
+async function renderInstancePage(): Promise<string> {
+  const inst: any = new (AdminInstance as any)();
+  inst.getContext = () => ({ request: { headers: { Host: "flair.example.com" } } });
+  const res = await inst.get();
+  return await res.text();
+}
+
+const MCP_URL = "https://flair.example.com/mcp";
+
+beforeEach(clearEnv);
+// Leave the module-global route state back at "not mounted" for any later file.
+afterAll(async () => { clearEnv(); await registerMcpOAuthRoute(makeDeps()); });
+
+describe("AdminInstance Endpoints table — MCP row (flair#1001)", () => {
+  it("flag OFF (default install): no /mcp URL, row says not enabled and names the variable", async () => {
+    const mounted = await registerMcpOAuthRoute(makeDeps());
+    expect(mounted).toBe(false); // precondition: the route really is not mounted
+
+    const html = await renderInstancePage();
+    expect(html).toContain("Endpoints");
+    // The defect: a live-looking URL for a path that 404s.
+    expect(html).not.toContain(MCP_URL);
+    // Actionable instead of silent — the operator learns the surface exists.
+    expect(html).toContain("Not enabled");
+    expect(html).toContain("FLAIR_MCP_OAUTH");
+  });
+
+  it("flag ON + issuer (route mounted): the /mcp URL is shown and no disabled marker", async () => {
+    process.env.FLAIR_MCP_OAUTH = "1";
+    process.env.FLAIR_MCP_ISSUER = "https://flair.example.com";
+    const mounted = await registerMcpOAuthRoute(makeDeps());
+    expect(mounted).toBe(true); // precondition: the route really is mounted
+
+    const html = await renderInstancePage();
+    expect(html).toContain(`<code>${MCP_URL}</code>`);
+    expect(html).not.toContain("Not enabled");
+    expect(html).not.toContain("FLAIR_MCP_OAUTH");
+  });
+
+  it("flag ON but issuer unset (route NOT mounted): no /mcp URL, row names the issuer variable", async () => {
+    process.env.FLAIR_MCP_OAUTH = "1";
+    const mounted = await registerMcpOAuthRoute(makeDeps());
+    expect(mounted).toBe(false); // flag alone does not mount the route
+
+    const html = await renderInstancePage();
+    expect(html).not.toContain(MCP_URL);
+    expect(html).toContain("FLAIR_MCP_ISSUER");
+  });
+
+  it("the sibling rows are unconditional routes and render in both states", async () => {
+    // Confirmed against a default install: GET /OAuthMetadata 200,
+    // GET /OAuthAuthorize 400, POST /OAuthToken 400, GET /AdminDashboard 401 —
+    // all registered, unlike /mcp which 404s exactly like a nonexistent path.
+    const siblings = [
+      "https://flair.example.com/OAuthMetadata",
+      "https://flair.example.com/OAuthAuthorize",
+      "https://flair.example.com/OAuthToken",
+      "https://flair.example.com/AdminDashboard",
+    ];
+
+    await registerMcpOAuthRoute(makeDeps()); // flag OFF
+    const offHtml = await renderInstancePage();
+    for (const url of siblings) expect(offHtml).toContain(`<code>${url}</code>`);
+
+    process.env.FLAIR_MCP_OAUTH = "1";
+    process.env.FLAIR_MCP_ISSUER = "https://flair.example.com";
+    await registerMcpOAuthRoute(makeDeps()); // flag ON
+    const onHtml = await renderInstancePage();
+    for (const url of siblings) expect(onHtml).toContain(`<code>${url}</code>`);
+  });
+});

--- a/test/unit/mcp-oauth-register.test.ts
+++ b/test/unit/mcp-oauth-register.test.ts
@@ -40,7 +40,7 @@ mock.module("harper", () => ({
 // legitimately `await import(...)`s for real — that was the source of the
 // intermittent "35 tests failed" flake in mcp-handler.test.ts.
 
-const { registerMcpOAuthRoute } = await import("../../resources/mcp-oauth.ts");
+const { registerMcpOAuthRoute, mcpRouteState } = await import("../../resources/mcp-oauth.ts");
 
 const ENV = ["FLAIR_MCP_OAUTH", "FLAIR_MCP_ISSUER", "FLAIR_PUBLIC_URL"];
 function clearEnv() { for (const k of ENV) delete process.env[k]; }
@@ -110,5 +110,57 @@ describe("registerMcpOAuthRoute — flag-OFF no-op", () => {
       issuer: "https://flair.example.com",
       resource: "https://flair.example.com/mcp",
     });
+  });
+});
+
+/**
+ * flair#1001 — the router publishes what it decided, so consumers that describe
+ * the surface (the admin Endpoints table) never have to re-read the flag and
+ * cannot disagree with the routing decision. These assertions pin the recorded
+ * state to the same branch that produced the `mounted` return value.
+ */
+describe("mcpRouteState — the router's own record of the mount decision", () => {
+  it("flag OFF → not mounted, and the status names the flag that would enable it", async () => {
+    clearEnv();
+    await registerMcpOAuthRoute(makeDeps());
+    const state = mcpRouteState();
+    expect(state.mounted).toBe(false);
+    expect((state as any).status).toBe("Not enabled");
+    expect((state as any).reason).toContain("FLAIR_MCP_OAUTH");
+  });
+
+  it("flag ON but no issuer → still not mounted, and the reason names the issuer variable", async () => {
+    clearEnv();
+    process.env.FLAIR_MCP_OAUTH = "1";
+    await registerMcpOAuthRoute(makeDeps());
+    const state = mcpRouteState();
+    // The flag alone is not enough — this is why a consumer re-reading
+    // FLAIR_MCP_OAUTH would still advertise a /mcp that 404s.
+    expect(state.mounted).toBe(false);
+    expect((state as any).reason).toContain("FLAIR_MCP_ISSUER");
+  });
+
+  it("flag ON + issuer → mounted, matching the route that was actually registered", async () => {
+    clearEnv();
+    process.env.FLAIR_MCP_OAUTH = "1";
+    process.env.FLAIR_MCP_ISSUER = "https://flair.example.com";
+    await registerMcpOAuthRoute(makeDeps());
+    expect(mcpRouteState().mounted).toBe(true);
+    expect(httpCalls[0].options).toEqual({ urlPath: "/mcp" });
+  });
+
+  it("the recorded state always agrees with the returned mounted value", async () => {
+    for (const env of [
+      {},
+      { FLAIR_MCP_OAUTH: "1" },
+      { FLAIR_MCP_OAUTH: "1", FLAIR_MCP_ISSUER: "https://flair.example.com" },
+      { FLAIR_MCP_OAUTH: "off", FLAIR_MCP_ISSUER: "https://flair.example.com" },
+    ] as Array<Record<string, string>>) {
+      clearEnv();
+      Object.assign(process.env, env);
+      const mounted = await registerMcpOAuthRoute(makeDeps());
+      expect(mcpRouteState().mounted).toBe(mounted);
+    }
+    clearEnv();
   });
 });


### PR DESCRIPTION
## The problem

`resources/AdminInstance.ts` rendered the MCP row of the Endpoints table as a literal:

```
<tr><td>MCP</td><td><code>${publicUrl}/mcp</code></td></tr>
```

`/mcp` is gated behind `FLAIR_MCP_OAUTH`, which is default-off — when it is off,
`registerMcpOAuthRoute()` early-returns and no route is registered. So the operator-facing
page whose whole job is to say what this instance serves was asserting an endpoint that
404s on a default install.

Re-derived before changing anything, on a running default install. `/mcp` is JSON-RPC over
POST, so a GET-only probe would not have been conclusive:

```
POST /mcp             -> 404
POST /OAuthToken      -> 400   (positive control: a route that IS registered)
POST /zzz-not-a-route -> 404   (negative control: a route that is NOT registered)
```

`/mcp` is indistinguishable from a path that does not exist.

## The sibling rows are fine

Checked, because fixing MCP and leaving a sibling with the same defect would be worse than
not looking. Every other row is a `Resource` subclass exported from `resources/OAuth.ts` /
`resources/AdminDashboard.ts` and loaded unconditionally by the `jsResource` glob — no
feature flag, no early return. Behaviour on the same default install:

```
GET /OAuthMetadata  -> 200
GET /OAuthAuthorize -> 400
POST /OAuthToken    -> 400
GET /AdminDashboard -> 401
```

All registered. MCP was the only inaccurate row.

## The fix

The row is kept and marked, not dropped. A missing row tells an operator nothing; "Not
enabled — set `FLAIR_MCP_OAUTH`" is actionable and still teaches them the surface exists.

Crucially, the state is **not** a second read of the flag. `registerMcpOAuthRoute()` now
records the outcome of its own mount decision and publishes it via `mcpRouteState()`; the
admin page renders whatever the router recorded. A second, independent read of
`FLAIR_MCP_OAUTH` would have reproduced this very bug one level up — and would still have
been wrong, because the flag alone is not sufficient: with the flag on and no issuer
configured the route does not mount either. Each non-mounted branch authors its own
operator-facing status and remedy at the point it decides, so there is nothing to keep in
sync.

There is deliberately **no exported setter**. `decide()` is module-private, which makes a
second writer — and therefore a second source of truth — structurally impossible rather
than merely discouraged. Every `return` in `registerMcpOAuthRoute` goes through it, so a
branch cannot decide the route's fate without publishing that decision.

`AdminInstance.ts` now imports `mcp-oauth.js`. Both modules are already loaded by the same
`jsResource: dist/resources/*.js` glob in every process that serves the admin page, and
nothing else in `src/` or `resources/` imports `AdminInstance`, so this only changes the
order of two loads within that batch. The ordering constraint documented in `config.yaml`
is `loadEnv` before `jsResource`, which is unaffected.

## Tests

`test/unit/admin-instance-endpoints.test.ts` renders the real `AdminInstance.get()` HTML
and drives the real `registerMcpOAuthRoute()` to establish each state, so it covers the
whole path — router decision, recorded state, rendered row — rather than a
re-implementation of it. That matters here specifically: the bug is a second description of
the routing decision drifting from the router, so a test that re-derived the flag would
have the same defect.

Three states, because a test covering only the off state would pass while the on state
rendered wrongly:

- flag off → no `/mcp` URL, row says "Not enabled" and names `FLAIR_MCP_OAUTH`
- flag on + issuer → `<code><public-url>/mcp</code>` present, no disabled marker
- flag on, issuer unset → no `/mcp` URL, row names `FLAIR_MCP_ISSUER`

Plus a fourth asserting the sibling rows render in both states, and new cases in
`test/unit/mcp-oauth-register.test.ts` pinning the recorded state to the branch that
produced the `mounted` return value, including a loop asserting the two never disagree.

**Mutation check.** Restoring the unconditional `<code>${publicUrl}/mcp</code>` row: 2 of
the new tests fail, 9 pass. Restored: 11 pass. Separately, making `decide()` record a
constant instead of the branch's own decision: 5 fail, 6 pass — including the admin-page
tests, which is the coupling the fix is supposed to create. Restored: 11 pass.

Closes #1001
