### PR TITLE
docs: correct stale 5.2/Fabric operability docs

### DIFF
--- a/.changelog/unreleased/added-fabric-docs-freshness-043.md
+++ b/.changelog/unreleased/added-fabric-docs-freshness-043.md
@@ -1,0 +1,4 @@
+- **Fabric deployment docs corrected for 5.2+.** Fixed ops-API port (9925, same hostname),
+  clarified cluster_status availability on Fabric, documented the mcp.enabled manual flip
+  and its upgrade-reverts trap, and versioned log paths (hdb.log froze at 5.2, system.log
+  is the live log 5.2+). Closes #1153, #1156, #1157.

--- a/docs/deploying-on-fabric.md
+++ b/docs/deploying-on-fabric.md
@@ -129,13 +129,16 @@ where nothing answers:
 # --target https://<fabric-node>:19926/<instance>     → ops derived as :19925 ✓
 ```
 
+**Fabric's ops API runs on the same hostname at port 9925** <!-- docs-freshness-allow: Fabric ops API port, not legacy data port --> (the deploy/upgrade path already targets this port). For a managed `*.harperfabric.com` instance:
+
+```bash
+# Same hostname, port 9925 — not port 442 <!-- docs-freshness-allow: Fabric ops API -->
+flair init --target https://<cluster>.<org>.harperfabric.com \
+    --ops-target https://<cluster>.<org>.harperfabric.com:9925 <!-- docs-freshness-allow: Fabric ops API -->
+```
+
 **Pass `--ops-target <url>` explicitly** (or set `FLAIR_OPS_TARGET`) on any command that
 touches the ops API: `init --target`, `agent add --target`, `federation token --target`.
-
-> **Gap — needs a Fabric account to verify.** This guide does not state the correct
-> ops-API URL for a managed `*.harperfabric.com` instance, or whether the ops API is
-> reachable remotely there at all. The derivation above is certain (read from source);
-> the right value to pass is not.
 
 Precedence: `--target` > `--url` > `FLAIR_TARGET` > `FLAIR_URL` > localhost. For ops:
 `--ops-target` > `FLAIR_OPS_TARGET` > derived > localhost.
@@ -250,8 +253,9 @@ and shells out to `lsof`. The command you'd reach for when something breaks is u
 here. Unavailable too: `start`, `stop`, `restart`, `snapshot`, `reembed`, `rem`, `bridge`.
 
 **Fabric's own cluster topology is invisible.** `fleet verify` sweeps *Flair's* federation
-peer table, not Harper's cluster nodes — `cluster_status` is harper-pro-only and absent
-from the OSS `harper` build. **`0 peers known` means "0 on file", never "0 exist."**
+peer table, not Harper's cluster nodes. **`cluster_status` works on Fabric** — Fabric
+always runs harper-pro (not the OSS harper build), so cluster_status is available over
+the ops API. `0 peers known` means "0 on file", never "0 exist."
 
 **There is no disk or quota telemetry.** `flair status` reports usage for two directories:
 no free space, no total, no quota, no warning threshold, walk capped at six levels, no
@@ -262,6 +266,35 @@ with nothing saying so. The one indirect signal is a migration halting for space
 > server-side. That is uncited and unverified, so this guide doesn't rely on it — and it
 > wouldn't matter: Flair calls it only as a post-failure convergence oracle and discards
 > the `size` field. Component disk usage is invisible structurally.
+
+### The `mcp.enabled` operator step
+
+MCP is **off by default**. The shipped component `config.yaml` contains
+`@harperfast/oauth` → `mcp` → `enabled: false`. Until [flair#1152](https://github.com/tpsdev-ai/flair/issues/1152)
+lands (interpolate from env — *ON HOLD*), you must flip this manually:
+
+1. In your deployed component's `config.yaml`, change:
+    ```yaml
+    '@harperfast/oauth':
+     mcp:
+       enabled: true      # was: false
+    ```
+2. Re-deploy the component so Harper picks up the new value.
+3. **Verify the `/mcp` surface is actually serving** (the flag alone does not
+   guarantee it — a secret that is stored but never decrypted fails at self-verify):
+    ```bash
+    # Check /mcp is reachable and returning MCP protocol (not a loopback proxy or 404)
+    curl -sf https://\<cluster\>.\<org\>.harperfabric.com/mcp
+    # Should return MCP JSON-RPC content; if you get HTML redirect or 404 the flag
+    # is not effective
+    ```
+
+**⚠ SECURITY CAVEAT — the upgrade-reverts trap.** Any package update or fleet component
+update re-ships the literal `enabled: false` and silently darkens a live `/mcp` surface.
+You must **re-flip to `true` after every upgrade** and re-deploy. An updated component
+without this re-flip will appear healthy (`/Health` green) while its MCP tools are
+dark to every connected client. If you rely on MCP, add the re-flip to your upgrade
+runbook.
 
 ### Known hazard: unbounded npm cache
 

--- a/docs/hosted-on-fabric.md
+++ b/docs/hosted-on-fabric.md
@@ -79,6 +79,35 @@ The staging file is written in every case, so a fallback never strands you mid-r
 
 `--secrets-mechanism <fabric-env-secrets|env-file>` remains an explicit override and skips the probe entirely.
 
+### The `mcp.enabled` operator step (Fabric)
+
+MCP is **off by default**. The shipped component `config.yaml` contains
+`@harperfast/oauth` → `mcp` → `enabled: false`. Until [flair#1152](https://github.com/tpsdev-ai/flair/issues/1152)
+lands (interpolate from env — *ON HOLD*), you must flip this manually:
+
+1. In your deployed component's `config.yaml`, change:
+   ```yaml
+   '@harperfast/oauth':
+     mcp:
+       enabled: true     # was: false
+   ```
+2. Re-deploy the component so Harper picks up the new value.
+3. **Verify the `/mcp` surface is actually serving** (the flag alone does not
+   guarantee it — a secret that is stored but never decrypted fails at self-verify):
+   ```bash
+   # Check /mcp is reachable and returning MCP protocol (not a loopback proxy or 404)
+   curl -sf https://<cluster>.<org>.harperfabric.com/mcp
+   # Should return MCP JSON-RPC content; if you get HTML redirect or 404 the flag
+   # is not effective
+   ```
+
+**⚠ SECURITY CAVEAT — the upgrade-reverts trap.** Any package update or fleet component
+update re-ships the literal `enabled: false` and silently darkens a live `/mcp` surface.
+You must **re-flip to `true` after every upgrade** and re-deploy. An updated component
+without this re-flip will appear healthy (`/Health` green) while its MCP tools are
+dark to every connected client. If you rely on MCP, add the re-flip to your upgrade
+runbook.
+
 ---
 
 ## Agent authentication
@@ -140,7 +169,7 @@ flair fleet verify --target https://<cluster>.<org>.harperfabric.com
 
 **`flair doctor`** takes no `--target` — it hardcodes localhost, reads a local PID file, and shells out to `lsof`. Unavailable too: `start`, `stop`, `restart`, `snapshot`, `reembed`, `rem`, `bridge`.
 
-**Fabric's own cluster topology is invisible.** `fleet verify` sweeps *Flair's* federation peer table, not Harper's cluster nodes. `cluster_status` is harper-pro-only. `0 peers known` means "0 on file", never "0 exist."
+**Fabric's own cluster topology is invisible.** `fleet verify` sweeps *Flair's* federation peer table, not Harper's cluster nodes. **`cluster_status` works on Fabric** — Fabric always runs harper-pro (not the OSS harper build), so cluster_status is available over the ops API. `0 peers known` means "0 on file", never "0 exist."
 
 ---
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -23,7 +23,8 @@ If it fails to start:
 lsof -i :19926
 
 # Check logs (macOS)
-cat ~/.flair/data/log/hdb.log | tail -50
+cat ~/.flair/data/log/hdb.log | tail -50     # Harper ≤ 5.1 only (see below)
+cat ~/.flair/data/log/system.log | tail -50   # Harper 5.2+ (live log)
 
 # Check logs (Linux)
 journalctl --user -u flair --since "10 minutes ago"
@@ -242,6 +243,14 @@ flair --help          # all commands
 flair <command> -h    # command-specific help
 ```
 
-Logs: `~/.flair/data/log/hdb.log`
+**Log paths depend on Harper version:**
+
+- **Harper ≤ 5.1:** `~/.flair/data/log/hdb.log`
+- **Harper 5.2+:** `~/.flair/data/log/system.log`
+
+> ⚠ **On Harper 5.2+, `hdb.log` freezes at the upgrade boundary.** The live log is
+> `system.log`. The Harper ops `read_log` endpoint keeps serving the frozen `hdb.log`,
+> so remote diagnosis reads days-stale entries that look current. Always check
+> `system.log` after upgrading to 5.2+.
 
 File issues: [github.com/tpsdev-ai/flair/issues](https://github.com/tpsdev-ai/flair/issues)


### PR DESCRIPTION
Corrects three areas of stale Fabric documentation discovered during the 0.42.0 managed-Fabric deploy.

## Changes

### Closes #1153 - ops API port & cluster_status on Fabric
- **Ports section:** Removed unresolvable placeholder text. Fabric's ops API serves on the same hostname at port `9925` (confirmed on a live managed instance). Added concrete `flair init` example with `--ops-target` pointing at port 9925.
- **Topology section (both docs):** Changed the claim from "cluster_status is harper-pro-only" to "cluster_status works on Fabric" — Fabric always runs harper-pro, so the endpoint is available over the ops API.

### Closes #1156 - mcp.enabled operator step + upgrade-reverts trap
Added identical sections to both Fabric deployment guides:
- Name the exact shipped config key path (`@harperfast/oauth` → `mcp` → `enabled: false`)
- Three-step operator procedure: flip to `true`, re-deploy, verify `/mcp` surface
- **Security caveat** (upgraded to ⚠): any package or fleet update re-ships `enabled: false` and silently darkens a live MCP surface. Operators must re-flip after every upgrade. Without it, `/Health` remains green while MCP tools are unreachable.

### Closes #1157 - versioned log path documentation
- Split log paths by Harper version: `hdb.log` (≤ 5.1) and `system.log` (5.2+)
- Added explicit warning that `hdb.log` freezes at the 5.2 upgrade boundary and the Harper ops `read_log` endpoint keeps serving the frozen file, producing days-stale entries that look current

## Verification
- `node scripts/docs-freshness-check.mjs` — all 7/7 checks pass
- Pre-commit hooks: workspace-deps, dep-ages, no impl-term leaks, ASCII box alignment
