### PR TITLE
fix(upgrade): report when a launchd fallback leaves the instance unmanaged (#1022)

### DIFF
--- a/.changelog/unreleased/fixed-upgrade-reports-launchd-detachment.md
+++ b/.changelog/unreleased/fixed-upgrade-reports-launchd-detachment.md
@@ -1,0 +1,20 @@
+- **An upgrade that drops the instance out of launchd now says so, instead of reporting success.**
+  On macOS, `flair upgrade` and `flair restart` fall back to a plain detached start when a launchd
+  operation fails. The fallback is right — a running instance beats a down one — but it leaves the
+  process outside the manager that owns it, so it will not come back after a reboot, and the run
+  still finished with `✅ verified: healthy, authenticated, running <version>`. Every one of those
+  facts was true; none of them was the one that mattered (#1022). After a restart, both commands now
+  ask launchd what it is actually running and compare it against the process serving the instance.
+  A run that ends detached reports the verified facts **without** a success marker, names the job,
+  says the instance will not survive a reboot, and gives the commands that restore it. A clean run
+  prints exactly the line it always did.
+
+  The launchd start also no longer waits out its full startup budget to discover a plist it could
+  never have run. `launchctl load` and `launchctl start` both exit 0 for a job whose program does not
+  exist, so the only symptom was a 60-second timeout naming a port — twice, once for the stop and
+  once for the start. A plist records absolute paths, and switching Node runtimes moves all of them,
+  so those paths are now checked before launchd is asked to do anything: a stale one fails
+  immediately, naming the path that moved and the `flair init && flair restart` that re-points it.
+  Likewise, the stop leg asks whether launchd is running this instance before waiting a minute for a
+  process it does not control to exit. The fallbacks are unchanged; only the waiting and the
+  reporting are.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -22,7 +22,7 @@ import {
 } from "node:fs";
 import { homedir, hostname, tmpdir } from "node:os";
 import { join, resolve, sep, dirname } from "node:path";
-import { spawn, execFileSync } from "node:child_process";
+import { spawn, execFileSync, spawnSync, execSync } from "node:child_process";
 import { createRequire } from "node:module";
 import { createHash, randomUUID, randomBytes } from "node:crypto";
 import { create as tarCreate, extract as tarExtract, list as tarList } from "tar";
@@ -114,6 +114,17 @@ import {
 } from "./lib/auth-resolve.js";
 import { validateSnapshotArchive, extractSnapshotSafely } from "./lib/safe-snapshot-extract.js";
 import { escapeXml, unescapeXml } from "./lib/xml-escape.js";
+import {
+  assessLaunchdManagement,
+  diagnoseLaunchdPlistPaths,
+  isDetached,
+  pickInstancePid,
+  renderDetachedWarning,
+  renderVerifiedSummary,
+  LAUNCHCTL_QUERY_TIMEOUT_MS,
+  type LaunchctlLister,
+  type LaunchdManagement,
+} from "./lib/launchd-management.js";
 // Value-only static import so `--interval`'s advertised default cannot drift
 // from the one the scheduler actually validates against. The module itself is
 // still loaded lazily at call time (the `await import()`s below) for the
@@ -1871,6 +1882,16 @@ export async function checkAgentRegistered(
 // Used during restart to confirm the old Harper process actually exited before
 // we start polling /Health — otherwise the still-shutting-down old process can
 // answer and we'd declare restart success while a gap is still ahead.
+/**
+ * Is `pid` a process that exists right now? Signal 0 performs the permission
+ * and existence checks without delivering anything (flair#1022) — a `hdb.pid`
+ * left behind by a process that is gone is not evidence about a running
+ * instance, and treating it as such produces confident wrong answers.
+ */
+function isProcessAlive(pid: number): boolean {
+  try { process.kill(pid, 0); return true; } catch { return false; }
+}
+
 async function waitForProcessExit(pid: number, timeoutMs: number): Promise<void> {
   const deadline = Date.now() + timeoutMs;
   while (Date.now() < deadline) {
@@ -10595,8 +10616,29 @@ program
     // The delegated `flair restart` printed its own success line; don't say it twice.
     if (!restartWasDelegated) console.log("✅ Flair restarted");
 
+    // flair#1022 — the headline defect. The restart above is allowed to fall
+    // back off launchd to a plain detached spawn, and SHOULD be: a running
+    // instance beats a down one. What was missing is that the fallback changes
+    // whether anything brings this instance back after a reboot, and the
+    // verification below made no claim about it. `healthy, authenticated,
+    // running <new version>` was every word true of an instance that had just
+    // been orphaned.
+    //
+    // Observed here rather than reported by the restart, because
+    // `restartAfterUpgrade` may have delegated to the newly installed CLI in a
+    // CHILD PROCESS (flair#905) — no in-process flag crosses that boundary.
+    // Asking launchd is the one form of this check that is correct on both
+    // paths.
+    const management = observeLaunchdManagement(upgradeDataDir, port);
+    const detached = isDetached(management);
+
     if (!shouldVerify) {
       console.log("  (--no-verify: skipping post-restart verification)");
+      if (detached) {
+        for (const line of renderDetachedWarning(management, "Flair is running, but NOT under launchd.")) {
+          console.error(line);
+        }
+      }
       return;
     }
 
@@ -10615,7 +10657,17 @@ program
 
     const verdict = decideAfterVerify(verify, previousFlairVersion);
     if (verdict.kind === "ok") {
-      console.log(`✅ verified: healthy, authenticated${verify.version ? `, running ${verify.version}` : ""}`);
+      // flair#1022: the verified facts are unchanged and still stated — the
+      // upgrade did land. What changes is the MARKER and the claim around it.
+      // A run that ended up outside its process manager has not fully
+      // succeeded, so it does not get a ✅, and the line names the property
+      // that is wrong rather than only the ones that are right. The choice
+      // lives in renderVerifiedSummary so it is testable without performing an
+      // upgrade — no CI lane runs this darwin path.
+      const summary = renderVerifiedSummary(verify.version, management);
+      for (const line of summary.lines) {
+        if (summary.degraded) console.error(line); else console.log(line);
+      }
       return;
     }
 
@@ -10628,10 +10680,21 @@ program
     // "print an honest note but roll back anyway" branch that used to sit below
     // is gone — that credentials case can no longer reach the rollback path.)
     if (verdict.kind === "healthy-unverified") {
-      console.log(`✅ upgrade complete: the instance is up and healthy${expectedFlairVersion ? ` on @tpsdev-ai/flair@${expectedFlairVersion}` : ""}.`);
+      // flair#1022: same rule as the "ok" branch above — the ✅ is withheld
+      // when the run left the instance outside launchd, and the reason is
+      // named. This branch already qualifies the version claim; the process
+      // manager is a second, independent qualification.
+      console.log(detached
+        ? `⚠️  upgrade complete: the instance is up and healthy${expectedFlairVersion ? ` on @tpsdev-ai/flair@${expectedFlairVersion}` : ""}, but NOT under launchd.`
+        : `✅ upgrade complete: the instance is up and healthy${expectedFlairVersion ? ` on @tpsdev-ai/flair@${expectedFlairVersion}` : ""}.`);
       console.log(`   The version could not be verified — the checker couldn't authenticate to /HealthDetail (${verdict.reason}).`);
       console.log("   The server is confirmed running (public /Health passed); this is a verification gap, not an upgrade failure — nothing was rolled back.");
       console.log("   To enable full post-upgrade verification: set FLAIR_ADMIN_PASS, or run `flair init` to provision ~/.flair/admin-pass or an agent key.");
+      if (detached) {
+        for (const line of renderDetachedWarning(management, "The instance is NOT running under launchd.")) {
+          console.error(line);
+        }
+      }
       return;
     }
 
@@ -10749,6 +10812,13 @@ program
       const { plistPath } = resolveLaunchdLabel(dataDir);
       if (existsSync(plistPath)) {
         try {
+          // flair#1022, same pre-flight as startFlairProcess: launchctl exits 0
+          // for a job it cannot exec, so a stale plist is only ever observable
+          // as a startup timeout unless the paths are checked first.
+          const stalePlist = diagnoseLaunchdPlistPaths(plistPath);
+          if (stalePlist) {
+            throw new Error(`${stalePlist.message} Fix it with: ${stalePlist.remedy.join(" && ")}`);
+          }
           const { execSync } = await import("node:child_process");
           const { label, migrated } = ensureLaunchdServiceLoaded(dataDir, (cmd) => execSync(cmd, { stdio: "pipe" }));
           if (migrated) console.log(`Migrated launchd service off the legacy label (${LEGACY_LAUNCHD_LABEL}) → ${label} ✓`);
@@ -10914,6 +10984,74 @@ function assertPortInstanceOwnedBy(port: number, dataDir: string, listeningPids:
   );
 }
 
+// ─── "is it still under launchd?" (flair#1022) ─────────────────────────────
+//
+// The pure logic lives in src/lib/launchd-management.ts; these two adapters
+// are the only places that talk to real launchd or the real filesystem, so a
+// test can exercise every branch above without either.
+
+/** `launchctl list <label>`, capped so an unreachable launchd cannot hang the CLI. */
+const realLaunchctlLister: LaunchctlLister = (label) => {
+  const res = spawnSync("launchctl", ["list", label], {
+    encoding: "utf-8",
+    timeout: LAUNCHCTL_QUERY_TIMEOUT_MS,
+  });
+  return { code: res.status, stdout: res.stdout ?? "" };
+};
+
+/**
+ * Which process is actually serving `dataDir` — Harper's own `hdb.pid` first,
+ * then the listener on `port`.
+ *
+ * `hdb.pid` is written by the Harper process itself on every boot regardless
+ * of who spawned it, which is exactly the property this needs: it is the same
+ * number on the launchd path and on the direct-spawn fallback, so comparing it
+ * against launchd's reported PID is a real comparison rather than a proxy.
+ * The port listener is the backstop for an install whose PID file is missing;
+ * `null` (neither available) is handled by the caller as "no evidence", never
+ * as "detached".
+ */
+function resolveInstanceServingPid(dataDir: string, port: number): number | null {
+  let listeningPids: number[] = [];
+  try {
+    listeningPids = listeningPidsOnPort(port, (cmd) => execSync(cmd, { encoding: "utf-8" }));
+  } catch { /* lsof unavailable — the PID file may still answer */ }
+  return pickInstancePid({
+    pidFilePid: readHarperPid(dataDir),
+    isAlive: isProcessAlive,
+    listeningPids,
+  });
+}
+
+/**
+ * Observe whether `dataDir`'s instance is running under launchd right now.
+ *
+ * Called AFTER a restart completes, by both `flair restart` and `flair
+ * upgrade` — see the module header for why this is an observation rather than
+ * a flag carried out of `startFlairProcess` (the upgrade's restart may happen
+ * in a child process, so no in-process flag survives).
+ */
+function observeLaunchdManagement(dataDir: string, port: number): LaunchdManagement {
+  // Answered without touching the filesystem or lsof off darwin — this runs on
+  // the success path of every restart and upgrade, including Linux's, where
+  // there is no launchd to have fallen back from.
+  if (process.platform !== "darwin") {
+    return { state: "not-applicable", detail: `${process.platform} does not use launchd` };
+  }
+  const { label, plistPath } = resolveLaunchdLabel(dataDir);
+  if (!existsSync(plistPath)) {
+    return { state: "no-service", detail: `no launchd service is registered for this instance (${plistPath})` };
+  }
+  return assessLaunchdManagement({
+    platform: process.platform,
+    label,
+    plistPath,
+    instancePid: resolveInstanceServingPid(dataDir, port),
+    plistExists: existsSync,
+    list: realLaunchctlLister,
+  });
+}
+
 /**
  * Stop the local Flair (Harper) process — launchd `stop` on darwin when a
  * plist is present (falling back on failure), otherwise a manual SIGTERM by
@@ -10957,9 +11095,47 @@ async function stopFlairProcess(port: number, dataDir: string): Promise<void> {
         // can race against the still-shutting-down old process and return
         // success before the new one comes up.
         const oldPid = readHarperPid(dataDir);
+        // flair#1022: ask launchd whether the process we are about to wait on
+        // is even its job's, BEFORE unloading. When the instance is already
+        // running outside launchd — the state a previous fallback leaves
+        // behind, and the state a stale plist guarantees — the unload has
+        // nothing to signal, so waiting on `oldPid` burns the FULL startup
+        // budget and then reports the meaningless
+        // "Process <pid> did not exit within 60000ms". That was the first of
+        // the reported incident's two 60-second hangs. The unload still runs
+        // (a loaded-but-broken job must not be left able to respawn); only the
+        // wait is skipped, and the fallback is entered immediately with a
+        // reason that names the real condition.
+        //
+        // Gated on a LIVE recorded PID, and that gate is load-bearing: with no
+        // running process there is nothing to wait for and nothing to
+        // reattribute, and `stopFlairProcess` is documented as a harmless
+        // no-op when the instance is already stopped. Without the gate, an
+        // already-stopped instance takes the port fallback, which refuses when
+        // it cannot attribute a listener (flair#915) — turning an idempotent
+        // stop into a failed restart. Caught by the flair#902/#914 suites.
+        //
+        // Asked BEFORE the unload, because after it launchd no longer knows
+        // the label at all and every answer would be "detached".
+        const managed = oldPid !== null && isProcessAlive(oldPid)
+          ? assessLaunchdManagement({
+            platform: process.platform,
+            label,
+            plistPath,
+            instancePid: oldPid,
+            plistExists: existsSync,
+            list: realLaunchctlLister,
+          })
+          : null;
         // unload stops the job AND prevents KeepAlive from respawning it.
         // launchctl stop alone is insufficient for a KeepAlive job (flair#874).
         try { execSync(`launchctl unload "${plistPath}"`, { stdio: "pipe" }); } catch {}
+        if (managed && isDetached(managed)) {
+          throw new Error(
+            `launchd is not running this instance — ${managed.detail}`
+            + `${managed.remedy?.length ? ` Fix it with: ${managed.remedy.join(" && ")}` : ""}`,
+          );
+        }
         if (oldPid) await waitForProcessExit(oldPid, STARTUP_TIMEOUT_MS);
         return;
       } catch (err: any) {
@@ -11019,6 +11195,21 @@ async function startFlairProcess(port: number, dataDir: string): Promise<void> {
       // success.
       assertLaunchdServiceOwnedBy(dataDir, label, plistPath, "start");
       try {
+        // flair#1022: launchd will not tell us it cannot exec the job.
+        // `launchctl load` and `launchctl start` BOTH exit 0 for a plist whose
+        // ProgramArguments[0] does not exist (measured, see the module header),
+        // so the only way this loop learns anything is by waiting the full
+        // startup budget for a port that will never open — the reported
+        // incident's second 60-second hang, ending in "did not respond within
+        // 60000ms (120 attempts)", an error about a port that says nothing
+        // about the cause. The paths in the plist are absolute and checkable
+        // with an existsSync, so check them first and turn a two-minute silence
+        // into an immediate, named diagnosis. Still falls back — a running
+        // instance beats a down one — just without the wait or the mystery.
+        const stalePlist = diagnoseLaunchdPlistPaths(plistPath);
+        if (stalePlist) {
+          throw new Error(`${stalePlist.message} Fix it with: ${stalePlist.remedy.join(" && ")}`);
+        }
         const { execSync } = await import("node:child_process");
         ensureLaunchdServiceLoaded(dataDir, (cmd) => execSync(cmd, { stdio: "pipe" }));
         await waitForHealth(port, DEFAULT_ADMIN_USER, process.env.HDB_ADMIN_PASSWORD ?? "", STARTUP_TIMEOUT_MS);
@@ -11246,6 +11437,18 @@ program
     // and saying so here is what keeps that true when someone adds one.
     try {
       await restartFlair(port, defaultDataDir());
+      // flair#1022: a restart that fell back off launchd left the instance
+      // running but unmanaged, and "✅ Flair restarted" was true of both
+      // outcomes. Ask launchd what it is actually running now — an
+      // observation, not a flag out of the restart, so it is right even when
+      // the detachment predates this command.
+      const managed = observeLaunchdManagement(defaultDataDir(), port);
+      if (isDetached(managed)) {
+        for (const line of renderDetachedWarning(managed, "Flair restarted, but it is NOT running under launchd.")) {
+          console.error(line);
+        }
+        return;
+      }
       console.log("✅ Flair restarted");
     } catch (err: any) {
       console.error(`❌ Flair failed to restart: ${err?.message ?? err}`);
@@ -16888,4 +17091,8 @@ export {
   resolveLaunchdLabel,
   migrateLegacyLaunchdLabel,
   ensureLaunchdServiceLoaded,
+
+  // launchd management observation (flair#1022)
+  observeLaunchdManagement,
+  resolveInstanceServingPid,
 };

--- a/src/lib/launchd-management.ts
+++ b/src/lib/launchd-management.ts
@@ -1,0 +1,453 @@
+/**
+ * launchd-management.ts — "is this instance actually under launchd?", and
+ * "why did launchd refuse to run it?" (flair#1022).
+ *
+ * `flair upgrade` on macOS restarts through launchd and falls back to a plain
+ * detached spawn when a launchd operation fails. The fallback is the right
+ * behaviour — a running instance beats a down one — but it changes a load
+ * bearing property of the install that nothing was measuring: the process is no
+ * longer owned by a service manager, so it does not come back after a reboot.
+ * The reported incident ended in `verified: healthy, authenticated, running
+ * <new version>`, every word of which was true, while the instance had just
+ * been orphaned. **Healthy and managed are different claims** and only the
+ * first was being made.
+ *
+ * Two things live here, and the split matters:
+ *
+ *   1. `assessLaunchdManagement()` — an OBSERVATION taken after the fact.
+ *      Deliberately not a flag threaded down from whichever function did the
+ *      falling back: `flair upgrade` hands its restart to the NEWLY INSTALLED
+ *      CLI in a child process (flair#905), so no in-process bookkeeping
+ *      survives the boundary. Asking launchd directly, at verification time,
+ *      is the only form of this check that works on both the delegated and
+ *      the in-process path — and it also catches a detachment this run did
+ *      not cause.
+ *
+ *   2. `diagnoseLaunchdPlistPaths()` — a PRE-FLIGHT taken before the fact, and
+ *      the reason the incident took two minutes to produce no information.
+ *      **`launchctl load` and `launchctl start` both exit 0 for a job whose
+ *      program does not exist.** Measured on macOS 15, not assumed: loading a
+ *      plist whose ProgramArguments[0] points at a deleted path succeeds,
+ *      `start` succeeds, and the only evidence of the failure is a nonzero
+ *      `LastExitStatus` and a missing `PID` in `launchctl list <label>` after
+ *      the fact. So the CLI's launchd path cannot learn anything from
+ *      launchctl's exit codes; it waits the full startup budget for a port
+ *      that was never going to open, and then falls back.
+ *
+ *      A plist records absolute paths — the node binary (`process.execPath` at
+ *      `flair init` time), Harper's entrypoint under that same install's
+ *      `node_modules`, and the package working directory. Switch Node runtimes
+ *      with a version manager and every one of them can move. That is knowable
+ *      from a `readFileSync` and an `existsSync`, in microseconds, and it names
+ *      both the stale path and the fix.
+ *
+ * Never logs plist CONTENTS. The plist embeds HDB_ADMIN_PASSWORD; only
+ * extracted program/working-directory paths ever reach a message, and the
+ * extractor below reads exactly those keys rather than returning the document.
+ */
+import { existsSync, readFileSync } from "node:fs";
+import { unescapeXml } from "./xml-escape.js";
+
+/**
+ * Ceiling on the `launchctl list` spawn. A status query answers instantly when
+ * launchd is reachable; this only exists so an unreachable service manager
+ * cannot turn a post-upgrade summary line into a hang. Same reasoning as
+ * scheduler-platform's STATUS_CHECK_TIMEOUT_MS.
+ */
+export const LAUNCHCTL_QUERY_TIMEOUT_MS = 5_000;
+
+// ─── plist path pre-flight ────────────────────────────────────────────────
+
+/** The absolute paths a plist tells launchd to exec, and where from. */
+export interface PlistProgramRefs {
+  /** ProgramArguments, in order. Empty when the key is absent or malformed. */
+  programArguments: string[];
+  /** WorkingDirectory, or null when the key is absent. */
+  workingDirectory: string | null;
+}
+
+/**
+ * Extract ONLY the exec-related paths from a plist: ProgramArguments and
+ * WorkingDirectory.
+ *
+ * Regex rather than a plist parser for the same reason `readPlistRootPath`
+ * uses one — this reads documents `buildLaunchdPlist` wrote, the shape is
+ * fixed, and a parser would pull the whole `EnvironmentVariables` dict
+ * (including the admin password) into memory to answer a question about two
+ * keys. Values are XML-escaped on the way in, so they are unescaped on the way
+ * out; a path containing `&` is stored as `&amp;` and returned as `&`.
+ *
+ * Returns null when the file cannot be read at all. A readable plist with
+ * neither key returns an empty/null refs object, which callers treat as "no
+ * evidence" rather than "broken" — a hand-written plist that uses `Program`
+ * instead of `ProgramArguments` is not ours to judge.
+ */
+export function readPlistProgramRefs(
+  plistPath: string,
+  read: (p: string) => string = (p) => readFileSync(p, "utf-8"),
+): PlistProgramRefs | null {
+  let raw: string;
+  try {
+    raw = read(plistPath);
+  } catch {
+    return null;
+  }
+  const programArguments: string[] = [];
+  const argsBlock = raw.match(/<key>ProgramArguments<\/key>\s*<array>([\s\S]*?)<\/array>/);
+  if (argsBlock) {
+    for (const m of argsBlock[1].matchAll(/<string>([^<]*)<\/string>/g)) {
+      programArguments.push(unescapeXml(m[1]));
+    }
+  }
+  const wd = raw.match(/<key>WorkingDirectory<\/key>\s*<string>([^<]*)<\/string>/);
+  return { programArguments, workingDirectory: wd ? unescapeXml(wd[1]) : null };
+}
+
+/**
+ * A path a plist names that is no longer on disk.
+ *
+ * Modelled as `StalePlistPath | null` rather than a `{ ok: true } | { ok:
+ * false }` union on purpose: `tsconfig.cli.json` compiles src/cli.ts with
+ * `strict: false`, and without `strictNullChecks` TypeScript does not narrow a
+ * discriminated union keyed on a BOOLEAN literal — every `d.message` at a call
+ * site becomes an error. A nullable object narrows under both configurations,
+ * so the same helper is usable from cli.ts and from a strict-mode test.
+ */
+export interface StalePlistPath {
+  /** Which plist key names the path that has gone missing. */
+  kind: "ProgramArguments" | "WorkingDirectory";
+  /** The path in the plist that no longer exists on disk. */
+  stalePath: string;
+  /** One line naming the stale path — safe to print, contains no plist content beyond this path. */
+  message: string;
+  /**
+   * Commands that re-register the service against the current runtime.
+   *
+   * BARE commands, with no trailing `# explanation`: these are rendered joined
+   * by ` && ` so an operator can paste the whole line, and a `#` anywhere in
+   * that line comments out everything after it. Explanation belongs in
+   * `message`, which is prose nobody will paste into a shell.
+   */
+  remedy: string[];
+}
+
+/**
+ * Does this plist still point at things that exist?
+ *
+ * Only ABSOLUTE paths are checked. `ProgramArguments` for a Flair service is
+ * `[<node>, <harper entrypoint>, "run", "."]` — the trailing literals are
+ * arguments, not paths, and an install whose plist was hand-edited to use a
+ * relative program is resolved by launchd against WorkingDirectory in a way
+ * this check has no business second-guessing. A missing absolute path, by
+ * contrast, is not ambiguous: launchd cannot exec it, and will not say so.
+ *
+ * The remedy is `flair init` because init unconditionally rewrites the plist
+ * from `process.execPath` and the currently-resolved Harper entrypoint — it is
+ * what re-points a service at the Node the operator is actually using now —
+ * followed by a restart to bring the job up under the rewritten plist.
+ */
+export function diagnoseLaunchdPlistPaths(
+  plistPath: string,
+  deps: { read?: (p: string) => string; exists?: (p: string) => boolean } = {},
+): StalePlistPath | null {
+  const exists = deps.exists ?? existsSync;
+  const refs = readPlistProgramRefs(plistPath, deps.read);
+  if (!refs) return null;
+
+  const remedy = ["flair init", "flair restart"];
+  const rewriteNote =
+    "`flair init` rewrites the plist against the Node runtime in use now, and `flair restart` " +
+    "brings the job back up under it.";
+
+  for (const arg of refs.programArguments) {
+    if (!arg.startsWith("/")) continue;
+    if (exists(arg)) continue;
+    return {
+      kind: "ProgramArguments",
+      stalePath: arg,
+      message:
+        `the launchd plist at ${plistPath} runs ${arg}, which no longer exists. ` +
+        `launchd cannot exec a missing program and reports no error for it — ` +
+        `load and start both succeed and the service never comes up. ` +
+        `A plist commonly goes stale like this after switching Node runtimes, ` +
+        `which moves both the node binary and the globally installed package tree. ` +
+        rewriteNote,
+      remedy,
+    };
+  }
+
+  const wd = refs.workingDirectory;
+  if (wd && wd.startsWith("/") && !exists(wd)) {
+    return {
+      kind: "WorkingDirectory",
+      stalePath: wd,
+      message:
+        `the launchd plist at ${plistPath} sets WorkingDirectory to ${wd}, which no longer exists. ` +
+        `launchd refuses to spawn a job whose working directory is missing, and reports no error for it — ` +
+        `load and start both succeed and the service never comes up. ` +
+        rewriteNote,
+      remedy,
+    };
+  }
+
+  return null;
+}
+
+// ─── launchctl job state ──────────────────────────────────────────────────
+
+export interface LaunchctlJobState {
+  /** launchd knows this label. False when `launchctl list <label>` could not find it. */
+  registered: boolean;
+  /** The job's running process, or null when launchd reports no PID (job not running). */
+  pid: number | null;
+  /** The job's last exit status, or null when launchd reported none. */
+  lastExitStatus: number | null;
+}
+
+/**
+ * Parse `launchctl list <label>` output.
+ *
+ * The output is a plist-ish dict of `"Key" = value;` lines. The two that
+ * matter: `"PID"` is present ONLY while the job is running, and
+ * `"LastExitStatus"` records how the last run ended. A job whose program is
+ * missing has no PID and a nonzero LastExitStatus — that combination is the
+ * signature of the failure this module exists to name.
+ */
+export function parseLaunchctlList(output: string): { pid: number | null; lastExitStatus: number | null } {
+  const pidMatch = output.match(/"PID"\s*=\s*(\d+)\s*;/);
+  const exitMatch = output.match(/"LastExitStatus"\s*=\s*(-?\d+)\s*;/);
+  return {
+    pid: pidMatch ? Number(pidMatch[1]) : null,
+    lastExitStatus: exitMatch ? Number(exitMatch[1]) : null,
+  };
+}
+
+/** Runs `launchctl list <label>`; injected so tests never touch real launchd. */
+export type LaunchctlLister = (label: string) => { code: number | null; stdout: string };
+
+export function readLaunchctlJobState(label: string, list: LaunchctlLister): LaunchctlJobState {
+  let res: { code: number | null; stdout: string };
+  try {
+    res = list(label);
+  } catch {
+    return { registered: false, pid: null, lastExitStatus: null };
+  }
+  if (res.code !== 0) return { registered: false, pid: null, lastExitStatus: null };
+  const { pid, lastExitStatus } = parseLaunchctlList(res.stdout);
+  return { registered: true, pid, lastExitStatus };
+}
+
+/**
+ * Which PID to treat as "the process serving this instance".
+ *
+ * Harper's own `hdb.pid` is preferred — it is written by the serving process on
+ * every boot regardless of who spawned it, so it is the same number on the
+ * launchd path and on the direct-spawn fallback, which is what makes comparing
+ * it against launchd's reported PID a real comparison.
+ *
+ * The liveness check is the part that is easy to leave out and expensive to
+ * omit. A `hdb.pid` left behind by a process that is gone names a PID that
+ * matches nothing, and a mismatch is what this module reports as DETACHED — so
+ * a stale file would produce a loud, wrong warning on a perfectly healthy
+ * launchd install. A check that cries wolf on healthy installs is worse than no
+ * check at all, because it is the reason the real warning gets skipped. A dead
+ * PID is no evidence, so it is discarded and the port listener answers instead.
+ */
+export function pickInstancePid(input: {
+  pidFilePid: number | null;
+  isAlive: (pid: number) => boolean;
+  listeningPids: number[];
+}): number | null {
+  const { pidFilePid, isAlive, listeningPids } = input;
+  if (pidFilePid !== null && isAlive(pidFilePid)) return pidFilePid;
+  return listeningPids.length > 0 ? listeningPids[0] : null;
+}
+
+// ─── the verdict ──────────────────────────────────────────────────────────
+
+export type LaunchdManagementState =
+  /** Not macOS — launchd is not the process manager here and nothing is claimed. */
+  | "not-applicable"
+  /** macOS, but no service is registered for this instance. Never was managed; not a degradation. */
+  | "no-service"
+  /** A service is registered AND launchd is running this instance's process. */
+  | "managed"
+  /** A service is registered and launchd is NOT running this instance's process. */
+  | "detached";
+
+export interface LaunchdManagement {
+  state: LaunchdManagementState;
+  /** The label examined, when there was one. */
+  label?: string;
+  /** One line of evidence for the verdict. Present for every state. */
+  detail: string;
+  /** Commands that restore management. Present iff state === "detached". */
+  remedy?: string[];
+}
+
+/** True when the instance is running outside the service manager that is registered to own it. */
+export function isDetached(m: LaunchdManagement): boolean {
+  return m.state === "detached";
+}
+
+export interface AssessLaunchdManagementInput {
+  /** process.platform. */
+  platform: string;
+  /** The instance's launchd label, from resolveLaunchdLabel(dataDir). */
+  label: string;
+  /** That label's plist path. */
+  plistPath: string;
+  /**
+   * The PID actually serving this instance — Harper's own `hdb.pid`, or the
+   * process listening on the instance's port. null when neither is readable.
+   */
+  instancePid: number | null;
+  plistExists: (p: string) => boolean;
+  list: LaunchctlLister;
+  /** Injected so the stale-path explanation can be attached to a detached verdict. */
+  diagnose?: (plistPath: string) => StalePlistPath | null;
+}
+
+/**
+ * Is this instance under launchd right now?
+ *
+ * The evidence, in the order it is weighed:
+ *
+ *   - Not darwin, or no plist for this data dir ⇒ nothing claims to manage it,
+ *     and there is no degradation to report. `no-service` is deliberately NOT
+ *     an alarm: an instance that was never registered has not lost anything,
+ *     and warning about it on every run is how a real warning gets ignored.
+ *   - `launchctl list <label>` cannot find the label, although the plist is on
+ *     disk ⇒ **detached**. The service exists but is not loaded.
+ *   - launchd reports no PID for the label ⇒ **detached**. The registered job
+ *     is not running, so whatever is serving the port is not launchd's.
+ *     `LastExitStatus` is carried into the detail because it is the difference
+ *     between "never started" and "started and died".
+ *   - launchd reports a PID that is not the instance's PID ⇒ **detached**, and
+ *     this is the exact shape the incident produced: launchd holds a job that
+ *     is failing, while a directly-spawned process answers on the port.
+ *   - launchd reports a PID and we cannot read the instance's own ⇒ **managed**.
+ *     A live job under this instance's label is positive evidence; refusing to
+ *     believe it because `hdb.pid` was unreadable would warn on healthy
+ *     installs, which is its own defect.
+ *
+ * A parent-process check is NOT used, and that is worth stating because it is
+ * the obvious first idea: the direct-start fallback spawns `detached: true` and
+ * `unref()`s, so once the CLI exits its child is reparented to PID 1 — exactly
+ * like a launchd-managed job. Both paths look identical from the parent PID,
+ * so the parent PID cannot distinguish them.
+ */
+export function assessLaunchdManagement(input: AssessLaunchdManagementInput): LaunchdManagement {
+  const { platform, label, plistPath, instancePid, plistExists, list } = input;
+  if (platform !== "darwin") {
+    return { state: "not-applicable", detail: `${platform} does not use launchd` };
+  }
+  if (!plistExists(plistPath)) {
+    return { state: "no-service", detail: `no launchd service is registered for this instance (${plistPath})` };
+  }
+
+  const job = readLaunchctlJobState(label, list);
+  const diagnose = input.diagnose ?? ((p: string) => diagnoseLaunchdPlistPaths(p));
+  const detachedRemedy = (): { remedy: string[]; because: string } => {
+    const stale = diagnose(plistPath);
+    if (!stale) {
+      return {
+        remedy: ["flair restart"],
+        because: "",
+      };
+    }
+    return { remedy: stale.remedy, because: ` Cause: ${stale.message}` };
+  };
+
+  if (!job.registered) {
+    const { remedy, because } = detachedRemedy();
+    return {
+      state: "detached",
+      label,
+      detail: `the launchd service ${label} is registered on disk but not loaded, so launchd is not managing this instance.${because}`,
+      remedy,
+    };
+  }
+
+  if (job.pid === null) {
+    const { remedy, because } = detachedRemedy();
+    const exit = job.lastExitStatus === null
+      ? ""
+      : ` launchd's last run of it exited ${job.lastExitStatus}.`;
+    return {
+      state: "detached",
+      label,
+      detail: `the launchd job ${label} is loaded but not running, so whatever is serving this instance was not started by launchd.${exit}${because}`,
+      remedy,
+    };
+  }
+
+  if (instancePid !== null && instancePid !== job.pid) {
+    const { remedy, because } = detachedRemedy();
+    return {
+      state: "detached",
+      label,
+      detail:
+        `this instance is served by process ${instancePid}, but launchd's job ${label} is process ${job.pid} — ` +
+        `the running instance is not the one launchd manages.${because}`,
+      remedy,
+    };
+  }
+
+  return { state: "managed", label, detail: `launchd job ${label} is running as process ${job.pid}` };
+}
+
+/**
+ * The lines to print for a degraded (detached) outcome.
+ *
+ * Kept here rather than at the two call sites so `flair restart` and `flair
+ * upgrade` cannot drift into saying different things about the same condition,
+ * and so the wording is assertable in a unit test without running either
+ * command. Deliberately says what is WRONG (not managed), what it COSTS (no
+ * restart after reboot), and what to DO — an operator who reads only the first
+ * line still knows they have to act.
+ */
+export function renderDetachedWarning(m: LaunchdManagement, headline: string): string[] {
+  const lines = [`⚠️  ${headline}`, `   ${m.detail}`];
+  lines.push("   This instance will NOT come back after a reboot until launchd manages it again.");
+  // One paste-able line, not one command per line: an operator copying a fix
+  // out of a warning copies a line, and a two-step fix pasted as one step is
+  // how half a remedy gets applied.
+  if (m.remedy?.length) lines.push(`   Fix: ${m.remedy.join(" && ")}`);
+  return lines;
+}
+
+/** What `flair upgrade` prints once its post-restart probe has PASSED. */
+export interface VerifiedSummary {
+  /** True when the run finished outside launchd — no unqualified success marker is emitted. */
+  degraded: boolean;
+  /** Exactly what to print. Written to stderr when degraded, stdout otherwise. */
+  lines: string[];
+}
+
+/**
+ * The final status line of a successful `flair upgrade`, given what the probe
+ * found AND what launchd is doing.
+ *
+ * This is the reported defect reduced to a function, on purpose. The bug was
+ * never in the probe — `healthy, authenticated, running <version>` was true —
+ * it was that those three facts were rendered as an unqualified ✅ while a
+ * fourth, unmeasured fact (the instance had been dropped out of its process
+ * manager) was the one that mattered. Deciding it here rather than inline in
+ * the command means the decision is testable without performing an upgrade,
+ * which on the darwin path nothing else can do: no CI lane runs it.
+ *
+ * The verified facts are still reported in the degraded case. The upgrade DID
+ * land, and hiding that would swap one misleading summary for another; what
+ * changes is the marker and the sentence around it.
+ */
+export function renderVerifiedSummary(version: string | null, m: LaunchdManagement): VerifiedSummary {
+  const facts = `healthy, authenticated${version ? `, running ${version}` : ""}`;
+  if (!isDetached(m)) {
+    return { degraded: false, lines: [`✅ verified: ${facts}`] };
+  }
+  return {
+    degraded: true,
+    lines: renderDetachedWarning(m, `upgrade landed (${facts}) but the instance is NOT running under launchd.`),
+  };
+}

--- a/test/unit/launchd-management-reporting.test.ts
+++ b/test/unit/launchd-management-reporting.test.ts
@@ -1,0 +1,853 @@
+// launchd-management-reporting.test.ts — flair#1022.
+//
+// The defect, from a real upgrade: `flair upgrade` hit two 60-second launchd
+// timeouts, fell back to a port-based stop and then a direct (non-launchd)
+// start, and finished with
+//
+//     ✅ verified: healthy, authenticated, running 0.33.0
+//
+// Every word of which was true. The instance was healthy, authenticated and on
+// the new version — and no longer under the process manager that is supposed to
+// own it, so it would not have come back after a reboot. **Healthy and managed
+// are different claims, and only the first was being made.**
+//
+// What these tests pin:
+//
+//   1. `assessLaunchdManagement` calls the degraded state degraded. Every
+//      branch, including the ones that must NOT warn — a check that fires on a
+//      healthy install is worse than no check, because it trains an operator to
+//      skip the line where the real warning will appear.
+//   2. `diagnoseLaunchdPlistPaths` names the stale path. `launchctl load` and
+//      `launchctl start` both exit 0 for a job whose program does not exist
+//      (measured on macOS 15 — that is precisely why the CLI could only learn
+//      about the failure by waiting out its startup budget), so the plist's own
+//      absolute paths are the only up-front evidence available.
+//   3. End to end, through the real CLI: a `flair restart` that ends detached
+//      does NOT print an unqualified success marker, and one that ends managed
+//      still does — plus both of the incident's 60-second waits, asserted as
+//      elapsed time rather than as a code path.
+//
+// SAFETY — this file manipulates launchd-shaped state on a host that may be
+// running a real Flair:
+//
+//   - HOME is a throwaway directory, via a genuinely spawned subprocess
+//     (Bun's os.homedir() ignores an in-process process.env.HOME mutation).
+//     Every plist, data dir and label therefore resolves inside the fixture.
+//   - `launchctl` is a shim on PATH that records its arguments and answers from
+//     files this test writes. **No launchctl command in this file reaches real
+//     launchd**, and none names a real ~/Library/LaunchAgents path.
+//   - The only process any test can signal is a health stub it spawned itself,
+//     and each test asserts whether that stub should still be serving — so a
+//     stray SIGTERM shows up as a failed assertion rather than as damage. One
+//     test DOES expect its stub to be stopped, because it asks the CLI to stop
+//     the instance the stub stands in for; it says so at the assertion.
+//   - No test lets the CLI reach a REAL direct-start fallback, because that
+//     fallback spawns a real Harper. Cases that must reach the start leg run
+//     the CLI out of a copied package tree containing no Harper, so the
+//     fallback exits on `resolveHarperBin` instead of launching a database
+//     (see probePackage). Every other case is arranged so the launchd path
+//     succeeds against the shim + stub, or the run aborts before the start leg.
+//
+// COVERAGE — the end-to-end half of this file is darwin-only, because the code
+// it exercises is gated on `process.platform === "darwin"` and CI runs Linux.
+// Nothing in CI will ever run it. The pure tests are deliberately
+// platform-independent so at least the decision logic is gated somewhere.
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync, existsSync, readFileSync, cpSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import {
+  assessLaunchdManagement,
+  diagnoseLaunchdPlistPaths,
+  isDetached,
+  parseLaunchctlList,
+  pickInstancePid,
+  readLaunchctlJobState,
+  readPlistProgramRefs,
+  renderDetachedWarning,
+  renderVerifiedSummary,
+  type LaunchctlLister,
+} from "../../src/lib/launchd-management.ts";
+import { launchdLabel, launchdPlistPath } from "../../src/cli";
+
+const isDarwin = process.platform === "darwin";
+const repoRoot = join(import.meta.dirname, "..", "..");
+const cliPath = join(repoRoot, "src", "cli.ts");
+
+/** `launchctl list <label>` output for a job launchd is currently running. */
+function listRunning(label: string, pid: number): string {
+  return `{\n\t"Label" = "${label}";\n\t"OnDemand" = false;\n\t"LastExitStatus" = 0;\n\t"PID" = ${pid};\n};\n`;
+}
+
+/**
+ * `launchctl list <label>` output for a job that is loaded but NOT running —
+ * no PID key at all, and a nonzero LastExitStatus. This is the real shape of a
+ * job whose program cannot be exec'd: 19968 is what launchd recorded in the
+ * measurement behind this fix.
+ */
+function listLoadedNotRunning(label: string, lastExitStatus = 19968): string {
+  return `{\n\t"Label" = "${label}";\n\t"OnDemand" = false;\n\t"LastExitStatus" = ${lastExitStatus};\n};\n`;
+}
+
+/** A lister that always answers with `stdout`, exit 0. */
+function listerFor(stdout: string): LaunchctlLister {
+  return () => ({ code: 0, stdout });
+}
+
+/** A lister that answers as launchctl does for an unregistered label. */
+const unregisteredLister: LaunchctlLister = (label) => ({
+  code: 113,
+  stdout: `Could not find service "${label}" in domain for port\n`,
+});
+
+function plistWith(opts: {
+  label: string;
+  rootPath: string;
+  programArguments?: string[];
+  workingDirectory?: string;
+}): string {
+  const args = (opts.programArguments ?? ["/usr/bin/true", "run", "."])
+    .map((a) => `    <string>${a}</string>`)
+    .join("\n");
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key><string>${opts.label}</string>
+  <key>ProgramArguments</key>
+  <array>
+${args}
+  </array>
+  <key>WorkingDirectory</key><string>${opts.workingDirectory ?? "/"}</string>
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>ROOTPATH</key><string>${opts.rootPath}</string>
+  </dict>
+</dict>
+</plist>`;
+}
+
+// ─── 1. the verdict: is this instance under launchd? ───────────────────────
+
+describe("flair#1022 — assessLaunchdManagement distinguishes healthy from managed", () => {
+  const base = {
+    label: "ai.tpsdev.flair.deadbeef",
+    plistPath: "/fixture/LaunchAgents/ai.tpsdev.flair.deadbeef.plist",
+    plistExists: () => true,
+    // Fixed answer so these tests never depend on the real filesystem: the
+    // plist paths are "fine", so a detached verdict carries the generic remedy.
+    diagnose: () => null,
+  };
+
+  test("a plist whose job launchd is running, as this instance's process, is managed", () => {
+    const m = assessLaunchdManagement({
+      ...base,
+      platform: "darwin",
+      instancePid: 4242,
+      list: listerFor(listRunning(base.label, 4242)),
+    });
+    expect(m.state).toBe("managed");
+    expect(isDetached(m)).toBe(false);
+  });
+
+  test("THE DEFECT: a loaded job with no running process is detached, not managed", () => {
+    const m = assessLaunchdManagement({
+      ...base,
+      platform: "darwin",
+      // A directly-spawned process is serving the instance — the fallback's
+      // outcome. launchd holds the job and is running nothing.
+      instancePid: 4242,
+      list: listerFor(listLoadedNotRunning(base.label)),
+    });
+    expect(m.state).toBe("detached");
+    expect(isDetached(m)).toBe(true);
+    // The operator has to be able to act on this: it says which job, that
+    // launchd is not running it, and how the last attempt ended.
+    expect(m.detail).toContain(base.label);
+    expect(m.detail).toContain("19968");
+    expect(m.remedy?.length ?? 0).toBeGreaterThan(0);
+  });
+
+  test("launchd running a DIFFERENT process than the one serving the instance is detached", () => {
+    const m = assessLaunchdManagement({
+      ...base,
+      platform: "darwin",
+      instancePid: 4242,
+      list: listerFor(listRunning(base.label, 9999)),
+    });
+    expect(m.state).toBe("detached");
+    expect(m.detail).toContain("4242");
+    expect(m.detail).toContain("9999");
+  });
+
+  test("a plist on disk whose label launchd does not know is detached", () => {
+    const m = assessLaunchdManagement({
+      ...base,
+      platform: "darwin",
+      instancePid: 4242,
+      list: unregisteredLister,
+    });
+    expect(m.state).toBe("detached");
+    expect(m.detail).toContain("not loaded");
+  });
+
+  // ─── the false-positive guards. An over-eager check is its own defect. ───
+
+  test("POSITIVE CONTROL: a running job with an unreadable instance PID is managed, not detached", () => {
+    // hdb.pid missing and lsof unavailable is a real condition on a working
+    // install. A live job under THIS instance's label is positive evidence;
+    // demanding a second, less reliable source before believing it would warn
+    // on healthy installs every time.
+    const m = assessLaunchdManagement({
+      ...base,
+      platform: "darwin",
+      instancePid: null,
+      list: listerFor(listRunning(base.label, 4242)),
+    });
+    expect(m.state).toBe("managed");
+  });
+
+  test("POSITIVE CONTROL: off darwin nothing is claimed, and launchctl is never consulted", () => {
+    let consulted = 0;
+    const m = assessLaunchdManagement({
+      ...base,
+      platform: "linux",
+      instancePid: 4242,
+      list: () => { consulted++; return { code: 0, stdout: "" }; },
+    });
+    expect(m.state).toBe("not-applicable");
+    expect(isDetached(m)).toBe(false);
+    expect(consulted).toBe(0);
+  });
+
+  test("POSITIVE CONTROL: an instance with no registered service is not a degradation", () => {
+    // Nothing ever claimed to manage it, so nothing was lost. Reporting this
+    // as detached would mean every non-launchd macOS install warns forever.
+    const m = assessLaunchdManagement({
+      ...base,
+      platform: "darwin",
+      instancePid: 4242,
+      plistExists: () => false,
+      list: listerFor(listRunning(base.label, 4242)),
+    });
+    expect(m.state).toBe("no-service");
+    expect(isDetached(m)).toBe(false);
+  });
+
+  test("a detached verdict carries the plist diagnosis as its cause when there is one", () => {
+    const m = assessLaunchdManagement({
+      ...base,
+      platform: "darwin",
+      instancePid: 4242,
+      list: listerFor(listLoadedNotRunning(base.label)),
+      diagnose: () => ({
+        kind: "ProgramArguments",
+        stalePath: "/old/runtime/bin/node",
+        message: "the launchd plist runs /old/runtime/bin/node, which no longer exists.",
+        remedy: ["flair init", "flair restart"],
+      }),
+    });
+    expect(m.state).toBe("detached");
+    expect(m.detail).toContain("/old/runtime/bin/node");
+    expect(m.remedy).toEqual(["flair init", "flair restart"]);
+  });
+});
+
+describe("flair#1022 — pickInstancePid keeps a stale PID file from faking a detachment", () => {
+  const alive = (pid: number) => pid === 4242;
+
+  test("prefers a live hdb.pid over the port listener", () => {
+    expect(pickInstancePid({ pidFilePid: 4242, isAlive: alive, listeningPids: [7777] })).toBe(4242);
+  });
+
+  test("POSITIVE CONTROL: a DEAD hdb.pid is discarded, not reported as the instance", () => {
+    // A leftover PID file names a number that matches nothing, and a mismatch
+    // is exactly what this module calls "detached" — so without this, a stale
+    // file produces a loud, wrong warning on a healthy launchd install.
+    expect(pickInstancePid({ pidFilePid: 9999, isAlive: alive, listeningPids: [7777] })).toBe(7777);
+  });
+
+  test("falls back to the listener when there is no PID file, and to null when there is nothing", () => {
+    expect(pickInstancePid({ pidFilePid: null, isAlive: alive, listeningPids: [7777] })).toBe(7777);
+    expect(pickInstancePid({ pidFilePid: null, isAlive: alive, listeningPids: [] })).toBeNull();
+    expect(pickInstancePid({ pidFilePid: 9999, isAlive: alive, listeningPids: [] })).toBeNull();
+  });
+});
+
+describe("flair#1022 — parseLaunchctlList / readLaunchctlJobState", () => {
+  test("reads PID and LastExitStatus out of launchctl's dict", () => {
+    expect(parseLaunchctlList(listRunning("x", 1234))).toEqual({ pid: 1234, lastExitStatus: 0 });
+  });
+
+  test("a job with no PID key reports pid null — that absence IS the signal", () => {
+    expect(parseLaunchctlList(listLoadedNotRunning("x", 19968))).toEqual({ pid: null, lastExitStatus: 19968 });
+  });
+
+  test("a nonzero exit from launchctl means the label is not registered", () => {
+    expect(readLaunchctlJobState("x", unregisteredLister)).toEqual({
+      registered: false, pid: null, lastExitStatus: null,
+    });
+  });
+
+  test("a lister that throws is not registered rather than an exception", () => {
+    expect(readLaunchctlJobState("x", () => { throw new Error("launchctl missing"); })).toEqual({
+      registered: false, pid: null, lastExitStatus: null,
+    });
+  });
+});
+
+// ─── 2. why launchd failed: the stale-path pre-flight ──────────────────────
+
+describe("flair#1022 — diagnoseLaunchdPlistPaths names the stale path up front", () => {
+  let dir: string;
+  let plistPath: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "flair1022-plist-"));
+    plistPath = join(dir, "svc.plist");
+  });
+  afterEach(() => rmSync(dir, { recursive: true, force: true }));
+
+  test("reads ProgramArguments and WorkingDirectory back out of a plist", () => {
+    writeFileSync(plistPath, plistWith({
+      label: "svc",
+      rootPath: "/data",
+      programArguments: ["/bin/node", "/pkg/harper.js", "run", "."],
+      workingDirectory: "/pkg",
+    }));
+    expect(readPlistProgramRefs(plistPath)).toEqual({
+      programArguments: ["/bin/node", "/pkg/harper.js", "run", "."],
+      workingDirectory: "/pkg",
+    });
+  });
+
+  test("decodes XML-escaped paths, so a path containing & is reported literally", () => {
+    writeFileSync(plistPath, plistWith({
+      label: "svc",
+      rootPath: "/data",
+      programArguments: ["/opt/a&amp;b/node", "run"],
+      workingDirectory: "/opt/a&amp;b",
+    }));
+    const refs = readPlistProgramRefs(plistPath)!;
+    expect(refs.programArguments[0]).toBe("/opt/a&b/node");
+    expect(refs.workingDirectory).toBe("/opt/a&b");
+  });
+
+  test("THE 60-SECOND WAIT: a missing program is detected without asking launchd anything", () => {
+    // This is the whole point. launchctl load and launchctl start BOTH exit 0
+    // here; the only other way to find out is to wait out the startup budget
+    // against a port that will never open.
+    const gone = join(dir, "runtimes", "v22", "bin", "node");
+    writeFileSync(plistPath, plistWith({
+      label: "svc",
+      rootPath: dir,
+      programArguments: [gone, join(dir, "harper.js"), "run", "."],
+      workingDirectory: dir,
+    }));
+    const stale = diagnoseLaunchdPlistPaths(plistPath);
+    expect(stale).not.toBeNull();
+    expect(stale!.kind).toBe("ProgramArguments");
+    expect(stale!.stalePath).toBe(gone);
+    expect(stale!.message).toContain(gone);
+    // Naming the path without naming the fix leaves the operator where they
+    // started, so the remedy is part of the contract.
+    expect(stale!.remedy.join(" ")).toContain("flair init");
+  });
+
+  test("a missing WorkingDirectory is caught too", () => {
+    const node = join(dir, "node");
+    writeFileSync(node, "#!/bin/sh\n", { mode: 0o755 });
+    const goneDir = join(dir, "gone-package-dir");
+    writeFileSync(plistPath, plistWith({
+      label: "svc",
+      rootPath: dir,
+      programArguments: [node, "run", "."],
+      workingDirectory: goneDir,
+    }));
+    const stale = diagnoseLaunchdPlistPaths(plistPath);
+    expect(stale).not.toBeNull();
+    expect(stale!.kind).toBe("WorkingDirectory");
+    expect(stale!.stalePath).toBe(goneDir);
+  });
+
+  test("POSITIVE CONTROL: a plist whose paths all exist is clean", () => {
+    const node = join(dir, "node");
+    const harper = join(dir, "harper.js");
+    writeFileSync(node, "#!/bin/sh\n", { mode: 0o755 });
+    writeFileSync(harper, "// harper\n");
+    writeFileSync(plistPath, plistWith({
+      label: "svc",
+      rootPath: dir,
+      programArguments: [node, harper, "run", "."],
+      workingDirectory: dir,
+    }));
+    expect(diagnoseLaunchdPlistPaths(plistPath)).toBeNull();
+  });
+
+  test("POSITIVE CONTROL: non-absolute ProgramArguments are arguments, not paths, and are never flagged", () => {
+    const node = join(dir, "node");
+    writeFileSync(node, "#!/bin/sh\n", { mode: 0o755 });
+    // "run" and "." are Harper's own arguments — flagging them as missing files
+    // would make every healthy install look broken.
+    writeFileSync(plistPath, plistWith({
+      label: "svc",
+      rootPath: dir,
+      programArguments: [node, "run", "."],
+      workingDirectory: dir,
+    }));
+    expect(diagnoseLaunchdPlistPaths(plistPath)).toBeNull();
+  });
+
+  test("POSITIVE CONTROL: an unreadable or foreign plist is no evidence, not a failure", () => {
+    expect(diagnoseLaunchdPlistPaths(join(dir, "does-not-exist.plist"))).toBeNull();
+    // A hand-written plist using <key>Program</key> rather than
+    // ProgramArguments is not ours to judge.
+    writeFileSync(plistPath, "<plist><dict><key>Program</key><string>/nope</string></dict></plist>");
+    expect(diagnoseLaunchdPlistPaths(plistPath)).toBeNull();
+  });
+
+  test("never returns plist CONTENT — only the extracted paths", () => {
+    // The plist embeds HDB_ADMIN_PASSWORD; a diagnosis that echoed the document
+    // would put it in an operator's terminal and in every captured log.
+    const gone = join(dir, "gone", "node");
+    writeFileSync(plistPath, plistWith({ label: "svc", rootPath: dir, programArguments: [gone] })
+      .replace("<key>ROOTPATH</key>", "<key>HDB_ADMIN_PASSWORD</key><string>hunter2-not-a-real-secret</string><key>ROOTPATH</key>"));
+    const stale = diagnoseLaunchdPlistPaths(plistPath)!;
+    expect(stale.message).not.toContain("hunter2-not-a-real-secret");
+    expect(JSON.stringify(readPlistProgramRefs(plistPath))).not.toContain("hunter2-not-a-real-secret");
+  });
+});
+
+describe("flair#1022 — renderVerifiedSummary is the reported defect, reduced to a function", () => {
+  const detached = {
+    state: "detached" as const,
+    label: "ai.tpsdev.flair.deadbeef",
+    detail: "the launchd job is loaded but not running.",
+    remedy: ["flair init", "flair restart"],
+  };
+
+  test("THE INCIDENT LINE: a detached run does not emit `✅ verified: ...`", () => {
+    const s = renderVerifiedSummary("0.33.0", detached);
+    expect(s.degraded).toBe(true);
+    const text = s.lines.join("\n");
+    // The literal string from the incident report must not be produced.
+    expect(text).not.toContain("✅ verified: healthy, authenticated, running 0.33.0");
+    expect(text).not.toContain("✅");
+    // The facts are still reported — the upgrade DID land, and saying it did
+    // not would swap one misleading summary for another.
+    expect(text).toContain("healthy, authenticated, running 0.33.0");
+    // ...alongside the thing that is actually wrong.
+    expect(text).toContain("NOT running under launchd");
+    expect(text).toContain("Fix: flair init && flair restart");
+  });
+
+  test("POSITIVE CONTROL: a managed run still reports exactly the success line it always did", () => {
+    const s = renderVerifiedSummary("0.33.0", {
+      state: "managed",
+      label: "ai.tpsdev.flair.deadbeef",
+      detail: "launchd job is running as process 4242",
+    });
+    expect(s.degraded).toBe(false);
+    expect(s.lines).toEqual(["✅ verified: healthy, authenticated, running 0.33.0"]);
+  });
+
+  test("POSITIVE CONTROL: Linux and unregistered-service runs are unchanged too", () => {
+    for (const m of [
+      { state: "not-applicable" as const, detail: "linux does not use launchd" },
+      { state: "no-service" as const, detail: "no launchd service is registered for this instance" },
+    ]) {
+      const s = renderVerifiedSummary("0.33.0", m);
+      expect(s.degraded).toBe(false);
+      expect(s.lines).toEqual(["✅ verified: healthy, authenticated, running 0.33.0"]);
+    }
+  });
+
+  test("an unknown version is omitted rather than printed as null, on both paths", () => {
+    expect(renderVerifiedSummary(null, { state: "managed", detail: "ok" }).lines)
+      .toEqual(["✅ verified: healthy, authenticated"]);
+    expect(renderVerifiedSummary(null, detached).lines.join("\n")).toContain("(healthy, authenticated)");
+  });
+
+  test("a degraded summary is never routed to stdout as a success", () => {
+    // `degraded` is what selects stderr at the call site, so the two must not
+    // disagree: a degraded:false result carrying a warning, or vice versa,
+    // would put the warning on the success channel.
+    const s = renderVerifiedSummary("0.33.0", detached);
+    expect(s.degraded).toBe(true);
+    expect(s.lines[0].startsWith("⚠️")).toBe(true);
+  });
+});
+
+describe("flair#1022 — renderDetachedWarning", () => {
+  test("leads with a non-success marker, names the cost, and ends with commands", () => {
+    const lines = renderDetachedWarning(
+      {
+        state: "detached",
+        label: "ai.tpsdev.flair.deadbeef",
+        detail: "the launchd job is loaded but not running.",
+        remedy: ["flair init", "flair restart"],
+      },
+      "upgrade landed but the instance is NOT running under launchd.",
+    );
+    const text = lines.join("\n");
+    expect(text).not.toContain("✅");
+    expect(lines[0]).toContain("⚠️");
+    expect(text).toContain("will NOT come back after a reboot");
+    expect(text).toContain("flair init");
+    expect(text).toContain("flair restart");
+  });
+});
+
+// ─── 3. end to end, through the real CLI ───────────────────────────────────
+
+describe("flair#1022 — `flair restart` reports the launchd outcome, not just liveness", () => {
+  let tmpHome: string;
+  let shimBin: string;
+  let dataDir: string;
+  let launchAgentsDir: string;
+  let launchctlLog: string;
+  let listDir: string;
+  let listCount: string;
+  let label: string;
+  let plistPath: string;
+  const spawned: Array<{ pid: number; kill: (s?: number) => void }> = [];
+  const probeDirs: string[] = [];
+
+  beforeEach(() => {
+    tmpHome = mkdtempSync(join(tmpdir(), "flair1022-home-"));
+    shimBin = mkdtempSync(join(tmpdir(), "flair1022-bin-"));
+    launchAgentsDir = join(tmpHome, "Library", "LaunchAgents");
+    mkdirSync(launchAgentsDir, { recursive: true });
+    dataDir = join(tmpHome, ".flair", "data");
+    mkdirSync(dataDir, { recursive: true });
+
+    launchctlLog = join(tmpHome, "launchctl-invocations.log");
+    listDir = join(tmpHome, "launchctl-list-responses");
+    mkdirSync(listDir, { recursive: true });
+    listCount = join(tmpHome, "launchctl-list-count");
+
+    label = launchdLabel(dataDir);
+    plistPath = launchdPlistPath(label, launchAgentsDir);
+
+    // The shim: records every invocation, answers `list` from numbered files
+    // (so one run can be told "running" and then "not running", which is
+    // exactly the sequence a restart that falls back produces), and exits 0
+    // for load/unload/start the way real launchctl does.
+    writeFileSync(
+      join(shimBin, "launchctl"),
+      [
+        "#!/bin/sh",
+        `printf '%s\\n' "$*" >> "$LAUNCHCTL_LOG"`,
+        `if [ "$1" = "list" ]; then`,
+        `  n=0`,
+        `  if [ -f "$LAUNCHCTL_LIST_COUNT" ]; then n=$(cat "$LAUNCHCTL_LIST_COUNT"); fi`,
+        `  n=$((n+1))`,
+        `  printf '%s' "$n" > "$LAUNCHCTL_LIST_COUNT"`,
+        `  f="$LAUNCHCTL_LIST_DIR/$n"`,
+        `  if [ ! -f "$f" ]; then f="$LAUNCHCTL_LIST_DIR/default"; fi`,
+        `  if [ -f "$f" ]; then cat "$f"; exit 0; fi`,
+        `  printf 'Could not find service "%s"\\n' "$2" >&2`,
+        `  exit 113`,
+        `fi`,
+        "exit 0",
+      ].join("\n"),
+      { mode: 0o755 },
+    );
+  });
+
+  afterEach(() => {
+    // Only ever the stubs this file started, by recorded PID.
+    for (const proc of spawned.splice(0)) {
+      try { proc.kill(); } catch { /* already gone */ }
+    }
+    for (const dir of [tmpHome, shimBin, ...probeDirs.splice(0)]) rmSync(dir, { recursive: true, force: true });
+  });
+
+  /**
+   * A copy of `src/` in a package directory that contains NO Harper, used to
+   * make the direct-start fallback exit safely instead of launching a real
+   * database.
+   *
+   * `harperSearchRoots()` is `[flairPackageDir(), process.cwd()]`, and
+   * `flairPackageDir()` is derived from the running file's own directory — so
+   * running the CLI from a copy re-points BOTH roots at a tree whose
+   * `node_modules/harper/dist/bin/harper.js` does not exist, and
+   * `resolveHarperBin` returns null. The copy lives INSIDE the repo so Bun
+   * still resolves the CLI's own bare imports (commander, tweetnacl, …) by
+   * walking up to the real node_modules; a copy under /tmp would not resolve
+   * them, and a symlinked node_modules would put Harper back.
+   *
+   * Removed in afterEach. The `.` prefix and the fixed name keep a crashed run
+   * from leaving something that looks like source.
+   */
+  function probePackage(): string {
+    const dir = mkdtempSync(join(repoRoot, ".flair1022-probe-"));
+    probeDirs.push(dir);
+    cpSync(join(repoRoot, "src"), join(dir, "src"), { recursive: true });
+    return dir;
+  }
+
+  async function runCli(args: string[], packageDir?: string) {
+    const entry = packageDir ? join(packageDir, "src", "cli.ts") : cliPath;
+    const proc = Bun.spawn(["bun", entry, ...args], {
+      cwd: packageDir ?? repoRoot,
+      env: {
+        ...(process.env as Record<string, string>),
+        HOME: tmpHome,
+        PATH: `${shimBin}:${process.env.PATH ?? ""}`,
+        LAUNCHCTL_LOG: launchctlLog,
+        LAUNCHCTL_LIST_DIR: listDir,
+        LAUNCHCTL_LIST_COUNT: listCount,
+      },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const stdout = await new Response(proc.stdout).text();
+    const stderr = await new Response(proc.stderr).text();
+    const exitCode = await proc.exited;
+    return { stdout, stderr, exitCode };
+  }
+
+  /** A stand-in for "an instance is listening here", in its own process. */
+  async function spawnHealthStub(): Promise<{ port: number; pid: number; alive: () => Promise<boolean> }> {
+    const portFile = join(tmpHome, "stub-port");
+    const script = join(tmpHome, "health-stub.mjs");
+    writeFileSync(
+      script,
+      [
+        `import { createServer } from "node:http";`,
+        `import { writeFileSync } from "node:fs";`,
+        `const srv = createServer((_req, res) => { res.writeHead(200, { "content-type": "application/json" }); res.end('{"status":"ok"}'); });`,
+        `srv.listen(0, "127.0.0.1", () => writeFileSync(process.argv[2], String(srv.address().port)));`,
+      ].join("\n"),
+    );
+    const proc = Bun.spawn(["bun", script, portFile], { stdout: "ignore", stderr: "ignore" });
+    spawned.push(proc as any);
+    for (let i = 0; i < 100 && !existsSync(portFile); i++) await new Promise((r) => setTimeout(r, 50));
+    if (!existsSync(portFile)) throw new Error("health stub did not report a port");
+    const port = Number(readFileSync(portFile, "utf-8").trim());
+    return {
+      port,
+      pid: proc.pid,
+      alive: async () => {
+        try {
+          return (await fetch(`http://127.0.0.1:${port}/Health`, { signal: AbortSignal.timeout(2000) })).ok;
+        } catch { return false; }
+      },
+    };
+  }
+
+  /** A plist for this fixture's instance whose paths all exist. */
+  function writeHealthyPlist(): void {
+    const node = join(tmpHome, "node");
+    const harper = join(tmpHome, "harper.js");
+    writeFileSync(node, "#!/bin/sh\n", { mode: 0o755 });
+    writeFileSync(harper, "// harper\n");
+    writeFileSync(plistPath, plistWith({
+      label,
+      rootPath: dataDir,
+      programArguments: [node, harper, "run", "."],
+      workingDirectory: tmpHome,
+    }));
+  }
+
+  test.if(isDarwin)(
+    "THE DEFECT: a restart that ends with the instance outside launchd does NOT report unqualified success",
+    async () => {
+      writeHealthyPlist();
+      const stub = await spawnHealthStub();
+
+      // The incident's sequence, one launchctl `list` call at a time:
+      //   #1 (the stop leg)  — launchd's job is running, so the stop takes the
+      //                        launchd path and the restart proceeds normally.
+      //   #2 (the post-restart observation) — launchd's job is NOT running.
+      //      Something else is answering on the port. That is precisely what a
+      //      fallback to a direct start leaves behind.
+      writeFileSync(join(listDir, "1"), listRunning(label, 4242));
+      writeFileSync(join(listDir, "default"), listLoadedNotRunning(label));
+
+      const { stdout, stderr, exitCode } = await runCli(["restart", "--port", String(stub.port)]);
+
+      // The restart itself worked — the instance is up. This is not a failure
+      // to restart, and must not be reported as one.
+      expect(exitCode).toBe(0);
+
+      // The headline assertion. On unmodified main this line IS printed, and
+      // it is the entire bug.
+      expect(stdout).not.toContain("✅ Flair restarted");
+
+      // And the operator is told what is wrong, what it costs, and what to do.
+      const warning = stderr;
+      expect(warning).toContain("NOT running under launchd");
+      expect(warning).toContain("will NOT come back after a reboot");
+      expect(warning).toContain(label);
+      expect(warning).toContain("flair restart");
+
+      // Nothing was signalled: the stub this test started is still serving.
+      expect(await stub.alive()).toBe(true);
+    },
+    30_000,
+  );
+
+  test.if(isDarwin)(
+    "POSITIVE CONTROL: a clean restart, still managed by launchd, still reports success",
+    async () => {
+      writeHealthyPlist();
+      const stub = await spawnHealthStub();
+
+      // launchd reports the job running as the very process that is serving
+      // the port — which is what "managed" means. The CLI resolves the serving
+      // PID from the port (no hdb.pid in this fixture), so this is a real
+      // comparison, not a rubber stamp.
+      writeFileSync(join(listDir, "default"), listRunning(label, stub.pid));
+
+      const { stdout, stderr, exitCode } = await runCli(["restart", "--port", String(stub.port)]);
+
+      expect(exitCode).toBe(0);
+      expect(stdout).toContain("✅ Flair restarted");
+      // An over-corrected fix that warns on every run is its own defect.
+      expect(stderr).not.toContain("NOT running under launchd");
+      expect(stderr).not.toContain("will NOT come back after a reboot");
+      expect(await stub.alive()).toBe(true);
+    },
+    30_000,
+  );
+
+  test.if(isDarwin)(
+    "THE FIRST 60-SECOND WAIT: the stop leg does not wait on a process launchd is not running",
+    async () => {
+      // The incident's first hang: "launchd stop failed, falling back to
+      // port-based stop: Process <pid> did not exit within 60000ms". The
+      // unload had nothing to signal, because the process serving the instance
+      // was not launchd's job — so the CLI waited a minute for an exit that was
+      // never going to be caused by anything it did, and then reported the
+      // wait, not the reason.
+      //
+      // Runs out of a Harper-free package tree so the eventual direct-start
+      // fallback exits on resolveHarperBin rather than launching a database.
+      const pkg = probePackage();
+      const gone = join(tmpHome, "runtimes", "v22", "bin", "node");
+      writeFileSync(plistPath, plistWith({
+        label,
+        rootPath: dataDir,
+        programArguments: [gone, join(tmpHome, "harper.js"), "run", "."],
+        workingDirectory: tmpHome,
+      }));
+      // A LIVE process is recorded as serving this instance...
+      const stub = await spawnHealthStub();
+      writeFileSync(join(dataDir, "hdb.pid"), String(stub.pid));
+      // ...and launchd is running nothing. That combination is the whole
+      // condition: the unload cannot stop what launchd does not own.
+      writeFileSync(join(listDir, "default"), listLoadedNotRunning(label));
+
+      const started = Date.now();
+      const { stderr, exitCode } = await runCli(["restart", "--port", String(stub.port)], pkg);
+      const elapsedMs = Date.now() - started;
+
+      // The stop fell back — as it should — but for a REASON, immediately.
+      expect(stderr).toContain("launchd stop failed, falling back to port-based stop");
+      expect(stderr).not.toContain("did not exit within");
+      expect(stderr).toContain("not running this instance");
+      // And the cause of the whole mess is named, with the fix.
+      expect(stderr).toContain(gone);
+      expect(stderr).toContain("Fix it with: flair init && flair restart");
+
+      // Both of the incident's 60-second waits are gone from this one run:
+      // the stop no longer waits on a foreign process, and the start no longer
+      // polls a port for a job that cannot be exec'd.
+      expect(elapsedMs).toBeLessThan(20_000);
+
+      // The fallback stop did its job — the listener was signalled. This is
+      // the ONE test here that expects the stub to be stopped, because the CLI
+      // was correctly asked to stop the instance the stub stands in for.
+      expect(await stub.alive()).toBe(false);
+
+      // The run ends in failure because the probe tree has no Harper to start,
+      // which is what keeps a real database from being launched here.
+      expect(exitCode).toBe(1);
+    },
+    60_000,
+  );
+
+  test.if(isDarwin)(
+    "THE 60-SECOND WAIT: a stale plist aborts the launchd start immediately, naming the path and the fix",
+    async () => {
+      // The start leg is the half that produced
+      // "Harper at port 19926 did not respond within 60000ms (120 attempts)" —
+      // 120 polls against a port launchd was never going to open, because
+      // launchctl load/start report success for a job they cannot exec.
+      //
+      // Reaching this leg means the CLI will fall back to a DIRECT start, and
+      // a direct start spawns a real Harper — unacceptable from a unit test.
+      // So the CLI is run out of a package tree with no Harper in it
+      // (`probePackage` below), which makes the fallback exit on
+      // resolveHarperBin instead of launching a database. The launchd path
+      // under test is completely unaffected by that; it is only what happens
+      // AFTER it gives up that changes.
+      const pkg = probePackage();
+      const gone = join(tmpHome, "runtimes", "v22", "bin", "node");
+      writeFileSync(plistPath, plistWith({
+        label,
+        rootPath: dataDir,
+        programArguments: [gone, join(tmpHome, "harper.js"), "run", "."],
+        workingDirectory: tmpHome,
+      }));
+      // launchd's job is running, so the STOP leg completes cleanly and the
+      // run reaches the start leg — which is the leg under test.
+      writeFileSync(join(listDir, "default"), listRunning(label, 4242));
+
+      const started = Date.now();
+      const { stderr, exitCode } = await runCli(["restart", "--port", "59997"], pkg);
+      const elapsedMs = Date.now() - started;
+
+      expect(exitCode).toBe(1);
+      // Named cause, named fix — the whole difference from a bare timeout.
+      expect(stderr).toContain("launchd start failed");
+      expect(stderr).toContain(gone);
+      expect(stderr).toContain("Fix it with: flair init && flair restart");
+
+      // The pre-flight ran BEFORE launchd was asked to do anything, so no load
+      // and no start was issued for a job that cannot run.
+      // Matched per line on the VERB, not as a substring: `unload <plist>`
+      // contains `load <plist>`, so a substring check here passes for the
+      // wrong reason and would keep passing if the pre-flight were removed.
+      const verbs = readFileSync(launchctlLog, "utf-8")
+        .split("\n").map((l) => l.trim()).filter(Boolean)
+        .map((l) => l.split(/\s+/)[0]);
+      expect(verbs).not.toContain("load");
+      expect(verbs).not.toContain("start");
+      // Positive control on that parse: the stop leg's unload DID happen, so
+      // an empty or mis-parsed log cannot make the two assertions above pass
+      // vacuously.
+      expect(verbs).toContain("unload");
+
+      // And the point of all of it: the operator is not left staring at a
+      // frozen terminal. STARTUP_TIMEOUT_MS is 60s and the old path burned all
+      // of it here; 20s is a generous ceiling that still fails loudly if the
+      // wait ever comes back.
+      expect(elapsedMs).toBeLessThan(20_000);
+    },
+    60_000,
+  );
+
+  test.if(isDarwin)(
+    "every launchctl invocation names this fixture's instance — never a real install",
+    async () => {
+      writeHealthyPlist();
+      const stub = await spawnHealthStub();
+      writeFileSync(join(listDir, "default"), listRunning(label, stub.pid));
+      await runCli(["restart", "--port", String(stub.port)]);
+
+      const lines = readFileSync(launchctlLog, "utf-8")
+        .split("\n").map((l) => l.trim()).filter(Boolean);
+      expect(lines.length).toBeGreaterThan(0);
+      // Same property test/unit/snapshot-datadir-instance-targeting.test.ts
+      // pins, re-asserted here because this file adds new launchctl traffic
+      // (`list`) to the same code paths.
+      expect(lines.filter((l) => !l.includes(label))).toEqual([]);
+      const plistArgs = lines.flatMap((l) => l.split(/\s+/).filter((a) => a.endsWith(".plist")));
+      expect(plistArgs.filter((a) => a !== plistPath)).toEqual([]);
+    },
+    30_000,
+  );
+});


### PR DESCRIPTION
## The defect

A real upgrade ended like this:

```
launchd stop failed, falling back to port-based stop: Process <pid> did not exit within 60000ms
launchd start failed, falling back to direct start: Harper at port <port> did not respond within 60000ms (120 attempts)

Verifying...
✅ verified: healthy, authenticated, running 0.33.0
```

Every word of that last line was true. The instance was healthy, authenticated, and on the new version — and it had just been dropped out of the process manager that owns it, so it would not have come back after a reboot. **Healthy and managed are different claims, and only the first was being made.**

The fallbacks are not the bug and are not removed here: a running instance beats a down one. The reporting is the bug.

## What changed

**1. Verification now covers service management.** After a restart, `flair upgrade` and `flair restart` ask launchd what it is actually running and compare it against the process serving the instance.

**2. A degraded run does not get a success marker.** The verified facts are still reported — the upgrade did land, and hiding that would swap one misleading summary for another — but the marker changes and the line names what is wrong:

```
⚠️  upgrade landed (healthy, authenticated, running 0.33.0) but the instance is NOT running under launchd.
   the launchd job <label> is loaded but not running, so whatever is serving this instance was not
   started by launchd. launchd's last run of it exited 19968. Cause: the launchd plist at <path>
   runs <path>, which no longer exists. ...
   This instance will NOT come back after a reboot until launchd manages it again.
   Fix: flair init && flair restart
```

Exit code stays 0 — the upgrade did succeed at upgrading, and failing the command would break `flair upgrade && ...` for a condition that is recoverable in two commands. Flagging that as a deliberate choice for review.

**3. The timeouts are diagnosed instead of only waited out.** Both 60-second waits are gone, and neither fallback is:

- **Measured, not assumed:** `launchctl load` and `launchctl start` both exit **0** for a job whose program does not exist. The only trace is a missing `PID` and a nonzero `LastExitStatus` in `launchctl list <label>` afterwards. So the start leg could never learn anything from launchctl's exit codes — it polled a port 120 times for a job that was never going to spawn. A plist records absolute paths (the node binary, Harper's entrypoint under that install's `node_modules`, the working directory), and switching Node runtimes moves all of them. Those paths are now checked before launchd is asked to do anything.
- The stop leg asks whether launchd is running this instance before waiting out the startup budget for a process it does not control. That was the first hang: the unload had nothing to signal because the running process was not launchd's job.

## How "is it under launchd?" is determined

`launchctl list <label>` reports a `PID` only while the job is running; that PID is compared against the instance's own — Harper's `hdb.pid`, falling back to the port listener. Verified against a live managed instance: `hdb.pid` and launchd's reported PID are the same number.

**A parent-process check was considered and rejected as unreliable.** The direct-start fallback spawns `detached: true` and `unref()`s, so once the CLI exits its child is reparented to PID 1 — identical to a launchd job. The parent PID cannot distinguish the two cases.

False positives were the main design risk, so the guards are explicit and tested: a live job under this instance's label with an unreadable instance PID is **managed** (positive evidence beats a missing file); an instance with no registered service is **not** a degradation; a **dead** `hdb.pid` is discarded rather than reported as a mismatch, because a stale PID file would otherwise fire this warning on a perfectly healthy install.

## Testing

This is the **darwin-only launchd branch that no CI lane executes** — CI runs Linux and these paths are gated on `process.platform === "darwin"`. The tests were written on the assumption that nothing else will ever catch a regression here.

- **Fail before, pass after.** Three end-to-end tests fail on unmodified main. Two of them fail by *taking 60 seconds* — 60,060 ms and 60,020 ms, the incident's two hangs reproduced and measured. Both waits are asserted as elapsed time, not as a code path.
- **Positive controls.** A clean managed restart still prints the success line; a managed upgrade still prints the exact success line it always did; Linux and no-service installs are unchanged and never consult launchctl.
- **Mutation check: 11 controls broken one at a time, all 11 caught**, restored green after each. Nine are caught by the new tests; the two covering the stop leg's liveness gate are caught by the pre-existing #902 / #915 suites — including one regression this branch introduced and those suites found (an over-eager short-circuit broke the documented "stopping an already-stopped instance is a no-op" behaviour). That is now gated on a live recorded PID.
- **Suite:** 3859 pass / 0 fail across 206 files, against a measured baseline of 3825 pass / 0 fail across 205 files on unmodified `origin/main` — exactly the 34 tests added, no other movement. `npm run build && npm run build:cli` first; docs-freshness 7/7 ran and passed (no DID NOT RUN). The one pre-existing `tsc` error in `resources/auth-middleware.ts` is present and unchanged on main.

Test safety, given these paths manipulate launchd on a host that may be running a real instance: every test operates inside its own throwaway `HOME`, `launchctl` is a recording shim on `PATH` that never reaches real launchd, and no test can signal a process it did not spawn. The cases that must reach the start leg run the CLI out of a copied package tree containing no Harper, so the direct-start fallback exits on binary resolution rather than launching a database.

## Not fixed here

- The CI coverage gap itself (no lane executes the darwin launchd branch) is tracked separately and deliberately untouched.
- If the plist paths all exist but launchd still fails to bring the job up, the start leg still waits its full budget before falling back. That residual case is genuinely undiagnosable up front from the plist alone.

Closes #1022

🤖 Generated with [Claude Code](https://claude.com/claude-code)
