### PR TITLE
docs: Harper Fabric Quick Start for a reachable FLAIR_URL

### DIFF
--- a/.changelog/unreleased/added-fabric-quickstart.md
+++ b/.changelog/unreleased/added-fabric-quickstart.md
@@ -1,0 +1,6 @@
+- **Harper Fabric Quick Start for a reachable `FLAIR_URL`.** New
+  [`docs/quickstart-fabric.md`](docs/quickstart-fabric.md) walks a first-time
+  Cursor / Grok Bot user through `flair deploy`, remote `flair agent add
+  --target`, and pasting the HTTPS origin into the plugin. Laptop
+  `docs/quickstart.md` stays the local path and now points at Fabric when
+  `127.0.0.1:19926` is not enough.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -81,6 +81,6 @@ config.yaml    Flair server configuration (port via CLI or HTTP_PORT env).
 | How do I run the CLI? | `src/cli.ts` → `flair --help` |
 | What are the design rules? | `DESIGN.md` |
 | How do I contribute? | `CONTRIBUTING.md` |
-| How do I use Flair? | `README.md` → `docs/quickstart.md` |
+| How do I use Flair? | `README.md` → `docs/quickstart.md` (laptop) · `docs/quickstart-fabric.md` (reachable URL) |
 | What does the data model look like? | `schemas/` |
 | Where is planned/proposed work? | GitHub issues — not in this repo. Nothing in the tree is a proposal |

--- a/README.md
+++ b/README.md
@@ -347,7 +347,7 @@ flair agent add otherbot --target https://your-server:19926
 
 ### Harper Fabric
 
-Managed hosting with multi-region replication and failover. Federation runs against Harper Fabric hubs — pair your local instance to sync memories across nodes. Full guide: **[docs/deploying-on-fabric.md](docs/deploying-on-fabric.md)**.
+Managed hosting with multi-region replication and failover. Need a public URL for Cursor / Grok Bot / cloud agents? Start at **[docs/quickstart-fabric.md](docs/quickstart-fabric.md)**. Federation, pairing, and operator detail: **[docs/deploying-on-fabric.md](docs/deploying-on-fabric.md)**.
 
 ## Security
 

--- a/docs/deploying-on-fabric.md
+++ b/docs/deploying-on-fabric.md
@@ -21,6 +21,9 @@ you already have, [Remote Server](../README.md#remote-server) is simpler and kee
 
 ## Quickstart
 
+New user who just needs a reachable `FLAIR_URL` for Cursor / Grok Bot? Start at
+[quickstart-fabric.md](quickstart-fabric.md). This page is the operator path.
+
 ### 1. Deploy the component
 
 ```bash

--- a/docs/deployment-shapes.md
+++ b/docs/deployment-shapes.md
@@ -5,7 +5,7 @@ Flair runs in one of three shapes. Pick yours and follow only that path.
 | You want to... | Shape | Start here |
 |---|---|---|
 | Run Flair on your own machine or VPS. `flair init` installs Harper, creates your agent identity, and you're running. | **Standalone local** | [standalone-local.md](standalone-local.md) |
-| Run Flair on [Harper Fabric](https://www.harperdb.io/) — managed hosting, multi-region replication, no shell on the node. You deploy a component; agents connect over HTTPS. | **Hosted on Fabric** | [hosted-on-fabric.md](hosted-on-fabric.md) |
+| Run Flair on [Harper Fabric](https://www.harperdb.io/) — managed hosting, multi-region replication, no shell on the node. You deploy a component; agents connect over HTTPS. | **Hosted on Fabric** | [quickstart-fabric.md](quickstart-fabric.md) (new-user URL) · [hosted-on-fabric.md](hosted-on-fabric.md) |
 | Load Flair into a Harper instance you already run. In-process calls — no HTTP, no second process, no key to distribute. Over HTTP it is one memory API among many. | **Embedded in a Harper app** | [embedding-in-a-harper-app.md](embedding-in-a-harper-app.md) |
 
 ---

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -116,10 +116,11 @@ Note: embeddings run on CPU in Docker (no Metal acceleration). Performance is ac
 
 Deploying to a Harper Fabric cluster is a different mechanism from the installs above — `flair deploy` pushes Flair as a cluster component instead of `npm install -g`. To upgrade an already-deployed Fabric instance in place, use `FABRIC_USER=<admin> FABRIC_PASSWORD=<pass> flair upgrade --target <fabric-url>` (or `--fabric-password-file <path>` in place of the env var), not the local upgrade path. Inline `--fabric-user`/`--fabric-password` flags also work but are discouraged — both leak to shell history and `ps`. See [`docs/upgrade.md` — Upgrading a Fabric-deployed instance](upgrade.md#upgrading-a-fabric-deployed-instance) for the full walkthrough, including the automatic post-deploy fleet-convergence sweep.
 
-For the hosted shape end to end — when to choose it, ports and auth against a managed
-Fabric endpoint, pairing local spokes to a hosted hub, and what you can and cannot
-observe without a shell on the node — see
-[`docs/deploying-on-fabric.md`](deploying-on-fabric.md).
+New user who needs a reachable `FLAIR_URL` for Cursor / Grok Bot? Start at
+[`docs/quickstart-fabric.md`](quickstart-fabric.md). For the hosted shape end to
+end — when to choose it, ports and auth against a managed Fabric endpoint, pairing
+local spokes to a hosted hub, and what you can and cannot observe without a shell
+on the node — see [`docs/deploying-on-fabric.md`](deploying-on-fabric.md).
 
 ---
 

--- a/docs/hosted-on-fabric.md
+++ b/docs/hosted-on-fabric.md
@@ -2,6 +2,8 @@
 
 Deploy Flair as a component to a [Harper Fabric](https://www.harperdb.io/) instance. You do not run the Harper process yourself: managed hosting, multi-region replication, no shell on the node.
 
+Need a public URL for Cursor / Grok Bot / cloud agents? Start at [quickstart-fabric.md](quickstart-fabric.md).
+
 ---
 
 ## Deploy

--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -195,7 +195,8 @@ If it has a custom memory protocol, the adapter pattern is small (~200 lines). L
 
 ## See also
 
-- [Quickstart](quickstart.md) — `flair init` to working memory in 30 seconds
+- [Quickstart](quickstart.md) — `flair init` to working memory on a laptop
+- [Fabric Quickstart](quickstart-fabric.md) — `flair deploy` to a reachable Harper Fabric URL
 - [Embedding in a Harper app](embedding-in-a-harper-app.md) — run Flair as a component of your own Harper instance and call it in-process
 - [Memory bridges](bridges.md) — import/export Flair ↔ Mem0, ChatGPT, claude-project, markdown, agentic-stack (five bridges shipped)
 - [Federation](federation.md) — pair instances peer-to-peer for cross-machine sync

--- a/docs/quickstart-fabric.md
+++ b/docs/quickstart-fabric.md
@@ -1,0 +1,106 @@
+# Fabric Quick Start
+
+From zero to a **reachable** Flair URL — so Cursor, Grok Bot, and cloud agents can actually hit it.
+
+Laptop Flair from [`docs/quickstart.md`](quickstart.md) listens on `127.0.0.1:19926`. That loopback origin is not reachable from Grok Bot or Cursor cloud agents. This page is the start path when you need a public HTTPS origin.
+
+Fabric is **Harper-hosted**, not a Flair-operated cloud. You deploy Flair as a component onto [Harper Fabric](https://www.harperdb.io/).
+
+## 0. Prerequisites
+
+**Node.js 22 or newer**, a user-writable npm global prefix (do not install with `sudo` — same rule as the [local Quick Start](quickstart.md#0-prerequisites)), and **a Harper Fabric account** ([harperdb.io](https://www.harperdb.io/)). You need the org name, cluster name, and admin credentials for that account.
+
+```bash
+node --version   # v22.x.x or newer
+npm i -g @tpsdev-ai/flair
+```
+
+Lead with environment credentials so they stay out of `ps` and shell history:
+
+```bash
+export FABRIC_USER=<admin>
+export FABRIC_PASSWORD=<pass>
+```
+
+Scripting? Use `--fabric-password-file <path>` (mode `0600`) instead of `FABRIC_PASSWORD`. Inline `--fabric-password` works and leaks — do not lead with it.
+
+`FABRIC_ORG` / `FABRIC_CLUSTER` can stand in for the flags below. `--fabric-token` is accepted but **fails** — Fabric `deploy_component` is Basic-auth only.
+
+## 1. Deploy
+
+```bash
+# Validate args and package layout without deploying
+flair deploy --fabric-org <org> --fabric-cluster <cluster> --dry-run
+
+flair deploy --fabric-org <org> --fabric-cluster <cluster>
+```
+
+The target defaults to `https://<cluster>.<org>.harperfabric.com`. Override with `--target` if your instance URL is different. `flair deploy` writes `FLAIR_PUBLIC_URL` to that same origin so OAuth and A2A discovery do not advertise loopback.
+
+## 2. What success looks like
+
+```
+→ Deploying flair to https://<cluster>.<org>.harperfabric.com
+
+✓ Flair vX.Y.Z deployed and verified serving
+
+  URL:     https://<cluster>.<org>.harperfabric.com
+  Project: flair
+```
+
+A fleet-verify table follows. That HTTPS origin is your `FLAIR_URL`.
+
+Then set an admin password in Fabric Studio (Cluster Settings → Admin). `flair agent add` against a remote instance requires `--admin-pass` — it will not reuse `~/.flair/admin-pass` or `FLAIR_ADMIN_PASS` from your laptop.
+
+## 3. Register an agent against the remote instance
+
+`flair agent add` takes a positional id and `--target`. There is no `--remote` flag on this command (`--remote` belongs to `flair init`).
+
+On Fabric, ops lives on the **same hostname at port 9925**, not the CLI's default "data port − 1" derivation (that would be `:442`, where nothing answers). Pass `--ops-target` explicitly: <!-- docs-freshness-allow: Fabric ops API port, not legacy data port -->
+
+```bash
+export FLAIR_URL=https://<cluster>.<org>.harperfabric.com
+
+# Fabric ops is :9925 on the same host, not derived :442. docs-freshness-allow: Fabric ops API
+flair agent add mybot --target "$FLAIR_URL" --ops-target https://<cluster>.<org>.harperfabric.com:9925 --admin-pass <fabric-admin-password>
+```
+
+```
+Keypair written: ~/.flair/keys/mybot.key
+✅ Agent 'mybot' (mybot) registered (ops: https://<cluster>.<org>.harperfabric.com:9925) <!-- docs-freshness-allow: Fabric ops API -->
+   Private key: ~/.flair/keys/mybot.key
+```
+
+The private key stays on **this machine**. The Fabric node stores only the public key.
+
+## 4. Point the Cursor plugin at it
+
+This is why Fabric is the recommended start for **Grok Bot / Cursor cloud agents**: they cannot see your laptop's `127.0.0.1:19926`.
+
+In Cursor: **Plugins → Configure**
+
+| Variable | Value |
+|---|---|
+| `FLAIR_URL` | `https://<cluster>.<org>.harperfabric.com` |
+| `FLAIR_AGENT_ID` | `mybot` (the id you just added) |
+
+Those are the two plugin schema fields. Local Cursor's `npx` can use the key from step 3 at `~/.flair/keys/mybot.key`. A cloud agent's `npx` runs on a different machine — that VM needs the key (or host-env admin credentials). See [`packages/cursor-flair/README.md`](../packages/cursor-flair/README.md).
+
+## 5. Verify
+
+```bash
+flair status --target "$FLAIR_URL"
+FLAIR_URL="$FLAIR_URL" flair memory add --agent mybot "Fabric Quick Start is reachable"
+```
+
+`flair memory add` has no `--target`; it honors `FLAIR_URL`. Then in Cursor:
+
+> Load my Flair bootstrap, then store a test memory
+
+You should see `bootstrap` return soul + memories, then `memory_store` confirm an id.
+
+## What's next
+
+Federation, pairing spokes, upgrades (`flair upgrade --target`), ports, and what you can observe without a shell on the node: **[docs/deploying-on-fabric.md](deploying-on-fabric.md)**.
+
+Still on a laptop only, no public URL needed: **[docs/quickstart.md](quickstart.md)**.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -2,6 +2,8 @@
 
 From zero to a persistent agent memory in five minutes.
 
+> **Need a reachable URL (Cursor cloud / Grok Bot / another machine)?** This guide is the laptop path — `flair init` binds `127.0.0.1:19926`, which those clients cannot see. Deploy on Harper Fabric instead: **[docs/quickstart-fabric.md](quickstart-fabric.md)**.
+
 ## 0. Prerequisites
 
 **Node.js 22 or newer.** No Docker, no database to install, no API keys — Flair runs in a single process and computes embeddings locally.

--- a/docs/standalone-local.md
+++ b/docs/standalone-local.md
@@ -235,7 +235,8 @@ Full walkthrough: [federation.md](federation.md).
 ## See also
 
 - [deployment-shapes.md](deployment-shapes.md) — choose your shape
-- [quickstart.md](quickstart.md) — zero to working in 5 minutes
+- [quickstart.md](quickstart.md) — zero to working in 5 minutes (laptop)
+- [quickstart-fabric.md](quickstart-fabric.md) — reachable Harper Fabric URL for Cursor cloud / Grok Bot
 - [upgrade.md](upgrade.md) — full upgrade mechanics (re-embedding, rollback, downgrade)
 - [federation.md](federation.md) — hub-and-spoke sync between instances
 - [troubleshooting.md](troubleshooting.md) — common issues and automated diagnosis

--- a/packages/cursor-flair/README.md
+++ b/packages/cursor-flair/README.md
@@ -6,13 +6,17 @@ This bundle is **not an npm runtime**. It wires Cursor to the stdio MCP server [
 
 ## Prerequisites
 
-A running Flair instance and an agent identity:
+A running Flair instance and an agent identity.
+
+**Laptop (this machine only):**
 
 ```bash
 npm i -g @tpsdev-ai/flair
 flair init --agent <id>    # Harper + agent + key at ~/.flair/keys/<id>.key
 flair status               # default HTTP origin: http://127.0.0.1:19926
 ```
+
+**Grok Bot / Cursor cloud / another machine:** `127.0.0.1:19926` is not reachable. Start on Harper Fabric: **[docs/quickstart-fabric.md](../../docs/quickstart-fabric.md)**.
 
 `<id>` must match the `FLAIR_AGENT_ID` you configure in the plugin. Node.js **>= 22** is required on the machine that runs `npx` (the MCP server's engines field).
 
@@ -30,20 +34,18 @@ Set these under **Plugins → Configure**. `FLAIR_CLIENT=cursor` is set for you 
 |---|---|---|---|
 | `FLAIR_AGENT_ID` | yes | — | Must match `flair agent add <id>` |
 | `FLAIR_URL` | no | `http://127.0.0.1:19926` | Reachable Flair HTTP origin |
-| `FLAIR_KEY_PATH` | no | `~/.flair/keys/<id>.key` on the **npx host** | Not a plugin variable; set in that machine's host env if you need a non-default path |
-| `FLAIR_ADMIN_USER` / `FLAIR_ADMIN_PASSWORD` | no | — | Basic auth for standalone Flair when a key file cannot be mounted. **Never commit values.** Set in the host env of the machine that runs `npx`, not in `mcp.json` |
 
-`FLAIR_KEY_PATH` and `FLAIR_ADMIN_*` are documented here in the README only — they are **not** declared as plugin variables and **not** interpolated into `mcp.json`. Set them in the host env of the machine that runs `npx`. Keeping them out of `mcp.json` is deliberate: an unsubstituted `${FLAIR_KEY_PATH}` would be truthy and break key auto-resolve, and an unsubstituted admin password would send literal Basic auth.
+Those are the only two fields in the plugin schema (`plugin.json`). `FLAIR_KEY_PATH` and `FLAIR_ADMIN_*` are documented here in the README only — they are **not** declared as plugin variables and **not** interpolated into `mcp.json`. Set them in the host env of the machine that runs `npx`. Keeping them out of `mcp.json` is deliberate: an unsubstituted `${FLAIR_KEY_PATH}` would be truthy and break key auto-resolve, and an unsubstituted admin password would send literal Basic auth.
 
 ## Grok Bot / Cursor cloud agents
 
-`npx` runs on the **agent machine**. That process's `localhost` is not your laptop.
+`npx` runs on the **agent machine**. That process's `localhost` is not your laptop. Laptop `flair init` on `127.0.0.1:19926` is not reachable from Grok Bot or Cursor cloud agents.
 
-- Set `FLAIR_URL` to an origin the agent VM can reach: a VPS, Harper Fabric, Tailscale, or a tunnel. The default `http://127.0.0.1:19926` points at the npx host, which on a cloud agent is the cloud VM.
-- Put the agent key on **that** machine (`FLAIR_KEY_PATH`, or the default `~/.flair/keys/<id>.key` there), **or** set `FLAIR_ADMIN_USER` / `FLAIR_ADMIN_PASSWORD` in the host env of the machine that runs `npx`.
+**Start on Harper Fabric** when you need a public URL: **[docs/quickstart-fabric.md](../../docs/quickstart-fabric.md)**. Deploy, register an agent with `--target`, then paste that `https://<cluster>.<org>.harperfabric.com` origin into `FLAIR_URL`. Fabric is Harper-hosted, not a Flair-operated cloud.
+
+- Set `FLAIR_URL` to an origin the agent VM can reach. The default `http://127.0.0.1:19926` points at the npx host, which on a cloud agent is the cloud VM.
+- The agent key lives on the **npx host** at `~/.flair/keys/<id>.key` (or `FLAIR_KEY_PATH` in that machine's environment). If you cannot mount a key, set `FLAIR_ADMIN_USER` / `FLAIR_ADMIN_PASSWORD` in the host env of the machine that runs `npx` — not in plugin Configure.
 - Node **>= 22** must be on that same machine.
-
-There is no hosted Flair cloud product. You run the instance (or tunnel to one you run).
 
 ## Skills
 

--- a/scripts/docs-freshness-check.mjs
+++ b/scripts/docs-freshness-check.mjs
@@ -85,7 +85,7 @@ const PROSE_DOCS = collectProseDocs();
 
 // Getting-started docs must not hardcode a concrete Flair version at all — every
 // version there should be a `vX.Y.Z` placeholder or an external tool's version.
-const GETTING_STARTED_DOCS = ["docs/quickstart.md"].filter((f) => existsSync(join(ROOT, f)));
+const GETTING_STARTED_DOCS = ["docs/quickstart.md", "docs/quickstart-fabric.md"].filter((f) => existsSync(join(ROOT, f)));
 
 const fileLines = new Map();
 function linesOf(relPath) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Laptop `flair init` binds `127.0.0.1:19926`, which Grok Bot and Cursor cloud agents cannot reach. This adds a stranger-friendly Harper Fabric Quick Start and points the local guide, Cursor plugin README, and existing Fabric operator docs at it.

Rebased onto current `main` (after #1252 / #1253). The only conflict was `packages/cursor-flair/README.md`: Configure table stays the two real `plugin.json` fields (`FLAIR_AGENT_ID`, `FLAIR_URL`); #1253's host-env wording for `FLAIR_KEY_PATH` / admin vars is kept in the prose under the table.

## What changed

- New [`docs/quickstart-fabric.md`](docs/quickstart-fabric.md): deploy with `FABRIC_USER` / `FABRIC_PASSWORD` (or `--fabric-password-file`), register an agent with the real `flair agent add <id> --target` / `--ops-target` flags, paste the HTTPS origin into the Cursor plugin.
- Local [`docs/quickstart.md`](docs/quickstart.md) stays the laptop path and now callouts Fabric when a public URL is needed.
- [`packages/cursor-flair/README.md`](packages/cursor-flair/README.md) recommends Fabric as the start path for Grok Bot / cloud agents, and does not list `FLAIR_KEY_PATH` / admin vars as plugin schema fields.
- One-line pointers from README, `docs/deployment.md`, and the Fabric operator pages.

Fabric is Harper-hosted, not a Flair-operated cloud. No deploy/CLI code changes.

## Test plan

Read-through of documented commands against the real CLI (no live Fabric deploy in this PR):

- [x] `src/cli.ts` deploy options / help strings: `--fabric-org`, `--fabric-cluster`, `--target` override of `https://<cluster>.<org>.harperfabric.com`, `FABRIC_USER` / `FABRIC_PASSWORD` / `--fabric-password-file`. Did not lead with inline `--fabric-password`.
- [x] Deploy success copy matches `src/cli.ts` (`✓ Flair … deployed and verified serving`, `URL:` / `Project:`). Noted that the CLI's printed next-step (`flair agent add --remote … --name`) is **not** a real `agent add` invocation — `--remote` is an `init` flag; `agent add` is `add <id>` plus `--target`.
- [x] `flair agent add` handler: positional `<id>`, `--target`, `--ops-target`, `--admin-pass` required for remote (no local `~/.flair/admin-pass` / `FLAIR_ADMIN_PASS` fallback). Fabric ops port 9925 called out because HTTPS:443 derives `:442`.
- [x] `flair status --target` exists; `flair memory add` has no `--target` and honors `FLAIR_URL`.
- [x] `packages/cursor-flair/.cursor-plugin/plugin.json` variables are only `FLAIR_AGENT_ID` and `FLAIR_URL`.
- [x] `node scripts/changelog-fragments.mjs check` — pass (2 fragments).
- [x] `node scripts/docs-freshness-check.mjs` — 6/7 passed, including getting-started (now 2 docs) and port-drift. `cli-command-descriptions` skipped here because `dist/cli.js` is not built; CI runs that check after `build:cli`.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-636c1ba5-adbd-4cbd-bb98-57771562c0b9?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-636c1ba5-adbd-4cbd-bb98-57771562c0b9&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>




---
No issue: Harper Fabric quickstart docs (part of the Cursor plugin publish path).
