### PR TITLE
chore: bump @harperfast/oauth to 2.5.0 (CIMD-on-Fabric for claude.ai)

### DIFF
--- a/.changelog/unreleased/changed-bump-harperfast-oauth-250.md
+++ b/.changelog/unreleased/changed-bump-harperfast-oauth-250.md
@@ -1,0 +1,1 @@
+- Bumped `@harperfast/oauth` to 2.5.0 (upstream oauth#200 — CIMD auth on Fabric for claude.ai remote MCP).

--- a/bun.lock
+++ b/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "@tpsdev-ai/flair",
       "dependencies": {
-        "@harperfast/oauth": "2.4.0",
+        "@harperfast/oauth": "2.5.0",
         "@types/js-yaml": "4.0.9",
         "commander": "14.0.3",
         "harper": "5.2.0",
@@ -357,7 +357,7 @@
 
     "@harperfast/extended-iterable": ["@harperfast/extended-iterable@1.0.3", "", {}, "sha512-sSAYhQca3rDWtQUHSAPeO7axFIUJOI6hn1gjRC5APVE1a90tuyT8f5WIgRsFhhWA7htNkju2veB9eWL6YHi/Lw=="],
 
-    "@harperfast/oauth": ["@harperfast/oauth@2.4.0", "", { "dependencies": { "jsonwebtoken": "^9.0.2", "jwks-rsa": "^3.1.0" }, "peerDependencies": { "harper": ">=5.0.0" } }, "sha512-cSmisQDG4EKR73G5jFHWq6eTxQ529WkSW5+Tplf+FKbdXN7j2HIEslkFZ1nPsD0DrVei5tdg3AF4IGfjFOYsfw=="],
+    "@harperfast/oauth": ["@harperfast/oauth@2.5.0", "", { "dependencies": { "jsonwebtoken": "^9.0.2", "jwks-rsa": "^3.1.0" }, "peerDependencies": { "harper": ">=5.0.0" } }, "sha512-c/3U+m3L7pKvuoIqfuGC5PJlecr1jO/RTufDHQKd3AIP6E2sKFwz5evjv95qK7zozO7xIkKGWxdK6HE7soI6UQ=="],
 
     "@harperfast/rocksdb-js": ["@harperfast/rocksdb-js@2.5.0", "", { "dependencies": { "@harperfast/extended-iterable": "1.0.3", "msgpackr": "2.0.4", "ordered-binary": "1.6.1" }, "optionalDependencies": { "@harperfast/rocksdb-js-darwin-arm64": "2.5.0", "@harperfast/rocksdb-js-darwin-x64": "2.5.0", "@harperfast/rocksdb-js-linux-arm64-glibc": "2.5.0", "@harperfast/rocksdb-js-linux-arm64-musl": "2.5.0", "@harperfast/rocksdb-js-linux-x64-glibc": "2.5.0", "@harperfast/rocksdb-js-linux-x64-musl": "2.5.0", "@harperfast/rocksdb-js-win32-arm64": "2.5.0", "@harperfast/rocksdb-js-win32-x64": "2.5.0" }, "bin": { "rocksdb-js": "./bin/rocksdb-js.mjs" } }, "sha512-v8T3J9n87seoDwKPmYxKdeC7gyA6lI9CJqU/MJMYfjfF1hyzb0aOjzRZx2X4wqm+iBJKtLNp8EKjEpIQuajeQQ=="],
 

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "node": ">=22"
   },
   "dependencies": {
-    "@harperfast/oauth": "2.4.0",
+    "@harperfast/oauth": "2.5.0",
     "@types/js-yaml": "4.0.9",
     "commander": "14.0.3",
     "harper": "5.2.0",

--- a/test/integration/mcp-oauth-boot-safety.test.ts
+++ b/test/integration/mcp-oauth-boot-safety.test.ts
@@ -137,7 +137,7 @@ describe("flair#1136 mutation-prove: mcp.enabled: true with env unset", () => {
   );
 
   test(
-    "${ENV} trap: Harper boots DEGRADED when mcp.enabled is ${FLAIR_MCP_OAUTH} and env is unset",
+    "${ENV} backstop: an unresolved mcp.enabled placeholder fail-safes to DISABLED (oauth 2.5.0+)",
     async () => {
       const workDir = mkdtempSync(join(tmpdir(), "flair-mutation-prove-env-"));
       const configPath = join(workDir, "config.yaml");
@@ -154,32 +154,31 @@ describe("flair#1136 mutation-prove: mcp.enabled: true with env unset", () => {
       const mutated = shipped.replace("enabled: false", 'enabled: "${FLAIR_MCP_OAUTH}"');
       writeFileSync(configPath, mutated, "utf-8");
 
-      // With FLAIR_MCP_OAUTH unset, expandEnvVar returns the literal
-      // "${FLAIR_MCP_OAUTH}" string. coerceConfigBoolean returns undefined
-      // for it, so the original truthy string is preserved. The plugin then
-      // enters issuer validation and fails on the unset issuer URL.
-      // This is WHY the shipped default MUST be literal false — ${ENV}
-      // interpolation of unset vars produces a truthy string that enables
-      // the crash path.
+      // oauth 2.5.0+ backstop: normalizeBooleanField detects the unresolved
+      // ${FLAIR_MCP_OAUTH} placeholder on mcp.enabled, warns, and DELETES the
+      // field — so the documented default (disabled) applies and Harper boots
+      // CLEAN with mcp OFF, instead of the pre-2.5.0 behavior where the truthy
+      // placeholder string enabled the crash path. We STILL ship literal false
+      // (proven by the sibling shipped-config test) — this proves the plugin
+      // fail-safes the ${ENV} form rather than failing degraded.
       const harper = await startHarper({
         cwd: workDir,
         harperBinDir: REPO_ROOT,
       });
       instances.push(harper);
 
-      // PROOF: degraded — health is 500, not 200.
-      const healthRes = await fetch(`${harper.httpURL}/health`, {
+      // PROOF: clean boot — Harper is healthy (ops API 200), NOT degraded.
+      const opsRes = await fetch(harper.opsURL, {
         signal: AbortSignal.timeout(10_000),
       });
-      expect(healthRes.status).toBe(500);
+      expect(opsRes.status).toBe(200);
 
-      // /mcp surfaces the same issuer validation error.
+      // /mcp is 404 — MCP is OFF (the placeholder was dropped to the default),
+      // not 500 (which is what a degraded plugin load returns).
       const mcpRes = await fetch(`${harper.httpURL}/mcp`, {
         signal: AbortSignal.timeout(10_000),
       });
-      expect(mcpRes.status).toBe(500);
-      const mcpBody = await mcpRes.text();
-      expect(mcpBody).toContain("mcp.issuer must be an absolute http(s) origin");
+      expect(mcpRes.status).toBe(404);
 
       // Clean up the temp dir.
       try { rmSync(workDir, { recursive: true, force: true }); } catch { /* ok */ }


### PR DESCRIPTION
Bumps the `@harperfast/oauth` dependency 2.4.0 → 2.5.0 so the Fabric hub (deployed via the flair component) runs oauth 2.5.0 — the upstream oauth#200 fix for CIMD auth on Fabric for claude.ai remote MCP. Dependency + lockfile + changelog only; no flair code change. Installs clean, flair builds.

Follow-up commit d409724 refocuses the #1136 boot-safety integration test to oauth 2.5.0's intentional fail-safe-to-disabled behavior (an unresolved `${ENV}` placeholder on `mcp.enabled` now drops to the documented default instead of staying truthy). Test-only, +14/-15; K&S re-approved on the current head.

No issue: infra dependency bump for the hub; upstream context is HarperFast/oauth#200 and the CHANGELOG heads-up #207.
