### PR TITLE
release: v0.39.0

### DIFF
--- a/.changelog/unreleased/added-adk-flair.md
+++ b/.changelog/unreleased/added-adk-flair.md
@@ -1,1 +1,0 @@
-- **adk-flair: Flair as the memory backend for Google ADK agents.** New `packages/adk-flair` Python package implementing `BaseMemoryService` with compound-tag user scoping, Ed25519-signed API calls, and semantic search. Published to PyPI as `adk-flair`.

--- a/.changelog/unreleased/fixed-secrets-push-processenv.md
+++ b/.changelog/unreleased/fixed-secrets-push-processenv.md
@@ -1,1 +1,0 @@
-- Fix `mcp enable` secrets push to send `processEnv: true` instead of `tier: processEnv` and verify the field on read-back so inert rows (core ignoring unknown params) are caught rather than silently failing at boot. Closes #1105

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,16 @@ node scripts/changelog-fragments.mjs check    # what CI checks
 version cut. **Do not add entries to this section by hand** — the release step replaces its body,
 so a hand-written entry here is lost.
 
+## [0.39.0] - 2026-08-06
+
+### Added
+
+- **adk-flair: Flair as the memory backend for Google ADK agents.** New `packages/adk-flair` Python package implementing `BaseMemoryService` with compound-tag user scoping, Ed25519-signed API calls, and semantic search. Published to PyPI as `adk-flair`.
+
+### Fixed
+
+- Fix `mcp enable` secrets push to send `processEnv: true` instead of `tier: processEnv` and verify the field on read-back so inert rows (core ignoring unknown params) are caught rather than silently failing at boot. Closes #1105
+
 ## [0.38.0] - 2026-08-05
 
 ### Added

--- a/bun.lock
+++ b/bun.lock
@@ -25,7 +25,7 @@
     },
     "packages/flair-bench": {
       "name": "@tpsdev-ai/flair-bench",
-      "version": "0.38.0",
+      "version": "0.39.0",
       "bin": {
         "flair-bench": "dist/cli-shim.cjs",
       },
@@ -48,21 +48,21 @@
     },
     "packages/flair-client": {
       "name": "@tpsdev-ai/flair-client",
-      "version": "0.38.0",
+      "version": "0.39.0",
       "devDependencies": {
         "typescript": "5.9.3",
       },
     },
     "packages/flair-mcp": {
       "name": "@tpsdev-ai/flair-mcp",
-      "version": "0.38.0",
+      "version": "0.39.0",
       "bin": {
         "flair-mcp": "dist/mcp-shim.cjs",
         "flair-session-start": "dist/session-start-hook.js",
       },
       "dependencies": {
         "@modelcontextprotocol/sdk": "1.27.1",
-        "@tpsdev-ai/flair-client": "0.38.0",
+        "@tpsdev-ai/flair-client": "0.39.0",
         "zod": "4.3.6",
       },
       "devDependencies": {
@@ -71,9 +71,9 @@
     },
     "packages/langgraph-flair": {
       "name": "@tpsdev-ai/langgraph-flair",
-      "version": "0.38.0",
+      "version": "0.39.0",
       "dependencies": {
-        "@tpsdev-ai/flair-client": "0.38.0",
+        "@tpsdev-ai/flair-client": "0.39.0",
       },
       "peerDependencies": {
         "@langchain/langgraph-checkpoint": ">=0.0.10",
@@ -81,9 +81,9 @@
     },
     "packages/n8n-nodes-flair": {
       "name": "@tpsdev-ai/n8n-nodes-flair",
-      "version": "0.38.0",
+      "version": "0.39.0",
       "dependencies": {
-        "@tpsdev-ai/flair-client": "0.38.0",
+        "@tpsdev-ai/flair-client": "0.39.0",
         "zod": "3.25.76",
       },
       "devDependencies": {
@@ -100,10 +100,10 @@
     },
     "packages/openclaw-flair": {
       "name": "@tpsdev-ai/openclaw-flair",
-      "version": "0.38.0",
+      "version": "0.39.0",
       "dependencies": {
         "@sinclair/typebox": "0.34.48",
-        "@tpsdev-ai/flair-client": "0.38.0",
+        "@tpsdev-ai/flair-client": "0.39.0",
       },
       "devDependencies": {
         "typescript": "5.9.3",
@@ -114,10 +114,10 @@
     },
     "packages/pi-flair": {
       "name": "@tpsdev-ai/pi-flair",
-      "version": "0.38.0",
+      "version": "0.39.0",
       "dependencies": {
         "@sinclair/typebox": "0.34.48",
-        "@tpsdev-ai/flair-client": "0.38.0",
+        "@tpsdev-ai/flair-client": "0.39.0",
       },
       "devDependencies": {
         "@mariozechner/pi-coding-agent": "0.73.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tpsdev-ai/flair",
-  "version": "0.38.0",
+  "version": "0.39.0",
   "packageManager": "bun@1.3.10",
   "description": "Identity, memory, and soul for AI agents. Cryptographic identity (Ed25519), semantic memory with local embeddings, and persistent personality — all in a single process.",
   "type": "module",

--- a/packages/flair-bench/package.json
+++ b/packages/flair-bench/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tpsdev-ai/flair-bench",
-  "version": "0.38.0",
+  "version": "0.39.0",
   "description": "Standalone embedding recall benchmark for flair — run real recall numbers (p@3/MRR) against any GGUF embedding model, batch-compare, get a host-aware recommendation, and share redacted results. No flair install required.",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/flair-bench/src/version.ts
+++ b/packages/flair-bench/src/version.ts
@@ -5,4 +5,4 @@
  * attribute edge cases in a published dist/ build. test/version-sync.test.ts
  * asserts this stays equal to package.json's "version" field.
  */
-export const TOOL_VERSION = "0.38.0";
+export const TOOL_VERSION = "0.39.0";

--- a/packages/flair-client/package.json
+++ b/packages/flair-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tpsdev-ai/flair-client",
-  "version": "0.38.0",
+  "version": "0.39.0",
   "description": "Lightweight client for Flair — identity, memory, and soul for AI agents. Zero heavy dependencies.",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/flair-mcp/package.json
+++ b/packages/flair-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tpsdev-ai/flair-mcp",
-  "version": "0.38.0",
+  "version": "0.39.0",
   "description": "MCP server for Flair — persistent memory for Claude Code, Cursor, and any MCP client.",
   "type": "module",
   "main": "dist/index.js",
@@ -27,7 +27,7 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "1.27.1",
-    "@tpsdev-ai/flair-client": "0.38.0",
+    "@tpsdev-ai/flair-client": "0.39.0",
     "zod": "4.3.6"
   },
   "license": "Apache-2.0",

--- a/packages/langgraph-flair/package.json
+++ b/packages/langgraph-flair/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tpsdev-ai/langgraph-flair",
-  "version": "0.38.0",
+  "version": "0.39.0",
   "description": "LangGraph BaseStore adapter backed by Flair — durable agent memory with crypto-pinned identity, federation, and cross-orchestrator portability.",
   "type": "module",
   "main": "dist/index.js",
@@ -36,7 +36,7 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
-    "@tpsdev-ai/flair-client": "0.38.0"
+    "@tpsdev-ai/flair-client": "0.39.0"
   },
   "peerDependencies": {
     "@langchain/langgraph-checkpoint": ">=0.0.10"

--- a/packages/n8n-nodes-flair/package.json
+++ b/packages/n8n-nodes-flair/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tpsdev-ai/n8n-nodes-flair",
-  "version": "0.38.0",
+  "version": "0.39.0",
   "description": "n8n community node — use Flair as your AI Agent's memory backend. Includes FlairChatMemory (Memory port) and FlairSearch (Tool port).",
   "type": "commonjs",
   "main": "dist/index.js",
@@ -48,7 +48,7 @@
     "langchain"
   ],
   "dependencies": {
-    "@tpsdev-ai/flair-client": "0.38.0",
+    "@tpsdev-ai/flair-client": "0.39.0",
     "zod": "3.25.76"
   },
   "peerDependencies": {

--- a/packages/openclaw-flair/package.json
+++ b/packages/openclaw-flair/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tpsdev-ai/openclaw-flair",
-  "version": "0.38.0",
+  "version": "0.39.0",
   "description": "OpenClaw memory plugin for Flair — agent identity and semantic memory",
   "type": "module",
   "main": "./dist/index.js",
@@ -58,7 +58,7 @@
   },
   "dependencies": {
     "@sinclair/typebox": "0.34.48",
-    "@tpsdev-ai/flair-client": "0.38.0"
+    "@tpsdev-ai/flair-client": "0.39.0"
   },
   "devDependencies": {
     "typescript": "5.9.3"

--- a/packages/pi-flair/package.json
+++ b/packages/pi-flair/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tpsdev-ai/pi-flair",
-  "version": "0.38.0",
+  "version": "0.39.0",
   "description": "Flair memory extension for pi — persistent memory access from within pi sessions",
   "type": "module",
   "main": "dist/index.js",
@@ -21,7 +21,7 @@
     "node": ">=18"
   },
   "dependencies": {
-    "@tpsdev-ai/flair-client": "0.38.0",
+    "@tpsdev-ai/flair-client": "0.39.0",
     "@sinclair/typebox": "0.34.48"
   },
   "license": "Apache-2.0",


### PR DESCRIPTION
Version bump across workspace packages to v0.39.0.

See CHANGELOG.md for what's in this release.

After CI is green and this is merged:
```
git checkout main && git pull
./scripts/release.sh 0.39.0 --publish
```