### PR TITLE
doctor/init: positive-control audit-log verification — silent non-recording can no longer look like a pass

### DIFF
--- a/.changelog/unreleased/fixed-970-verify-audit-log.md
+++ b/.changelog/unreleased/fixed-970-verify-audit-log.md
@@ -1,0 +1,19 @@
+- **`flair doctor` and `flair init` now verify the Harper audit log actually
+  records — silent non-recording can no longer look like a pass.** Both
+  commands run a positive control: write two ephemeral probe rows'-worth of
+  changes (PUT + PATCH), read the audit trail back via `read_audit_log`, and
+  assert both write entries are present. A node whose audit log is enabled but
+  empty — the state a cluster base-copy/resync produces, where `describe_table`
+  still reports `audit: true` and `read_audit_log` answers clean empty —
+  previously went entirely unchecked. Classification: entries present reports
+  "recording (verified now)" (a present-tense claim only — the probe proves
+  current recording, never historical completeness); enabled-but-missing
+  entries reports NOT RECORDING with the base-copy caveat (audit history has a
+  hard start boundary at copy time on a resynced node); `read_audit_log`
+  rejecting with HTTP 400 reports DISABLED with the remedy (`logging.auditLog`
+  in the root `harperdb-config.yaml`, not flair's component `config.yaml`);
+  and an unprobeable instance (unreachable ops API, no agent key, no admin
+  credential) renders UNVERIFIED — an unrun check must not look like a pass.
+  The probe row is ephemeral (TTL backstop), deleted best-effort after the
+  read, and all assertions are boolean — audit-entry content is never echoed
+  into command output. (flair#970)

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1915,6 +1915,200 @@ export async function verifySemanticSearch(
   }
 }
 
+/**
+ * Result of a real write→read_audit_log round-trip (flair#970):
+ *   - ok:       the probe's writes came back as audit entries — the audit log
+ *               is RECORDING NOW. Deliberately not carrying any stronger
+ *               claim: this proves current recording, never historical
+ *               completeness (a node that joined or resynced via base copy has
+ *               a hard start boundary at copy time — harper#2212 — so "ok"
+ *               must never be rendered as "history complete/healthy").
+ *   - degraded: cause "not-recording" — read_audit_log answered cleanly but
+ *               the probe's writes are missing (audit enabled, pipeline not
+ *               recording: the exact silent state flair#970 observed);
+ *               cause "disabled" — read_audit_log 400s because
+ *               `logging.auditLog` is off in the ROOT harperdb-config.yaml.
+ *   - skipped:  could not run the check (no agent/key, no admin credentials
+ *               for the ops API, ops API unreachable, probe write failed).
+ *               Callers MUST render this as UNVERIFIED — an unrun check must
+ *               not look like a pass.
+ */
+export type AuditVerifyResult =
+  | { state: "ok" }
+  | { state: "degraded"; cause: "not-recording" | "disabled"; detail: string }
+  | { state: "skipped"; reason: AuditSkipReason; detail: string };
+
+export type AuditSkipReason =
+  | "no-agent"
+  | "no-key"
+  | "key-load"
+  | "no-admin-credentials"
+  | "probe-failed";
+
+/**
+ * Positive control for the Harper audit log (flair#970): verify that audit
+ * ACTUALLY records by writing and then reading the audit trail back — never by
+ * trusting the `audit: true` flag `describe_table` reports.
+ *
+ * Why a positive control: records applied via cluster base-copy/resync are
+ * committed with audit explicitly disabled (harper Table.ts isCopyApply, filed
+ * upstream as harper#2212), so a node can report audit enabled, answer
+ * read_audit_log with HTTP 200, and still hold zero entries. Before this
+ * check, nothing in flair declared, read, or verified audit — the canonical
+ * check that cannot fire.
+ *
+ * Probe (modeled on verifySemanticSearch above, same skipped/degraded/ok
+ * discipline):
+ *   1. PUT an ephemeral probe row (id `flair-doctor-audit-probe-<uuid>`,
+ *      short inert marker content — ephemeral durability so a failed cleanup
+ *      self-prunes; the DELETE in `finally` is best-effort).
+ *   2. PATCH it — verified live on harper@5.2.0: PATCH /Memory/<id> returns
+ *      204 and generates an audit entry with operation "patch" (PUT generates
+ *      "upsert", DELETE "delete").
+ *   3. `read_audit_log` (search_type hash_value, the probe id) over the ops
+ *      API with Basic admin auth — the operations API only exists on its own
+ *      port/socket, so the agent's Ed25519 header cannot authenticate it.
+ *   4. Assert BOTH write entries are present. The probe's own DELETE lands
+ *      AFTER the read, so it is never required (audit is append-only; the
+ *      probe's entries persisting after the row is gone is by design).
+ *
+ * All assertions are BOOLEAN (entry counts only). Audit entries carry full
+ * record images (`records: [value]`), so no entry content is ever copied into
+ * a result detail — the detail strings are fixed text plus counts/statuses.
+ */
+export async function verifyAuditLog(
+  baseUrl: string,
+  agentIdOpt: string | undefined,
+  keysDir: string,
+  opsUrl: string,
+  adminUser: string | undefined,
+  adminPass: string | undefined,
+): Promise<AuditVerifyResult> {
+  // Resolve an agent + key to sign the probe writes with — identical
+  // resolution to verifySemanticSearch so the two probes agree on identity.
+  let agentId = agentIdOpt || process.env.FLAIR_AGENT_ID || undefined;
+  if (!agentId) {
+    try {
+      const keyFiles = readdirSync(keysDir).filter((f) => f.endsWith(".key"));
+      const agentKeyFile = keyFiles.find((f) => !isNodeKeyId(f.replace(/\.key$/, ""), keysDir));
+      if (agentKeyFile) agentId = agentKeyFile.replace(/\.key$/, "");
+    } catch { /* keysDir missing */ }
+  }
+  if (!agentId) {
+    return { state: "skipped", reason: "no-agent", detail: "no agent id or key found" };
+  }
+  let keyPath = resolveKeyPath(agentId);
+  if (!keyPath) {
+    const candidate = join(keysDir, `${agentId}.key`);
+    if (existsSync(candidate)) keyPath = candidate;
+  }
+  if (!keyPath) {
+    return { state: "skipped", reason: "no-key", detail: `no private key for agent '${agentId}'` };
+  }
+  if (!adminUser || !adminPass) {
+    return {
+      state: "skipped",
+      reason: "no-admin-credentials",
+      detail: "no admin credentials for the ops API (read_audit_log requires them)",
+    };
+  }
+
+  const id = `flair-doctor-audit-probe-${randomUUID()}`;
+  const path = `/Memory/${id}`;
+  let stored = false;
+  try {
+    // Write 1: PUT the probe row. Ephemeral durability — TTL is the cleanup
+    // backstop if the finally-DELETE fails.
+    const putRes = await authFetch(baseUrl, agentId, keyPath, "PUT", path, {
+      id,
+      agentId,
+      content: `flair doctor audit probe (inert marker, safe to ignore) [${id}]`,
+      durability: "ephemeral",
+      createdAt: new Date().toISOString(),
+    });
+    if (!putRes.ok && putRes.status !== 204) {
+      return { state: "skipped", reason: "probe-failed", detail: `could not write probe row: HTTP ${putRes.status}` };
+    }
+    stored = true;
+
+    // Write 2: PATCH — a second, distinct audit-visible write (live-verified
+    // to produce its own entry on harper@5.2.0; see doc comment).
+    const patchRes = await authFetch(baseUrl, agentId, keyPath, "PATCH", path, {
+      content: `flair doctor audit probe (inert marker, second write) [${id}]`,
+    });
+    if (!patchRes.ok && patchRes.status !== 204) {
+      return { state: "skipped", reason: "probe-failed", detail: `could not apply second probe write: HTTP ${patchRes.status}` };
+    }
+
+    // Read the audit trail back over the ops API.
+    let auditRes: Response;
+    try {
+      auditRes = await fetch(`${opsUrl.replace(/\/+$/, "")}/`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Basic ${Buffer.from(`${adminUser}:${adminPass}`).toString("base64")}`,
+        },
+        body: JSON.stringify({
+          operation: "read_audit_log",
+          database: "flair",
+          table: "Memory",
+          search_type: "hash_value",
+          search_values: [id],
+        }),
+        signal: AbortSignal.timeout(10_000),
+      });
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : String(err);
+      return { state: "skipped", reason: "probe-failed", detail: `ops API unreachable at ${opsUrl} (${message.slice(0, 80)})` };
+    }
+    if (auditRes.status === 400) {
+      // harper rejects read_audit_log with HTTP 400 ("To use this operation
+      // audit log must be enabled in harperdb-config.yaml") when
+      // logging.auditLog is off — live-verified on harper@5.2.0.
+      return { state: "degraded", cause: "disabled", detail: "read_audit_log rejected the probe: audit logging is not enabled on this instance" };
+    }
+    if (!auditRes.ok) {
+      // 401/403/404/5xx tell us nothing about whether audit records — that is
+      // "could not verify", never "verified" and never "broken".
+      return { state: "skipped", reason: "probe-failed", detail: `read_audit_log failed: HTTP ${auditRes.status}` };
+    }
+    const body = (await auditRes.json().catch(() => null)) as
+      | Record<string, Array<{ operation?: string }>>
+      | null;
+    // BOOLEAN classification only: count the probe's write entries. Audit
+    // entries carry full record images — none of that content may reach the
+    // result (and via it, doctor/init output).
+    const entries = body && Array.isArray(body[id]) ? body[id] : [];
+    const writeEntries = entries.filter((e) => e && typeof e === "object" && e.operation !== "delete");
+    if (writeEntries.length >= 2) {
+      return { state: "ok" };
+    }
+    // Enabled-but-empty (or partial) is the critical row: we put data in and
+    // could not see it come back — the pipeline is broken, not "empty". The
+    // pre-fix world silently passed this as ok.
+    return {
+      state: "degraded",
+      cause: "not-recording",
+      detail: `probe made 2 writes; read_audit_log returned ${writeEntries.length} write ${writeEntries.length === 1 ? "entry" : "entries"}`,
+    };
+  } catch (err: unknown) {
+    if (err instanceof KeyLoadError) {
+      return { state: "skipped", reason: "key-load", detail: err.message };
+    }
+    const message = err instanceof Error ? err.message : String(err);
+    return { state: "skipped", reason: "probe-failed", detail: `probe error: ${message.slice(0, 100)}` };
+  } finally {
+    // Best-effort cleanup — ephemeral TTL is the backstop if this fails. The
+    // DELETE itself appends one more audit entry AFTER the read, by design.
+    if (stored) {
+      try {
+        await authFetch(baseUrl, agentId, keyPath, "DELETE", path);
+      } catch { /* leave the ephemeral row; it'll age out */ }
+    }
+  }
+}
+
 // ─── Doctor: client-integration network checks (flair#588) ────────────────────
 //
 // The pure filesystem checks (MCP block parsing, CLAUDE.md, SessionStart hook)
@@ -3791,6 +3985,31 @@ program
         console.log(`   ${render.wrap(render.c.dim, "Fix: install without sudo (see README Quick Start), then:")} flair restart && flair doctor`);
       } else {
         console.log(`${render.icons.warn} Semantic search not verified ${render.wrap(render.c.dim, `(${embedCheck.detail})`)}`);
+      }
+
+      // Verify the audit log ACTUALLY records (flair#970) — a positive
+      // control, not a flag read: `describe_table` reports `audit: true` on
+      // nodes whose audit trail is empty (base-copy elision, harper#2212).
+      // Same surface as the semantic-search check above.
+      console.log("Verifying audit log...");
+      const auditCheck = await verifyAuditLog(httpUrl, agentId, keysDir, `http://127.0.0.1:${opsPort}`, adminUser, adminPass);
+      if (auditCheck.state === "ok") {
+        // Present tense ONLY: the probe proves current recording, never
+        // historical completeness — see AuditVerifyResult's doc comment.
+        console.log(`Audit log: recording (verified now) ✓ ${render.wrap(render.c.dim, "(verifies current recording, not history — a resynced node's audit has a hard start boundary at its copy time)")}`);
+      } else if (auditCheck.state === "degraded") {
+        if (auditCheck.cause === "disabled") {
+          console.log(`\n${render.icons.error} ${render.wrap(render.c.red, "Audit log DISABLED")} — ${auditCheck.detail}.`);
+          console.log(`   ${render.wrap(render.c.dim, "Fix: enable logging.auditLog in the ROOT harperdb-config.yaml (the Harper instance config, NOT flair's component config.yaml), then restart Harper.")}`);
+        } else {
+          console.log(`\n${render.icons.error} ${render.wrap(render.c.red, "Audit log NOT RECORDING")} — ${auditCheck.detail}.`);
+          console.log(`   ${render.wrap(render.c.red, "Audit reports as enabled, but fresh writes produced no audit entries — do not treat the audit log as a record of what happened.")}`);
+          console.log(`   ${render.wrap(render.c.dim, "On a node that joined or resynced via cluster base copy, audit history has a hard start boundary at copy time (harper#2212) — \"no history\" does not mean \"nothing happened\".")}`);
+          console.log(`   ${render.wrap(render.c.dim, "Check logging.auditLog in the ROOT harperdb-config.yaml (not flair's component config.yaml), then restart Harper.")}`);
+        }
+      } else {
+        // An unrun check must not look like a pass.
+        console.log(`${render.icons.warn} Audit log: UNVERIFIED (could not probe — ${auditCheck.detail})`);
       }
 
       // Output — admin password printed once, never written to disk
@@ -13401,6 +13620,66 @@ program
           if (remedy) console.log(`     ${render.wrap(render.c.dim, remedy)}`);
           break;
         }
+      }
+    }
+
+    // 4b. Audit-log positive control (flair#970) — REAL write→read_audit_log
+    // round-trip, only if Harper is responding. `describe_table` reporting
+    // `audit: true` proves nothing: a node that joined or resynced via
+    // cluster base copy holds zero audit history while reporting audit
+    // enabled and answering read_audit_log with clean empty (harper#2212).
+    // So doctor writes probe rows and asserts their audit entries come back —
+    // never trusts the flag. Same ok/degraded/skipped discipline as the
+    // embeddings check above: skipped is rendered UNVERIFIED, never as a pass.
+    if (harperResponding) {
+      // read_audit_log only exists on the ops API (its own port), which the
+      // agent's Ed25519 header cannot authenticate — resolve the local admin
+      // credential (env or ~/.flair/admin-pass; never prompts). A file with
+      // unsafe permissions throws — that is "could not probe", not "broken".
+      let auditAdminPass: string | undefined;
+      let auditCredIssue: string | null = null;
+      try {
+        auditAdminPass = resolveLocalAdminPass(undefined);
+      } catch (err: unknown) {
+        auditCredIssue = err instanceof Error ? err.message : String(err);
+      }
+      const auditStatus = auditCredIssue
+        ? ({ state: "skipped", reason: "no-admin-credentials", detail: auditCredIssue } as const)
+        : await verifyAuditLog(
+            baseUrl,
+            opts.agent,
+            defaultKeysDir(),
+            `http://127.0.0.1:${resolveOpsPort(opts)}`,
+            DEFAULT_ADMIN_USER,
+            auditAdminPass,
+          );
+      switch (auditStatus.state) {
+        case "ok":
+          // Present-tense claim ONLY (see AuditVerifyResult): the probe
+          // proves the log records writes NOW — never that history is
+          // complete. Overclaiming here would rebuild the false trust
+          // anchor this check exists to kill, one layer up.
+          console.log(`  ${render.icons.ok} Audit log: recording (verified now) ${render.wrap(render.c.dim, "(verifies current recording, not history — a resynced node's audit has a hard start boundary at its copy time)")}`);
+          break;
+        case "degraded":
+          if (auditStatus.cause === "disabled") {
+            console.log(`  ${render.icons.error} Audit log DISABLED ${render.wrap(render.c.dim, `— ${auditStatus.detail}`)}`);
+            console.log(`     ${render.wrap(render.c.dim, "Fix: enable logging.auditLog in the ROOT harperdb-config.yaml (the Harper instance config, NOT flair's component config.yaml), then restart Harper.")}`);
+          } else {
+            console.log(`  ${render.icons.error} Audit log NOT RECORDING ${render.wrap(render.c.dim, `— ${auditStatus.detail}`)}`);
+            console.log(`     ${render.wrap(render.c.red, "Audit reports as enabled, but fresh writes produced no audit entries — do not treat the audit log as a record of what happened.")}`);
+            console.log(`     ${render.wrap(render.c.dim, "On a node that joined or resynced via cluster base copy, audit history has a hard start boundary at copy time (harper#2212) — \"no history\" does not mean \"nothing happened\".")}`);
+            console.log(`     ${render.wrap(render.c.dim, "Check logging.auditLog in the ROOT harperdb-config.yaml (not flair's component config.yaml), then restart Harper.")}`);
+          }
+          issues++;
+          break;
+        case "skipped":
+          // An unrun check must not look like a pass — UNVERIFIED, visually
+          // distinct from ok, but not a hard issue (mirrors the embeddings
+          // skip: the operator may simply have no agent or no local admin
+          // credential on this box).
+          console.log(`  ${render.icons.warn} Audit log: UNVERIFIED (could not probe — ${auditStatus.detail})`);
+          break;
       }
     }
 

--- a/test/unit/doctor-audit-verify.test.ts
+++ b/test/unit/doctor-audit-verify.test.ts
@@ -1,0 +1,255 @@
+import { describe, it, expect, beforeAll, afterAll, afterEach } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import nacl from "tweetnacl";
+
+import { verifyAuditLog } from "../../src/cli.ts";
+
+/**
+ * flair#970 — audit-log positive control.
+ *
+ * `flair doctor` / `flair init` must verify the Harper audit log ACTUALLY
+ * records — by writing probe rows and reading their audit entries back —
+ * never by trusting the `audit: true` flag. A node that joined or resynced
+ * via cluster base copy reports audit enabled and answers read_audit_log
+ * with clean empty (harper#2212): before this check, that state passed
+ * silently (the canonical check that cannot fire).
+ *
+ * verifyAuditLog() drives the gate. We mock global.fetch to simulate each
+ * server state (same shape as the sibling doctor-embed-verify.test.ts):
+ *   - entries present:   both probe writes come back as audit entries → "ok"
+ *   - empty array:       {"<id>": []} — enabled but NOT recording → "degraded"
+ *                        ★ the positive-control row: the pre-fix world
+ *                          silently passed this state as ok
+ *   - HTTP 400:          audit disabled in the root harperdb-config.yaml
+ *                        → "degraded" with the enable remedy cause
+ *   - ops unreachable:   → "skipped" (rendered UNVERIFIED by both callers —
+ *                          an unrun check must not look like a pass)
+ *
+ * A real Ed25519 key is written to disk so the signing path runs exactly as
+ * in production; only the network is mocked.
+ */
+
+const AGENT_ID = "doctor-audit-test-agent";
+const BASE_URL = "http://127.0.0.1:19926";
+const OPS_URL = "http://127.0.0.1:19925";
+const ADMIN_USER = "admin";
+const ADMIN_PASS = "test-admin-pass";
+let keysDir: string;
+const realFetch = globalThis.fetch;
+
+beforeAll(() => {
+  keysDir = mkdtempSync(join(tmpdir(), "flair-doctor-audit-keys-"));
+  // Real 32-byte Ed25519 seed so buildEd25519Auth() can sign the probe writes.
+  const kp = nacl.sign.keyPair();
+  writeFileSync(join(keysDir, `${AGENT_ID}.key`), Buffer.from(kp.secretKey.slice(0, 32)));
+});
+
+afterAll(() => {
+  rmSync(keysDir, { recursive: true, force: true });
+});
+
+afterEach(() => {
+  globalThis.fetch = realFetch;
+});
+
+function jsonResponse(status: number, body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+interface Call { method: string; url: string; body?: unknown }
+
+/**
+ * Install a fetch mock simulating the flair REST surface (PUT/PATCH/DELETE
+ * /Memory/<id> on BASE_URL) plus the Harper ops API (POST on OPS_URL).
+ *
+ * `auditEntriesFor(id)` builds the read_audit_log response body for the probe
+ * id captured from the PUT; `auditStatus` overrides the ops HTTP status;
+ * `opsThrows` makes the ops fetch reject (unreachable).
+ */
+function mockServer(opts: {
+  auditEntriesFor?: (id: string) => unknown[];
+  auditStatus?: number;
+  auditBody?: unknown;
+  opsThrows?: boolean;
+  patchStatus?: number;
+  putStatus?: number;
+}): Call[] {
+  const calls: Call[] = [];
+  let probeId = "";
+  globalThis.fetch = (async (input: any, init?: any) => {
+    const url = typeof input === "string" ? input : input.url;
+    const method = (init?.method ?? "GET").toUpperCase();
+    let body: unknown;
+    try { body = init?.body ? JSON.parse(init.body) : undefined; } catch { body = init?.body; }
+    calls.push({ method, url, body });
+
+    if (url.startsWith(OPS_URL)) {
+      if (opts.opsThrows) throw new Error("connect ECONNREFUSED 127.0.0.1:19925");
+      if (opts.auditStatus && opts.auditStatus !== 200) {
+        return jsonResponse(opts.auditStatus, opts.auditBody ?? { error: "To use this operation audit log must be enabled in harperdb-config.yaml" });
+      }
+      return jsonResponse(200, { [probeId]: opts.auditEntriesFor ? opts.auditEntriesFor(probeId) : [] });
+    }
+    if (method === "PUT") {
+      probeId = url.split("/Memory/")[1] ?? "";
+      return jsonResponse(opts.putStatus ?? 200, { id: probeId });
+    }
+    if (method === "PATCH") {
+      return new Response(null, { status: opts.patchStatus ?? 204 });
+    }
+    if (method === "DELETE") return jsonResponse(200, { ok: true });
+    return jsonResponse(404, { error: "unexpected" });
+  }) as typeof fetch;
+  return calls;
+}
+
+// A distinctive marker planted inside mocked audit-entry record images. If it
+// ever shows up in a result, the check leaked audit-entry content — which
+// doctor/init would then print (Sherlock's binding requirement: assertions on
+// audit entries are BOOLEAN; entry content must never reach the output).
+const RECORD_CONTENT_MARKER = "SECRET-AUDIT-RECORD-CONTENT-must-never-leak";
+
+function entryFor(id: string, operation: string) {
+  return {
+    operation,
+    timestamp: Date.now(),
+    user_name: "admin",
+    ids: [id],
+    records: [{ id, content: RECORD_CONTENT_MARKER }],
+  };
+}
+
+describe("verifyAuditLog (flair#970: audit-log positive control)", () => {
+  it("returns 'ok' when both probe writes come back as audit entries", async () => {
+    // Live-verified harper@5.2.0 shape: PUT → "upsert", PATCH → "patch".
+    const calls = mockServer({ auditEntriesFor: (id) => [entryFor(id, "upsert"), entryFor(id, "patch")] });
+
+    const result = await verifyAuditLog(BASE_URL, AGENT_ID, keysDir, OPS_URL, ADMIN_USER, ADMIN_PASS);
+    expect(result.state).toBe("ok");
+
+    // The probe really did write → write → read-audit → delete.
+    expect(calls.some((c) => c.method === "PUT" && c.url.includes("/Memory/"))).toBe(true);
+    expect(calls.some((c) => c.method === "PATCH" && c.url.includes("/Memory/"))).toBe(true);
+    const opsCall = calls.find((c) => c.url.startsWith(OPS_URL));
+    expect(opsCall).toBeDefined();
+    expect((opsCall!.body as any)?.operation).toBe("read_audit_log");
+    expect((opsCall!.body as any)?.search_type).toBe("hash_value");
+    expect(calls.some((c) => c.method === "DELETE" && c.url.includes("/Memory/"))).toBe(true);
+
+    // Probe hygiene: ephemeral durability + namespaced probe id.
+    const putCall = calls.find((c) => c.method === "PUT")!;
+    expect((putCall.body as any)?.durability).toBe("ephemeral");
+    expect(putCall.url).toContain("/Memory/flair-doctor-audit-probe-");
+
+    // Boolean-only assertion: no audit-entry content in the result.
+    expect(JSON.stringify(result)).not.toContain(RECORD_CONTENT_MARKER);
+  });
+
+  it("★ positive control: {\"<id>\": []} (enabled but NOT recording) classifies 'degraded', never 'ok'", async () => {
+    // THE flair#970 row. read_audit_log answers HTTP 200 with a well-formed
+    // empty history — exactly what a base-copied node returns (harper#2212).
+    // The pre-fix world had no check here at all, so this state passed
+    // silently. If you put data in and can't see it come back, the pipeline
+    // is broken, not empty.
+    mockServer({ auditEntriesFor: () => [] });
+
+    const result = await verifyAuditLog(BASE_URL, AGENT_ID, keysDir, OPS_URL, ADMIN_USER, ADMIN_PASS);
+    expect(result.state).toBe("degraded");
+    if (result.state === "degraded") expect(result.cause).toBe("not-recording");
+  });
+
+  it("returns 'degraded' when only ONE of the two writes was recorded (partial recording)", async () => {
+    mockServer({ auditEntriesFor: (id) => [entryFor(id, "upsert")] });
+    const result = await verifyAuditLog(BASE_URL, AGENT_ID, keysDir, OPS_URL, ADMIN_USER, ADMIN_PASS);
+    expect(result.state).toBe("degraded");
+    if (result.state === "degraded") expect(result.cause).toBe("not-recording");
+  });
+
+  it("does not count a DELETE entry toward the two write entries", async () => {
+    // Only delete entries present — the write pipeline still isn't recording.
+    mockServer({ auditEntriesFor: (id) => [entryFor(id, "delete"), entryFor(id, "delete")] });
+    const result = await verifyAuditLog(BASE_URL, AGENT_ID, keysDir, OPS_URL, ADMIN_USER, ADMIN_PASS);
+    expect(result.state).toBe("degraded");
+  });
+
+  it("returns 'degraded' (cause: disabled) on HTTP 400 — audit disabled in the root config", async () => {
+    // harper@5.2.0 (live-verified): read_audit_log → 400 "To use this
+    // operation audit log must be enabled in harperdb-config.yaml" when
+    // logging.auditLog is off. The remedy callers render names the knob in
+    // the ROOT harperdb-config.yaml, not flair's component config.yaml.
+    mockServer({ auditStatus: 400 });
+    const result = await verifyAuditLog(BASE_URL, AGENT_ID, keysDir, OPS_URL, ADMIN_USER, ADMIN_PASS);
+    expect(result.state).toBe("degraded");
+    if (result.state === "degraded") expect(result.cause).toBe("disabled");
+  });
+
+  it("returns 'skipped' when the ops API is unreachable (rendered UNVERIFIED, never a pass)", async () => {
+    mockServer({ opsThrows: true });
+    const result = await verifyAuditLog(BASE_URL, AGENT_ID, keysDir, OPS_URL, ADMIN_USER, ADMIN_PASS);
+    expect(result.state).toBe("skipped");
+    if (result.state === "skipped") {
+      expect(result.reason).toBe("probe-failed");
+      expect(result.detail).toContain("unreachable");
+    }
+  });
+
+  it("returns 'skipped' on an unexpected read_audit_log status (401) — cannot verify is not verified", async () => {
+    // A 401/403/5xx from the ops API says nothing about whether audit
+    // records. It must land in skipped (UNVERIFIED), never in ok or degraded.
+    mockServer({ auditStatus: 401, auditBody: { error: "unauthorized" } });
+    const result = await verifyAuditLog(BASE_URL, AGENT_ID, keysDir, OPS_URL, ADMIN_USER, ADMIN_PASS);
+    expect(result.state).toBe("skipped");
+  });
+
+  it("returns 'skipped' when no agent id or key is available", async () => {
+    const emptyKeysDir = mkdtempSync(join(tmpdir(), "flair-doctor-audit-empty-"));
+    const prev = process.env.FLAIR_AGENT_ID;
+    delete process.env.FLAIR_AGENT_ID;
+    try {
+      const result = await verifyAuditLog(BASE_URL, undefined, emptyKeysDir, OPS_URL, ADMIN_USER, ADMIN_PASS);
+      expect(result.state).toBe("skipped");
+      if (result.state === "skipped") expect(result.reason).toBe("no-agent");
+    } finally {
+      if (prev !== undefined) process.env.FLAIR_AGENT_ID = prev;
+      rmSync(emptyKeysDir, { recursive: true, force: true });
+    }
+  });
+
+  it("returns 'skipped' when no admin credentials are available for the ops API", async () => {
+    // No probe write may happen either: without ops credentials the check
+    // cannot complete, so it must not leave side effects behind.
+    const calls = mockServer({ auditEntriesFor: () => [] });
+    const result = await verifyAuditLog(BASE_URL, AGENT_ID, keysDir, OPS_URL, ADMIN_USER, undefined);
+    expect(result.state).toBe("skipped");
+    if (result.state === "skipped") expect(result.reason).toBe("no-admin-credentials");
+    expect(calls.length).toBe(0);
+  });
+
+  it("returns 'skipped' when the probe row cannot be written", async () => {
+    mockServer({ putStatus: 503 });
+    const result = await verifyAuditLog(BASE_URL, AGENT_ID, keysDir, OPS_URL, ADMIN_USER, ADMIN_PASS);
+    expect(result.state).toBe("skipped");
+    if (result.state === "skipped") expect(result.reason).toBe("probe-failed");
+  });
+
+  it("deletes the probe row (finally) even when classification is degraded", async () => {
+    const calls = mockServer({ auditEntriesFor: () => [] });
+    await verifyAuditLog(BASE_URL, AGENT_ID, keysDir, OPS_URL, ADMIN_USER, ADMIN_PASS);
+    expect(calls.some((c) => c.method === "DELETE" && c.url.includes("/Memory/flair-doctor-audit-probe-"))).toBe(true);
+  });
+
+  it("never echoes audit-entry content into degraded/skipped results either", async () => {
+    // Same boolean-only guard as the ok case, on the degraded path: mocked
+    // entries carry a distinctive record image; the result must not.
+    const withEntries = await (async () => {
+      mockServer({ auditEntriesFor: (id) => [entryFor(id, "upsert")] });
+      return verifyAuditLog(BASE_URL, AGENT_ID, keysDir, OPS_URL, ADMIN_USER, ADMIN_PASS);
+    })();
+    expect(JSON.stringify(withEntries)).not.toContain(RECORD_CONTENT_MARKER);
+  });
+});


### PR DESCRIPTION
## What

`flair doctor` and `flair init` now run a positive control against the Harper audit log: write two probe changes, read the audit trail back via `read_audit_log`, and classify from what actually comes back — never from the `audit: true` flag.

Before this, nothing in flair declared, read, or verified audit anywhere. A node whose audit log records nothing — the state cluster base-copy/resync produces (HarperFast/harper#2212) — reported `audit: true` in `describe_table`, answered `read_audit_log` with a clean empty result, and passed every check we had: the canonical check that cannot fire.

## How

New `verifyAuditLog(...)` in `src/cli.ts`, modeled on `verifySemanticSearch` (same `{ state: "ok" | "degraded" | "skipped" }` discipline), wired into both `flair init` (after the embeddings check) and `flair doctor` (section 4b):

1. PUT an ephemeral probe row (`flair-doctor-audit-probe-<uuid>`, short inert marker content; ephemeral durability so TTL is the cleanup backstop).
2. PATCH it — the second, distinct audit-visible write.
3. `read_audit_log` (`search_type: hash_value`, the probe id) over the ops API.
4. Assert BOTH write entries are present — the probe's own DELETE lands after the read and is never required (audit is append-only; probe entries persisting after the row is gone is by design). Delete the probe in a `finally`.

Classification:

- both write entries present → **ok**, rendered "Audit log: recording (verified now)" — a present-tense claim only. The probe proves current recording, never historical completeness; the ok rendering carries the resynced-node caveat so it cannot be read as "forensics available".
- clean-empty / partial history → **degraded, NOT RECORDING** — the flair#970 row — with the base-copy caveat: audit history has a hard start boundary at copy time on a resynced node (HarperFast/harper#2212), so "no history" does not mean "nothing happened".
- HTTP 400 → **degraded, DISABLED**, remedy naming `logging.auditLog` in the ROOT `harperdb-config.yaml` (the Harper instance config, not flair's component `config.yaml`).
- ops API unreachable / no agent key / no admin credential → **skipped**, rendered "UNVERIFIED (could not probe — <reason>)" — an unrun check must not look like a pass.

All assertions on audit entries are boolean (entry counts only). Audit entries carry full record images, so no entry content ever reaches a result detail or command output; the tests plant a distinctive marker inside mocked record images and assert it never appears in any result.

## Live verification (ephemeral harper@5.2.0 instance)

Settles the spec's open PATCH question — no second-PUT fallback needed:

- `PATCH /Memory/<id>` → 204 and generates its own audit entry, operation `patch` (PUT records as `upsert`, DELETE as `delete`).
- Probe round-trip: PUT + PATCH + PUT → 3 entries `[upsert, patch, upsert]`; after DELETE → `[upsert, patch, upsert, delete]`.
- Never-written id → HTTP 200 `{"<id>": []}` — the exact silent shape the issue observed.
- `logging.auditLog` off → HTTP 400 `To use this operation audit log must be enabled in harperdb-config.yaml`.

## Tests

`test/unit/doctor-audit-verify.test.ts` (sibling of `doctor-embed-verify.test.ts`, same `global.fetch` mock shape): 12 cases — entries⇒ok; **`{"<id>": []}`⇒degraded (the positive-control row: the pre-fix world silently passed this state)**; partial (1 entry)⇒degraded; delete-entries-don't-count⇒degraded; 400⇒degraded-disabled; unreachable⇒skipped; unexpected 401⇒skipped (cannot-verify is not verified); no-agent/no-credentials/write-failure⇒skipped; finally-cleanup; no-content-leak guards on ok and degraded paths.

Mutation check: reverting the classifier to the pre-fix world (empty ⇒ ok) turns 3 tests red — including the positive-control row — restoring turns all 12 green.

Unit suite: 4607 pass / 0 fail (self-measured baseline on main: 4595 pass / 0 fail).

Closes #970

🤖 Generated with [Claude Code](https://claude.com/claude-code)
