### PR TITLE
feat(flair-bench): deterministic recall eval + shared plumbing (Layer 1, #1216-a)

### DIFF
--- a/.changelog/unreleased/added-flair-bench-deterministic-recall-eval.md
+++ b/.changelog/unreleased/added-flair-bench-deterministic-recall-eval.md
@@ -1,0 +1,13 @@
+- **Deterministic recall-quality eval + CI gate (flair-bench Layer 1).** A new
+  fixed-corpus, fixed-label, fixed-seed recall eval computes recall@1/5/10,
+  nDCG@10 and MRR against hand-curated relevant-memory labels, through Flair's
+  real BM25+RRF retrieval at documented defaults — no LLM judge, no
+  corpus-derived relevance. It is measured ±0.000 across runs and gates CI on
+  per-metric floors set a margin of ≥2 whole queries above that noise band, so a
+  breach is a real regression rather than sampling wobble. This is now the
+  authoritative recall-quality number; the `flair quality` recall spot-check
+  remains a live-health cratering probe (its self-pollution caveats are tracked
+  in flair#967 / #857 / #996), and the composite-vs-raw recall-harness remains
+  the scoring-config diagnostic. The shared ingest/retrieve/metrics plumbing
+  (`packages/flair-bench/lib/`) is the foundation the LongMemEval_s harness
+  (Layer 2) builds on unchanged.

--- a/packages/flair-bench/lib/index.ts
+++ b/packages/flair-bench/lib/index.ts
@@ -1,0 +1,29 @@
+/**
+ * flair-bench/lib — shared eval plumbing for the flair-bench evaluation layers.
+ *
+ * This directory is the FOUNDATION referenced by #1216: the one ingest + one
+ * retrieve + one metrics implementation that Layer 1 (deterministic recall
+ * eval, #17 / #1216-a) and Layer 2 (LongMemEval_s end-to-end, #1216-b) both
+ * build on, so the two layers can never diverge on how memories are written to
+ * or read from Flair (a divergence would be a silent confound — Kern's design).
+ *
+ * It is REPO-INTERNAL tooling: not part of the published @tpsdev-ai/flair-bench
+ * tarball (the package's `files` ships only dist/ built from src/, and this
+ * lives outside src/). It is consumed by bench runners and tests via bun's
+ * runtime TypeScript resolution, and it spawns nothing itself — callers supply
+ * a running ephemeral Harper (test/helpers/harper-lifecycle) plus a bench
+ * identity.
+ */
+export * from "./types.js";
+export * from "./signed-fetch.js";
+export { ingestSessionHistory } from "./ingest.js";
+export { retrieveContext, suggestRetrieveLimit } from "./retrieve.js";
+export {
+  recallAtK,
+  ndcgAtK,
+  reciprocalRank,
+  scoreQuery,
+  aggregate,
+  type PerQueryScore,
+  type AggregateScore,
+} from "./metrics.js";

--- a/packages/flair-bench/lib/ingest.ts
+++ b/packages/flair-bench/lib/ingest.ts
@@ -1,0 +1,79 @@
+/**
+ * ingest.ts — write session history into Flair, per-event.
+ *
+ * The single ingestion path both eval layers share (Kern's #1216 design). One
+ * Memory per SessionEvent — the granularity Flair itself uses in production
+ * (`memory_service.py` writes one Memory per event) and the locked #1216
+ * decision. If Layer 1 and Layer 2 ingested differently, a discrepancy between
+ * them would be a silent confound; this module is the one place the mapping
+ * lives, so "how exactly are sessions written to Flair?" has a single answer.
+ *
+ * The write is a PUT /Memory/<id> with the same body the recall-harness uses
+ * (id, agentId, content, durability, createdAt) via the shared signed-fetch —
+ * so the memories this produces are byte-identical to what the existing,
+ * deterministic harness produces.
+ */
+import type { BenchClient, IngestOptions, IngestResult, SessionHistory } from "./types.js";
+import { signedFetch } from "./signed-fetch.js";
+
+function toIso(t: string | number | undefined): { iso: string; synthetic: boolean } {
+  if (t === undefined) return { iso: new Date().toISOString(), synthetic: true };
+  if (typeof t === "number") return { iso: new Date(t).toISOString(), synthetic: false };
+  return { iso: t, synthetic: false };
+}
+
+/**
+ * Write every event of every session as its own Memory, scoped to
+ * `client.agent.id` (Kern's `userId`). Timestamps are preserved verbatim
+ * (temporal ordering survives). Returns the written ids in order plus whether
+ * any timestamp had to be synthesised.
+ *
+ * Throws on the first failed write with the HTTP status + body — a seeding
+ * failure must surface loudly, never degrade into a low recall number that
+ * looks like a retrieval regression.
+ */
+export async function ingestSessionHistory(
+  client: BenchClient,
+  sessions: SessionHistory[],
+  opts: IngestOptions = {},
+): Promise<IngestResult> {
+  const granularity = opts.granularity ?? "per-event";
+  if (granularity !== "per-event") {
+    throw new Error(`ingestSessionHistory: only "per-event" granularity is implemented (got "${granularity}"). Any other granularity is a labelled ablation, not a default — implement it explicitly.`);
+  }
+  const concurrency = Math.max(1, opts.concurrency ?? 6);
+  const { harper, agent } = client;
+
+  // Flatten to a single ordered event stream. One Memory per event.
+  const events = sessions.flatMap((s) => s.events);
+  const ids: string[] = [];
+  let syntheticTimestamps = false;
+
+  const start = performance.now();
+  for (let i = 0; i < events.length; i += concurrency) {
+    const batch = events.slice(i, i + concurrency);
+    await Promise.all(
+      batch.map(async (ev) => {
+        const { iso, synthetic } = toIso(ev.createdAt);
+        if (synthetic) syntheticTimestamps = true;
+        const path = `/Memory/${ev.id}`;
+        const res = await signedFetch(harper, agent, "PUT", path, {
+          id: ev.id,
+          agentId: agent.id,
+          content: ev.content,
+          durability: ev.durability ?? "standard",
+          createdAt: iso,
+        });
+        if (!res.ok) {
+          throw new Error(`ingest event ${ev.id} failed: HTTP ${res.status} ${JSON.stringify(res.body ?? null).slice(0, 400)}`);
+        }
+      }),
+    );
+    // Preserve write order in the returned id list regardless of Promise.all
+    // resolution order.
+    for (const ev of batch) ids.push(ev.id);
+  }
+  const elapsedMs = performance.now() - start;
+
+  return { written: ids.length, ids, syntheticTimestamps, elapsedMs };
+}

--- a/packages/flair-bench/lib/metrics.ts
+++ b/packages/flair-bench/lib/metrics.ts
@@ -1,0 +1,126 @@
+/**
+ * metrics.ts — pure ranking metrics for the deterministic recall eval.
+ *
+ * No I/O, no Harper, no corpus knowledge — given a retrieved ranking and a set
+ * of KNOWN-relevant ids, compute recall@k, nDCG@k, and reciprocal rank. Kept
+ * pure so the numbers are unit-testable against hand-checked rankings without
+ * spawning anything (a metric you can't check by hand is a metric you can't
+ * trust to gate CI).
+ *
+ * Relevance is a SET per query. Layer 1's curated corpus labels one relevant
+ * memory per query (so recall@k degrades to hit@k, nDCG to 1/log2(rank+1)
+ * normalised, MRR to 1/rank) — but the SET signature is what lets Layer 2 reuse
+ * these unchanged when a LongMemEval question has several relevant memories.
+ *
+ * Binary relevance only (relevant or not) — LongMemEval and this corpus both
+ * label membership, not graded gains. If graded relevance is ever needed, add a
+ * gains map here rather than teaching every call site a second scale.
+ */
+
+function toSet(relevant: Iterable<string>): Set<string> {
+  return relevant instanceof Set ? relevant : new Set(relevant);
+}
+
+/**
+ * recall@k = |relevant ∩ top-k| / |relevant|.
+ * With one relevant id this is hit@k (1 if it's in the top k, else 0).
+ * Returns 0 for an empty relevant set (nothing to recall) — a caller that
+ * treats "no labels" as a real 0.0 has a corpus bug, not a recall result.
+ */
+export function recallAtK(rankedIds: string[], relevant: Iterable<string>, k: number): number {
+  const rel = toSet(relevant);
+  if (rel.size === 0) return 0;
+  if (k <= 0) return 0;
+  const topK = rankedIds.slice(0, k);
+  let hits = 0;
+  for (const id of topK) if (rel.has(id)) hits++;
+  return hits / rel.size;
+}
+
+/**
+ * nDCG@k with binary gains. DCG = Σ_{i in top-k, relevant} 1/log2(i+2) where i
+ * is the 0-based rank position (so rank 0 → 1/log2(2) = 1). IDCG is the DCG of
+ * the ideal ranking (all relevants packed at the top, capped at k). Returns 0
+ * when nothing relevant appears in the top k, and for an empty relevant set.
+ */
+export function ndcgAtK(rankedIds: string[], relevant: Iterable<string>, k: number): number {
+  const rel = toSet(relevant);
+  if (rel.size === 0 || k <= 0) return 0;
+  const topK = rankedIds.slice(0, k);
+  let dcg = 0;
+  for (let i = 0; i < topK.length; i++) {
+    if (rel.has(topK[i]!)) dcg += 1 / Math.log2(i + 2);
+  }
+  const idealHits = Math.min(rel.size, k);
+  let idcg = 0;
+  for (let i = 0; i < idealHits; i++) idcg += 1 / Math.log2(i + 2);
+  return idcg === 0 ? 0 : dcg / idcg;
+}
+
+/**
+ * Reciprocal rank of the FIRST relevant id (1/rank, rank 1-based). 0 if no
+ * relevant id appears anywhere in the ranking. Mean over queries = MRR.
+ */
+export function reciprocalRank(rankedIds: string[], relevant: Iterable<string>): number {
+  const rel = toSet(relevant);
+  if (rel.size === 0) return 0;
+  for (let i = 0; i < rankedIds.length; i++) {
+    if (rel.has(rankedIds[i]!)) return 1 / (i + 1);
+  }
+  return 0;
+}
+
+export interface PerQueryScore {
+  recallAt1: number;
+  recallAt5: number;
+  recallAt10: number;
+  ndcgAt10: number;
+  reciprocalRank: number;
+}
+
+export interface AggregateScore {
+  recallAt1: number;
+  recallAt5: number;
+  recallAt10: number;
+  ndcgAt10: number;
+  mrr: number;
+  nQueries: number;
+}
+
+/** Score one query's ranking against its relevant set at the fixed ks the
+ *  Layer 1 eval reports (1/5/10, nDCG@10). */
+export function scoreQuery(rankedIds: string[], relevant: Iterable<string>): PerQueryScore {
+  return {
+    recallAt1: recallAtK(rankedIds, relevant, 1),
+    recallAt5: recallAtK(rankedIds, relevant, 5),
+    recallAt10: recallAtK(rankedIds, relevant, 10),
+    ndcgAt10: ndcgAtK(rankedIds, relevant, 10),
+    reciprocalRank: reciprocalRank(rankedIds, relevant),
+  };
+}
+
+/** Mean each metric across per-query scores. Empty input → all zeros with
+ *  nQueries 0 (a caller must treat that as "no eval ran", not a real floor
+ *  breach). */
+export function aggregate(perQuery: PerQueryScore[]): AggregateScore {
+  const n = perQuery.length;
+  if (n === 0) return { recallAt1: 0, recallAt5: 0, recallAt10: 0, ndcgAt10: 0, mrr: 0, nQueries: 0 };
+  const sum = perQuery.reduce(
+    (a, s) => ({
+      recallAt1: a.recallAt1 + s.recallAt1,
+      recallAt5: a.recallAt5 + s.recallAt5,
+      recallAt10: a.recallAt10 + s.recallAt10,
+      ndcgAt10: a.ndcgAt10 + s.ndcgAt10,
+      reciprocalRank: a.reciprocalRank + s.reciprocalRank,
+    }),
+    { recallAt1: 0, recallAt5: 0, recallAt10: 0, ndcgAt10: 0, reciprocalRank: 0 },
+  );
+  return {
+    recallAt1: sum.recallAt1 / n,
+    recallAt5: sum.recallAt5 / n,
+    recallAt10: sum.recallAt10 / n,
+    ndcgAt10: sum.ndcgAt10 / n,
+    mrr: sum.reciprocalRank / n,
+    nQueries: n,
+  };
+}

--- a/packages/flair-bench/lib/retrieve.ts
+++ b/packages/flair-bench/lib/retrieve.ts
@@ -1,0 +1,64 @@
+/**
+ * retrieve.ts — query Flair's REAL retrieval, at documented defaults.
+ *
+ * The single retrieval path both eval layers share. Calls POST /SemanticSearch
+ * — the same endpoint `flair memory search` uses — so the eval measures Flair's
+ * actual BM25 + union-RRF hybrid retrieval, not a reimplementation of it.
+ *
+ * Documented defaults (held fixed across the eval):
+ *   - scoring="raw": the production default since flair#623 (composite's
+ *     unconditional durability/recency multiplier was net-harmful to precision
+ *     once hybrid retrieval went live).
+ *   - hybrid BM25+RRF: enabled at the Harper PROCESS level via
+ *     FLAIR_HYBRID_RETRIEVAL=true at spawn time (it is not a per-request
+ *     parameter). The eval runner sets it before startHarper; this module just
+ *     issues the query. nomic search prefixes are on by default in the shipped
+ *     build (flair#504), so a default spawn already exercises the production
+ *     retrieval path end to end.
+ *
+ * Retrieve WIDE, score at k: SemanticSearch's candidate pool is limit×5, so a
+ * limit smaller than corpus/5 can drop a relevant record from the candidate set
+ * entirely — an artefact of the request, not a recall signal. Callers pass a
+ * limit chosen so limit×5 comfortably exceeds the corpus size; the metrics then
+ * slice the returned ranking at k (1/5/10). See suggestRetrieveLimit.
+ */
+import type { BenchClient, RetrievedContext, RetrievedItem, RetrieveOptions } from "./types.js";
+import { signedFetch } from "./signed-fetch.js";
+
+/** A limit whose candidate pool (limit×5) covers a corpus of `corpusSize`,
+ *  never below 20 (SemanticSearch's own comfortable floor for the small
+ *  curated corpora). */
+export function suggestRetrieveLimit(corpusSize: number): number {
+  return Math.max(20, Math.ceil(corpusSize / 5) + 10);
+}
+
+/**
+ * Retrieve context for one query, scoped to `client.agent.id`. Returns the
+ * ranked memory ids (rank 0 = best) plus full items and this query's latency.
+ * Throws on a non-OK search — a failed query must not silently score as a miss.
+ */
+export async function retrieveContext(
+  client: BenchClient,
+  query: string,
+  opts: RetrieveOptions = {},
+): Promise<RetrievedContext> {
+  const { harper, agent } = client;
+  const limit = opts.limit ?? 20;
+  const scoring = opts.scoring ?? "raw";
+
+  const t0 = performance.now();
+  const res = await signedFetch(harper, agent, "POST", "/SemanticSearch", {
+    agentId: agent.id,
+    q: query,
+    limit,
+    scoring,
+  });
+  const latencyMs = performance.now() - t0;
+
+  if (!res.ok) {
+    throw new Error(`retrieveContext failed for "${query.slice(0, 60)}": HTTP ${res.status} ${JSON.stringify(res.body ?? null).slice(0, 300)}`);
+  }
+  const results: any[] = Array.isArray(res.body?.results) ? res.body.results : [];
+  const items: RetrievedItem[] = results.map((r) => ({ id: r.id, score: r._score ?? r.score ?? 0, content: r.content }));
+  return { rankedIds: items.map((i) => i.id), items, latencyMs };
+}

--- a/packages/flair-bench/lib/signed-fetch.ts
+++ b/packages/flair-bench/lib/signed-fetch.ts
@@ -1,0 +1,104 @@
+/**
+ * signed-fetch.ts — the ONE authenticated read/write path both eval layers use.
+ *
+ * Extracted verbatim (behaviourally) from test/bench/recall-harness/run.ts so
+ * the Layer 1 deterministic recall eval (#17) and the later Layer 2
+ * LongMemEval_s harness (#1216-b) issue byte-identical Ed25519 TPS-signed
+ * requests. A divergence in HOW memories get written or queried between the two
+ * layers would be a silent confound — Layer 1 would validate recall on one
+ * ingestion/retrieval and Layer 2 would run its number on another. One module,
+ * two layers on top (Kern's shared-plumbing design, #1216).
+ *
+ * Pure transport: no Harper lifecycle, no corpus, no metrics. Callers pass a
+ * running HarperInstance (spawned via test/helpers/harper-lifecycle) and a
+ * TestAgent. Nothing here touches ~/.flair or any live service.
+ */
+import nacl from "tweetnacl";
+import { randomUUID } from "node:crypto";
+
+/** An ephemeral test/bench identity. Ed25519 keypair minted per run — never a
+ *  real agent, never persisted. `id` is the Flair `agentId` all writes/queries
+ *  are scoped to (Kern's `userId` maps to this — Flair memory is agent-scoped). */
+export interface TestAgent {
+  id: string;
+  publicKey: string;
+  secretKey: Uint8Array;
+}
+
+/** The minimal shape of a running ephemeral Harper this module talks to.
+ *  Structurally compatible with harper-lifecycle's HarperInstance so callers
+ *  can pass that straight through without importing the lifecycle here (keeps
+ *  this transport layer free of the test-helper dependency). */
+export interface HarperEndpoint {
+  httpURL: string;
+  opsURL: string;
+  admin: { username: string; password: string };
+}
+
+export interface SignedResponse {
+  ok: boolean;
+  status: number;
+  body: any;
+}
+
+export function mkAgent(id: string): TestAgent {
+  const kp = nacl.sign.keyPair();
+  return { id, publicKey: Buffer.from(kp.publicKey).toString("base64"), secretKey: kp.secretKey };
+}
+
+export function ed25519Header(agent: TestAgent, method: string, p: string): string {
+  const ts = Date.now().toString();
+  const nonce = randomUUID();
+  const payload = `${agent.id}:${ts}:${nonce}:${method}:${p}`;
+  const sig = nacl.sign.detached(new TextEncoder().encode(payload), agent.secretKey);
+  return `TPS-Ed25519 ${agent.id}:${ts}:${nonce}:${Buffer.from(sig).toString("base64")}`;
+}
+
+/** Ed25519 TPS-signed request — the exact same authenticated read path
+ *  `flair memory search` and the recall-harness use. Parses JSON when it can,
+ *  falls back to raw text. */
+export async function signedFetch(
+  harper: HarperEndpoint,
+  agent: TestAgent,
+  method: string,
+  p: string,
+  body?: unknown,
+): Promise<SignedResponse> {
+  const res = await fetch(`${harper.httpURL}${p}`, {
+    method,
+    headers: { Authorization: ed25519Header(agent, method, p), "Content-Type": "application/json" },
+    body: body !== undefined ? JSON.stringify(body) : undefined,
+  });
+  const text = await res.text();
+  let parsed: any;
+  try { parsed = JSON.parse(text); } catch { parsed = text; }
+  return { ok: res.ok, status: res.status, body: parsed };
+}
+
+/** Basic-auth admin operation against Harper's ops API (agent registration,
+ *  bulk field updates). Returns the raw Response so callers can inspect status
+ *  + body themselves. */
+export async function adminOp(harper: HarperEndpoint, op: Record<string, any>): Promise<Response> {
+  return fetch(harper.opsURL, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: "Basic " + Buffer.from(`${harper.admin.username}:${harper.admin.password}`).toString("base64"),
+    },
+    body: JSON.stringify(op),
+  });
+}
+
+/** Register a bench agent so its Ed25519 public key resolves at auth time.
+ *  Idempotent enough for bench use (a fresh ephemeral Harper has no prior
+ *  record); throws with the HTTP status + body on failure so a seeding bug is
+ *  never mistaken for a recall regression. */
+export async function registerAgent(harper: HarperEndpoint, agent: TestAgent): Promise<void> {
+  const res = await adminOp(harper, {
+    operation: "insert",
+    database: "flair",
+    table: "Agent",
+    records: [{ id: agent.id, name: agent.id, kind: "agent", publicKey: agent.publicKey, createdAt: new Date().toISOString() }],
+  });
+  if (!res.ok) throw new Error(`registerAgent(${agent.id}): HTTP ${res.status} ${await res.text().catch(() => "")}`);
+}

--- a/packages/flair-bench/lib/types.ts
+++ b/packages/flair-bench/lib/types.ts
@@ -1,0 +1,107 @@
+/**
+ * types.ts — shared vocabulary for the flair-bench eval layers.
+ *
+ * Layer 1 (deterministic recall eval, #17) and Layer 2 (LongMemEval_s, #1216-b)
+ * both describe their input as "session history to write into Flair" and their
+ * retrieval as "context for a query", so those shapes live here once.
+ */
+import type { HarperEndpoint, TestAgent } from "./signed-fetch.js";
+
+/** Durability level a memory is written at — mirrors Flair's Memory schema.
+ *  Held fixed by the corpus for a deterministic eval; a Layer 2 ablation may
+ *  vary it, which is exactly why it travels on the event, not the ingest opts. */
+export type Durability = "permanent" | "persistent" | "standard" | "ephemeral";
+
+/**
+ * One turn / event of a conversation — the atomic unit Flair actually ingests.
+ * Flair writes one Memory per event (`memory_service.py`'s
+ * `_deterministic_record_id(app, user, session, event)`), so the bench ingests
+ * at the SAME granularity: one Memory per SessionEvent. This is the locked
+ * ingestion decision for #1216 (per-turn / per-event — the headline; any other
+ * granularity is a labelled ablation, never the default).
+ */
+export interface SessionEvent {
+  /** Stable id for this event. Becomes (part of) the Memory id, so a labelled
+   *  relevance target can point at it. Required — the whole eval keys on it. */
+  id: string;
+  /** The memory text written to Flair. */
+  content: string;
+  /** Optional role (user/assistant/…) — carried for Layer 2 fidelity; Layer 1
+   *  leaves it unset. Not written to the Memory body unless a future opt asks. */
+  role?: string;
+  /** Absolute creation time. Preserved verbatim so temporal ordering survives
+   *  ingestion (LongMemEval's temporal ability depends on it). Accepts an ISO
+   *  string or epoch ms. When omitted, ingest stamps `now` and records that it
+   *  did — a bench must never silently invent a timestamp it depends on. */
+  createdAt?: string | number;
+  /** Durability the memory is written at. Defaults to "standard" when unset. */
+  durability?: Durability;
+}
+
+/** A single session's ordered events. */
+export interface SessionHistory {
+  sessionId: string;
+  events: SessionEvent[];
+}
+
+/** Everything the plumbing needs to reach a running ephemeral Harper as one
+ *  identity. Bundled so `ingestSessionHistory` / `retrieveContext` match Kern's
+ *  `(userId, …)` intent while keeping the transport explicit. */
+export interface BenchClient {
+  harper: HarperEndpoint;
+  agent: TestAgent;
+}
+
+export interface IngestOptions {
+  /** Ingestion granularity. Only "per-event" is implemented (the locked #1216
+   *  decision); the field exists so a Layer 2 ablation is a labelled, explicit
+   *  opt-in, never a silent default change. */
+  granularity?: "per-event";
+  /** Max concurrent writes. Kept modest — the ephemeral instance runs
+   *  THREADS_COUNT=1 and the native embed engine serialises internally, so
+   *  more concurrency buys queueing, not throughput. */
+  concurrency?: number;
+}
+
+export interface IngestResult {
+  /** How many Memory records were written (one per event). */
+  written: number;
+  /** Event ids, in write order — the id space the relevance labels reference. */
+  ids: string[];
+  /** True if any event lacked a createdAt and the ingest stamped `now`. A
+   *  temporal eval that sees this true against a corpus it believed carried
+   *  timestamps has a bug upstream, not a recall finding. */
+  syntheticTimestamps: boolean;
+  /** Wall-clock for the whole ingest pass (ms) — a one-time setup cost,
+   *  reported separately from per-query latency. */
+  elapsedMs: number;
+}
+
+export interface RetrieveOptions {
+  /** Number of candidates to request. The eval retrieves WIDE (so the
+   *  candidate pool covers the corpus — SemanticSearch's candidateLimit is
+   *  limit×5) and scores at k afterwards. Defaults are chosen per corpus by the
+   *  caller; see retrieve.ts. */
+  limit?: number;
+  /** Scoring mode. Defaults to "raw" — the production default since flair#623
+   *  (composite's unconditional durability/recency multiplier was net-harmful
+   *  to precision once hybrid retrieval went live). */
+  scoring?: "raw" | "composite";
+}
+
+export interface RetrievedItem {
+  id: string;
+  score: number;
+  content?: string;
+}
+
+export interface RetrievedContext {
+  /** Retrieved memory ids in rank order (rank 0 = best). The recall metrics
+   *  consume exactly this. */
+  rankedIds: string[];
+  /** Full results (id + score + content) for callers that need more than ids
+   *  (Layer 2's reader consumes the content). */
+  items: RetrievedItem[];
+  /** Round-trip wall-clock for this one query (ms). */
+  latencyMs: number;
+}

--- a/packages/flair-bench/test/recall-metrics.test.ts
+++ b/packages/flair-bench/test/recall-metrics.test.ts
@@ -1,0 +1,86 @@
+/**
+ * recall-metrics.test.ts — pure ranking-metric correctness for the shared
+ * eval plumbing (packages/flair-bench/lib/metrics). Hand-computed expectations,
+ * no I/O — a gate that scores CI recall floors has to be checkable by hand.
+ */
+import { describe, expect, test } from "bun:test";
+import {
+  recallAtK,
+  ndcgAtK,
+  reciprocalRank,
+  scoreQuery,
+  aggregate,
+} from "../lib/index";
+
+const RANKING = ["a", "b", "c", "d", "e"];
+
+describe("recallAtK", () => {
+  test("single relevant, hit@k semantics", () => {
+    expect(recallAtK(RANKING, ["c"], 1)).toBe(0); // c is at index 2
+    expect(recallAtK(RANKING, ["c"], 3)).toBe(1); // c in top 3
+    expect(recallAtK(RANKING, ["a"], 1)).toBe(1);
+  });
+  test("multi-relevant = fraction of relevant set found in top-k", () => {
+    expect(recallAtK(RANKING, ["b", "d"], 2)).toBe(0.5); // only b in top 2, of 2 relevant
+    expect(recallAtK(RANKING, ["b", "d"], 5)).toBe(1);
+  });
+  test("edge cases score 0, never throw", () => {
+    expect(recallAtK(RANKING, [], 5)).toBe(0);
+    expect(recallAtK(RANKING, ["a"], 0)).toBe(0);
+    expect(recallAtK([], ["a"], 5)).toBe(0);
+  });
+});
+
+describe("ndcgAtK (binary gains)", () => {
+  test("single relevant at rank 1 = 1.0", () => {
+    expect(ndcgAtK(RANKING, ["a"], 10)).toBeCloseTo(1, 10);
+  });
+  test("single relevant at rank 3 = 1/log2(4) normalised by ideal 1", () => {
+    // c at 0-based index 2 → 1/log2(2+2) = 0.5; idcg (1 relevant) = 1.
+    expect(ndcgAtK(RANKING, ["c"], 10)).toBeCloseTo(0.5, 10);
+  });
+  test("two relevant, ideal-normalised", () => {
+    // b@idx1 → 1/log2(3), d@idx3 → 1/log2(5); idcg = 1/log2(2) + 1/log2(3).
+    const dcg = 1 / Math.log2(3) + 1 / Math.log2(5);
+    const idcg = 1 / Math.log2(2) + 1 / Math.log2(3);
+    expect(ndcgAtK(RANKING, ["b", "d"], 10)).toBeCloseTo(dcg / idcg, 10);
+  });
+  test("nothing relevant in top-k = 0; empty set = 0", () => {
+    expect(ndcgAtK(RANKING, ["z"], 10)).toBe(0);
+    expect(ndcgAtK(RANKING, [], 10)).toBe(0);
+  });
+});
+
+describe("reciprocalRank", () => {
+  test("1/rank of first relevant (1-based)", () => {
+    expect(reciprocalRank(RANKING, ["c"])).toBeCloseTo(1 / 3, 10);
+    expect(reciprocalRank(RANKING, ["d", "b"])).toBeCloseTo(1 / 2, 10); // first-seen is b at rank 2
+  });
+  test("miss = 0", () => {
+    expect(reciprocalRank(RANKING, ["z"])).toBe(0);
+    expect(reciprocalRank(RANKING, [])).toBe(0);
+  });
+});
+
+describe("scoreQuery + aggregate", () => {
+  test("scoreQuery reports the fixed ks", () => {
+    const s = scoreQuery(RANKING, ["a"]);
+    expect(s.recallAt1).toBe(1);
+    expect(s.recallAt5).toBe(1);
+    expect(s.recallAt10).toBe(1);
+    expect(s.ndcgAt10).toBeCloseTo(1, 10);
+    expect(s.reciprocalRank).toBe(1);
+  });
+  test("aggregate means each metric across queries", () => {
+    const agg = aggregate([scoreQuery(RANKING, ["a"]), scoreQuery(RANKING, ["c"])]);
+    expect(agg.nQueries).toBe(2);
+    expect(agg.recallAt1).toBe(0.5); // 1 and 0
+    expect(agg.mrr).toBeCloseTo((1 + 1 / 3) / 2, 10);
+  });
+  test("empty aggregate is 0/0, not a divide-by-zero", () => {
+    const agg = aggregate([]);
+    expect(agg.nQueries).toBe(0);
+    expect(agg.recallAt1).toBe(0);
+    expect(agg.mrr).toBe(0);
+  });
+});

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -13960,7 +13960,14 @@ program
 // a real user query, so a high score means "recall is functioning", not
 // "recall is optimal". Its job is to catch recall CRATERING (embeddings
 // down, index busted) — the score collapsing toward 0 is the signal, not
-// fine-grained precision grading. Requires an actual agent identity to
+// fine-grained precision grading. NOTE (#1216): this cue-from-the-memory
+// design is self-polluting as a recall-QUALITY metric — relevance is
+// query/corpus overlap by construction, so near-duplicate density reads as a
+// recall collapse (flair#967 / #857 / #996). It is deliberately NOT the
+// recall-quality number; that authority is the deterministic, fixed-label,
+// CI-gated eval at test/bench/recall-eval (recall@k / nDCG@10 / MRR). This
+// probe stays scoped to live-health cratering only. Requires an actual
+// agent identity to
 // query AS (semantic search is agent-scoped) — no identity, fewer than the
 // sample-size memories to sample, or a search error all degrade to `null` +
 // a `gaps` entry, same graceful-degradation contract as every metric here —

--- a/test/bench/recall-eval/README.md
+++ b/test/bench/recall-eval/README.md
@@ -1,0 +1,98 @@
+# recall-eval — deterministic recall-quality eval (Layer 1, #1216-a)
+
+The authoritative recall-**quality** number for Flair, and the CI gate that
+defends it. Fixed corpus, fixed query set, fixed relevance labels, fixed seeds →
+the same numbers every run. No LLM judge, no sliding-window cue, no
+corpus-derived relevance.
+
+It replaces the noisy recall-quality signal (`flair quality` recall
+spot-check) as the number we trust. See "What this fixes" below.
+
+## What it measures
+
+On the curated corpus (`../recall-harness/corpus.ts` — reused verbatim, one
+source of truth), for each labelled query it retrieves through Flair's real
+BM25+RRF at documented defaults (hybrid on, `scoring=raw`, nomic prefixes on)
+and scores the ranking against the query's **fixed, hand-curated** relevant
+memory id:
+
+- **recall@1 / recall@5 / recall@10**
+- **nDCG@10**
+- **MRR**
+
+## What this fixes (#17)
+
+The old recall-quality signal — the `flair quality` recall spot-check
+(`src/cli.ts` `deriveRecallCue` + `computeRecallSpotCheck`) — has three defects
+this eval removes:
+
+1. **Self-pollution.** The spot-check derives its "query" from a memory's OWN
+   text (a sliding partial cue) and counts recall a success when that same
+   memory returns. Relevance == query/corpus overlap by construction, so a
+   corpus of near-duplicates scores a false "recall collapse" that is really
+   duplicate density (flair#967 / #857 / #996). Here the labels are hand-curated
+   and provably NOT reproducible from corpus-query overlap
+   (`test/unit/recall-eval-labels.test.ts` — 6 of 30 curated labels differ from
+   what lexical overlap would pick, and swapping to overlap labels changes the
+   metric).
+2. **Threshold below the noise.** This eval measures the noise band first
+   (±0.000 across runs — fixed corpus + deterministic HNSW build) and sets each
+   floor a margin of ≥2 whole queries below the measured value — orders of
+   magnitude above the noise, so a breach is a real regression.
+3. **Sliding-window noise.** Replaced by the deterministic rank metrics above.
+
+The spot-check itself stays in place as a **live-health cratering probe** (a
+different job: catch recall going to zero on a real corpus). This eval is the
+**recall-quality** authority. The sibling `../recall-harness` is the
+**scoring-config diagnostic** (composite-vs-raw / prefix A/B) — a third,
+different question. Three roles, not three competing answers.
+
+## Running it
+
+Requires a build (Harper serves `dist/resources/*.js`) and the embedding model.
+
+```bash
+bun run build
+
+# 3 independent runs (default) — reports mean + run-to-run spread + floors
+bun run test/bench/recall-eval/run.ts
+
+# more runs / measure without enforcing floors
+bun run test/bench/recall-eval/run.ts --runs 5
+bun run test/bench/recall-eval/run.ts --no-floor-check
+```
+
+Reuse a pre-downloaded model (read-only) to skip a HuggingFace pull:
+
+```bash
+export FLAIR_MODELS_DIR=/path/to/an/existing/flair/checkout/models
+```
+
+## The CI gate
+
+`test/integration/recall-eval-gate.test.ts` runs this eval on the integration
+lane (where the model is pre-downloaded), asserts every metric clears its floor,
+and runs the self-pollution mutation-check against real retrieval. It skips
+**visibly** when no model is present, so it never falsely passes.
+
+## Measured (this build)
+
+`nomic-embed-text-v1.5-Q4_K_M`, hybrid BM25+RRF on, `scoring=raw`, 3 independent
+runs, 87 records / 30 labelled queries:
+
+| metric | value | spread (3 runs) | floor |
+|---|---|---|---|
+| recall@1  | 0.833 | 0.000 | 0.73 |
+| recall@5  | 0.967 | 0.000 | 0.87 |
+| recall@10 | 0.967 | 0.000 | 0.90 |
+| nDCG@10   | 0.917 | 0.000 | 0.82 |
+| MRR       | 0.902 | 0.000 | 0.80 |
+
+## Files
+
+- `labels.ts` — the curated corpus binding (reuses `../recall-harness/corpus`),
+  the FIXED relevance labels, the floors, and the lexical-overlap self-pollution
+  control used by the mutation-check.
+- `eval.ts` — one eval run (ingest → wait-searchable → retrieve → score),
+  pure orchestration over `packages/flair-bench/lib`.
+- `run.ts` — the multi-run runner (mean + spread + floor check).

--- a/test/bench/recall-eval/eval.ts
+++ b/test/bench/recall-eval/eval.ts
@@ -1,0 +1,99 @@
+/**
+ * eval.ts — Layer 1 deterministic recall eval orchestration.
+ *
+ * Pure orchestration over the shared plumbing (packages/flair-bench/lib): ingest
+ * the curated corpus per-event, wait until it is actually searchable, retrieve
+ * every labelled query through Flair's real BM25+RRF at documented defaults, and
+ * score each ranking against its FIXED curated labels. No LLM judge, no
+ * sliding-window cue, no corpus-derived relevance — the whole point of the #17
+ * fix. Deterministic: fixed corpus, fixed query set, fixed labels.
+ *
+ * Takes a running ephemeral Harper + registered agent (caller owns the
+ * lifecycle) so the same function serves both the manual multi-run runner
+ * (./run.ts) and the CI gate (test/integration/recall-eval-gate.test.ts).
+ */
+import {
+  ingestSessionHistory,
+  retrieveContext,
+  suggestRetrieveLimit,
+  scoreQuery,
+  aggregate,
+  type BenchClient,
+  type AggregateScore,
+  type PerQueryScore,
+} from "../../../packages/flair-bench/lib/index";
+import { CORPUS } from "../recall-harness/corpus";
+import { buildCorpusSessions, LABELLED_QUERIES, type LabelledQuery } from "./labels";
+
+export interface QueryOutcome {
+  queryId: string;
+  kind: string;
+  /** 0-based rank of the first relevant id, -1 if not retrieved at all. */
+  rank: number;
+  score: PerQueryScore;
+}
+
+export interface RecallEvalResult {
+  aggregate: AggregateScore;
+  perQuery: QueryOutcome[];
+  ingest: { written: number; elapsedMs: number; syntheticTimestamps: boolean };
+  retrievalLatencyMeanMs: number;
+}
+
+/** Poll one query until its relevant id surfaces, so a not-yet-indexed corpus
+ *  never scores as a recall miss. Memory.put awaits embedding, but HNSW
+ *  visibility has a documented async lag in this codebase (see the harness's
+ *  waitSearchable). Uses the first labelled query as the canary. */
+async function waitSearchable(client: BenchClient, limit: number, timeoutMs = 45_000): Promise<void> {
+  const canary = LABELLED_QUERIES[0]!;
+  const wantId = canary.relevantIds[0]!;
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const ctx = await retrieveContext(client, canary.q, { limit });
+    if (ctx.rankedIds.includes(wantId)) return;
+    await new Promise((r) => setTimeout(r, 1500));
+  }
+  throw new Error(`recall-eval waitSearchable: canary "${canary.q.slice(0, 50)}" never surfaced ${wantId} within ${timeoutMs}ms (embedding engine slow/down?)`);
+}
+
+/**
+ * Run the full Layer 1 recall eval once against an already-running client.
+ * Optionally scores against an ALTERNATE label map (queryId → relevant ids) —
+ * used by the mutation-check to compare the curated labels against the
+ * self-polluting corpus-derived control on the SAME retrieval ranking. When
+ * `labelsOverride` is omitted, each query's own curated `relevantIds` are used.
+ */
+export async function runRecallEval(
+  client: BenchClient,
+  labelsOverride?: Record<string, string[]>,
+): Promise<RecallEvalResult> {
+  const limit = suggestRetrieveLimit(CORPUS.length);
+
+  const ingest = await ingestSessionHistory(client, buildCorpusSessions());
+  await waitSearchable(client, limit);
+
+  const perQuery: QueryOutcome[] = [];
+  const scores: PerQueryScore[] = [];
+  let latencySum = 0;
+
+  for (const lq of LABELLED_QUERIES) {
+    const relevant = labelsOverride ? (labelsOverride[lq.id] ?? lq.relevantIds) : lq.relevantIds;
+    const ctx = await retrieveContext(client, lq.q, { limit });
+    latencySum += ctx.latencyMs;
+    const relSet = new Set(relevant);
+    const rank = ctx.rankedIds.findIndex((id) => relSet.has(id));
+    const score = scoreQuery(ctx.rankedIds, relevant);
+    perQuery.push({ queryId: lq.id, kind: lq.kind, rank, score });
+    scores.push(score);
+  }
+
+  return {
+    aggregate: aggregate(scores),
+    perQuery,
+    ingest: { written: ingest.written, elapsedMs: ingest.elapsedMs, syntheticTimestamps: ingest.syntheticTimestamps },
+    retrievalLatencyMeanMs: latencySum / LABELLED_QUERIES.length,
+  };
+}
+
+export { LABELLED_QUERIES };
+export type { LabelledQuery };

--- a/test/bench/recall-eval/labels.ts
+++ b/test/bench/recall-eval/labels.ts
@@ -1,0 +1,149 @@
+/**
+ * labels.ts — Layer 1 deterministic recall eval: the curated corpus binding,
+ * the FIXED relevance labels, the floors, and the self-pollution control.
+ *
+ * This is the #17 fix's ground truth. The old recall QUALITY signal — the
+ * `flair quality` recall SPOT-CHECK (src/cli.ts `deriveRecallCue` +
+ * `computeRecallSpotCheck`) — derives its "query" from a memory's OWN text (a
+ * sliding partial cue) and calls recall a success when that same memory comes
+ * back. That is self-pollution: the relevance label IS corpus-query overlap by
+ * construction, so a corpus of near-duplicates scores a "recall collapse" that
+ * is really duplicate density, not a retrieval failure (flair#967 / #857 /
+ * #996). This eval replaces that as the authoritative recall-quality number
+ * with FIXED, hand-curated labels that are NOT derived from the corpus text.
+ *
+ * SINGLE SOURCE OF TRUTH: the corpus itself is the already-curated, already
+ * deterministic v1 instrument in ../recall-harness/corpus.ts — reused verbatim
+ * (not copied) so there is exactly one corpus + one set of labels. Its
+ * `expectMarker`s were written by hand against one specific record and checked
+ * that no other record answers the query more directly (see that file's
+ * "GROUND TRUTH" header). We consume those hand assignments as the fixed
+ * labels; we never recompute them from text.
+ */
+import { CORPUS, QUERIES } from "../recall-harness/corpus";
+import type { SessionEvent, SessionHistory } from "../../../packages/flair-bench/lib/index";
+
+/** Bench identity id-space. A record's Memory id is derived from its marker so
+ *  a label can point at it deterministically — same scheme the recall-harness
+ *  uses, kept distinct by AGENT_ID so the two never collide if both ever run
+ *  against one instance. */
+export const AGENT_ID = "recall-eval-layer1";
+export const idFor = (marker: string): string => `${AGENT_ID}-${marker.replace(/::/g, "-")}`;
+
+/** A labelled query: stable id, the query text, and the FIXED set of relevant
+ *  memory ids (curated, corpus-independent). */
+export interface LabelledQuery {
+  id: string;
+  q: string;
+  kind: string;
+  relevantIds: string[];
+}
+
+/** The curated corpus as per-event sessions (one Memory per record — the locked
+ *  per-event granularity). Timestamps preserved: createdAt = now − ageDays, the
+ *  same relative recency shape the harness seeds. Modelled as one session; the
+ *  ingest flattens events regardless, and Layer 1 has no cross-session
+ *  structure to preserve (Layer 2 will). */
+export function buildCorpusSessions(now: number = Date.now()): SessionHistory[] {
+  const events: SessionEvent[] = CORPUS.map((rec) => ({
+    id: idFor(rec.marker),
+    content: rec.text,
+    durability: rec.durability,
+    createdAt: now - rec.ageDays * 24 * 3600_000,
+  }));
+  return [{ sessionId: "layer1-recall-corpus", events }];
+}
+
+/** The labelled query set. Query id encodes kind + target + index so it is
+ *  stable and human-readable in a failure. relevantIds is the FIXED curated
+ *  label — one relevant memory per query (the corpus assigns exactly one). */
+export const LABELLED_QUERIES: LabelledQuery[] = QUERIES.map((query, i) => ({
+  id: `${query.kind}:${query.expectMarker}:${i}`,
+  q: query.q,
+  kind: query.kind,
+  relevantIds: [idFor(query.expectMarker)],
+}));
+
+/** The fixed relevance labels as a plain map (queryId → relevant memory ids).
+ *  This is the authoritative label — asserted-against in CI, and the thing the
+ *  self-pollution mutation-check proves is NOT reproducible from corpus text. */
+export const RELEVANCE_LABELS: Record<string, string[]> = Object.fromEntries(
+  LABELLED_QUERIES.map((q) => [q.id, q.relevantIds]),
+);
+
+// ── Self-pollution control (for the mutation-check, NOT the eval) ────────────
+//
+// This reconstructs what a CORPUS-DERIVED labelling would produce: for each
+// query, the label is the corpus record whose text has the highest lexical
+// (token) overlap with the query text — i.e. relevance == query/corpus overlap,
+// the exact defect the spot-check has. The eval never calls this; the
+// mutation-check does, to prove (a) the curated labels differ from it (so they
+// are real, not overlap artefacts) and (b) swapping to it changes the metric.
+
+const STOPWORDS = new Set(
+  "a an the of to in on for and or is are was were be been being do does did what which who whom whose how why when where that this these those it its as at by with from into your you my i me we our their they them he she his her".split(
+    /\s+/,
+  ),
+);
+
+function tokenize(s: string): Set<string> {
+  return new Set(
+    s
+      .toLowerCase()
+      .split(/[^a-z0-9]+/)
+      .filter((t) => t.length >= 3 && !STOPWORDS.has(t)),
+  );
+}
+
+/** For each labelled query, the id of the corpus record with the greatest
+ *  token overlap with the query text — the self-polluting "relevance = overlap"
+ *  labelling. Ties break to the earliest corpus record (deterministic). */
+export function deriveLexicalOverlapLabels(): Record<string, string[]> {
+  const corpusTokens = CORPUS.map((rec) => ({ marker: rec.marker, toks: tokenize(rec.text) }));
+  const out: Record<string, string[]> = {};
+  for (const lq of LABELLED_QUERIES) {
+    const qToks = tokenize(lq.q);
+    let bestMarker = corpusTokens[0]!.marker;
+    let bestOverlap = -1;
+    for (const { marker, toks } of corpusTokens) {
+      let overlap = 0;
+      for (const t of qToks) if (toks.has(t)) overlap++;
+      if (overlap > bestOverlap) {
+        bestOverlap = overlap;
+        bestMarker = marker;
+      }
+    }
+    out[lq.id] = [idFor(bestMarker)];
+  }
+  return out;
+}
+
+// ── Floors (the CI gate) ─────────────────────────────────────────────────────
+//
+// Per-metric minimums the eval must clear. Set BELOW the measured value by a
+// margin that DWARFS the run-to-run noise band, so a breach means a real
+// regression, not sampling wobble (#17 defect (b): the old threshold sat below
+// the noise, so it could neither catch a regression nor avoid false alarms).
+//
+// Measured on this build (fresh clone, nomic-embed-text-v1.5-Q4_K_M, hybrid
+// BM25+RRF on, scoring=raw, prefixes on = documented defaults), 3 independent
+// spawn→ingest→retrieve runs — see ./run.ts output and the PR body:
+//   recall@1  = 0.833   (spread 0.000 across 3 runs)
+//   recall@5  = 0.967   (spread 0.000)
+//   recall@10 = 0.967   (spread 0.000)
+//   nDCG@10   = 0.917   (spread 0.000)
+//   MRR       = 0.902   (spread 0.000)
+// Noise band: 0.000 on every metric (fixed corpus + deterministic HNSW build,
+// matching the recall-harness's own long-observed ±0.000). Each floor sits a
+// margin below its measured value — recall@1 0.10 (≈3 queries at N=30),
+// recall@5 0.10, recall@10 0.067, nDCG@10 0.097, MRR 0.102. Every margin is
+// ≥2 whole queries and orders of magnitude above the 0.000 noise, so a breach
+// is a real regression, never sampling wobble (the #17 defect (b) fix: the old
+// threshold sat AT/below the noise instead of meaningfully above it).
+export const FLOORS = {
+  recallAt1: 0.73,
+  recallAt5: 0.87,
+  recallAt10: 0.9,
+  ndcgAt10: 0.82,
+  mrr: 0.8,
+} as const;

--- a/test/bench/recall-eval/run.ts
+++ b/test/bench/recall-eval/run.ts
@@ -1,0 +1,124 @@
+#!/usr/bin/env bun
+/**
+ * run.ts — Layer 1 deterministic recall eval runner (#17 fix, #1216-a).
+ *
+ * Spawns a FRESH ephemeral Harper per run (independent: fresh HNSW build +
+ * embedding warmup), ingests the curated corpus via the shared plumbing,
+ * retrieves every labelled query through Flair's real BM25+RRF at documented
+ * defaults, and reports recall@1/5/10, nDCG@10, MRR — plus the run-to-run
+ * SPREAD, which is the load-bearing number: a "deterministic" metric is only
+ * deterministic if you ran it enough times to see the spread is ~0.
+ *
+ * This is the recall-QUALITY instrument. It reports fixed-metric floors and
+ * fails (exit 1) if any metric falls below its floor — the same numbers the CI
+ * gate (test/integration/recall-eval-gate.test.ts) asserts. It is NOT the
+ * composite-vs-raw scoring DIAGNOSTIC — that is the sibling recall-harness
+ * (../recall-harness/run.ts), a different question (does a scoring config
+ * regress), left in place.
+ *
+ * USAGE:
+ *   bun run test/bench/recall-eval/run.ts                 # 3 runs (default)
+ *   bun run test/bench/recall-eval/run.ts --runs 5        # more runs
+ *   bun run test/bench/recall-eval/run.ts --no-floor-check # measure only
+ *
+ * Reuse a pre-downloaded embedding model (read-only) to skip a HuggingFace
+ * pull: export FLAIR_MODELS_DIR=/path/to/an/existing/flair/checkout/models
+ */
+import { existsSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+import { startHarper, stopHarper, type HarperInstance } from "../../helpers/harper-lifecycle";
+import { mkAgent, registerAgent, type BenchClient } from "../../../packages/flair-bench/lib/index";
+import { runRecallEval, LABELLED_QUERIES } from "./eval";
+import { AGENT_ID, FLOORS } from "./labels";
+import { CORPUS } from "../recall-harness/corpus";
+
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../../..");
+
+function assertBuilt(): void {
+  const marker = path.join(REPO_ROOT, "dist", "resources", "SemanticSearch.js");
+  if (!existsSync(marker)) {
+    console.error(`FATAL: ${marker} not found. Harper serves resources from dist/, not TypeScript source.`);
+    console.error(`Run \`bun run build\` in ${REPO_ROOT} first, then re-run this eval.`);
+    process.exit(2);
+  }
+}
+
+function argVal(flag: string, dflt: string): string {
+  const i = process.argv.indexOf(flag);
+  return i >= 0 && process.argv[i + 1] ? process.argv[i + 1]! : dflt;
+}
+const RUNS = Math.max(1, parseInt(argVal("--runs", "3"), 10) || 3);
+const CHECK_FLOORS = !process.argv.includes("--no-floor-check");
+
+type MetricKey = "recallAt1" | "recallAt5" | "recallAt10" | "ndcgAt10" | "mrr";
+const METRICS: MetricKey[] = ["recallAt1", "recallAt5", "recallAt10", "ndcgAt10", "mrr"];
+const fmt = (x: number, d = 3) => x.toFixed(d);
+
+async function oneRun(runIdx: number): Promise<Record<MetricKey, number>> {
+  const label = `[run ${runIdx}/${RUNS}]`;
+  const prevHybrid = process.env.FLAIR_HYBRID_RETRIEVAL;
+  process.env.FLAIR_HYBRID_RETRIEVAL = "true"; // documented default: hybrid BM25+RRF on
+  let harper: HarperInstance | undefined;
+  try {
+    console.log(`${label} spawning ephemeral Harper...`);
+    harper = await startHarper({ cwd: REPO_ROOT, harperBinDir: REPO_ROOT });
+    const agent = mkAgent(AGENT_ID);
+    await registerAgent(harper, agent);
+    const client: BenchClient = { harper, agent };
+    console.log(`${label} ingesting ${CORPUS.length} records, then measuring ${LABELLED_QUERIES.length} queries...`);
+    const res = await runRecallEval(client);
+    const a = res.aggregate;
+    console.log(
+      `${label} recall@1=${fmt(a.recallAt1)} recall@5=${fmt(a.recallAt5)} recall@10=${fmt(a.recallAt10)} nDCG@10=${fmt(a.ndcgAt10)} MRR=${fmt(a.mrr)}  (ingest ${res.ingest.elapsedMs.toFixed(0)}ms, retrieval mean ${res.retrievalLatencyMeanMs.toFixed(1)}ms/q)`,
+    );
+    if (res.ingest.syntheticTimestamps) console.warn(`${label} WARNING: some events had synthetic timestamps — corpus should carry its own.`);
+    return { recallAt1: a.recallAt1, recallAt5: a.recallAt5, recallAt10: a.recallAt10, ndcgAt10: a.ndcgAt10, mrr: a.mrr };
+  } finally {
+    if (harper) await stopHarper(harper, { keepInstallDir: false });
+    if (prevHybrid === undefined) delete process.env.FLAIR_HYBRID_RETRIEVAL;
+    else process.env.FLAIR_HYBRID_RETRIEVAL = prevHybrid;
+  }
+}
+
+async function main() {
+  assertBuilt();
+  console.log(`recall-eval (Layer 1, #17) — ${CORPUS.length} records / ${LABELLED_QUERIES.length} labelled queries, ${RUNS} independent run(s)`);
+  console.log(`retrieval: hybrid BM25+RRF on, scoring=raw (documented defaults)`);
+  if (process.env.FLAIR_MODELS_DIR) console.log(`FLAIR_MODELS_DIR=${process.env.FLAIR_MODELS_DIR}`);
+  console.log();
+
+  const runs: Record<MetricKey, number>[] = [];
+  for (let i = 1; i <= RUNS; i++) runs.push(await oneRun(i));
+
+  console.log(`\n══ AGGREGATE over ${RUNS} run(s) ══\n`);
+  const mean: Record<string, number> = {};
+  const spread: Record<string, number> = {};
+  for (const m of METRICS) {
+    const vals = runs.map((r) => r[m]);
+    const mn = vals.reduce((s, x) => s + x, 0) / vals.length;
+    const sp = Math.max(...vals) - Math.min(...vals);
+    mean[m] = mn;
+    spread[m] = sp;
+    console.log(`  ${m.padEnd(10)} mean=${fmt(mn)}  spread(max−min)=${fmt(sp)}  floor=${fmt(FLOORS[m])}  [${vals.map((v) => fmt(v)).join(", ")}]`);
+  }
+  const maxSpread = Math.max(...METRICS.map((m) => spread[m]!));
+  console.log(`\n  noise band (max spread across all metrics over ${RUNS} runs): ${fmt(maxSpread)}`);
+
+  if (!CHECK_FLOORS) {
+    console.log(`\n(--no-floor-check: floors not enforced)`);
+    return;
+  }
+  const breaches = METRICS.filter((m) => mean[m]! < FLOORS[m]);
+  if (breaches.length) {
+    console.error(`\nFLOOR BREACH on ${breaches.length} metric(s):`);
+    for (const m of breaches) console.error(`  ${m}: mean ${fmt(mean[m]!)} < floor ${fmt(FLOORS[m])}`);
+    process.exit(1);
+  }
+  console.log(`\nAll ${METRICS.length} metrics clear their floors.`);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/test/bench/recall-harness/README.md
+++ b/test/bench/recall-harness/README.md
@@ -4,6 +4,16 @@ Measures Flair's recall precision (p@3, MRR) against a **harder, representative
 synthetic corpus**, on a **fully ephemeral Harper instance**. It never touches
 any live checkout, the live `:9926` service, or any production memory.
 
+> **Which recall tool is which (#1216).** This harness is the **scoring-config
+> diagnostic** — its job is composite-vs-raw / prefix A/B ("does this config
+> regress"), and it is manually invoked, not a CI gate. The **authoritative
+> recall-quality number** (recall@1/5/10, nDCG@10, MRR with fixed curated
+> labels, gated in CI) lives next door in
+> [`../recall-eval`](../recall-eval/README.md). They share one corpus
+> (`corpus.ts`, reused by both) and one ingest/retrieve implementation
+> (`packages/flair-bench/lib/`), so the two can never diverge on how memories
+> are written or read — they only ask different questions.
+
 ## Why this exists
 
 Two recall tools already live in `ops/tools/agent-fabric/`:

--- a/test/integration/recall-eval-gate.test.ts
+++ b/test/integration/recall-eval-gate.test.ts
@@ -1,0 +1,99 @@
+/**
+ * recall-eval-gate.test.ts — the deterministic recall-quality CI GATE (#1216-a,
+ * closes the #17 noisy-metric defect).
+ *
+ * Spawns a fresh ephemeral Harper, ingests the curated corpus via the shared
+ * plumbing, retrieves every labelled query through Flair's real BM25+RRF at
+ * documented defaults, and asserts every metric clears its floor. The floors
+ * sit a margin ≥2 whole queries below the measured value — orders of magnitude
+ * above the 0.000 run-to-run noise band (see labels.ts) — so a breach here is a
+ * real recall regression, not sampling wobble.
+ *
+ * Also carries the self-pollution MUTATION-CHECK against real retrieval: the
+ * same deterministic ranking scored under the curated labels vs the
+ * corpus-derived (lexical-overlap) labels must give DIFFERENT numbers — proof
+ * the curated labels are real and not the overlap artefact the old spot-check
+ * scored on.
+ *
+ * MODEL-GATED: the embedding model must be present (FLAIR_MODELS_DIR or
+ * <cwd>/models, where CI pre-downloads it). Without it, this skips VISIBLY
+ * rather than triggering a HuggingFace pull mid-suite — the same
+ * graceful-skip posture the other model-dependent lanes use. In the integration
+ * lane the model IS present, so the gate fires.
+ */
+import { describe, expect, test, beforeAll, afterAll } from "bun:test";
+import { existsSync } from "node:fs";
+import path from "node:path";
+import { startHarper, stopHarper, type HarperInstance } from "../helpers/harper-lifecycle";
+import { mkAgent, registerAgent, type BenchClient } from "../../packages/flair-bench/lib/index";
+import { runRecallEval } from "../bench/recall-eval/eval";
+import { AGENT_ID, FLOORS, deriveLexicalOverlapLabels } from "../bench/recall-eval/labels";
+
+const MODEL_FILE = "nomic-embed-text-v1.5.Q4_K_M.gguf";
+function modelPresent(): boolean {
+  const dirs = [process.env.FLAIR_MODELS_DIR, path.join(process.cwd(), "models")].filter(Boolean) as string[];
+  return dirs.some((d) => existsSync(path.join(d, MODEL_FILE)));
+}
+
+const HAS_MODEL = modelPresent();
+const gate = HAS_MODEL ? describe : describe.skip;
+if (!HAS_MODEL) {
+  console.warn(`[recall-eval-gate] SKIPPING: embedding model ${MODEL_FILE} not found in FLAIR_MODELS_DIR or <cwd>/models. This gate needs it; a runner with the model runs it.`);
+}
+
+gate("deterministic recall-quality gate (#1216-a / #17)", () => {
+  let harper: HarperInstance;
+  let client: BenchClient;
+  let curated: Awaited<ReturnType<typeof runRecallEval>>;
+
+  beforeAll(async () => {
+    const prev = process.env.FLAIR_HYBRID_RETRIEVAL;
+    process.env.FLAIR_HYBRID_RETRIEVAL = "true"; // documented default
+    try {
+      harper = await startHarper();
+    } finally {
+      if (prev === undefined) delete process.env.FLAIR_HYBRID_RETRIEVAL;
+      else process.env.FLAIR_HYBRID_RETRIEVAL = prev;
+    }
+    const agent = mkAgent(AGENT_ID);
+    await registerAgent(harper, agent);
+    client = { harper, agent };
+    curated = await runRecallEval(client);
+  }, 180_000);
+
+  afterAll(async () => {
+    if (harper) await stopHarper(harper, { keepInstallDir: false });
+  });
+
+  test("ingest wrote the whole corpus with real timestamps", () => {
+    expect(curated.ingest.written).toBeGreaterThan(0);
+    expect(curated.ingest.syntheticTimestamps).toBe(false);
+  });
+
+  test("recall@1 clears its floor", () => {
+    expect(curated.aggregate.recallAt1).toBeGreaterThanOrEqual(FLOORS.recallAt1);
+  });
+  test("recall@5 clears its floor", () => {
+    expect(curated.aggregate.recallAt5).toBeGreaterThanOrEqual(FLOORS.recallAt5);
+  });
+  test("recall@10 clears its floor", () => {
+    expect(curated.aggregate.recallAt10).toBeGreaterThanOrEqual(FLOORS.recallAt10);
+  });
+  test("nDCG@10 clears its floor", () => {
+    expect(curated.aggregate.ndcgAt10).toBeGreaterThanOrEqual(FLOORS.ndcgAt10);
+  });
+  test("MRR clears its floor", () => {
+    expect(curated.aggregate.mrr).toBeGreaterThanOrEqual(FLOORS.mrr);
+  });
+
+  test("mutation-check: corpus-derived labels score DIFFERENTLY than curated (self-pollution absent)", async () => {
+    // Same deterministic retrieval, scored under the self-polluting
+    // lexical-overlap labels. If the curated labels were just corpus overlap,
+    // these would match. They must not: the lexical labels mislabel the
+    // trap/hard queries, so scoring against them is strictly worse.
+    const polluted = await runRecallEval(client, deriveLexicalOverlapLabels());
+    expect(polluted.aggregate.mrr).not.toBe(curated.aggregate.mrr);
+    expect(polluted.aggregate.mrr).toBeLessThan(curated.aggregate.mrr);
+    expect(polluted.aggregate.recallAt1).toBeLessThan(curated.aggregate.recallAt1);
+  }, 120_000);
+});

--- a/test/unit/recall-eval-labels.test.ts
+++ b/test/unit/recall-eval-labels.test.ts
@@ -1,0 +1,76 @@
+/**
+ * recall-eval-labels.test.ts — the #17 self-pollution proof, hermetic.
+ *
+ * The defect the deterministic recall eval (#1216-a) fixes: the old recall
+ * QUALITY signal (`flair quality` recall spot-check) derived its relevance
+ * label from the target memory's OWN text — relevance == query/corpus overlap,
+ * so a corpus of near-duplicates scores a false "recall collapse" (flair#967 /
+ * #857 / #996). This test proves the Layer 1 labels are FIXED and curated, NOT
+ * reproducible from corpus-query text overlap, and that scoring against the
+ * two labellings gives DIFFERENT metrics (so the curated labels are real, not
+ * an overlap artefact). No Harper — pure label + metric math.
+ */
+import { describe, expect, test } from "bun:test";
+import {
+  RELEVANCE_LABELS,
+  deriveLexicalOverlapLabels,
+  LABELLED_QUERIES,
+  idFor,
+} from "../bench/recall-eval/labels";
+import { CORPUS } from "../bench/recall-harness/corpus";
+import { recallAtK } from "../../packages/flair-bench/lib/index";
+
+describe("Layer 1 recall labels are curated, not corpus-derived (#17)", () => {
+  test("every curated label resolves to a real corpus record", () => {
+    const realIds = new Set(CORPUS.map((r) => idFor(r.marker)));
+    for (const lq of LABELLED_QUERIES) {
+      expect(lq.relevantIds.length).toBeGreaterThan(0);
+      for (const id of lq.relevantIds) expect(realIds.has(id)).toBe(true);
+    }
+  });
+
+  test("curated labels DIFFER from the self-polluting lexical-overlap labelling", () => {
+    // The control: relevance == the corpus record with max token overlap with
+    // the query (what a corpus-derived label produces — the spot-check defect).
+    const derived = deriveLexicalOverlapLabels();
+    let differing = 0;
+    for (const lq of LABELLED_QUERIES) {
+      const curated = RELEVANCE_LABELS[lq.id]!.join(",");
+      const overlap = derived[lq.id]!.join(",");
+      if (curated !== overlap) differing++;
+    }
+    // If the curated labels were just corpus-query overlap, this would be 0.
+    // It is not: a meaningful fraction of queries are answered by a record that
+    // is NOT the highest-lexical-overlap one (the whole reason the corpus has
+    // trap/hard queries). That is the self-pollution being absent.
+    expect(differing).toBeGreaterThanOrEqual(3);
+    // And the two label MAPS are not identical.
+    expect(JSON.stringify(RELEVANCE_LABELS)).not.toBe(JSON.stringify(derived));
+  });
+
+  test("mutation-check: swapping to corpus-derived labels CHANGES the metric", () => {
+    // Oracle ranking per query: the curated answer first, then the rest of the
+    // corpus. Under the CURATED labels this scores recall@1 = 1.0 by
+    // construction. Under the corpus-derived labels it must score LOWER,
+    // because for the diverging queries the lexical label is a DIFFERENT record
+    // that is not at rank 0. A metric that did not move here would mean the two
+    // labellings were interchangeable — i.e. the labels were corpus-derived
+    // after all. It moves, so they are real.
+    const derived = deriveLexicalOverlapLabels();
+    const allIds = CORPUS.map((r) => idFor(r.marker));
+
+    let curatedHits = 0;
+    let derivedHits = 0;
+    for (const lq of LABELLED_QUERIES) {
+      const curatedId = lq.relevantIds[0]!;
+      const ranking = [curatedId, ...allIds.filter((id) => id !== curatedId)];
+      curatedHits += recallAtK(ranking, lq.relevantIds, 1);
+      derivedHits += recallAtK(ranking, derived[lq.id]!, 1);
+    }
+    const curatedRecall1 = curatedHits / LABELLED_QUERIES.length;
+    const derivedRecall1 = derivedHits / LABELLED_QUERIES.length;
+
+    expect(curatedRecall1).toBe(1); // oracle + curated labels = perfect by construction
+    expect(derivedRecall1).toBeLessThan(curatedRecall1); // reverting to overlap labels changes it
+  });
+});


### PR DESCRIPTION
## flair-bench eval FOUNDATION + Layer 1 — deterministic recall eval (#1216-a)

The shared plumbing every flair-bench eval layer builds on, plus the deterministic
recall-quality eval + CI gate that fixes the noisy self-polluting recall metric.
Layer 2 (LongMemEval_s end-to-end + the gemma4 judge) is a separate later slice
that reuses this foundation unchanged.

### Shared plumbing (`packages/flair-bench/lib/`) — Kern's design

One ingest + one retrieve + one metrics implementation, so Layer 1 and the later
Layer 2 can never diverge on how memories are written to or read from Flair (a
divergence would be a silent confound):

- `ingestSessionHistory(client, sessions, opts)` — **per-event** writes (one
  Memory per event, the granularity Flair itself uses in `memory_service.py`; the
  locked #1216 decision), timestamps preserved. Byte-identical write shape to the
  existing recall-harness.
- `retrieveContext(client, query, opts)` — Flair's **real BM25+RRF** via
  `/SemanticSearch` at documented defaults (hybrid on, `scoring=raw`, nomic
  prefixes on).
- `metrics.ts` — pure recall@k / nDCG@k / reciprocal-rank over a relevant-id
  **set** (so Layer 2's multi-relevant questions reuse it unchanged).
- `signed-fetch.ts` — the shared Ed25519 TPS-signed read/write path.

Repo-internal tooling (outside `src/`, not in the published tarball); consumed by
bench runners + tests via bun.

### Layer 1 — deterministic recall eval (`test/bench/recall-eval/`)

recall@1/5/10, nDCG@10, MRR on the **curated corpus** (reused verbatim from
`recall-harness/corpus.ts` — one source of truth) against **FIXED, hand-curated**
relevance labels. No LLM judge, no corpus-derived relevance.

**Measured (fresh clone, `nomic-embed-text-v1.5-Q4_K_M`, hybrid BM25+RRF on,
`scoring=raw`, 3 independent spawn→ingest→retrieve runs, 87 records / 30 labelled
queries):**

| metric | value | spread (3 runs) | CI floor | margin above noise |
|---|---|---|---|---|
| recall@1  | 0.833 | 0.000 | 0.73 | 0.103 (≈3 queries) |
| recall@5  | 0.967 | 0.000 | 0.87 | 0.097 |
| recall@10 | 0.967 | 0.000 | 0.90 | 0.067 (≈2 queries) |
| nDCG@10   | 0.917 | 0.000 | 0.82 | 0.097 |
| MRR       | 0.902 | 0.000 | 0.80 | 0.102 |

**Noise band = 0.000** on every metric across 3 runs (fixed corpus +
deterministic HNSW build). Every floor margin is ≥2 whole queries — orders of
magnitude above the noise, so a breach is a real regression.

### The #17 fix — which metric was noisy, and the three defects

The noisy recall-quality signal is the **`flair quality` recall spot-check**
(`src/cli.ts` `deriveRecallCue` + `computeRecallSpotCheck`), not the (already
deterministic, curated) recall-harness. Its defects, all removed here:

1. **Self-pollution** — it derives its "query" from a memory's OWN text (a sliding
   partial cue) and scores recall on the same memory returning; relevance ==
   query/corpus overlap by construction, so near-duplicate density reads as a
   recall collapse (flair#967 / #857 / #996). The new labels are provably NOT
   reproducible from corpus-query overlap: `test/unit/recall-eval-labels.test.ts`
   shows 6 of 30 curated labels differ from what lexical overlap would pick, and
   swapping to overlap labels changes the metric. The CI gate repeats this
   mutation-check against **real retrieval**.
2. **Threshold below the noise** — floors are set from a measured noise band
   (0.000) with margins ≥2 whole queries above it.
3. **Sliding-window noise** — replaced by the deterministic rank metrics.

### "Don't leave two competing metrics" — three roles, not three answers

- **recall-eval (new)** = the authoritative recall-**quality** number (CI-gated).
- **recall-harness (unchanged)** = the scoring-config **diagnostic**
  (composite-vs-raw / prefix A/B) — a different question; left in place, now
  shares corpus + plumbing, README updated to say so.
- **`flair quality` recall spot-check (unchanged, comment only)** = a
  live-health **cratering probe** — scoped to that job by a docstring note; its
  self-pollution as a *quality* metric is tracked in flair#967 / #857 / #996.

Ripping the spot-check out of the shipped CLI (an invasive production change) or
rewriting the deterministic recall-harness was deliberately **out of scope** for
this foundation slice.

### CI gate

`test/integration/recall-eval-gate.test.ts` runs on the integration lane (model
pre-downloaded), asserts every floor, and runs the mutation-check. It **skips
visibly** when no model is present (never a false pass).

### Verification (this session)

- 3-run stability + floors: PASS (table above), production `:9926` untouched
  (health 200 throughout; all Harper instances ephemeral + HOME-isolated).
- Fast unit suite: **4191 pass / 0 fail** vs origin/main baseline **4188 pass /
  0 fail** = +3 (the new hermetic test), **zero regressions**.
- flair-bench package suite: 60 pass / 0 fail. Integration gate: 7 pass.
- `tsc -p tsconfig.test.check.json` (strict) exit 0; `tsc -p tsconfig.cli.json`
  exit 0; `changelog-fragments.mjs check` exit 0.
- `package.json` / `bun.lock` untouched.

### Note on the issue number

The task referenced "issue #17" for the noisy quality-sweep, but GitHub #17 is an
unrelated already-merged PR (SearchMemories → FindMemories). The actual noisy
metric is the recall spot-check above; the open tracking issues are flair#967 /
#857 / #996. Not using `Closes #17` to avoid a misleading link.

Refs #1216 — Layer 2 remains.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
