### PR TITLE
doctor: recognize client-native MCP config shapes — FLAIR_URL optional, per-client literal fixtures with drift detection

### DIFF
--- a/.changelog/unreleased/fixed-1287-doctor-client-native-shapes.md
+++ b/.changelog/unreleased/fixed-1287-doctor-client-native-shapes.md
@@ -1,0 +1,17 @@
+- `flair doctor` no longer false-negatives a working MCP setup written by a
+  client's own tooling (#1287). Root cause: doctor demanded `FLAIR_URL` in the
+  wired block, while flair-client treats it as optional (falling back to its
+  built-in default) and the documented `claude mcp add` command sets only
+  `FLAIR_AGENT_ID` — so a stock setup that followed our own docs was reported
+  as "no Flair MCP server configured" and told to run a fix it didn't need.
+  Doctor's requirement now matches flair-client's actual contract: agent id
+  required, URL optional. A URL-less block reports as configured with an
+  explicit "FLAIR_URL not set — flair-mcp defaults to <url>" note, and
+  reachability/registration are verified against that default. The Codex TOML
+  scanner gets the same contract plus support for the inline `env = { ... }`
+  table form Codex itself preserves. Detection is now pinned by literal
+  client-native fixtures for all five registry clients (captured from
+  `claude mcp add` / `gemini mcp add`, codex source, Cursor and Antigravity
+  docs), each with a drift-detection assertion that the fixture is not
+  byte-identical to our own wire output — a fixture regenerated from our
+  generator can no longer masquerade as client coverage.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -83,6 +83,7 @@ import {
 } from "./lib/mcp-enable.js";
 import {
   readClientMcpBlock,
+  effectiveFlairUrl,
   checkClaudeMdBootstrap,
   detectWiredFlairMcp,
   inspectSessionStartHook,
@@ -13879,14 +13880,24 @@ program
 
         console.log(`  ${render.icons.ok} ${client.label}: MCP server configured (${render.wrap(render.c.dim, block.configPath)})`);
 
-        const reachable = await probeFlairReachable(block.flairUrl!);
+        // flair#1287: a block with FLAIR_AGENT_ID but no FLAIR_URL is a
+        // WORKING setup — flair-client falls back to its built-in default —
+        // and must never be reported as unconfigured. Say which URL applies
+        // and keep verifying against it, exactly as for an explicit one.
+        const eff = effectiveFlairUrl(block);
+        const urlLabel = eff.defaulted ? `${eff.url} (client default)` : eff.url;
+        if (eff.defaulted) {
+          console.log(`     ${render.icons.info} FLAIR_URL not set — flair-mcp defaults to ${render.wrap(render.c.dim, eff.url)}`);
+        }
+
+        const reachable = await probeFlairReachable(eff.url);
         if (!reachable) {
-          console.log(`     ${render.icons.warn} FLAIR_URL ${render.wrap(render.c.dim, block.flairUrl!)} not reachable — cannot verify agent registration`);
+          console.log(`     ${render.icons.warn} FLAIR_URL ${render.wrap(render.c.dim, urlLabel)} not reachable — cannot verify agent registration`);
           continue;
         }
-        console.log(`     ${render.icons.ok} FLAIR_URL ${render.wrap(render.c.dim, block.flairUrl!)} reachable`);
+        console.log(`     ${render.icons.ok} FLAIR_URL ${render.wrap(render.c.dim, urlLabel)} reachable`);
 
-        const reg = await checkAgentRegistered(block.flairUrl!, block.agentId!, defaultKeysDir());
+        const reg = await checkAgentRegistered(eff.url, block.agentId!, defaultKeysDir());
         if (reg.state === "registered") {
           console.log(`     ${render.icons.ok} agent '${block.agentId}' registered`);
         } else if (reg.state === "not-registered") {

--- a/src/doctor-client.ts
+++ b/src/doctor-client.ts
@@ -624,26 +624,48 @@ function readCodexFlairBlock(configPath: string): ClientMcpBlockResult {
 }
 
 /**
- * Pull one env value out of the `[mcp_servers.flair]` block text, accepting
- * BOTH TOML shapes a real Codex config carries for env:
+ * The two env keys the codex scanner ever looks for, each with LITERAL
+ * regexes for both TOML shapes a real Codex config carries:
  *
- *   1. the `[mcp_servers.flair.env]` sub-table (`FLAIR_AGENT_ID = "..."` on
- *      its own line) — what `codex mcp add` serializes (toml_edit Table via
- *      table_from_pairs, openai/codex codex-rs config/edit/document_helpers.rs),
- *      what Codex's own config docs show, and what our tomlSnippet() writes;
- *   2. the inline table (`env = { "FLAIR_AGENT_ID" = "..." }`, bare or quoted
- *      keys) — valid Codex TOML that `codex mcp add` itself PRESERVES when
- *      merging into a hand-written inline entry (merge_inline_table, same
- *      file). The old line-anchored regex silently missed this shape — the
- *      flair#1287 defect class (a client-accepted config our detector
- *      rejects) in TOML form.
+ *   `line`   — the `[mcp_servers.flair.env]` sub-table form (`FLAIR_AGENT_ID
+ *              = "..."` on its own line): what `codex mcp add` serializes
+ *              (toml_edit Table via table_from_pairs, openai/codex
+ *              codex-rs config/edit/document_helpers.rs), what Codex's own
+ *              config docs show, and what our tomlSnippet() writes;
+ *   `inline` — the inline table (`env = { "FLAIR_AGENT_ID" = "..." }`, bare
+ *              or quoted keys): valid Codex TOML that `codex mcp add` itself
+ *              PRESERVES when merging into a hand-written inline entry
+ *              (merge_inline_table, same file). The old line-anchored regex
+ *              silently missed this shape — the flair#1287 defect class (a
+ *              client-accepted config our detector rejects) in TOML form.
+ *
+ * Spelled out as regex LITERALS per key rather than built via `new RegExp`
+ * with the key interpolated: the key set is closed (these two), and literal
+ * patterns keep the scanner off the non-literal-regexp SAST surface entirely
+ * — there is nothing dynamic for an injected pattern to ride in on. The
+ * `keyof` parameter type makes a third key a compile error here, not a
+ * silently unmatched scan.
  */
-function scanCodexEnvValue(block: string, key: string): string | undefined {
-  const lineMatch = block.match(new RegExp(`^\\s*${key}\\s*=\\s*"([^"]*)"`, "m"));
+const CODEX_ENV_PATTERNS = {
+  FLAIR_AGENT_ID: {
+    line: /^\s*FLAIR_AGENT_ID\s*=\s*"([^"]*)"/m,
+    inline: /"?FLAIR_AGENT_ID"?\s*=\s*"([^"]*)"/,
+  },
+  FLAIR_URL: {
+    line: /^\s*FLAIR_URL\s*=\s*"([^"]*)"/m,
+    inline: /"?FLAIR_URL"?\s*=\s*"([^"]*)"/,
+  },
+} as const;
+
+/** Pull one env value out of the `[mcp_servers.flair]` block text — see
+ *  CODEX_ENV_PATTERNS for the two shapes each key is matched against. */
+function scanCodexEnvValue(block: string, key: keyof typeof CODEX_ENV_PATTERNS): string | undefined {
+  const patterns = CODEX_ENV_PATTERNS[key];
+  const lineMatch = block.match(patterns.line);
   if (lineMatch?.[1]) return lineMatch[1];
   const inlineEnv = block.match(/^\s*env\s*=\s*\{([^}]*)\}/m);
   if (inlineEnv) {
-    const inlineMatch = inlineEnv[1].match(new RegExp(`"?${key}"?\\s*=\\s*"([^"]*)"`));
+    const inlineMatch = inlineEnv[1].match(patterns.inline);
     if (inlineMatch?.[1]) return inlineMatch[1];
   }
   return undefined;

--- a/src/doctor-client.ts
+++ b/src/doctor-client.ts
@@ -524,19 +524,53 @@ function readTextFile(path: string): string | null {
 
 // ── check 1: MCP server block present + configured ─────────────────────────
 
+/**
+ * flair-client's own DEFAULT_URL (packages/flair-client/src/client.ts:
+ * `this.url = config.url ?? readEnvOrUnset("FLAIR_URL") ?? DEFAULT_URL`).
+ * Duplicated here as a value rather than imported — flair-client does not
+ * export it, and this module stays dependency-light by the same convention as
+ * the AgentGateState type duplication below. A unit test
+ * (doctor-client-native-shapes.test.ts) asserts this literal matches
+ * flair-client's source, so the two cannot drift silently.
+ */
+export const FLAIR_CLIENT_DEFAULT_URL = "http://localhost:19926";
+
 export interface ClientMcpBlockResult {
   present: boolean;
   configPath: string;
   agentId?: string;
   flairUrl?: string;
+  /** True when the block is present and working but carries no FLAIR_URL —
+   *  flair-client falls back to FLAIR_CLIENT_DEFAULT_URL internally, so this
+   *  is a WORKING configuration, never a missing one (flair#1287). Callers
+   *  must render it as "present (URL defaulted)", not as unconfigured. */
+  urlDefaulted?: boolean;
+}
+
+/**
+ * The URL the wired flair-mcp process will actually connect to: the block's
+ * FLAIR_URL when set, else flair-client's built-in default. `defaulted` tells
+ * the caller which of the two it got, so doctor's output can say so
+ * (flair#1287 — a defaulted URL is still a probe-able, working URL).
+ */
+export function effectiveFlairUrl(block: Pick<ClientMcpBlockResult, "flairUrl">): { url: string; defaulted: boolean } {
+  return block.flairUrl ? { url: block.flairUrl, defaulted: false } : { url: FLAIR_CLIENT_DEFAULT_URL, defaulted: true };
 }
 
 /**
  * Read the Flair MCP server block from `clientId`'s config file. `present`
- * is true only when the block exists AND both FLAIR_AGENT_ID and FLAIR_URL
- * are set (non-empty) — a half-wired block (e.g. block present, env missing)
- * counts as absent for the pass/fail check, but agentId/flairUrl are still
- * returned when partially found so callers can use whatever is known.
+ * is true when the block exists AND FLAIR_AGENT_ID is set (non-empty).
+ *
+ * FLAIR_URL is deliberately NOT required (flair#1287): flair-client treats it
+ * as optional and falls back to FLAIR_CLIENT_DEFAULT_URL, and the documented
+ * `claude mcp add` command (docs/mcp-clients.md) sets only FLAIR_AGENT_ID —
+ * so a URL-less block is a WORKING setup that doctor used to false-negative
+ * as "no Flair MCP server configured". Doctor's requirement now matches
+ * flair-client's actual contract: agent id required (flair-mcp refuses to
+ * start without one — "(none — required)" in docs), URL optional
+ * (`urlDefaulted` reports the fallback so the output can distinguish it).
+ * agentId/flairUrl are still returned when partially found so callers can use
+ * whatever is known.
  */
 export function readClientMcpBlock(clientId: ClientId, homeDir: string): ClientMcpBlockResult {
   const configPath = withHome(homeDir, () => clientConfigPath(clientId));
@@ -552,7 +586,11 @@ function readJsonFlairBlock(configPath: string): ClientMcpBlockResult {
     if (!flair || typeof flair !== "object") return { present: false, configPath };
     const agentId: string | undefined = typeof flair.env?.FLAIR_AGENT_ID === "string" && flair.env.FLAIR_AGENT_ID ? flair.env.FLAIR_AGENT_ID : undefined;
     const flairUrl: string | undefined = typeof flair.env?.FLAIR_URL === "string" && flair.env.FLAIR_URL ? flair.env.FLAIR_URL : undefined;
-    return { present: !!agentId && !!flairUrl, configPath, agentId, flairUrl };
+    // FLAIR_URL optional — see readClientMcpBlock's doc (flair#1287). Any
+    // extra fields the client's own tooling writes (e.g. `claude mcp add`'s
+    // `type: "stdio"`) are irrelevant to presence and deliberately ignored.
+    const present = !!agentId;
+    return { present, configPath, agentId, flairUrl, urlDefaulted: present && !flairUrl };
   } catch {
     // Malformed JSON — treat as "not present", never throw.
     return { present: false, configPath };
@@ -582,10 +620,36 @@ function readCodexFlairBlock(configPath: string): ClientMcpBlockResult {
   const raw = readTextFile(configPath);
   if (!raw) return { present: false, configPath };
   const scanned = scanCodexFlairBlock(raw);
-  return { present: scanned.present, configPath, agentId: scanned.agentId, flairUrl: scanned.flairUrl };
+  return { present: scanned.present, configPath, agentId: scanned.agentId, flairUrl: scanned.flairUrl, urlDefaulted: scanned.urlDefaulted };
 }
 
-function scanCodexFlairBlock(raw: string): { present: boolean; agentId?: string; flairUrl?: string } {
+/**
+ * Pull one env value out of the `[mcp_servers.flair]` block text, accepting
+ * BOTH TOML shapes a real Codex config carries for env:
+ *
+ *   1. the `[mcp_servers.flair.env]` sub-table (`FLAIR_AGENT_ID = "..."` on
+ *      its own line) — what `codex mcp add` serializes (toml_edit Table via
+ *      table_from_pairs, openai/codex codex-rs config/edit/document_helpers.rs),
+ *      what Codex's own config docs show, and what our tomlSnippet() writes;
+ *   2. the inline table (`env = { "FLAIR_AGENT_ID" = "..." }`, bare or quoted
+ *      keys) — valid Codex TOML that `codex mcp add` itself PRESERVES when
+ *      merging into a hand-written inline entry (merge_inline_table, same
+ *      file). The old line-anchored regex silently missed this shape — the
+ *      flair#1287 defect class (a client-accepted config our detector
+ *      rejects) in TOML form.
+ */
+function scanCodexEnvValue(block: string, key: string): string | undefined {
+  const lineMatch = block.match(new RegExp(`^\\s*${key}\\s*=\\s*"([^"]*)"`, "m"));
+  if (lineMatch?.[1]) return lineMatch[1];
+  const inlineEnv = block.match(/^\s*env\s*=\s*\{([^}]*)\}/m);
+  if (inlineEnv) {
+    const inlineMatch = inlineEnv[1].match(new RegExp(`"?${key}"?\\s*=\\s*"([^"]*)"`));
+    if (inlineMatch?.[1]) return inlineMatch[1];
+  }
+  return undefined;
+}
+
+function scanCodexFlairBlock(raw: string): { present: boolean; agentId?: string; flairUrl?: string; urlDefaulted?: boolean } {
   const startMatch = raw.match(/^\[mcp_servers\.flair\]\s*$/m);
   if (!startMatch || startMatch.index === undefined) return { present: false };
 
@@ -599,11 +663,12 @@ function scanCodexFlairBlock(raw: string): { present: boolean; agentId?: string;
   }
   const block = blockLines.join("\n");
 
-  const agentMatch = block.match(/^\s*FLAIR_AGENT_ID\s*=\s*"([^"]*)"/m);
-  const urlMatch = block.match(/^\s*FLAIR_URL\s*=\s*"([^"]*)"/m);
-  const agentId = agentMatch?.[1] || undefined;
-  const flairUrl = urlMatch?.[1] || undefined;
-  return { present: !!agentId && !!flairUrl, agentId, flairUrl };
+  const agentId = scanCodexEnvValue(block, "FLAIR_AGENT_ID");
+  const flairUrl = scanCodexEnvValue(block, "FLAIR_URL");
+  // FLAIR_URL optional — same contract as readJsonFlairBlock (flair#1287);
+  // docs/mcp-clients.md's own Codex snippet sets only FLAIR_AGENT_ID.
+  const present = !!agentId;
+  return { present, agentId, flairUrl, urlDefaulted: present && !flairUrl };
 }
 
 // ── check 2: FLAIR_URL to use when (re-)wiring a client (flair#727) ────────

--- a/test/unit/doctor-client-native-shapes.test.ts
+++ b/test/unit/doctor-client-native-shapes.test.ts
@@ -1,0 +1,354 @@
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, rmSync, readFileSync, writeFileSync, mkdirSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+
+import {
+  readClientMcpBlock,
+  effectiveFlairUrl,
+  FLAIR_CLIENT_DEFAULT_URL,
+} from "../../src/doctor-client.ts";
+import {
+  ALL_CLIENTS,
+  clientConfigPath,
+  tomlSnippet,
+  wireClaudeCode,
+  wireCodex,
+  wireGemini,
+  wireCursor,
+  wireAntigravity,
+  type ClientId,
+  type WireEnv,
+} from "../../src/install/clients.ts";
+
+/**
+ * flair#1287 — doctor false-negatived a WORKING setup written by a client's
+ * own tooling. Root cause (Kern's ruling on the issue): readJsonFlairBlock
+ * demanded BOTH FLAIR_AGENT_ID and FLAIR_URL for `present`, while flair-client
+ * treats FLAIR_URL as optional (falls back to its DEFAULT_URL) and the
+ * documented `claude mcp add` command sets only FLAIR_AGENT_ID.
+ *
+ * The fixtures below are the LITERAL client-native config shapes — what each
+ * client's own tooling writes today — NOT the output of our wire functions.
+ * That distinction is the whole point: the #1287 defect was precisely that
+ * the client-written shape and our generated shape drifted apart, and a
+ * fixture produced by our own generator can never express that defect class.
+ * Each fixture therefore also carries a DRIFT-DETECTION assertion: doctor
+ * must accept the fixture AND the fixture must NOT be byte-identical to what
+ * our wire function writes. If those ever converge, the fixture has stopped
+ * testing anything our generator round-trip doesn't already cover, and must
+ * be re-captured from the client's tooling.
+ *
+ * Fixture provenance (verify before editing any of these):
+ *   claude-code — CAPTURED LIVE 2026-08-20 from `claude mcp add flair
+ *     --scope user -e FLAIR_AGENT_ID=canary -- npx -y
+ *     @tpsdev-ai/flair-mcp@0.46.0` run against an isolated HOME
+ *     (machineID/userID anonymized to zeros; every other byte literal,
+ *     including the `type: "stdio"` field and the env with ONLY
+ *     FLAIR_AGENT_ID — the exact shape the 2026-08-19 canary hit).
+ *   gemini — CAPTURED LIVE 2026-08-20 from `gemini mcp add flair npx
+ *     --scope user -e FLAIR_AGENT_ID=canary -- -y @tpsdev-ai/flair-mcp@0.46.0`
+ *     against an isolated HOME. Byte literal.
+ *   codex — derived from openai/codex source (`codex mcp add` serializes env
+ *     as a `[mcp_servers.<name>.env]` sub-table with sorted keys:
+ *     codex-rs/core/src/config/edit/document_helpers.rs,
+ *     serialize_mcp_server_table → table_from_pairs, read 2026-08-20) and
+ *     Codex's config docs, which show the same sub-table form. Structure is
+ *     source-verified; inter-table whitespace is approximated (the scanner is
+ *     line-anchored and whitespace-insensitive). Not captured live: the host
+ *     codex install's vendor binary is broken.
+ *   cursor — cursor.com/docs/context/mcp "Using mcp.json" (CLI Server -
+ *     Node.js example shape, read 2026-08-20), with the flair values our
+ *     docs/mcp-clients.md tells users to set (FLAIR_AGENT_ID only).
+ *   antigravity — antigravity.google/docs/mcp "standardized format" example
+ *     (read 2026-08-20), including a sibling non-flair server entry as their
+ *     doc shows; flair entry per our docs (FLAIR_AGENT_ID only).
+ */
+
+// ── the literal client-native fixtures ──────────────────────────────────────
+
+const CLAUDE_CODE_NATIVE = `{
+  "firstStartTime": "2026-08-20T18:32:54.311Z",
+  "machineID": "0000000000000000000000000000000000000000000000000000000000000000",
+  "opusProMigrationComplete": true,
+  "sonnet1m45MigrationComplete": true,
+  "seenNotifications": {},
+  "hasResetAutoModeOptInForDefaultOffer": true,
+  "migrationVersion": 13,
+  "userID": "0000000000000000000000000000000000000000000000000000000000000000",
+  "mcpServers": {
+    "flair": {
+      "type": "stdio",
+      "command": "npx",
+      "args": [
+        "-y",
+        "@tpsdev-ai/flair-mcp@0.46.0"
+      ],
+      "env": {
+        "FLAIR_AGENT_ID": "canary"
+      }
+    }
+  }
+}`;
+
+const CODEX_NATIVE = `[mcp_servers.flair]
+command = "npx"
+args = ["-y", "@tpsdev-ai/flair-mcp@0.46.0"]
+
+[mcp_servers.flair.env]
+FLAIR_AGENT_ID = "canary"
+`;
+
+const GEMINI_NATIVE = `{
+  "mcpServers": {
+    "flair": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "@tpsdev-ai/flair-mcp@0.46.0"
+      ],
+      "env": {
+        "FLAIR_AGENT_ID": "canary"
+      }
+    }
+  }
+}`;
+
+const CURSOR_NATIVE = `{
+  "mcpServers": {
+    "flair": {
+      "command": "npx",
+      "args": ["-y", "@tpsdev-ai/flair-mcp@0.46.0"],
+      "env": {
+        "FLAIR_AGENT_ID": "canary"
+      }
+    }
+  }
+}`;
+
+const ANTIGRAVITY_NATIVE = `{
+  "mcpServers": {
+    "sqlite-explorer": {
+      "command": "node",
+      "args": ["/usr/local/bin/sqlite-mcp-server.js"],
+      "env": {
+        "SQLITE_DB_PATH": "/var/data/app.db"
+      }
+    },
+    "flair": {
+      "command": "npx",
+      "args": ["-y", "@tpsdev-ai/flair-mcp@0.46.0"],
+      "env": {
+        "FLAIR_AGENT_ID": "canary"
+      }
+    }
+  }
+}`;
+
+const NATIVE_FIXTURES: Record<ClientId, string> = {
+  "claude-code": CLAUDE_CODE_NATIVE,
+  codex: CODEX_NATIVE,
+  gemini: GEMINI_NATIVE,
+  cursor: CURSOR_NATIVE,
+  antigravity: ANTIGRAVITY_NATIVE,
+};
+
+const WIRE_FNS: Record<ClientId, (env: WireEnv) => { ok: boolean; message: string }> = {
+  "claude-code": wireClaudeCode,
+  codex: wireCodex,
+  gemini: wireGemini,
+  cursor: wireCursor,
+  antigravity: wireAntigravity,
+};
+
+// The env our wire functions are fed for the drift comparison. Same agent id
+// as the fixtures; a URL because WireEnv requires one (our generator always
+// writes FLAIR_URL — one of the very drifts these fixtures exist to pin).
+const WIRE_ENV: WireEnv = { FLAIR_AGENT_ID: "canary", FLAIR_URL: "http://127.0.0.1:19926" };
+
+// ── isolation ───────────────────────────────────────────────────────────────
+
+let isoHome: string;
+
+beforeEach(() => {
+  isoHome = mkdtempSync(join(tmpdir(), "flair-native-shapes-"));
+});
+
+afterEach(() => {
+  rmSync(isoHome, { recursive: true, force: true });
+});
+
+/** clientConfigPath()/the wire functions resolve HOME from the live env at
+ *  call time (see resolveHome in src/install/clients.ts) — same technique as
+ *  client-wiring.test.ts, scoped to a callback so no test leaks the override. */
+function withHomeEnv<T>(home: string, fn: () => T): T {
+  const prev = process.env.HOME;
+  process.env.HOME = home;
+  try {
+    return fn();
+  } finally {
+    if (prev === undefined) delete process.env.HOME;
+    else process.env.HOME = prev;
+  }
+}
+
+function writeNativeFixture(home: string, clientId: ClientId): string {
+  const path = withHomeEnv(home, () => clientConfigPath(clientId));
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, NATIVE_FIXTURES[clientId]);
+  return path;
+}
+
+/** Run OUR wire function for `clientId` against a fresh HOME and return the
+ *  exact file bytes it wrote — the "our generator" side of every drift
+ *  assertion. */
+function ourWireOutput(clientId: ClientId): string {
+  const wireHome = mkdtempSync(join(tmpdir(), "flair-wire-out-"));
+  try {
+    return withHomeEnv(wireHome, () => {
+      const res = WIRE_FNS[clientId](WIRE_ENV);
+      // Positive control: if the wire itself failed, the drift comparison
+      // below would be comparing against an error message's absence.
+      expect(res.ok).toBe(true);
+      return readFileSync(clientConfigPath(clientId), "utf-8");
+    });
+  } finally {
+    rmSync(wireHome, { recursive: true, force: true });
+  }
+}
+
+// ── the per-client suites ───────────────────────────────────────────────────
+
+describe("doctor recognizes client-NATIVE MCP config shapes (flair#1287)", () => {
+  it("carries a client-native fixture for EVERY registry client — a new ALL_CLIENTS entry must add one", () => {
+    expect(Object.keys(NATIVE_FIXTURES).sort()).toEqual(ALL_CLIENTS.map((c) => c.id).sort());
+  });
+
+  for (const client of ALL_CLIENTS) {
+    const id = client.id;
+
+    it(`${id}: accepts the client-native shape — present, agent read, URL defaulted`, () => {
+      writeNativeFixture(isoHome, id);
+      const block = readClientMcpBlock(id, isoHome);
+      expect(block.present).toBe(true);
+      expect(block.agentId).toBe("canary");
+      expect(block.flairUrl).toBeUndefined();
+      expect(block.urlDefaulted).toBe(true);
+    });
+
+    it(`${id}: fixture still expresses the defect class — no FLAIR_URL anywhere in it`, () => {
+      // Every client's documented native wiring sets only FLAIR_AGENT_ID
+      // (flair-client defaults the URL). A FLAIR_URL sneaking into a fixture
+      // means it was regenerated from our wire functions — which always
+      // write one — and no longer tests what the client writes.
+      expect(NATIVE_FIXTURES[id].includes("FLAIR_URL")).toBe(false);
+    });
+
+    it(`${id}: drift detection — fixture is NOT byte-identical to our wire function's output`, () => {
+      // Kern's ruling, point 4: a fixture matching our own generator is not
+      // testing the defect class. If this fires, do NOT "fix" the fixture by
+      // regenerating it — re-capture it from the client's own tooling.
+      const wired = ourWireOutput(id);
+      expect(NATIVE_FIXTURES[id]).not.toBe(wired);
+      if (id === "codex") {
+        // The TOML generator's raw snippet is the entry-level equivalent.
+        expect(NATIVE_FIXTURES[id]).not.toBe(tomlSnippet(WIRE_ENV) + "\n");
+      } else {
+        // Whole-file inequality could be satisfied by sibling keys alone
+        // (claude-code's fixture carries real top-level state), so also pin
+        // inequality of the flair ENTRY itself.
+        const fixtureEntry = JSON.stringify(JSON.parse(NATIVE_FIXTURES[id]).mcpServers.flair);
+        const wiredEntry = JSON.stringify(JSON.parse(wired).mcpServers.flair);
+        expect(fixtureEntry).not.toBe(wiredEntry);
+      }
+    });
+  }
+
+  it("claude-code: the fixture carries the literal `type: \"stdio\"` field `claude mcp add` writes", () => {
+    // The 2026-08-19 canary's observed shape. Presence detection must ignore
+    // extra client-written fields; this pins that the fixture keeps carrying
+    // one (our own generator never writes `type`).
+    expect(JSON.parse(CLAUDE_CODE_NATIVE).mcpServers.flair.type).toBe("stdio");
+  });
+
+  it("codex: also accepts the inline env table form codex preserves for hand-written entries", () => {
+    // `codex mcp add` serializes env as a sub-table, but PRESERVES an entry a
+    // user hand-wrote as an inline table (merge_inline_table in the same
+    // codex source) — so this is also a codex-native shape doctor must read.
+    const toml = [
+      "[mcp_servers.flair]",
+      'command = "npx"',
+      'args = ["-y", "@tpsdev-ai/flair-mcp@0.46.0"]',
+      'env = { "FLAIR_AGENT_ID" = "canary" }',
+      "",
+    ].join("\n");
+    const path = join(isoHome, ".codex", "config.toml");
+    mkdirSync(dirname(path), { recursive: true });
+    writeFileSync(path, toml);
+    const block = readClientMcpBlock("codex", isoHome);
+    expect(block.present).toBe(true);
+    expect(block.agentId).toBe("canary");
+    expect(block.urlDefaulted).toBe(true);
+  });
+
+  it("codex: inline env table with bare (unquoted) keys reads the same", () => {
+    const toml = [
+      "[mcp_servers.flair]",
+      'command = "npx"',
+      'args = ["-y", "@tpsdev-ai/flair-mcp@0.46.0"]',
+      'env = { FLAIR_AGENT_ID = "canary", FLAIR_URL = "http://127.0.0.1:9926" }',
+      "",
+    ].join("\n");
+    const path = join(isoHome, ".codex", "config.toml");
+    mkdirSync(dirname(path), { recursive: true });
+    writeFileSync(path, toml);
+    const block = readClientMcpBlock("codex", isoHome);
+    expect(block.present).toBe(true);
+    expect(block.agentId).toBe("canary");
+    expect(block.flairUrl).toBe("http://127.0.0.1:9926");
+    expect(block.urlDefaulted).toBe(false);
+  });
+});
+
+// ── the env-var-incomplete case, explicitly (Kern's ruling, point 5) ────────
+
+describe("env-incomplete-but-working block (flair#1287)", () => {
+  it("FLAIR_AGENT_ID present + FLAIR_URL absent → present, urlDefaulted, and the effective URL is flair-client's default", () => {
+    writeFileSync(
+      join(isoHome, ".claude.json"),
+      JSON.stringify({
+        mcpServers: {
+          flair: {
+            type: "stdio",
+            command: "npx",
+            args: ["-y", "@tpsdev-ai/flair-mcp@0.46.0"],
+            env: { FLAIR_AGENT_ID: "canary" },
+          },
+        },
+      }),
+    );
+    const block = readClientMcpBlock("claude-code", isoHome);
+    expect(block.present).toBe(true);
+    expect(block.urlDefaulted).toBe(true);
+    const eff = effectiveFlairUrl(block);
+    expect(eff.defaulted).toBe(true);
+    expect(eff.url).toBe(FLAIR_CLIENT_DEFAULT_URL);
+  });
+
+  it("an explicit FLAIR_URL passes through effectiveFlairUrl untouched (not defaulted)", () => {
+    const eff = effectiveFlairUrl({ flairUrl: "http://harper.local:19926" });
+    expect(eff.defaulted).toBe(false);
+    expect(eff.url).toBe("http://harper.local:19926");
+  });
+
+  it("FLAIR_CLIENT_DEFAULT_URL matches flair-client's own DEFAULT_URL source — the two cannot drift silently", () => {
+    // doctor-client duplicates the value (flair-client doesn't export it);
+    // this reads the authoritative source line so a change there fails here.
+    const src = readFileSync(
+      join(import.meta.dirname, "..", "..", "packages", "flair-client", "src", "client.ts"),
+      "utf-8",
+    );
+    const m = src.match(/const DEFAULT_URL = "([^"]+)"/);
+    expect(m?.[1]).toBe(FLAIR_CLIENT_DEFAULT_URL);
+  });
+});

--- a/test/unit/doctor-client.test.ts
+++ b/test/unit/doctor-client.test.ts
@@ -71,16 +71,35 @@ describe("readClientMcpBlock", () => {
     expect(res.flairUrl).toBe("http://127.0.0.1:9926");
   });
 
-  it("claude-code: not present when the block exists but is missing FLAIR_URL", () => {
+  it("claude-code: PRESENT (URL defaulted) when the block has FLAIR_AGENT_ID but no FLAIR_URL (flair#1287)", () => {
+    // This test used to assert present:false — encoding the flair#1287
+    // false-negative: flair-client treats FLAIR_URL as optional (falls back
+    // to its DEFAULT_URL), so a URL-less block is a working setup and doctor
+    // must not demand a var the client doesn't need.
     writeFileSync(
       join(isoHome, ".claude.json"),
       JSON.stringify({ mcpServers: { flair: { command: "npx", env: { FLAIR_AGENT_ID: "me" } } } }),
     );
     const res = readClientMcpBlock("claude-code", isoHome);
-    expect(res.present).toBe(false);
-    // Partial info still surfaced.
+    expect(res.present).toBe(true);
+    expect(res.urlDefaulted).toBe(true);
     expect(res.agentId).toBe("me");
     expect(res.flairUrl).toBeUndefined();
+  });
+
+  it("claude-code: NOT present when the block is missing FLAIR_AGENT_ID (URL alone is not a working setup)", () => {
+    // Positive control for the flair#1287 relaxation: only FLAIR_URL became
+    // optional. FLAIR_AGENT_ID is genuinely required (flair-mcp refuses to
+    // start without one), so a block carrying only a URL stays not-present.
+    writeFileSync(
+      join(isoHome, ".claude.json"),
+      JSON.stringify({ mcpServers: { flair: { command: "npx", env: { FLAIR_URL: "http://127.0.0.1:9926" } } } }),
+    );
+    const res = readClientMcpBlock("claude-code", isoHome);
+    expect(res.present).toBe(false);
+    expect(res.urlDefaulted).toBeFalsy();
+    // Partial info still surfaced.
+    expect(res.flairUrl).toBe("http://127.0.0.1:9926");
   });
 
   it("claude-code: not present (never throws) on malformed JSON", () => {


### PR DESCRIPTION
Closes #1287

## Root cause (per Kern's design ruling on the issue)

`readJsonFlairBlock` required BOTH `FLAIR_AGENT_ID` and `FLAIR_URL` for `present: true`, while flair-client treats `FLAIR_URL` as optional (constructor falls back to its `DEFAULT_URL`, `http://localhost:19926`) and the documented `claude mcp add` command sets only `FLAIR_AGENT_ID`. So a stock user who followed our own docs had a working server that doctor reported as "no Flair MCP server configured", with a fix suggestion they didn't need. The canary's `type: "stdio"` theory was a correlation: `doctor --fix` rewrites the block with both env vars, which is why "fixing" it made detection pass. Detection never inspected `type` at all.

## Changes

1. **`FLAIR_URL` optional for `present`** (`readJsonFlairBlock`): agent id remains required (flair-mcp refuses to start without one — "(none — required)" in docs/mcp-clients.md); URL absent means flair-client's default applies. A new `urlDefaulted` field reports the fallback. A positive-control test pins that a URL-only block (no agent id) is still not-present.
2. **Distinct doctor output for env-incomplete-but-working blocks**: renders as configured with an explicit note, and reachability/registration checks run against the default URL:
   ```
   ✓ Claude Code: MCP server configured (~/.claude.json)
      ℹ FLAIR_URL not set — flair-mcp defaults to http://localhost:19926
      ⚠ FLAIR_URL http://localhost:19926 (client default) not reachable — cannot verify agent registration
   ```
   (verified end-to-end against an isolated HOME wired by a real `claude mcp add`; previously this exact state rendered `✗ ... no Flair MCP server configured`). The default URL lives in `FLAIR_CLIENT_DEFAULT_URL` with a test asserting it matches flair-client's source line, so the duplicate can't drift silently.
3. **Same contract for the Codex TOML scanner**, plus it now reads the inline `env = { ... }` table form (quoted or bare keys) — valid Codex TOML that `codex mcp add` preserves when merging into a hand-written inline entry; the old line-anchored regex silently missed it (same defect class, TOML face).
4. **Literal client-native fixtures for all 5 registry clients** (`test/unit/doctor-client-native-shapes.test.ts`), never our wire functions' output:
   - claude-code — captured live from `claude mcp add` against an isolated HOME (carries the literal `type: "stdio"` field and env with only `FLAIR_AGENT_ID`; machineID/userID anonymized to zeros)
   - gemini — captured live from `gemini mcp add` against an isolated HOME
   - codex — derived from openai/codex source (`codex mcp add` serializes env as a `[mcp_servers.<name>.env]` sub-table, sorted keys — codex-rs config/edit/document_helpers.rs) + Codex config docs; the host codex binary is broken so this one could not be captured live
   - cursor — cursor.com/docs/context/mcp mcp.json example shape
   - antigravity — antigravity.google/docs/mcp standardized-format example, sibling server entry included
5. **Per-fixture drift detection**: each fixture asserts doctor accepts it AND that it is NOT byte-identical to our wire function's output for the same client (entry-level JSON inequality too, so sibling keys alone can't satisfy it; `tomlSnippet` comparison for codex). A fixture regenerated from our own generator fails the suite. A registry-coverage count fails if a client is added to `ALL_CLIENTS` without a native fixture.

## Mutation checks (break the fix → red → restore → green, per mutation)

| # | Mutation | Red (targeted tests fired) | Restored |
|---|----------|---------------------------|----------|
| M1 | `readJsonFlairBlock` requires both env vars again | 6 fail: 4 JSON-client native-shape tests + env-incomplete test + rewritten legacy test | green |
| M2 | Codex scanner requires both env vars again | 2 fail: codex native + codex inline-env | green |
| M3 | Inline env-table branch removed from codex scanner | 2 fail: both inline-env tests | green |
| M4 | `effectiveFlairUrl` never reports `defaulted` | 1 fail: env-incomplete effective-URL test | green |
| M5 | Gemini fixture replaced with `wireGemini` output (drift-assertion positive control) | 3 fail incl. the drift-detection test | green |
| M6 | `FLAIR_CLIENT_DEFAULT_URL` drifted to `:9926` | 1 fail: source-drift test | green |
| M7 | Cursor fixture removed from the fixture map | 4 fail incl. the registry-coverage count | green |
| M8 | `urlDefaulted` hardcoded `false` | 6 fail: all urlDefaulted assertions | green |

## Test counts

Self-measured baseline at `origin/main` (e4f2f8bd), full unit suite: **4578 pass / 6 fail / 2 errors, 4584 tests, 240 files**. With this branch: **4601 pass / 6 fail / 2 errors, 4607 tests, 241 files** — +23 tests, all new, all passing; the failing set is byte-identical to baseline (pre-existing memory-search-scope authz suite + embeddings-provider export errors, unrelated to this change). `bunx tsc --noEmit` error output is byte-identical to the origin/main baseline. `node scripts/changelog-fragments.mjs check` passes.

## Honest limits

- The doctor OUTPUT branch itself (the `console.log` lines in `src/cli.ts`) is exercised end-to-end manually (transcript above) but not unit-tested — the monolithic doctor command has no output harness. The decision signal it branches on (`urlDefaulted` / `effectiveFlairUrl`) is fully unit- and mutation-covered.
- The codex fixture is source-derived, not tooling-captured (broken vendor binary on the build host); inter-table whitespace is approximated, structure is source-verified. Worth re-capturing from a working `codex mcp add` when one is at hand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
