### PR TITLE
cursor marketplace: add category + version to plugin entry

### DIFF
--- a/.changelog/unreleased/changed-cursor-marketplace-entry-polish.md
+++ b/.changelog/unreleased/changed-cursor-marketplace-entry-polish.md
@@ -1,0 +1,1 @@
+- **Cursor marketplace entry: optional `category` and `version` fields added** to the plugin entry in `.cursor-plugin/marketplace.json`, per Cursor's marketplace submission checklist. No functional change.

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -9,7 +9,9 @@
     {
       "name": "flair",
       "source": "./packages/cursor-flair",
-      "description": "Self-hosted identity, memory, and soul for Cursor agents. Your memories live in your own Flair instance — not a cloud memory SaaS."
+      "description": "Self-hosted identity, memory, and soul for Cursor agents. Your memories live in your own Flair instance — not a cloud memory SaaS.",
+      "category": "Productivity",
+      "version": "0.1.0"
     }
   ]
 }


### PR DESCRIPTION
No issue: Cursor marketplace listing polish (category + version fields per Cursor's submission checklist).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
