### PR TITLE
fix(cli): detect flair-mcp by wiring; add Antigravity (agy) MCP client

### DIFF
--- a/.changelog/unreleased/added-antigravity-mcp-client.md
+++ b/.changelog/unreleased/added-antigravity-mcp-client.md
@@ -1,0 +1,7 @@
+- **Added the Antigravity CLI (`agy`) as a wire-able MCP client.** `flair init`,
+  `flair doctor` and the client registry now detect Antigravity and can write
+  the pinned `flair-mcp` server into its MCP config at
+  `~/.gemini/config/mcp_config.json` (a sibling of, and distinct from, Gemini
+  CLI's `~/.gemini/settings.json`). Note: the end-to-end wiring has not yet been
+  verified against a live `agy` — after wiring, restart Antigravity and confirm
+  the flair tools appear.

--- a/.changelog/unreleased/fixed-flair-mcp-upgrade-detection.md
+++ b/.changelog/unreleased/fixed-flair-mcp-upgrade-detection.md
@@ -1,0 +1,9 @@
+- **`flair upgrade` no longer reports a correctly-wired `flair-mcp` as "not
+  detected".** It used to probe `flair-mcp` as a global npm install, but
+  `flair-mcp` is zero-install via `npx` and is never installed globally — so a
+  correctly-wired machine was told it was missing, with an `npm install -g`
+  remedy that does nothing. Upgrade now detects `flair-mcp` by its actual wiring
+  (the pinned version in a wired MCP client config, or the presence of the Flair
+  SessionStart hook) and shows that version against the latest. "Missing" now
+  means not wired anywhere; the remedy for a wired-but-behind or unwired
+  `flair-mcp` is `flair doctor --fix`, never a global install.

--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -15,6 +15,7 @@ Where Flair already runs. Each integration shown here is a working surface — t
 | **Continue.dev** | [`flair-mcp`](#claude-code-cursor-codex-gemini-cli-continuedev-via-flair-mcp) | MCP config | Standard MCP server |
 | **OpenAI Codex CLI** | [`flair-mcp`](#claude-code-cursor-codex-gemini-cli-continuedev-via-flair-mcp) | MCP config | Standard MCP server |
 | **Gemini CLI** | [`flair-mcp`](#claude-code-cursor-codex-gemini-cli-continuedev-via-flair-mcp) | MCP config | Standard MCP server |
+| **Antigravity CLI** (`agy`) | [`flair-mcp`](#claude-code-cursor-codex-gemini-cli-continuedev-via-flair-mcp) | MCP config | `~/.gemini/config/mcp_config.json`; pickup by a live `agy` pending verification |
 | **Goose** (block/goose) | [`flair-mcp`](#claude-code-cursor-codex-gemini-cli-continuedev-via-flair-mcp) | MCP config | Goose ships native MCP support |
 | **LangGraph (TS)** | [`langgraph-flair`](#langgraph-typescript) | FlairClient | Drop-in `BaseStore` |
 | **OpenClaw** | [`openclaw-flair`](#openclaw) | Ed25519 | Native plugin + context engine |
@@ -68,6 +69,8 @@ FLAIR_AGENT_ID = "codex"
 ```
 
 **Gemini CLI** (`~/.gemini/settings.json`): same shape as Cursor.
+
+**Antigravity CLI** (`agy`) (`~/.gemini/config/mcp_config.json` — Antigravity's own MCP config, separate from Gemini CLI's `settings.json`): same shape as Cursor. Newly added; the config path follows Antigravity's documentation, but Flair has not yet verified end-to-end pickup by a live `agy` — after wiring, restart Antigravity and confirm the flair tools appear.
 
 **Continue.dev** (`~/.continue/config.json`):
 ```json

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -54,8 +54,8 @@ import {
   type FleetSweepResult,
 } from "./fleet-verify.js";
 import { markStale, sortOldestVersionFirst, type FleetPresenceRow } from "./fleet-presence.js";
-import { detectClients, renderWiringSummary, wireClaudeCode, wireCodex, wireGemini, wireCursor, clientConfigPath, codexConfigHasFlairSection, type ClientId } from "./install/clients.js";
-import { flairCliVersion, clearFlairCliVersionCache, mcpServerSpec, unpinnedSpecWarning } from "./lib/mcp-spec.js";
+import { detectClients, renderWiringSummary, wireClaudeCode, wireCodex, wireGemini, wireCursor, wireAntigravity, clientConfigPath, codexConfigHasFlairSection, type ClientId } from "./install/clients.js";
+import { flairCliVersion, clearFlairCliVersionCache, mcpServerSpec, unpinnedSpecWarning, FLAIR_MCP_PACKAGE } from "./lib/mcp-spec.js";
 import {
   resolveAgentKeyPath,
   loadEd25519PrivateKeyFromFile,
@@ -81,6 +81,7 @@ import {
 import {
   readClientMcpBlock,
   checkClaudeMdBootstrap,
+  detectWiredFlairMcp,
   inspectSessionStartHook,
   upgradeSessionStartHookCommand,
   fixClaudeMdBootstrap,
@@ -2783,12 +2784,61 @@ export function shouldPrintUpgradeLine(status: UpgradeStatus, showAll: boolean):
 export function upgradeStatusSuffix(name: string, status: UpgradeStatus): string {
   if (status === "current") return " (current)";
   if (status === "missing") {
-    return name === "@tpsdev-ai/flair-mcp"
+    return name === FLAIR_MCP_PACKAGE
       ? " (zero-install via npx — run: flair doctor --fix)"
       : " (run: npm install -g)";
   }
   if (status === "optional") return " (install via: openclaw plugins install @tpsdev-ai/openclaw-flair)";
+  // flair-mcp is refreshed by re-pinning its wiring (`flair doctor --fix` /
+  // the post-upgrade pin refresh), never `npm install -g` — a global bin does
+  // nothing for an `npx -y -p @tpsdev-ai/flair-mcp` invocation (flair#1208).
+  if (status === "outdated" && name === FLAIR_MCP_PACKAGE) {
+    return " (npx-wired — run: flair doctor --fix to re-pin)";
+  }
   return "";
+}
+
+/**
+ * Resolve the `flair upgrade` finding for flair-mcp from its ACTUAL wiring,
+ * not a global-install probe (flair#1208).
+ *
+ * flair-mcp is zero-install via npx (#1168): a correctly-wired machine never
+ * installs it globally, so the global bin/lib probe returning null is the
+ * NORMAL state, not "missing". Its real installed version is the pin its wiring
+ * carries (a client MCP config's args, refreshed by `flair doctor --fix`).
+ *
+ * Resolution order:
+ *   1. Legacy global install — the bin/lib probe found a version. Honor it.
+ *   2. Not wired anywhere — genuinely missing; the remedy (upgradeStatusSuffix)
+ *      is `flair doctor --fix`, never `npm install -g`.
+ *   3. Wired with a concrete pin — that pin IS the installed version
+ *      (current when it equals latest, else outdated → re-pin via doctor).
+ *   4. Wired but unpinned (a bare npx spec / the SessionStart hook) — `npx -y`
+ *      re-resolves latest every session, so the effective version IS latest →
+ *      current.
+ */
+export function resolveFlairMcpFinding(
+  globalProbe: string | null,
+  latest: string,
+  wiring: { wired: boolean; pinnedVersion: string | null },
+): { installed: string | null; status: UpgradeStatus } {
+  // 1. Legacy global install.
+  if (globalProbe !== null) {
+    return { installed: globalProbe, status: globalProbe === latest ? "current" : "outdated" };
+  }
+  // 2. Not wired anywhere.
+  if (!wiring.wired) {
+    return { installed: null, status: "missing" };
+  }
+  // 3. Wired with a pin.
+  if (wiring.pinnedVersion) {
+    return {
+      installed: wiring.pinnedVersion,
+      status: wiring.pinnedVersion === latest ? "current" : "outdated",
+    };
+  }
+  // 4. Wired but unpinned — npx resolves latest on every session.
+  return { installed: latest, status: "current" };
 }
 
 /**
@@ -3132,7 +3182,7 @@ program
   .option("--data-dir <dir>", "Harper data directory")
   .option("--skip-start", "Skip Harper startup (assume already running)")
   .option("--skip-soul", "Skip interactive personality setup")
-  .option("--client <client>", "MCP client(s) to wire: claude-code, codex, gemini, cursor, all, or none")
+  .option("--client <client>", "MCP client(s) to wire: claude-code, codex, gemini, cursor, antigravity, all, or none")
   .option("--no-mcp", "Skip MCP client wiring (instance + agent only)")
   .option("--skip-smoke", "Skip the MCP smoke test")
   .option("--skip-claude-md", "Skip appending the Flair bootstrap line to CLAUDE.md (claude-code only)")
@@ -3360,9 +3410,9 @@ program
     const noMcp = opts.mcp === false;
     const selectedClients: ClientId[] = [];
     if (clientOpt && clientOpt !== "all" && clientOpt !== "none" && !noMcp) {
-      const valid: ClientId[] = ["claude-code", "codex", "gemini", "cursor"];
+      const valid: ClientId[] = ["claude-code", "codex", "gemini", "cursor", "antigravity"];
       if (!valid.includes(clientOpt as ClientId)) {
-        console.error(`Unknown client: ${clientOpt}. Valid: claude-code, codex, gemini, cursor, all, none`);
+        console.error(`Unknown client: ${clientOpt}. Valid: claude-code, codex, gemini, cursor, antigravity, all, none`);
         process.exit(1);
       }
       selectedClients.push(clientOpt as ClientId);
@@ -3959,6 +4009,7 @@ program
               case "codex": result = wireCodex({ ...mcpEnv, FLAIR_CLIENT: "codex" }); break;
               case "gemini": result = wireGemini({ ...mcpEnv, FLAIR_CLIENT: "gemini" }); break;
               case "cursor": result = wireCursor({ ...mcpEnv, FLAIR_CLIENT: "cursor" }); break;
+              case "antigravity": result = wireAntigravity({ ...mcpEnv, FLAIR_CLIENT: "antigravity" }); break;
               default: result = { ok: false, message: `Unknown client: ${clientId}` };
             }
             wiringResults.push({ client: clientId, message: result.message, wired: result.ok });
@@ -10505,16 +10556,27 @@ program
           try { primeVersionCheckCache(latest); } catch { /* best-effort */ }
         }
 
-        const installed = probe();
+        const globalProbe = probe();
+        let installed: string | null;
         let status: Status;
-        if (installed === null) {
-          // openclaw-plugin packages are optional — if openclaw isn't
-          // installed, don't surface a misleading "install with npm" advice.
-          status = kind === "openclaw-plugin" ? "optional" : "missing";
-        } else if (installed === latest) {
-          status = "current";
+        if (name === FLAIR_MCP_PACKAGE) {
+          // flair-mcp is zero-install via npx (#1168) — a null global probe is
+          // the NORMAL state, not "missing". Resolve it from its actual wiring
+          // (the pin in a client MCP config / the SessionStart hook) so the
+          // listing is truthful and the remedy actually works (flair#1208).
+          const home = process.env.HOME ?? homedir();
+          ({ installed, status } = resolveFlairMcpFinding(globalProbe, latest, detectWiredFlairMcp(home)));
         } else {
-          status = "outdated";
+          installed = globalProbe;
+          if (installed === null) {
+            // openclaw-plugin packages are optional — if openclaw isn't
+            // installed, don't surface a misleading "install with npm" advice.
+            status = kind === "openclaw-plugin" ? "optional" : "missing";
+          } else if (installed === latest) {
+            status = "current";
+          } else {
+            status = "outdated";
+          }
         }
         findings.push({ name, installed, latest, status, kind });
 
@@ -10541,12 +10603,19 @@ program
 
     const outdated = findings.filter((f) => f.status === "outdated");
     const missing = findings.filter((f) => f.status === "missing");
+    // flair-mcp is refreshed by re-pinning its wiring (`flair doctor --fix` /
+    // the post-upgrade pin refresh below), NEVER `npm install -g` — a global
+    // bin does nothing for an `npx -y -p @tpsdev-ai/flair-mcp` invocation
+    // (#1168/#1208). So a stale-pinned flair-mcp drives a remedy line, not the
+    // npm-install + restart transaction. It is kept out of npmUpgrades here and
+    // surfaced separately below.
+    const flairMcpOutdated = outdated.find((f) => f.name === FLAIR_MCP_PACKAGE) ?? null;
     // openclaw plugins upgrade through `openclaw plugins install`, not `npm
     // install -g` (npm-installed wouldn't connect to OpenClaw's gateway slot).
     // Split outdated into npm-upgradeable vs openclaw-plugin so we can use
     // the right command for each.
     const npmUpgrades = outdated
-      .filter((f) => f.kind !== "openclaw-plugin")
+      .filter((f) => f.kind !== "openclaw-plugin" && f.name !== FLAIR_MCP_PACKAGE)
       .map(({ name, installed, latest }) => ({ pkg: name, installed: installed ?? "unknown", latest }));
     const openclawUpgrades = outdated
       .filter((f) => f.kind === "openclaw-plugin")
@@ -10558,15 +10627,26 @@ program
       return;
     }
 
-    if (missing.length > 0 && outdated.length === 0) {
-      const npmMissing = missing.filter((f) => f.name !== "@tpsdev-ai/flair-mcp");
-      const mcpMissing = missing.filter((f) => f.name === "@tpsdev-ai/flair-mcp");
-      console.log(`\n❔ ${missing.length} package${missing.length > 1 ? "s" : ""} not detected — all detected packages are up to date.`);
-      if (npmMissing.length > 0) {
-        console.log(`   Install missing: npm install -g ${npmMissing.map((f) => f.name).join(" ")}`);
+    // Nothing to install via npm/openclaw. What is left is advisory: packages
+    // not detected (missing) and/or a flair-mcp whose wired pin is behind latest
+    // — both fixed by re-wiring (`flair doctor --fix`), never by the
+    // npm-install + restart transaction below (#1168/#1208). Print the remedies
+    // and stop.
+    if (totalUpgrades === 0) {
+      if (missing.length > 0) {
+        const npmMissing = missing.filter((f) => f.name !== FLAIR_MCP_PACKAGE);
+        const mcpMissing = missing.some((f) => f.name === FLAIR_MCP_PACKAGE);
+        console.log(`\n❔ ${missing.length} package${missing.length > 1 ? "s" : ""} not detected — all detected packages are up to date.`);
+        if (npmMissing.length > 0) {
+          console.log(`   Install missing: npm install -g ${npmMissing.map((f) => f.name).join(" ")}`);
+        }
+        if (mcpMissing) {
+          console.log(`   flair-mcp is zero-install via npx — run: flair doctor --fix to wire the hook`);
+        }
       }
-      if (mcpMissing.length > 0) {
-        console.log(`   flair-mcp is zero-install via npx — run: flair doctor --fix to re-wire the hook`);
+      if (flairMcpOutdated) {
+        console.log(`\n⬆️  flair-mcp is wired via npx (pinned ${flairMcpOutdated.installed} → latest ${flairMcpOutdated.latest}).`);
+        console.log(`   Re-pin it: flair doctor --fix`);
       }
       return;
     }
@@ -13209,6 +13289,7 @@ program
                     client.id === "claude-code" ? wireClaudeCode(wireEnv) :
                     client.id === "codex" ? wireCodex(wireEnv) :
                     client.id === "gemini" ? wireGemini(wireEnv) :
+                    client.id === "antigravity" ? wireAntigravity(wireEnv) :
                     wireCursor(wireEnv);
                   console.log(`     ${wireResult.ok ? render.icons.ok : render.icons.warn} ${wireResult.message}`);
                   if (wireResult.ok) fixed++;

--- a/src/doctor-client.ts
+++ b/src/doctor-client.ts
@@ -23,7 +23,8 @@
 import { spawnSync } from "node:child_process";
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { dirname, join } from "node:path";
-import { clientConfigPath, type ClientId } from "./install/clients.js";
+import { ALL_CLIENTS, clientConfigPath, type ClientId } from "./install/clients.js";
+import { FLAIR_MCP_PACKAGE } from "./lib/mcp-spec.js";
 
 // The exact substring `flair init` writes into CLAUDE.md (src/cli.ts, the
 // `init` action) and that the doctor check + fix both key off of.
@@ -402,6 +403,80 @@ export function checkSessionStartHook(homeDir: string): SessionStartHookCheckRes
   } catch {
     return { present: false, path };
   }
+}
+
+// ── flair-mcp presence by WIRING, not global install (flair#1208) ───────────
+//
+// flair-mcp is zero-install via npx by design (#1168): a correctly-wired
+// machine invokes it as `npx -y -p @tpsdev-ai/flair-mcp` and NEVER installs it
+// globally, so `flair upgrade`'s global bin/lib probe finds nothing and
+// mis-reports it "not detected." Its real "installed version" is the pin its
+// wiring carries — the mcpServerSpec() written into a client's MCP config
+// (pinned since #1135). Detect it there instead.
+
+/**
+ * Extract a pinned `@tpsdev-ai/flair-mcp` version from any wiring string — a
+ * client MCP `args` array, a Codex TOML args line, or a SessionStart hook
+ * command. Returns the version when the spec is written
+ * `@tpsdev-ai/flair-mcp@<ver>`; null for a bare/unpinned spec.
+ *
+ * The SessionStart hook is deliberately unpinned (`npx -y -p
+ * @tpsdev-ai/flair-mcp`, buildSessionStartHookCommand above), so a hook
+ * establishes that flair-mcp is wired but never carries a version — the pin
+ * comes from the client MCP config.
+ */
+export function extractFlairMcpPin(text: string): string | null {
+  if (typeof text !== "string") return null;
+  // `@tpsdev-ai/flair-mcp@<version>`; the version token runs until the first
+  // character that can't appear in a spec embedded in JSON args / TOML.
+  const m = text.match(/@tpsdev-ai\/flair-mcp@([0-9A-Za-z][^\s"'\],]*)/);
+  return m ? m[1]! : null;
+}
+
+/**
+ * flair-mcp's presence resolved from its actual wiring rather than a global
+ * install probe (flair#1208).
+ *
+ * `wired` is true when a Flair SessionStart hook OR any known client's MCP
+ * config references the flair-mcp package. `pinnedVersion` is the concrete
+ * version pinned in that wiring, or null when the only wiring found is unpinned
+ * (a bare npx spec / the SessionStart hook).
+ *
+ * Iterates the SAME client registry (ALL_CLIENTS) and per-client config paths
+ * (clientConfigPath) that wiring uses, so a client added to the registry is
+ * scanned here automatically — no second list to keep in step.
+ */
+export interface FlairMcpWiring {
+  wired: boolean;
+  pinnedVersion: string | null;
+}
+
+export function detectWiredFlairMcp(homeDir: string): FlairMcpWiring {
+  let wired = false;
+  let pinnedVersion: string | null = null;
+
+  // The package name only ever appears in a Flair MCP wiring block, so its
+  // presence in a config's text is a reliable "flair-mcp is wired here" signal.
+  const note = (text: string | null | undefined): void => {
+    if (!text || !text.includes(FLAIR_MCP_PACKAGE)) return;
+    wired = true;
+    if (!pinnedVersion) {
+      const pin = extractFlairMcpPin(text);
+      if (pin) pinnedVersion = pin;
+    }
+  };
+
+  // 1. The SessionStart hook (claude-code). Establishes wiring; unpinned by design.
+  const hook = checkSessionStartHook(homeDir);
+  if (hook.present && isFlairHookCommand(hook.command ?? "")) note(hook.command);
+
+  // 2. Every known client's MCP config — a wired flair block carries the spec.
+  for (const client of ALL_CLIENTS) {
+    const configPath = withHome(homeDir, () => clientConfigPath(client.id));
+    note(readTextFile(configPath));
+  }
+
+  return { wired, pinnedVersion };
 }
 
 /**

--- a/src/install/clients.ts
+++ b/src/install/clients.ts
@@ -233,9 +233,16 @@ function wireJsonMcp(
   configPath: string,
   label: string,
   env: WireEnv,
+  // The parenthetical appended to a successful wire/refresh message. Defaults to
+  // the confident "restart <label> to pick it up". A client whose end-to-end
+  // pickup Flair has NOT verified (Antigravity — flair#1209) passes an honest
+  // note instead, so the message claims only what it did (wrote the config), not
+  // that the client will read it.
+  pickupNote?: string,
 ): { ok: boolean; message: string } {
   const home = resolveHome();
   const display = configPath.startsWith(home) ? "~" + configPath.slice(home.length) : configPath;
+  const note = pickupNote ?? `restart ${label} to pick it up`;
   try {
     let config: any = {};
     if (existsSync(configPath)) {
@@ -257,7 +264,7 @@ function wireJsonMcp(
     mkdirSync(dirname(configPath), { recursive: true });
     writeFileSync(configPath, JSON.stringify(config, null, 2) + "\n");
     const action = urlAgentMatch ? "refreshed pin in" : "wired";
-    return { ok: true, message: `${label}: ${action} ${display} (restart ${label} to pick it up)` };
+    return { ok: true, message: `${label}: ${action} ${display} (${note})` };
   } catch (err: unknown) {
     const reason = err instanceof Error ? err.message : String(err);
     return {
@@ -391,8 +398,19 @@ function _wireCursor(env: WireEnv): { ok: boolean; message: string } {
 // Antigravity uses the same standard JSON `mcpServers` stdio schema as Gemini/
 // Cursor (command/args/env), so wireJsonMcp merges into it byte-identically —
 // only the config PATH differs (flair#1209).
+//
+// The success message deliberately does NOT claim "restart Antigravity to pick
+// it up": Flair writes the config to the documented path, but has not verified
+// end-to-end that a live `agy` reads it. So the message claims only the write,
+// and asks the user to confirm pickup (flair#1209 review — honesty on an
+// unverified integration).
 function _wireAntigravity(env: WireEnv): { ok: boolean; message: string } {
-  return wireJsonMcp(antigravityConfigPath(), "Antigravity", env);
+  return wireJsonMcp(
+    antigravityConfigPath(),
+    "Antigravity",
+    env,
+    "wiring unverified against a real agy — restart Antigravity and confirm the flair tools appear",
+  );
 }
 
 // ---- Exported detection & wiring array ------------------------------------------

--- a/src/install/clients.ts
+++ b/src/install/clients.ts
@@ -14,7 +14,7 @@
 //   All paths are resolved cross-platform (Linux included) via standard
 //   per-client locations under $HOME / $XDG_CONFIG_HOME.
 
-export type ClientId = "claude-code" | "codex" | "gemini" | "cursor";
+export type ClientId = "claude-code" | "codex" | "gemini" | "cursor" | "antigravity";
 
 /**
  * The env block every wire function writes into a client's MCP server config.
@@ -290,6 +290,24 @@ function codexConfigPath(): string {
 }
 
 /**
+ * Antigravity CLI (`agy`) + Antigravity 2.0 IDE + SDK: they share ONE central
+ * MCP config at ~/.gemini/config/mcp_config.json on every OS (flair#1209).
+ *
+ * This is a SIBLING of, and distinct from, Gemini CLI's ~/.gemini/settings.json
+ * (geminiConfigPath above) — both tools live under ~/.gemini but read different
+ * files, so wiring one never touches the other. Same standard `mcpServers`
+ * stdio schema (command/args/env) the JSON clients above use.
+ *
+ * Path per Antigravity's own docs (antigravity.google/docs/mcp) and a Google
+ * Developer Advocate write-up (atamel.dev "Where does Antigravity look for MCP
+ * Servers?"). NOTE: the end-to-end wiring has NOT been verified against a real
+ * `agy` install — see the PR body.
+ */
+function antigravityConfigPath(): string {
+  return join(resolveHome(), ".gemini", "config", "mcp_config.json");
+}
+
+/**
  * Single dispatcher for "where does this client's MCP config live" — used by
  * `flair doctor`'s client-integration checks (flair#588) to read the config
  * without duplicating the per-client path logic that already lives here.
@@ -305,6 +323,8 @@ export function clientConfigPath(id: ClientId): string {
       return geminiConfigPath();
     case "cursor":
       return cursorConfigPath();
+    case "antigravity":
+      return antigravityConfigPath();
   }
 }
 
@@ -368,6 +388,13 @@ function _wireCursor(env: WireEnv): { ok: boolean; message: string } {
   return wireJsonMcp(cursorConfigPath(), "Cursor", env);
 }
 
+// Antigravity uses the same standard JSON `mcpServers` stdio schema as Gemini/
+// Cursor (command/args/env), so wireJsonMcp merges into it byte-identically —
+// only the config PATH differs (flair#1209).
+function _wireAntigravity(env: WireEnv): { ok: boolean; message: string } {
+  return wireJsonMcp(antigravityConfigPath(), "Antigravity", env);
+}
+
 // ---- Exported detection & wiring array ------------------------------------------
 
 export const ALL_CLIENTS: Omit<Client, "detected">[] = [
@@ -394,6 +421,13 @@ export const ALL_CLIENTS: Omit<Client, "detected">[] = [
     label: "Cursor",
     bin: "cursor",
     wire: _wireCursor,
+  },
+  {
+    id: "antigravity",
+    label: "Antigravity",
+    // Google's Antigravity CLI — the executable is `agy` (flair#1209).
+    bin: "agy",
+    wire: _wireAntigravity,
   },
 ];
 
@@ -512,4 +546,10 @@ export function wireCursor(
   env: WireEnv
 ): { ok: boolean; message: string } {
   return _wireCursor(env);
+}
+
+export function wireAntigravity(
+  env: WireEnv
+): { ok: boolean; message: string } {
+  return _wireAntigravity(env);
 }

--- a/test/unit/antigravity-client.test.ts
+++ b/test/unit/antigravity-client.test.ts
@@ -1,0 +1,128 @@
+// flair#1209 — add the Antigravity CLI (`agy`) as a wire-able MCP client.
+//
+// Antigravity (the agy CLI + the 2.0 IDE + the SDK) share one central MCP config
+// at ~/.gemini/config/mcp_config.json (per antigravity.google/docs/mcp and
+// atamel.dev "Where does Antigravity look for MCP Servers?"). It uses the same
+// standard JSON `mcpServers` stdio schema (command/args/env) as Gemini/Cursor.
+//
+// HONESTY: these tests exercise config-path resolution + JSON serialization
+// only. End-to-end wiring against a real `agy` install is UNVERIFIED (agy not
+// present in CI/this host) — see the PR body.
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, rmSync, existsSync, readFileSync, mkdirSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  wireAntigravity,
+  clientConfigPath,
+  detectClients,
+  ALL_CLIENTS,
+} from "../../src/install/clients.ts";
+import { readClientMcpBlock, detectWiredFlairMcp } from "../../src/doctor-client.ts";
+
+const ENV = { FLAIR_AGENT_ID: "wirebot", FLAIR_URL: "http://127.0.0.1:19926" };
+
+/** This repo's real version, read straight from package.json — the pin the
+ *  wire function must write. Independent of mcpServerSpec() so a regression that
+ *  unpins BOTH writer and helper still fails here. */
+const PKG_VERSION: string = JSON.parse(
+  readFileSync(join(import.meta.dirname, "..", "..", "package.json"), "utf-8"),
+).version;
+
+let isoHome: string;
+let prevHome: string | undefined;
+
+beforeEach(() => {
+  isoHome = mkdtempSync(join(tmpdir(), "flair-antigravity-home-"));
+  prevHome = process.env.HOME;
+  process.env.HOME = isoHome;
+});
+
+afterEach(() => {
+  if (prevHome !== undefined) process.env.HOME = prevHome;
+  else delete process.env.HOME;
+  rmSync(isoHome, { recursive: true, force: true });
+});
+
+describe("Antigravity client registration (flair#1209)", () => {
+  it("is in the client registry with the `agy` bin", () => {
+    const antigravity = ALL_CLIENTS.find((c) => c.id === "antigravity");
+    expect(antigravity).toBeDefined();
+    expect(antigravity!.bin).toBe("agy");
+    expect(antigravity!.label).toBe("Antigravity");
+    // detectClients() must surface it (detected flag driven by `agy` on PATH).
+    expect(detectClients().some((c) => c.id === "antigravity")).toBe(true);
+  });
+
+  it("clientConfigPath resolves to ~/.gemini/config/mcp_config.json", () => {
+    expect(clientConfigPath("antigravity")).toBe(
+      join(isoHome, ".gemini", "config", "mcp_config.json"),
+    );
+  });
+
+  it("config path is DISTINCT from Gemini CLI's settings.json (no collision under ~/.gemini)", () => {
+    expect(clientConfigPath("antigravity")).not.toBe(clientConfigPath("gemini"));
+    expect(clientConfigPath("gemini")).toBe(join(isoHome, ".gemini", "settings.json"));
+  });
+
+  it("wires ~/.gemini/config/mcp_config.json with the pinned flair MCP stdio server", () => {
+    const res = wireAntigravity(ENV);
+    expect(res.ok).toBe(true);
+    const cfgPath = join(isoHome, ".gemini", "config", "mcp_config.json");
+    expect(existsSync(cfgPath)).toBe(true);
+    const cfg = JSON.parse(readFileSync(cfgPath, "utf-8"));
+    expect(cfg.mcpServers.flair.command).toBe("npx");
+    // Pinned per #1135/#907 — same guarantee the other JSON clients get.
+    expect(cfg.mcpServers.flair.args).toEqual(["-y", `@tpsdev-ai/flair-mcp@${PKG_VERSION}`]);
+    expect(cfg.mcpServers.flair.env.FLAIR_AGENT_ID).toBe("wirebot");
+    expect(cfg.mcpServers.flair.env.FLAIR_URL).toBe(ENV.FLAIR_URL);
+  });
+
+  it("does NOT touch Gemini's ~/.gemini/settings.json when wiring Antigravity", () => {
+    wireAntigravity(ENV);
+    expect(existsSync(join(isoHome, ".gemini", "settings.json"))).toBe(false);
+  });
+
+  it("preserves existing mcpServers and is idempotent on re-run", () => {
+    const cfgPath = join(isoHome, ".gemini", "config", "mcp_config.json");
+    mkdirSync(join(isoHome, ".gemini", "config"), { recursive: true });
+    writeFileSync(cfgPath, JSON.stringify({ mcpServers: { other: { command: "x", args: [] } } }, null, 2));
+
+    const first = wireAntigravity(ENV);
+    expect(first.ok).toBe(true);
+    const cfg1 = JSON.parse(readFileSync(cfgPath, "utf-8"));
+    // Pre-existing server survives the merge.
+    expect(cfg1.mcpServers.other).toEqual({ command: "x", args: [] });
+    expect(cfg1.mcpServers.flair).toBeDefined();
+
+    const second = wireAntigravity(ENV);
+    expect(second.ok).toBe(true);
+    expect(second.message).toContain("already wired");
+    // Byte-for-byte unchanged on the idempotent re-run.
+    expect(readFileSync(cfgPath, "utf-8")).toBe(JSON.stringify(cfg1, null, 2) + "\n");
+  });
+
+  it("stamps FLAIR_CLIENT provenance when the caller sets it", () => {
+    wireAntigravity({ ...ENV, FLAIR_CLIENT: "antigravity" });
+    const cfgPath = join(isoHome, ".gemini", "config", "mcp_config.json");
+    const cfg = JSON.parse(readFileSync(cfgPath, "utf-8"));
+    expect(cfg.mcpServers.flair.env.FLAIR_CLIENT).toBe("antigravity");
+  });
+
+  it("round-trips: doctor's readClientMcpBlock reads back the wired Antigravity block", () => {
+    wireAntigravity(ENV);
+    const block = readClientMcpBlock("antigravity", isoHome);
+    expect(block.present).toBe(true);
+    expect(block.agentId).toBe("wirebot");
+    expect(block.flairUrl).toBe(ENV.FLAIR_URL);
+    expect(block.configPath).toBe(join(isoHome, ".gemini", "config", "mcp_config.json"));
+  });
+
+  it("a flair-mcp wired ONLY into Antigravity counts as wired for upgrade detection (#1208 x #1209)", () => {
+    wireAntigravity(ENV);
+    const wiring = detectWiredFlairMcp(isoHome);
+    expect(wiring.wired).toBe(true);
+    expect(wiring.pinnedVersion).toBe(PKG_VERSION);
+  });
+});

--- a/test/unit/antigravity-client.test.ts
+++ b/test/unit/antigravity-client.test.ts
@@ -103,6 +103,16 @@ describe("Antigravity client registration (flair#1209)", () => {
     expect(readFileSync(cfgPath, "utf-8")).toBe(JSON.stringify(cfg1, null, 2) + "\n");
   });
 
+  it("wire success message is HONEST — no confident pickup claim, carries the unverified caveat (flair#1209 review)", () => {
+    const res = wireAntigravity(ENV);
+    expect(res.ok).toBe(true);
+    // Flair wrote the config, but has NOT verified a live agy reads it — so the
+    // message must not claim the confident "restart Antigravity to pick it up"
+    // the other JSON clients get, and must name the unverified state.
+    expect(res.message).toContain("unverified against a real agy");
+    expect(res.message).not.toContain("restart Antigravity to pick it up");
+  });
+
   it("stamps FLAIR_CLIENT provenance when the caller sets it", () => {
     wireAntigravity({ ...ENV, FLAIR_CLIENT: "antigravity" });
     const cfgPath = join(isoHome, ".gemini", "config", "mcp_config.json");

--- a/test/unit/flair-mcp-detection.test.ts
+++ b/test/unit/flair-mcp-detection.test.ts
@@ -1,0 +1,146 @@
+// flair#1208 — `flair upgrade` must detect flair-mcp by its ACTUAL wiring, not
+// a global-install probe. flair-mcp is zero-install via npx (#1168), so a
+// correctly-wired machine never has it globally; the global probe returning
+// null is the NORMAL state, not "missing".
+import { describe, test, expect } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { resolveFlairMcpFinding } from "../../src/cli";
+import {
+  extractFlairMcpPin,
+  detectWiredFlairMcp,
+  buildSessionStartHookCommand,
+} from "../../src/doctor-client";
+
+const LATEST = "0.44.9";
+
+// ── the pure resolver: global probe + wiring -> {installed, status} ──────────
+describe("resolveFlairMcpFinding", () => {
+  test("legacy global install matching latest => current (honors the probe)", () => {
+    expect(resolveFlairMcpFinding(LATEST, LATEST, { wired: false, pinnedVersion: null }))
+      .toEqual({ installed: LATEST, status: "current" });
+  });
+
+  test("legacy global install behind latest => outdated", () => {
+    expect(resolveFlairMcpFinding("0.44.5", LATEST, { wired: false, pinnedVersion: null }))
+      .toEqual({ installed: "0.44.5", status: "outdated" });
+  });
+
+  test("global probe null + NOT wired anywhere => missing", () => {
+    expect(resolveFlairMcpFinding(null, LATEST, { wired: false, pinnedVersion: null }))
+      .toEqual({ installed: null, status: "missing" });
+  });
+
+  // The core acceptance of #1208: a null global probe on a WIRED machine must
+  // NOT be "missing".
+  test("global probe null + wired with a pin == latest => current from wiring, NOT missing", () => {
+    const finding = resolveFlairMcpFinding(null, LATEST, { wired: true, pinnedVersion: LATEST });
+    expect(finding.status).toBe("current");
+    expect(finding.installed).toBe(LATEST);
+    expect(finding.status).not.toBe("missing");
+  });
+
+  test("global probe null + wired with a stale pin => outdated (shows the pin), NOT missing", () => {
+    const finding = resolveFlairMcpFinding(null, LATEST, { wired: true, pinnedVersion: "0.44.5" });
+    expect(finding).toEqual({ installed: "0.44.5", status: "outdated" });
+    expect(finding.status).not.toBe("missing");
+  });
+
+  test("global probe null + wired but UNPINNED (bare npx / hook) => current at latest", () => {
+    // A bare `npx -y` re-resolves latest every session, so the effective
+    // installed version IS latest.
+    const finding = resolveFlairMcpFinding(null, LATEST, { wired: true, pinnedVersion: null });
+    expect(finding).toEqual({ installed: LATEST, status: "current" });
+    expect(finding.status).not.toBe("missing");
+  });
+});
+
+// ── pin extraction ──────────────────────────────────────────────────────────
+describe("extractFlairMcpPin", () => {
+  test("pulls the version from a pinned client args spec", () => {
+    expect(extractFlairMcpPin('"args": ["-y", "@tpsdev-ai/flair-mcp@0.44.5"]')).toBe("0.44.5");
+  });
+
+  test("pulls the version from a pinned Codex TOML args line", () => {
+    expect(extractFlairMcpPin('args = ["-y", "@tpsdev-ai/flair-mcp@1.2.3-rc.1"]')).toBe("1.2.3-rc.1");
+  });
+
+  test("returns null for a bare/unpinned spec", () => {
+    expect(extractFlairMcpPin('"args": ["-y", "@tpsdev-ai/flair-mcp"]')).toBeNull();
+  });
+
+  test("returns null for the (unpinned) SessionStart hook command", () => {
+    expect(extractFlairMcpPin(buildSessionStartHookCommand("me"))).toBeNull();
+  });
+
+  test("returns null when the package is absent entirely", () => {
+    expect(extractFlairMcpPin('"args": ["-y", "some-other-package@1.0.0"]')).toBeNull();
+  });
+});
+
+// ── the real code path: read a temp HOME's wiring files ─────────────────────
+describe("detectWiredFlairMcp (reads actual config files under HOME)", () => {
+  function withTempHome(fn: (home: string) => void): void {
+    const home = mkdtempSync(join(tmpdir(), "flair-mcp-detect-"));
+    try {
+      fn(home);
+    } finally {
+      rmSync(home, { recursive: true, force: true });
+    }
+  }
+
+  test("empty HOME => not wired", () => {
+    withTempHome((home) => {
+      expect(detectWiredFlairMcp(home)).toEqual({ wired: false, pinnedVersion: null });
+    });
+  });
+
+  test("SessionStart hook present (unpinned) => wired, no pin", () => {
+    withTempHome((home) => {
+      mkdirSync(join(home, ".claude"), { recursive: true });
+      writeFileSync(
+        join(home, ".claude", "settings.json"),
+        JSON.stringify({
+          hooks: { SessionStart: [{ hooks: [{ type: "command", command: buildSessionStartHookCommand("me") }] }] },
+        }),
+      );
+      expect(detectWiredFlairMcp(home)).toEqual({ wired: true, pinnedVersion: null });
+    });
+  });
+
+  test("client MCP config with a pinned flair server => wired, pin extracted", () => {
+    withTempHome((home) => {
+      mkdirSync(join(home, ".gemini"), { recursive: true });
+      writeFileSync(
+        join(home, ".gemini", "settings.json"),
+        JSON.stringify({
+          mcpServers: {
+            flair: {
+              command: "npx",
+              args: ["-y", "@tpsdev-ai/flair-mcp@0.44.5"],
+              env: { FLAIR_AGENT_ID: "me", FLAIR_URL: "http://127.0.0.1:9926" },
+            },
+          },
+        }),
+      );
+      expect(detectWiredFlairMcp(home)).toEqual({ wired: true, pinnedVersion: "0.44.5" });
+    });
+  });
+
+  test("hook present but NO global install => resolves to current, NOT missing (issue #1208 acceptance)", () => {
+    withTempHome((home) => {
+      mkdirSync(join(home, ".claude"), { recursive: true });
+      writeFileSync(
+        join(home, ".claude", "settings.json"),
+        JSON.stringify({
+          hooks: { SessionStart: [{ hooks: [{ type: "command", command: buildSessionStartHookCommand("me") }] }] },
+        }),
+      );
+      // globalProbe null (not globally installed) + hook present.
+      const finding = resolveFlairMcpFinding(null, LATEST, detectWiredFlairMcp(home));
+      expect(finding.status).not.toBe("missing");
+      expect(finding).toEqual({ installed: LATEST, status: "current" });
+    });
+  });
+});

--- a/test/unit/upgrade-probes.test.ts
+++ b/test/unit/upgrade-probes.test.ts
@@ -194,8 +194,18 @@ describe("upgradeStatusSuffix", () => {
     expect(suffix).toContain("npm install -g");
   });
 
-  test("outdated packages have no suffix", () => {
-    expect(upgradeStatusSuffix("@tpsdev-ai/flair-mcp", "outdated")).toBe("");
+  // flair#1208: an outdated flair-mcp is re-pinned by re-wiring (`flair doctor
+  // --fix`), never `npm install -g` — a global bin does nothing for an
+  // `npx -y -p @tpsdev-ai/flair-mcp` invocation. So its outdated line carries
+  // the doctor remedy, while every other package still has no outdated suffix.
+  test("outdated flair-mcp shows the doctor re-pin remedy, never npm install -g", () => {
+    const suffix = upgradeStatusSuffix("@tpsdev-ai/flair-mcp", "outdated");
+    expect(suffix).toContain("flair doctor --fix");
+    expect(suffix).not.toContain("npm install -g");
+    expect(suffix).not.toContain("npm i -g");
+  });
+
+  test("outdated non-mcp packages have no suffix", () => {
     expect(upgradeStatusSuffix("@tpsdev-ai/flair", "outdated")).toBe("");
   });
 


### PR DESCRIPTION
Two client-registry fixes for the 0.44.9 patch. Isolated to the CLI / doctor / client-wiring subsystem (`src/cli.ts`, `src/doctor-client.ts`, `src/install/clients.ts`).

## #1208 — `flair upgrade` false-negative on npx-wired flair-mcp (Closes #1208)

`flair upgrade` probed flair-mcp as a **global** install (`probeBinVersion ?? probeLibVersion`, both global). flair-mcp is zero-install via npx by design (#1168) and is never globally installed, so on a correctly-wired machine the probe found nothing → status `missing` → `❔ not detected`, with an `npm install -g` remedy that installs a bin the `npx -y -p @tpsdev-ai/flair-mcp` hook never uses.

**Fix — detect flair-mcp by its actual wiring** (Option A in the issue):
- New `detectWiredFlairMcp(homeDir)` (`src/doctor-client.ts`) scans the SessionStart hook and every known client's MCP config. `wired` = referenced anywhere; `pinnedVersion` = the concrete pin from a client config's `args` (the hook is unpinned by design). It iterates the same `ALL_CLIENTS` registry + `clientConfigPath` that wiring uses, so a new client is scanned automatically.
- New pure `resolveFlairMcpFinding(globalProbe, latest, wiring)` (`src/cli.ts`): legacy global install honored first; else not-wired → `missing`; else pinned → current/outdated from the pin; else wired-but-unpinned → `current` (npx re-resolves latest each session).
- `missing` for flair-mcp now means **not wired anywhere**. The remedy for wired-but-behind or unwired is `flair doctor --fix`, never `npm install -g` — flair-mcp is kept out of the npm-global upgrade set entirely.
- Preserves the #1172 advice-suffix behavior; this is the detection counterpart.

**End-to-end evidence** (`flair upgrade --check`, HOME-isolated, flair-mcp not globally installed on the build host):

| Wiring state | Output |
|---|---|
| SessionStart hook present | `✅ @tpsdev-ai/flair-mcp: 0.44.8 → 0.44.8 (current)` |
| stale client pin 0.44.5 | `⬆️ @tpsdev-ai/flair-mcp: 0.44.5 → 0.44.8 (npx-wired — run: flair doctor --fix to re-pin)` |
| not wired anywhere | `❔ @tpsdev-ai/flair-mcp: not detected → 0.44.8 (zero-install via npx — run: flair doctor --fix)` |

No `npm install -g @tpsdev-ai/flair-mcp` is emitted in any state.

## #1209 — add the Antigravity CLI (`agy`) as a wire-able MCP client (Refs #1209)

Added Antigravity to the client registry (`src/install/clients.ts` + the `flair init` / `flair doctor --fix` dispatch in `src/cli.ts`): detection by the `agy` executable, and wiring the pinned `npx -y -p @tpsdev-ai/flair-mcp` server entry, same shape as Gemini/Cursor/Claude.

**Config path found:** `~/.gemini/config/mcp_config.json` (workspace-level `.agents/mcp_config.json`), standard JSON `mcpServers` stdio schema (`command` / `args` / `env`).
**Sources:** Antigravity's own docs (antigravity.google/docs/mcp) and a Google Developer Advocate write-up (atamel.dev, "Where does Antigravity look for MCP Servers?"). Both agree on the path and schema. Note this is a **sibling of, and distinct from,** Gemini CLI's `~/.gemini/settings.json` — both live under `~/.gemini` but read different files, so wiring one never touches the other.

**⚠️ UNVERIFIED without `agy`:** Antigravity is not installed on the build host, so the end-to-end wiring has **not** been exercised against a real `agy`. Config-path resolution and JSON serialization are unit-tested; the pinned-server round-trip is read back through doctor's `readClientMcpBlock`. **Needs verification on a machine with `agy` installed** before treating Antigravity wiring as confirmed. This is why the issue is `Refs`, not `Closes`.

## Tests
- Fast unit suite (`bun test test/unit/ test/*.test.ts`): **4410 pass / 0 fail** (baseline on origin/main: 4381 / 0). Added `test/unit/flair-mcp-detection.test.ts` (15) and `test/unit/antigravity-client.test.ts` (9); the existing `clients-pin-refresh` suite auto-generated 3 passing Antigravity cases through the standard JSON pin-refresh path.
- Updated one existing assertion in `upgrade-probes.test.ts` (`outdated flair-mcp` now carries the doctor re-pin remedy instead of an empty suffix — the intentional #1208 behavior change; the main flair package still has no outdated suffix).
- Every added test mutation-checked (broke the SUT, saw the test fail, restored to green).
- Typecheck clean (one pre-existing, unrelated error in `resources/auth-middleware.ts` present on origin/main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
