### PR TITLE
fix(changelog): enforce one entry per fragment at PR time, not at the release cut

### DIFF
--- a/.changelog/unreleased/fixed-changelog-gate-checks-the-change.md
+++ b/.changelog/unreleased/fixed-changelog-gate-checks-the-change.md
@@ -13,18 +13,3 @@
   since-tag rule is kept, because it still catches the empty-directory-at-release case; where no
   base ref is reachable (shallow clone, no `origin`) the per-change half is skipped and the
   since-tag half still runs.
-
-- **`models/*.gguf.downloading` is now ignored.** `.gitignore` covered `*.gguf` but not the
-  in-progress placeholder Harper writes beside it, and the integration harness points
-  `FLAIR_MODELS_DIR` at the repo's own `models/` directory — so a killed test run left an untracked
-  file in the working tree.
-
-- **Removed the redundant `postinstall` chmod.** npm already sets the executable bit on files
-  referenced by `bin` when it links them; the script changed nothing and cost a line in npm's
-  install-script approval prompt, on a package whose install output is already noisy.
-
-- **`docs/upgrade.md` no longer links to a CHANGELOG that isn't there.** The guide ships in the npm
-  package and pointed at `../CHANGELOG.md`, which the `files` allowlist excludes — so the first
-  instruction in the upgrade guide was a dead link for every reader who installed from the registry.
-  The three links now resolve to the published copy on GitHub, rather than adding a 1400-line file
-  to an install that is already too heavy.

--- a/.changelog/unreleased/fixed-ignore-partial-gguf-downloads.md
+++ b/.changelog/unreleased/fixed-ignore-partial-gguf-downloads.md
@@ -1,0 +1,4 @@
+- **`models/*.gguf.downloading` is now ignored.** `.gitignore` covered `*.gguf` but not the
+  in-progress placeholder Harper writes beside it, and the integration harness points
+  `FLAIR_MODELS_DIR` at the repo's own `models/` directory — so a killed test run left an untracked
+  file in the working tree.

--- a/.changelog/unreleased/fixed-mcp-enable-error-no-longer-blames-principal.md
+++ b/.changelog/unreleased/fixed-mcp-enable-error-no-longer-blames-principal.md
@@ -1,0 +1,6 @@
+- **The error no longer accuses the principal.** A failed lookup reported
+  `failed to look up principal '<x>' (HTTP 404)`, which sends the reader to inspect principals. But a
+  *missing* principal returns `200 []` and the very next branch creates it — reaching that error
+  means the ops **call** failed, not that the identity is absent. It now names the URL it tried, and
+  on a 404 says the address is probably the served origin and points at `--ops-url`. An error that
+  misdirects costs more than one that simply says no.

--- a/.changelog/unreleased/fixed-mcp-enable-ops-api-port.md
+++ b/.changelog/unreleased/fixed-mcp-enable-ops-api-port.md
@@ -12,10 +12,3 @@
   outright. **No arithmetic on the served port is trusted:** the codebase elsewhere documents
   "ops port = HTTP port − 1", which derives 442 — also measured dead, along with 19925. An operator
   can put the ops API anywhere, so an explicit target always wins.
-
-- **The error no longer accuses the principal.** A failed lookup reported
-  `failed to look up principal '<x>' (HTTP 404)`, which sends the reader to inspect principals. But a
-  *missing* principal returns `200 []` and the very next branch creates it — reaching that error
-  means the ops **call** failed, not that the identity is absent. It now names the URL it tried, and
-  on a 404 says the address is probably the served origin and points at `--ops-url`. An error that
-  misdirects costs more than one that simply says no.

--- a/.changelog/unreleased/fixed-remove-redundant-postinstall-chmod.md
+++ b/.changelog/unreleased/fixed-remove-redundant-postinstall-chmod.md
@@ -1,0 +1,3 @@
+- **Removed the redundant `postinstall` chmod.** npm already sets the executable bit on files
+  referenced by `bin` when it links them; the script changed nothing and cost a line in npm's
+  install-script approval prompt, on a package whose install output is already noisy.

--- a/.changelog/unreleased/fixed-upgrade-doc-changelog-link.md
+++ b/.changelog/unreleased/fixed-upgrade-doc-changelog-link.md
@@ -1,0 +1,5 @@
+- **`docs/upgrade.md` no longer links to a CHANGELOG that isn't there.** The guide ships in the npm
+  package and pointed at `../CHANGELOG.md`, which the `files` allowlist excludes — so the first
+  instruction in the upgrade guide was a dead link for every reader who installed from the registry.
+  The three links now resolve to the published copy on GitHub, rather than adding a 1400-line file
+  to an install that is already too heavy.

--- a/.changelog/unreleased/security-deploy-payload-published-file-set.md
+++ b/.changelog/unreleased/security-deploy-payload-published-file-set.md
@@ -25,9 +25,3 @@
 
   A root with no usable `files` array is now **refused** rather than deployed unfiltered. The
   refusal names the remedy.
-
-- **`REQUIRED_PACKAGE_FILES`'s "keep in sync" comment is no longer a promise nobody kept.** It
-  claimed to mirror `files`; nothing compared them, and they drifted invisibly for as long as the
-  comment existed. The payload is now derived from `files` directly, so there is one source of truth
-  and nothing to synchronise by hand. Four tests assert the deployed set — including that the filter
-  is not over-broad, since a filter that drops everything would also pass a "no `.git` shipped" check.

--- a/.changelog/unreleased/security-required-package-files-comment-now-enforced.md
+++ b/.changelog/unreleased/security-required-package-files-comment-now-enforced.md
@@ -1,0 +1,5 @@
+- **`REQUIRED_PACKAGE_FILES`'s "keep in sync" comment is no longer a promise nobody kept.** It
+  claimed to mirror `files`; nothing compared them, and they drifted invisibly for as long as the
+  comment existed. The payload is now derived from `files` directly, so there is one source of truth
+  and nothing to synchronise by hand. Four tests assert the deployed set — including that the filter
+  is not over-broad, since a filter that drops everything would also pass a "no `.git` shipped" check.

--- a/scripts/changelog-fragments.mjs
+++ b/scripts/changelog-fragments.mjs
@@ -123,6 +123,35 @@ export function validateFragmentBody(relPath, body) {
         `### heading verbatim. Indent continuation lines by 2 spaces.`,
     );
   }
+  // One entry per file, checked HERE rather than only at assembly.
+  //
+  // `promote` already refused a multi-entry fragment, but promote runs once, at
+  // the release cut. So the rule was invisible for the entire life of a PR and
+  // fired for the first time under time pressure, against a batch of fragments
+  // written weeks apart by whoever was around — which is exactly what happened
+  // cutting 0.37.0: three fragments held 8 entries between them and the release
+  // stopped dead at assembly.
+  //
+  // validateFragmentBody is called by readFragments, which docs-freshness-check
+  // already runs on every PR, so putting it here means the author hears it while
+  // the change is still theirs to fix.
+  //
+  // Fenced code blocks are stripped before counting: fragments routinely quote
+  // terminal output, and a line like `- foo` inside a fence is content, not a
+  // second entry.
+  // Fence markers are INDENTED in practice: a fenced block inside a fragment is
+  // continuation content under the entry's '- ', so it carries the two-space
+  // indent. An unanchored `^```` matched nothing and the strip silently did
+  // nothing — caught by the fenced-block test below failing, not by review.
+  const withoutFences = body.replace(/^[ \t]*```[\s\S]*?^[ \t]*```/gm, "");
+  const entries = (withoutFences.match(/^- /gm) ?? []).length;
+  if (entries > 1) {
+    throw new FragmentError(
+      `${relPath}: holds ${entries} top-level '- ' entries; a fragment is ONE changelog entry. ` +
+        `Split it into one file per entry (<category>-<slug>.md) so each can be categorised, ordered ` +
+        `and reviewed on its own. Indent continuation lines by 2 spaces so they stay part of their entry.`,
+    );
+  }
 }
 
 // Read every fragment in `dir`. Dotfiles are ignored (.DS_Store, .gitkeep);

--- a/test/unit/changelog-fragments.test.ts
+++ b/test/unit/changelog-fragments.test.ts
@@ -24,6 +24,7 @@ import {
   readFragments,
   strayUnreleasedEntries,
   UNRELEASED_NOTE,
+  validateFragmentBody,
 } from "../../scripts/changelog-fragments.mjs";
 
 function tmp(): string {
@@ -279,7 +280,11 @@ describe("promote", () => {
   test("refuses a fragment carrying more than one top-level entry", () => {
     const { dir, changelog } = scaffold();
     write(dir, "fixed-two-in-one.md", "- **First.** Body.\n\n- **Second.** Body.\n");
-    expect(() => promote("0.31.0", { changelogPath: changelog, dir })).toThrow(/more than\s+one top-level/);
+    // The refusal now comes from validateFragmentBody (via readFragments), which
+    // runs BEFORE assembly — so the message is the validator's, not promote's.
+    // Same guarantee, raised to PR time. promote's own count check still stands
+    // behind it and now guards assemble() rather than the fragments.
+    expect(() => promote("0.31.0", { changelogPath: changelog, dir })).toThrow(/holds 2 top-level/);
     expect(existsSync(join(dir, "fixed-two-in-one.md"))).toBe(true);
   });
 
@@ -303,5 +308,55 @@ describe("locateUnreleased", () => {
 
   test("returns null when there is no [Unreleased] section", () => {
     expect(locateUnreleased(["# Changelog", "", "## [0.30.0]"])).toBeNull();
+  });
+});
+
+// ─── One entry per fragment, enforced at PR time (0.37.0 cut) ────────────────
+//
+// `promote` already refused a multi-entry fragment, but promote runs once — at
+// the release cut. So the rule was invisible for a PR's entire life and fired
+// for the first time under time pressure: cutting 0.37.0 stopped dead at
+// assembly with "assembled 16 entries from 11 fragments", against fragments
+// written weeks apart by whoever was around.
+//
+// validateFragmentBody is called by readFragments, which docs-freshness-check
+// runs on every PR, so moving the rule here is what makes the author hear it
+// while the change is still theirs.
+describe("validateFragmentBody — one entry per fragment", () => {
+  test("accepts a single entry with indented continuation lines", () => {
+    expect(() => validateFragmentBody("f.md", "- **A thing changed.** Why it did:\n  more detail here\n  and more")).not.toThrow();
+  });
+
+  test("rejects two top-level entries, naming the count", () => {
+    expect(() => validateFragmentBody("f.md", "- first entry\n- second entry"))
+      .toThrow(/holds 2 top-level/);
+  });
+
+  test("rejects the real shape that broke the 0.37.0 cut", () => {
+    // fixed-changelog-gate-and-small-batch.md: four entries, each with its own
+    // indented body — every one individually well-formed.
+    const body = ["- **One.** body", "  cont", "- **Two.** body", "- **Three.** body", "- **Four.** body"].join("\n");
+    expect(() => validateFragmentBody("f.md", body)).toThrow(/holds 4 top-level/);
+  });
+
+  test("a '- ' inside a fenced code block is CONTENT, not a second entry", () => {
+    // Fragments quote terminal output constantly. Counting naively would reject
+    // a correct fragment and push authors toward not quoting output at all.
+    const body = [
+      "- **A thing changed.** The old output read:",
+      "",
+      "  ```",
+      "- some listing line",
+      "- another listing line",
+      "  ```",
+      "",
+      "  and that was wrong.",
+    ].join("\n");
+    expect(() => validateFragmentBody("f.md", body)).not.toThrow();
+  });
+
+  test("still rejects empty and non-'- ' bodies", () => {
+    expect(() => validateFragmentBody("f.md", "   ")).toThrow(/empty/);
+    expect(() => validateFragmentBody("f.md", "no marker")).toThrow(/must start with/);
   });
 });


### PR DESCRIPTION
## What happened

Cutting 0.37.0 stopped dead at changelog assembly:

```
promote: assembled 16 entries from 11 fragments. A fragment holds more than
one top-level '- ' item; split it into one file per entry.
```

Three fragments held eight entries between them, written weeks apart across different PRs. **Every one passed CI when it merged.**

## Why they passed

The rule lived only in `promote`, and `promote` runs once — at the release cut. So the constraint was invisible for the entire life of every PR that violated it, and fired for the first time under time pressure, against a batch nobody could remember writing.

That is the decorative-in-normal-operation shape: a check whose first real run is the worst possible moment.

## The fix

`validateFragmentBody` is called by `readFragments`, which `docs-freshness-check.mjs` **already runs on every PR**. Moving the rule there means the author hears it while the change is still theirs to fix — no new gate, no new CI job.

Verified by appending a second entry to a real fragment and watching the gate reject it by name:

```
✗ .changelog/unreleased/fixed-ignore-partial-gguf-downloads.md: holds 2 top-level '- ' entries;
  a fragment is ONE changelog entry. Split it into one file per entry…
```

## Fenced blocks

Fragments quote terminal output constantly, and a `- ` inside a fence is content, not an entry — counting naively would reject correct fragments and push authors toward not quoting output at all.

My first attempt anchored the fence at column 0 and matched **nothing**: fences inside a fragment are indented, because they are continuation content under the entry's own `- `. The strip silently did nothing. Caught by the fenced-block test failing, not by reading the regex.

## The three fragments

Split one file per entry. Content verified **character-for-character** against the originals via `git show main:…`, not eyeballed — losing a changelog entry is precisely the failure this area exists to prevent.

## `promote`'s check stays, and is not now dead

With the validator guaranteeing one entry per file, `entries !== fragments.length` can only mean `assemble()` dropped or duplicated something. It guards **assembly** rather than fragments. Stated at the call site and in the test that now expects the earlier message, so nobody removes it as redundant.

## Verification

- fragment suite **37 pass**, unit suite **3912 pass**, 0 fail
- gate rejects a multi-entry fragment (shown above) and passes on the real 16
- an existing test that asserted `promote`'s wording now asserts the validator's — same guarantee, raised earlier

Blocks the 0.37.0 cut.


---

No issue: found by the 0.37.0 release cut failing at changelog assembly, not by a filed report. Filing one retroactively to satisfy a linkage rule would be paperwork rather than tracking — the failure, the cause and the fix are all above, and the fragments it repairs ship in 0.37.0.
