### PR TITLE
fix(smoke): warm embedding model before golden-path assertions (#1219)

### DIFF
--- a/.changelog/unreleased/fixed-smoke-embedding-cold-start-flake.md
+++ b/.changelog/unreleased/fixed-smoke-embedding-cold-start-flake.md
@@ -1,0 +1,10 @@
+- **Golden-path smoke suite no longer flakes on a cold-start embedding
+  timeout.** The embedding backend loads its model lazily on the first embed
+  call, and `/Health` returning 200 does not mean that load has finished — so on
+  a cold or loaded CI runner the first timed write (Step 2) could pay the model
+  load and exceed `writeMemory`'s 10s client abort, surfacing as
+  `TimeoutError: The operation timed out` at ~10s (flair#1219, seen across
+  #1217/#1221/#1222). The suite now warms the embedding model in `beforeAll` via
+  a throwaway agent+memory write with a generous budget, so the measured
+  golden-path write is always a warm write. Test-only: production
+  `writeMemory`'s 10s timeout is unchanged.

--- a/test/smoke/golden-path.test.ts
+++ b/test/smoke/golden-path.test.ts
@@ -18,6 +18,7 @@
 import { describe, test, expect, beforeAll, afterAll } from "bun:test";
 import {
   resolveFlairInstance,
+  warmEmbeddingModel,
   createAgent,
   writeMemory,
   searchMemories,
@@ -43,10 +44,27 @@ let markerId: string;
 const RANDOM = `smoke-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
 const MARKER_CONTENT = `Smoke test marker ${RANDOM}`;
 
+// flair#1219: cold-start budget for warming the embedding model in beforeAll.
+// The model loads lazily on the first embed call and that load can exceed the
+// per-write 10s client timeout on a cold/loaded CI runner, so the warm-up must
+// be allowed to run well past both the default hook timeout and that 10s abort.
+const WARMUP_TIMEOUT_MS = 120_000;
+
 beforeAll(async () => {
   flair = await resolveFlairInstance();
   console.log(`[golden-path] Flair instance: ${flair.baseUrl}`);
-});
+
+  // flair#1219: warm the embedding model BEFORE any timed step. `/Health` 200
+  // does not imply the embedding model is loaded — it loads lazily on the first
+  // embed call. Paying that cold-start cost here (on a throwaway agent+memory)
+  // guarantees the measured Step-2 write is a warm write, never the one that
+  // absorbs the model load. Without this, Step 2 flaked with
+  // `TimeoutError: The operation timed out` at ~10s on cold CI runners.
+  const warm = await warmEmbeddingModel(flair);
+  console.log(
+    `[golden-path] Embedding model warm (${warm.elapsedMs}ms, ${warm.attempts} attempt(s))`,
+  );
+}, WARMUP_TIMEOUT_MS);
 
 afterAll(async () => {
   if (flair && agentId) {

--- a/test/smoke/helpers/flair-instance.ts
+++ b/test/smoke/helpers/flair-instance.ts
@@ -209,6 +209,85 @@ export async function writeMemory(
 }
 
 /**
+ * Warm the embedding model before the timed golden-path assertions run.
+ *
+ * flair#1219 — the flake this kills: the embedding backend
+ * (harper-fabric-embeddings → llama.cpp) loads the model lazily on the FIRST
+ * embedding call, not at Harper boot. `/Health` returning 200 therefore does
+ * NOT mean the model is ready. On a cold or loaded CI runner that first load
+ * can take well over 10s — longer than `writeMemory`'s client-side
+ * `AbortSignal.timeout(10_000)` on `PUT /Memory` — so whichever timed step is
+ * first (Step 2, Write memory) intermittently died with
+ * `TimeoutError: The operation timed out` at ~10s. It reproduces green
+ * locally where the model is already warm (a warm write is ~3s). Confirmed
+ * across #1217/#1221/#1222.
+ *
+ * This helper pays the cold-start cost UP FRONT, on a throwaway agent+memory,
+ * with a generous budget and a couple of retries, so the model is hot before
+ * the measured Step-2 write ever runs. It exercises the exact same path the
+ * timed step does (create agent → PUT /Memory, admin-authed), so it warms
+ * precisely what Step 2 needs. It creates and deletes its own throwaway agent,
+ * leaving no residue in the instance.
+ *
+ * NOTE: this deliberately does NOT weaken `writeMemory`'s 10s timeout — that
+ * timeout is a real client-side guard and stays put. The fix is to ensure the
+ * measured write is never the one that pays for the model load.
+ */
+export async function warmEmbeddingModel(
+  flair: FlairInstance,
+  opts?: { timeoutMs?: number; attempts?: number },
+): Promise<{ elapsedMs: number; attempts: number }> {
+  const timeoutMs = opts?.timeoutMs ?? 90_000;
+  const maxAttempts = opts?.attempts ?? 3;
+
+  // A real throwaway agent so the write is fully valid and reaches the
+  // server-side embedding step (Memory.put → getEmbedding) rather than being
+  // rejected before it. Mirrors Step 1 + Step 2 of the golden path.
+  const warmAgentId = await createAgent(flair.opsUrl, flair.authHeader);
+  const t0 = performance.now();
+  let lastErr: unknown;
+
+  try {
+    for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+      const memId = `${warmAgentId}-warmup-${Date.now()}-${randomBytes(4).toString("hex")}`;
+      const body = {
+        id: memId,
+        agentId: warmAgentId,
+        content: `embedding warm-up ${memId}`,
+        type: "memory",
+        durability: "ephemeral",
+        createdAt: new Date().toISOString(),
+      };
+      try {
+        // Generous per-attempt budget: this call is EXPECTED to absorb the
+        // cold model load, so it must not use writeMemory's 10s abort.
+        const res = await fetch(`${flair.baseUrl}/Memory/${encodeURIComponent(memId)}`, {
+          method: "PUT",
+          headers: { "Content-Type": "application/json", Authorization: flair.authHeader },
+          body: JSON.stringify(body),
+          signal: AbortSignal.timeout(timeoutMs),
+        });
+        if (res.ok) {
+          return { elapsedMs: Math.round(performance.now() - t0), attempts: attempt };
+        }
+        lastErr = new Error(`HTTP ${res.status} ${await res.text().catch(() => "")}`);
+      } catch (err) {
+        lastErr = err;
+      }
+      // Brief backoff before retrying a still-loading model.
+      if (attempt < maxAttempts) await new Promise(r => setTimeout(r, 1000));
+    }
+    throw new Error(
+      `warmEmbeddingModel: embedding model did not become ready within ` +
+      `${maxAttempts} attempt(s) @ ${timeoutMs}ms each: ${String(lastErr)}`,
+    );
+  } finally {
+    // Never let a warm-up leak an agent into the instance, even on failure.
+    await flair.cleanup([warmAgentId]).catch(() => {});
+  }
+}
+
+/**
  * Search memories via the Flair REST API.
  */
 export async function searchMemories(


### PR DESCRIPTION
## What

Kills the recurring Smoke Tests (Golden Path) flake: Step 2 (Write memory) intermittently died with `TimeoutError: The operation timed out` at ~10s on cold CI runners (hit #1217/#1221/#1222, masking real signal).

## Root cause

The embedding backend (harper-fabric-embeddings -> llama.cpp) loads its model **lazily on the first embed call**, not at Harper boot. The boot probe that kicks off the load is fire-and-forget and does **not** gate `/Health` — so `/Health` can return 200 while the model is still loading in the background (`resources/embeddings-provider.ts`: `register()` "loads the model in the background and retries readiness on the next call").

The CI smoke gate waits only for `/Health` 200, then runs the tests. The first timed write (Step 2) is the first real `getEmbedding`, so it blocks on the remaining cold model load. On a cold/loaded runner that exceeds the smoke helper's client-side `AbortSignal.timeout(10_000)` on `PUT /Memory` -> the fetch aborts at ~10s. Reproduces green locally where the model is already warm (a warm write is ~3s).

## Fix (test-side only)

Warm the embedding model in `beforeAll` via a throwaway agent + memory write with a generous budget (`warmEmbeddingModel` in `test/smoke/helpers/flair-instance.ts`), so the measured Step-2 write is always a warm write. The warm-up exercises the exact same path (create agent -> `PUT /Memory`, admin-authed) and cleans up its throwaway agent.

**Production `writeMemory`'s 10s timeout is deliberately unchanged** — that guard is real; the fix is to ensure the measured write is never the one that pays for the model load.

## Verification

HOME-isolated ephemeral Harper (fresh **cold** boot per run, OS-assigned random ports, model not pre-warmed), never touching prod :9926.

- **Failure reproduced:** injecting a 12s cold first-embed, the **baseline** (no warm-up) fails Step 2 at **10002ms** with `TIMEOUT_ERR` — the exact reported symptom — cascading Steps 3-4.
- **Fix proven:** with the same 12s injection, the warm-up step absorbs the full 12s (`warmUp=12051ms`/`12069ms`) and Step 2 passes (2/2 green).
- **Stability:** 5 organic cold-boot runs -> **5/5 green**, warm-up runs before Step 2 every time.
- Fast unit suite: **4219 pass / 0 fail** (product diff is empty; change is test-only).
- No orphaned Harpers; prod :9926 healthy throughout.

Refs #1219 (fixes flake #1 of 2 — the Socket Firewall ECONNRESET flake #2 remains open)