### PR TITLE
fix(authz): extract scoped search into makeScopedSearch, fix boolean-injection in Memory + WorkspaceState (slice 2a)

### DIFF
--- a/resources/Memory.ts
+++ b/resources/Memory.ts
@@ -21,6 +21,7 @@ import {
   makeAuthGate,
   makeReadScope,
   makeByIdReadGate,
+  makeScopedSearch,
   resolveAuthGate,
   stampAttribution,
   FORBIDDEN,
@@ -73,6 +74,7 @@ function wantsTrust(target: any, opts: { includeTrust?: boolean } | undefined): 
  */
 export const memoryReadScope = makeReadScope(RECORD_TYPES.Memory.readScope, RECORD_TYPES.Memory.ownerField);
 const memoryByIdReadGate = makeByIdReadGate(memoryReadScope);
+const memoryScopedSearch = makeScopedSearch(memoryReadScope);
 // See makeAuthGate's doc (record-type-kit.ts): must be wired as a genuine
 // prototype method below, never a class-field assignment — Harper's
 // relationship-traversal RBAC path reads allowRead off the prototype.
@@ -580,27 +582,12 @@ export class Memory extends (databases as any).flair.Memory {
     // from RECORD_TYPES.Memory — see this file's header — delegating
     // "open-within-org" to memory-read-scope.ts's resolveReadScope()
     // unchanged) so get() above and search() here cannot drift.
-    const scope = await memoryReadScope(gate.agentId);
-    const agentIdCondition: any = scope.condition;
-
-    // Harper passes `query` as a RequestTarget (extends URLSearchParams) or a
-    // conditions array. For URL-based GET /Memory?... calls, URL params are no
-    // longer translated to conditions here — callers should use
-    // POST /Memory/search_by_conditions with an explicit conditions array.
-    // For programmatic calls with a conditions array, we wrap with the agentId scope.
-    if (query && typeof query === "object" && !Array.isArray(query)) {
-      if (Array.isArray(query.conditions) && query.conditions.length > 0) {
-        query.conditions = [agentIdCondition, ...query.conditions];
-        return withDetachedTxn(ctx, () => super.search(query));
-      }
-      // Fallback: no conditions array present — just scope and pass through
-    }
-
-    // Fallback: plain array or no query (internal calls)
-    const conditions = Array.isArray(query) && query.length > 0
-      ? [agentIdCondition, ...query]
-      : [agentIdCondition];
-    return withDetachedTxn(ctx, () => super.search(conditions));
+    //
+    // The scope condition is nested as the outermost AND block via
+    // makeScopedSearch (record-type-kit.ts) — same correct composition
+    // MemoryCandidate.search() already applies — so a caller-supplied
+    // `operator: "or"` cannot boolean-inject past the owner scope.
+    return memoryScopedSearch(gate.agentId, query, (q) => withDetachedTxn(ctx, () => super.search(q)));
   }
 
   async post(content: any, context?: any) {

--- a/resources/WorkspaceState.ts
+++ b/resources/WorkspaceState.ts
@@ -15,6 +15,7 @@ import {
   makeAuthGate,
   makeReadScope,
   makeByIdReadGate,
+  makeScopedSearch,
   resolveAuthGate,
   stampAttribution,
   FORBIDDEN,
@@ -31,6 +32,7 @@ import { RECORD_TYPES } from "./record-types.js";
 // runtime consumer.
 export const workspaceReadScope = makeReadScope(RECORD_TYPES.WorkspaceState.readScope, RECORD_TYPES.WorkspaceState.ownerField);
 const workspaceByIdReadGate = makeByIdReadGate(workspaceReadScope);
+const workspaceScopedSearch = makeScopedSearch(workspaceReadScope);
 // See makeAuthGate's doc (record-type-kit.ts): must be wired as a genuine
 // prototype method below, never a class-field assignment — Harper's
 // relationship-traversal RBAC path reads allowRead off the prototype.
@@ -91,23 +93,11 @@ export class WorkspaceState extends (databases as any).flair.WorkspaceState {
     if (gate.kind === "denied") return gate.response;
     if (gate.kind === "unfiltered") return super.search(query);
 
-    const scope = await workspaceReadScope(gate.agentId);
-    const agentIdCondition = scope.condition;
-
-    // Harper passes `query` as a request target object (pathname, id, isCollection…).
-    // Inject the scope condition into its `.conditions` array.
-    if (query && typeof query === "object" && !Array.isArray(query)) {
-      const existing = query.conditions ?? [];
-      query.conditions = Array.isArray(existing)
-        ? [agentIdCondition, ...existing]
-        : [agentIdCondition, existing];
-      return super.search(query);
-    }
-
-    const conditions = Array.isArray(query) && query.length > 0
-      ? [agentIdCondition, ...query]
-      : [agentIdCondition];
-    return super.search(conditions);
+    // Non-admin agent: scope to own records only.  The scope condition is
+    // nested as the outermost AND block via makeScopedSearch (record-type-kit.ts)
+    // — same correct composition MemoryCandidate.search() already applies — so a
+    // caller-supplied `operator: "or"` cannot boolean-inject past the owner scope.
+    return workspaceScopedSearch(gate.agentId, query, (q) => super.search(q));
   }
 
   async post(content: any) {

--- a/resources/record-type-kit.ts
+++ b/resources/record-type-kit.ts
@@ -274,7 +274,62 @@ export function makeByIdReadGate(
   };
 }
 
-// ─── (c) No-forge attribution — stampAttribution ───────────────────────────
+// ─── (c) Scoped search — makeScopedSearch ────────────────────────────────
+
+/**
+ * Produces a scoped search() override that nests the caller's conditions
+ * inside the agent-scope condition as the OUTERMOST `and` block, so a
+ * caller-supplied `operator: "or"` cannot boolean-inject past the owner
+ * scope.
+ *
+ * This is the correct composition that MemoryCandidate.search() already
+ * applies (the only resource that got it right).  Memory.search() and
+ * WorkspaceState.search() both used a flat prepend — `[agentCondition,
+ * ...query.conditions]` — which lets a caller-supplied `query.operator`
+ * survive and turn the scope condition into one OR-branch.
+ *
+ * Every table that composes this gets the correct nesting by default;
+ * a fifth table added later cannot accidentally reintroduce the flat-
+ * prepend bug.
+ *
+ * `superSearch` is a caller-supplied closure so the class's own
+ * `super.search()` (which cannot be referenced from outside the class
+ * body) stays exactly where it was.
+ */
+export function makeScopedSearch(
+  readScope: (authAgentId: string) => Promise<RecordTypeReadScope>,
+): (agentId: string, query: any, superSearch: (q: any) => any) => any {
+  return async function scopedSearch(agentId: string, query: any, superSearch: (q: any) => any): Promise<any> {
+    const scope = await readScope(agentId);
+    const agentCondition = scope.condition;
+
+    // Object with a conditions array — nest caller's conditions inside the
+    // scope condition as the outermost AND block so a caller-supplied
+    // `operator: "or"` cannot boolean-inject past the owner scope.
+    if (query && typeof query === "object" && !Array.isArray(query)) {
+      if (Array.isArray(query.conditions) && query.conditions.length > 0) {
+        return superSearch({
+          ...query,
+          conditions: [agentCondition, { conditions: query.conditions, operator: query.operator || "and" }],
+          operator: "and",
+        });
+      }
+      // No (or empty) conditions array — just scope, preserving other query
+      // properties but NOT a caller-supplied operator (force "and").
+      const { conditions: _c, operator: _o, ...rest } = query;
+      return superSearch({ ...rest, conditions: [agentCondition], operator: "and" });
+    }
+
+    // Plain array or no query — wrap in an object with operator "and" so
+    // the scope condition is always the outermost AND.
+    const conditions = Array.isArray(query) && query.length > 0
+      ? [agentCondition, { conditions: query, operator: "and" }]
+      : [agentCondition];
+    return superSearch({ conditions, operator: "and" });
+  };
+}
+
+// ─── (d) No-forge attribution — stampAttribution ───────────────────────────
 
 /**
  * Four idioms observed verbatim across the five tables' write paths (post()/

--- a/test/unit/coordination-write-auth.test.ts
+++ b/test/unit/coordination-write-auth.test.ts
@@ -78,9 +78,18 @@ class BaseWorkspaceState {
     return workspaceStore.get(id) ?? null;
   }
   async search(query: any) {
-    const conditions = Array.isArray(query) ? query : Array.isArray(query?.conditions) ? query.conditions : [];
+    // Respect query.operator — Harper combines top-level conditions with
+    // the query's operator (default "and").
+    const topLevel = Array.isArray(query) ? { conditions: query, operator: "and" } : query || {};
+    const conds = Array.isArray(topLevel.conditions) ? topLevel.conditions : [];
+    const op = topLevel.operator || "and";
     let records = Array.from(workspaceStore.values());
-    for (const cond of conditions) records = records.filter((r) => matchesCondition(r, cond));
+    if (conds.length > 0) {
+      records = records.filter((r) => {
+        const results = conds.map((c: any) => matchesCondition(r, c));
+        return op === "or" ? results.some(Boolean) : results.every(Boolean);
+      });
+    }
     async function* gen() {
       for (const r of records) yield r;
     }
@@ -318,3 +327,66 @@ describe("WorkspaceState.delete() — ownership check uses the raw record (super
     expect(res instanceof Response).toBe(false);
   });
 });
+
+// ─── Boolean-injection guard (authz-hardening slice 2a) ────────────────────
+
+describe("WorkspaceState.search() — boolean-injection guard (authz-hardening slice 2a)", () => {
+  it("a non-admin agent's search() cannot use operator:'or' + wildcard to see another agent's workspace records", async () => {
+    workspaceStore.set("ws-mine", { id: "ws-mine", agentId: "agent-1", ref: "main" });
+    workspaceStore.set("ws-theirs", { id: "ws-theirs", agentId: "agent-2", ref: "main" });
+
+    const ws = makeWorkspace(agentCtx("agent-1"));
+
+    // A malicious caller supplies a condition that matches EVERY row (no
+    // record's agentId equals this sentinel) combined with operator:"or",
+    // hoping the "or" escapes to the top level and unions in every agent's
+    // rows.  The owner condition is always the outermost AND — the attacker's
+    // wildcard+"or" stays trapped inside a nested group that itself must
+    // still satisfy the AND, so it can only ever narrow the caller's OWN
+    // rows, never broaden past them.
+    const res: any = await ws.search({
+      conditions: [{ attribute: "agentId", comparator: "not_equal", value: "no-such-agent-sentinel" }],
+      operator: "or",
+    });
+    const results: any[] = [];
+    for await (const rec of res) results.push(rec);
+    expect(results.map((rec) => rec.id)).toEqual(["ws-mine"]);
+  });
+
+  it("a non-admin agent sees only own workspace records with a normal scoped search", async () => {
+    workspaceStore.set("ws-mine", { id: "ws-mine", agentId: "agent-1" });
+    workspaceStore.set("ws-theirs", { id: "ws-theirs", agentId: "agent-2" });
+
+    const ws = makeWorkspace(agentCtx("agent-1"));
+    const res: any = await ws.search({ conditions: [] });
+    const results: any[] = [];
+    for await (const rec of res) results.push(rec);
+    expect(results.map((rec) => rec.id)).toEqual(["ws-mine"]);
+  });
+
+  it("an admin agent sees all workspace records, unfiltered", async () => {
+    workspaceStore.set("ws-mine", { id: "ws-mine", agentId: "agent-1" });
+    workspaceStore.set("ws-theirs", { id: "ws-theirs", agentId: "agent-2" });
+
+    const ws = makeWorkspace(agentCtx("agent-admin", true));
+    const res: any = await ws.search({ conditions: [] });
+    const results: any[] = [];
+    for await (const rec of res) results.push(rec);
+    expect(results.map((rec) => rec.id).sort()).toEqual(["ws-mine", "ws-theirs"]);
+  });
+
+  it("anonymous is denied with 401", async () => {
+    workspaceStore.set("ws-1", { id: "ws-1", agentId: "agent-1" });
+    const ws = makeWorkspace(anonCtx());
+    const res: any = await ws.search({ conditions: [] });
+    expect(res instanceof Response).toBe(true);
+    expect((res as Response).status).toBe(401);
+  });
+});
+
+// ─── MUTATION-CHECK NOTE ────────────────────────────────────────────────────
+// The boolean-injection test above was manually mutation-tested during
+// development: temporarily reverting WorkspaceState.search() to the flat
+// prepend — `query.conditions = [agentIdCondition, ...existing]` — made the
+// test FAIL (observed "ws-theirs" in the result), confirming the guard is
+// not vacuously true.  Reverted before commit.

--- a/test/unit/memory-search-scope.test.ts
+++ b/test/unit/memory-search-scope.test.ts
@@ -1,0 +1,216 @@
+/**
+ * memory-search-scope.test.ts — boolean-injection guard for Memory.search().
+ *
+ * The bug (authz-hardening slice 2a): Memory.search() used a flat prepend —
+ * `query.conditions = [agentIdCondition, ...query.conditions]` — which let a
+ * caller-supplied `operator: "or"` survive and turn the scope condition into
+ * one OR-branch.  MemoryCandidate.search() got this right (nested AND block);
+ * Memory.search() and WorkspaceState.search() both had the same flat-prepend
+ * defect despite a docstring claiming the correct behaviour.
+ *
+ * The fix extracts the correct composition into record-type-kit.ts's
+ * makeScopedSearch(), which both resources now compose.
+ *
+ * No other test/unit/ file imports resources/Memory.ts with a harper mock
+ * (memory-soul-read-gate.test.ts deliberately avoids it — see its docstring),
+ * so this file owns the mock+import with no collision risk.
+ */
+import { describe, it, expect, beforeEach, mock } from "bun:test";
+
+process.env.FLAIR_RATE_LIMIT_ENABLED = "false";
+delete (process.env as any).FLAIR_PUBLIC;
+
+// ─── In-memory Harper Memory mock ───────────────────────────────────────────
+
+let memoryStore: Map<string, any>;
+let instanceRow: any = null;
+
+function matchesCondition(record: any, cond: any): boolean {
+  if (cond.operator && Array.isArray(cond.conditions)) {
+    const results = cond.conditions.map((c: any) => matchesCondition(record, c));
+    return cond.operator === "or" ? results.some(Boolean) : results.every(Boolean);
+  }
+  const fieldVal = record[cond.attribute];
+  if (cond.comparator === "equals") return fieldVal === cond.value;
+  if (cond.comparator === "not_equal") return fieldVal !== cond.value;
+  return true;
+}
+
+class BaseMemory {
+  async get(target?: any) {
+    const id = typeof target === "string" ? target : target?.id;
+    return memoryStore.get(id) ?? null;
+  }
+  async put(content: any) {
+    memoryStore.set(content.id, { ...content });
+    return { ...content };
+  }
+  async post(content: any) {
+    const id = content.id ?? `mem-${Math.random().toString(36).slice(2)}`;
+    content.id = id;
+    memoryStore.set(id, { ...content });
+    return { ...content };
+  }
+  search(query?: any) {
+    // Respect query.operator — Harper combines top-level conditions with
+    // the query's operator (default "and").  This is the behaviour the
+    // boolean-injection guard protects against: a caller-supplied
+    // `operator: "or"` at the top level would OR the scope condition with
+    // the caller's conditions if the scope is flat-prepended instead of
+    // nested.
+    const topLevel = Array.isArray(query) ? { conditions: query, operator: "and" } : query || {};
+    const conds = Array.isArray(topLevel.conditions) ? topLevel.conditions : [];
+    const op = topLevel.operator || "and";
+    let records = Array.from(memoryStore.values());
+    if (conds.length > 0) {
+      records = records.filter((r) => {
+        const results = conds.map((c: any) => matchesCondition(r, c));
+        return op === "or" ? results.some(Boolean) : results.every(Boolean);
+      });
+    }
+    async function* gen() {
+      for (const r of records) yield r;
+    }
+    return gen();
+  }
+  async delete(id: any) {
+    memoryStore.delete(id);
+    return { ok: true };
+  }
+}
+
+const databasesMock = {
+  flair: {
+    Memory: BaseMemory,
+    Agent: { get: async () => null, search: async () => [] },
+    Instance: {
+      search: () => {
+        async function* gen() {
+          if (instanceRow) yield instanceRow;
+        }
+        return gen();
+      },
+    },
+    MemoryGrant: {
+      search: () => {
+        async function* gen() {
+          // empty — no grants in these tests
+        }
+        return gen();
+      },
+    },
+  },
+};
+
+mock.module("harper", () => ({
+  server: { http: () => {}, getUser: async () => null },
+  databases: databasesMock,
+  Resource: class {},
+}));
+
+const { Memory } = await import("../../resources/Memory.ts");
+const { _resetLocalInstanceIdCacheForTests } = await import("../../resources/instance-identity.ts");
+
+function makeMemory(ctxRequest: any) {
+  const r: any = new (Memory as any)();
+  r.getContext = () => ({ request: ctxRequest });
+  return r;
+}
+const agentCtx = (agentId: string, isAdmin = false) => ({ tpsAgent: agentId, tpsAgentIsAdmin: isAdmin });
+const anonCtx = () => ({ tpsAnonymous: true });
+
+function memoryRow(overrides: Record<string, any> = {}) {
+  return {
+    id: `mem-${Math.random().toString(36).slice(2)}`,
+    agentId: "agent-1",
+    content: "test memory",
+    visibility: "shared",
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  memoryStore = new Map();
+  instanceRow = null;
+  _resetLocalInstanceIdCacheForTests();
+});
+
+// ─── Boolean-injection guard ────────────────────────────────────────────────
+
+describe("Memory.search() — boolean-injection guard (authz-hardening slice 2a)", () => {
+  it("a non-admin agent's search() cannot use operator:'or' + wildcard to see another agent's memories", async () => {
+    // Seed: agent-1 owns one memory, agent-2 owns a PRIVATE memory.
+    // Memory uses "open-within-org" scoping (own records OR non-private
+    // records), so the other agent's record must be private for the
+    // boolean-injection guard to be meaningful — a shared record from
+    // another agent is legitimately visible.
+    memoryStore.set("mem-mine", memoryRow({ id: "mem-mine", agentId: "agent-1", content: "my memory" }));
+    memoryStore.set("mem-theirs", memoryRow({ id: "mem-theirs", agentId: "agent-2", content: "their memory", visibility: "private" }));
+
+    const r = makeMemory(agentCtx("agent-1"));
+
+    // A malicious caller supplies a condition that matches EVERY row (no
+    // record's agentId equals this sentinel) combined with operator:"or",
+    // hoping the "or" escapes to the top level and unions in every agent's
+    // rows.  The owner condition is always the outermost AND — the attacker's
+    // wildcard+"or" stays trapped inside a nested group that itself must
+    // still satisfy the AND, so it can only ever narrow the caller's OWN
+    // rows, never broaden past them.
+    const res: any = await r.search({
+      conditions: [{ attribute: "agentId", comparator: "not_equal", value: "no-such-agent-sentinel" }],
+      operator: "or",
+    });
+    const results: any[] = [];
+    for await (const rec of res) results.push(rec);
+    expect(results.map((rec) => rec.id)).toEqual(["mem-mine"]);
+  });
+
+  it("a non-admin agent sees only own memories with a normal scoped search", async () => {
+    memoryStore.set("mem-mine", memoryRow({ id: "mem-mine", agentId: "agent-1" }));
+    memoryStore.set("mem-theirs", memoryRow({ id: "mem-theirs", agentId: "agent-2", visibility: "private" }));
+
+    const r = makeMemory(agentCtx("agent-1"));
+    const res: any = await r.search({ conditions: [] });
+    const results: any[] = [];
+    for await (const rec of res) results.push(rec);
+    expect(results.map((rec) => rec.id)).toEqual(["mem-mine"]);
+  });
+
+  it("an admin agent sees all memories, unfiltered", async () => {
+    memoryStore.set("mem-mine", memoryRow({ id: "mem-mine", agentId: "agent-1" }));
+    memoryStore.set("mem-theirs", memoryRow({ id: "mem-theirs", agentId: "agent-2" }));
+
+    const r = makeMemory(agentCtx("agent-admin", true));
+    const res: any = await r.search({ conditions: [] });
+    const results: any[] = [];
+    for await (const rec of res) results.push(rec);
+    expect(results.map((rec) => rec.id).sort()).toEqual(["mem-mine", "mem-theirs"]);
+  });
+
+  it("an internal call (no request context) is unfiltered", async () => {
+    memoryStore.set("mem-mine", memoryRow({ id: "mem-mine", agentId: "agent-1" }));
+    memoryStore.set("mem-theirs", memoryRow({ id: "mem-theirs", agentId: "agent-2" }));
+
+    const r: any = new (Memory as any)();
+    r.getContext = () => undefined;
+    const res: any = await r.search({});
+    const results: any[] = [];
+    for await (const rec of res) results.push(rec);
+    expect(results.map((rec) => rec.id).sort()).toEqual(["mem-mine", "mem-theirs"]);
+  });
+
+  it("anonymous is denied with 401", async () => {
+    memoryStore.set("mem-1", memoryRow({ id: "mem-1", agentId: "agent-1" }));
+    const r = makeMemory(anonCtx());
+    const res: any = await r.search({ conditions: [] });
+    expect(res instanceof Response).toBe(true);
+    expect((res as Response).status).toBe(401);
+  });
+});
+
+// ─── MUTATION-CHECK NOTE ────────────────────────────────────────────────────
+// The boolean-injection test above was manually mutation-tested during
+// development: temporarily reverting Memory.search() to the flat prepend —
+// `query.conditions = [agentIdCondition, ...query.conditions]` — made the
+// test FAIL (observed "mem-theirs" in the result), confirming the guard is
+// not vacuously true.  Reverted before commit.


### PR DESCRIPTION
## Problem

One composition replicated across three resources, with exactly one correct instance:

| Resource | search() behaviour | Status |
|---|---|---|
| MemoryCandidate | Nests caller block, forces outer AND | ✅ Correct |
| Memory | Flat prepend — caller's operator survives | ❌ Broken |
| WorkspaceState | Same flat prepend | ❌ Broken |

Memory.search()'s docstring claimed the correct behaviour:

> Security Critical: the agentId condition is wrapped as the outermost
> `and` block so user-supplied query operators cannot bypass it via
> boolean injection (e.g. [..., "or", { wildcard }]).

But the code did a flat prepend — `query.conditions = [agentIdCondition, ...query.conditions]` — which lets a caller-supplied `query.operator` survive. A reader who trusts the comment stops looking.

## Fix

Extracted the correct composition into `record-type-kit.ts`'s `makeScopedSearch(readScope)` — returns an async function taking `(agentId, query, superSearch)` that nests the caller's conditions inside the scope condition as the outermost AND block, forcing operator to `"and"`.

Both Memory.search() and WorkspaceState.search() now compose `makeScopedSearch` instead of hand-rolling the flat prepend. A fifth table added later gets correct composition by default.

## Tests

- **`test/unit/memory-search-scope.test.ts`** — new file, 5 tests: boolean-injection guard, normal scoped search, admin unfiltered, internal unfiltered, anonymous denied
- **`test/unit/coordination-write-auth.test.ts`** — 4 tests added to existing file (avoids harper mock collision): boolean-injection guard, normal scoped search, admin unfiltered, anonymous denied
- Both mocks updated to respect `query.operator` — the old mocks always AND-ed top-level conditions, making the injection guard vacuously true

## Mutation verification

- **Memory**: Reverted to flat prepend → `"mem-theirs"` leaked into results → test failed → restored
- **WorkspaceState**: Reverted to flat prepend → `"ws-theirs"` leaked into results → test failed → restored

## Scope

Slice 2a — Memory + WorkspaceState only. Integration is slice 2b (separate PR).


No issue: tracked on our private ops board (ops-eluz, slice 2a). Security hardening; the finding is not public.
