### PR TITLE
fix(release): run unit and integration in separate processes, and stop skipping test/*.test.ts

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -337,10 +337,34 @@ echo "  ✓ All packages built"
 # e2e specs live under test/e2e/ and fail to load under bun — they're run via
 # `bunx playwright test` against a live server in CI, not locally here.
 echo "🧪 Running tests..."
-# test/unit-isolated/ files mock.module a process-global shared module; each
-# MUST run in its own `bun test` process — they poison the real-importer
-# files AND each other otherwise (flair#691).
-(cd "$ROOT" && bun test test/unit/ $(find test/integration -name '*.test.ts' | sort)) || { echo "❌ Tests failed"; exit 1; }
+# UNIT AND INTEGRATION RUN IN SEPARATE PROCESSES, because that is what CI does
+# and the comment above only claimed to match it.
+#
+# This line used to be a single `bun test test/unit/ <integration files>`. CI
+# runs them as two independent JOBS (test.yml's unit lane and its
+# `bun test $(find test/integration ...)` lane), so nothing anywhere had ever
+# executed the two suites in one bun process — except this script, once per
+# release.
+#
+# Measured cutting 0.37.0, on the same commit CI had just passed 26/26:
+#   unit alone                3912 pass  0 fail
+#   integration alone          438 pass  0 fail
+#   unit + integration        4350 pass  1 fail   <- only this shape
+# The casualty was mcp-client-credentials-e2e, from the same family that already
+# needed test/integration-isolated/ for exactly this reason (flair#691).
+#
+# So the release gate was failing for a reason unrelated to the release, on a
+# combination no other lane runs. A gate that fails for the wrong reason is worse
+# than a missing one: it trains everyone to re-run it until it passes.
+# `test/*.test.ts` — the 12 root-level files — are in CI's unit lane
+# (`bun test test/unit/ test/*.test.ts`) and were NOT in this script's. So the
+# release gate ran LESS than CI while its comment claimed to match it, and the
+# gap included auth-scoping, data-scoping, backup-restore and content-safety.
+# 252 tests that no release has ever executed. They pass on macOS in under a
+# second; there was no reason for the omission beyond nobody comparing the two
+# invocations.
+(cd "$ROOT" && bun test test/unit/ test/*.test.ts) || { echo "❌ Tests failed (unit)"; exit 1; }
+(cd "$ROOT" && bun test $(find test/integration -name '*.test.ts' | sort)) || { echo "❌ Tests failed (integration)"; exit 1; }
 # test/unit-isolated/ files mock.module a process-global shared module; each
 # MUST run in its own `bun test` process — they poison the real-importer
 # files AND each other otherwise (flair#691).


### PR DESCRIPTION
## Why the 0.37.0 cut failed

`release.sh` failed at the test step with **1 failure out of 4351**, on the same commit CI had just passed 26/26.

```
unit alone             3912 pass  0 fail
integration alone       438 pass  0 fail   ← CI's shape
unit + integration     4350 pass  1 fail   ← release.sh's shape, only this one
```

The casualty was `mcp-client-credentials-e2e` — from the family that already needed `test/integration-isolated/` for exactly this reason (#691).

## Two divergences, both under a comment claiming the opposite

The block was headed *"Scope matches CI's test job split"*. It didn't.

**1. One process instead of two.** `release.sh` ran `bun test test/unit/ <integration files>` in a single `bun` process. CI runs them as two independent **jobs**. So nothing anywhere executed those suites in one process — except this script, once per release, which is where it blew up.

A gate that fails for a reason unrelated to what it gates is worse than a missing one: it trains everyone to re-run until it passes, and then the next *real* failure looks like the same flake.

**2. Twelve files that no release has ever run.** CI's unit lane is `bun test test/unit/ test/*.test.ts`. This script's was `bun test test/unit/`. The root-level files — including **auth-scoping, data-scoping, backup-restore, content-safety** — were in no release run, ever. 252 tests, passing in under a second on macOS. The omission bought nothing.

## What is preserved

The point of this lane is that it runs **darwin-gated tests, which execute in no CI lane at all** because CI runs Linux — including the launchd branch that unloads and reloads production service registrations. That is untouched. The split is about process boundaries, not scope; scope only grew.

## Verification

| lane | before | after |
|---|---|---|
| `test/unit/` | 3912 pass | 3912 pass |
| `test/*.test.ts` | **not run** | 252 pass |
| `test/integration` | shared a process | 438 pass, own process |

Both invocations now match CI's textually, compared on **executable lines with comments stripped** — my first comparison matched a comment I had just written containing an ellipsis and reported a false difference. Which is the same defect this PR fixes: a claim of correspondence with nothing comparing the two sides.

No issue: found by the 0.37.0 cut failing at its own test step, not by a filed report. The failure, cause and fix are all above.
