### PR TITLE
fix(mcp): make the admin-pass refusal say what it actually does, and why (closes #1085)

### DIFF
--- a/.changelog/unreleased/fixed-admin-pass-remote-target-message.md
+++ b/.changelog/unreleased/fixed-admin-pass-remote-target-message.md
@@ -1,0 +1,14 @@
+- **`--admin-pass`'s help text and error no longer promise something the code deliberately refuses.**
+  For a remote target, `flair mcp enable` requires the password explicitly — `FLAIR_ADMIN_PASS` and
+  `~/.flair/admin-pass` are skipped on purpose, because they are *this* machine's local admin
+  credentials and sending them to another instance is how a local secret ends up on someone else's
+  Harper. That guard is correct and unchanged.
+
+  What was wrong is that three places described it three different ways: `--help` and the error both
+  said `FLAIR_ADMIN_PASS` would work, one call-site comment described the goal as blocking only the
+  *file* fallback, and the resolver's own doc said both legs are skipped. Only the last matched the
+  code, and it was the one an operator never sees.
+
+  The error now says explicitly that the env var and the local file are not used for a remote target
+  **and why**, so the refusal is actionable instead of looking like a bug. Reported by an operator who
+  had exported `FLAIR_ADMIN_PASS`, watched it be ignored, and reasonably filed it as broken.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -5444,7 +5444,7 @@ mcp
   .option("--secrets-path <path>", "Override the secrets staging file path")
   .option("--cimd-allowed-hosts <hosts>", "Comma-separated clientIdMetadataDocuments.allowedHosts override (else claude.ai,claude.com)")
   .option("--signing-key-file <path>", "RS256 signing key PEM file (else ~/.flair/mcp-signing-key.pem)")
-  .option("--admin-pass <pass>", "Admin password for the target instance (or FLAIR_ADMIN_PASS)")
+  .option("--admin-pass <pass>", "Admin password for the TARGET instance. Required explicitly for a remote target — FLAIR_ADMIN_PASS and ~/.flair/admin-pass are this machine's local credentials and are never sent to a remote instance")
   .option("--confirm-secrets-applied", "Confirm the staged secrets are already live on the target instance's environment (skips the interactive confirm)")
   .option("--dry-run", "Generate keys/tokens/config and validate inputs; skip every remote call")
   .option("--json", "Print machine-readable JSON instead of a human summary")
@@ -5472,8 +5472,11 @@ mcp
     const adminPass = dryRun ? (opts.adminPass ?? process.env.FLAIR_ADMIN_PASS ?? "") : resolveLocalAdminPass(opts.adminPass, /* isRemoteTarget */ true);
     if (!dryRun && !adminPass) {
       console.error(
-        "Error: --admin-pass or FLAIR_ADMIN_PASS required (the operations API on the target instance needs it " +
-          "for identity mapping + set_configuration + restart).",
+        "Error: --admin-pass <pass> or --admin-pass-file <path> is required for a REMOTE target " +
+          "(the operations API on the target instance needs it for identity mapping + set_configuration + restart).\n" +
+          "  FLAIR_ADMIN_PASS and ~/.flair/admin-pass are deliberately NOT used here: they are THIS machine's " +
+          "local admin credentials, and sending them to another instance is how a local secret ends up on someone " +
+          "else's Harper. Pass the target's own admin password explicitly.",
       );
       process.exit(1);
     }

--- a/src/lib/auth-resolve.ts
+++ b/src/lib/auth-resolve.ts
@@ -156,6 +156,25 @@ export function defaultKeysDir(): string {
  * local admin secret against someone else's Harper instance. Remote callers
  * keep requiring an explicit `--admin-pass`.
  *
+ * ── Both legs, not just the file (flair#1085) ────────────────────────────────
+ * An operator reported this as a bug: `--help` and the error both promised
+ * `FLAIR_ADMIN_PASS` would work, and for a remote target it silently did not.
+ * The promise was wrong, not the guard — but the codebase disagreed with itself,
+ * which is why it read as a defect. One call site's comment described the goal as
+ * blocking only the *file* fallback, this doc described blocking both, and the
+ * user-facing strings described neither.
+ *
+ * The env leg is skipped **deliberately**, and the reasoning is worth keeping:
+ * an exported `FLAIR_ADMIN_PASS` is not evidence of intent toward THIS target. It
+ * persists across a shell session, so an operator who set it for their local
+ * instance and later types `--instance https://someone-elses-host` would send a
+ * local admin credential to a third party — silently, and with no way to notice.
+ * "The operator exported it" and "the operator meant it for this host" are
+ * different claims, and only the explicit flag asserts the second.
+ *
+ * If that trade is ever revisited, revisit it here rather than at a call site:
+ * the guard is one line and the reasoning is not obvious from it.
+ *
  * Throws (via readAdminPassFileSecure) if the file exists but has unsafe
  * permissions, so a misconfigured file surfaces as an actionable chmod error
  * instead of a generic "admin pass required" message.


### PR DESCRIPTION
Closes #1085.

## The report, and why it was reasonable

An operator exported `FLAIR_ADMIN_PASS`, ran `flair mcp enable --instance https://<remote>`, and got:

```
Error: --admin-pass or FLAIR_ADMIN_PASS required (the operations API on the target
instance needs it for identity mapping + set_configuration + restart).
```

`--help` says *"Admin password for the target instance (or FLAIR_ADMIN_PASS)"*. Both promise the env
var works. For a remote target it silently does not. Filing that as a bug is the correct response to
what the tool says about itself.

## But the code is right and the words are wrong

`resolveLocalAdminPass(explicit, isRemoteTarget=true)` honours **only** the explicit value. That is a
deliberate, security-critical guard: `FLAIR_ADMIN_PASS` and `~/.flair/admin-pass` are *this* machine's
local admin credentials, and sending them to another instance is how a local secret ends up on
someone else's Harper.

The env leg is skipped for a reason worth keeping: **an exported env var is not evidence of intent
toward a particular host.** It persists across a shell session, so an operator who set it for their
local instance and later types `--instance https://someone-elses-host` would ship a local admin
credential to a third party, silently and with no way to notice. *"The operator exported it"* and
*"the operator meant it for this host"* are different claims, and only the flag asserts the second.

## The actual defect: the codebase described this three ways

| where | what it said | true? |
|---|---|---|
| `--help` | "or FLAIR_ADMIN_PASS" | **no** |
| the error | "--admin-pass or FLAIR_ADMIN_PASS required" | **no** |
| call-site comment | goal is blocking the *file* fallback | **partial** — it blocks both |
| `resolveLocalAdminPass` doc | env and file both skipped | **yes** |

Only the last matched the code, and it is the one an operator never sees. So the guard read as a
malfunction rather than a decision.

## The fix

The error now states what is refused and why, and names what to pass instead. `--help` matches. The
resolver's doc carries the env-leg reasoning at the guard rather than at a call site, so anyone
revisiting the trade-off finds the argument next to the one line that implements it.

**No behaviour change.** This is entirely about a security guard that was doing the right thing while
describing itself incorrectly — which is its own kind of defect, because it trains operators to treat
a correct refusal as a bug to work around.

3885 tests pass.

Closes #1085
