### PR TITLE
fix(ci): type-check the test suite, with the backlog as an explicit exclude list

### DIFF
--- a/.changelog/unreleased/fixed-typecheck-test-suite.md
+++ b/.changelog/unreleased/fixed-typecheck-test-suite.md
@@ -1,0 +1,10 @@
+- **The test suite is now type-checked in CI.** Both project tsconfigs excluded `test/`, so
+  `tsc --noEmit` — what CI runs as its Type Check lane — never read a test file, and bun's
+  transpiler strips types rather than checking them. A guard test could call a function that
+  no longer exists, pass a wrong-shaped argument, or assert against a renamed property, and
+  the only signal was whether it happened to fail at runtime. That matters most for guard
+  tests, which are how we know a control still works. A new `tsconfig.test.check.json` covers
+  the suite under `strict`, with an explicit exclude list for the files carrying a known
+  backlog — a visible, shrinkable list rather than a blanket relaxation, since relaxing the
+  compiler options until everything passed would have bought coverage of ~30 files by
+  weakening the check on ~260.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1008,6 +1008,19 @@ jobs:
       # Root CLI entry point (tsconfig.cli.json — strict: false, matches build:cli)
       - name: Type check root CLI
         run: npx tsc --noEmit -p tsconfig.cli.json
+      # Test suite (#1014). Nothing type-checked test/ before this: both project
+      # configs excluded it, so bun's transpiler — which strips types rather than
+      # checking them — was the only thing that ever read those files. A guard test
+      # could reference a deleted function or assert against a renamed property and
+      # the only signal was whether it happened to fail at runtime.
+      #
+      # tsconfig.test.check.json carries an explicit exclude list: a visible,
+      # shrinkable backlog rather than a blanket relaxation. Relaxing compiler
+      # options until the whole suite passed would have bought coverage of ~30 files
+      # by weakening the check on ~260, and the relaxation would then be invisible.
+      # Each file removed from that list is a small, reviewable PR.
+      - name: Type check test suite (strict, excl. known backlog — #1014)
+        run: npx tsc --noEmit -p tsconfig.test.check.json
       # Build flair-client so workspace consumers (n8n-nodes-flair, pi-flair,
       # openclaw-flair) can resolve @tpsdev-ai/flair-client emitted types.
       # Without this, workspace tsc fails with "Cannot find module" because

--- a/tsconfig.test.check.json
+++ b/tsconfig.test.check.json
@@ -1,0 +1,60 @@
+{
+  "//": "Type-checks the test suite under strict. The exclude list is a VISIBLE, SHRINKABLE backlog \u2014 each file removed from it is a small reviewable PR. Two distinct causes are represented: (1) the majority carry genuine type rot (assertions and object literals that drifted from the shapes they mock) \u2014 114 errors across 29 files when this was written; (2) test/integration/in-process-api.test.ts and test/unit/changelog-fragments.test.ts fail only because they import untyped .js/.mjs modules, which is a property of the imported module rather than the test. Do not add to this list without recording which cause applies.",
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "noEmit": true,
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "allowImportingTsExtensions": true,
+    "types": [
+      "node",
+      "bun-types"
+    ],
+    "paths": {
+      "harper": [
+        "./types/harper.d.ts"
+      ]
+    }
+  },
+  "include": [
+    "test/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules",
+    "dist",
+    "test/entity-vocab.test.ts",
+    "test/integration/bridge-markdown.test.ts",
+    "test/integration/federation-watch.test.ts",
+    "test/integration/in-process-api.test.ts",
+    "test/integration/init-remote-ops.test.ts",
+    "test/integration/presence-api.test.ts",
+    "test/unit-isolated/semantic-search-scoping.test.ts",
+    "test/unit/abstention.test.ts",
+    "test/unit/agent-admin.test.ts",
+    "test/unit/audit-gate.test.ts",
+    "test/unit/auth-middleware-spoke-sync.test.ts",
+    "test/unit/auth-middleware.test.ts",
+    "test/unit/bridges-runtime-formats.test.ts",
+    "test/unit/changelog-fragments.test.ts",
+    "test/unit/cli-target-flag.test.ts",
+    "test/unit/doctor-client-network.test.ts",
+    "test/unit/ed25519-auth.test.ts",
+    "test/unit/federation-bootstrap-user.test.ts",
+    "test/unit/federation-cleanup.test.ts",
+    "test/unit/keys-prune.test.ts",
+    "test/unit/local-no-auth.test.ts",
+    "test/unit/mcp-client-credentials-live-package.test.ts",
+    "test/unit/mcp-enable.test.ts",
+    "test/unit/mcp-grant-family.test.ts",
+    "test/unit/mcp-surface-tripwire.test.ts",
+    "test/unit/migrations-embedding-stamp.test.ts",
+    "test/unit/migrations-source-fields.test.ts",
+    "test/unit/record-types-registry.test.ts",
+    "test/unit/temporal-scoring.test.ts",
+    "test/unit/upgrade-probes.test.ts",
+    "test/unit/upgrade-verify-rollback.test.ts"
+  ]
+}


### PR DESCRIPTION
Nothing type-checked `test/` before this. Both project configs excluded it, so `tsc --noEmit` — what CI runs as its Type Check lane — never read a test file, and bun's transpiler strips types rather than checking them. A test could call a function that no longer exists, pass a wrong-shaped argument, or assert against a renamed property, and the only signal was whether it happened to fail at runtime.

That matters most for **guard tests**, which are how we know a control still works.

## Measured before deciding

A tsconfig covering `test/**/*.ts` under `strict` produces **114 errors across 29 files, out of 290 test files total** — so **90% of the suite is already strict-clean**. The debt is concentrated, not diffuse.

Top codes: `TS2352` (27), `TS2741` (23), `TS2339` (20), `TS2322` (18), `TS2345` (10) — assertions and object literals that drifted from the shapes they mock, which is exactly the rot the issue describes.

## The shape of the fix, and why not the other one

`tsconfig.test.check.json` checks the suite under `strict` with an **explicit exclude list**. **260 files are checked.**

The alternative — relaxing compiler options until the whole suite passes — buys coverage of ~30 files by weakening the check on ~260, and the relaxation is invisible thereafter. An exclude list is the opposite: visible, countable, and each file removed from it is a small reviewable PR.

The list records **two distinct causes**, so the backlog is honest about what kind of debt each entry is:
- 29 files with genuine type rot.
- 2 files (`in-process-api.test.ts`, `changelog-fragments.test.ts`) that fail only because they import untyped `.js`/`.mjs` modules — a property of the imported module, not the test.

## Mutation check

The whole point is a check that can fail, so:

```
deliberate type error added → exit 2, TS2322 reported
error removed              → exit 0, 260 test files checked
```

Fails when broken, passes when restored.

## One trap worth recording

A first attempt used `noStrictGenericChecks`, which **TypeScript has removed** — the config dies with `TS5102` before checking a single file. That failure *looks* like "ran and found nothing." Separately, `npx tsc` in a worktree without `node_modules` resolves a **decoy `tsc` package** ("This is not the tsc command you are looking for"), exits non-zero, reports no errors, and checks **0 files**. Both are the absence-reads-as-success shape this repo keeps finding; both are why the mutation check above is reported rather than assumed.

Closes #1014.
