### PR TITLE
fix(doctor): classify key-decode failures instead of guessing two wrong causes

### DIFF
--- a/.changelog/unreleased/fixed-doctor-key-decode-classification.md
+++ b/.changelog/unreleased/fixed-doctor-key-decode-classification.md
@@ -1,0 +1,16 @@
+- **`flair doctor` no longer explains one unreadable key as two different wrong causes.** A key
+  file that OpenSSL could not decode surfaced twice in the same report — once as `Embeddings: not
+  verified` advising `Pass --agent <id>`, and once as `could not verify agent registration
+  (instance unreachable: ...)` printed six lines beneath doctor's own `✓ Harper responding` tick
+  (#1023). Neither was the cause: an agent had been selected, and the instance had demonstrably
+  answered. The operator was sent to check firewalls and ports for a file on their own disk. The
+  fix is structural rather than better wording — signing strictly precedes the request, so
+  `authFetch` now raises a distinct `KeyLoadError` for the signing half only, and no caller has to
+  infer from an error string whether the network was ever reached. Doctor names the file that
+  failed and that it could not be parsed as an Ed25519 private key; an unrecognised failure
+  reports the operation and the raw error and asserts **no** cause at all. `--agent` is suggested
+  only where it can actually resolve an identity — a remedy that cannot change the outcome is now
+  omitted rather than printed. Registration findings also carry the reachability the run already
+  established, so `unreachable` can no longer be claimed after this run watched the instance
+  respond. Key-decode failures are recognised by the crypto backend's structured error code
+  across both OpenSSL and BoringSSL, whose wording for the identical failure differs.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -104,6 +104,42 @@ date
 
 If using the MCP server, restart Claude Code after rotating keys.
 
+### "signing key ... could not be parsed as an Ed25519 private key"
+
+**Symptoms:** `flair doctor` reports, naming the file:
+
+```
+⚠️ could not verify agent 'my-agent' registration — signing key
+   /home/you/.flair/keys/my-agent.key could not be parsed as an Ed25519 private key
+   (error:1E08010C:DECODER routines::unsupported)
+```
+
+**This is not a connectivity problem.** The failure happens locally, before any
+request is sent — the instance is untouched. Checking ports, firewalls or the
+Flair URL will not help. (Before #1023 doctor reported exactly this as
+`instance unreachable`, and separately suggested passing `--agent`; neither was
+the cause.)
+
+**Causes:** the bytes in that file are not a private key Flair can read. Most
+often either the file is truncated or corrupt, or it is not an agent key at all
+— `~/.flair/keys/<id>.key` is also where the federation keystore writes its own
+**encrypted** key files, which are not loadable as plain Ed25519 seeds.
+
+**Fix:** identify which it is before touching the file — the two have opposite
+remedies, and the wrong one loses a key.
+
+```bash
+# Is this id an agent, or a federation instance?
+flair agent list
+flair federation status
+
+# If it IS an agent and the file is corrupt, re-register a fresh keypair:
+flair agent rotate-key <agent-id>
+```
+
+If the id does not appear as an agent, leave the file alone — it belongs to the
+keystore, and doctor simply has no business signing with it.
+
 ### Port conflict
 
 **Symptoms:** `flair start` fails, "address already in use".

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -84,11 +84,13 @@ import {
   inferSoleAgentId,
   fixCommandAgentHint,
   describeAgentGateFinding,
+  embeddingsSkipRemedy,
   classifyKeyFile,
   resolveCollisionSafeName,
   pruneDateStamp,
   PRUNED_DIR_NAME,
   type AgentGateState,
+  type SemanticSkipReason,
   type KeyPruneClass,
 } from "./doctor-client.js";
 import {
@@ -109,6 +111,7 @@ import {
   resolveKeyPath,
   buildEd25519Auth,
   authFetch,
+  KeyLoadError,
   isLocalBase,
   authedRequest,
 } from "./lib/auth-resolve.js";
@@ -1662,7 +1665,12 @@ async function waitForHealth(httpPort: number, adminUser: string, adminPass: str
 export type SemanticVerifyResult =
   | { state: "ok"; score: number }
   | { state: "degraded"; detail: string }
-  | { state: "skipped"; detail: string };
+  // flair#1023: `skipped` covers several unrelated situations, and the
+  // renderer used to print ONE remedy ("pass --agent") for all of them —
+  // advice that cannot fix a key that won't decode, or an HTTP 500 from the
+  // probe. `reason` is what lets the caller pick a remedy that is actually
+  // reachable from the failure, instead of a remedy-shaped sentence.
+  | { state: "skipped"; reason: SemanticSkipReason; detail: string };
 
 /**
  * Verify that semantic search ACTUALLY works by storing a memory with a
@@ -1693,7 +1701,7 @@ export async function verifySemanticSearch(
     } catch { /* keysDir missing */ }
   }
   if (!agentId) {
-    return { state: "skipped", detail: "no agent id or key found" };
+    return { state: "skipped", reason: "no-agent", detail: "no agent id or key found" };
   }
   // Find the signing key. Prefer the standard locations (resolveKeyPath), but
   // fall back to the keysDir we were handed — `flair init` keys live there and
@@ -1704,7 +1712,7 @@ export async function verifySemanticSearch(
     if (existsSync(candidate)) keyPath = candidate;
   }
   if (!keyPath) {
-    return { state: "skipped", detail: `no private key for agent '${agentId}'` };
+    return { state: "skipped", reason: "no-key", detail: `no private key for agent '${agentId}'` };
   }
 
   // Distinctive content vs. a PARAPHRASE query with deliberately ZERO shared
@@ -1726,7 +1734,7 @@ export async function verifySemanticSearch(
     });
     if (!writeRes.ok && writeRes.status !== 204) {
       const text = await writeRes.text().catch(() => "");
-      return { state: "skipped", detail: `could not write probe memory: HTTP ${writeRes.status} ${text.slice(0, 80)}` };
+      return { state: "skipped", reason: "probe-failed", detail: `could not write probe memory: HTTP ${writeRes.status} ${text.slice(0, 80)}` };
     }
     stored = true;
 
@@ -1741,7 +1749,7 @@ export async function verifySemanticSearch(
     });
     if (!searchRes.ok) {
       const text = await searchRes.text().catch(() => "");
-      return { state: "skipped", detail: `SemanticSearch failed: HTTP ${searchRes.status} ${text.slice(0, 80)}` };
+      return { state: "skipped", reason: "probe-failed", detail: `SemanticSearch failed: HTTP ${searchRes.status} ${text.slice(0, 80)}` };
     }
     const data = await searchRes.json() as { results?: any[]; _warning?: string };
 
@@ -1769,8 +1777,15 @@ export async function verifySemanticSearch(
     }
     return { state: "ok", score };
   } catch (err: unknown) {
+    // flair#1023: distinguish "your key will not load" from "the probe
+    // request failed". The former is raised before any request leaves the
+    // process, so it is never evidence about the instance — and "pass
+    // --agent" cannot fix it.
+    if (err instanceof KeyLoadError) {
+      return { state: "skipped", reason: "key-load", detail: err.message };
+    }
     const message = err instanceof Error ? err.message : String(err);
-    return { state: "skipped", detail: `probe error: ${message.slice(0, 100)}` };
+    return { state: "skipped", reason: "probe-failed", detail: `probe error: ${message.slice(0, 100)}` };
   } finally {
     // Best-effort cleanup of the ephemeral probe memory.
     if (stored) {
@@ -1816,6 +1831,11 @@ export async function probeFlairReachable(url: string, timeoutMs = 2000): Promis
  *   any other status, or a network error/timeout -> "unreachable" (could not
  *     verify one way or the other — e.g. a bare 401/403/500 doesn't tell us
  *     whether the agent exists, so we don't claim NOT registered on those)
+ *   the key file exists but will not load -> "key-unreadable" (flair#1023 —
+ *     signing happens strictly before the request, so authFetch can only
+ *     raise KeyLoadError while the instance is still untouched. This USED to
+ *     land in the catch below and be reported as "instance unreachable",
+ *     which doctor printed directly beneath its own "Harper responding" tick)
  *   no local key found for agentId (checked resolveKeyPath, then keysDir) -> "no-key"
  *     (can't sign the request at all — distinct from "unreachable" so the
  *     caller can print an accurate reason)
@@ -1843,7 +1863,7 @@ export async function checkAgentRegistered(
   baseUrl: string,
   agentId: string,
   keysDir: string,
-): Promise<{ state: "registered" | "not-registered" | "unreachable" | "no-key"; detail?: string }> {
+): Promise<{ state: AgentGateState; detail?: string }> {
   let keyPath = resolveKeyPath(agentId);
   if (!keyPath) {
     const candidate = join(keysDir, `${agentId}.key`);
@@ -1862,6 +1882,13 @@ export async function checkAgentRegistered(
     }
     return { state: "unreachable", detail: `HTTP ${res.status} ${text.slice(0, 80)}` };
   } catch (err: unknown) {
+    // flair#1023: a key that will not load is NOT a reachability fact. It is
+    // raised before the request is sent, so reporting it as "unreachable"
+    // sends the operator to firewalls and ports for a problem that is on
+    // their own disk.
+    if (err instanceof KeyLoadError) {
+      return { state: "key-unreadable", detail: err.message };
+    }
     const message = err instanceof Error ? err.message : String(err);
     return { state: "unreachable", detail: `instance unreachable: ${message.slice(0, 100)}` };
   }
@@ -4440,7 +4467,13 @@ export async function classifyKeysDir(keysDir: string, baseUrl: string): Promise
         entries: [],
       };
     }
-    const decision = classifyKeyFile(c.agentId, true, { state: reg.state, detail: reg.detail }, baseUrl);
+    // flair#1023 added "key-unreadable". It cannot occur here — this key's
+    // seed already parsed via isValidPrivateKeySeedFile above — but is
+    // handled explicitly rather than folded into the else: a key that will
+    // not load means exactly what prune already calls "invalid".
+    const decision = reg.state === "key-unreadable"
+      ? classifyKeyFile(c.agentId, false, null, baseUrl)
+      : classifyKeyFile(c.agentId, true, { state: reg.state, detail: reg.detail }, baseUrl);
     entries.push({ name: c.name, class: decision.class, reason: decision.reason, agentId: c.agentId });
   }
 
@@ -12347,13 +12380,20 @@ program
           console.log(`     ${render.wrap(render.c.dim, "See:")} docs/troubleshooting.md ${render.wrap(render.c.dim, "→ \"Semantic search DEGRADED\"")}`);
           issues++;
           break;
-        case "skipped":
-          // Could not run the round-trip (no agent / no key). Don't claim
-          // all-clear — surface that the check was skipped, but don't count it
-          // as a hard issue since the user may simply not have an agent yet.
+        case "skipped": {
+          // Could not run the round-trip. Don't claim all-clear — surface that
+          // the check was skipped, but don't count it as a hard issue since
+          // the user may simply not have an agent yet.
+          //
+          // flair#1023: the remedy is chosen from the classified reason
+          // (embeddingsSkipRemedy, src/doctor-client.ts) instead of being
+          // printed unconditionally. A key that will not decode gets no
+          // "pass --agent" advice, because following it changes nothing.
           console.log(`  ${render.icons.warn} Embeddings: not verified ${render.wrap(render.c.dim, `(${semanticStatus.detail})`)}`);
-          console.log(`     ${render.wrap(render.c.dim, "Pass --agent <id> (or set FLAIR_AGENT_ID) so doctor can run a real semantic round-trip.")}`);
+          const remedy = embeddingsSkipRemedy(semanticStatus.reason);
+          if (remedy) console.log(`     ${render.wrap(render.c.dim, remedy)}`);
           break;
+        }
       }
     }
 
@@ -12508,7 +12548,11 @@ program
           console.log(`        ${render.wrap(render.c.dim, "Fix:")} flair agent add ${block.agentId}`);
           issues++;
         } else {
-          console.log(`     ${render.icons.warn} could not verify agent registration ${render.wrap(render.c.dim, `(${reg.detail})`)}`);
+          // flair#1023: `reachable` was just established two lines above, so
+          // reuse the same self-inconsistency guard the agent gates use
+          // rather than echoing a detail that may claim the opposite.
+          const finding = describeAgentGateFinding(block.agentId!, reg.state, reg.detail, { instanceReachable: reachable });
+          console.log(`     ${render.icons.warn} ${finding?.message ?? `could not verify agent registration (${reg.detail})`}`);
         }
       }
 
@@ -12594,7 +12638,10 @@ program
     for (const id of verifiedReadAgentIds) {
       const reg = await checkAgentRegistered(baseUrl, id, defaultKeysDir());
       agentGates.push({ id, state: reg.state, detail: reg.detail });
-      const finding = describeAgentGateFinding(id, reg.state, reg.detail);
+      // harperResponding is necessarily true here (verifiedReadAgentIds is
+      // empty otherwise), so an "unreachable" verdict from this loop is
+      // always a self-contradiction — flair#1023. Hand the guard the fact.
+      const finding = describeAgentGateFinding(id, reg.state, reg.detail, { instanceReachable: harperResponding });
       if (finding?.isIssue) issues++;
     }
 
@@ -12605,7 +12652,7 @@ program
     // agent and moves on to the next (failure isolation).
     function renderAgentGateHeader(gate: { id: string; state: AgentGateState; detail?: string }): boolean {
       console.log(`    ${render.wrap(render.c.dim, `Agent: ${gate.id}`)}`);
-      const finding = describeAgentGateFinding(gate.id, gate.state, gate.detail);
+      const finding = describeAgentGateFinding(gate.id, gate.state, gate.detail, { instanceReachable: harperResponding });
       if (!finding) return true;
       const icon = finding.icon === "error" ? render.icons.error : render.icons.warn;
       console.log(`      ${icon} ${finding.message}`);
@@ -12787,7 +12834,7 @@ program
       if (agentGates.length === 0) {
         console.log(`  ${render.icons.info} Pass --agent <id> (with a matching key in ~/.flair/keys) to see migration state — requires a verified read, same as Fleet presence above.`);
       } else {
-        const passedGates = agentGates.filter((g) => describeAgentGateFinding(g.id, g.state, g.detail) === null);
+        const passedGates = agentGates.filter((g) => describeAgentGateFinding(g.id, g.state, g.detail, { instanceReachable: harperResponding }) === null);
         for (const gate of passedGates) {
           renderAgentGateHeader(gate);
           const keyPath = resolveKeyPath(gate.id) ?? join(defaultKeysDir(), `${gate.id}.key`);

--- a/src/doctor-client.ts
+++ b/src/doctor-client.ts
@@ -552,14 +552,6 @@ export interface AgentGateFinding {
 }
 
 /**
- * Render decision for one agent's registration-gate outcome, ahead of a
- * verified-read section (Fleet presence / Migrations). Returns null when the
- * agent is registered — the caller should proceed with its actual signed
- * read for that agent. Otherwise returns the finding to print for THAT
- * agent's subsection; the caller must still move on to the next agent
- * (failure isolation, flair#722) rather than aborting the whole section.
- */
-/**
  * What the run has already established about the instance, at the moment this
  * finding is rendered (flair#1023).
  *
@@ -574,6 +566,14 @@ export interface RunReachability {
   instanceReachable?: boolean;
 }
 
+/**
+ * Render decision for one agent's registration-gate outcome, ahead of a
+ * verified-read section (Fleet presence / Migrations). Returns null when the
+ * agent is registered — the caller should proceed with its actual signed
+ * read for that agent. Otherwise returns the finding to print for THAT
+ * agent's subsection; the caller must still move on to the next agent
+ * (failure isolation, flair#722) rather than aborting the whole section.
+ */
 export function describeAgentGateFinding(
   agentId: string,
   state: AgentGateState,
@@ -585,11 +585,15 @@ export function describeAgentGateFinding(
   // watched the instance answer. When it is, report the honest thing: the
   // check failed, and we know it was not connectivity.
   if (state === "unreachable" && reachability?.instanceReachable === true) {
+    // Strip the caller's own "instance unreachable:" prefix before quoting the
+    // detail — that prefix IS the claim being disclaimed, and leaving it in
+    // would reassert it in the same sentence that denies it.
+    const raw = detail?.replace(/^instance unreachable:\s*/i, "").trim();
     return {
       icon: "warn",
       message:
         `could not verify agent '${agentId}' registration — the instance responded to this run, ` +
-        `so this is not a connectivity problem${detail ? ` (${detail})` : ""}`,
+        `so this is not a connectivity problem${raw ? ` (${raw})` : ""}`,
       isIssue: false,
     };
   }

--- a/src/doctor-client.ts
+++ b/src/doctor-client.ts
@@ -496,8 +496,39 @@ export function fixCommandAgentHint(keyAgentIds: string[]): string {
 }
 
 /** checkAgentRegistered's (src/cli.ts) result states — duplicated here as a
- *  type only (no import) to keep this module network/crypto-free. */
-export type AgentGateState = "registered" | "not-registered" | "unreachable" | "no-key";
+ *  type only (no import) to keep this module network/crypto-free.
+ *
+ *  "key-unreadable" (flair#1023) is deliberately its own member rather than a
+ *  flavour of "unreachable": the two have opposite locations (their disk vs
+ *  the network), opposite remedies, and — because signing precedes the
+ *  request — are never ambiguous at the point they are raised. */
+export type AgentGateState = "registered" | "not-registered" | "unreachable" | "no-key" | "key-unreadable";
+
+/** Why verifySemanticSearch (src/cli.ts) returned `skipped` — duplicated here
+ *  as a type only (no import), same convention as AgentGateState. */
+export type SemanticSkipReason = "no-agent" | "no-key" | "key-load" | "probe-failed";
+
+/**
+ * The remedy line to print under doctor's "Embeddings: not verified" warning,
+ * or null when no remedy applies (flair#1023 requirement 4).
+ *
+ * doctor used to print "Pass --agent <id> ..." for EVERY skip reason. That
+ * sentence only fixes the two cases where no agent identity was resolved. It
+ * cannot fix a key that will not decode — following it produces the identical
+ * error — and it cannot fix an HTTP failure from the probe itself. Printing a
+ * remedy that provably will not change the outcome spends the operator's time
+ * and is worse than printing nothing, so those cases now print nothing.
+ */
+export function embeddingsSkipRemedy(reason: SemanticSkipReason): string | null {
+  switch (reason) {
+    case "no-agent":
+    case "no-key":
+      return "Pass --agent <id> (or set FLAIR_AGENT_ID) so doctor can run a real semantic round-trip.";
+    case "key-load":
+    case "probe-failed":
+      return null;
+  }
+}
 
 /** AgentGateState minus "unreachable", for the parts of the surface (like
  *  classifyKeyFile below) that only ever see it once instance reachability
@@ -528,10 +559,54 @@ export interface AgentGateFinding {
  * agent's subsection; the caller must still move on to the next agent
  * (failure isolation, flair#722) rather than aborting the whole section.
  */
-export function describeAgentGateFinding(agentId: string, state: AgentGateState, detail?: string): AgentGateFinding | null {
+/**
+ * What the run has already established about the instance, at the moment this
+ * finding is rendered (flair#1023).
+ *
+ * `instanceReachable: true` means an earlier check in the SAME run got a
+ * response — the state doctor is in whenever it reaches the agent gates at
+ * all, since it only enumerates agents when Harper answered. Passing it makes
+ * the contradiction in flair#1023 unrepresentable rather than merely fixed:
+ * no arrangement of inputs can produce a message claiming the instance is
+ * unreachable underneath a tick saying it responded.
+ */
+export interface RunReachability {
+  instanceReachable?: boolean;
+}
+
+export function describeAgentGateFinding(
+  agentId: string,
+  state: AgentGateState,
+  detail?: string,
+  reachability?: RunReachability,
+): AgentGateFinding | null {
+  // Self-inconsistency guard. "unreachable" is a legitimate state — a bare
+  // 500, a timeout — but it must never be ASSERTED after this run has already
+  // watched the instance answer. When it is, report the honest thing: the
+  // check failed, and we know it was not connectivity.
+  if (state === "unreachable" && reachability?.instanceReachable === true) {
+    return {
+      icon: "warn",
+      message:
+        `could not verify agent '${agentId}' registration — the instance responded to this run, ` +
+        `so this is not a connectivity problem${detail ? ` (${detail})` : ""}`,
+      isIssue: false,
+    };
+  }
   switch (state) {
     case "registered":
       return null;
+    case "key-unreadable":
+      return {
+        icon: "warn",
+        // Names the file and the operation. No cause is invented and no fix
+        // hint is offered: the failure classes that land here (a corrupt key,
+        // a file that is not an agent key at all) have different remedies and
+        // we cannot tell them apart from the bytes. A remedy we cannot stand
+        // behind is the flair#1023 defect, not a fix for it.
+        message: `could not verify agent '${agentId}' registration — ${detail ?? "its signing key could not be loaded"}`,
+        isIssue: false,
+      };
     case "no-key":
       return {
         icon: "warn",

--- a/src/lib/auth-resolve.ts
+++ b/src/lib/auth-resolve.ts
@@ -214,7 +214,110 @@ export function buildEd25519Auth(agentId: string, method: string, path: string, 
   return `TPS-Ed25519 ${agentId}:${ts}:${nonce}:${sig}`;
 }
 
-/** Authenticated fetch against Flair using Ed25519. */
+// ─── Key-load failures, told apart from transport failures (flair#1023) ─────
+//
+// An unparseable key file used to reach callers as a bare Error out of
+// authFetch, indistinguishable from `fetch` rejecting. Every caller with a
+// single `catch` around "sign, then send" therefore attributed it to the
+// network — `flair doctor` reported an operator's undecodable key as
+// "instance unreachable", six lines under its own `✓ Harper responding`.
+//
+// The fix is structural, not a better guess: signing STRICTLY precedes the
+// request, so the phase that failed is already known at the point of failure
+// and no longer has to be inferred from the error text. authFetch wraps only
+// the signing half in KeyLoadError; anything thrown after that is genuinely
+// transport. A caller that wants to tell them apart does `instanceof`, and
+// one that doesn't keeps working — KeyLoadError is an Error whose `message`
+// is strictly more informative than what it replaces.
+
+/**
+ * Why a key file could not be turned into a usable signing key.
+ *
+ * "unknown" is a real, load-bearing member, not a fallback to tidy up later:
+ * an unrecognised failure must stay unrecognised so callers report the raw
+ * error instead of asserting a cause they haven't established (flair#1023).
+ */
+export type KeyLoadFailureKind = "not-found" | "unreadable" | "decode" | "unknown";
+
+/**
+ * Classify a throw from `buildEd25519Auth`.
+ *
+ * Keyed on the STRUCTURED `code` property rather than on message text,
+ * because the message is not stable across crypto backends. Probed directly
+ * on the same 60-byte malformed input:
+ *
+ *   Node (OpenSSL)   ERR_OSSL_UNSUPPORTED       error:1E08010C:DECODER routines::unsupported
+ *                    ERR_OSSL_ASN1_WRONG_TAG    error:068000A8:asn1 encoding routines::wrong tag
+ *   Bun (BoringSSL)  ERR_OSSL_NO_START_LINE     error:0900006e:PEM routines:...:NO_START_LINE
+ *                    ERR_OSSL_WRONG_TAG         error:0c0000be:ASN.1 encoding routines:...:WRONG_TAG
+ *
+ * The first line is the error in flair#1023, and matching it alone would have
+ * left the tests (bun) and the shipped CLI (node) classifying differently.
+ * So the rule is the `ERR_OSSL_` family as a whole — sound here because
+ * buildEd25519Auth does no I/O beyond reading the file: any crypto-backend
+ * error it raises is about the key, never about the instance. Message text is
+ * a secondary signal only, for a backend that reports no code we recognise.
+ */
+export function classifyKeyLoadFailure(err: unknown): KeyLoadFailureKind {
+  const code = typeof (err as { code?: unknown })?.code === "string" ? (err as { code: string }).code : "";
+  if (code === "ENOENT") return "not-found";
+  if (code === "EACCES" || code === "EPERM" || code === "EISDIR") return "unreadable";
+  if (code.startsWith("ERR_OSSL")) return "decode";
+  const message = err instanceof Error ? err.message : String(err ?? "");
+  // `asn\.?1` because the two backends punctuate it differently:
+  // "asn1 encoding routines" (OpenSSL) vs "ASN.1 encoding routines" (BoringSSL).
+  if (/DECODER routines|asn\.?1 encoding routines|PEM routines/i.test(message)) return "decode";
+  return "unknown";
+}
+
+/** A signing key could not be loaded — distinct from the instance being down. */
+export class KeyLoadError extends Error {
+  /** The file we tried to read. Known at the point of failure; used to be discarded. */
+  readonly keyPath: string;
+  readonly kind: KeyLoadFailureKind;
+  /** The underlying error's message, preserved verbatim for the operator. */
+  readonly underlying: string;
+
+  constructor(keyPath: string, kind: KeyLoadFailureKind, underlying: string) {
+    super(describeKeyLoadFailure(keyPath, kind, underlying));
+    this.name = "KeyLoadError";
+    this.keyPath = keyPath;
+    this.kind = kind;
+    this.underlying = underlying;
+  }
+
+  static from(keyPath: string, err: unknown): KeyLoadError {
+    const underlying = err instanceof Error ? err.message : String(err ?? "");
+    return new KeyLoadError(keyPath, classifyKeyLoadFailure(err), underlying);
+  }
+}
+
+/**
+ * One line an operator can act on: what we were doing, which file, and — only
+ * when it has actually been established — why. The "unknown" arm deliberately
+ * states no cause and shows the raw error instead (flair#1023 requirement 1).
+ */
+export function describeKeyLoadFailure(keyPath: string, kind: KeyLoadFailureKind, underlying: string): string {
+  switch (kind) {
+    case "not-found":
+      return `signing key ${keyPath} does not exist`;
+    case "unreadable":
+      return `signing key ${keyPath} could not be read (${underlying})`;
+    case "decode":
+      return `signing key ${keyPath} could not be parsed as an Ed25519 private key (${underlying})`;
+    case "unknown":
+      // No cause is asserted — we genuinely do not know one.
+      return `signing key ${keyPath} could not be loaded: ${underlying}`;
+  }
+}
+
+/**
+ * Authenticated fetch against Flair using Ed25519.
+ *
+ * Throws {@link KeyLoadError} if the key could not be loaded — a failure that
+ * provably happened BEFORE any byte hit the network, so no caller need guess
+ * whether the instance is reachable. Anything else thrown here is transport.
+ */
 export async function authFetch(
   baseUrl: string,
   agentId: string,
@@ -223,7 +326,12 @@ export async function authFetch(
   path: string,
   body?: unknown,
 ): Promise<Response> {
-  const auth = buildEd25519Auth(agentId, method, path, keyPath);
+  let auth: string;
+  try {
+    auth = buildEd25519Auth(agentId, method, path, keyPath);
+  } catch (err: unknown) {
+    throw KeyLoadError.from(keyPath, err);
+  }
   const headers: Record<string, string> = { Authorization: auth };
   if (body !== undefined) headers["Content-Type"] = "application/json";
   return fetch(`${baseUrl}${path}`, {

--- a/test/unit/doctor-key-decode-classification.test.ts
+++ b/test/unit/doctor-key-decode-classification.test.ts
@@ -1,0 +1,334 @@
+/**
+ * doctor-key-decode-classification.test.ts — flair#1023.
+ *
+ * One unparseable key file used to surface in `flair doctor` twice, under two
+ * different explanations, neither of which was the cause:
+ *
+ *     ⚠️ Embeddings: not verified (probe error: error:1E08010C:DECODER routines::unsupported)
+ *        Pass --agent <id> (or set FLAIR_AGENT_ID) so doctor can run a real semantic round-trip.
+ *     ⚠️ could not verify agent 'X' registration
+ *        (instance unreachable: error:1E08010C:DECODER routines::unsupported)
+ *
+ * — the second printed six lines under doctor's own "✓ Harper responding".
+ *
+ * The root cause was structural, not a bad string: authFetch signs and then
+ * sends inside one function, so every caller's single `catch` attributed a
+ * signing failure to the network. Signing strictly precedes the request, so
+ * the phase is knowable at the point of failure; authFetch now raises
+ * KeyLoadError for the signing half only.
+ *
+ * These tests hold the four properties the issue asks for:
+ *   1. no cause is attached to an unclassified error;
+ *   2. the key-decode class is named, WITH the file that failed;
+ *   3. "unreachable" is never claimed after this run saw the instance answer;
+ *   4. a remedy is only printed when it could change the outcome.
+ *
+ * Plus a POSITIVE CONTROL: a healthy key still takes the normal successful
+ * path. Without it, every assertion here would also pass with signing
+ * unconditionally broken.
+ *
+ * The malformed fixture is 60 synthetic, deterministic, NON-SECRET bytes —
+ * generated from an arithmetic sequence, never a real key — so nothing
+ * sensitive can reach this test's failure output. Its shape mirrors the
+ * real-world file that produced the report, and it drives the loader down
+ * the same last-resort branch: under Node it raises the report's exact
+ * `error:1E08010C:DECODER routines::unsupported`; under bun (BoringSSL, which
+ * runs this suite) the same branch raises
+ * `error:0900006e:PEM routines:...:NO_START_LINE`. Both were probed directly.
+ * Assertions here are therefore on the CLASSIFICATION, which is identical
+ * across backends — the backend-specific strings are exercised separately
+ * from constructed errors.
+ */
+
+import { describe, test, expect, beforeAll, afterAll, afterEach } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import nacl from "tweetnacl";
+
+import {
+  authFetch,
+  classifyKeyLoadFailure,
+  describeKeyLoadFailure,
+  KeyLoadError,
+} from "../../src/lib/auth-resolve.ts";
+import { checkAgentRegistered, verifySemanticSearch } from "../../src/cli.ts";
+import { describeAgentGateFinding, embeddingsSkipRemedy } from "../../src/doctor-client.ts";
+
+// The literal string from the issue report — what Node's OpenSSL raises.
+// Bun links BoringSSL and words the SAME failure differently, so anything
+// asserting on backend-specific text below constructs the error itself.
+const DECODER_ERROR = "error:1E08010C:DECODER routines::unsupported";
+
+// Deliberately distinctive ids so resolveKeyPath's real-home lookups
+// (~/.flair/keys, ~/.tps/secrets/flair) can never shadow the temp fixture —
+// this test must never read or write a real key directory.
+const BAD_AGENT = "flair1023-undecodable-agent";
+const GOOD_AGENT = "flair1023-healthy-agent";
+const BASE_URL = "http://127.0.0.1:19926";
+
+let keysDir: string;
+let badKeyPath: string;
+const realFetch = globalThis.fetch;
+
+beforeAll(() => {
+  keysDir = mkdtempSync(join(tmpdir(), "flair-1023-keys-"));
+
+  // Non-secret, deterministic, and NOT an Ed25519 key in any accepted format.
+  badKeyPath = join(keysDir, `${BAD_AGENT}.key`);
+  writeFileSync(badKeyPath, Buffer.from(Array.from({ length: 60 }, (_, i) => (i * 37 + 11) & 0xff)));
+
+  // Positive control: a genuinely valid 32-byte seed.
+  const kp = nacl.sign.keyPair();
+  writeFileSync(join(keysDir, `${GOOD_AGENT}.key`), Buffer.from(kp.secretKey.slice(0, 32)));
+});
+
+afterAll(() => {
+  rmSync(keysDir, { recursive: true, force: true });
+});
+
+afterEach(() => {
+  globalThis.fetch = realFetch;
+});
+
+// ── The fixture actually reproduces the reported failure ────────────────────
+
+describe("fixture", () => {
+  test("the malformed key reproduces the exact OpenSSL error from the report", async () => {
+    // Any fetch at all would mean the failure was NOT purely local.
+    globalThis.fetch = (() => {
+      throw new Error("network must not be touched when the key cannot load");
+    }) as unknown as typeof fetch;
+
+    const err = await authFetch(BASE_URL, BAD_AGENT, badKeyPath, "GET", "/Agent/x").then(
+      () => null,
+      (e: unknown) => e,
+    );
+    expect(err).toBeInstanceOf(KeyLoadError);
+    const keyErr = err as KeyLoadError;
+    // Classified as a key-decode failure under whichever crypto backend is
+    // running, and never mistaken for the network.
+    expect(keyErr.kind).toBe("decode");
+    expect(keyErr.keyPath).toBe(badKeyPath);
+    // The backend's own words are passed through verbatim, not paraphrased.
+    expect(keyErr.underlying.length).toBeGreaterThan(0);
+    expect(keyErr.message).toContain(keyErr.underlying);
+  });
+
+  test("both crypto backends' wording for this failure classifies identically", () => {
+    // Guards the split that made the test suite (bun) and the shipped CLI
+    // (node) disagree: same defect, four different strings.
+    const shapes = [
+      { code: "ERR_OSSL_UNSUPPORTED", message: DECODER_ERROR },
+      { code: "ERR_OSSL_ASN1_WRONG_TAG", message: "error:068000A8:asn1 encoding routines::wrong tag" },
+      { code: "ERR_OSSL_NO_START_LINE", message: "error:0900006e:PEM routines:OPENSSL_internal:NO_START_LINE" },
+      { code: "ERR_OSSL_WRONG_TAG", message: "error:0c0000be:ASN.1 encoding routines:OPENSSL_internal:WRONG_TAG" },
+    ];
+    for (const s of shapes) {
+      expect(classifyKeyLoadFailure(Object.assign(new Error(s.message), { code: s.code }))).toBe("decode");
+      // ...and on message alone, for a backend that supplies no code.
+      expect(classifyKeyLoadFailure(new Error(s.message))).toBe("decode");
+    }
+  });
+});
+
+// ── 1 + 2: classify, or say nothing — and name the file either way ─────────
+
+describe("classifyKeyLoadFailure", () => {
+  test("OpenSSL's DECODER rejection is the decode class (structured code, not message text)", () => {
+    const e = Object.assign(new Error(DECODER_ERROR), { code: "ERR_OSSL_UNSUPPORTED" });
+    expect(classifyKeyLoadFailure(e)).toBe("decode");
+  });
+
+  test("a mis-shaped DER body is also the decode class", () => {
+    const e = Object.assign(new Error("error:068000A8:asn1 encoding routines::wrong tag"), {
+      code: "ERR_OSSL_ASN1_WRONG_TAG",
+    });
+    expect(classifyKeyLoadFailure(e)).toBe("decode");
+  });
+
+  test("an OpenSSL build that reports no code we know still classifies on the message", () => {
+    expect(classifyKeyLoadFailure(new Error(DECODER_ERROR))).toBe("decode");
+  });
+
+  test("a missing file is not-found, an unreadable one is unreadable", () => {
+    expect(classifyKeyLoadFailure(Object.assign(new Error("x"), { code: "ENOENT" }))).toBe("not-found");
+    expect(classifyKeyLoadFailure(Object.assign(new Error("x"), { code: "EACCES" }))).toBe("unreadable");
+  });
+
+  test("anything unrecognised stays UNKNOWN — the point of the issue", () => {
+    // The defect was attaching a confident cause to whatever error arrived.
+    // An unrecognised failure must remain unrecognised.
+    expect(classifyKeyLoadFailure(new Error("something nobody has seen before"))).toBe("unknown");
+    expect(classifyKeyLoadFailure("a bare string")).toBe("unknown");
+  });
+});
+
+describe("describeKeyLoadFailure", () => {
+  test("the decode class names the file AND the expected key type", () => {
+    const msg = describeKeyLoadFailure("/keys/agent.key", "decode", DECODER_ERROR);
+    expect(msg).toContain("/keys/agent.key");
+    expect(msg).toContain("Ed25519");
+    expect(msg).toContain(DECODER_ERROR);
+  });
+
+  test("the unknown class asserts NO cause — it names the operation and shows the error", () => {
+    const msg = describeKeyLoadFailure("/keys/agent.key", "unknown", "some novel failure");
+    expect(msg).toContain("/keys/agent.key");
+    expect(msg).toContain("some novel failure");
+    // No guess about why, and specifically not either of the two wrong ones.
+    expect(msg).not.toContain("unreachable");
+    expect(msg).not.toContain("--agent");
+  });
+
+  test("KeyLoadError.from keeps the path the code already had and used to discard", () => {
+    const err = KeyLoadError.from("/keys/agent.key", Object.assign(new Error(DECODER_ERROR), {
+      code: "ERR_OSSL_UNSUPPORTED",
+    }));
+    expect(err.keyPath).toBe("/keys/agent.key");
+    expect(err.kind).toBe("decode");
+    expect(err.message).toContain("/keys/agent.key");
+  });
+});
+
+// ── 3: never claim unreachable for a key that would not load ───────────────
+
+describe("checkAgentRegistered with an undecodable key", () => {
+  test("reports key-unreadable, names the file, and never says 'unreachable'", async () => {
+    globalThis.fetch = (() => {
+      throw new Error("network must not be touched when the key cannot load");
+    }) as unknown as typeof fetch;
+
+    const reg = await checkAgentRegistered(BASE_URL, BAD_AGENT, keysDir);
+    expect(reg.state).toBe("key-unreadable");
+    // Requirement 2 — name the file that failed and the key type expected.
+    expect(reg.detail).toContain(badKeyPath);
+    expect(reg.detail).toContain("Ed25519");
+    // The two wrong causes from the report.
+    expect(reg.detail).not.toContain("unreachable");
+    expect(reg.detail).not.toContain("--agent");
+  });
+
+  test("the rendered finding names the file and offers no remedy it cannot deliver", () => {
+    const f = describeAgentGateFinding(
+      BAD_AGENT,
+      "key-unreadable",
+      describeKeyLoadFailure(badKeyPath, "decode", DECODER_ERROR),
+      { instanceReachable: true },
+    );
+    expect(f).not.toBeNull();
+    expect(f!.icon).toBe("warn");
+    expect(f!.isIssue).toBe(false);
+    expect(f!.message).toContain(badKeyPath);
+    expect(f!.message).not.toContain("unreachable");
+    // Requirement 4 — no remedy is better than one that cannot work.
+    expect(f!.fixHint).toBeUndefined();
+  });
+});
+
+// ── 3 (general): the self-inconsistency guard ──────────────────────────────
+
+describe("describeAgentGateFinding reachability guard", () => {
+  test("'unreachable' is never asserted once this run already saw the instance answer", () => {
+    const f = describeAgentGateFinding("local", "unreachable", "instance unreachable: fetch failed", {
+      instanceReachable: true,
+    });
+    expect(f).not.toBeNull();
+    // The old output contradicted doctor's own "✓ Harper responding" tick.
+    expect(f!.message).toContain("the instance responded");
+    expect(f!.message).toContain("not a connectivity problem");
+    expect(f!.isIssue).toBe(false);
+  });
+
+  test("without an established reachability fact, 'unreachable' is still reportable", () => {
+    // The state is legitimate (a bare 500, a timeout) — the guard suppresses
+    // the CONTRADICTION, not the state.
+    const f = describeAgentGateFinding("local", "unreachable", "HTTP 500");
+    expect(f!.message).toContain("could not verify");
+    expect(f!.message).not.toContain("the instance responded");
+  });
+
+  test("key-unreadable never counts as an issue; only not-registered does", () => {
+    const cases: Array<[Parameters<typeof describeAgentGateFinding>[1], boolean]> = [
+      ["registered", false],
+      ["no-key", false],
+      ["not-registered", true],
+      ["unreachable", false],
+      ["key-unreadable", false],
+    ];
+    for (const [state, expectIssue] of cases) {
+      expect(describeAgentGateFinding("x", state)?.isIssue ?? false).toBe(expectIssue);
+    }
+  });
+});
+
+// ── 4: a remedy must be able to fix the error it is printed under ──────────
+
+describe("verifySemanticSearch with an undecodable key", () => {
+  test("skips with reason 'key-load', names the file, and suppresses the --agent advice", async () => {
+    globalThis.fetch = (() => {
+      throw new Error("network must not be touched when the key cannot load");
+    }) as unknown as typeof fetch;
+
+    const res = await verifySemanticSearch(BASE_URL, BAD_AGENT, keysDir);
+    expect(res.state).toBe("skipped");
+    const skipped = res as Extract<typeof res, { state: "skipped" }>;
+    expect(skipped.reason).toBe("key-load");
+    expect(skipped.detail).toContain(badKeyPath);
+    expect(skipped.detail).not.toContain("unreachable");
+    // The remedy the operator was given for this exact failure. Following it
+    // produces the identical error, so it must not be printed.
+    expect(embeddingsSkipRemedy(skipped.reason)).toBeNull();
+  });
+});
+
+describe("embeddingsSkipRemedy", () => {
+  test("'--agent' is offered only where it can actually resolve an identity", () => {
+    expect(embeddingsSkipRemedy("no-agent")).toContain("--agent");
+    expect(embeddingsSkipRemedy("no-key")).toContain("--agent");
+  });
+
+  test("no remedy is printed for failures --agent cannot change", () => {
+    expect(embeddingsSkipRemedy("key-load")).toBeNull();
+    expect(embeddingsSkipRemedy("probe-failed")).toBeNull();
+  });
+});
+
+// ── POSITIVE CONTROL ───────────────────────────────────────────────────────
+//
+// Everything above asserts on error branches. If signing were broken outright,
+// or if authFetch raised KeyLoadError unconditionally, every one of those
+// tests would still pass. These fail in that case.
+
+describe("positive control — a healthy key still takes the normal path", () => {
+  test("a valid seed signs and reaches the network, and a 200 reads as registered", async () => {
+    let sentAuth: string | undefined;
+    globalThis.fetch = (async (_url: string, init?: RequestInit) => {
+      sentAuth = (init?.headers as Record<string, string>)?.Authorization;
+      return new Response(JSON.stringify({ id: GOOD_AGENT }), { status: 200 });
+    }) as unknown as typeof fetch;
+
+    const reg = await checkAgentRegistered(BASE_URL, GOOD_AGENT, keysDir);
+    expect(reg.state).toBe("registered");
+    // Proof the request was actually signed and dispatched, not short-circuited.
+    expect(sentAuth).toBeDefined();
+    expect(sentAuth!.startsWith("TPS-Ed25519 ")).toBe(true);
+    expect(describeAgentGateFinding(GOOD_AGENT, reg.state, reg.detail, { instanceReachable: true })).toBeNull();
+  });
+
+  test("a genuine transport failure is still reported as unreachable, not as a key problem", async () => {
+    globalThis.fetch = (async () => {
+      throw new Error("fetch failed");
+    }) as unknown as typeof fetch;
+
+    const reg = await checkAgentRegistered(BASE_URL, GOOD_AGENT, keysDir);
+    expect(reg.state).toBe("unreachable");
+    expect(reg.detail).toContain("instance unreachable");
+  });
+
+  test("a healthy key with no agent resolvable still gets the --agent remedy", () => {
+    // The advice the issue calls wrong for a decode failure is RIGHT here, and
+    // must not have been removed wholesale.
+    expect(embeddingsSkipRemedy("no-agent")).toContain("FLAIR_AGENT_ID");
+  });
+});

--- a/test/unit/doctor-key-decode-classification.test.ts
+++ b/test/unit/doctor-key-decode-classification.test.ts
@@ -238,6 +238,10 @@ describe("describeAgentGateFinding reachability guard", () => {
     expect(f!.message).toContain("the instance responded");
     expect(f!.message).toContain("not a connectivity problem");
     expect(f!.isIssue).toBe(false);
+    // The disclaimed claim must not survive inside the quoted detail, or the
+    // sentence reasserts what it just denied. The raw error is still shown.
+    expect(f!.message).not.toContain("instance unreachable");
+    expect(f!.message).toContain("fetch failed");
   });
 
   test("without an established reachability fact, 'unreachable' is still reportable", () => {


### PR DESCRIPTION
Closes #1023.

One unparseable key file surfaced twice in a single `flair doctor` report, under two different explanations, neither of which was the cause — and one of which contradicted a check the same report had made six lines earlier.

## The defect

`error:1E08010C:DECODER routines::unsupported` is OpenSSL failing to decode a key. Doctor reported it as a missing `--agent`, and separately as an unreachable instance — directly beneath its own `✓ Harper responding` tick. An agent *had* been selected. The instance *had* answered. The operator was sent to check firewalls and ports for a file on their own disk.

Both messages came from a `catch` attaching a fixed explanation to whatever error arrived.

## Why it happened, and the fix

The cause is structural rather than a badly-worded string. `authFetch` signs and then sends inside one function, so a caller with a single `catch` around it cannot tell a signing failure from a transport failure and attributes everything to the network.

But signing *strictly precedes* the request. The phase that failed is already known at the point of failure — it was simply being discarded. `authFetch` now wraps only the signing half in a distinct `KeyLoadError` carrying the key path. Nothing downstream has to infer from an error string whether the network was ever reached, and no future caller can make this mistake by writing an ordinary `try`/`catch`.

On top of that structural split:

**Classify, or say nothing.** A key-decode failure is named as such, with the file that failed — the code knew which file it was reading and threw that away. An unrecognised failure stays unrecognised: it reports the operation and the raw error and asserts no cause at all.

**Recognition is by structured error code, not message text.** The two crypto backends word the identical failure four different ways:

| runtime | code | message |
| --- | --- | --- |
| Node (OpenSSL) | `ERR_OSSL_UNSUPPORTED` | `error:1E08010C:DECODER routines::unsupported` |
| Node (OpenSSL) | `ERR_OSSL_ASN1_WRONG_TAG` | `error:068000A8:asn1 encoding routines::wrong tag` |
| Bun (BoringSSL) | `ERR_OSSL_NO_START_LINE` | `error:0900006e:PEM routines:...:NO_START_LINE` |
| Bun (BoringSSL) | `ERR_OSSL_WRONG_TAG` | `error:0c0000be:ASN.1 encoding routines:...:WRONG_TAG` |

All four probed directly. Matching the reported string alone would have left the test suite (bun) and the shipped CLI (node) classifying the same defect differently — the first draft did exactly that, and the tests caught it.

**"Unreachable" cannot contradict an established fact.** Registration findings now carry the reachability the run already has. Worth noting how guaranteed this was: the agent-gate loop only runs `if (harperResponding)`, so *every* "instance unreachable" it could ever print was a self-contradiction, not an unlucky race.

**A remedy must be able to fix the error it is printed under.** `Pass --agent` is printed only for the skip reasons it can resolve. `verifySemanticSearch`'s `skipped` state now carries a reason, because it covered several unrelated situations that all received the same one-size advice.

### Before / after

Live `flair doctor` runs against a real responding instance, with a real key file that exhibits the bug — same command, same key, `origin/main` vs this branch (agent id and key path genericised):

**Before** — reproduces the report exactly:

```
  ✓ Harper responding on port 9926
  ⚠ Embeddings: not verified (probe error: error:1E08010C:DECODER routines::unsupported)
     Pass --agent <id> (or set FLAIR_AGENT_ID) so doctor can run a real semantic round-trip.
    Agent: my-agent
      ⚠ could not verify agent 'my-agent' registration (instance unreachable: error:1E08010C:DECODER routines::unsupported)
```

**After**:

```
  ✓ Harper responding on port 9926
  ⚠ Embeddings: not verified (signing key ~/.flair/keys/my-agent.key could not be
    parsed as an Ed25519 private key (error:1E08010C:DECODER routines::unsupported))
    Agent: my-agent
      ⚠ could not verify agent 'my-agent' registration — signing key
        ~/.flair/keys/my-agent.key could not be parsed as an Ed25519 private key
        (error:1E08010C:DECODER routines::unsupported)
```

No `unreachable`. No unreachable remedy. Both messages name the file, and neither contradicts the tick three lines above.

## Deliberately not fixed here

**No fix hint for the decode case.** A corrupt agent key and a federation keystore file produce the identical error and have opposite remedies — and `flair keys prune` would archive the latter. Guessing between them is the defect this PR fixes, so it doesn't guess. `docs/troubleshooting.md` gains a section on telling them apart.

**The namespace collision itself is filed separately as #1026.** `src/keystore.ts` writes AES-256-GCM blobs to the same `~/.flair/keys/<id>.key` template the plaintext agent keys use; the blob is exactly 60 bytes for a 32-byte seed (12 IV + 16 tag + 32 ciphertext), which is why it falls past every plaintext branch of the loader into `createPrivateKey(raw)`. That is the *source* of the undecodable file. Fixing it is a key-store change, not a reporting change, and is out of scope here.

Investigating that also **refuted** the initial theory that plaintext keys come in two incompatible formats. The 32-byte-raw vs 64-byte-base64 split is real, but both loaders handle both and both load cleanly. Only keystore blobs fail.

## Testing

New `test/unit/doctor-key-decode-classification.test.ts` — 21 tests. The malformed fixture is 60 synthetic, deterministic, non-secret bytes generated from an arithmetic sequence, never a real key, so nothing sensitive can reach failure output. It drives the loader down the same last-resort branch as the real file.

- Asserts the message names the file and the decode failure, and that it says neither `unreachable` nor `--agent`.
- Asserts the network is never touched when the key cannot load (fetch stubbed to throw).
- **Positive control**: a healthy key still signs, dispatches a `TPS-Ed25519` header and reads as registered; a genuine transport failure is still reported as unreachable; `--agent` is still offered where it applies.

**Mutation check** — six mutants, each applied, run, and reverted:

| mutant | result |
| --- | --- |
| unmutated | 21 pass / 0 fail |
| decode class becomes `unknown` | 15 pass / **6 fail** |
| `authFetch` rethrows raw instead of `KeyLoadError` | 18 pass / **3 fail** |
| reachability guard disabled | 20 pass / **1 fail** |
| remedy printed for every skip reason | 19 pass / **2 fail** |
| signing always fails (kills the positive control) | 17 pass / **4 fail** |
| restored | 21 pass / 0 fail |

All six caught, including the one that exists to prove the positive control is load-bearing rather than decorative.

### Counts, against a baseline measured on a clean `origin/main` worktree

CI's unit lane (`bun test test/unit/ test/*.test.ts`):

| | tests | files | pass | fail |
| --- | --- | --- | --- | --- |
| `origin/main` | 3825 | 205 | 3825 | 0 |
| this branch | 3846 | 206 | 3846 | 0 |

+21 tests in +1 file — exactly this PR's new file, no regressions.

Whole local suite (`bun test`, which also sweeps the integration lane):

| | tests | files | pass | fail | errors |
| --- | --- | --- | --- | --- | --- |
| `origin/main` | 4615 | 288 | 4595 | 20 | 8 |
| this branch | 4636 | 289 | 4616 | 20 | 8 |

+21 pass, +21 tests, +1 file. The 20 failures and 8 errors are byte-identical sets on both trees (diffed by test name) — integration cases needing network/model fixtures this host doesn't provide, plus the two below. Nothing in them is touched by this change.

(A bare `bun test` additionally sweeps `test/unit-isolated/`, whose `mock.module` calls poison two `test/unit/` embeddings files by design — hence CI running that directory one file per process. Those two fail identically on `origin/main` and pass in isolation on both trees.)

`tsc -p tsconfig.json --noEmit` reports the single pre-existing `resources/auth-middleware.ts(70,1)` error, unchanged; `src` typechecks clean. `docs-freshness-check` 7/7 ran and passed against a built CLI (no `DID NOT RUN`).