### PR TITLE
install: detect off-PATH npm prefix and print the exact fix — one-command install stops lying on user-prefix setups

### DIFF
--- a/.changelog/unreleased/fixed-1134-npm-prefix-path-detection.md
+++ b/.changelog/unreleased/fixed-1134-npm-prefix-path-detection.md
@@ -1,0 +1,16 @@
+- **install: off-PATH npm prefix is detected and the exact fix printed**
+  (flair#1134). `npm i -g` on a user-prefix setup (prefix = `~/.npm-global`)
+  succeeds, puts the `flair` bin in `<prefix>/bin`, and then `flair` is
+  command-not-found while the docs claim one-command readiness. Three
+  surfaces now detect that state, and every message names the actual bin
+  directory plus the exact `export PATH="<dir>:$PATH"` line for your shell
+  (zsh/bash rc file, `fish_add_path` for fish) — never "check your PATH":
+  a `postinstall` warning at install time (delivered via `/dev/tty`, since
+  npm ≥ 8 hides lifecycle output on success; measured working on npm 11
+  defaults), a TTY-gated one-shot banner when the CLI itself runs (npm ≥ 12
+  blocks install scripts by default, so on current npm the CLI is the first
+  thing of ours that executes — reached via npx or an absolute path), and a
+  `flair doctor` check. The postinstall is read-only, spawn-free, and can
+  never fail an install; the boot banner is silent for non-TTY automation
+  and skips dev checkouts, npx cache copies, and tar-swap deploys by
+  validating that the derived bin dir really holds the flair bin.

--- a/docs/mcp-clients.md
+++ b/docs/mcp-clients.md
@@ -30,6 +30,8 @@ flair agent add my-project
 flair status
 ```
 
+> **`flair: command not found` right after installing?** Your npm global prefix's bin dir isn't on PATH (common with a user prefix like `~/.npm-global`) — run `export PATH="$(npm prefix -g)/bin:$PATH"`, persist that line in your shell profile, and `flair doctor` will print the exact line for your shell any time.
+
 Flair runs as a local server at `http://127.0.0.1:19926` by default. The MCP server connects to it on demand via Ed25519-signed requests; nothing leaves your machine unless you explicitly route to a remote Flair instance.
 
 ---

--- a/package.json
+++ b/package.json
@@ -52,7 +52,8 @@
     "prepublishOnly": "npm run build && npm run build:cli",
     "test": "bun test",
     "test:e2e": "playwright test",
-    "release": "./scripts/release.sh"
+    "release": "./scripts/release.sh",
+    "postinstall": "node -e \"try{require('./dist/postinstall.cjs')}catch(e){}\""
   },
   "publishConfig": {
     "access": "public"

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -22,6 +22,7 @@ import {
 } from "node:fs";
 import { homedir, hostname, tmpdir } from "node:os";
 import { join, resolve, sep, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
 import { spawn, execFileSync, spawnSync, execSync } from "node:child_process";
 import { createRequire } from "node:module";
 import { createHash, randomUUID, randomBytes } from "node:crypto";
@@ -110,6 +111,11 @@ import {
   type SemanticSkipReason,
   type KeyPruneClass,
 } from "./doctor-client.js";
+import {
+  checkGlobalBinOnPath,
+  cliBootPathWarning,
+  resolveNpmGlobalPrefix,
+} from "./install/global-bin-path.js";
 import {
   installHook,
   uninstallHook,
@@ -13466,6 +13472,33 @@ program
       }
     }
 
+    // 0.5 npm global bin dir on PATH (flair#1134) — a user-prefix
+    // `npm i -g` succeeds and then `flair` is command-not-found because
+    // <prefix>/bin never made it into PATH. postinstall warns at install
+    // time, but lifecycle scripts are suppressed on several real paths
+    // (--ignore-scripts, bun without trustedDependencies, tar-swap
+    // deploys), so doctor re-runs the same check — cheap, local, and
+    // independent of Harper being up. When npm itself is absent or slow
+    // the check SKIPS silently: flair may be installed by other means,
+    // and "npm missing" has no actionable fix this check could print.
+    const npmGlobalPrefix = await resolveNpmGlobalPrefix();
+    if (npmGlobalPrefix) {
+      const binCheck = checkGlobalBinOnPath({
+        prefix: npmGlobalPrefix,
+        pathEnv: process.env.PATH,
+        shell: process.env.SHELL,
+      });
+      if ("message" in binCheck) {
+        console.log(`  ${render.icons.warn} ${render.wrap(render.c.yellow, `npm global bin dir ${binCheck.binDir} is NOT on PATH — global npm installs (flair included) won't be found by name`)}`);
+        for (const line of binCheck.message.split("\n")) {
+          console.log(`     ${render.wrap(render.c.dim, line)}`);
+        }
+        issues++;
+      } else {
+        console.log(`  ${render.icons.ok} npm global bin dir ${render.wrap(render.c.dim, binCheck.binDir)} is on PATH`);
+      }
+    }
+
     // Helper: try to reach Harper on a given port.
     // Must return true ONLY when Harper's /Health endpoint returns 200 OK.
     // A generic HTTP status > 0 (flair#862) would accept 404 from a Node
@@ -18651,6 +18684,24 @@ program
 // its Node-version check passes. The shim imports this module, so import.meta.main
 // is false there — without this explicit entry point the CLI would load but never run.
 async function runCli(): Promise<void> {
+  // flair#1134 — npm ≥12 blocks install scripts by default, so the
+  // postinstall PATH warning cannot fire there; the first thing of ours
+  // that executes is this CLI, reached via npx / absolute path / a PATH
+  // fixed-for-one-shell. Spawn-free (prefix derived from this file's own
+  // location), validated (the derived bin dir must really hold flair),
+  // TTY-gated (no per-run noise for automation), and skipped for `doctor`,
+  // which prints the full finding itself. Must never break the CLI.
+  if (process.argv[2] !== "doctor") {
+    try {
+      const banner = cliBootPathWarning({
+        packageDir: resolve(dirname(fileURLToPath(import.meta.url)), ".."),
+        pathEnv: process.env.PATH,
+        shell: process.env.SHELL,
+        stderrIsTTY: process.stderr.isTTY === true,
+      });
+      if (banner) console.error(banner);
+    } catch { /* a diagnostic must never take down the CLI */ }
+  }
   // A bare `flair` (no command) is a help request, not a usage error — show
   // help and exit 0, rather than commander's default (help + exit 1). Flags
   // like -h/--help/-v have argv beyond the binary and fall through to

--- a/src/install/global-bin-path.ts
+++ b/src/install/global-bin-path.ts
@@ -1,0 +1,322 @@
+// ─── npm global bin dir vs PATH (flair#1134) ────────────────────────────────
+//
+// `npm install -g @tpsdev-ai/flair` on a user-prefix setup (prefix =
+// ~/.npm-global or similar) succeeds, puts the `flair` bin in
+// `<prefix>/bin`, and then `flair` is "command not found" because that
+// directory was never added to PATH. The install instructions claim
+// one-command readiness, so the failure reads as a broken package, not a
+// broken PATH.
+//
+// This module is the single source of truth for detecting that state and
+// for the message that fixes it. Two consumers:
+//   - dist/postinstall.cjs (src/postinstall.cts) — runs at `npm i -g` time,
+//     the moment the user hits the lie.
+//   - `flair doctor` — cheap, always runs, and covers every path where
+//     lifecycle scripts are suppressed (--ignore-scripts, bun without
+//     trustedDependencies, the fleet's tar-swap deploys).
+//
+// Contract (errors must enable a response): every warning names the ACTUAL
+// bin directory and prints the exact line to add for the user's shell —
+// never "check your PATH". If we cannot VALIDATE the directory (the flair
+// bin is really there), we say nothing rather than print a wrong fix.
+//
+// Everything here is pure and dependency-injected except
+// resolveNpmGlobalPrefix (spawns `npm prefix -g` for doctor).
+
+import { join } from "node:path";
+import { existsSync } from "node:fs";
+
+// ─── path membership ────────────────────────────────────────────────────────
+
+/** Strip trailing separators ("/", and "\" on win32) without eating a bare root. */
+function stripTrailingSeps(p: string, win32: boolean): string {
+  const stripped = p.replace(win32 ? /[\\/]+$/ : /\/+$/, "");
+  return stripped === "" ? p.slice(0, 1) : stripped;
+}
+
+function normalizeEntry(entry: string, win32: boolean): string {
+  let e = stripTrailingSeps(entry.trim(), win32);
+  if (win32) e = e.replace(/\//g, "\\").toLowerCase();
+  return e;
+}
+
+/**
+ * The directory npm links global bins into for a given prefix:
+ * `<prefix>/bin` everywhere except win32, where shims land in the prefix
+ * itself (npm's own layout, not ours).
+ */
+export function npmGlobalBinDir(prefix: string, platform: NodeJS.Platform = process.platform): string {
+  const win32 = platform === "win32";
+  const clean = stripTrailingSeps(prefix.trim(), win32);
+  return win32 ? clean : join(clean, "bin");
+}
+
+/**
+ * Is `dir` one of the entries of `pathEnv`? Trailing slashes are ignored on
+ * both sides; win32 compares case-insensitively with either separator and
+ * splits on ";". Empty entries (historical "cwd" semantics) never match.
+ */
+export function isDirOnPath(
+  dir: string,
+  pathEnv: string | undefined,
+  platform: NodeJS.Platform = process.platform,
+): boolean {
+  if (!pathEnv) return false;
+  const win32 = platform === "win32";
+  const delim = win32 ? ";" : ":";
+  const want = normalizeEntry(dir, win32);
+  return pathEnv
+    .split(delim)
+    .filter((e) => e.trim() !== "")
+    .some((e) => normalizeEntry(e, win32) === want);
+}
+
+// ─── the fix, per shell ─────────────────────────────────────────────────────
+
+export interface ShellPathFix {
+  /** The line that fixes the CURRENT shell (or persists, for fish). */
+  exportLine: string;
+  /** One command that persists the fix, or null when we can't name the rc file. */
+  persistCommand: string | null;
+  /** The rc file the persist command appends to, for the message text. */
+  rcFile: string | null;
+}
+
+/** basename of $SHELL, lowercased — "/usr/local/bin/zsh" → "zsh". */
+function shellFlavor(shell: string | undefined): string {
+  if (!shell) return "";
+  return shell.replace(/\\/g, "/").split("/").pop()!.toLowerCase();
+}
+
+export function shellPathFix(binDir: string, shell: string | undefined): ShellPathFix {
+  const flavor = shellFlavor(shell);
+  if (flavor === "fish") {
+    // fish_add_path persists via a universal variable — one command does both.
+    const line = `fish_add_path ${binDir}`;
+    return { exportLine: line, persistCommand: line, rcFile: null };
+  }
+  const exportLine = `export PATH="${binDir}:$PATH"`;
+  const rcFile = flavor === "zsh" ? "~/.zshrc" : flavor === "bash" ? "~/.bashrc" : null;
+  return {
+    exportLine,
+    persistCommand: rcFile === null ? null : `echo '${exportLine}' >> ${rcFile}`,
+    rcFile,
+  };
+}
+
+// ─── the message ────────────────────────────────────────────────────────────
+
+/**
+ * The full actionable warning. Names the actual bin dir, gives the exact
+ * line for the user's shell, says how to persist it, and how to verify.
+ */
+export function formatOffPathMessage(
+  binDir: string,
+  shell: string | undefined,
+  platform: NodeJS.Platform = process.platform,
+): string {
+  if (platform === "win32") {
+    return [
+      `flair is installed in ${binDir}, but that directory is not on your PATH,`,
+      `so the "flair" command will not be found.`,
+      ``,
+      `Fix — add it to your user PATH (new terminals pick it up):`,
+      ``,
+      `  powershell -Command "[Environment]::SetEnvironmentVariable('Path', [Environment]::GetEnvironmentVariable('Path','User') + ';${binDir}', 'User')"`,
+      ``,
+      `Then open a new terminal and verify:  flair --version`,
+    ].join("\n");
+  }
+  const fix = shellPathFix(binDir, shell);
+  const lines = [
+    `flair is installed at ${binDir}/flair, but ${binDir} is not on your PATH,`,
+    `so the "flair" command will not be found.`,
+    ``,
+    `Fix — run this in your shell now:`,
+    ``,
+    `  ${fix.exportLine}`,
+  ];
+  if (fix.persistCommand) {
+    lines.push(``, `and persist it for new shells:`, ``, `  ${fix.persistCommand}`);
+  } else if (shellFlavor(shell) !== "fish") {
+    lines.push(``, `and add that same line to your shell's startup file to persist it.`);
+  }
+  lines.push(``, `Then verify:  flair --version`);
+  return lines.join("\n");
+}
+
+// ─── composed check (doctor + postinstall share this) ───────────────────────
+
+export interface GlobalBinCheckInput {
+  /** npm's global prefix (`npm prefix -g` / npm_config_prefix). */
+  prefix: string;
+  /** The PATH value to check against (process.env.PATH). */
+  pathEnv: string | undefined;
+  /** For the fix wording ($SHELL). */
+  shell?: string;
+  platform?: NodeJS.Platform;
+}
+
+export type GlobalBinCheck =
+  | { onPath: true; binDir: string }
+  | { onPath: false; binDir: string; exportLine: string; message: string };
+
+export function checkGlobalBinOnPath(input: GlobalBinCheckInput): GlobalBinCheck {
+  const platform = input.platform ?? process.platform;
+  const binDir = npmGlobalBinDir(input.prefix, platform);
+  if (isDirOnPath(binDir, input.pathEnv, platform)) return { onPath: true, binDir };
+  return {
+    onPath: false,
+    binDir,
+    exportLine: shellPathFix(binDir, input.shell).exportLine,
+    message: formatOffPathMessage(binDir, input.shell, platform),
+  };
+}
+
+// ─── postinstall decision (thin entry in src/postinstall.cts calls this) ────
+
+export interface PostinstallEnv {
+  /** process.env.npm_config_global — "true" on `npm i -g`. */
+  npmConfigGlobal?: string;
+  /** process.env.npm_config_prefix — set whenever the user configured a prefix. */
+  npmConfigPrefix?: string;
+  pathEnv?: string;
+  shell?: string;
+  platform?: NodeJS.Platform;
+  /** Root directory of the installed package (…/lib/node_modules/@tpsdev-ai/flair). */
+  packageDir?: string;
+  /** Injectable for tests: does `binDir` really contain the flair bin? */
+  binDirHasFlair?: (binDir: string) => boolean;
+}
+
+/**
+ * Fallback when npm_config_prefix is absent: derive prefix from where npm put
+ * us. String-based (not path.join) so the win32 shape stays faithful even in
+ * tests running on posix hosts.
+ */
+export function prefixFromPackageDir(packageDir: string, platform: NodeJS.Platform = process.platform): string {
+  // posix:  <prefix>/lib/node_modules/@tpsdev-ai/flair  → 4 segments up
+  // win32:  <prefix>\node_modules\@tpsdev-ai\flair      → 3 segments up
+  const win32 = platform === "win32";
+  const segments = stripTrailingSeps(packageDir, win32).split(win32 ? /[\\/]/ : "/");
+  const ups = win32 ? 3 : 4;
+  const kept = segments.slice(0, Math.max(1, segments.length - ups));
+  return kept.join(win32 ? "\\" : "/") || (win32 ? packageDir : "/");
+}
+
+function defaultBinDirHasFlair(binDir: string, platform: NodeJS.Platform): boolean {
+  const names = platform === "win32" ? ["flair.cmd", "flair"] : ["flair"];
+  return names.some((n) => existsSync(join(binDir, n)));
+}
+
+/**
+ * Decide what (if anything) the postinstall hook should print.
+ *
+ * Returns the warning message, or null when there is nothing to say:
+ *   - not a global install (npm_config_global !== "true" — local installs and
+ *     non-npm runners stay silent),
+ *   - no candidate prefix VALIDATES (the flair bin is not actually in the
+ *     candidate's bin dir — we never print a fix naming a wrong directory),
+ *   - or the bin dir is already on PATH.
+ */
+export function postinstallWarning(env: PostinstallEnv): string | null {
+  if (env.npmConfigGlobal !== "true") return null;
+  const platform = env.platform ?? process.platform;
+  const hasFlair = env.binDirHasFlair ?? ((d: string) => defaultBinDirHasFlair(d, platform));
+
+  const candidates: string[] = [];
+  if (env.npmConfigPrefix) candidates.push(env.npmConfigPrefix);
+  if (env.packageDir) candidates.push(prefixFromPackageDir(env.packageDir, platform));
+
+  for (const prefix of candidates) {
+    const binDir = npmGlobalBinDir(prefix, platform);
+    if (!hasFlair(binDir)) continue; // unvalidated — never name a wrong dir
+    if (isDirOnPath(binDir, env.pathEnv, platform)) return null;
+    return formatOffPathMessage(binDir, env.shell, platform);
+  }
+  return null;
+}
+
+// ─── CLI boot banner (the surface that runs when lifecycle scripts can't) ───
+//
+// npm ≥12 BLOCKS install scripts by default (allowScripts policy — measured
+// 2026-08-21 on npm 12.0.1: a user-prefix `npm i -g <tarball>` prints
+// "install scripts blocked" and the postinstall never runs). `--ignore-scripts`
+// and bun-without-trust do the same on older toolchains. On those paths the
+// FIRST thing of ours that executes is the CLI itself — reached via npx, an
+// absolute path, or a PATH the user fixed for one shell but never persisted.
+// So the CLI warns at boot, under tight gates:
+//   - spawn-free: the prefix is derived from the CLI's own on-disk location
+//     (no `npm prefix -g` on every command),
+//   - validated: the derived bin dir must really hold the flair bin,
+//   - TTY-gated: automation invoking flair by absolute path with a slim PATH
+//     must not get per-run noise; humans at terminals do.
+
+export interface BootPathWarningEnv {
+  /** Root directory of the installed package (dirname(dist)/..). */
+  packageDir: string;
+  pathEnv?: string;
+  shell?: string;
+  platform?: NodeJS.Platform;
+  /** process.stderr.isTTY — the noise gate. */
+  stderrIsTTY: boolean;
+  /** Injectable for tests: does `binDir` really contain the flair bin? */
+  binDirHasFlair?: (binDir: string) => boolean;
+}
+
+/** Compact per-boot variant of the message — this one repeats until fixed. */
+export function formatCompactOffPathBanner(binDir: string, shell: string | undefined): string {
+  const fix = shellPathFix(binDir, shell);
+  const lines = [
+    `flair: ${binDir} (where npm installed flair) is not on your PATH.`,
+    `  fix now:  ${fix.exportLine}`,
+  ];
+  if (fix.persistCommand && fix.persistCommand !== fix.exportLine) {
+    lines.push(`  persist:  ${fix.persistCommand}`);
+  } else if (!fix.persistCommand) {
+    lines.push(`  persist:  add that line to your shell's startup file`);
+  }
+  return lines.join("\n");
+}
+
+/**
+ * Decide what (if anything) the CLI should print to stderr at boot.
+ * Null when: not a TTY, the layout does not validate (dev checkouts, npx
+ * cache copies, tar-swap deploys — their derived dir has no flair bin), or
+ * the bin dir is on PATH.
+ */
+export function cliBootPathWarning(env: BootPathWarningEnv): string | null {
+  if (!env.stderrIsTTY) return null;
+  const platform = env.platform ?? process.platform;
+  const hasFlair = env.binDirHasFlair ?? ((d: string) => defaultBinDirHasFlair(d, platform));
+  const binDir = npmGlobalBinDir(prefixFromPackageDir(env.packageDir, platform), platform);
+  if (!hasFlair(binDir)) return null; // unvalidated — never name a wrong dir
+  if (isDirOnPath(binDir, env.pathEnv, platform)) return null;
+  return formatCompactOffPathBanner(binDir, env.shell);
+}
+
+// ─── doctor plumbing ────────────────────────────────────────────────────────
+
+/**
+ * `npm prefix -g`, best-effort. Returns the trimmed prefix or null when npm
+ * is absent / slow / errors — doctor SKIPS the check then (flair may have
+ * been installed by other means; a missing npm is not something this check
+ * can turn into an actionable finding).
+ */
+export async function resolveNpmGlobalPrefix(): Promise<string | null> {
+  try {
+    const { execFile } = await import("node:child_process");
+    const out = await new Promise<string>((resolve, reject) => {
+      execFile(
+        process.platform === "win32" ? "npm.cmd" : "npm",
+        ["prefix", "-g"],
+        { timeout: 5000, encoding: "utf-8", shell: process.platform === "win32" },
+        (err, stdout) => (err ? reject(err) : resolve(String(stdout))),
+      );
+    });
+    const prefix = out.trim();
+    return prefix === "" ? null : prefix;
+  } catch {
+    return null;
+  }
+}

--- a/src/postinstall.cts
+++ b/src/postinstall.cts
@@ -1,0 +1,83 @@
+/**
+ * postinstall.cts — `npm install -g` PATH check (flair#1134).
+ *
+ * THIS IS THE POSTINSTALL ENTRY (`package.json` "postinstall" requires
+ * dist/postinstall.cjs). It exists for exactly one case: a user-prefix
+ * global install (prefix = ~/.npm-global or similar) where npm links the
+ * `flair` bin into a directory that is not on PATH. The install "succeeds",
+ * then `flair` is command-not-found, and the docs' one-command install claim
+ * is a lie. This is the only surface that can reach the user at the moment
+ * that happens — a first-run banner can never run, because the bin the user
+ * would run is precisely what's unreachable.
+ *
+ * History note (#1078/#1008): the previous postinstall was removed because it
+ * was a NO-OP (chmod +x on bins npm already marks executable) that cost an
+ * install-script approval line. This one is not that: it does work no other
+ * surface can, it is read-only (env + one existsSync — no network, no
+ * writes), and it NEVER fails the install (every path swallows errors and
+ * exits 0). Where lifecycle scripts are suppressed — `--ignore-scripts`,
+ * bun without trustedDependencies, the fleet's tar-swap deploys (the #1078
+ * path, which manages PATH itself) — `flair doctor` runs the same check.
+ *
+ * Delivery: npm ≥8 hides lifecycle-script output on success (it only shows
+ * with --foreground-scripts or on failure), so printing to stderr alone
+ * would be invisible exactly where it matters. We write to /dev/tty first —
+ * that bypasses npm's captured pipes and lands on the interactive terminal —
+ * and fall back to stderr (visible under --foreground-scripts, bun, older
+ * npm; harmlessly buffered otherwise). No TTY (CI) ⇒ the fallback is the
+ * only path, which is the right amount of noise for CI: none visible.
+ *
+ * Like cli-shim.cts this is CommonJS on purpose: it parses and runs on any
+ * Node a user could have, and the ESM helper is loaded via dynamic import()
+ * with every failure swallowed — a postinstall must never be the thing that
+ * breaks an install.
+ */
+
+function writeToTty(text: string): boolean {
+  // npm captures the script's stdout/stderr pipes; the controlling terminal
+  // does not go through them. Best-effort, sync, closed either way.
+  //
+  // FLAIR_POSTINSTALL_NO_TTY: unit tests spawn this entry and assert on the
+  // stderr fallback; without the knob, a dev running the suite from a real
+  // terminal would have /dev/tty succeed — scribbling the banner over their
+  // screen and blanking the stderr the test asserts on (flaky by
+  // environment). The tty path's own coverage is the manual pty
+  // verification recorded in the flair#1134 PR (`script`-wrapped npm i -g).
+  if (process.env.FLAIR_POSTINSTALL_NO_TTY) return false;
+  try {
+    var fs = require("node:fs");
+    var fd = fs.openSync("/dev/tty", "w");
+    try {
+      fs.writeSync(fd, text);
+    } finally {
+      fs.closeSync(fd);
+    }
+    return true;
+  } catch (e) {
+    return false;
+  }
+}
+
+import("./install/global-bin-path.js")
+  .then(function (mod) {
+    try {
+      var path = require("node:path");
+      var message = mod.postinstallWarning({
+        npmConfigGlobal: process.env.npm_config_global,
+        npmConfigPrefix: process.env.npm_config_prefix,
+        pathEnv: process.env.PATH,
+        shell: process.env.SHELL,
+        // __dirname is <pkg>/dist — the package root is one up.
+        packageDir: path.resolve(__dirname, ".."),
+      });
+      if (message) {
+        var banner = "\n@tpsdev-ai/flair postinstall:\n\n" + message + "\n";
+        if (!writeToTty(banner)) console.error(banner);
+      }
+    } catch (e) {
+      // Never fail the install over a diagnostic.
+    }
+  })
+  .catch(function () {
+    // Helper unloadable (ancient Node, partial install) — never fail the install.
+  });

--- a/test/unit/global-bin-path.test.ts
+++ b/test/unit/global-bin-path.test.ts
@@ -1,0 +1,384 @@
+/**
+ * global-bin-path.test.ts — flair#1134: `npm i -g` on a user-prefix setup
+ * (prefix = ~/.npm-global) succeeds and then `flair` is command-not-found,
+ * because <prefix>/bin never made it into PATH while the docs claim
+ * one-command readiness.
+ *
+ * Covers the detection helper (prefix-in-PATH true/false, trailing-slash
+ * edges, win32 shapes), the message contract (names the ACTUAL bin dir and
+ * the exact export line — never "check your PATH"), the postinstall
+ * decision (global-only, validated-dir-only), and the real execution path
+ * of the postinstall entry (spawned, detached so /dev/tty is deterministically
+ * absent and the stderr fallback is what's under test).
+ */
+
+import { describe, test, expect } from "bun:test";
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import {
+  npmGlobalBinDir,
+  isDirOnPath,
+  shellPathFix,
+  formatOffPathMessage,
+  formatCompactOffPathBanner,
+  checkGlobalBinOnPath,
+  cliBootPathWarning,
+  postinstallWarning,
+  prefixFromPackageDir,
+} from "../../src/install/global-bin-path.js";
+
+const BIN = "/Users/casey/.npm-global/bin";
+
+// ─── npmGlobalBinDir ────────────────────────────────────────────────────────
+
+describe("npmGlobalBinDir", () => {
+  test("posix: <prefix>/bin", () => {
+    expect(npmGlobalBinDir("/Users/casey/.npm-global", "darwin")).toBe(BIN);
+  });
+
+  test("posix: trailing slash on the prefix is stripped first", () => {
+    expect(npmGlobalBinDir("/Users/casey/.npm-global/", "linux")).toBe(BIN);
+    expect(npmGlobalBinDir("/Users/casey/.npm-global///", "linux")).toBe(BIN);
+  });
+
+  test("win32: bins land in the prefix itself, not prefix/bin", () => {
+    expect(npmGlobalBinDir("C:\\Users\\casey\\npm", "win32")).toBe("C:\\Users\\casey\\npm");
+    expect(npmGlobalBinDir("C:\\Users\\casey\\npm\\", "win32")).toBe("C:\\Users\\casey\\npm");
+  });
+});
+
+// ─── isDirOnPath ────────────────────────────────────────────────────────────
+
+describe("isDirOnPath", () => {
+  test("present → true", () => {
+    expect(isDirOnPath(BIN, `/usr/bin:${BIN}:/bin`, "darwin")).toBe(true);
+  });
+
+  test("absent → false", () => {
+    expect(isDirOnPath(BIN, "/usr/bin:/bin:/usr/local/bin", "darwin")).toBe(false);
+  });
+
+  test("edge: trailing slash on the PATH entry still matches", () => {
+    expect(isDirOnPath(BIN, `/usr/bin:${BIN}/:/bin`, "darwin")).toBe(true);
+  });
+
+  test("edge: trailing slash on the dir argument still matches", () => {
+    expect(isDirOnPath(`${BIN}/`, `/usr/bin:${BIN}:/bin`, "darwin")).toBe(true);
+  });
+
+  test("undefined or empty PATH → false, never a throw", () => {
+    expect(isDirOnPath(BIN, undefined, "darwin")).toBe(false);
+    expect(isDirOnPath(BIN, "", "darwin")).toBe(false);
+  });
+
+  test("empty PATH entries (::) are ignored, not matched", () => {
+    expect(isDirOnPath(BIN, `/usr/bin::${BIN}`, "darwin")).toBe(true);
+    expect(isDirOnPath("", "/usr/bin::/bin", "darwin")).toBe(false);
+  });
+
+  test("a PREFIX of a PATH entry is not a match", () => {
+    expect(isDirOnPath(BIN, `${BIN}x:/usr/bin`, "darwin")).toBe(false);
+    expect(isDirOnPath(BIN, `${BIN}/deeper:/usr/bin`, "darwin")).toBe(false);
+  });
+
+  test("win32: ';' delimiter, case-insensitive, either separator", () => {
+    const dir = "C:\\Users\\casey\\npm";
+    expect(isDirOnPath(dir, "C:\\Windows;c:\\users\\casey\\NPM", "win32")).toBe(true);
+    expect(isDirOnPath(dir, "C:\\Windows;C:/Users/casey/npm", "win32")).toBe(true);
+    expect(isDirOnPath(dir, "C:\\Windows;C:\\Users\\casey", "win32")).toBe(false);
+  });
+});
+
+// ─── shellPathFix ───────────────────────────────────────────────────────────
+
+describe("shellPathFix", () => {
+  test("zsh → export line + ~/.zshrc persist", () => {
+    const fix = shellPathFix(BIN, "/bin/zsh");
+    expect(fix.exportLine).toBe(`export PATH="${BIN}:$PATH"`);
+    expect(fix.rcFile).toBe("~/.zshrc");
+    expect(fix.persistCommand).toBe(`echo 'export PATH="${BIN}:$PATH"' >> ~/.zshrc`);
+  });
+
+  test("bash → ~/.bashrc", () => {
+    expect(shellPathFix(BIN, "/usr/bin/bash").rcFile).toBe("~/.bashrc");
+  });
+
+  test("fish → fish_add_path is both the fix and the persist", () => {
+    const fix = shellPathFix(BIN, "/opt/homebrew/bin/fish");
+    expect(fix.exportLine).toBe(`fish_add_path ${BIN}`);
+    expect(fix.persistCommand).toBe(fix.exportLine);
+  });
+
+  test("unknown or absent shell → export line, no invented rc file", () => {
+    for (const shell of ["/bin/dash", undefined]) {
+      const fix = shellPathFix(BIN, shell);
+      expect(fix.exportLine).toBe(`export PATH="${BIN}:$PATH"`);
+      expect(fix.rcFile).toBeNull();
+      expect(fix.persistCommand).toBeNull();
+    }
+  });
+});
+
+// ─── message contract: names the dir, gives the exact line ──────────────────
+
+describe("formatOffPathMessage", () => {
+  test("names the ACTUAL bin dir and the exact export line (zsh)", () => {
+    const msg = formatOffPathMessage(BIN, "/bin/zsh", "darwin");
+    expect(msg).toContain(BIN);
+    expect(msg).toContain(`export PATH="${BIN}:$PATH"`);
+    expect(msg).toContain("~/.zshrc");
+    expect(msg).toContain("flair --version"); // enables verification, not just hope
+    expect(msg.toLowerCase()).not.toContain("check your path"); // the anti-goal
+  });
+
+  test("fish variant uses fish_add_path", () => {
+    const msg = formatOffPathMessage(BIN, "/usr/bin/fish", "linux");
+    expect(msg).toContain(`fish_add_path ${BIN}`);
+    expect(msg).not.toContain(".zshrc");
+  });
+
+  test("unknown shell still gives a runnable line plus honest persist wording", () => {
+    const msg = formatOffPathMessage(BIN, undefined, "linux");
+    expect(msg).toContain(`export PATH="${BIN}:$PATH"`);
+    expect(msg).toContain("startup file");
+  });
+
+  test("win32 names the dir and a concrete setx-equivalent command", () => {
+    const dir = "C:\\Users\\casey\\npm";
+    const msg = formatOffPathMessage(dir, undefined, "win32");
+    expect(msg).toContain(dir);
+    expect(msg).toContain("SetEnvironmentVariable");
+    expect(msg).toContain("flair --version");
+  });
+});
+
+// ─── checkGlobalBinOnPath (doctor's entry point) ────────────────────────────
+
+describe("checkGlobalBinOnPath", () => {
+  test("prefix's bin dir on PATH → onPath true with the dir named", () => {
+    const res = checkGlobalBinOnPath({
+      prefix: "/Users/casey/.npm-global",
+      pathEnv: `/usr/bin:${BIN}`,
+      shell: "/bin/zsh",
+      platform: "darwin",
+    });
+    expect(res.onPath).toBe(true);
+    expect(res.binDir).toBe(BIN);
+  });
+
+  test("off PATH → message carries dir + export line", () => {
+    const res = checkGlobalBinOnPath({
+      prefix: "/Users/casey/.npm-global",
+      pathEnv: "/usr/bin:/bin",
+      shell: "/bin/zsh",
+      platform: "darwin",
+    });
+    if (res.onPath) throw new Error("expected off-PATH result");
+    expect(res.binDir).toBe(BIN);
+    expect(res.exportLine).toBe(`export PATH="${BIN}:$PATH"`);
+    expect(res.message).toContain(BIN);
+    expect(res.message).toContain(res.exportLine);
+  });
+
+  test("edge: trailing slash on the configured prefix still matches PATH", () => {
+    const res = checkGlobalBinOnPath({
+      prefix: "/Users/casey/.npm-global/",
+      pathEnv: `${BIN}:/usr/bin`,
+      platform: "darwin",
+    });
+    expect(res.onPath).toBe(true);
+  });
+});
+
+// ─── postinstallWarning (decision logic) ────────────────────────────────────
+
+describe("postinstallWarning", () => {
+  const base = {
+    npmConfigGlobal: "true",
+    npmConfigPrefix: "/Users/casey/.npm-global",
+    pathEnv: "/usr/bin:/bin",
+    shell: "/bin/zsh",
+    platform: "darwin" as const,
+    binDirHasFlair: (d: string) => d === BIN,
+  };
+
+  test("not a global install → silent, even when off PATH", () => {
+    expect(postinstallWarning({ ...base, npmConfigGlobal: undefined })).toBeNull();
+    expect(postinstallWarning({ ...base, npmConfigGlobal: "false" })).toBeNull();
+  });
+
+  test("global + off PATH + validated dir → the actionable message", () => {
+    const msg = postinstallWarning(base);
+    expect(msg).not.toBeNull();
+    expect(msg!).toContain(BIN);
+    expect(msg!).toContain(`export PATH="${BIN}:$PATH"`);
+  });
+
+  test("global + on PATH → silent", () => {
+    expect(postinstallWarning({ ...base, pathEnv: `/usr/bin:${BIN}` })).toBeNull();
+  });
+
+  test("dir does not validate (no flair bin there) → silent, never a wrong fix", () => {
+    expect(postinstallWarning({ ...base, binDirHasFlair: () => false })).toBeNull();
+  });
+
+  test("no npm_config_prefix → prefix derived from the package's own location", () => {
+    const msg = postinstallWarning({
+      ...base,
+      npmConfigPrefix: undefined,
+      packageDir: "/Users/casey/.npm-global/lib/node_modules/@tpsdev-ai/flair",
+    });
+    expect(msg).not.toBeNull();
+    expect(msg!).toContain(BIN);
+  });
+});
+
+// ─── cliBootPathWarning (the surface that runs when lifecycle scripts can't) ─
+
+describe("cliBootPathWarning", () => {
+  const base = {
+    packageDir: "/Users/casey/.npm-global/lib/node_modules/@tpsdev-ai/flair",
+    pathEnv: "/usr/bin:/bin",
+    shell: "/bin/zsh",
+    platform: "darwin" as const,
+    stderrIsTTY: true,
+    binDirHasFlair: (d: string) => d === BIN,
+  };
+
+  test("TTY + validated + off PATH → compact banner with dir and export line", () => {
+    const banner = cliBootPathWarning(base);
+    expect(banner).not.toBeNull();
+    expect(banner!).toContain(BIN);
+    expect(banner!).toContain(`export PATH="${BIN}:$PATH"`);
+  });
+
+  test("no TTY → silent, regardless of PATH state (automation noise gate)", () => {
+    expect(cliBootPathWarning({ ...base, stderrIsTTY: false })).toBeNull();
+  });
+
+  test("bin dir on PATH → silent", () => {
+    expect(cliBootPathWarning({ ...base, pathEnv: `/usr/bin:${BIN}` })).toBeNull();
+  });
+
+  test("layout does not validate (dev checkout / npx cache) → silent", () => {
+    expect(cliBootPathWarning({ ...base, binDirHasFlair: () => false })).toBeNull();
+    // A real dev-checkout shape: chopping four segments off the repo root
+    // lands somewhere with no flair bin, so the default validator refuses.
+    expect(
+      cliBootPathWarning({ ...base, packageDir: "/Users/casey/ops/flair", binDirHasFlair: undefined }),
+    ).toBeNull();
+  });
+});
+
+describe("formatCompactOffPathBanner", () => {
+  test("zsh: fix line + separate persist line", () => {
+    const b = formatCompactOffPathBanner(BIN, "/bin/zsh");
+    expect(b).toContain(`export PATH="${BIN}:$PATH"`);
+    expect(b).toContain("~/.zshrc");
+  });
+
+  test("fish: fix IS the persist — no duplicate line", () => {
+    const b = formatCompactOffPathBanner(BIN, "/usr/bin/fish");
+    expect(b).toContain(`fish_add_path ${BIN}`);
+    expect(b).not.toContain("persist:");
+  });
+
+  test("unknown shell: still names the dir and a runnable line", () => {
+    const b = formatCompactOffPathBanner(BIN, undefined);
+    expect(b).toContain(BIN);
+    expect(b).toContain(`export PATH="${BIN}:$PATH"`);
+    expect(b).toContain("startup file");
+  });
+});
+
+describe("prefixFromPackageDir", () => {
+  test("posix: four segments up from the package root", () => {
+    expect(
+      prefixFromPackageDir("/Users/casey/.npm-global/lib/node_modules/@tpsdev-ai/flair", "darwin"),
+    ).toBe("/Users/casey/.npm-global");
+  });
+
+  test("win32: three segments up from the package root", () => {
+    expect(
+      prefixFromPackageDir("C:\\Users\\casey\\npm\\node_modules\\@tpsdev-ai\\flair", "win32"),
+    ).toBe("C:\\Users\\casey\\npm");
+  });
+});
+
+// ─── the postinstall ENTRY, actually executed ───────────────────────────────
+//
+// spawn the .cts entry the way npm would run the compiled .cjs: env-driven,
+// no arguments, must always exit 0. FLAIR_POSTINSTALL_NO_TTY pins the entry
+// to its stderr fallback — otherwise a suite run from a real terminal would
+// have /dev/tty succeed, scribbling on the screen and blanking the stderr
+// under assertion. The tty branch's coverage is the manual pty verification
+// (`script`-wrapped npm i -g) recorded in the flair#1134 PR.
+
+describe("postinstall entry (spawned)", () => {
+  const entry = join(import.meta.dir, "..", "..", "src", "postinstall.cts");
+
+  function runEntry(env: Record<string, string | undefined>) {
+    const res = spawnSync(process.execPath, [entry], {
+      env: { ...env, PATH: env.PATH ?? "/usr/bin:/bin", FLAIR_POSTINSTALL_NO_TTY: "1" },
+      encoding: "utf-8",
+      timeout: 15000,
+    });
+    return res;
+  }
+
+  function scratchPrefix(): string {
+    const prefix = mkdtempSync(join(tmpdir(), "flair-1134-prefix-"));
+    mkdirSync(join(prefix, "bin"), { recursive: true });
+    writeFileSync(join(prefix, "bin", "flair"), "#!/bin/sh\n", { mode: 0o755 });
+    return prefix;
+  }
+
+  test("global install, bin dir off PATH → warns on stderr with the dir, exit 0", () => {
+    const prefix = scratchPrefix();
+    try {
+      const res = runEntry({
+        npm_config_global: "true",
+        npm_config_prefix: prefix,
+        PATH: "/usr/bin:/bin",
+        SHELL: "/bin/zsh",
+      });
+      expect(res.status).toBe(0);
+      expect(res.stderr).toContain(join(prefix, "bin"));
+      expect(res.stderr).toContain(`export PATH="${join(prefix, "bin")}:$PATH"`);
+    } finally {
+      rmSync(prefix, { recursive: true, force: true });
+    }
+  });
+
+  test("global install, bin dir ON PATH → silent, exit 0", () => {
+    const prefix = scratchPrefix();
+    try {
+      const res = runEntry({
+        npm_config_global: "true",
+        npm_config_prefix: prefix,
+        PATH: `/usr/bin:/bin:${join(prefix, "bin")}`,
+        SHELL: "/bin/zsh",
+      });
+      expect(res.status).toBe(0);
+      expect(res.stderr).toBe("");
+    } finally {
+      rmSync(prefix, { recursive: true, force: true });
+    }
+  });
+
+  test("local (non-global) install → silent, exit 0", () => {
+    const prefix = scratchPrefix();
+    try {
+      const res = runEntry({
+        npm_config_prefix: prefix,
+        PATH: "/usr/bin:/bin",
+      });
+      expect(res.status).toBe(0);
+      expect(res.stderr).toBe("");
+    } finally {
+      rmSync(prefix, { recursive: true, force: true });
+    }
+  });
+});

--- a/tsconfig.cli.json
+++ b/tsconfig.cli.json
@@ -10,6 +10,6 @@
     "skipLibCheck": true,
     "types": ["node"]
   },
-  "include": ["src/cli.ts", "src/cli-shim.cts"],
+  "include": ["src/cli.ts", "src/cli-shim.cts", "src/postinstall.cts"],
   "exclude": ["node_modules", "test"]
 }


### PR DESCRIPTION
Closes #1134

## The bug

`npm install -g @tpsdev-ai/flair` on a user-prefix setup (prefix = `~/.npm-global` or similar) succeeds, links the `flair` bin into `<prefix>/bin`, and then `flair` is command-not-found — while docs/mcp-clients.md Step 1 claims one-command readiness. The canary's finding 3 is the same failure.

## What ships

One detection helper, `src/install/global-bin-path.ts` (pure, dependency-injected, strict-lane checked), consumed by **three surfaces**. Every warning names the **actual** bin directory and prints the **exact** line for the user's shell — `export PATH="<dir>:$PATH"` plus the zsh/bash rc persist command, `fish_add_path <dir>` for fish, a PowerShell `SetEnvironmentVariable` line on win32 — and a verify command. Never "check your PATH".

1. **`postinstall`** (`src/postinstall.cts` → `dist/postinstall.cjs`): fires at `npm i -g` time. Gated to global installs (`npm_config_global`), prefix from `npm_config_prefix` with a structural fallback (derive from the package's own install location), and it **never names a directory it hasn't validated** (the flair bin must actually be in it). Read-only — env plus one `existsSync`, no network, no writes — and every path swallows errors and exits 0: a diagnostic must never fail an install.
2. **CLI boot banner** (in `runCli`): compact two/three-line warning on stderr. Spawn-free (prefix derived from the CLI's own on-disk location, so no `npm prefix -g` cost on every command), validated the same way, **TTY-gated** so automation invoking flair by absolute path gets zero per-run noise, and skipped for `doctor` which prints the full finding itself. Dev checkouts, npx cache copies, and tar-swap deploys fail structural validation and stay silent.
3. **`flair doctor`**: new check between the version and port steps, using `npm prefix -g` (5s timeout; skips silently when npm itself is absent — flair may be installed by other means and "npm missing" has no fix this check could print). Off-PATH counts as an issue (exit 1) with the full message.

Plus the Step 1 caveat in `docs/mcp-clients.md` with the same one-line command.

## Surface choice — measured, not assumed

The spec (and #1078's history) framed this as "postinstall vs first-run banner; pick what actually executes." I measured what executes, with a probe package carrying the byte-identical built artifacts, installed into a HOME-isolated scratch prefix (`npm_config_prefix`, never the host's real global):

| Toolchain | Lifecycle script | Warning visible? |
|---|---|---|
| npm 11 (via `npx -y npm@11 i -g`), default flags, real pty | **runs** (advisory allowScripts warning) | **yes — via `/dev/tty`** |
| npm 11, `--foreground-scripts`, pipes | runs | yes — stderr |
| npm 12.0.1, default flags | **BLOCKED** (`allowScripts` policy) | no — script never runs |
| npm 12.0.1, `--allow-scripts=<name>` and `<name>@<version>` (the unblock command npm itself prints) | still blocked for a tarball install | no |
| npm 12.0.1, `--dangerously-allow-all-scripts`, pipes | runs, output **hidden** (npm ≥ 8 buffers lifecycle output on success) | no on pipes; **yes on a real pty via `/dev/tty`** |

Three consequences drove the design:

- **npm ≤ 11 — the bundled npm of every engines-supported Node LTS (engines: node ≥ 22 ships npm 10/11) — runs postinstall by default.** That is the install-time moment, and nothing else can occupy it. Keep postinstall.
- **npm ≥ 12 blocks install scripts by default**, so on current npm the first thing of ours that ever executes is the CLI itself — reached via npx, an absolute path, or a PATH fixed in one shell and never persisted. That is the boot banner. (A "first-run banner" alone was never sufficient for the install-time case, because the bin the user would run is precisely what's unreachable — but under npm 12 it is the *only* self-serve surface left, so both ship.)
- **npm hides successful lifecycle output** (since v8; `--foreground-scripts` exists for this), so the postinstall writes to `/dev/tty` first — measured delivering on a real pty where plain stderr was invisible — and falls back to stderr (visible under `--foreground-scripts`, bun, older npm; silent-by-capture in CI, which is the right amount of CI noise).

### Why re-adding postinstall doesn't repeat #1078

#1078 removed a postinstall that was a **no-op** — `chmod +x` on bins npm already marks executable — so it cost an install-script approval line for zero benefit. This one does work no other surface can do at install time, and the costs named there are handled: the fleet's tar-swap deploys never run lifecycle scripts (true then, true now) — they manage PATH themselves and `flair doctor` covers any drift; where bun or `--ignore-scripts` suppress it, the boot banner and doctor are the net. The script is read-only and structurally unable to fail an install.

## Tests

39 new tests in `test/unit/global-bin-path.test.ts`:

- detection: prefix-in-PATH true/false, trailing-slash on either side, undefined/empty PATH, empty `::` entries, prefix-of-entry non-match, win32 (`;`, case-insensitive, mixed separators)
- message content pinned: contains the actual bin dir + the exact export line; per-shell variants (zsh/bash rc file, fish_add_path, unknown-shell wording, win32); contains the verify command; asserts the anti-goal (`check your path`) is absent
- postinstall decision: global-only, validated-dir-only (never a wrong fix), prefix derivation from package location (posix + win32 shapes)
- boot banner decision: TTY gate, on-PATH silence, validation refusal on dev-checkout shapes
- the postinstall **entry actually executed**: spawned with npm-shaped env against a scratch prefix — warns with the real dir + export line and exits 0 off-PATH; silent on-PATH; silent for local installs. `FLAIR_POSTINSTALL_NO_TTY` pins the spawned entry to its stderr fallback (otherwise a dev's terminal would swallow the assertion); the tty branch is covered by the pty verification below.

**Mutation check**: detection forced to always-true → **10 tests red** across all three surfaces (including the pinned-message and spawned-entry tests) → restored → 39/39 green.

**Suite**: full unit lane (`bun test test/unit/ test/*.test.ts`) — baseline at origin/main self-measured **4840 pass / 0 fail (252 files)**; this branch **4879 pass / 0 fail (253 files)**. Typecheck lanes green (`tsconfig.check.src.json` strict, `tsconfig.cli.json`, `tsconfig.test.check.json`); `check-imports` 185 files / 0 failures; docs-freshness 7/7; changelog fragment included.

## Manual verification (exact commands)

All installs HOME-isolated with `npm_config_prefix` into scratch trees — the host's real global prefix was never written. A probe package (`bin` + the byte-identical `dist/postinstall.cjs` and `dist/install/global-bin-path.js` from this branch's build) was packed and installed because the real package's dependency closure (harper + a model-downloading trusted dep) makes a full registry install a poor lab; the npm *surface* — pack → `npm i -g <tarball>` → bin link → lifecycle — is the real one.

```bash
# probe pack
npm pack   # inside the probe dir

# npm 12, default → blocked (allowScripts); with scripts allowed, pipes → hidden; pty → delivered
env -i HOME=$S/home PATH=/usr/bin:/bin:/opt/homebrew/bin SHELL=/bin/zsh \
  npm_config_prefix=$S/prefix npm i -g $S/probe/flair-1134-surface-probe-0.0.1.tgz
env -i ... npm i -g --dangerously-allow-all-scripts --foreground-scripts $S/probe/...tgz   # message on stderr
python3 -c 'pty.spawn(["npm","i","-g","--dangerously-allow-all-scripts",tgz])'            # message via /dev/tty (sanitized env)

# npm 11, default flags, real pty → script runs, banner delivered
python3 -c 'pty.spawn(["npx","-y","npm@11","i","-g",tgz])'   # BANNER-DELIVERED, export line present

# boot banner, real built CLI in a simulated global layout (<prefix>/lib/node_modules/@tpsdev-ai/flair + bin symlink):
node <layout>/dist/cli-shim.cjs --version   # pty, PATH without <prefix>/bin → banner + version
                                            # pty, PATH with <prefix>/bin    → version only
                                            # pipes (no tty), off-PATH      → version only (noise gate)

# doctor, both branches (isolated HOME, dead port):
node <layout>/dist/cli-shim.cjs doctor --port 39999   # PATH without /opt/homebrew/bin → warn + full fix; with → ok tick
```

Known limits, stated rather than papered over: bun global installs (`~/.bun/bin`) are outside all three detections — different layout, different owner of PATH setup; npm 12's `--allow-scripts=<name>` not unblocking a **tarball** install is npm-side behavior observed here and worth its own upstream look; registry-spec installs may differ.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
