### PR TITLE
fix(adk-flair): make the ADK quickstart cold-run-safe (Python + JS)

### DIFF
--- a/.changelog/unreleased/fixed-adk-quickstart-cold-run.md
+++ b/.changelog/unreleased/fixed-adk-quickstart-cold-run.md
@@ -1,0 +1,5 @@
+- **`adk-flair` ships a runnable cross-session-recall quickstart.** New
+  `examples/quickstart.ts` (JS) and `examples/quickstart.py` (Python) plant a
+  fact in one session, wait for a freshly-booted Flair to make it searchable,
+  then recall it in a brand-new session and print the result — reliable on a
+  cold instance without weakening the adapter's production 2s search budget.

--- a/.changelog/unreleased/fixed-adk-quickstart-keyfile.md
+++ b/.changelog/unreleased/fixed-adk-quickstart-keyfile.md
@@ -1,0 +1,6 @@
+- **`adk-flair` reads the keyfile `flair agent add` actually writes.** The ADK
+  memory adapter (Python and JS) now accepts the raw 32-byte Ed25519 seed that
+  `flair agent add` writes to `~/.flair/keys/<id>.key` — alongside base64-encoded
+  seeds, base64 PKCS8 DER, and PEM — and expands a leading `~` in `FLAIR_KEYFILE`.
+  Following the documented quickstart no longer fails with a cryptic ASN.1 decode
+  error, and a missing keyfile now raises a clear message naming the resolved path.

--- a/packages/adk-flair-js/README.md
+++ b/packages/adk-flair-js/README.md
@@ -5,31 +5,67 @@
 [Flair](https://github.com/tpsdev-ai/flair) — a self-hosted, federated
 semantic memory engine. Keep your agent memory yours.
 
-```bash
-npm install @tpsdev-ai/adk-flair
-```
-
 ## Quickstart
 
-Swap the memory service in your ADK agent:
+```bash
+# 1. Install Flair and initialise it
+npm i -g @tpsdev-ai/flair
+flair init
+
+# 2. Provision an Ed25519 identity for your ADK app
+flair agent add my-adk-app
+# → writes ~/.flair/keys/my-adk-app.key
+
+# 3. Install adk-flair
+npm install @tpsdev-ai/adk-flair
+
+# 4. Set environment variables
+export FLAIR_URL=http://localhost:19926
+export FLAIR_AGENT_ID=my-adk-app
+export FLAIR_KEYFILE=~/.flair/keys/my-adk-app.key
+export GOOGLE_API_KEY=...   # or GEMINI_API_KEY, to run the agent
+```
+
+Then swap the memory service in your ADK agent (illustrative — `agent` and
+`sessionService` are your own, see the runnable example below for the full
+wiring):
 
 ```typescript
 import { FlairMemoryService } from "@tpsdev-ai/adk-flair";
-import { Runner } from "@google/adk";
+import { Agent, Runner, InMemorySessionService, PRELOAD_MEMORY } from "@google/adk";
 
 const memoryService = new FlairMemoryService({
-  url: "http://localhost:19926",
-  agentId: "my-adk-app",
-  keyfile: "~/.flair/keys/my-adk-app.key",
+  url: process.env.FLAIR_URL,          // http://localhost:19926
+  agentId: process.env.FLAIR_AGENT_ID, // my-adk-app
+  keyfile: process.env.FLAIR_KEYFILE,  // ~/.flair/keys/my-adk-app.key (~ is expanded)
+});
+
+const agent = new Agent({
+  model: "gemini-2.5-flash",
+  name: "my_agent",
+  instruction: "You are a helpful assistant with memory.",
+  tools: [PRELOAD_MEMORY],             // pulls past memories into the prompt
 });
 
 const runner = new Runner({
   agent,
   appName: "my-app",
-  sessionService,
+  sessionService: new InMemorySessionService(),
   memoryService,
 });
 ```
+
+### Run it end to end
+
+A complete, copy-paste-runnable demo lives at
+[`examples/quickstart.ts`](./examples/quickstart.ts). After the steps above:
+
+```bash
+bun run examples/quickstart.ts
+```
+
+It plants a fact in session 1, waits for Flair to make it searchable, then
+asks for it back in a fresh session 2 and prints whether the fact was recalled.
 
 ### Dev UI (AdkApiServer)
 
@@ -48,7 +84,7 @@ server.start();
 |---|---|---|---|
 | `FLAIR_URL` | No | `http://localhost:19926` | Flair HTTP endpoint |
 | `FLAIR_AGENT_ID` | Yes | — | Flair agent identity |
-| `FLAIR_KEYFILE` | Yes | — | Path to Ed25519 PKCS8 base64 keyfile |
+| `FLAIR_KEYFILE` | Yes | — | Path to the Ed25519 keyfile from `flair agent add` (raw seed; base64/PEM also accepted). A leading `~` is expanded. |
 | `FLAIR_ALLOW_REMOTE_URL` | No | — | Set to `1` to allow non-localhost URLs |
 
 All values can also be passed directly to the constructor.

--- a/packages/adk-flair-js/examples/quickstart.ts
+++ b/packages/adk-flair-js/examples/quickstart.ts
@@ -1,0 +1,212 @@
+/**
+ * adk-flair quickstart (JS/TS) — cross-session recall with a real Gemini model.
+ *
+ * Runs the Memory Bank ADK quickstart flow against Flair instead of Vertex AI
+ * Memory Bank:
+ *
+ *   1. Build a minimal ADK agent (Gemini) with FlairMemoryService as its memory.
+ *   2. Session 1 — the user tells the agent a fact; the after-agent callback
+ *      persists the turn to Flair.
+ *   3. SETTLE — poll searchMemory until that fact is retrievable (bounded), so
+ *      a freshly-booted Flair has finished indexing before we read back. This is
+ *      the demo's reliability step; it does NOT change the adapter's production
+ *      2s search budget (a deliberate graceful-degradation design).
+ *   4. Session 2 — a brand-new session asks for the fact; PRELOAD_MEMORY pulls it
+ *      from Flair and the agent answers. We print whether the fact was recalled.
+ *
+ * ─── Prerequisites (see README.md) ──────────────────────────────────────────
+ *   npm i -g @tpsdev-ai/flair && flair init
+ *   flair agent add my-adk-app          # writes ~/.flair/keys/my-adk-app.key
+ *   export FLAIR_URL=http://localhost:19926
+ *   export FLAIR_AGENT_ID=my-adk-app
+ *   export FLAIR_KEYFILE=~/.flair/keys/my-adk-app.key
+ *   export GOOGLE_API_KEY=...           # or GEMINI_API_KEY
+ *
+ * ─── Run ─────────────────────────────────────────────────────────────────────
+ *   bun run packages/adk-flair-js/examples/quickstart.ts
+ *   # or, after `npm install @tpsdev-ai/adk-flair` in your own project:
+ *   #   npx tsx quickstart.ts
+ *
+ * Exit code: 0 = fact recalled, 2 = not recalled, 1 = setup/settle error.
+ */
+
+import { FlairMemoryService } from "@tpsdev-ai/adk-flair";
+import {
+  Agent,
+  Runner,
+  InMemorySessionService,
+  PRELOAD_MEMORY,
+} from "@google/adk";
+import type { Session, Event } from "@google/adk";
+import type { Content } from "@google/genai";
+import * as crypto from "node:crypto";
+
+const APP_NAME = "adk-flair-quickstart-js";
+// A fresh user id per run keeps the demo idempotent: session 1 and session 2
+// share it (that's the cross-session recall), but re-running against the same
+// Flair never accumulates conflicting facts under one user. Set FLAIR_DEMO_USER
+// to pin a stable identity across runs instead.
+const USER_ID =
+  process.env["FLAIR_DEMO_USER"] ?? `demo-user-${crypto.randomUUID().slice(0, 8)}`;
+const MODEL = process.env["ADK_MODEL"] ?? "gemini-2.5-flash";
+const SETTLE_BUDGET_MS = 10_000;
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+/**
+ * Poll searchMemory until the planted token is retrievable, or the budget
+ * expires. Returns the number of polls it took, or null on timeout.
+ */
+async function settle(
+  memory: FlairMemoryService,
+  token: string,
+  budgetMs: number,
+): Promise<number | null> {
+  const deadline = Date.now() + budgetMs;
+  let attempt = 0;
+  while (Date.now() < deadline) {
+    attempt++;
+    const res = await memory.searchMemory({
+      appName: APP_NAME,
+      userId: USER_ID,
+      query: token,
+    });
+    const found = res.memories.some((m) =>
+      ((m.content?.parts?.[0] as { text?: string })?.text ?? "")
+        .toLowerCase()
+        .includes(token.toLowerCase()),
+    );
+    if (found) return attempt;
+    await sleep(500);
+  }
+  return null;
+}
+
+/** Run one agent turn and return all model-authored text concatenated. */
+async function runTurn(
+  runner: Runner,
+  sessionId: string,
+  text: string,
+): Promise<string> {
+  const out: string[] = [];
+  for await (const event of runner.runAsync({
+    userId: USER_ID,
+    sessionId,
+    newMessage: { role: "user", parts: [{ text }] } as Content,
+  })) {
+    const evt = event as Event;
+    if (evt.author === "quickstart_agent") {
+      for (const p of evt.content?.parts ?? []) {
+        const t = (p as { text?: string }).text;
+        if (t) out.push(t);
+      }
+    }
+  }
+  return out.join(" ").trim();
+}
+
+async function main(): Promise<void> {
+  const url = process.env["FLAIR_URL"] ?? "http://localhost:19926";
+  const agentId = process.env["FLAIR_AGENT_ID"];
+  const keyfile = process.env["FLAIR_KEYFILE"];
+
+  if (!agentId || !keyfile) {
+    console.error(
+      "Set FLAIR_AGENT_ID and FLAIR_KEYFILE first (see the README quickstart). " +
+        "Provision them with `flair agent add <id>`.",
+    );
+    process.exit(1);
+  }
+  if (!process.env["GOOGLE_API_KEY"] && !process.env["GEMINI_API_KEY"]) {
+    console.error(
+      "Set GOOGLE_API_KEY (or GEMINI_API_KEY) to a Gemini API key to run the agent.",
+    );
+    process.exit(1);
+  }
+
+  const memory = new FlairMemoryService({ url, agentId, keyfile });
+
+  // Persist each turn's events to Flair after the agent responds.
+  const afterAgentCallback = async (ctx: {
+    invocationContext: { session: Session };
+  }): Promise<void> => {
+    const s = ctx.invocationContext.session;
+    await memory.addEventsToMemory(APP_NAME, USER_ID, s.events, s.id);
+  };
+
+  const agent = new Agent({
+    model: MODEL,
+    name: "quickstart_agent",
+    instruction:
+      "You are a helpful assistant with long-term memory. Use the " +
+      "preload_memory tool to recall what you know about the user, and " +
+      "remember new facts they tell you.",
+    tools: [PRELOAD_MEMORY],
+    afterAgentCallback,
+  });
+
+  const sessionService = new InMemorySessionService();
+  const runner = new Runner({
+    agent,
+    appName: APP_NAME,
+    sessionService,
+    memoryService: memory,
+  });
+
+  console.log(
+    `adk-flair quickstart (JS) — Flair=${url} model=${MODEL} user=${USER_ID}`,
+  );
+
+  // ── Session 1: plant a fact ──────────────────────────────────────────────
+  const token = `zephyr-${crypto.randomUUID().slice(0, 8)}`;
+  const session1 = await sessionService.createSession({
+    appName: APP_NAME,
+    userId: USER_ID,
+  });
+  console.log(`\n[session 1] planting fact: favorite code word = '${token}'`);
+  const a1 = await runTurn(
+    runner,
+    session1.id,
+    `Remember this about me: my favorite code word is '${token}'. ` +
+      `Acknowledge that you've stored it.`,
+  );
+  console.log(`[session 1] agent: ${a1}`);
+
+  // ── Settle: wait until the fact is retrievable on this (possibly cold) Flair
+  console.log(`\n[settle] waiting for the fact to become searchable...`);
+  const polls = await settle(memory, token, SETTLE_BUDGET_MS);
+  if (polls === null) {
+    console.error(
+      `[settle] TIMED OUT after ${SETTLE_BUDGET_MS / 1000}s — the fact never ` +
+        `became searchable. Is Flair indexing? Is FLAIR_URL correct?`,
+    );
+    await memory.close();
+    process.exit(1);
+  }
+  console.log(`[settle] fact searchable after ${polls} poll(s)`);
+
+  // ── Session 2: recall in a brand-new session ─────────────────────────────
+  const session2 = await sessionService.createSession({
+    appName: APP_NAME,
+    userId: USER_ID,
+  });
+  console.log(`\n[session 2] asking: What is my favorite code word?`);
+  const a2 = await runTurn(runner, session2.id, "What is my favorite code word?");
+  console.log(`[session 2] agent: ${a2}`);
+
+  const recalled = a2.toLowerCase().includes(token.toLowerCase());
+  console.log(
+    `\nRECALLED: ${recalled ? "yes" : "no"} (planted '${token}', ` +
+      `${recalled ? "found" : "not found"} in the session-2 answer)`,
+  );
+
+  await memory.close();
+  process.exit(recalled ? 0 : 2);
+}
+
+main().catch((err) => {
+  console.error("quickstart failed:", err);
+  process.exit(1);
+});

--- a/packages/adk-flair-js/src/signing.ts
+++ b/packages/adk-flair-js/src/signing.ts
@@ -8,66 +8,141 @@
 
 import * as crypto from "node:crypto";
 import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+
+// PKCS8 DER prefix for an Ed25519 private key. Prepending this to a raw
+// 32-byte seed yields a full 48-byte PKCS8 DER that `createPrivateKey` accepts.
+// Mirrors src/lib/auth-resolve.ts:buildEd25519Auth so the adapter reads exactly
+// the keyfiles Flair itself writes and signs with.
+const ED25519_PKCS8_HEADER = Buffer.from(
+  "302e020100300506032b657004220420",
+  "hex",
+);
 
 /**
- * Load and validate an Ed25519 private key from a PKCS8 base64 keyfile.
+ * Expand a leading `~` / `~/` to the current user's home directory.
  *
- * Parses the key material in the constructor path so that a bad keyfile
- * fails immediately (before ADK's exception-swallowing search path can
- * turn it into permanent silent empty recall).
+ * `flair agent add <id>` and the README both hand users paths like
+ * `~/.flair/keys/<id>.key`. Node's `fs` does not expand `~` — a shell does —
+ * so a raw `readFileSync("~/...")` throws ENOENT for a cold user copying the
+ * quickstart verbatim. Expand here so the documented path just works.
+ */
+export function expandHome(p: string): string {
+  if (p === "~") return os.homedir();
+  if (p.startsWith("~/") || p.startsWith("~\\")) {
+    return path.join(os.homedir(), p.slice(2));
+  }
+  return p;
+}
+
+/**
+ * Load and validate an Ed25519 private key from a Flair keyfile.
  *
- * @param keyfilePath - Path to the keyfile (PKCS8 DER, base64-encoded)
+ * Accepts every on-disk encoding Flair itself produces or consumes (mirrors
+ * src/lib/auth-resolve.ts), so the keyfile written by `flair agent add`
+ * (a raw 32-byte seed) loads without a conversion step:
+ *
+ *   - raw 32-byte Ed25519 seed (binary) — what `flair agent add` writes
+ *   - base64-encoded raw 32-byte seed
+ *   - base64-encoded PKCS8 DER (the historical adk-flair format)
+ *   - PEM (`-----BEGIN PRIVATE KEY-----`)
+ *
+ * Parses the key material eagerly (in the constructor path) so that a bad
+ * keyfile fails immediately — before ADK's exception-swallowing search path
+ * can turn it into permanent silent empty recall.
+ *
+ * A leading `~`/`~/` in the path is expanded to the home directory.
+ *
+ * @param keyfilePath - Path to the keyfile (`~` accepted)
  * @returns A Node.js KeyObject for the Ed25519 private key
  * @throws If the keyfile is missing, unreadable, or contains invalid key material
  */
 export function loadEd25519Key(keyfilePath: string): crypto.KeyObject {
-  let b64: string;
+  const resolvedPath = expandHome(keyfilePath);
+
+  let raw: Buffer;
   try {
-    b64 = fs.readFileSync(keyfilePath, "utf-8").trim();
+    raw = fs.readFileSync(resolvedPath);
   } catch (err: unknown) {
+    const code = (err as NodeJS.ErrnoException | undefined)?.code;
+    if (code === "ENOENT") {
+      throw new Error(
+        `FLAIR_KEYFILE: keyfile not found at "${resolvedPath}"` +
+          (resolvedPath !== keyfilePath ? ` (expanded from "${keyfilePath}")` : "") +
+          `. Provision one with: flair agent add <agent-id> ` +
+          `(writes ~/.flair/keys/<agent-id>.key), then point FLAIR_KEYFILE at it.`,
+      );
+    }
     const msg = err instanceof Error ? err.message : String(err);
     throw new Error(
-      `FLAIR_KEYFILE: cannot read keyfile: ${msg}`
+      `FLAIR_KEYFILE: cannot read keyfile at "${resolvedPath}": ${msg}`,
     );
   }
 
-  if (b64.length === 0) {
-    throw new Error("FLAIR_KEYFILE: keyfile is empty");
-  }
-
-  let der: Buffer;
-  try {
-    der = Buffer.from(b64, "base64");
-  } catch {
-    throw new Error("FLAIR_KEYFILE: keyfile is not valid base64");
-  }
-
-  if (der.length === 0) {
-    throw new Error("FLAIR_KEYFILE: keyfile decoded to empty key material");
+  if (raw.length === 0) {
+    throw new Error(`FLAIR_KEYFILE: keyfile at "${resolvedPath}" is empty`);
   }
 
   let key: crypto.KeyObject;
   try {
-    key = crypto.createPrivateKey({
-      key: der,
-      format: "der",
-      type: "pkcs8",
-    });
+    key = parseEd25519(raw);
   } catch (err: unknown) {
     const msg = err instanceof Error ? err.message : String(err);
     throw new Error(
-      `FLAIR_KEYFILE: invalid Ed25519 key material: ${msg}`
+      `FLAIR_KEYFILE: invalid Ed25519 key material in "${resolvedPath}": ${msg}`,
     );
   }
 
   // Verify it's actually an Ed25519 key
   if (key.asymmetricKeyType !== "ed25519") {
     throw new Error(
-      `FLAIR_KEYFILE: expected Ed25519 key, got ${key.asymmetricKeyType ?? "unknown"}`
+      `FLAIR_KEYFILE: expected Ed25519 key in "${resolvedPath}", ` +
+        `got ${key.asymmetricKeyType ?? "unknown"}`,
     );
   }
 
   return key;
+}
+
+/**
+ * Turn raw keyfile bytes into an Ed25519 KeyObject, trying each format Flair
+ * emits. Throws if none parse.
+ */
+function parseEd25519(raw: Buffer): crypto.KeyObject {
+  // 1) Raw 32-byte seed on disk (binary) — `flair agent add` format.
+  if (raw.length === 32) {
+    return crypto.createPrivateKey({
+      key: Buffer.concat([ED25519_PKCS8_HEADER, raw]),
+      format: "der",
+      type: "pkcs8",
+    });
+  }
+
+  const text = raw.toString("utf-8").trim();
+
+  // 2) PEM.
+  if (text.includes("-----BEGIN")) {
+    return crypto.createPrivateKey(text);
+  }
+
+  // 3/4) base64 — either a raw 32-byte seed or a full PKCS8 DER.
+  const decoded = Buffer.from(text, "base64");
+  if (decoded.length === 0) {
+    throw new Error("keyfile did not decode to any key material");
+  }
+  if (decoded.length === 32) {
+    return crypto.createPrivateKey({
+      key: Buffer.concat([ED25519_PKCS8_HEADER, decoded]),
+      format: "der",
+      type: "pkcs8",
+    });
+  }
+  return crypto.createPrivateKey({
+    key: decoded,
+    format: "der",
+    type: "pkcs8",
+  });
 }
 
 /**

--- a/packages/adk-flair-js/test/unit/memory_service.test.ts
+++ b/packages/adk-flair-js/test/unit/memory_service.test.ts
@@ -5,10 +5,10 @@
  * Uses mock fetch to avoid requiring a live Flair instance.
  */
 
-import { describe, it, expect, beforeEach, afterEach, mock } from "bun:test";
+import { describe, it, expect, beforeEach, afterEach, mock, spyOn } from "bun:test";
 import { FlairMemoryService } from "../../src/memory_service.js";
 import { compoundTag, sanitizeTagSegment } from "../../src/tag.js";
-import { loadEd25519Key, signRequest } from "../../src/signing.js";
+import { loadEd25519Key, signRequest, expandHome } from "../../src/signing.js";
 import * as crypto from "node:crypto";
 import * as fs from "node:fs";
 import * as os from "node:os";
@@ -147,6 +147,58 @@ describe("signing", () => {
     const key = loadEd25519Key(keyfilePath);
     const header = signRequest(key, "test-agent", "POST", "/SemanticSearch");
     expect(header).toMatch(/^TPS-Ed25519 test-agent:\d+:[0-9a-f-]+:[A-Za-z0-9+/=]+$/);
+  });
+
+  it("loads a raw 32-byte seed keyfile (the `flair agent add` format)", () => {
+    // `flair agent add <id>` writes the private key as a raw 32-byte Ed25519
+    // seed (src/cli.ts), NOT PKCS8 base64. A cold user following the README
+    // points FLAIR_KEYFILE straight at ~/.flair/keys/<id>.key, so the adapter
+    // must read that format — otherwise the documented quickstart never works.
+    const { privateKey } = crypto.generateKeyPairSync("ed25519");
+    const pkcs8 = privateKey.export({ format: "der", type: "pkcs8" }); // 48 bytes
+    const seed = pkcs8.subarray(16); // raw 32-byte seed
+    expect(seed.length).toBe(32);
+    const seedPath = path.join(os.tmpdir(), `adk-flair-seed-${crypto.randomUUID()}.key`);
+    fs.writeFileSync(seedPath, seed); // binary, exactly like the CLI
+    try {
+      const key = loadEd25519Key(seedPath);
+      expect(key.asymmetricKeyType).toBe("ed25519");
+    } finally {
+      fs.unlinkSync(seedPath);
+    }
+  });
+
+  it("expands a leading ~/ to the home directory", () => {
+    // Point os.homedir() at a temp dir and drop a keyfile under ~/.flair/keys/.
+    const fakeHome = fs.mkdtempSync(path.join(os.tmpdir(), "adk-flair-home-"));
+    const keysDir = path.join(fakeHome, ".flair", "keys");
+    fs.mkdirSync(keysDir, { recursive: true });
+    fs.copyFileSync(keyfilePath, path.join(keysDir, "agent.key"));
+    const homedirSpy = spyOn(os, "homedir").mockReturnValue(fakeHome);
+    try {
+      expect(expandHome("~/.flair/keys/agent.key")).toBe(
+        path.join(fakeHome, ".flair", "keys", "agent.key"),
+      );
+      const key = loadEd25519Key("~/.flair/keys/agent.key");
+      expect(key.asymmetricKeyType).toBe("ed25519");
+    } finally {
+      homedirSpy.mockRestore();
+      fs.rmSync(fakeHome, { recursive: true, force: true });
+    }
+  });
+
+  it("throws a clear error naming the expanded path when a ~ keyfile is missing", () => {
+    const homedirSpy = spyOn(os, "homedir").mockReturnValue("/fake/home");
+    try {
+      // Never a bare ENOENT — the message must name the resolved path and stay
+      // FLAIR_KEYFILE-tagged so the constructor's error contract holds.
+      expect(() => loadEd25519Key("~/.flair/keys/missing.key")).toThrow("FLAIR_KEYFILE");
+      expect(() => loadEd25519Key("~/.flair/keys/missing.key")).toThrow(
+        "/fake/home/.flair/keys/missing.key",
+      );
+    } finally {
+      homedirSpy.mockRestore();
+    }
   });
 });
 

--- a/packages/adk-flair/README.md
+++ b/packages/adk-flair/README.md
@@ -33,15 +33,16 @@ flair init
 
 # 2. Provision an Ed25519 identity for your ADK app
 flair agent add my-adk-app
-# → writes ~/.flair/keys/my-adk-app.key (PKCS8 base64)
+# → writes ~/.flair/keys/my-adk-app.key
 
-# 3. Install adk-flair
-pip install adk-flair
+# 3. Install adk-flair (litellm powers the Gemini model in the example)
+pip install adk-flair litellm
 
 # 4. Set environment variables
 export FLAIR_URL=http://localhost:19926
 export FLAIR_AGENT_ID=my-adk-app
 export FLAIR_KEYFILE=$HOME/.flair/keys/my-adk-app.key
+export GOOGLE_API_KEY=...   # or GEMINI_API_KEY, to run the agent
 
 # 5. Use in your agent
 #    from adk_flair import FlairMemoryService
@@ -52,13 +53,25 @@ export FLAIR_KEYFILE=$HOME/.flair/keys/my-adk-app.key
 adk web --memory_service_uri="flair://localhost:19926"
 ```
 
+### Run it end to end
+
+A complete, copy-paste-runnable demo lives at
+[`examples/quickstart.py`](./examples/quickstart.py). After the steps above:
+
+```bash
+python examples/quickstart.py
+```
+
+It plants a fact in session 1, waits for Flair to make it searchable, then
+asks for it back in a fresh session 2 and prints whether the fact was recalled.
+
 ## Configuration
 
 | Setting          | Env var            | Default                       | Notes                                    |
 |------------------|--------------------|-------------------------------|------------------------------------------|
 | Server URL       | `FLAIR_URL`        | `http://localhost:19926`      | Must be localhost unless opt-in (below)  |
 | Agent ID         | `FLAIR_AGENT_ID`   | (required)                    | Must match `flair agent add <id>`        |
-| Private key path | `FLAIR_KEYFILE`    | (required)                    | PKCS8 base64 Ed25519 key                 |
+| Private key path | `FLAIR_KEYFILE`    | (required)                    | Keyfile from `flair agent add` (raw seed; base64/PEM also accepted). A leading `~` is expanded. |
 | Allow remote URL | `FLAIR_ALLOW_REMOTE_URL` | (unset)                 | Set to `1` to allow non-localhost URLs   |
 
 All settings can also be passed as constructor arguments:

--- a/packages/adk-flair/examples/quickstart.py
+++ b/packages/adk-flair/examples/quickstart.py
@@ -1,0 +1,195 @@
+"""adk-flair quickstart (Python) — cross-session recall with a real Gemini model.
+
+Runs the Memory Bank ADK quickstart flow against Flair instead of Vertex AI
+Memory Bank:
+
+  1. Build a minimal ADK agent (Gemini via LiteLLM) with FlairMemoryService as
+     its memory.
+  2. Session 1 — the user tells the agent a fact; the after-agent callback
+     persists the turn to Flair.
+  3. SETTLE — poll search_memory until that fact is retrievable (bounded), so a
+     freshly-booted Flair has finished indexing before we read back. This is the
+     demo's reliability step; it does NOT change the adapter's production 2s
+     search budget (a deliberate graceful-degradation design).
+  4. Session 2 — a brand-new session asks for the fact; preload_memory pulls it
+     from Flair and the agent answers. We print whether the fact was recalled.
+
+─── Prerequisites (see README.md) ──────────────────────────────────────────
+    npm i -g @tpsdev-ai/flair && flair init
+    flair agent add my-adk-app          # writes ~/.flair/keys/my-adk-app.key
+    pip install adk-flair litellm       # LiteLLM powers the Gemini model
+    export FLAIR_URL=http://localhost:19926
+    export FLAIR_AGENT_ID=my-adk-app
+    export FLAIR_KEYFILE=~/.flair/keys/my-adk-app.key
+    export GOOGLE_API_KEY=...           # or GEMINI_API_KEY
+
+─── Run ─────────────────────────────────────────────────────────────────────
+    python packages/adk-flair/examples/quickstart.py
+
+Exit code: 0 = fact recalled, 2 = not recalled, 1 = setup/settle error.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import sys
+import time
+import uuid
+
+APP_NAME = "adk-flair-quickstart-py"
+# A fresh user id per run keeps the demo idempotent: session 1 and session 2
+# share it (that's the cross-session recall), but re-running against the same
+# Flair never accumulates conflicting facts under one user. Set FLAIR_DEMO_USER
+# to pin a stable identity across runs instead.
+USER_ID = os.environ.get("FLAIR_DEMO_USER", f"demo-user-{uuid.uuid4().hex[:8]}")
+MODEL = os.environ.get("ADK_MODEL", "gemini/gemini-2.5-flash")  # LiteLLM syntax
+SETTLE_BUDGET_S = 10.0
+
+
+async def settle(memory, token: str, budget_s: float):
+    """Poll search_memory until the token is retrievable. Returns poll count or None."""
+    deadline = time.monotonic() + budget_s
+    attempt = 0
+    while time.monotonic() < deadline:
+        attempt += 1
+        res = await memory.search_memory(
+            app_name=APP_NAME, user_id=USER_ID, query=token
+        )
+        for m in res.memories:
+            text = m.content.parts[0].text if (m.content and m.content.parts) else ""
+            if token.lower() in (text or "").lower():
+                return attempt
+        await asyncio.sleep(0.5)
+    return None
+
+
+async def run_turn(runner, session_id: str, text: str) -> str:
+    """Run one agent turn and return all model-authored text concatenated."""
+    from google.genai import types
+
+    out: list[str] = []
+    async for event in runner.run_async(
+        user_id=USER_ID,
+        session_id=session_id,
+        new_message=types.Content(role="user", parts=[types.Part(text=text)]),
+    ):
+        if getattr(event, "author", "") == "quickstart_agent":
+            content = getattr(event, "content", None)
+            for p in (getattr(content, "parts", None) or []):
+                t = getattr(p, "text", None)
+                if t:
+                    out.append(str(t))
+    return " ".join(out).strip()
+
+
+async def main() -> int:
+    url = os.environ.get("FLAIR_URL", "http://localhost:19926")
+    agent_id = os.environ.get("FLAIR_AGENT_ID")
+    keyfile = os.environ.get("FLAIR_KEYFILE")
+
+    if not agent_id or not keyfile:
+        print(
+            "Set FLAIR_AGENT_ID and FLAIR_KEYFILE first (see the README quickstart). "
+            "Provision them with `flair agent add <id>`.",
+            file=sys.stderr,
+        )
+        return 1
+    if not os.environ.get("GOOGLE_API_KEY") and not os.environ.get("GEMINI_API_KEY"):
+        print(
+            "Set GOOGLE_API_KEY (or GEMINI_API_KEY) to a Gemini API key to run the agent.",
+            file=sys.stderr,
+        )
+        return 1
+
+    from adk_flair import FlairMemoryService
+    from google.adk import Agent
+    from google.adk.runners import Runner
+    from google.adk.tools import preload_memory
+    from google.adk.sessions import InMemorySessionService
+
+    try:
+        from google.adk.models.lite_llm import LiteLlm
+    except ImportError:
+        print(
+            "This example uses LiteLLM for the Gemini model — run `pip install litellm`.",
+            file=sys.stderr,
+        )
+        return 1
+
+    memory = FlairMemoryService(url=url, agent_id=agent_id, keyfile=keyfile)
+
+    async def after_agent_callback(callback_context):
+        """Persist each turn's events to Flair after the agent responds."""
+        await memory.add_events_to_memory(
+            app_name=APP_NAME,
+            user_id=USER_ID,
+            events=callback_context.session.events,
+            session_id=callback_context.session.id,
+        )
+
+    agent = Agent(
+        model=LiteLlm(model=MODEL),
+        name="quickstart_agent",
+        instruction=(
+            "You are a helpful assistant with long-term memory. Use the "
+            "preload_memory tool to recall what you know about the user, and "
+            "remember new facts they tell you."
+        ),
+        tools=[preload_memory],
+        after_agent_callback=after_agent_callback,
+    )
+
+    session_service = InMemorySessionService()
+    runner = Runner(
+        agent=agent,
+        app_name=APP_NAME,
+        session_service=session_service,
+        memory_service=memory,
+    )
+
+    print(f"adk-flair quickstart (Python) — Flair={url} model={MODEL} user={USER_ID}")
+
+    # ── Session 1: plant a fact ──────────────────────────────────────────────
+    token = f"zephyr-{uuid.uuid4().hex[:8]}"
+    session1 = await session_service.create_session(app_name=APP_NAME, user_id=USER_ID)
+    print(f"\n[session 1] planting fact: favorite code word = '{token}'")
+    a1 = await run_turn(
+        runner,
+        session1.id,
+        f"Remember this about me: my favorite code word is '{token}'. "
+        f"Acknowledge that you've stored it.",
+    )
+    print(f"[session 1] agent: {a1}")
+
+    # ── Settle: wait until the fact is retrievable on this (possibly cold) Flair
+    print("\n[settle] waiting for the fact to become searchable...")
+    polls = await settle(memory, token, SETTLE_BUDGET_S)
+    if polls is None:
+        print(
+            f"[settle] TIMED OUT after {SETTLE_BUDGET_S:.0f}s — the fact never "
+            f"became searchable. Is Flair indexing? Is FLAIR_URL correct?",
+            file=sys.stderr,
+        )
+        await memory.close()
+        return 1
+    print(f"[settle] fact searchable after {polls} poll(s)")
+
+    # ── Session 2: recall in a brand-new session ─────────────────────────────
+    session2 = await session_service.create_session(app_name=APP_NAME, user_id=USER_ID)
+    print("\n[session 2] asking: What is my favorite code word?")
+    a2 = await run_turn(runner, session2.id, "What is my favorite code word?")
+    print(f"[session 2] agent: {a2}")
+
+    recalled = token.lower() in a2.lower()
+    print(
+        f"\nRECALLED: {'yes' if recalled else 'no'} (planted '{token}', "
+        f"{'found' if recalled else 'not found'} in the session-2 answer)"
+    )
+
+    await memory.close()
+    return 0 if recalled else 2
+
+
+if __name__ == "__main__":
+    sys.exit(asyncio.run(main()))

--- a/packages/adk-flair/src/adk_flair/memory_service.py
+++ b/packages/adk-flair/src/adk_flair/memory_service.py
@@ -75,30 +75,77 @@ def _iso_now() -> str:
     return now.strftime("%Y-%m-%dT%H:%M:%S.") + f"{now.microsecond // 1000:03d}Z"
 
 
-def _load_ed25519_key(keyfile: str) -> ed25519.Ed25519PrivateKey:
-    """Load a PKCS8 base64-encoded Ed25519 private key from a Flair-managed keyfile.
+def _parse_ed25519_key(raw: bytes) -> ed25519.Ed25519PrivateKey:
+    """Parse Ed25519 key bytes in any encoding Flair produces or consumes.
 
-    Raises ValueError with the env-var name (never the filesystem path) on failure.
+    Mirrors src/lib/auth-resolve.ts:buildEd25519Auth so the adapter reads
+    exactly the keyfiles Flair itself writes and signs with:
+
+      - raw 32-byte Ed25519 seed (binary) — what ``flair agent add`` writes
+      - base64-encoded raw 32-byte seed
+      - base64-encoded PKCS8 DER (the historical adk-flair format)
+      - PEM (``-----BEGIN PRIVATE KEY-----``)
     """
-    try:
-        raw = Path(keyfile).read_text(encoding="utf-8").strip()
-        der = base64.b64decode(raw)
-        key = serialization.load_der_private_key(der, password=None)
+    # 1) Raw 32-byte seed on disk (binary) — `flair agent add` format.
+    if len(raw) == 32:
+        return ed25519.Ed25519PrivateKey.from_private_bytes(raw)
+
+    text = raw.decode("utf-8").strip()  # raises UnicodeDecodeError on binary junk
+
+    # 2) PEM.
+    if "-----BEGIN" in text:
+        key = serialization.load_pem_private_key(text.encode("ascii"), password=None)
         if not isinstance(key, ed25519.Ed25519PrivateKey):
-            raise ValueError(
-                f"FLAIR_KEYFILE does not contain an Ed25519 key "
-                f"(got {type(key).__name__})"
-            )
+            raise ValueError(f"not an Ed25519 key (got {type(key).__name__})")
         return key
+
+    # 3/4) base64 — either a raw 32-byte seed or a full PKCS8 DER.
+    decoded = base64.b64decode(text)
+    if len(decoded) == 32:
+        return ed25519.Ed25519PrivateKey.from_private_bytes(decoded)
+    key = serialization.load_der_private_key(decoded, password=None)
+    if not isinstance(key, ed25519.Ed25519PrivateKey):
+        raise ValueError(f"not an Ed25519 key (got {type(key).__name__})")
+    return key
+
+
+def _load_ed25519_key(keyfile: str) -> ed25519.Ed25519PrivateKey:
+    """Load and validate an Ed25519 private key from a Flair keyfile.
+
+    Accepts every on-disk encoding Flair produces (see ``_parse_ed25519_key``),
+    so the keyfile written by ``flair agent add`` (a raw 32-byte seed) loads
+    without a conversion step. A leading ``~`` in the path is expanded.
+
+    Raises ValueError naming FLAIR_KEYFILE on any failure — the failure lands
+    in the constructor, never deferred to first use (where ADK's
+    exception-swallowing search path would turn it into silent empty recall).
+    """
+    path = Path(keyfile).expanduser()
+    try:
+        raw = path.read_bytes()
     except FileNotFoundError:
         raise ValueError(
-            "FLAIR_KEYFILE points to a file that does not exist"
+            "FLAIR_KEYFILE points to a file that does not exist. Provision one "
+            "with `flair agent add <agent-id>` (writes ~/.flair/keys/<agent-id>.key), "
+            "then set FLAIR_KEYFILE to it."
         ) from None
-    except (base64.binascii.Error, ValueError) as exc:
-        if isinstance(exc, ValueError) and "FLAIR_KEYFILE" in str(exc):
+
+    if not raw.strip():
+        raise ValueError("FLAIR_KEYFILE points to an empty file")
+
+    try:
+        return _parse_ed25519_key(raw)
+    except ValueError as exc:
+        if "FLAIR_KEYFILE" in str(exc):
             raise
         raise ValueError(
-            "FLAIR_KEYFILE does not contain a valid PKCS8 base64-encoded Ed25519 key"
+            "FLAIR_KEYFILE does not contain a valid Ed25519 key (accepted: raw "
+            "32-byte seed, base64 seed, base64 PKCS8 DER, or PEM)"
+        ) from exc
+    except Exception as exc:  # UnicodeDecodeError, binascii.Error, InvalidKey, …
+        raise ValueError(
+            "FLAIR_KEYFILE does not contain a valid Ed25519 key (accepted: raw "
+            "32-byte seed, base64 seed, base64 PKCS8 DER, or PEM)"
         ) from exc
 
 

--- a/packages/adk-flair/tests/conftest.py
+++ b/packages/adk-flair/tests/conftest.py
@@ -25,7 +25,7 @@ from cryptography.hazmat.primitives.asymmetric import ed25519
 
 # ─── Paths ───────────────────────────────────────────────────────────────────
 
-_REPO_ROOT = Path(__file__).resolve().parents[4]  # flair repo root
+_REPO_ROOT = Path(__file__).resolve().parents[3]  # flair repo root (tests → adk-flair → packages → repo)
 _BOOT_HELPER = Path(__file__).resolve().parent / "helpers" / "boot-harper.mjs"
 
 
@@ -284,17 +284,46 @@ def live_flair():
         text=True,
     )
 
-    # Read the JSON config line
+    # Scan stdout for the JSON config line.
+    #
+    # boot-harper.mjs emits the Harper connection config as a single JSON line on
+    # stdout, but harper-lifecycle prints progress lines ("[harper-lifecycle] …")
+    # to stdout BEFORE it. Reading only the first line and json-parsing it fails
+    # on those logs ("Expecting value: line 1 column 2"), so every ephemeral test
+    # skipped even after the repo root was resolved correctly. Scan each line and
+    # take the first that parses as the expected config dict — mirrors the JS
+    # live-flair helper. boot-harper self-bounds (startup/health/warm-up timeouts)
+    # and exits on failure, closing stdout (EOF) so this loop terminates.
+    config = None
     try:
-        stdout_line = proc.stdout.readline()
-        if not stdout_line:
-            stderr_output = proc.stderr.read()
-            pytest.skip(
-                f"FLAIR_TEST_URL not set and ephemeral Harper failed to start: "
-                f"stderr={stderr_output}"
-            )
-        config = json.loads(stdout_line.strip())
-    except (json.JSONDecodeError, Exception) as exc:
+        while True:
+            line = proc.stdout.readline()
+            if not line:  # EOF — boot-harper exited without emitting config
+                break
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                candidate = json.loads(line)
+            except json.JSONDecodeError:
+                continue  # a harper-lifecycle progress log — keep scanning
+            if not isinstance(candidate, dict):
+                continue
+            if candidate.get("httpURL") and candidate.get("opsURL"):
+                config = candidate
+                break
+            if candidate.get("outcome") == "FLOOR-EXCEEDED":
+                # Capability gate (flair#1119): runner can't reach operating
+                # latency. Not a code defect — skip cleanly.
+                try:
+                    proc.kill()
+                    proc.wait(timeout=5)
+                except Exception:
+                    pass
+                pytest.skip(
+                    f"ephemeral Harper floor-exceeded (runner too slow): {candidate}"
+                )
+    except Exception as exc:
         stderr_output = ""
         try:
             proc.kill()
@@ -303,7 +332,20 @@ def live_flair():
         except Exception:
             pass
         pytest.skip(
-            f"FLAIR_TEST_URL not set and ephemeral Harper config parse failed: {exc}. "
+            f"FLAIR_TEST_URL not set and ephemeral Harper config read failed: {exc}. "
+            f"stderr={stderr_output}"
+        )
+
+    if config is None:
+        stderr_output = ""
+        try:
+            proc.kill()
+            proc.wait(timeout=5)
+            stderr_output = proc.stderr.read()
+        except Exception:
+            pass
+        pytest.skip(
+            "FLAIR_TEST_URL not set and ephemeral Harper produced no config line. "
             f"stderr={stderr_output}"
         )
 

--- a/packages/adk-flair/tests/test_memory_service.py
+++ b/packages/adk-flair/tests/test_memory_service.py
@@ -164,6 +164,70 @@ class TestConstructorValidation:
             with pytest.raises(ValueError, match="FLAIR_KEYFILE"):
                 _load_ed25519_key("/nonexistent/path")
 
+    def test_loads_raw_seed_keyfile(self, tmp_path):
+        """`flair agent add` writes a raw 32-byte Ed25519 seed, not PKCS8 base64.
+
+        A cold user points FLAIR_KEYFILE straight at ~/.flair/keys/<id>.key, so
+        the adapter must read that format or the documented quickstart is broken.
+        """
+        from adk_flair.memory_service import _load_ed25519_key
+        from cryptography.hazmat.primitives.asymmetric import ed25519
+        from cryptography.hazmat.primitives import serialization
+
+        key = ed25519.Ed25519PrivateKey.generate()
+        seed = key.private_bytes(
+            encoding=serialization.Encoding.Raw,
+            format=serialization.PrivateFormat.Raw,
+            encryption_algorithm=serialization.NoEncryption(),
+        )
+        assert len(seed) == 32
+        keyfile = tmp_path / "agent.key"
+        keyfile.write_bytes(seed)  # binary, exactly like the CLI
+
+        loaded = _load_ed25519_key(str(keyfile))
+        assert isinstance(loaded, ed25519.Ed25519PrivateKey)
+
+    def test_loads_pkcs8_base64_keyfile(self, tmp_path):
+        """The historical adk-flair format (base64 PKCS8 DER) still loads."""
+        from adk_flair.memory_service import _load_ed25519_key
+        from cryptography.hazmat.primitives.asymmetric import ed25519
+        from cryptography.hazmat.primitives import serialization
+        import base64
+
+        key = ed25519.Ed25519PrivateKey.generate()
+        der = key.private_bytes(
+            encoding=serialization.Encoding.DER,
+            format=serialization.PrivateFormat.PKCS8,
+            encryption_algorithm=serialization.NoEncryption(),
+        )
+        keyfile = tmp_path / "agent.key"
+        keyfile.write_text(base64.b64encode(der).decode("ascii"))
+
+        loaded = _load_ed25519_key(str(keyfile))
+        assert isinstance(loaded, ed25519.Ed25519PrivateKey)
+
+    def test_expands_home_in_keyfile_path(self, tmp_path, monkeypatch):
+        """A leading ~ in FLAIR_KEYFILE is expanded to the home directory."""
+        from adk_flair.memory_service import _load_ed25519_key
+        from cryptography.hazmat.primitives.asymmetric import ed25519
+        from cryptography.hazmat.primitives import serialization
+
+        fake_home = tmp_path / "home"
+        keys_dir = fake_home / ".flair" / "keys"
+        keys_dir.mkdir(parents=True)
+        key = ed25519.Ed25519PrivateKey.generate()
+        seed = key.private_bytes(
+            encoding=serialization.Encoding.Raw,
+            format=serialization.PrivateFormat.Raw,
+            encryption_algorithm=serialization.NoEncryption(),
+        )
+        (keys_dir / "agent.key").write_bytes(seed)
+
+        monkeypatch.setenv("HOME", str(fake_home))  # POSIX expanduser source
+        monkeypatch.setenv("USERPROFILE", str(fake_home))  # Windows parity
+        loaded = _load_ed25519_key("~/.flair/keys/agent.key")
+        assert isinstance(loaded, ed25519.Ed25519PrivateKey)
+
 
 # ─── search_memory ──────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Make the `adk-flair` quickstart real, reliable, and cold-run-safe

The `adk-flair` ADK↔Flair adapter (Python + JS) worked end-to-end when driven
by a test-generated PKCS8 keyfile, but a **cold external developer following the
documented quickstart could not get it running**. This PR closes that gap in
both languages and adds runnable examples that demonstrate cross-session recall
reliably on a freshly-booted Flair.

### Fix A — JS keyfile handling + README

- `loadEd25519Key` now **expands a leading `~`/`~/`** to the home directory
  (Node's `fs` does not), so the README's `~/.flair/keys/...` example no longer
  throws `ENOENT`. A missing keyfile now raises a clear, actionable error that
  names the resolved path instead of a bare `ENOENT`.
- The README jumped straight to `new FlairMemoryService(...)` with `agentId` /
  `keyfile` appearing from nowhere. It now mirrors the Python README:
  install + `flair init` + `flair agent add <id>` + env vars, and the snippet is
  marked illustrative with a pointer to the runnable example.

### Bonus fix (found while verifying A) — keyfile format mismatch

`flair agent add <id>` writes the private key as a **raw 32-byte Ed25519 seed**
(`src/cli.ts`), not PKCS8 base64. The adapters accepted **only** PKCS8 base64,
so pointing `FLAIR_KEYFILE` at the keyfile the CLI actually produces failed with
a cryptic `error:...ASN.1...NOT_ENOUGH_DATA`. Reproduced empirically before
fixing.

Both loaders now accept every encoding Flair itself produces/consumes — raw
32-byte seed, base64 seed, base64 PKCS8 DER, and PEM — mirroring the proven
logic in `src/lib/auth-resolve.ts`. This makes the documented provisioning path
the working path. (Not one of the 3 scoped issues, but the quickstart is broken
without it; flagged here for review.)

### Fix B — conftest silent-skip

- `_REPO_ROOT` was `parents[4]` (resolved one level above the repo root), so the
  ephemeral-boot build gate never found `dist/` and every Python integration test
  skipped with a **misdirecting** "dist/ is missing" reason. Changed to
  `parents[3]` (verified: resolves to the repo root containing `package.json` +
  `packages/adk-flair`).
- Verifying the fix surfaced a **second** blocker in the same path: the conftest
  read only the first stdout line and JSON-parsed it, but `boot-harper.mjs`
  prints `[harper-lifecycle]` progress lines to stdout before its JSON config
  line, so the tests then skipped with `config parse failed: Expecting value`.
  The conftest now scans stdout for the config line (mirrors the JS live-flair
  helper) and handles the `FLOOR-EXCEEDED` capability gate.

Result: the 9 `live_flair` integration tests now **run** via the ephemeral-boot
path (see evidence below).

### Fix C — cold-boot recall flake → complete runnable quickstart

New self-contained, copy-paste-runnable examples for **both** languages:

- `packages/adk-flair-js/examples/quickstart.ts` (native Gemini `gemini-2.5-flash`)
- `packages/adk-flair/examples/quickstart.py` (LiteLLM `gemini/gemini-2.5-flash`)

Each builds a minimal ADK agent, plants a fact in session 1, then **settles** —
polls `searchMemory` until the fact is retrievable (bounded ~10s, clear message
on timeout) — before running session 2 and printing whether the fact was
recalled. The settle removes the cold-boot flake **without changing the
adapter's production 2s search budget**. Each run uses a fresh per-run `user_id`
so re-running against the same Flair stays idempotent (running 3× under one user
otherwise accumulates conflicting facts — caught during verification). Both
READMEs reference the examples as "run this to see it work."

---

## Verification (on rockit, real Gemini, isolated ephemeral Flair)

**Fix A** — JS unit tests: `51 pass, 0 fail` in `memory_service.test.ts`
(`61 pass` across both unit files). New tests cover `~` expansion, the clear
missing-keyfile error, and raw-seed loading. Mutation-checked both:
disabling `expandHome` fails the `~` tests; disabling the raw-seed branch fails
the raw-seed test with the exact `ASN.1 ... NOT_ENOUGH_DATA` a cold user hits.
Python loader tests mutation-checked the same way (raw-seed branch off → fail,
on → pass).

**Fix B** — before/after with **no `FLAIR_TEST_URL`** (ephemeral-boot path):

- `parents[4]` (before): live_flair tests SKIP.
- `parents[3]` + stdout-scan (after): **`42 passed, 0 skipped`** — all 9
  `live_flair` tests run, including `test_cross_session_recall` through a real
  Gemini agent loop (`gemini/gemini-2.5-flash` via LiteLLM).

**Fix C** — both examples run against a COLD isolated ephemeral Flair (OS-assigned
port, HOME-isolated temp dir; prod `:9926` never touched), authenticated with a
**raw-seed keyfile** (the real `flair agent add` format — exercises the keyfile
fix end to end), **3× each, all recalled**:

```
JS:  RECALLED: yes (planted 'zephyr-5e95af8d')   settle: 1 poll
     RECALLED: yes (planted 'zephyr-a130adc0')   settle: 1 poll
     RECALLED: yes (planted 'zephyr-06fff53b')   settle: 1 poll   → 3/3
PY:  RECALLED: yes (planted 'zephyr-078f8c34')   settle: 1 poll
     RECALLED: yes (planted 'zephyr-90dbab5f')   settle: 1 poll
     RECALLED: yes (planted 'zephyr-425d5441')   settle: 1 poll   → 3/3
```

`.changelog/unreleased/` fragments added (category `fixed`) for A and C;
`changelog-fragments.mjs check` passes.

---

## ⚠️ CI coverage gap (reported, not fixed here)

**CI never runs the Python `adk-flair` tests.** `.github/workflows/test.yml`
runs `adk-flair-js` unit + integration tests, but there is no `pytest` step for
the Python package anywhere — `adk-flair-publish.yml` only builds/publishes on a
tag. So this silent-skip bug was invisible to CI, and even with this fix CI still
won't exercise these tests. Wiring it up is **not** a trivial one-line add (needs
Python setup, deps, a built `dist/`, and the same ephemeral-boot the JS
integration lane is itself skipped for on standard runners per #1126), so it is
left as a follow-up rather than done half-way here.

Out of scope (per task): publishing the Python package to PyPI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


No issue: ADK quickstart cold-run fixes from a verification sweep (raw-seed keyfile incompat that broke provisioning, ~ path expansion, cold-boot recall flake, silently-skipping Python tests). Python adk-flair CI-coverage gap tracked as a separate follow-up.
