### PR TITLE
fix: HOME-isolate resolveOpsPort unit tests

### DIFF
--- a/.changelog/unreleased/fixed-resolveopsport-test-isolation.md
+++ b/.changelog/unreleased/fixed-resolveopsport-test-isolation.md
@@ -1,0 +1,1 @@
+- **test**: HOME-isolate `resolveOpsPort` unit tests so they exercise the `httpPort-1` default path regardless of the host's `~/.flair/config.yaml`. A `mock.module("node:os")` shim makes `homedir()` delegate to `process.env.HOME`, and a `beforeEach` points HOME at a fresh empty temp dir so the config rung is correctly skipped.

--- a/test/unit/cli.test.ts
+++ b/test/unit/cli.test.ts
@@ -12,7 +12,7 @@
  *   - Commander program command registration
  */
 
-import { describe, test, expect, beforeEach, afterEach, beforeAll, afterAll } from "bun:test";
+import { describe, test, expect, beforeEach, afterEach, beforeAll, afterAll, mock } from "bun:test";
 import {
   mkdirSync,
   rmSync,
@@ -21,9 +21,22 @@ import {
   chmodSync,
 } from "node:fs";
 import { join } from "node:path";
-import { tmpdir, homedir } from "node:os";
+import { tmpdir } from "node:os";
 import nacl from "tweetnacl";
 import { createPrivateKey, sign as nodeCryptoSign } from "node:crypto";
+
+// Mock homedir() so tests can override it via process.env.HOME.
+// homedir() caches at first call (module load time), so setting
+// process.env.HOME in beforeEach comes too late. This mock delegates
+// to process.env.HOME when set, falling back to the real homedir().
+mock.module("node:os", () => {
+  const actual = { ...require("node:os") };
+  return {
+    ...actual,
+    homedir: () => process.env.HOME || actual.homedir(),
+  };
+});
+
 import {
   resolveKeyPath,
   buildEd25519Auth,
@@ -154,10 +167,10 @@ describe("resolveKeyPath", () => {
 });
 
 // ─── readPortFromConfig ───────────────────────────────────────────────────────
-// Note: readPortFromConfig() reads from homedir() (from node:os), which is
-// baked in at module load time and cannot be overridden via process.env.HOME.
-// We therefore test it against the live environment: if ~/.flair/config.yaml
-// exists, the function returns whatever port is configured there; otherwise null.
+// Note: readPortFromConfig() reads from homedir() (from node:os). The mock at
+// the top of this file makes homedir() delegate to process.env.HOME, so tests
+// can override HOME to isolate. These tests run against the live environment
+// (no HOME override) and verify the function doesn't throw.
 
 describe("readPortFromConfig", () => {
   test("returns a number or null (never throws)", () => {
@@ -360,10 +373,25 @@ describe("resolveHttpPort", () => {
 describe("resolveOpsPort", () => {
   let origFlairOpsPort: string | undefined;
   let origFlairUrl: string | undefined;
+  let origHome: string | undefined;
+  let origUserProfile: string | undefined;
+  let tmpHome: string;
 
   beforeAll(() => {
     origFlairOpsPort = process.env.FLAIR_OPS_PORT;
     origFlairUrl = process.env.FLAIR_URL;
+    origHome = process.env.HOME;
+    origUserProfile = process.env.USERPROFILE;
+  });
+
+  beforeEach(() => {
+    // HOME-isolate: resolveOpsPort reads configPath() = homedir()/.flair/config.yaml.
+    // A real install with a persisted opsPort would shadow the httpPort-1 default
+    // path that these tests exercise. Point HOME at a fresh empty temp dir so the
+    // config rung is correctly skipped.
+    tmpHome = makeTmpDir();
+    process.env.HOME = tmpHome;
+    if (process.env.USERPROFILE !== undefined) process.env.USERPROFILE = tmpHome;
   });
 
   afterEach(() => {
@@ -371,6 +399,11 @@ describe("resolveOpsPort", () => {
     else process.env.FLAIR_OPS_PORT = origFlairOpsPort;
     if (origFlairUrl === undefined) delete process.env.FLAIR_URL;
     else process.env.FLAIR_URL = origFlairUrl;
+    if (origHome === undefined) delete process.env.HOME;
+    else process.env.HOME = origHome;
+    if (origUserProfile === undefined) delete process.env.USERPROFILE;
+    else process.env.USERPROFILE = origUserProfile;
+    try { rmSync(tmpHome, { recursive: true, force: true }); } catch {}
   });
 
   test("uses explicit --ops-port flag over all others", () => {


### PR DESCRIPTION
## What

HOME-isolate the `resolveOpsPort` unit tests so they exercise the `httpPort-1` default path regardless of the host's `~/.flair/config.yaml`.

## Why

`resolveOpsPort`'s config rung (`configPath()` = `homedir()/.flair/config.yaml`) is intentional behavior (flair#863). The unit tests expect `httpPort-1` derivation but fail on any host with a persisted `opsPort` in `~/.flair/config.yaml` — the config rung shadows the default path. On release.sh's host (a real install with `opsPort: 9925`), these tests fail and block the release.

## Changes

- **`mock.module("node:os")` shim**: Makes `homedir()` delegate to `process.env.HOME`. Needed because `homedir()` caches at module load (top-level constants call it), so setting `process.env.HOME` in `beforeEach` comes too late without the shim.
- **`beforeEach` HOME isolation**: Points `process.env.HOME` (and `USERPROFILE` for Windows) at a fresh empty temp dir so the config rung is correctly skipped.
- **`afterEach` restoration**: Restores original `HOME`/`USERPROFILE`/`FLAIR_OPS_PORT`/`FLAIR_URL` and cleans up the temp dir.

## Verification

- **Reproduced**: With `opsPort: 9925` in `~/.flair/config.yaml`, the unisolated tests return 9925 instead of the derived value (9999/19999).
- **Fixed**: With HOME isolation, the tests return the correct derived values.
- **Mutation-checked**: Removing the `beforeEach` isolation causes the tests to fail against the simulated config.
- **Unit suite**: 4056 pass, 0 fail, 18 skip (baseline: 4056 pass, 0 fail, 18 skip — zero regressions).
- **Docs-freshness**: 7/7 pass.

Closes #1163
