### PR TITLE
continuity slice 2: Claude Code hook adapter — ephemeral session journal with agent-pull resume

### DIFF
--- a/.changelog/unreleased/added-1257-continuity-hook-adapter.md
+++ b/.changelog/unreleased/added-1257-continuity-hook-adapter.md
@@ -1,0 +1,15 @@
+- **Continuity slice 2: Claude Code hook adapter — ephemeral session journal
+  with agent-pull resume.** New `flair-continuity-capture` binary
+  (@tpsdev-ai/flair-mcp) journals working state on PostToolUse/Stop as
+  ephemeral+private memories tagged `adk:continuity:<sessionId>`, under a
+  strict capture discipline: mutating tools only (Write/Edit/NotebookEdit/
+  Bash), Bash description-only (never the command string), file paths only
+  (never content/diffs), Stop as a hard 400-char excerpt of assistant-chosen
+  prose, malformed hook JSON journals nothing. `flair-session-start` grows the
+  resume path: pointer-file fast path with an agentId-wide fallback
+  disambiguated by processUUID, expired rows excluded, at most one boot hint
+  line and never journal content. Fail-open throughout — Flair down or a
+  guard refusal never blocks the turn or boot; compaction never rotates the
+  session. Opt-in by installation: `flair hook install --continuity` /
+  `flair doctor --fix`; doctor reports installed / not-enabled / stale-form,
+  with a symmetric removal path. (flair#1257)

--- a/packages/flair-mcp/package.json
+++ b/packages/flair-mcp/package.json
@@ -6,7 +6,8 @@
   "main": "dist/index.js",
   "bin": {
     "flair-mcp": "dist/mcp-shim.cjs",
-    "flair-session-start": "dist/session-start-hook.js"
+    "flair-session-start": "dist/session-start-hook.js",
+    "flair-continuity-capture": "dist/continuity-capture-hook.js"
   },
   "files": [
     "dist/",
@@ -17,7 +18,7 @@
     "build": "tsc --noCheck",
     "test": "bun test",
     "prepublishOnly": "npm run build",
-    "postinstall": "node -e \"try{const{chmodSync,statSync}=require('fs');for(const p of ['dist/mcp-shim.cjs','dist/index.js','dist/session-start-hook.js']){try{if(statSync(p).isFile()){chmodSync(p,0o755);console.error('@tpsdev-ai/flair-mcp: chmod +x ' + p + ' OK')}}catch(e){if(e.code!=='ENOENT')console.error('postinstall warn:',e.message)}}}catch(e){console.error('postinstall warn:',e.message)}\""
+    "postinstall": "node -e \"try{const{chmodSync,statSync}=require('fs');for(const p of ['dist/mcp-shim.cjs','dist/index.js','dist/session-start-hook.js','dist/continuity-capture-hook.js']){try{if(statSync(p).isFile()){chmodSync(p,0o755);console.error('@tpsdev-ai/flair-mcp: chmod +x ' + p + ' OK')}}catch(e){if(e.code!=='ENOENT')console.error('postinstall warn:',e.message)}}}catch(e){console.error('postinstall warn:',e.message)}\""
   },
   "publishConfig": {
     "access": "public"

--- a/packages/flair-mcp/src/continuity-capture-hook.ts
+++ b/packages/flair-mcp/src/continuity-capture-hook.ts
@@ -104,18 +104,35 @@ export interface CaptureOutcome {
     | "write-failed";
 }
 
+/** Local STRUCTURAL type for the one client surface this factory touches —
+ *  declared here, not imported, so the type never depends on flair-client's
+ *  emitted declarations existing. The real FlairClient satisfies it (its
+ *  constructor takes a config superset; its instances carry request()). */
+interface FlairClientConstructor {
+  new (config: { agentId: string; url?: string; keyPath?: string }): ContinuityClient;
+}
+
 /** LAZY on purpose: @tpsdev-ai/flair-client resolves via its BUILT dist/, and
- *  this module must stay importable in module graphs that load before that
- *  build exists (the root `bun test test/unit/` CI lane — see the ordering
- *  note in test/unit/hook-install.test.ts). Tests always inject makeClient,
- *  so only the real binary ever takes this path. */
+ *  this module must both LOAD and TYPECHECK without that dist present — the
+ *  root `bun test test/unit/` lane AND the strict test-suite typecheck lane
+ *  each run before the client is built (see the ordering note in
+ *  test/unit/hook-install.test.ts). Tests always inject makeClient, so only
+ *  the real binary ever takes this path; the real module boundary is
+ *  exercised by the package-lane tests, which build the client first.
+ *
+ *  `@ts-ignore`, deliberately NOT `@ts-expect-error`: with the dist built the
+ *  import DOES resolve, and an expect-error directive would then itself be
+ *  the error. ts-ignore is inert in that state — verified locally in BOTH
+ *  states (dist present and dist deleted). */
 async function defaultClientFactory(agentId: string): Promise<ContinuityClient> {
-  const { FlairClient } = await import("@tpsdev-ai/flair-client");
+  // @ts-ignore -- resolvable only once flair-client's dist is built; see doc above
+  const mod = await import("@tpsdev-ai/flair-client");
+  const FlairClient = mod.FlairClient as unknown as FlairClientConstructor;
   return new FlairClient({
     agentId,
     url: readEnvOrUnset("FLAIR_URL"),
     keyPath: readEnvOrUnset("FLAIR_KEY_PATH"),
-  }) as unknown as ContinuityClient;
+  });
 }
 
 /**

--- a/packages/flair-mcp/src/continuity-capture-hook.ts
+++ b/packages/flair-mcp/src/continuity-capture-hook.ts
@@ -1,0 +1,202 @@
+#!/usr/bin/env node
+
+/**
+ * Flair continuity-capture hook for Claude Code (flair#1257 slice 2) — the
+ * PostToolUse/Stop hook target that auto-journals the agent's working state
+ * into the ephemeral Memory tier, so an unseen kill/crash/OOM never loses the
+ * cadence. Registered (opt-in) via `flair doctor --fix` / `flair hook install
+ * --continuity`; the resume side lives in ./session-start-hook.ts.
+ *
+ * WHAT IT WRITES — see ./continuity.ts's module doc for the full, binding
+ * capture discipline. In one breath: at most ONE ephemeral+private row per
+ * fire; mutating tools only; Bash description-only (NEVER the command);
+ * Write/Edit/NotebookEdit path-only; Stop = a hard-bounded excerpt of
+ * assistant-chosen prose; never the raw hook JSON, never tool results, never
+ * an attempt at secret-scrubbing (the bound is the control).
+ *
+ * NO-OP-ON-ANY-FAILURE GUARANTEE (same posture as session-start-hook.ts):
+ * this binary can never block or break the agent's turn. Malformed stdin,
+ * missing identity, missing state file, Flair unreachable, a #1261 guard 400,
+ * a timeout, an unexpected throw — every one degrades to "journal nothing",
+ * at most one debug-level stderr line (the installed command discards
+ * stderr), and exit 0. Malformed hook JSON in particular journals NOTHING —
+ * no partial extraction that might pull raw tool results into the journal
+ * (Sherlock's input-validation tightening).
+ *
+ * A hard timeout (FLAIR_CONTINUITY_TIMEOUT_MS, default 2s) bounds the journal
+ * write so a slow Flair can't make the agent wait on its own diary.
+ *
+ * CONFIG (env, read identically to the other hook binaries):
+ *   FLAIR_AGENT_ID   (required — absent → no-op)
+ *   FLAIR_URL        (default http://localhost:19926 via flair-client)
+ *   FLAIR_KEY_PATH   (default ~/.flair/keys/<agent>.key via flair-client)
+ *   FLAIR_CONTINUITY_TIMEOUT_MS (default 2000; clamped 250..10000)
+ *   FLAIR_SESSION_DIR (default ~/.flair/session — test override)
+ *   FLAIR_HOOK_PROBE (probe mode: exit immediately, no stdin read, no writes)
+ */
+
+import { isProbeMode, readEnvOrUnset, stripInterpolationLiteralsFromEnv } from "./env-guard.js";
+import {
+  buildJournalRow,
+  bumpSeq,
+  isSafeFileId,
+  planCapture,
+  resolveContinuityTimeoutMs,
+  resolveSessionDir,
+  type CaptureHookInput,
+  type ContinuityClient,
+} from "./continuity.js";
+
+/** Read all of stdin. Resolves on EOF, with a short fallback for manual runs
+ *  where nothing is piped (so it never hangs). */
+function readStdin(): Promise<string> {
+  return new Promise((resolve) => {
+    let data = "";
+    process.stdin.setEncoding("utf8");
+    process.stdin.on("data", (chunk) => (data += chunk));
+    process.stdin.on("end", () => resolve(data));
+    process.stdin.on("error", () => resolve(data));
+    setTimeout(() => resolve(data), 200).unref?.();
+  });
+}
+
+function withTimeout<T>(promise: Promise<T>, ms: number): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error("continuity_write_timeout")), ms);
+    timer.unref?.();
+    promise.then(
+      (value) => {
+        clearTimeout(timer);
+        resolve(value);
+      },
+      (err) => {
+        clearTimeout(timer);
+        reject(err);
+      },
+    );
+  });
+}
+
+/** Injectable dependencies so the whole flow is unit-testable without a live
+ *  Flair daemon or a real ~/.flair (homeOverride discipline). */
+export interface CaptureDeps {
+  makeClient?: (agentId: string) => ContinuityClient | Promise<ContinuityClient>;
+  sessionDir?: string;
+  env?: Record<string, string | undefined>;
+  now?: () => Date;
+  /** Debug-level warn sink (default: one stderr line). Never stdout. */
+  warn?: (message: string) => void;
+}
+
+export interface CaptureOutcome {
+  /** True only when a journal row was accepted by Flair. */
+  wrote: boolean;
+  /** Why nothing was written (or "written"). Diagnostic only — the process
+   *  exit code is 0 regardless (fail-open). */
+  reason:
+    | "written"
+    | "probe"
+    | "malformed-input"
+    | "not-capturable"
+    | "no-agent-id"
+    | "bad-session-id"
+    | "no-state"
+    | "write-failed";
+}
+
+/** LAZY on purpose: @tpsdev-ai/flair-client resolves via its BUILT dist/, and
+ *  this module must stay importable in module graphs that load before that
+ *  build exists (the root `bun test test/unit/` CI lane — see the ordering
+ *  note in test/unit/hook-install.test.ts). Tests always inject makeClient,
+ *  so only the real binary ever takes this path. */
+async function defaultClientFactory(agentId: string): Promise<ContinuityClient> {
+  const { FlairClient } = await import("@tpsdev-ai/flair-client");
+  return new FlairClient({
+    agentId,
+    url: readEnvOrUnset("FLAIR_URL"),
+    keyPath: readEnvOrUnset("FLAIR_KEY_PATH"),
+  }) as unknown as ContinuityClient;
+}
+
+/**
+ * Core capture flow. NEVER throws; never writes to stdout. Returns a
+ * diagnostic outcome for tests — the binary ignores it and exits 0.
+ */
+export async function runCapture(rawInput: string, deps: CaptureDeps = {}): Promise<CaptureOutcome> {
+  const env = deps.env ?? process.env;
+  const warn = deps.warn ?? ((message: string) => console.error(`flair-continuity-capture: ${message}`));
+  const now = deps.now ?? (() => new Date());
+
+  // Malformed / non-object hook JSON ⇒ journal NOTHING (Sherlock: no partial
+  // extraction — a half-parsed payload must never leak fields into a row).
+  let input: CaptureHookInput;
+  try {
+    const parsed: unknown = JSON.parse(rawInput);
+    if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
+      return { wrote: false, reason: "malformed-input" };
+    }
+    input = parsed as CaptureHookInput;
+  } catch {
+    return { wrote: false, reason: "malformed-input" };
+  }
+
+  // Pure capture decision first — a read-only tool or an empty Stop exits
+  // before touching the filesystem or minting a seq.
+  const plan = planCapture(input);
+  if (!plan) return { wrote: false, reason: "not-capturable" };
+
+  const agentId = env.FLAIR_AGENT_ID;
+  if (typeof agentId !== "string" || agentId === "" || !isSafeFileId(agentId)) {
+    return { wrote: false, reason: "no-agent-id" };
+  }
+  const harnessSessionId = input.session_id;
+  if (!isSafeFileId(harnessSessionId)) return { wrote: false, reason: "bad-session-id" };
+
+  // Per-process state, seeded by the SessionStart hook. Missing/unreadable ⇒
+  // continuity was never seeded for this harness session ⇒ journal nothing.
+  const sessionDir = deps.sessionDir ?? resolveSessionDir(env);
+  const state = bumpSeq(sessionDir, agentId, harnessSessionId, now());
+  if (!state) return { wrote: false, reason: "no-state" };
+
+  const row = buildJournalRow(agentId, state, plan, now());
+  const makeClient = deps.makeClient ?? defaultClientFactory;
+  try {
+    const client = await makeClient(agentId);
+    await withTimeout(Promise.resolve(client.request("PUT", `/Memory/${row.id}`, row)), resolveContinuityTimeoutMs(env));
+    return { wrote: true, reason: "written" };
+  } catch (err: unknown) {
+    // Fail-open: Flair unreachable, timeout, or the #1261 guard's 400 — one
+    // debug-level line, no retry, never a non-zero exit. The agent's turn is
+    // never blocked by its own journal.
+    const detail = err instanceof Error ? err.message : String(err);
+    warn(`journal write skipped (${detail.slice(0, 200)})`);
+    return { wrote: false, reason: "write-failed" };
+  }
+}
+
+/** Entry point. Reads stdin, captures, exits 0. Prints NOTHING to stdout —
+ *  a PostToolUse/Stop hook's stdout is harness-interpreted surface, and this
+ *  hook has nothing to say to it. */
+async function main(): Promise<void> {
+  // Probe mode (flair#1007 pattern): being reached is the whole answer.
+  // Exits BEFORE reading stdin and before any filesystem or network touch —
+  // a probe must cost nothing and change nothing (especially no seq burn).
+  if (isProbeMode()) return;
+  try {
+    stripInterpolationLiteralsFromEnv();
+    await runCapture(await readStdin());
+  } catch {
+    // Swallow everything — fail-open is the contract.
+  }
+}
+
+const importMeta = import.meta as ImportMeta & { main?: boolean };
+const isMain =
+  importMeta.main === true ||
+  (typeof process !== "undefined" &&
+    process.argv[1] != null &&
+    import.meta.url === `file://${process.argv[1]}`);
+
+if (isMain) {
+  void main().catch(() => {});
+}

--- a/packages/flair-mcp/src/continuity.ts
+++ b/packages/flair-mcp/src/continuity.ts
@@ -1,0 +1,625 @@
+/**
+ * Continuity core (flair#1257 slice 2) — the shared logic behind the Claude
+ * Code continuity hook adapter: the ephemeral session journal (write side,
+ * `flair-continuity-capture`) and the agent-pull resume path grown into
+ * `flair-session-start`.
+ *
+ * Design record: flair#1257 ("FINAL design (K&S ruled)" + the merged slice-2
+ * acceptance scenarios + Sherlock's capture-content rulings). The shape in one
+ * paragraph: continuity is the EXISTING `ephemeral` Memory tier (24h TTL,
+ * private-only — the #1261 server guard refuses ephemeral+shared), auto-written
+ * by harness hooks (PostToolUse/Stop), and resumed by agent-pull: SessionStart
+ * emits at most ONE hint line ("N entries from your previous session…"), never
+ * journal content. Promotion to durable memory is REM distillation's job
+ * (#1205, slice 3) — nothing here summarizes or promotes.
+ *
+ * CAPTURE DISCIPLINE (Sherlock-ruled, binding — do not drift)
+ * -----------------------------------------------------------
+ * - PostToolUse journals ONLY the mutating-tool allowlist (MUTATING_TOOLS
+ *   below). Read-only tools journal nothing — their results are
+ *   world-recoverable, and journaling them would copy tool payloads into a
+ *   store with cross-session readback.
+ * - Bash: journal the `description` field ONLY — NEVER the command string.
+ *   Argv is exactly where secrets ride; a journal that copies command lines
+ *   re-creates the transcript-leak class. No description ⇒ the literal
+ *   "bash: (no description)", never a fallback to the command.
+ * - Write/Edit/NotebookEdit: file path only — never content, never diffs.
+ * - Stop: a dedicated summary/intent field from the hook payload when present,
+ *   else the final assistant text — either way HARD-bounded (see
+ *   CAPTURE_BOUND_CHARS). Empty text ⇒ no journal (never a placeholder, never
+ *   a synthesis from tool results).
+ * - One row max per hook fire. Never the raw hook JSON. Never tool_response.
+ *   No secret-scrubbing attempts — the bound plus the already-user-visible
+ *   property of assistant prose IS the control; pattern-matching secrets is a
+ *   losing game and would only add false confidence.
+ *
+ * ROW SHAPE (per the merged acceptance set)
+ * -----------------------------------------
+ *   durability: "ephemeral", visibility: "private" (EXPLICIT — defense in
+ *   depth above the #1261 guard, never the durability-keyed default),
+ *   tags: ["adk:continuity:<sessionId>"], sessionId, and
+ *   meta: { seq, processUUID, sessionId, hook, tool? } — seq is a monotonic
+ *   per-process counter (ordering insurance over createdAt alone), processUUID
+ *   disambiguates concurrent processes sharing one agent identity.
+ *
+ * LOCAL FILES (never journal content — IDs and counters only)
+ * -----------------------------------------------------------
+ * - Pointer file  <dir>/<agentId>.current            (0600, dir 0700)
+ *     { sessionId, processUUID, updatedAt } — the last-known session for this
+ *     agent identity; the resume fast path. Rotated by SessionStart.
+ * - State file    <dir>/<agentId>.<harnessSessionId>.state.json (0600)
+ *     { sessionId, processUUID, seq, … } — seeded by SessionStart, read and
+ *     seq-incremented (atomically, tmp+rename) by every capture fire. Keyed by
+ *     the HARNESS session id so concurrent processes never share a state file
+ *     (scenario S8) and compaction — same harness session id — finds the same
+ *     file untouched (scenario S7: compaction ≠ restart; no rotation, no new
+ *     sessionId).
+ *
+ * FAIL-OPEN THROUGHOUT: continuity is a recovery aid, not a correctness gate.
+ * Flair unreachable, a #1261 guard 400, a malformed payload, a missing state
+ * file — every failure degrades to "journal nothing / hint nothing" and never
+ * blocks the agent's turn or boot.
+ */
+
+import { chmodSync, mkdirSync, readFileSync, renameSync, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { randomUUID } from "node:crypto";
+
+// ── constants ───────────────────────────────────────────────────────────────
+
+/** Tag prefix for journal rows — `adk:continuity:<sessionId>`. One tag, which
+ *  is exactly the shape #1205's REM `scope:"tagged"` distillation consumes. */
+export const CONTINUITY_TAG_PREFIX = "adk:continuity:";
+
+/**
+ * THE capture bound, in characters — applied as a HARD truncate (with a
+ * visible ellipsis) to EVERY journal content line, not just the Stop excerpt.
+ * Sherlock ruled a single uniform bound ("a bound that varies by content type
+ * is hard to audit — 400 chars, hard truncate, every time").
+ *
+ * This bound is LOAD-BEARING, not cosmetic: it is what keeps a Stop excerpt a
+ * summary instead of a dump, and it is the control that makes the capture
+ * class acceptable at all. Raising it — or "capturing the full final text" —
+ * is a security REGRESSION, not an enhancement.
+ */
+export const CAPTURE_BOUND_CHARS = 400;
+
+/**
+ * The mutating-tool allowlist — a CLOSED set; anything not listed journals
+ * nothing (fail-closed). Why each member is here and the notable exclusions:
+ * Write/Edit/NotebookEdit mutate file/cell state (NotebookEdit is included
+ * precisely because a cell edit is a state mutation, not a read); Bash can
+ * mutate anything. Read/Grep/Glob/WebFetch/WebSearch and every other
+ * read-only tool are EXCLUDED because their results are world-recoverable —
+ * the agent can simply re-observe them, and journaling them would copy tool
+ * payloads into the journal.
+ */
+export const MUTATING_TOOLS = ["Write", "Edit", "NotebookEdit", "Bash"] as const;
+export type MutatingTool = (typeof MUTATING_TOOLS)[number];
+
+/** Default resume-search page — older context is distillation's job (#1205). */
+export const RESUME_SEARCH_LIMIT = 50;
+
+/** Fallback (agentId-wide) search page — bounded superset of one session. */
+export const FALLBACK_SEARCH_LIMIT = 200;
+
+/** Journal-write timeout (ms): the hook must never make the agent wait on a
+ *  slow Flair. Overridable via FLAIR_CONTINUITY_TIMEOUT_MS, clamped below. */
+export const DEFAULT_CONTINUITY_TIMEOUT_MS = 2000;
+const CONTINUITY_TIMEOUT_FLOOR_MS = 250;
+const CONTINUITY_TIMEOUT_CEILING_MS = 10_000;
+
+/** Identifier shape for everything interpolated into a session-dir FILENAME
+ *  (agentId, harness session id). No `/`, no `\`, no whitespace — traversal
+ *  is impossible by shape; length-capped so a hostile hook payload can't
+ *  manufacture pathological filenames. */
+const SAFE_FILE_ID_RE = /^[A-Za-z0-9._-]{1,128}$/;
+
+export function isSafeFileId(value: unknown): value is string {
+  return typeof value === "string" && SAFE_FILE_ID_RE.test(value);
+}
+
+export function resolveContinuityTimeoutMs(env: Record<string, string | undefined> = process.env): number {
+  const raw = env.FLAIR_CONTINUITY_TIMEOUT_MS;
+  const parsed = raw != null ? Number(raw) : NaN;
+  return Number.isFinite(parsed) && parsed >= CONTINUITY_TIMEOUT_FLOOR_MS && parsed <= CONTINUITY_TIMEOUT_CEILING_MS
+    ? parsed
+    : DEFAULT_CONTINUITY_TIMEOUT_MS;
+}
+
+// ── session dir / pointer / state files ─────────────────────────────────────
+
+/** Where pointer + state files live. FLAIR_SESSION_DIR overrides for tests
+ *  (homeOverride discipline — no test ever touches the real ~/.flair). */
+export function resolveSessionDir(env: Record<string, string | undefined> = process.env): string {
+  const override = env.FLAIR_SESSION_DIR;
+  if (typeof override === "string" && override.trim() !== "") return override;
+  return join(homedir(), ".flair", "session");
+}
+
+export function pointerPath(sessionDir: string, agentId: string): string {
+  return join(sessionDir, `${agentId}.current`);
+}
+
+export function statePath(sessionDir: string, agentId: string, harnessSessionId: string): string {
+  return join(sessionDir, `${agentId}.${harnessSessionId}.state.json`);
+}
+
+export interface SessionPointer {
+  sessionId: string;
+  processUUID: string;
+  updatedAt: string;
+}
+
+export interface SessionState {
+  sessionId: string;
+  processUUID: string;
+  seq: number;
+  agentId: string;
+  harnessSessionId: string;
+  updatedAt: string;
+}
+
+/** 0600/0700 — the files carry session identifiers (never journal content),
+ *  but they are still per-agent working state; keep them owner-only. */
+function writeFilePrivate(path: string, data: string): void {
+  writeFileSync(path, data, { mode: 0o600 });
+  // writeFileSync's mode only applies on CREATE — an existing file keeps its
+  // old bits, so re-assert.
+  chmodSync(path, 0o600);
+}
+
+function ensureSessionDir(sessionDir: string): void {
+  mkdirSync(sessionDir, { recursive: true, mode: 0o700 });
+}
+
+/** Read + parse the pointer file. null on ANY problem (missing, unreadable,
+ *  malformed, wrong shape) — a bad pointer degrades to the fallback search,
+ *  never to an error. */
+export function readPointer(sessionDir: string, agentId: string): SessionPointer | null {
+  try {
+    const raw = readFileSync(pointerPath(sessionDir, agentId), "utf-8");
+    const parsed = JSON.parse(raw) as Partial<SessionPointer> | null;
+    if (parsed && typeof parsed.sessionId === "string" && parsed.sessionId !== "") {
+      return {
+        sessionId: parsed.sessionId,
+        processUUID: typeof parsed.processUUID === "string" ? parsed.processUUID : "",
+        updatedAt: typeof parsed.updatedAt === "string" ? parsed.updatedAt : "",
+      };
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+/** Read + parse a state file. null on ANY problem — capture then journals
+ *  nothing (continuity wasn't seeded for this harness session). */
+export function readState(sessionDir: string, agentId: string, harnessSessionId: string): SessionState | null {
+  try {
+    const raw = readFileSync(statePath(sessionDir, agentId, harnessSessionId), "utf-8");
+    const parsed = JSON.parse(raw) as Partial<SessionState> | null;
+    if (
+      parsed &&
+      typeof parsed.sessionId === "string" && parsed.sessionId !== "" &&
+      typeof parsed.processUUID === "string" && parsed.processUUID !== "" &&
+      typeof parsed.seq === "number" && Number.isFinite(parsed.seq)
+    ) {
+      return {
+        sessionId: parsed.sessionId,
+        processUUID: parsed.processUUID,
+        seq: parsed.seq,
+        agentId: typeof parsed.agentId === "string" ? parsed.agentId : agentId,
+        harnessSessionId: typeof parsed.harnessSessionId === "string" ? parsed.harnessSessionId : harnessSessionId,
+        updatedAt: typeof parsed.updatedAt === "string" ? parsed.updatedAt : "",
+      };
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Mint a fresh sessionId + processUUID, seed the per-harness-session state
+ * file (seq 0) and rotate the pointer file to the new session. Called by the
+ * SessionStart hook on startup/resume/clear — NEVER on compaction (the caller
+ * gates on `source`; compaction keeps the same harness session id, so the same
+ * state file — and therefore the same sessionId — stays in place untouched,
+ * which is what makes scenario S7 hold by construction).
+ *
+ * Throws on fs failure — the caller treats that as "continuity unavailable"
+ * and proceeds (fail-open), it never propagates out of the hook.
+ */
+export function seedSession(sessionDir: string, agentId: string, harnessSessionId: string, now: Date = new Date()): SessionState {
+  ensureSessionDir(sessionDir);
+  const state: SessionState = {
+    sessionId: `cs-${randomUUID()}`,
+    processUUID: randomUUID(),
+    seq: 0,
+    agentId,
+    harnessSessionId,
+    updatedAt: now.toISOString(),
+  };
+  writeFilePrivate(statePath(sessionDir, agentId, harnessSessionId), JSON.stringify(state, null, 2) + "\n");
+  const pointer: SessionPointer = { sessionId: state.sessionId, processUUID: state.processUUID, updatedAt: state.updatedAt };
+  writeFilePrivate(pointerPath(sessionDir, agentId), JSON.stringify(pointer, null, 2) + "\n");
+  return state;
+}
+
+/**
+ * Atomically increment the state file's seq and return the NEW state (the one
+ * whose seq this capture fire owns). Write-to-temp + rename so a concurrent
+ * reader never sees a torn file. Returns null on any failure — the caller
+ * journals nothing rather than journaling with a wrong/duplicate seq.
+ *
+ * The seq is consumed BEFORE the network write, so even a failed write burns
+ * its seq — gaps are fine, non-monotonicity is not.
+ */
+export function bumpSeq(sessionDir: string, agentId: string, harnessSessionId: string, now: Date = new Date()): SessionState | null {
+  const current = readState(sessionDir, agentId, harnessSessionId);
+  if (!current) return null;
+  const next: SessionState = { ...current, seq: current.seq + 1, updatedAt: now.toISOString() };
+  const finalPath = statePath(sessionDir, agentId, harnessSessionId);
+  const tmpPath = `${finalPath}.tmp-${process.pid}-${Math.random().toString(36).slice(2)}`;
+  try {
+    writeFilePrivate(tmpPath, JSON.stringify(next, null, 2) + "\n");
+    renameSync(tmpPath, finalPath);
+    return next;
+  } catch {
+    return null;
+  }
+}
+
+// ── capture planning (pure) ─────────────────────────────────────────────────
+
+/** Subset of the Claude Code hook payload the capture bin reads. It extracts
+ *  ONLY these fields — the raw hook JSON (tool_input.command, tool_response,
+ *  transcript_path, …) is NEVER stored or forwarded. */
+export interface CaptureHookInput {
+  hook_event_name?: unknown;
+  session_id?: unknown;
+  tool_name?: unknown;
+  tool_input?: unknown;
+  /** Stop payloads: the final assistant message text, when the harness
+   *  provides it. Assistant-chosen prose — already user-visible. */
+  last_assistant_message?: unknown;
+  /** A dedicated summary/intent field, when the harness provides one —
+   *  preferred over raw final text (intent-class by construction). */
+  summary?: unknown;
+  [key: string]: unknown;
+}
+
+export interface CapturePlan {
+  hook: "PostToolUse" | "Stop";
+  tool?: MutatingTool;
+  /** The full journal content line — already hard-bounded. */
+  content: string;
+}
+
+/** HARD truncate at CAPTURE_BOUND_CHARS with a visible ellipsis, so a reader
+ *  knows the excerpt is incomplete and never acts on a cut sentence as if it
+ *  were whole. See CAPTURE_BOUND_CHARS — the bound is load-bearing. */
+export function hardBound(text: string): string {
+  if (text.length <= CAPTURE_BOUND_CHARS) return text;
+  return `${text.slice(0, CAPTURE_BOUND_CHARS)}…`;
+}
+
+function asNonEmptyString(value: unknown): string | null {
+  return typeof value === "string" && value.trim() !== "" ? value : null;
+}
+
+/**
+ * Pure capture decision: hook payload → at most one journal line, or null for
+ * "journal nothing" (read-only tool, empty Stop text, unknown/missing fields).
+ * This function IS the capture discipline — see the module doc; every branch
+ * below maps to a Sherlock-ruled rule.
+ */
+export function planCapture(input: CaptureHookInput): CapturePlan | null {
+  const hook = input.hook_event_name;
+
+  if (hook === "PostToolUse") {
+    const tool = input.tool_name;
+    // Closed allowlist, fail-closed: an unknown or absent tool name journals
+    // nothing. Read-only tools land here by design (world-recoverable).
+    if (typeof tool !== "string" || !(MUTATING_TOOLS as readonly string[]).includes(tool)) return null;
+    const toolInput = (input.tool_input && typeof input.tool_input === "object" ? input.tool_input : {}) as Record<string, unknown>;
+
+    if (tool === "Bash") {
+      // description ONLY — NEVER the command string, and never a fallback to
+      // it. The command is argv: exactly where our leak history lives.
+      const description = asNonEmptyString(toolInput.description);
+      return { hook, tool, content: hardBound(description ? `bash: ${description}` : "bash: (no description)") };
+    }
+
+    // Write / Edit / NotebookEdit: file path only — never content, never
+    // diffs. NotebookEdit's path key has appeared as both `notebook_path` and
+    // `file_path` across harness doc generations — accept either; both are
+    // paths, neither is content.
+    const pathField = tool === "NotebookEdit" ? (toolInput.notebook_path ?? toolInput.file_path) : toolInput.file_path;
+    const path = asNonEmptyString(pathField);
+    const label = tool === "Write" ? "write" : tool === "Edit" ? "edit" : "notebook-edit";
+    return { hook, tool: tool as MutatingTool, content: hardBound(path ? `${label}: ${path}` : `${label}: (no file path)`) };
+  }
+
+  if (hook === "Stop") {
+    // Prefer a dedicated summary/intent field when the payload carries one
+    // (intent-class by construction beats prose the agent happened to emit);
+    // else the final assistant text. Both are assistant-chosen, user-visible
+    // prose — never tool payloads — and both get the same hard bound.
+    const source = asNonEmptyString(input.summary) ?? asNonEmptyString(input.last_assistant_message);
+    if (!source) return null; // tool-only turn ⇒ no journal, no placeholder
+    return { hook, content: hardBound(`stop: ${source.trim()}`) };
+  }
+
+  return null;
+}
+
+// ── journal row construction ────────────────────────────────────────────────
+
+export function continuityTag(sessionId: string): string {
+  return `${CONTINUITY_TAG_PREFIX}${sessionId}`;
+}
+
+export interface JournalRow {
+  id: string;
+  agentId: string;
+  content: string;
+  type: "session";
+  durability: "ephemeral";
+  /** EXPLICIT on every write — never the durability-keyed default. Hook-side
+   *  half of the #1261 defense-in-depth pair (server guard is the other). */
+  visibility: "private";
+  tags: string[];
+  sessionId: string;
+  meta: { seq: number; processUUID: string; sessionId: string; hook: string; tool?: string };
+  createdAt: string;
+}
+
+export function buildJournalRow(agentId: string, state: SessionState, plan: CapturePlan, now: Date = new Date()): JournalRow {
+  const meta: JournalRow["meta"] = {
+    seq: state.seq,
+    processUUID: state.processUUID,
+    sessionId: state.sessionId,
+    hook: plan.hook,
+  };
+  if (plan.tool) meta.tool = plan.tool;
+  return {
+    id: `${agentId}-${randomUUID()}`,
+    agentId,
+    content: plan.content,
+    type: "session",
+    durability: "ephemeral",
+    visibility: "private",
+    tags: [continuityTag(state.sessionId)],
+    sessionId: state.sessionId,
+    meta,
+    createdAt: now.toISOString(),
+  };
+}
+
+// ── resume (agent-pull) ─────────────────────────────────────────────────────
+
+/** Minimal client surface both hook binaries depend on (eases testing —
+ *  structurally satisfied by the real FlairClient). */
+export interface ContinuityClient {
+  request<T = unknown>(method: string, path: string, body?: unknown): Promise<T>;
+}
+
+interface RawJournalRow {
+  id?: string;
+  agentId?: string;
+  tags?: unknown;
+  sessionId?: unknown;
+  expiresAt?: unknown;
+  createdAt?: unknown;
+  meta?: unknown;
+  [key: string]: unknown;
+}
+
+export interface ResumeEntry {
+  id: string;
+  seq: number | null;
+  processUUID: string | null;
+  sessionId: string | null;
+  createdAt: string;
+}
+
+export interface ResumeResult {
+  /** The prior session's journal entries, seq-ordered — ONE process's entries
+   *  only, never an interleave of two processUUIDs. */
+  entries: ResumeEntry[];
+  /** The session those entries belong to (for the hint's search tag). */
+  sessionId: string | null;
+}
+
+function searchConditions(agentId: string, extra: Array<{ search_attribute: string; search_type: string; search_value: unknown }>, limit: number) {
+  return {
+    operator: "and",
+    conditions: [
+      { search_attribute: "agentId", search_type: "equals", search_value: agentId },
+      { search_attribute: "durability", search_type: "equals", search_value: "ephemeral" },
+      ...extra,
+    ],
+    get_attributes: ["*"],
+    limit,
+  };
+}
+
+function rowsFrom(result: unknown): RawJournalRow[] {
+  if (Array.isArray(result)) return result as RawJournalRow[];
+  const wrapped = (result as { results?: unknown[] } | null)?.results;
+  return Array.isArray(wrapped) ? (wrapped as RawJournalRow[]) : [];
+}
+
+/** Expired rows are excluded HERE, not just by MemoryMaintenance — the reap is
+ *  asynchronous, so a row whose expiresAt is past may still be in storage
+ *  (scenario S4: it must never reach the agent regardless). */
+function isLive(row: RawJournalRow, now: Date): boolean {
+  if (typeof row.expiresAt !== "string" || row.expiresAt === "") return true;
+  const expiry = Date.parse(row.expiresAt);
+  return !Number.isFinite(expiry) || expiry > now.getTime();
+}
+
+function continuitySessionOf(row: RawJournalRow): string | null {
+  const meta = row.meta as { sessionId?: unknown; processUUID?: unknown; seq?: unknown } | null | undefined;
+  if (meta && typeof meta.sessionId === "string" && meta.sessionId !== "") return meta.sessionId;
+  if (Array.isArray(row.tags)) {
+    for (const tag of row.tags) {
+      if (typeof tag === "string" && tag.startsWith(CONTINUITY_TAG_PREFIX)) {
+        const sid = tag.slice(CONTINUITY_TAG_PREFIX.length);
+        if (sid !== "") return sid;
+      }
+    }
+  }
+  return null;
+}
+
+function toEntry(row: RawJournalRow): ResumeEntry {
+  const meta = row.meta as { seq?: unknown; processUUID?: unknown; sessionId?: unknown } | null | undefined;
+  return {
+    id: typeof row.id === "string" ? row.id : "",
+    seq: meta && typeof meta.seq === "number" && Number.isFinite(meta.seq) ? meta.seq : null,
+    processUUID: meta && typeof meta.processUUID === "string" && meta.processUUID !== "" ? meta.processUUID : null,
+    sessionId: continuitySessionOf(row),
+    createdAt: typeof row.createdAt === "string" ? row.createdAt : "",
+  };
+}
+
+/** seq ascending (monotonic per process — the primary order), createdAt as
+ *  tiebreak ONLY (and as the order for legacy rows lacking a seq). */
+function seqOrder(a: ResumeEntry, b: ResumeEntry): number {
+  if (a.seq != null && b.seq != null && a.seq !== b.seq) return a.seq - b.seq;
+  if (a.createdAt !== b.createdAt) return a.createdAt < b.createdAt ? -1 : 1;
+  return 0;
+}
+
+/**
+ * Resume discovery, both layers as ruled on the issue:
+ *
+ *   FAST PATH — the pointer file named a prior session: search exactly that
+ *   session's tag. A session's rows are all one process's by construction
+ *   (sessionId is minted per process), so the tag IS the process filter.
+ *
+ *   FALLBACK — no (readable) pointer: agentId-wide ephemeral search,
+ *   disambiguated by the processUUID carried in row meta. Entries are grouped
+ *   by processUUID and ONLY the most recent group is returned — a resume
+ *   reconstruction MUST NEVER interleave entries from two distinct
+ *   processUUIDs (scenario S8; two live processes sharing an identity).
+ *   Rows without a processUUID cannot be attributed and are skipped.
+ *
+ * Every failure (Flair down, auth error, malformed response) resolves to zero
+ * entries — the caller then emits no hint. Never throws.
+ */
+export async function discoverResume(
+  client: ContinuityClient,
+  agentId: string,
+  pointer: SessionPointer | null,
+  now: Date = new Date(),
+): Promise<ResumeResult> {
+  try {
+    if (pointer) {
+      const body = searchConditions(
+        agentId,
+        [{ search_attribute: "tags", search_type: "contains", search_value: continuityTag(pointer.sessionId) }],
+        RESUME_SEARCH_LIMIT,
+      );
+      const rows = rowsFrom(await client.request("POST", "/Memory/search_by_conditions", body)).filter((r) => isLive(r, now));
+      const entries = rows.map(toEntry).sort(seqOrder).slice(0, RESUME_SEARCH_LIMIT);
+      return { entries, sessionId: entries.length > 0 ? pointer.sessionId : null };
+    }
+
+    const body = searchConditions(agentId, [], FALLBACK_SEARCH_LIMIT);
+    const rows = rowsFrom(await client.request("POST", "/Memory/search_by_conditions", body))
+      .filter((r) => isLive(r, now))
+      .filter((r) => continuitySessionOf(r) !== null);
+    const groups = new Map<string, ResumeEntry[]>();
+    for (const row of rows) {
+      const entry = toEntry(row);
+      if (!entry.processUUID) continue; // unattributable — never guess
+      const list = groups.get(entry.processUUID) ?? [];
+      list.push(entry);
+      groups.set(entry.processUUID, list);
+    }
+    let best: ResumeEntry[] | null = null;
+    let bestLatest = "";
+    for (const list of groups.values()) {
+      const latest = list.reduce((max, e) => (e.createdAt > max ? e.createdAt : max), "");
+      if (best === null || latest > bestLatest) {
+        best = list;
+        bestLatest = latest;
+      }
+    }
+    if (!best || best.length === 0) return { entries: [], sessionId: null };
+    const entries = [...best].sort(seqOrder).slice(0, RESUME_SEARCH_LIMIT);
+    return { entries, sessionId: entries[0]?.sessionId ?? null };
+  } catch {
+    return { entries: [], sessionId: null };
+  }
+}
+
+/**
+ * The resume hint — at most ONE line, informational, agent-pull (scenario
+ * S10): it names the count and the search tag, and NEVER carries journal
+ * content (not even summarized). Zero entries ⇒ null ⇒ the hook emits no hint
+ * at all — an empty journal is normal operation, not a warning.
+ */
+export function buildResumeHint(result: ResumeResult): string | null {
+  const n = result.entries.length;
+  if (n === 0 || !result.sessionId) return null;
+  const noun = n === 1 ? "entry" : "entries";
+  return `Continuity: ${n} short-term journal ${noun} from your previous session survived — search memory tag "${continuityTag(result.sessionId)}" if you need to recall what dropped from context.`;
+}
+
+// ── SessionStart-side boot plumbing ─────────────────────────────────────────
+
+/** The SessionStart payload fields the boot path reads. The "how did this
+ *  session start" discriminator has appeared as both `source` and
+ *  `how_started` across harness doc generations — read either. */
+export interface ContinuityBootInput {
+  source?: unknown;
+  how_started?: unknown;
+  session_id?: unknown;
+  [key: string]: unknown;
+}
+
+export interface ContinuityBoot {
+  active: boolean;
+  priorPointer: SessionPointer | null;
+}
+
+/**
+ * Filesystem half of the resume path (pointer read → mint → rotate → seed the
+ * capture state file), called by the SessionStart hook. Pure local work —
+ * runs regardless of Flair reachability so capture always has its state file.
+ * Never throws; any fs failure degrades to "resume hint may still fire,
+ * capture won't" — fail-open in both directions.
+ *
+ * COMPACTION IS NOT A RESTART (scenario S7): when the harness reports the
+ * session start came from compaction, NOTHING runs — no pointer read, no
+ * rotation, no state-file touch. The harness session id is unchanged across
+ * compaction, so the capture hook keeps finding the same state file and the
+ * same sessionId; the journal never fragments.
+ */
+export function prepareContinuityBoot(
+  input: ContinuityBootInput,
+  agentId: string,
+  env: Record<string, string | undefined> = process.env,
+): ContinuityBoot {
+  const startedFrom = typeof input.source === "string" ? input.source : typeof input.how_started === "string" ? input.how_started : "";
+  if (startedFrom === "compact") return { active: false, priorPointer: null };
+  // Without a harness session id there is nothing to key the capture state
+  // file by (manual runs, older harnesses) — stay fully inert.
+  if (!isSafeFileId(agentId) || !isSafeFileId(input.session_id)) return { active: false, priorPointer: null };
+
+  const sessionDir = resolveSessionDir(env);
+  const priorPointer = readPointer(sessionDir, agentId);
+  try {
+    seedSession(sessionDir, agentId, input.session_id);
+  } catch {
+    // Session dir unwritable — capture can't run this session, but a resume
+    // hint from the prior pointer is still valid and still cheap.
+  }
+  return { active: true, priorPointer };
+}

--- a/packages/flair-mcp/src/env-guard.ts
+++ b/packages/flair-mcp/src/env-guard.ts
@@ -77,3 +77,25 @@ export function stripInterpolationLiteralsFromEnv(
     }
   }
 }
+
+/**
+ * Hook probe mode (flair#1007) — shared by every hook binary this package
+ * ships (session-start-hook.ts, continuity-capture-hook.ts). `flair doctor`
+ * sets FLAIR_HOOK_PROBE to ask "does this command still resolve and execute?"
+ * and a probed binary answers by exiting immediately, before stdin, clients,
+ * network or any side effect — being reached at all IS the answer.
+ *
+ * Lives here (this module has no @tpsdev-ai/flair-client import) so the
+ * capture binary can share the ONE definition without pulling the client's
+ * built dist into module graphs that must load before it is built (see
+ * test/unit's CI-ordering note in test/unit/hook-install.test.ts).
+ * session-start-hook.ts re-exports it unchanged.
+ *
+ * Any non-empty value other than "0" enables it, so `FLAIR_HOOK_PROBE=1` and
+ * `FLAIR_HOOK_PROBE=true` both work and an accidentally-empty variable does
+ * not.
+ */
+export function isProbeMode(env: Record<string, string | undefined> = process.env): boolean {
+  const raw = env.FLAIR_HOOK_PROBE;
+  return typeof raw === "string" && raw !== "" && raw !== "0";
+}

--- a/packages/flair-mcp/src/session-start-hook.ts
+++ b/packages/flair-mcp/src/session-start-hook.ts
@@ -78,7 +78,14 @@
 import { FlairClient } from "@tpsdev-ai/flair-client";
 import { basename } from "node:path";
 import { deriveActivity, postPresenceSafe, resolvePresenceTimeoutMs, type PresencePoster } from "./presence.js";
-import { readEnvOrUnset, stripInterpolationLiteralsFromEnv } from "./env-guard.js";
+import { isProbeMode, readEnvOrUnset, stripInterpolationLiteralsFromEnv } from "./env-guard.js";
+import {
+  buildResumeHint,
+  discoverResume,
+  prepareContinuityBoot,
+  resolveContinuityTimeoutMs,
+  type ContinuityClient,
+} from "./continuity.js";
 
 /** Claude Code SessionStart additionalContext hard limit (chars). */
 const MAX_CHARS = 10_000;
@@ -94,13 +101,36 @@ const TIMEOUT_CEILING_MS = 30_000;
 /** Empty, inert hook output. Printing this is always a safe no-op. */
 const NOOP_OUTPUT = "{}";
 
-/** Shape of the SessionStart payload Claude Code writes to stdin (subset). */
+/** Shape of the SessionStart payload Claude Code writes to stdin (subset).
+ *  The "how did this session start" discriminator has appeared as both
+ *  `source` and `how_started` across harness doc generations — read either. */
 interface SessionStartInput {
   cwd?: string;
   source?: string;
+  how_started?: string;
   session_id?: string;
   [key: string]: unknown;
 }
+
+// ── continuity resume path (flair#1257 slice 2) ─────────────────────────────
+//
+// This hook is the SessionStart half of the continuity adapter (the capture
+// half is ./continuity-capture-hook.ts; the shared core, the boot plumbing
+// (prepareContinuityBoot) and the full design record are in ./continuity.ts).
+// On boot it:
+//   (a) reads the pointer file ~/.flair/session/<agentId>.current — the
+//       prior session, if any (fast path); a missing/unreadable pointer falls
+//       back to an agentId-wide ephemeral search inside discoverResume();
+//   (b) mints a fresh sessionId + processUUID, seeds the per-harness-session
+//       state file the capture hook increments, and rotates the pointer;
+//   (c) emits AT MOST one hint line ("N entries from your previous session —
+//       search tag …") appended to the bootstrap context. Journal CONTENT is
+//       never emitted (agent-pull, scenario S10); zero prior entries ⇒ zero
+//       hint. Flair down ⇒ zero hint, boot proceeds (fail-open).
+//
+// Compaction is NOT a restart: prepareContinuityBoot stays fully inert on a
+// compaction-sourced SessionStart — no rotation, no state-file touch, no
+// hint (scenario S7 holds by construction).
 
 /** Minimal surface of FlairClient this hook depends on (eases testing).
  *  `request` is optional and structurally matches PresencePoster (presence.ts)
@@ -117,14 +147,11 @@ interface BootstrapClient extends Partial<PresencePoster> {
 }
 
 /**
- * Probe mode (flair#1007) — see the module doc. Any non-empty value other
- * than "0" enables it, so `FLAIR_HOOK_PROBE=1` and `FLAIR_HOOK_PROBE=true`
- * both work and an accidentally-empty variable does not.
+ * Probe mode (flair#1007) — see the module doc. The predicate itself moved to
+ * ./env-guard.ts when the continuity capture binary (flair#1257) started
+ * sharing it; re-exported here unchanged so existing importers keep working.
  */
-export function isProbeMode(env: Record<string, string | undefined> = process.env): boolean {
-  const raw = env.FLAIR_HOOK_PROBE;
-  return typeof raw === "string" && raw !== "" && raw !== "0";
-}
+export { isProbeMode };
 
 /** Resolve the bootstrap timeout from env, clamped to a sane range. */
 function resolveTimeoutMs(): number {
@@ -232,6 +259,23 @@ export async function runHook(
         )
       : Promise.resolve();
 
+  // Continuity resume (flair#1257 slice 2) — the local half (pointer read →
+  // mint → rotate → seed capture state) runs unconditionally when applicable;
+  // the search half runs CONCURRENTLY with bootstrap below, bounded by its own
+  // short timeout, and resolves to null (no hint) on any failure. It needs the
+  // signed request() surface; a lightweight bootstrap-only client (tests)
+  // skips it entirely.
+  const continuity = prepareContinuityBoot(input, agentId);
+  const resumeHintDone: Promise<string | null> =
+    continuity.active && typeof client.request === "function"
+      ? withTimeout(
+          discoverResume(client as unknown as ContinuityClient, agentId, continuity.priorPointer).then((result) =>
+            buildResumeHint(result),
+          ),
+          resolveContinuityTimeoutMs(),
+        ).catch(() => null)
+      : Promise.resolve(null);
+
   let context = "";
   try {
     const res = await withTimeout(
@@ -246,16 +290,23 @@ export async function runHook(
     );
     context = res && res.context ? String(res.context) : "";
   } catch {
-    await presenceDone;
-    return NOOP_OUTPUT; // flair unreachable / auth error / timeout → no-op
+    context = ""; // flair unreachable / auth error / timeout → no bootstrap context
   }
 
+  const resumeHint = await resumeHintDone;
   await presenceDone;
 
-  if (!context.trim()) return NOOP_OUTPUT;
-  if (context.length > MAX_CHARS) context = context.slice(0, MAX_CHARS);
+  // Combine: bootstrap context first, then AT MOST one continuity hint line.
+  // Either piece may be absent; both absent ⇒ the inert no-op output.
+  const pieces: string[] = [];
+  if (context.trim()) pieces.push(context);
+  if (resumeHint) pieces.push(resumeHint);
+  if (pieces.length === 0) return NOOP_OUTPUT;
 
-  return hookOutput(context);
+  let combined = pieces.join("\n\n");
+  if (combined.length > MAX_CHARS) combined = combined.slice(0, MAX_CHARS);
+
+  return hookOutput(combined);
 }
 
 /** Default client factory — constructs a real FlairClient from FLAIR_* env,

--- a/packages/flair-mcp/test/continuity-resume.test.ts
+++ b/packages/flair-mcp/test/continuity-resume.test.ts
@@ -1,0 +1,207 @@
+/**
+ * continuity-resume.test.ts — flair#1257 slice 2: the SessionStart hook's
+ * resume path end-to-end through runHook's stdout contract (S1 cold start,
+ * S2 resume hint, S7 compaction, S10 fail-open / agent-pull).
+ *
+ * Lives in THIS package's lane (which builds @tpsdev-ai/flair-client first)
+ * because runHook's module statically imports the client by its built dist —
+ * the root test/unit lane runs before that build exists. The dist-free half
+ * of the continuity suite (capture discipline, resume discovery, boot
+ * plumbing, leak-guards) is test/unit/continuity-hook.test.ts.
+ *
+ * Hermetic: injected clients, per-test temp FLAIR_SESSION_DIR — no test ever
+ * touches the real ~/.flair (homeOverride discipline).
+ */
+
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { existsSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { runHook } from "../src/session-start-hook.ts";
+import {
+  continuityTag,
+  pointerPath,
+  readPointer,
+  readState,
+  seedSession,
+} from "../src/continuity.ts";
+
+const AGENT = "agent-a";
+const NOOP = "{}";
+
+const ORIGINAL_ENV = {
+  FLAIR_AGENT_ID: process.env.FLAIR_AGENT_ID,
+  FLAIR_SESSION_DIR: process.env.FLAIR_SESSION_DIR,
+};
+
+let dir: string;
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), "flair-continuity-resume-test-"));
+  process.env.FLAIR_SESSION_DIR = dir;
+  process.env.FLAIR_AGENT_ID = AGENT;
+});
+
+afterEach(() => {
+  for (const [key, value] of Object.entries(ORIGINAL_ENV)) {
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+  rmSync(dir, { recursive: true, force: true });
+});
+
+function journalRow(opts: { seq: number; sessionId: string; processUUID: string; content?: string }) {
+  return {
+    id: `${AGENT}-row-${opts.seq}`,
+    agentId: AGENT,
+    content: opts.content ?? "bash: something",
+    durability: "ephemeral",
+    visibility: "private",
+    tags: [continuityTag(opts.sessionId)],
+    sessionId: opts.sessionId,
+    createdAt: "2026-08-19T10:00:00.000Z",
+    expiresAt: "2999-01-01T00:00:00.000Z",
+    meta: { seq: opts.seq, processUUID: opts.processUUID, sessionId: opts.sessionId },
+  };
+}
+
+function startInput(extra: Record<string, unknown> = {}): string {
+  return JSON.stringify({ cwd: "/tmp/proj", source: "startup", session_id: "claude-new-sess", ...extra });
+}
+
+describe("session-start resume path (runHook end-to-end)", () => {
+  const JOURNAL_MARKER = "JOURNAL_CONTENT_MARKER_5a1c";
+
+  test("S1 cold start: pointer + state seeded, NO hint, boot proceeds clean", async () => {
+    const out = await runHook(startInput(), () => ({
+      bootstrap: async () => ({ context: "## Identity" }),
+      request: async () => [],
+    }));
+    const parsed = JSON.parse(out);
+    expect(parsed.hookSpecificOutput.additionalContext).toBe("## Identity");
+    expect(parsed.hookSpecificOutput.additionalContext).not.toContain("Continuity:");
+
+    // Local half ran: pointer + state exist, capture is ready.
+    expect(readPointer(dir, AGENT)).not.toBeNull();
+    expect(readState(dir, AGENT, "claude-new-sess")?.seq).toBe(0);
+  });
+
+  test("S2 resume: prior pointer ⇒ ONE hint line with count + old tag; journal CONTENT never injected; pointer rotates", async () => {
+    const prior = seedSession(dir, AGENT, "claude-old-sess"); // simulates the dead process's boot
+    const priorRows = [
+      journalRow({ seq: 1, sessionId: prior.sessionId, processUUID: prior.processUUID, content: `intent one ${JOURNAL_MARKER}` }),
+      journalRow({ seq: 2, sessionId: prior.sessionId, processUUID: prior.processUUID, content: `intent two ${JOURNAL_MARKER}` }),
+    ];
+    const out = await runHook(startInput(), () => ({
+      bootstrap: async () => ({ context: "## Identity" }),
+      request: async (_m: string, p: string) => (p === "/Memory/search_by_conditions" ? priorRows : {}),
+    }));
+    const context: string = JSON.parse(out).hookSpecificOutput.additionalContext;
+    const hintLines = context.split("\n").filter((l) => l.includes("Continuity:"));
+    expect(hintLines).toHaveLength(1); // at most ONE hint line
+    expect(hintLines[0]).toContain("2");
+    expect(hintLines[0]).toContain(continuityTag(prior.sessionId));
+    expect(context).not.toContain(JOURNAL_MARKER); // agent-pull: content NEVER injected
+
+    const rotated = readPointer(dir, AGENT);
+    expect(rotated?.sessionId).not.toBe(prior.sessionId); // minted + rotated
+  });
+
+  test("S7 compaction: no search, no hint, no rotation — the journal never fragments", async () => {
+    const seeded = seedSession(dir, AGENT, "claude-old-sess");
+    for (const sourceField of [{ source: "compact" }, { how_started: "compact" }]) {
+      const searches: string[] = [];
+      const out = await runHook(
+        JSON.stringify({ cwd: "/tmp/proj", session_id: "claude-old-sess", ...sourceField }),
+        () => ({
+          bootstrap: async () => ({ context: "ctx" }),
+          request: async (_m: string, p: string) => {
+            searches.push(p);
+            return [journalRow({ seq: 1, sessionId: seeded.sessionId, processUUID: seeded.processUUID })];
+          },
+        }),
+      );
+      expect(searches.filter((p) => p === "/Memory/search_by_conditions")).toHaveLength(0);
+      expect(JSON.parse(out).hookSpecificOutput.additionalContext).not.toContain("Continuity:");
+    }
+    expect(readPointer(dir, AGENT)?.sessionId).toBe(seeded.sessionId); // never rotated
+    expect(readState(dir, AGENT, "claude-old-sess")?.sessionId).toBe(seeded.sessionId);
+  });
+
+  test("S10 fail-open: Flair fully down ⇒ no hint, inert output, boot proceeds — capture state still seeded locally", async () => {
+    seedSession(dir, AGENT, "claude-old-sess"); // a prior session exists…
+    const out = await runHook(startInput(), () => ({
+      bootstrap: async () => {
+        throw new TypeError("fetch failed");
+      },
+      request: async () => {
+        throw new TypeError("fetch failed");
+      },
+    }));
+    expect(out).toBe(NOOP); // …but with Flair down there is NO hint and no error wall
+    expect(readState(dir, AGENT, "claude-new-sess")).not.toBeNull(); // local half still ran
+  });
+
+  test("zero prior entries ⇒ output contains no hint text at all (assert absence, not merely no error)", async () => {
+    seedSession(dir, AGENT, "claude-old-sess"); // pointer exists, journal empty
+    const out = await runHook(startInput(), () => ({
+      bootstrap: async () => ({ context: "## Identity" }),
+      request: async () => [],
+    }));
+    const context: string = JSON.parse(out).hookSpecificOutput.additionalContext;
+    expect(context).toBe("## Identity");
+    expect(context).not.toContain("Continuity:");
+  });
+
+  test("a hint can carry the output alone (bootstrap empty but journal present)", async () => {
+    const prior = seedSession(dir, AGENT, "claude-old-sess");
+    const out = await runHook(startInput(), () => ({
+      bootstrap: async () => ({ context: "" }),
+      request: async (_m: string, p: string) =>
+        p === "/Memory/search_by_conditions"
+          ? [journalRow({ seq: 1, sessionId: prior.sessionId, processUUID: prior.processUUID })]
+          : {},
+    }));
+    const context: string = JSON.parse(out).hookSpecificOutput.additionalContext;
+    expect(context).toContain("Continuity:");
+    expect(context).toContain(continuityTag(prior.sessionId));
+  });
+
+  test("no session_id in the payload ⇒ continuity fully inert (legacy behavior preserved, no files)", async () => {
+    const out = await runHook(JSON.stringify({ cwd: "/tmp/proj", source: "startup" }), () => ({
+      bootstrap: async () => ({ context: "ctx" }),
+      request: async () => [],
+    }));
+    expect(JSON.parse(out).hookSpecificOutput.additionalContext).toBe("ctx");
+    expect(existsSync(pointerPath(dir, AGENT))).toBe(false);
+  });
+
+  test("a bootstrap-only client (no request surface) skips the resume search but still seeds capture state", async () => {
+    const out = await runHook(startInput(), () => ({
+      bootstrap: async () => ({ context: "ctx" }),
+    }));
+    expect(JSON.parse(out).hookSpecificOutput.additionalContext).toBe("ctx");
+    expect(readState(dir, AGENT, "claude-new-sess")).not.toBeNull();
+  });
+
+  test("a hanging resume search is bounded by its own timeout and degrades to no-hint (never blocks boot)", async () => {
+    process.env.FLAIR_CONTINUITY_TIMEOUT_MS = "250";
+    try {
+      seedSession(dir, AGENT, "claude-old-sess");
+      const start = Date.now();
+      const out = await runHook(startInput(), () => ({
+        bootstrap: async () => ({ context: "ctx" }),
+        request: (_m: string, p: string) =>
+          p === "/Memory/search_by_conditions" ? new Promise(() => {}) : Promise.resolve({}),
+      }));
+      const elapsed = Date.now() - start;
+      const context: string = JSON.parse(out).hookSpecificOutput.additionalContext;
+      expect(context).toBe("ctx");
+      expect(context).not.toContain("Continuity:");
+      expect(elapsed).toBeLessThan(3000);
+    } finally {
+      delete process.env.FLAIR_CONTINUITY_TIMEOUT_MS;
+    }
+  });
+});

--- a/packages/flair-mcp/test/session-start-hook.test.ts
+++ b/packages/flair-mcp/test/session-start-hook.test.ts
@@ -1,4 +1,7 @@
-import { describe, test, expect, afterEach } from "bun:test";
+import { describe, test, expect, afterEach, beforeEach } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { runHook } from "../src/session-start-hook.ts";
 
 /**
@@ -15,10 +18,24 @@ const MAX_CHARS = 10_000;
 const NOOP = "{}";
 
 const ORIGINAL_AGENT_ID = process.env.FLAIR_AGENT_ID;
+const ORIGINAL_SESSION_DIR = process.env.FLAIR_SESSION_DIR;
+
+// The continuity resume path (flair#1257) writes pointer/state files under
+// FLAIR_SESSION_DIR (default ~/.flair/session). Point it at a per-test temp
+// dir so no test ever touches the real ~/.flair (homeOverride discipline).
+let sessionDir: string;
+
+beforeEach(() => {
+  sessionDir = mkdtempSync(join(tmpdir(), "flair-session-start-test-"));
+  process.env.FLAIR_SESSION_DIR = sessionDir;
+});
 
 afterEach(() => {
   if (ORIGINAL_AGENT_ID === undefined) delete process.env.FLAIR_AGENT_ID;
   else process.env.FLAIR_AGENT_ID = ORIGINAL_AGENT_ID;
+  if (ORIGINAL_SESSION_DIR === undefined) delete process.env.FLAIR_SESSION_DIR;
+  else process.env.FLAIR_SESSION_DIR = ORIGINAL_SESSION_DIR;
+  rmSync(sessionDir, { recursive: true, force: true });
 });
 
 const SAMPLE_INPUT = JSON.stringify({
@@ -186,10 +203,13 @@ describe("session-start hook", () => {
         },
       }));
 
-      expect(presenceCalls).toHaveLength(1);
-      expect(presenceCalls[0].method).toBe("POST");
-      expect(presenceCalls[0].path).toBe("/Presence");
-      expect(presenceCalls[0].body).toEqual({ activity: "coding" }); // no currentTask in the hook payload
+      // The stub's request() also serves the continuity resume search
+      // (flair#1257: POST /Memory/search_by_conditions) — filter to the
+      // presence surface this test is about.
+      const presenceOnly = presenceCalls.filter((c) => c.path === "/Presence");
+      expect(presenceOnly).toHaveLength(1);
+      expect(presenceOnly[0].method).toBe("POST");
+      expect(presenceOnly[0].body).toEqual({ activity: "coding" }); // no currentTask in the hook payload
       // The presence side effect never changes the hook's own output contract.
       const parsed = JSON.parse(out);
       expect(parsed.hookSpecificOutput.additionalContext).toBe("## Identity\nrole: test");

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -103,6 +103,8 @@ import {
   resolveCollisionSafeName,
   pruneDateStamp,
   PRUNED_DIR_NAME,
+  checkContinuityCaptureHooks,
+  fixContinuityCaptureHooks,
   type AgentGateState,
   type SemanticSkipReason,
   type KeyPruneClass,
@@ -111,6 +113,9 @@ import {
   installHook,
   uninstallHook,
   hookStatus,
+  installContinuityHooks,
+  uninstallContinuityHooks,
+  continuityHookStatus,
   isSupportedHarness,
   SUPPORTED_HARNESSES,
   type Harness,
@@ -4865,6 +4870,7 @@ hook
   .option("--agent <id>", "Agent ID to wire (else FLAIR_AGENT_ID, else the agent already wired for the claude-code MCP client)")
   .option("--agent-id <id>", "Alias for --agent")
   .option("--url <url>", "Flair URL to wire (else FLAIR_TARGET/FLAIR_URL, else the existing claude-code MCP wiring, else the local default)")
+  .option("--continuity", "Wire the continuity capture hooks instead (PostToolUse + Stop — flair#1257; installing them IS the opt-in)")
   .action((opts) => {
     const harness = requireSupportedHarness(opts.harness);
     const home = homedir();
@@ -4877,6 +4883,18 @@ hook
     }
     const flairUrl = resolveHookFlairUrl(opts, home);
     const dryRun = !!opts.dryRun;
+
+    if (opts.continuity) {
+      const result = installContinuityHooks({ homeDir: home, harness, agentId, flairUrl, dryRun });
+      console.log(`\n${render.wrap(render.c.bold, "🪝 flair hook install --continuity")}${dryRun ? render.wrap(render.c.dim, " (dry run)") : ""}\n`);
+      console.log(`  ${result.ok ? render.icons.ok : render.icons.error} ${result.message}`);
+      if (result.backupPath) {
+        console.log(`     ${render.wrap(render.c.dim, `backup: ${result.backupPath}`)}`);
+      }
+      console.log("");
+      if (!result.ok) process.exit(1);
+      return;
+    }
 
     const result = installHook({ homeDir: home, harness, agentId, flairUrl, dryRun });
 
@@ -4898,10 +4916,23 @@ hook
   .description("Remove the Flair SessionStart hook entry — only ours, everything else in the file is left untouched")
   .option("--harness <name>", `Target harness (${SUPPORTED_HARNESSES.join(", ")})`, "claude-code")
   .option("--dry-run", "Print the exact JSON delta without writing")
+  .option("--continuity", "Remove the continuity capture hooks instead (PostToolUse + Stop — flair#1257)")
   .action((opts) => {
     const harness = requireSupportedHarness(opts.harness);
     const home = homedir();
     const dryRun = !!opts.dryRun;
+
+    if (opts.continuity) {
+      const result = uninstallContinuityHooks({ homeDir: home, harness, dryRun });
+      console.log(`\n${render.wrap(render.c.bold, "🪝 flair hook uninstall --continuity")}${dryRun ? render.wrap(render.c.dim, " (dry run)") : ""}\n`);
+      console.log(`  ${result.ok ? render.icons.ok : render.icons.error} ${result.message}`);
+      if (result.backupPath) {
+        console.log(`     ${render.wrap(render.c.dim, `backup: ${result.backupPath}`)}`);
+      }
+      console.log("");
+      if (!result.ok) process.exit(1);
+      return;
+    }
 
     const result = uninstallHook({ homeDir: home, harness, dryRun });
 
@@ -4927,6 +4958,21 @@ hook
     const home = homedir();
     const status = hookStatus(home, harness);
 
+    // Continuity pair (flair#1257) — reported alongside the SessionStart
+    // status in every branch below. "absent" is NOT a failure: installing the
+    // pair is the opt-in, so absence renders as "not enabled".
+    const renderContinuity = (): void => {
+      const cont = continuityHookStatus(home, harness);
+      if (cont.state === "installed") {
+        console.log(`  ${render.icons.ok} continuity capture: PostToolUse + Stop wired`);
+      } else if (cont.state === "absent") {
+        console.log(`  ${render.icons.info} continuity capture: not enabled ${render.wrap(render.c.dim, "(opt-in: flair hook install --continuity)")}`);
+      } else {
+        const missing = !cont.postToolUse.present ? "PostToolUse missing" : !cont.stop.present ? "Stop missing" : "stale form";
+        console.log(`  ${render.icons.warn} continuity capture: ${cont.state} (${missing}) ${render.wrap(render.c.dim, "— re-run: flair hook install --continuity")}`);
+      }
+    };
+
     console.log(`\n${render.wrap(render.c.bold, "🪝 flair hook status")}\n`);
     console.log(`  ${render.wrap(render.c.dim, "Harness:")} ${status.harness}`);
     console.log(`  ${render.wrap(render.c.dim, "Config:")}  ${status.path}`);
@@ -4940,6 +4986,7 @@ hook
     if (!status.wired) {
       console.log(`  ${render.icons.error} not wired`);
       console.log(`     ${render.wrap(render.c.dim, "Fix:")} flair hook install`);
+      renderContinuity();
       console.log("");
       process.exit(1);
     }
@@ -4954,6 +5001,7 @@ hook
     } else {
       console.log(`     ${render.icons.warn} ${render.wrap(render.c.dim, "On failure:")} prints an error on every session — run \`flair hook install\` to adopt the silent form`);
     }
+    renderContinuity();
     console.log("");
   });
 
@@ -13693,6 +13741,65 @@ program
             }
           } else {
             console.log(`     ${render.wrap(render.c.dim, "Fix:")} flair doctor --fix ${render.wrap(render.c.dim, "(adds the flair-session-start SessionStart hook)")}`);
+          }
+          issues++;
+        }
+
+        // flair#1257 slice 2 — continuity capture pair (the check-5 twin of
+        // the SessionStart check above: installed / absent / stale-form).
+        // Continuity is OPT-IN — installing the PostToolUse+Stop pair IS the
+        // opt-in — so "absent" renders as informational "not enabled": NEVER
+        // a pass (an unrun check must not look green) and never counted as an
+        // issue. A partial/stale install IS an issue and is --fix-able;
+        // --fix also offers first-time enablement (the y/N prompt is the
+        // consent; non-TTY --fix is itself the consent signal, matching every
+        // other doctor fix).
+        const continuity = checkContinuityCaptureHooks(homedir());
+        if (continuity.state === "installed") {
+          console.log(`  ${render.icons.ok} Continuity capture hooks: PostToolUse + Stop wired in ${render.wrap(render.c.dim, continuity.path)}`);
+        } else if (continuity.state === "absent") {
+          console.log(`  ${render.icons.info} Continuity capture hooks: not enabled ${render.wrap(render.c.dim, "(opt-in — auto-journal working state into the ephemeral memory tier; enable: flair hook install --continuity)")}`);
+          if (autoFix) {
+            if (dryRun) {
+              console.log(`     ${render.wrap(render.c.dim, "Would wire the continuity capture hooks (PostToolUse + Stop) in")} ${continuity.path}`);
+            } else {
+              const proceed = await confirmFix(`  Enable continuity capture (PostToolUse + Stop hooks in ${continuity.path})? [y/N] `);
+              if (!proceed) {
+                console.log(`     Skipped.`);
+              } else {
+                const fixAgentId = claudeCodeAgentId || opts.agent || process.env.FLAIR_AGENT_ID;
+                const fixRes = fixContinuityCaptureHooks(homedir(), fixAgentId);
+                console.log(`     ${fixRes.ok ? render.icons.ok : render.icons.warn} ${fixRes.message}`);
+                if (fixRes.ok && fixRes.changed) fixed++;
+              }
+            }
+          }
+        } else {
+          const continuityDetail = continuity.state === "partial"
+            ? (!continuity.postToolUse.present ? "the PostToolUse entry is missing" : "the Stop entry is missing")
+            : "an entry is not the current form (unsilenced, hand-altered, or a drifted PostToolUse matcher)";
+          console.log(`  ${render.icons.warn} Continuity capture hooks: ${continuity.state} — ${continuityDetail}`);
+          if (autoFix) {
+            if (dryRun) {
+              console.log(`     ${render.wrap(render.c.dim, "Would rewrite the continuity capture hooks in")} ${continuity.path}`);
+            } else {
+              const proceed = await confirmFix(`  Rewrite the continuity capture hooks in ${continuity.path} to the current form? [y/N] `);
+              if (!proceed) {
+                console.log(`     Skipped.`);
+              } else {
+                const fixAgentId = claudeCodeAgentId || opts.agent || process.env.FLAIR_AGENT_ID;
+                // Preserve the FLAIR_URL an existing entry already carries —
+                // a repair must never silently re-point the hooks at a
+                // different instance.
+                const existingCommand = continuity.postToolUse.command || continuity.stop.command || "";
+                const existingUrl = existingCommand.match(/FLAIR_URL=(\S+)/)?.[1];
+                const fixRes = fixContinuityCaptureHooks(homedir(), fixAgentId, existingUrl);
+                console.log(`     ${fixRes.ok ? render.icons.ok : render.icons.warn} ${fixRes.message}`);
+                if (fixRes.ok && fixRes.changed) fixed++;
+              }
+            }
+          } else {
+            console.log(`     ${render.wrap(render.c.dim, "Fix:")} flair doctor --fix ${render.wrap(render.c.dim, "(rewrites both entries to the current form — same agent, same instance)")}`);
           }
           issues++;
         }

--- a/src/doctor-client.ts
+++ b/src/doctor-client.ts
@@ -168,6 +168,328 @@ export function isFlairHookCommand(command: string): boolean {
   return typeof command === "string" && command.includes("@tpsdev-ai/flair-mcp") && command.includes(SESSION_START_HOOK_MARKER);
 }
 
+// ── the continuity capture hooks (flair#1257 slice 2) ──────────────────────
+//
+// Continuity's write side is a pair of Claude Code hook entries — PostToolUse
+// (mutating tools only, via the matcher below) and Stop — both running the
+// SAME `flair-continuity-capture` binary shipped by @tpsdev-ai/flair-mcp.
+// Same ONE-builder discipline as the SessionStart command above (#1007):
+// every path that writes these entries (`flair doctor --fix`, `flair hook
+// install --continuity` in src/hook-install.ts) goes through
+// buildContinuityCaptureHookCommand, so the invocation's failure behaviour is
+// defined and tested in one place.
+//
+// Unlike the SessionStart command, this one captures NOTHING to re-emit: a
+// PostToolUse/Stop hook's stdout is harness-interpreted surface and the
+// capture binary never has anything to say to it, so the wrapper discards
+// BOTH streams and absorbs failure (`>/dev/null 2>/dev/null || true`). The
+// same #1007 reasoning applies: if the npx resolution breaks, the silence has
+// to be a property of the command string, because the binary's own fail-open
+// guarantee is behind the door that stopped opening. hookCommandIsSilenced()
+// recognizes this shape unchanged.
+//
+// INSTALLING THESE HOOKS IS THE OPT-IN. There is no env flag: an agent whose
+// settings.json carries the pair journals; one that doesn't, doesn't. Doctor
+// therefore reports "absent" as "not enabled" — informational, never a pass,
+// never a failure (see checkContinuityCaptureHooks / cli.ts's rendering).
+
+/** The exact substring identifying a Flair continuity-capture hook command. */
+export const CONTINUITY_CAPTURE_HOOK_MARKER = "flair-continuity-capture";
+
+/**
+ * The PostToolUse matcher written alongside our hook entry — the EXACT
+ * mutating-tool allowlist the capture binary enforces internally
+ * (packages/flair-mcp/src/continuity.ts's MUTATING_TOOLS: Write/Edit/
+ * NotebookEdit mutate file/cell state, Bash can mutate anything; read-only
+ * tools are world-recoverable and journal nothing). The matcher is an
+ * EFFICIENCY (no process spawn for a Read), not the control — the binary's
+ * own allowlist is the control and fires regardless of who spawns it.
+ */
+export const CONTINUITY_POST_TOOL_USE_MATCHER = "Write|Edit|NotebookEdit|Bash";
+
+/**
+ * Build the exact `command` string registered for BOTH continuity hook events
+ * (PostToolUse and Stop run the same binary; the payload's hook_event_name
+ * tells it which fired). Same strict value allow-list as the SessionStart
+ * builder — throws rather than emitting a quoted approximation.
+ */
+export function buildContinuityCaptureHookCommand(agentId: string, flairUrl?: string): string {
+  if (!isHookCommandValueSafe(agentId)) {
+    throw new Error(
+      `agent id '${agentId}' contains characters that cannot be safely written into a shell hook command (allowed: letters, digits, . _ : / -)`,
+    );
+  }
+  if (flairUrl != null && flairUrl !== "" && !isHookCommandValueSafe(flairUrl)) {
+    throw new Error(
+      `Flair URL '${flairUrl}' contains characters that cannot be safely written into a shell hook command (allowed: letters, digits, . _ : / -)`,
+    );
+  }
+  const env = flairUrl ? `FLAIR_AGENT_ID=${agentId} FLAIR_URL=${flairUrl}` : `FLAIR_AGENT_ID=${agentId}`;
+  const invocation = `${env} npx -y -p @tpsdev-ai/flair-mcp ${CONTINUITY_CAPTURE_HOOK_MARKER}`;
+  return `sh -c '${invocation} >/dev/null 2>/dev/null || true'`;
+}
+
+/** Does this command invoke the Flair continuity-capture binary at all? */
+export function isFlairContinuityCommand(command: string): boolean {
+  return (
+    typeof command === "string" &&
+    command.includes("@tpsdev-ai/flair-mcp") &&
+    command.includes(CONTINUITY_CAPTURE_HOOK_MARKER)
+  );
+}
+
+/** The two hook events continuity registers under. */
+export const CONTINUITY_HOOK_EVENTS = ["PostToolUse", "Stop"] as const;
+export type ContinuityHookEvent = (typeof CONTINUITY_HOOK_EVENTS)[number];
+
+/**
+ * installed  — both entries present, both in the current (silenced) form,
+ *              PostToolUse carrying the expected matcher.
+ * absent     — neither entry present. This is "not enabled": the feature is
+ *              opt-in, so absence is informational — NEVER rendered as a pass
+ *              (that would be an unrun check dressed as a green one) and never
+ *              as a failure.
+ * partial    — exactly one of the two entries present (a half-install: capture
+ *              without Stop journals actions but never intent, and vice
+ *              versa). A stale-form face; fixable.
+ * stale      — both present but at least one is not the current form (unsilenced,
+ *              hand-altered invocation, or a drifted PostToolUse matcher).
+ */
+export type ContinuityHookState = "installed" | "absent" | "partial" | "stale";
+
+export interface ContinuityHookEventReport {
+  present: boolean;
+  command?: string;
+  /** PostToolUse only — the matcher on the group carrying our entry. */
+  matcher?: string;
+  /** Present AND the exact shape we write today (silenced wrapper, unpinned
+   *  npx invocation, and — for PostToolUse — the expected matcher). */
+  currentForm: boolean;
+}
+
+export interface ContinuityCaptureHookReport {
+  path: string;
+  postToolUse: ContinuityHookEventReport;
+  stop: ContinuityHookEventReport;
+  state: ContinuityHookState;
+}
+
+function findContinuityEntry(config: any, event: ContinuityHookEvent): { group: any; hookIndex: number; groupIndex: number } | null {
+  const groups = config?.hooks?.[event];
+  if (!Array.isArray(groups)) return null;
+  for (let gi = 0; gi < groups.length; gi++) {
+    const hooks = groups[gi]?.hooks;
+    if (!Array.isArray(hooks)) continue;
+    for (let hi = 0; hi < hooks.length; hi++) {
+      if (typeof hooks[hi]?.command === "string" && hooks[hi].command.includes(CONTINUITY_CAPTURE_HOOK_MARKER)) {
+        return { group: groups[gi], hookIndex: hi, groupIndex: gi };
+      }
+    }
+  }
+  return null;
+}
+
+function continuityEventReport(config: any, event: ContinuityHookEvent): ContinuityHookEventReport {
+  const found = findContinuityEntry(config, event);
+  if (!found) return { present: false, currentForm: false };
+  const hook = found.group.hooks[found.hookIndex];
+  const command: string = typeof hook?.command === "string" ? hook.command : "";
+  const matcher: string | undefined = typeof found.group?.matcher === "string" ? found.group.matcher : undefined;
+  const shapeOk =
+    hook?.type === "command" &&
+    command.includes(`npx -y -p @tpsdev-ai/flair-mcp ${CONTINUITY_CAPTURE_HOOK_MARKER}`) &&
+    hookCommandIsSilenced(command);
+  const matcherOk = event !== "PostToolUse" || matcher === CONTINUITY_POST_TOOL_USE_MATCHER;
+  return { present: true, command, matcher, currentForm: shapeOk && matcherOk };
+}
+
+/**
+ * Doctor's check-5 twin of checkSessionStartHook for the continuity pair —
+ * pure fs read, no probe. A missing or unparseable settings.json reads as
+ * "absent" (not enabled), matching checkSessionStartHook's tolerance.
+ */
+export function checkContinuityCaptureHooks(homeDir: string): ContinuityCaptureHookReport {
+  const path = join(homeDir, ".claude", "settings.json");
+  let config: any = {};
+  const raw = readTextFile(path);
+  if (raw && raw.trim()) {
+    try {
+      config = JSON.parse(raw);
+    } catch {
+      config = {};
+    }
+  }
+  const postToolUse = continuityEventReport(config, "PostToolUse");
+  const stop = continuityEventReport(config, "Stop");
+  let state: ContinuityHookState;
+  if (!postToolUse.present && !stop.present) state = "absent";
+  else if (!postToolUse.present || !stop.present) state = "partial";
+  else if (postToolUse.currentForm && stop.currentForm) state = "installed";
+  else state = "stale";
+  return { path, postToolUse, stop, state };
+}
+
+export type ContinuityMutationAction = "add" | "update" | "noop";
+
+/**
+ * Pure merge of the continuity pair into a parsed settings object — the ONE
+ * mutation core both write paths (`flair doctor --fix` via
+ * fixContinuityCaptureHooks below, `flair hook install --continuity` via
+ * src/hook-install.ts) share. Idempotent: re-running with unchanged inputs is
+ * a structural no-op. Only OUR entries are ever touched — sibling hooks,
+ * groups and keys are preserved byte-identical; a group we don't own keeps
+ * its matcher (our binary's internal allowlist still filters — the matcher is
+ * an efficiency, not the control).
+ */
+export function computeContinuityHookInstall(
+  config: any,
+  agentId: string,
+  flairUrl?: string,
+): { changed: boolean; actions: Record<ContinuityHookEvent, ContinuityMutationAction>; newConfig: any } {
+  const command = buildContinuityCaptureHookCommand(agentId, flairUrl);
+  const newConfig = JSON.parse(JSON.stringify(config ?? {}));
+  const actions = { PostToolUse: "noop", Stop: "noop" } as Record<ContinuityHookEvent, ContinuityMutationAction>;
+  let changed = false;
+
+  newConfig.hooks = newConfig.hooks && typeof newConfig.hooks === "object" && !Array.isArray(newConfig.hooks) ? newConfig.hooks : {};
+
+  for (const event of CONTINUITY_HOOK_EVENTS) {
+    const existing = findContinuityEntry(newConfig, event);
+    if (existing) {
+      const hook = existing.group.hooks[existing.hookIndex];
+      const soleOwner = existing.group.hooks.length === 1;
+      const wantMatcher = event === "PostToolUse" && soleOwner;
+      const matcherCurrent = !wantMatcher || existing.group.matcher === CONTINUITY_POST_TOOL_USE_MATCHER;
+      if (hook.command === command && hook.type === "command" && matcherCurrent) continue;
+      existing.group.hooks[existing.hookIndex] = { type: "command", command };
+      if (wantMatcher) existing.group.matcher = CONTINUITY_POST_TOOL_USE_MATCHER;
+      actions[event] = "update";
+      changed = true;
+      continue;
+    }
+    newConfig.hooks[event] = Array.isArray(newConfig.hooks[event]) ? newConfig.hooks[event] : [];
+    const group: any = { hooks: [{ type: "command", command }] };
+    if (event === "PostToolUse") group.matcher = CONTINUITY_POST_TOOL_USE_MATCHER;
+    newConfig.hooks[event].push(group);
+    actions[event] = "add";
+    changed = true;
+  }
+
+  return { changed, actions, newConfig };
+}
+
+/**
+ * Pure removal of the continuity pair — deletes ONLY our entries (marker
+ * substring match, exactly how install finds them), then prunes any group /
+ * event array / `hooks` key left empty by that removal. Never touches
+ * anything else.
+ */
+export function computeContinuityHookRemoval(config: any): {
+  changed: boolean;
+  actions: Record<ContinuityHookEvent, "remove" | "noop">;
+  newConfig: any;
+} {
+  const newConfig = JSON.parse(JSON.stringify(config ?? {}));
+  const actions = { PostToolUse: "noop", Stop: "noop" } as Record<ContinuityHookEvent, "remove" | "noop">;
+  let changed = false;
+
+  for (const event of CONTINUITY_HOOK_EVENTS) {
+    const existing = findContinuityEntry(newConfig, event);
+    if (!existing) continue;
+    existing.group.hooks.splice(existing.hookIndex, 1);
+    if (existing.group.hooks.length === 0) {
+      newConfig.hooks[event].splice(existing.groupIndex, 1);
+    }
+    if (newConfig.hooks[event].length === 0) {
+      delete newConfig.hooks[event];
+    }
+    actions[event] = "remove";
+    changed = true;
+  }
+  if (changed && newConfig.hooks && typeof newConfig.hooks === "object" && Object.keys(newConfig.hooks).length === 0) {
+    delete newConfig.hooks;
+  }
+  return { changed, actions, newConfig };
+}
+
+/**
+ * `flair doctor --fix` write path: register (or repair to current form) the
+ * continuity pair in ~/.claude/settings.json. Merge-safe read-parse-write,
+ * mirroring fixSessionStartHook — creates the file if absent, refuses on a
+ * file it cannot parse.
+ */
+export function fixContinuityCaptureHooks(
+  homeDir: string,
+  agentId: string | undefined,
+  flairUrl?: string,
+): { ok: boolean; path: string; message: string; changed: boolean } {
+  const path = join(homeDir, ".claude", "settings.json");
+  if (!agentId) {
+    return {
+      ok: false,
+      path,
+      changed: false,
+      message: "no agent id known — pass --agent <id> (or set FLAIR_AGENT_ID) so doctor knows which agent to wire the continuity hooks to",
+    };
+  }
+  if (!isHookCommandValueSafe(agentId)) {
+    return {
+      ok: false,
+      path,
+      changed: false,
+      message: `agent id '${agentId}' contains characters that cannot be safely written into a shell hook command (allowed: letters, digits, . _ : / -)`,
+    };
+  }
+  if (flairUrl != null && flairUrl !== "" && !isHookCommandValueSafe(flairUrl)) {
+    return {
+      ok: false,
+      path,
+      changed: false,
+      message: `Flair URL '${flairUrl}' contains characters that cannot be safely written into a shell hook command (allowed: letters, digits, . _ : / -)`,
+    };
+  }
+  try {
+    let config: any = {};
+    const raw = readTextFile(path);
+    if (raw && raw.trim()) config = JSON.parse(raw);
+    const { changed, newConfig } = computeContinuityHookInstall(config, agentId, flairUrl);
+    if (!changed) {
+      return { ok: true, path, changed: false, message: `continuity capture hooks already current in ${path}` };
+    }
+    mkdirSync(dirname(path), { recursive: true });
+    writeFileSync(path, JSON.stringify(newConfig, null, 2) + "\n");
+    return { ok: true, path, changed: true, message: `wired the continuity capture hooks (PostToolUse + Stop) in ${path} (agent '${agentId}')` };
+  } catch (err: unknown) {
+    const reason = err instanceof Error ? err.message : String(err);
+    return { ok: false, path, changed: false, message: `could not write ${path}: ${reason}` };
+  }
+}
+
+/**
+ * Symmetric removal path (`flair doctor --fix` when disabling / `flair hook
+ * uninstall --continuity`). A no-op when nothing is wired — never creates a
+ * file that didn't exist, refuses on a file it cannot parse.
+ */
+export function removeContinuityCaptureHooks(homeDir: string): { ok: boolean; path: string; message: string; changed: boolean } {
+  const path = join(homeDir, ".claude", "settings.json");
+  const raw = readTextFile(path);
+  if (!raw || !raw.trim()) {
+    return { ok: true, path, changed: false, message: `no ${path} — continuity capture hooks are not enabled` };
+  }
+  try {
+    const config = JSON.parse(raw);
+    const { changed, newConfig } = computeContinuityHookRemoval(config);
+    if (!changed) {
+      return { ok: true, path, changed: false, message: `no continuity capture hooks found in ${path} — nothing to remove` };
+    }
+    writeFileSync(path, JSON.stringify(newConfig, null, 2) + "\n");
+    return { ok: true, path, changed: true, message: `removed the continuity capture hooks (PostToolUse + Stop) from ${path}` };
+  } catch (err: unknown) {
+    const reason = err instanceof Error ? err.message : String(err);
+    return { ok: false, path, changed: false, message: `could not update ${path}: ${reason}` };
+  }
+}
+
 // ── shared helpers ──────────────────────────────────────────────────────────
 
 /**

--- a/src/hook-install.ts
+++ b/src/hook-install.ts
@@ -58,8 +58,15 @@ import { dirname, join } from "node:path";
 import {
   SESSION_START_HOOK_MARKER,
   buildSessionStartHookCommand,
+  buildContinuityCaptureHookCommand,
+  checkContinuityCaptureHooks,
+  computeContinuityHookInstall,
+  computeContinuityHookRemoval,
   hookCommandIsSilenced,
   isHookCommandValueSafe,
+  type ContinuityCaptureHookReport,
+  type ContinuityHookEvent,
+  type ContinuityMutationAction,
 } from "./doctor-client.js";
 
 // ── harness registry ────────────────────────────────────────────────────────
@@ -469,4 +476,178 @@ export function hookStatus(homeDir: string, harness: Harness): HookStatusResult 
     silenced: hookCommandIsSilenced(command),
     agentId: env.agentId, flairUrl: env.flairUrl, command, parseError: null,
   };
+}
+
+// ── continuity capture hooks (flair#1257 slice 2) ──────────────────────────
+//
+// The PostToolUse + Stop pair that auto-journals working state into the
+// ephemeral Memory tier (see packages/flair-mcp/src/continuity.ts for the
+// capture discipline). INSTALLING THIS PAIR IS THE OPT-IN — there is no env
+// flag — so it gets the same standalone, symmetric, dry-run-able command
+// surface as the SessionStart hook (`flair hook install|uninstall
+// --continuity`, wired in src/cli.ts), sharing this module's Sherlock
+// conditions: fail-closed on malformed settings.json, backup before any real
+// mutation, idempotent merge that never touches unrelated hooks/keys,
+// --dry-run computes the delta without writing (no backup either). The pure
+// mutation cores (computeContinuityHookInstall / computeContinuityHookRemoval)
+// live in src/doctor-client.ts next to the ONE command builder so `flair
+// doctor --fix` and this family cannot drift apart.
+
+/** Mirror of buildHookCommand for the continuity pair — delegates to the ONE
+ *  builder in doctor-client.ts. Throws on unrepresentable values;
+ *  installContinuityHooks() checks first and reports instead. */
+export function buildContinuityHookCommand(agentId: string, flairUrl: string): string {
+  return buildContinuityCaptureHookCommand(agentId, flairUrl);
+}
+
+export interface ContinuityMutationResult {
+  ok: boolean;
+  path: string;
+  harness: Harness;
+  dryRun: boolean;
+  message: string;
+  backupPath: string | null;
+  /** Per-event outcome ("add"/"update"/"remove"/"noop"), null on refusal. */
+  actions: Record<ContinuityHookEvent, ContinuityMutationAction | "remove"> | null;
+}
+
+/** Install (or repair to current form) the continuity capture pair. */
+export function installContinuityHooks(opts: InstallHookOptions): ContinuityMutationResult {
+  const { homeDir, harness, agentId, flairUrl } = opts;
+  const dryRun = !!opts.dryRun;
+  const path = hookSettingsPath(homeDir, harness);
+
+  for (const [label, value] of [["agent id", agentId], ["Flair URL", flairUrl]] as const) {
+    if (!isHookCommandValueSafe(value)) {
+      return {
+        ok: false, path, harness, dryRun,
+        message: `${label} '${value}' contains characters that cannot be safely written into a shell hook command (allowed: letters, digits, . _ : / -) — refusing to write it`,
+        backupPath: null, actions: null,
+      };
+    }
+  }
+
+  if (dryRun) {
+    const read = readSettingsFile(path);
+    if (read.parseError) {
+      return {
+        ok: false, path, harness, dryRun,
+        message: `${read.parseError} — dry run: nothing would be written until this is fixed`,
+        backupPath: null, actions: null,
+      };
+    }
+    const { changed, actions } = computeContinuityHookInstall(read.parsed ?? {}, agentId, flairUrl);
+    const message = changed
+      ? `would wire the continuity capture hooks (PostToolUse: ${actions.PostToolUse}, Stop: ${actions.Stop}) in ${path} (dry run — nothing written)`
+      : `continuity capture hooks already current in ${path} — no changes`;
+    return { ok: true, path, harness, dryRun, message, backupPath: null, actions };
+  }
+
+  let backupPath: string | null = null;
+  if (existsSync(path)) {
+    try {
+      backupPath = takeBackup(path);
+    } catch (err: unknown) {
+      const reason = err instanceof Error ? err.message : String(err);
+      return {
+        ok: false, path, harness, dryRun,
+        message: `could not back up ${path} before mutating it: ${reason} — refusing to touch it`,
+        backupPath: null, actions: null,
+      };
+    }
+  }
+
+  const read = readSettingsFile(path);
+  if (read.parseError) {
+    return {
+      ok: false, path, harness, dryRun,
+      message: `${read.parseError} — refusing to modify a file we can't safely parse. Original left untouched at ${path}` +
+        (backupPath ? `; backup copy at ${backupPath}.` : "."),
+      backupPath, actions: null,
+    };
+  }
+
+  const { changed, actions, newConfig } = computeContinuityHookInstall(read.parsed ?? {}, agentId, flairUrl);
+  if (!changed) {
+    return { ok: true, path, harness, dryRun, message: `continuity capture hooks already current in ${path}`, backupPath, actions };
+  }
+
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, JSON.stringify(newConfig, null, 2) + "\n");
+  return {
+    ok: true, path, harness, dryRun,
+    message: `wired the continuity capture hooks (PostToolUse: ${actions.PostToolUse}, Stop: ${actions.Stop}) in ${path}`,
+    backupPath, actions,
+  };
+}
+
+/** Symmetric removal of the continuity pair — only ours, everything else in
+ *  the file left untouched. A no-op when nothing is installed. */
+export function uninstallContinuityHooks(opts: UninstallHookOptions): ContinuityMutationResult {
+  const { homeDir, harness } = opts;
+  const dryRun = !!opts.dryRun;
+  const path = hookSettingsPath(homeDir, harness);
+
+  if (dryRun) {
+    const read = readSettingsFile(path);
+    if (read.parseError) {
+      return {
+        ok: false, path, harness, dryRun,
+        message: `${read.parseError} — dry run: nothing would be removed until this is fixed`,
+        backupPath: null, actions: null,
+      };
+    }
+    const { changed, actions } = computeContinuityHookRemoval(read.parsed ?? {});
+    const message = changed
+      ? `would remove the continuity capture hooks (PostToolUse: ${actions.PostToolUse}, Stop: ${actions.Stop}) from ${path} (dry run — nothing written)`
+      : `no continuity capture hooks found in ${path} — nothing to remove`;
+    return { ok: true, path, harness, dryRun, message, backupPath: null, actions };
+  }
+
+  let backupPath: string | null = null;
+  if (existsSync(path)) {
+    try {
+      backupPath = takeBackup(path);
+    } catch (err: unknown) {
+      const reason = err instanceof Error ? err.message : String(err);
+      return {
+        ok: false, path, harness, dryRun,
+        message: `could not back up ${path} before mutating it: ${reason} — refusing to touch it`,
+        backupPath: null, actions: null,
+      };
+    }
+  }
+
+  const read = readSettingsFile(path);
+  if (read.parseError) {
+    return {
+      ok: false, path, harness, dryRun,
+      message: `${read.parseError} — refusing to modify a file we can't safely parse. Original left untouched at ${path}` +
+        (backupPath ? `; backup copy at ${backupPath}.` : "."),
+      backupPath, actions: null,
+    };
+  }
+
+  const { changed, actions, newConfig } = computeContinuityHookRemoval(read.parsed ?? {});
+  if (!changed) {
+    return { ok: true, path, harness, dryRun, message: `no continuity capture hooks found in ${path} — nothing to remove`, backupPath, actions };
+  }
+
+  writeFileSync(path, JSON.stringify(newConfig, null, 2) + "\n");
+  return {
+    ok: true, path, harness, dryRun,
+    message: `removed the continuity capture hooks (PostToolUse + Stop) from ${path}`,
+    backupPath, actions,
+  };
+}
+
+/** Read-only continuity status for `flair hook status` — the same report
+ *  doctor's check consumes, resolved through the harness's settings path. */
+export function continuityHookStatus(homeDir: string, harness: Harness): ContinuityCaptureHookReport {
+  // hookSettingsPath and checkContinuityCaptureHooks both resolve
+  // ~/.claude/settings.json from homeDir; asserting through the harness
+  // registry keeps a future second harness from silently reading the wrong
+  // file.
+  void hookSettingsPath(homeDir, harness);
+  return checkContinuityCaptureHooks(homeDir);
 }

--- a/test/unit/continuity-hook.test.ts
+++ b/test/unit/continuity-hook.test.ts
@@ -1,0 +1,691 @@
+/**
+ * continuity-hook.test.ts — flair#1257 slice 2: the Claude Code continuity
+ * hook adapter (capture bin + SessionStart resume path), tested against the
+ * merged acceptance set on the issue (S1–S10) and Sherlock's capture-content
+ * rulings.
+ *
+ * LEAK-GUARD PROTOCOL: every filter/bound test here has a POSITIVE CONTROL —
+ * the same marker planted in the field that IS allowed to flow (a Bash
+ * description, an in-bound Stop excerpt, a file path) must be observed in the
+ * write body. Without the control, a capture bin that stopped writing
+ * anything at all would pass every "marker absent" assertion (an unrun check
+ * must not look like a pass). Each guard was additionally mutation-checked
+ * during development (filter/bound broken → red, restored → green); the
+ * results are recorded in the PR.
+ *
+ * Everything is hermetic: injected clients (zero network), per-test temp dirs
+ * for the pointer/state files (FLAIR_SESSION_DIR / explicit sessionDir deps —
+ * the homeOverride discipline; no test ever touches the real ~/.flair).
+ */
+
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, readFileSync, rmSync, statSync, existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+// NOTE (CI ordering): this file runs in the ROOT `bun test test/unit/` lane,
+// which executes BEFORE flair-client's dist/ is built. Everything imported
+// here is therefore dist-free by construction: continuity.ts imports only
+// node builtins, and continuity-capture-hook.ts imports @tpsdev-ai/flair-client
+// LAZILY (only the real binary's default client factory ever resolves it).
+// The runHook end-to-end resume tests live in
+// packages/flair-mcp/test/continuity-resume.test.ts — that lane builds
+// flair-client first. See the matching note in test/unit/hook-install.test.ts.
+import {
+  CAPTURE_BOUND_CHARS,
+  CONTINUITY_TAG_PREFIX,
+  MUTATING_TOOLS,
+  buildJournalRow,
+  buildResumeHint,
+  bumpSeq,
+  continuityTag,
+  discoverResume,
+  hardBound,
+  isSafeFileId,
+  planCapture,
+  pointerPath,
+  prepareContinuityBoot,
+  readPointer,
+  readState,
+  seedSession,
+  statePath,
+  type ContinuityClient,
+  type SessionPointer,
+} from "../../packages/flair-mcp/src/continuity.ts";
+import { runCapture, type CaptureDeps } from "../../packages/flair-mcp/src/continuity-capture-hook.ts";
+
+const AGENT = "agent-a";
+const HARNESS_SESSION = "claude-sess-1";
+
+const ORIGINAL_ENV = {
+  FLAIR_AGENT_ID: process.env.FLAIR_AGENT_ID,
+  FLAIR_SESSION_DIR: process.env.FLAIR_SESSION_DIR,
+  FLAIR_CONTINUITY_TIMEOUT_MS: process.env.FLAIR_CONTINUITY_TIMEOUT_MS,
+};
+
+let dir: string;
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), "flair-continuity-test-"));
+  // Belt-and-suspenders: even a code path that ignores injected deps and
+  // falls back to env must land in the temp dir, never the real ~/.flair.
+  process.env.FLAIR_SESSION_DIR = dir;
+  delete process.env.FLAIR_AGENT_ID;
+  delete process.env.FLAIR_CONTINUITY_TIMEOUT_MS;
+});
+
+afterEach(() => {
+  for (const [key, value] of Object.entries(ORIGINAL_ENV)) {
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+  rmSync(dir, { recursive: true, force: true });
+});
+
+/** A client that records every request and answers from a canned map. */
+function recordingClient(respond?: (method: string, path: string, body: unknown) => unknown) {
+  const calls: Array<{ method: string; path: string; body: any }> = [];
+  const client: ContinuityClient = {
+    request: async (method: string, path: string, body?: unknown) => {
+      calls.push({ method, path, body });
+      return (respond ? respond(method, path, body) : {}) as any;
+    },
+  };
+  return { calls, client };
+}
+
+function captureDeps(overrides: Partial<CaptureDeps> = {}) {
+  const { calls, client } = recordingClient();
+  const warnings: string[] = [];
+  const deps: CaptureDeps = {
+    env: { FLAIR_AGENT_ID: AGENT },
+    sessionDir: dir,
+    makeClient: () => client,
+    warn: (m) => warnings.push(m),
+    ...overrides,
+  };
+  return { calls, client, warnings, deps };
+}
+
+function postToolUse(tool: string, toolInput: Record<string, unknown>, extra: Record<string, unknown> = {}): string {
+  return JSON.stringify({
+    hook_event_name: "PostToolUse",
+    session_id: HARNESS_SESSION,
+    tool_name: tool,
+    tool_input: toolInput,
+    ...extra,
+  });
+}
+
+function stopInput(fields: Record<string, unknown>): string {
+  return JSON.stringify({ hook_event_name: "Stop", session_id: HARNESS_SESSION, ...fields });
+}
+
+/** Journal row shape for resume stubs. */
+function row(opts: {
+  seq?: number;
+  processUUID?: string;
+  sessionId: string;
+  createdAt?: string;
+  expiresAt?: string;
+  content?: string;
+}) {
+  return {
+    id: `${AGENT}-${Math.random().toString(36).slice(2)}`,
+    agentId: AGENT,
+    content: opts.content ?? "bash: something",
+    durability: "ephemeral",
+    visibility: "private",
+    tags: [continuityTag(opts.sessionId)],
+    sessionId: opts.sessionId,
+    createdAt: opts.createdAt ?? "2026-08-19T10:00:00.000Z",
+    expiresAt: opts.expiresAt ?? "2999-01-01T00:00:00.000Z",
+    meta: {
+      seq: opts.seq ?? 1,
+      processUUID: opts.processUUID ?? "proc-1",
+      sessionId: opts.sessionId,
+    },
+  };
+}
+
+// ─── capture discipline (S6 + Sherlock rulings) ─────────────────────────────
+
+describe("capture: mutating-tool allowlist", () => {
+  test("the allowlist is the exact closed set the spec names (auditable)", () => {
+    expect([...MUTATING_TOOLS]).toEqual(["Write", "Edit", "NotebookEdit", "Bash"]);
+  });
+
+  test("a read-only tool fires ⇒ ZERO writes, no client ever built, no seq burned", async () => {
+    seedSession(dir, AGENT, HARNESS_SESSION);
+    for (const tool of ["Read", "Grep", "Glob", "WebFetch", "WebSearch", "TotallyUnknownTool"]) {
+      const outcome = await runCapture(postToolUse(tool, { file_path: "/x" }), {
+        env: { FLAIR_AGENT_ID: AGENT },
+        sessionDir: dir,
+        makeClient: () => {
+          throw new Error("client must not be constructed for a read-only tool");
+        },
+      });
+      expect(outcome.wrote).toBe(false);
+      expect(outcome.reason).toBe("not-capturable");
+    }
+    // No seq was consumed by any of the skipped fires.
+    expect(readState(dir, AGENT, HARNESS_SESSION)?.seq).toBe(0);
+  });
+
+  test("a capturable fire writes EXACTLY one row", async () => {
+    seedSession(dir, AGENT, HARNESS_SESSION);
+    const { calls, deps } = captureDeps();
+    const outcome = await runCapture(postToolUse("Write", { file_path: "/tmp/a.ts" }), deps);
+    expect(outcome.wrote).toBe(true);
+    expect(calls).toHaveLength(1);
+    expect(calls[0].method).toBe("PUT");
+    expect(calls[0].path.startsWith("/Memory/")).toBe(true);
+  });
+});
+
+describe("capture: Bash journals the description ONLY — never the command (leak-guard)", () => {
+  const CMD_MARKER = "LEAKMARKER_ARGV_c4f9";
+
+  test("command string planted with a marker never reaches the write body", async () => {
+    seedSession(dir, AGENT, HARNESS_SESSION);
+    const { calls, deps } = captureDeps();
+    await runCapture(
+      postToolUse("Bash", {
+        command: `export TOKEN=${CMD_MARKER}; ./deploy.sh --now`,
+        description: "Deploy the release",
+      }),
+      deps,
+    );
+    expect(calls).toHaveLength(1);
+    const bodyJson = JSON.stringify(calls[0].body);
+    expect(bodyJson).not.toContain(CMD_MARKER);
+    expect(calls[0].body.content).toBe("bash: Deploy the release");
+  });
+
+  test("POSITIVE CONTROL: the same marker in the description field IS captured (the fixture can express the leak)", async () => {
+    seedSession(dir, AGENT, HARNESS_SESSION);
+    const { calls, deps } = captureDeps();
+    await runCapture(postToolUse("Bash", { command: "true", description: `note ${CMD_MARKER}` }), deps);
+    expect(JSON.stringify(calls[0].body)).toContain(CMD_MARKER);
+  });
+
+  test("no description ⇒ the literal placeholder — NEVER a fallback to the command", async () => {
+    seedSession(dir, AGENT, HARNESS_SESSION);
+    const { calls, deps } = captureDeps();
+    await runCapture(postToolUse("Bash", { command: `secret-cmd ${CMD_MARKER}` }), deps);
+    expect(calls[0].body.content).toBe("bash: (no description)");
+    expect(JSON.stringify(calls[0].body)).not.toContain(CMD_MARKER);
+  });
+});
+
+describe("capture: Write/Edit/NotebookEdit journal the file path only — never content/diffs (leak-guard)", () => {
+  const CONTENT_MARKER = "LEAKMARKER_CONTENT_8b2d";
+
+  test("Write: planted file content never reaches the write body; the path does (its own positive control)", async () => {
+    seedSession(dir, AGENT, HARNESS_SESSION);
+    const { calls, deps } = captureDeps();
+    await runCapture(
+      postToolUse("Write", { file_path: "/tmp/project/config.ts", content: `API_KEY=${CONTENT_MARKER}`, file_text: `also ${CONTENT_MARKER}` }),
+      deps,
+    );
+    const bodyJson = JSON.stringify(calls[0].body);
+    expect(bodyJson).not.toContain(CONTENT_MARKER);
+    expect(calls[0].body.content).toBe("write: /tmp/project/config.ts");
+  });
+
+  test("Edit: old_string/new_string (the diff) never reach the write body", async () => {
+    seedSession(dir, AGENT, HARNESS_SESSION);
+    const { calls, deps } = captureDeps();
+    await runCapture(
+      postToolUse("Edit", { file_path: "/tmp/a.ts", old_string: `x=${CONTENT_MARKER}`, new_string: `y=${CONTENT_MARKER}` }),
+      deps,
+    );
+    const bodyJson = JSON.stringify(calls[0].body);
+    expect(bodyJson).not.toContain(CONTENT_MARKER);
+    expect(calls[0].body.content).toBe("edit: /tmp/a.ts");
+  });
+
+  test("NotebookEdit: path only (notebook_path or file_path spelling), never the cell source", async () => {
+    seedSession(dir, AGENT, HARNESS_SESSION);
+    const { calls, deps } = captureDeps();
+    await runCapture(
+      postToolUse("NotebookEdit", { notebook_path: "/tmp/nb.ipynb", new_source: `cell ${CONTENT_MARKER}` }),
+      deps,
+    );
+    expect(JSON.stringify(calls[0].body)).not.toContain(CONTENT_MARKER);
+    expect(calls[0].body.content).toBe("notebook-edit: /tmp/nb.ipynb");
+  });
+
+  test("raw hook JSON fields (tool_result, transcript_path, cwd) are never copied into the row", async () => {
+    seedSession(dir, AGENT, HARNESS_SESSION);
+    const { calls, deps } = captureDeps();
+    await runCapture(
+      postToolUse(
+        "Write",
+        { file_path: "/tmp/a.ts" },
+        {
+          tool_result: `raw output ${CONTENT_MARKER}`,
+          tool_response: { out: `more ${CONTENT_MARKER}` },
+          transcript_path: `/private/${CONTENT_MARKER}.jsonl`,
+          cwd: `/work/${CONTENT_MARKER}`,
+        },
+      ),
+      deps,
+    );
+    expect(JSON.stringify(calls[0].body)).not.toContain(CONTENT_MARKER);
+  });
+});
+
+describe("capture: Stop excerpt — bounded assistant-chosen prose (Sherlock ruling)", () => {
+  test("last_assistant_message becomes a bounded excerpt", async () => {
+    seedSession(dir, AGENT, HARNESS_SESSION);
+    const { calls, deps } = captureDeps();
+    await runCapture(stopInput({ last_assistant_message: "Merged the PR; next: notify the team." }), deps);
+    expect(calls[0].body.content).toBe("stop: Merged the PR; next: notify the team.");
+    expect(calls[0].body.meta.hook).toBe("Stop");
+  });
+
+  test("a dedicated summary field is PREFERRED over the raw final text", async () => {
+    seedSession(dir, AGENT, HARNESS_SESSION);
+    const { calls, deps } = captureDeps();
+    await runCapture(
+      stopInput({ summary: "was about to merge, waiting on review", last_assistant_message: "long prose that should lose" }),
+      deps,
+    );
+    expect(calls[0].body.content).toBe("stop: was about to merge, waiting on review");
+    expect(JSON.stringify(calls[0].body)).not.toContain("should lose");
+  });
+
+  test("HARD 400-char truncate with a visible ellipsis: a secret-shaped token BEYOND the bound never reaches the body", async () => {
+    // The bound is load-bearing (capture-full-text is a regression) — this
+    // test is the tripwire for that regression.
+    const SECRET_BEYOND = "sk_live_LEAKMARKER_BEYOND_400_7e1a";
+    const padding = "x".repeat(CAPTURE_BOUND_CHARS + 10);
+    seedSession(dir, AGENT, HARNESS_SESSION);
+    const { calls, deps } = captureDeps();
+    await runCapture(stopInput({ last_assistant_message: `${padding} ${SECRET_BEYOND}` }), deps);
+    const content: string = calls[0].body.content;
+    expect(JSON.stringify(calls[0].body)).not.toContain(SECRET_BEYOND);
+    expect(content.length).toBe(CAPTURE_BOUND_CHARS + 1); // 400 chars + the ellipsis
+    expect(content.endsWith("…")).toBe(true);
+  });
+
+  test("POSITIVE CONTROL: the same token INSIDE the first 400 chars IS captured (the bound, not a scrubber, is the control)", async () => {
+    const SECRET_WITHIN = "sk_live_LEAKMARKER_WITHIN_400_7e1a";
+    seedSession(dir, AGENT, HARNESS_SESSION);
+    const { calls, deps } = captureDeps();
+    await runCapture(stopInput({ last_assistant_message: `Done. ${SECRET_WITHIN} was already user-visible prose.` }), deps);
+    expect(JSON.stringify(calls[0].body)).toContain(SECRET_WITHIN);
+  });
+
+  test("empty / missing / whitespace final text ⇒ NO journal row (no placeholder, no tool-result synthesis)", async () => {
+    seedSession(dir, AGENT, HARNESS_SESSION);
+    for (const fields of [{}, { last_assistant_message: "" }, { last_assistant_message: "   \n " }, { last_assistant_message: 42 }]) {
+      const { calls, deps } = captureDeps();
+      const outcome = await runCapture(stopInput(fields), deps);
+      expect(outcome.wrote).toBe(false);
+      expect(calls).toHaveLength(0);
+    }
+    expect(readState(dir, AGENT, HARNESS_SESSION)?.seq).toBe(0);
+  });
+
+  test("hardBound is a single uniform bound (no variable-length excerpts)", () => {
+    expect(hardBound("short")).toBe("short");
+    const long = "y".repeat(CAPTURE_BOUND_CHARS * 3);
+    expect(hardBound(long).length).toBe(CAPTURE_BOUND_CHARS + 1);
+    expect(hardBound(long).endsWith("…")).toBe(true);
+  });
+});
+
+describe("capture: row shape — the S6 invariants on EVERY write body", () => {
+  test("durability ephemeral, visibility private EXPLICIT, one continuity tag, meta {seq, processUUID, sessionId, hook, tool?}", async () => {
+    const seeded = seedSession(dir, AGENT, HARNESS_SESSION);
+    const { calls, deps } = captureDeps();
+    await runCapture(postToolUse("Bash", { description: "step one" }), deps);
+    await runCapture(postToolUse("Edit", { file_path: "/tmp/b.ts" }), deps);
+    await runCapture(stopInput({ last_assistant_message: "wrapping up" }), deps);
+
+    expect(calls).toHaveLength(3);
+    for (const call of calls) {
+      const body = call.body;
+      expect(body.durability).toBe("ephemeral");
+      // EXPLICIT private — never omitted to ride the durability-keyed default
+      // (defense-in-depth above the #1261 server guard).
+      expect(body.visibility).toBe("private");
+      expect(body.tags).toEqual([`${CONTINUITY_TAG_PREFIX}${seeded.sessionId}`]);
+      expect(body.sessionId).toBe(seeded.sessionId);
+      expect(body.agentId).toBe(AGENT);
+      expect(body.meta.processUUID).toBe(seeded.processUUID);
+      expect(body.meta.sessionId).toBe(seeded.sessionId);
+      expect(typeof body.meta.seq).toBe("number");
+    }
+    expect(calls[0].body.meta.hook).toBe("PostToolUse");
+    expect(calls[0].body.meta.tool).toBe("Bash");
+    expect(calls[1].body.meta.tool).toBe("Edit");
+    expect(calls[2].body.meta.hook).toBe("Stop");
+    expect(calls[2].body.meta.tool).toBeUndefined();
+  });
+
+  test("seq is monotonic across fires and persisted in the state file (atomic increment)", async () => {
+    seedSession(dir, AGENT, HARNESS_SESSION);
+    const { calls, deps } = captureDeps();
+    await runCapture(postToolUse("Bash", { description: "one" }), deps);
+    await runCapture(postToolUse("Bash", { description: "two" }), deps);
+    await runCapture(postToolUse("Bash", { description: "three" }), deps);
+    expect(calls.map((c) => c.body.meta.seq)).toEqual([1, 2, 3]);
+    expect(readState(dir, AGENT, HARNESS_SESSION)?.seq).toBe(3);
+  });
+
+  test("even a FAILED write burns its seq — gaps are fine, duplicates are not", async () => {
+    seedSession(dir, AGENT, HARNESS_SESSION);
+    const failing = captureDeps({
+      makeClient: () => ({
+        request: async () => {
+          throw new Error("HTTP 500");
+        },
+      }),
+    });
+    await runCapture(postToolUse("Bash", { description: "will fail" }), failing.deps);
+    const ok = captureDeps();
+    await runCapture(postToolUse("Bash", { description: "will land" }), ok.deps);
+    expect(ok.calls[0].body.meta.seq).toBe(2);
+  });
+});
+
+describe("capture: fail-open (S9/S10 — a hook must never block the turn)", () => {
+  test("malformed hook JSON ⇒ ZERO writes, zero client construction, clean return (no partial extraction)", async () => {
+    seedSession(dir, AGENT, HARNESS_SESSION);
+    for (const raw of ["not-json{{{", "", "null", "[1,2,3]", '"just a string"', "42"]) {
+      const outcome = await runCapture(raw, {
+        env: { FLAIR_AGENT_ID: AGENT },
+        sessionDir: dir,
+        makeClient: () => {
+          throw new Error("client must not be constructed for malformed input");
+        },
+      });
+      expect(outcome.wrote).toBe(false);
+      expect(outcome.reason).toBe("malformed-input");
+    }
+    expect(readState(dir, AGENT, HARNESS_SESSION)?.seq).toBe(0);
+  });
+
+  test("missing or unsafe session_id ⇒ zero writes (path-traversal shapes refused)", async () => {
+    seedSession(dir, AGENT, HARNESS_SESSION);
+    for (const sid of [undefined, "", "../../evil", "a/b", "a b", 42]) {
+      const { calls, deps } = captureDeps();
+      const outcome = await runCapture(
+        JSON.stringify({ hook_event_name: "Stop", session_id: sid, last_assistant_message: "text" }),
+        deps,
+      );
+      expect(outcome.wrote).toBe(false);
+      expect(calls).toHaveLength(0);
+    }
+  });
+
+  test("no FLAIR_AGENT_ID ⇒ zero writes", async () => {
+    seedSession(dir, AGENT, HARNESS_SESSION);
+    const { calls, deps } = captureDeps({ env: {} });
+    const outcome = await runCapture(stopInput({ last_assistant_message: "text" }), deps);
+    expect(outcome.wrote).toBe(false);
+    expect(outcome.reason).toBe("no-agent-id");
+    expect(calls).toHaveLength(0);
+  });
+
+  test("state file missing (continuity never seeded) ⇒ zero writes", async () => {
+    const { calls, deps } = captureDeps();
+    const outcome = await runCapture(stopInput({ last_assistant_message: "text" }), deps);
+    expect(outcome.wrote).toBe(false);
+    expect(outcome.reason).toBe("no-state");
+    expect(calls).toHaveLength(0);
+  });
+
+  test("#1261 guard 400 on the write path ⇒ one debug warning, clean return, nothing stored client-side", async () => {
+    seedSession(dir, AGENT, HARNESS_SESSION);
+    const attempts: unknown[] = [];
+    const { warnings, deps } = captureDeps({
+      makeClient: () => ({
+        request: async (_m: string, _p: string, body?: unknown) => {
+          attempts.push(body);
+          throw new Error('PUT /Memory/x -> 400: {"error":"invalid_visibility_for_durability"}');
+        },
+      }),
+    });
+    const outcome = await runCapture(postToolUse("Bash", { description: "guarded" }), deps);
+    expect(outcome.wrote).toBe(false);
+    expect(outcome.reason).toBe("write-failed");
+    expect(attempts).toHaveLength(1); // the write was attempted once — no retry storm
+    expect(warnings).toHaveLength(1); // exactly one debug-level line
+  });
+
+  test("Flair unreachable ⇒ same fail-open shape, never a throw", async () => {
+    seedSession(dir, AGENT, HARNESS_SESSION);
+    const { warnings, deps } = captureDeps({
+      makeClient: () => ({
+        request: async () => {
+          throw new TypeError("fetch failed");
+        },
+      }),
+    });
+    const outcome = await runCapture(postToolUse("Write", { file_path: "/tmp/x" }), deps);
+    expect(outcome.wrote).toBe(false);
+    expect(warnings).toHaveLength(1);
+  });
+
+  test("a hung Flair is bounded by the 2s-class write timeout — the turn is never held hostage", async () => {
+    seedSession(dir, AGENT, HARNESS_SESSION);
+    const { warnings, deps } = captureDeps({
+      env: { FLAIR_AGENT_ID: AGENT, FLAIR_CONTINUITY_TIMEOUT_MS: "250" },
+      makeClient: () => ({
+        request: () => new Promise(() => {}), // never resolves
+      }),
+    });
+    const start = Date.now();
+    const outcome = await runCapture(postToolUse("Bash", { description: "hang" }), deps);
+    const elapsed = Date.now() - start;
+    expect(outcome.wrote).toBe(false);
+    expect(outcome.reason).toBe("write-failed");
+    expect(elapsed).toBeLessThan(2000);
+    expect(warnings).toHaveLength(1);
+  });
+});
+
+// ─── pointer / state files ──────────────────────────────────────────────────
+
+describe("session files: 0600 files in a 0700 dir, IDs only — never journal content", () => {
+  test("seedSession creates pointer + state with owner-only modes", () => {
+    const state = seedSession(dir, AGENT, HARNESS_SESSION);
+    const sub = join(dir); // FLAIR_SESSION_DIR IS the session dir in tests
+    expect((statSync(statePath(sub, AGENT, HARNESS_SESSION)).mode & 0o777)).toBe(0o600);
+    expect((statSync(pointerPath(sub, AGENT)).mode & 0o777)).toBe(0o600);
+    const pointer = readPointer(sub, AGENT);
+    expect(pointer?.sessionId).toBe(state.sessionId);
+    expect(pointer?.processUUID).toBe(state.processUUID);
+    expect(readState(sub, AGENT, HARNESS_SESSION)?.seq).toBe(0);
+  });
+
+  test("the session dir minted by seedSession is 0700 when it does not pre-exist", () => {
+    const fresh = join(dir, "nested", "session");
+    seedSession(fresh, AGENT, HARNESS_SESSION);
+    expect((statSync(fresh).mode & 0o777)).toBe(0o700);
+  });
+
+  test("bumpSeq without a state file returns null (capture then journals nothing)", () => {
+    expect(bumpSeq(dir, AGENT, "never-seeded")).toBeNull();
+  });
+
+  test("isSafeFileId refuses separators, whitespace and oversize", () => {
+    expect(isSafeFileId("abc-123.DEF_x")).toBe(true);
+    expect(isSafeFileId("a/b")).toBe(false);
+    expect(isSafeFileId("a\\b")).toBe(false);
+    expect(isSafeFileId("a b")).toBe(false);
+    expect(isSafeFileId("")).toBe(false);
+    expect(isSafeFileId("x".repeat(200))).toBe(false);
+    expect(isSafeFileId(undefined)).toBe(false);
+  });
+});
+
+// ─── resume discovery (S1/S2/S4/S8) ─────────────────────────────────────────
+
+describe("resume: pointer fast path", () => {
+  const PRIOR: SessionPointer = { sessionId: "cs-prior", processUUID: "proc-prior", updatedAt: "2026-08-19T09:00:00.000Z" };
+
+  test("searches exactly the prior session's tag and returns entries in seq order", async () => {
+    const rows = [
+      row({ seq: 3, sessionId: "cs-prior", createdAt: "2026-08-19T10:02:00.000Z" }),
+      row({ seq: 1, sessionId: "cs-prior", createdAt: "2026-08-19T10:00:00.000Z" }),
+      row({ seq: 2, sessionId: "cs-prior", createdAt: "2026-08-19T10:01:00.000Z" }),
+    ];
+    const { calls, client } = recordingClient(() => rows);
+    const result = await discoverResume(client, AGENT, PRIOR);
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0].path).toBe("/Memory/search_by_conditions");
+    const conditions = calls[0].body.conditions as Array<{ search_attribute: string; search_value: unknown }>;
+    expect(conditions.some((c) => c.search_attribute === "tags" && c.search_value === continuityTag("cs-prior"))).toBe(true);
+    expect(conditions.some((c) => c.search_attribute === "durability" && c.search_value === "ephemeral")).toBe(true);
+    expect(conditions.some((c) => c.search_attribute === "agentId" && c.search_value === AGENT)).toBe(true);
+
+    expect(result.sessionId).toBe("cs-prior");
+    expect(result.entries.map((e) => e.seq)).toEqual([1, 2, 3]);
+  });
+
+  test("expired rows are excluded even when the server still returns them (reap is async — S4)", async () => {
+    const rows = [
+      row({ seq: 1, sessionId: "cs-prior", expiresAt: "2026-08-18T00:00:00.000Z" }), // past — reaped-or-not, never surfaced
+      row({ seq: 2, sessionId: "cs-prior", expiresAt: "2999-01-01T00:00:00.000Z" }),
+    ];
+    const { client } = recordingClient(() => rows);
+    const result = await discoverResume(client, AGENT, PRIOR, new Date("2026-08-19T12:00:00.000Z"));
+    expect(result.entries.map((e) => e.seq)).toEqual([2]);
+  });
+
+  test("all rows expired ⇒ zero entries ⇒ null hint (expiry is normal, not data loss)", async () => {
+    const rows = [row({ seq: 1, sessionId: "cs-prior", expiresAt: "2026-08-18T00:00:00.000Z" })];
+    const { client } = recordingClient(() => rows);
+    const result = await discoverResume(client, AGENT, PRIOR, new Date("2026-08-19T12:00:00.000Z"));
+    expect(result.entries).toHaveLength(0);
+    expect(buildResumeHint(result)).toBeNull();
+  });
+
+  test("Flair unreachable ⇒ zero entries, never a throw", async () => {
+    const client: ContinuityClient = {
+      request: async () => {
+        throw new TypeError("fetch failed");
+      },
+    };
+    const result = await discoverResume(client, AGENT, PRIOR);
+    expect(result.entries).toHaveLength(0);
+    expect(result.sessionId).toBeNull();
+  });
+});
+
+describe("resume: agentId-wide fallback disambiguated by processUUID (S8)", () => {
+  test("two interleaved processes ⇒ ONLY the most recent process's entries, never an interleave", async () => {
+    const rows = [
+      row({ seq: 1, processUUID: "proc-old", sessionId: "cs-old", createdAt: "2026-08-19T08:00:00.000Z" }),
+      row({ seq: 1, processUUID: "proc-new", sessionId: "cs-new", createdAt: "2026-08-19T10:00:00.000Z" }),
+      row({ seq: 2, processUUID: "proc-old", sessionId: "cs-old", createdAt: "2026-08-19T08:01:00.000Z" }),
+      row({ seq: 2, processUUID: "proc-new", sessionId: "cs-new", createdAt: "2026-08-19T10:01:00.000Z" }),
+    ];
+    const { calls, client } = recordingClient(() => rows);
+    const result = await discoverResume(client, AGENT, null);
+
+    // agentId-wide: no tag condition on the fallback search.
+    const conditions = calls[0].body.conditions as Array<{ search_attribute: string }>;
+    expect(conditions.some((c) => c.search_attribute === "tags")).toBe(false);
+
+    expect(result.sessionId).toBe("cs-new");
+    expect(result.entries.map((e) => e.processUUID)).toEqual(["proc-new", "proc-new"]);
+    expect(result.entries.map((e) => e.seq)).toEqual([1, 2]);
+  });
+
+  test("rows without a processUUID are unattributable and never guessed into a reconstruction", async () => {
+    const orphan = row({ seq: 9, sessionId: "cs-x" }) as any;
+    delete orphan.meta.processUUID;
+    const good = row({ seq: 1, processUUID: "proc-a", sessionId: "cs-a" });
+    const { client } = recordingClient(() => [orphan, good]);
+    const result = await discoverResume(client, AGENT, null);
+    expect(result.entries.map((e) => e.seq)).toEqual([1]);
+  });
+
+  test("no rows at all (true cold start, S1) ⇒ zero entries, null hint", async () => {
+    const { client } = recordingClient(() => []);
+    const result = await discoverResume(client, AGENT, null);
+    expect(result.entries).toHaveLength(0);
+    expect(buildResumeHint(result)).toBeNull();
+  });
+});
+
+describe("resume hint: ONE line, count + tag, NEVER journal content (S10)", () => {
+  test("hint is a single line naming the count and the search tag", () => {
+    const hint = buildResumeHint({
+      entries: [
+        { id: "1", seq: 1, processUUID: "p", sessionId: "cs-prior", createdAt: "t" },
+        { id: "2", seq: 2, processUUID: "p", sessionId: "cs-prior", createdAt: "t" },
+      ],
+      sessionId: "cs-prior",
+    });
+    expect(hint).toBeTruthy();
+    expect(hint!.includes("\n")).toBe(false);
+    expect(hint).toContain("2");
+    expect(hint).toContain(continuityTag("cs-prior"));
+  });
+
+  test("zero entries ⇒ null (no hint at all — not an empty line, not a warning)", () => {
+    expect(buildResumeHint({ entries: [], sessionId: null })).toBeNull();
+    expect(buildResumeHint({ entries: [], sessionId: "cs-x" })).toBeNull();
+  });
+});
+
+// ─── the SessionStart boot plumbing (S1/S7 local half) ─────────────────────
+// The runHook end-to-end tests (hint injection, compaction, fail-open through
+// the hook's stdout contract) live in
+// packages/flair-mcp/test/continuity-resume.test.ts — see the CI-ordering
+// note at the top of this file.
+
+describe("prepareContinuityBoot (fs half of the resume path)", () => {
+  test("startup: reads the prior pointer BEFORE minting, then rotates and seeds capture state", () => {
+    const prior = seedSession(dir, AGENT, "claude-old-sess");
+    const boot = prepareContinuityBoot({ session_id: "claude-new-sess", source: "startup" }, AGENT, { FLAIR_SESSION_DIR: dir });
+    expect(boot.active).toBe(true);
+    expect(boot.priorPointer?.sessionId).toBe(prior.sessionId);
+    const rotated = readPointer(dir, AGENT);
+    expect(rotated?.sessionId).not.toBe(prior.sessionId);
+    expect(readState(dir, AGENT, "claude-new-sess")?.seq).toBe(0);
+  });
+
+  test("cold start: no pointer ⇒ priorPointer null (fallback search territory), files seeded", () => {
+    const boot = prepareContinuityBoot({ session_id: "claude-new-sess", source: "startup" }, AGENT, { FLAIR_SESSION_DIR: dir });
+    expect(boot.active).toBe(true);
+    expect(boot.priorPointer).toBeNull();
+    expect(readPointer(dir, AGENT)).not.toBeNull();
+  });
+
+  test("S7 compaction (either source spelling): fully inert — no pointer read, no rotation, no state touch", () => {
+    seedSession(dir, AGENT, "claude-old-sess");
+    const pointerBefore = readFileSync(pointerPath(dir, AGENT), "utf-8");
+    const stateBefore = readFileSync(statePath(dir, AGENT, "claude-old-sess"), "utf-8");
+    for (const input of [
+      { session_id: "claude-old-sess", source: "compact" },
+      { session_id: "claude-old-sess", how_started: "compact" },
+    ]) {
+      const boot = prepareContinuityBoot(input, AGENT, { FLAIR_SESSION_DIR: dir });
+      expect(boot.active).toBe(false);
+      expect(boot.priorPointer).toBeNull();
+    }
+    expect(readFileSync(pointerPath(dir, AGENT), "utf-8")).toBe(pointerBefore);
+    expect(readFileSync(statePath(dir, AGENT, "claude-old-sess"), "utf-8")).toBe(stateBefore);
+  });
+
+  test("no session_id ⇒ fully inert (legacy behavior preserved, zero files)", () => {
+    const boot = prepareContinuityBoot({ source: "startup" }, AGENT, { FLAIR_SESSION_DIR: dir });
+    expect(boot.active).toBe(false);
+    expect(existsSync(pointerPath(dir, AGENT))).toBe(false);
+  });
+
+  test("unsafe agent id ⇒ inactive, zero files", () => {
+    const boot = prepareContinuityBoot({ session_id: "s1", source: "startup" }, "agent/../evil", { FLAIR_SESSION_DIR: dir });
+    expect(boot.active).toBe(false);
+    expect(existsSync(pointerPath(dir, "agent/../evil"))).toBe(false);
+  });
+});

--- a/test/unit/doctor-client.test.ts
+++ b/test/unit/doctor-client.test.ts
@@ -15,6 +15,13 @@ import {
   resolveCollisionSafeName,
   pruneDateStamp,
   PRUNED_DIR_NAME,
+  CONTINUITY_CAPTURE_HOOK_MARKER,
+  CONTINUITY_POST_TOOL_USE_MATCHER,
+  buildContinuityCaptureHookCommand,
+  checkContinuityCaptureHooks,
+  fixContinuityCaptureHooks,
+  removeContinuityCaptureHooks,
+  hookCommandIsSilenced,
 } from "../../src/doctor-client.ts";
 
 /**
@@ -454,5 +461,150 @@ describe("resolveCollisionSafeName", () => {
 
   it("PRUNED_DIR_NAME is the literal '.pruned' the scanner must skip", () => {
     expect(PRUNED_DIR_NAME).toBe(".pruned");
+  });
+});
+
+// ─── flair#1257 slice 2 — continuity capture hooks (check-5 twin) ───────────
+
+describe("buildContinuityCaptureHookCommand", () => {
+  it("carries the marker, both env vars when a URL is given, and the silenced wrapper", () => {
+    const cmd = buildContinuityCaptureHookCommand("flint", "http://harper.local:19926");
+    expect(cmd).toContain(CONTINUITY_CAPTURE_HOOK_MARKER);
+    expect(cmd).toContain("FLAIR_AGENT_ID=flint");
+    expect(cmd).toContain("FLAIR_URL=http://harper.local:19926");
+    expect(cmd).toContain("npx -y -p @tpsdev-ai/flair-mcp flair-continuity-capture");
+    // Same silence property doctor's SessionStart check recognizes: a broken
+    // npx resolution must never print an error on every tool call.
+    expect(hookCommandIsSilenced(cmd)).toBe(true);
+  });
+
+  it("omits FLAIR_URL when none is given", () => {
+    const cmd = buildContinuityCaptureHookCommand("flint");
+    expect(cmd).toContain("FLAIR_AGENT_ID=flint");
+    expect(cmd).not.toContain("FLAIR_URL=");
+  });
+
+  it("REFUSES values that cannot be represented safely in a shell command (never escapes)", () => {
+    expect(() => buildContinuityCaptureHookCommand("bad agent")).toThrow();
+    expect(() => buildContinuityCaptureHookCommand("a'; rm -rf ~;'")).toThrow();
+    expect(() => buildContinuityCaptureHookCommand("flint", "http://x/'$(boom)'")).toThrow();
+  });
+});
+
+describe("checkContinuityCaptureHooks / fixContinuityCaptureHooks / removeContinuityCaptureHooks", () => {
+  const settingsPath = () => join(isoHome, ".claude", "settings.json");
+
+  it("absent when settings.json does not exist — 'not enabled', which is neither a pass nor a failure", () => {
+    const report = checkContinuityCaptureHooks(isoHome);
+    expect(report.state).toBe("absent");
+    expect(report.postToolUse.present).toBe(false);
+    expect(report.stop.present).toBe(false);
+  });
+
+  it("registration round-trip: fix wires BOTH events (PostToolUse with the allowlist matcher), check reads installed", () => {
+    const fix = fixContinuityCaptureHooks(isoHome, "flint", "http://localhost:19926");
+    expect(fix.ok).toBe(true);
+    expect(fix.changed).toBe(true);
+
+    const report = checkContinuityCaptureHooks(isoHome);
+    expect(report.state).toBe("installed");
+    expect(report.postToolUse.currentForm).toBe(true);
+    expect(report.stop.currentForm).toBe(true);
+    expect(report.postToolUse.matcher).toBe(CONTINUITY_POST_TOOL_USE_MATCHER);
+
+    // Idempotent: a second run is a structural no-op.
+    const again = fixContinuityCaptureHooks(isoHome, "flint", "http://localhost:19926");
+    expect(again.ok).toBe(true);
+    expect(again.changed).toBe(false);
+  });
+
+  it("the PostToolUse matcher written is EXACTLY the capture binary's mutating allowlist", () => {
+    expect(CONTINUITY_POST_TOOL_USE_MATCHER).toBe("Write|Edit|NotebookEdit|Bash");
+    fixContinuityCaptureHooks(isoHome, "flint");
+    const config = JSON.parse(readFileSync(settingsPath(), "utf-8"));
+    expect(config.hooks.PostToolUse[0].matcher).toBe("Write|Edit|NotebookEdit|Bash");
+  });
+
+  it("merge-safe: unrelated hooks and keys survive install AND removal byte-identically", () => {
+    mkdirSync(join(isoHome, ".claude"), { recursive: true });
+    const existing = {
+      model: "opus",
+      hooks: {
+        PostToolUse: [{ matcher: "Bash", hooks: [{ type: "command", command: "my-linter --fix" }] }],
+        SessionStart: [{ hooks: [{ type: "command", command: "echo hi" }] }],
+      },
+    };
+    writeFileSync(settingsPath(), JSON.stringify(existing, null, 2));
+
+    fixContinuityCaptureHooks(isoHome, "flint");
+    const afterInstall = JSON.parse(readFileSync(settingsPath(), "utf-8"));
+    expect(afterInstall.model).toBe("opus");
+    expect(afterInstall.hooks.PostToolUse[0]).toEqual(existing.hooks.PostToolUse[0]);
+    expect(afterInstall.hooks.SessionStart).toEqual(existing.hooks.SessionStart);
+    expect(checkContinuityCaptureHooks(isoHome).state).toBe("installed");
+
+    const removal = removeContinuityCaptureHooks(isoHome);
+    expect(removal.ok).toBe(true);
+    expect(removal.changed).toBe(true);
+    const afterRemoval = JSON.parse(readFileSync(settingsPath(), "utf-8"));
+    expect(afterRemoval).toEqual(existing); // ONLY our entries were removed
+    expect(checkContinuityCaptureHooks(isoHome).state).toBe("absent");
+  });
+
+  it("stale-form detection: an unsilenced command reads stale, and fix repairs it to current form", () => {
+    mkdirSync(join(isoHome, ".claude"), { recursive: true });
+    writeFileSync(
+      settingsPath(),
+      JSON.stringify({
+        hooks: {
+          PostToolUse: [{ matcher: CONTINUITY_POST_TOOL_USE_MATCHER, hooks: [{ type: "command", command: "FLAIR_AGENT_ID=flint npx -y @tpsdev-ai/flair-mcp flair-continuity-capture" }] }],
+          Stop: [{ hooks: [{ type: "command", command: "FLAIR_AGENT_ID=flint npx -y @tpsdev-ai/flair-mcp flair-continuity-capture" }] }],
+        },
+      }),
+    );
+    expect(checkContinuityCaptureHooks(isoHome).state).toBe("stale");
+
+    const fix = fixContinuityCaptureHooks(isoHome, "flint");
+    expect(fix.ok).toBe(true);
+    expect(fix.changed).toBe(true);
+    expect(checkContinuityCaptureHooks(isoHome).state).toBe("installed");
+  });
+
+  it("stale-form detection: a drifted PostToolUse matcher reads stale (the allowlist mirror matters)", () => {
+    fixContinuityCaptureHooks(isoHome, "flint");
+    const config = JSON.parse(readFileSync(settingsPath(), "utf-8"));
+    config.hooks.PostToolUse[0].matcher = "Bash"; // hand-narrowed
+    writeFileSync(settingsPath(), JSON.stringify(config, null, 2));
+    expect(checkContinuityCaptureHooks(isoHome).state).toBe("stale");
+  });
+
+  it("partial detection: only one of the two events wired", () => {
+    fixContinuityCaptureHooks(isoHome, "flint");
+    const config = JSON.parse(readFileSync(settingsPath(), "utf-8"));
+    delete config.hooks.Stop;
+    writeFileSync(settingsPath(), JSON.stringify(config, null, 2));
+    const report = checkContinuityCaptureHooks(isoHome);
+    expect(report.state).toBe("partial");
+    expect(report.postToolUse.present).toBe(true);
+    expect(report.stop.present).toBe(false);
+
+    // fix completes the pair.
+    const fix = fixContinuityCaptureHooks(isoHome, "flint");
+    expect(fix.changed).toBe(true);
+    expect(checkContinuityCaptureHooks(isoHome).state).toBe("installed");
+  });
+
+  it("removal on a machine with nothing wired is a clean no-op that creates no file", () => {
+    const removal = removeContinuityCaptureHooks(isoHome);
+    expect(removal.ok).toBe(true);
+    expect(removal.changed).toBe(false);
+    expect(existsSync(settingsPath())).toBe(false);
+  });
+
+  it("fix refuses an unsafe agent id / URL instead of writing a mangled command", () => {
+    expect(fixContinuityCaptureHooks(isoHome, "bad agent").ok).toBe(false);
+    expect(fixContinuityCaptureHooks(isoHome, "flint", "http://x/'$(boom)'").ok).toBe(false);
+    expect(fixContinuityCaptureHooks(isoHome, undefined).ok).toBe(false);
+    expect(existsSync(settingsPath())).toBe(false); // nothing was half-written
   });
 });

--- a/test/unit/hook-install.test.ts
+++ b/test/unit/hook-install.test.ts
@@ -8,13 +8,22 @@ import {
   uninstallHook,
   hookStatus,
   buildHookCommand,
+  buildContinuityHookCommand,
+  installContinuityHooks,
+  uninstallContinuityHooks,
+  continuityHookStatus,
   parseHookCommandEnv,
   hookSettingsPath,
   hookBackupPath,
   isSupportedHarness,
   SUPPORTED_HARNESSES,
 } from "../../src/hook-install.ts";
-import { SESSION_START_HOOK_MARKER, checkSessionStartHook } from "../../src/doctor-client.ts";
+import {
+  SESSION_START_HOOK_MARKER,
+  CONTINUITY_CAPTURE_HOOK_MARKER,
+  buildContinuityCaptureHookCommand,
+  checkSessionStartHook,
+} from "../../src/doctor-client.ts";
 // NOTE: the degradation-timeout test (Sherlock condition 5, "mock the
 // fetch") lives in packages/flair-mcp/test/session-start-hook.test.ts, NOT
 // here. That file already imports runHook (which transitively imports
@@ -408,4 +417,106 @@ describe("TLS-bypass-pattern scan (Sherlock condition 4)", () => {
       }
     });
   }
+});
+
+// ─── flair#1257 slice 2 — `flair hook install|uninstall --continuity` ────────
+// Same Sherlock conditions as the SessionStart family above: fail-closed on
+// malformed settings.json, backup before any real mutation, idempotent merge,
+// dry-run computes without writing, symmetric removal.
+
+describe("continuity hook install/uninstall/status wrappers", () => {
+  const settingsPath = () => hookSettingsPath(isoHome, "claude-code");
+
+  it("buildContinuityHookCommand delegates to the ONE doctor-client builder (no second literal)", () => {
+    expect(buildContinuityHookCommand(AGENT, URL)).toBe(buildContinuityCaptureHookCommand(AGENT, URL));
+    expect(buildContinuityHookCommand(AGENT, URL)).toContain(CONTINUITY_CAPTURE_HOOK_MARKER);
+  });
+
+  it("fresh install wires both events; status reads installed; re-run is a no-op", () => {
+    const first = installContinuityHooks({ homeDir: isoHome, harness: "claude-code", agentId: AGENT, flairUrl: URL });
+    expect(first.ok).toBe(true);
+    expect(first.actions).toEqual({ PostToolUse: "add", Stop: "add" });
+    expect(first.backupPath).toBeNull(); // nothing existed to back up
+
+    expect(continuityHookStatus(isoHome, "claude-code").state).toBe("installed");
+
+    const again = installContinuityHooks({ homeDir: isoHome, harness: "claude-code", agentId: AGENT, flairUrl: URL });
+    expect(again.ok).toBe(true);
+    expect(again.actions).toEqual({ PostToolUse: "noop", Stop: "noop" });
+  });
+
+  it("--dry-run computes the delta and writes NOTHING (no file, no backup)", () => {
+    const dry = installContinuityHooks({ homeDir: isoHome, harness: "claude-code", agentId: AGENT, flairUrl: URL, dryRun: true });
+    expect(dry.ok).toBe(true);
+    expect(dry.actions).toEqual({ PostToolUse: "add", Stop: "add" });
+    expect(existsSync(settingsPath())).toBe(false);
+    expect(existsSync(hookBackupPath(settingsPath()))).toBe(false);
+  });
+
+  it("a real mutation of an existing file takes a backup FIRST", () => {
+    mkdirSync(join(isoHome, ".claude"), { recursive: true });
+    writeFileSync(settingsPath(), JSON.stringify({ model: "opus" }));
+    const res = installContinuityHooks({ homeDir: isoHome, harness: "claude-code", agentId: AGENT, flairUrl: URL });
+    expect(res.ok).toBe(true);
+    expect(res.backupPath).toBe(hookBackupPath(settingsPath()));
+    expect(JSON.parse(readFileSync(res.backupPath!, "utf-8"))).toEqual({ model: "opus" });
+  });
+
+  it("malformed settings.json FAILS CLOSED — refuses to touch the file, backup already taken", () => {
+    mkdirSync(join(isoHome, ".claude"), { recursive: true });
+    writeFileSync(settingsPath(), "{ this is not json");
+    const res = installContinuityHooks({ homeDir: isoHome, harness: "claude-code", agentId: AGENT, flairUrl: URL });
+    expect(res.ok).toBe(false);
+    expect(readFileSync(settingsPath(), "utf-8")).toBe("{ this is not json"); // untouched
+    expect(res.backupPath).toBe(hookBackupPath(settingsPath()));
+  });
+
+  it("unsafe agent id / URL is REFUSED before any write or backup", () => {
+    const res = installContinuityHooks({ homeDir: isoHome, harness: "claude-code", agentId: "bad agent", flairUrl: URL });
+    expect(res.ok).toBe(false);
+    expect(existsSync(settingsPath())).toBe(false);
+    const res2 = installContinuityHooks({ homeDir: isoHome, harness: "claude-code", agentId: AGENT, flairUrl: "http://x/'$(boom)'" });
+    expect(res2.ok).toBe(false);
+  });
+
+  it("uninstall removes ONLY our entries and is symmetric with install; a second uninstall is a no-op", () => {
+    mkdirSync(join(isoHome, ".claude"), { recursive: true });
+    const foreign = {
+      hooks: { PostToolUse: [{ matcher: "Bash", hooks: [{ type: "command", command: "my-linter" }] }] },
+    };
+    writeFileSync(settingsPath(), JSON.stringify(foreign, null, 2));
+
+    installContinuityHooks({ homeDir: isoHome, harness: "claude-code", agentId: AGENT, flairUrl: URL });
+    expect(continuityHookStatus(isoHome, "claude-code").state).toBe("installed");
+
+    const removed = uninstallContinuityHooks({ homeDir: isoHome, harness: "claude-code" });
+    expect(removed.ok).toBe(true);
+    expect(removed.actions).toEqual({ PostToolUse: "remove", Stop: "remove" });
+    expect(JSON.parse(readFileSync(settingsPath(), "utf-8"))).toEqual(foreign);
+
+    const again = uninstallContinuityHooks({ homeDir: isoHome, harness: "claude-code" });
+    expect(again.ok).toBe(true);
+    expect(again.actions).toEqual({ PostToolUse: "noop", Stop: "noop" });
+    expect(continuityHookStatus(isoHome, "claude-code").state).toBe("absent");
+  });
+
+  it("uninstall --dry-run reports the removal without writing", () => {
+    installContinuityHooks({ homeDir: isoHome, harness: "claude-code", agentId: AGENT, flairUrl: URL });
+    const before = readFileSync(settingsPath(), "utf-8");
+    const dry = uninstallContinuityHooks({ homeDir: isoHome, harness: "claude-code", dryRun: true });
+    expect(dry.ok).toBe(true);
+    expect(dry.actions).toEqual({ PostToolUse: "remove", Stop: "remove" });
+    expect(readFileSync(settingsPath(), "utf-8")).toBe(before);
+  });
+
+  it("continuity install never disturbs an existing SessionStart hook (and vice versa)", () => {
+    installHook({ homeDir: isoHome, harness: "claude-code", agentId: AGENT, flairUrl: URL });
+    installContinuityHooks({ homeDir: isoHome, harness: "claude-code", agentId: AGENT, flairUrl: URL });
+    expect(checkSessionStartHook(isoHome).present).toBe(true);
+    expect(continuityHookStatus(isoHome, "claude-code").state).toBe("installed");
+
+    uninstallContinuityHooks({ homeDir: isoHome, harness: "claude-code" });
+    expect(checkSessionStartHook(isoHome).present).toBe(true); // SessionStart untouched
+    expect(continuityHookStatus(isoHome, "claude-code").state).toBe("absent");
+  });
 });


### PR DESCRIPTION
Slice 2 of 3 for the session-continuity primitive: the Claude Code hook adapter. Builds on the merged #1261 server guard (slice 1); REM distillation wiring (slice 3) trails. Implements the merged ten-scenario acceptance set and both capture-content security rulings recorded on the issue.

## What this adds

**Capture — new `flair-continuity-capture` bin (`@tpsdev-ai/flair-mcp`)**, the PostToolUse/Stop hook target. Reads the hook JSON from stdin and writes at most ONE ephemeral row per fire: `durability:"ephemeral"`, `visibility:"private"` sent EXPLICITLY (defense-in-depth above the #1261 guard), tag `adk:continuity:<sessionId>`, `meta:{seq,processUUID,sessionId,hook,tool?}`. sessionId/processUUID/seq come from a per-harness-session state file the SessionStart hook seeds; seq is an atomic (tmp+rename) increment consumed before the network write, so even a failed write burns its seq — gaps fine, duplicates never.

**Capture discipline (binding, per the security rulings on the issue):**
- PostToolUse journals ONLY the closed mutating allowlist: Write, Edit, NotebookEdit, Bash. Read-only tools exit 0 with zero writes (world-recoverable).
- Bash: the `description` field ONLY — never the command string (argv is the leak class). Absent description journals the literal `bash: (no description)`, never the command.
- Write/Edit/NotebookEdit: file path only — never content, never diffs.
- Stop: a dedicated summary field when the payload carries one, else the final assistant text — HARD-truncated at 400 chars with a visible ellipsis. The bound is load-bearing and commented as such in-source: capturing the full text is a regression, not an enhancement. Empty text journals nothing. No tool-result synthesis, no variable-length excerpts, no raw hook JSON, no secret-scrubbing attempts (the bound + already-user-visible prose is the control).
- Malformed/unparseable hook JSON exits 0 with ZERO writes — no partial extraction.

**Resume — `flair-session-start` grows the agent-pull resume path.** Pointer file `<agentId>.current` (0600, dir 0700) is the fast path; a missing/unreadable pointer falls back to an agentId-wide ephemeral search disambiguated by processUUID — a reconstruction never interleaves two processes' entries. Expired rows are excluded client-side even when the async reap hasn't run. Boot mints + rotates sessionId/processUUID and seeds the capture state file, then emits AT MOST one hint line ("N entries from your previous session — search tag …"); zero entries or no prior session ⇒ zero hint; journal content is NEVER injected. Compaction is not a restart: a compaction-sourced SessionStart touches nothing — no rotation, no state write, no hint, no fragmentation.

**Fail-open throughout.** 2s write timeout (clamped, env-tunable); unreachable Flair or a #1261 guard 400 ⇒ one debug-level stderr line, exit 0, the turn/boot is never blocked. SessionStart with Flair down still seeds local capture state and boots clean with no hint.

**Install via the supported channel.** One builder (`buildContinuityCaptureHookCommand`) following the existing #1007 ONE-builder pattern, silenced wrapper included, shared by every write path: `flair doctor --fix` and `flair hook install --continuity`. The PostToolUse entry carries the matcher `Write|Edit|NotebookEdit|Bash` — an efficiency mirror of the bin's own allowlist, which remains the actual control. Doctor gains a twin of the SessionStart check reporting installed / not-enabled / partial / stale-form; **absent renders "not enabled" — informational, never a pass and never an issue** (installing the pair IS the opt-in). Symmetric removal: `flair hook uninstall --continuity` and a doctor removal path; both merge-safe, backup-first, fail-closed on malformed settings, dry-run-able.

## Tests

Self-measured baseline on the merge-base vs this branch, same commands:

| Lane | Baseline | This branch |
|---|---|---|
| root unit (`bun test test/unit/ test/*.test.ts`) | 4595 pass, 0 fail | **4660 pass, 0 fail** (+65) |
| flair-mcp package (`bun test`, client built) | 96 pass, 0 fail | **105 pass, 0 fail** (+9) |
| typechecks (resources, src strict, cli, test-suite strict, flair-mcp strict) | clean | clean |

New coverage: `test/unit/continuity-hook.test.ts` (44 — capture discipline, leak-guards with positive controls, seq monotonicity, fail-open incl. bounded timeout, resume discovery incl. two-process disambiguation and expired-exclusion, file modes, boot plumbing), `packages/flair-mcp/test/continuity-resume.test.ts` (9 — runHook end-to-end: cold start, one-line hint, compaction inertness, fail-open, hint-alone output), plus doctor-client (12) and hook-install (9) additions covering the builder, registration round-trip, stale/partial detection, matcher drift, removal, and refusal of unsafe values.

CI-lane note: the root unit lane runs before the client package is built, so everything `test/unit/continuity-hook.test.ts` imports is dist-free by construction (the capture bin lazy-imports the client; verified by running the file with the client's dist deleted). The runHook end-to-end tests live in the package lane, which builds the client first.

**Mutation checks — 11 run, each: break, observe red, restore, observe green:**

1. Bash journals command instead of description → 3 tests red (leak-guard + its positive control + no-description)
2. 400-char bound removed → 2 red (beyond-bound token leak + uniform-bound)
3. Write/Edit journal tool_input instead of path → 3 red
4. Explicit `visibility:"private"` dropped (ride the default) → 1 red
5. Expired-row exclusion removed → 2 red
6. Fallback interleaves both processUUID groups → 1 red
7. Capture rethrows on write failure (fail-closed) → 4 red (guard-400, unreachable, timeout, +1)
8. seq increment frozen → 2 red
9. Allowlist widened to include read-only tools → 2 red
10. Compaction treated as restart → 2 red (both lanes)
11. Doctor stale-form detection blinded → 2 red

Every leak-guard has a positive control (the same marker planted in the allowed field IS observed in the write body), so a capture bin that stopped writing entirely cannot pass the absence assertions.

## Leaned on from earlier slices

Cross-agent isolation (owner-only read scope, anti-enumeration 404, federation exclusion of private rows) and the ephemeral+shared 400 are server-side properties merged in #1261/#1264/#1277 with their own integration coverage; this adapter's tests assert the hook-side halves (explicit private on every write, graceful 400 handling).

Refs #1257
