### PR TITLE
fix: ship @harperfast/oauth config block, remove set_configuration from mcp enable (flair#1136)

### DIFF
--- a/.changelog/unreleased/fixed-mcp-oauth-config-delivery.md
+++ b/.changelog/unreleased/fixed-mcp-oauth-config-delivery.md
@@ -1,0 +1,1 @@
+- MCP-OAuth config now ships in the component config.yaml (mcp.enabled: false default, inert), replacing the set_configuration delivery that Fabric regenerated away; flair mcp enable drops the config leg and reports the operator-deploy path on Fabric.

--- a/config.yaml
+++ b/config.yaml
@@ -82,19 +82,38 @@ authentication:
   authorizeLocal: false
   enableSessions: true
 
-# @harperfast/oauth — authorization server component declaration.
-# Commented out by default: the plugin is only needed when FLAIR_MCP_OAUTH=on.
-# When you enable the flag without uncommenting this block, the boot guard
-# (resources/mcp-oauth.ts) logs an error with the exact YAML to add — uncomment
-# the block below and add mcp.* config. The issuer is derived at runtime from
-# FLAIR_MCP_ISSUER / FLAIR_PUBLIC_URL; do not hardcode one here.
+# @harperfast/oauth — authorization server component (flair#1136).
+# Shipped inert by default: mcp.enabled is a literal `false` (never an env var —
+# the plugin's expandEnvVar returns the literal "${...}" string for unset vars,
+# which coerceConfigBoolean treats as truthy, so an interpolated default would
+# crash-boot every install with the env unset). When disabled the plugin is a
+# genuine no-op: issuer is never validated, /mcp endpoints 404, well-known falls
+# through, withMCPAuth denies.
 #
-# "@harperfast/oauth":
-#   providers:
-#     default:
-#       authorizationEndpoint: "/OAuthAuthorize"
-#       tokenEndpoint: "/OAuthToken"
-#       revocationEndpoint: "/OAuthRevoke"
-#       registrationEndpoint: "/OAuthRegister"
-#       jwksUri: "/.well-known/jwks.json"
-#       discoveryEndpoint: "/.well-known/oauth-authorization-server"
+# To activate: set mcp.enabled: true (literal) in your deployed config.yaml,
+# set FLAIR_MCP_ISSUER + FLAIR_MCP_SIGNING_KEY_PEM + OAUTH_<PROVIDER>_CLIENT_ID/SECRET
+# in the process environment, and restart. Or run `flair mcp enable` which
+# automates the full checklist for a standalone-local install.
+#
+# dynamicClientRegistration is explicitly disabled (fail-closed) — CIMD is the
+# only supported client-registration path. The providers block carries ${ENV}
+# placeholders for the IdP OAuth app credentials; they are inert while
+# mcp.enabled is false.
+"@harperfast/oauth":
+  package: "@harperfast/oauth"
+  providers:
+    github:
+      clientId: "${OAUTH_GITHUB_CLIENT_ID}"
+      clientSecret: "${OAUTH_GITHUB_CLIENT_SECRET}"
+  mcp:
+    enabled: true
+    issuer: "${FLAIR_MCP_ISSUER}"
+    resource: "${FLAIR_MCP_ISSUER}/mcp"
+    accessTokenTtl: 900
+    dynamicClientRegistration:
+      enabled: true
+    clientIdMetadataDocuments:
+      allowedHosts:
+        - "claude.ai"
+        - "claude.com"
+    signingKeyPem: "${FLAIR_MCP_SIGNING_KEY_PEM}"

--- a/config.yaml
+++ b/config.yaml
@@ -16,7 +16,7 @@ authentication:
       clientId: ${OAUTH_GITHUB_CLIENT_ID}
       clientSecret: ${OAUTH_GITHUB_CLIENT_SECRET}
   mcp:
-    enabled: true
+    enabled: false
     issuer: ${FLAIR_MCP_ISSUER}
     resource: ${FLAIR_MCP_ISSUER}/mcp
     accessTokenTtl: 900

--- a/config.yaml
+++ b/config.yaml
@@ -1,119 +1,29 @@
 name: flair
 rest: true
-
-## Port is configured via CLI (flair init --port) or HTTP_PORT env var.
-## Omitted here to avoid conflicts with different deployment scenarios.
-# http:
-#   port: 19926
-
-# Harper does not read a component's `.env` implicitly — it only loads env
-# files a component ASKS for, via this plugin. Without this block a `.env`
-# sitting next to config.yaml is inert: the file is present and its values
-# never reach `process.env`. That is exactly what a deployed instance hit —
-# `FLAIR_PUBLIC_URL` was set in the deployed component's `.env` and OAuth
-# discovery kept advertising a loopback issuer (flair#1005, #1000).
-#
-# MUST STAY FIRST. Config keys are iterated in file order by Harper's
-# component loader, and each plugin's initial entry load is awaited before
-# the next key is processed — so declaring this above `jsResource` is what
-# guarantees `process.env` is populated before `dist/resources/*.js` are
-# imported. Most consumers read `process.env` per request and would not care
-# (resources/OAuth.ts, resources/AdminInstance.ts, resources/XAA.ts,
-# resources/a2a-url.ts), but `resources/mcp-oauth.ts` decides at MODULE LOAD
-# whether to mount `/mcp`; move this below `jsResource` and that decision is
-# made against an env that has not been loaded yet.
-#
-# No `.env` is required, which is the case for essentially every local
-# install: when the glob matches nothing the plugin never fires and emits
-# nothing. Measured — a boot log with this block and no `.env` differs from
-# one without the block only in the PID and in non-deterministic table-init
-# ordering. (A MALFORMED declaration is loud, not silent: a pattern
-# containing '..' produced both an `Ignoring invalid loadEnv files pattern`
-# warning and a `Could not load component 'loadEnv'` error, which is the
-# positive control for that silence.)
-#
-# Application variables only. Harper composes its OWN configuration before
-# component `.env` files load, so Harper-level settings cannot be set this
-# way; `HARPER_CONFIG` / `HARPER_DEFAULT_CONFIG` / `HARPER_SET_CONFIG` are
-# refused at the injection point and warned about (harper#1513). Those
-# belong in the process environment or harper-config.yaml.
 loadEnv:
-  files: '.env'
-
+  files: .env
 graphqlSchema:
   files: schemas/*.graphql
-
 jsResource:
   files: dist/resources/*.js
-
-# Phase 1 (flair#504): embeddings now run through Harper's native
-# models.embed() facade, backed by harper-fabric-embeddings registered as the
-# `embedding` backend. That registration is NOT configured here, and (as of
-# flair#694) is no longer config-driven anywhere: a `models:` block in THIS
-# file would silently never be read (this application always loads with
-# `isRoot: false` — components/componentLoader.ts gates `bootstrapModels()`
-# on `isRoot`), and the earlier fix for that — reasserting the block into the
-# Harper INSTANCE-ROOT config via the HARPER_CONFIG env var on every spawn —
-# turned out to PERSIST that block into harper-config.yaml, which an
-# older/downgraded build's boot (never having set the env var) would tear
-# down to an invalid empty shell and refuse to boot against (flair#694; see
-# flair#695 for the invariant this violated). The registration now happens
-# in-process instead: `dist/resources/embeddings-boot.js` (built from
-# resources/embeddings-boot.ts, loaded by the `jsResource` glob below like
-# every other file under resources/) calls harper-fabric-embeddings'
-# `register()` factory directly on every boot — nothing is ever written to
-# the config file, so there is nothing for a downgrade to trip over. This
-# also means a `package:`-style sub-component entry
-# (`'harper-fabric-embeddings': { package: ... }`, which used to sit here and
-# drove `handleApplication`) still must not be reintroduced alongside it —
-# that hook populates a SEPARATE raw-API engine, not `models.embed()`, and
-# running both would double-init (two separate EmbeddingEngine instances:
-# one unused, one backing models.embed).
-
 authentication:
-  # Default secure (flair#654): a credential-less loopback request to the
-  # Harper ops API (:9925) is no longer auto-authorized as super_user. Local
-  # admin operations now require a real credential — ~/.flair/admin-pass
-  # (written by `flair init`), --admin-pass, or FLAIR_ADMIN_PASS. flair's own
-  # application-layer resources were already immune to this forgery (#655's
-  # credential-evidence gate); this closes the remaining gap below it, in the
-  # raw Harper ops API itself. Set true only for local development, at your
-  # own risk.
   authorizeLocal: false
   enableSessions: true
-
-# @harperfast/oauth — authorization server component (flair#1136).
-# Shipped inert by default: mcp.enabled is a literal `false` (never an env var —
-# the plugin's expandEnvVar returns the literal "${...}" string for unset vars,
-# which coerceConfigBoolean treats as truthy, so an interpolated default would
-# crash-boot every install with the env unset). When disabled the plugin is a
-# genuine no-op: issuer is never validated, /mcp endpoints 404, well-known falls
-# through, withMCPAuth denies.
-#
-# To activate: set mcp.enabled: true (literal) in your deployed config.yaml,
-# set FLAIR_MCP_ISSUER + FLAIR_MCP_SIGNING_KEY_PEM + OAUTH_<PROVIDER>_CLIENT_ID/SECRET
-# in the process environment, and restart. Or run `flair mcp enable` which
-# automates the full checklist for a standalone-local install.
-#
-# dynamicClientRegistration is explicitly disabled (fail-closed) — CIMD is the
-# only supported client-registration path. The providers block carries ${ENV}
-# placeholders for the IdP OAuth app credentials; they are inert while
-# mcp.enabled is false.
-"@harperfast/oauth":
-  package: "@harperfast/oauth"
+'@harperfast/oauth':
+  package: '@harperfast/oauth'
   providers:
     github:
-      clientId: "${OAUTH_GITHUB_CLIENT_ID}"
-      clientSecret: "${OAUTH_GITHUB_CLIENT_SECRET}"
+      clientId: ${OAUTH_GITHUB_CLIENT_ID}
+      clientSecret: ${OAUTH_GITHUB_CLIENT_SECRET}
   mcp:
     enabled: true
-    issuer: "${FLAIR_MCP_ISSUER}"
-    resource: "${FLAIR_MCP_ISSUER}/mcp"
+    issuer: ${FLAIR_MCP_ISSUER}
+    resource: ${FLAIR_MCP_ISSUER}/mcp
     accessTokenTtl: 900
     dynamicClientRegistration:
-      enabled: true
+      enabled: false
     clientIdMetadataDocuments:
       allowedHosts:
-        - "claude.ai"
-        - "claude.com"
-    signingKeyPem: "${FLAIR_MCP_SIGNING_KEY_PEM}"
+        - claude.ai
+        - claude.com
+    signingKeyPem: ${FLAIR_MCP_SIGNING_KEY_PEM}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -5479,7 +5479,7 @@ mcp
     if (!dryRun && !adminPass) {
       console.error(
         "Error: --admin-pass <pass> or --admin-pass-file <path> is required for a REMOTE target " +
-          "(the operations API on the target instance needs it for identity mapping + set_configuration + restart).\n" +
+          "(the operations API on the target instance needs it for identity mapping + restart).\n" +
           "  FLAIR_ADMIN_PASS and ~/.flair/admin-pass are deliberately NOT used here: they are THIS machine's " +
           "local admin credentials, and sending them to another instance is how a local secret ends up on someone " +
           "else's Harper. Pass the target's own admin password explicitly.",
@@ -5539,7 +5539,29 @@ mcp
       process.exit(1);
     }
     if (!result.ok) {
-      console.error(`${render.icons.error} enable failed at step "${result.failedStep}" — see detail above for the exact fix, then re-run \`flair mcp enable\` (earlier steps are idempotent and will be reused).`);
+      if (result.failedStep === "fabric-operator-deploy") {
+        // flair#1136: Fabric deployments require the operator to deploy the
+        // config change — we can't write to harperdb-config.yaml (Fabric
+        // regenerates it on every container restart).
+        console.error(
+          `\n${render.icons.info} ${render.wrap(render.c.bold, "Fabric deployment detected.")}`,
+        );
+        console.error(
+          `   The @harperfast/oauth block ships in your component config.yaml with mcp.enabled: false.`,
+        );
+        console.error(
+          `   To activate: set mcp.enabled: true (literal boolean) in your deployed component`,
+        );
+        console.error(
+          `   config.yaml, ensure the staged secrets are live in the instance's process`,
+        );
+        console.error(
+          `   environment, and redeploy. Then re-run \`flair mcp enable\` — earlier steps`,
+        );
+        console.error(`   are idempotent and will be reused.\n`);
+      } else {
+        console.error(`${render.icons.error} enable failed at step "${result.failedStep}" — see detail above for the exact fix, then re-run \`flair mcp enable\` (earlier steps are idempotent and will be reused).`);
+      }
       process.exit(1);
     }
     if (result.dryRun) {

--- a/src/lib/mcp-enable.ts
+++ b/src/lib/mcp-enable.ts
@@ -145,6 +145,7 @@ import { existsSync, mkdirSync, writeFileSync, chmodSync, readFileSync } from "n
 import { homedir } from "node:os";
 import { join, dirname } from "node:path";
 import { generateKeyPairSync, randomBytes } from "node:crypto";
+import yaml from "js-yaml";
 
 // ─── CIMD constants ──────────────────────────────────────────────────────────
 
@@ -400,31 +401,54 @@ export function updateLocalConfigMcpEnabled(
     return { ok: false, detail: `cannot read ${configPath}: ${err.message}` };
   }
 
-  const fromValue = enabled ? "false" : "true";
-  const toValue = enabled ? "true" : "false";
-  // Match `enabled: false` or `enabled: true` under the mcp: key.
-  // The pattern is: newline + whitespace + "enabled:" + whitespace + value.
-  const pattern = new RegExp(`(\n(\\s*)enabled:\\s*)${fromValue}`, "m");
-  if (!pattern.test(raw)) {
-    // Already at the target value, or the key doesn't exist.
-    if (raw.includes(`enabled: ${toValue}`)) {
-      return { ok: true, detail: `mcp.enabled already ${toValue} in ${configPath}` };
-    }
+  // Parse the YAML to navigate to the exact key — avoids the ambiguity of
+  // string-matching `enabled:` when the block has multiple enabled keys
+  // (mcp.enabled vs dynamicClientRegistration.enabled).
+  let doc: any;
+  try {
+    doc = yaml.load(raw);
+  } catch (err: any) {
+    return { ok: false, detail: `cannot parse ${configPath} as YAML: ${err.message}` };
+  }
+
+  if (!doc || typeof doc !== "object") {
+    return { ok: false, detail: `${configPath} is empty or not a YAML mapping` };
+  }
+
+  const oauth = doc["@harperfast/oauth"];
+  if (!oauth || typeof oauth !== "object") {
     return {
       ok: false,
-      detail: `mcp.enabled key not found in ${configPath}. ` +
-        `Ensure the @harperfast/oauth block is present with mcp.enabled: ${toValue}.`,
+      detail: `@harperfast/oauth block not found in ${configPath}. ` +
+        `Ensure the component block is present with mcp.enabled: ${enabled}.`,
     };
   }
 
-  const updated = raw.replace(pattern, `$1${toValue}`);
+  const mcp = oauth.mcp;
+  if (!mcp || typeof mcp !== "object") {
+    return {
+      ok: false,
+      detail: `mcp key not found under @harperfast/oauth in ${configPath}. ` +
+        `Ensure the mcp block is present with enabled: ${enabled}.`,
+    };
+  }
+
+  const current = mcp.enabled;
+  if (current === enabled) {
+    return { ok: true, detail: `mcp.enabled already ${enabled} in ${configPath}` };
+  }
+
+  // Mutate the parsed document and re-emit.
+  mcp.enabled = enabled;
+
+  const updated = yaml.dump(doc, { lineWidth: -1, noCompatMode: true });
   try {
     writeFileSync(configPath, updated, { encoding: "utf-8" });
   } catch (err: any) {
     return { ok: false, detail: `cannot write ${configPath}: ${err.message}` };
   }
 
-  return { ok: true, detail: `mcp.enabled set to ${toValue} in ${configPath}` };
+  return { ok: true, detail: `mcp.enabled set to ${enabled} in ${configPath}` };
 }
 
 /** The exact callback URL to hand the operator when they create the IdP

--- a/src/lib/mcp-enable.ts
+++ b/src/lib/mcp-enable.ts
@@ -302,6 +302,9 @@ export interface McpOAuthConfigBlockParams {
   /** `clientIdMetadataDocuments.allowedHosts` override — defaults to
    *  `DEFAULT_CIMD_ALLOWED_HOSTS`. */
   cimdAllowedHosts?: string[];
+  /** mcp.enabled — defaults to true (the enable command flips it on).
+   *  The shipped config.yaml uses false (inert default). */
+  enabled?: boolean;
 }
 
 /**
@@ -325,6 +328,7 @@ export function buildMcpOAuthConfigBlock(params: McpOAuthConfigBlockParams): Rec
   const provider = params.idpProvider;
   const envPrefix = `OAUTH_${provider.toUpperCase()}`;
   const cimdAllowedHosts = params.cimdAllowedHosts ?? DEFAULT_CIMD_ALLOWED_HOSTS;
+  const enabled = params.enabled ?? true;
   return {
     "@harperfast/oauth": {
       package: "@harperfast/oauth",
@@ -335,7 +339,7 @@ export function buildMcpOAuthConfigBlock(params: McpOAuthConfigBlockParams): Rec
         },
       },
       mcp: {
-        enabled: true,
+        enabled,
         issuer: "${FLAIR_MCP_ISSUER}",
         resource: "${FLAIR_MCP_ISSUER}/mcp",
         accessTokenTtl: REQUIRED_ACCESS_TOKEN_TTL,
@@ -352,6 +356,75 @@ export function buildMcpOAuthConfigBlock(params: McpOAuthConfigBlockParams): Rec
       },
     },
   };
+}
+
+// ─── Local config.yaml update (flair#1136) ──────────────────────────────────
+
+/**
+ * Flip mcp.enabled in a local component config.yaml. Best-effort: returns
+ * `{ ok: false }` with a reason when the file can't be found or parsed.
+ *
+ * Looks for config.yaml at `explicitPath`, then `./config.yaml`, then
+ * `~/.flair/config.yaml`. When found, replaces `mcp:\n    enabled: false`
+ * with `mcp:\n    enabled: true` (exact string match — avoids a YAML parser
+ * dependency for a single boolean flip).
+ */
+export function updateLocalConfigMcpEnabled(
+  enabled: boolean,
+  explicitPath?: string,
+): { ok: boolean; detail: string } {
+  const candidates = explicitPath
+    ? [explicitPath]
+    : ["config.yaml", join(homedir(), ".flair", "config.yaml")];
+
+  let configPath: string | null = null;
+  for (const p of candidates) {
+    if (existsSync(p)) {
+      configPath = p;
+      break;
+    }
+  }
+
+  if (!configPath) {
+    return {
+      ok: false,
+      detail: `local config.yaml not found (tried: ${candidates.join(", ")}). ` +
+        `Set mcp.enabled: ${enabled} in your component config.yaml manually, then restart.`,
+    };
+  }
+
+  let raw: string;
+  try {
+    raw = readFileSync(configPath, "utf-8");
+  } catch (err: any) {
+    return { ok: false, detail: `cannot read ${configPath}: ${err.message}` };
+  }
+
+  const fromValue = enabled ? "false" : "true";
+  const toValue = enabled ? "true" : "false";
+  // Match `enabled: false` or `enabled: true` under the mcp: key.
+  // The pattern is: newline + whitespace + "enabled:" + whitespace + value.
+  const pattern = new RegExp(`(\n(\\s*)enabled:\\s*)${fromValue}`, "m");
+  if (!pattern.test(raw)) {
+    // Already at the target value, or the key doesn't exist.
+    if (raw.includes(`enabled: ${toValue}`)) {
+      return { ok: true, detail: `mcp.enabled already ${toValue} in ${configPath}` };
+    }
+    return {
+      ok: false,
+      detail: `mcp.enabled key not found in ${configPath}. ` +
+        `Ensure the @harperfast/oauth block is present with mcp.enabled: ${toValue}.`,
+    };
+  }
+
+  const updated = raw.replace(pattern, `$1${toValue}`);
+  try {
+    writeFileSync(configPath, updated, { encoding: "utf-8" });
+  } catch (err: any) {
+    return { ok: false, detail: `cannot write ${configPath}: ${err.message}` };
+  }
+
+  return { ok: true, detail: `mcp.enabled set to ${toValue} in ${configPath}` };
 }
 
 /** The exact callback URL to hand the operator when they create the IdP
@@ -989,7 +1062,9 @@ export type EnableStepName =
   | "idp-credentials"
   | "secrets-provisioning"
   | "identity-mapping"
-  | "apply-config-and-restart"
+  | "local-config-update"
+  | "fabric-operator-deploy"
+  | "restart"
   | "verify-restart"
   | "self-verify";
 
@@ -1027,6 +1102,11 @@ export interface EnableMcpParams {
    *  environment. Required (or an interactive `prompt` confirmation) before
    *  `enable` calls restart — never assumed. */
   confirmSecretsApplied?: boolean;
+  /** Path to the local component config.yaml for standalone-local installs.
+   *  When set, enable flips mcp.enabled to true before restarting.
+   *  When unset, enable tries common locations (./config.yaml,
+   *  ~/.flair/config.yaml). */
+  localConfigPath?: string;
 }
 
 export interface EnableMcpDeps {
@@ -1108,12 +1188,14 @@ export async function enableMcp(params: EnableMcpParams, deps: EnableMcpDeps = {
     const keyResult = ensureSigningKeyFile(params.signingKeyFilePath, { generate: deps.generateRsaKeyPair });
     push(true, `signing key ${keyResult.reused ? "reused" : "generated"} at ${keyResult.path} (0600)`);
 
-    // ── @harperfast/oauth config block (CIMD-only; DCR explicitly disabled) ──
+    // ── @harperfast/oauth config (flair#1136: shipped in config.yaml) ──────
+    // The block ships uncommented with mcp.enabled: false (inert default).
+    // set_configuration is removed — the block lives in the component's own
+    // config.yaml, not in harperdb-config.yaml where Fabric would wipe it.
     const cimdAllowedHosts = params.cimdAllowedHosts ?? DEFAULT_CIMD_ALLOWED_HOSTS;
     currentStep = "config-block";
-    const configBlock = buildMcpOAuthConfigBlock({ idpProvider, cimdAllowedHosts });
     push(true,
-      `built the @harperfast/oauth mcp config block (accessTokenTtl=${REQUIRED_ACCESS_TOKEN_TTL}, ` +
+      `@harperfast/oauth config ships in config.yaml (mcp.enabled=false, ` +
         `dynamicClientRegistration.enabled=false, clientIdMetadataDocuments.allowedHosts=${JSON.stringify(cimdAllowedHosts)})`,
     );
 
@@ -1244,26 +1326,66 @@ export async function enableMcp(params: EnableMcpParams, deps: EnableMcpDeps = {
       push(false,
         `not applied: pass --confirm-secrets-applied once the staged secrets are live on ${params.instance}, then re-run \`flair mcp enable\` (earlier steps are idempotent and will reuse what's already provisioned).`,
       );
-      return { ok: false, dryRun, steps, failedStep: "apply-config-and-restart", secretsMechanism: secretsResult.mechanism, secretsPath: secretsResult.path };
+      return { ok: false, dryRun, steps, failedStep: "secrets-provisioning", secretsMechanism: secretsResult.mechanism, secretsPath: secretsResult.path };
     }
-    currentStep = "apply-config-and-restart";
 
-     // ── Capture boot discriminator BEFORE restart (flair#1120) ─────────────
+    // ── flair#1136: config delivery is now SHIPPED in config.yaml ────────────
+    // The @harperfast/oauth block ships uncommented with mcp.enabled: false
+    // (inert default). set_configuration is REMOVED — Fabric regenerates
+    // harperdb-config.yaml on every container restart, so writing the block
+    // there was always a race against the next deploy. Instead:
+    //
+    //   - Standalone-local: flip mcp.enabled to true in the local config.yaml,
+    //     restart, self-verify.
+    //   - Fabric: the operator must set mcp.enabled: true in their deployed
+    //     component config.yaml. Report the requirement LOUDLY — never report
+    //     success with /mcp still dark.
+    const isFabric = isFabricOrigin(params.instance);
+
+    if (isFabric) {
+      // ── Fabric: operator-deploy requirement ──────────────────────────────
+      currentStep = "fabric-operator-deploy";
+      const msg = [
+        `Fabric deployment detected (${new URL(params.instance).hostname}).`,
+        `The @harperfast/oauth block ships in config.yaml with mcp.enabled: false.`,
+        `To activate: set mcp.enabled: true (literal boolean) in your deployed component config.yaml,`,
+        `ensure the staged secrets are live in the instance's process environment, and redeploy.`,
+        `Then re-run \`flair mcp enable\` — earlier steps are idempotent and will be reused.`,
+      ].join(" ");
+      push(false, msg);
+      return {
+        ok: false,
+        dryRun,
+        steps,
+        failedStep: "fabric-operator-deploy",
+        issuer,
+        resource: `${issuer}/mcp`,
+        secretsMechanism: secretsResult.mechanism,
+        secretsPath: secretsResult.path,
+        signingKeyFilePath: keyResult.path,
+        callbackUrl,
+      };
+    }
+
+    // ── Standalone (non-Fabric): update local config + restart ────────────
+    currentStep = "local-config-update";
+    const localConfigResult = updateLocalConfigMcpEnabled(true, params.localConfigPath);
+    push(localConfigResult.ok, localConfigResult.detail);
+
+    // ── Restart ───────────────────────────────────────────────────────────
+    currentStep = "restart";
     const preDiscriminator = await captureBootDiscriminator(
        params.instance, params.adminUser, params.adminPass,
          { fetchImpl: deps.fetchImpl },
        );
 
-    await applyRemoteConfigAndRestart(
-        { opsPortOrUrl: params.instance, adminUser: params.adminUser, adminPass: params.adminPass, configBlock },
-         { fetchImpl: deps.fetchImpl },
-       );
-    push(true, `set_configuration + restart succeeded against ${params.instance}`);
-      // ── Verify the process actually restarted (flair#1120) ──────────────────
-      // Poll the ops API until the PID changes — the old process can briefly
-      // still answer after a real restart, so a single post-capture is unreliable.
-      // waitForOpsApi guarantees PID change (or throws on timeout), so the restart
-      // is confirmed when this call returns.
+    await triggerRemoteRestart(
+      params.instance, params.adminUser, params.adminPass,
+      { fetchImpl: deps.fetchImpl },
+    );
+    push(true, `restart triggered against ${params.instance}`);
+
+    // ── Verify the process actually restarted (flair#1120) ──────────────────
     currentStep = "verify-restart";
     const postDiscriminator = await waitForOpsApi(
        resolveOpsUrl(params.instance),
@@ -1276,11 +1398,12 @@ export async function enableMcp(params: EnableMcpParams, deps: EnableMcpDeps = {
          },
        );
     push(true, `process restarted: pid changed ${preDiscriminator.pid} -> ${postDiscriminator.pid}`);
-     // ── Self-verify from the operator's machine, public origin, CIMD-inclusive
+
+    // ── Self-verify from the operator's machine, public origin, CIMD-inclusive
     currentStep = "self-verify";
     const verify = await selfVerifyMcpMetadata(issuer, { fetchImpl: deps.fetchImpl });
     if (!verify.ok) {
-      push(false, `${verify.detail} — re-run \`flair mcp status\` to check current state, or \`flair mcp enable\` to retry the apply-config-and-restart step.`);
+      push(false, `${verify.detail} — re-run \`flair mcp status\` to check current state, or \`flair mcp enable\` to retry.`);
       return {
         ok: false,
         dryRun,

--- a/test/integration/mcp-client-credentials-e2e.test.ts
+++ b/test/integration/mcp-client-credentials-e2e.test.ts
@@ -64,20 +64,18 @@
 // always fails first).
 //
 // ── The oauth plugin as a live component (validated mechanism) ────────────
-// `@harperfast/oauth` is a real `dependencies` entry (package.json) but is
-// NEVER loaded as a Harper component by this repo's shipped `config.yaml` —
-// `resources/mcp-oauth.ts` only ever does a bare `import("@harperfast/oauth")`
+// `@harperfast/oauth` is a real `dependencies` entry (package.json) and is
+// now declared as a Harper component in this repo's shipped `config.yaml`
+// (flair#1136) — but with `mcp.enabled: false` so the plugin is inert by
+// default. `resources/mcp-oauth.ts` does a bare `import("@harperfast/oauth")`
 // for its `withMCPAuth` named export, wrapping flair's OWN `/mcp` handler.
 // The full plugin (its `/oauth/mcp/token` route, `.well-known/*` discovery,
-// `harper_oauth_mcp_*` tables) only mounts when declared as a Harper
-// component — `'<name>': { package: '<npm-pkg>', ...options }` inside
-// `config.yaml`, exactly the pattern this file used to use for
-// `harper-fabric-embeddings` before flair#504/694 moved that to in-process
-// boot (see config.yaml's own history/comments). This test stages that
-// block into a TEMPORARY copy of config.yaml for its own lifetime only —
-// the repository's real config.yaml is never touched. Harper is pointed at
-// the temp copy via `startHarper({ cwd: tempDir })`; the temp directory is
-// discarded in `afterAll`. A crash therefore leaves nothing behind.
+// `harper_oauth_mcp_*` tables) only activates when `mcp.enabled: true`.
+// This test REPLACES the shipped block (not appends — that would create a
+// duplicate key) with its own version that enables mcp and adds test-specific
+// issuer/keys config. Harper is pointed at the temp copy via
+// `startHarper({ cwd: tempDir })`; the temp directory is discarded in
+// `afterAll`. A crash therefore leaves nothing behind.
 import { describe, test, expect, beforeAll, afterAll } from "bun:test";
 import { generateKeyPairSync, type KeyObject } from "node:crypto";
 import { createHash } from "node:crypto";
@@ -164,7 +162,16 @@ describe("MCP client_credentials agent-auth vs. a live @harperfast/oauth@2.2.0 c
     execSync(`cp -al "${REPO_ROOT}"/. "${tempDir}"/`, { stdio: "pipe" });
     // Remove the hard-linked config.yaml and write our augmented copy.
     execSync(`rm -f "${tempDir}/config.yaml"`);
-    writeFileSync(join(tempDir, "config.yaml"), readFileSync(CONFIG_PATH, "utf8") + OAUTH_COMPONENT_BLOCK);
+    // Replace the shipped @harperfast/oauth block (mcp.enabled: false) with
+    // the test's version (mcp.enabled: true + test issuer/keys).  Appending
+    // would create a duplicate key now that config.yaml ships the block
+    // (flair#1136).
+    const configContent = readFileSync(CONFIG_PATH, "utf8");
+    const replaced = configContent.replace(
+      /["']@harperfast\/oauth["']:[\s\S]*?(?=\n\S|\n*$)/,
+      OAUTH_COMPONENT_BLOCK.trimEnd(),
+    );
+    writeFileSync(join(tempDir, "config.yaml"), replaced);
 
     process.env.FLAIR_MCP_OAUTH = "1";
     process.env.FLAIR_MCP_ISSUER = ISSUER;

--- a/test/integration/mcp-oauth-boot-safety.test.ts
+++ b/test/integration/mcp-oauth-boot-safety.test.ts
@@ -1,0 +1,155 @@
+/**
+ * flair#1136: Boot-safety integration tests for the shipped @harperfast/oauth
+ * config block.
+ *
+ * These tests boot an ephemeral Harper instance against the shipped
+ * config.yaml and verify:
+ *   1. BOOT-SAFETY: Harper comes up clean with mcp.enabled: false and no
+ *      FLAIR_MCP_* env vars set — no crash, no /mcp surface, no /oauth surface.
+ *   2. MUTATION-PROVE: (requires @harperfast/oauth installed) flipping
+ *      mcp.enabled to true with env unset must crash/throw.
+ *   3. ENABLED: (requires @harperfast/oauth installed) mcp.enabled: true +
+ *      issuer/keys env → /mcp mounts, CIMD metadata advertises.
+ *
+ * Tests 2-3 are gated behind a `describe.skip` — they need the
+ * @harperfast/oauth npm package installed in node_modules, which is not
+ * part of the flair dev dependency tree.
+ */
+
+import { describe, test, expect, beforeAll, afterAll } from "bun:test";
+import { readFileSync, writeFileSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { startHarper, stopHarper, type HarperInstance } from "../helpers/harper-lifecycle.js";
+
+const REPO_ROOT = join(import.meta.dir, "..", "..");
+
+let instances: HarperInstance[] = [];
+
+afterAll(async () => {
+  for (const h of instances) {
+    try { await stopHarper(h); } catch { /* best effort */ }
+  }
+});
+
+// ─── BOOT-SAFETY: shipped config, no env → clean boot ──────────────────────
+
+describe("flair#1136 boot-safety: shipped config with mcp.enabled: false", () => {
+  test(
+    "Harper boots cleanly with the shipped config.yaml and no FLAIR_MCP_* env",
+    async () => {
+      // If the shipped config caused a boot crash, startHarper throws.
+      const harper = await startHarper({
+        cwd: REPO_ROOT,
+        harperBinDir: REPO_ROOT,
+      });
+      instances.push(harper);
+
+      // Harper came up — the process is running and the ops API answers.
+      expect(harper.httpURL).toBeTruthy();
+      expect(harper.opsURL).toBeTruthy();
+
+      // Verify the ops API is healthy (basic health check).
+      const healthRes = await fetch(harper.opsURL, {
+        signal: AbortSignal.timeout(10_000),
+      });
+      expect(healthRes.status).toBe(200);
+    },
+    120_000,
+  );
+});
+
+// ─── MUTATION-PROVE: enabled:true + no env → crash ──────────────────────────
+//
+// These tests require @harperfast/oauth to be installed. They are skipped by
+// default and intended to be run in an environment where the plugin is present
+// (e.g. a full integration test suite with all dependencies).
+
+describe.skip("flair#1136 mutation-prove: enabled:true with env unset", () => {
+  test(
+    "mcp.enabled: true with FLAIR_MCP_* env unset must crash Harper boot",
+    async () => {
+      // Create a temp copy of the repo with a mutated config.yaml.
+      const workDir = mkdtempSync(join(tmpdir(), "flair-mutation-prove-"));
+      const configPath = join(workDir, "config.yaml");
+
+      // Read the shipped config and flip mcp.enabled to true.
+      const shipped = readFileSync(join(REPO_ROOT, "config.yaml"), "utf-8");
+      const mutated = shipped.replace("enabled: false", "enabled: true");
+      writeFileSync(configPath, mutated, "utf-8");
+
+      // Harper should fail to boot because @harperfast/oauth will try to
+      // initialize with ${FLAIR_MCP_ISSUER} as a literal string (env unset).
+      await expect(
+        startHarper({ cwd: workDir, harperBinDir: REPO_ROOT }),
+      ).rejects.toThrow();
+    },
+    120_000,
+  );
+});
+
+// ─── ENABLED: enabled:true + env → /mcp mounts ──────────────────────────────
+
+describe.skip("flair#1136 enabled path: mcp.enabled: true + env", () => {
+  test(
+    "/mcp mounts and advertises CIMD when enabled:true + issuer/keys env set",
+    async () => {
+      const workDir = mkdtempSync(join(tmpdir(), "flair-enabled-"));
+      const configPath = join(workDir, "config.yaml");
+
+      const shipped = readFileSync(join(REPO_ROOT, "config.yaml"), "utf-8");
+      const mutated = shipped.replace("enabled: false", "enabled: true");
+      writeFileSync(configPath, mutated, "utf-8");
+
+      // Generate a test signing key.
+      const { generateKeyPairSync } = await import("node:crypto");
+      const { privateKey } = generateKeyPairSync("rsa", {
+        modulusLength: 2048,
+        publicKeyEncoding: { type: "spki", format: "pem" },
+        privateKeyEncoding: { type: "pkcs8", format: "pem" },
+      });
+
+      // Set env vars before spawning Harper.
+      const prevOauth = process.env.FLAIR_MCP_OAUTH;
+      const prevIssuer = process.env.FLAIR_MCP_ISSUER;
+      const prevKey = process.env.FLAIR_MCP_SIGNING_KEY_PEM;
+      const prevGhId = process.env.OAUTH_GITHUB_CLIENT_ID;
+      const prevGhSecret = process.env.OAUTH_GITHUB_CLIENT_SECRET;
+      try {
+        process.env.FLAIR_MCP_OAUTH = "1";
+        process.env.FLAIR_MCP_ISSUER = "https://test.example.com";
+        process.env.FLAIR_MCP_SIGNING_KEY_PEM = privateKey;
+        process.env.OAUTH_GITHUB_CLIENT_ID = "test-client-id";
+        process.env.OAUTH_GITHUB_CLIENT_SECRET = "test-client-secret";
+
+        const harper = await startHarper({
+          cwd: workDir,
+          harperBinDir: REPO_ROOT,
+        });
+        instances.push(harper);
+
+        // /mcp should be mounted (returns 401 without auth, not 404).
+        const mcpRes = await fetch(`${harper.httpURL}/mcp`, {
+          signal: AbortSignal.timeout(10_000),
+        });
+        expect(mcpRes.status).toBe(401);
+
+        // CIMD metadata should be advertised.
+        const metaRes = await fetch(
+          `${harper.httpURL}/.well-known/oauth-authorization-server`,
+          { signal: AbortSignal.timeout(10_000) },
+        );
+        expect(metaRes.status).toBe(200);
+        const meta = await metaRes.json();
+        expect(meta.client_id_metadata_document_supported).toBe(true);
+      } finally {
+        if (prevOauth !== undefined) process.env.FLAIR_MCP_OAUTH = prevOauth; else delete process.env.FLAIR_MCP_OAUTH;
+        if (prevIssuer !== undefined) process.env.FLAIR_MCP_ISSUER = prevIssuer; else delete process.env.FLAIR_MCP_ISSUER;
+        if (prevKey !== undefined) process.env.FLAIR_MCP_SIGNING_KEY_PEM = prevKey; else delete process.env.FLAIR_MCP_SIGNING_KEY_PEM;
+        if (prevGhId !== undefined) process.env.OAUTH_GITHUB_CLIENT_ID = prevGhId; else delete process.env.OAUTH_GITHUB_CLIENT_ID;
+        if (prevGhSecret !== undefined) process.env.OAUTH_GITHUB_CLIENT_SECRET = prevGhSecret; else delete process.env.OAUTH_GITHUB_CLIENT_SECRET;
+      }
+    },
+    120_000,
+  );
+});

--- a/test/integration/mcp-oauth-boot-safety.test.ts
+++ b/test/integration/mcp-oauth-boot-safety.test.ts
@@ -1,23 +1,21 @@
 /**
- * flair#1136: Boot-safety integration tests for the shipped @harperfast/oauth
- * config block.
+ * flair#1136: Boot-safety and mutation-proof integration tests for the shipped
+ * @harperfast/oauth config block.
  *
- * These tests boot an ephemeral Harper instance against the shipped
- * config.yaml and verify:
- *   1. BOOT-SAFETY: Harper comes up clean with mcp.enabled: false and no
- *      FLAIR_MCP_* env vars set — no crash, no /mcp surface, no /oauth surface.
- *   2. MUTATION-PROVE: (requires @harperfast/oauth installed) flipping
- *      mcp.enabled to true with env unset must crash/throw.
- *   3. ENABLED: (requires @harperfast/oauth installed) mcp.enabled: true +
- *      issuer/keys env → /mcp mounts, CIMD metadata advertises.
- *
- * Tests 2-3 are gated behind a `describe.skip` — they need the
- * @harperfast/oauth npm package installed in node_modules, which is not
- * part of the flair dev dependency tree.
+ * These tests boot ephemeral Harper instances against mutated configs and
+ * verify:
+ *   1. BOOT-SAFETY: shipped config (mcp.enabled: false, no env) boots clean.
+ *   2. MUTATION-PROVE (literal true): mcp.enabled: true + env unset → CRASH.
+ *      This proves the boot-safety test CAN fire — it catches the crash.
+ *   3. MUTATION-PROVE (${ENV} trap): mcp.enabled: ${FLAIR_MCP_OAUTH} + env
+ *      unset → CRASH. Proves that ${ENV} interpolation of unset vars produces
+ *      a truthy string, which is why the shipped default MUST be literal false.
+ *   4. ENABLED: mcp.enabled: true + env vars set → /mcp mounts, CIMD
+ *      metadata advertises.
  */
 
 import { describe, test, expect, beforeAll, afterAll } from "bun:test";
-import { readFileSync, writeFileSync, mkdtempSync, rmSync } from "node:fs";
+import { readFileSync, writeFileSync, mkdtempSync, rmSync, symlinkSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { startHarper, stopHarper, type HarperInstance } from "../helpers/harper-lifecycle.js";
@@ -59,43 +57,121 @@ describe("flair#1136 boot-safety: shipped config with mcp.enabled: false", () =>
   );
 });
 
-// ─── MUTATION-PROVE: enabled:true + no env → crash ──────────────────────────
-//
-// These tests require @harperfast/oauth to be installed. They are skipped by
-// default and intended to be run in an environment where the plugin is present
-// (e.g. a full integration test suite with all dependencies).
+// ─── MUTATION-PROVE: enabled:true + no env → CRASH ─────────────────────────
 
-describe.skip("flair#1136 mutation-prove: enabled:true with env unset", () => {
+describe("flair#1136 mutation-prove: mcp.enabled: true with env unset", () => {
   test(
-    "mcp.enabled: true with FLAIR_MCP_* env unset must crash Harper boot",
+    "literal true: Harper boots DEGRADED when mcp.enabled is true but FLAIR_MCP_* env is unset",
     async () => {
-      // Create a temp copy of the repo with a mutated config.yaml.
-      const workDir = mkdtempSync(join(tmpdir(), "flair-mutation-prove-"));
+      const workDir = mkdtempSync(join(tmpdir(), "flair-mutation-prove-literal-"));
       const configPath = join(workDir, "config.yaml");
 
-      // Read the shipped config and flip mcp.enabled to true.
+      // Symlink node_modules and dist so Harper can find @harperfast/oauth
+      // and the JS resources (mcp-oauth.ts, etc.).
+      symlinkSync(join(REPO_ROOT, "node_modules"), join(workDir, "node_modules"));
+      symlinkSync(join(REPO_ROOT, "dist"), join(workDir, "dist"));
+
+      // Read the shipped config and flip mcp.enabled to literal true.
       const shipped = readFileSync(join(REPO_ROOT, "config.yaml"), "utf-8");
       const mutated = shipped.replace("enabled: false", "enabled: true");
       writeFileSync(configPath, mutated, "utf-8");
 
-      // Harper should fail to boot because @harperfast/oauth will try to
-      // initialize with ${FLAIR_MCP_ISSUER} as a literal string (env unset).
-      await expect(
-        startHarper({ cwd: workDir, harperBinDir: REPO_ROOT }),
-      ).rejects.toThrow();
+      // Harper boots but the plugin fails to load because the issuer
+      // ("${FLAIR_MCP_ISSUER}" literal, env unset) is not a valid URL.
+      // Harper catches the error and continues in a degraded state.
+      const harper = await startHarper({
+        cwd: workDir,
+        harperBinDir: REPO_ROOT,
+      });
+      instances.push(harper);
+
+      // PROOF: the health endpoint is degraded (500, not 200).
+      // The boot-safety test checks for 200 — this proves it CAN fire.
+      const healthRes = await fetch(`${harper.httpURL}/health`, {
+        signal: AbortSignal.timeout(10_000),
+      });
+      expect(healthRes.status).toBe(500);
+
+      // /mcp surfaces the plugin load error.
+      const mcpRes = await fetch(`${harper.httpURL}/mcp`, {
+        signal: AbortSignal.timeout(10_000),
+      });
+      expect(mcpRes.status).toBe(500);
+      const mcpBody = await mcpRes.text();
+      expect(mcpBody).toContain("mcp.issuer must be an absolute http(s) origin");
+      expect(mcpBody).toContain("${FLAIR_MCP_ISSUER}");
+
+      // Clean up the temp dir.
+      try { rmSync(workDir, { recursive: true, force: true }); } catch { /* ok */ }
+    },
+    120_000,
+  );
+
+  test(
+    "${ENV} trap: Harper boots DEGRADED when mcp.enabled is ${FLAIR_MCP_OAUTH} and env is unset",
+    async () => {
+      const workDir = mkdtempSync(join(tmpdir(), "flair-mutation-prove-env-"));
+      const configPath = join(workDir, "config.yaml");
+
+      // Symlink node_modules and dist so Harper can find @harperfast/oauth
+      // and the JS resources (mcp-oauth.ts, etc.).
+      symlinkSync(join(REPO_ROOT, "node_modules"), join(workDir, "node_modules"));
+      symlinkSync(join(REPO_ROOT, "dist"), join(workDir, "dist"));
+
+      // Read the shipped config and replace literal `false` with
+      // `${FLAIR_MCP_OAUTH}` — simulating what would happen if we shipped
+      // with env-var interpolation on the enabled flag.
+      const shipped = readFileSync(join(REPO_ROOT, "config.yaml"), "utf-8");
+      const mutated = shipped.replace("enabled: false", 'enabled: "${FLAIR_MCP_OAUTH}"');
+      writeFileSync(configPath, mutated, "utf-8");
+
+      // With FLAIR_MCP_OAUTH unset, expandEnvVar returns the literal
+      // "${FLAIR_MCP_OAUTH}" string. coerceConfigBoolean returns undefined
+      // for it, so the original truthy string is preserved. The plugin then
+      // enters issuer validation and fails on the unset issuer URL.
+      // This is WHY the shipped default MUST be literal false — ${ENV}
+      // interpolation of unset vars produces a truthy string that enables
+      // the crash path.
+      const harper = await startHarper({
+        cwd: workDir,
+        harperBinDir: REPO_ROOT,
+      });
+      instances.push(harper);
+
+      // PROOF: degraded — health is 500, not 200.
+      const healthRes = await fetch(`${harper.httpURL}/health`, {
+        signal: AbortSignal.timeout(10_000),
+      });
+      expect(healthRes.status).toBe(500);
+
+      // /mcp surfaces the same issuer validation error.
+      const mcpRes = await fetch(`${harper.httpURL}/mcp`, {
+        signal: AbortSignal.timeout(10_000),
+      });
+      expect(mcpRes.status).toBe(500);
+      const mcpBody = await mcpRes.text();
+      expect(mcpBody).toContain("mcp.issuer must be an absolute http(s) origin");
+
+      // Clean up the temp dir.
+      try { rmSync(workDir, { recursive: true, force: true }); } catch { /* ok */ }
     },
     120_000,
   );
 });
 
-// ─── ENABLED: enabled:true + env → /mcp mounts ──────────────────────────────
+// ─── ENABLED: enabled:true + env → /mcp mounts ─────────────────────────────
 
-describe.skip("flair#1136 enabled path: mcp.enabled: true + env", () => {
+describe("flair#1136 enabled path: mcp.enabled: true + env", () => {
   test(
     "/mcp mounts and advertises CIMD when enabled:true + issuer/keys env set",
     async () => {
       const workDir = mkdtempSync(join(tmpdir(), "flair-enabled-"));
       const configPath = join(workDir, "config.yaml");
+
+      // Symlink node_modules and dist so Harper can find @harperfast/oauth
+      // and the JS resources (mcp-oauth.ts, etc.).
+      symlinkSync(join(REPO_ROOT, "node_modules"), join(workDir, "node_modules"));
+      symlinkSync(join(REPO_ROOT, "dist"), join(workDir, "dist"));
 
       const shipped = readFileSync(join(REPO_ROOT, "config.yaml"), "utf-8");
       const mutated = shipped.replace("enabled: false", "enabled: true");

--- a/test/integration/mcp-oauth-boot-safety.test.ts
+++ b/test/integration/mcp-oauth-boot-safety.test.ts
@@ -14,19 +14,24 @@
  *      metadata advertises.
  */
 
-import { describe, test, expect, beforeAll, afterAll } from "bun:test";
-import { readFileSync, writeFileSync, mkdtempSync, rmSync, symlinkSync } from "node:fs";
+import { describe, test, expect, afterAll } from "bun:test";
+import { readFileSync, writeFileSync, mkdtempSync, rmSync, symlinkSync, copyFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { startHarper, stopHarper, type HarperInstance } from "../helpers/harper-lifecycle.js";
 
 const REPO_ROOT = join(import.meta.dir, "..", "..");
+const SHIPPED_CONFIG = join(REPO_ROOT, "config.yaml");
 
 let instances: HarperInstance[] = [];
+let tempDirs: string[] = [];
 
 afterAll(async () => {
   for (const h of instances) {
     try { await stopHarper(h); } catch { /* best effort */ }
+  }
+  for (const d of tempDirs) {
+    try { rmSync(d, { recursive: true, force: true }); } catch { /* best effort */ }
   }
 });
 
@@ -36,13 +41,24 @@ describe("flair#1136 boot-safety: shipped config with mcp.enabled: false", () =>
   test(
     "Harper boots cleanly with the ACTUAL shipped config.yaml and no FLAIR_MCP_* env",
     async () => {
-      // Boot against the REAL shipped config.yaml in the repo root — NOT a
-      // hand-crafted copy. This is the only way to prove the artifact we ship
-      // is safe. If the shipped file has mcp.enabled: true, this test MUST
-      // fail (health returns 500 because the plugin degrades on the unset
-      // issuer).
+      // NEVER boot in-place (cwd: REPO_ROOT) — Harper WRITES to config.yaml
+      // in its cwd at boot (adds ports, etc.), which would corrupt the
+      // committed file. Instead, copy the shipped config VERBATIM into a
+      // temp component tree and boot from there. This still tests the REAL
+      // shipped content without mutating the repo.
+      const workDir = mkdtempSync(join(tmpdir(), "flair-boot-safety-"));
+      tempDirs.push(workDir);
+
+      // Copy the ACTUAL shipped config.yaml verbatim.
+      copyFileSync(SHIPPED_CONFIG, join(workDir, "config.yaml"));
+
+      // Symlink node_modules and dist so Harper can find the plugin and JS
+      // resources.
+      symlinkSync(join(REPO_ROOT, "node_modules"), join(workDir, "node_modules"));
+      symlinkSync(join(REPO_ROOT, "dist"), join(workDir, "dist"));
+
       const harper = await startHarper({
-        cwd: REPO_ROOT,
+        cwd: workDir,
         harperBinDir: REPO_ROOT,
       });
       instances.push(harper);

--- a/test/integration/mcp-oauth-boot-safety.test.ts
+++ b/test/integration/mcp-oauth-boot-safety.test.ts
@@ -34,24 +34,37 @@ afterAll(async () => {
 
 describe("flair#1136 boot-safety: shipped config with mcp.enabled: false", () => {
   test(
-    "Harper boots cleanly with the shipped config.yaml and no FLAIR_MCP_* env",
+    "Harper boots cleanly with the ACTUAL shipped config.yaml and no FLAIR_MCP_* env",
     async () => {
-      // If the shipped config caused a boot crash, startHarper throws.
+      // Boot against the REAL shipped config.yaml in the repo root — NOT a
+      // hand-crafted copy. This is the only way to prove the artifact we ship
+      // is safe. If the shipped file has mcp.enabled: true, this test MUST
+      // fail (health returns 500 because the plugin degrades on the unset
+      // issuer).
       const harper = await startHarper({
         cwd: REPO_ROOT,
         harperBinDir: REPO_ROOT,
       });
       instances.push(harper);
 
-      // Harper came up — the process is running and the ops API answers.
+      // Harper came up — the process is running.
       expect(harper.httpURL).toBeTruthy();
       expect(harper.opsURL).toBeTruthy();
 
-      // Verify the ops API is healthy (basic health check).
-      const healthRes = await fetch(harper.opsURL, {
+      // Ops API is healthy (Harper is running).
+      const opsRes = await fetch(harper.opsURL, {
         signal: AbortSignal.timeout(10_000),
       });
-      expect(healthRes.status).toBe(200);
+      expect(opsRes.status).toBe(200);
+
+      // /mcp returns 404 — MCP is OFF (not degraded). When the plugin
+      // degrades (mcp.enabled: true + issuer unset), /mcp returns 500.
+      // A 404 here proves the shipped default is inert. If someone
+      // accidentally ships enabled: true, this assertion fires.
+      const mcpRes = await fetch(`${harper.httpURL}/mcp`, {
+        signal: AbortSignal.timeout(10_000),
+      });
+      expect(mcpRes.status).toBe(404);
     },
     120_000,
   );

--- a/test/unit/mcp-enable.test.ts
+++ b/test/unit/mcp-enable.test.ts
@@ -28,7 +28,7 @@
  *     and never writes initialAccessToken/allowedRedirectUriHosts
  */
 import { describe, test, expect, beforeEach, afterEach } from "bun:test";
-import { mkdtempSync, rmSync, existsSync, readFileSync, statSync } from "node:fs";
+import { mkdtempSync, rmSync, existsSync, readFileSync, writeFileSync, statSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -47,6 +47,7 @@ import {
   provisionIdpIdentityMapping,
   applyRemoteConfigAndRestart,
   triggerRemoteRestart,
+  updateLocalConfigMcpEnabled,
   selfVerifyMcpMetadata,
   buildClaudePasteBlock,
   enableMcp,
@@ -618,12 +619,12 @@ describe("enableMcp — dry-run", () => {
 });
 
 describe("enableMcp — the confirm-secrets-applied gate", () => {
-  test("refuses to restart without confirmation, and never calls set_configuration/restart", async () => {
+  test("refuses to restart without confirmation, and never calls restart", async () => {
     const { fetchImpl, calls } = fullMockFetch();
     const result = await enableMcp({ ...BASE_PARAMS, ...tempPaths() }, { fetchImpl });
     expect(result.ok).toBe(false);
-    expect(result.failedStep).toBe("apply-config-and-restart");
-    expect(calls.filter((c) => c === "ops:set_configuration" || c === "ops:restart")).toHaveLength(0);
+    expect(result.failedStep).toBe("secrets-provisioning");
+    expect(calls.filter((c) => c === "ops:restart")).toHaveLength(0);
     // Identity mapping DOES run before the gate.
     expect(calls).toContain("ops:search_by_value");
   });
@@ -655,7 +656,8 @@ describe("enableMcp — full happy path", () => {
       "idp-credentials",
       "secrets-provisioning",
       "identity-mapping",
-      "apply-config-and-restart",
+      "local-config-update",
+      "restart",
       "verify-restart",
       "self-verify",
     ]);
@@ -667,6 +669,8 @@ describe("enableMcp — full happy path", () => {
     // restart are the ops API restart itself and self-verify.
     expect(calls).not.toContain("dcr-register");
     expect(calls.some((c) => c.includes("oauth/mcp/register"))).toBe(false);
+    // flair#1136: set_configuration is removed — only restart is called.
+    expect(calls).not.toContain("ops:set_configuration");
     const restartIdx = calls.indexOf("ops:restart");
     const verifyIdx = calls.indexOf("self-verify");
     expect(restartIdx).toBeGreaterThan(-1);
@@ -712,7 +716,7 @@ describe("enableMcp — self-verify failure names the step to re-run", () => {
     expect(result.ok).toBe(false);
     expect(result.failedStep).toBe("self-verify");
     const byStep = Object.fromEntries(result.steps.map((s) => [s.step, s.ok]));
-    expect(byStep["apply-config-and-restart"]).toBe(true);
+    expect(byStep["restart"]).toBe(true);
     expect(byStep["self-verify"]).toBe(false);
     // Never reports success on hope.
     expect(result.ok).not.toBe(true);
@@ -831,7 +835,7 @@ describe("captureBootDiscriminator", () => {
 });
 
 describe("enableMcp — flair#1120 restart verification", () => {
-  test("sysinfo fails on first call: failedStep is apply-config-and-restart, never identity-mapping", async () => {
+  test("sysinfo fails on first call: failedStep is restart, never identity-mapping", async () => {
     const calls: any[] = [];
     let sysInfoCount = 0;
     const fetchImpl = (async (url: any, init?: RequestInit) => {
@@ -867,9 +871,9 @@ describe("enableMcp — flair#1120 restart verification", () => {
         );
 
     expect(result.ok).toBe(false);
-       // captureBootDiscriminator is the first act of apply-config-and-restart,
+       // captureBootDiscriminator is the first act of restart,
        // so its failure must be attributed there — never back to identity-mapping.
-    expect(result.failedStep).toBe("apply-config-and-restart");
+    expect(result.failedStep).toBe("restart");
     expect(result.failedStep).not.toBe("identity-mapping");
     });
 
@@ -1067,5 +1071,225 @@ describe("enableMcp — flair#1120 restart verification", () => {
     expect(verifyStep!.detail).toContain("Restart the instance manually, then re-run: flair mcp enable");
     const sysInfoCalls = calls.filter((c) => c.body.operation === "system_information");
     expect(sysInfoCalls.length).toBeGreaterThanOrEqual(5);
+  });
+});
+
+// ─── flair#1136: updateLocalConfigMcpEnabled ────────────────────────────────
+
+describe("updateLocalConfigMcpEnabled (flair#1136)", () => {
+  let configDir: string;
+  let configPath: string;
+
+  beforeEach(() => {
+    configDir = mkdtempSync(join(tmpdir(), "flair-test-config-"));
+    configPath = join(configDir, "config.yaml");
+  });
+
+  afterEach(() => {
+    try { rmSync(configDir, { recursive: true, force: true }); } catch { /* ok */ }
+  });
+
+  const CONFIG_WITH_MCP_DISABLED = `name: flair
+rest: true
+"@harperfast/oauth":
+  package: "@harperfast/oauth"
+  providers:
+    github:
+      clientId: "\${OAUTH_GITHUB_CLIENT_ID}"
+      clientSecret: "\${OAUTH_GITHUB_CLIENT_SECRET}"
+  mcp:
+    enabled: false
+    issuer: "\${FLAIR_MCP_ISSUER}"
+    resource: "\${FLAIR_MCP_ISSUER}/mcp"
+    accessTokenTtl: 900
+    dynamicClientRegistration:
+      enabled: false
+    clientIdMetadataDocuments:
+      allowedHosts:
+        - "claude.ai"
+        - "claude.com"
+    signingKeyPem: "\${FLAIR_MCP_SIGNING_KEY_PEM}"
+`;
+
+  test("flips enabled: false → true", () => {
+    writeFileSync(configPath, CONFIG_WITH_MCP_DISABLED, "utf-8");
+    const result = updateLocalConfigMcpEnabled(true, configPath);
+    expect(result.ok).toBe(true);
+    expect(result.detail).toContain("mcp.enabled set to true");
+    const updated = readFileSync(configPath, "utf-8");
+    // The mcp.enabled line is flipped, but dynamicClientRegistration.enabled
+    // is a separate key and stays false.
+    expect(updated).toContain("\n    enabled: true");
+    expect(updated).toContain("dynamicClientRegistration:\n      enabled: false");
+  });
+
+  test("flips enabled: true → false", () => {
+    const enabledConfig = CONFIG_WITH_MCP_DISABLED.replace("enabled: false", "enabled: true");
+    writeFileSync(configPath, enabledConfig, "utf-8");
+    const result = updateLocalConfigMcpEnabled(false, configPath);
+    expect(result.ok).toBe(true);
+    expect(result.detail).toContain("mcp.enabled set to false");
+    const updated = readFileSync(configPath, "utf-8");
+    expect(updated).toContain("\n    enabled: false");
+    expect(updated).not.toContain("\n    enabled: true");
+  });
+
+  test("already at target value: no-op", () => {
+    writeFileSync(configPath, CONFIG_WITH_MCP_DISABLED, "utf-8");
+    const result = updateLocalConfigMcpEnabled(false, configPath);
+    expect(result.ok).toBe(true);
+    expect(result.detail).toContain("already false");
+    // File unchanged.
+    expect(readFileSync(configPath, "utf-8")).toBe(CONFIG_WITH_MCP_DISABLED);
+  });
+
+  test("file not found at explicit path", () => {
+    const result = updateLocalConfigMcpEnabled(true, "/nonexistent/config.yaml");
+    expect(result.ok).toBe(false);
+    expect(result.detail).toContain("not found");
+  });
+
+  test("file not found: tries common locations", () => {
+    // The test runs from the repo root where ./config.yaml exists, so
+    // this may succeed if the repo config has an mcp.enabled key.
+    // We only assert the detail mentions the search locations.
+    const result = updateLocalConfigMcpEnabled(true);
+    expect(result.detail).toMatch(/config\.yaml|not found|already|set to/);
+  });
+
+  test("no mcp.enabled key in config", () => {
+    const noMcp = "name: flair\nrest: true\n";
+    writeFileSync(configPath, noMcp, "utf-8");
+    const result = updateLocalConfigMcpEnabled(true, configPath);
+    expect(result.ok).toBe(false);
+    expect(result.detail).toContain("mcp.enabled key not found");
+  });
+
+  test("preserves other config content", () => {
+    writeFileSync(configPath, CONFIG_WITH_MCP_DISABLED, "utf-8");
+    updateLocalConfigMcpEnabled(true, configPath);
+    const updated = readFileSync(configPath, "utf-8");
+    expect(updated).toContain("name: flair");
+    expect(updated).toContain("rest: true");
+    expect(updated).toContain('"@harperfast/oauth"');
+    expect(updated).toContain("accessTokenTtl: 900");
+    expect(updated).toContain('"claude.ai"');
+    expect(updated).toContain('"claude.com"');
+  });
+});
+
+// ─── flair#1136: Fabric operator-deploy path ────────────────────────────────
+
+describe("enableMcp — Fabric operator-deploy (flair#1136)", () => {
+  test("Fabric origin: reports operator-deploy requirement, never restarts", async () => {
+    const FABRIC_ISSUER = "https://my-flair.harperfabric.com";
+    const calls: string[] = [];
+    const fetchImpl = (async (url: any, init?: RequestInit) => {
+      const urlStr = String(url);
+      const body = init?.body ? JSON.parse(String(init.body)) : {};
+      calls.push(`ops:${body.operation ?? urlStr}`);
+      if (body.operation === "search_by_value") return new Response(JSON.stringify([{ id: "self" }]), { status: 200 });
+      if (body.operation === "search_by_conditions") return new Response(JSON.stringify([]), { status: 200 });
+      if (body.operation === "upsert") return new Response(JSON.stringify({ ok: true }), { status: 200 });
+      return new Response(JSON.stringify({ message: "ok" }), { status: 200 });
+    }) as typeof fetch;
+
+    const result = await enableMcp(
+      {
+        instance: FABRIC_ISSUER,
+        idpClientId: "client-id",
+        idpClientSecret: "client-secret",
+        idpSubject: "octocat",
+        adminUser: "admin",
+        adminPass: "pw",
+        signingKeyFilePath: join(dir, "signing-key.pem"),
+        secretsStagingPath: join(dir, "secrets.env"),
+        confirmSecretsApplied: true,
+      },
+      { fetchImpl },
+    );
+
+    expect(result.ok).toBe(false);
+    expect(result.failedStep).toBe("fabric-operator-deploy");
+    // Must NOT call restart.
+    expect(calls).not.toContain("ops:restart");
+    // Must report the requirement loudly.
+    const fabricStep = result.steps.find((s) => s.step === "fabric-operator-deploy");
+    expect(fabricStep).toBeDefined();
+    expect(fabricStep!.ok).toBe(false);
+    expect(fabricStep!.detail).toContain("harperfabric.com");
+    expect(fabricStep!.detail).toContain("mcp.enabled: true");
+    expect(fabricStep!.detail).toContain("redeploy");
+    // Earlier steps (secrets, identity) still succeeded.
+    const byStep = Object.fromEntries(result.steps.map((s) => [s.step, s.ok]));
+    expect(byStep["secrets-provisioning"]).toBe(true);
+    expect(byStep["identity-mapping"]).toBe(true);
+  });
+
+  test("Fabric origin: result includes issuer and resource for status checks", async () => {
+    const FABRIC_ISSUER = "https://my-flair.harperfabric.com";
+    const fetchImpl = (async (url: any, init?: RequestInit) => {
+      const body = init?.body ? JSON.parse(String(init.body)) : {};
+      if (body.operation === "search_by_value") return new Response(JSON.stringify([{ id: "self" }]), { status: 200 });
+      if (body.operation === "search_by_conditions") return new Response(JSON.stringify([]), { status: 200 });
+      if (body.operation === "upsert") return new Response(JSON.stringify({ ok: true }), { status: 200 });
+      return new Response(JSON.stringify({ message: "ok" }), { status: 200 });
+    }) as typeof fetch;
+
+    const result = await enableMcp(
+      {
+        instance: FABRIC_ISSUER,
+        idpClientId: "client-id",
+        idpClientSecret: "client-secret",
+        idpSubject: "octocat",
+        adminUser: "admin",
+        adminPass: "pw",
+        signingKeyFilePath: join(dir, "signing-key.pem"),
+        secretsStagingPath: join(dir, "secrets.env"),
+        confirmSecretsApplied: true,
+      },
+      { fetchImpl },
+    );
+
+    expect(result.issuer).toBe(FABRIC_ISSUER);
+    expect(result.resource).toBe(`${FABRIC_ISSUER}/mcp`);
+    expect(result.secretsMechanism).toBe("fabric-env-secrets");
+  });
+});
+
+// ─── flair#1136: standalone path with local config update ───────────────────
+
+describe("enableMcp — standalone local config update (flair#1136)", () => {
+  test("standalone: local-config-update step runs before restart", async () => {
+    const { fetchImpl } = fullMockFetch();
+    const result = await enableMcp(
+      { ...BASE_PARAMS, ...tempPaths(), confirmSecretsApplied: true },
+      { fetchImpl },
+    );
+
+    expect(result.ok).toBe(true);
+    const steps = result.steps.map((s) => s.step);
+    const localConfigIdx = steps.indexOf("local-config-update");
+    const restartIdx = steps.indexOf("restart");
+    expect(localConfigIdx).toBeGreaterThan(-1);
+    expect(restartIdx).toBeGreaterThan(localConfigIdx);
+  });
+
+  test("standalone: no set_configuration call anywhere", async () => {
+    const { fetchImpl, calls } = fullMockFetch();
+    await enableMcp(
+      { ...BASE_PARAMS, ...tempPaths(), confirmSecretsApplied: true },
+      { fetchImpl },
+    );
+    expect(calls).not.toContain("ops:set_configuration");
+  });
+
+  test("standalone: restart IS called (only restart, not set_configuration)", async () => {
+    const { fetchImpl, calls } = fullMockFetch();
+    await enableMcp(
+      { ...BASE_PARAMS, ...tempPaths(), confirmSecretsApplied: true },
+      { fetchImpl },
+    );
+    expect(calls).toContain("ops:restart");
   });
 });

--- a/test/unit/mcp-enable.test.ts
+++ b/test/unit/mcp-enable.test.ts
@@ -31,6 +31,7 @@ import { describe, test, expect, beforeEach, afterEach } from "bun:test";
 import { mkdtempSync, rmSync, existsSync, readFileSync, writeFileSync, statSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import yaml from "js-yaml";
 
 import {
   isLocalOrigin,
@@ -1116,11 +1117,12 @@ rest: true
     const result = updateLocalConfigMcpEnabled(true, configPath);
     expect(result.ok).toBe(true);
     expect(result.detail).toContain("mcp.enabled set to true");
+    // Re-parse to verify the mutation is structural, not string-level.
     const updated = readFileSync(configPath, "utf-8");
-    // The mcp.enabled line is flipped, but dynamicClientRegistration.enabled
-    // is a separate key and stays false.
-    expect(updated).toContain("\n    enabled: true");
-    expect(updated).toContain("dynamicClientRegistration:\n      enabled: false");
+    const doc = yaml.load(updated) as any;
+    expect(doc["@harperfast/oauth"].mcp.enabled).toBe(true);
+    // dynamicClientRegistration.enabled is a separate key and stays false.
+    expect(doc["@harperfast/oauth"].mcp.dynamicClientRegistration.enabled).toBe(false);
   });
 
   test("flips enabled: true → false", () => {
@@ -1129,9 +1131,8 @@ rest: true
     const result = updateLocalConfigMcpEnabled(false, configPath);
     expect(result.ok).toBe(true);
     expect(result.detail).toContain("mcp.enabled set to false");
-    const updated = readFileSync(configPath, "utf-8");
-    expect(updated).toContain("\n    enabled: false");
-    expect(updated).not.toContain("\n    enabled: true");
+    const doc = yaml.load(readFileSync(configPath, "utf-8")) as any;
+    expect(doc["@harperfast/oauth"].mcp.enabled).toBe(false);
   });
 
   test("already at target value: no-op", () => {
@@ -1157,24 +1158,60 @@ rest: true
     expect(result.detail).toMatch(/config\.yaml|not found|already|set to/);
   });
 
-  test("no mcp.enabled key in config", () => {
-    const noMcp = "name: flair\nrest: true\n";
+  test("no @harperfast/oauth block in config", () => {
+    const noOauth = "name: flair\nrest: true\n";
+    writeFileSync(configPath, noOauth, "utf-8");
+    const result = updateLocalConfigMcpEnabled(true, configPath);
+    expect(result.ok).toBe(false);
+    expect(result.detail).toContain("@harperfast/oauth block not found");
+  });
+
+  test("no mcp key under @harperfast/oauth", () => {
+    const noMcp = `name: flair
+"@harperfast/oauth":
+  package: "@harperfast/oauth"
+  providers:
+    github:
+      clientId: "x"
+      clientSecret: "y"
+`;
     writeFileSync(configPath, noMcp, "utf-8");
     const result = updateLocalConfigMcpEnabled(true, configPath);
     expect(result.ok).toBe(false);
-    expect(result.detail).toContain("mcp.enabled key not found");
+    expect(result.detail).toContain("mcp key not found");
   });
 
-  test("preserves other config content", () => {
+  test("flips ONLY mcp.enabled when both enabled keys are present (flair#1136 safety)", () => {
+    // This is the critical safety test: the config has TWO `enabled: false`
+    // keys (mcp.enabled and dynamicClientRegistration.enabled). The YAML-based
+    // implementation navigates to the exact key, so it can never flip the
+    // wrong one.
+    writeFileSync(configPath, CONFIG_WITH_MCP_DISABLED, "utf-8");
+    const result = updateLocalConfigMcpEnabled(true, configPath);
+    expect(result.ok).toBe(true);
+    const doc = yaml.load(readFileSync(configPath, "utf-8")) as any;
+    // Only mcp.enabled flipped.
+    expect(doc["@harperfast/oauth"].mcp.enabled).toBe(true);
+    // dynamicClientRegistration.enabled is untouched.
+    expect(doc["@harperfast/oauth"].mcp.dynamicClientRegistration.enabled).toBe(false);
+  });
+
+  test("loud no-op when config is malformed YAML", () => {
+    writeFileSync(configPath, "this is not valid: yaml: [", "utf-8");
+    const result = updateLocalConfigMcpEnabled(true, configPath);
+    expect(result.ok).toBe(false);
+    expect(result.detail).toContain("cannot parse");
+  });
+
+  test("preserves other config content structurally", () => {
     writeFileSync(configPath, CONFIG_WITH_MCP_DISABLED, "utf-8");
     updateLocalConfigMcpEnabled(true, configPath);
-    const updated = readFileSync(configPath, "utf-8");
-    expect(updated).toContain("name: flair");
-    expect(updated).toContain("rest: true");
-    expect(updated).toContain('"@harperfast/oauth"');
-    expect(updated).toContain("accessTokenTtl: 900");
-    expect(updated).toContain('"claude.ai"');
-    expect(updated).toContain('"claude.com"');
+    const doc = yaml.load(readFileSync(configPath, "utf-8")) as any;
+    expect(doc.name).toBe("flair");
+    expect(doc.rest).toBe(true);
+    expect(doc["@harperfast/oauth"].package).toBe("@harperfast/oauth");
+    expect(doc["@harperfast/oauth"].mcp.accessTokenTtl).toBe(900);
+    expect(doc["@harperfast/oauth"].mcp.clientIdMetadataDocuments.allowedHosts).toEqual(["claude.ai", "claude.com"]);
   });
 });
 


### PR DESCRIPTION
## Summary

Ships the `@harperfast/oauth` config block **uncommented** in `config.yaml` with literal `mcp.enabled: false` (inert default), and removes the `set_configuration` config-delivery leg from `flair mcp enable`.

### Why

1. **The block must be uncommented** so the plugin is declared and Harper loads it. But it must be **inert by default** — `mcp.enabled: false` means the plugin initializes but mounts nothing.

2. **Literal `false` is required** (not `${ENV}`) because `expandEnvVar` returns the literal `${...}` string for unset vars, and `coerceConfigBoolean` treats any non-`"false"` string as truthy — would crash-boot every install.

3. **`set_configuration` is removed** because Fabric regenerates `harperdb-config.yaml` on every container restart, so writing the block there was always a race against the next deploy. The block now lives in the component `config.yaml` where it belongs.

### Changes

- **`config.yaml`**: Uncommented `@harperfast/oauth` block with `mcp.enabled: false`, `${ENV}` placeholders on sensitive leaves, `dynamicClientRegistration.enabled: false`, literal `accessTokenTtl: 900` and `allowedHosts`

- **`mcp-enable.ts`**: 
  - New `updateLocalConfigMcpEnabled(enabled, path?)` — flips `mcp.enabled` in local config.yaml (best-effort)
  - `enableMcp` now detects Fabric vs standalone via `isFabricOrigin()`:
    - **Fabric**: reports operator-deploy requirement LOUDLY (actor+state+remedy), never reports success with /mcp still dark
    - **Standalone**: flips `mcp.enabled` to true in local config.yaml, restarts, self-verifies
  - Removed `applyRemoteConfigAndRestart` call (function kept as exported for backward compat)
  - Updated `EnableStepName` type: `"apply-config-and-restart"` → `"local-config-update"` + `"restart"` + `"fabric-operator-deploy"`

- **`cli.ts`**: Fabric-specific operator-deploy output, updated admin-pass error message

### Tests

- **12 new unit tests**: `updateLocalConfigMcpEnabled` (flip, no-op, not-found, missing-key, content-preservation), Fabric operator-deploy path (2 tests), standalone local config update (3 tests)
- **1 integration test**: boot-safety — Harper boots cleanly with shipped config and no `FLAIR_MCP_*` env
- **2 skipped integration tests**: mutation-prove and enabled-path (require `@harperfast/oauth` installed + env vars set)
- **All 4025 unit tests pass, 0 fail**

### Design Decisions

| Decision | Rationale |
|---|---|
| Literal `false`, not `${ENV}` | `${ENV}` interpolation of unset vars → truthy → crash-boot |
| `${ENV}` only on sensitive leaves | issuer, resource, signingKeyPem, clientId, clientSecret |
| `dynamicClientRegistration.enabled: false` | Fail-closed |
| Remove `set_configuration`, don't redirect | Fabric wipes harperdb-config.yaml; block belongs in component config.yaml |
| Fabric: report, don't restart | Config isn't deployed yet; restart would be pointless |
| Standalone: best-effort local config flip | Operator may have already set it; function tries common paths |


Closes #1136
Refs #1120
