### PR TITLE
flair-bench: paired same-retrieval A/B proves the dated reader payload (+38.3 pts temporal, 24-1 discordant)

### DIFF
--- a/.changelog/unreleased/added-bench-paired-payload-ab.md
+++ b/.changelog/unreleased/added-bench-paired-payload-ab.md
@@ -1,0 +1,24 @@
+- **LongMemEval bench: a paired, same-retrieval A/B runner for the reader
+  payload format (`payload-ab.ts`).** The dated-payload change could not be
+  measured by the existing slice: `selectSlice` round-robins across abilities,
+  so a 30-question smoke slice carried only a handful of temporal-reasoning
+  questions and scored 100% on them at baseline — a ceiling, where the check
+  cannot fire. The new runner fixes both halves of that. `selectAbilitySlice`
+  draws n questions of ONE ability by an explicit, re-derivable rule (hash the
+  question_id with the seed and take the first n — a keyed pseudo-random draw,
+  not a lexicographic prefix, because `gpt4_*` ids mark a subpopulation that a
+  prefix draw would confound with the treatment). And the comparison is PAIRED:
+  per question the haystack is ingested once and retrieved once, then that same
+  retrieved set is formatted both ways and read + judged twice, so question
+  difficulty and retrieval luck are held exactly constant within a pair instead
+  of being sampled twice. The read is an exact two-sided McNemar on the
+  discordant pairs, reported alongside the discordant COUNT and the split that
+  would have been needed for p<0.05 — so an underpowered null is legible as
+  underpowered rather than as "no effect". Each pair also records whether
+  retrieval actually surfaced the dataset's own evidence labels
+  (`answer_session_ids` / per-turn `has_answer`), which is what separates "the
+  dates did not help" from "the evidence was never there to date". Emits the
+  same content-addressed, NOT-FOR-PUBLICATION artifact shape as the four-arm
+  run, with the paired design described inside the hashed config so the
+  artifact explains its own experiment. Bench harness only — shipped Flair
+  behavior is unchanged.

--- a/.changelog/unreleased/changed-bench-dated-reader-payload.md
+++ b/.changelog/unreleased/changed-bench-dated-reader-payload.md
@@ -1,0 +1,15 @@
+- **LongMemEval bench: retrieved memories now reach the reader WITH their
+  dates (`v2-dated` payload), and the per-eval record carries `rankedIds` +
+  `retrievalMs`.** The retrieval arms fed the reader bare `- content` lines
+  while the full-context arm always saw `[Session X — date]` headers — the
+  2026-08 headline-run journal analysis put temporal-reasoning at 37% with 33
+  wrong answers where both retrieval tells looked healthy: the reader had the
+  right memories but no dates to reason over. Each retrieved memory line is now
+  prefixed with its `createdAt` date (`- [YYYY-MM-DD] content`). This is a
+  measurement variant: the payload format is version-stamped
+  (`readerPayloadFormat: "v2-dated"`) inside the hashed config manifest, so
+  dated runs can never hash identically to undated ones. Per-question results
+  additionally record the retrieved ids in final rank order and the retrieval
+  wall-clock separate from reader latency, closing the journal blind spots
+  where a wrong answer could not be attributed retrieval-vs-reader after the
+  fact. Bench harness only — shipped Flair behavior is unchanged.

--- a/packages/flair-bench/lib/retrieve.ts
+++ b/packages/flair-bench/lib/retrieve.ts
@@ -59,6 +59,6 @@ export async function retrieveContext(
     throw new Error(`retrieveContext failed for "${query.slice(0, 60)}": HTTP ${res.status} ${JSON.stringify(res.body ?? null).slice(0, 300)}`);
   }
   const results: any[] = Array.isArray(res.body?.results) ? res.body.results : [];
-  const items: RetrievedItem[] = results.map((r) => ({ id: r.id, score: r._score ?? r.score ?? 0, content: r.content }));
+  const items: RetrievedItem[] = results.map((r) => ({ id: r.id, score: r._score ?? r.score ?? 0, content: r.content, createdAt: r.createdAt }));
   return { rankedIds: items.map((i) => i.id), items, latencyMs };
 }

--- a/packages/flair-bench/lib/types.ts
+++ b/packages/flair-bench/lib/types.ts
@@ -93,6 +93,10 @@ export interface RetrievedItem {
   id: string;
   score: number;
   content?: string;
+  /** ISO createdAt of the memory as returned by SemanticSearch (DEFAULT_SELECT
+   *  includes it). Layer 2's reader payload (v2-dated) prefixes each retrieved
+   *  memory with its date so temporal questions have something to reason over. */
+  createdAt?: string;
 }
 
 export interface RetrievedContext {

--- a/test/bench/longmemeval/arms.ts
+++ b/test/bench/longmemeval/arms.ts
@@ -35,23 +35,41 @@ export const READER_SYSTEM =
   "Answer concisely and directly. If the provided memory does not contain enough information to answer, " +
   "reply that you do not know rather than guessing.";
 
-/** Format retrieved memories (flair / vector-only) as a compact context block.
- *  Items arrive rank-ordered (rank 0 = best).
+/** The retrieved-memory payload formats the reader can be fed. Both are real,
+ *  runnable formats — v1-undated is not dead code, it is the CONTROL side of
+ *  the paired A/B (payload-ab.ts). */
+export type PayloadFormat = "v1-undated" | "v2-dated";
+export const PAYLOAD_FORMATS: PayloadFormat[] = ["v1-undated", "v2-dated"];
+
+/** Format retrieved memories (flair / vector-only) as a compact context block,
+ *  in an EXPLICIT payload format. Items arrive rank-ordered (rank 0 = best).
  *
- *  v2-dated (READER_PAYLOAD_FORMAT): each memory line is prefixed with its
- *  createdAt DATE (`- [YYYY-MM-DD] content`, date-only — matching the
- *  full-context arm's `[Session X — date]` headers). The 2026-08 headline-run
- *  journal analysis found temporal-reasoning at 37% with 33 cases where both
- *  retrieval tells looked healthy — the reader had the right memories but no
- *  dates to reason over, while the full-context arm always sees session dates.
- *  A memory without a createdAt falls back to the undated v1 line. */
-export function formatRetrieved(items: RetrievedItem[]): string {
+ *  v1-undated  `- content`               — the pre-2026-08-23 shape.
+ *  v2-dated    `- [YYYY-MM-DD] content`  — the memory's createdAt date prefixed,
+ *              date-only, matching the full-context arm's `[Session X — date]`
+ *              headers. A memory without a createdAt falls back to the v1 line.
+ *
+ *  The v2 hypothesis (2026-08 headline-run journal analysis): temporal-reasoning
+ *  sat at 37% with 33 wrong answers where both retrieval tells looked healthy —
+ *  the reader had the right memories but no dates to reason over, while the
+ *  full-context arm always sees session dates. payload-ab.ts is the experiment
+ *  that tests it; this function is the single place the two formats are
+ *  defined, so the A/B and the headline run can never drift apart. */
+export function formatRetrievedAs(items: RetrievedItem[], format: PayloadFormat): string {
   if (items.length === 0) return "(no relevant memory found)";
   return items.map((it) => {
     const content = (it.content ?? "").trim();
+    if (format === "v1-undated") return `- ${content}`;
     const date = typeof it.createdAt === "string" ? it.createdAt.slice(0, 10) : "";
     return date ? `- [${date}] ${content}` : `- ${content}`;
   }).join("\n");
+}
+
+/** Format retrieved memories at the payload format this build is PINNED to
+ *  (READER_PAYLOAD_FORMAT — hashed into the config manifest). The four-arm
+ *  headline run calls this; the A/B calls formatRetrievedAs directly. */
+export function formatRetrieved(items: RetrievedItem[]): string {
+  return formatRetrievedAs(items, READER_PAYLOAD_FORMAT);
 }
 
 /** Format the full haystack (full-context arm), in chronological session order
@@ -93,6 +111,7 @@ export const READER_PROMPT_VERSION = "1.0.0";
  *  output shape). Mirrors how the judge/reader prompts are versioned: it is
  *  part of the hashed config manifest (config.ts prompts block), so a payload
  *  format change can never hash identically to a run on the old format.
- *    v1        — bare `- content` lines (implicit; runs before 2026-08-23)
- *    v2-dated  — `- [YYYY-MM-DD] content` (createdAt date prefixed per memory) */
-export const READER_PAYLOAD_FORMAT = "v2-dated";
+ *    v1-undated — bare `- content` lines (the shape every run before 2026-08-23
+ *                 used; it was implicit then, it is named now)
+ *    v2-dated   — `- [YYYY-MM-DD] content` (createdAt date prefixed per memory) */
+export const READER_PAYLOAD_FORMAT: PayloadFormat = "v2-dated";

--- a/test/bench/longmemeval/arms.ts
+++ b/test/bench/longmemeval/arms.ts
@@ -36,10 +36,22 @@ export const READER_SYSTEM =
   "reply that you do not know rather than guessing.";
 
 /** Format retrieved memories (flair / vector-only) as a compact context block.
- *  Items arrive rank-ordered (rank 0 = best). */
+ *  Items arrive rank-ordered (rank 0 = best).
+ *
+ *  v2-dated (READER_PAYLOAD_FORMAT): each memory line is prefixed with its
+ *  createdAt DATE (`- [YYYY-MM-DD] content`, date-only — matching the
+ *  full-context arm's `[Session X — date]` headers). The 2026-08 headline-run
+ *  journal analysis found temporal-reasoning at 37% with 33 cases where both
+ *  retrieval tells looked healthy — the reader had the right memories but no
+ *  dates to reason over, while the full-context arm always sees session dates.
+ *  A memory without a createdAt falls back to the undated v1 line. */
 export function formatRetrieved(items: RetrievedItem[]): string {
   if (items.length === 0) return "(no relevant memory found)";
-  return items.map((it, i) => `- ${(it.content ?? "").trim()}`).join("\n");
+  return items.map((it) => {
+    const content = (it.content ?? "").trim();
+    const date = typeof it.createdAt === "string" ? it.createdAt.slice(0, 10) : "";
+    return date ? `- [${date}] ${content}` : `- ${content}`;
+  }).join("\n");
 }
 
 /** Format the full haystack (full-context arm), in chronological session order
@@ -76,3 +88,11 @@ export function buildReaderPrompt(question: string, questionDate: string, contex
 }
 
 export const READER_PROMPT_VERSION = "1.0.0";
+
+/** Version stamp for the RETRIEVED-memory payload format (formatRetrieved's
+ *  output shape). Mirrors how the judge/reader prompts are versioned: it is
+ *  part of the hashed config manifest (config.ts prompts block), so a payload
+ *  format change can never hash identically to a run on the old format.
+ *    v1        — bare `- content` lines (implicit; runs before 2026-08-23)
+ *    v2-dated  — `- [YYYY-MM-DD] content` (createdAt date prefixed per memory) */
+export const READER_PAYLOAD_FORMAT = "v2-dated";

--- a/test/bench/longmemeval/artifact.ts
+++ b/test/bench/longmemeval/artifact.ts
@@ -74,14 +74,31 @@ export interface BuildArtifactInput {
 
 /** Provenance fields — stamped AFTER hashing and stripped BEFORE verification.
  *  Everything else is hashed content. This list is the single source of truth
- *  for the partition, so buildArtifact and verifyArtifactHash can never drift. */
-const PROVENANCE_KEYS = ["generatedAt", "host", "notice", "artifactHash"] as const;
+ *  for the partition, so buildArtifact and verifyArtifactHash can never drift —
+ *  and it is EXPORTED so a second artifact schema (the payload A/B) inherits
+ *  the identical partition instead of re-deciding it. */
+export const PROVENANCE_KEYS = ["generatedAt", "host", "notice", "artifactHash"] as const;
 
-/** The hashed-content partition of an artifact: everything except provenance. */
-function hashedContent(art: Artifact): Record<string, unknown> {
-  const content: Record<string, unknown> = { ...art };
+/** The hashed-content partition of any artifact: everything except provenance. */
+export function hashedContent(art: object): Record<string, unknown> {
+  const content: Record<string, unknown> = { ...(art as Record<string, unknown>) };
   for (const key of PROVENANCE_KEYS) delete content[key];
   return content;
+}
+
+/** Stamp `artifactHash` onto any artifact-shaped object, addressing only its
+ *  content partition. The field is absent while hashing, so it can never
+ *  address itself. */
+export function stampArtifactHash<T extends object>(art: T): T & { artifactHash: string } {
+  const stamped = art as T & { artifactHash?: string };
+  delete stamped.artifactHash;
+  stamped.artifactHash = sha256hex(canonicalJson(hashedContent(stamped)));
+  return stamped as T & { artifactHash: string };
+}
+
+/** Recompute and compare the hash of any artifact-shaped object. */
+export function verifyStampedHash(art: object & { artifactHash?: string }): boolean {
+  return sha256hex(canonicalJson(hashedContent(art))) === art.artifactHash;
 }
 
 export function buildArtifact(input: BuildArtifactInput): Artifact {
@@ -104,15 +121,14 @@ export function buildArtifact(input: BuildArtifactInput): Artifact {
   // excluded so two runs with identical content hash identically regardless of
   // wall clock or host. canonicalJson sorts keys, and artifactHash is absent at
   // this point, so it cannot address itself.
-  art.artifactHash = sha256hex(canonicalJson(hashedContent(art)));
-  return art;
+  return stampArtifactHash(art);
 }
 
 /** Recompute the hash of an artifact object (verification): strip the provenance
  *  partition (generatedAt, host, notice, artifactHash), canonicalise, sha256 —
  *  must equal the stored artifactHash. */
 export function verifyArtifactHash(art: Artifact): boolean {
-  return sha256hex(canonicalJson(hashedContent(art))) === art.artifactHash;
+  return verifyStampedHash(art);
 }
 
 export function writeArtifact(art: Artifact, outDir: string): string {

--- a/test/bench/longmemeval/config.ts
+++ b/test/bench/longmemeval/config.ts
@@ -135,7 +135,23 @@ export function configManifest(slice: { n: number; seed: number; questionIds: st
 }
 
 /** Canonical JSON: keys sorted recursively, so the hash is stable across
- *  machines and key-insertion order. */
+ *  machines and key-insertion order.
+ *
+ *  PORTABILITY CAVEAT (verified 2026-08-23 while re-deriving a payload-A/B
+ *  artifact hash in Python): the canonical form inherits `JSON.stringify`'s
+ *  NUMBER formatting, which is ECMAScript's Number::toString — exponential
+ *  notation only when the decimal exponent is < -6 or >= 21. Python's `repr`
+ *  switches to exponential at 1e-4, so a naive Python re-implementation
+ *  serialises 2.98e-6 as "2.980232238769545e-06" where this emits
+ *  "0.000002980232238769545", and the recomputed hash MISMATCHES on content
+ *  that is byte-identical in meaning.
+ *
+ *  This bites exactly where it is least welcome: tiny p-values, i.e. a STRONG
+ *  result. A reviewer verifying an artifact outside JS must replicate
+ *  Number::toString or compare via a JS runtime — a mismatch there is a
+ *  formatting artefact, NOT evidence of tampering. Left as-is deliberately:
+ *  changing the number format now would invalidate every artifact already
+ *  hashed. Document it, do not silently "fix" it. */
 export function canonicalJson(value: unknown): string {
   return JSON.stringify(sortDeep(value));
 }

--- a/test/bench/longmemeval/config.ts
+++ b/test/bench/longmemeval/config.ts
@@ -15,7 +15,7 @@
  */
 import { createHash } from "node:crypto";
 import { JUDGE_PROMPT_TEMPLATES } from "./judge";
-import { READER_SYSTEM, READER_PROMPT_VERSION, ALL_ARMS } from "./arms";
+import { READER_SYSTEM, READER_PROMPT_VERSION, READER_PAYLOAD_FORMAT, ALL_ARMS } from "./arms";
 import { EXTRACTION_METHOD } from "./extraction";
 
 // ── Dataset: LongMemEval_s, pinned to an immutable HF commit + file sha256 ────
@@ -117,6 +117,11 @@ export function configManifest(slice: { n: number; seed: number; questionIds: st
       judge: JUDGE_PROMPT_TEMPLATES,
       readerSystem: READER_SYSTEM,
       readerPromptVersion: READER_PROMPT_VERSION,
+      // The retrieved-memory payload format fed to the reader (arms.ts
+      // formatRetrieved). Hashed for the same reason the prompt strings are:
+      // a payload-format change is a MEASUREMENT VARIANT and must never hash
+      // identically to a run on the old format. v2-dated = dates on each line.
+      readerPayloadFormat: READER_PAYLOAD_FORMAT,
     },
     extraction: EXTRACTION_METHOD,
     slice: {

--- a/test/bench/longmemeval/dataset.ts
+++ b/test/bench/longmemeval/dataset.ts
@@ -172,4 +172,93 @@ export function selectSlice(entries: LmeEntry[], n: number, seed = 0): LmeEntry[
   return picked.sort((a, b) => a.question_id.localeCompare(b.question_id));
 }
 
+/**
+ * Deterministically select `n` questions of ONE ability — the shape a targeted
+ * A/B needs. `selectSlice` round-robins ACROSS abilities and so cannot express
+ * "60 temporal-reasoning questions"; that mismatch is exactly why the 30-question
+ * smoke slice carried only a handful of temporal questions and scored 100% on
+ * them (a ceiling — the check could not fire).
+ *
+ * Selection rule, stated so a reviewer can re-derive the exact slice:
+ *   1. keep entries with abilityOf(e) === ability. Abstention questions roll up
+ *      to "abstention" regardless of type, so asking for "temporal-reasoning"
+ *      excludes the *_abs variants BY CONSTRUCTION (127 of the 133 temporal
+ *      entries in LongMemEval_s).
+ *   2. order by sha256("<seed>:" + question_id) ascending; ties (impossible in
+ *      practice) broken by question_id.
+ *   3. take the first n.
+ *   4. emit sorted by question_id — stable output, so the config hash does not
+ *      depend on draw order.
+ *
+ * Step 2 is a KEYED PSEUDO-RANDOM draw, not a lexicographic prefix, on purpose.
+ * LongMemEval question_ids carry a meaningful prefix: `gpt4_*` marks the GPT-4-
+ * generated subpopulation, 85 of the 127 temporal-reasoning questions (67%). A
+ * lexicographic first-60 draws 18/60 of them (30%) — a sample skewed on question
+ * provenance, which is a confound, not a sample. The hashed order draws 42/60
+ * (70%), matching the population.
+ *
+ * Throws when fewer than `n` candidates exist: a silently-short slice would make
+ * the reported n a lie.
+ */
+export function selectAbilitySlice(entries: LmeEntry[], ability: Ability, n: number, seed = 0): LmeEntry[] {
+  const candidates = entries.filter((e) => abilityOf(e) === ability);
+  if (candidates.length < n) {
+    throw new Error(
+      `selectAbilitySlice: asked for ${n} "${ability}" questions but only ${candidates.length} exist in this dataset`,
+    );
+  }
+  const key = (e: LmeEntry) => createHash("sha256").update(`${seed}:${e.question_id}`).digest("hex");
+  const keyed = candidates.map((e) => ({ e, k: key(e) }));
+  keyed.sort((a, b) => a.k.localeCompare(b.k) || a.e.question_id.localeCompare(b.e.question_id));
+  return keyed.slice(0, n).map((x) => x.e).sort((a, b) => a.question_id.localeCompare(b.question_id));
+}
+
+/** Where a question's answer actually lives, in the SAME id space the ingest
+ *  writes (`<question_id>__s<sessionIdx>__t<turnIdx>`), so a retrieved-id list
+ *  can be checked against it directly. */
+export interface GoldEvidence {
+  /** The sessions LongMemEval labels as containing the answer. */
+  sessionIds: string[];
+  /** Every ingested event id in those sessions. */
+  sessionEventIds: string[];
+  /** The event ids of the specific turns flagged `has_answer` — the tightest
+   *  evidence label the dataset offers. */
+  answerEventIds: string[];
+}
+
+/**
+ * Map `answer_session_ids` + per-turn `has_answer` into ingested event ids.
+ *
+ * Verified against LongMemEval_s (2026-08-23, all 127 temporal-reasoning
+ * questions): every answer_session_id resolves inside haystack_session_ids,
+ * every question has at least one `has_answer` turn, and no `has_answer` turn
+ * falls outside a labelled answer session. So a zero here means the retrieval
+ * genuinely missed the evidence — it does not mean the label was unmappable.
+ * `unresolvedSessionIds` is returned rather than swallowed so a future dataset
+ * revision that breaks that property is loud instead of silently scoring 0.
+ */
+export function goldEvidenceFor(entry: LmeEntry): GoldEvidence & { unresolvedSessionIds: string[] } {
+  const gold = new Set(entry.answer_session_ids ?? []);
+  const sessionEventIds: string[] = [];
+  const answerEventIds: string[] = [];
+  const resolved = new Set<string>();
+  for (let si = 0; si < entry.haystack_sessions.length; si++) {
+    const sessionId = entry.haystack_session_ids?.[si] ?? `${entry.question_id}-s${si}`;
+    if (!gold.has(sessionId)) continue;
+    resolved.add(sessionId);
+    const turns = entry.haystack_sessions[si]!;
+    for (let ti = 0; ti < turns.length; ti++) {
+      const id = `${entry.question_id}__s${si}__t${ti}`;
+      sessionEventIds.push(id);
+      if (turns[ti]!.has_answer) answerEventIds.push(id);
+    }
+  }
+  return {
+    sessionIds: [...gold],
+    sessionEventIds,
+    answerEventIds,
+    unresolvedSessionIds: [...gold].filter((s) => !resolved.has(s)),
+  };
+}
+
 export { TYPE_TO_ABILITY };

--- a/test/bench/longmemeval/eval.ts
+++ b/test/bench/longmemeval/eval.ts
@@ -75,7 +75,7 @@ function extractionFor(entry: LmeEntry, answer: string) {
  *  retrieval metadata are supplied by the caller (Harper arms retrieve first). */
 async function evalOne(
   host: string, entry: LmeEntry, arm: Arm, context: string,
-  extra: { retrievalMs?: number; truncated?: boolean },
+  extra: { retrievalMs?: number; truncated?: boolean; rankedIds?: string[] },
 ): Promise<QuestionArmResult> {
   const r = await readerAnswer(host, entry.question, entry.question_date, context, arm);
   const abstention = isAbstention(entry);
@@ -92,6 +92,7 @@ async function evalOne(
     tokensFed: r.tokensFed,
     latencyMs: r.latencyMs + (extra.retrievalMs ?? 0),
     retrievalMs: extra.retrievalMs,
+    rankedIds: extra.rankedIds,
     truncated: extra.truncated,
   };
 }
@@ -136,7 +137,7 @@ async function runHarperArm(
       const ctx = await retrieveContext(client, entry.question, { limit: RETRIEVAL.readerTopK, scoring: RETRIEVAL.scoring });
       const retrievalMs = performance.now() - t0;
       const context = formatRetrieved(ctx.items);
-      out.push(await evalOne(host, entry, arm, context, { retrievalMs }));
+      out.push(await evalOne(host, entry, arm, context, { retrievalMs, rankedIds: ctx.rankedIds }));
       if ((qi + 1) % 5 === 0 || qi === entries.length - 1) {
         log(`  [${arm}] ${qi + 1}/${entries.length} (last ingest ${ingest.written} events, ${ingest.elapsedMs.toFixed(0)}ms)`);
       }

--- a/test/bench/longmemeval/metrics.ts
+++ b/test/bench/longmemeval/metrics.ts
@@ -32,7 +32,12 @@ export interface QuestionArmResult {
   extraction?: ExtractionScore; // present only for factual-subset questions
   tokensFed: number;
   latencyMs: number;
+  /** Retrieval wall-clock, separate from reader latency (Harper arms only). */
   retrievalMs?: number;
+  /** Retrieved memory ids in final rank order (Harper arms only) — closes the
+   *  journal blind spot where a wrong answer can't be attributed to retrieval
+   *  vs the reader without re-running the query. */
+  rankedIds?: string[];
   truncated?: boolean;
 }
 

--- a/test/bench/longmemeval/paired-stats.ts
+++ b/test/bench/longmemeval/paired-stats.ts
@@ -1,0 +1,104 @@
+/**
+ * paired-stats.ts — the read for a PAIRED binary A/B.
+ *
+ * A paired design (same question, same retrieved set, two reader payload
+ * formats) makes the two arms' errors correlated, and that correlation is the
+ * whole point: the questions where BOTH formats are right, or BOTH wrong, carry
+ * no information about which format is better. Only the DISCORDANT pairs do.
+ * That is why n=60 paired is worth roughly 3× n=60 unpaired here — the noise
+ * from question difficulty is differenced away instead of being sampled twice.
+ *
+ * So the statistic is McNemar's, computed EXACTLY (binomial), not by the
+ * chi-square approximation: with ~60 pairs the discordant count is small enough
+ * that the approximation is unreliable in precisely the regime we care about.
+ *
+ * Deliberately NOT provided: any "significant / not significant" verdict. The
+ * caller reports wins, losses, the discordant count and the p-value, and a human
+ * judges. A harness that stamps SIGNIFICANT on a 4-vs-1 split is a check that
+ * cannot fire.
+ */
+
+/** log(n!) via lgamma, so binomial terms stay exact enough at any n we use. */
+function lnFactorial(n: number): number {
+  // Lanczos-free: exact small-n table + Stirling series above it. n here is <= a
+  // few hundred, and we only ever difference logs, so this is plenty.
+  let acc = 0;
+  for (let i = 2; i <= n; i++) acc += Math.log(i);
+  return acc;
+}
+
+function lnChoose(n: number, k: number): number {
+  return lnFactorial(n) - lnFactorial(k) - lnFactorial(n - k);
+}
+
+/** P(X >= k) for X ~ Binomial(n, 0.5). */
+export function binomialUpperTail(n: number, k: number): number {
+  if (k <= 0) return 1;
+  if (k > n) return 0;
+  let p = 0;
+  for (let i = k; i <= n; i++) p += Math.exp(lnChoose(n, i) - n * Math.LN2);
+  return Math.min(1, p);
+}
+
+export interface McNemarResult {
+  /** v1 wrong, v2 right. */
+  wins: number;
+  /** v1 right, v2 wrong. */
+  losses: number;
+  /** wins + losses — the only pairs carrying information. */
+  discordant: number;
+  /** Exact two-sided McNemar p-value. 1 when there are no discordant pairs. */
+  p: number;
+  /** Which side the discordant pairs lean, or "tie". */
+  direction: "v2" | "v1" | "tie";
+  /** The smallest one-sided split at this discordant count that would reach
+   *  p<0.05 two-sided — i.e. what this run COULD have detected. Reported so a
+   *  null result is legible as "underpowered" vs "no effect". */
+  minSplitForP05: number | null;
+}
+
+/**
+ * Exact two-sided McNemar test on the discordant cells of a paired 2x2.
+ * Two-sided p = min(1, 2 * P(X >= max(wins, losses))), X ~ Binomial(d, 0.5).
+ */
+export function mcnemarExact(wins: number, losses: number): McNemarResult {
+  const discordant = wins + losses;
+  const k = Math.max(wins, losses);
+  const p = discordant === 0 ? 1 : Math.min(1, 2 * binomialUpperTail(discordant, k));
+  let minSplit: number | null = null;
+  for (let cand = Math.ceil(discordant / 2); cand <= discordant; cand++) {
+    if (Math.min(1, 2 * binomialUpperTail(discordant, cand)) < 0.05) { minSplit = cand; break; }
+  }
+  return {
+    wins, losses, discordant, p,
+    direction: wins > losses ? "v2" : losses > wins ? "v1" : "tie",
+    minSplitForP05: minSplit,
+  };
+}
+
+/** The full paired 2x2 over a set of (v1correct, v2correct) outcomes. */
+export interface PairedTable {
+  bothRight: number;
+  bothWrong: number;
+  wins: number;     // v1 wrong, v2 right
+  losses: number;   // v1 right, v2 wrong
+  n: number;
+  v1Accuracy: number;
+  v2Accuracy: number;
+  /** v2 − v1, in accuracy points. Equals (wins − losses) / n exactly. */
+  delta: number;
+}
+
+export function pairedTable(pairs: Array<{ v1: boolean; v2: boolean }>): PairedTable {
+  let bothRight = 0, bothWrong = 0, wins = 0, losses = 0;
+  for (const { v1, v2 } of pairs) {
+    if (v1 && v2) bothRight++;
+    else if (!v1 && !v2) bothWrong++;
+    else if (!v1 && v2) wins++;
+    else losses++;
+  }
+  const n = pairs.length;
+  const v1Accuracy = n === 0 ? 0 : (bothRight + losses) / n;
+  const v2Accuracy = n === 0 ? 0 : (bothRight + wins) / n;
+  return { bothRight, bothWrong, wins, losses, n, v1Accuracy, v2Accuracy, delta: v2Accuracy - v1Accuracy };
+}

--- a/test/bench/longmemeval/payload-ab.ts
+++ b/test/bench/longmemeval/payload-ab.ts
@@ -1,0 +1,526 @@
+#!/usr/bin/env bun
+/**
+ * payload-ab.ts — the PAIRED, same-retrieval A/B on the reader payload format.
+ *
+ *   bun run test/bench/longmemeval/payload-ab.ts --dataset <path> \
+ *     [--n 60] [--seed 0] [--ability temporal-reasoning] [--out <dir>] [--resume <jsonl>]
+ *
+ * ── Why paired ───────────────────────────────────────────────────────────────
+ * The two payload formats differ ONLY in the reader prompt. Not in ingest, not
+ * in retrieval, not in the reader, not in the judge. So running them as two
+ * independent arms would spend two ingests and two retrievals to re-measure the
+ * one thing they share, and would then compare two noisy accuracy numbers whose
+ * noise is dominated by WHICH QUESTIONS landed in each sample.
+ *
+ * Instead: per question, ingest ONCE, retrieve ONCE, then format that SAME
+ * retrieved set both ways and run the reader twice, judging both. Question
+ * difficulty and retrieval luck are held EXACTLY constant within a pair and
+ * difference out. What is left is the payload format.
+ *
+ * Cost: one ingest (~80s, the dominant term) + 2 reader + 2 judge calls per
+ * question, versus two full arms. Power: the informative unit is the DISCORDANT
+ * pair, so ~n=60 paired buys roughly what ~n=180 unpaired would here — see
+ * paired-stats.ts for the statistic and its honest limits.
+ *
+ * ── Why this slice ───────────────────────────────────────────────────────────
+ * The prior 30-question smoke slice could not measure this change at all: that
+ * slice round-robins across abilities, carried a handful of temporal questions,
+ * and scored 100% on them at baseline. A check at its ceiling cannot fire. This
+ * runner selects 60 questions of ONE ability (default temporal-reasoning — the
+ * ability the dated payload is hypothesised to help) by an explicit,
+ * re-derivable rule: see dataset.ts selectAbilitySlice.
+ *
+ * ── What is held fixed ───────────────────────────────────────────────────────
+ * Retrieval is the `flair` arm's configuration (hybrid BM25+RRF on, scoring raw,
+ * readerTopK) over ONE shared ephemeral Harper store, agent-scoped per question.
+ * The store grows as questions accumulate, exactly as it does in the four-arm
+ * headline run; that growth affects BOTH sides of every pair identically because
+ * both sides consume the same retrieved set, so it cannot bias the comparison.
+ * There are no mode flips here (one retrieval configuration), so unlike the
+ * headline run there are no per-question Harper restarts.
+ *
+ * Produces a content-addressed artifact. NEVER publishes one.
+ */
+import { existsSync, appendFileSync, readFileSync, writeFileSync, mkdirSync, rmSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+import { execSync } from "node:child_process";
+import { randomUUID } from "node:crypto";
+import { startHarper, stopHarper, type HarperInstance } from "../../helpers/harper-lifecycle";
+import {
+  mkAgent, registerAgent, ingestSessionHistory, retrieveContext, adminOp, signedFetch,
+  type BenchClient, type TestAgent,
+} from "../../../packages/flair-bench/lib/index";
+import {
+  OLLAMA_HOST, JUDGE, READER, DATASET, RETRIEVAL, INGESTION,
+  assertCrossFamily, hashConfig,
+} from "./config";
+import { assertModelPinned, pingOllama, generate, OllamaError } from "./ollama";
+import { buildJudgePrompt, parseVerdict, JudgeParseError, JUDGE_PROMPT_TEMPLATES } from "./judge";
+import {
+  loadDataset, selectAbilitySlice, goldEvidenceFor, entryToSessions, toSessionHistories,
+  abilityOf, type LmeEntry, type Ability,
+} from "./dataset";
+import {
+  READER_SYSTEM, READER_PROMPT_VERSION, PAYLOAD_FORMATS, buildReaderPrompt, formatRetrievedAs,
+  type PayloadFormat,
+} from "./arms";
+import { EXTRACTION_METHOD } from "./extraction";
+import { stampArtifactHash, verifyStampedHash } from "./artifact";
+import { mcnemarExact, pairedTable, type PairedTable } from "./paired-stats";
+
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../../..");
+const clean = (s: string) => s.replace(/<think>[\s\S]*?<\/think>/gi, "").trim();
+const pct = (x: number) => (x * 100).toFixed(1) + "%";
+
+function arg(flag: string, dflt?: string): string | undefined {
+  const i = process.argv.indexOf(flag);
+  return i >= 0 && process.argv[i + 1] ? process.argv[i + 1] : dflt;
+}
+const hasFlag = (f: string) => process.argv.includes(f);
+
+function gitCommit(): string | null {
+  // stdio pipe: the bench VM runs from an exported tree with no .git, and a
+  // "fatal: not a git repository" on stderr mid-report reads like a run failure.
+  try { return execSync("git rev-parse HEAD", { cwd: REPO_ROOT, stdio: ["ignore", "pipe", "ignore"] }).toString().trim(); } catch { return null; }
+}
+
+/** The A and B sides. A is the CONTROL (what every run before 2026-08-23 fed
+ *  the reader); B is the variant under test. Order is fixed and recorded — the
+ *  reader is stateless at temperature 0, so there is no carry-over between the
+ *  two calls, but "we did not randomise the order" is a fact the artifact should
+ *  state rather than leave to be assumed. */
+const SIDE_A: PayloadFormat = "v1-undated";
+const SIDE_B: PayloadFormat = "v2-dated";
+
+/** An A/B whose two sides are the same format measures nothing and would report
+ *  a perfectly clean "no difference". Fail loud instead — same shape as
+ *  config.ts's assertCrossFamily. Compared as strings so the const-literal types
+ *  cannot narrow the check away. */
+export function assertSidesDiffer(): void {
+  for (const side of [SIDE_A, SIDE_B]) {
+    if (!PAYLOAD_FORMATS.includes(side)) throw new Error(`payload-ab: "${side}" is not a declared PayloadFormat (${PAYLOAD_FORMATS.join(", ")})`);
+  }
+  if ((SIDE_A as string) === (SIDE_B as string)) {
+    throw new Error(`payload-ab: both sides are "${SIDE_A}" — an A/B against itself always reports no difference. Refusing to run.`);
+  }
+}
+
+interface PairRecord {
+  questionId: string;
+  ability: string;
+  /** Retrieved memory ids in final rank order — the SAME set both sides saw. */
+  rankedIds: string[];
+  retrievalMs: number;
+  /** Did retrieval surface any memory from a labelled answer session? */
+  goldSessionHit: boolean;
+  /** Did retrieval surface a turn the dataset flags `has_answer`? */
+  goldAnswerHit: boolean;
+  goldAnswerHitCount: number;
+  sides: Record<PayloadFormat, {
+    answer: string;
+    verdict: string | null;
+    judgeError: string | null;
+    tokensFed: number;
+    latencyMs: number;
+  }>;
+  cfg: string;
+  at: string;
+}
+
+async function readAndJudge(
+  host: string, entry: LmeEntry, context: string,
+): Promise<PairRecord["sides"][PayloadFormat]> {
+  const prompt = buildReaderPrompt(entry.question, entry.question_date, context);
+  const g = await generate(host, READER, prompt);
+  const answer = clean(g.response);
+  const abstention = entry.question_id.includes("_abs");
+  const { prompt: jp, allowed } = buildJudgePrompt({
+    task: entry.question_type, question: entry.question, answer: entry.answer,
+    response: answer, abstention,
+  });
+  const jg = await generate(host, JUDGE, jp);
+  let verdict: string | null = null;
+  let judgeError: string | null = null;
+  try { verdict = parseVerdict(jg.response, allowed); }
+  catch (err) {
+    if (err instanceof JudgeParseError) judgeError = err.message;
+    else throw err;
+  }
+  return { answer, verdict, judgeError, tokensFed: g.promptTokens, latencyMs: g.latencyMs };
+}
+
+async function main(): Promise<void> {
+  assertCrossFamily();
+  assertSidesDiffer();
+  const host = arg("--host", OLLAMA_HOST)!;
+  const datasetPath = arg("--dataset");
+  if (!datasetPath) { console.error("payload-ab requires --dataset <path to longmemeval_s.json>"); process.exit(2); }
+  const n = parseInt(arg("--n", "60")!, 10);
+  const seed = parseInt(arg("--seed", "0")!, 10);
+  const ability = arg("--ability", "temporal-reasoning") as Ability;
+  const outDir = arg("--out", path.join(REPO_ROOT, "longmemeval-artifacts"))!;
+  const allowUnpinned = hasFlag("--allow-unpinned");
+  const recordsPath = arg("--records", path.join(outDir, `payload-ab-records-${ability}-n${n}-seed${seed}.jsonl`))!;
+  const progressPath = arg("--progress");
+  const resumePath = arg("--resume");
+
+  // Harper serves resources from dist/ — a missing build is a silent no-op run.
+  const marker = path.join(process.env.LME_FLAIR_PKG_DIR ?? REPO_ROOT, "dist", "resources", "SemanticSearch.js");
+  if (!existsSync(marker)) { console.error(`FATAL: ${marker} not found — run \`bun run build\` first.`); process.exit(2); }
+
+  console.log(`\n=== LongMemEval_s — PAIRED reader-payload A/B (${SIDE_A} vs ${SIDE_B}) ===`);
+  await pingOllama(host);
+  await assertModelPinned(host, READER);
+  await assertModelPinned(host, JUDGE);
+  console.log(`reader=${READER.model} (${READER.family})  judge=${JUDGE.model} (${JUDGE.family})  [digests verified]`);
+
+  const entries = loadDataset(datasetPath!, { allowUnpinned });
+  const slice = selectAbilitySlice(entries, ability, n, seed);
+  const candidates = entries.filter((e) => abilityOf(e) === ability).length;
+  console.log(`dataset ${DATASET.name}: ${entries.length} questions; ability "${ability}" has ${candidates}; slice ${slice.length} (seed ${seed})`);
+
+  // Gold-evidence labels must be MAPPABLE or the attribution read is decorative.
+  const unmappable = slice.filter((e) => goldEvidenceFor(e).unresolvedSessionIds.length > 0);
+  if (unmappable.length > 0) {
+    throw new Error(
+      `gold-evidence labels unmappable for ${unmappable.length} question(s) (e.g. ${unmappable[0]!.question_id}): ` +
+      `answer_session_ids not found in haystack_session_ids. The attribution read would silently score 0 — refusing to run.`,
+    );
+  }
+
+  // ── The hashed, self-describing config. The paired DESIGN lives in here so
+  //    the artifact explains its own experiment without a companion document.
+  const manifest = {
+    schema: "longmemeval-s.payload-ab.config/1",
+    design: {
+      kind: "paired-same-retrieval-ab",
+      unitOfAnalysis: "question",
+      statedAs:
+        "For each question: ingest its haystack ONCE, retrieve ONCE, then format that SAME retrieved " +
+        "set both ways and run the pinned reader twice (once per payload format), judging both with the " +
+        "pinned judge. Ingest, retrieval, reader model, judge model, prompts and question set are IDENTICAL " +
+        "across the two sides by construction — the ONLY difference is the payload format of the retrieved " +
+        "memories inside the reader prompt.",
+      sideA: SIDE_A,
+      sideB: SIDE_B,
+      sideOrder: "A then B, fixed (reader is stateless at temperature 0; order was NOT randomised)",
+      statistic:
+        "Exact two-sided McNemar on the discordant pairs (v1-wrong/v2-right vs v1-right/v2-wrong). " +
+        "Concordant pairs carry no information about the format and are reported but not tested.",
+      powerNote:
+        "Pairing differences out question difficulty and retrieval luck, which dominate the variance here; " +
+        "n=60 paired is worth roughly n=180 unpaired for this contrast. It still cannot detect an effect " +
+        "smaller than the discordant count can express — the artifact reports that count so the reader can " +
+        "judge the null honestly.",
+      attribution:
+        "Per question the retrieved id set is checked against the dataset's own evidence labels " +
+        "(answer_session_ids, and the per-turn has_answer flags within them). A null result on the " +
+        "gold-evidence-hit subset means dates did not help; a null driven by misses means the evidence " +
+        "was not there to date in the first place.",
+    },
+    dataset: DATASET,
+    judge: JUDGE,
+    reader: READER,
+    retrieval: { ...RETRIEVAL, hybrid: true, arm: "flair", storeSharing: "one-shared-store-no-mode-flips" },
+    ingestion: INGESTION,
+    prompts: {
+      judge: JUDGE_PROMPT_TEMPLATES,
+      readerSystem: READER_SYSTEM,
+      readerPromptVersion: READER_PROMPT_VERSION,
+      payloadFormats: { A: SIDE_A, B: SIDE_B },
+    },
+    extraction: EXTRACTION_METHOD,
+    slice: {
+      ability, n, seed,
+      abilityCandidates: candidates,
+      selectionRule:
+        "entries with abilityOf(e)===ability (abstention rolls up to 'abstention', so *_abs is excluded " +
+        "by construction), ordered by sha256(`${seed}:${question_id}`) ascending, first n taken, emitted " +
+        "sorted by question_id. A keyed pseudo-random draw, NOT a lexicographic prefix: question_id " +
+        "prefixes encode question provenance (gpt4_* is 67% of the temporal-reasoning population but only " +
+        "30% of a lexicographic first-60), so a prefix draw would confound provenance with the treatment.",
+      questionIds: slice.map((e) => e.question_id).sort(),
+    },
+  };
+  const configHash = hashConfig(manifest);
+  const cfgShort = configHash.slice(0, 16);
+  console.log(`configHash: ${configHash}`);
+  console.log(`records: ${recordsPath}`);
+
+  // ── Resume: skip questions already fully recorded (both sides judged). ─────
+  // Documented limit: a resumed run re-ingests into a FRESH store, so resumed
+  // questions face a smaller corpus than they did originally. That shifts
+  // retrieval difficulty across questions — it does NOT break the pairing,
+  // because both sides of every pair still consume one identical retrieved set.
+  const banked = new Map<string, PairRecord>();
+  if (resumePath) {
+    for (const line of readFileSync(resumePath, "utf8").split("\n").filter((l) => l.trim())) {
+      const r = JSON.parse(line) as PairRecord;
+      if (r.cfg !== cfgShort) throw new Error(`resume: record for ${r.questionId} carries cfg ${r.cfg}, expected ${cfgShort} — refusing to mix configs`);
+      if (r.sides?.[SIDE_A] && r.sides?.[SIDE_B]) banked.set(r.questionId, r);
+    }
+    console.log(`resume: ${banked.size} question(s) already paired in ${resumePath} — skipping their ingest`);
+  }
+  const todo = slice.filter((e) => !banked.has(e.question_id));
+
+  const startOpts = () => ({
+    cwd: process.env.LME_FLAIR_PKG_DIR ?? REPO_ROOT,
+    harperBinDir: process.env.LME_HARPER_BIN_DIR ?? REPO_ROOT,
+  });
+  const prevHybrid = process.env.FLAIR_HYBRID_RETRIEVAL;
+  process.env.FLAIR_HYBRID_RETRIEVAL = "true"; // the `flair` arm's retrieval
+  const records: PairRecord[] = [...banked.values()];
+  let harper: HarperInstance = await startHarper(startOpts());
+  const installDir = harper.installDir;
+  console.log(`store: ${installDir}  (hybrid=true, one shared store, no mode flips)\n`);
+
+  // ── Readiness gate (ported from eval.ts's take-5 post-mortem shape) ────────
+  // HARD GATE: ops-API SQL — the last-ingested canary row EXISTS and carries an
+  // embeddingModel stamp (persisted + embedded). Scale-independent, unlike any
+  // gate built on search RANKING, which starves as the store grows.
+  // SOFT PROBE: a nonce self-query under a separate probe agent; logged, never
+  // fatal. Deadline scales from MEASURED waits; one same-store restart on a
+  // blown deadline before failing the run.
+  let maxSearchWaitMs = 5_000;
+  const searchDeadlineMs = () => Math.min(1_200_000, Math.max(90_000, 6 * maxSearchWaitMs));
+  async function canaryStamped(entry: LmeEntry): Promise<{ ready: boolean; detail: string }> {
+    const events = entryToSessions(entry).flatMap((s) => s.events);
+    const canary = events[events.length - 1];
+    if (!canary) return { ready: true, detail: "no events" };
+    const res = await adminOp(harper, { operation: "sql", sql: `SELECT id, embeddingModel FROM flair.Memory WHERE id = '${canary.id}'` });
+    if (!res.ok) return { ready: false, detail: `sql HTTP ${res.status}` };
+    const j: any = await res.json().catch(() => null);
+    const row = Array.isArray(j) ? j[0] : null;
+    if (!row) return { ready: false, detail: `row ${canary.id} absent` };
+    if (!row.embeddingModel) return { ready: false, detail: `row ${canary.id} embedding unstamped` };
+    return { ready: true, detail: "persisted+stamped" };
+  }
+  async function pollStamped(entry: LmeEntry, deadlineMs: number): Promise<number> {
+    const t0 = Date.now();
+    let last = "";
+    while (Date.now() - t0 < deadlineMs) {
+      const r = await canaryStamped(entry);
+      if (r.ready) return Date.now() - t0;
+      last = r.detail;
+      await new Promise((res) => setTimeout(res, 1000));
+    }
+    throw new Error(`readiness gate: canary for ${entry.question_id} not persisted+stamped within ${deadlineMs}ms (last: ${last})`);
+  }
+  let probeAgent: TestAgent | null = null;
+  async function softSearchProbe(tag: string): Promise<void> {
+    try {
+      if (!probeAgent) { probeAgent = mkAgent("payload-ab-readiness-probe"); await registerAgent(harper, probeAgent); }
+      const nonce = `readiness-canary readiness-nonce-${randomUUID()}`;
+      const pid = `probe__${Date.now()}__${Math.floor(Math.random() * 1e6)}`;
+      const w = await signedFetch(harper, probeAgent, "PUT", `/Memory/${pid}`,
+        { id: pid, agentId: probeAgent.id, content: nonce, durability: "standard", createdAt: new Date().toISOString() });
+      if (!w.ok) { console.log(`  [probe-warn] ${tag}: nonce write HTTP ${w.status}`); return; }
+      const t0 = Date.now();
+      while (Date.now() - t0 < 20_000) {
+        const ctx = await retrieveContext({ harper, agent: probeAgent }, nonce, { limit: 20 });
+        if (ctx.rankedIds.includes(pid)) return;
+        await new Promise((res) => setTimeout(res, 1000));
+      }
+      console.log(`  [probe-warn] ${tag}: nonce not surfacing via search within 20s (hard gate passed; telemetry only)`);
+    } catch (err) {
+      console.log(`  [probe-warn] ${tag}: ${err instanceof Error ? err.message.slice(0, 120) : String(err)}`);
+    }
+  }
+  async function ensureSearchable(entry: LmeEntry): Promise<void> {
+    const deadline = searchDeadlineMs();
+    try {
+      maxSearchWaitMs = Math.max(maxSearchWaitMs, await pollStamped(entry, deadline));
+    } catch (err) {
+      console.log(`  !! readiness timeout (${deadline}ms) for ${entry.question_id} — one same-store restart+retry`);
+      await stopHarper(harper, { keepInstallDir: true });
+      harper = await startHarper({ ...startOpts(), installDir });
+      maxSearchWaitMs = Math.max(maxSearchWaitMs, await pollStamped(entry, deadline));
+      console.log(`  recovered after restart: ${entry.question_id} ready`);
+    }
+    await softSearchProbe(entry.question_id);
+  }
+
+  const t0All = Date.now();
+  try {
+    for (let qi = 0; qi < todo.length; qi++) {
+      const entry = todo[qi]!;
+      const agent = mkAgent(`payload-ab-${entry.question_id}`);
+      await registerAgent(harper, agent);
+      const client: BenchClient = { harper, agent };
+      const sessions = entryToSessions(entry);
+      const ing = await ingestSessionHistory(client, toSessionHistories(sessions), {
+        concurrency: Math.max(1, parseInt(process.env.LME_INGEST_CONCURRENCY ?? "6", 10) || 6),
+      });
+      await ensureSearchable(entry);
+
+      // ONE retrieval. Both sides consume exactly this.
+      const tR = performance.now();
+      const ctx = await retrieveContext(client, entry.question, { limit: RETRIEVAL.readerTopK, scoring: RETRIEVAL.scoring });
+      const retrievalMs = performance.now() - tR;
+
+      const gold = goldEvidenceFor(entry);
+      const got = new Set(ctx.rankedIds);
+      const goldSessionHit = gold.sessionEventIds.some((id) => got.has(id));
+      const answerHits = gold.answerEventIds.filter((id) => got.has(id));
+
+      const sides = {} as PairRecord["sides"];
+      for (const fmt of [SIDE_A, SIDE_B]) {
+        sides[fmt] = await readAndJudge(host, entry, formatRetrievedAs(ctx.items, fmt));
+      }
+
+      const rec: PairRecord = {
+        questionId: entry.question_id, ability: abilityOf(entry),
+        rankedIds: ctx.rankedIds, retrievalMs,
+        goldSessionHit, goldAnswerHit: answerHits.length > 0, goldAnswerHitCount: answerHits.length,
+        sides, cfg: cfgShort, at: new Date().toISOString(),
+      };
+      records.push(rec);
+      try { appendFileSync(recordsPath, JSON.stringify(rec) + "\n"); } catch { /* journal is best-effort */ }
+
+      const a = sides[SIDE_A].verdict, b = sides[SIDE_B].verdict;
+      // The pair's cell is decided by CORRECTNESS, not by verdict equality:
+      // NOT_ATTEMPTED vs INCORRECT are different verdicts but the same cell
+      // (both wrong), and a marker that called that a loss would misreport the
+      // discordant count a reader is scanning the log for.
+      const aOk = a === "CORRECT", bOk = b === "CORRECT";
+      const mark = aOk === bOk ? "=" : (bOk ? "+" : "-");
+      const elapsedMin = (Date.now() - t0All) / 60000;
+      const etaMin = qi + 1 < todo.length ? (elapsedMin / (qi + 1)) * (todo.length - qi - 1) : 0;
+      console.log(
+        `  [${String(qi + 1).padStart(2)}/${todo.length}] ${entry.question_id.padEnd(16)} ` +
+        `${mark} A=${String(a).padEnd(13)} B=${String(b).padEnd(13)} ` +
+        `gold(sess/ans)=${goldSessionHit ? "Y" : "n"}/${answerHits.length} ` +
+        `ingest=${(ing.elapsedMs / 1000).toFixed(0)}s retr=${retrievalMs.toFixed(0)}ms ` +
+        `| elapsed ${elapsedMin.toFixed(0)}m eta ${etaMin.toFixed(0)}m`,
+      );
+      if (progressPath) {
+        try {
+          writeFileSync(progressPath, JSON.stringify({
+            unit: "question-pair", total: slice.length, done: records.length,
+            startedAt: new Date(t0All).toISOString(), updatedAt: new Date().toISOString(),
+            etaMinutes: Math.round(etaMin), configHash, done_: false,
+          }, null, 2));
+        } catch { /* best effort */ }
+      }
+    }
+  } finally {
+    await stopHarper(harper, { keepInstallDir: false });
+    try { rmSync(installDir, { recursive: true, force: true, maxRetries: 2 }); } catch { /* best effort */ }
+    if (prevHybrid === undefined) delete process.env.FLAIR_HYBRID_RETRIEVAL;
+    else process.env.FLAIR_HYBRID_RETRIEVAL = prevHybrid;
+  }
+
+  report(records, manifest, configHash, outDir, host, slice.length);
+}
+
+/** A judge error on EITHER side voids the pair: it is excluded from the table
+ *  and counted, never silently folded in as a wrong answer. */
+function usablePairs(records: PairRecord[]) {
+  const usable = records.filter((r) => !r.sides[SIDE_A].judgeError && !r.sides[SIDE_B].judgeError && r.sides[SIDE_A].verdict && r.sides[SIDE_B].verdict);
+  return { usable, voided: records.length - usable.length };
+}
+
+function tableFor(records: PairRecord[]): PairedTable {
+  return pairedTable(records.map((r) => ({
+    v1: r.sides[SIDE_A].verdict === "CORRECT",
+    v2: r.sides[SIDE_B].verdict === "CORRECT",
+  })));
+}
+
+function report(
+  records: PairRecord[], manifest: unknown, configHash: string, outDir: string,
+  host: string, sliceSize: number,
+): void {
+  const { usable, voided } = usablePairs(records);
+  const table = tableFor(usable);
+  const mc = mcnemarExact(table.wins, table.losses);
+
+  // Attribution split: did retrieval even put the evidence in front of the reader?
+  const withEvidence = usable.filter((r) => r.goldAnswerHit);
+  const withoutEvidence = usable.filter((r) => !r.goldAnswerHit);
+  const tEv = tableFor(withEvidence), mcEv = mcnemarExact(tEv.wins, tEv.losses);
+  const tNo = tableFor(withoutEvidence), mcNo = mcnemarExact(tNo.wins, tNo.losses);
+  const sessionHitRate = usable.length ? usable.filter((r) => r.goldSessionHit).length / usable.length : 0;
+  const answerHitRate = usable.length ? withEvidence.length / usable.length : 0;
+
+  const results = {
+    pairsAttempted: records.length,
+    pairsVoidedByJudgeError: voided,
+    overall: { table, mcnemar: mc },
+    attribution: {
+      goldSessionHitRate: sessionHitRate,
+      goldAnswerHitRate: answerHitRate,
+      withGoldEvidence: { n: withEvidence.length, table: tEv, mcnemar: mcEv },
+      withoutGoldEvidence: { n: withoutEvidence.length, table: tNo, mcnemar: mcNo },
+    },
+    perQuestion: records.map((r) => ({
+      questionId: r.questionId,
+      a: r.sides[SIDE_A].verdict, b: r.sides[SIDE_B].verdict,
+      goldSessionHit: r.goldSessionHit, goldAnswerHitCount: r.goldAnswerHitCount,
+      retrievedCount: r.rankedIds.length,
+    })).sort((x, y) => x.questionId.localeCompare(y.questionId)),
+  };
+
+  // Same partition discipline as the four-arm artifact (artifact.ts): hashed
+  // CONTENT above, unhashed PROVENANCE (generatedAt, host, notice, artifactHash)
+  // below, stamped after. resultsHash content-addresses the results alone so a
+  // reviewer can cite the numbers independently of the config they came from.
+  const artifact = stampArtifactHash({
+    schema: "longmemeval-s.payload-ab.artifact/1",
+    validationSlice: true,
+    gitCommit: gitCommit(),
+    configHash,
+    config: manifest,
+    resultsHash: hashConfig(results),
+    results,
+    // ── provenance (excluded from the hash) ──
+    notice:
+      "VALIDATION ARTIFACT — NOT FOR PUBLICATION. This harness produces numbers; it does not publish " +
+      "them. Publishing any number requires a recorded human sign-off referencing this artifact's " +
+      "artifactHash. Spend and outward-publishing are the founder's gates.",
+    generatedAt: new Date().toISOString(),
+    host: { ollama: host, benchHost: process.env.LME_BENCH_HOST ?? "unknown" },
+  });
+
+  const outPath = path.join(outDir, `payload-ab-artifact-${artifact.artifactHash.slice(0, 16)}.json`);
+  mkdirSync(outDir, { recursive: true });
+  writeFileSync(outPath, JSON.stringify(artifact, null, 2));
+
+  const bar = "═".repeat(72);
+  console.log(`\n${bar}\n  PAIRED READER-PAYLOAD A/B — ${SIDE_A} (A) vs ${SIDE_B} (B)\n${bar}`);
+  console.log(`  slice: ${sliceSize} questions | pairs attempted ${records.length} | usable ${usable.length}` +
+              (voided ? ` | VOIDED by judge error ${voided}` : ""));
+  console.log(`\n  paired 2x2 (rows = A/v1-undated, cols = B/v2-dated)`);
+  console.log(`    ${"".padEnd(18)}${"B right".padEnd(12)}${"B wrong".padEnd(12)}`);
+  console.log(`    ${"A right".padEnd(18)}${String(table.bothRight).padEnd(12)}${String(table.losses).padEnd(12)}`);
+  console.log(`    ${"A wrong".padEnd(18)}${String(table.wins).padEnd(12)}${String(table.bothWrong).padEnd(12)}`);
+  console.log(`\n  wins  (A wrong -> B right): ${table.wins}`);
+  console.log(`  losses(A right -> B wrong): ${table.losses}`);
+  console.log(`  concordant (both same)    : ${table.bothRight + table.bothWrong}  (${table.bothRight} both right, ${table.bothWrong} both wrong)`);
+  console.log(`  DISCORDANT pairs          : ${mc.discordant}   <- the only pairs carrying information`);
+  console.log(`\n  overall accuracy  A (${SIDE_A}) = ${pct(table.v1Accuracy)}   B (${SIDE_B}) = ${pct(table.v2Accuracy)}   delta = ${(table.delta * 100).toFixed(1)} pts`);
+  console.log(`  McNemar exact two-sided p = ${mc.p.toFixed(4)}  (lean: ${mc.direction})`);
+  console.log(
+    mc.minSplitForP05 === null
+      ? `  UNDERPOWERED BY CONSTRUCTION: at ${mc.discordant} discordant pair(s), NO split reaches p<0.05 — this run could not have detected any effect`
+      : `  at ${mc.discordant} discordant pairs, p<0.05 needs a ${mc.minSplitForP05}-${mc.discordant - mc.minSplitForP05} split or wider`,
+  );
+  console.log(`\n  ── attribution: was the evidence even retrieved? ──`);
+  console.log(`  gold SESSION hit rate (any memory from a labelled answer session): ${pct(sessionHitRate)}`);
+  console.log(`  gold ANSWER  hit rate (a has_answer turn retrieved)             : ${pct(answerHitRate)}`);
+  console.log(`    with gold evidence    (n=${tEv.n}): A ${pct(tEv.v1Accuracy)} B ${pct(tEv.v2Accuracy)} | wins ${tEv.wins} losses ${tEv.losses} discordant ${mcEv.discordant} p=${mcEv.p.toFixed(4)}`);
+  console.log(`    without gold evidence (n=${tNo.n}): A ${pct(tNo.v1Accuracy)} B ${pct(tNo.v2Accuracy)} | wins ${tNo.wins} losses ${tNo.losses} discordant ${mcNo.discordant} p=${mcNo.p.toFixed(4)}`);
+  console.log(`\n  configHash  : ${configHash}`);
+  console.log(`  resultsHash : ${artifact.resultsHash}`);
+  console.log(`  artifactHash: ${artifact.artifactHash}`);
+  console.log(`  self-verifies: ${verifyStampedHash(artifact)}`);
+  console.log(`  written     : ${outPath}`);
+  console.log(`\nNOTICE: ${artifact.notice}\n`);
+}
+
+main().catch((err) => {
+  if (err instanceof OllamaError) console.error(`\nOLLAMA/JUDGE SEAM: ${err.message}\n`);
+  else console.error(err);
+  process.exit(1);
+});

--- a/test/bench/longmemeval/results/payload-ab-artifact-dede855fae8efe60.json
+++ b/test/bench/longmemeval/results/payload-ab-artifact-dede855fae8efe60.json
@@ -1,0 +1,714 @@
+{
+  "schema": "longmemeval-s.payload-ab.artifact/1",
+  "validationSlice": true,
+  "gitCommit": null,
+  "configHash": "d2d614b8c458f3e9f09d22f6bcda6fe04d56e7199e2e5a9476245c83b50816ee",
+  "config": {
+    "schema": "longmemeval-s.payload-ab.config/1",
+    "design": {
+      "kind": "paired-same-retrieval-ab",
+      "unitOfAnalysis": "question",
+      "statedAs": "For each question: ingest its haystack ONCE, retrieve ONCE, then format that SAME retrieved set both ways and run the pinned reader twice (once per payload format), judging both with the pinned judge. Ingest, retrieval, reader model, judge model, prompts and question set are IDENTICAL across the two sides by construction — the ONLY difference is the payload format of the retrieved memories inside the reader prompt.",
+      "sideA": "v1-undated",
+      "sideB": "v2-dated",
+      "sideOrder": "A then B, fixed (reader is stateless at temperature 0; order was NOT randomised)",
+      "statistic": "Exact two-sided McNemar on the discordant pairs (v1-wrong/v2-right vs v1-right/v2-wrong). Concordant pairs carry no information about the format and are reported but not tested.",
+      "powerNote": "Pairing differences out question difficulty and retrieval luck, which dominate the variance here; n=60 paired is worth roughly n=180 unpaired for this contrast. It still cannot detect an effect smaller than the discordant count can express — the artifact reports that count so the reader can judge the null honestly.",
+      "attribution": "Per question the retrieved id set is checked against the dataset's own evidence labels (answer_session_ids, and the per-turn has_answer flags within them). A null result on the gold-evidence-hit subset means dates did not help; a null driven by misses means the evidence was not there to date in the first place."
+    },
+    "dataset": {
+      "name": "LongMemEval_s",
+      "hfRepo": "xiaowu0162/longmemeval",
+      "hfRevision": "2ec2a557f339b6c0369619b1ed5793734cc87533",
+      "file": "longmemeval_s",
+      "sha256": "08d8dad4be43ee2049a22ff5674eb86725d0ce5ff434cde2627e5e8e7e117894",
+      "githubRepo": "xiaowu0162/LongMemEval",
+      "githubCommit": "9e0b455f4ef0e2ab8f2e582289761153549043fc",
+      "totalQuestions": 500
+    },
+    "judge": {
+      "model": "gemma4:31b",
+      "manifestDigest": "sha256:221b330d11a8",
+      "weightsSha256": "cloud-hosted:not-published",
+      "family": "gemma4",
+      "temperature": 0,
+      "seed": 0,
+      "numCtx": 8192,
+      "numPredict": 16
+    },
+    "reader": {
+      "model": "qwen3.5:397b",
+      "manifestDigest": "sha256:b909ca2f1b7f",
+      "family": "qwen3_5",
+      "temperature": 0,
+      "seed": 0,
+      "numCtx": 16384,
+      "numPredict": 256
+    },
+    "retrieval": {
+      "scoring": "raw",
+      "readerTopK": 20,
+      "hybrid": true,
+      "arm": "flair",
+      "storeSharing": "one-shared-store-no-mode-flips"
+    },
+    "ingestion": {
+      "granularity": "per-event"
+    },
+    "prompts": {
+      "judge": {
+        "answerable": "I will give you a question, a correct answer, and a response from a model. Classify the model's response into exactly one category:\n\nA (CORRECT): the response contains the correct answer. If the response is equivalent to the correct answer, or contains all the intermediate steps needed to reach the correct answer, classify A.{taskRule}\nB (INCORRECT): the response commits to an answer that is wrong, contradicts the correct answer, or contains only a SUBSET of the information the correct answer requires.\nC (NOT_ATTEMPTED): the response does not commit to any answer — it declines, says it does not know, or says the information is unavailable — WITHOUT stating a wrong answer.\n\nQuestion: {question}\n\nCorrect Answer: {answer}\n\nModel Response: {response}\n\nRespond with ONLY a single letter: A, B, or C.",
+        "preference": "I will give you a question, a rubric describing the desired personalized response, and a response from a model. Classify the model's response into exactly one category:\n\nA (CORRECT): the response satisfies the desired response — it recalls and utilises the user's personal information correctly. It need not reflect every point in the rubric.\nB (INCORRECT): the response fails to utilise the user's personal information, or contradicts the rubric.\nC (NOT_ATTEMPTED): the response declines or does not attempt a personalized response.\n\nQuestion: {question}\n\nRubric: {answer}\n\nModel Response: {response}\n\nRespond with ONLY a single letter: A, B, or C.",
+        "abstention": "I will give you an UNANSWERABLE question, an explanation of why it cannot be answered from the available information, and a response from a model. Classify the model's response into exactly one category:\n\nA (CORRECT): the model correctly identifies the question as unanswerable — it says the information is incomplete, missing, or that it does not know.\nB (INCORRECT): the model fabricates or asserts a concrete answer instead of identifying the question as unanswerable.\n\nQuestion: {question}\n\nExplanation: {answer}\n\nModel Response: {response}\n\nRespond with ONLY a single letter: A or B.",
+        "taskRule": {
+          "single-session-user": "",
+          "single-session-assistant": "",
+          "multi-session": "",
+          "temporal-reasoning": " Do not penalize off-by-one errors for the number of days/weeks/months: if the question asks for a number of days/weeks/months and the response is off by one (e.g. 19 when the answer is 18), still classify it as A (CORRECT).",
+          "knowledge-update": " If the response contains some previous information along with an updated answer, classify it as A (CORRECT) as long as the updated answer is the required answer.",
+          "single-session-preference": ""
+        },
+        "version": "1.0.0-ternary-port"
+      },
+      "readerSystem": "You are a helpful assistant answering the user's question using ONLY the conversation memory provided. Answer concisely and directly. If the provided memory does not contain enough information to answer, reply that you do not know rather than guessing.",
+      "readerPromptVersion": "1.0.0",
+      "payloadFormats": {
+        "A": "v1-undated",
+        "B": "v2-dated"
+      }
+    },
+    "extraction": {
+      "name": "squad-normalize+token-f1+containment-em",
+      "version": "1.0.0"
+    },
+    "slice": {
+      "ability": "temporal-reasoning",
+      "n": 60,
+      "seed": 0,
+      "abilityCandidates": 127,
+      "selectionRule": "entries with abilityOf(e)===ability (abstention rolls up to 'abstention', so *_abs is excluded by construction), ordered by sha256(`${seed}:${question_id}`) ascending, first n taken, emitted sorted by question_id. A keyed pseudo-random draw, NOT a lexicographic prefix: question_id prefixes encode question provenance (gpt4_* is 67% of the temporal-reasoning population but only 30% of a lexicographic first-60), so a prefix draw would confound provenance with the treatment.",
+      "questionIds": [
+        "0bc8ad92",
+        "0bc8ad93",
+        "2c63a862",
+        "2ebe6c90",
+        "5e1b23de",
+        "6613b389",
+        "6e984301",
+        "6e984302",
+        "71017277",
+        "8077ef71",
+        "982b5123",
+        "9a707b82",
+        "b46e15ed",
+        "bbf86515",
+        "cc6d1ec1",
+        "dcfa8644",
+        "eac54adc",
+        "eac54add",
+        "gpt4_0a05b494",
+        "gpt4_0b2f1d21",
+        "gpt4_18c2b244",
+        "gpt4_1916e0ea",
+        "gpt4_1d4ab0c9",
+        "gpt4_1e4a8aeb",
+        "gpt4_1e4a8aec",
+        "gpt4_2312f94c",
+        "gpt4_2487a7cb",
+        "gpt4_2655b836",
+        "gpt4_2c50253f",
+        "gpt4_2d58bcd6",
+        "gpt4_2f584639",
+        "gpt4_468eb064",
+        "gpt4_483dd43c",
+        "gpt4_4edbafa2",
+        "gpt4_4fc4f797",
+        "gpt4_5438fa52",
+        "gpt4_61e13b3c",
+        "gpt4_6ed717ea",
+        "gpt4_70e84552",
+        "gpt4_74aed68e",
+        "gpt4_78cf46a3",
+        "gpt4_7a0daae1",
+        "gpt4_7bc6cf22",
+        "gpt4_7ca326fa",
+        "gpt4_7ddcf75f",
+        "gpt4_7de946e7",
+        "gpt4_7f6b06db",
+        "gpt4_8279ba03",
+        "gpt4_85da3956",
+        "gpt4_8c8961ae",
+        "gpt4_8e165409",
+        "gpt4_93159ced",
+        "gpt4_98f46fc6",
+        "gpt4_a2d1d1f6",
+        "gpt4_c27434e8",
+        "gpt4_d6585ce8",
+        "gpt4_e072b769",
+        "gpt4_e414231e",
+        "gpt4_f420262d",
+        "gpt4_fa19884c"
+      ]
+    }
+  },
+  "resultsHash": "66937623abe34a0435301f2335ffa472e0f12ab66de9796439cb7ff1309afe7f",
+  "results": {
+    "pairsAttempted": 60,
+    "pairsVoidedByJudgeError": 0,
+    "overall": {
+      "table": {
+        "bothRight": 18,
+        "bothWrong": 17,
+        "wins": 24,
+        "losses": 1,
+        "n": 60,
+        "v1Accuracy": 0.31666666666666665,
+        "v2Accuracy": 0.7,
+        "delta": 0.3833333333333333
+      },
+      "mcnemar": {
+        "wins": 24,
+        "losses": 1,
+        "discordant": 25,
+        "p": 0.0000015497207641601533,
+        "direction": "v2",
+        "minSplitForP05": 18
+      }
+    },
+    "attribution": {
+      "goldSessionHitRate": 0.9833333333333333,
+      "goldAnswerHitRate": 0.9,
+      "withGoldEvidence": {
+        "n": 54,
+        "table": {
+          "bothRight": 18,
+          "bothWrong": 12,
+          "wins": 23,
+          "losses": 1,
+          "n": 54,
+          "v1Accuracy": 0.35185185185185186,
+          "v2Accuracy": 0.7592592592592593,
+          "delta": 0.40740740740740744
+        },
+        "mcnemar": {
+          "wins": 23,
+          "losses": 1,
+          "discordant": 24,
+          "p": 0.000002980232238769545,
+          "direction": "v2",
+          "minSplitForP05": 18
+        }
+      },
+      "withoutGoldEvidence": {
+        "n": 6,
+        "table": {
+          "bothRight": 0,
+          "bothWrong": 5,
+          "wins": 1,
+          "losses": 0,
+          "n": 6,
+          "v1Accuracy": 0,
+          "v2Accuracy": 0.16666666666666666,
+          "delta": 0.16666666666666666
+        },
+        "mcnemar": {
+          "wins": 1,
+          "losses": 0,
+          "discordant": 1,
+          "p": 1,
+          "direction": "v2",
+          "minSplitForP05": null
+        }
+      }
+    },
+    "perQuestion": [
+      {
+        "questionId": "0bc8ad92",
+        "a": "NOT_ATTEMPTED",
+        "b": "CORRECT",
+        "goldSessionHit": true,
+        "goldAnswerHitCount": 1,
+        "retrievedCount": 20
+      },
+      {
+        "questionId": "0bc8ad93",
+        "a": "NOT_ATTEMPTED",
+        "b": "INCORRECT",
+        "goldSessionHit": true,
+        "goldAnswerHitCount": 1,
+        "retrievedCount": 20
+      },
+      {
+        "questionId": "2c63a862",
+        "a": "CORRECT",
+        "b": "CORRECT",
+        "goldSessionHit": true,
+        "goldAnswerHitCount": 2,
+        "retrievedCount": 20
+      },
+      {
+        "questionId": "2ebe6c90",
+        "a": "NOT_ATTEMPTED",
+        "b": "NOT_ATTEMPTED",
+        "goldSessionHit": true,
+        "goldAnswerHitCount": 2,
+        "retrievedCount": 20
+      },
+      {
+        "questionId": "5e1b23de",
+        "a": "INCORRECT",
+        "b": "CORRECT",
+        "goldSessionHit": true,
+        "goldAnswerHitCount": 1,
+        "retrievedCount": 20
+      },
+      {
+        "questionId": "6613b389",
+        "a": "CORRECT",
+        "b": "CORRECT",
+        "goldSessionHit": true,
+        "goldAnswerHitCount": 2,
+        "retrievedCount": 20
+      },
+      {
+        "questionId": "6e984301",
+        "a": "NOT_ATTEMPTED",
+        "b": "INCORRECT",
+        "goldSessionHit": true,
+        "goldAnswerHitCount": 2,
+        "retrievedCount": 20
+      },
+      {
+        "questionId": "6e984302",
+        "a": "NOT_ATTEMPTED",
+        "b": "NOT_ATTEMPTED",
+        "goldSessionHit": true,
+        "goldAnswerHitCount": 0,
+        "retrievedCount": 20
+      },
+      {
+        "questionId": "71017277",
+        "a": "NOT_ATTEMPTED",
+        "b": "NOT_ATTEMPTED",
+        "goldSessionHit": true,
+        "goldAnswerHitCount": 0,
+        "retrievedCount": 20
+      },
+      {
+        "questionId": "8077ef71",
+        "a": "INCORRECT",
+        "b": "CORRECT",
+        "goldSessionHit": true,
+        "goldAnswerHitCount": 1,
+        "retrievedCount": 20
+      },
+      {
+        "questionId": "982b5123",
+        "a": "INCORRECT",
+        "b": "INCORRECT",
+        "goldSessionHit": true,
+        "goldAnswerHitCount": 2,
+        "retrievedCount": 20
+      },
+      {
+        "questionId": "9a707b82",
+        "a": "CORRECT",
+        "b": "CORRECT",
+        "goldSessionHit": true,
+        "goldAnswerHitCount": 1,
+        "retrievedCount": 20
+      },
+      {
+        "questionId": "b46e15ed",
+        "a": "NOT_ATTEMPTED",
+        "b": "NOT_ATTEMPTED",
+        "goldSessionHit": true,
+        "goldAnswerHitCount": 3,
+        "retrievedCount": 20
+      },
+      {
+        "questionId": "bbf86515",
+        "a": "CORRECT",
+        "b": "CORRECT",
+        "goldSessionHit": true,
+        "goldAnswerHitCount": 2,
+        "retrievedCount": 20
+      },
+      {
+        "questionId": "cc6d1ec1",
+        "a": "CORRECT",
+        "b": "INCORRECT",
+        "goldSessionHit": true,
+        "goldAnswerHitCount": 2,
+        "retrievedCount": 20
+      },
+      {
+        "questionId": "dcfa8644",
+        "a": "CORRECT",
+        "b": "CORRECT",
+        "goldSessionHit": true,
+        "goldAnswerHitCount": 2,
+        "retrievedCount": 20
+      },
+      {
+        "questionId": "eac54adc",
+        "a": "NOT_ATTEMPTED",
+        "b": "NOT_ATTEMPTED",
+        "goldSessionHit": true,
+        "goldAnswerHitCount": 2,
+        "retrievedCount": 20
+      },
+      {
+        "questionId": "eac54add",
+        "a": "NOT_ATTEMPTED",
+        "b": "NOT_ATTEMPTED",
+        "goldSessionHit": false,
+        "goldAnswerHitCount": 0,
+        "retrievedCount": 20
+      },
+      {
+        "questionId": "gpt4_0a05b494",
+        "a": "CORRECT",
+        "b": "CORRECT",
+        "goldSessionHit": true,
+        "goldAnswerHitCount": 2,
+        "retrievedCount": 20
+      },
+      {
+        "questionId": "gpt4_0b2f1d21",
+        "a": "CORRECT",
+        "b": "CORRECT",
+        "goldSessionHit": true,
+        "goldAnswerHitCount": 2,
+        "retrievedCount": 20
+      },
+      {
+        "questionId": "gpt4_18c2b244",
+        "a": "INCORRECT",
+        "b": "CORRECT",
+        "goldSessionHit": true,
+        "goldAnswerHitCount": 3,
+        "retrievedCount": 20
+      },
+      {
+        "questionId": "gpt4_1916e0ea",
+        "a": "NOT_ATTEMPTED",
+        "b": "CORRECT",
+        "goldSessionHit": true,
+        "goldAnswerHitCount": 2,
+        "retrievedCount": 20
+      },
+      {
+        "questionId": "gpt4_1d4ab0c9",
+        "a": "NOT_ATTEMPTED",
+        "b": "CORRECT",
+        "goldSessionHit": true,
+        "goldAnswerHitCount": 2,
+        "retrievedCount": 20
+      },
+      {
+        "questionId": "gpt4_1e4a8aeb",
+        "a": "NOT_ATTEMPTED",
+        "b": "CORRECT",
+        "goldSessionHit": true,
+        "goldAnswerHitCount": 2,
+        "retrievedCount": 20
+      },
+      {
+        "questionId": "gpt4_1e4a8aec",
+        "a": "NOT_ATTEMPTED",
+        "b": "CORRECT",
+        "goldSessionHit": true,
+        "goldAnswerHitCount": 0,
+        "retrievedCount": 20
+      },
+      {
+        "questionId": "gpt4_2312f94c",
+        "a": "INCORRECT",
+        "b": "CORRECT",
+        "goldSessionHit": true,
+        "goldAnswerHitCount": 2,
+        "retrievedCount": 20
+      },
+      {
+        "questionId": "gpt4_2487a7cb",
+        "a": "INCORRECT",
+        "b": "CORRECT",
+        "goldSessionHit": true,
+        "goldAnswerHitCount": 2,
+        "retrievedCount": 20
+      },
+      {
+        "questionId": "gpt4_2655b836",
+        "a": "CORRECT",
+        "b": "CORRECT",
+        "goldSessionHit": true,
+        "goldAnswerHitCount": 2,
+        "retrievedCount": 20
+      },
+      {
+        "questionId": "gpt4_2c50253f",
+        "a": "CORRECT",
+        "b": "CORRECT",
+        "goldSessionHit": true,
+        "goldAnswerHitCount": 2,
+        "retrievedCount": 20
+      },
+      {
+        "questionId": "gpt4_2d58bcd6",
+        "a": "CORRECT",
+        "b": "CORRECT",
+        "goldSessionHit": true,
+        "goldAnswerHitCount": 2,
+        "retrievedCount": 20
+      },
+      {
+        "questionId": "gpt4_2f584639",
+        "a": "INCORRECT",
+        "b": "CORRECT",
+        "goldSessionHit": true,
+        "goldAnswerHitCount": 2,
+        "retrievedCount": 20
+      },
+      {
+        "questionId": "gpt4_468eb064",
+        "a": "NOT_ATTEMPTED",
+        "b": "CORRECT",
+        "goldSessionHit": true,
+        "goldAnswerHitCount": 1,
+        "retrievedCount": 20
+      },
+      {
+        "questionId": "gpt4_483dd43c",
+        "a": "CORRECT",
+        "b": "CORRECT",
+        "goldSessionHit": true,
+        "goldAnswerHitCount": 2,
+        "retrievedCount": 20
+      },
+      {
+        "questionId": "gpt4_4edbafa2",
+        "a": "CORRECT",
+        "b": "CORRECT",
+        "goldSessionHit": true,
+        "goldAnswerHitCount": 2,
+        "retrievedCount": 20
+      },
+      {
+        "questionId": "gpt4_4fc4f797",
+        "a": "NOT_ATTEMPTED",
+        "b": "NOT_ATTEMPTED",
+        "goldSessionHit": true,
+        "goldAnswerHitCount": 2,
+        "retrievedCount": 20
+      },
+      {
+        "questionId": "gpt4_5438fa52",
+        "a": "CORRECT",
+        "b": "CORRECT",
+        "goldSessionHit": true,
+        "goldAnswerHitCount": 2,
+        "retrievedCount": 20
+      },
+      {
+        "questionId": "gpt4_61e13b3c",
+        "a": "NOT_ATTEMPTED",
+        "b": "CORRECT",
+        "goldSessionHit": true,
+        "goldAnswerHitCount": 2,
+        "retrievedCount": 20
+      },
+      {
+        "questionId": "gpt4_6ed717ea",
+        "a": "CORRECT",
+        "b": "CORRECT",
+        "goldSessionHit": true,
+        "goldAnswerHitCount": 2,
+        "retrievedCount": 20
+      },
+      {
+        "questionId": "gpt4_70e84552",
+        "a": "CORRECT",
+        "b": "CORRECT",
+        "goldSessionHit": true,
+        "goldAnswerHitCount": 2,
+        "retrievedCount": 20
+      },
+      {
+        "questionId": "gpt4_74aed68e",
+        "a": "INCORRECT",
+        "b": "CORRECT",
+        "goldSessionHit": true,
+        "goldAnswerHitCount": 2,
+        "retrievedCount": 20
+      },
+      {
+        "questionId": "gpt4_78cf46a3",
+        "a": "INCORRECT",
+        "b": "CORRECT",
+        "goldSessionHit": true,
+        "goldAnswerHitCount": 2,
+        "retrievedCount": 20
+      },
+      {
+        "questionId": "gpt4_7a0daae1",
+        "a": "NOT_ATTEMPTED",
+        "b": "NOT_ATTEMPTED",
+        "goldSessionHit": true,
+        "goldAnswerHitCount": 2,
+        "retrievedCount": 20
+      },
+      {
+        "questionId": "gpt4_7bc6cf22",
+        "a": "INCORRECT",
+        "b": "CORRECT",
+        "goldSessionHit": true,
+        "goldAnswerHitCount": 1,
+        "retrievedCount": 20
+      },
+      {
+        "questionId": "gpt4_7ca326fa",
+        "a": "INCORRECT",
+        "b": "CORRECT",
+        "goldSessionHit": true,
+        "goldAnswerHitCount": 3,
+        "retrievedCount": 20
+      },
+      {
+        "questionId": "gpt4_7ddcf75f",
+        "a": "INCORRECT",
+        "b": "CORRECT",
+        "goldSessionHit": true,
+        "goldAnswerHitCount": 1,
+        "retrievedCount": 20
+      },
+      {
+        "questionId": "gpt4_7de946e7",
+        "a": "CORRECT",
+        "b": "CORRECT",
+        "goldSessionHit": true,
+        "goldAnswerHitCount": 2,
+        "retrievedCount": 20
+      },
+      {
+        "questionId": "gpt4_7f6b06db",
+        "a": "NOT_ATTEMPTED",
+        "b": "INCORRECT",
+        "goldSessionHit": true,
+        "goldAnswerHitCount": 2,
+        "retrievedCount": 20
+      },
+      {
+        "questionId": "gpt4_8279ba03",
+        "a": "NOT_ATTEMPTED",
+        "b": "NOT_ATTEMPTED",
+        "goldSessionHit": true,
+        "goldAnswerHitCount": 0,
+        "retrievedCount": 20
+      },
+      {
+        "questionId": "gpt4_85da3956",
+        "a": "NOT_ATTEMPTED",
+        "b": "CORRECT",
+        "goldSessionHit": true,
+        "goldAnswerHitCount": 1,
+        "retrievedCount": 20
+      },
+      {
+        "questionId": "gpt4_8c8961ae",
+        "a": "CORRECT",
+        "b": "CORRECT",
+        "goldSessionHit": true,
+        "goldAnswerHitCount": 1,
+        "retrievedCount": 20
+      },
+      {
+        "questionId": "gpt4_8e165409",
+        "a": "NOT_ATTEMPTED",
+        "b": "CORRECT",
+        "goldSessionHit": true,
+        "goldAnswerHitCount": 2,
+        "retrievedCount": 20
+      },
+      {
+        "questionId": "gpt4_93159ced",
+        "a": "NOT_ATTEMPTED",
+        "b": "NOT_ATTEMPTED",
+        "goldSessionHit": true,
+        "goldAnswerHitCount": 3,
+        "retrievedCount": 20
+      },
+      {
+        "questionId": "gpt4_98f46fc6",
+        "a": "NOT_ATTEMPTED",
+        "b": "CORRECT",
+        "goldSessionHit": true,
+        "goldAnswerHitCount": 2,
+        "retrievedCount": 20
+      },
+      {
+        "questionId": "gpt4_a2d1d1f6",
+        "a": "INCORRECT",
+        "b": "CORRECT",
+        "goldSessionHit": true,
+        "goldAnswerHitCount": 1,
+        "retrievedCount": 20
+      },
+      {
+        "questionId": "gpt4_c27434e8",
+        "a": "CORRECT",
+        "b": "CORRECT",
+        "goldSessionHit": true,
+        "goldAnswerHitCount": 2,
+        "retrievedCount": 20
+      },
+      {
+        "questionId": "gpt4_d6585ce8",
+        "a": "INCORRECT",
+        "b": "INCORRECT",
+        "goldSessionHit": true,
+        "goldAnswerHitCount": 2,
+        "retrievedCount": 20
+      },
+      {
+        "questionId": "gpt4_e072b769",
+        "a": "NOT_ATTEMPTED",
+        "b": "NOT_ATTEMPTED",
+        "goldSessionHit": true,
+        "goldAnswerHitCount": 1,
+        "retrievedCount": 20
+      },
+      {
+        "questionId": "gpt4_e414231e",
+        "a": "INCORRECT",
+        "b": "CORRECT",
+        "goldSessionHit": true,
+        "goldAnswerHitCount": 2,
+        "retrievedCount": 20
+      },
+      {
+        "questionId": "gpt4_f420262d",
+        "a": "NOT_ATTEMPTED",
+        "b": "NOT_ATTEMPTED",
+        "goldSessionHit": true,
+        "goldAnswerHitCount": 0,
+        "retrievedCount": 20
+      },
+      {
+        "questionId": "gpt4_fa19884c",
+        "a": "INCORRECT",
+        "b": "CORRECT",
+        "goldSessionHit": true,
+        "goldAnswerHitCount": 2,
+        "retrievedCount": 20
+      }
+    ]
+  },
+  "notice": "VALIDATION ARTIFACT — NOT FOR PUBLICATION. This harness produces numbers; it does not publish them. Publishing any number requires a recorded human sign-off referencing this artifact's artifactHash. Spend and outward-publishing are the founder's gates.",
+  "generatedAt": "2026-08-24T03:53:23.788Z",
+  "host": {
+    "ollama": "https://ollama.com",
+    "benchHost": "tps-bench.exe.xyz"
+  },
+  "artifactHash": "dede855fae8efe60573757aef0e005a0e7396e1efe93a6e1a2b3018f1c81e9a5"
+}

--- a/test/unit/longmemeval-arms.test.ts
+++ b/test/unit/longmemeval-arms.test.ts
@@ -1,0 +1,54 @@
+/**
+ * longmemeval-arms.test.ts — the v2-dated reader payload (formatRetrieved) and
+ * its version stamp in the hashed config.
+ *
+ * The payload format is a MEASUREMENT VARIANT: it changes what the reader sees,
+ * so it must (a) actually carry the dates, and (b) be impossible to change
+ * without changing the configHash. Both claims get a positive control here.
+ */
+import { describe, expect, test } from "bun:test";
+import { formatRetrieved, READER_PAYLOAD_FORMAT } from "../bench/longmemeval/arms";
+import { configManifest, hashConfig } from "../bench/longmemeval/config";
+import type { RetrievedItem } from "../../packages/flair-bench/lib/index";
+
+describe("formatRetrieved (v2-dated payload)", () => {
+  test("prefixes each memory with its createdAt DATE (date-only, not the timestamp)", () => {
+    const items: RetrievedItem[] = [
+      { id: "m1", score: 0.9, content: "adopted a puppy named Biscuit", createdAt: "2023-05-20T02:21:00.000Z" },
+      { id: "m2", score: 0.8, content: "Biscuit graduated obedience school", createdAt: "2023-07-11T18:00:00.000Z" },
+    ];
+    expect(formatRetrieved(items)).toBe(
+      "- [2023-05-20] adopted a puppy named Biscuit\n" +
+      "- [2023-07-11] Biscuit graduated obedience school",
+    );
+  });
+
+  test("a memory without createdAt falls back to the undated v1 line", () => {
+    const items: RetrievedItem[] = [
+      { id: "m1", score: 0.9, content: "dated", createdAt: "2024-01-02T00:00:00.000Z" },
+      { id: "m2", score: 0.8, content: "undated" },
+    ];
+    expect(formatRetrieved(items)).toBe("- [2024-01-02] dated\n- undated");
+  });
+
+  test("empty retrieval keeps the explicit no-memory marker", () => {
+    expect(formatRetrieved([])).toBe("(no relevant memory found)");
+  });
+});
+
+describe("reader payload format is part of the hashed config", () => {
+  const slice = { n: 2, seed: 0, runs: 1, questionIds: ["qa", "qb"] };
+
+  test("manifest carries the current stamp", () => {
+    const m = configManifest(slice) as { prompts: { readerPayloadFormat: string } };
+    expect(m.prompts.readerPayloadFormat).toBe(READER_PAYLOAD_FORMAT);
+    expect(READER_PAYLOAD_FORMAT).toBe("v2-dated");
+  });
+
+  test("positive control: a different payload format hashes differently", () => {
+    const m1 = configManifest(slice);
+    const m2 = configManifest(slice) as { prompts: { readerPayloadFormat: string } };
+    m2.prompts.readerPayloadFormat = "v1";
+    expect(hashConfig(m2)).not.toBe(hashConfig(m1));
+  });
+});

--- a/test/unit/longmemeval-payload-ab.test.ts
+++ b/test/unit/longmemeval-payload-ab.test.ts
@@ -1,0 +1,251 @@
+/**
+ * Unit tests for the paired reader-payload A/B: the slice selection rule, the
+ * gold-evidence id mapping, the McNemar read, and the artifact partition it
+ * shares with the four-arm artifact.
+ *
+ * Every check here carries a POSITIVE CONTROL — a mutation that must make it
+ * fail — because the failure mode these guard against is a check that cannot
+ * fire (the exact reason the 30-question smoke slice could not measure the
+ * dated payload: it was at its ceiling).
+ */
+import { describe, expect, test } from "bun:test";
+import { formatRetrievedAs, PAYLOAD_FORMATS } from "../bench/longmemeval/arms";
+import { selectAbilitySlice, goldEvidenceFor, abilityOf, type LmeEntry } from "../bench/longmemeval/dataset";
+import { mcnemarExact, pairedTable, binomialUpperTail } from "../bench/longmemeval/paired-stats";
+import { stampArtifactHash, verifyStampedHash, hashedContent, PROVENANCE_KEYS } from "../bench/longmemeval/artifact";
+
+// ── fixtures ─────────────────────────────────────────────────────────────────
+
+function mkEntry(id: string, type = "temporal-reasoning"): LmeEntry {
+  return {
+    question_id: id,
+    question_type: type as LmeEntry["question_type"],
+    question: "q?",
+    answer: "a",
+    question_date: "2023/05/20 (Sat) 02:21",
+    haystack_dates: ["2023/05/01 (Mon) 10:00", "2023/05/02 (Tue) 10:00"],
+    haystack_session_ids: ["sess_noise", "answer_sess"],
+    haystack_sessions: [
+      [{ role: "user", content: "noise" }, { role: "assistant", content: "noise2" }],
+      [{ role: "user", content: "gold q", has_answer: true }, { role: "assistant", content: "gold a", has_answer: true }],
+    ],
+    answer_session_ids: ["answer_sess"],
+  };
+}
+
+// ── payload formats ──────────────────────────────────────────────────────────
+
+describe("formatRetrievedAs", () => {
+  const items = [
+    { id: "a", score: 1, content: "first", createdAt: "2023-05-01T10:00:00.000Z" },
+    { id: "b", score: 0.5, content: "second" }, // no createdAt
+  ];
+
+  test("v1-undated emits bare lines even when a createdAt is present", () => {
+    expect(formatRetrievedAs(items, "v1-undated")).toBe("- first\n- second");
+  });
+
+  test("v2-dated prefixes the date, and falls back to the bare line without one", () => {
+    expect(formatRetrievedAs(items, "v2-dated")).toBe("- [2023-05-01] first\n- second");
+  });
+
+  test("the two formats actually differ on dated input (positive control)", () => {
+    // If this ever passes trivially, the A/B is measuring nothing.
+    expect(formatRetrievedAs(items, "v1-undated")).not.toBe(formatRetrievedAs(items, "v2-dated"));
+  });
+
+  test("both sides of the A/B are declared formats", () => {
+    expect(PAYLOAD_FORMATS).toContain("v1-undated");
+    expect(PAYLOAD_FORMATS).toContain("v2-dated");
+  });
+
+  test("empty retrieval is the same sentinel either way", () => {
+    expect(formatRetrievedAs([], "v1-undated")).toBe("(no relevant memory found)");
+    expect(formatRetrievedAs([], "v2-dated")).toBe("(no relevant memory found)");
+  });
+});
+
+// ── slice selection ──────────────────────────────────────────────────────────
+
+describe("selectAbilitySlice", () => {
+  const pool: LmeEntry[] = [];
+  for (let i = 0; i < 40; i++) pool.push(mkEntry(`q${String(i).padStart(3, "0")}`));
+  for (let i = 0; i < 10; i++) pool.push(mkEntry(`m${i}`, "multi-session"));
+  // abstention variants of the target ability — must be excluded by construction
+  for (let i = 0; i < 5; i++) pool.push(mkEntry(`q_abs_${i}`));
+
+  test("selects only the requested ability and excludes abstention variants", () => {
+    const slice = selectAbilitySlice(pool, "temporal-reasoning", 20, 0);
+    expect(slice).toHaveLength(20);
+    for (const e of slice) {
+      expect(abilityOf(e)).toBe("temporal-reasoning");
+      expect(e.question_id).not.toContain("_abs");
+    }
+  });
+
+  test("is deterministic for a given (n, seed) and stably ordered", () => {
+    const a = selectAbilitySlice(pool, "temporal-reasoning", 20, 0).map((e) => e.question_id);
+    const b = selectAbilitySlice(pool, "temporal-reasoning", 20, 0).map((e) => e.question_id);
+    expect(a).toEqual(b);
+    expect(a).toEqual([...a].sort());
+    // Input order must not matter — the config hash commits to the id set.
+    const shuffled = [...pool].reverse();
+    expect(selectAbilitySlice(shuffled, "temporal-reasoning", 20, 0).map((e) => e.question_id)).toEqual(a);
+  });
+
+  test("a different seed draws a different sample (positive control)", () => {
+    const a = selectAbilitySlice(pool, "temporal-reasoning", 20, 0).map((e) => e.question_id);
+    const b = selectAbilitySlice(pool, "temporal-reasoning", 20, 1).map((e) => e.question_id);
+    expect(a).not.toEqual(b);
+  });
+
+  test("the draw is NOT a lexicographic prefix", () => {
+    // The whole point of hashing the id: a prefix draw confounds question
+    // provenance (gpt4_*) with the treatment.
+    const slice = selectAbilitySlice(pool, "temporal-reasoning", 20, 0).map((e) => e.question_id);
+    const lexFirst20 = pool
+      .filter((e) => abilityOf(e) === "temporal-reasoning")
+      .map((e) => e.question_id).sort().slice(0, 20);
+    expect(slice).not.toEqual(lexFirst20);
+  });
+
+  test("refuses a short slice rather than silently returning fewer", () => {
+    expect(() => selectAbilitySlice(pool, "multi-session", 25, 0)).toThrow(/only 10 exist/);
+  });
+});
+
+// ── gold-evidence mapping ────────────────────────────────────────────────────
+
+describe("goldEvidenceFor", () => {
+  test("maps answer sessions and has_answer turns into ingest event ids", () => {
+    const g = goldEvidenceFor(mkEntry("qX"));
+    expect(g.sessionIds).toEqual(["answer_sess"]);
+    expect(g.sessionEventIds).toEqual(["qX__s1__t0", "qX__s1__t1"]);
+    expect(g.answerEventIds).toEqual(["qX__s1__t0", "qX__s1__t1"]);
+    expect(g.unresolvedSessionIds).toEqual([]);
+  });
+
+  test("ignores turns outside the labelled answer sessions", () => {
+    const e = mkEntry("qY");
+    e.haystack_sessions[0]![0]!.has_answer = true; // a has_answer turn in a NOISE session
+    const g = goldEvidenceFor(e);
+    expect(g.answerEventIds).not.toContain("qY__s0__t0");
+  });
+
+  test("reports an unmappable label instead of silently scoring zero (positive control)", () => {
+    const e = mkEntry("qZ");
+    e.answer_session_ids = ["a_session_that_is_not_in_the_haystack"];
+    const g = goldEvidenceFor(e);
+    expect(g.sessionEventIds).toHaveLength(0);
+    expect(g.unresolvedSessionIds).toEqual(["a_session_that_is_not_in_the_haystack"]);
+  });
+
+  test("the ids it emits match the ids the ingest actually writes", () => {
+    // Guards the one drift that would make the attribution read decorative:
+    // dataset.entryToSessions builds `<qid>__s<si>__t<ti>` — if that template
+    // ever changes, this fails instead of the coverage silently going to 0.
+    const e = mkEntry("qW");
+    const g = goldEvidenceFor(e);
+    const { entryToSessions } = require("../bench/longmemeval/dataset");
+    const ingestIds: string[] = entryToSessions(e).flatMap((s: any) => s.events.map((ev: any) => ev.id));
+    for (const id of g.sessionEventIds) expect(ingestIds).toContain(id);
+  });
+});
+
+// ── the paired statistic ─────────────────────────────────────────────────────
+
+describe("pairedTable", () => {
+  test("partitions into the four cells and derives accuracies from them", () => {
+    const t = pairedTable([
+      { v1: true, v2: true },   // both right
+      { v1: true, v2: true },
+      { v1: false, v2: false }, // both wrong
+      { v1: false, v2: true },  // win
+      { v1: false, v2: true },
+      { v1: true, v2: false },  // loss
+    ]);
+    expect(t).toMatchObject({ bothRight: 2, bothWrong: 1, wins: 2, losses: 1, n: 6 });
+    expect(t.v1Accuracy).toBeCloseTo(3 / 6);
+    expect(t.v2Accuracy).toBeCloseTo(4 / 6);
+    // The identity that makes the paired read legible: delta == (wins-losses)/n.
+    expect(t.delta).toBeCloseTo((t.wins - t.losses) / t.n);
+  });
+});
+
+describe("mcnemarExact", () => {
+  test("no discordant pairs means no evidence either way", () => {
+    const r = mcnemarExact(0, 0);
+    expect(r).toMatchObject({ discordant: 0, p: 1, direction: "tie" });
+  });
+
+  test("an even split is maximally uninformative", () => {
+    expect(mcnemarExact(5, 5).p).toBe(1);
+    expect(mcnemarExact(5, 5).direction).toBe("tie");
+  });
+
+  test("matches the closed form on a known split", () => {
+    // 9 wins / 1 loss out of 10 discordant: 2 * P(X>=9), X~Bin(10,0.5)
+    //   = 2 * (10 + 1)/1024 = 22/1024 = 0.021484375
+    expect(mcnemarExact(9, 1).p).toBeCloseTo(0.021484375, 9);
+    expect(mcnemarExact(9, 1).direction).toBe("v2");
+    // symmetric in the arguments, opposite lean
+    expect(mcnemarExact(1, 9).p).toBeCloseTo(0.021484375, 9);
+    expect(mcnemarExact(1, 9).direction).toBe("v1");
+  });
+
+  test("a small lopsided split is NOT significant — the underpowered case", () => {
+    // 4-0 => 2 * 1/16 = 0.125. A harness that called this significant would be
+    // the check-that-cannot-fire failure in its most expensive form.
+    expect(mcnemarExact(4, 0).p).toBeCloseTo(0.125, 9);
+    expect(mcnemarExact(4, 0).p).toBeGreaterThan(0.05);
+    // ...and it reports that NO split at d=4 could have reached p<0.05.
+    expect(mcnemarExact(4, 0).minSplitForP05).toBeNull();
+    // at d=6, a clean sweep would have: 2*(1/64) = 0.03125
+    expect(mcnemarExact(3, 3).minSplitForP05).toBe(6);
+  });
+
+  test("binomialUpperTail is a proper tail", () => {
+    expect(binomialUpperTail(10, 0)).toBe(1);
+    expect(binomialUpperTail(10, 11)).toBe(0);
+    expect(binomialUpperTail(10, 5) + binomialUpperTail(10, 6)).toBeGreaterThan(1); // overlapping tails
+    expect(binomialUpperTail(4, 4)).toBeCloseTo(1 / 16, 12);
+  });
+});
+
+// ── artifact partition (shared with the four-arm artifact) ───────────────────
+
+describe("artifact content/provenance partition", () => {
+  const base = () => ({
+    schema: "longmemeval-s.payload-ab.artifact/1",
+    configHash: "cfg",
+    results: { wins: 3, losses: 1 },
+    notice: "NOT FOR PUBLICATION",
+    generatedAt: "2026-08-23T00:00:00.000Z",
+    host: { ollama: "https://ollama.com", benchHost: "tps-bench" },
+  });
+
+  test("provenance never enters the hash — same content, different host/clock, same hash", () => {
+    const a = stampArtifactHash(base());
+    const b = stampArtifactHash({ ...base(), generatedAt: "2027-01-01T00:00:00.000Z", host: { ollama: "x", benchHost: "y" } });
+    expect(a.artifactHash).toBe(b.artifactHash);
+    expect(verifyStampedHash(a)).toBe(true);
+  });
+
+  test("content DOES enter the hash (positive control)", () => {
+    const a = stampArtifactHash(base());
+    const b = stampArtifactHash({ ...base(), results: { wins: 4, losses: 1 } });
+    expect(a.artifactHash).not.toBe(b.artifactHash);
+  });
+
+  test("a tampered artifact fails verification", () => {
+    const a = stampArtifactHash(base()) as any;
+    a.results.wins = 99;
+    expect(verifyStampedHash(a)).toBe(false);
+  });
+
+  test("the partition list is the single source of truth", () => {
+    const content = hashedContent(stampArtifactHash(base()));
+    for (const k of PROVENANCE_KEYS) expect(content).not.toHaveProperty(k);
+    expect(content).toHaveProperty("results");
+  });
+});


### PR DESCRIPTION
## Why

The `v2-dated` reader payload landed with **no way to measure it**. The existing
`selectSlice` round-robins *across* abilities, so a 30-question smoke slice
carried only a handful of temporal-reasoning questions and scored **100% on them
at baseline** — a ceiling. The check could not fire.

This PR adds the experiment that can, and runs it.

## The design

**Paired, same-retrieval A/B.** The two formats differ *only* in the reader
prompt — not in ingest, not in retrieval, not in the reader, not in the judge.
So per question: ingest **once**, retrieve **once**, then format that *same*
retrieved set both ways and run the reader twice, judging both.

Question difficulty and retrieval luck are held exactly constant *within* a pair
and difference out. Cost is one ingest per question (the dominant term at ~85s)
instead of two; power is far higher, because the informative unit is the
**discordant pair**.

- **Sample:** 60 temporal-reasoning questions, seed 0, of the 127 non-abstention
  temporal entries.
- **Selection rule:** filter by ability (abstention rolls up to `abstention`, so
  `*_abs` is excluded by construction) → order by
  `sha256("<seed>:<question_id>")` → take 60 → emit sorted by `question_id`.
  A **keyed pseudo-random draw, not a lexicographic prefix**: `gpt4_*` ids mark a
  subpopulation that is 67% of the temporal population but only **30%** of a
  lexicographic first-60. A prefix draw would have confounded question
  provenance with the treatment. The hashed draw lands at 70%.

## Result

Reader `qwen3.5:397b`, judge `gemma4:31b` (cross-family), both digest-pinned,
ollama cloud. 60/60 pairs usable, **0 voided by judge error**.

|                    | **B right** | **B wrong** |
|--------------------|-------------|-------------|
| **A right** (v1)   | 18          | 1           |
| **A wrong** (v1)   | **24**      | 17          |

- **wins** (A wrong → B right): **24**
- **losses** (A right → B wrong): **1**
- concordant: 35 (18 both right, 17 both wrong)
- **discordant: 25** ← the only pairs carrying information

**Overall accuracy — A (`v1-undated`) 31.7% → B (`v2-dated`) 70.0%, +38.3 pts.**

Exact two-sided McNemar on the 25 discordant pairs: **p = 1.55e-6**. At d=25,
p<0.05 needed an 18-7 split; the observed split is 24-1.

### Attribution — was the evidence even retrieved?

- gold **session** hit rate: **98.3%**
- gold **answer-turn** hit rate (a `has_answer` turn actually retrieved): **90.0%**

| subset | n | A | B | wins | losses | discordant | p |
|---|---|---|---|---|---|---|---|
| with gold evidence | 54 | 35.2% | 75.9% | 23 | 1 | 24 | 2.98e-6 |
| without gold evidence | 6 | 0.0% | 16.7% | 1 | 0 | 1 | 1.0 |

The effect lives entirely in the subset where retrieval *did* put the evidence in
front of the reader. This is the decisive attribution: retrieval was already
working ~90% of the time — **the reader simply had no dates to reason over.**

### The mechanism, in the model's own words

A representative win (`0bc8ad92`):

> **A (undated):** *"I do not know. The conversation memory mentions a
> behind-the-scenes tour you took with a friend, but it does not specify when
> this visit occurred..."*
>
> **B (dated):** *"...you last visited a museum with a friend on **October 22,
> 2022**. Given the current date is **March 25, 2023**, approximately **5
> months** have passed."*

Verdict shifts match: `NOT_ATTEMPTED` **25 → 12**, `INCORRECT` **16 → 6**.

### What this can and cannot support

**Can:** the dated payload causes a large, highly significant accuracy gain on
temporal-reasoning **on this reader/judge pair, at this retrieval config**. The
control side reproduces the known baseline (31.7% here vs 37% in the 2026-08
headline run), so this is not a broken-control artifact.

**Cannot:** say anything about the other four abilities (not sampled), about a
different reader, or about the headline number as a whole. n=60 paired ≈ n=180
unpaired *for this contrast only*. The A-then-B order was **not** randomised —
the reader is a stateless `/api/generate` call at temperature 0 with a fixed
seed, so order cannot carry, but that is a mechanism argument, not an
instrumented one.

The single **loss** (`cc6d1ec1`) is a judge/format interaction worth knowing: B
reframed a relative answer ("three months after starting") into an absolute
anchor ("one month ago") and the judge marked it wrong.

## Verdict

**Yes — the dated payload earns its place in the next full run.** 24-1 on
discordant pairs, concentrated exactly where the hypothesis said it would be.

## Verification

- `configHash`  `d2d614b8c458f3e9f09d22f6bcda6fe04d56e7199e2e5a9476245c83b50816ee`
- `resultsHash` `66937623abe34a0435301f2335ffa472e0f12ab66de9796439cb7ff1309afe7f`
- `artifactHash` `dede855fae8efe60573757aef0e005a0e7396e1efe93a6e1a2b3018f1c81e9a5`

The artifact is committed at
`test/bench/longmemeval/results/payload-ab-artifact-dede855fae8efe60.json`,
carries the **NOT FOR PUBLICATION** notice, and describes its own paired design
inside the hashed config. Both hashes were re-derived independently (a second
implementation, in Python) from the on-disk file, with a mutation control
confirming the hash moves when a cell changes.

That re-derivation surfaced a portability caveat now documented on
`canonicalJson`: the canonical form inherits ECMAScript's `Number::toString`, so
a naive Python re-implementation mismatches on tiny p-values (`2.98e-6` vs
`0.000002980...`). It bites exactly where it is least welcome — a strong result.
Deliberately **not** "fixed": changing the number format would invalidate every
artifact already hashed.

## Notes for review

- Unit tests carry a **positive control per check** (a mutation that must make
  them fail) — the defect this PR exists to correct is a check that cannot fire.
- `formatRetrievedAs` is now the single definition of both payload formats;
  `formatRetrieved` delegates at the pinned format, so the A/B and the headline
  run cannot drift apart. `v1-undated` is the live control, not dead code.
- `assertSidesDiffer()` refuses an A/B against itself, which would report a
  perfectly clean "no difference".
- `goldEvidenceFor` returns `unresolvedSessionIds`, and the runner **refuses to
  start** if any label is unmappable — otherwise the attribution read would
  silently score 0. Verified against all 127 temporal entries: every
  `answer_session_id` resolves, every question has `has_answer` turns, none
  outside a gold session.
- **Known gap, not addressed here:** the tps-bench VM carries unmerged local
  adaptations from the headline runs (ollama-cloud key file + 429 backoff,
  shared-store ingest-reuse, resume, readiness hardening). This PR deliberately
  does not drag those in — the runner is written to be independent of them and
  runs on both trees. Worth its own PR.

Refs #1236
