### PR TITLE
feat(adk-flair): custom_metadata store-and-return + subject + list_memories (#1332, #1333)

### DIFF
--- a/.changelog/unreleased/added-1332-1333-adk-metadata-subject-list.md
+++ b/.changelog/unreleased/added-1332-1333-adk-metadata-subject-list.md
@@ -1,0 +1,22 @@
+- **adk-flair: `custom_metadata` is now stored and returned, `subject` becomes
+  a first-class column, and `list_memories()` lands** (flair#1332, flair#1333;
+  design flair#1202). `add_memory()`/`add_events_to_memory()` serialize
+  `custom_metadata` into a new client-writable `Memory.metadata` JSON field —
+  store-and-return only, exactly ADK's contract: the blob is opaque to the
+  server and no key in it has any server-side effect (contract-tested:
+  `{"visibility":"shared"}` in the blob leaves the record private). Caps
+  reject with `ValueError`, never truncate: 64KB serialized, nesting ≤ 16,
+  ≤ 512 keys; non-serializable values skip that key with a WARNING.
+  `subject` (≤ 512 chars, explicit param authoritative over
+  `custom_metadata["subject"]`, never auto-extracted) is promoted to the
+  record's existing indexed `subject` column. `search_memory()` returns both
+  on `MemoryEntry.custom_metadata` (top-level subject surfaced as
+  `custom_metadata["subject"]`; malformed blobs fail soft to `{}` with a
+  WARNING) via a new opt-in `includeMetadata` flag on `/SemanticSearch` —
+  the default projection (and every other consumer's response) is
+  byte-unchanged. `MemoryEntry.author` now carries the writing agent id
+  (was always `None` — read a field Flair never projected). New
+  `list_memories(app_name, user_id, limit≤200, offset)` — a Flair-specific
+  extension beyond `BaseMemoryService` — pages memories newest-first with
+  the full projection, scoped by compound tag + agent identity, both pushed
+  down and re-verified client-side.

--- a/packages/adk-flair/README.md
+++ b/packages/adk-flair/README.md
@@ -223,10 +223,17 @@ Search hits are mapped to ADK's `MemoryEntry` type:
 MemoryEntry(
     id=record["id"],
     content=types.Content(role="model", parts=[types.Part(text=record["content"])]),
-    author=record.get("author"),
+    author=record.get("agentId"),       # the writing Flair agent
     timestamp=record.get("createdAt"),  # ISO 8601
+    custom_metadata={...},              # parsed metadata blob; see below
 )
 ```
+
+`author` is the Flair agent id that wrote the record. `custom_metadata` is the
+stored metadata blob parsed back to a dict (see the custom_metadata section);
+when the record carries a top-level `subject`, it is surfaced as
+`custom_metadata["subject"]` — `MemoryEntry` has no subject attribute, so the
+dict is its return channel.
 
 ## Idempotent writes
 
@@ -236,9 +243,104 @@ content; it never sees duplicates.
 
 ## custom_metadata
 
-`custom_metadata` keys are not supported by `adk-flair`. Passing unsupported
-keys logs a warning once per session — a user setting TTL must not believe it
-worked.
+`custom_metadata` is **stored and returned** (flair#1332): the dict you pass to
+`add_memory()` / `add_events_to_memory()` is serialized to JSON, stored on the
+Flair record's `metadata` field, and round-trips back on
+`MemoryEntry.custom_metadata` from `search_memory()` and `list_memories()` —
+nesting and typing preserved.
+
+```python
+await memory_service.add_memory(
+    app_name="my-app",
+    user_id="user-123",
+    memories=[...],
+    custom_metadata={
+        "merchant": "acme",
+        "price": {"amount": 12.5, "currency": "EUR"},
+        "media_url": "s3://receipts/2026-08/acme.jpg",
+    },
+)
+```
+
+**Store-and-return only.** That is ADK's own contract for the field (no ADK
+implementation filters searches by `custom_metadata`), and Flair honors it
+strictly: the blob is opaque to the server — never parsed, never queried, and
+**no key in it has any server-side effect**. `{"visibility": "shared"}` inside
+`custom_metadata` does not share the memory; use the explicit `visibility`
+parameter for that. You also cannot filter searches by a metadata key; if a
+key needs filtering, that's a schema promotion (like `subject` below), not a
+blob read.
+
+Caps — violations **reject with `ValueError` before anything is written**
+(never truncated: a silently truncated blob would corrupt the round-trip
+guarantee):
+
+- 64KB serialized JSON
+- nesting depth ≤ 16
+- ≤ 512 total keys
+
+A value that isn't JSON-serializable skips **that key** with a WARNING naming
+the session — the rest of the blob is stored. Malformed JSON encountered on
+read fails soft: that entry's `custom_metadata` is `{}` and a WARNING names
+the record id.
+
+### subject
+
+A short human-readable title (≤ 512 chars), promoted to the Flair record's
+top-level indexed `subject` column — cleanly queryable and usable by UIs,
+unlike a blob key. Two ways to set it; the explicit parameter wins when both
+are present. It is **never** auto-extracted from content.
+
+```python
+await memory_service.add_memory(
+    app_name="my-app", user_id="user-123", memories=[...],
+    subject="Receipt: Acme Groceries",          # explicit param (authoritative)
+    # or: custom_metadata={"subject": "..."}    # promoted from the blob
+)
+```
+
+On read, the stored column value is surfaced as `custom_metadata["subject"]`
+(the column is authoritative over a divergent blob key).
+
+### Security caveat
+
+Memory content **and metadata** are untrusted input to the consuming agent's
+context — treat every retrieved value like any retrieved document: render,
+don't execute; quote, don't trust. The adapter deliberately does **no**
+sanitization of metadata values: sanitization of free-form JSON is lossy (it
+corrupts the round-trip the field exists for) and gives false safety (no
+blocklist anticipates the consuming context). The boundary that matters is
+yours: whatever reads these values back must treat them as data.
+
+## list_memories
+
+`list_memories()` is a **Flair-specific extension** — it is *not* part of
+ADK's `BaseMemoryService` (which specifies only `search_memory`). Use it for
+memory review UIs, dashboards, or agent browsing where there's no query to
+search with:
+
+```python
+entries = await memory_service.list_memories(
+    app_name="my-app",
+    user_id="user-123",
+    limit=50,    # 1..200 — over the cap raises ValueError (never clamps)
+    offset=0,    # positional skip from the newest record
+)
+```
+
+- Returns `List[MemoryEntry]`, newest first (`createdAt` descending), with the
+  full projection: content, `author`, `timestamp`, `custom_metadata`
+  (including `subject`).
+- Scoped exactly like `search_memory`: the `adk:<app>:<user>` compound tag AND
+  the service's own agent identity, both pushed down server-side and
+  re-verified client-side on every row.
+- **Pagination is a point-in-time snapshot** — `offset` is positional, not a
+  live cursor. Writes between two page fetches shift positions, so a record
+  can appear twice or be skipped across page boundaries; dedupe by `id` if you
+  page a moving corpus.
+- Unlike `search_memory` (whose swallow-to-empty posture is ADK's contract),
+  `list_memories` **raises** on transport/server failure — a browsing UI must
+  be able to tell "no memories" from "Flair is down".
 
 ## What this adapter deliberately doesn't do
 

--- a/packages/adk-flair/src/adk_flair/memory_service.py
+++ b/packages/adk-flair/src/adk_flair/memory_service.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 
 import base64
 import hashlib
+import json
 import logging
 import math
 import os
@@ -30,7 +31,7 @@ import uuid
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict, List, Mapping, Optional, Sequence, Union
-from urllib.parse import urlparse
+from urllib.parse import quote, urlparse
 
 import httpx
 from cryptography.hazmat.primitives import serialization
@@ -74,6 +75,29 @@ _CONNECT_TIMEOUT_CAP = 5.0
 # level from inside add_memory; Sherlock's cosmetic note on #1237).
 _VALID_DURABILITIES = frozenset(["permanent", "persistent", "standard", "ephemeral"])
 _VALID_VISIBILITIES = frozenset(["private", "shared"])
+
+# custom_metadata caps (flair#1332, Sherlock hard requirements). REJECT, never
+# truncate — a truncated blob silently corrupts the store-and-return round-trip
+# guarantee, which is the entire contract of the field.
+#   - _METADATA_MAX_BYTES: serialized JSON size cap. 64KB is generous for
+#     structured attributes (merchant/price/category/media refs) while keeping
+#     a single memory record from becoming a blob store.
+#   - _METADATA_MAX_DEPTH / _METADATA_MAX_KEYS: cheap structural caps checked
+#     BEFORE serialization (billion-laughs-adjacent guard — a pathologically
+#     nested/wide dict is refused without ever attempting to serialize it).
+_METADATA_MAX_BYTES = 64 * 1024
+_METADATA_MAX_DEPTH = 16
+_METADATA_MAX_KEYS = 512
+
+# subject cap (flair#1332): subject is a short human-readable title promoted to
+# the record's top-level indexed `subject` column — never a content field.
+_SUBJECT_MAX_CHARS = 512
+
+# list_memories page-size hard cap (flair#1333). Reject-with-error (never
+# clamp) — consistent with every other adk-flair validation: a silently
+# clamped limit would make "I asked for 500, why did I get 200" a debugging
+# session instead of an immediate, actionable ValueError.
+_LIST_MEMORIES_MAX_LIMIT = 200
 
 # ─── Helpers ────────────────────────────────────────────────────────────────
 
@@ -303,6 +327,142 @@ def _resolve_timeout(
     return httpx.Timeout(connect=connect, read=read, write=write, pool=pool)
 
 
+# ─── custom_metadata / subject (flair#1332) ─────────────────────────────────
+
+
+def _validate_metadata_shape(custom_metadata: Mapping[str, object]) -> None:
+    """Structural caps on custom_metadata, checked BEFORE serialization.
+
+    Rejects nesting deeper than _METADATA_MAX_DEPTH levels or more than
+    _METADATA_MAX_KEYS total dict keys (counted across every level) with a
+    ValueError. Iterative traversal — no recursion, so adversarial nesting
+    can't blow the Python stack; a self-referencing structure terminates via
+    the depth cap (each revisit is pushed one level deeper).
+    """
+    stack: List[tuple] = [(custom_metadata, 1)]
+    key_count = 0
+    while stack:
+        node, depth = stack.pop()
+        if depth > _METADATA_MAX_DEPTH:
+            raise ValueError(
+                f"custom_metadata nesting exceeds {_METADATA_MAX_DEPTH} levels — "
+                "flatten the structure, or store a reference to the data instead "
+                "of embedding it"
+            )
+        if isinstance(node, Mapping):
+            key_count += len(node)
+            if key_count > _METADATA_MAX_KEYS:
+                raise ValueError(
+                    f"custom_metadata carries more than {_METADATA_MAX_KEYS} keys "
+                    "in total — split the data across memories, or store a "
+                    "reference to it instead"
+                )
+            children = node.values()
+        elif isinstance(node, (list, tuple)):
+            children = node
+        else:
+            continue
+        for child in children:
+            if isinstance(child, (Mapping, list, tuple)):
+                stack.append((child, depth + 1))
+
+
+def _serialize_custom_metadata(
+    custom_metadata: Optional[Mapping[str, object]],
+    context_key: str,
+) -> Optional[str]:
+    """Serialize custom_metadata to the JSON string stored in Memory.metadata.
+
+    Store-and-return contract (#1202): the blob is opaque to the server —
+    stored verbatim, returned verbatim, no key in it influences any server
+    decision.
+
+    - Structural caps (depth/key-count) and the serialized 64KB cap REJECT
+      with ValueError — never truncate (truncation corrupts the round-trip
+      guarantee; Sherlock hard requirement).
+    - A non-serializable VALUE skips that key with a WARNING naming the
+      session key — one bad value must not discard the caller's whole blob.
+
+    Returns None when there is nothing to store (no metadata, or every key
+    was skipped).
+    """
+    if not custom_metadata:
+        return None
+
+    _validate_metadata_shape(custom_metadata)
+
+    clean: Dict[str, Any] = {}
+    for key, value in custom_metadata.items():
+        if not isinstance(key, str):
+            logger.warning(
+                "adk-flair: custom_metadata key %r skipped — keys must be "
+                "strings (session=%s)", key, context_key,
+            )
+            continue
+        try:
+            json.dumps(value)
+        except (TypeError, ValueError):
+            logger.warning(
+                "adk-flair: custom_metadata key %r skipped — value is not "
+                "JSON-serializable (session=%s)", key, context_key,
+            )
+            continue
+        clean[key] = value
+
+    if not clean:
+        return None
+
+    serialized = json.dumps(clean)
+    size = len(serialized.encode("utf-8"))
+    if size > _METADATA_MAX_BYTES:
+        raise ValueError(
+            f"custom_metadata serializes to {size} bytes, over the "
+            f"{_METADATA_MAX_BYTES}-byte cap — store large payloads elsewhere "
+            "and keep a reference here. Rejected rather than truncated: a "
+            "truncated blob would silently corrupt the store-and-return "
+            "round-trip guarantee."
+        )
+    return serialized
+
+
+def _resolve_subject(
+    explicit_subject: Optional[str],
+    custom_metadata: Optional[Mapping[str, object]],
+) -> Optional[str]:
+    """Resolve the top-level `subject` column value (flair#1332).
+
+    Precedence: an explicit subject param is authoritative over
+    custom_metadata["subject"] when both are supplied. NEVER auto-extracted
+    from content. Rejects non-string or over-cap (512 chars) values with a
+    ValueError — subject is a short human-readable title promoted to an
+    indexed column, not a content field. Returns None when neither source
+    supplies one (empty strings resolve to None — nothing to promote).
+    """
+    subject: Any = explicit_subject
+    source = "subject param"
+    if subject is None and custom_metadata is not None:
+        try:
+            subject = custom_metadata.get("subject")
+        except AttributeError:
+            subject = None
+        source = 'custom_metadata["subject"]'
+    if subject is None:
+        return None
+    if not isinstance(subject, str):
+        raise ValueError(
+            f"{source} must be a string (got: {type(subject).__name__}) — "
+            "subject is promoted to the record's top-level subject column"
+        )
+    if len(subject) > _SUBJECT_MAX_CHARS:
+        raise ValueError(
+            f"{source} is {len(subject)} characters, over the "
+            f"{_SUBJECT_MAX_CHARS}-char cap — subject is a short "
+            "human-readable title; put longer text in content or "
+            "custom_metadata"
+        )
+    return subject or None
+
+
 # ─── FlairMemoryService ─────────────────────────────────────────────────────
 
 
@@ -361,9 +521,6 @@ class FlairMemoryService(BaseMemoryService):
 
         # httpx client — created lazily on first request
         self._client: Optional[httpx.AsyncClient] = None
-
-        # Per-session state for custom_metadata warn-once
-        self._warned_sessions: set[str] = set()
 
         # First-request URL logging gate
         self._url_logged = False
@@ -495,19 +652,27 @@ class FlairMemoryService(BaseMemoryService):
         session_id: Optional[str] = None,
         custom_metadata: Optional[Mapping[str, object]] = None,
     ) -> None:
-        """Incremental per-turn event writes (the quickstart's after_agent_callback path)."""
+        """Incremental per-turn event writes (the quickstart's after_agent_callback path).
+
+        custom_metadata (flair#1332) is stored on every record this call
+        writes, as an opaque JSON blob on the Memory record's `metadata`
+        field, and round-trips back on `MemoryEntry.custom_metadata` from
+        search_memory / list_memories. Store-and-return only — no key in it
+        has any server-side effect. Caps (ValueError before any write):
+        64KB serialized, nesting depth <= 16, <= 512 total keys.
+        custom_metadata["subject"] (a string) is additionally promoted to the
+        record's top-level `subject` column (<= 512 chars).
+        """
         tag = _compound_tag(app_name, user_id)
         sid = session_id or ""
 
-        # custom_metadata warn-once per session
-        if custom_metadata:
-            session_key = f"{app_name}:{user_id}:{sid}"
-            if session_key not in self._warned_sessions:
-                self._warned_sessions.add(session_key)
-                logger.warning(
-                    "adk-flair: custom_metadata ignored — adk-flair does not "
-                    "support custom_metadata keys (session=%s)", session_key
-                )
+        # custom_metadata → opaque JSON blob + optional promoted subject
+        # (flair#1332). Validated/serialized ONCE, before any write — a cap
+        # violation raises here and zero events are written, never a partial
+        # batch with silently-dropped metadata.
+        session_key = f"{app_name}:{user_id}:{sid}"
+        metadata_json = _serialize_custom_metadata(custom_metadata, session_key)
+        subject_value = _resolve_subject(None, custom_metadata)
 
         written = 0
         for event in events:
@@ -526,6 +691,10 @@ class FlairMemoryService(BaseMemoryService):
                 "tags": [tag],
                 "createdAt": _iso_now(),
             }
+            if metadata_json is not None:
+                body["metadata"] = metadata_json
+            if subject_value is not None:
+                body["subject"] = subject_value
             try:
                 await self._request("PUT", f"/Memory/{record_id}", json_body=body)
                 written += 1
@@ -552,8 +721,26 @@ class FlairMemoryService(BaseMemoryService):
         custom_metadata: Optional[Mapping[str, object]] = None,
         durability: Optional[str] = None,
         visibility: Optional[str] = None,
+        subject: Optional[str] = None,
     ) -> None:
         """Direct memory writes — each MemoryEntry becomes a Flair record.
+
+        custom_metadata (flair#1332) is stored on every record this call
+        writes, as an opaque JSON blob on the Memory record's `metadata`
+        field, and round-trips back on `MemoryEntry.custom_metadata` from
+        search_memory / list_memories. Store-and-return only (the ADK
+        contract, #1202): no key inside the blob has ANY server-side effect —
+        {"visibility": "shared"} in here does not share the memory (use the
+        explicit `visibility` param for that). Caps (ValueError before any
+        write; reject, never truncate): 64KB serialized, nesting depth <= 16,
+        <= 512 total keys. Non-JSON-serializable values skip that key with a
+        WARNING.
+
+        subject (flair#1332, Flair-specific extension): short human-readable
+        title promoted to the record's top-level indexed `subject` column.
+        Sourced from this param or custom_metadata["subject"]; the explicit
+        param is authoritative when both are present. <= 512 chars (ValueError
+        beyond). Never auto-extracted from content.
 
         Optional knobs (trust-anchor opt-in, never model-selected):
             durability: one of permanent, persistent, standard, ephemeral.
@@ -578,15 +765,13 @@ class FlairMemoryService(BaseMemoryService):
                 f"(got: {visibility!r})"
             )
 
-        # custom_metadata warn-once
-        if custom_metadata:
-            session_key = f"{app_name}:{user_id}:direct"
-            if session_key not in self._warned_sessions:
-                self._warned_sessions.add(session_key)
-                logger.warning(
-                    "adk-flair: custom_metadata ignored — adk-flair does not "
-                    "support custom_metadata keys"
-                )
+        # custom_metadata → opaque JSON blob + optional promoted subject
+        # (flair#1332). Validated/serialized ONCE, before any write — a cap
+        # violation raises here and zero records are written.
+        metadata_json = _serialize_custom_metadata(
+            custom_metadata, f"{app_name}:{user_id}:direct"
+        )
+        subject_value = _resolve_subject(subject, custom_metadata)
 
         written = 0
         for mem in memories:
@@ -606,6 +791,10 @@ class FlairMemoryService(BaseMemoryService):
             }
             if visibility is not None:
                 body["visibility"] = visibility
+            if metadata_json is not None:
+                body["metadata"] = metadata_json
+            if subject_value is not None:
+                body["subject"] = subject_value
             if mem.author:
                 body["author"] = mem.author
             try:
@@ -635,6 +824,14 @@ class FlairMemoryService(BaseMemoryService):
         """Semantic search over Flair memories scoped to this app+user.
 
         user_id is mandatory — missing/empty returns empty, never searches unscoped.
+
+        Each returned MemoryEntry carries (flair#1332):
+          - custom_metadata: the stored metadata blob, parsed back to a dict
+            (fail-soft {} + WARNING on malformed JSON — a corrupt blob must
+            never take recall down). When the record has a top-level subject,
+            it is surfaced as custom_metadata["subject"], the top-level column
+            being authoritative over any divergent blob key.
+          - author: the writing Flair agent id (the record's agentId).
         """
         # Mandatory user_id gate
         if not user_id:
@@ -648,6 +845,12 @@ class FlairMemoryService(BaseMemoryService):
                 "q": query,
                 "limit": 20,
                 "tag": tag,
+                # flair#1332: opt into the `metadata` blob in each hit.
+                # /SemanticSearch's default projection deliberately omits it
+                # (other consumers must not pay result-size for a blob they
+                # never read); this flag widens the projection for THIS
+                # request only. `subject` is in the default projection.
+                "includeMetadata": True,
             }
             result = await self._request("POST", "/SemanticSearch", json_body=body)
         except Exception:
@@ -673,20 +876,164 @@ class FlairMemoryService(BaseMemoryService):
             if tag not in hit_tags:
                 continue
 
-            content_text = hit.get("content") or ""
-            memories.append(
-                MemoryEntry(
-                    id=hit.get("id"),
-                    content=types.Content(
-                        role="model",
-                        parts=[types.Part(text=content_text)],
-                    ),
-                    author=hit.get("author"),
-                    timestamp=hit.get("createdAt"),
-                )
-            )
+            memories.append(self._hit_to_memory_entry(hit))
 
         return SearchMemoryResponse(memories=memories)
+
+    # ── list_memories (flair#1333 — Flair-specific extension) ───────────────
+
+    async def list_memories(
+        self,
+        *,
+        app_name: str,
+        user_id: str,
+        limit: int = 50,
+        offset: int = 0,
+    ) -> List[MemoryEntry]:
+        """List recent memories for an app+user, newest first.
+
+        Flair-specific extension — NOT part of ADK's BaseMemoryService (which
+        specifies only search_memory). Useful for memory review UIs,
+        dashboards, and agent contextual browsing where there is no query to
+        search with.
+
+        Scope: the same compound tag (adk:<app>:<user>) search_memory uses,
+        AND agentId == this service's agent identity — both pushed down as
+        server-side query conditions and re-verified client-side on every
+        returned row (defense in depth).
+
+        Pagination: `offset` is POSITIONAL over a point-in-time snapshot
+        ordered by createdAt descending — not a live cursor. Memories written
+        between two pages shift positions, so a record can appear twice or be
+        skipped across page boundaries. For a consistent view, take one page,
+        or dedupe by id across pages.
+
+        Args:
+            app_name: ADK app name (required).
+            user_id: ADK user id (required — never lists unscoped).
+            limit: page size, 1..200. Over-cap REJECTS with ValueError
+                (never silently clamps).
+            offset: number of newest records to skip (>= 0).
+
+        Returns:
+            List[MemoryEntry] with the full projection — content, author
+            (the writing agent id), timestamp, and custom_metadata (parsed
+            blob; top-level subject surfaced as custom_metadata["subject"]).
+
+        Raises:
+            ValueError: invalid app_name/user_id/limit/offset.
+            httpx.HTTPError / RuntimeError: transport or server failure.
+                Unlike search_memory (whose empty-on-error contract is ADK's),
+                this method PROPAGATES failures — a browsing UI must be able
+                to tell "no memories" from "Flair is down".
+        """
+        if not app_name:
+            raise ValueError("app_name is required")
+        if not user_id:
+            raise ValueError("user_id is required — list_memories never lists unscoped")
+        if not isinstance(limit, int) or isinstance(limit, bool) or limit < 1:
+            raise ValueError(f"limit must be a positive integer (got: {limit!r})")
+        if limit > _LIST_MEMORIES_MAX_LIMIT:
+            raise ValueError(
+                f"limit {limit} exceeds the hard cap of {_LIST_MEMORIES_MAX_LIMIT} "
+                "— page with offset instead"
+            )
+        if not isinstance(offset, int) or isinstance(offset, bool) or offset < 0:
+            raise ValueError(f"offset must be a non-negative integer (got: {offset!r})")
+
+        tag = _compound_tag(app_name, user_id)
+
+        # Harper REST collection query (signed like every other request —
+        # the signature covers path+query). The tag value is percent-encoded
+        # WHOLESALE: compound tags legitimately contain literal %XX escapes
+        # from _sanitize_tag_segment, which must survive the server's URL
+        # decode. limit(start,end) is Harper's offset window: start=offset,
+        # end=offset+limit.
+        path = (
+            f"/Memory/?tags={quote(tag, safe='')}"
+            f"&agentId={quote(self._agent_id, safe='')}"
+            f"&select(id,agentId,content,metadata,subject,tags,createdAt)"
+            f"&sort(-createdAt)"
+            f"&limit({offset},{offset + limit})"
+        )
+        rows = await self._request("GET", path)
+
+        if not isinstance(rows, list):
+            return []
+
+        entries: List[MemoryEntry] = []
+        for row in rows:
+            if not isinstance(row, dict):
+                continue
+            # Defense in depth: re-verify both scope conditions client-side,
+            # mirroring search_memory's tag re-verification.
+            if tag not in (row.get("tags") or []):
+                continue
+            if row.get("agentId") != self._agent_id:
+                continue
+            entries.append(self._hit_to_memory_entry(row))
+        return entries
+
+    # ── Hit → MemoryEntry mapping ────────────────────────────────────────────
+
+    def _hit_to_memory_entry(self, hit: Dict[str, Any]) -> MemoryEntry:
+        """Map a Flair Memory record/hit onto an ADK MemoryEntry.
+
+        author derives from the record's agentId — the writing Flair agent
+        (flair#1332 incidental fix: the old code read hit["author"], a field
+        Flair neither declares nor projects, so author was always None).
+        """
+        content_text = hit.get("content") or ""
+        return MemoryEntry(
+            id=hit.get("id"),
+            content=types.Content(
+                role="model",
+                parts=[types.Part(text=content_text)],
+            ),
+            author=hit.get("agentId"),
+            timestamp=hit.get("createdAt"),
+            custom_metadata=self._hit_custom_metadata(hit),
+        )
+
+    @staticmethod
+    def _hit_custom_metadata(hit: Dict[str, Any]) -> Dict[str, Any]:
+        """Rebuild MemoryEntry.custom_metadata from a record's stored fields.
+
+        - `metadata` (the opaque JSON blob) parses back to a dict. FAIL-SOFT:
+          malformed JSON (or JSON that isn't an object) yields {} plus a
+          WARNING naming the record id — a corrupt blob on one record must
+          never take the whole read path down.
+        - A top-level `subject` column is surfaced as
+          custom_metadata["subject"]. The COLUMN is authoritative (#1332
+          ruling): when the blob carries a divergent "subject" key, the
+          column value overwrites it in the returned dict. This also means a
+          subject written via the explicit param (never in the blob) still
+          round-trips on read — MemoryEntry has no subject attribute, so
+          custom_metadata is its only return channel.
+        """
+        parsed: Dict[str, Any] = {}
+        raw = hit.get("metadata")
+        if raw:
+            try:
+                loaded = json.loads(raw)
+            except (TypeError, ValueError):
+                logger.warning(
+                    "adk-flair: malformed metadata JSON on record %s — "
+                    "returning empty custom_metadata for it", hit.get("id"),
+                )
+            else:
+                if isinstance(loaded, dict):
+                    parsed = loaded
+                else:
+                    logger.warning(
+                        "adk-flair: metadata on record %s is JSON but not an "
+                        "object — returning empty custom_metadata for it",
+                        hit.get("id"),
+                    )
+        subject = hit.get("subject")
+        if isinstance(subject, str) and subject:
+            parsed["subject"] = subject
+        return parsed
 
     # ── Event text extraction ────────────────────────────────────────────────
 

--- a/packages/adk-flair/tests/test_memory_service.py
+++ b/packages/adk-flair/tests/test_memory_service.py
@@ -294,7 +294,9 @@ class TestSearchMemory:
                 {
                     "id": "mem-1",
                     "content": "remember this fact",
-                    "author": "test-agent",
+                    # author derives from the record's agentId (flair#1332
+                    # incidental fix) — records carry no "author" field.
+                    "agentId": "test-agent",
                     "createdAt": "2026-08-05T12:00:00.000Z",
                     "tags": ["adk:app:user"],
                 },
@@ -504,7 +506,10 @@ class TestAddEventsToMemory:
         assert service._client.request.call_count == 2
 
     @pytest.mark.asyncio
-    async def test_custom_metadata_warns_once(self, service, caplog):
+    async def test_custom_metadata_is_stored_not_warned(self, service, caplog):
+        """flair#1332: custom_metadata is no longer dropped with a warning —
+        it is serialized into body["metadata"] on every event record."""
+        import logging as _logging
         events = [_make_event("evt-1", "hello")]
 
         service._client.request.return_value = MagicMock(
@@ -513,22 +518,19 @@ class TestAddEventsToMemory:
             text="{}",
         )
 
-        # First call — should warn
-        await service.add_events_to_memory(
-            app_name="app", user_id="user", events=events,
-            session_id="sess-1", custom_metadata={"ttl": "7d"},
-        )
-        # Second call — should NOT warn again for same session
-        await service.add_events_to_memory(
-            app_name="app", user_id="user", events=events,
-            session_id="sess-1", custom_metadata={"ttl": "7d"},
-        )
+        with caplog.at_level(_logging.WARNING, logger="adk_flair"):
+            await service.add_events_to_memory(
+                app_name="app", user_id="user", events=events,
+                session_id="sess-1", custom_metadata={"ttl": "7d"},
+            )
 
+        body = service._client.request.call_args[1]["json"]
+        assert json.loads(body["metadata"]) == {"ttl": "7d"}
         custom_warnings = [
             r.message for r in caplog.records
-            if "custom_metadata" in r.message.lower()
+            if "custom_metadata" in str(r.message).lower()
         ]
-        assert len(custom_warnings) == 1  # warned once, not twice
+        assert custom_warnings == []  # supported now — nothing to warn about
 
 
 # ─── add_memory (explicit durability/visibility) ────────────────────────────

--- a/packages/adk-flair/tests/test_metadata_and_list.py
+++ b/packages/adk-flair/tests/test_metadata_and_list.py
@@ -1,0 +1,661 @@
+"""Tests for flair#1332 (custom_metadata + subject) and flair#1333 (list_memories).
+
+Two tiers, same split as the rest of the suite:
+
+  - Hermetic (default lane, ``-m "not live_flair"``): mocked httpx — write-body
+    shape, caps (64KB / depth / key-count / subject-512), precedence, read-path
+    fail-soft, list_memories URL construction + scoping + validation.
+
+  - Live (``@pytest.mark.live_flair``): a real ephemeral Harper — the nested
+    round-trip, the STORE-AND-RETURN CONTRACT test (Sherlock hard requirement:
+    metadata blob keys named after server knobs have ZERO effect on the
+    record's actual visibility/durability), subject persistence, and
+    list_memories pagination/scope against real query pushdown.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import logging
+import time
+import uuid
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+from cryptography.hazmat.primitives.asymmetric import ed25519
+from google.adk.memory.memory_entry import MemoryEntry
+from google.genai import types
+
+
+# ─── Fixtures (mirrors test_memory_service.py's mock-client service) ─────────
+
+
+@pytest.fixture
+def service():
+    """FlairMemoryService with a mock HTTP client and signing."""
+    from adk_flair.memory_service import FlairMemoryService
+
+    with patch(
+        "adk_flair.memory_service._load_ed25519_key",
+        return_value=MagicMock(),
+    ), patch(
+        "adk_flair.memory_service._sign_request",
+        return_value="TPS-Ed25519 test-agent:0:0:AAAA",
+    ), patch.dict("os.environ", {
+        "FLAIR_AGENT_ID": "test-agent",
+        "FLAIR_KEYFILE": "/fake/keyfile",
+    }, clear=True):
+        svc = FlairMemoryService(
+            url="http://localhost:19926",
+            agent_id="test-agent",
+            keyfile="/fake/keyfile",
+        )
+        svc._client = MagicMock()
+        svc._client.request = AsyncMock()
+        svc._client.request.return_value = MagicMock(
+            status_code=200,
+            headers={"content-type": "application/json"},
+            text="{}",
+        )
+        svc._url_logged = True
+        yield svc
+
+
+def _entry(text: str, entry_id: str = None, timestamp: str = None) -> MemoryEntry:
+    return MemoryEntry(
+        id=entry_id or f"mem-{uuid.uuid4().hex[:8]}",
+        content=types.Content(role="user", parts=[types.Part(text=text)]),
+        timestamp=timestamp,
+    )
+
+
+def _search_resp(results):
+    resp = MagicMock()
+    resp.status_code = 200
+    resp.headers = {"content-type": "application/json"}
+    resp.json.return_value = {"results": results}
+    return resp
+
+
+def _list_resp(rows):
+    resp = MagicMock()
+    resp.status_code = 200
+    resp.headers = {"content-type": "application/json"}
+    resp.json.return_value = rows
+    return resp
+
+
+# ─── Hermetic: metadata write path ───────────────────────────────────────────
+
+
+class TestMetadataWrite:
+    async def test_add_memory_serializes_metadata_into_body(self, service):
+        nested = {"merchant": "acme", "price": {"amount": 12.5, "ccy": "EUR"},
+                  "tags": ["a", "b"], "nested": {"deep": {"ok": True}}}
+        await service.add_memory(
+            app_name="app", user_id="user", memories=[_entry("fact")],
+            custom_metadata=nested,
+        )
+        body = service._client.request.call_args[1]["json"]
+        assert isinstance(body["metadata"], str)
+        assert json.loads(body["metadata"]) == nested
+
+    async def test_add_events_serializes_metadata_into_every_event_body(self, service):
+        ev1, ev2 = MagicMock(), MagicMock()
+        for i, ev in enumerate([ev1, ev2]):
+            ev.id = f"evt-{i}"
+            ev.content = types.Content(role="user", parts=[types.Part(text=f"turn {i}")])
+        await service.add_events_to_memory(
+            app_name="app", user_id="user", events=[ev1, ev2],
+            session_id="s1", custom_metadata={"source": "cam-1"},
+        )
+        assert service._client.request.call_count == 2
+        for call in service._client.request.call_args_list:
+            assert json.loads(call[1]["json"]["metadata"]) == {"source": "cam-1"}
+
+    async def test_no_metadata_means_no_metadata_key(self, service):
+        await service.add_memory(
+            app_name="app", user_id="user", memories=[_entry("plain")],
+        )
+        body = service._client.request.call_args[1]["json"]
+        assert "metadata" not in body
+        assert "subject" not in body
+
+    async def test_oversize_metadata_rejects_before_http(self, service):
+        with pytest.raises(ValueError, match="64|byte"):
+            await service.add_memory(
+                app_name="app", user_id="user", memories=[_entry("x")],
+                custom_metadata={"blob": "y" * (64 * 1024)},
+            )
+        assert service._client.request.call_count == 0
+
+    async def test_depth_over_16_rejects_before_http(self, service):
+        deep: dict = {"leaf": 1}
+        for _ in range(17):
+            deep = {"n": deep}
+        with pytest.raises(ValueError, match="nesting"):
+            await service.add_memory(
+                app_name="app", user_id="user", memories=[_entry("x")],
+                custom_metadata=deep,
+            )
+        assert service._client.request.call_count == 0
+
+    async def test_depth_16_exactly_is_accepted(self, service):
+        """Boundary control: the depth guard must not fire early."""
+        node: dict = {"leaf": 1}
+        for _ in range(15):
+            node = {"n": node}  # 16 dict levels total
+        await service.add_memory(
+            app_name="app", user_id="user", memories=[_entry("x")],
+            custom_metadata=node,
+        )
+        assert service._client.request.call_count == 1
+
+    async def test_key_count_over_512_rejects_before_http(self, service):
+        wide = {f"k{i}": i for i in range(513)}
+        with pytest.raises(ValueError, match="keys"):
+            await service.add_memory(
+                app_name="app", user_id="user", memories=[_entry("x")],
+                custom_metadata=wide,
+            )
+        assert service._client.request.call_count == 0
+
+    async def test_key_count_counts_nested_keys(self, service):
+        # 2 top-level + 511 nested = 513 total → reject
+        wide = {"a": {f"k{i}": i for i in range(511)}, "b": 1}
+        with pytest.raises(ValueError, match="keys"):
+            await service.add_memory(
+                app_name="app", user_id="user", memories=[_entry("x")],
+                custom_metadata=wide,
+            )
+
+    async def test_non_serializable_value_skips_key_with_warning(self, service, caplog):
+        with caplog.at_level(logging.WARNING, logger="adk_flair"):
+            await service.add_events_to_memory(
+                app_name="app", user_id="user",
+                events=[_make_simple_event("evt-1", "hello")],
+                session_id="sess-9",
+                custom_metadata={"good": "kept", "bad": object()},
+            )
+        body = service._client.request.call_args[1]["json"]
+        assert json.loads(body["metadata"]) == {"good": "kept"}
+        joined = " | ".join(str(r.getMessage()) for r in caplog.records
+                            if r.levelno == logging.WARNING)
+        assert "bad" in joined
+        assert "app:user:sess-9" in joined, (
+            "the WARNING must carry the session key so the skip is traceable"
+        )
+
+    async def test_all_values_non_serializable_yields_no_metadata_key(self, service):
+        await service.add_memory(
+            app_name="app", user_id="user", memories=[_entry("x")],
+            custom_metadata={"bad": object()},
+        )
+        body = service._client.request.call_args[1]["json"]
+        assert "metadata" not in body
+
+
+def _make_simple_event(event_id: str, text: str):
+    ev = MagicMock()
+    ev.id = event_id
+    ev.content = types.Content(role="user", parts=[types.Part(text=text)])
+    return ev
+
+
+# ─── Hermetic: subject write path ────────────────────────────────────────────
+
+
+class TestSubjectWrite:
+    async def test_explicit_subject_param_lands_top_level(self, service):
+        await service.add_memory(
+            app_name="app", user_id="user", memories=[_entry("x")],
+            subject="Receipt: Acme",
+        )
+        body = service._client.request.call_args[1]["json"]
+        assert body["subject"] == "Receipt: Acme"
+        assert "metadata" not in body  # subject alone stores no blob
+
+    async def test_metadata_subject_lands_top_level_and_stays_in_blob(self, service):
+        await service.add_memory(
+            app_name="app", user_id="user", memories=[_entry("x")],
+            custom_metadata={"subject": "From Blob", "k": 1},
+        )
+        body = service._client.request.call_args[1]["json"]
+        assert body["subject"] == "From Blob"
+        # The blob is stored verbatim — promotion copies, never strips.
+        assert json.loads(body["metadata"]) == {"subject": "From Blob", "k": 1}
+
+    async def test_explicit_param_authoritative_over_metadata_subject(self, service):
+        await service.add_memory(
+            app_name="app", user_id="user", memories=[_entry("x")],
+            custom_metadata={"subject": "blob-says"},
+            subject="param-says",
+        )
+        body = service._client.request.call_args[1]["json"]
+        assert body["subject"] == "param-says"
+        assert json.loads(body["metadata"])["subject"] == "blob-says"
+
+    async def test_subject_over_512_rejects_before_http(self, service):
+        with pytest.raises(ValueError, match="512"):
+            await service.add_memory(
+                app_name="app", user_id="user", memories=[_entry("x")],
+                subject="s" * 513,
+            )
+        assert service._client.request.call_count == 0
+
+    async def test_subject_512_exactly_is_accepted(self, service):
+        await service.add_memory(
+            app_name="app", user_id="user", memories=[_entry("x")],
+            subject="s" * 512,
+        )
+        assert service._client.request.call_args[1]["json"]["subject"] == "s" * 512
+
+    async def test_non_string_metadata_subject_rejects(self, service):
+        with pytest.raises(ValueError, match="string"):
+            await service.add_memory(
+                app_name="app", user_id="user", memories=[_entry("x")],
+                custom_metadata={"subject": {"not": "a string"}},
+            )
+        assert service._client.request.call_count == 0
+
+    async def test_subject_never_auto_extracted_from_content(self, service):
+        await service.add_memory(
+            app_name="app", user_id="user",
+            memories=[_entry("A very titled-looking first line\nbody")],
+        )
+        assert "subject" not in service._client.request.call_args[1]["json"]
+
+    async def test_metadata_subject_applies_on_event_writes_too(self, service):
+        await service.add_events_to_memory(
+            app_name="app", user_id="user",
+            events=[_make_simple_event("evt-1", "hello")],
+            session_id="s1",
+            custom_metadata={"subject": "Session Topic"},
+        )
+        body = service._client.request.call_args[1]["json"]
+        assert body["subject"] == "Session Topic"
+
+
+# ─── Hermetic: read path (search_memory) ─────────────────────────────────────
+
+
+class TestMetadataRead:
+    async def test_metadata_parsed_into_custom_metadata(self, service):
+        blob = {"merchant": "acme", "n": {"deep": [1, 2]}}
+        service._client.request.return_value = _search_resp([{
+            "id": "m1", "agentId": "test-agent", "content": "c",
+            "createdAt": "2026-08-22T00:00:00.000Z",
+            "tags": ["adk:app:user"], "metadata": json.dumps(blob),
+        }])
+        result = await service.search_memory(app_name="app", user_id="user", query="q")
+        assert result.memories[0].custom_metadata == blob
+
+    async def test_search_body_opts_into_metadata_projection(self, service):
+        service._client.request.return_value = _search_resp([])
+        await service.search_memory(app_name="app", user_id="user", query="q")
+        sent = service._client.request.call_args[1]["json"]
+        assert sent["includeMetadata"] is True
+
+    async def test_malformed_metadata_fails_soft_with_record_id_warning(self, service, caplog):
+        service._client.request.return_value = _search_resp([{
+            "id": "m-broken", "agentId": "test-agent", "content": "still readable",
+            "tags": ["adk:app:user"], "metadata": "{not json",
+        }])
+        with caplog.at_level(logging.WARNING, logger="adk_flair"):
+            result = await service.search_memory(app_name="app", user_id="user", query="q")
+        assert len(result.memories) == 1, "a corrupt blob must not drop the memory"
+        assert result.memories[0].custom_metadata == {}
+        joined = " | ".join(r.getMessage() for r in caplog.records
+                            if r.levelno == logging.WARNING)
+        assert "m-broken" in joined, "the WARNING must name the record id"
+
+    async def test_non_object_json_metadata_fails_soft(self, service, caplog):
+        service._client.request.return_value = _search_resp([{
+            "id": "m-arr", "agentId": "test-agent", "content": "c",
+            "tags": ["adk:app:user"], "metadata": "[1,2,3]",
+        }])
+        with caplog.at_level(logging.WARNING, logger="adk_flair"):
+            result = await service.search_memory(app_name="app", user_id="user", query="q")
+        assert result.memories[0].custom_metadata == {}
+
+    async def test_subject_column_authoritative_over_blob_key(self, service):
+        service._client.request.return_value = _search_resp([{
+            "id": "m1", "agentId": "test-agent", "content": "c",
+            "tags": ["adk:app:user"],
+            "metadata": json.dumps({"subject": "stale-blob-value"}),
+            "subject": "column-value",
+        }])
+        result = await service.search_memory(app_name="app", user_id="user", query="q")
+        assert result.memories[0].custom_metadata["subject"] == "column-value"
+
+    async def test_subject_column_surfaces_without_blob(self, service):
+        """A subject written via the explicit param has no blob — it must
+        still round-trip (MemoryEntry has no subject attribute; the
+        custom_metadata dict is its only return channel)."""
+        service._client.request.return_value = _search_resp([{
+            "id": "m1", "agentId": "test-agent", "content": "c",
+            "tags": ["adk:app:user"], "subject": "Param Subject",
+        }])
+        result = await service.search_memory(app_name="app", user_id="user", query="q")
+        assert result.memories[0].custom_metadata == {"subject": "Param Subject"}
+
+    async def test_author_derived_from_agent_id(self, service):
+        service._client.request.return_value = _search_resp([{
+            "id": "m1", "agentId": "test-agent", "content": "c",
+            "tags": ["adk:app:user"],
+        }])
+        result = await service.search_memory(app_name="app", user_id="user", query="q")
+        assert result.memories[0].author == "test-agent"
+
+    async def test_no_metadata_no_subject_yields_empty_dict(self, service):
+        service._client.request.return_value = _search_resp([{
+            "id": "m1", "agentId": "test-agent", "content": "c",
+            "tags": ["adk:app:user"],
+        }])
+        result = await service.search_memory(app_name="app", user_id="user", query="q")
+        assert result.memories[0].custom_metadata == {}
+
+
+# ─── Hermetic: list_memories ─────────────────────────────────────────────────
+
+
+class TestListMemories:
+    async def test_url_construction_default_page(self, service):
+        service._client.request.return_value = _list_resp([])
+        await service.list_memories(app_name="app", user_id="user")
+        method, path = service._client.request.call_args[0]
+        assert method == "GET"
+        assert path.startswith("/Memory/?")
+        assert "tags=adk%3Aapp%3Auser" in path
+        assert "agentId=test-agent" in path
+        assert "sort(-createdAt)" in path
+        assert "limit(0,50)" in path
+        assert "select(id,agentId,content,metadata,subject,tags,createdAt)" in path
+
+    async def test_offset_window(self, service):
+        service._client.request.return_value = _list_resp([])
+        await service.list_memories(app_name="app", user_id="user", limit=25, offset=10)
+        _, path = service._client.request.call_args[0]
+        assert "limit(10,35)" in path
+
+    async def test_tag_percent_escapes_survive_encoding(self, service):
+        """A user_id containing ':' produces a tag with literal %3A — the URL
+        value must encode the '%' itself so the server-side decode restores
+        the exact stored tag."""
+        service._client.request.return_value = _list_resp([])
+        await service.list_memories(app_name="app", user_id="alice:admin")
+        _, path = service._client.request.call_args[0]
+        # tag = adk:app:alice%3Aadmin → encoded: adk%3Aapp%3Aalice%253Aadmin
+        assert "tags=adk%3Aapp%3Aalice%253Aadmin" in path
+
+    async def test_limit_over_cap_rejects(self, service):
+        with pytest.raises(ValueError, match="200"):
+            await service.list_memories(app_name="app", user_id="user", limit=201)
+        assert service._client.request.call_count == 0
+
+    async def test_limit_at_cap_accepted(self, service):
+        service._client.request.return_value = _list_resp([])
+        await service.list_memories(app_name="app", user_id="user", limit=200)
+        _, path = service._client.request.call_args[0]
+        assert "limit(0,200)" in path
+
+    async def test_limit_zero_rejects(self, service):
+        with pytest.raises(ValueError, match="positive"):
+            await service.list_memories(app_name="app", user_id="user", limit=0)
+
+    async def test_negative_offset_rejects(self, service):
+        with pytest.raises(ValueError, match="offset"):
+            await service.list_memories(app_name="app", user_id="user", offset=-1)
+
+    async def test_empty_user_id_rejects(self, service):
+        with pytest.raises(ValueError, match="user_id"):
+            await service.list_memories(app_name="app", user_id="")
+        assert service._client.request.call_count == 0
+
+    async def test_empty_app_name_rejects(self, service):
+        with pytest.raises(ValueError, match="app_name"):
+            await service.list_memories(app_name="", user_id="user")
+
+    async def test_rows_map_to_full_memory_entries(self, service):
+        blob = {"k": "v"}
+        service._client.request.return_value = _list_resp([{
+            "id": "m1", "agentId": "test-agent", "content": "hello",
+            "createdAt": "2026-08-22T01:00:00.000Z",
+            "tags": ["adk:app:user"],
+            "metadata": json.dumps(blob), "subject": "Title",
+        }])
+        entries = await service.list_memories(app_name="app", user_id="user")
+        assert len(entries) == 1
+        e = entries[0]
+        assert e.id == "m1"
+        assert e.author == "test-agent"
+        assert e.timestamp == "2026-08-22T01:00:00.000Z"
+        assert e.content.parts[0].text == "hello"
+        assert e.custom_metadata == {"k": "v", "subject": "Title"}
+
+    async def test_scope_reverification_drops_foreign_rows(self, service):
+        service._client.request.return_value = _list_resp([
+            {"id": "mine", "agentId": "test-agent", "content": "c",
+             "tags": ["adk:app:user"]},
+            {"id": "wrong-tag", "agentId": "test-agent", "content": "c",
+             "tags": ["adk:app:other"]},
+            {"id": "wrong-agent", "agentId": "someone-else", "content": "c",
+             "tags": ["adk:app:user"]},
+        ])
+        entries = await service.list_memories(app_name="app", user_id="user")
+        assert [e.id for e in entries] == ["mine"]
+
+    async def test_non_list_response_returns_empty(self, service):
+        resp = MagicMock()
+        resp.status_code = 200
+        resp.headers = {"content-type": "application/json"}
+        resp.json.return_value = {"unexpected": "shape"}
+        service._client.request.return_value = resp
+        assert await service.list_memories(app_name="app", user_id="user") == []
+
+    async def test_transport_error_propagates(self, service):
+        """Unlike search_memory (ADK's swallow-to-empty contract), a browsing
+        API must distinguish 'no memories' from 'Flair is down'."""
+        service._client.request.side_effect = httpx.ConnectError("down")
+        with pytest.raises(httpx.ConnectError):
+            await service.list_memories(app_name="app", user_id="user")
+
+
+# ─── Live: round-trip + store-and-return contract + list ────────────────────
+
+
+def _sign(private_key: ed25519.Ed25519PrivateKey, agent_id: str,
+          method: str, path: str) -> str:
+    ts = str(int(time.time() * 1000))
+    nonce = str(uuid.uuid4())
+    payload = f"{agent_id}:{ts}:{nonce}:{method}:{path}".encode("utf-8")
+    sig = base64.b64encode(private_key.sign(payload)).decode("ascii")
+    return f"TPS-Ed25519 {agent_id}:{ts}:{nonce}:{sig}"
+
+
+async def _rest_get_memory(live, record_id: str) -> dict:
+    """Fetch one Memory record by id via signed REST — ground truth for the
+    stored row, independent of the adapter's read path."""
+    path = f"/Memory/{record_id}"
+    auth = _sign(live.private_key, live.agent_id, "GET", path)
+    async with httpx.AsyncClient(
+        base_url=live.http_url,
+        timeout=httpx.Timeout(connect=2, read=5, write=2, pool=2),
+    ) as client:
+        resp = await client.get(path, headers={"Authorization": auth})
+        if resp.status_code >= 400:
+            raise RuntimeError(f"GET {path} → {resp.status_code} {resp.text[:200]}")
+        return resp.json()
+
+
+def _live_service(live):
+    from adk_flair import FlairMemoryService
+    return FlairMemoryService(
+        url=live.http_url,
+        agent_id=live.agent_id,
+        keyfile=live.keyfile_path,
+        timeout=10.0,  # ephemeral Harper under test load — not a latency test
+    )
+
+
+@pytest.mark.live_flair
+class TestMetadataLive:
+    async def test_nested_metadata_round_trip(self, live_flair):
+        app, user = "meta-rt", f"u-{uuid.uuid4().hex[:8]}"
+        marker = f"rt-marker-{uuid.uuid4().hex[:8]}"
+        nested = {
+            "merchant": "acme", "price": {"amount": 12.5, "currency": "EUR"},
+            "media": ["s3://a.jpg", "s3://b.jpg"],
+            "flags": {"verified": True, "score": 0.93, "note": None},
+        }
+        service = _live_service(live_flair)
+        try:
+            await service.add_memory(
+                app_name=app, user_id=user,
+                memories=[_entry(f"receipt {marker}")],
+                custom_metadata=nested,
+            )
+            result = await service.search_memory(
+                app_name=app, user_id=user, query=marker,
+            )
+            assert result.memories, "written memory not found by search"
+            hit = next(
+                (m for m in result.memories
+                 if marker in (m.content.parts[0].text if m.content and m.content.parts else "")),
+                None,
+            )
+            assert hit is not None, "marker memory missing from results"
+            assert hit.custom_metadata == nested, (
+                f"round-trip mismatch: wrote {nested!r}, read {hit.custom_metadata!r}"
+            )
+        finally:
+            await service.close()
+
+    async def test_metadata_is_store_and_return_only(self, live_flair):
+        """SHERLOCK CONTRACT TEST: metadata blob keys that IMPERSONATE server
+        knobs (visibility/durability/residency) have ZERO effect on the
+        record's actual fields. Includes a positive control proving the
+        instrument fires: the EXPLICIT params DO change the stored fields."""
+        app, user = "meta-contract", f"u-{uuid.uuid4().hex[:8]}"
+        service = _live_service(live_flair)
+        smuggle = {"visibility": "shared", "durability": "permanent",
+                   "residency": "anywhere"}
+        try:
+            # ── The contract half: blob keys must be inert ────────────────
+            inert_id = f"contract-{uuid.uuid4().hex[:8]}"
+            await service.add_memory(
+                app_name=app, user_id=user,
+                memories=[_entry("contract probe", entry_id=inert_id)],
+                custom_metadata=smuggle,
+                # NO explicit durability/visibility → server defaults apply.
+            )
+            row = await _rest_get_memory(live_flair, inert_id)
+            assert row["durability"] == "standard", (
+                f"blob 'durability' key leaked into the record: {row['durability']!r}"
+            )
+            assert row["visibility"] == "private", (
+                f"blob 'visibility' key leaked into the record: {row['visibility']!r}"
+            )
+            assert "residency" not in row, "blob key materialized as a column"
+            # And the blob itself is stored verbatim (store-and-return).
+            assert json.loads(row["metadata"]) == smuggle
+
+            # ── Positive control: the explicit channel DOES move the fields ─
+            ctl_id = f"control-{uuid.uuid4().hex[:8]}"
+            await service.add_memory(
+                app_name=app, user_id=user,
+                memories=[_entry("positive control", entry_id=ctl_id)],
+                custom_metadata=smuggle,
+                durability="persistent", visibility="shared",
+            )
+            ctl = await _rest_get_memory(live_flair, ctl_id)
+            assert ctl["durability"] == "persistent"
+            assert ctl["visibility"] == "shared", (
+                "positive control failed — the instrument cannot detect a "
+                "visibility change, so the inert assertion above proves nothing"
+            )
+        finally:
+            await service.close()
+
+    async def test_subject_both_sources_and_precedence(self, live_flair):
+        app, user = "subj-rt", f"u-{uuid.uuid4().hex[:8]}"
+        service = _live_service(live_flair)
+        try:
+            param_id = f"subj-param-{uuid.uuid4().hex[:8]}"
+            blob_id = f"subj-blob-{uuid.uuid4().hex[:8]}"
+            both_id = f"subj-both-{uuid.uuid4().hex[:8]}"
+            await service.add_memory(
+                app_name=app, user_id=user,
+                memories=[_entry("via param", entry_id=param_id)],
+                subject="Param Subject",
+            )
+            await service.add_memory(
+                app_name=app, user_id=user,
+                memories=[_entry("via blob", entry_id=blob_id)],
+                custom_metadata={"subject": "Blob Subject"},
+            )
+            await service.add_memory(
+                app_name=app, user_id=user,
+                memories=[_entry("via both", entry_id=both_id)],
+                custom_metadata={"subject": "Blob Says"},
+                subject="Param Wins",
+            )
+            assert (await _rest_get_memory(live_flair, param_id))["subject"] == "Param Subject"
+            assert (await _rest_get_memory(live_flair, blob_id))["subject"] == "Blob Subject"
+            assert (await _rest_get_memory(live_flair, both_id))["subject"] == "Param Wins"
+        finally:
+            await service.close()
+
+
+@pytest.mark.live_flair
+class TestListMemoriesLive:
+    async def test_list_pagination_scope_and_order(self, live_flair):
+        app = "list-live"
+        user = f"u-{uuid.uuid4().hex[:8]}"
+        other_user = f"other-{uuid.uuid4().hex[:8]}"
+        service = _live_service(live_flair)
+        try:
+            # Three records with controlled createdAt (adapter passes
+            # MemoryEntry.timestamp through as createdAt).
+            ids = []
+            for i, ts in enumerate([
+                "2026-08-20T00:00:00.000Z",
+                "2026-08-21T00:00:00.000Z",
+                "2026-08-22T00:00:00.000Z",
+            ]):
+                rid = f"list-{i}-{uuid.uuid4().hex[:8]}"
+                ids.append(rid)
+                await service.add_memory(
+                    app_name=app, user_id=user,
+                    memories=[_entry(f"list item {i}", entry_id=rid, timestamp=ts)],
+                    custom_metadata={"idx": i},
+                    subject=f"Item {i}",
+                )
+            # A record for ANOTHER user — must never appear in `user`'s list.
+            foreign_id = f"foreign-{uuid.uuid4().hex[:8]}"
+            await service.add_memory(
+                app_name=app, user_id=other_user,
+                memories=[_entry("foreign item", entry_id=foreign_id)],
+            )
+
+            # Full page: newest first, foreign row absent.
+            entries = await service.list_memories(app_name=app, user_id=user)
+            got_ids = [e.id for e in entries]
+            assert got_ids == [ids[2], ids[1], ids[0]], (
+                f"expected createdAt DESC {list(reversed(ids))}, got {got_ids}"
+            )
+            assert foreign_id not in got_ids
+            # Full projection present.
+            assert entries[0].custom_metadata == {"idx": 2, "subject": "Item 2"}
+            assert entries[0].author == live_flair.agent_id
+            assert entries[0].timestamp == "2026-08-22T00:00:00.000Z"
+
+            # Pagination: limit=1 offset=1 → the middle record.
+            page = await service.list_memories(
+                app_name=app, user_id=user, limit=1, offset=1,
+            )
+            assert [e.id for e in page] == [ids[1]]
+        finally:
+            await service.close()

--- a/resources/SemanticSearch.ts
+++ b/resources/SemanticSearch.ts
@@ -66,7 +66,7 @@ export class SemanticSearch extends Resource {
     // recall-harness (test/bench/recall-harness/run.ts) and `recall-eval.mjs`
     // before reconsidering this default if the compositeScore formula or
     // corpus changes.
-    const { agentId: bodyAgentId, q, queryEmbedding, tag, subject, subjects, limit = 10, includeSuperseded = false, scoring = "raw", minScore = 0, since, asOf, includeTrust = false, abstain = false, explain = false } = data || {};
+    const { agentId: bodyAgentId, q, queryEmbedding, tag, subject, subjects, limit = 10, includeSuperseded = false, scoring = "raw", minScore = 0, since, asOf, includeTrust = false, includeMetadata = false, abstain = false, explain = false } = data || {};
 
     // Authenticated identity lives on the Harper Resource context (getContext().request).
     // `this.request` is NOT populated on Harper v5 Resources — prior reads here
@@ -250,7 +250,20 @@ export class SemanticSearch extends Resource {
       // default projection omits. Widen the select ONLY when the caller opts
       // in — passing undefined otherwise keeps the default (no `provenance`)
       // so a non-trust recall response stays byte-identical.
-      select: includeTrust ? [...DEFAULT_SELECT, "provenance"] : undefined,
+      //
+      // flair#1332: same idiom for the client-writable `metadata` JSON blob
+      // (ADK custom_metadata store-and-return). DEFAULT_SELECT deliberately
+      // does NOT grow it (K&S projection ruling — the shared retrieval core
+      // serves every consumer, and none of the others should pay result-size
+      // for an opaque blob they never read); adk-flair opts in per-request
+      // with `includeMetadata: true`. `subject` needs no widening — it is
+      // already in DEFAULT_SELECT. Neither flag ⇒ select stays undefined ⇒
+      // response bytes unchanged.
+      select: (includeTrust || includeMetadata)
+        ? [...DEFAULT_SELECT,
+           ...(includeTrust ? ["provenance"] : []),
+           ...(includeMetadata ? ["metadata"] : [])]
+        : undefined,
       // flair#744 slice 2 + confidence-band refinement: attach the absolute
       // per-result cosine confidence when the caller opts into abstention OR
       // the trust block — abstention reads the best of it for its verdict, and

--- a/schemas/memory.graphql
+++ b/schemas/memory.graphql
@@ -85,6 +85,19 @@ type Memory @table(database: "flair") {
                                # stamped by the ORIGINATING instance itself and preserved (never re-stamped) as the record flows through
                                # sync merges. @indexed for the later sync push-query filter (per-record signature verification and the
                                # classifier org-gate are separate, later slices — not built here).
+  metadata: String             # JSON blob (flair#1332/#1202): ADK custom_metadata, store-and-return. CLIENT-WRITABLE
+                               # (unlike provenance above, which is server-stamped) and OPAQUE TO THE SERVER by
+                               # contract: stored verbatim, returned verbatim, never parsed server-side, never
+                               # queryable (Harper cannot query into a JSON blob), and NO key inside this blob
+                               # ever influences any server decision — visibility, read-scope, durability,
+                               # expiry, federation, ranking, nothing. A blob carrying {"visibility":"shared"}
+                               # leaves the record's ACTUAL visibility at its default (contract-tested in
+                               # packages/adk-flair/tests/test_metadata_and_list.py). If a specific key ever
+                               # needs to be filterable, promote THAT key to its own @indexed scalar column
+                               # (the #1202-documented add-on pattern; `subject` below is the first example) —
+                               # never parse this blob. Size/shape caps are enforced at the writing client
+                               # (adk-flair: 64KB serialized, depth ≤ 16, ≤ 512 keys). Nullable/additive —
+                               # existing rows read null, unchanged behavior (clean-upgrade-path gate).
   entities: [String] @indexed  # attention-plane vocabulary strings (flair#675). Added in v1 (not v2) per K&S
                                # verdict on FLAIR-ATTENTION-PLANE.md — gives the future attention query
                                # uniform index pushdown across Memory/WorkspaceState/OrgEvent instead of a


### PR DESCRIPTION
Closes #1332
Closes #1333
Refs #1202

Implements the K&S-ruled design: ADK `custom_metadata` as store-and-return via a client-writable `Memory.metadata` JSON blob, `subject` promoted to the existing indexed column, and `list_memories()` as a Flair-specific extension.

## Projection path implemented (the ruling asked which)

**Neither pre-existing option worked**: `/SemanticSearch` has no client-passable `select`/projection param (the body destructure ignores one), and hits are not full records — they are projected through `DEFAULT_SELECT`, which already carries `subject` (and `createdAt`, `agentId`) but not `metadata`.

**Implemented: an opt-in `includeMetadata: true` flag on `/SemanticSearch`**, the exact `includeTrust`→`provenance` idiom already in the file (flair#744 slice 1). When set, the select widens to `[...DEFAULT_SELECT, "metadata"]` for that request only. `DEFAULT_SELECT` is untouched; with neither flag set the select stays `undefined` and every other consumer's response is **byte-identical** (TS unit lane confirms: 4599 pass / 0 fail, identical to a baseline run on origin/main). adk-flair sends the flag on every search; `subject` needs no widening. A generic client `select` param was deliberately NOT added — it would let any caller project arbitrary fields (e.g. `provenance` without the trust opt-in, or `embedding`) and is a bigger surface than the ruling needs.

## K&S conditions checklist

- [x] **Schema**: `metadata: String` declared on Memory — client-writable JSON blob, provenance idiom; the schema comment pins the opaque-to-server contract and points at the contract test.
- [x] **`subject` NOT re-added** — verified pre-existing at `schemas/memory.graphql` (`subject: String @indexed`, the 3-tier compression field).
- [x] **64KB hard cap — REJECT, never truncate** (Sherlock): `ValueError` before any write; hermetic test asserts zero HTTP calls.
- [x] **Depth/width caps**: nesting > 16 or > 512 total keys reject. Iterative check (no recursion to blow; a self-referencing dict terminates via the depth cap). Boundary control included: depth exactly 16 is accepted — the guard can't silently over-fire.
- [x] **Non-serializable values**: skip that key + WARNING (not DEBUG) carrying the session key; the rest of the blob is stored. Tested.
- [x] **subject**: explicit `add_memory(subject=...)` param added; `custom_metadata["subject"]` honored on both write paths; explicit param authoritative when both present; 512-char cap rejects; never auto-extracted from content. Hermetic + live tests, including precedence.
- [x] **Read path**: `search_memory` parses `metadata` fail-soft — malformed JSON ⇒ `{}` + WARNING naming the record id; the memory itself is still returned. Tested.
- [x] **`DEFAULT_SELECT` untouched** (see projection section above).
- [x] **author**: derived from `hit["agentId"]` — no new column. Was always `None` (read a field Flair never declares/projects). Tested hermetic + asserted live.
- [x] **STORE-AND-RETURN CONTRACT TEST** (Sherlock hard requirement): live test writes `custom_metadata={"visibility":"shared","durability":"permanent","residency":"anywhere"}` with no explicit knobs, then reads the row via signed REST: actual `durability=="standard"`, `visibility=="private"`, no `residency` column, blob stored verbatim. Includes a **positive control** (explicit `visibility="shared"`/`durability="persistent"` params DO move the stored fields) so the inert assertion is proven able to fire. Passing.
- [x] **`list_memories`** (#1333): exact ruled signature; same `_compound_tag` scope AND `agentId == self._agent_id` — both pushed down as query conditions and re-verified client-side per row; `createdAt` DESC; limit hard cap 200 **rejects with `ValueError`** (chose reject over clamp — consistent with every other adk-flair validation; a silent clamp turns "why did I get 200" into a debugging session); full projection incl. metadata/subject/author; docstring states point-in-time snapshot + positional offset + not part of ADK's `BaseMemoryService`.
- [x] **README**: metadata section, subject section, list_memories section, and the security caveat — content and metadata are untrusted input to the consuming agent's context; no sanitization, with the why (lossy to the round-trip + false safety).
- [x] **Changelog fragment** (`added-` category), validated with `changelog-fragments.mjs check`.

## Deviations (with reasons)

1. **Subject on read surfaces as `custom_metadata["subject"]`, not `MemoryEntry.subject`** — ADK's `MemoryEntry` is a pydantic model with no `subject` field and it silently ignores extras (verified against the installed google-adk: `MemoryEntry(..., subject="x")` drops the attribute). The dict is the only faithful return channel. Top-level column stays authoritative: on read it overwrites a divergent blob `"subject"` key.
2. **Caps enforced on `add_events_to_memory` too**, not only `add_memory` — #1202 threads custom_metadata through both write paths; validation runs once, before the loop, so a cap violation writes zero events (never a partial batch).
3. **Non-string `custom_metadata["subject"]` rejects** (`ValueError`) instead of silently staying blob-only — a value we can't faithfully store in a String column must fail loudly, not become "why is subject empty".
4. **`list_memories` propagates transport errors** (documented) rather than swallowing to empty — the swallow contract is ADK's for `search_memory`; a browsing API must distinguish "no memories" from "Flair is down".
5. **Explicit `subject` param added to `add_memory` only** — #1332's named surface. `add_events_to_memory` picks subject up via `custom_metadata["subject"]` (one subject per batch is the caller's explicit choice there).
6. **Warn-once state (`_warned_sessions`) removed** — dead after support lands; the warn-once test is replaced by a stored-not-warned test.

## Not in scope (follow-up)

- `packages/adk-flair-js` (the JS twin) still drops `customMetadata` with the warn-once — parity is a separate issue; nothing in this PR changes its behavior.
- Promoting further metadata keys to queryable columns (the #1202 add-on pattern) happens per-key, on demand.

## Test counts

| Lane | Baseline | This branch |
| --- | --- | --- |
| adk-flair hermetic (`-m "not live_flair"`) | 63 passed | **102 passed** (+39) |
| adk-flair live (`-m live_flair`, ephemeral Harper booted from THIS branch's dist, rockit) | 9 cases | **12 passed, 1 skipped** (13 cases; skip = pre-existing model-gated `test_cross_session_recall`, needs `ADK_TEST_MODEL`) |
| TS `bun test test/unit/` | 4599 pass / 0 fail | **4599 pass / 0 fail** (identical) |

The live lane exercises the real end-to-end path: the new `includeMetadata` projection through `/SemanticSearch`, the Harper collection query (`sort(-createdAt)`, `limit(offset,end)`, `select(...)`) through `Memory.search()`'s scoped path, and the store-and-return contract against the actual write pipeline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
