### PR TITLE
fix(mcp): exclude raw embedding vector from memory_get by default (#1188)

### DIFF
--- a/.changelog/unreleased/fixed-1188-mcp-get-embedding.md
+++ b/.changelog/unreleased/fixed-1188-mcp-get-embedding.md
@@ -1,0 +1,6 @@
+- **`memory_get` no longer inlines the raw embedding vector.** Retrieving a memory
+  by ID over the `/mcp` connector returned the record's full 768-float `embedding`
+  array inline — thousands of noise tokens per record on chat surfaces with a fixed
+  context budget. The vector is now omitted by default; pass `includeEmbedding=true`
+  to include it. The `memory_store` and `memory_update` responses are stripped the
+  same way; `memory_search` and `bootstrap` already excluded it.

--- a/resources/mcp-tools.ts
+++ b/resources/mcp-tools.ts
@@ -162,6 +162,29 @@ async function unwrap(value: any): Promise<any> {
   return value;
 }
 
+/**
+ * flair#1188 — remove the raw `embedding` vector from a record before it is
+ * returned over the MCP surface. A stored memory carries a 768-float
+ * `embedding` (the HNSW vector); inlined into a tool result that is thousands
+ * of noise tokens per record on chat connectors that have a fixed context
+ * budget, and the caller can never do anything useful with it. Returns a
+ * shallow copy WITHOUT `embedding` (never mutates the source record), and
+ * passes through anything that is not a plain record — null, primitives,
+ * arrays, and the `{ error, status }` shapes `unwrap` produces — untouched.
+ *
+ * `memory_search` already projects with an explicit select that omits
+ * `embedding` (resources/semantic-retrieval-core.ts's DEFAULT_SELECT), and
+ * `bootstrap` uses the same select-without-embedding pushdown, so this is only
+ * needed on the FULL-record read/write paths (memory_get, and the write
+ * responses that echo the stored row).
+ */
+function stripEmbedding(value: any): any {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return value;
+  if (!("embedding" in value)) return value;
+  const { embedding, ...rest } = value;
+  return rest;
+}
+
 // ── Tool implementations (thin wrappers over existing handlers) ──────────────
 //
 // Each takes the resolved agent + the parsed tool arguments and returns a plain
@@ -235,7 +258,10 @@ async function memoryStore(agent: ResolvedAgent, args: any) {
     }
     body.visibility = args.visibility;
   }
-  return unwrap(await h.post(body));
+  // flair#1188 — memory_store's response goes through the same buildWriteResponse
+  // echo as memory_update; strip the server-regenerated embedding so no write
+  // tool ever inlines the vector. No-op when the response carries none.
+  return stripEmbedding(await unwrap(await h.post(body)));
 }
 
 /**
@@ -308,7 +334,10 @@ async function memoryUpdate(agent: ResolvedAgent, args: any) {
     if (agent.clientId) record.claimedClient = agent.clientId;
     // A create needs a COLLECTION-bound instance (see resources/in-process.ts).
     const coll: any = await collectionResource(Cls, delegationContext(agent));
-    return unwrap(await coll.post(record));
+    // flair#1188 — the write response echoes the stored row (Memory.post
+    // regenerates the embedding server-side), so strip the vector before it
+    // returns over the MCP surface. No-op when the response carries none.
+    return stripEmbedding(await unwrap(await coll.post(record)));
   }
 
   const merged: Record<string, unknown> = { ...existing, content, updatedAt: new Date().toISOString() };
@@ -325,7 +354,9 @@ async function memoryUpdate(agent: ResolvedAgent, args: any) {
   // the same unloaded-instance defect on the write. The static form loads the
   // row by `merged.id` and threads the context, then dispatches through
   // Memory.put()'s own ownership gate — no scope change, same as the read.
-  return unwrap(await Cls.put(merged, delegationContext(agent)));
+  // flair#1188 — strip the embedding from the echoed write response (Memory.put
+  // regenerates the vector server-side); no-op when the response carries none.
+  return stripEmbedding(await unwrap(await Cls.put(merged, delegationContext(agent))));
 }
 
 async function memoryGet(agent: ResolvedAgent, args: any) {
@@ -348,7 +379,13 @@ async function memoryGet(agent: ResolvedAgent, args: any) {
   // a plain `{ id, includeTrust }` property — Memory.get()'s wantsTrust() reads
   // it there (the in-process shape alongside the HTTP query-param shape).
   const target = args?.includeTrust === true ? { id: args?.id, includeTrust: true } : args?.id;
-  return unwrap(await Cls.get(target, delegationContext(agent)));
+  const result = await unwrap(await Cls.get(target, delegationContext(agent)));
+  // flair#1188 — a by-id get loads the FULL record, including the 768-float
+  // `embedding` vector (search/bootstrap project it out; a raw get does not).
+  // Strip it by default so a chat connector isn't flooded with thousands of
+  // useless tokens per record; return it only when the caller explicitly opts
+  // in via includeEmbedding.
+  return args?.includeEmbedding === true ? result : stripEmbedding(result);
 }
 
 async function memoryDelete(agent: ResolvedAgent, args: any) {
@@ -597,13 +634,15 @@ export const TOOLS: Record<string, ToolEntry> = {
   memory_get: {
     def: {
       name: "memory_get",
-      description: "Retrieve a specific memory by ID.",
+      description:
+        "Retrieve a specific memory by ID. The record's raw embedding vector is omitted by default (it is large and not useful to a caller); pass includeEmbedding=true to include it.",
       annotations: { readOnlyHint: true },
       inputSchema: {
         type: "object",
         properties: {
           id: { type: "string", description: "Memory ID" },
           includeTrust: { type: "boolean", description: "Attach a trust-evidence block (provenance, author, usage, freshness, supersession) to the record. Default false." },
+          includeEmbedding: { type: "boolean", description: "Include the raw embedding vector (hundreds of floats) in the returned record. Omitted by default because it is large and rarely useful to a caller. Default false." },
         },
         required: ["id"],
       },

--- a/test/unit/mcp-handler.test.ts
+++ b/test/unit/mcp-handler.test.ts
@@ -95,7 +95,11 @@ class MemoryMock extends HarperShapedBase {
     const id = typeof target === "string" ? target : target?.id;
     lastCall = { resource: "Memory.get", ctx, args: id };
     if (id === "missing-id") return null;
-    const rec: any = { id, agentId: ctx?.request?.tpsAgent, content: "existing content", ok: true, resource: "Memory.get" };
+    // flair#1188 — a real by-id load returns the FULL stored row, INCLUDING the
+    // raw `embedding` vector. Modeled here so memory_get's default-strip (and
+    // its includeEmbedding opt-in) is exercised against a record that actually
+    // carries the vector, not a double that quietly lacks it.
+    const rec: any = { id, agentId: ctx?.request?.tpsAgent, content: "existing content", ok: true, resource: "Memory.get", embedding: [0.11, 0.22, 0.33] };
     // includeTrust is folded into the RequestTarget as a plain property by the
     // fixed memory_get (static Cls.get has no opts slot); Memory.get()'s
     // wantsTrust() reads it there and attachTrust() stamps a `trust` block.
@@ -573,6 +577,23 @@ describe("tools/call — scopes to the resolved agent (no forging)", () => {
     // Scoped to the caller — identity comes from the resolved agent, never args.
     expect(body.result.structuredContent.agentId).toBe("agt_bob");
     expect(body.result.structuredContent.content).toBe("existing content");
+    // flair#1188 — the raw embedding vector is stripped from the default
+    // response (it is thousands of noise tokens on a chat surface).
+    expect(body.result.structuredContent).not.toHaveProperty("embedding");
+  });
+
+  it("memory_get omits the embedding by default but returns it when includeEmbedding=true (flair#1188)", async () => {
+    // Default: stripped (asserted in the test above). Opt-in: present.
+    const res = await mcpHandler(post(
+      { jsonrpc: "2.0", id: 1, method: "tools/call", params: { name: "memory_get", arguments: { id: "mem-own-1", includeEmbedding: true } } },
+      { sub: "sub-bob" },
+    ));
+    const body = await parse(res);
+    expect(body.result.isError).toBeFalsy();
+    expect(body.result.structuredContent.id).toBe("mem-own-1");
+    // The vector is included only because the caller explicitly asked for it.
+    expect(Array.isArray(body.result.structuredContent.embedding)).toBe(true);
+    expect(body.result.structuredContent.embedding).toEqual([0.11, 0.22, 0.33]);
   });
 
   it("memory_get with includeTrust folds the flag into the RequestTarget so the trust block survives (flair#1181/#744)", async () => {


### PR DESCRIPTION
Closes #1188

## The bug

As of 0.44.4, the memory_get MCP tool (over the /mcp connector) returned the record's raw 768-float embedding array inline — thousands of noise tokens per record on chat surfaces with a fixed context budget. It only newly surfaced because memory_get returned 404 before 0.44.4 (fixed by #1181), so the inlined vector was never seen. search already excluded embeddings.

## The fix

- **memory_get**: strip the embedding by default. Added an opt-in boolean parameter includeEmbedding (default false) to the input schema and description — when true, the vector is included.
- **memory_store / memory_update**: strip the embedding from the echoed write response too. Both responses flow through the same buildWriteResponse path, where the server regenerates the vector server-side, so the write response could echo it. A small stripEmbedding helper is applied at the tool boundary; it is a no-op when the response carries no vector.

## Read-surface audit

| Read path | Inlined a vector? | Change |
| --- | --- | --- |
| memory_get | Yes — a by-id get loads the full row (no select projection) | Strip by default; includeEmbedding opt-in |
| memory_update (return) | Possible — echoed write response | Stripped defensively |
| memory_store (return) | Possible — same echoed write response path | Stripped defensively |
| soul_get | No — the Soul schema has no embedding field | Unchanged |
| bootstrap | No — every memory query uses an explicit select that omits embedding | Unchanged |
| memory_search | No — DEFAULT_SELECT already omits embedding | Unchanged (confirmed) |
| attention | No — explicit select omits embedding | Unchanged |

Only memory_get provably loaded the full row and inlined the vector; the write paths were stripped defensively because they share the echo shape.

## Tests

- Unit (test/unit/mcp-handler.test.ts): the Memory double's by-id load now carries an embedding (modeling the real full-row read). New assertions prove memory_get omits it by default and returns it under includeEmbedding=true.
- Mutation-checked: reverting the strip makes the default-strip assertion fail (the vector leaks); restoring it returns the suite to green.
- Changelog fragment added under .changelog/unreleased/ (docs-freshness gate: 7/7 pass).

## Verification

- Unit lane baseline on origin/main: 4366 pass, 0 fail (230 files).
- Same lane after this change: 4367 pass, 0 fail (+1 new test), no regressions.
- Strict typecheck: only the pre-existing unrelated resources/auth-middleware.ts error remains; no new type errors.
