### PR TITLE
fix(release): add adk-flair-js to version bump and publish lists

### DIFF
--- a/.changelog/unreleased/fixed-release-tooling-adk-flair-js-bump-site.md
+++ b/.changelog/unreleased/fixed-release-tooling-adk-flair-js-bump-site.md
@@ -1,0 +1,1 @@
+Release tooling: adk-flair-js added to the version-bump and stage-publish lists — the 0.40.0 cut failed its post-bump guard because the new package was not a bump site.

--- a/.changelog/unreleased/fixed-release-tooling-adk-flair-js-bump-site.md
+++ b/.changelog/unreleased/fixed-release-tooling-adk-flair-js-bump-site.md
@@ -1,1 +1,1 @@
-Release tooling: adk-flair-js added to the version-bump and stage-publish lists — the 0.40.0 cut failed its post-bump guard because the new package was not a bump site.
+- Release tooling: adk-flair-js added to the version-bump and stage-publish lists — the 0.40.0 cut failed its post-bump guard because the new package was not a bump site.

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -151,6 +151,7 @@ jobs:
             packages/pi-flair/package.json
             packages/n8n-nodes-flair/package.json
             packages/langgraph-flair/package.json
+            packages/adk-flair-js/package.json
             packages/flair-bench/package.json
           )
           for pj in "${PKG_JSONS[@]}"; do
@@ -205,6 +206,7 @@ jobs:
             packages/pi-flair
             packages/n8n-nodes-flair
             packages/langgraph-flair
+            packages/adk-flair-js
           )
           for dir in "${DIRS[@]}"; do
             name="$(node -p "require('./$dir/package.json').name")"
@@ -247,7 +249,7 @@ jobs:
           {
             echo "### 🚀 v$VERSION staged for release"
             echo ""
-            echo "All 8 lockstep-versioned workspace packages submitted to npm **staging**"
+            echo "All 9 lockstep-versioned workspace packages submitted to npm **staging**"
             echo "with provenance. They are **not live yet**."
             echo ""
             echo "**To release:** open [npmjs.com → Staged Packages](https://www.npmjs.com/settings/tpsdev-ai/staging),"

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -39,6 +39,7 @@ PACKAGES=(
   "$ROOT/packages/pi-flair"
   "$ROOT/packages/n8n-nodes-flair"
   "$ROOT/packages/langgraph-flair"
+  "$ROOT/packages/adk-flair-js"
   "$ROOT/packages/flair-bench"
   "$ROOT"
 )
@@ -50,6 +51,7 @@ PACKAGE_JSONS=(
   "$ROOT/packages/pi-flair/package.json"
   "$ROOT/packages/n8n-nodes-flair/package.json"
   "$ROOT/packages/langgraph-flair/package.json"
+  "$ROOT/packages/adk-flair-js/package.json"
   "$ROOT/packages/flair-bench/package.json"
   "$ROOT/package.json"
 )


### PR DESCRIPTION
release.sh 0.40.0 failed at the post-bump guard because `packages/adk-flair-js/package.json` was not in the bump loop (`PACKAGES`) or the publish verification list (`PACKAGE_JSONS`). The `git add` list and `check-version-sync.mjs` already knew about it, so the guard caught the mismatch correctly — the bump just never reached the file.

**Changes:**

- `scripts/release.sh`: add `packages/adk-flair-js` to `PACKAGES` (bump loop) and `PACKAGE_JSONS` (publish verification)
- `.github/workflows/release-publish.yml`: add `packages/adk-flair-js/package.json` to `PKG_JSONS` verification, add `packages/adk-flair-js` to `DIRS` staging loop, update summary count 8 → 9

**Dependency order:** `@tpsdev-ai/adk-flair` has no internal deps (only `@google/adk` and `@google/genai`), so it can go anywhere in the staging order. Placed after `langgraph-flair` alphabetically.

**Verification:** `node scripts/check-version-sync.mjs` passes at the 0.39.0 baseline (11 declaration sites, 744 tracked files).

No issue: release tooling — new package bump site