### PR TITLE
fix(doctor): classify node-scoped keys; never wire a node id as connector identity (#1193)

### DIFF
--- a/.changelog/unreleased/fixed-1193-classify-node-keys.md
+++ b/.changelog/unreleased/fixed-1193-classify-node-keys.md
@@ -1,0 +1,17 @@
+- **`flair doctor` no longer mistakes node-scoped federation keys for agent
+  signing keys.** `~/.flair/keys/` holds two kinds of file — agent Ed25519
+  signing keys (a `<name>.key` seed with a sibling `<name>.pub`) and
+  node-scoped federation keys (`flair_<hex8>.key`, an AES-GCM keystore blob
+  with no `.pub`). Doctor used to Ed25519-parse the node blob and warn that an
+  agent's signing key "could not be parsed … (DECODER routines::unsupported)",
+  which reads as agent-auth breakage when agent auth is fine. Node keys are now
+  classified structurally and skipped, with an informative note instead of the
+  false alarm.
+
+  This also closes a way `flair doctor --fix` could wire a broken connector: on
+  a host whose only key was a federation node key, `--fix` could infer that node
+  id as the sole agent and write `FLAIR_AGENT_ID=flair_<hex8>` into a client
+  config, so the connector authenticated as a phantom, unregistered node whose
+  key cannot sign — failing every read and write. `--fix` now refuses to wire a
+  node id from any source and points at `flair init --agent <name>` or
+  `flair agent add <name>` instead.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -89,8 +89,10 @@ import {
   applyOrReportSessionStartHook,
   resolveWireFlairUrl,
   planAgentIterations,
-  inferSoleAgentId,
   fixCommandAgentHint,
+  isNodeKeyId,
+  partitionKeyIds,
+  resolveFixAgentId,
   describeAgentGateFinding,
   embeddingsSkipRemedy,
   classifyKeyFile,
@@ -1806,7 +1808,11 @@ export async function verifySemanticSearch(
   if (!agentId) {
     try {
       const keyFiles = readdirSync(keysDir).filter((f) => f.endsWith(".key"));
-      if (keyFiles.length > 0) agentId = keyFiles[0].replace(/\.key$/, "");
+      // Skip node-scoped federation keys (flair#1193): they can't sign, so
+      // picking one here would fail the probe with a decode error that reads
+      // like a semantic-search regression rather than "no agent to sign as".
+      const agentKeyFile = keyFiles.find((f) => !isNodeKeyId(f.replace(/\.key$/, ""), keysDir));
+      if (agentKeyFile) agentId = agentKeyFile.replace(/\.key$/, "");
     } catch { /* keysDir missing */ }
   }
   if (!agentId) {
@@ -10791,8 +10797,12 @@ program
     await (async () => {
       const agentId = resolveAgentIdOrEnv({}) ?? (() => {
         try {
-          const keyFiles = readdirSync(defaultKeysDir()).filter((f) => f.endsWith(".key"));
-          return keyFiles.length > 0 ? keyFiles[0].replace(/\.key$/, "") : null;
+          const kd = defaultKeysDir();
+          const keyFiles = readdirSync(kd).filter((f) => f.endsWith(".key"));
+          // Node-scoped federation keys aren't agents (flair#1193) — never
+          // pin-refresh a connector as one.
+          const agentKeyFile = keyFiles.find((f) => !isNodeKeyId(f.replace(/\.key$/, ""), kd));
+          return agentKeyFile ? agentKeyFile.replace(/\.key$/, "") : null;
         } catch { return null; }
       })();
       if (!agentId) {
@@ -12900,9 +12910,29 @@ program
     const keysDir = defaultKeysDir();
     if (existsSync(keysDir)) {
       const keyFiles = (await import("node:fs")).readdirSync(keysDir).filter((f: string) => f.endsWith(".key"));
-      if (keyFiles.length > 0) {
-        keyAgentIds = keyFiles.map((f: string) => f.replace(/\.key$/, ""));
-        console.log(`  ${render.icons.ok} Keys found: ${render.wrap(render.c.bold, String(keyFiles.length))} agent(s) in ${render.wrap(render.c.dim, keysDir)}`);
+      // ~/.flair/keys is shared by agent Ed25519 signing keys and node-scoped
+      // federation keys (flair#1193). Only agent keys are signing identities;
+      // node keys are AES-GCM keystore blobs that must never be parsed as, or
+      // inferred as, an agent. Partition them out here so every downstream
+      // consumer of keyAgentIds (registration checks, --fix inference,
+      // fixCommandAgentHint) is node-free by construction.
+      const { agentKeyIds, nodeKeyIds } = partitionKeyIds(
+        keyFiles.map((f: string) => f.replace(/\.key$/, "")),
+        keysDir,
+      );
+      keyAgentIds = agentKeyIds;
+      if (agentKeyIds.length > 0) {
+        console.log(`  ${render.icons.ok} Keys found: ${render.wrap(render.c.bold, String(agentKeyIds.length))} agent(s) in ${render.wrap(render.c.dim, keysDir)}`);
+        if (nodeKeyIds.length > 0) {
+          console.log(`     ${render.icons.info} ${render.wrap(render.c.dim, `${nodeKeyIds.length} node-scoped federation key(s) present — not agent signing keys; skipping`)}`);
+        }
+      } else if (nodeKeyIds.length > 0) {
+        // Node keys but no agent key: functionally there is no agent identity
+        // here. Report it plainly (not the old DECODER false alarm) and point
+        // at the real remedy. Kept a warn — not an issues++ — so a genuine
+        // federation-only host doesn't newly fail doctor's exit code.
+        console.log(`  ${render.icons.warn} No agent signing key found — only ${render.wrap(render.c.bold, String(nodeKeyIds.length))} node-scoped federation key(s) in ${render.wrap(render.c.dim, keysDir)}`);
+        console.log(`     ${render.wrap(render.c.dim, "These are Fabric node keys, not agent identities. Fix:")} flair init --agent-id <your-agent>`);
       } else {
         console.log(`  ${render.icons.error} Keys directory exists but no .key files found`);
         console.log(`     ${render.wrap(render.c.dim, "Fix:")} flair init --agent-id <your-agent>`);
@@ -13155,12 +13185,23 @@ program
                 // nothing else identifies one — the only case doctor can
                 // infer without being told (see inferSoleAgentId's doc
                 // comment in doctor-client.ts for why 0/2+ keys don't guess).
-                const fixAgentId = opts.agent || process.env.FLAIR_AGENT_ID || anyKnownAgentId || inferSoleAgentId(keyAgentIds);
+                // flair#1193: resolveFixAgentId additionally refuses a
+                // node-scoped federation id from ANY source (inference, env,
+                // or a wired block a prior buggy run may have poisoned) — a
+                // node id can't sign, so wiring it would authenticate the
+                // connector as a phantom unregistered node.
+                const fixAgentId = resolveFixAgentId({
+                  optsAgent: opts.agent,
+                  envAgentId: process.env.FLAIR_AGENT_ID,
+                  anyKnownAgentId,
+                  keyAgentIds,
+                  keysDir: defaultKeysDir(),
+                });
                 if (!fixAgentId) {
                   if (keyAgentIds.length > 1) {
                     console.log(`     ${render.icons.warn} Cannot auto-wire ${client.label}: multiple agents found (${[...keyAgentIds].sort().join(", ")}) — pass --agent <id> to choose which one`);
                   } else {
-                    console.log(`     ${render.icons.warn} Cannot auto-wire ${client.label}: no agent registered — run \`flair agent add <id>\` first, then re-run \`flair doctor --fix\``);
+                    console.log(`     ${render.icons.warn} Cannot auto-wire ${client.label}: no agent identity found in keys/ — run \`flair init --agent <name>\` or \`flair agent add <name>\` before wiring a connector`);
                   }
                 } else {
                   const wireEnv = { FLAIR_AGENT_ID: fixAgentId, FLAIR_URL: resolveWireFlairUrl(block.flairUrl, baseUrl) };

--- a/src/doctor-client.ts
+++ b/src/doctor-client.ts
@@ -1159,3 +1159,90 @@ export function classifyKeyFile(
     reason: `agent '${agentId}' is not registered on ${baseUrl}${registration?.detail ? ` (${registration.detail})` : ""}`,
   };
 }
+
+// ── Node-scoped federation keys vs agent signing keys (flair#1193) ─────────
+//
+// `~/.flair/keys/` is a namespace shared by two writers with two file shapes:
+//
+//   • agent Ed25519 signing keys — a 32-byte raw seed at `<name>.key`, ALWAYS
+//     written together with a sibling `<name>.pub` (see the keypair write in
+//     src/cli.ts: the seed and the public key are emitted in the same block).
+//   • node-scoped federation keys — `flair_<hex8>.key`, an AES-256-GCM
+//     keystore blob written by FileKeyStore during Fabric provisioning
+//     (flair#1026). The id is minted as `flair_${randomBytes(4).toString("hex")}`
+//     in resources/Federation.ts, and NO `.pub` is ever written for it.
+//
+// Nothing used to tell them apart, so doctor tried to Ed25519-parse the node
+// blob — a "DECODER routines::unsupported" warning that reads as agent-auth
+// breakage when agent auth is fine — and `doctor --fix` could infer the node
+// id as the sole "agent" and wire it as a connector identity, authenticating
+// as a phantom, unregistered node whose key cannot sign (flair#1193).
+//
+// The guard is STRUCTURAL, not a parse attempt: a node id matches
+// `flair_<hex8>` AND has no sibling `.pub`. We deliberately do NOT classify by
+// parsing the file and treating a decode failure as "must be a node key" —
+// that is the exact fails-open move flair#1026 warns against (a genuinely
+// corrupt agent key would be misread as a node key and silently skipped).
+// A real agent always has a `.pub`; a node key never does, so `.pub` presence
+// is the primary, falsifiable signal and classification never depends on the
+// parse-failure of the thing being classified.
+
+/** The shape a Fabric node id always has: `flair_` + 8 lowercase hex chars. */
+const NODE_KEY_ID_RE = /^flair_[0-9a-f]{8}$/;
+
+/**
+ * True iff `id` names a node-scoped federation key rather than an agent
+ * signing key: it is shaped like a node id AND has no sibling `<id>.pub` in
+ * `keysDir`. Both conditions are required — an agent that happened to be named
+ * `flair_deadbeef` would still have a `.pub`, so it is never misclassified.
+ */
+export function isNodeKeyId(id: string, keysDir: string): boolean {
+  if (!NODE_KEY_ID_RE.test(id)) return false;
+  return !existsSync(join(keysDir, `${id}.pub`));
+}
+
+/**
+ * Partition `.key`-derived ids into agent signing keys and node-scoped
+ * federation keys (see isNodeKeyId). Node keys must never feed agent handling —
+ * Ed25519 parsing, registration checks, or connector-identity inference
+ * (flair#1193) — so callers keep only `agentKeyIds` for those paths and report
+ * `nodeKeyIds` informatively.
+ */
+export function partitionKeyIds(
+  ids: string[],
+  keysDir: string,
+): { agentKeyIds: string[]; nodeKeyIds: string[] } {
+  const agentKeyIds: string[] = [];
+  const nodeKeyIds: string[] = [];
+  for (const id of ids) {
+    (isNodeKeyId(id, keysDir) ? nodeKeyIds : agentKeyIds).push(id);
+  }
+  return { agentKeyIds, nodeKeyIds };
+}
+
+/**
+ * Resolve the agent id `doctor --fix` should wire a connector as, or undefined
+ * when none can be safely determined. A node-scoped federation id is NEVER
+ * returned regardless of source (flair#1193): it cannot sign, so wiring it
+ * yields a connector that authenticates as a phantom unregistered node and
+ * fails every read/write. When this returns undefined the caller MUST refuse
+ * and tell the user to create/register an agent — never fall back to a node id.
+ *
+ * `keyAgentIds` is expected to already be node-free (its producer partitions
+ * node keys out at enumeration), so `inferSoleAgentId` never sees one; the
+ * explicit `isNodeKeyId` guard additionally covers `optsAgent` / `envAgentId` /
+ * `anyKnownAgentId`, since a prior buggy run may have poisoned a wired block
+ * with a node id that would otherwise be read back and re-propagated.
+ */
+export function resolveFixAgentId(args: {
+  optsAgent?: string;
+  envAgentId?: string;
+  anyKnownAgentId?: string;
+  keyAgentIds: string[];
+  keysDir: string;
+}): string | undefined {
+  const { optsAgent, envAgentId, anyKnownAgentId, keyAgentIds, keysDir } = args;
+  const candidate = optsAgent || envAgentId || anyKnownAgentId || inferSoleAgentId(keyAgentIds);
+  if (candidate && isNodeKeyId(candidate, keysDir)) return undefined;
+  return candidate;
+}

--- a/test/unit/doctor-node-key-classify.test.ts
+++ b/test/unit/doctor-node-key-classify.test.ts
@@ -1,0 +1,149 @@
+/**
+ * doctor-node-key-classify.test.ts — flair#1193.
+ *
+ * `~/.flair/keys/` is a namespace shared by two writers: agent Ed25519 signing
+ * keys (32-byte raw seed at `<name>.key`, ALWAYS with a sibling `<name>.pub`)
+ * and node-scoped federation keys (`flair_<hex8>.key`, an AES-256-GCM keystore
+ * blob written by FileKeyStore during Fabric provisioning, with NO `.pub`).
+ * Nothing used to tell them apart, so `flair doctor` tried to Ed25519-parse the
+ * node blob (a "DECODER routines::unsupported" warning that reads as agent-auth
+ * breakage) and `doctor --fix` could infer the node id as the sole "agent" and
+ * wire it as a connector identity — a phantom, unregistered node whose key
+ * cannot sign, breaking every read/write.
+ *
+ * These tests exercise the classifier and the two decisions it feeds against
+ * REAL key files on disk in a temp dir (no Harper needed). The classifier is
+ * structural — node id shape AND no sibling `.pub` — so it never depends on the
+ * parse-failure of the thing it is classifying.
+ */
+
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { randomBytes as cryptoRandomBytes } from "node:crypto";
+import {
+  isNodeKeyId,
+  partitionKeyIds,
+  inferSoleAgentId,
+  resolveFixAgentId,
+} from "../../src/doctor-client.ts";
+
+const NODE_ID = "flair_1d786ba8";
+
+let keysDir: string;
+
+/** Write a node-scoped federation key: `flair_<hex8>.key`, ~60-byte blob, no `.pub`. */
+function writeNodeKey(dir: string, id: string): void {
+  writeFileSync(join(dir, `${id}.key`), cryptoRandomBytes(60)); // AES-256-GCM-shaped blob
+}
+
+/** Write an agent signing key: 32-byte seed `<name>.key` + a sibling `<name>.pub`. */
+function writeAgentKey(dir: string, name: string): void {
+  writeFileSync(join(dir, `${name}.key`), cryptoRandomBytes(32)); // raw Ed25519 seed
+  writeFileSync(join(dir, `${name}.pub`), cryptoRandomBytes(32)); // Ed25519 public key
+}
+
+beforeEach(() => {
+  keysDir = mkdtempSync(join(tmpdir(), "flair-1193-keys-"));
+});
+
+afterEach(() => {
+  rmSync(keysDir, { recursive: true, force: true });
+});
+
+describe("isNodeKeyId", () => {
+  test("a flair_<hex8> id with no sibling .pub is a node key", () => {
+    writeNodeKey(keysDir, NODE_ID);
+    expect(isNodeKeyId(NODE_ID, keysDir)).toBe(true);
+  });
+
+  test("a normal agent id (has a .pub) is NOT a node key", () => {
+    writeAgentKey(keysDir, "local");
+    expect(isNodeKeyId("local", keysDir)).toBe(false);
+  });
+
+  test("an id shaped like a node id but WITH a .pub is an agent, not a node key", () => {
+    // Structural guard: shape alone is not enough — the .pub sibling means a
+    // real keypair was written for it, so it is an agent even if oddly named.
+    writeAgentKey(keysDir, "flair_deadbeef");
+    expect(isNodeKeyId("flair_deadbeef", keysDir)).toBe(false);
+  });
+
+  test("wrong shape (not flair_<8 hex>) is never a node key", () => {
+    // No .pub for any of these, so only the shape rule keeps them agents.
+    expect(isNodeKeyId("local", keysDir)).toBe(false);
+    expect(isNodeKeyId("flair_1d786ba", keysDir)).toBe(false); // 7 hex
+    expect(isNodeKeyId("flair_1d786ba8a", keysDir)).toBe(false); // 9 hex
+    expect(isNodeKeyId("flair_ZZZZZZZZ", keysDir)).toBe(false); // non-hex
+    expect(isNodeKeyId("flair-1d786ba8", keysDir)).toBe(false); // wrong separator
+  });
+});
+
+describe("partitionKeyIds — doctor enumeration classification", () => {
+  test("splits the node key from the agent key (node never reaches the Ed25519/registration path)", () => {
+    writeNodeKey(keysDir, NODE_ID);
+    writeAgentKey(keysDir, "local");
+    const { agentKeyIds, nodeKeyIds } = partitionKeyIds([NODE_ID, "local"], keysDir);
+    // `local` is enumerated as an agent → it is the only id doctor will feed to
+    // planAgentIterations → checkAgentRegistered → buildEd25519Auth. The node
+    // id lands in nodeKeyIds, so the DECODER-warning path is never taken for it.
+    expect(agentKeyIds).toEqual(["local"]);
+    expect(nodeKeyIds).toEqual([NODE_ID]);
+  });
+
+  test("a node-only host yields zero agent keys", () => {
+    writeNodeKey(keysDir, NODE_ID);
+    const { agentKeyIds, nodeKeyIds } = partitionKeyIds([NODE_ID], keysDir);
+    expect(agentKeyIds).toEqual([]);
+    expect(nodeKeyIds).toEqual([NODE_ID]);
+  });
+});
+
+describe("inferSoleAgentId over the partitioned (node-free) pool", () => {
+  test("both present → returns the agent id, never the node id", () => {
+    writeNodeKey(keysDir, NODE_ID);
+    writeAgentKey(keysDir, "local");
+    const { agentKeyIds } = partitionKeyIds([NODE_ID, "local"], keysDir);
+    expect(inferSoleAgentId(agentKeyIds)).toBe("local");
+  });
+
+  test("node key only → returns undefined (NOT the node id)", () => {
+    writeNodeKey(keysDir, NODE_ID);
+    const { agentKeyIds } = partitionKeyIds([NODE_ID], keysDir);
+    expect(inferSoleAgentId(agentKeyIds)).toBeUndefined();
+  });
+});
+
+describe("resolveFixAgentId — doctor --fix connector identity (never a node id)", () => {
+  test("both present → wires the agent", () => {
+    writeNodeKey(keysDir, NODE_ID);
+    writeAgentKey(keysDir, "local");
+    const { agentKeyIds } = partitionKeyIds([NODE_ID, "local"], keysDir);
+    expect(resolveFixAgentId({ keyAgentIds: agentKeyIds, keysDir })).toBe("local");
+  });
+
+  test("node-only host → refuses (undefined) rather than wiring the node id", () => {
+    writeNodeKey(keysDir, NODE_ID);
+    const { agentKeyIds } = partitionKeyIds([NODE_ID], keysDir);
+    // This is the exact condition that prevents `doctor --fix` from writing
+    // FLAIR_AGENT_ID=flair_... : a falsy id makes the caller take the refusal
+    // branch instead of the wire branch.
+    expect(resolveFixAgentId({ keyAgentIds: agentKeyIds, keysDir })).toBeUndefined();
+  });
+
+  test("a node id supplied via env/explicit source is still refused (guard covers all sources)", () => {
+    writeNodeKey(keysDir, NODE_ID);
+    // Even if FLAIR_AGENT_ID (or --agent) names the node id, it cannot sign, so
+    // resolveFixAgentId drops it — a prior buggy run may have poisoned a wired
+    // block with exactly this value.
+    expect(resolveFixAgentId({ envAgentId: NODE_ID, keyAgentIds: [], keysDir })).toBeUndefined();
+    expect(resolveFixAgentId({ optsAgent: NODE_ID, keyAgentIds: [], keysDir })).toBeUndefined();
+    expect(resolveFixAgentId({ anyKnownAgentId: NODE_ID, keyAgentIds: [], keysDir })).toBeUndefined();
+  });
+
+  test("an explicit real agent is returned unchanged", () => {
+    writeAgentKey(keysDir, "ci-bot");
+    expect(resolveFixAgentId({ optsAgent: "ci-bot", keyAgentIds: [], keysDir })).toBe("ci-bot");
+  });
+});


### PR DESCRIPTION
## Summary

`flair doctor` treated every `~/.flair/keys/*.key` as an agent signing key. Node-scoped federation keys (`flair_<hex8>.key` — AES-GCM keystore blobs, ~60 bytes, no sibling `.pub`) got swept in, causing two failures:

1. doctor Ed25519-parsed the node blob → misleading `DECODER routines::unsupported` warning (reads as agent-auth breakage; auth was fine).
2. `doctor --fix` could auto-wire a node id as `FLAIR_AGENT_ID` in `~/.claude.json` → the connector authenticated as a phantom unregistered node with an unparseable key → all reads/writes failed. (Hit on a real user's machine.)

Closes #1193

## Fix

- `isNodeKeyId(id, keysDir)` — a node key iff the id matches `flair_<hex8>` AND has no sibling `<id>.pub` (agent keys always write a `.pub`; node keys never do — so a real agent is never misclassified, and classification never depends on parse-failure of the thing being classified).
- `partitionKeyIds(ids, keysDir)` — splits `.key`-derived ids into agentKeyIds vs nodeKeyIds.
- Node keys excluded from: the doctor enumeration/parse, registration checks, `inferSoleAgentId`/`planAgentIterations`, and the `keyFiles[0]` fallbacks. Node keys are reported informatively ("Fabric node keys, not agent identities") instead of the DECODER warning.
- `resolveFixAgentId` refuses a node id; when no real agent exists, `doctor --fix` fails loudly ("no agent identity found in keys/ — run `flair init --agent <name>`…") rather than ever defaulting the connector identity to a node id.

## Tests

- `test/unit/doctor-node-key-classify.test.ts` — 12 assertions over real on-disk key files (node `flair_<hex8>.key` with no `.pub` vs agent `local.key`+`local.pub`): isNodeKeyId classification, enumeration partition, `inferSoleAgentId` returns the agent (not the node id) when both exist and none when only a node key exists, and `doctor --fix` refuses to wire a node id.
- Mutation-checked: inverting the `.pub` guard fails 9/12; restored to green.
- Typecheck: only the pre-existing `auth-middleware.ts(71,1)` error, no new ones.

Implemented by a build agent; committed by flint after review (the builder stalled on a redundant local suite — CI runs the full suite here).
