### PR TITLE
Team Concierge example: ADK agent on adk-flair with shape-enforced write classes (#1229)

### DIFF
--- a/.changelog/unreleased/added-team-concierge-example.md
+++ b/.changelog/unreleased/added-team-concierge-example.md
@@ -1,0 +1,7 @@
+- Team Concierge example (`examples/team-concierge/`): a runnable ADK agent on
+  adk-flair that commits team knowledge to Flair through two shape-enforced
+  write helpers (`record_decision` → persistent+shared, `record_personal` →
+  standard+private — fixed classes, never model-selected), scopes users by the
+  connector's `adk:concierge:<user>` tag, and ships `scripts/verify.sh`
+  executing the scenario's isolation and distillation claims (with inline
+  mutation checks) against a live instance (#1229, epic #1228)

--- a/examples/team-concierge/README.md
+++ b/examples/team-concierge/README.md
@@ -1,0 +1,160 @@
+# Team Concierge — an ADK agent that commits team knowledge to Flair
+
+A front-office agent for a team: talk to it about ideas, decisions, PR
+context, constraints. It writes the durable knowledge into your Flair
+instance, where **every other agent on the team retrieves it through their own
+Flair paths** — Claude Code over MCP, OpenClaw, the CLI — with no transcript
+copy-paste. Built on [Google ADK](https://google.github.io/adk-docs/) with
+[adk-flair](../../packages/adk-flair) as the memory backend.
+
+## The identity and visibility model, stated plainly
+
+**One app identity, per-user tag scope for writes; teammates read with their
+own identities.** The Concierge is one ADK app (`concierge`) → one Flair agent
+identity (its own Ed25519 key, provisioned like any team agent). Users are
+scoped by the connector's compound tag `adk:concierge:<user>`. Nothing reads
+"as the concierge" except the concierge.
+
+Every write-site sets `visibility` **explicitly** — no write relies on the
+server's durability-keyed default:
+
+| content class | durability | visibility | who can read |
+|---|---|---|---|
+| Team decisions, constraints, spec/PR context (`record_decision`) | `persistent` | `shared` (explicit) | whole org — the point of the tool |
+| Personal user context/preferences (`record_personal`) | `standard` | `private` (explicit) | concierge identity only, tag-scoped per user |
+| Session episodes (raw turns, written by the after-agent callback) | `standard` | `private` (explicit) | distillation pipeline only |
+
+The write surface is **shape-enforced**: the model can only call
+`record_decision` / `record_personal`, whose durability+visibility are fixed
+inside the helpers — never parameters. The per-user tag derives from the
+authenticated ADK session's `user_id`, never from model output. The agent's
+tool list is the allowlist: memory ops only (two write helpers + read-only
+`load_memory`/`preload_memory`) — no soul writes, no workspace writes, no org
+events, no raw memory writes with caller-chosen flags. Server-side gates
+(attribution stamping, durability/visibility validation, the private-row read
+scope) remain the real boundary; the allowlist narrows the LLM surface on top.
+
+### The limitation, honestly
+
+> The compound tag `adk:concierge:<user>` is an application-level filter, not
+> an authz wall. There is no cryptographic isolation between users of the same
+> app, and **any holder of the Concierge's key can read every user's
+> "private" rows** — private means owner-only, and the single concierge
+> identity is the owner of all of them. A bug in the agent (wrong tag on a
+> write, missing tag on a search) could expose one user's context to another.
+> This is acceptable for a single-trust-domain internal team tool because the
+> application code is under team control. For true per-user cryptographic
+> isolation, use per-user agent identities (the epic's "Keep Your Memory
+> Yours" scenario — out of scope here).
+
+## 5-minute quickstart
+
+Prerequisites: a running Flair instance (`npm i -g @tpsdev-ai/flair && flair
+init` gives you one at `http://localhost:19926`), Python ≥ 3.10.
+
+```bash
+cd examples/team-concierge
+
+# 1. Install (adk-flair >= 0.44.13 is required for the explicit
+#    durability/visibility write knobs; until that version is on PyPI,
+#    install the connector from this repo checkout):
+pip install -e ../../packages/adk-flair
+pip install -e .
+
+# 2. Provision the concierge's own agent identity (never a shared/admin key):
+flair agent add concierge          # writes ~/.flair/keys/concierge.key
+
+# 3. Environment (no secrets inline — the keyfile stays a file):
+export FLAIR_URL=http://localhost:19926
+export FLAIR_AGENT_ID=concierge
+export FLAIR_KEYFILE=~/.flair/keys/concierge.key
+export GOOGLE_API_KEY=...          # or GEMINI_API_KEY; model override: ADK_MODEL
+
+# 4. Chat:
+scripts/run_chat.sh                # adk web (dev UI); or: scripts/run_chat.sh run
+```
+
+Tell it *"we decided to adopt the fastify adapter because it halves p99"* —
+then, from any other agent identity on the instance, search for "fastify
+adapter" and find the decision. That crossing of the identity wall is the
+demo.
+
+Note on `adk web`: the agent lives in the `concierge/` package directory
+(ADK discovers agents by importing the directory name, and `team-concierge`
+is not a valid Python module name). The `flair://` scheme is registered by
+`services.py` in this directory — not `services.yaml`, because ADK's generic
+YAML factory constructs services as `cls(uri=...)`, which
+`FlairMemoryService` (taking `url=`) rejects at boot; `adk_flair.register()`
+is the supported registration channel.
+
+## Verify — the demo IS the test
+
+`scripts/verify.sh` executes the scenario's claims against a live instance:
+the shared lane crosses the identity wall (a second identity's REST search
+finds the decision, persistent+shared, tagged `adk:concierge:<user>`); the
+private lane holds (search absence with an indexed-row positive control,
+by-id GET denied); per-user tag scope holds in both directions; and
+scope-tagged distillation gathers only that user's rows and (with a
+generative backend configured) stages `MemoryCandidate` rows whose `scopeTag`
+is exactly `adk:concierge:<user>`. Each assertion documents its mutation
+check inline — e.g. flip `_PERSONAL_CLASS["visibility"]` to `"shared"` in
+`concierge/agent.py` and the private-wall assertions fail.
+
+```bash
+# Throwaway identities, auto-provisioned via the ops API:
+FLAIR_URL=http://localhost:19926 \
+FLAIR_OPS_URL=http://localhost:19925 \
+FLAIR_ADMIN_USER=admin FLAIR_ADMIN_PASS=... \
+scripts/verify.sh
+
+# Or with pre-provisioned keys (e.g. the real concierge + a teammate's identity):
+FLAIR_URL=... CONCIERGE_AGENT_ID=concierge CONCIERGE_KEYFILE=~/.flair/keys/concierge.key \
+READER_AGENT_ID=flint READER_KEYFILE=~/.flair/keys/flint.key \
+scripts/verify.sh
+```
+
+The distillation-execute assertion needs the instance to have a generative
+backend (Harper `models:` block — see [docs/rem.md](../../docs/rem.md)).
+Without one it reports a loud SKIP (never a silent pass); set
+`REQUIRE_DISTILL=1` to make it a hard failure.
+
+Contributors: to run against a throwaway instance instead of your own, boot
+the repo's ephemeral Harper (`node packages/adk-flair/tests/helpers/boot-harper.mjs`
+from the repo root after `npm run build`) — it prints a JSON line with
+`httpURL`/`opsURL`/admin credentials to feed the variables above, and tears
+down when its stdin closes.
+
+## Session distillation (the #1205 pipeline)
+
+Raw session episodes land `standard`+`private` under the user's tag, which
+makes them distillation input: a nightly REM run with `scope:"tagged"` per
+`adk:concierge:<user>` stages `MemoryCandidate` rows for review. Two
+operational rules from the spec:
+
+- **The runner must execute as the concierge identity** (or admin). Episodes
+  are private to the concierge key — a runner under any other identity reads
+  zero episodes and distillation silently produces nothing.
+- **Auto-promote starts OFF.** Review candidates through the reviewer flow
+  first; enable `AutoPromoteCandidates` only after candidate quality has been
+  observed on real sessions.
+
+Success signal: a fact told to the Concierge on day N surfaces in its own
+bootstrap on day N+1 without anyone re-typing it.
+
+## Running against Fabric / a remote instance
+
+Point the same environment at a hosted instance — see
+[docs/quickstart-fabric.md](../../docs/quickstart-fabric.md) for provisioning
+an agent identity against Fabric (`flair agent add concierge --target ...
+--ops-target ... --admin-pass ...`). Environment stays the same shape:
+`FLAIR_URL` + the concierge keyfile, plus the connector's explicit remote
+opt-in `FLAIR_ALLOW_REMOTE_URL=1`. Never inline credentials in commands or
+config — keys stay in files, admin passwords in your secret store.
+
+## Not this example
+
+- Not a multi-tenant showcase: per-user **MCP** identities (each teammate's
+  agent reading with their own key) demonstrate real isolation; this example
+  deliberately uses one app identity and says so above.
+- No Discord/chat-platform integration; the Concierge is a terminal/web
+  surface.

--- a/examples/team-concierge/concierge/__init__.py
+++ b/examples/team-concierge/concierge/__init__.py
@@ -1,0 +1,1 @@
+from . import agent

--- a/examples/team-concierge/concierge/agent.py
+++ b/examples/team-concierge/concierge/agent.py
@@ -1,0 +1,293 @@
+"""Team Concierge — an ADK front-office agent that commits team knowledge to Flair.
+
+One ADK app (``concierge``) on adk-flair's FlairMemoryService → one Flair agent
+identity. Users are scoped by the connector's compound tag
+``adk:concierge:<user>`` (an application-level filter, NOT an authz wall — see
+the README's limitation paragraph). Teammates read what the Concierge records
+through their OWN Flair identities (MCP, CLI, native paths).
+
+Write surface (the whole point of this file):
+
+  The LLM can write memory ONLY through two shape-enforced helpers. Each
+  helper fixes its durability + visibility INSIDE the function body — the
+  model supplies content, never flags. The per-user tag derives from the
+  authenticated ADK session's ``user_id`` (via ToolContext), never from model
+  output. The Agent's ``tools`` list is the allowlist: memory ops only — no
+  soul writes, no workspace writes, no org events, no raw memory_store.
+
+    record_decision(text)  -> durability="persistent", visibility="shared"
+                              (team knowledge — org-open, survives curation)
+    record_personal(text)  -> durability="standard",   visibility="private"
+                              (per-user context — concierge-identity-only)
+
+  Session episodes (raw turns) are persisted by the after-agent callback as
+  durability="standard", visibility="private" — explicitly, not via the
+  server's durability-keyed default (every write-site sets visibility
+  explicitly; a shipped default is a trust anchor, flair#1222).
+"""
+
+from __future__ import annotations
+
+import inspect
+import os
+import uuid
+from typing import Any, Sequence
+
+from google.adk import Agent
+from google.adk.memory.memory_entry import MemoryEntry
+from google.adk.tools import ToolContext, load_memory, preload_memory
+from google.genai import types
+
+from adk_flair import FlairMemoryService
+
+APP_NAME = "concierge"
+
+# Model is not load-bearing for this example (spec §5) — any ADK-supported
+# model string works. Default: native Gemini; override with ADK_MODEL.
+MODEL = os.environ.get("ADK_MODEL", "gemini-2.5-flash")
+
+
+# ─── Connector capability gate ───────────────────────────────────────────────
+# record_decision needs adk-flair's explicit durability/visibility knobs on
+# add_memory (shipped in 0.44.13, flair#1234/#1237). The stock 0.44.12
+# add_memory hardcodes durability="standard" and has no visibility support at
+# all — silently downgrading a "team decision" to a private row would be the
+# exact failure this example exists to demonstrate against. Fail at import,
+# loudly, with the remedy — never at first use inside a chat session.
+def _assert_connector_supports_write_knobs() -> None:
+    params = inspect.signature(FlairMemoryService.add_memory).parameters
+    if "durability" not in params or "visibility" not in params:
+        raise RuntimeError(
+            "adk-flair >= 0.44.13 is required: this installed version's "
+            "add_memory() has no durability/visibility parameters, so "
+            "record_decision cannot produce a persistent+shared row. "
+            "Upgrade with `pip install -U adk-flair` (or, from a flair repo "
+            "checkout, `pip install -e packages/adk-flair`)."
+        )
+
+
+_assert_connector_supports_write_knobs()
+
+
+# ─── Memory service resolution ───────────────────────────────────────────────
+
+
+def _flair_service(tool_context: ToolContext) -> FlairMemoryService:
+    """The runner's memory service, required to be a FlairMemoryService.
+
+    There is deliberately NO fallback write channel: if the runner was wired
+    with a different memory service, refuse with the remedy instead of
+    silently writing somewhere with different durability semantics.
+    """
+    service = tool_context.get_invocation_context().memory_service
+    if isinstance(service, FlairMemoryService):
+        return service
+    raise RuntimeError(
+        "The Team Concierge requires FlairMemoryService as the runner's "
+        "memory service (got: "
+        f"{type(service).__name__ if service is not None else 'None'}). "
+        "Start it via scripts/run_chat.sh, or pass "
+        '--memory_service_uri="flair://localhost:19926" to adk web.'
+    )
+
+
+def _entry(text: str, author: str, entry_id: str | None = None) -> MemoryEntry:
+    return MemoryEntry(
+        id=entry_id,
+        content=types.Content(role="model", parts=[types.Part(text=text)]),
+        author=author,
+    )
+
+
+# ─── The two shape-enforced write helpers (the LLM's ONLY write surface) ─────
+#
+# Each write CLASS is a frozen module-level constant — the single source for
+# both the add_memory call and the confirmation returned to the model, so the
+# report can never claim a class the write didn't use. These are never
+# parameters and never model-selected (Sherlock hard requirement, flair#1229
+# review): a helper that took visibility as an argument would collapse the
+# visibility discipline.
+
+_DECISION_CLASS = {
+    "durability": "persistent",  # team knowledge survives curation cycles
+    "visibility": "shared",      # org-open: the shared lane IS the product
+}
+_PERSONAL_CLASS = {
+    "durability": "standard",    # personal context is expirable working set
+    "visibility": "private",     # concierge-identity-only, tag-scoped per user
+}
+_EPISODE_CLASS = {
+    "durability": "standard",    # raw turns: distillation input (#1205)
+    "visibility": "private",     # explicit — never the durability-keyed default
+}
+
+
+async def record_decision(decision: str, tool_context: ToolContext) -> dict:
+    """Record a team decision, constraint, or agreed piece of spec/PR context.
+
+    Use this when the user states something the WHOLE TEAM should be able to
+    retrieve later: a decision made, a constraint adopted, context about a
+    spec or PR. Write one self-contained statement including the why.
+
+    Args:
+        decision: The decision or constraint, as one self-contained statement.
+
+    Returns:
+        Confirmation including the memory class that was written.
+    """
+    service = _flair_service(tool_context)
+    # user_id comes from the authenticated ADK session (ToolContext.user_id is
+    # a read-only property over the invocation context) — the model cannot
+    # write "as" another user. The connector derives the compound tag
+    # adk:concierge:<user> from app_name+user_id internally.
+    user_id = tool_context.user_id
+    await service.add_memory(
+        app_name=APP_NAME,
+        user_id=user_id,
+        memories=[_entry(decision, author=user_id)],
+        **_DECISION_CLASS,  # FIXED write class — see the constant above
+    )
+    return {
+        "status": "recorded",
+        "memory_class": "team_decision",
+        **_DECISION_CLASS,
+        "note": "Retrievable by every agent identity on this Flair instance.",
+    }
+
+
+async def record_personal(note: str, tool_context: ToolContext) -> dict:
+    """Record personal context or a preference about the current user.
+
+    Use this for things that concern ONLY this user — preferences, working
+    style, personal context. Not for team decisions (use record_decision).
+
+    Args:
+        note: The personal context or preference, as one statement.
+
+    Returns:
+        Confirmation including the memory class that was written.
+    """
+    service = _flair_service(tool_context)
+    user_id = tool_context.user_id
+    await service.add_memory(
+        app_name=APP_NAME,
+        user_id=user_id,
+        memories=[_entry(note, author=user_id)],
+        **_PERSONAL_CLASS,  # FIXED write class — see the constant above
+    )
+    return {
+        "status": "recorded",
+        "memory_class": "personal_context",
+        **_PERSONAL_CLASS,
+        "note": "Visible only to the concierge identity, scoped to this user.",
+    }
+
+
+# ─── Session episode persistence (raw turns → distillation input, #1205) ─────
+
+
+def _event_text(event: Any) -> str | None:
+    """Extract text from an ADK Event (mirrors the connector's heuristic)."""
+    content = getattr(event, "content", None)
+    if content is not None:
+        texts = [
+            str(t)
+            for p in (getattr(content, "parts", None) or [])
+            if (t := getattr(p, "text", None))
+        ]
+        if texts:
+            return " ".join(texts)
+    text = getattr(event, "text", None)
+    return str(text) if text else None
+
+
+async def persist_session_episodes(
+    memory: FlairMemoryService,
+    *,
+    app_name: str,
+    user_id: str,
+    session_id: str,
+    events: Sequence[Any],
+) -> int:
+    """Write session events as episode memories: standard + private, EXPLICIT.
+
+    Rides add_memory (the only connector write surface with the explicit
+    knobs) rather than add_events_to_memory, so the visibility of the episode
+    lane is set at the write-site instead of inherited from the server's
+    durability-keyed default (spec §3: no write relies on the default).
+
+    Deterministic per-event ids make re-ingestion idempotent, mirroring the
+    connector's own session-write scheme.
+    """
+    entries: list[MemoryEntry] = []
+    for event in events:
+        text = _event_text(event)
+        if not text:
+            continue
+        event_id = getattr(event, "id", "") or str(uuid.uuid4())
+        entries.append(
+            _entry(
+                text,
+                author=getattr(event, "author", None) or user_id,
+                entry_id=f"{app_name}:{user_id}:{session_id}:{event_id}",
+            )
+        )
+    if entries:
+        await memory.add_memory(
+            app_name=app_name,
+            user_id=user_id,
+            memories=entries,
+            **_EPISODE_CLASS,  # FIXED episode class (spec §3 table)
+        )
+    return len(entries)
+
+
+async def _after_agent_callback(callback_context) -> None:
+    """Persist each turn's events to Flair after the agent responds."""
+    invocation_context = callback_context._invocation_context
+    service = invocation_context.memory_service
+    if not isinstance(service, FlairMemoryService):
+        return  # no Flair wired (e.g. bare `adk web` without the URI) — skip
+    session = invocation_context.session
+    await persist_session_episodes(
+        service,
+        app_name=session.app_name,
+        user_id=session.user_id,
+        session_id=session.id,
+        events=session.events or [],
+    )
+
+
+# ─── The agent ───────────────────────────────────────────────────────────────
+# The tools list IS the write-surface allowlist (Sherlock hard requirement):
+# two fixed-class write helpers plus read-only memory tools. Nothing here can
+# write a soul record, workspace state, an org event, or a raw memory row
+# with caller-chosen flags.
+
+root_agent = Agent(
+    model=MODEL,
+    name="team_concierge",
+    description=(
+        "Front-office concierge for the team: records decisions and context "
+        "into Flair so every agent on the team can retrieve them."
+    ),
+    instruction=(
+        "You are the Team Concierge. Teammates talk to you about ideas, "
+        "decisions, PR context, and constraints; your job is to commit the "
+        "durable knowledge to team memory and to answer from it.\n"
+        "\n"
+        "Recording rules:\n"
+        "- When the user states a decision, constraint, or team-relevant "
+        "context, call record_decision with ONE self-contained statement "
+        "(include the why). Confirm what you recorded.\n"
+        "- When the user shares a personal preference or context that only "
+        "concerns them, call record_personal.\n"
+        "- Never invent memory. To answer questions about prior decisions or "
+        "context, use load_memory first and answer only from what it "
+        "returns; say plainly when nothing is recorded.\n"
+        "- If a statement is ambiguous between team and personal, ask which "
+        "it is rather than guessing."
+    ),
+    tools=[record_decision, record_personal, load_memory, preload_memory],
+    after_agent_callback=_after_agent_callback,
+)

--- a/examples/team-concierge/concierge/services.py
+++ b/examples/team-concierge/concierge/services.py
@@ -1,0 +1,8 @@
+"""flair:// registration for `adk run` (which loads services from the agent
+folder itself), mirroring ../services.py (which `adk web` loads from the
+agents parent dir). Both exist because google-adk 2.7.1 resolves the services
+module from a different directory per command."""
+
+from adk_flair import register
+
+register()

--- a/examples/team-concierge/pyproject.toml
+++ b/examples/team-concierge/pyproject.toml
@@ -1,0 +1,27 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "team-concierge"
+version = "0.1.0"
+description = "Team Concierge — ADK front-office agent example on adk-flair"
+requires-python = ">=3.10"
+dependencies = [
+    "google-adk>=2.6",
+    # This example REQUIRES the explicit durability/visibility knobs on
+    # add_memory (adk-flair 0.44.13, flair#1234/#1237). PyPI may still serve
+    # 0.44.12 while the 0.44.13 publish is in flight — until it lands, install
+    # the connector from the repo checkout instead:
+    #     pip install -e ../../packages/adk-flair
+    # concierge/agent.py checks the installed connector at import and fails
+    # with this remedy if the knobs are missing.
+    "adk-flair>=0.44.12",
+    # verify.sh dependencies (both already transitive via adk-flair, pinned
+    # here because scripts/verify_impl.py imports them directly):
+    "httpx>=0.27",
+    "cryptography>=42",
+]
+
+[tool.hatch.build.targets.wheel]
+packages = ["concierge"]

--- a/examples/team-concierge/scripts/run_chat.sh
+++ b/examples/team-concierge/scripts/run_chat.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# Team Concierge — interactive runner.
+#
+#   scripts/run_chat.sh          # adk web (browser dev UI)
+#   scripts/run_chat.sh run      # adk run (terminal chat)
+#
+# Required environment (see README):
+#   FLAIR_URL       e.g. http://localhost:19926
+#   FLAIR_AGENT_ID  the concierge's Flair agent identity (e.g. "concierge")
+#   FLAIR_KEYFILE   path to that identity's Ed25519 keyfile
+#   GOOGLE_API_KEY  (or GEMINI_API_KEY) for the default Gemini model;
+#                   override the model with ADK_MODEL.
+set -euo pipefail
+
+EXAMPLE_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+
+: "${FLAIR_URL:?Set FLAIR_URL (e.g. http://localhost:19926)}"
+: "${FLAIR_AGENT_ID:?Set FLAIR_AGENT_ID (provision with: flair agent add concierge)}"
+: "${FLAIR_KEYFILE:?Set FLAIR_KEYFILE (e.g. ~/.flair/keys/concierge.key)}"
+
+# Derive the flair:// memory URI from FLAIR_URL (host:port only — identity
+# and keyfile always come from the env, never the URI).
+HOSTPORT="${FLAIR_URL#*://}"
+HOSTPORT="${HOSTPORT%%/*}"
+MEMORY_URI="flair://${HOSTPORT}"
+
+MODE="${1:-web}"
+cd "$EXAMPLE_DIR"
+
+case "$MODE" in
+  web)
+    # agents dir = this example dir; ADK loads services.py from it, which
+    # registers the flair:// scheme, then discovers the `concierge` package.
+    exec adk web --memory_service_uri="$MEMORY_URI" "$EXAMPLE_DIR"
+    ;;
+  run)
+    exec adk run --memory_service_uri="$MEMORY_URI" "$EXAMPLE_DIR/concierge"
+    ;;
+  *)
+    echo "usage: $0 [web|run]" >&2
+    exit 2
+    ;;
+esac

--- a/examples/team-concierge/scripts/verify.sh
+++ b/examples/team-concierge/scripts/verify.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# verify.sh — the Team Concierge scenario's claims, executed (spec §6).
+# The demo IS the test: run it against a LIVE Flair instance.
+#
+# Environment:
+#   FLAIR_URL              required — the instance under test
+#                          (non-localhost also needs FLAIR_ALLOW_REMOTE_URL=1,
+#                          the connector's remote-URL opt-in)
+#
+#   Identities — one of:
+#     (a) auto-provision (throwaway verify identities via the ops API):
+#         FLAIR_OPS_URL  FLAIR_ADMIN_USER  FLAIR_ADMIN_PASS
+#     (b) pre-provisioned keys (e.g. the real concierge + a teammate's key):
+#         CONCIERGE_AGENT_ID  CONCIERGE_KEYFILE
+#         READER_AGENT_ID     READER_KEYFILE
+#
+#   REQUIRE_DISTILL=1      make the execute-distill assertion (S4b) a hard
+#                          failure when the instance has no generative
+#                          backend, instead of a loudly-reported SKIP
+#   VERIFY_KEEP_ROWS=1     keep the rows the run created (debugging)
+#   VERIFY_SETTLE_BUDGET_S indexing settle budget per assertion (default 30)
+#
+# What it asserts (each negative has an in-script positive control; each
+# assertion documents its mutation check inline in verify_impl.py):
+#   S1  record_decision row is persistent+shared, carries adk:concierge:<user>,
+#       and a DIFFERENT agent identity retrieves it over REST
+#   S2  record_personal row is standard+private and the other identity can
+#       neither search it nor GET it by id (404)
+#   S3  per-user tag scope through the Concierge, both directions
+#   S4  scope:"tagged" reflection gathers only that user's rows; a manual
+#       execute distill stages MemoryCandidate rows whose scopeTag ==
+#       adk:concierge:<user> exactly
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PYTHON="${PYTHON:-python3}"
+
+if ! "$PYTHON" -c "import adk_flair, httpx, cryptography" 2>/dev/null; then
+  echo "verify.sh: missing Python deps — install the example first:" >&2
+  echo "  pip install -e ." >&2
+  echo "  (and, until adk-flair>=0.44.13 is on PyPI: pip install -e ../../packages/adk-flair)" >&2
+  exit 2
+fi
+
+exec "$PYTHON" "$SCRIPT_DIR/verify_impl.py"

--- a/examples/team-concierge/scripts/verify_impl.py
+++ b/examples/team-concierge/scripts/verify_impl.py
@@ -1,0 +1,551 @@
+"""verify.sh implementation — the Team Concierge scenario's claims, executed.
+
+Run through scripts/verify.sh (which documents the environment contract).
+
+What is asserted (spec flair#1229 §6), each against a LIVE Flair instance:
+
+  S1  Cross-harness, org-open: a decision recorded through the Concierge's
+      record_decision helper is retrievable by a DIFFERENT agent identity via
+      direct REST SemanticSearch, and the row is persistent + shared and
+      carries the compound tag adk:concierge:<user>.
+  S2  Private wall: personal context written through record_personal is NOT
+      returned to the other identity (search absence + by-id GET 404), with a
+      positive control proving the row is indexed and readable by its owner.
+  S3  Tag scope: userA's retrieval through the Concierge connector excludes
+      userB's personal rows, both directions (with positive controls).
+  S4  Distillation hook: a scripted session's episodes are gathered by
+      scope:"tagged" reflection for exactly one user, and (when the instance
+      has a generative backend) a manual execute distill stages >=1
+      MemoryCandidate whose scopeTag is EXACTLY adk:concierge:<user>.
+
+Every negative assertion has a paired positive control in-script, so "not
+found" can never mean "not indexed yet" or "the search never ran".
+
+Mutation checks (documented per assertion below, runnable by hand):
+  - Flip _PERSONAL_CLASS["visibility"] to "shared" in concierge/agent.py →
+    S2 MUST fail (reader sees the personal row). Restore → passes.
+  - Flip _DECISION_CLASS["visibility"] to "private" → S1 MUST fail.
+  - Change the tag the S3 searches use to the other user's → the positive
+    controls fail (proving the tag filter is what isolates).
+  - Point S4's tag at userB → the episode-content assertion fails.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import hashlib
+import json
+import os
+import sys
+import time
+import uuid
+from types import SimpleNamespace
+
+import httpx
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import ed25519
+
+# The example's own agent module — verify drives the SAME helpers the LLM
+# calls, not a parallel implementation.
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+from concierge.agent import (  # noqa: E402
+    APP_NAME,
+    persist_session_episodes,
+    record_decision,
+    record_personal,
+)
+from adk_flair import FlairMemoryService  # noqa: E402
+
+SETTLE_BUDGET_S = float(os.environ.get("VERIFY_SETTLE_BUDGET_S", "30"))
+
+# ─── Result accounting ───────────────────────────────────────────────────────
+
+RESULTS: list[tuple[str, str, str]] = []  # (status, name, detail)
+
+
+def record(status: str, name: str, detail: str = "") -> None:
+    RESULTS.append((status, name, detail))
+    print(f"[{status}] {name}" + (f" — {detail}" if detail else ""))
+
+
+def ensure(cond: bool, name: str, detail: str = "") -> None:
+    record("PASS" if cond else "FAIL", name, detail)
+
+
+# ─── Ed25519 REST client (TPS-Ed25519 auth, same scheme the connector uses) ──
+
+
+class SignedClient:
+    def __init__(self, base_url: str, agent_id: str, private_key: ed25519.Ed25519PrivateKey):
+        self.base_url = base_url.rstrip("/")
+        self.agent_id = agent_id
+        self._key = private_key
+        self._http = httpx.Client(base_url=self.base_url, timeout=10.0)
+
+    def _auth(self, method: str, path: str) -> str:
+        ts = str(int(time.time() * 1000))
+        nonce = str(uuid.uuid4())
+        payload = f"{self.agent_id}:{ts}:{nonce}:{method}:{path}".encode()
+        sig = base64.b64encode(self._key.sign(payload)).decode()
+        return f"TPS-Ed25519 {self.agent_id}:{ts}:{nonce}:{sig}"
+
+    def request(
+        self, method: str, path: str, body: dict | None = None, timeout: float | None = None
+    ) -> httpx.Response:
+        headers = {"Authorization": self._auth(method, path)}
+        if body is not None:
+            headers["Content-Type"] = "application/json"
+        kwargs: dict = {"headers": headers, "json": body}
+        if timeout is not None:
+            kwargs["timeout"] = timeout
+        return self._http.request(method, path, **kwargs)
+
+    def search(self, q: str, tag: str | None = None, limit: int = 20) -> list[dict]:
+        body: dict = {"agentId": self.agent_id, "q": q, "limit": limit}
+        if tag:
+            body["tag"] = tag
+        resp = self.request("POST", "/SemanticSearch", body)
+        if resp.status_code != 200:
+            raise RuntimeError(f"SemanticSearch as {self.agent_id} → {resp.status_code}")
+        return resp.json().get("results", [])
+
+    def close(self) -> None:
+        self._http.close()
+
+
+def make_keypair() -> tuple[ed25519.Ed25519PrivateKey, str]:
+    key = ed25519.Ed25519PrivateKey.generate()
+    pub = key.public_key().public_bytes(
+        encoding=serialization.Encoding.Raw, format=serialization.PublicFormat.Raw
+    )
+    return key, base64.b64encode(pub).decode()
+
+
+def key_to_pkcs8_b64(key: ed25519.Ed25519PrivateKey) -> str:
+    der = key.private_bytes(
+        encoding=serialization.Encoding.DER,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.NoEncryption(),
+    )
+    return base64.b64encode(der).decode()
+
+
+def load_keyfile(path: str) -> ed25519.Ed25519PrivateKey:
+    raw = open(os.path.expanduser(path), "rb").read()
+    if len(raw) == 32:
+        return ed25519.Ed25519PrivateKey.from_private_bytes(raw)
+    text = raw.decode().strip()
+    if "-----BEGIN" in text:
+        key = serialization.load_pem_private_key(text.encode(), password=None)
+    else:
+        decoded = base64.b64decode(text)
+        if len(decoded) == 32:
+            return ed25519.Ed25519PrivateKey.from_private_bytes(decoded)
+        key = serialization.load_der_private_key(decoded, password=None)
+    assert isinstance(key, ed25519.Ed25519PrivateKey)
+    return key
+
+
+def register_agent(ops_url: str, admin_user: str, admin_pass: str, agent_id: str, pub_b64: str) -> None:
+    auth = base64.b64encode(f"{admin_user}:{admin_pass}".encode()).decode()
+    resp = httpx.post(
+        ops_url,
+        headers={"Content-Type": "application/json", "Authorization": f"Basic {auth}"},
+        json={
+            "operation": "insert",
+            "database": "flair",
+            "table": "Agent",
+            "records": [{
+                "id": agent_id,
+                "name": agent_id,
+                "role": "agent",
+                "publicKey": pub_b64,
+                "createdAt": time.strftime("%Y-%m-%dT%H:%M:%S.000Z", time.gmtime()),
+            }],
+        },
+        timeout=15.0,
+    )
+    if resp.status_code >= 400:
+        raise RuntimeError(f"agent registration for {agent_id} failed: HTTP {resp.status_code}")
+
+
+# ─── Scripted Concierge session ──────────────────────────────────────────────
+# A deterministic stand-in for the live ADK loop: it carries exactly what the
+# helpers consume from a real ToolContext — the session's authenticated
+# user_id (read-only) and the runner's memory service. The full write path
+# (helper → fixed flags → connector add_memory → signed REST → server) is the
+# real product code; only the LLM's decision to call the tool is scripted.
+
+
+class ScriptedContext:
+    def __init__(self, service: FlairMemoryService, user_id: str):
+        self.user_id = user_id
+        self._service = service
+
+    def get_invocation_context(self):
+        return SimpleNamespace(memory_service=self._service)
+
+
+def content_hash_id(text: str) -> str:
+    """The record id the connector derives for an entry without an explicit id."""
+    return hashlib.sha256(text.encode()).hexdigest()[:32]
+
+
+def settle(predicate, budget_s: float = SETTLE_BUDGET_S) -> bool:
+    """Poll until predicate() is truthy (returns True) or budget expires."""
+    deadline = time.monotonic() + budget_s
+    while time.monotonic() < deadline:
+        if predicate():
+            return True
+        time.sleep(0.5)
+    return False
+
+
+# ─── Main scenario ───────────────────────────────────────────────────────────
+
+
+async def main() -> int:
+    flair_url = os.environ.get("FLAIR_URL", "")
+    if not flair_url:
+        print("FLAIR_URL is required (see scripts/verify.sh)", file=sys.stderr)
+        return 2
+
+    run_id = uuid.uuid4().hex[:8]
+    ops_url = os.environ.get("FLAIR_OPS_URL", "")
+    admin_user = os.environ.get("FLAIR_ADMIN_USER", "")
+    admin_pass = os.environ.get("FLAIR_ADMIN_PASS", "")
+
+    # ── Identities: provided keyfiles, or auto-provisioned via the ops API ──
+    if os.environ.get("CONCIERGE_KEYFILE") and os.environ.get("READER_KEYFILE"):
+        concierge_id = os.environ.get("CONCIERGE_AGENT_ID", "concierge")
+        reader_id = os.environ.get("READER_AGENT_ID", "")
+        if not reader_id:
+            print("READER_AGENT_ID is required with READER_KEYFILE", file=sys.stderr)
+            return 2
+        concierge_key = load_keyfile(os.environ["CONCIERGE_KEYFILE"])
+        reader_key = load_keyfile(os.environ["READER_KEYFILE"])
+        keyfile_path = os.path.expanduser(os.environ["CONCIERGE_KEYFILE"])
+        cleanup_keyfile = None
+    elif ops_url and admin_user and admin_pass:
+        concierge_id = f"concierge-verify-{run_id}"
+        reader_id = f"reader-verify-{run_id}"
+        concierge_key, concierge_pub = make_keypair()
+        reader_key, reader_pub = make_keypair()
+        register_agent(ops_url, admin_user, admin_pass, concierge_id, concierge_pub)
+        register_agent(ops_url, admin_user, admin_pass, reader_id, reader_pub)
+        # The connector reads the concierge key from a file, like production.
+        keyfile_path = os.path.join(
+            os.environ.get("TMPDIR", "/tmp"), f"concierge-verify-{run_id}.key"
+        )
+        with open(keyfile_path, "w") as fh:
+            fh.write(key_to_pkcs8_b64(concierge_key))
+        os.chmod(keyfile_path, 0o600)
+        cleanup_keyfile = keyfile_path
+        print(f"[setup] provisioned verify identities: {concierge_id}, {reader_id}")
+    else:
+        print(
+            "Provide either CONCIERGE_KEYFILE+READER_AGENT_ID+READER_KEYFILE, or "
+            "FLAIR_OPS_URL+FLAIR_ADMIN_USER+FLAIR_ADMIN_PASS for auto-provisioning.",
+            file=sys.stderr,
+        )
+        return 2
+
+    test_start_iso = time.strftime("%Y-%m-%dT%H:%M:%S.000Z", time.gmtime(time.time() - 60))
+
+    service = FlairMemoryService(url=flair_url, agent_id=concierge_id, keyfile=keyfile_path)
+    concierge_rest = SignedClient(flair_url, concierge_id, concierge_key)
+    reader_rest = SignedClient(flair_url, reader_id, reader_key)
+
+    user_a = f"alice-{run_id}"
+    user_b = f"bob-{run_id}"
+    tag_a = f"adk:{APP_NAME}:{user_a}"
+    tag_b = f"adk:{APP_NAME}:{user_b}"
+    ctx_a = ScriptedContext(service, user_a)
+    ctx_b = ScriptedContext(service, user_b)
+
+    token_d = f"quorum-{run_id}"
+    token_p = f"lantern-{run_id}"
+    token_pb = f"orchid-{run_id}"
+    decision_text = (
+        f"DECISION {token_d}: adopt the fastify adapter for the gateway because "
+        f"it halves p99 latency in the spike."
+    )
+    personal_a_text = f"PERSONAL {token_p}: {user_a} prefers terse one-screen briefs."
+    personal_b_text = f"PERSONAL {token_pb}: {user_b} prefers diagrams over prose."
+    created_ids: list[str] = []
+
+    print(f"\n=== Team Concierge verify — {flair_url} (run {run_id}) ===")
+    print(f"    concierge identity: {concierge_id}; cross-identity reader: {reader_id}")
+    print(f"    users: {user_a}, {user_b}\n")
+
+    # ═════ S1 — decision: persistent + shared, readable cross-identity ══════
+    # Mutation check: flip _DECISION_CLASS["visibility"] to "private" in
+    # concierge/agent.py → the reader search below finds NOTHING and S1 fails.
+    out = await record_decision(decision_text, ctx_a)  # scripted session, userA
+    ensure(
+        out.get("durability") == "persistent" and out.get("visibility") == "shared",
+        "S1 helper reports fixed class persistent+shared",
+        json.dumps({k: out[k] for k in ("durability", "visibility")}),
+    )
+    created_ids.append(content_hash_id(decision_text))
+
+    hit_holder: dict = {}
+
+    def _reader_sees_decision() -> bool:
+        for hit in reader_rest.search(token_d):
+            if token_d in (hit.get("content") or ""):
+                hit_holder.update(hit)
+                return True
+        return False
+
+    found = settle(_reader_sees_decision)
+    ensure(found, f"S1 decision retrievable by DIFFERENT identity ({reader_id}) via REST SemanticSearch")
+    if found:
+        ensure(hit_holder.get("visibility") == "shared", "S1 row visibility == shared",
+               f"got {hit_holder.get('visibility')!r}")
+        ensure(hit_holder.get("durability") == "persistent", "S1 row durability == persistent",
+               f"got {hit_holder.get('durability')!r}")
+        ensure(tag_a in (hit_holder.get("tags") or []),
+               f"S1 row carries compound tag {tag_a}",
+               f"tags={hit_holder.get('tags')}")
+
+    # ═════ S2 — personal: private wall against the other identity ═══════════
+    # Mutation check: flip _PERSONAL_CLASS["visibility"] to "shared" →
+    # the helper-report, search-absence, by-id-denied, and stored-flags
+    # assertions below ALL fail. Restore → passes. (The #1222-class
+    # regression detector.)
+    out = await record_personal(personal_a_text, ctx_a)
+    ensure(
+        out.get("durability") == "standard" and out.get("visibility") == "private",
+        "S2 helper reports fixed class standard+private",
+        json.dumps({k: out[k] for k in ("durability", "visibility")}),
+    )
+    personal_a_id = content_hash_id(personal_a_text)
+    created_ids.append(personal_a_id)
+
+    # Positive control FIRST: the owner (concierge identity) can see the row —
+    # so the absence assertions below can never pass because of slow indexing.
+    indexed = settle(
+        lambda: any(token_p in (h.get("content") or "") for h in concierge_rest.search(token_p))
+    )
+    ensure(indexed, "S2 positive control: owner identity sees the personal row (it IS indexed)")
+
+    reader_hits = reader_rest.search(token_p)
+    leaked = [h for h in reader_hits if token_p in (h.get("content") or "")]
+    ensure(
+        not leaked,
+        f"S2 private wall: {reader_id}'s search does NOT return the personal row",
+        f"reader got {len(reader_hits)} hits for the token query, "
+        f"{len(leaked)} containing the personal token",
+    )
+    # Denied by-id read: the auth-middleware guard 403s a cross-agent private
+    # read (resources/auth-middleware.ts); the resource layer behind it 404s.
+    # Either status is a wall — what must never happen is a 200 with content.
+    resp = reader_rest.request("GET", f"/Memory/{personal_a_id}")
+    ensure(
+        resp.status_code in (403, 404),
+        "S2 private wall: reader by-id GET is denied (403/404, never content)",
+        f"got HTTP {resp.status_code}",
+    )
+    resp = concierge_rest.request("GET", f"/Memory/{personal_a_id}")
+    row = resp.json() if resp.status_code == 200 else {}
+    ensure(
+        resp.status_code == 200
+        and row.get("visibility") == "private"
+        and row.get("durability") == "standard",
+        "S2 stored row is standard+private (owner read confirms persisted flags)",
+        f"HTTP {resp.status_code}, visibility={row.get('visibility')!r}, durability={row.get('durability')!r}",
+    )
+
+    # ═════ S3 — tag scope between users, both directions ════════════════════
+    # Mutation check: swap tag_a/tag_b in the two exclusion searches below —
+    # each then FINDS the other user's row through the connector, failing the
+    # assertion (proving the compound tag is what isolates, and that this is
+    # an application filter — see the README limitation paragraph).
+    await record_personal(personal_b_text, ctx_b)
+    created_ids.append(content_hash_id(personal_b_text))
+
+    async def _connector_hits(user_id: str, query: str) -> list[str]:
+        res = await service.search_memory(app_name=APP_NAME, user_id=user_id, query=query)
+        texts = []
+        for m in res.memories:
+            if m.content and m.content.parts:
+                texts.append(" ".join(p.text or "" for p in m.content.parts))
+        return texts
+
+    async def _settle_async(coro_factory, budget_s: float = SETTLE_BUDGET_S) -> bool:
+        deadline = time.monotonic() + budget_s
+        while time.monotonic() < deadline:
+            if await coro_factory():
+                return True
+            await asyncio.sleep(0.5)
+        return False
+
+    # Positive controls: each user retrieves their OWN personal row.
+    ok_a = await _settle_async(lambda: _contains(_connector_hits(user_a, token_p), token_p))
+    ensure(ok_a, f"S3 positive control: {user_a} retrieves their own personal row via the Concierge")
+    ok_b = await _settle_async(lambda: _contains(_connector_hits(user_b, token_pb), token_pb))
+    ensure(ok_b, f"S3 positive control: {user_b} retrieves their own personal row via the Concierge")
+
+    cross_ab = await _connector_hits(user_a, token_pb)
+    ensure(
+        not any(token_pb in t for t in cross_ab),
+        f"S3 {user_a}'s Concierge retrieval excludes {user_b}'s personal row",
+        f"{len(cross_ab)} hits, none containing {token_pb}",
+    )
+    cross_ba = await _connector_hits(user_b, token_p)
+    ensure(
+        not any(token_p in t for t in cross_ba),
+        f"S3 {user_b}'s Concierge retrieval excludes {user_a}'s personal row",
+        f"{len(cross_ba)} hits, none containing {token_p}",
+    )
+
+    # ═════ S4 — distillation hook: tagged gather + scopeTag on candidates ═══
+    # Mutation check: change `tag` below to tag_b → the "episode content
+    # gathered" assertion fails (userA's episodes are not under userB's tag);
+    # under execute mode the scopeTag equality assertion fails the same way.
+    episode_token = f"beacon-{run_id}"
+    session_id = f"verify-session-{run_id}"
+    events = [
+        SimpleNamespace(
+            id=f"ev-{i}-{run_id}",
+            author=author,
+            content=SimpleNamespace(parts=[SimpleNamespace(text=text)]),
+        )
+        for i, (author, text) in enumerate([
+            (user_a, f"We spiked both gateways this week, {episode_token} run."),
+            ("team_concierge", "Noted. What did the p99 comparison show?"),
+            (user_a, f"Fastify halved p99; we should adopt it — {episode_token}."),
+        ])
+    ]
+    wrote = await persist_session_episodes(
+        service, app_name=APP_NAME, user_id=user_a, session_id=session_id, events=events
+    )
+    ensure(wrote == 3, "S4 scripted session persisted 3 episode rows", f"wrote={wrote}")
+    created_ids += [f"{APP_NAME}:{user_a}:{session_id}:ev-{i}-{run_id}" for i in range(3)]
+
+    # Episodes are standard+private explicit — confirm one persisted row.
+    resp = concierge_rest.request("GET", f"/Memory/{APP_NAME}:{user_a}:{session_id}:ev-0-{run_id}")
+    row = resp.json() if resp.status_code == 200 else {}
+    ensure(
+        row.get("visibility") == "private" and row.get("durability") == "standard",
+        "S4 episode rows are standard+private (explicit at the write-site)",
+        f"visibility={row.get('visibility')!r}, durability={row.get('durability')!r}",
+    )
+
+    # 4a — tagged gather is per-user (the #1205b cross-user-bleed boundary).
+    def _gather() -> dict | None:
+        resp = concierge_rest.request(
+            "POST", "/ReflectMemories",
+            {"agentId": concierge_id, "scope": "tagged", "tag": tag_a, "since": test_start_iso},
+        )
+        if resp.status_code != 200:
+            return None
+        body = resp.json()
+        texts = [m.get("content") or "" for m in body.get("memories", [])]
+        return body if any(episode_token in t for t in texts) else None
+
+    gather_holder: dict = {}
+
+    def _gather_settled() -> bool:
+        body = _gather()
+        if body:
+            gather_holder.update(body)
+            return True
+        return False
+
+    ensure(settle(_gather_settled), "S4a tagged reflect gather includes the scripted episodes")
+    if gather_holder:
+        mems = gather_holder.get("memories", [])
+        ensure(
+            all(tag_a in (m.get("tags") or []) for m in mems),
+            f"S4a every gathered memory carries {tag_a} (no cross-user bleed into distillation)",
+            f"{len(mems)} memories gathered",
+        )
+        ensure(
+            not any(token_pb in (m.get("content") or "") for m in mems),
+            f"S4a gathered set contains nothing of {user_b}'s",
+        )
+
+    # 4b — execute distill stages MemoryCandidate rows stamped with scopeTag.
+    # Server-side generation can take minutes on a cold model — generous
+    # client timeout, distinct from the normal REST budget. A COLD backend can
+    # also abort Harper's open transaction (HTTP 422 "Transaction was aborted
+    # after exceeding the maximum open-transaction time") while the model
+    # loads; the first attempt warms it, so retry exactly once on 422.
+    def _execute_distill() -> httpx.Response:
+        return concierge_rest.request(
+            "POST", "/ReflectMemories",
+            {"agentId": concierge_id, "scope": "tagged", "tag": tag_a,
+             "since": test_start_iso, "execute": True},
+            timeout=float(os.environ.get("VERIFY_DISTILL_TIMEOUT_S", "300")),
+        )
+
+    resp = _execute_distill()
+    if resp.status_code == 422:
+        print("[S4b] transaction-abort on cold backend (HTTP 422) — retrying once, model now warm")
+        resp = _execute_distill()
+    if resp.status_code == 200:
+        body = resp.json()
+        cands = body.get("candidates", [])
+        ensure(len(cands) >= 1, "S4b manual execute distill staged >=1 MemoryCandidate",
+               f"count={len(cands)}, model={body.get('model')}")
+        ensure(
+            bool(cands) and all(c.get("scopeTag") == tag_a for c in cands),
+            f"S4b every staged candidate has scopeTag == {tag_a} (exact match, not just presence)",
+            f"scopeTags={[c.get('scopeTag') for c in cands]}",
+        )
+    elif resp.status_code == 503:
+        # No generative backend on this instance. This assertion CANNOT fire
+        # here — say so loudly rather than letting it look like a pass
+        # (an unrun check must not look like a pass). REQUIRE_DISTILL=1
+        # makes this a hard failure for instances that must have the backend.
+        detail = (
+            "instance has no generative backend (HTTP 503) — configure Harper's "
+            "models: block (see flair docs/rem.md) and re-run; set REQUIRE_DISTILL=1 "
+            "to make this a failure"
+        )
+        if os.environ.get("REQUIRE_DISTILL") == "1":
+            record("FAIL", "S4b execute distill (REQUIRE_DISTILL=1)", detail)
+        else:
+            record("SKIP", "S4b execute distill + scopeTag assertion", detail)
+    else:
+        record("FAIL", "S4b execute distill", f"HTTP {resp.status_code}: {resp.text[:200]}")
+
+    # ── Cleanup (best-effort; VERIFY_KEEP_ROWS=1 to skip) ───────────────────
+    if os.environ.get("VERIFY_KEEP_ROWS") != "1":
+        deleted = 0
+        for mem_id in created_ids:
+            r = concierge_rest.request("DELETE", f"/Memory/{mem_id}")
+            deleted += 1 if r.status_code < 400 else 0
+        print(f"\n[cleanup] deleted {deleted}/{len(created_ids)} verify rows "
+              f"(staged MemoryCandidate rows, if any, are left for the reviewer flow)")
+    if cleanup_keyfile:
+        try:
+            os.unlink(cleanup_keyfile)
+        except OSError:
+            pass
+
+    await service.close()
+    concierge_rest.close()
+    reader_rest.close()
+
+    # ── Summary ─────────────────────────────────────────────────────────────
+    passed = sum(1 for s, _, _ in RESULTS if s == "PASS")
+    failed = sum(1 for s, _, _ in RESULTS if s == "FAIL")
+    skipped = sum(1 for s, _, _ in RESULTS if s == "SKIP")
+    print(f"\n=== verify summary: {passed} passed, {failed} failed, {skipped} skipped ===")
+    if skipped:
+        for s, name, detail in RESULTS:
+            if s == "SKIP":
+                print(f"    SKIPPED (not a pass): {name} — {detail}")
+    return 1 if failed else 0
+
+
+async def _contains(coro, token: str) -> bool:
+    return any(token in t for t in await coro)
+
+
+if __name__ == "__main__":
+    sys.exit(asyncio.run(main()))

--- a/examples/team-concierge/services.py
+++ b/examples/team-concierge/services.py
@@ -1,0 +1,17 @@
+"""Register the flair:// URI scheme with ADK's service registry.
+
+`adk web` / `adk run` import this module from the agents dir, after which
+--memory_service_uri="flair://localhost:19926" resolves to a
+FlairMemoryService (identity still comes from FLAIR_AGENT_ID/FLAIR_KEYFILE).
+
+Why services.py and not services.yaml: ADK's generic YAML factory constructs
+the class as `cls(uri=...)`, but FlairMemoryService takes `url=` — verified
+against google-adk 2.7.1, where the YAML route fails at boot with
+`TypeError: FlairMemoryService.__init__() got an unexpected keyword argument
+'uri'`. adk_flair.register() installs a factory that parses the flair:// URI
+properly, so it is the supported registration channel.
+"""
+
+from adk_flair import register
+
+register()


### PR DESCRIPTION
Team Concierge — the K&S-approved spec's deliverable: a runnable ADK agent example on adk-flair in `examples/team-concierge/`, exercising per-user tag scoping, cross-harness portability, and the scope-tagged distillation hook end to end.

Refs #1228
Refs #1229

## What's in it

```
examples/team-concierge/
├── README.md            # quickstart + the identity/visibility model + the limitation paragraph
├── pyproject.toml
├── services.py          # flair:// registration for adk web (see deviation note)
├── concierge/
│   ├── __init__.py
│   ├── agent.py         # root_agent; the two shape-enforced write helpers; episode persistence
│   └── services.py      # same registration for adk run (loads from the agent dir)
└── scripts/
    ├── run_chat.sh      # adk web / adk run wrapper
    ├── verify.sh        # env contract + the assertion list
    └── verify_impl.py   # the scenario's claims, executed
```

## Shape enforcement (the Sherlock hard requirements, all structural)

- `record_decision` → `persistent`+`shared`, `record_personal` → `standard`+`private`: fixed in frozen module constants that feed **both** the `add_memory` call and the confirmation dict, so the report can never claim a class the write didn't use. Never parameters.
- The LLM's declared surface is one string each — verified against google-adk 2.7.1's generated function declarations: `record_decision(decision: str)`, `record_personal(note: str)`. `ToolContext` is injected by ADK and invisible to the model; the per-user tag derives from the authenticated session's `user_id` inside the connector.
- The `tools` list is the allowlist: the two helpers + read-only `load_memory`/`preload_memory`. No soul writes, no workspace writes, no org events, no raw memory writes.
- Session episodes ride `add_memory` with an explicit `standard`+`private` class (not `add_events_to_memory`, which cannot set visibility) — no write anywhere relies on the durability-keyed default.
- `agent.py` asserts at import that the installed adk-flair has the 0.44.13 write knobs and fails with the upgrade remedy if not (a 0.44.12 install would otherwise silently be unable to produce a shared row).

## Verification (run against an ephemeral HOME-isolated Harper from this branch's build)

Full instance (Ollama generative backend configured, `REQUIRE_DISTILL=1`): **21 passed, 0 failed, 0 skipped**, including:

- decision row readable by a second agent identity over REST, `visibility=shared`, `durability=persistent`, tagged `adk:concierge:<user>`
- private wall: owner-indexed positive control, then reader search absence + by-id GET denied (403)
- per-user tag scope through the connector, both directions, with per-user positive controls
- `scope:"tagged"` reflect gather: all 5 gathered memories carry the user's tag, nothing of the other user's
- execute distill staged 2 `MemoryCandidate` rows, **both `scopeTag == adk:concierge:<user>` exactly**

Mutation check (flip `_PERSONAL_CLASS["visibility"]` to `"shared"`): **4 S2 assertions fail, exit 1** — helper report, reader search leak (1 hit containing the personal token), by-id GET returns 200, stored flags show shared. Restore → 21/21 again.

Backend-less instance (the default quickstart posture): the distill-execute assertion reports a **loud SKIP labeled "not a pass"** with the models-config remedy, exit 0; with `REQUIRE_DISTILL=1` it is a **FAIL**, exit 1.

## Deviations from the spec's file plan (mechanical, each forced by ADK)

- `agent.py` lives in a `concierge/` package dir: ADK discovers agents by importing the directory name, and `team-concierge` is not a valid Python module name.
- `services.py` instead of `services.yaml`: ADK's generic YAML factory constructs `cls(uri=...)`, which `FlairMemoryService.__init__(url=...)` rejects — reproduced on google-adk 2.7.1 (`TypeError: ... unexpected keyword argument 'uri'`). `adk_flair.register()` is the supported channel. Two copies because `adk web` loads services from the agents parent dir and `adk run` from the agent dir itself.
- `scripts/verify_impl.py` added alongside `verify.sh` (the shell wrapper holds the env contract; the assertions live in Python).

## Notes for reviewers

- `pyproject.toml` pins `adk-flair>=0.44.12` per the in-flight PyPI publish; the README and the import-time capability check both steer to a repo-checkout install until 0.44.13 is published. The example genuinely requires 0.44.13.
- No CI changes needed: the workspace typecheck gate scans `packages/*/` only, so a root-level `examples/` dir is outside it.
- Two server-side observations surfaced while verifying (not addressed here): a cold generative backend can abort `/ReflectMemories` execute mode with HTTP 422 (Harper's 30s open-transaction ceiling) rather than the documented 502/503 — verify.sh retries once and documents it; and a cross-agent private by-id GET is denied by the auth middleware with a 403 naming the owner, while the resource layer behind it deliberately 404s to prevent enumeration.
