### PR TITLE
security(deps): override hono to ^4.12.34 — CORS ReDoS (GHSA-8j4g-w8fx-2239)

### DIFF
--- a/.changelog/unreleased/security-hono-redos-override.md
+++ b/.changelog/unreleased/security-hono-redos-override.md
@@ -1,0 +1,10 @@
+- **`hono` pinned forward to `^4.12.34`** — GHSA-8j4g-w8fx-2239, a ReDoS in the CORS middleware via
+  `Access-Control-Request-Headers`. Reaches us transitively through
+  `@tpsdev-ai/flair-mcp › @modelcontextprotocol/sdk`, so it is not fixable by changing a direct
+  dependency.
+
+  This advisory was published **after** the previous override batch merged, which is worth recording:
+  the dependency gate now goes red on main whenever a new advisory lands against something in the
+  tree, and on 2026-08-03 that happened four times in one evening. The gate is telling the truth —
+  main really is exposed until the pin lands — but "main is red" stops carrying information if it is
+  the normal state. Worth a deliberate policy rather than a reflex.

--- a/bun.lock
+++ b/bun.lock
@@ -132,6 +132,7 @@
   "overrides": {
     "brace-expansion": "^5.0.9",
     "fast-uri": "^4.1.2",
+    "hono": "^4.12.34",
     "react-native-fs": "npm:empty-npm-package@1.0.0",
     "undici": "^8.9.0",
   },
@@ -1050,7 +1051,7 @@
 
     "highlight.js": ["highlight.js@11.11.1", "", {}, "sha512-Xwwo44whKBVCYoliBQwaPvtd/2tYFkRQtXDWj1nackaV2JPXx3L0+Jvd8/qCJ2p+ML0/XVkJ2q+Mr+UVdpJK5w=="],
 
-    "hono": ["hono@4.12.32", "", {}, "sha512-XcuyW9qE2kJn07PkecMOBd5Vq/hMy7mmGw+idz1yblbg9N17ijJODrvPkn7/dwL3Kulj8LcRJ69DLOWf91dRUg=="],
+    "hono": ["hono@4.12.34", "", {}, "sha512-GqXJqY/xJkJmuloTrnV1ZEXG3fqte+VjkUqoRNZXcrUidiUOP4fMSIHHY4tsqZBK++kVyWmt/AAfSUuy57/eSA=="],
 
     "hosted-git-info": ["hosted-git-info@10.1.1", "", { "dependencies": { "lru-cache": "^11.1.0" } }, "sha512-DeOnSPAvOndYKfw075gt8yZzQ7S2hNztw34zBTfhIzLhmBTswIBg5/y+pqu/VD5cYWm5goAFTusDmUEmKZ0PEQ=="],
 

--- a/package.json
+++ b/package.json
@@ -76,7 +76,8 @@
     "react-native-fs": "npm:empty-npm-package@1.0.0",
     "brace-expansion": "^5.0.9",
     "undici": "^8.9.0",
-    "fast-uri": "^4.1.2"
+    "fast-uri": "^4.1.2",
+    "hono": "^4.12.34"
   },
   "devDependencies": {
     "@playwright/test": "1.59.1",


### PR DESCRIPTION
GHSA-8j4g-w8fx-2239 — moderate ReDoS in hono's CORS middleware via `Access-Control-Request-Headers`. Transitive through `@tpsdev-ai/flair-mcp › @modelcontextprotocol/sdk`, so not fixable by changing a direct dependency. Fixed in 4.12.34, which is latest published.

Gate: rc=1 → rc=0, blocking 1 → 0, advisories 15 → 14. 3859 tests pass.

**This is the fourth advisory wave today**, and it landed *after* #1079 merged — main went from green to red again within minutes. That is why #1077, #1078 and #1080 are all still showing a red audit lane despite #1079 having merged: they are not stale, they are failing on a newer advisory.

Worth naming the pattern rather than just pinning again: the gate now goes red on main whenever a new advisory lands against anything in the tree. It is telling the truth — main really is exposed until the pin lands — but a lane that is red on main by default stops carrying information, and the fix each time is a mechanical forward pin. That deserves a deliberate policy (fast-lane for advisory bumps? scheduled sweep? allowlist-with-short-expiry as the default response?) rather than a reflex, and I would rather raise it than quietly add a fifth override.

Same shape as the others: a plain version constraint, not an `npm:` alias, so #750's ENOTEMPTY failure mode is absent by construction.

No issue: dependency-advisory response, remediation is a version pin, nothing to close. Unblocks the audit lane on #1077, #1078, #1080 and #1081.