### PR TITLE
doctor: scheduled-drivers liveness section — a dead sync driver is visible where operators actually look

### DIFF
--- a/.changelog/unreleased/added-1278-doctor-scheduled-drivers.md
+++ b/.changelog/unreleased/added-1278-doctor-scheduled-drivers.md
@@ -1,0 +1,19 @@
+- **`flair doctor` now reports scheduled-driver liveness** (flair#1278). A new
+  "Scheduled drivers" section reports, for each background scheduler
+  (federation sync, REM nightly): installed, genuinely loaded per the service
+  manager, and how the last run ended — read through `launchctl print` /
+  `systemctl --user show`, reusing the flair#1231/#1282 exit-status parsers.
+  Neither of #1231's fleet incidents (launchd spawn error 209 from a missing
+  log directory, exit 126 from a stripped exec bit) was visible in doctor —
+  driver health only surfaced in `flair federation sync status` /
+  `flair rem nightly status`, commands an operator has to think to run. A
+  last-run failure renders loud with the named failure class, what is
+  happening (the schedule fires; the runs die), and the remedy (the job's
+  stderr log + the scheduler's status command), and counts as a doctor issue.
+  A scheduler that is not enabled renders as informational "not enabled" —
+  never the pass marker, never the fail marker, never an issue. One trap
+  encoded on the way: a systemd unit that has never completed a run reports
+  `ExecMainStatus=0, Result=success` (property defaults), so the exit
+  properties are only believed once `ExecMainExitTimestampMonotonic` proves a
+  run actually finished — "never ran" must not render as "last run
+  succeeded".

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -14323,6 +14323,79 @@ program
       }
     }
 
+    // 10. Scheduled drivers (flair#1278) — launchd/systemd liveness for the
+    // background schedulers (federation sync, REM nightly), read from the
+    // LOCAL service manager (no Harper dependency, so no harperResponding
+    // gate). Neither #1231 fleet incident (launchd spawn error 209 from a
+    // missing log dir, exit 126 from a stripped exec bit) was visible in
+    // doctor: driver health only surfaced in `flair federation sync status`
+    // / `flair rem nightly status` — commands an operator has to think to
+    // run, while doctor is the tool they actually run when something feels
+    // off. Reuses each scheduler's own status read (installed + genuinely
+    // loaded, flair#850) plus the #1282 last-exit plumbing
+    // (queryLastExitStatus); the verdict is describeScheduledDriverFinding
+    // (src/lib/scheduler-platform.ts) — pure decision logic, unit-tested
+    // without spawning launchctl/systemctl. Not-enabled renders as
+    // informational: an unenabled scheduler is a choice — never the pass
+    // marker, never the fail marker, never an issue.
+    console.log(`\n  ${render.wrap(render.c.bold, "Scheduled drivers")}`);
+    try {
+      const { queryLastExitStatus, describeScheduledDriverFinding } = await import("./lib/scheduler-platform.js");
+      const fedSched = await import("./federation/scheduler.js");
+      const remSched = await import("./rem/scheduler.js");
+      const guiDomain = `gui/${process.getuid?.() ?? ""}`;
+      const drivers = [
+        {
+          status: fedSched.schedulerStatus(),
+          label: "Federation sync driver",
+          enableCommand: "flair federation sync enable",
+          statusCommand: "flair federation sync status",
+          darwinTarget: `${guiDomain}/${fedSched.LAUNCHD_LABEL}`,
+          linuxServiceUnit: fedSched.SYSTEMD_SERVICE_UNIT,
+          stderrLogPath: join(homedir(), ".flair", "logs", "federation-sync.stderr.log"),
+        },
+        {
+          status: remSched.schedulerStatus(),
+          label: "REM nightly driver",
+          enableCommand: "flair rem nightly enable",
+          statusCommand: "flair rem nightly status",
+          darwinTarget: `${guiDomain}/${remSched.LAUNCHD_LABEL}`,
+          linuxServiceUnit: remSched.SYSTEMD_SERVICE_UNIT,
+          stderrLogPath: join(homedir(), ".flair", "logs", "rem-nightly.stderr.log"),
+        },
+      ];
+      for (const d of drivers) {
+        // Read the last run only when the service manager actually has the
+        // job — "not installed" and "not loaded" carry their own findings,
+        // and layering a last-exit read on top would blur which actor failed.
+        const lastExit = d.status.installed && d.status.active === true
+          ? queryLastExitStatus({ plat: d.status.platform, darwinTarget: d.darwinTarget, linuxServiceUnit: d.linuxServiceUnit })
+          : null;
+        const finding = describeScheduledDriverFinding({
+          label: d.label,
+          enableCommand: d.enableCommand,
+          statusCommand: d.statusCommand,
+          installed: d.status.installed,
+          active: d.status.active,
+          lastExit,
+          stderrLogPath: d.stderrLogPath,
+        });
+        console.log(`  ${render.icons[finding.icon]} ${finding.message}`);
+        finding.detail.forEach((line, i) => {
+          // Embed-verify degraded style: the actor+state line loud (red),
+          // the remedy dim.
+          const color = finding.state === "degraded" && i === 0 ? render.c.red : render.c.dim;
+          console.log(`     ${render.wrap(color, line)}`);
+        });
+        if (finding.isIssue) issues++;
+      }
+    } catch (err: any) {
+      // An unsupported platform (neither darwin nor linux) or a broken unit
+      // read must not take down doctor — report the section as unchecked
+      // (UNVERIFIED, not a pass), same as the other probes' skip discipline.
+      console.log(`  ${render.icons.warn} Scheduled drivers: could not check ${render.wrap(render.c.dim, `(${err?.message ?? err})`)}`);
+    }
+
     // Summary — see summarizeDoctorRun above (flair#721): distinguishes
     // issues --fix actually resolved this run from ones still outstanding.
     console.log("");

--- a/src/lib/scheduler-platform.ts
+++ b/src/lib/scheduler-platform.ts
@@ -296,6 +296,235 @@ export function describeExitCode(code: number | null): string {
   return `exit ${code}`;
 }
 
+// ─── last-run exit-status query (flair#1278) ────────────────────────────────
+// `verifyFirstRun` above answers "did the first run work?" at ENABLE time;
+// this answers "how did the most recent run end?" at DIAGNOSIS time (`flair
+// doctor`), reusing the same #1282 parsers so the two can never drift on how
+// a service manager's answer is read. Neither #1231 fleet incident (launchd
+// spawn error 209 from a missing log dir, exit 126 from a stripped exec bit)
+// was visible in doctor — driver health only surfaced in `flair federation
+// sync status` / `flair rem nightly status`, commands an operator has to
+// think to run.
+
+export type LastExitState =
+  /** A completed run's exit status was read back (see `exitCode`). */
+  | "recorded"
+  /** A run is in flight right now — no completed status to read yet. */
+  | "running"
+  /** The service manager answered, but has no completed run on record. */
+  | "never-ran"
+  /** The service manager could not be consulted, or its answer was unreadable. */
+  | "unavailable";
+
+export interface LastExitStatus {
+  state: LastExitState;
+  /** The recorded exit code. Non-null exactly when `state` is "recorded". */
+  exitCode: number | null;
+  /** Mechanical detail: which command said what. */
+  detail: string;
+}
+
+export interface QueryLastExitOpts {
+  plat: SchedulerPlatform;
+  /** darwin: the `<domain>/<label>` target for `launchctl print`. */
+  darwinTarget?: string;
+  /** linux: the SERVICE unit (not the timer) whose last run is read. */
+  linuxServiceUnit?: string;
+  /** Injectable process hook so unit tests never touch a real service manager. */
+  run?: (cmd: string[], timeoutMs: number) => SpawnReport;
+}
+
+/**
+ * Reads how the job's most recent run ended, from the only vantage that
+ * knows: the service manager itself.
+ *
+ * darwin: `launchctl print` carries `last exit code = N` once a run has
+ * completed (parseLaunchdPrintExit). linux: `systemctl --user show` on the
+ * service unit — with one trap encoded here rather than in every caller: a
+ * unit that has NEVER completed a run still reports `ExecMainStatus=0,
+ * Result=success` (systemd property defaults), so the exit properties are
+ * only believed when `ExecMainExitTimestampMonotonic` proves a run actually
+ * finished. Without that check, "never ran" renders as "last run succeeded"
+ * — the exact skipped-check-looks-like-a-pass shape this feature exists to
+ * kill.
+ */
+export function queryLastExitStatus(opts: QueryLastExitOpts): LastExitStatus {
+  const run = opts.run ?? ((cmd: string[], timeoutMs: number) => spawnReport(cmd, timeoutMs));
+
+  if (opts.plat === "darwin") {
+    const target = opts.darwinTarget;
+    if (!target) throw new Error("queryLastExitStatus: darwinTarget is required on darwin");
+    const printCmd = ["launchctl", "print", target];
+    const r = run(printCmd, STATUS_CHECK_TIMEOUT_MS);
+    if (spawnedNothing(r)) {
+      return { state: "unavailable", exitCode: null, detail: `launchctl could not be run (${printCmd.join(" ")})` };
+    }
+    if (r.code !== 0) {
+      return { state: "unavailable", exitCode: null, detail: `${printCmd.join(" ")} → code ${r.code} (job not loaded — no run record to read)` };
+    }
+    const { running, lastExitCode } = parseLaunchdPrintExit(r.stdout);
+    if (running) {
+      return { state: "running", exitCode: null, detail: `${printCmd.join(" ")} → a run is in flight` };
+    }
+    if (lastExitCode === null) {
+      return { state: "never-ran", exitCode: null, detail: `${printCmd.join(" ")} → no completed run recorded` };
+    }
+    return { state: "recorded", exitCode: lastExitCode, detail: `${printCmd.join(" ")} → last exit code = ${lastExitCode}` };
+  }
+
+  const unit = opts.linuxServiceUnit;
+  if (!unit) throw new Error("queryLastExitStatus: linuxServiceUnit is required on linux");
+  const showCmd = ["systemctl", "--user", "show", unit, "--property=ExecMainStatus,Result,ExecMainExitTimestampMonotonic"];
+  const r = run(showCmd, STATUS_CHECK_TIMEOUT_MS);
+  if (spawnedNothing(r)) {
+    return { state: "unavailable", exitCode: null, detail: `systemctl could not be run (${showCmd.join(" ")})` };
+  }
+  if (/failed to connect to bus/i.test(r.stderr)) {
+    return { state: "unavailable", exitCode: null, detail: `${showCmd.join(" ")} → ${r.stderr.trim()}` };
+  }
+  if (r.code !== 0) {
+    return { state: "unavailable", exitCode: null, detail: `${showCmd.join(" ")} → code ${r.code}${r.stderr.trim() ? `: ${r.stderr.trim()}` : ""}` };
+  }
+  // Believe the exit properties only when a run has actually finished — see
+  // the doc comment above for why this must be checked FIRST.
+  const ts = /^ExecMainExitTimestampMonotonic=(\d+)\s*$/m.exec(r.stdout);
+  if (ts && Number(ts[1]) === 0) {
+    return { state: "never-ran", exitCode: null, detail: `${showCmd.join(" ")} → no completed run recorded` };
+  }
+  const parsed = parseSystemdShowExit(r.stdout);
+  if (parsed.execMainStatus === null) {
+    return { state: "unavailable", exitCode: null, detail: `${showCmd.join(" ")} → no ExecMainStatus in the reply` };
+  }
+  const resultTxt = parsed.result ? `, Result=${parsed.result}` : "";
+  return {
+    state: "recorded",
+    exitCode: parsed.execMainStatus,
+    detail: `${showCmd.join(" ")} → ExecMainStatus=${parsed.execMainStatus}${resultTxt}`,
+  };
+}
+
+// ─── doctor finding for one scheduled driver (flair#1278) ───────────────────
+
+export interface ScheduledDriverFacts {
+  /** Human name, e.g. "Federation sync driver". */
+  label: string;
+  /** The command that enables this scheduler — named in remedies. */
+  enableCommand: string;
+  /** The scheduler's own status command — named in remedies. */
+  statusCommand: string;
+  /** Unit files present on disk (schedulerStatus().installed). */
+  installed: boolean;
+  /** Genuinely loaded per the service manager; null = query inconclusive. */
+  active: boolean | null;
+  /** Last-run read — null when it was not queried (nothing installed/loaded). */
+  lastExit: LastExitStatus | null;
+  /** The job's stderr log, named in the degraded remedy. */
+  stderrLogPath: string;
+}
+
+export type ScheduledDriverFindingState = "healthy" | "degraded" | "not-enabled" | "unverified";
+
+export interface ScheduledDriverFinding {
+  state: ScheduledDriverFindingState;
+  /**
+   * Which doctor marker to render: "ok" is the pass marker, "error" the fail
+   * marker. "info"/"warn" are NEITHER — the not-enabled and unverified states
+   * must be visually distinct from both a pass and a failure.
+   */
+  icon: "ok" | "warn" | "error" | "info";
+  /** true → doctor counts an issue and exits nonzero. */
+  isIssue: boolean;
+  message: string;
+  /** Indented continuation lines (actor+state+remedy when degraded). */
+  detail: string[];
+}
+
+/**
+ * Pure decision logic for `flair doctor`'s "Scheduled drivers" section
+ * (flair#1278) — extracted so it is unit-testable without spawning
+ * launchctl/systemctl, same idiom as formatEnableReport/assessDriver in the
+ * scheduler modules and summarizeDoctorRun in the CLI.
+ *
+ * The three load-bearing rules:
+ *   - not-enabled is a CHOICE, not a defect: informational marker, never the
+ *     pass marker, never the fail marker, never an issue (a skipped check
+ *     must not look like a pass — flair#970's rule applied to schedulers).
+ *   - a last-run failure IS a defect, reported loud with actor+state+remedy
+ *     (embed-verify style): the service manager is firing the job, the runs
+ *     themselves are dying, so the schedule looks alive while nothing is
+ *     delivered — the #1231 incident shape.
+ *   - "could not read" is UNVERIFIED, never a pass and never a hard failure
+ *     — the same discipline as doctor's audit-log and embeddings probes.
+ */
+export function describeScheduledDriverFinding(f: ScheduledDriverFacts): ScheduledDriverFinding {
+  if (!f.installed) {
+    return {
+      state: "not-enabled",
+      icon: "info",
+      isIssue: false,
+      message: `${f.label}: not enabled`,
+      detail: [`Opt-in — enable: ${f.enableCommand}`],
+    };
+  }
+  if (f.active === false) {
+    return {
+      state: "degraded",
+      icon: "error",
+      isIssue: true,
+      message: `${f.label}: INSTALLED BUT NOT LOADED — nothing will run it`,
+      detail: [
+        `The unit files are on disk, but the service manager does not have the job loaded, so it never fires.`,
+        `Fix: ${f.enableCommand}   # then check: ${f.statusCommand}`,
+      ],
+    };
+  }
+  if (f.active === null) {
+    return {
+      state: "unverified",
+      icon: "warn",
+      isIssue: false,
+      message: `${f.label}: UNVERIFIED — installed, but whether it is loaded could not be read`,
+      detail: [`Querying the service manager was inconclusive. Check: ${f.statusCommand}`],
+    };
+  }
+  // Loaded from here down.
+  const le = f.lastExit;
+  if (!le || le.state === "unavailable") {
+    return {
+      state: "unverified",
+      icon: "warn",
+      isIssue: false,
+      message: `${f.label}: loaded, but its last-run status could not be read`,
+      detail: [...(le ? [le.detail] : []), `Check: ${f.statusCommand}`],
+    };
+  }
+  if (le.state === "recorded" && le.exitCode !== 0) {
+    return {
+      state: "degraded",
+      icon: "error",
+      isIssue: true,
+      message: `${f.label} DEGRADED — loaded, but its last run failed (${describeExitCode(le.exitCode)})`,
+      detail: [
+        `The service manager has the job loaded and is firing it; the runs themselves are failing, so the schedule looks alive while nothing is delivered.`,
+        `Check ${f.stderrLogPath}, then: ${f.statusCommand}`,
+      ],
+    };
+  }
+  if (le.state === "running") {
+    return { state: "healthy", icon: "ok", isIssue: false, message: `${f.label}: loaded (a run is in flight now)`, detail: [] };
+  }
+  if (le.state === "never-ran") {
+    return {
+      state: "healthy",
+      icon: "ok",
+      isIssue: false,
+      message: `${f.label}: loaded (no completed run on record yet)`,
+      detail: [`Installed and loaded; the service manager has not recorded a completed run since it last (re)loaded the job.`],
+    };
+  }
+  return { state: "healthy", icon: "ok", isIssue: false, message: `${f.label}: loaded (last run: exit 0)`, detail: [] };
+}
+
 export interface VerifyFirstRunOpts {
   plat: SchedulerPlatform;
   /** darwin: the `<domain>/<label>` target for kickstart/print. */

--- a/src/rem/scheduler.ts
+++ b/src/rem/scheduler.ts
@@ -44,10 +44,16 @@ export { interpretActiveResult };
 export type { SchedulerPlatform };
 
 export const SHIM_PATH_DEFAULT = resolve(homedir(), ".flair", "bin", "flair-rem-nightly");
-export const LAUNCHD_PLIST_PATH = resolve(homedir(), "Library", "LaunchAgents", "dev.flair.rem.nightly.plist");
+// Unit names, exported (flair#1278) so `flair doctor`'s scheduled-drivers
+// section addresses the same job this module installs — same single-source
+// rule as the federation scheduler's LAUNCHD_LABEL/SYSTEMD_*_UNIT constants.
+export const LAUNCHD_LABEL = "dev.flair.rem.nightly";
+export const SYSTEMD_TIMER_UNIT = "flair-rem-nightly.timer";
+export const SYSTEMD_SERVICE_UNIT = "flair-rem-nightly.service";
+export const LAUNCHD_PLIST_PATH = resolve(homedir(), "Library", "LaunchAgents", `${LAUNCHD_LABEL}.plist`);
 export const SYSTEMD_USER_DIR = resolve(homedir(), ".config", "systemd", "user");
-export const SYSTEMD_TIMER_PATH = resolve(SYSTEMD_USER_DIR, "flair-rem-nightly.timer");
-export const SYSTEMD_SERVICE_PATH = resolve(SYSTEMD_USER_DIR, "flair-rem-nightly.service");
+export const SYSTEMD_TIMER_PATH = resolve(SYSTEMD_USER_DIR, SYSTEMD_TIMER_UNIT);
+export const SYSTEMD_SERVICE_PATH = resolve(SYSTEMD_USER_DIR, SYSTEMD_SERVICE_UNIT);
 
 export interface SchedulerSubstitutions {
   /** Absolute path to the flair binary the shim should invoke. */
@@ -233,9 +239,9 @@ function buildSubstitutions(opts: EnableOpts, shimPath: string, flairBin: string
  */
 function activeCheckCommand(plat: SchedulerPlatform): string[] {
   if (plat === "darwin") {
-    return ["launchctl", "print", `gui/${process.getuid?.() ?? ""}/dev.flair.rem.nightly`];
+    return ["launchctl", "print", `gui/${process.getuid?.() ?? ""}/${LAUNCHD_LABEL}`];
   }
-  return ["systemctl", "--user", "is-active", "flair-rem-nightly.timer"];
+  return ["systemctl", "--user", "is-active", SYSTEMD_TIMER_UNIT];
 }
 
 /**
@@ -504,7 +510,7 @@ export function enableScheduler(opts: EnableOpts): EnableResult {
         // remedy — kickstarting on top of it would blur which actor failed.
         firstRun = verifyFirstRun({
           plat,
-          darwinTarget: `gui/${process.getuid?.() ?? ""}/dev.flair.rem.nightly`,
+          darwinTarget: `gui/${process.getuid?.() ?? ""}/${LAUNCHD_LABEL}`,
           stderrLogPath,
         });
       }
@@ -524,7 +530,7 @@ export function enableScheduler(opts: EnableOpts): EnableResult {
   writeFileWithDir(servicePath, serviceContents, 0o600);
   writeFileWithDir(timerPath, timerContents, 0o600);
 
-  const loadCommand = ["systemctl", "--user", "enable", "--now", "flair-rem-nightly.timer"];
+  const loadCommand = ["systemctl", "--user", "enable", "--now", SYSTEMD_TIMER_UNIT];
   let loadResult: EnableResult["loadResult"];
   let firstRun: FirstRunVerification | undefined;
   if (!opts.skipLoad) {
@@ -534,7 +540,7 @@ export function enableScheduler(opts: EnableOpts): EnableResult {
       // Ordering gate (#1231): only after the load exited 0. Starts the
       // SERVICE unit directly (oneshot ⇒ blocks until the run exits) rather
       // than waiting for the nightly timer to fire.
-      firstRun = verifyFirstRun({ plat, linuxServiceUnit: "flair-rem-nightly.service", stderrLogPath });
+      firstRun = verifyFirstRun({ plat, linuxServiceUnit: SYSTEMD_SERVICE_UNIT, stderrLogPath });
     }
   }
   return {
@@ -573,7 +579,7 @@ export function disableScheduler(opts: DisableOpts = {}): DisableResult {
 
   const timerPath = opts.systemdTimerOverride ?? SYSTEMD_TIMER_PATH;
   const servicePath = opts.systemdServiceOverride ?? SYSTEMD_SERVICE_PATH;
-  const unloadCommand = ["systemctl", "--user", "disable", "--now", "flair-rem-nightly.timer"];
+  const unloadCommand = ["systemctl", "--user", "disable", "--now", SYSTEMD_TIMER_UNIT];
   let unloadResult: DisableResult["unloadResult"];
   if (existsSync(timerPath) || existsSync(servicePath)) {
     if (!opts.skipUnload) {

--- a/test/unit/doctor-scheduled-drivers.test.ts
+++ b/test/unit/doctor-scheduled-drivers.test.ts
@@ -1,0 +1,305 @@
+/**
+ * doctor-scheduled-drivers.test.ts — unit tests for the flair#1278 doctor
+ * section: scheduler/driver liveness where operators actually look.
+ *
+ * Two units under test, both in src/lib/scheduler-platform.ts:
+ *   - queryLastExitStatus(): reads how a scheduled job's most recent run
+ *     ended, through the service manager (reusing the #1282 parsers).
+ *   - describeScheduledDriverFinding(): the pure verdict logic the doctor
+ *     section renders — enabled-healthy / enabled-last-run-failed /
+ *     not-enabled / not-loaded / unverified.
+ *
+ * SAFETY: every queryLastExitStatus call injects `run`, so no test spawns a
+ * real launchctl or systemctl and none touches the user's service-manager
+ * domain (same idiom as scheduler-first-run-verify.test.ts).
+ */
+
+import { describe, it, expect } from "bun:test";
+import {
+  queryLastExitStatus,
+  describeScheduledDriverFinding,
+  describeExitCode,
+  type LastExitStatus,
+  type ScheduledDriverFacts,
+  type SpawnReport,
+} from "../../src/lib/scheduler-platform.ts";
+import * as render from "../../src/render.ts";
+
+// ─── queryLastExitStatus: darwin ────────────────────────────────────────────
+
+const DARWIN_TARGET = "gui/501/dev.flair.test.job";
+
+function darwinQuery(reply: SpawnReport) {
+  const calls: string[][] = [];
+  const result = queryLastExitStatus({
+    plat: "darwin",
+    darwinTarget: DARWIN_TARGET,
+    run: (cmd) => {
+      calls.push(cmd);
+      return reply;
+    },
+  });
+  return { result, calls };
+}
+
+const PRINT_FAILED_209 = "gui/501/dev.flair.test.job = {\n\tstate = waiting\n\tlast exit code = 209\n}\n";
+const PRINT_EXIT_0 = "gui/501/dev.flair.test.job = {\n\tstate = waiting\n\tlast exit code = 0\n}\n";
+const PRINT_RUNNING = "gui/501/dev.flair.test.job = {\n\tstate = running\n\tpid = 4242\n}\n";
+const PRINT_NEVER = "gui/501/dev.flair.test.job = {\n\tstate = waiting\n\tlast exit code = (never exited)\n}\n";
+
+describe("queryLastExitStatus — darwin", () => {
+  it("asks launchctl print for exactly the given target", () => {
+    const { calls } = darwinQuery({ code: 0, stdout: PRINT_EXIT_0, stderr: "" });
+    expect(calls).toEqual([["launchctl", "print", DARWIN_TARGET]]);
+  });
+
+  it("reads a recorded failing exit back out of launchctl print", () => {
+    const { result } = darwinQuery({ code: 0, stdout: PRINT_FAILED_209, stderr: "" });
+    expect(result.state).toBe("recorded");
+    expect(result.exitCode).toBe(209);
+  });
+
+  it("reads a recorded exit 0", () => {
+    const { result } = darwinQuery({ code: 0, stdout: PRINT_EXIT_0, stderr: "" });
+    expect(result.state).toBe("recorded");
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("reports an in-flight run as 'running', not as a recorded exit", () => {
+    const { result } = darwinQuery({ code: 0, stdout: PRINT_RUNNING, stderr: "" });
+    expect(result.state).toBe("running");
+    expect(result.exitCode).toBeNull();
+  });
+
+  it("reports a job that never completed a run as 'never-ran'", () => {
+    const { result } = darwinQuery({ code: 0, stdout: PRINT_NEVER, stderr: "" });
+    expect(result.state).toBe("never-ran");
+    expect(result.exitCode).toBeNull();
+  });
+
+  it("reports 'unavailable' when launchctl itself could not run", () => {
+    const { result } = darwinQuery({ code: null, stdout: "", stderr: "" });
+    expect(result.state).toBe("unavailable");
+  });
+
+  it("reports 'unavailable' when launchctl print fails (job not loaded)", () => {
+    const { result } = darwinQuery({ code: 3, stdout: "", stderr: "Could not find service" });
+    expect(result.state).toBe("unavailable");
+    expect(result.detail).toContain("code 3");
+  });
+
+  it("requires darwinTarget on darwin", () => {
+    expect(() => queryLastExitStatus({ plat: "darwin", run: () => ({ code: 0, stdout: "", stderr: "" }) })).toThrow(/darwinTarget/);
+  });
+});
+
+// ─── queryLastExitStatus: linux ─────────────────────────────────────────────
+
+const LINUX_UNIT = "flair-test.service";
+
+function linuxQuery(reply: SpawnReport) {
+  const calls: string[][] = [];
+  const result = queryLastExitStatus({
+    plat: "linux",
+    linuxServiceUnit: LINUX_UNIT,
+    run: (cmd) => {
+      calls.push(cmd);
+      return reply;
+    },
+  });
+  return { result, calls };
+}
+
+function show(props: { status: number; result: string; ts: number }): string {
+  return `ExecMainStatus=${props.status}\nResult=${props.result}\nExecMainExitTimestampMonotonic=${props.ts}\n`;
+}
+
+describe("queryLastExitStatus — linux", () => {
+  it("asks systemctl show for the SERVICE unit with the exit properties", () => {
+    const { calls } = linuxQuery({ code: 0, stdout: show({ status: 0, result: "success", ts: 5 }), stderr: "" });
+    expect(calls).toEqual([
+      ["systemctl", "--user", "show", LINUX_UNIT, "--property=ExecMainStatus,Result,ExecMainExitTimestampMonotonic"],
+    ]);
+  });
+
+  it("reads a recorded failing exit (Result carried into the detail)", () => {
+    const { result } = linuxQuery({ code: 0, stdout: show({ status: 126, result: "exit-code", ts: 123456 }), stderr: "" });
+    expect(result.state).toBe("recorded");
+    expect(result.exitCode).toBe(126);
+    expect(result.detail).toContain("Result=exit-code");
+  });
+
+  it("reads a recorded exit 0", () => {
+    const { result } = linuxQuery({ code: 0, stdout: show({ status: 0, result: "success", ts: 998877 }), stderr: "" });
+    expect(result.state).toBe("recorded");
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("NEVER-RAN TRAP: a unit with no completed run reports systemd's property defaults (ExecMainStatus=0, Result=success) — must read as 'never-ran', not as a passing run", () => {
+    const { result } = linuxQuery({ code: 0, stdout: show({ status: 0, result: "success", ts: 0 }), stderr: "" });
+    expect(result.state).toBe("never-ran");
+    expect(result.exitCode).toBeNull();
+  });
+
+  it("reports 'unavailable' when there is no session bus", () => {
+    const { result } = linuxQuery({ code: 1, stdout: "", stderr: "Failed to connect to bus: No medium found" });
+    expect(result.state).toBe("unavailable");
+  });
+
+  it("reports 'unavailable' when systemctl itself could not run", () => {
+    const { result } = linuxQuery({ code: null, stdout: "", stderr: "" });
+    expect(result.state).toBe("unavailable");
+  });
+
+  it("reports 'unavailable' when show fails outright", () => {
+    const { result } = linuxQuery({ code: 4, stdout: "", stderr: "Unit escaped the namespace" });
+    expect(result.state).toBe("unavailable");
+    expect(result.detail).toContain("code 4");
+  });
+
+  it("requires linuxServiceUnit on linux", () => {
+    expect(() => queryLastExitStatus({ plat: "linux", run: () => ({ code: 0, stdout: "", stderr: "" }) })).toThrow(/linuxServiceUnit/);
+  });
+});
+
+// ─── describeScheduledDriverFinding — the doctor section's verdicts ─────────
+
+const LOG_PATH = "/home/op/.flair/logs/federation-sync.stderr.log";
+
+function facts(overrides: Partial<ScheduledDriverFacts> = {}): ScheduledDriverFacts {
+  return {
+    label: "Federation sync driver",
+    enableCommand: "flair federation sync enable",
+    statusCommand: "flair federation sync status",
+    installed: true,
+    active: true,
+    lastExit: { state: "recorded", exitCode: 0, detail: "launchctl print → last exit code = 0" },
+    stderrLogPath: LOG_PATH,
+    ...overrides,
+  };
+}
+
+const recorded = (exitCode: number): LastExitStatus => ({
+  state: "recorded",
+  exitCode,
+  detail: `launchctl print → last exit code = ${exitCode}`,
+});
+
+describe("describeScheduledDriverFinding — enabled and healthy", () => {
+  it("installed + loaded + last run exit 0 → healthy, pass marker, no issue", () => {
+    const f = describeScheduledDriverFinding(facts());
+    expect(f.state).toBe("healthy");
+    expect(f.icon).toBe("ok");
+    expect(f.isIssue).toBe(false);
+    expect(f.message).toContain("exit 0");
+  });
+
+  it("a run in flight right now is healthy, not a failure", () => {
+    const f = describeScheduledDriverFinding(facts({ lastExit: { state: "running", exitCode: null, detail: "a run is in flight" } }));
+    expect(f.state).toBe("healthy");
+    expect(f.icon).toBe("ok");
+    expect(f.isIssue).toBe(false);
+  });
+
+  it("loaded with no completed run on record yet is healthy but says so explicitly (no silent pass on the run dimension)", () => {
+    const f = describeScheduledDriverFinding(facts({ lastExit: { state: "never-ran", exitCode: null, detail: "no completed run recorded" } }));
+    expect(f.state).toBe("healthy");
+    expect(f.isIssue).toBe(false);
+    expect(f.message).toContain("no completed run");
+    // Must NOT claim a run outcome it never observed.
+    expect(f.message).not.toContain("exit 0");
+  });
+});
+
+describe("describeScheduledDriverFinding — enabled, last run failed (degraded)", () => {
+  it("renders degraded with the fail marker and counts an issue", () => {
+    const f = describeScheduledDriverFinding(facts({ lastExit: recorded(209) }));
+    expect(f.state).toBe("degraded");
+    expect(f.icon).toBe("error");
+    expect(f.isIssue).toBe(true);
+    expect(f.message).toContain("DEGRADED");
+  });
+
+  it("leads with the named failure class (actor), states what is happening, and names the remedy — embed-verify style", () => {
+    const f = describeScheduledDriverFinding(facts({ lastExit: recorded(209) }));
+    // Actor: the exit class is named, not a bare number (describeExitCode).
+    expect(f.message).toContain(describeExitCode(209));
+    expect(f.message).toContain("launchd could not spawn");
+    // State: the schedule fires but the runs die — visible in the first detail line.
+    expect(f.detail[0]).toContain("loaded and is firing it");
+    expect(f.detail[0]).toContain("failing");
+    // Remedy: the job's stderr log and the scheduler's own status command.
+    const remedy = f.detail.join("\n");
+    expect(remedy).toContain(LOG_PATH);
+    expect(remedy).toContain("flair federation sync status");
+  });
+
+  it("exit 126 (the #1231 stripped-exec-bit incident) names the class too", () => {
+    const f = describeScheduledDriverFinding(facts({ lastExit: recorded(126) }));
+    expect(f.state).toBe("degraded");
+    expect(f.isIssue).toBe(true);
+    expect(f.message).toContain("not runnable");
+  });
+});
+
+describe("describeScheduledDriverFinding — not enabled", () => {
+  it("renders 'not enabled' and is never counted as an issue", () => {
+    const f = describeScheduledDriverFinding(facts({ installed: false, active: false, lastExit: null }));
+    expect(f.state).toBe("not-enabled");
+    expect(f.isIssue).toBe(false);
+    expect(f.message).toContain("not enabled");
+    // The enable command is offered as an opt-in hint, not a "Fix:".
+    expect(f.detail.join("\n")).toContain("flair federation sync enable");
+  });
+
+  it("is DISTINCT from both the pass marker and the fail marker", () => {
+    const notEnabled = describeScheduledDriverFinding(facts({ installed: false, active: false, lastExit: null }));
+    const healthy = describeScheduledDriverFinding(facts());
+    const degraded = describeScheduledDriverFinding(facts({ lastExit: recorded(209) }));
+
+    // Not the pass icon, not the fail icon — at the enum level...
+    expect(notEnabled.icon).not.toBe(healthy.icon);
+    expect(notEnabled.icon).not.toBe(degraded.icon);
+    // ...and at the level of the actual glyph doctor prints (render.icons is
+    // the exact marker table the doctor section renders findings through).
+    expect(render.icons[notEnabled.icon]).not.toBe(render.icons.ok);
+    expect(render.icons[notEnabled.icon]).not.toBe(render.icons.error);
+
+    // And not pass/fail at the wording level either.
+    expect(notEnabled.message).not.toContain("DEGRADED");
+    expect(notEnabled.message).not.toContain("loaded");
+    expect(notEnabled.message).not.toBe(healthy.message);
+    expect(notEnabled.message).not.toBe(degraded.message);
+  });
+});
+
+describe("describeScheduledDriverFinding — installed but dead or unreadable", () => {
+  it("installed but NOT loaded → degraded, fail marker, issue, remedy re-runs enable", () => {
+    const f = describeScheduledDriverFinding(facts({ active: false, lastExit: null }));
+    expect(f.state).toBe("degraded");
+    expect(f.icon).toBe("error");
+    expect(f.isIssue).toBe(true);
+    expect(f.message).toContain("NOT LOADED");
+    expect(f.detail.join("\n")).toContain("flair federation sync enable");
+  });
+
+  it("installed, loaded-state unreadable → UNVERIFIED, neither pass nor fail, no issue", () => {
+    const f = describeScheduledDriverFinding(facts({ active: null, lastExit: null }));
+    expect(f.state).toBe("unverified");
+    expect(f.icon).toBe("warn");
+    expect(f.isIssue).toBe(false);
+    expect(f.message).toContain("UNVERIFIED");
+  });
+
+  it("loaded but last-run status unreadable → unverified, not a pass (an unread check must not look green)", () => {
+    const f = describeScheduledDriverFinding(facts({ lastExit: { state: "unavailable", exitCode: null, detail: "launchctl could not be run" } }));
+    expect(f.state).toBe("unverified");
+    expect(f.icon).toBe("warn");
+    expect(f.isIssue).toBe(false);
+    expect(f.message).toContain("could not be read");
+    // The mechanical cause and the follow-up command both surface.
+    const detail = f.detail.join("\n");
+    expect(detail).toContain("launchctl could not be run");
+    expect(detail).toContain("flair federation sync status");
+  });
+});


### PR DESCRIPTION
Closes #1278.

## What

`flair doctor` gains a **Scheduled drivers** section: for each background scheduler (federation sync, REM nightly) it reports installed / genuinely loaded / how the last run ended, read from the local service manager. Neither of #1231's fleet incidents (launchd spawn error 209 from a missing log directory, exit 126 from a stripped exec bit) was catchable by doctor — driver health only surfaced in `flair federation sync status` / `flair rem nightly status`, commands an operator has to think to run, while doctor is the tool they actually run when something feels off.

Per Kern's design ruling on the issue: approved as specced, and the tarball-swap integration lane named in the issue body stays OUT of this PR (binding carve-out — separate concern, separate code region).

## How

- **`queryLastExitStatus()`** (src/lib/scheduler-platform.ts, new): reads the most recent run's outcome through the service manager, composing the #1282 parsers (`parseLaunchdPrintExit` / `parseSystemdShowExit`) so enable-time and diagnosis-time reads can never drift. Four honest states: `recorded` / `running` / `never-ran` / `unavailable`. One trap encoded here rather than in every caller: a systemd unit that has never completed a run still reports `ExecMainStatus=0, Result=success` (property defaults), so the exit properties are only believed once `ExecMainExitTimestampMonotonic` proves a run actually finished — otherwise "never ran" renders as "last run succeeded", the exact skipped-check-looks-like-a-pass shape this feature exists to kill.
- **`describeScheduledDriverFinding()`** (same file, new): the pure verdict logic the doctor section renders — extracted so it is unit-testable without spawning launchctl/systemctl, same idiom as `assessDriver`/`formatEnableReport`/`summarizeDoctorRun`. Rules:
  - **not enabled** → informational marker, never the pass marker, never the fail marker, never an issue (a scheduler you chose not to enable is a choice, not a defect — and a skipped check must not look like a pass);
  - **last run failed** → loud degraded finding, embed-verify style, with actor (named failure class via `describeExitCode` — 126/209 name their incident shapes), state (the service manager IS firing the job; the runs themselves are dying, so the schedule looks alive while nothing is delivered), and remedy (the job's stderr log + the scheduler's own status command); counts as a doctor issue;
  - **installed but not loaded** → degraded, remedy re-runs enable;
  - **could not read** (inconclusive manager query, unreadable last-run status) → UNVERIFIED, neither pass nor fail, no issue — same discipline as doctor's audit-log and embeddings probes.
- **Doctor wiring** (src/cli.ts): one contiguous section between Migrations and the summary. Local-only (no Harper dependency), wrapped so an unsupported platform degrades to a "could not check" line rather than taking down doctor. Reuses each scheduler's own `schedulerStatus()` (installed + genuinely-loaded, the flair#850 rule) — the last-exit read is only attempted when the manager actually has the job, so "not installed" / "not loaded" keep their own findings.
- **src/rem/scheduler.ts**: unit names (`LAUNCHD_LABEL`, `SYSTEMD_TIMER_UNIT`, `SYSTEMD_SERVICE_UNIT`) extracted to exported constants (parity with the federation scheduler) so doctor addresses the same job the module installs — the literals previously lived inline at five call sites.

One naming note for review honesty: the issue comment says `queryLastExitStatus` "shipped in #1282". What #1282 actually shipped is the parsers and `verifyFirstRun`; the named query function did not exist under any name. This PR adds it as a thin composition of those parsers — the reuse the design ruling intended.

## Tests

`test/unit/doctor-scheduled-drivers.test.ts` — 27 tests, 77 assertions, zero real service-manager spawns (injectable `run` hook, same idiom as scheduler-first-run-verify.test.ts):

- `queryLastExitStatus`: recorded failure / recorded success / running / never-ran / unavailable on both platforms, command-shape assertions, the systemd never-ran property-defaults trap, missing-target throws.
- `describeScheduledDriverFinding`: enabled-healthy, enabled-last-run-failed (actor+state+remedy each asserted, incl. the 209 and 126 incident classes), not-enabled, installed-not-loaded, unverified variants. The not-enabled case asserts distinctness from both the pass and fail markers at three levels: the icon enum, the actual glyph via the `render.icons` table doctor prints through, and the wording.
- **Mutation-checked**: 12 targeted mutations (drop the never-ran guard, not-enabled icon → pass marker, degraded `isIssue` → false ×2, recorded exitCode → 0 on both platforms, drop the running / print-failure branches, unverified icon → pass marker, drop the mechanical detail, never-ran claims exit 0, running counts an issue) — each caught by exactly its targeted test, all reverted.

Full unit suite (`bun test test/unit/ test/*.test.ts`, HOME-isolated): **4742 pass / 0 fail** across 248 files vs a self-measured origin/main baseline of 4715 pass / 0 fail across 247 files (+27 tests, +1 file, no regressions). `bunx tsc --noEmit -p tsconfig.check.json` clean. Changelog fragment added and `changelog-fragments.mjs check` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
