### PR TITLE
ci(structure): isolate oauth-dcr-e2e in test/integration-isolated/ directory

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -275,18 +275,20 @@ jobs:
           echo "Running integration suite ${repeats}x"
           for i in $(seq 1 "${repeats}"); do
             echo "::group::integration attempt ${i}/${repeats}"
-            bun test $(find test/integration -name '*.test.ts' ! -name 'oauth-dcr-e2e.test.ts' | sort)
+            bun test $(find test/integration -name '*.test.ts' | sort)
             echo "::endgroup::"
           done
-      # oauth-dcr-e2e: isolated because mcp-client-credentials-e2e modifies
-      # config.yaml and sets FLAIR_MCP_OAUTH=1; on macOS the env cleanup does
-      # not fully take effect before the next test file's Harper spawn inherits
-      # the env, causing the well-known handler to fall through
-      # (mcpOAuthEnabled() → true) while @harperfast/oauth is no longer
-      # declared → 404. One process per file is the established remedy
-      # (flair#691, test/unit-isolated/).
-      - name: Run isolated integration test (oauth-dcr-e2e)
-        run: bun test test/integration/oauth-dcr-e2e.test.ts
+      # test/integration-isolated/ holds files that must not share a bun test
+      # process with other integration files (env cross-contamination from
+      # mcp-client-credentials-e2e, see flair#691). Structurally excluded
+      # because `find test/integration` does not match `test/integration-isolated/`.
+      - name: Run isolated integration tests
+        run: |
+          for f in test/integration-isolated/*.test.ts; do
+            echo "::group::$f"
+            bun test "$f" || exit 1
+            echo "::endgroup::"
+          done
       # Single source of truth (#625): derive the Harper Docker image tag from the
       # harper version declared in package.json, so the Docker-based
       # E2E/Playwright validation can never drift behind the Harper that ships to

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -340,17 +340,19 @@ echo "🧪 Running tests..."
 # test/unit-isolated/ files mock.module a process-global shared module; each
 # MUST run in its own `bun test` process — they poison the real-importer
 # files AND each other otherwise (flair#691).
-(cd "$ROOT" && bun test test/unit/ $(find test/integration -name '*.test.ts' ! -name 'oauth-dcr-e2e.test.ts' | sort)) || { echo "❌ Tests failed"; exit 1; }
+(cd "$ROOT" && bun test test/unit/ $(find test/integration -name '*.test.ts' | sort)) || { echo "❌ Tests failed"; exit 1; }
+# test/unit-isolated/ files mock.module a process-global shared module; each
+# MUST run in its own `bun test` process — they poison the real-importer
+# files AND each other otherwise (flair#691).
 for f in "$ROOT"/test/unit-isolated/*.test.ts; do
   (cd "$ROOT" && bun test "$f") || { echo "❌ Tests failed ($f)"; exit 1; }
 done
-# oauth-dcr-e2e: isolated because mcp-client-credentials-e2e modifies config.yaml
-# and sets FLAIR_MCP_OAUTH=1; on macOS the env cleanup does not fully take effect
-# before the next test file's Harper spawn inherits the env, causing the well-known
-# handler to fall through (mcpOAuthEnabled() → true) while @harperfast/oauth is
-# no longer declared → 404. One process per file is the established remedy
-# (flair#691, test/unit-isolated/).
-(cd "$ROOT" && bun test test/integration/oauth-dcr-e2e.test.ts) || { echo "❌ Tests failed (oauth-dcr-e2e)"; exit 1; }
+# test/integration-isolated/: structurally excluded from the `find test/integration`
+# glob above; each file runs in its own process to prevent env cross-contamination
+# (flair#691, flair#1061).
+for f in "$ROOT"/test/integration-isolated/*.test.ts; do
+  (cd "$ROOT" && bun test "$f") || { echo "❌ Tests failed ($f)"; exit 1; }
+done
 echo "  ✓ Tests passed"
 
 # 6. Commit version bump (explicit paths — no -A)

--- a/test/integration-isolated/oauth-dcr-e2e.test.ts
+++ b/test/integration-isolated/oauth-dcr-e2e.test.ts
@@ -10,7 +10,7 @@
 // MODEL: test/integration/oauth-authorize-authz.test.ts.
 import { describe, expect, test, beforeAll, afterAll } from "bun:test";
 import { randomBytes } from "node:crypto";
-import { startHarper, stopHarper, HarperInstance } from "../../helpers/harper-lifecycle";
+import { startHarper, stopHarper, HarperInstance } from "../helpers/harper-lifecycle";
 
 const ALLOWED_REDIRECT_URI = "https://claude.com/api/mcp/auth_callback";
 const HEADER = "x-flair-initial-access-token";

--- a/test/integration-isolated/oauth-dcr-e2e.test.ts
+++ b/test/integration-isolated/oauth-dcr-e2e.test.ts
@@ -10,7 +10,7 @@
 // MODEL: test/integration/oauth-authorize-authz.test.ts.
 import { describe, expect, test, beforeAll, afterAll } from "bun:test";
 import { randomBytes } from "node:crypto";
-import { startHarper, stopHarper, HarperInstance } from "../helpers/harper-lifecycle";
+import { startHarper, stopHarper, HarperInstance } from "../../helpers/harper-lifecycle";
 
 const ALLOWED_REDIRECT_URI = "https://claude.com/api/mcp/auth_callback";
 const HEADER = "x-flair-initial-access-token";

--- a/test/unit/ci-gate-coverage.test.ts
+++ b/test/unit/ci-gate-coverage.test.ts
@@ -83,10 +83,12 @@ describe("every test file is reachable from a CI command", () => {
   });
 
   test("no test file sits in a directory CI never runs", () => {
-    // unit-isolated/ is run file-by-file in a loop (`bun test "$f"`), which the
-    // target parser sees as neither a dir nor the root glob — enumerate it here
-    // rather than teaching the parser about shell loops.
-    const loopRun = ["test/unit-isolated"];
+    // Both *-isolated/ directories are run file-by-file in a shell loop
+    // (`bun test "$f"` per file), which the target parser sees as neither a
+    // directory nor the root glob — enumerate them here rather than teaching
+    // the parser about shell loops. See flair#1063 (follow-up: derive this
+    // list conventionally from workflow or filesystem).
+    const loopRun = ["test/unit-isolated", "test/integration-isolated"];
     const covered = (f: string) =>
       (f.split("/").length === 2 && rootGlob) ||
       [...dirs, ...loopRun].some((d) => f.startsWith(`${d}/`));


### PR DESCRIPTION
## What

Move `test/integration/oauth-dcr-e2e.test.ts` into a new `test/integration-isolated/` directory, mirroring the `test/unit-isolated/` structural exclusion pattern from #691.

## Why

The file was excluded by name in two places (`.github/workflows/test.yml` and `scripts/release.sh`), requiring two files to stay in sync. Any third invocation that globs `test/integration/` would silently reintroduce the cross-contamination bug.

## Changes

- **New directory** `test/integration-isolated/` — structurally excluded from `find test/integration` globs (the directory name doesn't match)
- **Moved** `oauth-dcr-e2e.test.ts` there with fixed relative imports (`../helpers` → `../../helpers`)
- **Removed** both named exclusions (`! -name 'oauth-dcr-e2e.test.ts'`) from test.yml and release.sh
- **Added** isolated directory invocation loops in both files, matching the `test/unit-isolated/` pattern
- **Updated** `ci-gate-coverage.test.ts` loopRun list to include `test/integration-isolated/` so the coverage guard detects orphaned isolated directories too

## Verification

- Exclusion strings removed from both files (grep returns zero matches)
- Isolated test runs via explicit loop in both CI and release paths
- No test is dropped — the new directory is explicitly iterated
- Coverage guard in `ci-gate-coverage.test.ts` passes with both isolated directories accounted for

## Note: docs-freshness-check imprecision on PR branches

The `scripts/docs-freshness-check.mjs` gate (line 363) counts commits matching `/^(feat|fix)(\(|!|:)/` since the last `v*` tag and reports them as having "landed." On a PR branch, these commits have **not** landed and, under squash merge, never will — main receives a single commit titled from the PR title (here `ci(structure):`), which would not match. So the check can produce a false positive on PR branches that contain `fix:`-typed commits for non-user-facing changes (like CI fixes). The branch commits were retyped from `fix:` to `ci:` to fix the genuinely incorrect conventional-commit types, but the gate imprecision remains. Flagging for review — file a separate issue if desired.

## Known follow-up (file separately)

`loopRun` in `ci-gate-coverage.test.ts` is a hardcoded list that must be updated by hand whenever a new `*-isolated/` directory is added — the same manually-maintained-exclusion shape this PR removes one level up. A convention-based match (any `test/*-isolated/` directory) or parsing the loop out of the workflow would eliminate this drift vector. I will file this as flair#1063.

Closes #1061
