### PR TITLE
fix(deps): pin rocksdb-js forward for the silent storage read bug, without the 5.2 bump

### DIFF
--- a/.changelog/unreleased/fixed-rocksdb-storage-read-on-cache-miss.md
+++ b/.changelog/unreleased/fixed-rocksdb-storage-read-on-cache-miss.md
@@ -1,0 +1,18 @@
+- **`@harperfast/rocksdb-js` pinned forward to `^2.6.1`, fixing a silent storage read bug without
+  taking the rest of the Harper 5.2 bump.** In the affected versions `TransactionHandle::get`
+  honoured the caller's column-family override on its synchronous block-cache attempt but dropped it
+  in the async worker. Since every table in a database shares one read transaction, each table after
+  the first in a request was read through a foreign column family: cache hits correct, **cache misses
+  silently returning not-found**. Worst immediately after a restart, and healing as traffic warms the
+  cache — so it presents as intermittent missing data rather than an error.
+
+  harper 5.1.22 declares `^2.3.0`, so 2.6.1 satisfies the range and no Harper change is required.
+
+  **Taken separately from #1045 deliberately.** That PR pins harper 5.2.0, which is what turns the
+  Mixed-Version Federation lane red — verified as green on other PRs and absent from main, so the
+  failure is caused by the pin rather than inherited. 5.2.0 also carries genuinely wanted things (the
+  ops-API secrets operations that would remove a manual step from `flair mcp enable`), but those are
+  workflow value and this is correctness value. Correctness first; the full bump waits on
+  HarperFast/harper#2061 and #2062.
+
+  Verified against real storage rather than mocks: 438 integration tests pass with the new engine.

--- a/bun.lock
+++ b/bun.lock
@@ -130,6 +130,7 @@
     "harper-fabric-embeddings",
   ],
   "overrides": {
+    "@harperfast/rocksdb-js": "^2.6.1",
     "brace-expansion": "^5.0.9",
     "fast-uri": "^4.1.2",
     "hono": "^4.12.34",
@@ -283,23 +284,23 @@
 
     "@harperfast/oauth": ["@harperfast/oauth@2.4.0", "", { "dependencies": { "jsonwebtoken": "^9.0.2", "jwks-rsa": "^3.1.0" }, "peerDependencies": { "harper": ">=5.0.0" } }, "sha512-cSmisQDG4EKR73G5jFHWq6eTxQ529WkSW5+Tplf+FKbdXN7j2HIEslkFZ1nPsD0DrVei5tdg3AF4IGfjFOYsfw=="],
 
-    "@harperfast/rocksdb-js": ["@harperfast/rocksdb-js@2.5.0", "", { "dependencies": { "@harperfast/extended-iterable": "1.0.3", "msgpackr": "2.0.4", "ordered-binary": "1.6.1" }, "optionalDependencies": { "@harperfast/rocksdb-js-darwin-arm64": "2.5.0", "@harperfast/rocksdb-js-darwin-x64": "2.5.0", "@harperfast/rocksdb-js-linux-arm64-glibc": "2.5.0", "@harperfast/rocksdb-js-linux-arm64-musl": "2.5.0", "@harperfast/rocksdb-js-linux-x64-glibc": "2.5.0", "@harperfast/rocksdb-js-linux-x64-musl": "2.5.0", "@harperfast/rocksdb-js-win32-arm64": "2.5.0", "@harperfast/rocksdb-js-win32-x64": "2.5.0" }, "bin": { "rocksdb-js": "./bin/rocksdb-js.mjs" } }, "sha512-v8T3J9n87seoDwKPmYxKdeC7gyA6lI9CJqU/MJMYfjfF1hyzb0aOjzRZx2X4wqm+iBJKtLNp8EKjEpIQuajeQQ=="],
+    "@harperfast/rocksdb-js": ["@harperfast/rocksdb-js@2.6.1", "", { "dependencies": { "@harperfast/extended-iterable": "1.0.3", "msgpackr": "2.0.4", "ordered-binary": "1.6.1" }, "optionalDependencies": { "@harperfast/rocksdb-js-darwin-arm64": "2.6.1", "@harperfast/rocksdb-js-darwin-x64": "2.6.1", "@harperfast/rocksdb-js-linux-arm64-glibc": "2.6.1", "@harperfast/rocksdb-js-linux-arm64-musl": "2.6.1", "@harperfast/rocksdb-js-linux-x64-glibc": "2.6.1", "@harperfast/rocksdb-js-linux-x64-musl": "2.6.1", "@harperfast/rocksdb-js-win32-arm64": "2.6.1", "@harperfast/rocksdb-js-win32-x64": "2.6.1" }, "bin": { "rocksdb-js": "./bin/rocksdb-js.mjs" } }, "sha512-9LBZsbb/wrsqe5Bua6DjsSZhYhO8WbNMKgmiHoHAVmKh0TVKqSlvndQnM0X4O+TslxxOKUtMjt1PeZXX+8RFfA=="],
 
-    "@harperfast/rocksdb-js-darwin-arm64": ["@harperfast/rocksdb-js-darwin-arm64@2.5.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-AmBoXKqjVvLrcuqvyjDFVLAEp8r5nJt+djXkKGVVl9c8OohsaRMDl91TzVbTI/pWiPSL1BZKHLVMoYJZ/a+jKw=="],
+    "@harperfast/rocksdb-js-darwin-arm64": ["@harperfast/rocksdb-js-darwin-arm64@2.6.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-iq5lCjFey4aYG9/W7ETiaZQ5r2A43fX75DCCnIG7s9aVuE39Ug2TVKz8MOD7NPrIzygLbw7SYjijB23ApCquiA=="],
 
-    "@harperfast/rocksdb-js-darwin-x64": ["@harperfast/rocksdb-js-darwin-x64@2.5.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-Cy3qKRrZ6I1kE9NlK5dI8LdhA9wlpnYmwJfIa1xT/entpN/3lrkKR/VA190fmdCXa1LV4Rjx1BNM2pSQj9bpsg=="],
+    "@harperfast/rocksdb-js-darwin-x64": ["@harperfast/rocksdb-js-darwin-x64@2.6.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-F/m7eIriZVk1qTvt70ehNIEsvUTVPdF2g92ZQX8Pka/219E2b4T0S2e6VHB61EBN/W7ylrphbjo956wfHeqLsA=="],
 
-    "@harperfast/rocksdb-js-linux-arm64-glibc": ["@harperfast/rocksdb-js-linux-arm64-glibc@2.5.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-3SNtSriey9XqAeUr9gbILhX46iNUVLqA/of4z0C+S2J1QCnPywl1cPvT7YoF9ck0GOoCqXm1xbTUzAPxB2MDGw=="],
+    "@harperfast/rocksdb-js-linux-arm64-glibc": ["@harperfast/rocksdb-js-linux-arm64-glibc@2.6.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-Epiywik4lq3EkNAw13/JXZp08wZX+sKzeek/wsRP8L58WK8iiv+lL+1FeTQIaZ0y5x2bXfy1apyfvIPenTlpTg=="],
 
-    "@harperfast/rocksdb-js-linux-arm64-musl": ["@harperfast/rocksdb-js-linux-arm64-musl@2.5.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-jLFO8Stvl2LBEfZRjO7Kp2noO7Xse9jztZJuEM8uwAmj6y9hLf31ysGR4tVTdGqHTHkSNWIpy+mb0Fv+A9c2dg=="],
+    "@harperfast/rocksdb-js-linux-arm64-musl": ["@harperfast/rocksdb-js-linux-arm64-musl@2.6.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-oytTCkkB1m6aOMq5+W8iQxrKB+U53/Anfb5hgsky0UXHaJTQ55GO2KAxwMOLxAFwrTwsDc5RwZul0AdXvLdHjQ=="],
 
-    "@harperfast/rocksdb-js-linux-x64-glibc": ["@harperfast/rocksdb-js-linux-x64-glibc@2.5.0", "", { "os": "linux", "cpu": "x64" }, "sha512-50AVHiLIz7BDf/mihi6FYF21FAWkOVgexcp+SmPL9FouClq93D/IjmmNC5O2HmFVKKjAWvNaakHEyofdNNr8yw=="],
+    "@harperfast/rocksdb-js-linux-x64-glibc": ["@harperfast/rocksdb-js-linux-x64-glibc@2.6.1", "", { "os": "linux", "cpu": "x64" }, "sha512-A5tI89GD11eboM6l76nKqqcEM7UoB2ESbo/RPDoUaQxhhp0Q5o4CwVcgy/G+T4NBhhHSVASIvUgeR0L+xiG7Og=="],
 
-    "@harperfast/rocksdb-js-linux-x64-musl": ["@harperfast/rocksdb-js-linux-x64-musl@2.5.0", "", { "os": "linux", "cpu": "x64" }, "sha512-yWWULelWWMkavYbHJuYao5LAiG6IVK9/CzwsYdt/V0mgpVGBdGH5oKVbX+rwtM7H0vyqCNIuctXg9A0m8Bn48g=="],
+    "@harperfast/rocksdb-js-linux-x64-musl": ["@harperfast/rocksdb-js-linux-x64-musl@2.6.1", "", { "os": "linux", "cpu": "x64" }, "sha512-owicSZXl+CPKKong+NTBHGzzTZ8Vq633rsewu+B1u1qlXhpV0W5HiKtcvpyJ6PbIXukjt9STtBC1rImUiaPw3Q=="],
 
-    "@harperfast/rocksdb-js-win32-arm64": ["@harperfast/rocksdb-js-win32-arm64@2.5.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-r4UpDG9qeZR8GS7u3tQMJrMqhHPd+yU6m7fI6rqtkdjjULKvLMbpqQ8slkd7mzG0dSx3gYbVzCV1VijqA4vQmg=="],
+    "@harperfast/rocksdb-js-win32-arm64": ["@harperfast/rocksdb-js-win32-arm64@2.6.1", "", { "os": "win32", "cpu": "arm64" }, "sha512-GKVaaQnDmf8t1x5Ws6F2+WSevAeQRo85lFx/WEdtmkrqs/bE34lIYAUSQxzs2ALBs+R8kLj5gpoRc8KhBaUV+g=="],
 
-    "@harperfast/rocksdb-js-win32-x64": ["@harperfast/rocksdb-js-win32-x64@2.5.0", "", { "os": "win32", "cpu": "x64" }, "sha512-9CKwGDr8nBY/JoMT7AUUkUxmCQ6kfEqy9o/5mNDD6wjYfhMQ4ToTblTe33jgC84No3ociJavwT38HntXfO5xAA=="],
+    "@harperfast/rocksdb-js-win32-x64": ["@harperfast/rocksdb-js-win32-x64@2.6.1", "", { "os": "win32", "cpu": "x64" }, "sha512-LF8sQVLAvqKc0waKMBQ5ADiHVUv9kwpj79RudY5xCIh3Qn3va6EYKLSxQezOPyZDX0yAOzpzacFnYNAno+7mnQ=="],
 
     "@homebridge/ciao": ["@homebridge/ciao@1.3.9", "", { "dependencies": { "debug": "^4.4.3", "fast-deep-equal": "^3.1.3", "source-map-support": "^0.5.21", "tslib": "^2.8.1" }, "bin": { "ciao-bcs": "lib/bonjour-conformance-testing.js" } }, "sha512-TMy9zy173jDOpnFXDqL3BPIQn5lfcAkSsivYQatCCakoHk4fLGd7QjfAaNGYE3Ox+/ZI6Lq0e1gGcz1qdw/IbA=="],
 

--- a/package.json
+++ b/package.json
@@ -76,7 +76,8 @@
     "brace-expansion": "^5.0.9",
     "undici": "^8.9.0",
     "fast-uri": "^4.1.2",
-    "hono": "^4.12.34"
+    "hono": "^4.12.34",
+    "@harperfast/rocksdb-js": "^2.6.1"
   },
   "devDependencies": {
     "@playwright/test": "1.59.1",


### PR DESCRIPTION
Kern's proposal after withdrawing his #1045 approval, and it is the better shape. This takes the
**correctness** fix out of #1045 and leaves the parts that break things behind.

## The bug being fixed

`TransactionHandle::get` honoured the caller's column-family override on its synchronous block-cache
attempt and **dropped it in the async worker**. Every table in a database shares one read
transaction, so each table after the first in a request was read through a foreign column family:

- cache **hits** — correct
- cache **misses** — **silently return not-found**

Worst immediately after a restart, healing as traffic warms the cache. So it presents as intermittent
missing data rather than an error, which is the worst way for a storage bug to present.

## Why an override rather than #1045

harper 5.1.22 declares `@harperfast/rocksdb-js: ^2.3.0`. `2.6.1` satisfies that range, so the fix
lands with **no Harper change at all** — verified against the published 5.1.22 manifest, not assumed.

#1045 pins harper **5.2.0**, and that pin is what turns the Mixed-Version Federation lane red.
Measured, latest run per PR:

```
#1077  success        #1080  did not run
#1078  success        #1081  did not run
#1045  FAILURE   <- the pin
```

The lane is green where it runs and absent from main. So the failure is **caused by the pin, not
inherited** — which disproved the premise both approvals on #1045 rested on, and is why that PR is on
hold rather than merged.

5.2.0 does carry things we want: the ops-API secrets operations (`set_secret`, `list_secrets`,
`get_secrets_public_key`) that would remove a manual Fabric Studio step from `flair mcp enable`. But
that is **workflow** value weighed against **correctness** value here, and it can wait for
HarperFast/harper#2061 and #2062.

## Verification

A storage-engine bump is not something a unit suite exercises, so:

- **438 integration tests pass** — real Harper, real storage, with 2.6.1 resolved
- 3885 unit tests pass
- audit gate `rc=0`, build clean
- `harper` confirmed still at **5.1.22**; only the transitive storage engine moved

The federation lane on this PR is the real test of the split's premise: if it stays green while
#1045's is red, that confirms the pin — not the storage engine — is what breaks it.

Refs #1045, HarperFast/harper#2061, #2062

No issue: this is the correctness half of #1045, extracted after review. #1045 stays open for the
rest of the bump.
