### PR TITLE
bootstrap: eventsHint distinguishes budget-truncated from genuinely-empty — the by-design message can no longer mask dropped events

### DIFF
--- a/.changelog/unreleased/fixed-1298-events-truncated-hint.md
+++ b/.changelog/unreleased/fixed-1298-events-truncated-hint.md
@@ -1,0 +1,13 @@
+- **bootstrap: `eventsHint` distinguishes budget-truncated from genuinely-empty**
+  (flair#1298). When org events cleared the lookback window and every relevance
+  filter but none fit the remaining token budget, the empty `events` container
+  claimed "present-but-empty by design, not dropped" — exactly the false
+  reassurance the flair#1182 empty-container hints exist to prevent (the events
+  were dropped; the payload said they weren't). `eventsHint` now mirrors
+  `teammateFindingsHint`'s branches: the budget-truncated case says how many
+  relevant events were admitted-then-skipped and that raising `maxTokens`
+  includes them; the by-design wording is reserved for a genuinely event-less
+  window. The count is of admitted-then-skipped events only — never derived
+  from a gap that could imply withheld rows. Hint emission conditions are
+  unchanged (present exactly when `events` ships empty), so the flair#1290
+  `hintWhenEmpty` conformance invariant holds as declared.

--- a/resources/MemoryBootstrap.ts
+++ b/resources/MemoryBootstrap.ts
@@ -465,6 +465,14 @@ export class BootstrapMemories extends Resource {
     // read below). Declared out here so it is in scope for the response body even
     // if the events read (in a try/catch) yields nothing.
     const includedEvents: any[] = [];
+    // flair#1298 — count of events that ENTERED the admission loop (relevant to
+    // the caller, inside the lookback window, survived dedup + the no-op
+    // filter) but were skipped by the budget gate (`cost > tokenBudget`).
+    // Feeds the budget-truncated branch of eventsHint, mirroring
+    // teammateFindingsTruncated. Deliberately counts ONLY admitted-then-
+    // skipped events — never a gap derived from some larger tally, which
+    // could imply the existence of rows the caller was not allowed to see.
+    let eventsBudgetTruncated = 0;
     const leanMemory = (m: any, section: string) => ({
       id: m.id,
       content: m.content,
@@ -1358,7 +1366,10 @@ export class BootstrapMemories extends Resource {
         // /mcp path; the prose line is a subset of it). This is the #1199 fix:
         // events are content and must be budgeted like content.
         const cost = estimateTokens(JSON.stringify(structured));
-        if (cost > tokenBudget) continue;
+        // flair#1298 — an event that reached admission but does not fit the
+        // remaining budget is TRUNCATED, not irrelevant; count it so eventsHint
+        // can say so instead of claiming "empty by design" (#1182 contract).
+        if (cost > tokenBudget) { eventsBudgetTruncated++; continue; }
         const elapsed = Date.now() - new Date(evt.createdAt).getTime();
         const mins = Math.floor(elapsed / 60_000);
         const relTime = mins < 60 ? `${mins}min ago` : `${Math.floor(mins / 60)}h ago`;
@@ -1583,12 +1594,19 @@ export class BootstrapMemories extends Resource {
     // dropped". Present ONLY when the container is empty (a populated container
     // needs no hint), so a healthy payload is unchanged.
 
-    // events: [] — no org event in the lookback window was relevant to the
-    // caller after zero-row no-op auto-heal filtering (#1200). Present-but-empty
-    // by design, not a drop.
+    // events: [] — name WHICH empty this is (flair#1298, mirroring the
+    // teammateFindingsHint branches below): relevant-but-budget-truncated
+    // (events cleared the lookback window and every relevance filter but none
+    // fit the remaining token budget — saying "by design" there is exactly the
+    // false reassurance the #1182 hint contract forbids), or genuinely no
+    // relevant event in the window after zero-row no-op auto-heal filtering
+    // (#1200) — present-but-empty by design, not a drop.
     const eventsHint = includedEvents.length === 0
-      ? "No org events in the lookback window were relevant to you (org-wide, or targeted at you) "
-        + "after zero-row no-op auto-heal filtering. This container is present-but-empty by design, not dropped."
+      ? (eventsBudgetTruncated > 0
+          ? `No org events fit the token budget: ${eventsBudgetTruncated} relevant event(s) cleared the `
+            + "lookback window but were budget-truncated. Raise maxTokens to include them."
+          : "No org events in the lookback window were relevant to you (org-wide, or targeted at you) "
+            + "after zero-row no-op auto-heal filtering. This container is present-but-empty by design, not dropped.")
       : undefined;
 
     // teammateFindings: [] — name WHICH legitimate empty this is (no task → no

--- a/test/integration/bootstrap-events-truncated-hint-1298.test.ts
+++ b/test/integration/bootstrap-events-truncated-hint-1298.test.ts
@@ -1,0 +1,228 @@
+// flair#1298 — eventsHint must distinguish BUDGET-TRUNCATED from GENUINELY
+// EMPTY on the real REST path.
+//
+// The #1298 investigation started as a REST-vs-/mcp delivery divergence and a
+// CLOSED-transaction-chain theory; the mandatory fails-on-main gate DISPROVED
+// that mechanism (the REST path delivers events fine — see the issue's respec
+// comment). What survives instrumentation is a genuine #1182 hint-contract
+// violation: when seeded, relevant org events clear the lookback window and
+// every relevance filter but NONE fit the remaining token budget (the #1199
+// admission gate `cost > tokenBudget`), the events container ships empty and
+// eventsHint claims "present-but-empty BY DESIGN, not dropped" — exactly the
+// false reassurance the #1182 empty-container hints exist to prevent. The
+// events were dropped; the payload says they weren't. teammateFindingsHint
+// already has an explicit budget-truncated branch; eventsHint did not.
+//
+// What this suite pins, over the REAL Ed25519-signed REST path (the
+// bootstrap-trust-budget-conformance driver — NOT the inproc /mcp wrapper,
+// because the original false reassurance was observed over REST):
+//
+//   1. Genuinely-no-events control (runs FIRST, before any event is seeded —
+//      bun executes tests in declaration order): the by-design branch is
+//      unchanged behavior.
+//   2. THE positive control (fails on unmodified main): seeded relevant
+//      events + a tight maxTokens that zero-admits them → events:[] must
+//      carry the TRUNCATED hint (with the admitted-then-skipped count), and
+//      the "by design" wording must be ABSENT. On main this test goes red
+//      because the by-design wording fires on the truncated case.
+//   3. Generous-budget control: the same seed delivers all events and no
+//      eventsHint ships beside the populated container (#1290
+//      populated-or-hint, absent direction).
+//
+// The truncated count is of ADMITTED-THEN-SKIPPED events ONLY (events that
+// entered the admission loop for THIS caller and failed only the budget gate)
+// — never a gap derived from a larger tally, which could imply the existence
+// of rows the caller was not allowed to see (Sherlock ruling on the respec).
+//
+// TIGHT_MAX_TOKENS derivation (recorded per the respec): the #1298 walk-back
+// demonstrated maxTokens=1500 zero-admits with ITS trust-heavy seed; against
+// THIS fixture (20 permanents + includeTrust:true + three ~370-char event
+// summaries, each ~122 tokens serialized) the value was RE-DERIVED by an
+// empirical sweep (one Harper, eleven budgets — probe log quoted in the PR):
+//   800→2 events, 900→0, 1000→1, 1100→0, 1200→0, 1300→1, 1400→0, 1500→1,
+//   1600→1, 2000→0, 16000→3
+// — the same non-monotonic shape the walk-back reported (more budget admits
+// more MEMORIES first, which changes the residual left for events). 1100 is
+// chosen because it has the widest margin of the zero-admit values: at 1100
+// the admitted-memory set matches 1200's (memoriesIncluded=4) and 1200 still
+// zero-admits, so the 1100 residual is < 22 tokens against a ~122-token
+// cheapest event — over 100 tokens of drift needed to flip it (1200's own
+// margin is < 22). The `events.length === 0` precondition assertion below is
+// the guard: if drift in upstream admission ever lets an event slip in at
+// this budget, the test fails THERE with a re-derive message rather than
+// silently testing the wrong branch.
+//
+// Pattern: test/integration/bootstrap-trust-budget-conformance.test.ts
+// (Ed25519 signing, signed PUT seed, REST bootstrap driver) +
+// bootstrap-token-ledger-1270.test.ts (ops-API OrgEvent seed shape from the
+// issue: kind "status", scope "org", no targetIds, non-caller author,
+// distinct summaries inside the 24h lookback).
+import { describe, expect, test, beforeAll, afterAll } from "bun:test";
+import nacl from "tweetnacl";
+import { randomUUID } from "node:crypto";
+import { startHarper, stopHarper, HarperInstance } from "../helpers/harper-lifecycle";
+
+interface TestAgent { id: string; publicKey: string; secretKey: Uint8Array; }
+
+function mkAgent(id: string): TestAgent {
+  const kp = nacl.sign.keyPair();
+  return { id, publicKey: Buffer.from(kp.publicKey).toString("base64"), secretKey: kp.secretKey };
+}
+
+function ed25519Header(agent: TestAgent, method: string, path: string): string {
+  const ts = Date.now().toString();
+  const nonce = randomUUID();
+  const payload = `${agent.id}:${ts}:${nonce}:${method}:${path}`;
+  const sig = nacl.sign.detached(new TextEncoder().encode(payload), agent.secretKey);
+  return `TPS-Ed25519 ${agent.id}:${ts}:${nonce}:${Buffer.from(sig).toString("base64")}`;
+}
+
+async function adminOp(harper: HarperInstance, op: Record<string, any>): Promise<Response> {
+  return fetch(harper.opsURL, {
+    method: "POST",
+    headers: { "Content-Type": "application/json", Authorization: "Basic " + btoa(`${harper.admin.username}:${harper.admin.password}`) },
+    body: JSON.stringify(op),
+  });
+}
+
+async function registerAgent(harper: HarperInstance, agent: TestAgent): Promise<void> {
+  const res = await adminOp(harper, {
+    operation: "insert", database: "flair", table: "Agent",
+    records: [{ id: agent.id, name: agent.id, role: "agent", publicKey: agent.publicKey, createdAt: new Date().toISOString() }],
+  });
+  expect(res.status, `Agent insert for ${agent.id} returned ${res.status}`).toBe(200);
+}
+
+async function putMemory(harper: HarperInstance, agent: TestAgent, id: string, body: Record<string, any>): Promise<void> {
+  const path = `/Memory/${id}`;
+  const res = await fetch(`${harper.httpURL}${path}`, {
+    method: "PUT",
+    headers: { Authorization: ed25519Header(agent, "PUT", path), "Content-Type": "application/json" },
+    body: JSON.stringify({ id, ...body }),
+  });
+  if (![200, 204].includes(res.status)) {
+    throw new Error(`seed PUT ${id} → ${res.status}: ${await res.text()}`);
+  }
+}
+
+/** The REAL REST path: Ed25519-signed POST /BootstrapMemories. */
+async function bootstrap(harper: HarperInstance, agent: TestAgent, body: Record<string, any>): Promise<any> {
+  const path = "/BootstrapMemories";
+  const res = await fetch(`${harper.httpURL}${path}`, {
+    method: "POST",
+    headers: { Authorization: ed25519Header(agent, "POST", path), "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  const text = await res.text();
+  expect(res.status, `BootstrapMemories → ${res.status}: ${text.slice(0, 500)}`).toBe(200);
+  return JSON.parse(text);
+}
+
+let harper: HarperInstance;
+const sfx = Date.now().toString(36);
+const agent = mkAgent(`t1298-${sfx}-${randomUUID().slice(0, 8)}`);
+
+// Trust-heavy own seed (the walk-back's reproduction shape): permanents always
+// render, so at a tight budget they deterministically consume it before the
+// events section (events are admitted LAST) — no currentTask / embedding
+// ranking involved. Distinct content so the Memory dedup co-gate never
+// conflates them.
+const SEED_COUNT = 20;
+const SEED_CONTENT = Array.from({ length: SEED_COUNT }, (_, i) =>
+  `flair-1298 marker: standing rule number ${i + 1} — before finalizing any vendor agreement, always verify the ${["indemnification cap", "termination notice window", "data-residency clause", "price-escalation cap", "SLA credit floor"][i % 5]} against the current legal playbook revision.`);
+
+// The issue's OrgEvent shape: kind "status", scope "org", no targetIds,
+// authorId ≠ caller, createdAt inside the 24h lookback, distinct summaries
+// (no dedup collapse), kind not "migration" (the #1200 no-op filter cannot
+// fire). Summaries are deliberately long (~122 tokens serialized per event,
+// measured by the sweep) so no residual sliver of budget can admit one —
+// widens the zero-admit margin the tight case depends on.
+const EVENT_COUNT = 3;
+const eventSummary = (i: number) =>
+  `flair-1298 truncation fixture event ${i} (${sfx}) — renegotiation preparation milestone ${i} reached; ` +
+  "the vendor working group circulated the revised indemnification and data-residency riders for counsel review, " +
+  "flagged two open escalation-cap questions for the next sync, and confirmed the SLA credit floor language is " +
+  "settled pending final signature from the procurement lead.";
+
+// Derived by the empirical sweep documented above (probe log in the PR).
+const TIGHT_MAX_TOKENS = 1100;
+const GENEROUS_MAX_TOKENS = 16000;
+
+describe("flair#1298 — eventsHint: budget-truncated vs genuinely-empty on the REST path", () => {
+  beforeAll(async () => {
+    harper = await startHarper();
+    await registerAgent(harper, agent);
+    for (let i = 0; i < SEED_COUNT; i++) {
+      await putMemory(harper, agent, `${agent.id}-perm-${i}`, {
+        agentId: agent.id, content: SEED_CONTENT[i], durability: "permanent",
+        createdAt: new Date(Date.now() - 40 * 24 * 3600_000).toISOString(),
+      });
+    }
+  }, 300_000);
+
+  afterAll(async () => { if (harper) await stopHarper(harper); });
+
+  // ── 1. Genuinely no events (runs BEFORE the event seed below — bun runs
+  //       tests in declaration order) → the by-design branch, unchanged. ──
+  test("no org events in the window → the by-design branch fires (unchanged behavior)", async () => {
+    const body = await bootstrap(harper, agent, {
+      agentId: agent.id, maxTokens: GENEROUS_MAX_TOKENS, includeTrust: true, includeContext: false,
+    });
+    expect(body.events.length, "no events seeded yet — container genuinely empty (boot migrations are 0-row no-ops, filtered by #1200)").toBe(0);
+    expect(typeof body.eventsHint, "empty events → eventsHint ships (#1182)").toBe("string");
+    expect(body.eventsHint, "genuinely-empty case keeps the by-design wording").toContain("present-but-empty by design, not dropped");
+    expect(body.eventsHint, "genuinely-empty case must NOT claim truncation").not.toContain("budget-truncated");
+  }, 60_000);
+
+  // ── 2. THE positive control (RED on unmodified main): relevant events
+  //       zero-admitted by a tight budget must be reported as TRUNCATED,
+  //       never as empty-by-design. ──
+  test("seeded events zero-admitted by a tight budget → TRUNCATED hint with the admitted-then-skipped count; the by-design wording is ABSENT", async () => {
+    for (let i = 0; i < EVENT_COUNT; i++) {
+      const res = await adminOp(harper, {
+        operation: "insert", database: "flair", table: "OrgEvent",
+        records: [{
+          id: `t1298-ev-${i}-${sfx}`, authorId: `t1298-author-${sfx}`, kind: "status",
+          summary: eventSummary(i), scope: "org",
+          createdAt: new Date(Date.now() - i * 1000).toISOString(),
+        }],
+      });
+      expect(res.status, `OrgEvent seed ${i} → ${res.status}`).toBe(200);
+    }
+
+    const body = await bootstrap(harper, agent, {
+      agentId: agent.id, maxTokens: TIGHT_MAX_TOKENS, includeTrust: true, includeContext: false,
+    });
+
+    // Precondition guard on the empirically-derived tight value: the truncated
+    // branch is only under test if the budget really zero-admitted the events.
+    // If this fires, upstream admission changed — re-derive TIGHT_MAX_TOKENS
+    // (probe descending values until events:[]), don't weaken the assertions.
+    expect(body.events.length,
+      `TIGHT_MAX_TOKENS=${TIGHT_MAX_TOKENS} no longer zero-admits (events.length=${body.events.length}) — re-derive the tight value`,
+    ).toBe(0);
+
+    // The #1298 contract: truncated, said plainly, with the count.
+    expect(typeof body.eventsHint, "empty events → eventsHint ships (#1182)").toBe("string");
+    expect(body.eventsHint, "the hint must name the truncation").toContain("budget-truncated");
+    expect(body.eventsHint, "the count is the admitted-then-skipped tally — all three seeded events").toContain(`${EVENT_COUNT} relevant event(s)`);
+    expect(body.eventsHint, "the remedy is actionable (#1182: hints teach the knob)").toContain("Raise maxTokens");
+    // The false reassurance this issue exists to remove: on unmodified main
+    // this assertion is the one that goes red.
+    expect(body.eventsHint, "budget-truncated events must NEVER be described as empty by design").not.toContain("by design");
+  }, 60_000);
+
+  // ── 3. Generous budget: same seed delivers the events; no hint beside a
+  //       populated container (#1290 populated-or-hint, absent direction). ──
+  test("generous budget → all seeded events delivered over REST, and NO eventsHint ships", async () => {
+    const body = await bootstrap(harper, agent, {
+      agentId: agent.id, maxTokens: GENEROUS_MAX_TOKENS, includeTrust: true, includeContext: false,
+    });
+    expect(body.events.length, "all seeded events delivered on the REST path").toBeGreaterThanOrEqual(EVENT_COUNT);
+    for (let i = 0; i < EVENT_COUNT; i++) {
+      const found = body.events.some((e: any) => e.summary === eventSummary(i));
+      expect(found, `seeded event ${i} must be among the delivered events`).toBe(true);
+    }
+    expect("eventsHint" in body, "populated events → NO eventsHint (#1290 absent direction)").toBe(false);
+  }, 60_000);
+});


### PR DESCRIPTION
Closes #1298

## What

Per the respec on the issue (the original transaction-wrap spec was disproved by its own fails-on-main gate): when org events cleared the lookback window and every relevance filter but none fit the remaining token budget (`cost > tokenBudget` in the events admission loop), `events: []` shipped with the hint "present-but-empty **by design**, not dropped" — the exact false reassurance the #1182 empty-container hints exist to prevent. The events *were* dropped; the payload said they weren't. `teammateFindingsHint` already had an explicit budget-truncated branch; `eventsHint` did not.

`eventsHint` now mirrors the teammate branches:

- **budget-truncated** (new): "No org events fit the token budget: N relevant event(s) cleared the lookback window but were budget-truncated. Raise maxTokens to include them."
- **genuinely empty** (unchanged): the by-design wording, reserved for a window with no relevant events.

The count is tracked in the admission loop and is of **admitted-then-skipped events only** — events that entered admission for this caller and failed only the budget gate. It is never derived from a gap against some larger tally, so it cannot imply the existence of withheld/private rows (Sherlock's ruling on the respec).

No `withDetachedTxn` wraps in this PR — explicitly out of scope per Kern ("don't mix cosmetics with the hint fix"); the disproof showed no transaction bug exists on this path.

## Hint-contract conformance (#1290 / PR #1299)

`hintWhenEmpty` for `eventsHint` is presence-keyed ("present exactly when the `events` container ships empty") and text-agnostic — both branches satisfy the declared condition, so the invariant entry in `resources/mcp-tools.ts` needs no registration change and `conform()` holds as-is (verified against `test/helpers/mcp-conformance.ts`, which asserts presence/absence only). The new branch is exercised by the new integration test below; the conformance suite's own hint test still covers both presence directions.

## Test (fireable positive control, real Ed25519 REST path)

New: `test/integration/bootstrap-events-truncated-hint-1298.test.ts` — Ed25519-signed `POST /BootstrapMemories` driver (the bootstrap-trust-budget-conformance shape) + the issue's OrgEvent seed shape (kind `status`, scope `org`, no targetIds, non-caller author, distinct summaries inside the 24h lookback). Three cases, in declaration order:

1. **Genuinely no events** (runs before any event is seeded): by-design branch fires, no "budget-truncated" — unchanged behavior.
2. **THE positive control**: 3 seeded events + tight `maxTokens` + `includeTrust:true` → `events: []`, truncated hint present with count 3, **"by design" wording asserted ABSENT**. A precondition assertion pins that the tight budget really zero-admitted (fails with a re-derive message if upstream admission drifts).
3. **Generous budget**: all 3 seeded events delivered over REST (pinning the disproof: REST delivers events fine), and no `eventsHint` beside the populated container.

### Tight-budget derivation (recorded per the respec)

The walk-back demonstrated 1500 zero-admits with *its* seed; re-derived empirically against this fixture (20 permanents + includeTrust + three ~122-token events) with an 11-point sweep on one Harper:

```
maxTokens:  800  900  1000  1100  1200  1300  1400  1500  1600  2000  16000
events:      2    0     1     0     0     1     0     1     1     0      3
```

Same non-monotonic shape the walk-back reported (more budget admits more *memories* first, changing the residual left for events). **1100 chosen**: it shares 1200's admitted-memory set and 1200 still zero-admits, so 1100's residual is < 22 tokens against a ~122-token cheapest event — > 100 tokens of drift needed to flip it.

### Red on unmodified main (both runs quoted)

On unmodified main (fix stashed, dist rebuilt from main sources — the ephemeral Harper serves the built dist, so each red/green cycle rebuilds):

```
error: the hint must name the truncation
Expected to contain: "budget-truncated"
Received: "No org events in the lookback window were relevant to you (org-wide, or
targeted at you) after zero-row no-op auto-heal filtering. This container is
present-but-empty by design, not dropped."
(fail) ... seeded events zero-admitted by a tight budget → TRUNCATED hint ...
 2 pass
 1 fail
```

With the fix restored and rebuilt:

```
 3 pass
 0 fail
 21 expect() calls
Ran 3 tests across 1 file.
```

### Mutation check

Removed the truncated branch (by-design-only hint restored), rebuilt → the positive control goes red on the same assertion (`Expected to contain: "budget-truncated"`, 2 pass / 1 fail); branch restored, rebuilt → 3 pass / 0 fail.

## Suite runs vs self-measured origin/main baseline

| Lane | origin/main baseline | this branch |
|---|---|---|
| `bun test test/unit/ test/*.test.ts` | 4781 pass / 0 fail (250 files) | 4781 pass / 0 fail (250 files) |
| `test/unit-isolated/` one process per file | — | all green |
| 6 touched bootstrap/conformance integration suites¹ | 38 pass / 0 fail | 38 pass / 0 fail |
| + new 1298 suite | (red by design, quoted above) | 3 pass / 0 fail (41/41 total) |

¹ mcp-connector-conformance-suite, bootstrap-token-ledger-1270, bootstrap-trust-budget-conformance, bootstrap-self-describing-1182, mcp-bootstrap-payload-1182, bootstrap-payload-quality-1199.

Changelog fragment: `.changelog/unreleased/fixed-1298-events-truncated-hint.md` (validated: `changelog-fragments.mjs check` — 9 fragments, no stray entries).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
