### PR TITLE
fix(bootstrap): payload quality — de-dup serialization, honest tokens, freshness (#1199/#1200/#1201)

### DIFF
--- a/.changelog/unreleased/fixed-bootstrap-payload-quality.md
+++ b/.changelog/unreleased/fixed-bootstrap-payload-quality.md
@@ -1,0 +1,16 @@
+- **Bootstrap payload quality: no double-serialization, honest token accounting,
+  coherent counters, deduped org events, and freshness off `updatedAt`.** The
+  `/mcp` bootstrap connector no longer receives every soul and memory body twice
+  (once in the prose `context`, once in the structured containers): the
+  structured `soul`/`memories`/`predicted` fields are canonical, teammate
+  findings now ship in a new structured `teammateFindings` container, and the
+  prose `context` is opt-in (`includeContext`, off by default on the `/mcp`
+  path). `tokenEstimate` now reflects the actual serialized payload and
+  `maxTokens` bounds it. `memoriesIncluded` is own-scoped so it can no longer
+  exceed `memoriesAvailable`, with cross-agent hits counted separately as
+  `teammateFindingsIncluded`. Byte-identical org events are deduped before the
+  scarce-slot cutoff. Trust-block freshness (`ageDays`) now keys off a record's
+  own `updatedAt` (falling back to `createdAt`), so a record edited today reads
+  as fresh, and each bootstrap trust entry is tagged with its `section` so a
+  `matchQuality` of null on a lifecycle load is legible rather than reading as a
+  scoring failure.

--- a/resources/MemoryBootstrap.ts
+++ b/resources/MemoryBootstrap.ts
@@ -66,7 +66,11 @@ import { bestSemanticSimilarity, evaluateAbstention } from "./abstention.js";
  *
  * Request:
  *   { agentId, currentTask?, maxTokens?, includeSoul?, since?,
- *     channel?, surface?, subjects?, entities? }
+ *     channel?, surface?, subjects?, entities?, includeContext? }
+ *   `includeContext` (flair#1199): whether to assemble the prose `context`
+ *   mirror. Default true here (the resource/REST/CLI path); the /mcp bootstrap
+ *   wrapper passes false so a token-budgeted connector — which reads the
+ *   structured containers — never receives the same bodies twice.
  *   `entities` (flair#681): the caller's own declared attention-plane
  *   vocabulary strings (see resources/entity-vocab.ts) for collision
  *   surfacing's entity-overlap join. Invalid entries are silently dropped
@@ -76,12 +80,21 @@ import { bestSemanticSimilarity, evaluateAbstention } from "./abstention.js";
  *
  * Response:
  *   { context, sections, tokenEstimate, memoriesIncluded, memoriesAvailable,
- *     agentId, scope, soul, memories, predicted[, currentTaskHint] }
+ *     teammateFindingsIncluded, agentId, scope, soul, memories, predicted,
+ *     teammateFindings[, currentTaskHint][, predictedHint] }
  *   The self-describing keys (flair#1182 part 1) — `agentId` (resolved caller),
  *   `scope` (read model applied to the caller), `soul`/`memories`/`predicted`
  *   (the caller's OWN records as structured containers), and `currentTaskHint`
  *   (present only when currentTask is absent/blank) — are ALWAYS emitted so a
  *   client can tell an empty instance from one that doesn't support them.
+ *   flair#1199 — the structured containers are CANONICAL; `context` is a prose
+ *   mirror (opt-in via includeContext). Cross-agent teammate findings ship in
+ *   the `teammateFindings` container (own memories in `memories`), counted by
+ *   `teammateFindingsIncluded` (a separate denominator from `memoriesIncluded`,
+ *   which is own-scoped so it never exceeds `memoriesAvailable`). `tokenEstimate`
+ *   reflects the ACTUAL serialized payload, and `maxTokens` bounds it.
+ *   `predictedHint` is present only when subjects were provided but `predicted`
+ *   came back empty.
  */
 
 // Collision surfacing (flair#681) tunables.
@@ -120,6 +133,18 @@ const MAX_CANDIDATE_POOL = 100;
 // `minScore` request param) — preserved verbatim from the original raw
 // JS dot-product scan's `.filter((s) => s.score > 0.3)`.
 const TASK_RELEVANCE_FLOOR = 0.3;
+
+// flair#1199 — per-memory structured-payload overhead charged against the token
+// budget IN ADDITION to the rendered prose line. Each included memory ships as a
+// structured object ({id, content, durability, createdAt, updatedAt, agentId,
+// subject, section, ...}) which is the CANONICAL payload; its JSON keys cost
+// ~30-40 tokens beyond the prose line the fill loop measures. Charging it here
+// keeps the ACTUAL serialized payload (measured by tokenEstimate) within
+// maxTokens — the prose line alone under-charged, so the structured containers
+// crossed the cap. Sized to the non-content JSON a lean memory carries (id +
+// createdAt + updatedAt + agentId + durability + subject + section + key names,
+// ~55-70 tokens); conservative (errs slightly high, never low).
+const STRUCT_ITEM_OVERHEAD_TOKENS = 70;
 
 // Rough token estimate: ~4 chars per token for English text
 function estimateTokens(text: string): number {
@@ -172,6 +197,16 @@ export class BootstrapMemories extends Resource {
       subjects,    // e.g., ["flair", "auth"] — entities to preload context for
       includeTrust = false,  // flair#744 slice 1 — opt-in per-memory trust block
       abstain = false,       // flair#744 slice 2 — opt-in task-relevance abstention
+      // flair#1199 — whether to assemble the prose `context` string. The
+      // structured containers (soul/memories/predicted/teammateFindings) are the
+      // CANONICAL payload; `context` is a human/agent-readable MIRROR of the same
+      // bytes. Default TRUE here (the resource/REST/CLI path has always emitted
+      // prose, and every direct caller reads it) — but the /mcp bootstrap wrapper
+      // (resources/mcp-tools.ts) passes `false` by default, so a token-budgeted
+      // connector, which consumes the structured fields, never receives the same
+      // bodies twice. When false, `context` is a compact structural pointer (no
+      // bodies), so nothing crosses the wire twice on that path.
+      includeContext = true,
     } = data || {};
 
     // Authenticated identity lives on getContext().request — `this.request` is
@@ -216,28 +251,60 @@ export class BootstrapMemories extends Resource {
       collision: [],
       events: [],
     };
-    let tokenBudget = maxTokens;
+    // flair#1199 — the structured containers (soul/memories/predicted/
+    // teammateFindings) are the CANONICAL payload, and `tokenEstimate` now
+    // reports the ACTUAL serialized bytes. Reserve headroom for the JSON
+    // scaffolding those containers and the self-describing keys (scope/sections/
+    // counters) add on top of the raw content, so `maxTokens` bounds the real
+    // payload — not just the prose. Without this the containers ship on top of
+    // the memory-line budget and blow the cap (the reported 4000→4275+ overrun).
+    const structOverheadReserve = Math.min(600, Math.floor(maxTokens * 0.15));
+    // Single shared budget across soul + every memory section (soul used to be
+    // budgeted SEPARATELY and added ON TOP, so context alone could reach
+    // 1.4×maxTokens; #1199). Content selected therefore stays within
+    // maxTokens − reserve, and the serialized payload within maxTokens.
+    let tokenBudget = Math.max(0, maxTokens - structOverheadReserve);
+    // Own memories included in the payload (permanent + recent + predicted +
+    // own task-relevant). Denominator is `memoriesAvailable` (own-scoped), so
+    // memoriesIncluded ≤ memoriesAvailable always holds (#1199 coherent
+    // counters). Cross-agent teammate findings are counted separately below.
     let memoriesIncluded = 0;
     let memoriesAvailable = 0;
     let memoriesTruncated = 0;
+    // flair#1199 — cross-agent teammate findings included (a DIFFERENT
+    // denominator than own memories): counting these into `memoriesIncluded`
+    // is what let one client see included(9) > available(3).
+    let teammateFindingsIncluded = 0;
 
     // flair#1182 (part 1) — self-describing bootstrap. These structured
     // container keys are ALWAYS emitted on the response (empty `{}`/`[]` when
     // the caller has nothing), so a client can tell an *empty* instance from
     // one that doesn't support these keys at all — and can read the caller's
     // own soul/memories as structured data instead of parsing the `context`
-    // markdown string. Scoped to the CALLER'S OWN records only
-    // (permanent/recent/relevant/predicted are all agentId==self reads);
-    // teammate findings stay in `context`/`sections.teammate` and are never
-    // duplicated here, so these containers carry no other agent's data.
+    // markdown string. `soul`/`memories`/`predicted` are scoped to the CALLER'S
+    // OWN records only (permanent/recent/relevant/predicted are all agentId==self
+    // reads). flair#1199 — cross-agent teammate findings now have their OWN
+    // structured container (`teammateFindings`, below), attributed via `source`,
+    // rather than living only in the prose `context` (which is opt-in as of
+    // #1199); the own-only containers still carry no other agent's data.
     const soulMap: Record<string, unknown> = {};
     const includedOwnMemories: any[] = [];
     const includedPredicted: any[] = [];
+    // flair#1199 — teammate (cross-agent) findings get their OWN structured
+    // container. Before #1199 they lived ONLY in the prose `context`; now that
+    // `context` is an opt-in mirror (default off on the /mcp path), they need a
+    // structured home so a connector that consumes the containers still sees
+    // them. Kept SEPARATE from `memories`/`predicted` (which stay own-only per
+    // the #1182 boundary) and clearly attributed via `source`.
+    const includedTeammateFindings: any[] = [];
     const leanMemory = (m: any, section: string) => ({
       id: m.id,
       content: m.content,
       durability: m.durability ?? null,
       createdAt: m.createdAt ?? null,
+      // #1201 — the record's own last-write time, so a structured consumer can
+      // compute freshness off the same anchor the trust block's ageDays uses.
+      updatedAt: m.updatedAt ?? null,
       agentId: m.agentId ?? agentId,
       subject: m.subject ?? null,
       section,
@@ -288,12 +355,15 @@ export class BootstrapMemories extends Resource {
           if (maxChars > 100) {
             const truncated = `**${entry.key}:** ${entry.line.slice(entry.key.length + 6, entry.key.length + 6 + maxChars)}…(truncated)`;
             sections.soul.push(truncated);
-            soulTokens += estimateTokens(truncated);
+            const cost = estimateTokens(truncated);
+            soulTokens += cost;
+            tokenBudget -= cost; // #1199 — soul draws from the shared budget
           }
           continue;
         }
         sections.soul.push(entry.line);
         soulTokens += entry.tokens;
+        tokenBudget -= entry.tokens; // #1199 — soul draws from the shared budget
       }
     }
 
@@ -416,16 +486,25 @@ export class BootstrapMemories extends Resource {
     // requested, so a non-trust bootstrap fetches (and returns) exactly what it
     // did before. These records are never returned raw when the block is off,
     // so widening the select cannot change the off-path response bytes.
+    // #1201 — `updatedAt` is projected on BOTH paths (not just the trust path):
+    // the structured `memories`/`predicted` containers carry it so a consumer
+    // can compute freshness, and the trust block's ageDays keys off it.
     const OWN_SELECT = includeTrust
-      ? ["id", "agentId", "content", "durability", "createdAt", "supersedes", "subject", "validTo", "expiresAt", "_safetyFlags", "provenance", "usageCount", "validFrom"]
-      : ["id", "agentId", "content", "durability", "createdAt", "supersedes", "subject", "validTo", "expiresAt", "_safetyFlags"];
+      ? ["id", "agentId", "content", "durability", "createdAt", "updatedAt", "supersedes", "subject", "validTo", "expiresAt", "_safetyFlags", "provenance", "usageCount", "validFrom"]
+      : ["id", "agentId", "content", "durability", "createdAt", "updatedAt", "supersedes", "subject", "validTo", "expiresAt", "_safetyFlags"];
 
     // flair#744 slice 1 — the Memory records that became visible lines in the
     // memory-bearing sections (permanent/recent/predicted/relevant/teammate),
     // collected as they're added so the opt-in `trust` array below can carry a
     // self-contained block per included memory. Stays empty (and unused) when
-    // includeTrust is off.
-    const includedTrustMemories: any[] = [];
+    // includeTrust is off. flair#1201 — each entry carries the SECTION it landed
+    // in, so a trust entry's `matchQuality` is legible: null on a lifecycle
+    // section (permanent/recent/predicted — not a retrieval surface) reads as
+    // "not scored", not as a scoring failure, and a band on a retrieval section
+    // (relevant/teammate) is applied by the SAME rule to own and teammate
+    // records. Fixes the "own recent → null while teammate → strong looks like
+    // my own records scored worse" misread.
+    const includedTrustMemories: { m: any; section: string }[] = [];
 
     // flair#744 slice 2 — the best absolute semantic similarity seen while
     // scoring the task-relevant candidate pool (section 4). Drives the opt-in
@@ -477,11 +556,11 @@ export class BootstrapMemories extends Resource {
     const permanent = permanentRows.filter((m) => !permanentSupersededIds.has(m.id));
     for (const m of permanent) {
       const line = formatMemory(m, agentId);
-      const cost = estimateTokens(line);
+      const cost = estimateTokens(line) + STRUCT_ITEM_OVERHEAD_TOKENS; // #1199 structured cost
       if (cost <= tokenBudget) {
         sections.permanent.push(line);
         includedOwnMemories.push(leanMemory(m, "permanent"));
-        if (includeTrust) includedTrustMemories.push(m);
+        if (includeTrust) includedTrustMemories.push({ m, section: "permanent" });
         tokenBudget -= cost;
         memoriesIncluded++;
       } else {
@@ -545,14 +624,14 @@ export class BootstrapMemories extends Resource {
     let recentSpent = 0;
     for (const m of recent) {
       const line = formatMemory(m, agentId);
-      const cost = estimateTokens(line);
+      const cost = estimateTokens(line) + STRUCT_ITEM_OVERHEAD_TOKENS; // #1199 structured cost
       if (recentSpent + cost > recentBudget) {
         memoriesTruncated++;
         continue;
       }
       sections.recent.push(line);
       includedOwnMemories.push(leanMemory(m, "recent"));
-      if (includeTrust) includedTrustMemories.push(m);
+      if (includeTrust) includedTrustMemories.push({ m, section: "recent" });
       recentSpent += cost;
       tokenBudget -= cost;
       memoriesIncluded++;
@@ -592,14 +671,14 @@ export class BootstrapMemories extends Resource {
       let predictedSpent = 0;
       for (const m of subjectMemories) {
         const line = formatMemory(m, agentId);
-        const cost = estimateTokens(line);
+        const cost = estimateTokens(line) + STRUCT_ITEM_OVERHEAD_TOKENS; // #1199 structured cost
         if (predictedSpent + cost > predictedBudget) {
           memoriesTruncated++;
           continue;
         }
         sections.predicted.push(line);
         includedPredicted.push(leanMemory(m, "predicted"));
-        if (includeTrust) includedTrustMemories.push(m);
+        if (includeTrust) includedTrustMemories.push({ m, section: "predicted" });
         predictedSpent += cost;
         tokenBudget -= cost;
         memoriesIncluded++;
@@ -773,19 +852,38 @@ export class BootstrapMemories extends Resource {
         // section double-spends.
         for (const { memory: m } of scored) {
           const line = formatMemory(m, agentId);
-          const cost = estimateTokens(line);
+          const cost = estimateTokens(line) + STRUCT_ITEM_OVERHEAD_TOKENS; // #1199 structured cost
           if (cost > tokenBudget) continue;
           if (m._source) {
             sections.teammate.push(line);
+            // flair#1199 — cross-agent teammate findings join their OWN
+            // structured container (attributed via `source`), so a connector
+            // consuming the containers still sees them when prose `context` is
+            // off. Counted separately (teammateFindingsIncluded), NOT into
+            // memoriesIncluded — that different-denominator mix is what let
+            // included exceed available.
+            includedTeammateFindings.push({
+              id: m.id,
+              content: m.content,
+              durability: m.durability ?? null,
+              createdAt: m.createdAt ?? null,
+              updatedAt: m.updatedAt ?? null,
+              subject: m.subject ?? null,
+              source: m._source,
+              section: "teammate",
+            });
+            if (includeTrust) includedTrustMemories.push({ m, section: "teammate" });
+            tokenBudget -= cost;
+            teammateFindingsIncluded++;
           } else {
             sections.relevant.push(line);
             // flair#1182 — own task-relevant records join the `memories`
-            // container; teammate (`_source`) records stay in `context` only.
+            // container.
             includedOwnMemories.push(leanMemory(m, "relevant"));
+            if (includeTrust) includedTrustMemories.push({ m, section: "relevant" });
+            tokenBudget -= cost;
+            memoriesIncluded++;
           }
-          if (includeTrust) includedTrustMemories.push(m);
-          tokenBudget -= cost;
-          memoriesIncluded++;
         }
       }
     }
@@ -933,8 +1031,29 @@ export class BootstrapMemories extends Resource {
         eventResults.push(event);
       }
 
-      eventResults.sort((a: any, b: any) => (a.createdAt || "").localeCompare(b.createdAt || ""));
-      for (const evt of eventResults.slice(0, 10)) {
+      // flair#1200 — collapse byte-identical duplicate events before rendering.
+      // The same logical event can land in the table more than once (a producer
+      // that double-fires, or the same broadcast emitted from two paths); each
+      // physical row has a distinct id/createdAt (OrgEvent.post keys the id off
+      // a millisecond timestamp), so they aren't caught by primary-key upsert
+      // and render as exact dupes. Org-event slots are scarce (10), so dedup
+      // BEFORE the slice — otherwise ~half the slots are wasted on duplicates.
+      // Keyed on the CONTENT (kind + summary + detail + targets), keeping the
+      // most-recent occurrence per signature.
+      const eventBySignature = new Map<string, any>();
+      for (const evt of eventResults) {
+        const sig = JSON.stringify([
+          evt.kind ?? "",
+          evt.summary ?? "",
+          evt.detail ?? "",
+          Array.isArray(evt.targetIds) ? [...evt.targetIds].sort() : (evt.targetIds ?? null),
+        ]);
+        const prev = eventBySignature.get(sig);
+        if (!prev || (evt.createdAt || "") > (prev.createdAt || "")) eventBySignature.set(sig, evt);
+      }
+      const dedupedEvents = [...eventBySignature.values()]
+        .sort((a: any, b: any) => (a.createdAt || "").localeCompare(b.createdAt || ""));
+      for (const evt of dedupedEvents.slice(0, 10)) {
         const elapsed = Date.now() - new Date(evt.createdAt).getTime();
         const mins = Math.floor(elapsed / 60_000);
         const relTime = mins < 60 ? `${mins}min ago` : `${Math.floor(mins / 60)}h ago`;
@@ -989,9 +1108,27 @@ export class BootstrapMemories extends Resource {
       parts.push("## Recent Org Events\n" + sections.events.join("\n"));
     }
 
-    const context = parts.join("\n\n");
+    const fullContext = parts.join("\n\n");
+    // flair#1199 — the structured containers are canonical; `context` is a prose
+    // MIRROR of the same bytes. When includeContext is off (the /mcp default),
+    // ship a compact structural pointer instead of re-embedding every body — so
+    // no field's bytes cross the wire twice. Always a string, so a client can
+    // still tell an empty instance from an unsupported one. When on, the prose
+    // is the full assembled context (the resource/REST/CLI behaviour, unchanged).
+    const context = includeContext
+      ? fullContext
+      : (fullContext.length === 0
+          ? ""
+          : `Structured payload in soul/memories/predicted/teammateFindings `
+            + `(${memoriesIncluded} own + ${teammateFindingsIncluded} teammate memories, `
+            + `${sections.soul.length} soul entries). Pass includeContext:true for the assembled prose context.`);
     const soulTokens = sections.soul.reduce((sum, line) => sum + estimateTokens(line), 0);
-    const memoryTokens = maxTokens - tokenBudget;
+    // #1199 — memory-line token spend (informational breakdown), independent of
+    // the reserve/soul now sharing the budget. Sum of the rendered memory lines.
+    const memoryTokens = [
+      ...sections.permanent, ...sections.recent, ...sections.predicted,
+      ...sections.relevant, ...sections.teammate,
+    ].reduce((sum, line) => sum + estimateTokens(line), 0);
 
     // flair#744 slice 1 — opt-in per-memory trust block. Bootstrap renders
     // memories as text lines rather than result objects, so the block is
@@ -1000,9 +1137,12 @@ export class BootstrapMemories extends Resource {
     // HERE, in the response tail, strictly after all read-scope resolution and
     // purely for the response — never consulted for any authority decision
     // (#735-spirit zero-authority invariant). Default OFF ⇒ the `trust` key is
-    // absent ⇒ the response is byte-identical to pre-slice-1.
+    // absent ⇒ the response is byte-identical to pre-slice-1. flair#1201 — each
+    // entry carries its `section` so `matchQuality: null` on a lifecycle section
+    // reads as "not a retrieval surface", not as a scoring failure on the
+    // caller's own records.
     const trust = includeTrust
-      ? includedTrustMemories.map((m) => ({ id: m.id, ...buildTrustBlock(m) }))
+      ? includedTrustMemories.map(({ m, section }) => ({ id: m.id, section, ...buildTrustBlock(m) }))
       : undefined;
 
     // flair#744 slice 2 — opt-in abstention verdict for the task-relevance
@@ -1035,7 +1175,18 @@ export class BootstrapMemories extends Resource {
       ? undefined
       : "No currentTask was provided. Pass currentTask (a short description of what you're working on) to enable task-relevant memory retrieval, teammate findings, and collision surfacing.";
 
-    return {
+    // flair#1199 — when `subjects` were provided but nothing surfaced in
+    // `predicted`, say WHY (like currentTaskHint), so an empty `predicted: []`
+    // next to a non-empty `subjects` doesn't read as broken. Predicted fills
+    // from your OWN non-permanent memories whose `subject` matches one of the
+    // provided subjects; it stays empty until you've tagged memories that way.
+    const predictedHint = (predictedSubjects.length > 0 && includedPredicted.length === 0)
+      ? `No memories tagged with the requested subjects (${predictedSubjects.join(", ")}) were found. `
+        + `predicted surfaces your own non-permanent memories whose subject matches one of the provided `
+        + `subjects — it fills as you store memories tagged with these subjects.`
+      : undefined;
+
+    const responseBody: Record<string, unknown> = {
       context,
       // flair#1182 (part 1) — always-present self-describing keys: who the
       // server resolved the caller as, the read model applied, and the caller's
@@ -1046,7 +1197,12 @@ export class BootstrapMemories extends Resource {
       soul: soulMap,
       memories: includedOwnMemories,
       predicted: includedPredicted,
+      // flair#1199 — cross-agent teammate findings as a structured container
+      // (always present, `[]` when none), so a connector that consumes the
+      // containers still gets them when prose `context` is off.
+      teammateFindings: includedTeammateFindings,
       ...(currentTaskHint ? { currentTaskHint } : {}),
+      ...(predictedHint ? { predictedHint } : {}),
       ...(trust ? { trust } : {}),
       ...(abstention ? { abstention } : {}),
       sections: {
@@ -1062,12 +1218,26 @@ export class BootstrapMemories extends Resource {
         collision: sections.collision.length,
         events: sections.events.length,
       },
-      tokenEstimate: soulTokens + memoryTokens,
       soulTokens,
       memoryTokens,
+      // flair#1199 — own memories included (denominator: memoriesAvailable, also
+      // own-scoped), so memoriesIncluded ≤ memoriesAvailable always holds.
       memoriesIncluded,
       memoriesAvailable,
+      // Cross-agent teammate findings included — a SEPARATE denominator, labelled
+      // so it's never confused with the own-memory counters.
+      teammateFindingsIncluded,
       memoriesTruncated,
     };
+
+    // flair#1199 — tokenEstimate must reflect the ACTUAL serialized payload the
+    // caller receives (the structured containers included), not just the prose
+    // `context`. The old `soulTokens + memoryTokens` counted only the context
+    // string, so it under-reported by ~2× once the structured fields shipped
+    // alongside — the reported "maxTokens 4000 → tokenEstimate 4275 while the
+    // real payload was well over the cap". Measured over the assembled body
+    // (the ~1-line tokenEstimate field it omits is negligible).
+    const tokenEstimate = estimateTokens(JSON.stringify(responseBody));
+    return { ...responseBody, tokenEstimate };
   }
 }

--- a/resources/mcp-tools.ts
+++ b/resources/mcp-tools.ts
@@ -413,6 +413,13 @@ async function bootstrap(agent: ResolvedAgent, args: any) {
     surface: args?.surface,
     subjects: args?.subjects,
     entities: args?.entities,
+    // flair#1199 — a /mcp connector consumes the STRUCTURED containers
+    // (soul/memories/predicted/teammateFindings), so the prose `context` mirror
+    // is OFF by default here: shipping both doubled the payload past maxTokens
+    // (the reported ~2× overrun). The resource itself defaults includeContext
+    // true (the REST/CLI prose path); this wrapper flips it for the connector,
+    // and forwards an explicit true when a caller wants the prose anyway.
+    includeContext: args?.includeContext === true,
   };
   // flair#744 slice 1 — opt-in per-memory trust block array. Forwarded ONLY
   // when requested so a plain bootstrap delegates a byte-identical body.
@@ -707,6 +714,7 @@ export const TOOLS: Record<string, ToolEntry> = {
           },
           includeTrust: { type: "boolean", description: "Also return a `trust` array with a per-included-memory trust-evidence block (provenance, author, usage, freshness, supersession). Default false." },
           abstain: { type: "boolean", description: "Opt into a task-relevance abstention verdict: also return an `abstention` object ({ abstained, bestScore, threshold }) reporting whether any memory covered `currentTask` above a global confidence threshold. Default false." },
+          includeContext: { type: "boolean", description: "Also return the prose `context` string — a human-readable mirror of the structured soul/memories/predicted/teammateFindings containers (which are the canonical payload). Default false here: the structured fields already carry everything, so shipping the prose too would double the payload." },
         },
       },
     },

--- a/resources/trust-block.ts
+++ b/resources/trust-block.ts
@@ -158,7 +158,19 @@ export interface TrustBlock {
   validTo: string | null;
   /** Raw `createdAt` (server-clock write time), or null. */
   createdAt: string | null;
-  /** Whole days since `createdAt` (freshness), or null when unavailable. */
+  /**
+   * Raw `updatedAt` (server-clock last-write time), or null. This is the
+   * record's OWN update time — never a superseded predecessor's (#1189
+   * field-scoping) — and is what `ageDays` keys off (see below).
+   */
+  updatedAt: string | null;
+  /**
+   * Freshness: whole days since the record was last touched — keyed off
+   * `updatedAt` when present, falling back to `createdAt` (#1201). A record
+   * edited today must read as fresh even if it was first created weeks ago;
+   * keying age off the original `createdAt` made the freshest record present as
+   * the stalest. `null` when neither timestamp is parseable.
+   */
   ageDays: number | null;
 
   /**
@@ -191,6 +203,14 @@ export interface TrustableRecord {
   validFrom?: string | null;
   validTo?: string | null;
   createdAt?: string | null;
+  /**
+   * The record's own last-write time (#1201 freshness anchor). Falls back to
+   * `createdAt` when absent — a never-updated record has updatedAt == createdAt
+   * anyway (Memory.post stamps them equal on create), so age is unchanged for
+   * those. The record's OWN field only — never inherited from a superseded
+   * predecessor (#1189 field-scoping).
+   */
+  updatedAt?: string | null;
   supersedes?: string | null;
   /**
    * Absolute semantic similarity (cosine in [0,1]) the retrieval core attaches
@@ -237,6 +257,7 @@ export function buildTrustBlock(record: TrustableRecord, now: number = Date.now(
   const validFrom = typeof record.validFrom === "string" ? record.validFrom : null;
   const validTo = typeof record.validTo === "string" ? record.validTo : null;
   const createdAt = typeof record.createdAt === "string" ? record.createdAt : null;
+  const updatedAt = typeof record.updatedAt === "string" ? record.updatedAt : null;
 
   const validToMs = parseTime(validTo);
   const validFromMs = parseTime(validFrom);
@@ -247,9 +268,13 @@ export function buildTrustBlock(record: TrustableRecord, now: number = Date.now(
     validityStatus = "future";
   }
 
-  const createdMs = parseTime(createdAt);
-  const ageDays = Number.isFinite(createdMs)
-    ? Math.max(0, Math.floor((now - createdMs) / MS_PER_DAY))
+  // #1201 — freshness keys off the record's OWN last-write time (updatedAt),
+  // falling back to createdAt. A record updated today must not read as stale
+  // off its original createdAt. updatedAt is the record's own field, so this
+  // reintroduces no lineage-inheritance (#1189).
+  const freshnessMs = parseTime(updatedAt ?? createdAt);
+  const ageDays = Number.isFinite(freshnessMs)
+    ? Math.max(0, Math.floor((now - freshnessMs) / MS_PER_DAY))
     : null;
 
   return {
@@ -263,6 +288,7 @@ export function buildTrustBlock(record: TrustableRecord, now: number = Date.now(
     validFrom,
     validTo,
     createdAt,
+    updatedAt,
     ageDays,
     supersedes: typeof record.supersedes === "string" ? record.supersedes : null,
     // flair#744 refinement — confidence band from the result's absolute

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -15631,7 +15631,13 @@ program
         console.error(`${render.icons.error} No context available.`);
         process.exit(1);
       }
-      const tokensUsed = result.tokenEstimate ?? 0;
+      // flair#1199 — the budget footer reflects the PROSE the human injects
+      // (stdout = result.context), not the full serialized payload. tokenEstimate
+      // now measures the whole response (structured containers + prose), which
+      // the CLI's structured fields the human doesn't read would inflate.
+      const tokensUsed = typeof result.context === "string" && result.context.length > 0
+        ? Math.ceil(result.context.length / 4)
+        : (result.tokenEstimate ?? 0);
       const maxTokens = parseInt(opts.maxTokens, 10);
       const included = result.memoriesIncluded ?? 0;
       const truncated = result.memoriesTruncated ?? 0;

--- a/test/integration/bootstrap-payload-quality-1199.test.ts
+++ b/test/integration/bootstrap-payload-quality-1199.test.ts
@@ -1,0 +1,259 @@
+// ─── flair#1199 / #1200 / #1201 — bootstrap payload quality, proven live ──────
+//
+// These are the three defects a real /mcp connector (claude.ai) surfaced once
+// the #1182 fix made the full bootstrap payload visible:
+//
+//   #1199  DOUBLE SERIALIZATION — the prose `context` embedded every soul/memory
+//          body IN FULL, and the SAME bodies also shipped in the structured
+//          soul/memories/predicted containers, so everything crossed the wire
+//          twice (~2× over maxTokens). tokenEstimate counted only `context`, so
+//          it under-reported; and memoriesIncluded/memoriesAvailable used
+//          different denominators (one client saw included 9 > available 3).
+//   #1200  ORG-EVENT DUPLICATE PAIRS — byte-identical events rendered twice,
+//          wasting ~half the scarce org-event slots.
+//   #1201  FRESHNESS off createdAt (a record edited today read as 12 days stale)
+//          and a matchQuality inconsistency (own lifecycle → null vs teammate →
+//          band, reading as a scoring failure on the caller's own records).
+//
+// Driven through the SHIPPED /mcp `bootstrap` wrapper (TOOLS.bootstrap.impl, via
+// the fixture's generic `mcpTool` op) against a HOME-isolated ephemeral Harper —
+// the exact vantage the connector had. The wrapper defaults includeContext:false
+// (the connector consumes the structured containers), which is the surface the
+// "no bytes twice" proof needs.
+import { describe, expect, test, beforeAll, afterAll } from "bun:test";
+import { mkdtemp, rm, mkdir, cp, symlink } from "node:fs/promises";
+import { randomUUID } from "node:crypto";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { startHarper, stopHarper, HarperInstance } from "../helpers/harper-lifecycle";
+
+const REPO_ROOT = process.cwd();
+const FIXTURE = join(REPO_ROOT, "test", "fixtures", "inproc-app");
+
+let harper: HarperInstance;
+let appDir: string;
+
+const sfx = Date.now().toString(36);
+const AGENT = `boot1199-${sfx}`;
+const TEAMMATE = `boot1199-mate-${sfx}`;
+const SOUL_ROLE = `Payload-quality test subject ${sfx}`;
+
+// Distinctive markers so an assertion can locate a specific body unambiguously.
+const RECENT_MARKER = `RECENT-BODY-${sfx}-${randomUUID()}`;
+const UPDATED_MARKER = `UPDATED-TODAY-BODY-${sfx}-${randomUUID()}`;
+const TEAMMATE_MARKER = `TEAMMATE-BODY-${sfx}-${randomUUID()}`;
+const EVENT_SUMMARY = `dup-event-summary-${sfx}-${randomUUID()}`;
+
+const est = (s: string) => Math.ceil(s.length / 4);
+const nowIso = () => new Date().toISOString();
+const daysAgoIso = (d: number) => new Date(Date.now() - d * 24 * 3600_000).toISOString();
+
+async function fleet(op: string, body: Record<string, unknown> = {}): Promise<any> {
+  const res = await fetch(`${harper.httpURL}/AgentFleet/`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: "Basic " + btoa(`${harper.admin.username}:${harper.admin.password}`),
+    },
+    body: JSON.stringify({ op, ...body }),
+  });
+  const text = await res.text();
+  if (!res.ok) throw new Error(`AgentFleet ${op} → HTTP ${res.status}: ${text.slice(0, 400)}`);
+  return JSON.parse(text);
+}
+
+/** Call the shipped /mcp bootstrap wrapper as AGENT. */
+async function bootstrap(args: Record<string, unknown> = {}): Promise<any> {
+  const res = await fleet("mcpTool", { agentId: AGENT, tool: "bootstrap", args, isAdmin: false });
+  expect(res.ok, `bootstrap failed: ${JSON.stringify(res).slice(0, 500)}`).toBe(true);
+  return res.value;
+}
+
+async function ops(operation: Record<string, unknown>): Promise<{ status: number; body: any }> {
+  const res = await fetch(harper.opsURL, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: "Basic " + btoa(`${harper.admin.username}:${harper.admin.password}`),
+    },
+    body: JSON.stringify(operation),
+  });
+  const text = await res.text();
+  return { status: res.status, body: text ? JSON.parse(text) : null };
+}
+
+async function seedInsert(table: string, record: Record<string, unknown>): Promise<void> {
+  const { status } = await ops({ operation: "insert", database: "flair", table, records: [record] });
+  expect(status, `${table} insert → ${status}`).toBe(200);
+}
+
+beforeAll(async () => {
+  appDir = await mkdtemp(join(tmpdir(), "flair-inproc-boot1199-"));
+  await cp(FIXTURE, appDir, { recursive: true });
+  await mkdir(join(appDir, "node_modules", "@tpsdev-ai"), { recursive: true });
+  await symlink(REPO_ROOT, join(appDir, "node_modules", "@tpsdev-ai", "flair"), "dir");
+  harper = await startHarper({ cwd: appDir, harperBinDir: REPO_ROOT });
+
+  await fleet("register", { id: AGENT });
+  await fleet("register", { id: TEAMMATE });
+
+  await seedInsert("Soul", {
+    id: `${AGENT}:role`, agentId: AGENT, key: "role", value: SOUL_ROLE, createdAt: nowIso(),
+  });
+
+  // A recent (fresh) own memory — used for the "no bytes twice" proof.
+  await seedInsert("Memory", {
+    id: `${AGENT}-${randomUUID()}`, agentId: AGENT, content: RECENT_MARKER,
+    durability: "standard", visibility: "private", createdAt: nowIso(), updatedAt: nowIso(),
+    validFrom: nowIso(),
+  });
+
+  // The #1201 freshness record: created 12 days ago, EDITED today. Permanent so
+  // it is always included regardless of the recent adaptive window.
+  await seedInsert("Memory", {
+    id: `${AGENT}-updated-${randomUUID()}`, agentId: AGENT, content: UPDATED_MARKER,
+    durability: "permanent", visibility: "private",
+    createdAt: daysAgoIso(12), updatedAt: nowIso(), validFrom: daysAgoIso(12),
+  });
+
+  // A teammate's NON-PRIVATE memory (open-within-org read) — gives the
+  // teammateFindings container a real candidate.
+  await seedInsert("Memory", {
+    id: `${TEAMMATE}-${randomUUID()}`, agentId: TEAMMATE, content: TEAMMATE_MARKER,
+    durability: "standard", visibility: "shared", createdAt: nowIso(), updatedAt: nowIso(),
+    validFrom: nowIso(),
+  });
+
+  // #1200 — two BYTE-IDENTICAL org events (same kind+summary+detail+targets),
+  // distinct ids/createdAt (as OrgEvent.post would mint them). Org-scoped (no
+  // targets) so they surface for AGENT.
+  for (let i = 0; i < 2; i++) {
+    await seedInsert("OrgEvent", {
+      id: `${TEAMMATE}-evt-${i}-${randomUUID()}`, authorId: TEAMMATE,
+      kind: "status", summary: EVENT_SUMMARY, scope: "org",
+      createdAt: new Date(Date.now() - (i + 1) * 1000).toISOString(),
+    });
+  }
+}, 300_000);
+
+afterAll(async () => {
+  const dataDir = harper?.installDir;
+  if (harper) await stopHarper(harper);
+  if (dataDir) await rm(dataDir, { recursive: true, force: true, maxRetries: 4 });
+  if (appDir) await rm(appDir, { recursive: true, force: true });
+});
+
+describe("flair#1199/#1200/#1201 — bootstrap payload quality", () => {
+  // (a) #1199 — no field's bytes appear twice by default (/mcp path).
+  test("#1199 (a): by default no body ships twice — content is in the structured containers, NOT re-embedded in context", async () => {
+    const body = await bootstrap({ currentTask: "payload quality check", maxTokens: 8000 });
+
+    // The structured containers are canonical and carry the bodies.
+    expect(Array.isArray(body.memories), "memories is a structured array").toBe(true);
+    const ownContents = body.memories.map((m: any) => m.content);
+    expect(ownContents, "own recent memory is in the structured container").toContain(RECENT_MARKER);
+    expect(body.soul?.role, "soul body is in the structured container").toBe(SOUL_ROLE);
+    expect(Array.isArray(body.teammateFindings), "teammateFindings container present").toBe(true);
+
+    // ...and the prose `context` is a compact pointer, NOT the bodies — so the
+    // same bytes never cross the wire twice on the connector path.
+    expect(typeof body.context, "context is always a string").toBe("string");
+    expect(body.context, "context must NOT re-embed the memory body").not.toContain(RECENT_MARKER);
+    expect(body.context, "context must NOT re-embed the soul body").not.toContain(SOUL_ROLE);
+    expect(body.context, "default context is the structural pointer").toContain("includeContext:true");
+  }, 120_000);
+
+  // (a') opt-in restores the full prose mirror.
+  test("#1199: includeContext:true returns the full prose mirror (bodies in context)", async () => {
+    const body = await bootstrap({ currentTask: "payload quality check", maxTokens: 8000, includeContext: true });
+    expect(body.context, "opt-in prose carries the memory body").toContain(RECENT_MARKER);
+    expect(body.context, "opt-in prose carries the soul body").toContain(SOUL_ROLE);
+  }, 120_000);
+
+  // (b) #1199 — tokenEstimate reflects the ACTUAL payload, and maxTokens bounds it.
+  test("#1199 (b): tokenEstimate matches the real serialized payload, and maxTokens bounds it", async () => {
+    // Seed enough permanent content to overflow a modest cap.
+    for (let i = 0; i < 30; i++) {
+      await seedInsert("Memory", {
+        id: `${AGENT}-bulk-${i}-${randomUUID()}`, agentId: AGENT,
+        content: `bulk permanent memory ${i} ${sfx} ` + "lorem ipsum dolor sit amet ".repeat(12),
+        durability: "permanent", visibility: "private", createdAt: nowIso(), updatedAt: nowIso(),
+        validFrom: nowIso(),
+      });
+    }
+
+    const maxTokens = 3000;
+    const body = await bootstrap({ maxTokens });
+
+    // Honesty: tokenEstimate equals estimateTokens over the exact serialized body
+    // the caller received (minus the wrapper-appended flairVersion + the
+    // tokenEstimate field itself).
+    const { tokenEstimate, flairVersion, ...rest } = body;
+    const measured = est(JSON.stringify(rest));
+    expect(Math.abs(tokenEstimate - measured), `tokenEstimate ${tokenEstimate} vs measured ${measured}`).toBeLessThanOrEqual(5);
+
+    // The bound: the ACTUAL payload stays within maxTokens (the old estimate only
+    // covered `context` and let the structured fields blow past the cap).
+    expect(tokenEstimate, `tokenEstimate ${tokenEstimate} must be ≤ maxTokens ${maxTokens}`).toBeLessThanOrEqual(maxTokens);
+    // The cap actually engaged (proves it's bounding, not just fitting).
+    expect(body.memoriesTruncated, "bulk seed must have forced truncation").toBeGreaterThan(0);
+  }, 180_000);
+
+  // (c) #1199 — coherent counters: included ≤ available (same denominator).
+  test("#1199 (c): memoriesIncluded ≤ memoriesAvailable, teammate findings counted separately", async () => {
+    const body = await bootstrap({ currentTask: "counter coherence", maxTokens: 8000 });
+    expect(typeof body.memoriesAvailable, "memoriesAvailable is a number").toBe("number");
+    expect(typeof body.memoriesIncluded, "memoriesIncluded is a number").toBe("number");
+    expect(
+      body.memoriesIncluded,
+      `own included (${body.memoriesIncluded}) must never exceed own available (${body.memoriesAvailable})`,
+    ).toBeLessThanOrEqual(body.memoriesAvailable);
+    // Cross-agent findings are a SEPARATE denominator — labelled, never folded in.
+    expect(typeof body.teammateFindingsIncluded, "teammateFindingsIncluded is its own counter").toBe("number");
+  }, 120_000);
+
+  // (d) #1200 — org events deduped (scarce slots not wasted on exact dupes).
+  test("#1200 (d): byte-identical org events are deduped to a single slot", async () => {
+    const body = await bootstrap({ maxTokens: 8000, includeContext: true });
+    const eventsSection = body.context.split("## Recent Org Events")[1] ?? "";
+    const occurrences = eventsSection.split(EVENT_SUMMARY).length - 1;
+    expect(
+      occurrences,
+      `the duplicate event pair must render ONCE, not twice — events section:\n${eventsSection.slice(0, 400)}`,
+    ).toBe(1);
+  }, 120_000);
+
+  // (e) #1201 — freshness keys off updatedAt: a record edited today reads fresh.
+  test("#1201 (e): a record updated today shows small ageDays (not its 12-day-old createdAt)", async () => {
+    const body = await bootstrap({ maxTokens: 8000, includeTrust: true });
+    expect(Array.isArray(body.trust), "includeTrust returns a trust array").toBe(true);
+    const updatedEntry = body.trust.find((t: any) => {
+      const m = body.memories.find((mm: any) => mm.id === t.id);
+      return m && m.content === UPDATED_MARKER;
+    });
+    expect(updatedEntry, "the updated-today record must have a trust block").toBeDefined();
+    expect(
+      updatedEntry.ageDays,
+      `updated-today record must read as FRESH (ageDays off updatedAt), got ${updatedEntry.ageDays}`,
+    ).toBeLessThanOrEqual(1);
+  }, 120_000);
+
+  // (f) #1201 — matchQuality is consistent: determined by SURFACE (section), not
+  // by ownership. Every trust entry is section-tagged, and lifecycle sections
+  // (not a retrieval surface) carry null uniformly — so own-recent null no longer
+  // reads as a scoring failure next to a teammate band.
+  test("#1201 (f): trust entries are section-tagged; matchQuality is null on lifecycle sections for own AND teammate alike", async () => {
+    const body = await bootstrap({ currentTask: "match quality consistency", maxTokens: 8000, includeTrust: true });
+    expect(body.trust.length, "there is at least one trust entry to check").toBeGreaterThan(0);
+    const lifecycle = new Set(["permanent", "recent", "predicted"]);
+    for (const t of body.trust) {
+      expect(typeof t.section, `every trust entry carries a section, got ${JSON.stringify(t).slice(0, 120)}`).toBe("string");
+      if (lifecycle.has(t.section)) {
+        expect(
+          t.matchQuality,
+          `lifecycle section '${t.section}' must carry matchQuality null (not a retrieval surface), got ${t.matchQuality}`,
+        ).toBeNull();
+      }
+    }
+  }, 120_000);
+});

--- a/test/unit/trust-block.test.ts
+++ b/test/unit/trust-block.test.ts
@@ -144,6 +144,25 @@ describe("buildTrustBlock — freshness / validity", () => {
   it("ageDays is null when createdAt is absent", () => {
     expect(buildTrustBlock({ agentId: "a" }, NOW).ageDays).toBeNull();
   });
+
+  it("#1201 — ageDays keys off updatedAt (freshness), not the original createdAt", () => {
+    // Created 12 days ago, edited today: the record is fresh, and must read as
+    // fresh — keying age off createdAt alone made the freshest record present
+    // as the stalest.
+    const created = new Date(NOW - 12 * DAY).toISOString();
+    const updated = new Date(NOW).toISOString();
+    const b = buildTrustBlock({ agentId: "a", createdAt: created, updatedAt: updated }, NOW);
+    expect(b.ageDays).toBe(0);       // fresh — off updatedAt
+    expect(b.createdAt).toBe(created); // raw createdAt still preserved
+    expect(b.updatedAt).toBe(updated);
+  });
+
+  it("#1201 — ageDays falls back to createdAt when updatedAt is absent", () => {
+    const created = new Date(NOW - 3 * DAY).toISOString();
+    const b = buildTrustBlock({ agentId: "a", createdAt: created }, NOW);
+    expect(b.ageDays).toBe(3);
+    expect(b.updatedAt).toBeNull();
+  });
 });
 
 describe("buildTrustBlock — supersession", () => {


### PR DESCRIPTION
Fixes three bootstrap-payload quality defects a real /mcp connector (claude.ai) surfaced once #1182 made the full payload visible. All three live in the `BootstrapMemories.post` payload assembly.

## #1199 — double-serialization, token accounting, incoherent counters
- **Double serialization (root cause):** the prose `context` embedded every soul entry and memory body IN FULL, and the same bodies also shipped in the structured `soul`/`memories`/`predicted` containers — everything crossed the wire twice.
  - **Fix:** the structured containers are now canonical. The prose `context` is an opt-in mirror via a new `includeContext` param. It defaults **true** on the resource (REST/CLI/Ed25519 callers rely on the prose, and the whole scoping test suite asserts against it), but the **/mcp bootstrap wrapper passes `includeContext: false` by default** — so the token-budgeted connector, which consumes the structured fields, never receives the same bytes twice. When off, `context` is a compact structural pointer (always a string, never re-embedding bodies).
  - Teammate findings previously lived ONLY in `context`; they now have a structured home — a new `teammateFindings` container — so they survive the no-prose path.
- **tokenEstimate wrong (root cause):** the old estimate was `soulTokens + memoryTokens`, counting only the `context` string — it ignored the duplicated structured fields, and soul was budgeted *on top of* the memory budget (so `context` alone could reach ~1.4× maxTokens).
  - **Fix:** `tokenEstimate` now measures the actual serialized payload. Soul is folded into a single shared token budget, a per-item structured-overhead charge accounts for the container JSON keys, and a scaffolding reserve keeps the real payload within `maxTokens`.
- **Incoherent counters (root cause):** `memoriesIncluded` counted own + teammate (cross-agent) findings, while `memoriesAvailable` was own-scoped — so included could exceed available (one client saw 9 vs 3).
  - **Fix:** `memoriesIncluded` is now own-scoped (permanent + recent + predicted + own task-relevant), so `memoriesIncluded <= memoriesAvailable` always holds. Cross-agent hits are counted separately as `teammateFindingsIncluded`.
- **Minor:** a `predictedHint` is emitted when `subjects` were provided but `predicted` came back empty, so `predicted: []` next to non-empty `subjects` no longer reads as broken.

## #1200 — org-events duplicate pairs
The single-write path persists exactly one row per call (proven by the existing wrapper suite), so byte-identical duplicates come from multi-producer / repeated emissions at the source. Since org-event slots are scarce and the render is the common choke point, deduped **at render**: events are collapsed by content signature (kind + summary + detail + targets, keeping the most-recent) BEFORE the 10-slot cutoff, so duplicates never waste slots.

## #1201 — freshness + matchQuality
- **Freshness (root cause):** `ageDays` in the trust block keyed off `createdAt`, so a record edited today (createdAt 12 days old) read as 12 days stale.
  - **Fix:** freshness keys off the record's own `updatedAt`, falling back to `createdAt`. `updatedAt` is now projected on the own-memory read path and carried on the structured containers. Uses the record's own field only — no lineage inheritance (#1189).
- **matchQuality inconsistency:** own lifecycle memories carried `matchQuality: null` while teammate findings carried a band, reading as a scoring failure on the caller's own records.
  - **Fix:** every bootstrap trust entry is now tagged with its `section`. `matchQuality` is determined by surface, not ownership: lifecycle sections (permanent/recent/predicted — not a retrieval surface) carry null uniformly for own and teammate alike; retrieval sections carry a band. The section tag makes a null legible ("lifecycle load") rather than a failure.

## Tests
New `test/integration/bootstrap-payload-quality-1199.test.ts` drives the shipped /mcp bootstrap wrapper against a HOME-isolated ephemeral Harper and asserts: (a) no body ships twice by default; (b) `tokenEstimate` matches the real payload and `maxTokens` bounds it; (c) `memoriesIncluded <= memoriesAvailable`; (d) org events deduped; (e) an updated-today record shows small `ageDays`; (f) trust entries are section-tagged and `matchQuality` is null on lifecycle sections. Freshness and dedup fixes were mutation-checked (both fail when reverted). Added unit coverage for the `updatedAt` freshness anchor in `test/unit/trust-block.test.ts`.

Fast unit suite: 4129 pass / 0 fail. New + existing /mcp bootstrap + resource-path scoping suites: 42 pass / 0 fail. All 7 docs-freshness checks pass.

Closes #1199
Closes #1200
Closes #1201
