### PR TITLE
doctor/init know pi: native-extension detection, wiring checks, #1346 trap callout

### DIFF
--- a/.changelog/unreleased/added-1342-pi-doctor-init.md
+++ b/.changelog/unreleased/added-1342-pi-doctor-init.md
@@ -1,0 +1,12 @@
+- **`flair doctor` and `flair init` now know pi.** pi joins the client registry
+  as a native-extension host (pi has no MCP client support): detection is the
+  `pi` binary on PATH or `~/.pi/agent/settings.json` present, and
+  `flair init --client pi` wires a pinned `npm:@tpsdev-ai/pi-flair@<version>`
+  entry under `packages` in pi's settings — same idempotence and
+  existing-config preservation as the MCP clients. `flair doctor` reports
+  wired/not-wired with the pinned version, names the #1346 trap outright (an
+  `npm:` spec under `extensions` is silently ignored by pi; `doctor --fix`
+  moves it to `packages`), and is explicit about the env boundary: pi-flair
+  reads `FLAIR_AGENT_ID`/`FLAIR_URL`/`FLAIR_KEY_PATH` from the shell that
+  launches pi, so doctor verifies its own shell and says so rather than
+  pretending to see every pi launch. (#1342)

--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -22,7 +22,7 @@ Where Flair already runs. Each integration shown here is a working surface — t
 | **OpenClaw** | [`openclaw-flair`](#openclaw) | Ed25519 | Native plugin + context engine |
 | **n8n** | [`n8n-nodes-flair`](#n8n) | FlairApi credential | Three nodes (chat memory, search, store) |
 | **Hermes Agent** | [`hermes-flair`](#hermes-agent) | Ed25519 | Python `MemoryProvider` |
-| **Pi agent** | [`pi-flair`](#pi-agent) | Ed25519 | TS plugin |
+| **Pi agent** | [`pi-flair`](#pi-agent) | Ed25519 | Native pi extension (pi has no MCP support); `flair init --client pi` wires it, `flair doctor` checks it |
 
 Don't see your harness? If it speaks **MCP** — Flair already works with `flair-mcp`. If it has a **custom memory protocol** like LangGraph's `BaseStore` or CrewAI's `RAGStorage`, an adapter is a ~200-line package; [open an issue](https://github.com/tpsdev-ai/flair/issues) or [send a PR](https://github.com/tpsdev-ai/flair).
 
@@ -168,13 +168,34 @@ Auth: TPS-Ed25519 (the same model the rest of Flair uses) — writes are isolate
 
 ## Pi agent
 
-[`@tpsdev-ai/pi-flair`](https://www.npmjs.com/package/@tpsdev-ai/pi-flair) is the TS plugin for the [Pi coding agent](https://github.com/mariozechner/pi-coding-agent). Memory + identity for the Pi runtime.
+[`@tpsdev-ai/pi-flair`](https://www.npmjs.com/package/@tpsdev-ai/pi-flair) is the **native pi extension** for the [Pi coding agent](https://github.com/mariozechner/pi-coding-agent) — pi has no MCP client support, so this is a first-party plugin, not an MCP bridge. Memory + identity (`memory_search`, `memory_store`, `bootstrap`) for the pi runtime.
+
+Wire it (either form is equivalent):
 
 ```bash
-npm install @tpsdev-ai/pi-flair
+flair init --client pi        # writes a pinned "packages" entry into ~/.pi/agent/settings.json
+# or
+pi install npm:@tpsdev-ai/pi-flair
 ```
 
-Pi resolves the plugin via its standard plugin config; pin `agentId` per host.
+Which produces:
+
+```json
+{
+  "packages": ["npm:@tpsdev-ai/pi-flair@<version>"]
+}
+```
+
+**Known trap:** the `extensions` settings key takes local file paths only — an `npm:` spec there is *silently ignored* by pi, so the tools never register ([#1346](https://github.com/tpsdev-ai/flair/issues/1346)). Package sources belong under `packages`. `flair doctor` detects pi, verifies the wiring, calls this exact misconfiguration out, and `flair doctor --fix` moves the entry.
+
+pi settings carry no per-package env, so identity comes from the environment that launches pi:
+
+```bash
+export FLAIR_AGENT_ID=my-agent   # per host/purpose
+pi
+```
+
+Full details (tools, env reference, auto-recall/auto-capture flags, security notes): [`packages/pi-flair/README.md`](../packages/pi-flair/README.md).
 
 ---
 

--- a/docs/mcp-clients.md
+++ b/docs/mcp-clients.md
@@ -266,6 +266,24 @@ The MCP server has no client-side flags beyond these env vars; everything else (
 
 ---
 
+## What about pi?
+
+pi has no MCP client support, so Flair ships a **native pi extension** instead: [`@tpsdev-ai/pi-flair`](../packages/pi-flair/README.md). Same backend, same agent isolation, zero MCP in the path.
+
+Wiring is a `packages` entry in pi's own settings (`~/.pi/agent/settings.json`), not an `mcpServers` block:
+
+```json
+{
+  "packages": ["npm:@tpsdev-ai/pi-flair@<version>"]
+}
+```
+
+`flair init --client pi` writes exactly that (pinned), or use pi's own installer: `pi install npm:@tpsdev-ai/pi-flair`. `flair doctor` detects pi and checks the wiring — including the one known trap: **an `npm:` spec under the `extensions` settings key is silently ignored by pi** (`extensions` takes local file paths only; package sources belong under `packages` — [#1346](https://github.com/tpsdev-ai/flair/issues/1346)). Doctor calls that misconfiguration out by name, and `flair doctor --fix` moves the entry.
+
+One difference from the MCP clients above: pi settings carry no per-package `env` block, so `FLAIR_AGENT_ID` (and `FLAIR_URL` when non-default) must be exported in the environment that launches pi. Doctor reports what it sees in its own shell and says so — it cannot observe the environment of every pi launch.
+
+---
+
 ## What about Hermes (Nous Research)?
 
 Hermes uses its own Python-native `MemoryProvider` ABC instead of MCP. It has its own Flair integration in [`packages/hermes-flair/`](../packages/hermes-flair). Same backend, same agent isolation, different plug shape.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -58,7 +58,7 @@ import {
   type FleetSweepResult,
 } from "./fleet-verify.js";
 import { markStale, sortOldestVersionFirst, type FleetPresenceRow } from "./fleet-presence.js";
-import { detectClients, renderWiringSummary, wireClaudeCode, wireCodex, wireGemini, wireCursor, wireAntigravity, clientConfigPath, codexConfigHasFlairSection, type ClientId } from "./install/clients.js";
+import { detectClients, renderWiringSummary, wireClaudeCode, wireCodex, wireGemini, wireCursor, wireAntigravity, wirePi, piFlairSpec, PI_FLAIR_PACKAGE, PI_FLAIR_DEFAULT_URL, clientConfigPath, codexConfigHasFlairSection, type ClientId } from "./install/clients.js";
 import { flairCliVersion, clearFlairCliVersionCache, mcpServerSpec, unpinnedSpecWarning, FLAIR_MCP_PACKAGE } from "./lib/mcp-spec.js";
 import {
   resolveAgentKeyPath,
@@ -85,6 +85,7 @@ import {
 import {
   readClientMcpBlock,
   effectiveFlairUrl,
+  checkPiFlairWiring,
   checkClaudeMdBootstrap,
   detectWiredFlairMcp,
   inspectSessionStartHook,
@@ -3434,7 +3435,7 @@ program
   .option("--data-dir <dir>", "Harper data directory")
   .option("--skip-start", "Skip Harper startup (assume already running)")
   .option("--skip-soul", "Skip interactive personality setup")
-  .option("--client <client>", "MCP client(s) to wire: claude-code, codex, gemini, cursor, antigravity, all, or none")
+  .option("--client <client>", "Client(s) to wire: claude-code, codex, gemini, cursor, antigravity, pi (native extension), all, or none")
   .option("--no-mcp", "Skip MCP client wiring (instance + agent only)")
   .option("--skip-smoke", "Skip the MCP smoke test")
   .option("--skip-claude-md", "Skip appending the Flair bootstrap line to CLAUDE.md (claude-code only)")
@@ -3665,9 +3666,9 @@ program
     const noMcp = opts.mcp === false;
     const selectedClients: ClientId[] = [];
     if (clientOpt && clientOpt !== "all" && clientOpt !== "none" && !noMcp) {
-      const valid: ClientId[] = ["claude-code", "codex", "gemini", "cursor", "antigravity"];
+      const valid: ClientId[] = ["claude-code", "codex", "gemini", "cursor", "antigravity", "pi"];
       if (!valid.includes(clientOpt as ClientId)) {
-        console.error(`Unknown client: ${clientOpt}. Valid: claude-code, codex, gemini, cursor, antigravity, all, none`);
+        console.error(`Unknown client: ${clientOpt}. Valid: claude-code, codex, gemini, cursor, antigravity, pi, all, none`);
         process.exit(1);
       }
       selectedClients.push(clientOpt as ClientId);
@@ -4290,6 +4291,11 @@ program
               case "gemini": result = wireGemini({ ...mcpEnv, FLAIR_CLIENT: "gemini" }); break;
               case "cursor": result = wireCursor({ ...mcpEnv, FLAIR_CLIENT: "cursor" }); break;
               case "antigravity": result = wireAntigravity({ ...mcpEnv, FLAIR_CLIENT: "antigravity" }); break;
+              // pi is a NATIVE EXTENSION, not an MCP client (flair#1342):
+              // wirePi edits ~/.pi/agent/settings.json `packages`, and pi
+              // settings carry no env block — no FLAIR_CLIENT to stamp; the
+              // wire message tells the user what to export at pi launch.
+              case "pi": result = wirePi(mcpEnv); break;
               default: result = { ok: false, message: `Unknown client: ${clientId}` };
             }
             wiringResults.push({ client: clientId, message: result.message, wired: result.ok });
@@ -4302,7 +4308,12 @@ program
       // Launch flair-mcp and confirm it answers a JSON-RPC initialize over
       // stdio. Best-effort: failures warn but never fail the command. Skipped
       // with --skip-smoke, --no-mcp, --client none, or when nothing was wired.
-      if (!opts.skipSmoke && !noMcp && clientOpt !== "none" && wiringResults.length > 0) {
+      // pi doesn't run flair-mcp (native extension, flair#1342), so a pi-only
+      // wiring has nothing this smoke test exercises — spawning it anyway
+      // would render a green "MCP server responded" for a setup that never
+      // starts an MCP server.
+      const wiredAnyMcpClient = wiringResults.some((r) => r.client !== "pi");
+      if (!opts.skipSmoke && !noMcp && clientOpt !== "none" && wiringResults.length > 0 && wiredAnyMcpClient) {
         console.log("\n   Smoke-testing MCP server...");
         try {
           // Same spec that gets WIRED above — the smoke test must exercise the
@@ -14045,11 +14056,13 @@ program
 
     // 7. Client integration (flair#588) — the first 6 checks diagnose the
     // SERVER side. This diagnoses whether Flair is actually wired to a real
-    // MCP client (Claude Code, Codex, Gemini, Cursor): the MCP block present
-    // + reachable + the configured agent genuinely registered (every detected
-    // client), plus CLAUDE.md + the SessionStart hook (Claude Code only,
-    // since only Claude Code has those mechanisms). Reuses detectClients()
-    // rather than reimplementing client detection.
+    // client: for MCP clients (Claude Code, Codex, Gemini, Cursor,
+    // Antigravity) the MCP block present + reachable + the configured agent
+    // genuinely registered; for pi (a NATIVE EXTENSION host — flair#1342) the
+    // pi-flair reference in pi's own settings, including the flair#1346
+    // npm:-under-"extensions" trap; plus CLAUDE.md + the SessionStart hook
+    // (Claude Code only, since only Claude Code has those mechanisms). Reuses
+    // detectClients() rather than reimplementing client detection.
     console.log(`\n  ${render.wrap(render.c.bold, "Client integration")}`);
 
     // Prompt y/N before a content-editing fix, but only when interactive —
@@ -14084,6 +14097,163 @@ program
       }
 
       for (const client of detectedClients) {
+        // ── pi (flair#1342): NATIVE EXTENSION, not an MCP client ───────────
+        // There is no mcpServers block to read — pi loads @tpsdev-ai/pi-flair
+        // through its own settings.json (`packages`). Every check below is a
+        // filesystem fact except agent registration, which is only checkable
+        // when this shell exposes the env pi would launch with — and the
+        // output says which of the two it verified.
+        if (client.kind === "native-extension") {
+          let pi = checkPiFlairWiring(homedir(), process.cwd());
+
+          // --fix for pi needs no agent id (pi settings carry no env block);
+          // a resolvable id only improves the export hint in the message.
+          const wirePiFix = async (prompt: string): Promise<void> => {
+            if (dryRun) {
+              console.log(`     ${render.wrap(render.c.dim, "Would update")} ${pi.settingsPath}`);
+              return;
+            }
+            const proceed = await confirmFix(prompt);
+            if (!proceed) {
+              console.log(`     Skipped.`);
+              return;
+            }
+            const hintAgentId = resolveFixAgentId({
+              optsAgent: opts.agent,
+              envAgentId: process.env.FLAIR_AGENT_ID,
+              anyKnownAgentId,
+              keyAgentIds,
+              keysDir: defaultKeysDir(),
+            }) ?? "<your-agent-id>";
+            const wireResult = wirePi({ FLAIR_AGENT_ID: hintAgentId, FLAIR_URL: baseUrl });
+            console.log(`     ${wireResult.ok ? render.icons.ok : render.icons.warn} ${wireResult.message}`);
+            if (wireResult.ok) fixed++;
+          };
+
+          // (a) The flair#1346 trap FIRST, and by NAME: an npm: spec under
+          // "extensions" is silently ignored by pi — the user believes they
+          // are wired while pi registers zero tools. This is the documented
+          // field failure mode and must never fold into a generic "not
+          // wired": the fix is a MOVE to "packages", not an add.
+          const userTraps = pi.misconfigured.filter((m) => m.path === pi.settingsPath);
+          const projectTraps = pi.misconfigured.filter((m) => m.path !== pi.settingsPath);
+          for (const bad of pi.misconfigured) {
+            console.log(`  ${render.icons.error} pi: ${PI_FLAIR_PACKAGE} is listed under "extensions" as an npm: spec (${bad.entry}) in ${render.wrap(render.c.dim, bad.path)}`);
+            console.log(`     pi silently ignores npm: specs under "extensions", so the Flair tools never register (flair#1346). Package sources belong under "packages".`);
+            issues++;
+          }
+          if (userTraps.length > 0) {
+            if (autoFix) {
+              await wirePiFix(`  Move the npm: spec to "packages" in ${pi.settingsPath} now? [y/N] `);
+              // Re-derive the wiring from disk so the sections below reason
+              // about the POST-fix state — otherwise a move that just
+              // succeeded would still read as "not wired" and prompt again.
+              pi = checkPiFlairWiring(homedir(), process.cwd());
+            } else {
+              console.log(`     ${render.wrap(render.c.dim, "Fix:")} flair doctor --fix ${render.wrap(render.c.dim, `(moves it to "packages")`)}`);
+            }
+          }
+          if (projectTraps.length > 0) {
+            // wirePi edits the USER-scope settings only — a project-scope
+            // trap gets the exact manual fix, never a --fix that claims a
+            // file it does not touch.
+            console.log(`     ${render.wrap(render.c.dim, "Fix:")} move the entry from "extensions" to "packages" in ${projectTraps[0]!.path}`);
+          }
+
+          if (!pi.wired) {
+            console.log(`  ${render.icons.error} pi: ${PI_FLAIR_PACKAGE} not wired in ${render.wrap(render.c.dim, pi.settingsPath)}`);
+            if (autoFix) {
+              await wirePiFix(`  Wire pi now (adds ${piFlairSpec()} to "packages" in ${pi.settingsPath})? [y/N] `);
+            } else {
+              console.log(`     ${render.wrap(render.c.dim, "Fix:")} flair doctor --fix ${render.wrap(render.c.dim, `(adds ${piFlairSpec()} to "packages")`)} — or: pi install npm:${PI_FLAIR_PACKAGE}`);
+            }
+            issues++;
+            continue;
+          }
+
+          if (pi.wiredVia === "packages") {
+            console.log(`  ${render.icons.ok} pi: ${PI_FLAIR_PACKAGE} wired via "packages" (${pi.spec}) in ${render.wrap(render.c.dim, pi.wiredIn!)}`);
+            if (!pi.pinnedVersion) {
+              console.log(`     ${render.icons.info} unpinned — pi re-resolves latest on (re)install; pin with ${piFlairSpec()}`);
+            }
+          } else {
+            // extension-path: the documented pre-0.49 workaround (a local
+            // path to the installed dist/index.js). Works, but the canonical
+            // form is a "packages" entry — and a DANGLING path is a broken
+            // wiring pi skips silently, so check the one thing checkable.
+            if (pi.extensionPathExists) {
+              console.log(`  ${render.icons.ok} pi: ${PI_FLAIR_PACKAGE} wired via a file-path "extensions" entry (${pi.spec}) in ${render.wrap(render.c.dim, pi.wiredIn!)}`);
+              console.log(`     ${render.wrap(render.c.dim, `pre-0.49 workaround — the canonical form is a "packages" entry: ${piFlairSpec()}`)}`);
+            } else {
+              console.log(`  ${render.icons.error} pi: the "extensions" entry ${pi.spec} in ${render.wrap(render.c.dim, pi.wiredIn!)} points at a file that does not exist — pi silently skips missing extension paths`);
+              if (autoFix) {
+                await wirePiFix(`  Wire pi via "packages" instead (adds ${piFlairSpec()})? [y/N] `);
+              } else {
+                console.log(`     ${render.wrap(render.c.dim, "Fix:")} flair doctor --fix ${render.wrap(render.c.dim, `(adds ${piFlairSpec()} to "packages"; remove the dangling entry yourself)`)}`);
+              }
+              issues++;
+              continue;
+            }
+          }
+
+          // Env sanity (flair#1342 scope 3). pi settings carry no env block:
+          // pi-flair reads FLAIR_* from the environment of whatever shell/IDE
+          // launches pi. Doctor can only see ITS OWN environment — these
+          // lines verify this shell, and say so, rather than pretending to
+          // verify every pi launch. None of them counts as an issue: a clean
+          // pi launched elsewhere can be fine while this shell is bare, and
+          // vice versa.
+          console.log(`     ${render.wrap(render.c.dim, "pi-flair reads FLAIR_AGENT_ID / FLAIR_URL / FLAIR_KEY_PATH from the shell that launches pi — doctor sees only its own environment (this shell):")}`);
+          const piEnvAgent = process.env.FLAIR_AGENT_ID;
+          const piEnvUrl = process.env.FLAIR_URL;
+          const piEnvKey = process.env.FLAIR_KEY_PATH;
+          if (piEnvAgent) {
+            console.log(`     ${render.icons.ok} FLAIR_AGENT_ID set ('${piEnvAgent}')`);
+          } else {
+            console.log(`     ${render.icons.warn} FLAIR_AGENT_ID not set in this shell — pi-flair falls back to the cwd directory name as its agent id (identity varies by project); export FLAIR_AGENT_ID=<id> where pi is launched`);
+          }
+          if (piEnvUrl) {
+            console.log(`     ${render.icons.ok} FLAIR_URL set (${piEnvUrl})`);
+          } else {
+            console.log(`     ${render.icons.info} FLAIR_URL not set — pi-flair defaults to ${render.wrap(render.c.dim, PI_FLAIR_DEFAULT_URL)}`);
+          }
+          if (piEnvKey) {
+            if (existsSync(piEnvKey)) {
+              console.log(`     ${render.icons.ok} FLAIR_KEY_PATH set (${piEnvKey})`);
+            } else {
+              console.log(`     ${render.icons.warn} FLAIR_KEY_PATH points at a missing file (${piEnvKey})`);
+            }
+          } else {
+            console.log(`     ${render.icons.info} FLAIR_KEY_PATH not set — auto-resolved from ~/.flair/keys`);
+          }
+
+          // Agent registration — checkable only when this shell exposes an
+          // agent id at all; otherwise say what was NOT verified instead of
+          // skipping silently.
+          if (piEnvAgent) {
+            const piUrl = piEnvUrl || PI_FLAIR_DEFAULT_URL;
+            const piReachable = await probeFlairReachable(piUrl);
+            if (!piReachable) {
+              console.log(`     ${render.icons.warn} FLAIR_URL ${render.wrap(render.c.dim, piUrl)} not reachable — cannot verify agent registration`);
+            } else {
+              const piReg = await checkAgentRegistered(piUrl, piEnvAgent, defaultKeysDir());
+              if (piReg.state === "registered") {
+                console.log(`     ${render.icons.ok} agent '${piEnvAgent}' registered`);
+              } else if (piReg.state === "not-registered") {
+                console.log(`     ${render.icons.error} agent '${piEnvAgent}' is NOT registered on this Flair instance`);
+                console.log(`        ${render.wrap(render.c.dim, "Fix:")} flair agent add ${piEnvAgent}`);
+                issues++;
+              } else {
+                const piFinding = describeAgentGateFinding(piEnvAgent, piReg.state, piReg.detail, { instanceReachable: piReachable });
+                console.log(`     ${render.icons.warn} ${piFinding?.message ?? `could not verify agent registration (${piReg.detail})`}`);
+              }
+            }
+          } else {
+            console.log(`     ${render.wrap(render.c.dim, "agent registration not verified — no FLAIR_AGENT_ID visible to doctor")}`);
+          }
+          continue;
+        }
+
         const block = readClientMcpBlock(client.id, homedir());
         if (client.id === "claude-code" && block.agentId) claudeCodeAgentId = block.agentId;
         if (block.agentId) anyKnownAgentId = anyKnownAgentId ?? block.agentId;

--- a/src/doctor-client.ts
+++ b/src/doctor-client.ts
@@ -23,7 +23,15 @@
 import { spawnSync } from "node:child_process";
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { dirname, join } from "node:path";
-import { ALL_CLIENTS, clientConfigPath, type ClientId } from "./install/clients.js";
+import {
+  ALL_CLIENTS,
+  clientConfigPath,
+  piSettingsPath,
+  resolvePiExtensionPath,
+  scanPiSettings,
+  type ClientId,
+  type PiSettingsScan,
+} from "./install/clients.js";
 import { FLAIR_MCP_PACKAGE } from "./lib/mcp-spec.js";
 
 // The exact substring `flair init` writes into CLAUDE.md (src/cli.ts, the
@@ -691,6 +699,102 @@ function scanCodexFlairBlock(raw: string): { present: boolean; agentId?: string;
   // docs/mcp-clients.md's own Codex snippet sets only FLAIR_AGENT_ID.
   const present = !!agentId;
   return { present, agentId, flairUrl, urlDefaulted: present && !flairUrl };
+}
+
+// ── check 1b: pi native-extension wiring (flair#1342) ───────────────────────
+//
+// pi is in the client registry but is NOT an MCP client (kind:
+// "native-extension") — it loads @tpsdev-ai/pi-flair through its own
+// settings.json, so the mcpServers machinery above cannot see its wiring.
+// This is the pi twin of readClientMcpBlock: pure fs, never throws, malformed
+// input reads as "not present".
+//
+// WHAT DOCTOR CAN AND CANNOT CHECK FOR PI — stated here once, because the
+// rendering in cli.ts leans on it:
+//
+//   CAN  — pi presence (registry detection: `pi` on PATH or the settings file);
+//          whether pi-flair is referenced, WHERE (packages vs extensions), and
+//          the pinned version when the packages source carries one;
+//          the flair#1346 trap: an `npm:` spec under `extensions`, which pi
+//          silently ignores — reported as its own finding with the exact fix
+//          (move to `packages`), never folded into a generic "not wired";
+//          whether a file-path extensions entry resolves to a real file.
+//   CANNOT — the environment pi actually launches with. pi settings carry no
+//          per-package env, so FLAIR_AGENT_ID/FLAIR_URL/FLAIR_KEY_PATH come
+//          from whatever shell/IDE starts pi. Doctor sees only ITS OWN env and
+//          must say so when reporting env sanity — a green "FLAIR_AGENT_ID
+//          set" line proves this shell, not pi's.
+
+export interface PiFlairWiringReport {
+  /** User-scope settings path (~/.pi/agent/settings.json or the
+   *  PI_CODING_AGENT_DIR override) — reported even when absent. */
+  settingsPath: string;
+  /** Every settings file consulted, with existence — user scope always,
+   *  project scope (<cwd>/.pi/settings.json) when a cwd was given. */
+  checked: Array<{ path: string; exists: boolean }>;
+  wired: boolean;
+  /** How it is wired: a `packages` npm source (canonical) or a file-path
+   *  `extensions` entry (the documented pre-0.49 workaround). */
+  wiredVia: "packages" | "extension-path" | null;
+  /** The settings file the wiring was found in. */
+  wiredIn?: string;
+  /** The verbatim source/path entry that wires it. */
+  spec?: string;
+  pinnedVersion: string | null;
+  /** extension-path wiring only: does the resolved file exist? A dangling
+   *  path is a broken wiring pi skips silently. */
+  extensionPathExists?: boolean;
+  /** flair#1346 trap instances: npm: pi-flair specs under `extensions`,
+   *  by file. Reported independently of `wired` — a correct packages entry
+   *  does not launder a decoy that will mislead the next editor. */
+  misconfigured: Array<{ path: string; entry: string }>;
+}
+
+export function checkPiFlairWiring(homeDir: string, cwd?: string): PiFlairWiringReport {
+  const userPath = withHome(homeDir, () => piSettingsPath());
+  const files: Array<{ path: string; baseDir: string }> = [
+    // pi resolves user-scope relative paths against the agent dir (the
+    // settings file's own directory), project-scope against the project dir.
+    { path: userPath, baseDir: dirname(userPath) },
+  ];
+  if (cwd) files.push({ path: join(cwd, ".pi", "settings.json"), baseDir: cwd });
+
+  const report: PiFlairWiringReport = {
+    settingsPath: userPath,
+    checked: [],
+    wired: false,
+    wiredVia: null,
+    pinnedVersion: null,
+    misconfigured: [],
+  };
+
+  for (const file of files) {
+    const raw = readTextFile(file.path);
+    report.checked.push({ path: file.path, exists: raw !== null });
+    const scan: PiSettingsScan = scanPiSettings(raw);
+    for (const entry of scan.misconfiguredNpmUnderExtensions) {
+      report.misconfigured.push({ path: file.path, entry });
+    }
+    if (report.wired) continue; // first wiring found wins; keep collecting traps
+    if (scan.packagesSpec) {
+      report.wired = true;
+      report.wiredVia = "packages";
+      report.wiredIn = file.path;
+      report.spec = scan.packagesSpec;
+      report.pinnedVersion = scan.pinnedVersion;
+      continue;
+    }
+    if (scan.extensionFilePaths.length > 0) {
+      const entry = scan.extensionFilePaths[0]!;
+      report.wired = true;
+      report.wiredVia = "extension-path";
+      report.wiredIn = file.path;
+      report.spec = entry;
+      report.extensionPathExists = existsSync(resolvePiExtensionPath(entry, homeDir, file.baseDir));
+    }
+  }
+
+  return report;
 }
 
 // ── check 2: FLAIR_URL to use when (re-)wiring a client (flair#727) ────────

--- a/src/install/clients.ts
+++ b/src/install/clients.ts
@@ -1,9 +1,12 @@
 // ─── Client Detection & Wiring ──────────────────────────────────────────────────────
 //
-// Detects locally installed MCP clients and wires them to Flair.
-// Each client has:
-//   - detect(): boolean - returns true if client is installed
-//   - wire(options: { agentId: string; flairUrl: string }): { ok: boolean; message: string }
+// Detects locally installed clients and wires them to Flair. Most are MCP
+// clients (kind: "mcp" — wired via an mcpServers block/TOML table running
+// @tpsdev-ai/flair-mcp); pi is a native-extension host (kind:
+// "native-extension" — wired via pi's own settings.json `packages` key,
+// flair#1342). Each client has:
+//   - detection: `bin` on PATH, optionally widened by a declared detect() override
+//   - wire(env): { ok: boolean; message: string }
 //
 // Wiring contract (FIX 4 — onboarding dogfood round 1):
 //   "wired" MUST mean a config file was actually written. A wire function returns
@@ -14,7 +17,7 @@
 //   All paths are resolved cross-platform (Linux included) via standard
 //   per-client locations under $HOME / $XDG_CONFIG_HOME.
 
-export type ClientId = "claude-code" | "codex" | "gemini" | "cursor" | "antigravity";
+export type ClientId = "claude-code" | "codex" | "gemini" | "cursor" | "antigravity" | "pi";
 
 /**
  * The env block every wire function writes into a client's MCP server config.
@@ -34,7 +37,28 @@ export interface Client {
   label: string;
   /** The executable that has to be on PATH for this client to be usable. */
   bin: string;
+  /**
+   * How this client consumes Flair (flair#1342):
+   *   "mcp"              — runs @tpsdev-ai/flair-mcp via an MCP server config
+   *                        (mcpServers block / TOML table). readClientMcpBlock
+   *                        and the MCP-pin machinery apply.
+   *   "native-extension" — loads a Flair-shipped extension through the client's
+   *                        own plugin mechanism (pi + @tpsdev-ai/pi-flair — pi
+   *                        has no MCP client support). The MCP-pin machinery
+   *                        does NOT apply; wiring/checking is client-specific.
+   * Callers that iterate ALL_CLIENTS for MCP-shaped work MUST filter on this
+   * rather than assuming every registry entry has an mcpServers block.
+   */
+  kind: "mcp" | "native-extension";
   detected: boolean;
+  /**
+   * Optional detection override. Default detection is `bin` on PATH (one rule,
+   * see detectClients); a client whose presence is ALSO evidenced by a config
+   * file (pi: ~/.pi/agent/settings.json survives PATH quirks like a version
+   * manager or launchd context) declares that here. Must stay a pure
+   * filesystem check — detection never spawns a subprocess (flair#946).
+   */
+  detect?: () => boolean;
   wire: (env: WireEnv) => { ok: boolean; message: string };
 }
 
@@ -43,7 +67,7 @@ export interface Client {
 import { accessSync, constants, existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { dirname, join } from "node:path";
-import { mcpServerSpec } from "../lib/mcp-spec.js";
+import { flairCliVersion, isResolvedVersion, mcpServerSpec } from "../lib/mcp-spec.js";
 
 /**
  * Resolve the user's home dir. Prefer the live HOME/USERPROFILE env over
@@ -296,6 +320,305 @@ function codexConfigPath(): string {
   return join(resolveHome(), ".codex", "config.toml");
 }
 
+// ---- pi (native extension — NOT an MCP client) ------------------------------------
+//
+// pi has no MCP client support (packages/pi-flair/README "Design Decision"), so
+// Flair ships @tpsdev-ai/pi-flair as a NATIVE pi extension. Wiring pi therefore
+// means editing pi's OWN settings, not writing an mcpServers block (flair#1342):
+//
+//   ~/.pi/agent/settings.json          (user scope; pi's getSettingsPath() —
+//                                       agent dir overridable via the
+//                                       PI_CODING_AGENT_DIR env var, honored here)
+//   <project>/.pi/settings.json        (project scope)
+//
+// Two settings keys matter, and confusing them is the flair#1346 field failure:
+//
+//   "packages"    — package SOURCES (`npm:`, `git:`, local paths, or
+//                   { source, ...filters } objects). pi parses these through
+//                   parseSource() and AUTO-INSTALLS a missing/mismatched npm
+//                   package at resource collection (package-manager.js
+//                   resolvePackageSources), honoring an exact `@<version>` pin.
+//                   This is where npm:@tpsdev-ai/pi-flair belongs.
+//   "extensions"  — local FILE PATHS only. An `npm:` spec here is treated as a
+//                   path, fails existsSync, and is dropped WITHOUT ERROR — the
+//                   user believes they are wired and pi registers zero tools.
+//                   (Verified against pi 0.84.2's package-manager.js: the
+//                   extensions override list feeds resolvePathFromBase/
+//                   collectFilesFromPaths, never parseSource.)
+//
+// pi-flair reads FLAIR_AGENT_ID / FLAIR_URL / FLAIR_KEY_PATH from the process
+// environment of the pi that loads it — pi settings carry NO per-package env
+// block, so wiring here cannot pin an agent identity the way the MCP clients'
+// env blocks do. Wire messages say so instead of pretending.
+
+/** The npm package pi loads as its Flair extension. */
+export const PI_FLAIR_PACKAGE = "@tpsdev-ai/pi-flair";
+
+/**
+ * pi-flair's own DEFAULT_FLAIR_URL (packages/pi-flair/src/index.ts). Duplicated
+ * as a value rather than imported — the CLI does not depend on the pi-flair
+ * workspace package — by the same convention as doctor-client's
+ * FLAIR_CLIENT_DEFAULT_URL; a unit test (pi-client.test.ts) asserts this
+ * literal matches pi-flair's source so the two cannot drift silently.
+ */
+export const PI_FLAIR_DEFAULT_URL = "http://127.0.0.1:19926";
+
+/**
+ * The `packages` entry a wired pi gets. PINNED for the same reason as
+ * mcpServerSpec (flair#907): pi re-resolves an unpinned npm source to latest
+ * when (re)installing, and pi-flair ships in version lockstep with the CLI.
+ * Falls back to the bare spec when the CLI cannot read its own version — the
+ * same condition and caller-owed warning as mcpServerSpec.
+ */
+export function piFlairSpec(version: string = flairCliVersion()): string {
+  return isResolvedVersion(version)
+    ? `npm:${PI_FLAIR_PACKAGE}@${version}`
+    : `npm:${PI_FLAIR_PACKAGE}`;
+}
+
+/** pi's agent config dir: $PI_CODING_AGENT_DIR, else ~/.pi/agent (pi config.js). */
+function piAgentDir(): string {
+  const envDir = process.env.PI_CODING_AGENT_DIR;
+  if (envDir) return envDir;
+  return join(resolveHome(), ".pi", "agent");
+}
+
+/** pi user-scope settings: <agent dir>/settings.json. */
+export function piSettingsPath(): string {
+  return join(piAgentDir(), "settings.json");
+}
+
+/** A pi `packages` array entry is a source string or `{ source, ...filters }`. */
+export function piPackageEntrySource(entry: unknown): string | null {
+  if (typeof entry === "string") return entry;
+  if (entry && typeof entry === "object" && typeof (entry as { source?: unknown }).source === "string") {
+    return (entry as { source: string }).source;
+  }
+  return null;
+}
+
+/** Does this source string name the pi-flair package as an npm source
+ *  (bare `npm:@tpsdev-ai/pi-flair` or any `npm:@tpsdev-ai/pi-flair@<spec>`)? */
+export function isPiFlairNpmSource(source: string): boolean {
+  if (typeof source !== "string" || !source.startsWith("npm:")) return false;
+  const spec = source.slice("npm:".length).trim();
+  return spec === PI_FLAIR_PACKAGE || spec.startsWith(`${PI_FLAIR_PACKAGE}@`);
+}
+
+/** The version text of a pinned pi-flair npm source, or null when bare. */
+export function extractPiFlairPin(source: string): string | null {
+  if (!isPiFlairNpmSource(source)) return null;
+  const spec = source.slice("npm:".length).trim();
+  const version = spec.slice(`${PI_FLAIR_PACKAGE}@`.length);
+  return spec.startsWith(`${PI_FLAIR_PACKAGE}@`) && version ? version : null;
+}
+
+/**
+ * Does this `extensions` entry point at pi-flair BY PATH (the documented
+ * pre-0.49 workaround: a local path to the installed dist/index.js)? A
+ * substring heuristic on the package/directory name — the entry is user-
+ * written free text, so this is deliberately loose in the direction of
+ * REPORTING (doctor names the entry it matched); it never gates anything
+ * destructive.
+ */
+export function isPiFlairExtensionPath(entry: string): boolean {
+  if (typeof entry !== "string" || entry.startsWith("npm:") || entry.startsWith("git:")) return false;
+  return entry.includes("pi-flair");
+}
+
+/** What one pi settings file says about pi-flair. Pure — callers do the fs. */
+export interface PiSettingsScan {
+  /** File content parsed as a JSON object (false: missing/malformed/non-object). */
+  parsed: boolean;
+  /** The pi-flair source found under `packages`, verbatim. */
+  packagesSpec?: string;
+  /** Version from a pinned packages entry; null when bare or absent. */
+  pinnedVersion: string | null;
+  /** pi-flair FILE-PATH entries under `extensions` (the pre-0.49 workaround). */
+  extensionFilePaths: string[];
+  /** pi-flair `npm:` specs under `extensions` — pi silently ignores these
+   *  (flair#1346, the known field failure); doctor calls them out by name. */
+  misconfiguredNpmUnderExtensions: string[];
+}
+
+export function scanPiSettings(raw: string | null): PiSettingsScan {
+  const empty: PiSettingsScan = { parsed: false, pinnedVersion: null, extensionFilePaths: [], misconfiguredNpmUnderExtensions: [] };
+  if (!raw || !raw.trim()) return empty;
+  let config: unknown;
+  try {
+    config = JSON.parse(raw);
+  } catch {
+    return empty;
+  }
+  if (!config || typeof config !== "object" || Array.isArray(config)) return empty;
+  const cfg = config as { packages?: unknown; extensions?: unknown };
+
+  let packagesSpec: string | undefined;
+  let pinnedVersion: string | null = null;
+  if (Array.isArray(cfg.packages)) {
+    for (const entry of cfg.packages) {
+      const source = piPackageEntrySource(entry);
+      if (source && isPiFlairNpmSource(source)) {
+        packagesSpec = source;
+        pinnedVersion = extractPiFlairPin(source);
+        break;
+      }
+    }
+  }
+
+  const extensionFilePaths: string[] = [];
+  const misconfiguredNpmUnderExtensions: string[] = [];
+  if (Array.isArray(cfg.extensions)) {
+    for (const entry of cfg.extensions) {
+      if (typeof entry !== "string") continue;
+      if (isPiFlairNpmSource(entry)) misconfiguredNpmUnderExtensions.push(entry);
+      else if (isPiFlairExtensionPath(entry)) extensionFilePaths.push(entry);
+    }
+  }
+
+  return { parsed: true, packagesSpec, pinnedVersion, extensionFilePaths, misconfiguredNpmUnderExtensions };
+}
+
+/**
+ * Resolve a pi `extensions` path entry the way pi's loader will: `~/` against
+ * the home dir, a relative path against the settings file's own base dir, an
+ * absolute path as-is. `baseDir` is the directory pi treats as the scope's
+ * base (user scope: the agent dir).
+ */
+export function resolvePiExtensionPath(entry: string, homeDir: string, baseDir: string): string {
+  if (entry.startsWith("~/") || entry === "~") return join(homeDir, entry.slice(1));
+  if (entry.startsWith("/")) return entry;
+  return join(baseDir, entry);
+}
+
+/** Pretty-printed minimal settings snippet for copy-paste fallbacks. */
+function piJsonSnippet(): string {
+  return JSON.stringify({ packages: [piFlairSpec()] }, null, 2);
+}
+
+/**
+ * Wire pi by editing ~/.pi/agent/settings.json `packages` (flair#1342) — the
+ * same merge/idempotence/preservation contract as wireJsonMcp: sibling keys
+ * and entries survive byte-identical, a current entry is a no-op, a stale pin
+ * is refreshed, and ok:true means the file was actually written (or already
+ * correct). Two pi-specific rules on top:
+ *
+ *   • an `npm:` pi-flair spec under `extensions` is MOVED to `packages` — that
+ *     misplacement is silently ignored by pi (flair#1346), so leaving it while
+ *     adding a packages entry would preserve a decoy;
+ *   • an existing FILE-PATH `extensions` entry that resolves to a real file is
+ *     honored as already-wired (the documented pre-0.49 workaround) — the user
+ *     may deliberately be running a local build, so it is reported, not
+ *     rewritten.
+ *
+ * `env` is used for the launch-environment hint only: pi settings have no
+ * per-package env block, so FLAIR_AGENT_ID/FLAIR_URL must be exported by
+ * whatever shell launches pi — the message says so rather than implying the
+ * wiring carried them.
+ */
+function _wirePi(env: WireEnv): { ok: boolean; message: string } {
+  const path = piSettingsPath();
+  const home = resolveHome();
+  const display = path.startsWith(home) ? "~" + path.slice(home.length) : path;
+  const spec = piFlairSpec();
+  const envHint = `pi settings carry no env — export FLAIR_AGENT_ID=${env.FLAIR_AGENT_ID} in the shell that launches pi`;
+  try {
+    let config: any = {};
+    if (existsSync(path)) {
+      const raw = readFileSync(path, "utf-8").trim();
+      if (raw) config = JSON.parse(raw);
+    }
+    if (!config || typeof config !== "object" || Array.isArray(config)) {
+      throw new Error("settings.json is not a JSON object");
+    }
+    if (config.packages !== undefined && !Array.isArray(config.packages)) {
+      throw new Error(`"packages" exists but is not an array — not rewriting it`);
+    }
+    if (config.extensions !== undefined && !Array.isArray(config.extensions)) {
+      throw new Error(`"extensions" exists but is not an array — not rewriting it`);
+    }
+
+    // The #1346 trap: npm: pi-flair specs under `extensions`. Collect + drop.
+    let movedFromExtensions = false;
+    if (Array.isArray(config.extensions)) {
+      const kept = config.extensions.filter(
+        (e: unknown) => !(typeof e === "string" && isPiFlairNpmSource(e)),
+      );
+      movedFromExtensions = kept.length !== config.extensions.length;
+      if (movedFromExtensions) config.extensions = kept;
+    }
+
+    // Existing packages entry?
+    let entryIndex = -1;
+    let entrySource: string | null = null;
+    if (Array.isArray(config.packages)) {
+      for (let i = 0; i < config.packages.length; i++) {
+        const source = piPackageEntrySource(config.packages[i]);
+        if (source && isPiFlairNpmSource(source)) {
+          entryIndex = i;
+          entrySource = source;
+          break;
+        }
+      }
+    }
+
+    if (!movedFromExtensions && entrySource === spec) {
+      return { ok: true, message: `pi: already wired in ${display} (${spec})` };
+    }
+
+    if (!movedFromExtensions && entryIndex === -1) {
+      // No packages entry and nothing misplaced — honor a working file-path
+      // extensions entry (pre-0.49 workaround) instead of double-wiring.
+      const scan = scanPiSettings(JSON.stringify(config));
+      const workingPath = scan.extensionFilePaths.find((p) =>
+        existsSync(resolvePiExtensionPath(p, home, piAgentDir())),
+      );
+      if (workingPath) {
+        return {
+          ok: true,
+          message:
+            `pi: already wired via a file-path extension in ${display} (${workingPath}) — ` +
+            `the pre-0.49 workaround; the canonical form is a "packages" entry: ${spec}`,
+        };
+      }
+    }
+
+    config.packages = Array.isArray(config.packages) ? config.packages : [];
+    let action: string;
+    if (entryIndex >= 0) {
+      const entry = config.packages[entryIndex];
+      if (typeof entry === "string") config.packages[entryIndex] = spec;
+      else entry.source = spec; // object entry: refresh source, keep filters
+      action = movedFromExtensions
+        ? `moved ${PI_FLAIR_PACKAGE} out of "extensions" and refreshed the "packages" pin in`
+        : "refreshed pin in";
+    } else if (movedFromExtensions) {
+      config.packages.push(spec);
+      action = `moved ${PI_FLAIR_PACKAGE} from "extensions" to "packages" in`;
+    } else {
+      config.packages.push(spec);
+      action = "wired";
+    }
+
+    mkdirSync(dirname(path), { recursive: true });
+    writeFileSync(path, JSON.stringify(config, null, 2) + "\n");
+    const trapNote = movedFromExtensions
+      ? ` — pi silently ignores npm: specs under "extensions" (flair#1346)`
+      : "";
+    return {
+      ok: true,
+      message: `pi: ${action} ${display} (${spec} — pi installs the package on next launch; ${envHint})${trapNote}`,
+    };
+  } catch (err: unknown) {
+    const reason = err instanceof Error ? err.message : String(err);
+    return {
+      ok: false,
+      message: `pi: manual wiring needed (could not update ${display}: ${reason}).\n` +
+        `   Add this to ${display} (${envHint}):\n${indent(piJsonSnippet())}`,
+    };
+  }
+}
+
 /**
  * Antigravity CLI (`agy`) + Antigravity 2.0 IDE + SDK: they share ONE central
  * MCP config at ~/.gemini/config/mcp_config.json on every OS (flair#1209).
@@ -332,6 +655,11 @@ export function clientConfigPath(id: ClientId): string {
       return cursorConfigPath();
     case "antigravity":
       return antigravityConfigPath();
+    case "pi":
+      // NOT an MCP config: pi's own settings.json, where the pi-flair
+      // native-extension wiring lives (flair#1342). readClientMcpBlock over
+      // this file correctly reports "no MCP block" — pi never has one.
+      return piSettingsPath();
   }
 }
 
@@ -420,24 +748,28 @@ export const ALL_CLIENTS: Omit<Client, "detected">[] = [
     id: "claude-code",
     label: "Claude Code",
     bin: "claude",
+    kind: "mcp",
     wire: _wireClaudeCode,
   },
   {
     id: "codex",
     label: "Codex",
     bin: "codex",
+    kind: "mcp",
     wire: _wireCodex,
   },
   {
     id: "gemini",
     label: "Gemini",
     bin: "gemini",
+    kind: "mcp",
     wire: _wireGemini,
   },
   {
     id: "cursor",
     label: "Cursor",
     bin: "cursor",
+    kind: "mcp",
     wire: _wireCursor,
   },
   {
@@ -445,7 +777,22 @@ export const ALL_CLIENTS: Omit<Client, "detected">[] = [
     label: "Antigravity",
     // Google's Antigravity CLI — the executable is `agy` (flair#1209).
     bin: "agy",
+    kind: "mcp",
     wire: _wireAntigravity,
+  },
+  {
+    id: "pi",
+    label: "pi",
+    bin: "pi",
+    // NOT an MCP client — pi loads @tpsdev-ai/pi-flair as a native extension
+    // via its settings.json `packages` key (flair#1342). Consumers doing
+    // MCP-shaped work must filter on `kind`.
+    kind: "native-extension",
+    // pi is also detected by its settings file: a configured pi whose binary
+    // isn't on THIS shell's PATH (version manager, launchd context) is still
+    // a pi whose wiring is worth checking/fixing. Pure fs check, both legs.
+    detect: () => detectBin("pi") || existsSync(piSettingsPath()),
+    wire: _wirePi,
   },
 ];
 
@@ -531,14 +878,17 @@ export function renderWiringSummary(
 }
 
 /**
- * Detect every known client. One rule (`bin` on PATH) applied uniformly, so a
- * client added to ALL_CLIENTS is detected by declaring its executable — there is
- * no per-client branch here to forget to extend.
+ * Detect every known client. One rule (`bin` on PATH) applied uniformly — a
+ * client added to ALL_CLIENTS is detected by declaring its executable, with no
+ * per-client branch here to forget to extend. A client may widen that with a
+ * declared `detect` override (still a pure fs check — pi adds its settings
+ * file as a second signal, flair#1342); the override lives on the registry
+ * entry, so this function stays branch-free.
  */
 export function detectClients(): Client[] {
   return ALL_CLIENTS.map((client) => ({
     ...client,
-    detected: detectBin(client.bin),
+    detected: client.detect ? client.detect() : detectBin(client.bin),
   }));
 }
 
@@ -570,4 +920,10 @@ export function wireAntigravity(
   env: WireEnv
 ): { ok: boolean; message: string } {
   return _wireAntigravity(env);
+}
+
+export function wirePi(
+  env: WireEnv
+): { ok: boolean; message: string } {
+  return _wirePi(env);
 }

--- a/test/unit/clients-pin-refresh.test.ts
+++ b/test/unit/clients-pin-refresh.test.ts
@@ -107,8 +107,10 @@ function readCodexPin(): string | null {
 // ── JSON clients (Gemini, Cursor, Claude Code fallback) ────────────────────
 
 describe("flair#1135 — JSON client pin refresh (wireJsonMcp)", () => {
-  // Test every JSON-based client (all except Codex, which uses TOML).
-  const jsonClients = ALL_CLIENTS.filter(c => c.id !== "codex");
+  // Test every JSON-based MCP client (all except Codex, which uses TOML, and
+  // pi, which is a native-extension host with no mcpServers block — its pin
+  // refresh is covered in test/unit/pi-client.test.ts, flair#1342).
+  const jsonClients = ALL_CLIENTS.filter(c => c.id !== "codex" && c.kind === "mcp");
 
   for (const client of jsonClients) {
     describe(client.label, () => {

--- a/test/unit/doctor-client-native-shapes.test.ts
+++ b/test/unit/doctor-client-native-shapes.test.ts
@@ -145,7 +145,15 @@ const ANTIGRAVITY_NATIVE = `{
   }
 }`;
 
-const NATIVE_FIXTURES: Record<ClientId, string> = {
+// pi is in the registry but is NOT an MCP client (kind: "native-extension",
+// flair#1342) — it has no mcpServers block for readClientMcpBlock to accept,
+// so it has no fixture here BY DESIGN. Its native-shape coverage (settings.json
+// `packages`/`extensions`, including the flair#1346 npm:-under-extensions trap)
+// lives in test/unit/pi-client.test.ts.
+type McpClientId = Exclude<ClientId, "pi">;
+const MCP_CLIENTS = ALL_CLIENTS.filter((c) => c.kind === "mcp");
+
+const NATIVE_FIXTURES: Record<McpClientId, string> = {
   "claude-code": CLAUDE_CODE_NATIVE,
   codex: CODEX_NATIVE,
   gemini: GEMINI_NATIVE,
@@ -153,7 +161,7 @@ const NATIVE_FIXTURES: Record<ClientId, string> = {
   antigravity: ANTIGRAVITY_NATIVE,
 };
 
-const WIRE_FNS: Record<ClientId, (env: WireEnv) => { ok: boolean; message: string }> = {
+const WIRE_FNS: Record<McpClientId, (env: WireEnv) => { ok: boolean; message: string }> = {
   "claude-code": wireClaudeCode,
   codex: wireCodex,
   gemini: wireGemini,
@@ -192,7 +200,7 @@ function withHomeEnv<T>(home: string, fn: () => T): T {
   }
 }
 
-function writeNativeFixture(home: string, clientId: ClientId): string {
+function writeNativeFixture(home: string, clientId: McpClientId): string {
   const path = withHomeEnv(home, () => clientConfigPath(clientId));
   mkdirSync(dirname(path), { recursive: true });
   writeFileSync(path, NATIVE_FIXTURES[clientId]);
@@ -202,7 +210,7 @@ function writeNativeFixture(home: string, clientId: ClientId): string {
 /** Run OUR wire function for `clientId` against a fresh HOME and return the
  *  exact file bytes it wrote — the "our generator" side of every drift
  *  assertion. */
-function ourWireOutput(clientId: ClientId): string {
+function ourWireOutput(clientId: McpClientId): string {
   const wireHome = mkdtempSync(join(tmpdir(), "flair-wire-out-"));
   try {
     return withHomeEnv(wireHome, () => {
@@ -220,12 +228,16 @@ function ourWireOutput(clientId: ClientId): string {
 // ── the per-client suites ───────────────────────────────────────────────────
 
 describe("doctor recognizes client-NATIVE MCP config shapes (flair#1287)", () => {
-  it("carries a client-native fixture for EVERY registry client — a new ALL_CLIENTS entry must add one", () => {
-    expect(Object.keys(NATIVE_FIXTURES).sort()).toEqual(ALL_CLIENTS.map((c) => c.id).sort());
+  it("carries a client-native fixture for EVERY MCP registry client — a new mcp-kind ALL_CLIENTS entry must add one", () => {
+    // Filtered on kind, not on a hardcoded id list: a future MCP client is
+    // still forced to add a fixture, while a native-extension client (pi —
+    // no mcpServers block exists for it, flair#1342) is excluded by its
+    // declared kind rather than by someone remembering to exempt it here.
+    expect(Object.keys(NATIVE_FIXTURES).sort()).toEqual(MCP_CLIENTS.map((c) => c.id).sort());
   });
 
-  for (const client of ALL_CLIENTS) {
-    const id = client.id;
+  for (const client of MCP_CLIENTS) {
+    const id = client.id as McpClientId;
 
     it(`${id}: accepts the client-native shape — present, agent read, URL defaulted`, () => {
       writeNativeFixture(isoHome, id);

--- a/test/unit/mcp-spec-pinning.test.ts
+++ b/test/unit/mcp-spec-pinning.test.ts
@@ -54,10 +54,13 @@ afterEach(() => {
 });
 
 describe("every client writer pins the MCP spec (flair#907)", () => {
-  // Iterating ALL_CLIENTS rather than naming four clients is deliberate: a
-  // client added later is covered without anyone remembering to extend this
-  // test, which is the exact failure mode that produced the bug.
-  for (const client of ALL_CLIENTS) {
+  // Iterating the registry rather than naming clients is deliberate: a client
+  // added later is covered without anyone remembering to extend this test,
+  // which is the exact failure mode that produced the bug. Filtered on kind:
+  // pi (native-extension, flair#1342) never writes an MCP spec at all — its
+  // own pin discipline (npm:@tpsdev-ai/pi-flair@<version> in pi's `packages`)
+  // is asserted in test/unit/pi-client.test.ts.
+  for (const client of ALL_CLIENTS.filter((c) => c.kind === "mcp")) {
     it(`${client.label}: writes a pinned spec into its real config file`, () => {
       const res = client.wire({ ...ENV, FLAIR_CLIENT: client.id });
       expect(res.ok).toBe(true);

--- a/test/unit/pi-client.test.ts
+++ b/test/unit/pi-client.test.ts
@@ -1,0 +1,443 @@
+// flair#1342 — doctor/init know pi: detection, native-extension wiring, and
+// the flair#1346 misconfiguration callout.
+//
+// pi is NOT an MCP client (packages/pi-flair/README "Design Decision") — it
+// loads @tpsdev-ai/pi-flair through its own settings.json:
+//
+//   "packages"    package SOURCES (npm:/git:/local, or { source, ...filters })
+//                 — where npm:@tpsdev-ai/pi-flair belongs; pi auto-installs a
+//                 missing/mismatched npm package at startup and honors an
+//                 exact @<version> pin (pi 0.84.2 package-manager.js,
+//                 resolvePackageSources).
+//   "extensions"  local FILE PATHS only — an npm: spec here is treated as a
+//                 path, fails existsSync, and is dropped WITHOUT ERROR. That
+//                 silent drop is the flair#1346 field failure these tests
+//                 mutation-check: the same spec under "extensions" must
+//                 trigger the callout; moved to "packages" it must read clean.
+//
+// HONESTY: these tests exercise settings-path resolution, scanning, and the
+// wire/check round-trip. End-to-end pickup by a live pi (auto-install +
+// tool registration) was verified for the npm: packages route in flair#1348's
+// validation, not re-run here.
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import { chmodSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  ALL_CLIENTS,
+  clientConfigPath,
+  detectClients,
+  extractPiFlairPin,
+  isPiFlairNpmSource,
+  piFlairSpec,
+  piSettingsPath,
+  PI_FLAIR_DEFAULT_URL,
+  PI_FLAIR_PACKAGE,
+  scanPiSettings,
+  wirePi,
+} from "../../src/install/clients.ts";
+import { checkPiFlairWiring } from "../../src/doctor-client.ts";
+
+const ENV = { FLAIR_AGENT_ID: "wirebot", FLAIR_URL: "http://127.0.0.1:19926" };
+
+/** This repo's real version, read straight from package.json — the pin the
+ *  wire function must write (pi-flair ships in lockstep with the CLI).
+ *  Independent of piFlairSpec() so a regression that unpins BOTH writer and
+ *  helper still fails here. */
+const PKG_VERSION: string = JSON.parse(
+  readFileSync(join(import.meta.dirname, "..", "..", "package.json"), "utf-8"),
+).version;
+
+const PINNED_SPEC = `npm:${PI_FLAIR_PACKAGE}@${PKG_VERSION}`;
+
+let isoHome: string;
+let prevHome: string | undefined;
+let prevPath: string | undefined;
+let prevPiDir: string | undefined;
+
+beforeEach(() => {
+  isoHome = mkdtempSync(join(tmpdir(), "flair-pi-home-"));
+  prevHome = process.env.HOME;
+  process.env.HOME = isoHome;
+  // Detection reads PATH live (binInPath) and piSettingsPath honors
+  // PI_CODING_AGENT_DIR — pin both so a host with a real pi install (or a
+  // pi dir override) can never leak into these tests.
+  prevPath = process.env.PATH;
+  prevPiDir = process.env.PI_CODING_AGENT_DIR;
+  delete process.env.PI_CODING_AGENT_DIR;
+});
+
+afterEach(() => {
+  if (prevHome !== undefined) process.env.HOME = prevHome;
+  else delete process.env.HOME;
+  if (prevPath !== undefined) process.env.PATH = prevPath;
+  else delete process.env.PATH;
+  if (prevPiDir !== undefined) process.env.PI_CODING_AGENT_DIR = prevPiDir;
+  else delete process.env.PI_CODING_AGENT_DIR;
+  rmSync(isoHome, { recursive: true, force: true });
+});
+
+function userSettingsPath(): string {
+  return join(isoHome, ".pi", "agent", "settings.json");
+}
+
+function writeUserSettings(config: unknown): string {
+  const path = userSettingsPath();
+  mkdirSync(join(isoHome, ".pi", "agent"), { recursive: true });
+  writeFileSync(path, typeof config === "string" ? config : JSON.stringify(config, null, 2));
+  return path;
+}
+
+/** Put an executable named `pi` in an isolated dir and make it the whole PATH. */
+function fakePiOnPath(): void {
+  const binDir = join(isoHome, "bin");
+  mkdirSync(binDir, { recursive: true });
+  const p = join(binDir, "pi");
+  writeFileSync(p, "#!/bin/sh\nexit 0\n");
+  chmodSync(p, 0o755);
+  process.env.PATH = binDir;
+}
+
+// ── registry ────────────────────────────────────────────────────────────────
+
+describe("pi client registration (flair#1342)", () => {
+  it("is in the client registry as a native extension with the `pi` bin", () => {
+    const pi = ALL_CLIENTS.find((c) => c.id === "pi");
+    expect(pi).toBeDefined();
+    expect(pi!.bin).toBe("pi");
+    expect(pi!.label).toBe("pi");
+    // The load-bearing field: every MCP-shaped consumer (doctor's mcpServers
+    // loop, the pin machinery, the native-shape fixtures) filters on this.
+    expect(pi!.kind).toBe("native-extension");
+  });
+
+  it("clientConfigPath resolves to pi's OWN settings, ~/.pi/agent/settings.json", () => {
+    expect(clientConfigPath("pi")).toBe(userSettingsPath());
+  });
+
+  it("honors pi's PI_CODING_AGENT_DIR override, matching pi's getAgentDir()", () => {
+    const custom = join(isoHome, "custom-agent-dir");
+    process.env.PI_CODING_AGENT_DIR = custom;
+    expect(piSettingsPath()).toBe(join(custom, "settings.json"));
+  });
+
+  it("PI_FLAIR_DEFAULT_URL matches pi-flair's own DEFAULT_FLAIR_URL (drift guard)", () => {
+    const source = readFileSync(
+      join(import.meta.dirname, "..", "..", "packages", "pi-flair", "src", "index.ts"),
+      "utf-8",
+    );
+    expect(source).toContain(`DEFAULT_FLAIR_URL = "${PI_FLAIR_DEFAULT_URL}"`);
+  });
+});
+
+// ── detection ───────────────────────────────────────────────────────────────
+
+describe("pi detection: binary on PATH OR settings file (flair#1342)", () => {
+  function detectedPi(): boolean {
+    return detectClients().find((c) => c.id === "pi")!.detected;
+  }
+
+  it("not detected with neither the binary nor a settings file", () => {
+    process.env.PATH = join(isoHome, "empty");
+    expect(detectedPi()).toBe(false);
+  });
+
+  it("detected via the `pi` binary on PATH", () => {
+    fakePiOnPath();
+    expect(detectedPi()).toBe(true);
+  });
+
+  it("detected via ~/.pi/agent/settings.json alone — a configured pi whose bin escapes this shell's PATH is still checkable", () => {
+    process.env.PATH = join(isoHome, "empty");
+    writeUserSettings({ packages: [] });
+    expect(detectedPi()).toBe(true);
+  });
+});
+
+// ── source / scan helpers ───────────────────────────────────────────────────
+
+describe("pi settings scanning (flair#1342 / #1346)", () => {
+  it("recognizes pi-flair npm sources, bare and pinned — and not lookalikes", () => {
+    expect(isPiFlairNpmSource(`npm:${PI_FLAIR_PACKAGE}`)).toBe(true);
+    expect(isPiFlairNpmSource(`npm:${PI_FLAIR_PACKAGE}@0.48.0`)).toBe(true);
+    // Not npm: → not an npm source (it may be a valid PATH entry).
+    expect(isPiFlairNpmSource(`${PI_FLAIR_PACKAGE}`)).toBe(false);
+    // A different package sharing the prefix must not match.
+    expect(isPiFlairNpmSource(`npm:${PI_FLAIR_PACKAGE}-extras`)).toBe(false);
+    expect(isPiFlairNpmSource("npm:@tpsdev-ai/flair-mcp@0.48.0")).toBe(false);
+  });
+
+  it("extracts the pin from a pinned source and null from a bare one", () => {
+    expect(extractPiFlairPin(`npm:${PI_FLAIR_PACKAGE}@0.48.0`)).toBe("0.48.0");
+    expect(extractPiFlairPin(`npm:${PI_FLAIR_PACKAGE}`)).toBeNull();
+  });
+
+  it("piFlairSpec pins to this checkout's version", () => {
+    expect(piFlairSpec()).toBe(PINNED_SPEC);
+    expect(piFlairSpec("0.30.0")).toBe(`npm:${PI_FLAIR_PACKAGE}@0.30.0`);
+    // The unresolvable-version fallback is bare, never a broken pin.
+    expect(piFlairSpec("unknown")).toBe(`npm:${PI_FLAIR_PACKAGE}`);
+  });
+
+  it("finds a pinned packages entry (string form)", () => {
+    const scan = scanPiSettings(JSON.stringify({ packages: [`npm:${PI_FLAIR_PACKAGE}@0.48.0`] }));
+    expect(scan.parsed).toBe(true);
+    expect(scan.packagesSpec).toBe(`npm:${PI_FLAIR_PACKAGE}@0.48.0`);
+    expect(scan.pinnedVersion).toBe("0.48.0");
+    expect(scan.misconfiguredNpmUnderExtensions).toEqual([]);
+  });
+
+  it("finds a bare packages entry with a null pin", () => {
+    const scan = scanPiSettings(JSON.stringify({ packages: [`npm:${PI_FLAIR_PACKAGE}`] }));
+    expect(scan.packagesSpec).toBe(`npm:${PI_FLAIR_PACKAGE}`);
+    expect(scan.pinnedVersion).toBeNull();
+  });
+
+  it("finds an object packages entry ({ source, ...filters }) — pi's documented entry shape", () => {
+    const scan = scanPiSettings(
+      JSON.stringify({ packages: [{ source: `npm:${PI_FLAIR_PACKAGE}@0.48.0`, autoload: false }] }),
+    );
+    expect(scan.packagesSpec).toBe(`npm:${PI_FLAIR_PACKAGE}@0.48.0`);
+    expect(scan.pinnedVersion).toBe("0.48.0");
+  });
+
+  it("classifies a file-path extensions entry as the (working) pre-0.49 workaround, not a misconfiguration", () => {
+    const scan = scanPiSettings(
+      JSON.stringify({ extensions: [`~/.pi/agent/npm/node_modules/${PI_FLAIR_PACKAGE}/dist/index.js`] }),
+    );
+    expect(scan.extensionFilePaths.length).toBe(1);
+    expect(scan.misconfiguredNpmUnderExtensions).toEqual([]);
+  });
+
+  // ── the flair#1346 mutation check ─────────────────────────────────────────
+  // The detector must fire on the EXACT field failure (npm: under
+  // "extensions") and must go quiet when the one thing that is wrong is
+  // fixed (the same spec moved to "packages"). A detector that fires on both
+  // shapes, or on neither, is a check that cannot fire.
+
+  it("MUTANT: an npm: spec under `extensions` triggers the flair#1346 callout", () => {
+    const scan = scanPiSettings(JSON.stringify({ extensions: [`npm:${PI_FLAIR_PACKAGE}`] }));
+    expect(scan.misconfiguredNpmUnderExtensions).toEqual([`npm:${PI_FLAIR_PACKAGE}`]);
+    // And it is NOT simultaneously counted as working wiring.
+    expect(scan.packagesSpec).toBeUndefined();
+    expect(scan.extensionFilePaths).toEqual([]);
+  });
+
+  it("FIXED: the identical spec under `packages` reads clean", () => {
+    const scan = scanPiSettings(JSON.stringify({ packages: [`npm:${PI_FLAIR_PACKAGE}`] }));
+    expect(scan.misconfiguredNpmUnderExtensions).toEqual([]);
+    expect(scan.packagesSpec).toBe(`npm:${PI_FLAIR_PACKAGE}`);
+  });
+
+  it("malformed JSON reads as not-parsed, never throws", () => {
+    const scan = scanPiSettings("{ this is not json");
+    expect(scan.parsed).toBe(false);
+    expect(scan.packagesSpec).toBeUndefined();
+  });
+
+  it("unrelated packages/extensions entries are ignored", () => {
+    const scan = scanPiSettings(
+      JSON.stringify({
+        packages: ["npm:@some/other-package@1.0.0", { source: "git:github.com/x/y" }],
+        extensions: ["./extensions/mine.ts", "npm:@some/other-package"],
+      }),
+    );
+    expect(scan.packagesSpec).toBeUndefined();
+    expect(scan.extensionFilePaths).toEqual([]);
+    expect(scan.misconfiguredNpmUnderExtensions).toEqual([]);
+  });
+});
+
+// ── wiring ──────────────────────────────────────────────────────────────────
+
+describe("wirePi — settings.json `packages` with the wireJsonMcp discipline (flair#1342)", () => {
+  it("fresh wire: creates the file with a pinned packages entry and an honest env hint", () => {
+    const res = wirePi(ENV);
+    expect(res.ok).toBe(true);
+    const cfg = JSON.parse(readFileSync(userSettingsPath(), "utf-8"));
+    expect(cfg.packages).toEqual([PINNED_SPEC]);
+    // pi settings carry no env block — the message must put the launch-env
+    // burden where it lives instead of implying the wiring carried it.
+    expect(res.message).toContain("export FLAIR_AGENT_ID=wirebot");
+    // And never the MCP clients' confident restart claim.
+    expect(res.message).not.toContain("restart");
+  });
+
+  it("is idempotent: second run is a byte-identical no-op", () => {
+    wirePi(ENV);
+    const before = readFileSync(userSettingsPath(), "utf-8");
+    const second = wirePi(ENV);
+    expect(second.ok).toBe(true);
+    expect(second.message).toContain("already wired");
+    expect(readFileSync(userSettingsPath(), "utf-8")).toBe(before);
+  });
+
+  it("preserves sibling keys and other packages entries", () => {
+    writeUserSettings({
+      theme: "dark",
+      packages: ["npm:@some/other-package@1.0.0"],
+      extensions: ["./extensions/mine.ts"],
+    });
+    const res = wirePi(ENV);
+    expect(res.ok).toBe(true);
+    const cfg = JSON.parse(readFileSync(userSettingsPath(), "utf-8"));
+    expect(cfg.theme).toBe("dark");
+    expect(cfg.packages).toEqual(["npm:@some/other-package@1.0.0", PINNED_SPEC]);
+    expect(cfg.extensions).toEqual(["./extensions/mine.ts"]);
+  });
+
+  it("refreshes a stale pin (flair#1135 discipline)", () => {
+    writeUserSettings({ packages: [`npm:${PI_FLAIR_PACKAGE}@0.1.0`] });
+    const res = wirePi(ENV);
+    expect(res.ok).toBe(true);
+    expect(res.message).toContain("refreshed pin");
+    const cfg = JSON.parse(readFileSync(userSettingsPath(), "utf-8"));
+    expect(cfg.packages).toEqual([PINNED_SPEC]);
+  });
+
+  it("refreshes an object entry's source in place, preserving its filters", () => {
+    writeUserSettings({ packages: [{ source: `npm:${PI_FLAIR_PACKAGE}@0.1.0`, autoload: false }] });
+    const res = wirePi(ENV);
+    expect(res.ok).toBe(true);
+    const cfg = JSON.parse(readFileSync(userSettingsPath(), "utf-8"));
+    expect(cfg.packages).toEqual([{ source: PINNED_SPEC, autoload: false }]);
+  });
+
+  it("MOVES an npm: spec out of `extensions` into `packages` — the flair#1346 fix, named", () => {
+    writeUserSettings({ extensions: [`npm:${PI_FLAIR_PACKAGE}`, "./extensions/mine.ts"] });
+    const res = wirePi(ENV);
+    expect(res.ok).toBe(true);
+    expect(res.message).toContain("flair#1346");
+    const cfg = JSON.parse(readFileSync(userSettingsPath(), "utf-8"));
+    // The decoy is gone, the sibling survives, packages carries the pin.
+    expect(cfg.extensions).toEqual(["./extensions/mine.ts"]);
+    expect(cfg.packages).toEqual([PINNED_SPEC]);
+    // And the post-fix state reads clean + wired — the wire-side twin of the
+    // scanner mutation check above.
+    const after = checkPiFlairWiring(isoHome);
+    expect(after.misconfigured).toEqual([]);
+    expect(after.wired).toBe(true);
+    expect(after.wiredVia).toBe("packages");
+  });
+
+  it("honors a WORKING file-path extensions entry as already wired (pre-0.49 workaround), touching nothing", () => {
+    const extFile = join(isoHome, "pi-flair-dist", "index.js");
+    mkdirSync(join(isoHome, "pi-flair-dist"), { recursive: true });
+    writeFileSync(extFile, "// pi-flair build\n");
+    writeUserSettings({ extensions: [extFile] });
+    const before = readFileSync(userSettingsPath(), "utf-8");
+    const res = wirePi(ENV);
+    expect(res.ok).toBe(true);
+    expect(res.message).toContain("file-path extension");
+    expect(res.message).toContain("packages");
+    expect(readFileSync(userSettingsPath(), "utf-8")).toBe(before);
+  });
+
+  it("a DANGLING file-path entry is not treated as wired — wires packages alongside it", () => {
+    writeUserSettings({ extensions: [join(isoHome, "gone", "pi-flair", "index.js")] });
+    const res = wirePi(ENV);
+    expect(res.ok).toBe(true);
+    const cfg = JSON.parse(readFileSync(userSettingsPath(), "utf-8"));
+    expect(cfg.packages).toEqual([PINNED_SPEC]);
+  });
+
+  it("refuses malformed JSON with the manual snippet — never clobbers", () => {
+    writeUserSettings("{ broken");
+    const res = wirePi(ENV);
+    expect(res.ok).toBe(false);
+    expect(res.message).toContain("manual wiring needed");
+    expect(res.message).toContain(`"${PINNED_SPEC}"`);
+    // Original bytes intact.
+    expect(readFileSync(userSettingsPath(), "utf-8")).toBe("{ broken");
+  });
+
+  it("refuses a non-array `packages` key — never rewrites a shape it does not understand", () => {
+    writeUserSettings({ packages: { weird: true } });
+    const res = wirePi(ENV);
+    expect(res.ok).toBe(false);
+    expect(res.message).toContain("manual wiring needed");
+    const cfg = JSON.parse(readFileSync(userSettingsPath(), "utf-8"));
+    expect(cfg.packages).toEqual({ weird: true });
+  });
+});
+
+// ── doctor's wiring check ───────────────────────────────────────────────────
+
+describe("checkPiFlairWiring — what doctor reports for pi (flair#1342)", () => {
+  it("round-trips wirePi output: wired via packages, current pin", () => {
+    wirePi(ENV);
+    const report = checkPiFlairWiring(isoHome);
+    expect(report.wired).toBe(true);
+    expect(report.wiredVia).toBe("packages");
+    expect(report.wiredIn).toBe(userSettingsPath());
+    expect(report.pinnedVersion).toBe(PKG_VERSION);
+    expect(report.misconfigured).toEqual([]);
+  });
+
+  it("no settings anywhere: not wired, and the checked paths are named", () => {
+    const report = checkPiFlairWiring(isoHome);
+    expect(report.wired).toBe(false);
+    expect(report.settingsPath).toBe(userSettingsPath());
+    expect(report.checked).toEqual([{ path: userSettingsPath(), exists: false }]);
+  });
+
+  it("flags the flair#1346 trap with file and entry — and does NOT report it as wired", () => {
+    const path = writeUserSettings({ extensions: [`npm:${PI_FLAIR_PACKAGE}@0.48.0`] });
+    const report = checkPiFlairWiring(isoHome);
+    expect(report.misconfigured).toEqual([{ path, entry: `npm:${PI_FLAIR_PACKAGE}@0.48.0` }]);
+    expect(report.wired).toBe(false);
+  });
+
+  it("a correct packages entry does not launder a coexisting extensions decoy — both are reported", () => {
+    writeUserSettings({
+      packages: [PINNED_SPEC],
+      extensions: [`npm:${PI_FLAIR_PACKAGE}`],
+    });
+    const report = checkPiFlairWiring(isoHome);
+    expect(report.wired).toBe(true);
+    expect(report.wiredVia).toBe("packages");
+    expect(report.misconfigured.length).toBe(1);
+  });
+
+  it("extension-path wiring: reports whether the file actually exists", () => {
+    const extFile = join(isoHome, "pi-flair-dist", "index.js");
+    mkdirSync(join(isoHome, "pi-flair-dist"), { recursive: true });
+    writeFileSync(extFile, "// build\n");
+    writeUserSettings({ extensions: [extFile] });
+    const wired = checkPiFlairWiring(isoHome);
+    expect(wired.wiredVia).toBe("extension-path");
+    expect(wired.extensionPathExists).toBe(true);
+
+    rmSync(extFile);
+    const dangling = checkPiFlairWiring(isoHome);
+    expect(dangling.wiredVia).toBe("extension-path");
+    expect(dangling.extensionPathExists).toBe(false);
+  });
+
+  it("resolves a ~/ extension path against the given home", () => {
+    mkdirSync(join(isoHome, "dist"), { recursive: true });
+    writeFileSync(join(isoHome, "dist", "pi-flair.js"), "// build\n");
+    writeUserSettings({ extensions: ["~/dist/pi-flair.js"] });
+    const report = checkPiFlairWiring(isoHome);
+    expect(report.wiredVia).toBe("extension-path");
+    expect(report.extensionPathExists).toBe(true);
+  });
+
+  it("project-scope .pi/settings.json wires too (pi merges both scopes)", () => {
+    const project = join(isoHome, "project");
+    mkdirSync(join(project, ".pi"), { recursive: true });
+    writeFileSync(join(project, ".pi", "settings.json"), JSON.stringify({ packages: [PINNED_SPEC] }));
+    const report = checkPiFlairWiring(isoHome, project);
+    expect(report.wired).toBe(true);
+    expect(report.wiredIn).toBe(join(project, ".pi", "settings.json"));
+    expect(report.checked.length).toBe(2);
+  });
+
+  it("a malformed settings file reads as not wired, never a throw", () => {
+    writeUserSettings("not json at all");
+    const report = checkPiFlairWiring(isoHome);
+    expect(report.wired).toBe(false);
+    expect(report.checked[0]!.exists).toBe(true);
+  });
+});


### PR DESCRIPTION
Closes #1342

pi was the one shipped client `flair doctor` and `flair init` could not see. This adds it following the #1209 (Antigravity) registry pattern, adapted for a **native extension**: pi has no MCP client support, so pi-flair wires through pi's own `settings.json` `packages` key, never an `mcpServers` block.

## What changed

**Registry (`src/install/clients.ts`)** — pi joins `ALL_CLIENTS` with a new load-bearing `kind: "mcp" | "native-extension"` field. Every MCP-shaped consumer (doctor's mcpServers loop, the native-shape fixture suite, the pin suites) now filters on `kind` instead of assuming the registry is homogeneous — a future native-extension client gets the same treatment without a hardcoded exemption list.

**Detection** — `pi` binary on PATH **or** `~/.pi/agent/settings.json` present (a configured pi whose bin escapes this shell's PATH is still worth checking). Pure fs, no subprocess (the #946 rule); honors `PI_CODING_AGENT_DIR` exactly as pi's own `getAgentDir()` does (read from pi 0.84.2 `config.js`).

**Wiring (`flair init --client pi`, `doctor --fix`)** — `wirePi` edits `settings.json` `packages` with the `wireJsonMcp` discipline: pinned `npm:@tpsdev-ai/pi-flair@<version>` (lockstep with the CLI, #907 rationale — pi honors exact-version pins and auto-installs at startup, verified in pi 0.84.2 `package-manager.js` `resolvePackageSources`), idempotent byte-identical no-op, sibling keys/entries preserved, object entries (`{ source, ...filters }`) refreshed in place, refuses shapes it does not understand with the manual snippet. A working file-path `extensions` entry (the pre-0.49 workaround) is honored as already-wired, not rewritten.

**The #1346 trap is a named finding** — an `npm:` spec under `extensions` is *silently ignored* by pi (`extensions` takes local file paths only; the entry fails `existsSync` and is dropped without error — verified against pi 0.84.2 source). Doctor prints the exact misconfiguration with the exact fix, and `--fix` **moves** the entry to `packages`, then re-derives the wiring from disk so the post-fix state renders truthfully:

```
✗ pi: @tpsdev-ai/pi-flair is listed under "extensions" as an npm: spec (npm:@tpsdev-ai/pi-flair) in ~/.pi/agent/settings.json
   pi silently ignores npm: specs under "extensions", so the Flair tools never register (flair#1346). Package sources belong under "packages".
   Fix: flair doctor --fix (moves it to "packages")
```

## What doctor CAN and CANNOT check for pi

CAN: pi presence; whether pi-flair is referenced, **where** (`packages` vs `extensions`), and the pinned version; the #1346 misplacement as its own finding (independent of `wired` — a correct packages entry does not launder a coexisting decoy); whether a file-path extensions entry resolves to a real file.

CANNOT: the environment pi actually launches with. pi settings carry no per-package env block, so `FLAIR_AGENT_ID`/`FLAIR_URL`/`FLAIR_KEY_PATH` come from whatever shell/IDE starts pi. Doctor verifies **its own shell** and says so in the output ("doctor sees only its own environment"); agent registration is verified only when an agent id is visible to doctor, and the not-verified case is stated rather than skipped silently. Env findings are never counted as issues — a clean pi launched elsewhere can be fine while this shell is bare, and vice versa.

Also honest: `flair init`'s MCP smoke test is skipped for a pi-only wiring (it would spawn flair-mcp, which pi never runs, and render a green line for a setup that starts no MCP server).

## Verification

- **Full unit lane: 4976 pass / 0 fail across 257 files** (self-measured baseline on origin/main in the same worktree: 4940 / 0 / 256 — the +36 are exactly the new pi suite).
- **Mutation checks on the #1346 detector**, both directions: silenced detector (never pushes) → 3 tests fail; undiscriminating detector (fires on `packages` too) → 8 tests fail; restored → 36/36 green.
- **Live end-to-end** against an isolated HOME with the real host pi on PATH: trap fixture → callout rendered; `doctor --fix` (non-TTY) → entry moved, settings file confirmed `{"extensions": [], "packages": ["npm:@tpsdev-ai/pi-flair@0.48.0"]}`, re-derived state renders wired; second run with `FLAIR_AGENT_ID` exported → env lines flip to set, registration probe attempted and honestly reported unreachable (no Flair in that env).
- Ground truth for pi behavior read from pi 0.84.2 source (`config.js` settings path + agent-dir override; `package-manager.js` packages parsing/auto-install vs extensions path-only resolution) — consistent with the #1346 investigation and #1348 validation. End-to-end pickup by a live pi of the npm: packages route was verified in #1348, not re-run here.
- Docs: `mcp-clients.md` gains "What about pi?"; `integrations.md` Pi agent section rewritten around the real wiring shape. Changelog fragment `added-1342-pi-doctor-init.md` (fragments check passes).

No merge, no review requests — per dispatch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
