### PR TITLE
MemoryMaintenance expires only ephemeral rows

### DIFF
--- a/.changelog/unreleased/fixed-1265-maintenance-expiry-ephemeral-only.md
+++ b/.changelog/unreleased/fixed-1265-maintenance-expiry-ephemeral-only.md
@@ -1,0 +1,7 @@
+- **MemoryMaintenance expires only ephemeral rows.** The nightly / REM
+  maintenance pass previously deleted any memory whose `expiresAt` was in
+  the past, including persistent and other non-ephemeral rows that had
+  acquired an expiry (bug, import, API misuse). The docstring already
+  scoped expiry to the ephemeral tier; the delete predicate now matches.
+  Missing or unexpected durability is treated as non-ephemeral, so durable
+  rows are not silently reaped. (flair#1265)

--- a/resources/MemoryMaintenance.ts
+++ b/resources/MemoryMaintenance.ts
@@ -62,8 +62,16 @@ export class MemoryMaintenance extends Resource {
         if (targetAgent && record.agentId !== targetAgent) continue;
         stats.total++;
 
-        // 1. Delete expired memories
-        if (record.expiresAt && new Date(record.expiresAt) < now) {
+        // 1. Delete expired ephemeral memories. expiresAt is only a reap
+        // signal for the ephemeral tier (docstring + Memory.post() TTL
+        // stamp). A non-ephemeral row that acquired one (bug, import, API
+        // misuse) must survive — missing / unexpected durability is treated
+        // as non-ephemeral so we do not silently reap durable rows.
+        if (
+          record.durability === "ephemeral" &&
+          record.expiresAt &&
+          new Date(record.expiresAt) < now
+        ) {
           if (!dryRun) {
             try {
               await (databases as any).flair.Memory.delete(record.id);

--- a/test/unit-isolated/memory-maintenance-expiry.test.ts
+++ b/test/unit-isolated/memory-maintenance-expiry.test.ts
@@ -128,13 +128,14 @@ describe("flair#1265 mutation-check — durability filter stays in the delete pr
       join(import.meta.dir, "..", "..", "resources", "MemoryMaintenance.ts"),
       "utf8",
     );
-    const deleteBlock = src.match(/Delete expired[\s\S]*?continue;/);
-    expect(deleteBlock).not.toBeNull();
-    expect(deleteBlock![0]).toContain('durability === "ephemeral"');
-    expect(deleteBlock![0]).toContain("expiresAt");
-    // The pre-fix predicate (`expiresAt && new Date(expiresAt) < now` with
-    // no durability conjunct) must not reappear as the sole condition.
-    expect(deleteBlock![0]).not.toMatch(
+    // Pin the three conjuncts in one predicate. A looser "Delete expired"
+    // scan hits the file header first and is not a mutation-check.
+    expect(src).toMatch(
+      /record\.durability === "ephemeral"\s*&&\s*record\.expiresAt\s*&&\s*new Date\(record\.expiresAt\) < now/,
+    );
+    // The pre-#1265 predicate (`expiresAt && date < now` with no durability
+    // conjunct) must not reappear as the sole condition.
+    expect(src).not.toMatch(
       /if\s*\(\s*record\.expiresAt\s*&&\s*new Date\(record\.expiresAt\)\s*<\s*now\s*\)/,
     );
   });

--- a/test/unit-isolated/memory-maintenance-expiry.test.ts
+++ b/test/unit-isolated/memory-maintenance-expiry.test.ts
@@ -1,0 +1,141 @@
+/**
+ * memory-maintenance-expiry.test.ts — flair#1265.
+ *
+ * MemoryMaintenance's docstring has always scoped expiry deletes to
+ * ephemeral rows. The shipped predicate was `expiresAt < now` with no
+ * durability check, so a persistent (or any other non-ephemeral) row that
+ * ever acquired an expiresAt was silently reaped on the nightly pass.
+ *
+ * These tests run MemoryMaintenance.post() against an in-memory Memory
+ * table. No live Harper. Lives in unit-isolated/ so its harper mock owns
+ * the process (CI runs each file here in its own `bun test` invocation).
+ */
+import { describe, it, expect, beforeEach, mock } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const PAST = new Date(Date.now() - 3600_000).toISOString();
+const FUTURE = new Date(Date.now() + 3600_000).toISOString();
+const AGENT = "agent-1";
+
+let memoryStore: Map<string, any>;
+
+function fromStore(): AsyncIterable<any> {
+  async function* gen() {
+    for (const r of memoryStore.values()) yield r;
+  }
+  return gen();
+}
+
+const databasesMock = {
+  flair: {
+    Memory: {
+      search: () => fromStore(),
+      delete: async (id: string) => {
+        memoryStore.delete(id);
+        return { ok: true };
+      },
+      update: async (id: string, data: any) => {
+        memoryStore.set(id, { ...memoryStore.get(id), ...data });
+        return data;
+      },
+    },
+    Agent: { get: async () => null, search: async () => [] },
+  },
+};
+
+mock.module("harper", () => ({
+  databases: databasesMock,
+  Resource: class {},
+  server: { http: () => {}, getUser: async () => null },
+}));
+
+const { MemoryMaintenance } = await import("../../resources/MemoryMaintenance.ts");
+
+function seed(id: string, overrides: Record<string, any> = {}) {
+  const row = { id, agentId: AGENT, content: id, ...overrides };
+  memoryStore.set(id, row);
+  return row;
+}
+
+function makeMaintenance(ctxRequest: any) {
+  const r: any = new (MemoryMaintenance as any)();
+  r.getContext = () => ({ request: ctxRequest });
+  return r;
+}
+
+const adminCtx = () => ({ tpsAgent: "admin", tpsAgentIsAdmin: true });
+
+beforeEach(() => {
+  memoryStore = new Map();
+});
+
+describe("MemoryMaintenance expiry — ephemeral-only (flair#1265)", () => {
+  it("deletes an ephemeral row whose expiresAt is in the past", async () => {
+    seed("eph-expired", { durability: "ephemeral", expiresAt: PAST });
+
+    const result = await makeMaintenance(adminCtx()).post({});
+    expect(result.expired).toBe(1);
+    expect(memoryStore.has("eph-expired")).toBe(false);
+  });
+
+  it("leaves an ephemeral row whose expiresAt is still in the future", async () => {
+    seed("eph-live", { durability: "ephemeral", expiresAt: FUTURE });
+
+    const result = await makeMaintenance(adminCtx()).post({});
+    expect(result.expired).toBe(0);
+    expect(memoryStore.has("eph-live")).toBe(true);
+  });
+
+  it("positive control: a persistent row with past expiresAt SURVIVES", async () => {
+    // This is the row the pre-#1265 predicate would have deleted. If the
+    // durability filter is removed, this test goes red — that is the
+    // mutation-check.
+    seed("persist-expired", { durability: "persistent", expiresAt: PAST });
+    seed("eph-expired", { durability: "ephemeral", expiresAt: PAST });
+
+    const result = await makeMaintenance(adminCtx()).post({});
+
+    expect(memoryStore.has("persist-expired")).toBe(true);
+    expect(memoryStore.has("eph-expired")).toBe(false);
+    expect(result.expired).toBe(1);
+  });
+
+  it("does not reap other non-ephemeral (or missing / unexpected) durability", async () => {
+    seed("permanent-expired", { durability: "permanent", expiresAt: PAST });
+    seed("standard-expired", { durability: "standard", expiresAt: PAST });
+    seed("absent-durability", { expiresAt: PAST });
+    seed("garbage-durability", { durability: "durable", expiresAt: PAST });
+    seed("eph-expired", { durability: "ephemeral", expiresAt: PAST });
+
+    const result = await makeMaintenance(adminCtx()).post({});
+
+    expect(memoryStore.has("permanent-expired")).toBe(true);
+    expect(memoryStore.has("standard-expired")).toBe(true);
+    expect(memoryStore.has("absent-durability")).toBe(true);
+    expect(memoryStore.has("garbage-durability")).toBe(true);
+    expect(memoryStore.has("eph-expired")).toBe(false);
+    expect(result.expired).toBe(1);
+  });
+});
+
+describe("flair#1265 mutation-check — durability filter stays in the delete predicate", () => {
+  it("the expiry delete block requires durability === 'ephemeral'", () => {
+    // Behavioural tests above fail if the filter is removed (persistent
+    // row would be deleted). This scan fails on deletion of the conjunct
+    // even if a later rewrite stopped exercising the store.
+    const src = readFileSync(
+      join(import.meta.dir, "..", "..", "resources", "MemoryMaintenance.ts"),
+      "utf8",
+    );
+    const deleteBlock = src.match(/Delete expired[\s\S]*?continue;/);
+    expect(deleteBlock).not.toBeNull();
+    expect(deleteBlock![0]).toContain('durability === "ephemeral"');
+    expect(deleteBlock![0]).toContain("expiresAt");
+    // The pre-fix predicate (`expiresAt && new Date(expiresAt) < now` with
+    // no durability conjunct) must not reappear as the sole condition.
+    expect(deleteBlock![0]).not.toMatch(
+      /if\s*\(\s*record\.expiresAt\s*&&\s*new Date\(record\.expiresAt\)\s*<\s*now\s*\)/,
+    );
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #1265.

## Problem

`MemoryMaintenance` deleted any row whose `expiresAt` was in the past, with no durability check. The docstring already scoped expiry to ephemeral; `Memory.post()` only auto-stamps `expiresAt` for that tier. A persistent (or other non-ephemeral) row that ever acquired an expiry — bug, import, API misuse — was silently reaped on the nightly / REM pass.

Found during #1244 forensics. Not the #1244 cause (those rows had no `expiresAt`; these deletes are audited). Still P1 correctness.

## Fix

The delete predicate is now:

```
durability === "ephemeral" && expiresAt && expiresAt < now
```

Missing or unexpected durability is treated as non-ephemeral (do not silently reap durable rows). Ephemeral expiry meaning, delete audit, and the standard-session archive job are unchanged.

## Tests

`test/unit-isolated/memory-maintenance-expiry.test.ts` runs `MemoryMaintenance.post()` against an in-memory table (no live Harper):

- Expired ephemeral rows are deleted; unexpired ephemeral rows survive.
- Positive control: a persistent row with past `expiresAt` **survives**. Removing the durability filter deletes this row — that is the behavioural mutation-check.
- `permanent` / `standard` / absent / unexpected durability with past `expiresAt` also survive.
- Source scan pins the three-conjunct predicate and rejects the pre-#1265 `expiresAt && date < now` sole condition.

## Changelog

`.changelog/unreleased/fixed-1265-maintenance-expiry-ephemeral-only.md`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cbc890b3-1030-4a0e-a6f1-7fc84c7ef261?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cbc890b3-1030-4a0e-a6f1-7fc84c7ef261&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

