### PR TITLE
Bootstrap teammate pass ranks on the search hybrid ranker; inert task-relevance floor removed (#1246)

### DIFF
--- a/.changelog/unreleased/fixed-1246-bootstrap-search-ranker-parity.md
+++ b/.changelog/unreleased/fixed-1246-bootstrap-search-ranker-parity.md
@@ -1,0 +1,28 @@
+- **Bootstrap's teammate/task-relevant pass now ranks on the SAME hybrid
+  (BM25 + union-RRF) retrieval as `memory_search` — and the inert
+  `_score > 0.3` task-relevance floor is removed** (flair#1246). Bootstrap's
+  task-relevant candidate pass invoked the shared retrieval core in HNSW-only
+  mode (an accident of early code) while search ran hybrid, so the two
+  surfaces ranked the same store+query on different signals: a record whose
+  task-relevance is lexical (exact task terms inside semantically-atypical
+  prose) fused to rank 1 in search but ranked below bland-generic noise on
+  pure cosine in bootstrap (measured: cosine 0.5656 vs noise 0.6086 at N=21 —
+  HNSW rank 6, fused rank 1), and at field scale (corpus larger than the
+  bounded candidate pool) was excluded from bootstrap's pool entirely. The
+  pass now resolves its mode from the same `hybridEnabled()` selector search
+  uses and passes `currentTask` as the lexical leg, so bootstrap's teammate
+  picks and `memory_search` agree — one ranker, one scale — and the
+  `FLAIR_HYBRID_RETRIEVAL` kill-switch moves both surfaces together.
+
+  The historical `TASK_RELEVANCE_FLOOR` (0.3, carried verbatim from the
+  original raw JS dot-product scan) is removed rather than recalibrated: a
+  6-variant measurement on the shipped embedding model proved it inert
+  (nothing in 126 records scored under ~0.44 — it cut zero records and never
+  delivered "show nothing when nothing's relevant" either, since
+  fully-unrelated bland noise scores 0.44–0.63). Task-relevant selection is
+  fused retrieval rank plus the existing token budget. Count semantics are
+  unchanged in shape (`teammateFindingsIncluded + teammateFindingsTruncated
+  == teammateFindingsMatched`); "matched" now means "entered the scored
+  retrieval pool". A ranking-parity integration case (the measured
+  max-dilution fixture) pins bootstrap's top teammate pick to search's top
+  result so any future divergence of the two retrieval paths fails CI.

--- a/resources/MemoryBootstrap.ts
+++ b/resources/MemoryBootstrap.ts
@@ -21,6 +21,7 @@ import {
 // retrievalCount hit-tracking side effects (see resources/
 // semantic-retrieval-core.ts's module doc for the full boundary).
 import { retrieveCandidates, DEFAULT_SELECT } from "./semantic-retrieval-core.js";
+import { hybridEnabled } from "./bm25.js";
 import { buildTrustBlock } from "./trust-block.js";
 import { bestSemanticSimilarity, evaluateAbstention } from "./abstention.js";
 import { estimateTokens } from "./token-estimate.js";
@@ -58,8 +59,9 @@ import { estimateTokens } from "./token-estimate.js";
  *      (no new embedding code — Memory is the semantic surface, WorkspaceState/
  *      OrgEvent are the entity surface, per the K&S verdict). Gated on
  *      freshness (Presence, via the SAME internal roster path, never the raw
- *      table) and #550's existing relevance floor. See resources/
- *      collision-lib.ts for the pure join/rank/format logic.
+ *      table); drawn from #550's fused-rank scored pool (flair#1246 — no
+ *      relevance floor). See resources/collision-lib.ts for the pure
+ *      join/rank/format logic.
  *
  * Prediction: when context signals (channel, surface, subjects) are provided,
  * the bootstrap loads more aggressively — Flair is fast enough that the
@@ -135,9 +137,12 @@ import { estimateTokens } from "./token-estimate.js";
  *   memoriesAvailable` — included and truncated are disjoint sets of UNIQUE own
  *   memories (a memory budget-skipped in one section but admitted in another counts
  *   as included, never both). `teammateFindingsMatched` is the teammate match pool
- *   that cleared the relevance floor; `teammateFindingsIncluded +
- *   teammateFindingsTruncated == teammateFindingsMatched`, so "truncated" means
- *   "relevant but no budget," not "every candidate not selected."
+ *   that entered the scored candidate set — since flair#1246 that is the
+ *   K-bounded fused-rank retrieval pool (no relevance floor; the historical
+ *   `_score > 0.3` gate was measured inert and removed); `teammateFindingsIncluded
+ *   + teammateFindingsTruncated == teammateFindingsMatched` (the #1199 contract,
+ *   unchanged), so "truncated" means "retrieved but no budget," not "every
+ *   candidate not selected."
  *   `predictedHint` is present only when subjects were provided but `predicted`
  *   came back empty.
  */
@@ -217,10 +222,18 @@ const OWN_NONPERMANENT_FETCH_LIMIT = 500;
 const AVG_LINE_TOKEN_ESTIMATE = 60;
 const MIN_CANDIDATE_POOL = 50;
 const MAX_CANDIDATE_POOL = 100;
-// Bootstrap's own historical relevance floor (distinct from SemanticSearch's
-// `minScore` request param) — preserved verbatim from the original raw
-// JS dot-product scan's `.filter((s) => s.score > 0.3)`.
-const TASK_RELEVANCE_FLOOR = 0.3;
+// flair#1246 — the historical TASK_RELEVANCE_FLOOR (`_score > 0.3`, carried
+// verbatim from the original raw JS dot-product scan) is REMOVED, not
+// recalibrated: a 6-variant measurement on the shipped embedding model proved
+// it inert (126 records across field-analog/nonce/contamination/control/
+// max-dilution/scattered-senses shapes — nothing scored under ~0.44, so the
+// floor cut zero records and never delivered "show nothing when nothing's
+// relevant" either; fully-unrelated bland noise sits 0.44–0.63). Selection on
+// the task-relevant surface is fused retrieval rank + the token budget. Do
+// not reintroduce a constant floor — an absolute bar tight enough to exclude
+// bland noise (max-dilution noise cosine 0.6086) also excludes the
+// pathological on-task case (0.5656); a real relevance gate would need a
+// corpus-relative instrument, which is a new feature, not a constant.
 
 // flair#1207 — the per-item structured-payload overhead that #1199 charged
 // against the content-selection budget (a `+ STRUCT_ITEM_OVERHEAD_TOKENS = 70`
@@ -397,9 +410,10 @@ export class BootstrapMemories extends Resource {
     // is what let one client see included(9) > available(3).
     let teammateFindingsIncluded = 0;
     // flair#1207 — teammate findings SKIPPED for size in the task-relevant
-    // packing loop (cleared the relevance floor but didn't fit the BUDGET).
-    // Reported ALONGSIDE `teammateFindingsMatched` (the whole floor-clearing pool
-    // considered), so "truncated" unambiguously means "relevant-but-no-budget",
+    // packing loop (entered the scored retrieval pool but didn't fit the
+    // BUDGET; flair#1246 — the pool is the K-bounded fused-rank candidate
+    // set, no relevance floor). Reported ALONGSIDE `teammateFindingsMatched`
+    // (the whole scored pool considered), so "truncated" unambiguously means "relevant-but-no-budget",
     // NOT "every candidate not selected" — 0.44.9's `truncated:89` beside
     // `included:4` read as "89 relevant findings cut" with no pool to anchor it
     // (heskew's #1207 nit). Both are disjoint-and-exhaustive over the matched
@@ -907,12 +921,13 @@ export class BootstrapMemories extends Resource {
     }
 
     // Collision surfacing's semantic-match candidates (flair#681) — the
-    // BEST (highest-scoring) cross-agent memory per teammate from #550's
+    // BEST (top fused-rank) cross-agent memory per teammate from #550's
     // `scored` list below, captured here (before that list's tokens get
     // spent on the relevant/teammate sections) so the collision block can
-    // reuse the IDENTICAL scored+floor-gated set without recomputing or
-    // re-embedding anything. Stays empty when there's no currentTask (no
-    // `scored` list is ever built) or no cross-agent hits.
+    // reuse the IDENTICAL scored set (flair#1246 — fused retrieval rank, no
+    // floor gate) without recomputing or re-embedding anything. Stays empty
+    // when there's no currentTask (no `scored` list is ever built) or no
+    // cross-agent hits.
     const semanticTeammateMatches: SemanticMatchInput[] = [];
 
     // --- 4. Task-relevant memories (semantic search) ---
@@ -952,12 +967,27 @@ export class BootstrapMemories extends Resource {
           queryEmbedding,
           conditions: [scope.condition],
           limit: candidatePoolK,
-          // HNSW-leg pushdown ONLY (K&S verdict): no BM25 fusion for
-          // bootstrap — a different cost profile, since BM25 over the org
-          // corpus for a one-shot session-load could be MORE expensive than
-          // HNSW-only unless cached across sessions. Turning it on is an
-          // explicit opt-in follow-on, gated on its own harness run.
-          hybrid: false,
+          // flair#1246 — ONE RANKER, ONE SCALE: this pass now invokes the
+          // core in the SAME mode memory_search does (hybrid + q via the
+          // shared hybridEnabled() selector, so the FLAIR_HYBRID_RETRIEVAL
+          // kill-switch moves BOTH surfaces together — a split mode IS the
+          // #1246 bug). HNSW-only here was an accident of early code, and it
+          // made bootstrap's teammate picks diverge from search on the same
+          // store+query: a record whose task-relevance is LEXICAL (exact task
+          // terms in semantically-atypical prose) ranks BELOW bland-generic
+          // noise on pure cosine (measured at N=21: on-task 0.5656 vs noise
+          // 0.6086 — HNSW rank 6 while search fused it to rank 1), and at
+          // field scale (corpus >> candidatePoolK) that inversion becomes
+          // exclusion from the K-bounded pool entirely. The BM25 leg is the
+          // rescue: it admits the record at lexical rank 1 and union-RRF
+          // fusion carries it to the top, same as search. Perf (Kern-ratified
+          // trade): the BM25 corpus scan this adds to the bootstrap path is
+          // the same per-call scan every memory_search request already runs.
+          hybrid: hybridEnabled(),
+          // The lexical leg — same query text the embedding was computed
+          // from, so both legs rank the same question (parity with search,
+          // where `q` drives BM25 and the keyword bump).
+          q: currentTask,
           // Per-set (this K-bounded pool only, never cross-applied to the
           // permanent/recent/predicted sets above) — see this function's
           // supersededIds docs above and resources/
@@ -998,31 +1028,33 @@ export class BootstrapMemories extends Resource {
 
         // flair#744 slice 2: the best-match confidence for the abstention
         // decision — the max absolute cosine across the retrieved pool, read
-        // ONLY from `_semSimilarity` (never any principal/authority field). Note
-        // this floor (ABSTENTION_THRESHOLD ≈ 0.15) sits BELOW bootstrap's own
-        // long-standing TASK_RELEVANCE_FLOOR (0.3) that gates `scored` below, so
-        // an abstaining task (bestSim < 0.15) already has no candidate passing
-        // the floor — abstention only ADDS an explicit "nothing covered this"
-        // signal, it never removes a memory the reader would otherwise have seen.
+        // ONLY from `_semSimilarity` (never any principal/authority field).
+        // Abstention is unaffected by #1246's floor removal: it only ADDS an
+        // explicit "nothing covered this" signal against its own GLOBAL
+        // threshold (resources/abstention.ts), it never removes a memory the
+        // reader would otherwise have seen.
         if (abstain) taskBestSimilarity = bestSemanticSimilarity(candidates);
 
-        // Preserve the ORIGINAL score > 0.3 floor exactly (bootstrap's own
-        // historical relevance floor — distinct from SemanticSearch's
-        // `minScore` request param — strict inequality, applied client-side;
-        // `candidates` are already `_score`-sorted best-first, so filtering
-        // preserves that order). `retrieveCandidates()`'s cosine similarity
-        // replaces the raw JS dot product as the ranking signal (HNSW-only,
-        // no BM25) — the K&S-ratified, closest-to-a-wash choice; the
-        // recall harness gates any regression from this ranking-signal
-        // change (magnitude-sensitive dot product → normalized cosine).
+        // flair#1246 — selection is FUSED RETRIEVAL RANK + the token budget
+        // in the packing loop below; there is NO score floor (see the
+        // TASK_RELEVANCE_FLOOR removal note by the pool constants above —
+        // measured inert on the shipped embedding model). `candidates` arrive
+        // best-first on the same ranking memory_search uses (fused RRF order
+        // under hybrid; see retrieveCandidates), so this filter+map preserves
+        // that order. `score` carries `_score` — the honest absolute cosine
+        // (+ legacy keyword bump) per #985/#1267 — for display/reporting;
+        // ORDER and score can legitimately disagree (a BM25 rank-1 rescue
+        // outranks higher-cosine bland hits, which is the recall win).
         const scored = candidates
-          .filter((m: any) => !includedIds.has(m.id) && m._score > TASK_RELEVANCE_FLOOR)
+          .filter((m: any) => !includedIds.has(m.id))
           .map((m: any) => ({ memory: m, score: m._score }));
 
         // flair#681: the collision block's semantic surface — one candidate
-        // per teammate (the highest-scoring hit; `scored` is already sorted
-        // desc, so the first occurrence of a given `_source` IS the best
-        // one). `m._source` is only ever set for a cross-agent record (see
+        // per teammate (`scored` is sorted best-first by the fused retrieval
+        // rank, so the first occurrence of a given `_source` IS that
+        // teammate's best-ranked hit; its `score` field reports the honest
+        // absolute cosine, which per #985/#1267 can disagree with rank).
+        // `m._source` is only ever set for a cross-agent record (see
         // retrieveCandidates()'s `_source` tagging) — an own memory never
         // contributes here.
         const seenCollisionAgents = new Set<string>();
@@ -1112,7 +1144,8 @@ export class BootstrapMemories extends Resource {
     //   - Entity overlap (WorkspaceState + OrgEvent): exact vocabulary-string
     //     match, high-precision, no separate relevance score needed.
     //   - Semantic match (Memory, via #550/4 above): `semanticTeammateMatches`,
-    //     already floor-gated (score > 0.3) — reused as-is, no new scoring.
+    //     each teammate's best-ranked hit from the fused retrieval pool
+    //     (flair#1246 — no score floor) — reused as-is, no new scoring.
     // Gated on freshness (Presence, via the internal roster path) — a
     // teammate absent from the roster, or whose presenceStatus is "offline",
     // never surfaces regardless of how strong the entity/semantic match is.
@@ -1338,9 +1371,10 @@ export class BootstrapMemories extends Resource {
     let memoriesTruncatedUnique = 0;
     for (const id of truncatedOwnIds) if (!includedOwnIds.has(id)) memoriesTruncatedUnique++;
     memoriesTruncated = memoriesTruncatedUnique;
-    // flair#1207 — the teammate MATCH POOL considered (cleared the relevance
-    // floor, drawn from the bounded candidate pool): every matched teammate
-    // finding is EITHER included OR budget-truncated, so this equals their sum.
+    // flair#1207 — the teammate MATCH POOL considered (flair#1246: the
+    // cross-agent records that entered the scored set — drawn from the
+    // K-bounded fused-rank candidate pool, no relevance floor): every matched
+    // teammate finding is EITHER included OR budget-truncated, so this equals their sum.
     // Reporting it anchors `teammateFindingsTruncated` as "relevant-but-no-budget"
     // rather than an unexplained large number beside a small `included`.
     const teammateFindingsMatched = teammateFindingsIncluded + teammateFindingsTruncated;
@@ -1493,16 +1527,18 @@ export class BootstrapMemories extends Resource {
       : undefined;
 
     // teammateFindings: [] — name WHICH legitimate empty this is (no task → no
-    // retrieval; matched-but-budget-truncated; or nothing cleared the relevance
-    // floor), so it never reads as a silent drop.
+    // retrieval; matched-but-budget-truncated; or no cross-agent record entered
+    // the task-relevant retrieval pool at all — flair#1246: there is no
+    // relevance floor, so "empty" means empty retrieval, never a score cut),
+    // so it never reads as a silent drop.
     const teammateFindingsHint = includedTeammateFindings.length === 0
       ? (!taskProvided
           ? "No teammateFindings: cross-agent findings are retrieved against your currentTask, and none was provided. "
             + "Pass currentTask to populate this."
           : teammateFindingsTruncated > 0
             ? `No teammateFindings fit the token budget: ${teammateFindingsTruncated} relevant cross-agent finding(s) `
-              + "cleared the relevance floor but were budget-truncated. Raise maxTokens to include them."
-            : "No cross-agent (teammate) memory cleared the task-relevance floor for this currentTask. "
+              + "were retrieved but budget-truncated. Raise maxTokens to include them."
+            : "No cross-agent (teammate) memory entered the task-relevant retrieval pool for this currentTask. "
               + "This container is present-but-empty by design, not dropped.")
       : undefined;
 
@@ -1571,8 +1607,9 @@ export class BootstrapMemories extends Resource {
       // size-skip self-describing: "a relevant teammate finding didn't fit" is
       // now distinguishable from "no relevant teammate finding".
       teammateFindingsTruncated,
-      // flair#1207 — the teammate match POOL considered (cleared the relevance
-      // floor). teammateFindingsIncluded + teammateFindingsTruncated ==
+      // flair#1207 — the teammate match POOL considered (flair#1246: entered
+      // the scored fused-rank retrieval set; no relevance floor).
+      // teammateFindingsIncluded + teammateFindingsTruncated ==
       // teammateFindingsMatched, so "truncated" reads as "relevant-but-no-budget"
       // against a stated pool, not an unanchored large number.
       teammateFindingsMatched,

--- a/resources/abstention.ts
+++ b/resources/abstention.ts
@@ -47,11 +47,13 @@
  * GLOBAL / data-driven, NEVER per-principal (Sherlock binding condition 2).
  *
  * CONSERVATIVE hand-set value (0.15): well below the strong-match band real
- * embeddings produce for genuinely relevant memories, and below bootstrap's
- * own long-standing task-relevance floor (0.3, resources/MemoryBootstrap.ts's
- * TASK_RELEVANCE_FLOOR) — so abstention fires only when there is essentially
- * nothing semantically near the query, erring toward returning results rather
- * than over-abstaining. Promoting abstention to the DEFAULT recall mode, and
+ * embeddings produce for genuinely relevant memories (and below anything the
+ * flair#1246 measurement observed on the shipped model — 126 records across 6
+ * synthetic variants all scored ≥ ~0.44) — so abstention fires only when
+ * there is essentially nothing semantically near the query, erring toward
+ * returning results rather than over-abstaining. (Bootstrap's own
+ * TASK_RELEVANCE_FLOOR, which this comment once referenced, was removed by
+ * flair#1246 — that same measurement proved it inert.) Promoting abstention to the DEFAULT recall mode, and
  * tuning this value on the recall-bench corpus, is a SEPARATE follow-up (see
  * flair#744) — this slice ships the response shape at a safe opt-in floor, not
  * the calibrated default.

--- a/resources/semantic-retrieval-core.ts
+++ b/resources/semantic-retrieval-core.ts
@@ -92,10 +92,10 @@ export interface RetrieveCandidatesParams {
    *  (e.g. the embedding engine failed/was never called). */
   queryEmbedding?: number[] | null;
   /** Raw query text — drives BM25 lexical ranking (hybrid leg) and the
-   *  legacy keyword bump (HNSW-only leg). Optional: MemoryBootstrap never
-   *  supplies this — it has no free-text query, only a precomputed
-   *  `queryEmbedding`, and per the K&S verdict bootstrap gets HNSW-leg
-   *  pushdown only, no keyword bump. */
+   *  legacy keyword bump (HNSW-only leg). SemanticSearch passes the request
+   *  `q`; MemoryBootstrap's task-relevant pass passes `currentTask`
+   *  (flair#1246 — the same text its `queryEmbedding` was computed from, so
+   *  bootstrap and search rank on the same fused scale). */
   q?: string;
   /** Pre-built Harper conditions[] — the caller (SemanticSearch.post() /
    *  MemoryBootstrap.post()) already resolved scope.condition (and, for
@@ -144,15 +144,15 @@ export interface RetrieveCandidatesParams {
    * HNSW-only / keyword-fallback path (false). Explicit and REQUIRED — never
    * read from hybridEnabled() internally, so a caller gets a deterministic
    * mode regardless of the global FLAIR_HYBRID_RETRIEVAL env value.
-   * MemoryBootstrap ALWAYS passes false: the hybrid leg's BM25 corpus fetch
-   * (`corpusQuery` below) is an UNBOUNDED conditions-scoped scan (no
-   * `limit` — matches SemanticSearch's pre-existing, out-of-scope-for-this-PR
-   * behavior) run regardless of whether `q` is even supplied, which is
-   * exactly the kind of unbounded scan this PR removes bootstrap's need for.
-   * HNSW-leg-only for bootstrap is also the K&S-ratified default: BM25 for a
-   * one-shot session-load has a different (likely worse) cost profile than
-   * SemanticSearch's per-query BM25 — turning it on is an explicit opt-in
-   * follow-on, not this PR.
+   * Both production callers resolve it from the SAME hybridEnabled()
+   * selector — SemanticSearch since the hybrid activation, MemoryBootstrap's
+   * task-relevant pass since flair#1246 (one ranker, one scale: HNSW-only
+   * bootstrap ranked lexically-relevant records below bland-generic noise on
+   * pure cosine while search fused them to rank 1 — a structural divergence
+   * between the two surfaces on the same store+query). The hybrid leg's BM25
+   * corpus fetch (`corpusQuery` below) is an UNBOUNDED conditions-scoped
+   * scan (no `limit`), the same per-call scan every search request already
+   * runs — the Kern-ratified cost of putting bootstrap on the search ranker.
    */
   hybrid: boolean;
   /** Request context, for withDetachedTxn — both SemanticSearch and
@@ -378,8 +378,9 @@ export async function retrieveCandidates(params: RetrieveCandidatesParams): Prom
       }
     }
   } else if (qEmb) {
-    // ─── HNSW vector search path (legacy, hybrid flag OFF — or a caller
-    // like MemoryBootstrap forcing HNSW-leg-only regardless of the flag) ────
+    // ─── HNSW vector search path (legacy, hybrid flag OFF — the
+    // FLAIR_HYBRID_RETRIEVAL kill-switch path for BOTH production callers
+    // since flair#1246) ─────────────────────────────────────────────────────
     const query: any = {
       sort: { attribute: "embedding", target: qEmb, distance: "cosine" },
       select: hnswSelect,

--- a/test/integration/bootstrap-search-parity-1246.test.ts
+++ b/test/integration/bootstrap-search-parity-1246.test.ts
@@ -1,0 +1,228 @@
+// flair#1246 — bootstrap/search RANKING PARITY (real Harper, real embeddings).
+//
+// Bootstrap's teammate/task-relevant pass and memory_search now invoke the
+// SAME retrieval core in the SAME mode (hybrid + q — one ranker, one scale).
+// Before #1246, bootstrap forced `hybrid: false` (HNSW-only, an accident of
+// early code): the two surfaces ranked the same store+query on DIFFERENT
+// signals, so a record whose task-relevance is LEXICAL (exact task terms
+// inside semantically-atypical prose) fused to rank 1 in search while
+// bootstrap's pure-cosine ranking buried it under bland-generic noise — and
+// at field scale (corpus >> candidatePoolK) dropped it from the K-bounded
+// pool entirely. This test is the CI tripwire for any future re-divergence of
+// the two retrieval paths (the issue's original ask).
+//
+// FIXTURE — the measurement's v5 "max dilution" shape (6-variant measurement
+// on the shipped nomic model, ephemeral instance @ 39120e58): ONE on-task
+// record carrying the exact task terms once, buried in long unrelated prose,
+// plus a 20-record bland-generic noise cluster. Measured at this exact shape
+// (N=21): on-task cosine 0.5656 vs noise max 0.6086 → HNSW-only rank 6 under
+// five noise records; BM25 rank 1 (score 6.485 vs noise max 2.946) → fused
+// rank 1. So:
+//
+//   hybrid+q (post-#1246):  bootstrap teammate pick #1 == search result #1
+//                           == the on-task record  → this test PASSES.
+//   hybrid:false (mutation): search still fuses on-task to rank 1, but
+//                           bootstrap's teammate list leads with bland noise
+//                           (on-task sinks to ~rank 6) → the rank-1 parity
+//                           assertions FAIL. Verified both directions when
+//                           this landed.
+//
+// N=21 deliberately does NOT truncate the candidate pool (candidatePoolK >=
+// MIN_CANDIDATE_POOL=50), so plain membership can't be the tripwire here —
+// the fused-rank-1 vs HNSW-rank-~6 DIVERGENCE is (per the measurement, the
+// pool-exclusion form of the same inversion needs corpus >> K, too slow for
+// CI). Membership is still asserted for the issue's literal "present in
+// both" parity ask.
+//
+// MODEL-GATED like recall-eval-gate.test.ts: skips VISIBLY when the
+// embedding model isn't present rather than triggering a HuggingFace pull
+// mid-suite. The integration lane pre-downloads the model, so the gate fires
+// in CI.
+import { describe, expect, test, beforeAll, afterAll } from "bun:test";
+import { existsSync } from "node:fs";
+import path from "node:path";
+import nacl from "tweetnacl";
+import { randomUUID } from "node:crypto";
+import { startHarper, stopHarper, HarperInstance } from "../helpers/harper-lifecycle";
+
+const MODEL_FILE = "nomic-embed-text-v1.5.Q4_K_M.gguf";
+function modelPresent(): boolean {
+  const dirs = [process.env.FLAIR_MODELS_DIR, path.join(process.cwd(), "models")].filter(Boolean) as string[];
+  return dirs.some((d) => existsSync(path.join(d, MODEL_FILE)));
+}
+const HAS_MODEL = modelPresent();
+const gate = HAS_MODEL ? describe : describe.skip;
+if (!HAS_MODEL) {
+  console.warn(`[bootstrap-search-parity-1246] SKIPPING: embedding model ${MODEL_FILE} not found in FLAIR_MODELS_DIR or <cwd>/models.`);
+}
+
+interface TestAgent { id: string; publicKey: string; secretKey: Uint8Array; }
+
+function mkAgent(id: string): TestAgent {
+  const kp = nacl.sign.keyPair();
+  return { id, publicKey: Buffer.from(kp.publicKey).toString("base64"), secretKey: kp.secretKey };
+}
+
+function ed25519Header(agent: TestAgent, method: string, urlPath: string): string {
+  const ts = Date.now().toString();
+  const nonce = randomUUID();
+  const payload = `${agent.id}:${ts}:${nonce}:${method}:${urlPath}`;
+  const sig = nacl.sign.detached(new TextEncoder().encode(payload), agent.secretKey);
+  return `TPS-Ed25519 ${agent.id}:${ts}:${nonce}:${Buffer.from(sig).toString("base64")}`;
+}
+
+async function adminOp(harper: HarperInstance, op: Record<string, any>): Promise<Response> {
+  return fetch(harper.opsURL, {
+    method: "POST",
+    headers: { "Content-Type": "application/json", Authorization: "Basic " + btoa(`${harper.admin.username}:${harper.admin.password}`) },
+    body: JSON.stringify(op),
+  });
+}
+
+async function registerAgent(harper: HarperInstance, agent: TestAgent): Promise<void> {
+  const res = await adminOp(harper, {
+    operation: "insert", database: "flair", table: "Agent",
+    records: [{ id: agent.id, name: agent.id, role: "agent", publicKey: agent.publicKey, createdAt: new Date().toISOString() }],
+  });
+  expect(res.status, `Agent insert for ${agent.id} returned ${res.status}`).toBe(200);
+}
+
+/** Signed PUT to /Memory/<id> — the real write path, so the embedding is
+ *  generated for real (Memory.ts put() → getEmbedding()), never synthesized. */
+async function putMemory(harper: HarperInstance, agent: TestAgent, id: string, body: Record<string, any>): Promise<void> {
+  const urlPath = `/Memory/${id}`;
+  const res = await fetch(`${harper.httpURL}${urlPath}`, {
+    method: "PUT",
+    headers: { Authorization: ed25519Header(agent, "PUT", urlPath), "Content-Type": "application/json" },
+    body: JSON.stringify({ id, ...body }),
+  });
+  if (![200, 204].includes(res.status)) {
+    throw new Error(`seed PUT ${id} → ${res.status}: ${await res.text()}`);
+  }
+}
+
+async function post(harper: HarperInstance, agent: TestAgent, urlPath: string, body: Record<string, any>): Promise<any> {
+  const res = await fetch(`${harper.httpURL}${urlPath}`, {
+    method: "POST",
+    headers: { Authorization: ed25519Header(agent, "POST", urlPath), "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  const text = await res.text();
+  expect(res.status, `${urlPath} → ${res.status}: ${text.slice(0, 500)}`).toBe(200);
+  return JSON.parse(text);
+}
+
+// ── The v5 "max dilution" fixture (verbatim from the #1246 measurement) ──────
+// The SAME string is bootstrap's currentTask AND search's q — parity is only
+// meaningful on an identical store+query.
+const CURRENT_TASK =
+  "Pick up the connector-chronicle work: the conformance fixture parity eval needs to pass " +
+  "before we can cut the release candidate this week";
+
+// On-task: the exact task terms appear ONCE, buried in long unrelated prose —
+// lexically decisive (BM25 rank 1), semantically atypical (cosine BELOW the
+// bland noise cluster's best: 0.5656 vs 0.6086 measured).
+const ONTASK_CONTENT =
+  "Long weekend at the coast. The tide charts were wrong twice, so the kayaks went out late " +
+  "and came back later. Drove the ridge road with the windows down, stopped for peaches at " +
+  "the farm stand, argued amiably about whether the lighthouse is older than the pier. " +
+  "Somewhere in the glovebox is a napkin where I scrawled connector-chronicle conformance " +
+  "fixture parity eval so I would not forget it before Monday. The cottage stove smokes when " +
+  "the wind turns east, the board games are missing half their pieces, and the neighbor's dog " +
+  "adopted us for the duration. Sunburn on the left arm only, from trolling the dinghy. The " +
+  "drive home took four hours with the roadwork detour past the quarry.";
+
+// Bland-generic work prose — the kind that wins weak-pool cosine (measured
+// 0.44–0.63 against this task) while sharing no distinctive task term.
+const NOISE: string[] = [
+  "Team sync notes: reviewed the sprint board, moved two cards to done, and flagged the onboarding doc for a refresh.",
+  "Updated the status dashboard with the latest migration progress and pinged the group about the weekly demo.",
+  "Wrote up the retro summary: what went well, what to improve, and the action items we agreed on.",
+  "Checked in with the design crew about the new landing page copy and the button color debate.",
+  "Backlog grooming: closed stale tickets, merged duplicates, and re-prioritized the top of the queue.",
+  "Drafted the quarterly roadmap slide and shared it in the planning channel for comments.",
+  "Quick fix landed for the flaky nightly job; also tidied the runbook while I was in there.",
+  "Standup recap: blocked on the vendor response, otherwise steady progress across the board.",
+  "Documented the deploy checklist and added a section about rollback steps for the ops folks.",
+  "Paired with a teammate on the analytics report and cleaned up the spreadsheet formulas.",
+  "Migration status: three services moved over, two remaining, no incidents reported this week.",
+  "Collected feedback from the beta group and summarized the top requests for the product huddle.",
+  "Refreshed the internal wiki homepage and archived the outdated meeting notes from last quarter.",
+  "Budget review prep: pulled the invoice totals and drafted talking points for the finance sync.",
+  "Interview loop debrief written up and shared with the hiring committee for tomorrow's decision.",
+  "Set up the new monitoring alert thresholds and confirmed the on-call rotation for next month.",
+  "Customer call summary: they like the new flow, asked about export options and pricing tiers.",
+  "Cleaned up the shared drive folders and standardized the naming for the project archives.",
+  "Weekly metrics roundup posted: signups steady, churn slightly down, support queue healthy.",
+  "Offsite logistics: confirmed the venue, collected dietary notes, and drafted the agenda.",
+];
+
+let harper: HarperInstance;
+const teammate = mkAgent(`t1246-teammate-${randomUUID()}`);
+const reader = mkAgent(`t1246-reader-${randomUUID()}`);
+const ONTASK_ID = `${teammate.id}-ontask`;
+const noiseId = (i: number) => `${teammate.id}-noise-${String(i + 1).padStart(2, "0")}`;
+
+// Backdated so nothing rides a recency window (teammate records never enter
+// the reader's own-context sections anyway; this keeps the fixture inert to
+// future recency-window changes).
+const BACKDATED = new Date(Date.now() - 40 * 24 * 3600_000).toISOString();
+
+gate("flair#1246 — bootstrap teammate ranking agrees with memory_search (one ranker, one scale)", () => {
+  beforeAll(async () => {
+    harper = await startHarper();
+    await registerAgent(harper, teammate);
+    await registerAgent(harper, reader);
+    await putMemory(harper, teammate, ONTASK_ID, {
+      agentId: teammate.id, content: ONTASK_CONTENT, durability: "standard", visibility: "shared", createdAt: BACKDATED,
+    });
+    for (let i = 0; i < NOISE.length; i++) {
+      await putMemory(harper, teammate, noiseId(i), {
+        agentId: teammate.id, content: NOISE[i], durability: "standard", visibility: "shared", createdAt: BACKDATED,
+      });
+    }
+  }, 300_000);
+
+  afterAll(async () => { if (harper) await stopHarper(harper); });
+
+  test("the on-task record is search's top result AND bootstrap's top teammate pick — and the two picks agree", async () => {
+    // ── Search half: the fused ranking is the reference ranker. ──
+    const search = await post(harper, reader, "/SemanticSearch", {
+      agentId: reader.id, q: CURRENT_TASK, limit: 10, scoring: "raw",
+    });
+    const searchIds: string[] = (search.results ?? []).map((r: any) => r.id);
+    expect(searchIds.length, `search returned no results: ${JSON.stringify(search).slice(0, 300)}`).toBeGreaterThan(0);
+    // Present in search (the issue's literal parity ask) ...
+    expect(searchIds, "on-task record missing from search results entirely").toContain(ONTASK_ID);
+    // ... and fused to rank 1 (BM25 rank-1 rescue; measured fused rank 1 at
+    // this exact fixture shape).
+    expect(searchIds[0], `search top result was ${searchIds[0]} — fused ranking should put the lexically-decisive on-task record first`).toBe(ONTASK_ID);
+
+    // ── Bootstrap half: the SAME store + query through the teammate pass. ──
+    const boot = await post(harper, reader, "/BootstrapMemories", {
+      agentId: reader.id, maxTokens: 16000, currentTask: CURRENT_TASK,
+    });
+    const findings: any[] = boot.teammateFindings ?? [];
+    const findingIds: string[] = findings.map((f: any) => f.id);
+    expect(findingIds.length, `no teammateFindings at all — hint: ${boot.teammateFindingsHint ?? "none"}`).toBeGreaterThan(0);
+
+    // Present in bootstrap's teammate picks (parity: present in BOTH) ...
+    expect(findingIds, "on-task record missing from bootstrap's teammate findings — bootstrap's ranking diverged from search").toContain(ONTASK_ID);
+
+    // ... and the TOP pick (fused rank 1). THIS is the mutation tripwire:
+    // under hybrid:false the teammate list leads with bland noise (on-task
+    // measured at HNSW rank 6 in this exact fixture) while search still
+    // fuses it to rank 1 — membership alone stays green at N=21 because the
+    // candidate pool never truncates, but the top pick flips.
+    expect(findingIds[0], `bootstrap's top teammate pick was ${findingIds[0]} — the two retrieval surfaces rank the same store+query differently`).toBe(ONTASK_ID);
+
+    // The parity statement itself: bootstrap's #1 teammate pick IS search's
+    // #1 result. Stated independently of ONTASK_ID so a future fixture edit
+    // can't quietly turn this into two unrelated pins.
+    expect(findingIds[0], "bootstrap's top teammate pick and search's top result disagree").toBe(searchIds[0]);
+
+    // #1199 count contract holds with no relevance floor (flair#1246):
+    // matched == included + truncated ("matched" = entered the scored pool).
+    expect(boot.teammateFindingsIncluded + boot.teammateFindingsTruncated).toBe(boot.teammateFindingsMatched);
+  }, 120_000);
+});

--- a/test/integration/bootstrap-teammate-findings-e2e.test.ts
+++ b/test/integration/bootstrap-teammate-findings-e2e.test.ts
@@ -145,9 +145,10 @@ const ID_PRIVATE = `${owner.id}-private`;
 const ID_OWN = `${grantee.id}-own`;
 
 // Tightly-aligned domain (shared distinctive entity + subject phrase across
-// currentTask and all three memories) to clear MemoryBootstrap.ts's
-// `score > 0.3` raw-cosine threshold deterministically against the REAL
-// nomic embedding model, while keeping each memory's actual informational
+// currentTask and all three memories) so every record ranks high in
+// MemoryBootstrap.ts's task-relevant retrieval pool deterministically against
+// the REAL nomic embedding model (fused rank + budget selection since
+// flair#1246), while keeping each memory's actual informational
 // content genuinely distinct (so Memory.ts's dedup co-gate — cosine >= 0.95
 // AND lexical Jaccard >= 0.5 — never conflates them into one record).
 const CURRENT_TASK = "Prepare talking points for the Acme Corp vendor contract renegotiation meeting this week.";

--- a/test/unit-isolated/memory-bootstrap-scoping.test.ts
+++ b/test/unit-isolated/memory-bootstrap-scoping.test.ts
@@ -27,14 +27,16 @@ delete (process.env as any).FLAIR_PUBLIC;
 // technique as test/unit/memory-integrity.test.ts (constant vector → cosine
 // 1.0 between any two records using it). MemoryBootstrap.ts's task-relevant
 // path (flair-bootstrap-scale-fix: now routed through the shared
-// retrieveCandidates() core, resources/semantic-retrieval-core.ts) calls
+// retrieveCandidates() core, resources/semantic-retrieval-core.ts; since
+// flair#1246 in the SAME hybrid+q mode memory_search uses) calls
 // getEmbedding(currentTask) for the query vector; this mock's Memory.search()
 // never annotates $distance (no real HNSW sort), so retrieveCandidates()
 // falls back to its point-lookup cosine path (Memory.get(), also mocked
 // above), reading `record.embedding` directly off whatever's in the mock
-// store. The SAME 128-length vector on both sides deterministically clears
-// the `_score > 0.3` (TASK_RELEVANCE_FLOOR) threshold (cosine similarity
-// with itself = 1). memory-integrity.test.ts's own mock of this module only
+// store. The SAME 128-length vector on both sides gives a deterministic
+// cosine 1.0, ranking the record at the top of the fused candidate pool
+// (flair#1246 removed the old `_score > 0.3` TASK_RELEVANCE_FLOOR — selection
+// is fused rank + budget now). memory-integrity.test.ts's own mock of this module only
 // needs "a constant vector returned every call" (never compares its literal
 // values against anything) — length differing between the two files' mocks
 // doesn't matter to either.
@@ -281,9 +283,9 @@ describe("MemoryBootstrap.post() — centralized read-scoping", () => {
 // change whether a non-private record surfaces, or whether a private one
 // stays hidden.
 //
-// All records below carry embedding: FAKE_EMBEDDING so they clear the
-// `score > 0.3` deterministic-cosine-1.0 threshold against any currentTask
-// (mocked getEmbedding returns the same vector, see top of file). createdAt
+// All records below carry embedding: FAKE_EMBEDDING so they rank at the top
+// of the task-relevant pool (deterministic cosine 1.0 against any currentTask
+// — mocked getEmbedding returns the same vector, see top of file). createdAt
 // is pinned far in the past so nothing here is ever swept into the
 // recent/permanent sections instead — the point is to isolate the
 // task-relevant scored path exclusively.
@@ -294,7 +296,7 @@ describe("MemoryBootstrap.post() — flair#550 teammate-findings attribution + s
     reset();
     // A teammate record only RENDERS via the task-relevant teammate section
     // (own-context sections are own-only), so make it task-relevant: embedding
-    // + currentTask (mocked getEmbedding → cosine 1.0 clears score > 0.3).
+    // + currentTask (mocked getEmbedding → cosine 1.0 tops the fused pool).
     memoryStore.set("shared-attr", {
       id: "shared-attr", agentId: "agent-owner", content: "TEAMMATE-ATTR-FINDING",
       visibility: "shared", durability: "standard", createdAt: OLD_DATE, embedding: FAKE_EMBEDDING,


### PR DESCRIPTION
Closes #1246

Implements the measurement-ratified design (see the 6-variant measurement and Kern's ruling on the issue): bootstrap's teammate/task-relevant pass and `memory_search` now rank on the same scale, and the provably-inert relevance floor is gone.

## What changed

**1. Bootstrap's task-relevant pass runs the search ranker** (`resources/MemoryBootstrap.ts`). The `retrieveCandidates` call goes HNSW-only → hybrid, and passes `q: currentTask` as the lexical leg. HNSW-only was an accident of early code: the two surfaces ranked the same store+query on different signals, so a record whose task-relevance is lexical (exact task terms inside semantically-atypical prose) fused to rank 1 in search while bootstrap buried it under bland-generic noise on pure cosine — measured at N=21: on-task cosine 0.5656 vs noise max 0.6086, HNSW rank 6, BM25 rank 1 (6.485 vs noise max 2.946), fused rank 1. At field scale (corpus >> candidatePoolK) that inversion becomes exclusion from the K-bounded pool entirely — the plausible field mechanism behind the report.

One judgment call on the ratified "`hybrid: false` → `hybrid: true`" line, flagged for review: the pass resolves the mode from the same `hybridEnabled()` selector SemanticSearch uses rather than a literal `true`. Default is identical (flag ships ON), but a literal `true` would re-create the #1246 divergence in reverse whenever the documented `FLAIR_HYBRID_RETRIEVAL` kill-switch is flipped — search reverts to legacy while bootstrap stays hybrid. One ranker, one scale means one mode selector, two callers; the kill-switch now moves both surfaces together.

**2. `TASK_RELEVANCE_FLOOR` removed** (the `_score > 0.3` gate + the constant). The measurement proved it inert on the shipped embedding model: across 6 variants x 21 records (126 measured), nothing scored under ~0.44 — the floor cut zero records, and it never delivered "show nothing when nothing's relevant" either (fully-unrelated bland noise sits 0.44–0.63). It's removed rather than recalibrated because no absolute bar works at these scales: one tight enough to exclude max-dilution noise (0.6086) also cuts the pathological on-task case (0.5656). Selection is fused retrieval rank + the existing token budget. A removal note at the constant's old site and the module doc say why, so it doesn't quietly come back. The stale cross-reference in `resources/abstention.ts` is updated (ABSTENTION_THRESHOLD itself is untouched, and abstention only ever adds a signal — it never removes a memory).

**3. Count contracts unchanged in shape.** `teammateFindingsIncluded + teammateFindingsTruncated == teammateFindingsMatched` (#1199) still holds — matched is derived as that sum, and included/truncated remain disjoint-and-exhaustive over the scored pool. What changed is the pool's *meaning*: "matched" now reads "entered the scored (fused-rank, K-bounded) retrieval pool" rather than "cleared the floor" — derivation comments and the empty-container hint text updated to match. #1207/#1226 budget charging is untouched: the packing loop, `contentCost`, and truncation accounting are byte-identical; the only upstream change is candidate ordering and the absence of the (never-firing) floor filter. Conformance invariants (countCoherence, budgetCap) verified green — suite run below.

**4. Parity eval case** (`test/integration/bootstrap-search-parity-1246.test.ts`) — the issue's original ask, and the CI tripwire for future path divergence. Real Harper + real embeddings, seeded with the measurement's max-dilution fixture (one lexically-decisive on-task record + a 20-record bland noise cluster). Asserts: the on-task record is present in BOTH surfaces, it is search's top result AND bootstrap's top teammate pick, the two top picks agree with each other, and the #1199 count contract holds.

**Mutation-checked both directions** in this branch's verification run:
- fix state (hybrid + q): parity test PASSES;
- mutated back to `hybrid: false` (rebuilt, re-run): parity test FAILS exactly as the measurement predicts — bootstrap's top teammate pick becomes the measured HNSW-rank-1 noise record (`noise-17`) while search still fuses the on-task record to rank 1. N=21 can't truncate the candidate pool (candidatePoolK ≥ 50), so plain membership stays green under the mutation by design — the fused-rank-1 vs HNSW-rank-6 divergence assertions are the tripwire, per the measured data.

## Perf note (Kern-accepted)

`hybrid` on the bootstrap path adds a BM25 pass over the scoped corpus per bootstrap call. This is the same per-call corpus scan every `memory_search` request already runs (the hybrid leg's corpus fetch has no `limit` today on the search path either) — bootstrap inherits search's existing cost profile rather than a new one. Accepted in the ratification as the price of one ranker; if the corpus scan ever needs bounding, it's one shared fix in the core for both callers.

## Verification (vs a measured origin/main baseline at 39120e58, all lanes local)

| Lane | baseline (origin/main) | this branch |
|---|---|---|
| unit (`test/unit/` + `test/*.test.ts`) | 4577 pass / 0 fail | 4577 pass / 0 fail |
| unit-isolated (per-file) | 4 files, 0 fail | 4 files, 0 fail |
| integration (full, chunked) | 535 pass / 0 fail (71 files) | 536 pass / 0 fail (72 files) |
| integration-isolated | 11 pass / 0 fail | 11 pass / 0 fail |
| mcp-connector-conformance suite (countCoherence, budgetCap) | green | 19 pass / 0 fail |
| recall-eval gate (fired, model present — not skipped) | green | 7 pass / 0 fail |
| #1199 / #1207 / trust-budget contract tests | green | 6 pass / 0 fail |

The +1 integration delta is the new parity case. Ephemeral Harpers were HOME-isolated per the shared lifecycle helper; production instance health-checked 200 before and after the runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
