### PR TITLE
plugin: unpin @tpsdev-ai/flair-mcp in public mcp.json + CI drift check

### DIFF
--- a/.changelog/unreleased/changed-1307-unpin-plugin-mcp.md
+++ b/.changelog/unreleased/changed-1307-unpin-plugin-mcp.md
@@ -1,0 +1,5 @@
+- **Public plugin `mcp.json` no longer pins `@tpsdev-ai/flair-mcp`.**
+  `packages/cursor-flair/mcp.json` now uses unpinned `npx -y @tpsdev-ai/flair-mcp`,
+  so directory listings resolve latest instead of rotting at a stale version
+  (the listing had 0.44.13 while npm latest was 0.46.0). CI fails if a public
+  plugin `mcp.json` re-pins a version or dist-tag. (#1307)

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -79,6 +79,11 @@ jobs:
         # while the author still has the context — rather than at a release
         # weeks later, after the release branch and PR already exist.
         run: node scripts/check-version-sync.mjs
+      - name: "Check public plugin mcp.json does not pin flair-mcp"
+        # Directory listings scrape packages/*/mcp.json. A version or
+        # dist-tag pin here rots the listing (flair#1307: 0.44.13 while
+        # npm latest was 0.46.0). Unpinning is the policy.
+        run: node scripts/check-plugin-mcp-unpinned.mjs
       - name: "Check production dep bake time (≥7 days)"
         # Supply-chain bake-time guard. Fails if any external pinned production
         # dep was published <7 days ago — catches the "compromise published,

--- a/packages/cursor-flair/mcp.json
+++ b/packages/cursor-flair/mcp.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "flair": {
       "command": "npx",
-      "args": ["-y", "@tpsdev-ai/flair-mcp@0.44.13"],
+      "args": ["-y", "@tpsdev-ai/flair-mcp"],
       "env": {
         "FLAIR_AGENT_ID": "${FLAIR_AGENT_ID}",
         "FLAIR_URL": "${FLAIR_URL}",

--- a/scripts/check-plugin-mcp-unpinned.mjs
+++ b/scripts/check-plugin-mcp-unpinned.mjs
@@ -1,0 +1,110 @@
+#!/usr/bin/env node
+/**
+ * check-plugin-mcp-unpinned.mjs — public plugin mcp.json must not pin
+ * `@tpsdev-ai/flair-mcp` to a version or npm dist-tag.
+ *
+ * Why: directory listings scrape packages/cursor-flair/mcp.json. A pin
+ * like `@tpsdev-ai/flair-mcp@0.44.13` froze that listing while npm latest
+ * moved on (0.46.0). Public plugin manifests must stay unpinned
+ * (`npx -y @tpsdev-ai/flair-mcp`) so a listing refresh always resolves
+ * latest. flair#1307.
+ *
+ * User-local `flair init` wiring and docs/examples are a different
+ * surface and are not scanned here.
+ *
+ * Discovery, not inventory: every tracked mcp.json / .mcp.json under
+ * packages/ is scanned, so a future Claude Code / Grok / OpenClaw
+ * plugin manifest is covered the PR that adds it. Zero matches is a
+ * failure — this check must not pass silently.
+ *
+ * Usage:
+ *   node scripts/check-plugin-mcp-unpinned.mjs
+ *
+ * Exit codes:
+ *   0 — every public plugin mcp.json is unpinned (and at least one was found)
+ *   1 — a pin was found, or the check could not run
+ */
+
+import { readFileSync } from "node:fs";
+import { basename, dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { execFileSync } from "node:child_process";
+
+const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), "..");
+
+/** `@` after the package name is the pin — version *or* dist-tag (`latest`, `next`). */
+const PIN = "@tpsdev-ai/flair-mcp@";
+
+function isPluginMcpJson(path) {
+  if (!path.startsWith("packages/")) return false;
+  const name = basename(path);
+  return name === "mcp.json" || name === ".mcp.json";
+}
+
+function trackedFiles() {
+  let out;
+  try {
+    out = execFileSync("git", ["-C", REPO_ROOT, "ls-files", "-z"], {
+      encoding: "utf8",
+      maxBuffer: 64 * 1024 * 1024,
+    });
+  } catch (err) {
+    console.error(`❌ Could not list tracked files (git ls-files failed: ${err.message.trim()}).`);
+    console.error("   The plugin mcp.json pin scan cannot run, and must not pass silently.");
+    process.exit(1);
+  }
+  return out.split("\0").filter(Boolean);
+}
+
+function pinnedSpec(text) {
+  const idx = text.indexOf(PIN);
+  if (idx === -1) return null;
+  const rest = text.slice(idx);
+  const m = rest.match(/@tpsdev-ai\/flair-mcp@[^\s"'\\]+/);
+  return m ? m[0] : PIN;
+}
+
+const files = trackedFiles();
+if (files.length === 0) {
+  console.error("❌ git ls-files returned nothing — this check cannot run, and must not pass silently.");
+  process.exit(1);
+}
+
+const targets = files.filter(isPluginMcpJson);
+if (targets.length === 0) {
+  console.error("❌ No packages/**/mcp.json (or .mcp.json) files found.");
+  console.error("   A public plugin manifest is expected (packages/cursor-flair/mcp.json).");
+  console.error("   This check must not pass silently.");
+  process.exit(1);
+}
+
+const violations = [];
+for (const path of targets) {
+  let text;
+  try {
+    text = readFileSync(join(REPO_ROOT, path), "utf8");
+  } catch (err) {
+    console.error(`❌ Could not read ${path}: ${err.message}`);
+    process.exit(1);
+  }
+  const spec = pinnedSpec(text);
+  if (spec) violations.push({ path, spec });
+}
+
+if (violations.length > 0) {
+  console.error("");
+  console.error("❌ Public plugin mcp.json pins @tpsdev-ai/flair-mcp (flair#1307):");
+  console.error("");
+  for (const v of violations) {
+    console.error(`  ${v.path}: ${v.spec}`);
+  }
+  console.error("");
+  console.error("Public plugin configs must use unpinned `npx -y @tpsdev-ai/flair-mcp`");
+  console.error("so directory listings do not rot. Unpinning is the policy; do not bump the pin.");
+  process.exit(1);
+}
+
+console.log(`✓ ${targets.length} public plugin mcp.json file(s) use unpinned @tpsdev-ai/flair-mcp`);
+for (const path of targets) {
+  console.log(`  ${path}`);
+}

--- a/test/unit/plugin-mcp-unpinned.test.ts
+++ b/test/unit/plugin-mcp-unpinned.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, test } from "bun:test";
+import { readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+/**
+ * Public plugin mcp.json files are what directory listings scrape.
+ * A version or dist-tag pin (`@tpsdev-ai/flair-mcp@0.44.13`) rots the
+ * listing while npm latest moves on. Unpinning is the policy (flair#1307).
+ *
+ * The CI gate is scripts/check-plugin-mcp-unpinned.mjs. These tests pin
+ * the cursor-flair env contract and prove the pin detector would have
+ * caught the 0.44.13 drift.
+ */
+const PACKAGES = join(import.meta.dir, "../../packages");
+const PIN = "@tpsdev-ai/flair-mcp@";
+
+function pluginMcpJsonPaths(): string[] {
+  const out: string[] = [];
+  for (const name of readdirSync(PACKAGES)) {
+    for (const file of ["mcp.json", ".mcp.json"]) {
+      try {
+        const p = join(PACKAGES, name, file);
+        readFileSync(p);
+        out.push(p);
+      } catch {
+        // package has no plugin mcp.json
+      }
+    }
+  }
+  return out;
+}
+
+describe("public plugin mcp.json", () => {
+  const paths = pluginMcpJsonPaths();
+
+  test("at least one public plugin mcp.json exists", () => {
+    expect(paths.length).toBeGreaterThan(0);
+  });
+
+  test("does not pin @tpsdev-ai/flair-mcp to a version or dist-tag", () => {
+    for (const p of paths) {
+      const text = readFileSync(p, "utf8");
+      expect(text.includes(PIN), `${p} contains ${PIN}`).toBe(false);
+    }
+  });
+
+  test("cursor-flair keeps the existing env contract and unpinned npx spec", () => {
+    const cfg = JSON.parse(readFileSync(join(PACKAGES, "cursor-flair", "mcp.json"), "utf8"));
+    const flair = cfg.mcpServers.flair;
+    expect(flair.command).toBe("npx");
+    expect(flair.args).toEqual(["-y", "@tpsdev-ai/flair-mcp"]);
+    expect(flair.env).toEqual({
+      FLAIR_AGENT_ID: "${FLAIR_AGENT_ID}",
+      FLAIR_URL: "${FLAIR_URL}",
+      FLAIR_CLIENT: "cursor",
+    });
+  });
+
+  test("the pin detector would have caught @tpsdev-ai/flair-mcp@0.44.13", () => {
+    // Same predicate the CI script uses (indexOf of the `@` pin suffix).
+    expect('["-y", "@tpsdev-ai/flair-mcp@0.44.13"]'.includes(PIN)).toBe(true);
+    expect('["-y", "@tpsdev-ai/flair-mcp@latest"]'.includes(PIN)).toBe(true);
+    expect('["-y", "@tpsdev-ai/flair-mcp"]'.includes(PIN)).toBe(false);
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Public plugin `mcp.json` files no longer pin `@tpsdev-ai/flair-mcp`.

`packages/cursor-flair/mcp.json` was `@tpsdev-ai/flair-mcp@0.44.13` while npm latest is 0.46.0. Directory listings scrape that file, so the pin froze the listing. It now uses unpinned `npx -y @tpsdev-ai/flair-mcp`.

## Scope

Investigated every `@tpsdev-ai/flair-mcp@` occurrence. The only public plugin manifest that pinned a version was `packages/cursor-flair/mcp.json`. There is no Claude Code / Grok / OpenClaw `mcp.json` equivalent in this repo that pins.

Left alone (different surface):

- `flair init` / `mcpServerSpec()` user-local client wiring (still pins to the running CLI version)
- Docs and examples that use the `@<version>` placeholder
- Plugin skills, rules, listing copy, and the variables schema

Env in `mcp.json` is unchanged: `FLAIR_AGENT_ID`, `FLAIR_URL`, `FLAIR_CLIENT=cursor`. No `FLAIR_KEY_PATH` / `FLAIR_ADMIN_*`.

## CI

`scripts/check-plugin-mcp-unpinned.mjs` scans every tracked `mcp.json` / `.mcp.json` under `packages/`. It fails on `@tpsdev-ai/flair-mcp@` (version or dist-tag) and fails if it finds zero files (must not pass silently). Wired into the Unit Tests job next to the other `node scripts/check-*.mjs` gates.

Verified locally:

- Check is green on this tree
- Re-inserting `@tpsdev-ai/flair-mcp@0.44.13` makes the check exit 1
- `bun test test/unit/plugin-mcp-unpinned.test.ts` — 4 pass

Closes #1307.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-554a4203-d3ff-4035-9fdc-92fde734efa5?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-554a4203-d3ff-4035-9fdc-92fde734efa5&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

