### PR TITLE
ci: fail downgrade lane when baseline equals HEAD (empty delta)

### DIFF
--- a/.changelog/unreleased/fixed-downgrade-empty-delta-error.md
+++ b/.changelog/unreleased/fixed-downgrade-empty-delta-error.md
@@ -1,0 +1,1 @@
+- **Migration downgrade-and-revert lane now fails when baseline and HEAD are the same version.** Previously, between releases the lane installed `@tpsdev-ai/flair@latest` which resolved to the same version as HEAD, reporting green without exercising a genuine downgrade. The lane now detects this equality and exits with an error (#1016).

--- a/.github/workflows/migration-ci-lanes.yml
+++ b/.github/workflows/migration-ci-lanes.yml
@@ -168,6 +168,13 @@ jobs:
           HEAD_VERSION=$(node -p "require('$GITHUB_WORKSPACE/package.json').version")
           echo "Baseline (previously published): ${BASELINE_VERSION} — HEAD (PR build): ${HEAD_VERSION}"
 
+          # Property 2 of #1016: if baseline == HEAD, the lane installed the same
+          # binary twice and proved nothing. Fail loudly rather than reporting green.
+          if [[ "$BASELINE_VERSION" == "$HEAD_VERSION" ]]; then
+            echo "::error::downgrade proof did not run: baseline and HEAD are both ${HEAD_VERSION}. This lane installed the same binary twice and proved nothing. The baseline will not yield a real delta until the baseline source is changed (property 1 of #1016)."
+            exit 1
+          fi
+
           # ── 2. Init baseline, then seed the corpus AS the reserved
           # synthetic-migration test agent via the OPS API with Basic admin
           # auth — the version-stable authenticated write channel (see


### PR DESCRIPTION
## What changed

The **Migration downgrade-and-revert** lane in `migration-ci-lanes.yml` now detects when the baseline version and the HEAD version are identical, and fails the lane with an explicit error instead of reporting green.

**Before:** Between releases, `@tpsdev-ai/flair@latest` resolves to the same version already in `package.json`. The lane installs the same binary twice, exercises no real downgrade, and reports success.

**After:** The lane checks `BASELINE_VERSION == HEAD_VERSION` and exits with an error explaining that the proof did not run.

This is **property 2 of #1016** ("an empty delta must be an error, never a pass"). Property 1 (changing the baseline source) is deliberately not in this PR — it requires property 3 as well and would make the lane fail on every PR for a different reason.

## Expected CI behaviour

**The downgrade-and-revert lane will fail on this PR.** That is the proof the check works — baseline will equal HEAD because we are between releases. The lane will keep failing until property 1 lands. This is the issue being visible rather than hidden.

## Files changed

- `.github/workflows/migration-ci-lanes.yml` — added the equality check after `BASELINE_VERSION` and `HEAD_VERSION` are computed
- `.changelog/unreleased/fixed-downgrade-empty-delta-error.md` — changelog fragment
