### PR TITLE
test(mcp-e2e): explicit 180s afterAll timeout — teardown outgrew the default 5s in the macOS release lane

### DIFF
--- a/.changelog/unreleased/fixed-mcp-e2e-afterall-timeout.md
+++ b/.changelog/unreleased/fixed-mcp-e2e-afterall-timeout.md
@@ -1,0 +1,1 @@
+- The MCP client-credentials e2e test's `afterAll` teardown now carries an explicit 180s timeout (mirroring its `beforeAll`); its `rm -rf` of the hard-linked temp component tree had outgrown the default 5s hook budget as the dependency tree grew, surfacing only in the macOS release lane.

--- a/test/integration/mcp-client-credentials-e2e.test.ts
+++ b/test/integration/mcp-client-credentials-e2e.test.ts
@@ -191,11 +191,14 @@ describe("MCP client_credentials agent-auth vs. a live @harperfast/oauth@2.2.0 c
   afterAll(async () => {
     if (harper) await stopHarper(harper);
     if (tempDir) {
+      // rm -rf of the hard-linked temp tree (repo + node_modules, tens of
+      // thousands of inodes) is syscall-heavy and outgrows the default 5s hook
+      // timeout as the dependency tree grows — mirror beforeAll's 180s budget.
       await rm(tempDir, { recursive: true, force: true, maxRetries: 4 });
     }
     delete process.env.FLAIR_MCP_OAUTH;
     delete process.env.FLAIR_MCP_ISSUER;
-  });
+  }, 180_000);
 
   test("the repository's config.yaml is never mutated during this test run", () => {
     const after = sha256(CONFIG_PATH);


### PR DESCRIPTION
### What

The MCP client-credentials e2e test's `afterAll` teardown had no explicit timeout, so it ran under bun's default 5s hook budget. Its `rm -rf` of the hard-linked temp component tree (the whole repo + `node_modules`, tens of thousands of inodes) is syscall-heavy, and the harper 5.2 pin (#1045) grew the dependency tree just enough to push that cleanup past 5s — failing the hook.

### Why it surfaced now

This is a **darwin-gated integration test** that only runs in the macOS release lane (`release.sh`), never on CI's Linux runners. So it went green through 0.40.0 and first tripped when cutting 0.41.0 (the first release carrying the 5.2 pin).

### Measurement (not inference)

Ran the file in isolation: the failure is `afterAll` timing out at exactly 5002ms. With a raised timeout it passes in ~44s wall — but **4.5s user / 35s sys**: the wall time is filesystem syscalls (`cp -al` setup + `rm -rf` teardown of the linked tree), not compute and not harper boot. `beforeAll` already carried a 180s timeout for the same reason; `afterAll` was simply left at the default. **All 6 tests pass with the default per-test timeout once teardown has room** — the product (harper 5.2 + live @harperfast/oauth component) is unaffected.

### Fix

One line: give the `afterAll` the same explicit 180s timeout as its `beforeAll`, with a comment on why the teardown is slow.

No issue: release-lane test-infra fix (darwin-gated teardown timeout) uncovered while cutting 0.41.0.

### Verification

`bun test test/integration/mcp-client-credentials-e2e.test.ts` on macOS (rockit) → 6 pass, 0 fail with the DEFAULT timeout. CI's Linux lanes do not run this test, so local macOS execution is the verifying evidence.

