### PR TITLE
Hardening batch: 404-align private by-id reads, agent add --admin-pass-file, flair-client interpolation-literal guard, fail-closed snapshot tar handling

### DIFF
--- a/.changelog/unreleased/security-hardening-batch-1264-1259-1254-901-903.md
+++ b/.changelog/unreleased/security-hardening-batch-1264-1259-1254-901-903.md
@@ -1,0 +1,28 @@
+- **Hardening batch: anti-enumeration alignment, `agent add --admin-pass-file`,
+  interpolation-literal env guard in flair-client, fail-closed snapshot tar
+  handling.** Four small security/correctness fixes. (1) A cross-agent by-id
+  `GET /Memory/<id>` of a private memory used to 403 from the auth middleware
+  with an error naming the owning agent, while `Memory.get()` behind it
+  deliberately answers a generic 404 so a denied caller can't enumerate ids —
+  the middleware now returns the identical `not found` 404, so a denied private
+  read is indistinguishable from a missing id at both layers and never
+  discloses the owner (flair#1264). (2) `flair agent add` gains a real
+  `--admin-pass-file <path>` read in-process via the same owner-only-mode
+  reader `flair init` uses, so the admin password never appears in `ps` or
+  shell history; as an explicit flag it works for remote targets too, without
+  weakening the guard that keeps the ambient `FLAIR_ADMIN_PASS`/local-file
+  fallbacks from ever traveling to a remote host, and the Fabric quickstart now
+  leads with it (flair#1259). (3) `FlairClient`'s own env fallbacks
+  (`FLAIR_URL`, `FLAIR_AGENT_ID`, `FLAIR_CLIENT`, `FLAIR_ADMIN_USER`,
+  `FLAIR_ADMIN_PASSWORD`, `FLAIR_KEY_DIR`) now treat a wholesale unsubstituted
+  `${...}` interpolation literal as unset so the existing defaults apply,
+  covering every flair-client consumer at once; flair-mcp's process-boundary
+  strip stays as defense-in-depth (flair#1254). (4) Snapshot tar handling is
+  fail-closed: the containment check types its entry callback against
+  node-tar's own `ReadEntry` contract and refuses an entry whose path or link
+  target it cannot read (previously a missing property silently PASSED
+  containment), and the two restore paths that extracted with node-tar's
+  defaults — REM snapshot restore and `flair session snapshot restore`, which
+  silently dropped tampered entries and reported success — now validate the
+  whole archive first and abort a tampered restore before writing anything,
+  naming the offending entry (flair#901, flair#903).

--- a/docs/quickstart-fabric.md
+++ b/docs/quickstart-fabric.md
@@ -50,7 +50,7 @@ The target defaults to `https://<cluster>.<org>.harperfabric.com`. Override with
 
 A fleet-verify table follows. That HTTPS origin is your `FLAIR_URL`.
 
-Then set an admin password in Fabric Studio (Cluster Settings → Admin). `flair agent add` against a remote instance requires `--admin-pass` — it will not reuse `~/.flair/admin-pass` or `FLAIR_ADMIN_PASS` from your laptop.
+Then set an admin password in Fabric Studio (Cluster Settings → Admin). `flair agent add` against a remote instance requires an explicit `--admin-pass-file` or `--admin-pass` — it will not reuse `~/.flair/admin-pass` or `FLAIR_ADMIN_PASS` from your laptop.
 
 ## 3. Register an agent against the remote instance
 
@@ -61,11 +61,14 @@ On Fabric, ops lives on the **same hostname at port 9925**, not the CLI's defaul
 ```bash
 export FLAIR_URL=https://<cluster>.<org>.harperfabric.com
 
+# Keep the Fabric admin password in an owner-only file; the CLI reads it in-process.
+printf '%s\n' '<fabric-admin-password>' > ~/.flair/fabric-admin-pass && chmod 600 ~/.flair/fabric-admin-pass
+
 # Fabric ops is :9925 on the same host, not derived :442. docs-freshness-allow: Fabric ops API
-flair agent add mybot --target "$FLAIR_URL" --ops-target https://<cluster>.<org>.harperfabric.com:9925 --admin-pass <fabric-admin-password>
+flair agent add mybot --target "$FLAIR_URL" --ops-target https://<cluster>.<org>.harperfabric.com:9925 --admin-pass-file ~/.flair/fabric-admin-pass
 ```
 
-Same hygiene rule as step 0: an inline password lands in shell history and `ps`. Remote `agent add` honors **only** the explicit `--admin-pass` flag by design — `FLAIR_ADMIN_PASS` and `~/.flair/admin-pass` are this machine's *local* credentials and are never reused against a remote target — so keep the Fabric password in a mode-`0600` file and expand it at call time: `--admin-pass "$(cat <path>)"` stays out of shell history (the expanded value is still visible to local `ps` while the command runs).
+`--admin-pass-file` reads the file inside the CLI process (mode `0600` enforced), so the password never appears in shell history **or** `ps`. Inline `--admin-pass <pass>` still works but lands in both; the older `--admin-pass "$(cat <path>)"` workaround stays out of history but is still visible to local `ps` while the command runs. Remote `agent add` honors **only** an explicit flag by design — `FLAIR_ADMIN_PASS` and `~/.flair/admin-pass` are this machine's *local* credentials and are never reused against a remote target.
 
 ```
 Keypair written: ~/.flair/keys/mybot.key

--- a/packages/flair-client/src/auth.ts
+++ b/packages/flair-client/src/auth.ts
@@ -9,6 +9,7 @@ import { randomUUID, sign as ed25519Sign, createPrivateKey, type KeyObject } fro
 import { readFileSync, existsSync } from "node:fs";
 import { resolve } from "node:path";
 import { homedir } from "node:os";
+import { readEnvOrUnset } from "./env-guard.js";
 
 const PKCS8_ED25519_PREFIX = Buffer.from("302e020100300506032b657004220420", "hex");
 
@@ -29,8 +30,12 @@ export function resolveKeyPath(agentId: string, keyPath?: string): string | null
     const resolved = resolve(keyPath.replace(/^~/, homedir()));
     return existsSync(resolved) ? resolved : null;
   }
+  // flair#1254: an unsubstituted `${FLAIR_KEY_DIR}` literal reads as unset, so
+  // key resolution falls through to the standard locations below instead of
+  // probing a directory literally named "${FLAIR_KEY_DIR}".
+  const keyDir = readEnvOrUnset("FLAIR_KEY_DIR");
   const candidates = [
-    process.env.FLAIR_KEY_DIR ? resolve(process.env.FLAIR_KEY_DIR, `${agentId}.key`) : null,
+    keyDir ? resolve(keyDir, `${agentId}.key`) : null,
     resolve(homedir(), ".flair", "keys", `${agentId}.key`),
     resolve(homedir(), ".tps", "secrets", "flair", `${agentId}-priv.key`),
   ].filter(Boolean) as string[];

--- a/packages/flair-client/src/client.ts
+++ b/packages/flair-client/src/client.ts
@@ -11,6 +11,7 @@
 import type { KeyObject } from "node:crypto";
 import { createHash, createPrivateKey } from "node:crypto";
 import { loadPrivateKey, resolveKeyPath, signRequest } from "./auth.js";
+import { readEnvOrUnset } from "./env-guard.js";
 import type {
   FlairClientConfig,
   Memory,
@@ -45,17 +46,22 @@ export class FlairClient {
   private basicAuth: string | null = null;
 
   constructor(config: FlairClientConfig) {
-    this.url = (config.url ?? process.env.FLAIR_URL ?? DEFAULT_URL).replace(/\/$/, "");
-    this.agentId = config.agentId || process.env.FLAIR_AGENT_ID || "";
+    // Every env fallback below goes through readEnvOrUnset (flair#1254): a
+    // wholesale unsubstituted `${...}` interpolation literal — the shape an
+    // MCP-host config template leaves behind when it fails to substitute —
+    // reads as UNSET, so the existing defaults apply instead of the literal
+    // winning the `??`/`||` chain and poisoning the connection.
+    this.url = (config.url ?? readEnvOrUnset("FLAIR_URL") ?? DEFAULT_URL).replace(/\/$/, "");
+    this.agentId = config.agentId || readEnvOrUnset("FLAIR_AGENT_ID") || "";
     this.keyPath = config.keyPath;
     if (config.privateKey !== undefined) {
       this.rawPrivateKey = config.privateKey;
     }
-    this.claimedClient = config.claimedClient || process.env.FLAIR_CLIENT || undefined;
+    this.claimedClient = config.claimedClient || readEnvOrUnset("FLAIR_CLIENT") || undefined;
     this.timeoutMs = config.timeoutMs ?? DEFAULT_TIMEOUT;
     // Basic auth fallback for standalone deployments without Ed25519 keys
-    const adminUser = config.adminUser ?? process.env.FLAIR_ADMIN_USER;
-    const adminPass = config.adminPassword ?? process.env.FLAIR_ADMIN_PASSWORD;
+    const adminUser = config.adminUser ?? readEnvOrUnset("FLAIR_ADMIN_USER");
+    const adminPass = config.adminPassword ?? readEnvOrUnset("FLAIR_ADMIN_PASSWORD");
     if (adminUser && adminPass) {
       this.basicAuth = `Basic ${Buffer.from(`${adminUser}:${adminPass}`).toString("base64")}`;
     }

--- a/packages/flair-client/src/env-guard.ts
+++ b/packages/flair-client/src/env-guard.ts
@@ -1,0 +1,52 @@
+/**
+ * Interpolation-literal env guard (flair#1254, generalizing flair#1250/#1253).
+ *
+ * An MCP/agent host config template often forwards env like
+ *   "env": { "FLAIR_URL": "${FLAIR_URL}" }
+ * expecting the host to substitute `${FLAIR_URL}` with the real value. When
+ * the variable is unset and the host does NOT substitute, the consumer process
+ * is handed the LITERAL string `"${FLAIR_URL}"`. That literal is truthy, so it
+ * wins every `value ?? default` / `value || default` chain and the sensible
+ * default never applies — the connection then fails pointing nowhere near the
+ * real cause.
+ *
+ * flair#1253 stripped such literals at flair-mcp's process boundary, but the
+ * root exposure is HERE: FlairClient's constructor independently re-reads
+ * `process.env.FLAIR_*` as its own fallback, so every consumer of this client
+ * (CLI, adk, langgraph, n8n, ...) had the identical exposure and would each
+ * have needed its own boundary strip. This guard makes the client's own env
+ * fallbacks treat a wholesale `${...}` literal as absent, so the existing
+ * defaults (DEFAULT_URL, key-path derivation, no-basic-auth) apply instead —
+ * no new hardcoded defaults are introduced. flair-mcp's boundary strip stays
+ * as defense-in-depth.
+ *
+ * Semantics intentionally identical to packages/flair-mcp/src/env-guard.ts.
+ * Duplicated (not imported) because the dependency points the other way:
+ * flair-mcp depends on flair-client, and flair-client is zero-dep.
+ */
+
+/**
+ * True iff `value` is an unsubstituted interpolation literal like `${FLAIR_URL}`
+ * — i.e. the whole (trimmed) value is a single `${...}` placeholder the host
+ * never expanded. A value that merely CONTAINS a `${...}` (e.g. a real URL with
+ * a fragment) is left alone: only a wholesale placeholder is treated as unset.
+ */
+export function isUnsubstitutedInterpolation(value: string): boolean {
+  return /^\$\{.*\}$/.test(value.trim());
+}
+
+/**
+ * Read an env var, treating an unsubstituted `${...}` interpolation literal as
+ * unset: returns `undefined` for such a literal (and for a genuinely absent
+ * var) so a downstream default applies instead of the literal being used
+ * verbatim. A real value is returned unchanged (NOT trimmed — only the
+ * placeholder check trims).
+ */
+export function readEnvOrUnset(
+  name: string,
+  env: NodeJS.ProcessEnv = process.env,
+): string | undefined {
+  const v = env[name];
+  if (v === undefined) return undefined;
+  return isUnsubstitutedInterpolation(v) ? undefined : v;
+}

--- a/packages/flair-client/test/client.test.ts
+++ b/packages/flair-client/test/client.test.ts
@@ -1,4 +1,4 @@
-import { describe, test, expect, mock, beforeEach, spyOn } from "bun:test";
+import { describe, test, expect, mock, beforeEach, afterEach, spyOn } from "bun:test";
 
 // Mock fetch globally
 const originalFetch = globalThis.fetch;
@@ -66,6 +66,97 @@ describe("FlairClient", () => {
       const client = new FlairClient({ agentId: "test", claimedClient: "gemini" });
       expect(client.claimedClient).toBe("gemini");
       delete process.env.FLAIR_CLIENT;
+    });
+  });
+
+  // ─── flair#1254 — unsubstituted ${...} literals in the client's OWN env
+  // fallbacks read as unset, so the existing defaults apply. Mirrors
+  // flair-mcp's #1253 boundary strip, one layer down where every consumer
+  // (CLI, adk, langgraph, n8n, ...) is covered at once.
+  describe("interpolation-literal env fallbacks (flair#1254)", () => {
+    const SAVED: Record<string, string | undefined> = {};
+    const VARS = ["FLAIR_URL", "FLAIR_AGENT_ID", "FLAIR_CLIENT", "FLAIR_ADMIN_USER", "FLAIR_ADMIN_PASSWORD"];
+    beforeEach(() => {
+      for (const v of VARS) { SAVED[v] = process.env[v]; delete process.env[v]; }
+    });
+    afterEach(() => {
+      for (const v of VARS) {
+        if (SAVED[v] === undefined) delete process.env[v];
+        else process.env[v] = SAVED[v]!;
+      }
+    });
+
+    test("positive control (#1253 mirror): url undefined + literal ${FLAIR_URL} in env resolves to DEFAULT_URL, not the literal", () => {
+      process.env.FLAIR_URL = "${FLAIR_URL}";
+      const client = new FlairClient({ url: undefined, agentId: "test" });
+      expect(client.url).toBe("http://localhost:19926");
+      expect(client.url).not.toContain("${");
+    });
+
+    test("a real FLAIR_URL env value still wins over the default (guard is literal-shaped only)", () => {
+      process.env.FLAIR_URL = "http://real-host:5555";
+      const client = new FlairClient({ agentId: "test" });
+      expect(client.url).toBe("http://real-host:5555");
+    });
+
+    test("an explicit config.url beats even a literal-free env (no behavior change)", () => {
+      process.env.FLAIR_URL = "${FLAIR_URL}";
+      const client = new FlairClient({ agentId: "test", url: "http://explicit:1234" });
+      expect(client.url).toBe("http://explicit:1234");
+    });
+
+    test("literal ${FLAIR_AGENT_ID} reads as unset — agentId falls back to empty, not the literal", () => {
+      process.env.FLAIR_AGENT_ID = "${FLAIR_AGENT_ID}";
+      const client = new FlairClient({});
+      expect(client.agentId).toBe("");
+    });
+
+    test("literal ${FLAIR_CLIENT} reads as unset — claimedClient stays undefined", () => {
+      process.env.FLAIR_CLIENT = "${FLAIR_CLIENT}";
+      const client = new FlairClient({ agentId: "test" });
+      expect(client.claimedClient).toBeUndefined();
+    });
+
+    test("literal ${FLAIR_ADMIN_USER}/${FLAIR_ADMIN_PASSWORD} read as unset — no basic-auth header is manufactured from placeholders", () => {
+      process.env.FLAIR_ADMIN_USER = "${FLAIR_ADMIN_USER}";
+      process.env.FLAIR_ADMIN_PASSWORD = "${FLAIR_ADMIN_PASSWORD}";
+      const client = new FlairClient({ agentId: "test" });
+      expect((client as any).basicAuth).toBeNull();
+    });
+
+    test("real admin env values still produce basic auth (guard does not over-fire)", () => {
+      process.env.FLAIR_ADMIN_USER = "admin";
+      process.env.FLAIR_ADMIN_PASSWORD = "s3cret";
+      const client = new FlairClient({ agentId: "test" });
+      expect((client as any).basicAuth).toStartWith("Basic ");
+    });
+
+    test("literal ${FLAIR_KEY_DIR} reads as unset — key resolution never probes a directory literally named ${FLAIR_KEY_DIR}", () => {
+      const { mkdtempSync, mkdirSync, writeFileSync, rmSync } = require("node:fs") as typeof import("node:fs");
+      const { join } = require("node:path") as typeof import("node:path");
+      const { tmpdir } = require("node:os") as typeof import("node:os");
+      const savedKeyDir = process.env.FLAIR_KEY_DIR;
+      const savedCwd = process.cwd();
+      const root = mkdtempSync(join(tmpdir(), "flair-client-keydir-1254-"));
+      try {
+        // A directory LITERALLY named "${FLAIR_KEY_DIR}" relative to cwd — the
+        // path the unguarded fallback would resolve and find.
+        const literalDir = join(root, "${FLAIR_KEY_DIR}");
+        mkdirSync(literalDir, { recursive: true });
+        writeFileSync(join(literalDir, "keydir-1254-agent.key"), "not-a-real-key\n");
+        process.chdir(root);
+        process.env.FLAIR_KEY_DIR = "${FLAIR_KEY_DIR}";
+        const found = authMod.resolveKeyPath("keydir-1254-agent");
+        // Guarded: the literal reads as unset, the standard locations don't
+        // have this agent, so resolution finds nothing — instead of returning
+        // the planted file under the literal-named directory.
+        expect(found).toBeNull();
+      } finally {
+        process.chdir(savedCwd);
+        if (savedKeyDir === undefined) delete process.env.FLAIR_KEY_DIR;
+        else process.env.FLAIR_KEY_DIR = savedKeyDir;
+        rmSync(root, { recursive: true, force: true });
+      }
     });
   });
 });

--- a/packages/flair-mcp/src/env-guard.ts
+++ b/packages/flair-mcp/src/env-guard.ts
@@ -43,10 +43,13 @@ export function readEnvOrUnset(
 /**
  * Connection env vars that flair-client's OWN constructor reads straight from
  * `process.env` as a fallback (see flair-client/src/client.ts:
- * `this.url = config.url ?? process.env.FLAIR_URL ?? DEFAULT_URL`). For these,
- * skipping the literal only at flair-mcp's call site is NOT enough: flair-client
- * re-reads `process.env` and resurrects the `${...}` literal, defeating its own
- * default. Such a literal has to be removed from the process env itself.
+ * `this.url = config.url ?? readEnvOrUnset("FLAIR_URL") ?? DEFAULT_URL`). For
+ * these, skipping the literal only at flair-mcp's call site was NOT enough:
+ * flair-client re-read `process.env` and resurrected the `${...}` literal,
+ * defeating its own default. As of flair#1254 flair-client's env fallbacks
+ * apply this same literal-as-unset guard themselves, so the strip below is
+ * defense-in-depth rather than the only line — kept deliberately (an older
+ * flair-client on a consumer's disk does not have #1254).
  *
  * Only FLAIR_URL qualifies today: it is re-read by flair-client AND flair-mcp
  * still constructs a client when it is a literal. FLAIR_AGENT_ID is also re-read

--- a/resources/auth-middleware.ts
+++ b/resources/auth-middleware.ts
@@ -4,6 +4,7 @@ import { getEmbedding } from "./embeddings-provider.js";
 import { isAdmin, isPrincipalDeactivated, FLAIR_AGENT_USERNAME } from "./agent-auth.js";
 import { WINDOW_MS, isNonceReplay, recordNonce, importEd25519Key, b64ToArrayBuffer, parseTpsEd25519Header } from "./ed25519-auth.js";
 import { resolveReadScope } from "./memory-read-scope.js";
+import { NOT_FOUND } from "./record-type-kit.js";
 import { isForbiddenOwnerMutation, resolveGuardedRecord } from "./record-owner-guard.js";
 import { checkHttpRateLimit } from "./rate-limit.js";
 
@@ -659,11 +660,18 @@ server.http(async (request: any, nextLayer: any) => {
             // used to be a `visibility === "office"` bypass (any authenticated
             // agent, no grant needed) — that's gone; the private-exclusion is
             // now enforced the same way every other read path enforces it.
+            //
+            // Denial is the SAME 404 the resource layer returns (flair#1264):
+            // Memory.get() deliberately answers NOT_FOUND for a cross-agent
+            // private id so a denied caller can't distinguish "doesn't exist"
+            // from "exists but not yours" — a 403 here, worse yet one naming
+            // the owning agent, confirmed the id exists AND disclosed its
+            // owner, defeating that anti-enumeration contract one layer up.
+            // Reuses record-type-kit's NOT_FOUND so the two layers cannot
+            // drift apart in shape.
             const scope = await resolveReadScope(agentId);
             if (!scope.isAllowed(record)) {
-              return new Response(JSON.stringify({
-                error: `forbidden: cannot read memory owned by ${record.agentId}`,
-              }), { status: 403, headers: { "Content-Type": "application/json" } });
+              return NOT_FOUND();
             }
           }
         }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -26,6 +26,9 @@ import { spawn, execFileSync, spawnSync, execSync } from "node:child_process";
 import { createRequire } from "node:module";
 import { createHash, randomUUID, randomBytes } from "node:crypto";
 import { create as tarCreate, extract as tarExtract, list as tarList } from "tar";
+// flair#901 — tar listings/extracts type their entry callbacks against
+// node-tar's own export so an upstream property rename fails compilation.
+import type { ReadEntry as TarReadEntry } from "tar";
 import { keystore } from "./keystore.js";
 import { deploy as deployToFabric, validateOptions as validateDeployOptions, buildTargetUrl as buildDeployUrl, resolveDeployPublicUrl } from "./deploy.js";
 import {
@@ -4164,6 +4167,7 @@ agent
   .option("--name <name>", "Display name (defaults to id)")
   .option("--port <port>", "Harper HTTP port")
   .option("--admin-pass <pass>", "Admin password for registration")
+  .option("--admin-pass-file <path>", "Read the admin password from a file (chmod 600 enforced). Preferred over inline --admin-pass — keeps the secret out of ps and shell history; works for remote targets too (an explicit flag is operator intent).")
   .option("--keys-dir <dir>", "Directory for Ed25519 keys")
   .option("--ops-port <port>", "Harper operations API port")
   .option("--target <url>", "Remote Flair REST URL; derives the ops API URL (port-1) to seed the Agent there (env: FLAIR_TARGET)")
@@ -4182,6 +4186,22 @@ agent
       resolveEffectiveOpsUrl({ target: opts.target, opsTarget: opts.opsTarget }) ?? opsPort;
     const isRemoteTarget = typeof seedOpsTarget === "string";
 
+    // flair#1259 — --admin-pass-file resolves into the same explicit slot the
+    // inline flag uses (same shape as `flair federation sync`), read in-process
+    // via readAdminPassFileSecure so the secret never appears in ps or shell
+    // history. This does NOT weaken the #1085 remote guard below: an explicit
+    // flag naming a file IS operator intent toward this target, exactly like an
+    // explicit inline --admin-pass — what the guard blocks is the AMBIENT
+    // env/local-file fallbacks silently traveling to a third-party host.
+    if (!opts.adminPass && opts.adminPassFile) {
+      try {
+        opts.adminPass = readAdminPassFileSecure(opts.adminPassFile);
+      } catch (err: any) {
+        console.error(`Error reading --admin-pass-file ${opts.adminPassFile}: ${err.message}`);
+        process.exit(1);
+      }
+    }
+
     // #590 — local convenience fallback: FLAIR_ADMIN_PASS env, then the secure
     // ~/.flair/admin-pass file `flair init` already writes (mode 0600). Never
     // applied for a remote target — see resolveLocalAdminPass.
@@ -4196,13 +4216,14 @@ agent
     if (!adminPass) {
       if (isRemoteTarget) {
         console.error(
-          "Error: --admin-pass is required for agent add when targeting a remote instance " +
-          "(--target/--ops-target) — the local ~/.flair/admin-pass fallback is not used for remote targets."
+          "Error: --admin-pass <pass> or --admin-pass-file <path> is required for agent add when targeting " +
+          "a remote instance (--target/--ops-target) — the local ~/.flair/admin-pass and FLAIR_ADMIN_PASS " +
+          "fallbacks are never used for remote targets. Prefer --admin-pass-file: it keeps the secret out of ps."
         );
       } else {
         console.error(
-          "Error: --admin-pass is required for agent add (needed to insert into Agent table). " +
-          "Set FLAIR_ADMIN_PASS, or make sure ~/.flair/admin-pass exists (created by `flair init`)."
+          "Error: --admin-pass <pass> or --admin-pass-file <path> is required for agent add (needed to insert " +
+          "into Agent table). Set FLAIR_ADMIN_PASS, or make sure ~/.flair/admin-pass exists (created by `flair init`)."
         );
       }
       process.exit(1);
@@ -15159,7 +15180,7 @@ sessionSnapshot
     if (opts.dryRun) {
       console.log("(dry-run) snapshot contents:");
       const entries: string[] = [];
-      await tarList({ file: snapshotPath, onReadEntry: (entry: any) => entries.push(`  ${entry.path}  (${humanBytes(entry.size ?? 0)})`) });
+      await tarList({ file: snapshotPath, onReadEntry: (entry: TarReadEntry) => entries.push(`  ${entry.path}  (${humanBytes(entry.size ?? 0)})`) });
       for (const e of entries) console.log(e);
       return;
     }
@@ -15172,18 +15193,25 @@ sessionSnapshot
       console.error(`  Pass --target <new-path> or remove the existing dir.`);
       process.exit(1);
     }
+    // flair#903 — fail CLOSED on a tampered archive. node-tar's defaults below
+    // do contain malicious entries (leading "/" stripped, ".." entries
+    // dropped, no writing through a symlink — verified on the pinned tar
+    // against all four vectors), but they discard those entries SILENTLY: the
+    // restore printed the target dir as a plain success minus the parts it
+    // never mentioned. Validation runs BEFORE the target directory is even
+    // created — a tampered snapshot aborts the whole restore, names the
+    // offending entry, and writes nothing (same posture as the data-dir
+    // restore's extractSnapshotSafely). The default extract flags stay as
+    // containment defense-in-depth — deliberately NOT preservePaths; if that
+    // flag is ever added here, this call MUST move to extractSnapshotSafely.
+    // See src/lib/safe-snapshot-extract.ts.
+    try {
+      await validateSnapshotArchive({ file: snapshotPath, targetDir });
+    } catch (err: any) {
+      console.error(`Error: ${err.message}`);
+      process.exit(1);
+    }
     mkdirSync(targetDir, { recursive: true, mode: 0o700 });
-    // Deliberately NOT preservePaths, and deliberately NOT routed through
-    // extractSnapshotSafely. --snapshot is an operator-supplied path, so
-    // provenance here is no more controlled than the data-dir restore's — the
-    // difference is the flag, not the trust. node-tar's defaults keep their
-    // own containment: leading "/" stripped from entry paths, ".." entries
-    // dropped, and no writing through a symlink (including one created
-    // earlier in the same archive). Verified against the pinned tar (7.5.20)
-    // on all four cases, each contained, with a benign control entry landing
-    // to prove the archives parsed. Add `preservePaths` here and that
-    // containment disappears — this call would then need extractSnapshotSafely,
-    // exactly as the data-dir restore does. See src/lib/safe-snapshot-extract.ts.
     await tarExtract({ file: snapshotPath, cwd: targetDir });
     console.log(targetDir);
     console.error(`  extracted to: ${targetDir}`);

--- a/src/lib/safe-snapshot-extract.ts
+++ b/src/lib/safe-snapshot-extract.ts
@@ -29,6 +29,14 @@
 import { existsSync, realpathSync } from "node:fs";
 import { dirname, isAbsolute, resolve, sep } from "node:path";
 import { extract as tarExtract, list as tarList } from "tar";
+// flair#901 — the entry contract is TYPED against node-tar's own export, so a
+// property rename in a future tar release fails at COMPILE time. That is the
+// only place a rename can be caught: at runtime the defensive coercions below
+// would quietly turn a renamed property into ""/undefined, and this file's
+// whole job is to decide from those very properties. The runtime shape checks
+// in checkSnapshotEntry are the belt to this type's suspenders — they fail
+// CLOSED on an entry whose properties don't carry what the contract promises.
+import type { ReadEntry } from "tar";
 
 /** Thrown when a snapshot entry would resolve outside the target directory. */
 export class SnapshotPathEscapeError extends Error {
@@ -80,6 +88,18 @@ export function checkSnapshotEntry(
   linkpath: string | undefined,
   resolvedTargetDir: string,
 ): { ok: true } | { ok: false; reason: string } {
+  // flair#901 fail-closed shape checks: an entry this check cannot READ is an
+  // entry it must not PASS. An empty path used to resolve to the target dir
+  // itself (inside, so ok), and a link entry with no linkpath skipped the
+  // link branches entirely — both silently approved exactly when the input
+  // was least trustworthy (tampered archive, or an upstream property rename
+  // surviving to runtime).
+  if (!entryPath) {
+    return { ok: false, reason: "entry has an empty or unreadable path — refusing an entry this check cannot classify" };
+  }
+  if ((type === "Link" || type === "SymbolicLink") && !linkpath) {
+    return { ok: false, reason: `${type === "Link" ? "hard link" : "symlink"} "${entryPath}" has no readable link target — refusing an entry this check cannot classify` };
+  }
   if (looksAbsolute(entryPath)) {
     return { ok: false, reason: `entry has an absolute path ("${entryPath}"), which would write outside the target directory` };
   }
@@ -170,11 +190,17 @@ export async function validateSnapshotArchive(opts: {
   const violations: Array<{ entryPath: string; reason: string }> = [];
   await tarList({
     file: opts.file,
-    onReadEntry: (entry: any) => {
+    // Typed against tar's ReadEntry (flair#901) — a property rename upstream
+    // now fails compilation instead of coercing to ""/undefined at runtime.
+    // The coercions below remain as the runtime belt, and they no longer
+    // default to safe: checkSnapshotEntry refuses an empty path and a
+    // link-typed entry with no link target.
+    onReadEntry: (entry: ReadEntry) => {
+      const entryPath = typeof entry.path === "string" ? entry.path : "";
       const verdict = checkSnapshotEntry(
-        String(entry.path ?? ""),
+        entryPath,
         entry.type,
-        entry.linkpath ? String(entry.linkpath) : undefined,
+        typeof entry.linkpath === "string" && entry.linkpath !== "" ? entry.linkpath : undefined,
         resolvedTargetDir,
       );
       // `verdict.ok === false` rather than `!verdict.ok`: an explicit
@@ -182,7 +208,7 @@ export async function validateSnapshotArchive(opts: {
       // to its failure member, so `reason` is known to exist here. The union
       // is deliberately shaped so a caller cannot read a reason off a success.
       if (verdict.ok === false) {
-        violations.push({ entryPath: String(entry.path ?? ""), reason: verdict.reason });
+        violations.push({ entryPath, reason: verdict.reason });
       }
     },
   });

--- a/src/rem/snapshot.ts
+++ b/src/rem/snapshot.ts
@@ -20,6 +20,8 @@ import { mkdirSync, writeFileSync, statSync, chmodSync, rmSync, existsSync, read
 import { resolve } from "node:path";
 import { homedir } from "node:os";
 import { create as tarCreate, extract as tarExtract, list as tarList } from "tar";
+import type { ReadEntry } from "tar";
+import { validateSnapshotArchive } from "../lib/safe-snapshot-extract.js";
 
 export const SNAPSHOT_ROOT = resolve(homedir(), ".flair", "snapshots");
 
@@ -202,7 +204,7 @@ export async function extractSnapshot(opts: ExtractOpts): Promise<ExtractResult>
   const entries: ExtractEntry[] = [];
   await tarList({
     file: opts.snapshotPath,
-    onReadEntry: (e: any) => entries.push({ path: e.path, size: e.size ?? 0 }),
+    onReadEntry: (e: ReadEntry) => entries.push({ path: e.path, size: e.size ?? 0 }),
   });
 
   if (opts.dryRun) {
@@ -213,20 +215,20 @@ export async function extractSnapshot(opts: ExtractOpts): Promise<ExtractResult>
   if (existsSync(targetDir)) {
     throw new Error(`target directory already exists: ${targetDir}`);
   }
+  // flair#903 — fail CLOSED on a tampered archive. node-tar's defaults below
+  // do contain malicious entries (leading "/" stripped, ".." entries dropped,
+  // no writing through symlinks — verified on the pinned tar against all four
+  // vectors), but they discard those entries SILENTLY: the restore reported
+  // success minus the parts it never mentioned, and the operator held a
+  // partial restore they believed was complete. Validation runs BEFORE the
+  // target directory is even created: a tampered snapshot aborts the whole
+  // restore, names the offending entry, and writes nothing (same posture as
+  // the data-dir restore's extractSnapshotSafely). The default extract flags
+  // are kept as containment defense-in-depth — deliberately NOT
+  // preservePaths; if that flag is ever added here, this call MUST move to
+  // extractSnapshotSafely (see src/lib/safe-snapshot-extract.ts).
+  await validateSnapshotArchive({ file: opts.snapshotPath, targetDir });
   mkdirSync(targetDir, { recursive: true, mode: 0o700 });
-  // Deliberately NOT preservePaths, and deliberately NOT routed through
-  // src/lib/safe-snapshot-extract.ts. The snapshot path comes from the
-  // operator, so provenance here is no more controlled than the data-dir
-  // restore's — the difference is the flag, not the trust. With node-tar's
-  // defaults its own containment applies: it strips a leading "/" from entry
-  // paths, drops ".." entries, and refuses to write through a symlink,
-  // including one created earlier in the same archive. Verified against the
-  // pinned tar (7.5.20) on all four cases — absolute path, ".." traversal,
-  // in-archive symlink, pre-existing symlink in the target — each contained,
-  // with a benign control entry landing to prove the archives were valid.
-  // If `preservePaths` is ever added here, that containment is gone and this
-  // call MUST move to extractSnapshotSafely, which is why the data-dir
-  // restore needs the wrapper and this does not.
   await tarExtract({ file: opts.snapshotPath, cwd: targetDir });
 
   return { targetDir, entries };

--- a/test/data-scoping.test.ts
+++ b/test/data-scoping.test.ts
@@ -21,9 +21,9 @@ function checkAgentScope(
 }
 
 /**
- * Returns 403 message if agent tries to read another agent's PRIVATE memory,
- * null otherwise (within-org-read-open — mirrors resources/memory-read-
- * scope.ts's resolveReadScope().isAllowed()). Originally (the original
+ * Returns the denial message if agent tries to read another agent's PRIVATE
+ * memory, null otherwise (within-org-read-open — mirrors resources/memory-
+ * read-scope.ts's resolveReadScope().isAllowed()). Originally (the original
  * grant-gated read model) this also required a MemoryGrant for any
  * cross-agent read of a non-private memory; that grant gate is GONE now —
  * see resources/memory-read-scope.ts's module doc for the full model
@@ -34,7 +34,14 @@ function checkAgentScope(
  * office-visibility read leak — that was an accidental leak fixed by the
  * grant-gated model; this is a deliberate, later design decision that
  * supersedes the grant gate itself.)
+ *
+ * flair#1264: the denial is the SAME generic "not found" the resource layer
+ * (Memory.get()) answers — 404, never a 403 naming the owner. A denied
+ * caller must not be able to distinguish "doesn't exist" from "exists but
+ * not yours", and must never learn who owns the id it probed.
  */
+const MEMORY_READ_DENIAL = "not found";
+
 function checkMemoryReadScope(
   authenticatedAgent: string,
   memoryOwner: string,
@@ -43,7 +50,7 @@ function checkMemoryReadScope(
 ): string | null {
   if (isAdmin) return null;
   if (memoryOwner === authenticatedAgent) return null;
-  if (memoryVisibility === "private") return `forbidden: cannot read memory owned by ${memoryOwner}`;
+  if (memoryVisibility === "private") return MEMORY_READ_DENIAL;
   return null;
 }
 
@@ -102,7 +109,10 @@ describe("checkMemoryReadScope (Memory GET by ID)", () => {
   it("blocks reading another agent's PRIVATE memory — the ONE remaining private-exclusion invariant", () => {
     const err = checkMemoryReadScope("anvil", "flint", "private", false);
     expect(err).not.toBeNull();
-    expect(err).toContain("flint");
+    // flair#1264 anti-enumeration: the denial is a generic not-found — it
+    // must never name the owning agent or otherwise confirm the id exists.
+    expect(err).toBe(MEMORY_READ_DENIAL);
+    expect(err).not.toContain("flint");
   });
 
   it("within-org-read-open: another agent's 'standard'-durability memory (no visibility field) is readable too — durability only affects the WRITE-time default, not read scoping", () => {
@@ -118,7 +128,8 @@ describe("checkMemoryReadScope (Memory GET by ID)", () => {
     expect(checkMemoryReadScope("kern", "sherlock", undefined, false)).toBeNull();
     const err = checkMemoryReadScope("kern", "sherlock", "private", false);
     expect(err).not.toBeNull();
-    expect(err).toContain("sherlock");
+    // flair#1264: denial never discloses the owner.
+    expect(err).not.toContain("sherlock");
   });
 });
 

--- a/test/integration/memory-visibility-scoping-e2e.test.ts
+++ b/test/integration/memory-visibility-scoping-e2e.test.ts
@@ -127,11 +127,24 @@ describe("within-org-read-open — private/shared visibility + centralized read-
       expect(res.status).toBe(200);
     }, 30_000);
 
-    test("private-exclusion: grantee's GET of the PRIVATE memory is denied (never 200)", async () => {
+    test("private-exclusion: grantee's GET of the PRIVATE memory is denied as a generic 404 — no content, no owner, no existence confirmation (flair#1264)", async () => {
       const res = await authFetch(harper, grantee, "GET", `/Memory/${idPrivate}`);
-      expect([403, 404], `grantee GET private → ${res.status} (expected denied)`).toContain(res.status);
+      // flair#1264: exactly 404, matching the resource layer's anti-enumeration
+      // contract. A 403 here confirmed the id exists; the middleware's old
+      // message additionally named the owning agent.
+      expect(res.status, `grantee GET private → ${res.status} (expected 404)`).toBe(404);
       const text = await res.text();
       expect(text).not.toContain("explicitly private note");
+      expect(text).not.toContain(owner.id);
+      expect(text.toLowerCase()).not.toContain("forbidden");
+    }, 30_000);
+
+    test("cross-agent private GET is indistinguishable from a genuinely missing id (flair#1264)", async () => {
+      const denied = await authFetch(harper, grantee, "GET", `/Memory/${idPrivate}`);
+      const missing = await authFetch(harper, grantee, "GET", `/Memory/vis-owner-does-not-exist`);
+      expect(denied.status, `denied → ${denied.status}, missing → ${missing.status}`).toBe(missing.status);
+      // Same body shape, too — status parity alone still leaks if the bodies differ.
+      expect(await denied.text()).toBe(await missing.text());
     }, 30_000);
 
     test("within-org-read-open: stranger (no grant at all) CAN GET the legacy + shared memories — only the PRIVATE one is denied", async () => {
@@ -140,7 +153,8 @@ describe("within-org-read-open — private/shared visibility + centralized read-
         expect(res.status, `stranger GET ${id} → ${res.status} (expected 200 — no grant needed)`).toBe(200);
       }
       const privRes = await authFetch(harper, stranger, "GET", `/Memory/${idPrivate}`);
-      expect([403, 404], `stranger GET private → ${privRes.status} (expected denied)`).toContain(privRes.status);
+      expect(privRes.status, `stranger GET private → ${privRes.status} (expected 404, flair#1264)`).toBe(404);
+      expect(await privRes.text()).not.toContain(owner.id);
     }, 30_000);
   });
 

--- a/test/unit/agent-add-adminpass-fallback.test.ts
+++ b/test/unit/agent-add-adminpass-fallback.test.ts
@@ -141,6 +141,11 @@ describe("agent add / principal add — command wiring (#590)", () => {
     expect(hasOption(add, "--ops-target")).toBe(true);
   });
 
+  test("agent add has a real --admin-pass-file option (flair#1259 — read in-process, out of ps)", () => {
+    const add = findSubcommand("agent", "add");
+    expect(hasOption(add, "--admin-pass-file")).toBe(true);
+  });
+
   test("principal add still requires --admin-pass as an explicit option (flag not removed)", () => {
     const add = findSubcommand("principal", "add");
     expect(add).not.toBeUndefined();
@@ -203,7 +208,7 @@ describe("flair agent add / principal add — subprocess error paths (#590)", ()
       { HOME: tmpHome, FLAIR_ADMIN_PASS: undefined },
     );
     expect(exitCode).not.toBe(0);
-    expect(stderr).toContain("--admin-pass is required for agent add");
+    expect(stderr).toContain("is required for agent add");
   });
 
   test("agent add with FLAIR_ADMIN_PASS env set but bad Harper connection still gets past admin-pass resolution (does not error on missing --admin-pass)", async () => {
@@ -215,7 +220,7 @@ describe("flair agent add / principal add — subprocess error paths (#590)", ()
       ["agent", "add", "test-agent-590-env", "--port", "39999"],
       { HOME: tmpHome, FLAIR_ADMIN_PASS: "env-secret-pass" },
     );
-    expect(stderr).not.toContain("--admin-pass is required for agent add");
+    expect(stderr).not.toContain("is required for agent add");
   });
 
   test("agent add with --target set (remote) and no --admin-pass: STILL errors even if FLAIR_ADMIN_PASS is set (security guard)", async () => {
@@ -224,7 +229,7 @@ describe("flair agent add / principal add — subprocess error paths (#590)", ()
       { HOME: tmpHome, FLAIR_ADMIN_PASS: "env-secret-pass" },
     );
     expect(exitCode).not.toBe(0);
-    expect(stderr).toContain("--admin-pass is required for agent add");
+    expect(stderr).toContain("is required for agent add");
     expect(stderr).toContain("remote instance");
   });
 
@@ -239,8 +244,59 @@ describe("flair agent add / principal add — subprocess error paths (#590)", ()
       { HOME: tmpHome, FLAIR_ADMIN_PASS: undefined },
     );
     expect(exitCode).not.toBe(0);
-    expect(stderr).toContain("--admin-pass is required for agent add");
+    expect(stderr).toContain("is required for agent add");
     expect(stderr).toContain("remote instance");
+  });
+
+  // ── flair#1259 — --admin-pass-file: explicit flag, read in-process ──────────
+
+  test("agent add with --admin-pass-file works for a REMOTE target — an explicit flag is operator intent (flair#1259, does not weaken the #1085 ambient-fallback guard)", async () => {
+    const passFile = join(tmpHome, "fabric-admin-pass");
+    writeFileSync(passFile, "fabric-secret\n", "utf-8");
+    chmodSync(passFile, 0o600);
+
+    const { stderr } = await runCli(
+      ["agent", "add", "test-agent-1259-remote-file", "--target", "https://remote.example.com:9926", "--admin-pass-file", passFile],
+      { HOME: tmpHome, FLAIR_ADMIN_PASS: undefined },
+    );
+    // Must get PAST admin-pass resolution (fails later on the network call,
+    // remote.example.com being unreachable) — proves the file leg satisfied
+    // the remote guard the way inline --admin-pass does.
+    expect(stderr).not.toContain("is required for agent add");
+  });
+
+  test("agent add with --admin-pass-file works locally too (flair#1259)", async () => {
+    const passFile = join(tmpHome, "admin-pass-explicit");
+    writeFileSync(passFile, "explicit-file-secret\n", "utf-8");
+    chmodSync(passFile, 0o600);
+
+    const { stderr } = await runCli(
+      ["agent", "add", "test-agent-1259-local-file", "--port", "39999", "--admin-pass-file", passFile],
+      { HOME: tmpHome, FLAIR_ADMIN_PASS: undefined },
+    );
+    expect(stderr).not.toContain("is required for agent add");
+  });
+
+  test("agent add --admin-pass-file enforces owner-only mode — a 0644 file is refused with an actionable chmod error (flair#1259)", async () => {
+    const passFile = join(tmpHome, "world-readable-pass");
+    writeFileSync(passFile, "leaky-secret\n", "utf-8");
+    chmodSync(passFile, 0o644);
+
+    const { stderr, exitCode } = await runCli(
+      ["agent", "add", "test-agent-1259-mode", "--target", "https://remote.example.com:9926", "--admin-pass-file", passFile],
+      { HOME: tmpHome, FLAIR_ADMIN_PASS: undefined },
+    );
+    expect(exitCode).not.toBe(0);
+    expect(stderr).toContain("permissions 644 are too open");
+    expect(stderr).toContain("chmod 600");
+  });
+
+  test("agent add inline --admin-pass still works for a remote target (flair#1259 adds, never replaces)", async () => {
+    const { stderr } = await runCli(
+      ["agent", "add", "test-agent-1259-inline", "--target", "https://remote.example.com:9926", "--admin-pass", "inline-secret"],
+      { HOME: tmpHome, FLAIR_ADMIN_PASS: undefined },
+    );
+    expect(stderr).not.toContain("is required for agent add");
   });
 
   test("agent add (local) with a valid ~/.flair/admin-pass file and no --admin-pass/env: does not hit the missing-admin-pass guard", async () => {
@@ -255,7 +311,7 @@ describe("flair agent add / principal add — subprocess error paths (#590)", ()
     );
     // Should fail on the network call (port 1 / no Harper running), NOT on
     // "--admin-pass is required" — proves the file fallback resolved a pass.
-    expect(stderr).not.toContain("--admin-pass is required for agent add");
+    expect(stderr).not.toContain("is required for agent add");
   });
 
   test("principal add with no --admin-pass, no env, no file: errors clearly", async () => {

--- a/test/unit/snapshot-restore-path-escape.test.ts
+++ b/test/unit/snapshot-restore-path-escape.test.ts
@@ -25,8 +25,10 @@ import { gzipSync } from "node:zlib";
 import {
   extractSnapshotSafely,
   validateSnapshotArchive,
+  checkSnapshotEntry,
   SnapshotPathEscapeError,
 } from "../../src/lib/safe-snapshot-extract";
+import { extractSnapshot as remExtractSnapshot } from "../../src/rem/snapshot";
 import { createDataSnapshot } from "../../src/cli";
 
 // ─── minimal ustar writer ────────────────────────────────────────────────────
@@ -354,4 +356,188 @@ describe("snapshot restore — legitimate archives still restore correctly", () 
 
     expect(readlinkSync(join(targetDir, "models", "current.bin"))).toBe("real.bin");
   });
+});
+
+// ─── flair#901 — fail-closed entry contract ─────────────────────────────────
+// The containment check must refuse an entry it cannot READ, not pass it.
+// Before this fix an empty path resolved to the target dir itself (inside, so
+// ok) and a link entry with no linkpath skipped the link branches entirely —
+// both silently approved exactly the entries a tampered archive (or a tar
+// property rename surviving to runtime) would produce.
+describe("checkSnapshotEntry — fail-closed on unrecognizable entries (flair#901)", () => {
+  test("an entry with an empty path is refused, not resolved to the target dir", () => {
+    const verdict = checkSnapshotEntry("", "File", undefined, "/some/target");
+    expect(verdict.ok).toBe(false);
+    if (verdict.ok === false) expect(verdict.reason).toContain("cannot classify");
+  });
+
+  test("a symlink entry with NO link target is refused — the exact silent-pass shape #901 names", () => {
+    const verdict = checkSnapshotEntry("innocuous", "SymbolicLink", undefined, "/some/target");
+    expect(verdict.ok).toBe(false);
+    if (verdict.ok === false) expect(verdict.reason).toContain("no readable link target");
+  });
+
+  test("a hard-link entry with NO link target is refused too", () => {
+    const verdict = checkSnapshotEntry("innocuous", "Link", undefined, "/some/target");
+    expect(verdict.ok).toBe(false);
+  });
+
+  test("positive control: a normal file entry still passes (the refusal is shape-triggered, not blanket)", () => {
+    expect(checkSnapshotEntry("models/weights.bin", "File", undefined, "/some/target").ok).toBe(true);
+  });
+
+  // Note on scope, verified empirically: node-tar's CURRENT parser never
+  // surfaces a symlink entry with an empty linkname to onReadEntry at all — it
+  // drops the entry before any callback runs, so no archive-level fixture can
+  // reach the linkpath-missing branch through tarList today. The branch's
+  // trigger is the FUTURE failure #901 names (an upstream property rename
+  // surviving to runtime, where linkpath reads as undefined on a well-formed
+  // link entry); the direct tests above are its positive control, and the
+  // typed ReadEntry contract is the compile-time layer in front of it.
+  test("canary: if a future tar surfaces a linkpath-less link entry from a real archive, validation must refuse it (today the parser drops the entry pre-callback)", async () => {
+    const tarball = join(root, "malformed-link.tar.gz");
+    writeTarGz(tarball, [
+      { name: "harper-config.yaml", body: "# benign\n" },
+      { name: "mystery-link", type: "2", linkname: "" },
+    ]);
+
+    // Whichever the parser does — drop the entry (today) or surface it (a
+    // future tar) — the one outcome that must never happen is a validation
+    // PASS that then extracts a link entry the check never classified.
+    let surfaced = false;
+    const { list } = await import("tar");
+    await list({ file: tarball, onReadEntry: (e) => { if (e.path === "mystery-link") surfaced = true; } });
+
+    if (surfaced) {
+      await expect(validateSnapshotArchive({ file: tarball, targetDir })).rejects.toThrow(SnapshotPathEscapeError);
+    } else {
+      // Parser dropped it: validation of the remaining (benign) entries passes,
+      // and the dropped entry cannot be extracted by the same parser either.
+      await validateSnapshotArchive({ file: tarball, targetDir });
+    }
+    expect(readdirSync(targetDir)).toEqual([]);
+  });
+});
+
+// ─── flair#903 — the sibling extracts are no longer fail-open ───────────────
+// rem's extractSnapshot and `flair session snapshot restore` extract with
+// node-tar's DEFAULTS, which contain malicious entries but discard them
+// SILENTLY — a tampered snapshot restored minus the bad parts and reported
+// success. Both now run validateSnapshotArchive first: a tampered archive
+// aborts the whole restore, names the entry, and writes nothing.
+describe("rem extractSnapshot — tampered snapshot ABORTS instead of silently partial-restoring (flair#903)", () => {
+  test('a ".." traversal entry aborts the restore: throws, creates no target dir, writes nothing', async () => {
+    const tarball = join(root, "evil-rem.tar.gz");
+    writeTarGz(tarball, [
+      { name: "memories.jsonl", body: "{}\n" },
+      { name: "../../outside/pwned-rem.txt", body: MARKER },
+    ]);
+    const restoreTarget = join(root, "nest", "rem-restore");
+
+    await expect(
+      remExtractSnapshot({ snapshotPath: tarball, targetDir: restoreTarget }),
+    ).rejects.toThrow(SnapshotPathEscapeError);
+
+    // The whole point: NOT a partial restore. The target was never created,
+    // so there is no half-populated directory to mistake for a success.
+    expect(existsSync(restoreTarget)).toBe(false);
+    expectNothingEscaped();
+  });
+
+  test("an absolute-path entry aborts the same way", async () => {
+    const tarball = join(root, "evil-rem-abs.tar.gz");
+    writeTarGz(tarball, [
+      { name: "memories.jsonl", body: "{}\n" },
+      { name: join(outsideDir, "pwned-rem-abs.txt"), body: MARKER },
+    ]);
+    const restoreTarget = join(root, "nest", "rem-restore-abs");
+
+    await expect(
+      remExtractSnapshot({ snapshotPath: tarball, targetDir: restoreTarget }),
+    ).rejects.toThrow(SnapshotPathEscapeError);
+    expect(existsSync(restoreTarget)).toBe(false);
+    expectNothingEscaped();
+  });
+
+  test("positive control: a benign snapshot still extracts and reports its entries", async () => {
+    const tarball = join(root, "good-rem.tar.gz");
+    writeTarGz(tarball, [
+      { name: "memories.jsonl", body: "{}\n" },
+      { name: "metadata.json", body: "{}\n" },
+    ]);
+    const restoreTarget = join(root, "nest", "rem-restore-good");
+
+    const result = await remExtractSnapshot({ snapshotPath: tarball, targetDir: restoreTarget });
+
+    expect(result.targetDir).toBe(restoreTarget);
+    expect(existsSync(join(restoreTarget, "memories.jsonl"))).toBe(true);
+    expect(result.entries.map((e) => e.path).sort()).toEqual(["memories.jsonl", "metadata.json"]);
+  });
+
+  test("dry-run still lists without validating or writing (read-only path unchanged)", async () => {
+    const tarball = join(root, "evil-rem-dry.tar.gz");
+    writeTarGz(tarball, [
+      { name: "memories.jsonl", body: "{}\n" },
+      { name: "../../outside/pwned-dry.txt", body: MARKER },
+    ]);
+
+    const result = await remExtractSnapshot({ snapshotPath: tarball, dryRun: true });
+    expect(result.entries.length).toBe(2);
+    expect(result.targetDir).toBeUndefined();
+    expectNothingEscaped();
+  });
+});
+
+describe("flair session snapshot restore — tampered snapshot ABORTS (flair#903, real CLI subprocess)", () => {
+  const cliPath = join(import.meta.dirname, "..", "..", "src", "cli.ts");
+
+  async function runCli(args: string[]): Promise<{ stdout: string; stderr: string; exitCode: number }> {
+    const proc = Bun.spawn(["bun", cliPath, ...args], {
+      // HOME-isolated: nothing in this command should touch the real ~/.flair,
+      // and this makes sure of it.
+      env: { ...process.env, HOME: root },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const stdout = await new Response(proc.stdout).text();
+    const stderr = await new Response(proc.stderr).text();
+    const exitCode = await proc.exited;
+    return { stdout, stderr, exitCode };
+  }
+
+  test("a tampered snapshot is refused whole: non-zero exit, names the entry, target dir never created", async () => {
+    const tarball = join(root, "evil-session.tar.gz");
+    writeTarGz(tarball, [
+      { name: "session.jsonl", body: "{}\n" },
+      { name: "../../outside/pwned-session.txt", body: MARKER },
+    ]);
+    const restoreTarget = join(root, "nest", "session-restore");
+
+    const { stderr, exitCode } = await runCli([
+      "session", "snapshot", "restore", "--snapshot", tarball, "--target", restoreTarget,
+    ]);
+
+    expect(exitCode, `exit=${exitCode} stderr=${stderr.slice(0, 300)}`).not.toBe(0);
+    expect(stderr).toContain("refusing to restore");
+    expect(stderr).toContain("pwned-session.txt");
+    expect(existsSync(restoreTarget)).toBe(false);
+    expectNothingEscaped();
+  }, 30_000);
+
+  test("positive control: a benign session snapshot still restores with exit 0", async () => {
+    const tarball = join(root, "good-session.tar.gz");
+    writeTarGz(tarball, [
+      { name: "session.jsonl", body: "{}\n" },
+      { name: "metadata.json", body: "{}\n" },
+    ]);
+    const restoreTarget = join(root, "nest", "session-restore-good");
+
+    const { stderr, exitCode } = await runCli([
+      "session", "snapshot", "restore", "--snapshot", tarball, "--target", restoreTarget,
+    ]);
+
+    expect(exitCode, `exit=${exitCode} stderr=${stderr.slice(0, 300)}`).toBe(0);
+    expect(existsSync(join(restoreTarget, "session.jsonl"))).toBe(true);
+    expect(existsSync(join(restoreTarget, "metadata.json"))).toBe(true);
+  }, 30_000);
 });


### PR DESCRIPTION
Closes #1264. Closes #1259. Closes #1254. Closes #901. Closes #903.

Four small security/correctness fixes in one hardening pass, each with a positive control that was mutation-checked (fix reverted, test observed red, fix restored, test observed green).

## #1264 — cross-agent private by-id GET: 404 at both layers

The auth middleware's by-id Memory read guard returned a 403 whose message named the owning agent, while `Memory.get()` behind it deliberately answers a generic `not found` 404 so a denied caller can't enumerate ids. The middleware answer both confirmed the id exists and disclosed its owner. It now returns the identical 404 (reusing the resource kit's `NOT_FOUND` so the two layers cannot drift), making a denied cross-agent private read byte-identical to a genuinely missing id.

Tests (integration, real Harper): grantee/stranger GET of a private id is exactly 404 with no owner and no `forbidden` text; a denied read and a missing id return the same status **and body**; owner GET stays 200 (no over-fire). Mutation check: restoring the old 403 fails all three.

## #1259 — `flair agent add --admin-pass-file`

`agent add` accepted only inline `--admin-pass`; the documented workaround (`--admin-pass "$(cat path)"`) kept the value out of history but still exposed it to `ps`. Added a real `--admin-pass-file <path>` read in-process via the existing `readAdminPassFileSecure` (owner-only mode enforced), same shape as `flair federation sync`. It resolves into the explicit slot, so it works for remote targets: an explicit flag is operator intent, which is precisely what the remote guard (ambient env/file fallbacks never travel to a third-party host) distinguishes. `docs/quickstart-fabric.md` step 3 now leads with it.

Tests: file works for a remote target; file works locally; a 0644 file is refused with the actionable chmod error; inline `--admin-pass` still works remote. Mutation check: disabling the file resolution fails the three file tests.

## #1254 — flair-client treats wholesale `${...}` env values as unset

`FlairClient`'s constructor re-reads `process.env` as its own fallback, so a consumer that correctly passed `url: undefined` after seeing an unsubstituted `${FLAIR_URL}` literal still had the literal resurrected by the client. The client's env fallbacks (`FLAIR_URL`, `FLAIR_AGENT_ID`, `FLAIR_CLIENT`, `FLAIR_ADMIN_USER`, `FLAIR_ADMIN_PASSWORD`, and `FLAIR_KEY_DIR` in key resolution) now treat a wholesale `${...}` literal as absent, deferring to the existing `DEFAULT_URL`/derivations — no new hardcoded defaults. The guard's semantics are identical to flair-mcp's boundary strip, which stays in place as defense-in-depth (an older flair-client on a consumer's disk doesn't have this fix).

Tests mirror the flair-mcp positive control: literal in env + `url: undefined` resolves to `DEFAULT_URL`; real env values still win; explicit config still wins; no basic-auth header is manufactured from placeholder credentials; key resolution never probes a directory literally named `${FLAIR_KEY_DIR}` (fixture plants one). Mutation check: reverting to direct `process.env` reads fails all five guard tests.

## #901 + #903 — snapshot tar handling fails closed

**#901:** `onReadEntry` callbacks took `(entry: any)`, and the containment check coerced missing properties to safe defaults — an upstream property rename would have made a link entry with no linkpath pass the check that exists to reject it. Entry callbacks are now typed against node-tar's own `ReadEntry` export (a rename fails compilation), and `checkSnapshotEntry` refuses an entry whose path is empty/unreadable or whose link-typed entry carries no link target. Scope note, verified empirically: node-tar's current parser drops a malformed link entry before any callback runs, so the runtime branch's trigger is the future property-rename case; a canary test pins whichever behavior the parser exhibits to a safe outcome.

**#903:** the two sibling `tarExtract` call sites (REM snapshot restore, `flair session snapshot restore`) extracted with node-tar defaults, which contain malicious entries but discard them silently — a tampered snapshot restored minus the bad parts and reported success. Both now run `validateSnapshotArchive` (from #900) before the target directory is even created: a tampered archive aborts the whole restore with the existing actor+state+remedy refusal (what was rejected, nothing was written, restore from a snapshot you trust), never a partial restore reporting success. Default extract flags stay as containment defense-in-depth.

Tests: tampered fixtures (`..` traversal, absolute path) abort both paths — the REM path via the exported function, the session path via a real CLI subprocess (non-zero exit, names the entry, target dir never created); benign fixtures still restore. Mutation check: reverting to skip-behavior fails all three abort tests, empirically confirming the old fail-open shape.

## Test evidence

All lanes measured against a baseline on unmodified `origin/main` (39120e58), same machine:

| Lane | Baseline | After |
|---|---|---|
| `bun test test/unit/ test/*.test.ts` | 4577 pass / 0 fail | 4593 pass / 0 fail |
| `test/unit-isolated/` (one process per file) | 157 pass / 0 fail | 157 pass / 0 fail |
| flair-client package | 61 pass / 0 fail | 69 pass / 0 fail |
| flair-mcp package | 96 pass / 0 fail | 96 pass / 0 fail |
| `tsc --noEmit -p tsconfig.check.json` | clean | clean |
| integration: memory-visibility-scoping-e2e | 16 pass / 0 fail | 17 pass / 0 fail |
| integration: cli-local-admin-pass-fallback | 3 pass / 0 fail | 3 pass / 0 fail |

Changelog: one `security` fragment covering the four; `changelog-fragments.mjs check` and all 7 docs-freshness checks pass.

Out of scope, noted: node-tar's parser itself silently skips entries it cannot parse (they never reach any callback), so validation can only refuse what the parser surfaces; catching parser-skipped entries would need raw-block accounting — a different, structurally larger change than this batch. #955 (release tooling) deliberately excluded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
