### PR TITLE
connector principal mapping: the two-identity integration test + provisioning legibility (distinct-by-default formalized)

### DIFF
--- a/.changelog/unreleased/added-1280-connector-principal-mapping.md
+++ b/.changelog/unreleased/added-1280-connector-principal-mapping.md
@@ -1,0 +1,20 @@
+- **Connector principal mapping: distinct identities formalized, with the
+  two-identity integration test (flair#1280).** An OAuth `/mcp` connector's
+  token subject resolves to whatever Agent its `Credential(kind:"idp")`
+  mapping names — deliberately NOT constrained to be your CLI agent
+  (per-purpose connector identities are the product pattern; same-identity is
+  an explicit opt-in). What changed is legibility, not the model: `flair mcp
+  enable`'s identity-mapping step now states the resulting `sub → Agent`
+  mapping in as many words (plus the link remedy and the
+  `bootstrap.agentId`/`scope` diagnostic), `flair agent add` notes that a
+  connector is a distinct identity and prints the exact link command, and
+  `docs/notes/mcp-oauth-model2.md` documents the linking flow — re-running
+  `flair mcp enable --principal <agent> --idp-subject <sub>` re-points the
+  existing `(provider, subject)` Credential — including the JIT
+  `idpProvider: "mcp-oauth"` caveat. The contract is pinned end-to-end by
+  `test/integration/mcp-connector-principal-mapping.test.ts`, which drives the
+  real `mcpHandler`/`resolveAgentFromSub` (no hand-built principal contexts)
+  against a real store with two registered identities: cross-principal reads
+  see org-non-private rows and never private ones (404-never-403 by id),
+  bootstrap self-describes the resolved agent, and linking makes the connector
+  see exactly what the linked agent sees.

--- a/docs/notes/mcp-oauth-model2.md
+++ b/docs/notes/mcp-oauth-model2.md
@@ -46,6 +46,48 @@ context, so the wrapped handler scopes to the verified agent exactly as an
 Ed25519-signed REST call would. Identity always comes from the resolved agent,
 never from the tool arguments (no forging of agentId / authorId).
 
+### Which Agent is my connector? (distinct-by-default — flair#1280)
+
+**The connector's Agent is whatever the `Credential(kind:"idp")` mapping says
+— and that is NOT constrained to be your CLI agent.** Distinct identities are
+the ruled default (flair#1280): per-purpose connector identities are the
+product pattern for org/service installs, and same-identity is a deliberate
+opt-in, never something the server infers. The practical consequences:
+
+- **Where the mapping is decided.** `flair mcp enable --principal <agent-id>
+  --idp-subject <sub>` (the identity-mapping step, backed by
+  `provisionIdpIdentityMapping`) writes the mapping. The `--principal` you pass
+  is the Agent every `/mcp` call will read and write as. Pass an EXISTING
+  agent id to attach the sub to it; the step's output states the resulting
+  `sub → Agent` mapping in as many words.
+- **Linking a sub to an existing Agent (the same-identity opt-in).** Re-run
+  `flair mcp enable` with the SAME `--idp-provider`/`--idp-subject` and
+  `--principal <your-cli-agent-id>`. The existing `(provider, subject)`
+  Credential is RE-POINTED to that principal — one Credential row per subject,
+  so resolution stays deterministic. The link *replaces* the mapping; it does
+  not merge the two agents' memories.
+- **First diagnostic: ask the server who you are.** The `bootstrap` tool's
+  response always carries the resolved `agentId` and a `scope` descriptor
+  (`scope.agentId` / `scope.isAdmin` / `scope.reads`, flair#1182). "My memory
+  is empty over the connector" + a `bootstrap.agentId` you don't recognize =
+  the sub resolved to a different (often JIT-provisioned) Agent — link it as
+  above.
+- **JIT caveat.** A JIT-provisioned mapping (`FLAIR_MCP_JIT_PROVISION=1`)
+  stamps `idpProvider: "mcp-oauth"`. Runtime resolution matches on
+  `(kind, idpSubject)` only, but the *linking* upsert matches on
+  `(kind, idpProvider, idpSubject)` — so when re-linking a JIT-provisioned
+  sub, pass `--idp-provider mcp-oauth` (matching the JIT stamp), or first
+  revoke the JIT credential (`status: "revoked"`). Linking under a different
+  provider name creates a SECOND active credential for the same subject, and
+  which one wins resolution is unspecified.
+
+The two-identity contract (a distinct connector agent sees other agents'
+org-non-private rows, never their private rows, 404-never-403 by id; a linked
+connector sees exactly what the linked agent sees) is pinned end-to-end by
+`test/integration/mcp-connector-principal-mapping.test.ts`, which drives the
+real `mcpHandler`/`resolveAgentFromSub` against a real store with two
+registered identities.
+
 ## Enabling (operator checklist)
 
 1. **Install the AS plugin** — add `@harperfast/oauth` (already an exact-pinned

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -4483,6 +4483,15 @@ agent
     );
     console.log(`   Private key: ${privPath}`);
     console.log(`   Public key:  ${pubKeyB64url}`);
+    // flair#1280 — connector legibility at provisioning time: an OAuth /mcp
+    // connector resolves its own token subject to an Agent via
+    // Credential(kind:idp), NOT via this key, and the two identities are
+    // DISTINCT unless linked. One line here saves the "my connector memory is
+    // empty" discovery later.
+    console.log(
+      `   Note: an OAuth /mcp connector maps its own IdP subject to an Agent (distinct from '${id}' by default).\n` +
+        `   To point a connector at '${id}': flair mcp enable --principal ${id} --idp-subject <your-idp-login>`,
+    );
   });
 
 agent

--- a/src/lib/mcp-enable.ts
+++ b/src/lib/mcp-enable.ts
@@ -1340,9 +1340,19 @@ export async function enableMcp(params: EnableMcpParams, deps: EnableMcpDeps = {
       },
       { fetchImpl: deps.fetchImpl, now: deps.now },
     );
+    // flair#1280 — provisioning legibility: distinct identities are the
+    // DEFAULT (a connector sub is not your CLI agent unless you link them),
+    // and the one silent failure mode this surface has is discovering that
+    // via an empty bootstrap. So the step that creates the mapping states it
+    // plainly, names the link remedy, and points at the runtime diagnostic.
     push(true,
-      `principal '${principal}' ${mapping.principalCreated ? "created" : "already existed"}; ` +
-        `Credential(kind:idp) ${mapping.credentialReused ? "reused" : "created"} (${mapping.credentialId})`,
+      `connector identity: sub '${params.idpSubject}' (provider '${idpProvider}') resolves to Agent '${principal}' — ` +
+        `every /mcp call reads and writes AS '${principal}'. ` +
+        `principal ${mapping.principalCreated ? "created" : "already existed"}; ` +
+        `Credential(kind:idp) ${mapping.credentialReused ? "re-pointed" : "created"} (${mapping.credentialId}). ` +
+        `If your CLI signs as a DIFFERENT agent id, the connector sees that agent's DISTINCT memory scope (by design) — ` +
+        `re-run with --principal <your-agent-id> to link them. ` +
+        `Diagnostic: the bootstrap tool's agentId/scope fields always say who the server resolved you to.`,
     );
 
     // ── Gate: confirm the staged secrets are actually live before restarting ─

--- a/test/fixtures/inproc-app/resources/AgentFleet.js
+++ b/test/fixtures/inproc-app/resources/AgentFleet.js
@@ -254,6 +254,29 @@ async function mcpToolViaImpl(agentId, tool, args, isAdmin) {
   return entry.impl({ agentId, isAdmin: isAdmin === true, clientId: undefined }, args ?? {});
 }
 
+// ─── flair#1280 — the REAL /mcp handler, driven with a verified-token shape ───
+//
+// Every other op above hands the tools a HAND-BUILT `{ agentId, isAdmin }` —
+// which bypasses `resolveAgentFromSub` entirely, the exact fixture gap the
+// #1181 investigation documented. This op instead drives the SHIPPED
+// `resources/mcp-handler.ts` `mcpHandler` with `request.mcp = { sub }` — the
+// same post-`withMCPAuth` shape production hands it — so the REAL
+// `Credential(kind:"idp", idpSubject=sub)` lookup runs against the REAL store
+// and the resolved principal (not the caller's claim) scopes the tool call.
+// The only production layer not in the loop is `withMCPAuth`'s RS256 JWT
+// verification itself (an @harperfast/oauth concern with its own coverage);
+// everything from `request.mcp.sub` down is the shipped code path.
+async function mcpRpc(sub, rpc, clientId) {
+  const { mcpHandler } = await import("../node_modules/@tpsdev-ai/flair/dist/resources/mcp-handler.js");
+  const mcp = {};
+  if (sub != null) mcp.sub = sub;
+  if (clientId != null) mcp.client_id = clientId;
+  const res = await mcpHandler({ method: "POST", mcp, body: JSON.stringify(rpc) });
+  let parsed = null;
+  try { parsed = res?.body ? JSON.parse(res.body) : null; } catch { parsed = { unparseable: String(res?.body).slice(0, 400) }; }
+  return { status: res?.status, rpc: parsed };
+}
+
 /**
  * The DELIBERATELY unfiltered read — every agent's private records, by name.
  * `internalContext()` is what an infrastructure sweep asks for on purpose; an
@@ -354,6 +377,8 @@ export class AgentFleet extends Resource {
         return run(() => bootstrapViaMcp(body.agentId, body.args));
       case "mcpTool":
         return run(() => mcpToolViaImpl(body.agentId, body.tool, body.args, body.isAdmin));
+      case "mcpRpc":
+        return run(() => mcpRpc(body.sub, body.rpc, body.clientId));
       case "buildContextWith":
         return run(() => buildContextWith(body.agentId));
       case "createWithNoContext":

--- a/test/integration/mcp-connector-principal-mapping.test.ts
+++ b/test/integration/mcp-connector-principal-mapping.test.ts
@@ -1,0 +1,358 @@
+// ─── flair#1280 — OAuth connector principal mapping: the two-identity test ────
+//
+// Design ruling (issue #1280, Kern-approved): DISTINCT identities are a
+// feature; the defect is that ACCIDENTAL distinctness is silent. A connector's
+// token `sub` resolves through `Credential(kind:"idp", idpSubject=sub)` →
+// `principalId`, and nothing constrains that Agent to be the operator's CLI
+// identity. When they differ, every read over the connector is *correctly*
+// scoped to an agent that owns nothing — "my memory is empty" with no error
+// anywhere. The remedy is legibility (bootstrap self-describes; docs state the
+// mapping + the LINK opt-in), not same-principal defaulting magic.
+//
+// THE FIXTURE GAP THIS CLOSES (the #1181-investigation finding): no test
+// anywhere drove the real `resolveAgentFromSub` against real Harper with TWO
+// identities. Every integration suite hands tools a hand-built
+// `{ agentId, isAdmin }` (bypassing Credential resolution entirely), and the
+// one faithful OAuth-principal fixture (test/unit/mcp-handler.test.ts) only
+// ever runs against mocked handler doubles. This suite drives the SHIPPED
+// `mcpHandler` — `request.mcp = { sub }`, the post-`withMCPAuth` shape — via
+// the inproc-app fixture's `mcpRpc` op, so the real Credential lookup, the
+// real tool wrappers, and the real read-scope gates all run against a real
+// store. (The only production layer out of the loop is `withMCPAuth`'s RS256
+// JWT verification itself, which has its own coverage.)
+//
+// The identities:
+//   AGENT_A — the "operator's CLI" identity. Writes an org-non-private row and
+//             a private row directly (the fixture's in-process seam).
+//   AGENT_B — the connector's own, deliberately distinct identity. The token
+//             sub is provisioned to B through the REAL supported flow —
+//             `provisionIdpIdentityMapping` (src/lib/mcp-enable.ts), the exact
+//             function `flair mcp enable`'s identity-mapping step calls.
+//
+// The contract pinned (per the ruling, distinct-by-default formalized):
+//   (a) sub-resolved B sees A's org-non-private rows and NEVER A's private
+//       rows (search), with in-band positive controls so the never-sees
+//       assertions are proven able to fire;
+//   (b) B's bootstrap SELF-DESCRIBES as B (agentId + scope fields) — the
+//       first diagnostic for "why is my connector memory empty";
+//   (c) by-id GET on A's private row is 404 (the #1264 404-never-403 posture),
+//       while A's non-private row IS by-id readable cross-principal (control);
+//   (d) LINKING — the documented same-identity opt-in: re-running
+//       provisionIdpIdentityMapping with the SAME (provider, subject) and
+//       principal=A re-points the SAME Credential row (no duplicate; resolution
+//       stays deterministic), after which the connector sees exactly what A
+//       sees — including NO LONGER seeing B's private rows (the link replaces
+//       the mapping, it does not union identities).
+//
+// MUTATION PROOF (fixture can express leakage): flip PRIVATE_VISIBILITY below
+// to "shared" and the never-sees-private assertions in (a)/(c) FAIL — the
+// shared-row positive controls run the identical query/read shapes, so a leak
+// is observable by construction, not vacuously absent.
+//
+// Ordering: bun runs tests in declaration order; (d) re-points the credential,
+// so every sub→B assertion deliberately precedes it.
+import { describe, expect, test, beforeAll, afterAll } from "bun:test";
+import { mkdtemp, rm, mkdir, cp, symlink } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { startHarper, stopHarper, HarperInstance } from "../helpers/harper-lifecycle";
+import { provisionIdpIdentityMapping } from "../../src/lib/mcp-enable.ts";
+
+const REPO_ROOT = process.cwd();
+const FIXTURE = join(REPO_ROOT, "test", "fixtures", "inproc-app");
+
+let harper: HarperInstance;
+let appDir: string;
+let opsPort: number;
+
+const sfx = Date.now().toString(36);
+const AGENT_A = `pm-cli-a-${sfx}`; // the operator's CLI identity
+const AGENT_B = `pm-conn-b-${sfx}`; // the connector's distinct identity
+const SUB = `pm-idp-sub-${sfx}`; // the IdP subject the token carries
+const PROVIDER = "github"; // same provider on provision AND link (see docs note)
+
+// Single rare tokens so the BM25 lane surfaces them even keyword-only
+// (pattern: mcp-wrapper-layer-suite's SEARCH_TOKEN).
+const SHARED_MARKER = `pmshared${sfx}`;
+const PRIVATE_MARKER = `pmprivate${sfx}`;
+const B_MARKER = `pmconnown${sfx}`;
+
+// MUTATION KNOB — set to "shared" and the never-sees-private assertions below
+// MUST fail (verified at authoring time); restore to "private".
+const PRIVATE_VISIBILITY = "private";
+
+let sharedId: string; // A's org-non-private row
+let privateId: string; // A's private row
+let bPrivateId: string; // B's own private row, written OVER THE CONNECTOR
+let firstCredentialId: string;
+
+/** Drive one in-process fixture op (POST /AgentFleet). */
+async function fleet(op: string, body: Record<string, unknown> = {}): Promise<any> {
+  const res = await fetch(`${harper.httpURL}/AgentFleet/`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: "Basic " + btoa(`${harper.admin.username}:${harper.admin.password}`),
+    },
+    body: JSON.stringify({ op, ...body }),
+  });
+  const text = await res.text();
+  if (!res.ok) throw new Error(`AgentFleet ${op} → HTTP ${res.status}: ${text.slice(0, 400)}`);
+  return JSON.parse(text);
+}
+
+/**
+ * One JSON-RPC tools/call through the REAL mcpHandler, as the given sub.
+ * Returns the parsed JSON-RPC response object.
+ */
+async function mcpCall(sub: string, tool: string, args: Record<string, unknown> = {}): Promise<any> {
+  const out = await fleet("mcpRpc", {
+    sub,
+    rpc: { jsonrpc: "2.0", id: 1, method: "tools/call", params: { name: tool, arguments: args } },
+  });
+  expect(out.ok, `mcpRpc transport failed: ${JSON.stringify(out).slice(0, 400)}`).toBe(true);
+  return out.value.rpc;
+}
+
+/** The tool payload (structuredContent) of a NON-error tools/call, asserted so. */
+async function mcpTool(sub: string, tool: string, args: Record<string, unknown> = {}): Promise<any> {
+  const rpc = await mcpCall(sub, tool, args);
+  expect(rpc?.error, `tools/call ${tool} returned a JSON-RPC error: ${JSON.stringify(rpc?.error)}`).toBeUndefined();
+  return rpc.result?.structuredContent;
+}
+
+/** Read records straight out of storage, past every resource-level gate. */
+async function adminSearch(table: string, attribute: string, value: string): Promise<any[]> {
+  const res = await fetch(harper.opsURL, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: "Basic " + btoa(`${harper.admin.username}:${harper.admin.password}`),
+    },
+    body: JSON.stringify({
+      operation: "search_by_value",
+      database: "flair",
+      table,
+      search_attribute: attribute,
+      search_value: value,
+      get_attributes: ["*"],
+    }),
+  });
+  const body = await res.json().catch(() => []);
+  return Array.isArray(body) ? body : [];
+}
+
+beforeAll(async () => {
+  appDir = await mkdtemp(join(tmpdir(), "flair-inproc-principal-"));
+  await cp(FIXTURE, appDir, { recursive: true });
+  await mkdir(join(appDir, "node_modules", "@tpsdev-ai"), { recursive: true });
+  await symlink(REPO_ROOT, join(appDir, "node_modules", "@tpsdev-ai", "flair"), "dir");
+  harper = await startHarper({ cwd: appDir, harperBinDir: REPO_ROOT });
+  opsPort = Number(new URL(harper.opsURL).port);
+
+  // Two REGISTERED identities — full Principal shape via the Agent resource.
+  await fleet("register", { id: AGENT_A });
+  await fleet("register", { id: AGENT_B });
+
+  // Provision sub → B through the REAL supported flow (the same call `flair
+  // mcp enable --principal <id> --idp-subject <sub>` makes on its
+  // identity-mapping step), against the REAL ops API.
+  const mapping = await provisionIdpIdentityMapping({
+    opsPortOrUrl: opsPort,
+    adminUser: harper.admin.username,
+    adminPass: harper.admin.password,
+    principal: AGENT_B,
+    principalKind: "agent",
+    idpProvider: PROVIDER,
+    idpSubject: SUB,
+  });
+  // The flow ATTACHED to the existing B — it did not mint a shadow principal.
+  expect(mapping.principalCreated).toBe(false);
+  expect(mapping.credentialReused).toBe(false);
+  firstCredentialId = mapping.credentialId;
+
+  // A's two rows, written directly (the operator's own seam).
+  const shared = await fleet("remember", { agentId: AGENT_A, content: `org-visible note ${SHARED_MARKER}`, visibility: "shared" });
+  expect(shared.ok).toBe(true);
+  sharedId = shared.value?.id;
+  const priv = await fleet("remember", { agentId: AGENT_A, content: `owner-only note ${PRIVATE_MARKER}`, visibility: PRIVATE_VISIBILITY });
+  expect(priv.ok).toBe(true);
+  privateId = priv.value?.id;
+  expect(typeof sharedId).toBe("string");
+  expect(typeof privateId).toBe("string");
+}, 300_000);
+
+afterAll(async () => {
+  const dataDir = harper?.installDir;
+  if (harper) await stopHarper(harper);
+  if (dataDir) await rm(dataDir, { recursive: true, force: true, maxRetries: 4 });
+  if (appDir) await rm(appDir, { recursive: true, force: true });
+});
+
+describe("flair#1280 — connector principal mapping (distinct-by-default, formalized)", () => {
+  test("GROUND TRUTH: the seeded Credential + Memory rows are what the contract needs them to be", async () => {
+    // Exactly ONE idp Credential maps the sub, and it points at B.
+    const creds = (await adminSearch("Credential", "idpSubject", SUB)).filter((c) => c.kind === "idp");
+    expect(creds.length).toBe(1);
+    expect(creds[0].principalId).toBe(AGENT_B);
+    expect(creds[0].status).toBe("active");
+
+    // A's rows landed with the visibilities the assertions below key on. If
+    // the MUTATION KNOB is flipped, this test fails FIRST, naming the fixture.
+    const [storedShared] = await adminSearch("Memory", "id", sharedId);
+    expect(storedShared?.agentId).toBe(AGENT_A);
+    expect(storedShared?.visibility).toBe("shared");
+    const [storedPriv] = await adminSearch("Memory", "id", privateId);
+    expect(storedPriv?.agentId).toBe(AGENT_A);
+    expect(storedPriv?.visibility).toBe("private");
+  }, 120_000);
+
+  test("an UNMAPPED sub is denied live (JIT default-OFF): no anonymous, no admin, no tool run", async () => {
+    const rpc = await mcpCall(`pm-ghost-${sfx}`, "memory_search", { query: SHARED_MARKER, limit: 5 });
+    expect(rpc.error?.message).toContain("not a provisioned flair agent");
+  }, 120_000);
+
+  test("the connector WRITES as the RESOLVED agent (B) — attribution comes from the Credential, never the payload", async () => {
+    const echo = await mcpTool(SUB, "memory_store", {
+      content: `connector-written owner-only note ${B_MARKER}`,
+      visibility: "private",
+      // A forged agentId in the arguments must be ignored (resolution wins).
+      agentId: AGENT_A,
+    });
+    bPrivateId = echo?.id;
+    expect(typeof bPrivateId, `memory_store echo missing id: ${JSON.stringify(echo)}`).toBe("string");
+    const [stored] = await adminSearch("Memory", "id", bPrivateId);
+    expect(stored?.agentId, "the connector write must be attributed to the sub-RESOLVED agent B").toBe(AGENT_B);
+    expect(stored?.visibility).toBe("private");
+  }, 120_000);
+
+  test("(a) search as the connector: A's org-non-private row IS visible; A's private row NEVER is", async () => {
+    // OWNER CONTROL — the private row is real, indexed and owner-readable, so
+    // the absence below is a scope denial, not an indexing failure.
+    const ownerView = await fleet("semanticRecall", { agentId: AGENT_A, q: PRIVATE_MARKER, limit: 20 });
+    expect(ownerView.ok).toBe(true);
+    expect(
+      ownerView.value.some((r: any) => r.id === privateId),
+      "A must find its own private row (owner control)",
+    ).toBe(true);
+
+    // POSITIVE (and the leak instrument's control): the IDENTICAL query shape
+    // over the connector DOES surface A's org-non-private row cross-principal.
+    const sharedHits = await mcpTool(SUB, "memory_search", { query: SHARED_MARKER, limit: 20 });
+    expect(Array.isArray(sharedHits?.results), `memory_search must return results: ${JSON.stringify(sharedHits).slice(0, 300)}`).toBe(true);
+    const sharedHit = sharedHits.results.find((r: any) => r.id === sharedId);
+    expect(sharedHit, "the connector (B) must see A's org-non-private row").toBeDefined();
+    expect(sharedHit.agentId).toBe(AGENT_A);
+
+    // NEGATIVE: the same query shape aimed at the private marker returns
+    // NOTHING of A's private row — not the id, not the content, not anywhere
+    // in the serialized payload.
+    const privateHits = await mcpTool(SUB, "memory_search", { query: PRIVATE_MARKER, limit: 20 });
+    expect(Array.isArray(privateHits?.results)).toBe(true);
+    expect(
+      privateHits.results.some((r: any) => r.id === privateId),
+      "the connector (B) must NEVER see A's private row",
+    ).toBe(false);
+    expect(JSON.stringify(privateHits)).not.toContain(PRIVATE_MARKER);
+  }, 120_000);
+
+  test("(b) bootstrap over the connector SELF-DESCRIBES as B — the first 'why is my memory empty' diagnostic", async () => {
+    const boot = await mcpTool(SUB, "bootstrap", {});
+    // Who does the server think I am? These fields are the answer (#1182).
+    expect(boot?.agentId, "bootstrap must self-describe the RESOLVED agent").toBe(AGENT_B);
+    expect(boot?.scope?.agentId).toBe(AGENT_B);
+    expect(boot?.scope?.isAdmin).toBe(false);
+    expect(typeof boot?.scope?.reads).toBe("string");
+    expect(typeof boot?.flairVersion).toBe("string");
+
+    const payload = JSON.stringify(boot);
+    // PAYLOAD-SCAN CONTROL: the payload demonstrably carries memory content —
+    // B's own connector-written row is in it…
+    expect(payload, "B's own row must appear in B's bootstrap (scan control)").toContain(B_MARKER);
+    // …so the absence of A's private content is a real exclusion, not an
+    // empty payload passing vacuously.
+    expect(payload, "A's private content must never appear in B's bootstrap").not.toContain(PRIVATE_MARKER);
+  }, 120_000);
+
+  test("(c) by-id GET as the connector: A's private row → 404 (#1264 posture); A's non-private row → readable (control)", async () => {
+    // OWNER CONTROL: the row reads fine as its owner.
+    const owner = await fleet("recallById", { agentId: AGENT_A, id: privateId });
+    expect(owner.value?.id).toBe(privateId);
+
+    // CONTROL for the read path: cross-principal by-id on a NON-private row
+    // works — so the 404 below is the private exclusion, not a broken read.
+    const sharedRead = await mcpTool(SUB, "memory_get", { id: sharedId });
+    expect(sharedRead?.id).toBe(sharedId);
+    expect(String(sharedRead?.content)).toContain(SHARED_MARKER);
+
+    // THE ASSERTION: holding the exact private id gets 404, never 403, never
+    // the record.
+    const rpc = await mcpCall(SUB, "memory_get", { id: privateId });
+    expect(rpc.result?.isError, `expected a tool error, got: ${JSON.stringify(rpc.result?.structuredContent).slice(0, 300)}`).toBe(true);
+    expect(rpc.result?.structuredContent?.status).toBe(404);
+    expect(JSON.stringify(rpc)).not.toContain(PRIVATE_MARKER);
+  }, 120_000);
+
+  test("(d) LINK — the supported opt-in: re-pointing the sub to A re-uses the SAME Credential and the connector now sees exactly what A sees", async () => {
+    // The link is the SAME supported call, principal now A. Same provider +
+    // subject ⇒ the existing Credential row is RE-POINTED, not duplicated.
+    const mapping = await provisionIdpIdentityMapping({
+      opsPortOrUrl: opsPort,
+      adminUser: harper.admin.username,
+      adminPass: harper.admin.password,
+      principal: AGENT_A,
+      principalKind: "agent",
+      idpProvider: PROVIDER,
+      idpSubject: SUB,
+    });
+    expect(mapping.principalCreated).toBe(false);
+    expect(mapping.credentialReused, "the link must REUSE the existing (provider,subject) Credential").toBe(true);
+    expect(mapping.credentialId).toBe(firstCredentialId);
+
+    // Determinism: still exactly ONE idp Credential for this sub — a duplicate
+    // would make resolveAgentFromSub's answer iteration-order-dependent.
+    const creds = (await adminSearch("Credential", "idpSubject", SUB)).filter((c) => c.kind === "idp");
+    expect(creds.length).toBe(1);
+    expect(creds[0].principalId).toBe(AGENT_A);
+
+    // Runtime legibility flips with the mapping: bootstrap now self-describes
+    // as A.
+    const boot = await mcpTool(SUB, "bootstrap", {});
+    expect(boot?.agentId).toBe(AGENT_A);
+    expect(boot?.scope?.agentId).toBe(AGENT_A);
+
+    // The former 404 is now the owner's own read.
+    const nowOwn = await mcpTool(SUB, "memory_get", { id: privateId });
+    expect(nowOwn?.id).toBe(privateId);
+    expect(String(nowOwn?.content)).toContain(PRIVATE_MARKER);
+
+    // And search surfaces A's private row to the linked connector.
+    const hits = await mcpTool(SUB, "memory_search", { query: PRIVATE_MARKER, limit: 20 });
+    expect(hits.results.some((r: any) => r.id === privateId)).toBe(true);
+
+    // The link REPLACES the mapping — it does not union identities. B's
+    // private row (which the connector itself wrote three tests ago) is now
+    // invisible to it. Owner control first: B still reads its own row.
+    const bOwner = await fleet("recallById", { agentId: AGENT_B, id: bPrivateId });
+    expect(bOwner.value?.id).toBe(bPrivateId);
+    const bHits = await mcpTool(SUB, "memory_search", { query: B_MARKER, limit: 20 });
+    expect(
+      bHits.results.some((r: any) => r.id === bPrivateId),
+      "after linking to A, the connector must NOT see B's private rows",
+    ).toBe(false);
+
+    // "Exactly what A sees", pinned per-row over the seeded universe: for each
+    // row, connector-by-id visibility === A's direct by-id visibility.
+    for (const [id, label] of [
+      [sharedId, "A shared"],
+      [privateId, "A private"],
+      [bPrivateId, "B private"],
+    ] as const) {
+      const direct = await fleet("recallById", { agentId: AGENT_A, id });
+      const aSees = direct.value?.id === id;
+      const rpc = await mcpCall(SUB, "memory_get", { id });
+      const connectorSees = rpc.result?.isError !== true && rpc.result?.structuredContent?.id === id;
+      expect(connectorSees, `${label}: connector visibility (${connectorSees}) must equal A's direct visibility (${aSees})`).toBe(aSees);
+    }
+  }, 120_000);
+});


### PR DESCRIPTION
Closes #1280.

Implements the issue's design ruling (option 3, formalized; Kern-approved): **distinct identities stay the default; the deliverables are legibility + the two-identity integration test.** No resource-layer changes.

## Linking-flow verdict: EXISTS (STOP condition did not fire)

The issue bound a STOP if sub-to-Agent linking turned out not to exist as a supported operation. It exists:

- `provisionIdpIdentityMapping` (`src/lib/mcp-enable.ts`) is the supported surface — the exact function `flair mcp enable --principal <agent> --idp-subject <sub>` runs on its `identity-mapping` step. It writes the `Credential{kind:"idp", idpProvider, idpSubject} → principalId` row that `resolveAgentFromSub` reads at request time, attaches to an EXISTING Agent when the principal already exists, and on re-run with the same `(provider, subject)` **re-points the same Credential row** to the new `--principal` — which is precisely the "link a sub to an existing Agent" opt-in. The integration test drives this real function against the real ops API for both the initial provision and the link.
- Searched before concluding: `resolveAgentFromSub` + all call sites (`resources/mcp-handler.ts`, `resources/mcp-oauth.ts`), the JIT-provision path (`jitProvisionPrincipal`), `src/lib/mcp-enable.ts` + its CLI command (`flair mcp enable`), `flair agent add`, `resources/XAA.ts` (same Credential surface), `docs/notes/mcp-oauth-model2.md`, `docs/mcp-clients.md`.

Hence "Closes", not "Refs".

## 1. The two-identity integration test (the fixture gap, closed)

`test/integration/mcp-connector-principal-mapping.test.ts` + a new `mcpRpc` op in `test/fixtures/inproc-app/resources/AgentFleet.js`.

Every prior integration suite drove tools via a hand-built `{agentId, isAdmin}` (bypassing Credential resolution — the #1181-investigation fixture gap), and the one faithful OAuth-principal fixture (`test/unit/mcp-handler.test.ts`) only ran against mocked handler doubles. The new op hands the SHIPPED `mcpHandler` a `request.mcp = { sub }` (the post-`withMCPAuth` shape), so the real `Credential(kind:"idp")` lookup, real tool wrappers, and real read-scope gates all run against a real Harper store. The only production layer out of the loop is `withMCPAuth`'s RS256 JWT verification (own coverage).

7 tests, declaration-ordered (the link test mutates the mapping last):

1. **Ground truth** — exactly one idp Credential for the sub, pointing at B; A's rows landed with the visibilities the contract keys on (fails first, naming the fixture, if the mutation knob is flipped).
2. **Unmapped sub denied live** (JIT default-OFF): "not a provisioned flair agent", no anonymous/admin fallback.
3. **Connector writes as the RESOLVED agent** — attribution from the Credential; a forged `agentId` argument is ignored (verified in storage, past the gates).
4. **(a) search** — B sees A's org-non-private row (positive control, identical query shape) and NEVER A's private row (id, content, and full-payload scan), with an owner-control proving the private row is real and indexed.
5. **(b) bootstrap self-describes as B** — `agentId`/`scope.agentId`/`scope.isAdmin`/`scope.reads` + payload-scan control (B's own row present ⇒ the scan can see content ⇒ A's private absence is non-vacuous).
6. **(c) by-id GET** — A's private row → 404 (#1264 404-never-403 posture) with owner-control AND a cross-principal non-private by-id read as the read-path control.
7. **(d) LINK** — re-running the real `provisionIdpIdentityMapping` with `--principal`=A: `credentialReused: true`, same credentialId, still exactly ONE credential for the sub (resolution stays deterministic); bootstrap flips to self-describe as A; the former 404 becomes the owner's read; search surfaces A's private row; the link REPLACES the mapping (B's connector-written private row becomes invisible — no identity union); and a per-row sweep pins connector visibility == A's direct visibility over the full seeded universe.

## Mutation evidence (the fixture can express leakage)

Flipped `PRIVATE_VISIBILITY` ("private" → "shared") in the test fixture: **3 fail / 4 pass** — the ground-truth test (naming the fixture), the (a) "must NEVER see A's private row" assertion, and the (c) 404 assertion (the record came back instead of the tool error). Restored: **7 pass / 0 fail.** Honest scope note: the flip exercises the search and by-id legs; the bootstrap leg's never-private scan is instead backed by its own permanent in-band control (B's own row demonstrably appears in the scanned payload), since a shared row of A's does not enter B's bootstrap containers without currentTask scoring (#1182 own-only containers).

## 2. Legibility (provisioning + docs)

- `flair mcp enable` identity-mapping step now states plainly: which Agent the sub resolves to, that every /mcp call reads/writes AS that agent, the `--principal` link remedy, and the `bootstrap.agentId`/`scope` first diagnostic.
- `flair agent add` prints one note: a connector's IdP subject is a DISTINCT identity by default + the exact `flair mcp enable --principal <id> --idp-subject <sub>` link command.
- `docs/notes/mcp-oauth-model2.md` gains "Which Agent is my connector? (distinct-by-default — flair#1280)": the ruling, where the mapping is decided, the linking flow, the bootstrap self-describe diagnostic, and the JIT caveat below.

## Finding (documented, not changed — follow-up candidate)

Runtime resolution (`resolveAgentFromSub`) matches on `(kind, idpSubject)`; the linking upsert matches on `(kind, idpProvider, idpSubject)`. A JIT-provisioned credential is stamped `idpProvider: "mcp-oauth"`, so linking the same sub under a different provider name creates a SECOND active credential for the subject — and which wins resolution is iteration-order-dependent. The docs now instruct matching the provider (or revoking the JIT credential) when re-linking. A structural fix (unique-per-subject enforcement, or a deterministic winner + warning) would be a small resource-layer change and was out of this PR's ruled scope — happy to file it as its own issue.

## Test evidence (all self-measured on this branch; baseline measured on origin/main a1e468bf in the same worktree)

| Lane | Baseline (origin/main) | This branch |
|---|---|---|
| `bun test test/unit/ test/*.test.ts` | 4840 pass / 0 fail (252 files) | 4840 pass / 0 fail (252 files) |
| New suite `mcp-connector-principal-mapping` | n/a | 7 pass / 0 fail (70 expects) |
| Fixture-consuming integration suites (byid-static-pattern, in-process-agents, wrapper-layer, bootstrap-payload-1182, connector-conformance) | — | 62 pass / 0 fail (5 files) |

Changelog fragment: `.changelog/unreleased/added-1280-connector-principal-mapping.md` (`changelog-fragments.mjs check` green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
