### PR TITLE
mcp oauth config: derive resource from issuer, env-reference enabled — deploys stop reverting the operator's choice

### DIFF
--- a/.changelog/unreleased/fixed-1152-1180-mcp-config-shape.md
+++ b/.changelog/unreleased/fixed-1152-1180-mcp-config-shape.md
@@ -1,0 +1,23 @@
+- **MCP OAuth config: derive `resource` from the issuer, env-reference
+  `enabled` — deploys stop reverting the operator's choice** (#1152, #1180).
+  The shipped `config.yaml` (and the block `flair mcp enable` writes) no
+  longer sets `mcp.resource`: the old composite `${FLAIR_MCP_ISSUER}/mcp`
+  never interpolated (component env expansion is whole-token-only), so every
+  claude.ai connect bounced with `invalid_target`; absent, the component
+  derives `<issuer>/mcp` at request time — identical to flair's in-process
+  derivation. An operator needing a non-standard resource sets an explicit
+  literal absolute URL. `mcp.enabled` is now the whole-token env reference
+  `${FLAIR_MCP_OAUTH}` — the same flag flair's in-process `/mcp` route gates
+  on — so enablement lives in the instance environment, not the packed file,
+  and a re-packed deploy can no longer revert it. Requires
+  `@harperfast/oauth` >= 2.5.0, enforced by a resolved-version assertion
+  co-located with the behavioral boot-safety gate (below 2.5.0 an unresolved
+  placeholder is a truthy string — fail-open; from 2.5.0 the component
+  coerces only `"true"`/`"false"` and deletes anything else so the disabled
+  default applies). The two readers accept different vocabularies — flair's
+  strict flag takes 1/true/yes/on, the component only true/false — so
+  `FLAIR_MCP_OAUTH=true` is the one end-to-end enable value and is what
+  `flair mcp enable` now stages (previously `1`, which since the reshape
+  would yield a guarded `/mcp` with no authorization server behind it);
+  garbage values disable both sides. The asymmetry is documented at the
+  config and flag sites and pinned by boot tests.

--- a/config.yaml
+++ b/config.yaml
@@ -16,9 +16,42 @@ authentication:
       clientId: ${OAUTH_GITHUB_CLIENT_ID}
       clientSecret: ${OAUTH_GITHUB_CLIENT_SECRET}
   mcp:
-    enabled: false
+    # WHOLE-TOKEN env reference — the same FLAIR_MCP_OAUTH flag flair's
+    # in-process /mcp route gates on (resources/mcp-oauth-flag.ts). The on/off
+    # choice lives in the instance ENVIRONMENT, not in this packed file, so a
+    # re-packed deploy can no longer revert an operator's enablement
+    # (flair#1152). Requires @harperfast/oauth >= 2.5.0 (resolved-version
+    # assertion + behavioral gate: test/integration/mcp-oauth-boot-safety.test.ts).
+    #
+    # ASYMMETRY (load-bearing, measured on oauth 2.5.0): the two readers of
+    # this flag accept DIFFERENT vocabularies. The component's
+    # coerceConfigBoolean accepts ONLY "true"/"false" and DELETES any other
+    # string (unresolved placeholder, "1", "yes", garbage) so its disabled
+    # default applies. flair's mcpOAuthEnabled() accepts 1/true/yes/on.
+    #
+    # Failure modes (oauth 2.5.0):
+    #   unset             -> placeholder deleted -> both sides OFF, clean boot
+    #   true              -> BOTH sides ON — the one working enable value
+    #                        (`flair mcp enable` stages exactly this)
+    #   false             -> both sides OFF
+    #   1 / yes / on      -> flair /mcp handler ON, component AS OFF ->
+    #                        fail-closed broken-on: every /mcp request 401s,
+    #                        no AS is advertised. Use "true" instead.
+    #   garbage (maybe)   -> deleted -> component OFF; flair strict -> OFF.
+    #                        Inert: no /mcp handler, no data path (flair's own
+    #                        discovery documents still serve, by design).
+    # On oauth <2.5.0 there is NO normalization: an unresolved placeholder is
+    # a truthy string (fail-open) — the version assertion exists for that.
+    # If the component's `enabled` vocabulary changes, or it ever drives
+    # flair's handler registration directly, re-derive this table first.
+    enabled: ${FLAIR_MCP_OAUTH}
     issuer: ${FLAIR_MCP_ISSUER}
-    resource: ${FLAIR_MCP_ISSUER}/mcp
+    # No `resource:` key ON PURPOSE (flair#1180): when absent, the component
+    # derives `<issuer>/mcp` at request time (resolveResource) — identical to
+    # flair's in-process derivation. A composite like ${FLAIR_MCP_ISSUER}/mcp
+    # NEVER interpolates (env expansion is whole-token-only) and fails every
+    # connect with invalid_target. Escape hatch: an operator needing a
+    # non-standard resource sets an explicit LITERAL absolute URL here.
     accessTokenTtl: 900
     dynamicClientRegistration:
       enabled: false

--- a/docs/notes/mcp-oauth-model2.md
+++ b/docs/notes/mcp-oauth-model2.md
@@ -59,9 +59,12 @@ never from the tool arguments (no forging of agentId / authorId).
          clientId: ${OAUTH_GITHUB_CLIENT_ID}
          clientSecret: ${OAUTH_GITHUB_CLIENT_SECRET}
      mcp:
-       enabled: true
+       enabled: ${FLAIR_MCP_OAUTH}          # whole-token env reference (flair#1152) — the choice lives in the ENVIRONMENT, so a re-packed deploy can't revert it
        issuer: ${FLAIR_MCP_ISSUER}          # pin to your public origin — REQUIRED
-       resource: ${FLAIR_MCP_ISSUER}/mcp     # RFC-8707 audience the /mcp token binds to
+       # NO resource key (flair#1180): the plugin derives <issuer>/mcp when it is
+       # absent. A composite like ${FLAIR_MCP_ISSUER}/mcp never interpolates
+       # (whole-token-only expansion) and fails every connect with
+       # invalid_target. Non-standard resource: set an explicit LITERAL URL.
        accessTokenTtl: 900                    # 5–15 min (Sherlock req 1) — short-lived
        dynamicClientRegistration:
          enabled: false                       # DCR is NOT SUPPORTED (flair#756) — explicit, not omitted (an absent block leaves DCR OPEN by the plugin's own default)
@@ -82,7 +85,11 @@ never from the tool arguments (no forging of agentId / authorId).
    turning the surface on.
 
 2. **Set the env:**
-   - `FLAIR_MCP_OAUTH=1` — turns on the `/mcp` route registration.
+   - `FLAIR_MCP_OAUTH=true` — turns on the `/mcp` route registration AND the
+     component AS (flair#1152: `true` is the ONE value both readers accept —
+     flair's flag takes 1/true/yes/on, but the component's config read of the
+     same var accepts only "true"/"false" and deletes anything else, so `1`
+     gives you a guarded `/mcp` with no authorization server behind it).
    - `FLAIR_MCP_ISSUER=https://your-public-origin` (or `FLAIR_PUBLIC_URL`).
    - `FLAIR_MCP_JIT_PROVISION=1` — ONLY if you want unknown subjects
      auto-provisioned (default OFF; pre-provision Agent+Credential otherwise).

--- a/resources/mcp-oauth-flag.ts
+++ b/resources/mcp-oauth-flag.ts
@@ -29,6 +29,26 @@
  *
  * Read from `FLAIR_MCP_OAUTH` — truthy values: "1", "true", "yes", "on"
  * (case-insensitive). Anything else (incl. unset / empty) → OFF.
+ *
+ * ASYMMETRY (load-bearing, flair#1152, measured on oauth 2.5.0): config.yaml's
+ * `mcp.enabled: ${FLAIR_MCP_OAUTH}` hands the SAME env var to
+ * @harperfast/oauth, but the two readers accept DIFFERENT vocabularies. The
+ * component's coerceConfigBoolean takes ONLY "true"/"false" and DELETES any
+ * other string (unresolved placeholder, "1", "yes", garbage) so its disabled
+ * default applies; this function takes 1/true/yes/on. Consequences:
+ *   - "true" is the ONE value that enables both sides (`flair mcp enable`
+ *     stages exactly that).
+ *   - "1"/"yes"/"on" turn flair's /mcp handler ON while the component AS
+ *     stays OFF — fail-closed broken-on (every request 401s, no AS
+ *     advertised).
+ *   - garbage (e.g. "maybe") disables BOTH: the component deletes it, this
+ *     stays false, no /mcp handler exists — no data path (flair's own
+ *     discovery documents still serve whenever this flag is off, by design).
+ * If the component's vocabulary ever widens back to truthy-string, a garbage
+ * value would mount a live AS next to an unregistered /mcp — re-derive the
+ * garbage case (test/integration/mcp-oauth-boot-safety.test.ts) before
+ * relying on it, and NEVER let component `enabled` drive flair's handler
+ * registration directly without re-deriving that table.
  */
 export function mcpOAuthEnabled(): boolean {
   const raw = (process.env.FLAIR_MCP_OAUTH ?? "").trim().toLowerCase();

--- a/resources/mcp-oauth.ts
+++ b/resources/mcp-oauth.ts
@@ -200,7 +200,12 @@ export async function registerMcpOAuthRoute(deps: RegisterDeps = {}): Promise<bo
     return decide({
       mounted: false,
       status: "Not enabled",
-      reason: "Set FLAIR_MCP_OAUTH=1 (and an issuer) to serve MCP over HTTP.",
+      // "true" not "1": flair's flag accepts either, but the component's
+      // config-side read of the same var (config.yaml `mcp.enabled:
+      // ${FLAIR_MCP_OAUTH}`, flair#1152) accepts ONLY "true"/"false" — with
+      // "1" the /mcp route registers and every request 401s against a
+      // component that never mounted its AS.
+      reason: "Set FLAIR_MCP_OAUTH=true (and an issuer) to serve MCP over HTTP.",
     });
   }
 

--- a/src/lib/mcp-enable.ts
+++ b/src/lib/mcp-enable.ts
@@ -303,9 +303,10 @@ export interface McpOAuthConfigBlockParams {
   /** `clientIdMetadataDocuments.allowedHosts` override — defaults to
    *  `DEFAULT_CIMD_ALLOWED_HOSTS`. */
   cimdAllowedHosts?: string[];
-  /** mcp.enabled — defaults to true (the enable command flips it on).
-   *  The shipped config.yaml uses false (inert default). */
-  enabled?: boolean;
+  // flair#1152: no `enabled` param. mcp.enabled is ALWAYS emitted as the
+  // whole-token env reference ${FLAIR_MCP_OAUTH} — the on/off choice lives in
+  // the instance environment, never in the generated file, so a re-packed
+  // deploy cannot revert it. A param here would reintroduce the literal.
 }
 
 /**
@@ -331,7 +332,6 @@ export function buildMcpOAuthConfigBlock(params: McpOAuthConfigBlockParams): Rec
   const provider = params.idpProvider;
   const envPrefix = `OAUTH_${provider.toUpperCase()}`;
   const cimdAllowedHosts = params.cimdAllowedHosts ?? DEFAULT_CIMD_ALLOWED_HOSTS;
-  const enabled = params.enabled ?? true;
   return {
     "@harperfast/oauth": {
       package: "@harperfast/oauth",
@@ -342,9 +342,29 @@ export function buildMcpOAuthConfigBlock(params: McpOAuthConfigBlockParams): Rec
         },
       },
       mcp: {
-        enabled,
+        // flair#1152: whole-token env reference — same flag flair's in-process
+        // route gates on. ASYMMETRY (load-bearing, measured on oauth 2.5.0):
+        // the component's coerceConfigBoolean accepts ONLY "true"/"false" and
+        // DELETES any other string (unresolved placeholder, "1", "yes",
+        // garbage) so its disabled default applies; flair's mcpOAuthEnabled()
+        // (resources/mcp-oauth-flag.ts) accepts 1/true/yes/on. So "true" is
+        // the one value that enables BOTH; "1"/"yes"/"on" flip flair's /mcp
+        // handler on while the component AS stays off (fail-closed broken-on:
+        // all 401, no AS advertised); garbage/unset disable both. On oauth
+        // <2.5.0 there is NO normalization and an unresolved placeholder is a
+        // truthy string (fail-open) — which is why the resolved-version
+        // assertion in mcp-oauth-boot-safety.test.ts exists. If component
+        // `enabled` semantics ever change, or it ever drives flair handler
+        // registration directly, re-derive this table before shipping.
+        enabled: "${FLAIR_MCP_OAUTH}",
         issuer: "${FLAIR_MCP_ISSUER}",
-        resource: "${FLAIR_MCP_ISSUER}/mcp",
+        // flair#1180: NO `resource` key — the component's resolveResource()
+        // derives `<issuer>/mcp` at request time when it is absent, identical
+        // to flair's in-process derivation. The old composite
+        // "${FLAIR_MCP_ISSUER}/mcp" never interpolated (whole-token-only
+        // expansion) and failed every connect with invalid_target. Escape
+        // hatch: an operator needing a non-standard resource sets an explicit
+        // LITERAL absolute URL in config.yaml (never a composite).
         accessTokenTtl: REQUIRED_ACCESS_TOKEN_TTL,
         // Explicit fail-closed disable — see the doc comment above and the
         // module header for why an omitted block is NOT equivalent to this.
@@ -363,14 +383,25 @@ export function buildMcpOAuthConfigBlock(params: McpOAuthConfigBlockParams): Rec
 
 // ─── Local config.yaml update (flair#1136) ──────────────────────────────────
 
+/** The whole-token env reference `flair mcp enable` writes as mcp.enabled
+ *  (flair#1152). The on/off choice lives in the environment (the secrets
+ *  bundle stages FLAIR_MCP_OAUTH=true — see buildSecretsBundle for why it
+ *  must be "true"), never as a literal in the config file. */
+export const MCP_ENABLED_ENV_REFERENCE = "${FLAIR_MCP_OAUTH}";
+
 /**
- * Flip mcp.enabled in a local component config.yaml. Best-effort: returns
- * `{ ok: false }` with a reason when the file can't be found or parsed.
+ * Set mcp.enabled in a local component config.yaml to the flair#1152 shape.
+ * Best-effort: returns `{ ok: false }` with a reason when the file can't be
+ * found or parsed.
+ *
+ * `enabled: true` writes the WHOLE-TOKEN env reference ${FLAIR_MCP_OAUTH}
+ * (never a literal `true` — the env var, staged to `true` by the secrets bundle,
+ * carries the choice; a legacy literal `true` found in the file is normalized
+ * to the reference). `enabled: false` writes literal `false` — decisively off
+ * regardless of environment.
  *
  * Looks for config.yaml at `explicitPath`, then `./config.yaml`, then
- * `~/.flair/config.yaml`. When found, replaces `mcp:\n    enabled: false`
- * with `mcp:\n    enabled: true` (exact string match — avoids a YAML parser
- * dependency for a single boolean flip).
+ * `~/.flair/config.yaml`.
  */
 export function updateLocalConfigMcpEnabled(
   enabled: boolean,
@@ -388,11 +419,16 @@ export function updateLocalConfigMcpEnabled(
     }
   }
 
+  // The value the file should carry for this call (flair#1152): the env
+  // reference when enabling, literal false when disabling.
+  const target: string | boolean = enabled ? MCP_ENABLED_ENV_REFERENCE : false;
+  const targetLabel = enabled ? `${MCP_ENABLED_ENV_REFERENCE} (env-referenced)` : "false";
+
   if (!configPath) {
     return {
       ok: false,
       detail: `local config.yaml not found (tried: ${candidates.join(", ")}). ` +
-        `Set mcp.enabled: ${enabled} in your component config.yaml manually, then restart.`,
+        `Set mcp.enabled: ${targetLabel} in your component config.yaml manually, then restart.`,
     };
   }
 
@@ -422,7 +458,7 @@ export function updateLocalConfigMcpEnabled(
     return {
       ok: false,
       detail: `@harperfast/oauth block not found in ${configPath}. ` +
-        `Ensure the component block is present with mcp.enabled: ${enabled}.`,
+        `Ensure the component block is present with mcp.enabled: ${targetLabel}.`,
     };
   }
 
@@ -431,17 +467,17 @@ export function updateLocalConfigMcpEnabled(
     return {
       ok: false,
       detail: `mcp key not found under @harperfast/oauth in ${configPath}. ` +
-        `Ensure the mcp block is present with enabled: ${enabled}.`,
+        `Ensure the mcp block is present with enabled: ${targetLabel}.`,
     };
   }
 
   const current = mcp.enabled;
-  if (current === enabled) {
-    return { ok: true, detail: `mcp.enabled already ${enabled} in ${configPath}` };
+  if (current === target) {
+    return { ok: true, detail: `mcp.enabled already ${targetLabel} in ${configPath}` };
   }
 
   // Mutate the parsed document and re-emit.
-  mcp.enabled = enabled;
+  mcp.enabled = target;
 
   const updated = yaml.dump(doc, { lineWidth: -1, noCompatMode: true });
   try {
@@ -450,7 +486,7 @@ export function updateLocalConfigMcpEnabled(
     return { ok: false, detail: `cannot write ${configPath}: ${err.message}` };
   }
 
-  return { ok: true, detail: `mcp.enabled set to ${enabled} in ${configPath}` };
+  return { ok: true, detail: `mcp.enabled set to ${targetLabel} in ${configPath}` };
 }
 
 /** The exact callback URL to hand the operator when they create the IdP
@@ -475,7 +511,14 @@ export interface SecretsBundleParams {
 export function buildSecretsBundle(params: SecretsBundleParams): Record<string, string> {
   const envPrefix = `OAUTH_${params.idpProvider.toUpperCase()}`;
   return {
-    FLAIR_MCP_OAUTH: "1",
+    // "true" is the ONLY value both readers of this flag accept (flair#1152,
+    // measured against oauth 2.5.0): flair's strict mcpOAuthEnabled() takes
+    // 1/true/yes/on, but the component's coerceConfigBoolean takes ONLY
+    // "true"/"false" and DELETES anything else (disabled default applies).
+    // Staging "1" here would flip flair's /mcp handler ON while the
+    // component's AS stays OFF — fail-closed but broken-on (every request
+    // 401s, no AS is advertised). Keep this "true".
+    FLAIR_MCP_OAUTH: "true",
     FLAIR_MCP_ISSUER: params.issuer.replace(/\/+$/, ""),
     FLAIR_MCP_SIGNING_KEY_PEM: params.signingKeyPem,
     [`${envPrefix}_CLIENT_ID`]: params.idpClientId,
@@ -1334,9 +1377,9 @@ export async function enableMcp(params: EnableMcpParams, deps: EnableMcpDeps = {
       currentStep = "fabric-operator-deploy";
       const msg = [
         `Fabric deployment detected (${new URL(params.instance).hostname}).`,
-        `The @harperfast/oauth block ships in config.yaml with mcp.enabled: false.`,
-        `To activate: set mcp.enabled: true (literal boolean) in your deployed component config.yaml,`,
-        `ensure the staged secrets are live in the instance's process environment, and redeploy.`,
+        `The @harperfast/oauth block ships in config.yaml with mcp.enabled: \${FLAIR_MCP_OAUTH} (env-referenced, flair#1152) — no config edit is needed.`,
+        `To activate: apply the staged secrets (FLAIR_MCP_OAUTH=true among them) to the instance's environment (Fabric env), then restart the instance.`,
+        `Deploys can no longer revert the choice — it lives in the environment, not the packed file.`,
         `Then re-run \`flair mcp enable\` — earlier steps are idempotent and will be reused.`,
       ].join(" ");
       push(false, msg);

--- a/test/integration/mcp-client-credentials-e2e.test.ts
+++ b/test/integration/mcp-client-credentials-e2e.test.ts
@@ -66,8 +66,10 @@
 // ── The oauth plugin as a live component (validated mechanism) ────────────
 // `@harperfast/oauth` is a real `dependencies` entry (package.json) and is
 // now declared as a Harper component in this repo's shipped `config.yaml`
-// (flair#1136) — but with `mcp.enabled: false` so the plugin is inert by
-// default. `resources/mcp-oauth.ts` does a bare `import("@harperfast/oauth")`
+// (flair#1136) — with `mcp.enabled: ${FLAIR_MCP_OAUTH}` (env-referenced,
+// flair#1152) so the plugin is inert by default (unset env → the unresolved
+// placeholder is dropped to the plugin's disabled default on oauth 2.5.0+).
+// `resources/mcp-oauth.ts` does a bare `import("@harperfast/oauth")`
 // for its `withMCPAuth` named export, wrapping flair's OWN `/mcp` handler.
 // The full plugin (its `/oauth/mcp/token` route, `.well-known/*` discovery,
 // `harper_oauth_mcp_*` tables) only activates when `mcp.enabled: true`.
@@ -162,10 +164,10 @@ describe("MCP client_credentials agent-auth vs. a live @harperfast/oauth@2.2.0 c
     execSync(`cp -al "${REPO_ROOT}"/. "${tempDir}"/`, { stdio: "pipe" });
     // Remove the hard-linked config.yaml and write our augmented copy.
     execSync(`rm -f "${tempDir}/config.yaml"`);
-    // Replace the shipped @harperfast/oauth block (mcp.enabled: false) with
-    // the test's version (mcp.enabled: true + test issuer/keys).  Appending
-    // would create a duplicate key now that config.yaml ships the block
-    // (flair#1136).
+    // Replace the shipped @harperfast/oauth block (mcp.enabled env-referenced,
+    // flair#1152) with the test's version (mcp.enabled: true + test
+    // issuer/keys).  Appending would create a duplicate key now that
+    // config.yaml ships the block (flair#1136).
     const configContent = readFileSync(CONFIG_PATH, "utf8");
     const replaced = configContent.replace(
       /["']@harperfast\/oauth["']:[\s\S]*?(?=\n\S|\n*$)/,

--- a/test/integration/mcp-oauth-boot-safety.test.ts
+++ b/test/integration/mcp-oauth-boot-safety.test.ts
@@ -1,30 +1,92 @@
 /**
- * flair#1136: Boot-safety and mutation-proof integration tests for the shipped
- * @harperfast/oauth config block.
+ * flair#1136 / flair#1152 / flair#1180: Boot-safety, config-shape, and
+ * mutation-proof integration tests for the shipped @harperfast/oauth config
+ * block.
  *
- * These tests boot ephemeral Harper instances against mutated configs and
- * verify:
- *   1. BOOT-SAFETY: shipped config (mcp.enabled: false, no env) boots clean.
- *   2. MUTATION-PROVE (literal true): mcp.enabled: true + env unset → CRASH.
- *      This proves the boot-safety test CAN fire — it catches the crash.
- *   3. MUTATION-PROVE (${ENV} trap): mcp.enabled: ${FLAIR_MCP_OAUTH} + env
- *      unset → CRASH. Proves that ${ENV} interpolation of unset vars produces
- *      a truthy string, which is why the shipped default MUST be literal false.
- *   4. ENABLED: mcp.enabled: true + env vars set → /mcp mounts, CIMD
- *      metadata advertises.
+ * Since flair#1152 the shipped config.yaml carries `mcp.enabled:
+ * ${FLAIR_MCP_OAUTH}` (whole-token env reference) and — flair#1180 — NO
+ * `resource` key (the component's resolveResource() derives `<issuer>/mcp` at
+ * request time). These tests boot ephemeral Harper instances against the
+ * shipped and mutated configs and verify:
+ *
+ *   0. RESOLVED VERSION: the installed @harperfast/oauth is >= 2.5.0. Below
+ *      that, normalizeBooleanField does not exist and an unresolved
+ *      ${FLAIR_MCP_OAUTH} placeholder is a TRUTHY STRING — the env-referenced
+ *      `enabled` fails OPEN. Sherlock's binding (flair#1152 review): this
+ *      assertion lives in the SAME file as the behavioral gate below, so a
+ *      future downgrade or partial install trips both in one CI run.
+ *   1. SHIPPED SHAPE: config.yaml carries the whole-token env reference and
+ *      no resource key.
+ *   2. BOOT-SAFETY + ${ENV} BACKSTOP (behavioral gate): the ACTUAL shipped
+ *      config with FLAIR_MCP_* env unset boots CLEAN with /mcp 404 — i.e.
+ *      oauth 2.5.0's normalizeBooleanField deleted the unresolved placeholder
+ *      and the plugin default (disabled) applied. On oauth < 2.5.0 this test
+ *      FAILS (truthy placeholder + unresolved issuer -> degraded boot, /mcp
+ *      500). A red here is the dependency drift speaking — treat it as a
+ *      positive control, not a flake.
+ *   3. MUTATION-PROVE (literal true): mcp.enabled: true + env unset -> boots
+ *      DEGRADED. Proves test 2's clean-boot assertions CAN fire.
+ *   4. GARBAGE VALUE (flair#1152 residual): FLAIR_MCP_OAUTH=maybe. Measured
+ *      on oauth 2.5.0 the component's coerceConfigBoolean accepts ONLY
+ *      "true"/"false" and DELETES anything else — so garbage disables the
+ *      component too, and flair's strict mcpOAuthEnabled() stays false: BOTH
+ *      sides off, no /mcp handler, no data path. (The AS-metadata 200 in that
+ *      state is flair's OWN discovery document — oauth-discovery.ts serves it
+ *      whenever the strict flag is off — NOT the component's AS; the test
+ *      asserts the discriminating field.) If either reader's vocabulary ever
+ *      changes, this test is the tripwire.
+ *   5. ENABLED: shipped config VERBATIM + FLAIR_MCP_OAUTH=true -> /mcp
+ *      mounts, the COMPONENT's AS metadata advertises CIMD, and the RFC 9728
+ *      metadata carries the DERIVED `<issuer>/mcp` resource (flair#1180 — no
+ *      composite literal). "true" is the ONE value both readers accept:
+ *      flair's flag takes 1/true/yes/on but the component deletes anything
+ *      but "true"/"false", so e.g. FLAIR_MCP_OAUTH=1 yields a guarded /mcp
+ *      with NO authorization server behind it (fail-closed broken-on).
  */
 
-import { describe, test, expect, afterAll } from "bun:test";
+import { describe, test, expect, beforeAll, afterEach, afterAll } from "bun:test";
 import { readFileSync, writeFileSync, mkdtempSync, rmSync, symlinkSync, copyFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import yaml from "js-yaml";
 import { startHarper, stopHarper, type HarperInstance } from "../helpers/harper-lifecycle.js";
+import { mcpOAuthEnabled } from "../../resources/mcp-oauth-flag.ts";
 
 const REPO_ROOT = join(import.meta.dir, "..", "..");
 const SHIPPED_CONFIG = join(REPO_ROOT, "config.yaml");
 
+// The exact whole-token env reference the shipped config must carry
+// (flair#1152). Composites never interpolate — whole-token or nothing.
+const ENABLED_ENV_REFERENCE = "${FLAIR_MCP_OAUTH}";
+
 let instances: HarperInstance[] = [];
 let tempDirs: string[] = [];
+
+// ── Env hygiene: every boot in this file must control the FLAIR_MCP_* env ──
+// The shipped config now REFERENCES the environment, so an ambient
+// FLAIR_MCP_OAUTH leaking in from the runner would change what these tests
+// boot. Save once, restore after every test.
+const MCP_ENV_KEYS = [
+  "FLAIR_MCP_OAUTH",
+  "FLAIR_MCP_ISSUER",
+  "FLAIR_PUBLIC_URL",
+  "FLAIR_MCP_SIGNING_KEY_PEM",
+  "OAUTH_GITHUB_CLIENT_ID",
+  "OAUTH_GITHUB_CLIENT_SECRET",
+] as const;
+const savedEnv: Record<string, string | undefined> = {};
+beforeAll(() => {
+  for (const k of MCP_ENV_KEYS) savedEnv[k] = process.env[k];
+});
+afterEach(() => {
+  for (const k of MCP_ENV_KEYS) {
+    if (savedEnv[k] === undefined) delete process.env[k];
+    else process.env[k] = savedEnv[k]!;
+  }
+});
+function clearMcpEnv(): void {
+  for (const k of MCP_ENV_KEYS) delete process.env[k];
+}
 
 afterAll(async () => {
   for (const h of instances) {
@@ -35,27 +97,92 @@ afterAll(async () => {
   }
 });
 
-// ─── BOOT-SAFETY: shipped config, no env → clean boot ──────────────────────
+function makeWorkDirWithShippedConfig(prefix: string, mutate?: (shipped: string) => string): string {
+  const workDir = mkdtempSync(join(tmpdir(), prefix));
+  tempDirs.push(workDir);
+  // Symlink node_modules and dist so Harper can find @harperfast/oauth and
+  // the JS resources (mcp-oauth.ts, etc.).
+  symlinkSync(join(REPO_ROOT, "node_modules"), join(workDir, "node_modules"));
+  symlinkSync(join(REPO_ROOT, "dist"), join(workDir, "dist"));
+  if (mutate) {
+    const shipped = readFileSync(SHIPPED_CONFIG, "utf-8");
+    writeFileSync(join(workDir, "config.yaml"), mutate(shipped), "utf-8");
+  } else {
+    // NEVER boot in-place (cwd: REPO_ROOT) — Harper WRITES to config.yaml in
+    // its cwd at boot (adds ports, etc.), which would corrupt the committed
+    // file. Copy the ACTUAL shipped config verbatim instead.
+    copyFileSync(SHIPPED_CONFIG, join(workDir, "config.yaml"));
+  }
+  return workDir;
+}
 
-describe("flair#1136 boot-safety: shipped config with mcp.enabled: false", () => {
+// ─── 0. RESOLVED @harperfast/oauth VERSION (flair#1152 precondition) ────────
+
+describe("flair#1152 precondition: resolved @harperfast/oauth version", () => {
+  test("node_modules resolves @harperfast/oauth >= 2.5.0 (normalizeBooleanField fail-safe)", () => {
+    // This reads the RESOLVED tree, not the declared dependency: the drift
+    // that motivated it was a checkout whose package.json AND lockfile said
+    // 2.5.0 while node_modules held 2.4.0 — where the env-referenced
+    // mcp.enabled fails OPEN (an unresolved placeholder is a truthy string).
+    // A declared-version pin is not a control when the resolved tree
+    // diverges. Fails here => run a fresh install; do NOT ship the
+    // env-referenced config against the older component.
+    const pkgPath = join(REPO_ROOT, "node_modules", "@harperfast", "oauth", "package.json");
+    const pkg = JSON.parse(readFileSync(pkgPath, "utf-8")) as { version?: string };
+    expect(typeof pkg.version).toBe("string");
+    const version = pkg.version!;
+    const [major, minor] = version.split("-")[0]!.split(".").map(Number);
+    expect(Number.isFinite(major)).toBe(true);
+    expect(Number.isFinite(minor)).toBe(true);
+    // >= 2.5.0: major > 2, or major == 2 and minor >= 5.
+    const atLeast250 = major! > 2 || (major === 2 && minor! >= 5);
+    if (!atLeast250) {
+      throw new Error(
+        `resolved @harperfast/oauth is ${version} (< 2.5.0) — normalizeBooleanField is missing, ` +
+        `so the shipped mcp.enabled: ${ENABLED_ENV_REFERENCE} placeholder fails OPEN when unset. ` +
+        `Re-run a clean install; the behavioral gate in this file should be red too.`,
+      );
+    }
+  });
+});
+
+// ─── 1. SHIPPED SHAPE (flair#1152 + flair#1180) ─────────────────────────────
+
+describe("flair#1152/#1180 shipped config shape", () => {
+  test("mcp.enabled is the whole-token env reference; no resource key; issuer whole-token", () => {
+    const doc = yaml.load(readFileSync(SHIPPED_CONFIG, "utf-8")) as any;
+    const mcp = doc["@harperfast/oauth"].mcp;
+    // flair#1152: the on/off choice lives in the ENVIRONMENT. A literal here
+    // (true OR false) reintroduces the packed-file revert problem.
+    expect(mcp.enabled).toBe(ENABLED_ENV_REFERENCE);
+    // flair#1180: NO resource key — the component derives `<issuer>/mcp` at
+    // request time. A composite like `${FLAIR_MCP_ISSUER}/mcp` NEVER
+    // interpolates (whole-token-only expansion) and fails every connect with
+    // invalid_target. (Escape hatch for a non-standard resource: an explicit
+    // LITERAL absolute URL — which this assertion would catch; loosen it
+    // deliberately if that day comes.)
+    expect("resource" in mcp).toBe(false);
+    // issuer stays the whole-token reference that interpolates correctly.
+    expect(mcp.issuer).toBe("${FLAIR_MCP_ISSUER}");
+    // DCR stays explicitly disabled (flair#756) — untouched by the reshape.
+    expect(mcp.dynamicClientRegistration.enabled).toBe(false);
+  });
+});
+
+// ─── 2. BOOT-SAFETY + ${ENV} BACKSTOP: shipped config, env unset ────────────
+
+describe("flair#1136/#1152 boot-safety: shipped config with env-referenced mcp.enabled, env unset", () => {
   test(
-    "Harper boots cleanly with the ACTUAL shipped config.yaml and no FLAIR_MCP_* env",
+    "Harper boots CLEAN with the ACTUAL shipped config.yaml and no FLAIR_MCP_* env (oauth 2.5.0+ deletes the unresolved placeholder)",
     async () => {
-      // NEVER boot in-place (cwd: REPO_ROOT) — Harper WRITES to config.yaml
-      // in its cwd at boot (adds ports, etc.), which would corrupt the
-      // committed file. Instead, copy the shipped config VERBATIM into a
-      // temp component tree and boot from there. This still tests the REAL
-      // shipped content without mutating the repo.
-      const workDir = mkdtempSync(join(tmpdir(), "flair-boot-safety-"));
-      tempDirs.push(workDir);
-
-      // Copy the ACTUAL shipped config.yaml verbatim.
-      copyFileSync(SHIPPED_CONFIG, join(workDir, "config.yaml"));
-
-      // Symlink node_modules and dist so Harper can find the plugin and JS
-      // resources.
-      symlinkSync(join(REPO_ROOT, "node_modules"), join(workDir, "node_modules"));
-      symlinkSync(join(REPO_ROOT, "dist"), join(workDir, "dist"));
+      // BEHAVIORAL GATE for the resolved-version precondition above: on
+      // oauth < 2.5.0 the unresolved ${FLAIR_MCP_OAUTH} placeholder is a
+      // truthy string — the plugin tries to load with an unresolved issuer,
+      // boot degrades, and /mcp answers 500, so this test goes RED alongside
+      // the version assertion. That red is the drift speaking — a positive
+      // control, not a flake.
+      clearMcpEnv();
+      const workDir = makeWorkDirWithShippedConfig("flair-boot-safety-");
 
       const harper = await startHarper({
         cwd: workDir,
@@ -67,16 +194,15 @@ describe("flair#1136 boot-safety: shipped config with mcp.enabled: false", () =>
       expect(harper.httpURL).toBeTruthy();
       expect(harper.opsURL).toBeTruthy();
 
-      // Ops API is healthy (Harper is running).
+      // Ops API is healthy (Harper is running, NOT degraded).
       const opsRes = await fetch(harper.opsURL, {
         signal: AbortSignal.timeout(10_000),
       });
       expect(opsRes.status).toBe(200);
 
       // /mcp returns 404 — MCP is OFF (not degraded). When the plugin
-      // degrades (mcp.enabled: true + issuer unset), /mcp returns 500.
-      // A 404 here proves the shipped default is inert. If someone
-      // accidentally ships enabled: true, this assertion fires.
+      // degrades (enabled truthy + issuer unset), /mcp returns 500. A 404
+      // here proves the shipped default is inert with no env set.
       const mcpRes = await fetch(`${harper.httpURL}/mcp`, {
         signal: AbortSignal.timeout(10_000),
       });
@@ -86,24 +212,20 @@ describe("flair#1136 boot-safety: shipped config with mcp.enabled: false", () =>
   );
 });
 
-// ─── MUTATION-PROVE: enabled:true + no env → CRASH ─────────────────────────
+// ─── 3. MUTATION-PROVE: enabled:true + no env → DEGRADED ────────────────────
 
 describe("flair#1136 mutation-prove: mcp.enabled: true with env unset", () => {
   test(
     "literal true: Harper boots DEGRADED when mcp.enabled is true but FLAIR_MCP_* env is unset",
     async () => {
-      const workDir = mkdtempSync(join(tmpdir(), "flair-mutation-prove-literal-"));
-      const configPath = join(workDir, "config.yaml");
-
-      // Symlink node_modules and dist so Harper can find @harperfast/oauth
-      // and the JS resources (mcp-oauth.ts, etc.).
-      symlinkSync(join(REPO_ROOT, "node_modules"), join(workDir, "node_modules"));
-      symlinkSync(join(REPO_ROOT, "dist"), join(workDir, "dist"));
-
-      // Read the shipped config and flip mcp.enabled to literal true.
-      const shipped = readFileSync(join(REPO_ROOT, "config.yaml"), "utf-8");
-      const mutated = shipped.replace("enabled: false", "enabled: true");
-      writeFileSync(configPath, mutated, "utf-8");
+      clearMcpEnv();
+      const shipped = readFileSync(SHIPPED_CONFIG, "utf-8");
+      const mutated = shipped.replace(`enabled: ${ENABLED_ENV_REFERENCE}`, "enabled: true");
+      // The mutation must actually land — if the shipped enabled line ever
+      // changes shape, this replace would silently no-op and the test below
+      // would fail confusingly on the clean boot instead.
+      expect(mutated).not.toBe(shipped);
+      const workDir = makeWorkDirWithShippedConfig("flair-mutation-prove-literal-", () => mutated);
 
       // Harper boots but the plugin fails to load because the issuer
       // ("${FLAIR_MCP_ISSUER}" literal, env unset) is not a valid URL.
@@ -115,7 +237,7 @@ describe("flair#1136 mutation-prove: mcp.enabled: true with env unset", () => {
       instances.push(harper);
 
       // PROOF: the health endpoint is degraded (500, not 200).
-      // The boot-safety test checks for 200 — this proves it CAN fire.
+      // The boot-safety test checks for 200/404 — this proves it CAN fire.
       const healthRes = await fetch(`${harper.httpURL}/health`, {
         signal: AbortSignal.timeout(10_000),
       });
@@ -129,130 +251,158 @@ describe("flair#1136 mutation-prove: mcp.enabled: true with env unset", () => {
       const mcpBody = await mcpRes.text();
       expect(mcpBody).toContain("mcp.issuer must be an absolute http(s) origin");
       expect(mcpBody).toContain("${FLAIR_MCP_ISSUER}");
-
-      // Clean up the temp dir.
-      try { rmSync(workDir, { recursive: true, force: true }); } catch { /* ok */ }
-    },
-    120_000,
-  );
-
-  test(
-    "${ENV} backstop: an unresolved mcp.enabled placeholder fail-safes to DISABLED (oauth 2.5.0+)",
-    async () => {
-      const workDir = mkdtempSync(join(tmpdir(), "flair-mutation-prove-env-"));
-      const configPath = join(workDir, "config.yaml");
-
-      // Symlink node_modules and dist so Harper can find @harperfast/oauth
-      // and the JS resources (mcp-oauth.ts, etc.).
-      symlinkSync(join(REPO_ROOT, "node_modules"), join(workDir, "node_modules"));
-      symlinkSync(join(REPO_ROOT, "dist"), join(workDir, "dist"));
-
-      // Read the shipped config and replace literal `false` with
-      // `${FLAIR_MCP_OAUTH}` — simulating what would happen if we shipped
-      // with env-var interpolation on the enabled flag.
-      const shipped = readFileSync(join(REPO_ROOT, "config.yaml"), "utf-8");
-      const mutated = shipped.replace("enabled: false", 'enabled: "${FLAIR_MCP_OAUTH}"');
-      writeFileSync(configPath, mutated, "utf-8");
-
-      // oauth 2.5.0+ backstop: normalizeBooleanField detects the unresolved
-      // ${FLAIR_MCP_OAUTH} placeholder on mcp.enabled, warns, and DELETES the
-      // field — so the documented default (disabled) applies and Harper boots
-      // CLEAN with mcp OFF, instead of the pre-2.5.0 behavior where the truthy
-      // placeholder string enabled the crash path. We STILL ship literal false
-      // (proven by the sibling shipped-config test) — this proves the plugin
-      // fail-safes the ${ENV} form rather than failing degraded.
-      const harper = await startHarper({
-        cwd: workDir,
-        harperBinDir: REPO_ROOT,
-      });
-      instances.push(harper);
-
-      // PROOF: clean boot — Harper is healthy (ops API 200), NOT degraded.
-      const opsRes = await fetch(harper.opsURL, {
-        signal: AbortSignal.timeout(10_000),
-      });
-      expect(opsRes.status).toBe(200);
-
-      // /mcp is 404 — MCP is OFF (the placeholder was dropped to the default),
-      // not 500 (which is what a degraded plugin load returns).
-      const mcpRes = await fetch(`${harper.httpURL}/mcp`, {
-        signal: AbortSignal.timeout(10_000),
-      });
-      expect(mcpRes.status).toBe(404);
-
-      // Clean up the temp dir.
-      try { rmSync(workDir, { recursive: true, force: true }); } catch { /* ok */ }
     },
     120_000,
   );
 });
 
-// ─── ENABLED: enabled:true + env → /mcp mounts ─────────────────────────────
+// ─── 4. GARBAGE VALUE: FLAIR_MCP_OAUTH=maybe → inert AS, no data path ──────
 
-describe("flair#1136 enabled path: mcp.enabled: true + env", () => {
+describe("flair#1152 garbage value: FLAIR_MCP_OAUTH=maybe", () => {
+  test("flair's strict mcpOAuthEnabled() stays false for a garbage value (in-process divergence)", () => {
+    // The asymmetry that keeps the garbage case inert, asserted at its
+    // source: the component treats any non-empty resolved string as truthy;
+    // this function does not.
+    clearMcpEnv();
+    process.env.FLAIR_MCP_OAUTH = "maybe";
+    expect(mcpOAuthEnabled()).toBe(false);
+    // Positive control — the same code path DOES accept the real values, so
+    // a broken import/allowlist can't fake the assertion above.
+    process.env.FLAIR_MCP_OAUTH = "1";
+    expect(mcpOAuthEnabled()).toBe(true);
+  });
+
   test(
-    "/mcp mounts and advertises CIMD when enabled:true + issuer/keys env set",
+    "a garbage value disables BOTH sides — component deletes it, flair's strict flag stays off",
     async () => {
-      const workDir = mkdtempSync(join(tmpdir(), "flair-enabled-"));
-      const configPath = join(workDir, "config.yaml");
-
-      // Symlink node_modules and dist so Harper can find @harperfast/oauth
-      // and the JS resources (mcp-oauth.ts, etc.).
-      symlinkSync(join(REPO_ROOT, "node_modules"), join(workDir, "node_modules"));
-      symlinkSync(join(REPO_ROOT, "dist"), join(workDir, "dist"));
-
-      const shipped = readFileSync(join(REPO_ROOT, "config.yaml"), "utf-8");
-      const mutated = shipped.replace("enabled: false", "enabled: true");
-      writeFileSync(configPath, mutated, "utf-8");
-
-      // Generate a test signing key.
+      // The spec (and the flair#1152 security review) modeled the component
+      // as reading `enabled` truthy-string, predicting garbage would mount an
+      // inert AS. MEASURED on oauth 2.5.0 it is safer than that: the
+      // component's coerceConfigBoolean accepts ONLY "true"/"false" and
+      // normalizeBooleanField DELETES any other string ("maybe" included, and
+      // "1"/"yes"/"on" too) so the disabled default applies — the upstream
+      // "treat any non-boolean string as absent" ask is ALREADY implemented.
+      // flair's strict flag is also off for "maybe": no /mcp handler, no AS,
+      // no data path. Boot stays CLEAN (the deleted flag means the plugin
+      // never validates the issuer). If either reader's vocabulary changes,
+      // an assertion below flips — re-derive the whole table before shipping
+      // that change.
+      clearMcpEnv();
       const { generateKeyPairSync } = await import("node:crypto");
       const { privateKey } = generateKeyPairSync("rsa", {
         modulusLength: 2048,
         publicKeyEncoding: { type: "spki", format: "pem" },
         privateKeyEncoding: { type: "pkcs8", format: "pem" },
       });
+      process.env.FLAIR_MCP_OAUTH = "maybe";
+      process.env.FLAIR_MCP_ISSUER = "https://test.example.com";
+      process.env.FLAIR_MCP_SIGNING_KEY_PEM = privateKey;
+      process.env.OAUTH_GITHUB_CLIENT_ID = "test-client-id";
+      process.env.OAUTH_GITHUB_CLIENT_SECRET = "test-client-secret";
 
-      // Set env vars before spawning Harper.
-      const prevOauth = process.env.FLAIR_MCP_OAUTH;
-      const prevIssuer = process.env.FLAIR_MCP_ISSUER;
-      const prevKey = process.env.FLAIR_MCP_SIGNING_KEY_PEM;
-      const prevGhId = process.env.OAUTH_GITHUB_CLIENT_ID;
-      const prevGhSecret = process.env.OAUTH_GITHUB_CLIENT_SECRET;
-      try {
-        process.env.FLAIR_MCP_OAUTH = "1";
-        process.env.FLAIR_MCP_ISSUER = "https://test.example.com";
-        process.env.FLAIR_MCP_SIGNING_KEY_PEM = privateKey;
-        process.env.OAUTH_GITHUB_CLIENT_ID = "test-client-id";
-        process.env.OAUTH_GITHUB_CLIENT_SECRET = "test-client-secret";
+      const workDir = makeWorkDirWithShippedConfig("flair-garbage-value-");
+      const harper = await startHarper({
+        cwd: workDir,
+        harperBinDir: REPO_ROOT,
+      });
+      instances.push(harper);
 
-        const harper = await startHarper({
-          cwd: workDir,
-          harperBinDir: REPO_ROOT,
-        });
-        instances.push(harper);
+      // Clean boot — the deleted flag leaves the plugin fully inert (a
+      // degraded boot here would answer 500 on everything).
+      const opsRes = await fetch(harper.opsURL, {
+        signal: AbortSignal.timeout(10_000),
+      });
+      expect(opsRes.status).toBe(200);
 
-        // /mcp should be mounted (returns 401 without auth, not 404).
-        const mcpRes = await fetch(`${harper.httpURL}/mcp`, {
-          signal: AbortSignal.timeout(10_000),
-        });
-        expect(mcpRes.status).toBe(401);
+      // The AS-metadata path answers 200 — but it is FLAIR'S OWN discovery
+      // document (oauth-discovery.ts serves it whenever the strict flag is
+      // off), NOT the component's AS. Flair's document names the in-process
+      // /OAuthToken endpoint; the component's names its own /oauth/mcp path.
+      // If the component's AS ever mounts for a garbage value again
+      // (vocabulary widened back to truthy-string), this discriminator flips.
+      const metaRes = await fetch(
+        `${harper.httpURL}/.well-known/oauth-authorization-server`,
+        { signal: AbortSignal.timeout(10_000) },
+      );
+      expect(metaRes.status).toBe(200);
+      const meta = await metaRes.json();
+      expect(String(meta.token_endpoint)).toContain("/OAuthToken");
 
-        // CIMD metadata should be advertised.
-        const metaRes = await fetch(
-          `${harper.httpURL}/.well-known/oauth-authorization-server`,
-          { signal: AbortSignal.timeout(10_000) },
-        );
-        expect(metaRes.status).toBe(200);
-        const meta = await metaRes.json();
-        expect(meta.client_id_metadata_document_supported).toBe(true);
-      } finally {
-        if (prevOauth !== undefined) process.env.FLAIR_MCP_OAUTH = prevOauth; else delete process.env.FLAIR_MCP_OAUTH;
-        if (prevIssuer !== undefined) process.env.FLAIR_MCP_ISSUER = prevIssuer; else delete process.env.FLAIR_MCP_ISSUER;
-        if (prevKey !== undefined) process.env.FLAIR_MCP_SIGNING_KEY_PEM = prevKey; else delete process.env.FLAIR_MCP_SIGNING_KEY_PEM;
-        if (prevGhId !== undefined) process.env.OAUTH_GITHUB_CLIENT_ID = prevGhId; else delete process.env.OAUTH_GITHUB_CLIENT_ID;
-        if (prevGhSecret !== undefined) process.env.OAUTH_GITHUB_CLIENT_SECRET = prevGhSecret; else delete process.env.OAUTH_GITHUB_CLIENT_SECRET;
-      }
+      // flair side: mcpOAuthEnabled() is strict — no /mcp handler was
+      // registered. 404, not 401 (mounted+guarded) and not 500 (degraded).
+      const mcpRes = await fetch(`${harper.httpURL}/mcp`, {
+        signal: AbortSignal.timeout(10_000),
+      });
+      expect(mcpRes.status).toBe(404);
+    },
+    120_000,
+  );
+});
+
+// ─── 5. ENABLED: shipped config VERBATIM + env → /mcp mounts ────────────────
+
+describe("flair#1152 enabled path: shipped config verbatim + env set", () => {
+  test(
+    "/mcp mounts, CIMD advertises, and RFC 9728 metadata carries the DERIVED <issuer>/mcp resource",
+    async () => {
+      // flair#1152's whole point, end-to-end: NO config mutation. The shipped
+      // file already references the environment, so setting the env vars is
+      // the entire enablement story — nothing for a re-packed deploy to
+      // revert.
+      //
+      // "true", NOT "1": the component's coerceConfigBoolean accepts only
+      // "true"/"false" and deletes anything else, while flair's flag takes
+      // 1/true/yes/on — so "true" is the one value that enables BOTH sides
+      // (and it is what buildSecretsBundle stages). With "1" this test fails:
+      // /mcp is guarded (flair on) but the AS metadata 404s (component off).
+      clearMcpEnv();
+      const { generateKeyPairSync } = await import("node:crypto");
+      const { privateKey } = generateKeyPairSync("rsa", {
+        modulusLength: 2048,
+        publicKeyEncoding: { type: "spki", format: "pem" },
+        privateKeyEncoding: { type: "pkcs8", format: "pem" },
+      });
+      process.env.FLAIR_MCP_OAUTH = "true";
+      process.env.FLAIR_MCP_ISSUER = "https://test.example.com";
+      process.env.FLAIR_MCP_SIGNING_KEY_PEM = privateKey;
+      process.env.OAUTH_GITHUB_CLIENT_ID = "test-client-id";
+      process.env.OAUTH_GITHUB_CLIENT_SECRET = "test-client-secret";
+
+      const workDir = makeWorkDirWithShippedConfig("flair-enabled-");
+      const harper = await startHarper({
+        cwd: workDir,
+        harperBinDir: REPO_ROOT,
+      });
+      instances.push(harper);
+
+      // /mcp should be mounted (returns 401 without auth, not 404).
+      const mcpRes = await fetch(`${harper.httpURL}/mcp`, {
+        signal: AbortSignal.timeout(10_000),
+      });
+      expect(mcpRes.status).toBe(401);
+
+      // CIMD metadata should be advertised.
+      const metaRes = await fetch(
+        `${harper.httpURL}/.well-known/oauth-authorization-server`,
+        { signal: AbortSignal.timeout(10_000) },
+      );
+      expect(metaRes.status).toBe(200);
+      const meta = await metaRes.json();
+      expect(meta.client_id_metadata_document_supported).toBe(true);
+
+      // flair#1180 regression: with NO resource key configured, the RFC 9728
+      // Protected Resource Metadata advertises the DERIVED `<issuer>/mcp` —
+      // the same canonical value flair's in-process route binds tokens to.
+      // Under the old composite config this document carried the literal
+      // string "${FLAIR_MCP_ISSUER}/mcp" and every connect died with
+      // invalid_target.
+      const prmRes = await fetch(
+        `${harper.httpURL}/.well-known/oauth-protected-resource/mcp`,
+        { signal: AbortSignal.timeout(10_000) },
+      );
+      expect(prmRes.status).toBe(200);
+      const prm = await prmRes.json();
+      expect(prm.resource).toBe("https://test.example.com/mcp");
     },
     120_000,
   );

--- a/test/integration/mcp-oauth-boot-safety.test.ts
+++ b/test/integration/mcp-oauth-boot-safety.test.ts
@@ -316,10 +316,9 @@ describe("flair#1152 garbage value: FLAIR_MCP_OAUTH=maybe", () => {
 
       // The AS-metadata path answers 200 — but it is FLAIR'S OWN discovery
       // document (oauth-discovery.ts serves it whenever the strict flag is
-      // off), NOT the component's AS. Flair's document names the in-process
-      // /OAuthToken endpoint; the component's names its own /oauth/mcp path.
-      // If the component's AS ever mounts for a garbage value again
-      // (vocabulary widened back to truthy-string), this discriminator flips.
+      // off — it SHADOWS the component's well-known handlers in that state,
+      // so this document alone cannot reveal whether the component mounted).
+      // Flair's document names the in-process /OAuthToken endpoint.
       const metaRes = await fetch(
         `${harper.httpURL}/.well-known/oauth-authorization-server`,
         { signal: AbortSignal.timeout(10_000) },
@@ -327,6 +326,19 @@ describe("flair#1152 garbage value: FLAIR_MCP_OAUTH=maybe", () => {
       expect(metaRes.status).toBe(200);
       const meta = await metaRes.json();
       expect(String(meta.token_endpoint)).toContain("/OAuthToken");
+
+      // THE component-mount tripwire: /oauth/mcp/* is dispatched by the
+      // component itself (never shadowed by flair) and its dispatcher
+      // answers 404 whenever mcp.enabled is falsy (existence-hiding,
+      // dist/lib/mcp/index.js handleMCPGet). Garbage was DELETED by
+      // normalizeBooleanField -> disabled -> 404 here. If the component's
+      // vocabulary ever widens back to truthy-string, this becomes a live
+      // authorize endpoint (non-404) and THIS assertion fires.
+      const authorizeRes = await fetch(
+        `${harper.httpURL}/oauth/mcp/authorize`,
+        { signal: AbortSignal.timeout(10_000) },
+      );
+      expect(authorizeRes.status).toBe(404);
 
       // flair side: mcpOAuthEnabled() is strict — no /mcp handler was
       // registered. 404, not 401 (mounted+guarded) and not 500 (degraded).

--- a/test/unit/mcp-enable.test.ts
+++ b/test/unit/mcp-enable.test.ts
@@ -180,11 +180,28 @@ describe("buildMcpOAuthConfigBlock", () => {
     expect(oauth.package).toBe("@harperfast/oauth");
     expect(oauth.providers.github.clientId).toBe("${OAUTH_GITHUB_CLIENT_ID}");
     expect(oauth.providers.github.clientSecret).toBe("${OAUTH_GITHUB_CLIENT_SECRET}");
-    expect(oauth.mcp.enabled).toBe(true);
+    // flair#1152: mcp.enabled is the WHOLE-TOKEN env reference — never a
+    // literal boolean. The on/off choice lives in the environment, so a
+    // re-packed deploy cannot revert it.
+    expect(oauth.mcp.enabled).toBe("${FLAIR_MCP_OAUTH}");
     expect(oauth.mcp.accessTokenTtl).toBe(REQUIRED_ACCESS_TOKEN_TTL);
     expect(oauth.mcp.accessTokenTtl).toBe(900);
     expect(oauth.mcp.clientIdMetadataDocuments.allowedHosts).toEqual(DEFAULT_CIMD_ALLOWED_HOSTS);
     expect(oauth.mcp.signingKeyPem).toBe("${FLAIR_MCP_SIGNING_KEY_PEM}");
+  });
+
+  test("flair#1180: NO resource key is emitted — the component derives <issuer>/mcp", () => {
+    // The old composite `resource: "${FLAIR_MCP_ISSUER}/mcp"` NEVER
+    // interpolated (env expansion is whole-token-only) and failed every
+    // connect with invalid_target. Absent, the component's resolveResource()
+    // derives `<issuer>/mcp` at request time — identical to flair's
+    // in-process derivation. An operator needing a non-standard resource
+    // sets an explicit LITERAL absolute URL in config.yaml by hand.
+    const block = buildMcpOAuthConfigBlock({ idpProvider: "github" });
+    const mcp = (block["@harperfast/oauth"] as any).mcp;
+    expect("resource" in mcp).toBe(false);
+    // And nothing else in the block smuggles the composite back in.
+    expect(JSON.stringify(block)).not.toContain("${FLAIR_MCP_ISSUER}/mcp");
   });
 
   test("flair#756: dynamicClientRegistration is ALWAYS explicitly disabled — never omitted", () => {
@@ -245,7 +262,11 @@ describe("buildSecretsBundle / writeSecretsStagingFile / provisionSecrets", () =
       idpClientId: "client-id-value",
       idpClientSecret: "client-secret-value",
     });
-    expect(bundle.FLAIR_MCP_OAUTH).toBe("1");
+    // "true" EXACTLY (flair#1152): the component's coerceConfigBoolean
+    // accepts only "true"/"false" and DELETES anything else — staging "1"
+    // (flair-truthy, component-deleted) yields a guarded /mcp with NO
+    // authorization server behind it.
+    expect(bundle.FLAIR_MCP_OAUTH).toBe("true");
     expect(bundle.FLAIR_MCP_ISSUER).toBe(ISSUER);
     expect(bundle.FLAIR_MCP_SIGNING_KEY_PEM).toContain("BEGIN PRIVATE KEY");
     expect(bundle.OAUTH_GITHUB_CLIENT_ID).toBe("client-id-value");
@@ -1086,6 +1107,10 @@ describe("updateLocalConfigMcpEnabled (flair#1136)", () => {
     expect(readFileSync(REPO_CONFIG, "utf-8")).toBe(repoConfigBefore);
   });
 
+  // The flair#1152 shape: no `resource` key (flair#1180 — derived by the
+  // component), and mcp.enabled carrying either literal `false` (decisively
+  // off) or the whole-token env reference (the shipped/enabled shape).
+  const ENV_REF = "${FLAIR_MCP_OAUTH}";
   const CONFIG_WITH_MCP_DISABLED = `name: flair
 rest: true
 "@harperfast/oauth":
@@ -1097,7 +1122,6 @@ rest: true
   mcp:
     enabled: false
     issuer: "\${FLAIR_MCP_ISSUER}"
-    resource: "\${FLAIR_MCP_ISSUER}/mcp"
     accessTokenTtl: 900
     dynamicClientRegistration:
       enabled: false
@@ -1107,23 +1131,39 @@ rest: true
         - "claude.com"
     signingKeyPem: "\${FLAIR_MCP_SIGNING_KEY_PEM}"
 `;
+  const CONFIG_WITH_ENV_REF = CONFIG_WITH_MCP_DISABLED.replace(
+    "enabled: false",
+    `enabled: "\${FLAIR_MCP_OAUTH}"`,
+  );
 
-  test("flips enabled: false → true", () => {
+  test("enable writes the WHOLE-TOKEN env reference — never literal true (flair#1152)", () => {
     writeFileSync(configPath, CONFIG_WITH_MCP_DISABLED, "utf-8");
     const result = updateLocalConfigMcpEnabled(true, configPath);
     expect(result.ok).toBe(true);
-    expect(result.detail).toContain("mcp.enabled set to true");
+    expect(result.detail).toContain(`mcp.enabled set to ${ENV_REF}`);
     // Re-parse to verify the mutation is structural, not string-level.
     const updated = readFileSync(configPath, "utf-8");
     const doc = yaml.load(updated) as any;
-    expect(doc["@harperfast/oauth"].mcp.enabled).toBe(true);
+    // The env reference — the on/off choice lives in the environment
+    // (FLAIR_MCP_OAUTH, staged to "true" by the secrets bundle), so a re-packed
+    // deploy can no longer revert it. A literal true here is the regression.
+    expect(doc["@harperfast/oauth"].mcp.enabled).toBe(ENV_REF);
+    expect(doc["@harperfast/oauth"].mcp.enabled).not.toBe(true);
     // dynamicClientRegistration.enabled is a separate key and stays false.
     expect(doc["@harperfast/oauth"].mcp.dynamicClientRegistration.enabled).toBe(false);
   });
 
-  test("flips enabled: true → false", () => {
-    const enabledConfig = CONFIG_WITH_MCP_DISABLED.replace("enabled: false", "enabled: true");
-    writeFileSync(configPath, enabledConfig, "utf-8");
+  test("legacy literal true is normalized to the env reference on enable", () => {
+    const legacyEnabled = CONFIG_WITH_MCP_DISABLED.replace("enabled: false", "enabled: true");
+    writeFileSync(configPath, legacyEnabled, "utf-8");
+    const result = updateLocalConfigMcpEnabled(true, configPath);
+    expect(result.ok).toBe(true);
+    const doc = yaml.load(readFileSync(configPath, "utf-8")) as any;
+    expect(doc["@harperfast/oauth"].mcp.enabled).toBe(ENV_REF);
+  });
+
+  test("disable writes literal false — decisively off regardless of environment", () => {
+    writeFileSync(configPath, CONFIG_WITH_ENV_REF, "utf-8");
     const result = updateLocalConfigMcpEnabled(false, configPath);
     expect(result.ok).toBe(true);
     expect(result.detail).toContain("mcp.enabled set to false");
@@ -1131,13 +1171,22 @@ rest: true
     expect(doc["@harperfast/oauth"].mcp.enabled).toBe(false);
   });
 
-  test("already at target value: no-op", () => {
+  test("already at target value: no-op (disabled)", () => {
     writeFileSync(configPath, CONFIG_WITH_MCP_DISABLED, "utf-8");
     const result = updateLocalConfigMcpEnabled(false, configPath);
     expect(result.ok).toBe(true);
     expect(result.detail).toContain("already false");
     // File unchanged.
     expect(readFileSync(configPath, "utf-8")).toBe(CONFIG_WITH_MCP_DISABLED);
+  });
+
+  test("already at target value: no-op (env reference present, enable)", () => {
+    writeFileSync(configPath, CONFIG_WITH_ENV_REF, "utf-8");
+    const result = updateLocalConfigMcpEnabled(true, configPath);
+    expect(result.ok).toBe(true);
+    expect(result.detail).toContain(`already ${ENV_REF}`);
+    // File unchanged.
+    expect(readFileSync(configPath, "utf-8")).toBe(CONFIG_WITH_ENV_REF);
   });
 
   test("file not found at explicit path", () => {
@@ -1181,7 +1230,7 @@ rest: true
     expect(result.detail).toContain("mcp key not found");
   });
 
-  test("flips ONLY mcp.enabled when both enabled keys are present (flair#1136 safety)", () => {
+  test("updates ONLY mcp.enabled when both enabled keys are present (flair#1136 safety)", () => {
     // This is the critical safety test: the config has TWO `enabled: false`
     // keys (mcp.enabled and dynamicClientRegistration.enabled). The YAML-based
     // implementation navigates to the exact key, so it can never flip the
@@ -1190,8 +1239,8 @@ rest: true
     const result = updateLocalConfigMcpEnabled(true, configPath);
     expect(result.ok).toBe(true);
     const doc = yaml.load(readFileSync(configPath, "utf-8")) as any;
-    // Only mcp.enabled flipped.
-    expect(doc["@harperfast/oauth"].mcp.enabled).toBe(true);
+    // Only mcp.enabled updated — to the env reference (flair#1152).
+    expect(doc["@harperfast/oauth"].mcp.enabled).toBe(ENV_REF);
     // dynamicClientRegistration.enabled is untouched.
     expect(doc["@harperfast/oauth"].mcp.dynamicClientRegistration.enabled).toBe(false);
   });
@@ -1255,8 +1304,12 @@ describe("enableMcp — Fabric operator-deploy (flair#1136)", () => {
     expect(fabricStep).toBeDefined();
     expect(fabricStep!.ok).toBe(false);
     expect(fabricStep!.detail).toContain("harperfabric.com");
-    expect(fabricStep!.detail).toContain("mcp.enabled: true");
-    expect(fabricStep!.detail).toContain("redeploy");
+    // flair#1152: the guidance is env-first — set FLAIR_MCP_OAUTH in the
+    // instance environment; NEVER "edit the deployed config.yaml" (a
+    // re-packed deploy reverts that edit, which was the whole bug).
+    expect(fabricStep!.detail).toContain("FLAIR_MCP_OAUTH");
+    expect(fabricStep!.detail).toContain("environment");
+    expect(fabricStep!.detail).not.toContain("mcp.enabled: true");
     // Earlier steps (secrets, identity) still succeeded.
     const byStep = Object.fromEntries(result.steps.map((s) => [s.step, s.ok]));
     expect(byStep["secrets-provisioning"]).toBe(true);


### PR DESCRIPTION
Closes #1152
Closes #1180

## What this does

The shipped `config.yaml` oauth block (and the identical block `buildMcpOAuthConfigBlock()` generates for `flair mcp enable`) changes shape:

- **#1180 — `resource` is gone.** The old `resource: ${FLAIR_MCP_ISSUER}/mcp` was a composite token; component env expansion is whole-token-only, so it passed through VERBATIM and every claude.ai connect bounced with `invalid_target`. With the key absent, the component's `resolveResource()` derives `<issuer>/mcp` at request time — byte-identical to flair's in-process derivation, consistent across authorize/token/withMCPAuth. Escape hatch (documented at both sites): an operator needing a non-standard resource sets an explicit **literal** absolute URL.
- **#1152 — `enabled` is now the whole-token env reference `${FLAIR_MCP_OAUTH}`** — the same flag flair's in-process `/mcp` route gates on. The on/off choice moves out of the packed file into the instance environment, so a re-packed deploy can no longer revert an operator's enablement. `updateLocalConfigMcpEnabled(true, …)` now writes the env reference (never a literal `true`; legacy literal `true` is normalized); `(false, …)` writes literal `false` (decisively off). The Fabric guidance message now says "set the env var" instead of "edit the deployed config.yaml and redeploy" — the latter instruction was the bug.

## Preconditions (all landed)

- Fresh install resolves `@harperfast/oauth` **2.5.0** (verified: `node_modules/@harperfast/oauth/package.json`), where `normalizeBooleanField` exists — an unresolved `${FLAIR_MCP_OAUTH}` placeholder is **deleted** so the disabled default applies. Below 2.5.0 the placeholder is a truthy string (fail-open).
- **Resolved-version assertion** (reads the resolved `node_modules` package.json, fails < 2.5.0) lives in `test/integration/mcp-oauth-boot-safety.test.ts`, co-located with the behavioral gate per the review binding: the boot-safety test (shipped config verbatim, env cleared, clean boot + `/mcp` 404) goes red on the same drift, in the same CI run.
- **Garbage-value case** covered (see below — the observed behavior differs from the reviewed spec's model, in the safe direction).

## Empirical deviation from the reviewed spec — reviewers please re-check this part

The spec (and the security ruling on #1152) modeled the component reading `enabled` as a **truthy string**, predicting `FLAIR_MCP_OAUTH=maybe` would mount an inert AS. Measured against the resolved oauth 2.5.0, the component is stricter than that model:

- `coerceConfigBoolean` accepts **only** `"true"`/`"false"` (case-insensitive); `normalizeBooleanField` **deletes** anything else — unresolved placeholders, `"1"`, `"yes"`, `"on"`, and garbage alike — so the disabled default applies. The upstream ask in the spec ("treat any non-boolean string as absent") is **already implemented** in 2.5.0; no upstream filing needed.
- Therefore **garbage disables BOTH sides** (component: deleted; flair: strict flag off). No AS, no `/mcp`, clean boot. The 200 on `/.well-known/oauth-authorization-server` in that state is flair's **own** discovery document (served whenever the strict flag is off, by design) — the test asserts the discriminating `token_endpoint` field so a future vocabulary change flips it.
- The real residual is the **vocabulary asymmetry in the other direction**: flair's `mcpOAuthEnabled()` accepts `1/true/yes/on`; the component accepts only `true/false`. So `FLAIR_MCP_OAUTH=1` — the value `buildSecretsBundle` used to stage — would produce a **guarded `/mcp` with no authorization server behind it** (fail-closed, broken-on: every request 401s, no AS advertised). Fix in this PR: the bundle now stages `FLAIR_MCP_OAUTH=true`, the one value both readers accept; the asymmetry table is documented at the config site, the flag site, and the generator, and pinned by boot tests (`true` end-to-end; `maybe` both-off).

## Tests

- `test/integration/mcp-oauth-boot-safety.test.ts` rewritten: resolved-version assertion; shipped-shape assertions (env-referenced `enabled`, **no** `resource` key); boot-safety/backstop (shipped verbatim, env cleared → clean boot, `/mcp` 404 — red on oauth < 2.5.0); literal-`true` mutation-prove (degraded boot — the standing positive control); garbage-value in-process + boot tests; enabled path (shipped **verbatim** + env only → `/mcp` 401, CIMD advertised, and the RFC 9728 metadata carries the **derived** `https://…/mcp` resource — the direct #1180 regression assertion).
- `test/unit/mcp-enable.test.ts`: config-block assertions updated to the new shape (enabled as env reference, explicit no-resource test), `updateLocalConfigMcpEnabled` suite rewritten for the env-reference semantics, secrets-bundle value assertion (`true` exactly), Fabric-message assertions (env-first guidance, never "edit the deployed config").
- `test/unit/mcp-oauth-flag.test.ts` untouched and passing (flair's strict reader is deliberately unchanged).
- RFC 8707 regression suites (`test/integration/mcp-client-credentials-e2e.test.ts`, `test/unit/mcp-client-assertion.test.ts`) passing.

### Evidence (self-measured, same machine, fresh worktree off main)

Full unit suite (`bun test test/unit`):

| | pass | fail | errors | tests | files |
|---|---|---|---|---|---|
| origin/main baseline | 4575 | 6 | 2 | 4581 | 240 |
| this branch | 4578 | 6 | 2 | 4584 | 240 |

The 6 fails + 2 errors are identical on both sides (4 pre-existing `Memory.search()` boolean-injection-guard tests plus 2 environment-dependent items — none touch this change); the +3 passing tests are this PR's. Integration: `mcp-oauth-boot-safety` 7/7 (baseline 4/4 of the old suite), `mcp-client-credentials-e2e` 6/6 (baseline 6/6). `mcp-oauth-flag.test.ts` 22/22 untouched. Resolved `@harperfast/oauth` in the tested tree: **2.5.0** (fresh install; the version assertion mutation-checked against a faked 2.4.0).

Per-mutation results (break → red → restore → green, all green after restore):

| # | Mutation | Red assertion that fired |
|---|---|---|
| 1 | resolved oauth package.json faked to 2.4.0 | version assertion, with the drift message |
| 2 | config.yaml `enabled:` → literal `false` | shipped-shape test; literal-`true` mutation-prove's replace-guard (fails fast, pre-boot) |
| 3 | config.yaml composite `resource:` re-added | shipped-shape test (`"resource" in mcp`) |
| 4 | config.yaml `enabled:` → literal `true` | boot-safety clean-boot gate (`/mcp` 404 → 500 degraded) |
| 5 | flair flag widened to accept `maybe` | garbage in-process divergence test |
| 6 | component `coerceConfigBoolean` widened to accept `maybe` | garbage boot tripwire: `/oauth/mcp/authorize` 404 → 400 (live endpoint) |
| 7 | config.yaml composite `resource:` re-added | enabled-path: PRM document 200 → 404 (composite breaks the RFC 9728 path derivation before the resource value is even compared) |
| 8 | generator emits literal `enabled` / re-emits `resource` | both config-block unit tests |
| 9 | `updateLocalConfigMcpEnabled` writes literal `true` | 4 env-reference unit tests |
| 10 | bundle stages `"1"` | secrets-bundle value test |
| 11 | Fabric message reverted to "edit the deployed config.yaml" | operator-deploy message test |

Mutation-testing itself found one dead check and fixed it: the garbage test's original discriminator (AS-metadata `token_endpoint`) could NOT fire, because flair's discovery handler shadows the component's well-known route whenever the strict flag is off — replaced with the `/oauth/mcp/authorize` probe (second commit), which the component dispatches itself and 404s only while disabled. On mutation 11: the `toContain("FLAIR_MCP_OAUTH")` assertion alone is satisfied by the message's `mcp.enabled: ${FLAIR_MCP_OAUTH}` phrase; the red came from the paired `not.toContain("mcp.enabled: true")` on full reversion — the pair is the guard.

## Deliberately not done

- The optional deploy-staging regression codifying "an operator edit to the deployed config.yaml does not survive a re-packed deploy" (the revert mechanism behind #1152) is **not** included — skipped for scope; the mechanism is now moot for `mcp.enabled` (the choice no longer lives in the packed file) but remains undocumented-by-test for other keys.
- Lockfile drive-by from the fresh install (an unrelated bin entry) excluded from this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
