### PR TITLE
fix(cli): run the backwards-engine refusal on every boot path, not just start

### DIFF
--- a/.changelog/unreleased/fixed-engine-guard-covers-every-boot-path.md
+++ b/.changelog/unreleased/fixed-engine-guard-covers-every-boot-path.md
@@ -1,0 +1,30 @@
+- **The refusal to boot against a newer engine's data now runs on every boot path.** `flair start`
+  refuses when the data directory was written by a newer Harper — but that check had exactly one call
+  site, inline in `start`'s own action. `flair restart` goes straight to `restartFlair` →
+  `startFlairProcess` and never reached it, `flair upgrade` restarts by spawning the newly installed
+  CLI with `restart`, and the snapshot paths took the same unguarded route.
+
+  So the guard covered one of the doors a boot comes through, and not the one an **engine swap**
+  arrives by. Upgrading across a storage-format boundary left the instance down with a bare exit 1,
+  and the only explanation surfaced minutes later from the storage layer as an error about
+  compression internals — nowhere near the cause, and naming no remedy:
+
+  ```
+  the instance is REACHABLE after the upgrade   Expected: >= 200   Received: 0
+  the upgrade reported success                  Expected: 0        Received: 1
+  ```
+
+  The check is now a single function called from the top of `startFlairProcess`, before anything is
+  spawned or launchd is touched, which covers its callers — restart, upgrade and the snapshot paths
+  — in one place, plus `start`, which performs its own spawn and keeps its own framing and exit
+  code. Deliberately one function rather than a second copy: these two sites had already drifted once
+  on the spawn environment, where `start` set a host-qualified ops port and `startFlairProcess` set
+  none, silently re-widening the ops API on every restart.
+
+  **`flair restart` and `flair upgrade` now refuse rather than attempt the boot**, and the refusal
+  names the restore-from-backup path. An install whose engine version cannot be read is unaffected,
+  as before.
+
+  Tests assert the wiring rather than the logic, which was already covered: the decision has exactly
+  one implementation in the CLI, the guard precedes the first spawn, and a future boot path that
+  bypasses `startFlairProcess` fails the check rather than passing unnoticed.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -10942,14 +10942,15 @@ program
     }
 
     // flair#1047: refuse to boot if the store was written by a newer engine.
-    const runningHarperVersion = readInstalledHarperVersion(flairPackageDir());
-    if (runningHarperVersion) {
-      const backwardsError = checkEngineVersionBackwards(dataDir, runningHarperVersion);
-      if (backwardsError) {
-        console.error(`❌ Cannot start Flair — the data directory was written by a newer Harper engine.\n`);
-        console.error(backwardsError);
-        process.exit(1);
-      }
+    // Same guard startFlairProcess runs, so restart/upgrade/snapshot cannot
+    // reach a boot this command would refuse (flair#1093).
+    try {
+      guardEngineNotBackwards(dataDir);
+    } catch (err: any) {
+      if (!err?.engineBackwards) throw err;
+      console.error(`❌ Cannot start Flair — the data directory was written by a newer Harper engine.\n`);
+      console.error(err.message);
+      process.exit(1);
     }
 
     const platform = process.platform;
@@ -11334,7 +11335,44 @@ async function stopFlairProcess(port: number, dataDir: string): Promise<void> {
  * snapshot commands' restart leg brought the DEFAULT instance back up after
  * operating on a `--data-dir` elsewhere.
  */
+/**
+ * flair#1047's refusal, at the point every boot passes through (flair#1093).
+ *
+ * It used to live inline in the `start` command's action and nowhere else, so
+ * `flair restart`, `flair upgrade` (which restarts by spawning the new CLI with
+ * `restart`) and the snapshot paths all booted Harper without it. The guard
+ * covered one of the doors, and not the one an ENGINE SWAP comes through — so
+ * an upgrade across a storage-format boundary came back as a dead port and a
+ * bare exit 1 instead of a refusal naming actor, state and remedy.
+ *
+ * These same two functions had already drifted once, on the spawn environment:
+ * see the note above buildDirectSpawnEnv about `start` setting a host-qualified
+ * OPERATIONSAPI_NETWORK_PORT while startFlairProcess set none, silently
+ * re-widening the ops API on every restart. Same pair, same shape. This is why
+ * the check is a single function called from both rather than a second copy.
+ *
+ * Throws rather than exiting: `start` wants its own framing and an exit code,
+ * while restart/upgrade need the message to travel up as an error. Nothing here
+ * decides how it is presented.
+ */
+function guardEngineNotBackwards(dataDir: string): void {
+  const runningHarperVersion = readInstalledHarperVersion(flairPackageDir());
+  // No readable engine version means nothing to compare — the pre-stamp case
+  // checkEngineVersionBackwards already treats as "not backwards". Refusing here
+  // would brick every install written before the stamp existed.
+  if (!runningHarperVersion) return;
+  const backwardsError = checkEngineVersionBackwards(dataDir, runningHarperVersion);
+  if (!backwardsError) return;
+  const err: any = new Error(backwardsError);
+  err.engineBackwards = true;
+  throw err;
+}
+
 async function startFlairProcess(port: number, dataDir: string): Promise<void> {
+  // Before anything is spawned or launchd is touched: an older engine opening a
+  // newer store fails at the storage layer with an error about compression
+  // internals, minutes later and nowhere near the cause.
+  guardEngineNotBackwards(dataDir);
   if (process.platform === "darwin") {
     // resolveLaunchdLabel (flair#693) finds whichever label this data dir
     // is currently registered under before we attempt anything.

--- a/test/unit/engine-guard-boot-paths.test.ts
+++ b/test/unit/engine-guard-boot-paths.test.ts
@@ -1,0 +1,103 @@
+// flair#1093 — the backwards-engine refusal must cover EVERY boot path, not
+// just `flair start`.
+//
+// checkEngineVersionBackwards (#1047) had exactly one call site, inline in the
+// `start` command's action. `flair restart` goes straight to restartFlair ->
+// startFlairProcess and never reached it; `flair upgrade` restarts by spawning
+// the newly installed CLI with `restart`, so the path most likely to cross an
+// engine boundary was the one path with no guard. The observable result on
+// flair#1045 was an instance that came back DOWN with a bare exit 1 instead of
+// a refusal naming actor, state and remedy.
+//
+// The logic itself is tested in engine-version.test.ts. What failed here was
+// the WIRING, so that is what this file asserts. Reading the diff finds none of
+// this — the guard is correct and simply not connected to the second door.
+import { describe, test, expect } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const rawSrc = readFileSync(join(import.meta.dir, "..", "..", "src", "cli.ts"), "utf8");
+
+// Scan CODE, not prose. The guard carries a long comment explaining the bug it
+// fixes, and that comment names the very identifiers being counted below — a
+// raw scan reads those mentions as call sites and passes a file that has none.
+function stripComments(s: string): string {
+  return s.replace(/\/\*[\s\S]*?\*\//g, "").replace(/(^|[^:])\/\/.*$/gm, "$1");
+}
+const src = stripComments(rawSrc);
+
+/** Body of a top-level `function name(...)` / `async function name(...)`, by brace matching. */
+function functionBody(source: string, name: string): string {
+  const decl = new RegExp(`(?:async\\s+)?function\\s+${name}\\s*\\(`).exec(source);
+  if (!decl) throw new Error(`could not find function ${name} in cli.ts`);
+  const open = source.indexOf("{", decl.index);
+  let depth = 0;
+  for (let i = open; i < source.length; i++) {
+    if (source[i] === "{") depth++;
+    else if (source[i] === "}" && --depth === 0) return source.slice(open, i + 1);
+  }
+  throw new Error(`unbalanced braces reading ${name}`);
+}
+
+describe("the comment stripper (positive control)", () => {
+  test("removes commented-out code but keeps real code", () => {
+    expect(stripComments("// guardEngineNotBackwards(x)\n")).not.toContain("guardEngineNotBackwards(");
+    expect(stripComments("/* guardEngineNotBackwards(x) */\n")).not.toContain("guardEngineNotBackwards(");
+    expect(stripComments("guardEngineNotBackwards(x);\n")).toContain("guardEngineNotBackwards(");
+  });
+
+  test("does not eat a URL's double slash", () => {
+    expect(stripComments('const u = "https://example.com/x";')).toContain("example.com");
+  });
+});
+
+describe("the refusal has exactly one implementation", () => {
+  test("checkEngineVersionBackwards is called once in cli.ts, inside the guard", () => {
+    // Two call sites means two copies of the decision, which is how `start` and
+    // startFlairProcess drifted on the spawn env before this (see
+    // buildDirectSpawnEnv's note). One definition, many callers.
+    const calls = [...src.matchAll(/checkEngineVersionBackwards\s*\(/g)].length;
+    expect(calls).toBe(1);
+  });
+
+  test("that one call lives in guardEngineNotBackwards", () => {
+    expect(functionBody(src, "guardEngineNotBackwards")).toContain("checkEngineVersionBackwards(");
+  });
+});
+
+describe("every boot path runs the guard", () => {
+  test("startFlairProcess guards before it spawns anything", () => {
+    // startFlairProcess backs restart, upgrade and the snapshot paths — seven
+    // call sites — so guarding HERE is what covers them all. Asserting the
+    // guard runs BEFORE the spawn matters: after the spawn it would refuse a
+    // boot that already happened.
+    const body = functionBody(src, "startFlairProcess");
+    const guardAt = body.indexOf("guardEngineNotBackwards(");
+    expect(guardAt).toBeGreaterThan(-1);
+
+    const firstSpawn = Math.min(
+      ...["launchctl", "spawn(", "ensureLaunchdServiceLoaded("]
+        .map((m) => body.indexOf(m))
+        .filter((i) => i > -1),
+    );
+    expect(firstSpawn).toBeGreaterThan(guardAt);
+  });
+
+  test("the start command runs the same guard, not its own copy", () => {
+    // `start` needs different presentation (framing + exit code) but must not
+    // reimplement the decision to get it.
+    expect(src).toContain("guardEngineNotBackwards(dataDir)");
+    const guardCalls = [...src.matchAll(/guardEngineNotBackwards\s*\(\s*dataDir\s*\)/g)].length;
+    expect(guardCalls).toBeGreaterThanOrEqual(2);
+  });
+
+  test("no boot path calls startFlairProcess's spawn helpers directly", () => {
+    // The guard sits at the top of startFlairProcess. If a future path calls
+    // ensureLaunchdServiceLoaded itself instead of going through
+    // startFlairProcess, it boots unguarded — the exact shape of this bug.
+    // `start` is the one legitimate direct caller and guards itself, so the
+    // budget is 1 (plus the definition).
+    const direct = [...src.matchAll(/ensureLaunchdServiceLoaded\s*\(/g)].length;
+    expect(direct).toBeLessThanOrEqual(3);
+  });
+});


### PR DESCRIPTION
## What

`checkEngineVersionBackwards` (#1047) runs on every boot path now, not only `flair start`.

## The gap

It had exactly one call site, inline in the `start` command's action.

```
flair restart  -> restartFlair -> startFlairProcess   (no guard)
flair upgrade  -> spawns new CLI with `restart`       (no guard)
snapshot paths -> startFlairProcess                   (no guard)
```

So the guard covered one door, and not the one an **engine swap** comes through.

Observable on #1045: an instance whose store was written by Harper 5.2.0, handed a build carrying 5.1.22, came back **down with a bare exit 1**. The refusal would have named actor, state and remedy. Instead the operator gets a dead port and, minutes later and nowhere near the cause, an error about compression internals from the storage layer.

## Why one function rather than a second copy

These two functions have already drifted once, on the spawn environment. From the note above `buildDirectSpawnEnv`:

> These two sites used to build the env inline and had drifted: `start` set a host-qualified `OPERATIONSAPI_NETWORK_PORT`, `startFlairProcess` set none at all. […] the site that omitted the var silently re-widened the ops API to all interfaces on every restart/upgrade, and persisted it.

Same pair, same shape — caught then for the env, still open for the guard. So the decision gets a single implementation, and a test asserts `checkEngineVersionBackwards` is called exactly once in `cli.ts`.

The guard sits at the top of `startFlairProcess`, before anything spawns or launchd is touched, which covers its seven callers in one place. It throws rather than exits, so `start` keeps its framing and exit code while restart/upgrade let the message travel up. A missing engine version still returns early — refusing there would brick every install written before the stamp existed.

## What the tests assert

The logic is already covered in `engine-version.test.ts`. What failed here was the **wiring**, so that is what this asserts — reading the diff finds none of it, because the guard was correct and simply not attached to the second door.

- `checkEngineVersionBackwards` called exactly once in `cli.ts`
- the guard precedes the first spawn in `startFlairProcess` (after it, it would refuse a boot that already happened)
- a budget on direct `ensureLaunchdServiceLoaded` callers, so a future path bypassing `startFlairProcess` fails rather than passes unnoticed

Scans run over **comment-stripped** source with a positive control — the guard carries a long comment naming the very identifiers being counted, and a raw scan reads those as call sites and passes a file that has none.

## Verification

| mutation | result |
|---|---|
| guard removed from `startFlairProcess` | 2 fail |
| guard removed entirely | 2 fail |
| second inline copy of the decision | 3 fail |

`cli.ts` byte-identical after restore. Unit **3907 pass**, integration **438 pass**, 0 fail.

## Behaviour change worth naming

`flair restart` and `flair upgrade` now **refuse** when the store was written by a newer engine, where they previously attempted the boot and failed obscurely. That is the intent — the recovery lines in the refusal name the restore-from-backup path — but it is a real change in what those commands do.

Closes #1093. Context: this is what makes accepting Harper 5.2's one-way storage boundary safe, since crossing it currently fails silently.
