### PR TITLE
Team Concierge GCP deploy prep: Vertex AI Agent Engine package + 10-minute operator runbook

### DIFF
--- a/.changelog/unreleased/added-team-concierge-gcp-deploy.md
+++ b/.changelog/unreleased/added-team-concierge-gcp-deploy.md
@@ -1,0 +1,8 @@
+- Team Concierge GCP deploy package (`examples/team-concierge/deploy/gcp/`):
+  a 10-minute operator runbook + deploy script putting the example on Vertex
+  AI Agent Engine with Gemini and memory on a self-hosted Flair Fabric hub —
+  the Ed25519 identity is minted in Cloud Shell, delivered to the runtime via
+  a Secret Manager env reference, and materialized into adk-flair's keyfile
+  by a boot shim registered through ADK's services.py channel; includes a
+  verify chat helper, honest failure modes, and a full teardown path
+  (#1228, #1229)

--- a/examples/team-concierge/README.md
+++ b/examples/team-concierge/README.md
@@ -151,6 +151,11 @@ an agent identity against Fabric (`flair agent add concierge --target ...
 opt-in `FLAIR_ALLOW_REMOTE_URL=1`. Never inline credentials in commands or
 config — keys stay in files, admin passwords in your secret store.
 
+To run the Concierge **managed on GCP** — Vertex AI Agent Engine with Gemini,
+memory on your Fabric hub, the identity key minted in Cloud Shell and
+delivered via Secret Manager — follow the 10-minute
+[deploy/gcp/RUNBOOK.md](deploy/gcp/RUNBOOK.md).
+
 ## Not this example
 
 - Not a multi-tenant showcase: per-user **MCP** identities (each teammate's

--- a/examples/team-concierge/concierge/requirements.txt
+++ b/examples/team-concierge/concierge/requirements.txt
@@ -1,0 +1,19 @@
+# Dependencies for the Agent Engine container image (deploy/gcp/RUNBOOK.md).
+#
+# `adk deploy agent_engine` copies THIS folder into the image and runs
+# `pip install -r` on this exact file (google-adk 2.7.1 cli_deploy.py). If the
+# file is missing, the CLI generates one that omits adk-flair — and the
+# deployed container cannot import the memory backend. Local runs
+# (`pip install -e .`, adk web/run) never read this file; the example's
+# pyproject.toml stays the local dependency source.
+#
+# google-adk itself is NOT listed here on purpose: the generated Dockerfile
+# installs google-adk[a2a] pinned to the deploying environment's version
+# BEFORE these requirements, and re-pinning it here could silently diverge
+# from the CLI flags that were baked for that version.
+#
+# The explicit google-cloud-aiplatform line also pre-empts the deploy CLI's
+# _ensure_agent_engine_dependency fallback, which would otherwise append its
+# own aiplatform AND a second google-adk pin to this file at staging time.
+adk-flair>=0.44.13
+google-cloud-aiplatform[adk,agent_engines]>=1.164

--- a/examples/team-concierge/deploy/gcp/RUNBOOK.md
+++ b/examples/team-concierge/deploy/gcp/RUNBOOK.md
@@ -1,0 +1,267 @@
+# Team Concierge on Vertex AI Agent Engine — operator runbook
+
+Ten minutes from a GCP project to the [Team Concierge](../../README.md)
+running on **Vertex AI Agent Engine** (Google's managed ADK runtime — the
+current docs call it *Agent Runtime* on the *Gemini Enterprise Agent
+Platform*; the API resource is still `reasoningEngines`), with **Gemini** as
+the model and **memory on your self-hosted Flair Fabric hub** via
+[adk-flair](https://pypi.org/project/adk-flair/) ≥ 0.44.13.
+
+The shape, in one paragraph: `deploy.sh` wraps `adk deploy agent_engine`
+around the unchanged [`../../concierge`](../../concierge) agent folder.
+Agent Engine builds a container that runs ADK's API server with
+`--memory_service_uri=flair://<your-hub>:443`; a boot shim
+([`runtime/services.py`](runtime/services.py), staged via
+`--extra_packages`) registers the `flair://` scheme and turns the Ed25519
+key — delivered by Agent Engine from **Secret Manager** as an env var — into
+the keyfile adk-flair reads. The key is **minted in Cloud Shell** against
+your hub and never transits a laptop.
+
+Everything here is environment-and-file based: no credential ever appears
+inline in a command, and nothing in this runbook prints key material.
+
+## 1. Prerequisites (~2 min)
+
+- A GCP project with **billing enabled**, and permissions to enable APIs,
+  create secrets, and deploy Vertex AI resources (Owner on a scratch project
+  is the simple case).
+- A reachable **Flair Fabric hub** and its **admin password** — the
+  [Fabric quickstart](../../../../docs/quickstart-fabric.md) gets you from
+  zero to `https://<cluster>.<org>.harperfabric.com`.
+- Everything below runs in **Cloud Shell** (which is the point: the identity
+  key is born in the cloud environment). `gcloud` is already authenticated
+  there.
+
+```bash
+export PROJECT_ID=<your-project-id>
+export FLAIR_URL=https://<cluster>.<org>.harperfabric.com
+gcloud config set project "$PROJECT_ID"
+gcloud services enable aiplatform.googleapis.com \
+  secretmanager.googleapis.com cloudresourcemanager.googleapis.com
+```
+
+## 2. Cloud Shell tooling (~2 min)
+
+```bash
+# The flair CLI needs Node 22+ (Cloud Shell ships nvm if the default is older):
+node --version || nvm install 22
+npm i -g @tpsdev-ai/flair
+
+# The deploy CLI and the SDK it drives. google-adk does NOT depend on the
+# vertexai SDK — `adk deploy agent_engine` imports it lazily and fails
+# without it, so install both:
+pip install --user "google-adk~=2.7" "google-cloud-aiplatform[agent_engines,adk]"
+
+# This repo, for the example + deploy package:
+git clone https://github.com/tpsdev-ai/flair.git
+cd flair/examples/team-concierge/deploy/gcp
+```
+
+## 3. Mint the concierge's identity — in Cloud Shell (~1 min)
+
+The agent gets **its own** Flair identity (`concierge-gcp`), never a shared
+or admin key. Minting here means the private key exists only in this Cloud
+Shell session and, after step 4, in Secret Manager.
+
+```bash
+# Admin password into an owner-only file — typed at a hidden prompt, so it
+# never lands in shell history or `ps`:
+umask 077 && mkdir -p ~/.flair
+IFS= read -rs -p "Fabric admin password: " _p && printf '%s\n' "$_p" > ~/.flair/fabric-admin-pass && unset _p; echo
+
+# Register the identity against the hub. Fabric's ops API is port 9925 on
+# the SAME hostname (not the local "data port - 1" default):
+flair agent add concierge-gcp \
+  --target "$FLAIR_URL" \
+  --ops-target "$FLAIR_URL:9925" \
+  --admin-pass-file ~/.flair/fabric-admin-pass
+```
+
+Expected: `Keypair written: ~/.flair/keys/concierge-gcp.key` and a
+registration confirmation. The hub stores only the public key.
+
+## 4. Key → Secret Manager (~1 min)
+
+The keyfile is single-line base64 (PKCS8 Ed25519), so it survives
+env-var transport verbatim. Store the file, never echo it:
+
+```bash
+gcloud secrets create concierge-gcp-flair-key \
+  --data-file="$HOME/.flair/keys/concierge-gcp.key"
+
+# Agent Engine resolves secret references as its service agent; grant it
+# accessor on this one secret (not project-wide):
+PROJECT_NUMBER="$(gcloud projects describe "$PROJECT_ID" --format='value(projectNumber)')"
+gcloud secrets add-iam-policy-binding concierge-gcp-flair-key \
+  --member="serviceAccount:service-${PROJECT_NUMBER}@gcp-sa-aiplatform.iam.gserviceaccount.com" \
+  --role=roles/secretmanager.secretAccessor
+```
+
+If the binding fails because the service agent does not exist yet (fresh
+project), create it and retry:
+
+```bash
+gcloud beta services identity create --service=aiplatform.googleapis.com --project="$PROJECT_ID"
+```
+
+## 5. Deploy (~3 min)
+
+```bash
+PROJECT_ID="$PROJECT_ID" FLAIR_URL="$FLAIR_URL" ./deploy.sh
+```
+
+Defaults (override via env): `REGION=us-central1`,
+`FLAIR_AGENT_ID=concierge-gcp`, `FLAIR_KEY_SECRET=concierge-gcp-flair-key`,
+`GEMINI_MODEL=gemini-2.5-flash` (delivered to the agent as `ADK_MODEL` — the
+model knob the concierge already reads; any current Gemini id works, see
+[model + region constraints](#model--region-constraints)).
+
+The script renders the Agent Engine config (`env_vars` including the
+Secret Manager reference), derives the `flair://<host>:443` memory URI from
+`FLAIR_URL`, and runs `adk deploy agent_engine`. **Note the
+`projects/.../locations/.../reasoningEngines/<id>` resource name it prints**
+— the verify step and teardown both take it.
+
+To update an existing instance instead of creating a new one:
+`AGENT_ENGINE_ID=<id> ./deploy.sh`.
+
+## 6. Verify — the demo is the test (~2 min)
+
+Record a decision through the deployed agent, then prove it landed on the
+hub **readable by a different identity** — that crossing of the identity
+wall is the product claim.
+
+```bash
+export RESOURCE=projects/<p>/locations/<r>/reasoningEngines/<id>   # from step 5
+
+# 6a. Chat: record a team decision (use your real handle as --user; it
+#     becomes the adk:concierge:<user> scope on the hub):
+python3 chat.py --resource "$RESOURCE" --user <your-handle> \
+  "We decided to adopt the fastify adapter because it halves p99."
+```
+
+Expected: the concierge confirms it recorded a team decision
+(persistent + shared).
+
+```bash
+# 6b. Cross-identity read: mint a second, throwaway identity and search as it.
+flair agent add verify-reader \
+  --target "$FLAIR_URL" --ops-target "$FLAIR_URL:9925" \
+  --admin-pass-file ~/.flair/fabric-admin-pass
+
+flair memory search "fastify adapter" --agent verify-reader --target "$FLAIR_URL"
+```
+
+Expected: the decision row comes back — `visibility: "shared"`, content
+matching what you told the concierge — returned to an identity that did not
+write it. The hub stamps attribution server-side: the row belongs to
+`concierge-gcp` (the agent identity), scoped by the `adk:concierge:<user>`
+tag you chatted under.
+
+```bash
+# 6c. Shared org context in bootstrap:
+flair bootstrap --agent verify-reader --target "$FLAIR_URL"
+```
+
+Expected: the cold-start context includes the shared decision — this is what
+every teammate's agent sees on boot without anyone re-typing anything.
+
+Once verified, the Cloud Shell copy of the concierge key is redundant
+(Secret Manager holds it now):
+
+```bash
+rm -f ~/.flair/keys/concierge-gcp.key
+```
+
+## Honest failure modes
+
+**401s from the hub (identity not registered).** If step 3 was skipped, ran
+against a different hub than `FLAIR_URL`, or the secret holds a stale key
+(e.g. re-minted after upload), every memory op gets 401. Symptoms: chat
+works but recording fails; the instance's Cloud Logging shows adk-flair
+request errors. Fix: re-run step 3 against the right hub (`flair agent add`
+refuses an existing id — remove it first or pick a new id + secret), push
+the current keyfile as a **new secret version**
+(`gcloud secrets versions add concierge-gcp-flair-key --data-file=...`), and
+redeploy with `AGENT_ENGINE_ID=<id>` so the runtime picks it up.
+
+**Container fails at boot — key path.** `runtime/services.py` raises
+`RuntimeError: Neither FLAIR_KEYFILE nor FLAIR_ED25519_KEY is set` (visible
+in Cloud Logging) when the secret reference didn't reach the runtime:
+the secret id in the config doesn't exist, the service agent lacks
+`secretmanager.secretAccessor` (step 4), or a stray `.env` file in the agent
+folder replaced the deploy config's `env_vars` (deploy.sh refuses to deploy
+in that case — don't bypass it). A malformed key fails one line later, in
+FlairMemoryService's constructor, naming `FLAIR_KEYFILE`.
+
+**`FLAIR_URL ... is not a localhost address`.** adk-flair requires the
+explicit remote opt-in `FLAIR_ALLOW_REMOTE_URL=1`; deploy.sh always sets it.
+Seeing this error means the deploy config's env didn't land — same causes as
+above.
+
+**Region.** Agent Engine is region-restricted; `us-central1` is the
+documented default in the ADK deploy docs, and the supported list is on the
+[locations page](https://docs.cloud.google.com/agent-builder/locations#supported-regions-agent-engine).
+The Gemini model must also be available in the region you pick. Symptom of a
+mismatch: create/deploy fails immediately, or the first query errors with a
+model-availability message.
+
+**Hub latency.** adk-flair uses tight sub-2s HTTP timeouts with no retry —
+pick the GCP region nearest your Fabric hub, or memory ops will
+intermittently time out while chat still responds.
+
+## Model + region constraints
+
+- **Model**: variable, not hardcoded — `GEMINI_MODEL` → runtime `ADK_MODEL`.
+  Default `gemini-2.5-flash` (GA on Vertex AI, and the example's own local
+  default, so cloud and laptop behave identically). Newer Gemini lines (e.g.
+  Gemini 3 Flash) work by overriding the variable — check
+  [Vertex AI model docs](https://docs.cloud.google.com/vertex-ai/generative-ai/docs/models)
+  for current ids and regional availability. The runtime authenticates to
+  Gemini via the project's Vertex AI path (the generated image sets
+  `GOOGLE_GENAI_USE_ENTERPRISE=1` + project/region) — **no API key is
+  deployed anywhere in this package**.
+- **Region**: `REGION` variable, default `us-central1` (the canonical region
+  in the [ADK Agent Engine deploy docs](https://adk.dev/deploy/agent-runtime/deploy/)).
+  Supported list: [Agent Engine locations](https://docs.cloud.google.com/agent-builder/locations#supported-regions-agent-engine).
+
+## Teardown — dogfood must be cleanly removable
+
+Order: runtime first (stop the writer), then key material, then identity.
+
+```bash
+# 1. Delete the Agent Engine instance (child resources included):
+python3 - <<'PYEOF'
+import os, vertexai
+name = os.environ["RESOURCE"]
+segments = name.split("/")
+client = vertexai.Client(project=segments[1], location=segments[3])
+client.agent_engines.delete(name=name, force=True)
+print("deleted:", name)
+PYEOF
+
+# 2. Delete the secret (all versions):
+gcloud secrets delete concierge-gcp-flair-key
+
+# 3. Revoke the identity on the hub. `flair agent remove` only speaks to a
+#    LOCAL instance today (it dials 127.0.0.1's ops port), so against Fabric
+#    delete the Agent row via the ops API — this revokes the public key, so
+#    the identity can never authenticate again. curl prompts for the admin
+#    password (kept out of argv and history):
+curl -u admin "$FLAIR_URL:9925/" \
+  -H "Content-Type: application/json" \
+  -d '{"operation":"delete","database":"flair","table":"Agent","ids":["concierge-gcp"]}'
+# Same call with "verify-reader" for the throwaway reader identity.
+
+# 4. Cloud Shell remnants:
+rm -f ~/.flair/keys/concierge-gcp.key ~/.flair/keys/concierge-gcp.key.pub \
+      ~/.flair/keys/verify-reader.key ~/.flair/keys/verify-reader.key.pub \
+      ~/.flair/fabric-admin-pass
+```
+
+Deliberately **not** deleted: memories the concierge recorded. Team
+decisions are shared org knowledge — revoking the writer's key does not (and
+should not) claw back what the team already knows. If you want a full purge,
+delete the Memory rows for `agentId=concierge-gcp` through the same ops API
+(mirror what `flair agent remove` does locally: `search_by_value` on
+`agentId`, then `delete` by ids).

--- a/examples/team-concierge/deploy/gcp/chat.py
+++ b/examples/team-concierge/deploy/gcp/chat.py
@@ -1,0 +1,81 @@
+"""Verify chat against the deployed Team Concierge on Agent Engine.
+
+Usage (Cloud Shell, after deploy.sh — ADC supplies credentials, no keys here):
+
+    python3 chat.py --resource projects/<p>/locations/<r>/reasoningEngines/<id> \
+        --user <your-handle> "We decided to adopt X because Y"
+
+--user becomes the ADK user_id, which the connector scopes into the compound
+tag adk:concierge:<user>. Use your real handle: the verify step then checks
+that the decision landed on the hub under that scope, attributed to the
+concierge's Flair identity.
+
+The deployed instance registers stream_query(message, user_id[, session_id])
+(google-adk 2.7.1 registers these class methods at deploy); the vertexai
+client binds them on agent_engines.get(). This script prints streamed events'
+text parts and nothing else — no env, no headers, no key material.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+
+
+def _event_texts(event) -> list[str]:
+    """Text parts of one streamed event (dict-shaped over the wire)."""
+    if not isinstance(event, dict):
+        return []
+    content = event.get("content") or {}
+    parts = content.get("parts") or []
+    return [p["text"] for p in parts if isinstance(p, dict) and p.get("text")]
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument(
+        "--resource",
+        required=True,
+        help="projects/<p>/locations/<r>/reasoningEngines/<id> (printed by deploy.sh)",
+    )
+    parser.add_argument(
+        "--user",
+        required=True,
+        help="ADK user_id -> adk:concierge:<user> tag scope on the hub",
+    )
+    parser.add_argument("message", help="one chat message to send")
+    args = parser.parse_args()
+
+    segments = args.resource.split("/")
+    if len(segments) < 6 or segments[0] != "projects" or segments[2] != "locations":
+        print(
+            "chat.py: --resource must be the full name "
+            "projects/<p>/locations/<r>/reasoningEngines/<id> "
+            f"(got: {args.resource})",
+            file=sys.stderr,
+        )
+        return 2
+
+    import vertexai  # deferred: import cost only after arg validation
+
+    client = vertexai.Client(project=segments[1], location=segments[3])
+    engine = client.agent_engines.get(name=args.resource)
+
+    got_text = False
+    for event in engine.stream_query(message=args.message, user_id=args.user):
+        for text in _event_texts(event):
+            got_text = True
+            print(text)
+    if not got_text:
+        print(
+            "chat.py: the query streamed no text events. Check the instance's "
+            "logs in Cloud Logging (RUNBOOK: failure modes) — a memory-service "
+            "boot failure surfaces there, not here.",
+            file=sys.stderr,
+        )
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/examples/team-concierge/deploy/gcp/deploy.sh
+++ b/examples/team-concierge/deploy/gcp/deploy.sh
@@ -1,0 +1,147 @@
+#!/usr/bin/env bash
+# Team Concierge -> Vertex AI Agent Engine (Agent Runtime) deploy.
+#
+# Wraps `adk deploy agent_engine` (google-adk >= 2.7) around the UNCHANGED
+# ../../concierge agent folder. The folder name is load-bearing: it becomes
+# the ADK app_name in the image, which keeps the connector's compound tag
+# adk:concierge:<user> identical to local runs. Do not point this script at a
+# renamed copy.
+#
+# Required environment:
+#   PROJECT_ID        GCP project id
+#   FLAIR_URL         Fabric hub origin, e.g. https://<cluster>.<org>.harperfabric.com
+# Optional (defaults shown):
+#   REGION=us-central1                     Agent Engine region (see RUNBOOK)
+#   FLAIR_AGENT_ID=concierge-gcp           Flair identity minted in Cloud Shell
+#   FLAIR_KEY_SECRET=concierge-gcp-flair-key   Secret Manager secret id
+#   FLAIR_KEY_SECRET_VERSION=latest
+#   GEMINI_MODEL=gemini-2.5-flash          becomes ADK_MODEL in the runtime
+#   DISPLAY_NAME="Team Concierge"
+#   AGENT_ENGINE_ID=                       set to UPDATE an existing instance
+#
+# No secret material passes through this script. The Ed25519 key reaches the
+# runtime as a Secret Manager reference resolved by Agent Engine itself.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+AGENT_DIR="$(cd "$SCRIPT_DIR/../../concierge" && pwd)"
+
+fail() { echo "deploy.sh: $1" >&2; exit 1; }
+
+: "${PROJECT_ID:?Set PROJECT_ID (gcloud config get-value project shows the active one)}"
+: "${FLAIR_URL:?Set FLAIR_URL (e.g. https://<cluster>.<org>.harperfabric.com)}"
+REGION="${REGION:-us-central1}"
+FLAIR_AGENT_ID="${FLAIR_AGENT_ID:-concierge-gcp}"
+FLAIR_KEY_SECRET="${FLAIR_KEY_SECRET:-concierge-gcp-flair-key}"
+FLAIR_KEY_SECRET_VERSION="${FLAIR_KEY_SECRET_VERSION:-latest}"
+GEMINI_MODEL="${GEMINI_MODEL:-gemini-2.5-flash}"
+DISPLAY_NAME="${DISPLAY_NAME:-Team Concierge}"
+AGENT_ENGINE_ID="${AGENT_ENGINE_ID:-}"
+
+# ── Preflight: tools ─────────────────────────────────────────────────────────
+command -v adk >/dev/null 2>&1 \
+  || fail "adk CLI not found. pip install \"google-adk~=2.7\" first (RUNBOOK step 2)."
+python3 - <<'PYEOF' || exit 1
+import sys
+try:
+    from google.adk import version
+except ImportError:
+    sys.exit("deploy.sh: google-adk is not importable from python3.")
+from packaging.version import parse
+if parse(version.__version__) < parse("2.7"):
+    sys.exit(
+        "deploy.sh: google-adk %s found, but this deploy path was verified "
+        "against >= 2.7 (agent_engine config-file + extra_packages semantics). "
+        "pip install -U 'google-adk~=2.7'." % version.__version__
+    )
+try:
+    import vertexai  # noqa: F401
+except ImportError:
+    sys.exit(
+        "deploy.sh: the vertexai SDK is missing. `adk deploy agent_engine` "
+        "imports it lazily and google-adk does NOT depend on it. "
+        "pip install 'google-cloud-aiplatform[agent_engines,adk]'."
+    )
+PYEOF
+
+# ── Preflight: agent folder ──────────────────────────────────────────────────
+[ -f "$AGENT_DIR/agent.py" ] || fail "agent folder not found at $AGENT_DIR"
+[ -f "$AGENT_DIR/requirements.txt" ] \
+  || fail "missing $AGENT_DIR/requirements.txt — the image installs agent deps from it; without it adk generates one WITHOUT adk-flair and the container cannot boot."
+# A .env in the agent folder would REPLACE the env_vars from the deploy config
+# (google-adk cli_deploy.py reads agent-folder .env in preference), and dotenv
+# cannot express a Secret Manager reference — so the key delivery would
+# silently vanish. Refuse.
+[ ! -f "$AGENT_DIR/.env" ] \
+  || fail "$AGENT_DIR/.env exists. It would override the deploy config's env_vars (including the Secret Manager key reference). Remove it before deploying."
+
+# ── FLAIR_URL -> flair:// memory URI ─────────────────────────────────────────
+# adk-flair's flair:// factory defaults the port to 19926 and uses https for
+# any non-localhost host. A Fabric origin serves on 443, so the port must be
+# explicit in the URI or the runtime would dial https://<host>:19926.
+case "$FLAIR_URL" in
+  https://*) : ;;
+  http://localhost*|http://127.0.0.1*)
+    fail "FLAIR_URL is a localhost address — the Agent Engine runtime cannot reach your machine. Point it at the Fabric hub (https://...)." ;;
+  *) fail "FLAIR_URL must be https:// for a remote hub (got: $FLAIR_URL). The flair:// scheme always dials https for non-localhost hosts, so an http:// origin cannot work." ;;
+esac
+HOSTPORT="${FLAIR_URL#*://}"
+HOSTPORT="${HOSTPORT%%/*}"
+case "$HOSTPORT" in
+  *:*) : ;;
+  *) HOSTPORT="$HOSTPORT:443" ;;
+esac
+MEMORY_URI="flair://$HOSTPORT"
+
+# ── Render the Agent Engine config (env_vars incl. Secret Manager ref) ───────
+CONFIG_FILE="$(mktemp -d)/agent_engine_config.json"
+export _AE_FLAIR_URL="$FLAIR_URL" _AE_AGENT_ID="$FLAIR_AGENT_ID" \
+       _AE_MODEL="$GEMINI_MODEL" _AE_SECRET="$FLAIR_KEY_SECRET" \
+       _AE_SECRET_VERSION="$FLAIR_KEY_SECRET_VERSION" _AE_OUT="$CONFIG_FILE"
+python3 - <<'PYEOF'
+import json, os
+config = {
+    "env_vars": {
+        # Plain values -> deployment_spec.env; the dict value ->
+        # deployment_spec.secret_env (SecretRef), resolved by Agent Engine and
+        # exposed to the container as the FLAIR_ED25519_KEY env var. See
+        # runtime/services.py for the env->keyfile step.
+        "FLAIR_URL": os.environ["_AE_FLAIR_URL"],
+        "FLAIR_AGENT_ID": os.environ["_AE_AGENT_ID"],
+        "FLAIR_ALLOW_REMOTE_URL": "1",  # adk-flair's explicit remote opt-in
+        "ADK_MODEL": os.environ["_AE_MODEL"],  # the agent's model knob
+        "FLAIR_ED25519_KEY": {
+            "secret": os.environ["_AE_SECRET"],
+            "version": os.environ["_AE_SECRET_VERSION"],
+        },
+    }
+}
+with open(os.environ["_AE_OUT"], "w") as f:
+    json.dump(config, f, indent=2)
+PYEOF
+unset _AE_FLAIR_URL _AE_AGENT_ID _AE_MODEL _AE_SECRET _AE_SECRET_VERSION _AE_OUT
+
+echo "Deploying $AGENT_DIR"
+echo "  project=$PROJECT_ID region=$REGION model=$GEMINI_MODEL"
+echo "  memory:  $MEMORY_URI (identity: $FLAIR_AGENT_ID, key: Secret Manager/$FLAIR_KEY_SECRET)"
+[ -n "$AGENT_ENGINE_ID" ] && echo "  updating existing instance: $AGENT_ENGINE_ID"
+
+# ── Deploy ───────────────────────────────────────────────────────────────────
+# --extra_packages stages runtime/services.py at /app/services.py; the ADK api
+# server imports it at boot (before memory-service resolution), which writes
+# the keyfile and registers the flair:// scheme.
+set -- \
+  --project "$PROJECT_ID" \
+  --region "$REGION" \
+  --display_name "$DISPLAY_NAME" \
+  --description "Team Concierge — ADK agent, memory on self-hosted Flair" \
+  --agent_engine_config_file "$CONFIG_FILE" \
+  --extra_packages "$SCRIPT_DIR/runtime/services.py" \
+  --memory_service_uri "$MEMORY_URI"
+[ -n "$AGENT_ENGINE_ID" ] && set -- "$@" --agent_engine_id "$AGENT_ENGINE_ID"
+
+adk deploy agent_engine "$@" "$AGENT_DIR"
+
+echo
+echo "Note the reasoningEngines resource name printed above — chat.py and the"
+echo "teardown both take it. Verify next: RUNBOOK.md section 6."

--- a/examples/team-concierge/deploy/gcp/runtime/services.py
+++ b/examples/team-concierge/deploy/gcp/runtime/services.py
@@ -1,0 +1,67 @@
+"""Agent Engine boot shim: Secret Manager key -> keyfile, then flair:// registration.
+
+Staged via ``--extra_packages`` so it lands at ``/app/services.py`` in the
+Agent Engine container (each extra package is placed at ``/app/<basename>``
+and ``/app`` joins PYTHONPATH). The container's entrypoint is
+``adk api_server ... /app/agents``; at startup ADK imports a top-level
+``services`` module (google.adk.cli.service_registry.load_services_module)
+BEFORE it resolves ``--memory_service_uri`` — so everything in this file runs
+exactly once, before FlairMemoryService is constructed.
+
+Order matters:
+
+1. ``FLAIR_ED25519_KEY`` — delivered by Agent Engine as a plain env var from a
+   Secret Manager reference in the deploy config (``env_vars`` with a
+   ``{"secret": ..., "version": ...}`` value) — is written to an owner-only
+   file. adk-flair reads the key from a PATH (``FLAIR_KEYFILE``); there is no
+   key-material env var in the connector, by design.
+2. ``FLAIR_KEYFILE`` is pointed at that file, in-process.
+3. The key-material env var is scrubbed from this process so child processes
+   and debug env dumps don't carry it. (The container's environment still
+   holds the value — this narrows exposure, it does not eliminate it.)
+4. ``adk_flair.register()`` makes the ``flair://`` scheme resolvable.
+
+FlairMemoryService validates the keyfile eagerly in its constructor, so a
+missing or invalid key fails the container at boot — loudly, in Cloud Logging
+— rather than on the first chat turn.
+"""
+
+from __future__ import annotations
+
+import os
+
+_KEY_ENV = "FLAIR_ED25519_KEY"
+_KEYFILE_ENV = "FLAIR_KEYFILE"
+_KEY_PATH = "/tmp/flair/agent.key"
+
+
+def _materialize_keyfile() -> None:
+    if os.environ.get(_KEYFILE_ENV):
+        # An explicit keyfile (e.g. local api_server testing) wins.
+        return
+    material = os.environ.get(_KEY_ENV, "")
+    if not material:
+        raise RuntimeError(
+            f"Neither {_KEYFILE_ENV} nor {_KEY_ENV} is set. The deploy config "
+            f"must deliver the agent's Ed25519 key as the {_KEY_ENV} env var "
+            'via a Secret Manager reference ("env_vars": {"'
+            f"{_KEY_ENV}"
+            '": {"secret": "<secret-id>", "version": "latest"}}) — '
+            "see deploy.sh / RUNBOOK.md — or FLAIR_KEYFILE must point at an "
+            "existing keyfile."
+        )
+    os.makedirs(os.path.dirname(_KEY_PATH), mode=0o700, exist_ok=True)
+    fd = os.open(_KEY_PATH, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+    try:
+        os.write(fd, material.encode("utf-8"))
+    finally:
+        os.close(fd)
+    os.environ[_KEYFILE_ENV] = _KEY_PATH
+    del os.environ[_KEY_ENV]
+
+
+_materialize_keyfile()
+
+from adk_flair import register  # noqa: E402  — import only after key delivery
+
+register()


### PR DESCRIPTION
Refs #1228, #1229. No deploy performed — package + runbook; Sherlock's key-in-cloud-secret design pass is a pre-deploy gate.

## What

GCP deploy prep for the Team Concierge: a deploy package under `examples/team-concierge/deploy/gcp/` plus a 10-minute operator runbook that puts the **unchanged** `concierge/` agent on **Vertex AI Agent Engine** with **Gemini** as the model and **memory on a self-hosted Flair Fabric hub** via `adk-flair>=0.44.13` (confirmed on PyPI: `pip install 'adk-flair>=0.44.13'` resolves 0.44.13). The Ed25519 identity is minted **in Cloud Shell** (`flair agent add concierge-gcp --target ... --ops-target ...:9925 --admin-pass-file ...`) so the key is born in the cloud environment and never transits a laptop, then stored in **Secret Manager** and delivered to the runtime as a SecretRef env var; a boot shim turns it into the keyfile adk-flair reads.

```
examples/team-concierge/
├── concierge/requirements.txt        NEW — image deps (see "why it must live here")
├── README.md                         pointer to the runbook (4 lines)
└── deploy/gcp/
    ├── RUNBOOK.md                    the operator's 10-minute path + failure modes + teardown
    ├── deploy.sh                     config render + adk deploy agent_engine wrapper
    ├── chat.py                       verify helper (stream_query against the deployed instance)
    └── runtime/services.py           boot shim: secret env -> 0600 keyfile -> flair:// registration
```

## The verified deploy path (primary sources, no guessing)

- **The documented Python deploy command is `adk deploy agent_engine --project ... --region ... <agent_folder>`** — [ADK deploy docs](https://adk.dev/deploy/agent-runtime/deploy/) (google.github.io/adk-docs now 301s to adk.dev; the target is being renamed "Agent Runtime" on the "Gemini Enterprise Agent Platform", the API resource is still `reasoningEngines/*`). Verified against the installed CLI: `adk deploy agent_engine --help` on google-adk **2.7.1** from PyPI.
- **`google-adk` does NOT depend on the vertexai SDK.** `pip show google-adk` lists no aiplatform/vertexai requirement; `cli_deploy.py` does `import vertexai` lazily inside `to_agent_engine`. The runbook therefore installs `google-cloud-aiplatform[agent_engines,adk]` (1.164.0 verified) alongside.
- **Packaging**: the agent FOLDER is the deploy unit — copied to `/app/agents/<basename>`; the generated Dockerfile runs `pip install "google-adk[a2a]==<deploying-env version>"` then `pip install -r /app/agents/<app>/requirements.txt` (google-adk 2.7.1 `cli_deploy.py`, `_DOCKERFILE_TEMPLATE` + `to_agent_engine`). `--requirements_file` is deprecated AND dead (the flag only warns; nothing reads it). If the agent folder has no `requirements.txt`, the CLI generates one containing only aiplatform + google-adk — **no adk-flair** — hence the new `concierge/requirements.txt`. This is also why the folder is deployed as-is instead of wrapped: `app_name = basename(agent_folder)`, and a wrapper folder would rename the app, splitting the connector's `adk:concierge:<user>` tag namespace between episode writes (session app_name) and the helpers' fixed `APP_NAME`.
- **Env vars & secrets**: `.agent_engine_config.json` (auto-discovered in the agent folder or passed via `--agent_engine_config_file`) carries `env_vars`; plain string values land in `deployment_spec.env`, dict values `{"secret": "<id>", "version": "latest"}` land in `deployment_spec.secret_env` as SecretRef — verified in vertexai 1.164.0 `_genai/agent_engines.py` (`_update_deployment_spec_with_env_vars_dict_or_raise`) and the `aiplatform_v1` `EnvVar`/`SecretRef`/`SecretEnvVar` protos, matching the [deploy-an-agent doc](https://docs.cloud.google.com/gemini-enterprise-agent-platform/scale/runtime/deploy-an-agent). The runtime sees the secret payload as a normal env var. Per the same doc, the **Agent Platform service agent** (`service-PROJECT_NUMBER@gcp-sa-aiplatform.iam.gserviceaccount.com`) needs `roles/secretmanager.secretAccessor` — the runbook grants it per-secret, not project-wide. **Stdin-style env delivery does not exist for this runtime; SecretRef env is the supported mechanism**, so key-material-as-env is unavoidable at the platform boundary — the shim narrows it (below).
- **Hazard verified**: a `.env` file in the agent folder **replaces** the config's `env_vars` wholesale (`cli_deploy.py` lines 1101–1175), and dotenv cannot express a SecretRef — key delivery would silently vanish. `deploy.sh` refuses to deploy if `concierge/.env` exists.
- **Custom memory scheme at runtime**: the generated container's CMD is `adk api_server ... --memory_service_uri=<uri> "/app/agents"`; at startup `load_services_module("/app/agents")` does a plain `importlib.import_module("services")` and the memory service is constructed **eagerly right after** (`fast_api.py` 231–240, `service_registry.py` 188–237). `--extra_packages` entries land at `/app/<basename>` with `/app` on PYTHONPATH — so `runtime/services.py` staged as an extra package IS the top-level `services` module, imported before URI resolution. It materializes the key (0600, then scrubs the env var in-process), sets `FLAIR_KEYFILE`, and calls `adk_flair.register()`. `FlairMemoryService` validates the keyfile **in its constructor**, so a broken key fails the container at boot, loudly, in Cloud Logging.
- **flair:// URI shape**: adk-flair's factory defaults the port to **19926** and uses https for any non-localhost host — a bare `flair://<fabric-host>` would dial `https://<host>:19926` and hang. `deploy.sh` derives `flair://<host>:443` from `FLAIR_URL` (explicit port preserved) and rejects non-https remote origins outright, since the factory cannot produce plain http for a remote host.
- **Model**: `GEMINI_MODEL` variable → runtime `ADK_MODEL` (the knob `concierge/agent.py` already reads). Default `gemini-2.5-flash` — GA per the [Vertex AI model docs](https://docs.cloud.google.com/vertex-ai/generative-ai/docs/models) and identical to the example's local default, so laptop and cloud behave the same; newer Gemini lines are an env override away. No API key anywhere: the generated image bakes `GOOGLE_GENAI_USE_ENTERPRISE=1` + project/region, so model auth rides the project's Vertex path.
- **Region**: `REGION` variable, default `us-central1` (the canonical region in the ADK deploy docs); the docs delegate the authoritative list to the [Agent Engine locations page](https://docs.cloud.google.com/agent-builder/locations#supported-regions-agent-engine), which the runbook links.

## Verification performed (no GCP calls, nothing deployed)

- **Container boot path rehearsed end-to-end** in a HOME-isolated venv (google-adk 2.7.1 + adk-flair 0.44.13 from PyPI): generated a throwaway PKCS8 Ed25519 key, delivered it as the env var, imported `services` the way `load_services_module` does → keyfile written mode 0600, env scrubbed, then `get_service_registry().create_memory_service("flair://host:443")` returned a `FlairMemoryService` with `https://host:443` and the right agent id. **Negative control**: without the env var the import raises the shim's actionable RuntimeError — the check can fire.
- **`deploy.sh` executed** against a recording `adk` stub: full argv + rendered config JSON (SecretRef included) verified on the happy path, update path (`AGENT_ENGINE_ID` → `--agent_engine_id`), and explicit-port derivation; all four refusal branches (`.env` present, http:// hub, localhost hub, missing requirements.txt) exercised and fail with actor+state+remedy messages.
- `chat.py` arg-validation path executed; `stream_query(message, user_id)` matches the class-method schema google-adk 2.7.1 registers at deploy.
- `node scripts/changelog-fragments.mjs check` and `node scripts/docs-freshness-check.mjs` pass (the freshness corpus is README/SECURITY/CONTRIBUTING + docs/** — examples are outside it).

## Teardown honesty

The runbook's teardown deletes the Agent Engine instance (`client.agent_engines.delete(name=..., force=True)` — signature verified in vertexai 1.164.0), the secret, and revokes the identity. One limitation surfaced and documented rather than papered over: **`flair agent remove` only speaks to a local instance today** (it dials `127.0.0.1`'s ops port — `src/cli.ts` agent-remove handler), so remote revocation goes through the hub's ops API (`delete` on the `Agent` table — the same operation the CLI performs locally), with curl prompting for the admin password so it never enters argv or history. Memories the concierge recorded are deliberately retained: revoking the writer's key should not claw back shared team knowledge; a full-purge recipe is included for those who want it.

Placeholders only throughout — `<cluster>.<org>.harperfabric.com`, `example.test`; no internal hostnames.
