### PR TITLE
feat(mcp): connector-conformance suite for the /mcp tools (#1213)

### DIFF
--- a/.changelog/unreleased/added-connector-conformance-suite.md
+++ b/.changelog/unreleased/added-connector-conformance-suite.md
@@ -1,0 +1,8 @@
+- **Connector-conformance suite for the `/mcp` tools.** Every shipped `/mcp`
+  tool now has a declarative consumer contract (shape + semantic invariants),
+  co-located with its definition, driven against a seeded store through the tool's
+  real implementation. The suite codifies the historical connector-bug classes —
+  counted-equals-delivered, charged-equals-shipped, dedup-by-content-signature,
+  self-describing empty containers, the same-estimator `tokenEstimate` check, and
+  no leaked internal fields — and a fail-closed completeness check fails the build
+  if a new tool ships without a contract.

--- a/.changelog/unreleased/fixed-mcp-read-path-internal-field-leaks.md
+++ b/.changelog/unreleased/fixed-mcp-read-path-internal-field-leaks.md
@@ -1,0 +1,6 @@
+- **`/mcp` read paths no longer leak internal fields or throw a misdirecting
+  error.** `memory_get` now strips `embeddingModel` alongside `embedding` (the
+  write tools already dropped both, so the read path was the last leak), and
+  `memory_update` against a non-existent id now returns a clean `not found`
+  instead of throwing `Invalid primary key of null`. Nothing to do — connectors
+  simply stop seeing an internal model-id field and get a parseable 404.

--- a/resources/MemoryBootstrap.ts
+++ b/resources/MemoryBootstrap.ts
@@ -23,6 +23,7 @@ import {
 import { retrieveCandidates, DEFAULT_SELECT } from "./semantic-retrieval-core.js";
 import { buildTrustBlock } from "./trust-block.js";
 import { bestSemanticSimilarity, evaluateAbstention } from "./abstention.js";
+import { estimateTokens } from "./token-estimate.js";
 
 /**
  * POST /MemoryBootstrap
@@ -164,10 +165,10 @@ const TASK_RELEVANCE_FLOOR = 0.3;
 // may exceed `maxTokens` by the scaffolding overhead. See the module-doc CAP
 // CONTRACT above.
 
-// Rough token estimate: ~4 chars per token for English text
-function estimateTokens(text: string): number {
-  return Math.ceil(text.length / 4);
-}
+// Token estimate (~4 chars per token for English text) now lives in the
+// harper-free ./token-estimate.js module, so the content-selection budget, the
+// reported `tokenEstimate`, and the flair#1213 conformance tokenEstimate
+// invariant are all computed with ONE definition. See that module's header.
 
 // `agentId` is the BOOTSTRAPPING agent (the caller) — used only to decide
 // whether to annotate attribution, never to change what's read (that

--- a/resources/mcp-tools.ts
+++ b/resources/mcp-tools.ts
@@ -163,14 +163,35 @@ async function unwrap(value: any): Promise<any> {
 }
 
 /**
- * flair#1188 — remove the raw `embedding` vector from a record before it is
- * returned over the MCP surface. A stored memory carries a 768-float
- * `embedding` (the HNSW vector); inlined into a tool result that is thousands
- * of noise tokens per record on chat connectors that have a fixed context
- * budget, and the caller can never do anything useful with it. Returns a
- * shallow copy WITHOUT `embedding` (never mutates the source record), and
- * passes through anything that is not a plain record — null, primitives,
- * arrays, and the `{ error, status }` shapes `unwrap` produces — untouched.
+ * flair#1188 — the internal, embedding-engine-owned fields a memory record
+ * carries that must NEVER cross the MCP surface. Both are server-managed and
+ * useless (or misleading) to a connector:
+ *
+ *   - `embedding`     — the raw 768-float HNSW vector; thousands of noise
+ *                       tokens per record on a fixed-budget chat connector, and
+ *                       the caller can do nothing with it (flair#1188).
+ *   - `embeddingModel` — the model id stamped on every write
+ *                       (resources/Memory.ts stamps `content.embeddingModel =
+ *                       getModelId()`; schemas/memory.graphql declares it
+ *                       @indexed). The WRITE wrappers already treat it as
+ *                       internal — memory_update `delete`s it from both the
+ *                       overwrite and the supersede record — so the READ path
+ *                       must strip it too, or memory_get leaks an internal
+ *                       field the write echoes hide (flair#1213, Sherlock #1).
+ *
+ * Exported so the flair#1213 conformance "no leaked internal fields" invariant
+ * enumerates the SAME list this function strips: the strip and the assertion
+ * cannot drift, and adding a field here automatically extends both.
+ */
+export const INTERNAL_MEMORY_FIELDS = ["embedding", "embeddingModel"] as const;
+
+/**
+ * flair#1188 / flair#1213 — remove the internal embedding-engine fields (see
+ * `INTERNAL_MEMORY_FIELDS`) from a record before it is returned over the MCP
+ * surface. Returns a shallow copy WITHOUT those fields (never mutates the
+ * source record), and passes through anything that is not a plain record —
+ * null, primitives, arrays, and the `{ error, status }` shapes `unwrap`
+ * produces — untouched.
  *
  * `memory_search` already projects with an explicit select that omits
  * `embedding` (resources/semantic-retrieval-core.ts's DEFAULT_SELECT), and
@@ -178,11 +199,17 @@ async function unwrap(value: any): Promise<any> {
  * needed on the FULL-record read/write paths (memory_get, and the write
  * responses that echo the stored row).
  */
-function stripEmbedding(value: any): any {
+function stripInternalFields(value: any): any {
   if (!value || typeof value !== "object" || Array.isArray(value)) return value;
-  if (!("embedding" in value)) return value;
-  const { embedding, ...rest } = value;
-  return rest;
+  let out = value;
+  let copied = false;
+  for (const field of INTERNAL_MEMORY_FIELDS) {
+    if (field in out) {
+      if (!copied) { out = { ...out }; copied = true; }
+      delete out[field];
+    }
+  }
+  return out;
 }
 
 // ── Tool implementations (thin wrappers over existing handlers) ──────────────
@@ -261,7 +288,7 @@ async function memoryStore(agent: ResolvedAgent, args: any) {
   // flair#1188 — memory_store's response goes through the same buildWriteResponse
   // echo as memory_update; strip the server-regenerated embedding so no write
   // tool ever inlines the vector. No-op when the response carries none.
-  return stripEmbedding(await unwrap(await h.post(body)));
+  return stripInternalFields(await unwrap(await h.post(body)));
 }
 
 /**
@@ -294,8 +321,18 @@ async function memoryUpdate(agent: ResolvedAgent, args: any) {
   // `new Cls(undefined, ctx).get(id)` returned `undefined` for the caller's own
   // record (getProperty on an unloaded instance), so memory_update 404'd
   // ("memory not found") on the connector path before it ever reached a write.
-  const existing = await Cls.get(id, delegationContext(agent));
-  if (!existing) {
+  //
+  // flair#1213 — the get MUST be `unwrap`ped (as memoryGet does), not consumed
+  // raw. Memory.get()'s makeByIdReadGate returns a NOT_FOUND() *Response* (404)
+  // for an absent or non-readable id — a TRUTHY object with no `id` — so the
+  // bare `if (!existing)` guard never fired: the code fell through and PUT a
+  // record whose id spread off the Response as `undefined`, throwing the
+  // MISDIRECTING "Invalid primary key of null" instead of a clean 404. This is
+  // the same by-id-read-on-the-connector-seam class as #1181, caught by the
+  // conformance error contract (Kern #5). Unwrap, then treat a 404/error/absent
+  // result as "not found".
+  const existing = await unwrap(await Cls.get(id, delegationContext(agent)));
+  if (!existing || (existing as any).error != null || (existing as any).status === 404) {
     return { error: "memory not found", status: 404 };
   }
 
@@ -337,7 +374,7 @@ async function memoryUpdate(agent: ResolvedAgent, args: any) {
     // flair#1188 — the write response echoes the stored row (Memory.post
     // regenerates the embedding server-side), so strip the vector before it
     // returns over the MCP surface. No-op when the response carries none.
-    return stripEmbedding(await unwrap(await coll.post(record)));
+    return stripInternalFields(await unwrap(await coll.post(record)));
   }
 
   const merged: Record<string, unknown> = { ...existing, content, updatedAt: new Date().toISOString() };
@@ -356,7 +393,7 @@ async function memoryUpdate(agent: ResolvedAgent, args: any) {
   // Memory.put()'s own ownership gate — no scope change, same as the read.
   // flair#1188 — strip the embedding from the echoed write response (Memory.put
   // regenerates the vector server-side); no-op when the response carries none.
-  return stripEmbedding(await unwrap(await Cls.put(merged, delegationContext(agent))));
+  return stripInternalFields(await unwrap(await Cls.put(merged, delegationContext(agent))));
 }
 
 async function memoryGet(agent: ResolvedAgent, args: any) {
@@ -385,7 +422,7 @@ async function memoryGet(agent: ResolvedAgent, args: any) {
   // Strip it by default so a chat connector isn't flooded with thousands of
   // useless tokens per record; return it only when the caller explicitly opts
   // in via includeEmbedding.
-  return args?.includeEmbedding === true ? result : stripEmbedding(result);
+  return args?.includeEmbedding === true ? result : stripInternalFields(result);
 }
 
 async function memoryDelete(agent: ResolvedAgent, args: any) {
@@ -546,15 +583,192 @@ async function recordUsage(agent: ResolvedAgent, args: any) {
 
 type ToolImpl = (agent: ResolvedAgent, args: any) => Promise<any>;
 
+// ── flair#1213 — the connector CONSUMER CONTRACT, co-located with each tool ──
+//
+// Each ToolEntry below carries a declarative `contract`: the SHAPE and
+// SEMANTICS a /mcp connector is entitled to rely on from that tool. It lives
+// RIGHT NEXT TO the tool's def+impl (Kern #2) so a response-shape change to the
+// wrapper prompts a contract update in the same diff — the completeness check
+// catches a MISSING contract, co-location is what keeps a present one from going
+// STALE. The conformance suite
+// (test/integration/mcp-connector-conformance-suite.test.ts) reads these,
+// drives each tool's REAL `.impl` against a seeded store, and asserts every
+// declared field/type/invariant. The historical connector bugs
+// (#1181/#1188/#1182/#1199/#1200/#1206) each map to an invariant below, proven
+// by the mutation-validation log in the PR: revert the fix ⇒ a conformance test
+// goes red.
+
+type FieldType = "string" | "number" | "boolean" | "object" | "array";
+
+/** Semantic invariants — the class each historical connector bug lived in. */
+export interface ToolInvariants {
+  /**
+   * A self-describing COUNT field must equal the TOTAL length of the
+   * container(s) it describes: counted == delivered (flair#1199
+   * memoriesIncluded/teammateFindingsIncluded; flair#1206 sections.events).
+   * `count` may be a dotted path (e.g. "sections.events"); `containers` are
+   * top-level arrays whose lengths SUM to the count.
+   *
+   * `containers` is a list, not a single name, because `memoriesIncluded`
+   * legitimately spans TWO delivered own-memory containers: `memories`
+   * (permanent/recent/relevant) AND `predicted` (subject-matched) — both are
+   * own memories, both are counted (resources/MemoryBootstrap.ts increments
+   * memoriesIncluded at the predicted push too). Asserting it against
+   * `memories` alone would false-fail whenever predicted is non-empty; the
+   * correct invariant is memoriesIncluded === memories.length + predicted.length.
+   */
+  countEqualsDelivered?: Array<{ count: string; containers: string[] }>;
+  /**
+   * Containers that must be PRESENT and correctly typed even when the caller
+   * has none — an empty `[]`/`{}` with a hint, never a bare `{}`, a missing
+   * key, or `undefined` (self-describing empty, flair#1182).
+   */
+  selfDescribingEmpty?: Array<{ path: string; type: "array" | "object" }>;
+  /**
+   * No two entries in `container` share the same tuple of `signatureFields`
+   * (flair#1200 dedup). The signature is the SEMANTIC content key the tool
+   * actually dedups on — for org-events `kind+summary+detail+targetIds`
+   * (resources/MemoryBootstrap.ts's eventBySignature), the exact fields that
+   * stay EQUAL across physical duplicate rows. It deliberately excludes `id`
+   * and `createdAt`, which VARY between those rows (OrgEvent.post keys the id
+   * off a millisecond timestamp), so keying on either would miss the dupe the
+   * fixture seeds. See the conformance suite's fixture note.
+   */
+  dedupSignature?: { container: string; signatureFields: string[] };
+  /**
+   * `tokenEstimate` must equal the wrapper's OWN estimator applied to the
+   * delivered payload: estimateTokens(JSON.stringify(result minus excludeKeys))
+   * (flair#1199 double-serialization; Kern #1 / Sherlock #2). Same estimator,
+   * not a byte length or a different tokenizer — so it catches the class
+   * without being brittle to a future estimator change. `excludeKeys` are the
+   * fields added AFTER the estimate was taken (tokenEstimate itself, and the
+   * wrapper-injected flairVersion).
+   */
+  tokenEstimate?: { field: string; excludeKeys: string[] };
+  /**
+   * At the /mcp default the prose `field` (context) must be a compact POINTER,
+   * never a second copy of the structured bodies — the structured containers
+   * are canonical; prose is opt-in via includeContext (flair#1199). The suite
+   * asserts it carries none of the delivered event summaries / memory contents.
+   */
+  proseContextIsPointerAtDefault?: { field: string };
+  /**
+   * Per-element rules for a named array container: every element carries
+   * `requiredFields` and leaks none of `forbiddenFields`. Lets the leaked-
+   * internal-fields invariant (#1188) bite on bootstrap's `memories` and the
+   * shape invariant on its `events`, not just the flat record tools.
+   */
+  containerRules?: Array<{ container: string; requiredFields?: string[]; forbiddenFields?: readonly string[] }>;
+  /**
+   * Documents that the suite's UNIVERSAL structural check applies here (it runs
+   * on every tool regardless): no field value is a JSON-stringified object/
+   * array, and nothing serialized to a pending Promise or `[object Object]`
+   * (flair#1199/#1182 — the payload is fully resolved and structured).
+   */
+  fullyResolved?: boolean;
+}
+
+/**
+ * The declarative consumer contract for one /mcp tool. `requiredFields`,
+ * `fieldTypes` and `forbiddenFields` describe the RESULT OBJECT the tool
+ * returns; `invariants` carry the cross-field semantics; `errorShape` pins the
+ * one error case a connector must be able to parse (Kern #5).
+ */
+export interface ToolContract {
+  /** One line: what a connector gets back from this tool. */
+  summary: string;
+  /** Fields that MUST be present (and not undefined) on the result object. */
+  requiredFields?: string[];
+  /** Expected JS type per field on the result object. */
+  fieldTypes?: Record<string, FieldType>;
+  /**
+   * Fields that must NEVER appear on the result object. For the memory record
+   * tools this is `INTERNAL_MEMORY_FIELDS` — BOTH `embedding` and
+   * `embeddingModel` (flair#1188 + flair#1213 Sherlock #1), so the invariant
+   * bites on either leak.
+   */
+  forbiddenFields?: readonly string[];
+  invariants?: ToolInvariants;
+  /**
+   * One error case: the shape a connector must be able to parse when the tool
+   * refuses. `trigger` is a human note on how the suite provokes it; the
+   * response must carry every field in `fields` and leak none in `mustNotLeak`
+   * (no stack traces / internal paths).
+   */
+  errorShape?: { trigger: string; fields: string[]; mustNotLeak?: readonly string[] };
+}
+
 /**
  * The tool registry: definition (for tools/list) + implementation (for
- * tools/call), keyed by tool name. The single source of truth for BOTH the
- * advertised surface and the dispatch table — so tools/list and tools/call
- * cannot drift (a tool listed but not callable, or vice versa, is impossible).
+ * tools/call) + the connector CONTRACT (for the flair#1213 conformance suite),
+ * keyed by tool name. The single source of truth for the advertised surface,
+ * the dispatch table, AND the consumer contract — so none of the three can
+ * drift (a tool listed but not callable, or shipped without a contract, is
+ * impossible: `contract` is required by the type and by
+ * `checkContractCompleteness` at runtime).
  */
 interface ToolEntry {
   def: McpToolDef;
   impl: ToolImpl;
+  contract: ToolContract;
+}
+
+/** The result of the flair#1213 completeness gate. */
+export interface CompletenessResult {
+  ok: boolean;
+  /** How many tools the gate actually enumerated. `> 0` on any non-vacuous run. */
+  examined: number;
+  /** Tool names shipped with no contract. */
+  missing: string[];
+  reason?: string;
+}
+
+/**
+ * flair#1213 completeness gate — FAIL-CLOSED (the flair#953 lesson, Sherlock
+ * #3). Every tool shipped in `tools` must carry a `.contract`; a new /mcp tool
+ * without one fails the build.
+ *
+ * The fail-closed part is the point: if the registry cannot be enumerated — it
+ * is not a plain object (a broken import left it `undefined`), or it is empty —
+ * this returns `ok:false` with `examined:0`, NEVER a vacuous "0 tools examined,
+ * 0 missing, pass". A check that could not run must not render as passed. The
+ * conformance suite asserts both `ok` AND `examined > 0` so the vacuous path
+ * cannot masquerade as coverage; the fail-closed unit test exercises every
+ * branch.
+ */
+export function checkContractCompleteness(
+  tools: Record<string, ToolEntry> | Record<string, { contract?: unknown }> | undefined | null,
+): CompletenessResult {
+  if (!tools || typeof tools !== "object" || Array.isArray(tools)) {
+    return {
+      ok: false,
+      examined: 0,
+      missing: [],
+      reason: "TOOLS registry is not an enumerable object (unloadable import?) — refusing to pass vacuously",
+    };
+  }
+  const names = Object.keys(tools);
+  if (names.length === 0) {
+    return {
+      ok: false,
+      examined: 0,
+      missing: [],
+      reason: "TOOLS registry is empty — refusing to pass vacuously (a new tool must carry a conformance contract)",
+    };
+  }
+  const missing = names.filter((n) => {
+    const entry = (tools as Record<string, { contract?: unknown }>)[n];
+    return !entry || !entry.contract || typeof entry.contract !== "object";
+  });
+  return {
+    ok: missing.length === 0,
+    examined: names.length,
+    missing,
+    reason: missing.length
+      ? `${missing.length} tool(s) shipped with no conformance contract: ${missing.join(", ")}. `
+        + "Add a `contract` to each in resources/mcp-tools.ts (co-located with its def+impl)."
+      : undefined,
+  };
 }
 
 /**
@@ -612,6 +826,16 @@ export const TOOLS: Record<string, ToolEntry> = {
       },
     },
     impl: memorySearch,
+    contract: {
+      summary: "{ results: MemoryRecord[] } — semantic hits scoped to the caller's own + granted memories; each hit carries content, never the raw embedding.",
+      requiredFields: ["results"],
+      fieldTypes: { results: "array" },
+      invariants: {
+        selfDescribingEmpty: [{ path: "results", type: "array" }],
+        containerRules: [{ container: "results", requiredFields: ["id", "content"], forbiddenFields: INTERNAL_MEMORY_FIELDS }],
+        fullyResolved: true,
+      },
+    },
   },
   memory_store: {
     def: {
@@ -641,6 +865,14 @@ export const TOOLS: Record<string, ToolEntry> = {
       },
     },
     impl: memoryStore,
+    contract: {
+      summary: "Write echo { id, written:true, deduplicated } — the new id + confirmation. No internal embedding fields; round-trips via memory_get.",
+      requiredFields: ["id", "written"],
+      fieldTypes: { id: "string", written: "boolean", deduplicated: "boolean" },
+      forbiddenFields: INTERNAL_MEMORY_FIELDS,
+      invariants: { fullyResolved: true },
+      errorShape: { trigger: "an unrecognized visibility value (e.g. \"prvate\")", fields: ["error", "status"], mustNotLeak: INTERNAL_MEMORY_FIELDS },
+    },
   },
   memory_update: {
     def: {
@@ -660,6 +892,14 @@ export const TOOLS: Record<string, ToolEntry> = {
       },
     },
     impl: memoryUpdate,
+    contract: {
+      summary: "Write echo { id, written:true } for the in-place overwrite (or supersede). No internal embedding fields; the change round-trips via memory_get.",
+      requiredFields: ["id", "written"],
+      fieldTypes: { id: "string", written: "boolean" },
+      forbiddenFields: INTERNAL_MEMORY_FIELDS,
+      invariants: { fullyResolved: true },
+      errorShape: { trigger: "updating a non-existent id", fields: ["error", "status"] },
+    },
   },
   memory_get: {
     def: {
@@ -678,6 +918,14 @@ export const TOOLS: Record<string, ToolEntry> = {
       },
     },
     impl: memoryGet,
+    contract: {
+      summary: "The full memory record { id, agentId, content, durability, createdAt, ... } for the caller's own id — embedding + embeddingModel stripped by default.",
+      requiredFields: ["id", "agentId", "content", "createdAt"],
+      fieldTypes: { id: "string", agentId: "string", content: "string" },
+      forbiddenFields: INTERNAL_MEMORY_FIELDS,
+      invariants: { fullyResolved: true },
+      errorShape: { trigger: "get a non-existent / unowned id (makeByIdReadGate 404)", fields: ["error", "status"] },
+    },
   },
   memory_delete: {
     def: {
@@ -691,6 +939,11 @@ export const TOOLS: Record<string, ToolEntry> = {
       },
     },
     impl: memoryDelete,
+    contract: {
+      summary: "Deletes the caller's own memory (success echo is thin). The permanent-memory guard returns { error, status:403 } for a non-admin; the row round-trips as gone via memory_get.",
+      invariants: { fullyResolved: true },
+      errorShape: { trigger: "a non-admin deletes a permanent memory", fields: ["error", "status"] },
+    },
   },
   bootstrap: {
     def: {
@@ -719,6 +972,51 @@ export const TOOLS: Record<string, ToolEntry> = {
       },
     },
     impl: bootstrap,
+    contract: {
+      summary:
+        "Session context: { agentId, soul, memories, predicted, teammateFindings, events, sections, tokenEstimate, memoriesIncluded, ..., context, flairVersion }. "
+        + "Structured containers are canonical and always present; prose `context` is a pointer at the /mcp default (includeContext opt-in).",
+      requiredFields: [
+        "agentId", "soul", "memories", "predicted", "teammateFindings", "events",
+        "sections", "tokenEstimate", "memoriesIncluded", "memoriesAvailable",
+        "teammateFindingsIncluded", "context", "flairVersion",
+      ],
+      fieldTypes: {
+        agentId: "string", soul: "object", memories: "array", predicted: "array",
+        teammateFindings: "array", events: "array", sections: "object",
+        tokenEstimate: "number", memoriesIncluded: "number", memoriesAvailable: "number",
+        teammateFindingsIncluded: "number", context: "string", flairVersion: "string",
+      },
+      invariants: {
+        // count == delivered — the historical count/charge/deliver drift.
+        countEqualsDelivered: [
+          // memoriesIncluded spans BOTH own-memory containers (see the type doc).
+          { count: "memoriesIncluded", containers: ["memories", "predicted"] },     // #1199
+          { count: "teammateFindingsIncluded", containers: ["teammateFindings"] },  // #1199
+          { count: "sections.events", containers: ["events"] },                     // #1206
+        ],
+        // present + typed even when empty — never a bare {} / missing key (#1182).
+        selfDescribingEmpty: [
+          { path: "soul", type: "object" }, { path: "memories", type: "array" },
+          { path: "predicted", type: "array" }, { path: "teammateFindings", type: "array" },
+          { path: "events", type: "array" }, { path: "sections", type: "object" },
+        ],
+        // #1200 — dedup by the SEMANTIC content key (excludes id/createdAt, which
+        // vary across physical duplicate rows). See ToolInvariants.dedupSignature.
+        dedupSignature: { container: "events", signatureFields: ["kind", "summary", "detail", "targetIds"] },
+        // #1199 — tokenEstimate via the wrapper's own estimator over the delivered
+        // payload (minus the two fields added after it was measured).
+        tokenEstimate: { field: "tokenEstimate", excludeKeys: ["tokenEstimate", "flairVersion"] },
+        // #1199 — prose is a pointer at the default, not a second copy.
+        proseContextIsPointerAtDefault: { field: "context" },
+        // shape of the structured containers a connector reads; #1188 leak bites on memories.
+        containerRules: [
+          { container: "events", requiredFields: ["id", "kind", "summary", "createdAt"] },
+          { container: "memories", requiredFields: ["id", "content"], forbiddenFields: INTERNAL_MEMORY_FIELDS },
+        ],
+        fullyResolved: true, // #1182 — never a spread pending Promise collapsing to {flairVersion}.
+      },
+    },
   },
   soul_set: {
     def: {
@@ -734,6 +1032,10 @@ export const TOOLS: Record<string, ToolEntry> = {
       },
     },
     impl: soulSet,
+    contract: {
+      summary: "Writes a soul entry keyed `${agentId}:${key}`, attributed to the caller. Correctness is proven by the soul_get round-trip — this is the write flair#1181 broke on the connector path.",
+      invariants: { fullyResolved: true },
+    },
   },
   soul_get: {
     def: {
@@ -747,6 +1049,12 @@ export const TOOLS: Record<string, ToolEntry> = {
       },
     },
     impl: soulGet,
+    contract: {
+      summary: "The soul entry { id, agentId, key, value, createdAt } for the caller's own `${agentId}:${key}`.",
+      requiredFields: ["id", "agentId", "key", "value", "createdAt"],
+      fieldTypes: { id: "string", agentId: "string", key: "string", value: "string" },
+      invariants: { fullyResolved: true },
+    },
   },
   flair_workspace_set: {
     def: {
@@ -767,6 +1075,10 @@ export const TOOLS: Record<string, ToolEntry> = {
       },
     },
     impl: workspaceSet,
+    contract: {
+      summary: "Writes the caller's workspace state keyed `${agentId}:${ref}`, attributed to the caller (never the body). The echo is thin; persistence is verified in storage.",
+      invariants: { fullyResolved: true },
+    },
   },
   flair_orgevent: {
     def: {
@@ -786,6 +1098,10 @@ export const TOOLS: Record<string, ToolEntry> = {
       },
     },
     impl: orgEvent,
+    contract: {
+      summary: "Publishes an org event attributed to the caller (authorId from identity, never the body). The echo is thin; persistence is verified in storage.",
+      invariants: { fullyResolved: true },
+    },
   },
   attention: {
     def: {
@@ -805,6 +1121,15 @@ export const TOOLS: Record<string, ToolEntry> = {
       },
     },
     impl: attention,
+    contract: {
+      summary: "Grouped-by-source view { entity, windowDays, since, groups:{memory,relationship,workspaceState,presence,orgEvent}, counts } for entity E over N days.",
+      requiredFields: ["entity", "windowDays", "groups", "counts"],
+      fieldTypes: { entity: "string", windowDays: "number", groups: "object", counts: "object" },
+      invariants: {
+        selfDescribingEmpty: [{ path: "groups", type: "object" }, { path: "counts", type: "object" }],
+        fullyResolved: true,
+      },
+    },
   },
   record_usage: {
     def: {
@@ -823,6 +1148,12 @@ export const TOOLS: Record<string, ToolEntry> = {
       },
     },
     impl: recordUsage,
+    contract: {
+      summary: "Invariant acknowledgement { recorded:true } — byte-identical regardless of how many ids counted (no id enumeration, Sherlock).",
+      requiredFields: ["recorded"],
+      fieldTypes: { recorded: "boolean" },
+      invariants: { fullyResolved: true },
+    },
   },
 };
 

--- a/resources/token-estimate.ts
+++ b/resources/token-estimate.ts
@@ -1,0 +1,25 @@
+/**
+ * token-estimate.ts — the ONE token estimator the bootstrap payload budget and
+ * `tokenEstimate` report are computed with.
+ *
+ * Extracted to a harper-free module (no `import ... from "harper"`) for two
+ * reasons:
+ *
+ *   1. Single source of truth. `MemoryBootstrap` computes both its content-
+ *      selection budget and the reported `tokenEstimate` with THIS function, so
+ *      there is exactly one definition of "how many tokens is this text".
+ *   2. The flair#1213 connector-conformance suite asserts the tokenEstimate
+ *      invariant — `tokenEstimate === estimateTokens(JSON.stringify(deliveredPayload))`
+ *      — with the SAME estimator, not a byte length or a different tokenizer
+ *      (Kern #1 / Sherlock #2). Importing this module (which never pulls in
+ *      Harper) lets a plain bun:test process reconstruct the estimate exactly,
+ *      so the invariant catches the flair#1199 double-serialization class
+ *      without being brittle to a future estimator change: change the formula
+ *      here and both the report and the invariant move together.
+ *
+ * The estimate is deliberately coarse (~4 chars per token for English text). It
+ * is a budgeting/reporting heuristic, never a billing figure.
+ */
+export function estimateTokens(text: string): number {
+  return Math.ceil(text.length / 4);
+}

--- a/test/integration/mcp-connector-conformance-suite.test.ts
+++ b/test/integration/mcp-connector-conformance-suite.test.ts
@@ -1,0 +1,541 @@
+// ─── /mcp connector-CONFORMANCE suite — the consumer contract, not just "does it run" ───
+//
+// flair#1213. The #1197 wrapper-layer suite (mcp-wrapper-layer-suite.test.ts)
+// proved every tool's REAL `TOOLS.<tool>.impl` returns SOMETHING sane. This
+// suite is the next altitude up: per tool, it asserts the SHAPE and SEMANTICS a
+// /mcp connector is entitled to rely on — the declarative `contract` co-located
+// with each tool in resources/mcp-tools.ts — driven against a seeded ephemeral
+// store, same driver (the inproc-app fixture's generic `mcpTool` op) and same
+// HOME-isolated Harper lifecycle as #1197.
+//
+// Every historical connector bug maps to an invariant here, and the PR's
+// mutation-validation log proves each one BITES: revert the fix, a test below
+// goes red.
+//
+//   #1181  by-id reads via an unloaded instance 404'd the caller's own record
+//          → requiredFields (memory_get id/agentId/content) + the write→read
+//            round-trips go red.
+//   #1188  memory_get inlined the raw embedding vector
+//          → forbiddenFields (embedding) go red.
+//   #1213  …and embeddingModel still leaked on the read path (Sherlock #1)
+//          → forbiddenFields (embeddingModel) go red.
+//   #1182  bootstrap spread a PENDING PROMISE → {flairVersion} only
+//          → requiredFields + count==delivered + self-describing-empty go red.
+//   #1199  tokenEstimate under-reported (measured prose, not the real payload);
+//          prose context doubled the payload at the /mcp default
+//          → the same-estimator tokenEstimate invariant + prose-is-a-pointer go red.
+//   #1200  byte-identical duplicate org events wasted the scarce event slots
+//          → the dedup-by-content-signature invariant goes red.
+//   #1206  org events were counted+charged but not delivered structurally
+//          → count==delivered (sections.events) + requiredFields(events) go red.
+//
+// The completeness check (checkContractCompleteness) is CI-gated in THIS lane:
+// a new /mcp tool shipped without a contract fails the build, fail-closed.
+import { describe, expect, test, beforeAll, afterAll } from "bun:test";
+import { mkdtemp, rm, mkdir, cp, symlink } from "node:fs/promises";
+import { randomUUID } from "node:crypto";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { startHarper, stopHarper, HarperInstance } from "../helpers/harper-lifecycle";
+import {
+  TOOLS,
+  INTERNAL_MEMORY_FIELDS,
+  checkContractCompleteness,
+  type ToolContract,
+} from "../../resources/mcp-tools";
+// The wrapper's OWN token estimator (harper-free single source) — the
+// tokenEstimate invariant reconstructs the estimate with the SAME function the
+// handler used, so it catches the #1199 double-serialization class without
+// being brittle to a future estimator change (Kern #1 / Sherlock #2).
+import { estimateTokens } from "../../resources/token-estimate";
+
+const REPO_ROOT = process.cwd();
+const FIXTURE = join(REPO_ROOT, "test", "fixtures", "inproc-app");
+
+let harper: HarperInstance;
+let appDir: string;
+
+const sfx = Date.now().toString(36);
+const AGENT = `mcpconf-${sfx}`;
+const AGENT2 = `mcpconf-other-${sfx}`;
+const SOUL_ROLE = `MCP conformance test subject ${sfx}`;
+
+// A directly-seeded memory carrying KNOWN embedding + embeddingModel — the
+// engine-independent #1188 / #1213 differential: the record demonstrably HAS
+// both internal fields, so a read path that stops stripping either leaks a value
+// the forbiddenFields invariant can see.
+const GET_ID = `${AGENT}-${randomUUID()}`;
+const GET_CONTENT = `mcp conformance seeded record for memory_get ${sfx}`;
+const EMBEDDING = Array.from({ length: 768 }, (_, i) => Math.sin(i) / 10);
+
+const SEARCH_TOKEN = `zqxwconform${sfx}`;
+
+// A private memory owned by ANOTHER agent — the read-scope boundary: AGENT must
+// not be able to memory_get it.
+const OTHER_PRIV_ID = `${AGENT2}-${randomUUID()}`;
+const OTHER_PRIV_CONTENT = `agent2 private memory ${sfx} — AGENT must never read this`;
+
+/** Drive one in-process operation inside the fixture app. */
+async function fleet(op: string, body: Record<string, unknown> = {}): Promise<any> {
+  const res = await fetch(`${harper.httpURL}/AgentFleet/`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: "Basic " + btoa(`${harper.admin.username}:${harper.admin.password}`),
+    },
+    body: JSON.stringify({ op, ...body }),
+  });
+  const text = await res.text();
+  if (!res.ok) throw new Error(`AgentFleet ${op} → HTTP ${res.status}: ${text.slice(0, 400)}`);
+  return JSON.parse(text);
+}
+
+/** Call a /mcp tool wrapper (`TOOLS[tool].impl`) as AGENT (or admin) and unwrap the run() envelope. */
+async function tool(name: string, args: Record<string, unknown> = {}, opts: { agentId?: string; isAdmin?: boolean } = {}): Promise<any> {
+  const res = await fleet("mcpTool", { agentId: opts.agentId ?? AGENT, tool: name, args, isAdmin: opts.isAdmin ?? false });
+  expect(res.ok, `mcpTool ${name} failed: ${JSON.stringify(res).slice(0, 500)}`).toBe(true);
+  return res.value;
+}
+
+/** POST an ops-API operation with admin creds; returns the parsed JSON body. */
+async function ops(operation: Record<string, unknown>): Promise<any> {
+  const res = await fetch(harper.opsURL, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: "Basic " + btoa(`${harper.admin.username}:${harper.admin.password}`),
+    },
+    body: JSON.stringify(operation),
+  });
+  const text = await res.text();
+  return { status: res.status, body: text ? JSON.parse(text) : null };
+}
+
+async function seedInsert(table: string, record: Record<string, unknown>): Promise<void> {
+  const { status } = await ops({ operation: "insert", database: "flair", table, records: [record] });
+  expect(status, `${table} insert → ${status}`).toBe(200);
+}
+
+async function opsSearchEquals(table: string, attribute: string, value: string): Promise<any[]> {
+  const { status, body } = await ops({
+    operation: "search_by_conditions",
+    database: "flair",
+    table,
+    operator: "and",
+    get_attributes: ["*"],
+    conditions: [{ search_attribute: attribute, search_type: "equals", search_value: value }],
+  });
+  expect(status, `${table} search_by_conditions → ${status}`).toBe(200);
+  return Array.isArray(body) ? body : [];
+}
+
+// ── unique event summaries so counts/dedup are unambiguous ──────────────────
+const EV = randomUUID();
+const DUP_SUMMARY = `conf-1200 duplicate-pair ${EV}`;   // seeded TWICE (byte-identical content, distinct id/createdAt)
+const ORG_SUMMARY = `conf-1206 org-scoped ${EV}`;
+const MINE_SUMMARY = `conf-1206 targeted-to-me ${EV}`;
+const OTHER_SUMMARY = `conf-1206 targeted-elsewhere ${EV}`;
+
+beforeAll(async () => {
+  appDir = await mkdtemp(join(tmpdir(), "flair-inproc-mcpconf-"));
+  await cp(FIXTURE, appDir, { recursive: true });
+  await mkdir(join(appDir, "node_modules", "@tpsdev-ai"), { recursive: true });
+  await symlink(REPO_ROOT, join(appDir, "node_modules", "@tpsdev-ai", "flair"), "dir");
+  harper = await startHarper({ cwd: appDir, harperBinDir: REPO_ROOT });
+
+  await fleet("register", { id: AGENT });
+  await fleet("register", { id: AGENT2 });
+
+  // Soul entry (soul_get).
+  await seedInsert("Soul", {
+    id: `${AGENT}:role`, agentId: AGENT, key: "role", value: SOUL_ROLE,
+    createdAt: new Date().toISOString(),
+  });
+
+  // A memory carrying both internal fields (memory_get leak differential).
+  await seedInsert("Memory", {
+    id: GET_ID, agentId: AGENT, content: GET_CONTENT,
+    durability: "standard", visibility: "private",
+    embedding: EMBEDDING, embeddingModel: "seed-fixture",
+    createdAt: new Date().toISOString(), validFrom: new Date().toISOString(),
+  });
+
+  // Own memories so bootstrap.memories is non-empty (count==delivered, container
+  // rules bite) and search has hits.
+  for (let i = 0; i < 3; i++) {
+    await seedInsert("Memory", {
+      id: `${AGENT}-${randomUUID()}`, agentId: AGENT,
+      content: `${SEARCH_TOKEN} conformance own-memory ${i} ${sfx}`,
+      durability: "standard", visibility: "private",
+      createdAt: new Date(Date.now() - i * 1000).toISOString(), validFrom: new Date().toISOString(),
+    });
+  }
+
+  // A relationship on an entity (attention has cross-source data).
+  await seedInsert("Relationship", {
+    id: `${AGENT}-${randomUUID()}`, agentId: AGENT,
+    subject: `agent:${AGENT}`, predicate: "works_with", object: "repo:tpsdev-ai/flair",
+    confidence: 1.0, validFrom: new Date().toISOString(), createdAt: new Date().toISOString(),
+  });
+
+  // Another agent's PRIVATE memory (read-scope boundary).
+  await seedInsert("Memory", {
+    id: OTHER_PRIV_ID, agentId: AGENT2, content: OTHER_PRIV_CONTENT,
+    durability: "standard", visibility: "private",
+    createdAt: new Date().toISOString(), validFrom: new Date().toISOString(),
+  });
+
+  // Org events:
+  //  • a DUPLICATE PAIR — byte-identical content (kind+summary+detail+targetIds),
+  //    distinct id + createdAt (mimicking a double-fire) → #1200 collapses to 1.
+  //  • an org-scoped event, and one targeted at AGENT → both relevant.
+  //  • one targeted at someone else → the relevance filter excludes it.
+  const author = `conf-author-${EV}`;
+  for (let i = 0; i < 2; i++) {
+    await seedInsert("OrgEvent", {
+      id: `conf-dup-${i}-${EV}`, authorId: author, kind: "status",
+      summary: DUP_SUMMARY, detail: "same content twice", scope: "org",
+      createdAt: new Date(Date.now() - i * 1000).toISOString(),
+    });
+  }
+  await seedInsert("OrgEvent", {
+    id: `conf-org-${EV}`, authorId: author, kind: "status", summary: ORG_SUMMARY,
+    scope: "org", createdAt: new Date().toISOString(),
+  });
+  await seedInsert("OrgEvent", {
+    id: `conf-mine-${EV}`, authorId: author, kind: "handoff", summary: MINE_SUMMARY,
+    scope: "direct", targetIds: [AGENT], detail: "please pick this up",
+    createdAt: new Date().toISOString(),
+  });
+  await seedInsert("OrgEvent", {
+    id: `conf-other-${EV}`, authorId: author, kind: "handoff", summary: OTHER_SUMMARY,
+    scope: "direct", targetIds: [`someone-else-${EV}`], createdAt: new Date().toISOString(),
+  });
+}, 300_000);
+
+afterAll(async () => {
+  const dataDir = harper?.installDir;
+  if (harper) await stopHarper(harper);
+  if (dataDir) await rm(dataDir, { recursive: true, force: true, maxRetries: 4 });
+  if (appDir) await rm(appDir, { recursive: true, force: true });
+});
+
+// ── contract-driven assertion engine ────────────────────────────────────────
+
+type FieldType = "string" | "number" | "boolean" | "object" | "array";
+function jsTypeOf(v: any): string {
+  if (Array.isArray(v)) return "array";
+  if (v === null) return "null";
+  return typeof v;
+}
+function getPath(obj: any, path: string): any {
+  return path.split(".").reduce((o, k) => (o == null ? undefined : o[k]), obj);
+}
+function has(obj: any, key: string): boolean {
+  return obj != null && typeof obj === "object" && Object.prototype.hasOwnProperty.call(obj, key);
+}
+
+/**
+ * UNIVERSAL structural check (runs on every tool result): the payload is fully
+ * resolved and structured — never a double-serialized JSON string, never a
+ * pending Promise, never a stringified object (flair#1199/#1182).
+ */
+function assertFullyResolved(toolName: string, result: any): void {
+  if (typeof result === "string") {
+    let parsed: any;
+    try { parsed = JSON.parse(result); } catch { parsed = undefined; }
+    expect(
+      parsed !== null && typeof parsed === "object",
+      `${toolName}: result is a JSON string that parses to an object — double-serialized payload`,
+    ).toBe(false);
+  }
+  const seen = new WeakSet<object>();
+  (function walk(v: any, path: string): void {
+    if (v == null) return;
+    if (typeof v === "object") {
+      expect(typeof (v as any).then, `${toolName}: ${path} is a thenable/pending Promise in the payload`).not.toBe("function");
+      if (seen.has(v)) return;
+      seen.add(v);
+      for (const k of Object.keys(v)) walk(v[k], `${path}.${k}`);
+      return;
+    }
+    if (typeof v === "string") {
+      expect(v.includes("[object Object]"), `${toolName}: ${path} contains "[object Object]" (a stringified object)`).toBe(false);
+      expect(v.includes("[object Promise]"), `${toolName}: ${path} contains "[object Promise]" (a stringified Promise)`).toBe(false);
+    }
+  })(result, "result");
+}
+
+/** Apply a tool's full declarative contract to a driven result. */
+function conform(toolName: string, result: any, contract: ToolContract): void {
+  assertFullyResolved(toolName, result);
+
+  for (const f of contract.requiredFields ?? []) {
+    expect(result?.[f], `${toolName}: required field '${f}' missing (got ${JSON.stringify(result).slice(0, 220)})`).not.toBeUndefined();
+  }
+  for (const [f, t] of Object.entries(contract.fieldTypes ?? {})) {
+    if (result?.[f] === undefined) continue; // presence is requiredFields' job
+    expect(jsTypeOf(result[f]), `${toolName}: field '${f}' should be ${t}`).toBe(t as FieldType);
+  }
+  for (const f of contract.forbiddenFields ?? []) {
+    expect(has(result, f), `${toolName}: forbidden internal field '${f}' leaked over the /mcp surface`).toBe(false);
+  }
+
+  const inv = contract.invariants ?? {};
+
+  for (const { count, containers } of inv.countEqualsDelivered ?? []) {
+    let total = 0;
+    for (const c of containers) {
+      const arr = getPath(result, c);
+      expect(Array.isArray(arr), `${toolName}: container '${c}' must be an array for count==delivered`).toBe(true);
+      total += arr.length;
+    }
+    const reported = getPath(result, count);
+    expect(reported, `${toolName}: ${count} (=${reported}) must equal Σ[${containers.join(", ")}] lengths (=${total})`).toBe(total);
+  }
+
+  for (const { path, type } of inv.selfDescribingEmpty ?? []) {
+    const v = getPath(result, path);
+    expect(v, `${toolName}: ${path} must be present (self-describing empty, never missing/undefined)`).not.toBeUndefined();
+    expect(v, `${toolName}: ${path} must not be null`).not.toBeNull();
+    expect(jsTypeOf(v), `${toolName}: ${path} must be ${type}`).toBe(type);
+  }
+
+  if (inv.dedupSignature) {
+    const { container, signatureFields } = inv.dedupSignature;
+    const arr = getPath(result, container) ?? [];
+    const seen = new Set<string>();
+    for (const item of arr) {
+      const sig = JSON.stringify(signatureFields.map((f) => {
+        const v = item?.[f];
+        return Array.isArray(v) ? [...v].sort() : (v ?? null);
+      }));
+      expect(seen.has(sig), `${toolName}: duplicate '${container}' entry by content-signature ${sig}`).toBe(false);
+      seen.add(sig);
+    }
+  }
+
+  if (inv.tokenEstimate) {
+    const { field, excludeKeys } = inv.tokenEstimate;
+    const reported = result?.[field];
+    expect(typeof reported, `${toolName}: ${field} must be a number`).toBe("number");
+    const rest: any = { ...result };
+    for (const k of excludeKeys) delete rest[k];
+    const expected = estimateTokens(JSON.stringify(rest));
+    expect(
+      reported,
+      `${toolName}: ${field} (=${reported}) must equal the wrapper's OWN estimator over the delivered payload (=${expected}) — same-estimator invariant (#1199)`,
+    ).toBe(expected);
+  }
+
+  if (inv.proseContextIsPointerAtDefault) {
+    const ctx = result?.[inv.proseContextIsPointerAtDefault.field] ?? "";
+    expect(typeof ctx, `${toolName}: prose context must be a string`).toBe("string");
+    for (const ev of result?.events ?? []) {
+      if (ev?.summary) {
+        expect(ctx.includes(ev.summary), `${toolName}: prose context must not re-carry an event body at the /mcp default (#1199)`).toBe(false);
+      }
+    }
+    for (const m of result?.memories ?? []) {
+      if (m?.content) {
+        expect(ctx.includes(m.content), `${toolName}: prose context must not re-carry a memory body at the /mcp default (#1199)`).toBe(false);
+      }
+    }
+  }
+
+  for (const rule of inv.containerRules ?? []) {
+    const arr = getPath(result, rule.container);
+    if (!Array.isArray(arr)) continue;
+    for (const el of arr) {
+      for (const f of rule.requiredFields ?? []) {
+        expect(el?.[f], `${toolName}: ${rule.container}[].${f} required`).not.toBeUndefined();
+      }
+      for (const f of rule.forbiddenFields ?? []) {
+        expect(has(el, f), `${toolName}: ${rule.container}[] leaked internal field '${f}'`).toBe(false);
+      }
+    }
+  }
+}
+
+/** Assert a refused tool call returns a parseable error shape with no stack/path leak. */
+function assertErrorShape(toolName: string, resp: any, contract: ToolContract): void {
+  const es = contract.errorShape;
+  expect(es, `${toolName}: contract declares no errorShape`).toBeDefined();
+  for (const f of es!.fields) {
+    expect(resp?.[f], `${toolName}: error response must carry '${f}' (got ${JSON.stringify(resp).slice(0, 220)})`).not.toBeUndefined();
+  }
+  for (const f of es!.mustNotLeak ?? []) {
+    expect(has(resp, f), `${toolName}: error response leaked '${f}'`).toBe(false);
+  }
+  for (const v of Object.values(resp ?? {})) {
+    if (typeof v === "string") {
+      expect(/\n\s+at\s/.test(v), `${toolName}: error leaks a stack trace`).toBe(false);
+      expect(/\/(Users|home|private|var)\//.test(v), `${toolName}: error leaks a filesystem path`).toBe(false);
+    }
+  }
+}
+
+const C = (name: string): ToolContract => TOOLS[name].contract;
+
+// ── completeness (fail-closed) — CI-gated in this lane ───────────────────────
+describe("conformance completeness gate (fail-closed)", () => {
+  test("every shipped /mcp tool carries a contract, and the gate examined all of them", () => {
+    const res = checkContractCompleteness(TOOLS);
+    expect(res.missing, `tools shipped without a conformance contract: ${res.missing.join(", ")}`).toEqual([]);
+    expect(res.ok).toBe(true);
+    expect(res.examined, "the gate must have enumerated the whole registry (not a vacuous pass)").toBe(Object.keys(TOOLS).length);
+    expect(res.examined).toBeGreaterThan(0);
+  });
+});
+
+// ── per-tool conformance ─────────────────────────────────────────────────────
+describe("/mcp connector conformance — each tool honors its declared contract", () => {
+  test("bootstrap: full structured payload; counts, dedup, tokenEstimate, prose-pointer all hold at the /mcp default", async () => {
+    // Default call: includeContext NOT passed → the connector path.
+    const body = await tool("bootstrap", { currentTask: "conformance sweep", maxTokens: 8000 });
+    conform("bootstrap", body, C("bootstrap"));
+
+    // Relevance + delivery spot-checks (the #1206 structured-events move).
+    const summaries = (body.events ?? []).map((e: any) => e.summary);
+    expect(summaries, "duplicate-pair event delivered (collapsed to one)").toContain(DUP_SUMMARY);
+    expect(summaries, "org-scoped event delivered").toContain(ORG_SUMMARY);
+    expect(summaries, "event targeted at the caller delivered").toContain(MINE_SUMMARY);
+    expect(summaries, "event targeted at someone else must be filtered out").not.toContain(OTHER_SUMMARY);
+    // The dedup PAIR really collapsed: exactly one delivered event carries DUP_SUMMARY.
+    expect(summaries.filter((s: string) => s === DUP_SUMMARY).length, "the byte-identical duplicate pair must collapse to ONE (#1200)").toBe(1);
+    // memoriesIncluded spans memories+predicted, and there IS own content.
+    expect(body.memories.length, "own memories delivered").toBeGreaterThan(0);
+  }, 120_000);
+
+  test("memory_search: { results } with content-bearing hits and no embedding fields on any hit", async () => {
+    const res = await tool("memory_search", { query: SEARCH_TOKEN, limit: 10 });
+    conform("memory_search", res, C("memory_search"));
+    const hit = res.results.find((r: any) => typeof r?.content === "string" && r.content.includes(SEARCH_TOKEN));
+    expect(hit, "the seeded token memory must be among the results").toBeDefined();
+  }, 120_000);
+
+  test("memory_store: write echo { id, written, deduplicated }, no internal fields; round-trips via memory_get", async () => {
+    const content = `mcp conformance store ${sfx} ${randomUUID()}`;
+    const res = await tool("memory_store", { content, type: "decision", durability: "standard" });
+    conform("memory_store", res, C("memory_store"));
+    // round-trip (Kern #3): the write actually landed and reads back.
+    const back = await tool("memory_get", { id: res.id });
+    expect(back?.content, "memory_store → memory_get round-trip").toBe(content);
+  }, 120_000);
+
+  test("memory_get: full record with embedding AND embeddingModel stripped by default; the vector returns under includeEmbedding", async () => {
+    const def = await tool("memory_get", { id: GET_ID });
+    conform("memory_get", def, C("memory_get"));
+    expect(def.id, "record id round-trips").toBe(GET_ID);
+    expect(def.content, "record content round-trips").toBe(GET_CONTENT);
+    // The record demonstrably carries both internal fields — prove the strip is
+    // real, not vacuous — by opting the vector back in.
+    const withEmb = await tool("memory_get", { id: GET_ID, includeEmbedding: true });
+    expect(Array.isArray(withEmb?.embedding), "includeEmbedding:true returns the raw vector").toBe(true);
+    expect(withEmb.embedding.length, "the seeded 768-float vector round-trips").toBe(768);
+  }, 120_000);
+
+  test("memory_update: write echo, no internal fields; the change round-trips via memory_get", async () => {
+    const orig = `mcp conformance update-target ${sfx} ${randomUUID()}`;
+    const stored = await tool("memory_store", { content: orig, durability: "standard" });
+    const updated = `${orig} :: UPDATED ${randomUUID()}`;
+    const res = await tool("memory_update", { id: stored.id, content: updated });
+    conform("memory_update", res, C("memory_update"));
+    expect(res.id, "update echoes the same id").toBe(stored.id);
+    const after = await tool("memory_get", { id: stored.id });
+    expect(after?.content, "memory_update → memory_get round-trip").toBe(updated);
+  }, 120_000);
+
+  test("soul_get: the seeded soul entry with the contracted fields", async () => {
+    const res = await tool("soul_get", { key: "role" });
+    conform("soul_get", res, C("soul_get"));
+    expect(res.value, "soul value round-trips").toBe(SOUL_ROLE);
+  }, 120_000);
+
+  test("soul_set: writes an entry that round-trips via soul_get (the #1181 connector-path write)", async () => {
+    const key = `project-${sfx}`;
+    const value = `mcp conformance soul_set ${randomUUID()}`;
+    const res = await tool("soul_set", { key, value });
+    conform("soul_set", res, C("soul_set"));
+    const back = await tool("soul_get", { key });
+    expect(back?.value, "soul_set → soul_get round-trip").toBe(value);
+  }, 120_000);
+
+  test("flair_workspace_set: drives without error; persists a record attributed to the caller", async () => {
+    const ref = `cp-mcpconf-${sfx}`;
+    const res = await tool("flair_workspace_set", { ref, label: "conformance", phase: "review", summary: "conf suite" });
+    conform("flair_workspace_set", res, C("flair_workspace_set"));
+    const rows = await opsSearchEquals("WorkspaceState", "id", `${AGENT}:${ref}`);
+    expect(rows.length, "workspace_set persists exactly one record").toBe(1);
+    expect(rows[0].agentId, "attributed to the caller").toBe(AGENT);
+  }, 120_000);
+
+  test("flair_orgevent: drives without error; persists an event attributed to the caller", async () => {
+    const summary = `mcp conformance orgevent ${sfx} ${randomUUID()}`;
+    const res = await tool("flair_orgevent", { kind: "status", summary, scope: "org" });
+    conform("flair_orgevent", res, C("flair_orgevent"));
+    const rows = await opsSearchEquals("OrgEvent", "summary", summary);
+    expect(rows.length, "orgevent persists exactly one event").toBe(1);
+    expect(rows[0].authorId, "attributed to the caller").toBe(AGENT);
+  }, 120_000);
+
+  test("attention: grouped-by-source view with all five groups and a numeric total", async () => {
+    const res = await tool("attention", { entity: "repo:tpsdev-ai/flair", days: 30 });
+    conform("attention", res, C("attention"));
+    expect(Object.keys(res.groups ?? {}).sort(), "attention groups every source").toEqual(
+      ["memory", "orgEvent", "presence", "relationship", "workspaceState"].sort(),
+    );
+    expect(typeof res.counts?.total, "numeric total").toBe("number");
+    expect(res.counts.relationship, "the seeded relationship is counted").toBeGreaterThanOrEqual(1);
+  }, 120_000);
+
+  test("record_usage: the invariant { recorded:true } acknowledgement", async () => {
+    const res = await tool("record_usage", { memoryId: GET_ID, attribution: "conformance suite" });
+    conform("record_usage", res, C("record_usage"));
+    expect(res.recorded, "acknowledges recorded:true").toBe(true);
+  }, 120_000);
+});
+
+// ── error contract (Kern #5) — one refused case per tool that declares one ────
+describe("/mcp connector conformance — error responses are parseable and leak nothing", () => {
+  test("memory_get: a non-existent id returns { error, status }, no stack/path", async () => {
+    const resp = await tool("memory_get", { id: `${AGENT}-does-not-exist-${randomUUID()}` });
+    assertErrorShape("memory_get", resp, C("memory_get"));
+  }, 120_000);
+
+  test("memory_store: an unrecognized visibility returns { error, status }, no internal fields", async () => {
+    const resp = await tool("memory_store", { content: `bad-vis ${randomUUID()}`, visibility: "prvate" });
+    assertErrorShape("memory_store", resp, C("memory_store"));
+    expect(resp.status, "unrecognized visibility is a 400").toBe(400);
+  }, 120_000);
+
+  test("memory_update: a non-existent id returns { error, status }", async () => {
+    const resp = await tool("memory_update", { id: `${AGENT}-missing-${randomUUID()}`, content: "x" });
+    assertErrorShape("memory_update", resp, C("memory_update"));
+    expect(resp.status).toBe(404);
+  }, 120_000);
+
+  test("memory_delete: a non-admin deleting a permanent memory returns { error, status:403 }", async () => {
+    const permId = `${AGENT}-${randomUUID()}`;
+    await seedInsert("Memory", {
+      id: permId, agentId: AGENT, content: `conformance permanent ${sfx}`,
+      durability: "permanent", visibility: "private",
+      createdAt: new Date().toISOString(), validFrom: new Date().toISOString(),
+    });
+    const resp = await tool("memory_delete", { id: permId });
+    assertErrorShape("memory_delete", resp, C("memory_delete"));
+    expect(resp.status, "permanent delete by non-admin is 403").toBe(403);
+    const still = await tool("memory_get", { id: permId });
+    expect(still?.id, "the permanent memory survives the refused delete").toBe(permId);
+  }, 120_000);
+});
+
+// ── auth boundary (Kern #4) — the read scope a connector inherits ─────────────
+describe("/mcp connector conformance — read-scope boundary", () => {
+  test("memory_get: a caller cannot read another agent's PRIVATE memory", async () => {
+    const resp = await tool("memory_get", { id: OTHER_PRIV_ID });
+    // Must NOT return agent2's content — a 404/empty is correct (own + org-non-private scope).
+    const leaked = resp && typeof resp === "object" && resp.content === OTHER_PRIV_CONTENT;
+    expect(leaked, `memory_get must not leak another agent's private memory, got: ${JSON.stringify(resp).slice(0, 200)}`).toBe(false);
+  }, 120_000);
+});

--- a/test/unit/conformance-completeness-fail-closed.test.ts
+++ b/test/unit/conformance-completeness-fail-closed.test.ts
@@ -1,0 +1,119 @@
+// A skipped/unrunnable connector-conformance COMPLETENESS check must not render
+// as a passing one (flair#1213, Sherlock #3 — the flair#953 lesson).
+//
+// The completeness gate ("a new /mcp tool without a contract fails the build")
+// has the exact failure mode docs-freshness had: if it cannot enumerate the
+// tool list — the `TOOLS` import failed and left it `undefined`, or the registry
+// is empty — a naive gate finds "0 tools, 0 missing" and reports success. Six
+// checks, six ticks, one a lie. So `checkContractCompleteness` is FAIL-CLOSED:
+// an un-enumerable or empty registry returns ok:false with examined:0, and a
+// pass is only ever reported with examined > 0.
+//
+// These are behaviour tests on that function's contract: they drive it with a
+// real registry, an empty one, an unloadable one, and a registry missing a
+// contract, and assert the return value a CI step consumes — never inferring
+// "it would fail" from the happy path (which returns a perfectly well-formed
+// empty `missing` list either way).
+
+import { describe, expect, test } from "bun:test";
+import {
+  checkContractCompleteness,
+  INTERNAL_MEMORY_FIELDS,
+  TOOLS,
+  type CompletenessResult,
+} from "../../resources/mcp-tools.ts";
+
+describe("completeness gate — the real shipped registry", () => {
+  const res = checkContractCompleteness(TOOLS);
+
+  test("every shipped tool carries a contract (ok, nothing missing)", () => {
+    expect(res.missing, `tools missing a contract: ${res.missing.join(", ")}`).toEqual([]);
+    expect(res.ok).toBe(true);
+  });
+
+  test("examined equals the shipped tool count and is > 0 (not a vacuous pass)", () => {
+    const shipped = Object.keys(TOOLS).length;
+    expect(shipped).toBeGreaterThan(0);
+    expect(res.examined).toBe(shipped);
+  });
+});
+
+describe("fail-closed: a check that could not run must not look like a pass", () => {
+  // The whole bug in one table: an un-enumerable or empty registry is NOT ok,
+  // and its examined count is 0 — visibly distinct from a real pass (ok + a
+  // positive examined count). A caller that keys "did it pass?" off `ok` alone,
+  // or "how much did it cover?" off `examined`, can tell the two apart.
+  const cases: Array<[label: string, input: any]> = [
+    ["undefined (import left it unloaded)", undefined],
+    ["null", null],
+    ["an array (not a plain registry object)", []],
+    ["a string (not an object)", "TOOLS"],
+    ["an empty registry", {}],
+  ];
+
+  for (const [label, input] of cases) {
+    test(`${label} → ok:false, examined:0, with a reason`, () => {
+      const r: CompletenessResult = checkContractCompleteness(input);
+      expect(r.ok, `${label} must NOT report ok`).toBe(false);
+      expect(r.examined, `${label} must report examined:0`).toBe(0);
+      expect(typeof r.reason, `${label} must name why it did not pass`).toBe("string");
+    });
+  }
+
+  test("no input yields a pass with examined:0 (a pass always covered something)", () => {
+    for (const [, input] of cases) {
+      const r = checkContractCompleteness(input);
+      expect(r.ok && r.examined === 0, "a vacuous ok+examined:0 is impossible").toBe(false);
+    }
+  });
+});
+
+describe("fail-closed: a tool shipped without a contract fails and is named", () => {
+  test("a registry with one contract-less tool fails, names the tool, still examines it", () => {
+    const r = checkContractCompleteness({
+      good: { def: {}, impl: () => {}, contract: { summary: "ok" } } as any,
+      naked: { def: {}, impl: () => {} } as any,
+    });
+    expect(r.ok).toBe(false);
+    expect(r.examined).toBe(2);
+    expect(r.missing).toContain("naked");
+    expect(r.missing).not.toContain("good");
+    expect(r.reason).toContain("naked");
+  });
+
+  test("a contract that is not an object counts as missing", () => {
+    const r = checkContractCompleteness({ bad: { def: {}, impl: () => {}, contract: "nope" } as any });
+    expect(r.ok).toBe(false);
+    expect(r.missing).toContain("bad");
+  });
+
+  test("a healthy single-tool registry passes with examined:1", () => {
+    const r = checkContractCompleteness({ only: { def: {}, impl: () => {}, contract: { summary: "x" } } as any });
+    expect(r.ok).toBe(true);
+    expect(r.examined).toBe(1);
+    expect(r.missing).toEqual([]);
+  });
+});
+
+describe("the no-leaked-internal-fields enumeration (flair#1213 refinement #1)", () => {
+  // The invariant can only bite on a field it enumerates. Sherlock #1: the read
+  // path used to strip only `embedding` while `embeddingModel` still leaked, and
+  // a contract that checked only `embedding` would pass anyway. Pin BOTH.
+  test("INTERNAL_MEMORY_FIELDS enumerates BOTH embedding and embeddingModel", () => {
+    expect(INTERNAL_MEMORY_FIELDS).toContain("embedding");
+    expect(INTERNAL_MEMORY_FIELDS).toContain("embeddingModel");
+  });
+
+  test("every memory-record tool's forbiddenFields enumerates both", () => {
+    for (const name of ["memory_get", "memory_store", "memory_update"]) {
+      const forbidden = (TOOLS as any)[name].contract.forbiddenFields ?? [];
+      expect(forbidden, `${name} must forbid embedding`).toContain("embedding");
+      expect(forbidden, `${name} must forbid embeddingModel`).toContain("embeddingModel");
+    }
+    // memory_search enforces it per-result-element (containerRules).
+    const searchRule = (TOOLS as any).memory_search.contract.invariants.containerRules
+      .find((r: any) => r.container === "results");
+    expect(searchRule.forbiddenFields).toContain("embedding");
+    expect(searchRule.forbiddenFields).toContain("embeddingModel");
+  });
+});


### PR DESCRIPTION
Closes #1213. K&S-approved design (author tps-kern + tps-sherlock, 2026-08-16), all required refinements implemented.

## What this adds

A connector-conformance suite that, per `/mcp` tool, asserts the **consumer contract** (shape + semantics) by driving the real `TOOLS.<tool>.impl` against a seeded ephemeral store — extending the #1197 wrapper-layer suite and its inproc-app fixture. Each tool carries a declarative contract `{ requiredFields, fieldTypes, forbiddenFields, invariants, errorShape }` **co-located with its def+impl** in `resources/mcp-tools.ts`.

Semantic invariants codify the historical connector-bug classes: count==delivered, dedup by explicit per-tool content-signature, self-describing empty, same-estimator `tokenEstimate`, no-leaked-internal-fields, includeContext contract (prose is a pointer at the `/mcp` default), and fully-resolved (no stringified-objects / no pending-Promise).

## K&S-required refinements (all implemented)

1. **embeddingModel leak fixed + enumerated (Sherlock #1).** The read path's strip was narrower than the write path's delete — `memory_get` stripped only `embedding` while `embeddingModel` (a schema field stamped on every write) still leaked. Widened to `stripInternalFields` over an exported `INTERNAL_MEMORY_FIELDS = [embedding, embeddingModel]`, and the "no leaked internal fields" invariant enumerates **both** from that same const (strip and assertion cannot drift).
2. **tokenEstimate = same-estimator (Kern #1 / Sherlock #2).** Asserts `tokenEstimate === estimateTokens(JSON.stringify(deliveredPayload))` using the wrapper's own estimator, extracted to a harper-free `resources/token-estimate.ts` single source — catches the #1199 double-serialization class without being brittle to a future estimator change.
3. **Completeness check fail-closed (Sherlock #3, the #953 lesson).** `checkContractCompleteness` returns `ok:false` with `examined:0` for an un-enumerable or empty registry — never a vacuous pass. A behaviour unit test (`test/unit/conformance-completeness-fail-closed.test.ts`) mirrors `docs-freshness-skips.test.ts`.
4. **Contracts co-located with tool definitions (Kern #2)** so a response-shape change prompts a contract update in the same diff.
5. **Explicit per-tool dedup content-signature (Sherlock #4).** Pinned in the contract; the fixture seeds a real duplicate pair the signature catches.

## Signature reconciliation (finding)

The dispatch/Sherlock suggested the org-event dedup signature could be the event `id` or `authorId+kind+summary+createdAt`. Both `id` and `createdAt` **vary** between the physical duplicate rows #1200 collapses (`OrgEvent.post` keys the id off a millisecond timestamp), so keying on either would miss the dupe. The signature is pinned to the tuple the implementation actually dedups on — `kind+summary+detail+targetIds` (`MemoryBootstrap.ts` `eventBySignature`) — which is what makes the seeded pair collapse to one and the mutation bite.

## Count-invariant correction (finding)

`memoriesIncluded` is incremented for **both** delivered own-memory containers — `memories` (permanent/recent/relevant) **and** `predicted` (subject-matched) — so `memoriesIncluded == memories.length` (as literally stated in the brief) would false-fail whenever `predicted` is non-empty. The invariant is the faithful `memoriesIncluded == memories.length + predicted.length`.

## Latent bug caught in flight

The error-contract test surfaced a real defect: `memory_update` against a non-existent id fell through the `if (!existing)` guard (because `makeByIdReadGate` returns a truthy `NOT_FOUND()` **Response**, not `undefined`) and PUT a record with no id, throwing the **misdirecting** `Invalid primary key of null` instead of a clean 404. Same by-id-read-on-the-connector-seam class as #1181 — fixed by unwrapping the read.

## Mutation-validation (the acceptance bar)

Each historical fix reverted in place → rebuild → the conformance suite goes red on the named assertion → restored:

| Bug | Mutation | Conformance test that failed |
|-----|----------|------------------------------|
| #1181 | `memory_get` static→instance by-id read | `memory_get` requiredFields + the memory_store/update write→read round-trips (4 red) |
| #1188 | `memory_get` embedding strip reverted | `memory_get` forbiddenFields `embedding` leaked |
| embeddingModel fix | strip narrowed to `["embedding"]` only | `memory_get` forbiddenFields `embeddingModel` leaked |
| #1182 | `bootstrap` un-awaited spread | `bootstrap` requiredFields — payload collapsed to `{flairVersion}` |
| #1199 | `tokenEstimate` reverted to prose-only | `bootstrap` same-estimator tokenEstimate (84 vs 626) |
| #1200 | org-event dedup bypassed | `bootstrap` duplicate `events` entry by content-signature |
| #1206 | structured `events` container removed | `bootstrap` requiredFields `events` (+ count==delivered) |

## Verification (this session, HOME-isolated ephemeral Harper; baselines measured on unmodified origin/main)

- Conformance suite + fail-closed unit: **30 pass / 0 fail** (532 assertions).
- #1197 wrapper suite: **13 pass / 0 fail** (unchanged from baseline).
- Regression (wrapper + bootstrap #1182/#1199/#1207): **28 pass / 0 fail**.
- Full fast unit lane: **4426 pass / 0 fail**.
- docs-freshness gate: **7/7 pass** (changelog fragments added).

The suite lands in the same CI lane as #1197 (`test/integration/*.test.ts` glob); the completeness check is CI-gated in both that lane and the unit lane.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
