### PR TITLE
fix: emit rootPath + harperPid in boot-harper JSON line for recovery

### DIFF
--- a/.changelog/unreleased/changed-boot-harper-recovery-contract.md
+++ b/.changelog/unreleased/changed-boot-harper-recovery-contract.md
@@ -1,0 +1,1 @@
+- **boot-harper.mjs** now emits `rootPath` and `harperPid` in the JSON config line, enabling callers to recover from an interrupted teardown (kill by explicit PID, remove the install tree). The teardown contract is documented in the header comment, and `hdb.pid` is removed only after teardown fully completes, making a surviving `hdb.pid` a reliable orphan indicator.

--- a/packages/adk-flair-js/test/helpers/live-flair.ts
+++ b/packages/adk-flair-js/test/helpers/live-flair.ts
@@ -80,6 +80,10 @@ interface HarperConfig {
   adminPass: string;
   /** Ephemeral install tree — removed by the last worker during teardown. */
   installDir?: string;
+  /** Same as installDir — the ephemeral tree path for recovery. */
+  rootPath?: string;
+  /** Harper child process PID — for recovery after interrupted teardown. */
+  harperPid?: number | null;
 }
 
 // ─── Ed25519 key generation ──────────────────────────────────────────────────

--- a/packages/adk-flair-js/test/unit/boot_readiness.test.ts
+++ b/packages/adk-flair-js/test/unit/boot_readiness.test.ts
@@ -5,13 +5,18 @@
  * that Harper's /health returns 200. A half-booted instance (server up, app
  * absent) must fail loudly rather than handing tests a 404-serving URL.
  */
-import { test, expect } from "bun:test";
+import { test, expect, afterEach } from "bun:test";
 import { createServer } from "node:http";
 import type { Server } from "node:http";
-import { writeFileSync, unlinkSync } from "node:fs";
+import { writeFileSync, unlinkSync, existsSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { spawn, type ChildProcess } from "node:child_process";
 import { bootEphemeralHarper } from "../helpers/live-flair";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
 
 /**
  * Replicated from boot-harper.mjs — kept in sync manually.
@@ -187,3 +192,281 @@ test("bootEphemeralHarper rejects within budget when helper never emits config",
     cleanup();
   }
 });
+
+// ─── Recovery contract (flair#1121) ─────────────────────────────────────────
+// The JSON line must include rootPath and harperPid so callers can recover
+// from an interrupted teardown.
+
+/** Spawn a mock script that prints a JSON line and exits. Returns the parsed
+ *  config and the child process. */
+async function spawnMockBootHelper(jsonFields: Record<string, unknown>): Promise<{
+  config: Record<string, unknown>;
+  proc: ChildProcess;
+}> {
+  const scriptPath = join(tmpdir(), `adk-flair-test-mock-boot-${process.pid}.mjs`);
+  const jsonLine = JSON.stringify(jsonFields);
+  writeFileSync(scriptPath, [
+    "#!/usr/bin/env node",
+    `process.stdout.write('${jsonLine.replace(/'/g, "\\'")}\\n');`,
+    "// block until stdin closes",
+    "process.stdin.on('end', () => process.exit(0));",
+  ].join("\n"), "utf-8");
+
+  return new Promise((resolve, reject) => {
+    const proc = spawn(process.execPath, [scriptPath], {
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+    let stdout = "";
+    const timeout = setTimeout(() => {
+      try { proc.kill("SIGKILL"); } catch {}
+      try { unlinkSync(scriptPath); } catch {}
+      reject(new Error("mock boot helper timed out"));
+    }, 10_000);
+
+    proc.stdout?.on("data", (chunk: Buffer) => {
+      stdout += chunk.toString();
+      const lines = stdout.split("\n");
+      for (let i = 0; i < lines.length - 1; i++) {
+        const line = lines[i].trim();
+        if (!line) continue;
+        try {
+          const config = JSON.parse(line);
+          clearTimeout(timeout);
+          // Clean up the temp script
+          try { unlinkSync(scriptPath); } catch {}
+          resolve({ config, proc });
+          return;
+        } catch {
+          // not JSON yet
+        }
+      }
+    });
+
+    proc.on("error", (err) => {
+      clearTimeout(timeout);
+      try { unlinkSync(scriptPath); } catch {}
+      reject(err);
+    });
+  });
+}
+
+test("JSON line includes rootPath and harperPid", async () => {
+  const { config, proc } = await spawnMockBootHelper({
+    httpURL: "http://127.0.0.1:19926",
+    opsURL: "http://127.0.0.1:19925",
+    adminUser: "admin",
+    adminPass: "test123",
+    rootPath: "/tmp/flair-test-abc123",
+    harperPid: 424242,
+    outcome: "BOOTED+WARM",
+    floor_ms: 42,
+  });
+
+  try {
+    expect(config.rootPath).toBe("/tmp/flair-test-abc123");
+    expect(config.harperPid).toBe(424242);
+    // Backward compat: existing fields still present
+    expect(config.httpURL).toBe("http://127.0.0.1:19926");
+    expect(config.opsURL).toBe("http://127.0.0.1:19925");
+  } finally {
+    proc.stdin?.end();
+    try { proc.kill("SIGKILL"); } catch {}
+  }
+});
+
+test("JSON line with null harperPid (external mode) still includes the field", async () => {
+  const { config, proc } = await spawnMockBootHelper({
+    httpURL: "http://127.0.0.1:19926",
+    opsURL: "http://127.0.0.1:19925",
+    adminUser: "admin",
+    adminPass: "test123",
+    rootPath: "",
+    harperPid: null,
+    outcome: "BOOTED+WARM",
+    floor_ms: 42,
+  });
+
+  try {
+    expect(config.rootPath).toBe("");
+    expect(config.harperPid).toBeNull();
+  } finally {
+    proc.stdin?.end();
+    try { proc.kill("SIGKILL"); } catch {}
+  }
+});
+
+// ─── Source-level assertion (mutation-checkable) ───────────────────────────
+// Directly verifies the boot-harper.mjs source emits rootPath + harperPid in
+// the JSON config line. This catches regressions where the fields are removed
+// from the source without needing a real Harper boot.
+
+test("boot-harper.mjs source emits rootPath and harperPid in config object", () => {
+  const { readFileSync } = require("node:fs");
+  const bootHelperPath = join(
+    __dirname, "..", "..", "..", "..",
+    "packages", "adk-flair", "tests", "helpers", "boot-harper.mjs",
+  );
+  const source = readFileSync(bootHelperPath, "utf-8");
+
+  // The config object is built right before process.stdout.write
+  // Look for rootPath and harperPid keys in the config literal
+  expect(source).toMatch(/rootPath:\s*harper\.installDir/);
+  expect(source).toMatch(/harperPid:\s*harper\.process\?\.pid/);
+});
+
+// ─── Recovery-path test (flair#1121) ───────────────────────────────────────
+// Simulates the recovery contract: a wrapper that emits rootPath + harperPid,
+// then blocks until stdin closes. We SIGKILL it mid-teardown and exercise the
+// documented recovery path using the emitted fields.
+//
+// This is a mock test — it does NOT boot a real Harper. The real-Harper
+// integration test is too slow for CI (Harper warm-up >300s on cold runners).
+// The contract under test is the JSON line format + the recovery procedure,
+// both of which are exercised here.
+
+test("SIGKILL mid-teardown: recovery via harperPid + rootPath works (mock)", async () => {
+  const rootPath = join(tmpdir(), `flair-test-recovery-${process.pid}`);
+  const { mkdir, writeFile } = await import("node:fs/promises");
+
+  // Create a mock install tree with a fake hdb.pid (simulating an orphaned Harper)
+  await mkdir(rootPath, { recursive: true });
+  await writeFile(join(rootPath, "hdb.pid"), String(process.pid), "utf-8");
+
+  // Spawn a mock wrapper that:
+  // 1. Prints the JSON line with rootPath + harperPid
+  // 2. Spawns a child process (simulating Harper)
+  // 3. Blocks until stdin closes, then "tears down" (kills child, removes tree)
+  const mockScript = join(tmpdir(), `adk-flair-test-recovery-mock-${process.pid}.mjs`);
+  const escapedRootPath = rootPath.replace(/'/g, "\\'");
+  writeFileSync(mockScript, [
+    "import { spawn } from 'node:child_process';",
+    "import { rm } from 'node:fs/promises';",
+    "",
+    `const ROOT = '${escapedRootPath}';`,
+    "",
+    "// Spawn a mock Harper child (just sleeps)",
+    "const child = spawn(process.execPath, ['-e', 'setTimeout(() => {}, 300_000)'], {",
+    "  stdio: 'ignore',",
+    "  detached: true,",
+    "});",
+    "",
+    "// Emit the JSON config line",
+    "const config = {",
+    "  httpURL: 'http://127.0.0.1:19926',",
+    "  opsURL: 'http://127.0.0.1:19925',",
+    "  adminUser: 'admin',",
+    "  adminPass: 'test123',",
+    "  rootPath: ROOT,",
+    "  harperPid: child.pid,",
+    "  outcome: 'BOOTED+WARM',",
+    "  floor_ms: 42,",
+    "};",
+    "process.stdout.write(JSON.stringify(config) + '\\n');",
+    "",
+    "// Block until stdin closes (teardown signal)",
+    "await new Promise(r => process.stdin.on('end', r));",
+    "",
+    "// Teardown: kill child, then remove tree",
+    "try { child.kill('SIGTERM'); }",
+    "catch {}",
+    "// Simulate slow teardown — this is where SIGKILL catches us",
+    "await new Promise(r => setTimeout(r, 5000));",
+    "try { child.kill('SIGKILL'); } catch {}",
+    "await rm(ROOT, { recursive: true, force: true });",
+  ].join("\n"), "utf-8");
+
+  const cleanupMockScript = () => {
+    try { unlinkSync(mockScript); } catch {}
+  };
+
+  try {
+    // ── Spawn the mock wrapper ──────────────────────────────────────────
+    const wrapper = spawn(process.execPath, [mockScript], {
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+
+    // Read the JSON line
+    const config = await new Promise<Record<string, unknown>>((resolve, reject) => {
+      let stdout = "";
+      const timeout = setTimeout(() => {
+        try { wrapper.kill("SIGKILL"); } catch {}
+        reject(new Error("mock wrapper timed out"));
+      }, 30_000);
+
+      wrapper.stdout?.on("data", (chunk: Buffer) => {
+        stdout += chunk.toString();
+        const lines = stdout.split("\n");
+        for (let i = 0; i < lines.length - 1; i++) {
+          const line = lines[i].trim();
+          if (!line) continue;
+          try {
+            const cfg = JSON.parse(line);
+            if (cfg.httpURL && cfg.rootPath && cfg.harperPid) {
+              clearTimeout(timeout);
+              resolve(cfg);
+              return;
+            }
+          } catch { /* not JSON yet */ }
+        }
+      });
+
+      wrapper.on("error", (err) => {
+        clearTimeout(timeout);
+        reject(err);
+      });
+    });
+
+    const harperPid = config.harperPid as number;
+    expect(config.rootPath).toBe(rootPath);
+    expect(typeof harperPid).toBe("number");
+    expect(harperPid).toBeGreaterThan(0);
+
+    // ── Confirm the mock Harper child is alive ───────────────────────────
+    let childAlive = true;
+    try { process.kill(harperPid, 0); } catch { childAlive = false; }
+    expect(childAlive).toBe(true);
+
+    // ── Confirm the tree exists ─────────────────────────────────────────
+    expect(existsSync(rootPath)).toBe(true);
+    expect(existsSync(join(rootPath, "hdb.pid"))).toBe(true);
+
+    // ── SIGKILL the wrapper mid-teardown ────────────────────────────────
+    wrapper.stdin?.end(); // trigger teardown
+    await new Promise(r => setTimeout(r, 100)); // tiny window for teardown to start
+    try { wrapper.kill("SIGKILL"); } catch {}
+
+    // Wait for wrapper to exit
+    await new Promise<void>(r => {
+      wrapper.on("exit", () => r());
+      setTimeout(r, 5000);
+    });
+
+    // ── The mock Harper child should still be alive (orphaned) ──────────
+    // (The wrapper's teardown has a 5s sleep before killing the child,
+    // so our SIGKILL catches it before the child is killed.)
+    try { process.kill(harperPid, 0); childAlive = true; } catch { childAlive = false; }
+    // The child may or may not survive depending on timing — either is valid
+
+    // ── Exercise the documented recovery path ───────────────────────────
+    // 1. Kill by explicit harperPid
+    if (childAlive) {
+      try { process.kill(harperPid, "SIGKILL"); } catch {}
+      await new Promise(r => setTimeout(r, 1000));
+    }
+
+    // 2. Remove the tree by rootPath
+    if (existsSync(rootPath)) {
+      rmSync(rootPath, { recursive: true, force: true, maxRetries: 4 });
+    }
+
+    // ── Verify: no process, no tree ─────────────────────────────────────
+    let stillAlive = true;
+    try { process.kill(harperPid, 0); } catch { stillAlive = false; }
+    expect(stillAlive).toBe(false);
+    expect(existsSync(rootPath)).toBe(false);
+  } finally {
+    cleanupMockScript();
+    // Best-effort cleanup in case the test failed mid-way
+    try { rmSync(rootPath, { recursive: true, force: true, maxRetries: 2 }); } catch {}
+  }
+}, 60_000);

--- a/packages/adk-flair-js/test/unit/boot_readiness.test.ts
+++ b/packages/adk-flair-js/test/unit/boot_readiness.test.ts
@@ -207,7 +207,7 @@ async function spawnMockBootHelper(jsonFields: Record<string, unknown>): Promise
   const jsonLine = JSON.stringify(jsonFields);
   writeFileSync(scriptPath, [
     "#!/usr/bin/env node",
-    `process.stdout.write('${jsonLine.replace(/'/g, "\\'")}\\n');`,
+    `process.stdout.write(${JSON.stringify(jsonLine)} + "\\n");`,
     "// block until stdin closes",
     "process.stdin.on('end', () => process.exit(0));",
   ].join("\n"), "utf-8");
@@ -337,12 +337,11 @@ test("SIGKILL mid-teardown: recovery via harperPid + rootPath works (mock)", asy
   // 2. Spawns a child process (simulating Harper)
   // 3. Blocks until stdin closes, then "tears down" (kills child, removes tree)
   const mockScript = join(tmpdir(), `adk-flair-test-recovery-mock-${process.pid}.mjs`);
-  const escapedRootPath = rootPath.replace(/'/g, "\\'");
   writeFileSync(mockScript, [
     "import { spawn } from 'node:child_process';",
     "import { rm } from 'node:fs/promises';",
     "",
-    `const ROOT = '${escapedRootPath}';`,
+    `const ROOT = ${JSON.stringify(rootPath)};`,
     "",
     "// Spawn a mock Harper child (just sleeps)",
     "const child = spawn(process.execPath, ['-e', 'setTimeout(() => {}, 300_000)'], {",

--- a/packages/adk-flair/tests/helpers/boot-harper.mjs
+++ b/packages/adk-flair/tests/helpers/boot-harper.mjs
@@ -5,12 +5,29 @@
  * Usage:
  *   node boot-harper.mjs
  *
- * Outputs one JSON line to stdout with { httpURL, opsURL, adminUser, adminPass },
- * then blocks until stdin closes or SIGTERM arrives, at which point it tears
- * down Harper and exits.
+ * Outputs one JSON line to stdout with { httpURL, opsURL, adminUser, adminPass,
+ * rootPath, harperPid }, then blocks until stdin closes or SIGTERM arrives, at
+ * which point it tears down Harper and exits.
  *
  * The Python conftest spawns this as a subprocess, reads the JSON line, and
  * kills the process to trigger teardown.
+ *
+ * ─── Teardown contract ───────────────────────────────────────────────────
+ *
+ * On SIGTERM (or stdin-close), this helper calls stopHarper() which sends
+ * SIGTERM to the Harper child and WAITS for it to exit. A wrapper that follows
+ * SIGTERM with a kill -9 before exit KILLS TEARDOWN MID-FLIGHT and orphans the
+ * Harper child process + its install tree.
+ *
+ * Recovery: the JSON line now includes `harperPid` (the Harper child PID) and
+ * `rootPath` (the ephemeral install tree). If teardown is interrupted, the
+ * caller owns cleanup:
+ *   1. kill <harperPid>          — kill the orphaned Harper by explicit PID
+ *   2. rm -rf <rootPath>         — remove the leaked install tree
+ *
+ * A surviving `hdb.pid` file inside rootPath is a reliable orphan indicator:
+ * teardown removes it ONLY after stopHarper() completes fully. If hdb.pid
+ * still exists, teardown was interrupted and the tree is leaked.
  */
 import { startHarper, stopHarper } from "../../../../test/helpers/harper-lifecycle";
 import * as crypto from "node:crypto";
@@ -60,6 +77,8 @@ async function main() {
     adminUser: harper.admin.username,
     adminPass: harper.admin.password,
     installDir: harper.installDir,
+    rootPath: harper.installDir,
+    harperPid: harper.process?.pid ?? null,
     outcome: "BOOTED+WARM",
     floor_ms: warmup.floorMs,
   };
@@ -73,6 +92,17 @@ async function main() {
   });
 
   await stopHarper(harper);
+
+  // Remove hdb.pid as a completion sentinel — ONLY after teardown fully
+  // completes. If teardown is interrupted (kill -9), hdb.pid survives in
+  // the tree and is a reliable orphan indicator for the caller.
+  try {
+    const { unlink } = await import("node:fs/promises");
+    const { join } = await import("node:path");
+    await unlink(join(harper.installDir, "hdb.pid"));
+  } catch {
+    // best-effort — file may not exist or tree may already be gone
+  }
 }
 
 /**


### PR DESCRIPTION
## What

`boot-harper.mjs` now emits `rootPath` and `harperPid` in the JSON config line, enabling callers to recover from an interrupted teardown.

## Why

Three ephemeral test Harpers leaked as orphaned `harper.js dev` processes, each writing ~29G hdb.log in under an hour (EPIPE self-feeding loop). Root cause: the wrapper follows SIGTERM with `kill -9`, which kills teardown mid-flight and orphans the Harper child. The JSON line gave callers no way to recover — it printed neither the tree path nor the child PID.

## Changes

- **boot-harper.mjs**: Emit `rootPath` (alias for `installDir`) and `harperPid` (child PID) in the JSON config line
- **boot-harper.mjs**: Document the full teardown contract in the header comment
- **boot-harper.mjs**: Remove `hdb.pid` only after `stopHarper()` completes fully — surviving `hdb.pid` = reliable orphan indicator
- **live-flair.ts**: Update `HarperConfig` interface with `rootPath` and `harperPid` fields
- **Tests**: 4 new tests (JSON line assertions, source-level regression guard, mock recovery-path test), mutation-checked

## Verification

- Unit suite: 4025 pass, 3 fail, 9 skip (baseline: 4021 pass, 3 fail, 9 skip — +4 new tests, zero regressions)
- 3 failures are pre-existing CLI timeouts, identical on baseline
- Docs-freshness: 7/7 pass
- Mutation check: removing `rootPath`/`harperPid` from source causes the source-level test to fail

Closes #1121
