### PR TITLE
fix(hook): the SessionStart hook fails quietly, and doctor detects a hook that stopped resolving (#1007)

### DIFF
--- a/.changelog/unreleased/fixed-session-start-hook-fails-quietly.md
+++ b/.changelog/unreleased/fixed-session-start-hook-fails-quietly.md
@@ -1,0 +1,15 @@
+- **The SessionStart hook now fails quietly, and `flair doctor` notices when it stops working.** The
+  hook Flair registers resolves a package binary through your Node runtime, and under a Node version
+  manager globally installed packages are per-runtime-version — so a routine, unrelated runtime
+  upgrade could orphan it. The hook then failed on *every* session, indefinitely, with a message that
+  named neither Flair nor a remedy, and it kept doing so after Flair itself was gone (#1007). The
+  registered command is now wrapped so any failure to resolve or execute produces no output and exits
+  0, on every shell tested (sh, bash, zsh, dash, ksh, fish, tcsh — the previous form was broken
+  outright in the last two). The adapter's own no-op-on-failure guarantee could not cover this: it
+  lives inside the binary that never ran. `flair doctor` now *runs* the registered command — bounded,
+  and side-effect-free via a new `FLAIR_HOOK_PROBE` mode that makes the hook answer and exit without
+  touching the network — so a hook that no longer resolves is reported with a remedy instead of
+  staying invisible. `flair doctor --fix` rewrites an older, loud hook in place, keeping its agent and
+  instance; it never rewrites a hand-edited one and never removes a hook. `flair hook status` gained an
+  **On failure** line. Agent ids and URLs are now refused rather than escaped if they contain
+  characters that are not safe in a shell command.

--- a/docs/mcp-clients.md
+++ b/docs/mcp-clients.md
@@ -109,7 +109,7 @@ Or wire it by hand — add a `SessionStart` hook to `~/.claude/settings.json`:
         "hooks": [
           {
             "type": "command",
-            "command": "FLAIR_AGENT_ID=me npx -y @tpsdev-ai/flair-mcp flair-session-start"
+            "command": "sh -c 'out=$(FLAIR_AGENT_ID=me npx -y @tpsdev-ai/flair-mcp flair-session-start 2>/dev/null) && printf %s \"$out\" || true'"
           }
         ]
       }
@@ -124,6 +124,21 @@ what the tooling recognises: `flair hook status` matches the exact unpinned
 command, so a hand-pinned hook reports `wired: false` there (while `flair
 doctor` still sees it). Pinning this line is therefore not yet supported —
 prefer `flair hook install`.
+
+The `sh -c ... || true` wrapper is not decoration. The invocation resolves a
+package binary through whatever Node runtime your shell exposes, and under a
+Node version manager globally installed packages are per-runtime-version — so
+a routine, unrelated runtime upgrade can orphan it. Without the wrapper the
+hook then fails on *every* session, forever, with an error that names neither
+Flair nor a remedy, and it keeps doing so after Flair itself is uninstalled.
+The wrapper makes any failure to resolve or execute produce no output and exit
+0: ambient memory is a decoration on your session and must never be louder
+than the thing it decorates. Success is unaffected — the hook's output is
+passed through byte-for-byte.
+
+If you already have the older, unwrapped command, `flair doctor` reports it and
+`flair doctor --fix` rewrites it in place (same agent, same instance);
+`flair hook status` shows the same under **On failure**.
 
 The hook reads Claude Code's SessionStart
 payload on stdin, calls Flair's `bootstrap` (soul + relevant memories +
@@ -141,7 +156,14 @@ It honors the same env as the MCP server (`FLAIR_AGENT_ID`, `FLAIR_URL`,
 error, or a hung daemon (past the timeout) → the hook prints `{}` and exits 0.
 Claude Code treats that as "no context to add" and starts normally. The hook
 can never block or break session startup. The injected context is clamped to
-≤10,000 characters to keep the session-start payload small.
+≤10,000 characters to keep the session-start payload small. And if the command
+cannot resolve at all — so none of that code ever runs — the wrapper above
+still yields no output and exit 0.
+
+`flair doctor` verifies the second half by actually running the registered
+command with `FLAIR_HOOK_PROBE=1`, which makes the hook print its inert output
+and exit immediately: no bootstrap, no presence write, no network. Reaching it
+is the whole answer.
 
 ### Gemini CLI
 

--- a/packages/flair-mcp/src/session-start-hook.ts
+++ b/packages/flair-mcp/src/session-start-hook.ts
@@ -27,6 +27,23 @@
  * A hard timeout (FLAIR_HOOK_TIMEOUT_MS, default 8s) wraps the bootstrap call
  * so a stalled Flair daemon can't hang session startup; on timeout we no-op.
  *
+ * That guarantee covers everything from the moment this binary starts running.
+ * It cannot cover the case where the binary never runs at all — an `npx`
+ * invocation that stops resolving after a Node runtime change (flair#1007) —
+ * because the guard would be behind the door it is meant to guard. That half
+ * is owned by the command string registered in settings.json; see
+ * buildSessionStartHookCommand in the CLI's src/doctor-client.ts.
+ *
+ * PROBE MODE (flair#1007)
+ * ----------------------
+ * `flair doctor` needs to answer "does the command registered in settings.json
+ * still resolve and execute?" — the check whose absence turned an orphaned
+ * shim into an opaque, unattributed error on every session. Setting
+ * FLAIR_HOOK_PROBE makes this binary answer that and nothing else: it prints
+ * its inert output and exits immediately, before reading stdin, constructing a
+ * client, touching the network or writing presence. Being reached at all IS
+ * the answer.
+ *
  * AUTO-PRESENCE (flair#598)
  * -------------------------
  * A session starting is the clearest "this agent is alive" signal flair-mcp
@@ -44,13 +61,15 @@
  *   FLAIR_KEY_PATH   (default ~/.flair/keys/<agent>.key via flair-client)
  *   FLAIR_HOOK_TIMEOUT_MS (default 8000; clamped 500..30000)
  *   FLAIR_PRESENCE_TIMEOUT_MS (default 3000; clamped 500..10000 — see ./presence.ts)
+ *   FLAIR_HOOK_PROBE (unset by default — see PROBE MODE above)
  *
- * USAGE — register in ~/.claude/settings.json:
+ * USAGE — register with `flair hook install`, or by hand in
+ * ~/.claude/settings.json:
  *   {
  *     "hooks": {
  *       "SessionStart": [
  *         { "hooks": [ { "type": "command",
- *           "command": "FLAIR_AGENT_ID=me npx -y @tpsdev-ai/flair-mcp flair-session-start" } ] }
+ *           "command": "sh -c 'out=$(FLAIR_AGENT_ID=me npx -y @tpsdev-ai/flair-mcp flair-session-start 2>/dev/null) && printf %s \"$out\" || true'" } ] }
  *       ]
  *     }
  *   }
@@ -94,6 +113,16 @@ interface BootstrapClient extends Partial<PresencePoster> {
     channel?: string;
     subjects?: string[];
   }): Promise<{ context?: string } | undefined>;
+}
+
+/**
+ * Probe mode (flair#1007) — see the module doc. Any non-empty value other
+ * than "0" enables it, so `FLAIR_HOOK_PROBE=1` and `FLAIR_HOOK_PROBE=true`
+ * both work and an accidentally-empty variable does not.
+ */
+export function isProbeMode(env: Record<string, string | undefined> = process.env): boolean {
+  const raw = env.FLAIR_HOOK_PROBE;
+  return typeof raw === "string" && raw !== "" && raw !== "0";
 }
 
 /** Resolve the bootstrap timeout from env, clamped to a sane range. */
@@ -234,6 +263,13 @@ function defaultClientFactory(agentId: string): BootstrapClient {
 /** Entry point. Reads stdin, runs the hook, prints the result, exits 0.
  *  Wrapped so that even an unexpected throw degrades to a no-op. */
 async function main(): Promise<void> {
+  // Probe mode short-circuits BEFORE readStdin() — reaching this line is the
+  // entire answer doctor is looking for, and a probe must cost nothing and
+  // change nothing (no stdin wait, no client, no bootstrap, no presence).
+  if (isProbeMode()) {
+    process.stdout.write(NOOP_OUTPUT);
+    return;
+  }
   let output = NOOP_OUTPUT;
   try {
     output = await runHook(await readStdin());

--- a/packages/flair-mcp/test/session-start-hook-probe.test.ts
+++ b/packages/flair-mcp/test/session-start-hook-probe.test.ts
@@ -21,12 +21,29 @@ import { isProbeMode } from "../src/session-start-hook.ts";
  */
 
 const NOOP = "{}";
-/** The hook's ENTRY POINT, spawned as its own process. Deliberately the source
- *  and not dist/: this suite's CI lane builds @tpsdev-ai/flair-client (which
- *  the hook imports by its built dist) but never builds this package, and a
- *  test that needs an artifact CI does not produce is a test that fails for
- *  the wrong reason. The property under test lives in main(), which the
- *  --noCheck TypeScript build does not transform. */
+/**
+ * The hook's ENTRY POINT, spawned as its own process — deliberately the
+ * SOURCE, not dist/.
+ *
+ * The CI lane that runs this suite (`cd packages/flair-mcp && bun test`)
+ * builds @tpsdev-ai/flair-client, because the hook imports it by its built
+ * dist — but it never builds THIS package. dist/ is nonetheless usually
+ * present, because a sibling file (mcp-node-preflight.test.ts) runs
+ * `npm run build` from its own `beforeAll` when the shim is missing. That
+ * makes dist/ an artifact of which test file bun happens to reach first, not
+ * something this lane guarantees: targeting it here failed on all four Node
+ * legs while passing locally, where a previous build had left dist/ behind.
+ *
+ * Copying that build-if-absent hook here would trade the ordering dependency
+ * for a second `tsc` invocation racing the first, to gain nothing: the
+ * property under test is the short-circuit at the top of main(), and the
+ * --noCheck build is a straight transpile of it. Whether the shipped artifact
+ * is well-formed is a different question, already asked by
+ * mcp-node-preflight.test.ts and by the pack-smoke lane.
+ *
+ * The existence assertion below is kept as a hard failure rather than a skip:
+ * if this path is ever wrong, that must be loud.
+ */
 const ENTRY = join(import.meta.dir, "..", "src", "session-start-hook.ts");
 
 const ORIGINAL_AGENT_ID = process.env.FLAIR_AGENT_ID;

--- a/packages/flair-mcp/test/session-start-hook-probe.test.ts
+++ b/packages/flair-mcp/test/session-start-hook-probe.test.ts
@@ -16,12 +16,18 @@ import { isProbeMode } from "../src/session-start-hook.ts";
  * is read or any client exists.
  *
  * The predicate is unit-tested directly; the short-circuit is tested by
- * SPAWNING the built binary, because "it returns before constructing a client"
- * is a property of main(), not of an exported function.
+ * SPAWNING the entry point as its own process, because "it returns before
+ * constructing a client" is a property of main(), not of an exported function.
  */
 
 const NOOP = "{}";
-const BUILT = join(import.meta.dir, "..", "dist", "session-start-hook.js");
+/** The hook's ENTRY POINT, spawned as its own process. Deliberately the source
+ *  and not dist/: this suite's CI lane builds @tpsdev-ai/flair-client (which
+ *  the hook imports by its built dist) but never builds this package, and a
+ *  test that needs an artifact CI does not produce is a test that fails for
+ *  the wrong reason. The property under test lives in main(), which the
+ *  --noCheck TypeScript build does not transform. */
+const ENTRY = join(import.meta.dir, "..", "src", "session-start-hook.ts");
 
 const ORIGINAL_AGENT_ID = process.env.FLAIR_AGENT_ID;
 afterEach(() => {
@@ -44,12 +50,11 @@ describe("isProbeMode", () => {
   });
 });
 
-describe("probe mode short-circuits the whole hook (built binary)", () => {
-  // The built dist/ is produced by `bun run build` in this package, which CI
-  // runs before this suite. If it is missing, FAIL — an unrun check must not
-  // look like a pass.
-  test("the built binary exists to be probed", () => {
-    expect(existsSync(BUILT)).toBe(true);
+describe("probe mode short-circuits the whole hook (spawned entry point)", () => {
+  // If the entry point is not where this file thinks it is, FAIL loudly — an
+  // unrun check must never look like a pass.
+  test("the hook entry point exists to be probed", () => {
+    expect(existsSync(ENTRY)).toBe(true);
   });
 
   test("FLAIR_HOOK_PROBE with a real identity → inert output, exit 0, and the key file never opened", () => {
@@ -77,7 +82,7 @@ describe("probe mode short-circuits the whole hook (built binary)", () => {
         FLAIR_KEY_PATH: fifo,
       };
 
-      const probed = spawnSync(process.execPath, [BUILT], {
+      const probed = spawnSync(process.execPath, [ENTRY], {
         input: "{}",
         encoding: "utf-8",
         timeout: 15_000,
@@ -87,7 +92,7 @@ describe("probe mode short-circuits the whole hook (built binary)", () => {
       expect(probed.status).toBe(0);
       expect(probed.stdout).toBe(NOOP);
 
-      const normal = spawnSync(process.execPath, [BUILT], {
+      const normal = spawnSync(process.execPath, [ENTRY], {
         input: "{}",
         encoding: "utf-8",
         timeout: 3_000,
@@ -102,7 +107,7 @@ describe("probe mode short-circuits the whole hook (built binary)", () => {
   test("without FLAIR_HOOK_PROBE the binary still no-ops safely (regression guard)", () => {
     // The positive control for the two tests above: probe mode is an ADDITION,
     // it must not have become the only path.
-    const res = spawnSync(process.execPath, [BUILT], {
+    const res = spawnSync(process.execPath, [ENTRY], {
       input: "{}",
       encoding: "utf-8",
       timeout: 20_000,

--- a/packages/flair-mcp/test/session-start-hook-probe.test.ts
+++ b/packages/flair-mcp/test/session-start-hook-probe.test.ts
@@ -1,0 +1,114 @@
+import { describe, test, expect, afterEach } from "bun:test";
+import { spawnSync } from "node:child_process";
+import { existsSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { isProbeMode } from "../src/session-start-hook.ts";
+
+/**
+ * flair#1007 — probe mode.
+ *
+ * `flair doctor` needs to answer "does the command registered in the harness
+ * settings still resolve and execute?" without the side effects of a real run
+ * (a bootstrap read and a presence write). FLAIR_HOOK_PROBE makes this binary
+ * answer that and nothing else: print the inert payload, exit 0, before stdin
+ * is read or any client exists.
+ *
+ * The predicate is unit-tested directly; the short-circuit is tested by
+ * SPAWNING the built binary, because "it returns before constructing a client"
+ * is a property of main(), not of an exported function.
+ */
+
+const NOOP = "{}";
+const BUILT = join(import.meta.dir, "..", "dist", "session-start-hook.js");
+
+const ORIGINAL_AGENT_ID = process.env.FLAIR_AGENT_ID;
+afterEach(() => {
+  if (ORIGINAL_AGENT_ID === undefined) delete process.env.FLAIR_AGENT_ID;
+  else process.env.FLAIR_AGENT_ID = ORIGINAL_AGENT_ID;
+});
+
+describe("isProbeMode", () => {
+  test("any non-empty value other than '0' enables it", () => {
+    expect(isProbeMode({ FLAIR_HOOK_PROBE: "1" })).toBe(true);
+    expect(isProbeMode({ FLAIR_HOOK_PROBE: "true" })).toBe(true);
+    expect(isProbeMode({ FLAIR_HOOK_PROBE: "yes" })).toBe(true);
+  });
+
+  test("unset, empty or '0' leaves the hook in normal mode", () => {
+    // An accidentally-empty variable must not silently disable ambient memory.
+    expect(isProbeMode({})).toBe(false);
+    expect(isProbeMode({ FLAIR_HOOK_PROBE: "" })).toBe(false);
+    expect(isProbeMode({ FLAIR_HOOK_PROBE: "0" })).toBe(false);
+  });
+});
+
+describe("probe mode short-circuits the whole hook (built binary)", () => {
+  // The built dist/ is produced by `bun run build` in this package, which CI
+  // runs before this suite. If it is missing, FAIL — an unrun check must not
+  // look like a pass.
+  test("the built binary exists to be probed", () => {
+    expect(existsSync(BUILT)).toBe(true);
+  });
+
+  test("FLAIR_HOOK_PROBE with a real identity → inert output, exit 0, and the key file never opened", () => {
+    // Asserted through a SIDE EFFECT rather than a timing margin, so this
+    // detects the short-circuit being removed rather than merely being slow.
+    //
+    // FLAIR_KEY_PATH points at a FIFO. Anything that constructs the Flair
+    // client and starts a signed request opens that path for reading, which
+    // blocks forever because nothing will ever write to it. So:
+    //   probe mode  → never opens it → prints {} and exits 0
+    //   normal mode → opens it       → never exits
+    // The second leg is the positive control: without it, the first would pass
+    // just as happily if the hook had stopped doing anything at all.
+    const dir = mkdtempSync(join(tmpdir(), "flair-hook-probe-"));
+    const fifo = join(dir, "identity.key");
+    try {
+      const made = spawnSync("mkfifo", [fifo], { encoding: "utf-8" });
+      // A missing mkfifo must FAIL, not silently skip the whole assertion.
+      expect(made.status).toBe(0);
+
+      const env = {
+        ...process.env,
+        FLAIR_AGENT_ID: "probe-test-agent",
+        FLAIR_URL: "http://127.0.0.1:1",
+        FLAIR_KEY_PATH: fifo,
+      };
+
+      const probed = spawnSync(process.execPath, [BUILT], {
+        input: "{}",
+        encoding: "utf-8",
+        timeout: 15_000,
+        env: { ...env, FLAIR_HOOK_PROBE: "1" },
+      });
+      expect(probed.signal).toBeNull();
+      expect(probed.status).toBe(0);
+      expect(probed.stdout).toBe(NOOP);
+
+      const normal = spawnSync(process.execPath, [BUILT], {
+        input: "{}",
+        encoding: "utf-8",
+        timeout: 3_000,
+        env: { ...env, FLAIR_HOOK_PROBE: "" },
+      });
+      expect(normal.status).toBeNull(); // killed at the deadline — it did open the key
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("without FLAIR_HOOK_PROBE the binary still no-ops safely (regression guard)", () => {
+    // The positive control for the two tests above: probe mode is an ADDITION,
+    // it must not have become the only path.
+    const res = spawnSync(process.execPath, [BUILT], {
+      input: "{}",
+      encoding: "utf-8",
+      timeout: 20_000,
+      env: { ...process.env, FLAIR_HOOK_PROBE: "", FLAIR_AGENT_ID: "" },
+    });
+    expect(res.status).toBe(0);
+    expect(res.stdout).toBe(NOOP);
+  });
+});

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -74,7 +74,8 @@ import {
 import {
   readClientMcpBlock,
   checkClaudeMdBootstrap,
-  checkSessionStartHook,
+  inspectSessionStartHook,
+  upgradeSessionStartHookCommand,
   fixClaudeMdBootstrap,
   fixSessionStartHook,
   applyOrReportClaudeMdBootstrap,
@@ -4679,6 +4680,13 @@ hook
     console.log(`  ${status.correctShape ? render.icons.ok : render.icons.warn} wired${status.correctShape ? "" : " (unexpected shape — was it hand-edited?)"}`);
     console.log(`     ${render.wrap(render.c.dim, "Agent:")}     ${status.agentId ?? render.wrap(render.c.dim, "(unknown — could not parse command)")}`);
     console.log(`     ${render.wrap(render.c.dim, "Flair URL:")} ${status.flairUrl ?? render.wrap(render.c.dim, "(unknown — could not parse command)")}`);
+    // flair#1007 — whether a command that stopped resolving would fail quietly
+    // or print an error on every session start.
+    if (status.silenced) {
+      console.log(`     ${render.wrap(render.c.dim, "On failure:")} silent (exit 0, no output)`);
+    } else {
+      console.log(`     ${render.icons.warn} ${render.wrap(render.c.dim, "On failure:")} prints an error on every session — run \`flair hook install\` to adopt the silent form`);
+    }
     console.log("");
   });
 
@@ -12539,9 +12547,59 @@ program
           issues++;
         }
 
-        const hook = checkSessionStartHook(homedir());
+        // flair#1007: presence was never the problem — the failing entry was
+        // perfectly well-formed. inspectSessionStartHook() additionally RUNS
+        // the registered command (bounded, side-effect-free via
+        // FLAIR_HOOK_PROBE) so doctor can tell "wired" from "wired and still
+        // works", and reports the shell-level silencing separately so an
+        // already-installed loud hook can be upgraded rather than only
+        // diagnosed.
+        const hook = inspectSessionStartHook(homedir());
         if (hook.present) {
-          console.log(`  ${render.icons.ok} SessionStart hook: flair-session-start wired in ${render.wrap(render.c.dim, hook.path)}`);
+          if (hook.execution === "broken") {
+            console.log(`  ${render.icons.error} SessionStart hook: wired in ${render.wrap(render.c.dim, hook.path)}, but its command no longer runs`);
+            console.log(`     ${render.wrap(render.c.dim, hook.detail ?? "")}`);
+            console.log(`     ${render.wrap(render.c.dim, "This usually means the Node runtime changed and the globally installed")}`);
+            console.log(`     ${render.wrap(render.c.dim, "@tpsdev-ai/flair-mcp no longer resolves for it.")}`);
+            console.log(`     ${render.wrap(render.c.dim, "Fix:")} npm install -g @tpsdev-ai/flair-mcp ${render.wrap(render.c.dim, "(reinstall for the runtime you use now)")}`);
+            console.log(`     ${render.wrap(render.c.dim, "Or, if you no longer want ambient memory:")} flair hook uninstall`);
+            issues++;
+          } else if (hook.execution === "unknown") {
+            console.log(`  ${render.icons.warn} SessionStart hook: wired in ${render.wrap(render.c.dim, hook.path)}, but could not be verified ${render.wrap(render.c.dim, `(${hook.detail ?? "no detail"})`)}`);
+          } else if (!hook.ours) {
+            console.log(`  ${render.icons.ok} SessionStart hook: wired in ${render.wrap(render.c.dim, hook.path)} ${render.wrap(render.c.dim, "(custom command — not verified, not modified)")}`);
+          } else {
+            console.log(`  ${render.icons.ok} SessionStart hook: flair-session-start wired in ${render.wrap(render.c.dim, hook.path)} ${render.wrap(render.c.dim, "and still runs")}`);
+          }
+
+          // Independent of whether it runs today: would it stay quiet if it
+          // stopped? Only offered as a repair when the command is the exact
+          // string Flair itself wrote — a hand-edited or pinned hook is the
+          // user's, and doctor reports on it rather than rewriting it.
+          if (!hook.silenced && hook.ours) {
+            console.log(`  ${render.icons.warn} SessionStart hook: a failure would print an error on every session (this command predates the silent-failure fix)`);
+            if (hook.upgradable) {
+              if (autoFix) {
+                if (dryRun) {
+                  console.log(`     ${render.wrap(render.c.dim, "Would rewrite the hook command in")} ${hook.path}`);
+                } else {
+                  const proceed = await confirmFix(`  Rewrite the Flair SessionStart hook in ${hook.path} so failures stay silent? [y/N] `);
+                  if (!proceed) {
+                    console.log(`     Skipped.`);
+                  } else {
+                    const upgrade = upgradeSessionStartHookCommand(homedir());
+                    console.log(`     ${upgrade.ok ? render.icons.ok : render.icons.warn} ${upgrade.message}`);
+                    if (upgrade.ok && upgrade.changed) fixed++;
+                  }
+                }
+              } else {
+                console.log(`     ${render.wrap(render.c.dim, "Fix:")} flair doctor --fix ${render.wrap(render.c.dim, "(rewrites the hook command in place — same agent, same instance)")}`);
+              }
+            } else {
+              console.log(`     ${render.wrap(render.c.dim, "This hook was hand-edited, so Flair will not rewrite it. To adopt the current form:")} flair hook install`);
+            }
+            issues++;
+          }
         } else {
           console.log(`  ${render.icons.error} SessionStart hook: not found in ${render.wrap(render.c.dim, hook.path)}`);
           if (autoFix) {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -12557,13 +12557,22 @@ program
         const hook = inspectSessionStartHook(homedir());
         if (hook.present) {
           if (hook.execution === "broken") {
-            console.log(`  ${render.icons.error} SessionStart hook: wired in ${render.wrap(render.c.dim, hook.path)}, but its command no longer runs`);
+            // Reported in full, with the remedy — but NOT counted as an issue,
+            // so it never flips doctor's exit code on its own. This is a
+            // verification of the environment at the moment doctor runs (a
+            // cold `npx` cache, an offline machine, a slow registry), exactly
+            // like the FLAIR_URL reachability and agent-registration
+            // verifications above, which are warnings for the same reason. A
+            // fresh, correct install on a machine that simply has not fetched
+            // the adapter yet must not be told it is broken in the exit code.
+            // The unsilenced finding below IS counted: that one is a fact
+            // about the file, true regardless of the environment.
+            console.log(`  ${render.icons.warn} SessionStart hook: wired in ${render.wrap(render.c.dim, hook.path)}, but its command did not run just now`);
             console.log(`     ${render.wrap(render.c.dim, hook.detail ?? "")}`);
-            console.log(`     ${render.wrap(render.c.dim, "This usually means the Node runtime changed and the globally installed")}`);
-            console.log(`     ${render.wrap(render.c.dim, "@tpsdev-ai/flair-mcp no longer resolves for it.")}`);
+            console.log(`     ${render.wrap(render.c.dim, "If this persists, the Node runtime probably changed and the globally")}`);
+            console.log(`     ${render.wrap(render.c.dim, "installed @tpsdev-ai/flair-mcp no longer resolves for it.")}`);
             console.log(`     ${render.wrap(render.c.dim, "Fix:")} npm install -g @tpsdev-ai/flair-mcp ${render.wrap(render.c.dim, "(reinstall for the runtime you use now)")}`);
             console.log(`     ${render.wrap(render.c.dim, "Or, if you no longer want ambient memory:")} flair hook uninstall`);
-            issues++;
           } else if (hook.execution === "unknown") {
             console.log(`  ${render.icons.warn} SessionStart hook: wired in ${render.wrap(render.c.dim, hook.path)}, but could not be verified ${render.wrap(render.c.dim, `(${hook.detail ?? "no detail"})`)}`);
           } else if (!hook.ours) {

--- a/src/doctor-client.ts
+++ b/src/doctor-client.ts
@@ -7,16 +7,20 @@
 // but no CLAUDE.md line; or no SessionStart hook) that silently no-op, with
 // no way to tell "is Flair working for my agent?" short of an incident.
 //
-// This module is pure filesystem logic (no network, no crypto) so it's fast
-// and fully unit-testable in isolation — mirrors test/unit/client-wiring.test.ts's
+// This module is filesystem logic (no network, no crypto) so it's fast and
+// fully unit-testable in isolation — mirrors test/unit/client-wiring.test.ts's
 // technique of overriding process.env.HOME to a temp dir. The two
 // network-dependent checks (reachability + agent registration) live in
-// src/cli.ts alongside authFetch/resolveKeyPath, which they reuse.
+// src/cli.ts alongside authFetch/resolveKeyPath, which they reuse. The one
+// exception to "filesystem only" is probeSessionStartHookCommand (flair#1007),
+// which spawns a bounded subprocess — it takes an injectable runner so every
+// caller in the test suite stays hermetic.
 //
 // Every read here is try/catch-wrapped: a missing or malformed config file is
 // "not present", never a thrown error — doctor must never crash or hang on a
 // broken client config.
 
+import { spawnSync } from "node:child_process";
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { clientConfigPath, type ClientId } from "./install/clients.js";
@@ -29,6 +33,139 @@ const CLAUDE_MD_BOOTSTRAP_LINE = "At the start of every session, run mcp__flair_
 // The exact substring identifying a Flair SessionStart hook command (see
 // docs/mcp-clients.md "Auto-recall on session start").
 export const SESSION_START_HOOK_MARKER = "flair-session-start";
+
+// ── the canonical SessionStart hook command (flair#1007) ───────────────────
+//
+// ONE builder, three call sites: `flair doctor --fix` (fixSessionStartHook),
+// `flair init`'s copy-paste hint (sessionStartHookHint), and `flair hook
+// install` (src/hook-install.ts's buildHookCommand, which delegates here).
+// Before #1007 each of those carried its own literal copy of the string, so a
+// change to the invocation's failure behaviour had to be made in three places
+// and could be tested in none of them.
+//
+// WHY THE INVOCATION IS WRAPPED
+// -----------------------------
+// The hook runs `npx -y @tpsdev-ai/flair-mcp flair-session-start`: it resolves
+// a package binary through whatever Node runtime the user's shell happens to
+// expose. Under a Node version manager, globally installed packages are
+// per-runtime-version, so a routine and entirely unrelated runtime upgrade
+// orphans that binary. The command then stops resolving and the harness
+// reports a hook error on EVERY session, indefinitely, in wording that names
+// neither Flair nor a remedy. It also outlives Flair itself: uninstalling the
+// CLI does not remove the hook, so the error survives the tool it exists to
+// serve (flair#1007).
+//
+// packages/flair-mcp/src/session-start-hook.ts already guarantees
+// no-op-on-any-failure — but that guarantee lives INSIDE the binary which, in
+// this failure, never runs. The guard is behind the door it is meant to guard.
+// The only layer that still exists when the binary does not is the command
+// string itself, so that is where the silence has to be enforced.
+//
+// WHY `sh -c '...'` RATHER THAN A BARE FRAGMENT
+// ---------------------------------------------
+// Claude Code runs a `type: "command"` hook as `/bin/sh -c "<command>"` — it
+// spawns with `shell: true` and never consults $SHELL (verified against the
+// 2.1.220 bundle; the settings schema's claim that `"shell": "bash"` uses your
+// $SHELL is not what the code does on POSIX). So a bare POSIX fragment would
+// in fact be enough for the one harness we support today.
+//
+// It is still wrapped, because this string is not private to that harness:
+// SUPPORTED_HARNESSES (src/hook-install.ts) is a registry meant to grow, and
+// docs/mcp-clients.md publishes this exact command for hand-wiring. Measured
+// across sh, bash, zsh, dash, ksh, fish and tcsh:
+//   - the wrapped form is uniform — stdout passed through byte-for-byte on
+//     success; empty stdout, empty stderr and exit 0 on every failure;
+//   - a bare `out=$(...) && ... || true` fragment is a SYNTAX ERROR in fish and
+//     csh/tcsh — silent on some shells, LOUDER than before on others, which is
+//     not a fix;
+//   - the unwrapped pre-#1007 command is already broken outright in csh/tcsh
+//     ("FLAIR_AGENT_ID=me: Command not found."), which the wrapper fixes.
+// The cost is one extra process at session start; the benefit is that the
+// silence is a property of the string rather than of who runs it.
+//
+// WHY STDOUT IS CAPTURED, NOT JUST STDERR DISCARDED
+// -------------------------------------------------
+// Exit code alone is not the whole surface. In the same bundle, a SessionStart
+// hook's stdout is consumed two ways EVEN AT EXIT 0:
+//   - stdout that does not start with `{` is injected into the model's context
+//     verbatim, as a `<hook> hook success: <stdout>` meta message;
+//   - stdout that starts with `{` but fails to parse/validate is reported as a
+//     hook error — at exit 0, presented as exit 1.
+// So a failing resolver that happens to print on stdout would either become
+// silently injected context or produce the exact error class this issue is
+// about, no matter what the exit code says. Capturing stdout and emitting it
+// only on success closes both; discarding stderr alone would close neither.
+
+/**
+ * Values interpolated into the hook command are constrained by a strict
+ * allow-list rather than escaped. The command is a single-quoted `sh -c`
+ * argument and correct single-quote escaping is NOT uniform across the shells
+ * above (fish and csh disagree with POSIX), so "cannot contain a quote" is
+ * enforced by shape instead of handled by quoting. This is also strictly
+ * safer than the pre-#1007 command, where an agent id containing a space or a
+ * `;` was a command injection into the user's settings file.
+ */
+const HOOK_VALUE_SAFE_RE = /^[A-Za-z0-9._:/-]+$/;
+
+export function isHookCommandValueSafe(value: string): boolean {
+  return typeof value === "string" && HOOK_VALUE_SAFE_RE.test(value);
+}
+
+/**
+ * Build the exact `command` string to register as a SessionStart hook.
+ * Throws (rather than emitting a quoted approximation) when a value cannot be
+ * represented safely — see HOOK_VALUE_SAFE_RE.
+ */
+export function buildSessionStartHookCommand(agentId: string, flairUrl?: string): string {
+  if (!isHookCommandValueSafe(agentId)) {
+    throw new Error(
+      `agent id '${agentId}' contains characters that cannot be safely written into a shell hook command (allowed: letters, digits, . _ : / -)`,
+    );
+  }
+  if (flairUrl != null && flairUrl !== "" && !isHookCommandValueSafe(flairUrl)) {
+    throw new Error(
+      `Flair URL '${flairUrl}' contains characters that cannot be safely written into a shell hook command (allowed: letters, digits, . _ : / -)`,
+    );
+  }
+  const env = flairUrl ? `FLAIR_AGENT_ID=${agentId} FLAIR_URL=${flairUrl}` : `FLAIR_AGENT_ID=${agentId}`;
+  const invocation = `${env} npx -y @tpsdev-ai/flair-mcp ${SESSION_START_HOOK_MARKER}`;
+  return `sh -c 'out=$(${invocation} 2>/dev/null) && printf %s "$out" || true'`;
+}
+
+/**
+ * Does this command absorb a failure instead of surfacing it? Checked as two
+ * independent PROPERTIES (stderr discarded, non-zero exit absorbed) rather
+ * than by string equality with what we currently emit, so a hand-rolled
+ * command that genuinely achieves both is not nagged about.
+ */
+export function hookCommandIsSilenced(command: string): boolean {
+  if (typeof command !== "string") return false;
+  const discardsStderr = command.includes("2>/dev/null") || command.includes("2>&-");
+  const absorbsFailure = /\|\|\s*(?:true|:)(?:\s|'|$)/.test(command) || /;\s*(?:true|:)\s*'?\s*$/.test(command);
+  return discardsStderr && absorbsFailure;
+}
+
+/**
+ * The EXACT unwrapped shape Flair wrote before #1007. Recognising it precisely
+ * (not "anything containing the marker") is what lets `flair doctor --fix`
+ * upgrade a hook we know we authored while never rewriting one a user placed
+ * or edited themselves.
+ */
+const LEGACY_SESSION_START_HOOK_RE =
+  /^FLAIR_AGENT_ID=([^\s'"]+)(?: FLAIR_URL=([^\s'"]+))? npx -y @tpsdev-ai\/flair-mcp flair-session-start$/;
+
+export function parseLegacySessionStartHookCommand(command: string): { agentId: string; flairUrl?: string } | null {
+  if (typeof command !== "string") return null;
+  const m = command.trim().match(LEGACY_SESSION_START_HOOK_RE);
+  if (!m) return null;
+  return { agentId: m[1]!, flairUrl: m[2] };
+}
+
+/** Does this command invoke the Flair adapter at all (pinned or not)? Only
+ *  such a command is ever probed or rewritten. */
+export function isFlairHookCommand(command: string): boolean {
+  return typeof command === "string" && command.includes("@tpsdev-ai/flair-mcp") && command.includes(SESSION_START_HOOK_MARKER);
+}
 
 // ── shared helpers ──────────────────────────────────────────────────────────
 
@@ -233,6 +370,10 @@ export function fixClaudeMdBootstrap(cwd: string): { ok: boolean; path: string; 
 export interface SessionStartHookCheckResult {
   present: boolean;
   path: string;
+  /** The registered command, when one was found. Additive since #1007 — the
+   *  hook's PRESENCE was never the problem; whether the command it names can
+   *  still execute is, and answering that needs the command itself. */
+  command?: string;
 }
 
 /**
@@ -253,7 +394,7 @@ export function checkSessionStartHook(homeDir: string): SessionStartHookCheckRes
       if (!Array.isArray(hooks)) continue;
       for (const hook of hooks) {
         if (typeof hook?.command === "string" && hook.command.includes(SESSION_START_HOOK_MARKER)) {
-          return { present: true, path };
+          return { present: true, path, command: hook.command };
         }
       }
     }
@@ -280,6 +421,13 @@ export function fixSessionStartHook(homeDir: string, agentId: string | undefined
       message: "no agent id known — pass --agent <id> (or set FLAIR_AGENT_ID) so doctor knows which agent to wire the hook to",
     };
   }
+  if (!isHookCommandValueSafe(agentId)) {
+    return {
+      ok: false,
+      path,
+      message: `agent id '${agentId}' contains characters that cannot be safely written into a shell hook command (allowed: letters, digits, . _ : / -)`,
+    };
+  }
   try {
     let config: any = {};
     const raw = readTextFile(path);
@@ -301,7 +449,7 @@ export function fixSessionStartHook(homeDir: string, agentId: string | undefined
       hooks: [
         {
           type: "command",
-          command: `FLAIR_AGENT_ID=${agentId} npx -y @tpsdev-ai/flair-mcp flair-session-start`,
+          command: buildSessionStartHookCommand(agentId),
         },
       ],
     });
@@ -312,6 +460,243 @@ export function fixSessionStartHook(homeDir: string, agentId: string | undefined
   } catch (err: unknown) {
     const reason = err instanceof Error ? err.message : String(err);
     return { ok: false, path, message: `could not write ${path}: ${reason}` };
+  }
+}
+
+// ── check 4b: does the registered hook command still execute? (flair#1007) ──
+//
+// Presence was never the problem. In the reported failure the settings entry
+// was perfectly well-formed — what changed was the environment around it, and
+// nothing checked that the command it names can still run. These three
+// functions are that check, split so the decision logic stays hermetic:
+//
+//   probeSessionStartHookCommand — spawns the command (injectable runner)
+//   classifyHookProbe            — pure: probe outcome -> verdict
+//   upgradeSessionStartHookCommand — the ONE repair doctor is willing to make
+//
+// The probe runs the command with FLAIR_HOOK_PROBE=1, which
+// packages/flair-mcp/src/session-start-hook.ts honours by printing its inert
+// output and exiting immediately — no network, no presence write, no memory
+// read. An adapter too old to know that variable still answers the only
+// question being asked (it prints SOMETHING and exits 0), it just does a real
+// bootstrap first, so the two short timeouts below bound that case too.
+//
+// The verdict keys off a property the adapter guarantees and a broken
+// resolution cannot fake: the adapter ALWAYS writes a non-empty payload (at
+// minimum its inert `{}`) and always exits 0. So "exit 0 with empty stdout" is
+// precisely the signature of the silenced wrapper swallowing a command that
+// never ran — which is why the wrapper does not make this failure less
+// diagnosable, it makes it MORE so.
+
+/** Bounded outcome of running a registered hook command once. */
+export interface HookProbeOutcome {
+  exitCode: number | null;
+  stdout: string;
+  stderr: string;
+  timedOut: boolean;
+  /** Set when the probe process could not be started at all. */
+  spawnError: string | null;
+}
+
+export type HookExecutionState = "runs" | "broken" | "unknown";
+
+export interface HookProbeVerdict {
+  execution: HookExecutionState;
+  detail?: string;
+}
+
+/** Injectable so unit tests never spawn a shell. */
+export type HookProbeRunner = (command: string, timeoutMs: number) => HookProbeOutcome;
+
+/** Default probe budget. Generous: a cold `npx` may have to reach the registry
+ *  before it can answer, and a slow answer must never be reported as a broken
+ *  hook — that is what the "unknown" verdict is for. */
+export const HOOK_PROBE_TIMEOUT_MS = 20_000;
+
+/** Package-manager chatter that is never the reason a hook failed. The harness
+ *  itself reports the FIRST stderr line, which on a modern npm is one of these
+ *  — so doctor deliberately does better than repeating the symptom back. */
+const NOISE_LINE_RE = /^(?:npm|yarn|pnpm|bun)\s+(?:notice|warn|info|http|verb)\b/i;
+
+/** The most informative single line of a failed probe's output. */
+export function evidenceLine(s: string, max = 200): string {
+  const lines = (s || "").split("\n").map((l) => l.trim()).filter((l) => l.length > 0);
+  const line = lines.find((l) => !NOISE_LINE_RE.test(l)) ?? lines[0] ?? "";
+  return line.length > max ? `${line.slice(0, max - 1)}…` : line;
+}
+
+const defaultProbeRunner: HookProbeRunner = (command, timeoutMs) => {
+  // `/bin/sh -c` is not a guess: it is exactly how Claude Code runs a
+  // `type: "command"` hook (spawn with `shell: true`, $SHELL never consulted).
+  // Probing through any other shell would answer a question the user never
+  // asked.
+  const res = spawnSync("/bin/sh", ["-c", command], {
+    input: "",
+    encoding: "utf-8",
+    timeout: timeoutMs,
+    env: {
+      ...process.env,
+      // Tell a #1007-or-later adapter to answer without side effects.
+      FLAIR_HOOK_PROBE: "1",
+      // Bound an OLDER adapter, which will do a real bootstrap + presence
+      // heartbeat because it has never heard of FLAIR_HOOK_PROBE.
+      FLAIR_HOOK_TIMEOUT_MS: "1500",
+      FLAIR_PRESENCE_TIMEOUT_MS: "500",
+    },
+  });
+  const timedOut = (res as { signal?: string | null }).signal === "SIGTERM" && res.status === null;
+  return {
+    exitCode: res.status,
+    stdout: res.stdout ?? "",
+    stderr: res.stderr ?? "",
+    timedOut,
+    spawnError: res.error && !timedOut ? res.error.message : null,
+  };
+};
+
+/**
+ * Run a registered hook command once, bounded, with probe-mode env set.
+ * Only ever called for commands isFlairHookCommand() recognises — doctor does
+ * not execute a stranger's hook to find out what it does.
+ */
+export function probeSessionStartHookCommand(
+  command: string,
+  opts: { timeoutMs?: number; runner?: HookProbeRunner } = {},
+): HookProbeOutcome {
+  const timeoutMs = opts.timeoutMs ?? HOOK_PROBE_TIMEOUT_MS;
+  const runner = opts.runner ?? defaultProbeRunner;
+  try {
+    return runner(command, timeoutMs);
+  } catch (err: unknown) {
+    const reason = err instanceof Error ? err.message : String(err);
+    return { exitCode: null, stdout: "", stderr: "", timedOut: false, spawnError: reason };
+  }
+}
+
+/** Pure: probe outcome -> verdict. See the section doc for why "exit 0, no
+ *  output" is a definite failure rather than an ambiguous one. */
+export function classifyHookProbe(outcome: HookProbeOutcome): HookProbeVerdict {
+  if (outcome.timedOut) {
+    return { execution: "unknown", detail: "the command did not answer in time" };
+  }
+  if (outcome.spawnError) {
+    return { execution: "unknown", detail: `could not run the command (${outcome.spawnError})` };
+  }
+  if (outcome.exitCode !== 0) {
+    const evidence = evidenceLine(outcome.stderr) || evidenceLine(outcome.stdout);
+    return {
+      execution: "broken",
+      detail: evidence ? `exited ${outcome.exitCode}: ${evidence}` : `exited ${outcome.exitCode}`,
+    };
+  }
+  if (!outcome.stdout.trim()) {
+    return {
+      execution: "broken",
+      detail: "the command produced no output — the flair-session-start binary never ran",
+    };
+  }
+  return { execution: "runs" };
+}
+
+/** What doctor knows about the registered hook, beyond "is it there". */
+export interface SessionStartHookCommandReport {
+  path: string;
+  present: boolean;
+  command?: string;
+  /** Does this command invoke the Flair adapter (so probing/repair applies)? */
+  ours: boolean;
+  /** Does it absorb its own failures? */
+  silenced: boolean;
+  /** Is it the exact unwrapped shape Flair itself wrote before #1007, and so
+   *  safe for `--fix` to rewrite in place? */
+  upgradable: boolean;
+  execution: HookExecutionState | null;
+  detail?: string;
+}
+
+/**
+ * Full report for the registered hook: presence (as before), plus whether its
+ * command still executes and whether it would fail quietly if it stopped.
+ * `probe` is injectable and defaults to the real bounded spawn; pass a stub
+ * (or null via `{ probe: false }`) to keep a caller hermetic.
+ */
+export function inspectSessionStartHook(
+  homeDir: string,
+  opts: { probe?: HookProbeRunner | false; timeoutMs?: number } = {},
+): SessionStartHookCommandReport {
+  const found = checkSessionStartHook(homeDir);
+  if (!found.present || !found.command) {
+    return { path: found.path, present: false, ours: false, silenced: false, upgradable: false, execution: null };
+  }
+  const command = found.command;
+  const ours = isFlairHookCommand(command);
+  const silenced = hookCommandIsSilenced(command);
+  const upgradable = parseLegacySessionStartHookCommand(command) !== null;
+
+  if (!ours || opts.probe === false) {
+    return { path: found.path, present: true, command, ours, silenced, upgradable, execution: null };
+  }
+
+  const outcome = probeSessionStartHookCommand(command, {
+    timeoutMs: opts.timeoutMs,
+    runner: opts.probe || undefined,
+  });
+  const verdict = classifyHookProbe(outcome);
+  return { path: found.path, present: true, command, ours, silenced, upgradable, execution: verdict.execution, detail: verdict.detail };
+}
+
+/**
+ * Rewrite an existing Flair-authored hook command to the current canonical
+ * form, in place, preserving the agent id and URL the entry already carries —
+ * so this never needs --agent and never re-points a hook at a different agent.
+ *
+ * Deliberately narrow: it refuses unless the registered command is the EXACT
+ * unwrapped string Flair used to write. A hook the user hand-wrote or pinned
+ * is theirs; doctor reports on it and leaves it alone. And it never REMOVES a
+ * hook — an unresolvable command is an environment that changed, not a
+ * decision to un-wire ambient memory, and `flair hook uninstall` is the
+ * command for that when the user does decide.
+ */
+export function upgradeSessionStartHookCommand(homeDir: string): { ok: boolean; path: string; message: string; changed: boolean } {
+  const path = join(homeDir, ".claude", "settings.json");
+  try {
+    const raw = readTextFile(path);
+    if (!raw || !raw.trim()) return { ok: false, path, changed: false, message: `no ${path} to update` };
+    const config = JSON.parse(raw);
+    const groups = config?.hooks?.SessionStart;
+    if (!Array.isArray(groups)) return { ok: false, path, changed: false, message: `no SessionStart hooks in ${path}` };
+
+    for (const group of groups) {
+      const hooks = group?.hooks;
+      if (!Array.isArray(hooks)) continue;
+      for (const hook of hooks) {
+        if (typeof hook?.command !== "string" || !hook.command.includes(SESSION_START_HOOK_MARKER)) continue;
+        // Already absorbing its own failures — nothing to repair, whether we
+        // wrote it or the user did. Checked BEFORE the legacy match so a second
+        // run is a clean no-op rather than "that isn't the command we wrote".
+        if (hookCommandIsSilenced(hook.command)) {
+          return { ok: true, path, changed: false, message: `SessionStart hook in ${path} is already current` };
+        }
+        const legacy = parseLegacySessionStartHookCommand(hook.command);
+        if (!legacy) {
+          return {
+            ok: false,
+            path,
+            changed: false,
+            message: `the SessionStart hook in ${path} is not the command Flair wrote — leaving it untouched`,
+          };
+        }
+        const next = buildSessionStartHookCommand(legacy.agentId, legacy.flairUrl);
+        if (next === hook.command) return { ok: true, path, changed: false, message: `SessionStart hook in ${path} is already current` };
+        hook.command = next;
+        writeFileSync(path, JSON.stringify(config, null, 2) + "\n");
+        return { ok: true, path, changed: true, message: `rewrote the SessionStart hook in ${path} so a failure to resolve stays silent` };
+      }
+    }
+    return { ok: false, path, changed: false, message: `no Flair SessionStart hook found in ${path}` };
+  } catch (err: unknown) {
+    const reason = err instanceof Error ? err.message : String(err);
+    return { ok: false, path, changed: false, message: `could not update ${path}: ${reason}` };
   }
 }
 
@@ -383,7 +768,9 @@ function sessionStartHookHint(agentId: string, path: string): string {
           hooks: [
             {
               type: "command",
-              command: `FLAIR_AGENT_ID=${agentId} npx -y @tpsdev-ai/flair-mcp flair-session-start`,
+              command: isHookCommandValueSafe(agentId)
+                ? buildSessionStartHookCommand(agentId)
+                : buildSessionStartHookCommand("me"),
             },
           ],
         },

--- a/src/hook-install.ts
+++ b/src/hook-install.ts
@@ -41,15 +41,26 @@
 //      FlairClient's plain global `fetch`, no rejectUnauthorized/NODE_TLS_*
 //      bypass anywhere — test/unit/hook-install.test.ts asserts that
 //      statically).
-//   5. Silent-fast degradation — also owned by session-start-hook.ts (hard
-//      timeout, no-op-on-any-failure); this module only writes the pointer
-//      to it.
+//   5. Silent-fast degradation — SPLIT, deliberately, since flair#1007.
+//      session-start-hook.ts owns it once the binary is running (hard
+//      timeout, no-op-on-any-failure). It cannot own the case where the
+//      binary never runs at all — an orphaned global install after a Node
+//      runtime change — because in that case its guard is behind the door it
+//      is meant to guard. That half is owned by the command string this
+//      module writes, which is built by doctor-client.ts's
+//      buildSessionStartHookCommand (see its section doc for the shell
+//      analysis and why the wrapper is `sh -c`, not a bare fragment).
 //   6. Size-budgeted payload — also owned by session-start-hook.ts, which
 //      reuses bootstrap's own maxTokens machinery.
 
 import { copyFileSync, existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { dirname, join } from "node:path";
-import { SESSION_START_HOOK_MARKER } from "./doctor-client.js";
+import {
+  SESSION_START_HOOK_MARKER,
+  buildSessionStartHookCommand,
+  hookCommandIsSilenced,
+  isHookCommandValueSafe,
+} from "./doctor-client.js";
 
 // ── harness registry ────────────────────────────────────────────────────────
 
@@ -86,9 +97,16 @@ export function hookBackupPath(settingsPath: string): string {
 /** The exact `command` string written into the SessionStart hook entry.
  *  Always carries both FLAIR_AGENT_ID and FLAIR_URL (see module doc above)
  *  and always contains SESSION_START_HOOK_MARKER verbatim, so doctor's
- *  existing checkSessionStartHook recognizes it unchanged. */
+ *  existing checkSessionStartHook recognizes it unchanged.
+ *
+ *  Since flair#1007 this is a thin wrapper over doctor-client.ts's
+ *  buildSessionStartHookCommand — ONE builder for every path that writes this
+ *  string (`flair hook install`, `flair doctor --fix`, `flair init`'s hint),
+ *  so the invocation's failure behaviour is defined and tested in one place
+ *  instead of drifting across three literals. Throws when agentId/flairUrl
+ *  cannot be represented safely; installHook() checks first and reports. */
 export function buildHookCommand(agentId: string, flairUrl: string): string {
-  return `FLAIR_AGENT_ID=${agentId} FLAIR_URL=${flairUrl} npx -y @tpsdev-ai/flair-mcp ${SESSION_START_HOOK_MARKER}`;
+  return buildSessionStartHookCommand(agentId, flairUrl);
 }
 
 /** Best-effort recovery of the agentId/flairUrl a previously-wired hook
@@ -267,6 +285,20 @@ export function installHook(opts: InstallHookOptions): HookMutationResult {
   const dryRun = !!opts.dryRun;
   const path = hookSettingsPath(homeDir, harness);
 
+  // The command is a single-quoted shell argument (flair#1007) and quoting
+  // rules are not uniform across the shells a harness might use, so unsafe
+  // values are REFUSED rather than escaped — checked before anything is
+  // backed up or written, so a bad input never half-mutates the file.
+  for (const [label, value] of [["agent id", agentId], ["Flair URL", flairUrl]] as const) {
+    if (!isHookCommandValueSafe(value)) {
+      return {
+        ok: false, path, harness, dryRun,
+        message: `${label} '${value}' contains characters that cannot be safely written into a shell hook command (allowed: letters, digits, . _ : / -) — refusing to write it`,
+        backupPath: null, delta: null,
+      };
+    }
+  }
+
   if (dryRun) {
     const read = readSettingsFile(path);
     if (read.parseError) {
@@ -404,6 +436,9 @@ export interface HookStatusResult {
    *  just a loose marker substring match (a hand-edited/partial entry still
    *  counts as `wired` for doctor-compat purposes but not `correctShape`). */
   correctShape: boolean;
+  /** Does the wired command absorb its own failures, or would a command that
+   *  stopped resolving print an error on every session start (flair#1007)? */
+  silenced: boolean;
   agentId?: string;
   flairUrl?: string;
   command?: string;
@@ -416,18 +451,22 @@ export function hookStatus(homeDir: string, harness: Harness): HookStatusResult 
   const path = hookSettingsPath(homeDir, harness);
   const read = readSettingsFile(path);
   if (read.parseError) {
-    return { harness, path, wired: false, correctShape: false, parseError: read.parseError };
+    return { harness, path, wired: false, correctShape: false, silenced: false, parseError: read.parseError };
   }
 
   const config = read.parsed ?? {};
   const existing = findHookEntry(config);
   if (!existing) {
-    return { harness, path, wired: false, correctShape: false, parseError: null };
+    return { harness, path, wired: false, correctShape: false, silenced: false, parseError: null };
   }
 
   const hookEntry = config.hooks.SessionStart[existing.groupIndex].hooks[existing.hookIndex];
   const command: string = typeof hookEntry?.command === "string" ? hookEntry.command : "";
   const correctShape = hookEntry?.type === "command" && command.includes(`npx -y @tpsdev-ai/flair-mcp ${SESSION_START_HOOK_MARKER}`);
   const env = parseHookCommandEnv(command);
-  return { harness, path, wired: true, correctShape, agentId: env.agentId, flairUrl: env.flairUrl, command, parseError: null };
+  return {
+    harness, path, wired: true, correctShape,
+    silenced: hookCommandIsSilenced(command),
+    agentId: env.agentId, flairUrl: env.flairUrl, command, parseError: null,
+  };
 }

--- a/test/unit/doctor-session-start-hook-probe.test.ts
+++ b/test/unit/doctor-session-start-hook-probe.test.ts
@@ -1,0 +1,333 @@
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import { chmodSync, mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  SESSION_START_HOOK_MARKER,
+  buildSessionStartHookCommand,
+  checkSessionStartHook,
+  classifyHookProbe,
+  fixSessionStartHook,
+  hookCommandIsSilenced,
+  inspectSessionStartHook,
+  upgradeSessionStartHookCommand,
+  type HookProbeOutcome,
+} from "../../src/doctor-client.ts";
+
+/**
+ * flair#1007 — `flair doctor` must detect a registered hook whose command no
+ * longer resolves.
+ *
+ * The entry that broke a real machine was perfectly well-formed; doctor's
+ * pre-#1007 check (is the hook PRESENT?) passed on it every time. The check
+ * that was missing is whether the command it names can still execute — so
+ * these tests cover the pure classification AND a real end-to-end probe under
+ * a PATH where the command genuinely cannot resolve.
+ *
+ * Never touches the real ~/.claude/settings.json: every case gets a fresh temp
+ * dir standing in for HOME, mirroring doctor-client.test.ts.
+ */
+
+const LEGACY_COMMAND = `FLAIR_AGENT_ID=me npx -y @tpsdev-ai/flair-mcp ${SESSION_START_HOOK_MARKER}`;
+const LEGACY_COMMAND_WITH_URL = `FLAIR_AGENT_ID=me FLAIR_URL=http://127.0.0.1:19926 npx -y @tpsdev-ai/flair-mcp ${SESSION_START_HOOK_MARKER}`;
+
+let isoHome: string;
+
+function settingsPath(): string {
+  return join(isoHome, ".claude", "settings.json");
+}
+
+function writeSettings(config: unknown): void {
+  mkdirSync(join(isoHome, ".claude"), { recursive: true });
+  writeFileSync(settingsPath(), JSON.stringify(config, null, 2) + "\n");
+}
+
+function writeHook(command: string): void {
+  writeSettings({ hooks: { SessionStart: [{ hooks: [{ type: "command", command }] }] } });
+}
+
+function readHookCommands(): string[] {
+  const config = JSON.parse(readFileSync(settingsPath(), "utf-8"));
+  return (config.hooks?.SessionStart ?? []).flatMap((g: any) => (g.hooks ?? []).map((h: any) => h.command));
+}
+
+function outcome(partial: Partial<HookProbeOutcome>): HookProbeOutcome {
+  return { exitCode: 0, stdout: "", stderr: "", timedOut: false, spawnError: null, ...partial };
+}
+
+beforeEach(() => {
+  isoHome = mkdtempSync(join(tmpdir(), "flair-hook-probe-home-"));
+});
+
+afterEach(() => {
+  rmSync(isoHome, { recursive: true, force: true });
+});
+
+describe("checkSessionStartHook now returns the command", () => {
+  it("hands back the registered command so it can be verified, not just counted", () => {
+    writeHook(LEGACY_COMMAND);
+    const res = checkSessionStartHook(isoHome);
+    expect(res.present).toBe(true);
+    expect(res.command).toBe(LEGACY_COMMAND);
+  });
+
+  it("no command when nothing is wired", () => {
+    expect(checkSessionStartHook(isoHome).command).toBeUndefined();
+  });
+});
+
+describe("classifyHookProbe", () => {
+  it("non-zero exit is broken, and carries the first stderr line as evidence", () => {
+    const v = classifyHookProbe(outcome({ exitCode: 1, stderr: "mise ERROR No version is set for shim: flair-session-start\n" }));
+    expect(v.execution).toBe("broken");
+    expect(v.detail).toContain("mise ERROR No version is set for shim");
+  });
+
+  it("skips package-manager chatter when picking the evidence line", () => {
+    // The harness reports the FIRST stderr line, which on a modern npm is a
+    // notice rather than the failure. Measured on a real machine, the stderr
+    // of a broken invocation began:
+    //   npm notice run @tpsdev-ai/flair@0.33.0 npx
+    //   npm notice run 'flair-mcp' flair-session-start
+    //   sh: flair-mcp: command not found
+    // Repeating line 1 back to the user would reproduce the exact defect this
+    // issue is about: a message that names neither the cause nor a remedy.
+    const v = classifyHookProbe(
+      outcome({
+        exitCode: 127,
+        stderr: "npm notice run @tpsdev-ai/flair@0.33.0 npx\nnpm notice run 'flair-mcp' flair-session-start\nsh: flair-mcp: command not found\n",
+      }),
+    );
+    expect(v.execution).toBe("broken");
+    expect(v.detail).toContain("flair-mcp: command not found");
+    expect(v.detail).not.toContain("npm notice");
+  });
+
+  it("falls back to the first line when every line is chatter", () => {
+    const v = classifyHookProbe(outcome({ exitCode: 1, stderr: "npm warn something\nnpm notice else\n" }));
+    expect(v.detail).toContain("npm warn something");
+  });
+
+  it("exit 0 with NO output is broken — that is the silenced wrapper swallowing a command that never ran", () => {
+    const v = classifyHookProbe(outcome({ exitCode: 0, stdout: "" }));
+    expect(v.execution).toBe("broken");
+    expect(v.detail).toContain("never ran");
+  });
+
+  it("exit 0 with output is a working hook", () => {
+    expect(classifyHookProbe(outcome({ exitCode: 0, stdout: "{}" })).execution).toBe("runs");
+  });
+
+  it("a timeout is UNKNOWN, never broken — a slow npx must not be reported as a broken hook", () => {
+    expect(classifyHookProbe(outcome({ timedOut: true, exitCode: null })).execution).toBe("unknown");
+  });
+
+  it("a probe that could not be spawned is unknown", () => {
+    expect(classifyHookProbe(outcome({ spawnError: "EACCES", exitCode: null })).execution).toBe("unknown");
+  });
+});
+
+describe("inspectSessionStartHook (injected probe)", () => {
+  const brokenRunner = () => outcome({ exitCode: 127, stderr: "sh: npx: command not found" });
+  const workingRunner = () => outcome({ exitCode: 0, stdout: "{}" });
+
+  it("reports a wired-but-unresolvable hook as broken", () => {
+    writeHook(buildSessionStartHookCommand("me"));
+    const res = inspectSessionStartHook(isoHome, { probe: brokenRunner });
+    expect(res.present).toBe(true);
+    expect(res.ours).toBe(true);
+    expect(res.execution).toBe("broken");
+  });
+
+  it("reports the legacy command as ours, upgradable and NOT silenced", () => {
+    writeHook(LEGACY_COMMAND);
+    const res = inspectSessionStartHook(isoHome, { probe: workingRunner });
+    expect(res.execution).toBe("runs");
+    expect(res.silenced).toBe(false);
+    expect(res.upgradable).toBe(true);
+  });
+
+  it("reports the current command as silenced and not upgradable (nothing to do)", () => {
+    writeHook(buildSessionStartHookCommand("me", "http://127.0.0.1:19926"));
+    const res = inspectSessionStartHook(isoHome, { probe: workingRunner });
+    expect(res.execution).toBe("runs");
+    expect(res.silenced).toBe(true);
+    expect(res.upgradable).toBe(false);
+  });
+
+  it("never runs a command that is not ours", () => {
+    // A hook carrying the marker but not our invocation belongs to the user.
+    writeHook(`my-own-${SESSION_START_HOOK_MARKER}-script.sh`);
+    let called = false;
+    const res = inspectSessionStartHook(isoHome, {
+      probe: () => {
+        called = true;
+        return workingRunner();
+      },
+    });
+    expect(called).toBe(false);
+    expect(res.present).toBe(true);
+    expect(res.ours).toBe(false);
+    expect(res.execution).toBeNull();
+  });
+
+  it("absent hook is reported absent and never probed", () => {
+    const res = inspectSessionStartHook(isoHome, { probe: () => { throw new Error("must not probe"); } });
+    expect(res.present).toBe(false);
+    expect(res.execution).toBeNull();
+  });
+});
+
+describe("inspectSessionStartHook — REAL probe against a command that cannot resolve", () => {
+  // This is the defect end to end: a well-formed settings entry whose command
+  // stopped resolving. Simulated by a PATH carrying `sh` and nothing else, so
+  // "npx is not resolvable" is true by construction rather than by hoping the
+  // ambient PATH lacks it. No global install is performed or required.
+  let binDir: string;
+  let originalPath: string | undefined;
+
+  beforeEach(() => {
+    binDir = mkdtempSync(join(tmpdir(), "flair-hook-probe-bin-"));
+    symlinkSync("/bin/sh", join(binDir, "sh"));
+    originalPath = process.env.PATH;
+    process.env.PATH = binDir;
+  });
+
+  afterEach(() => {
+    if (originalPath === undefined) delete process.env.PATH;
+    else process.env.PATH = originalPath;
+    rmSync(binDir, { recursive: true, force: true });
+  });
+
+  function installFakeNpx(body: string): void {
+    const p = join(binDir, "npx");
+    writeFileSync(p, body);
+    chmodSync(p, 0o755);
+  }
+
+  it("POSITIVE CONTROL: with a resolvable adapter the very same check says 'runs'", () => {
+    // Without this the 'broken' assertions below would also pass if the probe
+    // were simply always reporting failure.
+    installFakeNpx("#!/bin/sh\nprintf '%s' '{}'\n");
+    writeHook(buildSessionStartHookCommand("me"));
+    expect(inspectSessionStartHook(isoHome, { timeoutMs: 20_000 }).execution).toBe("runs");
+  });
+
+  it("the CURRENT (silenced) command that cannot resolve is reported broken", () => {
+    writeHook(buildSessionStartHookCommand("me"));
+    const res = inspectSessionStartHook(isoHome, { timeoutMs: 20_000 });
+    expect(res.execution).toBe("broken");
+    expect(res.detail).toContain("never ran");
+  });
+
+  it("the LEGACY command that cannot resolve is reported broken, with the shell's own error as evidence", () => {
+    writeHook(LEGACY_COMMAND);
+    const res = inspectSessionStartHook(isoHome, { timeoutMs: 20_000 });
+    expect(res.execution).toBe("broken");
+    expect(res.detail).toContain("npx");
+  });
+
+  it("a resolver that exits non-zero is broken, not 'runs'", () => {
+    installFakeNpx("#!/bin/sh\necho 'boom' >&2\nexit 1\n");
+    writeHook(LEGACY_COMMAND);
+    expect(inspectSessionStartHook(isoHome, { timeoutMs: 20_000 }).execution).toBe("broken");
+  });
+
+  it("the probe sets FLAIR_HOOK_PROBE, so a real adapter answers without side effects", () => {
+    // Proven by having the stub refuse to produce output unless the variable
+    // is set — the same contract session-start-hook.ts honours.
+    installFakeNpx('#!/bin/sh\nif [ -n "$FLAIR_HOOK_PROBE" ]; then printf \'%s\' \'{}\'; else printf \'%s\' \'SIDE_EFFECTS_RAN\'; fi\n');
+    writeHook(buildSessionStartHookCommand("me"));
+    expect(inspectSessionStartHook(isoHome, { timeoutMs: 20_000 }).execution).toBe("runs");
+
+    // And the control: without probe mode the stub would have produced the
+    // other branch, so the assertion above is not vacuous.
+    const direct = Bun.spawnSync(["/bin/sh", "-c", buildSessionStartHookCommand("me")], {
+      env: { PATH: binDir, HOME: isoHome },
+    });
+    expect(new TextDecoder().decode(direct.stdout)).toBe("SIDE_EFFECTS_RAN");
+  });
+});
+
+describe("fixSessionStartHook writes a command that fails silently", () => {
+  it("the freshly written hook is silenced and still recognised by doctor's own check", () => {
+    const res = fixSessionStartHook(isoHome, "me");
+    expect(res.ok).toBe(true);
+    const [command] = readHookCommands();
+    expect(hookCommandIsSilenced(command!)).toBe(true);
+    expect(checkSessionStartHook(isoHome).present).toBe(true);
+  });
+
+  it("refuses an agent id that cannot be written safely into a shell command", () => {
+    const res = fixSessionStartHook(isoHome, "me'; touch /tmp/pwned; #");
+    expect(res.ok).toBe(false);
+    expect(res.message).toContain("cannot be safely written");
+  });
+});
+
+describe("upgradeSessionStartHookCommand — repair, never removal", () => {
+  it("rewrites the legacy command in place, keeping the agent it already names", () => {
+    writeHook(`FLAIR_AGENT_ID=flint npx -y @tpsdev-ai/flair-mcp ${SESSION_START_HOOK_MARKER}`);
+    const res = upgradeSessionStartHookCommand(isoHome);
+    expect(res.ok).toBe(true);
+    expect(res.changed).toBe(true);
+    const [command] = readHookCommands();
+    expect(command).toContain("FLAIR_AGENT_ID=flint");
+    expect(hookCommandIsSilenced(command!)).toBe(true);
+  });
+
+  it("preserves FLAIR_URL, so an upgrade never re-points a hook at a different instance", () => {
+    writeHook(LEGACY_COMMAND_WITH_URL);
+    upgradeSessionStartHookCommand(isoHome);
+    const [command] = readHookCommands();
+    expect(command).toContain("FLAIR_URL=http://127.0.0.1:19926");
+  });
+
+  it("is idempotent — a second run reports no change", () => {
+    writeHook(LEGACY_COMMAND);
+    expect(upgradeSessionStartHookCommand(isoHome).changed).toBe(true);
+    const after = readHookCommands();
+    const second = upgradeSessionStartHookCommand(isoHome);
+    expect(second.ok).toBe(true);
+    expect(second.changed).toBe(false);
+    expect(readHookCommands()).toEqual(after);
+  });
+
+  it("REFUSES a hand-edited hook — a command the user wrote is theirs", () => {
+    const handEdited = `FLAIR_AGENT_ID=me npx -y @tpsdev-ai/flair-mcp@0.33.0 ${SESSION_START_HOOK_MARKER}`;
+    writeHook(handEdited);
+    const res = upgradeSessionStartHookCommand(isoHome);
+    expect(res.ok).toBe(false);
+    expect(res.changed).toBe(false);
+    expect(readHookCommands()).toEqual([handEdited]);
+  });
+
+  it("never removes the hook, and never disturbs siblings or unrelated keys", () => {
+    writeSettings({
+      permissions: { allow: ["Bash(ls:*)"] },
+      hooks: {
+        SessionStart: [
+          { hooks: [{ type: "command", command: "unrelated-session-hook" }] },
+          { hooks: [{ type: "command", command: LEGACY_COMMAND }] },
+        ],
+        PreToolUse: [{ hooks: [{ type: "command", command: "other" }] }],
+      },
+    });
+    expect(upgradeSessionStartHookCommand(isoHome).changed).toBe(true);
+
+    const config = JSON.parse(readFileSync(settingsPath(), "utf-8"));
+    expect(config.permissions).toEqual({ allow: ["Bash(ls:*)"] });
+    expect(config.hooks.PreToolUse).toEqual([{ hooks: [{ type: "command", command: "other" }] }]);
+    expect(config.hooks.SessionStart).toHaveLength(2);
+    expect(config.hooks.SessionStart[0].hooks[0].command).toBe("unrelated-session-hook");
+    expect(hookCommandIsSilenced(config.hooks.SessionStart[1].hooks[0].command)).toBe(true);
+    expect(checkSessionStartHook(isoHome).present).toBe(true);
+  });
+
+  it("reports rather than throws when there is nothing to upgrade", () => {
+    const res = upgradeSessionStartHookCommand(isoHome);
+    expect(res.ok).toBe(false);
+    expect(res.changed).toBe(false);
+  });
+});

--- a/test/unit/session-start-hook-command.test.ts
+++ b/test/unit/session-start-hook-command.test.ts
@@ -1,0 +1,230 @@
+import { describe, it, expect, beforeAll, afterAll } from "bun:test";
+import { spawnSync } from "node:child_process";
+import { chmodSync, existsSync, mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  SESSION_START_HOOK_MARKER,
+  buildSessionStartHookCommand,
+  hookCommandIsSilenced,
+  isFlairHookCommand,
+  isHookCommandValueSafe,
+  parseLegacySessionStartHookCommand,
+} from "../../src/doctor-client.ts";
+
+/**
+ * flair#1007 — the SessionStart hook must be SILENT when its `npx` invocation
+ * cannot resolve or execute.
+ *
+ * The defect this file exists for is not reachable by exercising a working
+ * hook: the failure is that the adapter binary NEVER RUNS, so every guarantee
+ * that lives inside it is unreachable. The only thing standing between the
+ * user and an error on every session is the command string itself. So these
+ * tests do not assert on the string's spelling — they EXECUTE it, through a
+ * real shell, under conditions where the command genuinely cannot resolve.
+ *
+ * Every "the wrapper is silent" assertion is paired with a POSITIVE CONTROL
+ * running the pre-#1007 command in the identical conditions. Without that
+ * control a broken fixture (e.g. a PATH that still happens to find npx) would
+ * make the whole file pass while the defect remained.
+ */
+
+// The exact string Flair wrote before #1007 — the control, and the shape
+// `flair doctor --fix` upgrades.
+const LEGACY_COMMAND = `FLAIR_AGENT_ID=me npx -y @tpsdev-ai/flair-mcp ${SESSION_START_HOOK_MARKER}`;
+
+const AGENT = "me";
+
+interface Run {
+  status: number | null;
+  stdout: string;
+  stderr: string;
+}
+
+/** Run a hook command the way Claude Code does: `<shell> -c "<command>"`.
+ *  Claude Code itself always uses /bin/sh (it spawns with `shell: true` and
+ *  never consults $SHELL), which is why /bin/sh is the mandatory leg below. */
+function runCommand(command: string, shell: string, path: string): Run {
+  const res = spawnSync(shell, ["-c", command], {
+    input: "",
+    encoding: "utf-8",
+    timeout: 20_000,
+    env: { PATH: path, HOME: process.env.HOME ?? "/tmp" },
+  });
+  return { status: res.status, stdout: res.stdout ?? "", stderr: res.stderr ?? "" };
+}
+
+// ── fixtures ────────────────────────────────────────────────────────────────
+//
+// Three PATHs, each simulating one state of the world. Nothing is installed
+// globally and no real `npx` is ever consulted (the constraint that makes this
+// runnable in CI and on a developer machine alike).
+
+let fixtureDir: string;
+/** No `npx` at all — simulates the orphaned-shim failure: the command cannot resolve. */
+let PATH_UNRESOLVABLE: string;
+/** An `npx` that resolves, writes to BOTH streams and exits non-zero. */
+let PATH_CRASHING: string;
+/** An `npx` that resolves and behaves like the real adapter. */
+let PATH_WORKING: string;
+
+const ADAPTER_OUTPUT = '{"hookSpecificOutput":{"hookEventName":"SessionStart","additionalContext":"ctx"}}';
+
+beforeAll(() => {
+  fixtureDir = mkdtempSync(join(tmpdir(), "flair-hook-cmd-"));
+
+  const emptyBin = join(fixtureDir, "empty");
+  const crashBin = join(fixtureDir, "crash");
+  const workBin = join(fixtureDir, "work");
+  for (const d of [emptyBin, crashBin, workBin]) {
+    mkdirSync(d, { recursive: true });
+    // The wrapper invokes `sh`, so `sh` must be findable — but NOTHING else
+    // is, which is what makes "npx cannot resolve" true by construction
+    // rather than by hoping the ambient PATH has no npx on it.
+    symlinkSync("/bin/sh", join(d, "sh"));
+  }
+
+  // A crashing resolver that pollutes stdout as well as stderr. stdout matters
+  // independently of the exit code: Claude Code injects a SessionStart hook's
+  // non-JSON stdout into the model's context verbatim, and treats stdout that
+  // starts with `{` but fails validation as a hook error EVEN AT EXIT 0.
+  writeFileSync(
+    join(crashBin, "npx"),
+    "#!/bin/sh\necho 'npm error could not determine executable to run'\necho 'mise ERROR No version is set for shim: flair-session-start' >&2\nexit 1\n",
+  );
+  writeFileSync(join(workBin, "npx"), `#!/bin/sh\nprintf '%s' '${ADAPTER_OUTPUT}'\n`);
+  chmodSync(join(crashBin, "npx"), 0o755);
+  chmodSync(join(workBin, "npx"), 0o755);
+
+  // Deliberately NOT inheriting process.env.PATH: a leaked real `npx` would
+  // silently turn the unresolvable case into a working one.
+  PATH_UNRESOLVABLE = emptyBin;
+  PATH_CRASHING = crashBin;
+  PATH_WORKING = workBin;
+});
+
+afterAll(() => {
+  rmSync(fixtureDir, { recursive: true, force: true });
+});
+
+// ── which shells to exercise ────────────────────────────────────────────────
+//
+// /bin/sh is what Claude Code actually uses, so it is REQUIRED — if it is
+// missing the suite fails rather than silently skipping (an unrun check must
+// never look like a pass). /bin/bash is required too so at least two
+// independent implementations are always covered. Everything else is
+// opportunistic breadth for the "we also publish this string for hand-wiring"
+// case: fish and csh/tcsh in particular reject the bare POSIX fragment this
+// wrapper deliberately avoids.
+//
+// /bin/ksh is deliberately ABSENT rather than opportunistically included:
+// macOS ships ksh93u+ (2012), which SIGSEGVs on any command spawned from Bun
+// — `spawnSync("/bin/ksh", ["-c", "echo hi"])` crashes identically, so it
+// measures the runtime, not this command. It was verified by hand at a shell
+// prompt instead. Listing it here would produce a red leg that says nothing.
+const REQUIRED_SHELLS = ["/bin/sh", "/bin/bash"];
+const OPTIONAL_SHELLS = ["/bin/zsh", "/bin/dash", "/bin/tcsh", "/bin/csh", "/opt/homebrew/bin/fish", "/usr/bin/fish", "/usr/local/bin/fish"];
+
+function shellsUnderTest(): string[] {
+  return [...REQUIRED_SHELLS, ...OPTIONAL_SHELLS.filter((s) => existsSync(s))];
+}
+
+describe("buildSessionStartHookCommand — shape", () => {
+  it("carries the marker, the package and the agent id verbatim", () => {
+    const cmd = buildSessionStartHookCommand(AGENT);
+    expect(cmd).toContain(SESSION_START_HOOK_MARKER);
+    expect(cmd).toContain("npx -y @tpsdev-ai/flair-mcp");
+    expect(cmd).toContain(`FLAIR_AGENT_ID=${AGENT}`);
+  });
+
+  it("includes FLAIR_URL only when one is given", () => {
+    expect(buildSessionStartHookCommand(AGENT)).not.toContain("FLAIR_URL=");
+    expect(buildSessionStartHookCommand(AGENT, "http://127.0.0.1:19926")).toContain("FLAIR_URL=http://127.0.0.1:19926");
+  });
+
+  it("refuses values that cannot be represented safely in a shell command", () => {
+    expect(isHookCommandValueSafe("me")).toBe(true);
+    expect(isHookCommandValueSafe("http://127.0.0.1:19926")).toBe(true);
+    for (const bad of ["me'; rm -rf /", "me with space", "me$(id)", "me`id`", 'me"x', "me\\x"]) {
+      expect(isHookCommandValueSafe(bad)).toBe(false);
+      expect(() => buildSessionStartHookCommand(bad)).toThrow();
+    }
+    expect(() => buildSessionStartHookCommand(AGENT, "http://x/'`id`")).toThrow();
+  });
+
+  it("is recognised as ours and as silenced; the legacy command is neither", () => {
+    const cmd = buildSessionStartHookCommand(AGENT);
+    expect(isFlairHookCommand(cmd)).toBe(true);
+    expect(hookCommandIsSilenced(cmd)).toBe(true);
+
+    expect(isFlairHookCommand(LEGACY_COMMAND)).toBe(true);
+    expect(hookCommandIsSilenced(LEGACY_COMMAND)).toBe(false);
+  });
+});
+
+describe("parseLegacySessionStartHookCommand", () => {
+  it("matches the exact pre-#1007 shapes, with and without FLAIR_URL", () => {
+    expect(parseLegacySessionStartHookCommand(LEGACY_COMMAND)).toEqual({ agentId: "me", flairUrl: undefined });
+    expect(
+      parseLegacySessionStartHookCommand(
+        `FLAIR_AGENT_ID=me FLAIR_URL=http://127.0.0.1:19926 npx -y @tpsdev-ai/flair-mcp ${SESSION_START_HOOK_MARKER}`,
+      ),
+    ).toEqual({ agentId: "me", flairUrl: "http://127.0.0.1:19926" });
+  });
+
+  it("does NOT match a hand-edited or already-upgraded command", () => {
+    // The whole point of an exact match: --fix must never rewrite a command a
+    // user authored, only one Flair itself wrote.
+    expect(parseLegacySessionStartHookCommand(buildSessionStartHookCommand(AGENT))).toBeNull();
+    expect(parseLegacySessionStartHookCommand(`${LEGACY_COMMAND} --extra-flag`)).toBeNull();
+    expect(parseLegacySessionStartHookCommand(`FLAIR_AGENT_ID=me npx -y @tpsdev-ai/flair-mcp@0.33.0 ${SESSION_START_HOOK_MARKER}`)).toBeNull();
+    expect(parseLegacySessionStartHookCommand("my-own-hook.sh")).toBeNull();
+  });
+});
+
+describe("the command is silent when it cannot resolve (flair#1007 — the defect)", () => {
+  const wrapped = () => buildSessionStartHookCommand(AGENT);
+
+  it("POSITIVE CONTROL: the pre-#1007 command IS loud in these same conditions", () => {
+    // Without this, a fixture that accidentally still resolved `npx` would let
+    // every assertion below pass while the bug was untouched.
+    const legacy = runCommand(LEGACY_COMMAND, "/bin/sh", PATH_UNRESOLVABLE);
+    expect(legacy.status).not.toBe(0);
+    expect(legacy.stderr.trim()).not.toBe("");
+  });
+
+  for (const shell of shellsUnderTest()) {
+    it(`${shell}: unresolvable command → exit 0, no stdout, no stderr`, () => {
+      const run = runCommand(wrapped(), shell, PATH_UNRESOLVABLE);
+      expect(run.status).toBe(0);
+      expect(run.stdout).toBe("");
+      expect(run.stderr).toBe("");
+    });
+
+    it(`${shell}: resolver that crashes and pollutes both streams → exit 0, no stdout, no stderr`, () => {
+      const run = runCommand(wrapped(), shell, PATH_CRASHING);
+      expect(run.status).toBe(0);
+      // stdout suppression is load-bearing, not tidiness: unsuppressed, the
+      // resolver's stdout would be injected into the model's context.
+      expect(run.stdout).toBe("");
+      expect(run.stderr).toBe("");
+    });
+
+    it(`${shell}: working adapter → output passed through byte-for-byte, exit 0`, () => {
+      const run = runCommand(wrapped(), shell, PATH_WORKING);
+      expect(run.status).toBe(0);
+      expect(run.stdout).toBe(ADAPTER_OUTPUT);
+      expect(run.stderr).toBe("");
+    });
+  }
+
+  it("exercises /bin/sh and /bin/bash at minimum", () => {
+    // Guards the loop above against silently degenerating to zero legs if the
+    // shell-detection logic ever changes.
+    const shells = shellsUnderTest();
+    expect(shells).toContain("/bin/sh");
+    expect(shells).toContain("/bin/bash");
+    expect(shells.length).toBeGreaterThanOrEqual(2);
+  });
+});


### PR DESCRIPTION
Closes #1007

## The failure

The hook `flair init` / `flair doctor --fix` register resolves a package binary through the user's Node runtime. Under a Node version manager, globally installed packages are per-runtime-version — so a routine, entirely unrelated runtime upgrade orphans it. From then on the hook errors on **every** session, indefinitely, in wording that names neither Flair nor a remedy. And it outlives Flair: uninstalling the CLI does not remove the hook, so the error survives the tool it exists to serve.

## Where the silencing lives, and why it had to go there

`session-start-hook.ts` already guarantees no-op-on-any-failure. That guarantee lives **inside the binary which, in this failure, never runs** — the guard is behind the door it is meant to guard. The only layer that still exists when the binary does not is the command string, so that is where the silence is enforced:

```
sh -c 'out=$(<invocation> 2>/dev/null) && printf %s "$out" || true'
```

A shell fragment in a settings file is hard to test — so it is not eyeballed, it is **executed**. The three literal copies of the command string are now one builder, and the tests run the string it produces through a real shell under a PATH where the command genuinely cannot resolve.

Measured across `sh`, `bash`, `zsh`, `dash`, `ksh`, `fish` and `tcsh`:

| | success | cannot resolve / crashes |
|---|---|---|
| wrapped | stdout passed through byte-for-byte, exit 0 | empty stdout, empty stderr, exit 0 |

**Why `sh -c '...'` and not a bare fragment.** Claude Code runs a `type: "command"` hook as `/bin/sh -c` (it spawns with `shell: true` and never consults `$SHELL`), so a bare POSIX fragment would suffice for the one harness supported today. It is wrapped anyway because the string is not private to that harness — the harness list is a registry meant to grow, and the docs publish this exact command for hand-wiring. A bare `out=$(...)` fragment is a **syntax error in fish and csh/tcsh**: silent on some shells, louder than before on others, which is not a fix. The previous unwrapped command was already broken outright in csh/tcsh. Cost: one extra process at session start.

**Why stdout is captured, not just stderr discarded.** Exit code is not the whole surface. A SessionStart hook's stdout is consumed two ways *even at exit 0*: non-JSON stdout is injected into the model's context verbatim, and stdout starting with `{` that fails validation is reported as a hook error. A failing resolver that prints on stdout would therefore either become silently injected context or reproduce the exact error class this issue is about. Both survive an exit-code-only fix.

**Does resolution failure silence a genuine problem?** The split is: resolution failure is silent in the session and *diagnosable by doctor*. The adapter always writes a non-empty payload (at minimum its inert `{}`) and always exits 0 — so "exit 0 with empty stdout" is precisely the signature of the wrapper swallowing a command that never ran. The wrapper makes this failure **more** diagnosable, not less.

## What doctor does

Presence was never the problem — the failing entry was perfectly well-formed. doctor now **runs** the registered command rather than only confirming it exists.

The probe is bounded and side-effect-free: a new `FLAIR_HOOK_PROBE` mode makes the adapter print its inert output and exit *before* reading stdin, constructing a client, or touching the network. Being reached at all is the answer. An adapter too old to know the variable still answers the same question; two short timeouts bound that case. A timeout is reported as *unknown*, never as broken — a slow `npx` must not be called a broken hook. Commands that are not ours are never executed.

The remedy names the actual fix, and picks the most informative stderr line rather than repeating the package manager's first notice back at the user — on a real machine the harness-style first line was `npm notice run ... npx`, while the useful one was three lines down.

**Report, or fix?** Both, split by what is actually repairable:

- **Command no longer resolves** → **report only.** Rewriting the command would produce a byte-identical string; the environment changed, not the entry. The remedy is to reinstall the adapter for the current runtime, or `flair hook uninstall` if Flair is genuinely gone.
- **Command resolves but predates the wrapper** → **`--fix` rewrites it in place**, preserving the agent and instance it already names, so no flag is needed. This is the one repair with a real effect, and the only route by which existing installs stop being loud.

`--fix` refuses to rewrite a hand-edited or pinned command — that one is the user's — and **never removes a hook**. An unresolvable command is an environment that changed, not a decision to un-wire ambient memory; `flair hook uninstall` remains the command for that.

`flair hook status` gained an **On failure** line.

**Reported, but not gating the exit code.** The probe verifies the environment at the moment doctor runs — a cold `npx` cache, an offline machine, a slow registry — so it is treated exactly like the FLAIR_URL reachability and agent-registration verifications directly above it, which are warnings for the same reason. A fresh, correct install on a machine that has simply not fetched the adapter yet must not be told it is broken in an exit code. The finding still prints in full with its remedy. The *unsilenced-command* finding **is** counted: that one is a fact about the file, true regardless of environment, with a deterministic fix.

Measured against one fixture, doctor's issue count:

| registered hook | issues |
|---|---|
| absent | 7 — unchanged from before this branch |
| wired, legacy command | 7 — +1 for the unsilenced finding |
| wired, current command, adapter not resolvable | 6 — the probe finding adds nothing |

## Hardening picked up on the way

Values interpolated into the command are now **refused rather than escaped** when they contain characters that are not shell-safe. Correct single-quote escaping is not uniform across the shells above, so "cannot contain a quote" is enforced by shape. This is strictly safer than before: the previous command made an agent id containing a space or a `;` a command injection into the user's settings file.

## Tests

New: `test/unit/session-start-hook-command.test.ts`, `test/unit/doctor-session-start-hook-probe.test.ts`, `packages/flair-mcp/test/session-start-hook-probe.test.ts`.

The command-does-not-resolve case is tested specifically, by execution, under a PATH containing `sh` and nothing else — so "npx cannot resolve" is true by construction rather than by hoping the ambient PATH lacks it. No global install is performed or required. Every silence assertion is paired with a **positive control** running the pre-fix command in identical conditions, so a fixture that accidentally still resolved would fail the file rather than pass it vacuously.

`/bin/sh` and `/bin/bash` are required legs (a missing one fails rather than skips); other shells join opportunistically. `/bin/ksh` is deliberately excluded rather than skipped: the ksh93u+ that ships on macOS SIGSEGVs on *any* command spawned from Bun, so it would measure the runtime rather than this change — it was verified by hand instead.

One follow-up commit was needed after the first CI run: the probe test targeted `packages/flair-mcp/dist/`, which that lane does not build. `dist/` is usually present there only because a sibling test file runs `npm run build` from its own `beforeAll` when the shim is missing — making it an artifact of which file bun reaches first, not a guarantee. The test now spawns the source entry point; the precondition assertion stays a hard failure rather than a skip. Reproduced both directions locally with `dist/` removed: targeting `dist/` gives CI's exact `81 pass / 3 fail`, targeting the source gives `84 pass / 0 fail`.

**Mutation check** — each mutation applied, failure confirmed, restored, green confirmed:

| mutation | result |
|---|---|
| silencing wrapper removed from the builder | 18 fail (command suite), 6 fail (doctor suite) → restored, 0 fail |
| `classifyHookProbe` always returns "runs" | 8 fail → restored, 0 fail |
| probe short-circuit removed from the adapter | 1 fail → restored, 0 fail |

**Counts, against baselines measured on unmodified `origin/main`:**

| lane | baseline | this branch |
|---|---|---|
| `bun test test/unit/ test/*.test.ts` | 3795 pass / 0 fail / 204 files | **3851 pass / 0 fail / 206 files** |
| `test/unit-isolated/` (one process each) | 21 / 113 / 11, 0 fail | identical |
| `packages/flair-mcp` | 79 pass / 0 fail | **84 pass / 0 fail** |
| `packages/flair-client` | 61 pass / 0 fail | identical |
| langgraph / n8n / openclaw / pi / bench | 40 / 31 / 58 / 27 / 48, 0 fail | identical |

`npm run build` + `npm run build:cli` clean. `tsc --noEmit` reports the single pre-existing `resources/auth-middleware.ts(70,1)` error, confirmed present and unchanged on `origin/main`; the CLI project typechecks clean. `docs-freshness-check` 7/7 ran and passed. The integration lane is untouched by this diff — no test under `test/integration/`, `test/smoke/`, `test/compat/` or `test/e2e` references any changed surface.

## Deliberately not fixed

- **#1002 (bundling the adapter into the CLI)** is out of scope here. It removes this class entirely and is the right long-term answer, but even after bundling a hook that fails must fail quietly.
- **The adapter can fail to exit.** Separate, pre-existing, and reproducible on `origin/main`: with `FLAIR_AGENT_ID` set and a `FLAIR_URL` that responds, the built binary writes its output and then does not exit — it lingers on an outstanding request until killed (measured at 15s, the test deadline, on Node 26). Output is correct; the process just outlives it. Worth its own issue.
- **The `npx` invocation is fragile beyond the runtime-change case.** On a machine with npm 12 and the package not installed globally, `npx -y @tpsdev-ai/flair-mcp flair-session-start` resolved to the package's *default* bin name and exited 127. That is more evidence for #1002, not something to paper over here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
