### PR TITLE
fix(doctor): --fix never enables the opt-in continuity capture hooks; the flair-mcp re-pin is flair upgrade's job (flair#1324)

### DIFF
--- a/.changelog/unreleased/fixed-1324-doctor-fix-continuity-consent.md
+++ b/.changelog/unreleased/fixed-1324-doctor-fix-continuity-consent.md
@@ -1,0 +1,13 @@
+- **`flair doctor --fix` no longer enables the opt-in continuity capture
+  hooks.** On a clean install, `--fix` silently wired the PostToolUse + Stop
+  `flair-continuity-capture` pair into `~/.claude/settings.json` — journaling
+  every tool use and session stop without the opt-in doctor's own output says
+  the feature requires (flair#1324; the non-TTY consent prompt auto-answered
+  yes, so `--fix` alone was the trigger). Doctor's fixable set is broken
+  state: enabling continuity is `flair hook install --continuity` only.
+  `--fix` still repairs a partial or stale pair — evidence of a prior opt-in —
+  to the complete current form, and `--dry-run` matches the new behavior. In
+  the same consent family, `flair upgrade --check` no longer advises
+  `flair doctor --fix` to re-pin an npx-wired flair-mcp: the pin refresh is
+  `flair upgrade`'s own job, and it now also runs when a stale pin is the only
+  pending change instead of bouncing the user to doctor.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2999,11 +2999,13 @@ export function upgradeStatusSuffix(name: string, status: UpgradeStatus): string
       : " (run: npm install -g)";
   }
   if (status === "optional") return " (install via: openclaw plugins install @tpsdev-ai/openclaw-flair)";
-  // flair-mcp is refreshed by re-pinning its wiring (`flair doctor --fix` /
-  // the post-upgrade pin refresh), never `npm install -g` — a global bin does
-  // nothing for an `npx -y -p @tpsdev-ai/flair-mcp` invocation (flair#1208).
+  // flair-mcp is refreshed by re-pinning its wiring, never `npm install -g` —
+  // a global bin does nothing for an `npx -y -p @tpsdev-ai/flair-mcp`
+  // invocation (flair#1208). The re-pin is `flair upgrade`'s own job (the
+  // #1135/#1167 pin refresh) — never advise `doctor --fix` for it
+  // (flair#1324).
   if (status === "outdated" && name === FLAIR_MCP_PACKAGE) {
-    return " (npx-wired — run: flair doctor --fix to re-pin)";
+    return " (npx-wired — flair upgrade refreshes the pin)";
   }
   return "";
 }
@@ -11293,11 +11295,62 @@ program
       return;
     }
 
-    // Nothing to install via npm/openclaw. What is left is advisory: packages
-    // not detected (missing) and/or a flair-mcp whose wired pin is behind latest
-    // — both fixed by re-wiring (`flair doctor --fix`), never by the
-    // npm-install + restart transaction below (#1168/#1208). Print the remedies
-    // and stop.
+    // ONE pin-refresh implementation, two callers (flair#1324): the post-
+    // install refresh below (#1135/#1167), and the stale-pin-only path — when
+    // flair-mcp's wired pin is behind latest but no package needs installing,
+    // `flair upgrade` refreshes the pin itself instead of advising a
+    // `doctor --fix` round-trip. Only refreshes clients that are ALREADY
+    // wired — never wires new ones. Best-effort: failures warn but never fail
+    // the upgrade.
+    async function refreshWiredMcpClientPins(targetPort: number): Promise<void> {
+      const agentId = resolveAgentIdOrEnv({}) ?? (() => {
+        try {
+          const kd = defaultKeysDir();
+          const keyFiles = readdirSync(kd).filter((f) => f.endsWith(".key"));
+          // Node-scoped federation keys aren't agents (flair#1193) — never
+          // pin-refresh a connector as one.
+          const agentKeyFile = keyFiles.find((f) => !isNodeKeyId(f.replace(/\.key$/, ""), kd));
+          return agentKeyFile ? agentKeyFile.replace(/\.key$/, "") : null;
+        } catch { return null; }
+      })();
+      if (!agentId) {
+        console.log("\n   (no agent id known — skip MCP client pin refresh; run `flair init` to refresh manually)");
+        return;
+      }
+      const httpUrl = `http://127.0.0.1:${targetPort}`;
+      const mcpEnv = { FLAIR_AGENT_ID: agentId, FLAIR_URL: httpUrl };
+      const detected = detectClients().filter(c => c.detected);
+      if (detected.length === 0) return;
+      console.log("\n   Refreshing MCP client pins...");
+      for (const client of detected) {
+        const configPath = clientConfigPath(client.id);
+        if (!existsSync(configPath)) continue;
+        // Only refresh clients that are already wired — don't wire new ones.
+        let hasFlair = false;
+        try {
+          const raw = readFileSync(configPath, "utf-8");
+          if (client.id === "codex") {
+            hasFlair = codexConfigHasFlairSection(raw);
+          } else {
+            const cfg = JSON.parse(raw);
+            hasFlair = !!cfg.mcpServers?.flair;
+          }
+        } catch { /* unreadable/malformed — skip */ }
+        if (!hasFlair) continue;
+        const env = { ...mcpEnv, FLAIR_CLIENT: client.id } as { FLAIR_AGENT_ID: string; FLAIR_URL: string; FLAIR_CLIENT?: string };
+        const result = client.wire(env);
+        console.log(`   ${result.ok ? "✓" : "•"} ${result.message}`);
+      }
+    }
+
+    // Nothing to install via npm/openclaw. What is left is advisory (packages
+    // not detected) and/or a flair-mcp whose wired pin is behind latest. The
+    // stale pin is `flair upgrade`'s OWN job (flair#1324): refresh it right
+    // here rather than bouncing the user to `flair doctor --fix` — advice
+    // that was both roundabout and, until #1324, routed every upgrading user
+    // through doctor's consent hazard. Under --check, only say what a real
+    // run will do. `npm install -g` remains wrong for flair-mcp either way
+    // (#1168/#1208).
     if (totalUpgrades === 0) {
       if (missing.length > 0) {
         const npmMissing = missing.filter((f) => f.name !== FLAIR_MCP_PACKAGE);
@@ -11312,7 +11365,11 @@ program
       }
       if (flairMcpOutdated) {
         console.log(`\n⬆️  flair-mcp is wired via npx (pinned ${flairMcpOutdated.installed} → latest ${flairMcpOutdated.latest}).`);
-        console.log(`   Re-pin it: flair doctor --fix`);
+        if (checkOnly) {
+          console.log("   Run: flair upgrade (refreshes the pin)");
+        } else {
+          await refreshWiredMcpClientPins(resolveHttpPort({}));
+        }
       }
       return;
     }
@@ -11540,46 +11597,7 @@ program
     // version. Runs BEFORE the restart so --no-restart and --no-verify paths
     // also get the refresh (flair#1167). Best-effort: failures warn but never
     // fail the upgrade.
-    await (async () => {
-      const agentId = resolveAgentIdOrEnv({}) ?? (() => {
-        try {
-          const kd = defaultKeysDir();
-          const keyFiles = readdirSync(kd).filter((f) => f.endsWith(".key"));
-          // Node-scoped federation keys aren't agents (flair#1193) — never
-          // pin-refresh a connector as one.
-          const agentKeyFile = keyFiles.find((f) => !isNodeKeyId(f.replace(/\.key$/, ""), kd));
-          return agentKeyFile ? agentKeyFile.replace(/\.key$/, "") : null;
-        } catch { return null; }
-      })();
-      if (!agentId) {
-        console.log("\n   (no agent id known — skip MCP client pin refresh; run `flair init` to refresh manually)");
-        return;
-      }
-      const httpUrl = `http://127.0.0.1:${upgradePort}`;
-      const mcpEnv = { FLAIR_AGENT_ID: agentId, FLAIR_URL: httpUrl };
-      const detected = detectClients().filter(c => c.detected);
-      if (detected.length === 0) return;
-      console.log("\n   Refreshing MCP client pins...");
-      for (const client of detected) {
-        const configPath = clientConfigPath(client.id);
-        if (!existsSync(configPath)) continue;
-        // Only refresh clients that are already wired — don't wire new ones.
-        let hasFlair = false;
-        try {
-          const raw = readFileSync(configPath, "utf-8");
-          if (client.id === "codex") {
-            hasFlair = codexConfigHasFlairSection(raw);
-          } else {
-            const cfg = JSON.parse(raw);
-            hasFlair = !!cfg.mcpServers?.flair;
-          }
-        } catch { /* unreadable/malformed — skip */ }
-        if (!hasFlair) continue;
-        const env = { ...mcpEnv, FLAIR_CLIENT: client.id } as { FLAIR_AGENT_ID: string; FLAIR_URL: string; FLAIR_CLIENT?: string };
-        const result = client.wire(env);
-        console.log(`   ${result.ok ? "✓" : "•"} ${result.message}`);
-      }
-    })();
+    await refreshWiredMcpClientPins(upgradePort);
 
     // ── Restart + verify + rollback (flair#635) ─────────────────────────────
     // Decision (2026-07-08): restart is now the default post-upgrade step —
@@ -14223,31 +14241,19 @@ program
         // the SessionStart check above: installed / absent / stale-form).
         // Continuity is OPT-IN — installing the PostToolUse+Stop pair IS the
         // opt-in — so "absent" renders as informational "not enabled": NEVER
-        // a pass (an unrun check must not look green) and never counted as an
-        // issue. A partial/stale install IS an issue and is --fix-able;
-        // --fix also offers first-time enablement (the y/N prompt is the
-        // consent; non-TTY --fix is itself the consent signal, matching every
-        // other doctor fix).
+        // a pass (an unrun check must not look green), never counted as an
+        // issue, and NEVER wired by --fix (flair#1324: doctor's fixable set
+        // is broken state; initiating an opt-in the user hasn't made is not a
+        // fix — a y/N prompt auto-answers yes in every non-TTY run, so it was
+        // no consent gate at all; enablement is `flair hook install
+        // --continuity` only). A partial or stale pair IS evidence of a prior
+        // opt-in, so repairing it to the complete current form remains a
+        // legitimate --fix.
         const continuity = checkContinuityCaptureHooks(homedir());
         if (continuity.state === "installed") {
           console.log(`  ${render.icons.ok} Continuity capture hooks: PostToolUse + Stop wired in ${render.wrap(render.c.dim, continuity.path)}`);
         } else if (continuity.state === "absent") {
           console.log(`  ${render.icons.info} Continuity capture hooks: not enabled ${render.wrap(render.c.dim, "(opt-in — auto-journal working state into the ephemeral memory tier; enable: flair hook install --continuity)")}`);
-          if (autoFix) {
-            if (dryRun) {
-              console.log(`     ${render.wrap(render.c.dim, "Would wire the continuity capture hooks (PostToolUse + Stop) in")} ${continuity.path}`);
-            } else {
-              const proceed = await confirmFix(`  Enable continuity capture (PostToolUse + Stop hooks in ${continuity.path})? [y/N] `);
-              if (!proceed) {
-                console.log(`     Skipped.`);
-              } else {
-                const fixAgentId = claudeCodeAgentId || opts.agent || process.env.FLAIR_AGENT_ID;
-                const fixRes = fixContinuityCaptureHooks(homedir(), fixAgentId);
-                console.log(`     ${fixRes.ok ? render.icons.ok : render.icons.warn} ${fixRes.message}`);
-                if (fixRes.ok && fixRes.changed) fixed++;
-              }
-            }
-          }
         } else {
           const continuityDetail = continuity.state === "partial"
             ? (!continuity.postToolUse.present ? "the PostToolUse entry is missing" : "the Stop entry is missing")

--- a/test/unit/doctor-fix-continuity-consent.test.ts
+++ b/test/unit/doctor-fix-continuity-consent.test.ts
@@ -1,0 +1,192 @@
+/**
+ * flair#1324 — `doctor --fix` must never ENABLE the opt-in continuity capture
+ * hooks; it may only REPAIR an install the user evidently opted into before.
+ *
+ * The canary repro this guards against:
+ *
+ *   flair init --agent canary-test --no-mcp
+ *   flair doctor --fix --agent canary-test    # wrote PostToolUse + Stop hooks
+ *
+ * Doctor's own surface labels continuity "opt-in — enable: `flair hook
+ * install --continuity`", and installing the pair IS the opt-in (see
+ * src/doctor-client.ts, "INSTALLING THESE HOOKS IS THE OPT-IN"). A --fix that
+ * initiates that opt-in as a side effect is a consent defect, not a fix.
+ *
+ * These tests spawn the real CLI against an isolated HOME (the
+ * cli-startup-errors.test.ts technique) because the defect lives in doctor's
+ * fix-set WIRING in cli.ts, not in the pure write helpers — a pure-function
+ * test of fixContinuityCaptureHooks cannot see which states doctor calls it
+ * from. claude-code detection is forced deterministically by prepending a
+ * fake `claude` executable to the child PATH (detectClients() is a pure
+ * PATH scan — see binInPath in src/install/clients.ts).
+ *
+ * Every doctor assertion first proves the continuity section actually
+ * RENDERED in stdout — without that, "no hooks were written" would also pass
+ * if doctor crashed (or skipped the section) before reaching it, and the
+ * guard could never fire.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import { spawnSync } from "node:child_process";
+import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  CONTINUITY_CAPTURE_HOOK_MARKER,
+  buildContinuityCaptureHookCommand,
+  checkContinuityCaptureHooks,
+} from "../../src/doctor-client.ts";
+import { upgradeStatusSuffix } from "../../src/cli.ts";
+import { FLAIR_MCP_PACKAGE } from "../../src/lib/mcp-spec.ts";
+
+const CLI_SOURCE = join(__dirname, "..", "..", "src", "cli.ts");
+const AGENT = "canary-test";
+// A port nothing listens on — keeps doctor away from any real local Flair.
+const DEAD_PORT = "59993";
+const URL = `http://127.0.0.1:${DEAD_PORT}`;
+// Generous: each case cold-starts the CLI under bun and lets doctor walk all
+// of its (offline-failing) probes on a shared CI runner.
+const SPAWN_TEST_TIMEOUT = 120_000;
+
+let isoHome: string;
+let isoCwd: string;
+let fakeBin: string;
+
+beforeEach(() => {
+  isoHome = mkdtempSync(join(tmpdir(), "flair-1324-home-"));
+  isoCwd = mkdtempSync(join(tmpdir(), "flair-1324-cwd-"));
+  fakeBin = mkdtempSync(join(tmpdir(), "flair-1324-bin-"));
+  // Deterministic claude-code detection: an executable named `claude` on PATH.
+  const fakeClaude = join(fakeBin, "claude");
+  writeFileSync(fakeClaude, "#!/bin/sh\nexit 0\n");
+  chmodSync(fakeClaude, 0o755);
+});
+
+afterEach(() => {
+  rmSync(isoHome, { recursive: true, force: true });
+  rmSync(isoCwd, { recursive: true, force: true });
+  rmSync(fakeBin, { recursive: true, force: true });
+});
+
+function runCLI(args: string[]): { exitCode: number | null; stdout: string; stderr: string } {
+  const r = spawnSync("bun", [CLI_SOURCE, ...args], {
+    cwd: isoCwd, // doctor --fix appends to ./CLAUDE.md — keep that off the repo
+    env: {
+      ...process.env,
+      HOME: isoHome,
+      USERPROFILE: isoHome,
+      PATH: `${fakeBin}:${process.env.PATH ?? ""}`,
+      // Scrub ambient Flair identity/target so only the flags decide.
+      FLAIR_AGENT_ID: "",
+      FLAIR_URL: "",
+      FLAIR_TARGET: "",
+    },
+    timeout: SPAWN_TEST_TIMEOUT - 10_000,
+    encoding: "utf8",
+  });
+  return { exitCode: r.status, stdout: r.stdout ?? "", stderr: r.stderr ?? "" };
+}
+
+function settingsPath(): string {
+  return join(isoHome, ".claude", "settings.json");
+}
+
+function settingsContainsContinuityMarker(): boolean {
+  if (!existsSync(settingsPath())) return false;
+  return readFileSync(settingsPath(), "utf-8").includes(CONTINUITY_CAPTURE_HOOK_MARKER);
+}
+
+function writePartialInstall(): void {
+  // One of the two entries (Stop only) — the evident-prior-opt-in state the
+  // issue rules repairable.
+  const command = buildContinuityCaptureHookCommand(AGENT, URL);
+  mkdirSync(join(isoHome, ".claude"), { recursive: true });
+  writeFileSync(
+    settingsPath(),
+    JSON.stringify({ hooks: { Stop: [{ hooks: [{ type: "command", command }] }] } }, null, 2) + "\n",
+  );
+  expect(checkContinuityCaptureHooks(isoHome).state).toBe("partial");
+}
+
+describe("doctor --fix and the opt-in continuity capture hooks (flair#1324)", () => {
+  it(
+    "GUARD: --fix on a clean install leaves the continuity hooks NOT enabled",
+    () => {
+      const r = runCLI(["doctor", "--fix", "--agent", AGENT, "--port", DEAD_PORT]);
+      // Non-vacuous: doctor must have reached and rendered the continuity
+      // section, and the opt-in hint must still be there (it is the product's
+      // own statement that this is opt-in).
+      expect(r.stdout).toContain("Continuity capture hooks: not enabled");
+      expect(r.stdout).toContain("flair hook install --continuity");
+      // The defect: --fix used to wire PostToolUse + Stop right here.
+      expect(settingsContainsContinuityMarker()).toBe(false);
+      expect(checkContinuityCaptureHooks(isoHome).state).toBe("absent");
+    },
+    SPAWN_TEST_TIMEOUT,
+  );
+
+  it(
+    "POSITIVE CONTROL: the same fixture, spawn env and detector DO see hooks when the user opts in",
+    () => {
+      // Same spawn environment as the guard — proving the guard's "no hooks
+      // were written" cannot be explained by an environment where hooks
+      // simply can't be written or detected.
+      const r = runCLI(["hook", "install", "--continuity", "--agent", AGENT, "--url", URL]);
+      expect(r.exitCode).toBe(0);
+      expect(settingsContainsContinuityMarker()).toBe(true);
+      expect(checkContinuityCaptureHooks(isoHome).state).toBe("installed");
+    },
+    SPAWN_TEST_TIMEOUT,
+  );
+
+  it(
+    "--fix --dry-run on a clean install does not announce continuity wiring",
+    () => {
+      const r = runCLI(["doctor", "--fix", "--dry-run", "--port", DEAD_PORT]);
+      expect(r.stdout).toContain("Continuity capture hooks: not enabled");
+      expect(r.stdout).not.toContain("Would wire the continuity capture hooks");
+      expect(settingsContainsContinuityMarker()).toBe(false);
+    },
+    SPAWN_TEST_TIMEOUT,
+  );
+
+  it(
+    "REPAIR: --fix completes a PARTIAL install (prior opt-in evidence) to the full pair",
+    () => {
+      writePartialInstall();
+      const r = runCLI(["doctor", "--fix", "--agent", AGENT, "--port", DEAD_PORT]);
+      expect(r.stdout).toContain("Continuity capture hooks: partial");
+      const after = checkContinuityCaptureHooks(isoHome);
+      expect(after.state).toBe("installed");
+      expect(after.postToolUse.present).toBe(true);
+      expect(after.stop.present).toBe(true);
+      // The repair keeps the instance the user opted into — no silent re-point.
+      expect(after.postToolUse.command).toContain(`FLAIR_URL=${URL}`);
+    },
+    SPAWN_TEST_TIMEOUT,
+  );
+
+  it(
+    "--fix --dry-run on a PARTIAL install still announces the repair (and writes nothing)",
+    () => {
+      writePartialInstall();
+      const r = runCLI(["doctor", "--fix", "--dry-run", "--port", DEAD_PORT]);
+      expect(r.stdout).toContain("Would rewrite the continuity capture hooks");
+      expect(checkContinuityCaptureHooks(isoHome).state).toBe("partial");
+    },
+    SPAWN_TEST_TIMEOUT,
+  );
+});
+
+describe("upgrade --check re-pin advice (flair#1324)", () => {
+  it("an outdated npx-wired flair-mcp is flair upgrade's job, not doctor --fix's", () => {
+    const suffix = upgradeStatusSuffix(FLAIR_MCP_PACKAGE, "outdated");
+    expect(suffix).not.toContain("doctor --fix");
+    expect(suffix).toContain("flair upgrade");
+  });
+
+  it("POSITIVE CONTROL: the missing (never-wired) case still points at doctor --fix, so the assertion above is not blind to the phrase", () => {
+    expect(upgradeStatusSuffix(FLAIR_MCP_PACKAGE, "missing")).toContain("doctor --fix");
+  });
+});

--- a/test/unit/upgrade-probes.test.ts
+++ b/test/unit/upgrade-probes.test.ts
@@ -194,13 +194,15 @@ describe("upgradeStatusSuffix", () => {
     expect(suffix).toContain("npm install -g");
   });
 
-  // flair#1208: an outdated flair-mcp is re-pinned by re-wiring (`flair doctor
-  // --fix`), never `npm install -g` — a global bin does nothing for an
-  // `npx -y -p @tpsdev-ai/flair-mcp` invocation. So its outdated line carries
-  // the doctor remedy, while every other package still has no outdated suffix.
-  test("outdated flair-mcp shows the doctor re-pin remedy, never npm install -g", () => {
+  // flair#1208: an outdated flair-mcp is re-pinned by re-wiring, never
+  // `npm install -g` — a global bin does nothing for an
+  // `npx -y -p @tpsdev-ai/flair-mcp` invocation. flair#1324: the re-pin is
+  // `flair upgrade`'s own job, so the line names that instead of bouncing the
+  // user to `doctor --fix`; every other package still has no outdated suffix.
+  test("outdated flair-mcp says flair upgrade refreshes the pin — never npm install -g, never doctor --fix", () => {
     const suffix = upgradeStatusSuffix("@tpsdev-ai/flair-mcp", "outdated");
-    expect(suffix).toContain("flair doctor --fix");
+    expect(suffix).toContain("flair upgrade");
+    expect(suffix).not.toContain("doctor --fix");
     expect(suffix).not.toContain("npm install -g");
     expect(suffix).not.toContain("npm i -g");
   });


### PR DESCRIPTION
## What

Canary MAJOR finding (2026-08-22, 0.46.0 -> 0.47.0 leg): `flair doctor --fix` on a clean install silently wired the opt-in continuity capture hooks (PostToolUse + Stop running `flair-continuity-capture`) into `~/.claude/settings.json` — enabling, as a side effect, the very capture doctor's own output labels *"opt-in — enable: `flair hook install --continuity`"*. The y/N prompt was no consent gate: `confirmFix` auto-answers yes in every non-TTY run. Compounding it, `flair upgrade --check` sent every upgrading user into that hazard with "run: `flair doctor --fix` to re-pin".

## Fix (matches the issue's fix shape)

1. **doctor's fixable set is broken state only.** The `absent` branch loses its `--fix` offer and its `--dry-run` announcement; the informational opt-in line stays. A **partial or stale** pair is evidence of a prior opt-in, so `--fix` still repairs it to the complete current form (preserving the wired `FLAIR_URL`), in both real and `--dry-run` output.
2. **`upgrade --check` stops advising `doctor --fix` for the re-pin.** The listing suffix now reads `(npx-wired — flair upgrade refreshes the pin)`. For that sentence to be true in *every* case, the stale-pin-only path (`totalUpgrades === 0` with an outdated wired pin) now runs the same #1135/#1167 refresh in a real `flair upgrade` run instead of returning with the doctor advice; under `--check` it says `Run: flair upgrade (refreshes the pin)`. The refresh block is hoisted verbatim into `refreshWiredMcpClientPins()` — one implementation, two callers. The **missing** (never-wired) case keeps its `doctor --fix` advice: wiring an unwired client is a legitimate doctor fix, and after this PR that command no longer carries the consent hazard.

## Powered check (guard written first, red on unmodified main)

`test/unit/doctor-fix-continuity-consent.test.ts` spawns the real CLI against an isolated `HOME` with a fake `claude` on `PATH` (deterministic client detection). On main `8e83a73a`:

```
(fail) GUARD: --fix on a clean install leaves the continuity hooks NOT enabled
       expect(settingsContainsContinuityMarker()).toBe(false)  — received true
(fail) --fix --dry-run on a clean install does not announce continuity wiring
       stdout contained "Would wire the continuity capture hooks (PostToolUse + Stop)"
(fail) an outdated npx-wired flair-mcp is flair upgrade's job, not doctor --fix's
       received " (npx-wired — run: flair doctor --fix to re-pin)"
 4 pass / 3 fail
```

Non-vacuity: every doctor assertion first proves the continuity section rendered in stdout, so "no hooks written" cannot pass on a run that never reached the check. Positive controls: (a) the same fixture + spawn env + detector DO see hooks when opted in via `flair hook install --continuity`; (b) the `missing` suffix still contains `doctor --fix`, so the not-contains assertion is not blind to the phrase.

**Mutation check:** re-adding the absent-branch wiring flips the guard red (2 fail: write path + dry-run announcement); restored.

## Tests

- Unit lane (`bun test test/unit/ test/*.test.ts`): **4891 pass / 0 fail across 255 files** vs self-measured origin/main baseline **4884 / 0 across 254** — delta is exactly the 7 new guard tests.
- `tsc --noEmit -p tsconfig.check.src.json` clean; changelog fragment validates.
- One existing test updated: `upgrade-probes.test.ts` asserted the old doctor-re-pin phrase; its real intent (never `npm install -g`) is kept and now also pins never-`doctor --fix`.

Closes #1324

🤖 Generated with [Claude Code](https://claude.com/claude-code)
