### PR TITLE
feat(cli): unconditional pre-upgrade snapshot on engine version change, store stamp with backwards-boot refusal (flair#1047)

### DIFF
--- a/.changelog/unreleased/added-engine-version-stamp.md
+++ b/.changelog/unreleased/added-engine-version-stamp.md
@@ -1,0 +1,3 @@
+- **Flair now stamps the data directory with the Harper engine version and refuses to boot when the store was written by a newer engine.** If an older Harper boots against a store written by a newer one, the error names both versions, the data directory, and the remedy — reinstall the newer version or restore from a pre-upgrade snapshot.
+
+  This only helps from the release that ships it onward: the check lives in the version being downgraded *to*, so it cannot rescue a downgrade to a build that predates the stamp.

--- a/.changelog/unreleased/changed-engine-version-snapshot.md
+++ b/.changelog/unreleased/changed-engine-version-snapshot.md
@@ -1,0 +1,3 @@
+- **Pre-upgrade snapshots are now automatic when the Harper engine version changes.** The tested-downgrade guarantee that justified making snapshots opt-in does not hold across engine version boundaries — a Harper bump is the only realistic source of a cross-version boot break. Opting out requires `--no-engine-snapshot` and prints what is being given up.
+
+  Ordinary flair-version upgrades (same Harper) remain opt-in via `--snapshot`.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -38,6 +38,12 @@ import {
 } from "./component-env.js";
 import { fabricUpgrade } from "./fabric-upgrade.js";
 import { checkVersion, formatVersionNudge, primeVersionCheckCache, FLAIR_PKG_NAME } from "./version-check.js";
+import {
+  readInstalledHarperVersion,
+  fetchDeclaredHarperVersion,
+  writeEngineVersionStamp,
+  checkEngineVersionBackwards,
+} from "./engine-version.js";
 import { checkServerHandshake, formatHandshakeNudge, invalidateHandshakeCache } from "./version-handshake.js";
 import { probeInstance, type ProbeResult } from "./probe.js";
 import {
@@ -9843,12 +9849,17 @@ export function pruneOldSnapshots(
 
 /**
  * Decide what `flair upgrade`'s pre-upgrade snapshot step should do (opt-in
- * rewrite, 2026-07-08). Pure — takes the three booleans the action already
+ * rewrite, 2026-07-08). Pure — takes the booleans the action already
  * computes and returns the branch to take, without performing any I/O. Pulled
  * out of the action itself so the gating logic (default = no snapshot, no
  * abort; --snapshot = same abort-on-failure mechanism as before) is directly
  * unit-testable instead of only reachable via a full `flair upgrade` run
  * (test/unit/upgrade-data-snapshot.test.ts).
+ *
+ * flair#1047: when the engine (Harper) version is changing, the snapshot is
+ * unconditional — the tested-downgrade guarantee that justified making it
+ * opt-in does not hold across engine version boundaries. Opting out of THAT
+ * requires `--no-engine-snapshot` and prints what is being given up.
  *
  *   - "not-upgrading": @tpsdev-ai/flair isn't one of the packages being
  *     upgraded (or --snapshot wasn't requested and there's no data dir to
@@ -9859,15 +9870,22 @@ export function pruneOldSnapshots(
  *     to snapshot.
  *   - "snapshot": --snapshot was passed and there's data — run the real
  *     stop/snapshot/prune/restart flow, aborting the upgrade on failure.
+ *   - "engine-version-change": the engine version is changing and the operator
+ *     did not pass --no-engine-snapshot — same as "snapshot" but the message
+ *     names the reason (engine version change, not --snapshot flag).
  */
-export type UpgradeSnapshotDecision = "not-upgrading" | "nudge" | "no-data" | "snapshot";
+export type UpgradeSnapshotDecision = "not-upgrading" | "nudge" | "no-data" | "snapshot" | "engine-version-change";
 
 export function decideUpgradeSnapshotAction(
   flairIsUpgrading: boolean,
   snapshotRequested: boolean,
   hasDataDir: boolean,
+  engineVersionChanging?: boolean,
+  engineSnapshotOptOut?: boolean,
 ): UpgradeSnapshotDecision {
   if (!flairIsUpgrading) return "not-upgrading";
+  // Engine version change forces a snapshot unless explicitly opted out.
+  if (engineVersionChanging && hasDataDir && !engineSnapshotOptOut) return "engine-version-change";
   if (!snapshotRequested) return hasDataDir ? "nudge" : "not-upgrading";
   return hasDataDir ? "snapshot" : "no-data";
 }
@@ -9885,6 +9903,70 @@ export const UPGRADE_SNAPSHOT_NUDGE_LINES: readonly string[] = [
   "No pre-upgrade snapshot will be taken.",
   "To capture one first: `flair snapshot create` (physical) or `flair backup` (logical export), or re-run with --snapshot.",
 ];
+
+/**
+ * Run the stop → snapshot → prune → restart dance for a pre-upgrade snapshot.
+ * Extracted from the upgrade action so the --snapshot and engine-version-change
+ * branches share the same mechanism (flair#1047).
+ *
+ * On snapshot failure: aborts the upgrade (process.exit(1)), restarting Flair
+ * first if it was stopped. On restart-after-snapshot failure: also exits.
+ */
+async function runUpgradeSnapshot(port: number, dataDir: string): Promise<void> {
+  // Consistency: a running Harper's data dir can be mid-write, and a
+  // plain file copy of a live database directory isn't guaranteed
+  // point-in-time consistent (Harper 5.x = RocksDB: WAL/SST/MANIFEST
+  // can tear under a live copy). Stopping first — then immediately
+  // restarting the OLD version, before any package changes — gives a
+  // quiesced, safe-to-copy directory with only a brief blip, even for
+  // --no-restart (the snapshot's correctness doesn't depend on
+  // whether the caller wants a restart AFTER the upgrade — those are
+  // orthogonal). See docs/upgrade.md for the native-backup alternative
+  // considered and rejected (Harper's `get_backup` op backs up one
+  // table/schema at a time over the running HTTP API — not the whole
+  // data dir — and rejecting it here means this path never depends on
+  // the server being up).
+  let stoppedForSnapshot = false;
+  let snapshotPath: string | null = null;
+  try {
+    await stopFlairProcess(port, dataDir);
+    stoppedForSnapshot = true;
+    const snapshot = await createDataSnapshot(dataDir);
+    snapshotPath = snapshot.path;
+    const removed = pruneOldSnapshots();
+    console.log(`✅ Snapshot: ${snapshotPath} (${humanBytes(snapshot.bytes)})`);
+    console.log(`   Restore: flair snapshot restore "${snapshotPath}"`);
+    if (removed.length > 0) {
+      console.log(`   Pruned ${removed.length} older snapshot${removed.length > 1 ? "s" : ""} (keeping last ${UPGRADE_SNAPSHOT_RETAIN})`);
+    }
+  } catch (err: any) {
+    console.error(`❌ snapshot failed: ${err.message}`);
+    console.error("   Aborting upgrade — no packages were changed.");
+    if (stoppedForSnapshot) {
+      try { await startFlairProcess(port, dataDir); } catch { /* best effort — surface the original snapshot error, not this */ }
+    }
+    process.exit(1);
+  }
+  try {
+    await startFlairProcess(port, dataDir);
+  } catch (err: any) {
+    console.error(`❌ failed to restart Flair after the pre-upgrade snapshot: ${err.message}`);
+    console.error(`   The snapshot itself succeeded (${snapshotPath}) — no packages were changed. Check: flair doctor`);
+    process.exit(1);
+  }
+}
+
+/**
+ * Stamp the data directory with the currently-installed Harper engine version
+ * (flair#1047). Called after every successful boot — start, restart, upgrade.
+ * Best-effort: a failure to stamp is not a boot failure.
+ */
+function stampEngineVersionIfRunning(dataDir: string): void {
+  try {
+    const version = readInstalledHarperVersion(flairPackageDir());
+    if (version) writeEngineVersionStamp(dataDir, version);
+  } catch { /* best-effort — stamp failure must not prevent boot */ }
+}
 
 // ─── flair snapshot ─────────────────────────────────────────────────────────
 // Explicit, first-class surface for the physical data-dir snapshot mechanism
@@ -10124,6 +10206,7 @@ program
   .option("--no-restart", "Skip the restart after upgrade (stage new packages now, restart later)")
   .option("--no-verify", "Skip post-restart health/version/auth verification (default: verify — so a broken upgrade can't report success; see flair#635)")
   .option("--snapshot", "Take a pre-upgrade ~/.flair/data snapshot before the package swap, keep-last-3 retention (default: off — see `flair snapshot create` to take one by hand, or `flair backup` for a logical export; flair#637)")
+  .option("--no-engine-snapshot", "Skip the pre-upgrade snapshot even when the Harper engine version is changing (flair#1047). The snapshot is automatic on engine-version changes because the tested-downgrade guarantee does not hold across engine boundaries. Opting out prints what is being given up.")
   .option("--all", "Show transitive packages (e.g. flair-client) in the listing — verbose mode for debugging dep versions")
   // ── Fabric upgrade (--target) ────────────────────────────────────────────
   // When --target is passed, upgrade the Flair component DEPLOYED to that
@@ -10416,11 +10499,37 @@ program
     // moved from opt-out to opt-in. `flair snapshot create` (below) exposes
     // the exact same mechanism as a standalone command for anyone who wants
     // one without wrapping it around an upgrade.
+    //
+    // flair#1047: the tested-downgrade guarantee does not hold across engine
+    // version boundaries — a Harper bump is the only realistic source of a
+    // cross-version boot break. When the engine version is changing, the
+    // snapshot is unconditional. Opting out requires --no-engine-snapshot
+    // and prints what is being given up.
     const flairIsUpgrading = npmUpgrades.some((u) => u.pkg === "@tpsdev-ai/flair");
+    const hasDataDir = existsSync(upgradeDataDir);
+
+    // Determine whether the engine (Harper) version is changing.
+    let engineVersionChanging = false;
+    let currentEngineVersion: string | null = null;
+    let targetEngineVersion: string | null = null;
+    if (flairIsUpgrading && hasDataDir) {
+      currentEngineVersion = readInstalledHarperVersion(flairPackageDir());
+      const targetFlairVersion = flairFinding?.latest;
+      if (targetFlairVersion && currentEngineVersion) {
+        targetEngineVersion = await fetchDeclaredHarperVersion(targetFlairVersion);
+        engineVersionChanging = targetEngineVersion !== null && targetEngineVersion !== currentEngineVersion;
+      } else {
+        // Cannot determine — assume it might change (safe default).
+        engineVersionChanging = true;
+      }
+    }
+
     const snapshotDecision = decideUpgradeSnapshotAction(
       flairIsUpgrading,
       !!opts.snapshot,
-      existsSync(upgradeDataDir),
+      hasDataDir,
+      engineVersionChanging,
+      !!opts.noEngineSnapshot,
     );
     let snapshotPath: string | null = null;
     if (snapshotDecision === "nudge") {
@@ -10433,48 +10542,19 @@ program
       for (const line of UPGRADE_SNAPSHOT_NUDGE_LINES) console.log(render.wrap(render.c.dim, line));
     } else if (snapshotDecision === "no-data") {
       console.log(`\n(no data directory at ${upgradeDataDir} yet — nothing to snapshot)`);
+    } else if (snapshotDecision === "engine-version-change") {
+      // Engine version is changing — snapshot is unconditional (flair#1047).
+      // The operator can opt out with --no-engine-snapshot, which prints what
+      // is being given up (handled in the nudge branch above).
+      const fromLabel = currentEngineVersion ?? "unknown";
+      const toLabel = targetEngineVersion ?? "unknown";
+      console.log(`\nHarper engine version changing (${fromLabel} → ${toLabel}) — snapshotting data before upgrade...`);
+      console.log(render.wrap(render.c.dim, "The tested-downgrade guarantee does not hold across engine version boundaries."));
+      console.log(render.wrap(render.c.dim, "Pass --no-engine-snapshot to skip this (not recommended)."));
+      await runUpgradeSnapshot(upgradePort, upgradeDataDir);
     } else if (snapshotDecision === "snapshot") {
       console.log("\nSnapshotting data before upgrade...");
-      // Consistency: a running Harper's data dir can be mid-write, and a
-      // plain file copy of a live database directory isn't guaranteed
-      // point-in-time consistent (Harper 5.x = RocksDB: WAL/SST/MANIFEST
-      // can tear under a live copy). Stopping first — then immediately
-      // restarting the OLD version, before any package changes — gives a
-      // quiesced, safe-to-copy directory with only a brief blip, even for
-      // --no-restart (the snapshot's correctness doesn't depend on
-      // whether the caller wants a restart AFTER the upgrade — those are
-      // orthogonal). See docs/upgrade.md for the native-backup alternative
-      // considered and rejected (Harper's `get_backup` op backs up one
-      // table/schema at a time over the running HTTP API — not the whole
-      // data dir — and rejecting it here means this path never depends on
-      // the server being up).
-      let stoppedForSnapshot = false;
-      try {
-        await stopFlairProcess(upgradePort, upgradeDataDir);
-        stoppedForSnapshot = true;
-        const snapshot = await createDataSnapshot(upgradeDataDir);
-        snapshotPath = snapshot.path;
-        const removed = pruneOldSnapshots();
-        console.log(`✅ Snapshot: ${snapshotPath} (${humanBytes(snapshot.bytes)})`);
-        console.log(`   Restore: flair snapshot restore "${snapshotPath}"`);
-        if (removed.length > 0) {
-          console.log(`   Pruned ${removed.length} older snapshot${removed.length > 1 ? "s" : ""} (keeping last ${UPGRADE_SNAPSHOT_RETAIN})`);
-        }
-      } catch (err: any) {
-        console.error(`❌ snapshot failed: ${err.message}`);
-        console.error("   Aborting upgrade — no packages were changed. Omit --snapshot to proceed without one (not recommended).");
-        if (stoppedForSnapshot) {
-          try { await startFlairProcess(upgradePort, upgradeDataDir); } catch { /* best effort — surface the original snapshot error, not this */ }
-        }
-        process.exit(1);
-      }
-      try {
-        await startFlairProcess(upgradePort, upgradeDataDir);
-      } catch (err: any) {
-        console.error(`❌ failed to restart Flair after the pre-upgrade snapshot: ${err.message}`);
-        console.error(`   The snapshot itself succeeded (${snapshotPath}) — no packages were changed. Check: flair doctor`);
-        process.exit(1);
-      }
+      await runUpgradeSnapshot(upgradePort, upgradeDataDir);
     }
 
     // Perform upgrade. `latest` comes from the npm registry's HTTP
@@ -10844,6 +10924,17 @@ program
       process.exit(1);
     }
 
+    // flair#1047: refuse to boot if the store was written by a newer engine.
+    const runningHarperVersion = readInstalledHarperVersion(flairPackageDir());
+    if (runningHarperVersion) {
+      const backwardsError = checkEngineVersionBackwards(dataDir, runningHarperVersion);
+      if (backwardsError) {
+        console.error(`❌ Cannot start Flair — the data directory was written by a newer Harper engine.\n`);
+        console.error(backwardsError);
+        process.exit(1);
+      }
+    }
+
     const platform = process.platform;
     if (platform === "darwin") {
       // resolveLaunchdLabel (flair#693) finds whichever label this data
@@ -10865,6 +10956,7 @@ program
           if (migrated) console.log(`Migrated launchd service off the legacy label (${LEGACY_LAUNCHD_LABEL}) → ${label} ✓`);
           await waitForHealth(port, DEFAULT_ADMIN_USER, process.env.HDB_ADMIN_PASSWORD ?? "", STARTUP_TIMEOUT_MS);
           readyOpsSocketPosture(dataDir); // flair#763: re-assert socket posture on the freshly-created socket
+          stampEngineVersionIfRunning(dataDir); // flair#1047: stamp the store with the engine version
           console.log("✅ Flair started (launchd)");
           return;
         } catch (err: any) {
@@ -10908,6 +11000,7 @@ program
     try {
       await waitForHealth(port, DEFAULT_ADMIN_USER, adminPass, STARTUP_TIMEOUT_MS);
       readyOpsSocketPosture(dataDir); // flair#763: re-assert socket posture on the freshly-created socket
+      stampEngineVersionIfRunning(dataDir); // flair#1047: stamp the store with the engine version
       console.log(`✅ Flair started on port ${port}`);
     } catch {
       console.error("❌ Flair failed to start within timeout. Check logs in " + join(dataDir, "harper.log"));
@@ -11255,6 +11348,7 @@ async function startFlairProcess(port: number, dataDir: string): Promise<void> {
         ensureLaunchdServiceLoaded(dataDir, (cmd) => execSync(cmd, { stdio: "pipe" }));
         await waitForHealth(port, DEFAULT_ADMIN_USER, process.env.HDB_ADMIN_PASSWORD ?? "", STARTUP_TIMEOUT_MS);
         readyOpsSocketPosture(dataDir); // flair#763: re-assert socket posture across restart/upgrade
+        stampEngineVersionIfRunning(dataDir); // flair#1047: stamp the store with the engine version
         return;
       } catch (err: any) {
         console.error(`launchd start failed, falling back to direct start: ${err.message}`);
@@ -11305,6 +11399,7 @@ async function startFlairProcess(port: number, dataDir: string): Promise<void> {
 
   await waitForHealth(port, DEFAULT_ADMIN_USER, adminPass, STARTUP_TIMEOUT_MS);
   readyOpsSocketPosture(dataDir); // flair#763: re-assert socket posture across restart/upgrade
+  stampEngineVersionIfRunning(dataDir); // flair#1047: stamp the store with the engine version
 }
 
 /**

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -10507,6 +10507,7 @@ program
     // and prints what is being given up.
     const flairIsUpgrading = npmUpgrades.some((u) => u.pkg === "@tpsdev-ai/flair");
     const hasDataDir = existsSync(upgradeDataDir);
+    const flairFinding = findings.find((f) => f.name === "@tpsdev-ai/flair");
 
     // Determine whether the engine (Harper) version is changing.
     let engineVersionChanging = false;
@@ -10517,7 +10518,15 @@ program
       const targetFlairVersion = flairFinding?.latest;
       if (targetFlairVersion && currentEngineVersion) {
         targetEngineVersion = await fetchDeclaredHarperVersion(targetFlairVersion);
-        engineVersionChanging = targetEngineVersion !== null && targetEngineVersion !== currentEngineVersion;
+        if (targetEngineVersion === null) {
+          // Registry lookup failed — cannot determine the target Harper
+          // version. Assume it might change (safe default) and print why.
+          engineVersionChanging = true;
+          console.log(render.wrap(render.c.dim,
+            `Could not determine the target Harper version from the npm registry — forcing a pre-upgrade snapshot as a precaution.`));
+        } else {
+          engineVersionChanging = targetEngineVersion !== currentEngineVersion;
+        }
       } else {
         // Cannot determine — assume it might change (safe default).
         engineVersionChanging = true;
@@ -10604,7 +10613,6 @@ program
     // --restart is kept as a deprecated no-op for old muscle memory.
     // Upgrade = install → restart → verify → (rollback on failure), one
     // transaction — never report success on a broken restart.
-    const flairFinding = findings.find((f) => f.name === "@tpsdev-ai/flair");
     const previousFlairVersion = flairFinding?.installed ?? null;
     const expectedFlairVersion =
       flairFinding?.status === "outdated" && !flairInstallFailed

--- a/src/engine-version.ts
+++ b/src/engine-version.ts
@@ -1,0 +1,125 @@
+// engine-version.ts — Harper engine version tracking (flair#1047)
+//
+// Two concerns, one module:
+//
+// 1. STORE STAMP — flair records the engine version that last wrote the data
+//    directory. At boot, if the store was written by a NEWER engine than the
+//    one running, flair refuses to start and says so: which version wrote the
+//    store, which is running now, and what to do about it.
+//
+// 2. VERSION READ — read the Harper version installed alongside this flair
+//    package, and (when a target flair version is known) the Harper version
+//    that target declares. Used by the upgrade path to decide whether the
+//    engine version is changing and a pre-upgrade snapshot is therefore
+//    mandatory.
+//
+// The stamp is a single-line file in the data directory. It must survive the
+// data directory being moved and must not require a Harper query to read — if
+// the engine cannot boot, we still need to read it.
+
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+/** Filename of the engine-version stamp inside the data directory. */
+export const ENGINE_VERSION_STAMP = "engine-version.txt";
+
+/** Read the Harper version installed alongside this flair package. */
+export function readInstalledHarperVersion(packageRoot: string): string | null {
+  for (const name of ["harper", "@harperfast/harper"]) {
+    const pkgPath = join(packageRoot, "node_modules", ...name.split("/"), "package.json");
+    if (!existsSync(pkgPath)) continue;
+    try {
+      const pkg = JSON.parse(readFileSync(pkgPath, "utf-8")) as { version?: string };
+      if (pkg.version) return pkg.version;
+    } catch {
+      continue;
+    }
+  }
+  return null;
+}
+
+/**
+ * Fetch the Harper version that a given @tpsdev-ai/flair version declares as
+ * a dependency. Returns null when the lookup fails (network, unparseable, etc.)
+ * — callers treat null as "cannot determine, assume it might change."
+ */
+export async function fetchDeclaredHarperVersion(flairVersion: string): Promise<string | null> {
+  try {
+    const res = await fetch(
+      `https://registry.npmjs.org/@tpsdev-ai/flair/${flairVersion}`,
+      { signal: AbortSignal.timeout(5000) },
+    );
+    if (!res.ok) return null;
+    const data = await res.json() as { dependencies?: Record<string, string> };
+    return data.dependencies?.harper ?? data.dependencies?.["@harperfast/harper"] ?? null;
+  } catch {
+    return null;
+  }
+}
+
+// ─── Store stamp ─────────────────────────────────────────────────────────────
+
+/** Write the engine version stamp into the data directory. */
+export function writeEngineVersionStamp(dataDir: string, version: string): void {
+  writeFileSync(join(dataDir, ENGINE_VERSION_STAMP), `${version}\n`, "utf-8");
+}
+
+/** Read the engine version stamp from the data directory, or null if absent. */
+export function readEngineVersionStamp(dataDir: string): string | null {
+  const stampPath = join(dataDir, ENGINE_VERSION_STAMP);
+  if (!existsSync(stampPath)) return null;
+  try {
+    return readFileSync(stampPath, "utf-8").trim() || null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Check whether the running engine is OLDER than the engine that last wrote
+ * the store. Returns null when the check passes (no stamp, or stamp ≤ running),
+ * or an error message when the store is newer.
+ *
+ * The error must be actionable: actor, state, remedy.
+ */
+export function checkEngineVersionBackwards(
+  dataDir: string,
+  runningVersion: string,
+): string | null {
+  const stamp = readEngineVersionStamp(dataDir);
+  if (!stamp) return null; // no stamp — nothing to compare (pre-stamp install)
+
+  // Simple semver comparison: split on dots, compare numerically.
+  // This is deliberately NOT a full semver parse — the stamp and the running
+  // version both come from package.json `version` fields, which are always
+  // semver strings. A full semver library would handle pre-release tags
+  // correctly, but the failure mode of a naive compare (treating "5.2.0-rc1"
+  // as newer than "5.2.0") is a false REFUSAL — safe direction.
+  const stampParts = stamp.split(".").map(Number);
+  const runningParts = runningVersion.split(".").map(Number);
+  const len = Math.max(stampParts.length, runningParts.length);
+  for (let i = 0; i < len; i++) {
+    const s = stampParts[i] ?? 0;
+    const r = runningParts[i] ?? 0;
+    if (r < s) {
+      return [
+        `This Flair install is running Harper ${runningVersion}, but the data directory at`,
+        `  ${dataDir}`,
+        `was last written by Harper ${stamp} — a newer engine version.`,
+        ``,
+        `An older Harper cannot safely read a store written by a newer one.`,
+        `The data may appear intact but can be silently unreadable.`,
+        ``,
+        `To recover:`,
+        `  1. Reinstall the newer version:  npm install -g @tpsdev-ai/flair@latest`,
+        `  2. Or restore from a pre-upgrade snapshot:`,
+        `     flair snapshot restore ~/.flair/upgrade-snapshots/flair-data-<timestamp>.tar.gz`,
+        ``,
+        `This check only helps from the release that ships it onward — it cannot`,
+        `rescue a downgrade to a build that predates the stamp.`,
+      ].join("\n");
+    }
+    if (r > s) break; // running is newer — allowed
+  }
+  return null;
+}

--- a/src/engine-version.ts
+++ b/src/engine-version.ts
@@ -89,20 +89,23 @@ export function checkEngineVersionBackwards(
   const stamp = readEngineVersionStamp(dataDir);
   if (!stamp) return null; // no stamp — nothing to compare (pre-stamp install)
 
-  // Simple semver comparison: split on dots, compare numerically.
-  // This is deliberately NOT a full semver parse — the stamp and the running
-  // version both come from package.json `version` fields, which are always
-  // semver strings. A full semver library would handle pre-release tags
-  // correctly, but the failure mode of a naive compare (treating "5.2.0-rc1"
-  // as newer than "5.2.0") is a false REFUSAL — safe direction.
-  //
-  // However, Number("0-rc1") is NaN, and NaN < x / NaN > x are both false,
-  // so a pre-release segment on EITHER side would fall through every branch
-  // and return ALLOW. That is a false ALLOW — unsafe. An unparseable segment
-  // on either side must refuse.
-  const stampParts = stamp.split(".").map(Number);
-  const runningParts = runningVersion.split(".").map(Number);
-  if (stampParts.some(isNaN) || runningParts.some(isNaN)) {
+  const parsed = compareVersions(stamp, runningVersion);
+  if (parsed === null) {
+    // Genuinely unparseable — cannot determine ordering. Refuse with a
+    // message that does NOT claim one is newer than the other.
+    return [
+      `This Flair install is running Harper ${runningVersion}, but the data directory at`,
+      `  ${dataDir}`,
+      `was last written by Harper ${stamp}.`,
+      ``,
+      `The engine version stamp could not be compared to the running version.`,
+      `An older Harper cannot safely read a store written by a newer one.`,
+      ``,
+      ...RECOVERY_LINES,
+    ].join("\n");
+  }
+  if (parsed > 0) {
+    // stamp > running — backwards boot, refuse.
     return [
       `This Flair install is running Harper ${runningVersion}, but the data directory at`,
       `  ${dataDir}`,
@@ -111,38 +114,92 @@ export function checkEngineVersionBackwards(
       `An older Harper cannot safely read a store written by a newer one.`,
       `The data may appear intact but can be silently unreadable.`,
       ``,
-      `To recover:`,
-      `  1. Reinstall the newer version:  npm install -g @tpsdev-ai/flair@latest`,
-      `  2. Or restore from a pre-upgrade snapshot:`,
-      `     flair snapshot restore ~/.flair/upgrade-snapshots/flair-data-<timestamp>.tar.gz`,
-      ``,
-      `This check only helps from the release that ships it onward — it cannot`,
-      `rescue a downgrade to a build that predates the stamp.`,
+      ...RECOVERY_LINES,
     ].join("\n");
   }
-  const len = Math.max(stampParts.length, runningParts.length);
-  for (let i = 0; i < len; i++) {
-    const s = stampParts[i] ?? 0;
-    const r = runningParts[i] ?? 0;
-    if (r < s) {
-      return [
-        `This Flair install is running Harper ${runningVersion}, but the data directory at`,
-        `  ${dataDir}`,
-        `was last written by Harper ${stamp} — a newer engine version.`,
-        ``,
-        `An older Harper cannot safely read a store written by a newer one.`,
-        `The data may appear intact but can be silently unreadable.`,
-        ``,
-        `To recover:`,
-        `  1. Reinstall the newer version:  npm install -g @tpsdev-ai/flair@latest`,
-        `  2. Or restore from a pre-upgrade snapshot:`,
-        `     flair snapshot restore ~/.flair/upgrade-snapshots/flair-data-<timestamp>.tar.gz`,
-        ``,
-        `This check only helps from the release that ships it onward — it cannot`,
-        `rescue a downgrade to a build that predates the stamp.`,
-      ].join("\n");
-    }
-    if (r > s) break; // running is newer — allowed
-  }
-  return null;
+  return null; // running >= stamp — allowed
 }
+
+// ─── Version comparison (flair#1047) ─────────────────────────────────────────
+
+/**
+ * Compare two semver-like version strings.
+ * Returns negative when a < b, positive when a > b, zero when equal,
+ * or null when either version is genuinely unparseable (not N.N.N at all).
+ *
+ * Pre-release ordering follows semver: a version WITH a pre-release tag is
+ * LOWER than the same core without one (5.2.0-rc1 < 5.2.0). When both have
+ * pre-releases, identifiers are compared dot by dot — numeric parts
+ * numerically, the rest as strings.
+ */
+function compareVersions(a: string, b: string): number | null {
+  const pa = parseVersion(a);
+  const pb = parseVersion(b);
+  if (!pa || !pb) return null;
+
+  // Compare major.minor.patch (and any additional numeric components) numerically.
+  const coreLen = Math.max(pa.core.length, pb.core.length);
+  for (let i = 0; i < coreLen; i++) {
+    const ac = pa.core[i] ?? 0;
+    const bc = pb.core[i] ?? 0;
+    if (ac !== bc) return ac - bc;
+  }
+
+  // Cores are equal — compare pre-release tags.
+  if (pa.pre === null && pb.pre === null) return 0;
+  if (pa.pre === null) return 1;  // a has no pre-release → a > b
+  if (pb.pre === null) return -1; // b has no pre-release → a < b
+
+  // Both have pre-releases — compare identifiers dot by dot.
+  const len = Math.max(pa.pre.length, pb.pre.length);
+  for (let i = 0; i < len; i++) {
+    const ai = pa.pre[i];
+    const bi = pb.pre[i];
+    if (ai === undefined) return -1; // fewer identifiers → lower
+    if (bi === undefined) return 1;
+    const an = Number(ai);
+    const bn = Number(bi);
+    const aIsNum = !isNaN(an);
+    const bIsNum = !isNaN(bn);
+    if (aIsNum && bIsNum) {
+      if (an !== bn) return an - bn;
+    } else if (aIsNum) {
+      return -1; // numeric < string
+    } else if (bIsNum) {
+      return 1;
+    } else {
+      if (ai !== bi) return ai < bi ? -1 : 1;
+    }
+  }
+  return 0;
+}
+
+interface ParsedVersion {
+  core: number[];
+  pre: string[] | null; // null = no pre-release (release version)
+}
+
+function parseVersion(v: string): ParsedVersion | null {
+  // Split off pre-release: everything after the first hyphen.
+  const hyphenIdx = v.indexOf("-");
+  const coreStr = hyphenIdx === -1 ? v : v.slice(0, hyphenIdx);
+  const preStr = hyphenIdx === -1 ? null : v.slice(hyphenIdx + 1);
+
+  const coreParts = coreStr.split(".");
+  if (coreParts.length < 3) return null; // not at least N.N.N
+  const core = coreParts.map(Number);
+  if (core.some(isNaN)) return null; // non-numeric core component
+
+  const pre = preStr ? preStr.split(".") : null;
+  return { core, pre };
+}
+
+const RECOVERY_LINES = [
+  `To recover:`,
+  `  1. Reinstall the newer version:  npm install -g @tpsdev-ai/flair@latest`,
+  `  2. Or restore from a pre-upgrade snapshot:`,
+  `     flair snapshot restore ~/.flair/upgrade-snapshots/flair-data-<timestamp>.tar.gz`,
+  ``,
+  `This check only helps from the release that ships it onward — it cannot`,
+  `rescue a downgrade to a build that predates the stamp.`,
+];

--- a/src/engine-version.ts
+++ b/src/engine-version.ts
@@ -95,8 +95,31 @@ export function checkEngineVersionBackwards(
   // semver strings. A full semver library would handle pre-release tags
   // correctly, but the failure mode of a naive compare (treating "5.2.0-rc1"
   // as newer than "5.2.0") is a false REFUSAL — safe direction.
+  //
+  // However, Number("0-rc1") is NaN, and NaN < x / NaN > x are both false,
+  // so a pre-release segment on EITHER side would fall through every branch
+  // and return ALLOW. That is a false ALLOW — unsafe. An unparseable segment
+  // on either side must refuse.
   const stampParts = stamp.split(".").map(Number);
   const runningParts = runningVersion.split(".").map(Number);
+  if (stampParts.some(isNaN) || runningParts.some(isNaN)) {
+    return [
+      `This Flair install is running Harper ${runningVersion}, but the data directory at`,
+      `  ${dataDir}`,
+      `was last written by Harper ${stamp} — a newer engine version.`,
+      ``,
+      `An older Harper cannot safely read a store written by a newer one.`,
+      `The data may appear intact but can be silently unreadable.`,
+      ``,
+      `To recover:`,
+      `  1. Reinstall the newer version:  npm install -g @tpsdev-ai/flair@latest`,
+      `  2. Or restore from a pre-upgrade snapshot:`,
+      `     flair snapshot restore ~/.flair/upgrade-snapshots/flair-data-<timestamp>.tar.gz`,
+      ``,
+      `This check only helps from the release that ships it onward — it cannot`,
+      `rescue a downgrade to a build that predates the stamp.`,
+    ].join("\n");
+  }
   const len = Math.max(stampParts.length, runningParts.length);
   for (let i = 0; i < len; i++) {
     const s = stampParts[i] ?? 0;

--- a/test/unit/engine-version.test.ts
+++ b/test/unit/engine-version.test.ts
@@ -1,0 +1,157 @@
+// test/unit/engine-version.test.ts — unit tests for engine version tracking (flair#1047)
+
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import {
+  ENGINE_VERSION_STAMP,
+  readInstalledHarperVersion,
+  writeEngineVersionStamp,
+  readEngineVersionStamp,
+  checkEngineVersionBackwards,
+} from "../../src/engine-version.js";
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+let tmpRoot: string;
+beforeEach(() => {
+  tmpRoot = join(tmpdir(), `flair-engine-version-test-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`);
+  mkdirSync(tmpRoot, { recursive: true });
+});
+afterEach(() => {
+  try { rmSync(tmpRoot, { recursive: true, force: true }); } catch { /* best-effort */ }
+});
+
+function makeHarperPkg(dir: string, version: string): void {
+  const nodeModules = join(dir, "node_modules", "harper");
+  mkdirSync(nodeModules, { recursive: true });
+  writeFileSync(join(nodeModules, "package.json"), JSON.stringify({ name: "harper", version }), "utf-8");
+}
+
+// ─── readInstalledHarperVersion ─────────────────────────────────────────────
+
+describe("readInstalledHarperVersion", () => {
+  it("reads the version from node_modules/harper/package.json", () => {
+    makeHarperPkg(tmpRoot, "5.1.22");
+    expect(readInstalledHarperVersion(tmpRoot)).toBe("5.1.22");
+  });
+
+  it("reads from @harperfast/harper when harper is absent", () => {
+    const nodeModules = join(tmpRoot, "node_modules", "@harperfast", "harper");
+    mkdirSync(nodeModules, { recursive: true });
+    writeFileSync(join(nodeModules, "package.json"), JSON.stringify({ name: "@harperfast/harper", version: "5.2.0" }), "utf-8");
+    expect(readInstalledHarperVersion(tmpRoot)).toBe("5.2.0");
+  });
+
+  it("prefers harper over @harperfast/harper when both exist", () => {
+    makeHarperPkg(tmpRoot, "5.1.22");
+    const alt = join(tmpRoot, "node_modules", "@harperfast", "harper");
+    mkdirSync(alt, { recursive: true });
+    writeFileSync(join(alt, "package.json"), JSON.stringify({ name: "@harperfast/harper", version: "5.2.0" }), "utf-8");
+    expect(readInstalledHarperVersion(tmpRoot)).toBe("5.1.22");
+  });
+
+  it("returns null when no harper package is installed", () => {
+    expect(readInstalledHarperVersion(tmpRoot)).toBeNull();
+  });
+
+  it("returns null when the package.json is unparseable", () => {
+    const nodeModules = join(tmpRoot, "node_modules", "harper");
+    mkdirSync(nodeModules, { recursive: true });
+    writeFileSync(join(nodeModules, "package.json"), "not json", "utf-8");
+    expect(readInstalledHarperVersion(tmpRoot)).toBeNull();
+  });
+
+  it("returns null when the package.json has no version field", () => {
+    const nodeModules = join(tmpRoot, "node_modules", "harper");
+    mkdirSync(nodeModules, { recursive: true });
+    writeFileSync(join(nodeModules, "package.json"), JSON.stringify({ name: "harper" }), "utf-8");
+    expect(readInstalledHarperVersion(tmpRoot)).toBeNull();
+  });
+});
+
+// ─── writeEngineVersionStamp / readEngineVersionStamp ───────────────────────
+
+describe("engine version stamp", () => {
+  it("writes and reads the stamp", () => {
+    writeEngineVersionStamp(tmpRoot, "5.1.22");
+    expect(readEngineVersionStamp(tmpRoot)).toBe("5.1.22");
+  });
+
+  it("returns null when no stamp exists", () => {
+    expect(readEngineVersionStamp(tmpRoot)).toBeNull();
+  });
+
+  it("returns null when the stamp file is empty", () => {
+    writeFileSync(join(tmpRoot, ENGINE_VERSION_STAMP), "", "utf-8");
+    expect(readEngineVersionStamp(tmpRoot)).toBeNull();
+  });
+
+  it("returns null when the stamp file is whitespace-only", () => {
+    writeFileSync(join(tmpRoot, ENGINE_VERSION_STAMP), "  \n  ", "utf-8");
+    expect(readEngineVersionStamp(tmpRoot)).toBeNull();
+  });
+
+  it("writes the stamp file in the data directory", () => {
+    writeEngineVersionStamp(tmpRoot, "5.2.0");
+    const stampPath = join(tmpRoot, ENGINE_VERSION_STAMP);
+    expect(existsSync(stampPath)).toBe(true);
+    expect(readFileSync(stampPath, "utf-8").trim()).toBe("5.2.0");
+  });
+});
+
+// ─── checkEngineVersionBackwards ────────────────────────────────────────────
+
+describe("checkEngineVersionBackwards", () => {
+  it("returns null when no stamp exists (pre-stamp install)", () => {
+    expect(checkEngineVersionBackwards(tmpRoot, "5.1.22")).toBeNull();
+  });
+
+  it("returns null when the running version equals the stamp", () => {
+    writeEngineVersionStamp(tmpRoot, "5.1.22");
+    expect(checkEngineVersionBackwards(tmpRoot, "5.1.22")).toBeNull();
+  });
+
+  it("returns null when the running version is newer than the stamp", () => {
+    writeEngineVersionStamp(tmpRoot, "5.1.22");
+    expect(checkEngineVersionBackwards(tmpRoot, "5.2.0")).toBeNull();
+  });
+
+  it("returns an error when the running version is older than the stamp", () => {
+    writeEngineVersionStamp(tmpRoot, "5.2.0");
+    const err = checkEngineVersionBackwards(tmpRoot, "5.1.22");
+    expect(err).not.toBeNull();
+    expect(err!).toContain("5.2.0"); // stamp version
+    expect(err!).toContain("5.1.22"); // running version
+    expect(err!).toContain(tmpRoot); // data directory path
+    // Must contain a remedy
+    expect(err!).toMatch(/reinstall|restore|snapshot/i);
+  });
+
+  it("handles multi-digit version components correctly", () => {
+    writeEngineVersionStamp(tmpRoot, "5.10.0");
+    // 5.9.0 < 5.10.0 — numeric compare, not string compare
+    const err = checkEngineVersionBackwards(tmpRoot, "5.9.0");
+    expect(err).not.toBeNull();
+    expect(err!).toContain("5.10.0");
+    expect(err!).toContain("5.9.0");
+  });
+
+  it("handles different-length version strings (stamp has more components)", () => {
+    writeEngineVersionStamp(tmpRoot, "5.2.0.1");
+    const err = checkEngineVersionBackwards(tmpRoot, "5.2.0");
+    expect(err).not.toBeNull();
+  });
+
+  it("handles different-length version strings (running has more components)", () => {
+    writeEngineVersionStamp(tmpRoot, "5.2.0");
+    expect(checkEngineVersionBackwards(tmpRoot, "5.2.0.1")).toBeNull();
+  });
+
+  it("returns null when the stamp file is unreadable", () => {
+    // Create a directory where the stamp file should be — can't read a dir as a file
+    mkdirSync(join(tmpRoot, ENGINE_VERSION_STAMP), { recursive: true });
+    expect(checkEngineVersionBackwards(tmpRoot, "5.1.22")).toBeNull();
+  });
+});

--- a/test/unit/engine-version.test.ts
+++ b/test/unit/engine-version.test.ts
@@ -154,4 +154,39 @@ describe("checkEngineVersionBackwards", () => {
     mkdirSync(join(tmpRoot, ENGINE_VERSION_STAMP), { recursive: true });
     expect(checkEngineVersionBackwards(tmpRoot, "5.1.22")).toBeNull();
   });
+
+  // ── flair#1047: pre-release versions must refuse, not allow ────────────
+  // Number("0-rc1") is NaN, and NaN < x / NaN > x are both false, so a
+  // pre-release segment on either side would fall through every branch and
+  // return ALLOW. That is a false ALLOW — unsafe.
+
+  it("refuses when the stamp contains a pre-release segment (e.g. 5.2.0-beta.4)", () => {
+    writeEngineVersionStamp(tmpRoot, "5.2.0-beta.4");
+    const err = checkEngineVersionBackwards(tmpRoot, "5.1.22");
+    expect(err).not.toBeNull();
+    expect(err!).toContain("5.2.0-beta.4");
+    expect(err!).toContain("5.1.22");
+  });
+
+  it("refuses when the running version contains a pre-release segment (e.g. 5.2.0-rc1)", () => {
+    writeEngineVersionStamp(tmpRoot, "5.2.1");
+    const err = checkEngineVersionBackwards(tmpRoot, "5.2.0-rc1");
+    expect(err).not.toBeNull();
+    expect(err!).toContain("5.2.1");
+    expect(err!).toContain("5.2.0-rc1");
+  });
+
+  it("refuses when both versions contain pre-release segments", () => {
+    writeEngineVersionStamp(tmpRoot, "5.2.0-beta.4");
+    const err = checkEngineVersionBackwards(tmpRoot, "5.2.0-rc1");
+    expect(err).not.toBeNull();
+  });
+
+  it("refuses when the stamp has a pre-release and running is a plain release (stamp 5.2.0-rc1 vs running 5.2.0)", () => {
+    // This is the exact scenario flint reproduced: stamp 5.2.1, running 5.2.0-rc1
+    // returned ALLOW because Number("0-rc1") is NaN.
+    writeEngineVersionStamp(tmpRoot, "5.2.1");
+    const err = checkEngineVersionBackwards(tmpRoot, "5.2.0-rc1");
+    expect(err).not.toBeNull();
+  });
 });

--- a/test/unit/engine-version.test.ts
+++ b/test/unit/engine-version.test.ts
@@ -155,20 +155,37 @@ describe("checkEngineVersionBackwards", () => {
     expect(checkEngineVersionBackwards(tmpRoot, "5.1.22")).toBeNull();
   });
 
-  // ── flair#1047: pre-release versions must refuse, not allow ────────────
-  // Number("0-rc1") is NaN, and NaN < x / NaN > x are both false, so a
-  // pre-release segment on either side would fall through every branch and
-  // return ALLOW. That is a false ALLOW — unsafe.
+  // ── flair#1047: pre-release version ordering ──────────────────────────
+  // Pre-releases must be ordered correctly, not blanket-refused.
+  // A version WITH a pre-release is LOWER than the same core without one.
+  // Harper published 5.2.0-beta.4 on 2026-07-31 and 5.2.0 on 2026-08-01 —
+  // anyone who ran the beta must be able to start the release.
 
-  it("refuses when the stamp contains a pre-release segment (e.g. 5.2.0-beta.4)", () => {
+  it("allows beta → release: stamp 5.2.0-beta.4, running 5.2.0", () => {
     writeEngineVersionStamp(tmpRoot, "5.2.0-beta.4");
-    const err = checkEngineVersionBackwards(tmpRoot, "5.1.22");
-    expect(err).not.toBeNull();
-    expect(err!).toContain("5.2.0-beta.4");
-    expect(err!).toContain("5.1.22");
+    expect(checkEngineVersionBackwards(tmpRoot, "5.2.0")).toBeNull();
   });
 
-  it("refuses when the running version contains a pre-release segment (e.g. 5.2.0-rc1)", () => {
+  it("allows rc → release: stamp 5.2.0-rc1, running 5.2.0", () => {
+    writeEngineVersionStamp(tmpRoot, "5.2.0-rc1");
+    expect(checkEngineVersionBackwards(tmpRoot, "5.2.0")).toBeNull();
+  });
+
+  it("allows earlier pre-release → later pre-release: stamp 5.2.0-beta.4, running 5.2.0-rc1", () => {
+    writeEngineVersionStamp(tmpRoot, "5.2.0-beta.4");
+    expect(checkEngineVersionBackwards(tmpRoot, "5.2.0-rc1")).toBeNull();
+  });
+
+  it("refuses release → pre-release: stamp 5.2.0, running 5.2.0-rc1", () => {
+    // Same core, but stamp has no pre-release → stamp is newer.
+    writeEngineVersionStamp(tmpRoot, "5.2.0");
+    const err = checkEngineVersionBackwards(tmpRoot, "5.2.0-rc1");
+    expect(err).not.toBeNull();
+    expect(err!).toContain("5.2.0");
+    expect(err!).toContain("5.2.0-rc1");
+  });
+
+  it("refuses when the stamp core is newer regardless of pre-release (stamp 5.2.1, running 5.2.0-rc1)", () => {
     writeEngineVersionStamp(tmpRoot, "5.2.1");
     const err = checkEngineVersionBackwards(tmpRoot, "5.2.0-rc1");
     expect(err).not.toBeNull();
@@ -176,17 +193,30 @@ describe("checkEngineVersionBackwards", () => {
     expect(err!).toContain("5.2.0-rc1");
   });
 
-  it("refuses when both versions contain pre-release segments", () => {
+  it("refuses when the stamp has a pre-release but the core is newer (stamp 5.2.0-beta.4, running 5.1.22)", () => {
     writeEngineVersionStamp(tmpRoot, "5.2.0-beta.4");
-    const err = checkEngineVersionBackwards(tmpRoot, "5.2.0-rc1");
+    const err = checkEngineVersionBackwards(tmpRoot, "5.1.22");
     expect(err).not.toBeNull();
+    expect(err!).toContain("5.2.0-beta.4");
+    expect(err!).toContain("5.1.22");
   });
 
-  it("refuses when the stamp has a pre-release and running is a plain release (stamp 5.2.0-rc1 vs running 5.2.0)", () => {
-    // This is the exact scenario flint reproduced: stamp 5.2.1, running 5.2.0-rc1
-    // returned ALLOW because Number("0-rc1") is NaN.
-    writeEngineVersionStamp(tmpRoot, "5.2.1");
-    const err = checkEngineVersionBackwards(tmpRoot, "5.2.0-rc1");
+  // ── Genuinely unparseable input ────────────────────────────────────────
+
+  it("refuses with its own message when the stamp is not N.N.N (does not claim ordering)", () => {
+    writeEngineVersionStamp(tmpRoot, "not-a-version");
+    const err = checkEngineVersionBackwards(tmpRoot, "5.1.22");
     expect(err).not.toBeNull();
+    // Must NOT claim "newer engine version" — we didn't determine ordering.
+    expect(err!).not.toContain("newer engine version");
+    expect(err!).toContain("could not be compared");
+  });
+
+  it("refuses with its own message when the running version is not N.N.N", () => {
+    writeEngineVersionStamp(tmpRoot, "5.1.22");
+    const err = checkEngineVersionBackwards(tmpRoot, "garbage");
+    expect(err).not.toBeNull();
+    expect(err!).not.toContain("newer engine version");
+    expect(err!).toContain("could not be compared");
   });
 });

--- a/test/unit/upgrade-data-snapshot.test.ts
+++ b/test/unit/upgrade-data-snapshot.test.ts
@@ -277,6 +277,34 @@ describe("decideUpgradeSnapshotAction — opt-in gating (2026-07-08 rewrite)", (
   test("opt-in with nothing to snapshot: upgrading, --snapshot passed, no data dir yet → no-data (not an abort)", () => {
     expect(decideUpgradeSnapshotAction(true, true, false)).toBe("no-data");
   });
+
+  // ── flair#1047: engine-version-change forces snapshot ──────────────────
+
+  test("engine version changing, no opt-out, data exists → engine-version-change (forced snapshot)", () => {
+    expect(decideUpgradeSnapshotAction(true, false, true, true, false)).toBe("engine-version-change");
+  });
+
+  test("engine version changing, no opt-out, no data dir → not-upgrading (nothing to snapshot)", () => {
+    expect(decideUpgradeSnapshotAction(true, false, false, true, false)).toBe("not-upgrading");
+  });
+
+  test("engine version changing, --no-engine-snapshot opt-out, data exists → nudge (back to default)", () => {
+    expect(decideUpgradeSnapshotAction(true, false, true, true, true)).toBe("nudge");
+  });
+
+  test("engine version changing, --snapshot also passed → engine-version-change (more specific reason wins)", () => {
+    // Both triggers fire — engine-version-change is the more specific reason.
+    // The snapshot runs either way; the message just names the right cause.
+    expect(decideUpgradeSnapshotAction(true, true, true, true, false)).toBe("engine-version-change");
+  });
+
+  test("engine version NOT changing, no --snapshot → nudge (unchanged default)", () => {
+    expect(decideUpgradeSnapshotAction(true, false, true, false, false)).toBe("nudge");
+  });
+
+  test("engine version changing, not upgrading flair → not-upgrading (engine change irrelevant)", () => {
+    expect(decideUpgradeSnapshotAction(false, false, true, true, false)).toBe("not-upgrading");
+  });
 });
 
 describe("UPGRADE_SNAPSHOT_NUDGE_LINES — the opt-out recommendation text", () => {


### PR DESCRIPTION
## What

Two runtime guardrails so an upgrade that cannot be rolled back does not fail silently.

### (a) Unconditional pre-upgrade snapshot on engine version change

The pre-upgrade snapshot was made opt-in on 2026-07-08 on the explicit grounds that `test/compat/downgrade-boot.test.ts` already guaranteed downgrade worked. That guarantee does not hold across engine version boundaries — a Harper bump is the only realistic source of a cross-version boot break.

When `flair upgrade` detects the Harper engine version is changing, it now takes a snapshot unconditionally. Opting out requires `--no-engine-snapshot` and prints what is being given up. Ordinary flair-version upgrades (same Harper) remain opt-in via `--snapshot`.

The engine version is determined by reading the installed Harper's `package.json` and comparing it to the Harper version declared by the target `@tpsdev-ai/flair` on the npm registry. When the lookup fails, the safe default is "assume it might change."

### (b) Store stamp with backwards-boot refusal

Flair now stamps the data directory (`engine-version.txt`) with the Harper engine version at every successful boot. At startup, if the store was written by a newer engine, flair refuses to start. The error names:

- Which engine version wrote the store
- Which engine version is running now
- The data directory path
- The remedy: reinstall the newer version, or restore from a pre-upgrade snapshot

The stamp lives in the data directory so it survives the directory being moved and does not require a Harper query to read — if the engine cannot boot, we still need to read it.

**Limit:** this only helps from the release that ships it onward. The check lives in the version being downgraded *to*, so it cannot rescue a downgrade to a build that predates the stamp.

## Testing

- 19 new unit tests in `test/unit/engine-version.test.ts` covering version reading, stamp I/O, and backwards-boot check
- 6 new decision tests in `test/unit/upgrade-data-snapshot.test.ts` covering the engine-version-change branch
- Full unit suite: 3774 pass, 9 skip, 0 fail (3 flaky timeouts in unrelated `orgevent`/`presence` tests; all pass in isolation)
- Mutation-checked: breaking the backwards-boot comparison causes 4 test failures; removing the engine-version-change check causes 2 test failures

## Changelog

- `changed`: Pre-upgrade snapshots are now automatic when the Harper engine version changes
- `added`: Store stamp with backwards-boot refusal


---

Refs #1047 — partial. This is layers 2 and 3 (unconditional snapshot on engine change, store
stamp with a loud backwards-boot refusal). The CI-visibility half is #1048 and the invariant
restatement is #1050, so #1047 stays open.
