### PR TITLE
perf(recall): persistent incrementally-maintained BM25 index for the hybrid lexical leg (#1357)

### DIFF
--- a/.changelog/unreleased/fixed-1357-persistent-bm25-index.md
+++ b/.changelog/unreleased/fixed-1357-persistent-bm25-index.md
@@ -1,0 +1,33 @@
+- **Hybrid recall no longer rebuilds a full BM25 index on every query** (flair#1357;
+  Kern's design ruling, 2026-08-23). The hybrid lexical leg used to fetch the
+  ENTIRE scoped corpus out of Harper and call `buildBM25()` on it once per
+  recall, so retrieval latency grew linearly with store size — measured p50 5.6s
+  at 60k rows, 12.4s at 120k, 20.1s at 180k, extrapolating past 30s at 250k,
+  while vector-only recall over the same stores moved only 2.4s → 4.7s. The
+  lexical leg is now served from a persistent inverted index
+  (`resources/bm25-index.ts`) built once per process and maintained
+  incrementally from the Memory table's own change feed plus synchronous hooks
+  on flair's write paths, so a query touches only the documents that contain its
+  terms. Measured on a fixed 200-document matchable set inside a store grown 4×
+  (10.2k → 40.2k documents): the old path 35.9ms → 137.2ms per query (3.83×),
+  the new path 0.061ms → 0.059ms (0.96×, flat) — 584× and 2331× faster
+  respectively. The whole scoped-corpus scan is also gone from the
+  embedding-only search path, which never used it.
+
+  **Ranking is unchanged, by construction and by proof.** The index derives
+  per-query SCOPED BM25 statistics (N, avgdl, per-term df over exactly the
+  documents the query's `conditions[]` and temporal filters admit) and
+  accumulates term contributions in the same order as `buildBM25`, so scores are
+  bit-identical. Anything it cannot reproduce exactly — an unrecognised
+  condition attribute or comparator, a `tags`+`subject` intersection, or a BM25
+  score TIE inside the returned window (whose order is decided by Harper's query
+  plan, not by anything the index can observe) — makes it decline, and the
+  original per-query corpus scan answers instead. Unknown means slower, never
+  different. Verified byte-identical across 130 query shapes against a mocked
+  Harper and 73 query shapes against a live instance over the same data
+  directory, with a legacy-vs-legacy control run proving the harness itself is
+  deterministic.
+
+  `FLAIR_BM25_INDEX=false` (also `0` / `off`) forces every query back onto the
+  original path with no rebuild — the same kill-switch shape as
+  `FLAIR_HYBRID_RETRIEVAL`.

--- a/.changelog/unreleased/fixed-1357-persistent-bm25-index.md
+++ b/.changelog/unreleased/fixed-1357-persistent-bm25-index.md
@@ -29,20 +29,3 @@
   `FLAIR_BM25_INDEX=false` (also `0` / `off`) forces every query back onto the
   original path with no rebuild — the same kill-switch shape as
   `FLAIR_HYBRID_RETRIEVAL`.
-
-- **Hybrid recall now orders equal-scoring memories deterministically**
-  (flair#1363, found while proving flair#1357 above; Kern-ruled 2026-08-24).
-  `buildBM25().rank()` sorted on score alone, and because `Array.prototype.sort`
-  is stable, documents with bit-identical BM25 scores came back in whatever
-  order the corpus had been fetched in — Harper's, which is a QUERY-PLAN
-  artifact rather than a property of the store. Measured on a live instance: the
-  same rows, for the same query text, iterate in one order under the multi-agent
-  read-scope OR-group (the reader's own `agentId`-indexed rows lead) and in a
-  different one under a `tags`/`subject` filter (plain primary-key order), and
-  Harper's planner is cost-based so which applies depends on data distribution.
-  Ties are common — a memory matching one rare query term once, with the same
-  token count as another, scores identically, and the live corpus clusters at
-  19-33 tokens — so 96-99% of queries at realistic corpus shapes had a tie
-  inside the returned window. Both the scan path and the new index now sort by
-  score descending, then ascending `id`. The only results that move are ones
-  that had no defined order to begin with; nothing above a tie changes position.

--- a/.changelog/unreleased/fixed-1357-persistent-bm25-index.md
+++ b/.changelog/unreleased/fixed-1357-persistent-bm25-index.md
@@ -19,15 +19,30 @@
   documents the query's `conditions[]` and temporal filters admit) and
   accumulates term contributions in the same order as `buildBM25`, so scores are
   bit-identical. Anything it cannot reproduce exactly — an unrecognised
-  condition attribute or comparator, a `tags`+`subject` intersection, or a BM25
-  score TIE inside the returned window (whose order is decided by Harper's query
-  plan, not by anything the index can observe) — makes it decline, and the
-  original per-query corpus scan answers instead. Unknown means slower, never
-  different. Verified byte-identical across 130 query shapes against a mocked
-  Harper and 73 query shapes against a live instance over the same data
-  directory, with a legacy-vs-legacy control run proving the harness itself is
-  deterministic.
+  condition attribute or comparator, or a `tags`+`subject` intersection — makes
+  it decline, and the original per-query corpus scan answers instead. Unknown
+  means slower, never different. Verified identical across 130 query shapes
+  against a mocked Harper and 73 query shapes against a live instance over the
+  same data directory, with a legacy-vs-legacy control run proving the harness
+  itself is deterministic.
 
   `FLAIR_BM25_INDEX=false` (also `0` / `off`) forces every query back onto the
   original path with no rebuild — the same kill-switch shape as
   `FLAIR_HYBRID_RETRIEVAL`.
+
+- **Hybrid recall now orders equal-scoring memories deterministically**
+  (flair#1363, found while proving flair#1357 above; Kern-ruled 2026-08-24).
+  `buildBM25().rank()` sorted on score alone, and because `Array.prototype.sort`
+  is stable, documents with bit-identical BM25 scores came back in whatever
+  order the corpus had been fetched in — Harper's, which is a QUERY-PLAN
+  artifact rather than a property of the store. Measured on a live instance: the
+  same rows, for the same query text, iterate in one order under the multi-agent
+  read-scope OR-group (the reader's own `agentId`-indexed rows lead) and in a
+  different one under a `tags`/`subject` filter (plain primary-key order), and
+  Harper's planner is cost-based so which applies depends on data distribution.
+  Ties are common — a memory matching one rare query term once, with the same
+  token count as another, scores identically, and the live corpus clusters at
+  19-33 tokens — so 96-99% of queries at realistic corpus shapes had a tie
+  inside the returned window. Both the scan path and the new index now sort by
+  score descending, then ascending `id`. The only results that move are ones
+  that had no defined order to begin with; nothing above a tie changes position.

--- a/.changelog/unreleased/fixed-1363-bm25-tie-order.md
+++ b/.changelog/unreleased/fixed-1363-bm25-tie-order.md
@@ -1,0 +1,16 @@
+- **Hybrid recall now orders equal-scoring memories deterministically**
+  (flair#1363, found while proving flair#1357 above; Kern-ruled 2026-08-24).
+  `buildBM25().rank()` sorted on score alone, and because `Array.prototype.sort`
+  is stable, documents with bit-identical BM25 scores came back in whatever
+  order the corpus had been fetched in — Harper's, which is a QUERY-PLAN
+  artifact rather than a property of the store. Measured on a live instance: the
+  same rows, for the same query text, iterate in one order under the multi-agent
+  read-scope OR-group (the reader's own `agentId`-indexed rows lead) and in a
+  different one under a `tags`/`subject` filter (plain primary-key order), and
+  Harper's planner is cost-based so which applies depends on data distribution.
+  Ties are common — a memory matching one rare query term once, with the same
+  token count as another, scores identically, and the live corpus clusters at
+  19-33 tokens — so 96-99% of queries at realistic corpus shapes had a tie
+  inside the returned window. Both the scan path and the new index now sort by
+  score descending, then ascending `id`. The only results that move are ones
+  that had no defined order to begin with; nothing above a tie changes position.

--- a/resources/AgentSeed.ts
+++ b/resources/AgentSeed.ts
@@ -20,6 +20,7 @@
 import { Resource, databases } from "harper";
 import { isAdmin, allowAdmin, invalidateAdminCache } from "./agent-auth.js";
 import { reconcileAdminFields } from "./agent-admin.js";
+import { noteMemoryUpsert } from "./bm25-index-service.js";
 
 const DEFAULT_SOUL_KEYS = (agentId: string, displayName: string, role: string, now: string) => ({
   name: displayName,
@@ -132,6 +133,7 @@ export class AgentSeed extends Resource {
           archived: false,
         };
         await (databases as any).flair.Memory.put(record);
+        noteMemoryUpsert(record);
         memories.push(record);
       }
     } // end !hasOnboardingMemory

--- a/resources/Memory.ts
+++ b/resources/Memory.ts
@@ -32,6 +32,7 @@ import {
 import { RECORD_TYPES } from "./record-types.js";
 import { attachTrust } from "./trust-block.js";
 import { recordCitations } from "./usage-recording.js";
+import { noteMemoryUpsert, noteMemoryDelete } from "./bm25-index-service.js";
 
 /**
  * flair#744 slice 1 — read the opt-in `includeTrust` flag for a by-id get.
@@ -338,7 +339,11 @@ async function closeSupersededRecord(ctx: any, oldId: string, patch: Record<stri
   if (!existing) {
     throw new Error(`supersede-close: record ${oldId} not found`);
   }
-  await withDetachedTxn(ctx, () => (databases as any).flair.Memory.put({ ...existing, ...patch }));
+  const closed = { ...existing, ...patch };
+  await withDetachedTxn(ctx, () => (databases as any).flair.Memory.put(closed));
+  // flair#1357 — a supersede-close sets `validTo`, which the retrieval filters
+  // read, so the lexical index has to see it as eagerly as a content write.
+  noteMemoryUpsert(closed);
 }
 
 /** Does an agent hold a "write" grant from `ownerId`? Same MemoryGrant lookup
@@ -824,6 +829,11 @@ export class Memory extends (databases as any).flair.Memory {
 
     // ── Write the new record FIRST ──────────────────────────────────────────
     const result = await super.post(content);
+    // flair#1357 — read-your-write for the lexical leg. The table change feed
+    // (resources/bm25-index-service.ts) is the CORRECTNESS mechanism; this
+    // synchronous hook is what makes a store immediately searchable rather
+    // than searchable-after-the-feed-turns.
+    noteMemoryUpsert(content);
 
     // ── THEN close the superseded record ────────────────────────────────────
     // Write-new-BEFORE-close-old: the previous order (close-old via a fire-
@@ -868,7 +878,9 @@ export class Memory extends (databases as any).flair.Memory {
         });
       }
       delete content._reindex;
-      return super.put(content);
+      const reindexed = await super.put(content);
+      noteMemoryUpsert(content);
+      return reindexed;
     }
 
     // Create/update ownership (same rule as post): a non-admin agent may only
@@ -1121,6 +1133,8 @@ export class Memory extends (databases as any).flair.Memory {
 
     // ── Write the new/updated record FIRST ──────────────────────────────────
     const result = await super.put(content);
+    // flair#1357 — read-your-write for the lexical leg (see post()).
+    noteMemoryUpsert(content);
 
     // ── THEN close the superseded record (see post()) ───────────────────────
     await closeSupersededIfNeeded(ctx, content, "put");
@@ -1148,7 +1162,11 @@ export class Memory extends (databases as any).flair.Memory {
     // before the read-gate fix — the read-scoping override must not leak
     // into delete()'s internal record lookup.
     const record = await super.get(id);
-    if (!record) return super.delete(id);
+    if (!record) {
+      const gone = await super.delete(id);
+      noteMemoryDelete(id);
+      return gone;
+    }
 
     if (record.durability === "permanent") {
       // Middleware already guards this for non-admins, but belt-and-suspenders
@@ -1163,6 +1181,8 @@ export class Memory extends (databases as any).flair.Memory {
       }
     }
 
-    return super.delete(id);
+    const deleted = await super.delete(id);
+    noteMemoryDelete(id);
+    return deleted;
   }
 }

--- a/resources/MemoryFeed.ts
+++ b/resources/MemoryFeed.ts
@@ -4,6 +4,7 @@ import { computeContentHash, findExistingMemoryByContentHash } from "./memory-fe
 import { FORBIDDEN, UNAUTH, stampAttribution } from "./record-type-kit.js";
 import { assertValidVisibility, assertVisibilityAllowedForDurability, PRIVATE_VISIBILITY } from "./memory-visibility.js";
 import { assertValidDurability } from "./memory-durability.js";
+import { noteMemoryUpsert } from "./bm25-index-service.js";
 
 export class FeedMemories extends Resource {
   // Self-authorize via the Ed25519 agent verify (the auth reshape removes the
@@ -135,6 +136,8 @@ export class FeedMemories extends Resource {
     }
 
     await (databases as any).flair.Memory.put(record);
+    // flair#1357 — raw-table write: hook it explicitly (see bm25-index-service).
+    noteMemoryUpsert(record);
     return record;
   }
 

--- a/resources/MemoryMaintenance.ts
+++ b/resources/MemoryMaintenance.ts
@@ -19,6 +19,7 @@
 
 import { Resource, databases } from "harper";
 import { isAdmin } from "./agent-auth.js";
+import { noteMemoryUpsert, noteMemoryDelete } from "./bm25-index-service.js";
 
 export class MemoryMaintenance extends Resource {
   /** POST requires auth — either an agent acting on its own memories, or admin. */
@@ -75,6 +76,9 @@ export class MemoryMaintenance extends Resource {
           if (!dryRun) {
             try {
               await (databases as any).flair.Memory.delete(record.id);
+              // flair#1357 — ephemeral expiry removes the row from what the
+              // lexical leg may score.
+              noteMemoryDelete(record.id);
               stats.expired++;
             } catch {
               stats.errors++;
@@ -99,11 +103,16 @@ export class MemoryMaintenance extends Resource {
           if (ageDays > 30) {
             if (!dryRun) {
               try {
-                await (databases as any).flair.Memory.update(record.id, {
+                const archivedRow = {
                   ...record,
                   archived: true,
                   archivedAt: now.toISOString(),
-                });
+                };
+                await (databases as any).flair.Memory.update(record.id, archivedRow);
+                // flair#1357 — an `archived` flip changes what the retrieval
+                // conditions (`archived not_equal true`) admit, so the lexical
+                // index has to see it, not just content writes.
+                noteMemoryUpsert(archivedRow);
                 stats.archived++;
               } catch {
                 stats.errors++;

--- a/resources/bm25-index-service.ts
+++ b/resources/bm25-index-service.ts
@@ -1,0 +1,250 @@
+// ─── Harper wiring for the persistent BM25 index (flair#1357) ───────────────
+//
+// ./bm25-index.ts is the Harper-free data structure. This module owns the one
+// process-wide instance of it and answers the only two questions the retrieval
+// core asks: "can you serve this lexical leg?" and "here is a write you should
+// know about".
+//
+// ── WHERE THE INDEX STATE LIVES, AND WHY ────────────────────────────────────
+// In process memory, per Harper worker, NOT in a Harper table.
+//
+// A Harper-table posting list was considered and rejected on WRITE cost: a
+// memory averages ~26 tokens (the measured live corpus,
+// test/bench/corpus-profiler/profiles), so persisting postings would turn one
+// `Memory.put()` into ~25 additional indexed row writes inside the same
+// transaction — write amplification on the ingestion path in order to speed up
+// the read path. It would also put a Harper round-trip per query TERM back
+// into recall. The in-process structure costs one full corpus scan per worker
+// lifetime, which is exactly ONE instance of what the defect used to charge on
+// EVERY query.
+//
+// Footprint at 250k documents: ~6.5M postings held as paired Int32Arrays
+// (~52MB), the term dictionary (~20MB), and per-document scope metadata with
+// NO content and NO embedding (~50MB) — order 120MB steady state. For scale:
+// the code this replaces allocated a 250k-entry array of per-document term
+// Maps plus the whole projected corpus INCLUDING content, transiently, on
+// every single query.
+//
+// ── COLD BOOT: LAZY ─────────────────────────────────────────────────────────
+// Built on the first hybrid query that carries query text, not at component
+// start. Eager building would add a full corpus scan to every boot including
+// the many processes that never search (CLI verbs, migration boots, health
+// checks), and it would race the embedding engine's own model load. The first
+// query after boot pays what every query used to pay; every one after it pays
+// nothing. Concurrent first queries share a single build promise.
+//
+// ── STAYING CURRENT ─────────────────────────────────────────────────────────
+// Two mechanisms, deliberately overlapping:
+//
+//   1. THE TABLE'S OWN CHANGE FEED (`Memory.subscribe`) is the authority. It
+//      is the same audit-log-backed primitive `FeedMemories.connect()` already
+//      uses, and it observes the TABLE — so it sees writes that never touch a
+//      flair resource at all: operations-API writes, `flair` CLI direct
+//      writes, and Harper replication applying federated rows. A scheme built
+//      only from hooks in flair's own write paths CANNOT see those, which is
+//      why the feed — not the hook list — is the correctness argument.
+//      Verified against a stock instance: an operations-API insert and an
+//      operations-API delete both arrive (put/delete with the full row).
+//
+//   2. SYNCHRONOUS HOOKS at flair's own write surface (`noteMemoryUpsert` /
+//      `noteMemoryDelete`) give READ-YOUR-WRITE. The feed is asynchronous, so
+//      without the hooks a store immediately followed by a search would be a
+//      race — and the path being replaced had no such race, because it refetched
+//      the corpus every query. Both mechanisms are idempotent upserts keyed by
+//      id, so seeing a write twice is a no-op.
+//
+// If the feed cannot be established, or delivers an event shape we do not
+// understand (Harper emits a bare `reload` marker when a base copy / resync is
+// applied — precisely when the index CANNOT be patched incrementally), the
+// index marks itself stale and the next query rebuilds it. If subscription
+// fails outright, the index DISABLES itself and every query falls back to the
+// legacy per-query corpus scan. A slow-but-correct recall is acceptable; a
+// silently stale one is not — recall is the product floor.
+//
+// ── MULTI-WORKER ────────────────────────────────────────────────────────────
+// The instance is per worker thread, so in a multi-worker configuration each
+// worker pays its own first-query build and holds its own copy of the index.
+// Both of flair's shipped launch paths pin `THREADS_COUNT=1` (src/cli.ts's
+// launchd plist and its direct-spawn env), as does the integration harness, so
+// the shipped configuration has exactly one worker and "per worker" is "per
+// process". Cross-worker write visibility rides on mechanism (1): the feed is
+// audit-log-backed and the audit store is shared, so a write committed by
+// another worker still arrives. Mechanism (2) is local to the writing worker,
+// which is why it is an immediacy optimisation and never the correctness
+// argument.
+import { databases } from "harper";
+import { withDetachedTxn } from "./table-helpers.js";
+import { Bm25Index, INDEX_SELECT, type IndexRecord, type RankParams } from "./bm25-index.js";
+
+/** Kill switch. Default ON; set FLAIR_BM25_INDEX=false/0/off to force every
+ *  query back onto the legacy per-query corpus scan + buildBM25(). Read
+ *  per-call so it can be flipped without a rebuild and set per-case in tests. */
+export function bm25IndexEnabled(): boolean {
+  const v = (process.env.FLAIR_BM25_INDEX ?? "true").toLowerCase();
+  return v === "true" || v === "1" || v === "on";
+}
+
+type PendingEvent = { kind: "upsert"; record: IndexRecord } | { kind: "delete"; id: string };
+
+const index = new Bm25Index();
+let state: "empty" | "building" | "ready" | "disabled" = "empty";
+let buildPromise: Promise<boolean> | null = null;
+let pending: PendingEvent[] | null = null;
+let feedStarted = false;
+let disabledReason = "";
+
+/** Test seam — resets everything this module owns. */
+export function __resetBm25IndexForTests(): void {
+  index.clear();
+  state = "empty";
+  buildPromise = null;
+  pending = null;
+  feedStarted = false;
+  disabledReason = "";
+}
+
+/** Diagnostics, for tests and `flair doctor`-shaped callers. */
+export function bm25IndexStatus(): { state: string; size: number; postings: number; terms: number; reason: string } {
+  return { state, size: index.size, postings: index.postingCount, terms: index.termCount, reason: disabledReason };
+}
+
+function project(record: any): IndexRecord | null {
+  if (!record || typeof record.id !== "string") return null;
+  const out: IndexRecord = { id: record.id };
+  for (const k of INDEX_SELECT) if (k !== "id" && k in record) out[k] = record[k];
+  return out;
+}
+
+function apply(ev: PendingEvent): void {
+  if (ev.kind === "delete") index.remove(ev.id);
+  else index.upsert(ev.record);
+}
+
+function record(ev: PendingEvent): void {
+  if (state === "disabled" || state === "empty") return; // a later build will scan it
+  if (state === "building") { pending!.push(ev); return; }
+  apply(ev);
+}
+
+/** Read-your-write hook: call immediately after a committed Memory write that
+ *  changed content or any scope/temporal attribute. Safe to call for writes
+ *  that changed neither (it is an idempotent re-index of one row). */
+export function noteMemoryUpsert(row: any): void {
+  const r = project(row);
+  if (r) record({ kind: "upsert", record: r });
+}
+
+/** Read-your-write hook: call immediately after a committed Memory delete. */
+export function noteMemoryDelete(id: string): void {
+  if (typeof id === "string" && id.length > 0) record({ kind: "delete", id });
+}
+
+/** Force the next query to rebuild — used when the feed reports a change we
+ *  cannot express incrementally (a resync/base-copy `reload` marker). */
+export function markBm25IndexStale(reason: string): void {
+  if (state === "disabled") return;
+  disabledReason = reason;
+  state = "empty";
+  buildPromise = null;
+}
+
+function disable(reason: string): void {
+  state = "disabled";
+  disabledReason = reason;
+  buildPromise = null;
+  pending = null;
+  index.clear();
+}
+
+async function startFeed(ctx: any): Promise<void> {
+  if (feedStarted) return;
+  feedStarted = true;
+  const subscription = await withDetachedTxn(ctx, () =>
+    (databases as any).flair.Memory.subscribe({ omitCurrent: true }),
+  );
+  // Deliberately not awaited: the consumer runs for the life of the process.
+  (async () => {
+    try {
+      for await (const ev of subscription as any) {
+        const type = ev?.type;
+        if (type === "delete") {
+          record({ kind: "delete", id: String(ev.id) });
+        } else if (type === "put" || type === "insert" || type === "update" || type === "upsert") {
+          const r = project(ev?.value);
+          if (r) record({ kind: "upsert", record: r });
+          else markBm25IndexStale(`feed ${type} event carried no usable record`);
+        } else if (type !== undefined) {
+          // Includes Harper's `reload` base-copy/resync marker: the table's
+          // contents may have been replaced wholesale with no per-row events.
+          markBm25IndexStale(`unhandled feed event type ${String(type)}`);
+        }
+      }
+      disable("change feed ended");
+    } catch (err: any) {
+      disable("change feed error: " + String(err?.message ?? err));
+    }
+  })();
+}
+
+/**
+ * Build (or rebuild) the index from one full corpus scan.
+ *
+ * ORDER IS LOAD-BEARING: the change feed is started BEFORE the scan, and the
+ * events it delivers during the scan are buffered and replayed AFTER it. A
+ * delete that lands mid-scan for a row the cursor has not reached yet would
+ * otherwise be applied first and then undone by the cursor re-adding the row.
+ * Replaying after the scan lets the newer event win, whichever order they
+ * physically occurred in.
+ */
+async function build(ctx: any): Promise<boolean> {
+  state = "building";
+  pending = [];
+  index.clear();
+  try {
+    await startFeed(ctx);
+    const results = withDetachedTxn(ctx, () =>
+      (databases as any).flair.Memory.search({ select: INDEX_SELECT }),
+    );
+    for await (const row of results as any) {
+      const r = project(row);
+      if (r) index.upsert(r);
+    }
+  } catch (err: any) {
+    disable("build failed: " + String(err?.message ?? err));
+    return false;
+  }
+  const buffered = pending ?? [];
+  pending = null;
+  // `state` may have been knocked back to "empty" by a stale marker that
+  // arrived during the scan; in that case do not claim readiness.
+  if (state !== "building") return false;
+  state = "ready";
+  for (const ev of buffered) apply(ev);
+  return true;
+}
+
+async function ensureReady(ctx: any): Promise<boolean> {
+  if (!bm25IndexEnabled()) return false;
+  if (state === "disabled") return false;
+  if (state === "ready") return true;
+  if (!buildPromise) buildPromise = build(ctx).finally(() => { buildPromise = null; });
+  return buildPromise;
+}
+
+/**
+ * The lexical leg, served from the index. Returns the BM25 candidate ids
+ * (score>0, best-first, sliced to `limit`) — or NULL when the index declines,
+ * in which case the caller MUST run the legacy corpus scan + buildBM25(). Null
+ * is returned for: the kill switch, a failed/disabled index, and any query
+ * whose conditions the index cannot reproduce exactly (see
+ * ./bm25-index.ts's `planQuery`).
+ */
+export async function indexedBm25Ids(params: RankParams & { ctx?: any }): Promise<string[] | null> {
+  if (!(await ensureReady(params.ctx))) return null;
+  try {
+    return index.rank(params);
+  } catch (err: any) {
+    disable("rank failed: " + String(err?.message ?? err));
+    return null;
+  }
+}

--- a/resources/bm25-index.ts
+++ b/resources/bm25-index.ts
@@ -1,0 +1,707 @@
+// ─── Persistent, incrementally-maintained BM25 index (flair#1357) ────────────
+//
+// THE DEFECT THIS REPLACES: `retrieveCandidates()`'s hybrid leg used to fetch
+// the ENTIRE scoped corpus out of Harper and call `buildBM25()` on it — for
+// EVERY query. Tokenizing N documents and allocating N per-doc term maps per
+// recall makes retrieval latency linear in store size: measured 5.6s p50 at
+// 60k rows, 28.7s at 180k (flair#1357, LongMemEval take-6 latency journal),
+// extrapolating past 30s at 250k. Vector-only recall over the same stores
+// moved 2.4s → 4.7s, so the whole gap was the per-query index rebuild.
+//
+// Kern's ruling (2026-08-23) picked direction (a): a persistent index built on
+// WRITE and maintained incrementally, over (b) cached-corpus + dirty-tracking
+// (still pays a full scan+tokenize on the first cold query per scope, and its
+// invalidation is a consistency problem in its own right) and (c) Harper-side
+// lexical scoring (Harper has no native full-text/BM25 — its custom-index
+// registry exports only HNSW, and its comparators are
+// equals/in/contains/starts_with/ends_with/between, none of them ranked).
+//
+// ── THE HARD CONSTRAINT: ranking-identical, latency-only ────────────────────
+// Recall is the product FLOOR and hybrid is default-on, so this module is NOT
+// allowed to improve, degrade, or otherwise perturb ranking. It must return
+// the SAME ids in the SAME order as `buildBM25(corpus).rank(q)` filtered to
+// score>0 and sliced to SEM_LIMIT. Everything below that looks like a
+// restriction exists to keep that promise:
+//
+//   1. BM25 statistics are CORPUS-SCOPED. `idf` reads N and df; the length
+//      normalization reads avgdl. All three are computed over the set of
+//      documents matching the query's `conditions[]` + temporal filters —
+//      NOT over the whole store. A global-statistics index would return a
+//      different ORDER, which is precisely what we may not do. So this index
+//      holds every document once and derives per-query scoped statistics
+//      (see `Aggregates` below).
+//   2. Arithmetic is performed in the SAME ORDER as `buildBM25`, so the
+//      doubles are bit-identical: query terms are accumulated in
+//      `[...new Set(tokenize(q))]` order, and `avgdl` is a sum of integers
+//      (exact in a double regardless of summation order) divided by N.
+//   3. TIE-BREAKING IS NOT REPRODUCIBLE, SO TIES ARE DECLINED. Equal-scoring
+//      documents come back from `buildBM25().rank()` in Harper's corpus
+//      ITERATION order (stable sort), and that order is a query-planner
+//      artifact: measured, a scan under the multi-agent read-scope OR-group
+//      yields the reader's OWN agentId-indexed rows first and the rest after,
+//      while the same scan under a tags/subject filter comes back in
+//      primary-key order. When a tie could affect the returned window, `rank()`
+//      returns null and the caller falls back to the legacy scan. See the
+//      guard at the end of `rank()`.
+//   4. ANYTHING THIS MODULE CANNOT REPRODUCE EXACTLY MUST NOT BE SERVED FROM
+//      THE INDEX. `planQuery()` below is a conservative allowlist: an
+//      unrecognised condition attribute, comparator, or shape returns a plan
+//      of `null`, and the caller falls back to the legacy per-query corpus
+//      scan. Unknown means SLOW, never means WRONG.
+//
+// Harper-free on purpose — same rationale as ./bm25.ts and ./scoring.ts: the
+// scoring, the scope evaluation and the statistics derivation are unit-testable
+// against the SHIPPED code with no live Harper. The Harper wiring (lazy build
+// from a table scan, the change-feed subscription, the write hooks) lives in
+// ./bm25-index-service.ts.
+import { tokenize, BM25_K1, BM25_B } from "./bm25.js";
+import {
+  matchesConditions,
+  passesRecordFilters,
+  type Condition,
+  type LeafCondition,
+  type GroupCondition,
+  type RecordTimeFilters,
+} from "./bm25-filter.js";
+
+// ─── What the index stores per document ─────────────────────────────────────
+//
+// SUPPORTED_SCOPE_ATTRS is the CLOSED set of record attributes a query may
+// filter on and still be served from the index. It is closed for a security
+// reason, not a performance one: `matchesConditions` evaluates `not_equal`
+// against `record[attr]`, so a stored record MISSING an attribute the real row
+// carries would PASS a `not_equal` filter it should fail — a scope leak with
+// the shape of a ranking change. `planQuery()` rejects any condition naming an
+// attribute outside this set, so an attribute we do not store can never be
+// evaluated against a record that does not carry it.
+//
+// Every attribute `resources/SemanticSearch.ts` and
+// `resources/MemoryBootstrap.ts` actually put into `conditions[]` is here:
+// agentId + visibility (the read-scope OR-group, resources/memory-read-scope.ts),
+// archived (the always-present exclusion), tags and subject (the optional
+// filters). The rest are stored because they are cheap and a future caller
+// filtering on them should get the fast path rather than a silent fallback.
+export const SUPPORTED_SCOPE_ATTRS = [
+  "agentId", "visibility", "archived", "tags", "subject", "durability",
+  "source", "sessionId", "promotionStatus", "parentId", "derivedFrom",
+  "supersedes", "contentHash", "embeddingModel",
+] as const;
+
+// Attributes the TEMPORAL filters read (resources/bm25-filter.ts's
+// passesRecordFilters). Stored alongside the scope attributes; never
+// filterable via `conditions[]` (they have their own parameters).
+export const TEMPORAL_ATTRS = ["createdAt", "expiresAt", "validFrom", "validTo"] as const;
+
+/** The `select` a corpus scan needs in order to feed this index. */
+export const INDEX_SELECT: string[] = ["id", "content", ...SUPPORTED_SCOPE_ATTRS, ...TEMPORAL_ATTRS];
+
+const SUPPORTED_ATTR_SET: ReadonlySet<string> = new Set<string>(SUPPORTED_SCOPE_ATTRS);
+
+/** A record as handed to the index — a projected Memory row. */
+export interface IndexRecord {
+  id: string;
+  content?: string;
+  [attr: string]: any;
+}
+
+// ─── Per-document slot ──────────────────────────────────────────────────────
+interface Slot {
+  id: string;
+  /** Token count — `tokenize(content).length`, i.e. buildBM25's `docLen[i]`. */
+  dl: number;
+  /** Distinct-term count, for dead-posting accounting on delete. */
+  nTerms: number;
+  /** The scope/temporal attribute projection (see SUPPORTED_SCOPE_ATTRS). */
+  meta: IndexRecord;
+  /** Aggregate partition key — `agentId \0 visibility \0 archivedIsTrue`. */
+  pkey: string;
+  /**
+   * `min(expiresAt, validTo)` as epoch ms, or Infinity. `passesRecordFilters`
+   * excludes a record once EITHER is in the past, UNCONDITIONALLY (not gated
+   * on `asOf`), so expiry is monotone in wall-clock time: a document that
+   * falls out can never come back while the process runs. That is what lets
+   * the aggregates below be swept forward instead of recomputed.
+   */
+  expiry: number;
+}
+
+// A term's posting list: parallel arrays, grown by doubling. Not a Map — at
+// 250k docs × ~26 tokens (the measured live-corpus median,
+// test/bench/corpus-profiler/profiles) that is ~6.5M postings, and a Map entry
+// costs ~10x what an Int32Array cell does.
+interface Posting {
+  slots: Int32Array;
+  tfs: Int32Array;
+  len: number;
+}
+
+interface Agg { count: number; sumDl: number }
+
+function emptyPosting(): Posting {
+  return { slots: new Int32Array(4), tfs: new Int32Array(4), len: 0 };
+}
+
+function pushPosting(p: Posting, slot: number, tf: number): void {
+  if (p.len === p.slots.length) {
+    const slots = new Int32Array(p.slots.length * 2);
+    slots.set(p.slots);
+    const tfs = new Int32Array(p.tfs.length * 2);
+    tfs.set(p.tfs);
+    p.slots = slots;
+    p.tfs = tfs;
+  }
+  p.slots[p.len] = slot;
+  p.tfs[p.len] = tf;
+  p.len++;
+}
+
+// ─── Query plan ─────────────────────────────────────────────────────────────
+//
+// A plan says HOW the per-query corpus statistics (N, avgdl) can be derived.
+// `partitionConditions` are the conditions evaluable against a partition
+// representative `{agentId, visibility, archived}`; `facet` is at most one
+// tag- or subject-shaped restriction that the facet aggregates cover.
+// `exact: true` means neither aggregate applies and the statistics must be
+// computed by walking the stored metadata (still no Harper I/O and no
+// tokenization, but linear in store size — see `stats()`).
+interface QueryPlan {
+  partitionConditions: Condition[];
+  facetKey: string | null;
+  facetValues: string[] | null;
+  exact: boolean;
+}
+
+function isGroup(c: Condition): c is GroupCondition {
+  return (c as GroupCondition).operator !== undefined && Array.isArray((c as GroupCondition).conditions);
+}
+
+/** Every attribute a condition tree names, or null if the tree has a shape
+ *  `matchesConditions` would not evaluate the way we assume. */
+function conditionAttrs(c: Condition, out: Set<string>): boolean {
+  if (isGroup(c)) {
+    if (c.operator !== "or" && c.operator !== "and") return false;
+    for (const sub of c.conditions) if (!conditionAttrs(sub, out)) return false;
+    return true;
+  }
+  const leaf = c as LeafCondition;
+  if (typeof leaf.attribute !== "string") return false;
+  // Only the two comparators `matchesConditions` implements. Anything else is
+  // fail-closed THERE, which we must not silently reproduce as "in scope".
+  if (leaf.comparator !== "equals" && leaf.comparator !== "not_equal") return false;
+  out.add(leaf.attribute);
+  return true;
+}
+
+/** Does this condition tree restrict a single facet attribute to a value set
+ *  by `equals` alone (a leaf, or an OR-group of leaves on one attribute)? */
+function asFacet(c: Condition): { attr: string; values: string[] } | null {
+  if (!isGroup(c)) {
+    const leaf = c as LeafCondition;
+    if (leaf.comparator !== "equals") return null;
+    return { attr: leaf.attribute, values: [String(leaf.value)] };
+  }
+  if (c.operator !== "or" || c.conditions.length === 0) return null;
+  let attr: string | null = null;
+  const values: string[] = [];
+  for (const sub of c.conditions) {
+    if (isGroup(sub)) return null;
+    const leaf = sub as LeafCondition;
+    if (leaf.comparator !== "equals") return null;
+    if (attr === null) attr = leaf.attribute;
+    else if (attr !== leaf.attribute) return null;
+    values.push(String(leaf.value));
+  }
+  return attr ? { attr, values } : null;
+}
+
+const PARTITION_ATTRS: ReadonlySet<string> = new Set(["agentId", "visibility", "archived"]);
+const FACET_ATTRS: ReadonlySet<string> = new Set(["tags", "subject"]);
+
+export interface RankParams {
+  /** Raw query text — tokenized exactly as `buildBM25().rank()` does. */
+  q: string;
+  conditions: Condition[];
+  timeFilters?: RecordTimeFilters;
+  /**
+   * The caller's `scope.isAllowed` re-check. Evaluated per CANDIDATE always.
+   * It is additionally evaluated once per aggregate PARTITION — which is only
+   * sound if it reads nothing but `agentId`/`visibility` (the `ScopableRecord`
+   * contract, resources/memory-read-scope.ts). `resolveReadScope()` marks its
+   * predicate with `scopableOnly`; an unmarked predicate forces the exact
+   * statistics walk instead of the aggregates. Unknown means slow, not wrong.
+   */
+  isAllowed?: ((record: any) => boolean) & { scopableOnly?: boolean };
+  /** Top-N to return (SEM_LIMIT at the call site). */
+  limit: number;
+  /** Date.now() override, for tests. */
+  now?: number;
+}
+
+export class Bm25Index {
+  private slots: (Slot | null)[] = [];
+  private slotOf = new Map<string, number>();
+  private freeSlots: number[] = [];
+  private postings = new Map<string, Posting>();
+  private totalPostings = 0;
+  private deadPostings = 0;
+
+  /** Aggregates over LIVE, NOT-YET-EXPIRED docs, keyed by partition. */
+  private partitions = new Map<string, Agg>();
+  /** `${attr} ${value}` → partition → aggregate. Covers ONE facet
+   *  restriction (tags or subject); a query naming both falls back. */
+  private facets = new Map<string, Map<string, Agg>>();
+  /** A representative `{agentId, visibility, archived}` per partition key, so
+   *  a plan's partition conditions can be evaluated once per partition. */
+  private partitionRep = new Map<string, IndexRecord>();
+
+  /** Min-heap of (expiry, slot) for docs with a temporal bound. Entries may be
+   *  stale (doc re-indexed or removed); validated on pop. */
+  private expiryHeap: { ts: number; slot: number }[] = [];
+  /** Wall clock the aggregates have been swept to. */
+  private sweptTo = 0;
+  /** Slots retired by the sweep — removed from the aggregates. */
+  private retired = new Set<number>();
+
+  get size(): number { return this.slotOf.size; }
+  /** Live postings, for the memory-footprint assertions in the tests. */
+  get postingCount(): number { return this.totalPostings - this.deadPostings; }
+  get termCount(): number { return this.postings.size; }
+
+  has(id: string): boolean { return this.slotOf.has(id); }
+
+  clear(): void {
+    this.slots = [];
+    this.slotOf.clear();
+    this.freeSlots = [];
+    this.postings.clear();
+    this.totalPostings = 0;
+    this.deadPostings = 0;
+    this.partitions.clear();
+    this.facets.clear();
+    this.partitionRep.clear();
+    this.expiryHeap = [];
+    this.sweptTo = 0;
+    this.retired.clear();
+  }
+
+  // ─── Maintenance ──────────────────────────────────────────────────────────
+
+  /**
+   * Add or replace a document. Deliberately NOT "diff the content and patch
+   * the postings": an upsert always tombstones the old slot and appends a new
+   * one. Detecting an unchanged body would need a content fingerprint, and a
+   * fingerprint collision is a silently-wrong lexical index — the one failure
+   * mode this index may not have. The cost is a dead posting run per update,
+   * reclaimed by `compact()` below at O(1) amortized.
+   */
+  upsert(record: IndexRecord): void {
+    const id = record?.id;
+    if (typeof id !== "string" || id.length === 0) return;
+    this.remove(id);
+
+    const tokens = tokenize(record.content || "");
+    const tf = new Map<string, number>();
+    for (const t of tokens) tf.set(t, (tf.get(t) || 0) + 1);
+
+    const meta: IndexRecord = { id };
+    for (const attr of SUPPORTED_SCOPE_ATTRS) if (attr in record) meta[attr] = record[attr];
+    for (const attr of TEMPORAL_ATTRS) if (attr in record) meta[attr] = record[attr];
+
+    const slot = this.freeSlots.length > 0 ? this.freeSlots.pop()! : this.slots.length;
+    const entry: Slot = {
+      id,
+      dl: tokens.length,
+      nTerms: tf.size,
+      meta,
+      pkey: partitionKeyOf(meta),
+      expiry: expiryOf(meta),
+    };
+    this.slots[slot] = entry;
+    this.slotOf.set(id, slot);
+
+    for (const [term, count] of tf) {
+      let p = this.postings.get(term);
+      if (!p) { p = emptyPosting(); this.postings.set(term, p); }
+      pushPosting(p, slot, count);
+    }
+    this.totalPostings += tf.size;
+
+    // A document whose bound has ALREADY passed is born retired: it can never
+    // pass `passesRecordFilters`, so it must not enter the aggregates.
+    if (entry.expiry <= this.sweptTo) {
+      this.retired.add(slot);
+    } else {
+      this.addToAggregates(entry);
+      if (entry.expiry !== Infinity) heapPush(this.expiryHeap, { ts: entry.expiry, slot });
+    }
+  }
+
+  remove(id: string): void {
+    const slot = this.slotOf.get(id);
+    if (slot === undefined) return;
+    const entry = this.slots[slot];
+    this.slotOf.delete(id);
+    this.slots[slot] = null;
+    if (entry) {
+      if (!this.retired.delete(slot)) this.removeFromAggregates(entry);
+      this.deadPostings += entry.nTerms;
+    }
+    this.maybeCompact();
+  }
+
+  /**
+   * Drop tombstoned postings and reclaim their slots. Triggered when a quarter
+   * of the postings are dead, so the work is O(1) amortized per update. Slot
+   * NUMBERS are only recycled here, after every posting referencing them is
+   * gone — recycling earlier would let a stale posting resolve to an unrelated
+   * document.
+   */
+  private maybeCompact(): void {
+    if (this.deadPostings * 4 <= this.totalPostings || this.totalPostings === 0) return;
+    let live = 0;
+    for (const [term, p] of this.postings) {
+      let w = 0;
+      for (let r = 0; r < p.len; r++) {
+        const s = p.slots[r];
+        if (this.slots[s] === null) continue;
+        p.slots[w] = s;
+        p.tfs[w] = p.tfs[r];
+        w++;
+      }
+      p.len = w;
+      live += w;
+      if (w === 0) this.postings.delete(term);
+    }
+    this.totalPostings = live;
+    this.deadPostings = 0;
+    this.freeSlots = [];
+    for (let s = 0; s < this.slots.length; s++) if (this.slots[s] === null) this.freeSlots.push(s);
+  }
+
+  // ─── Aggregates ───────────────────────────────────────────────────────────
+
+  private addToAggregates(entry: Slot): void {
+    bump(this.partitions, entry.pkey, entry.dl, 1);
+    if (!this.partitionRep.has(entry.pkey)) {
+      this.partitionRep.set(entry.pkey, {
+        id: "",
+        agentId: entry.meta.agentId,
+        visibility: entry.meta.visibility,
+        archived: entry.meta.archived,
+      });
+    }
+    for (const fk of facetKeysOf(entry.meta)) {
+      let m = this.facets.get(fk);
+      if (!m) { m = new Map(); this.facets.set(fk, m); }
+      bump(m, entry.pkey, entry.dl, 1);
+    }
+  }
+
+  private removeFromAggregates(entry: Slot): void {
+    bump(this.partitions, entry.pkey, -entry.dl, -1);
+    for (const fk of facetKeysOf(entry.meta)) {
+      const m = this.facets.get(fk);
+      if (m) bump(m, entry.pkey, -entry.dl, -1);
+    }
+  }
+
+  /** Advance the aggregates to `now` by retiring every document whose
+   *  expiresAt/validTo has passed. Amortized O(1) per document per lifetime. */
+  private sweep(now: number): void {
+    if (now <= this.sweptTo) { this.sweptTo = Math.max(this.sweptTo, now); return; }
+    this.sweptTo = now;
+    while (this.expiryHeap.length > 0 && this.expiryHeap[0].ts < now) {
+      const top = heapPop(this.expiryHeap)!;
+      const entry = this.slots[top.slot];
+      if (!entry || entry.expiry !== top.ts) continue; // stale heap entry
+      if (this.retired.has(top.slot)) continue;
+      this.retired.add(top.slot);
+      this.removeFromAggregates(entry);
+    }
+  }
+
+  // ─── Planning ─────────────────────────────────────────────────────────────
+
+  /**
+   * Decide how this query's corpus statistics can be derived, or return null
+   * if the index must not serve it at all. Conservative by construction: every
+   * branch that cannot be reproduced EXACTLY either downgrades to the linear
+   * exact walk or refuses outright.
+   */
+  planQuery(conditions: Condition[], timeFilters: RecordTimeFilters, isAllowed?: RankParams["isAllowed"]): QueryPlan | null {
+    const attrs = new Set<string>();
+    for (const c of conditions) {
+      if (!conditionAttrs(c, attrs)) return null; // unknown shape/comparator
+    }
+    for (const a of attrs) if (!SUPPORTED_ATTR_SET.has(a)) return null; // unstored attribute
+
+    // `sinceDate`/`asOf` restrict the corpus by createdAt/validFrom/validTo,
+    // which the aggregates do not model. Exact walk.
+    const temporallyFiltered = Boolean(timeFilters?.sinceDate || timeFilters?.asOf);
+    // An isAllowed we cannot legally hoist to the partition level.
+    const hoistable = !isAllowed || isAllowed.scopableOnly === true;
+
+    const partitionConditions: Condition[] = [];
+    let facet: { attr: string; values: string[] } | null = null;
+    let exact = temporallyFiltered || !hoistable;
+
+    for (const c of conditions) {
+      const cAttrs = new Set<string>();
+      conditionAttrs(c, cAttrs);
+      if ([...cAttrs].every((a) => PARTITION_ATTRS.has(a))) { partitionConditions.push(c); continue; }
+      const f = asFacet(c);
+      if (f && FACET_ATTRS.has(f.attr) && facet === null) { facet = f; continue; }
+      // Mixed-attribute group, a second facet, or a non-equals restriction on
+      // a facet attribute: the aggregates cannot express it.
+      exact = true;
+      partitionConditions.push(c);
+    }
+
+    return {
+      partitionConditions,
+      facetKey: exact ? null : facet ? facet.attr : null,
+      facetValues: exact ? null : facet ? facet.values : null,
+      exact,
+    };
+  }
+
+  /**
+   * N and avgdl over the scoped corpus — the two statistics `buildBM25` derives
+   * from the whole fetched corpus. Returns the EXACT values the legacy path
+   * would have computed.
+   */
+  private stats(
+    plan: QueryPlan,
+    conditions: Condition[],
+    timeFilters: RecordTimeFilters,
+    isAllowed: RankParams["isAllowed"],
+    now: number,
+  ): { N: number; sumDl: number } {
+    if (plan.exact) {
+      // Linear in stored documents, but over in-memory metadata only: no
+      // Harper fetch, no tokenization, no per-doc allocation. This is the
+      // fallback for sinceDate/asOf/tag+subject-together queries.
+      let N = 0, sumDl = 0;
+      for (const entry of this.slots) {
+        if (!entry) continue;
+        if (!matchesConditions(conditions, entry.meta)) continue;
+        if (!passesRecordFilters(entry.meta, { ...timeFilters, now })) continue;
+        if (isAllowed && !isAllowed(entry.meta)) continue;
+        N++;
+        sumDl += entry.dl;
+      }
+      return { N, sumDl };
+    }
+
+    // Aggregate path: O(#partitions), independent of store size.
+    const source = plan.facetKey
+      ? mergeFacetAggregates(this.facets, plan.facetKey, plan.facetValues!)
+      : this.partitions;
+    let N = 0, sumDl = 0;
+    for (const [pkey, agg] of source) {
+      if (agg.count === 0) continue;
+      const rep = this.partitionRep.get(pkey);
+      if (!rep) continue;
+      if (!matchesConditions(plan.partitionConditions, rep)) continue;
+      if (isAllowed && !isAllowed(rep)) continue;
+      N += agg.count;
+      sumDl += agg.sumDl;
+    }
+    return { N, sumDl };
+  }
+
+  /**
+   * The lexical leg: the ids `buildBM25(scopedCorpus).rank(q)` would place in
+   * the top `limit` after dropping score-0 documents. Returns null when the
+   * index declines the query (see `planQuery`), in which case the caller MUST
+   * run the legacy corpus scan.
+   *
+   * FULLY SYNCHRONOUS on purpose. A Harper component worker is single-threaded
+   * JavaScript, so a body with no `await` in it cannot observe a write landing
+   * part-way through: every query sees one consistent index snapshot, the same
+   * guarantee the old single-pass corpus fetch gave.
+   */
+  rank(params: RankParams): string[] | null {
+    const { q, conditions, limit } = params;
+    const timeFilters: RecordTimeFilters = params.timeFilters ?? {};
+    const isAllowed = params.isAllowed;
+    const now = params.now ?? timeFilters.now ?? Date.now();
+
+    const plan = this.planQuery(conditions, timeFilters, isAllowed);
+    if (!plan) return null;
+
+    this.sweep(now);
+
+    const qToks = [...new Set(tokenize(q))];
+    if (qToks.length === 0) return [];
+
+    const effectiveFilters: RecordTimeFilters = { ...timeFilters, now };
+    // Scope decisions are memoized per slot: a slot reached through several
+    // query terms is evaluated once, and the df pass and the scoring pass
+    // agree by construction.
+    const inScope = new Map<number, boolean>();
+    const check = (slot: number): boolean => {
+      let v = inScope.get(slot);
+      if (v !== undefined) return v;
+      const entry = this.slots[slot];
+      v = !!entry
+        && matchesConditions(conditions, entry.meta)
+        && passesRecordFilters(entry.meta, effectiveFilters)
+        && (!isAllowed || isAllowed(entry.meta));
+      inScope.set(slot, v);
+      return v;
+    };
+
+    // ── Pass 1: df(t) over the SCOPED corpus ────────────────────────────────
+    const df: number[] = new Array(qToks.length).fill(0);
+    const lists: (Posting | undefined)[] = new Array(qToks.length);
+    for (let i = 0; i < qToks.length; i++) {
+      const p = this.postings.get(qToks[i]);
+      lists[i] = p;
+      if (!p) continue;
+      let n = 0;
+      for (let r = 0; r < p.len; r++) if (check(p.slots[r])) n++;
+      df[i] = n;
+    }
+
+    const { N, sumDl } = this.stats(plan, conditions, timeFilters, isAllowed, now);
+    const avgdl = sumDl / (N || 1);
+    const lengthNorm = avgdl || 1;
+
+    // ── Pass 2: score ───────────────────────────────────────────────────────
+    // Terms are visited in `qToks` order and contributions are accumulated in
+    // that order per document — the same addition sequence `buildBM25().rank()`
+    // uses, so the resulting doubles are bit-identical.
+    const scores = new Map<number, number>();
+    for (let i = 0; i < qToks.length; i++) {
+      const p = lists[i];
+      if (!p) continue;
+      const n = df[i];
+      const idf = Math.log(1 + (N - n + 0.5) / (n + 0.5));
+      for (let r = 0; r < p.len; r++) {
+        const slot = p.slots[r];
+        if (!check(slot)) continue;
+        const f = p.tfs[r];
+        const dl = this.slots[slot]!.dl;
+        const numer = f * (BM25_K1 + 1);
+        const denom = f + BM25_K1 * (1 - BM25_B + BM25_B * (dl / lengthNorm));
+        scores.set(slot, (scores.get(slot) || 0) + idf * (numer / denom));
+      }
+    }
+
+    // ── Rank ────────────────────────────────────────────────────────────────
+    // score>0 only (buildBM25's caller drops zeroes), then score DESC with ties
+    // broken by ascending id — the stable-sort-over-corpus-order semantics of
+    // the legacy path, given Harper scans in primary-key order.
+    const out: { id: string; score: number }[] = [];
+    for (const [slot, score] of scores) {
+      if (score > 0) out.push({ id: this.slots[slot]!.id, score });
+    }
+    // Score DESC. The id component only makes the sort a total order (so the
+    // ambiguity check below sees equal scores adjacent and the function is
+    // deterministic) — it never decides a RETURNED order, because any tie
+    // inside the window makes this function return null.
+    out.sort((a, b) => (b.score - a.score) || (a.id < b.id ? -1 : a.id > b.id ? 1 : 0));
+
+    // ── TIE AMBIGUITY: DECLINE RATHER THAN GUESS ────────────────────────────
+    // `buildBM25().rank()` sorts by score with `Array.prototype.sort`, which is
+    // stable, so EQUAL-SCORING documents come back in the order Harper yielded
+    // the corpus. That order is a QUERY-PLANNER ARTIFACT, not a property this
+    // index can reconstruct: measured against a live instance
+    // (test/integration/bm25-index-scan-order-1357.test.ts), a scan under the
+    // multi-agent read-scope OR-group yields the READER'S OWN agentId-indexed
+    // rows first and everything else after — while the same scan under a
+    // tags/subject filter comes back in primary-key order. Different plan,
+    // different tie order, same query text.
+    //
+    // Reproducing that would mean reproducing Harper's planner. Reordering
+    // ties ourselves would be a RANKING CHANGE, which this work is explicitly
+    // not allowed to make. So when a score tie could affect the returned
+    // window, the index declines and the caller's legacy corpus scan answers —
+    // slower, and exactly right. Ties strictly BELOW the window cannot change
+    // which ids are returned or in what order, so they are ignored; the pair
+    // STRADDLING the boundary can (it decides the last slot), so it is checked.
+    const bound = Math.min(out.length, limit + 1);
+    for (let i = 1; i < bound; i++) {
+      if (out[i].score === out[i - 1].score) return null;
+    }
+    return out.slice(0, limit).map((r) => r.id);
+  }
+}
+
+// ─── helpers ────────────────────────────────────────────────────────────────
+
+function bump(map: Map<string, Agg>, key: string, dl: number, count: number): void {
+  const a = map.get(key);
+  if (a) { a.count += count; a.sumDl += dl; return; }
+  map.set(key, { count, sumDl: dl });
+}
+
+function partitionKeyOf(meta: IndexRecord): string {
+  return `${meta.agentId ?? ""} ${meta.visibility ?? ""} ${meta.archived === true ? "1" : "0"}`;
+}
+
+function* facetKeysOf(meta: IndexRecord): Generator<string> {
+  const tags = meta.tags;
+  if (Array.isArray(tags)) for (const t of tags) yield `tags ${String(t)}`;
+  if (meta.subject !== undefined && meta.subject !== null) yield `subject ${String(meta.subject)}`;
+}
+
+function mergeFacetAggregates(
+  facets: Map<string, Map<string, Agg>>,
+  attr: string,
+  values: string[],
+): Map<string, Agg> {
+  // A record carries ONE subject and is counted once per tag it holds, and a
+  // tag-equals filter names a single tag — so summing across `values` never
+  // double-counts a document.
+  if (values.length === 1) return facets.get(`${attr} ${values[0]}`) ?? new Map();
+  const merged = new Map<string, Agg>();
+  for (const v of values) {
+    const m = facets.get(`${attr} ${v}`);
+    if (!m) continue;
+    for (const [pkey, agg] of m) bump(merged, pkey, agg.sumDl, agg.count);
+  }
+  return merged;
+}
+
+function expiryOf(meta: IndexRecord): number {
+  let e = Infinity;
+  const exp = meta.expiresAt ? Date.parse(meta.expiresAt) : NaN;
+  if (!Number.isNaN(exp)) e = Math.min(e, exp);
+  const vt = meta.validTo ? Date.parse(meta.validTo) : NaN;
+  if (!Number.isNaN(vt)) e = Math.min(e, vt);
+  return e;
+}
+
+// Binary min-heap on `.ts`.
+function heapPush(h: { ts: number; slot: number }[], v: { ts: number; slot: number }): void {
+  h.push(v);
+  let i = h.length - 1;
+  while (i > 0) {
+    const parent = (i - 1) >> 1;
+    if (h[parent].ts <= h[i].ts) break;
+    const tmp = h[parent]; h[parent] = h[i]; h[i] = tmp;
+    i = parent;
+  }
+}
+
+function heapPop(h: { ts: number; slot: number }[]): { ts: number; slot: number } | undefined {
+  if (h.length === 0) return undefined;
+  const top = h[0];
+  const last = h.pop()!;
+  if (h.length > 0) {
+    h[0] = last;
+    let i = 0;
+    for (;;) {
+      const l = 2 * i + 1, r = l + 1;
+      let m = i;
+      if (l < h.length && h[l].ts < h[m].ts) m = l;
+      if (r < h.length && h[r].ts < h[m].ts) m = r;
+      if (m === i) break;
+      const tmp = h[m]; h[m] = h[i]; h[i] = tmp;
+      i = m;
+    }
+  }
+  return top;
+}

--- a/resources/bm25-index.ts
+++ b/resources/bm25-index.ts
@@ -34,20 +34,25 @@
 //      doubles are bit-identical: query terms are accumulated in
 //      `[...new Set(tokenize(q))]` order, and `avgdl` is a sum of integers
 //      (exact in a double regardless of summation order) divided by N.
-//   3. TIE-BREAKING IS NOT REPRODUCIBLE, SO TIES ARE DECLINED. Equal-scoring
-//      documents come back from `buildBM25().rank()` in Harper's corpus
-//      ITERATION order (stable sort), and that order is a query-planner
-//      artifact: measured, a scan under the multi-agent read-scope OR-group
-//      yields the reader's OWN agentId-indexed rows first and the rest after,
-//      while the same scan under a tags/subject filter comes back in
-//      primary-key order. When a tie could affect the returned window, `rank()`
-//      returns null and the caller falls back to the legacy scan. See the
-//      guard at the end of `rank()`.
+//   3. TIE-BREAKING IS EXPLICIT AND SHARED (flair#1363). Equal-scoring
+//      documents used to come back from `buildBM25().rank()` in Harper's
+//      corpus ITERATION order (stable sort over the fetched corpus) — a
+//      query-planner artifact, measured to differ between the multi-agent
+//      read-scope OR-group (reader's own rows first) and a tags/subject filter
+//      (plain primary-key order) for the same rows and the same query text. No
+//      index can reconstruct a planner, so hybrid recall was nondeterministic
+//      for tied documents and this work could not have been correct while that
+//      remained true. Kern's ruling (2026-08-24): "byte-identical to a
+//      nondeterministic source is a contradiction." Both paths now sort by
+//      score DESC then ascending `id`, so the tie order is defined, identical,
+//      and reproducible without Harper.
 //   4. ANYTHING THIS MODULE CANNOT REPRODUCE EXACTLY MUST NOT BE SERVED FROM
 //      THE INDEX. `planQuery()` below is a conservative allowlist: an
 //      unrecognised condition attribute, comparator, or shape returns a plan
 //      of `null`, and the caller falls back to the legacy per-query corpus
-//      scan. Unknown means SLOW, never means WRONG.
+//      scan. Unknown means SLOW, never means WRONG. (Score ties were briefly
+//      in this category too — see 3; they no longer are, because the tie order
+//      is now defined rather than inherited.)
 //
 // Harper-free on purpose — same rationale as ./bm25.ts and ./scoring.ts: the
 // scoring, the scope evaluation and the statistics derivation are unit-testable
@@ -590,41 +595,23 @@ export class Bm25Index {
     }
 
     // ── Rank ────────────────────────────────────────────────────────────────
-    // score>0 only (buildBM25's caller drops zeroes), then score DESC with ties
-    // broken by ascending id — the stable-sort-over-corpus-order semantics of
-    // the legacy path, given Harper scans in primary-key order.
+    // score>0 only — `buildBM25`'s caller drops zeroes, and a document can only
+    // score 0 here by containing no query term at all (the +1 IDF variant is
+    // strictly positive for every term, so a match always contributes).
     const out: { id: string; score: number }[] = [];
     for (const [slot, score] of scores) {
       if (score > 0) out.push({ id: this.slots[slot]!.id, score });
     }
-    // Score DESC. The id component only makes the sort a total order (so the
-    // ambiguity check below sees equal scores adjacent and the function is
-    // deterministic) — it never decides a RETURNED order, because any tie
-    // inside the window makes this function return null.
+    // Score DESC, ties by ascending id — CHARACTER-FOR-CHARACTER the comparator
+    // `buildBM25().rank()` uses (resources/bm25.ts). That shared comparator is
+    // the whole reason this index can serve the lexical leg: tie order used to
+    // be inherited from Harper's corpus-scan order, which is a query-plan
+    // artifact an index cannot reconstruct (flair#1363). If one of these two
+    // comparators is ever changed, change BOTH — they are one contract written
+    // in two places, and test/unit/bm25-index-latency-1357.test.ts asserts
+    // top-N equality between the two implementations.
     out.sort((a, b) => (b.score - a.score) || (a.id < b.id ? -1 : a.id > b.id ? 1 : 0));
 
-    // ── TIE AMBIGUITY: DECLINE RATHER THAN GUESS ────────────────────────────
-    // `buildBM25().rank()` sorts by score with `Array.prototype.sort`, which is
-    // stable, so EQUAL-SCORING documents come back in the order Harper yielded
-    // the corpus. That order is a QUERY-PLANNER ARTIFACT, not a property this
-    // index can reconstruct: measured against a live instance
-    // (test/integration/bm25-index-scan-order-1357.test.ts), a scan under the
-    // multi-agent read-scope OR-group yields the READER'S OWN agentId-indexed
-    // rows first and everything else after — while the same scan under a
-    // tags/subject filter comes back in primary-key order. Different plan,
-    // different tie order, same query text.
-    //
-    // Reproducing that would mean reproducing Harper's planner. Reordering
-    // ties ourselves would be a RANKING CHANGE, which this work is explicitly
-    // not allowed to make. So when a score tie could affect the returned
-    // window, the index declines and the caller's legacy corpus scan answers —
-    // slower, and exactly right. Ties strictly BELOW the window cannot change
-    // which ids are returned or in what order, so they are ignored; the pair
-    // STRADDLING the boundary can (it decides the last slot), so it is checked.
-    const bound = Math.min(out.length, limit + 1);
-    for (let i = 1; i < bound; i++) {
-      if (out[i].score === out[i - 1].score) return null;
-    }
     return out.slice(0, limit).map((r) => r.id);
   }
 }

--- a/resources/bm25.ts
+++ b/resources/bm25.ts
@@ -108,7 +108,37 @@ export function buildBM25(docs: BM25Doc[]): BM25Index {
       }
       return { id: d.id, score: s };
     });
-    scored.sort((a, b) => b.score - a.score);
+    // Score DESC, ties broken by ascending id (flair#1363, Kern-ruled
+    // 2026-08-24, landed with the flair#1357 index work).
+    //
+    // This sort used to be `(a, b) => b.score - a.score` alone. Because
+    // `Array.prototype.sort` is stable, equal-scoring documents then came back
+    // in whatever order Harper's corpus scan had yielded them — and THAT order
+    // is a query-plan artifact, not a property of the store. Measured against a
+    // live instance (test/integration/bm25-index-scan-order-1357.test.ts): the
+    // same rows, for the same query text, iterate in one order under the
+    // multi-agent read-scope OR-group (the reader's own agentId-indexed rows
+    // lead, everything else follows) and in a DIFFERENT one under a
+    // tags/subject filter (plain primary-key order). Harper's planner is
+    // cost-based, so which of those applies is a function of data
+    // distribution. Hybrid recall was therefore nondeterministic for tied
+    // documents, and nothing in the suite could see it — only exact score ties
+    // move, and they move at the tail of the result window.
+    //
+    // Ties are NOT a curiosity: a document matching one rare query term once,
+    // with the same token count as another such document, scores identically,
+    // and flair's live corpus clusters at 19-33 tokens
+    // (test/bench/corpus-profiler/profiles/corpus-v2.json). Measured at
+    // realistic corpus shapes, 96-99% of queries have a tie inside the returned
+    // window.
+    //
+    // Making the tie-break EXPLICIT is what lets resources/bm25-index.ts serve
+    // the lexical leg at all: an index cannot reproduce a planner, but it can
+    // reproduce `id` ascending. Both paths now sort exactly this way, so their
+    // output is identical including tie order. The ranking change is confined
+    // to documents whose BM25 scores are bit-identical — where there was no
+    // defined order to preserve, only an accident to stop inheriting.
+    scored.sort((a, b) => (b.score - a.score) || (a.id < b.id ? -1 : a.id > b.id ? 1 : 0));
     return scored;
   }
 

--- a/resources/memory-read-scope.ts
+++ b/resources/memory-read-scope.ts
@@ -104,8 +104,18 @@ export interface ReadScope {
    * that either can't push the condition down into a Harper query (e.g.
    * MemoryBootstrap's in-memory candidate lists) or want a second check after
    * the fact (BM25's pre-fusion filter). Always agrees with `condition`.
+   *
+   * `scopableOnly` is a machine-readable restatement of the `ScopableRecord`
+   * parameter type: this predicate reads NOTHING but `agentId` and
+   * `visibility`. The BM25 index (resources/bm25-index.ts) needs that promise
+   * in a form it can TEST, not just read — it evaluates the predicate once per
+   * (agentId, visibility, archived) partition when deriving a query's corpus
+   * statistics, which is only sound for a predicate with no other inputs. An
+   * UNMARKED predicate is evaluated per record instead (correct, linear), so
+   * an unmarked one costs speed and never correctness. Do not set this flag on
+   * a predicate that reads any other field.
    */
-  isAllowed: (record: ScopableRecord | null | undefined) => boolean;
+  isAllowed: ((record: ScopableRecord | null | undefined) => boolean) & { scopableOnly?: boolean };
 }
 
 /**
@@ -135,6 +145,8 @@ export async function resolveReadScope(authAgentId: string): Promise<ReadScope> 
     if (!record) return false;
     return record.agentId === authAgentId || !isPrivateVisibility(record.visibility);
   };
+  // See ReadScope.isAllowed's doc: agentId + visibility, nothing else.
+  isAllowed.scopableOnly = true as const;
 
   return { allowedOwners: [authAgentId], condition, isAllowed };
 }

--- a/resources/semantic-retrieval-core.ts
+++ b/resources/semantic-retrieval-core.ts
@@ -59,6 +59,7 @@ import { cosineSimilarity } from "./dedup.js";
 import { compositeScore } from "./scoring.js";
 import { buildBM25, fuseRrfNormalized, SEM_LIMIT } from "./bm25.js";
 import { isAllowedBm25Candidate, type Condition } from "./bm25-filter.js";
+import { indexedBm25Ids } from "./bm25-index-service.js";
 
 // Convert HNSW cosine distance (1 - similarity) to similarity score.
 function distanceToSimilarity(distance: number): number {
@@ -260,21 +261,60 @@ export async function retrieveCandidates(params: RetrieveCandidatesParams): Prom
       }
     }
 
-    // ── (b) BM25 candidate records over the SCOPED corpus ────────────────
-    const corpusQuery: any = conditions.length > 0
-      ? { conditions, select }
-      : { select };
-    const corpusResults = withDetachedTxn(ctx, () => (databases as any).flair.Memory.search(corpusQuery));
+    // ── (b) The BM25 lexical leg ─────────────────────────────────────────
+    //
+    // flair#1357. This used to be unconditional: fetch the WHOLE scoped corpus
+    // out of Harper, then `buildBM25()` it — per query. That made retrieval
+    // latency linear in store size (5.6s p50 at 60k rows, 28.7s at 180k). The
+    // lexical leg is now served from a persistent, incrementally-maintained
+    // index (resources/bm25-index.ts) whose contract is RANKING-IDENTICAL:
+    // same ids, same order, byte for byte. The legacy scan below is still the
+    // reference implementation AND the fallback — the index returns null for
+    // any query it cannot reproduce exactly, and for a query with no text
+    // there is no lexical leg to serve at all.
     const allowedById = new Map<string, any>();
-    const bm25Docs: { id: string; content?: string }[] = [];
-    for await (const record of corpusResults) {
-      // Defense-in-depth: re-check the SAME conditions[] + temporal filters
-      // in-process. Even if a Harper query change ever let an out-of-scope
-      // record through, it is dropped here BEFORE it can be BM25-scored/fused.
-      if (!isAllowedBm25Candidate(record, conditions as Condition[], { sinceDate, asOf })) continue;
-      if (!passesAllowed(record)) continue;
-      allowedById.set(record.id, record);
-      bm25Docs.push({ id: record.id, content: record.content });
+    let bm25Ids: string[] = [];
+    // Only the no-signal listing branch (d) still needs the full scoped
+    // corpus materialised; every other branch resolves records by id.
+    const needCorpusListing = !q && !qEmb;
+    let servedFromIndex = false;
+
+    if (q) {
+      const fromIndex = await indexedBm25Ids({
+        q: String(q),
+        conditions: conditions as Condition[],
+        timeFilters: { sinceDate, asOf },
+        isAllowed,
+        limit: SEM_LIMIT,
+        ctx,
+      });
+      if (fromIndex) {
+        bm25Ids = fromIndex;
+        servedFromIndex = true;
+      }
+    }
+
+    if (!servedFromIndex && (q || needCorpusListing)) {
+      // ── Legacy path: scoped corpus scan + per-query buildBM25() ──────────
+      const corpusQuery: any = conditions.length > 0
+        ? { conditions, select }
+        : { select };
+      const corpusResults = withDetachedTxn(ctx, () => (databases as any).flair.Memory.search(corpusQuery));
+      const bm25Docs: { id: string; content?: string }[] = [];
+      for await (const record of corpusResults) {
+        // Defense-in-depth: re-check the SAME conditions[] + temporal filters
+        // in-process. Even if a Harper query change ever let an out-of-scope
+        // record through, it is dropped here BEFORE it can be BM25-scored/fused.
+        if (!isAllowedBm25Candidate(record, conditions as Condition[], { sinceDate, asOf })) continue;
+        if (!passesAllowed(record)) continue;
+        allowedById.set(record.id, record);
+        bm25Docs.push({ id: record.id, content: record.content });
+      }
+      if (q) {
+        const bm25 = buildBM25(bm25Docs);
+        const ranked = bm25.rank(String(q));
+        bm25Ids = ranked.filter(r => r.score > 0).slice(0, SEM_LIMIT).map(r => r.id);
+      }
     }
 
     // Carry semantic candidates that survived their temporal gate into the
@@ -287,12 +327,37 @@ export async function retrieveCandidates(params: RetrieveCandidatesParams): Prom
       }
     }
 
-    // ── (c) BM25 lexical ranking → top SEM_LIMIT (only when q present) ────
-    let bm25Ids: string[] = [];
-    if (q) {
-      const bm25 = buildBM25(bm25Docs);
-      const ranked = bm25.rank(String(q));
-      bm25Ids = ranked.filter(r => r.score > 0).slice(0, SEM_LIMIT).map(r => r.id);
+    // ── (b2) Resolve the index-served BM25 candidates ─────────────────────
+    // On the indexed path there is no corpus map to read from, so a BM25-only
+    // rescue is point-looked-up and projected down to `select`. The projection
+    // reproduces Harper's own `search({select})` shape exactly — the keys of
+    // `select` that the row actually carries, in `select` declaration order
+    // (measured; pinned by test/integration/bm25-index-scan-order-1357.test.ts).
+    //
+    // The freshly-read row is then re-checked against the SAME conditions[] +
+    // temporal filters + scope predicate before it is allowed into the fusion.
+    // The index already applied all three to its own copy of the row; this is
+    // the Sherlock gate applied to the row we are actually about to return, so
+    // a stale index entry can only ever REMOVE a candidate, never smuggle an
+    // out-of-scope record into the union.
+    if (servedFromIndex) {
+      const resolved: string[] = [];
+      for (const id of bm25Ids) {
+        if (allowedById.has(id)) { resolved.push(id); continue; }
+        const full = await withDetachedTxn(ctx, () => (databases as any).flair.Memory.get(id));
+        if (!full) continue;
+        if (!isAllowedBm25Candidate(full, conditions as Condition[], { sinceDate, asOf })) continue;
+        if (!passesAllowed(full)) continue;
+        const projected: any = {};
+        for (const key of select) if (key in full) projected[key] = (full as any)[key];
+        allowedById.set(id, projected);
+        if (qEmb) {
+          const storedEmbedding = Array.isArray((full as any).embedding) ? (full as any).embedding : [];
+          semSimById.set(id, cosineSimilarity(qEmb, storedEmbedding));
+        }
+        resolved.push(id);
+      }
+      bm25Ids = resolved;
     }
 
     // ── (d) No retrieval signal at all → full scoped listing ────────────

--- a/test/integration-heavy/bm25-index-equivalence-e2e-1357.test.ts
+++ b/test/integration-heavy/bm25-index-equivalence-e2e-1357.test.ts
@@ -1,0 +1,290 @@
+/**
+ * bm25-index-equivalence-e2e-1357.test.ts — flair#1357's equivalence proof
+ * against a REAL Harper, with real embeddings and the real HNSW leg.
+ *
+ * test/unit-isolated/bm25-index-equivalence-1357.test.ts proves the same
+ * contract over 122 query shapes against a mocked Harper. That mock is only as
+ * good as its two premises (scan order and `select` projection), which
+ * test/integration/bm25-index-scan-order-1357.test.ts pins against a live
+ * instance. This file closes the loop: one store, one query set, two boots of
+ * the SAME data directory —
+ *
+ *     boot 1  FLAIR_BM25_INDEX=false   the legacy per-query corpus rebuild
+ *     boot 2  FLAIR_BM25_INDEX=true    the persistent index
+ *
+ * — asserting the responses are identical. Two boots rather than a runtime
+ * toggle because the switch is read from the SERVER's environment, and adding
+ * a request-level override would be inventing a production knob to satisfy a
+ * test.
+ *
+ * WHAT IS EXCLUDED FROM THE COMPARISON, AND WHY: `retrievalCount` and
+ * `lastRetrieved` are hit-tracking side effects that `SemanticSearch.post()`
+ * writes for every result it returns. Running the query set twice necessarily
+ * moves them. Nothing else is excluded — ids, ORDER, `_score`, and every other
+ * projected field are compared exactly.
+ */
+import { describe, expect, test, beforeAll, afterAll } from "bun:test";
+import nacl from "tweetnacl";
+import { randomUUID } from "node:crypto";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { startHarper, stopHarper, HarperInstance } from "../helpers/harper-lifecycle";
+
+interface TestAgent { id: string; publicKey: string; secretKey: Uint8Array; }
+function mkAgent(id: string): TestAgent {
+  const kp = nacl.sign.keyPair();
+  return { id, publicKey: Buffer.from(kp.publicKey).toString("base64"), secretKey: kp.secretKey };
+}
+function ed25519Header(agent: TestAgent, method: string, path: string): string {
+  const ts = Date.now().toString();
+  const nonce = randomUUID();
+  const payload = `${agent.id}:${ts}:${nonce}:${method}:${path}`;
+  const sig = nacl.sign.detached(new TextEncoder().encode(payload), agent.secretKey);
+  return `TPS-Ed25519 ${agent.id}:${ts}:${nonce}:${Buffer.from(sig).toString("base64")}`;
+}
+async function adminOp(h: HarperInstance, op: Record<string, any>): Promise<Response> {
+  return fetch(h.opsURL, {
+    method: "POST",
+    headers: { "Content-Type": "application/json", Authorization: "Basic " + btoa(`${h.admin.username}:${h.admin.password}`) },
+    body: JSON.stringify(op),
+  });
+}
+
+const owner = mkAgent("bm25-eq-owner");
+const peer = mkAgent("bm25-eq-peer");
+
+// ─── Corpus ─────────────────────────────────────────────────────────────────
+function mulberry32(seed: number) {
+  return function () {
+    seed |= 0; seed = (seed + 0x6D2B79F5) | 0;
+    let t = Math.imul(seed ^ (seed >>> 15), 1 | seed);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+const VOCAB = ("vertex ingress proxy certificate fingerprint handshake buffer throughput benchmark " +
+  "rollout runbook cluster budget release cycle decision flag latency retrieval corpus index harper " +
+  "memory embedding cosine lexical ranking fusion candidate quorum ledger snapshot").split(" ");
+const TAGS = ["infra", "product", "research"];
+const SUBJECTS = ["nathan", "flint", "kern"];
+
+interface Seed { id: string; agentId: string; body: Record<string, any> }
+
+function makeSeeds(): Seed[] {
+  const rnd = mulberry32(13570823);
+  const seeds: Seed[] = [];
+  for (let i = 0; i < 90; i++) {
+    const words: string[] = [];
+    const len = 10 + Math.floor(rnd() * 20);
+    for (let w = 0; w < len; w++) words.push(VOCAB[Math.floor(rnd() * VOCAB.length)]);
+    const isPeer = rnd() < 0.35;
+    const body: Record<string, any> = {
+      content: words.join(" "),
+      durability: "standard",
+      archived: rnd() < 0.12,
+      createdAt: new Date(Date.parse("2026-05-01T00:00:00.000Z") + i * 7200_000).toISOString(),
+    };
+    const v = rnd();
+    if (v < 0.15) body.visibility = "private";
+    else if (v < 0.55) body.visibility = "shared";
+    if (rnd() < 0.45) body.tags = [TAGS[Math.floor(rnd() * TAGS.length)]];
+    if (rnd() < 0.5) body.subject = SUBJECTS[Math.floor(rnd() * SUBJECTS.length)];
+    seeds.push({
+      // Ids intentionally not in insertion order.
+      id: `eq-${String((i * 7919) % 10000).padStart(5, "0")}-${i}`,
+      agentId: isPeer ? peer.id : owner.id,
+      body,
+    });
+  }
+  // Exact-duplicate bodies whose ids sort against their insertion order — the
+  // only thing that can order these is the BM25 tie-break.
+  const twin = "vertex ingress proxy certificate fingerprint handshake rollout cluster";
+  for (const suffix of ["zzz", "aaa", "mmm"]) {
+    seeds.push({ id: `eq-tie-${suffix}`, agentId: owner.id, body: { content: twin, durability: "standard", archived: false, tags: ["infra"], subject: "flint", createdAt: "2026-05-01T00:00:00.000Z" } });
+  }
+  return seeds;
+}
+
+const SEEDS = makeSeeds();
+
+const QUERY_TEXTS = [
+  "vertex ingress certificate fingerprint",
+  "rollout cluster release cycle",
+  "retrieval corpus index latency ranking",
+  "harper memory embedding cosine",
+  "decision flag benchmark throughput",
+  "vertex ingress proxy certificate fingerprint handshake rollout cluster",
+  "candidate fusion lexical ranking quorum",
+  "buffer proxy budget runbook ledger snapshot",
+];
+
+function queryBodies(): { name: string; body: Record<string, any> }[] {
+  const out: { name: string; body: Record<string, any> }[] = [];
+  QUERY_TEXTS.forEach((q, i) => {
+    out.push({ name: `plain/${i}`, body: { q, limit: 25 } });
+    out.push({ name: `narrow/${i}`, body: { q, limit: 3 } });
+    out.push({ name: `tag/${i}`, body: { q, limit: 25, tag: TAGS[i % TAGS.length] } });
+    out.push({ name: `subject/${i}`, body: { q, limit: 25, subject: SUBJECTS[i % SUBJECTS.length] } });
+    out.push({ name: `tag+subject/${i}`, body: { q, limit: 25, tag: "infra", subject: "flint" } });
+    out.push({ name: `composite/${i}`, body: { q, limit: 25, scoring: "composite" } });
+    out.push({ name: `since/${i}`, body: { q, limit: 25, since: "2026-05-04T00:00:00.000Z" } });
+    out.push({ name: `minScore/${i}`, body: { q, limit: 25, minScore: 0.2 } });
+    out.push({ name: `trust/${i}`, body: { q, limit: 10, includeTrust: true } });
+  });
+  out.push({ name: "listing", body: { limit: 200 } });
+  return out;
+}
+
+const QUERIES = queryBodies();
+/** Hit-tracking side effects — see the header. */
+const VOLATILE = new Set(["retrievalCount", "lastRetrieved"]);
+
+function normalise(body: any): any {
+  const strip = (r: any) => {
+    const o: Record<string, any> = {};
+    for (const k of Object.keys(r)) if (!VOLATILE.has(k)) o[k] = r[k];
+    return o;
+  };
+  return { ...body, results: (body.results ?? []).map(strip) };
+}
+
+async function runQueries(h: HarperInstance, who: TestAgent): Promise<Record<string, string>> {
+  const out: Record<string, string> = {};
+  for (const { name, body } of QUERIES) {
+    const path = "/SemanticSearch";
+    const res = await fetch(`${h.httpURL}${path}`, {
+      method: "POST",
+      headers: { Authorization: ed25519Header(who, "POST", path), "Content-Type": "application/json" },
+      body: JSON.stringify({ agentId: who.id, ...body }),
+    });
+    const text = await res.text();
+    expect(res.status, `${name} → ${res.status}: ${text.slice(0, 200)}`).toBe(200);
+    out[name] = JSON.stringify(normalise(JSON.parse(text)));
+  }
+  return out;
+}
+
+let dataDir = "";
+let legacyResults: Record<string, string> = {};
+let legacyRepeat: Record<string, string> = {};
+let legacyRestart: Record<string, string> = {};
+let indexedResults: Record<string, string> = {};
+let legacyResultCount = 0;
+
+function divergedNames(a: Record<string, string>, b: Record<string, string>): string[] {
+  return QUERIES.filter(({ name }) => a[name] !== b[name]).map(({ name }) => name);
+}
+
+function firstRecordDiff(a: string, b: string): string {
+  const ra = JSON.parse(a).results, rb = JSON.parse(b).results;
+  for (let i = 0; i < Math.max(ra.length, rb.length); i++) {
+    const x = JSON.stringify(ra[i]), y = JSON.stringify(rb[i]);
+    if (x !== y) return `  [${i}] A=${(x ?? "<none>").slice(0, 400)}\n  [${i}] B=${(y ?? "<none>").slice(0, 400)}`;
+  }
+  return "  (results equal; envelope differs)";
+}
+
+describe("flair#1357 — indexed vs legacy lexical leg, real Harper, same data directory", () => {
+  beforeAll(async () => {
+    // ── BOOT 1: legacy per-query corpus rebuild ──────────────────────────────
+    // The data directory is created HERE, not by startHarper: a startHarper
+    // that mkdtemp'd its own directory OWNS it, and stopHarper would delete it
+    // between the two boots — taking the store this test exists to re-open.
+    dataDir = await mkdtemp(join(tmpdir(), "flair-test-1357-eq-"));
+    const prev = process.env.FLAIR_BM25_INDEX;
+    process.env.FLAIR_BM25_INDEX = "false";
+    let h: HarperInstance;
+    try { h = await startHarper({ installDir: dataDir }); } finally {
+      if (prev === undefined) delete process.env.FLAIR_BM25_INDEX; else process.env.FLAIR_BM25_INDEX = prev;
+    }
+    expect(h.ownsInstallDir).toBe(false);
+
+    const res = await adminOp(h, {
+      operation: "insert", database: "flair", table: "Agent",
+      records: [owner, peer].map((a) => ({ id: a.id, name: a.id, role: "agent", publicKey: a.publicKey, createdAt: new Date().toISOString() })),
+    });
+    expect(res.status).toBe(200);
+
+    for (const s of SEEDS) {
+      const who = s.agentId === owner.id ? owner : peer;
+      const path = `/Memory/${s.id}`;
+      const r = await fetch(`${h.httpURL}${path}`, {
+        method: "PUT",
+        headers: { Authorization: ed25519Header(who, "PUT", path), "Content-Type": "application/json" },
+        body: JSON.stringify({ id: s.id, agentId: s.agentId, ...s.body }),
+      });
+      if (![200, 204].includes(r.status)) throw new Error(`seed ${s.id} → ${r.status}: ${await r.text()}`);
+    }
+
+    legacyResults = await runQueries(h, owner);
+    legacyRepeat = await runQueries(h, owner); // same boot, same code — determinism control
+    legacyResultCount = Object.values(legacyResults)
+      .reduce((n, j) => n + (JSON.parse(j).results?.length ?? 0), 0);
+    await stopHarper(h);
+
+    // ── BOOT 2: the persistent index ─────────────────────────────────────────
+    process.env.FLAIR_BM25_INDEX = "true";
+    let hi: HarperInstance;
+    try { hi = await startHarper({ installDir: dataDir }); } finally {
+      if (prev === undefined) delete process.env.FLAIR_BM25_INDEX; else process.env.FLAIR_BM25_INDEX = prev;
+    }
+    indexedResults = await runQueries(hi, owner);
+    await stopHarper(hi);
+    delete process.env.ZZ_NO_FEED;
+
+    // ── BOOT 3: legacy AGAIN — the pure control, at the SAME boot distance ────
+    process.env.FLAIR_BM25_INDEX = "false";
+    let hc: HarperInstance;
+    try { hc = await startHarper({ installDir: dataDir }); } finally {
+      if (prev === undefined) delete process.env.FLAIR_BM25_INDEX; else process.env.FLAIR_BM25_INDEX = prev;
+    }
+    legacyRestart = await runQueries(hc, owner);
+    await stopHarper(hc);
+  }, 900_000);
+
+  afterAll(async () => { if (dataDir) await rm(dataDir, { recursive: true, force: true }).catch(() => {}); });
+
+  test("the fixture actually retrieves something (the comparison is not over empty sets)", () => {
+    expect(SEEDS.length).toBe(93);
+    expect(Object.keys(legacyResults).length).toBe(QUERIES.length);
+    expect(legacyResultCount).toBeGreaterThan(200);
+  });
+
+  test("DIAGNOSTIC", () => {
+    const repeat = divergedNames(legacyResults, legacyRepeat);
+    const restart = divergedNames(legacyResults, legacyRestart);
+    const indexed = divergedNames(legacyResults, indexedResults);
+    console.log(`\n  same-boot repeat diverged : ${JSON.stringify(repeat)}`);
+    console.log(`  legacy-vs-legacy CONTROL  : ${JSON.stringify(restart)}   (boot1 vs boot3)`);
+    console.log(`  indexed diverged          : ${JSON.stringify(indexed)}`);
+    for (const n of indexed.slice(0, 3)) {
+      console.log(`\n  --- ${n} (A=legacy boot1, B=indexed) ---\n${firstRecordDiff(legacyResults[n], indexedResults[n])}`);
+    }
+    for (const n of restart.slice(0, 3)) {
+      console.log(`\n  === ${n} (A=legacy boot1, B=legacy RESTART) ===\n${firstRecordDiff(legacyResults[n], legacyRestart[n])}`);
+    }
+    expect(true).toBe(true);
+  });
+
+  test("every query returns an IDENTICAL response on both paths", () => {
+    const diverged: string[] = [];
+    for (const { name } of QUERIES) {
+      if (legacyResults[name] !== indexedResults[name]) {
+        const a = JSON.parse(legacyResults[name]).results.map((r: any) => r.id);
+        const b = JSON.parse(indexedResults[name]).results.map((r: any) => r.id);
+        diverged.push(`${name}\n  legacy : ${JSON.stringify(a)}\n  indexed: ${JSON.stringify(b)}`);
+      }
+    }
+    expect(diverged.join("\n"), `${diverged.length}/${QUERIES.length} queries diverged`).toBe("");
+  });
+
+  test("the duplicate-content triple keeps its tie order across both paths", () => {
+    const tieOrder = (json: string) =>
+      JSON.parse(json).results.map((r: any) => r.id).filter((id: string) => id.startsWith("eq-tie-"));
+    const name = "plain/5"; // the query whose text IS the duplicated body
+    expect(tieOrder(legacyResults[name]).length).toBeGreaterThan(1);
+    expect(tieOrder(indexedResults[name])).toEqual(tieOrder(legacyResults[name]));
+  });
+});

--- a/test/integration-heavy/bm25-index-equivalence-e2e-1357.test.ts
+++ b/test/integration-heavy/bm25-index-equivalence-e2e-1357.test.ts
@@ -17,6 +17,15 @@
  * a request-level override would be inventing a production knob to satisfy a
  * test.
  *
+ * "IDENTICAL" MEANS IDS AND ORDER, UNDER THE EXPLICIT TIE-BREAK both paths now
+ * share (score DESC, then ascending id — flair#1363). Before that tie-break
+ * existed this suite reported 5/73 divergences, every one of them a single
+ * position at the tail of the window where two documents scored bit-identically
+ * and the legacy path was ordering them by Harper's corpus-iteration order —
+ * an order that is a query-plan artifact, not a ranking decision. Those five
+ * are the known, ruled-on change; they MATCH now, and the duplicate-content
+ * triple below pins the tie order itself rather than leaving it implied.
+ *
  * WHAT IS EXCLUDED FROM THE COMPARISON, AND WHY: `retrievalCount` and
  * `lastRetrieved` are hit-tracking side effects that `SemanticSearch.post()`
  * writes for every result it returns. Running the query set twice necessarily
@@ -280,11 +289,25 @@ describe("flair#1357 — indexed vs legacy lexical leg, real Harper, same data d
     expect(diverged.join("\n"), `${diverged.length}/${QUERIES.length} queries diverged`).toBe("");
   });
 
-  test("the duplicate-content triple keeps its tie order across both paths", () => {
+  test("the duplicate-content triple resolves identically on every run (flair#1363)", () => {
+    // SCOPE NOTE: this is the FUSED response order, not the lexical leg's. The
+    // BM25 tie-break orders the LEXICAL leg; by the time these ids reach a
+    // response they have been through candidate-union RRF with the HNSW leg,
+    // and three identically-embedded documents get whatever relative semantic
+    // rank Harper's vector index gives them. Asserting ascending id HERE would
+    // be asserting a property of the wrong layer — the lexical leg's tie order
+    // is pinned directly, against its own output, in test/unit/bm25.test.ts and
+    // test/unit-isolated/bm25-index-equivalence-1357.test.ts.
+    //
+    // What this level can prove, and what matters here: the triple surfaces,
+    // and all three runs agree about it — so the tie no longer leaks the query
+    // plan into the answer.
     const tieOrder = (json: string) =>
       JSON.parse(json).results.map((r: any) => r.id).filter((id: string) => id.startsWith("eq-tie-"));
     const name = "plain/5"; // the query whose text IS the duplicated body
-    expect(tieOrder(legacyResults[name]).length).toBeGreaterThan(1);
-    expect(tieOrder(indexedResults[name])).toEqual(tieOrder(legacyResults[name]));
+    const seen = tieOrder(legacyResults[name]);
+    expect(seen.length, "the tie fixture must actually surface").toBeGreaterThan(1);
+    expect(tieOrder(indexedResults[name])).toEqual(seen);
+    expect(tieOrder(legacyRestart[name])).toEqual(seen);
   });
 });

--- a/test/integration/bm25-index-scan-order-1357.test.ts
+++ b/test/integration/bm25-index-scan-order-1357.test.ts
@@ -1,0 +1,252 @@
+/**
+ * bm25-index-scan-order-1357.test.ts — pins the two REAL-HARPER PREMISES that
+ * the flair#1357 persistent BM25 index is built on, plus its incremental
+ * maintenance end to end.
+ *
+ * Both premises were established by measurement against a live instance, not
+ * from documentation. They live here so that a Harper change breaks a test
+ * instead of silently changing recall ranking:
+ *
+ *  1. CORPUS SCAN ORDER IS A QUERY-PLANNER ARTIFACT, NOT PRIMARY-KEY ORDER.
+ *     `buildBM25().rank()` sorts by score with `Array.prototype.sort`, which is
+ *     stable, so EQUAL-SCORING documents come back in corpus-iteration order —
+ *     making that order part of the ranking contract the index must not change.
+ *     MEASURED HERE: under the multi-agent read-scope OR-group
+ *     ((agentId == reader) OR (visibility != private)) Harper yields the
+ *     READER'S OWN rows first, in primary-key order, and everything else after;
+ *     under a tags/subject filter the same store comes back in plain
+ *     primary-key order. Two different orders for the same rows, decided by the
+ *     plan. That is why the index DECLINES a query whose returned window
+ *     contains a BM25 score tie (resources/bm25-index.ts, end of `rank()`)
+ *     instead of imposing a tie-break of its own.
+ *
+ *     This test originally seeded ONE agent, and passed — because with a single
+ *     agentId, "grouped by the agentId index" and "ascending primary key" are
+ *     the same sequence. The fixture could not express the difference it
+ *     existed to detect. It seeds two agents now.
+ *
+ *  2. `select` PROJECTS TO THE SUBSET OF `select` THE ROW ACTUALLY CARRIES, IN
+ *     `select` DECLARATION ORDER. On the indexed path a BM25-only rescue is no
+ *     longer read from a corpus scan; it is point-looked-up and projected in
+ *     process (resources/semantic-retrieval-core.ts). That projection has to
+ *     reproduce Harper's own shape exactly, or a rescued record's response
+ *     bytes would differ from a scanned one's.
+ *
+ * VEHICLE for premise 1: a `SemanticSearch` with neither `q` nor an embedding
+ * returns `allowedById.values()` — a Map built in corpus-scan order — and then
+ * stable-sorts on an all-equal `_rank`. So the response order IS the scan
+ * order.
+ */
+import { describe, expect, test, beforeAll, afterAll } from "bun:test";
+import nacl from "tweetnacl";
+import { randomUUID } from "node:crypto";
+import { startHarper, stopHarper, HarperInstance } from "../helpers/harper-lifecycle";
+// NOTE: nothing from resources/ is imported here on purpose — those modules
+// import `harper`, and importing it into the TEST process (rather than the
+// spawned instance) fails with "Unable to determine database storage path".
+// The projection property below is therefore asserted structurally.
+
+interface TestAgent { id: string; publicKey: string; secretKey: Uint8Array; }
+function mkAgent(id: string): TestAgent {
+  const kp = nacl.sign.keyPair();
+  return { id, publicKey: Buffer.from(kp.publicKey).toString("base64"), secretKey: kp.secretKey };
+}
+function ed25519Header(agent: TestAgent, method: string, path: string): string {
+  const ts = Date.now().toString();
+  const nonce = randomUUID();
+  const payload = `${agent.id}:${ts}:${nonce}:${method}:${path}`;
+  const sig = nacl.sign.detached(new TextEncoder().encode(payload), agent.secretKey);
+  return `TPS-Ed25519 ${agent.id}:${ts}:${nonce}:${Buffer.from(sig).toString("base64")}`;
+}
+async function adminOp(harper: HarperInstance, op: Record<string, any>): Promise<Response> {
+  return fetch(harper.opsURL, {
+    method: "POST",
+    headers: { "Content-Type": "application/json", Authorization: "Basic " + btoa(`${harper.admin.username}:${harper.admin.password}`) },
+    body: JSON.stringify(op),
+  });
+}
+
+let harper: HarperInstance;
+const agent = mkAgent("bm25-index-premises");
+const peer = mkAgent("bm25-index-premises-peer");
+
+// Ids in an order that is NOT their insertion order — otherwise "scan order"
+// and "ascending id" would agree for the wrong reason.
+const INSERT_ORDER = ["m-zulu", "m-alpha", "m-mike", "m-bravo", "m-yankee", "m-charlie"];
+const LEX_ORDER = [...INSERT_ORDER].sort();
+
+async function put(id: string, body: Record<string, any>, who: TestAgent = agent): Promise<Response> {
+  const path = `/Memory/${id}`;
+  return fetch(`${harper.httpURL}${path}`, {
+    method: "PUT",
+    headers: { Authorization: ed25519Header(who, "PUT", path), "Content-Type": "application/json" },
+    body: JSON.stringify({ id, agentId: who.id, durability: "standard", createdAt: new Date().toISOString(), ...body }),
+  });
+}
+
+async function search(body: Record<string, any>): Promise<any> {
+  const path = "/SemanticSearch";
+  const res = await fetch(`${harper.httpURL}${path}`, {
+    method: "POST",
+    headers: { Authorization: ed25519Header(agent, "POST", path), "Content-Type": "application/json" },
+    body: JSON.stringify({ agentId: agent.id, limit: 100, ...body }),
+  });
+  const text = await res.text();
+  expect(res.status, `SemanticSearch → ${res.status}: ${text.slice(0, 300)}`).toBe(200);
+  return JSON.parse(text);
+}
+
+const ids = (r: any) => (r.results ?? []).map((x: any) => x.id);
+
+// File-scope lifecycle: both describes below share ONE instance. A
+// describe-scoped afterAll would stop Harper before the second block ran.
+beforeAll(async () => {
+  harper = await startHarper();
+  const res = await adminOp(harper, {
+    operation: "insert", database: "flair", table: "Agent",
+    records: [agent, peer].map((a) => ({ id: a.id, name: a.id, role: "agent", publicKey: a.publicKey, createdAt: new Date().toISOString() })),
+  });
+  expect(res.status).toBe(200);
+  // Alternating owners: a single-agent fixture cannot tell "ascending primary
+  // key" apart from "grouped by the agentId index", and the read-scope
+  // OR-group's first leg IS an agentId equals.
+  for (let i = 0; i < INSERT_ORDER.length; i++) {
+    const id = INSERT_ORDER[i];
+    const who = i % 2 === 0 ? agent : peer;
+    const r = await put(id, {
+      content: `premise record ${id} shared body text`,
+      archived: false, visibility: "shared", tags: ["shared-tag"], subject: "shared-subject",
+    }, who);
+    if (![200, 204].includes(r.status)) throw new Error(`seed PUT ${id} → ${r.status}: ${await r.text()}`);
+  }
+}, 240_000);
+
+afterAll(async () => { if (harper) await stopHarper(harper); });
+
+describe("flair#1357 — real-Harper premises of the persistent BM25 index", () => {
+  test("PREMISE 1: the multi-agent scope scan is NOT primary-key order — own rows lead", async () => {
+    const observed = ids(await search({}));
+    const own = INSERT_ORDER.filter((_, i) => i % 2 === 0).sort();
+    const other = INSERT_ORDER.filter((_, i) => i % 2 === 1).sort();
+    // Own rows first (primary-key order within the group), then the rest.
+    expect(observed).toEqual([...own, ...other]);
+    // ...which is emphatically NOT the global primary-key order. If this ever
+    // starts matching, the planner changed and the tie-decline guard in
+    // resources/bm25-index.ts should be revisited — do not simply relax it.
+    expect(observed).not.toEqual(LEX_ORDER);
+  }, 60_000);
+
+  test("PREMISE 1: a tags/subject-filtered scan of the SAME rows comes back in a DIFFERENT order", async () => {
+    // Same store, same rows, different plan, different iteration order — the
+    // reason a fixed tie-break cannot be correct for every query.
+    expect(ids(await search({ tag: "shared-tag" }))).toEqual(LEX_ORDER);
+    expect(ids(await search({ subject: "shared-subject" }))).toEqual(LEX_ORDER);
+  }, 60_000);
+
+
+
+  test("PREMISE 2: `select` drops absent keys and keeps a FIXED declaration order", async () => {
+    // Asserted structurally, without naming DEFAULT_SELECT: a SPARSE row's key
+    // sequence must be a SUBSEQUENCE of a RICH row's. That holds if and only
+    // if the projection emits `select` in a fixed order and omits (rather than
+    // undefined-fills) the attributes a row does not carry — which is exactly
+    // what the in-process projection on the indexed path reproduces when it
+    // resolves a BM25-only rescue by point lookup.
+    let r = await put("m-sparse", { content: "sparse row", archived: false });
+    expect([200, 204]).toContain(r.status);
+    r = await put("m-rich", {
+      content: "rich row", archived: false, tags: ["t1"], subject: "flint",
+      source: "test", summary: "a summary", sessionId: "sess-1",
+      expiresAt: new Date(Date.now() + 86400_000).toISOString(),
+    });
+    expect([200, 204]).toContain(r.status);
+
+    const body = await search({});
+    const rows: Record<string, string[]> = {};
+    for (const row of body.results) rows[row.id] = Object.keys(row);
+    const sparse = rows["m-sparse"], rich = rows["m-rich"];
+    expect(sparse).toBeDefined();
+    expect(rich).toBeDefined();
+    // The rich row really is richer — otherwise the subsequence check is vacuous.
+    expect(rich.length).toBeGreaterThan(sparse.length);
+    for (const k of ["tags", "subject", "summary", "expiresAt"]) expect(rich).toContain(k);
+    for (const k of ["tags", "subject", "summary"]) expect(sparse).not.toContain(k);
+
+    let i = 0;
+    for (const k of rich) if (i < sparse.length && sparse[i] === k) i++;
+    expect(i, `sparse keys ${JSON.stringify(sparse)} are not a subsequence of rich keys ${JSON.stringify(rich)}`)
+      .toBe(sparse.length);
+  }, 60_000);
+});
+
+describe("flair#1357 — incremental maintenance against a live instance", () => {
+  const NEEDLE = "quokkastuff";
+
+  test("a stored memory is IMMEDIATELY findable through the lexical leg", async () => {
+    const r = await put("m-readyourwrite", { content: `${NEEDLE} appears exactly once in this store`, archived: false });
+    expect([200, 204]).toContain(r.status);
+    const found = await search({ q: NEEDLE, limit: 10 });
+    expect(ids(found)).toContain("m-readyourwrite");
+  }, 60_000);
+
+  test("an archive flip removes it from results, and un-archiving restores it", async () => {
+    let r = await put("m-archflip", { content: `${NEEDLE} archival candidate`, archived: false });
+    expect([200, 204]).toContain(r.status);
+    expect(ids(await search({ q: NEEDLE, limit: 10 }))).toContain("m-archflip");
+
+    r = await put("m-archflip", { content: `${NEEDLE} archival candidate`, archived: true });
+    expect([200, 204]).toContain(r.status);
+    expect(ids(await search({ q: NEEDLE, limit: 10 }))).not.toContain("m-archflip");
+
+    r = await put("m-archflip", { content: `${NEEDLE} archival candidate`, archived: false });
+    expect([200, 204]).toContain(r.status);
+    expect(ids(await search({ q: NEEDLE, limit: 10 }))).toContain("m-archflip");
+  }, 60_000);
+
+  test("a deleted memory disappears from the lexical leg", async () => {
+    const r = await put("m-doomed", { content: `${NEEDLE} doomed record`, archived: false });
+    expect([200, 204]).toContain(r.status);
+    expect(ids(await search({ q: NEEDLE, limit: 10 }))).toContain("m-doomed");
+
+    const path = "/Memory/m-doomed";
+    const d = await fetch(`${harper.httpURL}${path}`, {
+      method: "DELETE", headers: { Authorization: ed25519Header(agent, "DELETE", path) },
+    });
+    expect([200, 204]).toContain(d.status);
+    expect(ids(await search({ q: NEEDLE, limit: 10 }))).not.toContain("m-doomed");
+  }, 60_000);
+
+  test("a write that BYPASSES every flair resource still reaches the index (the change feed)", async () => {
+    // An operations-API insert is the shape a federation/replication apply or a
+    // direct admin write has: no flair JS write path runs, so no hook fires.
+    // Only the table's own change feed can carry it — which is exactly why the
+    // feed, not the hook list, is the correctness argument.
+    const FEED_NEEDLE = "wombatstuff";
+    const res = await adminOp(harper, {
+      operation: "insert", database: "flair", table: "Memory",
+      records: [{
+        id: "m-viafeed", agentId: agent.id, content: `${FEED_NEEDLE} inserted behind flair's back`,
+        durability: "standard", archived: false, createdAt: new Date().toISOString(),
+      }],
+    });
+    expect(res.status).toBe(200);
+
+    // The feed is asynchronous — poll briefly rather than assert on one tick.
+    let found: string[] = [];
+    for (let i = 0; i < 40; i++) {
+      found = ids(await search({ q: FEED_NEEDLE, limit: 10 }));
+      if (found.includes("m-viafeed")) break;
+      await new Promise((r) => setTimeout(r, 250));
+    }
+    expect(found).toContain("m-viafeed");
+
+    const del = await adminOp(harper, { operation: "delete", database: "flair", table: "Memory", ids: ["m-viafeed"] });
+    expect(del.status).toBe(200);
+    for (let i = 0; i < 40; i++) {
+      found = ids(await search({ q: FEED_NEEDLE, limit: 10 }));
+      if (!found.includes("m-viafeed")) break;
+      await new Promise((r) => setTimeout(r, 250));
+    }
+    expect(found).not.toContain("m-viafeed");
+  }, 120_000);
+});

--- a/test/integration/bm25-index-scan-order-1357.test.ts
+++ b/test/integration/bm25-index-scan-order-1357.test.ts
@@ -16,9 +16,17 @@
  *     READER'S OWN rows first, in primary-key order, and everything else after;
  *     under a tags/subject filter the same store comes back in plain
  *     primary-key order. Two different orders for the same rows, decided by the
- *     plan. That is why the index DECLINES a query whose returned window
- *     contains a BM25 score tie (resources/bm25-index.ts, end of `rank()`)
- *     instead of imposing a tie-break of its own.
+ *     plan.
+ *
+ *     THIS MEASUREMENT IS THE EVIDENCE BEHIND flair#1363. Hybrid recall was
+ *     nondeterministic for tied documents — the ranking it produced depended on
+ *     which plan Harper picked, which depends on data distribution. Kern's
+ *     ruling (2026-08-24): "byte-identical to a nondeterministic source is a
+ *     contradiction." Both the legacy scan and the index now break ties on
+ *     ascending `id` (resources/bm25.ts and resources/bm25-index.ts), so the
+ *     order below no longer reaches ranking at all. Keep this test: it is the
+ *     reason the tie-break exists, and it is what would tell us if the premise
+ *     ever changed.
  *
  *     This test originally seeded ONE agent, and passed — because with a single
  *     agentId, "grouped by the agentId index" and "ascending primary key" are

--- a/test/unit-isolated/bm25-index-equivalence-1357.test.ts
+++ b/test/unit-isolated/bm25-index-equivalence-1357.test.ts
@@ -14,17 +14,25 @@
  * same ids, same order, same fields, same numbers. Not "same set", not
  * "close enough".
  *
- * ── CORPUS ORDER AND TIES ───────────────────────────────────────────────────
- * `buildBM25().rank()` sorts with `(a,b) => b.score - a.score`, and
- * `Array.prototype.sort` is stable, so EQUAL-SCORING documents come back in
- * corpus-iteration order — which, measured against a live instance
- * (test/integration/bm25-index-scan-order-1357.test.ts), is a QUERY-PLANNER
- * artifact: own-agent rows lead under the multi-agent scope OR-group, plain
- * primary-key order under a tag/subject filter. The index cannot reproduce
- * that, so it DECLINES any query whose returned window contains a score tie
- * and the legacy scan answers instead. The mock below iterates in primary-key
- * order (one of the two real orders), inserts ids in shuffled order, and plants
- * exact-duplicate contents so the decline path is genuinely exercised.
+ * ── WHAT "BYTE-IDENTICAL" MEANS HERE (flair#1363, Kern 2026-08-24) ──────────
+ * Identical ids AND identical order, under an EXPLICIT tie-break: both paths
+ * sort by score DESC then ascending id.
+ *
+ * It could not mean anything else. `buildBM25().rank()` used to sort on score
+ * alone; a stable sort then left equal-scoring documents in Harper's
+ * corpus-iteration order, and that order is a query-planner artifact —
+ * measured on a live instance, the same rows for the same query text iterate
+ * own-agent-first under the multi-agent read-scope OR-group and
+ * primary-key-first under a tags/subject filter
+ * (test/integration/bm25-index-scan-order-1357.test.ts). Kern's ruling:
+ * "byte-identical to a nondeterministic source is a contradiction." So the
+ * tie-break is explicit in BOTH paths now, and this suite holds them to it.
+ *
+ * The mock iterates in primary-key order (one of the two real orders) and the
+ * fixture inserts ids in SHUFFLED order, so a path that still leaned on corpus
+ * order would diverge here. The exact-duplicate triple shares the query
+ * vocabulary deliberately: it plants ties inside the returned window of most
+ * query shapes rather than in a corner case.
  */
 import { describe, it, expect, mock, beforeEach, afterEach } from "bun:test";
 
@@ -202,13 +210,11 @@ function seedCorpus(n: number): void {
     if (rnd() < 0.05) row.supersedes = rows.length > 0 ? rows[Math.floor(rnd() * rows.length)].id : undefined;
     rows.push(row);
   }
-  // TIE FODDER: exact-duplicate bodies. Their BM25 scores are bit-identical for
-  // any query, so they are the decline guard's fixture. Their vocabulary is
-  // PRIVATE to them (`tiemarker`, `tz*` — absent from QUERY_VOCAB and FILLER),
-  // because three identical documents sharing the query vocabulary would tie
-  // inside the window of nearly every query and push the whole suite onto the
-  // fallback path, which is exactly what it must not silently do.
-  const twin = "tiemarker tz1 tz2 tz3 tz4 tz5 tz6 tz7";
+  // TIE FODDER: three exact-duplicate bodies drawn from the QUERY vocabulary,
+  // so they tie inside the returned window of most query shapes rather than in
+  // some corner. Their ids sort (aaa, mmm, zzz) against their insertion order
+  // (zzz, aaa, mmm), so only a real tie-break puts them in id order.
+  const twin = "vertex ingress proxy certificate fingerprint handshake rollout cluster";
   for (const [suffix, agentId] of [["zzz", "agent-a"], ["aaa", "agent-a"], ["mmm", "agent-b"]] as const) {
     rows.push({
       id: `mem-tie-${suffix}`, agentId, content: twin, contentHash: `tie-${suffix}`,
@@ -419,14 +425,17 @@ describe("flair#1357 — the indexed lexical leg is byte-identical to the legacy
     // whose returned window contains a BM25 score tie (the decline guard), so
     // this asserts a FLOOR on how much the index actually served rather than
     // exact equality — but a floor high enough that a blanket decline fails.
+    // ── THE ANTI-VACUITY CONTROL ─────────────────────────────────────────────
+    // Everything above would pass trivially if the index quietly declined every
+    // query and both "paths" were the same legacy code. Only the one case with
+    // NO query text at all (the full scoped listing) has a lexical leg to
+    // decline, so exactly one case may scan. Score ties are no longer a reason
+    // to fall back (flair#1363) — if this list grows a tie-shaped entry, the
+    // shared tie-break has come apart.
     const served = cases.length - fellBack.length;
     console.log(`\n  BM25 INDEX SERVE RATE: ${served}/${cases.length} query shapes ` +
-      `(${((100 * served) / cases.length).toFixed(0)}%); the rest hit the tie-decline guard ` +
-      `or have no query text.\n`);
-    expect(fellBack, "the no-text listing must fall back").toContain("listing");
-    // The index must actually serve SOMETHING, or every "both paths agree"
-    // assertion above is two runs of the same legacy code agreeing with itself.
-    expect(served, "the index served nothing — every equivalence assertion above is vacuous").toBeGreaterThan(0);
+      `(${((100 * served) / cases.length).toFixed(0)}%)\n`);
+    expect(fellBack.sort(), "queries that fell back to the legacy corpus scan").toEqual(["listing"]);
     expect(corpusScans).toBeGreaterThan(scansAfterBuild); // legacy control ran
     expect(bm25IndexStatus().state).toBe("ready");
   }, 120_000);
@@ -465,10 +474,10 @@ describe("flair#1357 — the indexed lexical leg is byte-identical to the legacy
     expect(JSON.stringify(corrupted)).not.toBe(JSON.stringify(legacy));
   }, 60_000);
 
-  it("a score tie in the returned window makes the index DECLINE, and the answer still matches", async () => {
+  it("tied documents come back in ascending id order on BOTH paths (flair#1363)", async () => {
     const { condition, isAllowed } = scopeFor("agent-a");
     const params = {
-      q: "tiemarker tz1 tz2 tz3",
+      q: "vertex ingress proxy certificate fingerprint handshake rollout cluster",
       queryEmbedding: qEmbFor(4242),
       conditions: [condition, { attribute: "archived", comparator: "not_equal", value: true }],
       limit: 200, agentId: "agent-a", isAllowed, hybrid: true, scoring: "raw", minScore: 0,
@@ -476,18 +485,27 @@ describe("flair#1357 — the indexed lexical leg is byte-identical to the legacy
     process.env.FLAIR_BM25_INDEX = "true";
     __resetBm25IndexForTests();
     await retrieveCandidates({ ...params } as any); // build
-    // The three exact-duplicate bodies tie on this query, so the index must
-    // refuse to serve the lexical leg at all.
-    const declined = await indexedBm25Ids({
+    // The index must SERVE this — a tie is no longer a reason to decline.
+    const servedIds = await indexedBm25Ids({
       q: params.q, conditions: params.conditions as any, timeFilters: {},
       isAllowed: params.isAllowed, limit: 50,
     });
-    expect(declined, "a window containing tied scores must be declined, not guessed").toBeNull();
+    expect(servedIds, "a tie is no longer a reason to decline the lexical leg").not.toBeNull();
+
+    // THE CONTRACT, asserted against the LEXICAL LEG's own output: all three
+    // duplicates rank in ASCENDING ID order — not the order they were inserted
+    // in (zzz, aaa, mmm), which is what inheriting corpus order produced.
+    expect(servedIds!.filter((id) => id.startsWith("mem-tie-")))
+      .toEqual(["mem-tie-aaa", "mem-tie-mmm", "mem-tie-zzz"]);
+
+    // The OTHER implementation of the same comparator is pinned directly
+    // against `buildBM25` in test/unit/bm25.test.ts. Reconstructing the scoped
+    // corpus here to re-derive the legacy leg would mean reimplementing
+    // `isAllowedBm25Candidate`'s conditions AND temporal filters in the test —
+    // and a test that duplicates the production filter stops testing it. The
+    // end-to-end equality below covers the two legs meeting.
 
     const { legacy, indexed } = await runBoth(params);
-    const tieOrder = (rs: any[]) => rs.map((r: any) => r.id).filter((id: string) => id.startsWith("mem-tie-"));
-    expect(tieOrder(legacy).length).toBe(3);
-    expect(tieOrder(indexed)).toEqual(tieOrder(legacy));
     expect(JSON.stringify(indexed)).toBe(JSON.stringify(legacy));
   }, 60_000);
 });

--- a/test/unit-isolated/bm25-index-equivalence-1357.test.ts
+++ b/test/unit-isolated/bm25-index-equivalence-1357.test.ts
@@ -1,0 +1,729 @@
+/**
+ * bm25-index-equivalence-1357.test.ts — flair#1357's LOAD-BEARING check.
+ *
+ * The fix replaces a per-query `buildBM25(wholeScopedCorpus)` with a
+ * persistent index. Kern's ruling made the contract latency-only and
+ * RANKING-IDENTICAL: recall is the product floor and hybrid is default-on, so
+ * a reordering — however defensible in the abstract — is a regression, not an
+ * improvement.
+ *
+ * This suite runs a FIXED store through the SHIPPED `retrieveCandidates()`
+ * twice per query — once with `FLAIR_BM25_INDEX=false` (the legacy corpus
+ * scan, i.e. the pre-fix code, which is still in the file as the fallback) and
+ * once with the index — and asserts the two responses are BYTE-IDENTICAL:
+ * same ids, same order, same fields, same numbers. Not "same set", not
+ * "close enough".
+ *
+ * ── CORPUS ORDER AND TIES ───────────────────────────────────────────────────
+ * `buildBM25().rank()` sorts with `(a,b) => b.score - a.score`, and
+ * `Array.prototype.sort` is stable, so EQUAL-SCORING documents come back in
+ * corpus-iteration order — which, measured against a live instance
+ * (test/integration/bm25-index-scan-order-1357.test.ts), is a QUERY-PLANNER
+ * artifact: own-agent rows lead under the multi-agent scope OR-group, plain
+ * primary-key order under a tag/subject filter. The index cannot reproduce
+ * that, so it DECLINES any query whose returned window contains a score tie
+ * and the legacy scan answers instead. The mock below iterates in primary-key
+ * order (one of the two real orders), inserts ids in shuffled order, and plants
+ * exact-duplicate contents so the decline path is genuinely exercised.
+ */
+import { describe, it, expect, mock, beforeEach, afterEach } from "bun:test";
+
+process.env.FLAIR_RATE_LIMIT_ENABLED = "false";
+
+// ─── In-memory Harper mock ───────────────────────────────────────────────────
+
+let memoryStore: Map<string, any>;
+let corpusScans: number;
+let feedListeners: ((ev: any) => void)[] = [];
+
+function cosine(a: number[], b: number[]): number {
+  let dot = 0, na = 0, nb = 0;
+  for (let i = 0; i < a.length; i++) { dot += a[i] * b[i]; na += a[i] * a[i]; nb += b[i] * b[i]; }
+  if (na === 0 || nb === 0) return 0;
+  return dot / (Math.sqrt(na) * Math.sqrt(nb));
+}
+
+function matchesCondition(record: any, cond: any): boolean {
+  if (cond.operator && Array.isArray(cond.conditions)) {
+    const results = cond.conditions.map((c: any) => matchesCondition(record, c));
+    return cond.operator === "or" ? results.some(Boolean) : results.every(Boolean);
+  }
+  const v = record[cond.attribute];
+  if (cond.comparator === "equals") return Array.isArray(v) ? v.includes(cond.value) : v === cond.value;
+  if (cond.comparator === "not_equal") return Array.isArray(v) ? !v.includes(cond.value) : v !== cond.value;
+  return true;
+}
+
+/** Harper's `select` projection: the keys of `select` the row actually
+ *  carries, in `select` declaration order. (Measured — see the integration
+ *  companion to this file.) */
+function project(record: any, select?: string[]): any {
+  const { embedding, ...rest } = record;
+  if (!select) return rest;
+  const out: any = {};
+  for (const k of select) if (k in rest) out[k] = rest[k];
+  return out;
+}
+
+function memorySearch(query: any) {
+  const conditions = Array.isArray(query?.conditions) ? query.conditions : [];
+  // ASCENDING PRIMARY KEY — Harper's real scan order.
+  let records = [...memoryStore.values()].sort((a, b) => (a.id < b.id ? -1 : a.id > b.id ? 1 : 0));
+  for (const cond of conditions) records = records.filter((r) => matchesCondition(r, cond));
+
+  if (query?.sort?.attribute === "embedding") {
+    const target = query.sort.target as number[];
+    const scored = records
+      .map((r) => ({ r, d: 1 - cosine(target, Array.isArray(r.embedding) ? r.embedding : []) }))
+      // Stable on ties, so the HNSW leg is deterministic across both runs.
+      .sort((a, b) => a.d - b.d)
+      .slice(0, query.limit ?? records.length);
+    const singleton = records.length === 1;
+    async function* gen() {
+      for (const { r, d } of scored) {
+        const base = project(r, query.select?.filter((s: string) => s !== "$distance"));
+        yield singleton ? base : { ...base, $distance: d };
+      }
+    }
+    return gen();
+  }
+
+  corpusScans++;
+  async function* gen() {
+    for (const r of records) yield project(r, query.select);
+  }
+  return gen();
+}
+
+const databasesMock = {
+  flair: {
+    Memory: {
+      search: (q: any) => memorySearch(q),
+      get: async (id: string) => memoryStore.get(id) ?? null,
+      subscribe: async () => {
+        // An async iterable driven by `emit()` below — the shape
+        // `Memory.subscribe({omitCurrent:true})` returns on a real instance
+        // (verified: {type:'put'|'delete', id, value}).
+        const queue: any[] = [];
+        let wake: (() => void) | null = null;
+        feedListeners.push((ev) => { queue.push(ev); wake?.(); });
+        return {
+          async *[Symbol.asyncIterator]() {
+            for (;;) {
+              while (queue.length > 0) yield queue.shift();
+              await new Promise<void>((r) => { wake = r; });
+            }
+          },
+        };
+      },
+    },
+  },
+};
+
+mock.module("harper", () => ({ databases: databasesMock, Resource: class {} }));
+
+const { retrieveCandidates } = await import("../../resources/semantic-retrieval-core.ts");
+const { __resetBm25IndexForTests, bm25IndexStatus, noteMemoryUpsert, noteMemoryDelete, indexedBm25Ids } =
+  await import("../../resources/bm25-index-service.ts");
+
+function emit(ev: any) { for (const l of feedListeners) l(ev); }
+
+// ─── Fixture ─────────────────────────────────────────────────────────────────
+
+const AGENTS = ["agent-a", "agent-b", "agent-c"];
+// The terms the query set is drawn from...
+const QUERY_VOCAB = [
+  "vertex", "ingress", "proxy", "certificate", "fingerprint", "handshake", "buffer",
+  "throughput", "benchmark", "rollout", "runbook", "cluster", "budget", "release",
+  "cycle", "decision", "flag", "latency", "retrieval", "corpus", "index", "harper",
+  "memory", "embedding", "cosine", "lexical", "ranking", "fusion", "candidate",
+];
+// ...plus filler, so documents are mostly distinct. A tiny vocabulary makes
+// exact BM25 score ties the norm rather than the exception, and the index
+// DECLINES a tie (see resources/bm25-index.ts) — with a 29-word vocabulary the
+// suite would spend its time proving the fallback works and never exercise the
+// indexed path at all. The deliberate tie triple below still covers decline.
+const FILLER = Array.from({ length: 600 }, (_, i) => `w${i}`);
+const VOCAB = [...QUERY_VOCAB, ...FILLER];
+const TAGS = ["infra", "product", "research", "ops"];
+const SUBJECTS = ["nathan", "flint", "kern", "sherlock"];
+
+// Deterministic PRNG — no Math.random anywhere in a ranking fixture.
+function mulberry32(seed: number) {
+  return function () {
+    seed |= 0; seed = (seed + 0x6D2B79F5) | 0;
+    let t = Math.imul(seed ^ (seed >>> 15), 1 | seed);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+const DIM = 8;
+const BASE_TIME = Date.parse("2026-06-01T00:00:00.000Z");
+
+function seedCorpus(n: number): void {
+  memoryStore = new Map();
+  const rnd = mulberry32(20260823);
+  const rows: any[] = [];
+  for (let i = 0; i < n; i++) {
+    const words: string[] = [];
+    const len = 6 + Math.floor(rnd() * 18);
+    for (let w = 0; w < len; w++) {
+      words.push(rnd() < 0.2
+        ? QUERY_VOCAB[Math.floor(rnd() * QUERY_VOCAB.length)]
+        : FILLER[Math.floor(rnd() * FILLER.length)]);
+    }
+    const embedding = Array.from({ length: DIM }, () => rnd() * 2 - 1);
+    const agentId = AGENTS[Math.floor(rnd() * AGENTS.length)];
+    const createdAt = new Date(BASE_TIME + i * 3600_000).toISOString();
+    const row: any = {
+      // ids are NOT generated in insertion order — the fixture must not make
+      // "insertion order" and "ascending id" the same thing.
+      id: `mem-${String((i * 7919) % 100000).padStart(5, "0")}-${i}`,
+      agentId,
+      content: words.join(" "),
+      contentHash: `h${i}`,
+      embedding,
+      durability: "standard",
+      createdAt,
+      updatedAt: createdAt,
+    };
+    const v = rnd();
+    if (v < 0.15) row.visibility = "private";
+    else if (v < 0.5) row.visibility = "shared";
+    // else: no visibility field at all (the legacy-row shape)
+    if (rnd() < 0.4) row.tags = [TAGS[Math.floor(rnd() * TAGS.length)]];
+    if (rnd() < 0.5) row.subject = SUBJECTS[Math.floor(rnd() * SUBJECTS.length)];
+    if (rnd() < 0.12) row.archived = true;
+    if (rnd() < 0.08) row.expiresAt = new Date(BASE_TIME - 86400_000).toISOString(); // already expired
+    if (rnd() < 0.08) row.expiresAt = new Date(BASE_TIME + 400 * 86400_000).toISOString(); // future
+    if (rnd() < 0.06) row.validTo = new Date(BASE_TIME - 86400_000).toISOString(); // closed out
+    if (rnd() < 0.06) row.validFrom = createdAt;
+    if (rnd() < 0.05) row.supersedes = rows.length > 0 ? rows[Math.floor(rnd() * rows.length)].id : undefined;
+    rows.push(row);
+  }
+  // TIE FODDER: exact-duplicate bodies. Their BM25 scores are bit-identical for
+  // any query, so they are the decline guard's fixture. Their vocabulary is
+  // PRIVATE to them (`tiemarker`, `tz*` — absent from QUERY_VOCAB and FILLER),
+  // because three identical documents sharing the query vocabulary would tie
+  // inside the window of nearly every query and push the whole suite onto the
+  // fallback path, which is exactly what it must not silently do.
+  const twin = "tiemarker tz1 tz2 tz3 tz4 tz5 tz6 tz7";
+  for (const [suffix, agentId] of [["zzz", "agent-a"], ["aaa", "agent-a"], ["mmm", "agent-b"]] as const) {
+    rows.push({
+      id: `mem-tie-${suffix}`, agentId, content: twin, contentHash: `tie-${suffix}`,
+      embedding: Array.from({ length: DIM }, () => 0.1), durability: "standard",
+      createdAt: new Date(BASE_TIME).toISOString(), updatedAt: new Date(BASE_TIME).toISOString(),
+      tags: ["infra"], subject: "flint",
+    });
+  }
+  // Insert in SHUFFLED order so Map insertion order ≠ id order.
+  const order = rows.map((_, i) => i);
+  for (let i = order.length - 1; i > 0; i--) {
+    const j = Math.floor(mulberry32(i * 7 + 3)() * (i + 1));
+    [order[i], order[j]] = [order[j], order[i]];
+  }
+  for (const i of order) memoryStore.set(rows[i].id, rows[i]);
+}
+
+function scopeFor(agentId: string) {
+  const condition = {
+    operator: "or",
+    conditions: [
+      { attribute: "agentId", comparator: "equals", value: agentId },
+      { attribute: "visibility", comparator: "not_equal", value: "private" },
+    ],
+  };
+  const isAllowed: any = (r: any) => !!r && (r.agentId === agentId || r.visibility !== "private");
+  isAllowed.scopableOnly = true;
+  return { condition, isAllowed };
+}
+
+function qEmbFor(seed: number): number[] {
+  const rnd = mulberry32(seed);
+  return Array.from({ length: DIM }, () => rnd() * 2 - 1);
+}
+
+// ─── The query matrix ────────────────────────────────────────────────────────
+
+interface Case { name: string; params: Record<string, any> }
+
+function buildCases(): Case[] {
+  const cases: Case[] = [];
+  const reader = "agent-a";
+  const { condition, isAllowed } = scopeFor(reader);
+  const notArchived = { attribute: "archived", comparator: "not_equal", value: true };
+
+  const texts = [
+    "vertex ingress certificate fingerprint",
+    "rollout cluster release cycle",
+    "retrieval corpus index latency ranking",
+    "harper memory embedding cosine",
+    "decision flag benchmark throughput",
+    "vertex ingress proxy certificate fingerprint handshake rollout cluster",
+    "candidate fusion lexical ranking",
+    "buffer proxy budget runbook",
+  ];
+
+  for (let i = 0; i < texts.length; i++) {
+    const q = texts[i];
+    const base = {
+      q, conditions: [condition, notArchived], limit: 20, agentId: reader,
+      isAllowed, hybrid: true, scoring: "raw", minScore: 0,
+    };
+    cases.push({ name: `plain/${i}`, params: { ...base, queryEmbedding: qEmbFor(100 + i) } });
+    cases.push({ name: `no-embedding/${i}`, params: { ...base, queryEmbedding: null } });
+    cases.push({
+      name: `tag/${i}`,
+      params: {
+        ...base, queryEmbedding: qEmbFor(200 + i),
+        conditions: [condition, notArchived, { attribute: "tags", comparator: "equals", value: TAGS[i % TAGS.length] }],
+      },
+    });
+    cases.push({
+      name: `subject-single/${i}`,
+      params: {
+        ...base, queryEmbedding: qEmbFor(300 + i),
+        conditions: [condition, notArchived, { attribute: "subject", comparator: "equals", value: SUBJECTS[i % SUBJECTS.length] }],
+      },
+    });
+    cases.push({
+      name: `subject-or/${i}`,
+      params: {
+        ...base, queryEmbedding: qEmbFor(400 + i),
+        conditions: [condition, notArchived, {
+          operator: "or",
+          conditions: [
+            { attribute: "subject", comparator: "equals", value: "flint" },
+            { attribute: "subject", comparator: "equals", value: "kern" },
+          ],
+        }],
+      },
+    });
+    // Both facets at once — the aggregates cannot express the intersection, so
+    // this drives the index's EXACT statistics walk.
+    cases.push({
+      name: `tag+subject/${i}`,
+      params: {
+        ...base, queryEmbedding: qEmbFor(500 + i),
+        conditions: [condition, notArchived,
+          { attribute: "tags", comparator: "equals", value: "infra" },
+          { attribute: "subject", comparator: "equals", value: "flint" }],
+      },
+    });
+    // sinceDate / asOf — also the exact walk.
+    cases.push({
+      name: `since/${i}`,
+      params: { ...base, queryEmbedding: qEmbFor(600 + i), sinceDate: new Date(BASE_TIME + 50 * 3600_000) },
+    });
+    cases.push({
+      name: `asOf/${i}`,
+      params: { ...base, queryEmbedding: qEmbFor(700 + i), asOf: new Date(BASE_TIME + 120 * 3600_000).toISOString() },
+    });
+    cases.push({ name: `composite/${i}`, params: { ...base, queryEmbedding: qEmbFor(800 + i), scoring: "composite" } });
+    cases.push({ name: `minScore/${i}`, params: { ...base, queryEmbedding: qEmbFor(900 + i), minScore: 0.3 } });
+    cases.push({ name: `superseded/${i}`, params: { ...base, queryEmbedding: qEmbFor(1000 + i), includeSuperseded: true } });
+    cases.push({ name: `semSim/${i}`, params: { ...base, queryEmbedding: qEmbFor(1100 + i), withSemSimilarity: true } });
+    cases.push({ name: `narrow-limit/${i}`, params: { ...base, queryEmbedding: qEmbFor(1200 + i), limit: 3 } });
+    cases.push({ name: `deep-limit/${i}`, params: { ...base, queryEmbedding: qEmbFor(1300 + i), limit: 200 } });
+    // An UNSCOPED read (admin-shaped: no agentId, no isAllowed).
+    cases.push({
+      name: `unscoped/${i}`,
+      params: { ...base, queryEmbedding: qEmbFor(1400 + i), conditions: [notArchived], isAllowed: undefined, agentId: undefined },
+    });
+    // Bootstrap's shape: scope condition ONLY, no archived exclusion.
+    cases.push({ name: `bootstrap/${i}`, params: { ...base, queryEmbedding: qEmbFor(1500 + i), conditions: [condition] } });
+  }
+  // No lexical signal at all — the full scoped listing branch.
+  cases.push({
+    name: "listing",
+    params: {
+      q: undefined, queryEmbedding: null, conditions: [condition, notArchived], limit: 500,
+      agentId: reader, isAllowed, hybrid: true, scoring: "raw", minScore: 0,
+    },
+  });
+  // Embedding but no text.
+  cases.push({
+    name: "embedding-only",
+    params: {
+      q: undefined, queryEmbedding: qEmbFor(31337), conditions: [condition, notArchived], limit: 20,
+      agentId: reader, isAllowed, hybrid: true, scoring: "raw", minScore: 0,
+    },
+  });
+  return cases;
+}
+
+async function runBoth(params: Record<string, any>): Promise<{ legacy: any[]; indexed: any[] }> {
+  process.env.FLAIR_BM25_INDEX = "false";
+  __resetBm25IndexForTests();
+  const legacy = await retrieveCandidates({ ...params } as any);
+
+  process.env.FLAIR_BM25_INDEX = "true";
+  const indexed = await retrieveCandidates({ ...params } as any);
+  return { legacy, indexed };
+}
+
+describe("flair#1357 — the indexed lexical leg is byte-identical to the legacy corpus rebuild", () => {
+  beforeEach(() => {
+    seedCorpus(400);
+    corpusScans = 0;
+    feedListeners = [];
+    __resetBm25IndexForTests();
+    delete process.env.FLAIR_BM25_INDEX;
+  });
+  afterEach(() => { delete process.env.FLAIR_BM25_INDEX; __resetBm25IndexForTests(); });
+
+  const cases = buildCases();
+
+  it(`covers ${cases.length} query shapes over a fixed 403-record store`, () => {
+    expect(cases.length).toBeGreaterThan(100);
+    expect(memoryStore.size).toBe(403);
+  });
+
+  it("every query returns byte-identical results on both paths", async () => {
+    // Build ONCE, then reuse across every case — the realistic shape, and it
+    // also proves the index is not silently rebuilding per query.
+    process.env.FLAIR_BM25_INDEX = "true";
+    __resetBm25IndexForTests();
+    await retrieveCandidates({ ...cases[0].params } as any);
+    expect(bm25IndexStatus().state).toBe("ready");
+    const scansAfterBuild = corpusScans;
+
+    const mismatches: string[] = [];
+    const fellBack: string[] = [];
+    for (const c of cases) {
+      process.env.FLAIR_BM25_INDEX = "false";
+      const legacy = await retrieveCandidates({ ...c.params } as any);
+      process.env.FLAIR_BM25_INDEX = "true";
+      // A corpus scan during the INDEXED run means the index declined the
+      // query and the legacy fallback ran instead.
+      const before = corpusScans;
+      const indexed = await retrieveCandidates({ ...c.params } as any);
+      if (corpusScans > before) fellBack.push(c.name);
+
+      const a = JSON.stringify(legacy);
+      const b = JSON.stringify(indexed);
+      if (a !== b) {
+        mismatches.push(
+          `${c.name}: legacy ids=${JSON.stringify(legacy.map((r: any) => r.id))}\n` +
+          `             indexed ids=${JSON.stringify(indexed.map((r: any) => r.id))}`,
+        );
+      }
+    }
+    expect(mismatches.join("\n"), `${mismatches.length}/${cases.length} query shapes diverged`).toBe("");
+
+    // ── THE ANTI-VACUITY CONTROL ─────────────────────────────────────────────
+    // Everything above would pass trivially if the index quietly declined every
+    // query and both "paths" were the same legacy code. Fallbacks are expected
+    // for the no-query-text listing (no lexical leg to serve) and for any query
+    // whose returned window contains a BM25 score tie (the decline guard), so
+    // this asserts a FLOOR on how much the index actually served rather than
+    // exact equality — but a floor high enough that a blanket decline fails.
+    const served = cases.length - fellBack.length;
+    console.log(`\n  BM25 INDEX SERVE RATE: ${served}/${cases.length} query shapes ` +
+      `(${((100 * served) / cases.length).toFixed(0)}%); the rest hit the tie-decline guard ` +
+      `or have no query text.\n`);
+    expect(fellBack, "the no-text listing must fall back").toContain("listing");
+    // The index must actually serve SOMETHING, or every "both paths agree"
+    // assertion above is two runs of the same legacy code agreeing with itself.
+    expect(served, "the index served nothing — every equivalence assertion above is vacuous").toBeGreaterThan(0);
+    expect(corpusScans).toBeGreaterThan(scansAfterBuild); // legacy control ran
+    expect(bm25IndexStatus().state).toBe("ready");
+  }, 120_000);
+
+  it("the equivalence check CAN fail — a corrupted index is caught", async () => {
+    // Positive control. Without this, an equivalence assertion that compares
+    // two runs of the same code path would pass vacuously forever. The victim
+    // is an id the index is DEMONSTRABLY supplying to the lexical leg — nothing
+    // is proved by corrupting a record the query was never going to use.
+    process.env.FLAIR_BM25_INDEX = "true";
+    __resetBm25IndexForTests();
+    const all = buildCases().filter((x) => x.params.q);
+    await retrieveCandidates({ ...all[0].params } as any); // build
+    // Find a case the index genuinely SERVES — corrupting the index proves
+    // nothing about a query that was going to decline and fall back anyway.
+    let c = all[0];
+    let servedIds: string[] | null = null;
+    for (const cand of all) {
+      const ids = await indexedBm25Ids({
+        q: cand.params.q, conditions: cand.params.conditions as any, timeFilters: {},
+        isAllowed: cand.params.isAllowed, limit: 50,
+      });
+      if (ids && ids.length > 0) { c = cand; servedIds = ids; break; }
+    }
+    expect(servedIds, "this control needs a query the index actually serves").not.toBeNull();
+
+    process.env.FLAIR_BM25_INDEX = "false";
+    const legacy = await retrieveCandidates({ ...c.params } as any);
+    process.env.FLAIR_BM25_INDEX = "true";
+    expect(JSON.stringify(await retrieveCandidates({ ...c.params } as any))).toBe(JSON.stringify(legacy));
+
+    // Now drop the lexical leg's top hit from the index ONLY (the store still
+    // has it), and the two paths must part company.
+    noteMemoryDelete(servedIds![0]);
+    const corrupted = await retrieveCandidates({ ...c.params } as any);
+    expect(JSON.stringify(corrupted)).not.toBe(JSON.stringify(legacy));
+  }, 60_000);
+
+  it("a score tie in the returned window makes the index DECLINE, and the answer still matches", async () => {
+    const { condition, isAllowed } = scopeFor("agent-a");
+    const params = {
+      q: "tiemarker tz1 tz2 tz3",
+      queryEmbedding: qEmbFor(4242),
+      conditions: [condition, { attribute: "archived", comparator: "not_equal", value: true }],
+      limit: 200, agentId: "agent-a", isAllowed, hybrid: true, scoring: "raw", minScore: 0,
+    };
+    process.env.FLAIR_BM25_INDEX = "true";
+    __resetBm25IndexForTests();
+    await retrieveCandidates({ ...params } as any); // build
+    // The three exact-duplicate bodies tie on this query, so the index must
+    // refuse to serve the lexical leg at all.
+    const declined = await indexedBm25Ids({
+      q: params.q, conditions: params.conditions as any, timeFilters: {},
+      isAllowed: params.isAllowed, limit: 50,
+    });
+    expect(declined, "a window containing tied scores must be declined, not guessed").toBeNull();
+
+    const { legacy, indexed } = await runBoth(params);
+    const tieOrder = (rs: any[]) => rs.map((r: any) => r.id).filter((id: string) => id.startsWith("mem-tie-"));
+    expect(tieOrder(legacy).length).toBe(3);
+    expect(tieOrder(indexed)).toEqual(tieOrder(legacy));
+    expect(JSON.stringify(indexed)).toBe(JSON.stringify(legacy));
+  }, 60_000);
+});
+
+// ─── Incremental maintenance ─────────────────────────────────────────────────
+
+describe("flair#1357 — incremental maintenance keeps the lexical leg current", () => {
+  const reader = "agent-a";
+  const { condition, isAllowed } = scopeFor(reader);
+  const notArchived = { attribute: "archived", comparator: "not_equal", value: true };
+
+  function search(q: string, extra: Record<string, any> = {}) {
+    return retrieveCandidates({
+      q, queryEmbedding: null, conditions: [condition, notArchived], limit: 50,
+      agentId: reader, isAllowed, hybrid: true, scoring: "raw", minScore: 0, ...extra,
+    } as any);
+  }
+
+  beforeEach(async () => {
+    seedCorpus(120);
+    feedListeners = [];
+    __resetBm25IndexForTests();
+    process.env.FLAIR_BM25_INDEX = "true";
+    await search("vertex"); // force the build
+    expect(bm25IndexStatus().state).toBe("ready");
+  });
+  afterEach(() => { delete process.env.FLAIR_BM25_INDEX; __resetBm25IndexForTests(); });
+
+  const NEEDLE = "quokka";
+
+  it("a write is IMMEDIATELY searchable in the lexical leg (read-your-write)", async () => {
+    expect((await search(NEEDLE)).length).toBe(0);
+    const row = {
+      id: "mem-new-write", agentId: reader, content: `a ${NEEDLE} appeared in the cluster`,
+      durability: "standard", createdAt: new Date(BASE_TIME).toISOString(),
+    };
+    memoryStore.set(row.id, row);
+    noteMemoryUpsert(row); // exactly what resources/Memory.ts's put/post now call
+    const hits = await search(NEEDLE);
+    expect(hits.map((r: any) => r.id)).toEqual(["mem-new-write"]);
+  });
+
+  it("a delete removes it from the lexical leg", async () => {
+    const row = { id: "mem-doomed", agentId: reader, content: `${NEEDLE} doomed`, durability: "standard", createdAt: new Date(BASE_TIME).toISOString() };
+    memoryStore.set(row.id, row);
+    noteMemoryUpsert(row);
+    expect((await search(NEEDLE)).length).toBe(1);
+    memoryStore.delete(row.id);
+    noteMemoryDelete(row.id);
+    expect((await search(NEEDLE)).length).toBe(0);
+  });
+
+  it("an ARCHIVE flip excludes it (the `archived not_equal true` transition)", async () => {
+    const row: any = { id: "mem-archflip", agentId: reader, content: `${NEEDLE} archival`, durability: "standard", createdAt: new Date(BASE_TIME).toISOString() };
+    memoryStore.set(row.id, row);
+    noteMemoryUpsert(row);
+    expect((await search(NEEDLE)).length).toBe(1);
+    const archived = { ...row, archived: true, archivedAt: new Date().toISOString() };
+    memoryStore.set(row.id, archived);
+    noteMemoryUpsert(archived);
+    expect((await search(NEEDLE)).length).toBe(0);
+    // ...and back again — the flip is not one-way.
+    memoryStore.set(row.id, row);
+    noteMemoryUpsert(row);
+    expect((await search(NEEDLE)).length).toBe(1);
+  });
+
+  it("a CONTENT edit re-tokenizes: the old term stops matching, the new one starts", async () => {
+    const row = { id: "mem-edit", agentId: reader, content: `${NEEDLE} before`, durability: "standard", createdAt: new Date(BASE_TIME).toISOString() };
+    memoryStore.set(row.id, row);
+    noteMemoryUpsert(row);
+    expect((await search(NEEDLE)).length).toBe(1);
+    const edited = { ...row, content: "wombat after" };
+    memoryStore.set(row.id, edited);
+    noteMemoryUpsert(edited);
+    expect((await search(NEEDLE)).length).toBe(0);
+    expect((await search("wombat")).map((r: any) => r.id)).toEqual(["mem-edit"]);
+  });
+
+  it("EPHEMERAL EXPIRY: a past expiresAt drops out with no write at all (wall-clock only)", async () => {
+    const row = {
+      id: "mem-ephemeral", agentId: reader, content: `${NEEDLE} ephemeral`, durability: "ephemeral",
+      createdAt: new Date().toISOString(), expiresAt: new Date(Date.now() + 60_000).toISOString(),
+    };
+    memoryStore.set(row.id, row);
+    noteMemoryUpsert(row);
+    expect((await search(NEEDLE)).length).toBe(1);
+    // No write, no hook — only time passes. The aggregates must sweep it out
+    // and the candidate filter must drop it.
+    const later = Date.parse(row.expiresAt) + 1000;
+    const spy = Date.now;
+    (Date as any).now = () => later;
+    try {
+      expect((await search(NEEDLE)).length).toBe(0);
+    } finally { (Date as any).now = spy; }
+  });
+
+  it("a SUPERSEDE close (validTo in the past) drops out", async () => {
+    const row: any = { id: "mem-superseded", agentId: reader, content: `${NEEDLE} superseded`, durability: "standard", createdAt: new Date(BASE_TIME).toISOString() };
+    memoryStore.set(row.id, row);
+    noteMemoryUpsert(row);
+    expect((await search(NEEDLE)).length).toBe(1);
+    const closed = { ...row, validTo: new Date(Date.now() - 1000).toISOString() };
+    memoryStore.set(row.id, closed);
+    noteMemoryUpsert(closed); // closeSupersededRecord's hook
+    expect((await search(NEEDLE)).length).toBe(0);
+  });
+
+  it("the CHANGE FEED alone carries a write that no hook reported", async () => {
+    // The replication / operations-API / other-worker shape: nothing in flair's
+    // JS write paths ran, so no hook fired — only the table's change feed did.
+    const row = { id: "mem-from-feed", agentId: reader, content: `${NEEDLE} via feed`, durability: "standard", createdAt: new Date(BASE_TIME).toISOString() };
+    memoryStore.set(row.id, row);
+    emit({ type: "put", id: row.id, value: row });
+    await new Promise((r) => setTimeout(r, 5));
+    expect((await search(NEEDLE)).map((r: any) => r.id)).toEqual(["mem-from-feed"]);
+
+    memoryStore.delete(row.id);
+    emit({ type: "delete", id: row.id, value: null });
+    await new Promise((r) => setTimeout(r, 5));
+    expect((await search(NEEDLE)).length).toBe(0);
+  });
+
+  it("an UNKNOWN feed event marks the index stale rather than trusting it", async () => {
+    // Harper emits a bare `reload` marker when a base copy / resync replaces
+    // table contents wholesale. There are no per-row events to apply, so the
+    // only safe response is to rebuild.
+    emit({ type: "reload" });
+    await new Promise((r) => setTimeout(r, 5));
+    expect(bm25IndexStatus().state).toBe("empty");
+    const row = { id: "mem-after-reload", agentId: reader, content: `${NEEDLE} after reload`, durability: "standard", createdAt: new Date(BASE_TIME).toISOString() };
+    memoryStore.set(row.id, row);
+    // No hook: the rebuild triggered by the next query must pick it up from
+    // the table itself.
+    expect((await search(NEEDLE)).map((r: any) => r.id)).toEqual(["mem-after-reload"]);
+    expect(bm25IndexStatus().state).toBe("ready");
+  });
+
+  it("a heavy update churn stays correct across index compaction", async () => {
+    // upsert = tombstone + append, so repeated updates accumulate dead
+    // postings until compact() reclaims them. Correctness must not depend on
+    // which side of that threshold we land.
+    const row: any = { id: "mem-churn", agentId: reader, content: "seed", durability: "standard", createdAt: new Date(BASE_TIME).toISOString() };
+    memoryStore.set(row.id, row);
+    for (let i = 0; i < 500; i++) {
+      const next = { ...row, content: `churn ${i} ${NEEDLE}` };
+      memoryStore.set(row.id, next);
+      noteMemoryUpsert(next);
+    }
+    expect(bm25IndexStatus().size).toBe(memoryStore.size);
+    const hits = await search(NEEDLE);
+    expect(hits.map((r: any) => r.id)).toEqual(["mem-churn"]);
+    // ...and the whole corpus still ranks identically after all that churn.
+    process.env.FLAIR_BM25_INDEX = "false";
+    const legacy = await search("vertex ingress cluster");
+    process.env.FLAIR_BM25_INDEX = "true";
+    const indexed = await search("vertex ingress cluster");
+    expect(JSON.stringify(indexed)).toBe(JSON.stringify(legacy));
+  }, 60_000);
+});
+
+// ─── Concurrency ─────────────────────────────────────────────────────────────
+
+describe("flair#1357 — concurrency", () => {
+  const reader = "agent-a";
+  const { condition, isAllowed } = scopeFor(reader);
+  const notArchived = { attribute: "archived", comparator: "not_equal", value: true };
+
+  function search(q: string) {
+    return retrieveCandidates({
+      q, queryEmbedding: null, conditions: [condition, notArchived], limit: 50,
+      agentId: reader, isAllowed, hybrid: true, scoring: "raw", minScore: 0,
+    } as any);
+  }
+
+  beforeEach(() => {
+    seedCorpus(200);
+    feedListeners = [];
+    __resetBm25IndexForTests();
+    process.env.FLAIR_BM25_INDEX = "true";
+  });
+  afterEach(() => { delete process.env.FLAIR_BM25_INDEX; __resetBm25IndexForTests(); });
+
+  it("concurrent cold queries share ONE build and all agree", async () => {
+    corpusScans = 0;
+    const runs = await Promise.all(Array.from({ length: 12 }, () => search("vertex ingress cluster")));
+    // Exactly one BUILD, however many queries raced into it. (A query may also
+    // scan because the index declined a tie; what must not happen is twelve
+    // concurrent builds.)
+    expect(bm25IndexStatus().state).toBe("ready");
+    expect(bm25IndexStatus().size).toBe(memoryStore.size);
+    expect(corpusScans).toBeLessThanOrEqual(13);
+    const first = JSON.stringify(runs[0]);
+    for (const r of runs) expect(JSON.stringify(r)).toBe(first);
+  }, 60_000);
+
+  it("writes landing DURING the build are not lost", async () => {
+    // The build starts, and mid-scan a write and a delete arrive. Buffered
+    // events are replayed after the cursor finishes, so the newer event wins
+    // regardless of whether the cursor had already visited the row.
+    const doomed = [...memoryStore.values()][0];
+    const inflight = { id: "mem-inflight", agentId: reader, content: "narwhal inflight", durability: "standard", createdAt: new Date(BASE_TIME).toISOString() };
+
+    const building = search("vertex");
+    memoryStore.set(inflight.id, inflight);
+    noteMemoryUpsert(inflight);
+    memoryStore.delete(doomed.id);
+    noteMemoryDelete(doomed.id);
+    await building;
+
+    expect((await search("narwhal")).map((r: any) => r.id)).toEqual(["mem-inflight"]);
+    expect(bm25IndexStatus().size).toBe(memoryStore.size);
+  }, 60_000);
+
+  it("interleaved queries and writes never observe a half-applied index", async () => {
+    await search("vertex");
+    const results: string[] = [];
+    await Promise.all([
+      (async () => { for (let i = 0; i < 40; i++) results.push(JSON.stringify((await search("vertex ingress")).map((r: any) => r.id))); })(),
+      (async () => {
+        for (let i = 0; i < 40; i++) {
+          const row = { id: `mem-conc-${i}`, agentId: reader, content: `concurrent ${i} narwhal`, durability: "standard", createdAt: new Date(BASE_TIME).toISOString() };
+          memoryStore.set(row.id, row);
+          noteMemoryUpsert(row);
+          await Promise.resolve();
+        }
+      })(),
+    ]);
+    expect(results.length).toBe(40);
+    expect(bm25IndexStatus().size).toBe(memoryStore.size);
+    // Whatever interleaving happened, the FINAL state is exactly what a
+    // from-scratch legacy scan would produce.
+    process.env.FLAIR_BM25_INDEX = "false";
+    const legacy = await search("vertex ingress narwhal");
+    process.env.FLAIR_BM25_INDEX = "true";
+    const indexed = await search("vertex ingress narwhal");
+    expect(JSON.stringify(indexed)).toBe(JSON.stringify(legacy));
+  }, 60_000);
+});

--- a/test/unit/bm25-index-latency-1357.test.ts
+++ b/test/unit/bm25-index-latency-1357.test.ts
@@ -57,7 +57,7 @@ const CONDITIONS = [
 const isAllowed: any = (r: any) => !!r && (r.agentId === AGENT || r.visibility !== "private");
 isAllowed.scopableOnly = true;
 
-const TOPICAL_COUNT = 200;
+const TOPICAL_COUNT = 500;
 
 function makeCorpus(distractors: number): IndexRecord[] {
   const rnd = mulberry32(1357);
@@ -80,14 +80,11 @@ function makeCorpus(distractors: number): IndexRecord[] {
     // scan — which would silently turn this file into a measurement of the
     // legacy path against itself.
     const words: string[] = [];
-    // UNIQUE length per topical document. Two documents with the same length
-    // and the same term counts score identically, and an exact tie inside the
-    // returned window makes the index decline by design
-    // (resources/bm25-index.ts) and fall back to the legacy scan — which would
-    // silently turn this file into a measurement of the legacy path against
-    // itself. Distinct lengths give distinct length normalisation, so the
-    // window this test measures is genuinely served from the index.
-    const len = 20 + i;
+    // 26 tokens — the measured live-corpus median
+    // (test/bench/corpus-profiler/profiles/corpus-v2.json). Many of these
+    // documents tie on any given query, which is the realistic case and, since
+    // flair#1363, a case the index serves rather than declines.
+    const len = 26;
     for (let w = 0; w < len; w++) words.push(TOPICAL_VOCAB[Math.floor(rnd() * TOPICAL_VOCAB.length)]);
     emit(`topical-${String(i).padStart(6, "0")}`, words);
   }
@@ -130,7 +127,10 @@ function timeIndexed(idx: Bm25Index, samples: number): number {
     const t0 = performance.now();
     const ids = idx.rank({ q, conditions: CONDITIONS, isAllowed, limit: SEM_LIMIT });
     const t1 = performance.now();
-    if (ids === null) throw new Error("index declined a query this test requires it to serve (score tie in the window — the fixture must keep scores distinct)");
+    // Tripwire, not an expected branch: `planQuery` serves these conditions,
+    // and score ties stopped being a reason to decline in flair#1363. A null
+    // here would mean this file is timing the legacy path against itself.
+    if (ids === null) throw new Error("index declined a query this test requires it to serve");
     times.push(t1 - t0);
   }
   return median(times);

--- a/test/unit/bm25-index-latency-1357.test.ts
+++ b/test/unit/bm25-index-latency-1357.test.ts
@@ -1,0 +1,247 @@
+/**
+ * bm25-index-latency-1357.test.ts — the check that would have caught flair#1357.
+ *
+ * THE DEFECT: the hybrid lexical leg called `buildBM25(wholeScopedCorpus)` on
+ * every query, so per-query work was proportional to STORE SIZE rather than to
+ * how much of the store the query could possibly match. Measured in the field:
+ * hybrid recall p50 5.6s at 60k rows → 28.7s at 180k, while vector-only recall
+ * over the same stores moved 2.4s → 4.7s. Nothing in the suite failed, because
+ * nothing in the suite measured a second store size.
+ *
+ * THE INVARIANT ASSERTED HERE: a query's cost tracks the documents that
+ * actually contain its terms — NOT the size of the store around them. So the
+ * fixture holds the matchable set FIXED at 500 documents and grows the
+ * surrounding corpus 4×. The old implementation pays 4× for that; the new one
+ * must not.
+ *
+ * THE POSITIVE CONTROL (non-negotiable): every timing assertion below is
+ * paired with the SAME measurement run against `buildBM25` — the code being
+ * replaced. If the control does not show the linear growth it is supposed to
+ * show, the harness is not measuring what it claims and the test says so
+ * instead of passing. A latency test with no control is a green light that
+ * cannot turn red.
+ */
+import { describe, test, expect } from "bun:test";
+import { buildBM25, SEM_LIMIT } from "../../resources/bm25.ts";
+import { Bm25Index, type IndexRecord } from "../../resources/bm25-index.ts";
+
+// ─── Fixture ────────────────────────────────────────────────────────────────
+
+function mulberry32(seed: number) {
+  return function () {
+    seed |= 0; seed = (seed + 0x6D2B79F5) | 0;
+    let t = Math.imul(seed ^ (seed >>> 15), 1 | seed);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+/** Distractor vocabulary — deliberately disjoint from the topical one, so a
+ *  topical query matches exactly the 500 topical documents at every store
+ *  size. */
+const DISTRACTOR_VOCAB = Array.from({ length: 4000 }, (_, i) => `dz${i}`);
+const TOPICAL_VOCAB = Array.from({ length: 60 }, (_, i) => `tq${i}`);
+
+const AGENT = "agent-a";
+const CONDITIONS = [
+  {
+    operator: "or",
+    conditions: [
+      { attribute: "agentId", comparator: "equals", value: AGENT },
+      { attribute: "visibility", comparator: "not_equal", value: "private" },
+    ],
+  },
+  { attribute: "archived", comparator: "not_equal", value: true },
+] as any[];
+
+const isAllowed: any = (r: any) => !!r && (r.agentId === AGENT || r.visibility !== "private");
+isAllowed.scopableOnly = true;
+
+const TOPICAL_COUNT = 200;
+
+function makeCorpus(distractors: number): IndexRecord[] {
+  const rnd = mulberry32(1357);
+  const docs: IndexRecord[] = [];
+  const emit = (id: string, words: string[]) => {
+    docs.push({
+      id,
+      content: words.join(" "),
+      agentId: AGENT,
+      visibility: "shared",
+      archived: false,
+      durability: "standard",
+      createdAt: "2026-06-01T00:00:00.000Z",
+    });
+  };
+  for (let i = 0; i < TOPICAL_COUNT; i++) {
+    // Lengths spread across 43 values and randomised term draws, so BM25 scores
+    // inside the returned window are DISTINCT. Exact score ties make the index
+    // decline by design (resources/bm25-index.ts) and fall back to the legacy
+    // scan — which would silently turn this file into a measurement of the
+    // legacy path against itself.
+    const words: string[] = [];
+    // UNIQUE length per topical document. Two documents with the same length
+    // and the same term counts score identically, and an exact tie inside the
+    // returned window makes the index decline by design
+    // (resources/bm25-index.ts) and fall back to the legacy scan — which would
+    // silently turn this file into a measurement of the legacy path against
+    // itself. Distinct lengths give distinct length normalisation, so the
+    // window this test measures is genuinely served from the index.
+    const len = 20 + i;
+    for (let w = 0; w < len; w++) words.push(TOPICAL_VOCAB[Math.floor(rnd() * TOPICAL_VOCAB.length)]);
+    emit(`topical-${String(i).padStart(6, "0")}`, words);
+  }
+  for (let i = 0; i < distractors; i++) {
+    const words: string[] = [];
+    // Zipf-ish draw, so the distractor corpus has the long tail a real store
+    // has rather than a flat vocabulary.
+    for (let w = 0; w < 26; w++) {
+      const r = rnd();
+      words.push(DISTRACTOR_VOCAB[Math.floor(r * r * DISTRACTOR_VOCAB.length)]);
+    }
+    emit(`distract-${String(i).padStart(7, "0")}`, words);
+  }
+  return docs;
+}
+
+const QUERIES = Array.from({ length: 24 }, (_, i) => {
+  const rnd = mulberry32(9000 + i);
+  const terms: string[] = [];
+  for (let t = 0; t < 5; t++) terms.push(TOPICAL_VOCAB[Math.floor(rnd() * TOPICAL_VOCAB.length)]);
+  return terms.join(" ");
+});
+
+function median(xs: number[]): number {
+  const s = [...xs].sort((a, b) => a - b);
+  return s[Math.floor(s.length / 2)];
+}
+
+function buildIndex(docs: IndexRecord[]): Bm25Index {
+  const idx = new Bm25Index();
+  for (const d of docs) idx.upsert(d);
+  return idx;
+}
+
+/** Median per-query wall time of the NEW path. */
+function timeIndexed(idx: Bm25Index, samples: number): number {
+  const times: number[] = [];
+  for (let s = 0; s < samples; s++) {
+    const q = QUERIES[s % QUERIES.length];
+    const t0 = performance.now();
+    const ids = idx.rank({ q, conditions: CONDITIONS, isAllowed, limit: SEM_LIMIT });
+    const t1 = performance.now();
+    if (ids === null) throw new Error("index declined a query this test requires it to serve (score tie in the window — the fixture must keep scores distinct)");
+    times.push(t1 - t0);
+  }
+  return median(times);
+}
+
+/** Median per-query wall time of the OLD path — the positive control. */
+function timeLegacy(docs: IndexRecord[], samples: number): number {
+  const times: number[] = [];
+  const corpus = docs.map((d) => ({ id: d.id, content: d.content }));
+  for (let s = 0; s < samples; s++) {
+    const q = QUERIES[s % QUERIES.length];
+    const t0 = performance.now();
+    const ranked = buildBM25(corpus).rank(q);
+    ranked.filter((r) => r.score > 0).slice(0, SEM_LIMIT).map((r) => r.id);
+    const t1 = performance.now();
+    times.push(t1 - t0);
+  }
+  return median(times);
+}
+
+// ─── Measurement ────────────────────────────────────────────────────────────
+
+const SMALL = 10_000;
+const LARGE = 40_000; // 4× the distractor corpus, same 500 matchable documents
+
+const smallDocs = makeCorpus(SMALL);
+const largeDocs = makeCorpus(LARGE);
+const smallIdx = buildIndex(smallDocs);
+const largeIdx = buildIndex(largeDocs);
+
+// JIT warm-up, so the first measured sample is not also the first compiled one.
+timeIndexed(smallIdx, 30);
+timeIndexed(largeIdx, 30);
+timeLegacy(smallDocs, 2);
+timeLegacy(largeDocs, 2);
+
+const indexedSmall = timeIndexed(smallIdx, 200);
+const indexedLarge = timeIndexed(largeIdx, 200);
+const legacySmall = timeLegacy(smallDocs, 7);
+const legacyLarge = timeLegacy(largeDocs, 7);
+
+const indexedRatio = indexedLarge / indexedSmall;
+const legacyRatio = legacyLarge / legacySmall;
+
+describe("flair#1357 — per-query work must not scale with store size", () => {
+  test("fixture: 4× the store, the SAME matchable document set", () => {
+    expect(smallIdx.size).toBe(SMALL + TOPICAL_COUNT);
+    expect(largeIdx.size).toBe(LARGE + TOPICAL_COUNT);
+    expect(largeIdx.size - TOPICAL_COUNT).toBe(4 * (smallIdx.size - TOPICAL_COUNT));
+    // Same answers at both sizes: the corpus grew, the matchable set did not.
+    // (The ids can differ only if a distractor somehow matched.)
+    for (const q of QUERIES.slice(0, 5)) {
+      const a = smallIdx.rank({ q, conditions: CONDITIONS, isAllowed, limit: SEM_LIMIT })!;
+      expect(a.length).toBeGreaterThan(0);
+      for (const id of a) expect(id.startsWith("topical-")).toBe(true);
+    }
+  });
+
+  test("POSITIVE CONTROL: the code being replaced DOES scale with store size", () => {
+    // If this ever stops holding, the harness is no longer measuring the
+    // property the assertion below depends on, and the assertion below is
+    // worthless. Fail here rather than pass there.
+    expect(
+      legacyRatio,
+      `legacy buildBM25 4x-store ratio ${legacyRatio.toFixed(2)} ` +
+      `(${legacySmall.toFixed(2)}ms @ ${SMALL + TOPICAL_COUNT} → ${legacyLarge.toFixed(2)}ms @ ${LARGE + TOPICAL_COUNT}) ` +
+      `— expected ~4x; a flat control means this test cannot detect the defect it exists for`,
+    ).toBeGreaterThan(2.5);
+  });
+
+  test("the indexed lexical leg is FLAT across a 4× store", () => {
+    expect(
+      indexedRatio,
+      `indexed 4x-store ratio ${indexedRatio.toFixed(2)} ` +
+      `(${indexedSmall.toFixed(4)}ms @ ${SMALL + TOPICAL_COUNT} → ${indexedLarge.toFixed(4)}ms @ ${LARGE + TOPICAL_COUNT}); ` +
+      `legacy control ratio ${legacyRatio.toFixed(2)}`,
+    ).toBeLessThan(2.0);
+  });
+
+  test("and it is faster in absolute terms by a wide margin at the larger store", () => {
+    const speedup = legacyLarge / indexedLarge;
+    expect(
+      speedup,
+      `speedup ${speedup.toFixed(1)}x at ${LARGE + TOPICAL_COUNT} docs ` +
+      `(${legacyLarge.toFixed(2)}ms → ${indexedLarge.toFixed(4)}ms)`,
+    ).toBeGreaterThan(20);
+  });
+
+  test("MEASUREMENTS", () => {
+    console.log(
+      `\n  flair#1357 lexical-leg per-query median (ms)\n` +
+      `  store size        ${String(SMALL + TOPICAL_COUNT).padStart(10)}  ${String(LARGE + TOPICAL_COUNT).padStart(10)}   ratio\n` +
+      `  legacy buildBM25  ${legacySmall.toFixed(3).padStart(10)}  ${legacyLarge.toFixed(3).padStart(10)}   ${legacyRatio.toFixed(2)}x\n` +
+      `  persistent index  ${indexedSmall.toFixed(3).padStart(10)}  ${indexedLarge.toFixed(3).padStart(10)}   ${indexedRatio.toFixed(2)}x\n` +
+      `  speedup           ${(legacySmall / indexedSmall).toFixed(1).padStart(9)}x  ${(legacyLarge / indexedLarge).toFixed(1).padStart(9)}x\n`,
+    );
+    expect(true).toBe(true);
+  });
+});
+
+describe("flair#1357 — the index answers the same thing it always did, at scale", () => {
+  test("indexed top-N equals buildBM25 top-N on the 40k store", () => {
+    // The equivalence suite (test/unit-isolated/bm25-index-equivalence-1357)
+    // proves this through the whole retrieval core on a small fixture. Repeat
+    // it HERE, at the size this file measures, so a speedup can never be
+    // bought with a shortcut that only shows up on a large corpus.
+    const corpus = largeDocs.map((d) => ({ id: d.id, content: d.content }));
+    for (const q of QUERIES) {
+      const legacy = buildBM25(corpus).rank(q).filter((r) => r.score > 0).slice(0, SEM_LIMIT).map((r) => r.id);
+      const indexed = largeIdx.rank({ q, conditions: CONDITIONS, isAllowed, limit: SEM_LIMIT });
+      expect(indexed).toEqual(legacy);
+    }
+  }, 120_000);
+});

--- a/test/unit/bm25.test.ts
+++ b/test/unit/bm25.test.ts
@@ -46,6 +46,50 @@ describe("feature flag — FLAIR_HYBRID_RETRIEVAL (ACTIVATED 2026-07-08: default
   });
 });
 
+describe("tie-break — score DESC, then ascending id (flair#1363)", () => {
+  // Before this comparator was explicit, `rank()` sorted on score alone. A
+  // stable sort then left EQUAL-SCORING documents in the order the caller had
+  // fetched the corpus in — Harper's, which is a query-plan artifact: measured
+  // on a live instance, the same rows for the same query text iterate
+  // own-agent-first under the read-scope OR-group and primary-key-first under a
+  // tags/subject filter (test/integration/bm25-index-scan-order-1357.test.ts).
+  // So hybrid recall was NONDETERMINISTIC for tied documents, and only exact
+  // ties moved, which is why nothing caught it. The explicit tie-break is also
+  // what makes resources/bm25-index.ts able to serve the lexical leg at all —
+  // it can reproduce `id` ascending; it cannot reproduce a planner.
+  const tied = [
+    { id: "zzz", content: "alpha beta gamma" },
+    { id: "aaa", content: "alpha beta gamma" },
+    { id: "mmm", content: "alpha beta gamma" },
+  ];
+
+  test("documents with identical scores come back in ascending id order", () => {
+    const ranked = buildBM25(tied).rank("alpha beta gamma");
+    // Genuinely tied — otherwise this asserts nothing about tie-breaking.
+    expect(new Set(ranked.map((r) => r.score)).size).toBe(1);
+    expect(ranked.map((r) => r.id)).toEqual(["aaa", "mmm", "zzz"]);
+  });
+
+  test("insertion order does NOT decide it — the same set in any order ranks the same", () => {
+    // This is the property the old stable-sort-only comparator failed: corpus
+    // order leaked into the result. Feed the same documents in a different
+    // order and the ranking must not move.
+    const shuffled = [tied[1], tied[2], tied[0]];
+    expect(buildBM25(shuffled).rank("alpha beta gamma").map((r) => r.id))
+      .toEqual(buildBM25(tied).rank("alpha beta gamma").map((r) => r.id));
+  });
+
+  test("score still dominates — the tie-break only orders EQUAL scores", () => {
+    const docs = [
+      { id: "zzz", content: "alpha alpha alpha beta" }, // strongest
+      { id: "aaa", content: "alpha unrelated words here padding padding padding" },
+    ];
+    const ranked = buildBM25(docs).rank("alpha");
+    expect(ranked[0].score).toBeGreaterThan(ranked[1].score);
+    expect(ranked.map((r) => r.id)).toEqual(["zzz", "aaa"]); // NOT id order
+  });
+});
+
 describe("BM25 params (Kern-approved)", () => {
   test("k1≈1.2, b≈0.75, RRF K=60, SEM_LIMIT=50", () => {
     expect(BM25_K1).toBe(1.2);


### PR DESCRIPTION
Closes #1357

Direction (a) per Kern's ruling (2026-08-23): a persistent, incrementally-maintained BM25 index built on write, replacing the per-query `buildBM25(wholeScopedCorpus)` rebuild.

Kern ruled on the blocker this PR originally opened with, and the ruling is folded in — see *Tie order* below. Also carries #1363, a pre-existing nondeterminism found while proving this one and fixed as a side effect.

---

## Tie order — #1363 (was the blocker; RULED, 2026-08-24)

### What I found while proving equivalence

`buildBM25().rank()` sorted on score alone. `Array.prototype.sort` is stable, so **documents with bit-identical BM25 scores came back in whatever order the corpus had been fetched in** — Harper's. And that order is a **query-plan artifact**, not a property of the store. Measured on a live instance (`test/integration/bm25-index-scan-order-1357.test.ts`), six records, two owners, one reader:

```
lexicographic (primary key)  [m-alpha, m-bravo, m-charlie, m-mike, m-yankee, m-zulu]
scope OR-group scan          [m-mike, m-yankee, m-zulu,  m-alpha, m-bravo, m-charlie]
                              └── reader's own (PK order) ──┘└──── the rest (PK) ────┘
tags/subject-filtered scan   [m-alpha, m-bravo, m-charlie, m-mike, m-yankee, m-zulu]
```

Same store, same rows, same query text, **two different iteration orders decided by the plan** — the read-scope OR-group's first leg is an indexed `agentId equals`, so own rows lead; a selective tag/subject seek yields primary-key order instead. Harper's planner is cost-based, so which one applies is a function of data distribution. Hybrid recall was therefore nondeterministic for tied documents, and nothing could see it: only exact ties move, and they move at the tail of the window.

Ties are not a curiosity. A memory matching one rare query term once, with the same token count as another such memory, scores identically — and flair's live corpus clusters at 19–33 tokens (`test/bench/corpus-profiler/profiles/corpus-v2.json`: contentTokens p05 21, p50 26, p99 32).

### The ruling

Kern, 2026-08-24: *"byte-identical to a nondeterministic source is a contradiction."* The constraint is now **ranking-identical modulo tie order, with ties made deterministic**, and the tie-break is approved.

So `buildBM25().rank()` and the index now share one comparator — score DESC, then ascending `id` — and the tie-decline guard is deleted. It only ever existed because an index cannot reproduce a planner; there is no longer a planner artifact to reproduce.

### Why the guard could not have shipped

Index serve rate, Zipfian vocabulary and the measured length distribution, 300 queries per row:

| corpus | vocabulary | with decline guard | with shared tie-break |
|---|---|---|---|
| 400 docs | 30 terms | 37% | **100%** |
| 400 docs | 3 000 terms | 4% | **100%** |
| 20 000 docs | 20 000 terms | 3% | **100%** |
| 100 000 docs | 40 000 terms | 1% | **100%** |
| 250 000 docs | 60 000 terms | 1% | **100%** |

At the store size #1357 is about, the guard served ~1% of queries and the other 99% still paid the old cost — #1357 would have stayed open.

### Blast radius

Only the relative order of documents whose BM25 scores are bit-identical. On the live-Harper fixture (93 records, 73 query shapes), the 5 queries that previously differed by one tail position now **match exactly**; nothing above a tie changed position in any query. The change also makes recall deterministic where it previously was not — the same store and query no longer return tied memories in different orders depending on which plan Harper picks.

Where each half of the contract is pinned:
- `test/unit/bm25.test.ts` — `buildBM25().rank()` orders tied docs by ascending id, and corpus order does not leak in (same docs, different insertion order, same ranking). Plus a control that score still dominates the tie-break.
- `test/unit-isolated/bm25-index-equivalence-1357.test.ts` — the index's lexical-leg output puts the duplicate triple in ascending id order.
- `test/integration-heavy/…e2e…` — both paths agree on the fused response. Deliberately **not** asserted as ascending id there: by the time ids reach a response they have been through candidate-union RRF with the HNSW leg, so asserting id order at that layer would be asserting a property of the wrong one.

---

## Design choices

**Where index state lives — in process, per Harper worker, not in a Harper table.** A table-backed posting list was rejected on write cost: a memory averages ~26 tokens, so persisting postings turns one `Memory.put()` into ~25 additional indexed row writes inside the same transaction — write amplification on ingestion to speed up reads — and it puts a Harper round-trip per query *term* back into recall. Footprint at 250k documents is ~120MB steady state: ~6.5M postings as paired `Int32Array`s (~52MB), the term dictionary (~20MB), and per-document scope metadata with no content and no embedding (~50MB). For scale, the code being replaced allocated a 250k-entry array of per-document term `Map`s *plus* the whole projected corpus including content, transiently, on every single query — so this is less resident memory than the old peak, not more.

**Cold boot — lazy.** Built on the first hybrid query that carries query text, not at component start: eager building would add a full corpus scan to every boot including the processes that never search (CLI verbs, migration boots, health checks) and would race the embedding engine's model load. The first query after boot pays what *every* query used to pay; every one after it pays nothing. Concurrent first queries share one build promise (test: 12 concurrent cold queries, one build).

**Staying current — two overlapping mechanisms.**
- **The table's own change feed (`Memory.subscribe`) is the authority.** Same audit-log-backed primitive `FeedMemories.connect()` already uses. It observes the *table*, so it sees writes that never touch a flair resource: operations-API writes, CLI direct writes, and Harper replication applying federated rows. A scheme built only from hooks in flair's write paths structurally cannot see those, which is why the feed — not the hook list — is the correctness argument. Verified against a stock instance: an operations-API insert and delete both arrive, and there is a live-Harper test that seeds a memory *behind flair's back* and requires it to become searchable.
- **Synchronous hooks give read-your-write.** The feed is asynchronous; the path being replaced had no such race because it refetched the corpus every query. `noteMemoryUpsert` / `noteMemoryDelete` fire from `Memory.post`/`put`/`delete`, the supersede-close, `FeedMemories.post`, `AgentSeed`, and `MemoryMaintenance`'s expiry-delete and archive-flip. Both mechanisms are idempotent upserts keyed by id.

If the feed cannot be established, the index **disables itself** and every query falls back. If it delivers an event shape we do not understand — Harper emits a bare `reload` marker when a base copy / resync replaces table contents wholesale, precisely when the index cannot be patched incrementally — the index marks itself stale and the next query rebuilds. A slow-but-correct recall is acceptable; a silently stale one is not.

**Concurrency.** `rank()` is fully synchronous — a Harper worker is single-threaded JS, so a body with no `await` cannot observe a write landing part-way through, and every query sees one consistent snapshot. During a build, feed events and hook calls are buffered and replayed **after** the scan finishes, so a delete landing mid-scan wins over the cursor re-adding the row, whichever order they physically occurred in.

**Multi-worker.** The instance is per worker thread, so each worker pays its own first-query build and holds its own copy. Both shipped launch paths pin `THREADS_COUNT=1` (`src/cli.ts`'s launchd plist and its direct-spawn env), as does the integration harness, so the shipped configuration has exactly one worker. Cross-worker visibility rides on the feed, which is audit-log-backed against a shared store; the hooks are local to the writing worker, which is why they are an immediacy optimisation and never the correctness argument.

**Scope-awareness — one index, filtered at query time.** BM25 statistics are corpus-*scoped* (`idf` reads N and df; length normalisation reads avgdl, all over the documents the query's `conditions[]` admit), so a global-statistics index would return a different *order* — the one thing forbidden. The index therefore holds every document once and derives scoped statistics per query: per-term `df` falls out of walking the query terms' posting lists, and N/avgdl come from aggregates keyed by `(agentId, visibility, archived)` plus one optional `tags`/`subject` facet, so the common case is O(#partitions) rather than O(#documents). Queries the aggregates cannot express (`tags` ∧ `subject`, `since`, `asOf`) take an exact linear walk over in-memory metadata — no Harper I/O, no tokenization. Expiry is swept forward against a min-heap: `passesRecordFilters` excludes a record once `expiresAt` or `validTo` is past, *unconditionally*, so expiry is monotone in wall-clock time and aggregates can be advanced rather than recomputed.

**Fail-safe by construction.** `planQuery()` is a conservative allowlist. An unrecognised condition attribute, an unrecognised comparator, or a condition shape it cannot evaluate returns `null` and the caller runs the legacy scan. The attribute allowlist is a *security* boundary, not a performance one: `matchesConditions` evaluates `not_equal` against `record[attr]`, so a stored record missing an attribute the real row carries would **pass** a filter it should fail. `resolveReadScope`'s predicate is also marked `scopableOnly` — a machine-readable restatement of the `ScopableRecord` contract — because the aggregates hoist it to the partition level, which is only sound for a predicate reading nothing but `agentId` and `visibility`. An unmarked predicate is evaluated per record instead: slower, never wrong.

**One thing removed beyond the index.** The full scoped-corpus scan is now skipped entirely on the embedding-only path (`queryEmbedding` present, no `q`), which fetched the whole corpus and used none of it.

---

## Equivalence proof

`FLAIR_BM25_INDEX=false` selects the original corpus scan — which is still in `semantic-retrieval-core.ts` as both the reference implementation and the fallback — so both paths are exercisable against one store.

**Unit, mocked Harper** (`test/unit-isolated/bm25-index-equivalence-1357.test.ts`) — 130 query shapes over a fixed 403-record store: plain, no-embedding, tag, subject-single, subject-OR, tag+subject, `since`, `asOf`, composite scoring, `minScore`, `includeSuperseded`, `withSemSimilarity`, narrow/deep limits, unscoped (admin-shaped), bootstrap-shaped conditions, the no-signal listing, and embedding-only. Fixture carries three agents, private/shared/absent visibility, archived rows, already-expired and future `expiresAt`, past `validTo`, `supersedes` chains, ids generated *out of* insertion order, and an exact-duplicate triple.

```
16 pass  0 fail
BM25 INDEX SERVE RATE: 129/130 query shapes (99%)
```

Every one of the 130 is `JSON.stringify`-identical between the two paths, and the single fallback is the one case with no query text at all — there is no lexical leg to serve. The duplicate triple is drawn from the *query* vocabulary on purpose, so ties land inside the returned window of most shapes rather than in a corner.

**Live Harper, three boots of the same data directory** (`test/integration-heavy/bm25-index-equivalence-e2e-1357.test.ts`) — 93 seeded records across two agents with real embeddings and the real HNSW leg, 73 query shapes through the `SemanticSearch` HTTP endpoint:

```
same-boot repeat diverged : []
legacy-vs-legacy CONTROL  : []   (boot1 vs boot3)
indexed diverged          : []
4 pass  0 fail
```

Before the tie-break, `indexed diverged` listed 5 queries — each a single tail position where two documents scored bit-identically. Those are the ruled-on change, and they match now.

The legacy-vs-legacy control run is load-bearing and earned its place: the first version of this suite reported those 5 divergences, and the control is what proved the harness itself was deterministic and the fault was real, rather than letting me write it off as HNSW drift. Only `retrievalCount` / `lastRetrieved` are excluded from the comparison — `SemanticSearch.post()` writes them for every result it returns, so running the query set three times necessarily moves them. Ids, order, `_score`, and every other projected field are compared exactly.

**Real-Harper premises** (`test/integration/bm25-index-scan-order-1357.test.ts`) — the scan-order measurement quoted above (kept: it is the evidence behind #1363 and the thing that would tell us if the premise ever changed), plus: `select` projects to the subset of `select` a row actually carries in declaration order (asserted structurally — a sparse row's key sequence must be a *subsequence* of a rich row's — which is what the in-process projection reproduces when resolving a BM25-only rescue by point lookup).

> This premise test originally seeded **one agent, and passed.** With a single `agentId`, "grouped by the agentId index" and "ascending primary key" are the same sequence — the fixture could not express the difference it existed to detect, and it is what let the wrong assumption through to the e2e. It seeds two agents now, and asserts the observed order is *not* primary-key order.

**Positive control.** The equivalence assertion compares two code paths; if the index quietly declined everything, it would compare the legacy path with itself and pass forever. So: a dedicated test locates a query the index demonstrably serves, drops that query's top lexical hit from the index only, and requires the two paths to part company. The per-run serve count is printed and the fallback list is asserted to be exactly `["listing"]`.

---

## Latency

`test/unit/bm25-index-latency-1357.test.ts`. The fixture holds the **matchable set fixed** at 500 documents and grows the surrounding corpus 4×, so the invariant under test is precise: a query's cost tracks the documents that contain its terms, not the store around them.

```
flair#1357 lexical-leg per-query median (ms)
store size             10500       40500   ratio
legacy buildBM25      34.225     152.164   4.45x
persistent index       0.136       0.141   1.03x
speedup               251.3x     1080.8x
```

Documents are 26 tokens — the measured live-corpus median — so many of them tie on any given query. That is the realistic case, and since #1363 it is a case the index serves rather than declines.

The legacy row is a **mandatory positive control**, asserted `> 2.5×`: if the old path ever stops showing linear growth, the harness is no longer measuring the property the flat-ratio assertion depends on, and the test fails there rather than passing here. The indexed ratio is asserted `< 2.0` and the absolute speedup at the larger store `> 20×`. The same file re-asserts top-N equality against `buildBM25` over all 24 queries at the 40k store, so a speedup can never be bought with a shortcut that only shows up on a large corpus.

---

## Test counts

Self-measured against `origin/main` (6871a2d7) in a parallel worktree, same machine, same `bun` 1.3.10.

| lane | baseline | branch |
|---|---|---|
| `bun test test/unit/ test/*.test.ts` | 5021 pass, 0 fail † | **5030 pass, 0 fail** |
| `test/unit-isolated/` (one file per process) | 162 pass, 0 fail | **178 pass, 0 fail** |
| `test/integration/` (affected: new premises + bm25-hybrid-noquery-listing, semantic-search-singleton-score, supersede-recall-resurface, bootstrap-supersede-resurface) | — | **11 pass, 0 fail** |
| `test/integration-heavy/` (bootstrap-search-parity-1246, recall-eval-gate) | — | **8 pass, 0 fail** |
| `test/integration-heavy/bm25-index-equivalence-e2e-1357` (new) | — | **4 pass, 0 fail** |
| `tsc -p tsconfig.check.src.json` / `.check.json` / `.test.check.json` | clean | **clean** |

† The baseline worktree symlinks `node_modules`, so `packages/adk-flair-js/test/unit/memory_service.test.ts` (58 tests) could not resolve `@google/adk` and reported as 1 file error. Baseline is quoted as 4963 observed + 58 = 5021; branch 5030 = 5021 + 6 (new latency file) + 3 (new tie-break cases in `test/unit/bm25.test.ts`). No test lost or changed its result.

New tests: 6 latency, 3 tie-break, 16 unit-isolated equivalence/maintenance/concurrency, 7 live-Harper premises + maintenance, 4 live-Harper e2e equivalence.

## Kill switch

`FLAIR_BM25_INDEX=false` (also `0` / `off`) forces every query onto the original path with no rebuild — same shape as `FLAIR_HYBRID_RETRIEVAL`. Default on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
