### PR TITLE
ci(smoke): gate pull requests, not only main

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -4,6 +4,17 @@ on:
   workflow_dispatch:
   push:
     branches: [main]
+  # Also gate PULL REQUESTS. Without this the lane ran only after merge, so it
+  # could never block anything — every merge to main was its first execution,
+  # and a red main was a matter of when rather than if.
+  #
+  # It happened: b659682 turned main red on a lane that had never run against
+  # either of the two PRs that produced it. Diagnosing that cost real time and
+  # the failure turned out to be unrelated to both changes — which is exactly
+  # the tax a post-merge-only gate charges. You pay it after the fact, on main,
+  # under pressure, instead of on a branch where it is cheap.
+  pull_request:
+    branches: [main]
 
 jobs:
   smoke:


### PR DESCRIPTION
## Why

`Smoke Tests (Golden Path)` triggered on **push-to-main and `workflow_dispatch` only**:

```yaml
on:
  workflow_dispatch:
  push:
    branches: [main]
```

It never ran on a pull request. So it **could not block anything** — every merge to main was its first execution, and a red main was a question of *when*, not *if*.

That happened on `b659682`: main went red on a lane that had never run against either of the two PRs that produced it. Diagnosing it cost real time, and the failure turned out to be **unrelated to both changes**. That is exactly the tax a post-merge-only gate charges — you pay it after the fact, on main, under pressure, instead of on a branch where it is cheap and blocks nobody.

## This is an outlier being corrected, not a new policy

| workflow | gates PRs |
|---|---|
| docker-test | yes |
| federation-compat | yes |
| migration-ci-lanes | yes |
| socket | yes |
| test | yes |
| **smoke** | **no** ← |

Matches `test.yml`'s exact form (`pull_request: branches: [main]`) rather than inventing a variant.

## What this does not do

**It does not diagnose the current red.** It makes the next one impossible to discover after the fact.

It does give the current failure a second data point, though: the lane now runs on this PR. If it passes here, the main failure was a flake. If it fails here too, it is real and I chase it before anything ships.

## Cost

One more lane per PR. The job is `timeout-minutes: 10` and does a build plus a pre-downloaded embedding model, so it is not free — but a lane that only runs where it cannot block is worth less than nothing, because it produces exactly the failure mode it was meant to prevent, at the worst moment.

No issue: found while checking release preconditions for 0.38.0, not from a filed report.


---

## Correction: this reverses a deliberate decision (Kern, on review)

The body above framed main-only as an omission. **It was not.** PR #442's description states the rationale:

> Separate CI workflow — not in main CI to avoid slowing PRs (`smoke.yml` is workflow_dispatch + main-only trigger).

I checked `git log` for the file and inferred from its silence; the reason was in the pull request description. So this PR **reverses a conscious trade-off**, and future readers should see that rather than a story about tidying up.

**#442 chose** faster PRs with post-merge smoke. **This chooses** ~2 minutes per PR for a lane that can block. What changed is the cost side — a red main halted the 0.38.0 release, and a red main is not acceptable. That makes the trade worth taking now; it does not make the original call wrong.

If PR wall-clock later becomes the binding constraint, the lever is making the lane cheaper — the Docker Harper and embedding-model pre-download are most of the two minutes — not removing its ability to block.
