### PR TITLE
fix: charge per-memory trust blocks against bootstrap token budget

### DIFF
--- a/.changelog/unreleased/fixed-trust-block-admission-charging.md
+++ b/.changelog/unreleased/fixed-trust-block-admission-charging.md
@@ -1,0 +1,10 @@
+- **Per-memory trust blocks are now charged against the bootstrap token budget.**
+  When `includeTrust:true`, each candidate memory's projected trust block (the
+  `buildTrustBlock(m)` serialization, including the conditional `matchQualityNote`)
+  is charged against `tokenBudget` at the same admission moment as its content
+  cost, at all five admission sites (permanent/recent/predicted/teammate/relevant).
+  Previously the trust array was built post-admission and serialized without ever
+  being counted, so `tokenEstimate` could overshoot `maxTokens * 1.25` on the
+  `/mcp` connector path (measured ~772 uncounted tokens on 0.44.11). The
+  `includeTrust:false` path is byte-identical — no trust cost is charged when
+  trust is off, so content-only selection is unchanged.

--- a/resources/MemoryBootstrap.ts
+++ b/resources/MemoryBootstrap.ts
@@ -152,6 +152,36 @@ const MAX_COLLISION_ENTRIES = 10;
 // never a scoring failure — see the `matchQualityNote` in the response tail.
 const LIFECYCLE_SECTIONS = new Set(["permanent", "recent", "predicted"]);
 
+// flair#1199 trust-admission — build the EXACT trust entry that ships for one
+// included memory (id + section + block + the conditional matchQualityNote), so
+// the admission loop can charge its REAL serialized cost at the same moment it
+// charges the content cost. Single source of truth: the response tail reuses
+// this same builder, so the charged size and the shipped size can never drift
+// (the #1226 "charge what ships" principle, extended to the per-item trust
+// block). The block is assembled purely for SIZING + the response — its content
+// never enters any authority/scope/attribution/dedup decision (the #735/#744
+// zero-authority invariant).
+//
+// flair#1225 — Kern ruled (on #1220) that a null `matchQuality` on an own-recent
+// (lifecycle) entry is CORRECT: lifecycle sections (permanent/recent/predicted)
+// are a window LOAD, not a retrieval surface, so there is no similarity to band
+// — the null means "not scored here", never a scoring failure on the caller's
+// own records (the #1201 misread: own-recent null beside a teammate band).
+// Behavior is unchanged (per Kern); the matchQualityNote only makes the null
+// self-describing in the payload — Fix 3's "any absent field says why" — so a
+// connector reads it right without knowing the #1201 contract.
+function buildTrustEntry(m: any, section: string): Record<string, unknown> {
+  const block = buildTrustBlock(m);
+  const matchQualityNote = block.matchQuality === null
+    ? (LIFECYCLE_SECTIONS.has(section)
+        ? `matchQuality is null because '${section}' is a lifecycle-window section, not a retrieval `
+          + `surface — there is no relevance score to band. This is correct (per flair#1225), not a scoring failure.`
+        : "matchQuality is null because no semantic similarity was attached to this result "
+          + "(e.g. a by-id read or a keyword-only degraded match).")
+    : undefined;
+  return { id: m.id, section, ...block, ...(matchQualityNote ? { matchQualityNote } : {}) };
+}
+
 // flair#1199/#1206 — the default cap on how many org events bootstrap ships.
 // Overridable per-request via `maxEvents`. Event slots are scarce AND (as of
 // #1199) token-charged, so this bounds both the count and the spend; the shared
@@ -646,7 +676,7 @@ export class BootstrapMemories extends Resource {
     // (relevant/teammate) is applied by the SAME rule to own and teammate
     // records. Fixes the "own recent → null while teammate → strong looks like
     // my own records scored worse" misread.
-    const includedTrustMemories: { m: any; section: string }[] = [];
+    const includedTrustMemories: Record<string, unknown>[] = [];
 
     // flair#744 slice 2 — the best absolute semantic similarity seen while
     // scoring the task-relevant candidate pool (section 4). Drives the opt-in
@@ -703,11 +733,16 @@ export class BootstrapMemories extends Resource {
       // on the REST path); see contentCost. #1207 stays honored: on the prose
       // path this is still the prose-line cost, so REST recall is unchanged.
       const cost = contentCost(struct, line);
-      if (cost <= tokenBudget) {
+      // flair#1199 trust-admission — charge the trust block's real serialized
+      // cost at the same moment as the content cost (per-item trust is CONTENT,
+      // not fixed scaffolding; see buildTrustEntry).
+      const trustEntry = includeTrust ? buildTrustEntry(m, "permanent") : null;
+      const trustCost = trustEntry ? estimateTokens(JSON.stringify(trustEntry)) : 0;
+      if (cost + trustCost <= tokenBudget) {
         sections.permanent.push(line);
         includedOwnMemories.push(struct);
-        if (includeTrust) includedTrustMemories.push({ m, section: "permanent" });
-        tokenBudget -= cost;
+        if (trustEntry) includedTrustMemories.push(trustEntry);
+        tokenBudget -= cost + trustCost;
         includedOwnIds.add(m.id); // #1207 — count by unique own-memory id
       } else {
         truncatedOwnIds.add(m.id); // #1207 — budget-skip, deduped against inclusions at the end
@@ -772,15 +807,19 @@ export class BootstrapMemories extends Resource {
       const line = formatMemory(m, agentId);
       const struct = leanMemory(m, "recent");
       const cost = contentCost(struct, line); // #1199 (0.44.11) — charge what ships; see contentCost
-      if (recentSpent + cost > recentBudget) {
+      // flair#1199 trust-admission — charge the trust block's real serialized
+      // cost against BOTH the recent sub-budget and the shared tokenBudget.
+      const trustEntry = includeTrust ? buildTrustEntry(m, "recent") : null;
+      const trustCost = trustEntry ? estimateTokens(JSON.stringify(trustEntry)) : 0;
+      if (recentSpent + cost + trustCost > recentBudget) {
         truncatedOwnIds.add(m.id); // #1207 — budget-skip; may still be admitted later via the task-relevant loop (deduped at the end)
         continue;
       }
       sections.recent.push(line);
       includedOwnMemories.push(struct);
-      if (includeTrust) includedTrustMemories.push({ m, section: "recent" });
-      recentSpent += cost;
-      tokenBudget -= cost;
+      if (trustEntry) includedTrustMemories.push(trustEntry);
+      recentSpent += cost + trustCost;
+      tokenBudget -= cost + trustCost;
       includedOwnIds.add(m.id); // #1207 — count by unique own-memory id
     }
 
@@ -819,15 +858,19 @@ export class BootstrapMemories extends Resource {
         const line = formatMemory(m, agentId);
         const struct = leanMemory(m, "predicted");
         const cost = contentCost(struct, line); // #1199 (0.44.11) — charge what ships; see contentCost
-        if (predictedSpent + cost > predictedBudget) {
+        // flair#1199 trust-admission — charge the trust block's real serialized
+        // cost against BOTH the predicted sub-budget and the shared tokenBudget.
+        const trustEntry = includeTrust ? buildTrustEntry(m, "predicted") : null;
+        const trustCost = trustEntry ? estimateTokens(JSON.stringify(trustEntry)) : 0;
+        if (predictedSpent + cost + trustCost > predictedBudget) {
           truncatedOwnIds.add(m.id); // #1207 — budget-skip (deduped against inclusions at the end)
           continue;
         }
         sections.predicted.push(line);
         includedPredicted.push(struct);
-        if (includeTrust) includedTrustMemories.push({ m, section: "predicted" });
-        predictedSpent += cost;
-        tokenBudget -= cost;
+        if (trustEntry) includedTrustMemories.push(trustEntry);
+        predictedSpent += cost + trustCost;
+        tokenBudget -= cost + trustCost;
         includedOwnIds.add(m.id); // #1207 — count by unique own-memory id; also the task-relevant loop's exclusion set (no predicted→relevant double-admit)
       }
     }
@@ -1023,7 +1066,13 @@ export class BootstrapMemories extends Resource {
               }
             : leanMemory(m, "relevant");
           const cost = contentCost(struct, line);
-          if (cost > tokenBudget) {
+          // flair#1199 trust-admission — charge the trust block's real serialized
+          // cost at the same moment as the content cost. The section (teammate vs
+          // relevant) is decided by `m._source`, so build the entry with the right
+          // section before the budget check.
+          const trustEntry = includeTrust ? buildTrustEntry(m, m._source ? "teammate" : "relevant") : null;
+          const trustCost = trustEntry ? estimateTokens(JSON.stringify(trustEntry)) : 0;
+          if (cost + trustCost > tokenBudget) {
             // flair#1207 — a size-skip in the score-ordered task-relevant loop
             // is no longer silent: record it on the denominator matching the
             // record's origin (own → truncatedOwnIds, teammate → the separate
@@ -1042,16 +1091,16 @@ export class BootstrapMemories extends Resource {
             // memoriesIncluded — that different-denominator mix is what let
             // included exceed available.
             includedTeammateFindings.push(struct);
-            if (includeTrust) includedTrustMemories.push({ m, section: "teammate" });
-            tokenBudget -= cost;
+            if (trustEntry) includedTrustMemories.push(trustEntry);
+            tokenBudget -= cost + trustCost;
             teammateFindingsIncluded++;
           } else {
             sections.relevant.push(line);
             // flair#1182 — own task-relevant records join the `memories`
             // container.
             includedOwnMemories.push(struct);
-            if (includeTrust) includedTrustMemories.push({ m, section: "relevant" });
-            tokenBudget -= cost;
+            if (trustEntry) includedTrustMemories.push(trustEntry);
+            tokenBudget -= cost + trustCost;
             includedOwnIds.add(m.id); // #1207 — count by unique own-memory id
           }
         }
@@ -1376,28 +1425,12 @@ export class BootstrapMemories extends Resource {
     // caller's own records. flair#1225 (0.44.11) — the null on a lifecycle
     // section is now SELF-EXPLAINING (matchQualityNote below), not just legible
     // via `section`.
-    const trust = includeTrust
-      ? includedTrustMemories.map(({ m, section }) => {
-          const block = buildTrustBlock(m);
-          // flair#1225 — Kern ruled (on #1220) that a null `matchQuality` on an
-          // own-recent (lifecycle) entry is CORRECT: lifecycle sections
-          // (permanent/recent/predicted) are a window LOAD, not a retrieval
-          // surface, so there is no similarity to band — the null means "not
-          // scored here", never a scoring failure on the caller's own records
-          // (the #1201 misread: own-recent null beside a teammate band). Behavior
-          // is unchanged (per Kern); this only makes the null self-describing in
-          // the payload — Fix 3's "any absent field says why" — so a connector
-          // reads it right without knowing the #1201 contract.
-          const matchQualityNote = block.matchQuality === null
-            ? (LIFECYCLE_SECTIONS.has(section)
-                ? `matchQuality is null because '${section}' is a lifecycle-window section, not a retrieval `
-                  + `surface — there is no relevance score to band. This is correct (per flair#1225), not a scoring failure.`
-                : "matchQuality is null because no semantic similarity was attached to this result "
-                  + "(e.g. a by-id read or a keyword-only degraded match).")
-            : undefined;
-          return { id: m.id, section, ...block, ...(matchQualityNote ? { matchQualityNote } : {}) };
-        })
-      : undefined;
+    // flair#1199 trust-admission — the trust entries were built (and their real
+    // serialized cost charged) at admission time via buildTrustEntry, so the
+    // response tail just ships them as-is. The #1225 matchQualityNote logic now
+    // lives in buildTrustEntry (single source of truth — the charged size and
+    // the shipped size can never drift).
+    const trust = includeTrust ? includedTrustMemories : undefined;
 
     // flair#744 slice 2 — opt-in abstention verdict for the task-relevance
     // surface. Present ONLY when `abstain` is requested (byte-identical to

--- a/test/integration/bootstrap-trust-budget-conformance.test.ts
+++ b/test/integration/bootstrap-trust-budget-conformance.test.ts
@@ -1,0 +1,156 @@
+// flair#1199 (trust-admission) — conformance budgetCap on the /mcp connector
+// path (includeContext:false) with includeTrust:true.
+//
+// The connector-conformance suite declares the invariant
+//   budgetCap: { estimate: "tokenEstimate", budget: "maxTokens", tolerance: 0.25 }
+// i.e. tokenEstimate <= maxTokens * (1 + 0.25). tokenEstimate is measured over
+// the FULL serialized response body (resources/MemoryBootstrap.ts response
+// tail), which includes the opt-in `trust` array when includeTrust:true.
+//
+// The bug this test pins: each per-item trust block (buildTrustBlock(m) +
+// the conditional matchQualityNote) is CONTENT — it scales with the number of
+// included memories and ships serialized in the response — but it was built
+// POST-admission (~line 1380) and never charged against tokenBudget. So on the
+// /mcp path with includeTrust:true, the trust array inflated tokenEstimate by
+// ~772 uncounted tokens (flint's field A/B on 0.44.11) and blew the budgetCap
+// invariant. The fix charges each candidate's projected trust serialization
+// against tokenBudget at the admission moment (all five sites), so the charged
+// size and the shipped size can never drift.
+//
+// Positive control: this test FAILS on current main (trust blocks uncounted →
+// tokenEstimate overshoots) and PASSES after the fix (trust blocks charged →
+// fewer memories admitted → tokenEstimate within tolerance).
+//
+// #1207 control (second test): includeTrust:false must be byte-identical to
+// pre-fix — the fix charges NO trust cost when trust is off, so the trust-off
+// selection is unchanged (no flat per-item overhead against the content
+// budget, which is exactly the #1199→#1207 regression this fix must not
+// reintroduce).
+//
+// Pattern: test/integration/bootstrap-teammate-findings-e2e.test.ts (Ed25519
+// signing, real embeddings via the signed PUT write path). Permanent memories
+// are used because they ALWAYS render (no currentTask / recency window
+// needed), so the seed deterministically exercises the permanent admission
+// site and its trust blocks.
+import { describe, expect, test, beforeAll, afterAll } from "bun:test";
+import nacl from "tweetnacl";
+import { randomUUID } from "node:crypto";
+import { startHarper, stopHarper, HarperInstance } from "../helpers/harper-lifecycle";
+
+interface TestAgent { id: string; publicKey: string; secretKey: Uint8Array; }
+
+function mkAgent(id: string): TestAgent {
+  const kp = nacl.sign.keyPair();
+  return { id, publicKey: Buffer.from(kp.publicKey).toString("base64"), secretKey: kp.secretKey };
+}
+
+function ed25519Header(agent: TestAgent, method: string, path: string): string {
+  const ts = Date.now().toString();
+  const nonce = randomUUID();
+  const payload = `${agent.id}:${ts}:${nonce}:${method}:${path}`;
+  const sig = nacl.sign.detached(new TextEncoder().encode(payload), agent.secretKey);
+  return `TPS-Ed25519 ${agent.id}:${ts}:${nonce}:${Buffer.from(sig).toString("base64")}`;
+}
+
+async function adminOp(harper: HarperInstance, op: Record<string, any>): Promise<Response> {
+  return fetch(harper.opsURL, {
+    method: "POST",
+    headers: { "Content-Type": "application/json", Authorization: "Basic " + btoa(`${harper.admin.username}:${harper.admin.password}`) },
+    body: JSON.stringify(op),
+  });
+}
+
+async function registerAgent(harper: HarperInstance, agent: TestAgent): Promise<void> {
+  const res = await adminOp(harper, {
+    operation: "insert", database: "flair", table: "Agent",
+    records: [{ id: agent.id, name: agent.id, role: "agent", publicKey: agent.publicKey, createdAt: new Date().toISOString() }],
+  });
+  expect(res.status, `Agent insert for ${agent.id} returned ${res.status}`).toBe(200);
+}
+
+async function putMemory(harper: HarperInstance, agent: TestAgent, id: string, body: Record<string, any>): Promise<void> {
+  const path = `/Memory/${id}`;
+  const res = await fetch(`${harper.httpURL}${path}`, {
+    method: "PUT",
+    headers: { Authorization: ed25519Header(agent, "PUT", path), "Content-Type": "application/json" },
+    body: JSON.stringify({ id, ...body }),
+  });
+  if (![200, 204].includes(res.status)) {
+    throw new Error(`seed PUT ${id} → ${res.status}: ${await res.text()}`);
+  }
+}
+
+async function bootstrap(harper: HarperInstance, agent: TestAgent, body: Record<string, any>): Promise<any> {
+  const path = "/BootstrapMemories";
+  const res = await fetch(`${harper.httpURL}${path}`, {
+    method: "POST",
+    headers: { Authorization: ed25519Header(agent, "POST", path), "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  const text = await res.text();
+  expect(res.status, `BootstrapMemories → ${res.status}: ${text.slice(0, 500)}`).toBe(200);
+  return JSON.parse(text);
+}
+
+let harper: HarperInstance;
+const agent = mkAgent(`t1199-${randomUUID()}`);
+
+// 20 distinct PERMANENT memories — permanent records always render, so the
+// seed deterministically fills the permanent admission site (and its trust
+// blocks) without needing currentTask or a recency window. Content is kept
+// genuinely distinct (distinctive rule number + phrasing) so Memory.ts's dedup
+// co-gate (cosine >= 0.95 AND lexical Jaccard >= 0.5) never conflates them.
+const SEED_COUNT = 20;
+const SEED_CONTENT = Array.from({ length: SEED_COUNT }, (_, i) =>
+  `flair-1199 marker: standing rule number ${i + 1} — before finalizing any vendor agreement, always verify the ${["indemnification cap", "termination notice window", "data-residency clause", "price-escalation cap", "SLA credit floor"][i % 5]} against the current legal playbook revision.`);
+
+const MAX_TOKENS = 4000;
+const TOLERANCE = 0.25;
+
+describe("flair#1199 — trust-block admission charging (budgetCap conformance on /mcp)", () => {
+  beforeAll(async () => {
+    harper = await startHarper();
+    await registerAgent(harper, agent);
+    for (let i = 0; i < SEED_COUNT; i++) {
+      await putMemory(harper, agent, `${agent.id}-perm-${i}`, {
+        agentId: agent.id, content: SEED_CONTENT[i], durability: "permanent",
+        createdAt: new Date(Date.now() - 40 * 24 * 3600_000).toISOString(),
+      });
+    }
+  }, 180_000);
+
+  afterAll(async () => { if (harper) await stopHarper(harper); });
+
+  test("budgetCap conformance: includeTrust:true on the /mcp path keeps tokenEstimate within maxTokens * (1 + tolerance)", async () => {
+    const body = await bootstrap(harper, agent, {
+      agentId: agent.id, maxTokens: MAX_TOKENS, includeTrust: true, includeContext: false,
+    });
+
+    // The trust array must actually be present and non-empty (the thing under
+    // test — otherwise the invariant would hold vacuously).
+    expect(Array.isArray(body.trust), "trust array must be present when includeTrust:true").toBe(true);
+    expect(body.trust.length, "trust array must be non-empty").toBeGreaterThan(0);
+
+    // The budgetCap invariant the connector-conformance suite asserts.
+    expect(body.tokenEstimate, `tokenEstimate ${body.tokenEstimate} exceeded maxTokens ${body.maxTokens} * (1 + ${TOLERANCE}) = ${body.maxTokens * (1 + TOLERANCE)}`).toBeLessThanOrEqual(body.maxTokens * (1 + TOLERANCE));
+  }, 60_000);
+
+  test("#1207 control: includeTrust:false is byte-identical to pre-fix — no trust cost charged, selection unchanged", async () => {
+    const trustOff = await bootstrap(harper, agent, {
+      agentId: agent.id, maxTokens: MAX_TOKENS, includeTrust: false, includeContext: false,
+    });
+
+    // The trust-off response must carry NO `trust` key (byte-identical to
+    // pre-slice-1), and must NOT charge any trust cost: every seeded permanent
+    // memory is admitted (content-only budget), none truncated. If the fix
+    // leaked trust cost into the trust-off path, some memories would be dropped
+    // here — the #1199→#1207 regression (a flat per-item overhead charged
+    // against the content budget).
+    expect(trustOff.trust, "trust-off response must not carry a `trust` key").toBeUndefined();
+    expect(trustOff.memoriesIncluded, `trust-off must admit all ${SEED_COUNT} seeded memories (no trust cost charged)`).toBe(SEED_COUNT);
+    expect(trustOff.memoriesTruncated, "trust-off must truncate nothing").toBe(0);
+
+    // And the trust-off path already conforms (no trust blocks to overrun).
+    expect(trustOff.tokenEstimate).toBeLessThanOrEqual(trustOff.maxTokens * (1 + TOLERANCE));
+  }, 60_000);
+});


### PR DESCRIPTION
## Summary

Fixes flair#1199 (trust-admission): per-memory trust blocks were built post-admission (~line 1380) and serialized into the `trust` array without ever being charged against `tokenBudget`. On the `/mcp` connector path (`includeContext:false`) with `includeTrust:true`, `tokenEstimate` could overshoot `maxTokens * 1.25` — measured ~772 uncounted tokens on 0.44.11.

## Change

When `includeTrust:true`, each candidate's projected trust block (`buildTrustBlock(m)` serialization, including the conditional `matchQualityNote`) is charged against `tokenBudget` at the same admission moment as its content cost, at all five admission sites (permanent/recent/predicted/teammate/relevant).

A single `buildTrustEntry(m, section)` helper builds the exact entry once at admission, used for both sizing and shipping — so the charged size and the shipped size can never drift (the #1226 "charge what ships" principle, extended to the per-item trust block). The response tail now just ships the pre-built entries.

The `includeTrust:false` path is byte-identical: no trust cost is charged when trust is off, so content-only selection is unchanged (the #1207 control).

## Tests

- `test/integration/bootstrap-trust-budget-conformance.test.ts` — new conformance test:
  - **Positive control** (`includeTrust:true` on `/mcp`): asserts `tokenEstimate <= maxTokens * 1.25`. Fails on current main (6154 > 5000), passes post-fix.
  - **#1207 control** (`includeTrust:false`): asserts no `trust` key, all seeded memories admitted, nothing truncated, and conformance — byte-identical to pre-fix.

## Zero-authority invariant

The trust block is assembled purely for sizing + the response; its content never enters any authority/scope/attribution/dedup decision (the #735/#744 zero-authority invariant). The existing tripwire tests still pass.

Refs #1199