### PR TITLE
docs: Harper 5.2 compatibility note and beta claim cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -404,7 +404,7 @@ Shipped: Ed25519 identity and auth · memory CRUD with durability enforcement an
 
 Next: git-backed memory sync · opt-in encryption at rest (AES-256-GCM per memory).
 
-> **Note:** Flair runs on [Harper v5](https://harper.fast), currently in beta. We run it in production daily and track upstream closely. Pin your Harper version.
+> **Note:** Flair runs on [Harper v5](https://harper.fast). We run it in production daily and track upstream closely. Pin your Harper version.
 
 ## License
 

--- a/docs/upgrade.md
+++ b/docs/upgrade.md
@@ -350,12 +350,11 @@ if you want to see it scripted end-to-end.
   between Flair versions.
 - **Config:** `~/.flair/config.yaml` format is additive — new options fall back to
   defaults when absent, old options aren't removed out from under you.
-- **Harper 5.2:** Starting with the next Flair release (PR #1045), Flair pins Harper
-  5.2.0. This upgrade is **forward-only** — Harper 5.2 writes LZ4-compressed storage
+- **Harper 5.2:** Starting with the release that pins Harper 5.2.0 (see CHANGELOG). This upgrade is **forward-only** — Harper 5.2 writes LZ4-compressed storage
   that Harper 5.1.x cannot read. If you need to roll back, you must restore from a
   pre-upgrade snapshot; installing an older Harper version will not boot against a
   5.2-written data directory. Flair automatically takes a snapshot when the Harper engine
-  minor version changes (`decideUpgradeSnapshot`), so a valid snapshot will exist if you
+  minor version changes, so a valid snapshot will exist if you
   upgraded via `flair upgrade`. Real snapshots for production datasets run hundreds of
   megabytes — plan disk capacity accordingly. Cleanup of old engine snapshots is manual;
   `flair snapshot list` shows your current pool, and you can delete entries you no longer

--- a/docs/upgrade.md
+++ b/docs/upgrade.md
@@ -351,13 +351,12 @@ if you want to see it scripted end-to-end.
 - **Config:** `~/.flair/config.yaml` format is additive — new options fall back to
   defaults when absent, old options aren't removed out from under you.
 - **Harper 5.2:** Starting with the release that pins Harper 5.2.0 (see CHANGELOG). This upgrade is **forward-only** — Harper 5.2 writes LZ4-compressed storage
-  that Harper 5.1.x cannot read. If you need to roll back, you must restore from a
-  pre-upgrade snapshot; installing an older Harper version will not boot against a
+  that Harper 5.1.x cannot read. If you need to roll back, restore the pre-upgrade snapshot: `flair snapshot restore <path>` (use `flair snapshot list` to find available snapshots). Note this is the physical engine snapshot restore, distinct from `flair restore` which replays a logical JSON export and cannot recover a 5.1-incompatible data directory. Installing an older Harper version will not boot against a
   5.2-written data directory. Flair automatically takes a snapshot when the Harper engine
   minor version changes, so a valid snapshot will exist if you
   upgraded via `flair upgrade`. Real snapshots for production datasets run hundreds of
   megabytes — plan disk capacity accordingly. Cleanup of old engine snapshots is manual;
-  `flair snapshot list` shows your current pool, and you can delete entries you no longer
+  `flair snapshot list` shows available snapshots, and you can delete entries you no longer
   need.
 
 ## Rollback

--- a/docs/upgrade.md
+++ b/docs/upgrade.md
@@ -350,6 +350,16 @@ if you want to see it scripted end-to-end.
   between Flair versions.
 - **Config:** `~/.flair/config.yaml` format is additive — new options fall back to
   defaults when absent, old options aren't removed out from under you.
+- **Harper 5.2:** Starting with the next Flair release (PR #1045), Flair pins Harper
+  5.2.0. This upgrade is **forward-only** — Harper 5.2 writes LZ4-compressed storage
+  that Harper 5.1.x cannot read. If you need to roll back, you must restore from a
+  pre-upgrade snapshot; installing an older Harper version will not boot against a
+  5.2-written data directory. Flair automatically takes a snapshot when the Harper engine
+  minor version changes (`decideUpgradeSnapshot`), so a valid snapshot will exist if you
+  upgraded via `flair upgrade`. Real snapshots for production datasets run hundreds of
+  megabytes — plan disk capacity accordingly. Cleanup of old engine snapshots is manual;
+  `flair snapshot list` shows your current pool, and you can delete entries you no longer
+  need.
 
 ## Rollback
 


### PR DESCRIPTION
## Changes

**Doc-only — no code changes.**

### `docs/upgrade.md`

Added a Harper 5.2 compatibility statement in the "Version compatibility" section. Covers:
- Harper 5.2.0 pin (from PR #1045) and that upgrades are forward-only (LZ4-compressed storage unreadable by 5.1.x)
- Rollback requires pre-upgrade snapshot restore; installing an older Harper version will not boot
- Automatic snapshot on engine minor version change (`decideUpgradeSnapshot`)
- Disk capacity planning (snapshots run hundreds of MB) and manual cleanup of old snapshots

### `README.md`

Removed stale "currently in beta" from the Harper v5 note. Harper 5 has been stable since 5.0.0. No other beta references remained.

Refs #1045
