### PR TITLE
security(deploy): derive the payload from the published file set, not the working tree

### DIFF
--- a/.changelog/unreleased/security-deploy-payload-published-file-set.md
+++ b/.changelog/unreleased/security-deploy-payload-published-file-set.md
@@ -1,0 +1,33 @@
+- **A deploy no longer ships the whole working tree.** `harper deploy` packs its root wholesale, and
+  the code assumed that root was an npm-installed package — where the tree already *is* the published
+  file set. That assumption is true for the intended path and silently false for the one our own
+  deploy procedure prescribes: a git checkout.
+
+  Measured on a production Fabric component: **36 top-level entries**, including `.git`, `.env`,
+  `models/` (80 MB), `test/`, `packages/`, `src/`, and a scratch `pr-body.md` left in the clone that
+  afternoon. **96 MB against the published tarball's 1.3 MB.**
+
+  Two consequences. An operator deploying from a checkout shipped `.git` — every secret ever
+  committed and later removed — and any `.env` sitting in the tree, into a component that is then
+  persisted and replicated across the cluster. And a 96 MB payload is what puts a deploy inside
+  HarperFast/harper#2062's aborted-transaction window, where the pre-saved blob is destroyed at the
+  source. The bloat and the cluster failure were the same bug wearing two hats.
+
+  Staging is now unconditional and restricted to the entries `files` declares, read from the deploy
+  root's own `package.json`. The payload equals the published package **by construction** rather than
+  by an operator happening to run from the right directory. For an npm-installed root the result is
+  unchanged, because such a tree contains nothing else. Measured after: 10 entries, 3.8 MB — `.git`,
+  `models/`, `packages/`, `test/`, `src/` all gone.
+
+  `.env` is explicitly kept: it is not in `files` and never reaches npm, but `config.yaml`'s
+  `loadEnv` reads it and shipping it is the point of the staging mechanism. Filtering it out broke
+  `FLAIR_PUBLIC_URL` on every deploy — caught by an existing test rather than in production.
+
+  A root with no usable `files` array is now **refused** rather than deployed unfiltered. The
+  refusal names the remedy.
+
+- **`REQUIRED_PACKAGE_FILES`'s "keep in sync" comment is no longer a promise nobody kept.** It
+  claimed to mirror `files`; nothing compared them, and they drifted invisibly for as long as the
+  comment existed. The payload is now derived from `files` directly, so there is one source of truth
+  and nothing to synchronise by hand. Four tests assert the deployed set — including that the filter
+  is not over-broad, since a filter that drops everything would also pass a "no `.git` shipped" check.

--- a/src/deploy.ts
+++ b/src/deploy.ts
@@ -114,8 +114,19 @@ export interface DeployResult {
   convergedAfterReplicationError?: boolean;
 }
 
-// Files that must be present in a Flair package for deployment.
-// Mirrors the `files` array in package.json — keep in sync.
+// Files that must be PRESENT for a deploy root to be usable at all — a
+// preflight sanity check, not the payload definition.
+//
+// This used to say "Mirrors the `files` array in package.json — keep in sync."
+// It did not, and nothing compared them. The payload was whatever sat in the
+// deploy root, which for a git checkout meant .git, models/, test/, packages/
+// and any stray file: 96 MB against a 1.3 MB published tarball, verified on a
+// production Fabric component. A rule asserted in a comment with no mechanism
+// behind it will drift, and this one drifted invisibly for as long as it existed.
+//
+// The payload is now derived from `files` directly, at pack time, by
+// publishedEntryNames() — so there is one source of truth and nothing left to
+// keep in sync by hand.
 export const REQUIRED_PACKAGE_FILES = [
   "dist",
   "schemas",
@@ -836,6 +847,71 @@ function isNodeModulesPath(root: string, path: string): boolean {
 }
 
 /**
+ * The top-level entries the payload may contain: whatever `files` declares, plus
+ * the three npm always-includes. Read from the deploy root's own package.json so
+ * there is ONE source of truth — a hardcoded copy here is how `files` and the
+ * payload drifted apart in the first place.
+ */
+export function publishedEntryNames(packageRoot: string): Set<string> {
+  // `.env` is not in `files` and never ships to npm, but it MUST reach the
+  // component: config.yaml's `loadEnv` reads it, and shipping it is the whole
+  // point of flair#1005 and of stageDeployRoot itself. Filtering it out breaks
+  // FLAIR_PUBLIC_URL on every deploy — caught by the operator-value test rather
+  // than in production, which is the only reason this comment exists.
+  //
+  // What goes INSIDE that file is a separate concern with its own issue
+  // (flair#1011, HDB_ADMIN_PASSWORD must not be written into a deployed .env).
+  // This function decides what may ship, not what the file may contain.
+  const always = ["package.json", "README.md", "LICENSE", "LICENCE", COMPONENT_ENV_FILENAME];
+  let declared: string[] = [];
+  try {
+    const pkg = JSON.parse(readFileSync(join(packageRoot, "package.json"), "utf8"));
+    if (Array.isArray(pkg.files)) declared = pkg.files;
+  } catch {
+    /* handled by the caller's emptiness check below */
+  }
+  // `files` entries are npm patterns; the ones flair uses are plain top-level
+  // names, optionally trailing-slashed ("dist/"). Normalise to the entry name.
+  const names = declared
+    .map((f) => String(f).replace(/^\.\//, "").replace(/\/+$/, ""))
+    .filter((f) => f !== "" && !f.includes("*") && !f.startsWith("!"));
+  return new Set([...names, ...always]);
+}
+
+/**
+ * Whether `packageRoot` declares a usable `files` array.
+ *
+ * Separate from `publishedEntryNames` deliberately. The refusal below used to
+ * ask whether the resulting set was larger than the always-includes, i.e. it
+ * compared against a hardcoded count — so adding one always-include silently
+ * stopped it firing. A check keyed to the length of a list that grows is a check
+ * that disables itself the next time someone edits that list.
+ */
+export function hasDeclaredFiles(packageRoot: string): boolean {
+  try {
+    const pkg = JSON.parse(readFileSync(join(packageRoot, "package.json"), "utf8"));
+    return Array.isArray(pkg.files) && pkg.files.length > 0;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * True when `src` is a top-level entry the published package would not contain.
+ *
+ * Only TOP-LEVEL entries are filtered. Once a directory is admitted its whole
+ * subtree ships, which is what npm does and what makes the staged copy equal the
+ * published tarball rather than merely similar.
+ */
+function isUnpublishedEntry(root: string, src: string, allowed: Set<string>): boolean {
+  const rel = relative(root, src);
+  if (rel === "") return false;
+  const parts = rel.split(sep);
+  if (parts.length > 1) return false;
+  return !allowed.has(parts[0]);
+}
+
+/**
  * Resolve the value `FLAIR_PUBLIC_URL` should carry for this deploy, or null.
  *
  * The deploy already knows this: `url` is the target it hands to harper AND the
@@ -872,8 +948,42 @@ export function stageDeployRoot(packageRoot: string, publicUrl: string | null): 
   const existing = existsSync(envPath) ? readFileSync(envPath, "utf8") : null;
   const plan = planComponentEnv(existing, publicUrl);
 
-  if (plan.text === null) {
-    return { dir: packageRoot, plan, cleanup: () => {} };
+  // ── Why this ALWAYS stages now ─────────────────────────────────────────────
+  //
+  // harper packs its CWD wholesale, so the payload is whatever sits in the
+  // deploy root. The comment above assumes that root is an npm-installed
+  // package, where the tree already IS the published file set. That assumption
+  // is true for the intended path and silently false for the one our own
+  // deploy procedure prescribes: a git checkout.
+  //
+  // Measured on the production Fabric origin 2026-08-03, deploying from a
+  // checkout at v0.36.0: the deployed component held 36 top-level entries —
+  // `.git`, `.env`, `models/`, `test/`, `packages/`, `src/`, and a scratch
+  // `pr-body.md` left in the clone that afternoon. Payload 96 MB against the
+  // published tarball's 1.3 MB, a factor of 74. `models/` alone was 80 MB.
+  //
+  // Two consequences, both bad. An operator deploying from a checkout ships
+  // `.git` (every secret ever committed and later removed) and any `.env`
+  // sitting in the tree, into a component that is then PERSISTED and REPLICATED
+  // across the cluster. And a 96 MB payload is what puts the deploy inside
+  // HarperFast/harper#2062's aborted-transaction window, where the pre-saved
+  // blob is destroyed at the source.
+  //
+  // So the filter is not an optimisation. Staging unconditionally, restricted to
+  // the entries `files` declares, makes the payload equal the published package
+  // BY CONSTRUCTION rather than by an operator happening to run from the right
+  // directory. For an npm-installed root the result is byte-identical to before,
+  // because such a tree contains nothing else.
+  const allowed = publishedEntryNames(packageRoot);
+  // An empty/unreadable `files` would filter the payload down to the
+  // always-includes and deploy a component with no dist/. Refuse instead: a
+  // deploy that silently ships almost nothing is worse than one that does not run.
+  if (!hasDeclaredFiles(packageRoot)) {
+    throw new Error(
+      `Cannot determine the published file set for ${packageRoot}: package.json has no usable "files" array. ` +
+        `Refusing to deploy rather than shipping an unfiltered payload (which would include .git and any .env) ` +
+        `or an empty one. Deploy from an npm-installed @tpsdev-ai/flair, or pass --package-root at one.`,
+    );
   }
 
   const dir = mkdtempSync(join(tmpdir(), STAGING_PREFIX));
@@ -882,12 +992,20 @@ export function stageDeployRoot(packageRoot: string, publicUrl: string | null): 
       recursive: true,
       dereference: false,
       verbatimSymlinks: true,
-      filter: (src) => !isNodeModulesPath(packageRoot, src),
+      filter: (src) =>
+        !isNodeModulesPath(packageRoot, src) && !isUnpublishedEntry(packageRoot, src, allowed),
     });
     // 0600 even though the generated content is a public URL: an operator's own
     // keys may have been merged through, and the file's permissions should not
     // depend on what happens to be in it.
-    writeFileSync(join(dir, COMPONENT_ENV_FILENAME), plan.text, { mode: 0o600 });
+    //
+    // `plan.text === null` means there is nothing to add — a loopback target, or
+    // an operator who already set the key. Staging still happened (the filter is
+    // the point now, not the `.env`), so any `.env` the root carried has been
+    // copied through unchanged and must be left alone.
+    if (plan.text !== null) {
+      writeFileSync(join(dir, COMPONENT_ENV_FILENAME), plan.text, { mode: 0o600 });
+    }
   } catch (err) {
     rmSync(dir, { recursive: true, force: true });
     throw err;

--- a/test/integration/deploy-replication-convergence.test.ts
+++ b/test/integration/deploy-replication-convergence.test.ts
@@ -124,7 +124,7 @@ function synthPackageRoot(behaviours: string[], peerNodeName: string): { root: s
     if (f.endsWith(".yaml")) writeFileSync(p, "port: 9926\n");
     else mkdirSync(p, { recursive: true });
   }
-  writeFileSync(join(root, "package.json"), JSON.stringify({ name: "@tpsdev-ai/flair", version: "9.9.9-test" }));
+  writeFileSync(join(root, "package.json"), JSON.stringify({ name: "@tpsdev-ai/flair", version: "9.9.9-test", files: ["dist/", "schemas/", "templates/", "docs/", "config.yaml", "LICENSE", "README.md", "SECURITY.md"] }));
 
   const binDir = join(root, "node_modules", "harper", "dist", "bin");
   mkdirSync(binDir, { recursive: true });

--- a/test/unit/deploy-staging.test.ts
+++ b/test/unit/deploy-staging.test.ts
@@ -26,7 +26,7 @@ import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, statSync, sym
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { COMPONENT_ENV_FILENAME, PUBLIC_URL_KEY, envKeyNames, readEnvValue } from "../../src/component-env.js";
-import { OAUTH_METADATA_PATH, resolveDeployPublicUrl, stageDeployRoot, verifyPublicIssuer } from "../../src/deploy.js";
+import { OAUTH_METADATA_PATH, publishedEntryNames, resolveDeployPublicUrl, stageDeployRoot, verifyPublicIssuer } from "../../src/deploy.js";
 
 const require_ = createRequire(import.meta.url);
 
@@ -67,7 +67,15 @@ function makePackageRoot(): string {
   mkdirSync(join(root, "dist", "resources"), { recursive: true });
   mkdirSync(join(root, "schemas"), { recursive: true });
   mkdirSync(join(root, "node_modules", "harper"), { recursive: true });
-  writeFileSync(join(root, "package.json"), JSON.stringify({ name: "@tpsdev-ai/flair", version: "0.0.0-test" }));
+  // `files` mirrors what a real npm-installed @tpsdev-ai/flair carries. The
+  // fixture omitted it before, which made it unfaithful to the thing it stands
+  // in for — an installed package always declares `files`, and stageDeployRoot
+  // now derives the payload from it.
+  writeFileSync(join(root, "package.json"), JSON.stringify({
+    name: "@tpsdev-ai/flair",
+    version: "0.0.0-test",
+    files: ["dist/", "schemas/", "templates/", "docs/", "config.yaml", "LICENSE", "README.md", "SECURITY.md"],
+  }));
   writeFileSync(join(root, "config.yaml"), "name: flair\nloadEnv:\n  files: '.env'\n");
   writeFileSync(join(root, "dist", "resources", "Memory.js"), "// resource\n");
   writeFileSync(join(root, "schemas", "schema.graphql"), "type Q { a: String }\n");
@@ -196,26 +204,33 @@ describe("stageDeployRoot — what harper actually uploads", () => {
     expect(envKeyNames(packed)).toEqual(["FLAIR_MCP_OAUTH", PUBLIC_URL_KEY]);
   });
 
-  test("an operator's own FLAIR_PUBLIC_URL is deployed unchanged, with nothing staged", async () => {
+  test("an operator's own FLAIR_PUBLIC_URL is carried through untouched", async () => {
     const root = makePackageRoot();
     writeFileSync(join(root, COMPONENT_ENV_FILENAME), "FLAIR_PUBLIC_URL=https://cdn.example.com\n");
 
     const staged = stageDeployRoot(root, "https://cluster.org.harperfabric.com");
     cleanups.push(staged.cleanup);
 
-    expect(staged.dir).toBe(root); // nothing copied at all
+    // Staging is now unconditional — the payload filter has to apply whether or
+    // not an .env needs writing, or a loopback deploy from a checkout would still
+    // ship .git. The operator's own value must survive the copy unmodified.
+    expect(staged.dir).not.toBe(root);
     expect(staged.plan.action).toBe("operator-value-kept");
-    expect(readEnvValue(await packedEnvText(root), PUBLIC_URL_KEY)).toBe("https://cdn.example.com");
+    expect(readEnvValue(await packedEnvText(staged.dir), PUBLIC_URL_KEY)).toBe("https://cdn.example.com");
   });
 
-  test("a loopback target stages nothing and ships no generated .env", async () => {
+  test("a loopback target ships no generated .env, but is still filtered", async () => {
     const root = makePackageRoot();
     const staged = stageDeployRoot(root, resolveDeployPublicUrl("http://127.0.0.1:9925"));
     cleanups.push(staged.cleanup);
 
-    expect(staged.dir).toBe(root);
+    // The .env contract is unchanged: a loopback target generates nothing.
     expect(staged.plan.action).toBe("unchanged");
-    expect(await packedEnvText(root)).toBeNull();
+    expect(await packedEnvText(staged.dir)).toBeNull();
+    // But the payload is still staged and filtered — this is the case that used
+    // to return packageRoot untouched and ship the whole working tree with it.
+    expect(staged.dir).not.toBe(root);
+    expect(existsSync(join(staged.dir, "node_modules"))).toBe(false);
   });
 
   test("the staged .env is written 0600", () => {
@@ -335,5 +350,86 @@ describe("verifyPublicIssuer", () => {
     });
     expect(result.checked).toBe(false);
     expect(result.detail).toContain("ECONNREFUSED");
+  });
+});
+
+// ─── flair#1020 and the private deploy-payload finding ────────────────────────
+//
+// harper packs the deploy root wholesale. When that root is an npm-installed
+// package the tree IS the published file set, which is the case the original
+// design assumed. Deploying from a git CHECKOUT — which our own deploy procedure
+// prescribes — silently shipped the entire working tree instead.
+//
+// Measured on the production Fabric origin 2026-08-03 at v0.36.0: 36 top-level
+// entries including .git, .env, models/ (80 MB), test/, packages/ and a scratch
+// pr-body.md. 96 MB against a 1.3 MB published tarball.
+//
+// These tests fail if the payload ever admits a top-level entry the published
+// package would not contain.
+describe("stageDeployRoot — the payload equals the published file set", () => {
+  function fixtureRoot(): string {
+    const root = mkdtempSync(join(tmpdir(), "flair-payload-fixture-"));
+    writeFileSync(join(root, "package.json"), JSON.stringify({
+      name: "@tpsdev-ai/flair",
+      version: "0.0.0-test",
+      files: ["dist/", "schemas/", "config.yaml", "README.md"],
+      workspaces: ["packages/*"],
+    }));
+    // published entries
+    for (const d of ["dist", "schemas"]) {
+      mkdirSync(join(root, d), { recursive: true });
+      writeFileSync(join(root, d, "keep.txt"), "published");
+    }
+    writeFileSync(join(root, "config.yaml"), "published: true");
+    writeFileSync(join(root, "README.md"), "# published");
+    // entries a checkout carries that MUST NOT ship
+    for (const d of [".git", "models", "packages", "test", "src", "scripts"]) {
+      mkdirSync(join(root, d), { recursive: true });
+      writeFileSync(join(root, d, "secret.txt"), "must not ship");
+    }
+    writeFileSync(join(root, "pr-body.md"), "scratch file left in the clone");
+    writeFileSync(join(root, "bun.lock"), "lock");
+    return root;
+  }
+
+  const roots: string[] = [];
+  afterEach(() => { for (const r of roots.splice(0)) rmSync(r, { recursive: true, force: true }); });
+
+  test("drops every unpublished top-level entry, including .git and models", () => {
+    const root = fixtureRoot(); roots.push(root);
+    const staged = stageDeployRoot(root, "https://example.invalid");
+    const got = new Set(require("node:fs").readdirSync(staged.dir));
+    for (const forbidden of [".git", "models", "packages", "test", "src", "scripts", "pr-body.md", "bun.lock"]) {
+      expect(got.has(forbidden)).toBe(false);
+    }
+    staged.cleanup();
+  });
+
+  test("keeps every published entry — the filter must not be over-broad", () => {
+    const root = fixtureRoot(); roots.push(root);
+    const staged = stageDeployRoot(root, "https://example.invalid");
+    const got = new Set(require("node:fs").readdirSync(staged.dir));
+    for (const kept of ["dist", "schemas", "config.yaml", "README.md", "package.json"]) {
+      expect(got.has(kept)).toBe(true);
+    }
+    // and subtrees survive: only TOP-LEVEL entries are filtered
+    expect(existsSync(join(staged.dir, "dist", "keep.txt"))).toBe(true);
+    staged.cleanup();
+  });
+
+  test("refuses to deploy when files cannot be determined, rather than shipping everything or nothing", () => {
+    const root = mkdtempSync(join(tmpdir(), "flair-nofiles-")); roots.push(root);
+    writeFileSync(join(root, "package.json"), JSON.stringify({ name: "@tpsdev-ai/flair", version: "0.0.0" }));
+    mkdirSync(join(root, ".git"), { recursive: true });
+    expect(() => stageDeployRoot(root, "https://example.invalid")).toThrow(/published file set/);
+  });
+
+  test("publishedEntryNames reads files from the root, not a hardcoded copy", () => {
+    const root = fixtureRoot(); roots.push(root);
+    const names = publishedEntryNames(root);
+    expect(names.has("dist")).toBe(true);
+    expect(names.has("schemas")).toBe(true);
+    expect(names.has("package.json")).toBe(true);
+    expect(names.has("models")).toBe(false);
   });
 });

--- a/test/unit/deploy.test.ts
+++ b/test/unit/deploy.test.ts
@@ -203,7 +203,7 @@ describe("flair deploy: dry-run end-to-end", () => {
     }
     writeFileSync(
       join(dir, "package.json"),
-      JSON.stringify({ name: "@tpsdev-ai/flair", version: "9.9.9-test" }),
+      JSON.stringify({ name: "@tpsdev-ai/flair", version: "9.9.9-test", files: ["dist/", "schemas/", "templates/", "docs/", "config.yaml", "LICENSE", "README.md", "SECURITY.md"] }),
     );
     return dir;
   }
@@ -421,7 +421,7 @@ describe("flair deploy: deploy() gating — --no-verify and --dry-run both skip 
     }
     writeFileSync(
       join(dir, "package.json"),
-      JSON.stringify({ name: "@tpsdev-ai/flair", version: "9.9.9-test" }),
+      JSON.stringify({ name: "@tpsdev-ai/flair", version: "9.9.9-test", files: ["dist/", "schemas/", "templates/", "docs/", "config.yaml", "LICENSE", "README.md", "SECURITY.md"] }),
     );
     return dir;
   }
@@ -590,7 +590,7 @@ describe("flair deploy: deploy() replication-flake retry + --ignore-replication-
     }
     writeFileSync(
       join(dir, "package.json"),
-      JSON.stringify({ name: "@tpsdev-ai/flair", version: "9.9.9-test" }),
+      JSON.stringify({ name: "@tpsdev-ai/flair", version: "9.9.9-test", files: ["dist/", "schemas/", "templates/", "docs/", "config.yaml", "LICENSE", "README.md", "SECURITY.md"] }),
     );
     return dir;
   }


### PR DESCRIPTION
Closes the deploy half of #1020, and removes 83% of the payload that lands inside
HarperFast/harper#2062's blob-destruction window.

## The problem, measured on production

`harper deploy` packs its root wholesale. `stageDeployRoot`'s own comment states the assumption:
*"That directory is an npm-installed package."* True for the intended path — where the tree already
**is** the published file set — and silently false for the one **our own deploy procedure
prescribes**: a fresh git checkout.

What was actually on the Fabric origin after deploying v0.36.0 from a checkout — 36 top-level
entries:

```
.git  .env  .env.example  .github  .gitignore  AGENTS.md  CHANGELOG.md  CONTRIBUTING.md
DESIGN.md  bun.lock  config.yaml  dist  docker  docs  models  package-lock.json  packages
playwright.config.ts  pr-body.md  resources  schemas  scripts  src  templates  test  tsconfig.*  types
```

`pr-body.md` is a scratch file I created in that clone hours earlier. That is the proof it packs
whatever sits in the directory rather than a curated set.

| | |
|---|---|
| checkout payload | **96,230,953 bytes** — `models/` 80M · `.git` 10M · `test/` 4.2M · `packages/` 1.1M |
| npm-install payload | **1,300,637 bytes** |
| real deploy payload | 95,783,483 bytes — matches the checkout to within 0.5% |

**Two consequences, and they compound.** An operator deploying from a checkout ships `.git` (every
secret ever committed and later removed) and any `.env` in the tree, into a component that is then
**persisted and replicated** across the cluster. And a 96 MB payload is what puts the deploy inside
harper#2062's aborted-transaction window, where the pre-saved blob is destroyed at the source. The
bloat and the cluster breakage were the same bug wearing two hats.

`packages/` mattering is not incidental: the published `package.json` declares
`workspaces: ["packages/*"]`, so a node installing a payload that contains `packages/` pulls the
whole workspace — including `flair-bench` → `node-llama-cpp` → a 444 MB CUDA extension.

## The fix

Staging is now **unconditional** and filtered to the entries `files` declares, read from the deploy
root's own `package.json`. The payload equals the published package **by construction** rather than
by an operator happening to run from the right directory. For an npm-installed root the result is
unchanged, because such a tree contains nothing else.

After: **10 entries, 3.8 MB.** `.git`, `models/`, `packages/`, `test/`, `src/`, `scripts/` all gone.

Staging had to become unconditional rather than only-when-writing-`.env`: the old early return
handed back `packageRoot` untouched for a loopback target or an operator-supplied URL, and those
paths would still have shipped the whole tree.

## Three things that went wrong while building this, all caught by tests

**The filter dropped `.env`.** It is not in `files` and never reaches npm — but `config.yaml`'s
`loadEnv` reads it, and shipping it is the entire point of the staging mechanism. Filtering it out
would have broken `FLAIR_PUBLIC_URL` on every deploy. An existing test caught it. What goes *inside*
that file is a separate concern with its own issue (#1011).

**The refusal guard disabled itself.** The first version asked whether the resulting set was larger
than the always-includes — a comparison against a hardcoded count. Adding `.env` to that list made
the guard stop firing, and a test caught that too. It now tests the real condition
(`hasDeclaredFiles`), with a positive control proving it still throws.

**The fixtures were unfaithful.** Four fixture sites built a root standing in for an npm-installed
`@tpsdev-ai/flair` while omitting `files` — the one field that defines what such a package is. I
updated them rather than softening the guard, and I want that called out explicitly for review: it
is the shape of change that can quietly turn "my code is wrong" into "the test was wrong."

## Verification

- **3863 pass, 0 fail** (main: 3859/0 — four new tests, no regressions)
- Typecheck: 1 error in `resources/auth-middleware.ts`, **pre-existing on main**, untouched here
- New tests assert both directions — that no unpublished entry ships, **and** that the filter is not
  over-broad. A filter that dropped everything would also pass a "no `.git` shipped" check.

Refs #1020, HarperFast/harper#2062

No issue: the security-relevant detail is tracked privately, since the mechanism would ship an
operator's `.env` into a persisted, replicated component. #1020 covers the `.git` half publicly.
