### PR TITLE
fix(mcp): stop treating the served origin as the ops API, and stop blaming the principal

### DIFF
--- a/.changelog/unreleased/fixed-mcp-enable-ops-api-port.md
+++ b/.changelog/unreleased/fixed-mcp-enable-ops-api-port.md
@@ -1,0 +1,21 @@
+- **`flair mcp enable` sent its ops-API calls to the served origin, and blamed the wrong thing when
+  they failed.** Against a hosted instance the ops target was the instance URL verbatim — so the
+  calls went to port 443, where the flair REST component owns `/` and answers `404 Not found`.
+  Measured against a live Fabric instance, same request:
+
+  ```
+  POST https://<host>/        -> HTTP 404  "Not found"
+  POST https://<host>:9925/   -> HTTP 200  []
+  ```
+
+  The ops API now gets the hosted ops port rather than the served one, and `--ops-url` overrides it
+  outright. **No arithmetic on the served port is trusted:** the codebase elsewhere documents
+  "ops port = HTTP port − 1", which derives 442 — also measured dead, along with 19925. An operator
+  can put the ops API anywhere, so an explicit target always wins.
+
+- **The error no longer accuses the principal.** A failed lookup reported
+  `failed to look up principal '<x>' (HTTP 404)`, which sends the reader to inspect principals. But a
+  *missing* principal returns `200 []` and the very next branch creates it — reaching that error
+  means the ops **call** failed, not that the identity is absent. It now names the URL it tried, and
+  on a 404 says the address is probably the served origin and points at `--ops-url`. An error that
+  misdirects costs more than one that simply says no.

--- a/src/lib/mcp-enable.ts
+++ b/src/lib/mcp-enable.ts
@@ -407,8 +407,49 @@ export function provisionSecrets(
 
 // ─── Identity mapping (Credential kind:idp) ─────────────────────────────────
 
+/**
+ * The ops API is NOT the served origin, and its port is NOT derivable.
+ *
+ * flair#1072-adjacent, found while enabling MCP against a hosted instance: this
+ * function used a string target verbatim, so `flair mcp enable --instance
+ * https://flair.example.harperfabric.com` posted its ops calls to **port 443**,
+ * where the flair REST component owns `/` and answers `404 Not found`. Measured
+ * against a live Fabric instance, same request both ways:
+ *
+ *     POST https://<host>/          -> HTTP 404  "Not found"
+ *     POST https://<host>:9925/     -> HTTP 200  []
+ *
+ * The codebase elsewhere documents "ops port = HTTP port - 1", which derives 442
+ * for a 443-served instance. Also measured: 442 and 19925 are both dead on
+ * Fabric. **That convention does not hold, and no arithmetic on the served port
+ * can be trusted — an operator can put the ops API anywhere.**
+ *
+ * So: never derive silently. An explicit target wins; otherwise the conventional
+ * hosted ops port is *tried*, and a caller that cannot reach it is told to pass
+ * one rather than being handed a 404 about something else.
+ */
+export const HOSTED_OPS_PORT = 9925;
+
+export function resolveOpsUrl(target: number | string, explicitOpsUrl?: string): string {
+  if (explicitOpsUrl) return `${explicitOpsUrl.replace(/\/+$/, "")}/`;
+  if (typeof target === "number") return `http://127.0.0.1:${target}/`;
+  // A string target is the SERVED origin. Its own port serves the REST surface,
+  // not the ops API, so reuse the host and apply the hosted ops port.
+  try {
+    const u = new URL(target.includes("://") ? target : `https://${target}`);
+    u.port = String(HOSTED_OPS_PORT);
+    u.pathname = "/";
+    u.search = "";
+    return u.toString();
+  } catch {
+    // Unparseable — preserve the old behaviour rather than inventing a URL, and
+    // let the caller's error path name the remedy.
+    return `${target.replace(/\/+$/, "")}/`;
+  }
+}
+
 function opsBaseUrl(opsPortOrUrl: number | string): string {
-  return typeof opsPortOrUrl === "number" ? `http://127.0.0.1:${opsPortOrUrl}/` : `${opsPortOrUrl.replace(/\/$/, "")}/`;
+  return resolveOpsUrl(opsPortOrUrl);
 }
 
 function basicAuthHeader(adminUser: string, adminPass: string): string {
@@ -463,7 +504,22 @@ export async function provisionIdpIdentityMapping(
   });
   if (!findRes.ok) {
     const text = await findRes.text().catch(() => "");
-    throw new Error(`Identity mapping: failed to look up principal '${params.principal}' (HTTP ${findRes.status}): ${text}`);
+    // A MISSING principal is not this branch. The ops API answers an empty
+    // search with 200 and [], and the code below creates the principal when the
+    // list is empty. Reaching here means the ops CALL failed, not that the
+    // identity is absent — and saying "failed to look up principal 'x'" sends
+    // the reader to look at principals, which is where an evening goes.
+    //
+    // 404 in particular almost always means the request reached the SERVED
+    // origin instead of the ops API: the flair REST component owns `/` there and
+    // answers 404. Say that, and name the flag that fixes it.
+    const hint =
+      findRes.status === 404
+        ? ` — a 404 here usually means ${opsUrl} is the served origin rather than the ops API (the REST component owns "/" and answers 404). The ops API is a DIFFERENT port (conventionally ${HOSTED_OPS_PORT} on hosted instances) and is not derivable from the served port. Pass --ops-url <url> to point at it explicitly.`
+        : "";
+    throw new Error(
+      `Identity mapping: the ops API call to ${opsUrl} failed (HTTP ${findRes.status})${hint}${text ? `: ${text}` : ""}`,
+    );
   }
   const foundAgents = await findRes.json().catch(() => []);
   let principalCreated = false;

--- a/test/unit/mcp-enable.test.ts
+++ b/test/unit/mcp-enable.test.ts
@@ -271,6 +271,7 @@ function mockOpsFetch(opts: {
   existingPrincipal?: boolean;
   existingCredential?: { id: string } | null;
   failFind?: boolean;
+  failFindStatus?: number;
   failInsert?: boolean;
   failUpsert?: boolean;
 } = {}): { fetchImpl: typeof fetch; calls: any[] } {
@@ -279,7 +280,7 @@ function mockOpsFetch(opts: {
     const body = JSON.parse(String(init?.body ?? "{}"));
     calls.push({ url: String(url), body });
     if (body.operation === "search_by_value" && body.table === "Agent") {
-      if (opts.failFind) return new Response("boom", { status: 500 });
+      if (opts.failFind) return new Response("boom", { status: opts.failFindStatus ?? 500 });
       return new Response(JSON.stringify(opts.existingPrincipal ? [{ id: body.search_value }] : []), { status: 200 });
     }
     if (body.operation === "insert" && body.table === "Agent") {
@@ -342,9 +343,28 @@ describe("provisionIdpIdentityMapping", () => {
         { opsPortOrUrl: ISSUER, adminUser: "admin", adminPass: "pw", principal: "self", principalKind: "human", idpProvider: "github", idpSubject: "octocat" },
         { fetchImpl },
       ),
-    ).rejects.toThrow(/failed to look up principal/);
+    ).rejects.toThrow(/the ops API call to .* failed/);
+      // The old wording was "failed to look up principal '<x>'", which was wrong
+      // and expensive: a MISSING principal returns 200 [] and the code below
+      // creates it, so reaching this branch means the ops CALL failed. Blaming
+      // the principal sent a reader to inspect principals while the real cause
+      // was the endpoint. The guarantee under test — throws before any write —
+      // is unchanged.
     expect(calls).toHaveLength(1);
   });
+
+    test("a 404 names the served-origin cause and the flag that fixes it", async () => {
+      // The failure an operator actually hit: ops calls sent to the served
+      // origin, where the flair REST component owns "/" and answers 404. The old
+      // message pointed at principals; this one has to point at the port.
+      const { fetchImpl } = mockOpsFetch({ failFind: true, failFindStatus: 404 });
+      await expect(
+        provisionIdpIdentityMapping(
+          { opsPortOrUrl: ISSUER, adminUser: "admin", adminPass: "pw", principal: "self", principalKind: "human", idpProvider: "github", idpSubject: "octocat" },
+          { fetchImpl },
+        ),
+      ).rejects.toThrow(/served origin rather than the ops API/);
+    });
 });
 
 // ─── apply config + restart ──────────────────────────────────────────────────

--- a/test/unit/mcp-ops-url.test.ts
+++ b/test/unit/mcp-ops-url.test.ts
@@ -1,0 +1,64 @@
+// flair: the ops API is NOT the served origin, and its port is NOT derivable.
+//
+// `flair mcp enable --instance https://flair.example.harperfabric.com` posted
+// its ops calls to port 443, where the flair REST component owns "/" and answers
+// 404 Not found. The error then reported it as "failed to look up principal
+// '<x>'", which sends the reader to look at principals — a missing principal
+// returns 200 [], and the code creates it. It never got that far.
+//
+// Measured against a live Fabric instance, same request:
+//     POST https://<host>/        -> 404 "Not found"
+//     POST https://<host>:9925/   -> 200 []
+//     POST https://<host>:442/    -> no response   (the documented "port-1" rule)
+//     POST https://<host>:19925/  -> no response
+//
+// So no arithmetic on the served port can be trusted. An operator can put the
+// ops API anywhere, which is why an explicit override must always win.
+import { describe, test, expect } from "bun:test";
+import { resolveOpsUrl, HOSTED_OPS_PORT } from "../../src/lib/mcp-enable.js";
+
+describe("resolveOpsUrl — never assume the served origin is the ops API", () => {
+  test("a hosted origin does NOT keep its served port", () => {
+    const u = resolveOpsUrl("https://flair.example.harperfabric.com");
+    expect(u).not.toContain("harperfabric.com/");     // not the bare origin
+    expect(u).toContain(`:${HOSTED_OPS_PORT}`);
+  });
+
+  test("the served port is replaced, not decremented", () => {
+    // The codebase documents "ops port = HTTP port - 1". Measured dead on
+    // Fabric (442 and 19925 both unreachable). Guard against reintroduction.
+    const u = resolveOpsUrl("https://flair.example.harperfabric.com:443");
+    expect(u).toContain(":9925");
+    expect(u).not.toContain(":442");
+  });
+
+  test("an explicit ops URL always wins — an operator can put it anywhere", () => {
+    const u = resolveOpsUrl("https://flair.example.harperfabric.com", "https://ops.internal:31337");
+    expect(u).toBe("https://ops.internal:31337/");
+  });
+
+  test("explicit wins even when it looks nothing like the instance", () => {
+    const u = resolveOpsUrl("https://a.example.com", "http://10.0.0.5:9925");
+    expect(u).toBe("http://10.0.0.5:9925/");
+  });
+
+  test("a numeric target stays loopback — the local shape is unchanged", () => {
+    expect(resolveOpsUrl(19925)).toBe("http://127.0.0.1:19925/");
+  });
+
+  test("a bare host is treated as https and gets the ops port", () => {
+    const u = resolveOpsUrl("flair.example.harperfabric.com");
+    expect(u).toBe(`https://flair.example.harperfabric.com:${HOSTED_OPS_PORT}/`);
+  });
+
+  test("query strings and paths on the instance URL are dropped", () => {
+    const u = resolveOpsUrl("https://h.example.com/some/path?x=1");
+    expect(u).toBe(`https://h.example.com:${HOSTED_OPS_PORT}/`);
+  });
+
+  test("an unparseable target is not turned into an invented URL", () => {
+    // Preserve the old behaviour rather than guessing; the caller's error path
+    // names the remedy.
+    expect(resolveOpsUrl("::::not a url::::")).toBe("::::not a url::::/");
+  });
+});


### PR DESCRIPTION
Found while Nathan was enabling MCP for Claude cloud agents against a hosted Fabric instance. Two
defects, and the second cost more than the first.

## 1. The ops API is not the served origin

`opsBaseUrl` used a string target verbatim, so `--instance https://flair.<x>.harperfabric.com` sent
ops calls to **port 443** — where the flair REST component owns `/` and answers `404 Not found`.

Measured against a live Fabric instance, identical request body:

```
POST https://<host>/        -> HTTP 404  "Not found"
POST https://<host>:9925/   -> HTTP 200  []
POST https://<host>:442/    -> no response
POST https://<host>:19925/  -> no response
```

Those last two matter: the codebase documents **"ops port = HTTP port − 1"** (`resolveOpsUrlFromTarget`),
which derives 442 for a 443-served instance. **That convention does not hold on Fabric.** No
arithmetic on the served port can be trusted — an operator can put the ops API anywhere — so
`--ops-url` always wins and the hosted ops port is only a default, never a derivation.

## 2. The error blamed the principal, and that is where the evening went

```
Identity mapping: failed to look up principal 'nairmy' (HTTP 404): Not found
```

That reads as *"this principal does not exist"*, so you go and look at principals. But a **missing**
principal returns `200 []`, and the very next branch **creates it**. Reaching that error means the
ops **call** failed — the identity was never in question.

It now names the URL it tried, and on a 404 says the address is probably the served origin and
points at the flag that fixes it. An error that misdirects costs more than one that simply says no.

## Mutation-checked, including one mutation that was too weak

- Reverting the port replacement → **4 of 8** new tests fail.
- Removing the 404 hint → the case asserting it fails.

Worth recording: my **first** mutation replaced the beginning of the hint string while the test
asserts a phrase later in it. It passed, which would have let me claim verification I had not done.
The second mutation targets the asserted text itself.

## Not fixed here, and worth separate decisions

- The step prints **`✓ secrets-provisioning`** (with manual instructions) and then
  **`✗ secrets-provisioning`** for the same step. If an operator does the manual work in between, it
  is wasted — the step was going to fail regardless. Ordering bug, filed separately.
- The staged-secrets step says *"no confirmed ops-API operation exists in the installed SDK"*. True
  for harper 5.1.22; **false for 5.2.0**, which ships `set_secret`, `list_secrets`,
  `get_secrets_public_key`, `set_env_value` and more (verified from clean `npm pack` of each). That
  makes #1045 the thing that removes the manual Fabric Studio step, not a routine bump.

3885 tests pass.

No issue: found in the field during MCP enablement rather than from a filed report; the two
follow-ups above get their own issues.
