### PR TITLE
security: bump form-data to 4.0.6, retire the two expiring allowlist entries

### DIFF
--- a/.changelog/unreleased/security-form-data-4-0-6.md
+++ b/.changelog/unreleased/security-form-data-4-0-6.md
@@ -1,0 +1,16 @@
+- **`form-data` pinned forward to `^4.0.6`, clearing GHSA-fjxv-7rqg-78g4 (critical
+  — predictable multipart boundary from an unsafe random function) and
+  GHSA-hmw2-7cc7-3qxx (high) — and retiring both audit-gate allowlist entries in
+  the same PR, exactly as their `removeWhen` conditions required.** The vulnerable
+  `form-data@4.0.0` was pinned exactly by `n8n-workflow@1.119.0` under the
+  first-party `@tpsdev-ai/n8n-nodes-flair` workspace package, so the lever is a
+  root `overrides` entry — bun overrides are flat and cannot be scoped to one
+  dependency edge, the same mechanism (and the same caveat) recorded for every
+  prior pin in that block. The flat override also moves `@types/request`'s
+  `form-data` (previously a separate `2.5.6` resolution, itself outside the
+  vulnerable range) onto `4.0.6`, collapsing the duplicate out of `bun.lock`; that
+  edge is a types-only consumer with no runtime path. Both allowlist entries
+  carried `expires: 2026-08-26` — the gate would have started hard-failing the
+  build within days, which is the mechanism working as designed. As with the
+  earlier batch: an override is a forward pin, not a fix — it comes off when
+  n8n-workflow resolves a patched `form-data` on its own.

--- a/.github/audit-allowlist.json
+++ b/.github/audit-allowlist.json
@@ -36,28 +36,6 @@
   },
   "entries": [
     {
-      "ghsa": "GHSA-fjxv-7rqg-78g4",
-      "package": "form-data",
-      "severity": "critical",
-      "class": "remediation-available",
-      "introducedBy": "workspace @tpsdev-ai/n8n-nodes-flair -> n8n-workflow -> form-data",
-      "reason": "Reached by a first-party workspace package, NOT a harper transitive \u2014 the exact case the old blanket warning wrongly claimed did not exist. form-data 4.0.6 fixes it. Held out of this PR only so the gate change stays reviewable on its own and does not carry a lockfile bump; taking the fix is the next action, not a someday.",
-      "added": "2026-07-27",
-      "expires": "2026-08-26",
-      "removeWhen": "The dependency PR raising the resolved form-data to >=4.0.6 merges. Delete this entry in that same PR; the gate fails on a stale entry, so it cannot be left behind."
-    },
-    {
-      "ghsa": "GHSA-hmw2-7cc7-3qxx",
-      "package": "form-data",
-      "severity": "high",
-      "class": "remediation-available",
-      "introducedBy": "workspace @tpsdev-ai/n8n-nodes-flair -> n8n-workflow -> form-data",
-      "reason": "Same dependency edge and same fix as GHSA-fjxv-7rqg-78g4; form-data 4.0.6 clears both advisories in one bump.",
-      "added": "2026-07-27",
-      "expires": "2026-08-26",
-      "removeWhen": "The dependency PR raising the resolved form-data to >=4.0.6 merges \u2014 the same bump that retires GHSA-fjxv-7rqg-78g4."
-    },
-    {
       "ghsa": "GHSA-86vw-mfpg-wwv9",
       "package": "jsonata",
       "severity": "high",

--- a/bun.lock
+++ b/bun.lock
@@ -148,6 +148,7 @@
     "adm-zip": "^0.6.0",
     "brace-expansion": "^5.0.9",
     "fast-uri": "^4.1.2",
+    "form-data": "^4.0.6",
     "hono": "^4.12.34",
     "js-yaml": "^4.3.1",
     "react-native-fs": "npm:empty-npm-package@1.0.0",
@@ -1212,7 +1213,7 @@
 
     "for-each": ["for-each@0.3.5", "", { "dependencies": { "is-callable": "^1.2.7" } }, "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg=="],
 
-    "form-data": ["form-data@4.0.0", "", { "dependencies": { "asynckit": "^0.4.0", "combined-stream": "^1.0.8", "mime-types": "^2.1.12" } }, "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww=="],
+    "form-data": ["form-data@4.0.6", "", { "dependencies": { "asynckit": "^0.4.0", "combined-stream": "^1.0.8", "es-set-tostringtag": "^2.1.0", "hasown": "^2.0.4", "mime-types": "^2.1.35" } }, "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ=="],
 
     "formdata-polyfill": ["formdata-polyfill@4.0.10", "", { "dependencies": { "fetch-blob": "^3.1.2" } }, "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g=="],
 
@@ -2350,8 +2351,6 @@
 
     "@tpsdev-ai/n8n-nodes-flair/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
 
-    "@types/request/form-data": ["form-data@2.5.6", "", { "dependencies": { "asynckit": "^0.4.0", "combined-stream": "^1.0.8", "es-set-tostringtag": "^2.1.0", "hasown": "^2.0.4", "mime-types": "^2.1.35", "safe-buffer": "^5.2.1" } }, "sha512-Ogz/E85h9tlfJzpI6TuFpGcHZFhLrb9Gw8wq9v40CxSCPnv7ahKr6Xgtkn0KYCDQJ8DNn5VoMO8EXr9V5PadyA=="],
-
     "accepts/mime-types": ["mime-types@2.1.35", "", { "dependencies": { "mime-db": "1.52.0" } }, "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw=="],
 
     "alasql/yargs": ["yargs@16.2.2", "", { "dependencies": { "cliui": "^7.0.2", "escalade": "^3.1.1", "get-caller-file": "^2.0.5", "require-directory": "^2.1.1", "string-width": "^4.2.0", "y18n": "^5.0.5", "yargs-parser": "^20.2.2" } }, "sha512-Nt9ZJjXTv5R8MHbqby/wXQ6Gi0Bb3TcYZkR1bzuL4yB2OxWPkXknz513gEF0GoA6tn00UpbPvERW8rzCuWCA6w=="],
@@ -2650,8 +2649,6 @@
 
     "@openclaw/ai/@google/genai/ws": ["ws@8.21.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g=="],
 
-    "@types/request/form-data/mime-types": ["mime-types@2.1.35", "", { "dependencies": { "mime-db": "1.52.0" } }, "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw=="],
-
     "accepts/mime-types/mime-db": ["mime-db@1.52.0", "", {}, "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="],
 
     "alasql/yargs/cliui": ["cliui@7.0.4", "", { "dependencies": { "string-width": "^4.2.0", "strip-ansi": "^6.0.0", "wrap-ansi": "^7.0.0" } }, "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ=="],
@@ -2841,8 +2838,6 @@
     "@modelcontextprotocol/sdk/express/type-is/content-type": ["content-type@2.0.0", "", {}, "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ=="],
 
     "@modelcontextprotocol/sdk/express/type-is/media-typer": ["media-typer@1.1.1", "", {}, "sha512-yz3xRaG20c6/BOzvYoDaGtPmGscs7YivItZEEqe6GbwNfHuxu9YNmvnEkMzKldAGY4/80pRcQRZSEnhquk9XuQ=="],
-
-    "@types/request/form-data/mime-types/mime-db": ["mime-db@1.52.0", "", {}, "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="],
 
     "alasql/yargs/cliui/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 

--- a/package.json
+++ b/package.json
@@ -83,7 +83,8 @@
     "@opentelemetry/core": "^2.8.0",
     "uuid": "^11.1.1",
     "tar": "^7.5.22",
-    "@tootallnate/once": "^2.0.1"
+    "@tootallnate/once": "^2.0.1",
+    "form-data": "^4.0.6"
   },
   "devDependencies": {
     "@playwright/test": "1.59.1",


### PR DESCRIPTION
No issue: allowlist expiry 2026-08-26

## What

Bumps the resolved `form-data` from 4.0.0 to 4.0.6 and deletes the two audit-gate allowlist entries that were holding the advisories open — GHSA-fjxv-7rqg-78g4 (critical) and GHSA-hmw2-7cc7-3qxx (high). Both entries expire 2026-08-26, at which point the gate starts hard-failing every build; this is the dependency PR their `removeWhen` conditions named.

## How

- `n8n-workflow@1.119.0` pins `form-data: 4.0.0` **exactly** (devDep edge of the first-party `@tpsdev-ai/n8n-nodes-flair` workspace package), so a direct bump is not available. The fix is a root `overrides` entry, `"form-data": "^4.0.6"` — the same flat-override mechanism as every existing pin in that block (bun overrides cannot be scoped to one edge; nested overrides are ignored).
- Allowlist entries for the two GHSAs are deleted in this same PR, as their own `removeWhen` text requires — the gate hard-fails stale entries, so leaving them is not an option.
- Lockfile diff is surgical: `form-data` 4.0.0 -> 4.0.6 (picks up its two new deps `es-set-tostringtag`/`hasown`, both already in-tree), plus the flat override collapsing the separate `@types/request/form-data@2.5.6` resolution (types-only consumer, itself NOT in the vulnerable range) onto 4.0.6. No other resolution moves.

## Verification (all local, this branch)

| Check | Before (origin/main 561c7e40) | After |
| --- | --- | --- |
| `bun scripts/audit-gate.mjs --explain` | PASS, 9 allowlisted advisories, 2 warnings: form-data entries expire in 3d | PASS, 7 allowlisted, form-data absent from `bun audit` findings, no warnings |
| `bun test test/unit/ test/*.test.ts` | 4940 pass / 0 fail, 256 files | 4940 pass / 0 fail, 256 files |
| isolated lane (one process per `test/unit-isolated/` file) | 162 pass / 0 fail, 5 files | 162 pass / 0 fail, 5 files |
| `node scripts/changelog-fragments.mjs check` | — | 5 fragments, no stray entries |

The only test-output delta is expect() calls 11409 -> 11399: `test/unit/audit-gate.test.ts` iterates the real allowlist (2 loops, 5 asserts per entry) and there are now 2 fewer entries. Accounted for, not drift.

An override is a forward pin, not a fix — it comes off when `n8n-workflow` resolves a patched `form-data` on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
