### PR TITLE
security(memory): refuse an unrecognised visibility at the REST and in-process writes

### DIFF
--- a/.changelog/unreleased/security-visibility-validated-at-every-write-boundary.md
+++ b/.changelog/unreleased/security-visibility-validated-at-every-write-boundary.md
@@ -1,0 +1,15 @@
+- **A misspelled `visibility` no longer writes a memory everyone can read.** `PUT /Memory/<id>` with
+  `{"visibility":"prvate"}` was accepted, and the read scope resolves visibility by exact match on
+  `private` — so the typo, a wrong case, or a retired tier like `office` all read as non-private and
+  were visible to every agent on the instance. flair#1006 closed this at the CLI flag and the MCP
+  tool argument; REST and the in-process API reach `Memory.put()`/`post()` without passing either.
+
+  Both now refuse an unrecognised value with `400 invalid_visibility`, naming the two valid values
+  and how to opt out. Refusing rather than dropping the key is deliberate: dropping it falls through
+  to the durability-keyed default, which for a permanent or persistent write is `shared` — the same
+  widening, arrived at silently.
+
+  **The read predicate is deliberately left permissive.** A row written before the field existed has
+  no visibility and must keep reading exactly as it always did. So write-validation is strictly
+  stronger than read-resolution, and the two must not be collapsed into one predicate — there is a
+  test whose only job is to fail if someone tries.

--- a/resources/Memory.ts
+++ b/resources/Memory.ts
@@ -7,6 +7,7 @@ import { scanFields, isStrictMode } from "./content-safety.js";
 import { invalidEntitiesResponse } from "./entity-vocab.js";
 import { checkRateLimit, rateLimitResponse } from "./rate-limiter.js";
 import { resolveAllowedOwners } from "./memory-read-scope.js";
+import { assertValidVisibility } from "./memory-visibility.js";
 import {
   DEDUP_COSINE_THRESHOLD_DEFAULT,
   DEDUP_LEXICAL_THRESHOLD_DEFAULT,
@@ -643,6 +644,27 @@ export class Memory extends (databases as any).flair.Memory {
     // existing record's visibility" concern here. Explicit visibility on the
     // write ALWAYS overrides; only stamp the default when the caller left it
     // unset. permanent|persistent → shared; standard|ephemeral|absent → private.
+      // ── flair#1009: refuse an unrecognised visibility BEFORE defaulting ──
+      // isPrivateVisibility() is an exact match on "private", so on the READ
+      // side every other value (a typo, a wrong case, a retired tier like
+      // "office") resolves to non-private and is readable by every agent on the
+      // instance. #1006 closed that at the CLI flag and the MCP tool argument;
+      // REST and the in-process API reach here without passing either.
+      //
+      // Refusing, rather than dropping the key: dropping it falls through to the
+      // durability-keyed default below, which for a permanent or persistent
+      // write is "shared" - the same widening, arrived at silently. A misspelled
+      // argument must not decide who can read a memory.
+      {
+        const visibilityError = assertValidVisibility(content.visibility);
+        if (visibilityError) {
+          return new Response(
+            JSON.stringify({ error: "invalid_visibility", message: visibilityError }),
+            { status: 400, headers: { "content-type": "application/json" } },
+          );
+        }
+      }
+
     if (content.visibility === undefined || content.visibility === null) {
       content.visibility = defaultVisibilityForDurability(content.durability);
     }
@@ -837,6 +859,27 @@ export class Memory extends (databases as any).flair.Memory {
     // Explicit visibility on the write ALWAYS overrides; only stamp the
     // default when the caller left it unset AND this is a fresh record.
     // permanent|persistent → shared; standard|ephemeral|absent → private.
+      // ── flair#1009: refuse an unrecognised visibility BEFORE defaulting ──
+      // isPrivateVisibility() is an exact match on "private", so on the READ
+      // side every other value (a typo, a wrong case, a retired tier like
+      // "office") resolves to non-private and is readable by every agent on the
+      // instance. #1006 closed that at the CLI flag and the MCP tool argument;
+      // REST and the in-process API reach here without passing either.
+      //
+      // Refusing, rather than dropping the key: dropping it falls through to the
+      // durability-keyed default below, which for a permanent or persistent
+      // write is "shared" - the same widening, arrived at silently. A misspelled
+      // argument must not decide who can read a memory.
+      {
+        const visibilityError = assertValidVisibility(content.visibility);
+        if (visibilityError) {
+          return new Response(
+            JSON.stringify({ error: "invalid_visibility", message: visibilityError }),
+            { status: 400, headers: { "content-type": "application/json" } },
+          );
+        }
+      }
+
     if (!preExisting && (content.visibility === undefined || content.visibility === null)) {
       content.visibility = defaultVisibilityForDurability(content.durability);
     }

--- a/resources/memory-visibility.ts
+++ b/resources/memory-visibility.ts
@@ -30,10 +30,57 @@
  */
 
 export const PRIVATE_VISIBILITY = "private";
+export const SHARED_VISIBILITY = "shared";
+
+/** The only values a WRITER may supply. Deliberately not derived from the read
+ *  predicate below — see the asymmetry note on assertValidVisibility. */
+export const WRITABLE_VISIBILITIES = [PRIVATE_VISIBILITY, SHARED_VISIBILITY] as const;
 
 /** True only when visibility is the literal string "private". Null, undefined,
  *  "shared", or any other value are all non-private (see migration invariant
  *  above) — never invert this to an allowlist of "shared". */
 export function isPrivateVisibility(visibility: string | null | undefined): boolean {
   return visibility === PRIVATE_VISIBILITY;
+}
+
+/**
+ * Reject a visibility a writer supplied that is not one of the two valid values.
+ * Returns an error message, or null when the value is acceptable.
+ *
+ * ── Why this is NOT the inverse of isPrivateVisibility (flair#1009) ──────────
+ *
+ * The read predicate above must stay "is this exactly 'private'", because a row
+ * written before the field existed has no visibility and must keep reading as it
+ * always did. That is a MIGRATION rule about stored data, and it is correct.
+ *
+ * The consequence is that on the read side every unrecognised value — a typo, a
+ * wrong case, a retired tier — resolves to non-private and is readable by every
+ * agent on the instance. #1006 closed that at the two writer-intent boundaries
+ * (the CLI flag, the MCP tool argument); REST and the in-process API still
+ * accepted anything, so `PUT /Memory/<id> {"visibility":"prvate"}` wrote a
+ * memory the caller believed was owner-only and everyone could read.
+ *
+ * So the two directions need different rules, and conflating them breaks one or
+ * the other:
+ *   - READING an unknown value must be permissive, or old rows break.
+ *   - WRITING an unknown value must be refused, or a typo silently widens who
+ *     can read a memory.
+ *
+ * Refusing is also the only safe option at write time. Silently dropping the key
+ * would fall back to the durability-keyed default, which for a permanent or
+ * persistent write is `shared` — the same wrong outcome, arrived at quietly.
+ *
+ * `undefined`/`null` are accepted: omitting the field is how a caller asks for
+ * the durability-keyed default, and that is a documented, intentional path.
+ */
+export function assertValidVisibility(visibility: unknown): string | null {
+  if (visibility === undefined || visibility === null) return null;
+  if (typeof visibility === "string" && (WRITABLE_VISIBILITIES as readonly string[]).includes(visibility)) {
+    return null;
+  }
+  return (
+    `visibility must be ${WRITABLE_VISIBILITIES.map((v) => `"${v}"`).join(" or ")} ` +
+    `(got: ${JSON.stringify(visibility)}). Omit it to use the durability-keyed default: ` +
+    `permanent/persistent -> shared, standard/ephemeral -> private.`
+  );
 }

--- a/test/unit/visibility-write-validation.test.ts
+++ b/test/unit/visibility-write-validation.test.ts
@@ -1,0 +1,138 @@
+// flair#1009 — a writer-supplied `visibility` that is not "private" or "shared"
+// must be REFUSED, not silently defaulted.
+//
+// The asymmetry this file exists to protect:
+//
+//   READING an unknown value must be permissive. A row written before the field
+//   existed has no visibility and must keep reading exactly as it always did —
+//   that is the migration invariant in memory-visibility.ts, and it is correct.
+//
+//   WRITING an unknown value must be refused. Because the read side is an exact
+//   match on "private", every other string — a typo, a wrong case, a retired
+//   tier like "office" — resolves to non-private and is readable by every agent
+//   on the instance.
+//
+// #1006 closed this at the two writer-intent boundaries (the CLI flag, the MCP
+// tool argument). REST and the in-process API reach Memory.put()/post() without
+// passing either, so `PUT /Memory/<id> {"visibility":"prvate"}` wrote a memory
+// the caller believed was owner-only and everyone could read.
+//
+// Both directions are asserted here. A validator that rejected everything would
+// pass a "typo is refused" test while breaking every legitimate write.
+import { describe, test, expect } from "bun:test";
+import {
+  assertValidVisibility,
+  isPrivateVisibility,
+  PRIVATE_VISIBILITY,
+  SHARED_VISIBILITY,
+  WRITABLE_VISIBILITIES,
+} from "../../resources/memory-visibility.js";
+
+describe("assertValidVisibility — write-side rejection (flair#1009)", () => {
+  test("accepts the two valid values", () => {
+    expect(assertValidVisibility(PRIVATE_VISIBILITY)).toBeNull();
+    expect(assertValidVisibility(SHARED_VISIBILITY)).toBeNull();
+  });
+
+  test("accepts absence — omitting the field asks for the durability-keyed default", () => {
+    expect(assertValidVisibility(undefined)).toBeNull();
+    expect(assertValidVisibility(null)).toBeNull();
+  });
+
+  test("rejects the typo that motivated the issue", () => {
+    const err = assertValidVisibility("prvate");
+    expect(err).not.toBeNull();
+    expect(err).toContain("prvate");
+  });
+
+  test("rejects wrong case — the read predicate is case-sensitive, so Private is NOT private", () => {
+    expect(assertValidVisibility("Private")).not.toBeNull();
+    expect(assertValidVisibility("PRIVATE")).not.toBeNull();
+    // and the reason it matters:
+    expect(isPrivateVisibility("Private")).toBe(false);
+  });
+
+  test("rejects a retired tier", () => {
+    // "office" is named in Memory.ts's own history as a value that leaked.
+    expect(assertValidVisibility("office")).not.toBeNull();
+  });
+
+  test("rejects non-strings rather than coercing them", () => {
+    for (const v of [1, true, {}, [], "", " private", "private "]) {
+      expect(assertValidVisibility(v)).not.toBeNull();
+    }
+  });
+
+  test("the error names both valid values and the way to opt out", () => {
+    const err = assertValidVisibility("nonsense") ?? "";
+    expect(err).toContain(`"${PRIVATE_VISIBILITY}"`);
+    expect(err).toContain(`"${SHARED_VISIBILITY}"`);
+    expect(err).toContain("Omit it");
+  });
+});
+
+describe("the read predicate stays permissive — the migration invariant", () => {
+  test("a record with no visibility is NOT private, and that must not change", () => {
+    expect(isPrivateVisibility(undefined)).toBe(false);
+    expect(isPrivateVisibility(null)).toBe(false);
+  });
+
+  test("an unknown STORED value still reads as non-private", () => {
+    // Rows written before #1009 may hold anything. The write path now refuses
+    // such values, but the read path must keep resolving them exactly as before
+    // — inverting this to an allowlist would silently privatise existing rows.
+    expect(isPrivateVisibility("office")).toBe(false);
+    expect(isPrivateVisibility("prvate")).toBe(false);
+  });
+
+  test("write-validation is STRICTER than read-resolution — that asymmetry is deliberate", () => {
+    // Every value the writer may supply is one the reader understands...
+    for (const v of WRITABLE_VISIBILITIES) {
+      expect(assertValidVisibility(v)).toBeNull();
+    }
+    // ...but the reverse does not hold, and must not: the reader accepts values
+    // the writer refuses. If someone ever "simplifies" these into one predicate,
+    // this test is what fails.
+    expect(isPrivateVisibility("office")).toBe(false);
+    expect(assertValidVisibility("office")).not.toBeNull();
+  });
+});
+
+// ─── Structural tripwire: the guard must remain WIRED ─────────────────────────
+//
+// The tests above validate `assertValidVisibility` in isolation. That is not
+// enough, and I proved it: neutering the guard inside `Memory.post()` broke
+// nothing — 3869 tests still passed. A validator nobody calls is not a control.
+//
+// This scan fails the build if either write path stops calling it. Same shape as
+// claimed-zero-authority-tripwire.test.ts, and same limitation, stated plainly:
+// it detects DELETION, not misbehaviour. A behavioural assertion needs the REST
+// surface against a live Harper, which is the integration lane's job — the
+// tripwire is what makes the unit lane able to notice at all.
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+describe("the visibility guard stays wired into both write paths", () => {
+  const src = readFileSync(join(import.meta.dir, "..", "..", "resources", "Memory.ts"), "utf8");
+
+  test("Memory.ts imports the validator", () => {
+    expect(src).toContain('from "./memory-visibility.js"');
+    expect(src).toContain("assertValidVisibility");
+  });
+
+  test("it is called once per write path — post() and put()", () => {
+    const calls = src.match(/assertValidVisibility\(content\.visibility\)/g) ?? [];
+    // Two default-visibility sites exist (post at ~647, put at ~841). Each needs
+    // its own guard: they are separate entry points, and REST reaches both.
+    expect(calls.length).toBe(2);
+  });
+
+  test("every durability-default site is preceded by a guard", () => {
+    // The failure this catches: someone adds a third write path with a
+    // durability default and forgets the guard. Counting both and comparing is
+    // what makes a NEW unguarded path fail rather than pass unnoticed.
+    const defaults = src.match(/defaultVisibilityForDurability\(content\.durability\)/g) ?? [];
+    const guards = src.match(/assertValidVisibility\(content\.visibility\)/g) ?? [];
+    expect(guards.length).toBe(defaults.length);
+  });
+});


### PR DESCRIPTION
Closes #1009 — the half of #1006 that was deliberately left out of its scope.

## The gap

`visibility` is a free-form `String` in `schemas/memory.graphql`, and the read scope resolves it via
`isPrivateVisibility()` — an **exact match on `private`**. Every other value is non-private and
readable by every agent on the instance.

#1006 constrained that at the two writer-intent boundaries: the CLI flag and the MCP tool argument.
Two surfaces still accepted anything, and both are the transport the others call through:

```
PUT /Memory/<id>  { "visibility": "prvate" }                    -> accepted, reads as shared
collectionResource(Memory, ctx).post({ visibility: "prvate" })  -> same
```

So a caller using `flair-client` directly, plain `curl`, or the Harper embedding path wrote a memory
they believed was owner-only and everyone could read. This is the shape I keep filing against us: **a
free-form string whose valid values live in a comment, compared by exact match, failing open.**

## The fix

Both write paths now refuse an unrecognised value with `400 invalid_visibility`, naming the two valid
values and how to opt out.

**Refusing rather than dropping the key is the load-bearing choice.** Dropping it falls through to
the durability-keyed default, which for a permanent or persistent write is `shared` — the same
widening, arrived at quietly. A misspelled argument must not decide who can read a memory.

## The asymmetry, and why it must survive

The read predicate stays permissive and that is **not** an oversight:

- **Reading** an unknown value must be permissive — a row written before the field existed has no
  visibility and must keep reading exactly as it always did. That is the migration invariant.
- **Writing** an unknown value must be refused — or a typo silently widens who can read a memory.

So write-validation is strictly stronger than read-resolution. A test exists whose only job is to
fail if someone ever collapses them into one predicate.

## Mutation-checked — and the first attempt failed the check

With only the isolated validator tests, I neutered the guard inside `Memory.post()` and **nothing
broke**: 3869 tests still passed. A validator nobody calls is not a control, and I would have shipped
one.

A structural tripwire now asserts both write paths call it, and — the part that matters — that the
**guard count equals the durability-default count**, so a third write path added later fails rather
than passing unnoticed. Neutering the guard now produces 2 failures.

Stated plainly, because it is a real limit: the tripwire detects **deletion, not misbehaviour**. A
behavioural assertion needs the REST surface against a live Harper, which is the integration lane's
job. The tripwire is what lets the unit lane notice at all. Same pattern and same limitation as
`claimed-zero-authority-tripwire.test.ts`.

## Verification

- **3872 pass, 0 fail** (main: 3859/0 — 13 new tests, no regressions)
- Typecheck: 1 error in `resources/auth-middleware.ts`, pre-existing on main, untouched
- Both directions asserted: a validator that rejected everything would pass a "typo is refused" test
  while breaking every legitimate write

Closes #1009
