### PR TITLE
test: pin the FLAIR_MCP_OAUTH vocabulary asymmetry and the deploy re-pack revert mechanism

### DIFF
--- a/.changelog/unreleased/added-1285-vocab-asymmetry-and-repack-tests.md
+++ b/.changelog/unreleased/added-1285-vocab-asymmetry-and-repack-tests.md
@@ -1,0 +1,7 @@
+- Regression tests pinning two mechanisms from the #1284 review (#1285): a
+  boot-level test for the `FLAIR_MCP_OAUTH` vocabulary asymmetry (`1` yields a
+  guarded `/mcp` with NO authorization server mounted — the broken-on state a
+  regression re-staging `'1'` in the secrets bundle would ship), and a deploy
+  re-pack test codifying that an operator edit to a deployed component
+  `config.yaml` does not survive a re-packed deploy (the payload derives
+  strictly from the package root's published file set).

--- a/test/integration/mcp-oauth-boot-safety.test.ts
+++ b/test/integration/mcp-oauth-boot-safety.test.ts
@@ -42,6 +42,16 @@
  *      flair's flag takes 1/true/yes/on but the component deletes anything
  *      but "true"/"false", so e.g. FLAIR_MCP_OAUTH=1 yields a guarded /mcp
  *      with NO authorization server behind it (fail-closed broken-on).
+ *   6. BROKEN-ON (flair#1285): FLAIR_MCP_OAUTH=1 with the FULL enablement env
+ *      otherwise staged — the exact state a regression re-staging '1' in
+ *      buildSecretsBundle would ship. Asserts BOTH halves at boot level:
+ *      flair's /mcp handler IS mounted and guarded (401), AND the component's
+ *      authorization-server surface is NOT (component-dispatched
+ *      /oauth/mcp/authorize answers 404, and the AS well-known — which flair's
+ *      discovery handler deliberately falls through when the strict flag is on
+ *      — has nobody behind it). The unit coverage in mcp-oauth-flag only
+ *      exercises flair's side of the vocabulary table; this is the
+ *      discriminating boot test for the divergence itself.
  */
 
 import { describe, test, expect, beforeAll, afterEach, afterAll } from "bun:test";
@@ -415,6 +425,88 @@ describe("flair#1152 enabled path: shipped config verbatim + env set", () => {
       expect(prmRes.status).toBe(200);
       const prm = await prmRes.json();
       expect(prm.resource).toBe("https://test.example.com/mcp");
+    },
+    120_000,
+  );
+});
+
+// ─── 6. BROKEN-ON (flair#1285): FLAIR_MCP_OAUTH=1 → guarded /mcp, NO AS ──────
+
+describe("flair#1285 vocabulary-asymmetry broken-on: FLAIR_MCP_OAUTH=1", () => {
+  test(
+    "flair's /mcp is mounted+guarded (401) while the component's authorization server is NOT mounted",
+    async () => {
+      // The exact state a regression re-staging '1' in buildSecretsBundle
+      // (src/lib/mcp-enable.ts) would deploy: the FULL enablement env —
+      // issuer, signing key, IdP credentials — with the flag spelled "1".
+      // flair's strict reader (resources/mcp-oauth-flag.ts) accepts 1/true/
+      // yes/on; the component's coerceConfigBoolean accepts ONLY "true"/
+      // "false" and DELETES anything else, so its disabled default applies.
+      // Result: broken-on — every /mcp request 401s and there is no
+      // authorization server for the client to satisfy the challenge against.
+      // Fail-closed (no unauthenticated data path), but broken; case 5 pins
+      // the one spelling that works, this pins the divergence itself.
+      clearMcpEnv();
+      const { generateKeyPairSync } = await import("node:crypto");
+      const { privateKey } = generateKeyPairSync("rsa", {
+        modulusLength: 2048,
+        publicKeyEncoding: { type: "spki", format: "pem" },
+        privateKeyEncoding: { type: "pkcs8", format: "pem" },
+      });
+      process.env.FLAIR_MCP_OAUTH = "1";
+      process.env.FLAIR_MCP_ISSUER = "https://test.example.com";
+      process.env.FLAIR_MCP_SIGNING_KEY_PEM = privateKey;
+      process.env.OAUTH_GITHUB_CLIENT_ID = "test-client-id";
+      process.env.OAUTH_GITHUB_CLIENT_SECRET = "test-client-secret";
+
+      const workDir = makeWorkDirWithShippedConfig("flair-broken-on-");
+      const harper = await startHarper({
+        cwd: workDir,
+        harperBinDir: REPO_ROOT,
+      });
+      instances.push(harper);
+
+      // Boot is CLEAN: normalizeBooleanField deleted the "1", so the plugin
+      // never validated its config and never degraded the boot.
+      const opsRes = await fetch(harper.opsURL, {
+        signal: AbortSignal.timeout(10_000),
+      });
+      expect(opsRes.status).toBe(200);
+
+      // HALF 1 — flair's side is ON: /mcp is registered and guarded.
+      // 401, not 404 (that would mean flair's reader stopped accepting "1" —
+      // re-derive the whole vocabulary table before shipping that) and not
+      // 500 (degraded boot).
+      const mcpRes = await fetch(`${harper.httpURL}/mcp`, {
+        signal: AbortSignal.timeout(10_000),
+      });
+      expect(mcpRes.status).toBe(401);
+
+      // HALF 2a — the component's AS is NOT mounted. /oauth/mcp/* is
+      // dispatched by the component itself and NEVER shadowed by flair (the
+      // same tripwire case 4 uses): its dispatcher answers 404 whenever
+      // mcp.enabled is falsy, and "1" was deleted. If the component's
+      // vocabulary ever widens to accept "1", this becomes a live authorize
+      // endpoint (non-404) and THIS assertion fires — at which point '1'
+      // would be broken differently, not fixed; re-derive the table.
+      const authorizeRes = await fetch(
+        `${harper.httpURL}/oauth/mcp/authorize`,
+        { signal: AbortSignal.timeout(10_000) },
+      );
+      expect(authorizeRes.status).toBe(404);
+
+      // HALF 2b — the client-visible symptom: NO AS metadata anywhere. With
+      // the strict flag ON, flair's discovery handler deliberately falls
+      // through to the component's well-known handlers (makeWellKnownHandler
+      // behaviour 2, resources/oauth-discovery.ts) — and the component is not
+      // there to answer. Contrast case 4 (flag off → flair's own document,
+      // 200) and case 5 (component on → component document, 200): here the
+      // 401 challenge from /mcp has no authorization server behind it at all.
+      const metaRes = await fetch(
+        `${harper.httpURL}/.well-known/oauth-authorization-server`,
+        { signal: AbortSignal.timeout(10_000) },
+      );
+      expect(metaRes.status).toBe(404);
     },
     120_000,
   );

--- a/test/unit/deploy-staging.test.ts
+++ b/test/unit/deploy-staging.test.ts
@@ -94,8 +94,8 @@ async function packedEntries(dir: string): Promise<string[]> {
   return names.filter((n) => n !== "." && n !== "").sort();
 }
 
-/** The `.env` content of a packed payload, or null when the payload has none. */
-async function packedEnvText(dir: string): Promise<string | null> {
+/** The text of one top-level entry of a packed payload, or null when absent. */
+async function packedFileText(dir: string, entryName: string): Promise<string | null> {
   const b64 = await packageDirectory(dir, HARPER_DEPLOY_PACK_OPTS);
   const out = tempDir();
   const tarPath = join(out, "payload.tar.gz");
@@ -104,8 +104,13 @@ async function packedEnvText(dir: string): Promise<string | null> {
   const dest = join(out, "x");
   mkdirSync(dest, { recursive: true });
   await extract({ file: tarPath, cwd: dest });
-  const p = join(dest, COMPONENT_ENV_FILENAME);
+  const p = join(dest, entryName);
   return existsSync(p) ? readFileSync(p, "utf8") : null;
+}
+
+/** The `.env` content of a packed payload, or null when the payload has none. */
+async function packedEnvText(dir: string): Promise<string | null> {
+  return packedFileText(dir, COMPONENT_ENV_FILENAME);
 }
 
 describe("resolveDeployPublicUrl", () => {
@@ -431,5 +436,56 @@ describe("stageDeployRoot — the payload equals the published file set", () => 
     expect(names.has("schemas")).toBe(true);
     expect(names.has("package.json")).toBe(true);
     expect(names.has("models")).toBe(false);
+  });
+});
+
+// ─── flair#1285: the re-pack revert mechanism ────────────────────────────────
+//
+// An operator edit to a DEPLOYED component's config.yaml does not survive the
+// next deploy. The payload derives strictly from the package root —
+// publishedEntryNames() reads package.json's `files`, stageDeployRoot copies
+// from the root, harper packs the staged copy — and nothing in that pipeline
+// reads deployed state back. So a hand-edit made on the instance (the
+// flair#1152 investigation's `mcp.enabled: true` flip, most notably) is
+// silently reverted by whatever the source tree carries, on every subsequent
+// deploy.
+//
+// That mechanism is WHY the on/off choice had to move to the environment
+// (`mcp.enabled: ${FLAIR_MCP_OAUTH}`, flair#1152): with the choice env-carried,
+// a re-pack reverts nothing that matters. This test pins the revert mechanism
+// itself — defense-in-depth now, but if it ever silently changed (a deploy
+// path that merges deployed state, say), config-file hand-edits would start
+// surviving and the #1152 threat model would need re-deriving.
+describe("stageDeployRoot — an operator edit to a deployed config.yaml does not survive a re-pack", () => {
+  test("the re-packed payload's config.yaml is the package root's, not the edited copy", async () => {
+    const root = makePackageRoot();
+    const pristine = readFileSync(join(root, "config.yaml"), "utf8");
+
+    // Deploy #1: stage the payload. The staged dir is what harper packs and
+    // the target unpacks — a faithful stand-in for the deployed component tree.
+    const staged1 = stageDeployRoot(root, "https://flair.example.com");
+    cleanups.push(staged1.cleanup);
+
+    // The operator hand-edits the deployed component's config.yaml.
+    const EDIT_MARKER = "# operator-live-edit";
+    writeFileSync(join(staged1.dir, "config.yaml"), pristine + `${EDIT_MARKER}\n`);
+
+    // POSITIVE CONTROL: packing the EDITED tree does carry the edit — the
+    // extraction can see an edit when one is present, so the absence asserted
+    // below is the mechanism speaking, not a probe that reads nothing.
+    const editedPacked = await packedFileText(staged1.dir, "config.yaml");
+    expect(editedPacked).toContain(EDIT_MARKER);
+
+    // Deploy #2: re-run the staging/pack path from the package root — the only
+    // input the mechanism reads. (The mutation this test exists to catch:
+    // skip this re-stage and pack staged1 instead, and the edit survives.)
+    const staged2 = stageDeployRoot(root, "https://flair.example.com");
+    cleanups.push(staged2.cleanup);
+
+    const repacked = await packedFileText(staged2.dir, "config.yaml");
+    expect(repacked).not.toBeNull();
+    expect(repacked).not.toContain(EDIT_MARKER);
+    // Strictly the root's bytes — not merely missing the marker.
+    expect(repacked).toBe(pristine);
   });
 });


### PR DESCRIPTION
Closes #1285. Both additions were named required in Kern's #1284 review. Test-only — no production code changes.

## 1. Boot-level vocabulary-asymmetry test (broken-on)

`test/integration/mcp-oauth-boot-safety.test.ts` gains case 6: boot a real ephemeral Harper with the shipped config verbatim and the FULL enablement env (issuer, signing key, IdP credentials), but `FLAIR_MCP_OAUTH=1` — the exact state a regression re-staging `'1'` in `buildSecretsBundle` would deploy. Asserts BOTH halves of the broken-on state:

- flair's in-process `/mcp` handler IS mounted and guarded: 401 — not 404 (off), not 500 (degraded); boot stays clean (ops 200).
- the oauth component's authorization-server surface is NOT mounted:
  - `/oauth/mcp/authorize` — component-dispatched, never shadowed by flair's discovery handler (the same tripwire the garbage-value case uses) — answers 404;
  - `/.well-known/oauth-authorization-server` answers 404: with the strict flag on, flair's discovery handler deliberately falls through to the component's well-knowns, and nobody is behind them. The 401 challenge has no authorization server to satisfy — the client-visible symptom of broken-on.

The existing unit coverage only exercises flair's side of the vocabulary table; this is the discriminating boot-level test for the divergence itself.

## 2. Deploy re-pack revert regression

`test/unit/deploy-staging.test.ts`: stage a payload (the deployed-tree stand-in), hand-edit the staged `config.yaml`, then re-run the staging path from the package root and pack with harper's real packer. The re-packed payload's `config.yaml` is byte-identical to the root's — the operator edit is gone. The payload derives strictly from `package.json`'s `files` set via `publishedEntryNames()`; nothing reads deployed state back.

Includes an in-test positive control: packing the edited tree DOES carry the edit, so the asserted absence is the mechanism speaking, not a probe that reads nothing. Also adds a `packedFileText` helper; `packedEnvText` now delegates to it.

## Mutation checks (both run, then reverted)

- Case 6 with `FLAIR_MCP_OAUTH="true"`: the component-mount assertion goes red — `/oauth/mcp/authorize` answers 400 (a live endpoint rejecting a malformed request), not 404 → 7 pass / 1 fail. The probe can see the component when it IS mounted.
- Re-pack test with the re-stage step removed (packing the edited tree instead): `not.toContain(EDIT_MARKER)` goes red → 24 pass / 1 fail. Without the re-pack, the edit survives.

## Runs (baseline self-measured at origin/main e4f2f8bd, same environment)

| lane | baseline | with this PR |
|---|---|---|
| `bun test test/integration/mcp-oauth-boot-safety.test.ts` | 7 pass / 0 fail (28 expects) | 8 pass / 0 fail (32 expects) |
| `bun test test/unit/deploy-staging.test.ts` | 24 tests (inside unit lane) | 25 pass / 0 fail (68 expects) |
| unit lane: `bun test test/unit/ test/*.test.ts` | 4715 pass / 0 fail (10811 expects, 247 files) | 4716 pass / 0 fail (10815 expects, 247 files) |

Changelog fragment included; `node scripts/changelog-fragments.mjs check` passes (1 fragment, 1 entry).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
