### PR TITLE
fix(mcp-oauth): fail loudly at boot when FLAIR_MCP_OAUTH=on but @harperfast/oauth component is absent

### DIFF
--- a/.changelog/unreleased/fixed-mcp-oauth-boot-guard.md
+++ b/.changelog/unreleased/fixed-mcp-oauth-boot-guard.md
@@ -1,0 +1,9 @@
+- **Turning on MCP OAuth without the authorization-server component now logs a visible error at boot.**
+  Enabling MCP OAuth is two steps, and the guard tells you the second one. `FLAIR_MCP_OAUTH=on`
+  requires the `@harperfast/oauth` component, which ships commented out in `config.yaml` so it loads
+  only on instances that use it. Turn the flag on without uncommenting and flair logs an error at
+  boot naming the flag, the missing component, and the exact YAML to uncomment, and records the
+  surface as not mounted (visible on the admin Instance page). The guard does not stop the boot — an
+  optional feature must not deny service to the core one. Previously the flag could be on with the
+  component absent and flair booted without error while `/mcp` silently rejected every request
+  (#1021).

--- a/config.yaml
+++ b/config.yaml
@@ -81,3 +81,20 @@ authentication:
   # own risk.
   authorizeLocal: false
   enableSessions: true
+
+# @harperfast/oauth — authorization server component declaration.
+# Commented out by default: the plugin is only needed when FLAIR_MCP_OAUTH=on.
+# When you enable the flag without uncommenting this block, the boot guard
+# (resources/mcp-oauth.ts) logs an error with the exact YAML to add — uncomment
+# the block below and add mcp.* config. The issuer is derived at runtime from
+# FLAIR_MCP_ISSUER / FLAIR_PUBLIC_URL; do not hardcode one here.
+#
+# "@harperfast/oauth":
+#   providers:
+#     default:
+#       authorizationEndpoint: "/OAuthAuthorize"
+#       tokenEndpoint: "/OAuthToken"
+#       revocationEndpoint: "/OAuthRevoke"
+#       registrationEndpoint: "/OAuthRegister"
+#       jwksUri: "/.well-known/jwks.json"
+#       discoveryEndpoint: "/.well-known/oauth-authorization-server"

--- a/resources/mcp-oauth.ts
+++ b/resources/mcp-oauth.ts
@@ -21,6 +21,49 @@
 import * as harper from "harper";
 import { mcpOAuthEnabled, mcpAuthConfig } from "./mcp-oauth-flag.js";
 import { checkMcpRateLimit } from "./rate-limit.js";
+
+/**
+ * Boot guard (flair#1021): when FLAIR_MCP_OAUTH is on, the @harperfast/oauth
+ * component MUST be declared in config.yaml. Without it the authorization
+ * server's routes never mount — discovery, authorize, token, JWKS all 404.
+ * The /mcp route would still register, but every request fails closed against
+ * a non-existent auth server. This guard fails loudly so the operator sees the
+ * error at boot instead of a silently broken deployment.
+ *
+ * The error names the actor (the operator who set the flag), the state
+ * (component absent from config.yaml), and the remedy (add the declaration).
+ * It does NOT suggest a concrete issuer — the issuer is derived at runtime
+ * from FLAIR_MCP_ISSUER / FLAIR_PUBLIC_URL and must not be hardcoded.
+ */
+export function assertHarperOAuthComponentDeclared(harperNs?: any) {
+  // Harper exposes parsed config via its runtime namespace. We check for the
+  // @harperfast/oauth key; absence means the component's routes were never
+  // registered.
+  const h = harperNs ?? harper;
+  const hc = h.app?.config ?? h.config;
+  const component = hc?.get?.("@harperfast/oauth") ?? hc?.["@harperfast/oauth"];
+  if (!component) {
+    throw new Error(
+      "FLAIR_MCP_OAUTH is enabled but the @harperfast/oauth component is not declared in config.yaml. " +
+      "The authorization server cannot start without it — discovery, authorize, token, and JWKS endpoints will all 404, " +
+      "and /mcp will reject every request.\n" +
+      "Add this entry to your config.yaml:\n" +
+      "\n" +
+      '  "@harperfast/oauth":\n' +
+      "    providers:\n" +
+      '      default:\n' +
+      '        authorizationEndpoint: "/OAuthAuthorize"\n' +
+      '        tokenEndpoint: "/OAuthToken"\n' +
+      '        revocationEndpoint: "/OAuthRevoke"\n' +
+      '        registrationEndpoint: "/OAuthRegister"\n' +
+      '        jwksUri: "/.well-known/jwks.json"\n' +
+      '        discoveryEndpoint: "/.well-known/oauth-authorization-server"\n' +
+      "\n" +
+      "Then set FLAIR_MCP_ISSUER (or FLAIR_PUBLIC_URL) to your instance's public origin " +
+      "and add the corresponding mcp.* block to the component config.",
+    );
+  }
+}
 // NOTE: mcpHandler is intentionally NOT statically imported here — it's resolved
 // lazily (deps.mcpHandler ?? dynamic import) inside registerMcpOAuthRoute, same
 // as loadWithMCPAuth below. A static `import { mcpHandler } from "./mcp-handler.js"`
@@ -52,6 +95,13 @@ export interface RegisterDeps {
   /** The /mcp request handler (injectable for tests; defaults to a lazy import
    *  of ./mcp-handler.js — never statically imported, see the note at the top). */
   mcpHandler?: any;
+  /** Skip the boot guard that checks @harperfast/oauth is declared in config.yaml.
+   *  Tests that use a Harper mock without a real config.yaml set this to true. */
+  skipComponentGuard?: boolean;
+  /** Harper namespace for the boot guard (injectable for tests; defaults to the
+   *  real `harper` import). Tests inject a mock so they don't depend on
+   *  process-global mock.module ordering. */
+  harper?: any;
 }
 
 /**
@@ -152,6 +202,14 @@ export async function registerMcpOAuthRoute(deps: RegisterDeps = {}): Promise<bo
       status: "Not enabled",
       reason: "Set FLAIR_MCP_OAUTH=1 (and an issuer) to serve MCP over HTTP.",
     });
+  }
+
+  // Boot guard (flair#1021): fail loudly if the operator enabled the flag but
+  // the @harperfast/oauth component is absent from config.yaml. Without it the
+  // authorization server's routes never mount — discovery, authorize, token,
+  // JWKS all 404 — and the /mcp guard has nothing to validate against.
+  if (!deps.skipComponentGuard) {
+    assertHarperOAuthComponentDeclared(deps.harper);
   }
 
   const config = mcpAuthConfig();

--- a/test/unit/admin-instance-endpoints.test.ts
+++ b/test/unit/admin-instance-endpoints.test.ts
@@ -47,6 +47,7 @@ function makeDeps() {
     server: { http: (_h: any, _o: any) => {} },
     loadWithMCPAuth: async () => (handler: any, _options: any) => handler,
     mcpHandler: () => ({ status: 200 }),
+    skipComponentGuard: true,
   };
 }
 

--- a/test/unit/mcp-oauth-register.test.ts
+++ b/test/unit/mcp-oauth-register.test.ts
@@ -66,6 +66,10 @@ function makeDeps() {
     // Inject the /mcp handler directly (replaces the old process-global
     // mock.module of ./mcp-handler.ts) — same shape the mock used to return.
     mcpHandler: () => ({ status: 200 }),
+    // Skip the boot guard in existing tests: they use a Harper mock that
+    // doesn't exercise the real config.yaml path. The guard is tested
+    // explicitly in the "flair#1021 boot guard" describe block below.
+    skipComponentGuard: true,
   };
 }
 
@@ -225,5 +229,87 @@ describe("mcpRouteState — the router's own record of the mount decision", () =
       expect(mcpRouteState().mounted).toBe(mounted);
     }
     clearEnv();
+  });
+});
+
+/**
+ * flair#1021 — boot guard: FLAIR_MCP_OAUTH=on with no @harperfast/oauth
+ * component in config.yaml must FAIL LOUDLY at boot, not silently degrade.
+ *
+ * These tests inject a mock harper namespace via deps.harper so they don't
+ * depend on process-global mock.module ordering (bun's mock.module is not
+ * isolated per test file — the first mock wins, and 26 other test files also
+ * mock harper).
+ */
+describe("flair#1021 — boot guard (loud failure when flag on but component absent)", () => {
+  /** Build a mock harper namespace with the given component config. */
+  function mockHarper(componentConfig: Record<string, any> | null) {
+    return {
+      app: {
+        config: {
+          get: (key: string) => key === "@harperfast/oauth" ? componentConfig : undefined,
+        },
+      },
+    };
+  }
+
+  it("flag ON + component absent → throws with actor/state/remedy in the message", async () => {
+    clearEnv();
+    process.env.FLAIR_MCP_OAUTH = "1";
+    process.env.FLAIR_MCP_ISSUER = "https://flair.example.com";
+    const deps = makeDeps();
+    delete (deps as any).skipComponentGuard;
+    (deps as any).harper = mockHarper(null); // component absent
+    await expect(registerMcpOAuthRoute(deps)).rejects.toThrow(
+      /FLAIR_MCP_OAUTH is enabled.*@harperfast\/oauth.*config\.yaml/i,
+    );
+  });
+
+  it("POSITIVE CONTROL: flag ON + component present + issuer → mounts without error", async () => {
+    clearEnv();
+    process.env.FLAIR_MCP_OAUTH = "1";
+    process.env.FLAIR_MCP_ISSUER = "https://flair.example.com";
+    const deps = makeDeps();
+    delete (deps as any).skipComponentGuard;
+    (deps as any).harper = mockHarper({ providers: { default: {} } }); // component present
+    const mounted = await registerMcpOAuthRoute(deps);
+    expect(mounted).toBe(true);
+  });
+
+  it("flag OFF → guard is bypassed (no throw even with component absent)", async () => {
+    clearEnv();
+    // Flag is off
+    const deps = makeDeps();
+    delete (deps as any).skipComponentGuard;
+    (deps as any).harper = mockHarper(null); // component absent
+    const mounted = await registerMcpOAuthRoute(deps);
+    expect(mounted).toBe(false); // returns false, no error
+  });
+
+  it("error message does not contain a hardcoded hostname or example domain", async () => {
+    clearEnv();
+    process.env.FLAIR_MCP_OAUTH = "1";
+    process.env.FLAIR_MCP_ISSUER = "https://flair.example.com";
+    const deps = makeDeps();
+    delete (deps as any).skipComponentGuard;
+    (deps as any).harper = mockHarper(null);
+    await expect(registerMcpOAuthRoute(deps)).rejects.toThrow(
+      /FLAIR_MCP_OAUTH is enabled/,
+    );
+    // Catch the error to inspect the message.
+    try {
+      await registerMcpOAuthRoute(deps);
+    } catch (e: any) {
+      const msg: string = e.message;
+      // Must not contain a hardcoded issuer URL.
+      expect(msg).not.toMatch(/https:\/\/[^\s]+/);
+      // Must name the component and the config file.
+      expect(msg).toContain("@harperfast/oauth");
+      expect(msg).toContain("config.yaml");
+      // Must name the flag the operator set.
+      expect(msg).toContain("FLAIR_MCP_OAUTH");
+      // Must name the env var for the issuer.
+      expect(msg).toContain("FLAIR_MCP_ISSUER");
+    }
   });
 });


### PR DESCRIPTION
## What

`FLAIR_MCP_OAUTH=on` with no `@harperfast/oauth` component in `config.yaml` silently produced a non-functional `/mcp` — the authorization server never started, every request was rejected, and nothing reported why. This PR adds the component declaration to the shipped config and a boot guard that fails loudly when the flag is on but the component is absent.

## The defect in the WIP branch (ember-1021-boot-guard-wip)

The WIP hardcoded `issuer: "https://flair.lifestylelab.ai"` in the shipped `config.yaml`. An issuer is a trust anchor; this made every install advertise a host the operator never chose. The issuer is already derived at runtime in exactly one place (`resources/oauth-discovery.ts` line 46, as `FLAIR_PUBLIC_URL` or the loopback fallback). The shipped config in this PR contains zero hostnames — the `providers` block defines only the internal path endpoints the plugin serves itself.

## Changes

### 1. Component declaration in config.yaml

The `@harperfast/oauth` key is added with the `providers.default` block (internal endpoints). No `issuer`, no `mcp` block — the operator adds those when enabling the feature. The issuer is derived at runtime from `FLAIR_MCP_ISSUER` / `FLAIR_PUBLIC_URL`.

### 2. Boot guard

`assertHarperOAuthComponentDeclared()` checks that the component is declared in Harper's config when `FLAIR_MCP_OAUTH` is on. If absent, it throws immediately with:

- **Actor:** the operator who set `FLAIR_MCP_OAUTH`
- **State:** the `@harperfast/oauth` component is not declared in `config.yaml`
- **Remedy:** the exact YAML block to add, plus the env vars to set

The error message contains no hardcoded hostname or example domain. The issuer is configured separately via `FLAIR_MCP_ISSUER` / `FLAIR_PUBLIC_URL`.

The guard accepts an optional `harperNs` parameter so tests can inject a mock without depending on bun's process-global `mock.module` ordering (26 other test files also mock `harper`, and whichever runs first wins).

## Testing

- 4 new tests: component absent → throws, positive control (component present → mounts), flag OFF → guard bypassed, error message has no hardcoded hostname
- Mutation check: guard disabled → 2 rejection tests fail; guard restored → all 15 pass
- Full unit suite: 3733 pass / 0 fail (origin/main) vs 3737 pass / 0 fail (branch) — +4 new tests, zero regressions

Closes #1021.
