### PR TITLE
federation sync: report private rows withheld on quiet path

### DIFF
--- a/.changelog/unreleased/fixed-1232-federation-sync-private-withheld.md
+++ b/.changelog/unreleased/fixed-1232-federation-sync-private-withheld.md
@@ -1,0 +1,9 @@
+- **`flair federation sync` now says when the quiet path is private rows
+  being withheld, not "no changes"** (flair#1232). Private Memory still
+  never leaves the instance. When the spoke found rows since the cursor
+  and the push filter held every one back, the printed line is `No
+  federable changes since last sync (N rows held back: private
+  visibility)` — count and reason only, no content. A genuine empty run
+  (nothing since the cursor, nothing withheld) still prints `No changes
+  since last sync.` Pairing, hub merge, lastSyncAt advance, and the
+  liveness ping are unchanged.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -7222,6 +7222,11 @@ export async function runFederationSyncOnce(opts: any): Promise<{ pushed: number
     }
 
     let totalBatches = 0;
+    // Memory rows that passed the since-cursor filter but were excluded as
+    // private. Used only so the quiet path can distinguish "nothing since
+    // the cursor" from "found rows, all withheld" (flair#1232). Does not
+    // change what gets pushed — private still never leaves the instance.
+    let privateHeldBack = 0;
 
     for (const table of tables) {
       let rows: any[] = [];
@@ -7255,11 +7260,10 @@ export async function runFederationSyncOnce(opts: any): Promise<{ pushed: number
         // filter only applies there; on the other 3 tables `row.visibility`
         // is always undefined, which isFederationPrivateVisibility() treats
         // as non-private (included) — a no-op for them.
-        rows = rows.concat(
-          batch
-            .filter((r: any) => r.updatedAt !== null || r.createdAt > since)
-            .filter((r: any) => table !== "Memory" || !isFederationPrivateVisibility(r.visibility)),
-        );
+        const sinceCursor = batch.filter((r: any) => r.updatedAt !== null || r.createdAt > since);
+        const federable = sinceCursor.filter((r: any) => table !== "Memory" || !isFederationPrivateVisibility(r.visibility));
+        if (table === "Memory") privateHeldBack += sinceCursor.length - federable.length;
+        rows = rows.concat(federable);
       }
       if (rows.length === 0) continue;
 
@@ -7384,7 +7388,15 @@ export async function runFederationSyncOnce(opts: any): Promise<{ pushed: number
         console.warn(`⚠️  Liveness ping error: ${pingErr?.message ?? pingErr}. Hub won't update spoke liveness.`);
       }
 
-      console.log("No changes since last sync.");
+      // flair#1232: "No changes" is true only when nothing was found since
+      // the cursor. If rows were found and every one was withheld as private,
+      // say so — count and reason only, never content. A zero withheld count
+      // must not invent a private-withheld story.
+      console.log(
+        privateHeldBack > 0
+          ? `No federable changes since last sync (${privateHeldBack} row${privateHeldBack === 1 ? "" : "s"} held back: private visibility).`
+          : "No changes since last sync.",
+      );
       return { pushed: 0, skipped: 0 };
     }
 

--- a/test/unit/federation-sync-push-privacy.test.ts
+++ b/test/unit/federation-sync-push-privacy.test.ts
@@ -126,6 +126,69 @@ describe("federation sync push — private-visibility filter", () => {
     expect(pushedRecordIds()).toEqual([]);
   });
 
+  /**
+   * flair#1232: the quiet path used to print "No changes since last sync."
+   * whenever totalBatches === 0 — including the case where rows WERE found
+   * since the cursor and every one was withheld as private. That message
+   * sent operators on a cursor/token/hub-loss hunt. The two stories below
+   * lock the distinction: withheld-private vs truly empty. Count + reason
+   * only; private content must not appear in the printed line.
+   */
+  function captureLogs(): { stdout: string[]; restore: () => void } {
+    const stdout: string[] = [];
+    const origLog = console.log;
+    console.log = (...args: any[]) => { stdout.push(args.map((a) => String(a)).join(" ")); };
+    return { stdout, restore: () => { console.log = origLog; } };
+  }
+
+  it("quiet path reports withheld-private count when every found row is private", async () => {
+    const secret = "SECRET CONTENT MUST NOT APPEAR IN THE MESSAGE";
+    const privateRows = Array.from({ length: 35 }, (_, i) => ({
+      id: `mem-private-${i}`,
+      agentId: "a1",
+      content: secret,
+      visibility: "private",
+      updatedAt: "2025-06-01T00:00:00.000Z",
+      createdAt: "2025-06-01T00:00:00.000Z",
+    }));
+    installMock(privateRows);
+
+    const logs = captureLogs();
+    try {
+      const { runFederationSyncOnce } = await import("../../src/cli");
+      const result = await runFederationSyncOnce({ adminPass: "test-admin-pass", opsPort: "9925" });
+
+      expect(result.error).toBeUndefined();
+      expect(pushedRecordIds()).toEqual([]);
+      expect(logs.stdout).toContain("No federable changes since last sync (35 rows held back: private visibility).");
+      expect(logs.stdout).not.toContain("No changes since last sync.");
+      expect(logs.stdout.join("\n")).not.toContain(secret);
+      // Liveness ping still fires — observability change only.
+      const emptyPings = hubSyncCalls().filter((c) => (c.body?.records ?? []).length === 0);
+      expect(emptyPings).toHaveLength(1);
+    } finally {
+      logs.restore();
+    }
+  });
+
+  it("quiet path still reads as no changes when nothing was found since the cursor", async () => {
+    installMock([]);
+
+    const logs = captureLogs();
+    try {
+      const { runFederationSyncOnce } = await import("../../src/cli");
+      const result = await runFederationSyncOnce({ adminPass: "test-admin-pass", opsPort: "9925" });
+
+      expect(result.error).toBeUndefined();
+      expect(pushedRecordIds()).toEqual([]);
+      expect(logs.stdout).toContain("No changes since last sync.");
+      expect(logs.stdout.join("\n")).not.toContain("held back");
+      expect(logs.stdout.join("\n")).not.toContain("private visibility");
+    } finally {
+      logs.restore();
+    }
+  });
+
   it("pushes a shared Memory row", async () => {
     installMock([
       { id: "mem-shared", agentId: "a1", content: "team update", visibility: "shared", updatedAt: "2025-06-01T00:00:00.000Z", createdAt: "2025-06-01T00:00:00.000Z" },


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #1232.

## Problem

`flair federation sync` printed **No changes since last sync.** whenever nothing was pushed (`totalBatches === 0`). That included the correct-behavior case where the spoke *did* find rows since the cursor and the private-visibility filter withheld every one of them.

On dtrt-pulse (2026-08-16) the hub lacked 35 spoke rows, all `visibility: "private"`. Sync said "no changes"; operators spent a cycle hunting cursor / token / hub-loss bugs.

Private never leaving the instance is correct. The message is not.

## Fix

Local bookkeeping on the sync-once path: count Memory rows that passed the since-cursor filter and were then dropped as private. The quiet path now distinguishes the two stories:

- Rows found, all withheld: `No federable changes since last sync (N rows held back: private visibility).` Count and reason only — no content.
- Nothing since the cursor, nothing withheld: `No changes since last sync.` (unchanged)

The push filter itself is unchanged. Soul / Agent / Relationship still have no visibility field and are not counted. Missing visibility is still not private (migration invariant). Pairing, hub merge, `lastSyncAt` advance, and the liveness ping are untouched.

## Tests

Two quiet-path cases in `test/unit/federation-sync-push-privacy.test.ts` (same mocked `runFederationSyncOnce` harness as the existing privacy suite — no live two-node cluster):

1. 35 private rows found → withheld message with count 35; secret content does not appear; liveness ping still fires.
2. Empty since-cursor result → still "No changes since last sync."; no private-withheld story.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2fe19e5f-bc26-4d97-9598-58e4ba17b805?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2fe19e5f-bc26-4d97-9598-58e4ba17b805&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

