### PR TITLE
fix: stop suggesting global install of flair-mcp in upgrade/doctor advice (#1168)

### DIFF
--- a/.changelog/unreleased/fixed-upgrade-check-no-global-flair-mcp.md
+++ b/.changelog/unreleased/fixed-upgrade-check-no-global-flair-mcp.md
@@ -1,0 +1,1 @@
+- `flair upgrade --check` and the doctor hook-warning path no longer suggest globally installing `@tpsdev-ai/flair-mcp`. flair-mcp is zero-install via npx; the advice now points to `flair doctor --fix` instead.

--- a/docs/upgrade.md
+++ b/docs/upgrade.md
@@ -177,7 +177,8 @@ If you'd rather upgrade by hand instead of `flair upgrade`:
 
 ```bash
 npm install -g @tpsdev-ai/flair@latest
-npm install -g @tpsdev-ai/flair-mcp@latest   # if installed
+# flair-mcp is zero-install via npx — no global install needed.
+# flair doctor --fix rewires the hook to the current npx form.
 flair restart
 ```
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2699,6 +2699,24 @@ export function shouldPrintUpgradeLine(status: UpgradeStatus, showAll: boolean):
 }
 
 /**
+ * Returns the human-readable suffix for a package status line in
+ * `flair upgrade` / `flair upgrade --check` output.
+ *
+ * flair-mcp is zero-install via npx — its suffix must never suggest a
+ * global install (flair#1168).
+ */
+export function upgradeStatusSuffix(name: string, status: UpgradeStatus): string {
+  if (status === "current") return " (current)";
+  if (status === "missing") {
+    return name === "@tpsdev-ai/flair-mcp"
+      ? " (zero-install via npx — run: flair doctor --fix)"
+      : " (run: npm install -g)";
+  }
+  if (status === "optional") return " (install via: openclaw plugins install @tpsdev-ai/openclaw-flair)";
+  return "";
+}
+
+/**
  * Pure flag resolution for `flair upgrade`'s restart/verify defaults
  * (flair#635 decision: restart is now the default; `--no-restart` opts
  * out). `--restart` is a deprecated no-op accepted for backward compat —
@@ -10429,10 +10447,7 @@ program
           : status === "optional" ? "○"
           : "❔";
         const installedLabel = installed ?? (status === "optional" ? "not installed (openclaw not detected)" : "not detected");
-        const suffix = status === "current" ? " (current)"
-          : status === "missing" ? " (run: npm install -g)"
-          : status === "optional" ? " (install via: openclaw plugins install @tpsdev-ai/openclaw-flair)"
-          : "";
+        const suffix = upgradeStatusSuffix(name, status);
         console.log(`  ${icon} ${name}: ${installedLabel} → ${latest}${suffix}`);
       } catch { /* skip unavailable packages */ }
     }
@@ -10461,8 +10476,15 @@ program
     }
 
     if (missing.length > 0 && outdated.length === 0) {
+      const npmMissing = missing.filter((f) => f.name !== "@tpsdev-ai/flair-mcp");
+      const mcpMissing = missing.filter((f) => f.name === "@tpsdev-ai/flair-mcp");
       console.log(`\n❔ ${missing.length} package${missing.length > 1 ? "s" : ""} not detected — all detected packages are up to date.`);
-      console.log(`   Install missing: npm install -g ${missing.map((f) => f.name).join(" ")}`);
+      if (npmMissing.length > 0) {
+        console.log(`   Install missing: npm install -g ${npmMissing.map((f) => f.name).join(" ")}`);
+      }
+      if (mcpMissing.length > 0) {
+        console.log(`   flair-mcp is zero-install via npx — run: flair doctor --fix to re-wire the hook`);
+      }
       return;
     }
 
@@ -13168,7 +13190,7 @@ program
               console.log(`  ${render.icons.warn} SessionStart hook: wired in ${render.wrap(render.c.dim, hook.path)}, but its command did not run just now`);
               console.log(`     ${render.wrap(render.c.dim, hook.detail ?? "")}`);
               console.log(`     ${render.wrap(render.c.dim, "The hook command could not be executed. Check that npx can resolve")}`);
-              console.log(`     ${render.wrap(render.c.dim, "@tpsdev-ai/flair-mcp — a cold cache, missing global install, or network")}`);
+              console.log(`     ${render.wrap(render.c.dim, "@tpsdev-ai/flair-mcp — a cold npx cache or network issue")}`);
               console.log(`     ${render.wrap(render.c.dim, "issue can prevent the adapter from running on its first invocation.")}`);
               console.log(`     ${render.wrap(render.c.dim, "Fix:")} flair doctor --fix ${render.wrap(render.c.dim, "(rewrites the hook to the current silent-failure form)")}`);
             }

--- a/test/unit/upgrade-probes.test.ts
+++ b/test/unit/upgrade-probes.test.ts
@@ -2,7 +2,7 @@ import { describe, test, expect, beforeEach, afterEach } from "bun:test";
 import { mkdtempSync, rmSync, writeFileSync, mkdirSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
-import { probeBinVersion, probeLibVersion, probeOpenclawPluginVersion, shouldPrintUpgradeLine } from "../../src/cli";
+import { probeBinVersion, probeLibVersion, probeOpenclawPluginVersion, shouldPrintUpgradeLine, upgradeStatusSuffix } from "../../src/cli";
 
 // execFileSync takes (file, args, opts) and returns Buffer|string. Tests
 // inject a fake that ignores input and returns a fixed string (or throws).
@@ -175,5 +175,38 @@ describe("shouldPrintUpgradeLine", () => {
       expect(shouldPrintUpgradeLine("outdated", showAll)).toBe(true);
       expect(shouldPrintUpgradeLine("missing", showAll)).toBe(true);
     }
+  });
+});
+
+// flair#1168: the upgrade/check advice must never recommend a global install
+// of flair-mcp — it is zero-install via npx.
+describe("upgradeStatusSuffix", () => {
+  test("missing flair-mcp does NOT suggest npm install -g", () => {
+    const suffix = upgradeStatusSuffix("@tpsdev-ai/flair-mcp", "missing");
+    expect(suffix).not.toContain("npm install -g");
+    expect(suffix).not.toContain("npm i -g");
+    expect(suffix).toContain("zero-install via npx");
+    expect(suffix).toContain("flair doctor --fix");
+  });
+
+  test("missing flair (the main package) still suggests npm install -g", () => {
+    const suffix = upgradeStatusSuffix("@tpsdev-ai/flair", "missing");
+    expect(suffix).toContain("npm install -g");
+  });
+
+  test("outdated packages have no suffix", () => {
+    expect(upgradeStatusSuffix("@tpsdev-ai/flair-mcp", "outdated")).toBe("");
+    expect(upgradeStatusSuffix("@tpsdev-ai/flair", "outdated")).toBe("");
+  });
+
+  test("current packages show (current)", () => {
+    expect(upgradeStatusSuffix("@tpsdev-ai/flair-mcp", "current")).toBe(" (current)");
+    expect(upgradeStatusSuffix("@tpsdev-ai/flair", "current")).toBe(" (current)");
+  });
+
+  test("optional packages show the openclaw install path", () => {
+    const suffix = upgradeStatusSuffix("@tpsdev-ai/openclaw-flair", "optional");
+    expect(suffix).toContain("openclaw plugins install");
+    expect(suffix).not.toContain("npm install -g");
   });
 });


### PR DESCRIPTION
Closes #1168.

## Problem

`flair upgrade --check` and the doctor hook-warning path wrongly suggest globally installing `@tpsdev-ai/flair-mcp` (e.g. `npm install -g @tpsdev-ai/flair-mcp`). flair-mcp is zero-install via npx — the corrected SessionStart hook form is `npx -y -p @tpsdev-ai/flair-mcp flair-session-start` (per #1166). A global install contradicts the documented no-global-install policy.

## Fix

Four places changed:

1. **`upgradeStatusSuffix`** (new exported function): when flair-mcp is "missing", returns `(zero-install via npx — run: flair doctor --fix)` instead of `(run: npm install -g)`. The main flair package still gets the npm install advice.

2. **`flair upgrade --check` "Install missing" message**: filters out flair-mcp from the `npm install -g` suggestion and prints a separate npx-based line.

3. **Doctor hook-warning**: `"missing global install"` changed to `"cold npx cache"` — the hook runs via npx, not a global install.

4. **`docs/upgrade.md`**: removed the `npm install -g @tpsdev-ai/flair-mcp@latest` line from the "upgrade by hand" section. Added a note that flair-mcp is zero-install via npx.

## Test

Added `upgradeStatusSuffix` tests in `test/unit/upgrade-probes.test.ts`:
- Missing flair-mcp does NOT suggest `npm install -g` (positive control)
- Missing flair (main package) still suggests `npm install -g`
- Outdated/current/optional packages have correct suffixes

Mutation-checked: breaking the flair-mcp special case causes the test to fail.
