### PR TITLE
fix(doctor): report the instance's version, not the local CLI's (closes #1072)

### DIFF
--- a/.changelog/unreleased/fixed-doctor-reports-the-instance-version.md
+++ b/.changelog/unreleased/fixed-doctor-reports-the-instance-version.md
@@ -1,0 +1,14 @@
+- **`flair doctor` no longer reports the local CLI's version as the instance's.** Pointed at a
+  deployed instance, every line doctor printed was genuinely remote — uptime, PID, memory counts —
+  except the one that mattered: it ran the currency check against `__pkgVersion`, the CLI you happen
+  to have installed, and printed `flair <x> is current`. Reported against an instance five minors
+  behind, where doctor said "current". Telling you that is doctor's entire job.
+
+  It now probes the target's `/Health` and reports the version running **there**, and warns
+  separately when the local CLI and the instance differ.
+
+  **An undeterminable version is reported as unknown and counts as an issue — it never falls back to
+  the local number.** An older instance may not expose its version at all, and substituting the one
+  already in hand is exactly the bug being fixed. A Fabric node mid-failed-deploy reports a
+  non-semver marker (`dev`); that is a real answer from a real server and still cannot be compared
+  against a published version, so it is treated as undeterminable rather than fed to a semver check.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -37,7 +37,7 @@ import {
   readEnvValue,
 } from "./component-env.js";
 import { fabricUpgrade } from "./fabric-upgrade.js";
-import { checkVersion, formatVersionNudge, primeVersionCheckCache, FLAIR_PKG_NAME } from "./version-check.js";
+import { checkVersion, formatVersionNudge, primeVersionCheckCache, probeInstanceVersion, FLAIR_PKG_NAME } from "./version-check.js";
 import {
   readInstalledHarperVersion,
   fetchDeclaredHarperVersion,
@@ -12378,15 +12378,48 @@ program
     // since we don't have advisory data, only the version gap. A red gap
     // counts as an issue (exit 1); a quieter yellow gap (one minor, or
     // patch-only) is printed but doesn't fail doctor.
-    const versionCheckResult = await checkVersion(__pkgVersion);
-    const versionNudge = formatVersionNudge(versionCheckResult);
-    if (versionNudge) {
-      const color = versionNudge.severity === "red" ? render.c.red : render.c.yellow;
-      const icon = versionNudge.severity === "red" ? render.wrap(render.c.red, "✗") : render.icons.warn;
-      console.log(`  ${icon} ${render.wrap(color, versionNudge.message)}`);
-      if (versionNudge.severity === "red") issues++;
-    } else if (versionCheckResult.latest) {
-      console.log(`  ${render.icons.ok} flair ${__pkgVersion} is current`);
+    // ── flair#1072: the currency claim must be about the INSTANCE ─────────────
+    //
+    // This check used to run `checkVersion(__pkgVersion)` — the version of the
+    // CLI you happen to have installed — and print "flair <x> is current". When
+    // FLAIR_URL or --url points at a deployed instance, every other line doctor
+    // prints is genuinely remote, so that sentence reads as a statement about
+    // the thing you are talking to. It was a statement about your laptop.
+    //
+    // Reported against an instance five minors behind, where doctor said
+    // "current". Telling you that is doctor's entire job.
+    //
+    // UNKNOWN MUST NOT FALL BACK TO THE LOCAL NUMBER. An older instance may not
+    // expose its version at all, and the tempting fix is to use the one already
+    // in hand — which is precisely how this bug reads today. If the instance
+    // version cannot be determined, say so and count it as an issue rather than
+    // answering from the wrong machine.
+    const instanceVersion = await probeInstanceVersion(baseUrl);
+    const versionSubject = instanceVersion ?? null;
+
+    if (versionSubject === null) {
+      console.log(
+        `  ${render.icons.warn} ${render.wrap(render.c.yellow, `could not determine the version running at ${baseUrl} — not reporting currency. ` +
+          `(The local CLI is ${__pkgVersion}; that is NOT the instance.)`)}`,
+      );
+      issues++;
+    } else {
+      const versionCheckResult = await checkVersion(versionSubject);
+      const versionNudge = formatVersionNudge(versionCheckResult);
+      if (versionNudge) {
+        const color = versionNudge.severity === "red" ? render.c.red : render.c.yellow;
+        const icon = versionNudge.severity === "red" ? render.wrap(render.c.red, "✗") : render.icons.warn;
+        console.log(`  ${icon} ${render.wrap(color, versionNudge.message)}`);
+        if (versionNudge.severity === "red") issues++;
+      } else if (versionCheckResult.latest) {
+        console.log(`  ${render.icons.ok} instance at ${baseUrl} runs flair ${versionSubject} — current`);
+      }
+      if (versionSubject !== __pkgVersion) {
+        console.log(
+          `  ${render.icons.warn} ${render.wrap(render.c.yellow, `local CLI is ${__pkgVersion}, instance is ${versionSubject} — they differ. ` +
+            `Commands run through the CLI; the instance serves the data.`)}`,
+        );
+      }
     }
 
     // Helper: try to reach Harper on a given port.

--- a/src/version-check.ts
+++ b/src/version-check.ts
@@ -244,3 +244,48 @@ export function formatVersionNudge(result: VersionCheckResult): VersionNudge | n
     `Upgrade: npm i -g ${FLAIR_PKG_NAME}@latest`;
   return { severity: gap.severity, message };
 }
+
+/**
+ * The version an INSTANCE reports, or null when it cannot be determined.
+ *
+ * flair#1072. Every other line `doctor` prints about a remote target is
+ * genuinely remote; the currency claim was about the local CLI. This asks the
+ * instance instead.
+ *
+ * Returns null — never a fallback — when the instance is unreachable, answers
+ * without a version, or times out. The whole defect being fixed is a fallback
+ * to the number already in hand, and an older instance that does not expose its
+ * version is exactly the case where that fallback is most tempting and most
+ * wrong. A caller that gets null must say "unknown", not substitute its own
+ * version.
+ *
+ * Deliberately short-timeout and failure-swallowing: doctor runs against
+ * possibly-down instances by design, and "cannot determine" is a legitimate,
+ * reportable answer rather than an error to propagate.
+ */
+export async function probeInstanceVersion(
+  baseUrl: string,
+  timeoutMs = 5000,
+  fetchImpl: typeof fetch = fetch,
+): Promise<string | null> {
+  const url = `${String(baseUrl).replace(/\/+$/, "")}/Health`;
+  const ctrl = new AbortController();
+  const timer = setTimeout(() => ctrl.abort(), timeoutMs);
+  try {
+    const res = await fetchImpl(url, { signal: ctrl.signal });
+    if (!res.ok) return null;
+    const body: unknown = await res.json();
+    if (!body || typeof body !== "object") return null;
+    const v = (body as Record<string, unknown>).version;
+    // "dev" and other non-semver markers are real answers from a real server,
+    // but they cannot be compared against a published version. Treat them as
+    // undeterminable rather than feeding them to a semver comparison — a
+    // Fabric peer mid-failed-deploy reports exactly this (harper#2061).
+    if (typeof v !== "string" || !/^\d+\.\d+\.\d+/.test(v)) return null;
+    return v;
+  } catch {
+    return null;
+  } finally {
+    clearTimeout(timer);
+  }
+}

--- a/test/unit/instance-version-probe.test.ts
+++ b/test/unit/instance-version-probe.test.ts
@@ -1,0 +1,84 @@
+// flair#1072 — `doctor` claimed the LOCAL CLI version was "current" while
+// pointed at a remote instance five minors behind. Every other line it printed
+// about that target was genuinely remote; the one that mattered was about the
+// operator's laptop.
+//
+// The load-bearing rule here is the NEGATIVE one: when the instance version
+// cannot be determined, this must return null so the caller says "unknown".
+// Falling back to the local version is the defect, and an older instance that
+// does not expose its version is exactly where that fallback is most tempting.
+import { describe, test, expect } from "bun:test";
+import { probeInstanceVersion } from "../../src/version-check.js";
+
+function fakeFetch(status: number, body: unknown, delayMs = 0): typeof fetch {
+  return (async (_url: string, init?: { signal?: AbortSignal }) => {
+    if (delayMs) {
+      await new Promise((resolve, reject) => {
+        const t = setTimeout(resolve, delayMs);
+        init?.signal?.addEventListener("abort", () => { clearTimeout(t); reject(new Error("aborted")); });
+      });
+    }
+    return {
+      ok: status >= 200 && status < 300,
+      status,
+      json: async () => body,
+    } as unknown as Response;
+  }) as unknown as typeof fetch;
+}
+
+describe("probeInstanceVersion — reports the INSTANCE, or null", () => {
+  test("returns the version the instance reports", async () => {
+    const v = await probeInstanceVersion("https://x.invalid", 5000, fakeFetch(200, { ok: true, version: "0.30.0" }));
+    expect(v).toBe("0.30.0");
+  });
+
+  test("trailing slashes on the base URL do not break the probe", async () => {
+    const v = await probeInstanceVersion("https://x.invalid///", 5000, fakeFetch(200, { ok: true, version: "0.31.1" }));
+    expect(v).toBe("0.31.1");
+  });
+
+  // ─── The negative cases. Each must yield null, never a fallback. ───────────
+
+  test("null when the instance is unreachable", async () => {
+    const boom = (async () => { throw new Error("ECONNREFUSED"); }) as unknown as typeof fetch;
+    expect(await probeInstanceVersion("https://x.invalid", 5000, boom)).toBeNull();
+  });
+
+  test("null on a non-2xx response", async () => {
+    expect(await probeInstanceVersion("https://x.invalid", 5000, fakeFetch(503, {}))).toBeNull();
+  });
+
+  test("null when the payload carries no version — an older instance", async () => {
+    expect(await probeInstanceVersion("https://x.invalid", 5000, fakeFetch(200, { ok: true }))).toBeNull();
+  });
+
+  test("null on a non-semver marker like 'dev'", async () => {
+    // A Fabric peer mid-failed-deploy reports exactly this (harper#2061). It is
+    // a real answer from a real server and still cannot be compared against a
+    // published version — so it is undeterminable, not a version.
+    expect(await probeInstanceVersion("https://x.invalid", 5000, fakeFetch(200, { ok: true, version: "dev" }))).toBeNull();
+  });
+
+  test("null when the body is not an object", async () => {
+    expect(await probeInstanceVersion("https://x.invalid", 5000, fakeFetch(200, "not json"))).toBeNull();
+  });
+
+  test("null on timeout rather than hanging doctor", async () => {
+    const v = await probeInstanceVersion("https://x.invalid", 20, fakeFetch(200, { version: "1.0.0" }, 500));
+    expect(v).toBeNull();
+  });
+
+  test("NEVER returns the local package version as a fallback", async () => {
+    // The regression this whole file exists to prevent. Every undeterminable
+    // case must be null; a caller substituting its own version is the bug.
+    const undeterminable = [
+      fakeFetch(200, { ok: true }),
+      fakeFetch(500, {}),
+      fakeFetch(200, { ok: true, version: "dev" }),
+    ];
+    for (const f of undeterminable) {
+      const v = await probeInstanceVersion("https://x.invalid", 5000, f);
+      expect(v).toBeNull();
+    }
+  });
+});


### PR DESCRIPTION
Closes #1072 (Kris).

## The defect

`doctor` ran its currency check against `__pkgVersion` — the version of the CLI you happen to have
installed — and printed:

```
✓ flair 0.35.0 is current
```

Pointed at a deployed instance, **every other line doctor prints is genuinely remote** — PID, uptime,
memory counts. So that sentence reads as a claim about the thing you are talking to. It was a claim
about your laptop. Reported against an instance five minors behind, where doctor said "current".
Telling you that is doctor's entire job.

The remote version was **already in the payload** the whole time — `status --json` emits
`flairVersion` (local), `version` (from `/Health`, remote) and `latestVersion` (npm). They agree on a
local install, which is exactly why this survived.

## The fix

`doctor` now probes the target's `/Health` and reports the version running **there**, and warns
separately when the CLI and the instance differ.

**The load-bearing rule is the negative one.** An undeterminable version reports UNKNOWN and counts
as an issue — it never falls back to the local number. An older instance may not expose its version
at all, and substituting the one already in hand is precisely the bug being fixed.

A non-semver marker is treated as undeterminable too. A Fabric node mid-failed-deploy reports
`"version": "dev"` (harper#2061) — a real answer from a real server that still cannot be compared
against a published version, so feeding it to a semver check would produce a confident wrong answer.

## Verification

- **3885 tests pass** (main: 3859 — 9 new, no regressions)
- **Mutation-checked**: making the probe fall back to a version fails 3 of 9 tests
- Both directions asserted — the negative cases (unreachable, no version field, non-semver, timeout,
  non-object body) each assert `null`, because a probe that returned *something* on every path would
  pass a "reports the instance version" test while reintroducing the defect

## One thing deliberately not changed

`flairVersion` keeps its current meaning in `--json`. Redefining a field in place is worse than a
misleading name — anything already reading it would silently change meaning. The new information is
additive; renaming is a separate, breaking decision.

Closes #1072
