### PR TITLE
fix: validate durability enum server-side

### DIFF
--- a/.changelog/unreleased/fixed-durability-enum-validation.md
+++ b/.changelog/unreleased/fixed-durability-enum-validation.md
@@ -1,0 +1,7 @@
+- **Server-side durability enum validation.** A writer-supplied `durability` that
+  is not one of `permanent`/`persistent`/`standard`/`ephemeral` is now refused with
+  a 400 naming the valid set, instead of being silently accepted and landing on the
+  narrower private branch by accident. Absent durability is unchanged (defaulted to
+  `standard`). Applied to both `Memory.post` and `Memory.put`; the adk-flair Python
+  adapter's `_VALID_DURABILITIES`/`_VALID_VISIBILITIES` frozensets were also moved to
+  module level (cosmetic).

--- a/packages/adk-flair/src/adk_flair/memory_service.py
+++ b/packages/adk-flair/src/adk_flair/memory_service.py
@@ -49,6 +49,11 @@ _LOCALHOST_HOSTS = frozenset({"localhost", "127.0.0.1", "::1", "[::1]"})
 _ALLOW_REMOTE_ENV = "FLAIR_ALLOW_REMOTE_URL"
 _TAG_PREFIX = "adk"
 
+# Valid enum values for the explicit write knobs (flair#1238 — moved to module
+# level from inside add_memory; Sherlock's cosmetic note on #1237).
+_VALID_DURABILITIES = frozenset(["permanent", "persistent", "standard", "ephemeral"])
+_VALID_VISIBILITIES = frozenset(["private", "shared"])
+
 # ─── Helpers ────────────────────────────────────────────────────────────────
 
 
@@ -443,9 +448,6 @@ class FlairMemoryService(BaseMemoryService):
         tag = _compound_tag(app_name, user_id)
 
         # ── Validate explicit durability ─────────────────────────────────
-        _VALID_DURABILITIES = frozenset(
-            ["permanent", "persistent", "standard", "ephemeral"]
-        )
         if durability is not None and durability not in _VALID_DURABILITIES:
             raise ValueError(
                 f"durability must be one of {sorted(_VALID_DURABILITIES)} "
@@ -453,7 +455,6 @@ class FlairMemoryService(BaseMemoryService):
             )
 
         # ── Validate explicit visibility ─────────────────────────────────
-        _VALID_VISIBILITIES = frozenset(["private", "shared"])
         if visibility is not None and visibility not in _VALID_VISIBILITIES:
             raise ValueError(
                 f"visibility must be one of {sorted(_VALID_VISIBILITIES)} "

--- a/resources/Memory.ts
+++ b/resources/Memory.ts
@@ -8,6 +8,7 @@ import { invalidEntitiesResponse } from "./entity-vocab.js";
 import { checkRateLimit, rateLimitResponse } from "./rate-limiter.js";
 import { resolveAllowedOwners } from "./memory-read-scope.js";
 import { assertValidVisibility } from "./memory-visibility.js";
+import { assertValidDurability } from "./memory-durability.js";
 import {
   DEDUP_COSINE_THRESHOLD_DEFAULT,
   DEDUP_LEXICAL_THRESHOLD_DEFAULT,
@@ -640,6 +641,23 @@ export class Memory extends (databases as any).flair.Memory {
     const usedMemoryIds = content?.usedMemoryIds;
     if (content && typeof content === "object") delete content.usedMemoryIds;
 
+    // ── flair#1238: refuse an unrecognised durability BEFORE defaulting ──
+    // defaultVisibilityForDurability treats any non-permanent/persistent string
+    // as the private branch, so an unknown durability via raw REST (or a future
+    // non-Python adapter) is silently accepted and lands on the narrower private
+    // branch by accident — fail-safe, but unvalidated by contract. Refusing at
+    // the schema boundary makes it safe by construction (mirrors the visibility
+    // guard below). Absent durability is accepted and defaulted to "standard".
+    {
+      const durabilityError = assertValidDurability(content.durability);
+      if (durabilityError) {
+        return new Response(
+          JSON.stringify({ error: "invalid_durability", message: durabilityError }),
+          { status: 400, headers: { "content-type": "application/json" } },
+        );
+      }
+    }
+
     content.durability ||= "standard";
     content.createdAt = new Date().toISOString();
     content.updatedAt = content.createdAt;
@@ -842,6 +860,21 @@ export class Memory extends (databases as any).flair.Memory {
     // below only when present.
     const usedMemoryIds = content?.usedMemoryIds;
     if (content && typeof content === "object") delete content.usedMemoryIds;
+
+    // ── flair#1238: refuse an unrecognised durability (mirrors post()) ──
+    // put() is the other HTTP-reachable write path (fresh create via CLI, and
+    // the update/patch path). Same guard as post(): a present-but-unknown
+    // durability is refused with 400; absent is accepted (no default stamped
+    // here — put() leaves durability untouched for updates).
+    {
+      const durabilityError = assertValidDurability(content.durability);
+      if (durabilityError) {
+        return new Response(
+          JSON.stringify({ error: "invalid_durability", message: durabilityError }),
+          { status: 400, headers: { "content-type": "application/json" } },
+        );
+      }
+    }
 
     const now = new Date().toISOString();
     content.updatedAt = now;

--- a/resources/memory-durability.ts
+++ b/resources/memory-durability.ts
@@ -1,0 +1,43 @@
+/**
+ * ─── The single "is this a valid durability" writer-intent guard ────────────
+ *
+ * Mirror of resources/memory-visibility.ts's assertValidVisibility, for the
+ * durability enum. Same asymmetry, same reason:
+ *
+ *   - READING an unknown durability must be permissive. A row written before a
+ *     tier existed (or by a non-Python adapter) may hold anything, and the read
+ *     side must keep resolving it exactly as before — defaultVisibilityForDurability
+ *     treats any non-permanent/persistent string as the private branch, and that
+ *     fail-safe must not change.
+ *   - WRITING an unknown durability must be refused. Today an unknown value via
+ *     raw REST (or a future non-Python adapter) is silently accepted and lands on
+ *     the narrower private branch by accident — fail-safe, but unvalidated by
+ *     contract. Refusing at the schema boundary makes it safe by construction and
+ *     makes adk-flair's "validated server-side" claim true as written (flair#1238,
+ *     from Sherlock's #1237 review).
+ *
+ * Deliberately has ZERO imports — same load-bearing reason as memory-visibility.ts:
+ * this module is a pure function + constant that any caller can import without
+ * dragging in "harper".
+ */
+
+/** The only values a WRITER may supply. */
+export const WRITABLE_DURABILITIES = ["permanent", "persistent", "standard", "ephemeral"] as const;
+
+/**
+ * Reject a durability a writer supplied that is not one of the four valid values.
+ * Returns an error message, or null when the value is acceptable.
+ *
+ * `undefined`/`null` are accepted: omitting the field is how a caller asks for
+ * the default ("standard"), and that is a documented, intentional path.
+ */
+export function assertValidDurability(durability: unknown): string | null {
+  if (durability === undefined || durability === null) return null;
+  if (typeof durability === "string" && (WRITABLE_DURABILITIES as readonly string[]).includes(durability)) {
+    return null;
+  }
+  return (
+    `durability must be ${WRITABLE_DURABILITIES.map((v) => `"${v}"`).join(" or ")} ` +
+    `(got: ${JSON.stringify(durability)}). Omit it to use the default "standard".`
+  );
+}

--- a/test/integration/durability-write-validation-e2e.test.ts
+++ b/test/integration/durability-write-validation-e2e.test.ts
@@ -1,0 +1,131 @@
+// flair#1238 — server-side durability enum validation, behavioural positive control.
+//
+// The unit lane (test/unit/durability-write-validation.test.ts) validates
+// assertValidDurability in isolation and trips if the guard is unwired. This file
+// is the behavioural proof: a PRESENT-but-unknown durability via the real REST
+// surface must be REFUSED with 400, while all four valid values and an absent
+// durability keep working exactly as before.
+//
+// This is the "prove it fires" control — pre-fix, an unknown durability was
+// silently accepted (200) and landed on the narrower private branch by accident.
+// Post-fix it is refused at the schema boundary.
+//
+// Pattern: test/integration/memory-visibility-scoping-e2e.test.ts (Ed25519
+// signing helpers, admin-op seeding).
+import { describe, expect, test, beforeAll, afterAll } from "bun:test";
+import nacl from "tweetnacl";
+import { randomUUID } from "node:crypto";
+import { startHarper, stopHarper, HarperInstance } from "../helpers/harper-lifecycle";
+
+interface TestAgent { id: string; publicKey: string; secretKey: Uint8Array; }
+
+function mkAgent(id: string): TestAgent {
+  const kp = nacl.sign.keyPair();
+  return { id, publicKey: Buffer.from(kp.publicKey).toString("base64"), secretKey: kp.secretKey };
+}
+
+function ed25519Header(agent: TestAgent, method: string, path: string): string {
+  const ts = Date.now().toString();
+  const nonce = randomUUID();
+  const payload = `${agent.id}:${ts}:${nonce}:${method}:${path}`;
+  const sig = nacl.sign.detached(new TextEncoder().encode(payload), agent.secretKey);
+  return `TPS-Ed25519 ${agent.id}:${ts}:${nonce}:${Buffer.from(sig).toString("base64")}`;
+}
+
+async function authFetch(harper: HarperInstance, agent: TestAgent, method: string, path: string, body?: unknown): Promise<Response> {
+  const headers: Record<string, string> = { Authorization: ed25519Header(agent, method, path) };
+  if (body !== undefined) headers["Content-Type"] = "application/json";
+  return fetch(`${harper.httpURL}${path}`, { method, headers, body: body !== undefined ? JSON.stringify(body) : undefined });
+}
+
+async function adminOp(harper: HarperInstance, op: Record<string, any>): Promise<Response> {
+  return fetch(harper.opsURL, {
+    method: "POST",
+    headers: { "Content-Type": "application/json", Authorization: "Basic " + btoa(`${harper.admin.username}:${harper.admin.password}`) },
+    body: JSON.stringify(op),
+  });
+}
+
+async function seedAgent(harper: HarperInstance, agent: TestAgent): Promise<void> {
+  const res = await adminOp(harper, {
+    operation: "insert", database: "flair", table: "Agent",
+    records: [{ id: agent.id, name: agent.id, role: "agent", publicKey: agent.publicKey, createdAt: new Date().toISOString() }],
+  });
+  expect(res.status).toBe(200);
+}
+
+let harper: HarperInstance;
+const agent = mkAgent("dur-owner");
+
+beforeAll(async () => {
+  harper = await startHarper();
+  await seedAgent(harper, agent);
+}, 180_000);
+
+afterAll(async () => {
+  if (harper) await stopHarper(harper);
+});
+
+describe("durability enum validation — write-side rejection (flair#1238)", () => {
+  test("positive control: a present-but-unknown durability is refused with 400", async () => {
+    const res = await authFetch(harper, agent, "POST", "/Memory", {
+      id: `dur-unknown-${randomUUID()}`,
+      agentId: agent.id,
+      content: "unknown durability",
+      durability: "forever",
+    });
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("invalid_durability");
+    expect(body.message).toContain("forever");
+    expect(body.message).toContain("permanent");
+    expect(body.message).toContain("persistent");
+    expect(body.message).toContain("standard");
+    expect(body.message).toContain("ephemeral");
+  }, 30_000);
+
+  test("all four valid values are accepted unchanged", async () => {
+    for (const durability of ["permanent", "persistent", "standard", "ephemeral"]) {
+      const res = await authFetch(harper, agent, "POST", "/Memory", {
+        id: `dur-valid-${durability}-${randomUUID()}`,
+        agentId: agent.id,
+        content: `a ${durability} decision, long enough for the safety scan`,
+        durability,
+      });
+      expect(res.status, `durability=${durability} → ${res.status}`).toBe(201);
+    }
+  }, 60_000);
+
+  test("absent durability is accepted and defaulted to \"standard\"", async () => {
+    const id = `dur-absent-${randomUUID()}`;
+    const res = await authFetch(harper, agent, "POST", "/Memory", {
+      id,
+      agentId: agent.id,
+      content: "no durability field, long enough for the safety scan",
+    });
+    expect(res.status).toBe(201);
+
+    // Confirm the default was stamped server-side.
+    const read = await adminOp(harper, {
+      operation: "search_by_value", database: "flair", table: "Memory",
+      search_attribute: "id", search_value: id, get_attributes: ["id", "durability"],
+    });
+    expect(read.status).toBe(200);
+    const rows = await read.json();
+    const record = Array.isArray(rows) ? rows[0] : rows;
+    expect(record?.durability).toBe("standard");
+  }, 30_000);
+
+  test("PUT is also guarded — unknown durability via the update path is refused", async () => {
+    const id = `dur-put-${randomUUID()}`;
+    const res = await authFetch(harper, agent, "PUT", `/Memory/${id}`, {
+      id,
+      agentId: agent.id,
+      content: "put with unknown durability",
+      durability: "forever",
+    });
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("invalid_durability");
+  }, 30_000);
+});

--- a/test/unit/durability-write-validation.test.ts
+++ b/test/unit/durability-write-validation.test.ts
@@ -1,0 +1,88 @@
+// flair#1238 — a writer-supplied `durability` that is not one of the four valid
+// values must be REFUSED, not silently accepted.
+//
+// The asymmetry this file exists to protect (mirror of the visibility guard):
+//
+//   READING an unknown durability must be permissive. defaultVisibilityForDurability
+//   treats any non-permanent/persistent string as the private branch, and a row
+//   written before a tier existed (or by a non-Python adapter) must keep resolving
+//   exactly as before — that fail-safe must not change.
+//
+//   WRITING an unknown durability must be refused. Today an unknown value via raw
+//   REST is silently accepted and lands on the narrower private branch by accident
+//   — fail-safe, but unvalidated by contract. Refusing at the schema boundary makes
+//   it safe by construction (flair#1238, from Sherlock's #1237 review).
+import { describe, test, expect } from "bun:test";
+import {
+  assertValidDurability,
+  WRITABLE_DURABILITIES,
+} from "../../resources/memory-durability.js";
+
+describe("assertValidDurability — write-side rejection (flair#1238)", () => {
+  test("accepts the four valid values", () => {
+    for (const v of WRITABLE_DURABILITIES) {
+      expect(assertValidDurability(v)).toBeNull();
+    }
+  });
+
+  test("accepts absence — omitting the field asks for the default \"standard\"", () => {
+    expect(assertValidDurability(undefined)).toBeNull();
+    expect(assertValidDurability(null)).toBeNull();
+  });
+
+  test("rejects an unknown value", () => {
+    const err = assertValidDurability("forever");
+    expect(err).not.toBeNull();
+    expect(err).toContain("forever");
+  });
+
+  test("rejects wrong case — the enum is case-sensitive", () => {
+    expect(assertValidDurability("Permanent")).not.toBeNull();
+    expect(assertValidDurability("STANDARD")).not.toBeNull();
+  });
+
+  test("rejects non-strings rather than coercing them", () => {
+    for (const v of [1, true, {}, [], "", " standard", "standard "]) {
+      expect(assertValidDurability(v)).not.toBeNull();
+    }
+  });
+
+  test("the error names all four valid values and the way to opt out", () => {
+    const err = assertValidDurability("nonsense") ?? "";
+    for (const v of WRITABLE_DURABILITIES) {
+      expect(err).toContain(`"${v}"`);
+    }
+    expect(err).toContain("Omit it");
+  });
+});
+
+// ─── Structural tripwire: the guard must remain WIRED ─────────────────────────
+//
+// The tests above validate `assertValidDurability` in isolation. That is not
+// enough — a validator nobody calls is not a control (the visibility guard proved
+// this: neutering it inside Memory.post() broke nothing, 3869 tests still passed).
+//
+// This scan fails the build if either write path stops calling it. Same shape as
+// visibility-write-validation.test.ts and claimed-zero-authority-tripwire.test.ts,
+// and same limitation, stated plainly: it detects DELETION, not misbehaviour. A
+// behavioural assertion (unknown durability → 400) needs the REST surface against
+// a live Harper, which is the integration lane's job (see
+// test/integration/durability-write-validation-e2e.test.ts).
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+describe("the durability guard stays wired into both write paths", () => {
+  const src = readFileSync(join(import.meta.dir, "..", "..", "resources", "Memory.ts"), "utf8");
+
+  test("Memory.ts imports the validator", () => {
+    expect(src).toContain('from "./memory-durability.js"');
+    expect(src).toContain("assertValidDurability");
+  });
+
+  test("it is called once per write path — post() and put()", () => {
+    const calls = src.match(/assertValidDurability\(content\.durability\)/g) ?? [];
+    // Two write paths exist (post and put). Each needs its own guard: they are
+    // separate entry points, and REST reaches both.
+    expect(calls.length).toBe(2);
+  });
+});


### PR DESCRIPTION
Closes #1238

## What

Server-side durability enum validation, mirroring the existing visibility guard (`assertValidVisibility`).

- New `assertValidDurability` in `resources/memory-durability.ts` (beside `memory-visibility.ts`), with `WRITABLE_DURABILITIES = ["permanent", "persistent", "standard", "ephemeral"]`.
- Applied in `Memory.post` and `Memory.put` **before** the `content.durability ||= "standard"` default: a present-but-unknown durability → 400 naming the valid set; absent stays defaulted (unchanged).
- Moved adk-flair's `_VALID_DURABILITIES`/`_VALID_VISIBILITIES` frozensets to module level (cosmetic, from Sherlock's #1237 review).

## Why

`defaultVisibilityForDurability` treats any non-permanent/persistent string as the private branch, so an unknown durability via raw REST (or a future non-Python adapter) is silently accepted and lands on the narrower private branch by accident — fail-safe today, but unvalidated by contract. Refusing at the schema boundary makes it safe by construction.

## Tests

- `test/unit/durability-write-validation.test.ts` — `assertValidDurability` in isolation + structural tripwire (guard wired into both write paths).
- `test/integration/durability-write-validation-e2e.test.ts` — behavioural positive control: unknown durability → 400 (fails pre-fix, passes post-fix), all four valid values unchanged, absent unchanged, PUT also guarded.