### PR TITLE
test: explicit 120s timeout on orgevent-cli beforeAll build hook

### DIFF
--- a/.changelog/unreleased/fixed-1300-orgevent-cli-hook-timeout.md
+++ b/.changelog/unreleased/fixed-1300-orgevent-cli-hook-timeout.md
@@ -1,0 +1,5 @@
+- The orgevent CLI unit suite no longer dice-rolls a hook timeout under CI
+  runner load (#1300). Its `beforeAll` execSyncs a full CLI build, which has
+  exceeded bun's default 5s hook budget on a PR that never touched the file
+  (observed 5005ms on #1299's run); the hook now carries an explicit 120s
+  timeout. Test-lane hygiene only — no runtime behavior changes.

--- a/test/unit/orgevent-cli.test.ts
+++ b/test/unit/orgevent-cli.test.ts
@@ -85,9 +85,13 @@ describe("flair orgevent", () => {
   let tmpDir: string;
   let keysDir: string;
 
+  // #1300: this hook execSyncs a full CLI build, which under parallel CI
+  // runner load has blown bun's default 5s hook budget (observed 5005ms on a
+  // PR that never touched this file). Explicit generous timeout removes the
+  // dice-roll; bun applies it per-hook (HookOptions = number | { timeout }).
   beforeAll(() => {
     execSync("bun run build:cli", { stdio: "ignore" });
-  });
+  }, 120_000);
 
   beforeEach(() => {
     tmpDir = makeTmpDir();


### PR DESCRIPTION
Closes #1300

## What

test/unit/orgevent-cli.test.ts's `beforeAll` execSyncs a full CLI build (`bun run build:cli`). Under parallel CI runner load that has exceeded bun's default 5s hook budget — observed as a 5005ms hook timeout on #1299's run, a PR that never touched this file. The hook now carries an explicit 120s timeout (bun per-hook `HookOptions = number | { timeout }`), removing the dice-roll. One hook, +5/-1 diff plus changelog fragment; no runtime behavior changes.

Note on the issue's "beforeEach" wording: bun reports a timed-out `beforeAll` as "a beforeEach/afterEach hook timed out for this test" — the failing hook at line 89 was always the `beforeAll` build; the actual `beforeEach` only mkdirs.

## Verification (all HOME/TMPDIR-isolated)

- **Timeout arg is actually applied (mutation check):** temporarily set the hook timeout to `1` — the file failed in a 20ms total run with `(fail) flair orgevent > (unnamed) / ^ a beforeEach/afterEach hook timed out for this test`, the execSync killed mid-build (`error: Command failed: bun run build:cli`). Restored to `120_000`; positive control confirms the second argument governs this hook.
- **File 3x green:** three consecutive runs of `bun test test/unit/orgevent-cli.test.ts`: `6 pass / 0 fail / 24 expect()` at 1136ms, 1095ms, 1072ms.
- **Full unit lane vs self-measured origin/main baseline (14248fb2):** baseline `4780 pass / 1 fail / 11050 expect() across 250 files`; this branch identical `4780 pass / 1 fail / 11050 expect() across 250 files`. The single fail is the same pre-existing, environment-specific case on unmodified origin/main: `createDataSnapshot > skips a unix domain socket without crashing the snapshot`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
