### PR TITLE
fix(flair-mcp): report package version in MCP initialize

### DIFF
--- a/.changelog/unreleased/fixed-1314-flair-mcp-serverinfo-version.md
+++ b/.changelog/unreleased/fixed-1314-flair-mcp-serverinfo-version.md
@@ -1,0 +1,1 @@
+- **flair-mcp `initialize` now reports the published package version.** Client UIs (Claude Code `/mcp`, Cursor) were showing `0.1.0` because `serverInfo.version` was hardcoded. It now reads `@tpsdev-ai/flair-mcp`'s `package.json`, so the version a debugger sees is the version that's running (flair#1314).

--- a/packages/flair-mcp/src/index.ts
+++ b/packages/flair-mcp/src/index.ts
@@ -53,6 +53,7 @@ import {
   type PresenceActivity,
 } from "./presence.js";
 import { readEnvOrUnset, stripInterpolationLiteralsFromEnv } from "./env-guard.js";
+import { serverInfo } from "./version.js";
 
 // ─── Error helpers ──────────────────────────────────────────────────────────
 
@@ -231,10 +232,7 @@ export async function runMcp(): Promise<void> {
 
   // ─── MCP Server ──────────────────────────────────────────────────────────────
 
-  const server = new McpServer({
-    name: "flair",
-    version: "0.1.0",
-  });
+  const server = new McpServer(serverInfo());
 
   // ─── Tools ───────────────────────────────────────────────────────────────────
 

--- a/packages/flair-mcp/src/version.ts
+++ b/packages/flair-mcp/src/version.ts
@@ -1,0 +1,56 @@
+/**
+ * version.ts — the version advertised in MCP `initialize` `serverInfo`.
+ *
+ * `process.env.npm_package_version` is only populated inside `npm run`, so
+ * reading this package's own package.json relative to THIS running module is
+ * the only way to report the version of the code that's actually executing
+ * (same reason as resources/version.ts). Walk-by-name rather than a fixed
+ * number of `..` hops, matching src/lib/mcp-spec.ts: this file compiles to
+ * dist/version.js, tests import the .ts next to src/, and a hardcoded depth
+ * is one move away from silently advertising the wrong package — or "dev".
+ */
+
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+/** The published package whose version `initialize` must report. */
+export const FLAIR_MCP_PACKAGE = "@tpsdev-ai/flair-mcp";
+
+/** What we advertise when package.json cannot be read. */
+export const UNKNOWN_VERSION = "dev";
+
+/**
+ * Walk up from `startDir` looking for `@tpsdev-ai/flair-mcp`'s own package.json.
+ * Exported for tests, which need to exercise the not-found path without
+ * corrupting a real install.
+ */
+export function resolvePackageVersionFrom(startDir: string): string {
+  let dir = startDir;
+  // 8 levels is far more than any real layout needs (dist/ → package root is 1)
+  // while still terminating on a pathological symlink loop.
+  for (let i = 0; i < 8; i++) {
+    try {
+      const pkg = JSON.parse(readFileSync(join(dir, "package.json"), "utf-8"));
+      if (pkg?.name === FLAIR_MCP_PACKAGE && typeof pkg.version === "string" && pkg.version) {
+        return pkg.version;
+      }
+    } catch {
+      // No package.json here, or unreadable/malformed — keep walking.
+    }
+    const parent = dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+  return process.env.npm_package_version ?? UNKNOWN_VERSION;
+}
+
+/** This package's version — what `initialize` puts in `serverInfo.version`. */
+export function resolvePackageVersion(): string {
+  return resolvePackageVersionFrom(dirname(fileURLToPath(import.meta.url)));
+}
+
+/** The `serverInfo` object passed to `McpServer` (and thus returned on initialize). */
+export function serverInfo(): { name: "flair"; version: string } {
+  return { name: "flair", version: resolvePackageVersion() };
+}

--- a/packages/flair-mcp/test/version.test.ts
+++ b/packages/flair-mcp/test/version.test.ts
@@ -1,0 +1,72 @@
+import { describe, test, expect } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import {
+  resolvePackageVersion,
+  resolvePackageVersionFrom,
+  serverInfo,
+  UNKNOWN_VERSION,
+} from "../src/version.ts";
+
+/**
+ * flair#1314 — MCP `initialize` advertised serverInfo.version `0.1.0` while
+ * the published package was ~0.46. Client UIs (Claude Code /mcp, Cursor)
+ * display that string. These tests lock that the version comes from this
+ * package's package.json, and that the initialize handshake reports it.
+ */
+
+const PKG_ROOT = join(import.meta.dir, "..");
+const pkg = JSON.parse(readFileSync(join(PKG_ROOT, "package.json"), "utf-8")) as {
+  name: string;
+  version: string;
+};
+
+describe("resolvePackageVersion", () => {
+  test("reads this package's package.json version", () => {
+    expect(pkg.name).toBe("@tpsdev-ai/flair-mcp");
+    expect(pkg.version).toMatch(/^\d+\.\d+\.\d+/);
+    expect(resolvePackageVersion()).toBe(pkg.version);
+  });
+
+  test("is not the old hardcoded 0.1.0", () => {
+    expect(resolvePackageVersion()).not.toBe("0.1.0");
+  });
+
+  test("a startDir with no @tpsdev-ai/flair-mcp package.json falls through to unknown", () => {
+    // Filesystem root has no matching package — proves the walk terminates
+    // and does not invent a version.
+    expect(resolvePackageVersionFrom("/")).toBe(process.env.npm_package_version ?? UNKNOWN_VERSION);
+  });
+});
+
+describe("serverInfo", () => {
+  test("name is flair and version is the package version", () => {
+    expect(serverInfo()).toEqual({ name: "flair", version: pkg.version });
+  });
+});
+
+describe("initialize handshake", () => {
+  test("reports the package version in serverInfo", async () => {
+    const server = new McpServer(serverInfo());
+    const client = new Client({ name: "flair-mcp-version-test", version: "0.0.0" });
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+    await Promise.all([server.connect(serverTransport), client.connect(clientTransport)]);
+    try {
+      expect(client.getServerVersion()).toEqual({ name: "flair", version: pkg.version });
+    } finally {
+      await client.close();
+      await server.close();
+    }
+  });
+});
+
+describe("index.ts construction site", () => {
+  test("McpServer is constructed from serverInfo(), not a hardcoded version", () => {
+    const src = readFileSync(join(PKG_ROOT, "src", "index.ts"), "utf-8");
+    expect(src).toContain("new McpServer(serverInfo())");
+    expect(src).not.toMatch(/version:\s*["']0\.1\.0["']/);
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #1314.

**Problem.** flair-mcp's MCP `initialize` advertised `serverInfo.version` as the hardcoded string `0.1.0` while `@tpsdev-ai/flair-mcp` is 0.48.0. Claude Code `/mcp` and Cursor display that string, so a debugging session sees the wrong package.

**Fix.** Read the version from this package's `package.json` (named walk from the running module, same pattern as `resources/version.ts` + `src/lib/mcp-spec.ts`). `McpServer` is constructed with `serverInfo()`. No published version bump.

**Test.** `packages/flair-mcp/test/version.test.ts` locks that `resolvePackageVersion()` equals `packages/flair-mcp/package.json`, and that an in-memory initialize handshake reports that version.

**Assign.** Could not assign to heskew from the coordinator (GitHub assign 403). Not blocking.

Scope is #1314 only. Does not touch #1330, #1351, or later issues.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f3a689df-c439-47e8-80b5-a8f77d32d2dd?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f3a689df-c439-47e8-80b5-a8f77d32d2dd&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

