### PR TITLE
fix: changelog gate checks the change not the directory, plus three small fixes

### DIFF
--- a/.changelog/unreleased/fixed-changelog-gate-and-small-batch.md
+++ b/.changelog/unreleased/fixed-changelog-gate-and-small-batch.md
@@ -1,0 +1,30 @@
+- **The changelog gate now asks whether *your* change wrote an entry, not whether the directory is
+  non-empty.** The old rule fired only when `.changelog/unreleased/` was empty *and* feat/fix commits
+  had landed since the last tag — so the first PR after a release cut satisfied it for every PR that
+  followed, until the next cut emptied the directory again.
+
+  That is not hypothetical. On 2026-08-03 four PRs merged with no fragment while the directory held
+  three entries from earlier work; the gate passed on all four, and v0.36.0 was assembled with
+  release notes omitting three authz security fixes — the entire reason to upgrade. They were
+  backfilled by hand at the cut, which is the moment this check exists to make unnecessary.
+
+  The gate now also compares against the PR's merge base and requires a fragment to have been
+  **added** in that range. Editing an entry someone else staged is not writing your own. The
+  since-tag rule is kept, because it still catches the empty-directory-at-release case; where no
+  base ref is reachable (shallow clone, no `origin`) the per-change half is skipped and the
+  since-tag half still runs.
+
+- **`models/*.gguf.downloading` is now ignored.** `.gitignore` covered `*.gguf` but not the
+  in-progress placeholder Harper writes beside it, and the integration harness points
+  `FLAIR_MODELS_DIR` at the repo's own `models/` directory — so a killed test run left an untracked
+  file in the working tree.
+
+- **Removed the redundant `postinstall` chmod.** npm already sets the executable bit on files
+  referenced by `bin` when it links them; the script changed nothing and cost a line in npm's
+  install-script approval prompt, on a package whose install output is already noisy.
+
+- **`docs/upgrade.md` no longer links to a CHANGELOG that isn't there.** The guide ships in the npm
+  package and pointed at `../CHANGELOG.md`, which the `files` allowlist excludes — so the first
+  instruction in the upgrade guide was a dead link for every reader who installed from the registry.
+  The three links now resolve to the published copy on GitHub, rather than adding a 1400-line file
+  to an install that is already too heavy.

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,9 @@ dist/
 .DS_Store
 package-lock.json
 *.gguf
+# Harper writes this placeholder while a model downloads; a killed run leaves
+# it behind as an untracked file (flair#1066). *.gguf does not cover it.
+*.gguf.downloading
 resources/*.js
 test-results/
 playwright-report/

--- a/docs/upgrade.md
+++ b/docs/upgrade.md
@@ -2,7 +2,7 @@
 
 This page covers the mechanics of upgrading Flair — the general path, valid across
 versions. For **what changed in a specific release** (behavior changes, new surfaces,
-breaking changes), see [`CHANGELOG.md`](../CHANGELOG.md) — each version has its own
+breaking changes), see [`CHANGELOG.md`](https://github.com/tpsdev-ai/flair/blob/main/CHANGELOG.md) — each version has its own
 `## [X.Y.Z]` section. Check the CHANGELOG entries between your current version and the
 target version before upgrading anything you depend on in production.
 
@@ -370,7 +370,7 @@ flair restore ~/flair-backup-<date>.json
 
 ### Known issue — upgrading *from* an older version can still report a false rollback
 
-The 0.25.1 fix (see [`CHANGELOG.md`](../CHANGELOG.md)) makes `flair upgrade` resolve a
+The 0.25.1 fix (see [`CHANGELOG.md`](https://github.com/tpsdev-ai/flair/blob/main/CHANGELOG.md)) makes `flair upgrade` resolve a
 credentials-only post-restart-verification failure to `healthy-unverified` instead of
 rolling back. That fix is **forward-only**: it lives in the *new* CLI code, but an
 upgrade's post-restart verification is run by the CLI that was already installed
@@ -526,7 +526,7 @@ you haven't personally tested.
 
 ## See also
 
-- [`CHANGELOG.md`](../CHANGELOG.md) — what actually changed, version by version.
+- [`CHANGELOG.md`](https://github.com/tpsdev-ai/flair/blob/main/CHANGELOG.md) — what actually changed, version by version.
 - [`docs/releasing.md`](releasing.md) — how a release gets published in the first
   place (staged npm publish with 2FA approval), if you're curious why a new version
   shows up when it does.

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@tpsdev-ai/flair",
   "version": "0.36.0",
   "packageManager": "bun@1.3.10",
-  "description": "Identity, memory, and soul for AI agents. Cryptographic identity (Ed25519), semantic memory with local embeddings, and persistent personality — all in a single process.",
+  "description": "Identity, memory, and soul for AI agents. Cryptographic identity (Ed25519), semantic memory with local embeddings, and persistent personality \u2014 all in a single process.",
   "type": "module",
   "license": "Apache-2.0",
   "repository": {
@@ -52,8 +52,7 @@
     "prepublishOnly": "npm run build && npm run build:cli",
     "test": "bun test",
     "test:e2e": "playwright test",
-    "release": "./scripts/release.sh",
-    "postinstall": "node -e \"try{const{chmodSync,statSync}=require('fs');for(const p of ['dist/cli-shim.cjs','dist/cli.js']){try{if(statSync(p).isFile()){chmodSync(p,0o755);console.error('@tpsdev-ai/flair: chmod +x ' + p + ' OK')}}catch(e){if(e.code!=='ENOENT')console.error('postinstall warn:',e.message)}}}catch(e){console.error('postinstall warn:',e.message)}\""
+    "release": "./scripts/release.sh"
   },
   "publishConfig": {
     "access": "public"

--- a/scripts/docs-freshness-check.mjs
+++ b/scripts/docs-freshness-check.mjs
@@ -405,6 +405,56 @@ defineCheck("changelog-unreleased", null, () => {
       msg: `no changelog fragments staged, but ${commitsSinceTag} feat/fix commit(s) have landed since the last release tag. Add ${FRAGMENT_DIR_REL}/<category>-<slug>.md describing what changed (categories: ${CATEGORIES.join(", ")}).`,
     });
   }
+
+  // ── Per-change rule (flair#1036) ─────────────────────────────────────────────
+  // The rule above asks whether the DIRECTORY is non-empty, which makes it nearly
+  // inert: once any one PR contributes a fragment, every subsequent PR satisfies
+  // it until the next release empties the directory again. Its only live window
+  // is the first PR after a cut.
+  //
+  // Measured, not hypothetical: on 2026-08-03, PRs #1068, #1069, #1070 and #1071
+  // all merged with no fragment while the directory held three from earlier work.
+  // The gate passed on every one of them, and v0.36.0 was assembled with release
+  // notes omitting three authz security fixes — the entire reason to upgrade.
+  // They were backfilled by hand at the release cut, which is exactly the moment
+  // this check exists to make unnecessary.
+  //
+  // So ask the question about THIS change instead: did the commits under review
+  // add a fragment? A fragment must be ADDED (--diff-filter=A) — editing someone
+  // else's staged entry is not writing your own.
+  const baseRef = process.env.GITHUB_BASE_REF
+    ? `origin/${process.env.GITHUB_BASE_REF}`
+    : "origin/main";
+  try {
+    const base = execFileSync("git", ["merge-base", "HEAD", baseRef],
+      { cwd: ROOT, stdio: ["ignore", "pipe", "ignore"] }).toString().trim();
+    if (base) {
+      const range = `${base}..HEAD`;
+      const subjects = execFileSync("git", ["log", range, "--pretty=%s"],
+        { cwd: ROOT, stdio: ["ignore", "pipe", "ignore"] }).toString().trim();
+      const changeCommits = subjects
+        ? subjects.split("\n").filter((s) => /^(feat|fix)(\(|!|:)/.test(s)).length
+        : 0;
+      const added = execFileSync("git",
+        ["diff", "--diff-filter=A", "--name-only", range, "--", `${FRAGMENT_DIR_REL}/`],
+        { cwd: ROOT, stdio: ["ignore", "pipe", "ignore"] }).toString().trim();
+      const addedCount = added ? added.split("\n").filter((p) => !/\/README\.md$/.test(p)).length : 0;
+
+      if (changeCommits > 0 && addedCount === 0) {
+        failures.push({
+          file: `${FRAGMENT_DIR_REL}/`, line: 1,
+          msg: `this change has ${changeCommits} feat/fix commit(s) since ${baseRef} but adds no changelog fragment. The directory being non-empty is not enough — an entry already there belongs to someone else's change. Add ${FRAGMENT_DIR_REL}/<category>-<slug>.md (categories: ${CATEGORIES.join(", ")}).`,
+        });
+      }
+    }
+  } catch {
+    // No base ref reachable — a shallow clone, a detached build, or a repo with
+    // no `origin`. The since-tag rule above still ran, so coverage is partial
+    // rather than absent, and the release-cut case is still guarded. Deliberately
+    // not a skip: skips suppress the whole check, and the half that DID run is
+    // the half that catches an empty directory at a release.
+  }
+
   return failures;
 });
 


### PR DESCRIPTION
Four issues, all small and mechanical except the first. Batched because four separate review cycles
for one-line changes costs more attention than it saves.

## flair#1036 — the changelog gate could not catch a single PR omitting its entry

The rule asked whether `.changelog/unreleased/` was non-empty. Once any one PR contributed a
fragment, every subsequent PR satisfied it until the next release emptied the directory again. Its
only live window was the first PR after a cut.

**This is not hypothetical, and it cost us today.** On 2026-08-03 PRs #1068, #1069, #1070 and #1071
all merged with no fragment while the directory held three entries from earlier work. The gate
passed on every one. v0.36.0 was then assembled with release notes omitting three authz security
fixes — the entire reason to upgrade — and I backfilled them by hand at the cut, which is precisely
the moment this check exists to make unnecessary.

The gate now also compares against the PR's merge base and requires a fragment to have been **added**
(`--diff-filter=A`) in that range. Editing an entry someone else staged is not writing your own.

The since-tag rule is retained: it still catches the empty-directory-at-release case. Where no base
ref is reachable (shallow clone, no `origin`), the per-change half is skipped and the since-tag half
still runs — deliberately not a skip, because skips suppress the whole check and the half that does
run is the half that guards a release.

### Both controls, because a gate that cannot fail is the bug being fixed

| fixture | expected | result |
|---|---|---|
| feat/fix commit, **no** fragment added, directory non-empty (so the old rule passes) | fail | **exit 1**, new message |
| feat/fix commit that **does** add its own fragment | pass | **exit 0** |

Worth recording that this took four attempts to test correctly: the first probe exercised the *old*
rule (empty directory), the second put both commits on one branch so the range legitimately
contained a fragment, and the third stashed my own modified script and tested unmodified code. Only
the fourth was a fixture that could express the defect.

## flair#1066 — `models/*.gguf.downloading` not ignored

`.gitignore` covered `*.gguf` but not the in-progress placeholder Harper writes beside it, and
`test/helpers/harper-lifecycle.ts` points `FLAIR_MODELS_DIR` at the repo's own `models/`. A killed
integration run left an untracked file in the working tree. `git check-ignore` confirms the new rule
matches.

## flair#1008 — redundant `postinstall` chmod

npm already sets the executable bit on `bin` entries when it links them, so the script changed
nothing — and it cost a line in npm's install-script approval prompt on a package whose install
output is already noisier than it should be. `bin` is unchanged; the shim keeps its mode from npm.

## flair#994 — `docs/upgrade.md` linked a CHANGELOG that does not ship

The guide ships in the npm package and its **first instruction** pointed at `../CHANGELOG.md`, which
the `files` allowlist excludes — a dead link for everyone who installed from the registry. Three
links repointed to the published copy on GitHub rather than adding a 1400-line file to an install
that #1004 already flags as too heavy.

Closes #1036, closes #1066, closes #1008, closes #994
