### PR TITLE
adk-flair-js: customMetadata store-and-return + subject + listMemories parity (flair#1335)

### DIFF
--- a/.changelog/unreleased/added-1335-adk-js-metadata-parity.md
+++ b/.changelog/unreleased/added-1335-adk-js-metadata-parity.md
@@ -1,0 +1,33 @@
+- **adk-flair-js: `customMetadata` parity with the Python package —
+  store-and-return + caps + `subject` + `listMemories()`** (flair#1335,
+  mirroring flair#1332/#1333 via #1334; design flair#1202). The JS adapter no
+  longer warn-drops `customMetadata`: `addMemory()`/`addEventsToMemory()`
+  serialize it into the client-writable `Memory.metadata` JSON blob —
+  store-and-return only, exactly ADK's contract: the blob is opaque to the
+  server and no key in it has any server-side effect (contract-tested live:
+  `{"visibility":"shared"}` in the blob leaves the record private, with a
+  positive control through the new explicit knobs). Caps reject with an
+  `Error`, never truncate: 64KB serialized, nesting ≤ 16, ≤ 512 keys;
+  non-serializable values skip that key with a warning. `subject` (≤ 512
+  chars, explicit `addMemory` option authoritative over
+  `customMetadata["subject"]`, never auto-extracted) is promoted to the
+  record's indexed `subject` column. `searchMemory()` opts into
+  `/SemanticSearch`'s `includeMetadata` flag and returns `FlairMemoryEntry`
+  objects carrying `customMetadata` (malformed blobs fail soft to `{}` with a
+  warning naming the record id), the record `id`, and the top-level `subject`
+  — surfaced BOTH as `entry.subject` and `customMetadata["subject"]` (column
+  authoritative), since `@google/adk`'s `MemoryEntry` is a plain-object
+  interface; the `customMetadata` channel keeps the return shape identical to
+  the Python package. `author`/`timestamp` now derive from the record's
+  `agentId`/`createdAt` (previously read fields Flair never projects — both
+  were always `undefined`). New `listMemories(appName, userId, {limit≤200,
+  offset})` pages memories newest-first with the full projection, scoped by
+  compound tag + agent identity, both pushed down and re-verified client-side;
+  transport errors propagate (browsing must distinguish "no memories" from
+  "Flair is down"). `addMemory()` also gains the Python package's explicit
+  `durability`/`visibility` options (flair#1234 parity, required by the
+  contract test's positive control) and its deterministic record ids
+  (`entry.id`, else content SHA-256 prefix — re-adds replace, not duplicate).
+  Creates now ride `POST /Memory/` with a 409→`PUT` fallback (flair#1336
+  parity via #1339) — the old PUT-shaped create 404s on hosted Harper Fabric
+  deployments where PUT is update-only.

--- a/packages/adk-flair-js/README.md
+++ b/packages/adk-flair-js/README.md
@@ -95,8 +95,9 @@ All values can also be passed directly to the constructor.
 
 Each ADK app authenticates as **one Flair agent** (its service identity).
 Per-user isolation is enforced by a **compound tag** — `adk:<app_name>:<user_id>`
-— attached to every record and filtered on every search. Colons in `app_name`
-or `user_id` are replaced with underscores to prevent delimiter breakage.
+— attached to every record and filtered on every search. Reserved characters
+(`%`, `:`, `_`) in `app_name` or `user_id` are percent-encoded so distinct
+identities never collide and the `:` delimiter stays unambiguous.
 
 ### Search path
 
@@ -107,7 +108,13 @@ or `user_id` are replaced with underscores to prevent delimiter breakage.
 
 ### Write path
 
-- Deterministic record IDs: `app:user:session:eventId` — re-ingestion upserts
+- Deterministic record IDs: `app:user:session:eventId` — re-ingestion upserts.
+  Direct `addMemory()` writes use the entry's `id` when supplied, else the
+  first 32 hex chars of the content's SHA-256 (re-adds replace, not duplicate)
+- Creates ride `POST /Memory/` (the create verb) with the id in the body; a
+  `409` (record already exists) falls back to `PUT /Memory/{id}`, preserving
+  replace semantics — a PUT-shaped create 404s on Harper deployments where
+  PUT is update-only (flair#1336)
 - Write failures log a structured warning (session id, event count, HTTP status)
 - No-text events are filtered (Vertex parity)
 
@@ -140,8 +147,49 @@ Implements `BaseMemoryService` from `@google/adk`.
 
 #### Extra methods (Vertex parity, not called by ADK)
 
-- **`addEventsToMemory(appName, userId, events, sessionId)`** — incremental per-turn writes
-- **`addMemory(appName, userId, memories)`** — direct memory writes
+- **`addEventsToMemory(appName, userId, events, sessionId, customMetadata?)`** — incremental per-turn writes
+- **`addMemory(appName, userId, memories, customMetadata?, opts?)`** — direct
+  memory writes. `opts`: `{ subject?, durability?, visibility? }`
+- **`listMemories(appName, userId, { limit?, offset? })`** — Flair-specific
+  browsing extension (NOT part of `BaseMemoryService`)
+
+### Custom metadata & subject
+
+`customMetadata` (an arbitrary JSON-serializable object) is stored on every
+record a write call produces, as an opaque blob on the record's `metadata`
+field, and round-trips back on `FlairMemoryEntry.customMetadata` from
+`searchMemory` / `listMemories`.
+
+**Store-and-return only** — ADK's contract: no key inside the blob has ANY
+server-side effect. `{"visibility": "shared"}` in the blob does **not** share
+the memory; use the explicit `opts.visibility` for that. Caps (throw before
+any write; reject, never truncate): 64KB serialized, nesting depth ≤ 16,
+≤ 512 total keys. Non-JSON-serializable values skip that key with a warning.
+
+`subject` is a short human-readable title (≤ 512 chars) promoted to the
+record's top-level indexed `subject` column — supplied via `opts.subject` or
+`customMetadata.subject` (the explicit option is authoritative when both are
+present), never auto-extracted from content. On read it surfaces both as
+`entry.subject` and `customMetadata["subject"]` (the column is authoritative
+over a divergent blob key; the `customMetadata` channel matches the Python
+package's return shape exactly).
+
+Read-path notes: `searchMemory` opts into `/SemanticSearch`'s
+`includeMetadata` projection flag; a malformed stored blob fails soft to `{}`
+with a warning naming the record id (a corrupt blob never takes recall down).
+Returned entries also carry the record `id`, `author` (the writing Flair
+agent id), and `timestamp` (the record's `createdAt`).
+
+### listMemories
+
+Lists an app+user's memories newest-first (`createdAt` DESC) with the full
+projection — no query needed. Scope is the compound tag AND the service's
+agent identity, both pushed down server-side and re-verified client-side.
+`limit` is 1..200 — over-cap **rejects** (never silently clamps); `offset` is
+positional over a point-in-time snapshot, not a live cursor. Unlike
+`searchMemory` (whose swallow-to-empty contract is ADK's), transport and HTTP
+failures **propagate** — a browsing UI must be able to tell "no memories"
+from "Flair is down".
 
 ## License
 

--- a/packages/adk-flair-js/src/index.ts
+++ b/packages/adk-flair-js/src/index.ts
@@ -5,5 +5,13 @@
  */
 
 export { FlairMemoryService } from "./memory_service.js";
+export type {
+  FlairMemoryEntry,
+  FlairSearchMemoryResponse,
+  AddMemoryOptions,
+  ListMemoriesOptions,
+  FlairDurability,
+  FlairVisibility,
+} from "./memory_service.js";
 export { compoundTag, sanitizeTagSegment, desanitizeTagSegment } from "./tag.js";
 export { loadEd25519Key, signRequest } from "./signing.js";

--- a/packages/adk-flair-js/src/memory_service.ts
+++ b/packages/adk-flair-js/src/memory_service.ts
@@ -2,10 +2,14 @@
  * FlairMemoryService — Flair as the memory backend for Google ADK (JS/TS).
  *
  * Implements @google/adk's `BaseMemoryService` interface (2 required methods)
- * plus the Vertex-parity extras (`addEventsToMemory`, `addMemory`).
+ * plus the Vertex-parity extras (`addEventsToMemory`, `addMemory`) and the
+ * Flair-specific `listMemories` browsing extension.
  *
  * Ported from the Python `adk-flair` package. See specs/ADK-FLAIR-ADAPTER.md
- * in the tpsdev-ai/cli repo for the full design.
+ * in the tpsdev-ai/cli repo for the full design; customMetadata/subject/
+ * listMemories semantics mirror the Python package's flair#1332/#1333
+ * implementation (#1334), and the create-verb semantics mirror flair#1336
+ * (#1339).
  */
 
 import type { BaseMemoryService, SearchMemoryRequest, SearchMemoryResponse } from "@google/adk";
@@ -22,6 +26,109 @@ import { compoundTag } from "./tag.js";
 const LOCALHOST_HOSTS = new Set(["localhost", "127.0.0.1", "::1", "[::1]"]);
 const ALLOW_REMOTE_ENV = "FLAIR_ALLOW_REMOTE_URL";
 const DEFAULT_FLAIR_URL = "http://localhost:19926";
+
+// customMetadata caps (flair#1332, Sherlock hard requirements — mirrors the
+// Python package). REJECT, never truncate — a truncated blob silently corrupts
+// the store-and-return round-trip guarantee, which is the entire contract of
+// the field.
+//   - METADATA_MAX_BYTES: serialized JSON size cap. 64KB is generous for
+//     structured attributes (merchant/price/category/media refs) while keeping
+//     a single memory record from becoming a blob store.
+//   - METADATA_MAX_DEPTH / METADATA_MAX_KEYS: cheap structural caps checked
+//     BEFORE serialization (billion-laughs-adjacent guard — a pathologically
+//     nested/wide object is refused without ever attempting to serialize it).
+const METADATA_MAX_BYTES = 64 * 1024;
+const METADATA_MAX_DEPTH = 16;
+const METADATA_MAX_KEYS = 512;
+
+// subject cap (flair#1332): subject is a short human-readable title promoted
+// to the record's top-level indexed `subject` column — never a content field.
+const SUBJECT_MAX_CHARS = 512;
+
+// listMemories page-size hard cap (flair#1333). Reject-with-error (never
+// clamp) — consistent with every other adk-flair validation: a silently
+// clamped limit would make "I asked for 500, why did I get 200" a debugging
+// session instead of an immediate, actionable error.
+const LIST_MEMORIES_MAX_LIMIT = 200;
+
+// Valid enum values for the explicit write knobs (mirrors the Python
+// package's flair#1234/#1238 validation).
+const VALID_DURABILITIES = new Set(["permanent", "persistent", "standard", "ephemeral"]);
+const VALID_VISIBILITIES = new Set(["private", "shared"]);
+
+// ─── Public types ───────────────────────────────────────────────────────────
+
+/** Explicit write knobs accepted by the Memory schema. */
+export type FlairDurability = "permanent" | "persistent" | "standard" | "ephemeral";
+export type FlairVisibility = "private" | "shared";
+
+/**
+ * A MemoryEntry as returned by this service's read paths (searchMemory /
+ * listMemories).
+ *
+ * @google/adk's `MemoryEntry` is a plain-object interface (content, author?,
+ * timestamp?) — unlike the Python package's pydantic model it drops nothing at
+ * runtime, so Flair surfaces its extra fields BOTH top-level and (for
+ * `subject`) inside `customMetadata`:
+ *
+ * - `customMetadata` — the stored metadata blob parsed back to an object
+ *   (fail-soft `{}` + warning on a malformed blob). When the record carries a
+ *   top-level `subject` column it is ALSO surfaced as
+ *   `customMetadata["subject"]` — the column is authoritative over any
+ *   divergent blob key, and this channel keeps the return shape identical to
+ *   the Python package (whose MemoryEntry has no subject attribute, making
+ *   custom_metadata its only subject return channel).
+ * - `subject` — the top-level subject column, surfaced directly as well
+ *   (JS-only convenience; same value as `customMetadata["subject"]`).
+ * - `id` — the Flair record id.
+ */
+export interface FlairMemoryEntry extends MemoryEntry {
+  /** Flair Memory record id. */
+  id?: string;
+  /** Top-level `subject` column value, when the record carries one. */
+  subject?: string;
+  /** Stored customMetadata blob, parsed back. Always present (possibly {}). */
+  customMetadata: Record<string, unknown>;
+}
+
+/** searchMemory response with the Flair-typed entries. */
+export interface FlairSearchMemoryResponse extends SearchMemoryResponse {
+  memories: FlairMemoryEntry[];
+}
+
+/**
+ * Options for `addMemory` (flair#1332 + Python-parity explicit knobs).
+ *
+ * All are trust-anchor opt-ins — never model-selected, never sourced from
+ * `customMetadata` (except `subject`, which `customMetadata.subject` may also
+ * supply; the explicit option is authoritative when both are present).
+ */
+export interface AddMemoryOptions {
+  /**
+   * Short human-readable title promoted to the record's top-level indexed
+   * `subject` column. <= 512 chars (rejects beyond). Never auto-extracted
+   * from content. Authoritative over `customMetadata["subject"]`.
+   */
+  subject?: string;
+  /**
+   * Explicit durability. Omitted → "standard" in the body (unchanged
+   * behaviour). One of permanent | persistent | standard | ephemeral.
+   */
+  durability?: FlairDurability;
+  /**
+   * Explicit visibility. Omitted → no visibility key in the body (server
+   * applies its durability-keyed default). One of private | shared.
+   */
+  visibility?: FlairVisibility;
+}
+
+/** Options for `listMemories` (flair#1333). */
+export interface ListMemoriesOptions {
+  /** Page size, 1..200. Over-cap REJECTS (never silently clamps). Default 50. */
+  limit?: number;
+  /** Number of newest records to skip (>= 0). Positional, not a live cursor. */
+  offset?: number;
+}
 
 // ─── Helpers ────────────────────────────────────────────────────────────────
 
@@ -58,6 +165,157 @@ function extractText(content: Content | undefined): string {
     .join(" ");
 }
 
+function isPlainObjectLike(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+// ─── customMetadata / subject (flair#1332 — mirrors the Python package) ─────
+
+/**
+ * Structural caps on customMetadata, checked BEFORE serialization.
+ *
+ * Rejects nesting deeper than METADATA_MAX_DEPTH levels or more than
+ * METADATA_MAX_KEYS total object keys (counted across every level) with an
+ * Error. Iterative traversal — no recursion, so adversarial nesting can't
+ * blow the stack; a self-referencing structure terminates via the depth cap
+ * (each revisit is pushed one level deeper), so a circular blob is rejected
+ * here and never reaches JSON.stringify.
+ */
+function validateMetadataShape(customMetadata: Record<string, unknown>): void {
+  const stack: Array<[unknown, number]> = [[customMetadata, 1]];
+  let keyCount = 0;
+  while (stack.length > 0) {
+    const [node, depth] = stack.pop()!;
+    if (depth > METADATA_MAX_DEPTH) {
+      throw new Error(
+        `customMetadata nesting exceeds ${METADATA_MAX_DEPTH} levels — ` +
+        "flatten the structure, or store a reference to the data instead " +
+        "of embedding it"
+      );
+    }
+    let children: Iterable<unknown>;
+    if (Array.isArray(node)) {
+      children = node;
+    } else if (isPlainObjectLike(node)) {
+      const keys = Object.keys(node);
+      keyCount += keys.length;
+      if (keyCount > METADATA_MAX_KEYS) {
+        throw new Error(
+          `customMetadata carries more than ${METADATA_MAX_KEYS} keys ` +
+          "in total — split the data across memories, or store a " +
+          "reference to it instead"
+        );
+      }
+      children = keys.map((k) => node[k]);
+    } else {
+      continue;
+    }
+    for (const child of children) {
+      if (Array.isArray(child) || isPlainObjectLike(child)) {
+        stack.push([child, depth + 1]);
+      }
+    }
+  }
+}
+
+/**
+ * Serialize customMetadata to the JSON string stored in Memory.metadata.
+ *
+ * Store-and-return contract (flair#1202): the blob is opaque to the server —
+ * stored verbatim, returned verbatim, no key in it influences any server
+ * decision.
+ *
+ * - Structural caps (depth/key-count) and the serialized 64KB cap REJECT
+ *   with an Error — never truncate (truncation corrupts the round-trip
+ *   guarantee; Sherlock hard requirement, mirrored from the Python package).
+ * - A non-serializable VALUE skips that key with a warning naming the
+ *   session key — one bad value must not discard the caller's whole blob.
+ *   (In JS "non-serializable" means JSON.stringify yields undefined —
+ *   functions, symbols, bare undefined — or throws: BigInt. Object keys are
+ *   always strings in JS, so the Python non-string-key skip has no analogue.)
+ *
+ * Returns null when there is nothing to store (no metadata, or every key
+ * was skipped).
+ */
+function serializeCustomMetadata(
+  customMetadata: Record<string, unknown> | undefined,
+  contextKey: string,
+): string | null {
+  if (!customMetadata || Object.keys(customMetadata).length === 0) return null;
+
+  validateMetadataShape(customMetadata);
+
+  const clean: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(customMetadata)) {
+    let probe: string | undefined;
+    try {
+      probe = JSON.stringify(value);
+    } catch {
+      probe = undefined;
+    }
+    if (probe === undefined) {
+      console.warn(
+        `[adk-flair] customMetadata key "${key}" skipped — value is not ` +
+        `JSON-serializable (session=${contextKey})`
+      );
+      continue;
+    }
+    clean[key] = value;
+  }
+
+  if (Object.keys(clean).length === 0) return null;
+
+  const serialized = JSON.stringify(clean);
+  const size = Buffer.byteLength(serialized, "utf8");
+  if (size > METADATA_MAX_BYTES) {
+    throw new Error(
+      `customMetadata serializes to ${size} bytes, over the ` +
+      `${METADATA_MAX_BYTES}-byte cap — store large payloads elsewhere ` +
+      "and keep a reference here. Rejected rather than truncated: a " +
+      "truncated blob would silently corrupt the store-and-return " +
+      "round-trip guarantee."
+    );
+  }
+  return serialized;
+}
+
+/**
+ * Resolve the top-level `subject` column value (flair#1332).
+ *
+ * Precedence: an explicit subject option is authoritative over
+ * customMetadata["subject"] when both are supplied. NEVER auto-extracted
+ * from content. Rejects non-string or over-cap (512 chars) values with an
+ * Error — subject is a short human-readable title promoted to an indexed
+ * column, not a content field. Returns null when neither source supplies
+ * one (empty strings resolve to null — nothing to promote).
+ */
+function resolveSubject(
+  explicitSubject: string | undefined,
+  customMetadata: Record<string, unknown> | undefined,
+): string | null {
+  let subject: unknown = explicitSubject;
+  let source = "subject option";
+  if ((subject === undefined || subject === null) && customMetadata !== undefined) {
+    subject = customMetadata["subject"];
+    source = 'customMetadata["subject"]';
+  }
+  if (subject === undefined || subject === null) return null;
+  if (typeof subject !== "string") {
+    throw new Error(
+      `${source} must be a string (got: ${typeof subject}) — ` +
+      "subject is promoted to the record's top-level subject column"
+    );
+  }
+  if (subject.length > SUBJECT_MAX_CHARS) {
+    throw new Error(
+      `${source} is ${subject.length} characters, over the ` +
+      `${SUBJECT_MAX_CHARS}-char cap — subject is a short ` +
+      "human-readable title; put longer text in content or customMetadata"
+    );
+  }
+  return subject || null;
+}
+
 // ─── FlairMemoryService ─────────────────────────────────────────────────────
 
 export class FlairMemoryService implements BaseMemoryService {
@@ -65,8 +323,6 @@ export class FlairMemoryService implements BaseMemoryService {
   private readonly _agentId: string;
   private readonly _privateKey: crypto.KeyObject;
   private readonly _timeoutMs: number;
-  /** Per-session state for custom_metadata warn-once (Python parity). */
-  private _warnedSessions: Set<string> = new Set();
 
   /**
    * @param url - Flair HTTP URL (default: FLAIR_URL env or http://localhost:19926)
@@ -155,7 +411,7 @@ export class FlairMemoryService implements BaseMemoryService {
 
   async searchMemory(
     request: SearchMemoryRequest,
-  ): Promise<SearchMemoryResponse> {
+  ): Promise<FlairSearchMemoryResponse> {
     const { appName, userId, query } = request;
 
     // Mandatory userId: empty ⇒ return empty, never search unscoped
@@ -170,6 +426,12 @@ export class FlairMemoryService implements BaseMemoryService {
       q: query,
       tag,
       limit: 20,
+      // flair#1332: opt into the `metadata` blob in each hit.
+      // /SemanticSearch's default projection deliberately omits it (other
+      // consumers must not pay result-size for a blob they never read);
+      // this flag widens the projection for THIS request only. `subject`
+      // is in the default projection.
+      includeMetadata: true,
     });
 
     const start = Date.now();
@@ -209,32 +471,21 @@ export class FlairMemoryService implements BaseMemoryService {
         }
 
         const data = (await resp.json()) as {
-          results?: Array<{
-            content?: string;
-            author?: string;
-            timestamp?: string;
-            tags?: string[];
-          }>;
+          results?: Array<Record<string, unknown>>;
         };
 
-        const results = data.results ?? [];
-        const memories: MemoryEntry[] = [];
+        const results = Array.isArray(data.results) ? data.results : [];
+        const memories: FlairMemoryEntry[] = [];
 
         for (const hit of results) {
-          // Per-hit tag re-verification: drop hits missing the compound tag
-          const hitTags = hit.tags ?? [];
+          if (!isPlainObjectLike(hit)) continue;
+
+          // Per-hit tag re-verification: drop hits missing the compound tag.
+          // Client-side analogue of Flair's isAllowed defense-in-depth.
+          const hitTags = Array.isArray(hit["tags"]) ? (hit["tags"] as unknown[]) : [];
           if (!hitTags.includes(tag)) continue;
 
-          const content: Content = {
-            role: "user",
-            parts: [{ text: hit.content ?? "" }],
-          } as Content;
-
-          memories.push({
-            content,
-            author: hit.author,
-            timestamp: hit.timestamp,
-          });
+          memories.push(this._hitToMemoryEntry(hit));
         }
 
         return { memories };
@@ -258,8 +509,14 @@ export class FlairMemoryService implements BaseMemoryService {
    * Add events to memory incrementally (the quickstart's after_agent_callback path).
    * Not called by ADK — use in after_agent_callback or directly.
    *
-   * @param customMetadata - If provided, logs a once-per-session warning that
-   *   custom_metadata is not supported by adk-flair (Python parity).
+   * customMetadata (flair#1332) is stored on every record this call writes,
+   * as an opaque JSON blob on the Memory record's `metadata` field, and
+   * round-trips back on `FlairMemoryEntry.customMetadata` from searchMemory /
+   * listMemories. Store-and-return only — no key in it has any server-side
+   * effect. Caps (Error before any write): 64KB serialized, nesting depth
+   * <= 16, <= 512 total keys. customMetadata["subject"] (a string) is
+   * additionally promoted to the record's top-level `subject` column
+   * (<= 512 chars).
    */
   async addEventsToMemory(
     appName: string,
@@ -268,24 +525,20 @@ export class FlairMemoryService implements BaseMemoryService {
     sessionId: string,
     customMetadata?: Record<string, unknown>,
   ): Promise<void> {
-    if (!events || events.length === 0) return;
-
-    // custom_metadata warn-once per session (Python parity)
-    if (customMetadata) {
-      const sessionKey = `${appName}:${userId}:${sessionId}`;
-      if (!this._warnedSessions.has(sessionKey)) {
-        this._warnedSessions.add(sessionKey);
-        console.warn(
-          "adk-flair: custom_metadata ignored — adk-flair does not " +
-          `support custom_metadata keys (session=${sessionKey})`
-        );
-      }
-    }
-
     const tag = compoundTag(appName, userId);
-    let written = 0;
 
-    for (const event of events) {
+    // customMetadata → opaque JSON blob + optional promoted subject
+    // (flair#1332). Validated/serialized ONCE, before any write — a cap
+    // violation throws here and zero events are written, never a partial
+    // batch with silently-dropped metadata.
+    const sessionKey = `${appName}:${userId}:${sessionId}`;
+    const metadataJson = serializeCustomMetadata(customMetadata, sessionKey);
+    const subjectValue = resolveSubject(undefined, customMetadata);
+
+    let written = 0;
+    const eventList = events ?? [];
+
+    for (const event of eventList) {
       const text = extractText(event.content);
       if (!text) continue;
 
@@ -299,6 +552,8 @@ export class FlairMemoryService implements BaseMemoryService {
         tags: [tag],
         createdAt: epochMsToIso(event.timestamp),
       };
+      if (metadataJson !== null) body["metadata"] = metadataJson;
+      if (subjectValue !== null) body["subject"] = subjectValue;
 
       try {
         await this._writeRecord(recordId, body);
@@ -307,7 +562,7 @@ export class FlairMemoryService implements BaseMemoryService {
         const msg = err instanceof Error ? err.message : String(err);
         console.warn(
           `[adk-flair] write failed for session ${sessionId} event ${event.id} ` +
-          `(written=${written}/${events.length}): ${msg}`
+          `(written=${written}/${eventList.length}): ${msg}`
         );
       }
     }
@@ -319,48 +574,86 @@ export class FlairMemoryService implements BaseMemoryService {
    * Add memory entries directly.
    * Not called by ADK — use for direct memory writes.
    *
-   * @param customMetadata - If provided, logs a once-per-session warning that
-   *   custom_metadata is not supported by adk-flair (Python parity).
+   * customMetadata (flair#1332) is stored on every record this call writes,
+   * as an opaque JSON blob on the Memory record's `metadata` field, and
+   * round-trips back on `FlairMemoryEntry.customMetadata` from searchMemory /
+   * listMemories. Store-and-return only (the ADK contract, flair#1202): no
+   * key inside the blob has ANY server-side effect — {"visibility":"shared"}
+   * in here does not share the memory (use the explicit `visibility` option
+   * for that). Caps (Error before any write; reject, never truncate): 64KB
+   * serialized, nesting depth <= 16, <= 512 total keys. Non-JSON-serializable
+   * values skip that key with a warning.
+   *
+   * opts.subject (flair#1332, Flair-specific extension): short human-readable
+   * title promoted to the record's top-level indexed `subject` column.
+   * Sourced from this option or customMetadata["subject"]; the explicit
+   * option is authoritative when both are present. <= 512 chars (Error
+   * beyond). Never auto-extracted from content.
+   *
+   * opts.durability / opts.visibility: trust-anchor opt-ins (Python-parity
+   * explicit knobs), validated against the schema enums. Omitted durability →
+   * "standard"; omitted visibility → no key in the body (server default).
+   *
+   * Record ids mirror the Python package: `entry.id` when the caller supplies
+   * one (FlairMemoryEntry input), else the first 32 hex chars of the content's
+   * SHA-256 — deterministic, so re-adding identical content replaces rather
+   * than duplicates.
    */
   async addMemory(
     appName: string,
     userId: string,
-    memories: MemoryEntry[],
+    memories: Array<MemoryEntry & { id?: string }>,
     customMetadata?: Record<string, unknown>,
+    opts?: AddMemoryOptions,
   ): Promise<void> {
-    if (!memories || memories.length === 0) return;
+    const tag = compoundTag(appName, userId);
 
-    // custom_metadata warn-once (Python parity)
-    if (customMetadata) {
-      const sessionKey = `${appName}:${userId}:direct`;
-      if (!this._warnedSessions.has(sessionKey)) {
-        this._warnedSessions.add(sessionKey);
-        console.warn(
-          "adk-flair: custom_metadata ignored — adk-flair does not " +
-          "support custom_metadata keys"
-        );
-      }
+    // Validate explicit durability / visibility (mirrors Python flair#1238).
+    if (opts?.durability !== undefined && !VALID_DURABILITIES.has(opts.durability)) {
+      throw new Error(
+        `durability must be one of ${[...VALID_DURABILITIES].sort().join(", ")} ` +
+        `(got: ${JSON.stringify(opts.durability)})`
+      );
+    }
+    if (opts?.visibility !== undefined && !VALID_VISIBILITIES.has(opts.visibility)) {
+      throw new Error(
+        `visibility must be one of ${[...VALID_VISIBILITIES].sort().join(", ")} ` +
+        `(got: ${JSON.stringify(opts.visibility)})`
+      );
     }
 
-    const tag = compoundTag(appName, userId);
-    let written = 0;
+    // customMetadata → opaque JSON blob + optional promoted subject
+    // (flair#1332). Validated/serialized ONCE, before any write — a cap
+    // violation throws here and zero records are written.
+    const metadataJson = serializeCustomMetadata(
+      customMetadata, `${appName}:${userId}:direct`,
+    );
+    const subjectValue = resolveSubject(opts?.subject, customMetadata);
 
-    for (const mem of memories) {
+    let written = 0;
+    const memoryList = memories ?? [];
+
+    for (const mem of memoryList) {
       const text = extractText(mem.content);
       if (!text) continue;
 
-      const recordId = `${appName}:${userId}:direct:${crypto.randomUUID()}`;
+      const recordId =
+        mem.id ??
+        crypto.createHash("sha256").update(text, "utf8").digest("hex").slice(0, 32);
       const body: Record<string, unknown> = {
         id: recordId,
         agentId: this._agentId,
         content: text,
         type: "session",
-        durability: "standard",
+        durability: opts?.durability ?? "standard",
         tags: [tag],
-        createdAt: mem.timestamp ?? new Date().toISOString(),
+        createdAt: mem.timestamp || new Date().toISOString(),
       };
+      if (opts?.visibility !== undefined) body["visibility"] = opts.visibility;
+      if (metadataJson !== null) body["metadata"] = metadataJson;
+      if (subjectValue !== null) body["subject"] = subjectValue;
       if (mem.author) {
-        body.author = mem.author;
+        body["author"] = mem.author;
       }
 
       try {
@@ -370,7 +663,7 @@ export class FlairMemoryService implements BaseMemoryService {
         const msg = err instanceof Error ? err.message : String(err);
         console.warn(
           `[adk-flair] direct memory write failed for id ${recordId} ` +
-          `(written=${written}/${memories.length}): ${msg}`
+          `(written=${written}/${memoryList.length}): ${msg}`
         );
       }
     }
@@ -378,33 +671,209 @@ export class FlairMemoryService implements BaseMemoryService {
     if (written === 0) return;
   }
 
-  // ─── Internal ─────────────────────────────────────────────────────────────
+  // ─── listMemories (flair#1333 — Flair-specific extension) ─────────────────
 
   /**
-   * Write a single record to Flair via PUT /Memory/{recordId}.
+   * List recent memories for an app+user, newest first.
    *
-   * The deterministic record ID is embedded in the URL path so the server
-   * can perform an idempotent upsert. The signing payload covers the full
-   * path (METHOD:pathname), so the path MUST include the record ID.
+   * Flair-specific extension — NOT part of ADK's BaseMemoryService (which
+   * specifies only searchMemory). Useful for memory review UIs, dashboards,
+   * and agent contextual browsing where there is no query to search with.
+   *
+   * Scope: the same compound tag (adk:<app>:<user>) searchMemory uses, AND
+   * agentId === this service's agent identity — both pushed down as
+   * server-side query conditions and re-verified client-side on every
+   * returned row (defense in depth).
+   *
+   * Pagination: `offset` is POSITIONAL over a point-in-time snapshot ordered
+   * by createdAt descending — not a live cursor. Memories written between
+   * two pages shift positions, so a record can appear twice or be skipped
+   * across page boundaries. For a consistent view, take one page, or dedupe
+   * by id across pages.
+   *
+   * Throws on invalid arguments, and — unlike searchMemory (whose
+   * empty-on-error contract is ADK's) — PROPAGATES transport and HTTP
+   * failures: a browsing UI must be able to tell "no memories" from
+   * "Flair is down".
    */
-  private async _writeRecord(
-    recordId: string,
-    body: Record<string, unknown>,
-  ): Promise<void> {
-    const path = `/Memory/${recordId}`;
-    const authHeader = signRequest(
-      this._privateKey,
-      this._agentId,
-      "PUT",
-      path,
-    );
+  async listMemories(
+    appName: string,
+    userId: string,
+    opts?: ListMemoriesOptions,
+  ): Promise<FlairMemoryEntry[]> {
+    const limit = opts?.limit ?? 50;
+    const offset = opts?.offset ?? 0;
 
+    if (!appName) {
+      throw new Error("appName is required");
+    }
+    if (!userId) {
+      throw new Error("userId is required — listMemories never lists unscoped");
+    }
+    if (typeof limit !== "number" || !Number.isInteger(limit) || limit < 1) {
+      throw new Error(`limit must be a positive integer (got: ${JSON.stringify(limit)})`);
+    }
+    if (limit > LIST_MEMORIES_MAX_LIMIT) {
+      throw new Error(
+        `limit ${limit} exceeds the hard cap of ${LIST_MEMORIES_MAX_LIMIT} ` +
+        "— page with offset instead"
+      );
+    }
+    if (typeof offset !== "number" || !Number.isInteger(offset) || offset < 0) {
+      throw new Error(`offset must be a non-negative integer (got: ${JSON.stringify(offset)})`);
+    }
+
+    const tag = compoundTag(appName, userId);
+
+    // Harper REST collection query (signed like every other request — the
+    // signature covers path+query). The tag value is percent-encoded
+    // WHOLESALE: compound tags legitimately contain literal %XX escapes from
+    // sanitizeTagSegment, which must survive the server's URL decode.
+    // limit(start,end) is Harper's offset window: start=offset,
+    // end=offset+limit.
+    const path =
+      `/Memory/?tags=${encodeURIComponent(tag)}` +
+      `&agentId=${encodeURIComponent(this._agentId)}` +
+      `&select(id,agentId,content,metadata,subject,tags,createdAt)` +
+      `&sort(-createdAt)` +
+      `&limit(${offset},${offset + limit})`;
+
+    const authHeader = signRequest(this._privateKey, this._agentId, "GET", path);
     const controller = new AbortController();
     const timeoutId = setTimeout(() => controller.abort(), this._timeoutMs);
 
+    let rows: unknown;
     try {
       const resp = await fetch(`${this._url}${path}`, {
-        method: "PUT",
+        method: "GET",
+        headers: { "Authorization": authHeader },
+        signal: controller.signal,
+      });
+      if (!resp.ok) {
+        const text = await resp.text().catch(() => "");
+        throw new Error(
+          `Flair GET /Memory/ → HTTP ${resp.status}` +
+          `${text ? `: ${text.slice(0, 200)}` : ""}`
+        );
+      }
+      rows = await resp.json();
+    } finally {
+      clearTimeout(timeoutId);
+    }
+
+    if (!Array.isArray(rows)) {
+      return [];
+    }
+
+    const entries: FlairMemoryEntry[] = [];
+    for (const row of rows) {
+      if (!isPlainObjectLike(row)) continue;
+      // Defense in depth: re-verify both scope conditions client-side,
+      // mirroring searchMemory's tag re-verification.
+      const rowTags = Array.isArray(row["tags"]) ? (row["tags"] as unknown[]) : [];
+      if (!rowTags.includes(tag)) continue;
+      if (row["agentId"] !== this._agentId) continue;
+      entries.push(this._hitToMemoryEntry(row));
+    }
+    return entries;
+  }
+
+  // ─── Hit → MemoryEntry mapping ─────────────────────────────────────────────
+
+  /**
+   * Map a Flair Memory record/hit onto a FlairMemoryEntry.
+   *
+   * author derives from the record's agentId — the writing Flair agent
+   * (flair#1332 incidental fix, mirrored: records carry no "author" field,
+   * so reading hit.author was always undefined). timestamp derives from the
+   * record's createdAt for the same reason.
+   */
+  private _hitToMemoryEntry(hit: Record<string, unknown>): FlairMemoryEntry {
+    const contentText = typeof hit["content"] === "string" ? hit["content"] : "";
+    const customMetadata = this._hitCustomMetadata(hit);
+    const subject = hit["subject"];
+
+    const entry: FlairMemoryEntry = {
+      content: {
+        role: "model",
+        parts: [{ text: contentText }],
+      } as Content,
+      customMetadata,
+    };
+    if (typeof hit["id"] === "string") entry.id = hit["id"];
+    if (typeof hit["agentId"] === "string") entry.author = hit["agentId"];
+    if (typeof hit["createdAt"] === "string") entry.timestamp = hit["createdAt"];
+    if (typeof subject === "string" && subject) entry.subject = subject;
+    return entry;
+  }
+
+  /**
+   * Rebuild FlairMemoryEntry.customMetadata from a record's stored fields.
+   *
+   * - `metadata` (the opaque JSON blob) parses back to an object. FAIL-SOFT:
+   *   malformed JSON (or JSON that isn't an object) yields {} plus a warning
+   *   naming the record id — a corrupt blob on one record must never take
+   *   the whole read path down.
+   * - A top-level `subject` column is surfaced as customMetadata["subject"].
+   *   The COLUMN is authoritative (flair#1332 ruling): when the blob carries
+   *   a divergent "subject" key, the column value overwrites it in the
+   *   returned object. This keeps the customMetadata return shape identical
+   *   to the Python package — a subject written via the explicit option
+   *   (never in the blob) still round-trips through customMetadata.
+   */
+  private _hitCustomMetadata(hit: Record<string, unknown>): Record<string, unknown> {
+    let parsed: Record<string, unknown> = {};
+    const raw = hit["metadata"];
+    if (raw) {
+      let loaded: unknown;
+      let malformed = false;
+      if (typeof raw === "string") {
+        try {
+          loaded = JSON.parse(raw);
+        } catch {
+          malformed = true;
+        }
+      } else {
+        malformed = true;
+      }
+      if (malformed) {
+        console.warn(
+          `[adk-flair] malformed metadata JSON on record ${String(hit["id"])} — ` +
+          "returning empty customMetadata for it"
+        );
+      } else if (isPlainObjectLike(loaded)) {
+        parsed = loaded;
+      } else {
+        console.warn(
+          `[adk-flair] metadata on record ${String(hit["id"])} is JSON but not ` +
+          "an object — returning empty customMetadata for it"
+        );
+      }
+    }
+    const subject = hit["subject"];
+    if (typeof subject === "string" && subject) {
+      parsed["subject"] = subject;
+    }
+    return parsed;
+  }
+
+  // ─── Internal ─────────────────────────────────────────────────────────────
+
+  /**
+   * Send one signed JSON-bodied request. The signing payload covers the full
+   * path (METHOD:pathname), so the path passed here is the one signed.
+   */
+  private async _sendJson(
+    method: string,
+    path: string,
+    body: Record<string, unknown>,
+  ): Promise<Response> {
+    const authHeader = signRequest(this._privateKey, this._agentId, method, path);
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), this._timeoutMs);
+    try {
+      return await fetch(`${this._url}${path}`, {
+        method,
         headers: {
           "Authorization": authHeader,
           "Content-Type": "application/json",
@@ -412,15 +881,45 @@ export class FlairMemoryService implements BaseMemoryService {
         body: JSON.stringify(body),
         signal: controller.signal,
       });
-
-      if (!resp.ok) {
-        const text = await resp.text().catch(() => "");
-        throw new Error(
-          `HTTP ${resp.status}${text ? `: ${text.slice(0, 200)}` : ""}`
-        );
-      }
     } finally {
       clearTimeout(timeoutId);
+    }
+  }
+
+  /**
+   * Create-or-replace one Memory record.
+   *
+   * Creates via `POST /Memory/` — Harper's collection create verb — with the
+   * id in the body. The previous shape, `PUT /Memory/{id}`, is update-only on
+   * some Harper deployments and 404s when the record does not exist yet
+   * (flair#1336, observed on hosted Harper Fabric; not reproducible on stock
+   * Harper 5.2.x, where PUT upserts). Mirrors the Python package's #1339 fix.
+   *
+   * A 409 from POST means the record already exists — re-ingestion of a
+   * deterministic id (addSessionToMemory re-saves a growing session's earlier
+   * events every time) or a caller-supplied id being rewritten. Fall back to
+   * `PUT /Memory/{id}` for exactly that case, preserving the pre-#1336
+   * replace/refresh semantics for existing rows. Any other error propagates
+   * unchanged (the write-path warning logs carry the real HTTP status).
+   */
+  private async _writeRecord(
+    recordId: string,
+    body: Record<string, unknown>,
+  ): Promise<void> {
+    const resp = await this._sendJson("POST", "/Memory/", body);
+    if (resp.ok) return;
+    if (resp.status !== 409) {
+      const text = await resp.text().catch(() => "");
+      throw new Error(
+        `HTTP ${resp.status}${text ? `: ${text.slice(0, 200)}` : ""}`
+      );
+    }
+    const putResp = await this._sendJson("PUT", `/Memory/${recordId}`, body);
+    if (!putResp.ok) {
+      const text = await putResp.text().catch(() => "");
+      throw new Error(
+        `HTTP ${putResp.status}${text ? `: ${text.slice(0, 200)}` : ""}`
+      );
     }
   }
 

--- a/packages/adk-flair-js/test/integration/metadata_and_list.test.ts
+++ b/packages/adk-flair-js/test/integration/metadata_and_list.test.ts
@@ -1,0 +1,226 @@
+/**
+ * Live tests for flair#1332/#1333 parity (flair#1335) — the JS port of
+ * packages/adk-flair/tests/test_metadata_and_list.py's live tier, against a
+ * real ephemeral Harper (via the shared getLiveFlair helper):
+ *
+ *  - the nested metadata round-trip,
+ *  - the STORE-AND-RETURN CONTRACT test (Sherlock hard requirement: metadata
+ *    blob keys named after server knobs have ZERO effect on the record's
+ *    actual visibility/durability), with a positive control proving the
+ *    instrument fires,
+ *  - subject persistence + precedence,
+ *  - listMemories pagination/scope against real query pushdown.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from "bun:test";
+import { FlairMemoryService, signRequest } from "../../src/index.js";
+import type { FlairMemoryEntry } from "../../src/index.js";
+import { getLiveFlair, type LiveFlairConfig } from "../helpers/live-flair.js";
+import type { MemoryEntry } from "@google/adk";
+import type { Content } from "@google/genai";
+import * as crypto from "node:crypto";
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function entry(text: string, id?: string, timestamp?: string): MemoryEntry & { id?: string } {
+  return {
+    id,
+    content: { role: "user", parts: [{ text }] } as Content,
+    timestamp,
+  };
+}
+
+/**
+ * Fetch one Memory record by id via signed REST — ground truth for the
+ * stored row, independent of the adapter's read path.
+ */
+async function restGetMemory(
+  config: LiveFlairConfig,
+  recordId: string,
+): Promise<Record<string, unknown>> {
+  const path = `/Memory/${recordId}`;
+  const auth = signRequest(config.privateKey, config.agentId, "GET", path);
+  const resp = await fetch(`${config.httpUrl}${path}`, {
+    headers: { Authorization: auth },
+  });
+  if (resp.status >= 400) {
+    throw new Error(`GET ${path} → ${resp.status} ${(await resp.text().catch(() => "")).slice(0, 200)}`);
+  }
+  return (await resp.json()) as Record<string, unknown>;
+}
+
+function liveService(config: LiveFlairConfig): FlairMemoryService {
+  return new FlairMemoryService({
+    url: config.httpUrl,
+    agentId: config.agentId,
+    keyfile: config.keyfilePath,
+    timeoutMs: 10_000, // ephemeral Harper under test load — not a latency test
+  });
+}
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+describe("customMetadata + subject + listMemories (live)", () => {
+  let config: LiveFlairConfig | null = null;
+  let service: FlairMemoryService | null = null;
+
+  beforeAll(async () => {
+    config = await getLiveFlair();
+    if (!config) {
+      console.log("SKIP: no live Flair available — skipping metadata/list integration tests");
+      return;
+    }
+    service = liveService(config);
+  }, { timeout: 200_000 });
+
+  afterAll(async () => {
+    if (service) await service.close();
+    if (config?.cleanup) await config.cleanup();
+  }, { timeout: 15_000 });
+
+  it("nested metadata round-trips through searchMemory", async () => {
+    if (!config || !service) {
+      console.log("SKIP: no live Flair configured");
+      return;
+    }
+
+    const app = "meta-rt-js";
+    const user = `u-${crypto.randomUUID().slice(0, 8)}`;
+    const marker = `rt-marker-${crypto.randomUUID().slice(0, 8)}`;
+    const nested = {
+      merchant: "acme", price: { amount: 12.5, currency: "EUR" },
+      media: ["s3://a.jpg", "s3://b.jpg"],
+      flags: { verified: true, score: 0.93, note: null },
+    };
+
+    await service.addMemory(app, user, [entry(`receipt ${marker}`)], nested);
+
+    const result = await service.searchMemory({
+      appName: app, userId: user, query: marker,
+    });
+    expect(result.memories.length).toBeGreaterThan(0);
+    const hit = result.memories.find((m) => {
+      const text = (m.content?.parts?.[0] as { text?: string })?.text ?? "";
+      return text.includes(marker);
+    }) as FlairMemoryEntry | undefined;
+    expect(hit).toBeDefined();
+    expect(hit!.customMetadata).toEqual(nested);
+  }, { timeout: 60_000 });
+
+  it("metadata is store-and-return ONLY (contract test with positive control)", async () => {
+    // SHERLOCK CONTRACT TEST: metadata blob keys that IMPERSONATE server
+    // knobs (visibility/durability/residency) have ZERO effect on the
+    // record's actual fields. Includes a positive control proving the
+    // instrument fires: the EXPLICIT options DO change the stored fields.
+    if (!config || !service) {
+      console.log("SKIP: no live Flair configured");
+      return;
+    }
+
+    const app = "meta-contract-js";
+    const user = `u-${crypto.randomUUID().slice(0, 8)}`;
+    const smuggle = {
+      visibility: "shared", durability: "permanent", residency: "anywhere",
+    };
+
+    // ── The contract half: blob keys must be inert ────────────────────────
+    const inertId = `contract-${crypto.randomUUID().slice(0, 8)}`;
+    await service.addMemory(
+      app, user, [entry("contract probe", inertId)], smuggle,
+      // NO explicit durability/visibility → server defaults apply.
+    );
+    const row = await restGetMemory(config, inertId);
+    // blob "durability" key must not leak into the record
+    expect(row["durability"]).toBe("standard");
+    // blob "visibility" key must not leak into the record
+    expect(row["visibility"]).toBe("private");
+    // blob key must not materialize as a column
+    expect(row).not.toContainKey("residency");
+    // And the blob itself is stored verbatim (store-and-return).
+    expect(JSON.parse(row["metadata"] as string)).toEqual(smuggle);
+
+    // ── Positive control: the explicit channel DOES move the fields ───────
+    // Without this, the inert assertions above prove nothing — the
+    // instrument must be shown to detect a moved field.
+    const ctlId = `control-${crypto.randomUUID().slice(0, 8)}`;
+    await service.addMemory(
+      app, user, [entry("positive control", ctlId)], smuggle,
+      { durability: "persistent", visibility: "shared" },
+    );
+    const ctl = await restGetMemory(config, ctlId);
+    expect(ctl["durability"]).toBe("persistent");
+    expect(ctl["visibility"]).toBe("shared");
+  }, { timeout: 60_000 });
+
+  it("subject persists from both sources with explicit-option precedence", async () => {
+    if (!config || !service) {
+      console.log("SKIP: no live Flair configured");
+      return;
+    }
+
+    const app = "subj-rt-js";
+    const user = `u-${crypto.randomUUID().slice(0, 8)}`;
+    const paramId = `subj-param-${crypto.randomUUID().slice(0, 8)}`;
+    const blobId = `subj-blob-${crypto.randomUUID().slice(0, 8)}`;
+    const bothId = `subj-both-${crypto.randomUUID().slice(0, 8)}`;
+
+    await service.addMemory(app, user, [entry("via param", paramId)], undefined, {
+      subject: "Param Subject",
+    });
+    await service.addMemory(app, user, [entry("via blob", blobId)], {
+      subject: "Blob Subject",
+    });
+    await service.addMemory(app, user, [entry("via both", bothId)], {
+      subject: "Blob Says",
+    }, { subject: "Param Wins" });
+
+    expect((await restGetMemory(config, paramId))["subject"]).toBe("Param Subject");
+    expect((await restGetMemory(config, blobId))["subject"]).toBe("Blob Subject");
+    expect((await restGetMemory(config, bothId))["subject"]).toBe("Param Wins");
+  }, { timeout: 60_000 });
+
+  it("listMemories: pagination, scope, and createdAt DESC order", async () => {
+    if (!config || !service) {
+      console.log("SKIP: no live Flair configured");
+      return;
+    }
+
+    const app = "list-live-js";
+    const user = `u-${crypto.randomUUID().slice(0, 8)}`;
+    const otherUser = `other-${crypto.randomUUID().slice(0, 8)}`;
+
+    // Three records with controlled createdAt (the adapter passes
+    // MemoryEntry.timestamp through as createdAt; POST honors it — #1339).
+    const timestamps = [
+      "2026-08-20T00:00:00.000Z",
+      "2026-08-21T00:00:00.000Z",
+      "2026-08-22T00:00:00.000Z",
+    ];
+    const ids: string[] = [];
+    for (let i = 0; i < timestamps.length; i++) {
+      const rid = `list-${i}-${crypto.randomUUID().slice(0, 8)}`;
+      ids.push(rid);
+      await service.addMemory(
+        app, user, [entry(`list item ${i}`, rid, timestamps[i])],
+        { idx: i }, { subject: `Item ${i}` },
+      );
+    }
+    // A record for ANOTHER user — must never appear in `user`'s list.
+    const foreignId = `foreign-${crypto.randomUUID().slice(0, 8)}`;
+    await service.addMemory(app, otherUser, [entry("foreign item", foreignId)]);
+
+    // Full page: newest first, foreign row absent.
+    const entries = await service.listMemories(app, user);
+    const gotIds = entries.map((e) => e.id);
+    expect(gotIds).toEqual([ids[2], ids[1], ids[0]]);
+    expect(gotIds).not.toContain(foreignId);
+    // Full projection present.
+    expect(entries[0].customMetadata).toEqual({ idx: 2, subject: "Item 2" });
+    expect(entries[0].author).toBe(config.agentId);
+    expect(entries[0].timestamp).toBe("2026-08-22T00:00:00.000Z");
+
+    // Pagination: limit=1 offset=1 → the middle record.
+    const page = await service.listMemories(app, user, { limit: 1, offset: 1 });
+    expect(page.map((e) => e.id)).toEqual([ids[1]]);
+  }, { timeout: 60_000 });
+});

--- a/packages/adk-flair-js/test/unit/memory_service.test.ts
+++ b/packages/adk-flair-js/test/unit/memory_service.test.ts
@@ -408,9 +408,13 @@ describe("searchMemory", () => {
         JSON.stringify({
           results: [
             {
+              id: "mem-1",
               content: "remembered fact",
-              author: "model",
-              timestamp: "2024-01-15T10:30:00.000Z",
+              // author derives from the record's agentId, timestamp from
+              // createdAt (flair#1332 incidental fix, mirrored from Python:
+              // records carry no "author"/"timestamp" fields).
+              agentId: "test-agent",
+              createdAt: "2024-01-15T10:30:00.000Z",
               tags: ["adk:my-app:user-1"],
             },
           ],
@@ -427,8 +431,9 @@ describe("searchMemory", () => {
 
     expect(result.memories).toHaveLength(1);
     expect(result.memories[0].content?.parts?.[0]).toEqual({ text: "remembered fact" });
-    expect(result.memories[0].author).toBe("model");
+    expect(result.memories[0].author).toBe("test-agent");
     expect(result.memories[0].timestamp).toBe("2024-01-15T10:30:00.000Z");
+    expect(result.memories[0].id).toBe("mem-1");
   });
 
   it("re-verifies compound tag on every hit", async () => {
@@ -592,13 +597,14 @@ describe("addSessionToMemory", () => {
     await service.addSessionToMemory(session);
 
     expect(calls).toHaveLength(2);
-    // First call
-    expect(calls[0].method).toBe("PUT");
-    expect(calls[0].url).toContain("/Memory/my-app:user-1:sess-1:evt-1");
+    // First call — creates ride POST /Memory/ with the id in the body
+    // (flair#1336 parity; see the create-verb describe block below).
+    expect(calls[0].method).toBe("POST");
+    expect(calls[0].url).toBe("http://localhost:19926/Memory/");
     expect(calls[0].body).toMatchObject({ id: "my-app:user-1:sess-1:evt-1", tags: ["adk:my-app:user-1"], type: "session", durability: "standard" });
     // Second call
-    expect(calls[1].method).toBe("PUT");
-    expect(calls[1].url).toContain("/Memory/my-app:user-1:sess-1:evt-2");
+    expect(calls[1].method).toBe("POST");
+    expect((calls[1].body as Record<string, unknown>).id).toBe("my-app:user-1:sess-1:evt-2");
   });
 
   it("filters no-text events", async () => {
@@ -676,14 +682,17 @@ describe("addSessionToMemory", () => {
     }
   });
 
-  it("sends PUT with id-bearing path (wire-shape guard)", async () => {
-    const calls: Array<{ method: string; url: string }> = [];
+  it("creates via POST /Memory/ with the id in the body (wire-shape guard)", async () => {
+    // flair#1336 parity: a PUT-shaped create 404s on Harper deployments
+    // where PUT is update-only — creates must ride the collection POST.
+    const calls: Array<{ method: string; url: string; body: unknown }> = [];
     globalThis.fetch = mock(async (url, init) => {
       calls.push({
         method: (init as RequestInit).method ?? "GET",
         url: String(url),
+        body: JSON.parse((init as RequestInit).body as string),
       });
-      return new Response(JSON.stringify({ ok: true }), { status: 200 });
+      return new Response(JSON.stringify({ ok: true }), { status: 201 });
     });
 
     const session = makeSession({
@@ -696,8 +705,130 @@ describe("addSessionToMemory", () => {
     await service.addSessionToMemory(session);
 
     expect(calls).toHaveLength(1);
-    expect(calls[0].method).toBe("PUT");
-    expect(calls[0].url).toBe("http://localhost:19926/Memory/ws-app:ws-user:sess-ws:evt-ws");
+    expect(calls[0].method).toBe("POST");
+    expect(calls[0].url).toBe("http://localhost:19926/Memory/");
+    expect((calls[0].body as Record<string, unknown>).id).toBe("ws-app:ws-user:sess-ws:evt-ws");
+  });
+});
+
+// ─── Create verb + conflict fallback (flair#1336 parity) ────────────────────
+
+describe("create verb and conflict fallback", () => {
+  let keyfilePath: string;
+  let service: FlairMemoryService;
+  let origFetch: typeof globalThis.fetch;
+
+  beforeEach(() => {
+    const { keyfilePath: kp } = generateTestKey();
+    keyfilePath = kp;
+    service = new FlairMemoryService({
+      url: "http://localhost:19926",
+      agentId: "test-agent",
+      keyfile: keyfilePath,
+    });
+    origFetch = globalThis.fetch;
+  });
+
+  afterEach(() => {
+    try { fs.unlinkSync(keyfilePath); } catch {}
+    globalThis.fetch = origFetch;
+  });
+
+  it("all write entrypoints create via POST /Memory/ with the id in the body", async () => {
+    const calls: Array<{ method: string; url: string; body: Record<string, unknown> }> = [];
+    globalThis.fetch = mock(async (url, init) => {
+      calls.push({
+        method: (init as RequestInit).method ?? "GET",
+        url: String(url),
+        body: JSON.parse((init as RequestInit).body as string) as Record<string, unknown>,
+      });
+      return new Response(JSON.stringify({ ok: true }), { status: 201 });
+    });
+
+    await service.addSessionToMemory(makeSession({
+      id: "sess-1", appName: "app", userId: "user",
+      events: [makeEvent({ id: "evt-1", text: "hello" })],
+    }));
+    await service.addEventsToMemory(
+      "app", "user", [makeEvent({ id: "evt-2", text: "turn" })], "sess-1",
+    );
+    await service.addMemory("app", "user", [
+      { ...makeMemoryEntry("fact"), id: "mem-1" },
+    ]);
+
+    expect(calls).toHaveLength(3);
+    for (const call of calls) {
+      expect(call.method).toBe("POST");
+      expect(call.url).toBe("http://localhost:19926/Memory/");
+    }
+    expect(calls[0].body.id).toBe("app:user:sess-1:evt-1");
+    expect(calls[1].body.id).toBe("app:user:sess-1:evt-2");
+    expect(calls[2].body.id).toBe("mem-1");
+  });
+
+  it("409 conflict falls back to PUT /Memory/{id} with the SAME body, no warning", async () => {
+    // The trap a naive PUT→POST swap walks into: without the fallback,
+    // every re-save of an already-ingested session event fails with 409 on
+    // every deployment where the old PUT path worked.
+    const calls: Array<{ method: string; url: string; body: Record<string, unknown> }> = [];
+    globalThis.fetch = mock(async (url, init) => {
+      calls.push({
+        method: (init as RequestInit).method ?? "GET",
+        url: String(url),
+        body: JSON.parse((init as RequestInit).body as string) as Record<string, unknown>,
+      });
+      return calls.length === 1
+        ? new Response("Conflict", { status: 409 })
+        : new Response(JSON.stringify({ ok: true }), { status: 200 });
+    });
+
+    const warnings: string[] = [];
+    const origWarn = console.warn;
+    console.warn = (...args: unknown[]) => { warnings.push(args.map(String).join(" ")); };
+
+    try {
+      await service.addSessionToMemory(makeSession({
+        id: "sess-1", appName: "app", userId: "user",
+        events: [makeEvent({ id: "evt-1", text: "hello" })],
+      }));
+    } finally {
+      console.warn = origWarn;
+    }
+
+    expect(calls).toHaveLength(2);
+    expect(calls[0].method).toBe("POST");
+    expect(calls[0].url).toBe("http://localhost:19926/Memory/");
+    expect(calls[1].method).toBe("PUT");
+    expect(calls[1].url).toBe("http://localhost:19926/Memory/app:user:sess-1:evt-1");
+    expect(calls[1].body).toEqual(calls[0].body);
+    // Idempotent re-ingestion must neither throw nor warn.
+    expect(warnings.filter((w) => w.includes("write failed"))).toEqual([]);
+  });
+
+  it("non-409 error does NOT fall back to PUT and the warning carries the real status", async () => {
+    const calls: string[] = [];
+    globalThis.fetch = mock(async (url, init) => {
+      calls.push((init as RequestInit).method ?? "GET");
+      return new Response("Not Found", { status: 404 });
+    });
+
+    const warnings: string[] = [];
+    const origWarn = console.warn;
+    console.warn = (...args: unknown[]) => { warnings.push(args.map(String).join(" ")); };
+
+    try {
+      await service.addMemory("app", "user", [
+        { ...makeMemoryEntry("fact"), id: "mem-404" },
+      ]);
+    } finally {
+      console.warn = origWarn;
+    }
+
+    expect(calls).toEqual(["POST"]); // no PUT fallback on non-409
+    const failWarnings = warnings.filter((w) => w.includes("write failed"));
+    expect(failWarnings).toHaveLength(1);
+    expect(failWarnings[0]).toContain("HTTP 404"); // the real status, never "?"
+    expect(failWarnings[0]).toContain("mem-404");
   });
 });
 
@@ -741,10 +872,15 @@ describe("addMemory", () => {
     ]);
 
     expect(calls).toHaveLength(2);
-    expect(calls[0].method).toBe("PUT");
-    expect(calls[0].url).toContain("/Memory/my-app:user-1:direct:");
+    expect(calls[0].method).toBe("POST");
+    expect(calls[0].url).toBe("http://localhost:19926/Memory/");
     expect((calls[0].body as Record<string, unknown>).tags).toEqual(["adk:my-app:user-1"]);
     expect((calls[0].body as Record<string, unknown>).content).toBe("fact one");
+    // Record id mirrors the Python package: no caller-supplied id ⇒ the
+    // first 32 hex chars of the content's SHA-256 (deterministic re-add).
+    const expectedId = crypto
+      .createHash("sha256").update("fact one", "utf8").digest("hex").slice(0, 32);
+    expect((calls[0].body as Record<string, unknown>).id).toBe(expectedId);
   });
 
   it("no-ops on empty memories", async () => {
@@ -801,8 +937,8 @@ describe("addEventsToMemory", () => {
     );
 
     expect(calls).toHaveLength(1);
-    expect(calls[0].method).toBe("PUT");
-    expect(calls[0].url).toContain("/Memory/my-app:user-1:sess-2:evt-1");
+    expect(calls[0].method).toBe("POST");
+    expect(calls[0].url).toBe("http://localhost:19926/Memory/");
     expect((calls[0].body as Record<string, unknown>).id).toBe("my-app:user-1:sess-2:evt-1");
   });
 });

--- a/packages/adk-flair-js/test/unit/metadata_and_list.test.ts
+++ b/packages/adk-flair-js/test/unit/metadata_and_list.test.ts
@@ -1,0 +1,522 @@
+/**
+ * Hermetic tests for flair#1332 (customMetadata + subject) and flair#1333
+ * (listMemories) — the JS-package parity port of #1334 (flair#1335).
+ *
+ * Mirrors packages/adk-flair/tests/test_metadata_and_list.py's hermetic tier:
+ * mocked fetch — write-body shape, caps (64KB / depth / key-count /
+ * subject-512), precedence, read-path fail-soft, listMemories URL
+ * construction + scoping + validation. The live tier is ported to
+ * test/integration/metadata_and_list.test.ts.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, mock } from "bun:test";
+import { FlairMemoryService } from "../../src/memory_service.js";
+import type { FlairMemoryEntry } from "../../src/memory_service.js";
+import type { MemoryEntry } from "@google/adk";
+import type { Event } from "@google/adk";
+import type { Content } from "@google/genai";
+import * as crypto from "node:crypto";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function generateTestKey(): string {
+  const { privateKey } = crypto.generateKeyPairSync("ed25519");
+  const der = privateKey.export({ format: "der", type: "pkcs8" });
+  const b64 = Buffer.from(der).toString("base64");
+  const keyfilePath = path.join(os.tmpdir(), `adk-flair-js-meta-${crypto.randomUUID()}.key`);
+  fs.writeFileSync(keyfilePath, b64, "utf-8");
+  return keyfilePath;
+}
+
+function entry(text: string, id?: string, timestamp?: string): MemoryEntry & { id?: string } {
+  return {
+    id,
+    content: { role: "user", parts: [{ text }] } as Content,
+    timestamp,
+  };
+}
+
+function makeSimpleEvent(eventId: string, text: string): Event {
+  return {
+    id: eventId,
+    invocationId: crypto.randomUUID(),
+    author: "user",
+    actions: {} as Event["actions"],
+    timestamp: Date.now(),
+    content: { role: "user", parts: [{ text }] } as Content,
+  };
+}
+
+interface CapturedCall {
+  method: string;
+  url: string;
+  body: Record<string, unknown> | null;
+}
+
+/** Install a mock fetch that records calls and answers with `responder`. */
+function captureFetch(
+  responder: (call: CapturedCall, index: number) => Response = () =>
+    new Response(JSON.stringify({ ok: true }), { status: 201 }),
+): CapturedCall[] {
+  const calls: CapturedCall[] = [];
+  globalThis.fetch = mock(async (url, init) => {
+    const rawBody = (init as RequestInit | undefined)?.body;
+    const call: CapturedCall = {
+      method: (init as RequestInit | undefined)?.method ?? "GET",
+      url: String(url),
+      body: typeof rawBody === "string" ? JSON.parse(rawBody) as Record<string, unknown> : null,
+    };
+    calls.push(call);
+    return responder(call, calls.length - 1);
+  });
+  return calls;
+}
+
+function searchResponse(results: unknown[]): Response {
+  return new Response(JSON.stringify({ results }), { status: 200 });
+}
+
+function listResponse(rows: unknown): Response {
+  return new Response(JSON.stringify(rows), { status: 200 });
+}
+
+/** Capture console.warn lines for the duration of `fn`. */
+async function withCapturedWarnings(fn: () => Promise<void>): Promise<string[]> {
+  const warnings: string[] = [];
+  const origWarn = console.warn;
+  console.warn = (...args: unknown[]) => { warnings.push(args.map(String).join(" ")); };
+  try {
+    await fn();
+  } finally {
+    console.warn = origWarn;
+  }
+  return warnings;
+}
+
+// ─── Shared fixture ──────────────────────────────────────────────────────────
+
+let keyfilePath: string;
+let service: FlairMemoryService;
+let origFetch: typeof globalThis.fetch;
+
+beforeEach(() => {
+  keyfilePath = generateTestKey();
+  service = new FlairMemoryService({
+    url: "http://localhost:19926",
+    agentId: "test-agent",
+    keyfile: keyfilePath,
+  });
+  origFetch = globalThis.fetch;
+});
+
+afterEach(() => {
+  try { fs.unlinkSync(keyfilePath); } catch {}
+  globalThis.fetch = origFetch;
+});
+
+// ─── Metadata write path ─────────────────────────────────────────────────────
+
+describe("metadata write path", () => {
+  it("addMemory serializes customMetadata into body.metadata", async () => {
+    const nested = {
+      merchant: "acme", price: { amount: 12.5, ccy: "EUR" },
+      tags: ["a", "b"], nested: { deep: { ok: true } },
+    };
+    const calls = captureFetch();
+    await service.addMemory("app", "user", [entry("fact")], nested);
+    expect(calls).toHaveLength(1);
+    const metadata = calls[0].body?.["metadata"];
+    expect(typeof metadata).toBe("string");
+    expect(JSON.parse(metadata as string)).toEqual(nested);
+  });
+
+  it("addEventsToMemory serializes customMetadata into every event body", async () => {
+    const calls = captureFetch();
+    await service.addEventsToMemory(
+      "app", "user",
+      [makeSimpleEvent("evt-0", "turn 0"), makeSimpleEvent("evt-1", "turn 1")],
+      "s1", { source: "cam-1" },
+    );
+    expect(calls).toHaveLength(2);
+    for (const call of calls) {
+      expect(JSON.parse(call.body?.["metadata"] as string)).toEqual({ source: "cam-1" });
+    }
+  });
+
+  it("no customMetadata means no metadata key and no subject key", async () => {
+    const calls = captureFetch();
+    await service.addMemory("app", "user", [entry("plain")]);
+    expect(calls[0].body).not.toContainKey("metadata");
+    expect(calls[0].body).not.toContainKey("subject");
+  });
+
+  it("oversize metadata (64KB) rejects before any HTTP call", async () => {
+    const calls = captureFetch();
+    await expect(
+      service.addMemory("app", "user", [entry("x")], { blob: "y".repeat(64 * 1024) }),
+    ).rejects.toThrow(/64|byte/);
+    expect(calls).toHaveLength(0);
+  });
+
+  it("nesting over 16 levels rejects before any HTTP call", async () => {
+    let deep: Record<string, unknown> = { leaf: 1 };
+    for (let i = 0; i < 17; i++) deep = { n: deep };
+    const calls = captureFetch();
+    await expect(
+      service.addMemory("app", "user", [entry("x")], deep),
+    ).rejects.toThrow(/nesting/);
+    expect(calls).toHaveLength(0);
+  });
+
+  it("nesting of exactly 16 levels is accepted (boundary control)", async () => {
+    // The depth guard must not fire early.
+    let node: Record<string, unknown> = { leaf: 1 };
+    for (let i = 0; i < 15; i++) node = { n: node }; // 16 object levels total
+    const calls = captureFetch();
+    await service.addMemory("app", "user", [entry("x")], node);
+    expect(calls).toHaveLength(1);
+  });
+
+  it("key count over 512 rejects before any HTTP call", async () => {
+    const wide: Record<string, unknown> = {};
+    for (let i = 0; i < 513; i++) wide[`k${i}`] = i;
+    const calls = captureFetch();
+    await expect(
+      service.addMemory("app", "user", [entry("x")], wide),
+    ).rejects.toThrow(/keys/);
+    expect(calls).toHaveLength(0);
+  });
+
+  it("key count counts nested keys", async () => {
+    // 2 top-level + 511 nested = 513 total → reject
+    const inner: Record<string, unknown> = {};
+    for (let i = 0; i < 511; i++) inner[`k${i}`] = i;
+    await expect(
+      service.addMemory("app", "user", [entry("x")], { a: inner, b: 1 }),
+    ).rejects.toThrow(/keys/);
+  });
+
+  it("non-serializable value skips that key with a warning naming the session", async () => {
+    const calls = captureFetch();
+    const warnings = await withCapturedWarnings(async () => {
+      await service.addEventsToMemory(
+        "app", "user", [makeSimpleEvent("evt-1", "hello")], "sess-9",
+        { good: "kept", bad: () => "not serializable" },
+      );
+    });
+    expect(calls).toHaveLength(1);
+    expect(JSON.parse(calls[0].body?.["metadata"] as string)).toEqual({ good: "kept" });
+    const joined = warnings.join(" | ");
+    expect(joined).toContain("bad");
+    // The warning must carry the session key so the skip is traceable.
+    expect(joined).toContain("app:user:sess-9");
+  });
+
+  it("all values non-serializable yields no metadata key", async () => {
+    const calls = captureFetch();
+    await withCapturedWarnings(async () => {
+      await service.addMemory("app", "user", [entry("x")], { bad: () => 1 });
+    });
+    expect(calls[0].body).not.toContainKey("metadata");
+  });
+
+  it("a circular blob is rejected by the depth cap, never serialized", async () => {
+    const circular: Record<string, unknown> = {};
+    circular["self"] = circular;
+    const calls = captureFetch();
+    await expect(
+      service.addMemory("app", "user", [entry("x")], circular),
+    ).rejects.toThrow(/nesting/);
+    expect(calls).toHaveLength(0);
+  });
+});
+
+// ─── Subject write path ──────────────────────────────────────────────────────
+
+describe("subject write path", () => {
+  it("explicit subject option lands top-level", async () => {
+    const calls = captureFetch();
+    await service.addMemory("app", "user", [entry("x")], undefined, {
+      subject: "Receipt: Acme",
+    });
+    expect(calls[0].body?.["subject"]).toBe("Receipt: Acme");
+    expect(calls[0].body).not.toContainKey("metadata"); // subject alone stores no blob
+  });
+
+  it("customMetadata.subject lands top-level and stays in the blob", async () => {
+    const calls = captureFetch();
+    await service.addMemory("app", "user", [entry("x")], { subject: "From Blob", k: 1 });
+    expect(calls[0].body?.["subject"]).toBe("From Blob");
+    // The blob is stored verbatim — promotion copies, never strips.
+    expect(JSON.parse(calls[0].body?.["metadata"] as string))
+      .toEqual({ subject: "From Blob", k: 1 });
+  });
+
+  it("explicit option is authoritative over customMetadata.subject", async () => {
+    const calls = captureFetch();
+    await service.addMemory("app", "user", [entry("x")],
+      { subject: "blob-says" }, { subject: "param-says" });
+    expect(calls[0].body?.["subject"]).toBe("param-says");
+    expect(JSON.parse(calls[0].body?.["metadata"] as string)["subject"]).toBe("blob-says");
+  });
+
+  it("subject over 512 chars rejects before any HTTP call", async () => {
+    const calls = captureFetch();
+    await expect(
+      service.addMemory("app", "user", [entry("x")], undefined, {
+        subject: "s".repeat(513),
+      }),
+    ).rejects.toThrow(/512/);
+    expect(calls).toHaveLength(0);
+  });
+
+  it("subject of exactly 512 chars is accepted", async () => {
+    const calls = captureFetch();
+    await service.addMemory("app", "user", [entry("x")], undefined, {
+      subject: "s".repeat(512),
+    });
+    expect(calls[0].body?.["subject"]).toBe("s".repeat(512));
+  });
+
+  it("non-string customMetadata.subject rejects", async () => {
+    const calls = captureFetch();
+    await expect(
+      service.addMemory("app", "user", [entry("x")], { subject: { not: "a string" } }),
+    ).rejects.toThrow(/string/);
+    expect(calls).toHaveLength(0);
+  });
+
+  it("subject is never auto-extracted from content", async () => {
+    const calls = captureFetch();
+    await service.addMemory("app", "user",
+      [entry("A very titled-looking first line\nbody")]);
+    expect(calls[0].body).not.toContainKey("subject");
+  });
+
+  it("customMetadata.subject applies on event writes too", async () => {
+    const calls = captureFetch();
+    await service.addEventsToMemory(
+      "app", "user", [makeSimpleEvent("evt-1", "hello")], "s1",
+      { subject: "Session Topic" },
+    );
+    expect(calls[0].body?.["subject"]).toBe("Session Topic");
+  });
+});
+
+// ─── Read path (searchMemory) ────────────────────────────────────────────────
+
+describe("metadata read path (searchMemory)", () => {
+  it("metadata blob parses into customMetadata", async () => {
+    const blob = { merchant: "acme", n: { deep: [1, 2] } };
+    captureFetch(() => searchResponse([{
+      id: "m1", agentId: "test-agent", content: "c",
+      createdAt: "2026-08-22T00:00:00.000Z",
+      tags: ["adk:app:user"], metadata: JSON.stringify(blob),
+    }]));
+    const result = await service.searchMemory({ appName: "app", userId: "user", query: "q" });
+    expect((result.memories[0] as FlairMemoryEntry).customMetadata).toEqual(blob);
+  });
+
+  it("search body opts into the metadata projection", async () => {
+    const calls = captureFetch(() => searchResponse([]));
+    await service.searchMemory({ appName: "app", userId: "user", query: "q" });
+    expect(calls[0].body?.["includeMetadata"]).toBe(true);
+  });
+
+  it("malformed metadata fails soft with a warning naming the record id", async () => {
+    captureFetch(() => searchResponse([{
+      id: "m-broken", agentId: "test-agent", content: "still readable",
+      tags: ["adk:app:user"], metadata: "{not json",
+    }]));
+    let result: Awaited<ReturnType<typeof service.searchMemory>> | undefined;
+    const warnings = await withCapturedWarnings(async () => {
+      result = await service.searchMemory({ appName: "app", userId: "user", query: "q" });
+    });
+    // A corrupt blob must not drop the memory.
+    expect(result!.memories).toHaveLength(1);
+    expect((result!.memories[0] as FlairMemoryEntry).customMetadata).toEqual({});
+    // The warning must name the record id.
+    expect(warnings.join(" | ")).toContain("m-broken");
+  });
+
+  it("non-object JSON metadata fails soft to {}", async () => {
+    captureFetch(() => searchResponse([{
+      id: "m-arr", agentId: "test-agent", content: "c",
+      tags: ["adk:app:user"], metadata: "[1,2,3]",
+    }]));
+    let result: Awaited<ReturnType<typeof service.searchMemory>> | undefined;
+    await withCapturedWarnings(async () => {
+      result = await service.searchMemory({ appName: "app", userId: "user", query: "q" });
+    });
+    expect((result!.memories[0] as FlairMemoryEntry).customMetadata).toEqual({});
+  });
+
+  it("subject column is authoritative over a divergent blob key", async () => {
+    captureFetch(() => searchResponse([{
+      id: "m1", agentId: "test-agent", content: "c",
+      tags: ["adk:app:user"],
+      metadata: JSON.stringify({ subject: "stale-blob-value" }),
+      subject: "column-value",
+    }]));
+    const result = await service.searchMemory({ appName: "app", userId: "user", query: "q" });
+    const hit = result.memories[0] as FlairMemoryEntry;
+    expect(hit.customMetadata["subject"]).toBe("column-value");
+    expect(hit.subject).toBe("column-value");
+  });
+
+  it("subject column surfaces without a blob — both channels", async () => {
+    // A subject written via the explicit option has no blob — it must still
+    // round-trip. JS MemoryEntry is a plain object, so Flair surfaces it
+    // top-level (entry.subject) AND as customMetadata.subject (the Python
+    // package's only channel — kept for cross-language parity).
+    captureFetch(() => searchResponse([{
+      id: "m1", agentId: "test-agent", content: "c",
+      tags: ["adk:app:user"], subject: "Param Subject",
+    }]));
+    const result = await service.searchMemory({ appName: "app", userId: "user", query: "q" });
+    const hit = result.memories[0] as FlairMemoryEntry;
+    expect(hit.customMetadata).toEqual({ subject: "Param Subject" });
+    expect(hit.subject).toBe("Param Subject");
+  });
+
+  it("author derives from agentId", async () => {
+    captureFetch(() => searchResponse([{
+      id: "m1", agentId: "test-agent", content: "c", tags: ["adk:app:user"],
+    }]));
+    const result = await service.searchMemory({ appName: "app", userId: "user", query: "q" });
+    expect(result.memories[0].author).toBe("test-agent");
+  });
+
+  it("no metadata and no subject yields an empty customMetadata object", async () => {
+    captureFetch(() => searchResponse([{
+      id: "m1", agentId: "test-agent", content: "c", tags: ["adk:app:user"],
+    }]));
+    const result = await service.searchMemory({ appName: "app", userId: "user", query: "q" });
+    expect((result.memories[0] as FlairMemoryEntry).customMetadata).toEqual({});
+  });
+});
+
+// ─── listMemories ────────────────────────────────────────────────────────────
+
+describe("listMemories", () => {
+  it("URL construction, default page", async () => {
+    const calls = captureFetch(() => listResponse([]));
+    await service.listMemories("app", "user");
+    expect(calls).toHaveLength(1);
+    expect(calls[0].method).toBe("GET");
+    const url = calls[0].url;
+    expect(url.startsWith("http://localhost:19926/Memory/?")).toBe(true);
+    expect(url).toContain("tags=adk%3Aapp%3Auser");
+    expect(url).toContain("agentId=test-agent");
+    expect(url).toContain("sort(-createdAt)");
+    expect(url).toContain("limit(0,50)");
+    expect(url).toContain("select(id,agentId,content,metadata,subject,tags,createdAt)");
+  });
+
+  it("offset window", async () => {
+    const calls = captureFetch(() => listResponse([]));
+    await service.listMemories("app", "user", { limit: 25, offset: 10 });
+    expect(calls[0].url).toContain("limit(10,35)");
+  });
+
+  it("tag percent-escapes survive URL encoding", async () => {
+    // A userId containing ':' produces a tag with literal %3A — the URL
+    // value must encode the '%' itself so the server-side decode restores
+    // the exact stored tag.
+    const calls = captureFetch(() => listResponse([]));
+    await service.listMemories("app", "alice:admin");
+    // tag = adk:app:alice%3Aadmin → encoded: adk%3Aapp%3Aalice%253Aadmin
+    expect(calls[0].url).toContain("tags=adk%3Aapp%3Aalice%253Aadmin");
+  });
+
+  it("limit over the 200 cap rejects (never clamps)", async () => {
+    const calls = captureFetch(() => listResponse([]));
+    await expect(service.listMemories("app", "user", { limit: 201 }))
+      .rejects.toThrow(/200/);
+    expect(calls).toHaveLength(0);
+  });
+
+  it("limit at the cap is accepted", async () => {
+    const calls = captureFetch(() => listResponse([]));
+    await service.listMemories("app", "user", { limit: 200 });
+    expect(calls[0].url).toContain("limit(0,200)");
+  });
+
+  it("limit zero rejects", async () => {
+    await expect(service.listMemories("app", "user", { limit: 0 }))
+      .rejects.toThrow(/positive/);
+  });
+
+  it("non-integer limit rejects", async () => {
+    await expect(service.listMemories("app", "user", { limit: 2.5 }))
+      .rejects.toThrow(/positive integer/);
+  });
+
+  it("negative offset rejects", async () => {
+    await expect(service.listMemories("app", "user", { offset: -1 }))
+      .rejects.toThrow(/offset/);
+  });
+
+  it("empty userId rejects", async () => {
+    const calls = captureFetch(() => listResponse([]));
+    await expect(service.listMemories("app", "")).rejects.toThrow(/userId/);
+    expect(calls).toHaveLength(0);
+  });
+
+  it("empty appName rejects", async () => {
+    await expect(service.listMemories("", "user")).rejects.toThrow(/appName/);
+  });
+
+  it("rows map to full FlairMemoryEntry projections", async () => {
+    const blob = { k: "v" };
+    captureFetch(() => listResponse([{
+      id: "m1", agentId: "test-agent", content: "hello",
+      createdAt: "2026-08-22T01:00:00.000Z",
+      tags: ["adk:app:user"],
+      metadata: JSON.stringify(blob), subject: "Title",
+    }]));
+    const entries = await service.listMemories("app", "user");
+    expect(entries).toHaveLength(1);
+    const e = entries[0];
+    expect(e.id).toBe("m1");
+    expect(e.author).toBe("test-agent");
+    expect(e.timestamp).toBe("2026-08-22T01:00:00.000Z");
+    expect((e.content?.parts?.[0] as { text?: string }).text).toBe("hello");
+    expect(e.customMetadata).toEqual({ k: "v", subject: "Title" });
+    expect(e.subject).toBe("Title");
+  });
+
+  it("scope re-verification drops foreign rows", async () => {
+    captureFetch(() => listResponse([
+      { id: "mine", agentId: "test-agent", content: "c", tags: ["adk:app:user"] },
+      { id: "wrong-tag", agentId: "test-agent", content: "c", tags: ["adk:app:other"] },
+      { id: "wrong-agent", agentId: "someone-else", content: "c", tags: ["adk:app:user"] },
+    ]));
+    const entries = await service.listMemories("app", "user");
+    expect(entries.map((e) => e.id)).toEqual(["mine"]);
+  });
+
+  it("non-array response returns empty", async () => {
+    captureFetch(() => listResponse({ unexpected: "shape" }));
+    expect(await service.listMemories("app", "user")).toEqual([]);
+  });
+
+  it("transport error PROPAGATES", async () => {
+    // Unlike searchMemory (ADK's swallow-to-empty contract), a browsing API
+    // must distinguish "no memories" from "Flair is down".
+    globalThis.fetch = mock(async () => {
+      throw new Error("connect ECONNREFUSED");
+    });
+    await expect(service.listMemories("app", "user"))
+      .rejects.toThrow(/ECONNREFUSED/);
+  });
+
+  it("HTTP error PROPAGATES with the status", async () => {
+    captureFetch(() => new Response("boom", { status: 500 }));
+    await expect(service.listMemories("app", "user"))
+      .rejects.toThrow(/500/);
+  });
+});


### PR DESCRIPTION
Ports the Python package's #1334 (flair#1332/#1333) customMetadata semantics to `packages/adk-flair-js`, closing the parity gap where the JS adapter still warn-dropped `customMetadata`. #1334's merged implementation is the specification; scope is `packages/adk-flair-js` only, plus the changelog fragment.

## Mirrored rulings (from #1334, K&S-ruled)

- [x] **customMetadata → body.metadata JSON serialization** on `addMemory`/`addEventsToMemory`, validated/serialized ONCE before any write (a cap violation writes zero records, never a partial batch).
- [x] **64KB REJECT (never truncate)** — `Error` before any HTTP call; truncation would corrupt the store-and-return round-trip guarantee.
- [x] **Depth ≤ 16, keys ≤ 512** — iterative structural check BEFORE serialization; boundary controls in tests (depth-16 and 512-char subject accepted). A circular blob terminates via the depth cap and never reaches `JSON.stringify`.
- [x] **Non-serializable values skipped + WARNING** naming the key and the session key. (JS meaning: `JSON.stringify` yields `undefined` — functions/symbols/undefined — or throws — BigInt. Object keys are always strings in JS, so Python's non-string-key skip has no analogue.)
- [x] **Subject write-through**: explicit `addMemory` option + `customMetadata.subject`, explicit option authoritative, 512 cap (reject beyond), non-string rejects, never auto-extracted from content. Blob stored verbatim — promotion copies, never strips.
- [x] **Read path**: `includeMetadata: true` on `/SemanticSearch` requests; fail-soft `JSON.parse` to `{}` + WARNING naming the record id; non-object JSON also fails soft.
- [x] **Subject surfacing per the JS return type** — decision below.
- [x] **listMemories**: compound tag + agentId scope pushed down AND re-verified client-side, `createdAt` DESC, limit cap 200 (reject, not clamp), offset positional over a point-in-time snapshot, full projection, transport/HTTP errors PROPAGATE (swallow-to-empty is the search-only contract).
- [x] **POST-for-create with 409→PUT fallback** (#1339 verb semantics) — see below.
- [x] **Store-and-return CONTRACT TEST against real ephemeral Harper** with positive control — see below.

## Subject-channel decision

`@google/adk`'s JS `MemoryEntry` is a **plain-object interface** (`content`, `author?`, `timestamp?`) — unlike the Python pydantic model it drops nothing at runtime. So the returned `FlairMemoryEntry` (exported, `extends MemoryEntry`) surfaces subject **both ways**:

- `entry.subject` top-level (JS-only convenience, typed), AND
- `customMetadata["subject"]` (column authoritative over a divergent blob key) — this keeps the return shape **identical to the Python package**, whose `MemoryEntry` has no subject attribute and uses `custom_metadata` as its only subject channel.

`FlairMemoryEntry` also carries `id` and an always-present `customMetadata` (possibly `{}`), and `author`/`timestamp` now derive from `agentId`/`createdAt` — the old JS code read `hit.author`/`hit.timestamp`, fields Flair never projects, so both were always `undefined` (the #1332 incidental fix, mirrored).

## Was the PUT fix needed?

**Yes.** `adk-flair-js` still created via `PUT /Memory/{id}` (the #1336 failure shape — update-only PUT 404s on hosted Harper Fabric). `_writeRecord` now POSTs `/Memory/` with the id in the body and falls back to `PUT /Memory/{id}` with the same body on 409 only; non-409 propagates with the real HTTP status in the write warning. Mirrored #1339's hermetic tests: verb regression across all three write entrypoints, 409 fallback (same body, no warning), non-409 no-fallback with status surfaced.

## Also in this port (deliberate, called out)

- `addMemory` gains the Python package's explicit `durability`/`visibility` options (flair#1234 parity) via a new **trailing** `opts` parameter — required so the contract test's **positive control** goes through the adapter exactly as the Python test does. Backward compatible: `customMetadata` stays the 4th positional arg.
- `addMemory` record ids mirror Python: `entry.id` when supplied (input type widened to `MemoryEntry & { id?: string }`), else the content's SHA-256 prefix (32 hex) — deterministic, so re-adds replace rather than duplicate (the old random-UUID-per-call duplicated on every re-add).
- README: documents the new API and corrects the stale "colons replaced with underscores" tag-sanitization description (percent-encoding landed with the #1205 mirror).

## Tests

| Lane | Baseline | Now |
|---|---|---|
| `bun test test/unit/` | 65 pass / 0 fail (2 files) | **110 pass / 0 fail** (3 files, +45 hermetic) |
| `bun test test/integration/` | 9 pass / 0 fail (3 files) | **13 pass / 0 fail** (4 files, +4 live) |
| `tsc -p tsconfig.json --noEmit` | clean | clean |

- Hermetic tier mirrors `test_metadata_and_list.py`: write-body shape, all caps with boundary controls, precedence, read-path fail-soft, listMemories URL construction (incl. the `%3A`→`%253A` double-encoding trap) + scoping + validation, plus the #1339 verb/fallback trio.
- Live tier (real ephemeral Harper via the existing `getLiveFlair` helper — no new lane needed): nested round-trip, **the store-and-return contract test** (blob claiming `visibility`/`durability`/`residency` moves nothing; REST readback as the independent instrument; positive control proves the explicit channel DOES move the fields), subject persistence + precedence, listMemories pagination/scope/order against real query pushdown.
- Fails-on-main control: against the pre-port implementation the new suites fail 38/42 (metadata/list) plus 8 verb/mapping tests — the checks fire.

Closes #1335
Refs #1334

🤖 Generated with [Claude Code](https://claude.com/claude-code)
