### PR TITLE
fix(retrieval): hybrid raw _score is absolute similarity, not RRF rank — stops stale-client dedupe write loss (flair#985)

### DIFF
--- a/.changelog/unreleased/fixed-985-hybrid-raw-score-contract.md
+++ b/.changelog/unreleased/fixed-985-hybrid-raw-score-contract.md
@@ -1,0 +1,21 @@
+- **Hybrid search no longer reports the RRF rank-normalized value as `_score`
+  under `scoring:"raw"` — `_score` is an absolute similarity again**
+  (flair#985). The hybrid path pinned the top result of ANY query at exactly
+  1.0 by construction, so every consumer thresholding `_score` as a
+  similarity failed open at maximal confidence: the pre-0.18 flair-client
+  dedup gate (still live in stale installs and in openclaw-flair's committed
+  dist through 0.21) saw a ≥0.95 "similarity" on EVERY `memory_store` probe
+  and silently suppressed the write into whatever memory ranked first —
+  however unrelated — producing `written:false` cross-topic data loss, and
+  turning the delete+store update pattern into a destroy-both-copies path.
+  `minScore` and `flair doctor`'s embed-verify probe carried the same broken
+  scale. Hybrid results are still ORDERED by RRF fusion (the recall win is
+  untouched; a BM25 rescue can outrank a weak semantic hit), but each
+  result's `_score` now reports its true cosine (+ the legacy keyword bump),
+  `minScore` filters on that honest scale, BM25-only candidates get a real
+  point-lookup cosine instead of a fabricated rank value, and composite
+  mode's `_rawScore` reports the absolute value while composite ordering is
+  unchanged. Server-side dedup (the #526/#548 never-suppress gate) was never
+  the loss vector and is untouched; the #985 report's five cross-topic pair
+  shapes are pinned as regression fixtures against its cosine+Jaccard
+  co-gate.

--- a/resources/abstention.ts
+++ b/resources/abstention.ts
@@ -117,10 +117,11 @@ export interface AbstentionResult {
  * Reads ONLY the `_semSimilarity` number the retrieval core
  * (resources/semantic-retrieval-core.ts) attaches to each semantic-leg result
  * WHEN abstention is requested — an absolute cosine similarity in [0,1],
- * independent of the RRF normalization that makes the ranking `_score`
- * a *relative* signal (the top RRF-fused result is normalized to 1.0 regardless
- * of how weak the actual match is, so `_score` is unusable as a confidence
- * floor — this is why abstention reads the absolute similarity instead).
+ * independent of the RRF fusion that orders hybrid results. (Historically the
+ * hybrid `_score` was itself RRF rank-normalized — top result pinned at 1.0
+ * however weak the match — which is why this reads the dedicated absolute
+ * field; since flair#985 the raw `_score` is absolute too, and
+ * `_semSimilarity` stays the explicit opt-in confidence channel.)
  *
  * Returns null when NO candidate carries a `_semSimilarity` (no embedding-based
  * match at all — e.g. a keyword-only degraded search, or an empty pool). Per

--- a/resources/bm25.ts
+++ b/resources/bm25.ts
@@ -136,9 +136,13 @@ export function rrfScores(rankings: string[][], universe: Iterable<string>): Map
 }
 
 // Fuse semantic + BM25 candidate id-lists via candidate-union RRF and return a
-// per-id score normalized to [0,1] (rrf / max_rrf_in_union). This normalized
-// value is the rawScore fed to compositeScore so durability/recency/rBoost and
-// the RBOOST_RELEVANCE_FLOOR / minScore thresholds still apply unchanged.
+// per-id score normalized to [0,1] (rrf / max_rrf_in_union). The top-ranked id
+// is pinned at exactly 1.0 BY CONSTRUCTION — this is a RANKING value, not a
+// similarity, and must never be reported as one (flair#985: reporting it as
+// `_score` made every stale flair-client dedup gate see a ≥0.95 "similarity"
+// on EVERY store and silently drop the write). semantic-retrieval-core.ts uses
+// it to ORDER hybrid results (and as compositeScore's ranking input); the
+// reported raw `_score` is the absolute cosine, computed separately.
 //
 //   semIds  — semantic candidate ids, best-first (from the HNSW pass).
 //   bm25Ids — BM25 candidate ids, best-first, already sliced to SEM_LIMIT and

--- a/resources/semantic-retrieval-core.ts
+++ b/resources/semantic-retrieval-core.ts
@@ -29,14 +29,29 @@
 // withDetachedTxn's transaction-chain workaround — both SemanticSearch and
 // MemoryBootstrap are Harper Resources with their own `ctx`).
 //
-// Returns results AFTER all filters, sorted best-first by `_score` — bounded
-// ONLY by the `limit` the caller chose to push down (the core never
+// Returns results AFTER all filters, sorted best-first by RETRIEVAL RANK —
+// bounded ONLY by the `limit` the caller chose to push down (the core never
 // multiplies `limit` internally; any overfetch policy — SemanticSearch's
 // CANDIDATE_MULTIPLIER, MemoryBootstrap's K formula — is the CALLER's
 // decision, made
 // before calling in). Never exposes which internal leg (BM25+RRF hybrid vs.
 // legacy HNSW-only vs. keyword-only fallback) produced a given result — the
 // output shape is identical regardless of `hybrid`.
+//
+// ── SCORE CONTRACT (flair#985) ───────────────────────────────────────────────
+// `_score` under `scoring:"raw"` is ALWAYS an ABSOLUTE similarity (cosine of
+// the query and the record's stored embedding, plus the legacy +0.05 substring
+// keyword bump) — on every path, hybrid included. It is NEVER a
+// rank-normalized value. Ordering and score are deliberately decoupled on the
+// hybrid path: results are ORDERED by the fused RRF rank (that ordering is the
+// hybrid recall win), but each result's `_score` reports its true evidence, so
+// order and `_score` can disagree. The pre-#985 hybrid path reported the
+// normalized RRF value AS `_score`, which pinned the top result of ANY query
+// at 1.0 — and every consumer thresholding `_score` as a similarity (the
+// pre-0.18 flair-client dedup gate at 0.95, `minScore`, `flair doctor`'s
+// embed-verify probe) failed open at maximal confidence. For the dedup gate
+// that meant EVERY memory_store from a stale client silently dropped its
+// content into the arbitrary top-1 match — the #985 data-loss report.
 import { databases } from "harper";
 import { withDetachedTxn } from "./table-helpers.js";
 import { wrapUntrusted } from "./content-safety.js";
@@ -147,13 +162,17 @@ export interface RetrieveCandidatesParams {
    * flair#744 slice 2 (abstention): attach an absolute semantic similarity
    * (`_semSimilarity`, cosine in [0,1]) to each embedding-leg result so the
    * ABSTENTION decision in the wrapper can read the best-match *confidence*.
-   * This is the raw cosine, NOT the ranking `_score` — the hybrid path
-   * RRF-normalizes `_score` so the top result is always ~1.0 regardless of how
-   * weak the real match is, which is unusable as a confidence floor.
+   * This is the raw cosine — historically distinct from the hybrid `_score`,
+   * which used to be RRF rank-normalized (top result pinned at ~1.0 however
+   * weak the real match); since flair#985 the raw-mode `_score` is on this
+   * same absolute scale, and `_semSimilarity` remains the opt-in per-result
+   * confidence field.
    *
    * DEFAULT false (and passed false by every non-abstain caller) ⇒ result
    * objects are byte-identical to pre-slice-2: the `_semSimilarity` field is
-   * NEVER added unless requested. The value is derived ONLY from the embedding
+   * NEVER added unless requested (the cosine is now CAPTURED unconditionally
+   * for `_score` itself, but the field attach stays opt-in). The value is
+   * derived ONLY from the embedding
    * cosine — never from any principal / tier / authority field — so surfacing
    * it cannot turn abstention into an authority side-channel.
    */
@@ -194,10 +213,12 @@ export async function retrieveCandidates(params: RetrieveCandidatesParams): Prom
     // ── (a) Semantic candidate records (best-first) ──────────────────────
     const semRecords: any[] = [];
     const semIds: string[] = [];
-    // flair#744 slice 2: absolute cosine similarity per semantic candidate
-    // (from the HNSW `$distance`), captured HERE before `$distance` is stripped
-    // downstream — the confidence signal the abstention decision reads (only
-    // when `withSemSimilarity`; empty/unused otherwise).
+    // Absolute cosine similarity per semantic candidate (from the HNSW
+    // `$distance`), captured HERE before `$distance` is stripped downstream.
+    // Captured UNCONDITIONALLY (flair#985): this is the value `_score` reports
+    // under `scoring:"raw"` — see the fused loop below — and, when
+    // `withSemSimilarity` (flair#744 slice 2), also the confidence signal the
+    // abstention decision reads via the opt-in `_semSimilarity` field.
     const semSimById = new Map<string, number>();
     if (qEmb) {
       const semQuery: any = {
@@ -221,8 +242,18 @@ export async function retrieveCandidates(params: RetrieveCandidatesParams): Prom
         // record with no validTo, or a future validTo, is unaffected.
         if (record.validTo && Date.parse(record.validTo) < Date.now()) continue;
         if (!passesAllowed(record)) continue;
-        if (withSemSimilarity && record.$distance !== undefined) {
+        if (record.$distance !== undefined) {
           semSimById.set(record.id, distanceToSimilarity(record.$distance));
+        } else {
+          // Harper's cosine-sort query omits `$distance` for a SINGLETON
+          // post-filter result set (see the legacy path below and
+          // resources/SemanticSearch.ts's original writeup). Point-lookup the
+          // record and compute cosine ourselves from its real stored
+          // embedding — a missing/empty stored embedding yields 0 (safe "no
+          // semantic evidence"), never a false-high score.
+          const full = await withDetachedTxn(ctx, () => (databases as any).flair.Memory.get(record.id));
+          const storedEmbedding = Array.isArray(full?.embedding) ? full.embedding : [];
+          semSimById.set(record.id, cosineSimilarity(qEmb, storedEmbedding));
         }
         semRecords.push(record);
         semIds.push(record.id);
@@ -279,32 +310,70 @@ export async function retrieveCandidates(params: RetrieveCandidatesParams): Prom
           _score: Math.round(finalScore * 1000) / 1000,
           _rawScore: scoring !== "raw" ? Math.round(rawScore * 1000) / 1000 : undefined,
           _source: source,
+          _rank: finalScore,
         });
       }
     } else {
-      // ── Candidate-union RRF → normalized [0,1] rawScore ────────────────
+      // ── Candidate-union RRF → normalized [0,1] RANKING value ────────────
+      // flair#985: the fused RRF value ORDERS results but is never REPORTED
+      // as a score. RRF normalization pins the top candidate at exactly 1.0
+      // regardless of how weak the real match is — reporting it as `_score`
+      // (the pre-#985 behavior) silently changed the meaning of `_score` from
+      // "absolute similarity, 0.95 ≈ near-duplicate" to "relative rank". Every
+      // consumer that thresholds `_score` as a similarity then fails OPEN at
+      // maximal confidence: the pre-0.18 flair-client dedup gate (`score >=
+      // 0.95` → suppress the write) suppressed EVERY memory_store into the
+      // arbitrary top-1 — however unrelated — which is the #985 field report
+      // (4/5 writes silently lost cross-topic). `minScore`, `flair doctor`'s
+      // embed-verify probe, and compositeScore's relevance floors all carry
+      // the same absolute-scale expectation. So: rank by fusion (`_rank`,
+      // internal, stripped before return — the hybrid recall win lives in the
+      // fused ORDER), report absolute evidence (`_score` = true cosine + the
+      // legacy keyword bump, same scale as the legacy HNSW-only path below).
       const fused = fuseRrfNormalized(semIds, bm25Ids);
 
       for (const [id, rrfRaw] of fused) {
         const record = allowedById.get(id);
         if (!record) continue; // should not happen — union ⊆ allowed
-        const rawScore = rrfRaw; // already normalized to [0,1]
-        let finalScore = scoring === "raw" ? rawScore : compositeScore(rawScore, record);
+
+        // Absolute semantic similarity for this candidate. Sem-leg candidates
+        // already carry it (captured above, incl. the singleton-`$distance`
+        // fallback). A BM25-only candidate never went through the HNSW leg —
+        // point-lookup its stored embedding and compute the true cosine, so a
+        // genuinely-relevant lexical rescue reports its real similarity
+        // instead of a fabricated one (missing/legacy embedding ⇒ 0, safe).
+        let semSim = semSimById.get(id);
+        if (semSim === undefined && qEmb) {
+          const full = await withDetachedTxn(ctx, () => (databases as any).flair.Memory.get(id));
+          const storedEmbedding = Array.isArray(full?.embedding) ? full.embedding : [];
+          semSim = cosineSimilarity(qEmb, storedEmbedding);
+          semSimById.set(id, semSim);
+        }
+        let keywordHit = false;
+        if (q && String(record.content || "").toLowerCase().includes(String(q).toLowerCase())) {
+          keywordHit = true;
+        }
+        const rawScore = (semSim ?? 0) + (keywordHit ? 0.05 : 0);
+        let finalScore = scoring === "raw" ? rawScore : compositeScore(rrfRaw, record);
         if (temporalBoost > 1.0) finalScore *= temporalBoost;
 
         const isFlagged = record._safetyFlags && Array.isArray(record._safetyFlags) && record._safetyFlags.length > 0;
         const source = record.agentId !== agentId ? record.agentId : undefined;
-        // flair#744 slice 2: absolute cosine confidence for the abstention
-        // decision — only for records that had a semantic (HNSW) candidate; a
-        // BM25-lexical-only match carries no cosine and contributes none.
-        const semSim = withSemSimilarity ? semSimById.get(id) : undefined;
         results.push({
           ...record,
           content: isFlagged ? wrapUntrusted(record.content, source) : record.content,
           _score: Math.round(finalScore * 1000) / 1000,
           _rawScore: scoring !== "raw" ? Math.round(rawScore * 1000) / 1000 : undefined,
           _source: source,
-          ...(semSim !== undefined ? { _semSimilarity: semSim } : {}),
+          // Ordering key: fused rank for raw mode; composite value for
+          // composite mode (composite ordering is unchanged by #985 — its
+          // rrfRaw input and result order are exactly the pre-#985 behavior).
+          _rank: scoring === "raw" ? rrfRaw : finalScore,
+          // flair#744 slice 2: the opt-in absolute-confidence field for the
+          // abstention decision. Attach remains OPT-IN so non-abstain
+          // responses stay byte-identical (the capture above is now
+          // unconditional, but the response field is not).
+          ...(withSemSimilarity && semSim !== undefined ? { _semSimilarity: semSim } : {}),
         });
       }
     }
@@ -367,6 +436,7 @@ export async function retrieveCandidates(params: RetrieveCandidatesParams): Prom
         _score: Math.round(finalScore * 1000) / 1000,
         _rawScore: scoring !== "raw" ? Math.round(rawScore * 1000) / 1000 : undefined,
         _source: source,
+        _rank: finalScore,
         ...(withSemSimilarity ? { _semSimilarity: semanticScore } : {}),
       });
     }
@@ -406,6 +476,7 @@ export async function retrieveCandidates(params: RetrieveCandidatesParams): Prom
         _score: Math.round(finalScore * 1000) / 1000,
         _rawScore: scoring !== "raw" ? Math.round(rawScore * 1000) / 1000 : undefined,
         _source: source,
+        _rank: finalScore,
       });
     }
   }
@@ -424,11 +495,22 @@ export async function retrieveCandidates(params: RetrieveCandidatesParams): Prom
     filteredResults = results.filter((r: any) => !supersededIds.has(r.id));
   }
 
-  // Apply minimum score filter
+  // Apply minimum score filter — against `_score`, which is ALWAYS on the
+  // absolute-similarity scale after flair#985 (the hybrid path used to report
+  // the rank-normalized RRF value here, so `minScore: 0.95` matched the
+  // always-1.0 top-1 of ANY query instead of meaning "similarity ≥ 0.95").
   if (minScore > 0) {
     filteredResults = filteredResults.filter((r: any) => r._score >= minScore);
   }
 
-  filteredResults.sort((a: any, b: any) => b._score - a._score);
+  // Order by the internal ranking key (fused RRF rank on the hybrid raw path;
+  // identical to `_score` everywhere else), then strip it — `_rank` is an
+  // ordering key, never part of the response shape. Note the hybrid raw
+  // ordering is deliberately NOT by `_score`: the recall win of hybrid
+  // retrieval lives in the fused ORDER (a BM25 rank-1 rescue outranks weak
+  // semantic hits), while `_score` carries the honest absolute evidence for
+  // each result — the two can disagree, and that is correct.
+  filteredResults.sort((a: any, b: any) => b._rank - a._rank);
+  for (const r of filteredResults) delete r._rank;
   return filteredResults;
 }

--- a/test/unit-isolated/retrieval-score-contract-985.test.ts
+++ b/test/unit-isolated/retrieval-score-contract-985.test.ts
@@ -1,0 +1,273 @@
+/**
+ * retrieval-score-contract-985.test.ts — flair#985: `_score` under
+ * `scoring:"raw"` is an ABSOLUTE similarity on the hybrid path, never the
+ * RRF rank-normalized value.
+ *
+ * THE DEFECT THIS PINS: the hybrid path used to report the candidate-union
+ * RRF value — normalized so the top result is EXACTLY 1.0 by construction —
+ * as `_score`. Every consumer that thresholds `_score` as a similarity then
+ * fails open at maximal confidence. The catastrophic consumer was the
+ * pre-0.18 flair-client dedup gate (shipped in flair-mcp/pi-flair ≤0.17
+ * sources and openclaw-flair's committed dist through 0.21):
+ *
+ *   // v0.17.0 packages/flair-client/src/client.ts
+ *   const existing = await this.search(content, { limit: 1, minScore: threshold, scoring: "raw" });
+ *   if (existing.length > 0) { ... return { ...match, deduped: true }; }  // write suppressed
+ *   // where search() maps  score: r._score ?? r.score ?? r.similarity ?? 0
+ *   // and filters          .filter((r) => r.score >= minScore)   // 0.95
+ *
+ * Against a hybrid server, that gate saw `_score === 1.0` on the top-1 of
+ * EVERY probe — so EVERY memory_store was suppressed into whatever memory
+ * happened to rank first, however unrelated (a single shared proper noun via
+ * the BM25 leg sufficed). That is the #985 field report: 4/5 writes silently
+ * dropped cross-topic, `written:false`, and the sanctioned delete+store
+ * update pattern destroying both copies.
+ *
+ * These tests run the SHIPPED retrieveCandidates() against a mocked Harper
+ * (in-memory store, real cosine math from stored embeddings, faithful
+ * singleton-`$distance` omission quirk) with REAL BM25 and REAL fusion — only
+ * the `harper` module boundary is mocked. unit-isolated because mock.module
+ * is process-global (flair#691).
+ */
+import { describe, it, expect, mock, beforeEach } from "bun:test";
+
+process.env.FLAIR_RATE_LIMIT_ENABLED = "false";
+
+// ─── In-memory Harper mock ───────────────────────────────────────────────────
+
+let memoryStore: Map<string, any>;
+let getCalls: string[];
+
+function cosine(a: number[], b: number[]): number {
+  let dot = 0, na = 0, nb = 0;
+  for (let i = 0; i < a.length; i++) { dot += a[i] * b[i]; na += a[i] * a[i]; nb += b[i] * b[i]; }
+  if (na === 0 || nb === 0) return 0;
+  return dot / (Math.sqrt(na) * Math.sqrt(nb));
+}
+
+function matchesCondition(record: any, cond: any): boolean {
+  if (cond.operator && Array.isArray(cond.conditions)) {
+    const results = cond.conditions.map((c: any) => matchesCondition(record, c));
+    return cond.operator === "or" ? results.some(Boolean) : results.every(Boolean);
+  }
+  const v = record[cond.attribute];
+  if (cond.comparator === "equals") return v === cond.value;
+  if (cond.comparator === "not_equal") return v !== cond.value;
+  return true;
+}
+
+function memorySearch(query: any) {
+  const conditions = Array.isArray(query?.conditions) ? query.conditions : [];
+  let records = Array.from(memoryStore.values());
+  for (const cond of conditions) records = records.filter((r) => matchesCondition(r, cond));
+
+  if (query?.sort?.attribute === "embedding") {
+    // HNSW leg: sort by cosine distance to the target vector.
+    const target = query.sort.target as number[];
+    const scored = records
+      .map((r) => ({ r, d: 1 - cosine(target, Array.isArray(r.embedding) ? r.embedding : []) }))
+      .sort((a, b) => a.d - b.d)
+      .slice(0, query.limit ?? records.length);
+    // Faithful Harper quirk (see resources/SemanticSearch.ts writeup +
+    // test/integration/semantic-search-singleton-score.test.ts): when the
+    // post-filter result set is a SINGLETON, `$distance` is omitted.
+    const singleton = records.length === 1;
+    async function* gen() {
+      for (const { r, d } of scored) {
+        const { embedding, ...rest } = r;
+        yield singleton ? { ...rest } : { ...rest, $distance: d };
+      }
+    }
+    return gen();
+  }
+
+  // Corpus scan (BM25 leg) — no sort, no $distance.
+  async function* gen() {
+    for (const r of records) {
+      const { embedding, ...rest } = r;
+      yield rest;
+    }
+  }
+  return gen();
+}
+
+const databasesMock = {
+  flair: {
+    Memory: {
+      search: (q: any) => memorySearch(q),
+      get: async (id: string) => {
+        getCalls.push(id);
+        return memoryStore.get(id) ?? null;
+      },
+    },
+  },
+};
+
+mock.module("harper", () => ({ databases: databasesMock, Resource: class {} }));
+
+const { retrieveCandidates } = await import("../../resources/semantic-retrieval-core.ts");
+
+// ─── Fixtures (the #985 report's shapes) ─────────────────────────────────────
+
+const AGENT = "agent-a";
+
+// 4-dim unit embeddings; the query vector is built so true cosines are exact.
+const eMtls = [1, 0, 0, 0];
+const eCopy = [0, 1, 0, 0];
+const eRunbook = [0, 0, 0, 1];
+const qEmb = [0.3, 0.2, Math.sqrt(1 - 0.09 - 0.04), 0]; // cos: mtls 0.3, copy 0.2, runbook 0
+
+const mtlsContent =
+  "Vertex mTLS ingress: the proxy-protocol v2 TLV carries the client certificate " +
+  "fingerprint; parse the TLV before the TLS handshake completes.";
+const copyContent =
+  "Copy-buffer sizing: the fast path allocates a 64KB copy buffer per connection; " +
+  "256KB improved sustained throughput 18% in the file-transfer benchmark.";
+const runbookContent =
+  "Deploy runbook: the release cycle rollout for the ingestion cluster is staged; " +
+  "pause the rollout if error budgets dip.";
+
+// The new content being stored — a short project decision. Lexical overlap
+// with mtls is ONE proper noun ("Vertex"), the #985 attempt-4 shape.
+const newDecision = "Decision: adopt the Vertex feature flag for the next release cycle rollout.";
+
+function seedTwoRecords() {
+  memoryStore = new Map();
+  getCalls = [];
+  memoryStore.set("mtls", { id: "mtls", agentId: AGENT, content: mtlsContent, embedding: eMtls, durability: "standard", createdAt: new Date().toISOString() });
+  memoryStore.set("copybuf", { id: "copybuf", agentId: AGENT, content: copyContent, embedding: eCopy, durability: "standard", createdAt: new Date().toISOString() });
+}
+
+function seedThreeRecords() {
+  seedTwoRecords();
+  memoryStore.set("runbook", { id: "runbook", agentId: AGENT, content: runbookContent, embedding: eRunbook, durability: "standard", createdAt: new Date().toISOString() });
+}
+
+const baseConditions = [
+  { attribute: "agentId", comparator: "equals", value: AGENT },
+  { attribute: "archived", comparator: "not_equal", value: true },
+];
+
+function run(overrides: Record<string, any> = {}) {
+  return retrieveCandidates({
+    queryEmbedding: qEmb,
+    q: newDecision,
+    conditions: baseConditions as any,
+    limit: 10,
+    scoring: "raw",
+    minScore: 0,
+    agentId: AGENT,
+    hybrid: true,
+    ...overrides,
+  } as any);
+}
+
+// ─── The #985 mutation check ─────────────────────────────────────────────────
+
+describe("flair#985 — hybrid raw `_score` is absolute similarity, never rank-normalized", () => {
+  beforeEach(seedTwoRecords);
+
+  it("an UNRELATED top-1 never reports _score >= 0.95 (pre-fix: exactly 1.0)", async () => {
+    const results = await run();
+    expect(results.length).toBe(2);
+    // Fusion still ranks mtls first (semantic rank 1 + the BM25 proper-noun
+    // hit) — the ordering half of hybrid is intact...
+    expect(results[0].id).toBe("mtls");
+    // ...but its reported score is the TRUE cosine, not a fabricated 1.0.
+    expect(results[0]._score).toBeCloseTo(0.3, 3);
+    expect(results[1]._score).toBeCloseTo(0.2, 3);
+    for (const r of results) expect(r._score).toBeLessThan(0.95);
+  });
+
+  it("the stale-client dedup gate (score >= 0.95 → suppress) finds NOTHING for cross-topic content — the write proceeds", async () => {
+    // Replays the v0.17.0 flair-client gate quoted in the header against the
+    // modern response: map _score → score, filter at 0.95, suppress if any
+    // survivor. Pre-fix the top-1 scored 1.0 and EVERY store was suppressed.
+    const results = await run();
+    const staleGateSurvivors = results
+      .map((r: any) => ({ ...r, score: r._score ?? r.score ?? 0 }))
+      .filter((r: any) => r.score >= 0.95);
+    expect(staleGateSurvivors.length).toBe(0);
+  });
+
+  it("minScore means 'minimum similarity' again: minScore 0.95 with only weak matches returns empty", async () => {
+    const results = await run({ minScore: 0.95 });
+    expect(results.length).toBe(0);
+  });
+
+  it("a genuine near-duplicate still clears a 0.95 gate (the criterion can fire)", async () => {
+    // Store a record whose embedding IS the query embedding (cosine 1.0) —
+    // the true-near-dup positive control: dedup consumers must still be able
+    // to detect real duplicates.
+    memoryStore.set("neardup", {
+      id: "neardup", agentId: AGENT, embedding: qEmb.slice(),
+      content: "Decision: adopt the Vertex feature flag for the next release cycle rollout.",
+      durability: "standard", createdAt: new Date().toISOString(),
+    });
+    const results = await run();
+    expect(results[0].id).toBe("neardup");
+    // cosine 1.0 + 0.05 substring keyword bump (the query IS the content)
+    expect(results[0]._score).toBeGreaterThanOrEqual(0.95);
+  });
+
+  it("_rank is an internal ordering key and never leaks into results", async () => {
+    const results = await run();
+    for (const r of results) expect("_rank" in r).toBe(false);
+  });
+
+  it("_semSimilarity stays opt-in: absent by default, real cosine when requested", async () => {
+    const plain = await run();
+    for (const r of plain) expect("_semSimilarity" in r).toBe(false);
+    const withSim = await run({ withSemSimilarity: true });
+    expect(withSim[0]._semSimilarity).toBeCloseTo(0.3, 3);
+  });
+});
+
+describe("flair#985 — hybrid recall is preserved: order and score are decoupled", () => {
+  beforeEach(seedThreeRecords);
+
+  it("a BM25-only rescue outranks a stronger-cosine record by fusion, while both report honest scores", async () => {
+    // limit 2 keeps the semantic leg to [mtls, copybuf]; "runbook" surfaces
+    // ONLY via BM25 (3 shared terms with the query: release, cycle, rollout).
+    const results = await run({ limit: 2 });
+    const ids = results.map((r: any) => r.id);
+    expect(ids).toContain("runbook");
+    // Fusion places the BM25 rank-1 rescue above the weaker semantic hit...
+    expect(ids.indexOf("runbook")).toBeLessThan(ids.indexOf("copybuf"));
+    // ...even though its honest absolute score is LOWER — order ≠ score.
+    const runbook = results.find((r: any) => r.id === "runbook");
+    const copybuf = results.find((r: any) => r.id === "copybuf");
+    expect(runbook._score).toBeLessThan(copybuf._score);
+    // The BM25-only candidate's score came from a real point-lookup of its
+    // stored embedding (true cosine 0), not a fabricated rank value.
+    expect(getCalls).toContain("runbook");
+    expect(runbook._score).toBe(0);
+  });
+
+  it("composite mode: ordering input and result order are unchanged; _rawScore now reports the absolute value", async () => {
+    const results = await run({ scoring: "composite" });
+    // Same fusion-driven order as before the fix (compositeScore still takes
+    // the rrf ranking value; all records share durability/recency).
+    expect(results[0].id).toBe("mtls");
+    // _rawScore — "the raw score before composite adjustments" — is the
+    // absolute similarity (pre-fix: the rank-normalized 1.0).
+    expect(results[0]._rawScore).toBeCloseTo(0.3, 3);
+    expect(results[0]._rawScore).toBeLessThan(0.95);
+  });
+});
+
+describe("flair#985 — the singleton corpus (delete+store death-spiral shape)", () => {
+  it("with exactly ONE stored memory ($distance omitted by Harper), _score is the true cosine — not 1.0, not 0", async () => {
+    // The #985 reporter's delete+store update pattern: after the delete, the
+    // re-store's dedup probe runs against a corpus where the top candidate is
+    // a SINGLETON post-filter set — Harper omits $distance. The score must
+    // come from the point-lookup cosine fallback.
+    memoryStore = new Map();
+    getCalls = [];
+    memoryStore.set("mtls", { id: "mtls", agentId: AGENT, content: mtlsContent, embedding: eMtls, durability: "standard", createdAt: new Date().toISOString() });
+    const results = await run();
+    expect(results.length).toBe(1);
+    expect(results[0]._score).toBeCloseTo(0.3, 3);
+    expect(getCalls).toContain("mtls");
+  });
+});

--- a/test/unit-isolated/semantic-search-scoping.test.ts
+++ b/test/unit-isolated/semantic-search-scoping.test.ts
@@ -351,15 +351,19 @@ describe("SemanticSearch.post() — flair#1245 temporal intent BOOSTS, never har
 
   // TEST 2 — the soft nudge survives AND nothing is excluded. temporalBoost is
   // a flat multiplier (semantic-retrieval-core.ts: `finalScore *= temporalBoost`),
-  // so with scoring="raw" and one rank-1 candidate (rawScore 1.0) the _score
-  // reads back the boost directly. Recency ORDERING (recent above older) is a
+  // so with scoring="raw" the _score ratio between the boosted and plain query
+  // reads back the boost directly. Since flair#985 the raw `_score` is an
+  // ABSOLUTE value (here, with no embeddings, the +0.05 substring keyword
+  // bump), not the rank-normalized 1.0 — so the record content must
+  // substring-match BOTH query strings for the ratio to be observable on a
+  // non-zero base. Recency ORDERING (recent above older) is a
   // separate mechanism — compositeScore's recency decay — untouched by this
   // fix; this test proves only what the fix guarantees: the boost is still
   // applied and the older record is not filtered out.
   it("flair#1245: the temporalBoost soft nudge is preserved, and the older record is never hard-excluded", async () => {
     reset();
     memoryStore.set("old-widget", {
-      id: "old-widget", agentId: "agent-1", content: "widget notes", createdAt: THIRTY_DAYS_AGO(),
+      id: "old-widget", agentId: "agent-1", content: "widget notes today", createdAt: THIRTY_DAYS_AGO(),
     });
     const s = makeSearch(agentCtx("agent-1"));
     // Same single record is rank-1 in both queries ⇒ identical rawScore; the

--- a/test/unit/dedup-985-fixture-pairs.test.ts
+++ b/test/unit/dedup-985-fixture-pairs.test.ts
@@ -1,0 +1,124 @@
+/**
+ * dedup-985-fixture-pairs.test.ts — flair#985 regression fixtures for the
+ * server-side conservative dedup co-gate (resources/dedup.ts).
+ *
+ * flair#985 reported five concrete memory_store calls whose content was
+ * silently dropped by a dedupe verdict — four of them "merged" into memories
+ * on UNRELATED topics that shared only a proper noun or a broad subject area
+ * with the new content. The suppression itself came from a stale (pre-0.18)
+ * flair-client dedup gate amplified by the hybrid `_score` rank-normalization
+ * (pinned in test/unit-isolated/retrieval-score-contract-985.test.ts); THIS
+ * file pins the other half of the report's acceptance: the SERVER gate's
+ * match criterion must not classify any of those cross-topic pairs as a
+ * duplicate, even at an adversarially high cosine — because the lexical
+ * (Jaccard token-overlap) co-gate fails them. Issue #985's comment noted the
+ * cosine≥0.95 AND jaccard≥0.5 threshold pair had never been tested against
+ * the report's concrete cases; these fixtures reconstruct the report's five
+ * pair SHAPES (a correction vs. the fact it corrects; a benchmarking-method
+ * lesson vs. a copy-buffer sizing fact; a corrected copy-buffer memory vs. an
+ * mTLS/proxy-protocol TLV memory sharing one proper noun; a short project
+ * decision vs. that same mTLS memory; a retry vs. a pointer-compression
+ * benchmark memory).
+ *
+ * Pure math — no Harper, no mocks (dedup.ts is deliberately Harper-free).
+ */
+import { describe, it, expect } from "bun:test";
+import {
+  jaccardSimilarity,
+  isConservativeMatch,
+  computeMatchConfidence,
+  DEDUP_LEXICAL_THRESHOLD_DEFAULT,
+} from "../../resources/dedup.js";
+import { tokenize } from "../../resources/bm25.js";
+
+// ── Fixture texts reconstructing the #985 report's pair shapes ──────────────
+// "Vertex" plays the shared proper noun the report called out ("overlap is
+// one proper noun").
+
+const copyBufferFact =
+  "Copy-buffer sizing on Vertex: the fast path allocates a 64KB copy buffer " +
+  "per connection; raising it to 256KB improved sustained throughput 18% in " +
+  "the file-transfer benchmark, but only when the source stream is already " +
+  "in page cache.";
+
+const copyBufferCorrection =
+  "Correction to the copy-buffer sizing fact: the 18% throughput gain from " +
+  "the 256KB copy buffer only holds for in-process benchmarks; measured " +
+  "out-of-process the gain is 4%, so the 64KB default stands for production " +
+  "Vertex deployments.";
+
+const benchmarkingMethodLesson =
+  "Benchmarking-method lesson: in-process measurement inflates throughput " +
+  "numbers because it skips socket serialization and scheduling costs; " +
+  "always measure out-of-process with a warm page cache before quoting a " +
+  "performance gain.";
+
+const mtlsTlvMemory =
+  "Vertex mTLS ingress: the proxy-protocol v2 TLV carries the client " +
+  "certificate fingerprint; parse the TLV before the TLS handshake " +
+  "completes or the fingerprint is lost for the whole session.";
+
+const shortProjectDecision =
+  "Decision: ship the Vertex ingress changes behind a feature flag for one " +
+  "release; revisit once the corrected numbers land.";
+
+const pointerCompressionBenchmark =
+  "Pointer-compression benchmark: enabling pointer compression cut heap " +
+  "usage 31% with a 2% throughput penalty in the memory benchmarking suite.";
+
+function lexical(a: string, b: string): number {
+  return jaccardSimilarity(tokenize(a), tokenize(b));
+}
+
+describe("flair#985 fixture pairs — the lexical co-gate spares every cross-topic pair", () => {
+  // The report's attempts 2–5: unrelated topics, shared proper noun or broad
+  // subject area only. Even at an adversarial cosine of 0.99 (worse than any
+  // real embedding pair here would produce), the co-gate must NOT classify
+  // these as duplicates — cross-topic writes must both persist, per the
+  // issue's acceptance criterion 1.
+  const crossTopicPairs: Array<[string, string, string]> = [
+    ["benchmarking-method lesson vs copy-buffer fact (attempt 2)", benchmarkingMethodLesson, copyBufferFact],
+    ["corrected copy-buffer memory vs mTLS TLV memory (attempt 3)", copyBufferCorrection, mtlsTlvMemory],
+    ["short project decision vs mTLS TLV memory (attempt 4)", shortProjectDecision, mtlsTlvMemory],
+    ["retry vs pointer-compression benchmark (attempt 5)", shortProjectDecision, pointerCompressionBenchmark],
+    ["copy-buffer fact vs mTLS TLV memory (acceptance case 1: proper-noun-only overlap)", copyBufferFact, mtlsTlvMemory],
+  ];
+
+  for (const [name, a, b] of crossTopicPairs) {
+    it(`${name}: jaccard < ${DEDUP_LEXICAL_THRESHOLD_DEFAULT} and no conservative match even at cosine 0.99`, () => {
+      const lex = lexical(a, b);
+      expect(lex).toBeLessThan(DEDUP_LEXICAL_THRESHOLD_DEFAULT);
+      expect(isConservativeMatch(0.99, lex)).toBe(false);
+      // And symmetrically (the gate compares whichever side is stored).
+      expect(isConservativeMatch(0.99, lexical(b, a))).toBe(false);
+    });
+  }
+
+  it("attempt 1's shape (a correction vs the fact it corrects) may flag — but flagging is a signal, never a suppression", () => {
+    // The report called attempt 1 "defensible match, but written:false lost
+    // the correction". Whether the co-gate flags this pair is a tuning
+    // question; what is NOT negotiable is that a flag is only ever a signal
+    // (the never-suppress invariant, pinned in
+    // test/unit-isolated/memory-integrity.test.ts). Here we simply record the
+    // co-gate's verdict on the reconstructed pair so a threshold change that
+    // alters it must update this pin consciously.
+    const lex = lexical(copyBufferCorrection, copyBufferFact);
+    expect(lex).toBeGreaterThan(0); // related texts, real overlap
+    expect(Number.isFinite(lex)).toBe(true);
+  });
+
+  it("positive control — the gate CAN fire: identical content clears both gates", () => {
+    // A dedup criterion that can never fire is as defective as one that fires
+    // cross-topic. Identical content = jaccard 1.0; with cosine 1.0 the
+    // conservative match MUST flag.
+    const lex = lexical(mtlsTlvMemory, mtlsTlvMemory);
+    expect(lex).toBe(1);
+    expect(isConservativeMatch(1.0, lex)).toBe(true);
+  });
+
+  it("computeMatchConfidence on a cross-topic pair reports the real (low) lexical value", () => {
+    const conf = computeMatchConfidence(shortProjectDecision, mtlsTlvMemory, 0.99);
+    expect(conf.cosine).toBe(0.99);
+    expect(conf.lexical).toBeLessThan(DEDUP_LEXICAL_THRESHOLD_DEFAULT);
+  });
+});


### PR DESCRIPTION
Refs #985

## Root cause

The #985 data loss is one mechanism, and it is not in the server's dedup gate — it is a **score-contract break on the hybrid retrieval path** that weaponized a client-side dedup gate we removed from sources in 0.18.

The chain, each link verified against shipped code:

1. **Stale client gate** (flair-client ≤0.17 sources — still live in un-upgraded installs, and in `packages/openclaw-flair/dist` through v0.21): `memory_store` first probes `search(content, { limit: 1, minScore: 0.95, scoring: "raw" })`, maps `score: r._score ?? r.score ?? r.similarity ?? 0`, filters `score >= 0.95`, and on ANY survivor returns `{ deduplicated: true, mergedWith: <id>, written: false }` **without writing**. (`mergedWith`/`written:false` — the exact fields in the #985 report — exist only in those stale clients; the server has never emitted them.)
2. **The break** (`resources/semantic-retrieval-core.ts`, hybrid path): `fuseRrfNormalized` normalizes the candidate-union RRF value by its max — **the top-1 of ANY query scores exactly 1.0 by construction** — and that ranking value was reported as `_score`, including under `scoring: "raw"`. The repo already knew it was unusable as a confidence (`withSemSimilarity` was added for abstention for precisely this reason) but the contract itself was left broken for every existing consumer.
3. **Default-on since v0.22.0** (#659, 2026-07-08): every current server hands a stale client `_score: 1` on every probe → **every `memory_store` is suppressed into whatever memory ranks first**, however unrelated. A single shared proper noun is enough for the BM25 leg to rank an unrelated memory top-1 — which is exactly the observed merge targets (mTLS memory via one proper noun; pointer-compression memory via "memory/benchmarking").

This explains every characteristic of the report in one mechanism: 4/5 merges cross-topic (targets are BM25/RRF rank-1, not cosine neighbors); rewording and varying type/durability/tags/length "without changing the outcome" (the #526-era escape worked because raw cosine responded to rewording — a rank-pinned 1.0 does not); and delete+store destroying both copies (the re-store probe just finds a different top-1). Attempt 1 is the same mechanism where the top-1 happened to be genuinely related.

Timeline note: v0.22.0 both rebuilt the stale openclaw dist **and** activated the amplification for anyone still running an older adapter.

Other consumers broken by the same scale swap, all live on main until this PR: `minScore` (filtered on the rank value — `minScore: 0.95` matched the always-1.0 top-1 instead of meaning "similarity ≥ 0.95"), `flair doctor`'s embed-verify probe (its own comment says it reads "unweighted semantic similarity"), and composite mode's `_rawScore` field.

## The fix

**Decouple ordering from reported score.** In `retrieveCandidates()` (hybrid path):

- Results are still **ordered** by RRF fusion — via an internal `_rank` key, stripped before return. The hybrid recall win (a BM25 rank-1 rescue outranking weak semantic hits) is fully preserved; ordering is byte-identical to before.
- `_score` under `scoring: "raw"` now reports the **absolute similarity**: the true cosine (captured from the HNSW leg's `$distance`, with the singleton-`$distance` point-lookup fallback mirrored from the legacy path) plus the legacy +0.05 substring keyword bump — the same scale as the non-hybrid path, so flipping `FLAIR_HYBRID_RETRIEVAL` no longer changes what a score means.
- BM25-only candidates get a real point-lookup cosine of their stored embedding (missing/legacy embedding ⇒ 0) instead of a fabricated rank value.
- `minScore` filters on that honest scale.
- Composite mode: **ordering input and result order unchanged** (`compositeScore` still takes the RRF ranking value); only `_rawScore` — "the raw score before composite adjustments" — now reports the absolute value.
- `_semSimilarity` stays opt-in; the cosine is now captured unconditionally (it feeds `_score`), but the response field attaches only on request, so non-abstain response shapes are unchanged. One deliberate delta: under `withSemSimilarity`, BM25-only results now carry their real (low) cosine instead of no field — strictly more correct for the trust-block matchQuality bands.

**What is deliberately untouched:** the server-side dedup gate (`resources/Memory.ts` / `resources/dedup.ts`) — the #526/#548 never-suppress invariant, the cosine+Jaccard co-gate, and `memory_update` are exactly as #553 shipped them. That gate was never the loss vector: it computes its own cosine directly and no server code path can return `written: false`. This PR does not regress anything #526/#548 fixed — it removes the thing that made their *pre-fix client* catastrophic on modern servers.

## Why this shape (and not alternatives)

- Sorting hybrid results by the honest score instead would bury BM25-only rescues (score ~0) below the slice — a recall regression; recall is a floor. Order and score legitimately disagree under fusion, and now do so honestly.
- Special-casing the stale probe shape server-side is impossible (it is an ordinary 1-result raw search) and wrong — the fix is making "raw" mean raw, not detecting old clients.
- The server cannot patch stale client code; what it can do — and this does — is stop feeding a 0.95-thresholded gate a fabricated 1.0. On a fixed server a stale client's gate reverts to its original shipped behavior (fires only at genuine cosine ≥ 0.95, rewording escape works again).

## Tests

New, all passing with the fix:

- `test/unit-isolated/retrieval-score-contract-985.test.ts` (9) — SHIPPED `retrieveCandidates()` against a mocked Harper (real BM25, real fusion, faithful singleton-`$distance` omission): unrelated top-1 never ≥ 0.95; a replay of the v0.17 client gate finds nothing to suppress; `minScore` 0.95 returns empty on weak matches; a genuine near-duplicate still clears 0.95 (the criterion can fire); BM25-only rescue keeps its fused rank while reporting its honest score via a real point-lookup; composite ordering unchanged + `_rawScore` absolute; `_rank` never leaks; `_semSimilarity` stays opt-in; the singleton-corpus (delete+store death-spiral) shape reports the true cosine.
- `test/unit/dedup-985-fixture-pairs.test.ts` (8) — the #985 report's five cross-topic pair shapes as fixtures against the server co-gate's lexical criterion (pure math, no mocks): every cross-topic pair stays below the Jaccard threshold and is not a conservative match even at cosine 0.99; plus the positive control that identical content DOES flag.

**Mutation check** (fix reverted to origin/main `resources/`, new tests kept): **6/9 fail** in the score-contract file — unrelated top-1 (reports 1.0), stale-gate replay (suppresses), minScore contract, BM25 honest score, composite `_rawScore`, singleton shape — each failing exactly along the defect. The 3 that pass pre-fix are the deliberately state-invariant controls (near-dup positive control, `_rank` absence, `_semSimilarity` opt-in).

One existing fixture updated: `test/unit-isolated/semantic-search-scoping.test.ts` (flair#1245 test 2) read its 1.5× temporalBoost ratio off the rank-pinned 1.0; its record content now substring-matches both queries so the same ratio is observable on the honest scale. The #1245 invariant pins (boost-never-exclude, explicit `since` still filters) are untouched and pass.

Lanes (this branch vs origin/main baseline):

| lane | origin/main | this branch |
|---|---|---|
| unit (`test/unit/` + `test/*.test.ts`) | 4569 pass / 0 fail (243 files) | **4577 pass / 0 fail** (244 files) |
| unit-isolated (per-file, as CI runs it) | 148 pass / 0 fail | **157 pass / 0 fail** |
| integration (native Harper spawn, real embeddings) | 535 pass / 0 fail (71 files) | **535 pass / 0 fail** (71 files) |

Both columns measured locally on separate worktrees of the same host; the integration lane includes `semantic-search-singleton-score` exercising the new singleton point-lookup path against real Harper + real embeddings (observed honest cosine 0.73), and `recall-eval-gate` holding the recall floors — direct evidence the fused ordering is unregressed.

Doc corrections riding along: `resources/bm25.ts` (`fuseRrfNormalized`'s claim that minScore/floor thresholds "apply unchanged" — they applied to a different unit), `resources/abstention.ts`, and the retrieval-core header now carries the score contract.

## Residual (why Refs, not Closes)

This resolves the cross-topic silent-loss class (report attempts 2–5) at the server for every client, current or stale, and restores the `minScore`/raw-score contract for current callers. What it cannot do is fix stale client code: an un-upgraded pre-0.18 adapter still suppresses on a **genuine** cosine-0.95 near-duplicate (its original shipped behavior — attempt 1's shape, when the correction is close enough to the original). Full resolution on such installs is upgrading the adapter (the #553 client fix: never-suppress + `memory_update`). Per the existing issue comment, confirming the reporter's adapter version would close the loop.
