### PR TITLE
fix(mcp): unify IdP credential matching on (kind, idpSubject) — supersede, never duplicate (flair#1317)

### DIFF
--- a/.changelog/unreleased/fixed-1317-credential-subject-unification.md
+++ b/.changelog/unreleased/fixed-1317-credential-subject-unification.md
@@ -1,0 +1,28 @@
+- **Identity mapping now enforces one active IdP credential per subject, so
+  re-linking a connector under a different provider name supersedes instead of
+  creating a duplicate whose resolution depended on iteration order
+  (flair#1317).** `provisionIdpIdentityMapping` deduplicated on
+  `(kind, idpProvider, idpSubject)` while `resolveAgentFromSub` resolves on
+  `(kind, idpSubject)`. A re-link under a new provider name — the ordinary case
+  when a JIT-provisioned sub (stamped `idpProvider: "mcp-oauth"`) is linked as,
+  say, `github` — matched nothing to reuse and INSERTED a second credential.
+  Both were `status: "active"` and both matched the resolver's filter, so which
+  Agent a token subject resolved to came down to whichever row the search
+  iterator served first: nondeterministic identity resolution on a
+  security-relevant mapping. Per the K&S ruling on #1317, the resolver's key is
+  the correct one and is unchanged; the linking layer now enforces the
+  uniqueness constraint the resolver already assumed. A cross-provider re-link
+  revokes the prior credential (terminal `status: "revoked"`, row retained for
+  audit, never resurrected by a later link) and writes the new one in a single
+  batched ops-API write with the survivor first, so there is no observable
+  two-active or zero-active window; the invariant is then re-read from the store
+  and a violation throws rather than returning a mapping that looks
+  deterministic and is not. `idpProvider` stays on the row as audit metadata but
+  no longer namespaces the subject. The result carries `credentialSuperseded` +
+  `supersededCredentialIds`, and `flair mcp enable`'s identity-mapping step
+  prints them as a revocation, not a de-duplication — an operator must not learn
+  about it later from something that stopped working. The same path heals stores
+  that the old key already left with several active credentials on one subject.
+  Pinned by `test/integration/mcp-connector-principal-mapping.test.ts` (e), which
+  reads two active credentials on unmodified main, and by (f), which proves a
+  revoked credential does not resolve at all — not merely that it loses a race.

--- a/docs/notes/mcp-oauth-model2.md
+++ b/docs/notes/mcp-oauth-model2.md
@@ -61,25 +61,43 @@ opt-in, never something the server infers. The practical consequences:
   agent id to attach the sub to it; the step's output states the resulting
   `sub → Agent` mapping in as many words.
 - **Linking a sub to an existing Agent (the same-identity opt-in).** Re-run
-  `flair mcp enable` with the SAME `--idp-provider`/`--idp-subject` and
-  `--principal <your-cli-agent-id>`. The existing `(provider, subject)`
-  Credential is RE-POINTED to that principal — one Credential row per subject,
-  so resolution stays deterministic. The link *replaces* the mapping; it does
-  not merge the two agents' memories.
+  `flair mcp enable` with the SAME `--idp-subject` and `--principal
+  <your-cli-agent-id>`. The existing Credential for that subject is RE-POINTED
+  to that principal — one ACTIVE Credential row per subject, so resolution stays
+  deterministic. The link *replaces* the mapping; it does not merge the two
+  agents' memories.
 - **First diagnostic: ask the server who you are.** The `bootstrap` tool's
   response always carries the resolved `agentId` and a `scope` descriptor
   (`scope.agentId` / `scope.isAdmin` / `scope.reads`, flair#1182). "My memory
   is empty over the connector" + a `bootstrap.agentId` you don't recognize =
   the sub resolved to a different (often JIT-provisioned) Agent — link it as
   above.
-- **JIT caveat.** A JIT-provisioned mapping (`FLAIR_MCP_JIT_PROVISION=1`)
-  stamps `idpProvider: "mcp-oauth"`. Runtime resolution matches on
-  `(kind, idpSubject)` only, but the *linking* upsert matches on
-  `(kind, idpProvider, idpSubject)` — so when re-linking a JIT-provisioned
-  sub, pass `--idp-provider mcp-oauth` (matching the JIT stamp), or first
-  revoke the JIT credential (`status: "revoked"`). Linking under a different
-  provider name creates a SECOND active credential for the same subject, and
-  which one wins resolution is unspecified.
+- **Re-linking under a different provider name SUPERSEDES (flair#1317).** A
+  JIT-provisioned mapping (`FLAIR_MCP_JIT_PROVISION=1`) stamps `idpProvider:
+  "mcp-oauth"`, so re-linking that sub as, say, `github` is a *provider change*.
+  The invariant is **at most one ACTIVE `Credential(kind:"idp", idpSubject)` per
+  subject, regardless of provider** — the same key runtime resolution uses. So
+  the link revokes the prior credential (terminal `status: "revoked"`, the row
+  retained for audit) and writes the new one, in a single batched write. You do
+  NOT need to match `--idp-provider` to the JIT stamp, and you do not need to
+  revoke anything by hand first. `provisionIdpIdentityMapping` returns
+  `credentialSuperseded: true` with the revoked ids, and the `flair mcp enable`
+  identity-mapping step prints them.
+
+  Read `credentialSuperseded` as **"the prior credential for this subject is now
+  dead"**, not "a duplicate was tidied up". `idpProvider` is audit/diagnostic
+  metadata on the row; it does not namespace the subject. Residual risk, ruled
+  acceptable (Sherlock, #1317): anyone who can run the link for a subject can
+  revoke that subject's existing credential, so two genuinely different people
+  sharing one subject string across providers would evict each other. IdP
+  subjects are opaque per-IdP identifiers, so this is remote — and the
+  alternative, duplicate active credentials resolved by iteration order, is
+  strictly worse.
+
+  Before the fix, the linking upsert deduped on `(kind, idpProvider,
+  idpSubject)` while resolution read `(kind, idpSubject)`, so a cross-provider
+  re-link silently created a SECOND active credential and which one won was
+  unspecified.
 
 The two-identity contract (a distinct connector agent sees other agents'
 org-non-private rows, never their private rows, 404-never-403 by id; a linked

--- a/src/lib/mcp-enable.ts
+++ b/src/lib/mcp-enable.ts
@@ -642,14 +642,74 @@ export interface IdentityMappingResult {
   principalCreated: boolean;
   credentialId: string;
   credentialReused: boolean;
+  /**
+   * flair#1317 — did this link REVOKE a prior credential for the same subject?
+   * True whenever one or more active credentials for `(kind:"idp", idpSubject)`
+   * under a DIFFERENT provider name were superseded. Not a cleanup: those
+   * credentials are dead, and anything that depended on them stops resolving.
+   */
+  credentialSuperseded: boolean;
+  /**
+   * The ids revoked by this call, in the order they were written. Plural
+   * because the pre-fix linking key could already have left several active
+   * credentials on one subject — this call heals that state, and the operator
+   * needs every id, not just one. Empty when nothing was superseded.
+   */
+  supersededCredentialIds: string[];
+}
+
+/** The resolver's own predicate, verbatim (resources/mcp-handler.ts
+ *  `resolveAgentFromSub`): a credential is resolvable unless it is explicitly
+ *  revoked. The linking layer MUST use the same test — a credential the linker
+ *  considers inactive but the resolver would still serve is exactly the
+ *  invisible-duplicate hole #1317 is about. */
+function isResolvableCredential(cred: { status?: unknown }): boolean {
+  return cred?.status !== "revoked";
 }
 
 /**
  * Map the operator's IdP subject to their principal via `Credential(kind:
  * "idp")` — the SAME credential surface resources/mcp-handler.ts's
- * `resolveAgentFromSub` reads at request time. Idempotent: an existing
- * mapping for (provider, subject) is reused (lastUsedAt bumped) rather than
- * duplicated; the principal Agent is created only if missing.
+ * `resolveAgentFromSub` reads at request time.
+ *
+ * ## The uniqueness constraint (flair#1317, K&S ruling 2026-08-21)
+ *
+ * **At most one ACTIVE `Credential(kind:"idp", idpSubject:<sub>)` exists at a
+ * time, regardless of `idpProvider`.** This function is where that invariant is
+ * enforced, because it is the only supported writer of the mapping.
+ *
+ * It used to dedup on `(kind, idpProvider, idpSubject)` while the resolver read
+ * `(kind, idpSubject)`. A re-link under a different provider name therefore
+ * matched nothing, INSERTED a second active credential, and left
+ * `resolveAgentFromSub` picking whichever row its search iterator served first
+ * — identity resolution by iteration order, on a security-relevant mapping.
+ *
+ * The resolver's key is the correct one and does not change: an IdP subject is
+ * an identity, and "who is this subject?" has exactly one answer. `idpProvider`
+ * stays on the row as audit/diagnostic metadata, but it does not participate in
+ * uniqueness. So:
+ *
+ *   - same provider, existing active credential → RE-POINT it (`credentialReused`);
+ *   - any OTHER active credential for the subject → SUPERSEDE it: terminal
+ *     `status: "revoked"`, never a soft flag a later path could flip back
+ *     (revoked rows are never reused here — a re-link after a revoke mints a
+ *     fresh credential);
+ *   - the re-point/insert and every revocation go out as ONE ops-API `upsert`
+ *     batch, so there is no observable window with two active credentials or
+ *     zero. If the batch fails, nothing is claimed and the call throws;
+ *   - after the write the invariant is RE-READ and asserted. A store that
+ *     somehow holds ≠1 active credential for the subject is a hard error, not a
+ *     silent nondeterministic mapping.
+ *
+ * The principal Agent is created only if missing.
+ *
+ * RESIDUAL RISK, by design (Sherlock, #1317): whoever can call this for a
+ * subject can revoke that subject's prior credential. If two genuinely
+ * different people ever shared a subject string across providers, one's link
+ * kills the other's mapping. IdP subjects are opaque per-IdP identifiers so the
+ * collision is remote, and the alternative — duplicate active credentials with
+ * order-dependent resolution — is strictly worse. `credentialSuperseded` exists
+ * so the operator is told, not so the event is hidden.
  */
 export async function provisionIdpIdentityMapping(
   params: IdentityMappingParams,
@@ -725,27 +785,47 @@ export async function provisionIdpIdentityMapping(
     principalCreated = true;
   }
 
-  // Reuse an existing Credential(kind:idp, provider, subject) mapping if present.
-  const searchCredRes = await fetchImpl(opsUrl, {
-    method: "POST",
-    headers: { "Content-Type": "application/json", Authorization: authHeader },
-    body: JSON.stringify({
-      operation: "search_by_conditions",
-      database: "flair",
-      table: "Credential",
-      operator: "and",
-      conditions: [
-        { search_attribute: "kind", search_type: "equals", search_value: "idp" },
-        { search_attribute: "idpProvider", search_type: "equals", search_value: params.idpProvider },
-        { search_attribute: "idpSubject", search_type: "equals", search_value: params.idpSubject },
-      ],
-      get_attributes: ["id", "principalId"],
-    }),
-  });
-  const existingCreds = searchCredRes.ok ? await searchCredRes.json().catch(() => []) : [];
-  const existing = Array.isArray(existingCreds) ? existingCreds[0] : undefined;
+  // ── flair#1317: look SUBJECT-WIDE, not (provider, subject) ─────────────────
+  // The resolver's key is (kind, idpSubject); anything narrower here leaves
+  // credentials that dedup cannot see but resolution can.
+  const findCredentialsForSubject = async (): Promise<any[]> => {
+    const res = await fetchImpl(opsUrl, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Authorization: authHeader },
+      body: JSON.stringify({
+        operation: "search_by_conditions",
+        database: "flair",
+        table: "Credential",
+        operator: "and",
+        conditions: [
+          { search_attribute: "kind", search_type: "equals", search_value: "idp" },
+          { search_attribute: "idpSubject", search_type: "equals", search_value: params.idpSubject },
+        ],
+        get_attributes: ["id", "principalId", "idpProvider", "idpSubject", "status", "label", "createdAt"],
+      }),
+    });
+    const body = res.ok ? await res.json().catch(() => []) : [];
+    return Array.isArray(body) ? body : [];
+  };
 
-  const credentialId = existing?.id ?? `cred_idp_${params.idpProvider}_${randomBytes(6).toString("hex")}`;
+  const subjectCreds = await findCredentialsForSubject();
+  const activeCreds = subjectCreds.filter(isResolvableCredential);
+
+  // Survivor: an ACTIVE same-provider credential is re-pointed (the idempotent
+  // re-run and the documented same-provider link). A revoked one is never
+  // resurrected — a re-link after a revoke mints a fresh credential.
+  const reused = activeCreds.find((c) => c?.idpProvider === params.idpProvider && c?.id);
+  const credentialId = reused?.id ?? `cred_idp_${params.idpProvider}_${randomBytes(6).toString("hex")}`;
+
+  // Everything else active for this subject is superseded. Under the old
+  // (provider, subject) key these rows were simply invisible; they are what made
+  // resolution order-dependent.
+  const superseded = activeCreds.filter((c) => c?.id && c.id !== credentialId);
+
+  // ONE batched write: the survivor first, then the revocations. A single
+  // ops-API operation is the strongest atomicity this surface can express, and
+  // ordering the survivor first means even a partially-applied batch can never
+  // leave the subject with ZERO resolvable credentials (the fail-open denial).
   const upsertRes = await fetchImpl(opsUrl, {
     method: "POST",
     headers: { "Content-Type": "application/json", Authorization: authHeader },
@@ -762,9 +842,25 @@ export async function provisionIdpIdentityMapping(
           status: "active",
           idpProvider: params.idpProvider,
           idpSubject: params.idpSubject,
-          createdAt: existing ? undefined : now,
+          createdAt: reused ? undefined : now,
           lastUsedAt: now,
         },
+        // Retained, not deleted: the revocation stays legible in storage and in
+        // Harper's table audit log (which records the full record image of
+        // every write). Identifying fields are echoed back so the row survives
+        // as a well-formed, revoked credential whichever merge semantics the
+        // ops API applies.
+        ...superseded.map((c) => ({
+          id: c.id,
+          principalId: c.principalId,
+          kind: "idp",
+          label: c.label,
+          status: "revoked",
+          idpProvider: c.idpProvider,
+          idpSubject: params.idpSubject,
+          createdAt: c.createdAt,
+          updatedAt: now,
+        })),
       ],
     }),
   });
@@ -773,7 +869,29 @@ export async function provisionIdpIdentityMapping(
     throw new Error(`Identity mapping: failed to write Credential(kind:idp) mapping (HTTP ${upsertRes.status}): ${text}`);
   }
 
-  return { principalCreated, credentialId, credentialReused: Boolean(existing) };
+  // ── The invariant, RE-READ ────────────────────────────────────────────────
+  // Asserting what we intended to write proves nothing. This asks the store.
+  // ≠1 active credential means the resolver's answer for this subject is
+  // order-dependent, so this fails LOUDLY rather than returning a mapping the
+  // operator would reasonably believe is deterministic.
+  const afterCreds = (await findCredentialsForSubject()).filter(isResolvableCredential);
+  if (afterCreds.length !== 1 || afterCreds[0]?.id !== credentialId) {
+    const seen = afterCreds.map((c) => `${c?.id} → ${c?.principalId} (provider '${c?.idpProvider}')`).join("; ") || "none";
+    throw new Error(
+      `Identity mapping: the uniqueness invariant does not hold after the write — subject '${params.idpSubject}' ` +
+        `has ${afterCreds.length} active Credential(kind:idp) row(s) [${seen}], expected exactly 1 (${credentialId}). ` +
+        `Runtime resolution for this subject would be iteration-order-dependent (flair#1317). ` +
+        `Inspect the Credential table for kind:"idp" idpSubject:"${params.idpSubject}" and revoke the rows that should not resolve.`,
+    );
+  }
+
+  return {
+    principalCreated,
+    credentialId,
+    credentialReused: Boolean(reused),
+    credentialSuperseded: superseded.length > 0,
+    supersededCredentialIds: superseded.map((c) => String(c.id)),
+  };
 }
 
 // ─── Restart only ────────────────────────────────────────────────────────────
@@ -1345,11 +1463,22 @@ export async function enableMcp(params: EnableMcpParams, deps: EnableMcpDeps = {
     // and the one silent failure mode this surface has is discovering that
     // via an empty bootstrap. So the step that creates the mapping states it
     // plainly, names the link remedy, and points at the runtime diagnostic.
+    // flair#1317 — a cross-provider re-link REVOKES the subject's prior
+    // credential (one active credential per subject is the invariant). That is
+    // a credential dying, so it is stated as such, by id: an operator must
+    // never discover it later from something that stopped working.
+    const supersedeNote = mapping.credentialSuperseded
+      ? ` SUPERSEDED: ${mapping.supersededCredentialIds.length} prior Credential(kind:idp) row(s) for this subject ` +
+        `were REVOKED, not de-duplicated — ${mapping.supersededCredentialIds.join(", ")}. ` +
+        `They no longer resolve, and anything relying on them stops working. ` +
+        `Exactly one active credential per (kind, idpSubject) is the invariant that keeps resolution deterministic.`
+      : "";
     push(true,
       `connector identity: sub '${params.idpSubject}' (provider '${idpProvider}') resolves to Agent '${principal}' — ` +
         `every /mcp call reads and writes AS '${principal}'. ` +
         `principal ${mapping.principalCreated ? "created" : "already existed"}; ` +
-        `Credential(kind:idp) ${mapping.credentialReused ? "re-pointed" : "created"} (${mapping.credentialId}). ` +
+        `Credential(kind:idp) ${mapping.credentialReused ? "re-pointed" : "created"} (${mapping.credentialId}).` +
+        `${supersedeNote} ` +
         `If your CLI signs as a DIFFERENT agent id, the connector sees that agent's DISTINCT memory scope (by design) — ` +
         `re-run with --principal <your-agent-id> to link them. ` +
         `Diagnostic: the bootstrap tool's agentId/scope fields always say who the server resolved you to.`,

--- a/test/integration/mcp-connector-principal-mapping.test.ts
+++ b/test/integration/mcp-connector-principal-mapping.test.ts
@@ -42,7 +42,18 @@
 //       principal=A re-points the SAME Credential row (no duplicate; resolution
 //       stays deterministic), after which the connector sees exactly what A
 //       sees — including NO LONGER seeing B's private rows (the link replaces
-//       the mapping, it does not union identities).
+//       the mapping, it does not union identities);
+//   (e) flair#1317 — RE-LINKING UNDER A DIFFERENT PROVIDER SUPERSEDES. The
+//       linking layer used to dedup on (kind, idpProvider, idpSubject) while
+//       the resolver reads (kind, idpSubject), so a re-link under a new
+//       provider name minted a SECOND active credential for the same subject
+//       and resolution became iteration-order-dependent. K&S ruling: unify the
+//       linking key on (kind, idpSubject); at most one ACTIVE credential per
+//       subject regardless of provider; the prior credential is hard-revoked,
+//       not duplicated;
+//   (f) flair#1317 fail-closed — a REVOKED credential does not resolve AT ALL,
+//       not merely "isn't returned first". This is the property that makes
+//       (e)'s supersede a real revocation rather than a re-ordering.
 //
 // MUTATION PROOF (fixture can express leakage): flip PRIVATE_VISIBILITY below
 // to "shared" and the never-sees-private assertions in (a)/(c) FAIL — the
@@ -70,6 +81,9 @@ const AGENT_A = `pm-cli-a-${sfx}`; // the operator's CLI identity
 const AGENT_B = `pm-conn-b-${sfx}`; // the connector's distinct identity
 const SUB = `pm-idp-sub-${sfx}`; // the IdP subject the token carries
 const PROVIDER = "github"; // same provider on provision AND link (see docs note)
+// flair#1317: the SECOND provider name the same subject gets re-linked under.
+// Under the pre-fix linking key this minted a duplicate active credential.
+const OTHER_PROVIDER = "mcp-oauth"; // the JIT stamp — the real-world collision
 
 // Single rare tokens so the BM25 lane surfaces them even keyword-only
 // (pattern: mcp-wrapper-layer-suite's SEARCH_TOKEN).
@@ -140,6 +154,19 @@ async function adminSearch(table: string, attribute: string, value: string): Pro
   });
   const body = await res.json().catch(() => []);
   return Array.isArray(body) ? body : [];
+}
+
+/** Write records straight into storage, past every resource-level gate. */
+async function adminUpsert(table: string, records: Record<string, unknown>[]): Promise<void> {
+  const res = await fetch(harper.opsURL, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: "Basic " + btoa(`${harper.admin.username}:${harper.admin.password}`),
+    },
+    body: JSON.stringify({ operation: "upsert", database: "flair", table, records }),
+  });
+  if (!res.ok) throw new Error(`admin upsert ${table} → HTTP ${res.status}: ${(await res.text()).slice(0, 300)}`);
 }
 
 beforeAll(async () => {
@@ -354,5 +381,116 @@ describe("flair#1280 — connector principal mapping (distinct-by-default, forma
       const connectorSees = rpc.result?.isError !== true && rpc.result?.structuredContent?.id === id;
       expect(connectorSees, `${label}: connector visibility (${connectorSees}) must equal A's direct visibility (${aSees})`).toBe(aSees);
     }
+  }, 120_000);
+
+  // ─── flair#1317 — the credential-matching asymmetry ────────────────────────
+  //
+  // RED ON MAIN (this is the regression, not a restatement): on unmodified
+  // main `provisionIdpIdentityMapping` dedups on (kind, idpProvider,
+  // idpSubject), so re-linking SUB under OTHER_PROVIDER finds nothing to reuse
+  // and INSERTS a second credential. Both are `status: "active"` and both match
+  // the resolver's (kind, idpSubject) filter, so `resolveAgentFromSub` returns
+  // whichever the search iterator serves first — identity resolution by
+  // iteration order. The `active.length` assertion below reads 2 on main.
+  test("(e) flair#1317 — re-linking the SAME subject under a DIFFERENT provider SUPERSEDES: one active credential, prior hard-revoked", async () => {
+    // PRECONDITION (and the control that the fixture is in the state the
+    // regression needs): after (d) there is exactly one active credential for
+    // SUB and it points at A, under PROVIDER.
+    const before = (await adminSearch("Credential", "idpSubject", SUB))
+      .filter((c) => c.kind === "idp" && c.status !== "revoked");
+    expect(before.length, "precondition: one active credential for SUB before the cross-provider re-link").toBe(1);
+    expect(before[0].principalId).toBe(AGENT_A);
+    expect(before[0].idpProvider).toBe(PROVIDER);
+
+    // THE DEFECT'S TRIGGER: same subject, DIFFERENT provider name.
+    const mapping = await provisionIdpIdentityMapping({
+      opsPortOrUrl: opsPort,
+      adminUser: harper.admin.username,
+      adminPass: harper.admin.password,
+      principal: AGENT_B,
+      principalKind: "agent",
+      idpProvider: OTHER_PROVIDER,
+      idpSubject: SUB,
+    });
+
+    const creds = (await adminSearch("Credential", "idpSubject", SUB)).filter((c) => c.kind === "idp");
+    const active = creds.filter((c) => c.status !== "revoked");
+
+    // THE INVARIANT: at most one ACTIVE Credential per (kind, idpSubject),
+    // regardless of provider — the constraint the resolver already assumes.
+    expect(
+      active.length,
+      `at most one active credential per (kind, idpSubject) — got ${active.length}: ` +
+        JSON.stringify(active.map((c) => ({ id: c.id, provider: c.idpProvider, principal: c.principalId, status: c.status }))),
+    ).toBe(1);
+    expect(active[0].principalId).toBe(AGENT_B);
+    expect(active[0].idpProvider).toBe(OTHER_PROVIDER);
+    expect(active[0].id).toBe(mapping.credentialId);
+
+    // SUPERSEDE, not duplicate and not delete: the prior row is RETAINED (so
+    // the revocation is recoverable from storage and from Harper's table audit
+    // log, which records the full record image of every write) and carries the
+    // TERMINAL "revoked" state — never a soft flag a later path could flip back.
+    const prior = creds.find((c) => c.id === firstCredentialId);
+    expect(prior, "the superseded credential row must be retained, not deleted").toBeDefined();
+    expect(prior!.status, "the superseded credential must be hard-revoked").toBe("revoked");
+    expect(prior!.principalId, "the superseded row keeps its prior principal for audit").toBe(AGENT_A);
+
+    // OBSERVABILITY: the caller is told a credential DIED, by id. `flair mcp
+    // enable`'s identity-mapping step reports this — an operator who re-links
+    // under a new provider name must not discover the revocation later.
+    expect(mapping.credentialSuperseded, "the result must report the supersede").toBe(true);
+    expect(mapping.supersededCredentialIds).toContain(firstCredentialId);
+    expect(mapping.credentialReused, "a cross-provider re-link is not a reuse").toBe(false);
+    expect(mapping.credentialId).not.toBe(firstCredentialId);
+
+    // DETERMINISM AT RUNTIME, repeated: with one active credential there is no
+    // iteration order left to depend on. (Repetition is the instrument: a
+    // two-active store can return the same answer once by luck.)
+    for (let i = 0; i < 3; i++) {
+      const boot = await mcpTool(SUB, "bootstrap", {});
+      expect(boot?.agentId, `bootstrap must resolve to B on every call (call ${i + 1})`).toBe(AGENT_B);
+      expect(boot?.scope?.agentId).toBe(AGENT_B);
+    }
+
+    // And the mapping really MOVED: A's private row — readable over the
+    // connector at the end of (d) — is no longer reachable.
+    const rpc = await mcpCall(SUB, "memory_get", { id: privateId });
+    expect(rpc.result?.isError, "after the supersede the connector is B again: A's private row is 404").toBe(true);
+    expect(rpc.result?.structuredContent?.status).toBe(404);
+  }, 120_000);
+
+  // Not a #1317 regression — #1317's supersede is only worth anything if
+  // "revoked" is a real denial. This pins the resolver's fail-closed property
+  // directly: the revoked credential is the ONLY credential for its subject, so
+  // "not returned first" cannot mask a pass. (Green on main too, by design —
+  // it is the security floor the supersede stands on.)
+  test("(f) flair#1317 fail-closed — a REVOKED credential does not resolve AT ALL, even as its subject's only credential", async () => {
+    const revokedSub = `pm-idp-revoked-${sfx}`;
+    const mapping = await provisionIdpIdentityMapping({
+      opsPortOrUrl: opsPort,
+      adminUser: harper.admin.username,
+      adminPass: harper.admin.password,
+      principal: AGENT_B,
+      principalKind: "agent",
+      idpProvider: PROVIDER,
+      idpSubject: revokedSub,
+    });
+
+    // POSITIVE CONTROL: while ACTIVE this sub resolves — so the denial below is
+    // the revocation, not an unprovisioned subject or a broken fixture.
+    const bootBefore = await mcpTool(revokedSub, "bootstrap", {});
+    expect(bootBefore?.agentId, "control: the active credential resolves").toBe(AGENT_B);
+
+    // The terminal state the supersede writes, applied directly.
+    await adminUpsert("Credential", [{ id: mapping.credentialId, status: "revoked" }]);
+    const [stored] = await adminSearch("Credential", "id", mapping.credentialId);
+    expect(stored?.status, "fixture control: the credential really is revoked in storage").toBe("revoked");
+    expect(stored?.principalId, "the row still names a real principal — so a resolver that ignored status WOULD resolve it").toBe(AGENT_B);
+
+    // THE ASSERTION: denied outright. Not de-prioritised — unresolvable.
+    const rpc = await mcpCall(revokedSub, "bootstrap", {});
+    expect(rpc.error?.message, `a revoked credential must not resolve: ${JSON.stringify(rpc).slice(0, 300)}`)
+      .toContain("not a provisioned flair agent");
   }, 120_000);
 });

--- a/test/unit/mcp-enable.test.ts
+++ b/test/unit/mcp-enable.test.ts
@@ -303,15 +303,71 @@ describe("buildSecretsBundle / writeSecretsStagingFile / provisionSecrets", () =
 
 // ─── identity mapping (Credential kind:idp) ──────────────────────────────────
 
+/**
+ * A minimal in-memory Credential table for the ops-API mocks (flair#1317).
+ *
+ * `provisionIdpIdentityMapping` now READS BACK its own write to assert the
+ * `(kind, idpSubject)` uniqueness invariant, so a mock that answers every
+ * `search_by_conditions` with a constant `[]` can no longer express a
+ * SUCCESSFUL provision — the read-back would see zero active credentials and
+ * the function would (correctly) fail closed. A fixture that cannot express
+ * the success path cannot express the defect either, so the mocks get a real
+ * (tiny) store rather than a constant.
+ *
+ * `handle` answers the two Credential ops and returns `null` for anything
+ * else, so each caller keeps its own fallthrough.
+ */
+function credentialTable(seed: Record<string, any>[] = []) {
+  const rows = new Map<string, any>(
+    seed.map((r) => [String(r.id), { kind: "idp", status: "active", ...r }]),
+  );
+  const handle = (body: any): Response | null => {
+    if (body?.operation === "search_by_conditions" && (body.table ?? "Credential") === "Credential") {
+      const cond = (name: string) =>
+        (body.conditions ?? []).find((c: any) => c.search_attribute === name)?.search_value;
+      const kind = cond("kind");
+      const subject = cond("idpSubject");
+      const provider = cond("idpProvider");
+      const hits = [...rows.values()].filter(
+        (r) =>
+          (kind === undefined || r.kind === kind) &&
+          (subject === undefined || r.idpSubject === subject) &&
+          (provider === undefined || r.idpProvider === provider),
+      );
+      return new Response(JSON.stringify(hits), { status: 200 });
+    }
+    if (body?.operation === "upsert" && body.table === "Credential") {
+      // Merge semantics, as the ops API applies: attributes absent from the
+      // record (JSON.stringify already dropped the `undefined`s) leave the
+      // stored value alone.
+      for (const rec of body.records ?? []) {
+        const id = String(rec.id);
+        rows.set(id, { ...(rows.get(id) ?? {}), ...rec });
+      }
+      return new Response(JSON.stringify({ message: "upserted" }), { status: 200 });
+    }
+    return null;
+  };
+  return { rows, handle, active: () => [...rows.values()].filter((r) => r.status !== "revoked") };
+}
+
 function mockOpsFetch(opts: {
   existingPrincipal?: boolean;
-  existingCredential?: { id: string } | null;
+  existingCredential?: Record<string, any> | null;
+  /** flair#1317 — seed several rows for one subject (the pre-fix duplicate state). */
+  existingCredentials?: Record<string, any>[];
   failFind?: boolean;
   failFindStatus?: number;
   failInsert?: boolean;
   failUpsert?: boolean;
-} = {}): { fetchImpl: typeof fetch; calls: any[] } {
+  /** flair#1317 — make the post-write invariant read-back lie (see its test). */
+  poisonReadBack?: (rows: Map<string, any>) => void;
+} = {}): { fetchImpl: typeof fetch; calls: any[]; creds: ReturnType<typeof credentialTable> } {
   const calls: any[] = [];
+  const seed = opts.existingCredentials ?? (opts.existingCredential ? [opts.existingCredential] : []);
+  const creds = credentialTable(
+    seed.map((c) => ({ idpProvider: "github", idpSubject: "octocat", principalId: "self", ...c })),
+  );
   const fetchImpl = (async (url: any, init?: RequestInit) => {
     const body = JSON.parse(String(init?.body ?? "{}"));
     calls.push({ url: String(url), body });
@@ -323,12 +379,15 @@ function mockOpsFetch(opts: {
       if (opts.failInsert) return new Response("insert failed", { status: 500 });
       return new Response(JSON.stringify({ message: "inserted" }), { status: 200 });
     }
-    if (body.operation === "search_by_conditions" && body.table === "Credential") {
-      return new Response(JSON.stringify(opts.existingCredential ? [opts.existingCredential] : []), { status: 200 });
+    if (body.operation === "upsert" && body.table === "Credential" && opts.failUpsert) {
+      return new Response("upsert failed", { status: 500 });
     }
-    if (body.operation === "upsert" && body.table === "Credential") {
-      if (opts.failUpsert) return new Response("upsert failed", { status: 500 });
-      return new Response(JSON.stringify({ message: "upserted" }), { status: 200 });
+    const credRes = creds.handle(body);
+    if (credRes) {
+      // The write has landed; let a test corrupt the store before the
+      // invariant read-back sees it.
+      if (body.operation === "upsert") opts.poisonReadBack?.(creds.rows);
+      return credRes;
     }
     if (body.operation === "set_configuration") {
       return new Response(JSON.stringify({ message: "Configuration successfully set." }), { status: 200 });
@@ -338,7 +397,7 @@ function mockOpsFetch(opts: {
     }
     return new Response("{}", { status: 200 });
   }) as typeof fetch;
-  return { fetchImpl, calls };
+  return { fetchImpl, calls, creds };
 }
 
 describe("provisionIdpIdentityMapping", () => {
@@ -350,8 +409,13 @@ describe("provisionIdpIdentityMapping", () => {
     );
     expect(result.principalCreated).toBe(true);
     expect(result.credentialReused).toBe(false);
+    expect(result.credentialSuperseded).toBe(false);
+    expect(result.supersededCredentialIds).toEqual([]);
     const ops = calls.map((c) => c.body.operation);
-    expect(ops).toEqual(["search_by_value", "insert", "search_by_conditions", "upsert"]);
+    // The trailing search_by_conditions is the flair#1317 invariant read-back:
+    // the function asks the STORE whether exactly one active credential now
+    // maps the subject, rather than trusting the write it just issued.
+    expect(ops).toEqual(["search_by_value", "insert", "search_by_conditions", "upsert", "search_by_conditions"]);
     const credRecord = calls[3].body.records[0];
     expect(credRecord.kind).toBe("idp");
     expect(credRecord.idpProvider).toBe("github");
@@ -367,9 +431,135 @@ describe("provisionIdpIdentityMapping", () => {
     );
     expect(result.principalCreated).toBe(false);
     expect(result.credentialReused).toBe(true);
+    expect(result.credentialSuperseded).toBe(false);
     expect(result.credentialId).toBe("cred_existing");
     const ops = calls.map((c) => c.body.operation);
-    expect(ops).toEqual(["search_by_value", "search_by_conditions", "upsert"]);
+    expect(ops).toEqual(["search_by_value", "search_by_conditions", "upsert", "search_by_conditions"]);
+  });
+
+  // ─── flair#1317 — the (kind, idpSubject) uniqueness constraint ─────────────
+
+  test("flair#1317: the dedup lookup keys on (kind, idpSubject) ONLY — provider must not narrow it", async () => {
+    // The defect in one assertion. The old lookup added an idpProvider
+    // condition, so a credential written under another provider name was
+    // invisible to dedup while remaining visible to the resolver, whose key is
+    // (kind, idpSubject).
+    const { fetchImpl, calls } = mockOpsFetch({ existingPrincipal: true });
+    await provisionIdpIdentityMapping(
+      { opsPortOrUrl: ISSUER, adminUser: "admin", adminPass: "pw", principal: "self", principalKind: "human", idpProvider: "github", idpSubject: "octocat" },
+      { fetchImpl },
+    );
+    const searches = calls.filter((c) => c.body.operation === "search_by_conditions");
+    expect(searches.length).toBe(2); // the dedup lookup + the invariant read-back
+    for (const s of searches) {
+      const attrs = s.body.conditions.map((c: any) => c.search_attribute).sort();
+      expect(attrs).toEqual(["idpSubject", "kind"]);
+    }
+  });
+
+  test("flair#1317: a re-link under a DIFFERENT provider supersedes — new credential active, prior REVOKED, reported by id", async () => {
+    const { fetchImpl, creds } = mockOpsFetch({
+      existingPrincipal: true,
+      existingCredential: { id: "cred_jit", idpProvider: "mcp-oauth", principalId: "agt_jit" },
+    });
+    const result = await provisionIdpIdentityMapping(
+      { opsPortOrUrl: ISSUER, adminUser: "admin", adminPass: "pw", principal: "self", principalKind: "human", idpProvider: "github", idpSubject: "octocat" },
+      { fetchImpl, now: () => "2026-08-24T00:00:00.000Z" },
+    );
+    expect(result.credentialReused, "a cross-provider re-link is not a reuse").toBe(false);
+    expect(result.credentialSuperseded).toBe(true);
+    expect(result.supersededCredentialIds).toEqual(["cred_jit"]);
+    expect(result.credentialId).not.toBe("cred_jit");
+
+    // The store, not the return value: exactly one resolvable row, and the
+    // prior one is RETAINED with the terminal state (not deleted, not soft).
+    expect(creds.active().map((r) => r.id)).toEqual([result.credentialId]);
+    expect(creds.rows.get("cred_jit")?.status).toBe("revoked");
+    expect(creds.rows.get("cred_jit")?.principalId, "the revoked row keeps its prior principal for audit").toBe("agt_jit");
+  });
+
+  test("flair#1317: supersede is ONE batched write — no observable two-active or zero-active window", async () => {
+    // Sherlock's atomicity requirement, at the granularity this surface can be
+    // observed: the re-point/insert and every revocation leave in a SINGLE
+    // ops-API operation, and the new credential is first in the batch so even a
+    // partially-applied batch can never strand the subject with zero.
+    const { fetchImpl, calls } = mockOpsFetch({
+      existingPrincipal: true,
+      existingCredentials: [
+        { id: "cred_a", idpProvider: "mcp-oauth", principalId: "agt_a" },
+        { id: "cred_b", idpProvider: "okta", principalId: "agt_b" },
+      ],
+    });
+    const result = await provisionIdpIdentityMapping(
+      { opsPortOrUrl: ISSUER, adminUser: "admin", adminPass: "pw", principal: "self", principalKind: "human", idpProvider: "github", idpSubject: "octocat" },
+      { fetchImpl },
+    );
+    const upserts = calls.filter((c) => c.body.operation === "upsert" && c.body.table === "Credential");
+    expect(upserts.length, "one write, not a deactivate-then-create sequence").toBe(1);
+    const records = upserts[0].body.records;
+    expect(records[0].id, "the surviving credential is written FIRST").toBe(result.credentialId);
+    expect(records[0].status).toBe("active");
+    expect(records.slice(1).map((r: any) => [r.id, r.status])).toEqual([
+      ["cred_a", "revoked"],
+      ["cred_b", "revoked"],
+    ]);
+    // …and the pre-existing duplicate state is HEALED, not preserved.
+    expect(result.supersededCredentialIds).toEqual(["cred_a", "cred_b"]);
+  });
+
+  test("flair#1317: a REVOKED credential is never resurrected — same provider, same subject mints a fresh one", async () => {
+    // Sherlock addition 2: "revoked" is terminal. Reusing a revoked row would
+    // make the supersede a soft flag with a re-activation path back.
+    const { fetchImpl, creds } = mockOpsFetch({
+      existingPrincipal: true,
+      existingCredential: { id: "cred_dead", idpProvider: "github", status: "revoked" },
+    });
+    const result = await provisionIdpIdentityMapping(
+      { opsPortOrUrl: ISSUER, adminUser: "admin", adminPass: "pw", principal: "self", principalKind: "human", idpProvider: "github", idpSubject: "octocat" },
+      { fetchImpl },
+    );
+    expect(result.credentialId).not.toBe("cred_dead");
+    expect(result.credentialReused).toBe(false);
+    expect(creds.rows.get("cred_dead")?.status, "the revoked row stays revoked").toBe("revoked");
+    // It was already dead, so nothing was superseded by this call.
+    expect(result.credentialSuperseded).toBe(false);
+  });
+
+  test("flair#1317: the post-write invariant read-back can FAIL — a store left with two active rows throws, never returns a mapping", async () => {
+    // The check must be able to fire. Poison the store right after the write so
+    // the read-back sees the very state the fix exists to prevent; if this
+    // still returned a mapping, the invariant assertion would be decorative.
+    const { fetchImpl } = mockOpsFetch({
+      existingPrincipal: true,
+      poisonReadBack: (rows) => {
+        rows.set("cred_smuggled", {
+          id: "cred_smuggled", kind: "idp", status: "active",
+          idpProvider: "smuggled", idpSubject: "octocat", principalId: "agt_other",
+        });
+      },
+    });
+    await expect(
+      provisionIdpIdentityMapping(
+        { opsPortOrUrl: ISSUER, adminUser: "admin", adminPass: "pw", principal: "self", principalKind: "human", idpProvider: "github", idpSubject: "octocat" },
+        { fetchImpl },
+      ),
+    ).rejects.toThrow(/uniqueness invariant does not hold.*2 active Credential/s);
+  });
+
+  test("flair#1317: the invariant error names the actor, the state and the remedy", async () => {
+    const { fetchImpl } = mockOpsFetch({
+      existingPrincipal: true,
+      poisonReadBack: (rows) => rows.clear(), // write vanished → zero active
+    });
+    const err = await provisionIdpIdentityMapping(
+      { opsPortOrUrl: ISSUER, adminUser: "admin", adminPass: "pw", principal: "self", principalKind: "human", idpProvider: "github", idpSubject: "octocat" },
+      { fetchImpl },
+    ).catch((e) => e as Error);
+    expect(err).toBeInstanceOf(Error);
+    expect(err.message).toContain("octocat");           // which subject
+    expect(err.message).toContain("0 active");           // what state
+    expect(err.message).toContain("flair#1317");         // why it matters
+    expect(err.message).toMatch(/revoke the rows/);      // what to do
   });
 
   test("throws on a failed principal lookup, never proceeds to write", async () => {
@@ -539,6 +729,7 @@ describe("buildClaudePasteBlock", () => {
 
 function fullMockFetch(overrides: { verifyStatus?: number; verifyBody?: any; sysInfoPidProvider?: () => number } = {}): { fetchImpl: typeof fetch; calls: string[] } {
   const calls: string[] = [];
+  const creds = credentialTable(); // flair#1317 — the mapping step reads its own write back
   let _sysInfoCallCount = 0;
   const fetchImpl = (async (url: any, init?: RequestInit) => {
     const urlStr = String(url);
@@ -552,7 +743,8 @@ function fullMockFetch(overrides: { verifyStatus?: number; verifyBody?: any; sys
     const body = JSON.parse(String(init?.body ?? "{}"));
     calls.push(`ops:${body.operation}`);
     if (body.operation === "search_by_value") return new Response(JSON.stringify([{ id: "self" }]), { status: 200 }); // principal exists
-    if (body.operation === "search_by_conditions") return new Response(JSON.stringify([]), { status: 200 }); // no existing credential
+    const credRes = creds.handle(body); // Credential search/upsert against a real (tiny) store
+    if (credRes) return credRes;
     if (body.operation === "system_information") {
        _sysInfoCallCount++;
        const pid = overrides.sysInfoPidProvider
@@ -844,6 +1036,7 @@ describe("enableMcp — flair#1120 restart verification", () => {
   test("sysinfo fails on first call: failedStep is restart, never identity-mapping", async () => {
     const calls: any[] = [];
     let sysInfoCount = 0;
+    const creds = credentialTable();
     const fetchImpl = (async (url: any, init?: RequestInit) => {
       const urlStr = String(url);
       const body = JSON.parse(String(init?.body ?? "{}"));
@@ -857,9 +1050,8 @@ describe("enableMcp — flair#1120 restart verification", () => {
         return new Response(JSON.stringify({ harperdb_processes: { core: [{ pid: 67890 }] } }), { status: 200 });
            }
       if (body.operation === "search_by_value") return new Response(JSON.stringify([{ id: "self" }]), { status: 200 });
-      if (body.operation === "search_by_conditions") return new Response(JSON.stringify([]), { status: 200 });
-      if (body.table === "Credential") return new Response(JSON.stringify([]), { status: 200 });
-      if (body.operation === "upsert") return new Response(JSON.stringify({ ok: true }), { status: 200 });
+      const credRes = creds.handle(body); // flair#1317: the mapping step reads its own write back
+      if (credRes) return credRes;
       if (urlStr.includes(".well-known")) {
         return new Response(JSON.stringify(CIMD_METADATA), { status: 200 });
           }
@@ -887,6 +1079,7 @@ describe("enableMcp — flair#1120 restart verification", () => {
     const calls: any[] = [];
     let sysInfoCallCount = 0;
     // Mock fetch: system_information always returns same PID (simulating thread bounce)
+    const creds = credentialTable();
     const fetchImpl = (async (url: any, init?: RequestInit) => {
       const urlStr = String(url);
       const body = JSON.parse(String(init?.body ?? "{}"));
@@ -897,9 +1090,8 @@ describe("enableMcp — flair#1120 restart verification", () => {
         return new Response(JSON.stringify({ harperdb_processes: { core: [{ pid: 12345 }] } }), { status: 200 });
        }
       if (body.operation === "search_by_value") return new Response(JSON.stringify([{ id: "self" }]), { status: 200 });
-      if (body.operation === "search_by_conditions") return new Response(JSON.stringify([]), { status: 200 });
-      if (body.table === "Credential") return new Response(JSON.stringify([]), { status: 200 });
-      if (body.operation === "upsert") return new Response(JSON.stringify({ ok: true }), { status: 200 });
+      const credRes = creds.handle(body); // flair#1317: the mapping step reads its own write back
+      if (credRes) return credRes;
        // self-verify endpoint
       if (urlStr.includes(".well-known")) {
         return new Response(JSON.stringify(CIMD_METADATA), { status: 200 });
@@ -938,6 +1130,7 @@ describe("enableMcp — flair#1120 restart verification", () => {
     const calls: any[] = [];
     let sysInfoCallCount = 0;
     // Mock fetch: system_information returns different PID on second call (real restart)
+    const creds = credentialTable();
     const fetchImpl = (async (url: any, init?: RequestInit) => {
       const urlStr = String(url);
       const body = JSON.parse(String(init?.body ?? "{}"));
@@ -949,9 +1142,8 @@ describe("enableMcp — flair#1120 restart verification", () => {
         return new Response(JSON.stringify({ harperdb_processes: { core: [{ pid }] } }), { status: 200 });
        }
       if (body.operation === "search_by_value") return new Response(JSON.stringify([{ id: "self" }]), { status: 200 });
-      if (body.operation === "search_by_conditions") return new Response(JSON.stringify([]), { status: 200 });
-      if (body.table === "Credential") return new Response(JSON.stringify([]), { status: 200 });
-      if (body.operation === "upsert") return new Response(JSON.stringify({ ok: true }), { status: 200 });
+      const credRes = creds.handle(body); // flair#1317: the mapping step reads its own write back
+      if (credRes) return credRes;
       if (urlStr.includes(".well-known")) {
         return new Response(JSON.stringify(CIMD_METADATA), { status: 200 });
        }
@@ -985,6 +1177,7 @@ describe("enableMcp — flair#1120 restart verification", () => {
   test("old PID for first 2 polls then new PID: SUCCEEDS (no false alarm)", async () => {
     const calls: any[] = [];
     let sysInfoCount = 0;
+    const creds = credentialTable();
     const fetchImpl = (async (url: any, init?: RequestInit) => {
       const urlStr = String(url);
       const body = JSON.parse(String(init?.body ?? "{}"));
@@ -1000,9 +1193,8 @@ describe("enableMcp — flair#1120 restart verification", () => {
         return new Response(JSON.stringify({ harperdb_processes: { core: [{ pid: 67890 }] } }), { status: 200 });
         }
       if (body.operation === "search_by_value") return new Response(JSON.stringify([{ id: "self" }]), { status: 200 });
-      if (body.operation === "search_by_conditions") return new Response(JSON.stringify([]), { status: 200 });
-      if (body.table === "Credential") return new Response(JSON.stringify([]), { status: 200 });
-      if (body.operation === "upsert") return new Response(JSON.stringify({ ok: true }), { status: 200 });
+      const credRes = creds.handle(body); // flair#1317: the mapping step reads its own write back
+      if (credRes) return credRes;
       if (urlStr.includes(".well-known")) {
         return new Response(JSON.stringify(CIMD_METADATA), { status: 200 });
         }
@@ -1035,6 +1227,7 @@ describe("enableMcp — flair#1120 restart verification", () => {
   test("always old PID: thread-bounce failure after timeout, failedStep verify-restart", async () => {
     const calls: any[] = [];
     let sysInfoCount = 0;
+    const creds = credentialTable();
     const fetchImpl = (async (url: any, init?: RequestInit) => {
       const urlStr = String(url);
       const body = JSON.parse(String(init?.body ?? "{}"));
@@ -1045,9 +1238,8 @@ describe("enableMcp — flair#1120 restart verification", () => {
         return new Response(JSON.stringify({ harperdb_processes: { core: [{ pid: 12345 }] } }), { status: 200 });
         }
       if (body.operation === "search_by_value") return new Response(JSON.stringify([{ id: "self" }]), { status: 200 });
-      if (body.operation === "search_by_conditions") return new Response(JSON.stringify([]), { status: 200 });
-      if (body.table === "Credential") return new Response(JSON.stringify([]), { status: 200 });
-      if (body.operation === "upsert") return new Response(JSON.stringify({ ok: true }), { status: 200 });
+      const credRes = creds.handle(body); // flair#1317: the mapping step reads its own write back
+      if (credRes) return credRes;
       if (urlStr.includes(".well-known")) {
         return new Response(JSON.stringify(CIMD_METADATA), { status: 200 });
         }
@@ -1270,13 +1462,14 @@ describe("enableMcp — Fabric operator-deploy (flair#1136)", () => {
   test("Fabric origin: reports operator-deploy requirement, never restarts", async () => {
     const FABRIC_ISSUER = "https://my-flair.harperfabric.com";
     const calls: string[] = [];
+    const creds = credentialTable();
     const fetchImpl = (async (url: any, init?: RequestInit) => {
       const urlStr = String(url);
       const body = init?.body ? JSON.parse(String(init.body)) : {};
       calls.push(`ops:${body.operation ?? urlStr}`);
       if (body.operation === "search_by_value") return new Response(JSON.stringify([{ id: "self" }]), { status: 200 });
-      if (body.operation === "search_by_conditions") return new Response(JSON.stringify([]), { status: 200 });
-      if (body.operation === "upsert") return new Response(JSON.stringify({ ok: true }), { status: 200 });
+      const credRes = creds.handle(body); // flair#1317: the mapping step reads its own write back
+      if (credRes) return credRes;
       return new Response(JSON.stringify({ message: "ok" }), { status: 200 });
     }) as typeof fetch;
 
@@ -1318,11 +1511,12 @@ describe("enableMcp — Fabric operator-deploy (flair#1136)", () => {
 
   test("Fabric origin: result includes issuer and resource for status checks", async () => {
     const FABRIC_ISSUER = "https://my-flair.harperfabric.com";
+    const creds = credentialTable();
     const fetchImpl = (async (url: any, init?: RequestInit) => {
       const body = init?.body ? JSON.parse(String(init.body)) : {};
       if (body.operation === "search_by_value") return new Response(JSON.stringify([{ id: "self" }]), { status: 200 });
-      if (body.operation === "search_by_conditions") return new Response(JSON.stringify([]), { status: 200 });
-      if (body.operation === "upsert") return new Response(JSON.stringify({ ok: true }), { status: 200 });
+      const credRes = creds.handle(body); // flair#1317: the mapping step reads its own write back
+      if (credRes) return credRes;
       return new Response(JSON.stringify({ message: "ok" }), { status: 200 });
     }) as typeof fetch;
 


### PR DESCRIPTION
Closes #1317

## The defect

`provisionIdpIdentityMapping` (src/lib/mcp-enable.ts) deduplicated on `(kind, idpProvider, idpSubject)`. `resolveAgentFromSub` (resources/mcp-handler.ts) resolves on `(kind, idpSubject)`.

So a re-link under a **different provider name** — the ordinary case when a JIT-provisioned sub (stamped `idpProvider: "mcp-oauth"`) is linked as, say, `github` — matched nothing to reuse and **INSERTED** a second credential. Both were `status: "active"`; both matched the resolver's filter. Which Agent a token subject resolved to then came down to whichever row the search iterator served first: nondeterministic identity resolution on a security-relevant mapping.

## Red on main — the powered check

The regression test was written first and run against **unmodified `main` at the exact merge base `4688a576`**, with zero changes under `src/` or `resources/` (`git diff --stat -- src/ resources/` empty at the time of the run):

```
error: at most one active credential per (kind, idpSubject) — got 2:
[{"id":"cred_idp_github_6a939a839358","provider":"github",
  "principal":"pm-cli-a-mt7dzmfn","status":"active"},
 {"id":"cred_idp_mcp-oauth_1db7d41d900c","provider":"mcp-oauth",
  "principal":"pm-conn-b-mt7dzmfn","status":"active"}]

Expected: 1
Received: 2

(fail) … > (e) flair#1317 — re-linking the SAME subject under a DIFFERENT
provider SUPERSEDES: one active credential, prior hard-revoked
 8 pass  1 fail  Ran 9 tests across 1 file.
```

Two active credentials for one subject, pointing at two different principals, both live. That is the defect, produced by the shipped supported flow against a real Harper.

## The design — Kern's ruling, with Sherlock's three additions

Both rulings are on #1317; this implements them as written.

**Kern (CTO ruling):** the resolver's key is correct *by design* — an IdP subject is an identity, and "who is this subject?" has exactly one answer. The bug is in the **linking layer**. Unify on `(kind, idpSubject)` there; enforce at-most-one active credential per subject regardless of provider; a cross-provider re-link **supersedes** rather than duplicates. **No resolver signature change** (it doesn't have the provider at call time, and changing it would cascade through `mcpHandler` / `mcp-oauth` / `XAA.ts` and change the semantics).

**Sherlock (security ruling), addition 1 — atomicity.** The re-point/insert and every revocation leave as **one batched ops-API `upsert`**, survivor first. A single operation is the strongest atomicity this surface can express, and survivor-first means even a partially applied batch can never strand the subject with **zero** active credentials (the fail-open denial). Pinned by a unit test that asserts exactly one `upsert` call and the record ordering within it — not a deactivate-then-create sequence.

**Sherlock, addition 2 — hard revoke, not a soft flag.** Superseded rows get terminal `status: "revoked"`. Revoked rows are **never reused** by a later link: a re-link after a revoke mints a fresh credential rather than resurrecting the dead one. Pinned by its own unit test — this closes the re-activation surface the old code had, where the lookup ignored `status` entirely and would have flipped a revoked same-provider row back to `active`.

**Sherlock, addition 3 — the cross-provider collision is a documented residual risk.** Whoever can run the link for a subject can revoke that subject's prior credential. Written up in `docs/notes/mcp-oauth-model2.md` and in the function's doc comment, in the terms Sherlock asked for: `credentialSuperseded: true` means *"the prior credential for this subject is now dead"*, not *"a duplicate was tidied up"*.

Plus Kern's point 3, the **fails-closed guarantee**: after the write the invariant is **re-read from the store** (asserting what we intended to write proves nothing). A subject left with anything other than exactly one active credential **throws**, naming the subject, the observed state, the rows, and the remedy — rather than returning a mapping the operator would reasonably believe is deterministic.

The linking layer now uses the resolver's own predicate verbatim (`status !== "revoked"`, factored out as `isResolvableCredential`). That equivalence is the real invariant: a credential the linker thinks is inactive but the resolver would still serve is exactly this bug's shape.

`idpProvider` stays on the row as audit/diagnostic metadata; it no longer namespaces the subject. The same code path **heals** stores the old key already left with several active credentials on one subject (`supersededCredentialIds` is plural for that reason).

## Revocation observability — the finding, stated plainly

**Our audit-log path does not cover credential revocation, and I did not add a half-measure.** What I found:

- `verifyAuditLog` (src/cli.ts:1996, the #970-era path) is a **`flair doctor` health probe**, not an audit emitter. It writes a probe row to the **`Memory`** table, PATCHes it, and calls `read_audit_log` to confirm Harper is *recording at all*. It never touches `Credential` and has no notion of a credential lifecycle.
- There is **no application-level revocation event** anywhere: no `OrgEvent` kind, no emit on any `status: "revoked"` write. Grepping `revoked` across `src/` and `resources/` turns up status *filters* and CLI *rendering*, and no event emission.
- Harper's own table audit log is generic and *does* capture the `Credential` upsert with a full record image — but only when `logging.auditLog` is enabled in the **root** `harperdb-config.yaml`, which flair does not ship or set (the CLI only *reports* the knob, at src/cli.ts:4064/14004). So on a default install there is no audit record of the revocation.

Rather than bolt a bespoke event onto this PR, the fix makes the revocation observable through the channels that already exist, and the tests assert those:

1. **The row is retained, not deleted**, carrying terminal `status: "revoked"` and its **prior `principalId`** — so the before/after mapping is recoverable straight from storage. Asserted in integration (e) and in the unit suite.
2. **The result reports it**: `credentialSuperseded: true` + `supersededCredentialIds: [...]`.
3. **The operator is told at the moment it happens**: `flair mcp enable`'s identity-mapping step now prints `SUPERSEDED: N prior Credential(kind:idp) row(s) for this subject were REVOKED, not de-duplicated — <ids>. They no longer resolve, and anything relying on them stops working.`

If we want a real credential-lifecycle audit event, that is its own issue — say the word and I'll file it.

## Fail-closed — asserted directly, not inferred

Integration test **(f)** pins the property the whole supersede rests on: a revoked credential **does not resolve at all**, not merely that it loses a race. The revoked credential is its subject's **only** credential, so "isn't returned first" cannot mask a pass; the row still names a real principal, so a resolver that ignored `status` **would** resolve it. The assertion is the outright denial (`forbidden: token subject is not a provisioned flair agent`), with a positive control immediately before it proving the same credential resolved fine while active.

(f) is green on `main` too, by design — it is the existing security floor, and it is now pinned so a future change can't quietly remove it.

## In-flight sessions under a superseded credential

**They do not keep working as the old principal — they switch to the new one, immediately, with no re-auth.** Verified, not assumed:

- `resolveAgentFromSub` is called **per `tools/call`** (resources/mcp-handler.ts:391). There is **no session cache and no resolved-agent cache** anywhere in `mcp-handler.ts` or `mcp-oauth.ts` (only the JWKS is cached, for JWT verification).
- The bearer token itself is untouched and stays valid — it is an AS-issued RS256 JWT and this change never touches token state. But the token only carries a `sub`; the `sub → Agent` mapping is re-read from the `Credential` table on every call, and the resolver skips `status === "revoked"`.

So the moment the supersede commits, the very next tool call on an existing connection resolves to the **new** principal. Integration (e) demonstrates exactly this with no new token: bootstrap self-describes as B on three consecutive calls, and A's private row — readable over that same connection at the end of (d) — returns 404.

**Is that acceptable? Yes, and it is the point.** A link is a deliberate operator action whose entire purpose is to change which Agent a subject resolves to; a grace window would mean the operator's re-link silently did nothing for the duration of a live session, which is the "my connector still shows the wrong memory" confusion #1280 exists to eliminate. It also means a revocation is *effective immediately* rather than bounded by token TTL — the right posture for a security control.

The one thing worth naming: this is an **identity change mid-session without a re-auth**, so a connector that cached its own `agentId` from an earlier `bootstrap` will be stale. The existing diagnostic covers it — `bootstrap` always self-describes the resolved agent — and the docs note points at it.

## Test counts (self-measured, same machine, same base `4688a576`)

| Lane | Baseline (clean `4688a576`) | With this change |
|---|---|---|
| Unit (`test/unit/ test/*.test.ts`) | 5106 pass / 0 fail / 11814 expects / 262 files | **5112 pass / 0 fail** / 11842 expects / 262 files |
| `test/integration/mcp-connector-principal-mapping.test.ts` | 7 pass / 0 fail / 70 expects | **9 pass / 0 fail** / 106 expects |
| All 5 `test/integration/mcp-*.test.ts` together | 33 pass / 0 fail | **35 pass / 0 fail** / 269 expects |
| `tsc --noEmit` × `check` / `check.src` / `cli` / `test.check` | — | **all clean** |

+6 unit tests, +2 integration tests. Pre-commit hook (workspace-deps, dep-ages, impl-term-leaks) green.

One combined-lane run showed a `waitForHealth` timeout in `mcp-bootstrap-payload-1182.test.ts`. That was local ambient contention, not this change: port 8883 on this box is held by the **production** Flair instance (`~/flair-prod`), plus another agent's worktree Harper was running. The file passes in isolation (2 pass / 0 fail) and the combined lane is green on re-run (35 pass / 0 fail) — the table above reports the clean run.

## Fixture change worth a reviewer's eye

The unit mocks answered every `search_by_conditions` with a constant `[]`. Once `provisionIdpIdentityMapping` reads back its own write, such a mock can no longer express a **successful** provision — the read-back sees zero active credentials and the function correctly fails closed. A fixture that can't express the success path can't express the defect either, so the mocks got a small real store (`credentialTable()`) instead of a constant: upserts land, searches serve what landed, with the ops API's merge semantics.

That store is also what makes the invariant check's own **positive control** possible: one test poisons the store *after* the write so the read-back sees two active rows and asserts the function **throws** — proving the assertion can fire rather than being decorative. A second poison case (write vanishes → zero active) asserts the error names the subject, the state, why it matters, and the remedy.

## Files

- `src/lib/mcp-enable.ts` — the fix, the result shape, the operator-facing supersede report
- `test/integration/mcp-connector-principal-mapping.test.ts` — (e) the regression, (f) fail-closed
- `test/unit/mcp-enable.test.ts` — 6 new tests + the stateful Credential mock
- `docs/notes/mcp-oauth-model2.md` — the "JIT caveat" this fix removes, replaced with the supersede semantics and the residual risk
- `.changelog/unreleased/fixed-1317-credential-subject-unification.md`

No merge, no review requests — K&S review at their own cadence.
