### PR TITLE
fix(authz): stamp agentId from principal in FeedMemories.post(), guard body-supplied id (slice 4)

### DIFF
--- a/pr-body.md
+++ b/pr-body.md
@@ -1,0 +1,28 @@
+## What changed
+
+**resources/MemoryFeed.ts** — `FeedMemories.post()` now resolves the authenticated principal via `resolveAgentAuth()` and stamps `agentId` from the principal using the kit's `stampAttribution()` in **stamp-strict** mode. Body-supplied `agentId` is no longer trusted: a mismatched value is rejected with 403 rather than silently overwritten. Additionally, a body-supplied record `id` is checked against the existing record's ownership before allowing the write.
+
+**test/unit/memory-feed-idor.test.ts** — Pure logic tests for the attribution-stamping and id-ownership guard (4 tests, no Harper needed).
+
+**test/integration/memory-feed-idor.test.ts** — Live Harper integration tests: guard against IDOR via body agentId spoofing and cross-agent record targeting, positive controls for own writes, and anonymous rejection.
+
+## Why
+
+The previous `post()` read `agentId` directly from `content.agentId` in the request body. A verified agent could feed a memory attributed to any `agentId` by including it in the body — even if the authenticated principal was different. A body-supplied `id` targeting another agent's record would silently overwrite it.
+
+## The fix
+
+1. **Resolve the authenticated principal** via `resolveAgentAuth()` at the start of `post()`.
+2. **Stamp `agentId` from the principal via `stampAttribution(stamp-strict)`** — rejects body-supplied `agentId` mismatches with 403. A caller sending another agent's id is either buggy or probing, and both are worth surfacing rather than silently correcting.
+3. **Guard body-supplied `id`** — if the body includes a record `id`, fetch the existing record and reject with 403 if its `agentId` differs from the stamped principal.
+4. **Reject anonymous writes** — `UNAUTH()` for unauthenticated callers.
+
+## Why stamp-strict over stamp-default
+
+stamp-default silently overwrites a forged `agentId` with the principal's. stamp-strict rejects the mismatch with 403. This endpoint's entire defect was trusting body-supplied identity — a caller sending another agent's id is either buggy or probing, and both are worth seeing.
+
+The risk with strict is breaking legitimate callers that echo `agentId` back in the body. **Verified: no such callers exist.** A full search of the flair repo (and the workspace) for `FeedMemories` and `/FeedMemories` returns only the resource definition itself and its own tests. There are no SDK wrappers, no CLI commands, and no internal callers that construct requests to this endpoint with a body-supplied `agentId`. The endpoint is consumed exclusively via HTTP POST by agents, and the only body shape that reaches it is whatever the agent sends. A caller echoing the *correct* agentId (matching the principal) passes through stamp-strict unchanged; a caller echoing a *wrong* one is exactly the bug this slice exists to prevent.
+
+## Mutation-verify
+
+Reverting `MemoryFeed.ts` to the body-trusting version (`const agentId = String(content?.agentId ?? "");`) allows a principal to feed a memory attributed to another agent via body agentId spoofing. The integration guard tests catch this.

--- a/resources/MemoryFeed.ts
+++ b/resources/MemoryFeed.ts
@@ -1,7 +1,7 @@
 import { Resource, databases } from "harper";
 import { allowVerified, resolveAgentAuth } from "./agent-auth.js";
 import { computeContentHash, findExistingMemoryByContentHash } from "./memory-feed-lib.js";
-import { FORBIDDEN, UNAUTH } from "./record-type-kit.js";
+import { FORBIDDEN, UNAUTH, stampAttribution } from "./record-type-kit.js";
 
 export class FeedMemories extends Resource {
   // Self-authorize via the Ed25519 agent verify (the auth reshape removes the
@@ -20,13 +20,14 @@ export class FeedMemories extends Resource {
     }
 
     // No-forge attribution: stamp agentId from the authenticated principal,
-    // never from the body. "stamp-default" — unconditional overwrite for
-    // non-admin agents; admin defaults-if-absent.
-    if (auth.kind === "agent" && !auth.isAdmin) {
-      content.agentId = auth.agentId;
-    } else if (auth.kind === "agent" && auth.isAdmin) {
-      content.agentId ||= auth.agentId;
-    }
+    // never from the body. "stamp-strict" — rejects body-supplied mismatches
+    // as 403 (this endpoint's defect was trusting body identity; a caller
+    // sending another agent's id is buggy or probing and both are worth seeing).
+    const attrResult = stampAttribution(
+      auth, content, 'agentId', 'stamp-strict',
+      'forbidden: cannot attribute a feed memory to another agent',
+    );
+    if (attrResult.denied) return attrResult.denied;
 
     // Guard against body-supplied id targeting another agent's record.
     if (content?.id) {

--- a/resources/MemoryFeed.ts
+++ b/resources/MemoryFeed.ts
@@ -19,15 +19,21 @@ export class FeedMemories extends Resource {
       return UNAUTH();
     }
 
-    // No-forge attribution: stamp agentId from the authenticated principal,
-    // never from the body. "stamp-strict" — rejects body-supplied mismatches
-    // as 403 (this endpoint's defect was trusting body identity; a caller
-    // sending another agent's id is buggy or probing and both are worth seeing).
-    const attrResult = stampAttribution(
-      auth, content, 'agentId', 'stamp-strict',
-      'forbidden: cannot attribute a feed memory to another agent',
-    );
-    if (attrResult.denied) return attrResult.denied;
+    // No-forge attribution: use the kit's stampAttribution (stamp-default) to
+    // stamp agentId from the authenticated principal, never from the body.
+    // Mode choice: stamp-default (silent overwrite) over stamp-strict (reject
+    // 403 on mismatch). This endpoint is the ingestion path — callers are MCP
+    // clients and agent-side tool calls. The defect this fix addresses was
+    // trusting a body-supplied identity; the correction is to always stamp from
+    // the authenticated principal. Silent overwrite is safe: the write always
+    // lands attributed to the real principal. It avoids a trade-off where
+    // probing attempts become indistinguishable from a buggy client echoing a
+    // field back AND breaks callers that harmlessly include agentId. A strict
+    // posture would reject those callers for no security gain — the write is
+    // already safe because we control attribution regardless of what the body
+    // says.
+    const attr = stampAttribution(auth, content, 'agentId', 'stamp-default', 'forbidden: cannot attribute a feed memory to another agent');
+    if (attr.denied) return attr.denied;
 
     // Guard against body-supplied id targeting another agent's record.
     if (content?.id) {

--- a/resources/MemoryFeed.ts
+++ b/resources/MemoryFeed.ts
@@ -1,18 +1,42 @@
 import { Resource, databases } from "harper";
-import { allowVerified } from "./agent-auth.js";
+import { allowVerified, resolveAgentAuth } from "./agent-auth.js";
 import { computeContentHash, findExistingMemoryByContentHash } from "./memory-feed-lib.js";
+import { FORBIDDEN, UNAUTH } from "./record-type-kit.js";
 
 export class FeedMemories extends Resource {
   // Self-authorize via the Ed25519 agent verify (the auth reshape removes the
-  // gate's admin elevation). NOTE: post() trusts content.agentId from the body —
-  // closing that create-spoofing gap is tracked with the table-resource
-  // create-ownership work (Memory.allowCreate), not in this auth-coverage pass.
+  // gate's admin elevation).
   async allowCreate(): Promise<boolean> {
     return allowVerified((this as any).getContext?.());
   }
 
   async post(content: any) {
-    const agentId = String(content?.agentId ?? "");
+    const ctx = (this as any).getContext?.();
+    const auth = await resolveAgentAuth(ctx);
+
+    // Anonymous HTTP must NOT write.
+    if (auth.kind === "anonymous") {
+      return UNAUTH();
+    }
+
+    // No-forge attribution: stamp agentId from the authenticated principal,
+    // never from the body. "stamp-default" — unconditional overwrite for
+    // non-admin agents; admin defaults-if-absent.
+    if (auth.kind === "agent" && !auth.isAdmin) {
+      content.agentId = auth.agentId;
+    } else if (auth.kind === "agent" && auth.isAdmin) {
+      content.agentId ||= auth.agentId;
+    }
+
+    // Guard against body-supplied id targeting another agent's record.
+    if (content?.id) {
+      const existingRecord = await (databases as any).flair.Memory.get(content.id);
+      if (existingRecord && existingRecord.agentId !== content.agentId) {
+        return FORBIDDEN("forbidden: cannot write a feed memory owned by another agent");
+      }
+    }
+
+    const agentId = content.agentId;
     const body = String(content?.content ?? "");
     if (!agentId || !body) {
       return new Response(JSON.stringify({ error: "agentId and content are required" }), {

--- a/resources/MemoryFeed.ts
+++ b/resources/MemoryFeed.ts
@@ -19,20 +19,27 @@ export class FeedMemories extends Resource {
       return UNAUTH();
     }
 
-    // No-forge attribution: use the kit's stampAttribution (stamp-default) to
-    // stamp agentId from the authenticated principal, never from the body.
-    // Mode choice: stamp-default (silent overwrite) over stamp-strict (reject
-    // 403 on mismatch). This endpoint is the ingestion path — callers are MCP
+    // No-forge attribution: use the kit's stampAttribution to stamp agentId
+    // from the authenticated principal, never from the body.
+    //
+    // Mode choice: stamp-strict (reject 403 on mismatch) over stamp-default
+    // (silent overwrite). This endpoint is the ingestion path — callers are MCP
     // clients and agent-side tool calls. The defect this fix addresses was
     // trusting a body-supplied identity; the correction is to always stamp from
-    // the authenticated principal. Silent overwrite is safe: the write always
-    // lands attributed to the real principal. It avoids a trade-off where
-    // probing attempts become indistinguishable from a buggy client echoing a
-    // field back AND breaks callers that harmlessly include agentId. A strict
-    // posture would reject those callers for no security gain — the write is
-    // already safe because we control attribution regardless of what the body
-    // says.
-    const attr = stampAttribution(auth, content, 'agentId', 'stamp-default', 'forbidden: cannot attribute a feed memory to another agent');
+    // the authenticated principal.
+    //
+    // Deciding point (adjudicated on PR #1071): a silent overwrite means a
+    // buggy client never learns it is buggy — it keeps sending the wrong
+    // agentId and keeps getting 200. A strict rejection surfaces the mismatch
+    // so the caller can fix it. The concern about breaking callers that
+    // harmlessly echo agentId back was checked: a full search of the repo and
+    // workspace for FeedMemories and /FeedMemories returns only the resource
+    // definition and its own tests — no SDK wrappers, no CLI commands, no
+    // internal callers construct requests with a body-supplied agentId. A
+    // caller echoing the correct agentId (matching the principal) passes
+    // through stamp-strict unchanged; a caller echoing a wrong one is exactly
+    // the bug this slice exists to prevent.
+    const attr = stampAttribution(auth, content, 'agentId', 'stamp-strict', 'forbidden: cannot attribute a feed memory to another agent');
     if (attr.denied) return attr.denied;
 
     // Guard against body-supplied id targeting another agent's record.

--- a/test/integration/memory-feed-idor.test.ts
+++ b/test/integration/memory-feed-idor.test.ts
@@ -55,7 +55,7 @@ describe("MemoryFeed IDOR guard (authz slice 4)", () => {
         operation: "insert", database: "flair", table: "Agent",
         records: [{ id: ag.id, name: ag.id, role: "agent", publicKey: ag.publicKey, createdAt: new Date().toISOString() }],
       });
-      expect(res.status, `register ${ag.id} → ${res.status}`).toBe(200);
+      expect(res.status).toBe(200);
     }
   }, 180_000);
 
@@ -72,11 +72,8 @@ describe("MemoryFeed IDOR guard (authz slice 4)", () => {
       headers: { Authorization: ed25519Header(agentA, "POST", path), "Content-Type": "application/json" },
       body: JSON.stringify({ agentId: agentB.id, content: "imposter memory" }),
     });
-    // stamp-default silently overwrites: the write succeeds, attributed to agentA.
-    expect(res.status).toBe(200);
-    const body = await res.json();
-    expect(body.agentId).toBe(agentA.id, "body-supplied agentId must be overridden to the authenticated principal");
-    expect(body.agentId).not.toBe(agentB.id);
+    // stamp-strict rejects body-supplied agentId mismatches as 403.
+    expect(res.status).toBe(403);
   }, 30_000);
 
   // ─── Guard: cannot target another agent's record via body id ────────────
@@ -90,7 +87,7 @@ describe("MemoryFeed IDOR guard (authz slice 4)", () => {
       headers: { Authorization: ed25519Header(agentB, "POST", path), "Content-Type": "application/json" },
       body: JSON.stringify({ id: bId, agentId: agentB.id, content: "agent b's memory" }),
     });
-    expect(createRes.status, `B's creation returned ${await createRes.text()}`).toBe(200);
+    expect(createRes.status).toBe(200);
 
     // Now agent A tries to feed a memory with agentB's id.
     const spoofRes = await fetch(`${harper.httpURL}${path}`, {
@@ -98,10 +95,9 @@ describe("MemoryFeed IDOR guard (authz slice 4)", () => {
       headers: { Authorization: ed25519Header(agentA, "POST", path), "Content-Type": "application/json" },
       body: JSON.stringify({ id: bId, agentId: agentA.id, content: "trying to overwrite b" }),
     });
-    const spoofText = await spoofRes.text();
 
     // The fix rejects this: existing record's agentId (agentB) ≠ stamped agentId (agentA).
-    expect(spoofRes.status, `A's spoof returned ${spoofRes.status}: ${spoofText}`).toBe(403);
+    expect(spoofRes.status).toBe(403);
   }, 30_000);
 
   // ─── Positive control: agent writing its own feed memory still works ────
@@ -131,7 +127,7 @@ describe("MemoryFeed IDOR guard (authz slice 4)", () => {
       headers: { Authorization: ed25519Header(agentA, "POST", path), "Content-Type": "application/json" },
       body: JSON.stringify({ id: aId, agentId: agentA.id, content: "agent a's memory" }),
     });
-    expect(createRes.status, `A's creation returned ${await createRes.text()}`).toBe(200);
+    expect(createRes.status).toBe(200);
 
     // Agent A feeds again with the same id (same content = dedup, returns existing).
     const updateRes = await fetch(`${harper.httpURL}${path}`, {
@@ -139,8 +135,10 @@ describe("MemoryFeed IDOR guard (authz slice 4)", () => {
       headers: { Authorization: ed25519Header(agentA, "POST", path), "Content-Type": "application/json" },
       body: JSON.stringify({ id: aId, agentId: agentA.id, content: "agent a's memory" }),
     });
-    const updateBody = await updateRes.json();
+    // Read body once — avoid double-read (ERR_BODY_ALREADY_USED).
+    const updateText = await updateRes.text();
     expect(updateRes.status).toBe(200);
+    const updateBody = JSON.parse(updateText);
     expect(updateBody.agentId).toBe(agentA.id);
   }, 30_000);
 
@@ -156,6 +154,6 @@ describe("MemoryFeed IDOR guard (authz slice 4)", () => {
     // allowCreate() (via allowVerified) rejects anonymous at the Harper resource
     // layer before post() is reached, so the observable response is 403 (AccessViolation).
     // The 401 check in post() is defense-in-depth for non-Harper callers.
-    expect(res.status, `anonymous returned ${await res.text()}`).toBe(403);
+    expect(res.status).toBe(403);
   }, 30_000);
 });

--- a/test/integration/memory-feed-idor.test.ts
+++ b/test/integration/memory-feed-idor.test.ts
@@ -55,7 +55,7 @@ describe("MemoryFeed IDOR guard (authz slice 4)", () => {
         operation: "insert", database: "flair", table: "Agent",
         records: [{ id: ag.id, name: ag.id, role: "agent", publicKey: ag.publicKey, createdAt: new Date().toISOString() }],
       });
-      expect(res.status).toBe(200);
+      expect(res.status, `register ${ag.id} → ${res.status}`).toBe(200);
     }
   }, 180_000);
 
@@ -72,8 +72,11 @@ describe("MemoryFeed IDOR guard (authz slice 4)", () => {
       headers: { Authorization: ed25519Header(agentA, "POST", path), "Content-Type": "application/json" },
       body: JSON.stringify({ agentId: agentB.id, content: "imposter memory" }),
     });
-    // stamp-strict rejects body-supplied agentId mismatches as 403.
-    expect(res.status).toBe(403);
+    // stamp-default silently overwrites: the write succeeds, attributed to agentA.
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.agentId).toBe(agentA.id, "body-supplied agentId must be overridden to the authenticated principal");
+    expect(body.agentId).not.toBe(agentB.id);
   }, 30_000);
 
   // ─── Guard: cannot target another agent's record via body id ────────────
@@ -87,7 +90,7 @@ describe("MemoryFeed IDOR guard (authz slice 4)", () => {
       headers: { Authorization: ed25519Header(agentB, "POST", path), "Content-Type": "application/json" },
       body: JSON.stringify({ id: bId, agentId: agentB.id, content: "agent b's memory" }),
     });
-    expect(createRes.status).toBe(200);
+    expect(createRes.status, `B's creation returned ${await createRes.text()}`).toBe(200);
 
     // Now agent A tries to feed a memory with agentB's id.
     const spoofRes = await fetch(`${harper.httpURL}${path}`, {
@@ -95,9 +98,10 @@ describe("MemoryFeed IDOR guard (authz slice 4)", () => {
       headers: { Authorization: ed25519Header(agentA, "POST", path), "Content-Type": "application/json" },
       body: JSON.stringify({ id: bId, agentId: agentA.id, content: "trying to overwrite b" }),
     });
+    const spoofText = await spoofRes.text();
 
     // The fix rejects this: existing record's agentId (agentB) ≠ stamped agentId (agentA).
-    expect(spoofRes.status).toBe(403);
+    expect(spoofRes.status, `A's spoof returned ${spoofRes.status}: ${spoofText}`).toBe(403);
   }, 30_000);
 
   // ─── Positive control: agent writing its own feed memory still works ────
@@ -109,8 +113,8 @@ describe("MemoryFeed IDOR guard (authz slice 4)", () => {
       headers: { Authorization: ed25519Header(agentA, "POST", path), "Content-Type": "application/json" },
       body: JSON.stringify({ agentId: agentA.id, content: "my own feed memory" }),
     });
-    expect(res.status).toBe(200);
     const body = await res.json();
+    expect(res.status).toBe(200);
     expect(body.agentId).toBe(agentA.id);
     expect(body.content).toBe("my own feed memory");
   }, 30_000);
@@ -127,7 +131,7 @@ describe("MemoryFeed IDOR guard (authz slice 4)", () => {
       headers: { Authorization: ed25519Header(agentA, "POST", path), "Content-Type": "application/json" },
       body: JSON.stringify({ id: aId, agentId: agentA.id, content: "agent a's memory" }),
     });
-    expect(createRes.status).toBe(200);
+    expect(createRes.status, `A's creation returned ${await createRes.text()}`).toBe(200);
 
     // Agent A feeds again with the same id (same content = dedup, returns existing).
     const updateRes = await fetch(`${harper.httpURL}${path}`, {
@@ -135,10 +139,8 @@ describe("MemoryFeed IDOR guard (authz slice 4)", () => {
       headers: { Authorization: ed25519Header(agentA, "POST", path), "Content-Type": "application/json" },
       body: JSON.stringify({ id: aId, agentId: agentA.id, content: "agent a's memory" }),
     });
-    // Read body once — avoid double-read (ERR_BODY_ALREADY_USED).
-    const updateText = await updateRes.text();
+    const updateBody = await updateRes.json();
     expect(updateRes.status).toBe(200);
-    const updateBody = JSON.parse(updateText);
     expect(updateBody.agentId).toBe(agentA.id);
   }, 30_000);
 
@@ -151,6 +153,9 @@ describe("MemoryFeed IDOR guard (authz slice 4)", () => {
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ agentId: agentA.id, content: "unauthenticated" }),
     });
-    expect(res.status).toBe(401);
+    // allowCreate() (via allowVerified) rejects anonymous at the Harper resource
+    // layer before post() is reached, so the observable response is 403 (AccessViolation).
+    // The 401 check in post() is defense-in-depth for non-Harper callers.
+    expect(res.status, `anonymous returned ${await res.text()}`).toBe(403);
   }, 30_000);
 });

--- a/test/integration/memory-feed-idor.test.ts
+++ b/test/integration/memory-feed-idor.test.ts
@@ -1,0 +1,159 @@
+// MemoryFeed IDOR integration test (authz slice 4, flair#1064).
+//
+// Guards against the defect where FeedMemories.post() trusted content.agentId
+// and content.id from the request body, allowing a principal to write memories
+// attributed to (or targeting) another agent.
+//
+// Mutation-verify: revert MemoryFeed.ts post() to the body-trusting version,
+// run this file — the GUARD tests MUST fail. Restore the fix — they MUST pass.
+import { describe, expect, test, beforeAll, afterAll } from "bun:test";
+import nacl from "tweetnacl";
+import { randomUUID } from "node:crypto";
+import { startHarper, stopHarper, HarperInstance } from "../helpers/harper-lifecycle";
+import { ensureFlairAgentRole, ensureFlairAgentUser } from "../../src/cli";
+
+interface TestAgent { id: string; publicKey: string; secretKey: Uint8Array; }
+
+function mkAgent(id: string): TestAgent {
+  const kp = nacl.sign.keyPair();
+  return { id, publicKey: Buffer.from(kp.publicKey).toString("base64"), secretKey: kp.secretKey };
+}
+
+function ed25519Header(agent: TestAgent, method: string, path: string): string {
+  const ts = Date.now().toString();
+  const nonce = randomUUID();
+  const payload = `${agent.id}:${ts}:${nonce}:${method}:${path}`;
+  const sig = nacl.sign.detached(new TextEncoder().encode(payload), agent.secretKey);
+  return `TPS-Ed25519 ${agent.id}:${ts}:${nonce}:${Buffer.from(sig).toString("base64")}`;
+}
+
+async function adminOp(harper: HarperInstance, op: Record<string, any>): Promise<Response> {
+  return fetch(harper.opsURL, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: "Basic " + btoa(`${harper.admin.username}:${harper.admin.password}`),
+    },
+    body: JSON.stringify(op),
+  });
+}
+
+let harper: HarperInstance;
+const agentA = mkAgent("feed-agent-a");
+const agentB = mkAgent("feed-agent-b");
+
+describe("MemoryFeed IDOR guard (authz slice 4)", () => {
+  beforeAll(async () => {
+    harper = await startHarper();
+
+    await ensureFlairAgentRole(harper.opsURL, harper.admin.username, harper.admin.password);
+    await ensureFlairAgentUser(harper.opsURL, harper.admin.username, harper.admin.password);
+
+    // Register both agents so resolveAgentAuth recognizes them.
+    for (const ag of [agentA, agentB]) {
+      const res = await adminOp(harper, {
+        operation: "insert", database: "flair", table: "Agent",
+        records: [{ id: ag.id, name: ag.id, role: "agent", publicKey: ag.publicKey, createdAt: new Date().toISOString() }],
+      });
+      expect(res.status, `register ${ag.id} → ${res.status}`).toBe(200);
+    }
+  }, 180_000);
+
+  afterAll(async () => {
+    if (harper) await stopHarper(harper);
+  }, 30_000);
+
+  // ─── Guard: body agentId is overridden to the authenticated principal ───
+
+  test("GUARD: agent A cannot feed a memory for agent B via body agentId", async () => {
+    const path = "/FeedMemories";
+    const res = await fetch(`${harper.httpURL}${path}`, {
+      method: "POST",
+      headers: { Authorization: ed25519Header(agentA, "POST", path), "Content-Type": "application/json" },
+      body: JSON.stringify({ agentId: agentB.id, content: "imposter memory" }),
+    });
+    // The fix stamps agentId from the authenticated principal.
+    // Even though the body says agentB, the record is attributed to agentA.
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.agentId).toBe(agentA.id, "body-supplied agentId must be overridden to the authenticated principal");
+    expect(body.agentId).not.toBe(agentB.id);
+  }, 30_000);
+
+  // ─── Guard: cannot target another agent's record via body id ────────────
+
+  test("GUARD: agent A cannot feed into agent B's record id", async () => {
+    // First, agent B creates a memory with a known id.
+    const bId = `${agentB.id}-idortarget`;
+    const path = "/FeedMemories";
+    const createRes = await fetch(`${harper.httpURL}${path}`, {
+      method: "POST",
+      headers: { Authorization: ed25519Header(agentB, "POST", path), "Content-Type": "application/json" },
+      body: JSON.stringify({ id: bId, agentId: agentB.id, content: "agent b's memory" }),
+    });
+    expect(createRes.status, `B's creation returned ${await createRes.text()}`).toBe(200);
+
+    // Now agent A tries to feed a memory with agentB's id.
+    const spoofRes = await fetch(`${harper.httpURL}${path}`, {
+      method: "POST",
+      headers: { Authorization: ed25519Header(agentA, "POST", path), "Content-Type": "application/json" },
+      body: JSON.stringify({ id: bId, agentId: agentA.id, content: "trying to overwrite b" }),
+    });
+    const spoofText = await spoofRes.text();
+
+    // The fix rejects this: existing record's agentId (agentB) ≠ stamped agentId (agentA).
+    expect(spoofRes.status, `A's spoof returned ${spoofRes.status}: ${spoofText}`).toBe(403);
+  }, 30_000);
+
+  // ─── Positive control: agent writing its own feed memory still works ────
+
+  test("POSITIVE CONTROL: agent can feed its own memory", async () => {
+    const path = "/FeedMemories";
+    const res = await fetch(`${harper.httpURL}${path}`, {
+      method: "POST",
+      headers: { Authorization: ed25519Header(agentA, "POST", path), "Content-Type": "application/json" },
+      body: JSON.stringify({ agentId: agentA.id, content: "my own feed memory" }),
+    });
+    expect(res.status, `own feed returned ${await res.text()}`).toBe(200);
+    const body = await res.json();
+    expect(body.agentId).toBe(agentA.id);
+    expect(body.content).toBe("my own feed memory");
+  }, 30_000);
+
+  // ─── Positive control: agent can reference its own record id ────────────
+
+  test("POSITIVE CONTROL: agent can feed into its own record id", async () => {
+    const aId = `${agentA.id}-idorsafe`;
+    const path = "/FeedMemories";
+
+    // Agent A creates a memory with a known id.
+    const createRes = await fetch(`${harper.httpURL}${path}`, {
+      method: "POST",
+      headers: { Authorization: ed25519Header(agentA, "POST", path), "Content-Type": "application/json" },
+      body: JSON.stringify({ id: aId, agentId: agentA.id, content: "agent a's memory" }),
+    });
+    expect(createRes.status, `A's creation returned ${await createRes.text()}`).toBe(200);
+
+    // Agent A feeds again with the same id (same content = dedup, returns existing).
+    const updateRes = await fetch(`${harper.httpURL}${path}`, {
+      method: "POST",
+      headers: { Authorization: ed25519Header(agentA, "POST", path), "Content-Type": "application/json" },
+      body: JSON.stringify({ id: aId, agentId: agentA.id, content: "agent a's memory" }),
+    });
+    expect(updateRes.status, `A's update returned ${await updateRes.text()}`).toBe(200);
+    const updateBody = await updateRes.json();
+    expect(updateBody.agentId).toBe(agentA.id);
+  }, 30_000);
+
+  // ─── Anonymous rejection ───────────────────────────────────────────────
+
+  test("GUARD: anonymous POST /FeedMemories is rejected", async () => {
+    const path = "/FeedMemories";
+    const res = await fetch(`${harper.httpURL}${path}`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ agentId: agentA.id, content: "unauthenticated" }),
+    });
+    expect(res.status, `anonymous returned ${await res.text()}`).toBe(401);
+  }, 30_000);
+});

--- a/test/integration/memory-feed-idor.test.ts
+++ b/test/integration/memory-feed-idor.test.ts
@@ -55,7 +55,7 @@ describe("MemoryFeed IDOR guard (authz slice 4)", () => {
         operation: "insert", database: "flair", table: "Agent",
         records: [{ id: ag.id, name: ag.id, role: "agent", publicKey: ag.publicKey, createdAt: new Date().toISOString() }],
       });
-      expect(res.status, `register ${ag.id} → ${res.status}`).toBe(200);
+      expect(res.status).toBe(200);
     }
   }, 180_000);
 
@@ -72,12 +72,8 @@ describe("MemoryFeed IDOR guard (authz slice 4)", () => {
       headers: { Authorization: ed25519Header(agentA, "POST", path), "Content-Type": "application/json" },
       body: JSON.stringify({ agentId: agentB.id, content: "imposter memory" }),
     });
-    // The fix stamps agentId from the authenticated principal.
-    // Even though the body says agentB, the record is attributed to agentA.
-    expect(res.status).toBe(200);
-    const body = await res.json();
-    expect(body.agentId).toBe(agentA.id, "body-supplied agentId must be overridden to the authenticated principal");
-    expect(body.agentId).not.toBe(agentB.id);
+    // stamp-strict rejects body-supplied agentId mismatches as 403.
+    expect(res.status).toBe(403);
   }, 30_000);
 
   // ─── Guard: cannot target another agent's record via body id ────────────
@@ -91,7 +87,7 @@ describe("MemoryFeed IDOR guard (authz slice 4)", () => {
       headers: { Authorization: ed25519Header(agentB, "POST", path), "Content-Type": "application/json" },
       body: JSON.stringify({ id: bId, agentId: agentB.id, content: "agent b's memory" }),
     });
-    expect(createRes.status, `B's creation returned ${await createRes.text()}`).toBe(200);
+    expect(createRes.status).toBe(200);
 
     // Now agent A tries to feed a memory with agentB's id.
     const spoofRes = await fetch(`${harper.httpURL}${path}`, {
@@ -99,10 +95,9 @@ describe("MemoryFeed IDOR guard (authz slice 4)", () => {
       headers: { Authorization: ed25519Header(agentA, "POST", path), "Content-Type": "application/json" },
       body: JSON.stringify({ id: bId, agentId: agentA.id, content: "trying to overwrite b" }),
     });
-    const spoofText = await spoofRes.text();
 
     // The fix rejects this: existing record's agentId (agentB) ≠ stamped agentId (agentA).
-    expect(spoofRes.status, `A's spoof returned ${spoofRes.status}: ${spoofText}`).toBe(403);
+    expect(spoofRes.status).toBe(403);
   }, 30_000);
 
   // ─── Positive control: agent writing its own feed memory still works ────
@@ -114,7 +109,7 @@ describe("MemoryFeed IDOR guard (authz slice 4)", () => {
       headers: { Authorization: ed25519Header(agentA, "POST", path), "Content-Type": "application/json" },
       body: JSON.stringify({ agentId: agentA.id, content: "my own feed memory" }),
     });
-    expect(res.status, `own feed returned ${await res.text()}`).toBe(200);
+    expect(res.status).toBe(200);
     const body = await res.json();
     expect(body.agentId).toBe(agentA.id);
     expect(body.content).toBe("my own feed memory");
@@ -132,7 +127,7 @@ describe("MemoryFeed IDOR guard (authz slice 4)", () => {
       headers: { Authorization: ed25519Header(agentA, "POST", path), "Content-Type": "application/json" },
       body: JSON.stringify({ id: aId, agentId: agentA.id, content: "agent a's memory" }),
     });
-    expect(createRes.status, `A's creation returned ${await createRes.text()}`).toBe(200);
+    expect(createRes.status).toBe(200);
 
     // Agent A feeds again with the same id (same content = dedup, returns existing).
     const updateRes = await fetch(`${harper.httpURL}${path}`, {
@@ -140,8 +135,10 @@ describe("MemoryFeed IDOR guard (authz slice 4)", () => {
       headers: { Authorization: ed25519Header(agentA, "POST", path), "Content-Type": "application/json" },
       body: JSON.stringify({ id: aId, agentId: agentA.id, content: "agent a's memory" }),
     });
-    expect(updateRes.status, `A's update returned ${await updateRes.text()}`).toBe(200);
-    const updateBody = await updateRes.json();
+    // Read body once — avoid double-read (ERR_BODY_ALREADY_USED).
+    const updateText = await updateRes.text();
+    expect(updateRes.status).toBe(200);
+    const updateBody = JSON.parse(updateText);
     expect(updateBody.agentId).toBe(agentA.id);
   }, 30_000);
 
@@ -154,6 +151,6 @@ describe("MemoryFeed IDOR guard (authz slice 4)", () => {
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ agentId: agentA.id, content: "unauthenticated" }),
     });
-    expect(res.status, `anonymous returned ${await res.text()}`).toBe(401);
+    expect(res.status).toBe(401);
   }, 30_000);
 });

--- a/test/unit/memory-feed-idor.test.ts
+++ b/test/unit/memory-feed-idor.test.ts
@@ -1,0 +1,75 @@
+// MemoryFeed IDOR — unit mutation-verify (authz slice 4, flair#1064).
+//
+// Pure logic tests — no Harper needed. Simulates the fixed post() attribution
+// stamping and asserts that a spoofed body agentId is correctly overridden.
+//
+// Mutation-verify procedure (per the spec's standing requirement):
+//   1. In resources/MemoryFeed.ts, revert post() to the body-trusting version:
+//        - Remove the resolveAgentAuth + UNAUTH + agentId-stamping block
+//        - Restore `const agentId = String(content?.agentId ?? "");`
+//   2. Run: bun test test/unit/memory-feed-idor.test.ts
+//      → "fixed version stamps agentId" test still passes (it's a pure logic
+//        assertion against the mock, not against the file).
+//   3. Run the integration test: bun test test/integration/memory-feed-idor.test.ts
+//      → GUARD tests MUST FAIL (body-trusting version allows spoofing).
+//   4. Restore the fix (the current version of MemoryFeed.ts).
+//   5. Run the integration test again → GUARD tests MUST PASS.
+//
+// This unit test documents the logic difference:
+//   Fixed:  agentId = auth.agentId (stamped from principal)
+//   Broken: agentId = content.agentId (read from body)
+
+import { describe, expect, test } from "bun:test";
+
+describe("MemoryFeed IDOR — unit mutation-verify", () => {
+  // Simulated resolveAgentAuth result for a non-admin agent.
+  const mockAuth = { kind: "agent" as const, agentId: "principal-x", isAdmin: false };
+
+  test("fixed version stamps agentId from principal", () => {
+    // Simulate the fixed post() logic:
+    //   content.agentId = auth.agentId (for non-admin agents)
+    const content = { agentId: "attacker-y", content: "spoofed" };
+    if (mockAuth.kind === "agent" && !mockAuth.isAdmin) {
+      content.agentId = mockAuth.agentId;
+    }
+    expect(content.agentId).toBe("principal-x", "fixed version: agentId is stamped from principal");
+    expect(content.agentId).not.toBe("attacker-y", "fixed version: body-supplied agentId is overridden");
+  });
+
+  test("body-trusting version would NOT override (defect documented)", () => {
+    // Simulate the BROKEN post() logic — for documentation.
+    // This test always passes because it describes the defect, not the fix.
+    // The actual mutation-verify is done by reverting the file and running
+    // the integration test (see procedure above).
+    const content = { agentId: "attacker-y", content: "spoofed" };
+    const brokenAgentId = String(content?.agentId ?? "");
+    expect(brokenAgentId).toBe("attacker-y", "broken version: agentId comes from body — the defect");
+  });
+
+  test("body-supplied id ownership check: rejects cross-agent targets", () => {
+    // Simulate the id-ownership guard: if body supplies an id, check if
+    // the existing record belongs to the authenticated principal.
+    const stampedAgentId = mockAuth.agentId; // "principal-x"
+    const bodyId = "other-agent-record-123";
+    // Mock: the existing record belongs to a different agent.
+    const mockExistingRecord = { id: bodyId, agentId: "other-agent" };
+
+    // Guard logic: existing record exists AND its agentId differs → FORBIDDEN.
+    const isForbidden =
+      !!mockExistingRecord && mockExistingRecord.agentId !== stampedAgentId;
+
+    expect(isForbidden).toBe(true, "cross-agent id target must be rejected");
+  });
+
+  test("body-supplied id ownership check: allows own record", () => {
+    const stampedAgentId = mockAuth.agentId; // "principal-x"
+    const bodyId = "principal-x-record-456";
+    // Mock: the existing record belongs to the same agent.
+    const mockExistingRecord = { id: bodyId, agentId: "principal-x" };
+
+    const isForbidden =
+      !!mockExistingRecord && mockExistingRecord.agentId !== stampedAgentId;
+
+    expect(isForbidden).toBe(false, "own record id must be allowed");
+  });
+});

--- a/test/unit/memory-feed-idor.test.ts
+++ b/test/unit/memory-feed-idor.test.ts
@@ -32,8 +32,10 @@ describe("MemoryFeed IDOR — unit mutation-verify", () => {
     if (mockAuth.kind === "agent" && !mockAuth.isAdmin) {
       content.agentId = mockAuth.agentId;
     }
-    expect(content.agentId).toBe("principal-x", "fixed version: agentId is stamped from principal");
-    expect(content.agentId).not.toBe("attacker-y", "fixed version: body-supplied agentId is overridden");
+    // fixed version: agentId is stamped from principal
+    expect(content.agentId).toBe("principal-x");
+    // fixed version: body-supplied agentId is overridden
+    expect(content.agentId).not.toBe("attacker-y");
   });
 
   test("body-trusting version would NOT override (defect documented)", () => {
@@ -43,7 +45,8 @@ describe("MemoryFeed IDOR — unit mutation-verify", () => {
     // the integration test (see procedure above).
     const content = { agentId: "attacker-y", content: "spoofed" };
     const brokenAgentId = String(content?.agentId ?? "");
-    expect(brokenAgentId).toBe("attacker-y", "broken version: agentId comes from body — the defect");
+    // broken version: agentId comes from body — the defect
+    expect(brokenAgentId).toBe("attacker-y");
   });
 
   test("body-supplied id ownership check: rejects cross-agent targets", () => {
@@ -58,7 +61,8 @@ describe("MemoryFeed IDOR — unit mutation-verify", () => {
     const isForbidden =
       !!mockExistingRecord && mockExistingRecord.agentId !== stampedAgentId;
 
-    expect(isForbidden).toBe(true, "cross-agent id target must be rejected");
+    // cross-agent id target must be rejected
+    expect(isForbidden).toBe(true);
   });
 
   test("body-supplied id ownership check: allows own record", () => {
@@ -70,6 +74,7 @@ describe("MemoryFeed IDOR — unit mutation-verify", () => {
     const isForbidden =
       !!mockExistingRecord && mockExistingRecord.agentId !== stampedAgentId;
 
-    expect(isForbidden).toBe(false, "own record id must be allowed");
+    // own record id must be allowed
+    expect(isForbidden).toBe(false);
   });
 });


### PR DESCRIPTION
## What changed

**resources/MemoryFeed.ts** — `FeedMemories.post()` now resolves the authenticated principal via `resolveAgentAuth()` and stamps `agentId` from the principal using the kit's `stampAttribution()` in **stamp-strict** mode. Body-supplied `agentId` is no longer trusted: a mismatched value is rejected with 403 rather than silently overwritten. Additionally, a body-supplied record `id` is checked against the existing record's ownership before allowing the write.

**test/unit/memory-feed-idor.test.ts** — Pure logic tests for the attribution-stamping and id-ownership guard (4 tests, no Harper needed).

**test/integration/memory-feed-idor.test.ts** — Live Harper integration tests: guard against IDOR via body agentId spoofing and cross-agent record targeting, positive controls for own writes, and anonymous rejection.

## Why

The previous `post()` read `agentId` directly from `content.agentId` in the request body. A verified agent could feed a memory attributed to any `agentId` by including it in the body — even if the authenticated principal was different. A body-supplied `id` targeting another agent's record would silently overwrite it.

## The fix

1. **Resolve the authenticated principal** via `resolveAgentAuth()` at the start of `post()`.
2. **Stamp `agentId` from the principal via `stampAttribution(stamp-strict)`** — rejects body-supplied `agentId` mismatches with 403. A caller sending another agent's id is either buggy or probing, and both are worth surfacing rather than silently correcting.
3. **Guard body-supplied `id`** — if the body includes a record `id`, fetch the existing record and reject with 403 if its `agentId` differs from the stamped principal.
4. **Reject anonymous writes** — `UNAUTH()` for unauthenticated callers.

## Why stamp-strict over stamp-default

stamp-default silently overwrites a forged `agentId` with the principal's. stamp-strict rejects the mismatch with 403. This endpoint's entire defect was trusting body-supplied identity — a caller sending another agent's id is either buggy or probing, and both are worth seeing.

The risk with strict is breaking legitimate callers that echo `agentId` back in the body. **Verified: no such callers exist.** A full search of the flair repo (and the workspace) for `FeedMemories` and `/FeedMemories` returns only the resource definition itself and its own tests. There are no SDK wrappers, no CLI commands, and no internal callers that construct requests to this endpoint with a body-supplied `agentId`. The endpoint is consumed exclusively via HTTP POST by agents, and the only body shape that reaches it is whatever the agent sends. A caller echoing the *correct* agentId (matching the principal) passes through stamp-strict unchanged; a caller echoing a *wrong* one is exactly the bug this slice exists to prevent.

## Mutation-verify

Reverting `MemoryFeed.ts` to the body-trusting version (`const agentId = String(content?.agentId ?? "");`) allows a principal to feed a memory attributed to another agent via body agentId spoofing. The integration guard tests catch this.



No issue: tracked on our private ops board (ops-eluz, slice 4). Security hardening; the finding is not public.
