### PR TITLE
adk-flair: pre-built ADK agent tools — create_flair_tools() (flair#1331)

### DIFF
--- a/.changelog/unreleased/added-1331-adk-agent-tools.md
+++ b/.changelog/unreleased/added-1331-adk-agent-tools.md
@@ -1,0 +1,20 @@
+- **adk-flair: pre-built ADK agent tools — `create_flair_tools()`**
+  (flair#1331). One factory call returns three ready-to-use async tool
+  functions — `store_memory(subject, description, tags, custom_metadata)`,
+  `search_memory(query, limit)` and `list_memories(limit, offset)` — bound to
+  one `FlairMemoryService` and one `app_name`/`user_id` scope, ready to pass
+  straight to `LlmAgent(tools=...)` (ADK wraps bare async callables in
+  `FunctionTool` and generates the Gemini declarations from the signatures
+  and docstrings). Explicit injection only: no env-var discovery, no service
+  registry, no ambient identity — the scope binds at factory time so the
+  model can never choose whose memory it touches, and scope parameters never
+  appear in any tool declaration. `subject` flows through the first-class
+  subject column; `tags` are stored inside `custom_metadata["tags"]`
+  (round-trip labels, deliberately never written to the record's scope-tag
+  array); results come back as plain JSON-serializable dicts with `subject`
+  hoisted alongside `content`, `author`, `timestamp` and `custom_metadata`;
+  failures the model can act on return as `{"error": ...}` instead of
+  raising. +32 hermetic tests (134 vs 102 baseline, incl. a
+  declaration-generation smoke test against the installed google-adk) and
+  +2 live (tool-level store→search→list round-trip, cross-user scope
+  isolation).

--- a/packages/adk-flair/README.md
+++ b/packages/adk-flair/README.md
@@ -342,6 +342,34 @@ entries = await memory_service.list_memories(
   `list_memories` **raises** on transport/server failure — a browsing UI must
   be able to tell "no memories" from "Flair is down".
 
+## Agent tools
+
+Pre-built tool functions so the model itself can store and recall memories —
+no boilerplate tool authoring:
+
+```python
+from adk_flair import FlairMemoryService, create_flair_tools
+
+memory_service = FlairMemoryService()
+agent = LlmAgent(
+    model="gemini-2.5-flash",
+    name="assistant",
+    tools=create_flair_tools(memory_service, app_name="my-app", user_id="user-123"),
+)
+```
+
+`create_flair_tools()` returns three plain async functions —
+`store_memory(subject, description, tags=None, custom_metadata=None)`,
+`search_memory(query, limit=5)` and `list_memories(limit=20, offset=0)` —
+which ADK wraps in `FunctionTool` automatically and turns into Gemini function
+declarations from their signatures and docstrings. Everything is explicit
+injection: the service and the `app_name`/`user_id` scope are arguments you
+pass at creation time, so the wiring stays auditable and the model can never
+pick its own memory scope (no ambient identity, no env-var or registry
+discovery). Create one tool set per user/session. `tags` are stored inside
+the memory's `custom_metadata` under `"tags"` — descriptive labels that
+round-trip on search and list, never part of the record's scope-tag array.
+
 ## What this adapter deliberately doesn't do
 
 - **No consolidation logic.** Flair's REM (nightly) owns consolidation — the

--- a/packages/adk-flair/src/adk_flair/__init__.py
+++ b/packages/adk-flair/src/adk_flair/__init__.py
@@ -1,7 +1,9 @@
 """adk-flair — Flair as the memory backend for Google ADK.
 
 Provides FlairMemoryService, a BaseMemoryService implementation that persists
-ADK agent memory into a Flair instance.
+ADK agent memory into a Flair instance, and create_flair_tools, a factory for
+pre-built agent tools (store_memory / search_memory / list_memories) bound to
+an explicit service + app/user scope.
 
 Quickstart:
     from adk_flair import FlairMemoryService
@@ -25,8 +27,9 @@ agent's services.py, or use services.yaml:
 """
 
 from adk_flair.memory_service import FlairMemoryService
+from adk_flair.tools import create_flair_tools
 
-__all__ = ["FlairMemoryService", "register"]
+__all__ = ["FlairMemoryService", "create_flair_tools", "register"]
 
 
 def register():

--- a/packages/adk-flair/src/adk_flair/tools.py
+++ b/packages/adk-flair/src/adk_flair/tools.py
@@ -1,0 +1,279 @@
+"""Pre-built ADK agent tools for Flair memory (flair#1331).
+
+``create_flair_tools()`` returns ready-to-use async tool functions —
+``store_memory`` / ``search_memory`` / ``list_memories`` — bound to ONE
+FlairMemoryService instance and ONE app+user scope.
+
+Explicit injection only. There is deliberately no environment-variable
+discovery, no ADK service-registry lookup, no module-level singleton and no
+ambient fallback of any kind: the service and scope a tool acts on are visible
+at the call site that created it, so the wiring is auditable. ``app_name`` and
+``user_id`` bind at FACTORY time, not per tool call — memory scope is
+application wiring, not something the model chooses. A tool signature that
+exposed ``user_id`` to the LLM would let a prompted model read or write
+another user's memories.
+
+The returned functions are plain async callables with type hints and
+docstrings. google-adk accepts bare callables in ``LlmAgent(tools=[...])``
+(``ToolUnion = Union[Callable, BaseTool, BaseToolset]``) and wraps each in a
+``FunctionTool`` automatically, generating the Gemini function declaration
+from the signature and docstring — no manual wrapping needed. Wrapping them
+yourself (``FunctionTool(tool)``) works too and produces the same declaration.
+
+Usage:
+    from google.adk.agents import LlmAgent
+    from adk_flair import FlairMemoryService, create_flair_tools
+
+    memory_service = FlairMemoryService()
+    agent = LlmAgent(
+        model="gemini-2.5-flash",
+        name="assistant",
+        instruction="...",
+        tools=create_flair_tools(
+            memory_service, app_name="my-app", user_id="user-123"
+        ),
+    )
+
+Design notes:
+  - ``tags`` on ``store_memory`` are stored INSIDE the memory's
+    ``custom_metadata`` blob under the key ``"tags"`` (the explicit param is
+    authoritative over a blob ``"tags"`` key, mirroring the ``subject``
+    precedence rule). They are descriptive labels with no server-side effect.
+    They are deliberately NOT written into the record's top-level ``tags``
+    array: that array is adk-flair's per-user scope boundary (the compound
+    ``adk:<app>:<user>`` tag), and a model-supplied value landing there could
+    forge another scope's tag.
+  - Tool return values are plain JSON-serializable dicts. Failures the model
+    can act on come back as ``{"error": "..."}`` — the shape ADK itself uses
+    for tool-level errors — rather than raised exceptions, so one bad call
+    degrades into a self-correctable message instead of aborting the run.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict, Optional
+
+import httpx
+
+from google.adk.memory.memory_entry import MemoryEntry
+from google.genai import types
+
+from adk_flair.memory_service import FlairMemoryService
+
+logger = logging.getLogger("adk_flair")
+
+__all__ = ["create_flair_tools"]
+
+
+def _entry_to_dict(entry: MemoryEntry) -> Dict[str, Any]:
+    """Map a MemoryEntry onto the plain JSON-serializable dict the tools return.
+
+    ``subject`` is hoisted to the top level (from ``custom_metadata["subject"]``,
+    where the read path surfaces the record's subject column) so the round-trip
+    is symmetric with ``store_memory(subject=...)``. The full ``custom_metadata``
+    dict is included unchanged alongside it.
+    """
+    text = FlairMemoryService._extract_content_text(entry.content) or ""
+    metadata = dict(entry.custom_metadata or {})
+    return {
+        "id": entry.id,
+        "subject": metadata.get("subject"),
+        "content": text,
+        "author": entry.author,
+        "timestamp": entry.timestamp,
+        "custom_metadata": metadata,
+    }
+
+
+def create_flair_tools(
+    memory_service: FlairMemoryService,
+    *,
+    app_name: str,
+    user_id: str,
+) -> list:
+    """Create the pre-built Flair memory tools for one ADK agent.
+
+    Returns ``[store_memory, search_memory, list_memories]`` — async functions
+    bound to ``memory_service`` and to the ``app_name``/``user_id`` scope given
+    here. Pass the list straight to ``LlmAgent(tools=...)``; ADK wraps bare
+    callables in ``FunctionTool`` automatically.
+
+    The scope binds at factory time on purpose: which user's memory a tool
+    touches is decided by the application when it wires the agent, never by
+    the model at call time. Create one tool set per (service, app, user)
+    scope — e.g. per session — rather than sharing one set across users.
+
+    Args:
+        memory_service: The FlairMemoryService instance the tools delegate to.
+            Explicit injection only — the factory never discovers a service
+            from the environment or a registry.
+        app_name: ADK app name the memories are scoped to (required,
+            non-empty).
+        user_id: User id the memories are scoped to (required, non-empty).
+
+    Returns:
+        list of three async tool callables, in the order
+        ``[store_memory, search_memory, list_memories]``.
+
+    Raises:
+        TypeError: memory_service is not a FlairMemoryService.
+        ValueError: empty ``app_name`` or ``user_id`` — a scope mistake must
+            fail at wiring time, not at the first tool call.
+    """
+    if not isinstance(memory_service, FlairMemoryService):
+        raise TypeError(
+            "memory_service must be a FlairMemoryService instance "
+            f"(got: {type(memory_service).__name__}) — construct one and pass "
+            "it in; the tools never discover a service ambiently"
+        )
+    if not app_name or not isinstance(app_name, str):
+        raise ValueError(
+            "app_name is required and must be a non-empty string — the tools "
+            "bind their memory scope at creation time"
+        )
+    if not user_id or not isinstance(user_id, str):
+        raise ValueError(
+            "user_id is required and must be a non-empty string — the tools "
+            "bind their memory scope at creation time"
+        )
+
+    async def store_memory(
+        subject: str,
+        description: str,
+        tags: Optional[list[str]] = None,
+        custom_metadata: Optional[dict] = None,
+    ) -> dict:
+        """Save a memory to the user's long-term memory store.
+
+        Use this when the conversation surfaces information worth remembering
+        across sessions — preferences, decisions, facts about the user, or
+        anything the user asks to have remembered. Storing the same
+        description again updates the existing memory rather than creating a
+        duplicate.
+
+        Args:
+            subject: Short human-readable title for the memory, a few words
+                up to 512 characters. Example: "Preferred airline seat".
+            description: The full text of the memory — state the fact so it
+                is understandable on its own when read back later.
+            tags: Optional short labels categorizing the memory, for example
+                ["travel", "preference"]. Returned with the memory on later
+                search and list calls.
+            custom_metadata: Optional dictionary of structured attributes to
+                store alongside the memory, for example {"source": "chat"}.
+                Stored and returned verbatim; keys have no effect on how the
+                memory is stored.
+
+        Returns:
+            On success a dict {"status": "stored", "subject": <subject>}.
+            On failure a dict {"error": <what went wrong and how to fix it>}.
+        """
+        if not description or not description.strip():
+            return {
+                "error": "description must be non-empty — provide the text "
+                "of the memory to store"
+            }
+
+        metadata: Optional[Dict[str, Any]] = (
+            dict(custom_metadata) if custom_metadata is not None else None
+        )
+        if tags is not None:
+            # Explicit param authoritative over a blob "tags" key (same rule
+            # as subject). Never mutates the caller's dict — copied above.
+            if metadata is None:
+                metadata = {}
+            metadata["tags"] = list(tags)
+
+        entry = MemoryEntry(
+            content=types.Content(
+                role="user", parts=[types.Part(text=description)]
+            )
+        )
+        try:
+            await memory_service.add_memory(
+                app_name=app_name,
+                user_id=user_id,
+                memories=[entry],
+                custom_metadata=metadata,
+                subject=subject,
+            )
+        except ValueError as exc:
+            # Validation (metadata caps, over-long subject): surface the
+            # actionable message so the model can shrink the payload & retry.
+            return {"error": str(exc)}
+        return {"status": "stored", "subject": subject}
+
+    async def search_memory(query: str, limit: int = 5) -> dict:
+        """Search the user's long-term memories by meaning.
+
+        Use this to recall previously stored information relevant to the
+        current conversation. Matching is semantic, so a natural-language
+        description of what you are looking for works better than bare
+        keywords.
+
+        Args:
+            query: What to look for, in natural language. Example: "the
+                user's dietary restrictions".
+            limit: Maximum number of memories to return. Default 5; values
+                above 20 still return at most 20.
+
+        Returns:
+            A dict {"count": <n>, "memories": [...]} where each memory has
+            "subject", "content", "author", "timestamp" and
+            "custom_metadata" fields, most relevant first. count 0 with an
+            empty list means nothing relevant was found (or the memory store
+            was unreachable).
+        """
+        if not isinstance(limit, int) or isinstance(limit, bool) or limit < 1:
+            return {"error": f"limit must be a positive integer (got: {limit!r})"}
+        response = await memory_service.search_memory(
+            app_name=app_name, user_id=user_id, query=query
+        )
+        memories = [_entry_to_dict(m) for m in response.memories[:limit]]
+        return {"count": len(memories), "memories": memories}
+
+    async def list_memories(limit: int = 20, offset: int = 0) -> dict:
+        """List the user's stored memories, newest first.
+
+        Use this to browse or review what is currently remembered when there
+        is no specific query to search with — for example to summarize stored
+        memories or check whether something was already saved.
+
+        Args:
+            limit: Page size — how many memories to return. Default 20,
+                maximum 200.
+            offset: How many of the newest memories to skip, for paging
+                through older ones. Default 0.
+
+        Returns:
+            A dict {"count": <n>, "offset": <offset>, "memories": [...]}
+            where each memory has "subject", "content", "author",
+            "timestamp" and "custom_metadata" fields. On failure returns
+            {"error": "..."} — for example when the memory store is
+            unreachable.
+        """
+        try:
+            entries = await memory_service.list_memories(
+                app_name=app_name, user_id=user_id, limit=limit, offset=offset
+            )
+        except ValueError as exc:
+            return {"error": str(exc)}
+        except (httpx.HTTPError, RuntimeError) as exc:
+            # list_memories propagates transport failures by contract (a
+            # browsing API must distinguish "no memories" from "Flair is
+            # down") — but a tool must hand the model a message, not a
+            # traceback.
+            logger.warning(
+                "adk-flair: list_memories tool call failed (app=%s): %s",
+                app_name, exc,
+            )
+            return {
+                "error": "memory store request failed "
+                f"({type(exc).__name__}: {exc}) — the memory store may be "
+                "unreachable; try again later"
+            }
+        memories = [_entry_to_dict(e) for e in entries]
+        return {"count": len(memories), "offset": offset, "memories": memories}
+
+    return [store_memory, search_memory, list_memories]

--- a/packages/adk-flair/tests/test_tools.py
+++ b/packages/adk-flair/tests/test_tools.py
@@ -1,0 +1,455 @@
+"""Tests for flair#1331 — pre-built ADK agent tools (create_flair_tools).
+
+Two tiers, same split as the rest of the suite:
+
+  - Hermetic (default lane, ``-m "not live_flair"``): factory binding and
+    validation, per-tool delegation onto a mocked FlairMemoryService, error
+    shapes, JSON-serializability, and the schema-generation smoke test that
+    runs the INSTALLED google-adk's own FunctionTool declaration build over
+    the returned callables.
+
+  - Live (``@pytest.mark.live_flair``): the tool-level round-trip against a
+    real ephemeral Harper — store via tool → search via tool → list via tool.
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+from unittest.mock import AsyncMock, MagicMock
+
+import httpx
+import pytest
+from google.adk.memory.base_memory_service import SearchMemoryResponse
+from google.adk.memory.memory_entry import MemoryEntry
+from google.adk.tools.function_tool import FunctionTool
+from google.genai import types
+
+from adk_flair import create_flair_tools
+from adk_flair.memory_service import FlairMemoryService
+
+
+# ─── Fixtures ────────────────────────────────────────────────────────────────
+
+
+def _mock_service() -> MagicMock:
+    """A FlairMemoryService stand-in with async method mocks.
+
+    spec'd to the real class so a tool delegating to a method that does not
+    exist (or misspelling a kwarg target) fails here instead of in prod.
+    """
+    svc = MagicMock(spec=FlairMemoryService)
+    svc.add_memory = AsyncMock(return_value=None)
+    svc.search_memory = AsyncMock(return_value=SearchMemoryResponse(memories=[]))
+    svc.list_memories = AsyncMock(return_value=[])
+    return svc
+
+
+def _entry(text: str, *, entry_id: str = None, meta: dict = None) -> MemoryEntry:
+    return MemoryEntry(
+        id=entry_id or f"mem-{uuid.uuid4().hex[:8]}",
+        content=types.Content(role="model", parts=[types.Part(text=text)]),
+        author="agent-a",
+        timestamp="2026-08-22T00:00:00.000Z",
+        custom_metadata=meta or {},
+    )
+
+
+@pytest.fixture
+def service():
+    return _mock_service()
+
+
+@pytest.fixture
+def tools(service):
+    return create_flair_tools(service, app_name="app", user_id="user")
+
+
+@pytest.fixture
+def store(tools):
+    return tools[0]
+
+
+@pytest.fixture
+def search(tools):
+    return tools[1]
+
+
+@pytest.fixture
+def listing(tools):
+    return tools[2]
+
+
+# ─── Hermetic: factory ───────────────────────────────────────────────────────
+
+
+class TestFactory:
+    def test_returns_three_named_async_tools(self, tools):
+        import inspect
+
+        assert [f.__name__ for f in tools] == [
+            "store_memory", "search_memory", "list_memories",
+        ]
+        for f in tools:
+            assert inspect.iscoroutinefunction(f), f.__name__
+            assert f.__doc__ and f.__doc__.strip(), f.__name__
+
+    def test_scope_params_are_keyword_only(self, service):
+        """The scope must be named at the call site — auditable wiring."""
+        with pytest.raises(TypeError):
+            create_flair_tools(service, "app", "user")
+
+    def test_empty_app_name_rejected_at_factory_time(self, service):
+        with pytest.raises(ValueError, match="app_name"):
+            create_flair_tools(service, app_name="", user_id="user")
+
+    def test_empty_user_id_rejected_at_factory_time(self, service):
+        with pytest.raises(ValueError, match="user_id"):
+            create_flair_tools(service, app_name="app", user_id="")
+
+    def test_non_service_rejected(self):
+        with pytest.raises(TypeError, match="FlairMemoryService"):
+            create_flair_tools(object(), app_name="app", user_id="user")
+
+    async def test_two_factories_bind_independent_scopes(self):
+        """Closure binding control: two tool sets never share scope/service."""
+        svc_a, svc_b = _mock_service(), _mock_service()
+        search_a = create_flair_tools(svc_a, app_name="app-a", user_id="ua")[1]
+        search_b = create_flair_tools(svc_b, app_name="app-b", user_id="ub")[1]
+
+        await search_a(query="q")
+        await search_b(query="q")
+
+        assert svc_a.search_memory.await_count == 1
+        assert svc_b.search_memory.await_count == 1
+        assert svc_a.search_memory.await_args.kwargs["app_name"] == "app-a"
+        assert svc_a.search_memory.await_args.kwargs["user_id"] == "ua"
+        assert svc_b.search_memory.await_args.kwargs["app_name"] == "app-b"
+        assert svc_b.search_memory.await_args.kwargs["user_id"] == "ub"
+
+
+# ─── Hermetic: store_memory delegation ───────────────────────────────────────
+
+
+class TestStoreMemory:
+    async def test_delegates_with_bound_scope_and_subject(self, service, store):
+        result = await store(subject="Title", description="the fact")
+
+        service.add_memory.assert_awaited_once()
+        kwargs = service.add_memory.await_args.kwargs
+        assert kwargs["app_name"] == "app"
+        assert kwargs["user_id"] == "user"
+        assert kwargs["subject"] == "Title"
+        assert kwargs["custom_metadata"] is None
+        [entry] = kwargs["memories"]
+        assert entry.content.parts[0].text == "the fact"
+        assert result == {"status": "stored", "subject": "Title"}
+
+    async def test_tags_land_in_custom_metadata_blob(self, service, store):
+        await store(subject="s", description="d", tags=["a", "b"])
+        kwargs = service.add_memory.await_args.kwargs
+        assert kwargs["custom_metadata"] == {"tags": ["a", "b"]}
+
+    async def test_tags_merge_with_metadata_param_wins_over_blob_key(
+        self, service, store
+    ):
+        await store(
+            subject="s", description="d", tags=["real"],
+            custom_metadata={"tags": ["blob"], "source": "chat"},
+        )
+        kwargs = service.add_memory.await_args.kwargs
+        assert kwargs["custom_metadata"] == {"tags": ["real"], "source": "chat"}
+
+    async def test_tags_never_reach_a_tags_kwarg(self, service, store):
+        """The record's top-level tags array is the scope boundary — the tool
+        must not offer the service any path into it."""
+        await store(subject="s", description="d", tags=["adk:app:other-user"])
+        assert "tags" not in service.add_memory.await_args.kwargs
+
+    async def test_caller_metadata_dict_is_not_mutated(self, service, store):
+        theirs = {"source": "chat"}
+        await store(subject="s", description="d", tags=["t"], custom_metadata=theirs)
+        assert theirs == {"source": "chat"}
+
+    async def test_empty_description_errors_without_service_call(
+        self, service, store
+    ):
+        result = await store(subject="s", description="   ")
+        assert "error" in result and "description" in result["error"]
+        service.add_memory.assert_not_awaited()
+
+    async def test_service_valueerror_becomes_error_dict(self, service, store):
+        service.add_memory.side_effect = ValueError("subject is 600 characters")
+        result = await store(subject="x" * 600, description="d")
+        assert result == {"error": "subject is 600 characters"}
+
+
+# ─── Hermetic: search_memory delegation ──────────────────────────────────────
+
+
+class TestSearchMemory:
+    async def test_delegates_query_with_bound_scope(self, service, search):
+        await search(query="what does the user eat")
+        service.search_memory.assert_awaited_once_with(
+            app_name="app", user_id="user", query="what does the user eat",
+        )
+
+    async def test_limit_slices_results(self, service, search):
+        service.search_memory.return_value = SearchMemoryResponse(
+            memories=[_entry(f"m{i}") for i in range(7)]
+        )
+        result = await search(query="q", limit=5)
+        assert result["count"] == 5
+        assert len(result["memories"]) == 5
+        assert [m["content"] for m in result["memories"]] == [
+            "m0", "m1", "m2", "m3", "m4",
+        ]
+
+    async def test_entry_mapping_hoists_subject(self, service, search):
+        service.search_memory.return_value = SearchMemoryResponse(
+            memories=[_entry("body", entry_id="id-1",
+                             meta={"subject": "Title", "k": 1})]
+        )
+        result = await search(query="q")
+        [m] = result["memories"]
+        assert m == {
+            "id": "id-1",
+            "subject": "Title",
+            "content": "body",
+            "author": "agent-a",
+            "timestamp": "2026-08-22T00:00:00.000Z",
+            "custom_metadata": {"subject": "Title", "k": 1},
+        }
+
+    async def test_no_subject_maps_to_none(self, service, search):
+        service.search_memory.return_value = SearchMemoryResponse(
+            memories=[_entry("plain")]
+        )
+        [m] = (await search(query="q"))["memories"]
+        assert m["subject"] is None
+        assert m["custom_metadata"] == {}
+
+    async def test_invalid_limit_errors_without_service_call(
+        self, service, search
+    ):
+        result = await search(query="q", limit=0)
+        assert "error" in result and "limit" in result["error"]
+        service.search_memory.assert_not_awaited()
+
+    async def test_empty_results_shape(self, search):
+        assert await search(query="q") == {"count": 0, "memories": []}
+
+
+# ─── Hermetic: list_memories delegation ──────────────────────────────────────
+
+
+class TestListMemories:
+    async def test_delegates_limit_and_offset_with_bound_scope(
+        self, service, listing
+    ):
+        await listing(limit=30, offset=10)
+        service.list_memories.assert_awaited_once_with(
+            app_name="app", user_id="user", limit=30, offset=10,
+        )
+
+    async def test_defaults(self, service, listing):
+        await listing()
+        kwargs = service.list_memories.await_args.kwargs
+        assert kwargs["limit"] == 20 and kwargs["offset"] == 0
+
+    async def test_result_shape(self, service, listing):
+        service.list_memories.return_value = [
+            _entry("newest", meta={"subject": "N"}), _entry("older"),
+        ]
+        result = await listing(offset=2)
+        assert result["count"] == 2
+        assert result["offset"] == 2
+        assert [m["content"] for m in result["memories"]] == ["newest", "older"]
+
+    async def test_service_valueerror_becomes_error_dict(self, service, listing):
+        service.list_memories.side_effect = ValueError(
+            "limit 500 exceeds the hard cap of 200"
+        )
+        result = await listing(limit=500)
+        assert result == {"error": "limit 500 exceeds the hard cap of 200"}
+
+    async def test_transport_error_becomes_error_dict(self, service, listing):
+        """The service PROPAGATES transport failures by contract; the tool
+        converts them — a model needs a message, not a traceback."""
+        service.list_memories.side_effect = httpx.ConnectError("down")
+        result = await listing()
+        assert "error" in result and "ConnectError" in result["error"]
+
+
+# ─── Hermetic: return values are JSON-serializable ──────────────────────────
+
+
+class TestJsonSerializable:
+    async def test_every_tool_result_survives_json_dumps(
+        self, service, store, search, listing
+    ):
+        service.search_memory.return_value = SearchMemoryResponse(
+            memories=[_entry("m", meta={"subject": "S", "n": [1, 2]})]
+        )
+        service.list_memories.return_value = [_entry("m")]
+        for result in (
+            await store(subject="s", description="d", tags=["t"],
+                        custom_metadata={"k": {"deep": True}}),
+            await search(query="q"),
+            await listing(),
+            await store(subject="s", description=""),  # error shape too
+        ):
+            json.dumps(result)  # raises TypeError on any non-JSON value
+
+
+# ─── Hermetic: schema generation against the installed google-adk ───────────
+
+
+def _declaration(func):
+    """Run the installed google-adk's own declaration build over a tool."""
+    decl = FunctionTool(func)._get_declaration()
+    assert decl is not None, f"{func.__name__}: no declaration generated"
+    return decl
+
+
+def _decl_properties_and_required(decl):
+    """Normalize across the two declaration shapes google-adk emits
+    (types.Schema `parameters` vs raw JSON-schema `parameters_json_schema`,
+    selected by the JSON_SCHEMA_FOR_FUNC_DECL feature flag)."""
+    js = getattr(decl, "parameters_json_schema", None)
+    if js:
+        return set(js.get("properties", {})), set(js.get("required", []))
+    params = decl.parameters
+    if params is None:
+        return set(), set()
+    return set(params.properties or {}), set(params.required or [])
+
+
+class TestSchemaGeneration:
+    def test_declarations_generate_for_all_three_tools(self, tools):
+        for func in tools:
+            decl = _declaration(func)
+            assert decl.name == func.__name__
+            assert decl.description and decl.description.strip()
+
+    def test_store_memory_declaration_params(self, store):
+        props, required = _decl_properties_and_required(_declaration(store))
+        assert props == {"subject", "description", "tags", "custom_metadata"}
+        assert required == {"subject", "description"}
+
+    def test_search_memory_declaration_params(self, search):
+        props, required = _decl_properties_and_required(_declaration(search))
+        assert props == {"query", "limit"}
+        assert required == {"query"}
+
+    def test_list_memories_declaration_params(self, listing):
+        props, required = _decl_properties_and_required(_declaration(listing))
+        assert props == {"limit", "offset"}
+        assert required == set()
+
+    def test_scope_never_appears_in_any_declaration(self, tools):
+        """The model must not be offered the scope: no app_name/user_id/
+        memory_service parameter may surface in any declaration."""
+        for func in tools:
+            props, _ = _decl_properties_and_required(_declaration(func))
+            assert not props & {"app_name", "user_id", "memory_service"}, (
+                f"{func.__name__} leaks scope params into its declaration"
+            )
+
+    async def test_function_tool_run_async_invokes_the_bare_callable(
+        self, service, search
+    ):
+        """End-to-end through ADK's own FunctionTool invocation path — proves
+        bare async callables execute, not just declare."""
+        service.search_memory.return_value = SearchMemoryResponse(
+            memories=[_entry("found")]
+        )
+        tool = FunctionTool(search)
+        result = await tool.run_async(
+            args={"query": "q"}, tool_context=MagicMock()
+        )
+        assert result["count"] == 1
+        assert result["memories"][0]["content"] == "found"
+
+    def test_llm_agent_accepts_the_bare_callables(self, tools):
+        """ToolUnion smoke test: LlmAgent's pydantic layer takes the list
+        as-is (Union[Callable, BaseTool, BaseToolset])."""
+        from google.adk.agents.llm_agent import LlmAgent
+
+        agent = LlmAgent(name="smoke", model="gemini-2.5-flash", tools=tools)
+        assert len(agent.tools) == 3
+
+
+# ─── Live: tool-level round-trip ─────────────────────────────────────────────
+
+
+def _live_service(live):
+    return FlairMemoryService(
+        url=live.http_url,
+        agent_id=live.agent_id,
+        keyfile=live.keyfile_path,
+        timeout=10.0,  # ephemeral Harper under test load — not a latency test
+    )
+
+
+@pytest.mark.live_flair
+class TestToolsLive:
+    async def test_store_search_list_round_trip(self, live_flair):
+        app, user = "tools-rt", f"u-{uuid.uuid4().hex[:8]}"
+        marker = f"tools-marker-{uuid.uuid4().hex[:8]}"
+        service = _live_service(live_flair)
+        store, search, listing = create_flair_tools(
+            service, app_name=app, user_id=user
+        )
+        try:
+            stored = await store(
+                subject="Round Trip",
+                description=f"the user prefers {marker} tea",
+                tags=["preference", "beverage"],
+                custom_metadata={"source": "tool-test"},
+            )
+            assert stored == {"status": "stored", "subject": "Round Trip"}
+
+            found = await search(query=marker, limit=5)
+            assert found["count"] >= 1, "stored memory not found by tool search"
+            hit = next(
+                (m for m in found["memories"] if marker in m["content"]), None
+            )
+            assert hit is not None, "marker memory missing from tool results"
+            assert hit["subject"] == "Round Trip"
+            assert hit["custom_metadata"]["tags"] == ["preference", "beverage"]
+            assert hit["custom_metadata"]["source"] == "tool-test"
+            assert hit["author"] == live_flair.agent_id
+
+            listed = await listing(limit=20)
+            assert listed["count"] >= 1
+            assert any(marker in m["content"] for m in listed["memories"]), (
+                "stored memory missing from tool list"
+            )
+        finally:
+            await service.close()
+
+    async def test_live_scope_isolation_between_tool_sets(self, live_flair):
+        """A second user's tool set must not see the first user's memory."""
+        app = "tools-iso"
+        user_a, user_b = f"a-{uuid.uuid4().hex[:8]}", f"b-{uuid.uuid4().hex[:8]}"
+        marker = f"iso-marker-{uuid.uuid4().hex[:8]}"
+        service = _live_service(live_flair)
+        store_a = create_flair_tools(service, app_name=app, user_id=user_a)[0]
+        _, search_b, list_b = create_flair_tools(
+            service, app_name=app, user_id=user_b
+        )
+        try:
+            await store_a(subject="A only", description=f"secret {marker}")
+
+            found_b = await search_b(query=marker)
+            assert all(
+                marker not in m["content"] for m in found_b["memories"]
+            ), "user B's search tool surfaced user A's memory"
+
+            listed_b = await list_b()
+            assert all(
+                marker not in m["content"] for m in listed_b["memories"]
+            ), "user B's list tool surfaced user A's memory"
+        finally:
+            await service.close()


### PR DESCRIPTION
Closes #1331

Pre-built ADK agent tools for adk-flair, built on the #1334 surface (custom_metadata store-and-return, subject column, list_memories).

## What

New module `adk_flair.tools`, exported as `from adk_flair import create_flair_tools`:

```python
create_flair_tools(memory_service: FlairMemoryService, *, app_name: str, user_id: str) -> list
```

Returns `[store_memory, search_memory, list_memories]` — async closures bound to one service and one app+user scope:

- `store_memory(subject: str, description: str, tags: Optional[list[str]] = None, custom_metadata: Optional[dict] = None)`
- `search_memory(query: str, limit: int = 5)`
- `list_memories(limit: int = 20, offset: int = 0)`

## Design (as ruled)

- **Explicit injection only.** No env-var discovery, no ADK registry lookup, no module-level singleton, no ambient fallback of any kind — not even opt-in. The service and scope a tool acts on are visible at the call site that created it.
- **Scope binds at factory time.** `app_name`/`user_id` are keyword-only factory arguments, validated non-empty at wiring time. The agent must not choose its own scope: a per-call `user_id` would be a model-controllable parameter that reads another user's memories. No ADK-idiomatic reason to do otherwise surfaced — ADK's own stateful tool examples close over their configuration the same way. Tests assert `app_name`/`user_id`/`memory_service` never appear in any generated declaration.
- **Async-only**, JSON-serializable plain-dict returns; model-actionable failures return `{"error": ...}` (the shape ADK's own FunctionTool uses for tool-level errors): validation `ValueError`s pass through verbatim so the model can shrink and retry; `list_memories` transport failures (which the service propagates by contract) are converted to an error dict — a model needs a message, not a traceback.

## FunctionTool vs bare callable (the compatibility question)

**Bare async callables are the supported form on the installed google-adk** (fresh resolve of the `>=2.6` pin → **2.7.1**; also verified identical on 2.6.2): `ToolUnion: TypeAlias = Union[Callable, BaseTool, BaseToolset]`, and `_convert_tool_union_to_tools` wraps any callable in `FunctionTool(func=tool_union)` automatically. So the factory returns bare functions — no manual wrapping needed, and `FunctionTool(tool)` still works and produces the same declaration. The suite runs ADK's own declaration build (`FunctionTool._get_declaration()`, which routes through `build_function_declaration` / the `parameters_json_schema` path under the JSON_SCHEMA feature flag) over all three tools, plus an execution test through `FunctionTool.run_async` and an `LlmAgent(tools=...)` acceptance test.

## Two decisions worth reviewer eyes

1. **`tags` land inside `custom_metadata["tags"]`, never in a service `tags` kwarg.** `add_memory` has no tags parameter, and the record's top-level `tags` array is the per-user scope boundary (compound `adk:<app>:<user>` tag). A model-supplied value landing there could forge another scope's tag and pass the read-path re-verification — so the tool deliberately offers the service no path into it (asserted in a test). Blob tags round-trip on search/list per the #1334 store-and-return contract; the explicit param is authoritative over a blob `"tags"` key (same rule as `subject`), and the caller's dict is never mutated.
2. **`search_memory(limit=5)` slices client-side.** The service's `search_memory` takes no limit (fixed request limit of 20, ADK's contract surface) — the tool slices to `limit` and documents that values above 20 still return at most 20.

`subject` flows through the #1334 first-class subject param path; results hoist `subject` to the top level of each memory dict (symmetric with `store_memory(subject=...)`) alongside the full `custom_metadata`.

## Tests

- **Hermetic: 134 pass vs 102 baseline (+32)** — factory binding/keyword-only/validation, independent scopes per factory, per-tool delegation onto a `spec`'d mock (kwargs asserted exactly), tags-merge precedence + no-mutation + no-tags-kwarg guard, error shapes, JSON-serializability of every return (error shapes included), declaration generation + required/property sets per tool, scope-leak assertion, `FunctionTool.run_async` execution, `LlmAgent` acceptance.
- **Live: 2 new, both green locally** on ephemeral Harper — tool-level store→search→list round-trip (subject/tags/metadata verified on the hit) and cross-user scope isolation between two tool sets.
- README "Agent tools" section; changelog fragment `added-1331-adk-agent-tools.md` (fragment check clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
