### PR TITLE
cursor-flair pre-publish: re-pin flair-mcp 0.44.13 + secret-hygiene and Memories-contrast docs

### DIFF
--- a/.changelog/unreleased/changed-cursor-flair-prepublish.md
+++ b/.changelog/unreleased/changed-cursor-flair-prepublish.md
@@ -1,0 +1,7 @@
+- **cursor-flair pre-publish: plugin re-pinned to `flair-mcp@0.44.13` + doc
+  fixes.** `packages/cursor-flair/mcp.json` now pins `@tpsdev-ai/flair-mcp@0.44.13`,
+  picking up the interpolation-literal guard (#1253) so an unsubstituted
+  `${FLAIR_URL}` cannot break the default install. `docs/quickstart-fabric.md`
+  step 3 gains the step-0 secret-hygiene note for remote `agent add` (#1255),
+  and the plugin README adds a factual "Flair vs Cursor's built-in Memories"
+  contrast.

--- a/docs/quickstart-fabric.md
+++ b/docs/quickstart-fabric.md
@@ -65,6 +65,8 @@ export FLAIR_URL=https://<cluster>.<org>.harperfabric.com
 flair agent add mybot --target "$FLAIR_URL" --ops-target https://<cluster>.<org>.harperfabric.com:9925 --admin-pass <fabric-admin-password>
 ```
 
+Same hygiene rule as step 0: an inline password lands in shell history and `ps`. Remote `agent add` honors **only** the explicit `--admin-pass` flag by design — `FLAIR_ADMIN_PASS` and `~/.flair/admin-pass` are this machine's *local* credentials and are never reused against a remote target — so keep the Fabric password in a mode-`0600` file and expand it at call time: `--admin-pass "$(cat <path>)"` stays out of shell history (the expanded value is still visible to local `ps` while the command runs).
+
 ```
 Keypair written: ~/.flair/keys/mybot.key
 ✅ Agent 'mybot' (mybot) registered (ops: https://<cluster>.<org>.harperfabric.com:9925) <!-- docs-freshness-allow: Fabric ops API -->

--- a/packages/cursor-flair/README.md
+++ b/packages/cursor-flair/README.md
@@ -4,6 +4,10 @@ Cursor Marketplace plugin for [Flair](https://tps.dev/#flair) — self-hosted id
 
 This bundle is **not an npm runtime**. It wires Cursor to the stdio MCP server [`@tpsdev-ai/flair-mcp`](https://www.npmjs.com/package/@tpsdev-ai/flair-mcp) and ships skills plus one always-on rule. Memories live in **your** Flair/Harper instance (local or a URL you run). Nothing is stored in Cursor cloud.
 
+## Flair vs Cursor's built-in Memories
+
+Cursor ships a native **Memories** feature: persistent notes the agent saves as you work, stored in Cursor's cloud with your Cursor account, available in Cursor. Flair is a different shape — one memory you own: self-hosted, semantically searchable, and shared across every AI you use (Cursor, Grok Bot, Claude Code, your own agents) and with your team. The two coexist: keep Memories for quick scratch notes; Flair is the memory that follows you across tools.
+
 ## Prerequisites
 
 A running Flair instance and an agent identity.

--- a/packages/cursor-flair/mcp.json
+++ b/packages/cursor-flair/mcp.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "flair": {
       "command": "npx",
-      "args": ["-y", "@tpsdev-ai/flair-mcp@0.44.12"],
+      "args": ["-y", "@tpsdev-ai/flair-mcp@0.44.13"],
       "env": {
         "FLAIR_AGENT_ID": "${FLAIR_AGENT_ID}",
         "FLAIR_URL": "${FLAIR_URL}",


### PR DESCRIPTION
Three small pre-publish changes to the Cursor plugin surface, all doc/config — no code logic.

## 1. Re-pin flair-mcp to 0.44.13

`packages/cursor-flair/mcp.json` now pins `@tpsdev-ai/flair-mcp@0.44.13` (verified live on npm: `npm view @tpsdev-ai/flair-mcp version` → `0.44.13`). This picks up the interpolation-literal guard (#1253) so an unsubstituted `FLAIR_URL` placeholder cannot break the default install. No `0.44.12` remains anywhere under `packages/cursor-flair/`.

## 2. Step-3 secret-hygiene note in quickstart-fabric (#1255)

Step 0 warns that inline secrets leak to `ps` and shell history; step 3 then used `--admin-pass <fabric-admin-password>` inline with no note. Added the mirroring note.

**Deviation from the issue sketch, deliberate:** the sketch suggested recommending `--admin-pass-file` / `FLAIR_ADMIN_PASS`. Both exist in the CLI, but **not for this command's remote path**: `agent add` declares no `--admin-pass-file` option (src/cli.ts, `agent add` options block), and `resolveLocalAdminPass` (src/lib/auth-resolve.ts) deliberately skips both the `FLAIR_ADMIN_PASS` env leg and the `~/.flair/admin-pass` file leg when the target is remote — the flair#1085 doc comment explains why (an exported local admin secret must never silently travel to a third-party host). The doc's own step 2 already states this. So the note recommends what the command actually supports: keep the password in a mode-0600 file and expand it at call time with command substitution (out of history; still briefly visible to local `ps`), and states the only-explicit-flag contract instead of naming mechanisms that would silently fail.

## 3. README: Flair vs Cursor's built-in Memories

Short factual contrast section after the intro of `packages/cursor-flair/README.md`: Cursor Memories = persistent notes in Cursor's cloud, per Cursor account, in Cursor; Flair = one memory you own — self-hosted, semantic search, shared across every AI you use and with your team. They coexist. No shade — collaborative posture.

## Verification

- `node scripts/changelog-fragments.mjs check` — 1 fragment, 1 entry, no strays
- `python3 -m json.tool packages/cursor-flair/mcp.json` — valid, pin reads `@tpsdev-ai/flair-mcp@0.44.13`
- `grep -rn "0.44.12" packages/cursor-flair/` — no matches

Refs #1250
Closes #1255

🤖 Generated with [Claude Code](https://claude.com/claude-code)
