### PR TITLE
test/repro: #1244 two-node repro — base-copy hypothesis disproved; residency-omission lane REPRODUCES the signature

### DIFF
--- a/.changelog/unreleased/added-1244-basecopy-retention-repro.md
+++ b/.changelog/unreleased/added-1244-basecopy-retention-repro.md
@@ -1,0 +1,9 @@
+- **Runnable two-node repro for the #1244 loss mechanism**
+  (`test/repro/basecopy-retention-repro.mjs`). Boots an ephemeral, fully
+  isolated two-node Harper cluster, partitions one node, writes rows only the
+  surviving node holds, ages the partition past `logging.auditRetention`, and
+  reconnects to force Harper's "bounded base-copy resync" — then asserts what
+  that lane actually does to receiver-only rows, with a positive-control
+  proving normal deletes do appear in `read_transaction_log`. A control lane
+  reconnects within retention to distinguish base-copy from incremental
+  catch-up. Nothing in it touches a production data directory or port.

--- a/test/repro/basecopy-retention-repro.mjs
+++ b/test/repro/basecopy-retention-repro.mjs
@@ -1,0 +1,557 @@
+#!/usr/bin/env node
+/**
+ * flair#1244 — decisive local repro for Harper replication base-copy/resync semantics.
+ *
+ * QUESTION UNDER TEST
+ * When a two-node Harper cluster reconnects after a partition longer than the audit/txn-log
+ * retention window, the sender upgrades incremental catch-up to a forced "bounded base-copy
+ * resync" (replicationConnection.ts shouldForceBaseCopyForRetention; the incident log line is
+ * "forcing a bounded base-copy resync"). The base-copy apply lane stores rows with NO
+ * audit/transaction-log entries by design (core Table.ts isCopyApply lane). flair#1244's
+ * forensics hypothesized this lane also silently DISCARDS receiver-only rows (rows that exist
+ * only on the reconnecting side) — 10 hub-only rows vanished from both nodes with zero delete
+ * transactions. This script forces exactly that reconnect shape locally and observes what the
+ * base-copy path actually does to receiver-only rows.
+ *
+ * LANES
+ *   basecopy — partition B, write rows only A holds, age past auditRetention, reconnect.
+ *              The reconnect MUST log "forcing a bounded base-copy resync" or the lane aborts
+ *              as UNPROVEN (the path under test never engaged).
+ *   control  — identical flow but reconnect WITHIN retention: incremental catch-up, no forced
+ *              base copy expected; distinguishes the base-copy path from normal replication.
+ *
+ * INSTRUMENT POSITIVE CONTROL
+ * Before partitioning, one canary row is deleted normally and the script asserts the 'delete'
+ * entry is visible via read_transaction_log on BOTH nodes. This is load-bearing: it proves a
+ * later "zero delete entries" observation is evidence about the mechanism, not a logging gap.
+ *
+ * ISOLATION / SAFETY
+ * - Every node lives in its own mkdtemp tree; HOME and ROOTPATH point INTO that tree. Nothing
+ *   under ~/.flair or any production path is read or written.
+ * - All ports are OS-assigned free ports (never 9925/9926/9933/1883).
+ * - Teardown kills ONLY child PIDs this script spawned (never pkill/pattern kill).
+ *
+ * USAGE
+ *   node test/repro/basecopy-retention-repro.mjs [--lane=basecopy|control|both] [--keep]
+ *
+ *   HARPER_PRO_DIR      dir whose node_modules contains @harperfast/harper-pro (optional; if
+ *                       unset the script npm-installs HARPER_PRO_VERSION into a temp sandbox)
+ *   HARPER_PRO_VERSION  version to install when HARPER_PRO_DIR is unset (default 5.2.2)
+ *
+ * Note on fidelity to flair: the repro uses a neutral audited table ("repro"."doc") rather than
+ * the flair component. The lane under test is Harper-core: flair's Memory writes terminate in
+ * the same Table.put on the same RocksDB-backed audited table and the base-copy receive lane
+ * is component-agnostic (core Table.ts, isCopyApply). A neutral schema keeps this script
+ * runnable verbatim by Harper upstream.
+ */
+
+import { spawn, execFileSync } from 'node:child_process';
+import { createServer } from 'node:net';
+import { mkdtemp, rm, readFile, writeFile } from 'node:fs/promises';
+import { createWriteStream, existsSync, readFileSync } from 'node:fs';
+import { createRequire } from 'node:module';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+// ─── knobs ────────────────────────────────────────────────────────────────────
+const RETENTION = '1m'; // logging.auditRetention — minutes so aging past it is fast
+const RETENTION_MS = 60_000;
+const N_BASE = 25; // rows written+replicated before the partition (incl. canary)
+const N_PARTITION = 10; // receiver-only rows written while B is down
+const ADMIN = { username: 'admin', password: 'repro123' }; // ephemeral throwaway credential
+const HARPER_PRO_VERSION = process.env.HARPER_PRO_VERSION ?? '5.2.2';
+
+const args = process.argv.slice(2);
+const laneArg = (args.find((a) => a.startsWith('--lane=')) ?? '--lane=both').slice(7);
+const KEEP = args.includes('--keep');
+// stop    — node-b's process exits and is later restarted (peer-down partition; default)
+// suspend — node-b is SIGSTOPped and later SIGCONTed: both processes stay up, the connection
+//           wedges and dies by ping timeout, and the resume looks like the incident's
+//           ECONNRESET-storm reconnect (no reboot, same connection objects recover)
+const PARTITION = (args.find((a) => a.startsWith('--partition=')) ?? '--partition=stop').slice(12);
+
+// ─── tiny utils ───────────────────────────────────────────────────────────────
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+const ts = () => new Date().toISOString().slice(11, 23);
+function say(...m) {
+	console.log(`[${ts()}]`, ...m);
+}
+function head(title) {
+	console.log(`\n${'═'.repeat(78)}\n[${ts()}] ${title}\n${'═'.repeat(78)}`);
+}
+let failures = 0;
+function check(desc, ok, actual) {
+	const mark = ok ? 'PASS' : 'FAIL';
+	if (!ok) failures++;
+	say(`${mark}  ${desc}${actual !== undefined ? ` — actual: ${actual}` : ''}`);
+	return ok;
+}
+
+async function getFreePorts(count) {
+	const servers = await Promise.all(
+		Array.from({ length: count }, () =>
+			new Promise((resolve, reject) => {
+				const srv = createServer();
+				srv.once('error', reject);
+				srv.listen(0, '127.0.0.1', () => resolve(srv));
+			})
+		)
+	);
+	const ports = servers.map((s) => s.address().port);
+	await Promise.all(servers.map((s) => new Promise((r) => s.close(() => r()))));
+	return ports;
+}
+
+import { connect } from 'node:net';
+function waitForTcp(port, timeoutMs = 60_000) {
+	return waitFor(
+		`tcp port ${port} listening`,
+		() =>
+			new Promise((resolve) => {
+				const sock = connect({ port, host: '127.0.0.1' });
+				sock.once('connect', () => {
+					sock.destroy();
+					resolve(true);
+				});
+				sock.once('error', () => resolve(false));
+			}),
+		timeoutMs
+	);
+}
+
+async function waitFor(desc, fn, timeoutMs = 60_000, intervalMs = 1000) {
+	const deadline = Date.now() + timeoutMs;
+	let lastErr;
+	while (Date.now() < deadline) {
+		try {
+			const v = await fn();
+			if (v) return v;
+		} catch (e) {
+			lastErr = e;
+		}
+		await sleep(intervalMs);
+	}
+	throw new Error(`Timed out waiting for: ${desc}${lastErr ? ` (last error: ${lastErr.message})` : ''}`);
+}
+
+// ─── harper-pro location ──────────────────────────────────────────────────────
+async function resolveHarperPro() {
+	let baseDir = process.env.HARPER_PRO_DIR;
+	if (!baseDir) {
+		baseDir = await mkdtemp(join(tmpdir(), 'hdb-1244-pkg-'));
+		say(`Installing @harperfast/harper-pro@${HARPER_PRO_VERSION} into ${baseDir} (one-time, ~500MB)`);
+		execFileSync('npm', ['install', `@harperfast/harper-pro@${HARPER_PRO_VERSION}`, '--no-fund', '--no-audit'], {
+			cwd: baseDir,
+			env: { ...process.env, HOME: baseDir, npm_config_cache: join(baseDir, '.npm') },
+			stdio: 'inherit',
+		});
+	}
+	const proDir = join(baseDir, 'node_modules', '@harperfast', 'harper-pro');
+	const binPath = join(proDir, 'dist', 'bin', 'harper.js');
+	if (!existsSync(binPath)) throw new Error(`harper-pro bin not found at ${binPath}`);
+	const version = createRequire(join(proDir, 'package.json'))('./package.json').version;
+	const YAML = createRequire(join(proDir, 'package.json'))('yaml');
+	say(`Using @harperfast/harper-pro ${version} at ${proDir}`);
+	return { binPath, YAML, version };
+}
+
+// ─── node lifecycle ───────────────────────────────────────────────────────────
+const LIVE = new Set(); // ChildProcess handles we spawned — the ONLY things we ever kill
+process.on('exit', () => {
+	for (const proc of LIVE) {
+		try {
+			proc.kill('SIGKILL');
+		} catch {}
+	}
+});
+for (const sig of ['SIGINT', 'SIGTERM']) {
+	process.on(sig, () => process.exit(130));
+}
+
+async function makeNode(name, harper) {
+	const dir = await mkdtemp(join(tmpdir(), `hdb-1244-${name}-`));
+	const [opsPort, httpPort, repPort, mqttPort, mqttsPort] = await getFreePorts(5);
+	const node = { name, dir, opsPort, httpPort, repPort, proc: null, harper };
+	node.opsUrl = `http://127.0.0.1:${opsPort}`;
+	node.wsUrl = `ws://127.0.0.1:${repPort}`;
+	const env = {
+		...process.env,
+		ROOTPATH: dir,
+		HOME: dir, // hard isolation: nothing outside this tree
+		HDB_ADMIN_USERNAME: ADMIN.username,
+		HDB_ADMIN_PASSWORD: ADMIN.password,
+		THREADS_COUNT: '1',
+		OPERATIONSAPI_NETWORK_PORT: String(opsPort),
+		HTTP_PORT: String(httpPort),
+	};
+	node.env = env;
+	say(`[${name}] install → ${dir} (ops:${opsPort} http:${httpPort} repl:${repPort})`);
+	execFileSync('node', [harper.binPath, 'install'], { cwd: dir, env, stdio: 'pipe' });
+	// Patch the generated config: identity, insecure local replication port, short audit
+	// retention, per-node mqtt ports (defaults collide across nodes), drop waf (its re2 native
+	// module has no darwin prebuild in the npm package; absent key = component never loads).
+	const cfgPath = join(dir, 'harper-config.yaml');
+	const cfg = harper.YAML.parse(await readFile(cfgPath, 'utf8'));
+	cfg.replication = { hostname: name, url: node.wsUrl, port: repPort, databases: '*' };
+	cfg.node = { ...(cfg.node ?? {}), hostname: name };
+	cfg.mqtt.network.port = mqttPort;
+	cfg.mqtt.network.securePort = mqttsPort;
+	cfg.logging.auditLog = true;
+	cfg.logging.auditRetention = RETENTION;
+	cfg.logging.level = 'info';
+	cfg.localStudio = { enabled: false };
+	delete cfg.waf;
+	await writeFile(cfgPath, harper.YAML.stringify(cfg));
+	return node;
+}
+
+async function startNode(node) {
+	const out = createWriteStream(join(node.dir, 'stdout.log'), { flags: 'a' });
+	const proc = spawn('node', [node.harper.binPath, 'run'], { cwd: node.dir, env: node.env });
+	proc.stdout.pipe(out);
+	proc.stderr.pipe(out);
+	node.proc = proc;
+	LIVE.add(proc);
+	proc.on('exit', () => LIVE.delete(proc));
+	await waitFor(
+		`${node.name} healthy on ${node.opsUrl}`,
+		async () => (await fetch(`${node.opsUrl}/health`, { signal: AbortSignal.timeout(2000) })).status === 200,
+		90_000
+	);
+	say(`[${node.name}] up (pid ${proc.pid})`);
+}
+
+async function stopNode(node) {
+	const proc = node.proc;
+	if (!proc || proc.exitCode !== null) return;
+	const exited = new Promise((r) => proc.once('exit', r));
+	try {
+		proc.kill('SIGCONT'); // a suspended node can't process SIGTERM
+	} catch {}
+	proc.kill('SIGTERM');
+	const t = setTimeout(() => {
+		try {
+			proc.kill('SIGKILL');
+		} catch {}
+	}, 10_000);
+	await exited;
+	clearTimeout(t);
+	node.proc = null;
+	say(`[${node.name}] stopped`);
+}
+
+function nodeLogs(node) {
+	let text = '';
+	for (const f of [join(node.dir, 'stdout.log'), join(node.dir, 'log', 'hdb.log')]) {
+		try {
+			text += readFileSync(f, 'utf8');
+		} catch {}
+	}
+	return text;
+}
+
+// ─── ops API ──────────────────────────────────────────────────────────────────
+async function ops(node, body) {
+	const res = await fetch(node.opsUrl, {
+		method: 'POST',
+		headers: {
+			'Content-Type': 'application/json',
+			Authorization: 'Basic ' + Buffer.from(`${ADMIN.username}:${ADMIN.password}`).toString('base64'),
+		},
+		body: JSON.stringify(body),
+		signal: AbortSignal.timeout(30_000),
+	});
+	const text = await res.text();
+	let json;
+	try {
+		json = JSON.parse(text);
+	} catch {
+		json = text;
+	}
+	if (!res.ok) {
+		const err = new Error(`${body.operation} on ${node.name} → HTTP ${res.status}: ${text.slice(0, 300)}`);
+		err.status = res.status;
+		throw err;
+	}
+	return json;
+}
+
+const recordCount = async (node) => (await ops(node, { operation: 'describe_table', database: 'repro', table: 'doc' })).record_count;
+
+async function idsPresent(node, ids) {
+	const rows = await ops(node, {
+		operation: 'search_by_id',
+		database: 'repro',
+		table: 'doc',
+		ids,
+		get_attributes: ['id'],
+	});
+	const found = new Set(rows.filter(Boolean).map((r) => r.id));
+	return { found: ids.filter((i) => found.has(i)), missing: ids.filter((i) => !found.has(i)) };
+}
+
+async function txnLog(node, from) {
+	return ops(node, { operation: 'read_transaction_log', database: 'repro', table: 'doc', from, limit: 1000 });
+}
+
+function deletesIn(logEntries, ids) {
+	const idSet = new Set(ids);
+	return logEntries.filter((e) => e.operation === 'delete' && (e.ids ?? []).some((i) => idSet.has(i)));
+}
+
+// ─── cluster assembly ─────────────────────────────────────────────────────────
+// `nodes` is caller-owned: nodes are pushed as soon as they exist so the caller's finally
+// block can stop/remove them even when cluster formation itself throws.
+async function formCluster(harper, nodes) {
+	const a = await makeNode('node-a', harper);
+	nodes.push(a);
+	const b = await makeNode('node-b', harper);
+	nodes.push(b);
+	await startNode(a);
+	await startNode(b);
+	// The replication WS server binds after the ops-API health endpoint answers — gate on the
+	// actual ports, then require a CLEAN add_node (its partial-success message embeds the error
+	// from the add_node_back call to the target; retry until both sides registered).
+	await waitForTcp(a.repPort);
+	await waitForTcp(b.repPort);
+	// add_node must run FROM EACH NODE, and authorization is passed as a PREFORMED
+	// 'Basic …' header string. Passing {username,password} loses: the initiator converts the
+	// object to a header string for its own hdb_nodes record, but the add_node_back it sends the
+	// target carries the RAW object, and the dialer sets headers.Authorization = that value
+	// verbatim (createWebSocket) — '[object Object]' — so the target's outbound legs close 1008
+	// ("no hdb_nodes entry for IP …": a plain-ws peer with no client cert is only identified by
+	// that header). A preformed string is stored verbatim on every record on both sides.
+	// node-b is still restarted afterwards so its dialer rebuilds from the final records (live
+	// connections cache the record they dialed with).
+	for (const [src, dst] of [
+		[a, b],
+		[b, a],
+	]) {
+		say(`add_node: registering ${dst.name} from ${src.name} (basic-auth bootstrap, plain ws for a local repro)`);
+		await waitFor(
+			`clean add_node ${src.name} → ${dst.name}`,
+			async () => {
+				const res = await ops(src, {
+					operation: 'add_node',
+					hostname: dst.name,
+					url: dst.wsUrl,
+					verify_tls: false,
+					retain_authorization: true,
+					authorization: 'Basic ' + Buffer.from(`${ADMIN.username}:${ADMIN.password}`).toString('base64'),
+				}).catch((e) => ({ message: `add_node error: ${e.message}` }));
+				say('add_node →', JSON.stringify(res).slice(0, 250));
+				return /error/i.test(JSON.stringify(res)) ? false : res;
+			},
+			60_000,
+			3000
+		);
+	}
+	say('restarting node-b so its replication dialer picks up the header-form auth record');
+	await stopNode(b);
+	await startNode(b);
+	await waitForTcp(b.repPort);
+	// BOTH outbound legs must authenticate before the cluster is usable — a half-connected pair
+	// (one side looping on 1008 rejects) still replicates everything written on the accepted side
+	// and looks healthy to a data-only probe.
+	const peerConnected = async (node, peerName) => {
+		const st = await ops(node, { operation: 'cluster_status' });
+		const peer = (st.connections ?? []).find((c) => c.name === peerName);
+		return Boolean(peer?.database_sockets?.some((s) => s.database === 'system' && s.connected === true));
+	};
+	await waitFor('node-a outbound leg to node-b connected (system)', () => peerConnected(a, b.name), 90_000, 2000);
+	await waitFor('node-b outbound leg to node-a connected (system)', () => peerConnected(b, a.name), 90_000, 2000);
+	say('both replication directions authenticated and connected');
+
+	say('creating audited table repro.doc on node-a');
+	await ops(a, { operation: 'create_database', database: 'repro' }).catch((e) => {
+		if (!/already exists/i.test(e.message)) throw e;
+	});
+	await ops(a, { operation: 'create_table', database: 'repro', table: 'doc', primary_key: 'id' });
+	await waitFor('schema replicated to node-b', () => ops(b, { operation: 'describe_table', database: 'repro', table: 'doc' }).then(() => true).catch(() => false), 60_000);
+
+	const records = Array.from({ length: N_BASE - 1 }, (_, i) => ({ id: `base-${String(i + 1).padStart(3, '0')}`, v: i + 1, wave: 'base' }));
+	records.push({ id: 'canary', v: 0, wave: 'canary' });
+	await ops(a, { operation: 'upsert', database: 'repro', table: 'doc', records });
+	await waitFor(`node-b has all ${N_BASE} base rows`, async () => (await recordCount(b)) === N_BASE, 60_000);
+	check(`replication live: both nodes hold ${N_BASE} rows`, (await recordCount(a)) === N_BASE && (await recordCount(b)) === N_BASE, `a=${await recordCount(a)} b=${await recordCount(b)}`);
+	return { a, b };
+}
+
+async function instrumentPositiveControl(a, b) {
+	head('STEP: instrument positive control — a NORMAL delete must appear in read_transaction_log');
+	const before = Date.now() - 60_000;
+	await ops(a, { operation: 'delete', database: 'repro', table: 'doc', ids: ['canary'] });
+	await waitFor('canary delete replicated to node-b', async () => (await recordCount(b)) === N_BASE - 1, 30_000);
+	const [la, lb] = [await txnLog(a, before), await txnLog(b, before)];
+	const da = deletesIn(la, ['canary']);
+	const db = deletesIn(lb, ['canary']);
+	check("node-a txn log shows the canary 'delete' entry", da.length === 1, JSON.stringify(da));
+	check("node-b txn log shows the canary 'delete' entry (receiver-side deletes ARE audited)", db.length === 1, JSON.stringify(db));
+}
+
+// ─── lanes ────────────────────────────────────────────────────────────────────
+async function runLane(lane, harper) {
+	head(`LANE ${lane.toUpperCase()} — retention ${RETENTION}, ${lane === 'basecopy' ? 'reconnect PAST retention (forced base copy expected)' : 'reconnect WITHIN retention (incremental catch-up expected)'}`);
+	const nodes = [];
+	try {
+		const { a, b } = await formCluster(harper, nodes);
+		await instrumentPositiveControl(a, b);
+
+		head(`STEP: partition — ${PARTITION === 'suspend' ? 'suspending (SIGSTOP)' : 'stopping'} node-b`);
+		const tPartition = Date.now();
+		const bLogMark = nodeLogs(b).length;
+		const aLogMark = nodeLogs(a).length;
+		if (PARTITION === 'suspend') {
+			process.kill(b.proc.pid, 'SIGSTOP');
+			say(`[node-b] suspended (pid ${b.proc.pid}) — process alive, silent on the wire`);
+		} else {
+			await stopNode(b);
+		}
+
+		const partIds = Array.from({ length: N_PARTITION }, (_, i) => `part-${String(i + 1).padStart(3, '0')}`);
+		if (lane === 'basecopy') {
+			// Write LATE in the aging window: the partition-era rows keep fresh audit entries at
+			// reconnect (mirrors the incident: lost rows' upsert payloads were still in the retained
+			// log) while node-b's replication cursor still ages past retention.
+			const preWriteWait = RETENTION_MS * 0.75;
+			say(`aging: waiting ${preWriteWait / 1000}s before writing partition-era rows`);
+			await sleep(preWriteWait);
+		}
+		say(`writing ${N_PARTITION} rows on node-a only (node-b is down): ${partIds[0]}..${partIds.at(-1)}`);
+		await ops(a, {
+			operation: 'upsert',
+			database: 'repro',
+			table: 'doc',
+			records: partIds.map((id) => ({ id, wave: 'partition-era', note: 'exists ONLY on node-a until reconnect' })),
+		});
+		const expectedTotal = N_BASE - 1 + N_PARTITION;
+		check(`node-a now holds ${expectedTotal} rows (only-copy of the ${N_PARTITION})`, (await recordCount(a)) === expectedTotal, await recordCount(a));
+
+		if (lane === 'basecopy') {
+			const target = tPartition + RETENTION_MS * 1.25;
+			say(`aging: waiting until partition age ${(target - tPartition) / 1000}s > retention ${RETENTION_MS / 1000}s`);
+			await sleep(Math.max(0, target - Date.now()));
+		} else {
+			say('control lane: reconnecting promptly (well within retention)');
+			await sleep(5_000);
+		}
+
+		head(`STEP: reconnect — ${PARTITION === 'suspend' ? 'resuming (SIGCONT)' : 'restarting'} node-b after ${((Date.now() - tPartition) / 1000).toFixed(0)}s of partition`);
+		if (PARTITION === 'suspend') {
+			process.kill(b.proc.pid, 'SIGCONT');
+			say(`[node-b] resumed (pid ${b.proc.pid})`);
+		} else {
+			await startNode(b);
+		}
+
+		// Convergence: counts stable on both nodes for 3 consecutive polls.
+		let stable = 0;
+		let last = '';
+		await waitFor(
+			'cluster convergence (counts stable x3)',
+			async () => {
+				const cur = `${await recordCount(a).catch(() => '?')}/${await recordCount(b).catch(() => '?')}`;
+				stable = cur === last && !cur.includes('?') ? stable + 1 : 0;
+				last = cur;
+				say(`counts a/b: ${cur}`);
+				return stable >= 3;
+			},
+			180_000,
+			4000
+		);
+
+		const FORCED = 'forcing a bounded base-copy resync';
+		// The direction that tests the hypothesis is node-b SENDING a base copy of `repro` TO
+		// node-a (the copy that does NOT mention node-a's receiver-only rows). The sender logs
+		// the force warn, so the gate is that exact line in node-b's log naming database repro
+		// and peer node-a. Per-database subscription re-requests trail the reconnect by tens of
+		// seconds — count stability alone closes the window too early (observed: the system-db
+		// force landed 16s after boot, repro later still).
+		const bRepro = /Peer node-a requested replication of database repro[\s\S]*?forcing a bounded base-copy resync/;
+		if (lane === 'basecopy') {
+			await waitFor(
+				'node-b forces a base copy of repro TOWARD node-a (the hypothesis direction)',
+				() => bRepro.test(nodeLogs(b).slice(bLogMark)),
+				180_000,
+				3000
+			).catch((e) => say(`WARNING: ${e.message} — verdict below reports which directions actually forced`));
+			// Let that copy finish and any post-copy disposal run before asserting.
+			say('settle: 20s after the hypothesis-direction base copy');
+			await sleep(20_000);
+		}
+
+		head('ASSERTIONS');
+		const bNew = nodeLogs(b).slice(bLogMark);
+		const aNew = nodeLogs(a).slice(aLogMark);
+		const forcedOnB = bNew.includes(FORCED);
+		const forcedOnA = aNew.includes(FORCED);
+		for (const [nn, logText, forced] of [
+			['node-a', aNew, forcedOnA],
+			['node-b', bNew, forcedOnB],
+		]) {
+			const lines = logText.split('\n').filter((l) => l.includes(FORCED) || l.includes('Replicating all tables to'));
+			say(`[${nn}] base-copy log lines since partition:${lines.length ? '\n    ' + lines.join('\n    ') : ' (none)'}`);
+		}
+		let hypDirection = false;
+		if (lane === 'basecopy') {
+			const engaged = forcedOnA || forcedOnB;
+			hypDirection = bRepro.test(bNew);
+			check('forced base-copy path ENGAGED (incident signature present in logs)', engaged, `node-a:${forcedOnA} node-b:${forcedOnB}`);
+			check('hypothesis direction ran: node-b base-copied database repro TOWARD node-a', hypDirection);
+			if (!hypDirection) {
+				say('LANE UNPROVEN for the hypothesis direction: node-a never received a repro base copy lacking its receiver-only rows.');
+			}
+		} else {
+			check('control: NO forced base copy (incremental catch-up served the reconnect)', !forcedOnA && !forcedOnB, `node-a:${forcedOnA} node-b:${forcedOnB}`);
+		}
+
+		const [ca, cb] = [await recordCount(a), await recordCount(b)];
+		const pa = await idsPresent(a, partIds);
+		const pb = await idsPresent(b, partIds);
+		say(`record_count: node-a=${ca} node-b=${cb} (expected ${expectedTotal} if nothing is discarded)`);
+		say(`partition-era rows on node-a: ${pa.found.length}/${N_PARTITION} present${pa.missing.length ? `, MISSING: ${pa.missing.join(',')}` : ''}`);
+		say(`partition-era rows on node-b: ${pb.found.length}/${N_PARTITION} present${pb.missing.length ? `, MISSING: ${pb.missing.join(',')}` : ''}`);
+
+		const [la, lb] = [await txnLog(a, tPartition - 120_000), await txnLog(b, tPartition - 120_000)];
+		const delA = deletesIn(la, partIds);
+		const delB = deletesIn(lb, partIds);
+		say(`'delete' txn-log entries naming partition-era ids: node-a=${delA.length} node-b=${delB.length}`);
+		if (delA.length) say('node-a delete entries: ' + JSON.stringify(delA));
+		if (delB.length) say('node-b delete entries: ' + JSON.stringify(delB));
+		const reloadIsh = (l) => l.filter((e) => /reload/i.test(JSON.stringify(e)));
+		say(`txn-log entries mentioning 'reload': node-a=${reloadIsh(la).length} node-b=${reloadIsh(lb).length}`);
+		const reloadLog = (t) => t.split('\n').filter((l) => /reload/i.test(l)).slice(0, 5);
+		say(`hdb.log lines mentioning 'reload' since partition: node-a=${JSON.stringify(reloadLog(aNew))} node-b=${JSON.stringify(reloadLog(bNew))}`);
+
+		head(`VERDICT — lane ${lane}`);
+		const survivedBoth = pa.missing.length === 0 && pb.missing.length === 0 && ca === expectedTotal && cb === expectedTotal;
+		const vanished = pa.missing.length === N_PARTITION && pb.found.length === 0;
+		if (lane === 'basecopy' && hypDirection) {
+			if (vanished && delA.length === 0 && delB.length === 0) {
+				say('INCIDENT SIGNATURE REPRODUCED: receiver-only rows discarded by the forced base-copy resync, zero delete transactions.');
+			} else if (survivedBoth) {
+				say('NOT REPRODUCED under this trigger shape: node-a received a forced base copy of repro that did not mention its receiver-only rows, and those rows SURVIVED on both nodes (per-row copy-apply is additive; nothing was discarded).');
+			} else {
+				say('PARTIAL / UNEXPECTED outcome — inspect the numbers above.');
+			}
+		} else if (lane === 'basecopy') {
+			say('VERDICT WITHHELD: hypothesis-direction base copy did not run inside the observation window; treat this run as proof-failure, not disproof.');
+		} else if (lane === 'control') {
+			check('control: rows replicated to node-b and nothing was lost', survivedBoth, `a=${ca} b=${cb} missingA=${pa.missing.length} missingB=${pb.missing.length}`);
+		}
+		say(`node dirs (${KEEP ? 'kept' : 'removed on exit'}): ${a.dir} ${b.dir}`);
+	} finally {
+		for (const n of nodes) await stopNode(n).catch(() => {});
+		if (!KEEP) for (const n of nodes) await rm(n.dir, { recursive: true, force: true }).catch(() => {});
+	}
+}
+
+// ─── main ─────────────────────────────────────────────────────────────────────
+const harper = await resolveHarperPro();
+const lanes = laneArg === 'both' ? ['basecopy', 'control'] : [laneArg];
+for (const lane of lanes) {
+	if (!['basecopy', 'control'].includes(lane)) throw new Error(`unknown lane: ${lane}`);
+	await runLane(lane, harper);
+}
+head(`DONE — ${failures === 0 ? 'all checks passed' : failures + ' check(s) FAILED'}`);
+process.exit(failures === 0 ? 0 : 1);

--- a/test/repro/basecopy-retention-repro.mjs
+++ b/test/repro/basecopy-retention-repro.mjs
@@ -19,6 +19,41 @@
  *              as UNPROVEN (the path under test never engaged).
  *   control  — identical flow but reconnect WITHIN retention: incremental catch-up, no forced
  *              base copy expected; distinguishes the base-copy path from normal replication.
+ *   residency — the remaining code-anchored suspect after the base-copy disproof (see the
+ *              #1244 thread): core Table.ts evaluates TableResource.getResidency on every
+ *              write where options.residencyId is undefined (i.e. essentially every ordinary
+ *              local write); if the returned list excludes this node's hostname, the LOCAL
+ *              record is omitted while writeCommit still writes a NORMAL audited put — no
+ *              delete transaction. This lane installs a residency function on node-a via a
+ *              tiny component (standing in for the unconfirmed Fabric-side call — no config
+ *              surface installs one) that excludes node-a for ids prefixed 'hubonly-'. Rows
+ *              written BEFORE the install stand in for the incident's hub-only rows; an
+ *              ordinary re-save then triggers the _writeUpdate re-entry.
+ *
+ *              --residency=record (default) | byid — the two API variants destroy differently,
+ *              and the difference is decisive (RecordEncoder.ts recordUpdater: a
+ *              record===undefined call never touches the primary store):
+ *                record — setResidency(fn(record)): a non-resident write stores a PARTIAL
+ *                         record (indexed fields only; even the primary-key field is dropped
+ *                         from the value) + INVALIDATED. For an EXISTING row this OVERWRITES
+ *                         the full local value — real local destruction via an ordinary
+ *                         audited put. The read path then treats the row as remote: with the
+ *                         peer up, reads transparently remote-fetch; with the residency
+ *                         nodes lacking the row (the incident's hub-only shape), every read
+ *                         returns nothing. The #1244-signature candidate.
+ *                byid   — setResidencyById(fn(id)): non-resident recordToStore is undefined,
+ *                         so a NEW row is simply never stored locally, but an EXISTING row's
+ *                         value is left untouched (stale, still readable). This variant
+ *                         CANNOT destroy already-stored rows — a useful negative bound.
+ *
+ *              Thread note (matters for fidelity): the residency function is a per-thread
+ *              static; only writes handled by a worker that ran the component see it. The
+ *              lane drives the marked writes through a REST resource exported by the same
+ *              component, which guarantees the write runs where the function is installed —
+ *              the same shape as a component's own writes (flair's Memory writes are
+ *              component writes). Ops-API writes served by another thread do NOT engage it
+ *              (verified empirically); assertion probes defeat the read path's transparent
+ *              remote fetch by probing local state with the peer stopped.
  *
  * INSTRUMENT POSITIVE CONTROL
  * Before partitioning, one canary row is deleted normally and the script asserts the 'delete'
@@ -32,7 +67,8 @@
  * - Teardown kills ONLY child PIDs this script spawned (never pkill/pattern kill).
  *
  * USAGE
- *   node test/repro/basecopy-retention-repro.mjs [--lane=basecopy|control|both] [--keep]
+ *   node test/repro/basecopy-retention-repro.mjs [--lane=basecopy|control|residency|both] [--keep]
+ *   (--lane=both runs basecopy + control; residency is run explicitly, with --residency=record|byid)
  *
  *   HARPER_PRO_DIR      dir whose node_modules contains @harperfast/harper-pro (optional; if
  *                       unset the script npm-installs HARPER_PRO_VERSION into a temp sandbox)
@@ -47,7 +83,7 @@
 
 import { spawn, execFileSync } from 'node:child_process';
 import { createServer } from 'node:net';
-import { mkdtemp, rm, readFile, writeFile } from 'node:fs/promises';
+import { mkdtemp, rm, readFile, writeFile, mkdir } from 'node:fs/promises';
 import { createWriteStream, existsSync, readFileSync } from 'node:fs';
 import { createRequire } from 'node:module';
 import { tmpdir } from 'node:os';
@@ -69,6 +105,8 @@ const KEEP = args.includes('--keep');
 //           wedges and dies by ping timeout, and the resume looks like the incident's
 //           ECONNRESET-storm reconnect (no reboot, same connection objects recover)
 const PARTITION = (args.find((a) => a.startsWith('--partition=')) ?? '--partition=stop').slice(12);
+// record — setResidency(fn(record)); byid — setResidencyById(fn(id)). See the lane doc above.
+const RESIDENCY_VARIANT = (args.find((a) => a.startsWith('--residency=')) ?? '--residency=record').slice(12);
 
 // ─── tiny utils ───────────────────────────────────────────────────────────────
 const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
@@ -278,6 +316,39 @@ async function ops(node, body) {
 
 const recordCount = async (node) => (await ops(node, { operation: 'describe_table', database: 'repro', table: 'doc' })).record_count;
 
+// POST to a REST resource served on the component/HTTP port (NOT the ops port). REST requests
+// are handled by a worker that loaded the components, which is what makes this the right
+// vehicle for writes that must engage a component-installed residency function.
+async function rest(node, path, body) {
+	const res = await fetch(`http://127.0.0.1:${node.httpPort}${path}`, {
+		method: 'POST',
+		headers: {
+			'Content-Type': 'application/json',
+			Authorization: 'Basic ' + Buffer.from(`${ADMIN.username}:${ADMIN.password}`).toString('base64'),
+		},
+		body: JSON.stringify(body),
+		signal: AbortSignal.timeout(30_000),
+	});
+	const text = await res.text();
+	let json;
+	try {
+		json = JSON.parse(text);
+	} catch {
+		json = text;
+	}
+	if (!res.ok) throw new Error(`POST ${path} on ${node.name} → HTTP ${res.status}: ${text.slice(0, 300)}`);
+	return json;
+}
+
+// Both outbound legs must authenticate before the cluster is usable — a half-connected pair
+// (one side looping on 1008 rejects) still replicates everything written on the accepted side
+// and looks healthy to a data-only probe.
+async function peerConnected(node, peerName) {
+	const st = await ops(node, { operation: 'cluster_status' });
+	const peer = (st.connections ?? []).find((c) => c.name === peerName);
+	return Boolean(peer?.database_sockets?.some((s) => s.database === 'system' && s.connected === true));
+}
+
 async function idsPresent(node, ids) {
 	const rows = await ops(node, {
 		operation: 'search_by_id',
@@ -350,14 +421,6 @@ async function formCluster(harper, nodes) {
 	await stopNode(b);
 	await startNode(b);
 	await waitForTcp(b.repPort);
-	// BOTH outbound legs must authenticate before the cluster is usable — a half-connected pair
-	// (one side looping on 1008 rejects) still replicates everything written on the accepted side
-	// and looks healthy to a data-only probe.
-	const peerConnected = async (node, peerName) => {
-		const st = await ops(node, { operation: 'cluster_status' });
-		const peer = (st.connections ?? []).find((c) => c.name === peerName);
-		return Boolean(peer?.database_sockets?.some((s) => s.database === 'system' && s.connected === true));
-	};
 	await waitFor('node-a outbound leg to node-b connected (system)', () => peerConnected(a, b.name), 90_000, 2000);
 	await waitFor('node-b outbound leg to node-a connected (system)', () => peerConnected(b, a.name), 90_000, 2000);
 	say('both replication directions authenticated and connected');
@@ -546,12 +609,256 @@ async function runLane(lane, harper) {
 	}
 }
 
+// ─── residency lane ───────────────────────────────────────────────────────────
+// The residency-probe component installed on node-a only. It (1) installs the residency
+// function at table-registration time — the stand-in for the unconfirmed Fabric-side
+// setResidency call — and (2) exports a REST driver so the harness can issue writes that run
+// in the component-loaded worker (where the per-thread residency static is actually set).
+// Ids prefixed 'hubonly-' reside only on node-b: the list EXCLUDES this node (node-a).
+// Everything else returns undefined = default residency (replicate everywhere).
+function residencyComponent(variant) {
+	const install =
+		variant === 'byid'
+			? `table.setResidencyById((id) => {
+		const list = String(id).startsWith('hubonly-') ? ['node-b'] : undefined;
+		console.log('[' + probe + '] getResidencyById(' + JSON.stringify(id) + ') -> ' + JSON.stringify(list));
+		return list;
+	});`
+			: `table.setResidency((record, context) => {
+		const id = record ? record.id : undefined;
+		const list = String(id).startsWith('hubonly-') ? ['node-b'] : undefined;
+		console.log('[' + probe + '] getResidency(id=' + JSON.stringify(id) + ') -> ' + JSON.stringify(list));
+		return list;
+	});`;
+	return `// flair#1244 residency-omission probe (ephemeral repro component; see test/repro/)
+const probe = 'residency-probe';
+const table = databases && databases.repro && databases.repro.doc;
+try {
+	if (!table) {
+		console.error('[' + probe + '] repro.doc NOT FOUND at load - residency NOT installed');
+	} else {
+		${install}
+		console.log('[' + probe + '] residency function INSTALLED on repro.doc (variant: ${variant})');
+	}
+} catch (e) {
+	console.error('[' + probe + '] install error: ' + e.message);
+}
+
+export class ResidencyDriver extends Resource {
+	static path = '/residency-driver';
+	async post(data) {
+		const written = [];
+		for (const record of data.records ?? []) {
+			await table.put(record);
+			written.push(record.id);
+		}
+		return { ok: true, written, pid: process.pid };
+	}
+}
+`;
+}
+
+async function restartNode(node) {
+	await stopNode(node);
+	await startNode(node);
+	await waitForTcp(node.repPort);
+}
+
+// Classify what node-a's store actually holds for each id: 'full' (value intact),
+// 'partial' (a value came back but its primary-key field is gone — the residency partial
+// preserves only indexed fields, and the pk is not among them), 'absent' (no value at all).
+// Run with the peer STOPPED, otherwise the read path transparently remote-fetches.
+async function classifyRows(node, ids) {
+	const rows = await ops(node, { operation: 'search_by_id', database: 'repro', table: 'doc', ids, get_attributes: ['*'] });
+	const byId = new Map();
+	const unmatched = [];
+	for (const r of rows.filter(Boolean)) {
+		if (r.id != null) byId.set(r.id, r);
+		else unmatched.push(r);
+	}
+	// search_by_id returns rows positionally for dynamic tables only when found; a partial row
+	// (id stripped from the value) cannot be matched back by content, so count them in order.
+	const out = {};
+	for (const id of ids) {
+		if (byId.has(id)) out[id] = { outcome: 'full', row: byId.get(id) };
+		else if (unmatched.length) out[id] = { outcome: 'partial', row: unmatched.shift() };
+		else out[id] = { outcome: 'absent', row: null };
+	}
+	return out;
+}
+const outcomes = (cls) => Object.fromEntries(Object.entries(cls).map(([id, v]) => [id, v.outcome]));
+
+async function runResidencyLane(harper) {
+	const variant = RESIDENCY_VARIANT;
+	if (!['record', 'byid'].includes(variant)) throw new Error(`unknown --residency variant: ${variant}`);
+	head(`LANE RESIDENCY (variant: ${variant}) — residency-omission on ordinary writes (suspect 1 of the #1244 remaining-suspects derivation)`);
+	const nodes = [];
+	const PRE = ['hubonly-pre-001', 'hubonly-pre-002', 'hubonly-pre-003', 'hubonly-pre-004', 'hubonly-pre-005'];
+	const FRESH = ['hubonly-fresh-001', 'hubonly-fresh-002', 'hubonly-fresh-003'];
+	const PLAIN = ['plain-101', 'plain-102', 'plain-103', 'plain-104', 'plain-105'];
+	const PLAIN_DRIVER = 'plain-201'; // unmarked row written via the SAME driver path (positive control for the vehicle)
+	try {
+		const { a, b } = await formCluster(harper, nodes);
+		await instrumentPositiveControl(a, b);
+		const tLane = Date.now();
+
+		head('STEP: pre-phase — write hub-only stand-ins BEFORE any residency exists (they must be ordinarily stored)');
+		// resaved:false pre-declares the attribute: on a dynamic table the resource-path write
+		// does not add attributes, and an undeclared field would be silently dropped from the
+		// stored record (the audit payload keeps it either way).
+		await ops(a, {
+			operation: 'upsert',
+			database: 'repro',
+			table: 'doc',
+			records: [
+				...PRE.map((id) => ({ id, wave: 'pre-residency', v: 1, resaved: false })),
+				...PLAIN.map((id) => ({ id, wave: 'pre-residency', v: 1, resaved: false })),
+			],
+		});
+		const afterPre = N_BASE - 1 + PRE.length + PLAIN.length;
+		await waitFor(`node-b replicated the pre-phase rows (${afterPre})`, async () => (await recordCount(b)) === afterPre, 60_000);
+		check(`pre-phase: both nodes hold ${afterPre} rows`, (await recordCount(a)) === afterPre && (await recordCount(b)) === afterPre, `a=${await recordCount(a)} b=${await recordCount(b)}`);
+
+		head('STEP: install residency on node-a — deploy the probe component and restart (table-registration-time install)');
+		const compDir = join(a.dir, 'components', 'residency-probe');
+		await mkdir(compDir, { recursive: true });
+		await writeFile(join(compDir, 'resources.js'), residencyComponent(variant));
+		await restartNode(a);
+		await waitFor('replication re-established after node-a restart (a→b)', () => peerConnected(a, b.name), 90_000, 2000);
+		await waitFor('replication re-established after node-a restart (b→a)', () => peerConnected(b, a.name), 90_000, 2000);
+		const aLogMark = nodeLogs(a).length;
+		const installLines = nodeLogs(a)
+			.split('\n')
+			.filter((l) => l.includes('residency-probe'));
+		say(`[node-a] residency-probe log lines: ${JSON.stringify(installLines)}`);
+		const installed = installLines.some((l) => l.includes('INSTALLED'));
+		check('residency function INSTALLED on node-a (component log line present)', installed);
+
+		let p = await idsPresent(a, PRE);
+		check('registration alone destroys nothing: hubonly-pre rows still present on node-a after the residency install', p.missing.length === 0, `present=${p.found.length}/${PRE.length}${p.missing.length ? ` missing=${p.missing.join(',')}` : ''}`);
+
+		head('STEP: trigger — ordinary writes through the component worker (fresh writes + the self-resave _writeUpdate re-entry)');
+		const fresh = await rest(a, '/residency-driver', { records: FRESH.map((id) => ({ id, wave: 'post-residency', v: 1, resaved: false })) });
+		say(`driver fresh-write response: ${JSON.stringify(fresh)}`);
+		const resave = await rest(a, '/residency-driver', {
+			records: [
+				...PRE.map((id) => ({ id, wave: 'pre-residency', v: 2, resaved: true })),
+				{ id: PLAIN_DRIVER, wave: 'post-residency', v: 1, resaved: false },
+				{ id: 'plain-101', wave: 'pre-residency', v: 2, resaved: true },
+			],
+		});
+		say(`driver self-resave response: ${JSON.stringify(resave)}`);
+		check('driver wrote all marked + control records', fresh.written?.length === FRESH.length && resave.written?.length === PRE.length + 2, `fresh=${JSON.stringify(fresh.written)} resave=${JSON.stringify(resave.written)}`);
+		say('settle: 10s for replication of the audited writes to node-b (and for the worker stdout pipe to flush)');
+		await sleep(10_000);
+		const residencyCalls = nodeLogs(a)
+			.slice(aLogMark)
+			.split('\n')
+			.filter((l) => l.includes('getResidency'));
+		// Observation only: console output from inside the write-commit path does not reliably
+		// surface in the captured logs. That the function evaluated the marked ids — and returned
+		// the node-a-excluding list — is proven by the OUTCOME split instead: hubonly-* and
+		// plain-* rows written in the SAME driver call diverge (see the assertions below).
+		say(`[node-a] residency function invocation lines captured (informational): ${residencyCalls.length}`);
+
+		head('OBSERVATION (not a gate): reads with the peer UP — the residency read path may transparently remote-fetch');
+		let t0 = Date.now();
+		const obsA = await idsPresent(a, [...PRE, ...FRESH]);
+		say(`node-a search with node-b up: ${obsA.found.length}/${PRE.length + FRESH.length} resolve by id (${Date.now() - t0}ms) — resolving here does NOT prove local storage`);
+
+		head('ASSERT: node-b (the residency list member) received the ordinary audited writes in full');
+		const pbPre = await idsPresent(b, PRE);
+		const pbFresh = await idsPresent(b, FRESH);
+		const bResaved = await ops(b, { operation: 'search_by_id', database: 'repro', table: 'doc', ids: [PRE[0]], get_attributes: ['*'] });
+		check('node-b holds ALL hubonly rows (pre + fresh) — they replicated as ordinary writes', pbPre.missing.length === 0 && pbFresh.missing.length === 0, `pre=${pbPre.found.length}/${PRE.length} fresh=${pbFresh.found.length}/${FRESH.length}`);
+		check('node-b sees the resave content (resaved flag) — the re-entry write was an ordinary replicated put', bResaved[0]?.resaved === true, JSON.stringify(bResaved[0]));
+
+		head('STEP: stop node-b, then probe node-a LOCAL state (defeats the transparent remote fetch)');
+		await stopNode(b);
+		t0 = Date.now();
+		const clsPre = await classifyRows(a, PRE);
+		const clsFresh = await classifyRows(a, FRESH);
+		const clsPlain = await classifyRows(a, [...PLAIN, PLAIN_DRIVER]);
+		say(`local probes took ${Date.now() - t0}ms`);
+		say(`node-a local state, pre-residency hubonly rows: ${JSON.stringify(outcomes(clsPre))}`);
+		say(`  sample stored value for ${PRE[0]}: ${JSON.stringify(clsPre[PRE[0]].row)}`);
+		say(`node-a local state, post-install hubonly rows: ${JSON.stringify(outcomes(clsFresh))}`);
+		say(`node-a local state, unmarked rows: ${JSON.stringify(outcomes(clsPlain))}`);
+		const caFinal = await recordCount(a);
+		say(`node-a record_count=${caFinal} (a destroyed-but-stubbed row still counts; the incident's counts were index/vector-based)`);
+		const preDestroyed = PRE.filter((id) => clsPre[id].outcome !== 'full');
+		const freshNotStored = FRESH.filter((id) => clsFresh[id].outcome !== 'full');
+		const plainIntact = [...PLAIN, PLAIN_DRIVER].filter((id) => clsPlain[id].outcome === 'full');
+		if (variant === 'record') {
+			check('(a) INCIDENT SIGNATURE: the ordinary re-save DESTROYED the pre-existing local values on node-a (partial/absent, not full)', preDestroyed.length === PRE.length, JSON.stringify(outcomes(clsPre)));
+		} else {
+			check('(a/byid) the byid variant left pre-existing local values in place (recordUpdater never touches the store for record===undefined) — expected: NO destruction', preDestroyed.length === 0, JSON.stringify(outcomes(clsPre)));
+			const stale = clsPre[PRE[0]].row;
+			check('(a2/byid) ...and the surviving local value is the STALE pre-resave one (v=1, resaved=false) — the resave was audit-only locally', stale?.v === 1 && stale?.resaved === false, JSON.stringify(stale));
+		}
+		check(`(a3) hubonly rows first written AFTER the install were never fully stored on node-a (${variant === 'record' ? 'partial stub only' : 'no store write at all'})`, freshNotStored.length === FRESH.length, JSON.stringify(outcomes(clsFresh)));
+		const plainResavedRow = clsPlain['plain-101'].row;
+		check('(c) unmarked rows untouched on node-a (incl. the driver-written one and the resaved control, which carries its update)', plainIntact.length === PLAIN.length + 1 && plainResavedRow?.resaved === true && plainResavedRow?.v === 2, `full=${plainIntact.length}/${PLAIN.length + 1} plain-101=${JSON.stringify(plainResavedRow)}`);
+
+		head('ASSERT: transaction log — ordinary puts, ZERO deletes (the instrument positive-control above proves deletes DO log)');
+		const la = await txnLog(a, tLane - 120_000);
+		const hubIds = [...PRE, ...FRESH];
+		const delEntries = deletesIn(la, hubIds);
+		const putEntries = la.filter((e) => e.operation !== 'delete' && (e.ids ?? []).some((i) => hubIds.includes(i)));
+		const resaveEntries = putEntries.filter((e) => (e.records ?? []).some((r) => r && r.resaved === true));
+		say(`txn-log entries naming hubonly ids: non-delete=${putEntries.length} delete=${delEntries.length}; operations=${JSON.stringify([...new Set(putEntries.map((e) => e.operation))])}`);
+		if (delEntries.length) say(`delete entries: ${JSON.stringify(delEntries)}`);
+		check('(b) ZERO delete transactions name any hubonly id', delEntries.length === 0, String(delEntries.length));
+		check('(b2) the destruction-triggering re-save is an ORDINARY audited entry carrying the full record payload', resaveEntries.length >= 1 && resaveEntries.some((e) => (e.records ?? []).some((r) => r && r.id === PRE[0] && r.resaved === true)), JSON.stringify(resaveEntries.at(-1)?.records?.find((r) => r?.id === PRE[0]) ?? null));
+		const restorePayload = putEntries
+			.flatMap((e) => e.records ?? [])
+			.filter((r) => r && r.id === PRE[0])
+			.at(-1);
+		say(`restore payload captured from the txn log: ${JSON.stringify(restorePayload)}`);
+
+		head('STEP: restore — remove the residency component, restart node-a, re-upsert the audit payload (node-b still down: reads are provably local)');
+		await rm(compDir, { recursive: true, force: true });
+		await restartNode(a);
+		await ops(a, { operation: 'upsert', database: 'repro', table: 'doc', records: [restorePayload] });
+		const restored = await ops(a, { operation: 'search_by_id', database: 'repro', table: 'doc', ids: [PRE[0]], get_attributes: ['*'] });
+		check('(d) restore from the transaction-log payload recovers the FULL row locally', restored[0]?.id === PRE[0] && restored[0]?.resaved === true && restored[0]?.v === 2, JSON.stringify(restored[0]));
+
+		head(`VERDICT — lane residency, variant ${variant}`);
+		const common =
+			installed &&
+			p.missing.length === 0 && // present after registration
+			freshNotStored.length === FRESH.length &&
+			delEntries.length === 0 &&
+			resaveEntries.length >= 1 &&
+			plainIntact.length === PLAIN.length + 1 &&
+			restored[0]?.id === PRE[0];
+		if (variant === 'record') {
+			if (common && preDestroyed.length === PRE.length) {
+				say('INCIDENT SIGNATURE REPRODUCED (record variant): with a setResidency function installed whose list excludes this node, an ORDINARY write (a self-resave) destroyed the pre-existing local values (partial/invalidated stub; reads return nothing once the residency peers cannot serve the row) with ZERO delete transactions; the destroying write is itself a normal audited put; unmarked rows are untouched; and the row is fully recoverable from its transaction-log payload. This demonstrates mechanism SUFFICIENCY for the #1244 observables. Whether anything installs such a residency function on the incident hub (the Fabric-side trigger question) remains open and is not answerable from this harness.');
+			} else {
+				say('NOT REPRODUCED (record variant): one or more signature components did not fire — see the failed checks above.');
+			}
+		} else {
+			if (common && preDestroyed.length === 0) {
+				say('BYID VARIANT BOUND CONFIRMED: setResidencyById omission cannot destroy an already-stored local row (the record===undefined write never touches the primary store — it only prevents NEW local storage and writes the audit entry). If the incident mechanism is residency omission, it must be the record-based setResidency variant (or the rows must have been first written AFTER the residency install).');
+			} else {
+				say('UNEXPECTED byid outcome — see the failed checks above.');
+			}
+		}
+		say(`node dirs (${KEEP ? 'kept' : 'removed on exit'}): ${a.dir} ${b.dir}`);
+	} finally {
+		for (const n of nodes) await stopNode(n).catch(() => {});
+		if (!KEEP) for (const n of nodes) await rm(n.dir, { recursive: true, force: true }).catch(() => {});
+	}
+}
+
 // ─── main ─────────────────────────────────────────────────────────────────────
 const harper = await resolveHarperPro();
 const lanes = laneArg === 'both' ? ['basecopy', 'control'] : [laneArg];
 for (const lane of lanes) {
-	if (!['basecopy', 'control'].includes(lane)) throw new Error(`unknown lane: ${lane}`);
-	await runLane(lane, harper);
+	if (!['basecopy', 'control', 'residency'].includes(lane)) throw new Error(`unknown lane: ${lane}`);
+	if (lane === 'residency') await runResidencyLane(harper);
+	else await runLane(lane, harper);
 }
 head(`DONE — ${failures === 0 ? 'all checks passed' : failures + ' check(s) FAILED'}`);
 process.exit(failures === 0 ? 0 : 1);

--- a/test/repro/transcripts/2026-08-18-basecopy-5.2.0.log
+++ b/test/repro/transcripts/2026-08-18-basecopy-5.2.0.log
@@ -1,0 +1,81 @@
+[18:00:46.890] Using @harperfast/harper-pro 5.2.0 at /private/tmp/claude-501/-Users-squeued-agents-flint/bc131193-b477-46bc-bbbb-400b2d96dfce/scratchpad/hp-sandbox-520/node_modules/@harperfast/harper-pro
+
+══════════════════════════════════════════════════════════════════════════════
+[18:00:46.891] LANE BASECOPY — retention 1m, reconnect PAST retention (forced base copy expected)
+══════════════════════════════════════════════════════════════════════════════
+[18:00:46.897] [node-a] install → /var/folders/59/t9shx29n79jf6n97k8lj98q40000gn/T/hdb-1244-node-a-2qFQVi (ops:52804 http:52805 repl:52806)
+[18:00:50.164] [node-b] install → /var/folders/59/t9shx29n79jf6n97k8lj98q40000gn/T/hdb-1244-node-b-QI3Q3f (ops:52810 http:52811 repl:52812)
+[18:00:54.497] [node-a] up (pid 72180)
+[18:00:55.505] [node-b] up (pid 72187)
+[18:00:56.506] add_node: registering node-b from node-a (basic-auth bootstrap, plain ws for a local repro)
+[18:00:56.527] add_node → {"message":"Successfully added 'ws://127.0.0.1:52812' to cluster"}
+[18:00:56.527] add_node: registering node-a from node-b (basic-auth bootstrap, plain ws for a local repro)
+[18:00:56.546] add_node → {"message":"Successfully added 'ws://127.0.0.1:52806' to cluster"}
+[18:00:56.546] restarting node-b so its replication dialer picks up the header-form auth record
+[18:00:56.646] [node-b] stopped
+[18:00:57.653] [node-b] up (pid 72192)
+[18:00:59.666] both replication directions authenticated and connected
+[18:00:59.666] creating audited table repro.doc on node-a
+[18:01:01.828] PASS  replication live: both nodes hold 25 rows — actual: a=25 b=25
+
+══════════════════════════════════════════════════════════════════════════════
+[18:01:01.828] STEP: instrument positive control — a NORMAL delete must appear in read_transaction_log
+══════════════════════════════════════════════════════════════════════════════
+[18:01:01.841] PASS  node-a txn log shows the canary 'delete' entry — actual: [{"operation":"delete","user_name":"admin","timestamp":1787076061830.654,"ids":["canary"],"records":[null]}]
+[18:01:01.841] PASS  node-b txn log shows the canary 'delete' entry (receiver-side deletes ARE audited) — actual: [{"operation":"delete","user_name":"admin","timestamp":1787076061830.654,"ids":["canary"],"records":[null]}]
+
+══════════════════════════════════════════════════════════════════════════════
+[18:01:01.841] STEP: partition — stopping node-b
+══════════════════════════════════════════════════════════════════════════════
+[18:01:01.948] [node-b] stopped
+[18:01:01.948] aging: waiting 45s before writing partition-era rows
+[18:01:46.950] writing 10 rows on node-a only (node-b is down): part-001..part-010
+[18:01:47.023] PASS  node-a now holds 34 rows (only-copy of the 10) — actual: 34
+[18:01:47.023] aging: waiting until partition age 75s > retention 60s
+
+══════════════════════════════════════════════════════════════════════════════
+[18:02:16.843] STEP: reconnect — restarting node-b after 75s of partition
+══════════════════════════════════════════════════════════════════════════════
+[18:02:17.850] [node-b] up (pid 72953)
+[18:02:17.857] counts a/b: 34/24
+[18:02:21.866] counts a/b: 34/34
+[18:02:25.875] counts a/b: 34/34
+[18:02:29.884] counts a/b: 34/34
+[18:02:33.893] counts a/b: 34/34
+[18:02:33.893] settle: 20s after the hypothesis-direction base copy
+
+══════════════════════════════════════════════════════════════════════════════
+[18:02:53.895] ASSERTIONS
+══════════════════════════════════════════════════════════════════════════════
+[18:02:53.896] [node-a] base-copy log lines since partition:
+    2026-08-18T18:02:17.938Z [http/1] [warn] [replication]: Peer node-b requested replication of database repro from 2026-08-18T18:01:01.830Z, which predates retained transaction-log history (oldest retained 2026-08-18T18:01:00.802Z, retention 60000ms); forcing a bounded base-copy resync.
+    2026-08-18T18:02:17.938Z [http/1] [info] [replication]: Replicating all tables to node-b
+    2026-08-18T18:02:17.938Z [http/1] [warn] [replication]: Peer node-b requested replication of database system from 2026-08-18T18:00:58.386Z, which predates retained transaction-log history (oldest retained 2026-08-18T18:00:49.387Z, retention 60000ms); forcing a bounded base-copy resync.
+    2026-08-18T18:02:17.938Z [http/1] [info] [replication]: Replicating all tables to node-b
+[18:02:53.896] [node-b] base-copy log lines since partition:
+    2026-08-18T18:00:58.241Z [http/1] [info] [replication]: Replicating all tables to node-a
+    2026-08-18T18:00:59.963Z [http/1] [info] [replication]: Replicating all tables to node-a
+    2026-08-18T18:02:33.466Z [http/1] [warn] [replication]: Peer node-a requested replication of database repro from 2026-08-18T18:00:59.963Z, which predates retained transaction-log history (oldest retained 2026-08-18T18:02:18.145Z, retention 60000ms); forcing a bounded base-copy resync.
+    2026-08-18T18:02:33.466Z [http/1] [info] [replication]: Replicating all tables to node-a
+    2026-08-18T18:02:33.467Z [http/1] [warn] [replication]: Peer node-a requested replication of database system from 2026-08-18T18:00:58.241Z, which predates retained transaction-log history (oldest retained 2026-08-18T18:02:17.169Z, retention 60000ms); forcing a bounded base-copy resync.
+    2026-08-18T18:02:33.467Z [http/1] [info] [replication]: Replicating all tables to node-a
+[18:02:53.896] PASS  forced base-copy path ENGAGED (incident signature present in logs) — actual: node-a:true node-b:true
+[18:02:53.896] PASS  hypothesis direction ran: node-b base-copied database repro TOWARD node-a
+[18:02:53.916] record_count: node-a=34 node-b=34 (expected 34 if nothing is discarded)
+[18:02:53.916] partition-era rows on node-a: 10/10 present
+[18:02:53.916] partition-era rows on node-b: 10/10 present
+[18:02:53.921] 'delete' txn-log entries naming partition-era ids: node-a=0 node-b=0
+[18:02:53.921] txn-log entries mentioning 'reload': node-a=1 node-b=1
+[18:02:53.921] hdb.log lines mentioning 'reload' since partition: node-a=[] node-b=[]
+
+══════════════════════════════════════════════════════════════════════════════
+[18:02:53.921] VERDICT — lane basecopy
+══════════════════════════════════════════════════════════════════════════════
+[18:02:53.921] NOT REPRODUCED under this trigger shape: node-a received a forced base copy of repro that did not mention its receiver-only rows, and those rows SURVIVED on both nodes (per-row copy-apply is additive; nothing was discarded).
+[18:02:53.921] node dirs (removed on exit): /var/folders/59/t9shx29n79jf6n97k8lj98q40000gn/T/hdb-1244-node-a-2qFQVi /var/folders/59/t9shx29n79jf6n97k8lj98q40000gn/T/hdb-1244-node-b-QI3Q3f
+[18:02:53.999] [node-a] stopped
+[18:02:54.061] [node-b] stopped
+
+══════════════════════════════════════════════════════════════════════════════
+[18:02:54.069] DONE — all checks passed
+══════════════════════════════════════════════════════════════════════════════

--- a/test/repro/transcripts/2026-08-18-basecopy-5.2.2.log
+++ b/test/repro/transcripts/2026-08-18-basecopy-5.2.2.log
@@ -1,0 +1,81 @@
+[17:57:17.720] Using @harperfast/harper-pro 5.2.2 at /private/tmp/claude-501/-Users-squeued-agents-flint/bc131193-b477-46bc-bbbb-400b2d96dfce/scratchpad/hp-sandbox/node_modules/@harperfast/harper-pro
+
+══════════════════════════════════════════════════════════════════════════════
+[17:57:17.722] LANE BASECOPY — retention 1m, reconnect PAST retention (forced base copy expected)
+══════════════════════════════════════════════════════════════════════════════
+[17:57:17.727] [node-a] install → /var/folders/59/t9shx29n79jf6n97k8lj98q40000gn/T/hdb-1244-node-a-4cYkzd (ops:52589 http:52590 repl:52591)
+[17:57:20.359] [node-b] install → /var/folders/59/t9shx29n79jf6n97k8lj98q40000gn/T/hdb-1244-node-b-txmHj9 (ops:52603 http:52604 repl:52605)
+[17:57:24.005] [node-a] up (pid 71225)
+[17:57:25.012] [node-b] up (pid 71229)
+[17:57:26.014] add_node: registering node-b from node-a (basic-auth bootstrap, plain ws for a local repro)
+[17:57:26.035] add_node → {"message":"Successfully added 'ws://127.0.0.1:52605' to cluster"}
+[17:57:26.035] add_node: registering node-a from node-b (basic-auth bootstrap, plain ws for a local repro)
+[17:57:26.055] add_node → {"message":"Successfully added 'ws://127.0.0.1:52591' to cluster"}
+[17:57:26.055] restarting node-b so its replication dialer picks up the header-form auth record
+[17:57:26.171] [node-b] stopped
+[17:57:27.178] [node-b] up (pid 71234)
+[17:57:29.188] both replication directions authenticated and connected
+[17:57:29.188] creating audited table repro.doc on node-a
+[17:57:31.350] PASS  replication live: both nodes hold 25 rows — actual: a=25 b=25
+
+══════════════════════════════════════════════════════════════════════════════
+[17:57:31.350] STEP: instrument positive control — a NORMAL delete must appear in read_transaction_log
+══════════════════════════════════════════════════════════════════════════════
+[17:57:31.366] PASS  node-a txn log shows the canary 'delete' entry — actual: [{"operation":"delete","user_name":"admin","timestamp":1787075851352.739,"ids":["canary"],"records":[null]}]
+[17:57:31.366] PASS  node-b txn log shows the canary 'delete' entry (receiver-side deletes ARE audited) — actual: [{"operation":"delete","user_name":"admin","timestamp":1787075851352.739,"ids":["canary"],"records":[null]}]
+
+══════════════════════════════════════════════════════════════════════════════
+[17:57:31.366] STEP: partition — stopping node-b
+══════════════════════════════════════════════════════════════════════════════
+[17:57:31.473] [node-b] stopped
+[17:57:31.474] aging: waiting 45s before writing partition-era rows
+[17:58:16.476] writing 10 rows on node-a only (node-b is down): part-001..part-010
+[17:58:16.545] PASS  node-a now holds 34 rows (only-copy of the 10) — actual: 34
+[17:58:16.545] aging: waiting until partition age 75s > retention 60s
+
+══════════════════════════════════════════════════════════════════════════════
+[17:58:46.368] STEP: reconnect — restarting node-b after 75s of partition
+══════════════════════════════════════════════════════════════════════════════
+[17:58:47.376] [node-b] up (pid 71571)
+[17:58:47.383] counts a/b: 34/24
+[17:58:51.393] counts a/b: 34/34
+[17:58:55.402] counts a/b: 34/34
+[17:58:59.411] counts a/b: 34/34
+[17:59:03.419] counts a/b: 34/34
+[17:59:03.419] settle: 20s after the hypothesis-direction base copy
+
+══════════════════════════════════════════════════════════════════════════════
+[17:59:23.421] ASSERTIONS
+══════════════════════════════════════════════════════════════════════════════
+[17:59:23.422] [node-a] base-copy log lines since partition:
+    2026-08-18T17:58:47.478Z [http/1] [warn] [replication]: Peer node-b requested replication of database repro from 2026-08-18T17:57:31.352Z, which predates retained transaction-log history (oldest retained 2026-08-18T17:57:30.326Z, retention 60000ms); forcing a bounded base-copy resync.
+    2026-08-18T17:58:47.478Z [http/1] [info] [replication]: Replicating all tables to node-b
+    2026-08-18T17:58:47.479Z [http/1] [warn] [replication]: Peer node-b requested replication of database system from 2026-08-18T17:57:27.889Z, which predates retained transaction-log history (oldest retained 2026-08-18T17:57:19.458Z, retention 60000ms); forcing a bounded base-copy resync.
+    2026-08-18T17:58:47.479Z [http/1] [info] [replication]: Replicating all tables to node-b
+[17:59:23.422] [node-b] base-copy log lines since partition:
+    2026-08-18T17:57:27.747Z [http/1] [info] [replication]: Replicating all tables to node-a
+    2026-08-18T17:57:29.486Z [http/1] [info] [replication]: Replicating all tables to node-a
+    2026-08-18T17:59:02.992Z [http/1] [warn] [replication]: Peer node-a requested replication of database repro from 2026-08-18T17:57:29.486Z, which predates retained transaction-log history (oldest retained 2026-08-18T17:58:47.704Z, retention 60000ms); forcing a bounded base-copy resync.
+    2026-08-18T17:59:02.992Z [http/1] [info] [replication]: Replicating all tables to node-a
+    2026-08-18T17:59:02.993Z [http/1] [warn] [replication]: Peer node-a requested replication of database system from 2026-08-18T17:57:27.747Z, which predates retained transaction-log history (oldest retained 2026-08-18T17:58:46.839Z, retention 60000ms); forcing a bounded base-copy resync.
+    2026-08-18T17:59:02.993Z [http/1] [info] [replication]: Replicating all tables to node-a
+[17:59:23.422] PASS  forced base-copy path ENGAGED (incident signature present in logs) — actual: node-a:true node-b:true
+[17:59:23.422] PASS  hypothesis direction ran: node-b base-copied database repro TOWARD node-a
+[17:59:23.436] record_count: node-a=34 node-b=34 (expected 34 if nothing is discarded)
+[17:59:23.436] partition-era rows on node-a: 10/10 present
+[17:59:23.436] partition-era rows on node-b: 10/10 present
+[17:59:23.442] 'delete' txn-log entries naming partition-era ids: node-a=0 node-b=0
+[17:59:23.442] txn-log entries mentioning 'reload': node-a=1 node-b=1
+[17:59:23.442] hdb.log lines mentioning 'reload' since partition: node-a=[] node-b=[]
+
+══════════════════════════════════════════════════════════════════════════════
+[17:59:23.442] VERDICT — lane basecopy
+══════════════════════════════════════════════════════════════════════════════
+[17:59:23.442] NOT REPRODUCED under this trigger shape: node-a received a forced base copy of repro that did not mention its receiver-only rows, and those rows SURVIVED on both nodes (per-row copy-apply is additive; nothing was discarded).
+[17:59:23.442] node dirs (kept): /var/folders/59/t9shx29n79jf6n97k8lj98q40000gn/T/hdb-1244-node-a-4cYkzd /var/folders/59/t9shx29n79jf6n97k8lj98q40000gn/T/hdb-1244-node-b-txmHj9
+[17:59:23.500] [node-a] stopped
+[17:59:23.562] [node-b] stopped
+
+══════════════════════════════════════════════════════════════════════════════
+[17:59:23.562] DONE — all checks passed
+══════════════════════════════════════════════════════════════════════════════

--- a/test/repro/transcripts/2026-08-18-basecopy-suspend-5.2.2.log
+++ b/test/repro/transcripts/2026-08-18-basecopy-suspend-5.2.2.log
@@ -1,0 +1,79 @@
+[18:03:24.806] Using @harperfast/harper-pro 5.2.2 at /private/tmp/claude-501/-Users-squeued-agents-flint/bc131193-b477-46bc-bbbb-400b2d96dfce/scratchpad/hp-sandbox/node_modules/@harperfast/harper-pro
+
+══════════════════════════════════════════════════════════════════════════════
+[18:03:24.808] LANE BASECOPY — retention 1m, reconnect PAST retention (forced base copy expected)
+══════════════════════════════════════════════════════════════════════════════
+[18:03:24.813] [node-a] install → /var/folders/59/t9shx29n79jf6n97k8lj98q40000gn/T/hdb-1244-node-a-QKNhcL (ops:52970 http:52971 repl:52972)
+[18:03:27.366] [node-b] install → /var/folders/59/t9shx29n79jf6n97k8lj98q40000gn/T/hdb-1244-node-b-2Iw3Rk (ops:52982 http:52983 repl:52984)
+[18:03:30.874] [node-a] up (pid 73343)
+[18:03:31.883] [node-b] up (pid 73352)
+[18:03:32.883] add_node: registering node-b from node-a (basic-auth bootstrap, plain ws for a local repro)
+[18:03:32.905] add_node → {"message":"Successfully added 'ws://127.0.0.1:52984' to cluster"}
+[18:03:32.905] add_node: registering node-a from node-b (basic-auth bootstrap, plain ws for a local repro)
+[18:03:32.925] add_node → {"message":"Successfully added 'ws://127.0.0.1:52972' to cluster"}
+[18:03:32.925] restarting node-b so its replication dialer picks up the header-form auth record
+[18:03:33.028] [node-b] stopped
+[18:03:34.035] [node-b] up (pid 73371)
+[18:03:36.045] both replication directions authenticated and connected
+[18:03:36.045] creating audited table repro.doc on node-a
+[18:03:38.212] PASS  replication live: both nodes hold 25 rows — actual: a=25 b=25
+
+══════════════════════════════════════════════════════════════════════════════
+[18:03:38.212] STEP: instrument positive control — a NORMAL delete must appear in read_transaction_log
+══════════════════════════════════════════════════════════════════════════════
+[18:03:38.224] PASS  node-a txn log shows the canary 'delete' entry — actual: [{"operation":"delete","user_name":"admin","timestamp":1787076218214.114,"ids":["canary"],"records":[null]}]
+[18:03:38.224] PASS  node-b txn log shows the canary 'delete' entry (receiver-side deletes ARE audited) — actual: [{"operation":"delete","user_name":"admin","timestamp":1787076218214.114,"ids":["canary"],"records":[null]}]
+
+══════════════════════════════════════════════════════════════════════════════
+[18:03:38.224] STEP: partition — suspending (SIGSTOP) node-b
+══════════════════════════════════════════════════════════════════════════════
+[18:03:38.224] [node-b] suspended (pid 73371) — process alive, silent on the wire
+[18:03:38.224] aging: waiting 45s before writing partition-era rows
+[18:04:23.226] writing 10 rows on node-a only (node-b is down): part-001..part-010
+[18:04:23.296] PASS  node-a now holds 34 rows (only-copy of the 10) — actual: 34
+[18:04:23.296] aging: waiting until partition age 75s > retention 60s
+
+══════════════════════════════════════════════════════════════════════════════
+[18:04:53.227] STEP: reconnect — resuming (SIGCONT) node-b after 75s of partition
+══════════════════════════════════════════════════════════════════════════════
+[18:04:53.227] [node-b] resumed (pid 73371)
+[18:04:53.240] counts a/b: 34/24
+[18:04:57.249] counts a/b: 34/34
+[18:05:01.258] counts a/b: 34/34
+[18:05:05.267] counts a/b: 34/34
+[18:05:09.274] counts a/b: 34/34
+[18:08:09.371] WARNING: Timed out waiting for: node-b forces a base copy of repro TOWARD node-a (the hypothesis direction) — verdict below reports which directions actually forced
+[18:08:09.371] settle: 20s after the hypothesis-direction base copy
+
+══════════════════════════════════════════════════════════════════════════════
+[18:08:29.373] ASSERTIONS
+══════════════════════════════════════════════════════════════════════════════
+[18:08:29.373] [node-a] base-copy log lines since partition:
+    2026-08-18T18:04:53.898Z [http/1] [warn] [replication]: Peer node-b requested replication of database system from 2026-08-18T18:03:34.767Z, which predates retained transaction-log history (oldest retained 2026-08-18T18:03:26.565Z, retention 60000ms); forcing a bounded base-copy resync.
+    2026-08-18T18:04:53.898Z [http/1] [info] [replication]: Replicating all tables to node-b
+    2026-08-18T18:04:53.898Z [http/1] [warn] [replication]: Peer node-b requested replication of database repro from 2026-08-18T18:03:38.214Z, which predates retained transaction-log history (oldest retained 2026-08-18T18:03:37.188Z, retention 60000ms); forcing a bounded base-copy resync.
+    2026-08-18T18:04:53.898Z [http/1] [info] [replication]: Replicating all tables to node-b
+[18:08:29.373] [node-b] base-copy log lines since partition:
+    2026-08-18T18:04:53.396Z [http/1] [warn] [replication]: Peer node-a requested replication of database system from 2026-08-18T18:03:34.621Z, which predates retained transaction-log history (oldest retained 2026-08-18T18:03:29.139Z, retention 60000ms); forcing a bounded base-copy resync.
+    2026-08-18T18:04:53.396Z [http/1] [info] [replication]: Replicating all tables to node-a
+[18:08:29.373] PASS  forced base-copy path ENGAGED (incident signature present in logs) — actual: node-a:true node-b:true
+[18:08:29.373] FAIL  hypothesis direction ran: node-b base-copied database repro TOWARD node-a
+[18:08:29.373] LANE UNPROVEN for the hypothesis direction: node-a never received a repro base copy lacking its receiver-only rows.
+[18:08:29.384] record_count: node-a=34 node-b=34 (expected 34 if nothing is discarded)
+[18:08:29.384] partition-era rows on node-a: 10/10 present
+[18:08:29.384] partition-era rows on node-b: 10/10 present
+[18:08:29.390] 'delete' txn-log entries naming partition-era ids: node-a=0 node-b=0
+[18:08:29.390] txn-log entries mentioning 'reload': node-a=0 node-b=1
+[18:08:29.390] hdb.log lines mentioning 'reload' since partition: node-a=[] node-b=[]
+
+══════════════════════════════════════════════════════════════════════════════
+[18:08:29.390] VERDICT — lane basecopy
+══════════════════════════════════════════════════════════════════════════════
+[18:08:29.390] VERDICT WITHHELD: hypothesis-direction base copy did not run inside the observation window; treat this run as proof-failure, not disproof.
+[18:08:29.390] node dirs (removed on exit): /var/folders/59/t9shx29n79jf6n97k8lj98q40000gn/T/hdb-1244-node-a-QKNhcL /var/folders/59/t9shx29n79jf6n97k8lj98q40000gn/T/hdb-1244-node-b-2Iw3Rk
+[18:08:29.500] [node-a] stopped
+[18:08:29.566] [node-b] stopped
+
+══════════════════════════════════════════════════════════════════════════════
+[18:08:29.573] DONE — 1 check(s) FAILED
+══════════════════════════════════════════════════════════════════════════════

--- a/test/repro/transcripts/2026-08-18-control-5.2.2.log
+++ b/test/repro/transcripts/2026-08-18-control-5.2.2.log
@@ -1,0 +1,70 @@
+[18:00:09.683] Using @harperfast/harper-pro 5.2.2 at /private/tmp/claude-501/-Users-squeued-agents-flint/bc131193-b477-46bc-bbbb-400b2d96dfce/scratchpad/hp-sandbox/node_modules/@harperfast/harper-pro
+
+══════════════════════════════════════════════════════════════════════════════
+[18:00:09.684] LANE CONTROL — retention 1m, reconnect WITHIN retention (incremental catch-up expected)
+══════════════════════════════════════════════════════════════════════════════
+[18:00:09.690] [node-a] install → /var/folders/59/t9shx29n79jf6n97k8lj98q40000gn/T/hdb-1244-node-a-dZIT8d (ops:52742 http:52743 repl:52744)
+[18:00:12.580] [node-b] install → /var/folders/59/t9shx29n79jf6n97k8lj98q40000gn/T/hdb-1244-node-b-kXkFwU (ops:52748 http:52749 repl:52750)
+[18:00:17.042] [node-a] up (pid 72057)
+[18:00:19.051] [node-b] up (pid 72062)
+[18:00:19.051] add_node: registering node-b from node-a (basic-auth bootstrap, plain ws for a local repro)
+[18:00:19.073] add_node → {"message":"Successfully added 'ws://127.0.0.1:52750' to cluster"}
+[18:00:19.073] add_node: registering node-a from node-b (basic-auth bootstrap, plain ws for a local repro)
+[18:00:19.093] add_node → {"message":"Successfully added 'ws://127.0.0.1:52744' to cluster"}
+[18:00:19.093] restarting node-b so its replication dialer picks up the header-form auth record
+[18:00:19.192] [node-b] stopped
+[18:00:20.199] [node-b] up (pid 72067)
+[18:00:22.210] both replication directions authenticated and connected
+[18:00:22.210] creating audited table repro.doc on node-a
+[18:00:24.382] PASS  replication live: both nodes hold 25 rows — actual: a=25 b=25
+
+══════════════════════════════════════════════════════════════════════════════
+[18:00:24.382] STEP: instrument positive control — a NORMAL delete must appear in read_transaction_log
+══════════════════════════════════════════════════════════════════════════════
+[18:00:24.394] PASS  node-a txn log shows the canary 'delete' entry — actual: [{"operation":"delete","user_name":"admin","timestamp":1787076024384.122,"ids":["canary"],"records":[null]}]
+[18:00:24.394] PASS  node-b txn log shows the canary 'delete' entry (receiver-side deletes ARE audited) — actual: [{"operation":"delete","user_name":"admin","timestamp":1787076024384.122,"ids":["canary"],"records":[null]}]
+
+══════════════════════════════════════════════════════════════════════════════
+[18:00:24.394] STEP: partition — stopping node-b
+══════════════════════════════════════════════════════════════════════════════
+[18:00:24.498] [node-b] stopped
+[18:00:24.499] writing 10 rows on node-a only (node-b is down): part-001..part-010
+[18:00:24.573] PASS  node-a now holds 34 rows (only-copy of the 10) — actual: 34
+[18:00:24.573] control lane: reconnecting promptly (well within retention)
+
+══════════════════════════════════════════════════════════════════════════════
+[18:00:29.576] STEP: reconnect — restarting node-b after 5s of partition
+══════════════════════════════════════════════════════════════════════════════
+[18:00:30.583] [node-b] up (pid 72082)
+[18:00:30.590] counts a/b: 34/24
+[18:00:34.599] counts a/b: 34/34
+[18:00:38.608] counts a/b: 34/34
+[18:00:42.618] counts a/b: 34/34
+[18:00:46.627] counts a/b: 34/34
+
+══════════════════════════════════════════════════════════════════════════════
+[18:00:46.627] ASSERTIONS
+══════════════════════════════════════════════════════════════════════════════
+[18:00:46.627] [node-a] base-copy log lines since partition: (none)
+[18:00:46.627] [node-b] base-copy log lines since partition:
+    2026-08-18T18:00:20.788Z [http/1] [info] [replication]: Replicating all tables to node-a
+    2026-08-18T18:00:22.516Z [http/1] [info] [replication]: Replicating all tables to node-a
+[18:00:46.627] PASS  control: NO forced base copy (incremental catch-up served the reconnect) — actual: node-a:false node-b:false
+[18:00:46.640] record_count: node-a=34 node-b=34 (expected 34 if nothing is discarded)
+[18:00:46.641] partition-era rows on node-a: 10/10 present
+[18:00:46.641] partition-era rows on node-b: 10/10 present
+[18:00:46.648] 'delete' txn-log entries naming partition-era ids: node-a=0 node-b=0
+[18:00:46.648] txn-log entries mentioning 'reload': node-a=0 node-b=0
+[18:00:46.648] hdb.log lines mentioning 'reload' since partition: node-a=[] node-b=[]
+
+══════════════════════════════════════════════════════════════════════════════
+[18:00:46.648] VERDICT — lane control
+══════════════════════════════════════════════════════════════════════════════
+[18:00:46.648] PASS  control: rows replicated to node-b and nothing was lost — actual: a=34 b=34 missingA=0 missingB=0
+[18:00:46.648] node dirs (removed on exit): /var/folders/59/t9shx29n79jf6n97k8lj98q40000gn/T/hdb-1244-node-a-dZIT8d /var/folders/59/t9shx29n79jf6n97k8lj98q40000gn/T/hdb-1244-node-b-kXkFwU
+[18:00:46.768] [node-a] stopped
+[18:00:46.841] [node-b] stopped
+
+══════════════════════════════════════════════════════════════════════════════
+[18:00:46.849] DONE — all checks passed
+══════════════════════════════════════════════════════════════════════════════

--- a/test/repro/transcripts/2026-08-20-basecopy-negcontrol-5.2.2.log
+++ b/test/repro/transcripts/2026-08-20-basecopy-negcontrol-5.2.2.log
@@ -1,0 +1,81 @@
+[03:52:59.781] Using @harperfast/harper-pro 5.2.2 at <HARPER_PRO_DIR>/node_modules/@harperfast/harper-pro
+
+══════════════════════════════════════════════════════════════════════════════
+[03:52:59.782] LANE BASECOPY — retention 1m, reconnect PAST retention (forced base copy expected)
+══════════════════════════════════════════════════════════════════════════════
+[03:52:59.788] [node-a] install → /var/folders/59/t9shx29n79jf6n97k8lj98q40000gn/T/hdb-1244-node-a-ov3UU2 (ops:59539 http:59540 repl:59541)
+[03:53:02.958] [node-b] install → /var/folders/59/t9shx29n79jf6n97k8lj98q40000gn/T/hdb-1244-node-b-WIywfi (ops:59546 http:59547 repl:59548)
+[03:53:07.777] [node-a] up (pid 14266)
+[03:53:09.786] [node-b] up (pid 14308)
+[03:53:09.786] add_node: registering node-b from node-a (basic-auth bootstrap, plain ws for a local repro)
+[03:53:09.810] add_node → {"message":"Successfully added 'ws://127.0.0.1:59548' to cluster"}
+[03:53:09.810] add_node: registering node-a from node-b (basic-auth bootstrap, plain ws for a local repro)
+[03:53:09.830] add_node → {"message":"Successfully added 'ws://127.0.0.1:59541' to cluster"}
+[03:53:09.830] restarting node-b so its replication dialer picks up the header-form auth record
+[03:53:09.956] [node-b] stopped
+[03:53:10.963] [node-b] up (pid 14349)
+[03:53:12.977] both replication directions authenticated and connected
+[03:53:12.977] creating audited table repro.doc on node-a
+[03:53:15.278] PASS  replication live: both nodes hold 25 rows — actual: a=25 b=25
+
+══════════════════════════════════════════════════════════════════════════════
+[03:53:15.278] STEP: instrument positive control — a NORMAL delete must appear in read_transaction_log
+══════════════════════════════════════════════════════════════════════════════
+[03:53:15.296] PASS  node-a txn log shows the canary 'delete' entry — actual: [{"operation":"delete","user_name":"admin","timestamp":1787284395281.9048,"ids":["canary"],"records":[null]}]
+[03:53:15.296] PASS  node-b txn log shows the canary 'delete' entry (receiver-side deletes ARE audited) — actual: [{"operation":"delete","user_name":"admin","timestamp":1787284395281.9048,"ids":["canary"],"records":[null]}]
+
+══════════════════════════════════════════════════════════════════════════════
+[03:53:15.296] STEP: partition — stopping node-b
+══════════════════════════════════════════════════════════════════════════════
+[03:53:15.482] [node-b] stopped
+[03:53:15.486] aging: waiting 45s before writing partition-era rows
+[03:54:00.487] writing 10 rows on node-a only (node-b is down): part-001..part-010
+[03:54:00.632] PASS  node-a now holds 34 rows (only-copy of the 10) — actual: 34
+[03:54:00.635] aging: waiting until partition age 75s > retention 60s
+
+══════════════════════════════════════════════════════════════════════════════
+[03:54:30.298] STEP: reconnect — restarting node-b after 75s of partition
+══════════════════════════════════════════════════════════════════════════════
+[03:54:31.306] [node-b] up (pid 15426)
+[03:54:31.314] counts a/b: 34/24
+[03:54:35.331] counts a/b: 34/34
+[03:54:39.339] counts a/b: 34/34
+[03:54:43.348] counts a/b: 34/34
+[03:54:47.360] counts a/b: 34/34
+[03:54:47.362] settle: 20s after the hypothesis-direction base copy
+
+══════════════════════════════════════════════════════════════════════════════
+[03:55:07.364] ASSERTIONS
+══════════════════════════════════════════════════════════════════════════════
+[03:55:07.369] [node-a] base-copy log lines since partition:
+    2026-08-21T03:54:31.435Z [http/1] [warn] [replication]: Peer node-b requested replication of database repro from 2026-08-21T03:53:15.281Z, which predates retained transaction-log history (oldest retained 2026-08-21T03:53:14.241Z, retention 60000ms); forcing a bounded base-copy resync.
+    2026-08-21T03:54:31.435Z [http/1] [info] [replication]: Replicating all tables to node-b
+    2026-08-21T03:54:31.435Z [http/1] [warn] [replication]: Peer node-b requested replication of database system from 2026-08-21T03:53:11.699Z, which predates retained transaction-log history (oldest retained 2026-08-21T03:53:01.975Z, retention 60000ms); forcing a bounded base-copy resync.
+    2026-08-21T03:54:31.435Z [http/1] [info] [replication]: Replicating all tables to node-b
+[03:55:07.370] [node-b] base-copy log lines since partition:
+    2026-08-21T03:53:11.524Z [http/1] [info] [replication]: Replicating all tables to node-a
+    2026-08-21T03:53:13.382Z [http/1] [info] [replication]: Replicating all tables to node-a
+    2026-08-21T03:54:47.000Z [http/1] [warn] [replication]: Peer node-a requested replication of database repro from 2026-08-21T03:53:13.382Z, which predates retained transaction-log history (oldest retained 2026-08-21T03:54:31.753Z, retention 60000ms); forcing a bounded base-copy resync.
+    2026-08-21T03:54:47.000Z [http/1] [info] [replication]: Replicating all tables to node-a
+    2026-08-21T03:54:47.001Z [http/1] [warn] [replication]: Peer node-a requested replication of database system from 2026-08-21T03:53:11.524Z, which predates retained transaction-log history (oldest retained 2026-08-21T03:54:30.816Z, retention 60000ms); forcing a bounded base-copy resync.
+    2026-08-21T03:54:47.001Z [http/1] [info] [replication]: Replicating all tables to node-a
+[03:55:07.370] PASS  forced base-copy path ENGAGED (incident signature present in logs) — actual: node-a:true node-b:true
+[03:55:07.370] PASS  hypothesis direction ran: node-b base-copied database repro TOWARD node-a
+[03:55:07.403] record_count: node-a=34 node-b=34 (expected 34 if nothing is discarded)
+[03:55:07.404] partition-era rows on node-a: 10/10 present
+[03:55:07.404] partition-era rows on node-b: 10/10 present
+[03:55:07.415] 'delete' txn-log entries naming partition-era ids: node-a=0 node-b=0
+[03:55:07.415] txn-log entries mentioning 'reload': node-a=1 node-b=1
+[03:55:07.416] hdb.log lines mentioning 'reload' since partition: node-a=[] node-b=[]
+
+══════════════════════════════════════════════════════════════════════════════
+[03:55:07.416] VERDICT — lane basecopy
+══════════════════════════════════════════════════════════════════════════════
+[03:55:07.416] NOT REPRODUCED under this trigger shape: node-a received a forced base copy of repro that did not mention its receiver-only rows, and those rows SURVIVED on both nodes (per-row copy-apply is additive; nothing was discarded).
+[03:55:07.416] node dirs (removed on exit): /var/folders/59/t9shx29n79jf6n97k8lj98q40000gn/T/hdb-1244-node-a-ov3UU2 /var/folders/59/t9shx29n79jf6n97k8lj98q40000gn/T/hdb-1244-node-b-WIywfi
+[03:55:07.544] [node-a] stopped
+[03:55:07.645] [node-b] stopped
+
+══════════════════════════════════════════════════════════════════════════════
+[03:55:07.653] DONE — all checks passed
+══════════════════════════════════════════════════════════════════════════════

--- a/test/repro/transcripts/2026-08-20-residency-byid-5.2.2.log
+++ b/test/repro/transcripts/2026-08-20-residency-byid-5.2.2.log
@@ -1,0 +1,100 @@
+[03:52:23.654] Using @harperfast/harper-pro 5.2.2 at <HARPER_PRO_DIR>/node_modules/@harperfast/harper-pro
+
+══════════════════════════════════════════════════════════════════════════════
+[03:52:23.655] LANE RESIDENCY (variant: byid) — residency-omission on ordinary writes (suspect 1 of the #1244 remaining-suspects derivation)
+══════════════════════════════════════════════════════════════════════════════
+[03:52:23.661] [node-a] install → /var/folders/59/t9shx29n79jf6n97k8lj98q40000gn/T/hdb-1244-node-a-8FPWdH (ops:59456 http:59457 repl:59458)
+[03:52:26.546] [node-b] install → /var/folders/59/t9shx29n79jf6n97k8lj98q40000gn/T/hdb-1244-node-b-Tc2Phi (ops:59463 http:59464 repl:59465)
+[03:52:30.527] [node-a] up (pid 13961)
+[03:52:32.548] [node-b] up (pid 13964)
+[03:52:32.550] add_node: registering node-b from node-a (basic-auth bootstrap, plain ws for a local repro)
+[03:52:32.592] add_node → {"message":"Successfully added 'ws://127.0.0.1:59465' to cluster"}
+[03:52:32.592] add_node: registering node-a from node-b (basic-auth bootstrap, plain ws for a local repro)
+[03:52:32.615] add_node → {"message":"Successfully added 'ws://127.0.0.1:59458' to cluster"}
+[03:52:32.615] restarting node-b so its replication dialer picks up the header-form auth record
+[03:52:32.731] [node-b] stopped
+[03:52:33.745] [node-b] up (pid 13970)
+[03:52:35.779] both replication directions authenticated and connected
+[03:52:35.779] creating audited table repro.doc on node-a
+[03:52:38.054] PASS  replication live: both nodes hold 25 rows — actual: a=25 b=25
+
+══════════════════════════════════════════════════════════════════════════════
+[03:52:38.054] STEP: instrument positive control — a NORMAL delete must appear in read_transaction_log
+══════════════════════════════════════════════════════════════════════════════
+[03:52:38.080] PASS  node-a txn log shows the canary 'delete' entry — actual: [{"operation":"delete","user_name":"admin","timestamp":1787284358058.2988,"ids":["canary"],"records":[null]}]
+[03:52:38.081] PASS  node-b txn log shows the canary 'delete' entry (receiver-side deletes ARE audited) — actual: [{"operation":"delete","user_name":"admin","timestamp":1787284358058.2988,"ids":["canary"],"records":[null]}]
+
+══════════════════════════════════════════════════════════════════════════════
+[03:52:38.081] STEP: pre-phase — write hub-only stand-ins BEFORE any residency exists (they must be ordinarily stored)
+══════════════════════════════════════════════════════════════════════════════
+[03:52:39.206] PASS  pre-phase: both nodes hold 34 rows — actual: a=34 b=34
+
+══════════════════════════════════════════════════════════════════════════════
+[03:52:39.206] STEP: install residency on node-a — deploy the probe component and restart (table-registration-time install)
+══════════════════════════════════════════════════════════════════════════════
+[03:52:39.374] [node-a] stopped
+[03:52:40.387] [node-a] up (pid 14009)
+[03:52:42.410] [node-a] residency-probe log lines: ["[residency-probe] residency function INSTALLED on repro.doc (variant: byid)"]
+[03:52:42.410] PASS  residency function INSTALLED on node-a (component log line present)
+[03:52:42.419] PASS  registration alone destroys nothing: hubonly-pre rows still present on node-a after the residency install — actual: present=5/5
+
+══════════════════════════════════════════════════════════════════════════════
+[03:52:42.422] STEP: trigger — ordinary writes through the component worker (fresh writes + the self-resave _writeUpdate re-entry)
+══════════════════════════════════════════════════════════════════════════════
+[03:52:42.437] driver fresh-write response: {"ok":true,"written":["hubonly-fresh-001","hubonly-fresh-002","hubonly-fresh-003"],"pid":14009}
+[03:52:42.445] driver self-resave response: {"ok":true,"written":["hubonly-pre-001","hubonly-pre-002","hubonly-pre-003","hubonly-pre-004","hubonly-pre-005","plain-201","plain-101"],"pid":14009}
+[03:52:42.447] PASS  driver wrote all marked + control records — actual: fresh=["hubonly-fresh-001","hubonly-fresh-002","hubonly-fresh-003"] resave=["hubonly-pre-001","hubonly-pre-002","hubonly-pre-003","hubonly-pre-004","hubonly-pre-005","plain-201","plain-101"]
+[03:52:42.447] settle: 10s for replication of the audited writes to node-b (and for the worker stdout pipe to flush)
+[03:52:52.447] [node-a] residency function invocation lines captured (informational): 0
+
+══════════════════════════════════════════════════════════════════════════════
+[03:52:52.447] OBSERVATION (not a gate): reads with the peer UP — the residency read path may transparently remote-fetch
+══════════════════════════════════════════════════════════════════════════════
+[03:52:52.450] node-a search with node-b up: 5/8 resolve by id (3ms) — resolving here does NOT prove local storage
+
+══════════════════════════════════════════════════════════════════════════════
+[03:52:52.451] ASSERT: node-b (the residency list member) received the ordinary audited writes in full
+══════════════════════════════════════════════════════════════════════════════
+[03:52:52.457] PASS  node-b holds ALL hubonly rows (pre + fresh) — they replicated as ordinary writes — actual: pre=5/5 fresh=3/3
+[03:52:52.457] PASS  node-b sees the resave content (resaved flag) — the re-entry write was an ordinary replicated put — actual: {"id":"hubonly-pre-001","__createdtime__":1787284358163.6182,"__updatedtime__":1787284362439.505,"v":2,"wave":"pre-residency","resaved":true}
+
+══════════════════════════════════════════════════════════════════════════════
+[03:52:52.457] STEP: stop node-b, then probe node-a LOCAL state (defeats the transparent remote fetch)
+══════════════════════════════════════════════════════════════════════════════
+[03:52:52.606] [node-b] stopped
+[03:52:52.613] local probes took 7ms
+[03:52:52.613] node-a local state, pre-residency hubonly rows: {"hubonly-pre-001":"full","hubonly-pre-002":"full","hubonly-pre-003":"full","hubonly-pre-004":"full","hubonly-pre-005":"full"}
+[03:52:52.613]   sample stored value for hubonly-pre-001: {"id":"hubonly-pre-001","__createdtime__":1787284358163.6182,"__updatedtime__":1787284358163.6182,"resaved":false,"v":1,"wave":"pre-residency"}
+[03:52:52.613] node-a local state, post-install hubonly rows: {"hubonly-fresh-001":"absent","hubonly-fresh-002":"absent","hubonly-fresh-003":"absent"}
+[03:52:52.613] node-a local state, unmarked rows: {"plain-101":"full","plain-102":"full","plain-103":"full","plain-104":"full","plain-105":"full","plain-201":"full"}
+[03:52:52.618] node-a record_count=35 (a destroyed-but-stubbed row still counts; the incident's counts were index/vector-based)
+[03:52:52.618] PASS  (a/byid) the byid variant left pre-existing local values in place (recordUpdater never touches the store for record===undefined) — expected: NO destruction — actual: {"hubonly-pre-001":"full","hubonly-pre-002":"full","hubonly-pre-003":"full","hubonly-pre-004":"full","hubonly-pre-005":"full"}
+[03:52:52.618] PASS  (a2/byid) ...and the surviving local value is the STALE pre-resave one (v=1, resaved=false) — the resave was audit-only locally — actual: {"id":"hubonly-pre-001","__createdtime__":1787284358163.6182,"__updatedtime__":1787284358163.6182,"resaved":false,"v":1,"wave":"pre-residency"}
+[03:52:52.619] PASS  (a3) hubonly rows first written AFTER the install were never fully stored on node-a (no store write at all) — actual: {"hubonly-fresh-001":"absent","hubonly-fresh-002":"absent","hubonly-fresh-003":"absent"}
+[03:52:52.619] PASS  (c) unmarked rows untouched on node-a (incl. the driver-written one and the resaved control, which carries its update) — actual: full=6/6 plain-101={"id":"plain-101","__createdtime__":1787284358163.6182,"__updatedtime__":1787284362439.505,"resaved":true,"v":2,"wave":"pre-residency"}
+
+══════════════════════════════════════════════════════════════════════════════
+[03:52:52.619] ASSERT: transaction log — ordinary puts, ZERO deletes (the instrument positive-control above proves deletes DO log)
+══════════════════════════════════════════════════════════════════════════════
+[03:52:52.625] txn-log entries naming hubonly ids: non-delete=3 delete=0; operations=["upsert"]
+[03:52:52.625] PASS  (b) ZERO delete transactions name any hubonly id — actual: 0
+[03:52:52.625] PASS  (b2) the destruction-triggering re-save is an ORDINARY audited entry carrying the full record payload — actual: {"id":"hubonly-pre-001","wave":"pre-residency","v":2,"resaved":true,"__updatedtime__":1787284362439.505,"__createdtime__":1787284358163.6182}
+[03:52:52.625] restore payload captured from the txn log: {"id":"hubonly-pre-001","wave":"pre-residency","v":2,"resaved":true,"__updatedtime__":1787284362439.505,"__createdtime__":1787284358163.6182}
+
+══════════════════════════════════════════════════════════════════════════════
+[03:52:52.625] STEP: restore — remove the residency component, restart node-a, re-upsert the audit payload (node-b still down: reads are provably local)
+══════════════════════════════════════════════════════════════════════════════
+[03:52:52.717] [node-a] stopped
+[03:52:53.724] [node-a] up (pid 14049)
+[03:52:53.731] PASS  (d) restore from the transaction-log payload recovers the FULL row locally — actual: {"id":"hubonly-pre-001","__createdtime__":1787284358163.6182,"__updatedtime__":1787284373727.98,"resaved":true,"v":2,"wave":"pre-residency"}
+
+══════════════════════════════════════════════════════════════════════════════
+[03:52:53.731] VERDICT — lane residency, variant byid
+══════════════════════════════════════════════════════════════════════════════
+[03:52:53.731] BYID VARIANT BOUND CONFIRMED: setResidencyById omission cannot destroy an already-stored local row (the record===undefined write never touches the primary store — it only prevents NEW local storage and writes the audit entry). If the incident mechanism is residency omission, it must be the record-based setResidency variant (or the rows must have been first written AFTER the residency install).
+[03:52:53.731] node dirs (removed on exit): /var/folders/59/t9shx29n79jf6n97k8lj98q40000gn/T/hdb-1244-node-a-8FPWdH /var/folders/59/t9shx29n79jf6n97k8lj98q40000gn/T/hdb-1244-node-b-Tc2Phi
+[03:52:53.824] [node-a] stopped
+
+══════════════════════════════════════════════════════════════════════════════
+[03:52:53.834] DONE — all checks passed
+══════════════════════════════════════════════════════════════════════════════

--- a/test/repro/transcripts/2026-08-20-residency-record-5.2.2.log
+++ b/test/repro/transcripts/2026-08-20-residency-record-5.2.2.log
@@ -1,0 +1,99 @@
+[03:51:46.305] Using @harperfast/harper-pro 5.2.2 at <HARPER_PRO_DIR>/node_modules/@harperfast/harper-pro
+
+══════════════════════════════════════════════════════════════════════════════
+[03:51:46.306] LANE RESIDENCY (variant: record) — residency-omission on ordinary writes (suspect 1 of the #1244 remaining-suspects derivation)
+══════════════════════════════════════════════════════════════════════════════
+[03:51:46.311] [node-a] install → /var/folders/59/t9shx29n79jf6n97k8lj98q40000gn/T/hdb-1244-node-a-MiqoXn (ops:59356 http:59357 repl:59358)
+[03:51:49.115] [node-b] install → /var/folders/59/t9shx29n79jf6n97k8lj98q40000gn/T/hdb-1244-node-b-mB9ibT (ops:59367 http:59368 repl:59369)
+[03:51:53.596] [node-a] up (pid 13656)
+[03:51:54.605] [node-b] up (pid 13662)
+[03:51:55.606] add_node: registering node-b from node-a (basic-auth bootstrap, plain ws for a local repro)
+[03:51:55.635] add_node → {"message":"Successfully added 'ws://127.0.0.1:59369' to cluster"}
+[03:51:55.635] add_node: registering node-a from node-b (basic-auth bootstrap, plain ws for a local repro)
+[03:51:55.662] add_node → {"message":"Successfully added 'ws://127.0.0.1:59358' to cluster"}
+[03:51:55.665] restarting node-b so its replication dialer picks up the header-form auth record
+[03:51:55.831] [node-b] stopped
+[03:51:56.839] [node-b] up (pid 13665)
+[03:51:58.862] both replication directions authenticated and connected
+[03:51:58.862] creating audited table repro.doc on node-a
+[03:52:01.157] PASS  replication live: both nodes hold 25 rows — actual: a=25 b=25
+
+══════════════════════════════════════════════════════════════════════════════
+[03:52:01.157] STEP: instrument positive control — a NORMAL delete must appear in read_transaction_log
+══════════════════════════════════════════════════════════════════════════════
+[03:52:01.190] PASS  node-a txn log shows the canary 'delete' entry — actual: [{"operation":"delete","user_name":"admin","timestamp":1787284321162.198,"ids":["canary"],"records":[null]}]
+[03:52:01.190] PASS  node-b txn log shows the canary 'delete' entry (receiver-side deletes ARE audited) — actual: [{"operation":"delete","user_name":"admin","timestamp":1787284321162.198,"ids":["canary"],"records":[null]}]
+
+══════════════════════════════════════════════════════════════════════════════
+[03:52:01.190] STEP: pre-phase — write hub-only stand-ins BEFORE any residency exists (they must be ordinarily stored)
+══════════════════════════════════════════════════════════════════════════════
+[03:52:02.322] PASS  pre-phase: both nodes hold 34 rows — actual: a=34 b=34
+
+══════════════════════════════════════════════════════════════════════════════
+[03:52:02.322] STEP: install residency on node-a — deploy the probe component and restart (table-registration-time install)
+══════════════════════════════════════════════════════════════════════════════
+[03:52:02.482] [node-a] stopped
+[03:52:03.494] [node-a] up (pid 13679)
+[03:52:05.514] [node-a] residency-probe log lines: ["[residency-probe] residency function INSTALLED on repro.doc (variant: record)"]
+[03:52:05.514] PASS  residency function INSTALLED on node-a (component log line present)
+[03:52:05.524] PASS  registration alone destroys nothing: hubonly-pre rows still present on node-a after the residency install — actual: present=5/5
+
+══════════════════════════════════════════════════════════════════════════════
+[03:52:05.527] STEP: trigger — ordinary writes through the component worker (fresh writes + the self-resave _writeUpdate re-entry)
+══════════════════════════════════════════════════════════════════════════════
+[03:52:05.546] driver fresh-write response: {"ok":true,"written":["hubonly-fresh-001","hubonly-fresh-002","hubonly-fresh-003"],"pid":13679}
+[03:52:05.554] driver self-resave response: {"ok":true,"written":["hubonly-pre-001","hubonly-pre-002","hubonly-pre-003","hubonly-pre-004","hubonly-pre-005","plain-201","plain-101"],"pid":13679}
+[03:52:05.556] PASS  driver wrote all marked + control records — actual: fresh=["hubonly-fresh-001","hubonly-fresh-002","hubonly-fresh-003"] resave=["hubonly-pre-001","hubonly-pre-002","hubonly-pre-003","hubonly-pre-004","hubonly-pre-005","plain-201","plain-101"]
+[03:52:05.556] settle: 10s for replication of the audited writes to node-b (and for the worker stdout pipe to flush)
+[03:52:15.560] [node-a] residency function invocation lines captured (informational): 0
+
+══════════════════════════════════════════════════════════════════════════════
+[03:52:15.560] OBSERVATION (not a gate): reads with the peer UP — the residency read path may transparently remote-fetch
+══════════════════════════════════════════════════════════════════════════════
+[03:52:15.570] node-a search with node-b up: 0/8 resolve by id (10ms) — resolving here does NOT prove local storage
+
+══════════════════════════════════════════════════════════════════════════════
+[03:52:15.570] ASSERT: node-b (the residency list member) received the ordinary audited writes in full
+══════════════════════════════════════════════════════════════════════════════
+[03:52:15.586] PASS  node-b holds ALL hubonly rows (pre + fresh) — they replicated as ordinary writes — actual: pre=5/5 fresh=3/3
+[03:52:15.586] PASS  node-b sees the resave content (resaved flag) — the re-entry write was an ordinary replicated put — actual: {"id":"hubonly-pre-001","__createdtime__":1787284321278.853,"__updatedtime__":1787284325548.374,"v":2,"wave":"pre-residency","resaved":true}
+
+══════════════════════════════════════════════════════════════════════════════
+[03:52:15.586] STEP: stop node-b, then probe node-a LOCAL state (defeats the transparent remote fetch)
+══════════════════════════════════════════════════════════════════════════════
+[03:52:15.788] [node-b] stopped
+[03:52:15.795] local probes took 7ms
+[03:52:15.795] node-a local state, pre-residency hubonly rows: {"hubonly-pre-001":"partial","hubonly-pre-002":"partial","hubonly-pre-003":"partial","hubonly-pre-004":"partial","hubonly-pre-005":"partial"}
+[03:52:15.795]   sample stored value for hubonly-pre-001: {"id":null,"__createdtime__":1787284321278.853,"__updatedtime__":1787284325548.374,"resaved":true,"v":2,"wave":"pre-residency"}
+[03:52:15.795] node-a local state, post-install hubonly rows: {"hubonly-fresh-001":"partial","hubonly-fresh-002":"partial","hubonly-fresh-003":"partial"}
+[03:52:15.795] node-a local state, unmarked rows: {"plain-101":"full","plain-102":"full","plain-103":"full","plain-104":"full","plain-105":"full","plain-201":"full"}
+[03:52:15.800] node-a record_count=38 (a destroyed-but-stubbed row still counts; the incident's counts were index/vector-based)
+[03:52:15.800] PASS  (a) INCIDENT SIGNATURE: the ordinary re-save DESTROYED the pre-existing local values on node-a (partial/absent, not full) — actual: {"hubonly-pre-001":"partial","hubonly-pre-002":"partial","hubonly-pre-003":"partial","hubonly-pre-004":"partial","hubonly-pre-005":"partial"}
+[03:52:15.800] PASS  (a3) hubonly rows first written AFTER the install were never fully stored on node-a (partial stub only) — actual: {"hubonly-fresh-001":"partial","hubonly-fresh-002":"partial","hubonly-fresh-003":"partial"}
+[03:52:15.800] PASS  (c) unmarked rows untouched on node-a (incl. the driver-written one and the resaved control, which carries its update) — actual: full=6/6 plain-101={"id":"plain-101","__createdtime__":1787284321278.853,"__updatedtime__":1787284325548.374,"resaved":true,"v":2,"wave":"pre-residency"}
+
+══════════════════════════════════════════════════════════════════════════════
+[03:52:15.800] ASSERT: transaction log — ordinary puts, ZERO deletes (the instrument positive-control above proves deletes DO log)
+══════════════════════════════════════════════════════════════════════════════
+[03:52:15.805] txn-log entries naming hubonly ids: non-delete=3 delete=0; operations=["upsert"]
+[03:52:15.805] PASS  (b) ZERO delete transactions name any hubonly id — actual: 0
+[03:52:15.805] PASS  (b2) the destruction-triggering re-save is an ORDINARY audited entry carrying the full record payload — actual: {"id":"hubonly-pre-001","wave":"pre-residency","v":2,"resaved":true,"__updatedtime__":1787284325548.374,"__createdtime__":1787284321278.853}
+[03:52:15.805] restore payload captured from the txn log: {"id":"hubonly-pre-001","wave":"pre-residency","v":2,"resaved":true,"__updatedtime__":1787284325548.374,"__createdtime__":1787284321278.853}
+
+══════════════════════════════════════════════════════════════════════════════
+[03:52:15.805] STEP: restore — remove the residency component, restart node-a, re-upsert the audit payload (node-b still down: reads are provably local)
+══════════════════════════════════════════════════════════════════════════════
+[03:52:15.930] [node-a] stopped
+[03:52:16.942] [node-a] up (pid 13884)
+[03:52:16.959] PASS  (d) restore from the transaction-log payload recovers the FULL row locally — actual: {"id":"hubonly-pre-001","__createdtime__":1787284321278.853,"__updatedtime__":1787284336950.789,"resaved":true,"v":2,"wave":"pre-residency"}
+
+══════════════════════════════════════════════════════════════════════════════
+[03:52:16.959] VERDICT — lane residency, variant record
+══════════════════════════════════════════════════════════════════════════════
+[03:52:16.959] INCIDENT SIGNATURE REPRODUCED (record variant): with a setResidency function installed whose list excludes this node, an ORDINARY write (a self-resave) destroyed the pre-existing local values (partial/invalidated stub; reads return nothing once the residency peers cannot serve the row) with ZERO delete transactions; the destroying write is itself a normal audited put; unmarked rows are untouched; and the row is fully recoverable from its transaction-log payload. This demonstrates mechanism SUFFICIENCY for the #1244 observables. Whether anything installs such a residency function on the incident hub (the Fabric-side trigger question) remains open and is not answerable from this harness.
+[03:52:16.959] node dirs (removed on exit): /var/folders/59/t9shx29n79jf6n97k8lj98q40000gn/T/hdb-1244-node-a-MiqoXn /var/folders/59/t9shx29n79jf6n97k8lj98q40000gn/T/hdb-1244-node-b-mB9ibT
+[03:52:17.065] [node-a] stopped
+
+══════════════════════════════════════════════════════════════════════════════
+[03:52:17.076] DONE — all checks passed
+══════════════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
## What

Runnable two-node local repro harness for the #1244 loss mechanism hypotheses, plus the
transcripts of the decisive runs.

`test/repro/basecopy-retention-repro.mjs` boots an ephemeral, fully isolated two-node
harper-pro cluster (public npm `@harperfast/harper-pro` — the replicator turns out to be
installable and readable, closing the "closed-code" gap in the #1244 forensics), then:

1. replicates a 25-row audited table and positive-controls the instrument — a normal
   delete must appear in `read_transaction_log` on BOTH nodes before any zero-delete
   observation counts as evidence;
2. partitions node-b, writes 10 rows only node-a holds, ages the partition past
   `logging.auditRetention` (minutes), reconnects;
3. gates the verdict on the hypothesis direction actually running — node-b logging
   `forcing a bounded base-copy resync` for the test database toward node-a (the exact
   incident log signature), i.e. node-a receiving a full base copy that does not mention
   its receiver-only rows;
4. asserts row survival/loss, delete-entry counts, and reload markers on both nodes.

A `--lane=control` reconnects within retention (incremental catch-up), and
`--partition=suspend` (SIGSTOP/SIGCONT) approximates the incident's wedged-connection
shape instead of a process restart.

`--lane=residency` (added 2026-08-20) tests the remaining suspect from the issue thread —
see the result update below.

## Result 1: base-copy hypothesis (2026-08-18)

**The #1244 base-copy mechanism hypothesis is NOT reproduced — it is disproved under this
trigger shape, on both 5.2.2 and 5.2.0.** With the forced base copy verifiably running in
the hypothesis direction:

- receiver-only rows survive on both nodes (34/34, all 10 present on both);
- zero `delete` transaction-log entries (and the positive control proves deletes do log);
- one `reload` marker per copy received — the same marker signature the incident showed,
  without any loss.

Reading the now-public replicator confirms why: the base-copy receive lane is per-row and
additive (`isCopyApply` snapshot puts with a no-regress guard); no code path disposes of
local rows the copy does not mention.

## Result 2: residency-omission lane (2026-08-20) — REPRODUCED

**The remaining code-anchored suspect — residency omission on an ordinary write —
REPRODUCES the full #1244 signature on harper-pro 5.2.2** (`--lane=residency`,
transcripts attached; the base-copy lane re-run the same day as negative control stays
clean). The lane installs a residency function on node-a at table-registration time via a
tiny throwaway component (standing in for the unconfirmed orchestration-side call — no
config surface installs one), excluding node-a for ids prefixed `hubonly-`, and drives
the trigger writes through a component-exported REST resource — necessary because the
residency function is a per-thread static: only writes handled by a worker that loaded
the component engage it (a component's own writes — flair's shape — always do; ops-API
writes served by another worker never do, verified empirically).

With `--residency=record` (`setResidency(fn(record))`), an ordinary self-resave of rows
that pre-existed the install:

- **destroyed their local values on node-a** — the full record is overwritten by a
  partial/INVALIDATED stub (indexed fields only; even the primary-key field is stripped
  from the stored value: `{"id":null, ...}`), and the read path thereafter treats the row
  as remote — with the residency peer stopped, by-id reads return the mutilated stub, and
  a row whose residency nodes never had it (the incident's hub-only shape) is
  unreachable everywhere;
- with **ZERO delete transaction-log entries** (the in-lane positive control again proves
  deletes do log);
- the destroying write is itself an **ordinary audited upsert carrying the full record
  payload**;
- unmarked rows written in the same driver call are untouched;
- **restore from the transaction-log payload recovers the full row** — exactly the
  incident's recovery path.

With `--residency=byid` (`setResidencyById(fn(id))`), a useful negative bound:
already-stored rows CANNOT be destroyed — `recordUpdater` never touches the primary
store for a `record === undefined` write (it only prevents new local storage and writes
the audit entry); the pre-existing local value survives, stale. So if residency omission
is the incident mechanism, it is the record-based variant (or the rows were first
written after the residency install).

This demonstrates mechanism **sufficiency** for the #1244 observables (local
disappearance + zero deletes + ordinary audited puts + audit-payload restore). What it
does not establish is the **trigger**: whether anything ever installs such a residency
function on the incident hub (the Fabric-side question in the issue thread) is not
answerable from this harness. One honest delta vs the incident: the destroyed rows here
leave a countable stub in `describe_table.record_count`, while the incident's counts
(graph-heal vector counts) dropped — consistent with index/vector-based counting of
mutilated rows, but not directly proven here.

## Notes

- Found en route: `add_node` with `retain_authorization: true` and an
  `{username,password}` object propagates the RAW object to the peer via `add_node_back`;
  the peer's dialer sets `headers.Authorization` to it verbatim and every outbound leg
  then loops on 1008 rejects. The harness passes a preformed `Basic …` string. Filed
  upstream as HarperFast/harper#2205.
- The harness uses a neutral audited table via the ops API rather than the flair
  component: the lanes under test are Harper-core and component-agnostic, and the neutral
  script is runnable verbatim by upstream. The residency lane's driver component exists
  precisely to give the trigger writes the same worker-thread shape as a real component's
  writes.

Refs #1244

🤖 Generated with [Claude Code](https://claude.com/claude-code)
