### PR TITLE
fix(mcp): cap request body size at 256 KB and wire serverInfo.version

### DIFF
--- a/resources/mcp-handler.ts
+++ b/resources/mcp-handler.ts
@@ -28,11 +28,117 @@ import { databases } from "harper";
 import { randomBytes } from "node:crypto";
 import { TOOLS, listToolDefs, type ResolvedAgent } from "./mcp-tools.js";
 import { agentRecordIsAdmin } from "./agent-admin.js";
+import { resolveVersion } from "./version.js";
 
 // The MCP protocol revision we implement (initialize handshake).
 const PROTOCOL_VERSION = "2025-06-18";
 
+// ─── Body size cap ───────────────────────────────────────────────────────────
+//
+// flair#1033 — the /mcp handler reads the entire request body into memory with
+// no size limit. Harper's HTTP layer imposes no cap on this path (the handler
+// is registered via srv.http() which goes through Harper's own HTTP chain, not
+// Fastify's 1 GB bodyLimit or the contentTypes handler's configurable 10 MB
+// default). /mcp is the first surface reachable by an open population of OAuth
+// clients rather than by Ed25519 agents we provisioned, so the reachability
+// story is materially different from the identical pattern on any other route.
+//
+// 256 KB is ~100x headroom over any legitimate MCP JSON-RPC request (a
+// memory_store with a large content field is a few KB; even a batch of 100
+// would be well under this). It is small enough that an attacker cannot
+// meaningfully consume memory through this path.
+const MAX_MCP_BODY_SIZE = 256 * 1024; // 256 KB
+
 const JSON_HEADERS = { "content-type": "application/json" };
+
+// ─── Body size cap helpers ───────────────────────────────────────────────────
+
+/**
+ * Read the request body into a string, enforcing a hard byte cap.
+ *
+ * Two-phase enforcement:
+ *   1. Content-Length check (reject before reading a single byte when the
+ *      client declares an oversized body).
+ *   2. Streaming read with a cap (catches chunked transfer encoding where
+ *      Content-Length is absent, and a client that lies about its declared
+ *      length).
+ *
+ * Handles three request shapes:
+ *   - Production: Harper Request with async-iterable `request.body` (RequestBody
+ *     wrapping Node IncomingMessage).
+ *   - Test doubles: `request.text()` as a function (returns pre-built string),
+ *     or `request.body` as a plain string.
+ *
+ * Throws an error with `code: "BODY_TOO_LARGE"` when the cap is exceeded, so
+ * the caller can distinguish a size rejection from a parse failure.
+ */
+async function readBodyCapped(request: any, maxBytes: number): Promise<string> {
+  // Phase 1: trust-but-verify the declared Content-Length.
+  const contentLength = request?.headers?.get?.("content-length");
+  if (contentLength != null) {
+    const declared = Number(contentLength);
+    if (!Number.isFinite(declared) || declared < 0) {
+      throw Object.assign(
+        new Error(`invalid Content-Length: ${contentLength}`),
+        { code: "BODY_TOO_LARGE" },
+      );
+    }
+    if (declared > maxBytes) {
+      throw Object.assign(
+        new Error(`request body too large: ${declared} bytes exceeds ${maxBytes}-byte limit`),
+        { code: "BODY_TOO_LARGE" },
+      );
+    }
+  }
+
+  // Phase 2: read with a cap.
+  const body = request.body;
+
+  // Test double: body is already a plain string.
+  if (typeof body === "string") {
+    if (Buffer.byteLength(body) > maxBytes) {
+      throw Object.assign(
+        new Error(`request body too large: exceeds ${maxBytes}-byte limit`),
+        { code: "BODY_TOO_LARGE" },
+      );
+    }
+    return body;
+  }
+
+  // Test double: request.text() is provided as a function (returns a string).
+  if (typeof request.text === "function") {
+    const text: string = await request.text();
+    if (typeof text === "string" && Buffer.byteLength(text) > maxBytes) {
+      throw Object.assign(
+        new Error(`request body too large: exceeds ${maxBytes}-byte limit`),
+        { code: "BODY_TOO_LARGE" },
+      );
+    }
+    return text;
+  }
+
+  // Production: Harper Request.body is a RequestBody (async-iterable, wraps
+  // Node IncomingMessage). Read chunk by chunk with a running cap.
+  if (body && typeof body[Symbol.asyncIterator] === "function") {
+    const chunks: Buffer[] = [];
+    let total = 0;
+    for await (const chunk of body) {
+      const buf = typeof chunk === "string" ? Buffer.from(chunk) : chunk;
+      total += buf.length;
+      if (total > maxBytes) {
+        throw Object.assign(
+          new Error(`request body too large: exceeds ${maxBytes}-byte limit`),
+          { code: "BODY_TOO_LARGE" },
+        );
+      }
+      chunks.push(buf);
+    }
+    return Buffer.concat(chunks).toString("utf-8");
+  }
+
+  // Fallback: body is absent or an unrecognised shape.
+  return String(body ?? "");
+}
 
 // ─── JSON-RPC helpers ────────────────────────────────────────────────────────
 
@@ -207,12 +313,16 @@ export async function mcpHandler(request: any): Promise<any> {
     return rpcError(null, -32600, "method not allowed: /mcp accepts JSON-RPC POST only", 405);
   }
 
-  // Parse the JSON-RPC body. Harper's Request wraps a Node stream — read text.
+  // Parse the JSON-RPC body with a size cap. Harper's Request wraps a Node
+  // stream — read text, but never unbounded.
   let msg: any;
   try {
-    const text = typeof request.text === "function" ? await request.text() : request.body;
+    const text = await readBodyCapped(request, MAX_MCP_BODY_SIZE);
     msg = typeof text === "string" ? JSON.parse(text) : text;
-  } catch {
+  } catch (err: any) {
+    if (err?.code === "BODY_TOO_LARGE") {
+      return rpcError(null, -32000, err.message, 413);
+    }
     return rpcError(null, -32700, "parse error: invalid JSON");
   }
   if (!msg || typeof msg !== "object" || msg.jsonrpc !== "2.0" || typeof msg.method !== "string") {
@@ -226,7 +336,7 @@ export async function mcpHandler(request: any): Promise<any> {
       return rpcResult(id, {
         protocolVersion: PROTOCOL_VERSION,
         capabilities: { tools: {} },
-        serverInfo: { name: "flair", version: "0.1.0" },
+        serverInfo: { name: "flair", version: resolveVersion() },
       });
 
     // Notifications (no id) — acknowledge with 202-ish empty 200; MCP clients send

--- a/test/unit/mcp-handler.test.ts
+++ b/test/unit/mcp-handler.test.ts
@@ -187,11 +187,13 @@ describe("tools/list — exactly the 12 curated tools", () => {
 
 // ─── initialize / ping ───────────────────────────────────────────────────────
 describe("protocol handshake", () => {
-  it("initialize advertises tools capability", async () => {
+  it("initialize returns the real package version, not a hardcoded string", async () => {
     const res = await mcpHandler(post({ jsonrpc: "2.0", id: 1, method: "initialize" }, { sub: "s" }));
     const body = await parse(res);
-    expect(body.result.capabilities.tools).toBeDefined();
     expect(body.result.serverInfo.name).toBe("flair");
+    // Must be a semver-like string (e.g. "0.33.0"), not the old hardcoded "0.1.0".
+    expect(body.result.serverInfo.version).toMatch(/^\d+\.\d+\.\d+/);
+    expect(body.result.serverInfo.version).not.toBe("0.1.0");
   });
   it("ping → empty result", async () => {
     const res = await mcpHandler(post({ jsonrpc: "2.0", id: 2, method: "ping" }, { sub: "s" }));
@@ -624,5 +626,152 @@ describe("protocol errors", () => {
     const res = await mcpHandler(post({ jsonrpc: "2.0", id: 9, method: "resources/list" }, { sub: "s" }));
     const body = await parse(res);
     expect(body.error.code).toBe(-32601);
+  });
+});
+
+// ─── Body size cap (flair#1033) ──────────────────────────────────────────────
+
+/** Build a request double with optional headers. */
+function requestWithHeaders(body: any, mcp: any, headers: Record<string, string> = {}) {
+  return {
+    method: "POST",
+    mcp,
+    headers: {
+      get: (name: string) => headers[name.toLowerCase()] ?? null,
+    },
+    text: async () => JSON.stringify(body),
+  };
+}
+
+/** Build a request double whose body is a string (simulates a pre-read body). */
+function requestWithStringBody(bodyStr: string, mcp: any, headers: Record<string, string> = {}) {
+  return {
+    method: "POST",
+    mcp,
+    headers: {
+      get: (name: string) => headers[name.toLowerCase()] ?? null,
+    },
+    body: bodyStr,
+  };
+}
+
+/** Build a request double whose body is an async iterable (simulates Harper's RequestBody). */
+function requestWithStreamBody(chunks: string[], mcp: any, headers: Record<string, string> = {}) {
+  return {
+    method: "POST",
+    mcp,
+    headers: {
+      get: (name: string) => headers[name.toLowerCase()] ?? null,
+    },
+    body: {
+      [Symbol.asyncIterator]() {
+        let i = 0;
+        return {
+          next: async () => {
+            if (i >= chunks.length) return { done: true, value: undefined };
+            return { done: false, value: chunks[i++] };
+          },
+        };
+      },
+    },
+  };
+}
+
+describe("body size cap", () => {
+  it("rejects when Content-Length exceeds the cap (413, JSON-RPC error)", async () => {
+    const bigBody = JSON.stringify({ jsonrpc: "2.0", id: 1, method: "ping" });
+    const res = await mcpHandler(requestWithHeaders(
+      { jsonrpc: "2.0", id: 1, method: "ping" },
+      { sub: "s" },
+      { "content-length": String(300 * 1024) }, // 300 KB > 256 KB cap
+    ));
+    expect(res.status).toBe(413);
+    const body = JSON.parse(res.body);
+    expect(body.error.code).toBe(-32000);
+    expect(body.error.message).toContain("too large");
+  });
+
+  it("POSITIVE CONTROL: a request under the cap succeeds", async () => {
+    const res = await mcpHandler(requestWithHeaders(
+      { jsonrpc: "2.0", id: 1, method: "ping" },
+      { sub: "s" },
+      { "content-length": "128" },
+    ));
+    expect(res.status).toBe(200);
+    const body = JSON.parse(res.body);
+    expect(body.result).toEqual({});
+  });
+
+  it("rejects an invalid (non-numeric) Content-Length", async () => {
+    const res = await mcpHandler(requestWithHeaders(
+      { jsonrpc: "2.0", id: 1, method: "ping" },
+      { sub: "s" },
+      { "content-length": "eleventy" },
+    ));
+    expect(res.status).toBe(413);
+    const body = JSON.parse(res.body);
+    expect(body.error.message).toContain("invalid Content-Length");
+  });
+
+  it("rejects a negative Content-Length", async () => {
+    const res = await mcpHandler(requestWithHeaders(
+      { jsonrpc: "2.0", id: 1, method: "ping" },
+      { sub: "s" },
+      { "content-length": "-1" },
+    ));
+    expect(res.status).toBe(413);
+    const body = JSON.parse(res.body);
+    expect(body.error.message).toContain("invalid Content-Length");
+  });
+
+  it("rejects a body that exceeds the cap during streaming read (no Content-Length header — chunked encoding path)", async () => {
+    // Build a body that's 300 KB — over the 256 KB cap.
+    const padding = "x".repeat(300 * 1024);
+    const bigPayload = JSON.stringify({ jsonrpc: "2.0", id: 1, method: "ping", padding });
+    const res = await mcpHandler(requestWithStreamBody(
+      [bigPayload],
+      { sub: "s" },
+      // No content-length header — simulates chunked transfer encoding.
+    ));
+    expect(res.status).toBe(413);
+    const body = JSON.parse(res.body);
+    expect(body.error.code).toBe(-32000);
+    expect(body.error.message).toContain("too large");
+  });
+
+  it("POSITIVE CONTROL: streaming read under the cap succeeds (no Content-Length)", async () => {
+    const res = await mcpHandler(requestWithStreamBody(
+      [JSON.stringify({ jsonrpc: "2.0", id: 1, method: "ping" })],
+      { sub: "s" },
+    ));
+    expect(res.status).toBe(200);
+    const body = JSON.parse(res.body);
+    expect(body.result).toEqual({});
+  });
+
+  it("rejects a string body that exceeds the cap", async () => {
+    const padding = "x".repeat(300 * 1024);
+    const bigPayload = JSON.stringify({ jsonrpc: "2.0", id: 1, method: "ping", padding });
+    const res = await mcpHandler(requestWithStringBody(bigPayload, { sub: "s" }));
+    expect(res.status).toBe(413);
+    const body = JSON.parse(res.body);
+    expect(body.error.message).toContain("too large");
+  });
+
+  it("POSITIVE CONTROL: string body under the cap succeeds", async () => {
+    const res = await mcpHandler(requestWithStringBody(
+      JSON.stringify({ jsonrpc: "2.0", id: 1, method: "ping" }),
+      { sub: "s" },
+    ));
+    expect(res.status).toBe(200);
+    const body = JSON.parse(res.body);
+    expect(body.result).toEqual({});
+  });
+
+  it("accepts an empty body (no Content-Length, no body bytes)", async () => {
+    const res = await mcpHandler(requestWithStreamBody([], { sub: "s" }));
+    // Empty body → not valid JSON-RPC → parse error, not a size rejection.
+    const body = JSON.parse(res.body);
+    expect(body.error.code).toBe(-32700);
   });
 });


### PR DESCRIPTION
## What

`resources/mcp-handler.ts` read the entire request body into memory with no size limit. This PR adds a 256 KB cap with two-phase enforcement, and wires `serverInfo.version` to the real package version instead of the hardcoded `"0.1.0"`.

## Why

`/mcp` is the first surface reachable by an open population of OAuth clients rather than by Ed25519 agents we provisioned. Harper's HTTP layer imposes no cap on this path — the handler is registered via `srv.http()` which goes through Harper's own HTTP chain, not Fastify's 1 GB `bodyLimit` or the contentTypes handler's configurable 10 MB default. The Node.js `http.IncomingMessage` stream has no built-in limit, so reading the body stream would allocate unbounded memory.

## The cap: 256 KB

~100x headroom over any legitimate MCP JSON-RPC request. A `memory_store` with a large content field is a few KB; even a batch of 100 would be well under this. Small enough that an attacker cannot meaningfully consume memory through this path.

## Enforcement

Two-phase, so neither half alone can be bypassed:

1. **Content-Length check** — reject before reading a single byte when the client declares an oversized body (HTTP 413 + JSON-RPC error).
2. **Streaming read with a running cap** — catches chunked transfer encoding where Content-Length is absent, and a client that lies about its declared length.

Also handles the three request shapes the handler actually receives: Harper's async-iterable `RequestBody` (production), test doubles with `request.text()` as a function, and test doubles with `request.body` as a plain string.

## `serverInfo.version`

Was hardcoded `"0.1.0"` while the product is at 0.33.0. Now reads from the bundled `package.json` via the existing `resolveVersion()` helper.

## Testing

- 9 new tests covering: Content-Length over/under cap, invalid/negative Content-Length, streaming read over/under cap (chunked path), string body over/under cap, empty body, and version is real semver.
- Every rejection test has a positive control (request under the limit succeeds) in the same describe block.
- Mutation check: cap removed → 3 rejection tests fail; cap restored → all 60 pass.
- Full unit suite: 3733 pass / 0 fail (origin/main) vs 3742 pass / 0 fail (branch) — +9 new tests, zero regressions.

Closes #1033.
