### PR TITLE
fix(keys): prune must not archive a key file it cannot identify

### DIFF
--- a/.changelog/unreleased/fixed-prune-unidentified-keys.md
+++ b/.changelog/unreleased/fixed-prune-unidentified-keys.md
@@ -1,0 +1,8 @@
+- **`flair keys prune` no longer archives a key file it cannot identify.** `~/.flair/keys/<id>.key`
+  is a namespace shared by two writers: plaintext Ed25519 seeds, and AES-256-GCM keystore blobs
+  written by `FileKeyStore`. A keystore blob does not parse as a seed, and prune classified any
+  unparseable file as `invalid` — which is prunable — so it would move a **live federation key**
+  into `.pruned/`. Recoverable, since prune archives rather than deletes, but wrong in the
+  direction of touching a key that is in use. Unparseable files are now classified
+  `unidentified`, reported for a human, and left where they are. "I could not parse this" and
+  "this is a stale agent key" are different findings, and only the second is safe to act on.

--- a/src/doctor-client.ts
+++ b/src/doctor-client.ts
@@ -1067,7 +1067,7 @@ export function resolveCollisionSafeName(existingNames: Iterable<string>, filena
   return `${filename}.${n}`;
 }
 
-export type KeyPruneClass = "keep" | "stale" | "invalid" | "ignored";
+export type KeyPruneClass = "keep" | "stale" | "invalid" | "unidentified" | "ignored";
 
 export interface KeyPruneDecision {
   class: KeyPruneClass;
@@ -1099,7 +1099,20 @@ export function classifyKeyFile(
   baseUrl: string,
 ): KeyPruneDecision {
   if (!seedValid) {
-    return { class: "invalid", reason: "not a parseable Ed25519 private key seed" };
+    // NOT "invalid", and therefore NOT prunable. "I could not parse this" and
+    // "this is a stale agent key" are different findings, and only the second
+    // is safe to act on. `~/.flair/keys/<id>.key` is a namespace shared by two
+    // writers: plaintext Ed25519 seeds, and AES-256-GCM keystore blobs written
+    // by FileKeyStore (flair#1026). A keystore blob is unparseable AS A SEED
+    // while being a LIVE federation key — classifying it "invalid" moved a key
+    // that was in use. An unidentified file is reported for a human and left
+    // exactly where it is.
+    return {
+      class: "unidentified",
+      reason:
+        "not a parseable Ed25519 private key seed — may be a keystore blob or another format; " +
+        "left in place, inspect it before removing anything (flair#1026)",
+    };
   }
   if (registration?.state === "registered") {
     return { class: "keep", reason: `agent '${agentId}' is registered on ${baseUrl} — never pruned` };

--- a/test/unit/doctor-client.test.ts
+++ b/test/unit/doctor-client.test.ts
@@ -358,10 +358,25 @@ describe("fixSessionStartHook", () => {
 describe("classifyKeyFile", () => {
   const BASE_URL = "http://127.0.0.1:19926";
 
-  it("invalid seed → class 'invalid', regardless of any registration result", () => {
+  // flair#1026: an unparseable file is NOT prunable. `~/.flair/keys/<id>.key`
+  // is a namespace shared by two writers — plaintext Ed25519 seeds and
+  // AES-256-GCM keystore blobs — so "will not parse as a seed" does not imply
+  // "junk". It previously classified as "invalid", which prune archives, so a
+  // LIVE federation key could be moved.
+  it("unparseable seed → class 'unidentified', which prune must not act on", () => {
     const d = classifyKeyFile("stray", false, null, BASE_URL);
-    expect(d.class).toBe("invalid");
+    expect(d.class).toBe("unidentified");
+    expect(d.class).not.toBe("invalid");
     expect(d.reason).toContain("not a parseable Ed25519");
+    expect(d.reason).toContain("left in place");
+  });
+
+  // POSITIVE CONTROL for the above: the classifier must still be *able* to
+  // return a prunable class. A change that made everything unidentified would
+  // satisfy the assertion above while silently disabling prune entirely.
+  it("POSITIVE CONTROL: a parseable but unregistered key is still prunable ('stale')", () => {
+    const d = classifyKeyFile("stray", true, { state: "not-registered" }, BASE_URL);
+    expect(d.class).toBe("stale");
   });
 
   it("valid seed + registered → class 'keep'", () => {

--- a/test/unit/keys-prune.test.ts
+++ b/test/unit/keys-prune.test.ts
@@ -137,8 +137,11 @@ describe("classifyKeysDir — N unregistered + M registered", () => {
   });
 });
 
-describe("classifyKeysDir — invalid files classified distinctly from unregistered", () => {
-  it("an unparseable .key file → class 'invalid', and never triggers a network call", async () => {
+describe("classifyKeysDir — unidentifiable files classified distinctly from unregistered", () => {
+  // flair#1026: an unparseable file is "unidentified", NOT "invalid", and is not
+  // prunable. The keys dir is shared with AES-256-GCM keystore blobs, which do
+  // not parse as seeds while being live federation keys.
+  it("an unparseable .key file → class 'unidentified', and never triggers a network call", async () => {
     writeFileSync(join(keysDir, "garbage.key"), "not-a-real-ed25519-seed-at-all");
     let called = false;
     globalThis.fetch = (async () => { called = true; return new Response("{}", { status: 200 }); }) as typeof fetch;
@@ -146,19 +149,19 @@ describe("classifyKeysDir — invalid files classified distinctly from unregiste
     const res = await classifyKeysDir(keysDir, BASE_URL);
     expect(res.aborted).toBe(false);
     expect(res.entries).toHaveLength(1);
-    expect(res.entries[0].class).toBe("invalid");
+    expect(res.entries[0].class).toBe("unidentified");
     expect(res.entries[0].name).toBe("garbage.key");
     expect(called).toBe(false);
   });
 
-  it("invalid and stale are both prunable but reported as distinct classes side by side", async () => {
+  it("unidentified and stale are reported as distinct classes side by side, and only stale is prunable", async () => {
     writeFileSync(join(keysDir, "garbage.key"), "not-a-real-ed25519-seed-at-all");
     writeSeedKey(keysDir, "agent-stale");
     globalThis.fetch = mockRegistrationFetch(new Set());
 
     const res = await classifyKeysDir(keysDir, BASE_URL);
     const byClass = Object.fromEntries(res.entries.map((e) => [e.name, e.class]));
-    expect(byClass["garbage.key"]).toBe("invalid");
+    expect(byClass["garbage.key"]).toBe("unidentified");
     expect(byClass["agent-stale.key"]).toBe("stale");
   });
 });
@@ -185,7 +188,7 @@ describe("classifyKeysDir — unreachable instance aborts the whole run", () => 
 // ─── applyKeyPrune ──────────────────────────────────────────────────────────
 
 describe("applyKeyPrune — --apply moves prunable keys, leaves registered ones untouched", () => {
-  it("moves exactly the stale + invalid entries into .pruned/<date>/, a registered agent's key is NEVER moved", async () => {
+  it("moves exactly the stale entries into .pruned/<date>/; a registered key and an UNIDENTIFIABLE file are NEVER moved", async () => {
     writeSeedKey(keysDir, "agent-stale-1");
     writeSeedKey(keysDir, "agent-stale-2");
     writeSeedKey(keysDir, "agent-registered");
@@ -196,18 +199,21 @@ describe("applyKeyPrune — --apply moves prunable keys, leaves registered ones 
     expect(classified.aborted).toBe(false);
 
     const moved = applyKeyPrune(keysDir, classified.entries, "2026-07-18");
-    expect(moved).toHaveLength(3);
-    expect(moved.map((m) => m.name).sort()).toEqual(["agent-stale-1.key", "agent-stale-2.key", "garbage.key"]);
+    expect(moved).toHaveLength(2);
+    expect(moved.map((m) => m.name).sort()).toEqual(["agent-stale-1.key", "agent-stale-2.key"]);
 
     // Prunable files are gone from the original location...
     expect(existsSync(join(keysDir, "agent-stale-1.key"))).toBe(false);
     expect(existsSync(join(keysDir, "agent-stale-2.key"))).toBe(false);
-    expect(existsSync(join(keysDir, "garbage.key"))).toBe(false);
     // ...and present in the archive.
     const archiveDir = join(keysDir, PRUNED_DIR_NAME, "2026-07-18");
     expect(existsSync(join(archiveDir, "agent-stale-1.key"))).toBe(true);
     expect(existsSync(join(archiveDir, "agent-stale-2.key"))).toBe(true);
-    expect(existsSync(join(archiveDir, "garbage.key"))).toBe(true);
+
+    // flair#1026 — THE POINT OF THIS CHANGE: the unparseable file stays exactly
+    // where it was. It may be a live keystore blob, and prune cannot tell.
+    expect(existsSync(join(keysDir, "garbage.key"))).toBe(true);
+    expect(existsSync(join(archiveDir, "garbage.key"))).toBe(false);
 
     // The registered agent's key is untouched, at its original path.
     expect(existsSync(join(keysDir, "agent-registered.key"))).toBe(true);


### PR DESCRIPTION
`flair keys prune` would archive a **live federation key**.

## The defect

`~/.flair/keys/<id>.key` is a namespace shared by two writers: plaintext Ed25519 seeds (`flair init`, `agent add`, `agent rotate-key`) and AES-256-GCM keystore blobs (`FileKeyStore.setPrivateKeySeed`). Same directory, same suffix, mutually unreadable formats.

`classifyKeyFile` returned `invalid` for anything whose seed would not parse — and `invalid` is in prune's prunable set alongside `stale`. A keystore blob does not parse as a seed. So prune classified a key that was **in use** as junk and moved it into `.pruned/`.

It archives rather than deletes, so this is recoverable rather than destructive. But the classification is wrong **in the direction of touching a key that is in use**, which is the direction that matters.

## The fix

An unparseable file is now `unidentified`: reported for a human, never pruned.

**"I could not parse this" and "this is a stale agent key" are different findings, and only the second is safe to act on.** The cost is that genuinely corrupt files are no longer auto-cleaned — a trade worth making, since prune is a convenience and key loss is not.

This is **item 3 of the four** in #1026. It is deliberately separate and first: the other three (separating the namespaces, a self-describing format, de-duplicating the two loaders) are a redesign needing a migration for installs that already have both formats side by side. This one is a few lines, needs no migration, and stops the sharp edge while that work happens.

## Verification

**Three existing tests encoded the old behaviour.** They were updated to assert the new intent rather than made to pass — and the property that still matters is preserved: an unidentifiable file triggers **no network call**.

**Mutation check:** reverting the classifier to `invalid` fails the suite; restoring it passes.

**Positive control:** a parseable-but-unregistered key is still classified `stale` and still prunable. Without it, a change that made *everything* unidentified would satisfy the new assertions while silently disabling prune altogether.

**Numbers:** unit **3770 pass / 0 fail**, against a baseline of **3769 / 0** measured on unmodified `origin/main` in the same worktree. `tsc --noEmit` clean. `docs-freshness` 7/7, all ran, no `DID NOT RUN`.

## Note

I nearly ran `flair keys prune` on an install carrying exactly these blobs, on the basis that its output reads as authoritative. Retracted before running it — which is how this got filed.

Refs #1026.
