### PR TITLE
release: v0.44.5

### DIFF
--- a/.changelog/unreleased/fixed-1188-mcp-get-embedding.md
+++ b/.changelog/unreleased/fixed-1188-mcp-get-embedding.md
@@ -1,6 +1,0 @@
-- **`memory_get` no longer inlines the raw embedding vector.** Retrieving a memory
-  by ID over the `/mcp` connector returned the record's full 768-float `embedding`
-  array inline — thousands of noise tokens per record on chat surfaces with a fixed
-  context budget. The vector is now omitted by default; pass `includeEmbedding=true`
-  to include it. The `memory_store` and `memory_update` responses are stripped the
-  same way; `memory_search` and `bootstrap` already excluded it.

--- a/.changelog/unreleased/fixed-1189-reset-successor-retrieval-stats.md
+++ b/.changelog/unreleased/fixed-1189-reset-successor-retrieval-stats.md
@@ -1,8 +1,0 @@
-- **`memory_update` with `preserveHistory: true` no longer copies the superseded
-  record's retrieval stats onto its successor.** The new supersedes-linked record
-  now starts with `retrievalCount` at 0 and no `lastRetrieved`, instead of
-  inheriting them from the record it replaces — which previously produced a
-  successor whose `lastRetrieved` predated its own `createdAt` ("retrieved before
-  it existed") and silently skewed recency- and usage-based ranking.
-  `retrievalCount` and `lastRetrieved` are record-scoped and reset on succession;
-  usage- and citation-ledger counters are unaffected.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,26 @@ node scripts/changelog-fragments.mjs check    # what CI checks
 version cut. **Do not add entries to this section by hand** — the release step replaces its body,
 so a hand-written entry here is lost.
 
+## [0.44.5] - 2026-08-14
+
+### Fixed
+
+- **`memory_get` no longer inlines the raw embedding vector.** Retrieving a memory
+  by ID over the `/mcp` connector returned the record's full 768-float `embedding`
+  array inline — thousands of noise tokens per record on chat surfaces with a fixed
+  context budget. The vector is now omitted by default; pass `includeEmbedding=true`
+  to include it. The `memory_store` and `memory_update` responses are stripped the
+  same way; `memory_search` and `bootstrap` already excluded it.
+
+- **`memory_update` with `preserveHistory: true` no longer copies the superseded
+  record's retrieval stats onto its successor.** The new supersedes-linked record
+  now starts with `retrievalCount` at 0 and no `lastRetrieved`, instead of
+  inheriting them from the record it replaces — which previously produced a
+  successor whose `lastRetrieved` predated its own `createdAt` ("retrieved before
+  it existed") and silently skewed recency- and usage-based ranking.
+  `retrievalCount` and `lastRetrieved` are record-scoped and reset on succession;
+  usage- and citation-ledger counters are unaffected.
+
 ## [0.44.4] - 2026-08-14
 
 ### Added

--- a/bun.lock
+++ b/bun.lock
@@ -25,7 +25,7 @@
     },
     "packages/adk-flair-js": {
       "name": "@tpsdev-ai/adk-flair",
-      "version": "0.44.4",
+      "version": "0.44.5",
       "dependencies": {
         "@google/adk": "^1.6.0",
         "@google/genai": "^1.52.0",
@@ -33,7 +33,7 @@
     },
     "packages/flair-bench": {
       "name": "@tpsdev-ai/flair-bench",
-      "version": "0.44.4",
+      "version": "0.44.5",
       "bin": {
         "flair-bench": "dist/cli-shim.cjs",
       },
@@ -56,21 +56,21 @@
     },
     "packages/flair-client": {
       "name": "@tpsdev-ai/flair-client",
-      "version": "0.44.4",
+      "version": "0.44.5",
       "devDependencies": {
         "typescript": "5.9.3",
       },
     },
     "packages/flair-mcp": {
       "name": "@tpsdev-ai/flair-mcp",
-      "version": "0.44.4",
+      "version": "0.44.5",
       "bin": {
         "flair-mcp": "dist/mcp-shim.cjs",
         "flair-session-start": "dist/session-start-hook.js",
       },
       "dependencies": {
         "@modelcontextprotocol/sdk": "1.27.1",
-        "@tpsdev-ai/flair-client": "0.44.4",
+        "@tpsdev-ai/flair-client": "0.44.5",
         "zod": "4.3.6",
       },
       "devDependencies": {
@@ -79,9 +79,9 @@
     },
     "packages/langgraph-flair": {
       "name": "@tpsdev-ai/langgraph-flair",
-      "version": "0.44.4",
+      "version": "0.44.5",
       "dependencies": {
-        "@tpsdev-ai/flair-client": "0.44.4",
+        "@tpsdev-ai/flair-client": "0.44.5",
       },
       "peerDependencies": {
         "@langchain/langgraph-checkpoint": ">=0.0.10",
@@ -89,9 +89,9 @@
     },
     "packages/n8n-nodes-flair": {
       "name": "@tpsdev-ai/n8n-nodes-flair",
-      "version": "0.44.4",
+      "version": "0.44.5",
       "dependencies": {
-        "@tpsdev-ai/flair-client": "0.44.4",
+        "@tpsdev-ai/flair-client": "0.44.5",
         "zod": "3.25.76",
       },
       "devDependencies": {
@@ -108,10 +108,10 @@
     },
     "packages/openclaw-flair": {
       "name": "@tpsdev-ai/openclaw-flair",
-      "version": "0.44.4",
+      "version": "0.44.5",
       "dependencies": {
         "@sinclair/typebox": "0.34.48",
-        "@tpsdev-ai/flair-client": "0.44.4",
+        "@tpsdev-ai/flair-client": "0.44.5",
       },
       "devDependencies": {
         "typescript": "5.9.3",
@@ -122,10 +122,10 @@
     },
     "packages/pi-flair": {
       "name": "@tpsdev-ai/pi-flair",
-      "version": "0.44.4",
+      "version": "0.44.5",
       "dependencies": {
         "@sinclair/typebox": "0.34.48",
-        "@tpsdev-ai/flair-client": "0.44.4",
+        "@tpsdev-ai/flair-client": "0.44.5",
       },
       "devDependencies": {
         "@mariozechner/pi-coding-agent": "0.73.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tpsdev-ai/flair",
-  "version": "0.44.4",
+  "version": "0.44.5",
   "packageManager": "bun@1.3.10",
   "description": "Identity, memory, and soul for AI agents. Cryptographic identity (Ed25519), semantic memory with local embeddings, and persistent personality — all in a single process.",
   "type": "module",

--- a/packages/adk-flair-js/package.json
+++ b/packages/adk-flair-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tpsdev-ai/adk-flair",
-  "version": "0.44.4",
+  "version": "0.44.5",
   "description": "Flair memory backend for Google ADK — self-hosted, federated, portable agent memory",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/adk-flair/pyproject.toml
+++ b/packages/adk-flair/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "adk-flair"
-version = "0.44.4"
+version = "0.44.5"
 description = "Flair memory backend for Google ADK — self-hosted, federated, portable agent memory"
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/packages/flair-bench/package.json
+++ b/packages/flair-bench/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tpsdev-ai/flair-bench",
-  "version": "0.44.4",
+  "version": "0.44.5",
   "description": "Standalone embedding recall benchmark for flair — run real recall numbers (p@3/MRR) against any GGUF embedding model, batch-compare, get a host-aware recommendation, and share redacted results. No flair install required.",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/flair-bench/src/version.ts
+++ b/packages/flair-bench/src/version.ts
@@ -5,4 +5,4 @@
  * attribute edge cases in a published dist/ build. test/version-sync.test.ts
  * asserts this stays equal to package.json's "version" field.
  */
-export const TOOL_VERSION = "0.44.4";
+export const TOOL_VERSION = "0.44.5";

--- a/packages/flair-client/package.json
+++ b/packages/flair-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tpsdev-ai/flair-client",
-  "version": "0.44.4",
+  "version": "0.44.5",
   "description": "Lightweight client for Flair — identity, memory, and soul for AI agents. Zero heavy dependencies.",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/flair-mcp/package.json
+++ b/packages/flair-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tpsdev-ai/flair-mcp",
-  "version": "0.44.4",
+  "version": "0.44.5",
   "description": "MCP server for Flair — persistent memory for Claude Code, Cursor, and any MCP client.",
   "type": "module",
   "main": "dist/index.js",
@@ -27,7 +27,7 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "1.27.1",
-    "@tpsdev-ai/flair-client": "0.44.4",
+    "@tpsdev-ai/flair-client": "0.44.5",
     "zod": "4.3.6"
   },
   "license": "Apache-2.0",

--- a/packages/langgraph-flair/package.json
+++ b/packages/langgraph-flair/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tpsdev-ai/langgraph-flair",
-  "version": "0.44.4",
+  "version": "0.44.5",
   "description": "LangGraph BaseStore adapter backed by Flair — durable agent memory with crypto-pinned identity, federation, and cross-orchestrator portability.",
   "type": "module",
   "main": "dist/index.js",
@@ -36,7 +36,7 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
-    "@tpsdev-ai/flair-client": "0.44.4"
+    "@tpsdev-ai/flair-client": "0.44.5"
   },
   "peerDependencies": {
     "@langchain/langgraph-checkpoint": ">=0.0.10"

--- a/packages/n8n-nodes-flair/package.json
+++ b/packages/n8n-nodes-flair/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tpsdev-ai/n8n-nodes-flair",
-  "version": "0.44.4",
+  "version": "0.44.5",
   "description": "n8n community node — use Flair as your AI Agent's memory backend. Includes FlairChatMemory (Memory port) and FlairSearch (Tool port).",
   "type": "commonjs",
   "main": "dist/index.js",
@@ -48,7 +48,7 @@
     "langchain"
   ],
   "dependencies": {
-    "@tpsdev-ai/flair-client": "0.44.4",
+    "@tpsdev-ai/flair-client": "0.44.5",
     "zod": "3.25.76"
   },
   "peerDependencies": {

--- a/packages/openclaw-flair/package.json
+++ b/packages/openclaw-flair/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tpsdev-ai/openclaw-flair",
-  "version": "0.44.4",
+  "version": "0.44.5",
   "description": "OpenClaw memory plugin for Flair — agent identity and semantic memory",
   "type": "module",
   "main": "./dist/index.js",
@@ -58,7 +58,7 @@
   },
   "dependencies": {
     "@sinclair/typebox": "0.34.48",
-    "@tpsdev-ai/flair-client": "0.44.4"
+    "@tpsdev-ai/flair-client": "0.44.5"
   },
   "devDependencies": {
     "typescript": "5.9.3"

--- a/packages/pi-flair/package.json
+++ b/packages/pi-flair/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tpsdev-ai/pi-flair",
-  "version": "0.44.4",
+  "version": "0.44.5",
   "description": "Flair memory extension for pi — persistent memory access from within pi sessions",
   "type": "module",
   "main": "dist/index.js",
@@ -21,7 +21,7 @@
     "node": ">=18"
   },
   "dependencies": {
-    "@tpsdev-ai/flair-client": "0.44.4",
+    "@tpsdev-ai/flair-client": "0.44.5",
     "@sinclair/typebox": "0.34.48"
   },
   "license": "Apache-2.0",


### PR DESCRIPTION
Version bump across workspace packages to v0.44.5.

See CHANGELOG.md for what's in this release.

After CI is green and this is merged:
```
git checkout main && git pull
./scripts/release.sh 0.44.5 --publish
```


No issue: release PR — version bump + changelog promotion only (constituent fixes #1190/#1191 already merged).
