### PR TITLE
chore(test): reap orphaned Harper instances so a failed setup cannot leak 3GB

### DIFF
--- a/test/helpers/harper-lifecycle.ts
+++ b/test/helpers/harper-lifecycle.ts
@@ -79,35 +79,30 @@ function installExitHook(): void {
   if (exitHookInstalled) return;
   exitHookInstalled = true;
   process.on("exit", reapLiveInstances);
-  // A signalled run must not skip the reap. Re-raise after cleaning so the exit
-  // code still reflects the signal rather than being swallowed.
+  // ── NO SIGNAL HANDLERS HERE. This is deliberate. ──────────────────────────
   //
-  // The listener MUST be removed before re-raising. Registering a handler for
-  // SIGINT/SIGTERM/SIGHUP replaces Node's default action (terminate), so
-  // re-raising while still registered re-enters this handler — forever. The
-  // process then survives the signal it was told to die on.
+  // A signal handler looked obviously right: an interrupted run should still
+  // reap, and CI cancellation IS SIGTERM, so without one every cancelled run
+  // leaks the original 27 GB incident again. Kern reviewed that reasoning and
+  // agreed. We were both wrong, and the evidence is unambiguous.
   //
-  // That is not theoretical: the first version of this hung CI's Integration
-  // Tests for 35 minutes against a ~15 minute norm, until the runner hard-killed
-  // it. And it broke the case this hook exists for — Ctrl-C would no longer stop
-  // a test run. Verified both ways in isolation: re-raising while registered
-  // loops indefinitely; removing the listener first exits 143, terminated by the
-  // signal, which is what a caller expects to see.
+  // test/integration/federation-watch.test.ts SIGTERMs the TEST RUNNER ITSELF,
+  // three times, as its fixture — and says so at line 74: "This sends SIGTERM to
+  // the test-runner process itself." A global handler here intercepts that,
+  // re-raises, and kills the run. Measured: the suite died after 53 of 58 files
+  // with exit 143, in federation-watch, on a lane that is otherwise green and
+  // where `exit code 143` appears zero times.
   //
-  // Kern's review note: removeAllListeners(sig) would drop EVERY listener for
-  // that signal, not just this one — so anything else registering its own
-  // cleanup (bun, a future harness, a library) would silently lose it and the
-  // re-raise would terminate before it ran. He suggested documenting that.
-  // Removing only our own handler is strictly better than a comment about the
-  // hazard, and costs one named reference.
-  for (const sig of ["SIGINT", "SIGTERM", "SIGHUP"] as const) {
-    const onSignal = () => {
-      reapLiveInstances();
-      process.off(sig, onSignal);
-      process.kill(process.pid, sig);
-    };
-    process.on(sig, onSignal);
-  }
+  // So this harness cannot own a process-wide signal handler: its own tests use
+  // signals as data. Any handler is either wrong for them or useless for us, and
+  // "wrong for them" is silent — it truncates a suite rather than failing a test.
+  //
+  // What is left: the exit hook, which covers clean exits including a suite that
+  // finishes with instances still tracked. An interrupted or cancelled run will
+  // leak, and that is the accepted cost. countStaleHarperTrees() makes the leak
+  // visible on the NEXT run instead of at 0 bytes free, which is the property
+  // that actually mattered — the incident was invisible for four days, not
+  // uncleaned for four days.
 }
 
 /**

--- a/test/helpers/harper-lifecycle.ts
+++ b/test/helpers/harper-lifecycle.ts
@@ -81,9 +81,22 @@ function installExitHook(): void {
   process.on("exit", reapLiveInstances);
   // A signalled run must not skip the reap. Re-raise after cleaning so the exit
   // code still reflects the signal rather than being swallowed.
+  //
+  // The listener MUST be removed before re-raising. Registering a handler for
+  // SIGINT/SIGTERM/SIGHUP replaces Node's default action (terminate), so
+  // re-raising while still registered re-enters this handler — forever. The
+  // process then survives the signal it was told to die on.
+  //
+  // That is not theoretical: the first version of this hung CI's Integration
+  // Tests for 35 minutes against a ~15 minute norm, until the runner hard-killed
+  // it. And it broke the case this hook exists for — Ctrl-C would no longer stop
+  // a test run. Verified both ways in isolation: re-raising while registered
+  // loops indefinitely; removing the listener first exits 143, terminated by the
+  // signal, which is what a caller expects to see.
   for (const sig of ["SIGINT", "SIGTERM", "SIGHUP"] as const) {
     process.on(sig, () => {
       reapLiveInstances();
+      process.removeAllListeners(sig);
       process.kill(process.pid, sig);
     });
   }

--- a/test/helpers/harper-lifecycle.ts
+++ b/test/helpers/harper-lifecycle.ts
@@ -1,4 +1,4 @@
-import { spawn, ChildProcess } from "node:child_process";
+import { spawn, execFileSync, ChildProcess } from "node:child_process";
 import { createServer } from "node:net";
 import type { AddressInfo, Server } from "node:net";
 import { mkdtemp, rm } from "node:fs/promises";
@@ -27,9 +27,45 @@ import { join } from "node:path";
 const LIVE_INSTANCES = new Set<{ pid?: number; installDir?: string; owns: boolean }>();
 let exitHookInstalled = false;
 
+/**
+ * Is `pid` still a direct child of this process?
+ *
+ * The reaper's one real hazard is pid REUSE: a tracked Harper dies on its own,
+ * the OS reuses its pid, and the exit hook SIGKILLs whatever now holds it.
+ * Sherlock found that window on review and judged it acceptable because "the
+ * blast radius is a test runner process on a dev machine."
+ *
+ * That is true in general and FALSE HERE. rockit runs production Flair
+ * (~/flair-prod, serving :9926) alongside these tests. A wrong kill on this
+ * machine can hit production — which is exactly the July 2026 incident, where a
+ * `pkill -f harper` took prod down. Rebuilding that with better manners is still
+ * rebuilding it.
+ *
+ * A spawned Harper is our CHILD. Production is not, and neither is any unrelated
+ * process that inherits a recycled pid. Checking parentage costs one `ps` at
+ * exit and turns "kill whatever holds this pid" into "kill it only if it is
+ * still the child we started".
+ *
+ * Not atomic — the pid could in principle be reused between this check and the
+ * kill — but it removes the entire class of victim that matters, since nothing
+ * we did not spawn is ever our child. Fails CLOSED: if parentage cannot be
+ * determined, the process is left alone and the tree is left behind. A leaked
+ * directory is recoverable; a killed production instance is not.
+ */
+function isOwnChild(pid: number): boolean {
+  try {
+    const out = execFileSync("ps", ["-o", "ppid=", "-p", String(pid)], {
+      encoding: "utf-8", timeout: 2000, stdio: ["ignore", "pipe", "ignore"],
+    });
+    return Number(out.trim()) === process.pid;
+  } catch {
+    return false; // gone, or unknowable — either way, do not kill it
+  }
+}
+
 function reapLiveInstances(): void {
   for (const inst of LIVE_INSTANCES) {
-    if (inst.pid) {
+    if (inst.pid && isOwnChild(inst.pid)) {
       try { process.kill(inst.pid, "SIGKILL"); } catch { /* already gone */ }
     }
     if (inst.installDir && inst.owns) {

--- a/test/helpers/harper-lifecycle.ts
+++ b/test/helpers/harper-lifecycle.ts
@@ -93,12 +93,20 @@ function installExitHook(): void {
   // a test run. Verified both ways in isolation: re-raising while registered
   // loops indefinitely; removing the listener first exits 143, terminated by the
   // signal, which is what a caller expects to see.
+  //
+  // Kern's review note: removeAllListeners(sig) would drop EVERY listener for
+  // that signal, not just this one — so anything else registering its own
+  // cleanup (bun, a future harness, a library) would silently lose it and the
+  // re-raise would terminate before it ran. He suggested documenting that.
+  // Removing only our own handler is strictly better than a comment about the
+  // hazard, and costs one named reference.
   for (const sig of ["SIGINT", "SIGTERM", "SIGHUP"] as const) {
-    process.on(sig, () => {
+    const onSignal = () => {
       reapLiveInstances();
-      process.removeAllListeners(sig);
+      process.off(sig, onSignal);
       process.kill(process.pid, sig);
-    });
+    };
+    process.on(sig, onSignal);
   }
 }
 

--- a/test/helpers/harper-lifecycle.ts
+++ b/test/helpers/harper-lifecycle.ts
@@ -2,9 +2,71 @@ import { spawn, ChildProcess } from "node:child_process";
 import { createServer } from "node:net";
 import type { AddressInfo, Server } from "node:net";
 import { mkdtemp, rm } from "node:fs/promises";
-import { existsSync } from "node:fs";
+import { existsSync, rmSync, readdirSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+
+// ─── Leak backstop: clean up even when the test framework never gets to ──────
+//
+// `stopHarper` is correct when it is CALLED. The leak is that it often is not:
+// if a `beforeAll` throws or times out, `afterAll` does not run, and the spawned
+// Harper survives holding its ~3 GB install tree open.
+//
+// Measured on rockit 2026-08-05, after a night of integration runs: NINE orphaned
+// `flair-test-*` trees totalling 27 GB, held open by four abandoned `harper dev`
+// processes — two of them FOUR DAYS old. The disk hit 0 bytes and no command
+// could run at all, because every tool needs to write before it executes.
+//
+// Deleting the directories alone would not have helped: a file held open by a
+// live process does not return its blocks. The process has to die first, which
+// is why this tracks processes rather than just paths.
+//
+// So: every instance registers here on spawn and deregisters on clean stop, and
+// a process-exit hook kills whatever is left. Exit handlers must be SYNCHRONOUS,
+// hence `process.kill` + `rmSync` rather than the async paths `stopHarper` uses.
+const LIVE_INSTANCES = new Set<{ pid?: number; installDir?: string; owns: boolean }>();
+let exitHookInstalled = false;
+
+function reapLiveInstances(): void {
+  for (const inst of LIVE_INSTANCES) {
+    if (inst.pid) {
+      try { process.kill(inst.pid, "SIGKILL"); } catch { /* already gone */ }
+    }
+    if (inst.installDir && inst.owns) {
+      try { rmSync(inst.installDir, { recursive: true, force: true, maxRetries: 2 }); } catch { /* best effort */ }
+    }
+  }
+  LIVE_INSTANCES.clear();
+}
+
+function installExitHook(): void {
+  if (exitHookInstalled) return;
+  exitHookInstalled = true;
+  process.on("exit", reapLiveInstances);
+  // A signalled run must not skip the reap. Re-raise after cleaning so the exit
+  // code still reflects the signal rather than being swallowed.
+  for (const sig of ["SIGINT", "SIGTERM", "SIGHUP"] as const) {
+    process.on(sig, () => {
+      reapLiveInstances();
+      process.kill(process.pid, sig);
+    });
+  }
+}
+
+/**
+ * How many abandoned `flair-test-*` trees are sitting in the temp dir.
+ *
+ * Surfaced so a leak fails a TEST rather than a machine three hours later. The
+ * incident above was invisible until the disk was full: nothing counted, so
+ * nothing complained, and the only signal was every command failing at once.
+ */
+export function countStaleHarperTrees(): number {
+  try {
+    return readdirSync(tmpdir()).filter((n) => n.startsWith("flair-test-")).length;
+  } catch {
+    return 0;
+  }
+}
 
 const STARTUP_TIMEOUT_MS = 45_000;
 const MAX_SPAWN_ATTEMPTS = 3;
@@ -60,6 +122,9 @@ export interface HarperInstance {
    * test) is the caller's to clean up.
    */
   ownsInstallDir: boolean;
+  /** Internal: the leak-backstop registry entry, so stopHarper can deregister
+   *  by identity. Absent for external instances, which own nothing. */
+  __tracked?: { pid?: number; installDir?: string; owns: boolean };
 }
 
 interface HarperExit { code: number | null; signal: NodeJS.Signals | null }
@@ -345,7 +410,19 @@ export async function startHarper(opts: StartHarperOptions = {}): Promise<Harper
         waitForHealth(httpURL, 60_000, () => exited, () => log),
         waitForHealth(opsURL, 60_000, () => exited, () => log),
       ]);
-      return { httpURL, opsURL, installDir, process: proc, admin: { username: "admin", password: "test123" }, external: false, ownsInstallDir };
+      // Register BEFORE returning. If a caller's beforeAll times out between
+      // here and its afterAll, the exit hook is the only thing that reaps this.
+      installExitHook();
+      const tracked = { pid: proc.pid, installDir, owns: ownsInstallDir };
+      LIVE_INSTANCES.add(tracked);
+      return {
+        httpURL, opsURL, installDir, process: proc,
+        admin: { username: "admin", password: "test123" },
+        external: false, ownsInstallDir,
+        // Carried so stopHarper can deregister the exact entry rather than
+        // searching by pid — a pid can be reused, an object identity cannot.
+        __tracked: tracked,
+      } as HarperInstance;
     } catch (err) {
       await killProcess(proc);
       lastErr = err as Error;
@@ -371,6 +448,10 @@ export interface StopHarperOptions {
 
 export async function stopHarper(inst: HarperInstance, opts: StopHarperOptions = {}): Promise<void> {
   if (inst.external) return;
+
+  // Deregister first: a clean stop must not leave the exit hook holding a stale
+  // entry that would SIGKILL a reused pid later.
+  if (inst.__tracked) LIVE_INSTANCES.delete(inst.__tracked);
 
   if (inst.process) await killProcess(inst.process);
   // Never remove a directory this instance didn't create (ownsInstallDir

--- a/test/unit/harper-lifecycle-leak-backstop.test.ts
+++ b/test/unit/harper-lifecycle-leak-backstop.test.ts
@@ -45,10 +45,10 @@ describe("the backstop is wired, not merely defined", () => {
     expect(CODE).toMatch(/LIVE_INSTANCES\.delete\(inst\.__tracked\)/);
   });
 
-  test("the exit hook covers signals, not just a clean exit", () => {
-    // `bun test` interrupted, or a CI runner cancelling the job, is exactly when
-    // a leak is most likely — an exit-only hook would miss all of it.
-    for (const sig of ["SIGINT", "SIGTERM", "SIGHUP"]) expect(CODE).toContain(sig);
+  test("the exit hook is installed for clean exits", () => {
+    // Signals are deliberately NOT handled — see the no-signal-handlers block
+    // below. federation-watch.test.ts SIGTERMs the runner as its fixture, so a
+    // handler here truncates the suite instead of protecting it.
     expect(CODE).toMatch(/process\.on\("exit", reapLiveInstances\)/);
   });
 
@@ -142,56 +142,29 @@ describe("the reaper kills only its own children", () => {
   });
 });
 
-// ─── The signal handler must not survive its own signal ─────────────────────
+// ─── No signal handlers: the harness must not intercept its own fixtures ────
 //
-// Registering a handler for SIGINT/SIGTERM/SIGHUP REPLACES Node's default
-// action (terminate). Re-raising while the listener is still registered
-// re-enters the handler forever, and the process survives the signal it was
-// told to die on.
+// An earlier version registered SIGINT/SIGTERM/SIGHUP so an interrupted run
+// would still reap. It broke the suite: federation-watch.test.ts SIGTERMs the
+// TEST RUNNER ITSELF as its fixture (its own comment says so), a global handler
+// intercepted that, and the run died after 53 of 58 files with exit 143.
 //
-// The first version of this hook did exactly that. It hung CI's Integration
-// Tests for 35 minutes against a ~15 minute norm until the runner hard-killed
-// the job — and it broke the very case the hook exists for, since Ctrl-C would
-// no longer stop a test run.
-//
-// Verified in isolation both ways: re-raising while registered loops
-// indefinitely; removing the listener first exits 143 (terminated by SIGTERM).
-describe("the signal handler removes its listener before re-raising", () => {
+// A handler here is either wrong for those tests or useless for us, and "wrong"
+// is silent — it truncates a suite rather than failing a test. So the exit hook
+// stands alone and interrupted runs are allowed to leak, with
+// countStaleHarperTrees making that visible on the next run.
+describe("the harness registers no process-wide signal handlers", () => {
   const CODE = readFileSync(join(import.meta.dir, "..", "helpers", "harper-lifecycle.ts"), "utf8")
     .replace(/\/\*[\s\S]*?\*\//g, "").replace(/(^|[^:])\/\/.*$/gm, "$1");
 
-  test("removeAllListeners precedes the re-raise", () => {
-    const hook = CODE.slice(CODE.indexOf("function installExitHook"), CODE.indexOf("export function countStaleHarperTrees"));
-    const remove = hook.indexOf("process.off(sig, onSignal)");
-    const raise = hook.indexOf("process.kill(process.pid, sig)");
-    expect(remove).toBeGreaterThan(-1);
-    // Targeted removal, not removeAllListeners — see the note at the handler.
-    expect(hook).not.toContain("removeAllListeners");
-    expect(raise).toBeGreaterThan(-1);
-    expect(remove).toBeLessThan(raise);
+  test("no process.on for SIGINT/SIGTERM/SIGHUP", () => {
+    // federation-watch.test.ts signals the runner deliberately. Anything we
+    // register here changes what that fixture does.
+    expect(CODE).not.toMatch(/process\.on\(\s*["']SIG/);
+    expect(CODE).not.toMatch(/for \(const sig of/);
   });
 
-  test("the reap still happens before either", () => {
-    // Order is reap -> deregister handler -> re-raise. Removing the listener
-    // first would be safe but would skip the cleanup this hook exists for.
-    const hook = CODE.slice(CODE.indexOf("function installExitHook"), CODE.indexOf("export function countStaleHarperTrees"));
-    expect(hook.indexOf("reapLiveInstances()")).toBeLessThan(hook.indexOf("process.off(sig, onSignal)"));
-  });
-
-  test("a re-raise-while-registered pattern loops — the property being avoided", async () => {
-    // Behavioural proof rather than a claim about Node's semantics, run in a
-    // child so it cannot take this suite down.
-    const { spawnSync } = await import("node:child_process");
-    const script = [
-      "let n=0;",
-      "process.on('SIGTERM',()=>{n++;if(n>4){console.log('LOOP');process.exit(9);}process.kill(process.pid,'SIGTERM');});",
-      "setTimeout(()=>{console.log('NOLOOP');process.exit(0);},800);",
-      "process.kill(process.pid,'SIGTERM');",
-    ].join("");
-    // spawnSync, not execFileSync: the loop path exits 9, and execFileSync
-    // throws on a non-zero exit before the output can be read — which would
-    // fail this test for the wrong reason.
-    const r = spawnSync(process.execPath, ["-e", script], { encoding: "utf-8", timeout: 15000 });
-    expect(String(r.stdout)).toContain("LOOP");
+  test("the exit hook is still installed — clean exits must still reap", () => {
+    expect(CODE).toMatch(/process\.on\("exit", reapLiveInstances\)/);
   });
 });

--- a/test/unit/harper-lifecycle-leak-backstop.test.ts
+++ b/test/unit/harper-lifecycle-leak-backstop.test.ts
@@ -101,3 +101,43 @@ describe("countStaleHarperTrees — so a leak is visible before the disk is gone
     }
   });
 });
+
+// ─── The pid-reuse guard Sherlock's review surfaced ─────────────────────────
+//
+// He found the window and judged it acceptable because "the blast radius is a
+// test runner process on a dev machine." True in general, FALSE on rockit: this
+// machine also runs production Flair (~/flair-prod, :9926). A reused pid here
+// could be prod — which is the July 2026 `pkill -f harper` incident with better
+// manners.
+//
+// So the reaper now kills only processes that are still OUR CHILD. Production is
+// not our child; neither is anything that inherited a recycled pid.
+describe("the reaper kills only its own children", () => {
+  const CODE = readFileSync(join(import.meta.dir, "..", "helpers", "harper-lifecycle.ts"), "utf8")
+    .replace(/\/\*[\s\S]*?\*\//g, "").replace(/(^|[^:])\/\/.*$/gm, "$1");
+
+  test("SIGKILL is gated on parentage, not on the pid alone", () => {
+    expect(CODE).toMatch(/if \(inst\.pid && isOwnChild\(inst\.pid\)\)/);
+  });
+
+  test("the parentage check fails CLOSED", () => {
+    // An unknowable pid must be left alone. A leaked directory is recoverable;
+    // a killed production instance is not.
+    const fn = CODE.slice(CODE.indexOf("function isOwnChild"), CODE.indexOf("function reapLiveInstances"));
+    expect(fn).toMatch(/catch\s*\{\s*return false/);
+  });
+
+  test("it compares against THIS process, not a hardcoded parent", () => {
+    const fn = CODE.slice(CODE.indexOf("function isOwnChild"), CODE.indexOf("function reapLiveInstances"));
+    expect(fn).toMatch(/=== process\.pid/);
+  });
+
+  test("stopHarper deregisters BEFORE it kills", () => {
+    // Sherlock noted the original tests asserted deregistration existed but not
+    // its ordering. If the kill came first, a pid could be reused in the gap
+    // while the entry was still tracked.
+    const fn = CODE.slice(CODE.indexOf("export async function stopHarper"));
+    const body = fn.slice(0, fn.indexOf("\n}"));
+    expect(body.indexOf("LIVE_INSTANCES.delete")).toBeLessThan(body.indexOf("killProcess"));
+  });
+});

--- a/test/unit/harper-lifecycle-leak-backstop.test.ts
+++ b/test/unit/harper-lifecycle-leak-backstop.test.ts
@@ -1,0 +1,103 @@
+// The leak backstop in test/helpers/harper-lifecycle.ts.
+//
+// WHY IT EXISTS, measured on rockit 2026-08-05: after a night of integration
+// runs, NINE orphaned `flair-test-*` trees totalling 27 GB, held open by four
+// abandoned `harper dev` processes — two of them four days old. The disk reached
+// zero bytes and NO command could run at all, because every tool writes an output
+// file before it executes.
+//
+// `stopHarper` was never wrong. It simply was not called: when a `beforeAll`
+// throws or times out, `afterAll` does not run, and the spawned Harper survives
+// holding its install tree open. Deleting the directories would not have helped
+// on its own — a file held open by a live process does not return its blocks.
+//
+// These are structural checks. The behavioural one (spawn a Harper, kill the
+// runner, assert nothing survives) needs a live Harper and belongs in the
+// integration lane; what is asserted here is that the mechanism is WIRED, which
+// is the half that silently rots.
+import { describe, expect, test } from "bun:test";
+import { readFileSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { countStaleHarperTrees } from "../helpers/harper-lifecycle.js";
+
+const SRC = readFileSync(join(import.meta.dir, "..", "helpers", "harper-lifecycle.ts"), "utf8");
+
+// Scan code, not prose — this file's own comments name every identifier below,
+// and a raw scan would pass on a file that had none of them.
+const CODE = SRC.replace(/\/\*[\s\S]*?\*\//g, "").replace(/(^|[^:])\/\/.*$/gm, "$1");
+
+describe("the backstop is wired, not merely defined", () => {
+  test("startHarper registers the instance before returning", () => {
+    // Registration must happen on the success path. A backstop that only runs
+    // when startHarper THROWS misses the case that actually leaked: a successful
+    // start followed by a beforeAll timeout somewhere else.
+    expect(CODE).toMatch(/LIVE_INSTANCES\.add\(/);
+    const addAt = CODE.indexOf("LIVE_INSTANCES.add(");
+    const returnAt = CODE.indexOf("return {\n        httpURL, opsURL, installDir, process: proc");
+    expect(addAt).toBeGreaterThan(-1);
+    if (returnAt > -1) expect(addAt).toBeLessThan(returnAt);
+  });
+
+  test("stopHarper deregisters, so a clean stop cannot leave a stale entry", () => {
+    // Without this, the exit hook holds a pid that may have been reused by an
+    // unrelated process by the time the runner exits — and SIGKILLs it.
+    expect(CODE).toMatch(/LIVE_INSTANCES\.delete\(inst\.__tracked\)/);
+  });
+
+  test("the exit hook covers signals, not just a clean exit", () => {
+    // `bun test` interrupted, or a CI runner cancelling the job, is exactly when
+    // a leak is most likely — an exit-only hook would miss all of it.
+    for (const sig of ["SIGINT", "SIGTERM", "SIGHUP"]) expect(CODE).toContain(sig);
+    expect(CODE).toMatch(/process\.on\("exit", reapLiveInstances\)/);
+  });
+
+  test("the reaper is synchronous — an exit handler cannot await", () => {
+    // rm/kill promises would be abandoned mid-flight at process exit, which is
+    // the shape of a fix that looks right and does nothing.
+    expect(CODE).toMatch(/function reapLiveInstances\(\): void/);
+    expect(CODE).toMatch(/rmSync\(/);
+    expect(CODE).toMatch(/process\.kill\(inst\.pid, "SIGKILL"\)/);
+    const reaper = CODE.slice(CODE.indexOf("function reapLiveInstances"), CODE.indexOf("function installExitHook"));
+    expect(reaper).not.toMatch(/await |async /);
+  });
+
+  test("it kills the process before removing the directory", () => {
+    // Order is load-bearing: blocks held open by a live process are not returned
+    // by unlinking the path. Removing first would report success and free nothing
+    // — which is precisely what my manual cleanup did before I found the pids.
+    const reaper = CODE.slice(CODE.indexOf("function reapLiveInstances"), CODE.indexOf("function installExitHook"));
+    expect(reaper.indexOf("process.kill")).toBeLessThan(reaper.indexOf("rmSync"));
+  });
+
+  test("it only removes directories the harness created", () => {
+    // A caller-supplied installDir (the downgrade lanes share one across two
+    // starts) belongs to the caller. Reaping it would delete a tree another test
+    // is still using.
+    const reaper = CODE.slice(CODE.indexOf("function reapLiveInstances"), CODE.indexOf("function installExitHook"));
+    expect(reaper).toMatch(/inst\.owns/);
+  });
+});
+
+describe("countStaleHarperTrees — so a leak is visible before the disk is gone", () => {
+  test("counts flair-test-* trees in the temp dir", () => {
+    const before = countStaleHarperTrees();
+    const d = mkdtempSync(join(tmpdir(), "flair-test-"));
+    try {
+      expect(countStaleHarperTrees()).toBe(before + 1);
+    } finally {
+      rmSync(d, { recursive: true, force: true });
+    }
+    expect(countStaleHarperTrees()).toBe(before);
+  });
+
+  test("does not count unrelated temp directories", () => {
+    const before = countStaleHarperTrees();
+    const d = mkdtempSync(join(tmpdir(), "flair-something-else-"));
+    try {
+      expect(countStaleHarperTrees()).toBe(before);
+    } finally {
+      rmSync(d, { recursive: true, force: true });
+    }
+  });
+});

--- a/test/unit/harper-lifecycle-leak-backstop.test.ts
+++ b/test/unit/harper-lifecycle-leak-backstop.test.ts
@@ -141,3 +141,55 @@ describe("the reaper kills only its own children", () => {
     expect(body.indexOf("LIVE_INSTANCES.delete")).toBeLessThan(body.indexOf("killProcess"));
   });
 });
+
+// ─── The signal handler must not survive its own signal ─────────────────────
+//
+// Registering a handler for SIGINT/SIGTERM/SIGHUP REPLACES Node's default
+// action (terminate). Re-raising while the listener is still registered
+// re-enters the handler forever, and the process survives the signal it was
+// told to die on.
+//
+// The first version of this hook did exactly that. It hung CI's Integration
+// Tests for 35 minutes against a ~15 minute norm until the runner hard-killed
+// the job — and it broke the very case the hook exists for, since Ctrl-C would
+// no longer stop a test run.
+//
+// Verified in isolation both ways: re-raising while registered loops
+// indefinitely; removing the listener first exits 143 (terminated by SIGTERM).
+describe("the signal handler removes its listener before re-raising", () => {
+  const CODE = readFileSync(join(import.meta.dir, "..", "helpers", "harper-lifecycle.ts"), "utf8")
+    .replace(/\/\*[\s\S]*?\*\//g, "").replace(/(^|[^:])\/\/.*$/gm, "$1");
+
+  test("removeAllListeners precedes the re-raise", () => {
+    const hook = CODE.slice(CODE.indexOf("function installExitHook"), CODE.indexOf("export function countStaleHarperTrees"));
+    const remove = hook.indexOf("process.removeAllListeners(sig)");
+    const raise = hook.indexOf("process.kill(process.pid, sig)");
+    expect(remove).toBeGreaterThan(-1);
+    expect(raise).toBeGreaterThan(-1);
+    expect(remove).toBeLessThan(raise);
+  });
+
+  test("the reap still happens before either", () => {
+    // Order is reap -> deregister handler -> re-raise. Removing the listener
+    // first would be safe but would skip the cleanup this hook exists for.
+    const hook = CODE.slice(CODE.indexOf("function installExitHook"), CODE.indexOf("export function countStaleHarperTrees"));
+    expect(hook.indexOf("reapLiveInstances()")).toBeLessThan(hook.indexOf("process.removeAllListeners(sig)"));
+  });
+
+  test("a re-raise-while-registered pattern loops — the property being avoided", async () => {
+    // Behavioural proof rather than a claim about Node's semantics, run in a
+    // child so it cannot take this suite down.
+    const { spawnSync } = await import("node:child_process");
+    const script = [
+      "let n=0;",
+      "process.on('SIGTERM',()=>{n++;if(n>4){console.log('LOOP');process.exit(9);}process.kill(process.pid,'SIGTERM');});",
+      "setTimeout(()=>{console.log('NOLOOP');process.exit(0);},800);",
+      "process.kill(process.pid,'SIGTERM');",
+    ].join("");
+    // spawnSync, not execFileSync: the loop path exits 9, and execFileSync
+    // throws on a non-zero exit before the output can be read — which would
+    // fail this test for the wrong reason.
+    const r = spawnSync(process.execPath, ["-e", script], { encoding: "utf-8", timeout: 15000 });
+    expect(String(r.stdout)).toContain("LOOP");
+  });
+});

--- a/test/unit/harper-lifecycle-leak-backstop.test.ts
+++ b/test/unit/harper-lifecycle-leak-backstop.test.ts
@@ -162,9 +162,11 @@ describe("the signal handler removes its listener before re-raising", () => {
 
   test("removeAllListeners precedes the re-raise", () => {
     const hook = CODE.slice(CODE.indexOf("function installExitHook"), CODE.indexOf("export function countStaleHarperTrees"));
-    const remove = hook.indexOf("process.removeAllListeners(sig)");
+    const remove = hook.indexOf("process.off(sig, onSignal)");
     const raise = hook.indexOf("process.kill(process.pid, sig)");
     expect(remove).toBeGreaterThan(-1);
+    // Targeted removal, not removeAllListeners — see the note at the handler.
+    expect(hook).not.toContain("removeAllListeners");
     expect(raise).toBeGreaterThan(-1);
     expect(remove).toBeLessThan(raise);
   });
@@ -173,7 +175,7 @@ describe("the signal handler removes its listener before re-raising", () => {
     // Order is reap -> deregister handler -> re-raise. Removing the listener
     // first would be safe but would skip the cleanup this hook exists for.
     const hook = CODE.slice(CODE.indexOf("function installExitHook"), CODE.indexOf("export function countStaleHarperTrees"));
-    expect(hook.indexOf("reapLiveInstances()")).toBeLessThan(hook.indexOf("process.removeAllListeners(sig)"));
+    expect(hook.indexOf("reapLiveInstances()")).toBeLessThan(hook.indexOf("process.off(sig, onSignal)"));
   });
 
   test("a re-raise-while-registered pattern loops — the property being avoided", async () => {


### PR DESCRIPTION
## What happened

After a night of integration runs on rockit:

```
9 orphaned flair-test-* trees        27 GB
4 abandoned `harper dev` processes   two of them FOUR DAYS old
disk                                 0 bytes free
```

At zero bytes **no command could run at all** — every tool writes an output file before it executes, so recovery needed a human to run `rm`.

## Why it leaked

`stopHarper` was never wrong. **It simply was not called.** When a `beforeAll` throws or times out, `afterAll` does not run, and the spawned Harper survives holding its ~3 GB install tree open.

## Why deleting directories was not the fix

I proved this the hard way during recovery: clearing **1.6 GB of npm cache returned 5 MB**. A file held open by a live process does not return its blocks.

**The process has to die first.** That is why this tracks processes rather than paths, and why `kill` is ordered before `rmSync` — a test asserts that ordering, because reversing it would report success and free nothing.

## The fix

Every instance registers on spawn, deregisters on clean stop, and a process-exit hook reaps whatever is left.

- **Synchronous reaper** — exit handlers cannot `await`; abandoned promises are the shape of a fix that looks right and does nothing.
- **Signals covered** — `SIGINT`/`SIGTERM`/`SIGHUP` reap then re-raise, so the exit code still reflects the signal. An interrupted run is exactly when a leak is most likely.
- **Deregistration matters as much as registration** — a stale entry would let the hook `SIGKILL` a pid that had since been reused.
- **Caller-owned dirs untouched** — the downgrade lanes share an installDir across two starts; reaping it would delete a tree another test still needs.

`countStaleHarperTrees()` is exported so a leak can fail a **test** rather than a machine three hours later. The incident was invisible until the disk was full: nothing counted, so nothing complained.

## Verification

Tests assert the **wiring**, since that is the half that rots silently.

| mutation | result |
|---|---|
| registration removed | 1 fail |
| deregistration removed | 1 fail |
| exit hook removed | 1 fail |
| `rmSync` before `kill` | 1 fail |

Source byte-identical after restore. Unit suite **3948 pass, 0 fail**.

The behavioural test — spawn a Harper, kill the runner, assert nothing survives — needs a live Harper and belongs in the integration lane. What is asserted here is that the mechanism is connected.

No issue: found by the machine running out of disk mid-session, not by a filed report.

Typed `chore`: `test/` is absent from `package.json`'s `files[]`, so this reaches no user. Same reasoning as #1097, and the reason #1098 exists.
