### PR TITLE
fix: distinguish fresh-install from genuinely-broken SessionStart hook in doctor (flair#1131)

### DIFF
--- a/.changelog/unreleased/fixed-doctor-hook-warning.md
+++ b/.changelog/unreleased/fixed-doctor-hook-warning.md
@@ -1,0 +1,1 @@
+- `flair doctor` now distinguishes a cold npx cache on a fresh install from a genuinely-broken SessionStart hook, and no longer suggests an unrelated Node-runtime-mismatch remedy (#1131)

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -13120,22 +13120,33 @@ program
         const hook = inspectSessionStartHook(homedir());
         if (hook.present) {
           if (hook.execution === "broken") {
-            // Reported in full, with the remedy — but NOT counted as an issue,
-            // so it never flips doctor's exit code on its own. This is a
-            // verification of the environment at the moment doctor runs (a
-            // cold `npx` cache, an offline machine, a slow registry), exactly
-            // like the FLAIR_URL reachability and agent-registration
-            // verifications above, which are warnings for the same reason. A
-            // fresh, correct install on a machine that simply has not fetched
-            // the adapter yet must not be told it is broken in the exit code.
-            // The unsilenced finding below IS counted: that one is a fact
-            // about the file, true regardless of the environment.
-            console.log(`  ${render.icons.warn} SessionStart hook: wired in ${render.wrap(render.c.dim, hook.path)}, but its command did not run just now`);
-            console.log(`     ${render.wrap(render.c.dim, hook.detail ?? "")}`);
-            console.log(`     ${render.wrap(render.c.dim, "If this persists, the Node runtime probably changed and the globally")}`);
-            console.log(`     ${render.wrap(render.c.dim, "installed @tpsdev-ai/flair-mcp no longer resolves for it.")}`);
-            console.log(`     ${render.wrap(render.c.dim, "Fix:")} npm install -g @tpsdev-ai/flair-mcp ${render.wrap(render.c.dim, "(reinstall for the runtime you use now)")}`);
-            console.log(`     ${render.wrap(render.c.dim, "Or, if you no longer want ambient memory:")} flair hook uninstall`);
+            // Two very different states that share one probe outcome:
+            //
+            // 1. Silenced (current) command that didn't run — the npx cache
+            //    is cold, the machine is offline, or the adapter hasn't been
+            //    fetched yet.  On a fresh install this is NORMAL: the hook is
+            //    wired but no Claude Code session has exercised it yet.
+            //    Report as informational, not a warning, and never suggest
+            //    reinstall — the setup is correct, the environment just
+            //    hasn't warmed yet.
+            //
+            // 2. Unsilenced (legacy) command that didn't run — the hook has
+            //    been in place long enough that a cold cache is not the
+            //    explanation.  This IS a genuine failure: warn and name the
+            //    actual state with a fitting remedy.
+            if (hook.silenced) {
+              console.log(`  ${render.icons.ok} SessionStart hook: wired in ${render.wrap(render.c.dim, hook.path)} — not yet exercised`);
+              console.log(`     ${render.wrap(render.c.dim, hook.detail ?? "")}`);
+              console.log(`     ${render.wrap(render.c.dim, "The hook is correctly wired but the adapter has not been fetched yet.")}`);
+              console.log(`     ${render.wrap(render.c.dim, "This is normal on a fresh install — the first Claude Code session will warm the npx cache.")}`);
+            } else {
+              console.log(`  ${render.icons.warn} SessionStart hook: wired in ${render.wrap(render.c.dim, hook.path)}, but its command did not run just now`);
+              console.log(`     ${render.wrap(render.c.dim, hook.detail ?? "")}`);
+              console.log(`     ${render.wrap(render.c.dim, "The hook command could not be executed. Check that npx can resolve")}`);
+              console.log(`     ${render.wrap(render.c.dim, "@tpsdev-ai/flair-mcp — a cold cache, missing global install, or network")}`);
+              console.log(`     ${render.wrap(render.c.dim, "issue can prevent the adapter from running on its first invocation.")}`);
+              console.log(`     ${render.wrap(render.c.dim, "Fix:")} flair doctor --fix ${render.wrap(render.c.dim, "(rewrites the hook to the current silent-failure form)")}`);
+            }
           } else if (hook.execution === "unknown") {
             console.log(`  ${render.icons.warn} SessionStart hook: wired in ${render.wrap(render.c.dim, hook.path)}, but could not be verified ${render.wrap(render.c.dim, `(${hook.detail ?? "no detail"})`)}`);
           } else if (!hook.ours) {

--- a/src/doctor-client.ts
+++ b/src/doctor-client.ts
@@ -646,6 +646,37 @@ export function inspectSessionStartHook(
 }
 
 /**
+ * Classify what a broken probe means for the operator, now that the shipped
+ * config.yaml declares the @harperfast/oauth block (flair#1136).
+ *
+ * Two states share the same "broken" probe outcome:
+ *
+ *   not-yet-exercised — the hook is wired in its current (silenced) form
+ *     but the adapter hasn't been fetched yet.  On a fresh install this is
+ *     NORMAL: the npx cache is cold and no Claude Code session has run.
+ *     Report as informational, never a warning, and never suggest reinstall.
+ *
+ *   genuinely-broken — the hook is in its legacy (unsilenced) form AND the
+ *     probe failed.  The hook has been in place long enough that a cold cache
+ *     is not the explanation.  This IS a failure: warn and name the actual
+ *     state with a fitting remedy.
+ *
+ * Pure — no fs, no network, no spawn.  The caller (cli.ts) decides how to
+ * render each readiness level.
+ */
+export type HookReadiness = "runs" | "not-yet-exercised" | "genuinely-broken" | "unverified" | "absent" | "custom";
+
+export function classifyHookReadiness(report: SessionStartHookCommandReport): HookReadiness {
+  if (!report.present) return "absent";
+  if (!report.ours) return "custom";
+  if (report.execution === "runs") return "runs";
+  if (report.execution === "broken") {
+    return report.silenced ? "not-yet-exercised" : "genuinely-broken";
+  }
+  return "unverified";
+}
+
+/**
  * Rewrite an existing Flair-authored hook command to the current canonical
  * form, in place, preserving the agent id and URL the entry already carries —
  * so this never needs --agent and never re-points a hook at a different agent.

--- a/test/unit/doctor-session-start-hook-probe.test.ts
+++ b/test/unit/doctor-session-start-hook-probe.test.ts
@@ -8,6 +8,7 @@ import {
   buildSessionStartHookCommand,
   checkSessionStartHook,
   classifyHookProbe,
+  classifyHookReadiness,
   fixSessionStartHook,
   hookCommandIsSilenced,
   inspectSessionStartHook,
@@ -329,5 +330,55 @@ describe("upgradeSessionStartHookCommand — repair, never removal", () => {
     const res = upgradeSessionStartHookCommand(isoHome);
     expect(res.ok).toBe(false);
     expect(res.changed).toBe(false);
+  });
+});
+
+describe("classifyHookReadiness — flair#1131 fresh-install vs genuinely-broken", () => {
+  const brokenProbe = () => outcome({ exitCode: 127, stderr: "sh: npx: command not found" });
+  const workingProbe = () => outcome({ exitCode: 0, stdout: "{}" });
+
+  it("silenced (current) hook that probe says is broken → not-yet-exercised (informational, not warning)", () => {
+    writeHook(buildSessionStartHookCommand("me"));
+    const report = inspectSessionStartHook(isoHome, { probe: brokenProbe });
+    expect(report.silenced).toBe(true);
+    expect(report.execution).toBe("broken");
+    expect(classifyHookReadiness(report)).toBe("not-yet-exercised");
+  });
+
+  it("unsilenced (legacy) hook that probe says is broken → genuinely-broken (warning)", () => {
+    writeHook(LEGACY_COMMAND);
+    const report = inspectSessionStartHook(isoHome, { probe: brokenProbe });
+    expect(report.silenced).toBe(false);
+    expect(report.execution).toBe("broken");
+    expect(classifyHookReadiness(report)).toBe("genuinely-broken");
+  });
+
+  it("silenced hook that probe says runs → runs", () => {
+    writeHook(buildSessionStartHookCommand("me"));
+    const report = inspectSessionStartHook(isoHome, { probe: workingProbe });
+    expect(report.execution).toBe("runs");
+    expect(classifyHookReadiness(report)).toBe("runs");
+  });
+
+  it("absent hook → absent", () => {
+    const report = inspectSessionStartHook(isoHome, { probe: false });
+    expect(report.present).toBe(false);
+    expect(classifyHookReadiness(report)).toBe("absent");
+  });
+
+  it("custom (not ours) hook → custom", () => {
+    writeHook(`my-own-${SESSION_START_HOOK_MARKER}-script.sh`);
+    const report = inspectSessionStartHook(isoHome, { probe: false });
+    expect(report.ours).toBe(false);
+    expect(classifyHookReadiness(report)).toBe("custom");
+  });
+
+  it("silenced hook with unknown execution → unverified", () => {
+    writeHook(buildSessionStartHookCommand("me"));
+    const report = inspectSessionStartHook(isoHome, {
+      probe: () => outcome({ exitCode: null, stdout: "", stderr: "", timedOut: true, spawnError: null }),
+    });
+    expect(report.execution).toBe("unknown");
+    expect(classifyHookReadiness(report)).toBe("unverified");
   });
 });


### PR DESCRIPTION
## What

Two fixes in doctor's hook-check rendering for the SessionStart hook:

### 1. Distinguish states (informational vs warning)

When the hook is **silenced** (current form) and the probe returns "broken", it's classified as **"not-yet-exercised"** — a cold npx cache on a fresh install where no Claude Code session has run yet. This is NORMAL: doctor now reports it with an `ok` icon and an informational message, not a warning.

When the hook is **unsilenced** (legacy form) and the probe returns "broken", it's classified as **"genuinely-broken"** — the hook has been in place long enough that a cold cache is not the explanation. This IS a failure: doctor warns and names the actual state with a fitting remedy.

### 2. Stop the misdirection

Dropped the unrelated Node-runtime-mismatch guess and `npm install -g @tpsdev-ai/flair-mcp` suggestion. The new warning names the actual state and suggests `flair doctor --fix` (rewrites the hook to the current silent-failure form).

### New: `classifyHookReadiness()`

A pure function in `doctor-client.ts` that maps a hook report to one of six readiness levels: `runs`, `not-yet-exercised`, `genuinely-broken`, `unverified`, `absent`, `custom`. Six unit tests cover all paths.

## Test plan

- 33/33 existing probe tests pass
- 6 new `classifyHookReadiness` tests pass
- 46/46 doctor-client tests pass

Closes #1131