### PR TITLE
fix(admin): escape publicUrl in Instance page Endpoints table (#1029)

### DIFF
--- a/.changelog/unreleased/security-escape-publicurl.md
+++ b/.changelog/unreleased/security-escape-publicurl.md
@@ -1,0 +1,7 @@
+- **The admin Instance page now HTML-escapes `publicUrl` in the Endpoints table and Public URL card.**
+  `FLAIR_PUBLIC_URL` is operator-set and not validated, and as of 0.34.0 the deploy step writes it
+  into the component's `.env` — so a value that used to be typed at a prompt now arrives through a
+  payload. The fix escapes on output at every interpolation site rather than sanitising the input,
+  which is the wrong layer. An operator setting a hostile value on their own instance is attacking
+  themselves; this is fixed because the shape is wrong and the input path widened, not because it
+  represents a meaningful external threat (#1029).

--- a/resources/AdminInstance.ts
+++ b/resources/AdminInstance.ts
@@ -118,7 +118,7 @@ export class AdminInstance extends Resource {
     // actionable and still teaches them the surface exists.
     const mcp = mcpRouteState();
     const mcpCell = mcp.mounted
-      ? `<code>${publicUrl}/mcp</code>`
+      ? `<code>${esc(publicUrl)}/mcp</code>`
       : `<span class="badge badge-gray">${esc(mcp.status)}</span>` +
         `<div style="margin-top:4px;color:#666;font-size:0.9em">${esc(mcp.reason)}</div>`;
 
@@ -147,7 +147,7 @@ export class AdminInstance extends Resource {
         </div>
         <div class="card">
           <h3>Public URL</h3>
-          <div style="font-family:monospace;font-size:0.9em;word-break:break-all">${publicUrl}</div>
+          <div style="font-family:monospace;font-size:0.9em;word-break:break-all">${esc(publicUrl)}</div>
         </div>
       </div>
 
@@ -162,12 +162,12 @@ export class AdminInstance extends Resource {
       <div class="card">
         <h3>Endpoints</h3>
         <table style="box-shadow:none">
-          <tr><td>API</td><td><code>${publicUrl}/</code></td></tr>
+          <tr><td>API</td><td><code>${esc(publicUrl)}/</code></td></tr>
           <tr><td>MCP</td><td>${mcpCell}</td></tr>
-          <tr><td>OAuth Discovery</td><td><code>${publicUrl}/OAuthMetadata</code></td></tr>
-          <tr><td>OAuth Authorize</td><td><code>${publicUrl}/OAuthAuthorize</code></td></tr>
-          <tr><td>OAuth Token</td><td><code>${publicUrl}/OAuthToken</code></td></tr>
-          <tr><td>Admin</td><td><code>${publicUrl}/AdminDashboard</code></td></tr>
+          <tr><td>OAuth Discovery</td><td><code>${esc(publicUrl)}/OAuthMetadata</code></td></tr>
+          <tr><td>OAuth Authorize</td><td><code>${esc(publicUrl)}/OAuthAuthorize</code></td></tr>
+          <tr><td>OAuth Token</td><td><code>${esc(publicUrl)}/OAuthToken</code></td></tr>
+          <tr><td>Admin</td><td><code>${esc(publicUrl)}/AdminDashboard</code></td></tr>
         </table>
       </div>
     `;

--- a/test/unit/admin-instance-endpoints.test.ts
+++ b/test/unit/admin-instance-endpoints.test.ts
@@ -37,6 +37,7 @@ mock.module("harper", () => ({
 
 const { AdminInstance } = await import("../../resources/AdminInstance.ts");
 const { registerMcpOAuthRoute } = await import("../../resources/mcp-oauth.ts");
+const { esc } = await import("../../resources/admin-layout.ts");
 
 const ENV = ["FLAIR_MCP_OAUTH", "FLAIR_MCP_ISSUER", "FLAIR_PUBLIC_URL"];
 function clearEnv() { for (const k of ENV) delete process.env[k]; }
@@ -124,5 +125,66 @@ describe("AdminInstance Endpoints table — MCP row (flair#1001)", () => {
     await registerMcpOAuthRoute(makeDeps()); // flag ON
     const onHtml = await renderInstancePage();
     for (const url of siblings) expect(onHtml).toContain(`<code>${url}</code>`);
+  });
+});
+
+// ── flair#1029: publicUrl output escaping ───────────────────────────────
+
+describe("AdminInstance — publicUrl output escaping (flair#1029)", () => {
+  /**
+   * Render the Instance page with FLAIR_PUBLIC_URL set to `value`.
+   * No Host header is provided, so resolvePublicUrl returns the env var.
+   */
+  async function renderWithPublicUrl(value: string): Promise<string> {
+    process.env.FLAIR_PUBLIC_URL = value;
+    const inst: any = new (AdminInstance as any)();
+    inst.getContext = () => ({ request: {} });
+    const res = await inst.get();
+    return await res.text();
+  }
+
+  it("escapes HTML metacharacters in publicUrl at every interpolation site", async () => {
+    const hostile = `https://evil.com/<script>alert('xss')</script>`;
+    const html = await renderWithPublicUrl(hostile);
+
+    // The raw metacharacters must not appear in the output.
+    expect(html).not.toContain("<script>");
+    expect(html).not.toContain("alert('xss')");
+
+    // The escaped equivalents must appear.
+    expect(html).toContain("&lt;script&gt;");
+    expect(html).toContain("alert(&#39;xss&#39;)");
+
+    // Every row in the Endpoints table must be escaped.
+    // API row
+    expect(html).toContain(`<code>${esc("https://evil.com/<script>alert('xss')</script>")}/</code>`);
+    // OAuth Discovery row
+    expect(html).toContain(`<code>${esc("https://evil.com/<script>alert('xss')</script>")}/OAuthMetadata</code>`);
+    // OAuth Authorize row
+    expect(html).toContain(`<code>${esc("https://evil.com/<script>alert('xss')</script>")}/OAuthAuthorize</code>`);
+    // OAuth Token row
+    expect(html).toContain(`<code>${esc("https://evil.com/<script>alert('xss')</script>")}/OAuthToken</code>`);
+    // Admin row
+    expect(html).toContain(`<code>${esc("https://evil.com/<script>alert('xss')</script>")}/AdminDashboard</code>`);
+    // Public URL card
+    expect(html).toContain(esc("https://evil.com/<script>alert('xss')</script>"));
+  });
+
+  it("positive control: an ordinary URL renders unchanged and still works as a link", async () => {
+    const ordinary = "https://flair.example.com";
+    const html = await renderWithPublicUrl(ordinary);
+
+    // The URL must appear verbatim in every row.
+    expect(html).toContain(`<code>${ordinary}/</code>`);
+    expect(html).toContain(`<code>${ordinary}/OAuthMetadata</code>`);
+    expect(html).toContain(`<code>${ordinary}/OAuthAuthorize</code>`);
+    expect(html).toContain(`<code>${ordinary}/OAuthToken</code>`);
+    expect(html).toContain(`<code>${ordinary}/AdminDashboard</code>`);
+
+    // The Public URL card also shows it verbatim.
+    expect(html).toContain(`<div style="font-family:monospace;font-size:0.9em;word-break:break-all">${ordinary}</div>`);
+
+    // esc() is a no-op on ordinary URLs — verify that explicitly.
+    expect(esc(ordinary)).toBe(ordinary);
   });
 });


### PR DESCRIPTION
## What

Escape `publicUrl` at every HTML interpolation site in the admin Instance page — the Endpoints table (6 rows) and the Public URL card.

## Why

`FLAIR_PUBLIC_URL` is operator-set and not validated. As of 0.34.0 the deploy step writes it into the component's `.env`, so a value that used to be typed at a prompt now arrives through a payload — widening the input path to an unescaped HTML sink.

The fix escapes on **output** rather than sanitising the input. Input sanitising is the wrong layer: it has to be right at every writer forever, and it silently corrupts legitimate values. Output escaping is right once at the sink.

## Severity

An operator setting a hostile `FLAIR_PUBLIC_URL` on their own instance is attacking themselves — this is not a meaningful external threat. Fixed because the shape is wrong and the input path widened, not because it represents a critical vulnerability.

## What was checked

- **Other admin pages**: `AdminIdp`, `AdminMemory`, `AdminConnectors`, `AdminPrincipals` already use `esc()` for all user/operator-controlled values. `AdminDashboard` only interpolates numeric counts. No other unescaped sinks found.
- **Other `publicUrl` consumers**: `oauth-discovery.ts`, `mcp-oauth.ts`, `XAA.ts`, `a2a-url.ts`, `component-env.ts`, `deploy.ts`, `cli.ts` — none render into HTML.

## Tests

- **Hostile input**: renders the page with `FLAIR_PUBLIC_URL=https://evil.com/<script>alert('xss')</script>` and asserts every interpolation site is escaped (no raw `<script>` in output, `&lt;script&gt;` present).
- **Positive control**: an ordinary URL (`https://flair.example.com`) renders verbatim in every row and the Public URL card. `esc()` is verified to be a no-op on ordinary URLs.
- **Mutation-checked**: removing the escaping causes the hostile-input test to fail (raw `<script>` appears in output). Restoring it makes the test pass.

## Test suite

- Baseline (`origin/main`): 3745 pass, 9 skip, 1 fail (pre-existing flaky in flair#914)
- This branch: 3748 pass (+2 new tests), 9 skip, 0 fail
- No regressions.



Closes #1029.
