### PR TITLE
ci(compat): add package.json and bun.lock to federation-compat path filter (#1047)

### DIFF
--- a/.github/workflows/federation-compat.yml
+++ b/.github/workflows/federation-compat.yml
@@ -67,6 +67,12 @@ on:
       - "test/compat/**"
       - "test/helpers/**"
       - ".github/workflows/federation-compat.yml"
+      # An engine version change is the only realistic source of a
+      # cross-version boot break, and it reaches us through the lockfile,
+      # not through source — a Harper bump touches only these two files
+      # (flair#1047).
+      - "package.json"
+      - "bun.lock"
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
## What

Adds `package.json` and `bun.lock` to the path filter in `federation-compat.yml`.

## Why

The downgrade-boot compat test (`test/compat/downgrade-boot.test.ts`) runs only in this lane, which is path-filtered. An engine version change is the only realistic source of a cross-version boot break, and it reaches us through the lockfile, not through source — a Harper bump touches only `package.json` and `bun.lock`. Those were not on the filter, so the guarantee has never been tested against the change class that breaks it.

## Verification

This PR itself touches `federation-compat.yml`, which is already on the filter, so the lane will run. The downgrade-boot test must come back green against main's current Harper (5.1.x).

Ref: #1047


---

Refs #1047 — partial. This is the CI-visibility half only; the runtime guardrails are #1049
and the invariant restatement is #1050, so #1047 stays open.
