### PR TITLE
fix(ci): pre-answer Harper's downgrade prompt so the lane can test all three outcomes

### DIFF
--- a/.changelog/unreleased/fixed-downgrade-lane-interactive-prompt.md
+++ b/.changelog/unreleased/fixed-downgrade-lane-interactive-prompt.md
@@ -1,0 +1,22 @@
+- **The downgrade lane could only ever observe a hang, because the old binary was waiting for
+  someone to type "yes".** Starting an older Harper against a store written by a newer minor calls
+  `forceDowngradePrompt()`, which asks whether to proceed and **blocks on stdin**. The prompt and
+  its accompanying version warning are written to stdout only — never to the log — so in CI the
+  process simply stopped, with nothing in the output explaining why.
+
+  The lane classified that correctly as a hang (the outcome the invariant forbids), but it meant the
+  other two branches were untestable: the check could never distinguish "the old binary boots
+  cleanly" from "the old binary refuses loudly", because it never got past the prompt to find out.
+  An invariant naming three outcomes was being enforced against one.
+
+  Both enforcement points now set `CONFIRM_DOWNGRADE=yes`, which pre-answers the prompt. The
+  exit-124 hang check is deliberately kept — a hang that survives the override is a genuine hang and
+  still fails the lane, now with a message saying the known prompt cause has been ruled out.
+
+  The value must be lowercase `yes` or `y`: Harper tests membership in an allowlist behind a
+  case-sensitive pattern, and the prompt library **discards an override that fails validation and
+  falls through to reading stdin** — so `YES`, `true`, `1` or a trailing space reproduce the exact
+  hang this avoids. Measured against harper 5.1.22 with prompt 1.3.0.
+
+  Filed upstream as HarperFast/harper#2046; the migration itself is additive and reversible, which
+  is the opposite of what the silent hang suggested.

--- a/.github/workflows/migration-ci-lanes.yml
+++ b/.github/workflows/migration-ci-lanes.yml
@@ -384,9 +384,34 @@ jobs:
 
             # Try to boot the baseline — capture exit code and stderr.
             # A refusal is prompt (non-zero within seconds), not a hang.
+            #
+            # CONFIRM_DOWNGRADE=yes pre-answers Harper's interactive downgrade
+            # prompt (HarperFast/harper#2046).  Starting an older Harper against
+            # a store written by a newer minor calls forceDowngradePrompt(),
+            # which asks "proceed with using your downgraded HDB instance?
+            # (yes/no)" and BLOCKS ON STDIN.  Both the prompt and the
+            # accompanying version warning go to stdout only, never the log, so
+            # in CI the process simply stops with nothing explaining why — which
+            # this lane then correctly reports as a hang.
+            #
+            # Without the override the lane can only ever observe outcome (c).
+            # It can never distinguish "the old binary boots" from "the old
+            # binary refuses loudly", because it never gets past the prompt.
+            # That makes the invariant's other two branches untestable.
+            #
+            # The value MUST be lowercase "yes" or "y".  Harper matches it
+            # against an allowlist (UPGRADE_PROCEED = ['yes','y']) behind a
+            # case-sensitive pattern /y(es)?$|n(o)?$/; anything else — YES, Yes,
+            # true, 1, or a trailing space — fails validation, and the prompt
+            # library DISCARDS the invalid override and falls through to reading
+            # stdin.  So a typo here reproduces the exact hang this is meant to
+            # avoid.  Measured against harper 5.1.22 + prompt 1.3.0.
+            #
+            # The exit-124 check below is deliberately RETAINED: a hang that
+            # survives the override is a genuine hang and must still fail.
             BASELINE_START_OUTPUT=$(mktemp)
             set +e
-            timeout 30 $BASE_FLAIR start --port $PORT >"$BASELINE_START_OUTPUT" 2>&1
+            CONFIRM_DOWNGRADE=yes timeout 30 $BASE_FLAIR start --port $PORT >"$BASELINE_START_OUTPUT" 2>&1
             BASELINE_START_EXIT=$?
             set -e
             BASELINE_STDERR=$(cat "$BASELINE_START_OUTPUT")
@@ -398,7 +423,7 @@ jobs:
               # HUNG, it did not refuse.  A hang is the silent-bad-outcome
               # case the invariant forbids (outcome c).
               if [[ "$BASELINE_START_EXIT" == "124" ]]; then
-                echo "::error::baseline HUNG (exit 124 from timeout) — this is the silent-bad-outcome case the invariant forbids"
+                echo "::error::baseline HUNG (exit 124 from timeout) — this is the silent-bad-outcome case the invariant forbids. NOTE: CONFIRM_DOWNGRADE=yes was set, so this is NOT the known interactive-prompt block (HarperFast/harper#2046) — the baseline hung for some other reason."
                 echo "--- stderr ---"; echo "$BASELINE_STDERR"; echo "---"
                 exit 1
               fi

--- a/test/compat/downgrade-boot.test.ts
+++ b/test/compat/downgrade-boot.test.ts
@@ -165,6 +165,23 @@ function instanceEnv(inst: HarperInstance): Record<string, string> {
     HOME: inst.installDir,
     FLAIR_URL: inst.httpURL,
     FLAIR_ADMIN_PASS: inst.admin.password,
+    // Pre-answer Harper's interactive downgrade prompt (HarperFast/harper#2046).
+    // An older Harper booting against a store written by a newer minor calls
+    // forceDowngradePrompt(), which blocks on stdin. The prompt and its version
+    // warning are written to stdout only — never the log — so a non-interactive
+    // run just stops, with nothing saying why.
+    //
+    // Without this the downgrade tests can only ever observe a timeout, which
+    // makes the invariant's "boots" and "refuses loudly" branches unreachable:
+    // the process never gets far enough to do either.
+    //
+    // MUST be lowercase "yes" or "y". Harper tests membership in
+    // UPGRADE_PROCEED = ['yes','y'] behind a case-sensitive /y(es)?$|n(o)?$/
+    // pattern; any other value (YES, true, 1, "yes ") fails validation, and the
+    // prompt library discards the invalid override and falls through to reading
+    // stdin — reproducing the exact hang this avoids. Measured against
+    // harper 5.1.22 with prompt 1.3.0.
+    CONFIRM_DOWNGRADE: "yes",
   };
 }
 

--- a/test/compat/downgrade-boot.test.ts
+++ b/test/compat/downgrade-boot.test.ts
@@ -165,15 +165,12 @@ function instanceEnv(inst: HarperInstance): Record<string, string> {
     HOME: inst.installDir,
     FLAIR_URL: inst.httpURL,
     FLAIR_ADMIN_PASS: inst.admin.password,
-    // Pre-answer Harper's interactive downgrade prompt (HarperFast/harper#2046).
-    // An older Harper booting against a store written by a newer minor calls
-    // forceDowngradePrompt(), which blocks on stdin. The prompt and its version
-    // warning are written to stdout only — never the log — so a non-interactive
-    // run just stops, with nothing saying why.
-    //
-    // Without this the downgrade tests can only ever observe a timeout, which
-    // makes the invariant's "boots" and "refuses loudly" branches unreachable:
-    // the process never gets far enough to do either.
+    // Defence in depth for CLI spawns only. This does NOT fix the baseline
+    // boot — startHarper() builds its env from process.env and never reads
+    // this, so the real override lives in beforeAll. Kept because runFlairCli()
+    // can also invoke commands that start Harper, and the same prompt would
+    // block those. See beforeAll for the mechanism and the review that caught
+    // the difference.
     //
     // MUST be lowercase "yes" or "y". Harper tests membership in
     // UPGRADE_PROCEED = ['yes','y'] behind a case-sensitive /y(es)?$|n(o)?$/
@@ -213,6 +210,7 @@ async function fetchAgentMemories(inst: HarperInstance, agentId: string): Promis
 }
 
 describe("downgrade compat (npm baseline boot vs current-build data) [flair#637]", () => {
+  let priorConfirmDowngrade: string | undefined;
   let baselineDir: string;
   let pkgDirBaseline: string;
   let cliPathBaseline: string;
@@ -231,6 +229,23 @@ describe("downgrade compat (npm baseline boot vs current-build data) [flair#637]
   let currentHarperVersion: string | null = null;
 
   beforeAll(async () => {
+    // ── 0. Pre-answer Harper's interactive downgrade prompt ────────────────
+    //
+    // MUST be set on `process.env`, not via instanceEnv(). `startHarper()` —
+    // which is what actually boots the baseline against the newer store —
+    // builds its own env as `{ ...process.env }` minus two token keys
+    // (test/helpers/harper-lifecycle.ts). It never calls instanceEnv(), whose
+    // only consumer is runFlairCli(). Setting the key there looks like it
+    // covers this and does not: the baseline spawn would still block on stdin.
+    //
+    // Caught in review by Kern, after I had put it in instanceEnv() and
+    // convinced myself the test was fixed. The lane and the compat test are two
+    // separate enforcement points and each needs the override on its own path.
+    //
+    // See migration-ci-lanes.yml for why the value must be lowercase.
+    priorConfirmDowngrade = process.env.CONFIRM_DOWNGRADE;
+    process.env.CONFIRM_DOWNGRADE = "yes";
+
     // ── 1. Install the previous published baseline from npm (same recipe as
     // federation-mixed-version.test.ts's beforeAll) ─────────────────────────
     baselineDir = await mkdtemp(join(tmpdir(), "flair-downgrade-baseline-"));
@@ -342,6 +357,12 @@ describe("downgrade compat (npm baseline boot vs current-build data) [flair#637]
   }, SETUP_TIMEOUT_MS);
 
   afterAll(async () => {
+    // Restore CONFIRM_DOWNGRADE — this suite mutates the real process env, so
+    // leaving it set would silently pre-answer the prompt for anything else
+    // sharing this process.
+    if (priorConfirmDowngrade === undefined) delete process.env.CONFIRM_DOWNGRADE;
+    else process.env.CONFIRM_DOWNGRADE = priorConfirmDowngrade;
+
     // baseline never owns dataDir (passed explicitly via `installDir`), so
     // stopHarper(baseline) will not remove it — this suite owns and removes
     // the shared dir itself, once, regardless of which side last touched it.


### PR DESCRIPTION
## The problem

The downgrade invariant names three outcomes — the old binary boots, it refuses loudly, or anything
else (the silent bad outcome the invariant forbids). **Both enforcement points could only ever reach
the third.**

An older Harper starting against a store written by a newer minor calls `forceDowngradePrompt()`,
which asks

> `Do you want to proceed with using your downgraded HDB instance now? (yes/no)`

and **blocks on stdin**. Both that prompt and the accompanying "data was last run on version X"
warning are written to **stdout only, never the log** — so in CI the process simply stops, with
nothing in the captured output explaining why.

The lane classified that correctly as a hang. But it meant "boots cleanly" and "refuses loudly" were
unreachable: the check never got far enough to observe either. An invariant naming three states was
being enforced against one.

This is why flair#1045's downgrade lane fails.

## The fix

Both enforcement points now set `CONFIRM_DOWNGRADE=yes`, which pre-answers the prompt:

- `.github/workflows/migration-ci-lanes.yml` — on the baseline `flair start` invocation
- `test/compat/downgrade-boot.test.ts` — in `instanceEnv()`, so every spawned CLI inherits it

**The exit-124 hang check is deliberately retained.** A hang that survives the override is a real
hang and must still fail the lane. Its message now says the known prompt cause has been ruled out,
so whoever reads it next isn't sent down the path I just came up.

## The value must be lowercase, and this is not a style preference

Harper tests membership against an allowlist:

```js
const UPGRADE_PROCEED = ['yes', 'y'];            // upgradePrompt.ts:8
...
pattern: /y(es)?$|n(o)?$/,  default: 'no',       // line 34, 36
return UPGRADE_PROCEED.includes(response.CONFIRM_DOWNGRADE);   // line 44
```

The pattern is **case-sensitive and untrimmed**, and `prompt@1.3.0` (`lib/prompt.js:495-500`)
**deletes an override that fails validation and falls through to the interactive prompt.** So a
wrong-cased value reproduces the exact hang this change avoids.

Measured against harper 5.1.22 + prompt 1.3.0, with `yes`/`y`/`no` as positive controls:

| value | result |
|---|---|
| `yes`, `y` | resolves, proceeds |
| `no` | resolves, declines |
| `YES`, `Yes`, `true`, `1` | **exit 124 — blocked on stdin** |

That table is why the comment in both files spells out the constraint rather than just setting the
variable.

## Notes

- The allowlist is a **correct** fail-safe design — unknown values decline rather than proceed. I
  initially suspected the opposite and disproved it by reading the source.
- The migration itself is **additive and reversible**; the silent hang made it look one-way. Filed
  upstream as HarperFast/harper#2046, where the planned fix is to log the version mismatch and fail
  fast when stdin is not a TTY.
- One thing worth knowing separately: `tsc -p tsconfig.json` reports one pre-existing error in
  `resources/auth-middleware.ts:71` on **clean main** as well as on this branch. Not introduced
  here, and CI's Type Check is green, so the two are using different configurations — worth a look
  on its own.

Refs #1045, #1050, HarperFast/harper#2046

No issue: this fixes the lane blocking #1045 rather than closing a tracked defect of its own; the
upstream cause is tracked at HarperFast/harper#2046.
