### PR TITLE
feat(distill): security foundations for ADK session distillation (#1205a)

### DIFF
--- a/.changelog/unreleased/added-machine-reviewer-namespace.md
+++ b/.changelog/unreleased/added-machine-reviewer-namespace.md
@@ -1,0 +1,6 @@
+- **Reserved the `machine:` reviewer namespace for automated promotions.**
+  Promotions record a `reviewerId` for audit and attribution. The `machine:`
+  prefix (canonical `machine:adk-auto-promote`) is now reserved for
+  machine-driven promotion paths so automated decisions can never be mistaken
+  for a human or agent reviewer, and `flair rem promote --reviewer` refuses any
+  value in that namespace.

--- a/.changelog/unreleased/security-adk-tag-sanitize-collision.md
+++ b/.changelog/unreleased/security-adk-tag-sanitize-collision.md
@@ -1,8 +1,10 @@
-- **adk-flair: closed a tag-collision in the per-user scope tag.** The ADK
-  memory adapter built its `adk:<app>:<user>` scope tag by replacing `:` with
-  `_`, so distinct identities like `alice:admin` and `alice_admin` collapsed to
-  the same tag. Because that tag is the per-user access-control boundary, the
-  collision could contaminate memory across users. Segments are now percent-
-  encoded (reversible, collision-free); no action is needed for existing
-  installs, though any tag written for a user id containing `:` or `_` will
-  differ from what the old scheme produced.
+- **adk-flair: closed a tag-collision in the per-user scope tag (Python and
+  JavaScript adapters).** Both the `adk-flair` (Python) and `@tpsdev-ai/adk-flair`
+  (JavaScript) memory adapters built the `adk:<app>:<user>` scope tag by
+  replacing `:` with `_`, so distinct identities like `alice:admin` and
+  `alice_admin` collapsed to the same tag. Because that tag is the per-user
+  access-control boundary, the collision could contaminate memory across users.
+  Segments are now percent-encoded (reversible, collision-free) in both
+  packages; no action is needed for existing installs, though any tag written
+  for a user id containing `:` or `_` will differ from what the old scheme
+  produced.

--- a/.changelog/unreleased/security-adk-tag-sanitize-collision.md
+++ b/.changelog/unreleased/security-adk-tag-sanitize-collision.md
@@ -1,0 +1,8 @@
+- **adk-flair: closed a tag-collision in the per-user scope tag.** The ADK
+  memory adapter built its `adk:<app>:<user>` scope tag by replacing `:` with
+  `_`, so distinct identities like `alice:admin` and `alice_admin` collapsed to
+  the same tag. Because that tag is the per-user access-control boundary, the
+  collision could contaminate memory across users. Segments are now percent-
+  encoded (reversible, collision-free); no action is needed for existing
+  installs, though any tag written for a user id containing `:` or `_` will
+  differ from what the old scheme produced.

--- a/.changelog/unreleased/security-rem-promote-tag-lineage.md
+++ b/.changelog/unreleased/security-rem-promote-tag-lineage.md
@@ -1,0 +1,11 @@
+- **`flair rem promote` now preserves the source scope tag and fails closed
+  for ADK-sourced candidates.** Promotion previously stamped only
+  `nightly-rem-promoted` / `from:<id>` and dropped the candidate's source tag.
+  For a candidate distilled from ADK session records (a source memory carries
+  an `adk:<app>:<user>` tag), the promoted claim now carries that scope tag
+  alongside the provenance tags. If such a candidate is ADK-sourced but its
+  scope tag cannot be uniquely and completely determined (multiple distinct
+  tags, or an unreadable source), or if it targets Soul (which is agent-scoped
+  and cannot carry a per-user tag), promotion is refused rather than writing a
+  claim that could leak across users. Non-ADK candidates promote exactly as
+  before.

--- a/packages/adk-flair-js/src/index.ts
+++ b/packages/adk-flair-js/src/index.ts
@@ -5,5 +5,5 @@
  */
 
 export { FlairMemoryService } from "./memory_service.js";
-export { compoundTag, sanitizeTagSegment } from "./tag.js";
+export { compoundTag, sanitizeTagSegment, desanitizeTagSegment } from "./tag.js";
 export { loadEd25519Key, signRequest } from "./signing.js";

--- a/packages/adk-flair-js/src/tag.ts
+++ b/packages/adk-flair-js/src/tag.ts
@@ -2,18 +2,45 @@
  * Compound tag helpers for adk-flair.
  *
  * Builds the `adk:<app_name>:<user_id>` compound tag used for per-user
- * scoping in Flair. Colons in segments are replaced with underscores to
- * prevent delimiter breakage.
+ * scoping in Flair. Reserved characters in segments are percent-encoded so
+ * distinct inputs never collide and the `:` delimiter stays unambiguous.
  */
 
 const TAG_PREFIX = "adk";
 
 /**
- * Sanitize a tag segment by replacing colons with underscores.
- * A colon in a segment would break the compound tag delimiter.
+ * Percent-encode the reserved characters in a tag segment so distinct inputs
+ * never collide and the compound-tag delimiter ':' stays unambiguous.
+ *
+ * The old scheme replaced ':' -> '_', which COLLIDED: userId="alice:admin"
+ * and userId="alice_admin" both sanitized to "alice_admin" — one tag for two
+ * distinct identities. Because the compound tag is the per-user access-control
+ * boundary (ADK session distillation, #1205), that collision is a cross-user
+ * contamination bug. Mirrors the Python fix in
+ * packages/adk-flair/src/adk_flair/memory_service.py.
+ *
+ * This encoding is reversible and collision-free. '%' is escaped FIRST so it
+ * can introduce escapes, then ':' (the delimiter) and '_' (the old escape
+ * char). Because every escape starts with an already-escaped '%', no input can
+ * forge another input's encoding — see desanitizeTagSegment for the inverse.
  */
 export function sanitizeTagSegment(segment: string): string {
-  return segment.replace(/:/g, "_");
+  return segment
+    .replace(/%/g, "%25")
+    .replace(/:/g, "%3A")
+    .replace(/_/g, "%5F");
+}
+
+/**
+ * Inverse of sanitizeTagSegment. '%25' is decoded LAST so a literal '%3A' in
+ * the original input (which encoded to '%253A') is not mistaken for an encoded
+ * ':'. Round-trips exactly: desanitizeTagSegment(sanitizeTagSegment(x)) === x.
+ */
+export function desanitizeTagSegment(segment: string): string {
+  return segment
+    .replace(/%3A/g, ":")
+    .replace(/%5F/g, "_")
+    .replace(/%25/g, "%");
 }
 
 /**

--- a/packages/adk-flair-js/test/unit/memory_service.test.ts
+++ b/packages/adk-flair-js/test/unit/memory_service.test.ts
@@ -7,7 +7,7 @@
 
 import { describe, it, expect, beforeEach, afterEach, mock, spyOn } from "bun:test";
 import { FlairMemoryService } from "../../src/memory_service.js";
-import { compoundTag, sanitizeTagSegment } from "../../src/tag.js";
+import { compoundTag, sanitizeTagSegment, desanitizeTagSegment } from "../../src/tag.js";
 import { loadEd25519Key, signRequest, expandHome } from "../../src/signing.js";
 import * as crypto from "node:crypto";
 import * as fs from "node:fs";
@@ -75,12 +75,44 @@ describe("tag helpers", () => {
   });
 
   it("sanitizes colons in segments", () => {
-    expect(sanitizeTagSegment("org:admin")).toBe("org_admin");
-    expect(compoundTag("app:name", "user:id")).toBe("adk:app_name:user_id");
+    // Colons are percent-encoded (%3A) so the compound-tag delimiter ':'
+    // remains the only literal colon in the tag.
+    expect(sanitizeTagSegment("org:admin")).toBe("org%3Aadmin");
+    expect(compoundTag("app:name", "user:id")).toBe("adk:app%3Aname:user%3Aid");
   });
 
   it("handles empty segments", () => {
     expect(compoundTag("app", "")).toBe("adk:app:");
+  });
+
+  it("does not collide ':' and '_' (regression #1205, Sherlock)", () => {
+    // The old ':' -> '_' scheme mapped 'alice:admin' and 'alice_admin' to the
+    // SAME tag. They must now differ — the compound tag is the per-user
+    // access-control boundary. (Mirrors the Python suite.)
+    expect(sanitizeTagSegment("alice:admin")).not.toBe(sanitizeTagSegment("alice_admin"));
+    expect(compoundTag("app", "alice:admin")).not.toBe(compoundTag("app", "alice_admin"));
+    expect(sanitizeTagSegment("alice:admin")).toBe("alice%3Aadmin");
+    expect(sanitizeTagSegment("alice_admin")).toBe("alice%5Fadmin");
+  });
+
+  it("encoding is injective, incl. the literal-escape trap", () => {
+    // 'alice%3Aadmin' (literal) must not collide with 'alice:admin' (encoded).
+    const tricky = [
+      "alice:admin", "alice_admin", "alice%3Aadmin", "alice%5Fadmin",
+      "alice%admin", "alice", "a:b_c", "a_b:c", "%25", ":", "_", "%",
+    ];
+    const encoded = tricky.map(sanitizeTagSegment);
+    expect(new Set(encoded).size).toBe(new Set(tricky).size);
+  });
+
+  it("round-trips through desanitize for every reserved-char combination", () => {
+    const inputs = [
+      "", "normal", "alice:admin", "alice_admin", "a:b_c:d",
+      "%", "%25", "%3A", "%5F", "%253A", "::__%%", "user@host:1_2",
+    ];
+    for (const x of inputs) {
+      expect(desanitizeTagSegment(sanitizeTagSegment(x))).toBe(x);
+    }
   });
 });
 
@@ -433,6 +465,37 @@ describe("searchMemory", () => {
     expect(texts).toContain("alice fact");
     expect(texts).toContain("alice fact 2");
     expect(texts).not.toContain("bob fact");
+  });
+
+  it("re-verification matches the escaped compound tag on read", async () => {
+    // A userId that requires escaping still matches on read: the encoded
+    // compound tag written on ingest is the one re-verified on search, and a
+    // neighbour that COLLIDED under the old scheme ('alice_admin') is NOT
+    // accepted for userId='alice:admin'. (Mirrors the Python suite.)
+    const wanted = compoundTag("my-app", "alice:admin");     // adk:my-app:alice%3Aadmin
+    const neighbour = compoundTag("my-app", "alice_admin");  // adk:my-app:alice%5Fadmin
+    expect(wanted).not.toBe(neighbour);
+
+    globalThis.fetch = mock(async () => {
+      return new Response(
+        JSON.stringify({
+          results: [
+            { content: "mine", tags: [wanted] },
+            { content: "neighbour", tags: [neighbour] },
+          ],
+        }),
+        { status: 200 },
+      );
+    });
+
+    const result = await service.searchMemory({
+      appName: "my-app",
+      userId: "alice:admin",
+      query: "fact",
+    });
+
+    const texts = result.memories.map((m) => (m.content?.parts?.[0] as { text?: string })?.text);
+    expect(texts).toEqual(["mine"]);
   });
 
   it("returns empty on HTTP error", async () => {

--- a/packages/adk-flair/src/adk_flair/memory_service.py
+++ b/packages/adk-flair/src/adk_flair/memory_service.py
@@ -53,8 +53,37 @@ _TAG_PREFIX = "adk"
 
 
 def _sanitize_tag_segment(value: str) -> str:
-    """Replace colons in a tag segment so the compound tag delimiter is unambiguous."""
-    return value.replace(":", "_")
+    """Percent-encode the reserved characters in a tag segment so distinct
+    inputs never collide and the compound-tag delimiter ':' stays unambiguous.
+
+    The old scheme replaced ':' -> '_', which COLLIDED: ``user_id="alice:admin"``
+    and ``user_id="alice_admin"`` both sanitized to ``alice_admin`` — one
+    tag for two distinct identities. Once the compound tag is the per-user
+    access-control boundary (ADK session distillation, #1205), that collision
+    is a cross-user contamination bug.
+
+    This encoding is reversible and collision-free. ``%`` is escaped FIRST so
+    it can introduce escapes, then ``:`` (the delimiter) and ``_`` (the old
+    escape char). Because every escape starts with an already-escaped ``%``,
+    no input can forge another input's encoding — see _desanitize_tag_segment
+    for the exact inverse.
+    """
+    return (
+        value.replace("%", "%25")
+        .replace(":", "%3A")
+        .replace("_", "%5F")
+    )
+
+
+def _desanitize_tag_segment(value: str) -> str:
+    """Inverse of _sanitize_tag_segment. ``%25`` is decoded LAST so a literal
+    ``%3A`` in the original input (which encoded to ``%253A``) is not mistaken
+    for an encoded ':'. Round-trips exactly: desanitize(sanitize(x)) == x."""
+    return (
+        value.replace("%3A", ":")
+        .replace("%5F", "_")
+        .replace("%25", "%")
+    )
 
 
 def _compound_tag(app_name: str, user_id: str) -> str:

--- a/packages/adk-flair/tests/test_memory_service.py
+++ b/packages/adk-flair/tests/test_memory_service.py
@@ -82,12 +82,41 @@ class TestCompoundTag:
 
     def test_sanitizes_colons(self):
         from adk_flair.memory_service import _compound_tag
-        assert _compound_tag("my:app", "org:admin") == "adk:my_app:org_admin"
+        # Colons in a segment are percent-encoded (%3A) so the compound-tag
+        # delimiter ':' remains the only literal colon in the tag.
+        assert _compound_tag("my:app", "org:admin") == "adk:my%3Aapp:org%3Aadmin"
 
     def test_sanitize_tag_segment(self):
         from adk_flair.memory_service import _sanitize_tag_segment
-        assert _sanitize_tag_segment("a:b:c") == "a_b_c"
+        assert _sanitize_tag_segment("a:b:c") == "a%3Ab%3Ac"
         assert _sanitize_tag_segment("normal") == "normal"
+
+    def test_no_collision_between_colon_and_underscore(self):
+        """Regression for #1205 (Sherlock): the old ':' -> '_' scheme mapped
+        'alice:admin' and 'alice_admin' to the SAME tag. They must now differ,
+        because the compound tag is the per-user access-control boundary."""
+        from adk_flair.memory_service import _sanitize_tag_segment, _compound_tag
+        assert _sanitize_tag_segment("alice:admin") != _sanitize_tag_segment("alice_admin")
+        assert _compound_tag("app", "alice:admin") != _compound_tag("app", "alice_admin")
+        # And the specific values, to pin the encoding:
+        assert _sanitize_tag_segment("alice:admin") == "alice%3Aadmin"
+        assert _sanitize_tag_segment("alice_admin") == "alice%5Fadmin"
+
+    def test_encoding_is_injective_on_tricky_pairs(self):
+        """Distinct inputs -> distinct outputs, including inputs that contain
+        the escape sequences literally (the fail-open trap of a naive scheme)."""
+        from adk_flair.memory_service import _sanitize_tag_segment
+        tricky = ["alice:admin", "alice_admin", "alice%3Aadmin", "alice%5Fadmin",
+                  "alice%admin", "alice", "a:b_c", "a_b:c", "%25", ":", "_", "%"]
+        encoded = [_sanitize_tag_segment(x) for x in tricky]
+        assert len(set(encoded)) == len(set(tricky)), "encoding collapsed distinct inputs"
+
+    def test_round_trip(self):
+        """desanitize(sanitize(x)) == x for every reserved-char combination."""
+        from adk_flair.memory_service import _sanitize_tag_segment, _desanitize_tag_segment
+        for x in ["", "normal", "alice:admin", "alice_admin", "a:b_c:d",
+                  "%", "%25", "%3A", "%5F", "%253A", "::__%%", "user@host:1_2"]:
+            assert _desanitize_tag_segment(_sanitize_tag_segment(x)) == x, x
 
 
 class TestDeterministicRecordId:
@@ -314,6 +343,34 @@ class TestSearchMemory:
         )
         assert len(result.memories) == 1
         assert result.memories[0].id == "mem-2"
+
+    @pytest.mark.asyncio
+    async def test_reverification_matches_escaped_compound_tag(self, service):
+        """A user_id that requires escaping still matches on read: the encoded
+        compound tag written on ingest is the same one re-verified on search,
+        and a colliding-under-the-OLD-scheme neighbour ('alice_admin') is
+        NOT accepted for user_id='alice:admin'."""
+        from adk_flair.memory_service import _compound_tag
+
+        wanted = _compound_tag("app", "alice:admin")      # adk:app:alice%3Aadmin
+        neighbour = _compound_tag("app", "alice_admin")   # adk:app:alice%5Fadmin
+        assert wanted != neighbour
+
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.headers = {"content-type": "application/json"}
+        mock_resp.json.return_value = {
+            "results": [
+                {"id": "mine", "content": "kept", "tags": [wanted]},
+                {"id": "neighbour", "content": "dropped", "tags": [neighbour]},
+            ],
+        }
+        service._client.request.return_value = mock_resp
+
+        result = await service.search_memory(
+            app_name="app", user_id="alice:admin", query="test",
+        )
+        assert [m.id for m in result.memories] == ["mine"]
 
     @pytest.mark.asyncio
     async def test_flair_down_returns_empty_with_warning(self, service, caplog):

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -8292,6 +8292,127 @@ export function decideCandidateAction(
   return { ok: true };
 }
 
+// ─── ADK tag-lineage on promote (#1205 slice 1205a — Sherlock security req) ───
+// ADK session records are written by adk-flair (memory_service.py) under a
+// SHARED-namespace agentId, with per-user separation carried ENTIRELY by a
+// compound scope tag `adk:<app>:<user>`. That tag is the access-control
+// boundary. A candidate distilled from those records therefore MUST carry the
+// scope tag when promoted, or the promoted claim lands in the shared agentId
+// memory retrievable by every other user of the app — a cross-user leak.
+//
+// `rem promote` historically hard-coded `["nightly-rem-promoted", from:<id>]`
+// and DROPPED the source tag. We now propagate the source scope tag for
+// ADK-sourced candidates, and FAIL CLOSED (refuse) when a candidate is
+// ADK-sourced but its scope tag can't be uniquely+completely determined.
+//
+// SCOPING (deliberate, per spec): fail-closed applies ONLY to ADK-sourced
+// candidates. Non-ADK candidates carry no `adk:` tag and promote byte-for-byte
+// as before — a transient/deleted source on a non-ADK candidate must NOT block
+// its promotion.
+//
+// SEAM (foundation only; the distillation engine is slice #1205b): ADK-sourcing
+// is detected here by re-reading the candidate's source memories and inspecting
+// their tags. That leaves ONE residual fail-open: an ADK-sourced candidate all
+// of whose source memories are unreadable (deleted/transient) yields no `adk:`
+// evidence and is treated as non-ADK. Closing that corner without regressing
+// non-ADK promotion requires the ENGINE to stamp the authoritative scope tag
+// onto the MemoryCandidate row at distillation time (it distills per single
+// scope:tagged tag, so it knows it authoritatively). `derivePromotedTags` is
+// written so that override can be threaded in later without touching callers.
+
+export const ADK_SCOPE_TAG_PREFIX = "adk:";
+
+export type SourceMemoryFetch =
+  | { ok: true; tags: string[] } // source memory was read; these are its tags
+  | { ok: false }; // source memory could not be read (missing/transient/authz)
+
+export type PromotedTagsDecision =
+  | { ok: true; tags: string[]; adkSourced: boolean }
+  | { ok: false; reason: string };
+
+/**
+ * Decide the tag set for a promoted Memory given the candidate id and the
+ * result of fetching each of its source memories. Pure — no I/O; the action
+ * callback does the fetching and threads the results here so this is unit-
+ * testable and the fail-closed logic is exercised directly.
+ *
+ *  - No `adk:` scope tag across readable sources → NON-ADK candidate; return
+ *    the provenance tags only (unchanged behavior).
+ *  - Exactly one `adk:` scope tag AND every source readable → ADK-sourced;
+ *    return [scopeTag, ...provenance].
+ *  - `adk:` evidence present but the scope tag is ambiguous (>1 distinct tag)
+ *    OR incomplete (some source unreadable) → REFUSE (fail-closed): a
+ *    tagless/mis-tagged claim in a shared ADK namespace is a cross-user leak,
+ *    not a benign miss.
+ */
+export function derivePromotedTags(
+  candidateId: string,
+  sources: SourceMemoryFetch[],
+): PromotedTagsDecision {
+  const provenance = ["nightly-rem-promoted", `from:${candidateId}`];
+
+  const adkTags = new Set<string>();
+  let anySourceUnreadable = false;
+  for (const s of sources) {
+    if (!s.ok) {
+      anySourceUnreadable = true;
+      continue;
+    }
+    for (const t of s.tags) {
+      if (typeof t === "string" && t.startsWith(ADK_SCOPE_TAG_PREFIX)) adkTags.add(t);
+    }
+  }
+
+  // No positive ADK evidence → non-ADK. An unreadable source with zero ADK
+  // evidence does NOT fail closed here (that would regress non-ADK promotion);
+  // see the SEAM note above.
+  if (adkTags.size === 0) {
+    return { ok: true, tags: provenance, adkSourced: false };
+  }
+
+  if (adkTags.size > 1) {
+    return {
+      ok: false,
+      reason: `ADK-sourced candidate spans multiple scope tags (${[...adkTags].sort().join(", ")}); refusing to promote — a merged cross-user claim would leak across users`,
+    };
+  }
+  if (anySourceUnreadable) {
+    return {
+      ok: false,
+      reason: `ADK-sourced candidate has unreadable source memories; the per-user scope tag cannot be confirmed — refusing to promote (fail-closed)`,
+    };
+  }
+  const scopeTag = [...adkTags][0];
+  return { ok: true, tags: [scopeTag, ...provenance], adkSourced: true };
+}
+
+// ─── Machine reviewer namespace (#1205 slice 1205a — Sherlock security req 4) ─
+// A promotion records a reviewerId that feeds audit/attribution
+// (schemas/memory.graphql:209). An automated (machine-driven) promotion path
+// must record a reviewerId that can NEVER be mistaken for a human/agent
+// reviewer, so attribution isn't laundered. Reserve the `machine:` namespace
+// for that, and forbid the human `--reviewer` path from claiming it.
+
+export const MACHINE_REVIEWER_PREFIX = "machine:";
+/** Canonical machine reviewerId for the ADK auto-promote consumer (#1205b). */
+export const MACHINE_REVIEWER_ADK_AUTO_PROMOTE = "machine:adk-auto-promote";
+
+/** True iff `id` is in the reserved machine-reviewer namespace — i.e. it
+ *  denotes an automated path, not a human or agent reviewer. */
+export function isMachineReviewerId(id: string | undefined | null): boolean {
+  return typeof id === "string" && id.startsWith(MACHINE_REVIEWER_PREFIX);
+}
+
+/** The human `flair rem promote` path must not record a reviewerId in the
+ *  reserved machine namespace — that would launder automated attribution onto
+ *  a human-operated promotion. Returns an error string, or null if allowed. */
+export function validateHumanReviewerId(reviewerId: string): string | null {
+  if (isMachineReviewerId(reviewerId)) {
+    return `--reviewer '${reviewerId}' uses the reserved '${MACHINE_REVIEWER_PREFIX}' namespace (reserved for automated promotion); use a human/agent reviewer id`;
+  }
+  return null;
+}
+
 // ─── flair rem promote ───────────────────────────────────────────────────────
 // Slice 2 of FLAIR-NIGHTLY-REM (ops-2qq). Promote a candidate to either Soul
 // or persistent Memory. Both --rationale and --to are required (spec § 5: no
@@ -8320,6 +8441,13 @@ rem
       process.exit(1);
     }
     const reviewerId = opts.reviewer || process.env.FLAIR_AGENT_ID || "admin";
+    // The human promote path must not record a reserved machine reviewerId
+    // (Sherlock #4): that would launder automated attribution.
+    const reviewerErr = validateHumanReviewerId(reviewerId);
+    if (reviewerErr) {
+      console.error(`Error: ${reviewerErr}`);
+      process.exit(1);
+    }
 
     try {
       // Fetch the candidate
@@ -8332,6 +8460,42 @@ rem
         process.exit(1);
       }
 
+      // ADK tag-lineage (#1205a): re-read the candidate's source memories and
+      // derive the promoted-claim tag set. Fail-closed for ADK-sourced
+      // candidates whose per-user scope tag can't be confirmed; unchanged for
+      // non-ADK candidates. See derivePromotedTags for the fail-closed rules.
+      const sourceIds: string[] = Array.isArray(candidate.sourceMemoryIds) ? candidate.sourceMemoryIds : [];
+      const sourceFetches: SourceMemoryFetch[] = [];
+      for (const sid of sourceIds) {
+        try {
+          const mem = await api("GET", `/Memory/${encodeURIComponent(String(sid))}`);
+          if (mem && !mem.error) {
+            sourceFetches.push({ ok: true, tags: Array.isArray(mem.tags) ? mem.tags : [] });
+          } else {
+            sourceFetches.push({ ok: false });
+          }
+        } catch {
+          sourceFetches.push({ ok: false });
+        }
+      }
+      const tagDecision = derivePromotedTags(candidateId, sourceFetches);
+      if (!tagDecision.ok) {
+        console.error(`Error: candidate ${candidateId} — ${(tagDecision as { ok: false; reason: string }).reason}`);
+        process.exit(1);
+      }
+      // Soul entries are agentId-scoped and cannot carry a per-user scope tag,
+      // so an ADK-sourced candidate promoted to Soul is a cross-user leak by
+      // construction — fail closed. (Server-side trust-tier enforcement that
+      // hard-locks the target is the engine slice #1205b; this is the CLI-side
+      // foundation.)
+      if (opts.to === "soul" && (tagDecision as { adkSourced?: boolean }).adkSourced) {
+        console.error(
+          `Error: candidate ${candidateId} is ADK-sourced (scope tag ${tagDecision.tags[0]}); Soul is agentId-scoped and cannot carry a per-user scope tag — refusing to promote to Soul (would leak across users). Promote ADK-sourced candidates to memory.`,
+        );
+        process.exit(1);
+      }
+      const promotedTags = tagDecision.tags;
+
       const decidedAt = new Date().toISOString();
 
       // Write the resulting Soul or Memory entry
@@ -8342,7 +8506,7 @@ rem
           agentId: candidate.agentId,
           content: candidate.claim,
           durability: "persistent",
-          tags: ["nightly-rem-promoted", `from:${candidateId}`],
+          tags: promotedTags,
           derivedFrom: candidate.sourceMemoryIds ?? [],
           promotionStatus: "approved",
           promotedAt: decidedAt,

--- a/test/unit/cli-rem-promote-reject.test.ts
+++ b/test/unit/cli-rem-promote-reject.test.ts
@@ -9,7 +9,17 @@
  */
 
 import { describe, test, expect } from "bun:test";
-import { validatePromoteOpts, validateRejectOpts, decideCandidateAction } from "../../src/cli.ts";
+import {
+  validatePromoteOpts,
+  validateRejectOpts,
+  decideCandidateAction,
+  derivePromotedTags,
+  isMachineReviewerId,
+  validateHumanReviewerId,
+  MACHINE_REVIEWER_PREFIX,
+  MACHINE_REVIEWER_ADK_AUTO_PROMOTE,
+  type SourceMemoryFetch,
+} from "../../src/cli.ts";
 
 describe("validatePromoteOpts", () => {
   test("accepts a fully-specified memory promotion", () => {
@@ -115,5 +125,120 @@ describe("decideCandidateAction", () => {
     expect(r.severity).toBe("info");
     expect(r.message).toMatch(/already rejected on 2026-05-03/);
     expect(r.message).toMatch(/by flint/);
+  });
+});
+
+// ─── ADK tag-lineage on promote (#1205a) ─────────────────────────────────────
+
+const ADK_TAG = "adk:myapp:alice%3Aadmin"; // an escaped compound scope tag
+const OTHER_ADK_TAG = "adk:myapp:bob";
+
+describe("derivePromotedTags", () => {
+  test("NON-ADK candidate (readable sources, no adk tag) → provenance only, unchanged", () => {
+    // Positive control: this MUST match the historical hard-coded tag set so
+    // non-ADK promotion is byte-for-byte unchanged.
+    const sources: SourceMemoryFetch[] = [
+      { ok: true, tags: ["episodic", "topic:infra"] },
+      { ok: true, tags: [] },
+    ];
+    const r = derivePromotedTags("cand_1", sources);
+    expect(r.ok).toBe(true);
+    if (!r.ok) throw new Error("unreachable");
+    expect(r.adkSourced).toBe(false);
+    expect(r.tags).toEqual(["nightly-rem-promoted", "from:cand_1"]);
+  });
+
+  test("NON-ADK candidate with an unreadable source (no adk evidence) → still promotes, unchanged", () => {
+    // A transient/deleted source on a non-ADK candidate must NOT fail closed.
+    const sources: SourceMemoryFetch[] = [
+      { ok: true, tags: ["episodic"] },
+      { ok: false },
+    ];
+    const r = derivePromotedTags("cand_2", sources);
+    expect(r.ok).toBe(true);
+    if (!r.ok) throw new Error("unreachable");
+    expect(r.adkSourced).toBe(false);
+    expect(r.tags).toEqual(["nightly-rem-promoted", "from:cand_2"]);
+  });
+
+  test("candidate with NO sources → non-ADK, provenance only", () => {
+    const r = derivePromotedTags("cand_3", []);
+    expect(r.ok).toBe(true);
+    if (!r.ok) throw new Error("unreachable");
+    expect(r.adkSourced).toBe(false);
+    expect(r.tags).toEqual(["nightly-rem-promoted", "from:cand_3"]);
+  });
+
+  test("ADK-sourced (single tag, all readable) → propagates scope tag ALONGSIDE provenance", () => {
+    const sources: SourceMemoryFetch[] = [
+      { ok: true, tags: [ADK_TAG, "episodic"] },
+      { ok: true, tags: [ADK_TAG] },
+    ];
+    const r = derivePromotedTags("cand_4", sources);
+    expect(r.ok).toBe(true);
+    if (!r.ok) throw new Error("unreachable");
+    expect(r.adkSourced).toBe(true);
+    expect(r.tags).toEqual([ADK_TAG, "nightly-rem-promoted", "from:cand_4"]);
+    // provenance tags are retained (added to, not replaced by, the scope tag):
+    expect(r.tags).toContain("nightly-rem-promoted");
+    expect(r.tags).toContain("from:cand_4");
+  });
+
+  test("ADK-sourced but a source is UNREADABLE → FAIL CLOSED", () => {
+    const sources: SourceMemoryFetch[] = [
+      { ok: true, tags: [ADK_TAG] },
+      { ok: false }, // could carry a different scope tag — cannot confirm
+    ];
+    const r = derivePromotedTags("cand_5", sources);
+    expect(r.ok).toBe(false);
+    if (r.ok) throw new Error("unreachable");
+    expect(r.reason).toMatch(/unreadable|fail-closed/i);
+  });
+
+  test("ADK-sourced spanning MULTIPLE distinct scope tags → FAIL CLOSED", () => {
+    const sources: SourceMemoryFetch[] = [
+      { ok: true, tags: [ADK_TAG] },
+      { ok: true, tags: [OTHER_ADK_TAG] },
+    ];
+    const r = derivePromotedTags("cand_6", sources);
+    expect(r.ok).toBe(false);
+    if (r.ok) throw new Error("unreachable");
+    expect(r.reason).toMatch(/multiple scope tags/i);
+    expect(r.reason).toContain(ADK_TAG);
+    expect(r.reason).toContain(OTHER_ADK_TAG);
+  });
+});
+
+// ─── Machine reviewer namespace (#1205a, Sherlock #4) ────────────────────────
+
+describe("isMachineReviewerId / machine reviewer namespace", () => {
+  test("the canonical machine reviewerId is in the reserved namespace and distinguishable", () => {
+    expect(MACHINE_REVIEWER_ADK_AUTO_PROMOTE.startsWith(MACHINE_REVIEWER_PREFIX)).toBe(true);
+    expect(isMachineReviewerId(MACHINE_REVIEWER_ADK_AUTO_PROMOTE)).toBe(true);
+  });
+
+  test("machine ids are recognized; human/agent ids are not", () => {
+    expect(isMachineReviewerId("machine:adk-auto-promote")).toBe(true);
+    expect(isMachineReviewerId("machine:anything")).toBe(true);
+    expect(isMachineReviewerId("admin")).toBe(false);
+    expect(isMachineReviewerId("flint")).toBe(false);
+    expect(isMachineReviewerId("adk:app:user")).toBe(false); // not a reviewer namespace
+    expect(isMachineReviewerId("")).toBe(false);
+    expect(isMachineReviewerId(undefined)).toBe(false);
+    expect(isMachineReviewerId(null)).toBe(false);
+  });
+});
+
+describe("validateHumanReviewerId", () => {
+  test("allows a human/agent reviewer id", () => {
+    expect(validateHumanReviewerId("admin")).toBeNull();
+    expect(validateHumanReviewerId("flint")).toBeNull();
+  });
+
+  test("rejects a human --reviewer that claims the reserved machine namespace", () => {
+    const err = validateHumanReviewerId(MACHINE_REVIEWER_ADK_AUTO_PROMOTE);
+    expect(err).not.toBeNull();
+    expect(err).toMatch(/reserved/);
+    expect(err).toContain(MACHINE_REVIEWER_PREFIX);
   });
 });


### PR DESCRIPTION
## Security foundations for ADK session distillation (slice #1205a)

Lands the three promotion/tag-isolation foundations the distillation engine (slice #1205b) will build on. K&S-approved design; implements Sherlock's mandatory security requirements. **Refs #1205** (does not close it — the engine slice remains).

### 1. Non-colliding tag sanitize (Sherlock, security-critical)
`_sanitize_tag_segment` (adk-flair `memory_service.py`) replaced only `:` -> `_`, so `user_id="alice:admin"` and `user_id="alice_admin"` both sanitized to `alice_admin` — a tag collision. Since the compound tag `adk:<app>:<user>` is the per-user access-control boundary once distillation relies on it, that collision is cross-user contamination. Replaced with a reversible percent-style encoding (escape `%` first, then `:` and `_`); added `_desanitize_tag_segment` as the exact inverse. Updated the two tests that pinned the old colliding output; added tests for collision-closure, injectivity on tricky inputs, round-trip, and escaped-compound-tag read-match.

### 2. `rem promote` tag-lineage, scoped + fail-closed (Sherlock #2)
`rem promote` hard-coded `["nightly-rem-promoted", "from:<id>"]` and dropped the source tag. New behavior, in the pure `derivePromotedTags`:
- **ADK-sourced** candidate (a source memory carries an `adk:<app>:<user>` tag) -> promoted claim carries the scope tag **alongside** the existing provenance tags.
- **ADK-sourced but untaggable** (multiple distinct scope tags, or an unreadable source) -> promotion **refused** (fail-closed). A tagless claim in a shared ADK namespace is a cross-user leak, not a benign miss.
- **Non-ADK** candidate -> promotes byte-for-byte as before (no adk tag, no fail-closed; a transient/deleted source does not block it).
- ADK-sourced -> **Soul** is refused (Soul is agentId-scoped and cannot carry a per-user tag).

### 3. Non-impersonating machine reviewerId (Sherlock #4)
Reserved the `machine:` reviewer namespace (canonical `machine:adk-auto-promote`) with `isMachineReviewerId` to keep it distinguishable from human/agent reviewers. The human `--reviewer` path now refuses any id in that namespace, so automated attribution can't be laundered. The auto-promote consumer is slice #1205b.

### Seam (foundation only)
Detecting ADK-sourcing by re-reading source memories leaves one residual fail-open: an ADK-sourced candidate all of whose source memories are unreadable yields no adk evidence and is treated as non-ADK. Closing it without regressing non-ADK promotion requires the engine (#1205b) to stamp the authoritative scope tag on the `MemoryCandidate` row at distillation (it distills per single `scope:tagged` tag, so it knows it authoritatively). `derivePromotedTags` is shaped so that override can be threaded in without touching callers. Documented in-code.

### Explicitly NOT in this slice
The distillation driver, tag-aware nightly runner, bounded tag-enumeration query, and server-side auto-promote-to-own-memory resource/policy — all slice #1205b.

### Verification (this session)
- **adk-flair Python:** 45 passed / 1 skipped (baseline 41 / 1). 4 new tests + 2 updated.
- **TS unit lane:** 4285 pass / 13 fail / 2 errors (baseline 4275 / 13 / 2 — the 13 fails + 2 errors are pre-existing harper-5.2 / fabric-replication / authz-integration tests, unrelated to this change). 10 new tests in `cli-rem-promote-reject`.
- **Every added test mutation-checked** (break -> fail -> restore -> green), including positive controls proving non-ADK promotion is unchanged and the collision pair now differs.
- tsc: no new type errors (the single pre-existing error is in `resources/auth-middleware.ts`, untouched).

Do not merge / no reviews requested — K&S dispatch + merge are the maintainer's.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
