### PR TITLE
chore(adk-flair): bump version to 0.39.0 — track flair's minor

### DIFF
--- a/.changelog/unreleased/changed-adk-flair-version-policy.md
+++ b/.changelog/unreleased/changed-adk-flair-version-policy.md
@@ -1,0 +1,1 @@
+- adk-flair versions now track flair's minor while 0.x (compat-signal policy).

--- a/packages/adk-flair/pyproject.toml
+++ b/packages/adk-flair/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "adk-flair"
-version = "0.1.0"
+version = "0.39.0"
 description = "Flair memory backend for Google ADK — self-hosted, federated, portable agent memory"
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/scripts/check-version-sync.mjs
+++ b/scripts/check-version-sync.mjs
@@ -88,6 +88,14 @@ const SOURCE_VERSION_FILES = [
     // Global so occurrences can be counted; see readDeclared.
     pattern: /(\bTOOL_VERSION\s*=\s*")([^"]*)(")/g,
   },
+  {
+    path: "packages/adk-flair/pyproject.toml",
+    label: "version",
+    // Matches: version = "X.Y.Z"  (TOML string)
+    // The adk-flair package tracks flair's minor while 0.x (compat-signal
+    // policy), so this must be bumped in lockstep with every release.
+    pattern: /(^version\s*=\s*")([^"]*)(")/gm,
+  },
 ];
 
 const INVENTORY = new Set([...PACKAGE_JSONS, ...SOURCE_VERSION_FILES.map((f) => f.path)]);

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -391,6 +391,7 @@ git -C "$ROOT" add \
   "$ROOT/packages/langgraph-flair/package.json" \
   "$ROOT/packages/flair-bench/package.json" \
   "$ROOT/packages/flair-bench/src/version.ts" \
+  "$ROOT/packages/adk-flair/pyproject.toml" \
   "$ROOT/bun.lock"
 
 # The fragment files consumed by step 1a are DELETED, so this needs -A to stage


### PR DESCRIPTION
While the family is 0.x, adk-flair matches flair's compat semver at the minor. Patch is free to vary from flair's.

No issue: version policy per ops-giss