### PR TITLE
fix(bootstrap): teammate-findings budget blowout + the invariant that catches it (Refs #1199 #1182; Closes #1225)

### DIFF
--- a/.changelog/unreleased/added-bootstrap-empty-container-hints.md
+++ b/.changelog/unreleased/added-bootstrap-empty-container-hints.md
@@ -1,0 +1,13 @@
+- **`bootstrap` now explains WHY any empty structured container is empty.** An
+  empty `events: []` was byte-indistinguishable from the 0.44.8 regression where
+  events were silently dropped — a connector could only tell the difference by
+  diffing against a previous payload (flair#1182). The self-describing rule that
+  already covered `predicted` is now applied across the containers: when a
+  container ships empty the payload carries a short hint naming the reason and
+  what fills it — `eventsHint`, `teammateFindingsHint` (alongside the existing
+  `predictedHint`) — present only when that container is empty, so a healthy
+  payload is unchanged. With `includeTrust: true`, a trust entry whose
+  `matchQuality` is `null` now carries a `matchQualityNote` saying why: on the
+  lifecycle sections (`permanent`/`recent`/`predicted`) a null band is correct —
+  those are a window load, not a retrieval surface — not a scoring failure on
+  your own records (flair#1225, documented in `docs/mcp-clients.md`).

--- a/.changelog/unreleased/fixed-connector-teammate-findings-budget.md
+++ b/.changelog/unreleased/fixed-connector-teammate-findings-budget.md
@@ -1,0 +1,14 @@
+- **`bootstrap` over the /mcp connector now respects `maxTokens` when teammate
+  findings are present.** The token budget charged each memory and teammate
+  finding its short *prose* line, but on the connector path (where the prose
+  `context` is a pointer) it is the heavier *structured* container object that
+  actually ships — and that object is what `tokenEstimate` measures. Teammate
+  findings, which carry an id, two timestamps and a source, ran well over their
+  prose line, so several rode outside the enforced budget: a `maxTokens: 4000`
+  bootstrap could serialize at ~5300 (+33%) with no org events involved
+  (flair#1199). The selector now charges each item what it actually ships on the
+  requested surface — the structured object on the connector path, the prose line
+  on the REST/CLI prose path (which keeps its 0.44.6 selection capacity, flair#1207
+  unchanged) — so a connector's payload stays within `maxTokens` plus a small,
+  fixed JSON-scaffolding tolerance. A teammate-heavy conformance fixture now makes
+  the budget-cap invariant catch this class (it fails if the fix is reverted).

--- a/docs/mcp-clients.md
+++ b/docs/mcp-clients.md
@@ -240,6 +240,14 @@ Writes are scoped per-agent (your `FLAIR_AGENT_ID`) and enforced by Flair's serv
 
 Which memories are non-private is decided at write time, and the default is not "shared". `memory_store` defaults `durability` to `standard`, and the server derives visibility from durability — `permanent`/`persistent` → `shared`, `standard`/`ephemeral` → `private` — so **a bare `memory_store` call writes an owner-only memory that no other agent can read.** Pass `visibility: "shared"` (or `"private"`, to be explicit) to say what you mean; the tool reports the visibility the write actually landed on so an agent can confirm it rather than assume.
 
+### Reading the `bootstrap` payload
+
+`bootstrap` returns the canonical structured containers — `soul`, `memories`, `predicted`, `teammateFindings`, `events` — plus counts and a `tokenEstimate`. The containers are **always present** (empty `[]`/`{}` when there's nothing), so an empty container is distinguishable from an unsupported one.
+
+**Empty containers say why they're empty (flair#1182).** When a structured container ships empty, the payload carries a short hint naming the reason and what fills it — `eventsHint`, `teammateFindingsHint`, `predictedHint`. This is present *only* when the container is empty, so a deliberately-empty container is never confused with a silent drop (a connector never has to diff against a previous payload to tell the two apart).
+
+**`matchQuality` is null on lifecycle sections — by design (flair#1225).** With `includeTrust: true`, each included memory carries a per-memory trust block, section-tagged, whose `matchQuality` is a `strong`/`moderate`/`breadcrumb` confidence band. On the **lifecycle sections** (`permanent`, `recent`, `predicted`) `matchQuality` is `null`: those are a lifecycle-window *load*, not a retrieval surface, so there is no relevance score to band. This is **correct, not a scoring failure** — an own-recent `null` next to a teammate's band does not mean your own records "scored worse". A retrieval band is only meaningful on the retrieval sections (`relevant`, `teammate`). The entry's `section` field makes this legible, and a `matchQualityNote` on any null entry states the reason inline.
+
 ---
 
 ## Configuration reference

--- a/resources/MemoryBootstrap.ts
+++ b/resources/MemoryBootstrap.ts
@@ -101,20 +101,35 @@ import { estimateTokens } from "./token-estimate.js";
  *
  *   CAP CONTRACT: `maxTokens` is the HARD cap on CONTENT SELECTION — the shared
  *   `tokenBudget` starts at `maxTokens` and every admitted soul/memory/finding
- *   line AND every org event (flair#1199 — events are content too; before this
- *   they were assembled but NEVER charged, so a maxTokens=4000 request serialized
- *   at 6286) is gated against the remaining budget, so the sum of selected CONTENT
- *   never exceeds `maxTokens`. `tokenEstimate` HONESTLY reports the real serialized
- *   payload (`JSON.stringify(responseBody)`), which includes the FIXED structured-
- *   container JSON scaffolding (keys/braces, counters, the sections map) and so may
- *   exceed `maxTokens` slightly by that bounded overhead — measurement is decoupled
- *   from budgeting, but the overhead is now scaffolding ONLY, never uncounted
- *   content. The connector-conformance suite asserts tokenEstimate <= maxTokens
- *   within a small tolerance for that scaffolding. flair#1207: #1199 had ALSO
- *   folded a per-item structured overhead + a scaffolding reserve INTO the
- *   selection budget, which silently shrank recall below 0.44.6 for the same
- *   `maxTokens`; that per-item overhead is a reporting concern (already captured by
- *   `tokenEstimate`) and no longer shrinks the content budget.
+ *   AND every org event (flair#1199 — events are content too; before this they
+ *   were assembled but NEVER charged, so a maxTokens=4000 request serialized at
+ *   6286) is gated against the remaining budget, so the sum of selected CONTENT
+ *   never exceeds `maxTokens`. Each item is charged the cost of what it ACTUALLY
+ *   SHIPS on the requested surface (see contentCost): on the /mcp connector path
+ *   (includeContext=false) the prose `context` is a pointer, so only the
+ *   STRUCTURED container object ships and is charged; on the REST/CLI prose path
+ *   (includeContext=true) the prose IS the shipped surface and is charged (0.44.6
+ *   capacity — flair#1207). `tokenEstimate` HONESTLY reports the real serialized
+ *   payload (`JSON.stringify(responseBody)`). On the connector path — where the
+ *   selection charge and `tokenEstimate` measure the SAME structured bytes —
+ *   `tokenEstimate` exceeds `maxTokens` only by the FIXED JSON scaffolding
+ *   (keys/braces, counters, the sections map, hints); the connector-conformance
+ *   budgetCap asserts tokenEstimate <= maxTokens within a small tolerance for
+ *   exactly that scaffolding. On the prose path the payload ALSO carries the
+ *   structured mirror, so `tokenEstimate` may exceed `maxTokens` by that mirror —
+ *   that overage is honest measurement, and shrinking prose selection to hide it
+ *   is the flair#1207 regression (below). flair#1199 (0.44.11): charging the
+ *   PROSE line but shipping the heavier STRUCTURED object on the /mcp path let
+ *   teammate findings ride OUTSIDE the enforced budget (soulTokens 377 +
+ *   memoryTokens 3574 = 3951 prose, just under a 4000 cap, yet tokenEstimate 5337
+ *   = +33%; teammateFindingsIncluded crept 4→5) — fixed by charging structured
+ *   on the connector path. flair#1207: #1199 had ALSO folded a per-item
+ *   structured overhead + a scaffolding reserve INTO the selection budget, which
+ *   silently shrank recall below 0.44.6 for the same `maxTokens`; that flat
+ *   per-item overhead is a reporting concern (already captured by `tokenEstimate`)
+ *   and no longer shrinks the content budget — the 0.44.11 fix charges the
+ *   item's REAL shipped serialization, not a flat surcharge, and only on the path
+ *   where that serialization is the shipped surface.
  *
  *   COUNT CONTRACT (flair#1207): `memoriesIncluded + memoriesTruncated <=
  *   memoriesAvailable` — included and truncated are disjoint sets of UNIQUE own
@@ -130,6 +145,12 @@ import { estimateTokens } from "./token-estimate.js";
 // Collision surfacing (flair#681) tunables.
 const COLLISION_WINDOW_DAYS = 7;
 const MAX_COLLISION_ENTRIES = 10;
+
+// flair#1201/#1225 — trust-block sections that are a lifecycle-window LOAD, not
+// a retrieval surface. A trust entry from one of these carries `matchQuality:
+// null` (no relevance score to band), which is CORRECT (Kern's #1220 ruling),
+// never a scoring failure — see the `matchQualityNote` in the response tail.
+const LIFECYCLE_SECTIONS = new Set(["permanent", "recent", "predicted"]);
 
 // flair#1199/#1206 — the default cap on how many org events bootstrap ships.
 // Overridable per-request via `maxEvents`. Event slots are scarce AND (as of
@@ -401,6 +422,36 @@ export class BootstrapMemories extends Resource {
       section,
     });
 
+    // flair#1199 (0.44.11) — the REAL cost an admitted content item adds to the
+    // serialized payload the caller RECEIVES, which is exactly what
+    // `tokenEstimate` measures. This is the fix for the teammate-findings
+    // budget blowout: the selector used to charge every memory/finding its
+    // PROSE line (`formatMemory`) but, on the /mcp connector path, ship the
+    // heavier STRUCTURED container object — and `tokenEstimate` measures the
+    // structured object. A teammate finding carries `id` + TWO ISO timestamps +
+    // `source` + `section` + JSON field names/quotes that the prose line does
+    // not, so the shipped object runs ~1.5–1.7× its prose line. Charging prose
+    // but shipping structured let several teammate findings ride OUTSIDE the
+    // enforced budget: a maxTokens=4000 bootstrap reported soulTokens 377 +
+    // memoryTokens 3574 = 3951 (prose, just under cap) yet serialized at 5337
+    // (+33%), and teammateFindingsIncluded crept 4→5. So charge what SHIPS:
+    //   - /mcp connector path (includeContext=false): the prose `context` is a
+    //     compact pointer (no bodies), so ONLY the structured container ships —
+    //     charge its serialized size. Now the sum of admitted content ≈
+    //     `tokenEstimate` minus the FIXED JSON scaffolding, so `tokenEstimate`
+    //     stays within maxTokens + the small scaffolding tolerance.
+    //   - REST/CLI prose path (includeContext=true): the prose IS the primary
+    //     shipped surface and flair#1207 deliberately fixed the selection budget
+    //     at 0.44.6 (prose) capacity — `tokenEstimate` is HONEST there and may
+    //     exceed maxTokens by the structured mirror it also ships. Charging
+    //     structured on THAT path would re-shrink prose recall below 0.44.6
+    //     (the exact #1207 regression). So keep charging prose on the prose
+    //     path. This is "fix the budget INPUT, not the cap": the figure the
+    //     selector tests against maxTokens is now the figure that becomes
+    //     `tokenEstimate` on each path.
+    const contentCost = (structured: unknown, proseLine: string): number =>
+      includeContext ? estimateTokens(proseLine) : estimateTokens(JSON.stringify(structured));
+
     // --- 1. Soul records (budgeted — prioritized by key importance) ---
     // Soul is who you are, but we still need to respect token budgets.
     // Workspace files (SOUL.md, AGENTS.md) can be massive — they're already
@@ -647,10 +698,14 @@ export class BootstrapMemories extends Resource {
     const permanent = permanentRows.filter((m) => !permanentSupersededIds.has(m.id));
     for (const m of permanent) {
       const line = formatMemory(m, agentId);
-      const cost = estimateTokens(line); // #1207 — prose-line cost only; overhead is a reporting concern (tokenEstimate), not a selection constraint
+      const struct = leanMemory(m, "permanent");
+      // #1199 (0.44.11) — charge what SHIPS (structured on the /mcp path, prose
+      // on the REST path); see contentCost. #1207 stays honored: on the prose
+      // path this is still the prose-line cost, so REST recall is unchanged.
+      const cost = contentCost(struct, line);
       if (cost <= tokenBudget) {
         sections.permanent.push(line);
-        includedOwnMemories.push(leanMemory(m, "permanent"));
+        includedOwnMemories.push(struct);
         if (includeTrust) includedTrustMemories.push({ m, section: "permanent" });
         tokenBudget -= cost;
         includedOwnIds.add(m.id); // #1207 — count by unique own-memory id
@@ -715,13 +770,14 @@ export class BootstrapMemories extends Resource {
     let recentSpent = 0;
     for (const m of recent) {
       const line = formatMemory(m, agentId);
-      const cost = estimateTokens(line); // #1207 — prose-line cost only; overhead is a reporting concern (tokenEstimate), not a selection constraint
+      const struct = leanMemory(m, "recent");
+      const cost = contentCost(struct, line); // #1199 (0.44.11) — charge what ships; see contentCost
       if (recentSpent + cost > recentBudget) {
         truncatedOwnIds.add(m.id); // #1207 — budget-skip; may still be admitted later via the task-relevant loop (deduped at the end)
         continue;
       }
       sections.recent.push(line);
-      includedOwnMemories.push(leanMemory(m, "recent"));
+      includedOwnMemories.push(struct);
       if (includeTrust) includedTrustMemories.push({ m, section: "recent" });
       recentSpent += cost;
       tokenBudget -= cost;
@@ -761,13 +817,14 @@ export class BootstrapMemories extends Resource {
       let predictedSpent = 0;
       for (const m of subjectMemories) {
         const line = formatMemory(m, agentId);
-        const cost = estimateTokens(line); // #1207 — prose-line cost only; overhead is a reporting concern (tokenEstimate), not a selection constraint
+        const struct = leanMemory(m, "predicted");
+        const cost = contentCost(struct, line); // #1199 (0.44.11) — charge what ships; see contentCost
         if (predictedSpent + cost > predictedBudget) {
           truncatedOwnIds.add(m.id); // #1207 — budget-skip (deduped against inclusions at the end)
           continue;
         }
         sections.predicted.push(line);
-        includedPredicted.push(leanMemory(m, "predicted"));
+        includedPredicted.push(struct);
         if (includeTrust) includedTrustMemories.push({ m, section: "predicted" });
         predictedSpent += cost;
         tokenBudget -= cost;
@@ -943,7 +1000,29 @@ export class BootstrapMemories extends Resource {
         // section double-spends.
         for (const { memory: m } of scored) {
           const line = formatMemory(m, agentId);
-          const cost = estimateTokens(line); // #1207 — prose-line cost only; overhead is a reporting concern (tokenEstimate), not a selection constraint
+          // flair#1199 (0.44.11) — build the STRUCTURED container object BEFORE
+          // the budget check so the finding is charged the cost of what actually
+          // ships (structured on the /mcp path), not its cheaper prose line. A
+          // teammate finding's structured object (id + two ISO timestamps +
+          // source + section) runs well over its prose line, and it — not the
+          // prose — is what `tokenEstimate` measures on the connector path. This
+          // is the fix for the teammate-findings blowout: charging prose but
+          // shipping structured let extra findings ride outside the enforced
+          // budget (see contentCost). Cross-agent findings (`m._source` set)
+          // ship in `teammateFindings`; own findings in `memories`.
+          const struct = m._source
+            ? {
+                id: m.id,
+                content: m.content,
+                durability: m.durability ?? null,
+                createdAt: m.createdAt ?? null,
+                updatedAt: m.updatedAt ?? null,
+                subject: m.subject ?? null,
+                source: m._source,
+                section: "teammate",
+              }
+            : leanMemory(m, "relevant");
+          const cost = contentCost(struct, line);
           if (cost > tokenBudget) {
             // flair#1207 — a size-skip in the score-ordered task-relevant loop
             // is no longer silent: record it on the denominator matching the
@@ -962,16 +1041,7 @@ export class BootstrapMemories extends Resource {
             // off. Counted separately (teammateFindingsIncluded), NOT into
             // memoriesIncluded — that different-denominator mix is what let
             // included exceed available.
-            includedTeammateFindings.push({
-              id: m.id,
-              content: m.content,
-              durability: m.durability ?? null,
-              createdAt: m.createdAt ?? null,
-              updatedAt: m.updatedAt ?? null,
-              subject: m.subject ?? null,
-              source: m._source,
-              section: "teammate",
-            });
+            includedTeammateFindings.push(struct);
             if (includeTrust) includedTrustMemories.push({ m, section: "teammate" });
             tokenBudget -= cost;
             teammateFindingsIncluded++;
@@ -979,7 +1049,7 @@ export class BootstrapMemories extends Resource {
             sections.relevant.push(line);
             // flair#1182 — own task-relevant records join the `memories`
             // container.
-            includedOwnMemories.push(leanMemory(m, "relevant"));
+            includedOwnMemories.push(struct);
             if (includeTrust) includedTrustMemories.push({ m, section: "relevant" });
             tokenBudget -= cost;
             includedOwnIds.add(m.id); // #1207 — count by unique own-memory id
@@ -1303,9 +1373,30 @@ export class BootstrapMemories extends Resource {
     // absent ⇒ the response is byte-identical to pre-slice-1. flair#1201 — each
     // entry carries its `section` so `matchQuality: null` on a lifecycle section
     // reads as "not a retrieval surface", not as a scoring failure on the
-    // caller's own records.
+    // caller's own records. flair#1225 (0.44.11) — the null on a lifecycle
+    // section is now SELF-EXPLAINING (matchQualityNote below), not just legible
+    // via `section`.
     const trust = includeTrust
-      ? includedTrustMemories.map(({ m, section }) => ({ id: m.id, section, ...buildTrustBlock(m) }))
+      ? includedTrustMemories.map(({ m, section }) => {
+          const block = buildTrustBlock(m);
+          // flair#1225 — Kern ruled (on #1220) that a null `matchQuality` on an
+          // own-recent (lifecycle) entry is CORRECT: lifecycle sections
+          // (permanent/recent/predicted) are a window LOAD, not a retrieval
+          // surface, so there is no similarity to band — the null means "not
+          // scored here", never a scoring failure on the caller's own records
+          // (the #1201 misread: own-recent null beside a teammate band). Behavior
+          // is unchanged (per Kern); this only makes the null self-describing in
+          // the payload — Fix 3's "any absent field says why" — so a connector
+          // reads it right without knowing the #1201 contract.
+          const matchQualityNote = block.matchQuality === null
+            ? (LIFECYCLE_SECTIONS.has(section)
+                ? `matchQuality is null because '${section}' is a lifecycle-window section, not a retrieval `
+                  + `surface — there is no relevance score to band. This is correct (per flair#1225), not a scoring failure.`
+                : "matchQuality is null because no semantic similarity was attached to this result "
+                  + "(e.g. a by-id read or a keyword-only degraded match).")
+            : undefined;
+          return { id: m.id, section, ...block, ...(matchQualityNote ? { matchQualityNote } : {}) };
+        })
       : undefined;
 
     // flair#744 slice 2 — opt-in abstention verdict for the task-relevance
@@ -1349,6 +1440,39 @@ export class BootstrapMemories extends Resource {
         + `subjects — it fills as you store memories tagged with these subjects.`
       : undefined;
 
+    // flair#1182 (0.44.11) — GENERALIZE the empty-container "say why" rule
+    // beyond predictedHint. `events: []` (deliberate no-op filtering) was
+    // byte-indistinguishable from the 0.44.8 silent-drop regression, where a
+    // container that SHOULD have had content shipped empty — a connector could
+    // only tell the difference by diffing against a previous payload. The rule
+    // (now applied consistently across the structured containers): any container
+    // that ships EMPTY carries a short hint naming WHY it is empty and what
+    // fills it, so "deliberately empty" is never confused with "silently
+    // dropped". Present ONLY when the container is empty (a populated container
+    // needs no hint), so a healthy payload is unchanged.
+
+    // events: [] — no org event in the lookback window was relevant to the
+    // caller after zero-row no-op auto-heal filtering (#1200). Present-but-empty
+    // by design, not a drop.
+    const eventsHint = includedEvents.length === 0
+      ? "No org events in the lookback window were relevant to you (org-wide, or targeted at you) "
+        + "after zero-row no-op auto-heal filtering. This container is present-but-empty by design, not dropped."
+      : undefined;
+
+    // teammateFindings: [] — name WHICH legitimate empty this is (no task → no
+    // retrieval; matched-but-budget-truncated; or nothing cleared the relevance
+    // floor), so it never reads as a silent drop.
+    const teammateFindingsHint = includedTeammateFindings.length === 0
+      ? (!taskProvided
+          ? "No teammateFindings: cross-agent findings are retrieved against your currentTask, and none was provided. "
+            + "Pass currentTask to populate this."
+          : teammateFindingsTruncated > 0
+            ? `No teammateFindings fit the token budget: ${teammateFindingsTruncated} relevant cross-agent finding(s) `
+              + "cleared the relevance floor but were budget-truncated. Raise maxTokens to include them."
+            : "No cross-agent (teammate) memory cleared the task-relevance floor for this currentTask. "
+              + "This container is present-but-empty by design, not dropped.")
+      : undefined;
+
     const responseBody: Record<string, unknown> = {
       context,
       // flair#1182 (part 1) — always-present self-describing keys: who the
@@ -1373,6 +1497,11 @@ export class BootstrapMemories extends Resource {
       events: includedEvents,
       ...(currentTaskHint ? { currentTaskHint } : {}),
       ...(predictedHint ? { predictedHint } : {}),
+      // flair#1182 (0.44.11) — empty-container hints, present only when the
+      // container ships empty (see above), so a deliberately-empty container is
+      // never confused with a silent drop.
+      ...(eventsHint ? { eventsHint } : {}),
+      ...(teammateFindingsHint ? { teammateFindingsHint } : {}),
       ...(trust ? { trust } : {}),
       ...(abstention ? { abstention } : {}),
       sections: {
@@ -1425,16 +1554,20 @@ export class BootstrapMemories extends Resource {
     // the real serialized size. Every CONTENT section — soul, memories, findings,
     // AND events (flair#1199) — is now gated against the shared `maxTokens`
     // budget, so no section blows the budget with uncounted content the way the
-    // 0.44.9 events array did (maxTokens=4000 → 6286). tokenEstimate may still
-    // exceed `maxTokens` slightly, by the FIXED structural JSON scaffolding
-    // (container keys/braces, counters, sections map, char/4 rounding) — that is
-    // genuine payload the caller pays for, and it is small and bounded, NOT
-    // uncounted content. The connector-conformance suite asserts
-    // tokenEstimate <= maxTokens within a small tolerance for exactly that
-    // scaffolding. Do NOT "fix" a small over-maxTokens tokenEstimate by shrinking
-    // memory selection — that is the #1199→#1207 regression (it dropped relevant
-    // findings, charging a per-item overhead against the content budget). If the
-    // real payload consistently overruns for a use case, raise `maxTokens`.
+    // 0.44.9 events array did (maxTokens=4000 → 6286). flair#1199 (0.44.11): on
+    // the /mcp connector path each content item is charged its STRUCTURED shipped
+    // cost — the same bytes tokenEstimate measures — so tokenEstimate exceeds
+    // `maxTokens` only by the FIXED structural JSON scaffolding (container
+    // keys/braces, counters, sections map, hints, char/4 rounding): genuine
+    // payload the caller pays for, small and bounded, NOT uncounted content. The
+    // connector-conformance suite asserts tokenEstimate <= maxTokens within a
+    // small tolerance for exactly that scaffolding. On the PROSE path
+    // (includeContext=true) the payload ALSO carries the structured mirror, so
+    // tokenEstimate legitimately exceeds `maxTokens` by that mirror — do NOT
+    // "fix" THAT overrun by shrinking prose selection: that is the #1199→#1207
+    // regression (it dropped relevant findings, charging a flat per-item overhead
+    // against the content budget). If the real payload consistently overruns for
+    // a use case, raise `maxTokens`.
     const tokenEstimate = estimateTokens(JSON.stringify(responseBody));
     return { ...responseBody, tokenEstimate };
   }

--- a/test/integration/bootstrap-payload-quality-1199.test.ts
+++ b/test/integration/bootstrap-payload-quality-1199.test.ts
@@ -36,6 +36,9 @@ let appDir: string;
 const sfx = Date.now().toString(36);
 const AGENT = `boot1199-${sfx}`;
 const TEAMMATE = `boot1199-mate-${sfx}`;
+// A dedicated agent for test (b)'s permanent-memory FLOOD, so it never pollutes
+// AGENT's store for the later events/trust tests (see (b) for the full rationale).
+const BULK_AGENT = `boot1199-bulk-${sfx}`;
 const SOUL_ROLE = `Payload-quality test subject ${sfx}`;
 
 // Distinctive markers so an assertion can locate a specific body unambiguously.
@@ -62,9 +65,9 @@ async function fleet(op: string, body: Record<string, unknown> = {}): Promise<an
   return JSON.parse(text);
 }
 
-/** Call the shipped /mcp bootstrap wrapper as AGENT. */
-async function bootstrap(args: Record<string, unknown> = {}): Promise<any> {
-  const res = await fleet("mcpTool", { agentId: AGENT, tool: "bootstrap", args, isAdmin: false });
+/** Call the shipped /mcp bootstrap wrapper (as AGENT by default). */
+async function bootstrap(args: Record<string, unknown> = {}, agentId: string = AGENT): Promise<any> {
+  const res = await fleet("mcpTool", { agentId, tool: "bootstrap", args, isAdmin: false });
   expect(res.ok, `bootstrap failed: ${JSON.stringify(res).slice(0, 500)}`).toBe(true);
   return res.value;
 }
@@ -182,9 +185,17 @@ describe("flair#1199/#1200/#1201 — bootstrap payload quality", () => {
     // Seed enough permanent content to overflow the cap even at the RESTORED
     // (0.44.6) selection capacity — so the cap demonstrably engages after the
     // #1207 budget restore (60 records × ~90 prose tokens ≫ the 3000 budget).
+    // Owned by a DEDICATED agent (BULK_AGENT), not AGENT: the greedy permanent
+    // section fills the whole budget with this flood, and since 0.44.11 charges
+    // the /mcp path its STRUCTURED shipped cost (heavier than the prose line), a
+    // 60-permanent flood in AGENT's store would starve the events/trust sections
+    // the LATER (d')/(e) tests read (they bootstrap AGENT). Scoping it here keeps
+    // AGENT's store clean for those tests — the same isolation discipline the
+    // teammate-budget fixture uses for its non-private findings.
+    await fleet("register", { id: BULK_AGENT });
     for (let i = 0; i < 60; i++) {
       await seedInsert("Memory", {
-        id: `${AGENT}-bulk-${i}-${randomUUID()}`, agentId: AGENT,
+        id: `${BULK_AGENT}-bulk-${i}-${randomUUID()}`, agentId: BULK_AGENT,
         content: `bulk permanent memory ${i} ${sfx} ` + "lorem ipsum dolor sit amet ".repeat(12),
         durability: "permanent", visibility: "private", createdAt: nowIso(), updatedAt: nowIso(),
         validFrom: nowIso(),
@@ -192,7 +203,7 @@ describe("flair#1199/#1200/#1201 — bootstrap payload quality", () => {
     }
 
     const maxTokens = 3000;
-    const body = await bootstrap({ maxTokens });
+    const body = await bootstrap({ maxTokens }, BULK_AGENT);
 
     // Honesty: tokenEstimate equals estimateTokens over the exact serialized body
     // the caller received (minus the wrapper-appended flairVersion + the

--- a/test/integration/bootstrap-teammate-budget-1199.test.ts
+++ b/test/integration/bootstrap-teammate-budget-1199.test.ts
@@ -1,0 +1,177 @@
+// ─── flair#1199 (0.44.11) — the TEAMMATE-heavy budget-cap fixture the 0.44.10 ──
+//     conformance suite MISSED (the invariant that now catches this class) ──────
+//
+// 0.44.10 added the budgetCap conformance invariant (tokenEstimate <= maxTokens +
+// tolerance) but its fixture is EVENTS-heavy (AGENT_BUDGET in
+// mcp-connector-conformance-suite.test.ts). That caught the #1199 events blowout
+// but is LEAN on teammate findings — so the REAL 0.44.10 blowout slipped past:
+// on the /mcp connector path a teammate finding was charged its cheap PROSE line
+// against the budget, but the heavier STRUCTURED container object is what SHIPS
+// and what `tokenEstimate` measures. A maxTokens=4000 bootstrap reported
+// soulTokens 377 + memoryTokens 3574 = 3951 (prose, just under cap) yet
+// serialized at 5337 (+33%), with events at ZERO, as teammateFindingsIncluded
+// crept 4→5 — the findings rode OUTSIDE the enforced budget.
+//
+// This fixture makes the budgetCap invariant BITE on the teammate class: MANY
+// cross-agent, NON-PRIVATE, real-embedded findings clustered on ONE distinct
+// task, bootstrapped by an agent that owns NOTHING, over the SHIPPED /mcp
+// `bootstrap` wrapper (TOOLS.bootstrap.impl via the inproc fixture's mcpTool op —
+// the includeContext=false connector surface where the structured object is the
+// only content that ships). It runs in its OWN HOME-isolated Harper: the
+// non-private findings are org-readable, so seeding them in the shared
+// conformance store would leak into every OTHER agent's task-relevant retrieval
+// (verified: they cleared the 0.3 relevance floor even against an unrelated
+// "budget sweep" task and starved that fixture's events). Isolation keeps the
+// class-under-test contained — the same reason bootstrap-teammate-findings-e2e
+// and bootstrap-budget-regression-1207 each run their own Harper.
+//
+// MUTATION CHECK (the load-bearing deliverable): with Fix 1 (charge the
+// structured shipped cost on the /mcp path) tokenEstimate stays within
+// maxTokens*(1+tolerance) → the budgetCap assertion PASSES. Revert Fix 1 (charge
+// the prose line) → extra findings ride in on the cheap charge while the heavy
+// structured objects ship anyway → tokenEstimate blows the ceiling → the
+// budgetCap assertion FAILS. Proven both directions in this session.
+import { describe, expect, test, beforeAll, afterAll } from "bun:test";
+import { mkdtemp, rm, mkdir, cp, symlink } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { startHarper, stopHarper, HarperInstance } from "../helpers/harper-lifecycle";
+// The SHIPPED contract — the budgetCap tolerance is read straight off it, so this
+// fixture asserts the SAME invariant the conformance suite declares (and can
+// never drift from it).
+import { TOOLS } from "../../resources/mcp-tools";
+
+const REPO_ROOT = process.cwd();
+const FIXTURE = join(REPO_ROOT, "test", "fixtures", "inproc-app");
+
+let harper: HarperInstance;
+let appDir: string;
+
+const sfx = Date.now().toString(36);
+// The bootstrapping agent OWNS NOTHING — so the whole payload is teammate
+// findings, isolating the class under test.
+const AGENT_TM = `tmbudget-${sfx}`;
+// The author of the cross-agent, non-private findings.
+const AGENT_TM_SRC = `tmbudget-src-${sfx}`;
+
+const TM_TASK =
+  "Coral reef bioacoustics monitoring: hydrophone drift correction and buoy " +
+  "calibration for the reef soundscape reconciliation.";
+
+// 40 distinct ~400-char findings, all in the reef-bioacoustics domain (heavy
+// shared vocabulary so each clears bootstrap's raw cosine floor of 0.3 against
+// TM_TASK), each with a per-index distinct clause so Memory.ts's write-time
+// dedup co-gate (cosine >= 0.95 AND lexical Jaccard >= 0.5) never collapses two.
+// 40 so the budget BINDS at BOTH maxTokens 2000 and 4000 (more findings than
+// either budget can hold), which is what makes the cap load-bearing and the
+// empirical maxTokens=4000 → 5337 blowout reproducible.
+const TM_MARKER = `REEF-FINDING-${sfx}`;
+const TM_FINDINGS = Array.from({ length: 40 }, (_, i) =>
+  `${TM_MARKER}-${i}: Coral reef bioacoustics monitoring buoy ${i} logged a hydrophone ` +
+  `drift of ${100 + i * 7} basis points during calibration window ${i}; the reef soundscape ` +
+  `reconciliation flagged hydrophone gain batch ${i} for a manual buoy calibration review ` +
+  `against the drift-correction baseline. Distinct note ${i}: the ${["dawn", "dusk", "midday", "night"][i % 4]} ` +
+  `chorus channel ${i} showed a ${["snapping-shrimp", "parrotfish", "grouper", "damselfish"][i % 4]} ` +
+  `signature offset of ${i * 3} milliseconds, reconciled batch ${i} against the buoy ${i} clock.`,
+);
+
+// Read the tolerance straight off the shipped contract so this fixture asserts
+// the SAME budgetCap the conformance suite declares (tolerance can't drift).
+const BUDGET_CAP = TOOLS.bootstrap.contract.invariants?.budgetCap;
+const TOLERANCE = BUDGET_CAP?.tolerance ?? 0.25;
+const ceilingFor = (maxTokens: number) => Math.ceil(maxTokens * (1 + TOLERANCE));
+
+async function fleet(op: string, body: Record<string, unknown> = {}): Promise<any> {
+  const res = await fetch(`${harper.httpURL}/AgentFleet/`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: "Basic " + btoa(`${harper.admin.username}:${harper.admin.password}`),
+    },
+    body: JSON.stringify({ op, ...body }),
+  });
+  const text = await res.text();
+  if (!res.ok) throw new Error(`AgentFleet ${op} → HTTP ${res.status}: ${text.slice(0, 400)}`);
+  return JSON.parse(text);
+}
+
+/** Call a /mcp tool wrapper (`TOOLS[tool].impl`) as an agent and unwrap the run() envelope. */
+async function tool(name: string, args: Record<string, unknown>, agentId: string): Promise<any> {
+  const res = await fleet("mcpTool", { agentId, tool: name, args, isAdmin: false });
+  expect(res.ok, `mcpTool ${name} failed: ${JSON.stringify(res).slice(0, 500)}`).toBe(true);
+  return res.value;
+}
+
+beforeAll(async () => {
+  appDir = await mkdtemp(join(tmpdir(), "flair-inproc-tmbudget-"));
+  await cp(FIXTURE, appDir, { recursive: true });
+  await mkdir(join(appDir, "node_modules", "@tpsdev-ai"), { recursive: true });
+  await symlink(REPO_ROOT, join(appDir, "node_modules", "@tpsdev-ai", "flair"), "dir");
+  harper = await startHarper({ cwd: appDir, harperBinDir: REPO_ROOT });
+
+  await fleet("register", { id: AGENT_TM });
+  await fleet("register", { id: AGENT_TM_SRC });
+
+  // AGENT_TM_SRC authors the findings NON-PRIVATE (visibility:"shared") through
+  // the real memory_store tool, so each carries a genuine embedding and is
+  // org-readable cross-agent (own + org-non-private read scope). AGENT_TM owns
+  // nothing, so its teammate section fills from these findings alone.
+  for (const content of TM_FINDINGS) {
+    await tool("memory_store", { content, durability: "standard", visibility: "shared" }, AGENT_TM_SRC);
+  }
+}, 300_000);
+
+afterAll(async () => {
+  const dataDir = harper?.installDir;
+  if (harper) await stopHarper(harper);
+  if (dataDir) await rm(dataDir, { recursive: true, force: true, maxRetries: 4 });
+  if (appDir) await rm(appDir, { recursive: true, force: true });
+});
+
+describe("flair#1199 (0.44.11) — teammate-heavy bootstrap respects maxTokens on the /mcp path", () => {
+  // Run the SAME budgetCap check at both a tight budget (2000 — where the
+  // mutation fires most sharply) and the empirical budget (4000 — where the OLD
+  // prose charge produced the reported 5337 blowout). The budget BINDS at both
+  // (40 findings > either capacity), so the cap is load-bearing, not vacuous.
+  for (const maxTokens of [2000, 4000]) {
+    test(`the budgetCap invariant bites the TEAMMATE class at maxTokens=${maxTokens}: tokenEstimate stays within budget+tolerance even with many heavy structured findings`, async () => {
+      // Default call (includeContext NOT passed) → the /mcp connector path, where
+      // only the structured containers ship and the structured object is what
+      // tokenEstimate measures.
+      const body = await tool("bootstrap", { currentTask: TM_TASK, maxTokens }, AGENT_TM);
+      const ceiling = ceilingFor(maxTokens);
+
+      // The budgetCap invariant's own fields must be present and numeric.
+      expect(typeof body.tokenEstimate, "tokenEstimate is a number").toBe("number");
+      expect(body.maxTokens, "maxTokens echoed").toBe(maxTokens);
+
+      // It really is teammate-heavy: the section filled from cross-agent findings…
+      expect(body.teammateFindings.length, "the teammate section is populated from cross-agent findings").toBeGreaterThan(3);
+      // …every delivered finding is attributed to the source teammate (cross-agent)…
+      expect(
+        body.teammateFindings.every((f: any) => f.source === AGENT_TM_SRC && f.section === "teammate"),
+        "every teammate finding is attributed to the source agent",
+      ).toBe(true);
+      // …AGENT_TM contributes no own memories, isolating the teammate class…
+      expect(body.memories.length + body.predicted.length, "AGENT_TM owns nothing").toBe(0);
+      // …the matched pool is coherent: included + truncated == matched…
+      expect(
+        body.teammateFindingsIncluded + body.teammateFindingsTruncated,
+        "teammate included + truncated == matched",
+      ).toBe(body.teammateFindingsMatched);
+      // …the budget BINDS here (some relevant findings were size-skipped), so the
+      // cap is doing real work, not passing vacuously…
+      expect(body.teammateFindingsTruncated, "the budget binds — relevant findings were size-skipped").toBeGreaterThan(0);
+
+      // THE LOAD-BEARING ASSERTION — the SAME budgetCap the conformance suite
+      // declares (ceiling = maxTokens * (1 + contract tolerance)). With Fix 1 the
+      // structured findings are charged what they ship, so this holds; revert
+      // Fix 1 and the uncounted structured weight blows the ceiling (mutation-
+      // validated: at maxTokens=2000, revert → tokenEstimate 2889 > 2500).
+      expect(
+        body.tokenEstimate,
+        `tokenEstimate (=${body.tokenEstimate}) must be <= maxTokens ${maxTokens} + ${Math.round(TOLERANCE * 100)}% scaffolding tolerance (=${ceiling}) — teammate findings must be charged what they SHIP (#1199 0.44.11)`,
+      ).toBeLessThanOrEqual(ceiling);
+    }, 120_000);
+  }
+});


### PR DESCRIPTION
## What & why

The 0.44.10 connector-budget blowout found dogfooding: a `maxTokens: 4000`
bootstrap serialized at **5337 (+33%)** with **zero org events** involved. The
selector charged each memory and teammate finding its short **prose** line, but
on the /mcp connector path (where the prose `context` is a pointer) the heavier
**structured** container object is what actually ships — and what `tokenEstimate`
measures. Teammate findings carry an id, two timestamps, a source and a section,
so their structured object runs ~1.5–1.7× their prose line; several rode
**outside** the enforced budget (`teammateFindingsIncluded` crept 4→5). Targets
**0.44.11**.

## The fixes

**Fix 1 — the budget INPUT, not the cap (#1199).** A path-conditional
`contentCost` charges each admitted item what it *actually ships* on the
requested surface:
- **/mcp connector path** (`includeContext=false`): only the structured
  container ships → charge its serialized size (the same bytes `tokenEstimate`
  measures) → payload stays within `maxTokens` + a small fixed JSON-scaffolding
  tolerance.
- **REST/CLI prose path** (`includeContext=true`): the prose is the shipped
  surface → charge the prose line, so the 0.44.6 selection capacity is preserved
  and the **#1207 recall guard is untouched** (verified below).

**Fix 2 — the systemic gap (the load-bearing deliverable).** The 0.44.10
`budgetCap` invariant existed, but its fixture was events-heavy / teammate-lean,
so this class slipped past. New **isolated, teammate-heavy fixture**
(`test/integration/bootstrap-teammate-budget-1199.test.ts`, 40 cross-agent
non-private real-embedded findings) makes the invariant BITE the teammate class.
It runs in its own HOME-isolated Harper because non-private findings are
org-readable and would pollute other agents' task-relevant retrieval (they clear
the 0.3 floor even against an unrelated task) — the same isolation discipline
now applied to the payload-quality permanent-flood test.

**Mutation check (both directions, this session):**

| maxTokens | with Fix 1 | Fix 1 reverted | ceiling |
|---|---|---|---|
| 2000 | tokenEstimate **2221** ✅ | **2893** ❌ | 2500 |
| 4000 | tokenEstimate **4221** ✅ | **5727** ❌ (reproduces the 5337-class blowout) | 5000 |

**Fix 3 — empty containers say why (#1182).** Generalized the predictedHint rule:
`eventsHint` and `teammateFindingsHint` name why a container ships empty, so a
deliberately-empty container is never byte-indistinguishable from the 0.44.8
silent-drop. Present only when the container is empty.

**Fix 4 — matchQuality null on lifecycle sections (#1225).** Behavior UNCHANGED
(Kern ruled on #1220 that null on own-recent is correct — a lifecycle window
load is not a retrieval surface). Now self-explaining via a `matchQualityNote` on
any null trust entry, plus a docs note in `docs/mcp-clients.md`. **Closes #1225.**

Events accounting (the 0.44.10 #1199 events fix) is unchanged and still correct.

## Verification (fresh, this session)

- **Fix 1 proof:** maxTokens=4000 teammate-heavy → `tokenEstimate` **4221 ≤ 5000**
  (vs the 5337 bug); maxTokens=2000 → **2221 ≤ 2500**.
- **Fix 2 mutation:** revert Fix 1 → the teammate-heavy budgetCap FAILS
  (2893 / 5727); with Fix 1 → passes. The invariant now catches the class.
- **Fast unit lane:** `test/unit/` 4219 pass / 0 fail; `test/unit-isolated/`
  (per-file, the CI way) 145 pass / 0 fail.
- **Integration lane:** conformance + wrapper + budget-regression-1207 (#1207
  recall guard) + payload-quality-1199 + teammate-findings-e2e + self-describing
  + bootstrap-payload-1182 + supersede + collision + the new teammate-budget +
  agent-journey + data-scoping → **all green**.
- **#1207 preserved:** the REST-path recall guard (large on-task record admitted;
  all 5 records ship; `memoriesTruncated=0`) stays green — the prose path still
  charges prose.
- Typecheck clean (`tsconfig.check.json`, test-check). Changelog fragments added
  and `changelog-fragments.mjs check` passes.
- All Harper instances HOME-isolated on dynamic ports; production `:9926`
  untouched.

Refs #1199 #1182
Closes #1225

🤖 Generated with [Claude Code](https://claude.com/claude-code)
