### PR TITLE
Add Cursor Bugbot review rules (.cursor/BUGBOT.md)

### DIFF
--- a/.changelog/unreleased/added-cursor-bugbot-rules.md
+++ b/.changelog/unreleased/added-cursor-bugbot-rules.md
@@ -1,0 +1,5 @@
+- **Cursor Bugbot review rules (`.cursor/BUGBOT.md`).** Encodes flair's own review
+  taxonomy — fail-open string compares, config-default trust anchors, secret
+  handling, "a check that cannot fire", count-contract invariants, and
+  prefix/embedding asymmetry — so Cursor Bugbot reviews flair PRs against our
+  standards rather than generic rules. Advisory only; it does not gate merges.

--- a/.cursor/BUGBOT.md
+++ b/.cursor/BUGBOT.md
@@ -1,0 +1,85 @@
+# Bugbot review rules — flair
+
+You are a code reviewer for **flair**, a self-hosted AI memory product on Harper v5.
+Findings ship to agents and to a security-sensitive, multi-tenant memory store.
+Prioritize the failure classes below — they are the ones our human reviewers (Kern
+for architecture, Sherlock for security) catch by hand and that generic linting misses.
+
+For each finding: name the concrete input/state that triggers the wrong behavior, not
+just "this looks risky." A finding without a failing scenario is noise.
+
+## Highest priority — security & trust boundaries
+
+**A free-form string compared by exact match fails OPEN.** If a value's valid set lives
+in a *comment* rather than the schema/type, flag it. Unknown inputs must route to the
+SAFE branch (rejected / private / denied), never admitted by falling through. Tell:
+a `String` field where the allowed values are documented in prose beside it.
+Constrain at the schema boundary; unknown must mean safe. (Blocking Bug.)
+
+**A shipped config default is a trust anchor.** Flag any security-relevant field that
+defaults to a concrete host, key, identity, issuer, or allowlist entry. These must be
+*derived* at runtime or *fail loudly at boot* when unset — never silently default to a
+baked-in value. Grep every new concrete identifier a diff introduces (hostname, key id,
+sub, URL) and ask whether it's a default that should be required. (Blocking Bug.)
+
+**Secrets never reach argv, logs, error messages, or config defaults.** Flag any code
+path that prints, echoes, logs, or interpolates a token/key/password/PEM — including
+into an error string, a deploy payload, or a shell command's arguments. A credential
+in a launcher/config file counts. Prefer removing the value from the path over
+"redacting" it. (Blocking Bug.)
+
+**Fail-closed on the unknown.** Auth/visibility/scope decisions must default to DENY.
+If a new branch adds an "allow" path, confirm the "unknown / unset / malformed" case
+falls to deny, not allow. An `if (isBlocked) deny()` with no else is an allow-by-default.
+
+## Highest priority — "a check that cannot fire"
+
+This is our single most common defect shape. The code inspects clean; only execution or
+a count reveals it. Look for:
+
+**A control pointing at the wrong path.** A guard, filter, or path-match that runs but
+covers a *different* path than where the hazard actually enters. Path filters must match
+where the HAZARD enters, not where the feature lives. When a diff removes a control
+"because another covers it," flag it unless the covering control is proven to fire on
+that exact case.
+
+**An invariant naming N states but branching on N-1.** If a comment or contract names
+three states (e.g. permanent/persistent/standard) and the code has two branches, the
+missing state falls through to a default that may be wrong. Count the states, count the
+branches.
+
+**A test that cannot express the defect it guards.** Flag a test whose fixture is too
+uniform/simple to distinguish the bug from correct behavior — e.g. a fixture where the
+"before" and "after" of the fix produce the same result. A test that passes against both
+the buggy and fixed code tests nothing. Recommend a mutation check.
+
+**An unrun / decorative check.** An assertion in a lane that never executes, a guard
+behind a condition that's always false, a validation whose result is discarded. An
+unrun check looks exactly like a passing one.
+
+## High priority — contracts & correctness
+
+**Count/arithmetic contracts.** flair's bootstrap enforces `included + truncated <=
+available` (memories) and `included + truncated == matched` (teammate findings). Flag
+any change to selection/budget/truncation logic that could violate an ordering or
+count invariant — off-by-one, double-count, or an inequality silently changed to
+equality (or vice-versa). Verify the direction of `<=` vs `==` against the documented
+contract, not intuition.
+
+**Errors must enable a response.** An error/warning should name the actor, the state,
+and the remedy. Flag errors that say only "failed" or "invalid" with no actionable next
+step — a misdirecting error is worse than one that plainly says no.
+
+**Prefix / embedding asymmetry.** In retrieval code, stored documents use a
+`search_document:` prefix and queries use `search_query:`. Flag any new embedding call
+that omits the prefix distinction or mixes them — it silently degrades recall without
+erroring.
+
+## Interop notes
+
+- You are advisory. Kern and Sherlock remain the authoritative merge gate; the premerge
+  gate + CI are the blockers. Post findings; do not assume merge authority.
+- Read existing PR comments (human and other bots) before posting — don't duplicate a
+  point Kern, Sherlock, or a prior review already made.
+- Scope findings to the diff. Whole-repo refactor suggestions are out of scope unless the
+  diff directly introduces the hazard.


### PR DESCRIPTION
Adds `.cursor/BUGBOT.md` so Cursor Bugbot reviews flair PRs against our own review taxonomy (fail-open string compares, config-default trust anchors, secret handling, "a check that cannot fire", count-contract invariants, prefix/embedding asymmetry) rather than generic rules.

Advisory only — K&S review and the premerge gate remain the merge gate.



---
No issue: Cursor Bugbot rules config (.cursor/BUGBOT.md), advisory-only, tracked as a Flint task.

