### PR TITLE
Temporal search intent must boost recency, not hard-filter (Refs #1245)

### DIFF
--- a/.changelog/unreleased/fixed-temporal-intent-boost-not-filter.md
+++ b/.changelog/unreleased/fixed-temporal-intent-boost-not-filter.md
@@ -1,0 +1,6 @@
+- **Recall no longer drops older memories when the query text merely mentions a
+  time.** A temporal word in a search query (e.g. an incidental "today" sitting
+  inside a slogan) used to derive a hard `since` cutoff that silently excluded
+  every memory older than that window — so an on-topic recall could return
+  nothing. Text-derived temporal intent now only nudges recency in ranking; it
+  never filters. An explicit `since` API parameter still hard-filters, unchanged.

--- a/resources/SemanticSearch.ts
+++ b/resources/SemanticSearch.ts
@@ -137,22 +137,22 @@ export class SemanticSearch extends Resource {
     let temporalBoost = 1.0;
     if (q && !sinceDate) {
       const lq = String(q).toLowerCase();
+      // flair#1245: a text-derived temporal match must ONLY nudge recency in
+      // ranking (temporalBoost, a soft multiplier applied in
+      // semantic-retrieval-core.ts) — it must NEVER derive a hard `sinceDate`
+      // exclusion. An incidental temporal word in the query TEXT (the #1245
+      // canary carried "today" inside a slogan) otherwise silently dropped
+      // every candidate older than the window → 0 results. Only the explicit
+      // `since` API param (set above, untouched here) still hard-filters.
       if (/\btoday\b|\bthis morning\b|\bthis afternoon\b/.test(lq)) {
-        const d = new Date(); d.setHours(0, 0, 0, 0);
-        sinceDate = d;
         temporalBoost = 1.5;
       } else if (/\byesterday\b/.test(lq)) {
-        const d = new Date(); d.setDate(d.getDate() - 1); d.setHours(0, 0, 0, 0);
-        sinceDate = d;
         temporalBoost = 1.3;
       } else if (/\bthis week\b|\blast few days\b/.test(lq)) {
-        sinceDate = new Date(Date.now() - 7 * 24 * 3600_000);
         temporalBoost = 1.2;
       } else if (/\blast week\b/.test(lq)) {
-        sinceDate = new Date(Date.now() - 14 * 24 * 3600_000);
         temporalBoost = 1.1;
       } else if (/\brecently\b|\blately\b/.test(lq)) {
-        sinceDate = new Date(Date.now() - 3 * 24 * 3600_000);
         temporalBoost = 1.3;
       }
     }

--- a/test/unit-isolated/semantic-search-scoping.test.ts
+++ b/test/unit-isolated/semantic-search-scoping.test.ts
@@ -316,3 +316,84 @@ describe("SemanticSearch.post() — centralized read-scoping", () => {
     expect(embedInputTypeCalls.every((t) => t === "query")).toBe(true);
   });
 });
+
+// ─── flair#1245: text-derived temporal intent must BOOST, not hard-EXCLUDE ───
+// These exercise the SHIPPED SemanticSearch.post() → retrieveCandidates() path
+// through this file's mocked Harper. getEmbedding() is stubbed to return null
+// (see the module-level mock above), so every `q`-bearing call here takes the
+// hybrid BM25 corpus leg, where the per-record temporal gate (sinceDate against
+// record.createdAt) is applied by isAllowedBm25Candidate() in
+// resources/bm25-filter.ts — the exact mechanism #1245 misfired through. A
+// single rank-1 BM25 candidate RRF-normalizes to rawScore 1.0, so under
+// scoring="raw" the reported _score IS the temporalBoost multiplier, which
+// makes the boost directly observable.
+describe("SemanticSearch.post() — flair#1245 temporal intent BOOSTS, never hard-EXCLUDEs", () => {
+  const THIRTY_DAYS_AGO = () => new Date(Date.now() - 30 * 24 * 3600_000).toISOString();
+
+  // TEST 1 — the #1245 regression control. An incidental temporal word in the
+  // query TEXT ("today", as in the canary's slogan) must not drop on-topic
+  // records that predate the derived window. Pre-fix this returned 0 results.
+  // MUTATION-CHECK anchor: re-adding `sinceDate = <today-midnight>` in the
+  // "today" branch of SemanticSearch.ts makes THIS test fail (0 results).
+  it("flair#1245 regression: an incidental temporal word boosts but never hard-excludes an older on-topic record", async () => {
+    reset();
+    memoryStore.set("slogan-1", {
+      id: "slogan-1", agentId: "agent-1",
+      content: "widget slogans for the campaign", createdAt: THIRTY_DAYS_AGO(),
+    });
+    const s = makeSearch(agentCtx("agent-1"));
+    // "today" appears incidentally; the query is about widget slogans, and the
+    // one matching record was created 30 days ago.
+    const res: any = await s.post({ agentId: "agent-1", q: "widget slogans for today", limit: 10 });
+    expect(res.results.length).toBeGreaterThan(0);
+    expect(res.results.map((r: any) => r.id)).toContain("slogan-1");
+  });
+
+  // TEST 2 — the soft nudge survives AND nothing is excluded. temporalBoost is
+  // a flat multiplier (semantic-retrieval-core.ts: `finalScore *= temporalBoost`),
+  // so with scoring="raw" and one rank-1 candidate (rawScore 1.0) the _score
+  // reads back the boost directly. Recency ORDERING (recent above older) is a
+  // separate mechanism — compositeScore's recency decay — untouched by this
+  // fix; this test proves only what the fix guarantees: the boost is still
+  // applied and the older record is not filtered out.
+  it("flair#1245: the temporalBoost soft nudge is preserved, and the older record is never hard-excluded", async () => {
+    reset();
+    memoryStore.set("old-widget", {
+      id: "old-widget", agentId: "agent-1", content: "widget notes", createdAt: THIRTY_DAYS_AGO(),
+    });
+    const s = makeSearch(agentCtx("agent-1"));
+    // Same single record is rank-1 in both queries ⇒ identical rawScore; the
+    // ONLY difference is the incidental "today" ⇒ temporalBoost 1.5.
+    const plain: any = await s.post({ agentId: "agent-1", q: "widget notes", scoring: "raw", limit: 10 });
+    const boosted: any = await s.post({ agentId: "agent-1", q: "widget notes today", scoring: "raw", limit: 10 });
+
+    // (a) NOT EXCLUDED: the 30-day-old record surfaces under the temporal query.
+    const boostedRec = boosted.results.find((r: any) => r.id === "old-widget");
+    const plainRec = plain.results.find((r: any) => r.id === "old-widget");
+    expect(boostedRec).toBeDefined();
+    expect(plainRec).toBeDefined();
+
+    // (b) BOOST PRESERVED: "today" multiplies the score by 1.5; it does not filter.
+    expect(boostedRec._score).toBeGreaterThan(plainRec._score);
+    expect(boostedRec._score / plainRec._score).toBeCloseTo(1.5, 2);
+  });
+
+  // TEST 3 — the positive control proving intentional filtering is intact. The
+  // EXPLICIT `since` API param (SemanticSearch.ts's `since ? new Date(since) : null`,
+  // deliberately left untouched) must STILL hard-filter older records out.
+  it("flair#1245: an explicit `since` param still hard-filters (intentional time-filtering unchanged)", async () => {
+    reset();
+    memoryStore.set("old-widget", {
+      id: "old-widget", agentId: "agent-1", content: "widget notes", createdAt: THIRTY_DAYS_AGO(),
+    });
+    memoryStore.set("new-widget", {
+      id: "new-widget", agentId: "agent-1", content: "widget notes", createdAt: new Date().toISOString(),
+    });
+    const s = makeSearch(agentCtx("agent-1"));
+    const sevenDaysAgo = new Date(Date.now() - 7 * 24 * 3600_000).toISOString();
+    const res: any = await s.post({ agentId: "agent-1", q: "widget notes", since: sevenDaysAgo, limit: 10 });
+    const ids = res.results.map((r: any) => r.id);
+    expect(ids).toContain("new-widget");     // within the explicit window
+    expect(ids).not.toContain("old-widget"); // 30 days old ⇒ hard-excluded by `since`
+  });
+});


### PR DESCRIPTION
## What

Text-derived temporal intent in a memory search must **boost recency in ranking, never hard-exclude** older records.

In `resources/SemanticSearch.ts`, the "Temporal intent detection" block scanned the whole query text for temporal words and set **both** a soft `temporalBoost` **and** a hard `sinceDate`. The `sinceDate` was applied as an exclusion in `resources/semantic-retrieval-core.ts` (`if (sinceDate && record.createdAt && new Date(record.createdAt) < sinceDate) continue;`). When a temporal word appeared incidentally — the #1245 canary carried "today" inside a slogan — it silently dropped every candidate older than the derived window, returning **0 results** for on-topic recall.

## Change

- Remove **only** the text-derived `sinceDate = ...` assignments (the five regex branches: today / yesterday / this week / last week / recently), and the now-dead `const d` computations that fed them.
- Keep **every** `temporalBoost = ...` assignment — the soft ranking nudge is unchanged.
- The explicit `since` API param line (`let sinceDate = since ? new Date(since) : null;`) is **untouched** — an explicit `since` still hard-filters.

`temporalBoost` and `sinceDate` feed independent mechanisms, so removing the text-derived `sinceDate` is clean (Kern-confirmed on the issue).

## Tests

Added to `test/unit-isolated/semantic-search-scoping.test.ts` — these exercise the shipped `SemanticSearch.post()` -> `retrieveCandidates()` path over the file's mocked Harper (getEmbedding stubbed to null -> the hybrid BM25 corpus leg, where the temporal gate actually fires via `isAllowedBm25Candidate`):

1. **Regression control (#1245 shape):** an incidental "today" against a 30-day-old on-topic record returns it (length > 0, record present). **Mutation-checked** — see below.
2. **Boost preserved:** "today" still multiplies the score by 1.5 (raw scoring isolates the multiplier on a single rank-1 candidate), and the older record is never excluded.
3. **Explicit `since` still filters:** passing `since` excludes the 30-day-old record and keeps the fresh one — the positive control proving intentional filtering is intact.

### Mutation-check (test 1)

- Re-added `sinceDate = <today-midnight>` in the "today" branch -> test 1 **FAILS with `Received: 0`** (the exact #1245 symptom).
- Reverted -> test 1 **PASSES**. No mutation marker remains in the committed code.

### Suite results (worktree off `origin/main`)

- Baseline (unmodified `origin/main`): main unit lane **4563 pass / 0 fail** (243 files); isolated lane **145 pass / 0 fail**; target file **11 pass**.
- With this change: main unit lane **4563 pass / 0 fail**; isolated lane **148 pass / 0 fail**; target file **14 pass** (11 existing + 3 new).
- `bunx tsc --noEmit -p tsconfig.check.json` -> clean (exit 0).
- `node scripts/changelog-fragments.mjs check` -> no stray entries.

No ephemeral Harper was started (all tests use the file's in-memory mock); production `/Health` on :9926 verified 200 before and after.

Refs #1245
