### PR TITLE
docs(changelog): add the missing fragments for the /mcp body cap (#1034)

### DIFF
--- a/.changelog/unreleased/fixed-mcp-serverinfo-version.md
+++ b/.changelog/unreleased/fixed-mcp-serverinfo-version.md
@@ -1,0 +1,4 @@
+- **`/mcp` reports its real version.** The `initialize` response hardcoded
+  `serverInfo.version` as `0.1.0`, which is the string a connecting client
+  displays and the one someone reads while diagnosing an incident. It now comes
+  from the package version.

--- a/.changelog/unreleased/security-mcp-body-cap.md
+++ b/.changelog/unreleased/security-mcp-body-cap.md
@@ -1,0 +1,9 @@
+- **`/mcp` now caps the request body at 256 KB.** The handler read the entire
+  request into memory with no limit, and Harper imposes none on this path —
+  `srv.http()` bypasses both Fastify's 1 GB `bodyLimit` and the contentTypes
+  handler's configurable default. Enforcement is two-phase: an oversized
+  `Content-Length` is rejected before a byte is read, and the streaming read
+  aborts mid-body, so a chunked request that omits or understates the header
+  cannot bypass it. This matters more here than the same pattern elsewhere
+  because `/mcp` is the first surface reachable by an open population of OAuth
+  clients rather than by agents we issued credentials to.


### PR DESCRIPTION
#1034 merged without a changelog fragment. Every other feat/fix commit since `v0.33.0` has one — 8 of 9 — so this is a single omission rather than a pattern, but the one it happened to is the security-relevant fix, which would have shipped in 0.34.0 with no release note at all.

Two fragments, because they are two entries: the body cap is `security`, the `serverInfo.version` fix is `fixed`.

## The gate could not have caught this

`docs-freshness-check.mjs`'s `changelog-unreleased` check fails when feat/fix commits exist since the last `v*` tag **and `.changelog/unreleased/` is empty**. It is a check on the directory, not on the change.

So once any single PR has contributed a fragment, the check is satisfied for every subsequent PR until the next release consumes the directory. In normal operation it can only fail in the narrow window immediately after a release cut — which is to say, almost never, and never for the case it looks like it covers.

That is not an argument against the check; a completely undocumented release is worth catching. It is an argument that **nothing currently detects a single PR omitting its entry**, which is the failure that actually occurs. Filed separately.

No issue: repairing an omission in an already-merged PR.
