### PR TITLE
conformance: token-decomposition invariant — the ledger identity is now enforced, closing #1290

### DIFF
--- a/.changelog/unreleased/added-1290-token-decomposition-invariant.md
+++ b/.changelog/unreleased/added-1290-token-decomposition-invariant.md
@@ -1,0 +1,15 @@
+- **Conformance: token-decomposition invariant — the #1270 ledger identity is
+  now enforced** (flair#1290, final step). A new `tokenDecomposition` invariant
+  type in the `/mcp` tool contracts asserts `tokenEstimate ≈ scaffoldTokens +
+  soulTokens + memoryTokens + trustTokens + eventsTokens` on every bootstrap
+  payload the conformance engine checks, bounded on both sides: the gap may not
+  exceed a per-shipped-item structured-overhead tolerance (an uncounted content
+  class — the exact #1270 field gap — overshoots it), and the ledger sum may
+  not exceed `tokenEstimate` beyond per-line rounding (a counter reporting
+  content that never shipped is the same defect mirrored). The identity's terms
+  and tolerance constants live in one place — the bootstrap contract
+  declaration — and the #1270 ledger suite now reads them from there instead of
+  re-declaring its own copy. Runs automatically at every `conform()` site: the
+  connector-conformance suite (default, tight-budget, event-detail, count,
+  trust, and hint fixtures) and the large-store heavy-lane workout. Test- and
+  contract-layer only; no runtime behavior changes.

--- a/resources/mcp-tools.ts
+++ b/resources/mcp-tools.ts
@@ -669,6 +669,67 @@ export interface ToolInvariants {
    */
   budgetCap?: { estimate: string; budget: string; tolerance: number };
   /**
+   * flair#1290 (step 4) — the flair#1270 payload token LEDGER, enforced:
+   *
+   *   result[total] ≈ Σ result[terms]
+   *
+   * (for bootstrap: tokenEstimate ≈ scaffoldTokens + soulTokens + memoryTokens
+   * + trustTokens + eventsTokens — the identity documented at the counters'
+   * definition in resources/MemoryBootstrap.ts's response tail). Every term
+   * must be a NUMBER (the counter convention reports 0, never omits), and the
+   * gap `total - Σ terms` is bounded on BOTH sides:
+   *
+   *   -roundingSlack <= gap <= perItemGap * shippedItems + fixedSlack
+   *
+   * UPPER bound — the ≈ gap on the connector path is the documented #1207
+   * measurement/budgeting decoupling: soulTokens/memoryTokens count rendered
+   * PROSE lines while the containers ship heavier STRUCTURED objects (id, two
+   * ISO timestamps, field keys, JSON escaping). That overhead is per-shipped-
+   * item and bounded, so the tolerance scales with the shipped item count
+   * (`shippedItems` = Σ lengths of `perItemContainers`) instead of pretending
+   * to be a constant. An uncounted content class (the #1270 field gap: trust
+   * blocks charged at admission but absent from the counters) overshoots it.
+   * LOWER bound — Σ-of-ceil per counted line can exceed ceil-of-Σ by at most
+   * one token per line; anything past `roundingSlack` means a counter is
+   * over-reporting (counting content that never shipped) — the same defect
+   * mirrored.
+   *
+   * `proseMirrorArg` names the request arg (bootstrap: includeContext) that
+   * legitimately adds the full prose mirror to the payload BESIDE the
+   * structured containers; when the driven args set it truthy only the lower
+   * bound is asserted (the upper gap widens by the mirror, by design — see
+   * the prose-path test in test/integration/bootstrap-token-ledger-1270
+   * .test.ts). When it is declared, conform() requires the request args —
+   * an unevaluated bound must not look like a pass.
+   *
+   * ONE tolerance definition: these constants were sized empirically in
+   * test/integration/bootstrap-token-ledger-1270.test.ts (measured 2026-08-20,
+   * gap 1144–1199 over 24 shipped items ≈ 48–50 tokens/item → perItemGap 60
+   * leaves ~10/item headroom), and that suite now reads them FROM THIS
+   * declaration rather than re-declaring them. POWER constraint: the
+   * tolerance must stay well below a trust-carrying fixture's trust spend
+   * (≈3400 tokens there) so zeroing one term out of the response tail
+   * overshoots it and goes red — if a payload change moves the gap, re-derive
+   * both numbers from that suite's printed ledger line; don't widen the slack
+   * until the mutation can't bite.
+   */
+  tokenDecomposition?: {
+    /** The reconciling total (bootstrap: "tokenEstimate"). */
+    total: string;
+    /** The ledger counters that must sum to it (each a number on the result). */
+    terms: string[];
+    /** Containers whose SHIPPED item count scales the structured-overhead tolerance. */
+    perItemContainers: string[];
+    /** Bounded per-shipped-item structured-overhead allowance (tokens). */
+    perItemGap: number;
+    /** Fixed allowance for the scaffold-adjacent remainder (tokens). */
+    fixedSlack: number;
+    /** Per-line ceil-rounding allowance below zero (tokens). */
+    roundingSlack: number;
+    /** Request arg that legitimately widens the gap (prose mirror): when truthy, only the lower bound runs. */
+    proseMirrorArg?: string;
+  };
+  /**
    * Count coherence (flair#1207): for each triple, `included + truncated <=
    * available`. 0.44.9 reported available:3 included:2 truncated:2 (2+2 > 3)
    * because a memory budget-skipped in one section was re-counted in the
@@ -1109,6 +1170,21 @@ export const TOOLS: Record<string, ToolEntry> = {
         // tolerance covers the fixed JSON scaffolding + the #1207 prose-vs-
         // structured charge gap; uncounted content does not fit under it.
         budgetCap: { estimate: "tokenEstimate", budget: "maxTokens", tolerance: 0.25 },
+        // flair#1290 step 4 — the #1270 token-ledger identity, enforced:
+        // tokenEstimate ≈ scaffold + soul + memory + trust + events, two-sided
+        // (constants sized in bootstrap-token-ledger-1270.test.ts, which reads
+        // them from HERE — one identity, one tolerance definition). The upper
+        // bound is waived when the request opted into the prose mirror
+        // (includeContext), which legitimately widens the gap by design.
+        tokenDecomposition: {
+          total: "tokenEstimate",
+          terms: ["scaffoldTokens", "soulTokens", "memoryTokens", "trustTokens", "eventsTokens"],
+          perItemContainers: ["memories", "predicted", "teammateFindings"],
+          perItemGap: 60,
+          fixedSlack: 150,
+          roundingSlack: 48,
+          proseMirrorArg: "includeContext",
+        },
         // #1207 — count arithmetic: included + truncated <= available. The
         // own-memory triple CAN fail: memoriesAvailable comes from an
         // independent count query, so a double-counted memory breaks it.

--- a/test/helpers/mcp-conformance.ts
+++ b/test/helpers/mcp-conformance.ts
@@ -162,6 +162,58 @@ export function conform(toolName: string, result: any, contract: ToolContract, o
     ).toBe(true);
   }
 
+  // flair#1290 step 4 — the #1270 token-ledger identity, enforced at every
+  // conform() site: total ≈ Σ terms, bounded on both sides. Constants and
+  // reasoning live in the contract declaration (ToolInvariants.tokenDecomposition,
+  // resources/mcp-tools.ts) — one identity, one tolerance definition; the
+  // ledger suite (bootstrap-token-ledger-1270.test.ts) reads the same ones.
+  if (inv.tokenDecomposition) {
+    const d = inv.tokenDecomposition;
+    const total = result?.[d.total];
+    expect(typeof total, `${toolName}: ${d.total} must be a number for tokenDecomposition`).toBe("number");
+    let termSum = 0;
+    for (const term of d.terms) {
+      const v = result?.[term];
+      expect(
+        typeof v,
+        `${toolName}: ledger term '${term}' must be a number — the counter convention reports 0, never omits (#1270)`,
+      ).toBe("number");
+      termSum += v;
+    }
+    const gap = total - termSum;
+    const decomposed = d.terms.map((t) => `${t}=${result?.[t]}`).join(" + ");
+    // Lower bound always: a counter reporting content that never shipped runs
+    // the sum ABOVE the total past per-line ceil rounding.
+    expect(
+      gap >= -d.roundingSlack,
+      `${toolName}: ledger sum exceeds ${d.total} beyond rounding — ${d.total}(${total}) - (${decomposed}) = ${gap} must be >= -${d.roundingSlack}; a counter is over-reporting (#1270 mirrored)`,
+    ).toBe(true);
+    // Upper bound: waived only when the request opted into the prose mirror,
+    // which legitimately widens the gap by the full prose context. When the
+    // contract declares that arg, the driven args are REQUIRED — an
+    // unevaluated bound must not look like a pass.
+    if (d.proseMirrorArg !== undefined) {
+      expect(
+        opts.args !== undefined,
+        `${toolName}: tokenDecomposition declares proseMirrorArg '${d.proseMirrorArg}' — pass the request args to conform() (an unevaluated check must not look like a pass)`,
+      ).toBe(true);
+    }
+    const proseMirrorOn = d.proseMirrorArg !== undefined && Boolean(opts.args![d.proseMirrorArg]);
+    if (!proseMirrorOn) {
+      let shippedItems = 0;
+      for (const c of d.perItemContainers) {
+        const arr = getPath(result, c);
+        expect(Array.isArray(arr), `${toolName}: tokenDecomposition per-item container '${c}' must be an array`).toBe(true);
+        shippedItems += arr.length;
+      }
+      const tolerance = d.perItemGap * shippedItems + d.fixedSlack;
+      expect(
+        gap <= tolerance,
+        `${toolName}: token-ledger identity broke — ${d.total}(${total}) - (${decomposed}) = ${gap} must be <= ${tolerance} (${d.perItemGap}/item × ${shippedItems} shipped items + ${d.fixedSlack} fixed): an uncounted content class reopens exactly the #1270 field gap`,
+      ).toBe(true);
+    }
+  }
+
   for (const { included, truncated, available } of inv.countCoherence ?? []) {
     const inc = result?.[included];
     const tru = result?.[truncated];

--- a/test/integration/bootstrap-token-ledger-1270.test.ts
+++ b/test/integration/bootstrap-token-ledger-1270.test.ts
@@ -50,6 +50,15 @@ import { startHarper, stopHarper, HarperInstance } from "../helpers/harper-lifec
 // The same estimator the handler budgets and reports with (single source,
 // harper-free) — reconstruction must be same-estimator or it proves nothing.
 import { estimateTokens } from "../../resources/token-estimate";
+// flair#1290 step 4 — the reconciliation identity is now a conform()-enforced
+// contract invariant, and ITS declaration (the bootstrap contract's
+// `invariants.tokenDecomposition`, resources/mcp-tools.ts) is the single home
+// of the identity's terms and tolerance constants. This suite reads them from
+// there: one identity, one tolerance definition — a re-declared copy here
+// would be exactly the two-definitions drift the invariant exists to prevent.
+import { TOOLS } from "../../resources/mcp-tools";
+
+const LEDGER = TOOLS.bootstrap.contract.invariants!.tokenDecomposition!;
 
 const REPO_ROOT = process.cwd();
 const FIXTURE = join(REPO_ROOT, "test", "fixtures", "inproc-app");
@@ -133,10 +142,11 @@ function reconstructScaffold(body: Record<string, any>): number {
   return estimateTokens(JSON.stringify(skeleton));
 }
 
-/** The reconciliation gap: tokenEstimate minus the five-term ledger sum. */
+/** The reconciliation gap: the contract's total minus its declared term sum
+ *  (tokenEstimate minus the five ledger counters — read from the SAME
+ *  tokenDecomposition declaration conform() enforces). */
 function ledgerGap(body: Record<string, any>): number {
-  return body.tokenEstimate
-    - (body.scaffoldTokens + body.soulTokens + body.memoryTokens + body.trustTokens + body.eventsTokens);
+  return body[LEDGER.total] - LEDGER.terms.reduce((sum, t) => sum + body[t], 0);
 }
 
 // ~40-day backdate for the ops-seeded own permanents: keeps them out of the
@@ -195,7 +205,7 @@ const BUDGET_TOLERANCE = 0.25;
 // Sizing (measured 2026-08-20, three consecutive runs of this fixture — the
 // [1270-ledger] line below prints the live figures: est 6064–6240, memory
 // 1222, trust 3336–3457, events 186, scaffold 156 → gap 1144–1199 over a
-// stable 24 shipped items ≈ 48–50 tokens/item): STRUCT_ITEM_GAP=60 leaves
+// stable 24 shipped items ≈ 48–50 tokens/item): perItemGap=60 leaves
 // ~10 tokens/item headroom. POWER constraint: the tolerance (1590 on the
 // measured payloads) must stay well below the fixture's trust spend
 // (trustTokens ≈ 3400) so the mutation check — zero trustTokens out of the
@@ -203,17 +213,20 @@ const BUDGET_TOLERANCE = 0.25;
 // fails. If a payload change moves the gap, re-derive both numbers from the
 // printed ledger line; don't just widen the slack until the mutation can't
 // bite.
-const STRUCT_ITEM_GAP = 60;
-const FIXED_SLACK = 150;
-// Σ-of-ceil per counted line can exceed ceil-of-Σ by at most one token per
-// line; the sum may therefore sit a hair ABOVE tokenEstimate. Anything past
-// this slack means a counter is over-reporting (counting content that never
-// shipped) — the opposite defect, equally a red.
-const ROUNDING_SLACK = 48;
+//
+// flair#1290 step 4: the constants LIVE in the bootstrap contract's
+// tokenDecomposition declaration (resources/mcp-tools.ts) — the invariant
+// conform() now enforces at every conformance site — and are read from there
+// (LEDGER above). perItemGap/fixedSlack bound the gap above; roundingSlack
+// bounds it below (Σ-of-ceil per counted line can exceed ceil-of-Σ by at most
+// one token per line — anything past it means a counter is over-reporting
+// content that never shipped, the opposite defect, equally a red).
+const STRUCT_ITEM_GAP = LEDGER.perItemGap;
+const ROUNDING_SLACK = LEDGER.roundingSlack;
 
 function ledgerTolerance(body: Record<string, any>): number {
-  const shippedItems = body.memories.length + body.predicted.length + body.teammateFindings.length;
-  return STRUCT_ITEM_GAP * shippedItems + FIXED_SLACK;
+  const shippedItems = LEDGER.perItemContainers.reduce((sum, c) => sum + body[c].length, 0);
+  return LEDGER.perItemGap * shippedItems + LEDGER.fixedSlack;
 }
 
 describe("flair#1270 — bootstrap payload token ledger (trustTokens/eventsTokens/scaffoldTokens reconcile tokenEstimate)", () => {

--- a/test/integration/mcp-connector-conformance-suite.test.ts
+++ b/test/integration/mcp-connector-conformance-suite.test.ts
@@ -35,6 +35,14 @@
 //   #1207  memoriesIncluded + memoriesTruncated exceeded memoriesAvailable
 //          (a memory counted in two sections; a predicted memory re-admitted)
 //          → the countCoherence invariant goes red once the count fix is reverted.
+//   #1270  trust blocks were charged at admission but ABSENT from the reported
+//          counters — a ~1178-token gap the payload's figures couldn't explain
+//          → the tokenDecomposition invariant (tokenEstimate ≈ scaffoldTokens +
+//            soulTokens + memoryTokens + trustTokens + eventsTokens, bounded on
+//            both sides) goes red at every bootstrap conform() site whose payload
+//            carries the zeroed/uncounted class (flair#1290 step 4; the terms and
+//            tolerance constants live in the contract declaration, shared with
+//            bootstrap-token-ledger-1270.test.ts — one identity, one definition).
 //
 // The completeness check (checkContractCompleteness) is CI-gated in THIS lane:
 // a new /mcp tool shipped without a contract fails the build, fail-closed.
@@ -378,6 +386,12 @@ describe("/mcp connector conformance — each tool honors its declared contract"
     expect(summaries.filter((s: string) => s === DUP_SUMMARY).length, "the byte-identical duplicate pair must collapse to ONE (#1200)").toBe(1);
     // memoriesIncluded spans memories+predicted, and there IS own content.
     expect(body.memories.length, "own memories delivered").toBeGreaterThan(0);
+    // flair#1290 step 4 — positive controls for the tokenDecomposition
+    // invariant (it ran inside conform() above): the events and memory terms
+    // genuinely participate on this payload, so a zeroed or uncounted term has
+    // something to lose HERE — the identity check is not vacuously green.
+    expect(body.eventsTokens, "eventsTokens term participates (events shipped)").toBeGreaterThan(0);
+    expect(body.memoryTokens, "memoryTokens term participates (memories shipped)").toBeGreaterThan(0);
   }, 120_000);
 
   test("bootstrap: events respect maxTokens and zero-row heals are suppressed (#1199/#1200 — budgetCap bites on revert)", async () => {
@@ -457,6 +471,11 @@ describe("/mcp connector conformance — each tool honors its declared contract"
     for (const t of trustBody.trust) {
       expect(deliveredIds.has(t.id), `trust entry ${t.id} must correlate to a delivered memory`).toBe(true);
     }
+    // flair#1290 step 4 — the trust TERM of the token-ledger identity genuinely
+    // participates at this conform() site (the invariant ran above with
+    // trustTokens in the sum): a trust-term desync can bite here, not only in
+    // the dedicated ledger suite.
+    expect(trustBody.trustTokens, "trustTokens term participates on the trust path").toBeGreaterThan(0);
     // Same count arithmetic holds under trust admission.
     expect(
       trustBody.memoriesIncluded + trustBody.memoriesTruncated,


### PR DESCRIPTION
Final step of the #1290 powered-invariants plan (step 4, sequenced behind #1297's ledger fields and #1299's conformance framework, both on main): the #1270 token-ledger identity is now an enforced contract invariant, not a single dedicated test.

## What

**New `tokenDecomposition` invariant type** (`ToolInvariants`, `resources/mcp-tools.ts`), implemented in the shared conformance engine (`test/helpers/mcp-conformance.ts`) and declared on the bootstrap contract:

```
tokenEstimate ≈ scaffoldTokens + soulTokens + memoryTokens + trustTokens + eventsTokens
```

bounded on **both** sides:

- **Upper**: `gap ≤ perItemGap(60) × shippedItems + fixedSlack(150)` — the documented #1207 prose-vs-structured charge gap is per-shipped-item (`memories` + `predicted` + `teammateFindings`), so the tolerance scales with item count. An uncounted content class — the exact field gap that motivated #1270 — overshoots it.
- **Lower**: `gap ≥ −roundingSlack(48)` — a counter reporting content that never shipped is the same defect mirrored.
- Every term must be a **number** (the counter convention reports 0, never omits).
- The upper bound is waived only when the request opted into the prose mirror (`includeContext`), which legitimately widens the gap by the full prose context; when the contract declares that arg, `conform()` **requires** the driven args instead of silently skipping the bound (an unrun check must not look like a pass).

**One identity, one tolerance definition.** The constants are the ones `bootstrap-token-ledger-1270.test.ts` (#1297) sized empirically, and they now live in a single place — the contract declaration. The ledger suite reads `perItemGap`/`fixedSlack`/`roundingSlack` and the term list *from the contract* instead of re-declaring its own copy, so the two assertions can never drift apart.

**Coverage**: the invariant runs automatically at all seven bootstrap `conform()` sites in the connector-conformance suite (default, tight-budget, event-detail, count, trust-path, and both hint fixtures) and at the heavy-lane large-store workout through the shared helper (617 expect() calls vs 605 before — exactly the invariant's 12 checks). Positive-control pins added where terms must participate: `eventsTokens`/`memoryTokens > 0` at the default site, `trustTokens > 0` at the trust site — a term that silently stops participating now fails even where the payload is small enough for the slack to absorb it.

## Powered check (each mutation applied to the response tail, run, then restored)

Per-site figures from an instrumented run (site → baseline gap / tolerance):
default 245/390 · budget 265/390 · detail 260/390 · count 100/210 · trust 100/210 · hint-a 47/150 · hint-b(no events) 47/150 · large-store 1355/1650.

**Mutation A — `eventsTokens: 0`:**

| conform() site | events spend | result |
|---|---|---|
| default (3 events) | 158 | **RED** (gap 404 > 390) |
| tight-budget (10 events) | 683 | **RED** (gap 948 > 390) |
| event-detail (10 events, detail) | 2243 | not reached (same test aborts at the tight-budget red; 260+2243 ≫ 390 from the measured baseline) |
| count / trust (2 lean events) | 99 | green by 11 — the 2-event spend sits under the fixed slack |
| hint-a (2 lean events) | 99 | green by 4 — same |
| hint-b (`maxEvents:0`) | 0 | green (carries no events — correctly unaffected) |
| large-store (heavy lane) | 0 | green (fixture seeds no OrgEvents — correctly unaffected) |

**Mutation B — `memoryTokens: 0`:** count site **RED** (gap 1641 > 210), heavy lane **RED** (gap 3005 > 1650); default site **RED** via the new participation pin (memoryTokens=0 while memories shipped). Demonstrates the sites Mutation A's small spend couldn't reach.

**Mutation C — `scaffoldTokens: 0`:** all four suite test blocks **RED** (439>390, 462>390, 296>210, 354>150) — including the hint fixtures, whose only material term is the scaffold.

Restore → 20/20 conformance, 3/3 ledger, 1/1 heavy, all green. The honest summary: any term zeroing whose spend exceeds the site's slack headroom goes red; sub-slack spends (a 2-lean-event container) are inside the tolerance's documented design and are covered by the participation pins instead.

## Validation

- `tsc --noEmit` on `tsconfig.check.json`, `tsconfig.check.src.json`, `tsconfig.test.check.json` — all clean.
- Full unit suite: 4644 pass / 6 fail / 2 errors — **byte-identical failure set to the self-measured origin/main baseline** (pre-existing, local-env: memory-search-scope mock ordering ×4, two embeddings-provider export mismatches).
- `mcp-connector-conformance-suite`: 20 pass (2067 expects; 1980 at baseline — 12×7 sites + 3 pins).
- `bootstrap-token-ledger-1270`: 3 pass, contract-sourced constants (live ledger line: est=6064 scaffold=156 soul=20 memory=1222 trust=3336 events=186 gap=1144 tol=1590).
- `bootstrap-large-store-conformance` (heavy lane, run locally): 1 pass, 617 expects, 5.7s seed.

Test- and contract-layer only; no runtime behavior changes. Changelog fragment included.

Closes #1290.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
