### PR TITLE
test(compat): print the upgrade output when the upgrade fails

### DIFF
--- a/test/compat/upgrade-restart-liveness.test.ts
+++ b/test/compat/upgrade-restart-liveness.test.ts
@@ -292,6 +292,44 @@ describe("upgrade restart liveness (real version boundary) [flair#905]", () => {
     targetVersion = installedVersion(prefix) ?? "";
     postUpgradeHealth = await waitForHealth(baseUrl);
     harperPid = listeningPid(new URL(baseUrl).port);
+
+    // ── Emit what the upgrade actually said, but ONLY when it went wrong ──────
+    //
+    // Without this, a CI failure here reads:
+    //
+    //     Expected: >= 200        Expected: 0
+    //     Received: 0             Received: 1
+    //
+    // and nothing else. The output that explains WHY was captured and then
+    // dropped on the floor, so diagnosing meant reproducing the whole upgrade
+    // locally — on ops-lrf5 (harper 5.2.0 leaves the instance down) that is
+    // exactly where the investigation stalled: the lane proved the symptom and
+    // discarded the evidence.
+    //
+    // Safe to print: this sandbox has a throwaway HOME, a temp npm prefix, and
+    // ADMIN_PASS is a literal checked into this public repo — there is nothing
+    // confidential in this environment to leak into a public Actions log. That
+    // is a property of THIS suite, not a general licence to dump child output;
+    // a suite carrying a real credential must not copy this.
+    if (upgrade.code !== 0 || postUpgradeHealth < 200) {
+      const tail = (s: string, n = 4000) =>
+        s.length > n ? `…(${s.length - n} earlier chars omitted)\n${s.slice(-n)}` : s || "(empty)";
+      console.error(
+        [
+          "",
+          "── flair upgrade FAILED — captured output follows ──────────────────",
+          `exit code:          ${upgrade.code}`,
+          `health after:       ${postUpgradeHealth} (0 = nothing answered on ${baseUrl})`,
+          `listening pid:      ${harperPid ?? "(none — nothing holds the port)"}`,
+          `installed version:  ${targetVersion || "(could not read)"}`,
+          "── stdout ─────────────────────────────────────────────────────────",
+          tail(upgrade.stdout),
+          "── stderr ─────────────────────────────────────────────────────────",
+          tail(upgrade.stderr),
+          "───────────────────────────────────────────────────────────────────",
+        ].join("\n"),
+      );
+    }
   }, SETUP_TIMEOUT_MS + UPGRADE_TIMEOUT_MS);
 
   afterAll(async () => {

--- a/test/compat/upgrade-restart-liveness.test.ts
+++ b/test/compat/upgrade-restart-liveness.test.ts
@@ -311,7 +311,32 @@ describe("upgrade restart liveness (real version boundary) [flair#905]", () => {
     // confidential in this environment to leak into a public Actions log. That
     // is a property of THIS suite, not a general licence to dump child output;
     // a suite carrying a real credential must not copy this.
-    if (upgrade.code !== 0 || postUpgradeHealth < 200) {
+    // The condition mirrors the STATE the assertions below require, not just the
+    // two loudest ones. Sherlock caught that `code !== 0 || health < 200` stays
+    // silent when the upgrade appears to succeed but never swapped the package
+    // (targetVersion unchanged) — the dump would be missing exactly when the
+    // failure is most confusing. A 5xx health also failed `toBeLessThan(500)`
+    // while reading as "fine" to the original condition.
+    //
+    // Kern reviewed the same question and called the original "exactly the
+    // complement (De Morgan)" of the assertions. It was the complement of TWO of
+    // them; the suite asserts on the version swap and the health RANGE as well.
+    // Recorded because the disagreement is the useful part: two reviewers, one
+    // saw a gap and one proved its absence, and the assertions settle it.
+    //
+    // Not covered here, deliberately: the `toContain` assertions on stdout. A
+    // failing toContain already prints the received string, so a dump would only
+    // repeat it. If a stdout assertion is ever changed to compare something the
+    // failure message does not show, this condition needs revisiting — stated
+    // rather than enforced, because enforcing it means duplicating every
+    // assertion's predicate here and that duplication is its own defect.
+    const upgradeLooksHealthy =
+      upgrade.code === 0 &&
+      postUpgradeHealth >= 200 &&
+      postUpgradeHealth < 500 &&
+      targetVersion !== "" &&
+      targetVersion !== driverVersion;
+    if (!upgradeLooksHealthy) {
       const tail = (s: string, n = 4000) =>
         s.length > n ? `…(${s.length - n} earlier chars omitted)\n${s.slice(-n)}` : s || "(empty)";
       console.error(

--- a/test/compat/upgrade-restart-liveness.test.ts
+++ b/test/compat/upgrade-restart-liveness.test.ts
@@ -330,6 +330,17 @@ describe("upgrade restart liveness (real version boundary) [flair#905]", () => {
     // failure message does not show, this condition needs revisiting — stated
     // rather than enforced, because enforcing it means duplicating every
     // assertion's predicate here and that duplication is its own defect.
+    //
+    // ADDING A NEW STRUCTURAL ASSERTION BELOW? Add it here too. This condition is
+    // a hand-written copy of the state those assertions require, and nothing
+    // compares the two — so `expect(harperPid).toBeGreaterThan(0)` added below
+    // and not added here means the dump stays silent on exactly the failure it
+    // was written to explain. Sherlock raised this on review; the only thing
+    // holding it is that the copy sits directly above what it mirrors, where a
+    // reviewer can see both at once. Proximity is a weak mechanism. It is the
+    // one this has, and the reason the alternative was rejected is that a
+    // stronger-looking one — re-deriving each predicate at the dump site — is
+    // the keep-in-sync defect with more surface area, not less.
     const upgradeLooksHealthy =
       upgrade.code === 0 &&
       postUpgradeHealth >= 200 &&


### PR DESCRIPTION
## What

When `flair upgrade` fails in the liveness suite, print what it actually said. Only on failure — a passing run stays silent.

## Why

On #1045 (harper 5.2.0 pinned) this suite fails with exactly this, and nothing else:

```
the instance is REACHABLE after the upgrade   Expected: >= 200   Received: 0
the upgrade reported success                  Expected: 0        Received: 1
```

The upgrade's stdout and stderr **are captured** into the result object and then never printed. So the lane proves the symptom and throws away the evidence for the cause — diagnosing it means reproducing a full install-and-upgrade cycle locally.

That is where **ops-lrf5** stalled. We know upgrading to 5.2.0 leaves the instance down and exits 1; we do not know why, and the CI run that demonstrates it cannot tell us. Two adjacent assertions do pass — `the restart was performed by the newly installed CLI` and `no upgrade output points an initialised instance at flair init` — so the install completes and a restart is attempted. The failure is somewhere after that, and the output that would say where is discarded.

This is a diagnosability fix, not a fix for the underlying blocker. It is deliberately separate from #1045 so it can land on main and help whoever picks that up.

## Truncation keeps the tail, not the head

A failure message is at the *end* of a stream. Truncating the tail would reproduce the exact problem this change fixes, so the helper drops the beginning and reports how much it dropped.

## On printing child output to a public log

This repo is public, so its Actions logs are public. Checked before writing it rather than after:

- throwaway `HOME`, temp npm prefix, sandbox torn down in `afterAll`
- `ADMIN_PASS` is the literal `flair905-upgrade-liveness-pass`, already committed to this public repo

There is nothing confidential in this environment to leak. The comment states that as a property of **this** suite specifically — a suite carrying a real credential must not copy the pattern, and I would rather that be written down than inferred from precedent.

## Verification

A diagnostic that only runs on failure is never exercised in normal operation, which is its own failure mode — so it was tested rather than assumed:

- **positive control** — synthetic `code: 1`, `health: 0` renders every field; a 4200-char stdout truncates the head and the tail marker survives
- **negative control** — `code: 0`, `health: 200` produces no output
- typechecks clean under `tsconfig.test.check.json`

Refs #905. Related: ops-lrf5 (private).
