### PR TITLE
federation status: reads never require identity-creation capability — keystore failure degrades visibly instead of 500ing

### DIFF
--- a/.changelog/unreleased/fixed-1233-federation-status-read-path.md
+++ b/.changelog/unreleased/fixed-1233-federation-status-read-path.md
@@ -1,0 +1,12 @@
+- `GET /FederationInstance` no longer 500s with "Keystore unavailable" when the
+  server's HOME-relative keystore is unwritable (the Fabric-managed hub shape) —
+  reads never require identity-creation capability (#1233). The identity row is
+  still created; a keystore write failure is logged server-side with the real
+  remedy and surfaced as a runtime-only `signingKeyAvailable: false` field on
+  the GET response. `flair federation status` now fetches instance and peers
+  independently — one failing read marks that section unverifiable instead of
+  aborting the whole render — and shows a degraded marker (keystore path +
+  permission fix) when the signing key is unavailable. Signing (pair/sync)
+  remains fail-closed; `loadInstanceSecretKey`'s error text names the real
+  recovery instead of the impossible "re-run flair federation status to
+  regenerate" advice.

--- a/resources/Federation.ts
+++ b/resources/Federation.ts
@@ -145,7 +145,26 @@ export class FederationInstance extends Resource {
         instance = i;
         break;
       }
-    } catch { /* table may not exist */ }
+    } catch (err: any) {
+      // Expected on genuine first boot: the Instance table doesn't exist yet,
+      // and the create branch below handles that. But a bare swallow here also
+      // hid every OTHER read failure (storage, permissions), making a
+      // persistently failing read indistinguishable from first boot
+      // (flair#1233). Log the error class so the two are tellable apart in
+      // server logs; behavior is unchanged — fall through to create.
+      console.warn(
+        "[federation] Instance read failed — proceeding as first boot (create branch will run). " +
+          "If this instance already has an identity, this is a real read error, not an absent table. " +
+          `${err?.constructor?.name ?? "Error"}: ${err?.message ?? err}`,
+      );
+    }
+
+    // Runtime-only signal (flair#1233): whether this instance's private key
+    // seed is present in the keystore, i.e. whether it can SIGN (pair/sync).
+    // Deliberately NOT persisted — the Instance.status enum is
+    // schema-constrained and this is transient machine state; recomputed on
+    // every GET.
+    let signingKeyAvailable = false;
 
     if (!instance) {
       // First boot — generate instance identity
@@ -164,15 +183,41 @@ export class FederationInstance extends Resource {
 
       await (databases as any).flair.Instance.put(instance);
 
-      // Store private key seed in encrypted keystore (not in DB)
+      // Store private key seed in encrypted keystore (not in DB).
+      //
+      // flair#1233: a keystore failure no longer aborts the GET. This is a
+      // READ path — the response never uses the private key, and the old
+      // throw here left federation state entirely unobservable on hosts
+      // whose HOME isn't writable (the #812 ENOTDIR class; keysDir() is
+      // homedir()-relative). Fail-closed stays where the key is USED:
+      // signing, in pair/sync, still throws when the key is absent. Here the
+      // failure is logged server-side and surfaced to the caller as
+      // signingKeyAvailable:false. Plaintext keys still never touch the DB.
       try {
         const { keystore } = await import("../src/keystore.js");
         const seed = kp.secretKey.slice(0, 32);
         keystore.setPrivateKeySeed(id, seed);
-      } catch (err) {
-        // Fail closed — never store plaintext keys in the database
-        console.error("[federation] FATAL: Could not store key seed in keystore. Federation identity not created.", err);
-        throw new Error("Keystore unavailable — cannot create federation identity without secure key storage");
+        signingKeyAvailable = true;
+      } catch (err: any) {
+        console.error(
+          "[federation] Could not store the federation signing key seed in the keystore " +
+            "($HOME/.flair/keys, relative to the Harper process's HOME). The identity row was created and " +
+            "reads work, but this instance cannot sign — pair/sync will fail until the keystore is fixed. " +
+            "Remedy: make $HOME/.flair/keys a directory writable by the Harper process (mode 0700). " +
+            "The seed for THIS identity was never stored, so after fixing the keystore, re-key: delete the " +
+            "Instance row and re-pair to mint a fresh identity. " +
+            `${err?.constructor?.name ?? "Error"}: ${err?.message ?? err}`,
+        );
+      }
+    } else {
+      // Existing identity: report whether its signing key is present and
+      // decryptable. getPrivateKeySeed is a read-only probe that returns null
+      // (never throws) when the key file is missing or unreadable.
+      try {
+        const { keystore } = await import("../src/keystore.js");
+        signingKeyAvailable = keystore.getPrivateKeySeed(instance.id) !== null;
+      } catch {
+        signingKeyAvailable = false;
       }
     }
 
@@ -181,6 +226,8 @@ export class FederationInstance extends Resource {
       publicKey: instance.publicKey,
       role: instance.role,
       status: instance.status,
+      // Runtime-only — see above; never persisted.
+      signingKeyAvailable,
     };
   }
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -29,7 +29,7 @@ import { create as tarCreate, extract as tarExtract, list as tarList } from "tar
 // flair#901 — tar listings/extracts type their entry callbacks against
 // node-tar's own export so an upstream property rename fails compilation.
 import type { ReadEntry as TarReadEntry } from "tar";
-import { keystore } from "./keystore.js";
+import { keystore, keyPath as keystoreKeyPath } from "./keystore.js";
 import { deploy as deployToFabric, validateOptions as validateDeployOptions, buildTargetUrl as buildDeployUrl, resolveDeployPublicUrl } from "./deploy.js";
 import {
   COMPONENT_ENV_FILENAME,
@@ -6764,7 +6764,16 @@ async function loadInstanceSecretKey(instanceId: string, opts: { adminPass?: str
     }
   }
 
-  throw new Error(`No private key found for instance ${instanceId}. Re-run 'flair federation status' to regenerate.`);
+  // flair#1233: the old advice here — "Re-run 'flair federation status' to
+  // regenerate" — was impossible: the server's create branch only fires when
+  // NO Instance row exists, so a re-run can never regenerate a key for an
+  // existing identity. Name the real remedy instead.
+  throw new Error(
+    `No usable private key for instance ${instanceId}. Expected keystore file: ${keystoreKeyPath(instanceId)} ` +
+    `(no legacy _keySeed in the Instance table either). Restore that key file from a backup of ~/.flair/keys ` +
+    `(and FLAIR_KEY_PASSPHRASE, if one was set when it was written), or re-key this instance: delete its ` +
+    `Instance row and re-pair to mint a fresh identity.`,
+  );
 }
 
 /**
@@ -6843,163 +6852,48 @@ federation
     const target = resolveTarget(opts);
     const baseUrl = target ? target.replace(/\/$/, "") : undefined;
     const mode = render.resolveOutputMode(opts);
+
+    // flair#1233: fetch instance and peers INDEPENDENTLY. One read failing
+    // must never take down the whole render — the principle latestPeerContact
+    // already documents for the driver verdict ("must never be the reason
+    // `federation status` fails"), extended to the two primary reads. Print
+    // what's available; mark the rest unverifiable.
+    let instance: any = null;
+    let instanceErr: any = null;
     try {
-      const instance = await api("GET", "/FederationInstance", undefined, baseUrl ? { baseUrl } : undefined);
-      const { peers } = await api("GET", "/FederationPeers", undefined, baseUrl ? { baseUrl } : undefined);
+      instance = await api("GET", "/FederationInstance", undefined, baseUrl ? { baseUrl } : undefined);
+    } catch (err) {
+      instanceErr = err;
+    }
 
-      // Driver state (flair#922). Computed from the LOCAL service manager, so
-      // it is only meaningful when the CLI is pointed at the local instance.
-      let driver: import("./federation/scheduler.js").SchedulerStatus | null = null;
-      let assessment: import("./federation/scheduler.js").DriverAssessment | null = null;
-      if (driverCheckAppliesTo(opts)) {
-        try {
-          const { schedulerStatus, assessDriver } = await import("./federation/scheduler.js");
-          driver = schedulerStatus();
-          let lastSyncAt: string | null = null;
-          for (const p of peers ?? []) {
-            if (!p?.lastSyncAt) continue;
-            const t = Date.parse(p.lastSyncAt);
-            if (Number.isFinite(t) && (lastSyncAt === null || t > Date.parse(lastSyncAt))) {
-              lastSyncAt = new Date(t).toISOString();
-            }
-          }
-          assessment = assessDriver({
-            installed: driver.installed,
-            active: driver.active,
-            intervalSeconds: driver.intervalSeconds,
-            lastSyncAt,
-            now: Date.now(),
-          });
-        } catch {
-          // An unsupported platform (neither darwin nor linux) or an
-          // unreadable unit must not take down `federation status` — the peer
-          // table is still the primary output.
-          driver = null;
-          assessment = null;
-        }
-      }
+    // peers: null = unverifiable (the read failed), [] = verified empty.
+    let peers: any[] | null = null;
+    let peersErr: any = null;
+    try {
+      const r = await api("GET", "/FederationPeers", undefined, baseUrl ? { baseUrl } : undefined);
+      peers = r.peers ?? [];
+    } catch (err) {
+      peersErr = err;
+    }
 
-      if (mode === "json") {
-        console.log(render.asJSON({ instance, peers, driver, driverAssessment: assessment }));
-        return;
-      }
+    // Auth-shaped failures stay FATAL even when the other read succeeded:
+    // both endpoints sit behind the same allowAdmin gate, so a 401/403 is a
+    // property of the session's credentials, not of one endpoint — and
+    // degrading it to "unverifiable" would swallow the actionable remedy
+    // (flair#634's UX, kept). Only non-auth failures degrade independently.
+    const authShaped = (err: any): boolean => {
+      if (!err) return false;
+      if (err.status === 401 || err.status === 403) return true;
+      const m = String(err.message ?? err);
+      return m.includes("missing_or_invalid_authorization") || m.includes("401");
+    };
 
-      const statusColor = instance.status === "active" ? render.c.green : render.c.yellow;
-      console.log(render.wrap(render.c.bold, "Federation"));
-      console.log(render.kv("Instance", `${instance.id}  ${render.wrap(render.c.dim, `(${instance.role})`)}`));
-      console.log(render.kv("Public key", render.wrap(render.c.dim, instance.publicKey)));
-      console.log(render.kv("Status", render.wrap(statusColor, instance.status)));
-
-      if (peers.length === 0) {
-        console.log(`\n${render.icons.info} ${render.wrap(render.c.dim, "No peers configured. Use 'flair federation pair' to connect to a hub.")}`);
-        return;
-      }
-
-      // Print the driver line BEFORE the per-peer table: "is anything running
-      // sync at all" is the question that decides how to read everything
-      // below it.
-      if (assessment) {
-        const icon = assessment.verdict === "driving" || assessment.verdict === "external-driver"
-          ? render.icons.ok
-          : assessment.verdict === "unknown"
-            ? render.icons.info
-            : render.icons.warn;
-        const color = assessment.verdict === "driving" || assessment.verdict === "external-driver"
-          ? render.c.green
-          : assessment.verdict === "unknown"
-            ? render.c.dim
-            : render.c.yellow;
-        console.log();
-        console.log(`${icon} ${render.wrap(color, assessment.headline)}`);
-        console.log(`  ${render.wrap(render.c.dim, assessment.detail)}`);
-        if (assessment.remedy) console.log(`  ${render.wrap(render.c.cyan, assessment.remedy)}`);
-      }
-
-      const now = Date.now();
-      const formatPeerAge = (iso: string | null, refNow: number, staleAfterMs: number): string => {
-        if (!iso) return render.wrap(render.c.red, "never");
-        const t = Date.parse(iso);
-        if (!Number.isFinite(t)) return render.wrap(render.c.red, "never");
-        const ageMs = refNow - t;
-        const ageStr = ageMs < 60_000 ? "<1m ago"
-          : ageMs < 3_600_000 ? `${Math.floor(ageMs / 60_000)}m ago`
-          : ageMs < 86_400_000 ? `${Math.floor(ageMs / 3_600_000)}h ago`
-          : `${Math.floor(ageMs / 86_400_000)}d ago`;
-        const stale = ageMs > staleAfterMs;
-        return render.wrap(stale ? render.c.yellow : render.c.dim, ageStr);
-      };
-      console.log();
-      const cols: render.TableColumn[] = [
-        { label: "peer", key: "id" },
-        { label: "role", key: "role", format: (v) => String(v ?? "—") },
-        {
-          label: "status",
-          key: "status",
-          format: (v) => {
-            const s = String(v ?? "—");
-            const color = s === "paired" || s === "connected" || s === "active" ? render.c.green : s === "revoked" ? render.c.red : render.c.yellow;
-            return render.wrap(color, s);
-          },
-        },
-        {
-          // Liveness: "did we hear from this peer recently?" Updates on every
-          // contact, even when 100% of records were skipped. See flair#444.
-          label: "last_sync",
-          key: "lastSyncAt",
-          format: (v) => formatPeerAge(v as string | null, now, 86_400_000),
-        },
-        {
-          // Progress: "did data actually flow in?" Updates only when merged>0.
-          // Diverging from last_sync means contact-yes but data-no — investigate.
-          label: "last_merge",
-          key: "lastMergeAt",
-          format: (v) => formatPeerAge(v as string | null, now, 86_400_000),
-        },
-        {
-          label: "relay",
-          key: "relayOnly",
-          format: (v) => (v ? render.wrap(render.c.cyan, "yes") : render.wrap(render.c.dim, "no")),
-        },
-      ];
-      console.log(render.table(cols, peers as Array<Record<string, unknown>>));
-
-      // Stale warning is gated on lastMergeAt (real progress), not lastSyncAt.
-      // A peer that "syncs" every 5min but hasn't merged a record in 24h is
-      // exactly the failure mode we want surfaced.
-      const haveStale = peers.some((p: any) => {
-        const cursor = p.lastMergeAt ?? p.lastSyncAt;
-        if (!cursor) return true;
-        const t = Date.parse(cursor);
-        return !Number.isFinite(t) || (now - t) > 86_400_000;
-      });
-      if (haveStale) {
-        console.log();
-        // The staleness warning used to fire identically whether sync was
-        // running and the peer was unreachable, or nothing had run sync since
-        // the day the spoke was paired (flair#922). Those need opposite
-        // actions, so the remedy is now chosen by the driver verdict instead
-        // of always pointing at SyncLog.
-        const noDriver = assessment?.verdict === "no-driver" || assessment?.verdict === "driver-inactive";
-        const remedy = noDriver
-          ? "Nothing is driving sync — see the driver line above. Run 'flair federation sync enable'."
-          : "Check skippedReasons in SyncLog or run 'flair federation sync'.";
-        console.log(`${render.icons.warn} ${render.wrap(render.c.yellow, "One or more peers haven't merged a record in >24h.")} ${render.wrap(render.c.dim, remedy)}`);
-      }
-
-      const haveContactButNoMerge = peers.some((p: any) => {
-        if (!p.lastSyncAt || !Number.isFinite(Date.parse(p.lastSyncAt))) return false;
-        if ((now - Date.parse(p.lastSyncAt)) > 3_600_000) return false; // only recent contact
-        // Contact within the last hour, but no merge ever (or stale by >1h)
-        if (!p.lastMergeAt) return true;
-        const tm = Date.parse(p.lastMergeAt);
-        return !Number.isFinite(tm) || (now - tm) > 3_600_000;
-      });
-      if (haveContactButNoMerge && !haveStale) {
-        console.log();
-        console.log(`${render.icons.warn} ${render.wrap(render.c.yellow, "Peer contact is fresh but no records merged in the last hour.")} ${render.wrap(render.c.dim, "Possible silent-skip scenario — check SyncLog.skippedReasons.")}`);
-      }
-    } catch (err: any) {
-      const msg = String(err.message ?? err);
+    // Both reads failed → nothing to render at all. Either way keep the
+    // classic failure UX (auth remedy when it's an auth problem), exit
+    // non-zero.
+    if ((instanceErr && peersErr) || authShaped(instanceErr) || authShaped(peersErr)) {
+      const primaryErr = instanceErr ?? peersErr;
+      const msg = String(primaryErr.message ?? primaryErr);
       if (msg.includes("missing_or_invalid_authorization") || msg.includes("401")) {
         console.error(`${render.icons.error} federation status requires auth.`);
         console.error(`  ${render.wrap(render.c.dim, "Set one of:")}`);
@@ -7010,6 +6904,203 @@ federation
       }
       console.error(`${render.icons.error} ${msg}`);
       process.exit(1);
+    }
+
+    // Driver state (flair#922). Computed from the LOCAL service manager, so
+    // it is only meaningful when the CLI is pointed at the local instance —
+    // and only when the peer read succeeded: the verdict is derived from
+    // peer contact, so with peers unverifiable it would be a confident claim
+    // built on no data.
+    let driver: import("./federation/scheduler.js").SchedulerStatus | null = null;
+    let assessment: import("./federation/scheduler.js").DriverAssessment | null = null;
+    if (peers !== null && driverCheckAppliesTo(opts)) {
+      try {
+        const { schedulerStatus, assessDriver } = await import("./federation/scheduler.js");
+        driver = schedulerStatus();
+        let lastSyncAt: string | null = null;
+        for (const p of peers) {
+          if (!p?.lastSyncAt) continue;
+          const t = Date.parse(p.lastSyncAt);
+          if (Number.isFinite(t) && (lastSyncAt === null || t > Date.parse(lastSyncAt))) {
+            lastSyncAt = new Date(t).toISOString();
+          }
+        }
+        assessment = assessDriver({
+          installed: driver.installed,
+          active: driver.active,
+          intervalSeconds: driver.intervalSeconds,
+          lastSyncAt,
+          now: Date.now(),
+        });
+      } catch {
+        // An unsupported platform (neither darwin nor linux) or an
+        // unreadable unit must not take down `federation status` — the peer
+        // table is still the primary output.
+        driver = null;
+        assessment = null;
+      }
+    }
+
+    if (mode === "json") {
+      console.log(render.asJSON({
+        instance,
+        peers,
+        driver,
+        driverAssessment: assessment,
+        // flair#1233: name what could not be read, so a partial result is
+        // distinguishable from "verified absent" (instance/peers stay null
+        // when their read failed).
+        ...(instanceErr || peersErr
+          ? {
+              unverifiable: {
+                ...(instanceErr ? { instance: String(instanceErr.message ?? instanceErr) } : {}),
+                ...(peersErr ? { peers: String(peersErr.message ?? peersErr) } : {}),
+              },
+            }
+          : {}),
+      }));
+      return;
+    }
+
+    console.log(render.wrap(render.c.bold, "Federation"));
+    if (instance) {
+      const statusColor = instance.status === "active" ? render.c.green : render.c.yellow;
+      console.log(render.kv("Instance", `${instance.id}  ${render.wrap(render.c.dim, `(${instance.role})`)}`));
+      console.log(render.kv("Public key", render.wrap(render.c.dim, instance.publicKey)));
+      console.log(render.kv("Status", render.wrap(statusColor, instance.status)));
+
+      // flair#1233 degraded marker — actor + state + remedy. The server sets
+      // signingKeyAvailable (runtime-only) on GET /FederationInstance; only
+      // an explicit false fires this. Older servers omit the field, which
+      // proves nothing either way, so no marker.
+      if (instance.signingKeyAvailable === false) {
+        console.log();
+        console.log(`${render.icons.warn} ${render.wrap(render.c.yellow, "Signing key unavailable — the server could not store or read this instance's private key.")}`);
+        console.log(`  ${render.wrap(render.c.dim, "Reads (this status) still work; pair/sync signing on that instance will fail until the keystore is fixed.")}`);
+        console.log(`  ${render.wrap(render.c.cyan, "Fix on the server: make $HOME/.flair/keys (under the Harper process's HOME) a directory writable by the Harper process, mode 0700. If the key was never stored, re-key: delete the Instance row and re-pair.")}`);
+      }
+    } else {
+      // Instance read failed but peers succeeded — render what we have.
+      console.log(render.kv("Instance", `${render.icons.warn} unverifiable — ${render.wrap(render.c.dim, String(instanceErr?.message ?? instanceErr))}`));
+    }
+
+    if (peers === null) {
+      // Peer read failed but the instance rendered — say so explicitly
+      // instead of aborting: "unverifiable" is a different claim from "no
+      // peers", and conflating them is how hub state became unobservable.
+      console.log();
+      console.log(`${render.icons.warn} ${render.wrap(render.c.yellow, "Peers unverifiable — the peer read failed. This says nothing about whether peers exist or sync runs.")}`);
+      console.log(`  ${render.wrap(render.c.dim, String(peersErr?.message ?? peersErr))}`);
+      return;
+    }
+
+    if (peers.length === 0) {
+      console.log(`\n${render.icons.info} ${render.wrap(render.c.dim, "No peers configured. Use 'flair federation pair' to connect to a hub.")}`);
+      return;
+    }
+
+    // Print the driver line BEFORE the per-peer table: "is anything running
+    // sync at all" is the question that decides how to read everything
+    // below it.
+    if (assessment) {
+      const icon = assessment.verdict === "driving" || assessment.verdict === "external-driver"
+        ? render.icons.ok
+        : assessment.verdict === "unknown"
+          ? render.icons.info
+          : render.icons.warn;
+      const color = assessment.verdict === "driving" || assessment.verdict === "external-driver"
+        ? render.c.green
+        : assessment.verdict === "unknown"
+          ? render.c.dim
+          : render.c.yellow;
+      console.log();
+      console.log(`${icon} ${render.wrap(color, assessment.headline)}`);
+      console.log(`  ${render.wrap(render.c.dim, assessment.detail)}`);
+      if (assessment.remedy) console.log(`  ${render.wrap(render.c.cyan, assessment.remedy)}`);
+    }
+
+    const now = Date.now();
+    const formatPeerAge = (iso: string | null, refNow: number, staleAfterMs: number): string => {
+      if (!iso) return render.wrap(render.c.red, "never");
+      const t = Date.parse(iso);
+      if (!Number.isFinite(t)) return render.wrap(render.c.red, "never");
+      const ageMs = refNow - t;
+      const ageStr = ageMs < 60_000 ? "<1m ago"
+        : ageMs < 3_600_000 ? `${Math.floor(ageMs / 60_000)}m ago`
+        : ageMs < 86_400_000 ? `${Math.floor(ageMs / 3_600_000)}h ago`
+        : `${Math.floor(ageMs / 86_400_000)}d ago`;
+      const stale = ageMs > staleAfterMs;
+      return render.wrap(stale ? render.c.yellow : render.c.dim, ageStr);
+    };
+    console.log();
+    const cols: render.TableColumn[] = [
+      { label: "peer", key: "id" },
+      { label: "role", key: "role", format: (v) => String(v ?? "—") },
+      {
+        label: "status",
+        key: "status",
+        format: (v) => {
+          const s = String(v ?? "—");
+          const color = s === "paired" || s === "connected" || s === "active" ? render.c.green : s === "revoked" ? render.c.red : render.c.yellow;
+          return render.wrap(color, s);
+        },
+      },
+      {
+        // Liveness: "did we hear from this peer recently?" Updates on every
+        // contact, even when 100% of records were skipped. See flair#444.
+        label: "last_sync",
+        key: "lastSyncAt",
+        format: (v) => formatPeerAge(v as string | null, now, 86_400_000),
+      },
+      {
+        // Progress: "did data actually flow in?" Updates only when merged>0.
+        // Diverging from last_sync means contact-yes but data-no — investigate.
+        label: "last_merge",
+        key: "lastMergeAt",
+        format: (v) => formatPeerAge(v as string | null, now, 86_400_000),
+      },
+      {
+        label: "relay",
+        key: "relayOnly",
+        format: (v) => (v ? render.wrap(render.c.cyan, "yes") : render.wrap(render.c.dim, "no")),
+      },
+    ];
+    console.log(render.table(cols, peers as Array<Record<string, unknown>>));
+
+    // Stale warning is gated on lastMergeAt (real progress), not lastSyncAt.
+    // A peer that "syncs" every 5min but hasn't merged a record in 24h is
+    // exactly the failure mode we want surfaced.
+    const haveStale = peers.some((p: any) => {
+      const cursor = p.lastMergeAt ?? p.lastSyncAt;
+      if (!cursor) return true;
+      const t = Date.parse(cursor);
+      return !Number.isFinite(t) || (now - t) > 86_400_000;
+    });
+    if (haveStale) {
+      console.log();
+      // The staleness warning used to fire identically whether sync was
+      // running and the peer was unreachable, or nothing had run sync since
+      // the day the spoke was paired (flair#922). Those need opposite
+      // actions, so the remedy is now chosen by the driver verdict instead
+      // of always pointing at SyncLog.
+      const noDriver = assessment?.verdict === "no-driver" || assessment?.verdict === "driver-inactive";
+      const remedy = noDriver
+        ? "Nothing is driving sync — see the driver line above. Run 'flair federation sync enable'."
+        : "Check skippedReasons in SyncLog or run 'flair federation sync'.";
+      console.log(`${render.icons.warn} ${render.wrap(render.c.yellow, "One or more peers haven't merged a record in >24h.")} ${render.wrap(render.c.dim, remedy)}`);
+    }
+
+    const haveContactButNoMerge = peers.some((p: any) => {
+      if (!p.lastSyncAt || !Number.isFinite(Date.parse(p.lastSyncAt))) return false;
+      if ((now - Date.parse(p.lastSyncAt)) > 3_600_000) return false; // only recent contact
+      // Contact within the last hour, but no merge ever (or stale by >1h)
+      if (!p.lastMergeAt) return true;
+      const tm = Date.parse(p.lastMergeAt);
+      return !Number.isFinite(tm) || (now - tm) > 3_600_000;
+    });
+    if (haveContactButNoMerge && !haveStale) {
+      console.log();
+      console.log(`${render.icons.warn} ${render.wrap(render.c.yellow, "Peer contact is fresh but no records merged in the last hour.")} ${render.wrap(render.c.dim, "Possible silent-skip scenario — check SyncLog.skippedReasons.")}`);
     }
   });
 

--- a/test/integration/federation-status-keystore-1233.test.ts
+++ b/test/integration/federation-status-keystore-1233.test.ts
@@ -1,0 +1,370 @@
+/**
+ * federation-status-keystore-1233.test.ts — flair#1233 regression: a READ
+ * path (GET /FederationInstance, and `flair federation status` on top of it)
+ * must never require identity-CREATION capability.
+ *
+ * ─── What broke ────────────────────────────────────────────────────────────
+ * FederationInstance.get() does find-or-create inline. On first authorized
+ * GET with no Instance row, it generates a keypair and writes the seed to the
+ * keystore — which is unconditionally homedir()-relative
+ * (src/keystore.ts keysDir() = <HOME>/.flair/keys). On a deployment shape
+ * where HOME isn't writable (Fabric-managed hub, the #812 class), that write
+ * throws, the GET 500s ("Keystore unavailable"), and the hub's federation
+ * state is unobservable by an operator at all — the 2026-08-16 tps.dtrt
+ * incident in flair#1233.
+ *
+ * Post-fix: the identity row is still created, the keystore failure is logged
+ * server-side, and the GET returns 200 with a RUNTIME-ONLY
+ * `signingKeyAvailable: false` field. Signing (pair/sync) remains fail-closed
+ * — the missing key fails there, its correct point of use.
+ *
+ * ─── Why a SIBLING FILE, not a describe in gate4-authgate.test.ts ──────────
+ * gate4 boots ONE shared Harper for four resource-gate suites, and its admin
+ * GET test creates the federation identity with a WORKING keystore. This
+ * file's core scenario is keystore-broken-BEFORE-first-identity-creation:
+ * <HOME>/.flair replaced by a regular file (the #812 ENOTDIR technique,
+ * deterministic for any user including root). That needs its own boot
+ * lifecycle, and mutating the shared instance's HOME would poison gate4's
+ * other suites. MODEL: migrations-provisioned-datadir.test.ts (the ENOTDIR
+ * blocker shape) + cli-local-admin-pass-fallback.test.ts (real-CLI
+ * subprocess pattern).
+ */
+import { describe, expect, test, beforeAll, afterAll } from "bun:test";
+import { existsSync, lstatSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { startHarper, stopHarper, HarperInstance } from "../helpers/harper-lifecycle";
+
+function makeTmpDir(prefix: string): string {
+  const dir = join(tmpdir(), `${prefix}-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+  mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+async function runCli(
+  args: string[],
+  env: Record<string, string | undefined>,
+): Promise<{ stdout: string; stderr: string; exitCode: number }> {
+  const cliPath = join(import.meta.dirname, "..", "..", "src", "cli.ts");
+  // Merge onto a copy of the real env, but explicitly DELETE any key passed
+  // as undefined — isolation even if the host shell has FLAIR_* set.
+  const merged: Record<string, string> = { ...process.env } as Record<string, string>;
+  for (const [k, v] of Object.entries(env)) {
+    if (v === undefined) delete merged[k];
+    else merged[k] = v;
+  }
+  const proc = Bun.spawn(["bun", cliPath, ...args], { env: merged, stdout: "pipe", stderr: "pipe" });
+  const stdout = await new Response(proc.stdout).text();
+  const stderr = await new Response(proc.stderr).text();
+  const exitCode = await proc.exited;
+  return { stdout, stderr, exitCode };
+}
+
+function basicAuth(harper: HarperInstance): string {
+  return "Basic " + Buffer.from(`${harper.admin.username}:${harper.admin.password}`).toString("base64");
+}
+
+// Env base for CLI runs: isolated HOME, admin Basic auth, everything else
+// that could change auth resolution or output mode explicitly cleared.
+function cliEnv(harper: HarperInstance, home: string, extra: Record<string, string | undefined> = {}) {
+  return {
+    HOME: home,
+    FLAIR_ADMIN_PASS: harper.admin.password,
+    HDB_ADMIN_PASSWORD: undefined,
+    FLAIR_AGENT_ID: undefined,
+    FLAIR_TOKEN: undefined,
+    FLAIR_TARGET: undefined,
+    FLAIR_OUTPUT: undefined,
+    ...extra,
+  };
+}
+
+// ─── A. Keystore-blocked instance: <HOME>/.flair is a regular file ──────────
+
+describe("flair#1233: GET /FederationInstance with an unusable keystore (HOME/.flair is a file)", () => {
+  let harper: HarperInstance;
+  let blockedFlairPath: string;
+  let firstBody: any;
+
+  beforeAll(async () => {
+    harper = await startHarper();
+    // Block AFTER boot, BEFORE the first authorized GET (which is what
+    // find-or-creates the identity). startHarper sets the spawned Harper's
+    // HOME (and ROOTPATH) to installDir, so keysDir() resolves under it. A
+    // regular file at <HOME>/.flair makes mkdir -p of <HOME>/.flair/keys fail
+    // with ENOTDIR for every user, root included — same technique as
+    // migrations-provisioned-datadir.test.ts (flair#812).
+    blockedFlairPath = join(harper.installDir, ".flair");
+    rmSync(blockedFlairPath, { recursive: true, force: true });
+    writeFileSync(blockedFlairPath, "flair#1233: this path is deliberately not a directory\n");
+  }, 240_000);
+
+  afterAll(async () => { if (harper) await stopHarper(harper); });
+
+  test("the blocker really is in place — <HOME>/.flair is a regular file", () => {
+    expect(existsSync(blockedFlairPath)).toBe(true);
+    expect(lstatSync(blockedFlairPath).isFile()).toBe(true);
+  });
+
+  test("RED-ON-MAIN: first admin GET → 200 with identity + signingKeyAvailable:false (main: 500 'Keystore unavailable')", async () => {
+    const res = await fetch(`${harper.httpURL}/FederationInstance`, {
+      headers: { Authorization: basicAuth(harper) },
+    });
+    const text = await res.text();
+    expect(res.status, `GET /FederationInstance returned ${res.status}: ${text.slice(0, 300)}`).toBe(200);
+    firstBody = JSON.parse(text);
+    expect(firstBody.id).toMatch(/^flair_/);
+    expect(firstBody.publicKey).toBeTruthy();
+    // The whole point of #1233: the read degrades VISIBLY instead of 500ing.
+    expect(firstBody.signingKeyAvailable).toBe(false);
+    // Runtime-only — must not repurpose the persisted status enum.
+    expect(firstBody.status).toBe("active");
+  }, 30_000);
+
+  test("steady state: identity now exists, key still missing → 200 + signingKeyAvailable:false (existing-identity probe path)", async () => {
+    const res = await fetch(`${harper.httpURL}/FederationInstance`, {
+      headers: { Authorization: basicAuth(harper) },
+    });
+    expect(res.status).toBe(200);
+    const body: any = await res.json();
+    // Same identity as the create-branch GET — proves the row persisted and
+    // this GET took the found-row path, whose signingKeyAvailable comes from
+    // the keystore probe, not the create-branch flag.
+    expect(body.id).toBe(firstBody.id);
+    expect(body.signingKeyAvailable).toBe(false);
+  }, 30_000);
+
+  test("CLI human render: degraded marker with keystore path + remedy, exit 0", async () => {
+    const tmpHome = makeTmpDir("flair-1233-cli-degraded");
+    try {
+      const { exitCode, stdout, stderr } = await runCli(
+        ["federation", "status", "--target", harper.httpURL],
+        cliEnv(harper, tmpHome, { FLAIR_OUTPUT: "human" }),
+      );
+      expect(exitCode, `stdout: ${stdout}\nstderr: ${stderr}`).toBe(0);
+      // Identity still renders...
+      expect(stdout).toContain(firstBody.id);
+      // ...with the actor+state+remedy degraded marker.
+      expect(stdout).toContain("Signing key unavailable");
+      expect(stdout).toContain(".flair/keys");
+      expect(stdout).toMatch(/writable by the Harper process/);
+    } finally {
+      rmSync(tmpHome, { recursive: true, force: true });
+    }
+  }, 30_000);
+
+  test("CLI JSON render: instance.signingKeyAvailable:false, peers verified, exit 0", async () => {
+    const tmpHome = makeTmpDir("flair-1233-cli-json");
+    try {
+      const { exitCode, stdout, stderr } = await runCli(
+        ["federation", "status", "--target", harper.httpURL, "--json"],
+        cliEnv(harper, tmpHome),
+      );
+      expect(exitCode, `stdout: ${stdout}\nstderr: ${stderr}`).toBe(0);
+      const body = JSON.parse(stdout);
+      expect(body.instance?.signingKeyAvailable).toBe(false);
+      expect(Array.isArray(body.peers)).toBe(true);
+      // Both reads succeeded — nothing is unverifiable.
+      expect(body.unverifiable).toBeUndefined();
+    } finally {
+      rmSync(tmpHome, { recursive: true, force: true });
+    }
+  }, 30_000);
+});
+
+// ─── B. First-boot control: normal writable HOME ────────────────────────────
+//
+// Kern's attack point on the spec: prove genuine first boot still works —
+// the create branch fires, the key REALLY lands in the keystore (positive
+// control that the blocker above targets the actual write path), and no
+// degraded marker renders.
+
+describe("flair#1233 control: genuine first boot with a writable HOME", () => {
+  let harper: HarperInstance;
+  let body: any;
+
+  beforeAll(async () => {
+    harper = await startHarper();
+  }, 240_000);
+
+  afterAll(async () => { if (harper) await stopHarper(harper); });
+
+  test("first admin GET → 200, identity created, signingKeyAvailable:true", async () => {
+    const res = await fetch(`${harper.httpURL}/FederationInstance`, {
+      headers: { Authorization: basicAuth(harper) },
+    });
+    const text = await res.text();
+    expect(res.status, `GET /FederationInstance returned ${res.status}: ${text.slice(0, 300)}`).toBe(200);
+    body = JSON.parse(text);
+    expect(body.id).toMatch(/^flair_/);
+    expect(body.publicKey).toBeTruthy();
+    expect(body.signingKeyAvailable).toBe(true);
+  }, 30_000);
+
+  test("the key file really exists where the keystore says it does (positive control for the ENOTDIR blocker)", () => {
+    // keysDir() is <HOME>/.flair/keys and startHarper sets HOME=installDir.
+    const keyFile = join(harper.installDir, ".flair", "keys", `${body.id}.key`);
+    expect(existsSync(keyFile), `expected key file at ${keyFile}`).toBe(true);
+  });
+
+  test("second GET (found-row path) → signingKeyAvailable still true", async () => {
+    const res = await fetch(`${harper.httpURL}/FederationInstance`, {
+      headers: { Authorization: basicAuth(harper) },
+    });
+    expect(res.status).toBe(200);
+    const second: any = await res.json();
+    expect(second.id).toBe(body.id);
+    expect(second.signingKeyAvailable).toBe(true);
+  }, 30_000);
+
+  test("CLI human render: NO degraded marker, exit 0", async () => {
+    const tmpHome = makeTmpDir("flair-1233-cli-healthy");
+    try {
+      const { exitCode, stdout, stderr } = await runCli(
+        ["federation", "status", "--target", harper.httpURL],
+        cliEnv(harper, tmpHome, { FLAIR_OUTPUT: "human" }),
+      );
+      expect(exitCode, `stdout: ${stdout}\nstderr: ${stderr}`).toBe(0);
+      expect(stdout).toContain(body.id);
+      expect(stdout).not.toContain("Signing key unavailable");
+      expect(stdout).not.toContain("unverifiable");
+    } finally {
+      rmSync(tmpHome, { recursive: true, force: true });
+    }
+  }, 30_000);
+});
+
+// ─── C. CLI independence: one read failing must not abort the render ────────
+//
+// Mock servers, not Harper: forcing exactly ONE of the two endpoints to fail
+// on a real instance would need server-side fault injection; a mock pins the
+// contract precisely. mock A is byte-for-byte the flair#1233 field incident —
+// an UNPATCHED hub whose /FederationInstance 500s "Keystore unavailable" —
+// proving the CLI half of the fix helps against old servers too.
+
+describe("flair#1233: CLI fetches instance and peers independently", () => {
+  const mockPeer = {
+    id: "peer-mock-1233",
+    role: "spoke",
+    status: "connected",
+    lastSyncAt: new Date().toISOString(),
+    lastMergeAt: new Date().toISOString(),
+    relayOnly: false,
+  };
+
+  function mockServer(handlers: Record<string, () => Response>) {
+    return Bun.serve({
+      port: 0,
+      hostname: "127.0.0.1",
+      fetch(req) {
+        const path = new URL(req.url).pathname;
+        const h = handlers[path];
+        return h ? h() : new Response("not found", { status: 404 });
+      },
+    });
+  }
+
+  // Dummy admin pass so api() sends Basic auth; the mocks ignore auth.
+  const mockCliEnv = (home: string, extra: Record<string, string | undefined> = {}) => ({
+    HOME: home,
+    FLAIR_ADMIN_PASS: "mock-test-pass",
+    HDB_ADMIN_PASSWORD: undefined,
+    FLAIR_AGENT_ID: undefined,
+    FLAIR_TOKEN: undefined,
+    FLAIR_TARGET: undefined,
+    FLAIR_OUTPUT: "human" as string | undefined,
+    ...extra,
+  });
+
+  test("instance 500s (unpatched #1233 hub), peers OK → peers render, instance marked unverifiable, exit 0", async () => {
+    const server = mockServer({
+      "/FederationInstance": () =>
+        new Response("Keystore unavailable — cannot create federation identity without secure key storage", { status: 500 }),
+      "/FederationPeers": () =>
+        Response.json({ peers: [mockPeer] }),
+    });
+    const tmpHome = makeTmpDir("flair-1233-mock-inst500");
+    try {
+      const { exitCode, stdout, stderr } = await runCli(
+        ["federation", "status", "--target", `http://127.0.0.1:${server.port}`],
+        mockCliEnv(tmpHome),
+      );
+      expect(exitCode, `stdout: ${stdout}\nstderr: ${stderr}`).toBe(0);
+      expect(stdout).toContain("unverifiable");
+      expect(stdout).toContain("Keystore unavailable");
+      // The peer table still rendered — the whole point.
+      expect(stdout).toContain("peer-mock-1233");
+    } finally {
+      server.stop(true);
+      rmSync(tmpHome, { recursive: true, force: true });
+    }
+  }, 30_000);
+
+  test("instance OK, peers 500 → instance renders, peers marked unverifiable (not 'no peers'), exit 0", async () => {
+    const server = mockServer({
+      "/FederationInstance": () =>
+        Response.json({ id: "flair_mock1233", publicKey: "pk", role: "hub", status: "active", signingKeyAvailable: true }),
+      "/FederationPeers": () =>
+        new Response("peer table read failed", { status: 500 }),
+    });
+    const tmpHome = makeTmpDir("flair-1233-mock-peers500");
+    try {
+      const { exitCode, stdout, stderr } = await runCli(
+        ["federation", "status", "--target", `http://127.0.0.1:${server.port}`],
+        mockCliEnv(tmpHome),
+      );
+      expect(exitCode, `stdout: ${stdout}\nstderr: ${stderr}`).toBe(0);
+      expect(stdout).toContain("flair_mock1233");
+      expect(stdout).toContain("Peers unverifiable");
+      // "read failed" must not be conflated with "verified empty".
+      expect(stdout).not.toContain("No peers configured");
+    } finally {
+      server.stop(true);
+      rmSync(tmpHome, { recursive: true, force: true });
+    }
+  }, 30_000);
+
+  test("both reads fail → classic failure UX, exit 1 (nothing to render is still an error)", async () => {
+    const server = mockServer({
+      "/FederationInstance": () => new Response("boom-instance", { status: 500 }),
+      "/FederationPeers": () => new Response("boom-peers", { status: 500 }),
+    });
+    const tmpHome = makeTmpDir("flair-1233-mock-both500");
+    try {
+      const { exitCode, stderr, stdout } = await runCli(
+        ["federation", "status", "--target", `http://127.0.0.1:${server.port}`],
+        mockCliEnv(tmpHome),
+      );
+      expect(exitCode, `stdout: ${stdout}\nstderr: ${stderr}`).not.toBe(0);
+      expect(stderr).toContain("boom-instance");
+    } finally {
+      server.stop(true);
+      rmSync(tmpHome, { recursive: true, force: true });
+    }
+  }, 30_000);
+
+  test("JSON mode carries the unverifiable map alongside what was read", async () => {
+    const server = mockServer({
+      "/FederationInstance": () =>
+        new Response("Keystore unavailable — cannot create federation identity without secure key storage", { status: 500 }),
+      "/FederationPeers": () =>
+        Response.json({ peers: [mockPeer] }),
+    });
+    const tmpHome = makeTmpDir("flair-1233-mock-json");
+    try {
+      const { exitCode, stdout, stderr } = await runCli(
+        ["federation", "status", "--target", `http://127.0.0.1:${server.port}`, "--json"],
+        mockCliEnv(tmpHome, { FLAIR_OUTPUT: undefined }),
+      );
+      expect(exitCode, `stdout: ${stdout}\nstderr: ${stderr}`).toBe(0);
+      const body = JSON.parse(stdout);
+      expect(body.instance).toBeNull();
+      expect(body.peers?.[0]?.id).toBe("peer-mock-1233");
+      expect(String(body.unverifiable?.instance)).toContain("Keystore unavailable");
+      expect(body.unverifiable?.peers).toBeUndefined();
+    } finally {
+      server.stop(true);
+      rmSync(tmpHome, { recursive: true, force: true });
+    }
+  }, 30_000);
+});


### PR DESCRIPTION
Closes #1233.

## Root cause

`FederationInstance.get()` does find-or-create inline. On the first authorized GET with no Instance row it generates a keypair and writes the seed to the keystore — which is unconditionally `homedir()`-relative (`src/keystore.ts` `keysDir()`). On a deployment shape where HOME is not writable (the Fabric-managed hub, the #812 ENOTDIR class), that write throws, the keystore's fail-closed guard — correct for CREATION — aborts the READ with a 500, and the hub's federation state is unobservable by an operator at all.

## Fix (read path only; signing stays fail-closed)

**`resources/Federation.ts` — `FederationInstance.get()`**
- `Instance.put()` kept (public identity data). A keystore write failure no longer throws: it is logged server-side (actor + state + remedy, error class included) and surfaced as a **runtime-only** `signingKeyAvailable: false` field on the GET response. Not `/Health`, not the persisted status enum — transient machine state stays runtime (K&S ruling on the spec).
- `signingKeyAvailable: true` when the write succeeded; existing-identity GETs probe the keystore read-only (`getPrivateKeySeed !== null`, never throws) so the field is truthful in steady state too.
- The bare `catch { /* table may not exist */ }` around the Instance search now logs the swallowed error class — absent-table (expected on genuine first boot) and a real read error are distinguishable in server logs. Behavior unchanged: the create branch still fires when the search finds nothing.

**`src/cli.ts` — `federation status`**
- The instance and peers reads are caught **independently**: print what's available, mark the rest unverifiable, never abort the whole render — extending the fail-open principle `latestPeerContact`'s own docstring states. The driver verdict (flair#922) is only computed when the peer read succeeded.
- Exception, deliberate: **auth-shaped failures (401/403) stay fatal** with the existing flair#634 remedy UX even if the other read succeeded — both endpoints sit behind the same `allowAdmin` gate, so bad credentials are a session property, and "unverifiable" would swallow the actionable remedy. (Caught live by `test/unit/local-no-auth.test.ts` during development.)
- Degraded marker when `signingKeyAvailable` is false — actor + state + remedy: names the server-side keystore path (`$HOME/.flair/keys` under the Harper process's HOME) and the permission fix. Exit 0: the status itself succeeded.
- JSON mode keeps its `{instance, peers, driver, driverAssessment}` shape and adds an `unverifiable` map only when a read failed.

**`loadInstanceSecretKey` error text**
- Dropped the impossible "Re-run 'flair federation status' to regenerate" advice (the create branch only fires when NO row exists). Now names the expected keystore file path and the real remedies: restore the key file (+ `FLAIR_KEY_PASSPHRASE` if one was set), or re-key (delete the Instance row and re-pair).

**Untouched:** pair/sync signing paths keep their fail-closed throws — the missing key still fails at its correct point of use.

## Tests — `test/integration/federation-status-keystore-1233.test.ts`

A **sibling file** rather than a new describe in `gate4-authgate.test.ts`: gate4 boots one shared Harper for four resource-gate suites and its admin GET creates the identity with a *working* keystore; this file's core scenario is keystore-broken-**before**-first-identity-creation, which needs its own boot lifecycle (and mutating the shared instance's HOME would poison gate4's other suites). Modeled on `migrations-provisioned-datadir.test.ts` (the #812 ENOTDIR blocker shape) + `cli-local-admin-pass-fallback.test.ts` (real-CLI subprocess pattern).

- **Blocked keystore** (real Harper, `<HOME>/.flair` replaced by a regular file — deterministic ENOTDIR for any user): first admin GET → 200 with identity + `signingKeyAvailable:false`; second GET proves the found-row probe path; CLI human render shows the degraded marker with keystore path + remedy, exit 0; CLI JSON carries the field.
- **First-boot control** (Kern's attack point, normal writable HOME): create branch fires, `signingKeyAvailable:true`, and the key file **really exists on disk** at `<HOME>/.flair/keys/<id>.key` — positive control that the blocker targets the actual write path. No degraded marker in the CLI render.
- **CLI independence** (mock servers — the only way to force exactly one endpoint to fail): instance-500s-peers-OK is byte-for-byte the #1233 field incident against an *unpatched* hub (the CLI half of the fix helps against old servers too); peers-500s-instance-OK renders the instance and says "Peers unverifiable", not "No peers configured"; both-fail exits 1; JSON `unverifiable` map.

### Red-on-main proof

New test file run against **unmodified origin/main** (fix stashed, rebuilt): exit 1, **4 pass / 9 fail**, the core one:

```
error: GET /FederationInstance returned 500: {"type":"error:Error","code":"Error","title":"Keystore unavailable — cannot create federation identity without secure key storage","status":500,"instance":"/FederationInstance"}
Expected: 200
Received: 500
```

Same file with the fix (rebuilt): exit 0, **13 pass / 0 fail, 46 expect() calls**.

### Mutation check

Restored the fail-closed throw inside the keystore catch → rebuilt → **red on exactly the 4 blocked-keystore tests** (`GET /FederationInstance returned 500: ... "MUTATION-CHECK: restored fail-closed throw"`); reverted → rebuilt → **13 pass / 0 fail**.

### Suites vs self-measured origin/main baseline (same machine, same session)

| Suite | origin/main | this branch |
|---|---|---|
| `bun test test/unit` (full, 243 files) | 4644 pass / 6 fail / 2 errors | 4644 pass / 6 fail / 2 errors — identical failures (`Memory.search()` boolean-injection guard ×4, pre-existing) |
| `gate4-authgate` + `cli-local-admin-pass-fallback` + `federation-sync-e2e` (integration) | 36 pass / 0 fail | 36 pass / 0 fail |
| `tsc --noEmit` | 1 pre-existing error (`resources/auth-middleware.ts:72`) | same single error |

The large `src/cli.ts` line count is mostly re-indentation from removing the action-wide try/catch; the behavioral hunks are the independent fetches, the auth-shaped gate, and the two markers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
