### PR TITLE
docs(changelog): scope the Bearer-token limit in the 0.36.0 notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,10 +44,20 @@ so a hand-written entry here is lost.
   (Ed25519 and Basic/agent-auth).  A deactivated agent can no longer
   authenticate with a new Ed25519 signature or a Basic credential.
 
-  **Known limit:** already-issued OAuth Bearer tokens survive deactivation
-  until expiry or explicit revocation.  This slice covers "deactivation
-  stops new authentications" only.  Full coverage (Bearer token
-  revocation on deactivation) is a follow-up slice.
+  **Known limit, and its actual scope:** already-issued OAuth Bearer tokens are not
+  checked against principal status.  **On a default deployment this is not an
+  exposure** — `/mcp` is the only surface that accepts a Flair-issued Bearer token,
+  it is not registered unless `FLAIR_MCP_OAUTH` is set, and Harper's own auth layer
+  claims any other `Bearer` header before a Flair resource sees it.
+
+  **If you have enabled MCP OAuth**, a deactivated agent's existing token keeps
+  working against `/mcp` until that token expires or is revoked, because the MCP
+  guard validates the JWT cryptographically without consulting the Agent table.
+  Until revocation-on-deactivation lands as a follow-up slice, deactivating an agent
+  on such a deployment should be paired with explicitly revoking its tokens.
+
+  So this slice covers "deactivation stops new authentications" everywhere, and
+  "deactivation stops all access" everywhere except an MCP-OAuth-enabled deployment.
 
 - **A hung old binary during a downgrade check is now reported as a hang, not as a clean refusal.**
   The downgrade invariant names three outcomes — the old binary boots, it refuses loudly, or


### PR DESCRIPTION
Notes-only change to the 0.36.0 CHANGELOG section. No code, no version change.

## Why this is worth a PR before the tag

The tag cuts the GitHub release from the CHANGELOG, so this wording becomes the permanent published
release note for 0.36.0. Fixing it after the tag means the artifact operators actually read stays
wrong.

## What was wrong

The deactivation entry said:

> **Known limit:** already-issued OAuth Bearer tokens survive deactivation until expiry or explicit
> revocation.

Accurate, but it never says *where* such a token can be used — so it reads as a general exposure
affecting everyone who upgrades.

## What the code actually says

Traced by Sherlock at my request, after I noticed the surrounding comments implied something
narrower than what we had published. All three checks are against merged code, not the spec:

1. `/mcp` is the only surface that accepts a Flair-issued Bearer token. `mcp-oauth.ts` registers
   `withMCPAuth` on the `/mcp` subroute **only** when `FLAIR_MCP_OAUTH` is truthy, and returns
   immediately otherwise — the documented default-OFF, byte-identical-when-off contract.
2. Harper's own auth layer claims any `Bearer` Authorization header for itself before a Flair
   resource sees it (`auth-middleware.ts:113-114`, `Federation.ts:252-253`).
3. No Flair REST resource validates Bearer tokens at all — `oauth-discovery.ts:62` states this
   outright. The OAuth endpoints issue and revoke tokens; they do not validate them.

**On a default deployment, a surviving Bearer token has no surface to authenticate against.**

## Why not just leave it

Overstating an exposure looks like the safe direction and isn't. It spends operator attention on a
problem they don't have, and — worse — it buries the operators who *do* have one. An MCP-OAuth
deployment has a real gap and a real action available today (revoke the deactivated agent's tokens),
and that action was invisible in a sentence addressed to everyone.

The revised entry separates the two cases and states the remedy.

## Follow-up this clarifies

Slice 1b was specced as "make Bearer validation consult principal status." That is **not** ours to
do — validation lives in `@harperfast/oauth`, which exposes no verify hook. But we own the
`OAuthToken` table and already set `revokedAt` in `OAuthRevoke`, so the same outcome is reachable by
revoking a principal's tokens on deactivation. Different mechanism, and it changes what 1b is.

## Review

Both K&S please. Sherlock: this is your analysis — confirm I have represented it correctly and
haven't over-corrected in the other direction. If any part of the trace is wrong, say so; I did not
execute it myself.

---

No issue: release-note wording correction found during the 0.36.0 cut, before the tag. Filing an
issue to close it in the same hour would be ceremony — the work is one paragraph and it must land
ahead of the tag or not at all. The follow-up it *does* imply (revocation-on-deactivation, i.e. the
real slice 1b) is tracked separately in the authz hardening spec.
