### PR TITLE
team-concierge example: comments teach the pattern — internal references and version-history noise removed, verified against published 0.46.0

### DIFF
--- a/.changelog/unreleased/changed-team-concierge-example-user-pass.md
+++ b/.changelog/unreleased/changed-team-concierge-example-user-pass.md
@@ -1,0 +1,8 @@
+- team-concierge example: every comment now teaches the pattern — internal
+  issue numbers, reviewer names, and version-publishing history removed from
+  the README, agent, verify scripts, and GCP runbook. Dependencies pin the
+  published release (`adk-flair>=0.46.0`) and the quickstart installs from
+  PyPI; the runbook's operational caveats were re-verified against the
+  published 0.46.0 CLI (one corrected: re-running `flair agent add` on an
+  existing id reports success but keeps the old public key — it does not
+  refuse).

--- a/examples/team-concierge/README.md
+++ b/examples/team-concierge/README.md
@@ -44,8 +44,8 @@ scope) remain the real boundary; the allowlist narrows the LLM surface on top.
 > write, missing tag on a search) could expose one user's context to another.
 > This is acceptable for a single-trust-domain internal team tool because the
 > application code is under team control. For true per-user cryptographic
-> isolation, use per-user agent identities (the epic's "Keep Your Memory
-> Yours" scenario — out of scope here).
+> isolation, use per-user agent identities — out of scope for this example
+> (see "Not this example" below).
 
 ## 5-minute quickstart
 
@@ -55,10 +55,7 @@ init` gives you one at `http://localhost:19926`), Python ≥ 3.10.
 ```bash
 cd examples/team-concierge
 
-# 1. Install (adk-flair >= 0.44.13 is required for the explicit
-#    durability/visibility write knobs; until that version is on PyPI,
-#    install the connector from this repo checkout):
-pip install -e ../../packages/adk-flair
+# 1. Install (pulls adk-flair and google-adk from PyPI):
 pip install -e .
 
 # 2. Provision the concierge's own agent identity (never a shared/admin key):
@@ -109,7 +106,7 @@ scripts/verify.sh
 
 # Or with pre-provisioned keys (e.g. the real concierge + a teammate's identity):
 FLAIR_URL=... CONCIERGE_AGENT_ID=concierge CONCIERGE_KEYFILE=~/.flair/keys/concierge.key \
-READER_AGENT_ID=flint READER_KEYFILE=~/.flair/keys/flint.key \
+READER_AGENT_ID=alice READER_KEYFILE=~/.flair/keys/alice.key \
 scripts/verify.sh
 ```
 
@@ -124,12 +121,12 @@ from the repo root after `npm run build`) — it prints a JSON line with
 `httpURL`/`opsURL`/admin credentials to feed the variables above, and tears
 down when its stdin closes.
 
-## Session distillation (the #1205 pipeline)
+## Session distillation
 
 Raw session episodes land `standard`+`private` under the user's tag, which
 makes them distillation input: a nightly REM run with `scope:"tagged"` per
 `adk:concierge:<user>` stages `MemoryCandidate` rows for review. Two
-operational rules from the spec:
+operational rules:
 
 - **The runner must execute as the concierge identity** (or admin). Episodes
   are private to the concierge key — a runner under any other identity reads

--- a/examples/team-concierge/concierge/agent.py
+++ b/examples/team-concierge/concierge/agent.py
@@ -23,7 +23,7 @@ Write surface (the whole point of this file):
   Session episodes (raw turns) are persisted by the after-agent callback as
   durability="standard", visibility="private" — explicitly, not via the
   server's durability-keyed default (every write-site sets visibility
-  explicitly; a shipped default is a trust anchor, flair#1222).
+  explicitly; a shipped default is a trust anchor).
 """
 
 from __future__ import annotations
@@ -42,27 +42,27 @@ from adk_flair import FlairMemoryService
 
 APP_NAME = "concierge"
 
-# Model is not load-bearing for this example (spec §5) — any ADK-supported
-# model string works. Default: native Gemini; override with ADK_MODEL.
+# Model is not load-bearing for this example — any ADK-supported model
+# string works. Default: native Gemini; override with ADK_MODEL.
 MODEL = os.environ.get("ADK_MODEL", "gemini-2.5-flash")
 
 
 # ─── Connector capability gate ───────────────────────────────────────────────
 # record_decision needs adk-flair's explicit durability/visibility knobs on
-# add_memory (shipped in 0.44.13, flair#1234/#1237). The stock 0.44.12
-# add_memory hardcodes durability="standard" and has no visibility support at
-# all — silently downgrading a "team decision" to a private row would be the
-# exact failure this example exists to demonstrate against. Fail at import,
-# loudly, with the remedy — never at first use inside a chat session.
+# add_memory. An older connector without them hardcodes durability="standard"
+# and has no visibility support at all — silently downgrading a "team
+# decision" to a private row would be the exact failure this example exists
+# to demonstrate against. Gate on the CAPABILITY (the signature), not a
+# version string, and fail at import, loudly, with the remedy — never at
+# first use inside a chat session.
 def _assert_connector_supports_write_knobs() -> None:
     params = inspect.signature(FlairMemoryService.add_memory).parameters
     if "durability" not in params or "visibility" not in params:
         raise RuntimeError(
-            "adk-flair >= 0.44.13 is required: this installed version's "
-            "add_memory() has no durability/visibility parameters, so "
-            "record_decision cannot produce a persistent+shared row. "
-            "Upgrade with `pip install -U adk-flair` (or, from a flair repo "
-            "checkout, `pip install -e packages/adk-flair`)."
+            "The installed adk-flair's add_memory() has no "
+            "durability/visibility parameters, so record_decision cannot "
+            "produce a persistent+shared row. Upgrade with "
+            "`pip install -U adk-flair`."
         )
 
 
@@ -104,9 +104,9 @@ def _entry(text: str, author: str, entry_id: str | None = None) -> MemoryEntry:
 # Each write CLASS is a frozen module-level constant — the single source for
 # both the add_memory call and the confirmation returned to the model, so the
 # report can never claim a class the write didn't use. These are never
-# parameters and never model-selected (Sherlock hard requirement, flair#1229
-# review): a helper that took visibility as an argument would collapse the
-# visibility discipline.
+# parameters and never model-selected: tool arguments are model-controlled
+# input, so a helper that took visibility as an argument would hand the write
+# policy to the model and collapse the visibility discipline.
 
 _DECISION_CLASS = {
     "durability": "persistent",  # team knowledge survives curation cycles
@@ -117,7 +117,7 @@ _PERSONAL_CLASS = {
     "visibility": "private",     # concierge-identity-only, tag-scoped per user
 }
 _EPISODE_CLASS = {
-    "durability": "standard",    # raw turns: distillation input (#1205)
+    "durability": "standard",    # raw turns: distillation input
     "visibility": "private",     # explicit — never the durability-keyed default
 }
 
@@ -183,7 +183,7 @@ async def record_personal(note: str, tool_context: ToolContext) -> dict:
     }
 
 
-# ─── Session episode persistence (raw turns → distillation input, #1205) ─────
+# ─── Session episode persistence (raw turns → distillation input) ────────────
 
 
 def _event_text(event: Any) -> str | None:
@@ -214,7 +214,7 @@ async def persist_session_episodes(
     Rides add_memory (the only connector write surface with the explicit
     knobs) rather than add_events_to_memory, so the visibility of the episode
     lane is set at the write-site instead of inherited from the server's
-    durability-keyed default (spec §3: no write relies on the default).
+    durability-keyed default (no write in this example relies on a default).
 
     Deterministic per-event ids make re-ingestion idempotent, mirroring the
     connector's own session-write scheme.
@@ -237,7 +237,7 @@ async def persist_session_episodes(
             app_name=app_name,
             user_id=user_id,
             memories=entries,
-            **_EPISODE_CLASS,  # FIXED episode class (spec §3 table)
+            **_EPISODE_CLASS,  # FIXED episode class — see the constant above
         )
     return len(entries)
 
@@ -259,7 +259,7 @@ async def _after_agent_callback(callback_context) -> None:
 
 
 # ─── The agent ───────────────────────────────────────────────────────────────
-# The tools list IS the write-surface allowlist (Sherlock hard requirement):
+# The tools list IS the write-surface allowlist:
 # two fixed-class write helpers plus read-only memory tools. Nothing here can
 # write a soul record, workspace state, an org event, or a raw memory row
 # with caller-chosen flags.

--- a/examples/team-concierge/concierge/requirements.txt
+++ b/examples/team-concierge/concierge/requirements.txt
@@ -15,5 +15,5 @@
 # The explicit google-cloud-aiplatform line also pre-empts the deploy CLI's
 # _ensure_agent_engine_dependency fallback, which would otherwise append its
 # own aiplatform AND a second google-adk pin to this file at staging time.
-adk-flair>=0.44.13
+adk-flair>=0.46.0
 google-cloud-aiplatform[adk,agent_engines]>=1.164

--- a/examples/team-concierge/deploy/gcp/RUNBOOK.md
+++ b/examples/team-concierge/deploy/gcp/RUNBOOK.md
@@ -5,7 +5,7 @@ running on **Vertex AI Agent Engine** (Google's managed ADK runtime — the
 current docs call it *Agent Runtime* on the *Gemini Enterprise Agent
 Platform*; the API resource is still `reasoningEngines`), with **Gemini** as
 the model and **memory on your self-hosted Flair Fabric hub** via
-[adk-flair](https://pypi.org/project/adk-flair/) ≥ 0.44.13.
+[adk-flair](https://pypi.org/project/adk-flair/).
 
 The shape, in one paragraph: `deploy.sh` wraps `adk deploy agent_engine`
 around the unchanged [`../../concierge`](../../concierge) agent folder.
@@ -258,8 +258,10 @@ above, not as the rotation itself.
 against a different hub than `FLAIR_URL`, or the secret holds a stale key
 (e.g. re-minted after upload), every memory op gets 401. Symptoms: chat
 works but recording fails; the instance's Cloud Logging shows adk-flair
-request errors. Fix: re-run step 3 against the right hub (`flair agent add`
-refuses an existing id — remove it first or pick a new id + secret), push
+request errors. Fix: re-run step 3 against the right hub (against an
+existing Agent row the hub keeps the OLD public key while the command
+reports success — delete the row first, as in teardown step 3, or pick a
+new id + secret), push
 the current keyfile as a **new secret version**
 (`gcloud secrets versions add concierge-gcp-flair-key --data-file=...`), and
 redeploy with `AGENT_ENGINE_ID=<id>` so the runtime picks it up.

--- a/examples/team-concierge/pyproject.toml
+++ b/examples/team-concierge/pyproject.toml
@@ -10,13 +10,10 @@ requires-python = ">=3.10"
 dependencies = [
     "google-adk>=2.6",
     # This example REQUIRES the explicit durability/visibility knobs on
-    # add_memory (adk-flair 0.44.13, flair#1234/#1237). PyPI may still serve
-    # 0.44.12 while the 0.44.13 publish is in flight — until it lands, install
-    # the connector from the repo checkout instead:
-    #     pip install -e ../../packages/adk-flair
-    # concierge/agent.py checks the installed connector at import and fails
-    # with this remedy if the knobs are missing.
-    "adk-flair>=0.44.12",
+    # FlairMemoryService.add_memory — record_decision's persistent+shared
+    # write class depends on them. concierge/agent.py checks the installed
+    # connector at import and fails with the remedy if the knobs are missing.
+    "adk-flair>=0.46.0",
     # verify.sh dependencies (both already transitive via adk-flair, pinned
     # here because scripts/verify_impl.py imports them directly):
     "httpx>=0.27",

--- a/examples/team-concierge/scripts/verify.sh
+++ b/examples/team-concierge/scripts/verify.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# verify.sh — the Team Concierge scenario's claims, executed (spec §6).
+# verify.sh — the Team Concierge scenario's claims, executed.
 # The demo IS the test: run it against a LIVE Flair instance.
 #
 # Environment:
@@ -38,7 +38,6 @@ PYTHON="${PYTHON:-python3}"
 if ! "$PYTHON" -c "import adk_flair, httpx, cryptography" 2>/dev/null; then
   echo "verify.sh: missing Python deps — install the example first:" >&2
   echo "  pip install -e ." >&2
-  echo "  (and, until adk-flair>=0.44.13 is on PyPI: pip install -e ../../packages/adk-flair)" >&2
   exit 2
 fi
 

--- a/examples/team-concierge/scripts/verify_impl.py
+++ b/examples/team-concierge/scripts/verify_impl.py
@@ -2,7 +2,7 @@
 
 Run through scripts/verify.sh (which documents the environment contract).
 
-What is asserted (spec flair#1229 §6), each against a LIVE Flair instance:
+What is asserted, each against a LIVE Flair instance:
 
   S1  Cross-harness, org-open: a decision recorded through the Concierge's
       record_decision helper is retrievable by a DIFFERENT agent identity via
@@ -313,8 +313,8 @@ async def main() -> int:
     # ═════ S2 — personal: private wall against the other identity ═══════════
     # Mutation check: flip _PERSONAL_CLASS["visibility"] to "shared" →
     # the helper-report, search-absence, by-id-denied, and stored-flags
-    # assertions below ALL fail. Restore → passes. (The #1222-class
-    # regression detector.)
+    # assertions below ALL fail. Restore → passes. (The detector for a
+    # write-site drifting back onto a default visibility.)
     out = await record_personal(personal_a_text, ctx_a)
     ensure(
         out.get("durability") == "standard" and out.get("visibility") == "private",
@@ -434,7 +434,7 @@ async def main() -> int:
         f"visibility={row.get('visibility')!r}, durability={row.get('durability')!r}",
     )
 
-    # 4a — tagged gather is per-user (the #1205b cross-user-bleed boundary).
+    # 4a — tagged gather is per-user (the cross-user-bleed boundary).
     def _gather() -> dict | None:
         resp = concierge_rest.request(
             "POST", "/ReflectMemories",


### PR DESCRIPTION
## What

A user-facing quality pass on `examples/team-concierge/`. The example read like an internal changelog — issue numbers, reviewer names, version-publishing sagas. One rule governed every edit: **every comment teaches the pattern; zero internal references.**

- **Issue citations removed, rationale kept.** Where a comment carried real design rationale (explicit visibility at every write-site because a shipped default is a trust anchor; frozen write-class constants so the model never selects visibility; capability-gated import) the rationale stays, stated as a design fact. Pure provenance ("shipped in X", "PyPI may still serve Y") is deleted — obsolete on the current release.
- **Reviewer names removed.** Requirements are stated as design facts ("tool arguments are model-controlled input, so a helper that took visibility as an argument would hand the write policy to the model").
- **Dependencies pin the published release**: `adk-flair>=0.46.0` in `pyproject.toml` and `concierge/requirements.txt`; the quickstart installs from PyPI — the repo-checkout fallback and all publish-timing commentary are gone. The import gate's error now names the missing capability, not a version history.
- **RUNBOOK caveats re-verified against the published 0.46.0** rather than carried forward. Confirmed still true in `@tpsdev-ai/flair@0.46.0` `dist/cli.js`: `agent rotate-key` and `agent remove` dial `127.0.0.1` only; `agent add` seeds `admin: false` with no `role` field and has no elevation flag; Node >= 22 engines; and adk-flair 0.46.0 still uses one-attempt sub-2s HTTP timeouts ("One attempt, no retry", `httpx.Timeout(connect=0.5, read=1.5, write=1.0)`). One claim was wrong and is fixed: `agent add` does **not** refuse an existing id — the seed treats 409/duplicate as success and the hub keeps the old public key (the rotation section already said so; the failure-modes section now agrees).

## Run evidence — published artifacts only

Isolated environment (fresh venv, HOME-isolated fake home; nothing global, nothing from the local tree):

- `adk-flair==0.46.0` + `google-adk 2.7.1` installed **from PyPI**; example installed with its own quickstart path (`pip install -e .`).
- `@tpsdev-ai/flair@0.46.0` installed **from npm** into a scratch dir; ephemeral instance booted with a HOME-isolated `flair init` (Harper on 19926/19925).
- `scripts/verify.sh` against that instance: **19 passed, 0 failed, 1 SKIP** — S1 (cross-identity shared read, persistent+shared, compound tag), S2 (private wall with positive control, by-id GET 404), S3 (per-user tag scope both directions), S4/S4a (episode persistence + tagged gather, no cross-user bleed) all passed. The SKIP is S4b execute-distill: the ephemeral instance has no generative backend (HTTP 503) and the script reported the documented loud SKIP rather than a silent pass.

Not run: the GCP Agent Engine deploy legs (`deploy.sh`, `chat.py`) — they need a GCP project; their operational claims were verified statically against the published packages as above. The interactive `adk web`/`run` chat leg was not exercised (needs a Gemini key); `verify.sh` drives the same helpers the LLM calls, so only the model's tool-choice is outside the run.

## Linkage

No issue: user-facing quality pass on the shipped example (Nathan review feedback).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
