### PR TITLE
fix(mcp): await unwrap in bootstrap so the full payload survives (#1182)

### DIFF
--- a/.changelog/unreleased/fixed-1182-bootstrap-payload.md
+++ b/.changelog/unreleased/fixed-1182-bootstrap-payload.md
@@ -1,0 +1,6 @@
+- **The `/mcp` `bootstrap` tool now returns its full payload, not just the
+  server version.** The wrapper spread an un-awaited Promise into its response,
+  so every computed field — the resolved agentId, the scope descriptor, the
+  soul map, the memories and predicted containers, and the opt-in abstention
+  verdict — was dropped and a connector caller saw only `{ flairVersion }`.
+  Awaiting the response restores the complete payload.

--- a/resources/mcp-tools.ts
+++ b/resources/mcp-tools.ts
@@ -423,7 +423,15 @@ async function bootstrap(agent: ResolvedAgent, args: any) {
   // flair#831 — attach the running Flair version to the RESPONSE (not the
   // delegated request body) so the calling agent learns the server version
   // on its very first call.
-  const result = unwrap(await h.post(body));
+  //
+  // flair#1182 — `unwrap` is async: it must be AWAITED before the result is
+  // spread, exactly as every sibling tool does (`await unwrap(...)` in
+  // memory_store / memory_update / memory_get). Without the await, `result` is
+  // the still-pending PROMISE, and `{ ...aPromise }` copies no own-enumerable
+  // keys — so the entire computed payload (resolved agentId, scope, soul,
+  // memories, predicted, the #1182.1 containers, the abstention verdict) was
+  // silently discarded and the caller saw ONLY the injected `flairVersion`.
+  const result = await unwrap(await h.post(body));
   if (result && typeof result === "object" && !Array.isArray(result)) {
     return { ...result, flairVersion: resolveVersion() };
   }

--- a/test/fixtures/inproc-app/resources/AgentFleet.js
+++ b/test/fixtures/inproc-app/resources/AgentFleet.js
@@ -211,6 +211,26 @@ async function updateById(agentId, id, content) {
   return { updated: after && after.content === content, content: after?.content ?? null };
 }
 
+// ─── flair#1182 (part 2) — the /mcp `bootstrap` wrapper drops the payload ──────
+//
+// resources/mcp-tools.ts's `bootstrap` tool wrapper builds its response as
+// `{ ...unwrap(await h.post(body)), flairVersion }`. `unwrap` is an ASYNC
+// function, so the sibling write/read tools spell it `await unwrap(...)`;
+// `bootstrap` omitted the await, so `result` was the unresolved PROMISE. Object-
+// spreading a Promise copies no own-enumerable keys (`{...aPromise}` === `{}`),
+// so the entire rich payload BootstrapMemories.post computed — agentId, scope,
+// soul, memories, predicted, the #1182.1 containers, the abstention verdict —
+// was discarded and only the injected `flairVersion` survived. This op drives
+// the REAL `resources/mcp-tools.ts` bootstrap wrapper (not a mirror) against the
+// real BootstrapMemories resource + real store, so the fix — and its mutation
+// proof — land on the shipped line. Imported dynamically (a relative path that
+// bypasses the package `exports` gate) so nothing else that loads this fixture
+// pays for the import.
+async function bootstrapViaMcp(agentId, args) {
+  const { TOOLS } = await import("../node_modules/@tpsdev-ai/flair/dist/resources/mcp-tools.js");
+  return TOOLS.bootstrap.impl({ agentId, isAdmin: false }, args ?? {});
+}
+
 /**
  * The DELIBERATELY unfiltered read — every agent's private records, by name.
  * `internalContext()` is what an infrastructure sweep asks for on purpose; an
@@ -307,6 +327,8 @@ export class AgentFleet extends Resource {
         return run(() => semanticRecallUnscoped(body.q, body.limit));
       case "recallUnscoped":
         return run(() => recallUnscoped());
+      case "bootstrapViaMcp":
+        return run(() => bootstrapViaMcp(body.agentId, body.args));
       case "buildContextWith":
         return run(() => buildContextWith(body.agentId));
       case "createWithNoContext":

--- a/test/integration/mcp-bootstrap-payload-1182.test.ts
+++ b/test/integration/mcp-bootstrap-payload-1182.test.ts
@@ -1,0 +1,157 @@
+// ─── flair#1182 (part 2) — the /mcp `bootstrap` wrapper must return the FULL ───
+// payload, proven live against a real BootstrapMemories + real store.
+//
+// The bug: resources/mcp-tools.ts's `bootstrap` tool built its response as
+// `{ ...unwrap(await h.post(body)), flairVersion }`. `unwrap` is an ASYNC
+// function — every sibling tool spells it `await unwrap(...)` — but `bootstrap`
+// dropped the `await`, so `result` was the unresolved PROMISE. Object-spreading
+// a Promise copies NO own-enumerable keys (`{...aPromise}` === `{}`), so the
+// entire rich payload BootstrapMemories.post computes — the resolved agentId,
+// the scope descriptor, the soul map, the memories/predicted containers, and
+// (the decisive tell) the opt-in abstention verdict — was silently discarded,
+// and a caller over the /mcp connector saw ONLY the injected `flairVersion`.
+//
+// Why an integration test (and why through the fixture): the payload path lives
+// in the REAL BootstrapMemories.post reading a REAL Soul + Memory out of the
+// store, and the drop lives in the REAL resources/mcp-tools.ts wrapper. The
+// inproc-app fixture's `bootstrapViaMcp` op imports the shipped `TOOLS.bootstrap`
+// and invokes its `.impl` in-process against a live Harper, so the assertions —
+// and the mutation proof (revert the `await` ⇒ these fail) — land on the shipped
+// line, not on a mirror of it.
+import { describe, expect, test, beforeAll, afterAll } from "bun:test";
+import { mkdtemp, rm, mkdir, cp, symlink } from "node:fs/promises";
+import { randomUUID } from "node:crypto";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { startHarper, stopHarper, HarperInstance } from "../helpers/harper-lifecycle";
+
+const REPO_ROOT = process.cwd();
+const FIXTURE = join(REPO_ROOT, "test", "fixtures", "inproc-app");
+
+let harper: HarperInstance;
+let appDir: string;
+
+const sfx = Date.now().toString(36);
+const AGENT = `boot1182-${sfx}`;
+const SOUL_ROLE = `Bootstrap payload test subject ${sfx}`;
+const PERM_MARKER = `boot1182 permanent marker: never delete the backup before an explicit go ${randomUUID()}`;
+
+/** Drive one in-process operation inside the fixture app. */
+async function fleet(op: string, body: Record<string, unknown> = {}): Promise<any> {
+  const res = await fetch(`${harper.httpURL}/AgentFleet/`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: "Basic " + btoa(`${harper.admin.username}:${harper.admin.password}`),
+    },
+    body: JSON.stringify({ op, ...body }),
+  });
+  const text = await res.text();
+  if (!res.ok) throw new Error(`AgentFleet ${op} → HTTP ${res.status}: ${text.slice(0, 400)}`);
+  return JSON.parse(text);
+}
+
+/** Insert a Soul record straight into storage (bootstrap reads it back by agentId). */
+async function seedSoul(agentId: string, key: string, value: string): Promise<void> {
+  const res = await fetch(harper.opsURL, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: "Basic " + btoa(`${harper.admin.username}:${harper.admin.password}`),
+    },
+    body: JSON.stringify({
+      operation: "insert",
+      database: "flair",
+      table: "Soul",
+      records: [{ id: `${agentId}:${key}`, agentId, key, value, createdAt: new Date().toISOString() }],
+    }),
+  });
+  expect(res.status, `Soul insert ${agentId}:${key} → ${res.status}`).toBe(200);
+}
+
+beforeAll(async () => {
+  appDir = await mkdtemp(join(tmpdir(), "flair-inproc-boot1182-"));
+  await cp(FIXTURE, appDir, { recursive: true });
+  await mkdir(join(appDir, "node_modules", "@tpsdev-ai"), { recursive: true });
+  await symlink(REPO_ROOT, join(appDir, "node_modules", "@tpsdev-ai", "flair"), "dir");
+  harper = await startHarper({ cwd: appDir, harperBinDir: REPO_ROOT });
+
+  // Seed the caller: an Agent principal, a Soul entry, and one permanent memory.
+  await fleet("register", { id: AGENT });
+  await seedSoul(AGENT, "role", SOUL_ROLE);
+  const written = await fleet("remember", { agentId: AGENT, content: PERM_MARKER, durability: "permanent", visibility: "private" });
+  expect(written.ok, `seeding the memory failed: ${JSON.stringify(written)}`).toBe(true);
+}, 300_000);
+
+afterAll(async () => {
+  const dataDir = harper?.installDir;
+  if (harper) await stopHarper(harper);
+  if (dataDir) await rm(dataDir, { recursive: true, force: true, maxRetries: 4 });
+  if (appDir) await rm(appDir, { recursive: true, force: true });
+});
+
+describe("flair#1182 part 2 — /mcp bootstrap returns the full payload, not just flairVersion", () => {
+  test("the real mcp-tools bootstrap wrapper returns agentId + scope + soul + the seeded memory (not a bare {flairVersion})", async () => {
+    const res = await fleet("bootstrapViaMcp", {
+      agentId: AGENT,
+      args: { currentTask: "verifying the bootstrap payload", maxTokens: 8000, includeTrust: true },
+    });
+    expect(res.ok, `bootstrapViaMcp failed: ${JSON.stringify(res).slice(0, 400)}`).toBe(true);
+    const body = res.value;
+
+    // ── THE BUG, stated directly: the wrapper used to return ONLY this key. ──
+    // If the await is dropped, `body` is exactly { flairVersion } and every
+    // assertion below fails. This one names the regression outright.
+    expect(
+      Object.keys(body ?? {}).sort(),
+      `bootstrap must return the rich payload, got keys: ${JSON.stringify(Object.keys(body ?? {}))}`,
+    ).not.toEqual(["flairVersion"]);
+
+    // ── resolved identity + scope descriptor (the #1182.1 self-describing keys) ──
+    expect(body.agentId, "resolved agentId must be the caller's").toBe(AGENT);
+    expect(body.scope?.agentId, "scope.agentId must be the caller's").toBe(AGENT);
+    expect(body.scope?.isAdmin, "a non-admin caller resolves as non-admin").toBe(false);
+    expect(typeof body.scope?.reads, "scope must describe the read model").toBe("string");
+
+    // ── the soul map carries the seeded identity as structured data ──
+    expect(body.soul, "soul container must be present").toBeDefined();
+    expect(body.soul.role, "soul must carry the seeded role").toBe(SOUL_ROLE);
+
+    // ── the memories container carries the caller's OWN seeded memory ──
+    expect(Array.isArray(body.memories), "memories must be an array").toBe(true);
+    const contents = body.memories.map((m: any) => m.content);
+    expect(contents, "the seeded permanent memory must be in the payload").toContain(PERM_MARKER);
+    for (const m of body.memories) {
+      expect(m.agentId, "every returned memory is the caller's OWN").toBe(AGENT);
+    }
+
+    // ── the always-present containers + the version the wrapper injects ──
+    expect(Array.isArray(body.predicted), "predicted container present").toBe(true);
+    expect(Object.prototype.hasOwnProperty.call(body, "context"), "context still present").toBe(true);
+    expect(typeof body.flairVersion, "flairVersion still injected by the wrapper").toBe("string");
+  }, 120_000);
+
+  test("abstain:true — the abstention verdict {abstained, bestScore, threshold} survives to the caller", async () => {
+    const res = await fleet("bootstrapViaMcp", {
+      agentId: AGENT,
+      args: { currentTask: "verifying the abstention verdict", maxTokens: 8000, abstain: true },
+    });
+    expect(res.ok, `bootstrapViaMcp(abstain) failed: ${JSON.stringify(res).slice(0, 400)}`).toBe(true);
+    const body = res.value;
+
+    // The decisive tell: abstain returns a COMPUTED verdict that never touches
+    // read-scope, so its presence proves the whole computed payload survived —
+    // it could not have been "gated away" by scoping.
+    expect(body.abstention, "abstain:true must return an abstention verdict").toBeDefined();
+    expect(
+      Object.prototype.hasOwnProperty.call(body.abstention, "abstained"),
+      "abstention verdict must carry `abstained`",
+    ).toBe(true);
+    expect(typeof body.abstention.abstained, "`abstained` is a boolean").toBe("boolean");
+    expect(
+      Object.prototype.hasOwnProperty.call(body.abstention, "bestScore"),
+      "abstention verdict must carry `bestScore` (may be null)",
+    ).toBe(true);
+    expect(typeof body.abstention.threshold, "abstention verdict must carry a numeric `threshold`").toBe("number");
+  }, 120_000);
+});


### PR DESCRIPTION
## Summary

The `/mcp` `bootstrap` tool returned a bare `{ "flairVersion": "..." }` instead of the rich payload (resolved agentId, scope descriptor, soul, memories, predicted, the self-describing container keys, and the opt-in abstention verdict). Calling `bootstrap` over the connector with every optional param populated still yielded only the version string.

Refs #1182

## Derived mechanism (not a guess)

`resources/mcp-tools.ts`'s `bootstrap` wrapper built its response as:

    const result = unwrap(await h.post(body));
    if (result && typeof result === "object" && !Array.isArray(result)) {
      return { ...result, flairVersion: resolveVersion() };
    }

`unwrap` is an **async** function. Every sibling tool spells it `await unwrap(...)` (memory_store, memory_update, memory_get); `bootstrap` dropped the `await`. So `result` was the still-pending **Promise**, and object-spreading a Promise copies no own-enumerable keys — `{ ...aPromise }` is `{}` — so the entire computed payload was discarded and only the injected `flairVersion` survived.

This is **not** a collection-binding or resource-routing problem. The `BootstrapMemories.post` override runs correctly on the instance the wrapper builds and returns the full payload — the existing Ed25519-HTTP integration test proves that payload, and the `abstain` verdict (a computed value that never touches read-scope) surviving in the fix proves the payload was dropped in the wrapper, not gated by scoping. The fix is to `await unwrap(...)`, matching the sibling tools.

Note: the related create paths (`memory_store`, `memory_update`) were migrated to `collectionResource(...)` in #944 because their `post()` is a table-backed create that needs a collection-bound instance. `bootstrap` targets a computed `Resource` whose `post()` is a plain override, so its instance invocation is fine — the only defect here was the missing `await`.

## Changes

- `resources/mcp-tools.ts` — await the async `unwrap` before spreading the bootstrap response, with a comment pinning why.
- `.changelog/unreleased/fixed-1182-bootstrap-payload.md` — changelog fragment.
- `test/integration/mcp-bootstrap-payload-1182.test.ts` — drives the real `TOOLS.bootstrap` wrapper against a live, HOME-isolated Harper seeded with a soul + a memory, and asserts the response carries the resolved agentId, the scope descriptor, the soul, and the seeded memory (not a bare `{ flairVersion }`). A second case asserts the `abstain:true` verdict `{ abstained, bestScore, threshold }` survives to the caller.
- `test/fixtures/inproc-app/resources/AgentFleet.js` — adds a `bootstrapViaMcp` op that invokes the shipped `TOOLS.bootstrap.impl` in-process, so the test and its mutation proof land on the real wrapper line rather than a mirror.
