### PR TITLE
fix(authz): add allowCreate + post() with no-forge attribution to Credential (slice 3)

### DIFF
--- a/resources/Credential.ts
+++ b/resources/Credential.ts
@@ -1,6 +1,7 @@
 import { databases } from "harper";
 import { resolveAgentAuth, allowVerified } from "./agent-auth.js";
 import { checkRateLimit, rateLimitResponse } from "./rate-limiter.js";
+import { stampAttribution, UNAUTH } from "./record-type-kit.js";
 
 /**
  * Credential resource — authentication surfaces for Principals.
@@ -24,6 +25,55 @@ export class Credential extends (databases as any).flair.Credential {
    * top of this for the paths they do see.
    */
   allowRead() { return allowVerified((this as any).getContext?.()); }
+
+  /**
+   * Self-authorize creation (same posture as allowRead).  Without this gate
+   * Harper routes POST /Credential to the base class's post() — which has
+   * no cross-principal check — letting an unauthenticated caller create
+   * credentials for any principal.
+   */
+  allowCreate() { return allowVerified((this as any).getContext?.()); }
+
+  /**
+   * Create a credential.  No-forge attribution via stampAttribution
+   * ("stamp-default" mode): a non-admin agent's credential is ALWAYS
+   * attributed to the authenticated identity — we never trust
+   * content.principalId from the body.  An admin may create on behalf of
+   * another principal (content.principalId honored if present, else
+   * defaults to the admin's own id).  Internal in-process callers keep
+   * whatever principalId they pass.
+   *
+   * Previously Credential had no post() override — the base class's post()
+   * ran with no cross-principal check, so any verified caller could create
+   * a credential for any principal by setting principalId in the body.
+   */
+  async post(content: any) {
+    const auth = await resolveAgentAuth((this as any).getContext?.());
+    if (auth.kind === "anonymous") return UNAUTH();
+
+    // No-forge attribution: stamp principalId from the authenticated
+    // identity.  "stamp-default" unconditionally overwrites for non-admin;
+    // admin may supply their own value (defaults to admin's id if absent).
+    stampAttribution(auth, content, "principalId", "stamp-default", "forbidden: unreachable for stamp-default");
+
+    const rl = checkRateLimit(auth.kind === "agent" ? auth.agentId : "internal");
+    if (!rl.allowed) return rateLimitResponse(rl.retryAfterMs!, "credential");
+
+    // Validate kind
+    const validKinds = ["webauthn", "bearer-token", "ed25519", "idp"];
+    if (!content.kind || !validKinds.includes(content.kind)) {
+      return new Response(JSON.stringify({ error: `kind must be one of: ${validKinds.join(", ")}` }), {
+        status: 400, headers: { "content-type": "application/json" },
+      });
+    }
+
+    const now = new Date().toISOString();
+    content.status = content.status || "active";
+    content.createdAt = content.createdAt || now;
+    content.updatedAt = now;
+
+    return super.post(content);
+  }
 
   async search(query?: any) {
     const auth = await resolveAgentAuth((this as any).getContext?.());
@@ -81,25 +131,22 @@ export class Credential extends (databases as any).flair.Credential {
   }
 
   async put(content: any) {
-    const ctx = (this as any).getContext?.();
-    const request = ctx?.request ?? ctx;
-    const authAgent: string | undefined = request?.tpsAgent;
-    const isAdminAgent: boolean = request?.tpsAgentIsAdmin ?? false;
+    const auth = await resolveAgentAuth((this as any).getContext?.());
 
-    if (!authAgent) {
+    if (auth.kind === "anonymous") {
       return new Response(JSON.stringify({ error: "authentication required" }), {
         status: 401, headers: { "content-type": "application/json" },
       });
     }
 
-    // Only admins can create credentials for other principals
-    if (!isAdminAgent && content.principalId && content.principalId !== authAgent) {
+    // Only admins can update credentials for other principals
+    if (auth.kind === "agent" && !auth.isAdmin && content.principalId && content.principalId !== auth.agentId) {
       return new Response(JSON.stringify({ error: "only admin principals can manage other principals' credentials" }), {
         status: 403, headers: { "content-type": "application/json" },
       });
     }
 
-    const rl = checkRateLimit(authAgent);
+    const rl = checkRateLimit(auth.kind === "agent" ? auth.agentId : "internal");
     if (!rl.allowed) return rateLimitResponse(rl.retryAfterMs!, "credential");
 
     // Validate kind
@@ -111,7 +158,7 @@ export class Credential extends (databases as any).flair.Credential {
     }
 
     const now = new Date().toISOString();
-    content.principalId = content.principalId || authAgent;
+    content.principalId = content.principalId || (auth.kind === "agent" ? auth.agentId : content.principalId);
     content.status = content.status || "active";
     content.createdAt = content.createdAt || now;
     content.updatedAt = now;
@@ -120,20 +167,17 @@ export class Credential extends (databases as any).flair.Credential {
   }
 
   async delete(_: any) {
-    const ctx = (this as any).getContext?.();
-    const request = ctx?.request ?? ctx;
-    const authAgent: string | undefined = request?.tpsAgent;
-    const isAdminAgent: boolean = request?.tpsAgentIsAdmin ?? false;
+    const auth = await resolveAgentAuth((this as any).getContext?.());
 
-    if (!authAgent) {
+    if (auth.kind === "anonymous") {
       return new Response(JSON.stringify({ error: "authentication required" }), {
         status: 401, headers: { "content-type": "application/json" },
       });
     }
 
-    if (!isAdminAgent) {
+    if (auth.kind === "agent" && !auth.isAdmin) {
       const existing = await super.get();
-      if (existing?.principalId && existing.principalId !== authAgent) {
+      if (existing?.principalId && existing.principalId !== auth.agentId) {
         return new Response(JSON.stringify({ error: "only admin principals can revoke other principals' credentials" }), {
           status: 403, headers: { "content-type": "application/json" },
         });

--- a/test/unit/credential-create-auth.test.ts
+++ b/test/unit/credential-create-auth.test.ts
@@ -1,0 +1,229 @@
+/**
+ * credential-create-auth.test.ts — no-forge attribution guard for
+ * Credential.post() (authz-hardening slice 3).
+ *
+ * The bug: Credential had allowRead() and put() but NO allowCreate() and
+ * NO post() override.  The cross-principal check lived only in put().
+ * record-owner-guard's resolveGuardedRecord matches /<Table>/<id> only
+ * and returns null for collection paths BY DESIGN — creation is delegated
+ * to per-resource no-forge attribution, and Credential had none.
+ *
+ * An attacker could POST /Credential with principalId set to any target
+ * and the base class's post() would create it with no cross-principal
+ * check.
+ *
+ * The fix adds allowCreate() (same posture as allowRead) and a post()
+ * override that uses stampAttribution("stamp-default") to stamp
+ * principalId from the authenticated identity — never trusting the body.
+ * put() and delete() are also refactored to use resolveAgentAuth instead
+ * of reading request.tpsAgent raw.
+ *
+ * No other test/unit/ file imports resources/Credential.ts with a harper
+ * mock, so this file owns the mock+import with no collision risk.
+ */
+import { describe, it, expect, beforeEach, mock } from "bun:test";
+
+process.env.FLAIR_RATE_LIMIT_ENABLED = "false";
+delete (process.env as any).FLAIR_PUBLIC;
+
+// ─── In-memory Harper Credential mock ───────────────────────────────────────
+
+let credentialStore: Map<string, any>;
+let instanceRow: any = null;
+let _currentRecordId: string | null = null; // set by delete() so super.get() can resolve
+
+class BaseCredential {
+  async get(target?: any) {
+    const id = typeof target === "string" ? target : target?.id ?? _currentRecordId;
+    return credentialStore.get(id) ?? null;
+  }
+  async put(content: any) {
+    credentialStore.set(content.id, { ...content });
+    return { ...content };
+  }
+  async post(content: any) {
+    const id = content.id ?? `cred-${Math.random().toString(36).slice(2)}`;
+    content.id = id;
+    credentialStore.set(id, { ...content });
+    return { ...content };
+  }
+  async delete(id: any) {
+    _currentRecordId = id;
+    credentialStore.delete(id);
+    return { ok: true };
+  }
+}
+
+const databasesMock = {
+  flair: {
+    Credential: BaseCredential,
+    Agent: { get: async () => null, search: async () => [] },
+    Instance: {
+      search: () => {
+        async function* gen() {
+          if (instanceRow) yield instanceRow;
+        }
+        return gen();
+      },
+    },
+  },
+};
+
+mock.module("harper", () => ({
+  server: { http: () => {}, getUser: async () => null },
+  databases: databasesMock,
+  Resource: class {},
+}));
+
+const { Credential } = await import("../../resources/Credential.ts");
+const { _resetLocalInstanceIdCacheForTests } = await import("../../resources/instance-identity.ts");
+
+function makeCredential(ctxRequest: any) {
+  const r: any = new (Credential as any)();
+  r.getContext = () => ({ request: ctxRequest });
+  return r;
+}
+const agentCtx = (agentId: string, isAdmin = false) => ({ tpsAgent: agentId, tpsAgentIsAdmin: isAdmin });
+const anonCtx = () => ({ tpsAnonymous: true });
+
+beforeEach(() => {
+  credentialStore = new Map();
+  instanceRow = null;
+  _currentRecordId = null;
+  _resetLocalInstanceIdCacheForTests();
+});
+
+// ─── post() — no-forge attribution ─────────────────────────────────────────
+
+describe("Credential.post() — no-forge attribution (authz-hardening slice 3)", () => {
+  it("stamps principalId from the authenticated agent, ignoring the body", async () => {
+    const cred = makeCredential(agentCtx("agent-1"));
+    const res: any = await cred.post({
+      kind: "bearer-token",
+      principalId: "agent-2", // attacker tries to create for another principal
+      label: "my token",
+    });
+    expect(res instanceof Response).toBe(false);
+    expect(res.principalId).toBe("agent-1"); // stamped, not trusted from body
+    expect(res.kind).toBe("bearer-token");
+    expect(res.status).toBe("active");
+    expect(res.createdAt).toBeTruthy();
+    expect(res.updatedAt).toBeTruthy();
+  });
+
+  it("denies anonymous with 401", async () => {
+    const cred = makeCredential(anonCtx());
+    const res: any = await cred.post({ kind: "bearer-token", label: "anon token" });
+    expect(res instanceof Response).toBe(true);
+    expect((res as Response).status).toBe(401);
+  });
+
+  it("rejects an invalid kind with 400", async () => {
+    const cred = makeCredential(agentCtx("agent-1"));
+    const res: any = await cred.post({ kind: "ssh-key", label: "bad kind" });
+    expect(res instanceof Response).toBe(true);
+    expect((res as Response).status).toBe(400);
+  });
+
+  it("allows an admin to create a credential for another principal", async () => {
+    const cred = makeCredential(agentCtx("admin-1", true));
+    const res: any = await cred.post({
+      kind: "bearer-token",
+      principalId: "agent-2",
+      label: "admin-created token",
+    });
+    expect(res instanceof Response).toBe(false);
+    expect(res.principalId).toBe("agent-2"); // admin's value honored
+  });
+
+  it("allows an internal call to set any principalId", async () => {
+    const r: any = new (Credential as any)();
+    r.getContext = () => undefined; // internal — no request context
+    const res: any = await r.post({
+      kind: "bearer-token",
+      principalId: "agent-3",
+      label: "internal token",
+    });
+    expect(res instanceof Response).toBe(false);
+    expect(res.principalId).toBe("agent-3");
+  });
+
+  it("defaults principalId to the admin's own id when admin omits it", async () => {
+    const cred = makeCredential(agentCtx("admin-1", true));
+    const res: any = await cred.post({
+      kind: "bearer-token",
+      label: "admin own token",
+    });
+    expect(res instanceof Response).toBe(false);
+    expect(res.principalId).toBe("admin-1");
+  });
+});
+
+// ─── put() — cross-principal guard ──────────────────────────────────────────
+
+describe("Credential.put() — cross-principal guard (refactored to resolveAgentAuth)", () => {
+  it("a non-admin cannot update another principal's credential", async () => {
+    credentialStore.set("cred-1", { id: "cred-1", principalId: "agent-2", kind: "bearer-token", status: "active" });
+    const cred = makeCredential(agentCtx("agent-1"));
+    const res: any = await cred.put({ id: "cred-1", principalId: "agent-2", kind: "bearer-token", status: "revoked" });
+    expect(res instanceof Response).toBe(true);
+    expect((res as Response).status).toBe(403);
+    // Verify the record was NOT mutated
+    expect(credentialStore.get("cred-1").status).toBe("active");
+  });
+
+  it("a non-admin can update their own credential", async () => {
+    credentialStore.set("cred-1", { id: "cred-1", principalId: "agent-1", kind: "bearer-token", status: "active" });
+    const cred = makeCredential(agentCtx("agent-1"));
+    const res: any = await cred.put({ id: "cred-1", principalId: "agent-1", kind: "bearer-token", status: "revoked" });
+    expect(res instanceof Response).toBe(false);
+    expect(credentialStore.get("cred-1").status).toBe("revoked");
+  });
+
+  it("denies anonymous with 401", async () => {
+    const cred = makeCredential(anonCtx());
+    const res: any = await cred.put({ id: "cred-1", kind: "bearer-token" });
+    expect(res instanceof Response).toBe(true);
+    expect((res as Response).status).toBe(401);
+  });
+});
+
+// ─── delete() — cross-principal guard ───────────────────────────────────────
+
+describe("Credential.delete() — cross-principal guard (refactored to resolveAgentAuth)", () => {
+  it("a non-admin cannot delete another principal's credential", async () => {
+    credentialStore.set("cred-1", { id: "cred-1", principalId: "agent-2", kind: "bearer-token" });
+    const cred = makeCredential(agentCtx("agent-1"));
+    // super.get() inside delete() is context-aware in Harper (resolves from
+    // the URL path).  In the mock we prime _currentRecordId so the base
+    // class's get() can resolve the record.
+    _currentRecordId = "cred-1";
+    const res: any = await cred.delete("cred-1");
+    expect(res instanceof Response).toBe(true);
+    expect((res as Response).status).toBe(403);
+    expect(credentialStore.has("cred-1")).toBe(true); // untouched
+  });
+
+  it("a non-admin can delete their own credential", async () => {
+    credentialStore.set("cred-1", { id: "cred-1", principalId: "agent-1", kind: "bearer-token" });
+    const cred = makeCredential(agentCtx("agent-1"));
+    _currentRecordId = "cred-1";
+    const res: any = await cred.delete("cred-1");
+    expect(res instanceof Response).toBe(false);
+    expect(credentialStore.has("cred-1")).toBe(false);
+  });
+
+  it("denies anonymous with 401", async () => {
+    const cred = makeCredential(anonCtx());
+    const res: any = await cred.delete("cred-1");
+    expect(res instanceof Response).toBe(true);
+    expect((res as Response).status).toBe(401);
+  });
+});
+
+// ─── MUTATION-CHECK NOTE ────────────────────────────────────────────────────
+// The no-forge attribution test above was manually mutation-tested during
+// development: temporarily removing the stampAttribution call from post()
+// made the guard test FAIL (observed principalId "agent-2" from the body
+// instead of the stamped "agent-1"), confirming the guard is not vacuously
+// true.  Reverted before commit.


### PR DESCRIPTION
## Problem

Credential had `allowRead()` and `put()` but NO `allowCreate()` and NO `post()` override. The cross-principal check lived only in `put()`. `record-owner-guard`'s `resolveGuardedRecord` matches `/<Table>/<id>` only and returns null for collection paths BY DESIGN — creation is delegated to per-resource no-forge attribution, and Credential had none.

An attacker could `POST /Credential` with `principalId` set to any target and the base class's `post()` would create it with no cross-principal check.

## Fix

- **`allowCreate()`** — same posture as `allowRead` (`allowVerified`). Without this gate Harper routes POST to the base class's `post()` with no auth check at all.
- **`post()` override** — uses `stampAttribution(stamp-default)` on `principalId`. A non-admin agent's credential is ALWAYS attributed to the authenticated identity — we never trust `content.principalId` from the body. Admin may create on behalf of another principal. Internal callers keep their value.
- **`put()` refactored** — uses `resolveAgentAuth` instead of reading `request.tpsAgent` raw (defense-in-depth; slice 1's middleware fix already covers this transitively, but consistency matters).
- **`delete()` refactored** — same treatment.

## Tests

`test/unit/credential-create-auth.test.ts` (12 tests):

| Method | Test | What it proves |
|---|---|---|
| post() | stamps principalId from auth | Body's `principalId: agent-2` → stamped to `agent-1` |
| post() | denies anonymous | 401 |
| post() | rejects invalid kind | 400 |
| post() | admin creates for another | Admin's `principalId: agent-2` honored |
| post() | internal passthrough | Internal caller's value kept |
| post() | admin defaults to own id | Omitted `principalId` → admin's own id |
| put() | non-admin blocked | Cross-principal update → 403, record untouched |
| put() | own update ok | Own credential updated |
| put() | anonymous denied | 401 |
| delete() | non-admin blocked | Cross-principal delete → 403, record untouched |
| delete() | own delete ok | Own credential deleted |
| delete() | anonymous denied | 401 |

## Mutation verification

Removed `stampAttribution` from `post()` → body's `principalId: agent-2` survived instead of being stamped to `agent-1` → guard test failed → restored.


No issue: tracked on our private ops board (ops-eluz, slice 3). Security hardening; the finding is not public.
