### PR TITLE
build: dist/build-info.json + buildCommit on /Health — the served code identifies itself

### DIFF
--- a/.changelog/unreleased/added-1076-build-info-stamp.md
+++ b/.changelog/unreleased/added-1076-build-info-stamp.md
@@ -1,0 +1,11 @@
+- **The build stamps its own identity, and the running server reports it
+  (#1076).** Both build scripts now write `dist/build-info.json` —
+  `{ version, commit, builtAt, builder }` — and `/Health` (plus the
+  authenticated `/HealthDetail`) gains an additive `buildCommit` field, with
+  `version` now served from that stamp rather than `package.json`. The served
+  code identifies itself: deploy verification asserts identity directly
+  (`grep` the stamp server-side, or `/Health` remotely) instead of hunting a
+  fresh dist-grep discriminator every release, and a stale `dist/` can no
+  longer masquerade as the version `package.json` claims. Builds outside a
+  git work tree (npm tarballs) stamp an honest `"commit": null` — the field
+  is never omitted and never fabricated.

--- a/docker/Dockerfile.clean-vm
+++ b/docker/Dockerfile.clean-vm
@@ -35,6 +35,7 @@ COPY src/ ./src/
 COPY resources/ ./resources/
 COPY schemas/ ./schemas/
 COPY packages/ ./packages/
+COPY scripts/write-build-info.mjs ./scripts/
 
 RUN bun install --frozen-lockfile
 RUN bun run build && bun run build:cli

--- a/docker/Dockerfile.test
+++ b/docker/Dockerfile.test
@@ -24,6 +24,7 @@ COPY src/ ./src/
 COPY resources/ ./resources/
 COPY schemas/ ./schemas/
 COPY packages/ ./packages/
+COPY scripts/write-build-info.mjs ./scripts/
 
 # Install dependencies
 RUN bun install --frozen-lockfile

--- a/package.json
+++ b/package.json
@@ -47,8 +47,8 @@
   "scripts": {
     "clean": "node -e \"require('fs').rmSync('dist',{recursive:true,force:true})\"",
     "prebuild": "npm run clean",
-    "build": "tsc -p tsconfig.json --noCheck",
-    "build:cli": "tsc -p tsconfig.cli.json --noCheck",
+    "build": "tsc -p tsconfig.json --noCheck && node scripts/write-build-info.mjs",
+    "build:cli": "tsc -p tsconfig.cli.json --noCheck && node scripts/write-build-info.mjs",
     "prepublishOnly": "npm run build && npm run build:cli",
     "test": "bun test",
     "test:e2e": "playwright test",

--- a/resources/build-info.ts
+++ b/resources/build-info.ts
@@ -1,0 +1,57 @@
+/**
+ * build-info.ts — read back the build-identity stamp the build wrote
+ * (flair#1076; the stamp itself is written by scripts/write-build-info.mjs
+ * at the end of both `build` and `build:cli`).
+ *
+ * WHY THE PATH IS MODULE-RELATIVE. The point of the stamp (Kern's ruling on
+ * #1076) is that the RUNNING server reports its own build identity — a
+ * file-only check proves the artifact on disk, not what the server loaded
+ * (the 0.25.0 stale-dist incident class). Compiled, this module executes as
+ * `dist/resources/build-info.js`, so `../build-info.json` is the stamp
+ * emitted by the very build whose modules Harper loaded (config.yaml's
+ * `jsResource: dist/resources/*.js`) — the same "resolve relative to THIS
+ * running module" idiom as resolveVersion() in resources/version.ts.
+ *
+ * When this module runs from SOURCE (a bun test importing resources/*.ts
+ * directly), `../build-info.json` is the repo root, where no stamp exists —
+ * the resolver returns null and callers fall back honestly (version from
+ * package.json, buildCommit served as null). A source run has no build, so
+ * it HAS no build identity; reaching over into dist/ would report someone
+ * else's.
+ *
+ * Read per call, not cached: identical lifecycle to resolveVersion()'s
+ * package.json read, and /Health stays a truthful view of the file rather
+ * than of whichever request happened to arrive first.
+ */
+import { existsSync, readFileSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+export interface BuildInfo {
+  version: string | null;
+  /** Full 40-hex sha, or null — an honest "built outside a git work tree"
+   *  (tarball builds). Never fabricated, never omitted (Sherlock, #1076). */
+  commit: string | null;
+  builtAt: string | null;
+  builder: string | null;
+}
+
+export function resolveBuildInfo(): BuildInfo | null {
+  try {
+    const here = dirname(fileURLToPath(import.meta.url));
+    const stampPath = join(here, "..", "build-info.json");
+    if (!existsSync(stampPath)) return null;
+    const raw = JSON.parse(readFileSync(stampPath, "utf-8"));
+    if (!raw || typeof raw !== "object") return null;
+    // Per-field validation, not a whole-object trust: a malformed stamp
+    // degrades field-by-field to null rather than inventing values.
+    return {
+      version: typeof raw.version === "string" && raw.version.length > 0 ? raw.version : null,
+      commit: typeof raw.commit === "string" && /^[0-9a-f]{40}$/.test(raw.commit) ? raw.commit : null,
+      builtAt: typeof raw.builtAt === "string" ? raw.builtAt : null,
+      builder: typeof raw.builder === "string" ? raw.builder : null,
+    };
+  } catch {
+    return null; // unreadable/corrupt stamp — same honest fallback as absent
+  }
+}

--- a/resources/health.ts
+++ b/resources/health.ts
@@ -4,6 +4,7 @@ import { homedir, platform } from "node:os";
 import { join, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 import { allowVerified, resolveAgentAuth } from "./agent-auth.js";
+import { resolveBuildInfo } from "./build-info.js";
 import { getMigrationStatusSnapshot } from "./migrations/status.js";
 import { resolveMigrationDataDirForRead } from "./migrations/data-dir.js";
 import { REM_DEDUP_STATS_PATH } from "./dedup-cluster.js";
@@ -82,7 +83,21 @@ export class Health extends Resource {
     // PUBLICLY over Fabric, the public surface must omit this field (the
     // richer, auth-gated /HealthDetail already carried version pre-existing —
     // this only adds it to the anonymous endpoint too).
-    return { ok: true, version: resolveVersion() };
+    //
+    // flair#1076: both values come from dist/build-info.json — the stamp the
+    // build wrote next to the modules Harper actually loaded — so /Health
+    // reports the identity of the SERVED code, not of whatever package.json
+    // sits on disk (the 0.25.0 stale-dist incident class; Kern's ruling).
+    // `version` falls back to the package.json resolver only when no stamp
+    // exists (source runs, pre-#1076 dists). `buildCommit` is ALWAYS present:
+    // a 40-hex sha when the build ran in a git work tree, an honest null
+    // otherwise (tarball builds) — never omitted, never fabricated (Sherlock).
+    const build = resolveBuildInfo();
+    return {
+      ok: true,
+      version: build?.version ?? resolveVersion(),
+      buildCommit: build?.commit ?? null,
+    };
   }
 }
 
@@ -614,10 +629,15 @@ export class HealthDetail extends Resource {
     stats.warnings = warnings;
 
     // ── Process info ──
-    // version: the RUNNING process's own package.json — used by `flair
-    // upgrade`'s post-restart verification (flair#635) to prove the new
-    // code is actually serving, not just installed on disk.
-    stats.version = resolveVersion();
+    // version: the RUNNING process's own build stamp (dist/build-info.json,
+    // flair#1076) — used by `flair upgrade`'s post-restart verification
+    // (flair#635) to prove the new code is actually serving, not just
+    // installed on disk. Falls back to the package.json resolver when no
+    // stamp exists; buildCommit mirrors /Health's field (always present,
+    // null when built outside a git work tree).
+    const build = resolveBuildInfo();
+    stats.version = build?.version ?? resolveVersion();
+    stats.buildCommit = build?.commit ?? null;
     stats.pid = process.pid;
     stats.uptimeSeconds = Math.floor(process.uptime());
 

--- a/scripts/write-build-info.mjs
+++ b/scripts/write-build-info.mjs
@@ -1,0 +1,66 @@
+#!/usr/bin/env node
+// write-build-info.mjs — stamp dist/build-info.json with the build's identity
+// (flair#1076).
+//
+// PROBLEM. dist/ carried no self-identification, so every fleet deploy proved
+// "the served code is new" by grepping dist/ for a marker chosen fresh from
+// each release's diff — per-release marker archaeology. And the server itself
+// could not report WHICH build it loaded (the 0.25.0 stale-dist incident
+// class: package.json says X, the loaded dist is older).
+//
+// FIX. Both build scripts (`build` and `build:cli`) end by running this, so a
+// dist/ tree always carries `{ version, commit, builtAt, builder }` alongside
+// the compiled modules it describes. resources/build-info.ts reads the file
+// back at request time and /Health serves it (resources/health.ts) — the
+// running server reports its own build identity.
+//
+// HONESTY (Sherlock ruling on #1076): `commit` is `git rev-parse HEAD` when
+// the build runs inside a git work tree, and an EXPLICIT null otherwise
+// (tarball builds — `npm install` from the packed tarball has no .git). A
+// null rendered as "unknown" downstream is fine; a fabricated sha is not, and
+// the key is always present — never silently omitted.
+//
+// Runs with cwd = the package root (how the package.json scripts invoke it);
+// everything below is cwd-relative so the stamp always describes the tree
+// being built, not wherever this script's source happens to live.
+
+import { execFileSync } from "node:child_process";
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+const root = process.cwd();
+
+const pkg = JSON.parse(readFileSync(join(root, "package.json"), "utf-8"));
+if (typeof pkg.version !== "string" || pkg.version.length === 0) {
+  console.error(`write-build-info: ${join(root, "package.json")} has no version — refusing to stamp an unidentifiable build`);
+  process.exit(1);
+}
+
+let commit = null;
+try {
+  const out = execFileSync("git", ["rev-parse", "HEAD"], {
+    cwd: root,
+    encoding: "utf-8",
+    // stderr ignored: outside a repo, git's complaint is expected noise — the
+    // null fallback below IS the correct answer there, not an error to print.
+    stdio: ["ignore", "pipe", "ignore"],
+    timeout: 10_000,
+  }).trim();
+  // Only a full 40-hex sha is a commit identity. Anything else (empty output,
+  // an odd wrapper mangling stdout) degrades to the honest null, never to a
+  // fabricated or truncated value.
+  if (/^[0-9a-f]{40}$/.test(out)) commit = out;
+} catch {
+  commit = null; // not a git work tree (e.g. building from the npm tarball)
+}
+
+const info = {
+  version: pkg.version,
+  commit,
+  builtAt: new Date().toISOString(),
+  builder: "tsc",
+};
+
+mkdirSync(join(root, "dist"), { recursive: true });
+writeFileSync(join(root, "dist", "build-info.json"), JSON.stringify(info, null, 2) + "\n");
+console.log(`write-build-info: dist/build-info.json ${info.version} @ ${commit ?? "null (no git work tree)"}`);

--- a/test/integration/health-build-info-e2e.test.ts
+++ b/test/integration/health-build-info-e2e.test.ts
@@ -1,0 +1,105 @@
+/**
+ * health-build-info-e2e.test.ts — flair#1076 against a REAL Harper instance:
+ * the running server reports its own build identity.
+ *
+ * Kern's ruling on #1076 is the shape of this file: a file-only check proves
+ * the artifact on disk, not what the server LOADED (the 0.25.0 stale-dist
+ * incident class) — so the load-bearing assertions here go through HTTP to a
+ * spawned Harper serving dist/resources/*.js, and require /Health's payload
+ * to EQUAL the stamp file field-for-field. The writer's own paths (git /
+ * no-git / no-version) are unit-covered in test/unit/build-info-stamp.test.ts.
+ *
+ * This file also carries the repo-identity assertion (stamp.version ===
+ * package.json version) that the deploy discriminator retires into — the
+ * release mutation-check target: stamp a wrong version into
+ * dist/build-info.json and "the stamp is this build's identity" goes red.
+ *
+ * Requires a built dist/ (bun run build) — same precondition as every file in
+ * this directory (config.yaml's jsResource loads dist/resources/*.js; the
+ * integration CI lane builds first).
+ */
+import { describe, expect, test, beforeAll, afterAll } from "bun:test";
+import { execFileSync } from "node:child_process";
+import { existsSync, readFileSync } from "node:fs";
+import { join, dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { startHarper, stopHarper, type HarperInstance } from "../helpers/harper-lifecycle";
+
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..", "..");
+const STAMP_PATH = join(REPO_ROOT, "dist", "build-info.json");
+
+let harper: HarperInstance;
+let stamp: { version: string; commit: string | null; builtAt: string; builder: string };
+
+describe("/Health serves the build's own identity (flair#1076)", () => {
+  beforeAll(async () => {
+    // Load the stamp BEFORE spawning: if the build didn't write it, fail here
+    // with the actionable cause, not downstream with a shapeless 404/null.
+    expect(
+      existsSync(STAMP_PATH),
+      `${STAMP_PATH} missing — run \`bun run build\` first; the build scripts write the stamp (flair#1076)`,
+    ).toBe(true);
+    stamp = JSON.parse(readFileSync(STAMP_PATH, "utf-8"));
+    harper = await startHarper();
+  }, 120_000);
+
+  afterAll(async () => {
+    if (harper) await stopHarper(harper);
+  });
+
+  test("identity: the stamp is THIS build's identity (version = package.json, builder = tsc)", () => {
+    // The deploy-verification identity check (`grep -o '"version": "X.Y.Z"'
+    // dist/build-info.json`) asserts exactly this equality server-side. The
+    // release mutation-check targets this test: stamp a wrong version into
+    // dist/build-info.json → red.
+    const pkg = JSON.parse(readFileSync(join(REPO_ROOT, "package.json"), "utf-8"));
+    expect(stamp.version).toBe(pkg.version);
+    expect(stamp.builder).toBe("tsc");
+    expect(Number.isFinite(new Date(stamp.builtAt).getTime())).toBe(true);
+  });
+
+  test("GET /Health: version and buildCommit come from the stamp the running server loaded", async () => {
+    const res = await fetch(`${harper.httpURL}/Health`);
+    expect(res.ok).toBe(true);
+    const body = (await res.json()) as { ok?: boolean; version?: string; buildCommit?: string | null };
+    expect(body.ok).toBe(true);
+    // Sherlock's honesty ruling: the field is ALWAYS present — a tarball
+    // build renders null, but the key is never silently omitted.
+    expect("buildCommit" in body).toBe(true);
+    // Field-for-field equality with the stamp — /Health is a truthful view of
+    // the file adjacent to the modules Harper loaded, not of package.json.
+    expect(body.version).toBe(stamp.version);
+    expect(body.buildCommit).toBe(stamp.commit);
+  });
+
+  test("this build ran in a git work tree, so buildCommit is a REAL 40-hex sha end-to-end", async () => {
+    // The null path is legitimate for tarball builds and unit-covered; HERE,
+    // built from a checkout, null (or anything but the tree's HEAD at build
+    // time) would be the stamp lying about a knowable fact.
+    const res = await fetch(`${harper.httpURL}/Health`);
+    const body = (await res.json()) as { buildCommit?: string | null };
+    expect(body.buildCommit).toMatch(/^[0-9a-f]{40}$/);
+  });
+
+  test("npm pack payload carries dist/build-info.json (dist/ ships wholesale)", () => {
+    // The stamp is only a deploy discriminator if it actually leaves the
+    // building machine. --dry-run --json lists the real pack payload from the
+    // files array; no tarball is written.
+    const out = execFileSync("npm", ["pack", "--dry-run", "--json"], {
+      cwd: REPO_ROOT,
+      encoding: "utf-8",
+      maxBuffer: 64 * 1024 * 1024,
+      timeout: 120_000,
+    });
+    // Output shape varies by npm major: <=11 prints an ARRAY of payloads,
+    // 12 prints an OBJECT keyed by package name (measured: npm 12.0.1).
+    type PackPayload = { files: Array<{ path: string }> };
+    const parsed = JSON.parse(out) as PackPayload[] | Record<string, PackPayload>;
+    const payload = Array.isArray(parsed)
+      ? parsed[0]
+      : (parsed["@tpsdev-ai/flair"] ?? Object.values(parsed)[0]);
+    expect(payload && Array.isArray(payload.files)).toBe(true);
+    const paths = payload.files.map((f) => f.path);
+    expect(paths).toContain("dist/build-info.json");
+  }, 120_000);
+});

--- a/test/unit/build-info-stamp.test.ts
+++ b/test/unit/build-info-stamp.test.ts
@@ -1,0 +1,125 @@
+/**
+ * build-info-stamp.test.ts — flair#1076, the writer half of the build-identity
+ * stamp: scripts/write-build-info.mjs, run exactly as the build scripts run it
+ * (`node scripts/write-build-info.mjs` with cwd = the package root).
+ *
+ * Each case builds an ISOLATED fake package root under mkdtemp — never the
+ * real repo — so the git-present and no-git paths are both driven explicitly
+ * rather than inherited from wherever the test process happens to run. The
+ * /Health-serves-the-stamp half (real ephemeral Harper) lives in
+ * test/integration/health-build-info-e2e.test.ts, which also carries the
+ * repo-identity assertion (dist stamp vs package.json) that the release
+ * mutation-check targets.
+ */
+import { describe, expect, test, afterAll } from "bun:test";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, readFileSync, realpathSync, rmSync, writeFileSync, existsSync } from "node:fs";
+import { join, dirname, resolve } from "node:path";
+import { tmpdir } from "node:os";
+import { fileURLToPath } from "node:url";
+import { resolveBuildInfo } from "../../resources/build-info";
+
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..", "..");
+const SCRIPT = join(REPO_ROOT, "scripts", "write-build-info.mjs");
+
+const cleanups: string[] = [];
+afterAll(() => {
+  for (const dir of cleanups) rmSync(dir, { recursive: true, force: true });
+});
+
+/** A throwaway package root containing only a package.json. realpath'd so the
+ *  paths git and the script see agree on macOS (/var/folders is a symlink). */
+function makePackageRoot(version: string): string {
+  const dir = realpathSync(mkdtempSync(join(tmpdir(), "flair-build-info-")));
+  cleanups.push(dir);
+  writeFileSync(join(dir, "package.json"), JSON.stringify({ name: "build-info-fixture", version }, null, 2));
+  return dir;
+}
+
+/** Env for spawning the script: inherited env minus any git redirection vars,
+ *  plus a discovery ceiling so `git rev-parse` can never wander up out of the
+ *  fixture and report some OTHER repo's HEAD (or this one's). */
+function scriptEnv(fixtureDir: string): Record<string, string> {
+  const env: Record<string, string> = { ...process.env as Record<string, string> };
+  delete env.GIT_DIR;
+  delete env.GIT_WORK_TREE;
+  delete env.GIT_INDEX_FILE;
+  env.GIT_CEILING_DIRECTORIES = dirname(fixtureDir);
+  return env;
+}
+
+function runScript(cwd: string): string {
+  return execFileSync("node", [SCRIPT], { cwd, env: scriptEnv(cwd), encoding: "utf-8" });
+}
+
+describe("scripts/write-build-info.mjs (flair#1076)", () => {
+  test("git work tree: stamps {version, commit, builtAt, builder} with the tree's real HEAD", () => {
+    const dir = makePackageRoot("9.9.9-test");
+    execFileSync("git", ["init", "-q"], { cwd: dir, env: scriptEnv(dir) });
+    execFileSync(
+      "git",
+      ["-c", "user.email=fixture@test", "-c", "user.name=fixture", "commit", "--allow-empty", "-q", "-m", "stamp fixture"],
+      { cwd: dir, env: scriptEnv(dir) },
+    );
+    const head = execFileSync("git", ["rev-parse", "HEAD"], { cwd: dir, env: scriptEnv(dir), encoding: "utf-8" }).trim();
+    expect(head).toMatch(/^[0-9a-f]{40}$/); // fixture sanity — the expected value is itself well-formed
+
+    const before = Date.now();
+    runScript(dir);
+
+    const stampPath = join(dir, "dist", "build-info.json");
+    expect(existsSync(stampPath)).toBe(true);
+    const stamp = JSON.parse(readFileSync(stampPath, "utf-8"));
+    expect(stamp.version).toBe("9.9.9-test");
+    expect(stamp.commit).toBe(head);
+    expect(stamp.builder).toBe("tsc");
+    // builtAt: a real ISO instant from THIS run, not a placeholder.
+    const builtAt = new Date(stamp.builtAt).getTime();
+    expect(Number.isFinite(builtAt)).toBe(true);
+    expect(Math.abs(builtAt - before)).toBeLessThan(60_000);
+  });
+
+  test("non-git dir (tarball build): commit is an EXPLICIT null — present in the JSON, never omitted", () => {
+    const dir = makePackageRoot("7.7.7-tarball");
+    runScript(dir);
+
+    const raw = readFileSync(join(dir, "dist", "build-info.json"), "utf-8");
+    const stamp = JSON.parse(raw);
+    expect(stamp.version).toBe("7.7.7-tarball");
+    // Sherlock's honesty ruling on #1076, both halves: the KEY must exist
+    // (never silently omitted) and the VALUE must be null (never fabricated).
+    expect(Object.hasOwn(stamp, "commit")).toBe(true);
+    expect(stamp.commit).toBeNull();
+    // And it is grep-ably explicit in the serialized file — the server-side
+    // deploy check reads this file with grep, not a JSON parser.
+    expect(raw).toContain('"commit": null');
+    expect(stamp.builder).toBe("tsc");
+  });
+
+  test("a package.json without a version fails the build loudly instead of stamping an unidentifiable dist", () => {
+    const dir = realpathSync(mkdtempSync(join(tmpdir(), "flair-build-info-")));
+    cleanups.push(dir);
+    writeFileSync(join(dir, "package.json"), JSON.stringify({ name: "no-version-fixture" }));
+    expect(() => runScript(dir)).toThrow(); // exit 1
+    expect(existsSync(join(dir, "dist", "build-info.json"))).toBe(false);
+  });
+
+  test("files-array ride-along: package.json ships dist/ wholesale, so the stamp rides into the npm payload", () => {
+    // The pack payload itself is asserted end-to-end (npm pack --dry-run) in
+    // test/integration/health-build-info-e2e.test.ts, which runs with a built
+    // dist/. This half pins the MECHANISM it relies on: the files array
+    // entry is the whole directory, not a glob that could strand a non-.js
+    // file. If someone narrows "dist/" this fails while the author still has
+    // the context.
+    const pkg = JSON.parse(readFileSync(join(REPO_ROOT, "package.json"), "utf-8"));
+    expect(pkg.files).toContain("dist/");
+  });
+
+  test("resolveBuildInfo() from a source run (no stamp adjacent to the module) is an honest null", () => {
+    // Imported as resources/build-info.ts, the module-relative stamp path is
+    // <repo-root>/build-info.json. Prove the precondition, then the fallback:
+    // no stamp → null → /Health would serve buildCommit: null, not a guess.
+    expect(existsSync(join(REPO_ROOT, "build-info.json"))).toBe(false);
+    expect(resolveBuildInfo()).toBeNull();
+  });
+});


### PR DESCRIPTION
## What

Closes #1076 — dist/ records its own build identity, and the running server reports it. The per-release deploy-discriminator hunt (grep dist/ for a marker chosen fresh from each release's diff) retires into one mechanism.

**1. The build stamps its identity.** Both `build` and `build:cli` end by running `scripts/write-build-info.mjs`, which writes `dist/build-info.json`:

```json
{
  "version": "0.46.0",
  "commit": "a1e468bf9634603b1ad48602b02dd14939066d68",
  "builtAt": "2026-08-21T13:53:18.166Z",
  "builder": "tsc"
}
```

- `version` from `package.json`; a version-less package.json fails the build loudly rather than stamping an unidentifiable dist.
- `commit` from `git rev-parse HEAD`, validated as a full 40-hex sha. Builds outside a git work tree (npm tarball builds) stamp an **explicit** `"commit": null` — the key is never omitted, and a sha is never fabricated or truncated. The serialized file carries `"commit": null` grep-ably, because the server-side deploy check reads this file with grep, not a JSON parser.

**2. The running server reports it.** New `resources/build-info.ts` resolves the stamp module-relative — compiled, that is `dist/resources/*` → `../build-info.json`, the file adjacent to the modules Harper actually loaded (config.yaml's `jsResource: dist/resources/*.js`). `/Health` (public, unauthenticated) now serves:

```json
{ "ok": true, "version": "<stamp.version>", "buildCommit": "<stamp.commit | null>" }
```

`buildCommit` is additive and **always present** (null when unknown, never silently omitted). `version` is now served from the stamp — the identity of the served code, not of whatever `package.json` sits on disk — with a fallback to the existing package.json resolver only when no stamp exists (source runs, pre-existing dists). `/HealthDetail` mirrors both fields, which is what `flair upgrade`'s post-restart verification reads. A file-only check proves the artifact on disk, not what the server loaded; this closes the stale-dist masquerade class the issue names.

**3. It ships.** `files` already carries `dist/` wholesale, so the stamp rides into the npm payload automatically — asserted, not assumed (see tests).

Deploy verification then asserts identity directly — `grep -o '"version": "X.Y.Z"' dist/build-info.json` server-side, or `/Health` remotely — every release, no more marker archaeology.

## Tests

- `test/unit/build-info-stamp.test.ts` (5, isolated fixture roots — never the repo): a git work tree stamps the fixture repo's **real HEAD**; a non-git dir stamps an explicit `"commit": null` (key present, value null, grep-able in the raw text); a version-less package.json exits non-zero and writes nothing; the files array ships `dist/` (the mechanism the pack ride-along relies on); the resolver returns an honest null on a source run with no stamp.
- `test/integration/health-build-info-e2e.test.ts` (4, real ephemeral Harper serving the built dist): the stamp is this build's identity (`version` = package.json, `builder` = `"tsc"`) — the release mutation-check target; `GET /Health` serves `version` + `buildCommit` **field-for-field from the stamp**, with the key required present; `buildCommit` is a real 40-hex sha end-to-end over HTTP; `npm pack --dry-run --json` payload contains `dist/build-info.json` (npm ≤11 array and npm 12 keyed-object output shapes both handled — measured on npm 12.0.1).

**Mutation check (run, then restored):** stamped `"version": "0.0.0-mutant"` into `dist/build-info.json` → exactly the identity test went red (`Expected: "0.46.0", Received: "0.0.0-mutant"`) while the truthful-view /Health tests stayed green — they assert the served payload equals the file, and the server truthfully served the mutated file. Restored by rebuilding.

**Runs (this branch vs self-measured origin/main baseline, same machine):**

| suite | baseline (origin/main) | this branch |
|---|---|---|
| unit lane (`bun test test/unit/ test/*.test.ts`) | 4840 pass / 0 fail, 252 files | 4845 pass / 0 fail, 253 files |
| touched integration (`version-handshake-e2e`, `probe-instance` [+ new `health-build-info-e2e`]) | 8 pass / 0 fail, 2 files | 12 pass / 0 fail, 3 files |

`changelog-fragments.mjs check`, `check-version-sync.mjs` (11 sites), and `check-imports.mjs dist` (185 files, 0 failures) all green; changelog fragment included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
