### PR TITLE
quality: recall spot-check becomes report-only; fix the cue; guard the sample (#967)

### DIFF
--- a/.changelog/unreleased/fixed-967-recall-spotcheck-precision.md
+++ b/.changelog/unreleased/fixed-967-recall-spotcheck-precision.md
@@ -1,0 +1,26 @@
+- **The nightly quality sweep's recall spot-check is report-only — it no longer
+  emits `quality.regression` events (flair#967).** Measured over 32 nightly runs
+  on a production instance, the metric's population σ was 0.291 and its mean
+  absolute run-to-run delta 0.223, against a `QUALITY_EVENT_RECALL_DROP_THRESHOLD`
+  of 0.2 — the alarm sat at 0.69σ, below the metric's own noise floor — and all 6
+  findings-mails the sweep had ever produced in 34 runs were this metric
+  oscillating. Lifetime precision: 0. The threshold literal is deliberately left
+  at 0.2: alerting authority was removed from a metric that never earned it, not
+  widened until it stopped talking. Recall regressions are detected by the
+  deterministic, fixed-label, CI-gated eval
+  (`test/integration-heavy/recall-eval-gate.test.ts`); `flair quality` still
+  computes, prints and snapshots recall@k/MRR for observability.
+
+  Two changes also make the retained number worth reading. `deriveRecallCue` no
+  longer hands an opaque slug (`pr-1359`, `kern-2026-08-23`, or the sweep's own
+  `quality-snapshot/<host>`) to semantic search as if it were a query — a
+  same-instant A/B over the same ten memories scored recall@5 0.60 / MRR 0.16
+  from subjects versus 1.00 / 0.78 from content — so a subject is used as the cue
+  only when it is discriminative, and otherwise the leading words of the memory's
+  content are. And a sampled window that cannot be scored fairly (two memories
+  deriving the same cue, so they must displace each other in one result list, or
+  a memory with no derivable cue at all) is now reported as UNHEALTHY with a
+  self-describing reason instead of being scored anyway. The spot-check also
+  stops grading its own `quality-snapshot` bookkeeping rows, which were a
+  guaranteed miss and a permanent constant penalty on every instance running
+  `flair quality --emit`.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -14928,23 +14928,42 @@ program
 // own id appears in its search's top-k; MRR = mean reciprocal rank (0 if
 // not found within k).
 //
-// Framing — this is a HEALTH SPOT-CHECK, not a benchmark and not a trust
-// judgment. Querying by a cue derived FROM the target memory is easier than
-// a real user query, so a high score means "recall is functioning", not
-// "recall is optimal". Its job is to catch recall CRATERING (embeddings
-// down, index busted) — the score collapsing toward 0 is the signal, not
-// fine-grained precision grading. NOTE (#1216): this cue-from-the-memory
-// design is self-polluting as a recall-QUALITY metric — relevance is
-// query/corpus overlap by construction, so near-duplicate density reads as a
-// recall collapse (flair#967 / #857 / #996). It is deliberately NOT the
-// recall-quality number; that authority is the deterministic, fixed-label,
-// CI-gated eval at test/bench/recall-eval (recall@k / nDCG@10 / MRR). This
-// probe stays scoped to live-health cratering only. Requires an actual
-// agent identity to
-// query AS (semantic search is agent-scoped) — no identity, fewer than the
-// sample-size memories to sample, or a search error all degrade to `null` +
-// a `gaps` entry, same graceful-degradation contract as every metric here —
-// NEVER a false 0.0 masquerading as a real (broken) score.
+// Framing — this is a REPORT-ONLY HEALTH SPOT-CHECK, not a benchmark, not a
+// trust judgment, and (since flair#967) not an alerting signal either.
+// Querying by a cue derived FROM the target memory is easier than a real
+// user query, so a high score means "recall is functioning", not "recall is
+// optimal". NOTE (#1216): this cue-from-the-memory design is self-polluting
+// as a recall-QUALITY metric — relevance is query/corpus overlap by
+// construction, so near-duplicate density reads as a recall collapse
+// (flair#967 / #857 / #996). It is deliberately NOT the recall-quality
+// number; that authority is the deterministic, fixed-label, CI-gated eval at
+// test/bench/recall-eval, wired as a gate in
+// test/integration-heavy/recall-eval-gate.test.ts.
+//
+// flair#967 — WHY THIS METRIC NO LONGER EMITS AN EVENT. Measured on rockit
+// production over 32 nightly runs: population σ = 0.291, mean absolute
+// run-to-run delta = 0.223, against a QUALITY_EVENT_RECALL_DROP_THRESHOLD of
+// 0.2. The alarm sat at 0.69σ — BELOW the metric's own noise floor, so the
+// median night-to-night wobble already exceeded the delta that declared a
+// regression. Replaying diffQualitySnapshots over the stored snapshot series
+// predicts the sweep's 6 findings-mails in 34 runs exactly, 6 for 6, and all
+// six were oscillation: lifetime precision 0. So the emission is gone. The
+// score is still computed, still printed, still snapshotted (history and the
+// cratering signal are both preserved) — it just no longer has the authority
+// to page anyone, because it never once earned it. That authority stays with
+// the deterministic CI gate above, which is fixed-label, hermetic and
+// actually detects ranking regressions. Re-arming this probe is a data
+// question, not a taste question: it needs a measured precision on the FIXED
+// cue derivation first, and a threshold DERIVED from that run-to-run variance
+// (≥2σ on the sample design), not another literal.
+//
+// Requires an actual agent identity to query AS (semantic search is
+// agent-scoped) — no identity, fewer than the sample-size memories to sample,
+// an UNHEALTHY sample (planRecallSpotCheck below: duplicate or empty cues, so
+// the window cannot be scored fairly) or a search error all degrade to `null`
+// + a `gaps` entry, same graceful-degradation contract as every metric here —
+// NEVER a false 0.0 masquerading as a real (broken) score, and never a number
+// quietly computed over a window that could not produce one.
 
 /** First-pass default, same "documented heuristic, not derived from data we
  *  don't have" spirit as health.ts's own 10%-hash-fallback threshold below.
@@ -14968,23 +14987,66 @@ export interface QualityMetricGap {
   reason: string;
 }
 
+/** Leading-word cap on the content-derived cue. 25, matching the arm of the
+ *  flair#967 A/B that was actually measured (same 10 memories, same instance,
+ *  same minute: subject cue → recall@5 0.60 / MRR 0.16; first-25-words-of-
+ *  content cue → 1.00 / 0.78). Still a PARTIAL cue by construction — capped,
+ *  never the whole memory for anything longer than the cap. */
+const RECALL_CUE_CONTENT_WORD_LIMIT = 25;
+
+/**
+ * Is `subject` DISCRIMINATIVE enough to be handed to semantic search as a
+ * query in its own right? (flair#967.)
+ *
+ * The old bar was `length >= 3`, which is a check on whether the subject
+ * EXISTS, not on whether it is a query. Measured consequence: slug-shaped
+ * subjects — `pr-1359`, `kern-2026-08-23`, the spot-check's own
+ * `quality-snapshot/127.0.0.1:9926` — carry almost no semantic signal, so
+ * searching one is a query for nothing in particular (searching `pr-1359` on
+ * rockit production returned, as top-1, a review note about PR #1275 from five
+ * days earlier). Worse, every memory sharing such a subject issues the
+ * IDENTICAL query and gets the IDENTICAL result list, so siblings must
+ * mutually displace each other and all but one are scored as misses no matter
+ * how healthy retrieval is.
+ *
+ * The rule, stated plainly — a subject is used as the cue only when it is:
+ *   1. at least 3 characters (the original bar, kept), AND
+ *   2. NOT opaque-identifier-shaped: an unspaced token carrying a digit or an
+ *      identifier separator (`/ : _ . # @ \`) is a slug, not a phrase.
+ *      Whitespace is the primary discriminator — `Harper 5.2 upgrade` is
+ *      prose and stays a cue; `kern-2026-08-23` is not. A bare hyphen does
+ *      NOT make a slug, so ordinary compounds (`two-gate`) survive, AND
+ *   3. carrying at least one alphabetic run of 3+ characters — a subject with
+ *      no word in it (`---`, `42`) is not a query either.
+ *
+ * Fails CLOSED: anything that isn't clearly a phrase falls back to content,
+ * which the A/B measured as the strictly better cue. Pure — no I/O.
+ */
+export function isDiscriminativeSubject(subject: string | null | undefined): boolean {
+  const s = (subject ?? "").trim();
+  if (s.length < 3) return false;
+  if (!/\s/.test(s) && /[0-9/:_.#@\\]/.test(s)) return false;
+  if (!/[A-Za-z]{3}/.test(s)) return false;
+  return true;
+}
+
 /**
  * Derive a PARTIAL search cue from a memory — used by the recall spot-check
  * (Slice 1d) to query for a memory without handing back its full content.
- * Prefers `subject` when present and non-trivial (a real word or phrase, not
- * empty/whitespace-only padding); otherwise falls back to the first sentence
- * of `content`, capped to the leading ~8 words so the cue stays a genuine
+ * Prefers `subject` ONLY when it is discriminative (isDiscriminativeSubject
+ * above — flair#967); otherwise falls back to the first sentence of
+ * `content`, capped to the leading ~25 words so the cue stays a genuine
  * partial cue rather than the whole memory. Pure — no I/O.
  */
 export function deriveRecallCue(memory: { subject?: string | null; content?: string | null }): string {
   const subject = (memory.subject ?? "").trim();
-  if (subject.length >= 3) return subject;
+  if (isDiscriminativeSubject(subject)) return subject;
   const content = (memory.content ?? "").trim();
   if (!content) return "";
   const sentenceMatch = content.match(/^[^.!?\n]+[.!?]?/);
   const firstSentence = (sentenceMatch ? sentenceMatch[0] : content).trim();
   const words = firstSentence.split(/\s+/).filter(Boolean);
-  const cueWordLimit = 8;
+  const cueWordLimit = RECALL_CUE_CONTENT_WORD_LIMIT;
   return words.length <= cueWordLimit ? firstSentence : words.slice(0, cueWordLimit).join(" ");
 }
 
@@ -15053,6 +15115,121 @@ export interface RecallSpotCheckFetchResult {
   k?: number;
   /** Present when ok is false — why the spot-check was skipped. */
   skipReason?: string;
+  /** Present whenever a window was actually assembled (healthy or not) —
+   *  flair#967's fail-closed sample guard. `healthy: false` is the one skip
+   *  reason that is a statement ABOUT THE SAMPLE rather than about the
+   *  instance, so it's carried structurally, not just in prose. */
+  sampleHealth?: RecallSampleHealth;
+}
+
+/**
+ * Can the sampled window be scored fairly at all? (flair#967, direction 4 in
+ * the issue — "an alert that cannot explain itself cannot be triaged", made
+ * structural.)
+ *
+ * The spot-check scores each sampled memory by searching ONE cue and asking
+ * whether that memory came back. If two sampled memories derive the SAME cue,
+ * they are one query with one answer list, so at most one of them can be found
+ * and the rest are counted as misses no matter how healthy retrieval is. That
+ * is not a low score, it is an UNSCORABLE window — and the honest output is to
+ * say so rather than to publish the number anyway.
+ */
+export interface RecallSampleHealth {
+  healthy: boolean;
+  /** Self-describing, human-readable — becomes the `gaps` entry's reason. */
+  reason?: string;
+  /** The cue values that more than one sampled memory derived. */
+  duplicateCues?: string[];
+  /** How many sampled memories derived NO cue at all (no subject, no content). */
+  emptyCueCount?: number;
+}
+
+/** What planRecallSpotCheck decided: which memories to query, with what cue,
+ *  and whether the resulting window is scorable. */
+export interface RecallSpotCheckPlan {
+  sampled: Array<{ id: string; cue: string }>;
+  health: RecallSampleHealth;
+  /** How many of the tool's own quality-snapshot rows were excluded before
+   *  sampling (flair#967 cause 2 — self-referential bookkeeping is never
+   *  scored: its subject is a hostname slug and its content is boilerplate
+   *  JSON, so it is a guaranteed miss and a permanent constant penalty). */
+  excludedSnapshotRows: number;
+}
+
+/** Rows the spot-check writes itself, and therefore must never grade itself
+ *  on — see RecallSpotCheckPlan['excludedSnapshotRows']. */
+function isQualitySnapshotRow(m: { subject?: string | null; type?: string | null }): boolean {
+  return m?.type === "quality-snapshot" || (m?.subject ?? "").startsWith("quality-snapshot/");
+}
+
+/**
+ * Pure planner for the recall spot-check: raw memory rows → the window to
+ * query (id + cue) plus that window's health. Extracted from
+ * fetchRecallSpotCheckData so the sampling, cue-derivation and
+ * fail-closed health rules are testable without any I/O (flair#967).
+ *
+ * Order of operations, and why:
+ *  1. drop the tool's own quality-snapshot rows (never grade your own
+ *     bookkeeping);
+ *  2. take the `sampleSize` most-recently-written remaining rows (unchanged —
+ *     recency is still the sampling frame; see the issue's direction 3 for the
+ *     stratified-sampling follow-up this deliberately does NOT take on);
+ *  3. derive each cue via deriveRecallCue;
+ *  4. judge the window: any duplicate cue, or any empty cue, makes it
+ *     UNSCORABLE — reported as unhealthy, never silently scored.
+ */
+export function planRecallSpotCheck(
+  memories: Array<{ id?: unknown; subject?: string | null; content?: string | null; createdAt?: string | null; type?: string | null }>,
+  opts: { sampleSize?: number } = {},
+): RecallSpotCheckPlan {
+  const sampleSize = opts.sampleSize ?? QUALITY_RECALL_SAMPLE_SIZE;
+  const rows = Array.isArray(memories) ? memories : [];
+  const scorable = rows.filter((m) => !isQualitySnapshotRow(m ?? {}));
+  const excludedSnapshotRows = rows.length - scorable.length;
+
+  const sorted = scorable.slice().sort((a: any, b: any) => {
+    const ta = a?.createdAt ? new Date(a.createdAt).getTime() : 0;
+    const tb = b?.createdAt ? new Date(b.createdAt).getTime() : 0;
+    return tb - ta;
+  });
+  const sampled = sorted.slice(0, sampleSize).map((m: any) => ({ id: String(m?.id), cue: deriveRecallCue(m ?? {}) }));
+
+  const counts = new Map<string, number>();
+  let emptyCueCount = 0;
+  for (const s of sampled) {
+    if (!s.cue) {
+      emptyCueCount += 1;
+      continue;
+    }
+    counts.set(s.cue, (counts.get(s.cue) ?? 0) + 1);
+  }
+  const duplicateCues = [...counts.entries()].filter(([, n]) => n > 1).map(([cue]) => cue);
+
+  if (duplicateCues.length === 0 && emptyCueCount === 0) {
+    return { sampled, health: { healthy: true }, excludedSnapshotRows };
+  }
+
+  const parts: string[] = [];
+  if (duplicateCues.length > 0) {
+    const shown = duplicateCues.slice(0, 3).map((c) => `"${c.length > 60 ? `${c.slice(0, 57)}...` : c}"`).join(", ");
+    const dupMemberCount = duplicateCues.reduce((n, c) => n + (counts.get(c) ?? 0), 0);
+    parts.push(
+      `${dupMemberCount} of the ${sampled.length} sampled memories derive the same cue as another (${shown}${duplicateCues.length > 3 ? `, +${duplicateCues.length - 3} more` : ""}) — identical cues are one query with one result list, so those memories must displace each other and cannot all be found`,
+    );
+  }
+  if (emptyCueCount > 0) {
+    parts.push(`${emptyCueCount} of the ${sampled.length} sampled memories have no derivable cue (no subject and no content)`);
+  }
+  return {
+    sampled,
+    health: {
+      healthy: false,
+      reason: `sample unhealthy — ${parts.join("; ")}. No score recorded for this run (flair#967: fail closed rather than publish an unscorable number).`,
+      duplicateCues,
+      emptyCueCount,
+    },
+    excludedSnapshotRows,
+  };
 }
 
 export interface QualityAgentActivity {
@@ -15143,9 +15320,15 @@ export interface QualityReport {
    * uses (api() → authedRequest, POST /SemanticSearch) — no new endpoint.
    * `agentId` is the identity the spot-check queried AS (the --agent value,
    * or FLAIR_AGENT_ID). `null` when there's no agent identity to query as,
-   * too few memories to sample, or a search errored — NEVER a false 0.0
-   * masquerading as a real (broken) score; always paired with a `gaps`
-   * entry in that case.
+   * too few scorable memories to sample, the sampled window was UNHEALTHY
+   * (duplicate/empty cues — flair#967's fail-closed guard), or a search
+   * errored — NEVER a false 0.0 masquerading as a real (broken) score, and
+   * never a number computed over a window that could not produce one; always
+   * paired with a `gaps` entry carrying the reason.
+   *
+   * REPORT-ONLY since flair#967: this number is printed and snapshotted for
+   * observability, and emits no OrgEvent at any delta. Recall REGRESSIONS are
+   * detected by test/integration-heavy/recall-eval-gate.test.ts.
    */
   recallSpotCheck: {
     agentId: string | null;
@@ -15399,28 +15582,31 @@ async function fetchRecallSpotCheckData(
     return { ok: false, agentId, skipReason: `could not fetch memories to sample: ${err?.message ?? String(err)}` };
   }
 
-  if (all.length < sampleSize) {
+  // Deterministic sample + cue derivation + fail-closed health judgment, all
+  // pure (planRecallSpotCheck above). Snapshot rows are excluded there, so the
+  // "enough memories" check has to run on the PLANNED window, not on the raw
+  // row count — an instance whose recent writes are mostly the sweep's own
+  // bookkeeping should skip with a reason, not score a short window.
+  const plan = planRecallSpotCheck(all, { sampleSize });
+  if (plan.sampled.length < sampleSize) {
+    const excluded = plan.excludedSnapshotRows > 0 ? ` (${plan.excludedSnapshotRows} quality-snapshot row(s) excluded — the spot-check never grades its own bookkeeping)` : "";
     return {
       ok: false,
       agentId,
-      skipReason: `agent '${agentId}' has ${all.length} memories, fewer than the ${sampleSize} needed to sample`,
+      skipReason: `agent '${agentId}' has ${plan.sampled.length} scorable memories, fewer than the ${sampleSize} needed to sample${excluded}`,
     };
   }
 
-  // Deterministic sample: the sampleSize most-recently-written memories.
-  const sorted = all.slice().sort((a: any, b: any) => {
-    const ta = a.createdAt ? new Date(a.createdAt).getTime() : 0;
-    const tb = b.createdAt ? new Date(b.createdAt).getTime() : 0;
-    return tb - ta;
-  });
-  const sampled = sorted.slice(0, sampleSize);
+  // flair#967: a window whose cues collide cannot be scored fairly — report
+  // that fact instead of a number, and don't spend the searches either.
+  if (!plan.health.healthy) {
+    return { ok: false, agentId, skipReason: plan.health.reason, sampleHealth: plan.health };
+  }
 
   const sampledIds: string[] = [];
   const perQueryResultIds: string[][] = [];
   try {
-    for (const m of sampled) {
-      const id = String(m.id);
-      const cue = deriveRecallCue(m);
+    for (const { id, cue } of plan.sampled) {
       const body = { agentId, q: cue, limit: k };
       const res = await api("POST", "/SemanticSearch", body, { baseUrl, agentId });
       const results: any[] = Array.isArray(res) ? res : (res?.results ?? []);
@@ -15431,7 +15617,7 @@ async function fetchRecallSpotCheckData(
     return { ok: false, agentId, skipReason: `recall spot-check search failed: ${err?.message ?? String(err)}` };
   }
 
-  return { ok: true, agentId, sampledIds, perQueryResultIds, k };
+  return { ok: true, agentId, sampledIds, perQueryResultIds, k, sampleHealth: plan.health };
 }
 
 // ─── flair quality --emit (Slice 2 of the memory-quality-observability arc:
@@ -15483,6 +15669,22 @@ async function fetchRecallSpotCheckData(
 export const QUALITY_EVENT_COVERAGE_ABS_THRESHOLD_PCT = 90;
 export const QUALITY_EVENT_COVERAGE_DROP_THRESHOLD_PCT = 5;
 export const QUALITY_EVENT_STALENESS_ABS_THRESHOLD_PCT = 10;
+/**
+ * RETAINED AT ITS ORIGINAL VALUE AND DELIBERATELY UNWIRED (flair#967).
+ *
+ * Nothing in diffQualitySnapshots reads this any more — the recall spot-check
+ * is report-only and emits no event at any delta (see the Slice 1d framing in
+ * the module doc for the 32-run σ = 0.291 / precision-0 measurement behind
+ * that). The constant stays, unchanged at 0.2, as the standing evidence that
+ * the fix was "remove alerting authority from a metric that never earned it",
+ * NOT "widen the gate until it stops talking" — a silenced check and a
+ * de-authorised one look identical in a changelog and are opposites in
+ * practice, and 0.2 sitting here at 0.69σ is the arithmetic that makes the
+ * difference legible. If this probe is ever re-armed, the replacement
+ * threshold must be DERIVED from the measured run-to-run variance of the
+ * FIXED cue derivation, not typed in — do not just re-reference this literal.
+ * Asserted unchanged by test/unit/quality-recall-spotcheck-967.test.ts.
+ */
 export const QUALITY_EVENT_RECALL_DROP_THRESHOLD = 0.2;
 export const QUALITY_EVENT_DEDUP_GROWTH_PCT_THRESHOLD = 0.5; // >50%
 export const QUALITY_EVENT_DEDUP_GROWTH_ABS_THRESHOLD = 5; // AND by >= 5 clusters
@@ -15585,29 +15787,30 @@ export function diffQualitySnapshots(current: QualitySnapshotCore, previous: Qua
     }
   }
 
-  // ── recall spot-check: recall@k and MRR, same delta-drop threshold ──
-  if (current.recallSpotCheck && previous.recallSpotCheck) {
-    const beforeR = previous.recallSpotCheck.recallAtK;
-    const afterR = current.recallSpotCheck.recallAtK;
-    if (beforeR - afterR > QUALITY_EVENT_RECALL_DROP_THRESHOLD) {
-      findings.push({
-        kind: "quality.regression",
-        scope: "quality",
-        summary: `recall spot-check recall@k dropped from ${beforeR} to ${afterR} since last snapshot`,
-        detail: { metric: "recallSpotCheck.recallAtK", before: beforeR, after: afterR, threshold: QUALITY_EVENT_RECALL_DROP_THRESHOLD },
-      });
-    }
-    const beforeM = previous.recallSpotCheck.mrr;
-    const afterM = current.recallSpotCheck.mrr;
-    if (beforeM - afterM > QUALITY_EVENT_RECALL_DROP_THRESHOLD) {
-      findings.push({
-        kind: "quality.regression",
-        scope: "quality",
-        summary: `recall spot-check MRR dropped from ${beforeM} to ${afterM} since last snapshot`,
-        detail: { metric: "recallSpotCheck.mrr", before: beforeM, after: afterM, threshold: QUALITY_EVENT_RECALL_DROP_THRESHOLD },
-      });
-    }
-  }
+  // ── recall spot-check: REPORT-ONLY, no branch here on purpose (flair#967) ──
+  //
+  // This metric used to emit two quality.regression events (recall@k and MRR,
+  // both at QUALITY_EVENT_RECALL_DROP_THRESHOLD). It no longer emits anything,
+  // at any delta. Measured, on rockit production:
+  //
+  //   32 nightly runs · population σ 0.291 · mean |run-to-run delta| 0.223
+  //   threshold 0.2  →  0.69σ, i.e. BELOW the metric's own noise floor
+  //   6 findings-mails in 34 runs, replay-predicted 6/6 from these branches,
+  //   all 6 oscillation  →  lifetime precision 0
+  //
+  // Removing an emission is not the same move as raising a threshold, and the
+  // distinction is the whole point: raising 0.2 would leave a check that still
+  // claims to detect recall regressions while detecting none, whereas this
+  // hands that job to the instrument that can actually do it — the
+  // deterministic, fixed-label, CI-gated eval in
+  // test/integration-heavy/recall-eval-gate.test.ts (test/bench/recall-eval),
+  // whose floors sit ≥2 whole queries below the measured value against a
+  // 0.000 noise band. QUALITY_EVENT_RECALL_DROP_THRESHOLD is left at 0.2,
+  // unwired, so that stays checkable rather than asserted.
+  //
+  // current.recallSpotCheck / previous.recallSpotCheck are still SNAPSHOTTED
+  // (buildQualitySnapshot above) — the history that made this diagnosis
+  // possible keeps accumulating, and `flair quality` still prints the number.
 
   // ── quiet agents: per-agent, NEWLY quiet only (was false last snapshot,
   // true now) — never re-fires for an agent that was already quiet last
@@ -15799,6 +16002,11 @@ program
 
     if (mode === "json") {
       const out: any = { healthy, url: baseUrl, flairVersion: __pkgVersion, ...report };
+      // flair#967: when a window was assembled, say whether it was scorable —
+      // structurally, not only as prose inside a `gaps` reason. An unhealthy
+      // sample is a FACT ABOUT THE RUN that a consumer must be able to read
+      // without string-matching.
+      if (recallSpotCheckData.sampleHealth) out.recallSampleHealth = recallSpotCheckData.sampleHealth;
       if (emitResult) {
         out.emit = { firstRun: emitResult.firstRun, snapshotId: emitResult.snapshotId, errors: emitResult.errors };
         out.emittedEvents = emitResult.emittedEvents.map((e) => ({
@@ -15915,15 +16123,15 @@ program
       console.log(`  ${render.wrap(render.c.dim, "an ops signal — near-duplicate memories piling up, not a trust judgment")}`);
     }
 
-    // Recall spot-check (flair-quality Slice 1d) — a health SPOT-CHECK, not
-    // a benchmark or trust judgment: catches recall cratering (embeddings/
-    // index down), not a quality grade. See QualityReport['recallSpotCheck']
-    // doc for the full framing.
+    // Recall spot-check (flair-quality Slice 1d) — a REPORT-ONLY health
+    // spot-check: not a benchmark, not a trust judgment, and since flair#967
+    // not an alerting signal either. See QualityReport['recallSpotCheck'] doc
+    // and the Slice 1d module doc for the full framing.
     if (report.recallSpotCheck) {
       const rc = report.recallSpotCheck;
-      console.log(`\n${render.wrap(render.c.bold, "Recall spot-check")} ${render.wrap(render.c.dim, `(agent ${rc.agentId ?? "—"}, health signal — not a benchmark)`)}`);
+      console.log(`\n${render.wrap(render.c.bold, "Recall spot-check")} ${render.wrap(render.c.dim, `(agent ${rc.agentId ?? "—"}, report-only — not a benchmark, not an alert)`)}`);
       console.log(render.kv(`recall@${rc.k}`, `${render.wrap(render.c.bold, rc.recallAtK.toFixed(2))} ${render.wrap(render.c.dim, `(MRR ${rc.mrr.toFixed(2)}, ${rc.sampleSize} sampled)`)}`));
-      console.log(`  ${render.wrap(render.c.dim, "catches recall cratering (embeddings/index down) — a high score means recall is functioning, not that it's optimal")}`);
+      console.log(`  ${render.wrap(render.c.dim, "observability only — recall REGRESSIONS are detected by the deterministic CI gate (test/bench/recall-eval), not by this number")}`);
     }
 
     // Gaps

--- a/test/unit/quality-recall-spotcheck-967.test.ts
+++ b/test/unit/quality-recall-spotcheck-967.test.ts
@@ -1,0 +1,391 @@
+/**
+ * quality-recall-spotcheck-967.test.ts — the powered check for flair#967.
+ *
+ * #967 is a diagnosed defect, so these tests were written to FAIL on
+ * unmodified main first (red-on-main log in the PR body) and are the reason
+ * the fix is believed. Three properties, plus positive controls:
+ *
+ *  1. ALERTING AUTHORITY — replaying a duplicate-cue window (the shape the
+ *     nightly sweep actually sampled on 2026-08-23) through the sweep's
+ *     decision chain must emit NO `quality.regression` for the recall
+ *     spot-check. On main it emits two.
+ *  2. CUE DERIVATION — `deriveRecallCue` must not hand an opaque slug
+ *     (`pr-1359`, `kern-2026-08-23`, `quality-snapshot/<host>`) to semantic
+ *     search as if it were a query. On main it does, because the only bar is
+ *     `subject.length >= 3`.
+ *  3. SAMPLE HEALTH — a window that cannot be scored fairly is recorded as
+ *     UNHEALTHY and reports that fact instead of a number (fail closed,
+ *     visibly).
+ *
+ * Positive controls (these pass on main AND on the branch, deliberately —
+ * they exist so a green run here cannot be a vacuous one):
+ *  - the diff machinery still emits for a metric that genuinely crossed a line;
+ *  - a genuine recall CRATER is still measured, reported and snapshotted;
+ *  - `QUALITY_EVENT_RECALL_DROP_THRESHOLD` is still literally 0.2 — the fix is
+ *    not "raise the threshold until it stops talking".
+ *
+ * Every number in the fixtures below is a MEASUREMENT, not an invention: they
+ * come from the 32-run history and the same-instant A/B recorded on flair#967
+ * (comment 5389889052), both taken against rockit production.
+ */
+
+import { describe, test, expect } from "bun:test";
+import {
+  computeQualityReport,
+  computeRecallSpotCheck,
+  deriveRecallCue,
+  isDiscriminativeSubject,
+  planRecallSpotCheck,
+  buildQualitySnapshot,
+  diffQualitySnapshots,
+  QUALITY_EVENT_RECALL_DROP_THRESHOLD,
+  QUALITY_RECALL_K,
+  QUALITY_RECALL_SAMPLE_SIZE,
+  type QualitySnapshotCore,
+} from "../../src/cli.ts";
+
+const NOW = new Date("2026-08-23T09:00:00.000Z").getTime();
+const daysAgo = (n: number) => new Date(NOW - n * 86_400_000).toISOString();
+
+/** Minimal /HealthDetail-shaped payload — same field names as
+ *  resources/health.ts's get() output (see quality-report.test.ts). Only the
+ *  recall spot-check matters here; the rest just has to be well-formed so no
+ *  OTHER metric accidentally produces the finding we're asserting about. */
+function healthFixture(overrides: Record<string, any> = {}) {
+  return {
+    ok: true,
+    caller: { agentId: "flint", isAdmin: true },
+    memories: {
+      total: 2998,
+      withEmbeddings: 2998,
+      hashFallback: 0,
+      modelCounts: { "nomic-embed-text-v1.5-Q4_K_M+searchprefix": 2998 },
+      expired: 100,
+    },
+    agents: {
+      count: 1,
+      names: ["flint"],
+      perAgent: [{ id: "flint", memoryCount: 2998, hashFallback: 0, writes24h: 40, lastWriteAt: daysAgo(0), usageCount: 100 }],
+    },
+    migrations: { migrations: [{ id: "embedding-backfill", state: "completed" }] },
+    ...overrides,
+  };
+}
+
+/** A prior snapshot carrying whatever recall pair a test needs to diff against.
+ *  Every other section is held IDENTICAL to what healthFixture() produces, so
+ *  the only thing that can generate a finding is the recall spot-check. */
+function previousSnapshot(recallAtK: number, mrr: number): QualitySnapshotCore {
+  return {
+    schemaVersion: 1,
+    computedAt: daysAgo(1),
+    agentFilter: "flint",
+    embeddingCoverage: { coveragePct: 100 },
+    staleness: { stalePct: 3 },
+    recallSpotCheck: { recallAtK, mrr },
+    quietAgents: { perAgent: [{ id: "flint", quiet: false, daysSinceLastWrite: 0 }] },
+    dedupClusters: null,
+  };
+}
+
+// ─── The measured duplicate-cue window ───────────────────────────────────────
+//
+// The per-query outcomes below are the DERIVED-CUE arm of the same-instant A/B
+// recorded on #967 — 10 sampled memories, one `POST /SemanticSearch` each,
+// limit=5, read-only against rockit production 0.48.0 (buildCommit a6cc5ad):
+//
+//   rank=5  cue='pr-1359'          rank=4  cue='kern-2026-08-23'
+//   rank=4  cue='pr-1359'          rank=5  cue='pr-1357'
+//   rank=0  cue='pr-1359'          rank=0  cue='kern-2026-08-23'
+//   rank=4  cue='kern-2026-08-24'  rank=0  cue='pr-1357'
+//   rank=2  cue='kern-2026-08-23'  rank=0  cue='pr-1357'
+//
+// which scores recall@5 = 6/10 = 0.60 and MRR = 1.65/10 = 0.165 — the numbers
+// the A/B reported for that arm. The CONTENT arm of the same A/B, same ten
+// memories, same minute, scored recall@5 = 1.00 / MRR = 0.78: every target was
+// retrievable from its own content, so `contentRank: 1` below is that arm
+// (modelled at rank 1; the measured MRR of 0.78 means "mostly rank 1-2").
+//
+// This is a REPLAY of a measurement, not a simulation of embedding search: no
+// scorer is being re-implemented here, the recorded rank of each query is
+// simply played back so the sweep's DECISION chain can be exercised over it.
+interface ReplayRow {
+  id: string;
+  subject: string;
+  content: string;
+  createdAt: string;
+  /** Rank the target came back at when queried by its SUBJECT. 0 = not in top-5. */
+  subjectCueRank: number;
+}
+
+const MEASURED_WINDOW: ReplayRow[] = [
+  { id: "m01", subject: "pr-1359", content: "Kern architecture review of the presence-beat refactor: the poller and the writer now share one clock source.", subjectCueRank: 5 },
+  { id: "m02", subject: "pr-1359", content: "Sherlock security review of the presence-beat refactor: no new credential surface, the token never reaches argv.", subjectCueRank: 4 },
+  { id: "m03", subject: "pr-1359", content: "Flint merge note for the presence-beat refactor: CI green across all lanes, both reviewers approved on the current head.", subjectCueRank: 0 },
+  { id: "m04", subject: "kern-2026-08-24", content: "Daily architecture digest: the federation connector rows have no external re-heal source, back up before any cluster operation.", subjectCueRank: 4 },
+  { id: "m05", subject: "kern-2026-08-23", content: "Daily architecture digest: base-copy resync applies state with no transaction-log entries by design, receiver-only rows are discarded.", subjectCueRank: 2 },
+  { id: "m06", subject: "kern-2026-08-23", content: "Follow-up on the resync note: seventy-two hour log retention is the boundary past which a receiver silently loses rows.", subjectCueRank: 4 },
+  { id: "m07", subject: "pr-1357", content: "Kern architecture review of the doctor native-extension probe: detection belongs in the wiring check, not the version banner.", subjectCueRank: 5 },
+  { id: "m08", subject: "kern-2026-08-23", content: "Third digest entry: hub-only rows written by the OAuth connector are the ones with no federation coverage today.", subjectCueRank: 0 },
+  { id: "m09", subject: "pr-1357", content: "Sherlock security review of the doctor native-extension probe: the probe reads a path, it never executes what it finds.", subjectCueRank: 0 },
+  { id: "m10", subject: "pr-1357", content: "Flint merge note for the doctor native-extension probe: changelog fragment present, refs not closes, no review requests.", subjectCueRank: 0 },
+].map((r, i) => ({ ...r, createdAt: new Date(NOW - i * 60_000).toISOString() }));
+
+const DISTRACTORS = ["old-a", "old-b", "old-c", "old-d", "old-e"];
+
+/** Play back the recorded rank for one query. `cue === row.subject` means the
+ *  subject-cue arm (the measured ranks above); anything else is the
+ *  content-derived arm, which the A/B measured at recall@5 1.00. */
+function replaySearch(row: ReplayRow, cue: string, k: number): string[] {
+  const rank = cue === row.subject ? row.subjectCueRank : 1;
+  const out = DISTRACTORS.slice(0, k);
+  if (rank >= 1 && rank <= k) out[rank - 1] = row.id;
+  return out;
+}
+
+/** The sweep's decision chain over a window, minus the HTTP hop: derive a cue
+ *  per sampled memory (production `deriveRecallCue`), play back that query's
+ *  recorded result list, score it (production `computeRecallSpotCheck` via
+ *  `computeQualityReport`), snapshot it (production `buildQualitySnapshot`)
+ *  and diff it against the previous snapshot (production
+ *  `diffQualitySnapshots`) — exactly what `flair quality --emit` does. */
+function replaySweep(rows: ReplayRow[], previous: QualitySnapshotCore | null) {
+  const k = QUALITY_RECALL_K;
+  const sampledIds = rows.map((r) => r.id);
+  const perQueryResultIds = rows.map((r) => replaySearch(r, deriveRecallCue(r), k));
+  const report = computeQualityReport(true, healthFixture(), {
+    now: NOW,
+    agentId: "flint",
+    recallSpotCheckData: { ok: true, agentId: "flint", sampledIds, perQueryResultIds, k },
+  });
+  const current = buildQualitySnapshot(report, new Date(NOW).toISOString());
+  return { report, current, findings: diffQualitySnapshots(current, previous), cues: rows.map((r) => deriveRecallCue(r)) };
+}
+
+const recallFindings = (findings: Array<{ detail: { metric: string } }>) =>
+  findings.filter((f) => f.detail.metric.startsWith("recallSpotCheck."));
+
+describe("flair#967 — recall spot-check precision", () => {
+  describe("1. alerting authority (RED on main)", () => {
+    test("the 2026-08-23 firing pair (0.6 → 0.2) emits NO recall regression — the metric has zero measured lifetime precision, so it no longer carries alerting authority", () => {
+      // The literal numbers the nightly sweep mailed on 2026-08-23. Population
+      // σ over 32 runs of this metric is 0.291 and the mean absolute
+      // run-to-run delta is 0.223 — both LARGER than the 0.2 that declares a
+      // regression, so this delta is inside the metric's own noise floor.
+      const current: QualitySnapshotCore = { ...previousSnapshot(0.2, 0.12), computedAt: new Date(NOW).toISOString() };
+      const findings = diffQualitySnapshots(current, previousSnapshot(0.6, 0.33));
+      expect(recallFindings(findings)).toEqual([]);
+    });
+
+    test("a full-range swing (1.0 → 0.3, the 2026-07-29 firing) also emits nothing — this is not a threshold that got wider, the emission is gone", () => {
+      const current: QualitySnapshotCore = { ...previousSnapshot(0.3, 0.23), computedAt: new Date(NOW).toISOString() };
+      const findings = diffQualitySnapshots(current, previousSnapshot(1.0, 0.87));
+      expect(recallFindings(findings)).toEqual([]);
+    });
+
+    test("replaying the measured duplicate-cue window through the whole sweep emits no recall regression", () => {
+      // Previous = 1.0, the maximum this metric actually recorded in its
+      // 32-run history (2026-07-29). On main the replayed window scores 0.60,
+      // a 0.40 drop, and the sweep mails a recall@k regression AND an MRR
+      // regression — the exact 6-for-6 false-alarm behaviour #967 documents.
+      const { findings } = replaySweep(MEASURED_WINDOW, previousSnapshot(1.0, 0.87));
+      expect(recallFindings(findings)).toEqual([]);
+    });
+
+    test("the same replay still MEASURES and RECORDS a number — report-only, not silenced", () => {
+      const { report, current } = replaySweep(MEASURED_WINDOW, previousSnapshot(1.0, 0.87));
+      expect(report.recallSpotCheck).not.toBeNull();
+      expect(report.recallSpotCheck!.sampleSize).toBe(10);
+      expect(current.recallSpotCheck).not.toBeNull();
+      // And with the cue fixed the replayed window scores the CONTENT arm of
+      // the A/B (1.00), not the subject arm (0.60) — the observability number
+      // is now worth reading, which is the point of keeping it.
+      expect(report.recallSpotCheck!.recallAtK).toBe(1);
+    });
+  });
+
+  describe("2. cue derivation (RED on main)", () => {
+    test("a slug-shaped subject is not a query — content wins over `pr-1359`", () => {
+      const row = MEASURED_WINDOW[0];
+      const cue = deriveRecallCue(row);
+      expect(cue).not.toBe("pr-1359");
+      expect(row.content.startsWith(cue.replace(/[.!?]$/, ""))).toBe(true);
+    });
+
+    test("date-slug subject (`kern-2026-08-23`) falls back to content too", () => {
+      expect(deriveRecallCue({ subject: "kern-2026-08-23", content: "Daily architecture digest about base-copy resync and transaction-log retention." })).not.toBe("kern-2026-08-23");
+    });
+
+    test("the tool's own bookkeeping subject (`quality-snapshot/<host>`) is a hostname-shaped slug, not a cue", () => {
+      expect(
+        deriveRecallCue({ subject: "quality-snapshot/127.0.0.1:9926", content: '{"schemaVersion":1,"computedAt":"2026-08-23T09:00:00.000Z"}' }),
+      ).not.toBe("quality-snapshot/127.0.0.1:9926");
+    });
+
+    test("CONTROL — a real prose subject is still preferred over content (the fix narrows the subject path, it does not delete it)", () => {
+      expect(
+        deriveRecallCue({ subject: "Harper RBAC two-gate model", content: "Some long content that would otherwise be the fallback cue." }),
+      ).toBe("Harper RBAC two-gate model");
+    });
+
+    test("CONTROL — a hyphenated ordinary word is not a slug", () => {
+      expect(deriveRecallCue({ subject: "two-gate", content: "irrelevant content" })).toBe("two-gate");
+    });
+
+    test("every cue derived from the measured window is unique once the subject preference is narrowed", () => {
+      const cues = MEASURED_WINDOW.map((r) => deriveRecallCue(r));
+      expect(new Set(cues).size).toBe(cues.length);
+    });
+  });
+
+  describe("3. positive controls (green on main AND on the branch, by design)", () => {
+    test("the diff machinery can still see an emission — a genuine coverage crossing fires", () => {
+      const prev = previousSnapshot(0.6, 0.33);
+      const current: QualitySnapshotCore = { ...prev, computedAt: new Date(NOW).toISOString(), embeddingCoverage: { coveragePct: 71 } };
+      const findings = diffQualitySnapshots(current, prev);
+      expect(findings.length).toBeGreaterThan(0);
+      expect(findings.some((f) => f.detail.metric === "embeddingCoverage.coveragePct")).toBe(true);
+    });
+
+    test("a genuine recall CRATER on a healthy sample is still measured, reported and snapshotted", () => {
+      // Ten distinct cues, every single query missing — the "embeddings down /
+      // index busted" case this probe exists for. It must still produce a real
+      // 0.0, not a gap and not a silence.
+      const sampledIds = Array.from({ length: 10 }, (_, i) => `x${i}`);
+      const scored = computeRecallSpotCheck(sampledIds, sampledIds.map(() => DISTRACTORS.slice()), QUALITY_RECALL_K);
+      expect(scored.recallAtK).toBe(0);
+      const report = computeQualityReport(true, healthFixture(), {
+        now: NOW,
+        agentId: "flint",
+        recallSpotCheckData: { ok: true, agentId: "flint", sampledIds, perQueryResultIds: sampledIds.map(() => DISTRACTORS.slice()), k: QUALITY_RECALL_K },
+      });
+      expect(report.recallSpotCheck).toEqual({ agentId: "flint", recallAtK: 0, mrr: 0, sampleSize: 10, k: QUALITY_RECALL_K });
+      expect(report.gaps.some((g) => g.metric === "recallSpotCheck")).toBe(false);
+      expect(buildQualitySnapshot(report).recallSpotCheck).toEqual({ recallAtK: 0, mrr: 0 });
+    });
+
+    test("the drop threshold literal is UNCHANGED at 0.2 — the fix removed the emission, it did not widen the gate", () => {
+      expect(QUALITY_EVENT_RECALL_DROP_THRESHOLD).toBe(0.2);
+    });
+  });
+
+  describe("4. sample-health guard — fail closed, visibly", () => {
+    /** n rows, newest first, with the given (subject, content) pairs. */
+    const rows = (specs: Array<{ subject?: string; content?: string; type?: string; id?: string }>) =>
+      specs.map((s, i) => ({
+        id: s.id ?? `m${String(i).padStart(2, "0")}`,
+        subject: s.subject ?? "",
+        content: s.content ?? `Distinct content number ${i} about an entirely separate topic from the others in this window.`,
+        createdAt: new Date(NOW - i * 60_000).toISOString(),
+        ...(s.type ? { type: s.type } : {}),
+      }));
+
+    test("the measured window is HEALTHY once cues come from content — ten distinct cues, ten queries", () => {
+      const plan = planRecallSpotCheck(MEASURED_WINDOW);
+      expect(plan.health.healthy).toBe(true);
+      expect(plan.sampled).toHaveLength(10);
+      expect(new Set(plan.sampled.map((s) => s.cue)).size).toBe(10);
+    });
+
+    test("duplicate cues → UNHEALTHY, and the reason NAMES the colliding cue", () => {
+      // Two memories whose content ALSO collides — the residual case the
+      // cue fix cannot rescue (genuine near-duplicate writes).
+      const dupe = "Kern review of the release burst: all four PRs share one changelog fragment.";
+      const plan = planRecallSpotCheck(rows([{ content: dupe }, { content: dupe }, ...Array.from({ length: 8 }, () => ({}))]));
+      expect(plan.health.healthy).toBe(false);
+      expect(plan.health.duplicateCues).toHaveLength(1);
+      expect(plan.health.reason).toContain("sample unhealthy");
+      expect(plan.health.reason).toContain("displace each other");
+      expect(plan.health.reason).toContain(dupe.slice(0, 40));
+    });
+
+    test("a memory with neither subject nor content → UNHEALTHY (no derivable cue), counted not hidden", () => {
+      const plan = planRecallSpotCheck(rows([{ subject: "", content: "" }, ...Array.from({ length: 9 }, () => ({}))]));
+      expect(plan.health.healthy).toBe(false);
+      expect(plan.health.emptyCueCount).toBe(1);
+      expect(plan.health.reason).toContain("no derivable cue");
+    });
+
+    test("the spot-check never grades its own bookkeeping — quality-snapshot rows are excluded before sampling", () => {
+      const withSnapshots = rows([
+        { id: "snap-1", subject: "quality-snapshot/127.0.0.1:9926", content: '{"schemaVersion":1,"computedAt":"a"}', type: "quality-snapshot" },
+        { id: "snap-2", subject: "quality-snapshot/127.0.0.1:9926", content: '{"schemaVersion":1,"computedAt":"b"}' },
+        ...Array.from({ length: 10 }, () => ({})),
+      ]);
+      const plan = planRecallSpotCheck(withSnapshots);
+      expect(plan.excludedSnapshotRows).toBe(2);
+      expect(plan.sampled.map((s) => s.id)).not.toContain("snap-1");
+      expect(plan.sampled.map((s) => s.id)).not.toContain("snap-2");
+      expect(plan.sampled).toHaveLength(QUALITY_RECALL_SAMPLE_SIZE);
+      expect(plan.health.healthy).toBe(true);
+    });
+
+    test("an unhealthy sample reaches the report as a null metric + a self-describing gap, never as a number", () => {
+      const dupe = "Identical content in two sampled memories.";
+      const plan = planRecallSpotCheck(rows([{ content: dupe }, { content: dupe }, ...Array.from({ length: 8 }, () => ({}))]));
+      const report = computeQualityReport(true, healthFixture(), {
+        now: NOW,
+        agentId: "flint",
+        recallSpotCheckData: { ok: false, agentId: "flint", skipReason: plan.health.reason, sampleHealth: plan.health },
+      });
+      expect(report.recallSpotCheck).toBeNull();
+      const gap = report.gaps.find((g) => g.metric === "recallSpotCheck");
+      expect(gap?.reason).toContain("sample unhealthy");
+
+      // ...and an unscorable run cannot become a phantom regression next
+      // night either: a null section on either side of the diff is a gap, not
+      // a drop (pre-existing missing-data rule, re-asserted here because the
+      // fail-closed guard is what now produces those nulls).
+      const current = buildQualitySnapshot(report, new Date(NOW).toISOString());
+      expect(current.recallSpotCheck).toBeNull();
+      expect(diffQualitySnapshots(current, previousSnapshot(1.0, 0.87))).toEqual([]);
+    });
+
+    test("sorting is still newest-first over the SCORABLE rows only", () => {
+      const plan = planRecallSpotCheck(rows(Array.from({ length: 14 }, () => ({}))));
+      expect(plan.sampled.map((s) => s.id)).toEqual(["m00", "m01", "m02", "m03", "m04", "m05", "m06", "m07", "m08", "m09"]);
+    });
+
+    test("too few scorable rows after excluding bookkeeping → a short plan the caller must skip on", () => {
+      const plan = planRecallSpotCheck(
+        rows([...Array.from({ length: 4 }, (_, i) => ({ id: `snap-${i}`, subject: "quality-snapshot/127.0.0.1:9926", type: "quality-snapshot" })), ...Array.from({ length: 8 }, () => ({}))]),
+      );
+      expect(plan.excludedSnapshotRows).toBe(4);
+      expect(plan.sampled.length).toBeLessThan(QUALITY_RECALL_SAMPLE_SIZE);
+    });
+
+    test("empty input is not a crash and not a healthy empty sample", () => {
+      const plan = planRecallSpotCheck([]);
+      expect(plan.sampled).toEqual([]);
+      expect(plan.health.healthy).toBe(true); // vacuously — the caller's sampleSize check is what rejects it
+      expect(plan.excludedSnapshotRows).toBe(0);
+    });
+  });
+
+  describe("5. isDiscriminativeSubject — the rule, stated", () => {
+    test.each([
+      ["Harper RBAC two-gate model", true],
+      ["two-gate", true],
+      ["Rotate the admin password", true],
+      ["Harper 5.2 upgrade", true], // whitespace ⇒ prose, digits are fine inside a phrase
+      ["ops", true],
+      ["pr-1359", false],
+      ["kern-2026-08-23", false],
+      ["quality-snapshot/127.0.0.1:9926", false],
+      ["v0.48.0", false],
+      ["session_notes", false],
+      ["README.md", false],
+      ["x", false],
+      ["", false],
+      ["---", false],
+      ["42", false],
+    ])("%s → discriminative: %s", (subject, expected) => {
+      expect(isDiscriminativeSubject(subject as string)).toBe(expected);
+    });
+
+    test("null/undefined are not discriminative (no crash)", () => {
+      expect(isDiscriminativeSubject(null)).toBe(false);
+      expect(isDiscriminativeSubject(undefined)).toBe(false);
+    });
+  });
+});

--- a/test/unit/quality-report.test.ts
+++ b/test/unit/quality-report.test.ts
@@ -479,18 +479,22 @@ describe("computeQualityReport", () => {
     });
 
     test("falls back to content when subject is empty/whitespace-only", () => {
+      // Cap widened 8 → 25 words in flair#967: 25 is the content arm that was
+      // actually MEASURED in the same-instant A/B (recall@5 1.00 / MRR 0.78 vs
+      // the subject arm's 0.60 / 0.16), so it is the cue length with evidence
+      // behind it. Still capped — see the ~25-word test below.
       const cue = deriveRecallCue({
         subject: "   ",
         content: "Rotate the Harper admin password using the domain socket procedure documented in ops.",
       });
-      expect(cue).toBe("Rotate the Harper admin password using the domain");
+      expect(cue).toBe("Rotate the Harper admin password using the domain socket procedure documented in ops.");
     });
 
-    test("falls back to content when subject is absent, capped to the leading ~8 words of the first sentence", () => {
+    test("falls back to content when subject is absent, capped to the leading ~25 words of the first sentence", () => {
       const cue = deriveRecallCue({
         content: "Never dump or decode a secret file, use length-only probes instead.",
       });
-      expect(cue).toBe("Never dump or decode a secret file, use");
+      expect(cue).toBe("Never dump or decode a secret file, use length-only probes instead.");
     });
 
     test("very short/trivial subject falls back to content rather than being used as-is", () => {
@@ -502,15 +506,26 @@ describe("computeQualityReport", () => {
       expect(deriveRecallCue({ content: "Ports rotated today." })).toBe("Ports rotated today.");
     });
 
-    test("caps at the leading ~8 words — never returns the full content (a PARTIAL cue, not the memory itself)", () => {
-      const cue = deriveRecallCue({ content: "one two three four five six seven eight nine ten eleven twelve" });
-      expect(cue.split(/\s+/).length).toBeLessThanOrEqual(8);
-      expect(cue).not.toContain("twelve");
+    test("caps at the leading ~25 words — never returns the full content (a PARTIAL cue, not the memory itself)", () => {
+      const words = Array.from({ length: 40 }, (_, i) => `w${i + 1}`).join(" ");
+      const cue = deriveRecallCue({ content: words });
+      expect(cue.split(/\s+/).length).toBeLessThanOrEqual(25);
+      expect(cue).not.toContain("w40");
     });
 
     test("both subject and content absent/empty → empty cue, not a crash", () => {
       expect(deriveRecallCue({})).toBe("");
       expect(deriveRecallCue({ subject: "", content: "" })).toBe("");
+    });
+
+    // flair#967 — the subject preference is now gated on the subject being
+    // DISCRIMINATIVE, not merely present. Full rule + red-on-main proof in
+    // test/unit/quality-recall-spotcheck-967.test.ts; this is the local
+    // regression anchor next to the tests above it changes the meaning of.
+    test("an opaque slug subject is not a cue — falls back to content (flair#967)", () => {
+      expect(deriveRecallCue({ subject: "pr-1359", content: "Kern architecture review of the presence-beat refactor." })).toBe(
+        "Kern architecture review of the presence-beat refactor.",
+      );
     });
   });
 
@@ -762,51 +777,41 @@ describe("flair-quality Slice 2 — snapshot + diff + OrgEvent thresholds", () =
     });
   });
 
-  describe("diffQualitySnapshots — recallSpotCheck (recall@k and MRR independently)", () => {
-    test("recall@k drops by more than the delta threshold → regression", () => {
+  describe("diffQualitySnapshots — recallSpotCheck is REPORT-ONLY (flair#967)", () => {
+    // These three used to assert the recall@k / MRR regression events. They
+    // now assert their ABSENCE, because the spot-check no longer carries
+    // alerting authority: 32 nightly runs on rockit production measured
+    // population σ 0.291 and mean |run-to-run delta| 0.223 against a 0.2
+    // threshold (0.69σ — below the metric's own noise floor), and all 6
+    // findings-mails the sweep ever produced in 34 runs were this metric
+    // oscillating. Lifetime precision 0. Recall regressions are detected by
+    // test/integration-heavy/recall-eval-gate.test.ts instead. Full rationale
+    // + the red-on-main proof: test/unit/quality-recall-spotcheck-967.test.ts.
+    test("recall@k drops by more than the old delta threshold → NO event", () => {
       const previous = snap({ recallSpotCheck: { recallAtK: 0.9, mrr: 0.8 } });
       const current = snap({ recallSpotCheck: { recallAtK: 0.6, mrr: 0.8 } }); // drop 0.3
-      const findings = diffQualitySnapshots(current, previous);
-      expect(findings).toEqual([
-        {
-          kind: "quality.regression",
-          scope: "quality",
-          summary: "recall spot-check recall@k dropped from 0.9 to 0.6 since last snapshot",
-          detail: { metric: "recallSpotCheck.recallAtK", before: 0.9, after: 0.6, threshold: QUALITY_EVENT_RECALL_DROP_THRESHOLD },
-        },
-      ]);
+      expect(diffQualitySnapshots(current, previous)).toEqual([]);
     });
 
-    test("MRR drops by more than the delta threshold, recall@k steady → regression on mrr only", () => {
+    test("MRR drops by more than the old delta threshold → NO event", () => {
       const previous = snap({ recallSpotCheck: { recallAtK: 0.9, mrr: 0.8 } });
       const current = snap({ recallSpotCheck: { recallAtK: 0.9, mrr: 0.5 } }); // drop 0.3
-      const findings = diffQualitySnapshots(current, previous);
-      expect(findings).toEqual([
-        {
-          kind: "quality.regression",
-          scope: "quality",
-          summary: "recall spot-check MRR dropped from 0.8 to 0.5 since last snapshot",
-          detail: { metric: "recallSpotCheck.mrr", before: 0.8, after: 0.5, threshold: QUALITY_EVENT_RECALL_DROP_THRESHOLD },
-        },
-      ]);
-    });
-
-    test("both recall@k and MRR drop → two independent findings", () => {
-      const previous = snap({ recallSpotCheck: { recallAtK: 0.9, mrr: 0.8 } });
-      const current = snap({ recallSpotCheck: { recallAtK: 0.5, mrr: 0.4 } });
-      const findings = diffQualitySnapshots(current, previous);
-      expect(findings).toHaveLength(2);
-      expect(findings.every((f) => f.kind === "quality.regression")).toBe(true);
-      expect(findings.map((f) => f.detail.metric).sort()).toEqual(["recallSpotCheck.mrr", "recallSpotCheck.recallAtK"]);
-    });
-
-    test("drop of exactly the threshold (0.2) → no event (exclusive boundary)", () => {
-      // 0.5 - 0.3 === 0.2 exactly in IEEE754 double (verified) — picked
-      // deliberately so this boundary test isn't at the mercy of float
-      // rounding noise the way e.g. 0.9 - 0.7 (> 0.2) would be.
-      const previous = snap({ recallSpotCheck: { recallAtK: 0.5, mrr: 0.8 } });
-      const current = snap({ recallSpotCheck: { recallAtK: 0.3, mrr: 0.8 } }); // drop exactly 0.2
       expect(diffQualitySnapshots(current, previous)).toEqual([]);
+    });
+
+    test("a full collapse of both (0.9/0.8 → 0.0/0.0) still emits nothing — report-only means report-only", () => {
+      const previous = snap({ recallSpotCheck: { recallAtK: 0.9, mrr: 0.8 } });
+      const current = snap({ recallSpotCheck: { recallAtK: 0, mrr: 0 } });
+      expect(diffQualitySnapshots(current, previous)).toEqual([]);
+    });
+
+    test("the drop threshold constant is still literally 0.2 — de-authorised, not widened", () => {
+      expect(QUALITY_EVENT_RECALL_DROP_THRESHOLD).toBe(0.2);
+    });
+
+    test("the snapshot still CARRIES the recall pair — history keeps accumulating even though nothing fires on it", () => {
+      const current = snap({ recallSpotCheck: { recallAtK: 0.42, mrr: 0.21 } });
+      expect(current.recallSpotCheck).toEqual({ recallAtK: 0.42, mrr: 0.21 });
     });
   });
 
@@ -964,7 +969,7 @@ describe("flair-quality Slice 2 — snapshot + diff + OrgEvent thresholds", () =
       const previous = snap({
         embeddingCoverage: { coveragePct: 96 }, // will cross + regress
         staleness: { stalePct: 5 }, // will cross
-        recallSpotCheck: { recallAtK: 0.9, mrr: 0.9 }, // both will regress
+        recallSpotCheck: { recallAtK: 0.9, mrr: 0.9 }, // report-only since #967 — will NOT fire
         quietAgents: {
           perAgent: [
             { id: "anvil", quiet: false, daysSinceLastWrite: 1 }, // will newly-quiet
@@ -988,8 +993,13 @@ describe("flair-quality Slice 2 — snapshot + diff + OrgEvent thresholds", () =
       const findings = diffQualitySnapshots(current, previous);
       const kinds = findings.map((f) => f.kind);
       expect(kinds.filter((k) => k === "quality.threshold_crossed")).toHaveLength(3); // coverage, staleness, anvil-quiet
-      expect(kinds.filter((k) => k === "quality.regression")).toHaveLength(4); // coverage, recall@k, mrr, dedup
-      expect(findings).toHaveLength(7);
+      expect(kinds.filter((k) => k === "quality.regression")).toHaveLength(2); // coverage, dedup
+      expect(findings).toHaveLength(5);
+      // ...and NOT recall@k or MRR, even though both moved 0.5/0.6 here — the
+      // spot-check is report-only since flair#967. This is the "every metric
+      // fires independently" test, so it is also the place a re-armed recall
+      // emission would show up unannounced.
+      expect(findings.some((f) => f.detail.metric.startsWith("recallSpotCheck."))).toBe(false);
       // Every finding is JSON-serializable (this is exactly what ends up in
       // an OrgEvent's `detail` field via JSON.stringify).
       for (const f of findings) expect(() => JSON.stringify(f.detail)).not.toThrow();


### PR DESCRIPTION
Closes #967

## The argument, stated plainly so it can be disagreed with

**This is not silencing a signal by raising a threshold.** Raising
`QUALITY_EVENT_RECALL_DROP_THRESHOLD` is explicitly the wrong fix and this PR
does not do it — the constant is left at `0.2`, unchanged, and a test asserts
it. What this PR does is **remove alerting authority from a metric with zero
measured precision**, while keeping the deterministic gate that actually
detects recall regressions.

Those two moves look identical in a changelog and are opposites in practice. A
raised threshold leaves behind a check that still *claims* to detect recall
regressions while detecting none — the exact "a check whose output does not mean
what its name says" failure #967 is about. De-authorising says the quiet part
out loud: this instrument cannot do this job, here is the one that can.

If you think the spot-check should keep some alerting role, the place to argue
is section 3 below — I think an absolute-zero floor would still have fired ~7
times on noise in the recorded series, but that is a claim about the *old* cue
derivation and it is worth attacking.

## The arithmetic

Sampling frame: all `quality-snapshot/127.0.0.1:9926` snapshots on rockit
production, 2026-07-23 → 2026-08-23, excluding the two bootstrap snapshots —
32 nightly runs. Full data and method in
[#967 comment 5389889052](https://github.com/tpsdev-ai/flair/issues/967#issuecomment-5389889052).

| statistic | recall@5 | MRR |
|---|---|---|
| min / max | 0.00 / 1.00 | 0.00 / 0.87 |
| mean | 0.341 | 0.255 |
| population σ | **0.291** | 0.230 |
| mean absolute run-to-run delta | **0.223** | 0.166 |

```
threshold                      0.2
population σ                   0.291
threshold / σ                  0.69σ        ← the alarm sits BELOW the noise floor
mean |run-to-run delta|        0.223        ← the MEDIAN nightly wobble already
                                              exceeds the delta that declares a
                                              regression
runs at or below the 0.2 that alerted:  15 of 32   ← 0.2 is the modal region,
                                                     not an outlier
```

**Precision = 0.** The sweep produced 6 findings-mails in 34 nightly runs
(2026-07-25, 07-29, 07-31, 08-15, 08-16, 08-23). Replaying
`diffQualitySnapshots`'s recall/MRR branches over the stored snapshot series
predicts firings on exactly those six dates and no others — 6 for 6. Every one
was this metric oscillating. It is not merely *a* noisy signal in the sweep; it
is the **only** thing that has ever made the sweep speak.

## The A/B: retrieval is healthy, the cue is the defect

Read-only against rockit production 0.48.0 (`a6cc5ad`), same 10 sampled
memories, same `POST /SemanticSearch` path, same minute, `limit=5`. Only the
cue differs:

| cue | recall@5 | MRR |
|---|---|---|
| `deriveRecallCue` — the subject (what the metric used) | 0.60 | 0.16 |
| first 25 words of `content` | **1.00** | **0.78** |

Per-query, the derived-cue arm:

```
rank=5  siblings-sharing-subject=3  cue='pr-1359'
rank=4  siblings-sharing-subject=3  cue='pr-1359'
rank=0  siblings-sharing-subject=3  cue='pr-1359'
rank=4  siblings-sharing-subject=1  cue='kern-2026-08-24'
rank=4  siblings-sharing-subject=4  cue='kern-2026-08-23'
rank=5  siblings-sharing-subject=3  cue='pr-1357'
rank=0  siblings-sharing-subject=4  cue='kern-2026-08-23'
rank=0  siblings-sharing-subject=3  cue='pr-1357'
rank=0  siblings-sharing-subject=3  cue='pr-1357'
rank=2  siblings-sharing-subject=4  cue='kern-2026-08-23'
```

Every target is retrievable at rank 1–3 from its own content. The same targets
sit at rank 4–5 or fall out of the top 5 entirely when queried by their subject.
Two compounding causes, both in `deriveRecallCue`, neither of them retrieval:

- identical subjects ⇒ identical cues ⇒ identical result lists, so siblings must
  displace each other;
- these subjects are **opaque identifiers**. `pr-1359` carries almost no
  semantic signal — searching it on that instance returns, as top-1, a review
  note about PR #1275 from five days earlier. `deriveRecallCue` preferred
  `subject` whenever it was ≥ 3 chars, with no check that the subject was
  *discriminative*.

Hybrid retrieval is not implicated (0.60 / 0.16 with `FLAIR_HYBRID_RETRIEVAL`
both true and false), embedding coverage was 100% (2998/2998, zero
hash-fallback), and the 0.48.0 deploy is exonerated by a positive control
(re-running the identical check on the identical instance ~13h later returned
0.70 with no deploy in between).

## What changed

### 1. Alerting authority moves to the instrument with power

`diffQualitySnapshots` no longer emits `quality.regression` for
`recallSpotCheck.recallAtK` or `.mrr`, at any delta. The recall branches are
gone, replaced by a comment carrying this arithmetic.

The score is **still computed, still printed, still snapshotted** — the history
that made this diagnosis possible keeps accumulating, and `flair quality` still
shows the number (relabelled `report-only — not a benchmark, not an alert`).

The authority moves to `test/integration-heavy/recall-eval-gate.test.ts`
(flair-bench Layer 1 / `test/bench/recall-eval`): deterministic, hand-curated
fixed labels that are *not* derived from the corpus text, hermetic, CI-gated,
floors sitting ≥2 whole queries below the measured value against a 0.000
run-to-run noise band. Its own module doc already names this spot-check as the
thing it replaced as the recall-quality number — this PR finishes that move
instead of leaving two instruments claiming the same job.

> **One correction to the issue's framing for the record:** that gate lives at
> `test/integration-heavy/recall-eval-gate.test.ts`, not `test/integration/`.
> It runs in the `Integration Tests (heavy)` CI job, not `Integration Tests`.
> Verified by running it, see counts below — it is model-gated and skips
> visibly without the embedding model, so "it is green" needed to mean "it
> actually ran".

`QUALITY_EVENT_RECALL_DROP_THRESHOLD` stays at `0.2`, unwired, with a doc
comment explaining exactly why it is still there and a test asserting the
literal. That constant sitting at 0.69σ is the arithmetic that makes
"de-authorised" distinguishable from "silenced", and I would rather it be
checkable than asserted. If this probe is ever re-armed, the replacement
threshold must be **derived** from the measured run-to-run variance of the
fixed cue derivation — not this literal, re-referenced.

### 2. The cue derivation is fixed anyway

New exported predicate `isDiscriminativeSubject`. A subject is used as the cue
only when **all** of:

1. it is at least 3 characters (the original bar, kept);
2. it is **not opaque-identifier-shaped** — an unspaced token carrying a digit
   or one of `/ : _ . # @ \` is a slug, not a phrase. Whitespace is the primary
   discriminator, so `Harper 5.2 upgrade` stays a cue while `kern-2026-08-23`
   does not; a bare hyphen does not make a slug, so ordinary compounds
   (`two-gate`) survive;
3. it contains at least one alphabetic run of 3+ characters — `---` and `42`
   are not queries either.

Everything else falls back to content, which the A/B measured as the strictly
better cue. Worked examples (all asserted in the test file):

| subject | cue? | why |
|---|---|---|
| `Harper RBAC two-gate model` | subject | prose |
| `Harper 5.2 upgrade` | subject | whitespace ⇒ phrase; digits are fine inside one |
| `two-gate` | subject | hyphen alone is not a slug |
| `pr-1359` | content | unspaced + digit |
| `kern-2026-08-23` | content | unspaced + digit |
| `quality-snapshot/127.0.0.1:9926` | content | unspaced + `/` + digits |
| `v0.48.0`, `README.md`, `session_notes` | content | identifier-shaped |
| `x`, `---`, `42` | content | no word in it |

The content cue's cap moves **8 → 25 words**. 25 is the arm that was actually
measured (1.00 / 0.78); 8 was never measured. It also matters practically: the
duplicate-cue guard below is only useful if distinct memories produce distinct
cues, and templated review notes can easily share their first 8 words. Still a
partial cue — capped, never the whole memory for anything longer.

### 3. Sample-health guard: fail closed, visibly

New exported pure planner `planRecallSpotCheck(memories, { sampleSize })` owns
sampling, cue derivation, and a health judgment, in this order:

1. drop the tool's own `quality-snapshot` rows — the spot-check never grades its
   own bookkeeping (issue direction 1: its subject is a hostname slug and its
   content is boilerplate JSON, a guaranteed miss and a permanent constant
   penalty of ≥ 1/sampleSize on every instance running `--emit`);
2. take the `sampleSize` most-recently-written remaining rows (recency is still
   the sampling frame — the stratified-sampling change in the issue's direction
   3 is deliberately **not** taken on here);
3. derive each cue;
4. judge: **any duplicate cue, or any empty cue, makes the window UNSCORABLE.**

An unhealthy window is reported as such — `ok: false` with a self-describing
reason, so `recallSpotCheck` is `null` + a `gaps` entry beginning
`sample unhealthy — …` naming the colliding cue and explaining the mechanism,
plus a structured `recallSampleHealth` object in `--json` so a consumer never
has to string-match. No searches are spent, and no number is published. An
unscorable run also cannot become a phantom regression on the *next* night: a
null section on either side of the diff was already "gap, not drop".

The 2026-08-23 window that started this — 9 ephemeral review notes with four
distinct subjects, `pr-1356`×3 / `pr-1355`×3 / `pr-1354`×2 / `pr-1353`×1 —
becomes **healthy** under the new cue rule (slug subjects ⇒ distinct content
cues), so the guard is for the residual case the cue fix cannot rescue: genuine
near-duplicate *content*.

### 4. `QUALITY_EVENT_RECALL_DROP_THRESHOLD` — untouched

Left at `0.2`. Asserted by two tests, in two files.

## Powered check — red on unmodified main

`test/unit/quality-recall-spotcheck-967.test.ts` was written **before** the
source changes and run against unmodified `origin/main` (`6871a2d7`):

```
 5 pass
 8 fail
Ran 13 tests across 1 file.
```

The 8 failures, all behavioural (no missing-symbol failures — every mandated red
test uses only exports that already exist on main):

| # | test | main's behaviour |
|---|---|---|
| 1 | the 2026-08-23 firing pair (0.6 → 0.2) emits NO recall regression | emitted 2 findings, verbatim: `recall spot-check recall@k dropped from 0.6 to 0.2 since last snapshot` + the MRR twin |
| 2 | a full-range swing (1.0 → 0.3, the 07-29 firing) also emits nothing | emitted 2 findings |
| 3 | replaying the measured duplicate-cue window through the whole sweep emits no recall regression | emitted `recall@k dropped from 1 to 0.6` + `MRR dropped from 0.87 to 0.16` |
| 4 | the same replay still MEASURES a number worth reading | scored 0.60, expected 1.00 |
| 5 | slug subject `pr-1359` → content wins | returned `"pr-1359"` |
| 6 | `kern-2026-08-23` → content wins | returned `"kern-2026-08-23"` |
| 7 | `quality-snapshot/127.0.0.1:9926` → content wins | returned the slug |
| 8 | every cue in the measured window is unique | 4 distinct cues for 10 memories |

**The replay fixture is a replay of a measurement, not a simulation.** It plays
back the per-query rank table above; no scorer is re-implemented. The check on
whether it is faithful: on main it produces **recall@5 = 0.60 and MRR = 0.16** —
the exact pair the A/B recorded for the derived-cue arm, arrived at through
production `deriveRecallCue` → `computeRecallSpotCheck` → `computeQualityReport`
→ `buildQualitySnapshot` → `diffQualitySnapshots`, i.e. the sweep's whole
decision chain minus the HTTP hop.

### Positive controls (green on main **and** on this branch, deliberately)

Present so a green run here cannot be a vacuous one:

- **the diff machinery can still see an emission** — a genuine embedding-coverage
  crossing (96% → 71%) still fires. Passing this while tests 1–3 fail is what
  proves the assertions can observe an emission at all;
- **a genuine recall CRATER is still measured, reported and snapshotted** — ten
  distinct cues, every query missing, still yields a real `recallAtK: 0` with no
  gap and a snapshot carrying `{recallAtK: 0, mrr: 0}`. Report-only means the
  cratering signal is *kept*, just not paging;
- **`QUALITY_EVENT_RECALL_DROP_THRESHOLD === 0.2`** — the fix did not widen the
  gate;
- two cue **CONTROL**s: a prose subject is still preferred over content, and a
  hyphenated ordinary word is not a slug. The fix narrows the subject path, it
  does not delete it.

## Counts — self-measured baseline vs branch

Baseline measured on this worktree at `origin/main` `6871a2d7` before any edit.

| lane | command | baseline (main) | branch |
|---|---|---|---|
| Unit | `bun test test/unit/ test/*.test.ts` | **5021 pass / 0 fail**, 258 files | **5060 pass / 0 fail**, 259 files |
| Recall eval gate (heavy) | `FLAIR_MODELS_DIR=… bun test test/integration-heavy/recall-eval-gate.test.ts` | — | **7 pass / 0 fail** — and it *ran*: no `[recall-eval-gate] SKIPPING` line, so the gate taking over alerting authority is demonstrably firing, not silently skipping |
| Integration (src/cli.ts importers, spot sample) | `bun test test/integration/cli-local-admin-pass-fallback.test.ts test/integration/probe-instance.test.ts` | — | **7 pass / 0 fail** |
| Typecheck | `bunx tsc --noEmit -p tsconfig.check.json` | clean | clean |
| Changelog gate | `node scripts/changelog-fragments.mjs check` | — | `✓ 9 fragment(s), 9 entr(ies), no stray [Unreleased] entries` |

+39 unit tests, +1 file. No integration test exercises `flair quality` —
verified by grepping the whole tree for `computeQualityReport`,
`deriveRecallCue`, `planRecallSpotCheck`, `quality --emit`, `qualitySnapshot`
and `quality.regression`; the only hit outside `test/unit/quality*` is a doc
comment in `test/bench/recall-eval/labels.ts`.

## Deliberately not done

- **No threshold change.** Forbidden as a fix, and it would have been the wrong
  one.
- **No stratified/diverse sampling** (issue direction 3). It changes what the
  sample *is*, and I would rather land the precision fix without also moving the
  sampling frame under it. The recency window remains, and the guard now tells
  you when that window is unscorable.
- **No scoring of duplicate-cue windows as "hit if any sibling returned"**
  (issue direction 2, alternative form). That re-introduces a number where I
  think the honest output is a refusal.

## What alerts now, if recall genuinely craters

Worth being explicit, because "we removed an alert" deserves the follow-up
question. The cratering causes this probe existed to catch have their own
signals that are *not* noise-floor-bound: `instance.embeddingsStatus` →
`degraded` and the `embeddingCoverage` absolute-floor + delta-drop events cover
"embeddings down / hash-fallback climbing", and migrations halt/fail events
cover a broken index rebuild. Ranking regressions — the thing this metric could
never actually see — are the CI gate's job. The residual gap is a live-instance
retrieval failure that leaves coverage at 100% and migrations clean; that gap
was already un-covered in practice, because the check nominally covering it had
precision 0 and would have been read as noise.

Re-arming is a data question, not a taste question: measure the fixed metric's
run-to-run variance over N runs, then derive a threshold (≥2σ on the sample
design) from *that*. Recorded in the code comment so the next person does not
have to rediscover it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
