### PR TITLE
fix: make MCP client wiring version-aware + refresh on upgrade (flair#1135)

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -54,7 +54,7 @@ import {
   type FleetSweepResult,
 } from "./fleet-verify.js";
 import { markStale, sortOldestVersionFirst, type FleetPresenceRow } from "./fleet-presence.js";
-import { detectClients, renderWiringSummary, wireClaudeCode, wireCodex, wireGemini, wireCursor, type ClientId } from "./install/clients.js";
+import { detectClients, renderWiringSummary, wireClaudeCode, wireCodex, wireGemini, wireCursor, clientConfigPath, codexConfigHasFlairSection, type ClientId } from "./install/clients.js";
 import { flairCliVersion, mcpServerSpec, unpinnedSpecWarning } from "./lib/mcp-spec.js";
 import {
   resolveAgentKeyPath,
@@ -3773,18 +3773,28 @@ program
                 ? JSON.parse(readFileSync(claudeJsonPath, "utf-8"))
                 : {};
               const existing = claudeJson.mcpServers?.flair;
-              if (existing && existing.env?.FLAIR_URL === httpUrl && existing.env?.FLAIR_AGENT_ID === agentId) {
+              const currentSpec = mcpServerSpec();
+              const existingArgs = existing?.args;
+              const argsMatch = Array.isArray(existingArgs) && existingArgs.includes(currentSpec);
+              const urlAgentMatch = existing && existing.env?.FLAIR_URL === httpUrl && existing.env?.FLAIR_AGENT_ID === agentId;
+              // flair#1135: the pin in `args` must match the current mcpServerSpec().
+              // A matching pin stays a no-op (idempotent); only a stale pin triggers a re-write.
+              if (urlAgentMatch && argsMatch) {
                 console.log(`   ✓ Claude Code already wired in ~/.claude.json`);
                 wiringResults.push({ client: "claude-code", message: "already wired", wired: true });
               } else {
                 claudeJson.mcpServers = claudeJson.mcpServers || {};
                 claudeJson.mcpServers.flair = flairMcpConfig;
                 writeFileSync(claudeJsonPath, JSON.stringify(claudeJson, null, 2));
-                const how = claudeJsonExisted ? "wired in ~/.claude.json" : "wired in ~/.claude.json (created)";
-                console.log(`   ✓ Claude Code ${how} (restart Claude Code to pick it up)`);
+                const action = urlAgentMatch ? "refreshed pin in ~/.claude.json"
+                  : claudeJsonExisted ? "wired in ~/.claude.json"
+                  : "wired in ~/.claude.json (created)";
+                console.log(`   ✓ Claude Code ${action} (restart Claude Code to pick it up)`);
                 wiringResults.push({
                   client: "claude-code",
-                  message: claudeJsonExisted ? "wired ~/.claude.json" : "created and wired ~/.claude.json",
+                  message: urlAgentMatch ? "refreshed pin in ~/.claude.json"
+                    : claudeJsonExisted ? "wired ~/.claude.json"
+                    : "created and wired ~/.claude.json",
                   wired: true,
                 });
               }
@@ -10843,6 +10853,49 @@ program
     });
 
     const verdict = decideAfterVerify(verify, previousFlairVersion);
+
+    // ── Refresh wired MCP client configs (flair#1135) ──────────────────────
+    // After a successful upgrade, the flair-mcp package on disk is newer than
+    // the pinned version in wired client configs. Re-run wiring for
+    // already-wired clients so the pin stays in lockstep with the installed
+    // version. Best-effort: failures warn but never fail the upgrade.
+    const refreshWiredClients = async () => {
+      const agentId = resolveAgentIdOrEnv({}) ?? (() => {
+        try {
+          const keyFiles = readdirSync(defaultKeysDir()).filter((f) => f.endsWith(".key"));
+          return keyFiles.length > 0 ? keyFiles[0].replace(/\.key$/, "") : null;
+        } catch { return null; }
+      })();
+      if (!agentId) {
+        console.log("\n   (no agent id known — skip MCP client pin refresh; run `flair init` to refresh manually)");
+        return;
+      }
+      const httpUrl = `http://127.0.0.1:${upgradePort}`;
+      const mcpEnv = { FLAIR_AGENT_ID: agentId, FLAIR_URL: httpUrl };
+      const detected = detectClients().filter(c => c.detected);
+      if (detected.length === 0) return;
+      console.log("\n   Refreshing MCP client pins...");
+      for (const client of detected) {
+        const configPath = clientConfigPath(client.id);
+        if (!existsSync(configPath)) continue;
+        // Only refresh clients that are already wired — don't wire new ones.
+        let hasFlair = false;
+        try {
+          const raw = readFileSync(configPath, "utf-8");
+          if (client.id === "codex") {
+            hasFlair = codexConfigHasFlairSection(raw);
+          } else {
+            const cfg = JSON.parse(raw);
+            hasFlair = !!cfg.mcpServers?.flair;
+          }
+        } catch { /* unreadable/malformed — skip */ }
+        if (!hasFlair) continue;
+        const env = { ...mcpEnv, FLAIR_CLIENT: client.id } as { FLAIR_AGENT_ID: string; FLAIR_URL: string; FLAIR_CLIENT?: string };
+        const result = client.wire(env);
+        console.log(`   ${result.ok ? "✓" : "•"} ${result.message}`);
+      }
+    };
+
     if (verdict.kind === "ok") {
       // flair#1022: the verified facts are unchanged and still stated — the
       // upgrade did land. What changes is the MARKER and the claim around it.
@@ -10855,6 +10908,7 @@ program
       for (const line of summary.lines) {
         if (summary.degraded) console.error(line); else console.log(line);
       }
+      await refreshWiredClients();
       return;
     }
 
@@ -10882,6 +10936,7 @@ program
           console.error(line);
         }
       }
+      await refreshWiredClients();
       return;
     }
 

--- a/src/install/clients.ts
+++ b/src/install/clients.ts
@@ -191,6 +191,40 @@ export function appendCodexFlairBlock(raw: string, env: WireEnv): string {
 }
 
 /**
+ * flair#1135: does the existing `[mcp_servers.flair]` TOML section carry the
+ * CURRENT pinned mcpServerSpec()? Pure string scan — no TOML parser needed
+ * (same rationale as codexConfigHasFlairSection).
+ */
+function codexFlairSectionHasCurrentPin(raw: string): boolean {
+  const idx = raw.indexOf("[mcp_servers.flair]");
+  if (idx === -1) return false;
+  const after = raw.slice(idx);
+  // Find the end of the section: the next top-level [header] that is NOT a
+  // sub-table of mcp_servers.flair (e.g. [mcp_servers.flair.env] is part of
+  // the same logical section and must not terminate the scan).
+  const nextHeader = after.slice("[mcp_servers.flair]".length).search(/\n\[(?!mcp_servers\.flair\.)/);
+  const section = nextHeader === -1 ? after : after.slice(0, "[mcp_servers.flair]".length + nextHeader);
+  return section.includes(mcpServerSpec());
+}
+
+/**
+ * flair#1135: replace the existing `[mcp_servers.flair]` TOML section with a
+ * fresh one carrying the current pin. Preserves everything else in the file.
+ */
+function replaceCodexFlairBlock(raw: string, env: WireEnv): string {
+  const idx = raw.indexOf("[mcp_servers.flair]");
+  if (idx === -1) return appendCodexFlairBlock(raw, env);
+  const before = raw.slice(0, idx);
+  const after = raw.slice(idx);
+  const nextHeader = after.slice("[mcp_servers.flair]".length).search(/\n\[(?!mcp_servers\.flair\.)/);
+  const rest = nextHeader === -1 ? "" : after.slice("[mcp_servers.flair]".length + nextHeader);
+  const newBlock = tomlSnippet(env) + "\n";
+  // Preserve the separator between the new block and whatever follows.
+  const sep = rest.length === 0 ? "" : rest.startsWith("\n") ? "" : "\n";
+  return before + newBlock + sep + rest;
+}
+
+/**
  * Merge the Flair MCP server into a JSON config file with an `mcpServers` map.
  * Creates the file (and parent dir) if absent; preserves existing servers and
  * any other top-level keys. Returns ok:true only when the file was written.
@@ -210,13 +244,20 @@ function wireJsonMcp(
     }
     config.mcpServers = config.mcpServers || {};
     const existing = config.mcpServers.flair;
-    if (existing && existing.env?.FLAIR_URL === env.FLAIR_URL && existing.env?.FLAIR_AGENT_ID === env.FLAIR_AGENT_ID) {
+    const currentSpec = mcpServerSpec();
+    const existingArgs = existing?.args;
+    const argsMatch = Array.isArray(existingArgs) && existingArgs.includes(currentSpec);
+    const urlAgentMatch = existing && existing.env?.FLAIR_URL === env.FLAIR_URL && existing.env?.FLAIR_AGENT_ID === env.FLAIR_AGENT_ID;
+    // flair#1135: the pin in `args` must match the current mcpServerSpec().
+    // A matching pin stays a no-op (idempotent); only a stale pin triggers a re-write.
+    if (urlAgentMatch && argsMatch) {
       return { ok: true, message: `${label}: already wired in ${display}` };
     }
     config.mcpServers.flair = flairMcpEntry(env);
     mkdirSync(dirname(configPath), { recursive: true });
     writeFileSync(configPath, JSON.stringify(config, null, 2) + "\n");
-    return { ok: true, message: `${label}: wired ${display} (restart ${label} to pick it up)` };
+    const action = urlAgentMatch ? "refreshed pin in" : "wired";
+    return { ok: true, message: `${label}: ${action} ${display} (restart ${label} to pick it up)` };
   } catch (err: unknown) {
     const reason = err instanceof Error ? err.message : String(err);
     return {
@@ -286,16 +327,22 @@ function _wireCodex(env: WireEnv): { ok: boolean; message: string } {
   // parser, but appending a new top-level table at EOF is safe TOML when the
   // exact header isn't already present (flair#727) — so an existing file only
   // forces the manual-print fallback when it's genuinely unreadable/
-  // unwritable (permissions, I/O error), never merely "exists". A file that
-  // already has the section is reported already-wired, matching the JSON
-  // clients' idempotency (wireJsonMcp above).
+  // unwritable (permissions, I/O error), never merely "exists".
+  //
+  // flair#1135: the "already wired" check is now version-aware — a section
+  // with a stale pin triggers a re-write instead of a no-op.
   const path = codexConfigPath();
   const display = "~/.codex/config.toml";
   try {
     if (existsSync(path)) {
       const raw = readFileSync(path, "utf-8");
-      if (codexConfigHasFlairSection(raw)) {
+      if (codexFlairSectionHasCurrentPin(raw)) {
         return { ok: true, message: `Codex: already wired in ${display}` };
+      }
+      if (codexConfigHasFlairSection(raw)) {
+        // Section exists but pin is stale — replace it.
+        writeFileSync(path, replaceCodexFlairBlock(raw, env));
+        return { ok: true, message: `Codex: refreshed pin in ${display} (restart Codex to pick it up)` };
       }
       writeFileSync(path, appendCodexFlairBlock(raw, env));
       return { ok: true, message: `Codex: wired ${display} (restart Codex to pick it up)` };

--- a/test/unit/clients-pin-refresh.test.ts
+++ b/test/unit/clients-pin-refresh.test.ts
@@ -1,0 +1,272 @@
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, rmSync, readFileSync, mkdirSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  mcpServerSpec,
+  flairCliVersion,
+  FLAIR_MCP_PACKAGE,
+} from "../../src/lib/mcp-spec.ts";
+import {
+  ALL_CLIENTS,
+  clientConfigPath,
+  codexConfigHasFlairSection,
+  tomlSnippet,
+  type ClientId,
+  type WireEnv,
+} from "../../src/install/clients.ts";
+
+/**
+ * flair#1135 — after `flair upgrade`, wired MCP client configs still pin the
+ * OLD `@tpsdev-ai/flair-mcp@<version>`. Re-running `flair init` says "already
+ * wired" and doesn't refresh. The fix makes all three "already wired" guards
+ * version-aware: a stale pin triggers a re-write; a matching pin stays a no-op.
+ *
+ * These tests are MUTATION-PROVEN: the stale→refresh test MUST fail before the
+ * guard change (it asserts the pin updates to the current version), and the
+ * current-pin→no-op test confirms idempotency (byte-identical output).
+ */
+
+const PKG_VERSION: string = JSON.parse(
+  readFileSync(join(import.meta.dirname, "..", "..", "package.json"), "utf-8"),
+).version;
+
+const CURRENT_SPEC = mcpServerSpec();
+const STALE_SPEC = `${FLAIR_MCP_PACKAGE}@0.0.0`; // a version that will never match
+
+const ENV: WireEnv = { FLAIR_AGENT_ID: "pinbot", FLAIR_URL: "http://127.0.0.1:19926" };
+
+let isoHome: string;
+let prevHome: string | undefined;
+
+beforeEach(() => {
+  isoHome = mkdtempSync(join(tmpdir(), "flair-pin-refresh-"));
+  prevHome = process.env.HOME;
+  process.env.HOME = isoHome;
+});
+
+afterEach(() => {
+  if (prevHome !== undefined) process.env.HOME = prevHome;
+  else delete process.env.HOME;
+  rmSync(isoHome, { recursive: true, force: true });
+});
+
+// ── Helpers ─────────────────────────────────────────────────────────────────
+
+/** Write a JSON MCP config with a specific pinned spec in args. */
+function writeJsonConfig(clientId: ClientId, spec: string) {
+  const path = clientConfigPath(clientId);
+  mkdirSync(join(path, ".."), { recursive: true });
+  writeFileSync(path, JSON.stringify({
+    mcpServers: {
+      flair: {
+        command: "npx",
+        args: ["-y", spec],
+        env: { FLAIR_AGENT_ID: ENV.FLAIR_AGENT_ID, FLAIR_URL: ENV.FLAIR_URL },
+      },
+    },
+  }, null, 2) + "\n");
+  return path;
+}
+
+/** Write a Codex TOML config with a specific pinned spec in args. */
+function writeCodexConfig(spec: string) {
+  const path = clientConfigPath("codex");
+  mkdirSync(join(path, ".."), { recursive: true });
+  const toml = [
+    `[mcp_servers.flair]`,
+    `command = "npx"`,
+    `args = ["-y", "${spec}"]`,
+    ``,
+    `[mcp_servers.flair.env]`,
+    `FLAIR_AGENT_ID = "${ENV.FLAIR_AGENT_ID}"`,
+    `FLAIR_URL = "${ENV.FLAIR_URL}"`,
+  ].join("\n") + "\n";
+  writeFileSync(path, toml);
+  return path;
+}
+
+/** Read the pinned spec from a JSON config's args array. */
+function readJsonPin(clientId: ClientId): string | null {
+  const raw = readFileSync(clientConfigPath(clientId), "utf-8");
+  const cfg = JSON.parse(raw);
+  const args = cfg.mcpServers?.flair?.args;
+  if (!Array.isArray(args)) return null;
+  return args.find((a: string) => a.startsWith(FLAIR_MCP_PACKAGE)) ?? null;
+}
+
+/** Read the pinned spec from a Codex TOML config. */
+function readCodexPin(): string | null {
+  const raw = readFileSync(clientConfigPath("codex"), "utf-8");
+  const m = raw.match(/args = \["-y", "([^"]+)"\]/);
+  return m ? m[1] : null;
+}
+
+// ── JSON clients (Gemini, Cursor, Claude Code fallback) ────────────────────
+
+describe("flair#1135 — JSON client pin refresh (wireJsonMcp)", () => {
+  // Test every JSON-based client (all except Codex, which uses TOML).
+  const jsonClients = ALL_CLIENTS.filter(c => c.id !== "codex");
+
+  for (const client of jsonClients) {
+    describe(client.label, () => {
+      it("stale pin → refresh: updates to current version", () => {
+        writeJsonConfig(client.id as ClientId, STALE_SPEC);
+        const path = clientConfigPath(client.id as ClientId);
+
+        // Pre-condition: the config has the stale pin.
+        expect(readJsonPin(client.id as ClientId)).toBe(STALE_SPEC);
+
+        // Wire — should refresh the pin.
+        const res = client.wire({ ...ENV, FLAIR_CLIENT: client.id });
+        expect(res.ok).toBe(true);
+        expect(res.message).toContain("refreshed pin");
+
+        // Post-condition: the config now has the current pin.
+        expect(readJsonPin(client.id as ClientId)).toBe(CURRENT_SPEC);
+
+        // The file should contain the current spec.
+        const raw = readFileSync(path, "utf-8");
+        expect(raw).toContain(CURRENT_SPEC);
+      });
+
+      it("current pin → no-op: byte-identical output", () => {
+        writeJsonConfig(client.id as ClientId, CURRENT_SPEC);
+        const path = clientConfigPath(client.id as ClientId);
+        const before = readFileSync(path, "utf-8");
+
+        // Wire — should be a no-op.
+        const res = client.wire({ ...ENV, FLAIR_CLIENT: client.id });
+        expect(res.ok).toBe(true);
+        expect(res.message).toContain("already wired");
+
+        // Post-condition: file is byte-identical.
+        const after = readFileSync(path, "utf-8");
+        expect(after).toBe(before);
+      });
+
+      it("no existing config → fresh wire (not a refresh)", () => {
+        // No config file exists — should be a fresh wire.
+        const res = client.wire({ ...ENV, FLAIR_CLIENT: client.id });
+        expect(res.ok).toBe(true);
+        expect(res.message).toContain("wired");
+        expect(res.message).not.toContain("refreshed");
+        expect(res.message).not.toContain("already wired");
+
+        // The config should have the current pin.
+        expect(readJsonPin(client.id as ClientId)).toBe(CURRENT_SPEC);
+      });
+    });
+  }
+});
+
+// ── Codex TOML client ──────────────────────────────────────────────────────
+
+describe("flair#1135 — Codex TOML pin refresh (_wireCodex)", () => {
+  const codexClient = ALL_CLIENTS.find(c => c.id === "codex")!;
+
+  it("stale pin → refresh: updates to current version", () => {
+    writeCodexConfig(STALE_SPEC);
+    const path = clientConfigPath("codex");
+
+    // Pre-condition: the config has the stale pin.
+    expect(readCodexPin()).toBe(STALE_SPEC);
+
+    // Wire — should refresh the pin.
+    const res = codexClient.wire({ ...ENV, FLAIR_CLIENT: "codex" });
+    expect(res.ok).toBe(true);
+    expect(res.message).toContain("refreshed pin");
+
+    // Post-condition: the config now has the current pin.
+    expect(readCodexPin()).toBe(CURRENT_SPEC);
+
+    const raw = readFileSync(path, "utf-8");
+    expect(raw).toContain(CURRENT_SPEC);
+  });
+
+  it("current pin → no-op: byte-identical output", () => {
+    writeCodexConfig(CURRENT_SPEC);
+    const path = clientConfigPath("codex");
+    const before = readFileSync(path, "utf-8");
+
+    // Wire — should be a no-op.
+    const res = codexClient.wire({ ...ENV, FLAIR_CLIENT: "codex" });
+    expect(res.ok).toBe(true);
+    expect(res.message).toContain("already wired");
+
+    // Post-condition: file is byte-identical.
+    const after = readFileSync(path, "utf-8");
+    expect(after).toBe(before);
+  });
+
+  it("no existing config → fresh wire (not a refresh)", () => {
+    const res = codexClient.wire({ ...ENV, FLAIR_CLIENT: "codex" });
+    expect(res.ok).toBe(true);
+    expect(res.message).toContain("wired");
+    expect(res.message).not.toContain("refreshed");
+    expect(res.message).not.toContain("already wired");
+
+    expect(readCodexPin()).toBe(CURRENT_SPEC);
+  });
+
+  it("stale pin → refresh preserves other TOML content", () => {
+    const path = clientConfigPath("codex");
+    mkdirSync(join(path, ".."), { recursive: true });
+    const prefix = [
+      `# Codex config`,
+      `log_level = "info"`,
+      ``,
+    ].join("\n") + "\n";
+    const suffix = [
+      ``,
+      `[other_server]`,
+      `command = "echo"`,
+    ].join("\n") + "\n";
+    const toml = prefix +
+      `[mcp_servers.flair]\ncommand = "npx"\nargs = ["-y", "${STALE_SPEC}"]\n\n[mcp_servers.flair.env]\nFLAIR_AGENT_ID = "${ENV.FLAIR_AGENT_ID}"\nFLAIR_URL = "${ENV.FLAIR_URL}"\n` +
+      suffix;
+    writeFileSync(path, toml);
+
+    const res = codexClient.wire({ ...ENV, FLAIR_CLIENT: "codex" });
+    expect(res.ok).toBe(true);
+    expect(res.message).toContain("refreshed pin");
+
+    const raw = readFileSync(path, "utf-8");
+    // Prefix preserved.
+    expect(raw).toContain("# Codex config");
+    expect(raw).toContain('log_level = "info"');
+    // Pin updated.
+    expect(raw).toContain(CURRENT_SPEC);
+    expect(raw).not.toContain(STALE_SPEC);
+    // Suffix preserved.
+    expect(raw).toContain("[other_server]");
+    expect(raw).toContain('command = "echo"');
+  });
+});
+
+// ── codexFlairSectionHasCurrentPin (internal, tested via _wireCodex) ────────
+
+describe("flair#1135 — codexConfigHasFlairSection (existing, unchanged)", () => {
+  it("detects the section header", () => {
+    expect(codexConfigHasFlairSection("[mcp_servers.flair]\ncommand = \"npx\"\n")).toBe(true);
+  });
+
+  it("does not false-positive on a sub-table header", () => {
+    expect(codexConfigHasFlairSection("[mcp_servers.flair.env]\nFLAIR_URL = \"...\"\n")).toBe(false);
+  });
+
+  it("does not false-positive on a different server", () => {
+    expect(codexConfigHasFlairSection("[mcp_servers.other]\ncommand = \"echo\"\n")).toBe(false);
+  });
+});
+
+// ── tomlSnippet (existing, unchanged — regression guard) ────────────────────
+
+describe("flair#1135 — tomlSnippet still pins (regression guard)", () => {
+  it("pins to the current version", () => {
+    const snippet = tomlSnippet(ENV);
+    expect(snippet).toContain(CURRENT_SPEC);
+    expect(snippet).not.toContain(`"${FLAIR_MCP_PACKAGE}"`);
+  });
+});


### PR DESCRIPTION
## Summary

Makes all three MCP client-wiring guards version-aware so stale `@tpsdev-ai/flair-mcp` pins in client configs are refreshed by `flair init` re-runs and `flair upgrade`.

### Changes

1. **`wireJsonMcp` (JSON clients)** — compares `existing.args` against `mcpServerSpec()`, returns "refreshed pin in" when URL/agent match but pin is stale.

2. **Inline Claude Code wiring (`cli.ts`)** — same version-aware comparison on the inline `args` array.

3. **`_wireCodex` (TOML)** — new helpers `codexFlairSectionHasCurrentPin()` and `replaceCodexFlairBlock()` for version-aware TOML section detection and replacement.

4. **`flair upgrade` refresh** — after a successful upgrade, calls `refreshWiredClients()` which detects installed clients, checks if already wired, and re-wires to refresh stale pins. Best-effort: failures warn but never fail the upgrade.

### Mutation Proof

- **stale pin → refresh**: config with `@tpsdev-ai/flair-mcp@0.40.0` → re-wired to current `@tpsdev-ai/flair-mcp@0.41.0`
- **current pin → no-op**: config already at current pin → byte-identical, no re-write
- **all three wiring shapes**: JSON (Claude Code, Gemini, Cursor) + Codex TOML

### Tests

17 new tests in `test/unit/clients-pin-refresh.test.ts` covering stale→refresh, current→no-op, fresh wire, all three shapes, TOML content preservation, edge cases. All 17 pass. All 15 existing `mcp-spec-pinning.test.ts` tests pass. Full unit suite: 3974 pass, 2 pre-existing failures, 9 skip.

### ⚠️ Flag: SessionStart Hook Inconsistency

The SessionStart hook uses **unpinned** `npx -y @tpsdev-ai/flair-mcp` (self-updating) while the client MCP-server config **pins** for supply-chain reasons (flair#907). This is an inconsistency — the pin exists precisely to guard the supply chain, but the hook bypasses it. Worth a separate issue to decide whether the hook should also pin.


Closes #1135
