### PR TITLE
adk-flair: configurable HTTP timeouts — hosted Flair no longer false-fails on the 1.5s read default (Closes #1323)

### DIFF
--- a/.changelog/unreleased/fixed-1323-adk-flair-timeout-override.md
+++ b/.changelog/unreleased/fixed-1323-adk-flair-timeout-override.md
@@ -1,0 +1,12 @@
+- **adk-flair: HTTP timeouts are now configurable — hosted Flair no longer
+  false-fails on the hardcoded 1.5s read timeout.** The shipped timeouts are
+  deliberate localhost fail-fast tuning (ADK's search path swallows exceptions,
+  so a down local Flair must fail instantly), but against a hosted Flair over
+  TLS + WAN they timed out ordinary searches with no override available
+  (flair#1323). New: `FlairMemoryService(timeout=...)` accepts float seconds
+  (read/write, connect derived as `min(timeout, 5.0)`) or a verbatim
+  `httpx.Timeout`, plus `FLAIR_HTTP_TIMEOUT` / `FLAIR_HTTP_CONNECT_TIMEOUT`
+  env vars (constructor wins). Defaults are unchanged when nothing is set —
+  local stays fail-fast. The effective timeouts now log once alongside the
+  first-request URL line, so a timeout misconfiguration is diagnosable from
+  the agent's own output.

--- a/packages/adk-flair/README.md
+++ b/packages/adk-flair/README.md
@@ -73,6 +73,8 @@ asks for it back in a fresh session 2 and prints whether the fact was recalled.
 | Agent ID         | `FLAIR_AGENT_ID`   | (required)                    | Must match `flair agent add <id>`        |
 | Private key path | `FLAIR_KEYFILE`    | (required)                    | Keyfile from `flair agent add` (raw seed; base64/PEM also accepted). A leading `~` is expanded. |
 | Allow remote URL | `FLAIR_ALLOW_REMOTE_URL` | (unset)                 | Set to `1` to allow non-localhost URLs   |
+| HTTP timeout     | `FLAIR_HTTP_TIMEOUT` | (unset — fail-fast defaults, read 1.5s) | Read/write timeout in seconds (float). Set for hosted Flair (below). |
+| Connect timeout  | `FLAIR_HTTP_CONNECT_TIMEOUT` | (unset — derived)     | Connect/pool timeout in seconds (float). Rarely needed on its own. |
 
 All settings can also be passed as constructor arguments:
 
@@ -141,14 +143,22 @@ By default, `adk-flair` only allows localhost URLs (`localhost`, `127.0.0.1`,
 `::1`, `[::1]`). This prevents a typo'd `FLAIR_URL` from silently shipping
 every user query to a stranger.
 
-To connect to a remote Flair instance, set `FLAIR_ALLOW_REMOTE_URL=1`:
+To connect to a remote Flair instance, set `FLAIR_ALLOW_REMOTE_URL=1` — and
+raise the HTTP timeout, because the defaults are tuned for localhost fail-fast
+(read 1.5s) and will time out ordinary searches over TLS/WAN latency:
 
 ```bash
 export FLAIR_ALLOW_REMOTE_URL=1
 export FLAIR_URL=https://flair.example.com:19926
+export FLAIR_HTTP_TIMEOUT=30
 ```
 
-The resolved URL is logged once at WARNING on the first request.
+Equivalently in code: `FlairMemoryService(timeout=30.0)` (float seconds), or
+pass a full `httpx.Timeout` for per-phase control. The constructor argument
+wins over the env var.
+
+The resolved URL and the effective timeouts are logged once at WARNING on the
+first request.
 
 ## Security
 

--- a/packages/adk-flair/src/adk_flair/memory_service.py
+++ b/packages/adk-flair/src/adk_flair/memory_service.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 import base64
 import hashlib
 import logging
+import math
 import os
 import time
 import uuid
@@ -239,8 +240,13 @@ def _positive_seconds_from_env(env_var: str) -> Optional[float]:
         raise ValueError(
             f"{env_var} must be a number of seconds (got: {raw!r})"
         ) from None
-    if value <= 0:
-        raise ValueError(f"{env_var} must be > 0 seconds (got: {raw!r})")
+    # Non-finite values slip a bare `<= 0` guard (nan compares False to
+    # everything; inf <= 0 is False) and would yield a NO-timeout client —
+    # and "inf"/"Infinity"/"nan" all parse successfully via float().
+    if not math.isfinite(value) or value <= 0:
+        raise ValueError(
+            f"{env_var} must be a finite number > 0 seconds (got: {raw!r})"
+        )
     return value
 
 
@@ -265,8 +271,11 @@ def _resolve_timeout(
 
     if timeout is not None:
         timeout = float(timeout)
-        if timeout <= 0:
-            raise ValueError(f"timeout must be > 0 seconds (got: {timeout!r})")
+        # Same non-finite guard as the env path: nan/inf pass a bare `<= 0`.
+        if not math.isfinite(timeout) or timeout <= 0:
+            raise ValueError(
+                f"timeout must be a finite number > 0 seconds (got: {timeout!r})"
+            )
 
     read_override = timeout if timeout is not None else _positive_seconds_from_env(_TIMEOUT_ENV)
     connect_override = _positive_seconds_from_env(_CONNECT_TIMEOUT_ENV)

--- a/packages/adk-flair/src/adk_flair/memory_service.py
+++ b/packages/adk-flair/src/adk_flair/memory_service.py
@@ -28,7 +28,7 @@ import time
 import uuid
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Dict, List, Mapping, Optional, Sequence
+from typing import Any, Dict, List, Mapping, Optional, Sequence, Union
 from urllib.parse import urlparse
 
 import httpx
@@ -48,6 +48,26 @@ logger = logging.getLogger("adk_flair")
 _LOCALHOST_HOSTS = frozenset({"localhost", "127.0.0.1", "::1", "[::1]"})
 _ALLOW_REMOTE_ENV = "FLAIR_ALLOW_REMOTE_URL"
 _TAG_PREFIX = "adk"
+
+# HTTP timeout configuration (flair#1323).
+#
+# The defaults are deliberate LOCALHOST FAIL-FAST tuning, not an accident:
+# ADK's search path swallows exceptions, so a down local Flair must fail
+# instantly rather than hang the agent on every recall. Against a hosted
+# Flair over TLS + WAN these numbers false-fail (connect=0.5s barely covers
+# a cold TLS handshake; read=1.5s is under a legitimate server-side
+# embed + hybrid retrieval) — hosted deployments override via the
+# constructor `timeout` param or the env vars below.
+_TIMEOUT_ENV = "FLAIR_HTTP_TIMEOUT"          # read/write timeout, seconds (float)
+_CONNECT_TIMEOUT_ENV = "FLAIR_HTTP_CONNECT_TIMEOUT"  # connect/pool timeout, seconds (float)
+_DEFAULT_CONNECT_TIMEOUT = 0.5
+_DEFAULT_READ_TIMEOUT = 1.5
+_DEFAULT_WRITE_TIMEOUT = 1.0
+_DEFAULT_POOL_TIMEOUT = 0.5
+# When only a read timeout is given, connect is derived as
+# min(read, _CONNECT_TIMEOUT_CAP): connection setup should never need more
+# than a few seconds even over WAN, while read scales with server-side work.
+_CONNECT_TIMEOUT_CAP = 5.0
 
 # Valid enum values for the explicit write knobs (flair#1238 — moved to module
 # level from inside add_memory; Sherlock's cosmetic note on #1237).
@@ -203,6 +223,77 @@ def _is_localhost(host: str) -> bool:
     return host.lower() in _LOCALHOST_HOSTS
 
 
+def _positive_seconds_from_env(env_var: str) -> Optional[float]:
+    """Parse an env var as positive float seconds; None when unset/empty.
+
+    Raises ValueError naming the env var on garbage — the failure lands in the
+    constructor, never deferred to first use (where ADK's exception-swallowing
+    search path would turn a misconfigured timeout into silent empty recall).
+    """
+    raw = os.environ.get(env_var, "").strip()
+    if not raw:
+        return None
+    try:
+        value = float(raw)
+    except ValueError:
+        raise ValueError(
+            f"{env_var} must be a number of seconds (got: {raw!r})"
+        ) from None
+    if value <= 0:
+        raise ValueError(f"{env_var} must be > 0 seconds (got: {raw!r})")
+    return value
+
+
+def _resolve_timeout(
+    timeout: Optional[Union[float, httpx.Timeout]],
+) -> httpx.Timeout:
+    """Resolve the effective httpx.Timeout for the Flair client (flair#1323).
+
+    Precedence, per knob (highest wins):
+      - An ``httpx.Timeout`` constructor param is used VERBATIM — fully
+        specified, so both env vars are ignored.
+      - read/write:  float constructor param > FLAIR_HTTP_TIMEOUT > defaults
+        (read=1.5, write=1.0 — localhost fail-fast, see comment at the
+        constants).
+      - connect/pool: FLAIR_HTTP_CONNECT_TIMEOUT > min(resolved read, 5.0)
+        when read was overridden > default (0.5).
+
+    With neither param nor env set the defaults are returned unchanged.
+    """
+    if isinstance(timeout, httpx.Timeout):
+        return timeout
+
+    if timeout is not None:
+        timeout = float(timeout)
+        if timeout <= 0:
+            raise ValueError(f"timeout must be > 0 seconds (got: {timeout!r})")
+
+    read_override = timeout if timeout is not None else _positive_seconds_from_env(_TIMEOUT_ENV)
+    connect_override = _positive_seconds_from_env(_CONNECT_TIMEOUT_ENV)
+
+    if read_override is None and connect_override is None:
+        return httpx.Timeout(
+            connect=_DEFAULT_CONNECT_TIMEOUT,
+            read=_DEFAULT_READ_TIMEOUT,
+            write=_DEFAULT_WRITE_TIMEOUT,
+            pool=_DEFAULT_POOL_TIMEOUT,
+        )
+
+    if read_override is not None:
+        read = write = read_override
+        connect = pool = min(read_override, _CONNECT_TIMEOUT_CAP)
+    else:
+        read = _DEFAULT_READ_TIMEOUT
+        write = _DEFAULT_WRITE_TIMEOUT
+        connect = _DEFAULT_CONNECT_TIMEOUT
+        pool = _DEFAULT_POOL_TIMEOUT
+
+    if connect_override is not None:
+        connect = pool = connect_override
+
+    return httpx.Timeout(connect=connect, read=read, write=write, pool=pool)
+
+
 # ─── FlairMemoryService ─────────────────────────────────────────────────────
 
 
@@ -217,6 +308,11 @@ class FlairMemoryService(BaseMemoryService):
         url: Flair server URL. Default: FLAIR_URL or http://localhost:19926
         agent_id: Flair agent identity. Default: FLAIR_AGENT_ID
         keyfile: Path to PKCS8 base64 Ed25519 key. Default: FLAIR_KEYFILE
+        timeout: HTTP timeout. A float sets the read/write timeout in seconds
+            (connect derived as min(timeout, 5.0)); an httpx.Timeout is used
+            verbatim. Default: FLAIR_HTTP_TIMEOUT / FLAIR_HTTP_CONNECT_TIMEOUT
+            env vars, else localhost fail-fast defaults (read=1.5s) — hosted
+            Flair over TLS/WAN needs an override (flair#1323).
     """
 
     def __init__(
@@ -224,6 +320,7 @@ class FlairMemoryService(BaseMemoryService):
         url: Optional[str] = None,
         agent_id: Optional[str] = None,
         keyfile: Optional[str] = None,
+        timeout: Optional[Union[float, httpx.Timeout]] = None,
     ):
         # Resolve URL
         raw_url = (url or os.environ.get("FLAIR_URL", "http://localhost:19926")).rstrip("/")
@@ -249,6 +346,10 @@ class FlairMemoryService(BaseMemoryService):
             raise ValueError("FLAIR_KEYFILE is required (set env var or pass keyfile)")
         self._private_key = _load_ed25519_key(resolved_keyfile)
 
+        # Resolve HTTP timeouts in the constructor (param > env > fail-fast
+        # defaults) so a malformed FLAIR_HTTP_TIMEOUT fails here, loudly.
+        self._timeout = _resolve_timeout(timeout)
+
         # httpx client — created lazily on first request
         self._client: Optional[httpx.AsyncClient] = None
 
@@ -265,7 +366,7 @@ class FlairMemoryService(BaseMemoryService):
         if self._client is None:
             self._client = httpx.AsyncClient(
                 base_url=self._url,
-                timeout=httpx.Timeout(connect=0.5, read=1.5, write=1.0, pool=0.5),
+                timeout=self._timeout,
             )
         return self._client
 
@@ -274,7 +375,14 @@ class FlairMemoryService(BaseMemoryService):
     ) -> Any:
         """Make an authenticated request to Flair. One attempt, no retry."""
         if not self._url_logged:
-            logger.warning("adk-flair: using Flair at %s (agent=%s)", self._url, self._agent_id)
+            logger.warning(
+                "adk-flair: using Flair at %s (agent=%s, timeouts: connect=%ss "
+                "read=%ss write=%ss pool=%ss — override via FLAIR_HTTP_TIMEOUT "
+                "if hosted searches time out)",
+                self._url, self._agent_id,
+                self._timeout.connect, self._timeout.read,
+                self._timeout.write, self._timeout.pool,
+            )
             self._url_logged = True
 
         auth = _sign_request(self._private_key, self._agent_id, method, path)

--- a/packages/adk-flair/tests/test_timeout_config.py
+++ b/packages/adk-flair/tests/test_timeout_config.py
@@ -124,6 +124,32 @@ class TestTimeoutResolution:
         with pytest.raises(ValueError, match="timeout"):
             _make_service({}, timeout=0)
 
+    # Non-finite values slip a bare `<= 0` guard (nan compares False to
+    # everything; inf <= 0 is False) and would create a NO-timeout client —
+    # each must be rejected at construction (Sherlock, PR #1327 review).
+
+    def test_infinite_env_raises_in_constructor(self):
+        with pytest.raises(ValueError, match="FLAIR_HTTP_TIMEOUT.*finite"):
+            _make_service({"FLAIR_HTTP_TIMEOUT": "inf"})
+
+    def test_infinity_string_env_raises_in_constructor(self):
+        # float("Infinity") parses to inf — env values are strings, so the
+        # spelled-out form must hit the same rejection as "inf".
+        with pytest.raises(ValueError, match="FLAIR_HTTP_TIMEOUT.*finite"):
+            _make_service({"FLAIR_HTTP_TIMEOUT": "Infinity"})
+
+    def test_nan_env_raises_in_constructor(self):
+        with pytest.raises(ValueError, match="FLAIR_HTTP_CONNECT_TIMEOUT.*finite"):
+            _make_service({"FLAIR_HTTP_CONNECT_TIMEOUT": "nan"})
+
+    def test_infinite_param_raises(self):
+        with pytest.raises(ValueError, match="timeout.*finite"):
+            _make_service({}, timeout=float("inf"))
+
+    def test_nan_param_raises(self):
+        with pytest.raises(ValueError, match="timeout.*finite"):
+            _make_service({}, timeout=float("nan"))
+
     async def test_effective_timeouts_logged_with_first_request_line(self, caplog):
         """The first-request WARNING line carries the effective timeouts, so a
         false-fail is diagnosable from the agent's own output."""

--- a/packages/adk-flair/tests/test_timeout_config.py
+++ b/packages/adk-flair/tests/test_timeout_config.py
@@ -1,0 +1,279 @@
+"""Tests for HTTP timeout configuration (flair#1323).
+
+Two tiers, both hermetic (no live_flair fixture — this file runs in the
+CI hermetic lane):
+
+1. Resolution unit tests — constructor param / env var / default precedence,
+   observable in the created httpx client's timeout config.
+2. The acceptance pair from flair#1323 — a deliberately slow (>1.5s) local
+   HTTP server: the same request FAILS under the shipped defaults (positive
+   control that the default really is the fail-fast path) and SUCCEEDS under
+   an overridden timeout.
+"""
+
+from __future__ import annotations
+
+import json
+import threading
+import time
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from unittest.mock import MagicMock, patch
+
+import httpx
+import pytest
+
+
+_DEFAULTS = {"connect": 0.5, "read": 1.5, "write": 1.0, "pool": 0.5}
+
+
+def _make_service(env: dict[str, str], **kwargs):
+    """Construct a FlairMemoryService with key-loading/signing mocked and an
+    exactly-controlled environment (clear=True — no ambient FLAIR_* leaks in)."""
+    from adk_flair.memory_service import FlairMemoryService
+
+    base_env = {"FLAIR_AGENT_ID": "test-agent", "FLAIR_KEYFILE": "/fake/keyfile"}
+    with patch(
+        "adk_flair.memory_service._load_ed25519_key",
+        return_value=MagicMock(),
+    ), patch.dict("os.environ", {**base_env, **env}, clear=True):
+        return FlairMemoryService(url="http://localhost:19926", **kwargs)
+
+
+def _client_timeout(svc) -> httpx.Timeout:
+    """The timeout config of the ACTUALLY CREATED httpx client — the
+    acceptance criterion is observability in the client, not in a field."""
+    return svc._http.timeout
+
+
+# ─── Resolution: param / env / default precedence ───────────────────────────
+
+
+class TestTimeoutResolution:
+    def test_default_unchanged_when_nothing_set(self):
+        svc = _make_service({})
+        t = _client_timeout(svc)
+        assert (t.connect, t.read, t.write, t.pool) == (
+            _DEFAULTS["connect"], _DEFAULTS["read"], _DEFAULTS["write"], _DEFAULTS["pool"],
+        )
+
+    def test_float_param_sets_read_write_and_caps_connect(self):
+        svc = _make_service({}, timeout=30.0)
+        t = _client_timeout(svc)
+        assert t.read == 30.0
+        assert t.write == 30.0
+        assert t.connect == 5.0  # min(30, 5.0) cap
+        assert t.pool == 5.0
+
+    def test_small_float_param_keeps_connect_below_cap(self):
+        svc = _make_service({}, timeout=2.0)
+        t = _client_timeout(svc)
+        assert t.read == 2.0
+        assert t.connect == 2.0  # min(2, 5.0)
+
+    def test_httpx_timeout_param_passes_through_verbatim(self):
+        explicit = httpx.Timeout(connect=7.0, read=42.0, write=9.0, pool=3.0)
+        svc = _make_service({}, timeout=explicit)
+        t = _client_timeout(svc)
+        assert (t.connect, t.read, t.write, t.pool) == (7.0, 42.0, 9.0, 3.0)
+
+    def test_env_timeout_applied(self):
+        svc = _make_service({"FLAIR_HTTP_TIMEOUT": "10"})
+        t = _client_timeout(svc)
+        assert t.read == 10.0
+        assert t.write == 10.0
+        assert t.connect == 5.0
+        assert t.pool == 5.0
+
+    def test_connect_env_alone_keeps_default_read(self):
+        svc = _make_service({"FLAIR_HTTP_CONNECT_TIMEOUT": "8"})
+        t = _client_timeout(svc)
+        assert t.connect == 8.0
+        assert t.pool == 8.0
+        assert t.read == _DEFAULTS["read"]
+        assert t.write == _DEFAULTS["write"]
+
+    def test_connect_env_overrides_derived_connect(self):
+        svc = _make_service({"FLAIR_HTTP_CONNECT_TIMEOUT": "9"}, timeout=30.0)
+        t = _client_timeout(svc)
+        assert t.read == 30.0
+        assert t.connect == 9.0  # explicit connect env beats the min(read, 5) rule
+
+    def test_float_param_beats_env(self):
+        svc = _make_service({"FLAIR_HTTP_TIMEOUT": "3"}, timeout=20.0)
+        t = _client_timeout(svc)
+        assert t.read == 20.0
+
+    def test_httpx_timeout_param_ignores_env(self):
+        explicit = httpx.Timeout(connect=1.0, read=2.0, write=3.0, pool=4.0)
+        svc = _make_service(
+            {"FLAIR_HTTP_TIMEOUT": "99", "FLAIR_HTTP_CONNECT_TIMEOUT": "88"},
+            timeout=explicit,
+        )
+        t = _client_timeout(svc)
+        assert (t.connect, t.read, t.write, t.pool) == (1.0, 2.0, 3.0, 4.0)
+
+    def test_garbage_env_raises_in_constructor(self):
+        with pytest.raises(ValueError, match="FLAIR_HTTP_TIMEOUT"):
+            _make_service({"FLAIR_HTTP_TIMEOUT": "fast"})
+
+    def test_nonpositive_env_raises_in_constructor(self):
+        with pytest.raises(ValueError, match="FLAIR_HTTP_CONNECT_TIMEOUT"):
+            _make_service({"FLAIR_HTTP_CONNECT_TIMEOUT": "0"})
+
+    def test_nonpositive_param_raises(self):
+        with pytest.raises(ValueError, match="timeout"):
+            _make_service({}, timeout=0)
+
+    async def test_effective_timeouts_logged_with_first_request_line(self, caplog):
+        """The first-request WARNING line carries the effective timeouts, so a
+        false-fail is diagnosable from the agent's own output."""
+        svc = _make_service({}, timeout=30.0)
+        svc._client = MagicMock()
+        resp = MagicMock(status_code=200, headers={"content-type": "application/json"})
+        resp.json.return_value = {}
+
+        async def _fake_request(*a, **k):
+            return resp
+
+        svc._client.request = _fake_request
+        with patch(
+            "adk_flair.memory_service._sign_request",
+            return_value="TPS-Ed25519 test-agent:0:0:AAAA",
+        ), caplog.at_level("WARNING", logger="adk_flair"):
+            await svc._request("POST", "/SemanticSearch", json_body={})
+
+        lines = [r.getMessage() for r in caplog.records if "using Flair at" in r.getMessage()]
+        assert len(lines) == 1
+        assert "read=30.0s" in lines[0]
+        assert "connect=5.0s" in lines[0]
+
+
+# ─── Acceptance pair: slow server vs fail-fast default (flair#1323) ─────────
+
+
+class _SlowSearchHandler(BaseHTTPRequestHandler):
+    """Responds to POST /SemanticSearch after a delay > the 1.5s default read
+    timeout — the hosted-Flair shape (server-side embed + hybrid retrieval)."""
+
+    delay_seconds = 2.0
+
+    def do_POST(self):  # noqa: N802 — BaseHTTPRequestHandler API
+        length = int(self.headers.get("Content-Length", 0))
+        self.rfile.read(length)
+        time.sleep(self.delay_seconds)
+        body = json.dumps({"results": []}).encode("utf-8")
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def log_message(self, *args):  # silence per-request stderr noise
+        pass
+
+
+@pytest.fixture
+def slow_flair_url():
+    """A local HTTP server that answers searches slower than the default read
+    timeout. Hermetic — a socket on 127.0.0.1, no Harper involved."""
+    server = ThreadingHTTPServer(("127.0.0.1", 0), _SlowSearchHandler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    yield f"http://127.0.0.1:{server.server_address[1]}"
+    server.shutdown()
+    server.server_close()
+    thread.join(timeout=5)
+
+
+def _make_slow_server_service(url: str, **kwargs):
+    from adk_flair.memory_service import FlairMemoryService
+
+    with patch(
+        "adk_flair.memory_service._load_ed25519_key",
+        return_value=MagicMock(),
+    ), patch.dict("os.environ", {
+        "FLAIR_AGENT_ID": "test-agent",
+        "FLAIR_KEYFILE": "/fake/keyfile",
+    }, clear=True):
+        svc = FlairMemoryService(url=url, agent_id="test-agent",
+                                 keyfile="/fake/keyfile", **kwargs)
+    svc._url_logged = True  # suppress first-request log noise
+    return svc
+
+
+class TestSlowServerAcceptancePair:
+    """The issue's acceptance pair. Both halves hit the SAME slow server with
+    the SAME request — only the timeout config differs."""
+
+    async def test_slow_search_fails_under_defaults(self, slow_flair_url):
+        """Positive control: the shipped defaults really are fail-fast — a
+        2s response dies on the 1.5s read timeout."""
+        svc = _make_slow_server_service(slow_flair_url)
+        try:
+            with patch(
+                "adk_flair.memory_service._sign_request",
+                return_value="TPS-Ed25519 test-agent:0:0:AAAA",
+            ):
+                with pytest.raises(httpx.ReadTimeout):
+                    await svc._request(
+                        "POST", "/SemanticSearch",
+                        json_body={"agentId": "test-agent", "q": "q", "limit": 1},
+                    )
+        finally:
+            await svc.close()
+
+    async def test_slow_search_succeeds_under_override(self, slow_flair_url):
+        """The same 2s response succeeds once the timeout is overridden."""
+        svc = _make_slow_server_service(slow_flair_url, timeout=10.0)
+        try:
+            with patch(
+                "adk_flair.memory_service._sign_request",
+                return_value="TPS-Ed25519 test-agent:0:0:AAAA",
+            ):
+                result = await svc._request(
+                    "POST", "/SemanticSearch",
+                    json_body={"agentId": "test-agent", "q": "q", "limit": 1},
+                )
+            assert result == {"results": []}
+        finally:
+            await svc.close()
+
+    async def test_slow_search_user_visible_symptom_and_fix(self, slow_flair_url, caplog):
+        """End-to-end through search_memory: defaults -> silently empty with
+        the 'search failed' warning (the field-reported symptom); override ->
+        the search completes WITHOUT that warning. Both branches return [] (the
+        server has zero hits), so the warning is the distinguishing signal."""
+        from google.adk.memory.base_memory_service import SearchMemoryResponse
+
+        with patch(
+            "adk_flair.memory_service._sign_request",
+            return_value="TPS-Ed25519 test-agent:0:0:AAAA",
+        ):
+            svc_default = _make_slow_server_service(slow_flair_url)
+            try:
+                with caplog.at_level("WARNING", logger="adk_flair"):
+                    resp = await svc_default.search_memory(
+                        app_name="app", user_id="user", query="q"
+                    )
+                assert isinstance(resp, SearchMemoryResponse)
+                assert resp.memories == []  # swallowed timeout -> empty recall
+                assert any(
+                    "search failed" in r.getMessage() for r in caplog.records
+                ), "defaults against a slow server must hit the swallowed-timeout path"
+            finally:
+                await svc_default.close()
+
+            caplog.clear()
+            svc_override = _make_slow_server_service(slow_flair_url, timeout=10.0)
+            try:
+                with caplog.at_level("WARNING", logger="adk_flair"):
+                    resp = await svc_override.search_memory(
+                        app_name="app", user_id="user", query="q"
+                    )
+                assert isinstance(resp, SearchMemoryResponse)
+                assert resp.memories == []  # zero hits — but the search COMPLETED:
+                assert not any(
+                    "search failed" in r.getMessage() for r in caplog.records
+                ), "override must not fall into the swallowed-timeout path"
+            finally:
+                await svc_override.close()


### PR DESCRIPTION
Closes #1323

## What

adk-flair's HTTP timeouts were hardcoded to `httpx.Timeout(connect=0.5, read=1.5, write=1.0, pool=0.5)` with no override. Those numbers are deliberate localhost fail-fast tuning (ADK's search path swallows exceptions, so a down local Flair must fail instantly rather than hang the agent) — but against a hosted Flair over TLS + WAN they false-fail: connect=0.5s barely covers a cold TLS handshake and read=1.5s is under a legitimate server-side embed + hybrid retrieval. Field-reported in a real ADK agent against a hosted cluster.

## Fix shape (per the issue)

- **Constructor param** `timeout: Optional[Union[float, httpx.Timeout]] = None` — a float sets read/write seconds with connect/pool derived as `min(timeout, 5.0)` (documented rule: connection setup is bounded even over WAN; read scales with server-side work); an `httpx.Timeout` passes through verbatim and ignores the env vars (fully specified).
- **Env overrides**, read and validated at construction (a malformed value raises in the constructor, never deferred into the exception-swallowing search path): `FLAIR_HTTP_TIMEOUT` (seconds, read/write) and `FLAIR_HTTP_CONNECT_TIMEOUT` (connect/pool). Per-knob precedence: constructor param > env > default.
- **Defaults unchanged** when nothing is set — the local fail-fast property is kept and now documented at the constants as a design property, not an accident.
- **Diagnosability**: effective timeouts log once alongside the existing first-request URL warning, so a false-fail is visible in the agent's own output, with the override env var named in the line.
- **Docs**: README config table + the Remote Flair URLs section now set `FLAIR_HTTP_TIMEOUT` as part of the hosted setup — the safe path is the easy path.

## Tests (all hermetic — run in the adk-flair Python unit lane)

`packages/adk-flair/tests/test_timeout_config.py`, 16 tests:

- Resolution matrix: default unchanged when nothing set; float param (read/write set, connect capped); `httpx.Timeout` verbatim; env applied; connect-env alone; connect-env vs derived connect; **param beats env**; verbatim param ignores env; garbage/non-positive env and param raise in the constructor with the env var named.
- First-request log line carries the effective timeouts, exactly once.
- **The issue's acceptance pair**, against a real local HTTP server that responds after 2.0s: the same request **fails under defaults** with `httpx.ReadTimeout` (positive control that the default really is fail-fast — completes in ~1.51s, the read timeout firing) and **succeeds under `timeout=10.0`** (~2.12s, waiting out the response). A third end-to-end test shows the user-visible symptom through `search_memory`: defaults → silently empty recall with the swallowed-timeout warning; override → completes without it.

## Verification

- Hermetic lane: **58 passed, 9 deselected** (baseline 42 passed + 16 new), `pytest packages/adk-flair/tests -m "not live_flair"`.
- Fails-on-main positive control: the new test file run against the pre-fix `memory_service.py` fails **14/16** — the only two passing are the two that must pass there (`test_default_unchanged_when_nothing_set`, `test_slow_search_fails_under_defaults`, since defaults are identical on main).

Changelog fragment: `.changelog/unreleased/fixed-1323-adk-flair-timeout-override.md` (`changelog-fragments.mjs check` green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
