### PR TITLE
cli: --entities on memory add / workspace set / orgevent; invalid_entity error names the format

### DIFF
--- a/.changelog/unreleased/added-entities-cli-option.md
+++ b/.changelog/unreleased/added-entities-cli-option.md
@@ -1,0 +1,10 @@
+- **`--entities <csv>` on `flair memory add`, `flair workspace set`, and `flair orgevent`.**
+  The `entities` fields documented in `docs/entity-vocabulary.md` are now reachable from the
+  CLI: pass a comma-separated list of `type:value` vocabulary strings (e.g.
+  `--entities "repo:tpsdev-ai/flair,issue:tpsdev-ai/flair#1288"`) and they land on the written
+  record, feeding `flair attention`. Values are validated client-side against the closed type
+  set before any signing or network work; a malformed value is rejected with an error that
+  names the `type:value` format and lists the valid types. The `invalid_entity` rejections on
+  `flair attention` and the server's `invalid_entities` write rejection now carry the same
+  actionable hint (the server response gains an additive `message` field — `error` and
+  `invalid` are unchanged). (#1288)

--- a/docs/entity-vocabulary.md
+++ b/docs/entity-vocabulary.md
@@ -89,6 +89,21 @@ Per the attention-plane spec's K&S-approved refinements, `entities: [String] @in
 Existing rows on all three tables simply carry no `entities` — readers must tolerate absence,
 the same pattern already used for `Presence.activityUpdatedAt`. No migration, no backfill.
 
+All three fields are reachable from the CLI (flair#1288): `flair memory add`,
+`flair workspace set`, and `flair orgevent` take `--entities <csv>`, a comma-separated list of
+vocabulary strings:
+
+```bash
+flair memory add --agent flint --entities "repo:tpsdev-ai/flair,issue:tpsdev-ai/flair#1288" "shipped the entities CLI surface"
+```
+
+The CLI validates each value before writing (a malformed value is rejected with the
+`type:value` format and the valid type list); the server re-validates on every write path
+regardless. The CLI's validator is an inlined copy of this module
+(`src/lib/entity-vocab-cli.ts` — `src/` can't import across the packaging boundary into
+`resources/`), pinned to it by `test/unit/cli-entities-option.test.ts`; the server-side gate
+remains this module alone.
+
 `Relationship` gets **no** `entities` field: its `subject`/`object` columns already carry
 free-form entity-reference strings and are already indexed — they're the vocabulary carrier
 for that table. They are lowercased on write today but not yet validated against this

--- a/resources/AttentionQuery.ts
+++ b/resources/AttentionQuery.ts
@@ -78,7 +78,7 @@
 
 import { Resource, databases } from "harper";
 import { resolveAgentAuth, allowVerified, type AgentAuthVerdict } from "./agent-auth.js";
-import { isValidEntity } from "./entity-vocab.js";
+import { entityFormatHint, isValidEntity } from "./entity-vocab.js";
 import { resolveReadScope } from "./memory-read-scope.js";
 import { withDetachedTxn } from "./table-helpers.js";
 import { checkRateLimit, rateLimitResponse } from "./rate-limiter.js";
@@ -118,7 +118,7 @@ interface ParsedQuery {
 function parseQueryInput(data: any): ParsedQuery | Response {
   const entity = data?.entity;
   if (typeof entity !== "string" || entity.length === 0) {
-    return badRequest("invalid_entity", "entity is required (a vocabulary string, e.g. 'repo:owner/name')");
+    return badRequest("invalid_entity", `entity is required — ${entityFormatHint()}`);
   }
   // Exact match on the full type:value string — the SAME validator every
   // write path (Memory/WorkspaceState/OrgEvent) gates `entities` writes
@@ -126,7 +126,9 @@ function parseQueryInput(data: any): ParsedQuery | Response {
   // closed, documented type set / grammar — never a prefix/regex match, so
   // this stays a plain indexed equality lookup, never a scan.
   if (!isValidEntity(entity)) {
-    return badRequest("invalid_entity", `'${entity}' is not a well-formed vocabulary string (type:value, closed type set)`);
+    // flair#1288 (canary finding 5): the rejection must say what well-formed
+    // looks like — name the type:value format and enumerate the valid types.
+    return badRequest("invalid_entity", `'${entity}' is not a well-formed vocabulary string — ${entityFormatHint()}`);
   }
 
   let days = DEFAULT_WINDOW_DAYS;

--- a/resources/entity-vocab.ts
+++ b/resources/entity-vocab.ts
@@ -112,6 +112,24 @@ export function isValidEntity(entity: unknown): entity is string {
   return VALUE_VALIDATORS[parsed.type](parsed.value);
 }
 
+/**
+ * Canonical "what does well-formed look like" hint for invalid_entity /
+ * invalid_entities rejections (flair#1288, nightly-canary finding 5): every
+ * rejection of an entity string must name the `type:value` format AND
+ * enumerate the closed type set — errors must enable a response. Built from
+ * ENTITY_TYPES so the enumeration can never drift from the vocabulary it
+ * describes.
+ *
+ * The CLI ships an inlined copy of this module for its client-side pre-check
+ * (src/lib/entity-vocab-cli.ts — cross-boundary imports from src/ into
+ * resources/ don't survive npm packaging; same reason src/cli.ts inlines the
+ * federation crypto helpers). test/unit/cli-entities-option.test.ts pins the
+ * two implementations together, this hint string included.
+ */
+export function entityFormatHint(): string {
+  return `entities are 'type:value' vocabulary strings (e.g. 'repo:owner/name'); valid types: ${ENTITY_TYPES.join(", ")}`;
+}
+
 export interface EntityValidationResult {
   valid: boolean;
   /** The subset of the input that failed validation (as their original string form). */
@@ -144,8 +162,15 @@ export function validateEntities(entities: unknown): EntityValidationResult {
 export function invalidEntitiesResponse(entities: unknown): Response | null {
   const result = validateEntities(entities);
   if (result.valid) return null;
+  // `message` is additive (flair#1288) — `error` and `invalid` keep their
+  // exact shapes for existing consumers; the new field makes the rejection
+  // actionable on its own (names the format, enumerates the valid types).
   return new Response(
-    JSON.stringify({ error: "invalid_entities", invalid: result.invalid }),
+    JSON.stringify({
+      error: "invalid_entities",
+      invalid: result.invalid,
+      message: `invalid entities: ${result.invalid.join(", ")} — ${entityFormatHint()}`,
+    }),
     { status: 400, headers: { "Content-Type": "application/json" } },
   );
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -140,6 +140,7 @@ import {
   type ResolvedSigningIdentity,
 } from "./lib/signing-identity.js";
 import { validateSnapshotArchive, extractSnapshotSafely } from "./lib/safe-snapshot-extract.js";
+import { entityFormatHint, parseEntitiesCsv } from "./lib/entity-vocab-cli.js";
 import { escapeXml, unescapeXml } from "./lib/xml-escape.js";
 import {
   assessLaunchdManagement,
@@ -15617,6 +15618,32 @@ sessionSnapshot
 
 // ─── Memory and Soul commands ────────────────────────────────────────────────
 
+// ─── --entities <csv> (flair#1288) ──────────────────────────────────────────
+//
+// Shared parse+validate for the `--entities <csv>` option on `memory add`,
+// `workspace set`, and `orgevent`. Comma-delimited to match the existing CLI
+// list-option convention (`--tags <csv>`, `--derived-from <csv>`); safe
+// because no entity grammar admits a comma. Invalid input exits 1 with the
+// canonical message — it names the offending values, the `type:value`
+// format, and the closed type set (errors must enable a response; same hint
+// the attention path's server-side invalid_entity 400 carries). The server
+// still re-validates on every write path (resources/entity-vocab.ts via
+// Memory/WorkspaceState/OrgEvent) — this client-side gate exists so a typo
+// is caught before any signing/network work, with a message a raw 400 body
+// never matched.
+function parseEntitiesOptionOrExit(csv: string): string[] {
+  const { entities, invalid } = parseEntitiesCsv(csv);
+  if (invalid.length > 0) {
+    console.error(`error: invalid --entities value${invalid.length === 1 ? "" : "s"}: ${invalid.join(", ")}`);
+    console.error(`  ${entityFormatHint()}`);
+    process.exit(1);
+  }
+  return entities;
+}
+
+const ENTITIES_OPTION_DESCRIPTION =
+  "Comma-separated entity vocabulary strings this record touches (type:value from the closed type set, e.g. repo:tpsdev-ai/flair — see docs/entity-vocabulary.md; feeds `flair attention`)";
+
 const memory = program.command("memory").description("Manage agent memories");
 memory.command("add [content]")
   .description("Write a new memory row for an agent (content via positional arg or --content)")
@@ -15627,6 +15654,7 @@ memory.command("add [content]")
   .option("--subject <text>", "one-line title / entity this memory is about")
   .option("--derived-from <csv>", "Comma-separated source Memory IDs this memory was distilled/reflected from (sets Memory.derivedFrom; used by the `rem rapid` reflection loop)")
   .option("--visibility <value>", "Writer-controlled sharing intent (sets Memory.visibility): 'private' (owner-only, never visible to any other agent) or 'shared' (visible to owner + every other agent on this instance — open within the org, not gated by a MemoryGrant). Omit to use the server's durability-keyed default: permanent/persistent -> shared, standard/ephemeral -> private (flair#509)")
+  .option("--entities <csv>", ENTITIES_OPTION_DESCRIPTION)
   .action(async (contentArg, opts) => {
     const content = contentArg ?? opts.content;
     if (!content) { console.error("error: content required (positional arg or --content)"); process.exit(1); }
@@ -15656,6 +15684,12 @@ memory.command("add [content]")
     }
     if (opts.derivedFrom) {
       body.derivedFrom = String(opts.derivedFrom).split(",").map((x: string) => x.trim()).filter(Boolean);
+    }
+    // flair#1288: validated client-side; exits 1 with the canonical
+    // format-and-type-set message on any malformed value.
+    if (opts.entities) {
+      const entities = parseEntitiesOptionOrExit(String(opts.entities));
+      if (entities.length > 0) body.entities = entities;
     }
     const out = await api("PUT", `/Memory/${memId}`, body, { agentId });
     console.log(JSON.stringify(out, null, 2));
@@ -18045,6 +18079,7 @@ workspace
   .option("--task <id>", "Task/issue id this workspace is attached to")
   .option("--phase <phase>", "Current phase (e.g. design, implement, review)")
   .option("--summary <text>", "Short summary of current workspace state")
+  .option("--entities <csv>", ENTITIES_OPTION_DESCRIPTION)
   .option("--agent <id>", "Agent ID (env: FLAIR_AGENT_ID)")
   .option("--port <port>", "Harper HTTP port")
   .option("--target <url>", "Remote Flair URL (env: FLAIR_TARGET)")
@@ -18062,6 +18097,10 @@ workspace
         process.exit(1);
       }
     }
+
+    // flair#1288: validate --entities before any key/network work; exits 1
+    // with the canonical format-and-type-set message on any malformed value.
+    const entities = opts.entities ? parseEntitiesOptionOrExit(String(opts.entities)) : undefined;
 
     const keyPath = resolveKeyPath(agentId);
     if (!keyPath) {
@@ -18093,6 +18132,7 @@ workspace
     if (opts.task) body.taskId = opts.task;
     if (opts.phase) body.phase = opts.phase;
     if (opts.summary) body.summary = opts.summary;
+    if (entities && entities.length > 0) body.entities = entities;
 
     const res = await fetch(`${baseUrl}/WorkspaceState/${id}`, {
       method: "PUT",
@@ -18141,6 +18181,8 @@ interface PublishOrgEventParams {
   detail?: string;
   scope?: string;
   targetIds?: string[];
+  /** Validated entity vocabulary strings (flair#1288) — callers validate before passing. */
+  entities?: string[];
 }
 // Flat `{ ok: boolean; ...optional }` shape — same convention
 // RecallSpotCheckFetchResult uses above, deliberately NOT a `{ok:true}|
@@ -18197,6 +18239,7 @@ async function publishOrgEvent(params: PublishOrgEventParams): Promise<PublishOr
   if (params.detail) body.detail = params.detail;
   if (params.scope) body.scope = params.scope;
   if (params.targetIds && params.targetIds.length > 0) body.targetIds = params.targetIds;
+  if (params.entities && params.entities.length > 0) body.entities = params.entities;
 
   const res = await fetch(`${params.baseUrl}/OrgEvent/${id}`, {
     method: "PUT",
@@ -18221,6 +18264,7 @@ program
   .option("--detail <text>", "Longer detail payload")
   .option("--scope <scope>", "Scope of the event (e.g. an agent id, repo, or 'org')")
   .option("--target <agentId>", "Recipient agent id (repeatable)", (val: string, acc: string[]) => { acc.push(val); return acc; }, [] as string[])
+  .option("--entities <csv>", ENTITIES_OPTION_DESCRIPTION)
   .option("--agent <id>", "Agent ID (env: FLAIR_AGENT_ID)")
   .option("--port <port>", "Harper HTTP port")
   .option("--target-url <url>", "Remote Flair URL (env: FLAIR_TARGET)")
@@ -18236,6 +18280,10 @@ program
     const baseUrl = resolveBaseUrl({ target: opts.targetUrl, port: opts.port }).replace(/\/$/, "");
     const targetIds = Array.isArray(opts.target) && opts.target.length > 0 ? (opts.target as string[]) : undefined;
 
+    // flair#1288: validate --entities before any key/network work; exits 1
+    // with the canonical format-and-type-set message on any malformed value.
+    const entities = opts.entities ? parseEntitiesOptionOrExit(String(opts.entities)) : undefined;
+
     const result = await publishOrgEvent({
       agentId,
       baseUrl,
@@ -18244,6 +18292,7 @@ program
       detail: opts.detail,
       scope: opts.scope,
       targetIds,
+      entities,
     });
 
     if (!result.ok) {

--- a/src/lib/entity-vocab-cli.ts
+++ b/src/lib/entity-vocab-cli.ts
@@ -1,0 +1,125 @@
+/**
+ * entity-vocab-cli.ts — CLI-side copy of the attention-plane entity
+ * vocabulary validator (resources/entity-vocab.ts is the canonical module).
+ *
+ * INLINED, not imported: cross-boundary imports from src/ into resources/
+ * don't survive npm packaging — tsconfig.cli.json compiles with
+ * `rootDir: "src"`, so dist/cli.js has no resources/ module it can resolve
+ * at the same relative path. This is the same reason src/cli.ts inlines the
+ * federation crypto helpers (see the note beside `sortKeys()` there) and the
+ * private-visibility filter. The two files MUST stay in sync:
+ * test/unit/cli-entities-option.test.ts imports BOTH and pins ENTITY_TYPES
+ * equality, validator parity across a known-answer table, and the
+ * entityFormatHint() string — drift fails CI rather than shipping.
+ *
+ * Used by the `--entities <csv>` option on `flair memory add`,
+ * `flair workspace set`, and `flair orgevent` (flair#1288): the CLI validates
+ * before any signing/network work so a malformed entity is rejected
+ * client-side with an error that names the `type:value` format and
+ * enumerates the closed type set. The server independently re-validates on
+ * every write path (resources/Memory.ts / WorkspaceState.ts / OrgEvent.ts via
+ * invalidEntitiesResponse) — this module is UX, not the security gate.
+ */
+
+/** The closed set of entity types. Mirror of resources/entity-vocab.ts — extend BOTH together. */
+export const ENTITY_TYPES = [
+  "repo",
+  "issue",
+  "customer",
+  "subsystem",
+  "agent",
+  "person",
+] as const;
+
+export type EntityType = (typeof ENTITY_TYPES)[number];
+
+const ENTITY_TYPE_SET: ReadonlySet<string> = new Set(ENTITY_TYPES);
+
+/**
+ * A "slug" value: lowercase alphanumeric segments joined by single `-` or
+ * `_` separators. Used for `customer:`, `subsystem:`, `agent:`, `person:`.
+ */
+const SLUG_RE = /^[a-z0-9]+(?:[-_][a-z0-9]+)*$/;
+
+/** A single repo path segment (owner or name): lowercase alphanumeric with `.`, `-`, `_` internal. */
+const REPO_SEGMENT_RE = /^[a-z0-9]+(?:[.\-_][a-z0-9]+)*$/;
+
+/** `<owner>/<name>` — both segments valid, exactly one `/`. */
+function isValidRepoValue(value: string): boolean {
+  const parts = value.split("/");
+  if (parts.length !== 2) return false;
+  const [owner, name] = parts;
+  return REPO_SEGMENT_RE.test(owner) && REPO_SEGMENT_RE.test(name);
+}
+
+/** `<owner>/<name>#<n>` — a valid repo value, `#`, then a positive integer (no leading zero). */
+function isValidIssueValue(value: string): boolean {
+  const hashIndex = value.indexOf("#");
+  if (hashIndex === -1) return false;
+  const repoPart = value.slice(0, hashIndex);
+  const numberPart = value.slice(hashIndex + 1);
+  if (!/^[1-9][0-9]*$/.test(numberPart)) return false;
+  return isValidRepoValue(repoPart);
+}
+
+function isValidSlugValue(value: string): boolean {
+  return SLUG_RE.test(value);
+}
+
+const VALUE_VALIDATORS: Record<EntityType, (value: string) => boolean> = {
+  repo: isValidRepoValue,
+  issue: isValidIssueValue,
+  customer: isValidSlugValue,
+  subsystem: isValidSlugValue,
+  agent: isValidSlugValue,
+  person: isValidSlugValue,
+};
+
+/** Split an entity string on its first `:` into { type, value }; null if it can't be well-formed. */
+function parseEntity(entity: string): { type: string; value: string } | null {
+  if (typeof entity !== "string" || entity.length === 0) return null;
+  const colonIndex = entity.indexOf(":");
+  if (colonIndex <= 0) return null; // no colon, or colon is the first char (empty type)
+  const type = entity.slice(0, colonIndex);
+  const value = entity.slice(colonIndex + 1);
+  if (value.length === 0) return null;
+  return { type, value };
+}
+
+/** Full validation: well-formed `type:value`, type in the closed set, value matches the type's grammar. */
+export function isValidEntity(entity: unknown): entity is string {
+  if (typeof entity !== "string") return false;
+  const parsed = parseEntity(entity);
+  if (!parsed) return false;
+  if (!ENTITY_TYPE_SET.has(parsed.type)) return false;
+  return VALUE_VALIDATORS[parsed.type as EntityType](parsed.value);
+}
+
+/**
+ * Canonical "what does well-formed look like" hint (flair#1288): names the
+ * `type:value` format AND enumerates the closed type set, so the rejection
+ * enables a response. Must produce the EXACT string resources/entity-vocab.ts's
+ * entityFormatHint() produces — the sync test compares them verbatim.
+ */
+export function entityFormatHint(): string {
+  return `entities are 'type:value' vocabulary strings (e.g. 'repo:owner/name'); valid types: ${ENTITY_TYPES.join(", ")}`;
+}
+
+export interface ParsedEntitiesOption {
+  /** Every non-empty trimmed element of the CSV, in input order (valid or not). */
+  entities: string[];
+  /** The subset that failed vocabulary validation. Empty means all valid. */
+  invalid: string[];
+}
+
+/**
+ * Parse a `--entities <csv>` option value: comma-split, trim, drop empties —
+ * the same list-option convention `--tags <csv>` / `--derived-from <csv>`
+ * already use (safe here because no entity grammar admits a comma) — then
+ * validate each element against the vocabulary.
+ */
+export function parseEntitiesCsv(csv: string): ParsedEntitiesOption {
+  const entities = String(csv).split(",").map((x) => x.trim()).filter(Boolean);
+  const invalid = entities.filter((e) => !isValidEntity(e));
+  return { entities, invalid };
+}

--- a/test/unit/attention-query.test.ts
+++ b/test/unit/attention-query.test.ts
@@ -172,6 +172,23 @@ describe("AttentionQuery.post() — input validation", () => {
     expect((res as Response).status).toBe(400);
   });
 
+  it("every invalid_entity rejection names the type:value format and enumerates the valid types (flair#1288, canary finding 5)", async () => {
+    reset();
+    const q = makeQuery(agentCtx("agent-1"));
+    // Missing, malformed-grammar, and unknown-type — all three rejections
+    // must say what well-formed looks like, or the error doesn't enable a
+    // response (the canary hit exactly this: a 400 with no path to success).
+    for (const payload of [{}, { entity: "not-a-vocab-string" }, { entity: "project:foo" }]) {
+      const res = await q.post(payload);
+      expect(res instanceof Response).toBe(true);
+      expect((res as Response).status).toBe(400);
+      const body = await (res as Response).json();
+      expect(body.error).toBe("invalid_entity");
+      expect(body.detail).toContain("type:value");
+      expect(body.detail).toContain("valid types: repo, issue, customer, subsystem, agent, person");
+    }
+  });
+
   it("non-integer / non-positive days is a 400", async () => {
     reset();
     const q = makeQuery(agentCtx("agent-1"));

--- a/test/unit/cli-entities-option.test.ts
+++ b/test/unit/cli-entities-option.test.ts
@@ -1,0 +1,352 @@
+/**
+ * cli-entities-option.test.ts — `--entities <csv>` on the three CLI write
+ * commands (flair#1288, nightly-canary 2026-08-19 finding 2).
+ *
+ * `docs/entity-vocabulary.md` documents `entities: [String] @indexed` on
+ * Memory / WorkspaceState / OrgEvent, but no CLI surface reached it. This
+ * suite pins the new option on `memory add`, `workspace set`, and `orgevent`:
+ *
+ *   - accepted entities land on the written record (the PUT body — same
+ *     mock-server technique as cli-memory-add-derived-from.test.ts /
+ *     orgevent-cli.test.ts; the server-side persistence gate for these
+ *     tables is invalidEntitiesResponse, covered below and in the resources
+ *     suites);
+ *   - a malformed value is rejected client-side, exit 1, with a message that
+ *     names the `type:value` format AND enumerates the closed type set
+ *     (errors must enable a response — canary finding 5's class), and the
+ *     rejection fires BEFORE any request is made (zero writes on the mock);
+ *   - the CLI's inlined vocabulary copy (src/lib/entity-vocab-cli.ts) cannot
+ *     drift from the canonical resources/entity-vocab.ts: ENTITY_TYPES,
+ *     validator verdicts over a known-answer table (expected verdicts
+ *     asserted, so the parity check can't go vacuous), and the
+ *     entityFormatHint() string are pinned 1:1;
+ *   - the server-side invalid_entities 400 body now carries the same
+ *     actionable `message` (additive field — `error`/`invalid` unchanged).
+ *
+ * HOME is pointed at the per-test tmp dir and keys live in a per-test
+ * FLAIR_KEY_DIR — no invocation can touch a real ~/.flair.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import { spawn } from "node:child_process";
+import { mkdirSync, rmSync, writeFileSync, chmodSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { createServer, IncomingMessage, ServerResponse, Server } from "node:http";
+import nacl from "tweetnacl";
+
+import {
+  ENTITY_TYPES as CLI_ENTITY_TYPES,
+  isValidEntity as cliIsValidEntity,
+  entityFormatHint as cliEntityFormatHint,
+  parseEntitiesCsv,
+} from "../../src/lib/entity-vocab-cli";
+import {
+  ENTITY_TYPES as CANONICAL_ENTITY_TYPES,
+  isValidEntity as canonicalIsValidEntity,
+  entityFormatHint as canonicalEntityFormatHint,
+  invalidEntitiesResponse,
+} from "../../resources/entity-vocab";
+
+const REPO_ROOT = join(import.meta.dirname ?? __dirname, "..", "..");
+
+/** Every assertion on the improved error message, in one place. */
+const FORMAT_SNIPPET = "type:value";
+const TYPE_LIST_SNIPPET = "valid types: repo, issue, customer, subsystem, agent, person";
+
+type Capture = { method?: string; path?: string; body?: any };
+
+function makeTmpDir(): string {
+  const dir = join(tmpdir(), `flair-entities-test-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+  mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+function startCaptureServer(captures: Capture[]): Promise<{ server: Server; url: string }> {
+  return new Promise((resolve) => {
+    const server = createServer((req: IncomingMessage, res: ServerResponse) => {
+      let body = "";
+      req.on("data", (c) => (body += c));
+      req.on("end", () => {
+        let parsed: any = undefined;
+        try { parsed = body ? JSON.parse(body) : undefined; } catch { parsed = body; }
+        captures.push({ method: req.method, path: req.url, body: parsed });
+        res.writeHead(200, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({ ok: true, id: "mock-id" }));
+      });
+    });
+    server.listen(0, "127.0.0.1", () => {
+      const port = (server.address() as any).port;
+      resolve({ server, url: `http://127.0.0.1:${port}` });
+    });
+  });
+}
+
+function stopServer(server: Server): Promise<void> {
+  return new Promise((resolve) => server.close(() => resolve()));
+}
+
+function writeAgentKey(keysDir: string, agentId: string): void {
+  const kp = nacl.sign.keyPair();
+  const seed = kp.secretKey.slice(0, 32);
+  writeFileSync(join(keysDir, `${agentId}.key`), Buffer.from(seed));
+  chmodSync(join(keysDir, `${agentId}.key`), 0o600);
+}
+
+describe("--entities on the CLI write commands (flair#1288)", () => {
+  let tmpDir: string;
+  let keysDir: string;
+
+  beforeEach(() => {
+    tmpDir = makeTmpDir();
+    keysDir = join(tmpDir, "keys");
+    mkdirSync(keysDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  function runCli(args: string[], env: Record<string, string>): Promise<{ code: number | null; stdout: string; stderr: string }> {
+    return new Promise((resolve) => {
+      const child = spawn("bun", ["src/cli.ts", ...args], {
+        cwd: REPO_ROOT,
+        // HOME → tmp dir: no invocation may read or write the real ~/.flair.
+        env: { ...process.env, HOME: tmpDir, FLAIR_KEY_DIR: keysDir, ...env },
+      });
+      let out = "";
+      let err = "";
+      child.stdout?.on("data", (d) => (out += d.toString()));
+      child.stderr?.on("data", (d) => (err += d.toString()));
+      child.on("close", (code) => resolve({ code, stdout: out, stderr: err }));
+    });
+  }
+
+  function expectImprovedMessage(stderr: string, offending: string): void {
+    expect(stderr).toContain("invalid --entities value");
+    expect(stderr).toContain(offending);
+    expect(stderr).toContain(FORMAT_SNIPPET);
+    expect(stderr).toContain(TYPE_LIST_SNIPPET);
+  }
+
+  // ── flair memory add ──────────────────────────────────────────────────────
+
+  it("memory add: accepted entities land on the written record (CSV split + trim)", async () => {
+    const captures: Capture[] = [];
+    const { server, url } = await startCaptureServer(captures);
+    try {
+      const { code } = await runCli(
+        ["memory", "add", "attention-plane memory", "--agent", "krais",
+         "--entities", "repo:tpsdev-ai/flair, issue:tpsdev-ai/flair#1288"],
+        { FLAIR_URL: url, FLAIR_AGENT_ID: "" },
+      );
+      expect(code).toBe(0);
+      const put = captures.find((c) => c.method === "PUT" && c.path?.startsWith("/Memory/"));
+      expect(put).toBeTruthy();
+      expect(put!.body.entities).toEqual(["repo:tpsdev-ai/flair", "issue:tpsdev-ai/flair#1288"]);
+    } finally {
+      await stopServer(server);
+    }
+  });
+
+  it("memory add: omitting --entities leaves the field off the record (no regression)", async () => {
+    const captures: Capture[] = [];
+    const { server, url } = await startCaptureServer(captures);
+    try {
+      const { code } = await runCli(
+        ["memory", "add", "a plain memory", "--agent", "krais"],
+        { FLAIR_URL: url, FLAIR_AGENT_ID: "" },
+      );
+      expect(code).toBe(0);
+      const put = captures.find((c) => c.method === "PUT" && c.path?.startsWith("/Memory/"));
+      expect(put).toBeTruthy();
+      expect(put!.body.entities).toBeUndefined();
+    } finally {
+      await stopServer(server);
+    }
+  });
+
+  it("memory add: an unknown entity type is rejected with the format + type-set message, before any write", async () => {
+    const captures: Capture[] = [];
+    const { server, url } = await startCaptureServer(captures);
+    try {
+      const { code, stderr } = await runCli(
+        ["memory", "add", "content", "--agent", "krais", "--entities", "repo:tpsdev-ai/flair,project:foo"],
+        { FLAIR_URL: url, FLAIR_AGENT_ID: "" },
+      );
+      expect(code).toBe(1);
+      expectImprovedMessage(stderr, "project:foo");
+      expect(captures.length).toBe(0); // validation fires BEFORE the write path
+    } finally {
+      await stopServer(server);
+    }
+  });
+
+  it("memory add: a colon-less value is rejected with the same message", async () => {
+    const captures: Capture[] = [];
+    const { server, url } = await startCaptureServer(captures);
+    try {
+      const { code, stderr } = await runCli(
+        ["memory", "add", "content", "--agent", "krais", "--entities", "not-a-vocab-string"],
+        { FLAIR_URL: url, FLAIR_AGENT_ID: "" },
+      );
+      expect(code).toBe(1);
+      expectImprovedMessage(stderr, "not-a-vocab-string");
+      expect(captures.length).toBe(0);
+    } finally {
+      await stopServer(server);
+    }
+  });
+
+  // ── flair workspace set ───────────────────────────────────────────────────
+
+  it("workspace set: accepted entities land on the written record", async () => {
+    const agentId = "test-agent-ws";
+    writeAgentKey(keysDir, agentId);
+    const captures: Capture[] = [];
+    const { server, url } = await startCaptureServer(captures);
+    try {
+      const { code } = await runCli(
+        ["workspace", "set", "--ref", "feat/1288-entities-cli", "--entities", "repo:tpsdev-ai/flair,subsystem:attention_plane"],
+        { FLAIR_AGENT_ID: agentId, FLAIR_URL: url },
+      );
+      expect(code).toBe(0);
+      const put = captures.find((c) => c.method === "PUT" && c.path?.startsWith("/WorkspaceState/"));
+      expect(put).toBeTruthy();
+      expect(put!.body.entities).toEqual(["repo:tpsdev-ai/flair", "subsystem:attention_plane"]);
+      expect(put!.body.agentId).toBe(agentId);
+    } finally {
+      await stopServer(server);
+    }
+  });
+
+  it("workspace set: a malformed entity is rejected with the format + type-set message, before any write", async () => {
+    const agentId = "test-agent-ws";
+    writeAgentKey(keysDir, agentId);
+    const captures: Capture[] = [];
+    const { server, url } = await startCaptureServer(captures);
+    try {
+      const { code, stderr } = await runCli(
+        ["workspace", "set", "--ref", "feat/x", "--entities", "repo:UPPER/Case"],
+        { FLAIR_AGENT_ID: agentId, FLAIR_URL: url },
+      );
+      expect(code).toBe(1);
+      expectImprovedMessage(stderr, "repo:UPPER/Case");
+      expect(captures.length).toBe(0);
+    } finally {
+      await stopServer(server);
+    }
+  });
+
+  // ── flair orgevent ────────────────────────────────────────────────────────
+
+  it("orgevent: accepted entities land on the written record", async () => {
+    const agentId = "test-agent-oe";
+    writeAgentKey(keysDir, agentId);
+    const captures: Capture[] = [];
+    const { server, url } = await startCaptureServer(captures);
+    try {
+      const { code } = await runCli(
+        ["orgevent", "--kind", "coord.claim", "--summary", "claiming the attention plane",
+         "--entities", "repo:tpsdev-ai/flair,agent:flint"],
+        { FLAIR_AGENT_ID: agentId, FLAIR_URL: url },
+      );
+      expect(code).toBe(0);
+      const put = captures.find((c) => c.method === "PUT" && c.path?.startsWith("/OrgEvent/"));
+      expect(put).toBeTruthy();
+      expect(put!.body.entities).toEqual(["repo:tpsdev-ai/flair", "agent:flint"]);
+      expect(put!.body.authorId).toBe(agentId);
+    } finally {
+      await stopServer(server);
+    }
+  });
+
+  it("orgevent: a malformed entity is rejected with the format + type-set message, before any write", async () => {
+    const agentId = "test-agent-oe";
+    writeAgentKey(keysDir, agentId);
+    const captures: Capture[] = [];
+    const { server, url } = await startCaptureServer(captures);
+    try {
+      const { code, stderr } = await runCli(
+        ["orgevent", "--kind", "status", "--summary", "hi", "--entities", "issue:tpsdev-ai/flair#0"],
+        { FLAIR_AGENT_ID: agentId, FLAIR_URL: url },
+      );
+      expect(code).toBe(1);
+      expectImprovedMessage(stderr, "issue:tpsdev-ai/flair#0");
+      expect(captures.length).toBe(0);
+    } finally {
+      await stopServer(server);
+    }
+  });
+});
+
+// ── the inlined CLI copy is pinned to the canonical module ──────────────────
+//
+// src/lib/entity-vocab-cli.ts exists only because cli.ts cannot import across
+// the src/ → resources/ packaging boundary (tsconfig.cli.json rootDir). These
+// tests are the stay-in-sync guard: extend resources/entity-vocab.ts without
+// the CLI copy (or vice versa) and this file goes red.
+
+describe("entity-vocab-cli stays in sync with resources/entity-vocab.ts", () => {
+  it("ENTITY_TYPES are identical", () => {
+    expect([...CLI_ENTITY_TYPES]).toEqual([...CANONICAL_ENTITY_TYPES]);
+  });
+
+  it("entityFormatHint() is byte-identical (and names the format + every type)", () => {
+    expect(cliEntityFormatHint()).toBe(canonicalEntityFormatHint());
+    expect(cliEntityFormatHint()).toContain(FORMAT_SNIPPET);
+    for (const t of CANONICAL_ENTITY_TYPES) {
+      expect(cliEntityFormatHint()).toContain(t);
+    }
+  });
+
+  it("validator verdicts agree across a known-answer table (expected verdicts asserted — parity can't go vacuous)", () => {
+    const KNOWN: Array<[entity: string, valid: boolean]> = [
+      ["repo:tpsdev-ai/flair", true],
+      ["issue:tpsdev-ai/flair#1288", true],
+      ["customer:acme-corp", true],
+      ["subsystem:memory_core", true],
+      ["agent:flint", true],
+      ["person:nathan", true],
+      ["project:foo", false],             // unknown type
+      ["not-a-vocab-string", false],      // no colon
+      ["repo:noslash", false],            // repo needs owner/name
+      ["repo:Tpsdev/Flair", false],       // lowercase only
+      ["issue:tpsdev-ai/flair#0", false], // issue number must be positive, no leading zero
+      ["customer:-bad", false],           // slug: no leading separator
+      ["repo:", false],                   // empty value
+      [":value", false],                  // empty type
+    ];
+    for (const [entity, valid] of KNOWN) {
+      expect(cliIsValidEntity(entity)).toBe(valid);
+      expect(canonicalIsValidEntity(entity)).toBe(valid);
+    }
+  });
+});
+
+describe("parseEntitiesCsv", () => {
+  it("splits on commas, trims, drops empties, reports the invalid subset", () => {
+    const { entities, invalid } = parseEntitiesCsv(" repo:tpsdev-ai/flair , ,project:foo,agent:flint,");
+    expect(entities).toEqual(["repo:tpsdev-ai/flair", "project:foo", "agent:flint"]);
+    expect(invalid).toEqual(["project:foo"]);
+  });
+
+  it("an all-valid CSV reports nothing invalid", () => {
+    const { invalid } = parseEntitiesCsv("repo:tpsdev-ai/flair,person:nathan");
+    expect(invalid).toEqual([]);
+  });
+});
+
+describe("invalidEntitiesResponse (server-side write rejection)", () => {
+  it("keeps error/invalid shapes and adds an actionable message naming the format + type set (flair#1288)", async () => {
+    const res = invalidEntitiesResponse(["project:foo"]);
+    expect(res).not.toBeNull();
+    expect(res!.status).toBe(400);
+    const body = await res!.json();
+    expect(body.error).toBe("invalid_entities");
+    expect(body.invalid).toEqual(["project:foo"]);
+    expect(body.message).toContain("project:foo");
+    expect(body.message).toContain(FORMAT_SNIPPET);
+    expect(body.message).toContain(TYPE_LIST_SNIPPET);
+  });
+});


### PR DESCRIPTION
## What

Nightly canary 2026-08-19 finding 2 (MAJOR): `docs/entity-vocabulary.md` documents `entities: [String] @indexed` on Memory, WorkspaceState, and OrgEvent, but no CLI surface reached it. Kern's design ruling on the issue picked option (a): make the CLI reach it, tight scope.

- **`--entities <csv>`** on `flair memory add`, `flair workspace set`, and `flair orgevent`. Comma-delimited, matching the existing CLI list-option convention (`--tags <csv>`, `--derived-from <csv>`); safe because no entity grammar admits a comma. Accepted values land on the written record and feed `flair attention`.
- **Client-side validation against the closed type set**, before any signing/network work. A malformed value exits 1 with a message that names the `type:value` format AND enumerates the valid types (`repo, issue, customer, subsystem, agent, person`) — errors must enable a response.
- **Same message fix on the paths the canary hit (finding 5):** `flair attention`'s server-side `invalid_entity` 400s (missing / malformed / unknown-type) now carry the same format-and-type-set hint, and the server's `invalid_entities` write rejection gains an additive `message` field (`error` and `invalid` shapes unchanged).
- Docs: `docs/entity-vocabulary.md` now shows the CLI usage it previously only implied.

## Scope boundary (per Kern's ruling — binding)

Additive only. No schema change; the `entities` fields already exist. No validation-pipeline refactor: the server-side gate is still `resources/entity-vocab.ts` via `invalidEntitiesResponse` on every write path, untouched except for the additive `message` field and the new `entityFormatHint()` export.

## Why `src/lib/entity-vocab-cli.ts` exists

`src/cli.ts` cannot import `resources/entity-vocab.ts`: `tsconfig.cli.json` compiles with `rootDir: "src"`, so a cross-boundary import doesn't survive npm packaging — the same reason `cli.ts` already inlines the federation crypto helpers and the private-visibility filter. The inlined copy is pinned to the canonical module by sync tests: `ENTITY_TYPES` equality, validator parity over a known-answer table (expected verdicts asserted, so parity can't go vacuous), and a byte-identical `entityFormatHint()` string. Drift fails CI.

## Tests

`test/unit/cli-entities-option.test.ts` (14 tests) + 1 in `test/unit/attention-query.test.ts`:

- Each of the three commands: accepted entities land on the PUT body (mock-server capture, same technique as `cli-memory-add-derived-from.test.ts` / `orgevent-cli.test.ts`); malformed values exit 1 with the improved message (asserts it contains `type:value` and the full type list) and make **zero** requests — the gate fires before the write path.
- Attention: all three `invalid_entity` rejection shapes (missing, malformed grammar, unknown type) carry the format + enumerated types in `detail`.
- `invalidEntitiesResponse`: `error`/`invalid` unchanged, new `message` names format + types.
- Sync pins between the CLI copy and the canonical module (above).
- HOME is pointed at a per-test tmp dir and keys live in a per-test `FLAIR_KEY_DIR` — no invocation touches a real `~/.flair`.

**Mutation checks** (weaken → red → restore → green):

1. CLI validator forced always-valid → 6 red (all three commands' rejection tests + known-answer parity + CSV parse) → restored → green.
2. `entityFormatHint()` stripped of format + type enumeration → 3 red (attention message test, hint sync pin, `invalidEntitiesResponse` message test) → restored → green.

## Verification

- Full unit suite (`bun test test/unit/ test/*.test.ts`): **4730 pass / 0 fail** across 248 files, vs self-measured `origin/main` baseline 4715 pass / 0 fail across 247 files — delta is exactly the 15 new tests.
- All four CI typecheck lanes clean: `tsconfig.check.json`, `tsconfig.check.src.json`, `tsconfig.cli.json`, `tsconfig.test.check.json`.
- Live smoke of the canary's repro shape: `flair memory add --entities "repository:tpsdev-ai/flair" ...` now exits 1 with `error: invalid --entities value: repository:tpsdev-ai/flair` + the format-and-type-set hint (previously: `unknown option '--entities'`).

Changelog fragment: `.changelog/unreleased/added-entities-cli-option.md`.

Closes #1288

🤖 Generated with [Claude Code](https://claude.com/claude-code)
