### PR TITLE
scheduler enable: verify the first run before claiming success; shims stop depending on the exec bit

### DIFF
--- a/.changelog/unreleased/fixed-1231-scheduler-first-run-verify.md
+++ b/.changelog/unreleased/fixed-1231-scheduler-first-run-verify.md
@@ -1,0 +1,17 @@
+- **`flair federation sync enable` and `flair rem nightly enable` now verify
+  the job's FIRST RUN through the service manager before claiming success**
+  (flair#1231). Previously the ✅ headline only required launchd/systemd to
+  *accept* the job; two shipped defects (a scheduler shim whose exec bit is
+  stripped by tarball extraction, and a log directory nothing ever created)
+  both passed that check and silently killed every real run. Now: both shims
+  run the CLI under `node <script>` (read permission suffices — no exec-bit
+  dependency), with the node binary resolved to an absolute path at enable
+  time so the shim performs zero PATH lookups at run time; enable creates
+  `~/.flair/logs` (mode 0700 — the REM log carries memory content); and after
+  a successful load, enable triggers the first run via the service manager
+  (`launchctl kickstart` + exit-status poll on macOS, blocking
+  `systemctl --user start` + status read on Linux) and refuses the success
+  headline unless that run exited 0 — failures report the exit status, a
+  stderr tail from the job's log, and the fix to apply. "Service manager
+  unreachable" and "run still going after 12s" are reported as their own
+  distinct states, never as success.

--- a/src/federation/scheduler.ts
+++ b/src/federation/scheduler.ts
@@ -57,13 +57,14 @@
  * `flair federation sync --admin-pass-file`, which reads it through
  * readAdminPassFileSecure() and refuses a file that is not owner-only.
  */
-import { existsSync, chmodSync, rmSync, readFileSync } from "node:fs";
+import { existsSync, chmodSync, rmSync, readFileSync, mkdirSync } from "node:fs";
 import { resolve, dirname } from "node:path";
 import { homedir } from "node:os";
 import { fileURLToPath } from "node:url";
 import { escapeXml } from "../lib/xml-escape.js";
 import {
   type SchedulerPlatform,
+  type FirstRunVerification,
   detectPlatform as detectPlatformFor,
   spawnReport,
   readTemplate,
@@ -71,6 +72,9 @@ import {
   writeFileWithDir,
   interpretActiveResult,
   describeLoadFailure as describeLoadFailureFor,
+  describeExitCode,
+  resolveNodeBin,
+  verifyFirstRun,
   STATUS_CHECK_TIMEOUT_MS,
 } from "../lib/scheduler-platform.js";
 
@@ -102,6 +106,11 @@ export const MAX_INTERVAL_SECONDS = 86_400;
 export interface FederationSchedulerSubstitutions {
   /** Absolute path to the flair binary the shim should invoke. */
   FLAIR_BIN: string;
+  /**
+   * Absolute path to the node binary that runs FLAIR_BIN, resolved at enable
+   * time (#1231). Baked in so the shim performs zero PATH lookups at run time.
+   */
+  NODE_BIN: string;
   /** Absolute path to the shim script the scheduler should call. */
   SHIM_PATH: string;
   /** Operator's home directory (HOME env var value). */
@@ -130,6 +139,12 @@ export interface EnableOpts {
   target?: string;
   /** Absolute path to the flair binary. Defaults to argv[1]. */
   flairBin?: string;
+  /**
+   * Absolute path to the node binary baked into the shim. Defaults to
+   * resolveNodeBin() — the enabling runtime's own binary, or `command -v
+   * node` resolved once at enable time (#1231).
+   */
+  nodeBin?: string;
   /** Override platform for testing. */
   platformOverride?: SchedulerPlatform;
   /** Override target paths for testing. */
@@ -152,6 +167,19 @@ export interface EnableResult {
   intervalSeconds: number;
   loadCommand: string[];
   loadResult?: { code: number | null; stdout: string; stderr: string };
+  /**
+   * True ONLY when the service manager was observed to run the job once and
+   * it exited 0 (#1231). formatEnableReport() refuses the success headline
+   * without it — a load command exiting 0 proves the job was ACCEPTED, not
+   * that it can RUN.
+   */
+  firstRunVerified: boolean;
+  /**
+   * How verification concluded. Absent when it was never attempted: load
+   * skipped (tests) or load failed (a load failure is its own failure mode —
+   * verification is only attempted after the load exits 0).
+   */
+  firstRun?: FirstRunVerification;
 }
 
 export interface DisableOpts {
@@ -228,7 +256,7 @@ export function validateInterval(intervalSeconds: number): void {
   }
 }
 
-function buildSubstitutions(opts: EnableOpts, shimPath: string, flairBin: string): FederationSchedulerSubstitutions {
+function buildSubstitutions(opts: EnableOpts, shimPath: string, flairBin: string, nodeBin: string): FederationSchedulerSubstitutions {
   validateInterval(opts.intervalSeconds);
   const adminPassFile = opts.adminPassFile ?? "";
   if (adminPassFile && !existsSync(adminPassFile)) {
@@ -239,6 +267,7 @@ function buildSubstitutions(opts: EnableOpts, shimPath: string, flairBin: string
   }
   return {
     FLAIR_BIN: flairBin,
+    NODE_BIN: nodeBin,
     SHIM_PATH: shimPath,
     HOME: opts.homeOverride ?? homedir(),
     INTERVAL_SECONDS: String(opts.intervalSeconds),
@@ -265,9 +294,31 @@ function launchdDomain(): string {
 export function enableScheduler(opts: EnableOpts): EnableResult {
   const plat = detectPlatform(opts.platformOverride);
   const flairBin = opts.flairBin ?? process.argv[1] ?? "flair";
+  const nodeBin = resolveNodeBin(opts.nodeBin);
   const shimPath = opts.shimPathOverride ?? SHIM_PATH_DEFAULT;
   const templateRoot = opts.templateRootOverride ?? defaultTemplateRoot();
-  const subs = buildSubstitutions(opts, shimPath, flairBin);
+  const subs = buildSubstitutions(opts, shimPath, flairBin, nodeBin);
+
+  // 0. Create the log directory the unit files point stdout/stderr at.
+  // Nothing else ever creates it — launchd kills a job whose StandardOutPath
+  // directory is missing (spawn error 209) and systemd fails the unit (#1231).
+  //
+  // Mode 0700 is load-bearing, NOT cosmetic: this directory also receives
+  // REM's nightly log, which carries distillation CANDIDATE CONTENT — actual
+  // memory text, not just sync counts and errors. Relaxing it to 0755 (e.g.
+  // "for shared debugging") would expose memory content to every local user.
+  const logsDir = resolve(subs.HOME, ".flair", "logs");
+  try {
+    mkdirSync(logsDir, { recursive: true, mode: 0o700 });
+  } catch (err: any) {
+    throw new Error(
+      `could not create the scheduler log directory ${logsDir}: ${err?.message ?? err}. ` +
+        `The service manager writes the job's stdout/stderr there; without it the first run dies ` +
+        `before producing any output. Fix whatever blocks creating that directory, then re-run ` +
+        `\`flair federation sync enable\`.`,
+    );
+  }
+  const stderrLogPath = resolve(logsDir, "federation-sync.stderr.log");
 
   // 1. Deploy the shim (always — both platforms invoke it).
   const shimContents = renderTemplate(readTemplate(templateRoot, "bin/flair-federation-sync.sh.tmpl"), subs);
@@ -285,14 +336,28 @@ export function enableScheduler(opts: EnableOpts): EnableResult {
 
     const loadCommand = ["launchctl", "bootstrap", launchdDomain(), plistPath];
     let loadResult: EnableResult["loadResult"];
+    let firstRun: FirstRunVerification | undefined;
     if (!opts.skipLoad) {
       // Bootout first in case a prior install left the job loaded — this is
       // what makes re-running enable (e.g. to change --interval) idempotent
       // rather than a "service already loaded" failure.
       spawnReport(["launchctl", "bootout", launchdDomain(), plistPath]);
       loadResult = spawnReport(loadCommand);
+      if (loadResult.code === 0) {
+        // Ordering gate (#1231): verify the first run ONLY after the load
+        // exited 0. A load failure is its own failure mode with its own
+        // remedy — kickstarting on top of it would blur which actor failed.
+        firstRun = verifyFirstRun({
+          plat,
+          darwinTarget: `${launchdDomain()}/${LAUNCHD_LABEL}`,
+          stderrLogPath,
+        });
+      }
     }
-    return { platform: plat, shimPath, schedulerPath: plistPath, intervalSeconds: opts.intervalSeconds, loadCommand, loadResult };
+    return {
+      platform: plat, shimPath, schedulerPath: plistPath, intervalSeconds: opts.intervalSeconds,
+      loadCommand, loadResult, firstRunVerified: firstRun?.verified === true, firstRun,
+    };
   }
 
   // Linux: systemd user units.
@@ -306,14 +371,24 @@ export function enableScheduler(opts: EnableOpts): EnableResult {
 
   const loadCommand = ["systemctl", "--user", "enable", "--now", SYSTEMD_TIMER_UNIT];
   let loadResult: EnableResult["loadResult"];
+  let firstRun: FirstRunVerification | undefined;
   if (!opts.skipLoad) {
     spawnReport(["systemctl", "--user", "daemon-reload"]);
     // Restart so a changed --interval takes effect on re-enable; `enable
     // --now` alone leaves an already-running timer on its old schedule.
     loadResult = spawnReport(loadCommand);
-    if (loadResult.code === 0) spawnReport(["systemctl", "--user", "restart", SYSTEMD_TIMER_UNIT]);
+    if (loadResult.code === 0) {
+      spawnReport(["systemctl", "--user", "restart", SYSTEMD_TIMER_UNIT]);
+      // Ordering gate (#1231): only after the load exited 0. Starts the
+      // SERVICE unit directly (oneshot ⇒ blocks until the run exits) rather
+      // than waiting out the timer.
+      firstRun = verifyFirstRun({ plat, linuxServiceUnit: SYSTEMD_SERVICE_UNIT, stderrLogPath });
+    }
   }
-  return { platform: plat, shimPath, schedulerPath: timerPath, intervalSeconds: opts.intervalSeconds, loadCommand, loadResult };
+  return {
+    platform: plat, shimPath, schedulerPath: timerPath, intervalSeconds: opts.intervalSeconds,
+    loadCommand, loadResult, firstRunVerified: firstRun?.verified === true, firstRun,
+  };
 }
 
 /** Removes the scheduler entry. Peer records and sync history are untouched. */
@@ -649,6 +724,14 @@ export interface FormattedReport {
  * success-vs-failure decision (flair#850: never print a success headline
  * before activation is known to have succeeded), extracted from the CLI
  * action so it is unit-testable without spawning launchctl/systemctl.
+ *
+ * flair#1231 deepened the #850 rule by one layer: activation exiting 0 proves
+ * the service manager ACCEPTED the job, not that the job can run — a stripped
+ * exec bit and a missing log directory both passed activation and killed the
+ * first real run invisibly. So the ✅ headline is now additionally gated on
+ * `firstRunVerified`: success may not be claimed until the thing the operator
+ * asked for — a sync run through the service manager — has been observed to
+ * happen once.
  */
 export function formatEnableReport(r: EnableResult, input: { adminPassFile?: string; target?: string }): FormattedReport {
   const activationFailed = !!r.loadResult && r.loadResult.code !== 0;
@@ -676,6 +759,53 @@ export function formatEnableReport(r: EnableResult, input: { adminPassFile?: str
     return { lines, ok: false };
   }
 
+  if (!r.firstRunVerified) {
+    const fr = r.firstRun;
+    const headline =
+      fr?.outcome === "run-failed"
+        ? `⚠️  Federation sync driver installed but the first run FAILED (${describeExitCode(fr.exitCode)})`
+        : fr?.outcome === "timeout"
+          ? `⚠️  Federation sync driver installed but the first run did not complete within ${Math.round(fr.budgetMs / 1000)}s — cannot confirm it works`
+          : fr?.outcome === "manager-unavailable"
+            ? `⚠️  Federation sync driver installed but the service manager is unreachable — cannot verify the first run`
+            : fr?.outcome === "start-failed"
+              ? `⚠️  Federation sync driver installed but the first run could not be started`
+              : `⚠️  Federation sync driver installed but the first run was never verified`;
+    const lines = [
+      headline,
+      `   Interval:    every ${r.intervalSeconds}s`,
+      `   Scheduler:   ${r.schedulerPath}`,
+      `   Shim:        ${r.shimPath}`,
+      credLine,
+    ];
+    if (input.target) lines.push(`   Target:      ${input.target}`);
+    if (r.loadResult) lines.push(`   Load:        ${r.loadCommand.join(" ")} → ok`);
+    if (fr) {
+      lines.push(`   First run:   ${fr.detail}`);
+      if (fr.stderrTail) {
+        lines.push(`   Log tail (${fr.logPath}):`);
+        for (const l of fr.stderrTail.split("\n")) lines.push(`     ${l}`);
+      } else if (fr.logEmpty) {
+        lines.push(`   Log file ${fr.logPath} exists but is EMPTY — the run died before writing anything.`);
+      } else {
+        lines.push(`   No log file at ${fr.logPath}.`);
+      }
+    }
+    lines.push("");
+    if (fr?.outcome === "timeout") {
+      lines.push(`   The run may legitimately still be going. Check the log above and \`flair federation status\`;`);
+      lines.push(`   nothing has been CONFIRMED to sync yet.`);
+    } else if (fr?.outcome === "manager-unavailable") {
+      lines.push(`   The driver files are installed, but launchctl/systemctl could not be consulted, so whether`);
+      lines.push(`   sync runs is UNKNOWN. Fix the service manager for this session, then re-run \`flair federation sync enable\`.`);
+    } else {
+      lines.push(`   Nothing has synced. Fix the cause above, then re-run \`flair federation sync enable\`.`);
+    }
+    lines.push("");
+    lines.push(`   Check anytime with: flair federation sync status`);
+    return { lines, ok: false };
+  }
+
   const lines = [
     `✅ Federation sync driver enabled (${r.platform})`,
     `   Interval:    every ${r.intervalSeconds}s`,
@@ -685,9 +815,10 @@ export function formatEnableReport(r: EnableResult, input: { adminPassFile?: str
   ];
   if (input.target) lines.push(`   Target:      ${input.target}`);
   if (r.loadResult) lines.push(`   Load:        ${r.loadCommand.join(" ")} → ok`);
+  lines.push(`   First run:   completed through the service manager, exit 0`);
   lines.push("");
-  lines.push(`The first sync runs immediately. Confirm with \`flair federation status\`,`);
-  lines.push(`which now reports whether anything is actually driving sync.`);
+  lines.push(`Confirm anytime with \`flair federation status\`,`);
+  lines.push(`which reports whether anything is actually driving sync.`);
   lines.push(`Disable with \`flair federation sync disable\`.`);
   return { lines, ok: true };
 }

--- a/src/lib/scheduler-platform.ts
+++ b/src/lib/scheduler-platform.ts
@@ -13,9 +13,15 @@
  *
  * `interpretActiveResult()` in particular encodes a production lesson
  * (flair#850) that took a real outage to learn. It must not be re-derived.
+ * flair#1231 extended it one layer deeper: a load command exiting 0 proves the
+ * service manager ACCEPTED the job, not that the job can RUN — two fleet
+ * incidents (a stripped exec bit, a missing log directory) both passed the
+ * load check and died on the first real run, invisibly. The rule now encoded
+ * in `verifyFirstRun()`: success may not be claimed until the thing the
+ * operator asked for has been observed to happen once.
  */
 import { existsSync, mkdirSync, writeFileSync, readFileSync } from "node:fs";
-import { resolve, dirname } from "node:path";
+import { resolve, dirname, isAbsolute } from "node:path";
 import { platform } from "node:os";
 import { spawnSync, type SpawnSyncReturns } from "node:child_process";
 
@@ -147,4 +153,266 @@ export function writeFileWithDir(path: string, contents: string, mode: number = 
   const dir = dirname(path);
   if (!existsSync(dir)) mkdirSync(dir, { recursive: true, mode: 0o700 });
   writeFileSync(path, contents, { mode });
+}
+
+// ─── node binary resolution (flair#1231) ────────────────────────────────────
+
+/**
+ * Resolves the ABSOLUTE path to the node binary at enable time, so the shim
+ * can `exec "<node>" "<script>"` with ZERO PATH lookups at run time.
+ *
+ * Why this exists: the shims switched from `exec "{{FLAIR_BIN}}"` (which
+ * required an exec bit that tarball extraction strips — the #1231 regression)
+ * to running the CLI under node, which needs read permission only. But a bare
+ * `exec node …` would introduce a run-time PATH lookup the old absolute-path
+ * form never had: whatever PATH the service manager's environment carries
+ * would pick the `node` that runs with the operator's credentials. So the
+ * node path is resolved HERE, once, from the enabling process's own
+ * environment, and baked into the shim — symmetric with how FLAIR_BIN is
+ * already handled.
+ *
+ * Resolution order:
+ *   1. `explicit` — caller/test override.
+ *   2. `process.execPath` when the enabling runtime IS node (the published
+ *      CLI's case): absolute, known-good, already trusted to run this code.
+ *   3. `command -v node` in the enabling shell environment (dev/test under
+ *      bun): the one deliberate PATH consultation, made at enable time by the
+ *      operator's own session, never later by the service manager.
+ * Nothing resolvable ⇒ throw — enable must fail loudly rather than bake a
+ * run-time lookup into the shim.
+ */
+export function resolveNodeBin(explicit?: string): string {
+  if (explicit) return explicit;
+  if (!process.versions.bun && process.execPath && isAbsolute(process.execPath)) {
+    return process.execPath;
+  }
+  const r = spawnReport(["/bin/sh", "-c", "command -v node"], STATUS_CHECK_TIMEOUT_MS);
+  const found = r.stdout.trim().split("\n")[0]?.trim() ?? "";
+  if (r.code === 0 && found && isAbsolute(found) && existsSync(found)) return found;
+  throw new Error(
+    "unable to resolve an absolute path to a node binary (not running under node, and `command -v node` " +
+      "found nothing). The scheduler shim runs `<node> <flair-script>` with the node path baked in at " +
+      "enable time — refusing to install a shim that would resolve `node` from the service manager's PATH " +
+      "at run time. Install node (or put it on PATH for this shell) and re-run enable.",
+  );
+}
+
+// ─── first-run verification (flair#1231) ────────────────────────────────────
+// A load/bootstrap command exiting 0 proves the service manager accepted the
+// job — not that the job can run. The only vantage that exercises the real
+// failure modes (launchd spawn error 209 from a missing log dir, exit 126
+// from a stripped exec bit) is the service manager itself, so the first run
+// is triggered and observed THROUGH it, never via a bare spawn of the shim.
+
+/** Poll cadence for darwin `launchctl print` first-run polling. */
+export const FIRST_RUN_POLL_INTERVAL_MS = 150;
+/** Total budget for first-run verification on both platforms. */
+export const FIRST_RUN_BUDGET_MS = 12_000;
+
+export type FirstRunOutcome =
+  /** The service manager ran the job once and it exited 0. */
+  | "success"
+  /** The job ran and exited nonzero (or systemd recorded a failure Result). */
+  | "run-failed"
+  /** The kickstart/start request itself was rejected by the service manager. */
+  | "start-failed"
+  /** The run did not complete inside the budget — it may still be running. */
+  | "timeout"
+  /** launchctl/systemctl could not be consulted at all — CANNOT VERIFY. */
+  | "manager-unavailable";
+
+export interface FirstRunVerification {
+  /** True ONLY for outcome "success". Everything else withholds the claim. */
+  verified: boolean;
+  outcome: FirstRunOutcome;
+  /** The run's recorded exit status, when one was recorded. */
+  exitCode: number | null;
+  /** Mechanical detail: which command said what. */
+  detail: string;
+  /** The stderr log consulted for the failure tail. */
+  logPath: string;
+  /** Last lines of the log, when the file exists and is non-empty. */
+  stderrTail: string;
+  /** The log file exists but is EMPTY — the run died before writing. */
+  logEmpty: boolean;
+  /** Budget the verification ran under (for honest timeout wording). */
+  budgetMs: number;
+}
+
+/** Injectable process/clock hooks so unit tests never touch a real service manager. */
+export interface FirstRunHooks {
+  run?: (cmd: string[], timeoutMs: number) => SpawnReport;
+  sleep?: (ms: number) => void;
+  now?: () => number;
+}
+
+/** Synchronous sleep without spawning anything. */
+function sleepSync(ms: number): void {
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
+}
+
+/**
+ * Parses `launchctl print <domain>/<label>` for run state. `last exit code`
+ * is absent (or "(never exited)") until a run has completed, and `pid =` /
+ * `state = running` are present only while one is in flight.
+ */
+export function parseLaunchdPrintExit(output: string): { running: boolean; lastExitCode: number | null } {
+  const running = /^\s*state\s*=\s*(?:running|spawn)/m.test(output) || /^\s*pid\s*=\s*\d+/m.test(output);
+  const m = /last exit (?:code|status)\s*=\s*(-?\d+)/.exec(output);
+  return { running, lastExitCode: m ? Number(m[1]) : null };
+}
+
+/** Parses `systemctl --user show <unit> --property=ExecMainStatus,Result`. */
+export function parseSystemdShowExit(output: string): { execMainStatus: number | null; result: string | null } {
+  const m = /^ExecMainStatus=(-?\d+)\s*$/m.exec(output);
+  const r = /^Result=(\S+)\s*$/m.exec(output);
+  return { execMainStatus: m ? Number(m[1]) : null, result: r ? r[1] : null };
+}
+
+/** Reads the last lines of a log file for failure diagnostics. Never throws. */
+export function readLogTail(path: string, maxLines = 12, maxChars = 1500): { exists: boolean; empty: boolean; tail: string } {
+  let text: string;
+  try {
+    text = readFileSync(path, "utf-8");
+  } catch {
+    return { exists: false, empty: false, tail: "" };
+  }
+  const trimmed = text.trimEnd();
+  if (!trimmed) return { exists: true, empty: true, tail: "" };
+  let tail = trimmed.split("\n").slice(-maxLines).join("\n");
+  if (tail.length > maxChars) tail = tail.slice(-maxChars);
+  return { exists: true, empty: false, tail };
+}
+
+/**
+ * Names the failure class for a recorded exit status, so the report can lead
+ * with actor+state instead of a bare number.
+ */
+export function describeExitCode(code: number | null): string {
+  if (code === null) return "no exit status recorded";
+  if (code === 126) return "exit 126 — found but not runnable (permission denied / exec format)";
+  if (code === 127) return "exit 127 — command not found";
+  if (code === 209) return "exit 209 — launchd could not spawn the job (a missing/unwritable log directory produces this)";
+  return `exit ${code}`;
+}
+
+export interface VerifyFirstRunOpts {
+  plat: SchedulerPlatform;
+  /** darwin: the `<domain>/<label>` target for kickstart/print. */
+  darwinTarget?: string;
+  /** linux: the SERVICE unit (not the timer) to start-and-read. */
+  linuxServiceUnit?: string;
+  /** The job's stderr log file, consulted for the failure-path tail. */
+  stderrLogPath: string;
+  pollIntervalMs?: number;
+  budgetMs?: number;
+  hooks?: FirstRunHooks;
+}
+
+function spawnedNothing(r: SpawnReport): boolean {
+  return r.code === null && !r.stdout.trim() && !r.stderr.trim();
+}
+
+/**
+ * Triggers the job's first run through the service manager and reads back how
+ * it ended (flair#1231). Call ONLY after the load/bootstrap command exited 0 —
+ * a load failure is its own failure mode with its own remedy, and layering a
+ * kickstart on top of it would blur which actor failed.
+ *
+ * darwin: `launchctl kickstart -k` returns immediately (it does NOT block for
+ * exit), so the recorded exit status is POLLED out of `launchctl print` until
+ * a completed run is visible or the budget lapses. linux: `systemctl --user
+ * start` on a oneshot blocks until the run exits, so a single
+ * `systemctl --user show` read afterwards suffices.
+ *
+ * "Can't tell" is its own state: a missing/unreachable service manager yields
+ * outcome "manager-unavailable", distinct from "run-failed" — the remedy
+ * points at the service manager, not at the job.
+ */
+export function verifyFirstRun(opts: VerifyFirstRunOpts): FirstRunVerification {
+  const run = opts.hooks?.run ?? ((cmd: string[], timeoutMs: number) => spawnReport(cmd, timeoutMs));
+  const sleep = opts.hooks?.sleep ?? sleepSync;
+  const now = opts.hooks?.now ?? Date.now;
+  const pollIntervalMs = opts.pollIntervalMs ?? FIRST_RUN_POLL_INTERVAL_MS;
+  const budgetMs = opts.budgetMs ?? FIRST_RUN_BUDGET_MS;
+
+  const finish = (outcome: FirstRunOutcome, exitCode: number | null, detail: string): FirstRunVerification => {
+    const log = outcome === "success"
+      ? { exists: false, empty: false, tail: "" } // no diagnostics needed on success
+      : readLogTail(opts.stderrLogPath);
+    return {
+      verified: outcome === "success",
+      outcome,
+      exitCode,
+      detail,
+      logPath: opts.stderrLogPath,
+      stderrTail: log.tail,
+      logEmpty: log.exists && log.empty,
+      budgetMs,
+    };
+  };
+
+  if (opts.plat === "darwin") {
+    const target = opts.darwinTarget;
+    if (!target) throw new Error("verifyFirstRun: darwinTarget is required on darwin");
+    const kickCmd = ["launchctl", "kickstart", "-k", target];
+    const kick = run(kickCmd, SPAWN_TIMEOUT_MS);
+    if (spawnedNothing(kick)) {
+      return finish("manager-unavailable", null, `launchctl could not be run (${kickCmd.join(" ")})`);
+    }
+    if (kick.code !== 0) {
+      return finish("start-failed", null, `${kickCmd.join(" ")} → code ${kick.code}${kick.stderr.trim() ? `: ${kick.stderr.trim()}` : ""}`);
+    }
+    const deadline = now() + budgetMs;
+    // Poll: kickstart returned immediately, so watch `launchctl print` until a
+    // COMPLETED run (not running + a recorded exit code) is visible.
+    for (;;) {
+      const printCmd = ["launchctl", "print", target];
+      const r = run(printCmd, STATUS_CHECK_TIMEOUT_MS);
+      if (spawnedNothing(r)) {
+        return finish("manager-unavailable", null, `launchctl could not be run (${printCmd.join(" ")})`);
+      }
+      if (r.code === 0) {
+        const { running, lastExitCode } = parseLaunchdPrintExit(r.stdout);
+        if (!running && lastExitCode !== null) {
+          return lastExitCode === 0
+            ? finish("success", 0, `${printCmd.join(" ")} → last exit code = 0`)
+            : finish("run-failed", lastExitCode, `${printCmd.join(" ")} → last exit code = ${lastExitCode}`);
+        }
+      }
+      if (now() >= deadline) {
+        return finish("timeout", null, `no completed run visible in ${printCmd.join(" ")} within ${Math.round(budgetMs / 1000)}s`);
+      }
+      sleep(pollIntervalMs);
+    }
+  }
+
+  // linux
+  const unit = opts.linuxServiceUnit;
+  if (!unit) throw new Error("verifyFirstRun: linuxServiceUnit is required on linux");
+  const startCmd = ["systemctl", "--user", "start", unit];
+  const start = run(startCmd, budgetMs);
+  if (spawnedNothing(start)) {
+    return finish("manager-unavailable", null, `systemctl could not be run (${startCmd.join(" ")})`);
+  }
+  if (/failed to connect to bus/i.test(start.stderr)) {
+    return finish("manager-unavailable", null, `${startCmd.join(" ")} → ${start.stderr.trim()}`);
+  }
+  if (start.code === null) {
+    return finish("timeout", null, `${startCmd.join(" ")} did not return within ${Math.round(budgetMs / 1000)}s`);
+  }
+  const showCmd = ["systemctl", "--user", "show", unit, "--property=ExecMainStatus,Result"];
+  const show = run(showCmd, STATUS_CHECK_TIMEOUT_MS);
+  const parsed = parseSystemdShowExit(show.stdout);
+  if (start.code === 0) {
+    // A blocking start of a oneshot exits 0 only when the run succeeded; the
+    // show read supplies the recorded status for the report.
+    return finish("success", parsed.execMainStatus ?? 0, `${startCmd.join(" ")} → ok`);
+  }
+  const resultTxt = parsed.result ? `, Result=${parsed.result}` : "";
+  return finish(
+    "run-failed",
+    parsed.execMainStatus,
+    `${startCmd.join(" ")} → code ${start.code}${resultTxt}${start.stderr.trim() ? `: ${start.stderr.trim()}` : ""}`,
+  );
 }

--- a/src/rem/scheduler.ts
+++ b/src/rem/scheduler.ts
@@ -21,6 +21,7 @@ import { fileURLToPath } from "node:url";
 import { escapeXml } from "../lib/xml-escape.js";
 import {
   type SchedulerPlatform,
+  type FirstRunVerification,
   detectPlatform as detectPlatformFor,
   spawnReport,
   readTemplate as readTemplateFrom,
@@ -28,6 +29,9 @@ import {
   writeFileWithDir,
   interpretActiveResult,
   describeLoadFailure as describeLoadFailureFor,
+  describeExitCode,
+  resolveNodeBin,
+  verifyFirstRun,
   SPAWN_TIMEOUT_MS,
   STATUS_CHECK_TIMEOUT_MS,
 } from "../lib/scheduler-platform.js";
@@ -48,6 +52,11 @@ export const SYSTEMD_SERVICE_PATH = resolve(SYSTEMD_USER_DIR, "flair-rem-nightly
 export interface SchedulerSubstitutions {
   /** Absolute path to the flair binary the shim should invoke. */
   FLAIR_BIN: string;
+  /**
+   * Absolute path to the node binary that runs FLAIR_BIN, resolved at enable
+   * time (#1231). Baked in so the shim performs zero PATH lookups at run time.
+   */
+  NODE_BIN: string;
   /** Absolute path to the shim script the scheduler should call. */
   SHIM_PATH: string;
   /** Operator's home directory (HOME env var value). */
@@ -75,6 +84,12 @@ export interface EnableOpts {
   minute: number;
   /** Absolute path to the flair binary. Defaults to argv[0]'s nearest bin dir. */
   flairBin?: string;
+  /**
+   * Absolute path to the node binary baked into the shim. Defaults to
+   * resolveNodeBin() — the enabling runtime's own binary, or `command -v
+   * node` resolved once at enable time (#1231).
+   */
+  nodeBin?: string;
   /** Override platform for testing. */
   platformOverride?: SchedulerPlatform;
   /** Override target paths for testing. */
@@ -82,6 +97,8 @@ export interface EnableOpts {
   launchdPlistOverride?: string;
   systemdTimerOverride?: string;
   systemdServiceOverride?: string;
+  /** Override HOME written into the units (testing). */
+  homeOverride?: string;
   /** Override the template root for testing. */
   templateRootOverride?: string;
   /** Skip the launchctl/systemctl invocation (testing). */
@@ -94,6 +111,19 @@ export interface EnableResult {
   schedulerPath: string;
   loadCommand: string[];
   loadResult?: { code: number | null; stdout: string; stderr: string };
+  /**
+   * True ONLY when the service manager was observed to run the job once and
+   * it exited 0 (#1231). formatEnableReport() refuses the success headline
+   * without it — a load command exiting 0 proves the job was ACCEPTED, not
+   * that it can RUN.
+   */
+  firstRunVerified: boolean;
+  /**
+   * How verification concluded. Absent when it was never attempted: load
+   * skipped (tests) or load failed (a load failure is its own failure mode —
+   * verification is only attempted after the load exits 0).
+   */
+  firstRun?: FirstRunVerification;
 }
 
 export interface DisableOpts {
@@ -176,15 +206,16 @@ function validateSchedule(hour: number, minute: number): void {
   }
 }
 
-function buildSubstitutions(opts: EnableOpts, shimPath: string, flairBin: string): SchedulerSubstitutions {
+function buildSubstitutions(opts: EnableOpts, shimPath: string, flairBin: string, nodeBin: string): SchedulerSubstitutions {
   validateSchedule(opts.hour, opts.minute);
   if (!/^[a-zA-Z0-9_-]+$/.test(opts.agentId)) {
     throw new Error(`invalid agent id: ${opts.agentId}`);
   }
   return {
     FLAIR_BIN: flairBin,
+    NODE_BIN: nodeBin,
     SHIM_PATH: shimPath,
-    HOME: homedir(),
+    HOME: opts.homeOverride ?? homedir(),
     AGENT_ID: opts.agentId,
     FLAIR_URL: opts.flairUrl,
     HOUR: String(opts.hour),
@@ -285,10 +316,14 @@ export interface FormattedReport {
  * succeeded) is unit-testable without spawning a real launchctl/systemctl or
  * parsing CLI argv.
  *
- * `r.loadResult` is only set when the load command actually ran (the CLI
- * never sets `skipLoad`). A missing `loadResult` (test-only path) is treated
- * as success — matches the CLI's real-world behavior, which always runs the
- * load command and therefore always gets a `loadResult`.
+ * flair#1231 deepened the #850 rule by one layer: activation exiting 0 proves
+ * the service manager ACCEPTED the job, not that the job can run — a stripped
+ * exec bit and a missing log directory both passed activation and killed the
+ * first real run invisibly. So the ✅ headline is now additionally gated on
+ * `firstRunVerified`: success may not be claimed until the thing the operator
+ * asked for — a REM run through the service manager — has been observed to
+ * happen once. A missing `loadResult`/`firstRun` (test-only skipLoad shape)
+ * therefore withholds the headline too, instead of being treated as success.
  */
 export function formatEnableReport(r: EnableResult, input: EnableReportInput): FormattedReport {
   const { hour, minute, agentId, flairUrl } = input;
@@ -315,6 +350,53 @@ export function formatEnableReport(r: EnableResult, input: EnableReportInput): F
     return { lines, ok: false };
   }
 
+  if (!r.firstRunVerified) {
+    const fr = r.firstRun;
+    const headline =
+      fr?.outcome === "run-failed"
+        ? `⚠️  REM nightly scheduler installed but the first run FAILED (${describeExitCode(fr.exitCode)})`
+        : fr?.outcome === "timeout"
+          ? `⚠️  REM nightly scheduler installed but the first run did not complete within ${Math.round(fr.budgetMs / 1000)}s — cannot confirm it works`
+          : fr?.outcome === "manager-unavailable"
+            ? `⚠️  REM nightly scheduler installed but the service manager is unreachable — cannot verify the first run`
+            : fr?.outcome === "start-failed"
+              ? `⚠️  REM nightly scheduler installed but the first run could not be started`
+              : `⚠️  REM nightly scheduler installed but the first run was never verified`;
+    const lines = [
+      headline,
+      `   Schedule:    ${scheduleTime} local time`,
+      `   Scheduler:   ${r.schedulerPath}`,
+      `   Shim:        ${r.shimPath}`,
+      `   Agent:       ${agentId}`,
+      `   Flair URL:   ${flairUrl}`,
+    ];
+    if (r.loadResult) lines.push(`   Load:        ${r.loadCommand.join(" ")} → ok`);
+    if (fr) {
+      lines.push(`   First run:   ${fr.detail}`);
+      if (fr.stderrTail) {
+        lines.push(`   Log tail (${fr.logPath}):`);
+        for (const l of fr.stderrTail.split("\n")) lines.push(`     ${l}`);
+      } else if (fr.logEmpty) {
+        lines.push(`   Log file ${fr.logPath} exists but is EMPTY — the run died before writing anything.`);
+      } else {
+        lines.push(`   No log file at ${fr.logPath}.`);
+      }
+    }
+    lines.push("");
+    if (fr?.outcome === "timeout") {
+      lines.push(`   The run may legitimately still be going (a REM cycle can be slow). Check the log above and`);
+      lines.push(`   \`flair rem nightly status\`; no cycle has been CONFIRMED to work yet.`);
+    } else if (fr?.outcome === "manager-unavailable") {
+      lines.push(`   The scheduler files are installed, but launchctl/systemctl could not be consulted, so whether`);
+      lines.push(`   the nightly cycle runs is UNKNOWN. Fix the service manager for this session, then re-run \`flair rem nightly enable\`.`);
+    } else {
+      lines.push(`   No REM cycle has run. Fix the cause above, then re-run \`flair rem nightly enable\`.`);
+    }
+    lines.push("");
+    lines.push(`   Check anytime with: flair rem nightly status`);
+    return { lines, ok: false };
+  }
+
   const lines = [
     `✅ REM nightly scheduler enabled (${r.platform})`,
     `   Schedule:    ${scheduleTime} local time`,
@@ -326,9 +408,9 @@ export function formatEnableReport(r: EnableResult, input: EnableReportInput): F
   if (r.loadResult) {
     lines.push(`   Load:        ${r.loadCommand.join(" ")} → ok`);
   }
+  lines.push(`   First run:   completed through the service manager, exit 0`);
   lines.push("");
-  lines.push(`Tip: run \`flair rem nightly run-once --dry-run\` to verify the cycle works`);
-  lines.push(`     before the first scheduled fire. Disable with \`flair rem nightly disable\`.`);
+  lines.push(`Disable with \`flair rem nightly disable\`.`);
   return { lines, ok: true };
 }
 
@@ -372,9 +454,31 @@ export function formatStatusReport(s: SchedulerStatus): FormattedReport {
 export function enableScheduler(opts: EnableOpts): EnableResult {
   const plat = detectPlatform(opts.platformOverride);
   const flairBin = opts.flairBin ?? process.argv[1] ?? "flair";
+  const nodeBin = resolveNodeBin(opts.nodeBin);
   const shimPath = opts.shimPathOverride ?? SHIM_PATH_DEFAULT;
   const templateRoot = opts.templateRootOverride ?? defaultTemplateRoot();
-  const subs = buildSubstitutions(opts, shimPath, flairBin);
+  const subs = buildSubstitutions(opts, shimPath, flairBin, nodeBin);
+
+  // 0. Create the log directory the unit files point stdout/stderr at.
+  // Nothing else ever creates it — launchd kills a job whose StandardOutPath
+  // directory is missing (spawn error 209) and systemd fails the unit (#1231).
+  //
+  // Mode 0700 is load-bearing, NOT cosmetic: REM's nightly log carries
+  // distillation CANDIDATE CONTENT — actual memory text, not just counts.
+  // Relaxing it to 0755 (e.g. "for shared debugging") would expose memory
+  // content to every local user.
+  const logsDir = resolve(subs.HOME, ".flair", "logs");
+  try {
+    mkdirSync(logsDir, { recursive: true, mode: 0o700 });
+  } catch (err: any) {
+    throw new Error(
+      `could not create the scheduler log directory ${logsDir}: ${err?.message ?? err}. ` +
+        `The service manager writes the job's stdout/stderr there; without it the first run dies ` +
+        `before producing any output. Fix whatever blocks creating that directory, then re-run ` +
+        `\`flair rem nightly enable\`.`,
+    );
+  }
+  const stderrLogPath = resolve(logsDir, "rem-nightly.stderr.log");
 
   // 1. Deploy the shim (always — both platforms invoke it).
   const shimContents = renderTemplate(readTemplate(templateRoot, "bin/flair-rem-nightly.sh.tmpl"), subs);
@@ -389,12 +493,26 @@ export function enableScheduler(opts: EnableOpts): EnableResult {
 
     const loadCommand = ["launchctl", "bootstrap", `gui/${process.getuid?.() ?? ""}`, plistPath];
     let loadResult: EnableResult["loadResult"];
+    let firstRun: FirstRunVerification | undefined;
     if (!opts.skipLoad) {
       // Bootout first in case a prior install left the job loaded.
       spawnReport(["launchctl", "bootout", `gui/${process.getuid?.() ?? ""}`, plistPath]);
       loadResult = spawnReport(loadCommand);
+      if (loadResult.code === 0) {
+        // Ordering gate (#1231): verify the first run ONLY after the load
+        // exited 0. A load failure is its own failure mode with its own
+        // remedy — kickstarting on top of it would blur which actor failed.
+        firstRun = verifyFirstRun({
+          plat,
+          darwinTarget: `gui/${process.getuid?.() ?? ""}/dev.flair.rem.nightly`,
+          stderrLogPath,
+        });
+      }
     }
-    return { platform: plat, shimPath, schedulerPath: plistPath, loadCommand, loadResult };
+    return {
+      platform: plat, shimPath, schedulerPath: plistPath, loadCommand, loadResult,
+      firstRunVerified: firstRun?.verified === true, firstRun,
+    };
   }
 
   // Linux: systemd user units.
@@ -408,11 +526,21 @@ export function enableScheduler(opts: EnableOpts): EnableResult {
 
   const loadCommand = ["systemctl", "--user", "enable", "--now", "flair-rem-nightly.timer"];
   let loadResult: EnableResult["loadResult"];
+  let firstRun: FirstRunVerification | undefined;
   if (!opts.skipLoad) {
     spawnReport(["systemctl", "--user", "daemon-reload"]);
     loadResult = spawnReport(loadCommand);
+    if (loadResult.code === 0) {
+      // Ordering gate (#1231): only after the load exited 0. Starts the
+      // SERVICE unit directly (oneshot ⇒ blocks until the run exits) rather
+      // than waiting for the nightly timer to fire.
+      firstRun = verifyFirstRun({ plat, linuxServiceUnit: "flair-rem-nightly.service", stderrLogPath });
+    }
   }
-  return { platform: plat, shimPath, schedulerPath: timerPath, loadCommand, loadResult };
+  return {
+    platform: plat, shimPath, schedulerPath: timerPath, loadCommand, loadResult,
+    firstRunVerified: firstRun?.verified === true, firstRun,
+  };
 }
 
 /**

--- a/templates/bin/flair-federation-sync.sh.tmpl
+++ b/templates/bin/flair-federation-sync.sh.tmpl
@@ -25,4 +25,11 @@ if [ -n "${FLAIR_ADMIN_PASS_FILE:-}" ] && [ -f "${FLAIR_ADMIN_PASS_FILE}" ]; the
   set -- "$@" --admin-pass-file "${FLAIR_ADMIN_PASS_FILE}"
 fi
 
-exec "{{FLAIR_BIN}}" federation sync "$@"
+# Run the CLI under node rather than exec-ing it directly: `node <script>`
+# needs READ permission only, so the shim keeps working when a deploy method
+# (npm-pack tarball extraction) strips the exec bit from the script (#1231).
+# NODE_BIN is an ABSOLUTE path resolved at enable time — the shim performs
+# zero PATH lookups at run time, exactly like the old absolute-FLAIR_BIN
+# form. Do not replace it with a bare `node`: that would hand binary
+# selection to whatever PATH the service manager happens to carry.
+exec "{{NODE_BIN}}" "{{FLAIR_BIN}}" federation sync "$@"

--- a/templates/bin/flair-rem-nightly.sh.tmpl
+++ b/templates/bin/flair-rem-nightly.sh.tmpl
@@ -5,5 +5,12 @@
 #
 # Single line that invokes the CLI's run-once subcommand — the runner module
 # does all the work. Logs land in {{HOME}}/.flair/logs/.
+#
+# Run the CLI under node rather than exec-ing it directly: `node <script>`
+# needs READ permission only, so the shim keeps working when a deploy method
+# (npm-pack tarball extraction) strips the exec bit from the script (#1231).
+# NODE_BIN is an ABSOLUTE path resolved at enable time — the shim performs
+# zero PATH lookups at run time. Do not replace it with a bare `node`: that
+# would hand binary selection to whatever PATH the service manager carries.
 set -e
-exec {{FLAIR_BIN}} rem nightly run-once
+exec "{{NODE_BIN}}" "{{FLAIR_BIN}}" rem nightly run-once

--- a/test/rem-scheduler.test.ts
+++ b/test/rem-scheduler.test.ts
@@ -23,8 +23,10 @@ import {
   type EnableResult,
   type SchedulerStatus,
 } from "../src/rem/scheduler.ts";
+import { type FirstRunVerification } from "../src/lib/scheduler-platform.ts";
 
 let testRoot: string;
+let home: string;
 let shimPath: string;
 let plistPath: string;
 let timerPath: string;
@@ -33,6 +35,8 @@ let templateRoot: string;
 
 beforeEach(() => {
   testRoot = mkdtempSync(join(tmpdir(), "flair-rem-scheduler-test-"));
+  home = join(testRoot, "home");
+  mkdirSync(home, { recursive: true });
   shimPath = join(testRoot, "bin", "flair-rem-nightly");
   plistPath = join(testRoot, "LaunchAgents", "dev.flair.rem.nightly.plist");
   timerPath = join(testRoot, "systemd", "flair-rem-nightly.timer");
@@ -51,10 +55,16 @@ function baseOpts(overrides: Partial<EnableOpts> = {}): EnableOpts {
     hour: 3,
     minute: 0,
     flairBin: "/usr/local/bin/flair",
+    // Pinned so shim-content assertions are hermetic — no dependency on what
+    // resolveNodeBin() finds on the machine running the tests.
+    nodeBin: "/usr/local/bin/node",
     shimPathOverride: shimPath,
     launchdPlistOverride: plistPath,
     systemdTimerOverride: timerPath,
     systemdServiceOverride: servicePath,
+    // #1231: enable now mkdirs HOME/.flair/logs — keep it inside the temp
+    // tree, never the real home directory.
+    homeOverride: home,
     templateRootOverride: templateRoot,
     skipLoad: true,
     ...overrides,
@@ -63,6 +73,7 @@ function baseOpts(overrides: Partial<EnableOpts> = {}): EnableOpts {
 
 const sampleSubs: SchedulerSubstitutions = {
   FLAIR_BIN: "/usr/local/bin/flair",
+  NODE_BIN: "/usr/local/bin/node",
   SHIM_PATH: "/Users/test/.flair/bin/flair-rem-nightly",
   HOME: "/Users/test",
   AGENT_ID: "test-agent",
@@ -116,8 +127,24 @@ describe("enableScheduler (darwin)", () => {
     expect(plist).not.toContain("{{");
 
     const shim = readFileSync(shimPath, "utf-8");
-    expect(shim).toContain("/usr/local/bin/flair rem nightly run-once");
+    // #1231: run the CLI UNDER NODE (read permission suffices — survives
+    // npm-pack tarball extraction stripping the exec bit), with the node
+    // binary resolved to an ABSOLUTE path at enable time (no run-time PATH
+    // lookup). This replaces the old direct-exec pin.
+    expect(shim).toContain(`exec "/usr/local/bin/node" "/usr/local/bin/flair" rem nightly run-once`);
+    expect(shim).not.toContain("exec /usr/local/bin/flair");
+    expect(shim).not.toMatch(/exec\s+node\b/);
     expect(shim).toContain("#!/bin/sh");
+  });
+
+  it("creates HOME/.flair/logs with mode 0700 (#1231 — launchd spawn error 209 otherwise)", () => {
+    const logsDir = join(home, ".flair", "logs");
+    expect(existsSync(logsDir)).toBe(false);
+    enableScheduler(baseOpts({ platformOverride: "darwin" }));
+    expect(existsSync(logsDir)).toBe(true);
+    // 0700 is load-bearing: the REM nightly log carries distillation
+    // candidate CONTENT (memory text), not just counts.
+    expect(statSync(logsDir).mode & 0o777).toBe(0o700);
   });
 
   it("does not invoke launchctl when skipLoad=true", () => {
@@ -154,6 +181,14 @@ describe("enableScheduler (linux)", () => {
     const r = enableScheduler(baseOpts({ platformOverride: "linux", hour: 7, minute: 5 }));
     const timer = readFileSync(timerPath, "utf-8");
     expect(timer).toContain("OnCalendar=*-*-* 07:05:00");
+  });
+
+  it("creates HOME/.flair/logs with mode 0700 (#1231 — systemd append: targets need the directory)", () => {
+    const logsDir = join(home, ".flair", "logs");
+    expect(existsSync(logsDir)).toBe(false);
+    enableScheduler(baseOpts({ platformOverride: "linux" }));
+    expect(existsSync(logsDir)).toBe(true);
+    expect(statSync(logsDir).mode & 0o777).toBe(0o700);
   });
 });
 
@@ -353,6 +388,21 @@ describe("describeLoadFailure (flair#850 — remedy naming)", () => {
 
 describe("formatEnableReport (flair#850 — the core honesty fix)", () => {
   const reportInput = { hour: 3, minute: 0, agentId: "test-agent", flairUrl: "http://127.0.0.1:9926" };
+  const LOG_PATH = "/home/test/.flair/logs/rem-nightly.stderr.log";
+
+  function verifiedRun(over: Partial<FirstRunVerification> = {}): FirstRunVerification {
+    return {
+      verified: true,
+      outcome: "success",
+      exitCode: 0,
+      detail: "systemctl --user start flair-rem-nightly.service → ok",
+      logPath: LOG_PATH,
+      stderrTail: "",
+      logEmpty: false,
+      budgetMs: 12_000,
+      ...over,
+    };
+  }
 
   function baseEnableResult(overrides: Partial<EnableResult> = {}): EnableResult {
     return {
@@ -360,11 +410,13 @@ describe("formatEnableReport (flair#850 — the core honesty fix)", () => {
       shimPath: "/home/test/.flair/bin/flair-rem-nightly",
       schedulerPath: "/home/test/.config/systemd/user/flair-rem-nightly.timer",
       loadCommand: ["systemctl", "--user", "enable", "--now", "flair-rem-nightly.timer"],
+      firstRunVerified: true,
+      firstRun: verifiedRun(),
       ...overrides,
     };
   }
 
-  it("SUCCESS PATH: reports success when loadResult.code === 0", () => {
+  it("SUCCESS PATH: reports success when loadResult.code === 0 AND the first run was verified", () => {
     const r = baseEnableResult({ loadResult: { code: 0, stdout: "", stderr: "" } });
     const { lines, ok } = formatEnableReport(r, reportInput);
     expect(ok).toBe(true);
@@ -372,11 +424,16 @@ describe("formatEnableReport (flair#850 — the core honesty fix)", () => {
     expect(lines.join("\n")).not.toMatch(/NOT activated/);
   });
 
-  it("SUCCESS PATH: reports success when loadResult is absent (test-only skipLoad shape)", () => {
-    const r = baseEnableResult({ loadResult: undefined });
+  it("NO-CLAIM PATH (#1231): a loadResult-absent result WITHOUT firstRunVerified no longer reads as success", () => {
+    // Pre-#1231 this shape was treated as success ("the CLI never sets
+    // skipLoad"). That was one layer short: nothing about this result proves
+    // a run ever happened, so the headline is now withheld.
+    const r = baseEnableResult({ loadResult: undefined, firstRunVerified: false, firstRun: undefined });
     const { lines, ok } = formatEnableReport(r, reportInput);
-    expect(ok).toBe(true);
-    expect(lines.join("\n")).toContain("✅ REM nightly scheduler enabled");
+    const text = lines.join("\n");
+    expect(ok).toBe(false);
+    expect(text).not.toContain("✅ REM nightly scheduler enabled");
+    expect(text).toContain("never verified");
   });
 
   it("FAILURE PATH: does NOT print a success headline when loadResult.code !== 0", () => {
@@ -436,6 +493,89 @@ describe("formatEnableReport (flair#850 — the core honesty fix)", () => {
     expect(text).not.toContain("✅ REM nightly scheduler enabled");
     expect(text).toMatch(/NOT activated/);
     expect(text).toContain("Re-run the activation command above manually");
+  });
+
+  // ── #1231: activation succeeded, but the first RUN was not verified ──────
+  // The load command exiting 0 proves the service manager ACCEPTED the job,
+  // not that the job can run. The ✅ headline is additionally gated on
+  // firstRunVerified.
+
+  function failedRun(over: Partial<FirstRunVerification> = {}): FirstRunVerification {
+    return {
+      verified: false,
+      outcome: "run-failed",
+      exitCode: 126,
+      detail: "launchctl print gui/501/dev.flair.rem.nightly → last exit code = 126",
+      logPath: LOG_PATH,
+      stderrTail: "",
+      logEmpty: false,
+      budgetMs: 12_000,
+      ...over,
+    };
+  }
+
+  it("#1231: load ok + first run FAILED refuses the ✅ headline with exit status + remedy", () => {
+    const r = baseEnableResult({
+      loadResult: { code: 0, stdout: "", stderr: "" },
+      firstRunVerified: false,
+      firstRun: failedRun({ stderrTail: "Error: connect ECONNREFUSED 127.0.0.1:9926" }),
+    });
+    const { lines, ok } = formatEnableReport(r, reportInput);
+    const text = lines.join("\n");
+    expect(ok).toBe(false);
+    expect(text).not.toContain("✅ REM nightly scheduler enabled");
+    expect(text).toContain("first run FAILED");
+    expect(text).toContain("exit 126");
+    // Kern's addition: the stderr tail from the log file is part of the report.
+    expect(text).toContain("ECONNREFUSED");
+    expect(text).toContain(LOG_PATH);
+    // Remedy names THIS command.
+    expect(text).toContain("flair rem nightly enable");
+  });
+
+  it("#1231: an EMPTY log file after a failed run is itself reported as diagnostic", () => {
+    const r = baseEnableResult({
+      loadResult: { code: 0, stdout: "", stderr: "" },
+      firstRunVerified: false,
+      firstRun: failedRun({ exitCode: 209, logEmpty: true }),
+    });
+    const text = formatEnableReport(r, reportInput).lines.join("\n");
+    expect(text).toContain("EMPTY");
+    expect(text).toContain("died before writing");
+  });
+
+  it("#1231: timeout withholds the headline but says the run may still be going", () => {
+    const r = baseEnableResult({
+      loadResult: { code: 0, stdout: "", stderr: "" },
+      firstRunVerified: false,
+      firstRun: failedRun({ outcome: "timeout", exitCode: null }),
+    });
+    const { lines, ok } = formatEnableReport(r, reportInput);
+    const text = lines.join("\n");
+    expect(ok).toBe(false);
+    expect(text).not.toContain("✅ REM nightly scheduler enabled");
+    expect(text).toContain("did not complete within 12s");
+  });
+
+  it("#1231: service manager unreachable is its OWN state — remedy points at the manager, not the job", () => {
+    const r = baseEnableResult({
+      loadResult: { code: 0, stdout: "", stderr: "" },
+      firstRunVerified: false,
+      firstRun: failedRun({ outcome: "manager-unavailable", exitCode: null, detail: "launchctl could not be run" }),
+    });
+    const { lines, ok } = formatEnableReport(r, reportInput);
+    const text = lines.join("\n");
+    expect(ok).toBe(false);
+    expect(text).toContain("service manager is unreachable");
+    expect(text).toContain("cannot verify the first run");
+    expect(text).toContain("Fix the service manager");
+    expect(text).not.toContain("first run FAILED");
+  });
+
+  it("#1231: enableScheduler with skipLoad reports firstRunVerified=false — never manufactured", () => {
+    const r = enableScheduler(baseOpts({ platformOverride: "linux" }));
+    expect(r.firstRunVerified).toBe(false);
+    expect(r.firstRun).toBeUndefined();
   });
 });
 

--- a/test/unit/federation-scheduler.test.ts
+++ b/test/unit/federation-scheduler.test.ts
@@ -39,6 +39,7 @@ import {
   type SchedulerStatus,
   type DriverAssessmentInput,
 } from "../../src/federation/scheduler.ts";
+import { type FirstRunVerification } from "../../src/lib/scheduler-platform.ts";
 
 let testRoot: string;
 let home: string;
@@ -71,6 +72,9 @@ function baseOpts(overrides: Partial<EnableOpts> = {}): EnableOpts {
   return {
     intervalSeconds: 300,
     flairBin: "/usr/local/bin/flair",
+    // Pinned so shim-content assertions are hermetic — no dependency on what
+    // resolveNodeBin() finds on the machine running the tests.
+    nodeBin: "/usr/local/bin/node",
     shimPathOverride: shimPath,
     launchdPlistOverride: plistPath,
     systemdTimerOverride: timerPath,
@@ -84,6 +88,7 @@ function baseOpts(overrides: Partial<EnableOpts> = {}): EnableOpts {
 
 const sampleSubs: FederationSchedulerSubstitutions = {
   FLAIR_BIN: "/usr/local/bin/flair",
+  NODE_BIN: "/usr/local/bin/node",
   SHIM_PATH: "/Users/test/.flair/bin/flair-federation-sync",
   HOME: "/Users/test",
   INTERVAL_SECONDS: "300",
@@ -309,6 +314,39 @@ describe("enableScheduler validation", () => {
   });
 });
 
+// ─── the log directory (#1231 mechanism 1) ──────────────────────────────────
+// The unit files point stdout/stderr INTO ~/.flair/logs, and the service
+// manager does not create that directory — launchd kills the job with spawn
+// error 209. enable must create it.
+
+describe("enableScheduler — log directory (#1231)", () => {
+  for (const platformOverride of ["darwin", "linux"] as const) {
+    it(`${platformOverride}: creates HOME/.flair/logs with mode 0700`, () => {
+      const logsDir = join(home, ".flair", "logs");
+      expect(existsSync(logsDir)).toBe(false);
+      enableScheduler(baseOpts({ platformOverride }));
+      expect(existsSync(logsDir)).toBe(true);
+      // 0700 is load-bearing: the directory also receives REM's nightly log,
+      // which carries distillation candidate CONTENT (memory text).
+      expect(statSync(logsDir).mode & 0o777).toBe(0o700);
+    });
+  }
+
+  it("reports a failed log-dir creation as its own failure, naming the directory", () => {
+    // A FILE squatting on the logs path makes mkdir fail.
+    mkdirSync(join(home, ".flair"), { recursive: true });
+    writeFileSync(join(home, ".flair", "logs"), "not a directory\n");
+    expect(() => enableScheduler(baseOpts({ platformOverride: "darwin" }))).toThrow(/log directory/);
+    expect(() => enableScheduler(baseOpts({ platformOverride: "darwin" }))).toThrow(/federation sync enable/);
+  });
+
+  it("is idempotent when the directory already exists", () => {
+    enableScheduler(baseOpts({ platformOverride: "linux" }));
+    expect(() => enableScheduler(baseOpts({ platformOverride: "linux" }))).not.toThrow();
+    expect(existsSync(join(home, ".flair", "logs"))).toBe(true);
+  });
+});
+
 // ─── the shim ───────────────────────────────────────────────────────────────
 
 describe("shim", () => {
@@ -316,11 +354,26 @@ describe("shim", () => {
     enableScheduler(baseOpts({ platformOverride: "darwin", adminPassFile: passFile }));
     const shim = readFileSync(shimPath, "utf-8");
     expect(shim).toStartWith("#!/bin/sh");
-    expect(shim).toContain(`exec "/usr/local/bin/flair" federation sync`);
+    // #1231: run the CLI UNDER NODE (read permission suffices — survives
+    // npm-pack tarball extraction stripping the exec bit), with the node
+    // binary resolved to an ABSOLUTE path at enable time. This assertion
+    // replaces the old deliberate pin on `exec "/usr/local/bin/flair"`.
+    expect(shim).toContain(`exec "/usr/local/bin/node" "/usr/local/bin/flair" federation sync`);
     expect(shim).toContain("--admin-pass-file");
     // Never the value.
     expect(shim).not.toContain("PLACEHOLDER-not-a-real-password");
     expect(shim).not.toContain("{{");
+  });
+
+  it("never direct-execs FLAIR_BIN and never resolves node from PATH at run time", () => {
+    enableScheduler(baseOpts({ platformOverride: "darwin" }));
+    const shim = directives(readFileSync(shimPath, "utf-8"));
+    // The exec-bit dependency (#1231): a direct exec of the script requires
+    // +x, which tarball extraction strips.
+    expect(shim).not.toContain(`exec "/usr/local/bin/flair"`);
+    // Sherlock's finding on the fix: a bare `node` would introduce a run-time
+    // PATH lookup the old absolute-path form never had.
+    expect(shim).not.toMatch(/exec\s+node\b/);
   });
 
   it("is syntactically valid /bin/sh", () => {
@@ -554,6 +607,22 @@ describe("assessDriver — driver present vs absent vs present-but-peer-unreacha
 // ─── report formatting ──────────────────────────────────────────────────────
 
 describe("formatEnableReport (flair#850 — no success headline before activation succeeded)", () => {
+  const LOG_PATH = "/home/test/.flair/logs/federation-sync.stderr.log";
+
+  function verifiedRun(over: Partial<FirstRunVerification> = {}): FirstRunVerification {
+    return {
+      verified: true,
+      outcome: "success",
+      exitCode: 0,
+      detail: "systemctl --user start flair-federation-sync.service → ok",
+      logPath: LOG_PATH,
+      stderrTail: "",
+      logEmpty: false,
+      budgetMs: 12_000,
+      ...over,
+    };
+  }
+
   function result(over: Partial<EnableResult> = {}): EnableResult {
     return {
       platform: "linux",
@@ -561,14 +630,17 @@ describe("formatEnableReport (flair#850 — no success headline before activatio
       schedulerPath: "/home/test/.config/systemd/user/flair-federation-sync.timer",
       intervalSeconds: 300,
       loadCommand: ["systemctl", "--user", "enable", "--now", "flair-federation-sync.timer"],
+      firstRunVerified: true,
+      firstRun: verifiedRun(),
       ...over,
     };
   }
 
-  it("reports success when the load succeeded", () => {
+  it("reports success when the load succeeded AND the first run was verified", () => {
     const { lines, ok } = formatEnableReport(result({ loadResult: { code: 0, stdout: "", stderr: "" } }), {});
     expect(ok).toBe(true);
     expect(lines.join("\n")).toContain("✅ Federation sync driver enabled");
+    expect(lines.join("\n")).toContain("First run:");
   });
 
   it("does NOT print a success headline when activation failed", () => {
@@ -597,6 +669,114 @@ describe("formatEnableReport (flair#850 — no success headline before activatio
     const text = lines.join("\n");
     expect(text).toContain("/home/test/.flair/admin-pass");
     expect(text).toContain("path only");
+  });
+});
+
+describe("formatEnableReport (flair#1231 — no success headline before the FIRST RUN is verified)", () => {
+  const LOG_PATH = "/home/test/.flair/logs/federation-sync.stderr.log";
+
+  function firstRun(over: Partial<FirstRunVerification> = {}): FirstRunVerification {
+    return {
+      verified: false,
+      outcome: "run-failed",
+      exitCode: 1,
+      detail: "launchctl print gui/501/dev.flair.federation.sync → last exit code = 1",
+      logPath: LOG_PATH,
+      stderrTail: "",
+      logEmpty: false,
+      budgetMs: 12_000,
+      ...over,
+    };
+  }
+
+  function result(over: Partial<EnableResult> = {}): EnableResult {
+    return {
+      platform: "darwin",
+      shimPath: "/home/test/.flair/bin/flair-federation-sync",
+      schedulerPath: "/home/test/Library/LaunchAgents/dev.flair.federation.sync.plist",
+      intervalSeconds: 300,
+      loadCommand: ["launchctl", "bootstrap", "gui/501", "/home/test/Library/LaunchAgents/dev.flair.federation.sync.plist"],
+      loadResult: { code: 0, stdout: "", stderr: "" },
+      firstRunVerified: false,
+      firstRun: firstRun(),
+      ...over,
+    };
+  }
+
+  it("load ok + first run FAILED: refuses the ✅ headline and reports actor+state+remedy", () => {
+    const { lines, ok } = formatEnableReport(
+      result({
+        firstRun: firstRun({
+          exitCode: 126,
+          detail: "launchctl print gui/501/dev.flair.federation.sync → last exit code = 126",
+          stderrTail: "sh: /home/test/.flair/bin/flair-federation-sync: Permission denied",
+        }),
+      }),
+      {},
+    );
+    const text = lines.join("\n");
+    expect(ok).toBe(false);
+    expect(text).not.toMatch(/^✅/m);
+    // Actor + state: the DRIVER install worked, the RUN failed, with status.
+    expect(text).toContain("first run FAILED");
+    expect(text).toContain("exit 126");
+    expect(text).toContain("Nothing has synced");
+    // Diagnostics: the stderr tail from the log file.
+    expect(text).toContain("Permission denied");
+    expect(text).toContain(LOG_PATH);
+    // Remedy: re-run THIS command after fixing.
+    expect(text).toContain("flair federation sync enable");
+  });
+
+  it("an EMPTY log file after a failed run is itself reported as diagnostic", () => {
+    const { lines } = formatEnableReport(
+      result({ firstRun: firstRun({ exitCode: 209, stderrTail: "", logEmpty: true }) }),
+      {},
+    );
+    const text = lines.join("\n");
+    expect(text).toContain("EMPTY");
+    expect(text).toContain("died before writing");
+  });
+
+  it("timeout: withholds the headline but says the run may still be going", () => {
+    const { lines, ok } = formatEnableReport(
+      result({ firstRun: firstRun({ outcome: "timeout", exitCode: null, detail: "no completed run visible within 12s" }) }),
+      {},
+    );
+    const text = lines.join("\n");
+    expect(ok).toBe(false);
+    expect(text).not.toMatch(/^✅/m);
+    expect(text).toContain("did not complete within 12s");
+    expect(text).toMatch(/still be going/);
+  });
+
+  it("service manager unreachable is its OWN state — remedy points at the manager, not the sync job", () => {
+    const { lines, ok } = formatEnableReport(
+      result({ firstRun: firstRun({ outcome: "manager-unavailable", exitCode: null, detail: "launchctl could not be run" }) }),
+      {},
+    );
+    const text = lines.join("\n");
+    expect(ok).toBe(false);
+    expect(text).not.toMatch(/^✅/m);
+    expect(text).toContain("service manager is unreachable");
+    expect(text).toContain("cannot verify the first run");
+    expect(text).toContain("Fix the service manager");
+    // NOT the run-failed wording — nothing is known to have failed.
+    expect(text).not.toContain("first run FAILED");
+  });
+
+  it("a result with NO firstRun at all (load skipped / never attempted) still refuses the headline", () => {
+    const { lines, ok } = formatEnableReport(result({ loadResult: undefined, firstRunVerified: false, firstRun: undefined }), {});
+    const text = lines.join("\n");
+    expect(ok).toBe(false);
+    expect(text).not.toMatch(/^✅/m);
+    expect(text).toContain("never verified");
+  });
+
+  it("enableScheduler with skipLoad reports firstRunVerified=false — the claim is never manufactured", () => {
+    const r = enableScheduler(baseOpts({ platformOverride: "darwin" }));
+    expect(r.firstRunVerified).toBe(false);
+    expect(r.firstRun).toBeUndefined();
   });
 });
 

--- a/test/unit/launchd-plist-xml-escape.test.ts
+++ b/test/unit/launchd-plist-xml-escape.test.ts
@@ -308,6 +308,7 @@ describe("renderPlistTemplate — the rem nightly scheduler plist", () => {
   function subs(over: Record<string, string> = {}) {
     return {
       FLAIR_BIN: "/usr/local/bin/flair",
+      NODE_BIN: "/usr/local/bin/node",
       SHIM_PATH: "/Users/example/.flair/bin/flair-rem-nightly",
       HOME: "/Users/example",
       AGENT_ID: "test-agent",

--- a/test/unit/scheduler-first-run-verify.test.ts
+++ b/test/unit/scheduler-first-run-verify.test.ts
@@ -1,0 +1,303 @@
+/**
+ * scheduler-first-run-verify.test.ts — unit tests for the flair#1231
+ * primitives in src/lib/scheduler-platform.ts: first-run verification through
+ * the service manager, enable-time node resolution, and the parsers/helpers
+ * they stand on.
+ *
+ * SAFETY: every verifyFirstRun call injects `hooks.run` (and `hooks.sleep` /
+ * `hooks.now` where timing matters), so no test spawns a real launchctl or
+ * systemctl and none touches the user's service-manager domain. Log-file
+ * fixtures live in a fresh temp dir.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync, existsSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import {
+  resolveNodeBin,
+  verifyFirstRun,
+  parseLaunchdPrintExit,
+  parseSystemdShowExit,
+  readLogTail,
+  describeExitCode,
+  FIRST_RUN_POLL_INTERVAL_MS,
+  FIRST_RUN_BUDGET_MS,
+  type SpawnReport,
+} from "../../src/lib/scheduler-platform.ts";
+
+let testRoot: string;
+let logPath: string;
+
+beforeEach(() => {
+  testRoot = mkdtempSync(join(tmpdir(), "flair-first-run-verify-test-"));
+  logPath = join(testRoot, "job.stderr.log");
+});
+
+afterEach(() => {
+  rmSync(testRoot, { recursive: true, force: true });
+});
+
+/** Builds a run hook that replays canned responses per command name. */
+function cannedRun(responses: Array<{ match: (cmd: string[]) => boolean; reply: SpawnReport | (() => SpawnReport) }>) {
+  const calls: string[][] = [];
+  const run = (cmd: string[], _timeoutMs: number): SpawnReport => {
+    calls.push(cmd);
+    for (const r of responses) {
+      if (r.match(cmd)) return typeof r.reply === "function" ? r.reply() : r.reply;
+    }
+    throw new Error(`unexpected command in test: ${cmd.join(" ")}`);
+  };
+  return { run, calls };
+}
+
+const ok: SpawnReport = { code: 0, stdout: "", stderr: "" };
+const isKickstart = (c: string[]) => c[1] === "kickstart";
+const isPrint = (c: string[]) => c[1] === "print";
+const isStart = (c: string[]) => c[2] === "start";
+const isShow = (c: string[]) => c[2] === "show";
+
+const PRINT_RUNNING = "gui/501/dev.flair.test = {\n\tstate = running\n\tpid = 4242\n}\n";
+const PRINT_NEVER = "gui/501/dev.flair.test = {\n\tstate = not running\n\tlast exit code = (never exited)\n}\n";
+const printExited = (code: number) => `gui/501/dev.flair.test = {\n\tstate = not running\n\tlast exit code = ${code}\n}\n`;
+
+// ─── constants pinned to the spec (addendum: 100–200ms poll, 10–15s budget) ──
+
+describe("first-run verification constants", () => {
+  it("poll interval is 100–200ms and the budget is 10–15s", () => {
+    expect(FIRST_RUN_POLL_INTERVAL_MS).toBeGreaterThanOrEqual(100);
+    expect(FIRST_RUN_POLL_INTERVAL_MS).toBeLessThanOrEqual(200);
+    expect(FIRST_RUN_BUDGET_MS).toBeGreaterThanOrEqual(10_000);
+    expect(FIRST_RUN_BUDGET_MS).toBeLessThanOrEqual(15_000);
+  });
+});
+
+// ─── parsers ────────────────────────────────────────────────────────────────
+
+describe("parseLaunchdPrintExit", () => {
+  it("running job: pid/state present, no completed exit", () => {
+    expect(parseLaunchdPrintExit(PRINT_RUNNING)).toEqual({ running: true, lastExitCode: null });
+  });
+
+  it("never-exited job: not running, no numeric exit code yet", () => {
+    expect(parseLaunchdPrintExit(PRINT_NEVER)).toEqual({ running: false, lastExitCode: null });
+  });
+
+  it("completed job: reads the recorded exit code", () => {
+    expect(parseLaunchdPrintExit(printExited(0))).toEqual({ running: false, lastExitCode: 0 });
+    expect(parseLaunchdPrintExit(printExited(126))).toEqual({ running: false, lastExitCode: 126 });
+  });
+
+  it("accepts the 'last exit status' spelling too", () => {
+    expect(parseLaunchdPrintExit("state = not running\nlast exit status = 3\n").lastExitCode).toBe(3);
+  });
+});
+
+describe("parseSystemdShowExit", () => {
+  it("reads ExecMainStatus and Result", () => {
+    expect(parseSystemdShowExit("ExecMainStatus=1\nResult=exit-code\n")).toEqual({ execMainStatus: 1, result: "exit-code" });
+    expect(parseSystemdShowExit("ExecMainStatus=0\nResult=success\n")).toEqual({ execMainStatus: 0, result: "success" });
+  });
+
+  it("returns nulls on unparseable output rather than inventing a status", () => {
+    expect(parseSystemdShowExit("")).toEqual({ execMainStatus: null, result: null });
+  });
+});
+
+// ─── helpers ────────────────────────────────────────────────────────────────
+
+describe("readLogTail", () => {
+  it("distinguishes missing, empty and populated log files", () => {
+    expect(readLogTail(join(testRoot, "nope.log"))).toEqual({ exists: false, empty: false, tail: "" });
+    writeFileSync(logPath, "");
+    expect(readLogTail(logPath)).toEqual({ exists: true, empty: true, tail: "" });
+    writeFileSync(logPath, "line1\nline2\n");
+    expect(readLogTail(logPath)).toEqual({ exists: true, empty: false, tail: "line1\nline2" });
+  });
+
+  it("returns only the last N lines of a long log", () => {
+    writeFileSync(logPath, Array.from({ length: 50 }, (_, i) => `line${i}`).join("\n"));
+    const { tail } = readLogTail(logPath, 3);
+    expect(tail).toBe("line47\nline48\nline49");
+  });
+});
+
+describe("describeExitCode", () => {
+  it("names the known failure classes so reports lead with actor+state", () => {
+    expect(describeExitCode(126)).toContain("permission denied");
+    expect(describeExitCode(127)).toContain("command not found");
+    expect(describeExitCode(209)).toContain("log directory");
+    expect(describeExitCode(1)).toBe("exit 1");
+    expect(describeExitCode(null)).toContain("no exit status");
+  });
+});
+
+// ─── resolveNodeBin (#1231, Sherlock: no run-time PATH lookup in the shim) ──
+
+describe("resolveNodeBin", () => {
+  it("an explicit override wins untouched", () => {
+    expect(resolveNodeBin("/opt/node/bin/node")).toBe("/opt/node/bin/node");
+  });
+
+  it("resolves an ABSOLUTE existing path or fails loudly — never a bare name", () => {
+    let out: string;
+    try {
+      out = resolveNodeBin();
+    } catch (e: any) {
+      // A machine with no node anywhere: enable must fail loudly rather than
+      // bake a PATH lookup into the shim.
+      expect(String(e?.message)).toMatch(/absolute path to a node binary/);
+      return;
+    }
+    expect(out.startsWith("/")).toBe(true);
+    expect(existsSync(out)).toBe(true);
+  });
+});
+
+// ─── verifyFirstRun: darwin (kickstart + poll) ──────────────────────────────
+
+describe("verifyFirstRun (darwin)", () => {
+  const target = "gui/501/dev.flair.test";
+
+  it("polls launchctl print until a completed exit-0 run is visible → verified", () => {
+    let printCall = 0;
+    const { run, calls } = cannedRun([
+      { match: isKickstart, reply: ok },
+      {
+        match: isPrint,
+        reply: () => {
+          printCall++;
+          // First two polls: still running. Third: completed cleanly.
+          const body = printCall < 3 ? PRINT_RUNNING : printExited(0);
+          return { code: 0, stdout: body, stderr: "" };
+        },
+      },
+    ]);
+    const sleeps: number[] = [];
+    const r = verifyFirstRun({
+      plat: "darwin",
+      darwinTarget: target,
+      stderrLogPath: logPath,
+      hooks: { run, sleep: (ms) => sleeps.push(ms), now: Date.now },
+    });
+    expect(r.verified).toBe(true);
+    expect(r.outcome).toBe("success");
+    expect(r.exitCode).toBe(0);
+    // It genuinely polled (kickstart returns immediately — the exit status
+    // must be READ, not assumed), at the configured interval.
+    expect(calls.filter(isPrint).length).toBe(3);
+    expect(sleeps.every((ms) => ms === FIRST_RUN_POLL_INTERVAL_MS)).toBe(true);
+    expect(sleeps.length).toBe(2);
+  });
+
+  it("a nonzero recorded exit is run-failed and carries the stderr tail from the log", () => {
+    writeFileSync(logPath, "sh: permission denied\n");
+    const { run } = cannedRun([
+      { match: isKickstart, reply: ok },
+      { match: isPrint, reply: { code: 0, stdout: printExited(126), stderr: "" } },
+    ]);
+    const r = verifyFirstRun({ plat: "darwin", darwinTarget: target, stderrLogPath: logPath, hooks: { run } });
+    expect(r.verified).toBe(false);
+    expect(r.outcome).toBe("run-failed");
+    expect(r.exitCode).toBe(126);
+    expect(r.stderrTail).toContain("permission denied");
+  });
+
+  it("an empty log after a failed run is flagged as logEmpty (died before writing)", () => {
+    writeFileSync(logPath, "");
+    const { run } = cannedRun([
+      { match: isKickstart, reply: ok },
+      { match: isPrint, reply: { code: 0, stdout: printExited(209), stderr: "" } },
+    ]);
+    const r = verifyFirstRun({ plat: "darwin", darwinTarget: target, stderrLogPath: logPath, hooks: { run } });
+    expect(r.outcome).toBe("run-failed");
+    expect(r.logEmpty).toBe(true);
+    expect(r.stderrTail).toBe("");
+  });
+
+  it("no completed run inside the budget → timeout, NOT success and NOT failure", () => {
+    const { run } = cannedRun([
+      { match: isKickstart, reply: ok },
+      { match: isPrint, reply: { code: 0, stdout: PRINT_RUNNING, stderr: "" } },
+    ]);
+    // Fake clock: each now() call advances 5s, so the 12s budget lapses after
+    // a few polls without any real sleeping.
+    let t = 0;
+    const r = verifyFirstRun({
+      plat: "darwin",
+      darwinTarget: target,
+      stderrLogPath: logPath,
+      hooks: { run, sleep: () => {}, now: () => (t += 5_000) },
+    });
+    expect(r.verified).toBe(false);
+    expect(r.outcome).toBe("timeout");
+    expect(r.exitCode).toBeNull();
+  });
+
+  it("launchctl unspawnable → manager-unavailable (its own state, not run-failed)", () => {
+    const { run } = cannedRun([{ match: isKickstart, reply: { code: null, stdout: "", stderr: "" } }]);
+    const r = verifyFirstRun({ plat: "darwin", darwinTarget: target, stderrLogPath: logPath, hooks: { run } });
+    expect(r.verified).toBe(false);
+    expect(r.outcome).toBe("manager-unavailable");
+  });
+
+  it("kickstart rejected → start-failed with the command's own diagnostics", () => {
+    const { run } = cannedRun([
+      { match: isKickstart, reply: { code: 113, stdout: "", stderr: "Could not find service\n" } },
+    ]);
+    const r = verifyFirstRun({ plat: "darwin", darwinTarget: target, stderrLogPath: logPath, hooks: { run } });
+    expect(r.verified).toBe(false);
+    expect(r.outcome).toBe("start-failed");
+    expect(r.detail).toContain("Could not find service");
+  });
+});
+
+// ─── verifyFirstRun: linux (blocking start + single show read) ──────────────
+
+describe("verifyFirstRun (linux)", () => {
+  const unit = "flair-test.service";
+
+  it("blocking start exits 0 → verified, with the recorded status from show", () => {
+    const { run, calls } = cannedRun([
+      { match: isStart, reply: ok },
+      { match: isShow, reply: { code: 0, stdout: "ExecMainStatus=0\nResult=success\n", stderr: "" } },
+    ]);
+    const r = verifyFirstRun({ plat: "linux", linuxServiceUnit: unit, stderrLogPath: logPath, hooks: { run } });
+    expect(r.verified).toBe(true);
+    expect(r.outcome).toBe("success");
+    expect(r.exitCode).toBe(0);
+    // Single show read after the blocking start — no polling on linux.
+    expect(calls.filter(isShow).length).toBe(1);
+  });
+
+  it("start fails → run-failed with ExecMainStatus as the exit code", () => {
+    writeFileSync(logPath, "Error: something broke\n");
+    const { run } = cannedRun([
+      { match: isStart, reply: { code: 1, stdout: "", stderr: "Job for flair-test.service failed.\n" } },
+      { match: isShow, reply: { code: 0, stdout: "ExecMainStatus=126\nResult=exit-code\n", stderr: "" } },
+    ]);
+    const r = verifyFirstRun({ plat: "linux", linuxServiceUnit: unit, stderrLogPath: logPath, hooks: { run } });
+    expect(r.verified).toBe(false);
+    expect(r.outcome).toBe("run-failed");
+    expect(r.exitCode).toBe(126);
+    expect(r.stderrTail).toContain("something broke");
+  });
+
+  it("no session bus → manager-unavailable, never run-failed", () => {
+    const { run } = cannedRun([
+      { match: isStart, reply: { code: 1, stdout: "", stderr: "Failed to connect to bus: No medium found\n" } },
+    ]);
+    const r = verifyFirstRun({ plat: "linux", linuxServiceUnit: unit, stderrLogPath: logPath, hooks: { run } });
+    expect(r.verified).toBe(false);
+    expect(r.outcome).toBe("manager-unavailable");
+  });
+
+  it("start killed by its timeout (null code) → timeout — the run may still be going", () => {
+    const { run } = cannedRun([
+      { match: isStart, reply: { code: null, stdout: "", stderr: "partial\n" } },
+    ]);
+    const r = verifyFirstRun({ plat: "linux", linuxServiceUnit: unit, stderrLogPath: logPath, hooks: { run } });
+    expect(r.verified).toBe(false);
+    expect(r.outcome).toBe("timeout");
+  });
+});


### PR DESCRIPTION
Closes #1231

## Problem

Both scheduler enables (`flair federation sync enable`, `flair rem nightly enable`) could print the ✅ success headline while the first real run was already dead. The load command exiting 0 proves the service manager **accepted** the job — not that the job can **run**. Two shipped mechanisms produced exactly that silent failure:

1. **Exec-bit dependency**: the shims did `exec "{{FLAIR_BIN}}" …`, which requires `+x` on the CLI script. `npm pack` tarball extraction normalizes non-bin files to non-executable, so any deploy that extracts a tarball without lifecycle scripts strips the bit and every run dies with exit 126 (regression since the defensive postinstall chmod was removed in v0.37.0).
2. **Missing log directory**: the launchd plists and systemd units point stdout/stderr at `~/.flair/logs/…`, and nothing ever created that directory — launchd kills the job with spawn error 209.

## Fix (per the approved spec on #1231, including both review addenda)

- **Shims run the CLI under node** — `exec "{{NODE_BIN}}" "{{FLAIR_BIN}}" …`. `node <script>` needs read permission only, so the shim survives any extraction method. Per the security review: `NODE_BIN` is resolved to an **absolute path at enable time** (`process.execPath` when the enabling runtime is node, else `command -v node`, else enable fails loudly) and baked into the shim — zero PATH lookups at run time, matching the old absolute-`FLAIR_BIN` trust model.
- **Both `enableScheduler`s create `~/.flair/logs` mode 0700** before writing unit files. The mode is load-bearing, not cosmetic (documented at both call sites): the REM nightly log carries distillation *candidate content* — actual memory text, not just counts. A failed creation is its own actor+state+remedy error.
- **First-run verification through the service manager** (`verifyFirstRun()` in `src/lib/scheduler-platform.ts`) — the only vantage that exercises both failure modes; a bare spawn of the shim would reproduce neither. Ordering gate: only attempted after the load/bootstrap exits 0.
  - darwin: `launchctl kickstart -k` returns immediately, so the recorded exit status is **polled** out of `launchctl print` (150ms interval, 12s budget).
  - linux: `systemctl --user start` on the oneshot **blocks**, then a single `systemctl --user show --property=ExecMainStatus,Result` read.
  - "Service manager unreachable" is its own distinct outcome ("cannot verify"), as is timeout ("the run may still be going") — neither is reported as success or conflated with a failed run.
- **`EnableResult.firstRunVerified`** + detail; **`formatEnableReport` refuses the ✅ headline without it**. Failure reports carry the recorded exit status (126/127/209 named), a stderr tail from the job's log, and the empty-log-file diagnostic (the run died before writing anything).

## Tests

- Deliberate shim-pin assertion updated to the `exec node` form, plus a guard that the shim never direct-execs the script and never resolves `node` from PATH at run time.
- Log-dir creation (existence + 0700) asserted for both platforms in both scheduler test files; failed-creation error asserted.
- `formatEnableReport` `firstRunVerified: false` cases in both files: run-failed (exit status + stderr tail + remedy), timeout, manager-unavailable (remedy points at the manager), empty-log diagnostic, and the never-verified shape. The old "loadResult absent ⇒ success" REM case is deliberately inverted.
- New `test/unit/scheduler-first-run-verify.test.ts` covers `verifyFirstRun` (hermetic, injected process/clock hooks), both parsers, `resolveNodeBin`, `readLogTail`, and pins the poll/budget constants to the specced ranges.

Unit lane: **4635 pass / 0 fail** (self-measured baseline on unmodified main: 4595 / 0 — the +40 are all from this change). Every new behavior was mutation-checked: reverting each fix (shim exec form ×2, mkdir ×2, 0700→0755 ×2, report gate ×2, success-on-any-exit, bus detection, hardcoded `firstRunVerified`) turns the suite red; restoring turns it green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
