### PR TITLE
fix: stop mcp-client-credentials-e2e from mutating the repo config.yaml (#1058)

### DIFF
--- a/.changelog/unreleased/fixed-config-yaml-test-mutation.md
+++ b/.changelog/unreleased/fixed-config-yaml-test-mutation.md
@@ -1,0 +1,7 @@
+- **A crashed test run no longer leaves `config.yaml` permanently modified.**
+  `mcp-client-credentials-e2e` wrote the OAuth component block into the repository's real
+  `config.yaml` and restored it in `afterAll`. A kill or crash mid-run left the block in place,
+  and the next real instance start would silently 404 on `/.well-known/oauth-authorization-server`
+  — the OAuth surface was absent with no error, because `@harperfast/oauth` is not a declared
+  dependency in the shipped config. The test now stages the block into a temp copy and points
+  Harper at it; the real `config.yaml` is never touched.

--- a/test/integration/mcp-client-credentials-e2e.test.ts
+++ b/test/integration/mcp-client-credentials-e2e.test.ts
@@ -150,8 +150,11 @@ describe("MCP client_credentials agent-auth vs. a live @harperfast/oauth@2.2.0 c
     // Capture the real config.yaml checksum BEFORE anything touches it.
     configChecksum = sha256(CONFIG_PATH);
 
-    // Build a temp component tree: hard-link everything from the repo root
-    // (excluding .git), then replace config.yaml with our OAuth-augmented copy.
+    // Build a temp component tree: hard-link everything under the repo root
+    // (including .git and node_modules), then replace config.yaml with our
+    // OAuth-augmented copy.  The temp tree is removed with rm -rf in afterAll;
+    // that does not affect the originals because hard links are reference-counted
+    // — unlinking the temp copy leaves the repo file intact.
     // Hard links are transparent to the filesystem — Harper's component loader
     // sees a real directory tree, not symlinks.  Symlinks fail because Harper
     // resolves componentDirectory with realpathSync and its security loader

--- a/test/integration/mcp-client-credentials-e2e.test.ts
+++ b/test/integration/mcp-client-credentials-e2e.test.ts
@@ -74,15 +74,18 @@
 // `config.yaml`, exactly the pattern this file used to use for
 // `harper-fabric-embeddings` before flair#504/694 moved that to in-process
 // boot (see config.yaml's own history/comments). This test stages that
-// block into a TEMPORARY copy of config.yaml for its own lifetime only
-// (restored in `afterAll`, even on failure) — `bun test test/integration/`
-// runs test files sequentially in one process (this repo's CI invokes it as
-// a single `bun test test/integration/`), so this mutation window never
-// overlaps another integration test's own `startHarper()` config read.
+// block into a TEMPORARY copy of config.yaml for its own lifetime only —
+// the repository's real config.yaml is never touched. Harper is pointed at
+// the temp copy via `startHarper({ cwd: tempDir })`; the temp directory is
+// discarded in `afterAll`. A crash therefore leaves nothing behind.
 import { describe, test, expect, beforeAll, afterAll } from "bun:test";
 import { generateKeyPairSync, type KeyObject } from "node:crypto";
+import { createHash } from "node:crypto";
 import { readFileSync, writeFileSync } from "node:fs";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { execSync } from "node:child_process";
 import { startHarper, stopHarper, type HarperInstance } from "../helpers/harper-lifecycle";
 import {
   signClientAssertion,
@@ -92,7 +95,8 @@ import {
   McpTokenRequestError,
 } from "../../src/mcp-client-assertion";
 
-const CONFIG_PATH = join(process.cwd(), "config.yaml");
+const REPO_ROOT = process.cwd();
+const CONFIG_PATH = join(REPO_ROOT, "config.yaml");
 const ISSUER = "https://cimd-test.flair-663.internal";
 const ALLOWED_HOST = "cimd-test.flair-663.internal";
 const AGENT_ID = "mcp-cc-e2e-agent";
@@ -119,11 +123,16 @@ const OAUTH_COMPONENT_BLOCK = `
         - '${ALLOWED_HOST}'
 `;
 
-let originalConfig: string;
+let configChecksum: string;
+let tempDir: string;
 let harper: HarperInstance;
 let clientId: string;
 let tokenEndpoint: string;
 let agentPrivateKey: KeyObject;
+
+function sha256(path: string): string {
+  return createHash("sha256").update(readFileSync(path)).digest("hex");
+}
 
 async function adminOp(op: Record<string, any>): Promise<Response> {
   return fetch(harper.opsURL, {
@@ -138,13 +147,27 @@ async function adminOp(op: Record<string, any>): Promise<Response> {
 
 describe("MCP client_credentials agent-auth vs. a live @harperfast/oauth@2.2.0 component", () => {
   beforeAll(async () => {
-    originalConfig = readFileSync(CONFIG_PATH, "utf8");
-    writeFileSync(CONFIG_PATH, originalConfig + OAUTH_COMPONENT_BLOCK);
+    // Capture the real config.yaml checksum BEFORE anything touches it.
+    configChecksum = sha256(CONFIG_PATH);
+
+    // Build a temp component tree: hard-link everything from the repo root
+    // (excluding .git), then replace config.yaml with our OAuth-augmented copy.
+    // Hard links are transparent to the filesystem — Harper's component loader
+    // sees a real directory tree, not symlinks.  Symlinks fail because Harper
+    // resolves componentDirectory with realpathSync and its security loader
+    // (checkAllowedModulePath) rejects paths that don't start with the
+    // realpath'd directory.
+    tempDir = await mkdtemp(join(tmpdir(), "flair-test-"));
+    execSync(`cp -al "${REPO_ROOT}"/. "${tempDir}"/`, { stdio: "pipe" });
+    // Remove the hard-linked config.yaml and write our augmented copy.
+    execSync(`rm -f "${tempDir}/config.yaml"`);
+    writeFileSync(join(tempDir, "config.yaml"), readFileSync(CONFIG_PATH, "utf8") + OAUTH_COMPONENT_BLOCK);
 
     process.env.FLAIR_MCP_OAUTH = "1";
     process.env.FLAIR_MCP_ISSUER = ISSUER;
 
-    harper = await startHarper();
+    // Point Harper at the temp tree — it reads config.yaml from its cwd.
+    harper = await startHarper({ cwd: tempDir });
 
     // Seed the agent MCPClientMetadata.ts will serve a CIMD document for.
     const agentKeyPair = generateKeyPairSync("ed25519");
@@ -164,9 +187,16 @@ describe("MCP client_credentials agent-auth vs. a live @harperfast/oauth@2.2.0 c
 
   afterAll(async () => {
     if (harper) await stopHarper(harper);
-    writeFileSync(CONFIG_PATH, originalConfig);
+    if (tempDir) {
+      await rm(tempDir, { recursive: true, force: true, maxRetries: 4 });
+    }
     delete process.env.FLAIR_MCP_OAUTH;
     delete process.env.FLAIR_MCP_ISSUER;
+  });
+
+  test("the repository's config.yaml is never mutated during this test run", () => {
+    const after = sha256(CONFIG_PATH);
+    expect(after).toBe(configChecksum);
   });
 
   test("the plugin mounts for real: /.well-known/oauth-authorization-server advertises client_credentials + private_key_jwt + EdDSA", async () => {


### PR DESCRIPTION
## What

Fixes #1058: `test/integration/mcp-client-credentials-e2e.test.ts` no longer mutates the repository's real `config.yaml`.

## Before

The test wrote `OAUTH_COMPONENT_BLOCK` into the real `config.yaml` (~line 142) and restored it in `afterAll` (~line 167). A crash or kill mid-run left `config.yaml` permanently modified, silently breaking the OAuth surface on the next real instance start.

## After

The test builds a temp component tree via hard links (`cp -al`), replaces `config.yaml` with the OAuth-augmented copy, and points Harper at the temp dir via `startHarper({ cwd: tempDir })`. The temp tree is discarded in `afterAll`. A crash therefore leaves nothing behind.

## Guard

A SHA-256 guard test fails if the real `config.yaml` is modified during the run.

### Mutation check

Reintroducing the `writeFileSync` mutation causes the guard to fail:

```sh
$ bun test /tmp/mutation-test.ts
✗ the repository's config.yaml is never mutated during this test run
  Expected: "9c70dd9c4e2ab1885e24e50d96cc65797819397fdd3b03198b2a86a071ad88fa"
  Received: "3a76ce5d43e93a12376b621aece246475e8aad0a174c5c05c358eda2b07d2a78"
```

### Crash simulation

Killing the test mid-run (timeout 8s) leaves `config.yaml` byte-identical:

```sh
$ sha256sum config.yaml  # before
9c70dd9c4e2ab1885e24e50d96cc65797819397fdd3b03198b2a86a071ad88fa
$ timeout 8 bun test test/integration/mcp-client-credentials-e2e.test.ts
$ sha256sum config.yaml  # after — identical
9c70dd9c4e2ab1885e24e50d96cc65797819397fdd3b03198b2a86a071ad88fa
```

## Why hard links, not symlinks

Harper's component loader resolves `componentDirectory` with `realpathSync` and its security loader (`checkAllowedModulePath`) rejects module paths that don't start with the realpath'd directory. Symlinks cause the `flair` database to not be created because the schema/JS resource files resolve outside the allowed path. Hard links are transparent to the filesystem — Harper sees a real directory tree.