### PR TITLE
adk-flair: create via POST /Memory with 409→PUT fallback; Memory.post() createdAt parity (Closes #1336)

### DIFF
--- a/.changelog/unreleased/fixed-1336-adk-post-create.md
+++ b/.changelog/unreleased/fixed-1336-adk-post-create.md
@@ -1,0 +1,21 @@
+- **adk-flair: creates now use `POST /Memory/` (the create verb) instead of
+  `PUT /Memory/{id}`, with a 409 → PUT fallback for re-ingestion; `Memory`
+  `post()` gains createdAt parity with `put()`** (flair#1336). All three write
+  entrypoints (`add_session_to_memory`, `add_events_to_memory`, `add_memory`)
+  previously created records via `PUT /Memory/{id}` — update-only on some
+  hosted Harper Fabric deployments, where a PUT-shaped create 404s and every
+  adk-flair write fails (not reproducible on stock Harper 5.2.0/5.2.2/5.2.4,
+  where PUT upserts). Creates go through `POST /Memory/` with the id in the
+  body; a 409 (record already exists — deterministic-id re-ingestion of a
+  growing session) falls back to `PUT /Memory/{id}`, preserving the old
+  replace/refresh semantics. HTTP failures now raise `FlairRequestError`
+  (a `RuntimeError` subclass, message unchanged) carrying `.status_code` —
+  the write-path warning logs that used to print the undiagnosable
+  `status=?` now show the real status. Server side: `Memory.post()` honors a
+  caller-supplied `createdAt` exactly as `put()` always has (`?? now`) —
+  moving creates onto POST would otherwise silently re-stamp historical
+  timestamps (`MemoryEntry.timestamp`) with server-now; `validFrom` follows
+  `createdAt`, `updatedAt` stays the true write moment, and the ephemeral
+  `expiresAt` stamp remains anchored to write time, so a caller `createdAt`
+  cannot move the flair#1257 exposure window. Grants no new capability: PUT
+  already accepted arbitrary `createdAt` from the same principals.

--- a/packages/adk-flair/src/adk_flair/__init__.py
+++ b/packages/adk-flair/src/adk_flair/__init__.py
@@ -26,10 +26,10 @@ agent's services.py, or use services.yaml:
         class: adk_flair.memory_service.FlairMemoryService
 """
 
-from adk_flair.memory_service import FlairMemoryService
+from adk_flair.memory_service import FlairMemoryService, FlairRequestError
 from adk_flair.tools import create_flair_tools
 
-__all__ = ["FlairMemoryService", "create_flair_tools", "register"]
+__all__ = ["FlairMemoryService", "FlairRequestError", "create_flair_tools", "register"]
 
 
 def register():

--- a/packages/adk-flair/src/adk_flair/memory_service.py
+++ b/packages/adk-flair/src/adk_flair/memory_service.py
@@ -99,6 +99,30 @@ _SUBJECT_MAX_CHARS = 512
 # session instead of an immediate, actionable ValueError.
 _LIST_MEMORIES_MAX_LIMIT = 200
 
+# ─── Errors ─────────────────────────────────────────────────────────────────
+
+
+class FlairRequestError(RuntimeError):
+    """An HTTP-level failure from Flair, carrying the status code.
+
+    Subclasses RuntimeError with an identical message to the bare
+    RuntimeError this replaced, so existing ``except RuntimeError`` /
+    ``str(exc)`` handling is unchanged. What it adds: ``status_code``
+    (plus ``method``/``path``/``reason``) as attributes — the write-path
+    warning logs probe ``exc.status_code`` and, before this class existed,
+    always fell through to ``status=?`` (the undiagnosable log line in
+    flair#1336's field report). It also lets callers branch on specific
+    statuses (the 409 create-fallback in ``_write_memory_record``).
+    """
+
+    def __init__(self, method: str, path: str, status_code: int, reason: str):
+        super().__init__(f"Flair {method} {path} → {status_code} {reason}")
+        self.method = method
+        self.path = path
+        self.status_code = status_code
+        self.reason = reason
+
+
 # ─── Helpers ────────────────────────────────────────────────────────────────
 
 
@@ -585,14 +609,39 @@ class FlairMemoryService(BaseMemoryService):
             raise
 
         if resp.status_code >= 400:
-            raise RuntimeError(
-                f"Flair {method} {path} → {resp.status_code} {resp.reason_phrase}"
+            raise FlairRequestError(
+                method, path, resp.status_code, resp.reason_phrase
             )
 
         ctype = resp.headers.get("content-type", "")
         if "json" in ctype:
             return resp.json()
         return resp.text
+
+    async def _write_memory_record(
+        self, record_id: str, body: Dict[str, Any]
+    ) -> None:
+        """Create-or-replace one Memory record.
+
+        Creates via ``POST /Memory/`` — Harper's collection create verb —
+        with the id in the body. The previous shape, ``PUT /Memory/{id}``,
+        is update-only on some Harper deployments and 404s when the record
+        does not exist yet (flair#1336, observed on hosted Harper Fabric;
+        not reproducible on stock Harper 5.2.x, where PUT upserts).
+
+        A 409 from POST means the record already exists — re-ingestion of a
+        deterministic id (add_session_to_memory re-saves a growing session's
+        earlier events every time) or a caller-supplied id being rewritten.
+        Fall back to ``PUT /Memory/{id}`` for exactly that case, preserving
+        the pre-#1336 replace/refresh semantics for existing rows. Any other
+        error propagates unchanged.
+        """
+        try:
+            await self._request("POST", "/Memory/", json_body=body)
+        except FlairRequestError as exc:
+            if exc.status_code != 409:
+                raise
+            await self._request("PUT", f"/Memory/{record_id}", json_body=body)
 
     # ── BaseMemoryService implementation ─────────────────────────────────────
 
@@ -627,7 +676,7 @@ class FlairMemoryService(BaseMemoryService):
                 "createdAt": _iso_now(),
             }
             try:
-                await self._request("PUT", f"/Memory/{record_id}", json_body=body)
+                await self._write_memory_record(record_id, body)
                 written += 1
             except Exception as exc:
                 status = getattr(getattr(exc, "response", None), "status_code", None) or getattr(exc, "status_code", None) or "?"
@@ -696,7 +745,7 @@ class FlairMemoryService(BaseMemoryService):
             if subject_value is not None:
                 body["subject"] = subject_value
             try:
-                await self._request("PUT", f"/Memory/{record_id}", json_body=body)
+                await self._write_memory_record(record_id, body)
                 written += 1
             except Exception as exc:
                 status = getattr(getattr(exc, "response", None), "status_code", None) or getattr(exc, "status_code", None) or "?"
@@ -798,7 +847,7 @@ class FlairMemoryService(BaseMemoryService):
             if mem.author:
                 body["author"] = mem.author
             try:
-                await self._request("PUT", f"/Memory/{record_id}", json_body=body)
+                await self._write_memory_record(record_id, body)
                 written += 1
             except Exception as exc:
                 status = getattr(getattr(exc, "response", None), "status_code", None) or getattr(exc, "status_code", None) or "?"

--- a/packages/adk-flair/tests/test_memory_service.py
+++ b/packages/adk-flair/tests/test_memory_service.py
@@ -524,7 +524,11 @@ class TestAddEventsToMemory:
                 session_id="sess-1", custom_metadata={"ttl": "7d"},
             )
 
-        body = service._client.request.call_args[1]["json"]
+        # flair#1336 intersection pin: the metadata-carrying body rides the
+        # POST create verb — #1334's plumbing must survive the verb switch.
+        args = service._client.request.call_args
+        assert (args[0][0], args[0][1]) == ("POST", "/Memory/")
+        body = args[1]["json"]
         assert json.loads(body["metadata"]) == {"ttl": "7d"}
         custom_warnings = [
             r.message for r in caplog.records
@@ -748,6 +752,116 @@ class TestAddMemory:
             )
             body = service._client.request.call_args[1]["json"]
             assert body["durability"] == dur
+
+
+# ─── Create verb + conflict fallback (flair#1336) ───────────────────────────
+
+
+def _mock_response(status_code: int, reason: str = "") -> MagicMock:
+    return MagicMock(
+        status_code=status_code,
+        reason_phrase=reason,
+        headers={"content-type": "application/json"},
+        text="{}",
+    )
+
+
+class TestCreateVerbAndConflictFallback:
+    """flair#1336: creates must use POST /Memory/ (the create verb), never a
+    bare PUT /Memory/{id} — PUT-shaped creates 404 on Harper deployments
+    where PUT is update-only (observed on hosted Harper Fabric). A 409 from
+    POST (record already exists — deterministic-id re-ingestion) falls back
+    to PUT, preserving the old replace semantics."""
+
+    @pytest.mark.asyncio
+    async def test_all_write_entrypoints_create_via_post_collection(self, service):
+        """Every write entrypoint issues POST /Memory/ with the id in the
+        body — the direct regression assertion for flair#1336."""
+        service._client.request.return_value = _mock_response(201)
+
+        session = _make_session("app", "user", "sess-1", [_make_event("evt-1", "hello")])
+        await service.add_session_to_memory(session)
+
+        args = service._client.request.call_args
+        assert args[0][0] == "POST"
+        assert args[0][1] == "/Memory/"
+        assert args[1]["json"]["id"] == "app:user:sess-1:evt-1"
+
+        service._client.request.reset_mock()
+        await service.add_events_to_memory(
+            app_name="app", user_id="user",
+            events=[_make_event("evt-2", "turn")], session_id="sess-1",
+        )
+        args = service._client.request.call_args
+        assert (args[0][0], args[0][1]) == ("POST", "/Memory/")
+
+        service._client.request.reset_mock()
+        await service.add_memory(
+            app_name="app", user_id="user",
+            memories=[MemoryEntry(
+                id="mem-1",
+                content=types.Content(role="user", parts=[types.Part(text="fact")]),
+            )],
+        )
+        args = service._client.request.call_args
+        assert (args[0][0], args[0][1]) == ("POST", "/Memory/")
+        assert args[1]["json"]["id"] == "mem-1"
+
+    @pytest.mark.asyncio
+    async def test_conflict_falls_back_to_put_replace(self, service, caplog):
+        """POST → 409 (record exists) → PUT /Memory/{id} with the SAME body.
+        Idempotent re-ingestion must neither raise nor warn.
+
+        This is the trap a naive PUT→POST swap walks into: without the
+        fallback, every re-save of an already-ingested session event fails
+        with 409 on every deployment where the old PUT path worked."""
+        service._client.request.side_effect = [
+            _mock_response(409, "Conflict"),
+            _mock_response(200),
+        ]
+
+        session = _make_session("app", "user", "sess-1", [_make_event("evt-1", "hello")])
+        await service.add_session_to_memory(session)
+
+        assert service._client.request.call_count == 2
+        first, second = service._client.request.call_args_list
+        assert (first[0][0], first[0][1]) == ("POST", "/Memory/")
+        assert (second[0][0], second[0][1]) == ("PUT", "/Memory/app:user:sess-1:evt-1")
+        assert second[1]["json"] == first[1]["json"]
+
+        warnings = [r.message for r in caplog.records if r.levelname == "WARNING"]
+        assert not any("write failed" in str(w).lower() for w in warnings)
+
+    @pytest.mark.asyncio
+    async def test_non_conflict_error_propagates_with_real_status(self, service, caplog):
+        """A non-409 failure does NOT fall back to PUT, and the warning log
+        carries the real status (status=404), not the pre-#1336 'status=?' —
+        FlairRequestError exposes .status_code and the log line reads it."""
+        service._client.request.return_value = _mock_response(404, "Not Found")
+
+        await service.add_memory(
+            app_name="app", user_id="user",
+            memories=[MemoryEntry(
+                id="mem-404",
+                content=types.Content(role="user", parts=[types.Part(text="fact")]),
+            )],
+        )
+
+        assert service._client.request.call_count == 1  # no PUT fallback on non-409
+        warnings = [r.getMessage() for r in caplog.records if r.levelname == "WARNING"]
+        assert any("status=404" in w for w in warnings), warnings
+
+    def test_flair_request_error_is_runtime_error_with_same_message(self):
+        """Message stays byte-identical to the bare RuntimeError it replaced;
+        the status/method/path ride along as attributes."""
+        from adk_flair.memory_service import FlairRequestError
+
+        exc = FlairRequestError("POST", "/Memory/", 404, "Not Found")
+        assert isinstance(exc, RuntimeError)
+        assert str(exc) == "Flair POST /Memory/ → 404 Not Found"
+        assert exc.status_code == 404
+        assert exc.method == "POST"
+        assert exc.path == "/Memory/"
 
 
 # ─── Event text extraction ──────────────────────────────────────────────────

--- a/packages/adk-flair/tests/test_portability.py
+++ b/packages/adk-flair/tests/test_portability.py
@@ -257,3 +257,65 @@ class TestPortability:
             f"Session memory content not in REST search results. "
             f"Results: {[r.get('content', '')[:80] for r in results]}"
         )
+
+    @pytest.mark.asyncio
+    async def test_reingest_same_id_replaces_without_error(self, live_flair, caplog):
+        """flair#1336 fallback, end-to-end against real Harper: create a
+        record via the POST path, then re-write the SAME id with new content.
+        Harper answers the second POST with 409; the adapter must fall back
+        to PUT and REPLACE the row — no exception, no 'write failed' warning,
+        and the stored content is the second version.
+
+        Fails on a naive POST-only client (warning + stale content) and on a
+        409-treated-as-skip client (stale content)."""
+        import logging as _logging
+
+        from adk_flair import FlairMemoryService
+        from adk_flair.memory_service import _compound_tag
+
+        app = "portability-test"
+        user = "reingest-user"
+        tag = _compound_tag(app, user)
+
+        service = FlairMemoryService(
+            url=live_flair.http_url,
+            agent_id=live_flair.agent_id,
+            keyfile=live_flair.keyfile_path,
+        )
+
+        rid = f"reingest-{uuid.uuid4().hex[:8]}"
+        marker_v2 = f"reingest-v2-{uuid.uuid4().hex[:8]}"
+
+        def entry(text: str) -> MemoryEntry:
+            return MemoryEntry(
+                id=rid,
+                content=types.Content(role="user", parts=[types.Part(text=text)]),
+            )
+
+        with caplog.at_level(_logging.WARNING, logger="adk_flair"):
+            await service.add_memory(
+                app_name=app, user_id=user,
+                memories=[entry(f"reingest-v1-{uuid.uuid4().hex[:8]}")],
+            )
+            await service.add_memory(
+                app_name=app, user_id=user, memories=[entry(marker_v2)],
+            )
+        await service.close()
+
+        warnings = [r.getMessage() for r in caplog.records if r.levelname == "WARNING"]
+        assert not any("write failed" in w.lower() for w in warnings), (
+            f"re-ingestion of an existing id must not fail: {warnings}"
+        )
+
+        # Replace semantics preserved: the row now holds the v2 content.
+        results = await _flair_search(
+            live_flair.http_url,
+            live_flair.agent_id,
+            live_flair.private_key,
+            marker_v2,
+            tag=tag,
+        )
+        assert any(marker_v2 in r.get("content", "") for r in results), (
+            f"re-ingested content not found — 409 fallback did not replace. "
+            f"Results: {[r.get('content', '')[:80] for r in results]}"
+        )

--- a/resources/Memory.ts
+++ b/resources/Memory.ts
@@ -659,8 +659,22 @@ export class Memory extends (databases as any).flair.Memory {
     }
 
     content.durability ||= "standard";
-    content.createdAt = new Date().toISOString();
-    content.updatedAt = content.createdAt;
+    // ── flair#1336: honor a caller-supplied createdAt (parity with put()) ──
+    // put() — the other HTTP-reachable create path — has always preserved the
+    // caller's createdAt (`content.createdAt ?? now`), and adk-flair's
+    // add_memory forwards MemoryEntry.timestamp through it for historical
+    // imports. When #1336 moved client creates onto POST, this line's
+    // unconditional re-stamp silently discarded those timestamps (caught by
+    // the #1334 list-pagination live test: rows written with backdated
+    // timestamps came back stamped "now"). Honoring the caller grants no new
+    // capability — PUT already accepted arbitrary createdAt from the same
+    // principals. validFrom below keys off createdAt and follows it, exactly
+    // as on the put() path; updatedAt stays the true write moment; the
+    // ephemeral expiresAt stamp keys off Date.now(), so a backdated create
+    // cannot stretch the #1257 exposure window.
+    const nowIso = new Date().toISOString();
+    content.createdAt = content.createdAt ?? nowIso;
+    content.updatedAt = nowIso;
     content.archived = content.archived ?? false;
 
     // ─── Default visibility (durability-keyed) — Layer 1, part A ────────────
@@ -713,9 +727,13 @@ export class Memory extends (databases as any).flair.Memory {
       content.visibility = defaultVisibilityForDurability(content.durability);
     }
 
-    // Validate derivedFrom source IDs exist (best-effort, non-blocking)
+    // Validate derivedFrom source IDs exist (best-effort, non-blocking).
+    // lastReflected keys off updatedAt (the write moment), NOT createdAt —
+    // since #1336 a create may carry a backdated caller createdAt, and the
+    // reflection bookkeeping must record when the derivation actually ran.
+    // (Pre-#1336 the two were always identical here.)
     if (Array.isArray(content.derivedFrom) && content.derivedFrom.length > 0) {
-      const now = content.createdAt;
+      const now = content.updatedAt;
       for (const sourceId of content.derivedFrom) {
         try {
           const src = await (databases as any).flair.Memory.get(sourceId);

--- a/test/integration/post-create-createdat-parity-1336.test.ts
+++ b/test/integration/post-create-createdat-parity-1336.test.ts
@@ -1,0 +1,145 @@
+// flair#1336 — POST /Memory createdAt parity with PUT, behavioural positive control.
+//
+// #1336 moved client creates (adk-flair) from `PUT /Memory/{id}` onto
+// `POST /Memory/` — the create verb — because PUT-shaped creates 404 on some
+// hosted Harper deployments. That exposed an undocumented POST/PUT asymmetry:
+// put() has always honored a caller-supplied createdAt (`?? now`), while
+// post() unconditionally re-stamped it with server-now, silently discarding
+// historical timestamps (adk-flair forwards MemoryEntry.timestamp as
+// createdAt; the #1334 list-pagination live test caught the discard).
+//
+// This file is the fails-on-main control for the parity fix:
+//   - pre-fix: the backdated-createdAt POST round-trips as "now"  → test 1 RED
+//   - post-fix: caller createdAt is preserved; validFrom follows it; the
+//     ephemeral expiresAt stamp stays anchored to the WRITE moment, so a
+//     backdated (or forward-dated) createdAt cannot move the #1257
+//     exposure window.
+//
+// Pattern: test/integration/durability-write-validation-e2e.test.ts
+// (Ed25519 signing helpers, admin-op seeding, startHarper lifecycle).
+import { describe, expect, test, beforeAll, afterAll } from "bun:test";
+import nacl from "tweetnacl";
+import { randomUUID } from "node:crypto";
+import { startHarper, stopHarper, HarperInstance } from "../helpers/harper-lifecycle";
+
+interface TestAgent { id: string; publicKey: string; secretKey: Uint8Array; }
+
+function mkAgent(id: string): TestAgent {
+  const kp = nacl.sign.keyPair();
+  return { id, publicKey: Buffer.from(kp.publicKey).toString("base64"), secretKey: kp.secretKey };
+}
+
+function ed25519Header(agent: TestAgent, method: string, path: string): string {
+  const ts = Date.now().toString();
+  const nonce = randomUUID();
+  const payload = `${agent.id}:${ts}:${nonce}:${method}:${path}`;
+  const sig = nacl.sign.detached(new TextEncoder().encode(payload), agent.secretKey);
+  return `TPS-Ed25519 ${agent.id}:${ts}:${nonce}:${Buffer.from(sig).toString("base64")}`;
+}
+
+async function authFetch(harper: HarperInstance, agent: TestAgent, method: string, path: string, body?: unknown): Promise<Response> {
+  const headers: Record<string, string> = { Authorization: ed25519Header(agent, method, path) };
+  if (body !== undefined) headers["Content-Type"] = "application/json";
+  return fetch(`${harper.httpURL}${path}`, { method, headers, body: body !== undefined ? JSON.stringify(body) : undefined });
+}
+
+async function adminOp(harper: HarperInstance, op: Record<string, any>): Promise<Response> {
+  return fetch(harper.opsURL, {
+    method: "POST",
+    headers: { "Content-Type": "application/json", Authorization: "Basic " + btoa(`${harper.admin.username}:${harper.admin.password}`) },
+    body: JSON.stringify(op),
+  });
+}
+
+async function seedAgent(harper: HarperInstance, agent: TestAgent): Promise<void> {
+  const res = await adminOp(harper, {
+    operation: "insert", database: "flair", table: "Agent",
+    records: [{ id: agent.id, name: agent.id, role: "agent", publicKey: agent.publicKey, createdAt: new Date().toISOString() }],
+  });
+  expect(res.status).toBe(200);
+}
+
+async function getRecord(harper: HarperInstance, agent: TestAgent, id: string): Promise<any> {
+  const res = await authFetch(harper, agent, "GET", `/Memory/${id}`);
+  expect(res.status).toBe(200);
+  return res.json();
+}
+
+let harper: HarperInstance;
+const agent = mkAgent("parity-owner-1336");
+
+// A timestamp unambiguously in the past — a re-stamp to "now" can never
+// collide with it, so the assertion cannot pass by accident.
+const BACKDATED = "2020-01-05T00:00:00.000Z";
+
+beforeAll(async () => {
+  harper = await startHarper();
+  await seedAgent(harper, agent);
+}, 120_000);
+
+afterAll(async () => {
+  await stopHarper(harper);
+});
+
+describe("flair#1336 — POST /Memory createdAt parity with PUT", () => {
+  test("POST preserves a caller-supplied createdAt; validFrom follows it; updatedAt is the write moment", async () => {
+    const id = `parity-post-backdated-${randomUUID().slice(0, 8)}`;
+    const before = Date.now();
+    const res = await authFetch(harper, agent, "POST", "/Memory/", {
+      id, agentId: agent.id, content: `historical import ${id}`,
+      type: "session", durability: "standard", createdAt: BACKDATED,
+    });
+    expect(res.status).toBe(201);
+
+    const row = await getRecord(harper, agent, id);
+    expect(row.createdAt).toBe(BACKDATED);          // RED on pre-#1336 main: re-stamped to now
+    expect(row.validFrom).toBe(BACKDATED);          // temporal validity keys off createdAt
+    expect(Date.parse(row.updatedAt)).toBeGreaterThanOrEqual(before); // write moment, never backdated
+  });
+
+  test("POST without createdAt still stamps server-now (default unchanged)", async () => {
+    const id = `parity-post-default-${randomUUID().slice(0, 8)}`;
+    const before = Date.now();
+    const res = await authFetch(harper, agent, "POST", "/Memory/", {
+      id, agentId: agent.id, content: `fresh write ${id}`,
+      type: "session", durability: "standard",
+    });
+    expect(res.status).toBe(201);
+
+    const row = await getRecord(harper, agent, id);
+    expect(Date.parse(row.createdAt)).toBeGreaterThanOrEqual(before);
+    expect(row.createdAt).toBe(row.updatedAt);
+  });
+
+  test("ephemeral expiresAt stays anchored to the write moment, not a caller createdAt", async () => {
+    // The #1257 containment bound: expiresAt = write-time + TTL. If it keyed
+    // off createdAt, a FORWARD-dated createdAt would stretch the exposure
+    // window; a backdated one would pre-expire the row. Neither may happen.
+    const id = `parity-post-ephemeral-${randomUUID().slice(0, 8)}`;
+    const before = Date.now();
+    const res = await authFetch(harper, agent, "POST", "/Memory/", {
+      id, agentId: agent.id, content: `ephemeral historical ${id}`,
+      type: "session", durability: "ephemeral", createdAt: BACKDATED,
+    });
+    expect(res.status).toBe(201);
+
+    const row = await getRecord(harper, agent, id);
+    expect(row.createdAt).toBe(BACKDATED);
+    const ttlHours = Number(process.env.FLAIR_EPHEMERAL_TTL_HOURS || 24);
+    const expires = Date.parse(row.expiresAt);
+    expect(expires).toBeGreaterThanOrEqual(before + ttlHours * 3600_000 - 60_000);
+    expect(expires).toBeLessThanOrEqual(Date.now() + ttlHours * 3600_000 + 60_000);
+  });
+
+  test("PUT create with the same backdated createdAt behaves identically (the parity frame)", async () => {
+    const id = `parity-put-backdated-${randomUUID().slice(0, 8)}`;
+    const res = await authFetch(harper, agent, "PUT", `/Memory/${id}`, {
+      id, agentId: agent.id, content: `historical import via put ${id}`,
+      type: "session", durability: "standard", createdAt: BACKDATED,
+    });
+    expect(res.status).toBe(200);
+
+    const row = await getRecord(harper, agent, id);
+    expect(row.createdAt).toBe(BACKDATED);
+  });
+});


### PR DESCRIPTION
Closes #1336

## What ships

**Client (adk-flair):** all three write entrypoints (`add_session_to_memory`, `add_events_to_memory`, `add_memory` — the issue names two; main has three) created records via `PUT /Memory/{id}`. They now create via `POST /Memory/` (the create verb) with the id in the body, falling back to `PUT /Memory/{id}` on a 409 so deterministic-id re-ingestion keeps its replace semantics (a blind verb swap regresses every re-save: POST on an existing id is `409 Record already exists`, measured on stock Harper and on casa). HTTP errors now raise `FlairRequestError` (a `RuntimeError` subclass, message byte-identical) carrying `.status_code` — the write-path warning logs probed `exc.status_code`, but `_request` raised a bare `RuntimeError`, which is exactly why the issue's field report reads `status=?` and why the original failure's true status was never captured.

**Server (`resources/Memory.ts`):** `Memory.post()` now honors a caller-supplied `createdAt` exactly as `put()` always has (`?? now`). This was the one thing POST lacked that PUT had: moving creates onto POST silently re-stamped historical timestamps (`MemoryEntry.timestamp` → `createdAt`) with server-now — caught live by the #1334 list-pagination test (backdated rows came back stamped "now"). `validFrom` follows `createdAt` (same as put()); `updatedAt` stays the true write moment; ephemeral `expiresAt` remains anchored to write time, so a caller `createdAt` cannot move the #1257 exposure window. **No new capability granted: PUT already accepted arbitrary `createdAt` from the same principals.**

## Investigation: the issue's premise is refuted — including on casa itself

The issue states "PUT /Memory/{id} is an update operation… if the record does not exist, Harper returns 404." Measured everywhere, including the reporting instance with restored credentials:

### Full discriminator matrix (minimal adk-shaped Memory body, fresh ids; casa = flair 0.46.0 / **Harper 5.2.3** via `registration_info`)

| Environment | Harper | Principal | `PUT /Memory/{fresh-id}` | `POST /Memory/` |
|---|---|---|---|---|
| Local lane | 5.2.0 (fleet pin) | admin · Ed25519 agent | **200 creates** | **201 creates** |
| Local lane | 5.2.2 | admin | **200 creates** | **201 creates** |
| Local lane | 5.2.4 (npm latest) | admin · Ed25519 agent | **200 creates** | **201 creates** |
| **casa** | **5.2.3** | admin | **200 creates** (readback 200) | **201** |
| **casa** | 5.2.3 | **registered Ed25519 agent** (fresh probe agent, exact adk signing path) | **200 creates** (readback 200; search 200) | **201** |
| **casa** | 5.2.3 | unregistered Ed25519 agent | 401 `unknown_agent` (uniform across PUT/POST/GET/search; **no row lands** — admin readback 404) | 401 `unknown_agent` |
| **casa** | 5.2.3 | anonymous | 401 | 401 |

Additional cells, all non-404: slash-bearing composite ids (`probe-1336-slash/2026-08-22/shot.png`) — PUT **200 creates**, readback 200 raw and `%2F`-encoded, both principals; colon/dot/`@` id shapes — route resolves; collection-PUT (empty id) — 400. All probe rows and probe agents deleted and deletion verified (404 readbacks).

### The reported 404 is not reproducible — and the reporting deployment is currently healthy

`/HealthDetail` on casa shows the reporting agent (`visual-memory-vault`) **registered, with 13 memories, all 13 written within the last 24h** (lastWrite ~1h before the issue was filed). Writes are landing under the agent's own identity.

Because the client logged `status=?` (the diagnosability bug fixed here), the original failure's status was never actually recorded. With every verb × principal × id-shape combination now measured non-404 on casa's current state, the remaining candidates are environmental and transient:

- a window where the flair application was not yet serving on Harper — Harper's catch-all answers **404 for `/Memory/...` routes while `/health` is already 200** (documented in `tests/helpers/boot-harper.mjs`); casa had a deploy + redeploy cycle on 2026-08-20 and a credential rotation in the window, and a later manual `POST /Memory` test would then have succeeded, producing exactly the reported PUT-404/POST-201 split as a **time-confounded A/B**;
- a since-corrected client config (e.g. a `FLAIR_URL` with a path component — every request would 404 at the catch-all).

The verb-vs-principal confound in the original A/B is also worth naming: adk-flair has **no `POST /Memory` call site**, so the successful POST was necessarily issued outside the failing client.

## Why this PR is still the right fix

- Create-verb-for-creates is correct API shape regardless, and is now proven equivalent-or-better on every measured stack (including casa under both admin and agent identity).
- If the failure recurs, `FlairRequestError` makes the log line say `status=NNN` instead of `status=?` — the original incident would have been diagnosable in one glance.
- The 409 fallback preserves idempotent re-ingestion exactly.
- The `Memory.post()` createdAt parity closes a real POST/PUT asymmetry that any POST-writing client would hit.

## Test evidence

| Lane | Baseline (main) | This PR |
|---|---|---|
| adk-flair hermetic (`pytest -m "not live_flair"`) | **102 passed** | **106 passed** (+4) |
| adk-flair live (`pytest -m live_flair`, ephemeral Harper) | 12 passed / 1 skipped (model-gated) | **13 passed / 1 skipped** (+1: real-409 re-ingest fallback e2e) |
| TS unit (`bun test test/unit/`) | — | **4599 pass / 0 fail** |
| TS integration (targeted: durability-write, dedup-supersede, continuity-1257, visibility-scoping + new parity file) | — | **46 pass / 0 fail** |

**Mutation checks (all restored-green after):**
- Revert client to PUT-shaped creates → 2 hermetic tests RED (verb regression + fallback).
- Remove the 409 fallback (naive POST-only) → 1 hermetic test RED (the idempotency trap).
- Revert the `Memory.post()` createdAt parity → 2 TS integration tests RED (`post-create-createdat-parity-1336.test.ts` — the fails-on-main positive control) **and** the #1334 list-pagination live test RED (independent confirmation from a pre-existing test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
