### PR TITLE
feat(flair-bench): LongMemEval_s end-to-end benchmark (Layer 2) (Refs #1216)

### DIFF
--- a/.changelog/unreleased/added-longmemeval-s-layer2-benchmark.md
+++ b/.changelog/unreleased/added-longmemeval-s-layer2-benchmark.md
@@ -1,0 +1,12 @@
+- **LongMemEval_s end-to-end benchmark (Layer 2).** A new `flair-bench`
+  harness (`test/bench/longmemeval/`) that ingests each LongMemEval_s question's
+  multi-session history into real Flair, retrieves via Flair's real BM25+RRF
+  retrieval, has a pinned reader answer, and has a pinned local judge grade it —
+  across four arms (flair, vector-only, full-context, no-context). Everything is
+  pinned for local reproducibility: the dataset (HF commit + sha256), the judge
+  and reader (Ollama manifest digests), num_ctx, retrieval config, and the exact
+  grading prompts — all folded into a content-addressed run artifact. Judge and
+  reader run locally via Ollama, so anyone re-runs the exact number with no
+  external API key or spend. The harness produces numbers; publishing one is a
+  separate, gated human decision recorded against the artifact hash. Repo-
+  internal tooling — not part of the published `@tpsdev-ai/flair-bench` package.

--- a/test/bench/longmemeval/README.md
+++ b/test/bench/longmemeval/README.md
@@ -1,0 +1,123 @@
+# LongMemEval_s — Layer 2 end-to-end benchmark (#1216-b)
+
+The end-to-end memory benchmark: per question, ingest a multi-session history
+into **real Flair**, retrieve context via Flair's **real BM25+RRF** retrieval,
+have a **pinned reader** answer, and have a **pinned local judge** grade the
+answer. It sits on top of the shared plumbing merged in #1216-a
+(`packages/flair-bench/lib/`) — the same `ingestSessionHistory` /
+`retrieveContext` the Layer 1 recall eval uses, so the two layers can never
+diverge on how memories are written or read (a divergence would be a silent
+confound).
+
+**Reproducibility is the edge.** Everything that can move the number is pinned
+and committed: the dataset (by HF commit + sha256), the judge and reader (by
+Ollama manifest digest — tags are mutable, digests are not), num_ctx, the
+retrieval config, the ingestion granularity, and the exact judge/reader prompt
+strings (folded into the config hash). Anyone re-runs the exact number locally
+with `ollama pull` — no OpenAI key, no per-run spend.
+
+## Arms
+
+| arm | context fed to the reader | role |
+|-----|---------------------------|------|
+| `flair` | BM25+RRF hybrid retrieval, documented defaults | the headline |
+| `vector-only` | the same retrieval with BM25 disabled (pure HNSW) | ablation |
+| `full-context` | the entire haystack (own larger, pinned num_ctx) | ceiling + **memory-validity check** |
+| `no-context` | nothing — only the question | **contamination probe** |
+
+Reader and judge are the **same across all arms** — only the context differs.
+
+- `no-context` high ⇒ the reader is answering from prior knowledge /
+  contamination, and the number is suspect.
+- `full-context ≈ flair` ⇒ the benchmark is measuring long-context, not memory;
+  a large `full-context − flair` gap ⇒ retrieval is losing relevant information.
+
+## Pinned components
+
+- **Dataset:** LongMemEval_s, HF `xiaowu0162/longmemeval` @
+  `2ec2a557f339b6c0369619b1ed5793734cc87533`, file `longmemeval_s`,
+  sha256 `08d8dad4be43ee2049a22ff5674eb86725d0ce5ff434cde2627e5e8e7e117894`.
+  Judge prompts ported from `xiaowu0162/LongMemEval` @
+  `9e0b455f4ef0e2ab8f2e582289761153549043fc`
+  (`src/evaluation/evaluate_qa.py`).
+- **Judge:** `gemma4:31b-it-q8_0`, LOCAL on Newton via Ollama, manifest digest
+  `sha256:53dd8459790f8795177444daa9e33f417e03c0d1cdedb80b6c73898603d20aef`.
+  temp 0, fixed num_ctx, **plaintext** verdict (never Ollama's JSON/structured
+  mode — non-deterministic at fixed seed, Ollama #12559).
+- **Reader:** `qwen3.6:27b-coding-mxfp8` (Qwen family — a **different family**
+  than the Gemma judge, the self-preference control), digest
+  `sha256:a7185d39ff35a472a2721b87e1bbb90810bcd381d415666ce2137838e66f2780`.
+
+The harness **fails loud** if a model's current digest on the host does not
+match the pinned digest, if the dataset sha256 does not match, or if the judge
+family equals the reader family.
+
+## Grading
+
+The SimpleQA ternary — **CORRECT / INCORRECT / NOT_ATTEMPTED** — carrying
+LongMemEval's expert per-task rubric text (off-by-one leniency for temporal;
+subset-of-the-answer is wrong; updated-answer-present is right for
+knowledge-update; a rubric for preference; the unanswerable framing for
+abstention). The verdict is parsed as a **plaintext exact enum** (A/B/C);
+anything the parser cannot resolve to a single allowed letter is a **judge
+error**, never a silent pass. Headline accuracy = CORRECT / judged;
+`NOT_ATTEMPTED` on an answerable question is broken out separately, and
+abstention questions are reported as their own bucket.
+
+An **independent F1/EM cross-check** (`extraction.ts` — pure SQuAD-style string
+math, NOT the LLM judge) runs on the factual subset (IE, multi-session,
+temporal, knowledge-update). A large judge-vs-F1 gap is the tell for a lenient
+judge (the LightRAG cautionary case).
+
+## Get the dataset (pinned)
+
+Not committed to the repo (278 MB, HF LFS). Fetch it pinned:
+
+```bash
+curl -sL \
+  "https://huggingface.co/datasets/xiaowu0162/longmemeval/resolve/2ec2a557f339b6c0369619b1ed5793734cc87533/longmemeval_s" \
+  -o longmemeval_s.json
+shasum -a 256 longmemeval_s.json
+# expect: 08d8dad4be43ee2049a22ff5674eb86725d0ce5ff434cde2627e5e8e7e117894
+```
+
+## Run
+
+```bash
+# 0. build (Harper serves resources from dist/)
+bun run build
+
+# 1. prove the judge: correct + DETERMINISTIC ternary verdicts on known pairs
+bun run test/bench/longmemeval/run.ts verify-judge --repeats 3
+
+# 2. run a slice over the four arms → content-addressed artifact
+bun run test/bench/longmemeval/run.ts run \
+  --dataset ./longmemeval_s.json --n 24 --seed 0 --runs 5
+```
+
+`LME_OLLAMA_HOST` overrides the Ollama endpoint (default Newton
+`http://192.168.2.64:11434`).
+
+`LME_FULL_CTX` overrides the full-context arm's window (default `131072`, the
+pinned publishable value). A ~100k-token prefill is minutes per call, so a
+validation slice may reduce it (e.g. `LME_FULL_CTX=16384`) — the value used is
+folded into the config hash and recorded in the artifact, so a reduced window is
+never silent. Reduce it ONLY for validation; the publishable run uses the pinned
+default.
+
+## The publish gate is structural
+
+The run emits a **content-addressed artifact** (`artifact.ts`): config hash +
+per-run hashes + the numbers, addressed by `artifactHash`. There is **no
+`--publish` flag** and no publish function. Publishing any number is a separate,
+gated human decision recorded against a specific `artifactHash` — spend and
+outward-publishing are the founder's gates. The full ≥5×500 publishable run is a
+separate gated execution; the default `--runs`/`--n` here are sized for
+validation.
+
+## Isolation
+
+Each run spawns a **fresh ephemeral Harper** per Harper-arm
+(`test/helpers/harper-lifecycle`), which HOME-isolates itself to a temp dir —
+ingest **never** touches production `~/.flair` / `:9926`. Runs are independent
+(fresh instance, fresh ingest), so the ≥5-run std reflects real variance.

--- a/test/bench/longmemeval/arms.ts
+++ b/test/bench/longmemeval/arms.ts
@@ -1,0 +1,78 @@
+/**
+ * arms.ts — the four benchmark arms and the reader prompt.
+ *
+ * The ONLY thing that varies across arms is the CONTEXT fed to the reader
+ * (Kern §5a: pin the reader across all arms; only the context changes):
+ *
+ *   - flair        BM25+RRF hybrid retrieval at documented defaults (the headline).
+ *   - vector-only  the same retrieval with BM25 disabled — pure HNSW/vector
+ *                  (a clean ablation: Flair with hybrid off, everything else
+ *                  identical). Set at the Harper PROCESS level via
+ *                  FLAIR_HYBRID_RETRIEVAL=false (eval.ts spawns a second Harper).
+ *   - full-context the ENTIRE haystack (the ceiling AND the memory-validity
+ *                  check: if it ≈ flair, the benchmark is measuring long-context,
+ *                  not memory). Uses its own larger, still-pinned num_ctx.
+ *   - no-context   the reader gets ONLY the question — zero memories. The
+ *                  decisive contamination probe (Sherlock #2): if this scores
+ *                  high, the number reflects the reader's prior knowledge, not
+ *                  the memory layer, and the whole result is suspect.
+ *
+ * The question_date is given to the reader in EVERY arm (it is the clock, not
+ * memory), so temporal questions have a reference "today" and the arms differ
+ * only in memory content — including no-context, whose memory content is empty.
+ */
+import type { RetrievedItem } from "../../../packages/flair-bench/lib/index";
+import type { LmeSession } from "./dataset";
+
+export type Arm = "flair" | "vector-only" | "full-context" | "no-context";
+export const ALL_ARMS: Arm[] = ["flair", "vector-only", "full-context", "no-context"];
+
+/** Arms that retrieve from a running Flair (need an ephemeral Harper). */
+export const HARPER_ARMS: Arm[] = ["flair", "vector-only"];
+
+export const READER_SYSTEM =
+  "You are a helpful assistant answering the user's question using ONLY the conversation memory provided. " +
+  "Answer concisely and directly. If the provided memory does not contain enough information to answer, " +
+  "reply that you do not know rather than guessing.";
+
+/** Format retrieved memories (flair / vector-only) as a compact context block.
+ *  Items arrive rank-ordered (rank 0 = best). */
+export function formatRetrieved(items: RetrievedItem[]): string {
+  if (items.length === 0) return "(no relevant memory found)";
+  return items.map((it, i) => `- ${(it.content ?? "").trim()}`).join("\n");
+}
+
+/** Format the full haystack (full-context arm), in chronological session order
+ *  with dates, truncated to a character budget derived from the arm's num_ctx.
+ *  Truncation is reported by the caller (a truncated ceiling is a documented
+ *  limitation, not a silent one — Kern 3a). */
+export function formatFullContext(sessions: LmeSession[], charBudget: number): { text: string; truncated: boolean } {
+  const parts: string[] = [];
+  let used = 0;
+  let truncated = false;
+  for (const s of sessions) {
+    const header = `\n[Session ${s.sessionId} — ${s.date}]\n`;
+    if (used + header.length > charBudget) { truncated = true; break; }
+    parts.push(header); used += header.length;
+    for (const ev of s.events) {
+      const line = `${ev.role ?? "?"}: ${ev.content}\n`;
+      if (used + line.length > charBudget) { truncated = true; break; }
+      parts.push(line); used += line.length;
+    }
+    if (truncated) break;
+  }
+  return { text: parts.join(""), truncated };
+}
+
+/** Assemble the final reader prompt for one (question, arm). */
+export function buildReaderPrompt(question: string, questionDate: string, context: string): string {
+  return (
+    `${READER_SYSTEM}\n\n` +
+    `Current date: ${questionDate}\n\n` +
+    `Conversation memory:\n${context || "(none)"}\n\n` +
+    `Question: ${question}\n` +
+    `Answer:`
+  );
+}
+
+export const READER_PROMPT_VERSION = "1.0.0";

--- a/test/bench/longmemeval/artifact.ts
+++ b/test/bench/longmemeval/artifact.ts
@@ -1,0 +1,97 @@
+/**
+ * artifact.ts — the STRUCTURAL publish gate.
+ *
+ * The harness PRODUCES a number; it never publishes one. Publishing is a
+ * separate, gated human decision (spend / outward-publish are the founder's
+ * gates). To make that gate structural rather than a conversation (Sherlock #4),
+ * the run emits a CONTENT-ADDRESSED artifact:
+ *
+ *   artifactHash = sha256( canonical( configHash + per-run hashes + numbers ) )
+ *
+ * A human sign-off is recorded against a specific artifactHash — "approved to
+ * publish artifact <hash>", not "the number seemed fine at some point". A
+ * reviewer can recompute the hash from the committed config + the recorded
+ * per-run outputs and confirm the published number is the one that was signed.
+ *
+ * There is deliberately NO publish function and NO --publish flag here. The
+ * artifact carries a NOTICE stating exactly that.
+ */
+import { writeFileSync, mkdirSync } from "node:fs";
+import { join } from "node:path";
+import { canonicalJson, sha256hex } from "./config";
+import type { ArmAggregate, ArmRunMetrics } from "./metrics";
+
+export interface RunRecord {
+  runIndex: number;
+  /** sha256 of this run's canonical raw per-(question,arm) outcomes. */
+  runHash: string;
+  /** Per-arm metrics for this single run. */
+  arms: ArmRunMetrics[];
+}
+
+export interface Artifact {
+  schema: string;
+  notice: string;
+  validationSlice: boolean;
+  generatedAt: string;
+  gitCommit: string | null;
+  host: { ollama: string; benchHost: string };
+  configHash: string;
+  config: unknown;          // the full pinned manifest (self-describing artifact)
+  runHashes: string[];
+  aggregate: ArmAggregate[];
+  /** Filled in AFTER hashing (excluded from the hash — the hash addresses
+   *  everything above it). */
+  artifactHash?: string;
+}
+
+export function hashRunResults(raw: unknown): string {
+  return sha256hex(canonicalJson(raw));
+}
+
+export interface BuildArtifactInput {
+  configHash: string;
+  config: unknown;
+  runHashes: string[];
+  aggregate: ArmAggregate[];
+  gitCommit: string | null;
+  ollamaHost: string;
+  benchHost: string;
+  validationSlice: boolean;
+}
+
+export function buildArtifact(input: BuildArtifactInput): Artifact {
+  const art: Artifact = {
+    schema: "longmemeval-s.layer2.artifact/1",
+    notice:
+      "VALIDATION ARTIFACT — NOT FOR PUBLICATION. This harness produces numbers; it does not " +
+      "publish them. Publishing any number requires a recorded human sign-off referencing this " +
+      "artifact's artifactHash. Spend and outward-publishing are the founder's gates.",
+    validationSlice: input.validationSlice,
+    generatedAt: new Date().toISOString(),
+    gitCommit: input.gitCommit,
+    host: { ollama: input.ollamaHost, benchHost: input.benchHost },
+    configHash: input.configHash,
+    config: input.config,
+    runHashes: input.runHashes,
+    aggregate: input.aggregate,
+  };
+  // Hash everything above artifactHash. canonicalJson sorts keys, and
+  // artifactHash is absent at this point, so it cannot address itself.
+  art.artifactHash = sha256hex(canonicalJson(art));
+  return art;
+}
+
+/** Recompute the hash of an artifact object (verification): strip artifactHash,
+ *  canonicalise, sha256 — must equal the stored artifactHash. */
+export function verifyArtifactHash(art: Artifact): boolean {
+  const { artifactHash, ...rest } = art;
+  return sha256hex(canonicalJson(rest)) === artifactHash;
+}
+
+export function writeArtifact(art: Artifact, outDir: string): string {
+  mkdirSync(outDir, { recursive: true });
+  const path = join(outDir, `longmemeval-s-artifact-${art.artifactHash!.slice(0, 16)}.json`);
+  writeFileSync(path, JSON.stringify(art, null, 2));
+  return path;
+}

--- a/test/bench/longmemeval/config.ts
+++ b/test/bench/longmemeval/config.ts
@@ -1,0 +1,151 @@
+/**
+ * config.ts — the PINNED, content-addressed configuration for the LongMemEval_s
+ * Layer 2 benchmark. Everything that could move the number is pinned HERE, and
+ * `configManifest()` folds all of it (including the exact judge/reader prompt
+ * template strings) into one object that `hashConfig()` content-addresses.
+ *
+ * This is the eval equivalent of pre-registration (Kern §4a, Sherlock #4): the
+ * config is written and hashed BEFORE a run, and every run's output references
+ * that hash — so a reviewer can verify the reported number came from THIS
+ * config, and config-shopping (run 10, publish the best) leaves a trace.
+ *
+ * Reproducibility is the edge (#1216): anyone re-runs the exact number locally
+ * with `ollama pull` at the pinned digests + this dataset commit — no OpenAI
+ * key, no spend. Pin by DIGEST, never by tag (tags are mutable).
+ */
+import { createHash } from "node:crypto";
+import { JUDGE_PROMPT_TEMPLATES } from "./judge";
+import { READER_SYSTEM, READER_PROMPT_VERSION, ALL_ARMS } from "./arms";
+import { EXTRACTION_METHOD } from "./extraction";
+
+// ── Dataset: LongMemEval_s, pinned to an immutable HF commit + file sha256 ────
+export const DATASET = {
+  name: "LongMemEval_s",
+  hfRepo: "xiaowu0162/longmemeval",
+  hfRevision: "2ec2a557f339b6c0369619b1ed5793734cc87533",
+  file: "longmemeval_s",
+  sha256: "08d8dad4be43ee2049a22ff5674eb86725d0ce5ff434cde2627e5e8e7e117894",
+  // The GitHub repo commit the judge prompts were ported from.
+  githubRepo: "xiaowu0162/LongMemEval",
+  githubCommit: "9e0b455f4ef0e2ab8f2e582289761153549043fc",
+  totalQuestions: 500,
+} as const;
+
+// ── Judge: gemma4:31b-it-q8_0, LOCAL on Newton via Ollama ────────────────────
+// Pinned by manifest digest (immutable); the GGUF weights blob sha256 is
+// recorded too, as an even-more-verifiable content hash of the weights.
+export const JUDGE = {
+  model: "gemma4:31b-it-q8_0",
+  manifestDigest: "sha256:53dd8459790f8795177444daa9e33f417e03c0d1cdedb80b6c73898603d20aef",
+  weightsSha256: "sha256:a0feadb736f521df6de4b1bd3cbf06c00f9fd04570ddc1e47b8ec9ecbbd6b51d",
+  family: "gemma4",
+  temperature: 0,
+  seed: 0,
+  numCtx: 8192,
+  numPredict: 16,
+} as const;
+
+// ── Reader: qwen3.6:27b-coding-mxfp8 (Qwen family) ───────────────────────────
+// A DIFFERENT family than the Gemma judge — the self-preference control
+// (judge family != reader family). Pinned by manifest digest.
+export const READER = {
+  model: "qwen3.6:27b-coding-mxfp8",
+  manifestDigest: "sha256:a7185d39ff35a472a2721b87e1bbb90810bcd381d415666ce2137838e66f2780",
+  family: "qwen3_5",
+  temperature: 0,
+  seed: 0,
+  numCtx: 16384,       // retrieval arms (flair / vector-only / no-context)
+  numPredict: 256,
+} as const;
+
+// The full-context arm needs a much larger (still fixed, still pinned) window
+// to hold a ~115k-token haystack — its job is to be the ceiling, so it must
+// actually receive the history (Kern 3a). Both models support 262144.
+//
+// The pinned default for the publishable run is 131072. It is overridable via
+// LME_FULL_CTX ONLY to make a validation slice tractable (a ~100k-token prefill
+// is minutes/call) — and because configManifest() reads FULL_CONTEXT, whatever
+// value is used is RECORDED in the config hash and the artifact, so a reduced
+// validation window is never silent. char budget ≈ 3 chars/token.
+const FULL_CTX_NUMCTX = parseInt(process.env.LME_FULL_CTX ?? "131072", 10);
+export const FULL_CONTEXT = {
+  numCtx: FULL_CTX_NUMCTX,
+  charBudget: FULL_CTX_NUMCTX * 3,
+} as const;
+
+// ── Retrieval: documented defaults, held fixed across arms ───────────────────
+export const RETRIEVAL = {
+  scoring: "raw" as const,       // production default since flair#623
+  readerTopK: 20,                // memories fed to the reader (flair / vector-only)
+  // hybrid on/off is a Harper PROCESS-level env (FLAIR_HYBRID_RETRIEVAL), set
+  // per arm by eval.ts: flair=true, vector-only=false.
+} as const;
+
+export const INGESTION = {
+  granularity: "per-event" as const, // the LOCKED #1216 decision (one Memory per turn)
+} as const;
+
+export const OLLAMA_HOST = process.env.LME_OLLAMA_HOST ?? "http://192.168.2.64:11434";
+
+// Cross-family self-preference control — fail loud if it is ever violated.
+export function assertCrossFamily(): void {
+  if (JUDGE.family === READER.family) {
+    throw new Error(
+      `self-preference control violated: judge family (${JUDGE.family}) === reader family (${READER.family}). ` +
+      `The judge must be a different family than the reader.`,
+    );
+  }
+}
+
+/** The full configuration object that gets content-addressed. Includes the
+ *  exact prompt template strings so any edit to a grading/reader prompt changes
+ *  the hash. */
+export function configManifest(slice: { n: number; seed: number; questionIds: string[]; runs: number }) {
+  return {
+    schema: "longmemeval-s.layer2.config/1",
+    dataset: DATASET,
+    judge: JUDGE,
+    reader: READER,
+    fullContext: FULL_CONTEXT,
+    retrieval: RETRIEVAL,
+    ingestion: INGESTION,
+    arms: ALL_ARMS,
+    prompts: {
+      judge: JUDGE_PROMPT_TEMPLATES,
+      readerSystem: READER_SYSTEM,
+      readerPromptVersion: READER_PROMPT_VERSION,
+    },
+    extraction: EXTRACTION_METHOD,
+    slice: {
+      n: slice.n,
+      seed: slice.seed,
+      runs: slice.runs,
+      // The exact questions this config commits to, sorted for a stable hash.
+      questionIds: [...slice.questionIds].sort(),
+    },
+  };
+}
+
+/** Canonical JSON: keys sorted recursively, so the hash is stable across
+ *  machines and key-insertion order. */
+export function canonicalJson(value: unknown): string {
+  return JSON.stringify(sortDeep(value));
+}
+function sortDeep(v: any): any {
+  if (Array.isArray(v)) return v.map(sortDeep);
+  if (v && typeof v === "object") {
+    const out: Record<string, any> = {};
+    for (const k of Object.keys(v).sort()) out[k] = sortDeep(v[k]);
+    return out;
+  }
+  return v;
+}
+
+export function sha256hex(s: string): string {
+  return createHash("sha256").update(s).digest("hex");
+}
+
+/** The content-address of a config manifest. */
+export function hashConfig(manifest: unknown): string {
+  return sha256hex(canonicalJson(manifest));
+}

--- a/test/bench/longmemeval/config.ts
+++ b/test/bench/longmemeval/config.ts
@@ -88,8 +88,11 @@ export const INGESTION = {
 export const OLLAMA_HOST = process.env.LME_OLLAMA_HOST ?? "http://192.168.2.64:11434";
 
 // Cross-family self-preference control — fail loud if it is ever violated.
+// Compared as strings on purpose: the pinned literals differ today, but this is
+// a runtime guard against a FUTURE config edit that sets them equal, so the
+// comparison must not be narrowed away by the const-literal types.
 export function assertCrossFamily(): void {
-  if (JUDGE.family === READER.family) {
+  if ((JUDGE.family as string) === (READER.family as string)) {
     throw new Error(
       `self-preference control violated: judge family (${JUDGE.family}) === reader family (${READER.family}). ` +
       `The judge must be a different family than the reader.`,

--- a/test/bench/longmemeval/dataset.ts
+++ b/test/bench/longmemeval/dataset.ts
@@ -1,0 +1,175 @@
+/**
+ * dataset.ts — load LongMemEval_s, verify it against the pinned sha256, map
+ * each question's multi-session haystack to the shared ingest shape, and select
+ * a deterministic slice that covers every ability.
+ *
+ * The dataset file is NOT committed to the repo (278MB, distributed via HF LFS).
+ * It is pinned instead by (HF repo, commit, file, sha256) in config.ts and
+ * fetched with the exact curl in this directory's README. loadDataset() refuses
+ * a file whose sha256 does not match the pin unless `allowUnpinned` — a number
+ * produced against an unpinned dataset is not reproducible (Kern §8).
+ */
+import { readFileSync } from "node:fs";
+import { createHash } from "node:crypto";
+import type { SessionHistory, SessionEvent } from "../../../packages/flair-bench/lib/index";
+import type { LmeTask } from "./judge";
+import { DATASET } from "./config";
+
+export interface LmeTurn { role: string; content: string; has_answer?: boolean }
+export interface LmeEntry {
+  question_id: string;
+  question_type: LmeTask;
+  question: string;
+  answer: string;
+  question_date: string;
+  haystack_dates: string[];
+  haystack_session_ids: string[];
+  haystack_sessions: LmeTurn[][];
+  answer_session_ids: string[];
+}
+
+export interface LmeSession { sessionId: string; date: string; events: SessionEvent[] }
+
+/** The 5 LongMemEval abilities + abstention broken out separately. A question's
+ *  ability is its type's bucket UNLESS it is an abstention question (`_abs`),
+ *  which always rolls up to `abstention` regardless of type. */
+export type Ability =
+  | "information-extraction"
+  | "multi-session"
+  | "temporal-reasoning"
+  | "knowledge-update"
+  | "single-session-preference"
+  | "abstention";
+
+const TYPE_TO_ABILITY: Record<LmeTask, Ability> = {
+  "single-session-user": "information-extraction",
+  "single-session-assistant": "information-extraction",
+  "multi-session": "multi-session",
+  "temporal-reasoning": "temporal-reasoning",
+  "knowledge-update": "knowledge-update",
+  "single-session-preference": "single-session-preference",
+};
+
+/** The factual subset the F1/EM cross-check applies to (Kern §4b): the fact-
+ *  bearing abilities, excluding preference (rubric) and abstention (no fact). */
+export const FACTUAL_ABILITIES: Ability[] = [
+  "information-extraction",
+  "multi-session",
+  "temporal-reasoning",
+  "knowledge-update",
+];
+
+export function isAbstention(entry: LmeEntry): boolean {
+  return entry.question_id.includes("_abs");
+}
+
+export function abilityOf(entry: LmeEntry): Ability {
+  return isAbstention(entry) ? "abstention" : TYPE_TO_ABILITY[entry.question_type];
+}
+
+export function sha256File(path: string): string {
+  return createHash("sha256").update(readFileSync(path)).digest("hex");
+}
+
+export function loadDataset(path: string, opts: { allowUnpinned?: boolean } = {}): LmeEntry[] {
+  const actual = sha256File(path);
+  if (actual !== DATASET.sha256) {
+    const msg =
+      `dataset sha256 mismatch: file=${actual} pinned=${DATASET.sha256}. ` +
+      `Fetch the pinned file (see README) — a number against an unpinned dataset is not reproducible.`;
+    if (!opts.allowUnpinned) throw new Error(msg);
+    console.warn(`[longmemeval] WARNING (--allow-unpinned): ${msg}`);
+  }
+  const entries = JSON.parse(readFileSync(path, "utf8")) as LmeEntry[];
+  if (!Array.isArray(entries)) throw new Error("dataset root is not an array");
+  return entries;
+}
+
+/** Strip LongMemEval's weekday parenthetical and parse to an ISO timestamp.
+ *  "2023/05/20 (Sat) 02:21" -> Date. Preserves ordering (the temporal ability
+ *  depends on it). Returns undefined for an unparseable date (caller decides). */
+export function parseLmeDate(s: string): string | undefined {
+  if (!s) return undefined;
+  const cleaned = s.replace(/\s*\([A-Za-z]{3}\)\s*/, " ").trim(); // drop "(Sat)"
+  const m = cleaned.match(/^(\d{4})\/(\d{2})\/(\d{2})\s+(\d{2}):(\d{2})/);
+  if (!m) { const d = new Date(cleaned); return isNaN(+d) ? undefined : d.toISOString(); }
+  const [, y, mo, da, hh, mm] = m;
+  const d = new Date(Date.UTC(+y!, +mo! - 1, +da!, +hh!, +mm!));
+  return isNaN(+d) ? undefined : d.toISOString();
+}
+
+/**
+ * Map one question's haystack to the shared SessionHistory[] shape — one event
+ * per turn (the locked per-event granularity), timestamps preserved from the
+ * session's date, roles carried. Event ids are stable and derived from the
+ * question + session + turn index, so a re-run produces byte-identical memories.
+ */
+export function entryToSessions(entry: LmeEntry): LmeSession[] {
+  const out: LmeSession[] = [];
+  for (let si = 0; si < entry.haystack_sessions.length; si++) {
+    const turns = entry.haystack_sessions[si]!;
+    const sessionId = entry.haystack_session_ids?.[si] ?? `${entry.question_id}-s${si}`;
+    const dateRaw = entry.haystack_dates?.[si] ?? "";
+    const iso = parseLmeDate(dateRaw);
+    const events: SessionEvent[] = turns.map((t, ti) => ({
+      id: `${entry.question_id}__s${si}__t${ti}`,
+      content: `${t.role}: ${t.content}`,
+      role: t.role,
+      createdAt: iso,       // session-level date (LongMemEval provides per-session dates)
+      durability: "standard",
+    }));
+    out.push({ sessionId, date: dateRaw, events });
+  }
+  return out;
+}
+
+/** The SessionHistory[] the shared ingestSessionHistory() consumes. */
+export function toSessionHistories(sessions: LmeSession[]): SessionHistory[] {
+  return sessions.map((s) => ({ sessionId: s.sessionId, events: s.events }));
+}
+
+/**
+ * Deterministically select `n` questions that cover every ability. Sorts all
+ * entries by question_id (stable), buckets by ability, then round-robins across
+ * abilities so the slice spans them — always including at least some abstention
+ * questions (the contamination/abstention behaviour must be represented). Given
+ * (n, seed) the selection is reproducible; `seed` rotates the per-bucket start
+ * so different slices are available without shuffling non-deterministically.
+ */
+export function selectSlice(entries: LmeEntry[], n: number, seed = 0): LmeEntry[] {
+  const buckets = new Map<Ability, LmeEntry[]>();
+  const sorted = [...entries].sort((a, b) => a.question_id.localeCompare(b.question_id));
+  for (const e of sorted) {
+    const ab = abilityOf(e);
+    if (!buckets.has(ab)) buckets.set(ab, []);
+    buckets.get(ab)!.push(e);
+  }
+  const abilities = [...buckets.keys()].sort();
+  // Rotate each bucket by seed for stable-but-selectable variety.
+  for (const ab of abilities) {
+    const arr = buckets.get(ab)!;
+    const rot = ((seed % arr.length) + arr.length) % arr.length;
+    buckets.set(ab, arr.slice(rot).concat(arr.slice(0, rot)));
+  }
+  const picked: LmeEntry[] = [];
+  const cursor = new Map<Ability, number>(abilities.map((a) => [a, 0]));
+  while (picked.length < n) {
+    let progressed = false;
+    for (const ab of abilities) {
+      if (picked.length >= n) break;
+      const i = cursor.get(ab)!;
+      const arr = buckets.get(ab)!;
+      if (i < arr.length) {
+        picked.push(arr[i]!);
+        cursor.set(ab, i + 1);
+        progressed = true;
+      }
+    }
+    if (!progressed) break; // exhausted every bucket
+  }
+  // Stable output order (by question_id) so the slice — and its config hash — is
+  // independent of round-robin insertion order.
+  return picked.sort((a, b) => a.question_id.localeCompare(b.question_id));
+}
+
+export { TYPE_TO_ABILITY };

--- a/test/bench/longmemeval/eval.ts
+++ b/test/bench/longmemeval/eval.ts
@@ -1,0 +1,202 @@
+/**
+ * eval.ts — the LongMemEval_s Layer 2 pipeline orchestration.
+ *
+ * Per question: ingest its multi-session haystack into Flair (shared per-event
+ * ingest), retrieve context (shared BM25+RRF retrieval at documented defaults),
+ * a PINNED reader answers from the retrieved memories, and the PINNED gemma4
+ * judge grades the answer with the ternary rubric. Four arms; the reader/judge
+ * are the SAME across all arms — only the context differs (Kern §5a).
+ *
+ * A "run" is independent (Kern §7a): a FRESH ephemeral Harper is spawned per
+ * (run, Harper-arm), re-ingested, re-retrieved — so the ≥-run std reflects real
+ * run-to-run variance, not carried state. The ephemeral Harper HOME-isolates
+ * itself (harper-lifecycle sets HOME=<temp dir>), so ingest NEVER touches prod
+ * ~/.flair / :9926.
+ */
+import {
+  startHarper, stopHarper, type HarperInstance,
+} from "../../helpers/harper-lifecycle";
+import {
+  mkAgent, registerAgent, ingestSessionHistory, retrieveContext, type BenchClient,
+} from "../../../packages/flair-bench/lib/index";
+import { OLLAMA_HOST, READER, JUDGE, RETRIEVAL, FULL_CONTEXT } from "./config";
+import { generate } from "./ollama";
+import { buildJudgePrompt, parseVerdict, JudgeParseError, type LmeTask } from "./judge";
+import { buildReaderPrompt, formatRetrieved, formatFullContext, HARPER_ARMS, type Arm } from "./arms";
+import { scoreExtraction } from "./extraction";
+import {
+  entryToSessions, toSessionHistories, abilityOf, isAbstention, FACTUAL_ABILITIES,
+  type LmeEntry,
+} from "./dataset";
+import { aggregateArmRun, type QuestionArmResult, type ArmRunMetrics } from "./metrics";
+import { hashRunResults } from "./artifact";
+
+export interface RunOptions {
+  repoRoot: string;
+  host?: string;
+  /** Log progress lines. */
+  log?: (s: string) => void;
+}
+
+const clean = (s: string) => s.replace(/<think>[\s\S]*?<\/think>/gi, "").trim();
+
+/** One reader call for a given assembled context. */
+async function readerAnswer(
+  host: string, question: string, questionDate: string, context: string, arm: Arm,
+): Promise<{ answer: string; tokensFed: number; latencyMs: number }> {
+  const prompt = buildReaderPrompt(question, questionDate, context);
+  const numCtxOverride = arm === "full-context" ? FULL_CONTEXT.numCtx : undefined;
+  const g = await generate(host, READER, prompt, { numCtxOverride });
+  return { answer: clean(g.response), tokensFed: g.promptTokens, latencyMs: g.latencyMs };
+}
+
+/** One judge call. Returns verdict=null + judgeError on an unparseable verdict
+ *  (never a silent pass). */
+async function judgeOne(
+  host: string, task: LmeTask, question: string, answer: string, response: string, abstention: boolean,
+): Promise<{ verdict: QuestionArmResult["verdict"]; judgeError?: string }> {
+  const { prompt, allowed } = buildJudgePrompt({ task, question, answer, response, abstention });
+  const g = await generate(host, JUDGE, prompt);
+  try {
+    return { verdict: parseVerdict(g.response, allowed) };
+  } catch (err) {
+    if (err instanceof JudgeParseError) return { verdict: null, judgeError: err.message };
+    throw err;
+  }
+}
+
+function extractionFor(entry: LmeEntry, answer: string) {
+  const ability = abilityOf(entry);
+  if (!FACTUAL_ABILITIES.includes(ability)) return undefined;
+  return scoreExtraction(answer, entry.answer);
+}
+
+/** Evaluate one (question, arm) end to end (reader → judge). `context` and any
+ *  retrieval metadata are supplied by the caller (Harper arms retrieve first). */
+async function evalOne(
+  host: string, entry: LmeEntry, arm: Arm, context: string,
+  extra: { retrievalMs?: number; truncated?: boolean },
+): Promise<QuestionArmResult> {
+  const r = await readerAnswer(host, entry.question, entry.question_date, context, arm);
+  const abstention = isAbstention(entry);
+  const j = await judgeOne(host, entry.question_type, entry.question, entry.answer, r.answer, abstention);
+  return {
+    questionId: entry.question_id,
+    ability: abilityOf(entry),
+    isAbstention: abstention,
+    arm,
+    answer: r.answer,
+    verdict: j.verdict,
+    judgeError: j.judgeError,
+    extraction: extractionFor(entry, r.answer),
+    tokensFed: r.tokensFed,
+    latencyMs: r.latencyMs + (extra.retrievalMs ?? 0),
+    retrievalMs: extra.retrievalMs,
+    truncated: extra.truncated,
+  };
+}
+
+/** The no-Harper arms: full-context (whole haystack) and no-context (nothing). */
+async function runNoHarperArms(host: string, entries: LmeEntry[], log: (s: string) => void): Promise<QuestionArmResult[]> {
+  const out: QuestionArmResult[] = [];
+  for (const entry of entries) {
+    const sessions = entryToSessions(entry);
+    // full-context
+    const fc = formatFullContext(sessions, FULL_CONTEXT.charBudget);
+    out.push(await evalOne(host, entry, "full-context", fc.text, { truncated: fc.truncated }));
+    // no-context (the contamination probe): zero memory
+    out.push(await evalOne(host, entry, "no-context", "", {}));
+  }
+  log(`  no-Harper arms done (${entries.length} q × 2 arms)`);
+  return out;
+}
+
+/** A Harper arm: spawn a fresh ephemeral Harper with hybrid on/off, then per
+ *  question ingest → wait searchable → retrieve → read → judge. */
+async function runHarperArm(
+  arm: Arm, hybrid: boolean, entries: LmeEntry[], opts: RunOptions, host: string,
+): Promise<QuestionArmResult[]> {
+  const log = opts.log ?? (() => {});
+  const prev = process.env.FLAIR_HYBRID_RETRIEVAL;
+  process.env.FLAIR_HYBRID_RETRIEVAL = hybrid ? "true" : "false";
+  let harper: HarperInstance | undefined;
+  const out: QuestionArmResult[] = [];
+  try {
+    log(`  [${arm}] spawning ephemeral Harper (hybrid=${hybrid})...`);
+    harper = await startHarper({ cwd: opts.repoRoot, harperBinDir: opts.repoRoot });
+    for (let qi = 0; qi < entries.length; qi++) {
+      const entry = entries[qi]!;
+      const agent = mkAgent(`lme-${arm}-${entry.question_id}`);
+      await registerAgent(harper, agent);
+      const client: BenchClient = { harper, agent };
+      const sessions = entryToSessions(entry);
+      const ingest = await ingestSessionHistory(client, toSessionHistories(sessions));
+      await waitSearchable(client, sessions);
+      const t0 = performance.now();
+      const ctx = await retrieveContext(client, entry.question, { limit: RETRIEVAL.readerTopK, scoring: RETRIEVAL.scoring });
+      const retrievalMs = performance.now() - t0;
+      const context = formatRetrieved(ctx.items);
+      out.push(await evalOne(host, entry, arm, context, { retrievalMs }));
+      if ((qi + 1) % 5 === 0 || qi === entries.length - 1) {
+        log(`  [${arm}] ${qi + 1}/${entries.length} (last ingest ${ingest.written} events, ${ingest.elapsedMs.toFixed(0)}ms)`);
+      }
+    }
+  } finally {
+    if (harper) await stopHarper(harper, { keepInstallDir: false });
+    if (prev === undefined) delete process.env.FLAIR_HYBRID_RETRIEVAL;
+    else process.env.FLAIR_HYBRID_RETRIEVAL = prev;
+  }
+  return out;
+}
+
+/** After ingesting a question's haystack, poll until it is actually searchable
+ *  so a not-yet-indexed corpus never scores as a retrieval miss. Canary = the
+ *  last ingested event's own content; wait until its id surfaces. */
+async function waitSearchable(client: BenchClient, sessions: ReturnType<typeof entryToSessions>, timeoutMs = 45_000): Promise<void> {
+  const allEvents = sessions.flatMap((s) => s.events);
+  const canary = allEvents[allEvents.length - 1];
+  if (!canary) return;
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const ctx = await retrieveContext(client, canary.content.slice(0, 200), { limit: 20 });
+    if (ctx.rankedIds.includes(canary.id)) return;
+    await new Promise((r) => setTimeout(r, 1000));
+  }
+  throw new Error(`waitSearchable: canary event ${canary.id} never surfaced within ${timeoutMs}ms (embedding engine slow/down?)`);
+}
+
+export interface OneRunResult {
+  runIndex: number;
+  results: QuestionArmResult[];
+  armMetrics: ArmRunMetrics[];
+  runHash: string;
+}
+
+/** Run ALL arms once over the slice. Fresh Harper per Harper-arm. */
+export async function runOnce(runIndex: number, entries: LmeEntry[], opts: RunOptions): Promise<OneRunResult> {
+  const host = opts.host ?? OLLAMA_HOST;
+  const log = opts.log ?? (() => {});
+  log(`[run ${runIndex}] starting (${entries.length} questions × 4 arms)`);
+
+  const results: QuestionArmResult[] = [];
+  results.push(...(await runNoHarperArms(host, entries, log)));
+  results.push(...(await runHarperArm("flair", true, entries, opts, host)));
+  results.push(...(await runHarperArm("vector-only", false, entries, opts, host)));
+
+  const arms: Arm[] = ["flair", "vector-only", "full-context", "no-context"];
+  const armMetrics = arms.map((a) => aggregateArmRun(a, results));
+
+  // Content-address the run by its DECISIONS (answer/verdict/tokens/extraction),
+  // NOT wall-clock latency — a faithful re-run reproduces this hash.
+  const decisions = results
+    .map((r) => ({
+      questionId: r.questionId, arm: r.arm, answer: r.answer,
+      verdict: r.verdict, judgeError: r.judgeError ?? null,
+      tokensFed: r.tokensFed, extraction: r.extraction ?? null,
+    }))
+    .sort((a, b) => (a.arm + a.questionId).localeCompare(b.arm + b.questionId));
+  const runHash = hashRunResults(decisions);
+
+  log(`[run ${runIndex}] done — runHash ${runHash.slice(0, 16)}`);
+  return { runIndex, results, armMetrics, runHash };
+}

--- a/test/bench/longmemeval/extraction.ts
+++ b/test/bench/longmemeval/extraction.ts
@@ -1,0 +1,110 @@
+/**
+ * extraction.ts — the INDEPENDENT F1/EM cross-check on the factual subset.
+ *
+ * Why it exists: an LLM judge can be lenient (the LightRAG cautionary case —
+ * 0.96 judge accuracy against 0.09 F1). The cross-check is only meaningful if it
+ * is computed WITHOUT the judge — a separate, pinned, deterministic extraction
+ * against LongMemEval's own gold answer key (Sherlock #5, Kern §4b). So this
+ * file is pure string math: SQuAD-style normalisation + token F1 + a
+ * containment EM. No model, no network, no judge.
+ *
+ * Applied to the FACTUAL subset only — information-extraction, multi-session,
+ * temporal, and knowledge-update. Preference (graded against a rubric, not a
+ * fact) and abstention (no factual gold) are excluded, defined by question type
+ * up front, not by post-hoc filtering (Kern §4b).
+ *
+ * The F1/EM number is EXPECTED to sit below the judge accuracy — a short gold
+ * answer embedded in a fluent sentence scores lower on token overlap than a
+ * human/judge would. The value is the GAP: a large judge-vs-F1 gap is the
+ * signal that the judge may be lenient, which is exactly what this catches.
+ */
+
+/** SQuAD normalisation: lowercase, strip punctuation, drop articles, collapse
+ *  whitespace. Deterministic and dependency-free. */
+export function normalize(s: string): string {
+  return s
+    .toLowerCase()
+    .replace(/\b(a|an|the)\b/g, " ")
+    .replace(/[‘’“”]/g, "'")
+    .replace(/[^\p{L}\p{N}\s]/gu, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function tokens(s: string): string[] {
+  const n = normalize(s);
+  return n.length ? n.split(" ") : [];
+}
+
+/** SQuAD token-overlap F1 between a prediction and a single gold answer. */
+export function tokenF1(prediction: string, gold: string): number {
+  const p = tokens(prediction);
+  const g = tokens(gold);
+  if (p.length === 0 && g.length === 0) return 1;
+  if (p.length === 0 || g.length === 0) return 0;
+  // Multiset intersection.
+  const gCounts = new Map<string, number>();
+  for (const t of g) gCounts.set(t, (gCounts.get(t) ?? 0) + 1);
+  let overlap = 0;
+  for (const t of p) {
+    const c = gCounts.get(t) ?? 0;
+    if (c > 0) { overlap++; gCounts.set(t, c - 1); }
+  }
+  if (overlap === 0) return 0;
+  const precision = overlap / p.length;
+  const recall = overlap / g.length;
+  return (2 * precision * recall) / (precision + recall);
+}
+
+/**
+ * Containment EM: 1 if the normalised gold answer appears as a contiguous
+ * token-boundary substring of the normalised prediction, else 0. This is the
+ * fair EM for a RAG reader (a fluent sentence "You graduated with a degree in
+ * Business Administration" should EM-match gold "Business Administration"),
+ * unlike strict string equality which would be ~0 for every sentence answer.
+ * We also expose strict EM for transparency.
+ */
+export function containmentEM(prediction: string, gold: string): number {
+  const p = ` ${normalize(prediction)} `;
+  const g = normalize(gold);
+  if (g.length === 0) return 0;
+  return p.includes(` ${g} `) ? 1 : 0;
+}
+
+export function strictEM(prediction: string, gold: string): number {
+  return normalize(prediction) === normalize(gold) ? 1 : 0;
+}
+
+export interface ExtractionScore {
+  f1: number;
+  containmentEM: number;
+  strictEM: number;
+}
+
+/**
+ * Score one prediction against gold answer(s). LongMemEval gives a single
+ * answer string per question; we accept an array to support alias sets (max
+ * over aliases — the standard SQuAD reduction). A `|`-delimited gold string is
+ * split into aliases.
+ */
+export function scoreExtraction(prediction: string, gold: string | string[]): ExtractionScore {
+  const golds = (Array.isArray(gold) ? gold : String(gold).split("|")).map((g) => g.trim()).filter(Boolean);
+  if (golds.length === 0) return { f1: 0, containmentEM: 0, strictEM: 0 };
+  let best: ExtractionScore = { f1: 0, containmentEM: 0, strictEM: 0 };
+  for (const g of golds) {
+    const s: ExtractionScore = {
+      f1: tokenF1(prediction, g),
+      containmentEM: containmentEM(prediction, g),
+      strictEM: strictEM(prediction, g),
+    };
+    // Rank aliases by F1 (the primary cross-check metric).
+    if (s.f1 > best.f1 || (s.f1 === best.f1 && s.containmentEM > best.containmentEM)) best = s;
+  }
+  return best;
+}
+
+/** The pinned extraction identity, folded into the config hash. */
+export const EXTRACTION_METHOD = {
+  name: "squad-normalize+token-f1+containment-em",
+  version: "1.0.0",
+} as const;

--- a/test/bench/longmemeval/judge.ts
+++ b/test/bench/longmemeval/judge.ts
@@ -1,0 +1,217 @@
+/**
+ * judge.ts — the LLM judge: LongMemEval's expert per-task grading rubrics,
+ * PORTED verbatim in substance, reframed onto the SimpleQA ternary.
+ *
+ * Two design constraints meet here (the two RESOLVED-design comments on #1216):
+ *
+ *  1. PORT LongMemEval's expert per-task judge prompts. Its ~97% human
+ *     agreement is prompt-driven, not model-driven — so the task-specific
+ *     leniency rules (off-by-one days for temporal; "subset of the answer" is
+ *     wrong; "updated answer present" is right for knowledge-update; a rubric,
+ *     not a fact, for preference; the unanswerable framing for abstention) are
+ *     lifted from src/evaluation/evaluate_qa.py at the pinned repo commit
+ *     (config.DATASET.githubCommit).
+ *
+ *  2. Grade with the SimpleQA ternary — CORRECT / INCORRECT / NOT_ATTEMPTED
+ *     (abstention-aware). LongMemEval's original prompt is BINARY (yes/no). We
+ *     keep its rubric text but split "no" into INCORRECT (committed a wrong
+ *     answer) vs NOT_ATTEMPTED (declined / said it didn't know). This is what
+ *     lets the reader's abstention behaviour be BROKEN OUT separately (metrics)
+ *     instead of silently counted as wrong — the honest treatment of a memory
+ *     system that correctly declines when it has nothing.
+ *
+ * The verdict is parsed as a PLAINTEXT exact enum (A/B/C). Anything the parser
+ * cannot resolve to a single allowed letter is a JudgeParseError — NEVER a
+ * silent pass. A judge that fails open (an unparseable verdict scored as
+ * correct, or as a benign default) is the exact fail-open trap the design
+ * names; here it surfaces as an error the run must account for.
+ *
+ * The ternary→binary reconciliation for the headline LongMemEval accuracy lives
+ * in metrics.ts: accuracy counts CORRECT only (NOT_ATTEMPTED and INCORRECT are
+ * both not-correct), which matches LongMemEval's own accuracy = correct/total.
+ */
+
+export type Verdict = "CORRECT" | "INCORRECT" | "NOT_ATTEMPTED";
+
+/** The six LongMemEval question types (from the dataset's `question_type`). */
+export type LmeTask =
+  | "single-session-user"
+  | "single-session-assistant"
+  | "single-session-preference"
+  | "multi-session"
+  | "temporal-reasoning"
+  | "knowledge-update";
+
+export class JudgeParseError extends Error {
+  constructor(public raw: string, public allowed: string[]) {
+    super(`judge verdict not a clean enum (allowed ${allowed.join("/")}): ${JSON.stringify(raw).slice(0, 160)}`);
+  }
+}
+
+// ── Ported task-specific rubric clauses (evaluate_qa.py get_anscheck_prompt) ──
+// The clause that follows the shared CORRECT definition, per task. Empty string
+// where LongMemEval adds no task-specific leniency beyond the base rule.
+const TASK_RULE: Record<LmeTask, string> = {
+  "single-session-user": "",
+  "single-session-assistant": "",
+  "multi-session": "",
+  "temporal-reasoning":
+    " Do not penalize off-by-one errors for the number of days/weeks/months: if the question asks for a number of days/weeks/months and the response is off by one (e.g. 19 when the answer is 18), still classify it as A (CORRECT).",
+  "knowledge-update":
+    " If the response contains some previous information along with an updated answer, classify it as A (CORRECT) as long as the updated answer is the required answer.",
+  "single-session-preference": "", // handled by the dedicated preference template
+};
+
+/**
+ * Answerable questions (all types except abstention). Ternary A/B/C. Preserves
+ * LongMemEval's "subset of the required information ⇒ not correct" rule (folded
+ * into the INCORRECT definition) and each task's leniency clause.
+ */
+export const ANSWERABLE_TEMPLATE =
+  `I will give you a question, a correct answer, and a response from a model. Classify the model's response into exactly one category:
+
+A (CORRECT): the response contains the correct answer. If the response is equivalent to the correct answer, or contains all the intermediate steps needed to reach the correct answer, classify A.{taskRule}
+B (INCORRECT): the response commits to an answer that is wrong, contradicts the correct answer, or contains only a SUBSET of the information the correct answer requires.
+C (NOT_ATTEMPTED): the response does not commit to any answer — it declines, says it does not know, or says the information is unavailable — WITHOUT stating a wrong answer.
+
+Question: {question}
+
+Correct Answer: {answer}
+
+Model Response: {response}
+
+Respond with ONLY a single letter: A, B, or C.`;
+
+/**
+ * Preference questions grade against a RUBRIC, not a fact (LongMemEval's
+ * single-session-preference prompt). "Recalls and utilises the user's personal
+ * information correctly" is the CORRECT bar; it need not hit every rubric point.
+ */
+export const PREFERENCE_TEMPLATE =
+  `I will give you a question, a rubric describing the desired personalized response, and a response from a model. Classify the model's response into exactly one category:
+
+A (CORRECT): the response satisfies the desired response — it recalls and utilises the user's personal information correctly. It need not reflect every point in the rubric.
+B (INCORRECT): the response fails to utilise the user's personal information, or contradicts the rubric.
+C (NOT_ATTEMPTED): the response declines or does not attempt a personalized response.
+
+Question: {question}
+
+Rubric: {answer}
+
+Model Response: {response}
+
+Respond with ONLY a single letter: A, B, or C.`;
+
+/**
+ * Abstention (unanswerable) questions. LongMemEval's abstention prompt: the
+ * CORRECT behaviour is to identify the question as unanswerable. Two-way (A/B)
+ * — a C here is out of range and is treated as a parse ERROR, never a pass.
+ */
+export const ABSTENTION_TEMPLATE =
+  `I will give you an UNANSWERABLE question, an explanation of why it cannot be answered from the available information, and a response from a model. Classify the model's response into exactly one category:
+
+A (CORRECT): the model correctly identifies the question as unanswerable — it says the information is incomplete, missing, or that it does not know.
+B (INCORRECT): the model fabricates or asserts a concrete answer instead of identifying the question as unanswerable.
+
+Question: {question}
+
+Explanation: {answer}
+
+Model Response: {response}
+
+Respond with ONLY a single letter: A or B.`;
+
+/** The set of raw templates, exported so config.ts can fold them into the
+ *  content-addressed config hash — an edit to any grading prompt changes the
+ *  config hash, so a number can never be silently produced under a mutated
+ *  rubric. */
+export const JUDGE_PROMPT_TEMPLATES = {
+  answerable: ANSWERABLE_TEMPLATE,
+  preference: PREFERENCE_TEMPLATE,
+  abstention: ABSTENTION_TEMPLATE,
+  taskRule: TASK_RULE,
+  version: "1.0.0-ternary-port",
+} as const;
+
+export interface JudgeCase {
+  task: LmeTask;
+  question: string;
+  /** The correct answer (or, for preference, the rubric; for abstention, the
+   *  explanation of why it is unanswerable). */
+  answer: string;
+  /** The reader's response being graded. */
+  response: string;
+  /** True when the question is unanswerable (question_id carries the `_abs`
+   *  suffix in LongMemEval). */
+  abstention: boolean;
+}
+
+/** Build the judge prompt for one case. */
+export function buildJudgePrompt(c: JudgeCase): { prompt: string; allowed: string[] } {
+  if (c.abstention) {
+    return {
+      prompt: ABSTENTION_TEMPLATE
+        .replace("{question}", c.question)
+        .replace("{answer}", c.answer)
+        .replace("{response}", c.response),
+      allowed: ["A", "B"],
+    };
+  }
+  if (c.task === "single-session-preference") {
+    return {
+      prompt: PREFERENCE_TEMPLATE
+        .replace("{question}", c.question)
+        .replace("{answer}", c.answer)
+        .replace("{response}", c.response),
+      allowed: ["A", "B", "C"],
+    };
+  }
+  return {
+    prompt: ANSWERABLE_TEMPLATE
+      .replace("{taskRule}", TASK_RULE[c.task] ?? "")
+      .replace("{question}", c.question)
+      .replace("{answer}", c.answer)
+      .replace("{response}", c.response),
+    allowed: ["A", "B", "C"],
+  };
+}
+
+const LETTER_TO_VERDICT: Record<string, Verdict> = {
+  A: "CORRECT",
+  B: "INCORRECT",
+  C: "NOT_ATTEMPTED",
+};
+
+/**
+ * Parse a plaintext judge response into a single allowed letter, STRICTLY.
+ *
+ * The model is instructed to emit only the letter (verified: it does, at
+ * temp 0 with think:false and a tiny num_predict). We accept a small amount of
+ * decoration ("A", "A.", "**A**", "Verdict: A") but REFUSE anything that
+ * resolves to zero or more than one distinct allowed letter — that is a
+ * JudgeParseError the run records as a judge error, never a silent pass.
+ */
+export function parseVerdict(raw: string, allowed: string[]): Verdict {
+  const cleaned = raw
+    .trim()
+    .replace(/^```[a-z]*\s*|\s*```$/gi, "")
+    .replace(/^["'`*_\s]+|["'`*_.\s]+$/g, "");
+
+  // Exact single letter — the overwhelming common case.
+  const exact = cleaned.toUpperCase();
+  if (allowed.includes(exact)) return LETTER_TO_VERDICT[exact]!;
+
+  // Otherwise, find every standalone allowed letter (letter not glued to other
+  // word characters). If they all agree on ONE letter, accept it; if there are
+  // zero, or a disagreement, it is unparseable → error (never guess).
+  const letters = new Set<string>();
+  const re = /(?<![A-Za-z])([ABC])(?![A-Za-z])/g;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(cleaned.toUpperCase())) !== null) {
+    if (allowed.includes(m[1]!)) letters.add(m[1]!);
+  }
+  if (letters.size === 1) {
+    return LETTER_TO_VERDICT[[...letters][0]!]!;
+  }
+  throw new JudgeParseError(raw, allowed);
+}

--- a/test/bench/longmemeval/metrics.ts
+++ b/test/bench/longmemeval/metrics.ts
@@ -1,0 +1,200 @@
+/**
+ * metrics.ts — pure aggregation over graded questions. No I/O, no model, no
+ * Harper: given per-(question,arm) outcomes, compute per-ability accuracy (the
+ * 5 abilities), abstention BROKEN OUT separately, overall accuracy, the
+ * independent F1/EM cross-check on the factual subset, tokens/query, and
+ * p50/p95 latency — then mean±std across runs (pass^k, not best-of).
+ *
+ * Grading uses the SimpleQA ternary. LongMemEval headline accuracy = CORRECT /
+ * judged: NOT_ATTEMPTED and INCORRECT are both not-correct. NOT_ATTEMPTED on an
+ * answerable question is reported SEPARATELY (the abstention-aware breakout) so
+ * a reader that correctly declines isn't silently lumped with one that's wrong.
+ *
+ * Judge errors (an unparseable verdict — never a silent pass) are counted and
+ * surfaced; accuracy is computed over successfully-judged questions, so a judge
+ * error neither inflates nor deflates the number, but its COUNT is always
+ * reported and a nonzero count flags the run.
+ */
+import type { Verdict } from "./judge";
+import type { Ability } from "./dataset";
+import { FACTUAL_ABILITIES } from "./dataset";
+import type { Arm } from "./arms";
+import type { ExtractionScore } from "./extraction";
+
+export interface QuestionArmResult {
+  questionId: string;
+  ability: Ability;
+  isAbstention: boolean;
+  arm: Arm;
+  answer: string;
+  verdict: Verdict | null;   // null ⇒ judge error
+  judgeError?: string;
+  extraction?: ExtractionScore; // present only for factual-subset questions
+  tokensFed: number;
+  latencyMs: number;
+  retrievalMs?: number;
+  truncated?: boolean;
+}
+
+export interface AbilityMetric { n: number; judged: number; correct: number; accuracy: number }
+
+export interface ArmRunMetrics {
+  arm: Arm;
+  n: number;
+  judged: number;
+  judgeErrors: number;
+  overallAccuracy: number;
+  /** Accuracy over ANSWERABLE questions only (abstention excluded). This is the
+   *  number the no-context contamination probe must read: an abstention
+   *  question is trivially "correct" with no context (no memory ⇒ "I don't
+   *  know" ⇒ correct abstention), so including it would mask contamination. */
+  overallAccuracyAnswerable: number;
+  answerableJudged: number;
+  perAbility: Partial<Record<Ability, AbilityMetric>>;
+  abstention: AbilityMetric;              // correct-abstention rate on _abs questions
+  notAttemptedRateAnswerable: number;     // C-rate on answerable questions
+  incorrectRateAnswerable: number;
+  factual: { n: number; f1: number; containmentEM: number; strictEM: number };
+  tokensPerQueryMean: number;
+  tokensPerQueryP50: number;
+  latencyP50Ms: number;
+  latencyP95Ms: number;
+  retrievalP50Ms: number | null;
+  anyTruncated: boolean;
+}
+
+export function mean(xs: number[]): number {
+  return xs.length ? xs.reduce((a, b) => a + b, 0) / xs.length : 0;
+}
+/** Sample std (n-1). 0 for n<2. */
+export function std(xs: number[]): number {
+  const n = xs.length;
+  if (n < 2) return 0;
+  const m = mean(xs);
+  return Math.sqrt(xs.reduce((a, b) => a + (b - m) ** 2, 0) / (n - 1));
+}
+/** Nearest-rank percentile (p in [0,100]). */
+export function percentile(xs: number[], p: number): number {
+  if (xs.length === 0) return 0;
+  const s = [...xs].sort((a, b) => a - b);
+  const rank = Math.ceil((p / 100) * s.length);
+  return s[Math.min(s.length - 1, Math.max(0, rank - 1))]!;
+}
+
+/** Aggregate one run's results for ONE arm. */
+export function aggregateArmRun(arm: Arm, results: QuestionArmResult[]): ArmRunMetrics {
+  const rs = results.filter((r) => r.arm === arm);
+  const n = rs.length;
+  const judged = rs.filter((r) => r.verdict !== null);
+  const judgeErrors = n - judged.length;
+  const correct = judged.filter((r) => r.verdict === "CORRECT").length;
+
+  const perAbility: Partial<Record<Ability, AbilityMetric>> = {};
+  const abilities = new Set(rs.map((r) => r.ability));
+  for (const ab of abilities) {
+    if (ab === "abstention") continue; // broken out separately
+    const abRs = rs.filter((r) => r.ability === ab);
+    const abJudged = abRs.filter((r) => r.verdict !== null);
+    const abCorrect = abJudged.filter((r) => r.verdict === "CORRECT").length;
+    perAbility[ab] = {
+      n: abRs.length,
+      judged: abJudged.length,
+      correct: abCorrect,
+      accuracy: abJudged.length ? abCorrect / abJudged.length : 0,
+    };
+  }
+
+  const absRs = rs.filter((r) => r.isAbstention);
+  const absJudged = absRs.filter((r) => r.verdict !== null);
+  const absCorrect = absJudged.filter((r) => r.verdict === "CORRECT").length;
+  const abstention: AbilityMetric = {
+    n: absRs.length,
+    judged: absJudged.length,
+    correct: absCorrect,
+    accuracy: absJudged.length ? absCorrect / absJudged.length : 0,
+  };
+
+  const answerable = rs.filter((r) => !r.isAbstention && r.verdict !== null);
+  const notAttempted = answerable.filter((r) => r.verdict === "NOT_ATTEMPTED").length;
+  const incorrect = answerable.filter((r) => r.verdict === "INCORRECT").length;
+  const answerableCorrect = answerable.filter((r) => r.verdict === "CORRECT").length;
+
+  const factualRs = rs.filter((r) => FACTUAL_ABILITIES.includes(r.ability) && r.extraction);
+  const factual = {
+    n: factualRs.length,
+    f1: mean(factualRs.map((r) => r.extraction!.f1)),
+    containmentEM: mean(factualRs.map((r) => r.extraction!.containmentEM)),
+    strictEM: mean(factualRs.map((r) => r.extraction!.strictEM)),
+  };
+
+  const tokens = rs.map((r) => r.tokensFed);
+  const latencies = rs.map((r) => r.latencyMs);
+  const retr = rs.filter((r) => r.retrievalMs !== undefined).map((r) => r.retrievalMs!);
+
+  return {
+    arm,
+    n,
+    judged: judged.length,
+    judgeErrors,
+    overallAccuracy: judged.length ? correct / judged.length : 0,
+    overallAccuracyAnswerable: answerable.length ? answerableCorrect / answerable.length : 0,
+    answerableJudged: answerable.length,
+    perAbility,
+    abstention,
+    notAttemptedRateAnswerable: answerable.length ? notAttempted / answerable.length : 0,
+    incorrectRateAnswerable: answerable.length ? incorrect / answerable.length : 0,
+    factual,
+    tokensPerQueryMean: mean(tokens),
+    tokensPerQueryP50: percentile(tokens, 50),
+    latencyP50Ms: percentile(latencies, 50),
+    latencyP95Ms: percentile(latencies, 95),
+    retrievalP50Ms: retr.length ? percentile(retr, 50) : null,
+    anyTruncated: rs.some((r) => r.truncated),
+  };
+}
+
+export interface MeanStd { mean: number; std: number; runs: number[] }
+function ms(runs: number[]): MeanStd { return { mean: mean(runs), std: std(runs), runs }; }
+
+export interface ArmAggregate {
+  arm: Arm;
+  runs: number;
+  overallAccuracy: MeanStd;
+  /** Answerable-only accuracy across runs — the contamination-probe number. */
+  overallAccuracyAnswerable: MeanStd;
+  perAbility: Partial<Record<Ability, MeanStd>>;
+  abstentionAccuracy: MeanStd;
+  notAttemptedRateAnswerable: MeanStd;
+  factualF1: MeanStd;
+  factualContainmentEM: MeanStd;
+  tokensPerQueryMean: MeanStd;
+  latencyP50Ms: MeanStd;
+  latencyP95Ms: MeanStd;
+  judgeErrorsTotal: number;
+}
+
+/** Aggregate an arm across ≥1 runs (mean±std). Per-ability std is reported too
+ *  (Kern §7c). */
+export function aggregateArmAcrossRuns(arm: Arm, perRun: ArmRunMetrics[]): ArmAggregate {
+  const allAbilities = new Set<Ability>();
+  for (const r of perRun) for (const k of Object.keys(r.perAbility)) allAbilities.add(k as Ability);
+  const perAbility: Partial<Record<Ability, MeanStd>> = {};
+  for (const ab of allAbilities) {
+    perAbility[ab] = ms(perRun.map((r) => r.perAbility[ab]?.accuracy ?? 0));
+  }
+  return {
+    arm,
+    runs: perRun.length,
+    overallAccuracy: ms(perRun.map((r) => r.overallAccuracy)),
+    overallAccuracyAnswerable: ms(perRun.map((r) => r.overallAccuracyAnswerable)),
+    perAbility,
+    abstentionAccuracy: ms(perRun.map((r) => r.abstention.accuracy)),
+    notAttemptedRateAnswerable: ms(perRun.map((r) => r.notAttemptedRateAnswerable)),
+    factualF1: ms(perRun.map((r) => r.factual.f1)),
+    factualContainmentEM: ms(perRun.map((r) => r.factual.containmentEM)),
+    tokensPerQueryMean: ms(perRun.map((r) => r.tokensPerQueryMean)),
+    latencyP50Ms: ms(perRun.map((r) => r.latencyP50Ms)),
+    latencyP95Ms: ms(perRun.map((r) => r.latencyP95Ms)),
+    judgeErrorsTotal: perRun.reduce((a, r) => a + r.judgeErrors, 0),
+  };
+}

--- a/test/bench/longmemeval/ollama.ts
+++ b/test/bench/longmemeval/ollama.ts
@@ -1,0 +1,150 @@
+/**
+ * ollama.ts — the ONE deterministic Ollama call path for the Layer 2 harness.
+ *
+ * Both the reader and the judge run LOCAL on Newton via Ollama. Reproducibility
+ * is the edge (#1216 design), so this client is deliberately narrow:
+ *
+ *   - temperature 0 + a fixed seed + a fixed num_ctx — the run-to-run mean±std
+ *     must reflect the memory layer, not sampling noise. A temp≠0 judge would
+ *     make the ≥5-run spread sampling noise and collapse the reproducibility
+ *     claim (Sherlock #3).
+ *   - PLAINTEXT only. We NEVER use Ollama's JSON / structured-output mode: it is
+ *     non-deterministic even at a fixed seed (Ollama #12559), and the judge
+ *     decision explicitly forbids it. The judge parses a plaintext exact-enum
+ *     verdict instead (judge.ts).
+ *   - think:false — the reader/judge models carry a "thinking" capability;
+ *     thinking tokens are non-deterministic and pollute a short verdict/answer,
+ *     so we disable them. (Verified empirically: gemma4/qwen3.6 honor it and
+ *     return clean output.)
+ *   - DIGEST-pinned. Ollama tags are MUTABLE; sha256 manifest digests are not.
+ *     assertModelPinned() refuses to run if the model currently resolving on
+ *     the host does not match the digest recorded in config.ts — so "I re-ran
+ *     the exact number" means the exact weights, not whatever the tag points at
+ *     today.
+ *
+ * Pure transport + a pin check. No dataset, no prompts, no scoring.
+ */
+
+export interface OllamaModelSpec {
+  model: string;
+  /** The immutable manifest digest recorded at pin time (config.ts). */
+  manifestDigest: string;
+  temperature: number;
+  seed: number;
+  numCtx: number;
+  numPredict: number;
+}
+
+export interface GenerateResult {
+  /** The model's raw text response (thinking disabled, plaintext). */
+  response: string;
+  /** Real prompt token count from the model (tokens FED to the reader/judge). */
+  promptTokens: number;
+  /** Real generated token count. */
+  evalTokens: number;
+  /** Wall-clock round trip for this call (ms). */
+  latencyMs: number;
+  doneReason: string;
+}
+
+export class OllamaError extends Error {}
+
+/**
+ * A single deterministic generation. `numCtxOverride` lets the full-context arm
+ * use its own (still fixed, still pinned) larger window without changing the
+ * spec's default num_ctx for every other call — see config.ts FULL_CONTEXT.
+ */
+export async function generate(
+  host: string,
+  spec: OllamaModelSpec,
+  prompt: string,
+  opts: { numCtxOverride?: number; numPredictOverride?: number } = {},
+): Promise<GenerateResult> {
+  const body = {
+    model: spec.model,
+    prompt,
+    stream: false,
+    think: false, // deterministic, no thinking tokens
+    // NOTE: no `format` field — plaintext only. JSON/structured mode is
+    // non-deterministic at fixed seed (Ollama #12559) and forbidden by design.
+    options: {
+      temperature: spec.temperature,
+      seed: spec.seed,
+      num_ctx: opts.numCtxOverride ?? spec.numCtx,
+      num_predict: opts.numPredictOverride ?? spec.numPredict,
+    },
+  };
+  const t0 = performance.now();
+  let res: Response;
+  try {
+    res = await fetch(`${host}/api/generate`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    });
+  } catch (err) {
+    throw new OllamaError(`generate(${spec.model}) transport failure to ${host}: ${err instanceof Error ? err.message : String(err)}`);
+  }
+  const latencyMs = performance.now() - t0;
+  const text = await res.text();
+  if (!res.ok) {
+    throw new OllamaError(`generate(${spec.model}) HTTP ${res.status}: ${text.slice(0, 300)}`);
+  }
+  let j: any;
+  try { j = JSON.parse(text); } catch {
+    throw new OllamaError(`generate(${spec.model}) non-JSON envelope: ${text.slice(0, 200)}`);
+  }
+  if (typeof j.response !== "string") {
+    throw new OllamaError(`generate(${spec.model}) missing response field: ${text.slice(0, 200)}`);
+  }
+  return {
+    response: j.response,
+    promptTokens: j.prompt_eval_count ?? 0,
+    evalTokens: j.eval_count ?? 0,
+    latencyMs,
+    doneReason: j.done_reason ?? "",
+  };
+}
+
+/**
+ * Refuse to run unless the model's CURRENT manifest digest on the host matches
+ * the digest pinned in config.ts. Tags are mutable; a silent re-tag would make
+ * "re-run the number" reproduce a different model. Fail loud, never warn-and-go
+ * (a shipped default that resolves to whatever-is-there is a trust anchor —
+ * MEMORY.md).
+ */
+export async function assertModelPinned(host: string, spec: OllamaModelSpec): Promise<{ actualDigest: string }> {
+  let res: Response;
+  try {
+    res = await fetch(`${host}/api/tags`, { signal: AbortSignal.timeout(10_000) });
+  } catch (err) {
+    throw new OllamaError(`assertModelPinned: cannot reach Ollama at ${host}: ${err instanceof Error ? err.message : String(err)}`);
+  }
+  if (!res.ok) throw new OllamaError(`assertModelPinned: /api/tags HTTP ${res.status}`);
+  const j: any = await res.json();
+  const found = (j.models ?? []).find((m: any) => m.name === spec.model);
+  if (!found) {
+    throw new OllamaError(
+      `assertModelPinned: model "${spec.model}" is not present on ${host}. ` +
+      `Pull it first: ollama pull ${spec.model} (expected digest ${spec.manifestDigest}).`,
+    );
+  }
+  const actualDigest = found.digest?.startsWith("sha256:") ? found.digest : `sha256:${found.digest}`;
+  if (actualDigest !== spec.manifestDigest) {
+    throw new OllamaError(
+      `assertModelPinned: DIGEST MISMATCH for "${spec.model}". ` +
+      `pinned=${spec.manifestDigest} actual=${actualDigest}. ` +
+      `The tag moved — pin the new digest deliberately or pull the pinned one; never run against an unpinned model.`,
+    );
+  }
+  return { actualDigest };
+}
+
+/** Confirm the host answers at all (a decisive early failure vs a slow timeout
+ *  mid-run). Returns the raw /api/tags model names. */
+export async function pingOllama(host: string): Promise<string[]> {
+  const res = await fetch(`${host}/api/tags`, { signal: AbortSignal.timeout(8_000) });
+  if (!res.ok) throw new OllamaError(`pingOllama: HTTP ${res.status} from ${host}`);
+  const j: any = await res.json();
+  return (j.models ?? []).map((m: any) => m.name);
+}

--- a/test/bench/longmemeval/run.ts
+++ b/test/bench/longmemeval/run.ts
@@ -1,0 +1,190 @@
+#!/usr/bin/env bun
+/**
+ * run.ts — LongMemEval_s Layer 2 harness CLI (#1216-b).
+ *
+ *   bun run test/bench/longmemeval/run.ts verify-judge [--repeats 3]
+ *       Prove the pinned gemma4 judge returns the CORRECT ternary verdict, and
+ *       returns it DETERMINISTICALLY (identical across repeats at temp 0), on a
+ *       set of known (answer, gold) pairs spanning every task + abstention.
+ *
+ *   bun run test/bench/longmemeval/run.ts run --dataset <path> [--n 24] [--seed 0] [--runs 2] [--out <dir>]
+ *       Run the four arms over a slice; emit the content-addressed artifact.
+ *       Pins the dataset (sha256), the reader + judge (digest), num_ctx, and all
+ *       configs. Produces a number; NEVER publishes one (artifact.ts NOTICE).
+ *
+ * Reproducibility: `ollama pull` the pinned digests + fetch the pinned dataset
+ * (see README) and anyone re-runs the exact number locally — no OpenAI key.
+ */
+import { existsSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+import { execSync } from "node:child_process";
+import {
+  OLLAMA_HOST, JUDGE, READER, DATASET, RETRIEVAL, FULL_CONTEXT,
+  assertCrossFamily, configManifest, hashConfig,
+} from "./config";
+import { assertModelPinned, pingOllama, generate, OllamaError } from "./ollama";
+import { buildJudgePrompt, parseVerdict, type LmeTask, type Verdict } from "./judge";
+import { loadDataset, selectSlice, abilityOf, isAbstention } from "./dataset";
+import { runOnce } from "./eval";
+import { aggregateArmAcrossRuns, type ArmRunMetrics } from "./metrics";
+import { buildArtifact, writeArtifact, verifyArtifactHash } from "./artifact";
+import { ALL_ARMS, type Arm } from "./arms";
+
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../../..");
+
+function arg(flag: string, dflt?: string): string | undefined {
+  const i = process.argv.indexOf(flag);
+  return i >= 0 && process.argv[i + 1] ? process.argv[i + 1] : dflt;
+}
+const hasFlag = (f: string) => process.argv.includes(f);
+const fmt = (x: number, d = 3) => x.toFixed(d);
+const pct = (x: number) => (x * 100).toFixed(1) + "%";
+
+function gitCommit(): string | null {
+  try { return execSync("git rev-parse HEAD", { cwd: REPO_ROOT }).toString().trim(); } catch { return null; }
+}
+
+function assertBuilt(): void {
+  const marker = path.join(REPO_ROOT, "dist", "resources", "SemanticSearch.js");
+  if (!existsSync(marker)) {
+    console.error(`FATAL: ${marker} not found — Harper serves resources from dist/. Run \`bun run build\` first.`);
+    process.exit(2);
+  }
+}
+
+// ── verify-judge: the load-bearing judge determinism + correctness proof ──────
+interface JudgeProbe { name: string; task: LmeTask; question: string; answer: string; response: string; abstention: boolean; expect: Verdict }
+const JUDGE_PROBES: JudgeProbe[] = [
+  { name: "ie-correct", task: "single-session-user", question: "What degree did I graduate with?", answer: "Business Administration", response: "You graduated with a degree in Business Administration.", abstention: false, expect: "CORRECT" },
+  { name: "ie-incorrect", task: "single-session-user", question: "What degree did I graduate with?", answer: "Business Administration", response: "You graduated in Computer Science.", abstention: false, expect: "INCORRECT" },
+  { name: "ie-not-attempted", task: "single-session-user", question: "What degree did I graduate with?", answer: "Business Administration", response: "I don't have enough information in our conversations to answer that.", abstention: false, expect: "NOT_ATTEMPTED" },
+  { name: "temporal-off-by-one", task: "temporal-reasoning", question: "How many days passed between my two trips?", answer: "18 days", response: "There were 19 days between them.", abstention: false, expect: "CORRECT" },
+  { name: "knowledge-update", task: "knowledge-update", question: "What is my current phone number?", answer: "555-1234", response: "You previously used 555-0000, but your current number is 555-1234.", abstention: false, expect: "CORRECT" },
+  { name: "multi-session-subset", task: "multi-session", question: "Which three cities did I visit last year?", answer: "Paris, Rome, and Tokyo", response: "You visited Paris.", abstention: false, expect: "INCORRECT" },
+  { name: "preference-correct", task: "single-session-preference", question: "Recommend a restaurant for dinner.", answer: "The user is vegan; the response should recommend vegan-friendly options.", response: "Since you're vegan, try the plant-based tasting menu at Green Table.", abstention: false, expect: "CORRECT" },
+  { name: "abstention-correct", task: "single-session-user", question: "What did I say about my sister's wedding?", answer: "The user never mentioned a sister or a wedding in any session.", response: "I don't have any information about your sister's wedding in our conversations.", abstention: true, expect: "CORRECT" },
+  { name: "abstention-hallucination", task: "single-session-user", question: "What did I say about my sister's wedding?", answer: "The user never mentioned a sister or a wedding in any session.", response: "You mentioned your sister's wedding is scheduled for June.", abstention: true, expect: "INCORRECT" },
+];
+
+async function verifyJudge(host: string, repeats: number): Promise<void> {
+  console.log(`\n=== verify-judge: ${JUDGE.model} @ temp ${JUDGE.temperature}, ${repeats} repeats each ===\n`);
+  await assertModelPinned(host, JUDGE);
+  let failures = 0;
+  for (const p of JUDGE_PROBES) {
+    const { prompt, allowed } = buildJudgePrompt(p);
+    const verdicts: string[] = [];
+    for (let i = 0; i < repeats; i++) {
+      const g = await generate(host, JUDGE, prompt);
+      let v: string;
+      try { v = parseVerdict(g.response, allowed); } catch (e) { v = `PARSE_ERROR(${JSON.stringify(g.response).slice(0, 40)})`; }
+      verdicts.push(v);
+    }
+    const deterministic = verdicts.every((v) => v === verdicts[0]);
+    const correct = verdicts[0] === p.expect;
+    const ok = deterministic && correct;
+    if (!ok) failures++;
+    console.log(
+      `  ${ok ? "PASS" : "FAIL"}  ${p.name.padEnd(24)} expect=${p.expect.padEnd(14)} got=${verdicts[0]!.padEnd(14)} ` +
+      `${deterministic ? "deterministic" : "NON-DETERMINISTIC " + JSON.stringify(verdicts)}`,
+    );
+  }
+  console.log(`\n${failures === 0 ? "ALL PASS" : failures + " FAILURE(S)"} — ${JUDGE_PROBES.length} probes × ${repeats} repeats\n`);
+  if (failures > 0) process.exit(1);
+}
+
+// ── run: the slice ───────────────────────────────────────────────────────────
+async function runSlice(): Promise<void> {
+  assertBuilt();
+  assertCrossFamily();
+  const host = arg("--host", OLLAMA_HOST)!;
+  const datasetPath = arg("--dataset");
+  if (!datasetPath) { console.error("run requires --dataset <path to longmemeval_s.json>"); process.exit(2); }
+  const n = parseInt(arg("--n", "24")!, 10);
+  const seed = parseInt(arg("--seed", "0")!, 10);
+  const runs = parseInt(arg("--runs", "2")!, 10);
+  const outDir = arg("--out", path.join(REPO_ROOT, "longmemeval-artifacts"))!;
+  const allowUnpinned = hasFlag("--allow-unpinned");
+  const validationSlice = !hasFlag("--full-run");
+
+  console.log(`\n=== LongMemEval_s Layer 2 — ${validationSlice ? "VALIDATION SLICE" : "run"} ===`);
+  console.log(`host=${host}  n=${n}  seed=${seed}  runs=${runs}`);
+
+  // Pin gates: reachability + digest match (fail loud, tags are mutable).
+  await pingOllama(host);
+  await assertModelPinned(host, READER);
+  await assertModelPinned(host, JUDGE);
+  console.log(`reader=${READER.model} (${READER.family})  judge=${JUDGE.model} (${JUDGE.family})  [digests verified]`);
+
+  const entries = loadDataset(datasetPath!, { allowUnpinned });
+  console.log(`dataset ${DATASET.name} loaded: ${entries.length} questions (sha256 ${allowUnpinned ? "UNVERIFIED" : "verified"})`);
+  const slice = selectSlice(entries, n, seed);
+  const abilityCounts: Record<string, number> = {};
+  for (const e of slice) abilityCounts[abilityOf(e)] = (abilityCounts[abilityOf(e)] ?? 0) + 1;
+  console.log(`slice: ${slice.length} questions across abilities: ${JSON.stringify(abilityCounts)}`);
+
+  const manifest = configManifest({ n, seed, runs, questionIds: slice.map((e) => e.question_id) });
+  const configHash = hashConfig(manifest);
+  console.log(`configHash: ${configHash}\n`);
+
+  const perArmRuns = new Map<Arm, ArmRunMetrics[]>(ALL_ARMS.map((a) => [a, []]));
+  const runHashes: string[] = [];
+  for (let i = 1; i <= runs; i++) {
+    const r = await runOnce(i, slice, { repoRoot: REPO_ROOT, host, log: (s) => console.log(s) });
+    runHashes.push(r.runHash);
+    for (const m of r.armMetrics) perArmRuns.get(m.arm)!.push(m);
+  }
+
+  const aggregate = ALL_ARMS.map((a) => aggregateArmAcrossRuns(a, perArmRuns.get(a)!));
+  const artifact = buildArtifact({
+    configHash, config: manifest, runHashes, aggregate,
+    gitCommit: gitCommit(), ollamaHost: host, benchHost: "rockit", validationSlice,
+  });
+  const artifactPath = writeArtifact(artifact, outDir);
+
+  // ── report ──
+  console.log(`\n${"═".repeat(64)}\n  RESULTS (${validationSlice ? "VALIDATION SLICE — NOT PUBLISHABLE" : "run"}) — ${runs} run(s), mean±std\n${"═".repeat(64)}`);
+  for (const a of aggregate) {
+    console.log(`\n[${a.arm}]  overall accuracy: ${pct(a.overallAccuracy.mean)} ± ${pct(a.overallAccuracy.std)}   (runs: ${a.overallAccuracy.runs.map((x) => pct(x)).join(", ")})`);
+    console.log(`    ${"overall (answerable only)".padEnd(28)} ${pct(a.overallAccuracyAnswerable.mean)} ± ${pct(a.overallAccuracyAnswerable.std)}`);
+    for (const [ab, msd] of Object.entries(a.perAbility)) {
+      console.log(`    ${ab.padEnd(28)} ${pct(msd!.mean)} ± ${pct(msd!.std)}`);
+    }
+    console.log(`    ${"abstention (broken out)".padEnd(28)} ${pct(a.abstentionAccuracy.mean)} ± ${pct(a.abstentionAccuracy.std)}`);
+    console.log(`    ${"not-attempted (answerable)".padEnd(28)} ${pct(a.notAttemptedRateAnswerable.mean)}`);
+    console.log(`    ${"factual F1 (cross-check)".padEnd(28)} ${fmt(a.factualF1.mean)}   containment-EM ${fmt(a.factualContainmentEM.mean)}`);
+    console.log(`    ${"tokens/query (mean)".padEnd(28)} ${a.tokensPerQueryMean.mean.toFixed(0)}`);
+    console.log(`    ${"latency p50 / p95 (ms)".padEnd(28)} ${a.latencyP50Ms.mean.toFixed(0)} / ${a.latencyP95Ms.mean.toFixed(0)}`);
+    if (a.judgeErrorsTotal > 0) console.log(`    !! judge errors: ${a.judgeErrorsTotal} (unparseable verdicts — NOT counted as pass)`);
+  }
+  const nc = aggregate.find((a) => a.arm === "no-context")!;
+  const fl = aggregate.find((a) => a.arm === "flair")!;
+  const fc = aggregate.find((a) => a.arm === "full-context")!;
+  console.log(`\n── contamination / validity reads (ANSWERABLE questions only) ──`);
+  console.log(`  no-context accuracy = ${pct(nc.overallAccuracyAnswerable.mean)}  (HIGH ⇒ reader prior knowledge / contamination — number suspect)`);
+  console.log(`    (measured on answerable questions — an abstention question is trivially correct with no context, so it is excluded here)`);
+  console.log(`  full-context − flair = ${pct(fc.overallAccuracyAnswerable.mean - fl.overallAccuracyAnswerable.mean)}  (≈0 ⇒ measuring long-context not memory; large ⇒ retrieval losing info)`);
+  console.log(`\nartifactHash: ${artifact.artifactHash}`);
+  console.log(`artifact self-verifies: ${verifyArtifactHash(artifact)}`);
+  console.log(`written: ${artifactPath}`);
+  console.log(`\nNOTICE: ${artifact.notice}\n`);
+}
+
+async function main() {
+  const cmd = process.argv[2];
+  try {
+    if (cmd === "verify-judge") {
+      await verifyJudge(arg("--host", OLLAMA_HOST)!, parseInt(arg("--repeats", "3")!, 10));
+    } else if (cmd === "run") {
+      await runSlice();
+    } else {
+      console.log("usage: run.ts <verify-judge|run> [options] — see file header");
+      process.exit(2);
+    }
+  } catch (err) {
+    if (err instanceof OllamaError) console.error(`\nOLLAMA/JUDGE SEAM: ${err.message}\n`);
+    else console.error(err);
+    process.exit(1);
+  }
+}
+main();

--- a/test/unit/longmemeval-artifact.test.ts
+++ b/test/unit/longmemeval-artifact.test.ts
@@ -1,0 +1,81 @@
+import { describe, test, expect } from "bun:test";
+import { buildArtifact, verifyArtifactHash, hashRunResults } from "../bench/longmemeval/artifact";
+import { configManifest, hashConfig, canonicalJson } from "../bench/longmemeval/config";
+
+// The publish gate is STRUCTURAL (Sherlock #4): the run emits a content-
+// addressed artifact, and a human signs off on a specific artifactHash. These
+// tests pin that the hash actually addresses the content and self-verifies.
+
+const baseInput = () => ({
+  configHash: "deadbeef",
+  config: { schema: "test", a: 1 },
+  runHashes: ["r1", "r2"],
+  aggregate: [] as any[],
+  gitCommit: "abc123",
+  ollamaHost: "http://host:11434",
+  benchHost: "rockit",
+  validationSlice: true,
+});
+
+describe("artifact — content addressing", () => {
+  test("artifactHash self-verifies (hash excludes the hash field)", () => {
+    const art = buildArtifact(baseInput());
+    expect(art.artifactHash).toBeTruthy();
+    expect(verifyArtifactHash(art)).toBe(true);
+  });
+
+  test("identical inputs → identical artifactHash (excluding volatile generatedAt)", () => {
+    const a = buildArtifact(baseInput());
+    const b = buildArtifact(baseInput());
+    // generatedAt differs by wall-clock, so the whole-artifact hash may differ;
+    // the config + run hashes are what's reproducible.
+    expect(a.configHash).toBe(b.configHash);
+    expect(a.runHashes).toEqual(b.runHashes);
+  });
+
+  test("a changed number changes the artifactHash (tamper-evident)", () => {
+    const a = buildArtifact(baseInput());
+    const tampered = { ...a } as any;
+    delete tampered.artifactHash;
+    tampered.runHashes = ["r1", "CHANGED"];
+    const reAdded = buildArtifact({ ...baseInput(), runHashes: ["r1", "CHANGED"] });
+    expect(reAdded.artifactHash).not.toBe(a.artifactHash);
+  });
+
+  test("carries the NOT-FOR-PUBLICATION notice", () => {
+    const art = buildArtifact(baseInput());
+    expect(art.notice).toContain("NOT FOR PUBLICATION");
+    expect(art.notice).toContain("sign-off");
+  });
+
+  test("there is no publish function exported", async () => {
+    const mod = await import("../bench/longmemeval/artifact");
+    expect((mod as any).publish).toBeUndefined();
+    expect((mod as any).publishArtifact).toBeUndefined();
+  });
+});
+
+describe("config hash — pre-registration", () => {
+  const slice = { n: 3, seed: 0, runs: 2, questionIds: ["qb", "qa", "qc"] };
+
+  test("is deterministic and order-independent for questionIds", () => {
+    const h1 = hashConfig(configManifest(slice));
+    const h2 = hashConfig(configManifest({ ...slice, questionIds: ["qc", "qa", "qb"] }));
+    expect(h1).toBe(h2); // manifest sorts questionIds
+  });
+
+  test("changes when the slice changes (config-shopping leaves a trace)", () => {
+    const h1 = hashConfig(configManifest(slice));
+    const h2 = hashConfig(configManifest({ ...slice, questionIds: ["qa", "qb", "qd"] }));
+    expect(h1).not.toBe(h2);
+  });
+
+  test("canonicalJson sorts keys recursively", () => {
+    expect(canonicalJson({ b: 1, a: { d: 2, c: 3 } })).toBe('{"a":{"c":3,"d":2},"b":1}');
+  });
+
+  test("hashRunResults is stable for equal decision sets", () => {
+    const set = [{ arm: "flair", questionId: "q1", verdict: "CORRECT" }];
+    expect(hashRunResults(set)).toBe(hashRunResults(set));
+  });
+});

--- a/test/unit/longmemeval-dataset.test.ts
+++ b/test/unit/longmemeval-dataset.test.ts
@@ -1,0 +1,101 @@
+import { describe, test, expect } from "bun:test";
+import {
+  abilityOf, isAbstention, selectSlice, parseLmeDate, entryToSessions, TYPE_TO_ABILITY,
+  type LmeEntry,
+} from "../bench/longmemeval/dataset";
+
+function mkEntry(id: string, type: LmeEntry["question_type"], overrides: Partial<LmeEntry> = {}): LmeEntry {
+  return {
+    question_id: id,
+    question_type: type,
+    question: "q",
+    answer: "a",
+    question_date: "2023/05/30 (Tue) 23:40",
+    haystack_dates: ["2023/05/20 (Sat) 02:21"],
+    haystack_session_ids: ["s0"],
+    haystack_sessions: [[{ role: "user", content: "hello" }, { role: "assistant", content: "hi" }]],
+    answer_session_ids: [],
+    ...overrides,
+  };
+}
+
+describe("ability mapping", () => {
+  test("each question type maps to its ability", () => {
+    expect(abilityOf(mkEntry("a", "single-session-user"))).toBe("information-extraction");
+    expect(abilityOf(mkEntry("b", "single-session-assistant"))).toBe("information-extraction");
+    expect(abilityOf(mkEntry("c", "multi-session"))).toBe("multi-session");
+    expect(abilityOf(mkEntry("d", "temporal-reasoning"))).toBe("temporal-reasoning");
+    expect(abilityOf(mkEntry("e", "knowledge-update"))).toBe("knowledge-update");
+    expect(abilityOf(mkEntry("f", "single-session-preference"))).toBe("single-session-preference");
+  });
+
+  test("_abs suffix OVERRIDES the type bucket → abstention", () => {
+    const e = mkEntry("q123_abs", "single-session-user");
+    expect(isAbstention(e)).toBe(true);
+    expect(abilityOf(e)).toBe("abstention"); // not information-extraction
+  });
+
+  test("TYPE_TO_ABILITY covers all six types", () => {
+    expect(Object.keys(TYPE_TO_ABILITY).length).toBe(6);
+  });
+});
+
+describe("parseLmeDate", () => {
+  test("strips the weekday parenthetical and parses to ISO", () => {
+    const iso = parseLmeDate("2023/05/20 (Sat) 02:21");
+    expect(iso).toBe("2023-05-20T02:21:00.000Z");
+  });
+  test("orders correctly (temporal ability depends on it)", () => {
+    const a = parseLmeDate("2023/05/20 (Sat) 02:21")!;
+    const b = parseLmeDate("2023/05/21 (Sun) 02:21")!;
+    expect(new Date(a) < new Date(b)).toBe(true);
+  });
+  test("empty / unparseable → undefined", () => {
+    expect(parseLmeDate("")).toBeUndefined();
+  });
+});
+
+describe("entryToSessions — per-event, timestamps preserved", () => {
+  test("one event per turn, stable ids, session date stamped", () => {
+    const sessions = entryToSessions(mkEntry("qX", "single-session-user"));
+    expect(sessions.length).toBe(1);
+    expect(sessions[0]!.events.length).toBe(2);
+    expect(sessions[0]!.events[0]!.id).toBe("qX__s0__t0");
+    expect(sessions[0]!.events[0]!.content).toBe("user: hello");
+    expect(sessions[0]!.events[0]!.createdAt).toBe("2023-05-20T02:21:00.000Z");
+    expect(sessions[0]!.events[0]!.role).toBe("user");
+  });
+});
+
+describe("selectSlice — deterministic + ability coverage", () => {
+  const entries: LmeEntry[] = [];
+  const types: LmeEntry["question_type"][] = [
+    "single-session-user", "multi-session", "temporal-reasoning", "knowledge-update", "single-session-preference",
+  ];
+  for (let i = 0; i < 50; i++) entries.push(mkEntry(`q${String(i).padStart(3, "0")}`, types[i % types.length]!));
+  for (let i = 0; i < 10; i++) entries.push(mkEntry(`q${String(100 + i).padStart(3, "0")}_abs`, "single-session-user"));
+
+  test("is deterministic for a fixed (n, seed)", () => {
+    const a = selectSlice(entries, 12, 0).map((e) => e.question_id);
+    const b = selectSlice(entries, 12, 0).map((e) => e.question_id);
+    expect(a).toEqual(b);
+  });
+
+  test("spans multiple abilities (round-robin), including abstention", () => {
+    const slice = selectSlice(entries, 12, 0);
+    const abilities = new Set(slice.map((e) => abilityOf(e)));
+    expect(abilities.size).toBeGreaterThanOrEqual(5);
+    expect(abilities.has("abstention")).toBe(true);
+  });
+
+  test("output is sorted by question_id (hash-stable regardless of pick order)", () => {
+    const ids = selectSlice(entries, 12, 0).map((e) => e.question_id);
+    expect(ids).toEqual([...ids].sort());
+  });
+
+  test("a different seed can select a different slice", () => {
+    const s0 = selectSlice(entries, 6, 0).map((e) => e.question_id).join(",");
+    const s3 = selectSlice(entries, 6, 3).map((e) => e.question_id).join(",");
+    expect(s0).not.toBe(s3);
+  });
+});

--- a/test/unit/longmemeval-extraction.test.ts
+++ b/test/unit/longmemeval-extraction.test.ts
@@ -1,0 +1,56 @@
+import { describe, test, expect } from "bun:test";
+import { normalize, tokenF1, containmentEM, strictEM, scoreExtraction } from "../bench/longmemeval/extraction";
+
+// The F1/EM cross-check must be INDEPENDENT of the LLM judge (Sherlock #5) —
+// pure string math against LongMemEval's gold key. These pin its behaviour so a
+// silent regression in the anchor is caught.
+
+describe("normalize — SQuAD-style", () => {
+  test("lowercases, strips articles + punctuation, collapses whitespace", () => {
+    expect(normalize("The  Business Administration!")).toBe("business administration");
+    expect(normalize("A dog, and an apple.")).toBe("dog and apple");
+  });
+});
+
+describe("tokenF1", () => {
+  test("exact match after normalization is 1", () => {
+    expect(tokenF1("Business Administration", "business administration")).toBe(1);
+  });
+  test("gold contained in a fluent sentence scores partial (< 1, > 0)", () => {
+    const f1 = tokenF1("You graduated with a degree in Business Administration.", "Business Administration");
+    expect(f1).toBeGreaterThan(0);
+    expect(f1).toBeLessThan(1);
+  });
+  test("no overlap is 0", () => {
+    expect(tokenF1("Computer Science", "Business Administration")).toBe(0);
+  });
+  test("empty prediction is 0 against a non-empty gold", () => {
+    expect(tokenF1("", "anything")).toBe(0);
+  });
+});
+
+describe("EM variants", () => {
+  test("containmentEM matches gold as a token-boundary substring", () => {
+    expect(containmentEM("You graduated with a degree in Business Administration.", "Business Administration")).toBe(1);
+    expect(containmentEM("You graduated in Computer Science.", "Business Administration")).toBe(0);
+  });
+  test("containmentEM respects token boundaries (no mid-word match)", () => {
+    // "art" must not match inside "Business" etc. — gold "cat" not present as a word.
+    expect(containmentEM("concatenate the strings", "cat")).toBe(0);
+  });
+  test("strictEM only on full normalized equality", () => {
+    expect(strictEM("Business Administration", "the business administration")).toBe(1);
+    expect(strictEM("a degree in Business Administration", "Business Administration")).toBe(0);
+  });
+});
+
+describe("scoreExtraction — alias reduction", () => {
+  test("takes the best alias (| delimited)", () => {
+    const s = scoreExtraction("I moved to Tokyo.", "Kyoto|Tokyo|Osaka");
+    expect(s.containmentEM).toBe(1);
+    expect(s.f1).toBeGreaterThan(0);
+  });
+  test("empty gold yields zeros, not a crash", () => {
+    expect(scoreExtraction("anything", "")).toEqual({ f1: 0, containmentEM: 0, strictEM: 0 });
+  });
+});

--- a/test/unit/longmemeval-judge.test.ts
+++ b/test/unit/longmemeval-judge.test.ts
@@ -1,0 +1,78 @@
+import { describe, test, expect } from "bun:test";
+import {
+  parseVerdict, JudgeParseError, buildJudgePrompt, ANSWERABLE_TEMPLATE, PREFERENCE_TEMPLATE, ABSTENTION_TEMPLATE,
+} from "../bench/longmemeval/judge";
+
+// The judge must parse a PLAINTEXT exact enum and treat anything it cannot
+// resolve as an ERROR — never a silent pass (the fail-open trap the design
+// names). These tests pin that boundary: what is accepted, and what MUST throw.
+
+describe("parseVerdict — strict enum, fail-loud", () => {
+  test("clean single letters map to the ternary", () => {
+    expect(parseVerdict("A", ["A", "B", "C"])).toBe("CORRECT");
+    expect(parseVerdict("B", ["A", "B", "C"])).toBe("INCORRECT");
+    expect(parseVerdict("C", ["A", "B", "C"])).toBe("NOT_ATTEMPTED");
+  });
+
+  test("tolerates light decoration around a single letter", () => {
+    expect(parseVerdict(" A ", ["A", "B", "C"])).toBe("CORRECT");
+    expect(parseVerdict("A.", ["A", "B", "C"])).toBe("CORRECT");
+    expect(parseVerdict("**B**", ["A", "B", "C"])).toBe("INCORRECT");
+    expect(parseVerdict("Verdict: C", ["A", "B", "C"])).toBe("NOT_ATTEMPTED");
+    expect(parseVerdict("a", ["A", "B", "C"])).toBe("CORRECT"); // case-insensitive
+  });
+
+  test("ERRORS on an empty / letterless response (never a silent pass)", () => {
+    expect(() => parseVerdict("", ["A", "B", "C"])).toThrow(JudgeParseError);
+    expect(() => parseVerdict("the answer looks fine to me", ["A", "B", "C"])).toThrow(JudgeParseError);
+  });
+
+  test("ERRORS on two DIFFERENT letters (ambiguous, never guesses)", () => {
+    expect(() => parseVerdict("A or B", ["A", "B", "C"])).toThrow(JudgeParseError);
+    expect(() => parseVerdict("Between B and C, I'd say...", ["A", "B", "C"])).toThrow(JudgeParseError);
+  });
+
+  test("a letter glued inside a word is NOT a verdict", () => {
+    // "Correct" contains no standalone A/B/C; must error, not read the 'C'.
+    expect(() => parseVerdict("Absolutely correct", ["A", "B", "C"])).toThrow(JudgeParseError);
+  });
+
+  test("abstention questions allow only A/B — a C is an ERROR, not a pass", () => {
+    expect(parseVerdict("A", ["A", "B"])).toBe("CORRECT");
+    expect(parseVerdict("B", ["A", "B"])).toBe("INCORRECT");
+    expect(() => parseVerdict("C", ["A", "B"])).toThrow(JudgeParseError);
+  });
+});
+
+describe("buildJudgePrompt — right rubric per task", () => {
+  test("answerable non-preference uses the answerable template with the task rule", () => {
+    const p = buildJudgePrompt({ task: "temporal-reasoning", question: "q", answer: "a", response: "r", abstention: false });
+    expect(p.allowed).toEqual(["A", "B", "C"]);
+    expect(p.prompt).toContain("off-by-one"); // temporal leniency clause ported
+    expect(p.prompt).not.toContain("{taskRule}");
+  });
+
+  test("knowledge-update carries its ported leniency clause", () => {
+    const p = buildJudgePrompt({ task: "knowledge-update", question: "q", answer: "a", response: "r", abstention: false });
+    expect(p.prompt).toContain("updated answer");
+  });
+
+  test("preference uses the rubric template (allows A/B/C)", () => {
+    const p = buildJudgePrompt({ task: "single-session-preference", question: "q", answer: "rubric", response: "r", abstention: false });
+    expect(p.prompt).toContain("Rubric:");
+    expect(p.allowed).toEqual(["A", "B", "C"]);
+  });
+
+  test("abstention uses the unanswerable template and restricts to A/B", () => {
+    const p = buildJudgePrompt({ task: "single-session-user", question: "q", answer: "why unanswerable", response: "r", abstention: true });
+    expect(p.prompt).toContain("UNANSWERABLE");
+    expect(p.allowed).toEqual(["A", "B"]);
+  });
+
+  test("no placeholders survive substitution", () => {
+    for (const t of ["single-session-user", "multi-session", "temporal-reasoning", "knowledge-update"] as const) {
+      const p = buildJudgePrompt({ task: t, question: "Q?", answer: "A", response: "R", abstention: false });
+      expect(p.prompt).not.toMatch(/\{(question|answer|response|taskRule)\}/);
+    }
+  });
+});

--- a/test/unit/longmemeval-metrics.test.ts
+++ b/test/unit/longmemeval-metrics.test.ts
@@ -1,0 +1,100 @@
+import { describe, test, expect } from "bun:test";
+import {
+  aggregateArmRun, aggregateArmAcrossRuns, mean, std, percentile, type QuestionArmResult,
+} from "../bench/longmemeval/metrics";
+import type { Verdict } from "../bench/longmemeval/judge";
+import type { Ability } from "../bench/longmemeval/dataset";
+
+function r(over: Partial<QuestionArmResult>): QuestionArmResult {
+  return {
+    questionId: "q", ability: "information-extraction", isAbstention: false, arm: "flair",
+    answer: "", verdict: "CORRECT", tokensFed: 100, latencyMs: 10, ...over,
+  };
+}
+
+describe("stats helpers", () => {
+  test("mean / sample-std / percentile", () => {
+    expect(mean([1, 2, 3])).toBe(2);
+    expect(std([2, 2, 2])).toBe(0);
+    expect(std([1])).toBe(0);            // n<2 → 0, never NaN
+    expect(percentile([1, 2, 3, 4], 50)).toBe(2);
+    expect(percentile([], 95)).toBe(0);
+  });
+});
+
+describe("aggregateArmRun — accuracy + abstention breakout", () => {
+  const results: QuestionArmResult[] = [
+    r({ questionId: "q1", verdict: "CORRECT", ability: "information-extraction" }),
+    r({ questionId: "q2", verdict: "INCORRECT", ability: "information-extraction" }),
+    r({ questionId: "q3", verdict: "NOT_ATTEMPTED", ability: "multi-session" }),
+    r({ questionId: "q4", verdict: "CORRECT", ability: "multi-session" }),
+    // abstention questions (broken out separately)
+    r({ questionId: "q5_abs", verdict: "CORRECT", isAbstention: true, ability: "abstention" }),
+    r({ questionId: "q6_abs", verdict: "INCORRECT", isAbstention: true, ability: "abstention" }),
+  ];
+
+  test("overall accuracy = CORRECT / judged (NOT_ATTEMPTED counts as not-correct)", () => {
+    const m = aggregateArmRun("flair", results);
+    // 3 CORRECT of 6 judged
+    expect(m.overallAccuracy).toBeCloseTo(3 / 6, 10);
+    expect(m.judged).toBe(6);
+    expect(m.judgeErrors).toBe(0);
+  });
+
+  test("answerable-only accuracy EXCLUDES abstention (the contamination-probe number)", () => {
+    // An abstention question is trivially correct with no context — including it
+    // would mask contamination. overallAccuracyAnswerable must ignore it.
+    const m = aggregateArmRun("flair", results);
+    // answerable q1..q4: 2 CORRECT of 4
+    expect(m.overallAccuracyAnswerable).toBeCloseTo(2 / 4, 10);
+    expect(m.answerableJudged).toBe(4);
+    // overall (incl. abstention) is different: 3 of 6
+    expect(m.overallAccuracy).toBeCloseTo(3 / 6, 10);
+  });
+
+  test("abstention is broken out and NOT in perAbility", () => {
+    const m = aggregateArmRun("flair", results);
+    expect(m.abstention.n).toBe(2);
+    expect(m.abstention.accuracy).toBeCloseTo(1 / 2, 10);
+    expect((m.perAbility as any).abstention).toBeUndefined();
+  });
+
+  test("NOT_ATTEMPTED on answerable is reported separately, not as correct", () => {
+    const m = aggregateArmRun("flair", results);
+    // answerable = q1..q4; one NOT_ATTEMPTED
+    expect(m.notAttemptedRateAnswerable).toBeCloseTo(1 / 4, 10);
+    expect(m.incorrectRateAnswerable).toBeCloseTo(1 / 4, 10);
+  });
+
+  test("a judge error is excluded from the accuracy denominator but COUNTED", () => {
+    const withErr = [...results, r({ questionId: "q7", verdict: null, judgeError: "unparseable" })];
+    const m = aggregateArmRun("flair", withErr);
+    expect(m.judgeErrors).toBe(1);
+    expect(m.judged).toBe(6);                       // the error is not judged
+    expect(m.overallAccuracy).toBeCloseTo(3 / 6, 10); // denominator excludes it
+  });
+
+  test("factual F1 only over factual-subset questions that carry extraction", () => {
+    const withF1 = [
+      r({ questionId: "f1", ability: "information-extraction", extraction: { f1: 1, containmentEM: 1, strictEM: 1 } }),
+      r({ questionId: "f2", ability: "temporal-reasoning", extraction: { f1: 0.5, containmentEM: 0, strictEM: 0 } }),
+      // preference has no extraction — excluded from the cross-check
+      r({ questionId: "p1", ability: "single-session-preference", verdict: "CORRECT" }),
+    ];
+    const m = aggregateArmRun("flair", withF1);
+    expect(m.factual.n).toBe(2);
+    expect(m.factual.f1).toBeCloseTo(0.75, 10);
+  });
+});
+
+describe("aggregateArmAcrossRuns — mean±std (pass^k)", () => {
+  test("aggregates overall accuracy across runs with a spread", () => {
+    const run1 = aggregateArmRun("flair", [r({ verdict: "CORRECT" }), r({ verdict: "INCORRECT" })]);
+    const run2 = aggregateArmRun("flair", [r({ verdict: "CORRECT" }), r({ verdict: "CORRECT" })]);
+    const agg = aggregateArmAcrossRuns("flair", [run1, run2]);
+    expect(agg.runs).toBe(2);
+    expect(agg.overallAccuracy.mean).toBeCloseTo((0.5 + 1) / 2, 10);
+    expect(agg.overallAccuracy.std).toBeGreaterThan(0);
+    expect(agg.overallAccuracy.runs).toEqual([0.5, 1]);
+  });
+});


### PR DESCRIPTION
## LongMemEval_s end-to-end benchmark — Layer 2 (Refs #1216)

Builds on #1216-a (PR #1218): reuses the shared `packages/flair-bench/lib/`
(`ingestSessionHistory`, `retrieveContext`, `metrics`, `signed-fetch`) — no
re-implementation of ingest/retrieve. Lives in `test/bench/longmemeval/`
alongside the Layer 1 recall eval, repo-internal (not shipped in the published
`@tpsdev-ai/flair-bench` package).

### Pipeline (per question)
ingest a LongMemEval_s multi-session history into **real Flair** (per-event, the
locked granularity; timestamps preserved) → retrieve via Flair's **real
BM25+RRF** at documented defaults → a **pinned reader** answers from the
retrieved memories → the **pinned local judge** grades with the SimpleQA ternary.

### Four arms (reader + judge identical across all — only context varies)
- **flair** — BM25+RRF hybrid (the headline)
- **vector-only** — same retrieval, BM25 disabled (pure HNSW ablation, via `FLAIR_HYBRID_RETRIEVAL=false`)
- **full-context** — the entire haystack (ceiling **and** memory-validity check)
- **no-context** — only the question (the decisive contamination probe, measured on answerable questions)

### Pinned for local reproducibility (the edge)
- **Dataset:** LongMemEval_s, HF `xiaowu0162/longmemeval` @ `2ec2a557f339b6c0369619b1ed5793734cc87533`, file `longmemeval_s`, sha256 `08d8dad4be43ee2049a22ff5674eb86725d0ce5ff434cde2627e5e8e7e117894`. Judge prompts ported from `xiaowu0162/LongMemEval` @ `9e0b455f4ef0e2ab8f2e582289761153549043fc`.
- **Judge:** `gemma4:31b-it-q8_0` LOCAL on Newton, manifest digest `sha256:53dd8459…d20aef`. temp 0, fixed num_ctx, plaintext verdict (never Ollama JSON mode — non-deterministic at fixed seed).
- **Reader:** `qwen3.6:27b-coding-mxfp8` (Qwen family — a **different** family than the Gemma judge: the self-preference control), digest `sha256:a7185d39…f2780`.

The harness **fails loud** on a digest mismatch, a dataset sha mismatch, or a judge==reader family collision. Everything (incl. the exact grading prompts) is folded into a **content-addressed config hash**.

### Grading
LongMemEval's expert per-task rubrics ported verbatim in substance (off-by-one
leniency for temporal; subset-is-wrong; updated-answer-is-right for
knowledge-update; a rubric for preference; the unanswerable framing for
abstention), reframed onto **CORRECT / INCORRECT / NOT_ATTEMPTED**. The verdict
is a plaintext exact enum (A/B/C); anything unparseable is a **judge error,
never a silent pass**. Headline accuracy = CORRECT/judged; NOT_ATTEMPTED on an
answerable question and abstention questions are broken out separately. An
**independent F1/EM cross-check** (pure SQuAD-style string math, not the judge)
runs on the factual subset.

### Publish gate is structural
The run emits a content-addressed artifact (config hash + per-run hashes + the
numbers, addressed by `artifactHash`) carrying a NOT-FOR-PUBLICATION notice.
There is **no `--publish` flag**. Publishing a number is a separate, gated human
decision recorded against the artifact hash.

### Proofs (this build, real judge on Newton)
- `verify-judge`: gemma4 returns the **correct** ternary verdict, **deterministically** (identical across 3 repeats at temp 0), on 9 probes spanning every task type + abstention (incl. off-by-one temporal and knowledge-update leniency). ALL PASS.
- Unit suite: full `test/unit/` = **4240 pass / 0 fail** (adds 49 new tests for the parser, extraction, metrics, dataset slicing, artifact hashing).
- End-to-end validated on a small slice against real Flair + real gemma4 (results in the build report; a **validation slice, not the publishable run**). The full ≥5×500 run is a separate gated execution.

### Isolation
Fresh ephemeral Harper per run (HOME-isolated to a temp dir — never touches prod
`~/.flair` / `:9926`); runs are independent so the ≥5-run std is real variance.

Do not merge; no reviews requested.
