### PR TITLE
bench: port the tps-bench harness into the repo, with every knob classified (#1366)

### DIFF
--- a/.changelog/unreleased/fixed-1366-bench-harness-parity.md
+++ b/.changelog/unreleased/fixed-1366-bench-harness-parity.md
@@ -1,0 +1,18 @@
+- **The LongMemEval bench harness in the repo is now the harness that produced
+  the numbers.** The adaptations made on the bench VM during the headline runs —
+  ollama-cloud key-file auth with 429/5xx backoff, shared-store ingest-reuse,
+  resume from the per-eval journal, and the hardened readiness gate — lived only
+  on that VM, so "run it yourself" reproduced a *different* harness than the one
+  that made the numbers. They are ported here, with each knob classified as
+  artifact-affecting (enters the hashed config) or operational-only, and a
+  standing test that reconstructs each published run's manifest from repo code
+  and asserts it content-addresses to that run's recorded `configHash`. The
+  reconstruction is projected onto the key set the artifact actually recorded,
+  so the manifest can keep growing without invalidating past artifacts — while a
+  changed pin, prompt or extraction method still fails loudly.
+
+  The cloud model pins are added as a `LME_MODEL_PROFILE=local|cloud` selector
+  rather than by editing the pinned constants, so `local` stays the default and
+  hashes exactly as before — no already-published local artifact is invalidated.
+
+  Bench tooling only; nothing in the shipped package changes.

--- a/test/bench/longmemeval/README.md
+++ b/test/bench/longmemeval/README.md
@@ -12,9 +12,13 @@ confound).
 **Reproducibility is the edge.** Everything that can move the number is pinned
 and committed: the dataset (by HF commit + sha256), the judge and reader (by
 Ollama manifest digest — tags are mutable, digests are not), num_ctx, the
-retrieval config, the ingestion granularity, and the exact judge/reader prompt
-strings (folded into the config hash). Anyone re-runs the exact number locally
-with `ollama pull` — no OpenAI key, no per-run spend.
+retrieval config, the ingestion granularity, the store topology, and the exact
+judge/reader prompt strings (all folded into the config hash). Anyone re-runs
+the exact configuration with `ollama pull` — no OpenAI key, no per-run spend.
+
+Read "What 'reproducible' does and does not mean here" below before quoting
+that sentence at anyone: the config reproduces exactly, the reader's *text*
+does not under the cloud profile.
 
 ## Arms
 
@@ -40,17 +44,44 @@ Reader and judge are the **same across all arms** — only the context differs.
   Judge prompts ported from `xiaowu0162/LongMemEval` @
   `9e0b455f4ef0e2ab8f2e582289761153549043fc`
   (`src/evaluation/evaluate_qa.py`).
-- **Judge:** `gemma4:31b-it-q8_0`, LOCAL on Newton via Ollama, manifest digest
-  `sha256:53dd8459790f8795177444daa9e33f417e03c0d1cdedb80b6c73898603d20aef`.
-  temp 0, fixed num_ctx, **plaintext** verdict (never Ollama's JSON/structured
-  mode — non-deterministic at fixed seed, Ollama #12559).
-- **Reader:** `qwen3.6:27b-coding-mxfp8` (Qwen family — a **different family**
-  than the Gemma judge, the self-preference control), digest
-  `sha256:a7185d39ff35a472a2721b87e1bbb90810bcd381d415666ce2137838e66f2780`.
+### Model profiles — `LME_MODEL_PROFILE=local|cloud`
+
+Two pinned model sets. `local` is the default, so an unset environment behaves
+exactly as it always has.
+
+| | `local` (default) — Newton | `cloud` — ollama.com |
+|---|---|---|
+| **Judge** | `gemma4:31b-it-q8_0`<br>`sha256:53dd8459790f8795177444daa9e33f417e03c0d1cdedb80b6c73898603d20aef`<br>weights `sha256:a0feadb7…` | `gemma4:31b`<br>`sha256:221b330d11a8`<br>weights `cloud-hosted:not-published` |
+| **Reader** | `qwen3.6:27b-coding-mxfp8`<br>`sha256:a7185d39ff35a472a2721b87e1bbb90810bcd381d415666ce2137838e66f2780` | `qwen3.5:397b`<br>`sha256:b909ca2f1b7f` |
+
+Both profiles keep judge family `gemma4` and reader family `qwen3_5`, so the
+cross-family self-preference control holds either way rather than depending on
+which profile you happened to run.
+
+Judge settings are identical across profiles: temp 0, fixed num_ctx, and a
+**plaintext** verdict (never Ollama's JSON/structured mode — non-deterministic
+at fixed seed, Ollama #12559).
+
+**The published headline run used `cloud`.** Those pins live here so a clean
+checkout can reproduce the published `configHash`; before flair#1366 they
+existed only as an in-place edit on the bench VM, which is what made the
+headline unreproducible from the repo.
+
+Selecting a profile is **artifact-affecting** and needs no extra hashed field:
+`configManifest()` has always folded the whole judge/reader objects into the
+hash, so the pins themselves carry the identity.
+
+`test/unit/longmemeval-repro.test.ts` holds both properties — that the `cloud`
+pins still reconstruct the published headline `configHash`, and that the `local`
+pins are byte-for-byte what they were before profiles existed. It asserts them
+on **pin values and a reconstructed historical manifest**, never on a pin of
+"whatever the current manifest hashes to"; see "Reproducing a past run" below
+for why that distinction is the whole design.
 
 The harness **fails loud** if a model's current digest on the host does not
-match the pinned digest, if the dataset sha256 does not match, or if the judge
-family equals the reader family.
+match the pinned digest, if the dataset sha256 does not match, if the judge
+family equals the reader family, or if `LME_MODEL_PROFILE` is set to anything
+other than a known profile name.
 
 ## Grading
 
@@ -95,15 +126,158 @@ bun run test/bench/longmemeval/run.ts run \
   --dataset ./longmemeval_s.json --n 24 --seed 0 --runs 5
 ```
 
-`LME_OLLAMA_HOST` overrides the Ollama endpoint (default Newton
-`http://192.168.2.64:11434`).
+### Running against ollama.com (how the headline was produced)
 
-`LME_FULL_CTX` overrides the full-context arm's window (default `131072`, the
-pinned publishable value). A ~100k-token prefill is minutes per call, so a
-validation slice may reduce it (e.g. `LME_FULL_CTX=16384`) — the value used is
-folded into the config hash and recorded in the artifact, so a reduced window is
-never silent. Reduce it ONLY for validation; the publishable run uses the pinned
-default.
+```bash
+LME_MODEL_PROFILE=cloud \
+LME_OLLAMA_HOST=https://ollama.com \
+LME_OLLAMA_KEY_FILE=$HOME/.config/ollama-api-key \
+LME_ARMS=flair,vector-only \
+bun run test/bench/longmemeval/run.ts run \
+  --dataset ./longmemeval_s.json --n 500 --seed 0 --runs 1 \
+  --records ./records.jsonl --progress ./progress.json
+```
+
+The API key is referenced **by path** and read in-process. It never appears in
+argv, so never in shell history, `ps` output, or a transcript — and never in a
+log line or the artifact. Unset ⇒ no auth header at all.
+
+### Environment reference, and what each knob can move
+
+Every variable is classified. The test being applied is *"can this change the
+measured quantity while the harness is working correctly?"* — not *"does it
+affect the run"*, which is true of all of them.
+
+**Artifact-affecting** — must enter the hashed config, or two genuinely
+different measurements collide on one `configHash`:
+
+| variable | effect | how it is hashed |
+|---|---|---|
+| `LME_MODEL_PROFILE` | selects the judge/reader pins | via `manifest.judge` / `manifest.reader` — the pins themselves |
+| `LME_ARMS` | which arms run | `manifest.arms` (`run.ts` records the SELECTED arms, not `ALL_ARMS`) |
+| `LME_FULL_CTX` | full-context arm window | `manifest.fullContext` |
+| *(implicit)* both Harper arms selected ⇒ shared-store ingest-reuse | store topology | `manifest.ingestion.harperStoreSharing` |
+
+`LME_FULL_CTX` defaults to `131072`, the pinned publishable value. A ~100k-token
+prefill is minutes per call, so a validation slice may reduce it (e.g. `16384`)
+— the value used is folded into the config hash, so a reduced window is never
+silent. Reduce it ONLY for validation.
+
+The store-topology entry is the subtle one and is a **measurement-validity**
+property, not an optimisation. See "Ingest-reuse" below.
+
+**Operational-only** — cannot change the measured quantity under correct
+operation; they govern whether the run completes, how fast, and what telemetry
+it emits. If one of these ever moves a number, that is a bug to fix, not a
+variant to hash — hashing it would content-address the breakage:
+
+| variable | purpose | why it cannot move a number |
+|---|---|---|
+| `LME_OLLAMA_HOST`, `LME_OLLAMA_KEY_FILE` | endpoint + credentials | `assertModelPinned()` aborts unless the served digest matches the pin, so any endpoint either serves the pinned weights or the run stops |
+| *(429/5xx backoff)* | cloud rate-limit resilience | the request body is byte-identical on every attempt at temp 0 / seed 0, so a retry turns "no answer" into the same answer; only 429 and 5xx retry, everything else still fails loud |
+| `LME_RECORDS_JSONL` | per-eval JSONL journal | pure write-side observer — nothing reads it during a normal run, so no field it records can feed back into a result |
+| `LME_RESUME=1` | resume from the journal | banked `(question, arm)` pairs are replayed, never re-evaluated, so the decision set is unchanged; `runHash` is resume-invariant (see caveat below) |
+| `LME_PROGRESS_FILE` | machine-readable progress | write-only telemetry, never read back |
+| `LME_INGEST_CONCURRENCY` | ingest parallelism (default 6) | memories are fully determined by the dataset, so the store end-state is identical at any concurrency |
+| `LME_FLAIR_PKG_DIR`, `LME_HARPER_BIN_DIR` | locate the system under test | say *where* Flair lives, not how it behaves |
+| `LME_BENCH_HOST` | provenance label | lands in the artifact's unhashed provenance partition |
+| `LME_SHARED_COUNT_PROBE=1` | row-count probe logging | logging only |
+
+### Ingest-reuse (shared store, alternating mode)
+
+When both Harper arms are selected, one ingest per question serves both. This
+exists for **validity**, not speed. Under the older whole-arm phasing the
+`flair` arm ran over a store that grew question by question while `vector-only`
+ran over an already-full-size store; filtered-ANN candidate recall degrades as
+the HNSW graph grows, so `vector-only` faced a systematically harder task — an
+asymmetry biased *toward* the result we would most like to be true. Alternating
+the mode per question over one shared store makes both arms query the
+byte-identical store state.
+
+A shared-store run and a per-arm-store run therefore must never share a
+`configHash`: one of them contains a confound, and hashing the topology is what
+stops them being compared as if interchangeable. (It is also ~2× faster — the
+reason it was reachable, not the reason it is correct.)
+
+### Resume, and what the hashes actually guarantee
+
+`runHash` content-addresses the run's **decisions** (answer / verdict /
+tokensFed / extraction) and is resume-invariant. `configHash` is deterministic
+from the config.
+
+`artifactHash` covers the whole aggregate, which includes latency percentiles —
+wall clock. **Artifact hashes are therefore not host- or wall-clock invariant**;
+`configHash` and `runHash` are the reproducible identities. Banked journal lines
+carry their original `latencyMs` so a resumed run replays latency faithfully,
+but a journal written before that field existed falls back to `0`.
+
+### What "reproducible" does and does not mean here
+
+Be precise about this, because the claim is the product.
+
+**Reproducible:** `configHash`. It is a pure function of the pinned config, so
+any checkout with the same profile and slice derives it exactly. The
+reproduction of the published headline `configHash` from repo code is asserted
+in `test/unit/longmemeval-repro.test.ts`.
+
+#### Reproducing a past run as the harness evolves
+
+The manifest **is expected to grow** — every new measurement variant adds a
+field, and #1364's `prompts.readerPayloadFormat` is the first example. That
+creates an obvious tension: an old artifact's `configHash` was computed over a
+manifest that did not have the new field, so current code cannot emit that hash
+directly.
+
+The resolution is that a historical run is reproduced by **reconstructing the
+manifest as that run recorded it** — projecting the current manifest onto
+exactly the key set the artifact carries — and checking the reconstruction
+hashes to the recorded `configHash`. `test/unit/longmemeval-repro.test.ts` does
+this for every artifact in `results/`, and the behavior is deliberately
+asymmetric:
+
+- **a field is added** — the projection drops it, the old hash still reproduces,
+  nothing needs rewriting. The new field still governs the identity of *new*
+  runs through the normal `configHash` path.
+- **a pinned value the old run depended on changes**, or **a field it had is
+  removed** — the reconstruction fails, because that genuinely means the repo
+  can no longer express the configuration behind a published number.
+
+So the rule when that test fails: **do not re-pin the expected hash and do not
+relax the projection.** Either the change was unintended, or the affected
+headline must be re-run and its artifact replaced — a real decision with a real
+cost, which is exactly what the test is there to force.
+
+Adding a new headline? Commit its artifact to `results/` and add a row to
+`HISTORICAL_VARIANTS`. Old rows stay; the repo accumulates the ability to
+reproduce every number it has published.
+
+**Reproducible in practice:** the assembled reader prompt. A clean-checkout
+`n=2` run reproduced the headline run's `tokensFed` exactly — 3174 / 3159 /
+4548 / 4722 across four `(question, arm)` pairs — i.e. retrieval and payload
+formatting are byte-faithful.
+
+**NOT reproducible under the `cloud` profile:** `runHash`, because it
+content-addresses the reader's answer text and **the cloud reader is not
+deterministic at temperature 0 / seed 0**. Measured directly on
+`qwen3.5:397b` via ollama.com: four calls with a byte-identical prompt
+(32 prompt tokens each) returned **three distinct completions**, diverging
+after a 68-character common prefix ("Two is unusual…" vs "The number 2 is
+unusual…"). This is a property of batched cloud inference — MoE routing and
+mixed-precision kernels are not bitwise-stable across batch composition — not
+of this harness.
+
+The practical consequence: under `cloud`, two faithful runs of the same config
+agree on what was measured and on the questions asked, and their **verdicts**
+agreed 4/4 in the sample above, but their `runHash` and `artifactHash` will
+differ. A published cloud number is a *statistical* result to be re-run and
+compared within variance, not a hash anyone can re-derive — which is why the
+run count and the reported std matter.
+
+The `local` profile runs single-stream against a pinned local digest and is
+expected to be closer to bitwise-stable, but that has **not** been measured;
+do not claim it without a measurement. (The cloud *judge* returned an identical
+verdict 4/4 in the same probe, but on a trivial 16-token prompt — that is not
+evidence of judge determinism on real rubric prompts.)
 
 ## The publish gate is structural
 

--- a/test/bench/longmemeval/config.ts
+++ b/test/bench/longmemeval/config.ts
@@ -31,32 +31,104 @@ export const DATASET = {
   totalQuestions: 500,
 } as const;
 
-// ── Judge: gemma4:31b-it-q8_0, LOCAL on Newton via Ollama ────────────────────
-// Pinned by manifest digest (immutable); the GGUF weights blob sha256 is
-// recorded too, as an even-more-verifiable content hash of the weights.
-export const JUDGE = {
-  model: "gemma4:31b-it-q8_0",
-  manifestDigest: "sha256:53dd8459790f8795177444daa9e33f417e03c0d1cdedb80b6c73898603d20aef",
-  weightsSha256: "sha256:a0feadb736f521df6de4b1bd3cbf06c00f9fd04570ddc1e47b8ec9ecbbd6b51d",
-  family: "gemma4",
-  temperature: 0,
-  seed: 0,
-  numCtx: 8192,
-  numPredict: 16,
+// ── Model profiles: `local` (Newton) and `cloud` (ollama.com) ────────────────
+//
+// ARTIFACT-AFFECTING, and already captured with no new hashed field. The judge
+// and reader are different MODELS across profiles, so they trivially change
+// what is measured — but `configManifest()` has always folded the whole JUDGE
+// and READER objects (model + manifestDigest + family + sampling params) into
+// the hash. Selecting a profile therefore changes the configHash through the
+// pins themselves, exactly as pulling a different model would.
+//
+// This is why the selector must NOT add a `modelProfile` key to the manifest:
+// the profile name is a redundant restatement of the pins, and adding it would
+// change the hash of every LOCAL run that has already been published for no
+// gain in information. The pins ARE the identity; the profile name is a
+// convenience for choosing between two pinned sets.
+//
+// Ported from tps-bench (2026-08-20), where the headline runs were made. The
+// VM edited these constants IN PLACE to the cloud values — which is precisely
+// the drift #1366 is about: the repo could then only express the local pins,
+// so a clean checkout could not reproduce the published configHash at all.
+// Both pinned sets now live here and `local` remains the default, so an
+// unset environment reproduces pre-port behavior byte-for-byte.
+export type ModelProfile = "local" | "cloud";
+export const MODEL_PROFILE: ModelProfile = (() => {
+  // `|| "local"`, not `?? "local"`: an env var exported as EMPTY is the shell's
+  // ordinary way of saying "unset" (`LME_MODEL_PROFILE= bun run ...`, or a CI
+  // runner materialising an undefined secret), and treating that as an invalid
+  // value would fail a run that asked for nothing unusual. Any NON-EMPTY value
+  // that is not a known profile is still fatal — an unrecognised profile must
+  // never quietly resolve to a default and mislabel the artifact's pins.
+  const raw = process.env.LME_MODEL_PROFILE || "local";
+  if (raw !== "local" && raw !== "cloud") {
+    throw new Error(
+      `LME_MODEL_PROFILE must be "local" or "cloud" (got "${raw}"). ` +
+      `local = the Newton pins; cloud = the ollama.com pins used for the published headline run.`,
+    );
+  }
+  return raw;
+})();
+
+// Judge: Gemma family. LOCAL is pinned by manifest digest (immutable) plus the
+// GGUF weights blob sha256, an even-more-verifiable content hash of the
+// weights. CLOUD cannot offer a weights hash — ollama.com does not publish
+// one — so the field records that explicitly rather than being dropped: a
+// missing key and a knowingly-unavailable key must not hash the same.
+const JUDGE_PROFILES = {
+  local: {
+    model: "gemma4:31b-it-q8_0",
+    manifestDigest: "sha256:53dd8459790f8795177444daa9e33f417e03c0d1cdedb80b6c73898603d20aef",
+    weightsSha256: "sha256:a0feadb736f521df6de4b1bd3cbf06c00f9fd04570ddc1e47b8ec9ecbbd6b51d",
+    family: "gemma4",
+    temperature: 0,
+    seed: 0,
+    numCtx: 8192,
+    numPredict: 16,
+  },
+  cloud: {
+    // Tag "gemma4:31b" is the cloud-API name for gemma4:31b-cloud; digest
+    // recorded from ollama.com /api/tags on 2026-08-20.
+    model: "gemma4:31b",
+    manifestDigest: "sha256:221b330d11a8",
+    weightsSha256: "cloud-hosted:not-published",
+    family: "gemma4",
+    temperature: 0,
+    seed: 0,
+    numCtx: 8192,
+    numPredict: 16,
+  },
 } as const;
 
-// ── Reader: qwen3.6:27b-coding-mxfp8 (Qwen family) ───────────────────────────
-// A DIFFERENT family than the Gemma judge — the self-preference control
-// (judge family != reader family). Pinned by manifest digest.
-export const READER = {
-  model: "qwen3.6:27b-coding-mxfp8",
-  manifestDigest: "sha256:a7185d39ff35a472a2721b87e1bbb90810bcd381d415666ce2137838e66f2780",
-  family: "qwen3_5",
-  temperature: 0,
-  seed: 0,
-  numCtx: 16384,       // retrieval arms (flair / vector-only / no-context)
-  numPredict: 256,
+// Reader: Qwen family — a DIFFERENT family than the Gemma judge, which is the
+// self-preference control (judge family != reader family, asserted below).
+// The cloud profile keeps family "qwen3_5", so the control is preserved across
+// profiles rather than quietly depending on which one you ran.
+const READER_PROFILES = {
+  local: {
+    model: "qwen3.6:27b-coding-mxfp8",
+    manifestDigest: "sha256:a7185d39ff35a472a2721b87e1bbb90810bcd381d415666ce2137838e66f2780",
+    family: "qwen3_5",
+    temperature: 0,
+    seed: 0,
+    numCtx: 16384,       // retrieval arms (flair / vector-only / no-context)
+    numPredict: 256,
+  },
+  cloud: {
+    // Strongest general Qwen-family cloud tag; digest recorded from
+    // ollama.com /api/tags on 2026-08-20.
+    model: "qwen3.5:397b",
+    manifestDigest: "sha256:b909ca2f1b7f",
+    family: "qwen3_5",
+    temperature: 0,
+    seed: 0,
+    numCtx: 16384,
+    numPredict: 256,
+  },
 } as const;
+
+export const JUDGE = JUDGE_PROFILES[MODEL_PROFILE];
+export const READER = READER_PROFILES[MODEL_PROFILE];
 
 // The full-context arm needs a much larger (still fixed, still pinned) window
 // to hold a ~115k-token haystack — its job is to be the ceiling, so it must

--- a/test/bench/longmemeval/eval.ts
+++ b/test/bench/longmemeval/eval.ts
@@ -17,12 +17,15 @@ import {
   startHarper, stopHarper, type HarperInstance,
 } from "../../helpers/harper-lifecycle";
 import {
-  mkAgent, registerAgent, ingestSessionHistory, retrieveContext, type BenchClient,
+  mkAgent, registerAgent, ingestSessionHistory, retrieveContext, adminOp, signedFetch,
+  type BenchClient, type TestAgent,
 } from "../../../packages/flair-bench/lib/index";
 import { OLLAMA_HOST, READER, JUDGE, RETRIEVAL, FULL_CONTEXT } from "./config";
 import { generate } from "./ollama";
 import { buildJudgePrompt, parseVerdict, JudgeParseError, type LmeTask } from "./judge";
-import { buildReaderPrompt, formatRetrieved, formatFullContext, HARPER_ARMS, type Arm } from "./arms";
+import { buildReaderPrompt, formatRetrieved, formatFullContext, HARPER_ARMS, ALL_ARMS, type Arm } from "./arms";
+import { writeFileSync, rmSync, appendFileSync, readFileSync, existsSync } from "node:fs";
+import { randomUUID } from "node:crypto";
 import { scoreExtraction } from "./extraction";
 import {
   entryToSessions, toSessionHistories, abilityOf, isAbstention, FACTUAL_ABILITIES,
@@ -39,6 +42,160 @@ export interface RunOptions {
 }
 
 const clean = (s: string) => s.replace(/<think>[\s\S]*?<\/think>/gi, "").trim();
+
+// ═══════════════════════════════════════════════════════════════════════════
+// ARTIFACT-AFFECTING vs OPERATIONAL-ONLY (flair#1366)
+//
+// Everything below was ported from tps-bench, where it was written DURING the
+// headline runs. Each knob is classified, and the test that decides it is:
+//
+//   ARTIFACT-AFFECTING — under CORRECT operation, two runs that differ only in
+//     this setting can legitimately report different numbers. It must enter the
+//     hashed config, or the two runs collide on one configHash and the artifact
+//     stops identifying what was measured.
+//
+//   OPERATIONAL-ONLY — under CORRECT operation it cannot change the measured
+//     quantity. It governs whether the run COMPLETES, how long it takes, and
+//     what telemetry is emitted. If one of these ever does change a number,
+//     that is a BUG to fix, not a variant to hash — hashing it would mint a
+//     fresh content-address for a broken run and hide the breakage.
+//
+// The distinction is not "does it touch the run" (all of them do). It is
+// "can it change the answer while everything is working".
+//
+//   ARTIFACT-AFFECTING   SELECTED_ARMS            -> manifest.arms (run.ts)
+//                        shared-store ingest-reuse -> manifest.ingestion
+//                                                     .harperStoreSharing
+//                        model profile             -> manifest.judge/.reader
+//                                                     (config.ts, via the pins)
+//
+//   OPERATIONAL-ONLY     INGEST_CONCURRENCY, RECORDS_JSONL journal (+ its
+//                        rankedIds/retrievalMs/cfg/latencyMs fields),
+//                        LME_RESUME, PROGRESS_FILE, readiness deadline /
+//                        restart-retry / nonce probe, 429+5xx backoff
+//                        (ollama.ts), LME_FLAIR_PKG_DIR / LME_HARPER_BIN_DIR /
+//                        LME_BENCH_HOST path+provenance overrides (run.ts).
+//
+// Each declaration below states its own reasoning; see also the README table.
+// ═══════════════════════════════════════════════════════════════════════════
+
+// ── Arm selection (2026-08-21, headline run): LME_ARMS=comma,list ────────────
+// ARTIFACT-AFFECTING — recorded as manifest.arms by run.ts. A 3-arm run and a
+// 4-arm run are different measurements over the same dataset (different
+// aggregate content, and the contamination/ceiling reads that depend on the
+// missing arms simply do not exist), so they must not share a configHash.
+//
+// Default = all four arms (zero behavior change when unset). An unknown arm
+// name is a FATAL config error — a typo must never silently skip an arm, which
+// would otherwise be indistinguishable from a deliberate subset.
+// Canonical ALL_ARMS order is preserved regardless of list order.
+export const SELECTED_ARMS: Arm[] = (() => {
+  const raw = (process.env.LME_ARMS ?? ALL_ARMS.join(","))
+    .split(",").map((s) => s.trim()).filter(Boolean);
+  for (const a of raw) {
+    if (!(ALL_ARMS as string[]).includes(a)) {
+      throw new Error(`LME_ARMS contains unknown arm "${a}" (valid: ${ALL_ARMS.join(", ")})`);
+    }
+  }
+  return ALL_ARMS.filter((a) => raw.includes(a));
+})();
+
+// ── Ingest client concurrency (2026-08-21, resize prep): LME_INGEST_CONCURRENCY
+// OPERATIONAL-ONLY. Parallel PUT workers for ingestSessionHistory (lib default
+// 6). Throughput only: the memories are fully determined by the dataset (ids,
+// content and timestamps all come from the entry, none are generated at write
+// time), so the store END-STATE is identical at any concurrency. What varies is
+// the interleaving of writes within a batch window — and that nondeterminism
+// already exists at the shipped default of 6, so pinning it would advertise a
+// determinism the harness has never had. Logged rather than hashed.
+// Raise to ~2× cores on bigger VMs.
+const INGEST_CONCURRENCY = Math.max(1, parseInt(process.env.LME_INGEST_CONCURRENCY ?? "6", 10) || 6);
+
+// ── Per-eval journal (take-4 post-mortem, 2026-08-22): LME_RECORDS_JSONL ─────
+// OPERATIONAL-ONLY, and the cleanest case of it: this is a pure WRITE-SIDE
+// observer. It appends a line describing a result that already exists; nothing
+// downstream of the eval reads it during a normal run, so no field it records
+// — rankedIds, retrievalMs, cfg, latencyMs — can feed back into an answer, a
+// verdict, or a metric. Adding a field to the journal cannot move a number,
+// which is exactly why the journal is free to be verbose.
+//
+// Take-4 died 13h in with every per-question result held in-memory only —
+// unrecoverable. When set, every eval is appended as one JSON line the moment
+// it exists, so a crashed run's completed evals survive on disk.
+const RECORDS_JSONL = process.env.LME_RECORDS_JSONL;
+
+// configHash carried on every new journal line (take-5 gap: lines had no
+// config identity; resume validation had to fall back to dataset spot-checks).
+// Journal metadata only — never read back into a result.
+let JOURNAL_CFG = "";
+export function setJournalContext(configHash: string): void { JOURNAL_CFG = configHash.slice(0, 16); }
+
+// ── Resume (take-5 crash, 2026-08-22): LME_RESUME=1 ─────────────────────────
+// OPERATIONAL-ONLY with one honest caveat, stated precisely because a reviewer
+// should be able to check it rather than take it on faith.
+//
+// Resume loads the per-eval journal, SKIPS (question, arm) pairs already
+// recorded, and replays the banked lines into results. A skipped pair is never
+// re-evaluated, so no answer or verdict is regenerated — a resumed run and an
+// uninterrupted run produce the SAME set of decisions. `runHash` content-
+// addresses exactly those decisions (answer/verdict/tokensFed/extraction, see
+// runOnce below) and is therefore resume-invariant.
+//
+// CAVEAT: `artifactHash` covers the whole aggregate, which includes
+// latencyP50Ms/latencyP95Ms — wall clock. Banked lines carry their original
+// `latencyMs`, so a journal written by this code replays latency faithfully;
+// but a line from BEFORE the journal recorded latencyMs falls back to 0 and
+// would drag those percentiles down. Accuracy metrics are exact either way.
+// Note this is a property of artifactHash generally, not of resume: artifact
+// hashes are not wall-clock invariant, so `configHash` + `runHash` are the
+// reproducible identities. (Tracked as a separate finding on #1366.)
+//
+// Extraction is recomputed from the dataset rather than journalled, so an
+// extraction-method change cannot be silently inherited from an old journal.
+interface BankedLine {
+  questionId: string; arm: Arm; ability: string; isAbstention: boolean;
+  answer: string; verdict: string | null; judgeError: string | null; tokensFed: number;
+}
+export function loadResumeJournal(path: string): Map<string, Map<Arm, BankedLine>> {
+  const out = new Map<string, Map<Arm, BankedLine>>();
+  const lines = readFileSync(path, "utf8").split("\n").filter((l) => l.trim());
+  for (const [i, raw] of lines.entries()) {
+    let l: BankedLine;
+    try { l = JSON.parse(raw); } catch { throw new Error(`resume: journal line ${i + 1} unparseable`); }
+    if (!l.questionId || !l.arm) throw new Error(`resume: journal line ${i + 1} missing questionId/arm`);
+    if (!out.has(l.questionId)) out.set(l.questionId, new Map());
+    const arms = out.get(l.questionId)!;
+    if (arms.has(l.arm)) throw new Error(`resume: duplicate (${l.questionId}, ${l.arm}) at journal line ${i + 1}`);
+    arms.set(l.arm, l);
+  }
+  return out;
+}
+
+// ── Machine-readable progress (2026-08-21, headline run): LME_PROGRESS_FILE ──
+// OPERATIONAL-ONLY — write-only telemetry for a watcher; never read back.
+// Written after EVERY (question, arm) evaluation, and stamped done:true (with
+// the artifact path) by run.ts after the artifact is written. `questionsDone`
+// counts (question, arm) units; `totalQuestions` is questions × selected arms
+// (unit recorded in the file so a watcher never misreads the denominator).
+const PROGRESS_FILE = process.env.LME_PROGRESS_FILE;
+const progressState = {
+  startedAt: new Date().toISOString(),
+  unit: "question-arm",
+  totalQuestions: 0,
+  questionsDone: 0,
+  arm: "",
+  verdictCounts: { CORRECT: 0, INCORRECT: 0, NOT_ATTEMPTED: 0 } as Record<string, number>,
+  errors: 0,
+  done: false,
+  artifactPath: null as string | null,
+  updatedAt: "",
+};
+export function writeProgress(patch: Partial<typeof progressState> = {}): void {
+  if (!PROGRESS_FILE) return;
+  Object.assign(progressState, patch);
+  progressState.updatedAt = new Date().toISOString();
+  try { writeFileSync(PROGRESS_FILE, JSON.stringify(progressState, null, 2)); } catch { /* progress is best-effort */ }
+}
 
 /** One reader call for a given assembled context. */
 async function readerAnswer(
@@ -80,6 +237,24 @@ async function evalOne(
   const r = await readerAnswer(host, entry.question, entry.question_date, context, arm);
   const abstention = isAbstention(entry);
   const j = await judgeOne(host, entry.question_type, entry.question, entry.answer, r.answer, abstention);
+  if (j.verdict) progressState.verdictCounts[j.verdict] = (progressState.verdictCounts[j.verdict] ?? 0) + 1;
+  else progressState.errors++;
+  writeProgress({ questionsDone: progressState.questionsDone + 1, arm });
+  if (RECORDS_JSONL) {
+    try {
+      appendFileSync(RECORDS_JSONL, JSON.stringify({
+        questionId: entry.question_id, arm, ability: abilityOf(entry), isAbstention: abstention,
+        answer: r.answer, verdict: j.verdict, judgeError: j.judgeError ?? null,
+        tokensFed: r.tokensFed, latencyMs: r.latencyMs + (extra.retrievalMs ?? 0),
+        // Journal-completeness (2026-08-23): retrieval wall-clock SEPARATE from
+        // reader latency, and the retrieved ids in final rank order — without
+        // these a wrong answer can't be attributed retrieval-vs-reader, nor
+        // retrieval latency separated, from the journal alone.
+        retrievalMs: extra.retrievalMs ?? null, rankedIds: extra.rankedIds ?? null,
+        cfg: JOURNAL_CFG, at: new Date().toISOString(),
+      }) + "\n");
+    } catch { /* journal is best-effort */ }
+  }
   return {
     questionId: entry.question_id,
     ability: abilityOf(entry),
@@ -97,18 +272,25 @@ async function evalOne(
   };
 }
 
-/** The no-Harper arms: full-context (whole haystack) and no-context (nothing). */
-async function runNoHarperArms(host: string, entries: LmeEntry[], log: (s: string) => void): Promise<QuestionArmResult[]> {
+/** The no-Harper arms: full-context (whole haystack) and no-context (nothing).
+ *  Each runs only when selected (LME_ARMS). */
+async function runNoHarperArms(
+  host: string, entries: LmeEntry[], log: (s: string) => void,
+  isDone: (qid: string, arm: Arm) => boolean = () => false,
+): Promise<QuestionArmResult[]> {
+  const doFc = SELECTED_ARMS.includes("full-context");
+  const doNc = SELECTED_ARMS.includes("no-context");
   const out: QuestionArmResult[] = [];
   for (const entry of entries) {
-    const sessions = entryToSessions(entry);
-    // full-context
-    const fc = formatFullContext(sessions, FULL_CONTEXT.charBudget);
-    out.push(await evalOne(host, entry, "full-context", fc.text, { truncated: fc.truncated }));
+    if (doFc && !isDone(entry.question_id, "full-context")) {
+      const sessions = entryToSessions(entry);
+      const fc = formatFullContext(sessions, FULL_CONTEXT.charBudget);
+      out.push(await evalOne(host, entry, "full-context", fc.text, { truncated: fc.truncated }));
+    }
     // no-context (the contamination probe): zero memory
-    out.push(await evalOne(host, entry, "no-context", "", {}));
+    if (doNc && !isDone(entry.question_id, "no-context")) out.push(await evalOne(host, entry, "no-context", "", {}));
   }
-  log(`  no-Harper arms done (${entries.length} q × 2 arms)`);
+  log(`  no-Harper arms done (${entries.length} q × ${(doFc ? 1 : 0) + (doNc ? 1 : 0)} arms)`);
   return out;
 }
 
@@ -124,14 +306,20 @@ async function runHarperArm(
   const out: QuestionArmResult[] = [];
   try {
     log(`  [${arm}] spawning ephemeral Harper (hybrid=${hybrid})...`);
-    harper = await startHarper({ cwd: opts.repoRoot, harperBinDir: opts.repoRoot });
+    harper = await startHarper({
+      // tps-bench: cwd => the npm-installed published @tpsdev-ai/flair package
+      // (the system under test), harperBinDir => the install root (npm hoists
+      // harper there). Unset => original worktree behavior.
+      cwd: process.env.LME_FLAIR_PKG_DIR ?? opts.repoRoot,
+      harperBinDir: process.env.LME_HARPER_BIN_DIR ?? opts.repoRoot,
+    });
     for (let qi = 0; qi < entries.length; qi++) {
       const entry = entries[qi]!;
       const agent = mkAgent(`lme-${arm}-${entry.question_id}`);
       await registerAgent(harper, agent);
       const client: BenchClient = { harper, agent };
       const sessions = entryToSessions(entry);
-      const ingest = await ingestSessionHistory(client, toSessionHistories(sessions));
+      const ingest = await ingestSessionHistory(client, toSessionHistories(sessions), { concurrency: INGEST_CONCURRENCY });
       await waitSearchable(client, sessions);
       const t0 = performance.now();
       const ctx = await retrieveContext(client, entry.question, { limit: RETRIEVAL.readerTopK, scoring: RETRIEVAL.scoring });
@@ -150,17 +338,313 @@ async function runHarperArm(
   return out;
 }
 
+/**
+ * Ingest-reuse mode (take-2, 2026-08-21): ONE ingest per question serves BOTH
+ * Harper arms.
+ *
+ * ARTIFACT-AFFECTING — recorded by run.ts as
+ * `ingestion.harperStoreSharing = "ingest-once-shared-store-alternating-mode"`
+ * (vs "per-arm-store"), and it MUST be, for a reason that is the opposite of
+ * bookkeeping: this is not an optimisation that happens to be observable, it is
+ * a MEASUREMENT-VALIDITY property. The two topologies genuinely measure
+ * different things, and the per-arm topology measures the wrong one.
+ *
+ * Under the old whole-arm phasing, the flair arm ran first over a store that
+ * GREW question by question, then the vector-only arm ran over a store that was
+ * already full size. Filtered-ANN candidate recall degrades as the HNSW graph
+ * grows, so vector-only was being asked a systematically harder question than
+ * flair was — an index-state asymmetry biased FOR flair, i.e. biased toward the
+ * result we would most like to be true. Alternating per question removes it:
+ * both arms query the byte-identical store state (memories 1..i).
+ *
+ * So a shared-store run and a per-arm-store run must never share a configHash.
+ * They are not the same experiment reported at two speeds; one of them contains
+ * a confound. Hashing the topology is what stops a reader from comparing them
+ * as if they were interchangeable.
+ *
+ * (It is also ~2× faster — ingest is embedding compute, ~95% of arm time;
+ * measured 99% 4-core saturation, libuv embed workers hot, JS main thread idle.
+ * That is the reason it was reachable, not the reason it is correct.)
+ *
+ * Design constraint that shapes the loop: hybrid on/off is a Harper
+ * PROCESS-level env (read per-call server-side, but not per-request), and the
+ * HNSW index grows as questions accumulate. A naive "flair phase then
+ * vector-only phase" would have vector-only querying a full-size index while
+ * flair queried a growing one — a systematic index-state asymmetry biased FOR
+ * flair (filtered-ANN candidate recall degrades as the graph grows). So we
+ * ALTERNATE the Harper's mode per question over ONE shared store
+ * (StartHarperOptions.installDir reuse — the lifecycle's documented shape).
+ * Each phase: the arm matching the current mode (1) queries the question
+ * ingested in the PREVIOUS phase (query-only, ZERO ingest), then (2) ingests
+ * and queries the NEXT question; then the store restarts with the mode
+ * flipped.
+ *
+ * Effect: every question is ingested exactly once, and BOTH arms query it
+ * against the byte-identical store state (memories 1..i) — exact per-question
+ * index parity, 1 restart per question (~10-20s each vs ~700s saved per
+ * question). Queries are agent-scoped (one agent per question, keypair held
+ * in-memory across restarts), so results never see other questions' memories.
+ */
+async function runHarperArmsShared(
+  entries: LmeEntry[], opts: RunOptions, host: string,
+  isDone: (qid: string, arm: Arm) => boolean = () => false,
+): Promise<QuestionArmResult[]> {
+  const log = opts.log ?? (() => {});
+  const prev = process.env.FLAIR_HYBRID_RETRIEVAL;
+  const startOpts = () => ({
+    cwd: process.env.LME_FLAIR_PKG_DIR ?? opts.repoRoot,
+    harperBinDir: process.env.LME_HARPER_BIN_DIR ?? opts.repoRoot,
+  });
+  const countProbe = process.env.LME_SHARED_COUNT_PROBE === "1";
+  const out: QuestionArmResult[] = [];
+  const agents = new Map<string, TestAgent>();
+  const restartMs: number[] = [];
+  let ingests = 0;
+  const phaseIngests: Record<string, number> = { flair: 0, "vector-only": 0 };
+  let hybrid = true;
+  process.env.FLAIR_HYBRID_RETRIEVAL = "true";
+  log(`  [shared] ingest-reuse: one ingest/question serves both Harper arms; alternating mode flip (1 restart/question) keeps exact per-question index parity`);
+  let harper = await startHarper(startOpts());
+  const installDir = harper.installDir;
+  log(`  [shared] store: ${installDir}`);
+
+  /** Memory row count via the ops API — smoke-mode proof that both arms query
+   *  the same corpus and that a query-only phase ingested nothing. */
+  async function memoryRows(): Promise<number | string> {
+    const res = await adminOp(harper, { operation: "sql", sql: "SELECT COUNT(*) AS n FROM flair.Memory" });
+    if (!res.ok) return `probe-failed HTTP ${res.status}`;
+    const j: any = await res.json().catch(() => null);
+    const row = Array.isArray(j) ? j[0] : j;
+    return row?.n ?? row?.["COUNT(*)"] ?? JSON.stringify(row).slice(0, 60);
+  }
+
+  // ── Readiness hardening (take-4 post-mortem, 2026-08-22) ──────────────────
+  // OPERATIONAL-ONLY — and this is the classification most worth challenging,
+  // so here is the argument in full.
+  //
+  // A readiness gate obviously CAN move a number: pass too early and the arm
+  // queries a half-indexed corpus and scores as a retrieval miss. The reason it
+  // is still operational-only is that the gate is a CORRECTNESS PRECONDITION,
+  // not a measurement parameter. Its contract is binary — "this question's
+  // corpus is fully persisted and embedded" — and it is applied per question,
+  // before EITHER arm queries, so it cannot tilt one arm against the other. A
+  // gate that passes early does not produce a different valid measurement; it
+  // produces an INVALID one. Hashing the deadline would content-address the
+  // breakage and make a broken run look like a legitimate variant.
+  //
+  // What makes that argument hold in practice is the shape of the gate itself
+  // (see "Readiness gate v2" below): the hard gate is a DETERMINISTIC,
+  // SCALE-INDEPENDENT predicate — the row exists and its embeddingModel stamp
+  // is set — so there is no threshold to tune and nothing for a reviewer to
+  // suspect of having been tuned toward a nicer result. The one gate that WAS
+  // scale-sensitive and ranking-based got demoted to non-fatal telemetry for
+  // exactly this reason.
+  //
+  // The deadline and the restart-retry are therefore about not dying, not about
+  // when to look: they bound how long we wait for that predicate to go true.
+  //
+  // Post-restart index readiness lags /health and GROWS with store size (fixed
+  // 45s deadline died at ~66k rows, 13h in). Deadline scales from MEASURED
+  // waits: 6× the max observed, floor 90s, cap 20min. On a blown deadline: ONE
+  // same-mode store restart (flushes/reloads index pipelines) and one retry at
+  // the same deadline before failing the run — then it FAILS, loudly. There is
+  // no "give up and query anyway" path, which is what would make this
+  // artifact-affecting.
+  let maxSearchWaitMs = 5_000; // scaling floor
+  const searchDeadlineMs = () => Math.min(1_200_000, Math.max(90_000, 6 * maxSearchWaitMs));
+  async function restartSameMode(): Promise<void> {
+    const t0 = performance.now();
+    await stopHarper(harper, { keepInstallDir: true });
+    harper = await startHarper({ ...startOpts(), installDir });
+    restartMs.push(performance.now() - t0);
+  }
+  // ── Readiness gate v2 (take-5 post-mortem, 2026-08-22) ────────────────────
+  // Take-4/5 both died at q133's PENDING-path check in vector-only mode. Repro
+  // (repro-canary.ts): in a fresh single-question store the same canary ranks
+  // 1-2 in BOTH modes — it was indexed all along. The failure needs the ~66k-
+  // row store: agent-filtered ANN candidate recall collapses at scale for
+  // generic content in pure-vector mode. Conclusion: ANY readiness gate built
+  // on search RANKING can starve at scale — including a nonce self-match. So:
+  //   HARD GATE (deterministic, scale-independent): ops-API SQL — the canary
+  //     row EXISTS and its embeddingModel stamp is set (persisted + embedded).
+  //   SOFT PROBE (telemetry, never fatal): nonce self-query under a separate
+  //     probe agent — watches the search path; logged WARN on miss.
+  // Scaled deadline + one same-mode restart-retry kept as backstops.
+  async function canaryStamped(entry: LmeEntry): Promise<{ ready: boolean; detail: string }> {
+    const events = entryToSessions(entry).flatMap((s) => s.events);
+    const canary = events[events.length - 1];
+    if (!canary) return { ready: true, detail: "no events" };
+    const res = await adminOp(harper, { operation: "sql", sql: `SELECT id, embeddingModel FROM flair.Memory WHERE id = '${canary.id}'` });
+    if (!res.ok) return { ready: false, detail: `sql HTTP ${res.status}` };
+    const j: any = await res.json().catch(() => null);
+    const row = Array.isArray(j) ? j[0] : null;
+    if (!row) return { ready: false, detail: `row ${canary.id} absent` };
+    if (!row.embeddingModel) return { ready: false, detail: `row ${canary.id} embedding unstamped` };
+    return { ready: true, detail: "persisted+stamped" };
+  }
+  async function pollStamped(entry: LmeEntry, deadlineMs: number): Promise<number> {
+    const t0 = Date.now();
+    let last = "";
+    while (Date.now() - t0 < deadlineMs) {
+      const r = await canaryStamped(entry);
+      if (r.ready) return Date.now() - t0;
+      last = r.detail;
+      await new Promise((res) => setTimeout(res, 1000));
+    }
+    throw new Error(`readiness gate: canary for ${entry.question_id} not persisted+stamped within ${deadlineMs}ms (last: ${last})`);
+  }
+  let probeAgent: TestAgent | null = null;
+  async function softSearchProbe(tag: string): Promise<void> {
+    try {
+      if (!probeAgent) {
+        probeAgent = mkAgent(`lme-readiness-probe`);
+        await registerAgent(harper, probeAgent);
+      }
+      const nonce = `readiness-canary readiness-nonce-${randomUUID()}`;
+      const pid = `probe__${Date.now()}__${Math.floor(Math.random() * 1e6)}`;
+      const w = await signedFetch(
+        harper, probeAgent, "PUT", `/Memory/${pid}`,
+        { id: pid, agentId: probeAgent.id, content: nonce, durability: "standard", createdAt: new Date().toISOString() },
+      );
+      if (!w.ok) { log(`  [shared][probe-warn] ${tag}: nonce write HTTP ${w.status}`); return; }
+      const t0 = Date.now();
+      while (Date.now() - t0 < 20_000) {
+        const ctx = await retrieveContext({ harper, agent: probeAgent }, nonce, { limit: 20 });
+        if (ctx.rankedIds.includes(pid)) return; // search path serving
+        await new Promise((res) => setTimeout(res, 1000));
+      }
+      log(`  [shared][probe-warn] ${tag}: nonce not surfacing via search within 20s (hard gate passed; search-path telemetry only)`);
+    } catch (err) {
+      log(`  [shared][probe-warn] ${tag}: ${err instanceof Error ? err.message.slice(0, 120) : String(err)}`);
+    }
+  }
+  async function ensureSearchable(entry: LmeEntry): Promise<void> {
+    const deadline = searchDeadlineMs();
+    try {
+      maxSearchWaitMs = Math.max(maxSearchWaitMs, await pollStamped(entry, deadline));
+    } catch (err) {
+      log(`  [shared] !! readiness timeout (${deadline}ms) for ${entry.question_id} — one same-mode restart+retry: ${err instanceof Error ? err.message.slice(0, 140) : String(err)}`);
+      await restartSameMode();
+      maxSearchWaitMs = Math.max(maxSearchWaitMs, await pollStamped(entry, deadline));
+      log(`  [shared] recovered after restart: ${entry.question_id} ready`);
+    }
+    await softSearchProbe(entry.question_id);
+  }
+
+  /** Query + eval one entry under the CURRENT mode (no ingest here). */
+  async function queryEval(entry: LmeEntry, arm: Arm): Promise<void> {
+    const agent = agents.get(entry.question_id)!;
+    const client: BenchClient = { harper, agent };
+    if (countProbe) log(`  [shared][probe] Memory rows before ${arm} query of ${entry.question_id}: ${await memoryRows()}`);
+    const t0 = performance.now();
+    const ctx = await retrieveContext(client, entry.question, { limit: RETRIEVAL.readerTopK, scoring: RETRIEVAL.scoring });
+    const retrievalMs = performance.now() - t0;
+    out.push(await evalOne(host, entry, arm, formatRetrieved(ctx.items), { retrievalMs, rankedIds: ctx.rankedIds }));
+  }
+
+  async function flipMode(): Promise<void> {
+    const t0 = performance.now();
+    await stopHarper(harper, { keepInstallDir: true });
+    hybrid = !hybrid;
+    process.env.FLAIR_HYBRID_RETRIEVAL = hybrid ? "true" : "false";
+    harper = await startHarper({ ...startOpts(), installDir });
+    restartMs.push(performance.now() - t0);
+  }
+
+  // Resume partitioning: fully-banked questions are skipped outright; a
+  // question with exactly ONE arm banked (the crash boundary) gets its corpus
+  // ingested and ONLY the missing arm queried; the rest run the normal
+  // alternation.
+  const singles: Array<{ entry: LmeEntry; missing: Arm }> = [];
+  const todo: LmeEntry[] = [];
+  for (const e of entries) {
+    const f = isDone(e.question_id, "flair");
+    const v = isDone(e.question_id, "vector-only");
+    if (f && v) continue;
+    if (f || v) singles.push({ entry: e, missing: f ? "vector-only" : "flair" });
+    else todo.push(e);
+  }
+  if (singles.length || entries.length !== todo.length) {
+    log(`  [shared] resume partition: ${entries.length - todo.length - singles.length} fully banked, ${singles.length} single-arm, ${todo.length} to run`);
+  }
+
+  try {
+    for (const { entry, missing } of singles) {
+      const needHybrid = missing === "flair";
+      if (hybrid !== needHybrid) await flipMode();
+      const agent = mkAgent(`lme-shared-${entry.question_id}`);
+      agents.set(entry.question_id, agent);
+      await registerAgent(harper, agent);
+      const client: BenchClient = { harper, agent };
+      const sessions = entryToSessions(entry);
+      await ingestSessionHistory(client, toSessionHistories(sessions), { concurrency: INGEST_CONCURRENCY });
+      ingests++; phaseIngests[missing]! += 1;
+      await ensureSearchable(entry);
+      await queryEval(entry, missing);
+      log(`  [shared] single-arm resume: ${entry.question_id} ${missing} done`);
+    }
+
+    let idx = 0;
+    let pending: LmeEntry | null = null; // ingested last phase; other arm still owes its query
+    entries = todo;
+    while (idx < entries.length || pending) {
+      const arm: Arm = hybrid ? "flair" : "vector-only";
+      // (a) the pending question: QUERY-ONLY under this mode — zero ingest.
+      if (pending) {
+        const entry = pending; pending = null;
+        // canary re-check after restart: index must still serve this corpus
+        await ensureSearchable(entry);
+        await queryEval(entry, arm);
+      }
+      // (b) next question: ingest ONCE + query under this same mode.
+      if (idx < entries.length) {
+        const entry = entries[idx++]!;
+        const agent = mkAgent(`lme-shared-${entry.question_id}`);
+        agents.set(entry.question_id, agent);
+        await registerAgent(harper, agent);
+        const client: BenchClient = { harper, agent };
+        const sessions = entryToSessions(entry);
+        const ingest = await ingestSessionHistory(client, toSessionHistories(sessions), { concurrency: INGEST_CONCURRENCY });
+        ingests++; phaseIngests[arm]! += 1;
+        await ensureSearchable(entry);
+        await queryEval(entry, arm);
+        pending = entry;
+        if (idx % 5 === 0 || idx === entries.length) {
+          const mr = restartMs.length ? (restartMs.reduce((a, b) => a + b, 0) / restartMs.length / 1000).toFixed(1) : "n/a";
+          log(`  [shared] ${idx}/${entries.length} ingested (last: ${ingest.written} events, ${ingest.elapsedMs.toFixed(0)}ms; ingests ${ingests}; restarts ${restartMs.length}, mean ${mr}s; searchWait max ${(maxSearchWaitMs / 1000).toFixed(1)}s, next deadline ${(searchDeadlineMs() / 1000).toFixed(0)}s)`);
+        }
+      }
+      // (c) flip the mode if any work remains.
+      if (idx < entries.length || pending) await flipMode();
+    }
+    log(`  [shared] complete: ${ingests} ingests for ${entries.length} questions × 2 arms = ${out.length} evals ` +
+        `(flair-phase ingests ${phaseIngests.flair}, vector-phase ingests ${phaseIngests["vector-only"]}); ` +
+        `${restartMs.length} restarts, mean ${(restartMs.reduce((a, b) => a + b, 0) / Math.max(1, restartMs.length) / 1000).toFixed(1)}s`);
+  } finally {
+    await stopHarper(harper, { keepInstallDir: false });
+    try { rmSync(installDir, { recursive: true, force: true, maxRetries: 2 }); } catch { /* best effort */ }
+    if (prev === undefined) delete process.env.FLAIR_HYBRID_RETRIEVAL;
+    else process.env.FLAIR_HYBRID_RETRIEVAL = prev;
+  }
+  return out;
+}
+
 /** After ingesting a question's haystack, poll until it is actually searchable
  *  so a not-yet-indexed corpus never scores as a retrieval miss. Canary = the
- *  last ingested event's own content; wait until its id surfaces. */
-async function waitSearchable(client: BenchClient, sessions: ReturnType<typeof entryToSessions>, timeoutMs = 45_000): Promise<void> {
+ *  last ingested event's own content; wait until its id surfaces.
+ *  Returns the observed wait in ms so callers can SCALE future deadlines from
+ *  measured readiness latency (take-4 post-mortem: a fixed 45s deadline died
+ *  13h in — post-restart index readiness lags /health and grows with store
+ *  size; ~66k rows crossed 45s). */
+async function waitSearchable(client: BenchClient, sessions: ReturnType<typeof entryToSessions>, timeoutMs = 45_000): Promise<number> {
   const allEvents = sessions.flatMap((s) => s.events);
   const canary = allEvents[allEvents.length - 1];
-  if (!canary) return;
-  const deadline = Date.now() + timeoutMs;
+  if (!canary) return 0;
+  const t0 = Date.now();
+  const deadline = t0 + timeoutMs;
   while (Date.now() < deadline) {
     const ctx = await retrieveContext(client, canary.content.slice(0, 200), { limit: 20 });
-    if (ctx.rankedIds.includes(canary.id)) return;
+    if (ctx.rankedIds.includes(canary.id)) return Date.now() - t0;
     await new Promise((r) => setTimeout(r, 1000));
   }
   throw new Error(`waitSearchable: canary event ${canary.id} never surfaced within ${timeoutMs}ms (embedding engine slow/down?)`);
@@ -177,15 +661,62 @@ export interface OneRunResult {
 export async function runOnce(runIndex: number, entries: LmeEntry[], opts: RunOptions): Promise<OneRunResult> {
   const host = opts.host ?? OLLAMA_HOST;
   const log = opts.log ?? (() => {});
-  log(`[run ${runIndex}] starting (${entries.length} questions × 4 arms)`);
+  log(`[run ${runIndex}] starting (${entries.length} questions × ${SELECTED_ARMS.length} arms: ${SELECTED_ARMS.join(", ")})`);
+  writeProgress({ totalQuestions: entries.length * SELECTED_ARMS.length });
 
   const results: QuestionArmResult[] = [];
-  results.push(...(await runNoHarperArms(host, entries, log)));
-  results.push(...(await runHarperArm("flair", true, entries, opts, host)));
-  results.push(...(await runHarperArm("vector-only", false, entries, opts, host)));
 
-  const arms: Arm[] = ["flair", "vector-only", "full-context", "no-context"];
-  const armMetrics = arms.map((a) => aggregateArmRun(a, results));
+  // ── Resume: fold banked journal evals into results, skip their pairs. ─────
+  let isDone: (qid: string, arm: Arm) => boolean = () => false;
+  if (process.env.LME_RESUME === "1") {
+    if (!RECORDS_JSONL || !existsSync(RECORDS_JSONL)) {
+      throw new Error(`LME_RESUME=1 but journal ${RECORDS_JSONL ?? "(LME_RECORDS_JSONL unset)"} does not exist`);
+    }
+    const banked = loadResumeJournal(RECORDS_JSONL);
+    const byId = new Map(entries.map((e) => [e.question_id, e]));
+    let n = 0;
+    for (const [qid, arms] of banked) {
+      const entry = byId.get(qid);
+      if (!entry) throw new Error(`resume: journal question ${qid} not in this run's slice — journal/config mismatch`);
+      for (const [arm, l] of arms) {
+        if (!(SELECTED_ARMS as string[]).includes(arm)) continue;
+        results.push({
+          questionId: qid, ability: abilityOf(entry), isAbstention: l.isAbstention, arm,
+          answer: l.answer, verdict: (l.verdict ?? null) as QuestionArmResult["verdict"],
+          judgeError: l.judgeError ?? undefined, extraction: extractionFor(entry, l.answer),
+          tokensFed: l.tokensFed, latencyMs: (l as any).latencyMs ?? 0,
+        });
+        if (l.verdict) progressState.verdictCounts[l.verdict] = (progressState.verdictCounts[l.verdict] ?? 0) + 1;
+        else progressState.errors++;
+        n++;
+      }
+    }
+    progressState.questionsDone = n;
+    isDone = (qid, arm) => banked.get(qid)?.has(arm) ?? false;
+    log(`[resume] ${n} banked evals folded in from ${RECORDS_JSONL}; their (question,arm) pairs will be skipped`);
+    writeProgress({});
+  }
+
+  if (SELECTED_ARMS.includes("full-context") || SELECTED_ARMS.includes("no-context")) {
+    results.push(...(await runNoHarperArms(host, entries, log, isDone)));
+  }
+  const sharedStore = SELECTED_ARMS.includes("flair") && SELECTED_ARMS.includes("vector-only");
+  if (sharedStore) {
+    // Ingest-reuse: one ingest per question serves both Harper arms.
+    results.push(...(await runHarperArmsShared(entries, opts, host, isDone)));
+  } else {
+    if (process.env.LME_RESUME === "1" && (SELECTED_ARMS.includes("flair") || SELECTED_ARMS.includes("vector-only"))) {
+      throw new Error("LME_RESUME=1 is only supported for the shared-store (flair+vector-only) path — a single Harper arm would re-run banked pairs and duplicate results");
+    }
+    if (SELECTED_ARMS.includes("flair")) {
+      results.push(...(await runHarperArm("flair", true, entries, opts, host)));
+    }
+    if (SELECTED_ARMS.includes("vector-only")) {
+      results.push(...(await runHarperArm("vector-only", false, entries, opts, host)));
+    }
+  }
+
+  const armMetrics = SELECTED_ARMS.map((a) => aggregateArmRun(a, results));
 
   // Content-address the run by its DECISIONS (answer/verdict/tokens/extraction),
   // NOT wall-clock latency — a faithful re-run reproduces this hash.

--- a/test/bench/longmemeval/ollama.ts
+++ b/test/bench/longmemeval/ollama.ts
@@ -25,6 +25,23 @@
  * Pure transport + a pin check. No dataset, no prompts, no scoring.
  */
 
+// ── Cloud auth (ported from tps-bench, adopted 2026-08-20) ──────────────────
+// OPERATIONAL-ONLY: transport credentials, deliberately NOT in the hashed
+// config. Which endpoint served a pinned digest cannot change what is
+// measured — assertModelPinned() already fails loud unless the digest matches,
+// so authenticating to ollama.com and authenticating to Newton either serve
+// the SAME pinned weights or the run aborts.
+//
+// The key is referenced BY PATH and read IN-PROCESS: it never appears in argv
+// (so never in shell history, `ps`, or a transcript), never in the artifact,
+// and never in a log line. Unset => no header at all, i.e. byte-identical
+// behavior to a local/Newton run.
+import { readFileSync } from "node:fs";
+const _KEY_FILE = process.env.LME_OLLAMA_KEY_FILE;
+const AUTH_HEADERS: Record<string, string> = _KEY_FILE
+  ? { Authorization: "Bearer " + readFileSync(_KEY_FILE, "utf8").trim() }
+  : {};
+
 export interface OllamaModelSpec {
   model: string;
   /** The immutable manifest digest recorded at pin time (config.ts). */
@@ -74,19 +91,50 @@ export async function generate(
       num_predict: opts.numPredictOverride ?? spec.numPredict,
     },
   };
-  const t0 = performance.now();
-  let res: Response;
-  try {
-    res = await fetch(`${host}/api/generate`, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify(body),
-    });
-  } catch (err) {
-    throw new OllamaError(`generate(${spec.model}) transport failure to ${host}: ${err instanceof Error ? err.message : String(err)}`);
+  // ── Cloud-cap resilience (ported from tps-bench, headline run 2026-08-21) ─
+  // OPERATIONAL-ONLY: HTTP 429 backs off 60s → 300s → 300s before failing; a
+  // 5xx gets ONE 30s retry. Not in the hashed config, and the reasoning is
+  // checkable rather than a matter of taste: the request body is byte-for-byte
+  // identical on every attempt and the model is pinned with temperature 0 /
+  // seed 0 / fixed num_ctx+num_predict, so a retry can only turn "no answer"
+  // into "the same answer this call was always going to produce". It cannot
+  // select among answers — there is no resampling and no prompt mutation.
+  //
+  // Deliberately NARROW: only 429 and 5xx retry, and only for a bounded number
+  // of rounds. Any other status still fails loud. Retrying a 4xx (a malformed
+  // prompt, a wrong model name) would be masking a broken call, and retrying
+  // until success would let a flaky endpoint quietly shape the sample.
+  const RATE_WAITS = [60_000, 300_000, 300_000];
+  let rateAttempt = 0;
+  let serverRetried = false;
+  let t0: number, res: Response, latencyMs: number, text: string;
+  for (;;) {
+    t0 = performance.now();
+    try {
+      res = await fetch(`${host}/api/generate`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json", ...AUTH_HEADERS },
+        body: JSON.stringify(body),
+      });
+    } catch (err) {
+      throw new OllamaError(`generate(${spec.model}) transport failure to ${host}: ${err instanceof Error ? err.message : String(err)}`);
+    }
+    latencyMs = performance.now() - t0;
+    text = await res.text();
+    if (res.status === 429 && rateAttempt < RATE_WAITS.length) {
+      const wait = RATE_WAITS[rateAttempt++]!;
+      console.error(`[ollama] 429 from ${host} — backing off ${wait / 1000}s (round ${rateAttempt}/${RATE_WAITS.length})`);
+      await new Promise((r) => setTimeout(r, wait));
+      continue;
+    }
+    if (res.status >= 500 && !serverRetried) {
+      serverRetried = true;
+      console.error(`[ollama] HTTP ${res.status} from ${host} — one retry in 30s`);
+      await new Promise((r) => setTimeout(r, 30_000));
+      continue;
+    }
+    break;
   }
-  const latencyMs = performance.now() - t0;
-  const text = await res.text();
   if (!res.ok) {
     throw new OllamaError(`generate(${spec.model}) HTTP ${res.status}: ${text.slice(0, 300)}`);
   }
@@ -116,7 +164,7 @@ export async function generate(
 export async function assertModelPinned(host: string, spec: OllamaModelSpec): Promise<{ actualDigest: string }> {
   let res: Response;
   try {
-    res = await fetch(`${host}/api/tags`, { signal: AbortSignal.timeout(10_000) });
+    res = await fetch(`${host}/api/tags`, { headers: AUTH_HEADERS, signal: AbortSignal.timeout(10_000) });
   } catch (err) {
     throw new OllamaError(`assertModelPinned: cannot reach Ollama at ${host}: ${err instanceof Error ? err.message : String(err)}`);
   }
@@ -143,7 +191,7 @@ export async function assertModelPinned(host: string, spec: OllamaModelSpec): Pr
 /** Confirm the host answers at all (a decisive early failure vs a slow timeout
  *  mid-run). Returns the raw /api/tags model names. */
 export async function pingOllama(host: string): Promise<string[]> {
-  const res = await fetch(`${host}/api/tags`, { signal: AbortSignal.timeout(8_000) });
+  const res = await fetch(`${host}/api/tags`, { headers: AUTH_HEADERS, signal: AbortSignal.timeout(8_000) });
   if (!res.ok) throw new OllamaError(`pingOllama: HTTP ${res.status} from ${host}`);
   const j: any = await res.json();
   return (j.models ?? []).map((m: any) => m.name);

--- a/test/bench/longmemeval/repro-canary.ts
+++ b/test/bench/longmemeval/repro-canary.ts
@@ -1,0 +1,144 @@
+#!/usr/bin/env bun
+/**
+ * repro-canary.ts — the diagnostic behind the readiness gate's SHAPE.
+ *
+ * Ported from tps-bench with the harness (flair#1366). It is in the repo
+ * because eval.ts's readiness-gate comment cites it as evidence, and a
+ * classification a reviewer cannot check is a classification taken on faith.
+ *
+ * The question it settled (take-5 post-mortem, 2026-08-22): when the run died
+ * waiting on canary 51a45a95__s50__t11 in vector-only mode, was that canary
+ * UNINDEXED, or indexed but OUTRANKED (present, yet rank > 20 for its own
+ * prefix query)?
+ *
+ * Method: ingest ONLY question 51a45a95's haystack into a fresh ephemeral
+ * Harper with FLAIR_HYBRID_RETRIEVAL=false (the mode of the phase that died),
+ * settle generously, then run the exact check the harness ran
+ * (content.slice(0,200), limit 20) AND a limit-100 query to find the true
+ * rank. Repeat under hybrid=true (the mode of the ingest phase that PASSED).
+ * Also probe the proposed fix: a nonce canary under a SEPARATE probe agent.
+ *
+ * Result: in a fresh single-question store the canary ranks 1-2 in BOTH modes
+ * — it was indexed all along. The failure needs the ~66k-row store, where
+ * agent-filtered ANN candidate recall collapses for generic content in
+ * pure-vector mode.
+ *
+ * Why that matters for the gate: ANY readiness gate built on search RANKING
+ * can starve at scale, including a nonce self-match. So the hard gate became a
+ * deterministic, scale-independent existence+embeddingModel-stamp check, and
+ * the ranking probe was demoted to non-fatal telemetry. That demotion is what
+ * lets the readiness gate be classified OPERATIONAL-ONLY: there is no
+ * scale-sensitive threshold left that could be tuned toward a nicer number.
+ *
+ * Usage:
+ *   bun test/bench/longmemeval/repro-canary.ts --dataset <longmemeval_s.json>
+ */
+import { startHarper, stopHarper } from "../../helpers/harper-lifecycle";
+import {
+  mkAgent, registerAgent, ingestSessionHistory, retrieveContext, signedFetch,
+  type BenchClient, type TestAgent,
+} from "../../../packages/flair-bench/lib/index";
+import { loadDataset, entryToSessions, toSessionHistories } from "./dataset";
+import { randomUUID } from "node:crypto";
+import { rmSync } from "node:fs";
+
+const QID = process.env.LME_CANARY_QID ?? "51a45a95";
+
+// No baked-in dataset path: the VM copy defaulted to an absolute /home path
+// that only existed there. A shipped default that resolves to whatever is on
+// disk is a trust anchor — require it explicitly.
+const argi = process.argv.indexOf("--dataset");
+const datasetPath = (argi >= 0 ? process.argv[argi + 1] : undefined) ?? process.env.LME_DATASET;
+if (!datasetPath) {
+  console.error("repro-canary requires --dataset <path to longmemeval_s.json> (or LME_DATASET)");
+  process.exit(2);
+}
+
+const entries = loadDataset(datasetPath);
+const entry = entries.find((e) => e.question_id === QID);
+if (!entry) {
+  console.error(`repro-canary: question ${QID} not present in ${datasetPath}`);
+  process.exit(2);
+}
+const sessions = entryToSessions(entry);
+const events = sessions.flatMap((s) => s.events);
+const canary = events[events.length - 1]!;
+console.log(`events: ${events.length}; canary id: ${canary.id}`);
+console.log(`canary content (${canary.content.length} ch): ${JSON.stringify(canary.content.slice(0, 300))}`);
+
+const startOpts = {
+  cwd: process.env.LME_FLAIR_PKG_DIR,
+  harperBinDir: process.env.LME_HARPER_BIN_DIR,
+};
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+/** Rank of `id` for `query`, or -1 when absent from the top `limit`. */
+async function rankIn(client: BenchClient, query: string, limit: number, id: string): Promise<number> {
+  const ctx = await retrieveContext(client, query, { limit, scoring: "raw" });
+  return ctx.rankedIds.indexOf(id);
+}
+
+// The question agent is created once and REUSED across both modes: its keypair
+// must survive the restart, or the second pass would query a different agent's
+// (empty) scope and "prove" a starvation that is really an identity change.
+let questionAgent: TestAgent | null = null;
+
+async function testMode(hybrid: boolean, installDir?: string): Promise<string> {
+  process.env.FLAIR_HYBRID_RETRIEVAL = hybrid ? "true" : "false";
+  const harper = await startHarper({ ...startOpts, installDir });
+  const dir = harper.installDir;
+  try {
+    if (!installDir) {
+      questionAgent = mkAgent(`lme-shared-${QID}`);
+      await registerAgent(harper, questionAgent);
+      const c: BenchClient = { harper, agent: questionAgent };
+      const t0 = performance.now();
+      await ingestSessionHistory(c, toSessionHistories(sessions), { concurrency: 16 });
+      console.log(`[hybrid=${hybrid}] ingested in ${((performance.now() - t0) / 1000).toFixed(0)}s`);
+      await sleep(20_000); // generous settle, far beyond anything the harness allows
+    } else {
+      await sleep(10_000);
+    }
+    const client: BenchClient = { harper, agent: questionAgent! };
+
+    const q = canary.content.slice(0, 200);
+    const r20 = await rankIn(client, q, 20, canary.id);   // the harness's exact check
+    const r100 = await rankIn(client, q, 100, canary.id); // the true rank
+    const rFull = await rankIn(client, canary.content.slice(0, 2000), 100, canary.id);
+
+    // The proposed fix shape: a nonce under a SEPARATE probe agent.
+    const probe = mkAgent(`lme-readiness-probe-${hybrid}`);
+    await registerAgent(harper, probe);
+    const pc: BenchClient = { harper, agent: probe };
+    const nonce = `readiness-canary readiness-nonce-${randomUUID()}`;
+    const pid = `probe__${hybrid}__${Date.now()}`;
+    const w = await signedFetch(harper, probe, "PUT", `/Memory/${pid}`, {
+      id: pid, agentId: probe.id, content: nonce, durability: "standard", createdAt: new Date().toISOString(),
+    });
+    if (!w.ok) throw new Error(`probe write failed ${w.status}`);
+    let pRank = -1;
+    const pt0 = Date.now();
+    while (Date.now() - pt0 < 60_000) {
+      pRank = await rankIn(pc, nonce, 20, pid);
+      if (pRank >= 0) break;
+      await sleep(1000);
+    }
+
+    // Agent scoping must hold across the shared store, or ingest-reuse would be
+    // leaking one question's memories into another's retrieval.
+    const leak = await rankIn(client, nonce, 100, pid);
+    console.log(
+      `[hybrid=${hybrid}] prefix200: rank@20=${r20} rank@100=${r100} | fullContent: rank=${rFull} | ` +
+      `nonce-probe: rank=${pRank} in ${((Date.now() - pt0) / 1000).toFixed(1)}s | ` +
+      `cross-agent leak: ${leak === -1 ? "NONE" : "LEAKED rank " + leak}`,
+    );
+    return dir;
+  } finally {
+    await stopHarper(harper, { keepInstallDir: true });
+  }
+}
+
+const dir = await testMode(false); // the mode that died
+await testMode(true, dir);         // the mode that passed
+rmSync(dir, { recursive: true, force: true });
+console.log("repro done");

--- a/test/bench/longmemeval/results/longmemeval-s-artifact-635df13be42d3f30.json
+++ b/test/bench/longmemeval/results/longmemeval-s-artifact-635df13be42d3f30.json
@@ -1,0 +1,911 @@
+{
+  "schema": "longmemeval-s.layer2.artifact/1",
+  "notice": "VALIDATION ARTIFACT — NOT FOR PUBLICATION. This harness produces numbers; it does not publish them. Publishing any number requires a recorded human sign-off referencing this artifact's artifactHash. Spend and outward-publishing are the founder's gates.",
+  "validationSlice": false,
+  "generatedAt": "2026-08-23T10:49:35.699Z",
+  "gitCommit": null,
+  "host": {
+    "ollama": "https://ollama.com",
+    "benchHost": "tps-bench.exe.xyz"
+  },
+  "configHash": "a43d28c920a436b6a2f96ce60b178de5bf17e3e29c59f250b8d7a68098d06a51",
+  "config": {
+    "schema": "longmemeval-s.layer2.config/1",
+    "dataset": {
+      "name": "LongMemEval_s",
+      "hfRepo": "xiaowu0162/longmemeval",
+      "hfRevision": "2ec2a557f339b6c0369619b1ed5793734cc87533",
+      "file": "longmemeval_s",
+      "sha256": "08d8dad4be43ee2049a22ff5674eb86725d0ce5ff434cde2627e5e8e7e117894",
+      "githubRepo": "xiaowu0162/LongMemEval",
+      "githubCommit": "9e0b455f4ef0e2ab8f2e582289761153549043fc",
+      "totalQuestions": 500
+    },
+    "judge": {
+      "model": "gemma4:31b",
+      "manifestDigest": "sha256:221b330d11a8",
+      "weightsSha256": "cloud-hosted:not-published",
+      "family": "gemma4",
+      "temperature": 0,
+      "seed": 0,
+      "numCtx": 8192,
+      "numPredict": 16
+    },
+    "reader": {
+      "model": "qwen3.5:397b",
+      "manifestDigest": "sha256:b909ca2f1b7f",
+      "family": "qwen3_5",
+      "temperature": 0,
+      "seed": 0,
+      "numCtx": 16384,
+      "numPredict": 256
+    },
+    "fullContext": {
+      "numCtx": 131072,
+      "charBudget": 393216
+    },
+    "retrieval": {
+      "scoring": "raw",
+      "readerTopK": 20
+    },
+    "ingestion": {
+      "granularity": "per-event",
+      "harperStoreSharing": "ingest-once-shared-store-alternating-mode"
+    },
+    "arms": [
+      "flair",
+      "vector-only",
+      "no-context"
+    ],
+    "prompts": {
+      "judge": {
+        "answerable": "I will give you a question, a correct answer, and a response from a model. Classify the model's response into exactly one category:\n\nA (CORRECT): the response contains the correct answer. If the response is equivalent to the correct answer, or contains all the intermediate steps needed to reach the correct answer, classify A.{taskRule}\nB (INCORRECT): the response commits to an answer that is wrong, contradicts the correct answer, or contains only a SUBSET of the information the correct answer requires.\nC (NOT_ATTEMPTED): the response does not commit to any answer — it declines, says it does not know, or says the information is unavailable — WITHOUT stating a wrong answer.\n\nQuestion: {question}\n\nCorrect Answer: {answer}\n\nModel Response: {response}\n\nRespond with ONLY a single letter: A, B, or C.",
+        "preference": "I will give you a question, a rubric describing the desired personalized response, and a response from a model. Classify the model's response into exactly one category:\n\nA (CORRECT): the response satisfies the desired response — it recalls and utilises the user's personal information correctly. It need not reflect every point in the rubric.\nB (INCORRECT): the response fails to utilise the user's personal information, or contradicts the rubric.\nC (NOT_ATTEMPTED): the response declines or does not attempt a personalized response.\n\nQuestion: {question}\n\nRubric: {answer}\n\nModel Response: {response}\n\nRespond with ONLY a single letter: A, B, or C.",
+        "abstention": "I will give you an UNANSWERABLE question, an explanation of why it cannot be answered from the available information, and a response from a model. Classify the model's response into exactly one category:\n\nA (CORRECT): the model correctly identifies the question as unanswerable — it says the information is incomplete, missing, or that it does not know.\nB (INCORRECT): the model fabricates or asserts a concrete answer instead of identifying the question as unanswerable.\n\nQuestion: {question}\n\nExplanation: {answer}\n\nModel Response: {response}\n\nRespond with ONLY a single letter: A or B.",
+        "taskRule": {
+          "single-session-user": "",
+          "single-session-assistant": "",
+          "multi-session": "",
+          "temporal-reasoning": " Do not penalize off-by-one errors for the number of days/weeks/months: if the question asks for a number of days/weeks/months and the response is off by one (e.g. 19 when the answer is 18), still classify it as A (CORRECT).",
+          "knowledge-update": " If the response contains some previous information along with an updated answer, classify it as A (CORRECT) as long as the updated answer is the required answer.",
+          "single-session-preference": ""
+        },
+        "version": "1.0.0-ternary-port"
+      },
+      "readerSystem": "You are a helpful assistant answering the user's question using ONLY the conversation memory provided. Answer concisely and directly. If the provided memory does not contain enough information to answer, reply that you do not know rather than guessing.",
+      "readerPromptVersion": "1.0.0"
+    },
+    "extraction": {
+      "name": "squad-normalize+token-f1+containment-em",
+      "version": "1.0.0"
+    },
+    "slice": {
+      "n": 500,
+      "seed": 0,
+      "runs": 1,
+      "questionIds": [
+        "001be529",
+        "00ca467f",
+        "0100672e",
+        "01493427",
+        "031748ae",
+        "031748ae_abs",
+        "06878be2",
+        "06db6396",
+        "06f04340",
+        "07741c44",
+        "07741c45",
+        "078150f1",
+        "07b6f563",
+        "0862e8bf",
+        "0862e8bf_abs",
+        "08e075c7",
+        "08f4fc43",
+        "0977f2af",
+        "099778bb",
+        "09ba9854",
+        "09ba9854_abs",
+        "09d032c9",
+        "0a34ad58",
+        "0a995998",
+        "0bb5a684",
+        "0bc8ad92",
+        "0bc8ad93",
+        "0db4c65d",
+        "0ddfec37",
+        "0ddfec37_abs",
+        "0e4e4c46",
+        "0e5e2d1a",
+        "0ea62687",
+        "0edc2aef",
+        "0f05491a",
+        "10d9b85a",
+        "10e09553",
+        "118b2229",
+        "1192316e",
+        "129d1232",
+        "1568498a",
+        "15745da0",
+        "15745da0_abs",
+        "157a136e",
+        "16c90bf4",
+        "184da446",
+        "18bc8abd",
+        "18dcd5a5",
+        "1903aded",
+        "195a1a1b",
+        "19b5f2b3",
+        "19b5f2b3_abs",
+        "1a1907b4",
+        "1a8a66a6",
+        "1b9b7252",
+        "1c0ddc50",
+        "1c549ce4",
+        "1cea1afa",
+        "1d4da289",
+        "1d4e3b97",
+        "1da05512",
+        "1de5cff2",
+        "1e043500",
+        "1f2b8d4f",
+        "1faac195",
+        "2133c1b5",
+        "2133c1b5_abs",
+        "21436231",
+        "21d02d0d",
+        "22d2cb42",
+        "2311e44b",
+        "2311e44b_abs",
+        "2318644b",
+        "25e5aa4f",
+        "2698e78f",
+        "2698e78f_abs",
+        "26bdc477",
+        "27016adc",
+        "2788b940",
+        "28bcfaac",
+        "28dc39ac",
+        "29f2956b",
+        "29f2956b_abs",
+        "2a1811e2",
+        "2b8f3739",
+        "2bf43736",
+        "2c63a862",
+        "2ce6a0f2",
+        "2e6d26dc",
+        "2ebe6c90",
+        "2ebe6c92",
+        "311778f1",
+        "32260d93",
+        "3249768e",
+        "352ab8bd",
+        "35a27287",
+        "36580ce8",
+        "36b9f61e",
+        "370a8ff4",
+        "37d43f65",
+        "37f165cf",
+        "38146c39",
+        "3a704032",
+        "3b6f954b",
+        "3ba21379",
+        "3c1045c8",
+        "3d86fd0a",
+        "3e321797",
+        "3f1e9474",
+        "3fdac837",
+        "3fe836c9",
+        "4100d0a0",
+        "41275add",
+        "41698283",
+        "42ec0761",
+        "4388e9dd",
+        "45dc21b6",
+        "46a3abf7",
+        "488d3006",
+        "4adc0475",
+        "4b24c848",
+        "4baee567",
+        "4bc144e2",
+        "4c36ccef",
+        "4d6b87c8",
+        "4dfccbf7",
+        "4dfccbf8",
+        "4f54b7c9",
+        "4fd1909e",
+        "5025383b",
+        "505af2f5",
+        "50635ada",
+        "51a45a95",
+        "51b23612",
+        "51c32626",
+        "54026fce",
+        "545bd2b5",
+        "55241a1f",
+        "561fabcd",
+        "577d4d32",
+        "57f827a0",
+        "5809eb10",
+        "5831f84d",
+        "58470ed2",
+        "58bf7951",
+        "58ef2f1c",
+        "59524333",
+        "5a4f22c0",
+        "5a7937c8",
+        "5c40ec5b",
+        "5d3d2817",
+        "5e1b23de",
+        "60036106",
+        "60159905",
+        "603deb26",
+        "60472f9c",
+        "6071bd76",
+        "60bf93ed",
+        "60bf93ed_abs",
+        "60d45044",
+        "618f13b2",
+        "61f8c8f8",
+        "6222b6eb",
+        "6456829e",
+        "6456829e_abs",
+        "65240037",
+        "6613b389",
+        "66f24dbb",
+        "67e0d0f2",
+        "681a1674",
+        "69fee5aa",
+        "6a1eabeb",
+        "6a27ffc2",
+        "6ade9755",
+        "6ae235be",
+        "6aeb4375",
+        "6aeb4375_abs",
+        "6b168ec8",
+        "6b7dfb22",
+        "6c49646a",
+        "6cb6f249",
+        "6d550036",
+        "6e984301",
+        "6e984302",
+        "6f9b354f",
+        "7024f17c",
+        "70b3e69b",
+        "71017276",
+        "71017277",
+        "71315a70",
+        "7161e7e2",
+        "71a3fd6b",
+        "720133ac",
+        "726462e0",
+        "72e3ee87",
+        "73d42213",
+        "7401057b",
+        "7405e8b1",
+        "7527f7e2",
+        "75499fd8",
+        "75832dbd",
+        "75f70248",
+        "76d63226",
+        "778164c6",
+        "77eafa52",
+        "7a87bd0c",
+        "7a8d0b71",
+        "7e00a6cb",
+        "7e974930",
+        "8077ef71",
+        "80ec1f4f",
+        "80ec1f4f_abs",
+        "81507db6",
+        "830ce83f",
+        "8464fc84",
+        "852ce960",
+        "853b0a1d",
+        "8550ddae",
+        "85fa3a3f",
+        "86b68151",
+        "86f00804",
+        "8752c811",
+        "87f22b4a",
+        "88432d0a",
+        "88432d0a_abs",
+        "89527b6b",
+        "8979f9ec",
+        "89941a93",
+        "89941a94",
+        "8a137a7f",
+        "8a2466db",
+        "8aef76bc",
+        "8b9d4367",
+        "8c18457d",
+        "8cf4d046",
+        "8cf51dda",
+        "8e91e7d9",
+        "8e9d538c",
+        "8ebdbe50",
+        "8fb83627",
+        "91b15a6e",
+        "92a0aa75",
+        "945e3d21",
+        "94f70d80",
+        "95228167",
+        "95bcc1c8",
+        "982b5123",
+        "982b5123_abs",
+        "993da5e2",
+        "9a707b81",
+        "9a707b82",
+        "9aaed6a3",
+        "9bbe84a2",
+        "9d25d4e0",
+        "9ea5eabc",
+        "9ee3ecd6",
+        "a06e4cfe",
+        "a08a253f",
+        "a11281a2",
+        "a1cc6108",
+        "a1eacc2a",
+        "a2f3aa27",
+        "a3045048",
+        "a3332713",
+        "a346bb18",
+        "a3838d2b",
+        "a40e080f",
+        "a4996e51",
+        "a82c026e",
+        "a89d7624",
+        "a96c20ee",
+        "a96c20ee_abs",
+        "a9f6b44c",
+        "aae3761f",
+        "ac031881",
+        "ad7109d1",
+        "af082822",
+        "af8d2e46",
+        "afdc33df",
+        "affe2881",
+        "b01defab",
+        "b0479f84",
+        "b29f3365",
+        "b320f3f8",
+        "b3c15d39",
+        "b46e15ed",
+        "b46e15ee",
+        "b5ef892d",
+        "b6019101",
+        "b6025781",
+        "b759caee",
+        "b86304ba",
+        "b9cfe692",
+        "ba358f49",
+        "ba358f49_abs",
+        "ba61f0b9",
+        "bb7c3b45",
+        "bbf86515",
+        "bc149d6b",
+        "bc8a6e93",
+        "bc8a6e93_abs",
+        "bcbe585f",
+        "bf659f65",
+        "c14c00dd",
+        "c18a7dc8",
+        "c19f7a0b",
+        "c2ac3c61",
+        "c4a1ceb8",
+        "c4ea545c",
+        "c4f10528",
+        "c5e8278d",
+        "c6853660",
+        "c7cf7dfd",
+        "c7dc5443",
+        "c8090214",
+        "c8090214_abs",
+        "c8c3f81d",
+        "c8f1aeed",
+        "c960da58",
+        "c9f37c46",
+        "caf03d32",
+        "caf9ead2",
+        "cc06de0d",
+        "cc539528",
+        "cc5ded98",
+        "cc6d1ec1",
+        "ccb36322",
+        "ce6d2d27",
+        "ceb54acb",
+        "cf22b7bf",
+        "d01c6aa8",
+        "d23cf73b",
+        "d24813b1",
+        "d3ab962e",
+        "d52b4f67",
+        "d596882b",
+        "d6062bb9",
+        "d6233ab6",
+        "d682f1a2",
+        "d7c942c3",
+        "d851d5ba",
+        "d905b33f",
+        "dad224aa",
+        "db467c8c",
+        "dc439ea3",
+        "dccbc061",
+        "dcfa8644",
+        "dd2973ad",
+        "dfde3500",
+        "e01b8e2f",
+        "e25c3b8d",
+        "e3038f8c",
+        "e3fc4d6e",
+        "e47becba",
+        "e48988bc",
+        "e493bb7c",
+        "e4e14d04",
+        "e56a43b9",
+        "e5ba910e_abs",
+        "e6041065",
+        "e61a7584",
+        "e66b632c",
+        "e831120c",
+        "e8a79c70",
+        "e9327a54",
+        "e982271f",
+        "eac54adc",
+        "eac54add",
+        "eaca4986",
+        "eace081b",
+        "ec81a493",
+        "ed4ddc30",
+        "edced276",
+        "edced276_abs",
+        "eeda8a6d",
+        "eeda8a6d_abs",
+        "ef66a6e5",
+        "ef9cf60a",
+        "efc3f7c2",
+        "f0853d11",
+        "f0e564bc",
+        "f35224e0",
+        "f4f1d8a4",
+        "f4f1d8a4_abs",
+        "f523d9fe",
+        "f685340e",
+        "f685340e_abs",
+        "f8c5f88b",
+        "f9e8c073",
+        "faba32e5",
+        "fca70973",
+        "fca762bc",
+        "fea54f57",
+        "gpt4_0a05b494",
+        "gpt4_0b2f1d21",
+        "gpt4_15e38248",
+        "gpt4_18c2b244",
+        "gpt4_1916e0ea",
+        "gpt4_194be4b3",
+        "gpt4_1a1dc16d",
+        "gpt4_1d4ab0c9",
+        "gpt4_1d80365e",
+        "gpt4_1e4a8aeb",
+        "gpt4_1e4a8aec",
+        "gpt4_213fd887",
+        "gpt4_21adecb5",
+        "gpt4_2312f94c",
+        "gpt4_2487a7cb",
+        "gpt4_2655b836",
+        "gpt4_2ba83207",
+        "gpt4_2c50253f",
+        "gpt4_2d58bcd6",
+        "gpt4_2f56ae70",
+        "gpt4_2f584639",
+        "gpt4_2f8be40d",
+        "gpt4_2f91af09",
+        "gpt4_31ff4165",
+        "gpt4_372c3eed",
+        "gpt4_372c3eed_abs",
+        "gpt4_385a5000",
+        "gpt4_45189cb4",
+        "gpt4_468eb063",
+        "gpt4_468eb064",
+        "gpt4_483dd43c",
+        "gpt4_4929293a",
+        "gpt4_4929293b",
+        "gpt4_4cd9eba1",
+        "gpt4_4edbafa2",
+        "gpt4_4ef30696",
+        "gpt4_4fc4f797",
+        "gpt4_5438fa52",
+        "gpt4_5501fe77",
+        "gpt4_59149c77",
+        "gpt4_59149c78",
+        "gpt4_59c863d7",
+        "gpt4_5dcc0aab",
+        "gpt4_61e13b3c",
+        "gpt4_65aabe59",
+        "gpt4_68e94287",
+        "gpt4_68e94288",
+        "gpt4_6dc9b45b",
+        "gpt4_6ed717ea",
+        "gpt4_70e84552",
+        "gpt4_70e84552_abs",
+        "gpt4_731e37d7",
+        "gpt4_74aed68e",
+        "gpt4_76048e76",
+        "gpt4_78cf46a3",
+        "gpt4_7a0daae1",
+        "gpt4_7abb270c",
+        "gpt4_7bc6cf22",
+        "gpt4_7ca326fa",
+        "gpt4_7ddcf75f",
+        "gpt4_7de946e7",
+        "gpt4_7f6b06db",
+        "gpt4_7fce9456",
+        "gpt4_8279ba02",
+        "gpt4_8279ba03",
+        "gpt4_85da3956",
+        "gpt4_88806d6e",
+        "gpt4_8c8961ae",
+        "gpt4_8e165409",
+        "gpt4_93159ced",
+        "gpt4_93159ced_abs",
+        "gpt4_93f6379c",
+        "gpt4_98f46fc6",
+        "gpt4_9a159967",
+        "gpt4_a1b77f9c",
+        "gpt4_a2d1d1f6",
+        "gpt4_a56e767c",
+        "gpt4_ab202e7f",
+        "gpt4_af6db32f",
+        "gpt4_b0863698",
+        "gpt4_b4a80587",
+        "gpt4_b5700ca0",
+        "gpt4_b5700ca9",
+        "gpt4_c27434e8",
+        "gpt4_c27434e8_abs",
+        "gpt4_cd90e484",
+        "gpt4_d12ceb0e",
+        "gpt4_d31cdae3",
+        "gpt4_d6585ce8",
+        "gpt4_d6585ce9",
+        "gpt4_d84a3211",
+        "gpt4_d9af6064",
+        "gpt4_e05b82a6",
+        "gpt4_e061b84f",
+        "gpt4_e061b84g",
+        "gpt4_e072b769",
+        "gpt4_e414231e",
+        "gpt4_e414231f",
+        "gpt4_ec93e27f",
+        "gpt4_f2262a51",
+        "gpt4_f420262c",
+        "gpt4_f420262d",
+        "gpt4_f49edff3",
+        "gpt4_fa19884c",
+        "gpt4_fa19884d",
+        "gpt4_fe651585",
+        "gpt4_fe651585_abs"
+      ]
+    }
+  },
+  "runHashes": [
+    "ac91279144f89a104d3c25549e16357a80adda7c92eae622df25a683fc85c084"
+  ],
+  "aggregate": [
+    {
+      "arm": "flair",
+      "runs": 1,
+      "overallAccuracy": {
+        "mean": 0.66,
+        "std": 0,
+        "runs": [
+          0.66
+        ]
+      },
+      "overallAccuracyAnswerable": {
+        "mean": 0.6382978723404256,
+        "std": 0,
+        "runs": [
+          0.6382978723404256
+        ]
+      },
+      "perAbility": {
+        "information-extraction": {
+          "mean": 0.9666666666666667,
+          "std": 0,
+          "runs": [
+            0.9666666666666667
+          ]
+        },
+        "multi-session": {
+          "mean": 0.5950413223140496,
+          "std": 0,
+          "runs": [
+            0.5950413223140496
+          ]
+        },
+        "knowledge-update": {
+          "mean": 0.6944444444444444,
+          "std": 0,
+          "runs": [
+            0.6944444444444444
+          ]
+        },
+        "single-session-preference": {
+          "mean": 0.5,
+          "std": 0,
+          "runs": [
+            0.5
+          ]
+        },
+        "temporal-reasoning": {
+          "mean": 0.3700787401574803,
+          "std": 0,
+          "runs": [
+            0.3700787401574803
+          ]
+        }
+      },
+      "abstentionAccuracy": {
+        "mean": 1,
+        "std": 0,
+        "runs": [
+          1
+        ]
+      },
+      "notAttemptedRateAnswerable": {
+        "mean": 0.19148936170212766,
+        "std": 0,
+        "runs": [
+          0.19148936170212766
+        ]
+      },
+      "factualF1": {
+        "mean": 0.1599332073368728,
+        "std": 0,
+        "runs": [
+          0.1599332073368728
+        ]
+      },
+      "factualContainmentEM": {
+        "mean": 0.5659090909090909,
+        "std": 0,
+        "runs": [
+          0.5659090909090909
+        ]
+      },
+      "tokensPerQueryMean": {
+        "mean": 5306.642,
+        "std": 0,
+        "runs": [
+          5306.642
+        ]
+      },
+      "latencyP50Ms": {
+        "mean": 8703.488137001172,
+        "std": 0,
+        "runs": [
+          8703.488137001172
+        ]
+      },
+      "latencyP95Ms": {
+        "mean": 25882.706019997597,
+        "std": 0,
+        "runs": [
+          25882.706019997597
+        ]
+      },
+      "judgeErrorsTotal": 0
+    },
+    {
+      "arm": "vector-only",
+      "runs": 1,
+      "overallAccuracy": {
+        "mean": 0.648,
+        "std": 0,
+        "runs": [
+          0.648
+        ]
+      },
+      "overallAccuracyAnswerable": {
+        "mean": 0.6276595744680851,
+        "std": 0,
+        "runs": [
+          0.6276595744680851
+        ]
+      },
+      "perAbility": {
+        "information-extraction": {
+          "mean": 0.9583333333333334,
+          "std": 0,
+          "runs": [
+            0.9583333333333334
+          ]
+        },
+        "multi-session": {
+          "mean": 0.6528925619834711,
+          "std": 0,
+          "runs": [
+            0.6528925619834711
+          ]
+        },
+        "knowledge-update": {
+          "mean": 0.6944444444444444,
+          "std": 0,
+          "runs": [
+            0.6944444444444444
+          ]
+        },
+        "single-session-preference": {
+          "mean": 0.3333333333333333,
+          "std": 0,
+          "runs": [
+            0.3333333333333333
+          ]
+        },
+        "temporal-reasoning": {
+          "mean": 0.3228346456692913,
+          "std": 0,
+          "runs": [
+            0.3228346456692913
+          ]
+        }
+      },
+      "abstentionAccuracy": {
+        "mean": 0.9666666666666667,
+        "std": 0,
+        "runs": [
+          0.9666666666666667
+        ]
+      },
+      "notAttemptedRateAnswerable": {
+        "mean": 0.18085106382978725,
+        "std": 0,
+        "runs": [
+          0.18085106382978725
+        ]
+      },
+      "factualF1": {
+        "mean": 0.1563406551771647,
+        "std": 0,
+        "runs": [
+          0.1563406551771647
+        ]
+      },
+      "factualContainmentEM": {
+        "mean": 0.5818181818181818,
+        "std": 0,
+        "runs": [
+          0.5818181818181818
+        ]
+      },
+      "tokensPerQueryMean": {
+        "mean": 5093.766,
+        "std": 0,
+        "runs": [
+          5093.766
+        ]
+      },
+      "latencyP50Ms": {
+        "mean": 3109.5644640000537,
+        "std": 0,
+        "runs": [
+          3109.5644640000537
+        ]
+      },
+      "latencyP95Ms": {
+        "mean": 4986.465401999652,
+        "std": 0,
+        "runs": [
+          4986.465401999652
+        ]
+      },
+      "judgeErrorsTotal": 0
+    },
+    {
+      "arm": "no-context",
+      "runs": 1,
+      "overallAccuracy": {
+        "mean": 0.06,
+        "std": 0,
+        "runs": [
+          0.06
+        ]
+      },
+      "overallAccuracyAnswerable": {
+        "mean": 0,
+        "std": 0,
+        "runs": [
+          0
+        ]
+      },
+      "perAbility": {
+        "information-extraction": {
+          "mean": 0,
+          "std": 0,
+          "runs": [
+            0
+          ]
+        },
+        "multi-session": {
+          "mean": 0,
+          "std": 0,
+          "runs": [
+            0
+          ]
+        },
+        "knowledge-update": {
+          "mean": 0,
+          "std": 0,
+          "runs": [
+            0
+          ]
+        },
+        "single-session-preference": {
+          "mean": 0,
+          "std": 0,
+          "runs": [
+            0
+          ]
+        },
+        "temporal-reasoning": {
+          "mean": 0,
+          "std": 0,
+          "runs": [
+            0
+          ]
+        }
+      },
+      "abstentionAccuracy": {
+        "mean": 1,
+        "std": 0,
+        "runs": [
+          1
+        ]
+      },
+      "notAttemptedRateAnswerable": {
+        "mean": 1,
+        "std": 0,
+        "runs": [
+          1
+        ]
+      },
+      "factualF1": {
+        "mean": 0.026055714922135743,
+        "std": 0,
+        "runs": [
+          0.026055714922135743
+        ]
+      },
+      "factualContainmentEM": {
+        "mean": 0.011363636363636364,
+        "std": 0,
+        "runs": [
+          0.011363636363636364
+        ]
+      },
+      "tokensPerQueryMean": {
+        "mean": 114.026,
+        "std": 0,
+        "runs": [
+          114.026
+        ]
+      },
+      "latencyP50Ms": {
+        "mean": 0,
+        "std": 0,
+        "runs": [
+          0
+        ]
+      },
+      "latencyP95Ms": {
+        "mean": 0,
+        "std": 0,
+        "runs": [
+          0
+        ]
+      },
+      "judgeErrorsTotal": 0
+    }
+  ],
+  "artifactHash": "635df13be42d3f30e9db7a9e3cd2d032aa0f9e426d19d938052976032c935b98"
+}

--- a/test/bench/longmemeval/run.ts
+++ b/test/bench/longmemeval/run.ts
@@ -20,13 +20,13 @@ import { fileURLToPath } from "node:url";
 import path from "node:path";
 import { execSync } from "node:child_process";
 import {
-  OLLAMA_HOST, JUDGE, READER, DATASET, RETRIEVAL, FULL_CONTEXT,
+  OLLAMA_HOST, JUDGE, READER, DATASET, RETRIEVAL, FULL_CONTEXT, INGESTION,
   assertCrossFamily, configManifest, hashConfig,
 } from "./config";
 import { assertModelPinned, pingOllama, generate, OllamaError } from "./ollama";
 import { buildJudgePrompt, parseVerdict, type LmeTask, type Verdict } from "./judge";
 import { loadDataset, selectSlice, abilityOf, isAbstention } from "./dataset";
-import { runOnce } from "./eval";
+import { runOnce, SELECTED_ARMS, writeProgress, setJournalContext } from "./eval";
 import { aggregateArmAcrossRuns, type ArmRunMetrics } from "./metrics";
 import { buildArtifact, writeArtifact, verifyArtifactHash } from "./artifact";
 import { ALL_ARMS, type Arm } from "./arms";
@@ -45,8 +45,19 @@ function gitCommit(): string | null {
   try { return execSync("git rev-parse HEAD", { cwd: REPO_ROOT }).toString().trim(); } catch { return null; }
 }
 
+// LME_FLAIR_PKG_DIR / LME_HARPER_BIN_DIR (ported from tps-bench): point the
+// harness at an npm-installed published @tpsdev-ai/flair instead of the
+// worktree, so the bench can run on a VM that has the package but not the repo.
+//
+// OPERATIONAL-ONLY, with a caveat worth stating: these do not change the
+// harness's behavior at all — they only say WHERE the system under test lives.
+// But they do mean the system under test may not be a git checkout, in which
+// case gitCommit() below returns null and the artifact records no build
+// identity for Flair itself. That is a pre-existing provenance gap in the
+// artifact schema (the headline artifact has gitCommit: null), not something
+// these variables introduce; it is called out on #1366 for a follow-up.
 function assertBuilt(): void {
-  const marker = path.join(REPO_ROOT, "dist", "resources", "SemanticSearch.js");
+  const marker = path.join(process.env.LME_FLAIR_PKG_DIR ?? REPO_ROOT, "dist", "resources", "SemanticSearch.js");
   if (!existsSync(marker)) {
     console.error(`FATAL: ${marker} not found — Harper serves resources from dist/. Run \`bun run build\` first.`);
     process.exit(2);
@@ -124,10 +135,38 @@ async function runSlice(): Promise<void> {
   console.log(`slice: ${slice.length} questions across abilities: ${JSON.stringify(abilityCounts)}`);
 
   const manifest = configManifest({ n, seed, runs, questionIds: slice.map((e) => e.question_id) });
+  // ── The two ARTIFACT-AFFECTING overrides (flair#1366) ─────────────────────
+  // Both of these are settings that can change what is measured while the
+  // harness is working correctly, so both must enter the hashed config. See the
+  // classification header in eval.ts for the test being applied.
+
+  // (1) The arms ACTUALLY run (LME_ARMS subset). A 3-arm run must never hash
+  // identically to a 4-arm run: the aggregate contains different arms, and the
+  // contamination / ceiling reads that need the missing arms do not exist.
+  (manifest as { arms: Arm[] }).arms = SELECTED_ARMS;
+
+  // (2) The Harper-store topology. When both Harper arms run, one ingest per
+  // question serves both over a shared store with a per-question mode flip
+  // (take-2 ingest-reuse). This is a MEASUREMENT-VALIDITY difference, not a
+  // speed one: per-arm stores gave the vector-only arm a full-size HNSW graph
+  // while flair queried a growing one — a confound biased FOR flair. A
+  // shared-store run and a per-arm-store run therefore must never share a
+  // configHash even though models, dataset and prompts are identical.
+  const sharedStore = SELECTED_ARMS.includes("flair") && SELECTED_ARMS.includes("vector-only");
+  (manifest as { ingestion: unknown }).ingestion = {
+    ...INGESTION,
+    harperStoreSharing: sharedStore ? "ingest-once-shared-store-alternating-mode" : "per-arm-store",
+  };
   const configHash = hashConfig(manifest);
+  setJournalContext(configHash); // journal lines carry cfg identity from now on
+  if (process.env.LME_RESUME === "1") console.log(`resume: LME_RESUME=1 — banked (question,arm) pairs from ${process.env.LME_RECORDS_JSONL} will be skipped`);
+  console.log(`arms: ${SELECTED_ARMS.join(", ")}`);
+  if (sharedStore) {
+    console.log(`ingest-reuse (take-2): one ingest per question serves flair + vector-only over a shared store with per-question mode flip. configHash intentionally differs from per-arm-store runs (ingestion.harperStoreSharing is hashed).`);
+  }
   console.log(`configHash: ${configHash}\n`);
 
-  const perArmRuns = new Map<Arm, ArmRunMetrics[]>(ALL_ARMS.map((a) => [a, []]));
+  const perArmRuns = new Map<Arm, ArmRunMetrics[]>(SELECTED_ARMS.map((a) => [a, []]));
   const runHashes: string[] = [];
   for (let i = 1; i <= runs; i++) {
     const r = await runOnce(i, slice, { repoRoot: REPO_ROOT, host, log: (s) => console.log(s) });
@@ -135,10 +174,10 @@ async function runSlice(): Promise<void> {
     for (const m of r.armMetrics) perArmRuns.get(m.arm)!.push(m);
   }
 
-  const aggregate = ALL_ARMS.map((a) => aggregateArmAcrossRuns(a, perArmRuns.get(a)!));
+  const aggregate = SELECTED_ARMS.map((a) => aggregateArmAcrossRuns(a, perArmRuns.get(a)!));
   const artifact = buildArtifact({
     configHash, config: manifest, runHashes, aggregate,
-    gitCommit: gitCommit(), ollamaHost: host, benchHost: "rockit", validationSlice,
+    gitCommit: gitCommit(), ollamaHost: host, benchHost: process.env.LME_BENCH_HOST ?? "rockit", validationSlice,
   });
   const artifactPath = writeArtifact(artifact, outDir);
 
@@ -157,13 +196,21 @@ async function runSlice(): Promise<void> {
     console.log(`    ${"latency p50 / p95 (ms)".padEnd(28)} ${a.latencyP50Ms.mean.toFixed(0)} / ${a.latencyP95Ms.mean.toFixed(0)}`);
     if (a.judgeErrorsTotal > 0) console.log(`    !! judge errors: ${a.judgeErrorsTotal} (unparseable verdicts — NOT counted as pass)`);
   }
-  const nc = aggregate.find((a) => a.arm === "no-context")!;
-  const fl = aggregate.find((a) => a.arm === "flair")!;
-  const fc = aggregate.find((a) => a.arm === "full-context")!;
+  // Contamination / validity reads — each only when its arm(s) ran.
+  const nc = aggregate.find((a) => a.arm === "no-context");
+  const fl = aggregate.find((a) => a.arm === "flair");
+  const fc = aggregate.find((a) => a.arm === "full-context");
   console.log(`\n── contamination / validity reads (ANSWERABLE questions only) ──`);
-  console.log(`  no-context accuracy = ${pct(nc.overallAccuracyAnswerable.mean)}  (HIGH ⇒ reader prior knowledge / contamination — number suspect)`);
-  console.log(`    (measured on answerable questions — an abstention question is trivially correct with no context, so it is excluded here)`);
-  console.log(`  full-context − flair = ${pct(fc.overallAccuracyAnswerable.mean - fl.overallAccuracyAnswerable.mean)}  (≈0 ⇒ measuring long-context not memory; large ⇒ retrieval losing info)`);
+  if (nc) {
+    console.log(`  no-context accuracy = ${pct(nc.overallAccuracyAnswerable.mean)}  (HIGH ⇒ reader prior knowledge / contamination — number suspect)`);
+    console.log(`    (measured on answerable questions — an abstention question is trivially correct with no context, so it is excluded here)`);
+  }
+  if (fc && fl) {
+    console.log(`  full-context − flair = ${pct(fc.overallAccuracyAnswerable.mean - fl.overallAccuracyAnswerable.mean)}  (≈0 ⇒ measuring long-context not memory; large ⇒ retrieval losing info)`);
+  } else {
+    console.log(`  full-context − flair: NOT AVAILABLE (full-context arm not run — LME_ARMS=${SELECTED_ARMS.join(",")})`);
+  }
+  writeProgress({ done: true, artifactPath });
   console.log(`\nartifactHash: ${artifact.artifactHash}`);
   console.log(`artifact self-verifies: ${verifyArtifactHash(artifact)}`);
   console.log(`written: ${artifactPath}`);

--- a/test/unit/longmemeval-repro.test.ts
+++ b/test/unit/longmemeval-repro.test.ts
@@ -1,0 +1,312 @@
+import { describe, test, expect } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { verifyArtifactHash } from "../bench/longmemeval/artifact";
+import { hashConfig, canonicalJson } from "../bench/longmemeval/config";
+
+/**
+ * HISTORICAL-VARIANT reproducibility for the LongMemEval bench (flair#1366).
+ *
+ * The harness that produced our headline numbers lived only on the tps-bench
+ * VM, so "run it yourself" reproduced a DIFFERENT harness than the one that made
+ * the numbers. #1366 ported it. This test is the standing proof that the gap
+ * stays closed as the harness keeps moving.
+ *
+ * ── What this test asserts, and why it is shaped this way ──────────────────
+ *
+ * The naive version pins "the manifest that current code emits" to a literal
+ * hash. That version is wrong, and #1364 proved it within a day: adding
+ * `prompts.readerPayloadFormat` — a legitimate measurement change — broke the
+ * pin, and the only ways to get green again would have been to re-pin to a new
+ * number (destroying the property being protected) or delete the test.
+ *
+ * So the assertion is instead: **repo code can still reconstruct the manifest
+ * of a PAST run and reproduce its recorded configHash.** For each committed
+ * historical artifact, the current manifest is projected onto exactly the key
+ * set that artifact recorded, and the projection must hash to the artifact's
+ * `configHash`.
+ *
+ * That gives the right failure behavior in every direction:
+ *
+ *   - a field is ADDED to the manifest (a new measurement variant) -> the
+ *     projection drops it, the historical hash still reproduces, no churn.
+ *     The new field still governs the identity of NEW runs through the ordinary
+ *     configHash path; it is simply not part of what the old run was.
+ *   - a pinned VALUE the old run depended on changes (a model digest, a prompt
+ *     string, the extraction method, a dataset pin) -> the projection differs
+ *     and this FAILS. That is the real regression: the repo can no longer
+ *     express the configuration that produced a published number.
+ *   - a field the old run HAD is removed -> the projection is missing a key and
+ *     this FAILS, which is correct for the same reason.
+ *
+ * WHEN THIS FAILS, do not re-pin the expected hash and do not relax the
+ * projection. A failure means a published number is no longer reproducible from
+ * repo code. Either the change was unintended (revert it), or it is deliberate
+ * — in which case the affected headline must be RE-RUN and its artifact
+ * replaced, which is a decision with a cost, not a test edit.
+ *
+ * Adding a new headline later? Commit its artifact and add a row to
+ * HISTORICAL_VARIANTS. Old rows stay; that is the point.
+ *
+ * ── Scope: what this does NOT prove ───────────────────────────────────────
+ *
+ * It reproduces the CONFIG identity, not the numbers. Under the `cloud` profile
+ * the reader is not deterministic at temperature 0 / seed 0 (measured: four
+ * calls, byte-identical prompt, three distinct completions — batched cloud
+ * inference is not bitwise-stable), so `runHash` and `artifactHash` cannot be
+ * re-derived by anyone. Note also that `artifactHash` covers latency
+ * percentiles and so is not wall-clock invariant. `configHash` is the
+ * reproducible identity; see the README section "What 'reproducible' does and
+ * does not mean here".
+ */
+
+const RESULTS_DIR = join(import.meta.dir, "..", "bench", "longmemeval", "results");
+const CONFIG_TS = join(import.meta.dir, "..", "bench", "longmemeval", "config.ts");
+
+interface HistoricalVariant {
+  /** What ran, in one line — this is what a reviewer reads first. */
+  label: string;
+  artifactFile: string;
+  configHash: string;
+  artifactHash: string;
+  profile: "local" | "cloud";
+  /** Overrides run.ts applies to the manifest after configManifest(). */
+  armsFrom: "artifact";
+  ingestionSharingFrom: "artifact";
+}
+
+const HISTORICAL_VARIANTS: HistoricalVariant[] = [
+  {
+    label:
+      "published headline — tps-bench 2026-08-23, n=500 (all of LongMemEval_s), seed 0, " +
+      "1 run, arms flair+vector-only+no-context, shared-store ingest-reuse, cloud pins, " +
+      "v1 reader payload (pre-#1364)",
+    artifactFile: "longmemeval-s-artifact-635df13be42d3f30.json",
+    configHash: "a43d28c920a436b6a2f96ce60b178de5bf17e3e29c59f250b8d7a68098d06a51",
+    artifactHash: "635df13be42d3f30e9db7a9e3cd2d032aa0f9e426d19d938052976032c935b98",
+    profile: "cloud",
+    armsFrom: "artifact",
+    ingestionSharingFrom: "artifact",
+  },
+];
+
+/** The pinned LOCAL models, as they stood before #1366 introduced profiles.
+ *  These are VALUES, not a manifest shape, so they are immune to the
+ *  manifest-shape churn that makes a whole-manifest hash pin a treadmill. */
+const LOCAL_PINS = {
+  judge: {
+    model: "gemma4:31b-it-q8_0",
+    manifestDigest: "sha256:53dd8459790f8795177444daa9e33f417e03c0d1cdedb80b6c73898603d20aef",
+    weightsSha256: "sha256:a0feadb736f521df6de4b1bd3cbf06c00f9fd04570ddc1e47b8ec9ecbbd6b51d",
+    family: "gemma4",
+    temperature: 0,
+    seed: 0,
+    numCtx: 8192,
+    numPredict: 16,
+  },
+  reader: {
+    model: "qwen3.6:27b-coding-mxfp8",
+    manifestDigest: "sha256:a7185d39ff35a472a2721b87e1bbb90810bcd381d415666ce2137838e66f2780",
+    family: "qwen3_5",
+    temperature: 0,
+    seed: 0,
+    numCtx: 16384,
+    numPredict: 256,
+  },
+};
+
+const loadArtifact = (file: string) => JSON.parse(readFileSync(join(RESULTS_DIR, file), "utf8"));
+
+/**
+ * Keep only the keys `template` has, recursively — the "as this variant
+ * recorded it" projection. Arrays are taken whole: they are ordered values
+ * (questionIds, arms), not key sets to be filtered.
+ */
+function projectOnto(template: unknown, value: unknown): unknown {
+  if (Array.isArray(template)) return value;
+  if (template && typeof template === "object" && value && typeof value === "object") {
+    const out: Record<string, unknown> = {};
+    for (const k of Object.keys(template as Record<string, unknown>)) {
+      if (k in (value as Record<string, unknown>)) {
+        out[k] = projectOnto(
+          (template as Record<string, unknown>)[k],
+          (value as Record<string, unknown>)[k],
+        );
+      }
+    }
+    return out;
+  }
+  return value;
+}
+
+/**
+ * The model profile is process-wide and read at import time, so each profile
+ * must be measured in its own process — importing config.ts twice with
+ * different environments is not possible in one. A subprocess that failed
+ * would otherwise yield an empty string that compares unequal for the wrong
+ * reason, so a non-zero exit or any stderr is raised loudly instead.
+ */
+async function inProfile(env: Record<string, string | undefined>, body: string): Promise<string> {
+  const script = `import { configManifest, hashConfig, JUDGE, READER, MODEL_PROFILE } from ${JSON.stringify(CONFIG_TS)};\n${body}`;
+  const childEnv: Record<string, string> = { ...process.env } as Record<string, string>;
+  for (const [k, v] of Object.entries(env)) {
+    if (v === undefined) delete childEnv[k];
+    else childEnv[k] = v;
+  }
+  const proc = Bun.spawn(["bun", "run", "-"], {
+    stdin: new TextEncoder().encode(script),
+    env: childEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [out, err, code] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+    proc.exited,
+  ]);
+  if (code !== 0 || err.trim()) {
+    throw new Error(`profile subprocess failed (exit ${code}): ${err.slice(0, 500)}`);
+  }
+  return out.trim();
+}
+
+/** The manifest current repo code emits for a historical variant's run params. */
+async function currentManifestFor(v: HistoricalVariant, config: Record<string, any>): Promise<any> {
+  const json = await inProfile(
+    { LME_MODEL_PROFILE: v.profile, LME_FULL_CTX: String(config.fullContext.numCtx) },
+    `
+      const c = ${JSON.stringify(config)};
+      const m = configManifest({
+        n: c.slice.n, seed: c.slice.seed, runs: c.slice.runs, questionIds: c.slice.questionIds,
+      });
+      // The two artifact-affecting overrides run.ts applies — see run.ts.
+      m.arms = c.arms;
+      m.ingestion = { ...m.ingestion, harperStoreSharing: c.ingestion.harperStoreSharing };
+      process.stdout.write(JSON.stringify(m));
+    `,
+  );
+  return JSON.parse(json);
+}
+
+describe("longmemeval historical-variant reproducibility (#1366)", () => {
+  for (const v of HISTORICAL_VARIANTS) {
+    describe(v.label, () => {
+      const artifact = loadArtifact(v.artifactFile);
+
+      test("the committed artifact self-verifies", () => {
+        expect(artifact.configHash).toBe(v.configHash);
+        expect(artifact.artifactHash).toBe(v.artifactHash);
+        expect(verifyArtifactHash(artifact)).toBe(true);
+      });
+
+      test("a tampered artifact does NOT self-verify", () => {
+        // Positive control: without it, verifyArtifactHash returning true above
+        // would be consistent with it returning true for anything.
+        const tampered = JSON.parse(JSON.stringify(artifact));
+        tampered.config.slice.n = artifact.config.slice.n - 1;
+        expect(verifyArtifactHash(tampered)).toBe(false);
+      });
+
+      test("repo code reconstructs this variant's manifest and reproduces its configHash", async () => {
+        const current = await currentManifestFor(v, artifact.config);
+        const reconstructed = projectOnto(artifact.config, current);
+        // Hash equality implies byte-identical canonical JSON, i.e. exactly the
+        // same keys AND values — so the projection cannot pass vacuously.
+        expect(hashConfig(reconstructed)).toBe(v.configHash);
+      });
+
+      test("every field this variant recorded is still expressible from repo code", async () => {
+        // Same property as above, asserted field-by-field so a failure names the
+        // field that drifted instead of only reporting two unequal hashes.
+        const current = await currentManifestFor(v, artifact.config);
+        for (const key of Object.keys(artifact.config)) {
+          expect({ [key]: projectOnto(artifact.config[key], current[key]) })
+            .toEqual({ [key]: artifact.config[key] });
+        }
+      });
+
+      test("the harness HAS evolved since this variant — the projection is doing real work", async () => {
+        // Guards the opposite failure: if the projection were a no-op, this test
+        // file would silently degrade into "nothing ever changes" and stop
+        // proving that old artifacts survive harness evolution.
+        const current = await currentManifestFor(v, artifact.config);
+        const addedSinceVariant = Object.keys(current.prompts)
+          .filter((k) => !(k in artifact.config.prompts));
+        // As of #1364 this is ["readerPayloadFormat"]. Not pinned to that exact
+        // list on purpose — pinning it would be the treadmill this test exists
+        // to avoid. Only the DIRECTION is asserted: current is a superset.
+        expect(Object.keys(current.prompts).length)
+          .toBeGreaterThanOrEqual(Object.keys(artifact.config.prompts).length);
+        if (addedSinceVariant.length > 0) {
+          expect(hashConfig(current)).not.toBe(v.configHash);
+        }
+      });
+    });
+  }
+
+  describe("model profiles", () => {
+    test("the local pins are exactly what they were before profiles were introduced", async () => {
+      // The neutrality property of #1366: cloud pins were added as a PROFILE
+      // rather than by editing the constants in place (which is what tps-bench
+      // did), so no already-published local run is invalidated. Asserted on the
+      // PIN VALUES rather than a whole-manifest hash, so legitimate manifest
+      // growth does not force this to be rewritten.
+      const got = JSON.parse(await inProfile({ LME_MODEL_PROFILE: undefined },
+        `process.stdout.write(JSON.stringify({ profile: MODEL_PROFILE, judge: JUDGE, reader: READER }));`));
+      expect(got.profile).toBe("local");
+      expect(got.judge).toEqual(LOCAL_PINS.judge);
+      expect(got.reader).toEqual(LOCAL_PINS.reader);
+    });
+
+    test("the cloud pins are exactly what the published headline recorded", async () => {
+      // Ties the cloud profile to the published record rather than to a second
+      // copy of the same literals: if these ever diverge, the headline stops
+      // being reproducible, and that is the thing worth failing on.
+      const headline = loadArtifact(HISTORICAL_VARIANTS[0]!.artifactFile);
+      const got = JSON.parse(await inProfile({ LME_MODEL_PROFILE: "cloud" },
+        `process.stdout.write(JSON.stringify({ judge: JUDGE, reader: READER }));`));
+      expect(got.judge).toEqual(headline.config.judge);
+      expect(got.reader).toEqual(headline.config.reader);
+    });
+
+    test("absent, empty and explicit 'local' are the same configuration", async () => {
+      // A CI runner that materialises an undefined variable as "" must not take
+      // a different path from one that omits it.
+      const pins = `process.stdout.write(JSON.stringify({ p: MODEL_PROFILE, j: JUDGE.model, r: READER.model }));`;
+      const absent = await inProfile({ LME_MODEL_PROFILE: undefined }, pins);
+      const empty = await inProfile({ LME_MODEL_PROFILE: "" }, pins);
+      const explicit = await inProfile({ LME_MODEL_PROFILE: "local" }, pins);
+      expect(empty).toBe(absent);
+      expect(explicit).toBe(absent);
+    });
+
+    test("the profile switch is not inert", async () => {
+      // If the selector silently resolved to one profile, a cloud run and a
+      // local run would be indistinguishable by configHash — exactly the
+      // collision the hash exists to prevent.
+      const ref = `
+        const m = configManifest({ n: 2, seed: 0, runs: 1, questionIds: ["q-a", "q-b"] });
+        process.stdout.write(hashConfig(m));
+      `;
+      const local = await inProfile({ LME_MODEL_PROFILE: "local" }, ref);
+      const cloud = await inProfile({ LME_MODEL_PROFILE: "cloud" }, ref);
+      expect(cloud).not.toBe(local);
+    });
+
+    test("an unknown profile is fatal, not a silent fallback", async () => {
+      // A free-form string compared by exact match must fail CLOSED: an
+      // unrecognised profile has to stop the run, never quietly select a
+      // default and mislabel the artifact's pins.
+      await expect(
+        inProfile({ LME_MODEL_PROFILE: "cloudy" }, `process.stdout.write(MODEL_PROFILE);`),
+      ).rejects.toThrow();
+    });
+  });
+
+  test("canonicalJson is order-independent, which is what makes the hash portable", () => {
+    const a = canonicalJson({ b: 1, a: { d: 2, c: [3, { f: 4, e: 5 }] } });
+    const b = canonicalJson({ a: { c: [3, { e: 5, f: 4 }], d: 2 }, b: 1 });
+    expect(a).toBe(b);
+    expect(hashConfig({ x: 1, y: 2 })).toBe(hashConfig({ y: 2, x: 1 }));
+  });
+});


### PR DESCRIPTION
Closes #1366
Refs #1236

The harness that produced our headline LongMemEval numbers lived only on tps-bench. "Run it yourself" reproduced a **different harness** than the one that made the numbers, and the gap sat exactly on the parts that touch measurement. This ports it, classifies every knob, and verifies the result against the published headline artifact.

> **Rebased onto #1364 (2026-08-24).** One conflict, in `eval.ts`: #1364's `rankedIds` on the returned `QuestionArmResult` versus my comment explaining why I'd held it back. Resolved by keeping #1364's line and dropping the now-obsolete note — the field is theirs and is upstream. `config.ts` auto-merged with both sides intact (their `readerPayloadFormat` + portability caveat, my model profiles), no duplicated pins.
>
> **With #1364 upstream, the repo and the VM now fully converge** — see verification 3. The reproducibility test was also redesigned, because #1364 broke the original pin *by design*; see "Reproducing a past run" below.

## The classification

The test applied throughout is **"can this change the measured quantity while the harness is working correctly?"** — not "does it affect the run", which is true of all of them.

- **Artifact-affecting** — under correct operation, two runs differing only in this setting can legitimately report different numbers. It must enter the hashed config, or the two runs collide on one `configHash` and the artifact stops identifying what was measured.
- **Operational-only** — cannot change the measured quantity under correct operation. It governs whether the run completes, how fast, and what telemetry it emits. If one of these ever moves a number, that is a **bug to fix, not a variant to hash** — hashing it would mint a fresh content-address for a broken run and hide the breakage.

### Artifact-affecting

| item | hashed as | reasoning |
|---|---|---|
| **Shared-store ingest-reuse** | `ingestion.harperStoreSharing` = `ingest-once-shared-store-alternating-mode` \| `per-arm-store` | This is a **measurement-validity** property, not an optimisation. Under whole-arm phasing, `flair` queried a store that grew question by question while `vector-only` queried an already-full-size one; filtered-ANN candidate recall degrades as the HNSW graph grows, so `vector-only` faced a systematically harder task — an asymmetry **biased toward the result we would most like to be true**. The two topologies genuinely measure different things and one contains a confound; hashing the topology is what stops them being compared as interchangeable. (Carried from the VM, which already recorded this field.) |
| **Model profile** (`LME_MODEL_PROFILE`) | `judge` / `reader` — the pins themselves | Different models trivially change what is measured. Needs **no new hashed field**: `configManifest()` has always folded the whole judge/reader objects into the hash. Adding a `modelProfile` key would be a redundant restatement of the pins that changed every already-published local hash for zero information gain. |
| **Selected arms** (`LME_ARMS`) | `arms` (the *selected* arms, not `ALL_ARMS`) | A 3-arm and a 4-arm run produce different aggregate content, and the contamination/ceiling reads needing the absent arms do not exist. An unknown arm name is fatal — a typo must not be indistinguishable from a deliberate subset. |

### Operational-only

| item | reasoning |
|---|---|
| **Cloud key-file auth** | `assertModelPinned()` aborts unless the served digest matches the pin, so any endpoint either serves the pinned weights or the run stops. Credentials cannot select an outcome. Key referenced **by path**, read in-process — never in argv, logs, or the artifact. |
| **429/5xx backoff** (60s/300s/300s; one 30s 5xx retry) | The request body is byte-identical on every attempt at temp 0 / seed 0 / fixed `num_ctx`+`num_predict`, so a retry can only turn "no answer" into the same answer this call was always going to produce. There is no resampling and no prompt mutation. Deliberately **narrow**: only 429 and 5xx, only bounded rounds — retrying a 4xx would mask a broken call, and retrying until success would let a flaky endpoint shape the sample. |
| **Per-eval journal** + its `rankedIds` / `retrievalMs` / `cfg` / `latencyMs` fields | A pure **write-side observer**: it appends a line describing a result that already exists, and nothing reads it during a normal run. No field it records can feed back into an answer, a verdict, or a metric — which is exactly why it is free to be verbose. |
| **Resume** (`LME_RESUME=1`) | Banked `(question, arm)` pairs are **replayed, never re-evaluated**, so the decision set is identical to an uninterrupted run. `runHash` content-addresses exactly those decisions and is resume-invariant. Extraction is recomputed from the dataset, so an extraction-method change can't be silently inherited from an old journal. *Caveat stated in code:* `artifactHash` covers latency percentiles, so a journal predating the `latencyMs` field would drag them down — a property of `artifactHash` generally, not of resume (see finding 2). |
| **Readiness hardening** | The one most worth challenging, so the argument in full: a gate that passes early *does* corrupt a number — but it is a **correctness precondition, not a measurement parameter**. Its contract is binary, and it is applied per question before *either* arm queries, so it cannot tilt one arm against the other. A lax gate produces an **invalid** run, not a different valid one; hashing the deadline would content-address the breakage. What makes this hold in practice is the gate's shape: the hard gate is a **deterministic, scale-independent** predicate (row exists + `embeddingModel` stamped) with no threshold to tune, and the scale-sensitive ranking probe was **demoted to non-fatal telemetry** precisely so no tunable could be suspected of having been tuned toward a nicer result. On a blown deadline it retries once and then **fails loudly** — there is no "give up and query anyway" path, which is what would make it artifact-affecting. |
| `LME_INGEST_CONCURRENCY` | Memories are fully determined by the dataset (ids, content, timestamps all from the entry), so the store end-state is identical at any concurrency. The write interleaving that varies already varies at the shipped default of 6 — pinning it would advertise a determinism the harness never had. |
| `LME_PROGRESS_FILE` | Write-only telemetry, never read back. |
| `LME_FLAIR_PKG_DIR` / `LME_HARPER_BIN_DIR` / `LME_BENCH_HOST` | Say *where* the system under test lives and label provenance; `benchHost` lands in the artifact's unhashed provenance partition. |

## How the cloud pins are carried

The VM edited the pinned constants **in place** — which is precisely the drift this issue is about, since the repo could then only express the local pins and a clean checkout could not reproduce the published `configHash` at all. Here they are a `LME_MODEL_PROFILE=local|cloud` selector with **`local` as the default**, so an unset environment reproduces pre-port behavior byte-for-byte. Empty-string is treated as unset (the shell's ordinary way of saying so); any other unrecognised value is **fatal**, never a silent fallback.

## Verification

Everything below is a command that was run, not an inference.

**1. Repo code reproduces the published headline `configHash` exactly.** Rebuilding the manifest from repo constants under the cloud profile, for the headline slice:

```
recomputed : a43d28c920a436b6a2f96ce60b178de5bf17e3e29c59f250b8d7a68098d06a51
headline   : a43d28c920a436b6a2f96ce60b178de5bf17e3e29c59f250b8d7a68098d06a51
MATCH      : true
```

The headline artifact (`635df13b…`, n=500, flair+vector-only+no-context, shared store) is committed at `test/bench/longmemeval/results/` and this is asserted as a standing test.

**2. Local profile is hash-neutral** — re-verified against post-#1364 main. `configManifest({n:2,seed:0,runs:1,questionIds:["q-a","q-b"]})`:

| tree / profile | configHash |
|---|---|
| `origin/main@8524b241` (with #1364, without this PR) | `696fde1ce21ea572…` |
| this branch, profile unset | `696fde1ce21ea572…` |
| this branch, `LME_MODEL_PROFILE=local` | `696fde1ce21ea572…` |
| this branch, `LME_MODEL_PROFILE=cloud` | `b98277aabcaa0cc2…` |

Adding the profiles moves nothing for local runs. No already-published local artifact is invalidated.

**3. The repo harness and the VM harness now FULLY converge.** Before the rebase they differed by `prompts.readerPayloadFormat`; with #1364 upstream that delta is gone. Same slice (n=2, seed 0, both Harper arms, shared store), computed in both trees:

```
VM harness   (~/bench)              : 0f8000def0367ab04f5f4fb651b8ffd2b699293a2e7efdb74e42b4cc23b08530
repo harness (this branch, cloud)   : 0f8000def0367ab04f5f4fb651b8ffd2b699293a2e7efdb74e42b4cc23b08530
```

Identical, no residual delta. Code-only diff (comments stripped) of the whole harness dir against the VM:

| file | result |
|---|---|
| `ollama.ts`, `run.ts`, `eval.ts`, `arms.ts`, `artifact.ts`, `dataset.ts`, `metrics.ts`, `paired-stats.ts`, `extraction.ts`, `judge.ts` | **converged — 0 code lines differ** |
| `config.ts` | 42 lines — **only** the profile selector. The repo is strictly more capable here: the VM can express the cloud pins alone (it edited the constants in place), the repo expresses both and defaults to local. |

**4. A clean checkout produces a self-verifying artifact** — re-run on the rebased tree. The branch was staged to the VM as a separate tree and run n=2, both Harper arms, cloud reader+judge:

```
reader=qwen3.5:397b (qwen3_5)  judge=gemma4:31b (gemma4)  [digests verified]
configHash: 0f8000def0367ab04f5f4fb651b8ffd2b699293a2e7efdb74e42b4cc23b08530
[shared] complete: 2 ingests for 2 questions × 2 arms = 4 evals
[run 1] done — runHash ca45369b65244eeb
artifactHash: fc42377965934839e1b0bb7a2cdd0632d47fb5bbbac3d3533c0c81a695086b6e
artifact self-verifies: true
```

`2 ingests for 2 questions × 2 arms` is the ingest-reuse property holding. Journal carried all required fields (`rankedIds`, `retrievalMs`, `cfg`, `latencyMs`); readiness gate, progress file and optional-arm guards all exercised.

Note the `runHash` moved from `88d3ac2b1bc07212` (pre-rebase, v1 payload) to `ca45369b65244eeb` under #1364's dated payload — different reader payload, different answers. That is the intended mechanism working end-to-end: the payload format changed what was measured, and the change is now carried in `configHash` via `prompts.readerPayloadFormat` rather than being invisible.

**5. Per-eval records agree with the actual headline run.** Measured **pre-rebase**, when the branch still carried the v1 payload the headline was produced with — which is precisely why it is the valid comparison against `headline-records.jsonl`. Same two questions:

| question | arm | verdict | tokensFed |
|---|---|---|---|
| `001be529` | flair | ✅ both CORRECT | ✅ both 3174 |
| `001be529` | vector-only | ✅ both CORRECT | ✅ both 3159 |
| `031748ae_abs` | flair | ✅ both CORRECT | ✅ both 4722 |
| `031748ae_abs` | vector-only | ✅ both CORRECT | ✅ both 4548 |

`tokensFed` identical **to the token** on all four means the assembled reader prompts were byte-identical — retrieval and payload formatting reproduce faithfully.

**6. Resume is verifiably result-preserving** — re-verified on the rebased tree. Re-running the same config with `LME_RESUME=1` against the journal from run 4:

```
[resume] 4 banked evals folded in; their (question,arm) pairs will be skipped
  [shared] resume partition: 2 fully banked, 0 single-arm, 0 to run
  [shared] complete: 0 ingests for 0 questions × 2 arms = 0 evals
[run 1] done — runHash ca45369b65244eeb          <- identical to the uninterrupted run
artifactHash: fc42377965934839e1b0bb7a2cdd0632d47fb5bbbac3d3533c0c81a695086b6e   <- identical
artifact self-verifies: true
```

Nothing was re-evaluated and the resumed run produced a **byte-identical artifact**. That is the operational-only classification demonstrated rather than asserted — and it also confirms the documented caveat's other half: because the journal carried `latencyMs`, the latency percentiles replayed faithfully and even `artifactHash` matched.

**7. The guard test fails when it should — and no longer fails when it shouldn't.** Mutation-checked against the redesigned test (each reverted):

| mutation | result | intent |
|---|---|---|
| **add** a new manifest field (a future measurement variant) | **11 pass / 0 fail** ✅ | harness growth must not invalidate past artifacts |
| move a cloud pin digest by one character | 3 fail ✅ | the headline's pins must stay expressible |
| change `READER_PROMPT_VERSION` | 2 fail ✅ | a prompt the headline depended on |
| **remove** a field the headline had | 2 fail ✅ | reconstruction genuinely impossible |
| move a local pin | 1 fail ✅ | neutrality only — precisely scoped |

The first row is the one that matters: under the original design it was a failure, and the only ways to green were to re-pin (destroying the property) or delete the test.

## Reproducing a past run — why the test was redesigned

The original test pinned "the hash current code emits" to a literal. #1364 proved that wrong within a day: adding `prompts.readerPayloadFormat` is a legitimate measurement change, and it broke the pin.

Re-pinning would have been the wrong fix. The manifest **is expected to grow** — every new variant adds a field — so a pin on current output is a treadmill that gets rewritten until someone rewrites it carelessly.

The test now asserts the property actually being sold: **repo code can reconstruct a past run's manifest and reproduce its recorded `configHash`.** For each artifact in `results/`, the current manifest is projected onto exactly the key set that artifact recorded, and the projection must hash to its `configHash`. Behaviour is deliberately asymmetric:

- **field added** → projection drops it, old hash still reproduces, no churn. The new field still governs *new* runs through the normal `configHash` path.
- **pinned value changed, or a field removed** → fails, because the repo genuinely can no longer express a published configuration.

Hash equality implies byte-identical canonical JSON, so the projection cannot pass vacuously; a separate test asserts the projection is doing real work (current manifest ⊋ historical, and the unprojected hash *differs*), so this can't silently degrade into "nothing ever changes".

Adding a headline later means committing its artifact and adding a row to `HISTORICAL_VARIANTS`. Old rows stay — the repo accumulates the ability to reproduce every number it has published.

Neutrality is likewise asserted on **pin values** (local pins equal the pre-port literals; cloud pins equal what the headline artifact recorded) rather than a whole-manifest hash, for the same immunity to shape churn.

Also confirmed the strict typecheck actually covers these files (`tsconfig.json` excludes `test/`; `tsconfig.test.check.json`, which CI runs, does not — verified by injecting a type error and watching it fire).

`bun test test/unit/longmemeval-*.test.ts` → 58 pass / 0 fail. `tsc -p tsconfig.test.check.json` → 0 errors. Changelog fragment validates.

## Findings that need a decision (not fixed here)

**1. The cloud reader is not deterministic at temperature 0 / seed 0.** Measured directly on `qwen3.5:397b` via ollama.com — four calls, byte-identical 32-token prompt, **three distinct completions**, diverging after a 68-char common prefix:

```
#1: ...only even prime number... "Two is unusual because it is the only even prime..."
#2: ...only even prime number... "The number 2 is unusual because it is the only even prime..."
reader: all 4 identical? false
judge:  all 4 identical? true  ["A","A","A","A"]   (trivial 16-token prompt — NOT a determinism proof)
```

This is batched cloud inference (MoE routing, mixed-precision kernels are not bitwise-stable across batch composition), **not** this harness — item 5 above shows the prompts reproduce exactly while the text does not.

Consequence for the claim: under `cloud`, `configHash` reproduces exactly and prompts reproduce exactly, but **`runHash` and `artifactHash` cannot be re-derived by anyone, including us**. Verdicts agreed 4/4 in the sample, so accuracy may be stable in aggregate — but that is a statistical claim, not a reproducibility one. The README now scopes this honestly. The `local` profile is *expected* to be closer to bitwise-stable but that is **unmeasured**; I have not claimed it.

**2. `artifactHash` is not wall-clock invariant.** It covers the aggregate, which includes `latencyP50Ms`/`latencyP95Ms`. `artifact.ts` says two runs with identical content hash identically "regardless of wall clock or host" — that is not true as written. `configHash` and `runHash` are the reproducible identities. Fixing it would change the artifact schema and invalidate published hashes, so it wants its own decision.

**3. The headline artifact records `gitCommit: null`.** `~/bench` on the VM is not a git repo, so the build of Flair under test is unrecorded — and `gitCommit` *is* in the hashed content partition. A provenance gap adjacent to this issue; `LME_FLAIR_PKG_DIR` (ported here) is what makes the no-git-repo case reachable, but it did not introduce the gap.

## Remaining drift, explicitly

Code-only diff (comments stripped) of this branch against the VM tree:

Post-rebase, code-only (comments stripped):

| file | delta | attribution |
|---|---|---|
| `ollama.ts`, `run.ts`, `eval.ts` | **zero** | exact port; `eval.ts` converged once #1364's `rankedIds` line landed upstream (kept theirs, dropped my hold-back note) |
| `arms.ts`, `artifact.ts`, `dataset.ts`, `metrics.ts`, `paired-stats.ts`, `extraction.ts`, `judge.ts` | **zero** | #1364's, now upstream — not duplicated here |
| `config.ts` | profile selector only | intended: the VM hardcoded the cloud pins, the repo expresses both |
| `agreement-records.ts` | **not ported** | judge-agreement study, a separate workstream — flagged, not silently dropped |
| `repro-canary.ts` | ported | the diagnostic the readiness-gate comment cites as evidence; VM's hardcoded `/home/exedev` dataset path replaced with an explicit required argument |
| `test/helpers/harper-lifecycle.ts` | VM is **behind** the repo | VM snapshot predates `appendRootConfigYaml` (#1257). Repo is a strict superset; the bench never passes that option (grepped). No port needed. |
| `payload-ab.ts` log marker | VM is **behind** #1364 | #1364 has the better version; not reverted |

The VM is now the thing that lags the repo, which is the right direction.

## Note for the reviewer

**The #1364 interaction is resolved.** It merged first; this branch is rebased onto it, the one conflict is resolved in #1364's favour, and the two are complementary as expected.

The predicted tripwire did fire — #1364's new manifest field broke the original hash pin. That was the correct signal and the wrong test shape, so the test is now a historical-variant reconstruction (see above) that survives manifest growth while still failing on a changed pin, prompt, extraction method, or removed field. The mutation matrix in verification 7 demonstrates both halves.

One judgement call worth a second opinion: the projection means a **newly added** manifest field is invisible to historical reconstruction. I believe that is correct — a field that did not exist was not part of what the old run measured, and new runs are still governed by the ordinary `configHash` — but it is the load-bearing assumption of the design, so it should be agreed rather than assumed.

Still standing from the original review, unchanged by the rebase: the three findings above (cloud reader nondeterminism, `artifactHash` not wall-clock invariant, `gitCommit: null` in the headline artifact). The first is the one with publication consequences.

No merge, no review requests — per the dispatch.
