### PR TITLE
test: sweep flair-bridge-test-* temp trees in roundtrip suite teardown

### DIFF
--- a/.changelog/unreleased/fixed-1293-bridge-roundtrip-tmp-leak.md
+++ b/.changelog/unreleased/fixed-1293-bridge-roundtrip-tmp-leak.md
@@ -1,0 +1,7 @@
+- The unit lane no longer leaks `flair-bridge-test-*` temp trees into TMPDIR
+  on every run (#1293). `runRoundTrip` mkdtemps one tree per call and leaves
+  it behind by design (its `tmpExportPath` is a debugging affordance); the
+  round-trip unit suite now tracks each tree it causes and sweeps them in
+  `afterAll`. Leaked trees have previously filled a builder host's disk and
+  taken an agent offline. Test-lane hygiene only — no runtime behavior
+  changes.

--- a/test/unit/bridges-runtime-roundtrip.test.ts
+++ b/test/unit/bridges-runtime-roundtrip.test.ts
@@ -1,6 +1,6 @@
-import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { describe, test, expect, beforeEach, afterEach, afterAll } from "bun:test";
 import { mkdirSync, rmSync, writeFileSync, readFileSync } from "node:fs";
-import { join } from "node:path";
+import { join, dirname } from "node:path";
 import { tmpdir } from "node:os";
 import { runRoundTrip } from "../../src/bridges/runtime/roundtrip";
 import type { YamlBridgeDescriptor } from "../../src/bridges/types";
@@ -11,6 +11,21 @@ function sandbox(): string {
   mkdirSync(d, { recursive: true });
   return d;
 }
+
+// #1293: runRoundTrip mkdtemps a flair-bridge-test-* tree per call and leaves
+// it behind (tmpExportPath is part of its result, for debugging), so this
+// suite leaked one tree per result-producing call on every unit-lane run.
+// Track each tree via the returned tmpExportPath and sweep them in afterAll —
+// after, not per-test, because one test reads tmpExportPath back.
+const bridgeTestTrees: string[] = [];
+async function roundTrip(opts: Parameters<typeof runRoundTrip>[0]) {
+  const result = await runRoundTrip(opts);
+  bridgeTestTrees.push(dirname(result.tmpExportPath));
+  return result;
+}
+afterAll(() => {
+  for (const tree of bridgeTestTrees) rmSync(tree, { recursive: true, force: true });
+});
 
 // Agentic-stack-like descriptor with matching import/export, for round-trip.
 const descriptor: YamlBridgeDescriptor = {
@@ -56,7 +71,7 @@ describe("runRoundTrip: passing paths", () => {
       JSON.stringify({ id: "l1", claim: "Always test before merging.", topic: "ci", tags: ["ci"] }),
       JSON.stringify({ id: "l2", claim: "Stack PRs carefully.", topic: "git", tags: ["git", "ops"] }),
     ].join("\n") + "\n");
-    const result = await runRoundTrip({ descriptor, cwd: dir });
+    const result = await roundTrip({ descriptor, cwd: dir });
     expect(result.passed).toBe(true);
     expect(result.expectedCount).toBe(2);
     expect(result.actualCount).toBe(2);
@@ -67,7 +82,7 @@ describe("runRoundTrip: passing paths", () => {
 
   test("empty fixture round-trips trivially", async () => {
     writeFileSync(join(dir, "fixture.jsonl"), "");
-    const result = await runRoundTrip({ descriptor, cwd: dir });
+    const result = await roundTrip({ descriptor, cwd: dir });
     expect(result.passed).toBe(true);
     expect(result.expectedCount).toBe(0);
     expect(result.actualCount).toBe(0);
@@ -87,7 +102,7 @@ describe("runRoundTrip: failing paths", () => {
       export: { targets: [{ path: "out.jsonl", format: "jsonl", map: { content: "$.c" } }] },
     };
     let thrown: any = null;
-    try { await runRoundTrip({ descriptor: d, cwd: dir }); } catch (e) { thrown = e; }
+    try { await roundTrip({ descriptor: d, cwd: dir }); } catch (e) { thrown = e; }
     expect(thrown).toBeInstanceOf(BridgeRuntimeError);
     expect(thrown.detail.field).toBe("import");
   });
@@ -100,7 +115,7 @@ describe("runRoundTrip: failing paths", () => {
       import: { sources: [{ path: "x.jsonl", format: "jsonl", map: { content: "$.c" } }] },
     };
     let thrown: any = null;
-    try { await runRoundTrip({ descriptor: d, cwd: dir }); } catch (e) { thrown = e; }
+    try { await roundTrip({ descriptor: d, cwd: dir }); } catch (e) { thrown = e; }
     expect(thrown).toBeInstanceOf(BridgeRuntimeError);
     expect(thrown.detail.field).toBe("export");
   });
@@ -122,7 +137,7 @@ describe("runRoundTrip: failing paths", () => {
         }],
       },
     };
-    const result = await runRoundTrip({ descriptor: buggy, cwd: dir });
+    const result = await roundTrip({ descriptor: buggy, cwd: dir });
     expect(result.passed).toBe(false);
     expect(result.mismatches.length).toBeGreaterThan(0);
     // The dropped field shows up in mismatches
@@ -142,7 +157,7 @@ describe("runRoundTrip: failing paths", () => {
         }],
       },
     };
-    const result = await runRoundTrip({ descriptor: ephDesc, cwd: dir });
+    const result = await roundTrip({ descriptor: ephDesc, cwd: dir });
     expect(result.passed).toBe(true);
     expect(result.expectedCount).toBe(0);
     expect(result.actualCount).toBe(0);
@@ -152,7 +167,7 @@ describe("runRoundTrip: failing paths", () => {
     const altPath = join(dir, "alt.jsonl");
     writeFileSync(altPath,
       JSON.stringify({ id: "alt-1", claim: "from alt fixture", topic: "misc" }) + "\n");
-    const result = await runRoundTrip({ descriptor, cwd: dir, fixturePath: altPath });
+    const result = await roundTrip({ descriptor, cwd: dir, fixturePath: altPath });
     expect(result.passed).toBe(true);
     expect(result.expectedCount).toBe(1);
   });
@@ -160,7 +175,7 @@ describe("runRoundTrip: failing paths", () => {
   test("tmpExportPath is a readable jsonl of the exported records", async () => {
     writeFileSync(join(dir, "fixture.jsonl"),
       JSON.stringify({ id: "l1", claim: "hi", topic: "t", tags: ["a"] }) + "\n");
-    const result = await runRoundTrip({ descriptor, cwd: dir });
+    const result = await roundTrip({ descriptor, cwd: dir });
     const written = readFileSync(result.tmpExportPath, "utf-8");
     expect(written.trim().split("\n").length).toBe(1);
     const parsed = JSON.parse(written.trim());


### PR DESCRIPTION
Closes #1293

## What

The unit lane leaked `flair-bridge-test-*` temp trees into TMPDIR on every run. Source: `src/bridges/runtime/roundtrip.ts` `runRoundTrip()` mkdtemps one tree per call and leaves it behind by design — its `tmpExportPath` result field is a debugging affordance, and one test reads that file back after the call. The only unit suite reaching it is `test/unit/bridges-runtime-roundtrip.test.ts`, which cleaned its own `flair-roundtrip-*` sandboxes but not the trees `runRoundTrip` created internally.

Fix, mirroring the suite's existing track-and-remove pattern: all `runRoundTrip` calls route through a thin wrapper that records `dirname(result.tmpExportPath)`, and a file-level `afterAll` sweeps the recorded trees (`afterAll` rather than per-test because the "tmpExportPath is a readable jsonl" test reads the export back). The two throwing tests fail descriptor validation before the mkdtemp, so result-tracking covers every tree the suite creates. No product-code changes — `runRoundTrip` keeps its debugging affordance for CLI use.

Note on the issue's "~18 per full run": on this host the full unit lane leaks exactly 6 per run (one per result-producing `runRoundTrip` call); the ~18 was presumably multiple runs' accumulation or a different environment. Either way: 6 → 0 here.

## Verification (all HOME/TMPDIR-isolated, fresh TMPDIR per measurement)

- **Baseline leak on unmodified origin/main (14248fb2), full unit lane:** trees matching `flair-bridge-test-*` in TMPDIR before: **0**; after: **6**.
- **This branch, suite alone:** before: **0**; after: **0** (8 pass / 0 fail).
- **This branch, FULL unit lane:** before: **0**; after: **0** — zero net new.
- **Teardown mutation check (the sweep is what removes them):** with the `afterAll` sweep disabled (`if (false)`), the suite leaves **6** trees; sweep restored, **0**. The 6 matches the baseline count exactly, so the teardown accounts for every tree the suite creates.
- **Full unit lane vs self-measured origin/main baseline:** baseline `4780 pass / 1 fail / 11050 expect() across 250 files`; this branch identical `4780 pass / 1 fail / 11050 expect() across 250 files`. The single fail is the same pre-existing, environment-specific case on unmodified origin/main: `createDataSnapshot > skips a unix domain socket without crashing the snapshot`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
