### PR TITLE
security(deps): override undici, brace-expansion and fast-uri to clear 7 advisories

### DIFF
--- a/.changelog/unreleased/security-resolve-seven-advisories-via-overrides.md
+++ b/.changelog/unreleased/security-resolve-seven-advisories-via-overrides.md
@@ -1,0 +1,26 @@
+- **Seven advisories resolved by pinning three transitive dependencies forward.** A wave of
+  advisories published on 2026-08-03 took the dependency gate from one blocking entry to seven, and
+  five of them were the same package:
+
+  | package | advisories | worst |
+  |---|---|---|
+  | `undici` → `^8.9.0` | 5 | **high** — cross-user information disclosure |
+  | `brace-expansion` → `^5.0.9` | 1 | **high** — DoS via unbounded intermediate arrays, bypassing the CVE-2026-14257 mitigation |
+  | `fast-uri` → `^4.1.2` | 1 | **high** — host confusion via backslash |
+
+  All three reach us transitively — through `pi-coding-agent`, `openclaw`, and
+  `harper › @fastify/static › glob › minimatch` — so none could be fixed by changing a direct
+  dependency. Total advisories drop from 21 to 14, and every remaining one is allowlisted with a
+  dated justification.
+
+  These are plain version overrides, deliberately **not** `npm:` aliases. flair#750 records an alias
+  override (`harper` → `npm:@harperfast/harper@…`) that collided with the already-installed scoped
+  copy, left npm's tree `invalid`, and made any second npm operation fail — which broke the clean-VM
+  install gate and was reverted. A version constraint introduces no second package name, so that
+  failure mode is absent by construction. Verified: build, a second `bun install` against the
+  reified tree, and the full unit suite (3859 tests) all pass.
+
+  Worth stating for whoever revisits these: an override is a **forward pin, not a fix**. Each one is
+  correct only until the upstream dependency resolves the advisory itself, at which point the
+  override becomes a pin holding a version we no longer need to hold. Re-check them at each
+  dependency bump rather than treating them as settled.

--- a/bun.lock
+++ b/bun.lock
@@ -130,7 +130,10 @@
     "harper-fabric-embeddings",
   ],
   "overrides": {
+    "brace-expansion": "^5.0.9",
+    "fast-uri": "^4.1.2",
     "react-native-fs": "npm:empty-npm-package@1.0.0",
+    "undici": "^8.9.0",
   },
   "packages": {
     "@agentclientprotocol/sdk": ["@agentclientprotocol/sdk@1.1.0", "", { "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" } }, "sha512-NT2KqphUJ3w6EksUL51ZhJgIYgq/ZLGcBPkyMKgRSO5PMVwe9DnKKX+Htnvk6KHh6dUuh34UHK4gKp+4te1Mdg=="],
@@ -691,7 +694,7 @@
 
     "bowser": ["bowser@2.14.1", "", {}, "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg=="],
 
-    "brace-expansion": ["brace-expansion@5.0.8", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg=="],
+    "brace-expansion": ["brace-expansion@5.0.9", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg=="],
 
     "braces": ["braces@3.0.3", "", { "dependencies": { "fill-range": "^7.1.1" } }, "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA=="],
 
@@ -935,7 +938,7 @@
 
     "fast-string-width": ["fast-string-width@3.0.2", "", { "dependencies": { "fast-string-truncated-width": "^3.0.2" } }, "sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg=="],
 
-    "fast-uri": ["fast-uri@3.1.4", "", {}, "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw=="],
+    "fast-uri": ["fast-uri@4.1.2", "", {}, "sha512-TyGmBcbDTZXcb2cj5MV89DrF42DKvb3y5DDUNh95iO+IMeAzMkVSxK1PZRrRIpc9yg8U2GhGdbofNa0LS/a4Bw=="],
 
     "fast-wrap-ansi": ["fast-wrap-ansi@0.2.2", "", { "dependencies": { "fast-string-width": "^3.0.2" } }, "sha512-7F2Fl+TjRSenLqlU3UjSH0iyqopqoZIu7eZVpEirP2g1GtWa2G/ecEmBdgz31+Mxr+ELclgg6sokpSFIQiZ02Q=="],
 
@@ -1725,7 +1728,7 @@
 
     "ulidx": ["ulidx@0.5.0", "", { "dependencies": { "layerr": "^0.1.2" } }, "sha512-fZFAVMxsp3QSwOpIta6uqc3ZjHfRe4m3GllM+HO4MNQMXlzcUhWihHKWuBxFcDYATsuyxjBwCH0MqVsj/D/how=="],
 
-    "undici": ["undici@8.5.0", "", {}, "sha512-xamtWoB1EshgjpmlXd7GGm2VfdDtw1+rD8uhry8pSNW3If6S8E0m2T2+orSKeZXEn/aPJMviCpDBA65WJt8zhg=="],
+    "undici": ["undici@8.10.0", "", {}, "sha512-HvltHd7avK13QIw/oLe4qoOLyoVSoafqJ2jYOrtMRBkbYT31eiBQ8O0ehRKZiEZCMEyLFQNIADpgCWC5fALvYQ=="],
 
     "undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
 
@@ -1833,8 +1836,6 @@
 
     "@mariozechner/pi-ai/typebox": ["typebox@1.3.8", "", {}, "sha512-xYaJgF0KMvBViKWRaKTAtfR6sDt/yH6xAjGAHXYJxKxUF4pVyPXZZhIlwOg6cDIE81N7L0pyIHs136RHBm6rLQ=="],
 
-    "@mariozechner/pi-ai/undici": ["undici@7.29.0", "", {}, "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw=="],
-
     "@mariozechner/pi-coding-agent/chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
 
     "@mariozechner/pi-coding-agent/diff": ["diff@8.0.4", "", {}, "sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw=="],
@@ -1844,8 +1845,6 @@
     "@mariozechner/pi-coding-agent/hosted-git-info": ["hosted-git-info@9.0.3", "", { "dependencies": { "lru-cache": "^11.1.0" } }, "sha512-Hc+ghLoSt6QaYZUv0WBiIvmMDZuZZ7oaDvdH8MbfOO4lOsxdXLEvuC6ePoGs9H1X9oCLyq6+NVN0MKqD+ydxyg=="],
 
     "@mariozechner/pi-coding-agent/typebox": ["typebox@1.3.8", "", {}, "sha512-xYaJgF0KMvBViKWRaKTAtfR6sDt/yH6xAjGAHXYJxKxUF4pVyPXZZhIlwOg6cDIE81N7L0pyIHs136RHBm6rLQ=="],
-
-    "@mariozechner/pi-coding-agent/undici": ["undici@7.29.0", "", {}, "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw=="],
 
     "@mariozechner/pi-coding-agent/uuid": ["uuid@14.0.1", "", { "bin": { "uuid": "dist-node/bin/uuid" } }, "sha512-6ZxzVpzDXDa3bJWaHilVayA+BH/1zmxCJoVgvmqJnid/gPoKHxUrS/aC/T6LGQtNHT+XHG9fXPJB4d+IrU30Ew=="],
 
@@ -1890,8 +1889,6 @@
     "duplexify/readable-stream": ["readable-stream@2.3.8", "", { "dependencies": { "core-util-is": "~1.0.0", "inherits": "~2.0.3", "isarray": "~1.0.0", "process-nextick-args": "~2.0.0", "safe-buffer": "~5.1.1", "string_decoder": "~1.1.1", "util-deprecate": "~1.0.1" } }, "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA=="],
 
     "ecdsa-sig-formatter/safe-buffer": ["safe-buffer@5.2.1", "", {}, "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="],
-
-    "fast-json-stringify/fast-uri": ["fast-uri@4.1.1", "", {}, "sha512-YPOs1zD5TG2+EZt+r88LwF6mclA7TPkpwMP7ZN3TO2HiHS8TXvq7QA/17iJsV9dubcLo/f8eEYqMBruyQV21hQ=="],
 
     "fastify/pino": ["pino@10.3.1", "", { "dependencies": { "@pinojs/redact": "^0.4.0", "atomic-sleep": "^1.0.0", "on-exit-leak-free": "^2.1.0", "pino-abstract-transport": "^3.0.0", "pino-std-serializers": "^7.0.0", "process-warning": "^5.0.0", "quick-format-unescaped": "^4.0.3", "real-require": "^0.2.0", "safe-stable-stringify": "^2.3.1", "sonic-boom": "^4.0.1", "thread-stream": "^4.0.0" }, "bin": { "pino": "bin.js" } }, "sha512-r34yH/GlQpKZbU1BvFFqOjhISRo1MNx1tWYsYvmj6KIRHSPMT2+yHOEb1SG6NMvRoHRF0a07kCOox/9yakl1vg=="],
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@tpsdev-ai/flair",
   "version": "0.36.0",
   "packageManager": "bun@1.3.10",
-  "description": "Identity, memory, and soul for AI agents. Cryptographic identity (Ed25519), semantic memory with local embeddings, and persistent personality — all in a single process.",
+  "description": "Identity, memory, and soul for AI agents. Cryptographic identity (Ed25519), semantic memory with local embeddings, and persistent personality \u2014 all in a single process.",
   "type": "module",
   "license": "Apache-2.0",
   "repository": {
@@ -73,7 +73,10 @@
     "tweetnacl": "1.0.3"
   },
   "overrides": {
-    "react-native-fs": "npm:empty-npm-package@1.0.0"
+    "react-native-fs": "npm:empty-npm-package@1.0.0",
+    "brace-expansion": "^5.0.9",
+    "undici": "^8.9.0",
+    "fast-uri": "^4.1.2"
   },
   "devDependencies": {
     "@playwright/test": "1.59.1",


### PR DESCRIPTION
## What happened

A wave of advisories published **2026-08-03** took the dependency gate from **1 blocking entry to 7**
and turned the `Dependency Audit` lane red on every open PR. main still shows green because that
lane last ran at 06:50Z, before the wave — it is **stale-green, not green**, which is exactly the
failure cli#332 describes.

Five of the seven are the same package.

| package | override | advisories | worst |
|---|---|---|---|
| `undici` | `^8.9.0` | 5 | **high** — cross-user information disclosure |
| `brace-expansion` | `^5.0.9` | 1 | **high** — DoS via unbounded intermediate arrays, bypassing the CVE-2026-14257 mitigation |
| `fast-uri` | `^4.1.2` | 1 | **high** — host confusion via backslash |

All three arrive transitively — `pi-coding-agent`, `openclaw`, and
`harper › @fastify/static › glob › minimatch` — so none is reachable by changing a direct
dependency.

**Result: 21 advisories → 14, all remaining allowlisted with dated justifications. Gate rc=1 → rc=0.**

## Why overrides, and why these are not the ones that broke us before

These are **plain version constraints, not `npm:` aliases.** flair#750 records an alias override
(`harper` → `npm:@harperfast/harper@…`) that collided with the already-installed scoped copy, left
npm's tree `invalid`, and made any *second* npm operation fail with `ENOTEMPTY` — which broke the
clean-VM install gate and was reverted.

A version constraint introduces no second package name, so that failure mode is absent by
construction rather than by hope. Verified rather than assumed:

- `npm run build` + `build:cli` — clean
- **a second `bun install` against the reified tree** — `rc=0`, no `ENOTEMPTY`, no `invalid` tree
- full unit suite — **3859 pass, 0 fail**

## One correction worth recording

My first read was that the override had *caused* the jump from 15 advisories to 21. It had not.
Measured with the override stashed: **21 before, 20 after** — the override removed one and
introduced none, and my lockfile churn was a single line. The growth was newly published advisories
arriving between two gate runs hours apart. I nearly reported a regression I had not caused.

## Caveat for whoever revisits these

An override is a **forward pin, not a fix**. Each is correct only until the upstream dependency
resolves the advisory itself, after which the override is just a pin holding a version we no longer
need to hold. Re-check at each dependency bump rather than treating them as settled — the same
discipline the audit allowlist already enforces by expiring its entries.

Unblocks #1077 and #1078, both of which are Sherlock-approved and red only on this lane.

No issue: a dependency-advisory response, not a tracked defect of its own. The advisories are
upstream (GHSA-rgw5-rvv9-x895, GHSA-4cwx-7wf7-3272, GHSA-7p8r-x3mc-p8w7 and the undici set) and the
remediation is a version pin, so there is nothing here to close. It unblocks #1077, #1078 and #1080,
which carry their own linkage.
