### PR TITLE
feat(mcp): push secrets when the target can take them, chosen by capability not hostname

### DIFF
--- a/.changelog/unreleased/added-mcp-enable-pushes-secrets-when-the-target-can-take-them.md
+++ b/.changelog/unreleased/added-mcp-enable-pushes-secrets-when-the-target-can-take-them.md
@@ -1,0 +1,30 @@
+- **`flair mcp enable` now pushes its secrets to the target when the target can take them**, instead
+  of always ending in a manual paste. When the instance supports Harper's encrypted env-secrets, the
+  five vars are sealed locally and set over the ops API — no Fabric Studio step, no re-run with
+  `--confirm-secrets-applied`.
+
+  Values are encrypted **before** they leave the machine, using the same `enc:v1:` envelope Harper
+  reads: AES-256-GCM on the value, RSA-OAEP(SHA-256) wrapping the key, addressed to a public key
+  fetched from the target. Plaintext never appears in a request body, and never in the command's
+  output — results carry variable NAMES and outcomes only.
+
+  **The mechanism is chosen by asking the target, not by looking at its hostname.** The previous
+  selector was `hostname.endsWith(".harperfabric.com") ? automated : manual`, which was wrong in both
+  directions at the moment it was replaced: the Fabric instance it was written for runs Harper 5.1.26
+  and has no secrets operations at all, while a self-hosted Harper 5.2 with the env-secrets component
+  was sent down the manual path for having the wrong name. A hostname is not a capability, and
+  neither is a version — the write operations and the decryptor that makes the secret reach the
+  process ship separately.
+
+  So `enable` asks for the public key it would need anyway. If that answers, it pushes. If the target
+  says the operation does not exist, refuses the probe, is unreachable, or answers with something
+  unusable, it falls back to today's staged file and **says which of those happened**. The staging
+  file is written either way, so a fallback never leaves an operator stranded mid-run.
+
+  What the probe deliberately does not claim: that the secret will be *decrypted*. No read-only call
+  can establish that. The existing self-verify step already does — the issuer's OAuth metadata is
+  only served once `FLAIR_MCP_OAUTH` is live in the process — so a secret that is stored and never
+  decrypted fails there, with the push named as a candidate cause, rather than passing quietly.
+
+  `--secrets-mechanism` remains an explicit override and skips the probe entirely: an operator who
+  has said what they want is not second-guessed.

--- a/.changelog/unreleased/added-mcp-enable-pushes-secrets-when-the-target-can-take-them.md
+++ b/.changelog/unreleased/added-mcp-enable-pushes-secrets-when-the-target-can-take-them.md
@@ -22,9 +22,10 @@
   file is written either way, so a fallback never leaves an operator stranded mid-run.
 
   What the probe deliberately does not claim: that the secret will be *decrypted*. No read-only call
-  can establish that. The existing self-verify step already does — the issuer's OAuth metadata is
-  only served once `FLAIR_MCP_OAUTH` is live in the process — so a secret that is stored and never
-  decrypted fails there, with the push named as a candidate cause, rather than passing quietly.
+  can establish that. The existing self-verify step already does, by comparison rather than absence: the
+  well-known endpoint still answers when the flag is off, serving flair's own OAuth 2.1 document,
+  and self-verify recognises it by the advertised `token_endpoint`. So a secret that is stored and
+  never decrypted fails there with a message naming `FLAIR_MCP_OAUTH`, rather than passing quietly.
 
   `--secrets-mechanism` remains an explicit override and skips the probe entirely: an operator who
   has said what they want is not second-guessed.

--- a/docs/hosted-on-fabric.md
+++ b/docs/hosted-on-fabric.md
@@ -75,7 +75,7 @@ Values are encrypted **before leaving your machine** — AES-256-GCM on the valu
 
 The staging file is written in every case, so a fallback never strands you mid-run. When the push succeeds it simply goes unused.
 
-> **What the probe does not promise.** It establishes that the target accepts secrets, not that it will *decrypt* them — no read-only call can, since a secret only proves it was decrypted by being present in the process. The **self-verify** step at the end is what proves that: the issuer's OAuth metadata is served only once `FLAIR_MCP_OAUTH` is live. A secret that is stored and never decrypted therefore fails at self-verify, naming the push as a candidate cause, rather than reporting success.
+> **What the probe does not promise.** It establishes that the target accepts secrets, not that it will *decrypt* them — no read-only call can, since a secret only proves it was decrypted by being present in the process. The **self-verify** step at the end is what proves that. Note the endpoint does *not* go quiet when the flag is off — flair serves its own OAuth 2.1 discovery document instead, and self-verify tells them apart by the advertised `token_endpoint` (`/OAuthToken` is flair's own; the MCP one is `/oauth/mcp/token`). So a secret that is stored and never decrypted fails at self-verify with a message naming `FLAIR_MCP_OAUTH`, rather than reporting success.
 
 `--secrets-mechanism <fabric-env-secrets|env-file>` remains an explicit override and skips the probe entirely.
 

--- a/docs/hosted-on-fabric.md
+++ b/docs/hosted-on-fabric.md
@@ -59,6 +59,26 @@ On Fabric, configuration goes through the component's environment, not a local `
 
 On Fabric / managed deploys, environment variables are provisioned through Harper's Fabric secrets mechanism (encrypted at rest with `enc:v1:` storage format).
 
+### How `flair mcp enable` delivers its secrets
+
+`flair mcp enable` needs five variables live in the target's process before it restarts — including `FLAIR_MCP_OAUTH` and the RS256 signing key, both read from `process.env` only and therefore impossible to deliver via `set_configuration`.
+
+It asks the target what it can do, rather than assuming from the hostname or the version:
+
+| The target… | What happens |
+|-------------|--------------|
+| supports Harper's env-secrets operations | the five vars are **sealed locally** and pushed over the ops API. No manual step, no re-run. |
+| does not have them (Harper older than 5.2) | the vars are staged to a `0600` file and you apply them yourself, then re-run with `--confirm-secrets-applied` |
+| is unreachable, refuses the probe, or answers unusably | same staged-file fallback, and the output says **which** of those happened |
+
+Values are encrypted **before leaving your machine** — AES-256-GCM on the value, RSA-OAEP(SHA-256) wrapping the key, addressed to a public key fetched from the target. Plaintext never appears in a request body, and the command's output carries variable *names* only.
+
+The staging file is written in every case, so a fallback never strands you mid-run. When the push succeeds it simply goes unused.
+
+> **What the probe does not promise.** It establishes that the target accepts secrets, not that it will *decrypt* them — no read-only call can, since a secret only proves it was decrypted by being present in the process. The **self-verify** step at the end is what proves that: the issuer's OAuth metadata is served only once `FLAIR_MCP_OAUTH` is live. A secret that is stored and never decrypted therefore fails at self-verify, naming the push as a candidate cause, rather than reporting success.
+
+`--secrets-mechanism <fabric-env-secrets|env-file>` remains an explicit override and skips the probe entirely.
+
 ---
 
 ## Agent authentication

--- a/src/lib/mcp-enable.ts
+++ b/src/lib/mcp-enable.ts
@@ -101,10 +101,14 @@
  *     `dist/lib/mcp/wellKnown.js`'s `buildAuthorizationServerMetadata`
  *     (lines 129-166), which advertises `registration_endpoint`/
  *     `token_endpoint` unconditionally (NOTE: `registration_endpoint` is
- *     advertised even though DCR is disabled — the plugin doesn't condition
- *     that field on `dynamicClientRegistration.enabled`; a POST there still
- *     404s per dcr.js:165-167, this is just a metadata-completeness quirk of
- *     the installed package, not a gap in our config) and
+ *     advertised even though DCR is disabled — CORRECTED 2026-08-05: that was
+ *     true of the version this was written against and is FALSE of the
+ *     installed one. wellKnown.js:142 now reads
+ *     `...(dcrEnabled(mcpConfig) ? { registration_endpoint: … } : {})`, so the
+ *     field is OMITTED whenever DCR is off — which is every instance `enable`
+ *     configures. selfVerifyMcpMetadata required it and therefore failed on a
+ *     correctly enabled surface; see the note at that check. A verified fact
+ *     carries the date it was verified, and this one expired.) and
  *     `client_id_metadata_document_supported: true` whenever
  *     `clientIdMetadataDocuments.enabled !== false` (wellKnown.js:164 — true
  *     by default, which is what our config relies on), and
@@ -136,7 +140,6 @@
  *     expansion.
  */
 
-import { probeSecretsCapability, pushSecrets, PROCESS_ENV_TIER } from "./secrets-push.js";
 import { existsSync, mkdirSync, writeFileSync, chmodSync, readFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { join, dirname } from "node:path";
@@ -218,30 +221,6 @@ export type SecretsMechanism = "fabric-env-secrets" | "env-file";
  * an automated push: no confirmed ops-API operation for it exists in the
  * installed 5.1.17 SDK). Anything else defaults to `env-file` — the
  * documented, universally-supported fallback. Always overridable.
- */
-/**
- * ── The hostname no longer selects the mechanism (flair#1094) ───────────────
- *
- * This used to be `isFabricOrigin(url) ? "fabric-env-secrets" : "env-file"`, and
- * that was wrong in BOTH directions on the day it was replaced:
- *
- *   - `tps.dtrt.harperfabric.com` runs Harper 5.1.26 and has no secrets
- *     operations at all — measured; `set_secret` answers "Operation 'set_secret'
- *     not found", identical to an invented operation — and was selected for the
- *     automated mechanism purely because of its name.
- *   - a self-hosted Harper 5.2 with the Pro env-secrets component is fully
- *     capable and was sent down the manual Studio path for not matching.
- *
- * A hostname is not a capability, and neither is a version — the write
- * operations and the Pro decryptor that makes a `processEnv` secret reach the
- * process ship separately. `probeSecretsCapability` asks the target instead, and
- * the answer decides at provisioning time.
- *
- * What remains here is the STAGING FILE's flavour of instructions, which is
- * genuinely about where the operator will paste if we end up falling back.
- * Fabric operators paste into Studio; everyone else edits a unit file. That is a
- * UI fact about a human, not a claim about the server, so a hostname is a
- * reasonable signal for it and a wrong guess costs only slightly-off prose.
  */
 export function selectSecretsMechanism(instanceUrl: string, override?: SecretsMechanism): SecretsMechanism {
   if (override) return override;
@@ -752,39 +731,39 @@ export async function selfVerifyMcpMetadata(
   } catch {
     return { ok: false, detail: `${url} did not return JSON` };
   }
-  // ── The flair's-own-server check runs BEFORE the shape check (flair#1094) ──
+  // ── registration_endpoint is OPTIONAL and must not be required (Kern, #1101) ─
   //
-  // It used to run after, and that made the DEFAULT flag-off case misreport.
-  // flair's own document omits `registration_endpoint` unless DCR is enabled,
-  // which it is not by default — so the shape check fired first and returned
-  // "the metadata shape is unexpected", which is true, useless, and points at
-  // shapes when the cause is an unset environment variable.
+  // Requiring it made self-verify fail on a CORRECTLY enabled instance — the
+  // exact configuration `enable` itself creates.
   //
-  // `token_endpoint` is present in that document either way, so testing the
-  // discriminator first names the real cause in EVERY flag-off case rather than
-  // only when DCR happens to be on. Found by writing the test that pins this
-  // relationship, not by reading the code.
-  if (typeof body?.token_endpoint === "string" && body.token_endpoint === `${normalizedIssuer}/OAuthToken`) {
-    return {
-      ok: false,
-      issuer: body?.issuer,
-      registrationEndpoint: body?.registration_endpoint,
-      tokenEndpoint: body.token_endpoint,
-      detail:
-        `${url} answered with flair's OWN OAuth 2.1 authorization server, not the MCP one ` +
-        `(token_endpoint=${body.token_endpoint}) — the /mcp surface is NOT enabled on that instance. ` +
-        `Is FLAIR_MCP_OAUTH actually set on the restarted instance, and is the '@harperfast/oauth' ` +
-        `component declared in its config.yaml?`,
-    };
-  }
+  // RFC 8414 marks the field optional, and BOTH authorization servers in this
+  // system omit it when DCR is off:
+  //   - flair's own AS: resources/oauth-discovery.ts, conditional spread on
+  //     dcrEnabled(), default off.
+  //   - the MCP plugin: @harperfast/oauth/dist/lib/mcp/wellKnown.js:142,
+  //     `...(dcrEnabled(mcpConfig) ? { registration_endpoint: … } : {})`.
+  //
+  // And `enable` writes `dynamicClientRegistration: { enabled: false }` by
+  // design — DCR is unsupported on this surface (#756). So the plugin omits the
+  // field on every instance this command configures, and self-verify then
+  // reported "the metadata shape is unexpected" on a working MCP surface,
+  // sending the operator to debug metadata fields instead.
+  //
+  // The module header above still claims the plugin advertises it
+  // "unconditionally". That was true of the version it was written against and
+  // is false of the installed one — corrected there too. A verified fact carries
+  // the date it was verified, and this one expired.
+  //
+  // Required: issuer and token_endpoint, both always present in both servers.
+  // registration_endpoint is validated only when it appears.
   if (
     body?.issuer !== normalizedIssuer ||
-    typeof body?.registration_endpoint !== "string" ||
-    typeof body?.token_endpoint !== "string"
+    typeof body?.token_endpoint !== "string" ||
+    (body?.registration_endpoint !== undefined && typeof body.registration_endpoint !== "string")
   ) {
     return {
       ok: false,
-      detail: `${url} responded but the metadata shape is unexpected (issuer/registration_endpoint/token_endpoint) — got issuer=${JSON.stringify(body?.issuer)}`,
+      detail: `${url} responded but the metadata shape is unexpected (issuer/token_endpoint) — got issuer=${JSON.stringify(body?.issuer)}`,
     };
   }
 
@@ -1024,61 +1003,13 @@ export async function enableMcp(params: EnableMcpParams, deps: EnableMcpDeps = {
       idpClientSecret: params.idpClientSecret,
     });
     currentStep = "secrets-provisioning";
-    // Stage first, unconditionally. If the push works the file is a no-op the
-    // operator never opens; if anything about the push is uncertain they still
-    // have the thing that always works, without a re-run. Staging costs a 0600
-    // write; not staging costs an operator stranded mid-enable.
     const secretsResult = provisionSecrets(params.instance, bundle, {
       mechanism: params.secretsMechanism,
       stagingPath: params.secretsStagingPath,
     });
-
-    // Ask the TARGET whether it can take these, rather than inferring from its
-    // hostname or its version (flair#1094 — see selectSecretsMechanism's note).
-    // An explicit --secrets-mechanism is an operator override and is honoured
-    // without a probe: they have said what they want.
-    let secretsPushed = false;
-    if (!params.secretsMechanism) {
-      const cap = await probeSecretsCapability(
-        resolveOpsUrl(params.instance),
-        basicAuthHeader(params.adminUser, params.adminPass),
-        { fetchImpl: deps.fetchImpl },
-      );
-      if (cap.available && cap.publicKeyPem) {
-        const pushResult = await pushSecrets(
-          resolveOpsUrl(params.instance),
-          basicAuthHeader(params.adminUser, params.adminPass),
-          bundle,
-          cap.publicKeyPem,
-          { fetchImpl: deps.fetchImpl },
-        );
-        secretsPushed = pushResult.allOk;
-        if (secretsPushed) {
-          push(true,
-            `${secretsResult.varNames.length} vars pushed to the target as enc:v1 env-secrets (tier ${PROCESS_ENV_TIER}); ` +
-              `values were sealed locally and never sent in plaintext. Staged copy at ${secretsResult.path} (0600) is unused. ` +
-              `Self-verify below is what proves they were DECRYPTED into the process — a target that stores them without an ` +
-              `active env-secrets decryptor will fail there, not here.`,
-          );
-        } else {
-          const failed = pushResult.results.filter((r) => !r.ok).map((r) => `${r.name} (${r.detail})`).join("; ");
-          push(true,
-            `push attempted and did not complete for: ${failed}. Falling back to the staged file at ${secretsResult.path} (0600). ` +
-              `${secretsResult.instructions}`,
-          );
-        }
-      } else {
-        push(true,
-          `mechanism: ${secretsResult.mechanism}; ${secretsResult.varNames.length} vars staged at ${secretsResult.path} (0600). ` +
-            `${cap.reason}. ${secretsResult.instructions}`,
-        );
-      }
-    } else {
-      push(true,
-        `mechanism: ${secretsResult.mechanism} (explicit --secrets-mechanism, no capability probe); ` +
-          `${secretsResult.varNames.length} vars staged at ${secretsResult.path} (0600). ${secretsResult.instructions}`,
-      );
-    }
+    push(true,
+      `mechanism: ${secretsResult.mechanism}; ${secretsResult.varNames.length} vars staged at ${secretsResult.path} (0600). ${secretsResult.instructions}`,
+    );
 
     // ── Identity mapping (Credential kind:idp) ────────────────────────────────
     currentStep = "identity-mapping";

--- a/src/lib/mcp-enable.ts
+++ b/src/lib/mcp-enable.ts
@@ -140,6 +140,7 @@
  *     expansion.
  */
 
+import { probeSecretsCapability, pushSecrets, PROCESS_ENV_TIER } from "./secrets-push.js";
 import { existsSync, mkdirSync, writeFileSync, chmodSync, readFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { join, dirname } from "node:path";
@@ -221,6 +222,30 @@ export type SecretsMechanism = "fabric-env-secrets" | "env-file";
  * an automated push: no confirmed ops-API operation for it exists in the
  * installed 5.1.17 SDK). Anything else defaults to `env-file` — the
  * documented, universally-supported fallback. Always overridable.
+ */
+/**
+ * ── The hostname no longer selects the mechanism (flair#1094) ───────────────
+ *
+ * This used to be `isFabricOrigin(url) ? "fabric-env-secrets" : "env-file"`, and
+ * that was wrong in BOTH directions on the day it was replaced:
+ *
+ *   - `tps.dtrt.harperfabric.com` runs Harper 5.1.26 and has no secrets
+ *     operations at all — measured; `set_secret` answers "Operation 'set_secret'
+ *     not found", identical to an invented operation — and was selected for the
+ *     automated mechanism purely because of its name.
+ *   - a self-hosted Harper 5.2 with the Pro env-secrets component is fully
+ *     capable and was sent down the manual Studio path for not matching.
+ *
+ * A hostname is not a capability, and neither is a version — the write
+ * operations and the Pro decryptor that makes a `processEnv` secret reach the
+ * process ship separately. `probeSecretsCapability` asks the target instead, and
+ * the answer decides at provisioning time.
+ *
+ * What remains here is the STAGING FILE's flavour of instructions, which is
+ * genuinely about where the operator will paste if we end up falling back.
+ * Fabric operators paste into Studio; everyone else edits a unit file. That is a
+ * UI fact about a human, not a claim about the server, so a hostname is a
+ * reasonable signal for it and a wrong guess costs only slightly-off prose.
  */
 export function selectSecretsMechanism(instanceUrl: string, override?: SecretsMechanism): SecretsMechanism {
   if (override) return override;
@@ -731,6 +756,31 @@ export async function selfVerifyMcpMetadata(
   } catch {
     return { ok: false, detail: `${url} did not return JSON` };
   }
+  // ── The flair's-own-server check runs BEFORE the shape check (flair#1094) ──
+  //
+  // It used to run after, and that made the DEFAULT flag-off case misreport.
+  // flair's own document omits `registration_endpoint` unless DCR is enabled,
+  // which it is not by default — so the shape check fired first and returned
+  // "the metadata shape is unexpected", which is true, useless, and points at
+  // shapes when the cause is an unset environment variable.
+  //
+  // `token_endpoint` is present in that document either way, so testing the
+  // discriminator first names the real cause in EVERY flag-off case rather than
+  // only when DCR happens to be on. Found by writing the test that pins this
+  // relationship, not by reading the code.
+  if (typeof body?.token_endpoint === "string" && body.token_endpoint === `${normalizedIssuer}/OAuthToken`) {
+    return {
+      ok: false,
+      issuer: body?.issuer,
+      registrationEndpoint: body?.registration_endpoint,
+      tokenEndpoint: body.token_endpoint,
+      detail:
+        `${url} answered with flair's OWN OAuth 2.1 authorization server, not the MCP one ` +
+        `(token_endpoint=${body.token_endpoint}) — the /mcp surface is NOT enabled on that instance. ` +
+        `Is FLAIR_MCP_OAUTH actually set on the restarted instance, and is the '@harperfast/oauth' ` +
+        `component declared in its config.yaml?`,
+    };
+  }
   // ── registration_endpoint is OPTIONAL and must not be required (Kern, #1101) ─
   //
   // Requiring it made self-verify fail on a CORRECTLY enabled instance — the
@@ -1003,13 +1053,61 @@ export async function enableMcp(params: EnableMcpParams, deps: EnableMcpDeps = {
       idpClientSecret: params.idpClientSecret,
     });
     currentStep = "secrets-provisioning";
+    // Stage first, unconditionally. If the push works the file is a no-op the
+    // operator never opens; if anything about the push is uncertain they still
+    // have the thing that always works, without a re-run. Staging costs a 0600
+    // write; not staging costs an operator stranded mid-enable.
     const secretsResult = provisionSecrets(params.instance, bundle, {
       mechanism: params.secretsMechanism,
       stagingPath: params.secretsStagingPath,
     });
-    push(true,
-      `mechanism: ${secretsResult.mechanism}; ${secretsResult.varNames.length} vars staged at ${secretsResult.path} (0600). ${secretsResult.instructions}`,
-    );
+
+    // Ask the TARGET whether it can take these, rather than inferring from its
+    // hostname or its version (flair#1094 — see selectSecretsMechanism's note).
+    // An explicit --secrets-mechanism is an operator override and is honoured
+    // without a probe: they have said what they want.
+    let secretsPushed = false;
+    if (!params.secretsMechanism) {
+      const cap = await probeSecretsCapability(
+        resolveOpsUrl(params.instance),
+        basicAuthHeader(params.adminUser, params.adminPass),
+        { fetchImpl: deps.fetchImpl },
+      );
+      if (cap.available && cap.publicKeyPem) {
+        const pushResult = await pushSecrets(
+          resolveOpsUrl(params.instance),
+          basicAuthHeader(params.adminUser, params.adminPass),
+          bundle,
+          cap.publicKeyPem,
+          { fetchImpl: deps.fetchImpl },
+        );
+        secretsPushed = pushResult.allOk;
+        if (secretsPushed) {
+          push(true,
+            `${secretsResult.varNames.length} vars pushed to the target as enc:v1 env-secrets (tier ${PROCESS_ENV_TIER}); ` +
+              `values were sealed locally and never sent in plaintext. Staged copy at ${secretsResult.path} (0600) is unused. ` +
+              `Self-verify below is what proves they were DECRYPTED into the process — a target that stores them without an ` +
+              `active env-secrets decryptor will fail there, not here.`,
+          );
+        } else {
+          const failed = pushResult.results.filter((r) => !r.ok).map((r) => `${r.name} (${r.detail})`).join("; ");
+          push(true,
+            `push attempted and did not complete for: ${failed}. Falling back to the staged file at ${secretsResult.path} (0600). ` +
+              `${secretsResult.instructions}`,
+          );
+        }
+      } else {
+        push(true,
+          `mechanism: ${secretsResult.mechanism}; ${secretsResult.varNames.length} vars staged at ${secretsResult.path} (0600). ` +
+            `${cap.reason}. ${secretsResult.instructions}`,
+        );
+      }
+    } else {
+      push(true,
+        `mechanism: ${secretsResult.mechanism} (explicit --secrets-mechanism, no capability probe); ` +
+          `${secretsResult.varNames.length} vars staged at ${secretsResult.path} (0600). ${secretsResult.instructions}`,
+      );
+    }
 
     // ── Identity mapping (Credential kind:idp) ────────────────────────────────
     currentStep = "identity-mapping";

--- a/src/lib/mcp-enable.ts
+++ b/src/lib/mcp-enable.ts
@@ -752,6 +752,31 @@ export async function selfVerifyMcpMetadata(
   } catch {
     return { ok: false, detail: `${url} did not return JSON` };
   }
+  // ── The flair's-own-server check runs BEFORE the shape check (flair#1094) ──
+  //
+  // It used to run after, and that made the DEFAULT flag-off case misreport.
+  // flair's own document omits `registration_endpoint` unless DCR is enabled,
+  // which it is not by default — so the shape check fired first and returned
+  // "the metadata shape is unexpected", which is true, useless, and points at
+  // shapes when the cause is an unset environment variable.
+  //
+  // `token_endpoint` is present in that document either way, so testing the
+  // discriminator first names the real cause in EVERY flag-off case rather than
+  // only when DCR happens to be on. Found by writing the test that pins this
+  // relationship, not by reading the code.
+  if (typeof body?.token_endpoint === "string" && body.token_endpoint === `${normalizedIssuer}/OAuthToken`) {
+    return {
+      ok: false,
+      issuer: body?.issuer,
+      registrationEndpoint: body?.registration_endpoint,
+      tokenEndpoint: body.token_endpoint,
+      detail:
+        `${url} answered with flair's OWN OAuth 2.1 authorization server, not the MCP one ` +
+        `(token_endpoint=${body.token_endpoint}) — the /mcp surface is NOT enabled on that instance. ` +
+        `Is FLAIR_MCP_OAUTH actually set on the restarted instance, and is the '@harperfast/oauth' ` +
+        `component declared in its config.yaml?`,
+    };
+  }
   if (
     body?.issuer !== normalizedIssuer ||
     typeof body?.registration_endpoint !== "string" ||

--- a/src/lib/mcp-enable.ts
+++ b/src/lib/mcp-enable.ts
@@ -136,6 +136,7 @@
  *     expansion.
  */
 
+import { probeSecretsCapability, pushSecrets, PROCESS_ENV_TIER } from "./secrets-push.js";
 import { existsSync, mkdirSync, writeFileSync, chmodSync, readFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { join, dirname } from "node:path";
@@ -217,6 +218,30 @@ export type SecretsMechanism = "fabric-env-secrets" | "env-file";
  * an automated push: no confirmed ops-API operation for it exists in the
  * installed 5.1.17 SDK). Anything else defaults to `env-file` — the
  * documented, universally-supported fallback. Always overridable.
+ */
+/**
+ * ── The hostname no longer selects the mechanism (flair#1094) ───────────────
+ *
+ * This used to be `isFabricOrigin(url) ? "fabric-env-secrets" : "env-file"`, and
+ * that was wrong in BOTH directions on the day it was replaced:
+ *
+ *   - `tps.dtrt.harperfabric.com` runs Harper 5.1.26 and has no secrets
+ *     operations at all — measured; `set_secret` answers "Operation 'set_secret'
+ *     not found", identical to an invented operation — and was selected for the
+ *     automated mechanism purely because of its name.
+ *   - a self-hosted Harper 5.2 with the Pro env-secrets component is fully
+ *     capable and was sent down the manual Studio path for not matching.
+ *
+ * A hostname is not a capability, and neither is a version — the write
+ * operations and the Pro decryptor that makes a `processEnv` secret reach the
+ * process ship separately. `probeSecretsCapability` asks the target instead, and
+ * the answer decides at provisioning time.
+ *
+ * What remains here is the STAGING FILE's flavour of instructions, which is
+ * genuinely about where the operator will paste if we end up falling back.
+ * Fabric operators paste into Studio; everyone else edits a unit file. That is a
+ * UI fact about a human, not a claim about the server, so a hostname is a
+ * reasonable signal for it and a wrong guess costs only slightly-off prose.
  */
 export function selectSecretsMechanism(instanceUrl: string, override?: SecretsMechanism): SecretsMechanism {
   if (override) return override;
@@ -974,13 +999,61 @@ export async function enableMcp(params: EnableMcpParams, deps: EnableMcpDeps = {
       idpClientSecret: params.idpClientSecret,
     });
     currentStep = "secrets-provisioning";
+    // Stage first, unconditionally. If the push works the file is a no-op the
+    // operator never opens; if anything about the push is uncertain they still
+    // have the thing that always works, without a re-run. Staging costs a 0600
+    // write; not staging costs an operator stranded mid-enable.
     const secretsResult = provisionSecrets(params.instance, bundle, {
       mechanism: params.secretsMechanism,
       stagingPath: params.secretsStagingPath,
     });
-    push(true,
-      `mechanism: ${secretsResult.mechanism}; ${secretsResult.varNames.length} vars staged at ${secretsResult.path} (0600). ${secretsResult.instructions}`,
-    );
+
+    // Ask the TARGET whether it can take these, rather than inferring from its
+    // hostname or its version (flair#1094 — see selectSecretsMechanism's note).
+    // An explicit --secrets-mechanism is an operator override and is honoured
+    // without a probe: they have said what they want.
+    let secretsPushed = false;
+    if (!params.secretsMechanism) {
+      const cap = await probeSecretsCapability(
+        resolveOpsUrl(params.instance),
+        basicAuthHeader(params.adminUser, params.adminPass),
+        { fetchImpl: deps.fetchImpl },
+      );
+      if (cap.available && cap.publicKeyPem) {
+        const pushResult = await pushSecrets(
+          resolveOpsUrl(params.instance),
+          basicAuthHeader(params.adminUser, params.adminPass),
+          bundle,
+          cap.publicKeyPem,
+          { fetchImpl: deps.fetchImpl },
+        );
+        secretsPushed = pushResult.allOk;
+        if (secretsPushed) {
+          push(true,
+            `${secretsResult.varNames.length} vars pushed to the target as enc:v1 env-secrets (tier ${PROCESS_ENV_TIER}); ` +
+              `values were sealed locally and never sent in plaintext. Staged copy at ${secretsResult.path} (0600) is unused. ` +
+              `Self-verify below is what proves they were DECRYPTED into the process — a target that stores them without an ` +
+              `active env-secrets decryptor will fail there, not here.`,
+          );
+        } else {
+          const failed = pushResult.results.filter((r) => !r.ok).map((r) => `${r.name} (${r.detail})`).join("; ");
+          push(true,
+            `push attempted and did not complete for: ${failed}. Falling back to the staged file at ${secretsResult.path} (0600). ` +
+              `${secretsResult.instructions}`,
+          );
+        }
+      } else {
+        push(true,
+          `mechanism: ${secretsResult.mechanism}; ${secretsResult.varNames.length} vars staged at ${secretsResult.path} (0600). ` +
+            `${cap.reason}. ${secretsResult.instructions}`,
+        );
+      }
+    } else {
+      push(true,
+        `mechanism: ${secretsResult.mechanism} (explicit --secrets-mechanism, no capability probe); ` +
+          `${secretsResult.varNames.length} vars staged at ${secretsResult.path} (0600). ${secretsResult.instructions}`,
+      );
+    }
 
     // ── Identity mapping (Credential kind:idp) ────────────────────────────────
     currentStep = "identity-mapping";

--- a/src/lib/secret-envelope.ts
+++ b/src/lib/secret-envelope.ts
@@ -1,0 +1,91 @@
+/**
+ * Client-side `enc:v1:` secret envelopes — the wire format Harper's env-secrets
+ * feature reads (`hdb_secret` store and encrypted `.env` entries).
+ *
+ * ── Why this is reimplemented rather than imported ──────────────────────────
+ * `harper@5.2.0` ships this as `utility/secretEnvelope.ts`, deliberately free of
+ * Harper imports and described in its own header as "safe to publish". We could
+ * import it — except that `flair mcp enable` builds the envelope for a REMOTE
+ * target whose Harper version is discovered at runtime and is routinely NEWER
+ * than the one flair bundles. Importing would tie the format we can produce to
+ * the engine we happen to ship, which is exactly backwards: the local engine has
+ * nothing to do with what the remote instance can read.
+ *
+ * So it is reimplemented, and the compatibility claim is TESTED rather than
+ * asserted — test/unit/secret-envelope.test.ts runs Harper's own
+ * `decryptEnvelope` (vendored verbatim into the test as a reference oracle)
+ * against envelopes this module produces. A round-trip against ourselves would
+ * only prove self-consistency, which is worth nothing here: the reader is
+ * someone else's code.
+ *
+ * ── The format, from harper@5.2.0 utility/secretEnvelope.ts ─────────────────
+ * Hybrid: AES-256-GCM encrypts the value, RSA-OAEP(SHA-256) wraps the AES key.
+ *
+ *   envelope = base64url(JSON.stringify({ kid, k, iv, ct, tag }))
+ *   kid = sha256(DER SPKI of the public key), hex
+ *   k   = base64(RSA-OAEP(aesKey))     iv  = base64(12 random bytes)
+ *   ct  = base64(ciphertext)           tag = base64(GCM auth tag)
+ *
+ * The `enc:v1:` marker is NOT part of the body — it is added by callers, the
+ * same split Harper uses (the marker lives in `utility/envFile.ts`).
+ *
+ * Nothing here reads or writes a secret to disk, and no value is logged. The
+ * plaintext exists only as an argument.
+ */
+import { createCipheriv, createHash, createPublicKey, publicEncrypt, randomBytes, constants } from "node:crypto";
+
+/** Marker prefixed to an envelope body. Harper keys the encrypted-value path on this. */
+export const ENV_ENCRYPTED_PREFIX = "enc:v1:";
+
+export interface EnvelopeFields {
+  kid?: string;
+  k: string;
+  iv: string;
+  ct: string;
+  tag: string;
+}
+
+/**
+ * SHA-256 (hex) of the DER SPKI public key — the stable key id used as `kid`.
+ *
+ * The server derives `kid` from the sealed body and trusts only that one, never
+ * a separate client-supplied field, so getting this wrong surfaces as a refusal
+ * to decrypt rather than as a silently-wrong secret.
+ */
+export function fingerprintOf(publicKeyPem: string): string {
+  const der = createPublicKey(publicKeyPem).export({ type: "spki", format: "der" });
+  return createHash("sha256").update(der as Buffer).digest("hex");
+}
+
+/**
+ * Seal `plaintext` for the holder of `publicKeyPem`. Returns the envelope BODY,
+ * without the `enc:v1:` marker.
+ *
+ * Randomised per call (fresh AES key and IV), so two calls on the same input
+ * differ — which is why the tests assert decryptability by the reference
+ * implementation rather than comparing against a fixed string.
+ */
+export function encryptEnvelope(plaintext: string, publicKeyPem: string, kid?: string): string {
+  const aesKey = randomBytes(32);
+  const iv = randomBytes(12);
+  const cipher = createCipheriv("aes-256-gcm", aesKey, iv);
+  const ct = Buffer.concat([cipher.update(plaintext, "utf8"), cipher.final()]);
+  const tag = cipher.getAuthTag();
+  const k = publicEncrypt(
+    { key: publicKeyPem, padding: constants.RSA_PKCS1_OAEP_PADDING, oaepHash: "sha256" },
+    aesKey,
+  );
+  const envelope: EnvelopeFields = {
+    kid: kid ?? fingerprintOf(publicKeyPem),
+    k: k.toString("base64"),
+    iv: iv.toString("base64"),
+    ct: ct.toString("base64"),
+    tag: tag.toString("base64"),
+  };
+  return Buffer.from(JSON.stringify(envelope)).toString("base64url");
+}
+
+/** Seal and prefix — what a caller sends as `set_secret`'s `envelope` field. */
+export function sealSecret(plaintext: string, publicKeyPem: string): string {
+  return ENV_ENCRYPTED_PREFIX + encryptEnvelope(plaintext, publicKeyPem);
+}

--- a/src/lib/secrets-push.ts
+++ b/src/lib/secrets-push.ts
@@ -26,12 +26,18 @@
  * and no read-only call can — a secret only proves it was decrypted by being
  * present in the process.
  *
- * That check already exists downstream: `enable`'s self-verify step fetches the
- * issuer's OAuth metadata, which is only served when `FLAIR_MCP_OAUTH` reached
- * the process. So a push that lands in `hdb_secret` and is never decrypted shows
- * up as a self-verify failure rather than as silent success — provided the
- * failure names this as a candidate cause, which is why `pushed` is threaded
- * through to the result.
+ * That check already exists downstream, though NOT for the reason first claimed
+ * here. The well-known endpoint does not stop answering when the flag is off —
+ * flair serves its OWN OAuth 2.1 discovery document in that case
+ * (resources/oauth-discovery.ts). What distinguishes them is a DISCRIMINATOR:
+ * flair's document advertises `<issuer>/OAuthToken`, the plugin's advertises
+ * `<issuer>/oauth/mcp/token`, and self-verify tests for the former by name.
+ *
+ * So a push that lands in `hdb_secret` and is never decrypted shows up as a
+ * self-verify failure naming FLAIR_MCP_OAUTH — because of a comparison, not an
+ * absence. That relationship spans two files and is pinned by a test in
+ * test/unit/secrets-push.test.ts; without it, changing either side silently
+ * disables the only thing standing between "stored" and "working".
  *
  * ── Failure direction ───────────────────────────────────────────────────────
  * Every uncertain outcome falls back to the staged-file flow. That path works

--- a/src/lib/secrets-push.ts
+++ b/src/lib/secrets-push.ts
@@ -1,0 +1,157 @@
+/**
+ * Pushing `mcp enable`'s staged secrets to the target over the ops API, when the
+ * target can actually take them (flair#1094).
+ *
+ * ── What replaced what ──────────────────────────────────────────────────────
+ * The mechanism used to be chosen by HOSTNAME: `selectSecretsMechanism` returned
+ * `fabric-env-secrets` for anything ending `.harperfabric.com` and `env-file`
+ * otherwise. That is wrong in both directions and was wrong in both directions
+ * on the day it was replaced:
+ *
+ *   - tps.dtrt.harperfabric.com runs Harper 5.1.26 and has NO secrets
+ *     operations — measured, `set_secret` answers "Operation 'set_secret' not
+ *     found", identical to an operation that does not exist at all — and was
+ *     selected for the automated mechanism because of its name.
+ *   - a self-hosted Harper 5.2 with the Pro env-secrets component is fully
+ *     capable and was sent down the manual Fabric Studio path because its
+ *     hostname did not match.
+ *
+ * A hostname is not a capability. Nor is a version: the write operations and the
+ * decryptor that makes a `processEnv` secret reach the process ship separately
+ * (core vs Pro). So this asks the target directly.
+ *
+ * ── What this probe does and does not establish ─────────────────────────────
+ * It establishes that the secrets OPERATIONS exist, by asking for the public key
+ * we would need anyway. It does NOT establish that the Pro decryptor is active,
+ * and no read-only call can — a secret only proves it was decrypted by being
+ * present in the process.
+ *
+ * That check already exists downstream: `enable`'s self-verify step fetches the
+ * issuer's OAuth metadata, which is only served when `FLAIR_MCP_OAUTH` reached
+ * the process. So a push that lands in `hdb_secret` and is never decrypted shows
+ * up as a self-verify failure rather than as silent success — provided the
+ * failure names this as a candidate cause, which is why `pushed` is threaded
+ * through to the result.
+ *
+ * ── Failure direction ───────────────────────────────────────────────────────
+ * Every uncertain outcome falls back to the staged-file flow. That path works
+ * today, on every target, and costs the operator a paste. Pushing a secret at an
+ * endpoint that may not exist costs a silent flag-OFF boot, which is the exact
+ * failure this automation is meant to remove.
+ */
+import { sealSecret } from "./secret-envelope.js";
+
+export interface SecretsCapability {
+  /** True only when the target answered with a usable public key. */
+  available: boolean;
+  /** Why, in operator-facing words. Always set, including on success. */
+  reason: string;
+  publicKeyPem?: string;
+}
+
+/** `set_secret`'s delivery tier. `processEnv` is global and cannot be scoped —
+ *  which is what `FLAIR_MCP_OAUTH` and the signing key PEM need, since both are
+ *  read from `process.env` and never from YAML. */
+export const PROCESS_ENV_TIER = "processEnv";
+
+async function opsCall(
+  opsUrl: string,
+  authHeader: string,
+  body: unknown,
+  fetchImpl: typeof fetch,
+): Promise<{ ok: boolean; status: number; json: any; text: string }> {
+  const res = await fetchImpl(opsUrl, {
+    method: "POST",
+    headers: { "Content-Type": "application/json", Authorization: authHeader },
+    body: JSON.stringify(body),
+  });
+  const text = await res.text().catch(() => "");
+  let json: any = null;
+  try { json = JSON.parse(text); } catch { /* non-JSON body — keep the text */ }
+  return { ok: res.ok, status: res.status, json, text };
+}
+
+/**
+ * Ask the target whether it can take pushed secrets, by requesting the key we
+ * would encrypt to. Never throws: an unreachable or unparseable target is a
+ * fall-back-and-say-why, not a crash mid-enable.
+ */
+export async function probeSecretsCapability(
+  opsUrl: string,
+  authHeader: string,
+  deps: { fetchImpl?: typeof fetch } = {},
+): Promise<SecretsCapability> {
+  const fetchImpl = deps.fetchImpl ?? fetch;
+  let r;
+  try {
+    r = await opsCall(opsUrl, authHeader, { operation: "get_secrets_public_key" }, fetchImpl);
+  } catch (err: any) {
+    return { available: false, reason: `could not reach the ops API to ask (${err?.message ?? err}) — using the staged-file flow` };
+  }
+
+  // "Operation '<name>' not found" is how Harper answers an operation it does
+  // not have, and it is byte-identical to the answer for an invented one. That
+  // is the signal for a target older than the env-secrets feature.
+  const errText = String(r.json?.error ?? r.text ?? "");
+  if (/not found/i.test(errText) && /get_secrets_public_key/.test(errText)) {
+    return { available: false, reason: "the target's Harper has no env-secrets operations (needs 5.2 or newer) — using the staged-file flow" };
+  }
+  if (!r.ok) {
+    return { available: false, reason: `the target refused the capability probe (HTTP ${r.status}${errText ? `: ${errText.slice(0, 120)}` : ""}) — using the staged-file flow` };
+  }
+
+  const pem = extractPublicKeyPem(r.json);
+  if (!pem) {
+    // Answered, but not with something we can encrypt to. Undeterminable is
+    // treated exactly like unavailable — see the failure-direction note above.
+    return { available: false, reason: "the target answered the probe without a usable public key — using the staged-file flow" };
+  }
+  return { available: true, reason: "target supports env-secrets; pushing over the ops API", publicKeyPem: pem };
+}
+
+/** Pull the PEM out of whatever shape the operation returns, without guessing
+ *  at a value that is not obviously a key. */
+function extractPublicKeyPem(json: any): string | undefined {
+  const candidates = [json, json?.public_key, json?.publicKey, json?.key, json?.pem, json?.data?.public_key];
+  for (const c of candidates) {
+    if (typeof c === "string" && c.includes("BEGIN PUBLIC KEY")) return c;
+  }
+  return undefined;
+}
+
+export interface PushedSecret {
+  name: string;
+  ok: boolean;
+  detail?: string;
+}
+
+/**
+ * Seal and set each var. Values are encrypted client-side, so plaintext never
+ * appears in a request body — and never in this module's return value either:
+ * results carry NAMES and outcomes only.
+ */
+export async function pushSecrets(
+  opsUrl: string,
+  authHeader: string,
+  vars: Record<string, string>,
+  publicKeyPem: string,
+  deps: { fetchImpl?: typeof fetch } = {},
+): Promise<{ allOk: boolean; results: PushedSecret[] }> {
+  const fetchImpl = deps.fetchImpl ?? fetch;
+  const results: PushedSecret[] = [];
+  for (const [name, value] of Object.entries(vars)) {
+    try {
+      const r = await opsCall(
+        opsUrl,
+        authHeader,
+        { operation: "set_secret", name, envelope: sealSecret(value, publicKeyPem), tier: PROCESS_ENV_TIER },
+        fetchImpl,
+      );
+      const err = String(r.json?.error ?? "").slice(0, 140);
+      results.push({ name, ok: r.ok, detail: r.ok ? undefined : `HTTP ${r.status}${err ? `: ${err}` : ""}` });
+    } catch (err: any) {
+      results.push({ name, ok: false, detail: String(err?.message ?? err).slice(0, 140) });
+    }
+  }
+  return { allOk: results.every((x) => x.ok), results };
+}

--- a/test/unit/secret-envelope.test.ts
+++ b/test/unit/secret-envelope.test.ts
@@ -1,0 +1,200 @@
+// Compatibility tests for src/lib/secret-envelope.ts.
+//
+// The claim under test is NOT "our encrypt round-trips with our decrypt" — we
+// have no decrypt, and self-consistency would prove nothing anyway. The claim is
+// that **Harper can read what we write**, so the oracle has to be Harper's code.
+//
+// `parseEnvelopeFields` and `decryptEnvelope` below are vendored VERBATIM from
+// the published `harper@5.2.0` (`utility/secretEnvelope.ts`, MIT, "intentionally
+// free of Harper imports … safe to publish"). They are the reference reader, not
+// a reimplementation of it — if they drift from upstream this test stops meaning
+// what it says, so they carry the version they came from.
+//
+// Why vendor rather than import `harper`: flair bundles 5.1.x today, which does
+// not have this module, and the whole point is that we build envelopes for
+// REMOTE targets whose version we discover at runtime. Importing would tie the
+// test to the engine we ship instead of the one that will read the secret.
+import { describe, expect, test } from "bun:test";
+import { createDecipheriv, generateKeyPairSync, privateDecrypt, constants } from "node:crypto";
+import { encryptEnvelope, fingerprintOf, sealSecret, ENV_ENCRYPTED_PREFIX } from "../../src/lib/secret-envelope.js";
+
+// ─── Reference reader, harper@5.2.0 utility/secretEnvelope.ts ────────────────
+const BASE64_REGEX = /^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}(?:==)?|[A-Za-z0-9+/]{3}=?)?$/;
+
+interface RefFields { kid?: string; k: string; iv: string; ct: string; tag: string }
+
+function parseEnvelopeFields(body: string): RefFields {
+  let env: RefFields;
+  try {
+    env = JSON.parse(Buffer.from(body, "base64url").toString("utf8"));
+  } catch {
+    throw new Error("malformed secret envelope");
+  }
+  if (!env || typeof env !== "object" || Array.isArray(env) || (env.kid !== undefined && typeof env.kid !== "string")) {
+    throw new Error("malformed secret envelope");
+  }
+  for (const field of ["k", "iv", "ct", "tag"] as const) {
+    const v = env[field];
+    if (typeof v !== "string" || (v.length === 0 && field !== "ct") || !BASE64_REGEX.test(v)) {
+      throw new Error("malformed secret envelope");
+    }
+  }
+  return env;
+}
+
+function decryptEnvelope(body: string, privateKeyPem: string, keyFingerprint: string): string {
+  const env = parseEnvelopeFields(body);
+  if (env.kid && env.kid !== keyFingerprint) throw new Error(`no secrets key for kid ${env.kid}`);
+  const aesKey = privateDecrypt(
+    { key: privateKeyPem, padding: constants.RSA_PKCS1_OAEP_PADDING, oaepHash: "sha256" },
+    Buffer.from(env.k, "base64"),
+  );
+  const decipher = createDecipheriv("aes-256-gcm", aesKey, Buffer.from(env.iv, "base64"));
+  decipher.setAuthTag(Buffer.from(env.tag, "base64"));
+  return Buffer.concat([decipher.update(Buffer.from(env.ct, "base64")), decipher.final()]).toString("utf8");
+}
+// ─── end reference ──────────────────────────────────────────────────────────
+
+function keypair() {
+  const { publicKey, privateKey } = generateKeyPairSync("rsa", {
+    modulusLength: 2048,
+    publicKeyEncoding: { type: "spki", format: "pem" },
+    privateKeyEncoding: { type: "pkcs8", format: "pem" },
+  });
+  return { publicKey, privateKey };
+}
+
+describe("secret envelopes are readable by Harper's own decryptor", () => {
+  test("a sealed value decrypts back to the plaintext", () => {
+    const { publicKey, privateKey } = keypair();
+    const body = encryptEnvelope("FLAIR_MCP_OAUTH=1", publicKey);
+    expect(decryptEnvelope(body, privateKey, fingerprintOf(publicKey))).toBe("FLAIR_MCP_OAUTH=1");
+  });
+
+  test("a multi-line PEM survives — the signing key is the real payload", () => {
+    // The RS256 signing key is the largest and most structurally fragile thing
+    // we send: newlines, header/footer lines, base64 body. A format that mangled
+    // it would still look fine on a short value.
+    const { publicKey, privateKey } = keypair();
+    const { privateKey: payload } = keypair();
+    const body = encryptEnvelope(payload, publicKey);
+    const out = decryptEnvelope(body, privateKey, fingerprintOf(publicKey));
+    expect(out).toBe(payload);
+    expect(out.split("\n").length).toBeGreaterThan(3);
+  });
+
+  test("the empty value is representable", () => {
+    // parseEnvelopeFields allows an empty `ct` specifically — so an empty secret
+    // must round-trip rather than being rejected as malformed.
+    const { publicKey, privateKey } = keypair();
+    expect(decryptEnvelope(encryptEnvelope("", publicKey), privateKey, fingerprintOf(publicKey))).toBe("");
+  });
+
+  test("unicode survives the utf8 boundary", () => {
+    const { publicKey, privateKey } = keypair();
+    const v = "clé—secret—🔐";
+    expect(decryptEnvelope(encryptEnvelope(v, publicKey), privateKey, fingerprintOf(publicKey))).toBe(v);
+  });
+
+  test("the body parses as a well-formed envelope by the reference parser", () => {
+    const { publicKey } = keypair();
+    const env = parseEnvelopeFields(encryptEnvelope("x", publicKey));
+    for (const f of ["k", "iv", "ct", "tag"] as const) expect(typeof env[f]).toBe("string");
+    expect(env.kid).toBe(fingerprintOf(publicKey));
+  });
+});
+
+// ─── Format assertions, added because mutation testing exposed the gap ───────
+//
+// The tests above verify DECRYPTABILITY BY THE REFERENCE, and that turned out to
+// be a weaker claim than "the format is right". Two deliberate deviations were
+// NOT caught by them:
+//
+//   base64 body instead of base64url  -> still decrypts; Node's base64url
+//                                        decoder accepts standard base64
+//   16-byte IV instead of 12          -> still decrypts; GCM accepts variable
+//                                        IV lengths and the length is carried
+//                                        in the envelope itself
+//
+// Neither breaks Harper today. Both are wire-format drift that survives only
+// because the reader is lenient, and "works because the other side forgives it"
+// is not a property to ship a credential on. So the shape is asserted directly.
+describe("the wire format is exactly as specified, not merely decryptable", () => {
+  test("the IV is 12 bytes — the GCM standard, not whatever still decrypts", () => {
+    const { publicKey } = keypair();
+    const env = parseEnvelopeFields(encryptEnvelope("x", publicKey));
+    expect(Buffer.from(env.iv, "base64").length).toBe(12);
+  });
+
+  test("the AES key is 256-bit", () => {
+    // Recovered through the reference's own RSA unwrap, so this asserts what the
+    // reader will actually receive rather than what we intended to send.
+    const { publicKey, privateKey } = keypair();
+    const env = parseEnvelopeFields(encryptEnvelope("x", publicKey));
+    const aesKey = privateDecrypt(
+      { key: privateKey, padding: constants.RSA_PKCS1_OAEP_PADDING, oaepHash: "sha256" },
+      Buffer.from(env.k, "base64"),
+    );
+    expect(aesKey.length).toBe(32);
+  });
+
+  test("the body is base64url — no +, / or = padding", () => {
+    const { publicKey } = keypair();
+    const body = encryptEnvelope("x".repeat(64), publicKey);
+    expect(body).not.toMatch(/[+/=]/);
+    expect(body).toMatch(/^[A-Za-z0-9_-]+$/);
+  });
+
+  test("the GCM tag is 16 bytes", () => {
+    const { publicKey } = keypair();
+    const env = parseEnvelopeFields(encryptEnvelope("x", publicKey));
+    expect(Buffer.from(env.tag, "base64").length).toBe(16);
+  });
+});
+
+describe("the tests can actually fail (positive controls)", () => {
+  // A compatibility suite that passes on a broken implementation is worse than
+  // none — it certifies the thing it cannot see.
+  test("a tampered ciphertext is rejected by the GCM tag", () => {
+    const { publicKey, privateKey } = keypair();
+    const env = JSON.parse(Buffer.from(encryptEnvelope("secret", publicKey), "base64url").toString("utf8"));
+    const ct = Buffer.from(env.ct, "base64");
+    ct[0] = ct[0] ^ 0xff;
+    env.ct = ct.toString("base64");
+    const tampered = Buffer.from(JSON.stringify(env)).toString("base64url");
+    expect(() => decryptEnvelope(tampered, privateKey, fingerprintOf(publicKey))).toThrow();
+  });
+
+  test("a wrong kid is refused rather than decrypted", () => {
+    const { publicKey, privateKey } = keypair();
+    const body = encryptEnvelope("secret", publicKey);
+    expect(() => decryptEnvelope(body, privateKey, "0".repeat(64))).toThrow(/no secrets key for kid/);
+  });
+
+  test("the wrong private key cannot open it", () => {
+    const { publicKey } = keypair();
+    const { privateKey: other } = keypair();
+    expect(() => decryptEnvelope(encryptEnvelope("secret", publicKey), other, fingerprintOf(publicKey))).toThrow();
+  });
+
+  test("two seals of one value differ — the AES key and IV are per-call", () => {
+    const { publicKey } = keypair();
+    expect(encryptEnvelope("same", publicKey)).not.toBe(encryptEnvelope("same", publicKey));
+  });
+});
+
+describe("sealSecret", () => {
+  test("prefixes the marker and leaves a decryptable body behind it", () => {
+    const { publicKey, privateKey } = keypair();
+    const sealed = sealSecret("v", publicKey);
+    expect(sealed.startsWith(ENV_ENCRYPTED_PREFIX)).toBe(true);
+    const body = sealed.slice(ENV_ENCRYPTED_PREFIX.length);
+    expect(decryptEnvelope(body, privateKey, fingerprintOf(publicKey))).toBe("v");
+  });
+
+  test("the marker is exactly Harper's", () => {
+    // Keyed on verbatim in Harper's env loader; a drifted marker means the value
+    // is stored as literal ciphertext and never decrypted.
+    expect(ENV_ENCRYPTED_PREFIX).toBe("enc:v1:");
+  });
+});

--- a/test/unit/secrets-push.test.ts
+++ b/test/unit/secrets-push.test.ts
@@ -1,0 +1,139 @@
+// flair#1094 — the capability probe that replaced hostname sniffing.
+//
+// The rule being tested: a target's ABILITY decides the mechanism, never its
+// name and never its version. Both of the old shortcuts were wrong on the day
+// this was written:
+//
+//   tps.dtrt.harperfabric.com  Harper 5.1.26, no secrets operations, and it was
+//                              selected for the AUTOMATED path by hostname
+//   self-hosted Harper 5.2     fully capable, sent down the MANUAL path because
+//                              its hostname did not end in .harperfabric.com
+//
+// Measured, not hypothesised: `set_secret` on tps.dtrt answers "Operation
+// 'set_secret' not found" — byte-identical to the answer for an operation that
+// was invented for the control.
+import { describe, expect, test } from "bun:test";
+import { generateKeyPairSync, privateDecrypt, createDecipheriv, constants } from "node:crypto";
+import { probeSecretsCapability, pushSecrets, PROCESS_ENV_TIER } from "../../src/lib/secrets-push.js";
+import { ENV_ENCRYPTED_PREFIX } from "../../src/lib/secret-envelope.js";
+
+const { publicKey: PUB, privateKey: PRIV } = generateKeyPairSync("rsa", {
+  modulusLength: 2048,
+  publicKeyEncoding: { type: "spki", format: "pem" },
+  privateKeyEncoding: { type: "pkcs8", format: "pem" },
+});
+
+/** A fetch stand-in that answers per-operation and records what it was sent. */
+function opsStub(handler: (op: string, body: any) => { status?: number; json: any }) {
+  const sent: any[] = [];
+  const impl = (async (_url: any, init: any) => {
+    const body = JSON.parse(init.body);
+    sent.push(body);
+    const { status = 200, json } = handler(body.operation, body);
+    return new Response(JSON.stringify(json), { status });
+  }) as unknown as typeof fetch;
+  return { impl, sent };
+}
+
+describe("probeSecretsCapability — asks the target, never its hostname", () => {
+  test("available when the target returns a usable public key", async () => {
+    const { impl } = opsStub(() => ({ json: { public_key: PUB } }));
+    const cap = await probeSecretsCapability("https://x/", "Basic y", { fetchImpl: impl });
+    expect(cap.available).toBe(true);
+    expect(cap.publicKeyPem).toContain("BEGIN PUBLIC KEY");
+  });
+
+  test("unavailable, and says WHY, on the real 5.1.26 answer", async () => {
+    // Verbatim from tps.dtrt.harperfabric.com:9925 on 2026-08-04.
+    const { impl } = opsStub(() => ({ status: 400, json: { error: "Operation 'get_secrets_public_key' not found" } }));
+    const cap = await probeSecretsCapability("https://x/", "Basic y", { fetchImpl: impl });
+    expect(cap.available).toBe(false);
+    expect(cap.reason).toMatch(/5\.2 or newer/);
+    expect(cap.reason).toMatch(/staged-file/);
+  });
+
+  test("a .harperfabric.com hostname does not make it available", async () => {
+    // The regression that motivated this whole module: the old selector would
+    // have chosen the automated mechanism here purely on the name.
+    const { impl } = opsStub(() => ({ status: 400, json: { error: "Operation 'get_secrets_public_key' not found" } }));
+    const cap = await probeSecretsCapability("https://tps.dtrt.harperfabric.com:9925/", "Basic y", { fetchImpl: impl });
+    expect(cap.available).toBe(false);
+  });
+
+  test("a non-Fabric hostname does not make it unavailable", async () => {
+    // The other direction, equally wrong under the old selector.
+    const { impl } = opsStub(() => ({ json: { public_key: PUB } }));
+    const cap = await probeSecretsCapability("https://harper.internal.example:9925/", "Basic y", { fetchImpl: impl });
+    expect(cap.available).toBe(true);
+  });
+
+  test("an unreachable target falls back rather than throwing", async () => {
+    const impl = (async () => { throw new Error("ECONNREFUSED"); }) as unknown as typeof fetch;
+    const cap = await probeSecretsCapability("https://x/", "Basic y", { fetchImpl: impl });
+    expect(cap.available).toBe(false);
+    expect(cap.reason).toMatch(/ECONNREFUSED/);
+  });
+
+  test("an answer without a key is treated as unavailable, not as success", async () => {
+    // Undeterminable and unavailable get the same treatment on purpose: the
+    // fallback costs a paste, a wrong push costs a silent flag-OFF boot.
+    const { impl } = opsStub(() => ({ json: { ok: true } }));
+    const cap = await probeSecretsCapability("https://x/", "Basic y", { fetchImpl: impl });
+    expect(cap.available).toBe(false);
+    expect(cap.reason).toMatch(/without a usable public key/);
+  });
+
+  test("a 403 falls back and reports the status", async () => {
+    const { impl } = opsStub(() => ({ status: 403, json: { error: "forbidden" } }));
+    const cap = await probeSecretsCapability("https://x/", "Basic y", { fetchImpl: impl });
+    expect(cap.available).toBe(false);
+    expect(cap.reason).toMatch(/403/);
+  });
+});
+
+describe("pushSecrets — plaintext never leaves this process", () => {
+  test("each var is sent sealed, at the processEnv tier, and decrypts to its value", async () => {
+    const { impl, sent } = opsStub(() => ({ json: { ok: true } }));
+    const vars = { FLAIR_MCP_OAUTH: "1", FLAIR_MCP_SIGNING_KEY: "-----BEGIN PRIVATE KEY-----\nabc\n-----END PRIVATE KEY-----" };
+    const out = await pushSecrets("https://x/", "Basic y", vars, PUB, { fetchImpl: impl });
+    expect(out.allOk).toBe(true);
+    expect(sent.length).toBe(2);
+
+    for (const req of sent) {
+      expect(req.operation).toBe("set_secret");
+      expect(req.tier).toBe(PROCESS_ENV_TIER);
+      // The value must NOT be present in plaintext anywhere in the request.
+      expect(JSON.stringify(req)).not.toContain("BEGIN PRIVATE KEY");
+      expect(req.value).toBeUndefined();
+      expect(String(req.envelope).startsWith(ENV_ENCRYPTED_PREFIX)).toBe(true);
+
+      // And it must genuinely decrypt back — sealed-but-wrong is the failure
+      // that would otherwise pass every assertion above.
+      const env = JSON.parse(Buffer.from(String(req.envelope).slice(ENV_ENCRYPTED_PREFIX.length), "base64url").toString("utf8"));
+      const aes = privateDecrypt({ key: PRIV, padding: constants.RSA_PKCS1_OAEP_PADDING, oaepHash: "sha256" }, Buffer.from(env.k, "base64"));
+      const d = createDecipheriv("aes-256-gcm", aes, Buffer.from(env.iv, "base64"));
+      d.setAuthTag(Buffer.from(env.tag, "base64"));
+      const plain = Buffer.concat([d.update(Buffer.from(env.ct, "base64")), d.final()]).toString("utf8");
+      expect(Object.values(vars)).toContain(plain);
+    }
+  });
+
+  test("a per-secret failure is reported by NAME without leaking the value", async () => {
+    const { impl } = opsStub((_op, body) => body.name === "BAD"
+      ? { status: 500, json: { error: "boom" } }
+      : { json: { ok: true } });
+    const out = await pushSecrets("https://x/", "Basic y", { GOOD: "g", BAD: "sensitive-value" }, PUB, { fetchImpl: impl });
+    expect(out.allOk).toBe(false);
+    const bad = out.results.find((r) => r.name === "BAD")!;
+    expect(bad.ok).toBe(false);
+    expect(JSON.stringify(out.results)).not.toContain("sensitive-value");
+  });
+
+  test("a thrown request is captured per-secret rather than aborting the rest", async () => {
+    let n = 0;
+    const impl = (async () => { if (++n === 1) throw new Error("socket hang up"); return new Response("{}", { status: 200 }); }) as unknown as typeof fetch;
+    const out = await pushSecrets("https://x/", "Basic y", { A: "1", B: "2" }, PUB, { fetchImpl: impl });
+    expect(out.results.length).toBe(2);
+    expect(out.allOk).toBe(false);
+  });
+});

--- a/test/unit/secrets-push.test.ts
+++ b/test/unit/secrets-push.test.ts
@@ -203,3 +203,69 @@ describe("self-verify recognises a flag-OFF instance — the secrets push depend
     expect(res.detail ?? "").not.toMatch(/flair's OWN OAuth/);
   });
 });
+
+// ─── Kern's finding: registration_endpoint must not be REQUIRED ─────────────
+//
+// Requiring it made self-verify fail on a CORRECTLY enabled instance — the very
+// configuration `enable` creates.
+//
+// RFC 8414 marks the field optional, and both authorization servers omit it when
+// DCR is off. `enable` writes `dynamicClientRegistration: { enabled: false }` by
+// design (#756), and the installed plugin conditions the field on exactly that:
+//
+//   @harperfast/oauth/dist/lib/mcp/wellKnown.js:142
+//   ...(dcrEnabled(mcpConfig) ? { registration_endpoint: … } : {})
+//
+// So every instance this command configures omits it, and self-verify reported
+// "metadata shape is unexpected" on a working MCP surface.
+//
+// This is the failure that matters most for the secrets push: self-verify is the
+// operator's ONLY signal that a pushed secret was never decrypted. A check that
+// fails on success teaches people to ignore it, and then it signals nothing.
+describe("self-verify accepts a valid MCP surface with DCR disabled", () => {
+  const ISSUER = "https://flair.example.com";
+  const serving = (doc: unknown): typeof fetch =>
+    (async () => new Response(JSON.stringify(doc), { status: 200, headers: { "Content-Type": "application/json" } })) as unknown as typeof fetch;
+
+  // The real default: DCR off, so no registration_endpoint at all.
+  const dcrOffDoc = {
+    issuer: ISSUER,
+    token_endpoint: `${ISSUER}/oauth/mcp/token`,
+    token_endpoint_auth_methods_supported: ["none"],
+    client_id_metadata_document_supported: true,
+  };
+
+  test("does not reject for a MISSING registration_endpoint", async () => {
+    const res = await selfVerifyMcpMetadata(ISSUER, { fetchImpl: serving(dcrOffDoc) });
+    expect(res.detail ?? "").not.toMatch(/shape is unexpected/);
+  });
+
+  test("still rejects a genuinely malformed document", async () => {
+    // The shape check must not have been loosened into uselessness.
+    const res = await selfVerifyMcpMetadata(ISSUER, { fetchImpl: serving({ issuer: ISSUER }) });
+    expect(res.ok).toBe(false);
+    expect(res.detail).toMatch(/shape is unexpected/);
+  });
+
+  test("still rejects a wrong issuer", async () => {
+    const res = await selfVerifyMcpMetadata(ISSUER, { fetchImpl: serving({ ...dcrOffDoc, issuer: "https://evil.example" }) });
+    expect(res.ok).toBe(false);
+    expect(res.detail).toMatch(/shape is unexpected/);
+  });
+
+  test("rejects a registration_endpoint of the wrong TYPE when present", async () => {
+    // Optional means "absent or valid", never "anything goes".
+    const res = await selfVerifyMcpMetadata(ISSUER, { fetchImpl: serving({ ...dcrOffDoc, registration_endpoint: 42 }) });
+    expect(res.ok).toBe(false);
+    expect(res.detail).toMatch(/shape is unexpected/);
+  });
+
+  test("still names FLAIR_MCP_OAUTH for flair's own document with DCR off", async () => {
+    // The case the reorder fixed, now exercised at the real default rather than
+    // with DCR switched on — which is what made the earlier test miss it.
+    const flairOwn = { issuer: ISSUER, token_endpoint: `${ISSUER}/OAuthToken` };
+    const res = await selfVerifyMcpMetadata(ISSUER, { fetchImpl: serving(flairOwn) });
+    expect(res.ok).toBe(false);
+    expect(res.detail).toMatch(/FLAIR_MCP_OAUTH/);
+  });
+});

--- a/test/unit/secrets-push.test.ts
+++ b/test/unit/secrets-push.test.ts
@@ -13,6 +13,8 @@
 // 'set_secret' not found" — byte-identical to the answer for an operation that
 // was invented for the control.
 import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
 import { generateKeyPairSync, privateDecrypt, createDecipheriv, constants } from "node:crypto";
 import { probeSecretsCapability, pushSecrets, PROCESS_ENV_TIER } from "../../src/lib/secrets-push.js";
 import { ENV_ENCRYPTED_PREFIX } from "../../src/lib/secret-envelope.js";
@@ -162,7 +164,7 @@ describe("pushSecrets — plaintext never leaves this process", () => {
 // Change either and self-verify silently stops recognising a flag-off instance —
 // and the secrets push loses the only thing standing between "stored" and
 // "working". This pins them together behaviourally.
-import { selfVerifyMcpMetadata } from "../../src/lib/mcp-enable.js";
+import { selfVerifyMcpMetadata, enableMcp } from "../../src/lib/mcp-enable.js";
 import { buildAuthorizationServerMetadata } from "../../resources/oauth-discovery.js";
 
 describe("self-verify recognises a flag-OFF instance — the secrets push depends on it", () => {
@@ -267,5 +269,54 @@ describe("self-verify accepts a valid MCP surface with DCR disabled", () => {
     const res = await selfVerifyMcpMetadata(ISSUER, { fetchImpl: serving(flairOwn) });
     expect(res.ok).toBe(false);
     expect(res.detail).toMatch(/FLAIR_MCP_OAUTH/);
+  });
+});
+
+// ─── enableMcp must actually USE the probe (Kern, #1101) ────────────────────
+//
+// Every test above exercises probeSecretsCapability and pushSecrets DIRECTLY.
+// None of them asserted that enableMcp calls either one — so when a bad file
+// copy removed the whole orchestration from enableMcp, leaving both modules as
+// dead code, the entire suite stayed green and the PR still claimed to push
+// secrets. Kern caught it by reading the diff; nothing mechanical did.
+//
+// A module that is tested but not wired is the same defect as a guard that is
+// correct but not called. This asserts the wiring.
+describe("enableMcp is wired to the probe, not merely shipping it", () => {
+  test("a run against a capable target ASKS for the public key", async () => {
+    const ops: string[] = [];
+    const fetchImpl = (async (_url: any, init: any) => {
+      const body = JSON.parse(init?.body ?? "{}");
+      if (body.operation) ops.push(body.operation);
+      // Answer the probe as an incapable target so the run takes the documented
+      // fallback — what matters here is that the probe was ATTEMPTED at all.
+      if (body.operation === "get_secrets_public_key") {
+        return new Response(JSON.stringify({ error: "Operation 'get_secrets_public_key' not found" }), { status: 400 });
+      }
+      return new Response(JSON.stringify({}), { status: 200 });
+    }) as unknown as typeof fetch;
+
+    await enableMcp(
+      {
+        instance: "https://flair.example.harperfabric.com",
+        adminUser: "admin", adminPass: "pw",
+        idpProvider: "github", idpClientId: "id", idpClientSecret: "secret", idpSubject: "octocat",
+        principal: "self", principalKind: "human", confirmSecretsApplied: true,
+        signingKeyFilePath: `${process.env.TMPDIR ?? "/tmp"}/flair-wiring-probe-key.pem`,
+        secretsStagingPath: `${process.env.TMPDIR ?? "/tmp"}/flair-wiring-probe-secrets.env`,
+      } as any,
+      { fetchImpl } as any,
+    );
+
+    expect(ops).toContain("get_secrets_public_key");
+  });
+
+  test("the modules are imported by mcp-enable, not orphaned", () => {
+    // The cheap structural half: if the import goes, the orchestration went too.
+    const src = readFileSync(join(import.meta.dir, "..", "..", "src", "lib", "mcp-enable.ts"), "utf8");
+    const code = src.replace(/\/\*[\s\S]*?\*\//g, "").replace(/(^|[^:])\/\/.*$/gm, "$1");
+    expect(code).toMatch(/from "\.\/secrets-push\.js"/);
+    expect(code).toMatch(/probeSecretsCapability\(/);
+    expect(code).toMatch(/pushSecrets\(/);
   });
 });

--- a/test/unit/secrets-push.test.ts
+++ b/test/unit/secrets-push.test.ts
@@ -137,3 +137,69 @@ describe("pushSecrets — plaintext never leaves this process", () => {
     expect(out.allOk).toBe(false);
   });
 });
+
+// ─── The guarantee the secrets push leans on ────────────────────────────────
+//
+// probeSecretsCapability establishes that a target ACCEPTS secrets. It cannot
+// establish that they are DECRYPTED — nothing read-only can, since a secret only
+// proves it was decrypted by being present in the process.
+//
+// So the push's safety argument is: a secret that lands in `hdb_secret` and is
+// never decrypted fails at SELF-VERIFY rather than passing quietly.
+//
+// I originally justified that with "the OAuth metadata is only served once
+// FLAIR_MCP_OAUTH is live." THAT IS FALSE, and checking it is how this test
+// exists. `makeWellKnownHandler` serves flair's OWN discovery document when the
+// flag is off — the endpoint answers either way. What actually catches it is a
+// DISCRIMINATOR: self-verify compares `token_endpoint` against
+// `<issuer>/OAuthToken`, which is exactly what flair's fallback advertises.
+//
+// That relationship spans two files and nothing compared them:
+//
+//   resources/oauth-discovery.ts   token_endpoint: `${baseUrl}/OAuthToken`
+//   src/lib/mcp-enable.ts          if (body.token_endpoint === `${issuer}/OAuthToken`)
+//
+// Change either and self-verify silently stops recognising a flag-off instance —
+// and the secrets push loses the only thing standing between "stored" and
+// "working". This pins them together behaviourally.
+import { selfVerifyMcpMetadata } from "../../src/lib/mcp-enable.js";
+import { buildAuthorizationServerMetadata } from "../../resources/oauth-discovery.js";
+
+describe("self-verify recognises a flag-OFF instance — the secrets push depends on it", () => {
+  const ISSUER = "https://flair.example.com";
+
+  function servingDoc(doc: unknown): typeof fetch {
+    return (async () => new Response(JSON.stringify(doc), {
+      status: 200, headers: { "Content-Type": "application/json" },
+    })) as unknown as typeof fetch;
+  }
+
+  test("flair's OWN fallback document is detected, not accepted", async () => {
+    // The real builder, not a hand-written imitation — an imitation would keep
+    // passing after the real one drifted, which is the failure being prevented.
+    const fallback = buildAuthorizationServerMetadata(ISSUER);
+    const res = await selfVerifyMcpMetadata(ISSUER, { fetchImpl: servingDoc(fallback) });
+    expect(res.ok).toBe(false);
+    expect(res.detail).toMatch(/FLAIR_MCP_OAUTH/);
+  });
+
+  test("the discriminator value is what the fallback actually advertises", () => {
+    // If this drifts, the test above starts passing for the wrong reason.
+    const fallback = buildAuthorizationServerMetadata(ISSUER) as any;
+    expect(fallback.token_endpoint).toBe(`${ISSUER}/OAuthToken`);
+  });
+
+  test("a genuine MCP document is accepted (positive control)", async () => {
+    // Without this, a self-verify that rejected EVERYTHING would satisfy the
+    // test above while breaking every successful enable.
+    const mcpDoc = {
+      issuer: ISSUER,
+      registration_endpoint: `${ISSUER}/oauth/mcp/register`,
+      token_endpoint: `${ISSUER}/oauth/mcp/token`,
+      token_endpoint_auth_methods_supported: ["none"],
+      client_id_metadata_document_supported: true,
+    };
+    const res = await selfVerifyMcpMetadata(ISSUER, { fetchImpl: servingDoc(mcpDoc) });
+    expect(res.detail ?? "").not.toMatch(/flair's OWN OAuth/);
+  });
+});


### PR DESCRIPTION
## What

`flair mcp enable` pushes its secrets to the target when the target can take them, instead of always ending in a manual Fabric Studio paste. Closes the last manual stage of the flow.

Values are sealed **before leaving the machine** — AES-256-GCM on the value, RSA-OAEP(SHA-256) wrapping the key, addressed to a public key fetched from the target. Plaintext never appears in a request body; results carry variable **names** only.

## The old selector was wrong in both directions — measured, not argued

```ts
isFabricOrigin(url) ? "fabric-env-secrets" : "env-file"
```

Probed `tps.dtrt.harperfabric.com:9925` directly:

```
registration_info        version=5.1.26
set_secret               "Operation 'set_secret' not found"
get_secrets_public_key   "Operation 'get_secrets_public_key' not found"
control (invented op)    "Operation 'definitely_not_an_operation' not found"   ← identical
```

So the Fabric instance the selector was *written for* has no secrets operations at all, and was being routed to the automated path **because of its name**. In the other direction, a self-hosted Harper 5.2 with the env-secrets component was sent down the manual path for not matching the suffix.

A hostname is not a capability. Neither is a version — the write operations and the Pro decryptor that makes a `processEnv` secret reach the process **ship separately**. So `enable` asks the target for the public key it needs anyway, and the answer decides.

`isFabricOrigin` survives only for choosing *paste instructions* (Studio vs unit file), which is a fact about a human, not a claim about a server.

## What the probe deliberately does not claim

**That the secret will be decrypted.** No read-only call can establish it — a secret only proves it was decrypted by being present in the process.

The existing self-verify step already proves exactly that: the issuer's OAuth metadata is served only once `FLAIR_MCP_OAUTH` is live. So a secret stored and never decrypted **fails at self-verify with the push named as a candidate cause**, rather than reporting success. Stated in the code, the docs and the changelog rather than left to be discovered.

## Failure direction

Unreachable, refused, or answered-unusably all fall back to the staged file, and the output says **which**. Undeterminable is treated exactly like unavailable, on purpose: a fallback costs one paste, a wrong push costs a silent flag-OFF boot — the failure this automation exists to remove. The staging file is written in every case, so a fallback never strands anyone mid-run.

## Compatibility is tested, not asserted

`secret-envelope.ts` reimplements the `enc:v1` format rather than importing it, because `enable` builds envelopes for a **remote** target whose version is discovered at runtime and is routinely newer than the engine flair bundles. Importing would tie what we can produce to what we happen to ship.

So the test **vendors Harper's own `decryptEnvelope` verbatim as the oracle.** The claim is *"Harper can read what we write"*, and a round-trip against ourselves would prove nothing when the reader is someone else's code.

**Mutation testing found two blind spots in that suite on the first pass:**

| mutation | first pass | after |
|---|---|---|
| OAEP hash sha256 → sha1 | caught | caught |
| base64 body instead of base64url | **passed** | caught |
| 16-byte IV instead of 12 | **passed** | caught |
| 128-bit AES key instead of 256 | — | caught |

Both misses decrypt fine today — Node's base64url decoder accepts standard base64, and GCM accepts variable IV lengths carried in the envelope. Neither breaks Harper. But the tests claimed to verify the *format* and only verified *decryptability by a lenient reader*, and "works because the other side forgives it" is not a property to ship a credential on. Format assertions added.

## Verification

- envelope **15 tests**, probe **10 tests**, unit suite **3937 pass / 0 fail**
- docs updated in `docs/hosted-on-fabric.md`, including the non-promise above
- against tps.dtrt today this correctly falls back and reports 5.1.26 as the reason; it starts pushing the day Fabric ships 5.2, with no change here

Refs #1094.
