### PR TITLE
Refuse ephemeral+shared Memory writes server-side (flair#1257 hard precondition)

### DIFF
--- a/.changelog/unreleased/security-1257-ephemeral-private-guard.md
+++ b/.changelog/unreleased/security-1257-ephemeral-private-guard.md
@@ -1,10 +1,16 @@
-- **Ephemeral memories are now private-only, enforced server-side.** `ephemeral`
-  is the continuity-journal tier (auto-captured working state, self-pruning);
-  its durability-keyed default visibility was already `private`, but a default
-  is not a constraint — an explicit `visibility:"shared"` on an ephemeral write
-  was accepted, which would have made journal entries org-readable and
-  federation-pushed. `Memory.post()` and `Memory.put()` now refuse the
-  combination with 400 (`invalid_visibility_for_durability`), including a PUT
-  that flips a stored ephemeral row to `shared` without naming a durability of
-  its own. Promoting a row out of `ephemeral` (e.g. distillation lifting it to
+- **Ephemeral memories are now private-only, enforced server-side on every
+  caller-facing write path.** `ephemeral` is the continuity-journal tier
+  (auto-captured working state, self-pruning); its durability-keyed default
+  visibility was already `private`, but a default is not a constraint — an
+  explicit `visibility:"shared"` on an ephemeral write was accepted, which
+  would have made journal entries org-readable and federation-pushed.
+  `Memory.post()` and `Memory.put()` now refuse the combination with 400
+  (`invalid_visibility_for_durability`), including a PUT that flips a stored
+  ephemeral row to `shared` without naming a durability of its own.
+  `POST /FeedMemories`, which writes through the raw table and so had inherited
+  none of the Memory write guards, now applies the same validation set
+  (durability enum, visibility enum, and the ephemeral-private rule) and stamps
+  `private` on an ephemeral feed write that omits visibility — previously such
+  a row landed with no visibility field at all, which reads as non-private.
+  Promoting a row out of `ephemeral` (e.g. distillation lifting it to
   `persistent`) while sharing it in the same write remains allowed. (flair#1257)

--- a/.changelog/unreleased/security-1257-ephemeral-private-guard.md
+++ b/.changelog/unreleased/security-1257-ephemeral-private-guard.md
@@ -1,0 +1,10 @@
+- **Ephemeral memories are now private-only, enforced server-side.** `ephemeral`
+  is the continuity-journal tier (auto-captured working state, self-pruning);
+  its durability-keyed default visibility was already `private`, but a default
+  is not a constraint — an explicit `visibility:"shared"` on an ephemeral write
+  was accepted, which would have made journal entries org-readable and
+  federation-pushed. `Memory.post()` and `Memory.put()` now refuse the
+  combination with 400 (`invalid_visibility_for_durability`), including a PUT
+  that flips a stored ephemeral row to `shared` without naming a durability of
+  its own. Promoting a row out of `ephemeral` (e.g. distillation lifting it to
+  `persistent`) while sharing it in the same write remains allowed. (flair#1257)

--- a/resources/Memory.ts
+++ b/resources/Memory.ts
@@ -7,7 +7,7 @@ import { scanFields, isStrictMode } from "./content-safety.js";
 import { invalidEntitiesResponse } from "./entity-vocab.js";
 import { checkRateLimit, rateLimitResponse } from "./rate-limiter.js";
 import { resolveAllowedOwners } from "./memory-read-scope.js";
-import { assertValidVisibility } from "./memory-visibility.js";
+import { assertValidVisibility, assertVisibilityAllowedForDurability } from "./memory-visibility.js";
 import { assertValidDurability } from "./memory-durability.js";
 import {
   DEDUP_COSINE_THRESHOLD_DEFAULT,
@@ -691,6 +691,24 @@ export class Memory extends (databases as any).flair.Memory {
         }
       }
 
+      // ── flair#1257: ephemeral memories are private-only (hard precondition) ──
+      // The durability-keyed default below sends ephemeral to "private", but a
+      // default is not a constraint — an explicit visibility:"shared" here would
+      // make continuity-journal entries org-readable AND federation-pushed.
+      // Refused at the server so the boundary holds for every caller, not just
+      // the hooks that promise to send "private". content.durability is already
+      // defaulted ("standard" when absent) and enum-validated above, so this
+      // sees the row's effective durability.
+      {
+        const tierError = assertVisibilityAllowedForDurability(content.durability, content.visibility);
+        if (tierError) {
+          return new Response(
+            JSON.stringify({ error: "invalid_visibility_for_durability", message: tierError }),
+            { status: 400, headers: { "content-type": "application/json" } },
+          );
+        }
+      }
+
     if (content.visibility === undefined || content.visibility === null) {
       content.visibility = defaultVisibilityForDurability(content.durability);
     }
@@ -916,6 +934,27 @@ export class Memory extends (databases as any).flair.Memory {
         if (visibilityError) {
           return new Response(
             JSON.stringify({ error: "invalid_visibility", message: visibilityError }),
+            { status: 400, headers: { "content-type": "application/json" } },
+          );
+        }
+      }
+
+      // ── flair#1257: ephemeral memories are private-only (hard precondition) ──
+      // Same rule as post(), with one PUT-specific wrinkle: an update payload
+      // may omit durability entirely (put() stamps no durability default), so
+      // `PUT /Memory/<id> {"visibility":"shared"}` against a stored ephemeral
+      // row names no durability of its own — the EFFECTIVE durability is the
+      // pre-existing row's, and the flip must refuse just like a fresh
+      // ephemeral+shared create. An explicit durability on the write wins: a
+      // write that promotes the row OUT of ephemeral (e.g. distillation lifting
+      // it to persistent, #1205) while sharing it is a legitimate promotion,
+      // not an ephemeral share. preExisting was fetched above.
+      {
+        const effectiveDurability = content.durability ?? preExisting?.durability;
+        const tierError = assertVisibilityAllowedForDurability(effectiveDurability, content.visibility);
+        if (tierError) {
+          return new Response(
+            JSON.stringify({ error: "invalid_visibility_for_durability", message: tierError }),
             { status: 400, headers: { "content-type": "application/json" } },
           );
         }

--- a/resources/MemoryFeed.ts
+++ b/resources/MemoryFeed.ts
@@ -2,6 +2,8 @@ import { Resource, databases } from "harper";
 import { allowVerified, resolveAgentAuth } from "./agent-auth.js";
 import { computeContentHash, findExistingMemoryByContentHash } from "./memory-feed-lib.js";
 import { FORBIDDEN, UNAUTH, stampAttribution } from "./record-type-kit.js";
+import { assertValidVisibility, assertVisibilityAllowedForDurability, PRIVATE_VISIBILITY } from "./memory-visibility.js";
+import { assertValidDurability } from "./memory-durability.js";
 
 export class FeedMemories extends Resource {
   // Self-authorize via the Ed25519 agent verify (the auth reshape removes the
@@ -59,6 +61,47 @@ export class FeedMemories extends Resource {
       });
     }
 
+    // ── Write-side durability/visibility validation (#1009/#1238/#1257) ─────
+    // This endpoint writes via the RAW table object below — NOT the exported
+    // Memory resource — so it inherits NONE of Memory.post()/put()'s write
+    // guards (Sherlock's #1261 review: ephemeral+shared, and any invalid
+    // visibility or durability, landed through POST /FeedMemories untouched).
+    // The three guards are applied here in the same order as Memory.post().
+    //
+    // Placed BEFORE the content-hash dedup early-return, deliberately: a
+    // refused combination must refuse deterministically, not return 200 with
+    // the existing record whenever a duplicate happens to exist.
+    //
+    // The effective durability for the tier rule is the one the record below
+    // actually stamps — `content.durability ?? "standard"`. A raw table put
+    // REPLACES the row, so even an update-in-place that omits durability
+    // produces a "standard" row regardless of what it replaces; the stored
+    // row's tier is decided entirely by this payload.
+    const durability = content.durability ?? "standard";
+    {
+      const durabilityError = assertValidDurability(content.durability);
+      if (durabilityError) {
+        return new Response(JSON.stringify({ error: "invalid_durability", message: durabilityError }), {
+          status: 400,
+          headers: { "Content-Type": "application/json" },
+        });
+      }
+      const visibilityError = assertValidVisibility(content.visibility);
+      if (visibilityError) {
+        return new Response(JSON.stringify({ error: "invalid_visibility", message: visibilityError }), {
+          status: 400,
+          headers: { "Content-Type": "application/json" },
+        });
+      }
+      const tierError = assertVisibilityAllowedForDurability(durability, content.visibility);
+      if (tierError) {
+        return new Response(JSON.stringify({ error: "invalid_visibility_for_durability", message: tierError }), {
+          status: 400,
+          headers: { "Content-Type": "application/json" },
+        });
+      }
+    }
+
     const now = new Date().toISOString();
     const contentHash = computeContentHash(agentId, body);
 
@@ -71,11 +114,25 @@ export class FeedMemories extends Resource {
       agentId,
       content: body,
       contentHash,
-      durability: content.durability ?? "standard",
+      durability,
       createdAt: content.createdAt ?? now,
       updatedAt: content.updatedAt ?? now,
       archived: content.archived ?? false,
     };
+
+    // flair#1257, omission leak: this endpoint stamps NO durability-keyed
+    // visibility default (unlike Memory.post/put — Layer 1), so an ephemeral
+    // feed write with visibility omitted would land with no visibility field
+    // at all, which the read side resolves to NON-private (the migration
+    // invariant). The refusal guard above cannot see an omission, so the
+    // private-only tier invariant is closed here by stamping "private" on
+    // exactly the ephemeral case. Deliberately NOT the general durability-
+    // keyed default: stamping it for standard/persistent/permanent would flip
+    // the visibility of every existing feed caller's writes — a behavioural
+    // change this fix must not smuggle in.
+    if (record.durability === "ephemeral" && (record.visibility === undefined || record.visibility === null)) {
+      record.visibility = PRIVATE_VISIBILITY;
+    }
 
     await (databases as any).flair.Memory.put(record);
     return record;

--- a/resources/memory-visibility.ts
+++ b/resources/memory-visibility.ts
@@ -84,3 +84,57 @@ export function assertValidVisibility(visibility: unknown): string | null {
     `permanent/persistent -> shared, standard/ephemeral -> private.`
   );
 }
+
+/** Deliberately a LOCAL literal, not an import from memory-durability.ts: this
+ *  module's zero-imports property is load-bearing (see the header — src/cli.ts
+ *  must be able to import it with no transitive baggage), and the tripwire
+ *  tests in test/unit/visibility-write-validation.test.ts pin the value to the
+ *  durability enum so the two cannot drift apart silently. */
+export const EPHEMERAL_DURABILITY = "ephemeral";
+
+/**
+ * ─── flair#1257 hard precondition: ephemeral memories are private-only ───────
+ *
+ * `ephemeral` is the continuity-journal tier: auto-captured working state,
+ * self-pruning, never meant to leave its owner. `defaultVisibilityForDurability`
+ * keys it to `private`, but a DEFAULT is not a CONSTRAINT — before this guard,
+ * an explicit `visibility:"shared"` on an ephemeral write was accepted, which
+ * would have made journal entries org-readable AND federation-pushed. Kern's
+ * #1257 ruling requires the server to REFUSE the combination so the boundary
+ * holds for every caller (REST, in-process, any adapter), not just the hooks
+ * that promise to send `private` explicitly.
+ *
+ * The rule is deliberately "ephemeral may only carry `private` or nothing",
+ * NOT "refuse ephemeral+shared": on the read side any value other than the
+ * literal "private" resolves to non-private (the migration invariant above),
+ * so an unknown value on an ephemeral row would leak exactly like "shared".
+ * assertValidVisibility refuses unknowns first at both call sites, but this
+ * guard must stay fail-closed on its own — unknown means refused, not allowed.
+ *
+ * Absent (`undefined`/`null`) is accepted: it resolves through the
+ * durability-keyed default, which for ephemeral is `private` — the documented,
+ * intentional path (and the one the continuity hooks use, belt-and-suspenders
+ * with an explicit `private`).
+ *
+ * Returns an error message, or null when the combination is acceptable.
+ * `durability` is the EFFECTIVE durability of the row being written — for
+ * Memory.put() updates, where the payload may omit durability, the caller
+ * passes the pre-existing row's durability as the fallback so a PUT that flips
+ * a stored ephemeral row to shared refuses too.
+ */
+export function assertVisibilityAllowedForDurability(
+  durability: unknown,
+  visibility: unknown,
+): string | null {
+  if (durability !== EPHEMERAL_DURABILITY) return null;
+  if (visibility === undefined || visibility === null || visibility === PRIVATE_VISIBILITY) {
+    return null;
+  }
+  return (
+    `ephemeral memories are private-only (continuity journal tier, flair#1257): ` +
+    `durability "${EPHEMERAL_DURABILITY}" cannot be written with visibility ${JSON.stringify(visibility)}. ` +
+    `Omit visibility (the durability-keyed default is "${PRIVATE_VISIBILITY}") or set it to ` +
+    `"${PRIVATE_VISIBILITY}"; for a memory other agents should read, use durability ` +
+    `"standard", "persistent", or "permanent".`
+  );
+}

--- a/test/integration/ephemeral-visibility-guard-e2e.test.ts
+++ b/test/integration/ephemeral-visibility-guard-e2e.test.ts
@@ -1,0 +1,247 @@
+// flair#1257 — ephemeral memories are private-only, behavioural positive control.
+//
+// `ephemeral` is the continuity-journal tier (auto-captured working state,
+// self-pruning). Its durability-keyed DEFAULT visibility is "private", but a
+// default is not a constraint: before this guard, an explicit
+// visibility:"shared" on an ephemeral write was accepted via the real REST
+// surface, which would have made journal entries org-readable AND
+// federation-pushed. Kern's #1257 ruling: the server must REFUSE the
+// combination (400) so the boundary holds for every caller — not just the
+// continuity hooks that promise to send "private".
+//
+// The unit lane (test/unit/visibility-write-validation.test.ts) pins the pure
+// rule and trips if the guard is unwired. This file is the "prove it fires"
+// control: the refusals below were mutation-checked by removing the two
+// Memory.ts guard blocks — the POST and both PUT refusal tests then went red
+// (writes succeeded), and went green again with the guard restored.
+//
+// Pattern: test/integration/durability-write-validation-e2e.test.ts (Ed25519
+// signing helpers, admin-op seeding).
+import { describe, expect, test, beforeAll, afterAll } from "bun:test";
+import nacl from "tweetnacl";
+import { randomUUID } from "node:crypto";
+import { startHarper, stopHarper, HarperInstance } from "../helpers/harper-lifecycle";
+
+interface TestAgent { id: string; publicKey: string; secretKey: Uint8Array; }
+
+function mkAgent(id: string): TestAgent {
+  const kp = nacl.sign.keyPair();
+  return { id, publicKey: Buffer.from(kp.publicKey).toString("base64"), secretKey: kp.secretKey };
+}
+
+function ed25519Header(agent: TestAgent, method: string, path: string): string {
+  const ts = Date.now().toString();
+  const nonce = randomUUID();
+  const payload = `${agent.id}:${ts}:${nonce}:${method}:${path}`;
+  const sig = nacl.sign.detached(new TextEncoder().encode(payload), agent.secretKey);
+  return `TPS-Ed25519 ${agent.id}:${ts}:${nonce}:${Buffer.from(sig).toString("base64")}`;
+}
+
+async function authFetch(harper: HarperInstance, agent: TestAgent, method: string, path: string, body?: unknown): Promise<Response> {
+  const headers: Record<string, string> = { Authorization: ed25519Header(agent, method, path) };
+  if (body !== undefined) headers["Content-Type"] = "application/json";
+  return fetch(`${harper.httpURL}${path}`, { method, headers, body: body !== undefined ? JSON.stringify(body) : undefined });
+}
+
+async function adminOp(harper: HarperInstance, op: Record<string, any>): Promise<Response> {
+  return fetch(harper.opsURL, {
+    method: "POST",
+    headers: { "Content-Type": "application/json", Authorization: "Basic " + btoa(`${harper.admin.username}:${harper.admin.password}`) },
+    body: JSON.stringify(op),
+  });
+}
+
+async function seedAgent(harper: HarperInstance, agent: TestAgent): Promise<void> {
+  const res = await adminOp(harper, {
+    operation: "insert", database: "flair", table: "Agent",
+    records: [{ id: agent.id, name: agent.id, role: "agent", publicKey: agent.publicKey, createdAt: new Date().toISOString() }],
+  });
+  expect(res.status).toBe(200);
+}
+
+/** Read a row's durability+visibility back through the admin surface, so the
+ *  assertions below are about what was STORED, not what the response claimed. */
+async function readStored(harper: HarperInstance, id: string): Promise<{ durability?: string; visibility?: string } | null> {
+  const read = await adminOp(harper, {
+    operation: "search_by_value", database: "flair", table: "Memory",
+    search_attribute: "id", search_value: id, get_attributes: ["id", "durability", "visibility"],
+  });
+  expect(read.status).toBe(200);
+  const rows = await read.json();
+  const record = Array.isArray(rows) ? rows[0] : rows;
+  return record ?? null;
+}
+
+let harper: HarperInstance;
+const agent = mkAgent("eph-owner");
+
+beforeAll(async () => {
+  harper = await startHarper();
+  await seedAgent(harper, agent);
+}, 180_000);
+
+afterAll(async () => {
+  if (harper) await stopHarper(harper);
+});
+
+describe("ephemeral memories are private-only (flair#1257)", () => {
+  test("POSITIVE CONTROL (a): POST ephemeral+shared is refused with 400, and nothing is stored", async () => {
+    const id = `eph-shared-post-${randomUUID()}`;
+    const res = await authFetch(harper, agent, "POST", "/Memory", {
+      id,
+      agentId: agent.id,
+      content: "a continuity journal entry that must never go org-readable",
+      durability: "ephemeral",
+      visibility: "shared",
+    });
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("invalid_visibility_for_durability");
+    // Actor + state + remedy: the tier, the refused value, and both exits.
+    expect(body.message).toContain("private-only");
+    expect(body.message).toContain("shared");
+    expect(body.message).toContain("Omit visibility");
+    expect(body.message).toContain("1257");
+    // The refusal must be a refusal — no row lands.
+    expect(await readStored(harper, id)).toBeNull();
+  }, 30_000);
+
+  test("POSITIVE CONTROL (b): PUT flipping a stored ephemeral row to shared is refused — merged payload shape", async () => {
+    // Create the row the way the continuity hook would: ephemeral, visibility
+    // omitted, lands private via the durability-keyed default.
+    const id = `eph-flip-merged-${randomUUID()}`;
+    const post = await authFetch(harper, agent, "POST", "/Memory", {
+      id, agentId: agent.id,
+      content: "journal entry to be flipped, long enough for the safety scan",
+      durability: "ephemeral",
+    });
+    expect(post.status).toBe(201);
+
+    // memory_update-style flip: the merged {...existing, ...patch} payload
+    // carries durability:"ephemeral" alongside the new visibility.
+    const put = await authFetch(harper, agent, "PUT", `/Memory/${id}`, {
+      id, agentId: agent.id,
+      content: "journal entry to be flipped, long enough for the safety scan",
+      durability: "ephemeral",
+      visibility: "shared",
+    });
+    expect(put.status).toBe(400);
+    const body = await put.json();
+    expect(body.error).toBe("invalid_visibility_for_durability");
+
+    // The stored row is untouched: still ephemeral, still private.
+    const stored = await readStored(harper, id);
+    expect(stored?.durability).toBe("ephemeral");
+    expect(stored?.visibility).toBe("private");
+  }, 30_000);
+
+  test("POSITIVE CONTROL (b'): PUT flip with durability OMITTED still refuses — effective durability comes from the stored row", async () => {
+    // The sharper case: `PUT /Memory/<id> {"visibility":"shared"}` names no
+    // durability of its own. put() stamps no durability default, so the only
+    // thing that can make this refuse is the guard consulting the pre-existing
+    // row. A guard reading content.durability alone sails past this.
+    const id = `eph-flip-partial-${randomUUID()}`;
+    const post = await authFetch(harper, agent, "POST", "/Memory", {
+      id, agentId: agent.id,
+      content: "journal entry for the partial-put flip, long enough for the scan",
+      durability: "ephemeral",
+    });
+    expect(post.status).toBe(201);
+
+    const put = await authFetch(harper, agent, "PUT", `/Memory/${id}`, {
+      id, agentId: agent.id,
+      content: "journal entry for the partial-put flip, long enough for the scan",
+      visibility: "shared",
+    });
+    expect(put.status).toBe(400);
+    const body = await put.json();
+    expect(body.error).toBe("invalid_visibility_for_durability");
+
+    const stored = await readStored(harper, id);
+    expect(stored?.durability).toBe("ephemeral");
+    expect(stored?.visibility).toBe("private");
+  }, 30_000);
+
+  test("(c) ephemeral with visibility omitted lands 201 and STORED private — the durability-keyed default, unchanged", async () => {
+    const id = `eph-default-${randomUUID()}`;
+    const res = await authFetch(harper, agent, "POST", "/Memory", {
+      id, agentId: agent.id,
+      content: "hook-captured working state, visibility left to the default",
+      durability: "ephemeral",
+    });
+    expect(res.status).toBe(201);
+    const stored = await readStored(harper, id);
+    expect(stored?.durability).toBe("ephemeral");
+    expect(stored?.visibility).toBe("private");
+  }, 30_000);
+
+  test("(d) ephemeral with EXPLICIT private is accepted — the hook's belt-and-suspenders write shape", async () => {
+    const id = `eph-explicit-private-${randomUUID()}`;
+    const res = await authFetch(harper, agent, "POST", "/Memory", {
+      id, agentId: agent.id,
+      content: "hook-captured working state with explicit private visibility",
+      durability: "ephemeral",
+      visibility: "private",
+    });
+    expect(res.status).toBe(201);
+    const stored = await readStored(harper, id);
+    expect(stored?.visibility).toBe("private");
+  }, 30_000);
+
+  test("(e) no over-fire: standard+shared and persistent+shared still write", async () => {
+    for (const durability of ["standard", "persistent"]) {
+      const res = await authFetch(harper, agent, "POST", "/Memory", {
+        id: `eph-nooverfire-${durability}-${randomUUID()}`,
+        agentId: agent.id,
+        content: `a ${durability} shared decision, long enough for the safety scan`,
+        durability,
+        visibility: "shared",
+      });
+      expect(res.status, `durability=${durability}+shared → ${res.status}`).toBe(201);
+    }
+  }, 30_000);
+
+  test("(e') no over-fire on PUT: flipping a stored STANDARD row to shared still works", async () => {
+    const id = `std-flip-${randomUUID()}`;
+    const post = await authFetch(harper, agent, "POST", "/Memory", {
+      id, agentId: agent.id,
+      content: "a standard note that its owner later decides to share",
+      durability: "standard",
+    });
+    expect(post.status).toBe(201);
+
+    const put = await authFetch(harper, agent, "PUT", `/Memory/${id}`, {
+      id, agentId: agent.id,
+      content: "a standard note that its owner later decides to share",
+      durability: "standard",
+      visibility: "shared",
+    });
+    expect(put.status).toBe(200);
+    const stored = await readStored(harper, id);
+    expect(stored?.visibility).toBe("shared");
+  }, 30_000);
+
+  test("promotion OUT of ephemeral may share in the same write — the #1205 distillation shape", async () => {
+    // Explicit durability on the write wins over the stored row's: lifting a
+    // journal entry to persistent while sharing it is a promotion, not an
+    // ephemeral share. This is the write shape REM distillation produces.
+    const id = `eph-promote-${randomUUID()}`;
+    const post = await authFetch(harper, agent, "POST", "/Memory", {
+      id, agentId: agent.id,
+      content: "a journal entry distillation deems worth keeping and sharing",
+      durability: "ephemeral",
+    });
+    expect(post.status).toBe(201);
+
+    const put = await authFetch(harper, agent, "PUT", `/Memory/${id}`, {
+      id, agentId: agent.id,
+      content: "a journal entry distillation deems worth keeping and sharing",
+      durability: "persistent",
+      visibility: "shared",
+    });
+    expect(put.status).toBe(200);
+    const stored = await readStored(harper, id);
+    expect(stored?.durability).toBe("persistent");
+    expect(stored?.visibility).toBe("shared");
+  }, 30_000);
+});

--- a/test/integration/ephemeral-visibility-guard-e2e.test.ts
+++ b/test/integration/ephemeral-visibility-guard-e2e.test.ts
@@ -221,6 +221,87 @@ describe("ephemeral memories are private-only (flair#1257)", () => {
     expect(stored?.visibility).toBe("shared");
   }, 30_000);
 
+  // ─── POST /FeedMemories — the raw-table bypass (Sherlock, #1261 review) ────
+  //
+  // FeedMemories.post() writes via the RAW table object, not the exported
+  // Memory resource, so before the fix it inherited NONE of the write guards:
+  // ephemeral+shared — and outright invalid values like "public" — landed
+  // untouched. These are the positive controls that the guards now run on
+  // this path too. Mutation-checked alongside the Memory.ts controls: with
+  // the MemoryFeed.ts guard block removed, the two refusal tests below went
+  // red (200 writes), and the omission test stored a row with NO visibility.
+  test("POSITIVE CONTROL (feed): POST /FeedMemories ephemeral+shared is refused with 400, nothing stored", async () => {
+    const id = `feed-eph-shared-${randomUUID()}`;
+    const res = await authFetch(harper, agent, "POST", "/FeedMemories", {
+      id, agentId: agent.id,
+      content: `feed journal entry that must never go org-readable ${id}`,
+      durability: "ephemeral",
+      visibility: "shared",
+    });
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("invalid_visibility_for_durability");
+    expect(body.message).toContain("private-only");
+    expect(await readStored(harper, id)).toBeNull();
+  }, 30_000);
+
+  test("POSITIVE CONTROL (feed): an invalid visibility value is refused too — the #1009 guard now covers this path", async () => {
+    const id = `feed-invalid-vis-${randomUUID()}`;
+    const res = await authFetch(harper, agent, "POST", "/FeedMemories", {
+      id, agentId: agent.id,
+      content: `feed entry with an invalid visibility value ${id}`,
+      visibility: "public",
+    });
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("invalid_visibility");
+    expect(await readStored(harper, id)).toBeNull();
+  }, 30_000);
+
+  test("(feed) ephemeral with visibility OMITTED lands STORED private — the omission leak is closed", async () => {
+    // This endpoint stamps no durability-keyed visibility default, so before
+    // the fix an ephemeral feed write with visibility omitted stored a row
+    // with NO visibility field — which the read side resolves to NON-private.
+    const id = `feed-eph-default-${randomUUID()}`;
+    const res = await authFetch(harper, agent, "POST", "/FeedMemories", {
+      id, agentId: agent.id,
+      content: `feed-captured ephemeral state, visibility omitted ${id}`,
+      durability: "ephemeral",
+    });
+    expect(res.status).toBe(200);
+    const stored = await readStored(harper, id);
+    expect(stored?.durability).toBe("ephemeral");
+    expect(stored?.visibility).toBe("private");
+  }, 30_000);
+
+  test("(feed) no over-fire: a plain feed write still works, and its visibility handling is UNCHANGED", async () => {
+    // Default (standard) feed write with no visibility: succeeds, and — pinned
+    // deliberately — still stores NO visibility field. Only the ephemeral tier
+    // gets the omission stamp; flipping every feed caller's default to private
+    // would be a behavioural change this fix must not smuggle in.
+    const id = `feed-plain-${randomUUID()}`;
+    const res = await authFetch(harper, agent, "POST", "/FeedMemories", {
+      id, agentId: agent.id,
+      content: `an ordinary feed memory, defaults all round ${id}`,
+    });
+    expect(res.status).toBe(200);
+    const stored = await readStored(harper, id);
+    expect(stored?.durability).toBe("standard");
+    expect(stored?.visibility ?? null).toBeNull();
+
+    // And an explicit persistent+shared feed write passes the tier guard.
+    const id2 = `feed-shared-${randomUUID()}`;
+    const res2 = await authFetch(harper, agent, "POST", "/FeedMemories", {
+      id: id2, agentId: agent.id,
+      content: `a persistent shared feed memory ${id2}`,
+      durability: "persistent",
+      visibility: "shared",
+    });
+    expect(res2.status).toBe(200);
+    const stored2 = await readStored(harper, id2);
+    expect(stored2?.visibility).toBe("shared");
+  }, 30_000);
+
   test("promotion OUT of ephemeral may share in the same write — the #1205 distillation shape", async () => {
     // Explicit durability on the write wins over the stored row's: lifting a
     // journal entry to persistent while sharing it is a promotion, not an

--- a/test/unit-isolated/memory-integrity.test.ts
+++ b/test/unit-isolated/memory-integrity.test.ts
@@ -1044,14 +1044,33 @@ describe("durability-keyed default visibility (write path)", () => {
     expect((await BaseMemory.get(r2.id)).visibility).toBe("private");
   });
 
-  it("Memory.post: an explicit visibility ALWAYS overrides the durability default", async () => {
+  it("Memory.post: an explicit visibility overrides the durability default — EXCEPT ephemeral, which is private-only (flair#1257)", async () => {
+    // Narrowing override on a durable tier: permanent defaults to shared,
+    // explicit private wins.
     const m = makeMemory(agentCtx("agent-1"));
     const r = await m.post({ agentId: "agent-1", content: "Explicitly private despite being permanent.", durability: "permanent", visibility: "private" });
     expect((await BaseMemory.get(r.id)).visibility).toBe("private");
 
+    // Widening override on a non-ephemeral tier: standard defaults to private,
+    // explicit shared wins. (This carries the claim the ephemeral+shared case
+    // below used to carry, on a tier where widening is still legal.)
+    const m3 = makeMemory(agentCtx("agent-1"));
+    const r3 = await m3.post({ agentId: "agent-1", content: "Explicitly shared while standard, long enough for the gate.", durability: "standard", visibility: "shared" });
+    expect((await BaseMemory.get(r3.id)).visibility).toBe("shared");
+
+    // ...but ephemeral+shared is REFUSED with 400 (flair#1257 hard
+    // precondition, K&S-ratified): ephemeral is the continuity-journal tier
+    // and is private-only — the pre-#1257 contract this test used to encode
+    // ("an explicit visibility ALWAYS overrides") deliberately no longer
+    // holds for it. Positive control: the refusal names the guard's error
+    // code and writes nothing.
+    const sizeBefore = memoryStore.size;
     const m2 = makeMemory(agentCtx("agent-1"));
     const r2 = await m2.post({ agentId: "agent-1", content: "Explicitly shared despite being ephemeral.", durability: "ephemeral", visibility: "shared" });
-    expect((await BaseMemory.get(r2.id)).visibility).toBe("shared");
+    expect(r2 instanceof Response).toBe(true);
+    expect((r2 as Response).status).toBe(400);
+    expect((await (r2 as Response).json()).error).toBe("invalid_visibility_for_durability");
+    expect(memoryStore.size).toBe(sizeBefore); // the refusal stored nothing
   });
 
   it("Memory.put (fresh id, not yet existing): same durability-keyed default applies", async () => {

--- a/test/unit/visibility-write-validation.test.ts
+++ b/test/unit/visibility-write-validation.test.ts
@@ -22,11 +22,14 @@
 import { describe, test, expect } from "bun:test";
 import {
   assertValidVisibility,
+  assertVisibilityAllowedForDurability,
   isPrivateVisibility,
+  EPHEMERAL_DURABILITY,
   PRIVATE_VISIBILITY,
   SHARED_VISIBILITY,
   WRITABLE_VISIBILITIES,
 } from "../../resources/memory-visibility.js";
+import { WRITABLE_DURABILITIES } from "../../resources/memory-durability.js";
 
 describe("assertValidVisibility — write-side rejection (flair#1009)", () => {
   test("accepts the two valid values", () => {
@@ -98,6 +101,61 @@ describe("the read predicate stays permissive — the migration invariant", () =
   });
 });
 
+// ─── flair#1257: ephemeral memories are private-only ──────────────────────────
+//
+// `ephemeral` is the continuity-journal tier. Its durability-keyed DEFAULT is
+// private, but a default is not a constraint — before #1257 an explicit
+// visibility:"shared" on an ephemeral write was accepted, making journal
+// entries org-readable and federation-pushed. These tests pin the refusal rule
+// itself; the behavioural REST proof (POST/PUT → 400) lives in
+// test/integration/ephemeral-visibility-guard-e2e.test.ts.
+describe("assertVisibilityAllowedForDurability — ephemeral is private-only (flair#1257)", () => {
+  test("refuses ephemeral + shared — the combination the guard exists for", () => {
+    const err = assertVisibilityAllowedForDurability(EPHEMERAL_DURABILITY, SHARED_VISIBILITY);
+    expect(err).not.toBeNull();
+    // Actor + state + remedy: names the tier, the refused value, and both exits.
+    expect(err).toContain("private-only");
+    expect(err).toContain('"shared"');
+    expect(err).toContain("Omit visibility");
+    expect(err).toContain("1257");
+  });
+
+  test("fail-closed: ephemeral + any PRESENT non-private value is refused, not just \"shared\"", () => {
+    // The read side resolves anything other than the literal "private" to
+    // non-private (migration invariant), so an unknown value on an ephemeral
+    // row would leak exactly like "shared". assertValidVisibility refuses
+    // unknowns first at both call sites, but this guard must not depend on
+    // that layering to be safe.
+    for (const v of ["office", "prvate", "Private", "public", "", 1, true]) {
+      expect(assertVisibilityAllowedForDurability(EPHEMERAL_DURABILITY, v)).not.toBeNull();
+    }
+  });
+
+  test("accepts ephemeral + private, and ephemeral + absent (the default path)", () => {
+    expect(assertVisibilityAllowedForDurability(EPHEMERAL_DURABILITY, PRIVATE_VISIBILITY)).toBeNull();
+    expect(assertVisibilityAllowedForDurability(EPHEMERAL_DURABILITY, undefined)).toBeNull();
+    expect(assertVisibilityAllowedForDurability(EPHEMERAL_DURABILITY, null)).toBeNull();
+  });
+
+  test("no over-fire: every NON-ephemeral durability may still write shared", () => {
+    for (const d of WRITABLE_DURABILITIES) {
+      if (d === EPHEMERAL_DURABILITY) continue;
+      expect(assertVisibilityAllowedForDurability(d, SHARED_VISIBILITY)).toBeNull();
+    }
+    // And an absent effective durability (fresh PUT with no durability and no
+    // pre-existing row) is not ephemeral, so shared passes through to the
+    // ordinary visibility rules.
+    expect(assertVisibilityAllowedForDurability(undefined, SHARED_VISIBILITY)).toBeNull();
+  });
+
+  test("drift-pin: EPHEMERAL_DURABILITY is a real member of the durability enum", () => {
+    // memory-visibility.ts declares the literal locally to keep its zero-imports
+    // property (src/cli.ts safety). This is what keeps the local literal and the
+    // enum from drifting apart silently.
+    expect(WRITABLE_DURABILITIES as readonly string[]).toContain(EPHEMERAL_DURABILITY);
+  });
+});
+
 // ─── Structural tripwire: the guard must remain WIRED ─────────────────────────
 //
 // The tests above validate `assertValidVisibility` in isolation. That is not
@@ -134,5 +192,20 @@ describe("the visibility guard stays wired into both write paths", () => {
     const defaults = src.match(/defaultVisibilityForDurability\(content\.durability\)/g) ?? [];
     const guards = src.match(/assertValidVisibility\(content\.visibility\)/g) ?? [];
     expect(guards.length).toBe(defaults.length);
+  });
+
+  test("the flair#1257 ephemeral-private guard is wired into both write paths", () => {
+    // Same shape and same limitation as the tripwire above: detects DELETION,
+    // not misbehaviour — the behavioural 400s live in the integration lane
+    // (ephemeral-visibility-guard-e2e.test.ts, which is also where the
+    // mutation-check was run: guard removed → those tests go red).
+    expect(src).toContain("assertVisibilityAllowedForDurability");
+    const calls = src.match(/assertVisibilityAllowedForDurability\(/g) ?? [];
+    // One call in post(), one in put(); the import line does not match the
+    // trailing "(". put()'s call must see the EFFECTIVE durability — the
+    // pre-existing row's when the update payload omits it — or a partial PUT
+    // flipping a stored ephemeral row to shared sails past the guard.
+    expect(calls.length).toBe(2);
+    expect(src).toContain("content.durability ?? preExisting?.durability");
   });
 });


### PR DESCRIPTION
## What

The flair#1257 hard precondition (Kern's ruling, required before the continuity build merges): the Memory write path now REFUSES `durability:"ephemeral"` + `visibility:"shared"` with 400.

`ephemeral` is the continuity-journal tier — auto-captured working state, self-pruning, never meant to leave its owner. Its durability-keyed default visibility is already `private`, but a default is not a constraint: an explicit `visibility:"shared"` on an ephemeral write was accepted, which would have made journal entries org-readable AND federation-pushed.

## Where the guard lives, and why

- **`resources/memory-visibility.ts` — `assertVisibilityAllowedForDurability(durability, visibility)`.** `assertValidVisibility` is deliberately a single-field value check at a seam with no durability context, and its call-count is pinned by an existing tripwire test — so the cross-field rule is a sibling pure function in the same zero-import module (the zero-imports property is load-bearing for `src/cli.ts`; the `"ephemeral"` literal is declared locally and pinned to the durability enum by a unit drift-pin test).
- **Fail-closed by shape:** the rule is "ephemeral may only carry `private` or nothing", not "refuse ephemeral+shared". On the read side any value other than the literal `private` resolves to non-private (the migration invariant), so an unknown value on an ephemeral row would leak exactly like `shared`. `assertValidVisibility` refuses unknowns first at both call sites, but this guard does not depend on that layering.
- **Wired into BOTH write paths**, immediately after the #1009 visibility guard in `Memory.post()` and `Memory.put()`. The PUT wrinkle: an update payload may omit durability entirely (put() stamps no durability default), so `PUT /Memory/<id> {"visibility":"shared"}` against a stored ephemeral row names no durability of its own — put() passes the EFFECTIVE durability (`content.durability ?? preExisting?.durability`). Explicit durability on the write wins, so promoting a row OUT of ephemeral while sharing it in the same write (the #1205 distillation shape) stays legal — verified by test.
- **Error contract:** 400 `invalid_visibility_for_durability`; the message names the tier, the refused value, and both remedies (omit visibility / set private; use standard/persistent/permanent for shareable memories), citing #1257.

No existing writer sends ephemeral+shared (grepped all packages/adapters: n8n, pi-flair, hermes, adk, openclaw, bridges import-runner all omit visibility or pass caller values through the same refusal class that already rejects e.g. `public`).

## Tests

Unit (`test/unit/visibility-write-validation.test.ts`): pure-rule positive control (ephemeral+shared refused, message asserts actor+state+remedy), fail-closed sweep (any present non-private value), accept private/absent, no-over-fire across every non-ephemeral durability, enum drift-pin, and a wiring tripwire (2 call sites + the `preExisting` fallback expression).

Integration (`test/integration/ephemeral-visibility-guard-e2e.test.ts`, real REST surface, Ed25519 auth, ephemeral HOME-isolated Harper):

- (a) POST ephemeral+shared → 400, nothing stored
- (b) PUT flip of a stored ephemeral row → 400 (merged-payload shape) — row stays ephemeral+private
- (b') PUT flip with durability OMITTED → 400 (proves the preExisting-derived effective durability) — row stays ephemeral+private
- (c) ephemeral, visibility omitted → 201, STORED private (durability-keyed default unchanged, verified via admin read-back)
- (d) ephemeral + explicit private → 201 (the continuity hook's belt-and-suspenders shape)
- (e) standard+shared and persistent+shared POST → 201; PUT flipping a stored standard row to shared → 200 (no over-fire)
- promotion: PUT ephemeral row → persistent+shared in one write → 200 (the #1205 distillation shape)

**Mutation check (both states reported):** with the two guard blocks removed from `Memory.ts` and rebuilt, exactly the three refusal tests went RED — writes succeeded (Expected 400, Received 201/200/200) — while the five acceptance tests stayed green. Guard restored and rebuilt: 8/8 green.

**Suite counts:** full unit lane (`bun test test/unit/ test/*.test.ts`) — baseline on unmodified origin/main: 4563 pass / 0 fail; with this change: 4569 pass / 0 fail (+6 = the new unit tests). Adjacent controls `memory-visibility-scoping-e2e` + `durability-write-validation-e2e`: 20/20 green.

Changelog fragment: `.changelog/unreleased/security-1257-ephemeral-private-guard.md` (`security`); `changelog-fragments.mjs check` passes.

This is build slice (1) of the #1257 final design. Slice (2) — the continuity hook adapter, which also sends `visibility:"private"` explicitly (precondition (b)) — is a follow-up.

Refs #1257

🤖 Generated with [Claude Code](https://claude.com/claude-code)
