### PR TITLE
fix(mcp): report a failure against the step that ran, not the last one that passed

### DIFF
--- a/.changelog/unreleased/fixed-mcp-enable-step-attribution.md
+++ b/.changelog/unreleased/fixed-mcp-enable-step-attribution.md
@@ -1,0 +1,16 @@
+- **A failed `flair mcp enable` step is now reported against the step that failed.** The catch
+  attributed errors to `steps[steps.length - 1]` — the last step that *succeeded* — so a throw inside
+  identity mapping was filed against secrets provisioning, which had just completed:
+
+  ```
+  ✓ secrets-provisioning   ...apply these 5 vars via Fabric Studio, then re-run
+  ✗ secrets-provisioning   unexpected error: Identity mapping: ... (HTTP 404)
+  ```
+
+  Two results for one step name, and the `✓` instructs several minutes of manual work in a web UI
+  that the `✗` makes pointless. Read in reading order — which is how people read — you do the work
+  first and discover afterwards that the step failed anyway. It also makes a run un-skimmable:
+  scanning for the first `✗` finds a `✓` for that same step above it.
+
+  A test asserts the narrow fact (an identity-mapping failure reports `identity-mapping`) and a
+  broader invariant: no step name may carry both a pass and a failure in one run.

--- a/src/lib/mcp-enable.ts
+++ b/src/lib/mcp-enable.ts
@@ -890,18 +890,28 @@ export async function enableMcp(params: EnableMcpParams, deps: EnableMcpDeps = {
   const steps: EnableStepResult[] = [];
   // The step currently executing, so a throw is attributed to IT rather than to
   // the last step that succeeded (flair#1087).
-  let currentStep: EnableStepName | undefined;
+  //
+  // `push` deliberately takes NO step name: it reads this variable. A name passed
+  // per-call would be the same string typed twice (once here, once at the push),
+  // and the two drifting apart is precisely the misattribution #1087 is about —
+  // a rule that only a comment or a source scan could enforce. Deriving it makes
+  // a wrong name unrepresentable instead of merely discouraged, so there is
+  // nothing left for a reviewer to check.
+  //
+  // Initialised to the first step rather than left undefined so a throw before
+  // any assignment cannot be attributed to an arbitrary fallback name.
+  let currentStep: EnableStepName = "local-origin-check";
   const dryRun = Boolean(params.dryRun);
-  const push = (step: EnableStepName, ok: boolean, detail: string) => steps.push({ step, ok, detail });
+  const push = (ok: boolean, detail: string) => steps.push({ step: currentStep, ok, detail });
 
   // ── Local-origin refusal (scenario addendum, binding) ─────────────────────
   currentStep = "local-origin-check";
   const localCheck = checkLocalOriginRefusal(params.instance);
   if (localCheck.refused) {
-    push("local-origin-check", false, localCheck.message);
+    push(false, localCheck.message);
     return { ok: false, dryRun, refused: { message: localCheck.message }, steps, failedStep: "local-origin-check" };
   }
-  push("local-origin-check", true, `${params.instance} is a public-shaped origin`);
+  push(true, `${params.instance} is a public-shaped origin`);
 
   const issuer = (params.issuer ?? params.instance).replace(/\/+$/, "");
   const idpProvider = params.idpProvider ?? "github";
@@ -912,15 +922,13 @@ export async function enableMcp(params: EnableMcpParams, deps: EnableMcpDeps = {
     // ── RS256 signing keypair ─────────────────────────────────────────────────
     currentStep = "signing-key";
     const keyResult = ensureSigningKeyFile(params.signingKeyFilePath, { generate: deps.generateRsaKeyPair });
-    push("signing-key", true, `signing key ${keyResult.reused ? "reused" : "generated"} at ${keyResult.path} (0600)`);
+    push(true, `signing key ${keyResult.reused ? "reused" : "generated"} at ${keyResult.path} (0600)`);
 
     // ── @harperfast/oauth config block (CIMD-only; DCR explicitly disabled) ──
     const cimdAllowedHosts = params.cimdAllowedHosts ?? DEFAULT_CIMD_ALLOWED_HOSTS;
     currentStep = "config-block";
     const configBlock = buildMcpOAuthConfigBlock({ idpProvider, cimdAllowedHosts });
-    push(
-      "config-block",
-      true,
+    push(true,
       `built the @harperfast/oauth mcp config block (accessTokenTtl=${REQUIRED_ACCESS_TOKEN_TTL}, ` +
         `dynamicClientRegistration.enabled=false, clientIdMetadataDocuments.allowedHosts=${JSON.stringify(cimdAllowedHosts)})`,
     );
@@ -934,14 +942,12 @@ export async function enableMcp(params: EnableMcpParams, deps: EnableMcpDeps = {
         !params.idpClientSecret && "--idp-client-secret",
         !params.idpSubject && "--idp-subject",
       ].filter(Boolean).join(", ");
-      push(
-        "idp-credentials",
-        false,
+      push(false,
         `missing ${missing}. Create a ${idpProvider} OAuth app with callback URL ${callbackUrl}, then re-run with the credentials.`,
       );
       return { ok: false, dryRun, steps, failedStep: "idp-credentials", callbackUrl };
     }
-    push("idp-credentials", true, `${idpProvider} OAuth app credentials present; callback URL: ${callbackUrl}`);
+    push(true, `${idpProvider} OAuth app credentials present; callback URL: ${callbackUrl}`);
 
     if (dryRun) {
       // Dry-run stops here — everything above is pure/local generation; no
@@ -972,9 +978,7 @@ export async function enableMcp(params: EnableMcpParams, deps: EnableMcpDeps = {
       mechanism: params.secretsMechanism,
       stagingPath: params.secretsStagingPath,
     });
-    push(
-      "secrets-provisioning",
-      true,
+    push(true,
       `mechanism: ${secretsResult.mechanism}; ${secretsResult.varNames.length} vars staged at ${secretsResult.path} (0600). ${secretsResult.instructions}`,
     );
 
@@ -992,9 +996,7 @@ export async function enableMcp(params: EnableMcpParams, deps: EnableMcpDeps = {
       },
       { fetchImpl: deps.fetchImpl, now: deps.now },
     );
-    push(
-      "identity-mapping",
-      true,
+    push(true,
       `principal '${principal}' ${mapping.principalCreated ? "created" : "already existed"}; ` +
         `Credential(kind:idp) ${mapping.credentialReused ? "reused" : "created"} (${mapping.credentialId})`,
     );
@@ -1007,9 +1009,7 @@ export async function enableMcp(params: EnableMcpParams, deps: EnableMcpDeps = {
       );
     }
     if (!confirmed) {
-      push(
-        "apply-config-and-restart",
-        false,
+      push(false,
         `not applied: pass --confirm-secrets-applied once the staged secrets are live on ${params.instance}, then re-run \`flair mcp enable\` (earlier steps are idempotent and will reuse what's already provisioned).`,
       );
       return { ok: false, dryRun, steps, failedStep: "apply-config-and-restart", secretsMechanism: secretsResult.mechanism, secretsPath: secretsResult.path };
@@ -1021,13 +1021,13 @@ export async function enableMcp(params: EnableMcpParams, deps: EnableMcpDeps = {
       { opsPortOrUrl: params.instance, adminUser: params.adminUser, adminPass: params.adminPass, configBlock },
       { fetchImpl: deps.fetchImpl },
     );
-    push("apply-config-and-restart", true, `set_configuration + restart succeeded against ${params.instance}`);
+    push(true, `set_configuration + restart succeeded against ${params.instance}`);
 
     // ── Self-verify from the operator's machine, public origin, CIMD-inclusive
     currentStep = "self-verify";
     const verify = await selfVerifyMcpMetadata(issuer, { fetchImpl: deps.fetchImpl });
     if (!verify.ok) {
-      push("self-verify", false, `${verify.detail} — re-run \`flair mcp status\` to check current state, or \`flair mcp enable\` to retry the apply-config-and-restart step.`);
+      push(false, `${verify.detail} — re-run \`flair mcp status\` to check current state, or \`flair mcp enable\` to retry the apply-config-and-restart step.`);
       return {
         ok: false,
         dryRun,
@@ -1037,7 +1037,7 @@ export async function enableMcp(params: EnableMcpParams, deps: EnableMcpDeps = {
         resource: `${issuer}/mcp`,
       };
     }
-    push("self-verify", true, verify.detail);
+    push(true, verify.detail);
 
     const resource = `${issuer}/mcp`;
     return {
@@ -1064,9 +1064,12 @@ export async function enableMcp(params: EnableMcpParams, deps: EnableMcpDeps = {
     // Two results for one step, and the ✓ instructs several minutes of manual
     // work in a web UI that the ✗ makes pointless. Read in order, you do the
     // work first.
-    const failed = currentStep ?? "signing-key";
-    push(failed, false, `unexpected error: ${err?.message ?? err}`);
-    return { ok: false, dryRun, steps, failedStep: failed };
+    // No `?? "signing-key"` fallback: currentStep is initialised to the first
+    // step, so there is no undefined case to invent a name for. A fallback here
+    // would attribute a throw to a step chosen for being a plausible default —
+    // the same misattribution this handler exists to prevent, one layer down.
+    push(false, `unexpected error: ${err?.message ?? err}`);
+    return { ok: false, dryRun, steps, failedStep: currentStep };
   }
 }
 

--- a/src/lib/mcp-enable.ts
+++ b/src/lib/mcp-enable.ts
@@ -888,6 +888,9 @@ export interface EnableMcpResult {
  */
 export async function enableMcp(params: EnableMcpParams, deps: EnableMcpDeps = {}): Promise<EnableMcpResult> {
   const steps: EnableStepResult[] = [];
+  // The step currently executing, so a throw is attributed to IT rather than to
+  // the last step that succeeded (flair#1087).
+  let currentStep: EnableStepName | undefined;
   const dryRun = Boolean(params.dryRun);
   const push = (step: EnableStepName, ok: boolean, detail: string) => steps.push({ step, ok, detail });
 
@@ -960,6 +963,7 @@ export async function enableMcp(params: EnableMcpParams, deps: EnableMcpDeps = {
       idpClientId: params.idpClientId,
       idpClientSecret: params.idpClientSecret,
     });
+    currentStep = "secrets-provisioning";
     const secretsResult = provisionSecrets(params.instance, bundle, {
       mechanism: params.secretsMechanism,
       stagingPath: params.secretsStagingPath,
@@ -971,6 +975,7 @@ export async function enableMcp(params: EnableMcpParams, deps: EnableMcpDeps = {
     );
 
     // ── Identity mapping (Credential kind:idp) ────────────────────────────────
+    currentStep = "identity-mapping";
     const mapping = await provisionIdpIdentityMapping(
       {
         opsPortOrUrl: params.instance,
@@ -1007,6 +1012,7 @@ export async function enableMcp(params: EnableMcpParams, deps: EnableMcpDeps = {
     }
 
     // ── Apply config + restart ────────────────────────────────────────────────
+    currentStep = "apply-config-and-restart";
     await applyRemoteConfigAndRestart(
       { opsPortOrUrl: params.instance, adminUser: params.adminUser, adminPass: params.adminPass, configBlock },
       { fetchImpl: deps.fetchImpl },
@@ -1014,6 +1020,7 @@ export async function enableMcp(params: EnableMcpParams, deps: EnableMcpDeps = {
     push("apply-config-and-restart", true, `set_configuration + restart succeeded against ${params.instance}`);
 
     // ── Self-verify from the operator's machine, public origin, CIMD-inclusive
+    currentStep = "self-verify";
     const verify = await selfVerifyMcpMetadata(issuer, { fetchImpl: deps.fetchImpl });
     if (!verify.ok) {
       push("self-verify", false, `${verify.detail} — re-run \`flair mcp status\` to check current state, or \`flair mcp enable\` to retry the apply-config-and-restart step.`);
@@ -1042,9 +1049,20 @@ export async function enableMcp(params: EnableMcpParams, deps: EnableMcpDeps = {
       callbackUrl,
     };
   } catch (err: any) {
-    const lastStep = steps.length > 0 ? steps[steps.length - 1].step : "signing-key";
-    push(lastStep, false, `unexpected error: ${err?.message ?? err}`);
-    return { ok: false, dryRun, steps, failedStep: lastStep };
+    // flair#1087: blame the step that was RUNNING, never the last one that
+    // succeeded. This read steps[steps.length - 1] — the last COMPLETED step —
+    // so a throw inside identity-mapping was reported against
+    // secrets-provisioning, which had just succeeded. An operator saw:
+    //
+    //     ✓ secrets-provisioning   ...apply these 5 vars in Fabric Studio, then re-run
+    //     ✗ secrets-provisioning   unexpected error: Identity mapping: ...
+    //
+    // Two results for one step, and the ✓ instructs several minutes of manual
+    // work in a web UI that the ✗ makes pointless. Read in order, you do the
+    // work first.
+    const failed = currentStep ?? "signing-key";
+    push(failed, false, `unexpected error: ${err?.message ?? err}`);
+    return { ok: false, dryRun, steps, failedStep: failed };
   }
 }
 

--- a/src/lib/mcp-enable.ts
+++ b/src/lib/mcp-enable.ts
@@ -895,6 +895,7 @@ export async function enableMcp(params: EnableMcpParams, deps: EnableMcpDeps = {
   const push = (step: EnableStepName, ok: boolean, detail: string) => steps.push({ step, ok, detail });
 
   // ── Local-origin refusal (scenario addendum, binding) ─────────────────────
+  currentStep = "local-origin-check";
   const localCheck = checkLocalOriginRefusal(params.instance);
   if (localCheck.refused) {
     push("local-origin-check", false, localCheck.message);
@@ -909,11 +910,13 @@ export async function enableMcp(params: EnableMcpParams, deps: EnableMcpDeps = {
 
   try {
     // ── RS256 signing keypair ─────────────────────────────────────────────────
+    currentStep = "signing-key";
     const keyResult = ensureSigningKeyFile(params.signingKeyFilePath, { generate: deps.generateRsaKeyPair });
     push("signing-key", true, `signing key ${keyResult.reused ? "reused" : "generated"} at ${keyResult.path} (0600)`);
 
     // ── @harperfast/oauth config block (CIMD-only; DCR explicitly disabled) ──
     const cimdAllowedHosts = params.cimdAllowedHosts ?? DEFAULT_CIMD_ALLOWED_HOSTS;
+    currentStep = "config-block";
     const configBlock = buildMcpOAuthConfigBlock({ idpProvider, cimdAllowedHosts });
     push(
       "config-block",
@@ -923,6 +926,7 @@ export async function enableMcp(params: EnableMcpParams, deps: EnableMcpDeps = {
     );
 
     // ── IdP OAuth-app credential intake ───────────────────────────────────────
+    currentStep = "idp-credentials";
     const callbackUrl = idpCallbackUrl(issuer, idpProvider);
     if (!params.idpClientId || !params.idpClientSecret || !params.idpSubject) {
       const missing = [

--- a/test/unit/mcp-enable-step-attribution.test.ts
+++ b/test/unit/mcp-enable-step-attribution.test.ts
@@ -15,6 +15,8 @@
 // just succeeded; the error was filed against secrets-provisioning.
 import { describe, test, expect } from "bun:test";
 import { enableMcp } from "../../src/lib/mcp-enable.js";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
 
 /** An ops API that answers 404 to everything — the shape that broke identity
  *  mapping in the field (calls hitting the served origin). */
@@ -73,5 +75,36 @@ describe("enableMcp — the failed step is the one that ran, not the one before 
     // A step that reports both ✓ and ✗ is un-skimmable: someone scanning for the
     // first ✗ finds a ✓ for that same name above it.
     expect(contradictory).toEqual([]);
+  });
+});
+
+// ─── The gap a review called "sufficient" ────────────────────────────────────
+//
+// The first version of this fix set `currentStep` before the four ASYNC
+// operations only. Four steps run before that — local-origin-check, signing-key,
+// config-block, idp-credentials — during which `currentStep` was undefined and
+// the catch fell back to the literal "signing-key".
+//
+// So a throw during idp-credentials would have been reported as a signing-key
+// failure: the same defect class this PR fixes, with a different wrong answer.
+// A partial fix for a defect class is how the class survives.
+describe("every step sets the tracker — no window attributes a throw elsewhere", () => {
+  const src = readFileSync(
+    join(import.meta.dir, "..", "..", "src", "lib", "mcp-enable.ts"),
+    "utf8",
+  );
+
+  test("each step name that can be pushed is also assigned to currentStep", () => {
+    const pushed = new Set(
+      [...src.matchAll(/push\(\s*"([a-z-]+)"/g)].map((m) => m[1]),
+    );
+    const tracked = new Set(
+      [...src.matchAll(/currentStep\s*=\s*"([a-z-]+)"/g)].map((m) => m[1]),
+    );
+    const untracked = [...pushed].filter((s) => !tracked.has(s));
+    // If a new step is added and pushed without setting currentStep, a throw
+    // inside it lands on whichever step was set last. This is the counting
+    // check that makes that fail rather than pass unnoticed.
+    expect(untracked).toEqual([]);
   });
 });

--- a/test/unit/mcp-enable-step-attribution.test.ts
+++ b/test/unit/mcp-enable-step-attribution.test.ts
@@ -1,0 +1,77 @@
+// flair#1087 — a failure must be attributed to the step that was RUNNING, not
+// to the last step that succeeded.
+//
+// The observed output, enabling MCP against a hosted instance:
+//
+//     ✓ secrets-provisioning   ...apply these 5 vars via Fabric Studio, then re-run
+//     ✗ secrets-provisioning   unexpected error: Identity mapping: ... (HTTP 404)
+//
+// Two results for ONE step name. The ✓ instructs several minutes of manual work
+// in a web UI; the ✗ makes that work pointless. Read in order — which is how
+// people read — you do the work first and then discover it was wasted.
+//
+// The cause was `steps[steps.length - 1].step` in the catch: the last COMPLETED
+// step, not the failing one. identity-mapping threw; secrets-provisioning had
+// just succeeded; the error was filed against secrets-provisioning.
+import { describe, test, expect } from "bun:test";
+import { enableMcp } from "../../src/lib/mcp-enable.js";
+
+/** An ops API that answers 404 to everything — the shape that broke identity
+ *  mapping in the field (calls hitting the served origin). */
+const opsAlways404: typeof fetch = (async () =>
+  new Response("Not found", { status: 404 })) as unknown as typeof fetch;
+
+describe("enableMcp — the failed step is the one that ran, not the one before it", () => {
+  test("an identity-mapping failure is reported against identity-mapping", async () => {
+    const res = await enableMcp(
+      {
+        instance: "https://flair.example.harperfabric.com",
+        adminUser: "admin",
+        adminPass: "pw",
+        idpProvider: "github",
+        idpClientId: "id",
+        idpClientSecret: "secret",
+        idpSubject: "octocat",
+        principal: "self",
+        principalKind: "human",
+        confirmSecretsApplied: true,
+      } as any,
+      { fetchImpl: opsAlways404 } as any,
+    );
+
+    expect(res.ok).toBe(false);
+    // The whole point: NOT "secrets-provisioning".
+    expect(res.failedStep).toBe("identity-mapping");
+  });
+
+  test("no step name carries both a pass and a failure in one run", async () => {
+    const res = await enableMcp(
+      {
+        instance: "https://flair.example.harperfabric.com",
+        adminUser: "admin",
+        adminPass: "pw",
+        idpProvider: "github",
+        idpClientId: "id",
+        idpClientSecret: "secret",
+        idpSubject: "octocat",
+        principal: "self",
+        principalKind: "human",
+        confirmSecretsApplied: true,
+      } as any,
+      { fetchImpl: opsAlways404 } as any,
+    );
+
+    const byName = new Map<string, Set<boolean>>();
+    for (const s of res.steps ?? []) {
+      if (!byName.has(s.step)) byName.set(s.step, new Set());
+      byName.get(s.step)!.add(s.ok);
+    }
+    const contradictory = [...byName.entries()]
+      .filter(([, outcomes]) => outcomes.size > 1)
+      .map(([name]) => name);
+
+    // A step that reports both ✓ and ✗ is un-skimmable: someone scanning for the
+    // first ✗ finds a ✓ for that same name above it.
+    expect(contradictory).toEqual([]);
+  });
+});

--- a/test/unit/mcp-enable-step-attribution.test.ts
+++ b/test/unit/mcp-enable-step-attribution.test.ts
@@ -95,16 +95,30 @@ describe("every step sets the tracker — no window attributes a throw elsewhere
   );
 
   test("each step name that can be pushed is also assigned to currentStep", () => {
+    // Deliberately permissive: [a-z-]+ silently DROPPED any step name with a
+    // digit or underscore from BOTH sets, so `push("verify-2", ...)` untracked
+    // would have passed this check. Sherlock caught it — a narrow pattern in a
+    // completeness check is itself a check that cannot fire.
     const pushed = new Set(
-      [...src.matchAll(/push\(\s*"([a-z-]+)"/g)].map((m) => m[1]),
+      [...src.matchAll(/push\(\s*"([^"]+)"/g)].map((m) => m[1]),
     );
     const tracked = new Set(
-      [...src.matchAll(/currentStep\s*=\s*"([a-z-]+)"/g)].map((m) => m[1]),
+      [...src.matchAll(/currentStep\s*=\s*"([^"]+)"/g)].map((m) => m[1]),
     );
     const untracked = [...pushed].filter((s) => !tracked.has(s));
     // If a new step is added and pushed without setting currentStep, a throw
     // inside it lands on whichever step was set last. This is the counting
     // check that makes that fail rather than pass unnoticed.
     expect(untracked).toEqual([]);
+  });
+
+  test("the scan's own pattern is not too narrow to see an unusual step name", () => {
+    // The regression Sherlock found: a narrow [a-z-]+ dropped names containing a
+    // digit or underscore from BOTH sets, so an untracked `verify-2` passed.
+    // A completeness check whose pattern cannot see the thing it counts is the
+    // exact defect class this file exists to guard.
+    const sample = 'push("verify-2", true, "x"); push("odd_name", true, "y");';
+    const seen = [...sample.matchAll(/push\(\s*"([^"]+)"/g)].map((m) => m[1]);
+    expect(seen).toEqual(["verify-2", "odd_name"]);
   });
 });

--- a/test/unit/mcp-enable-step-attribution.test.ts
+++ b/test/unit/mcp-enable-step-attribution.test.ts
@@ -94,31 +94,52 @@ describe("every step sets the tracker — no window attributes a throw elsewhere
     "utf8",
   );
 
-  test("each step name that can be pushed is also assigned to currentStep", () => {
-    // Deliberately permissive: [a-z-]+ silently DROPPED any step name with a
-    // digit or underscore from BOTH sets, so `push("verify-2", ...)` untracked
-    // would have passed this check. Sherlock caught it — a narrow pattern in a
-    // completeness check is itself a check that cannot fire.
-    const pushed = new Set(
-      [...src.matchAll(/push\(\s*"([^"]+)"/g)].map((m) => m[1]),
-    );
-    const tracked = new Set(
-      [...src.matchAll(/currentStep\s*=\s*"([^"]+)"/g)].map((m) => m[1]),
-    );
-    const untracked = [...pushed].filter((s) => !tracked.has(s));
-    // If a new step is added and pushed without setting currentStep, a throw
-    // inside it lands on whichever step was set last. This is the counting
-    // check that makes that fail rather than pass unnoticed.
+  // Extract the EnableStepName union members — the authoritative list of steps.
+  // Scanning the TYPE rather than the call sites is what makes this a
+  // completeness check: a step you added to the union but never tracked shows up
+  // here, whereas scanning calls could only ever find steps that already exist.
+  const unionBody = src.slice(
+    src.indexOf("export type EnableStepName ="),
+    src.indexOf(";", src.indexOf("export type EnableStepName =")),
+  );
+  const declared = [...unionBody.matchAll(/"([^"]+)"/g)].map((m) => m[1]);
+  const tracked = new Set(
+    [...src.matchAll(/currentStep\s*=\s*"([^"]+)"/g)].map((m) => m[1]),
+  );
+
+  test("the union scan actually found the steps (guards the two above it)", () => {
+    // Without this, a changed type declaration silently yields `declared: []`,
+    // and BOTH tests below pass by having nothing to check — the vacuum this
+    // file exists to prevent, one level up.
+    expect(declared.length).toBeGreaterThanOrEqual(8);
+    expect(declared).toContain("identity-mapping");
+  });
+
+  test("every declared step assigns currentStep", () => {
+    // Add a step to the union, forget the tracker, and a throw inside it lands
+    // on whichever step was set last — the original bug, re-entering through
+    // the one door the type system does not watch.
+    const untracked = declared.filter((s) => !tracked.has(s));
     expect(untracked).toEqual([]);
   });
 
-  test("the scan's own pattern is not too narrow to see an unusual step name", () => {
-    // The regression Sherlock found: a narrow [a-z-]+ dropped names containing a
-    // digit or underscore from BOTH sets, so an untracked `verify-2` passed.
-    // A completeness check whose pattern cannot see the thing it counts is the
-    // exact defect class this file exists to guard.
+  test("push takes no step name — a wrong one must stay unrepresentable", () => {
+    // The fix for #1087 was not the counting check; it was deleting push's step
+    // parameter so the name is READ from currentStep. That removes wrong-name,
+    // and reviewers Kern and Sherlock split on whether a comment was enough to
+    // hold the line. It is not: this asserts the shape instead.
+    //
+    // Sherlock's runtime assertion (`if (currentStep !== step) throw`) was the
+    // other candidate. It validates a parameter that no longer needs to exist,
+    // and it adds a throw path to the reporting code inside the catch block that
+    // does the reporting. Removing the parameter beats checking it.
+    const named = [...src.matchAll(/(?<!steps\.)push\(\s*"([^"]+)"/g)].map((m) => m[1]);
+    expect(named).toEqual([]);
+  });
+
+  test("that shape check can see a reintroduced name (positive control)", () => {
     const sample = 'push("verify-2", true, "x"); push("odd_name", true, "y");';
-    const seen = [...sample.matchAll(/push\(\s*"([^"]+)"/g)].map((m) => m[1]);
+    const seen = [...sample.matchAll(/(?<!steps\.)push\(\s*"([^"]+)"/g)].map((m) => m[1]);
     expect(seen).toEqual(["verify-2", "odd_name"]);
   });
 });


### PR DESCRIPTION
Closes #1087.

The catch attributed errors to `steps[steps.length - 1].step` — the last step that **succeeded** — so a throw inside identity mapping was filed against secrets provisioning, which had just completed. What an operator saw:

```
✓ secrets-provisioning   ...apply these 5 vars via Fabric Studio, then re-run
✗ secrets-provisioning   unexpected error: Identity mapping: ... (HTTP 404)
```

Two results for one step name. The `✓` instructs several minutes of manual work in a web UI; the `✗` makes it pointless. **Read in reading order — which is how people read — you do the work first.** It also makes a run un-skimmable: scanning for the first `✗` finds a `✓` for that same step above it.

Now tracks the in-flight step and blames that.

**Two tests, deliberately at different levels.** One asserts the narrow fact (an identity-mapping failure reports `identity-mapping`). The other asserts the invariant — **no step name carries both a pass and a failure in one run** — which is what would catch a *future* step reporting twice for some different reason. The narrow test alone would not.

Mutation-checked: restoring the old attribution fails both. 3896 tests pass.

Found in the same session as #1086 and #1089, from the run where the underlying 404 cost an evening — the misattribution is why it was hard to see which half had actually failed.