### PR TITLE
fix(ci): isolate oauth-dcr-e2e test from cross-file env interference

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -275,9 +275,18 @@ jobs:
           echo "Running integration suite ${repeats}x"
           for i in $(seq 1 "${repeats}"); do
             echo "::group::integration attempt ${i}/${repeats}"
-            bun test test/integration/
+            bun test $(find test/integration -name '*.test.ts' ! -name 'oauth-dcr-e2e.test.ts' | sort)
             echo "::endgroup::"
           done
+      # oauth-dcr-e2e: isolated because mcp-client-credentials-e2e modifies
+      # config.yaml and sets FLAIR_MCP_OAUTH=1; on macOS the env cleanup does
+      # not fully take effect before the next test file's Harper spawn inherits
+      # the env, causing the well-known handler to fall through
+      # (mcpOAuthEnabled() → true) while @harperfast/oauth is no longer
+      # declared → 404. One process per file is the established remedy
+      # (flair#691, test/unit-isolated/).
+      - name: Run isolated integration test (oauth-dcr-e2e)
+        run: bun test test/integration/oauth-dcr-e2e.test.ts
       # Single source of truth (#625): derive the Harper Docker image tag from the
       # harper version declared in package.json, so the Docker-based
       # E2E/Playwright validation can never drift behind the Harper that ships to

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -340,10 +340,17 @@ echo "🧪 Running tests..."
 # test/unit-isolated/ files mock.module a process-global shared module; each
 # MUST run in its own `bun test` process — they poison the real-importer
 # files AND each other otherwise (flair#691).
-(cd "$ROOT" && bun test test/unit/ test/integration/) || { echo "❌ Tests failed"; exit 1; }
+(cd "$ROOT" && bun test test/unit/ $(find test/integration -name '*.test.ts' ! -name 'oauth-dcr-e2e.test.ts' | sort)) || { echo "❌ Tests failed"; exit 1; }
 for f in "$ROOT"/test/unit-isolated/*.test.ts; do
   (cd "$ROOT" && bun test "$f") || { echo "❌ Tests failed ($f)"; exit 1; }
 done
+# oauth-dcr-e2e: isolated because mcp-client-credentials-e2e modifies config.yaml
+# and sets FLAIR_MCP_OAUTH=1; on macOS the env cleanup does not fully take effect
+# before the next test file's Harper spawn inherits the env, causing the well-known
+# handler to fall through (mcpOAuthEnabled() → true) while @harperfast/oauth is
+# no longer declared → 404. One process per file is the established remedy
+# (flair#691, test/unit-isolated/).
+(cd "$ROOT" && bun test test/integration/oauth-dcr-e2e.test.ts) || { echo "❌ Tests failed (oauth-dcr-e2e)"; exit 1; }
 echo "  ✓ Tests passed"
 
 # 6. Commit version bump (explicit paths — no -A)

--- a/test/integration/oauth-dcr-e2e.test.ts
+++ b/test/integration/oauth-dcr-e2e.test.ts
@@ -179,6 +179,7 @@ describe("DCR when an operator has opted in (real Harper)", () => {
 
   test("discovery advertises the registration endpoint again", async () => {
     const res = await fetch(`${harper.httpURL}/.well-known/oauth-authorization-server`);
+    expect(res.status).toBe(200);
     const doc = await res.json() as any;
     expect(doc.registration_endpoint).toBe(`${doc.issuer}/OAuthRegister`);
   });


### PR DESCRIPTION
## Problem

`test/integration/oauth-dcr-e2e.test.ts` fails in-suite on macOS (2 failures, reproducibly) but passes alone. Both failures hit `GET /.well-known/oauth-authorization-server` and get 404.

## Root cause

`mcp-client-credentials-e2e.test.ts` (which runs first alphabetically) modifies `config.yaml` and sets `FLAIR_MCP_OAUTH=1` in `process.env`. On macOS, the `afterAll` cleanup does not fully take effect before the next test file's Harper spawn inherits the env. The well-known handler sees `mcpOAuthEnabled() → true` and falls through to `next()`, but `@harperfast/oauth` is no longer declared in `config.yaml` → 404.

## Fix

1. **Isolate `oauth-dcr-e2e.test.ts`** in its own `bun test` process — same pattern as `test/unit-isolated/` (flair#691). Applied to both `.github/workflows/test.yml` and `scripts/release.sh`.

2. **Pin `res.status` before `res.json()`** in the "discovery advertises the registration endpoint again" test — a 404 now surfaces as an assertion failure instead of a `SyntaxError`.

## Verification

- DCR test alone: 11 pass / 0 fail (Linux, this host)
- CI runs the same combination on Linux and passes; the isolation ensures macOS gets the same clean process boundary


---

Closes #1057.
