### PR TITLE
fix: make LongMemEval artifactHash reproducible

### DIFF
--- a/.changelog/unreleased/fixed-artifacthash-reproducibility.md
+++ b/.changelog/unreleased/fixed-artifacthash-reproducibility.md
@@ -1,0 +1,8 @@
+- **LongMemEval `artifactHash` is now reproducible.** `buildArtifact` previously
+  stamped `generatedAt` (wall clock) and `host` into the artifact before hashing,
+  so two runs with identical config and numbers produced different hashes. The
+  artifact is now partitioned into hashed content (`schema`, `validationSlice`,
+  `configHash`, `config`, `runHashes`, `aggregate`, `gitCommit`) and unhashed
+  provenance (`generatedAt`, `host`, `notice`, `artifactHash`); provenance is
+  stamped after hashing and stripped before verification, so identical content
+  hashes identically regardless of where or when it ran.

--- a/test/bench/longmemeval/artifact.ts
+++ b/test/bench/longmemeval/artifact.ts
@@ -8,6 +8,13 @@
  *
  *   artifactHash = sha256( canonical( configHash + per-run hashes + numbers ) )
  *
+ * The artifact is partitioned into hashed CONTENT (schema, validationSlice,
+ * configHash, config, runHashes, aggregate, gitCommit) and unhashed PROVENANCE
+ * (generatedAt, host, notice, artifactHash). Provenance is stamped AFTER hashing
+ * and stripped BEFORE verification, so two runs with identical content hash
+ * identically regardless of wall clock or host — host-invariance IS the
+ * reproducibility claim.
+ *
  * A human sign-off is recorded against a specific artifactHash — "approved to
  * publish artifact <hash>", not "the number seemed fine at some point". A
  * reviewer can recompute the hash from the committed config + the recorded
@@ -30,18 +37,23 @@ export interface RunRecord {
 }
 
 export interface Artifact {
+  // ── Hashed CONTENT — everything that determines the measured number. ──
   schema: string;
-  notice: string;
   validationSlice: boolean;
-  generatedAt: string;
   gitCommit: string | null;
-  host: { ollama: string; benchHost: string };
   configHash: string;
   config: unknown;          // the full pinned manifest (self-describing artifact)
   runHashes: string[];
   aggregate: ArmAggregate[];
+
+  // ── Unhashed PROVENANCE — stamped AFTER hashing, stripped BEFORE verify. ──
+  // These describe WHERE/WHEN the number was produced, not WHAT it is, so they
+  // must never enter the hash (host-invariance IS the reproducibility claim).
+  notice: string;
+  generatedAt: string;
+  host: { ollama: string; benchHost: string };
   /** Filled in AFTER hashing (excluded from the hash — the hash addresses
-   *  everything above it). */
+   *  the content partition above it). */
   artifactHash?: string;
 }
 
@@ -60,6 +72,18 @@ export interface BuildArtifactInput {
   validationSlice: boolean;
 }
 
+/** Provenance fields — stamped AFTER hashing and stripped BEFORE verification.
+ *  Everything else is hashed content. This list is the single source of truth
+ *  for the partition, so buildArtifact and verifyArtifactHash can never drift. */
+const PROVENANCE_KEYS = ["generatedAt", "host", "notice", "artifactHash"] as const;
+
+/** The hashed-content partition of an artifact: everything except provenance. */
+function hashedContent(art: Artifact): Record<string, unknown> {
+  const content: Record<string, unknown> = { ...art };
+  for (const key of PROVENANCE_KEYS) delete content[key];
+  return content;
+}
+
 export function buildArtifact(input: BuildArtifactInput): Artifact {
   const art: Artifact = {
     schema: "longmemeval-s.layer2.artifact/1",
@@ -76,17 +100,19 @@ export function buildArtifact(input: BuildArtifactInput): Artifact {
     runHashes: input.runHashes,
     aggregate: input.aggregate,
   };
-  // Hash everything above artifactHash. canonicalJson sorts keys, and
-  // artifactHash is absent at this point, so it cannot address itself.
-  art.artifactHash = sha256hex(canonicalJson(art));
+  // Hash the CONTENT partition only — provenance (generatedAt, host, notice) is
+  // excluded so two runs with identical content hash identically regardless of
+  // wall clock or host. canonicalJson sorts keys, and artifactHash is absent at
+  // this point, so it cannot address itself.
+  art.artifactHash = sha256hex(canonicalJson(hashedContent(art)));
   return art;
 }
 
-/** Recompute the hash of an artifact object (verification): strip artifactHash,
- *  canonicalise, sha256 — must equal the stored artifactHash. */
+/** Recompute the hash of an artifact object (verification): strip the provenance
+ *  partition (generatedAt, host, notice, artifactHash), canonicalise, sha256 —
+ *  must equal the stored artifactHash. */
 export function verifyArtifactHash(art: Artifact): boolean {
-  const { artifactHash, ...rest } = art;
-  return sha256hex(canonicalJson(rest)) === artifactHash;
+  return sha256hex(canonicalJson(hashedContent(art))) === art.artifactHash;
 }
 
 export function writeArtifact(art: Artifact, outDir: string): string {

--- a/test/unit/longmemeval-artifact.test.ts
+++ b/test/unit/longmemeval-artifact.test.ts
@@ -1,5 +1,8 @@
 import { describe, test, expect } from "bun:test";
-import { buildArtifact, verifyArtifactHash, hashRunResults } from "../bench/longmemeval/artifact";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { buildArtifact, verifyArtifactHash, writeArtifact, hashRunResults } from "../bench/longmemeval/artifact";
 import { configManifest, hashConfig, canonicalJson } from "../bench/longmemeval/config";
 
 // The publish gate is STRUCTURAL (Sherlock #4): the run emits a content-
@@ -24,13 +27,30 @@ describe("artifact — content addressing", () => {
     expect(verifyArtifactHash(art)).toBe(true);
   });
 
-  test("identical inputs → identical artifactHash (excluding volatile generatedAt)", () => {
+  test("identical inputs at different wall-times → identical artifactHash (reproducibility)", async () => {
     const a = buildArtifact(baseInput());
+    await new Promise((r) => setTimeout(r, 5)); // force a different wall-clock ms
     const b = buildArtifact(baseInput());
-    // generatedAt differs by wall-clock, so the whole-artifact hash may differ;
-    // the config + run hashes are what's reproducible.
-    expect(a.configHash).toBe(b.configHash);
-    expect(a.runHashes).toEqual(b.runHashes);
+    // The wall clock DID differ — but it is provenance, not content, so the
+    // hash must be identical. This is the whole reproducibility claim.
+    expect(a.generatedAt).not.toBe(b.generatedAt);
+    expect(a.artifactHash).toBe(b.artifactHash);
+  });
+
+  test("mutating one aggregate number changes the artifactHash (tamper-evident)", () => {
+    const a = buildArtifact(baseInput());
+    const b = buildArtifact({
+      ...baseInput(),
+      aggregate: [{ arm: "flair", overallAccuracy: { mean: 0.42, std: 0, runs: [0.42] } }] as any,
+    });
+    expect(b.artifactHash).not.toBe(a.artifactHash);
+  });
+
+  test("verifyArtifactHash round-trips a written artifact", () => {
+    const art = buildArtifact(baseInput());
+    const path = writeArtifact(art, join(tmpdir(), "lme-artifact-test"));
+    const written = JSON.parse(readFileSync(path, "utf8"));
+    expect(verifyArtifactHash(written)).toBe(true);
   });
 
   test("a changed number changes the artifactHash (tamper-evident)", () => {


### PR DESCRIPTION
Closes #1239

## What

`buildArtifact` (test/bench/longmemeval/artifact.ts) stamped `generatedAt` (wall clock) and `host` into the artifact **before** hashing, so two runs with identical config and numbers produced different `artifactHash`es — breaking the benchmark's reproducibility pitch.

The artifact is now partitioned into:

- **Hashed CONTENT** — `schema`, `validationSlice`, `configHash`, `config`, `runHashes`, `aggregate`, `gitCommit`
- **Unhashed PROVENANCE** — `generatedAt`, `host`, `notice`, `artifactHash`

Provenance is stamped **after** hashing (exactly as `artifactHash` already was), and `verifyArtifactHash` strips the same provenance set. A single `PROVENANCE_KEYS` constant + `hashedContent()` helper is the source of truth so the two can never drift.

## Ruling (per issue)

- **gitCommit IN-hash** — the code that produced the number is content.
- **host OUT** — where it ran must not change what was measured; host-invariance is precisely the reproducibility claim.

## Tests

- **Positive control** — two `buildArtifact` calls with identical input at different wall-times → identical `artifactHash`. This **fails on current main** (1 fail: `generatedAt` differs → hash differs) and passes post-fix.
- Mutating one aggregate number → hash changes (tamper-evident).
- `verifyArtifactHash` round-trips a written artifact (write → read → verify).

Full suite: 11 pass, 0 fail.