### PR TITLE
fix(cli): flair test banner prints the resolved target URL (#1351)

### DIFF
--- a/.changelog/unreleased/fixed-test-banner-resolved-url.md
+++ b/.changelog/unreleased/fixed-test-banner-resolved-url.md
@@ -1,0 +1,1 @@
+- **`flair test` banner now prints the URL the test actually talks to.** With `FLAIR_URL` pointed at a remote, the command already ran against that remote but the banner printed `127.0.0.1:<port>` — so connectivity debugging claimed a possibly-dead local instance. The banner now uses the same resolved target the test's own client uses (flair#1351).

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -13172,7 +13172,10 @@ program
       process.exit(1);
     }
 
-    const baseUrl = `http://127.0.0.1:${resolveHttpPort(opts)}`;
+    // Single source of truth (flair#1351): banner prints the URL the test's
+    // own client uses. resolveBaseUrl is the existing CLI resolver; pass the
+    // same value through to api() so the two cannot diverge.
+    const baseUrl = resolveBaseUrl(opts);
     console.log(`\n${render.wrap(render.c.bold, "Flair test")} ${render.wrap(render.c.dim, `(url: ${baseUrl})`)}\n`);
 
     let passed = 0;
@@ -13207,7 +13210,7 @@ program
         createdAt: new Date().toISOString(),
       };
       if (agentId) body.agentId = agentId;
-      await api("PUT", `/Memory/${id}`, body);
+      await api("PUT", `/Memory/${id}`, body, { baseUrl });
       memoryId = id;
       return true;
     });
@@ -13217,7 +13220,7 @@ program
       await new Promise(r => setTimeout(r, 1500)); // allow indexing
       const body: Record<string, any> = { q: "flair test", limit: 5 };
       if (agentId) body.agentId = agentId;
-      const result = await api("POST", "/SemanticSearch", body);
+      const result = await api("POST", "/SemanticSearch", body, { baseUrl });
       return (result?.results?.length ?? 0) > 0;
     });
 
@@ -13228,7 +13231,7 @@ program
         console.log(`       (skipped — no id returned from write step)`);
         return true;
       }
-      await api("DELETE", `/Memory/${memoryId}`, agentId ? { agentId } : undefined);
+      await api("DELETE", `/Memory/${memoryId}`, agentId ? { agentId } : undefined, { baseUrl });
       return true;
     });
 

--- a/test/unit/cli-test-banner.test.ts
+++ b/test/unit/cli-test-banner.test.ts
@@ -1,0 +1,89 @@
+/**
+ * cli-test-banner.test.ts — flair#1351
+ *
+ * `flair test` honors FLAIR_URL in its client (`api()`) but used to print
+ * `http://127.0.0.1:<port extracted from FLAIR_URL>` in the banner. With
+ * FLAIR_URL pointed at a remote, the test ran against the remote while the
+ * banner claimed a possibly-dead local instance.
+ *
+ * The banner must render the same resolved URL the test's own client uses —
+ * one value, not a second derivation. These tests spawn the real CLI so the
+ * assertion is on the banner text an operator sees.
+ */
+import { describe, test, expect } from "bun:test";
+import { spawn } from "node:child_process";
+import { mkdtempSync, rmSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+const cliPath = join(import.meta.dirname, "..", "..", "src", "cli.ts");
+
+function runCli(args: string[], env: NodeJS.ProcessEnv): Promise<{ code: number | null; stdout: string; stderr: string }> {
+  return new Promise((resolve) => {
+    const child = spawn("bun", [cliPath, ...args], { env, cwd: join(import.meta.dirname, "..", "..") });
+    let out = "";
+    let err = "";
+    child.stdout?.on("data", (d) => (out += d.toString()));
+    child.stderr?.on("data", (d) => (err += d.toString()));
+    child.on("close", (code) => resolve({ code, stdout: out, stderr: err }));
+  });
+}
+
+function isolatedEnv(overrides: NodeJS.ProcessEnv = {}): { env: NodeJS.ProcessEnv; cleanup: () => void } {
+  const tmpHome = mkdtempSync(join(tmpdir(), "flair1351-home-"));
+  const env: NodeJS.ProcessEnv = {
+    ...process.env,
+    HOME: tmpHome,
+    ...overrides,
+  };
+  delete env.FLAIR_TARGET;
+  return {
+    env,
+    cleanup: () => rmSync(tmpHome, { recursive: true, force: true }),
+  };
+}
+
+describe("flair#1351 — flair test banner prints the resolved target URL", () => {
+  test("banner text under FLAIR_URL override contains the override, not the default", async () => {
+    // Remote-looking override (the casa-cluster shape): old banner extracted
+    // only the port and printed http://127.0.0.1:9926. A localhost mock URL
+    // would not catch that host-swap — 127.0.0.1:<extracted-port> looks right.
+    const override = "https://casa.example.test:9926";
+    const { env, cleanup } = isolatedEnv({ FLAIR_URL: override });
+    try {
+      const { stdout } = await runCli(["test", "--agent", "test-1351"], env);
+      expect(stdout).toContain(`(url: ${override})`);
+      expect(stdout).not.toContain("127.0.0.1:9926");
+      expect(stdout).not.toContain("127.0.0.1:19926");
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("default banner is stock :19926, not the stale :9926 literal (#1347 family sweep)", async () => {
+    const { env, cleanup } = isolatedEnv();
+    delete env.FLAIR_URL;
+    try {
+      const { stdout } = await runCli(["test", "--agent", "test-1351"], env);
+      expect(stdout).toContain("(url: http://127.0.0.1:19926)");
+      // Colon-anchored: ":19926" contains the substring "9926", so a bare
+      // contains-check could never catch a flip back to the fossilized spoke
+      // port. The leading colon makes ":9926" match ONLY the old literal.
+      expect(stdout).toContain(":19926");
+      expect(stdout).not.toContain(":9926");
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("source sweep: flair test command does not hardcode 127.0.0.1:9926", () => {
+    const src = readFileSync(cliPath, "utf-8");
+    const start = src.indexOf("// ─── flair test");
+    const end = src.indexOf("// ─── flair deploy");
+    expect(start).toBeGreaterThan(-1);
+    expect(end).toBeGreaterThan(start);
+    const block = src.slice(start, end);
+    expect(block).not.toMatch(/127\.0\.0\.1:9926/);
+    expect(block).not.toMatch(/localhost:9926/);
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #1351.

Could not assign to heskew from the coordinator (GitHub assign 403). Did not block on assign.

## Problem

`flair test` already honors `FLAIR_URL` in its client (`api()`), but the banner built a different URL: `http://127.0.0.1:${resolveHttpPort(opts)}`. `resolveHttpPort` only extracts a port from `FLAIR_URL`, so a remote override such as `https://casa.example:9926` ran against the remote while the banner printed `http://127.0.0.1:9926`. During connectivity debugging that is actively misleading.

## Fix

Investigate first, then make the banner and the client the same value — no second URL resolver.

- Banner now calls the existing `resolveBaseUrl(opts)` (the CLI's unified target resolver: `--target` / `--url` / `FLAIR_TARGET` / `FLAIR_URL` / `http://127.0.0.1:<resolveHttpPort>`).
- That same `baseUrl` is passed through to every `api()` call in `flair test`, so the printed target is the one the test actually talks to.

## Tests

- Banner text under a remote `FLAIR_URL` override contains the override, not `127.0.0.1:9926` / `:19926`.
- Default banner (isolated `HOME`, no `FLAIR_URL`) is stock `:19926`, colon-anchored so it cannot silently flip back to the stale `:9926` (#1347 family sweep).
- Source sweep of the `flair test` command block: no hardcoded `127.0.0.1:9926` / `localhost:9926`.

## Changelog

`.changelog/unreleased/fixed-test-banner-resolved-url.md`

Scope is #1351 only. No mix with #1330, #1314, or later issues.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-837f8a20-a739-43f4-aad1-252ce5016dba?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-837f8a20-a739-43f4-aad1-252ce5016dba&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

