### PR TITLE
feat(oauth): rate limit the OAuth endpoints and /mcp

### DIFF
--- a/.changelog/unreleased/security-oauth-rate-limiting.md
+++ b/.changelog/unreleased/security-oauth-rate-limiting.md
@@ -1,0 +1,27 @@
+- **The OAuth endpoints and `/mcp` are now rate limited.** `/OAuthToken`,
+  `/OAuthAuthorize` and `/OAuthRevoke` share a budget of 30 requests per minute
+  per caller; `/OAuthRegister` gets 5 per five minutes; `/mcp` gets 120 per
+  minute per verified token subject. A rejected request answers `429` with a
+  `Retry-After`. On by default — nothing to configure — and no other path is
+  affected.
+
+  The counter is consumed before any credential is examined, so a `429` reveals
+  nothing about what the request was carrying: a valid authorization code and a
+  garbage one get byte-identical responses once a bucket is spent. No
+  `RateLimit-*` headers are published on allowed requests.
+
+  Tunable via `FLAIR_OAUTH_RATE_LIMIT`, `FLAIR_OAUTH_REGISTER_RATE_LIMIT` and
+  `FLAIR_MCP_RATE_LIMIT`; `FLAIR_RATE_LIMIT=off` disables it entirely. A limit
+  of zero, a negative number or a non-numeric value is refused in favour of the
+  default, with a warning naming the variable — a shell that expanded an unset
+  variable cannot quietly switch the control off.
+
+  Keying is on the socket peer address. `X-Forwarded-For` is ignored unless
+  `FLAIR_TRUSTED_PROXY` names how many proxy hops genuinely sit in front, since
+  an instance that trusts that header without a proxy can be bypassed by varying
+  it. **The limiter is per node**: on a multi-node deployment the effective
+  ceiling is the limit times the node count, and counters reset on component
+  reload. A cluster-shared counter would turn every counted request into a
+  durable replicated write on an authentication hot path, which is a worse
+  denial-of-service shape than the one being defended against. See
+  [docs/auth.md](docs/auth.md) for what this does and does not protect against.

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -108,6 +108,57 @@ The protected-resource document is also served at the RFC 9728 §3.1
 path-appended URL `/.well-known/oauth-protected-resource/mcp`, which is the form
 MCP clients construct from the resource identifier.
 
+### Rate limiting
+
+The OAuth endpoints and the OAuth-guarded `/mcp` surface are rate limited. This
+is on by default; nothing needs configuring for it to apply.
+
+| Surface | Default | Window | Keyed on |
+|---------|---------|--------|----------|
+| `/OAuthToken`, `/OAuthAuthorize`, `/OAuthRevoke` (one shared budget) | 30 | 60s | Caller address |
+| `/OAuthRegister` | 5 | 300s | Caller address |
+| `/mcp` | 120 | 60s | The verified token subject |
+
+A rejected request gets `429` with a `Retry-After`, and a body that echoes
+nothing back. The counter is consumed *before* any credential is examined, so a
+`429` says nothing about the credential that came with it — a valid
+authorization code and a garbage one get byte-identical responses once a bucket
+is spent. No `RateLimit-*` headers are emitted on requests that are allowed;
+publishing a live remaining-count on a credential endpoint is a pacing aid for
+exactly the caller you don't want to help.
+
+| Variable | Default | Meaning |
+|----------|---------|---------|
+| `FLAIR_RATE_LIMIT` | on | Set to `off` to disable rate limiting entirely. An unrecognised value leaves it **enabled**. |
+| `FLAIR_OAUTH_RATE_LIMIT` | `30` | Requests per 60s for the token/authorize/revoke budget. |
+| `FLAIR_OAUTH_REGISTER_RATE_LIMIT` | `5` | Registrations per 300s. |
+| `FLAIR_MCP_RATE_LIMIT` | `120` | `/mcp` calls per 60s per token subject. |
+| `FLAIR_TRUSTED_PROXY` | `0` | Number of trusted reverse-proxy hops in front of this instance. |
+
+A limit set to `0`, a negative number, or anything non-numeric is refused and the
+default is used, with a warning naming the variable — so a shell that expanded an
+unset variable cannot silently switch the control off.
+
+**`FLAIR_TRUSTED_PROXY` and NAT.** By default the key is the socket peer address
+and `X-Forwarded-For` is ignored completely, because that header is caller-supplied:
+an instance that honours it with no proxy in front can be bypassed by anyone
+willing to vary a header. Set `FLAIR_TRUSTED_PROXY` to the number of proxies that
+genuinely sit in front and append to `X-Forwarded-For`, and the key becomes the
+entry those hops wrote (counted from the right — never the leftmost entry, which
+the original caller controls). Keying on an address means a busy NAT shares one
+budget; the defaults leave roughly two orders of magnitude of headroom over real
+usage, and raising them is a one-variable change.
+
+**This limiter is per node.** The counter lives in the serving process. On a
+multi-node deployment the effective ceiling is the configured limit times the
+number of nodes, and the counters reset when a component reloads. That is a
+deliberate trade: a cluster-shared counter in a Harper table would make every
+counted request a durable replicated write on an authentication hot path, which
+is a worse denial-of-service shape than the one being defended against. The
+control here bounds how fast a caller can guess against 256-bit secrets, and a
+small constant multiplier does not change that. It does **not** defend against a
+distributed botnet, and it is not a capacity control.
+
 Every URL in every one of these documents derives from `FLAIR_PUBLIC_URL`,
 falling back to the loopback bind address. **Set `FLAIR_PUBLIC_URL` on any
 deployment reachable at something other than localhost** — otherwise the

--- a/resources/auth-middleware.ts
+++ b/resources/auth-middleware.ts
@@ -5,6 +5,7 @@ import { isAdmin, FLAIR_AGENT_USERNAME } from "./agent-auth.js";
 import { WINDOW_MS, isNonceReplay, recordNonce, importEd25519Key, b64ToArrayBuffer, parseTpsEd25519Header } from "./ed25519-auth.js";
 import { resolveReadScope } from "./memory-read-scope.js";
 import { isForbiddenOwnerMutation, resolveGuardedRecord } from "./record-owner-guard.js";
+import { checkHttpRateLimit } from "./rate-limit.js";
 
 // --- Admin credentials ---
 // Admin auth is sourced exclusively from Harper's own environment variables
@@ -69,6 +70,26 @@ async function backfillEmbedding(memoryId: string): Promise<void> {
 
 server.http(async (request: any, nextLayer: any) => {
   const url = new URL(request.url, "http://" + (request.headers.get("host") || "localhost"));
+
+  // ── Rate limiting, FIRST ───────────────────────────────────────────────────
+  // Before the public-path passthrough below (the OAuth endpoints all sit on it,
+  // so a hook placed after it would never run for them), and before anything
+  // reads a credential.
+  //
+  // Ordering is a security property, not tidiness. The counter is consumed for
+  // every request to a throttled endpoint whether or not the credential that
+  // came with it was any good — if only failures were counted, "did this consume
+  // budget" would answer "was that credential valid", which is a cleaner
+  // enumeration oracle than the 400 the endpoint already returns. Because the
+  // decision is made here, a limited request carries no information about what
+  // it was carrying: a valid authorization code and a garbage one get the same
+  // 429 and the same body.
+  //
+  // Only the OAuth endpoints named in rate-limit.ts's PATH_POLICY are affected.
+  // Every other path — /Memory, /Presence, /FederationSync, everything agents
+  // actually use — returns null here and is untouched.
+  const limited = checkHttpRateLimit(request, url.pathname);
+  if (limited) return limited;
 
   // A2A discovery endpoints: GET returns public agent-card metadata (per
   // A2A spec, cards are intentionally public). POST invokes JSON-RPC

--- a/resources/mcp-oauth.ts
+++ b/resources/mcp-oauth.ts
@@ -20,6 +20,7 @@
 
 import * as harper from "harper";
 import { mcpOAuthEnabled, mcpAuthConfig } from "./mcp-oauth-flag.js";
+import { checkMcpRateLimit } from "./rate-limit.js";
 // NOTE: mcpHandler is intentionally NOT statically imported here — it's resolved
 // lazily (deps.mcpHandler ?? dynamic import) inside registerMcpOAuthRoute, same
 // as loadWithMCPAuth below. A static `import { mcpHandler } from "./mcp-handler.js"`
@@ -116,6 +117,33 @@ async function defaultLoadWithMCPAuth(): Promise<(handler: any, options?: any) =
   return mod.withMCPAuth;
 }
 
+/**
+ * Wrap the /mcp handler in the per-subject rate limit.
+ *
+ * Placed INSIDE `withMCPAuth` — i.e. the guard runs first and this runs second —
+ * so the key is the RS256-verified `sub` from the token rather than a network
+ * address. That is the identity worth limiting on for an authenticated surface:
+ * it is the authorization server's own assertion, it survives the caller
+ * changing address, and it is exactly the thing "a valid token can hammer the
+ * tools" is about. Authentication is not a rate limit.
+ *
+ * The consequence of that placement, stated rather than left implicit: requests
+ * bearing an INVALID token are rejected by `withMCPAuth` before this runs and so
+ * are not counted here. Those cost one JWT verification against a locally-cached
+ * key and touch no flair table or tool, which is a materially cheaper path than
+ * a tool call — but it is not zero, and it is not throttled at this layer.
+ *
+ * Exported for tests: the limiter's behaviour is asserted directly on this
+ * wrapper, without needing the plugin present.
+ */
+export function rateLimitedMcpHandler(handler: (request: any) => Promise<any>): (request: any) => Promise<any> {
+  return async (request: any) => {
+    const limited = checkMcpRateLimit(request);
+    if (limited) return limited;
+    return handler(request);
+  };
+}
+
 export async function registerMcpOAuthRoute(deps: RegisterDeps = {}): Promise<boolean> {
   if (!mcpOAuthEnabled()) {
     // OFF → no route, no import, no side effects.
@@ -184,7 +212,7 @@ export async function registerMcpOAuthRoute(deps: RegisterDeps = {}): Promise<bo
   // resolves a different node_modules copy of the plugin (docs/mcp-oauth.md
   // §"Using withMCPAuth from a different component").
   srv.http(
-    withMCPAuth(handler, {
+    withMCPAuth(rateLimitedMcpHandler(handler), {
       getConfig: () => mcpAuthConfig(),
     }),
     { urlPath: "/mcp" },

--- a/resources/rate-limit.ts
+++ b/resources/rate-limit.ts
@@ -1,0 +1,466 @@
+/**
+ * rate-limit.ts — throttling for the OAuth authorization-server surface and the
+ * OAuth-guarded `/mcp` surface.
+ *
+ * ── Why this exists ─────────────────────────────────────────────────────────
+ * `/OAuthToken` accepts three grant types on one unauthenticated endpoint;
+ * `/OAuthRegister` creates a durable row; `/OAuthAuthorize` mints authorization
+ * codes; `/mcp` runs tools for anyone holding a valid token. None of them were
+ * throttled. Authentication is not a rate limit: a *valid* token can hammer the
+ * tool surface just as effectively as an invalid one can hammer the token
+ * endpoint.
+ *
+ * ── PER-NODE, IN-MEMORY. Say it out loud. ───────────────────────────────────
+ * The counter is a process-local Map. Flair runs on Harper Fabric with more than
+ * one node behind a GTM, and components hot-reload. So, precisely:
+ *
+ *   - The EFFECTIVE ceiling is `limit x <number of nodes serving the origin>`,
+ *     not `limit`. A caller cannot choose their node, but repeated attempts do
+ *     spread across them.
+ *   - The counter RESETS on component reload/restart. Reload is operator-
+ *     initiated, so this is not something a caller can trigger — but a deploy
+ *     does clear every bucket.
+ *   - A fixed window admits up to `2 x limit` across a window boundary.
+ *
+ * The alternative — a Harper table-backed counter — is cluster-visible but is
+ * the wrong trade here, and not merely because of latency:
+ *
+ *   1. A flair table is REPLICATED. Every counted request would become a
+ *      durable write fanned out to every node. An attacker sending N requests
+ *      would generate N cluster-wide replicated writes. That is write
+ *      amplification on the exact hot path the limiter exists to protect — a
+ *      strictly worse DoS shape than the one being defended against.
+ *   2. Replication is eventually consistent, so the shared counter would not be
+ *      accurate for a burst anyway. It would buy correctness at the timescale of
+ *      replication lag, which is the timescale a burst has already finished in.
+ *
+ * And the security value does not hinge on the exact multiplier. This is a
+ * BRUTE-FORCE control, not a capacity control: what matters is that the number
+ * of guesses per unit time is bounded and small, against secrets with 256 bits
+ * of entropy (`randomBytes(32)` — resources/OAuth.ts). Whether the ceiling is
+ * 30/min or 60/min is immaterial to that; whether it is bounded at all is not.
+ *
+ * WHAT WOULD CHANGE THIS ANSWER: a guessable-secret space small enough that a
+ * small constant multiplier matters; a node count large enough that `limit x N`
+ * stops being meaningfully bounded; or Harper gaining a shared, NON-replicated
+ * cache primitive (a counter that is cluster-visible without becoming durable
+ * replicated storage), at which point the per-node argument stops being the
+ * honest one.
+ *
+ * WHAT THIS DOES NOT PROTECT AGAINST, stated plainly:
+ *   - A distributed botnet. Per-IP keying is defeated by enough distinct source
+ *     addresses; nothing here changes that.
+ *   - Aggregate cluster capacity. This is a per-node, per-key control.
+ *   - Anything at all if the operator sets `FLAIR_RATE_LIMIT=off`.
+ *
+ * ── The counter is consumed BEFORE any credential is looked at ──────────────
+ * `checkHttpRateLimit` runs at the top of auth-middleware, before the request
+ * body is parsed and before any grant, code, secret or token is evaluated. That
+ * is deliberate and it is a security property, not an implementation detail: if
+ * the limiter only counted FAILURES, then "did this attempt consume budget"
+ * would answer "was that credential valid" — an enumeration oracle strictly
+ * better than the 400 the endpoint already returns. Counting unconditionally
+ * means a 429 carries no information about the credential that accompanied it,
+ * and a valid credential and a garbage one are byte-identical once limited.
+ *
+ * For the same reason nothing here emits `RateLimit-Limit`/`RateLimit-Remaining`
+ * on a request that was ALLOWED. Those headers are conventional and harmless on
+ * an ordinary API; on a credential endpoint they hand a caller a free pacing
+ * oracle for staying just under the threshold. `Retry-After` on the 429 itself
+ * is the one hint we give, because a client that cannot back off correctly is a
+ * client that retries in a tight loop.
+ */
+
+// ─── Configuration ──────────────────────────────────────────────────────────
+
+/** One-shot log guard — a warning per request would be its own amplification. */
+const warnedOnce = new Set<string>();
+function warnOnce(tag: string, message: string): void {
+  if (warnedOnce.has(tag)) return;
+  warnedOnce.add(tag);
+  console.error(`[rate-limit] ${message}`);
+}
+
+/** Test-only: forget which one-shot warnings have fired. */
+export function __resetWarningsForTest(): void {
+  warnedOnce.clear();
+}
+
+/**
+ * Master switch. Enabled unless `FLAIR_RATE_LIMIT` is exactly `off`/`0`/`false`
+ * (case-insensitive). Deliberately opt-OUT: a limiter that has to be discovered
+ * and switched on is a limiter that is off on every instance that most needs it.
+ *
+ * An unrecognised value is treated as ENABLED and warned about, so a typo
+ * (`FLAIR_RATE_LIMIT=disabled`) cannot silently disable the control.
+ */
+export function rateLimitEnabled(): boolean {
+  const raw = (process.env.FLAIR_RATE_LIMIT ?? "").trim().toLowerCase();
+  if (raw === "") return true;
+  if (raw === "off" || raw === "0" || raw === "false" || raw === "no") {
+    warnOnce("disabled", "DISABLED by FLAIR_RATE_LIMIT — the OAuth and /mcp surfaces are unthrottled.");
+    return false;
+  }
+  if (raw === "on" || raw === "1" || raw === "true" || raw === "yes") return true;
+  warnOnce(
+    "bad-master",
+    `FLAIR_RATE_LIMIT is set to an unrecognised value — keeping rate limiting ENABLED. ` +
+      `Use FLAIR_RATE_LIMIT=off to disable it.`,
+  );
+  return true;
+}
+
+/**
+ * Read a positive-integer limit from the environment, falling back to `dflt`.
+ *
+ * Zero and negatives are REJECTED rather than honoured. A limit of 0 would mean
+ * "reject everything", which is not a rate limit an operator arrives at by
+ * intent — it is what a shell that expanded an unset variable produces. Every
+ * rejection is warned about by NAME so a typo is visible rather than silently
+ * swapped for the default.
+ */
+export function envLimit(name: string, dflt: number): number {
+  const raw = (process.env[name] ?? "").trim();
+  if (raw === "") return dflt;
+  const n = Number(raw);
+  if (!Number.isInteger(n) || n <= 0) {
+    warnOnce(`bad-limit:${name}`, `${name} is not a positive integer — using the default of ${dflt}.`);
+    return dflt;
+  }
+  return n;
+}
+
+export interface Policy {
+  /**
+   * Bucket name — part of the key, so paths sharing a bucket share one budget.
+   *
+   * `/OAuthToken`, `/OAuthAuthorize` and `/OAuthRevoke` deliberately SHARE the
+   * `oauth` bucket. They are one credential surface: a caller working through
+   * codes, refresh tokens and revocations is making one run of attempts, and
+   * bounding the total is tighter than bounding each separately, which would
+   * hand the same caller three times the budget for the same activity. Nor
+   * would splitting protect anyone from anyone else — the key is the caller
+   * either way, so the party a split would isolate is the party from itself.
+   *
+   * `/OAuthRegister` gets its own, much tighter bucket: it is a different kind
+   * of abuse (durable, replicated rows) at a different natural rate (once per
+   * client, ever), so folding it in would either loosen the registration limit
+   * or throttle ordinary token traffic down to a registration-shaped rate.
+   */
+  readonly bucket: string;
+  /** Requests permitted per window. */
+  readonly limit: number;
+  /** Window length in ms. */
+  readonly windowMs: number;
+}
+
+/**
+ * Limits, and why each number.
+ *
+ * `/OAuthToken`, `/OAuthAuthorize`, `/OAuthRevoke` — 30 per minute per caller.
+ * A real authorization flow is a handful of requests per user per hour: one
+ * authorize, one code exchange, one refresh per access-token lifetime (1 hour,
+ * resources/OAuth.ts). 30/min leaves roughly two orders of magnitude of headroom
+ * over legitimate use while capping a guessing run at 1800/hour/node against a
+ * 256-bit space.
+ *
+ * `/OAuthRegister` — 5 per five minutes. Registration is a once-per-client
+ * event, and each one creates a durable, replicated row. This is the table-
+ * pollution ceiling. (Registration is additionally gated; see the DCR work.)
+ *
+ * `/mcp` — 120 per minute per verified token subject. An agent doing real work
+ * makes many tool calls in a burst; this is sized to be invisible to genuine use
+ * and to stop one token from monopolising the surface.
+ */
+export function policyFor(bucket: "oauth" | "register" | "mcp"): Policy {
+  switch (bucket) {
+    case "register":
+      return { bucket: "register", limit: envLimit("FLAIR_OAUTH_REGISTER_RATE_LIMIT", 5), windowMs: 300_000 };
+    case "mcp":
+      return { bucket: "mcp", limit: envLimit("FLAIR_MCP_RATE_LIMIT", 120), windowMs: 60_000 };
+    case "oauth":
+    default:
+      return { bucket: "oauth", limit: envLimit("FLAIR_OAUTH_RATE_LIMIT", 30), windowMs: 60_000 };
+  }
+}
+
+/** Paths this module throttles, and which policy each uses. Nothing else is touched. */
+const PATH_POLICY: Record<string, "oauth" | "register"> = {
+  "/OAuthToken": "oauth",
+  "/OAuthAuthorize": "oauth",
+  "/OAuthRevoke": "oauth",
+  "/OAuthRegister": "register",
+};
+
+/**
+ * Which policy applies to a pathname, or null for "not throttled".
+ *
+ * Exact match only. A prefix test would pull in unrelated sibling routes, and
+ * the OAuth endpoints are addressed by their exact resource path.
+ */
+export function policyForPath(pathname: string): Policy | null {
+  const kind = PATH_POLICY[pathname];
+  return kind ? policyFor(kind) : null;
+}
+
+// ─── The counter ────────────────────────────────────────────────────────────
+
+interface Bucket {
+  /** Start of the current fixed window, ms epoch. */
+  windowStart: number;
+  /** Requests counted in the current window, including the one being decided. */
+  count: number;
+}
+
+/**
+ * Hard cap on tracked keys. Without one, a caller rotating source addresses
+ * turns the limiter itself into a memory-exhaustion primitive — the classic way
+ * a rate limiter becomes the DoS. 20 000 entries is far above any legitimate key
+ * count for a single instance and costs on the order of a megabyte.
+ *
+ * Eviction is LRU (see `consume`: a touched key is re-inserted at the back of
+ * the Map). That ordering matters and is the right way round: a caller hammering
+ * one key keeps it hot, so it is the LAST thing evicted and stays limited; the
+ * entries evicted under pressure are idle ones, which had unspent budget anyway.
+ *
+ * Named trade-off: at the cap, an evicted key gets a fresh budget. Bounded
+ * memory is worth more than a perfectly-retained counter, and a caller able to
+ * fill 20 000 distinct keys is already distributed across 20 000 sources, which
+ * per-key limiting was never the control for.
+ */
+export const MAX_TRACKED_KEYS = 20_000;
+
+const buckets = new Map<string, Bucket>();
+
+/** Test-only: drop all counters so cases don't inherit each other's state. */
+export function __resetBucketsForTest(): void {
+  buckets.clear();
+}
+
+/** Test-only: how many keys are currently tracked. */
+export function __trackedKeyCountForTest(): number {
+  return buckets.size;
+}
+
+export interface Decision {
+  /** True = over the limit, reject. */
+  limited: boolean;
+  /** The configured limit that was applied. */
+  limit: number;
+  /** Seconds until the current window ends (>= 1). */
+  retryAfterSec: number;
+}
+
+/**
+ * Count one request against `key` and decide.
+ *
+ * ALWAYS consumes, including when the answer is "limited" — a caller that keeps
+ * hammering keeps the window pinned rather than trickling through at exactly the
+ * limit. Callers must invoke this before evaluating any credential; see the
+ * module header for why that is a security property.
+ */
+export function consume(key: string, policy: Policy, now: number = Date.now()): Decision {
+  const existing = buckets.get(key);
+
+  let bucket: Bucket;
+  if (!existing || now - existing.windowStart >= policy.windowMs) {
+    bucket = { windowStart: now, count: 1 };
+  } else {
+    bucket = { windowStart: existing.windowStart, count: existing.count + 1 };
+  }
+
+  // delete-then-set moves the key to the back of the Map's insertion order,
+  // which is what makes the eviction below LRU rather than first-seen.
+  buckets.delete(key);
+  buckets.set(key, bucket);
+
+  if (buckets.size > MAX_TRACKED_KEYS) evictOldest(now, policy.windowMs);
+
+  const elapsed = now - bucket.windowStart;
+  return {
+    limited: bucket.count > policy.limit,
+    limit: policy.limit,
+    retryAfterSec: Math.max(1, Math.ceil((policy.windowMs - elapsed) / 1000)),
+  };
+}
+
+/**
+ * Bring the Map back under the cap: drop expired windows first (they carry no
+ * information), then the least-recently-used entries.
+ *
+ * Not a periodic sweep. A timer in a Harper component outlives nothing useful
+ * and has to be torn down on reload; doing the work only when the cap is
+ * actually reached keeps the steady state at zero cost.
+ */
+function evictOldest(now: number, windowMs: number): void {
+  for (const [k, b] of buckets) {
+    if (buckets.size <= MAX_TRACKED_KEYS) break;
+    if (now - b.windowStart >= windowMs) buckets.delete(k);
+  }
+  for (const k of buckets.keys()) {
+    if (buckets.size <= MAX_TRACKED_KEYS) break;
+    buckets.delete(k);
+  }
+}
+
+// ─── Caller identity ────────────────────────────────────────────────────────
+
+/**
+ * How many proxy hops in front of this instance are trusted, or 0 for "none".
+ *
+ * `FLAIR_TRUSTED_PROXY` — unset/`0` means the socket peer address is the only
+ * thing used. A positive integer N means the instance genuinely sits behind N
+ * trusted reverse proxies that append to `X-Forwarded-For`.
+ *
+ * DEFAULT OFF, and that direction is the point: `X-Forwarded-For` is a request
+ * header, so an instance that trusts it without a proxy in front lets any caller
+ * mint a fresh bucket per request by rotating the header — a limiter that is
+ * bypassable by anyone who has read this file. Trusting it has to be a decision
+ * an operator makes about their own topology.
+ */
+export function trustedProxyHops(): number {
+  const raw = (process.env.FLAIR_TRUSTED_PROXY ?? "").trim().toLowerCase();
+  if (raw === "" || raw === "0" || raw === "off" || raw === "false" || raw === "no") return 0;
+  if (raw === "on" || raw === "true" || raw === "yes") return 1;
+  const n = Number(raw);
+  if (!Number.isInteger(n) || n < 0) {
+    warnOnce("bad-proxy", `FLAIR_TRUSTED_PROXY is not a non-negative integer — treating it as 0 (no proxy trusted).`);
+    return 0;
+  }
+  return n;
+}
+
+/** Sentinel used when no caller address can be determined. See `callerKey`. */
+export const UNKNOWN_CALLER = "addr:unknown";
+
+/**
+ * The rate-limit key component identifying the caller.
+ *
+ * Sources, in order:
+ *  1. `X-Forwarded-For`, but ONLY when `FLAIR_TRUSTED_PROXY` is set, and then
+ *     the entry `hops` from the RIGHT — never the leftmost. Each proxy appends
+ *     the peer it saw, so the rightmost entries are the ones written by the
+ *     trusted hops; the leftmost is whatever the original caller chose to send
+ *     and is worth nothing. Taking the left entry is the classic way this
+ *     control is made bypassable.
+ *  2. Harper's `request.ip` — the socket peer address. On a Fabric UDS listener
+ *     Harper substitutes the real client address from the PROXY v1 header when
+ *     one is present (harper/dist/server/http.js).
+ *  3. `UNKNOWN_CALLER`, warned about once.
+ *
+ * Step 3 collapses every caller into ONE bucket, which is deliberately the
+ * fail-SAFE direction — over-restrictive, never unthrottled. It is also loud:
+ * silently not limiting would be an unrun check that looks like a pass, and an
+ * operator who never learns the limiter degraded cannot fix it.
+ */
+export function callerKey(request: any): string {
+  const hops = trustedProxyHops();
+  if (hops > 0) {
+    const raw =
+      request?.headers?.get?.("x-forwarded-for") ??
+      request?.headers?.asObject?.["x-forwarded-for"] ??
+      "";
+    if (typeof raw === "string" && raw.trim() !== "") {
+      const parts = raw.split(",").map((s: string) => s.trim()).filter(Boolean);
+      // The trusted hops appended the last `hops` entries; the one the nearest
+      // trusted proxy observed as its own peer sits at length - hops.
+      const idx = parts.length - hops;
+      if (idx >= 0 && parts[idx]) return `xff:${parts[idx]}`;
+      // Fewer entries than trusted hops: the chain is shorter than configured, so
+      // no entry in it was written by a trusted hop. Fall through to the socket
+      // peer rather than trust a caller-supplied value.
+    }
+  }
+
+  const ip = request?.ip;
+  if (typeof ip === "string" && ip !== "") return `addr:${ip}`;
+
+  warnOnce(
+    "no-addr",
+    "no client address available on the request — every caller now shares ONE bucket per endpoint, " +
+      "which throttles more than intended. If this instance sits behind a reverse proxy that sets " +
+      "X-Forwarded-For, set FLAIR_TRUSTED_PROXY to the number of trusted hops.",
+  );
+  return UNKNOWN_CALLER;
+}
+
+// ─── Responses ──────────────────────────────────────────────────────────────
+
+/**
+ * The 429 body. Identical for every endpoint, every key and every grant type,
+ * and it echoes nothing back — no client_id, no address, no grant type, no
+ * remaining count. `slow_down` is a real OAuth error code (RFC 8628 s3.5) and
+ * means exactly this, so a spec-aware client already knows what to do with it.
+ */
+export const LIMITED_BODY = JSON.stringify({
+  error: "slow_down",
+  error_description: "too many requests",
+});
+
+export function limitedHeaders(decision: Decision): Record<string, string> {
+  return {
+    "content-type": "application/json",
+    "retry-after": String(decision.retryAfterSec),
+    // Do not add RateLimit-Limit/Remaining here or on the success path; see the
+    // module header on why a pacing oracle is not wanted on a credential endpoint.
+    "cache-control": "no-store",
+  };
+}
+
+/** A 429 as a `Response` — for the default dispatch chain (auth-middleware). */
+export function limitedResponse(decision: Decision): Response {
+  return new Response(LIMITED_BODY, { status: 429, headers: limitedHeaders(decision) });
+}
+
+// ─── Entry points ───────────────────────────────────────────────────────────
+
+/**
+ * The auth-middleware hook. Returns a 429 `Response` to short-circuit with, or
+ * null to continue.
+ *
+ * Must be called before the public-path passthrough and before anything reads
+ * the body: the three OAuth endpoints this covers all sit on that passthrough,
+ * so a hook placed after it would never run for them.
+ */
+export function checkHttpRateLimit(request: any, pathname: string): Response | null {
+  if (!rateLimitEnabled()) return null;
+  const policy = policyForPath(pathname);
+  if (!policy) return null;
+
+  const decision = consume(`${policy.bucket}|${callerKey(request)}`, policy);
+  return decision.limited ? limitedResponse(decision) : null;
+}
+
+/**
+ * The `/mcp` hook. Keyed on the RS256-verified token subject (and `client_id`
+ * when present), never on an address: `/mcp` is authenticated, so the strongest
+ * available identity is the one the authorization server signed. That also makes
+ * this limit survive a caller changing address, which per-IP keying does not.
+ *
+ * Returns a Harper listener result (`{ status, body, headers }`) to short-circuit
+ * with, or null to continue. Runs INSIDE `withMCPAuth`, so `request.mcp` is
+ * populated; an unverified request never reaches here because the guard fails
+ * closed ahead of it.
+ */
+export function checkMcpRateLimit(request: any): { status: number; body: string; headers: Record<string, string> } | null {
+  if (!rateLimitEnabled()) return null;
+  const policy = policyFor("mcp");
+
+  const sub = typeof request?.mcp?.sub === "string" ? request.mcp.sub : "";
+  const clientId = typeof request?.mcp?.client_id === "string" ? request.mcp.client_id : "";
+  // No verified subject should be impossible here (withMCPAuth fails closed), but
+  // if it ever were, fall back to the caller address rather than to no limit.
+  const identity = sub ? `sub:${sub}|cid:${clientId}` : callerKey(request);
+
+  const decision = consume(`${policy.bucket}|${identity}`, policy);
+  if (!decision.limited) return null;
+  return {
+    status: 429,
+    headers: limitedHeaders(decision),
+    body: JSON.stringify({
+      jsonrpc: "2.0",
+      id: null,
+      error: { code: -32029, message: "too many requests" },
+    }),
+  };
+}

--- a/test/integration/oauth-rate-limit-e2e.test.ts
+++ b/test/integration/oauth-rate-limit-e2e.test.ts
@@ -1,0 +1,277 @@
+// oauth-rate-limit-e2e.test.ts — the OAuth surface's rate limiter, driven over
+// real HTTP against a real Harper spawn.
+//
+// A unit test of the counter proves the arithmetic. It does not prove the
+// limiter is WIRED IN — that requests to a live instance are actually counted
+// and actually rejected. That is what this file is for: real fetches, past the
+// threshold, against a running server.
+//
+// Every limit assertion here is paired with a POSITIVE CONTROL. Asserting only
+// that a 429 eventually arrives would pass against a limiter configured to
+// reject everything, which is not a working limiter. So each case first shows
+// the requests BELOW the threshold being served normally.
+//
+// MODEL: test/integration/oauth-authorize-authz.test.ts.
+import { describe, expect, test, beforeAll, afterAll } from "bun:test";
+import { randomUUID } from "node:crypto";
+import { startHarper, stopHarper, HarperInstance } from "../helpers/harper-lifecycle";
+
+const ALLOWED_REDIRECT_URI = "https://claude.com/api/mcp/auth_callback";
+
+// Small enough to exhaust in a handful of requests. The window is 60s, so once a
+// bucket is spent it STAYS spent for the rest of the file — the cases below are
+// ordered to depend on that rather than fight it.
+const OAUTH_LIMIT = 6;
+const REGISTER_LIMIT = 3;
+
+async function adminOp(harper: HarperInstance, op: Record<string, any>): Promise<Response> {
+  return fetch(harper.opsURL, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: "Basic " + btoa(`${harper.admin.username}:${harper.admin.password}`),
+    },
+    body: JSON.stringify(op),
+  });
+}
+
+/** POST a form-encoded body to /OAuthToken, the way a real OAuth client does. */
+async function postToken(harper: HarperInstance, body: Record<string, string>, headers: Record<string, string> = {}) {
+  const res = await fetch(`${harper.httpURL}/OAuthToken`, {
+    method: "POST",
+    headers: { "content-type": "application/json", ...headers },
+    body: JSON.stringify(body),
+  });
+  return { status: res.status, text: await res.text(), retryAfter: res.headers.get("retry-after") };
+}
+
+let harper: HarperInstance;
+const savedEnv: Record<string, string | undefined> = {};
+const clientId = `flair_cl_ratelimit_${randomUUID()}`;
+const validCode = `code_${randomUUID()}`;
+
+describe("OAuth rate limiting (real Harper, real HTTP)", () => {
+  beforeAll(async () => {
+    // Set BEFORE the spawn — startHarper hands its own process.env to the child.
+    for (const k of ["FLAIR_OAUTH_RATE_LIMIT", "FLAIR_OAUTH_REGISTER_RATE_LIMIT", "FLAIR_RATE_LIMIT", "FLAIR_TRUSTED_PROXY"]) {
+      savedEnv[k] = process.env[k];
+    }
+    process.env.FLAIR_OAUTH_RATE_LIMIT = String(OAUTH_LIMIT);
+    process.env.FLAIR_OAUTH_REGISTER_RATE_LIMIT = String(REGISTER_LIMIT);
+    delete process.env.FLAIR_RATE_LIMIT;
+    delete process.env.FLAIR_TRUSTED_PROXY;
+
+    harper = await startHarper();
+
+    // A registered client and a genuinely valid, unused authorization code.
+    // Inserted through the admin ops API rather than run through the consent
+    // flow: the point here is to have a credential that really does exchange for
+    // a token, so "valid" and "garbage" can be compared once the bucket is spent.
+    await adminOp(harper, {
+      operation: "insert", database: "flair", table: "OAuthClient",
+      records: [{
+        id: clientId, name: "rate-limit test client",
+        redirectUris: [ALLOWED_REDIRECT_URI],
+        grantTypes: ["authorization_code", "refresh_token"],
+        scope: "memory:read", registeredBy: "test",
+        createdAt: new Date().toISOString(),
+      }],
+    });
+    await adminOp(harper, {
+      operation: "insert", database: "flair", table: "OAuthAuthCode",
+      records: [{
+        id: validCode, clientId, principalId: "admin",
+        redirectUri: ALLOWED_REDIRECT_URI, scope: "memory:read",
+        expiresAt: new Date(Date.now() + 600_000).toISOString(),
+        used: false, createdAt: new Date().toISOString(),
+      }],
+    });
+  }, 180_000);
+
+  afterAll(async () => {
+    if (harper) await stopHarper(harper);
+    for (const [k, v] of Object.entries(savedEnv)) {
+      if (v === undefined) delete process.env[k];
+      else process.env[k] = v;
+    }
+  });
+
+  // ── POSITIVE CONTROL ──────────────────────────────────────────────────────
+
+  test("POSITIVE CONTROL: a genuinely valid authorization code still exchanges for a token", async () => {
+    const res = await postToken(harper, {
+      grant_type: "authorization_code", code: validCode, client_id: clientId,
+      redirect_uri: ALLOWED_REDIRECT_URI,
+    });
+    expect(res.status).toBe(200);
+    expect(JSON.parse(res.text).access_token).toStartWith("flair_at_");
+  });
+
+  test("POSITIVE CONTROL: every request up to the limit is served, none is throttled", async () => {
+    // One of the budget was spent above, so drive the remainder.
+    for (let i = 1; i < OAUTH_LIMIT; i++) {
+      const res = await postToken(harper, { grant_type: "authorization_code", code: "nope", client_id: clientId });
+      expect(res.status).not.toBe(429);
+      expect(res.status).toBe(400); // invalid_grant — the endpoint is working normally
+    }
+  });
+
+  // ── THE LIMIT ─────────────────────────────────────────────────────────────
+
+  test("the request past the limit is rejected with 429 and a Retry-After", async () => {
+    const res = await postToken(harper, { grant_type: "authorization_code", code: "nope", client_id: clientId });
+    expect(res.status).toBe(429);
+    expect(Number(res.retryAfter)).toBeGreaterThanOrEqual(1);
+    expect(JSON.parse(res.text).error).toBe("slow_down");
+  });
+
+  test("it STAYS limited — the counter is not reset by a further attempt", async () => {
+    for (let i = 0; i < 3; i++) {
+      expect((await postToken(harper, { grant_type: "refresh_token", refresh_token: "x" })).status).toBe(429);
+    }
+  });
+
+  // ── NO ENUMERATION ORACLE ────────────────────────────────────────────────
+
+  test("once limited, a VALID credential and a garbage one are byte-identical", async () => {
+    // The whole point of consuming the counter before evaluating the credential.
+    // If the limiter only counted failures, a valid credential would slip past a
+    // spent bucket and "did I get a 429" would answer "was that credential
+    // good" — a cleaner oracle than the 400 the endpoint already returns.
+    const good = await postToken(harper, {
+      grant_type: "authorization_code", code: validCode, client_id: clientId,
+      redirect_uri: ALLOWED_REDIRECT_URI,
+    });
+    const bad = await postToken(harper, {
+      grant_type: "authorization_code", code: "definitely-not-a-real-code", client_id: "flair_cl_nope",
+      redirect_uri: ALLOWED_REDIRECT_URI,
+    });
+    expect(good.status).toBe(429);
+    expect(bad.status).toBe(429);
+    expect(good.text).toBe(bad.text);
+  });
+
+  test("an unsupported grant type is limited identically — the grant is never read", async () => {
+    const res = await postToken(harper, { grant_type: "totally_made_up" });
+    expect(res.status).toBe(429);
+  });
+
+  test("the 429 body echoes nothing back to the caller", async () => {
+    const res = await postToken(harper, { grant_type: "authorization_code", code: "abc", client_id: "sentinel-client-id" });
+    expect(res.text).not.toContain("sentinel-client-id");
+    expect(res.text).not.toContain("authorization_code");
+    expect(res.text).not.toContain("127.0.0.1");
+  });
+
+  test("X-Forwarded-For does NOT buy a fresh bucket when no proxy is trusted", async () => {
+    // FLAIR_TRUSTED_PROXY is unset for this instance, so the header is ignored
+    // entirely. If it were honoured by default, this limiter would be
+    // bypassable by anyone willing to vary a header.
+    for (const spoof of ["1.2.3.4", "5.6.7.8", "9.10.11.12"]) {
+      const res = await postToken(harper, { grant_type: "refresh_token", refresh_token: "x" }, { "x-forwarded-for": spoof });
+      expect(res.status).toBe(429);
+    }
+  });
+
+  // ── BLAST RADIUS ─────────────────────────────────────────────────────────
+
+  test("registration has its OWN budget — it still works while the token bucket is spent", async () => {
+    const res = await fetch(`${harper.httpURL}/OAuthRegister`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ client_name: "separate bucket", redirect_uris: [ALLOWED_REDIRECT_URI] }),
+    });
+    expect(res.status).not.toBe(429);
+    expect((await res.json() as any).client_id).toStartWith("flair_cl_");
+  });
+
+  test("registration is limited on its own, tighter budget", async () => {
+    let sawLimit = false;
+    for (let i = 0; i < REGISTER_LIMIT + 2; i++) {
+      const res = await fetch(`${harper.httpURL}/OAuthRegister`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ client_name: `flood ${i}`, redirect_uris: [ALLOWED_REDIRECT_URI] }),
+      });
+      if (res.status === 429) sawLimit = true;
+      await res.text();
+    }
+    expect(sawLimit).toBe(true);
+  });
+
+  test("UNTHROTTLED PATHS ARE UNTOUCHED: /Health still answers with both OAuth buckets spent", async () => {
+    for (let i = 0; i < 10; i++) {
+      const res = await fetch(`${harper.httpURL}/Health`);
+      expect(res.status).toBe(200);
+      await res.text();
+    }
+  });
+
+  test("UNTHROTTLED PATHS ARE UNTOUCHED: discovery still answers", async () => {
+    for (let i = 0; i < 10; i++) {
+      const res = await fetch(`${harper.httpURL}/.well-known/oauth-authorization-server`);
+      expect(res.status).toBe(200);
+      await res.text();
+    }
+  });
+
+  test("UNTHROTTLED PATHS ARE UNTOUCHED: an ordinary resource path is not rate limited", async () => {
+    // /Memory denies an anonymous caller — the point is that it denies for the
+    // usual reason and never with a 429.
+    for (let i = 0; i < 10; i++) {
+      const res = await fetch(`${harper.httpURL}/Memory`);
+      expect(res.status).not.toBe(429);
+      await res.text();
+    }
+  });
+});
+
+// ─── Keying, proven over real HTTP ──────────────────────────────────────────
+
+describe("OAuth rate limiting keys per caller (trusted-proxy mode, real Harper)", () => {
+  let proxied: HarperInstance;
+  const saved: Record<string, string | undefined> = {};
+
+  beforeAll(async () => {
+    for (const k of ["FLAIR_OAUTH_RATE_LIMIT", "FLAIR_TRUSTED_PROXY"]) saved[k] = process.env[k];
+    process.env.FLAIR_OAUTH_RATE_LIMIT = String(OAUTH_LIMIT);
+    process.env.FLAIR_TRUSTED_PROXY = "1";
+    proxied = await startHarper();
+  }, 180_000);
+
+  afterAll(async () => {
+    if (proxied) await stopHarper(proxied);
+    for (const [k, v] of Object.entries(saved)) {
+      if (v === undefined) delete process.env[k];
+      else process.env[k] = v;
+    }
+  });
+
+  test("one caller's exhausted budget does not limit a DIFFERENT caller", async () => {
+    // With one trusted hop the rightmost X-Forwarded-For entry is the key, so
+    // two values are two callers. This is the assertion that shows the limiter
+    // keys per caller over real HTTP rather than throttling globally.
+    for (let i = 0; i <= OAUTH_LIMIT; i++) {
+      await postToken(proxied, { grant_type: "refresh_token", refresh_token: "x" }, { "x-forwarded-for": "203.0.113.10" });
+    }
+    const first = await postToken(proxied, { grant_type: "refresh_token", refresh_token: "x" }, { "x-forwarded-for": "203.0.113.10" });
+    expect(first.status).toBe(429);
+
+    // POSITIVE CONTROL for the keying: a different caller is unaffected.
+    const second = await postToken(proxied, { grant_type: "refresh_token", refresh_token: "x" }, { "x-forwarded-for": "198.51.100.20" });
+    expect(second.status).not.toBe(429);
+    expect(second.status).toBe(400);
+  });
+
+  test("SPOOF RESISTANCE: prepending an attacker-chosen entry does not buy a fresh bucket", async () => {
+    // The trusted proxy appends what it saw, so the RIGHTMOST entry is the one
+    // written by the trusted hop. Keying on the leftmost — the entry the caller
+    // controls — is the classic way this control is made useless.
+    const res = await postToken(
+      proxied,
+      { grant_type: "refresh_token", refresh_token: "x" },
+      { "x-forwarded-for": "9.9.9.9, 203.0.113.10" },
+    );
+    expect(res.status).toBe(429);
+  });
+});

--- a/test/unit/mcp-oauth-register.test.ts
+++ b/test/unit/mcp-oauth-register.test.ts
@@ -40,7 +40,8 @@ mock.module("harper", () => ({
 // legitimately `await import(...)`s for real — that was the source of the
 // intermittent "35 tests failed" flake in mcp-handler.test.ts.
 
-const { registerMcpOAuthRoute, mcpRouteState } = await import("../../resources/mcp-oauth.ts");
+const { registerMcpOAuthRoute, mcpRouteState, rateLimitedMcpHandler } = await import("../../resources/mcp-oauth.ts");
+const { __resetBucketsForTest } = await import("../../resources/rate-limit.ts");
 
 const ENV = ["FLAIR_MCP_OAUTH", "FLAIR_MCP_ISSUER", "FLAIR_PUBLIC_URL"];
 function clearEnv() { for (const k of ENV) delete process.env[k]; }
@@ -110,6 +111,68 @@ describe("registerMcpOAuthRoute — flag-OFF no-op", () => {
       issuer: "https://flair.example.com",
       resource: "https://flair.example.com/mcp",
     });
+  });
+
+  it("the handler handed to withMCPAuth is the RATE-LIMITED one, not the bare handler", async () => {
+    // The wrapper has to sit INSIDE withMCPAuth so it can key on the verified
+    // token subject. If a future edit passes `handler` straight through, /mcp
+    // goes back to being unthrottled for anyone holding a valid token — with no
+    // other symptom. This asserts the composition, so that edit fails here.
+    clearEnv();
+    process.env.FLAIR_MCP_OAUTH = "1";
+    process.env.FLAIR_MCP_ISSUER = "https://flair.example.com";
+    const deps = makeDeps();
+    await registerMcpOAuthRoute(deps);
+    expect(withMCPAuthCalls[0].handler).not.toBe(deps.mcpHandler);
+  });
+});
+
+describe("rateLimitedMcpHandler", () => {
+  const MCP_ENV = ["FLAIR_MCP_RATE_LIMIT", "FLAIR_RATE_LIMIT"];
+  let savedMcpEnv: Record<string, string | undefined> = {};
+
+  beforeEach(() => {
+    __resetBucketsForTest();
+    savedMcpEnv = {};
+    for (const k of MCP_ENV) { savedMcpEnv[k] = process.env[k]; delete process.env[k]; }
+  });
+
+  const restore = () => {
+    for (const k of MCP_ENV) {
+      if (savedMcpEnv[k] === undefined) delete process.env[k];
+      else process.env[k] = savedMcpEnv[k];
+    }
+  };
+
+  const call = (sub: string) => ({ mcp: { sub, client_id: "cid" }, ip: "203.0.113.7" });
+
+  it("POSITIVE CONTROL: calls under the limit reach the real handler", async () => {
+    process.env.FLAIR_MCP_RATE_LIMIT = "3";
+    let reached = 0;
+    const wrapped = rateLimitedMcpHandler(async () => { reached++; return { status: 200 }; });
+    for (let i = 0; i < 3; i++) expect((await wrapped(call("s1"))).status).toBe(200);
+    expect(reached).toBe(3);
+    restore();
+  });
+
+  it("over the limit it returns 429 and the real handler is NEVER invoked", async () => {
+    process.env.FLAIR_MCP_RATE_LIMIT = "2";
+    let reached = 0;
+    const wrapped = rateLimitedMcpHandler(async () => { reached++; return { status: 200 }; });
+    for (let i = 0; i < 2; i++) await wrapped(call("s1"));
+    const res = await wrapped(call("s1"));
+    expect(res.status).toBe(429);
+    expect(reached).toBe(2); // the tool surface was not touched by the rejected call
+    restore();
+  });
+
+  it("a different verified subject is unaffected by another's exhausted budget", async () => {
+    process.env.FLAIR_MCP_RATE_LIMIT = "2";
+    const wrapped = rateLimitedMcpHandler(async () => ({ status: 200 }));
+    for (let i = 0; i < 3; i++) await wrapped(call("s1"));
+    expect((await wrapped(call("s1"))).status).toBe(429);
+    expect((await wrapped(call("s2"))).status).toBe(200);
+    restore();
   });
 });
 

--- a/test/unit/rate-limit.test.ts
+++ b/test/unit/rate-limit.test.ts
@@ -1,0 +1,386 @@
+// rate-limit.test.ts — resources/rate-limit.ts.
+//
+// The counter itself is pure and process-local, so it is unit-testable end to
+// end. What a unit test CANNOT show is that the limiter is wired into a running
+// instance and actually rejects real traffic — that is
+// test/integration/oauth-rate-limit-e2e.test.ts's job, driving real HTTP past
+// the threshold against a real Harper spawn.
+//
+// EVERY limit case here carries a POSITIVE CONTROL: the requests below the
+// threshold are asserted to be ALLOWED, not just the one above it asserted to be
+// rejected. A test that only checks for the 429 passes with the limit set to
+// zero, which is a broken limiter, not a working one.
+import { describe, expect, test, beforeEach, afterEach } from "bun:test";
+import {
+  consume,
+  policyFor,
+  policyForPath,
+  callerKey,
+  checkHttpRateLimit,
+  checkMcpRateLimit,
+  envLimit,
+  rateLimitEnabled,
+  trustedProxyHops,
+  limitedResponse,
+  LIMITED_BODY,
+  UNKNOWN_CALLER,
+  MAX_TRACKED_KEYS,
+  __resetBucketsForTest,
+  __resetWarningsForTest,
+  __trackedKeyCountForTest,
+} from "../../resources/rate-limit.ts";
+
+// bun runs every test file in ONE process, so both the bucket Map and the
+// one-shot warning set are shared state. Reset them per case, and restore any
+// env var touched so a later FILE doesn't inherit it.
+const TOUCHED = [
+  "FLAIR_RATE_LIMIT",
+  "FLAIR_OAUTH_RATE_LIMIT",
+  "FLAIR_OAUTH_REGISTER_RATE_LIMIT",
+  "FLAIR_MCP_RATE_LIMIT",
+  "FLAIR_TRUSTED_PROXY",
+];
+let saved: Record<string, string | undefined> = {};
+
+beforeEach(() => {
+  __resetBucketsForTest();
+  __resetWarningsForTest();
+  saved = {};
+  for (const k of TOUCHED) {
+    saved[k] = process.env[k];
+    delete process.env[k];
+  }
+});
+
+afterEach(() => {
+  for (const k of TOUCHED) {
+    if (saved[k] === undefined) delete process.env[k];
+    else process.env[k] = saved[k];
+  }
+});
+
+/** A request stub shaped like Harper's: `.ip` plus a Headers-ish `.get`. */
+function req(ip: string | undefined, headers: Record<string, string> = {}): any {
+  return {
+    ip,
+    headers: { get: (n: string) => headers[n.toLowerCase()] ?? null, asObject: headers },
+  };
+}
+
+// ─── The counter ────────────────────────────────────────────────────────────
+
+describe("consume", () => {
+  const policy = { bucket: "t", limit: 3, windowMs: 1000 };
+
+  test("POSITIVE CONTROL: every request up to the limit is allowed", () => {
+    for (let i = 1; i <= policy.limit; i++) {
+      expect(consume("k", policy, 1000).limited).toBe(false);
+    }
+  });
+
+  test("the request AFTER the limit is rejected", () => {
+    for (let i = 1; i <= policy.limit; i++) consume("k", policy, 1000);
+    expect(consume("k", policy, 1000).limited).toBe(true);
+  });
+
+  test("stays rejected while the window holds, then allows again once it rolls", () => {
+    for (let i = 1; i <= policy.limit + 2; i++) consume("k", policy, 1000);
+    expect(consume("k", policy, 1500).limited).toBe(true);
+    // A fresh window starts at windowMs after the first request.
+    expect(consume("k", policy, 2000).limited).toBe(false);
+  });
+
+  test("distinct keys have independent budgets", () => {
+    for (let i = 1; i <= policy.limit + 1; i++) consume("a", policy, 1000);
+    expect(consume("a", policy, 1000).limited).toBe(true);
+    expect(consume("b", policy, 1000).limited).toBe(false);
+  });
+
+  test("retryAfterSec counts down within the window and is never 0", () => {
+    const first = consume("k", policy, 1000);
+    expect(first.retryAfterSec).toBe(1);
+    const late = consume("k", policy, 1999);
+    expect(late.retryAfterSec).toBeGreaterThanOrEqual(1);
+  });
+
+  test("bounded memory: tracked keys never exceed the cap, and the HOT key survives eviction", () => {
+    const hot = { bucket: "t", limit: 5, windowMs: 60_000 };
+    // Put the hot key over its limit first.
+    for (let i = 0; i < 6; i++) consume("hot", hot, 1000);
+    expect(consume("hot", hot, 1000).limited).toBe(true);
+
+    // Now flood with distinct keys, touching the hot key as we go so it stays
+    // most-recently-used. This is the shape of the attack the cap exists for:
+    // a caller rotating source addresses to grow the Map without bound.
+    for (let i = 0; i < MAX_TRACKED_KEYS + 500; i++) {
+      consume(`flood-${i}`, hot, 1000);
+      if (i % 100 === 0) consume("hot", hot, 1000);
+    }
+
+    expect(__trackedKeyCountForTest()).toBeLessThanOrEqual(MAX_TRACKED_KEYS);
+    // LRU, not first-seen: the key being hammered is the last thing evicted, so
+    // it is still limited rather than handed a fresh budget.
+    expect(consume("hot", hot, 1000).limited).toBe(true);
+  });
+});
+
+// ─── Which paths are throttled ──────────────────────────────────────────────
+
+describe("policyForPath", () => {
+  test("covers the four OAuth endpoints", () => {
+    for (const p of ["/OAuthToken", "/OAuthAuthorize", "/OAuthRevoke", "/OAuthRegister"]) {
+      expect(policyForPath(p)).not.toBeNull();
+    }
+  });
+
+  test("registration has its own, tighter policy than the rest of the OAuth surface", () => {
+    const reg = policyForPath("/OAuthRegister")!;
+    const tok = policyForPath("/OAuthToken")!;
+    expect(reg.bucket).not.toBe(tok.bucket);
+    expect(reg.limit).toBeLessThan(tok.limit);
+  });
+
+  test("throttles NOTHING else — the agent surface and discovery are untouched", () => {
+    for (const p of [
+      "/Memory", "/Memory/abc", "/Presence", "/FederationSync", "/FederationPair",
+      "/Health", "/OAuthMetadata", "/.well-known/oauth-authorization-server",
+      "/.well-known/oauth-protected-resource", "/mcp", "/Admin", "/SemanticSearch",
+    ]) {
+      expect(policyForPath(p)).toBeNull();
+    }
+  });
+
+  test("matching is exact — a lookalike prefix is not throttled by accident", () => {
+    expect(policyForPath("/OAuthTokenSomethingElse")).toBeNull();
+    expect(policyForPath("/OAuthToken/")).toBeNull();
+  });
+});
+
+// ─── Caller identity ────────────────────────────────────────────────────────
+
+describe("callerKey", () => {
+  test("uses the socket peer address by default", () => {
+    expect(callerKey(req("203.0.113.7"))).toBe("addr:203.0.113.7");
+  });
+
+  test("SPOOF RESISTANCE: X-Forwarded-For is ignored entirely when no proxy is trusted", () => {
+    const key = callerKey(req("203.0.113.7", { "x-forwarded-for": "10.0.0.1" }));
+    expect(key).toBe("addr:203.0.113.7");
+    expect(key).not.toContain("10.0.0.1");
+  });
+
+  test("SPOOF RESISTANCE: with one trusted hop it takes the RIGHTMOST entry, never the caller-supplied left one", () => {
+    process.env.FLAIR_TRUSTED_PROXY = "1";
+    // A caller sent "1.1.1.1"; the trusted proxy appended the address it actually
+    // saw. Keying on the left entry would let anyone mint a fresh bucket per
+    // request just by varying a header.
+    const key = callerKey(req("127.0.0.1", { "x-forwarded-for": "1.1.1.1, 203.0.113.7" }));
+    expect(key).toBe("xff:203.0.113.7");
+    expect(key).not.toContain("1.1.1.1");
+  });
+
+  test("with two trusted hops it takes the entry two from the right", () => {
+    process.env.FLAIR_TRUSTED_PROXY = "2";
+    expect(callerKey(req("127.0.0.1", { "x-forwarded-for": "1.1.1.1, 203.0.113.7, 10.0.0.9" })))
+      .toBe("xff:203.0.113.7");
+  });
+
+  test("a chain SHORTER than the configured hop count falls back to the socket peer", () => {
+    process.env.FLAIR_TRUSTED_PROXY = "3";
+    expect(callerKey(req("203.0.113.7", { "x-forwarded-for": "1.1.1.1" }))).toBe("addr:203.0.113.7");
+  });
+
+  test("no address available collapses to ONE shared bucket — restrictive, never unthrottled", () => {
+    expect(callerKey(req(undefined))).toBe(UNKNOWN_CALLER);
+    expect(callerKey(req(""))).toBe(UNKNOWN_CALLER);
+  });
+});
+
+describe("trustedProxyHops", () => {
+  test("defaults to trusting nothing", () => {
+    expect(trustedProxyHops()).toBe(0);
+  });
+
+  test("accepts a hop count and the boolean spellings", () => {
+    process.env.FLAIR_TRUSTED_PROXY = "2";
+    expect(trustedProxyHops()).toBe(2);
+    process.env.FLAIR_TRUSTED_PROXY = "true";
+    expect(trustedProxyHops()).toBe(1);
+    process.env.FLAIR_TRUSTED_PROXY = "off";
+    expect(trustedProxyHops()).toBe(0);
+  });
+
+  test("garbage is treated as NO trusted proxy, not as one", () => {
+    process.env.FLAIR_TRUSTED_PROXY = "yes-please";
+    expect(trustedProxyHops()).toBe(0);
+  });
+});
+
+// ─── Configuration ──────────────────────────────────────────────────────────
+
+describe("configuration", () => {
+  test("limits default to the documented values", () => {
+    expect(policyFor("oauth").limit).toBe(30);
+    expect(policyFor("register").limit).toBe(5);
+    expect(policyFor("mcp").limit).toBe(120);
+  });
+
+  test("a valid override is honoured", () => {
+    process.env.FLAIR_OAUTH_RATE_LIMIT = "7";
+    expect(policyFor("oauth").limit).toBe(7);
+  });
+
+  test("zero, negative and non-numeric values fall back to the default rather than disabling the control", () => {
+    for (const bad of ["0", "-1", "abc", "1.5", ""]) {
+      process.env.FLAIR_OAUTH_RATE_LIMIT = bad;
+      __resetWarningsForTest();
+      expect(envLimit("FLAIR_OAUTH_RATE_LIMIT", 30)).toBe(30);
+    }
+  });
+
+  test("rate limiting is ON unless explicitly switched off", () => {
+    expect(rateLimitEnabled()).toBe(true);
+    process.env.FLAIR_RATE_LIMIT = "off";
+    expect(rateLimitEnabled()).toBe(false);
+  });
+
+  test("a TYPO in the master switch leaves the control ENABLED", () => {
+    // "disabled" is not one of the accepted off spellings. Treating an
+    // unrecognised value as "off" would let a typo silently unthrottle the
+    // instance — an unrun check that looks like a pass.
+    process.env.FLAIR_RATE_LIMIT = "disabled";
+    expect(rateLimitEnabled()).toBe(true);
+  });
+});
+
+// ─── The HTTP entry point ───────────────────────────────────────────────────
+
+describe("checkHttpRateLimit", () => {
+  test("POSITIVE CONTROL: requests under the limit pass through (null = continue)", () => {
+    process.env.FLAIR_OAUTH_RATE_LIMIT = "3";
+    for (let i = 0; i < 3; i++) {
+      expect(checkHttpRateLimit(req("203.0.113.7"), "/OAuthToken")).toBeNull();
+    }
+  });
+
+  test("over the limit it returns a 429 carrying Retry-After", async () => {
+    process.env.FLAIR_OAUTH_RATE_LIMIT = "3";
+    for (let i = 0; i < 3; i++) checkHttpRateLimit(req("203.0.113.7"), "/OAuthToken");
+    const res = checkHttpRateLimit(req("203.0.113.7"), "/OAuthToken");
+    expect(res).not.toBeNull();
+    expect(res!.status).toBe(429);
+    expect(Number(res!.headers.get("retry-after"))).toBeGreaterThanOrEqual(1);
+    expect(await res!.text()).toBe(LIMITED_BODY);
+  });
+
+  test("the 429 body leaks nothing about the caller, the endpoint or the credential", async () => {
+    // Identical bytes for every key and every endpoint. Anything echoed back
+    // here would be a free confirmation channel on an unauthenticated surface.
+    const body = JSON.parse(LIMITED_BODY);
+    expect(Object.keys(body).sort()).toEqual(["error", "error_description"]);
+    expect(body.error).toBe("slow_down");
+    expect(LIMITED_BODY).not.toContain("203.0.113");
+    expect(LIMITED_BODY).not.toContain("client");
+    expect(LIMITED_BODY).not.toContain("grant");
+  });
+
+  test("no RateLimit-* pacing headers are emitted", () => {
+    const res = limitedResponse({ limited: true, limit: 3, retryAfterSec: 42 });
+    expect(res.headers.get("ratelimit-limit")).toBeNull();
+    expect(res.headers.get("ratelimit-remaining")).toBeNull();
+    expect(res.headers.get("ratelimit-reset")).toBeNull();
+    expect(res.headers.get("retry-after")).toBe("42");
+  });
+
+  test("registration keeps its own budget when the token budget is heavily used", () => {
+    // The limits are deliberately the wrong way round for this case: the token
+    // budget is LARGER than the registration budget, so if the two shared a key
+    // the token traffic alone would push the shared count past the registration
+    // limit. With equal-or-smaller limits the assertion passes either way and
+    // proves nothing — which is what a first draft of this test did.
+    process.env.FLAIR_OAUTH_RATE_LIMIT = "10";
+    process.env.FLAIR_OAUTH_REGISTER_RATE_LIMIT = "2";
+    const caller = req("203.0.113.7");
+    for (let i = 0; i < 10; i++) expect(checkHttpRateLimit(caller, "/OAuthToken")).toBeNull();
+    expect(checkHttpRateLimit(caller, "/OAuthRegister")).toBeNull();
+    expect(checkHttpRateLimit(caller, "/OAuthRegister")).toBeNull();
+    expect(checkHttpRateLimit(caller, "/OAuthRegister")).not.toBeNull();
+  });
+
+  test("an exhausted token budget does not close registration", () => {
+    process.env.FLAIR_OAUTH_RATE_LIMIT = "2";
+    process.env.FLAIR_OAUTH_REGISTER_RATE_LIMIT = "5";
+    const caller = req("203.0.113.7");
+    for (let i = 0; i < 3; i++) checkHttpRateLimit(caller, "/OAuthToken");
+    expect(checkHttpRateLimit(caller, "/OAuthToken")).not.toBeNull();
+    expect(checkHttpRateLimit(caller, "/OAuthRegister")).toBeNull();
+  });
+
+  test("distinct callers do not spend each other's budget", () => {
+    process.env.FLAIR_OAUTH_RATE_LIMIT = "2";
+    for (let i = 0; i < 3; i++) checkHttpRateLimit(req("203.0.113.7"), "/OAuthToken");
+    expect(checkHttpRateLimit(req("203.0.113.7"), "/OAuthToken")).not.toBeNull();
+    expect(checkHttpRateLimit(req("198.51.100.4"), "/OAuthToken")).toBeNull();
+  });
+
+  test("an unthrottled path is never rejected, however many times it is called", () => {
+    process.env.FLAIR_OAUTH_RATE_LIMIT = "1";
+    for (let i = 0; i < 50; i++) {
+      expect(checkHttpRateLimit(req("203.0.113.7"), "/Memory")).toBeNull();
+    }
+  });
+
+  test("the master switch off means no request is ever rejected", () => {
+    process.env.FLAIR_RATE_LIMIT = "off";
+    process.env.FLAIR_OAUTH_RATE_LIMIT = "1";
+    for (let i = 0; i < 20; i++) {
+      expect(checkHttpRateLimit(req("203.0.113.7"), "/OAuthToken")).toBeNull();
+    }
+  });
+});
+
+// ─── The /mcp entry point ───────────────────────────────────────────────────
+
+describe("checkMcpRateLimit", () => {
+  const mcpReq = (sub: string, clientId = "cid", ip = "203.0.113.7"): any => ({
+    ...req(ip),
+    mcp: { sub, client_id: clientId },
+  });
+
+  test("POSITIVE CONTROL: calls under the limit pass through", () => {
+    process.env.FLAIR_MCP_RATE_LIMIT = "3";
+    for (let i = 0; i < 3; i++) expect(checkMcpRateLimit(mcpReq("sub-a"))).toBeNull();
+  });
+
+  test("over the limit returns a 429 with a JSON-RPC error body", () => {
+    process.env.FLAIR_MCP_RATE_LIMIT = "3";
+    for (let i = 0; i < 3; i++) checkMcpRateLimit(mcpReq("sub-a"));
+    const res = checkMcpRateLimit(mcpReq("sub-a"));
+    expect(res).not.toBeNull();
+    expect(res!.status).toBe(429);
+    expect(JSON.parse(res!.body).error.message).toBe("too many requests");
+    expect(Number(res!.headers["retry-after"])).toBeGreaterThanOrEqual(1);
+  });
+
+  test("keyed on the VERIFIED SUBJECT, not the address: a second subject on the same address is unaffected", () => {
+    process.env.FLAIR_MCP_RATE_LIMIT = "2";
+    for (let i = 0; i < 3; i++) checkMcpRateLimit(mcpReq("sub-a"));
+    expect(checkMcpRateLimit(mcpReq("sub-a"))).not.toBeNull();
+    expect(checkMcpRateLimit(mcpReq("sub-b"))).toBeNull();
+  });
+
+  test("keyed on the VERIFIED SUBJECT, not the address: the SAME subject stays limited from a new address", () => {
+    // This is the property per-IP keying cannot give: a token that changes
+    // network position keeps its budget.
+    process.env.FLAIR_MCP_RATE_LIMIT = "2";
+    for (let i = 0; i < 3; i++) checkMcpRateLimit(mcpReq("sub-a", "cid", "203.0.113.7"));
+    expect(checkMcpRateLimit(mcpReq("sub-a", "cid", "198.51.100.4"))).not.toBeNull();
+  });
+
+  test("the /mcp budget is separate from the OAuth endpoints'", () => {
+    process.env.FLAIR_OAUTH_RATE_LIMIT = "1";
+    process.env.FLAIR_MCP_RATE_LIMIT = "5";
+    for (let i = 0; i < 3; i++) checkHttpRateLimit(req("203.0.113.7"), "/OAuthToken");
+    expect(checkMcpRateLimit(mcpReq("sub-a"))).toBeNull();
+  });
+});


### PR DESCRIPTION
Refs #1017 — item 2 of the tracked set. Item 3 (dynamic client registration) is a separate PR; item 4 remains open, so this deliberately does not close the issue.

## What was unthrottled

`/OAuthToken` accepts three grant types on one unauthenticated endpoint. `/OAuthRegister` creates a durable row. `/OAuthAuthorize` mints authorization codes. `/mcp` runs tools for anyone holding a valid token. None of them had any rate limit. Authentication is not a rate limit — a *valid* token can hammer the tool surface just as effectively as an invalid one can hammer the token endpoint.

## The design, and the trade-off it names

**Per node, in memory. Deliberately, and stated as such in the module header, the changelog and `docs/auth.md`.**

Flair runs on Harper Fabric with more than one node behind a GTM, and components hot-reload, so a process-local counter means the effective ceiling is `limit × node count` and the counters reset on every deploy. The obvious alternative is a table-backed counter, and it is the wrong trade here for two reasons, only one of which is latency:

1. A flair table is **replicated**. Every counted request would become a durable write fanned out to every node — so N requests from an attacker become N cluster-wide replicated writes, on the exact hot path the limiter exists to protect. That is a strictly worse denial-of-service shape than the one being defended against.
2. Replication is eventually consistent, so the shared counter would not be accurate for a burst anyway. It buys correctness at the timescale of replication lag, which is the timescale a burst has already finished in.

And the security value does not hinge on the multiplier. This is a **brute-force control, not a capacity control**: what matters is that guesses per unit time are bounded and small against secrets with 256 bits of entropy. Whether the ceiling is 30/min or 60/min does not change that; whether it is bounded at all does.

**What would change this answer** — a guessable-secret space small enough for a small constant multiplier to matter; a node count large enough that `limit × N` stops being meaningfully bounded; or Harper gaining a shared **non-replicated** cache primitive.

**What this does not protect against** — a distributed botnet (per-address keying is defeated by enough distinct sources), aggregate cluster capacity, or anything at all if an operator sets `FLAIR_RATE_LIMIT=off`.

## Limits and keys

| Surface | Default | Window | Key |
|---|---|---|---|
| `/OAuthToken`, `/OAuthAuthorize`, `/OAuthRevoke` (one shared budget) | 30 | 60s | Caller address |
| `/OAuthRegister` | 5 | 300s | Caller address |
| `/mcp` | 120 | 60s | Verified token subject |

The three credential endpoints share one budget because they are one attack surface, and splitting would hand the same caller three times the budget for the same activity. Registration is separate because it is a different kind of abuse (durable replicated rows) at a different natural rate.

`/mcp` is keyed on the RS256-verified `sub`, not an address — the strongest identity available on an authenticated surface, and one that survives a caller changing network position. Keying on `client_id` alone would be defeated by open registration, which is why the two items interact.

**Address resolution.** The key is the socket peer address. `X-Forwarded-For` is ignored entirely unless `FLAIR_TRUSTED_PROXY` names how many hops genuinely sit in front — an instance that honours that header with no proxy is bypassable by anyone willing to vary it. When it is trusted, the entry is taken from the **right**, never the caller-controlled leftmost.

## No enumeration oracle

The counter is consumed at the top of the middleware, before the body is parsed and before any credential is examined. If only failures were counted, "did this consume budget" would answer "was that credential valid" — a cleaner oracle than the 400 the endpoint already returns. A test drives a genuinely valid authorization code and a garbage one against a spent bucket and asserts the responses are byte-identical.

No `RateLimit-*` headers are emitted on allowed requests: a live remaining-count on a credential endpoint is a pacing aid for exactly the caller you do not want to help. `Retry-After` on the 429 is the one hint, so a client that must back off can.

## Blast radius

Only the four OAuth paths are throttled. Every other path returns "no policy" and is untouched — asserted directly, including that `/Memory`, `/Presence`, `/FederationSync`, `/Health` and both discovery documents are never rate limited.

`FLAIR_MCP_OAUTH` is untouched and still default-off. The `/mcp` wrapper is correct in both flag states: when off, no route is registered and none of this code runs.

## Testing

Full lanes, measured on unmodified `origin/main` (c5d0dc7) in a separate worktree first:

| Lane | Baseline | This branch |
|---|---|---|
| `bun test test/unit/ test/*.test.ts` | 3825 pass, 0 fail (205 files) | 3867 pass, 0 fail (206 files) |
| `bun test test/integration/` | 417 pass, 0 fail (53 files) | 432 pass, 0 fail (54 files) |

Built with `npm run build && npm run build:cli` before both, so the integration lane and `docs-freshness-check` (7/7, no `DID NOT RUN`) actually ran. The one pre-existing `tsc --noEmit` error in `resources/auth-middleware.ts` is present and unchanged on `origin/main`.

Every limit assertion carries a positive control — the requests below the threshold are asserted to be served, not just the one above it asserted to be rejected. A test that only checks for the 429 passes against a limiter set to zero.

**The limiter is proven to limit against a running instance**, not only in a unit test of the counter: the integration lane drives real HTTP past the threshold against a real Harper spawn, and a separate probe against a live instance with the limit set to 4 returned `400,400,400,400,429,429,429` and emitted no address-degradation warning, confirming the key is the real socket peer address.

### Mutation checks — each control broken, test confirmed failing, restored, confirmed green

| Control | Mutation | Broken | Restored |
|---|---|---|---|
| The 429 short-circuits | compute the decision, never apply it | FAIL (8 cases) | PASS |
| Hook runs before the public-path passthrough | move it below the early return | FAIL (8 cases) | PASS |
| XFF ignored with no trusted proxy | trust one hop unconditionally | FAIL | PASS |
| XFF entry taken from the right | take the leftmost | FAIL | PASS |
| Per-endpoint bucket separation | drop the bucket from the key | FAIL | PASS |
| Bounded memory (cap + LRU) | remove the eviction call | FAIL | PASS |
| Master-switch typo leaves it enabled | treat unrecognised as off | FAIL | PASS |
| Zero/garbage limit falls back to default | allow zero | FAIL | PASS |
| `/mcp` limiter composed inside `withMCPAuth` | pass the bare handler | FAIL | PASS |
| `/mcp` wrapper short-circuits | call the check, ignore the result | FAIL | PASS |

Two mutations initially reported PASS. One was the mutation failing to apply (fixed and re-run); the other was a real gap — the bucket-separation test used a registration limit *higher* than the token limit, so a shared key would not have tripped it. The test now sets the limits the other way round, and the mutation fails.

## Found, not fixed

`resources/auth-middleware.ts`'s Basic-auth path calls `server.getUser(user, pass)` on every non-public path with no throttle, which is a password-guessing surface of its own. It is outside this issue's scope and covering it would change behaviour for every existing Basic caller, so it is called out rather than folded in.
