### PR TITLE
feat(oauth): close dynamic client registration unless an operator opens it

### DIFF
--- a/.changelog/unreleased/security-dcr-off-by-default.md
+++ b/.changelog/unreleased/security-dcr-off-by-default.md
@@ -1,0 +1,30 @@
+- **Dynamic client registration is now off unless an operator turns it on.**
+  `POST /OAuthRegister` used to accept anonymous registrations from anyone who
+  could reach the instance, gated only by a redirect-URI host match — so on a
+  publicly-reachable Flair, anyone could create rows in the durable, replicated
+  `OAuthClient` table, each one a `client_id` that `/OAuthAuthorize` would
+  subsequently honour. It now answers `403 access_denied` by default, and the
+  RFC 8414 / `/OAuthMetadata` discovery documents stop advertising a
+  `registration_endpoint`, because advertising one that refuses every request is
+  a discovery document that misdirects.
+
+  **This changes behaviour for anyone relying on anonymous registration.** To
+  keep it, set `FLAIR_OAUTH_DCR_TOKEN` to an initial access token of at least 32
+  characters (RFC 7591 §3.1) and have clients present it in an
+  `X-Flair-Initial-Access-Token` header. Registering clients ahead of time and
+  leaving registration off is the better shape where it is workable.
+
+  That one variable is the whole interface: there is no separate enable switch,
+  so enabling registration and supplying the credential that guards it are the
+  same act, and "on, and open to the internet" is not a state reachable by
+  forgetting a setting. A token shorter than the minimum leaves registration
+  **off** rather than enabling it weakly, and says so by variable name.
+
+  The token belongs in the process environment. `flair deploy` will not generate
+  a component `.env` containing it — a deploy payload is stored in Harper's
+  deployment record and replicated to every node.
+
+  RFC 7591 presents this token as `Authorization: Bearer`, which cannot work
+  here: Harper's own auth layer claims that header and answers `401` before any
+  Flair code runs. Hence the dedicated header. See
+  [docs/auth.md](docs/auth.md#dynamic-client-registration).

--- a/.changelog/unreleased/security-dcr-off-by-default.md
+++ b/.changelog/unreleased/security-dcr-off-by-default.md
@@ -9,7 +9,7 @@
   a discovery document that misdirects.
 
   **This changes behaviour for anyone relying on anonymous registration.** To
-  keep it, set `FLAIR_OAUTH_DCR_TOKEN` to an initial access token of at least 32
+  keep it, set `FLAIR_OAUTH_DCR_TOKEN` to an initial access token of 32 to 508
   characters (RFC 7591 §3.1) and have clients present it in an
   `X-Flair-Initial-Access-Token` header. Registering clients ahead of time and
   leaving registration off is the better shape where it is workable.
@@ -17,8 +17,12 @@
   That one variable is the whole interface: there is no separate enable switch,
   so enabling registration and supplying the credential that guards it are the
   same act, and "on, and open to the internet" is not a state reachable by
-  forgetting a setting. A token shorter than the minimum leaves registration
+  forgetting a setting. A token outside the accepted length leaves registration
   **off** rather than enabling it weakly, and says so by variable name.
+
+  Note that registration rate limiting runs in front of this gate, so refused
+  attempts spend budget and a flood against a closed endpoint is answered `429`
+  rather than `403`.
 
   The token belongs in the process environment. `flair deploy` will not generate
   a component `.env` containing it — a deploy payload is stored in Harper's

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -82,9 +82,17 @@ That one variable is the whole interface. There is no separate "enable" switch,
 which is the point: enabling registration and supplying the credential that
 guards it are the same act, so "on, and open to the internet" is not a state you
 can reach by forgetting a setting — it does not exist in the configuration. A
-token shorter than 32 characters is refused and registration stays **off**, with
+token outside 32–508 characters is refused and registration stays **off**, with
 a warning naming the variable; a weak shared secret on an unauthenticated public
 endpoint is nearer to open than to closed.
+
+Registration is also rate limited, and the limiter runs **in front of** this
+gate: refused attempts spend budget too, so a flood against a closed endpoint is
+answered `429`, not `403`. That is deliberate — the limiter is the cheaper check
+and the one bounding volume — but it means a client retrying hard against an
+instance that has not opted in sees `429` and should read it as "stop", not as a
+different answer to the same question. The budget is 5 per five minutes by
+default (`FLAIR_OAUTH_REGISTER_RATE_LIMIT`).
 
 Keep the token in the process environment. Do not put it in a component `.env`
 for `flair deploy` to ship — a deploy payload is stored in Harper's deployment

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -62,22 +62,64 @@ Flair includes a built-in OAuth 2.1 authorization server for client integrations
 
 ### Dynamic Client Registration
 
-Clients register automatically on first connection:
+**Registration is off by default.** `POST /OAuthRegister` answers `403
+access_denied`, and the discovery documents do not advertise a
+`registration_endpoint`. Nothing needs doing to be in this state — it is what a
+fresh install does, and it is what an internet-reachable instance should stay in
+unless there is a reason otherwise.
+
+`OAuthClient` rows are durable and replicated, and every one of them is a
+`client_id` that `/OAuthAuthorize` will subsequently honour, so an open
+registration endpoint on a public instance means anyone can fill that table.
+
+To turn registration on, set an initial access token (RFC 7591 §3.1):
+
+```sh
+FLAIR_OAUTH_DCR_TOKEN=$(openssl rand -base64 32)
+```
+
+That one variable is the whole interface. There is no separate "enable" switch,
+which is the point: enabling registration and supplying the credential that
+guards it are the same act, so "on, and open to the internet" is not a state you
+can reach by forgetting a setting — it does not exist in the configuration. A
+token shorter than 32 characters is refused and registration stays **off**, with
+a warning naming the variable; a weak shared secret on an unauthenticated public
+endpoint is nearer to open than to closed.
+
+Keep the token in the process environment. Do not put it in a component `.env`
+for `flair deploy` to ship — a deploy payload is stored in Harper's deployment
+record and replicated to every node. `flair deploy` refuses to generate one
+containing this key, and warns if your own file assigns it.
+
+Clients then present it in a request header:
 
 ```
 POST /OAuthRegister
 Content-Type: application/json
+X-Flair-Initial-Access-Token: <the token>
 
 {
   "client_name": "Claude Desktop",
-  "redirect_uris": ["http://localhost:3000/callback"],
+  "redirect_uris": ["https://claude.com/api/mcp/auth_callback"],
   "grant_types": ["authorization_code"],
   "response_types": ["code"],
   "token_endpoint_auth_method": "none"
 }
 ```
 
-Returns `client_id` and `client_secret` (if applicable).
+Returns `client_id`. A missing or wrong token answers `401 invalid_token`.
+
+**Why a header and not `Authorization: Bearer`,** which is what RFC 7591 §3.1
+specifies: Harper's own auth layer claims every `Authorization: Bearer …` header
+and validates it as a Harper operation token, so a Bearer-carrying request to
+`/OAuthRegister` is answered `401 {"error":"invalid token"}` before any Flair
+code runs. Measured, not assumed — no header returns 200, `Bearer <anything>`
+returns 401, a custom header returns 200.
+
+Registering clients ahead of time and leaving this off is the better shape where
+it is workable — the surface exists to serve one known client shape, and the
+`@harperfast/oauth` authorization server used by the `/mcp` surface takes CIMD
+rather than registration.
 
 ### Authorization Code Flow with PKCE
 
@@ -93,7 +135,7 @@ Standard OAuth 2.1 authorization code flow:
 
 | Endpoint | Method | Description |
 |----------|--------|-------------|
-| `/OAuthRegister` | POST | Dynamic client registration |
+| `/OAuthRegister` | POST | Dynamic client registration — off unless `FLAIR_OAUTH_DCR_TOKEN` is set |
 | `/OAuthAuthorize` | GET/POST | Authorization endpoint |
 | `/OAuthToken` | POST | Token endpoint |
 | `/.well-known/oauth-authorization-server` | GET | Authorization server metadata (RFC 8414) |

--- a/resources/OAuth.ts
+++ b/resources/OAuth.ts
@@ -2,6 +2,7 @@ import { Resource, databases } from "harper";
 import { createHash, randomBytes } from "node:crypto";
 import { handleJwtBearerGrant } from "./XAA.js";
 import { resolveAgentAuth } from "./agent-auth.js";
+import { decideRegistration } from "./dcr-gate.js";
 import { buildAuthorizationServerMetadata } from "./oauth-discovery.js";
 
 /**
@@ -99,9 +100,35 @@ export class OAuthRegister extends Resource {
   // Dynamic Client Registration (RFC 7591) — clients must be able to register
   // anonymously to bootstrap. Validation (redirect_uri allow-list, etc.)
   // happens in post(). Pattern matches FederationPair.allowCreate (#299).
+  //
+  // This stays `true` — it is Harper's ROLE gate, and returning false here would
+  // answer with Harper's own 403 body instead of an RFC 7591-shaped error. WHO
+  // may register is decided in post() via resources/dcr-gate.ts, in one place.
+  // Deliberately not enforced in both: one condition in two places is how the
+  // two drift apart.
   allowCreate() { return true; }
 
   async post(data: any) {
+    // Registration gate FIRST — before the redirect-URI policy is applied,
+    // before anything is read off the body, and before any write. A caller who
+    // may not register learns only that; running the redirect-URI check first
+    // would turn a closed endpoint into a probe for what this server accepts.
+    const decision = decideRegistration((this as any).getContext?.()?.request ?? (this as any).getContext?.());
+    if (!decision.allowed) {
+      if (decision.reason === "disabled") {
+        return new Response(JSON.stringify({
+          error: "access_denied",
+          error_description:
+            "dynamic client registration is not enabled on this server " +
+            "(set FLAIR_OAUTH_DCR_TOKEN to enable it)",
+        }), { status: 403, headers: { "content-type": "application/json" } });
+      }
+      return new Response(JSON.stringify({
+        error: "invalid_token",
+        error_description: "a valid initial access token is required to register a client",
+      }), { status: 401, headers: { "content-type": "application/json" } });
+    }
+
     const redirectUris: string[] = data?.redirect_uris ?? [];
     const clientName: string = data?.client_name ?? "Unknown Client";
 

--- a/resources/dcr-gate.ts
+++ b/resources/dcr-gate.ts
@@ -53,7 +53,7 @@
  * endpoint can actually support.
  */
 
-import { createHash, timingSafeEqual } from "node:crypto";
+import { timingSafeEqual } from "node:crypto";
 
 /** The header the initial access token arrives in. See the module header. */
 export const INITIAL_ACCESS_TOKEN_HEADER = "x-flair-initial-access-token";
@@ -68,11 +68,22 @@ export const INITIAL_ACCESS_TOKEN_HEADER = "x-flair-initial-access-token";
  */
 export const MIN_INITIAL_ACCESS_TOKEN_LEN = 32;
 
-let warnedShort = false;
+/**
+ * Longest accepted initial access token.
+ *
+ * A bound is needed because the constant-time comparison below works over
+ * fixed-width buffers; it is set far above any plausible token (508 bytes is
+ * ~15x a 32-byte base64 secret) so it constrains nothing real. A configured
+ * value outside the range disables registration and says so, rather than
+ * failing every comparison silently for a reason no operator could deduce.
+ */
+export const MAX_INITIAL_ACCESS_TOKEN_LEN = 508;
 
-/** Test-only: forget the one-shot short-token warning. */
+let warnedBadLength = false;
+
+/** Test-only: forget the one-shot bad-length warning. */
 export function __resetDcrWarningForTest(): void {
-  warnedShort = false;
+  warnedBadLength = false;
 }
 
 /**
@@ -86,12 +97,12 @@ export function __resetDcrWarningForTest(): void {
 export function initialAccessToken(): string | undefined {
   const raw = (process.env.FLAIR_OAUTH_DCR_TOKEN ?? "").trim();
   if (raw === "") return undefined;
-  if (raw.length < MIN_INITIAL_ACCESS_TOKEN_LEN) {
-    if (!warnedShort) {
-      warnedShort = true;
+  if (raw.length < MIN_INITIAL_ACCESS_TOKEN_LEN || Buffer.byteLength(raw, "utf8") > MAX_INITIAL_ACCESS_TOKEN_LEN) {
+    if (!warnedBadLength) {
+      warnedBadLength = true;
       console.error(
-        `[oauth-dcr] FLAIR_OAUTH_DCR_TOKEN is shorter than ${MIN_INITIAL_ACCESS_TOKEN_LEN} characters — ` +
-          `dynamic client registration stays DISABLED. Set a longer token to enable it.`,
+        `[oauth-dcr] FLAIR_OAUTH_DCR_TOKEN must be between ${MIN_INITIAL_ACCESS_TOKEN_LEN} and ` +
+          `${MAX_INITIAL_ACCESS_TOKEN_LEN} characters — dynamic client registration stays DISABLED.`,
       );
     }
     return undefined;
@@ -104,21 +115,65 @@ export function dcrEnabled(): boolean {
   return initialAccessToken() !== undefined;
 }
 
+/** Width of the comparison buffers: a 4-byte length prefix plus the token bytes. */
+const COMPARE_WIDTH = MAX_INITIAL_ACCESS_TOKEN_LEN + 4;
+
+/**
+ * Encode a value into a fixed-width buffer as `<uint32 byte length><bytes><zero
+ * padding>`, or null if it does not fit.
+ *
+ * The length prefix is what makes zero-padding safe. Padding alone would make
+ * `"abc"` and `"abc\0"` compare equal, because both pad to the same bytes;
+ * prefixing the length means two buffers are equal exactly when the two inputs
+ * are the same length AND the same bytes.
+ */
+function fixedWidth(value: string): Buffer | null {
+  const bytes = Buffer.from(value, "utf8");
+  if (bytes.length > MAX_INITIAL_ACCESS_TOKEN_LEN) return null;
+  const buf = Buffer.alloc(COMPARE_WIDTH);
+  buf.writeUInt32BE(bytes.length, 0);
+  bytes.copy(buf, 4);
+  return buf;
+}
+
 /**
  * Does the presented token match the configured one?
  *
- * Compared as SHA-256 digests so the comparison is over fixed-length buffers:
- * `timingSafeEqual` throws on a length mismatch, which would itself leak the
- * configured token's length, and comparing raw strings with `===` leaks a prefix
- * match through timing. Digesting first removes both. Returns false whenever
- * registration is disabled, so a caller cannot reach the compare at all.
+ * Both values are widened to the same fixed-size buffer and compared with
+ * `timingSafeEqual`. Equal width is not a convenience — it is the whole point:
+ *
+ *  - `timingSafeEqual` THROWS on a length mismatch, so handing it the raw values
+ *    would turn the configured token's length into an oracle (throw vs. false).
+ *  - `===` on strings short-circuits at the first differing byte, so it leaks a
+ *    prefix match through timing.
+ *
+ * Fixed-width buffers remove both, and the comparison touches every byte of the
+ * secret regardless of the input.
+ *
+ * DELIBERATELY NOT HASHED. An earlier revision digested both sides to get equal
+ * lengths. That works, but a hash of a credential sitting in an equality check
+ * reads — to a human and to a static analyser alike — as password-at-rest
+ * storage, which invites the obvious "why isn't this a KDF" question. The honest
+ * answer is that a KDF is the wrong primitive here: this is an equality check on
+ * a high-entropy machine credential on an unauthenticated request path, so
+ * deliberate per-request computational cost would be handing an attacker a
+ * cheap amplification lever on the exact endpoint the rate limiter exists to
+ * protect. Padding gets the same constant-time property with no hash to explain
+ * and no cost to exploit.
+ *
+ * Returns false whenever registration is disabled, so a caller cannot reach the
+ * comparison at all.
  */
 export function initialAccessTokenMatches(presented: unknown): boolean {
   const expected = initialAccessToken();
   if (expected === undefined) return false;
   if (typeof presented !== "string" || presented === "") return false;
-  const a = createHash("sha256").update(presented).digest();
-  const b = createHash("sha256").update(expected).digest();
+  const a = fixedWidth(presented);
+  const b = fixedWidth(expected);
+  // `b` cannot be null — initialAccessToken() already bounds the configured
+  // value — but null-checking both keeps this total rather than relying on that
+  // invariant holding in a future edit.
+  if (a === null || b === null) return false;
   return timingSafeEqual(a, b);
 }
 

--- a/resources/dcr-gate.ts
+++ b/resources/dcr-gate.ts
@@ -1,0 +1,155 @@
+/**
+ * dcr-gate.ts — who may register an OAuth client (RFC 7591 Dynamic Client
+ * Registration) on flair's own authorization server.
+ *
+ * ── The state this replaces ─────────────────────────────────────────────────
+ * `OAuthRegister.allowCreate()` returned `true` unconditionally and the only
+ * gate in `post()` was a redirect-URI host match. On a publicly-reachable
+ * instance that means anyone can create rows in `OAuthClient` — a durable,
+ * replicated table — as fast as they can send requests, and every one of those
+ * rows is a client_id that will subsequently be honoured by `/OAuthAuthorize`.
+ *
+ * ── Registration is now OFF unless an operator turns it on ──────────────────
+ * `FLAIR_OAUTH_DCR_TOKEN` is the whole interface. Absent — which is every
+ * install that has not deliberately opted in — `POST /OAuthRegister` refuses,
+ * and `/OAuthMetadata` and `/.well-known/oauth-authorization-server` stop
+ * advertising a `registration_endpoint`, because advertising one that refuses
+ * everything is a discovery document that lies.
+ *
+ * ── Why ONE variable and not a mode enum ────────────────────────────────────
+ * There is deliberately no `FLAIR_OAUTH_DCR=open`, and no way to enable
+ * registration without also supplying the credential that guards it. Enabling
+ * and crededentialling are the SAME ACT, so the "on, and open to the internet"
+ * state is not reachable by forgetting an argument — it does not exist in the
+ * configuration space at all. A mode enum plus an optional token would put that
+ * state one typo away, and the difference between the two designs is only
+ * visible on the day someone makes the typo.
+ *
+ * That is also why a token shorter than `MIN_INITIAL_ACCESS_TOKEN_LEN` disables
+ * registration rather than enabling it weakly. A four-character shared secret on
+ * an unauthenticated public endpoint is nearer to open than to closed, and a
+ * control that silently degrades to almost-off is worse than one that is off,
+ * because only one of the two is visible. The refusal is logged, by variable
+ * NAME and minimum length — never the value.
+ *
+ * ── Why a header and not `Authorization: Bearer` ────────────────────────────
+ * RFC 7591 s3.1 presents the initial access token as a Bearer token. That
+ * channel does not work here, and this is measured rather than assumed: Harper's
+ * own auth layer claims every `Authorization: Bearer ...` header for itself and
+ * validates it as a Harper OPERATION token, so a Bearer-carrying request to
+ * `/OAuthRegister` is answered `401 {"error":"invalid token"}` before any code
+ * in resources/ runs. (Probed against a live instance: no header -> 200,
+ * `Bearer <anything>` -> 401, custom header -> 200. Same mechanism documented in
+ * resources/oauth-wellknown.ts's header for the REST surface.) So the token
+ * arrives in `X-Flair-Initial-Access-Token`, which does reach the handler.
+ *
+ * ── This is not the same surface as flair#756's DCR removal ─────────────────
+ * flair#756 disabled Dynamic Client Registration on the `@harperfast/oauth`
+ * plugin's authorization server (`/oauth/mcp/register`) in favour of CIMD, and
+ * deleted the gate-token machinery there. This module is about flair's OWN
+ * OAuth 2.1 AS in resources/OAuth.ts, a separate endpoint that was left open.
+ * The posture is the same one #756 settled on — registration is closed unless
+ * an operator deliberately opens it — arrived at through the mechanism this
+ * endpoint can actually support.
+ */
+
+import { createHash, timingSafeEqual } from "node:crypto";
+
+/** The header the initial access token arrives in. See the module header. */
+export const INITIAL_ACCESS_TOKEN_HEADER = "x-flair-initial-access-token";
+
+/**
+ * Shortest initial access token that will enable registration.
+ *
+ * The token guards an unauthenticated, publicly-reachable endpoint, so its only
+ * defence is length. 32 characters of anything reasonable clears any offline
+ * guessing concern; the per-IP rate limit on `/OAuthRegister` covers online
+ * guessing. Anything shorter is refused outright rather than accepted weakly.
+ */
+export const MIN_INITIAL_ACCESS_TOKEN_LEN = 32;
+
+let warnedShort = false;
+
+/** Test-only: forget the one-shot short-token warning. */
+export function __resetDcrWarningForTest(): void {
+  warnedShort = false;
+}
+
+/**
+ * The configured initial access token, or undefined when registration is off.
+ *
+ * Undefined covers all three of: variable unset, variable empty, and variable
+ * too short to be a credential. Callers therefore cannot accidentally treat
+ * "misconfigured" as "open" — there is one value that means enabled and it is a
+ * usable token.
+ */
+export function initialAccessToken(): string | undefined {
+  const raw = (process.env.FLAIR_OAUTH_DCR_TOKEN ?? "").trim();
+  if (raw === "") return undefined;
+  if (raw.length < MIN_INITIAL_ACCESS_TOKEN_LEN) {
+    if (!warnedShort) {
+      warnedShort = true;
+      console.error(
+        `[oauth-dcr] FLAIR_OAUTH_DCR_TOKEN is shorter than ${MIN_INITIAL_ACCESS_TOKEN_LEN} characters — ` +
+          `dynamic client registration stays DISABLED. Set a longer token to enable it.`,
+      );
+    }
+    return undefined;
+  }
+  return raw;
+}
+
+/** Is `POST /OAuthRegister` open for business on this instance? */
+export function dcrEnabled(): boolean {
+  return initialAccessToken() !== undefined;
+}
+
+/**
+ * Does the presented token match the configured one?
+ *
+ * Compared as SHA-256 digests so the comparison is over fixed-length buffers:
+ * `timingSafeEqual` throws on a length mismatch, which would itself leak the
+ * configured token's length, and comparing raw strings with `===` leaks a prefix
+ * match through timing. Digesting first removes both. Returns false whenever
+ * registration is disabled, so a caller cannot reach the compare at all.
+ */
+export function initialAccessTokenMatches(presented: unknown): boolean {
+  const expected = initialAccessToken();
+  if (expected === undefined) return false;
+  if (typeof presented !== "string" || presented === "") return false;
+  const a = createHash("sha256").update(presented).digest();
+  const b = createHash("sha256").update(expected).digest();
+  return timingSafeEqual(a, b);
+}
+
+/** Read the initial access token off a Harper request. Never logs it. */
+export function presentedInitialAccessToken(request: any): string | undefined {
+  const raw =
+    request?.headers?.get?.(INITIAL_ACCESS_TOKEN_HEADER) ??
+    request?.headers?.asObject?.[INITIAL_ACCESS_TOKEN_HEADER] ??
+    undefined;
+  if (typeof raw !== "string") return undefined;
+  const trimmed = raw.trim();
+  return trimmed === "" ? undefined : trimmed;
+}
+
+export type DcrDecision =
+  /** Registration is switched off on this instance. */
+  | { allowed: false; reason: "disabled" }
+  /** Registration is on, but this request did not present the right token. */
+  | { allowed: false; reason: "invalid_token" }
+  | { allowed: true };
+
+/**
+ * The single decision point. `resources/OAuth.ts` calls this before it reads
+ * ANYTHING else off the request — before the redirect-URI check, before any
+ * write — so a caller who is not allowed to register learns nothing about the
+ * server's registration policy beyond the fact that they may not.
+ */
+export function decideRegistration(request: any): DcrDecision {
+  if (!dcrEnabled()) return { allowed: false, reason: "disabled" };
+  if (!initialAccessTokenMatches(presentedInitialAccessToken(request))) {
+    return { allowed: false, reason: "invalid_token" };
+  }
+  return { allowed: true };
+}

--- a/resources/oauth-discovery.ts
+++ b/resources/oauth-discovery.ts
@@ -28,6 +28,7 @@
  */
 
 import { mcpOAuthEnabled } from "./mcp-oauth-flag.js";
+import { dcrEnabled } from "./dcr-gate.js";
 
 /** RFC 9728 §3.1 — Protected Resource Metadata well-known path. */
 export const PRM_PATH = "/.well-known/oauth-protected-resource";
@@ -71,13 +72,21 @@ export function mcpResourceUri(baseUrl: string = oauthPublicBaseUrl()): string {
  * `/OAuthRevoke`.
  *
  * Served at BOTH `/.well-known/oauth-authorization-server` and `/OAuthMetadata`.
+ *
+ * `registration_endpoint` is present ONLY while dynamic client registration is
+ * actually enabled (resources/dcr-gate.ts). RFC 8414 s2 makes the field
+ * OPTIONAL, and advertising an endpoint that refuses every request is a
+ * discovery document that misdirects: a client would follow it, be refused, and
+ * have learned nothing it can act on. Omitting it tells the truth — this server
+ * does not do dynamic registration — which is a state a spec-compliant client
+ * already knows how to handle.
  */
 export function buildAuthorizationServerMetadata(baseUrl: string = oauthPublicBaseUrl()) {
   return {
     issuer: baseUrl,
     authorization_endpoint: `${baseUrl}/OAuthAuthorize`,
     token_endpoint: `${baseUrl}/OAuthToken`,
-    registration_endpoint: `${baseUrl}/OAuthRegister`,
+    ...(dcrEnabled() ? { registration_endpoint: `${baseUrl}/OAuthRegister` } : {}),
     revocation_endpoint: `${baseUrl}/OAuthRevoke`,
     response_types_supported: ["code"],
     grant_types_supported: [

--- a/src/component-env.ts
+++ b/src/component-env.ts
@@ -60,6 +60,12 @@ export const NEVER_GENERATED_SECRET_KEYS = [
   "FABRIC_PASSWORD",
   "FLAIR_CLUSTER_ADMIN_PASS",
   "CLI_TARGET_PASSWORD",
+  // The DCR initial access token (resources/dcr-gate.ts). It is a bearer
+  // credential for an unauthenticated public endpoint, so it belongs in the
+  // process environment, never in a deploy payload — that payload is ingested
+  // into an hdb_deployment row and replicated to every node, per the argument
+  // at the top of this file.
+  "FLAIR_OAUTH_DCR_TOKEN",
 ] as const;
 
 /**

--- a/test/e2e/flair-endpoints.spec.ts
+++ b/test/e2e/flair-endpoints.spec.ts
@@ -131,7 +131,13 @@ test.describe("OAuth Discovery", () => {
     expect(body).toHaveProperty("token_endpoint");
   });
 
-  test("POST /OAuthRegister with valid client data returns client_id", async ({ request }) => {
+  test("POST /OAuthRegister is refused on an instance that has not opted in", async ({ request }) => {
+    // Dynamic client registration is now off unless the operator sets
+    // FLAIR_OAUTH_DCR_TOKEN, and this container does not. Being an admin does
+    // not help: the gate is the initial access token, not agent identity — so
+    // the admin credential below is exactly the "surely this still works"
+    // control. The enabled path is covered against a real spawn in
+    // test/integration/oauth-dcr-e2e.test.ts.
     const res = await request.post("/OAuthRegister", {
       headers: { ...adminAuth(), "Content-Type": "application/json" },
       data: {
@@ -140,11 +146,8 @@ test.describe("OAuth Discovery", () => {
         grant_types: ["authorization_code"],
       },
     });
-    expect(res.status()).toBe(200);
-    const body = await res.json();
-    expect(body).toHaveProperty("client_id");
-    expect(typeof body.client_id).toBe("string");
-    expect(body.client_id.length).toBeGreaterThan(0);
+    expect(res.status()).toBe(403);
+    expect((await res.json()).error).toBe("access_denied");
   });
 });
 

--- a/test/integration/oauth-dcr-e2e.test.ts
+++ b/test/integration/oauth-dcr-e2e.test.ts
@@ -50,10 +50,20 @@ async function clientRowCount(h: HarperInstance): Promise<number> {
 describe("DCR is closed on a default install (real Harper)", () => {
   let harper: HarperInstance;
   let savedToken: string | undefined;
+  let savedRegisterLimit: string | undefined;
 
   beforeAll(async () => {
     savedToken = process.env.FLAIR_OAUTH_DCR_TOKEN;
     delete process.env.FLAIR_OAUTH_DCR_TOKEN;
+    // The registration rate limiter runs BEFORE this gate (deliberately — see
+    // the ordering test at the bottom of this file), and its default budget is
+    // 5 per five minutes. These cases make more registration attempts than that
+    // against one instance, so at the default the later ones would be answered
+    // 429 by the limiter and never reach the gate under test. Raising it takes
+    // an unrelated control out of the path; it does not weaken a single
+    // assertion below, each of which still demands an exact status and body.
+    savedRegisterLimit = process.env.FLAIR_OAUTH_REGISTER_RATE_LIMIT;
+    process.env.FLAIR_OAUTH_REGISTER_RATE_LIMIT = "100";
     harper = await startHarper();
   }, 180_000);
 
@@ -61,6 +71,8 @@ describe("DCR is closed on a default install (real Harper)", () => {
     if (harper) await stopHarper(harper);
     if (savedToken === undefined) delete process.env.FLAIR_OAUTH_DCR_TOKEN;
     else process.env.FLAIR_OAUTH_DCR_TOKEN = savedToken;
+    if (savedRegisterLimit === undefined) delete process.env.FLAIR_OAUTH_REGISTER_RATE_LIMIT;
+    else process.env.FLAIR_OAUTH_REGISTER_RATE_LIMIT = savedRegisterLimit;
   });
 
   test("an anonymous POST /OAuthRegister is refused with 403", async () => {
@@ -113,10 +125,18 @@ describe("DCR is closed on a default install (real Harper)", () => {
 describe("DCR when an operator has opted in (real Harper)", () => {
   let harper: HarperInstance;
   let savedToken: string | undefined;
+  let savedRegisterLimit: string | undefined;
 
   beforeAll(async () => {
     savedToken = process.env.FLAIR_OAUTH_DCR_TOKEN;
     process.env.FLAIR_OAUTH_DCR_TOKEN = TOKEN;
+    // Same reason as the closed block: keep the registration limiter out of the
+    // path so these assertions test the gate. This block currently makes four
+    // registration requests against a default budget of five — it passes today
+    // by one request, and the fifth test anyone adds would fail for a reason
+    // that has nothing to do with what they were testing.
+    savedRegisterLimit = process.env.FLAIR_OAUTH_REGISTER_RATE_LIMIT;
+    process.env.FLAIR_OAUTH_REGISTER_RATE_LIMIT = "100";
     harper = await startHarper();
   }, 180_000);
 
@@ -124,6 +144,8 @@ describe("DCR when an operator has opted in (real Harper)", () => {
     if (harper) await stopHarper(harper);
     if (savedToken === undefined) delete process.env.FLAIR_OAUTH_DCR_TOKEN;
     else process.env.FLAIR_OAUTH_DCR_TOKEN = savedToken;
+    if (savedRegisterLimit === undefined) delete process.env.FLAIR_OAUTH_REGISTER_RATE_LIMIT;
+    else process.env.FLAIR_OAUTH_REGISTER_RATE_LIMIT = savedRegisterLimit;
   });
 
   test("POSITIVE CONTROL: the right initial access token registers a client", async () => {
@@ -159,5 +181,49 @@ describe("DCR when an operator has opted in (real Harper)", () => {
     const res = await fetch(`${harper.httpURL}/.well-known/oauth-authorization-server`);
     const doc = await res.json() as any;
     expect(doc.registration_endpoint).toBe(`${doc.issuer}/OAuthRegister`);
+  });
+});
+
+// ─── The limiter sits IN FRONT of the gate ──────────────────────────────────
+
+describe("the registration rate limiter runs BEFORE the DCR gate (real Harper)", () => {
+  // This is the interaction that broke both of these suites when rate limiting
+  // and the DCR gate first met on one branch: every registration attempt spends
+  // budget, INCLUDING the ones the gate is about to refuse, so a flood against a
+  // closed endpoint is answered 429 rather than 403.
+  //
+  // That is the order we want. The limiter is the cheaper check and it is the
+  // one protecting the endpoint from volume; making the gate run first would
+  // mean an attacker's refused attempts cost the server gate work and never
+  // exhausted anything. Nothing asserted it, so it took a CI failure on a
+  // combined branch to notice — hence this test.
+  let harper: HarperInstance;
+  let savedToken: string | undefined;
+  let savedRegisterLimit: string | undefined;
+  const LIMIT = 3;
+
+  beforeAll(async () => {
+    savedToken = process.env.FLAIR_OAUTH_DCR_TOKEN;
+    delete process.env.FLAIR_OAUTH_DCR_TOKEN; // closed: every attempt is gate-refused
+    savedRegisterLimit = process.env.FLAIR_OAUTH_REGISTER_RATE_LIMIT;
+    process.env.FLAIR_OAUTH_REGISTER_RATE_LIMIT = String(LIMIT);
+    harper = await startHarper();
+  }, 180_000);
+
+  afterAll(async () => {
+    if (harper) await stopHarper(harper);
+    if (savedToken === undefined) delete process.env.FLAIR_OAUTH_DCR_TOKEN;
+    else process.env.FLAIR_OAUTH_DCR_TOKEN = savedToken;
+    if (savedRegisterLimit === undefined) delete process.env.FLAIR_OAUTH_REGISTER_RATE_LIMIT;
+    else process.env.FLAIR_OAUTH_REGISTER_RATE_LIMIT = savedRegisterLimit;
+  });
+
+  test("refused registrations still spend budget, and the limiter answers once it is gone", async () => {
+    const seen: number[] = [];
+    for (let i = 0; i < LIMIT + 2; i++) seen.push((await register(harper, `flood-${i}`)).status);
+    // The first LIMIT attempts reach the gate and are refused by it...
+    expect(seen.slice(0, LIMIT)).toEqual(Array(LIMIT).fill(403));
+    // ...and past that the limiter answers first, so the gate is never reached.
+    expect(seen.slice(LIMIT)).toEqual([429, 429]);
   });
 });

--- a/test/integration/oauth-dcr-e2e.test.ts
+++ b/test/integration/oauth-dcr-e2e.test.ts
@@ -1,0 +1,163 @@
+// oauth-dcr-e2e.test.ts — dynamic client registration, over real HTTP against a
+// real Harper spawn.
+//
+// The unit test proves the gate's logic. This proves it is REACHED: that a
+// default install genuinely refuses `POST /OAuthRegister`, that no client row is
+// created when it does, and that an operator who opts in genuinely gets a
+// working endpoint. Two Harper instances, because the difference under test is a
+// boot-time environment variable.
+//
+// MODEL: test/integration/oauth-authorize-authz.test.ts.
+import { describe, expect, test, beforeAll, afterAll } from "bun:test";
+import { randomBytes } from "node:crypto";
+import { startHarper, stopHarper, HarperInstance } from "../helpers/harper-lifecycle";
+
+const ALLOWED_REDIRECT_URI = "https://claude.com/api/mcp/auth_callback";
+const HEADER = "x-flair-initial-access-token";
+// Generated, not a literal, so nothing token-shaped is committed to the repo.
+const TOKEN = randomBytes(24).toString("base64url");
+
+function registerBody(name: string) {
+  return JSON.stringify({ client_name: name, redirect_uris: [ALLOWED_REDIRECT_URI] });
+}
+
+async function register(h: HarperInstance, name: string, headers: Record<string, string> = {}) {
+  const res = await fetch(`${h.httpURL}/OAuthRegister`, {
+    method: "POST",
+    headers: { "content-type": "application/json", ...headers },
+    body: registerBody(name),
+  });
+  return { status: res.status, text: await res.text() };
+}
+
+/** How many OAuthClient rows exist, via the admin ops API. */
+async function clientRowCount(h: HarperInstance): Promise<number> {
+  const res = await fetch(h.opsURL, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: "Basic " + btoa(`${h.admin.username}:${h.admin.password}`),
+    },
+    body: JSON.stringify({ operation: "search_by_value", database: "flair", table: "OAuthClient", search_attribute: "registeredBy", search_value: "dcr", get_attributes: ["id"] }),
+  });
+  if (res.status !== 200) return -1;
+  const rows = await res.json() as any[];
+  return Array.isArray(rows) ? rows.length : -1;
+}
+
+// ─── Default install: registration is closed ────────────────────────────────
+
+describe("DCR is closed on a default install (real Harper)", () => {
+  let harper: HarperInstance;
+  let savedToken: string | undefined;
+
+  beforeAll(async () => {
+    savedToken = process.env.FLAIR_OAUTH_DCR_TOKEN;
+    delete process.env.FLAIR_OAUTH_DCR_TOKEN;
+    harper = await startHarper();
+  }, 180_000);
+
+  afterAll(async () => {
+    if (harper) await stopHarper(harper);
+    if (savedToken === undefined) delete process.env.FLAIR_OAUTH_DCR_TOKEN;
+    else process.env.FLAIR_OAUTH_DCR_TOKEN = savedToken;
+  });
+
+  test("an anonymous POST /OAuthRegister is refused with 403", async () => {
+    const res = await register(harper, "uninvited");
+    expect(res.status).toBe(403);
+    expect(JSON.parse(res.text).error).toBe("access_denied");
+  });
+
+  test("NO client row is created by a refused registration", async () => {
+    // The point of the endpoint being closed is the durable, replicated row it
+    // no longer creates. A 403 that still wrote would be no fix at all.
+    const before = await clientRowCount(harper);
+    expect(before).toBeGreaterThanOrEqual(0); // the ops probe itself works
+    for (let i = 0; i < 3; i++) await register(harper, `uninvited-${i}`);
+    expect(await clientRowCount(harper)).toBe(before);
+  });
+
+  test("presenting a token when none is configured does not open it", async () => {
+    const res = await register(harper, "guesser", { [HEADER]: "a".repeat(40) });
+    expect(res.status).toBe(403);
+  });
+
+  test("the refusal happens BEFORE the redirect-URI policy is applied", async () => {
+    // A bad redirect URI would be a 400 invalid_redirect_uri if the policy ran
+    // first. A closed endpoint must not double as a probe for what this server
+    // would accept.
+    const res = await fetch(`${harper.httpURL}/OAuthRegister`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ client_name: "probe", redirect_uris: ["https://evil.example.com/cb"] }),
+    });
+    expect(res.status).toBe(403);
+    expect((await res.text())).not.toContain("invalid_redirect_uri");
+  });
+
+  test("discovery does NOT advertise a registration endpoint", async () => {
+    for (const path of ["/.well-known/oauth-authorization-server", "/OAuthMetadata"]) {
+      const res = await fetch(`${harper.httpURL}${path}`);
+      expect(res.status).toBe(200);
+      const doc = await res.json() as any;
+      // POSITIVE CONTROL: the document is otherwise intact.
+      expect(doc.token_endpoint).toBe(`${doc.issuer}/OAuthToken`);
+      expect(doc.registration_endpoint).toBeUndefined();
+    }
+  });
+});
+
+// ─── Opted in: registration works, and only with the token ──────────────────
+
+describe("DCR when an operator has opted in (real Harper)", () => {
+  let harper: HarperInstance;
+  let savedToken: string | undefined;
+
+  beforeAll(async () => {
+    savedToken = process.env.FLAIR_OAUTH_DCR_TOKEN;
+    process.env.FLAIR_OAUTH_DCR_TOKEN = TOKEN;
+    harper = await startHarper();
+  }, 180_000);
+
+  afterAll(async () => {
+    if (harper) await stopHarper(harper);
+    if (savedToken === undefined) delete process.env.FLAIR_OAUTH_DCR_TOKEN;
+    else process.env.FLAIR_OAUTH_DCR_TOKEN = savedToken;
+  });
+
+  test("POSITIVE CONTROL: the right initial access token registers a client", async () => {
+    const res = await register(harper, "invited", { [HEADER]: TOKEN });
+    expect(res.status).toBe(200);
+    expect(JSON.parse(res.text).client_id).toStartWith("flair_cl_");
+  });
+
+  test("no token → 401, and no row", async () => {
+    const before = await clientRowCount(harper);
+    const res = await register(harper, "no-token");
+    expect(res.status).toBe(401);
+    expect(JSON.parse(res.text).error).toBe("invalid_token");
+    expect(await clientRowCount(harper)).toBe(before);
+  });
+
+  test("a wrong token → 401, and no row", async () => {
+    const before = await clientRowCount(harper);
+    const res = await register(harper, "wrong-token", { [HEADER]: randomBytes(24).toString("base64url") });
+    expect(res.status).toBe(401);
+    expect(await clientRowCount(harper)).toBe(before);
+  });
+
+  test("the token in an Authorization: Bearer header does not work", async () => {
+    // Harper's own auth layer claims that header before flair's code runs, which
+    // is why the token travels in a dedicated one. Pinned so nobody 'fixes' the
+    // gate to read Bearer and ships a path that can never be reached.
+    const res = await register(harper, "bearer-attempt", { authorization: `Bearer ${TOKEN}` });
+    expect(res.status).not.toBe(200);
+  });
+
+  test("discovery advertises the registration endpoint again", async () => {
+    const res = await fetch(`${harper.httpURL}/.well-known/oauth-authorization-server`);
+    const doc = await res.json() as any;
+    expect(doc.registration_endpoint).toBe(`${doc.issuer}/OAuthRegister`);
+  });
+});

--- a/test/integration/oauth-rate-limit-e2e.test.ts
+++ b/test/integration/oauth-rate-limit-e2e.test.ts
@@ -17,6 +17,11 @@ import { randomUUID } from "node:crypto";
 import { startHarper, stopHarper, HarperInstance } from "../helpers/harper-lifecycle";
 
 const ALLOWED_REDIRECT_URI = "https://claude.com/api/mcp/auth_callback";
+// Registration is gated (see resources/dcr-gate.ts); this instance opts in so
+// the registration path is reachable and its budget can actually be measured.
+// Generated, not a literal, so nothing token-shaped is committed to the repo.
+const DCR_TOKEN = randomUUID() + randomUUID();
+const DCR_HEADER = "x-flair-initial-access-token";
 
 // Small enough to exhaust in a handful of requests. The window is 60s, so once a
 // bucket is spent it STAYS spent for the rest of the file — the cases below are
@@ -53,13 +58,20 @@ const validCode = `code_${randomUUID()}`;
 describe("OAuth rate limiting (real Harper, real HTTP)", () => {
   beforeAll(async () => {
     // Set BEFORE the spawn — startHarper hands its own process.env to the child.
-    for (const k of ["FLAIR_OAUTH_RATE_LIMIT", "FLAIR_OAUTH_REGISTER_RATE_LIMIT", "FLAIR_RATE_LIMIT", "FLAIR_TRUSTED_PROXY"]) {
+    for (const k of ["FLAIR_OAUTH_RATE_LIMIT", "FLAIR_OAUTH_REGISTER_RATE_LIMIT", "FLAIR_RATE_LIMIT", "FLAIR_TRUSTED_PROXY", "FLAIR_OAUTH_DCR_TOKEN"]) {
       savedEnv[k] = process.env[k];
     }
     process.env.FLAIR_OAUTH_RATE_LIMIT = String(OAUTH_LIMIT);
     process.env.FLAIR_OAUTH_REGISTER_RATE_LIMIT = String(REGISTER_LIMIT);
     delete process.env.FLAIR_RATE_LIMIT;
     delete process.env.FLAIR_TRUSTED_PROXY;
+    // Registration is closed unless an operator opts in, so this instance opts
+    // in. Without it every registration below is refused 403 by the DCR gate,
+    // and a test asking "did registration survive the token bucket being spent"
+    // could no longer tell a SEPARATE BUCKET from a CLOSED ENDPOINT — both
+    // answer non-429. The budget has to be reachable for a claim about the
+    // budget to mean anything.
+    process.env.FLAIR_OAUTH_DCR_TOKEN = DCR_TOKEN;
 
     harper = await startHarper();
 
@@ -178,25 +190,38 @@ describe("OAuth rate limiting (real Harper, real HTTP)", () => {
   test("registration has its OWN budget — it still works while the token bucket is spent", async () => {
     const res = await fetch(`${harper.httpURL}/OAuthRegister`, {
       method: "POST",
-      headers: { "content-type": "application/json" },
+      headers: { "content-type": "application/json", [DCR_HEADER]: DCR_TOKEN },
       body: JSON.stringify({ client_name: "separate bucket", redirect_uris: [ALLOWED_REDIRECT_URI] }),
     });
     expect(res.status).not.toBe(429);
+    // A 200 with a real client_id, not merely "not 429": the point is that the
+    // registration budget was untouched by everything spent on /OAuthToken, and
+    // only a registration that actually SUCCEEDS demonstrates that.
+    expect(res.status).toBe(200);
     expect((await res.json() as any).client_id).toStartWith("flair_cl_");
   });
 
   test("registration is limited on its own, tighter budget", async () => {
-    let sawLimit = false;
+    // Credentialled, so this floods the path that really creates rows — the
+    // expensive thing the limiter exists to bound. Flooding with refused
+    // requests would show the limiter counting, but not that it protects the
+    // write.
+    const seen: number[] = [];
     for (let i = 0; i < REGISTER_LIMIT + 2; i++) {
       const res = await fetch(`${harper.httpURL}/OAuthRegister`, {
         method: "POST",
-        headers: { "content-type": "application/json" },
+        headers: { "content-type": "application/json", [DCR_HEADER]: DCR_TOKEN },
         body: JSON.stringify({ client_name: `flood ${i}`, redirect_uris: [ALLOWED_REDIRECT_URI] }),
       });
-      if (res.status === 429) sawLimit = true;
+      seen.push(res.status);
       await res.text();
     }
-    expect(sawLimit).toBe(true);
+    // The budget was already partly spent by the test above, so the exact index
+    // where it flips is not fixed — but the tail must be limited, and a run that
+    // never limits at all (or limits from the very first call) is a failure.
+    expect(seen).toContain(429);
+    expect(seen.at(-1)).toBe(429);
+    expect(seen[0]).not.toBe(429);
   });
 
   test("UNTHROTTLED PATHS ARE UNTOUCHED: /Health still answers with both OAuth buckets spent", async () => {

--- a/test/integration/oauth-wellknown-e2e.test.ts
+++ b/test/integration/oauth-wellknown-e2e.test.ts
@@ -97,8 +97,12 @@ describe("OAuth discovery at the well-known paths (real Harper)", () => {
       expect(doc.issuer).toBe(base);
       expect(doc.token_endpoint).toBe(`${base}/OAuthToken`);
       expect(doc.authorization_endpoint).toBe(`${base}/OAuthAuthorize`);
-      expect(doc.registration_endpoint).toBe(`${base}/OAuthRegister`);
       expect(doc.revocation_endpoint).toBe(`${base}/OAuthRevoke`);
+      // No `registration_endpoint`: dynamic client registration is off unless an
+      // operator sets FLAIR_OAUTH_DCR_TOKEN, and this instance has not. The
+      // enabled case is covered in test/integration/oauth-dcr-e2e.test.ts, which
+      // spawns an instance that has.
+      expect(doc.registration_endpoint).toBeUndefined();
       expect(doc.code_challenge_methods_supported).toEqual(["S256"]);
     }, 30_000);
 

--- a/test/unit/dcr-gate.test.ts
+++ b/test/unit/dcr-gate.test.ts
@@ -1,0 +1,141 @@
+// dcr-gate.test.ts — resources/dcr-gate.ts.
+//
+// The property that matters most here is not "a wrong token is refused" but
+// "there is no configuration in which registration is on AND open". Enabling
+// registration and supplying its credential are the same act, so the failure
+// mode this replaces — an endpoint anyone on the internet may write rows
+// through — cannot be reached by forgetting a setting. The cases below assert
+// that as a shape, by enumerating what each configuration does.
+import { describe, expect, test, beforeEach, afterEach } from "bun:test";
+import {
+  dcrEnabled,
+  decideRegistration,
+  initialAccessToken,
+  initialAccessTokenMatches,
+  presentedInitialAccessToken,
+  INITIAL_ACCESS_TOKEN_HEADER,
+  MIN_INITIAL_ACCESS_TOKEN_LEN,
+  __resetDcrWarningForTest,
+} from "../../resources/dcr-gate.ts";
+
+const GOOD = "a".repeat(MIN_INITIAL_ACCESS_TOKEN_LEN);
+const ALSO_GOOD = "b".repeat(MIN_INITIAL_ACCESS_TOKEN_LEN + 8);
+
+let saved: string | undefined;
+beforeEach(() => {
+  saved = process.env.FLAIR_OAUTH_DCR_TOKEN;
+  delete process.env.FLAIR_OAUTH_DCR_TOKEN;
+  __resetDcrWarningForTest();
+});
+afterEach(() => {
+  if (saved === undefined) delete process.env.FLAIR_OAUTH_DCR_TOKEN;
+  else process.env.FLAIR_OAUTH_DCR_TOKEN = saved;
+});
+
+function req(headers: Record<string, string> = {}): any {
+  return { headers: { get: (n: string) => headers[n.toLowerCase()] ?? null, asObject: headers } };
+}
+
+describe("registration is off unless an operator turns it on", () => {
+  test("DEFAULT: no variable set → disabled", () => {
+    expect(dcrEnabled()).toBe(false);
+    expect(decideRegistration(req())).toEqual({ allowed: false, reason: "disabled" });
+  });
+
+  test("an empty or whitespace value is still disabled", () => {
+    for (const v of ["", "   ", "\t"]) {
+      process.env.FLAIR_OAUTH_DCR_TOKEN = v;
+      expect(dcrEnabled()).toBe(false);
+    }
+  });
+
+  test("a token too short to be a credential DISABLES registration rather than enabling it weakly", () => {
+    // A short shared secret on an unauthenticated public endpoint is nearer to
+    // open than to closed. Degrading to almost-off would be worse than off,
+    // because only one of the two is visible to the operator.
+    process.env.FLAIR_OAUTH_DCR_TOKEN = "short";
+    expect(initialAccessToken()).toBeUndefined();
+    expect(dcrEnabled()).toBe(false);
+    expect(decideRegistration(req({ [INITIAL_ACCESS_TOKEN_HEADER]: "short" })))
+      .toEqual({ allowed: false, reason: "disabled" });
+  });
+
+  test("exactly the minimum length is accepted; one character less is not", () => {
+    process.env.FLAIR_OAUTH_DCR_TOKEN = "x".repeat(MIN_INITIAL_ACCESS_TOKEN_LEN);
+    expect(dcrEnabled()).toBe(true);
+    process.env.FLAIR_OAUTH_DCR_TOKEN = "x".repeat(MIN_INITIAL_ACCESS_TOKEN_LEN - 1);
+    expect(dcrEnabled()).toBe(false);
+  });
+
+  test("THE SHAPE: there is no value of the variable that enables registration WITHOUT a credential", () => {
+    // Anything that switches registration on is, by construction, also the token
+    // a caller has to present. Enumerating the interesting spellings that might
+    // be mistaken for "on, no credential" on some other design.
+    for (const v of ["1", "true", "on", "yes", "open", "enabled"]) {
+      process.env.FLAIR_OAUTH_DCR_TOKEN = v;
+      __resetDcrWarningForTest();
+      const enabled = dcrEnabled();
+      if (enabled) {
+        // If such a value ever DID enable it, an empty presentation must still fail.
+        expect(decideRegistration(req())).not.toEqual({ allowed: true });
+      } else {
+        expect(decideRegistration(req())).toEqual({ allowed: false, reason: "disabled" });
+      }
+    }
+  });
+});
+
+describe("when registration is enabled", () => {
+  beforeEach(() => { process.env.FLAIR_OAUTH_DCR_TOKEN = GOOD; });
+
+  test("POSITIVE CONTROL: the right token is allowed", () => {
+    expect(decideRegistration(req({ [INITIAL_ACCESS_TOKEN_HEADER]: GOOD }))).toEqual({ allowed: true });
+  });
+
+  test("no token at all is refused as invalid_token, not as disabled", () => {
+    // The distinction matters to the operator reading the response: 'disabled'
+    // means change the server, 'invalid_token' means change the client.
+    expect(decideRegistration(req())).toEqual({ allowed: false, reason: "invalid_token" });
+  });
+
+  test("a wrong token is refused", () => {
+    expect(decideRegistration(req({ [INITIAL_ACCESS_TOKEN_HEADER]: ALSO_GOOD })))
+      .toEqual({ allowed: false, reason: "invalid_token" });
+  });
+
+  test("a correct PREFIX of the token is refused", () => {
+    expect(initialAccessTokenMatches(GOOD.slice(0, GOOD.length - 1))).toBe(false);
+  });
+
+  test("the token with anything appended is refused", () => {
+    expect(initialAccessTokenMatches(GOOD + "x")).toBe(false);
+  });
+
+  test("non-string presentations are refused rather than coerced", () => {
+    for (const v of [undefined, null, 0, 1, true, {}, [], [GOOD]]) {
+      expect(initialAccessTokenMatches(v)).toBe(false);
+    }
+  });
+
+  test("an Authorization: Bearer header does NOT satisfy the gate", () => {
+    // Not a preference — measured. Harper's own auth layer claims every
+    // `Authorization: Bearer ...` and answers 401 before flair's code runs, so
+    // that channel cannot carry this token; honouring it here would be dead
+    // code that reads as a working path.
+    expect(decideRegistration(req({ authorization: `Bearer ${GOOD}` })))
+      .toEqual({ allowed: false, reason: "invalid_token" });
+  });
+});
+
+describe("presentedInitialAccessToken", () => {
+  test("reads the header, trims it, and treats blank as absent", () => {
+    expect(presentedInitialAccessToken(req({ [INITIAL_ACCESS_TOKEN_HEADER]: `  ${GOOD}  ` }))).toBe(GOOD);
+    expect(presentedInitialAccessToken(req({ [INITIAL_ACCESS_TOKEN_HEADER]: "   " }))).toBeUndefined();
+    expect(presentedInitialAccessToken(req())).toBeUndefined();
+  });
+
+  test("survives a request with no headers object at all", () => {
+    expect(presentedInitialAccessToken(undefined)).toBeUndefined();
+    expect(presentedInitialAccessToken({})).toBeUndefined();
+  });
+});

--- a/test/unit/dcr-gate.test.ts
+++ b/test/unit/dcr-gate.test.ts
@@ -15,6 +15,7 @@ import {
   presentedInitialAccessToken,
   INITIAL_ACCESS_TOKEN_HEADER,
   MIN_INITIAL_ACCESS_TOKEN_LEN,
+  MAX_INITIAL_ACCESS_TOKEN_LEN,
   __resetDcrWarningForTest,
 } from "../../resources/dcr-gate.ts";
 
@@ -67,6 +68,24 @@ describe("registration is off unless an operator turns it on", () => {
     expect(dcrEnabled()).toBe(false);
   });
 
+  test("exactly the maximum length is accepted; one byte more is not", () => {
+    // The upper bound exists because the comparison is over fixed-width
+    // buffers. Out of range must DISABLE registration with a message, never
+    // silently fail every comparison for a reason no operator could deduce.
+    process.env.FLAIR_OAUTH_DCR_TOKEN = "x".repeat(MAX_INITIAL_ACCESS_TOKEN_LEN);
+    expect(dcrEnabled()).toBe(true);
+    __resetDcrWarningForTest();
+    process.env.FLAIR_OAUTH_DCR_TOKEN = "x".repeat(MAX_INITIAL_ACCESS_TOKEN_LEN + 1);
+    expect(dcrEnabled()).toBe(false);
+  });
+
+  test("the bound is on BYTES, not characters — a multi-byte token cannot slip past it", () => {
+    // "é" is two UTF-8 bytes, so this is under the limit by character count and
+    // over it by byte count. The buffer the comparison uses is sized in bytes.
+    process.env.FLAIR_OAUTH_DCR_TOKEN = "é".repeat(MAX_INITIAL_ACCESS_TOKEN_LEN - 10);
+    expect(dcrEnabled()).toBe(false);
+  });
+
   test("THE SHAPE: there is no value of the variable that enables registration WITHOUT a credential", () => {
     // Anything that switches registration on is, by construction, also the token
     // a caller has to present. Enumerating the interesting spellings that might
@@ -109,6 +128,18 @@ describe("when registration is enabled", () => {
 
   test("the token with anything appended is refused", () => {
     expect(initialAccessTokenMatches(GOOD + "x")).toBe(false);
+  });
+
+  test("PADDING COLLISION: the token with trailing NULs appended is refused", () => {
+    // The comparison widens both sides into a zero-padded fixed-size buffer. A
+    // length prefix is what stops "tok" and "tok\0" from producing identical
+    // buffers; without it this case would be accepted.
+    expect(initialAccessTokenMatches(GOOD + "\0")).toBe(false);
+    expect(initialAccessTokenMatches(GOOD + "\0\0\0")).toBe(false);
+  });
+
+  test("an over-long presentation is refused rather than throwing", () => {
+    expect(initialAccessTokenMatches("y".repeat(MAX_INITIAL_ACCESS_TOKEN_LEN + 100))).toBe(false);
   });
 
   test("non-string presentations are refused rather than coerced", () => {

--- a/test/unit/oauth-discovery.test.ts
+++ b/test/unit/oauth-discovery.test.ts
@@ -13,7 +13,7 @@
  * clients or silently doesn't.
  */
 
-import { describe, test, expect, afterEach } from "bun:test";
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
 import {
   AS_METADATA_PATH,
   PRM_PATH,
@@ -69,8 +69,31 @@ describe("buildAuthorizationServerMetadata (RFC 8414)", () => {
     expect(doc.issuer).toBe(BASE);
     expect(doc.authorization_endpoint).toBe(`${BASE}/OAuthAuthorize`);
     expect(doc.token_endpoint).toBe(`${BASE}/OAuthToken`);
-    expect(doc.registration_endpoint).toBe(`${BASE}/OAuthRegister`);
     expect(doc.revocation_endpoint).toBe(`${BASE}/OAuthRevoke`);
+  });
+
+  // `registration_endpoint` is now conditional on dynamic client registration
+  // actually being enabled (resources/dcr-gate.ts). RFC 8414 §2 makes the field
+  // optional; advertising an endpoint that refuses every request would send a
+  // client down a path with no recovery. These two cases are the pair — the
+  // absent case alone would pass against a build that never emits the field.
+  describe("registration_endpoint tracks whether registration is enabled", () => {
+    let saved: string | undefined;
+    beforeEach(() => { saved = process.env.FLAIR_OAUTH_DCR_TOKEN; });
+    afterEach(() => {
+      if (saved === undefined) delete process.env.FLAIR_OAUTH_DCR_TOKEN;
+      else process.env.FLAIR_OAUTH_DCR_TOKEN = saved;
+    });
+
+    test("omitted when registration is off (the default)", () => {
+      delete process.env.FLAIR_OAUTH_DCR_TOKEN;
+      expect(buildAuthorizationServerMetadata(BASE).registration_endpoint).toBeUndefined();
+    });
+
+    test("POSITIVE CONTROL: present when an operator has opted in", () => {
+      process.env.FLAIR_OAUTH_DCR_TOKEN = "z".repeat(48);
+      expect(buildAuthorizationServerMetadata(BASE).registration_endpoint).toBe(`${BASE}/OAuthRegister`);
+    });
   });
 
   test("no endpoint can point somewhere other than the issuer origin", () => {

--- a/test/unit/resource-allow-decision.test.ts
+++ b/test/unit/resource-allow-decision.test.ts
@@ -222,7 +222,7 @@ const EARLY_RETURN_ENDPOINTS: Array<{ path: string; file: string; className: str
   { path: "/AgentCard*", file: "AgentCard.ts", className: "AgentCard", note: "public discovery metadata, per A2A spec" },
   { path: "/FederationSync", file: "Federation.ts", className: "FederationSync", note: "self-verifies via verifyBodySignatureFresh (Ed25519 body signature + anti-replay)" },
   { path: "/FederationPair", file: "Federation.ts", className: "FederationPair", note: "self-verifies via verifyBodySignatureFresh + one-time PairingToken" },
-  { path: "/OAuthRegister", file: "OAuth.ts", className: "OAuthRegister", note: "OAuth 2.1 dynamic client registration — spec requires no pre-auth" },
+  { path: "/OAuthRegister", file: "OAuth.ts", className: "OAuthRegister", note: "OAuth 2.1 dynamic client registration — self-gates in post() via resources/dcr-gate.ts: OFF unless FLAIR_OAUTH_DCR_TOKEN is set, and then the initial access token is required" },
   { path: "/OAuthAuthorize", file: "OAuth.ts", className: "OAuthAuthorize", note: "#609 fix: post() requires a real Authorization header present before trusting resolveAgentAuth" },
   { path: "/OAuthToken", file: "OAuth.ts", className: "OAuthToken", note: "authenticates via PKCE verifier / client_secret in the body, not agent identity" },
   { path: "/OAuthRevoke", file: "OAuth.ts", className: "OAuthRevoke", note: "OAuth 2.1 revocation — token itself is the credential" },


### PR DESCRIPTION
Refs #1017 — item 3 of the tracked set. Item 2 (rate limiting) landed as #1028; item 4 remains open, so this deliberately does not close the issue. The two are independent, touch disjoint source files, and this branch is mergeable against a main that already contains #1028.

## What was open

`OAuthRegister.allowCreate()` returned `true` unconditionally and the only gate in `post()` was a redirect-URI host match. On a publicly-reachable instance that means anyone can create rows in `OAuthClient` — a durable, replicated table — as fast as they can send requests, and every one of those rows is a `client_id` that `/OAuthAuthorize` will subsequently honour.

Measured against a live spawn before the change: an anonymous `POST /OAuthRegister` with no credential of any kind returned `200` and a fresh `client_id`.

## What it does now

**Registration is off by default.** `POST /OAuthRegister` answers `403 access_denied`, and the RFC 8414 / `/OAuthMetadata` documents stop advertising a `registration_endpoint` — RFC 8414 §2 makes the field optional, and advertising an endpoint that refuses every request is a discovery document that misdirects rather than one that refuses.

To turn it on, an operator sets `FLAIR_OAUTH_DCR_TOKEN` to an initial access token (RFC 7591 §3.1). Clients present it in `X-Flair-Initial-Access-Token`.

### One variable, no mode enum — that is the design, not a shortcut

There is deliberately no `FLAIR_OAUTH_DCR=open` and no way to enable registration without also supplying the credential that guards it. **Enabling and credentialling are the same act**, so "on, and open to the internet" is not a state reachable by forgetting a setting — it does not exist in the configuration space at all. A mode enum with an optional token would put that state one typo away, and the difference between the two designs is only visible on the day someone makes the typo. Removing the parameter beats validating it.

Same reasoning for the length bounds: a token outside them leaves registration **off** rather than enabling it weakly, and says so by variable name. A short shared secret on an unauthenticated public endpoint is nearer to open than to closed, and a control that silently degrades to almost-off is worse than one that is off, because only one of the two is visible.

### Ordering and comparison

The gate runs **before** the redirect-URI policy and before anything is read off the body, so a closed endpoint does not double as a probe for what this server would accept — pinned by a test that sends a disallowed redirect URI to a closed instance and asserts `403`, not `400 invalid_redirect_uri`.

The comparison is constant-time and **does not hash**. Both values are widened into a fixed-size buffer as `<uint32 byte length><bytes><zero padding>` and compared with `timingSafeEqual`. Equal width is the whole point: `timingSafeEqual` throws on a length mismatch, which would turn the configured token's length into an oracle, and `===` on strings leaks a prefix match through timing. The length prefix is load-bearing — padding alone would make `tok` and `tok\0` compare equal — and there is a test that fails without it.

Two earlier revisions digested both sides instead (SHA-256, then a keyed HMAC). Both work, and CodeQL flagged both as a high-severity insufficient-effort password hash. The scanner is wrong about the intent and right that the code *reads* that way — a hash of a credential in an equality check looks like password-at-rest storage. The remedy it implies, a KDF, would be a genuine defect here: deliberate per-request computational cost on an unauthenticated endpoint is an amplification lever on the exact path #1028's limiter exists to protect. Padding gets the same constant-time property with no hash to explain and no cost to exploit.

`allowCreate()` stays `true` — it is Harper's role gate, and returning `false` there would answer with Harper's own body instead of an RFC 7591-shaped error. Who may register is decided in one place, in `post()`, via `resources/dcr-gate.ts`.

### Why a header rather than `Authorization: Bearer`

RFC 7591 §3.1 presents the initial access token as a Bearer token. That channel does not work here, and this is **measured, not assumed**: Harper's own auth layer claims every `Authorization: Bearer …` header and validates it as a Harper operation token, so a Bearer-carrying request to `/OAuthRegister` is answered `401 {"error":"invalid token"}` before any code under `resources/` runs. Probed against a live instance: no header → 200, `Bearer <anything>` → 401, custom header → 200. Honouring Bearer in the gate would be dead code that reads like a working path, so it is not there — and a test pins that, so nobody "fixes" it back.

### Secret handling

`FLAIR_OAUTH_DCR_TOKEN` is added to the deploy generator's never-generate list. A deploy payload is ingested into an `hdb_deployment` row and replicated to every node, so no credential belongs in one. The existing name-based notice already flags it if an operator's own `.env` assigns it. The token is never logged — the length warning names the variable and the bounds, nothing else.

## Consistency with the direction already set

flair#756 disabled DCR on the `@harperfast/oauth` plugin's authorization server in favour of CIMD and deleted the gate-token machinery there — "DCR is UNSUPPORTED on this surface, not legacy". This is flair's *own* OAuth 2.1 AS, a separate endpoint that was left open. The posture is the same one #756 settled on — registration closed unless an operator deliberately opens it — reached through the mechanism this endpoint can actually support. `docs/auth.md` says outright that pre-registering clients and leaving this off is the better shape where it is workable.

## Breaking change

Anyone relying on anonymous registration is affected. The changelog says so and names the remedy. Note that flair's own AS mints opaque `flair_at_…` tokens that nothing under `resources/` validates, and `FLAIR_MCP_OAUTH` is default-off, so on a default install the practical blast radius is the registration endpoint itself.

Three existing tests asserted the old contract and were updated rather than deleted: the well-known integration test now asserts the field is **absent** on a default instance (the present case is covered in the new DCR integration file), the Playwright endpoint spec asserts the refusal — with an admin credential attached, which is the "surely this still works" control, since the gate is the token and not agent identity — and the allow-decision registry note now records where the gate lives.

## Testing

Branch is rebased onto the `main` that now contains #1028, so these numbers are for the two changes **together**.

| Lane | This branch |
|---|---|
| `bun test test/unit/ test/*.test.ts` | **4006 pass, 0 fail** (212 files) |
| `bun test test/integration/` | **443 pass, 0 fail** (55 files) |

Built with `npm run build && npm run build:cli` before both, so the integration lane and `docs-freshness-check` (7/7, no `DID NOT RUN`) actually ran. The one pre-existing `tsc --noEmit` error in `resources/auth-middleware.ts` is present and unchanged on `origin/main`.

Both states are driven against a **real Harper spawn**, not just a unit test of the gate: one instance with no token configured, one with. The closed instance is asserted to create **no `OAuthClient` row** — the point of the endpoint being closed is the durable replicated row it no longer creates, and a 403 that still wrote would be no fix at all. The opted-in instance has a positive control that the right token really does register a client.

### The two PRs broke each other, and that was worth finding

Rate limiting and this gate were written on separate branches and were green separately. Combined, two integration tests failed. Both failures were real information; neither was a defect in either implementation.

**`refusal happens BEFORE the redirect-URI policy` got 429 where it expected 403.** The registration limiter runs *in front of* this gate, and its default budget is 5 per 300s. The preceding tests in that block issue exactly 5 registration requests, so the one under test was the 6th and never reached the gate. Run alone against a fresh instance it passes — the ordering property was intact; the suite was measuring an exhausted bucket.

**`registration has its OWN budget` got `client_id: undefined`.** Its first assertion — `not 429`, with the token bucket fully spent — *passed*, which is the actual evidence that bucket separation holds. The next line failed because this PR closes registration by default. The precondition was invalidated, not the subject.

Both are fixed by restoring each test's precondition, not by relaxing what it asserts. That distinction is load-bearing on the second one: simply expecting 403 would have made it pass **whether or not the buckets were separate**, since a separate bucket and a closed endpoint both answer non-429. It now opts into DCR, presents the token, and asserts **200 plus a real `client_id`**. The flood test is credentialled for the same reason — it floods the path that actually creates rows, the expensive thing the limiter exists to bound. The DCR suites raise the registration limit to take an unrelated control out of the path, with every assertion still demanding an exact status and body; the opted-in block got the same treatment because it makes 4 requests against a budget of 5 and passes today by one request.

A new test pins the ordering that caused all of it, since nothing asserted it: with a budget of 3, five attempts against a closed endpoint must return `403,403,403,429,429`. `docs/auth.md` and the changelog now state it too, so an operator seeing 429 on a closed endpoint can read it correctly.

### Mutation checks — each control broken, guarding test confirmed failing, restored, confirmed green

| Control | Mutation | Broken | Restored |
|---|---|---|---|
| Registration off unless a token is configured | remove the `dcrEnabled()` gate | FAIL | PASS |
| The presented token must match | remove the comparison | FAIL | PASS |
| A too-short token disables rather than weakly enables | drop the length floor | FAIL | PASS |
| Whole-value comparison, no prefix match | compare an 8-char prefix | FAIL | PASS |
| Length prefix defeats the padding collision | drop the length prefix | FAIL | PASS |
| The size bound is on bytes, not characters | bound `.length` instead | FAIL | PASS |
| Gate runs before the redirect-URI policy | move it below | FAIL | PASS |
| Discovery omits the endpoint when off | advertise unconditionally | FAIL | PASS |
| Registration has a bucket separate from `/OAuthToken` | point `/OAuthRegister` at the `oauth` bucket | FAIL | PASS |
| The limiter is in the registration path at all | remove the `PATH_POLICY` entry | FAIL | PASS |
| The registration limit actually binds | raise it to 1000000 | FAIL | PASS |

The last three had to be re-run against the **full file** rather than a `-t` filter. `-t` runs only the named test, so the earlier tests that spend a bucket never execute — which made one mutation look survivable when the precondition simply never existed. Worth knowing for anyone extending these suites.
