### PR TITLE
fix(embeddings): host-aware HFE thread count via FLAIR_EMBED_THREADS (flair#1330)

### DIFF
--- a/.changelog/unreleased/changed-embed-threads-host-aware.md
+++ b/.changelog/unreleased/changed-embed-threads-host-aware.md
@@ -1,0 +1,8 @@
+- **Embedder thread count is now host-aware, and overridable via
+  `FLAIR_EMBED_THREADS`** (flair#1330). Flair now passes `threads` through
+  `embeddings-boot` to harper-fabric-embeddings instead of inheriting HFE's
+  fixed default of 6 — which left cores idle on an 8-vCPU ingest host and
+  oversubscribed a 4-core one. Unset, the value is
+  `max(1, availableParallelism() − 1)` (cgroup-aware; one core left for
+  Harper). Set `FLAIR_EMBED_THREADS` to a positive integer to pin. Invalid
+  values fall back to the default. Env-only — not a `config.yaml` key.

--- a/.env.example
+++ b/.env.example
@@ -42,3 +42,9 @@ FLAIR_ADMIN_AGENTS=
 # Set it here only to advertise a DIFFERENT host — a CDN, a reverse proxy, a
 # vanity domain. A value you set is never overwritten by a deploy.
 FLAIR_PUBLIC_URL=
+
+# CPU threads for in-process embedding (harper-fabric-embeddings / llama.cpp).
+# Unset = max(1, availableParallelism() - 1): host-aware, one core left for
+# Harper. A positive integer pins the count. Invalid values fall back to the
+# default. Env-only — not a config.yaml key (flair#1330).
+# FLAIR_EMBED_THREADS=

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -108,7 +108,7 @@ EXPOSE 19926
 CMD ["flair", "start", "--foreground"]
 ```
 
-Note: embeddings run on CPU in Docker (no Metal acceleration). Performance is acceptable for small-to-medium memory stores (< 10K memories).
+Note: embeddings run on CPU in Docker (no Metal acceleration). Performance is acceptable for small-to-medium memory stores (< 10K memories). Thread count follows `FLAIR_EMBED_THREADS` (default `max(1, availableParallelism() − 1)`); pin it if the container CPU quota and the host you want to use disagree.
 
 ---
 
@@ -186,6 +186,16 @@ Set these in the Flair process environment (`~/Library/LaunchAgents/ai.tpsdev.fl
 | `FLAIR_KEY_PASSPHRASE` | Passphrase used to derive the AES-256-GCM key that wraps federation private-key seeds at rest. Auto-generated to `~/.flair/keys/.passphrase` if unset. | Set explicitly for production federation deployments so the passphrase isn't auto-generated and lost on disk wipe. |
 | `HTTP_PORT` | Override the Harper HTTP port. Useful for sandboxes; production deployments should configure the port in `config.yaml` instead. | Rare. |
 | `FLAIR_OPS_BIND` | Bind address for the Harper **ops API**. Resolution order: `flair init --ops-bind` > this variable > the `opsBind` key `flair init` persists in `~/.flair/config.yaml` > `127.0.0.1`. Every Flair-managed Harper start re-asserts the resolved value, so the persisted key is what makes a choice survive `flair restart` / `flair upgrade`. | Only for deployments that genuinely need remote ops admin (multi-host / Fabric) — set it to `0.0.0.0`, or record it once with `flair init --ops-bind 0.0.0.0`. Single-host installs want the loopback default. |
+
+### Performance-related environment variables
+
+These are read by the Harper process at boot (same places as the table above: launchd plist, systemd unit, component `.env` / Fabric env). They are **not** `config.yaml` keys — embedding registration is in-process and must not persist into Harper's config file.
+
+| Variable | Default | What it does |
+|----------|---------|--------------|
+| `FLAIR_EMBED_THREADS` | `max(1, availableParallelism() − 1)` | CPU threads for in-process embedding (harper-fabric-embeddings / llama.cpp). Host-aware so a 4-core box does not inherit HFE's fixed 6, and an 8-vCPU ingest host is not stuck at 6 idle cores. One core is left for Harper's event loop and the OS. `availableParallelism()` respects a container CPU quota. Set a positive integer to pin. Invalid values fall back to the default. |
+| `FLAIR_HYBRID_RETRIEVAL` | `true` | Hybrid BM25 + vector retrieval. Set `false` / `0` / `off` to revert to the legacy HNSW + keyword-bump path. |
+| `FLAIR_MODELS_DIR` | `<data-dir>/models` | Directory the embedding GGUF is loaded from (and downloaded into on first boot). Point this at a pre-seeded directory to skip the HuggingFace download; see [troubleshooting.md](troubleshooting.md). |
 
 ---
 

--- a/docs/standalone-local.md
+++ b/docs/standalone-local.md
@@ -107,6 +107,9 @@ logging:
 | `HDB_ADMIN_PASSWORD` | Bootstrap password for the embedded Harper. After first start, the persisted user record is the source of truth. | Set at install time. See [secrets-and-keys.md](secrets-and-keys.md) for rotation. |
 | `FLAIR_KEY_PASSPHRASE` | Passphrase for AES-256-GCM encryption of federation private-key seeds. | Set explicitly for production federation deployments. |
 | `FLAIR_URL` | Override the Flair base URL for CLI commands (points to a remote instance). | When connecting from a different machine. |
+| `FLAIR_EMBED_THREADS` | CPU threads for in-process embedding. Default is `max(1, availableParallelism() − 1)` — host-aware, one core left for Harper. | Pin a positive integer on a dedicated ingest host, or when the default leaves cores idle / oversubscribed. See [deployment.md](deployment.md#performance-related-environment-variables). |
+| `FLAIR_HYBRID_RETRIEVAL` | Hybrid BM25 + vector retrieval (default on). | Set `false` to revert to HNSW-only. |
+| `FLAIR_MODELS_DIR` | Directory the embedding GGUF is loaded from. | When the model lives outside `<data-dir>/models`. |
 
 ---
 

--- a/packages/adk-flair-js/test/integration/explain_plan.test.ts
+++ b/packages/adk-flair-js/test/integration/explain_plan.test.ts
@@ -152,7 +152,7 @@ describe("ExplainPlan", () => {
     expect(firstCondition["attribute"]).toBe("tags");
     expect(firstCondition["comparator"]).toBe("equals");
     expect(firstCondition["value"]).toBe(tag);
-  });
+  }, { timeout: 60_000 }); // 150 embeds (3 users × 50) — not a 5s unit of work; matches metadata_and_list
 
   it("empty user returns empty", async () => {
     if (!config || !service) {

--- a/resources/embeddings-boot.ts
+++ b/resources/embeddings-boot.ts
@@ -84,6 +84,7 @@
  * Harper boot), registration is skipped and logged — Harper falls back to
  * keyword-only search, matching the pre-existing degrade contract.
  */
+import { availableParallelism } from "node:os";
 import { resolveModelsDir } from "./embeddings-provider.js";
 
 const LOGICAL_NAME = "default";
@@ -152,6 +153,44 @@ function benchModelPathOverride(): string | undefined {
   return process.env.FLAIR_RECALL_HARNESS_MODEL_PATH || undefined;
 }
 
+/**
+ * llama.cpp CPU thread count passed to HFE `register({config:{threads}})`.
+ *
+ * HFE's own default is a fixed 6 (see harper-fabric-embeddings' `init()`
+ * table). flair never used to pass `threads`, so every host inherited that
+ * 6: an 8-vCPU ingest box left cores idle (flair#1330), a 4-core laptop
+ * oversubscribed. We always pass an explicit value.
+ *
+ * Default (unset / empty / non-integer / <1): `max(1, cores - 1)`. Safer
+ * than `min(6, cores)` — that still leaves the 8-vCPU case idle at 6 —
+ * and safer than using every core: Harper's JS worker (`THREADS_COUNT=1`)
+ * and the OS keep one. `availableParallelism()` (not `os.cpus().length`)
+ * so a cgroup CPU quota (Docker / k8s / Fabric) is what we count.
+ *
+ * Override: `FLAIR_EMBED_THREADS` — a positive integer, env-only. A
+ * config.yaml key would go through Harper's models-config persist path,
+ * which is exactly the class of state embeddings-boot exists to avoid
+ * (flair#694). Invalid values fall through to the host-aware default.
+ */
+export function resolveEmbedThreads(
+  env: NodeJS.ProcessEnv = process.env,
+  cores: number = availableParallelism(),
+): number {
+  const parsed = parsePositiveInt(env.FLAIR_EMBED_THREADS);
+  if (parsed !== undefined) return parsed;
+  const safeCores = Number.isFinite(cores) && cores >= 1 ? Math.floor(cores) : 1;
+  return Math.max(1, safeCores - 1);
+}
+
+function parsePositiveInt(raw: string | undefined): number | undefined {
+  if (raw == null) return undefined;
+  const trimmed = raw.trim();
+  if (trimmed === "") return undefined;
+  const n = Number(trimmed);
+  if (!Number.isInteger(n) || n < 1) return undefined;
+  return n;
+}
+
 let registered = false;
 
 /**
@@ -165,12 +204,16 @@ export async function registerEmbeddingsBackend(): Promise<void> {
   try {
     const { register } = await import("harper-fabric-embeddings");
     const modelPath = benchModelPathOverride();
+    const threads = resolveEmbedThreads();
     await register({
       logicalName: LOGICAL_NAME,
       kind: "embedding",
-      config: modelPath
-        ? { modelPath, pooling: EMBEDDING_POOLING }
-        : { modelName: MODEL_NAME, modelsDir: resolveModelsDir(), pooling: EMBEDDING_POOLING },
+      config: {
+        ...(modelPath
+          ? { modelPath, pooling: EMBEDDING_POOLING }
+          : { modelName: MODEL_NAME, modelsDir: resolveModelsDir(), pooling: EMBEDDING_POOLING }),
+        threads,
+      },
     });
   } catch (err) {
     // Not installed, or globalThis.models isn't ready (module loaded outside

--- a/test/unit/embeddings-boot-threads.test.ts
+++ b/test/unit/embeddings-boot-threads.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import { availableParallelism } from "node:os";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { resolveEmbedThreads } from "../../resources/embeddings-boot.ts";
+
+/**
+ * resolveEmbedThreads() (flair#1330) — the value embeddings-boot passes to
+ * HFE `register({config:{threads}})`. HFE's own default is a fixed 6;
+ * flair used to omit the field and inherit that on every host.
+ *
+ * Locks:
+ *   1. The host-aware default is `max(1, cores - 1)`, not `min(6, cores)`
+ *      and not HFE's 6. Injected `cores` so CI machine size cannot hide a
+ *      formula change.
+ *   2. The no-arg form actually calls `availableParallelism()` (cgroup-
+ *      aware), not `os.cpus().length`.
+ *   3. `FLAIR_EMBED_THREADS` is the override; invalid values fall through.
+ *   4. embeddings-boot's `register()` call site actually passes
+ *      `threads: resolveEmbedThreads()` — a source tripwire so the helper
+ *      cannot drift off the plumbing.
+ */
+describe("resolveEmbedThreads (flair#1330 — host-aware HFE threads)", () => {
+  const SAVED = process.env.FLAIR_EMBED_THREADS;
+
+  beforeEach(() => {
+    delete process.env.FLAIR_EMBED_THREADS;
+  });
+
+  afterEach(() => {
+    if (SAVED === undefined) delete process.env.FLAIR_EMBED_THREADS;
+    else process.env.FLAIR_EMBED_THREADS = SAVED;
+  });
+
+  describe("host-aware default (env unset)", () => {
+    it("8 cores → 7 (the measured idle-core case: HFE's 6 left 2 cores unused)", () => {
+      expect(resolveEmbedThreads({}, 8)).toBe(7);
+    });
+
+    it("4 cores → 3 (avoids HFE's 6-thread oversubscription on a small host)", () => {
+      expect(resolveEmbedThreads({}, 4)).toBe(3);
+    });
+
+    it("6 cores → 5 (does not cling to HFE's fixed 6)", () => {
+      expect(resolveEmbedThreads({}, 6)).toBe(5);
+    });
+
+    it("2 cores → 1 (leaves one core; never returns 0)", () => {
+      expect(resolveEmbedThreads({}, 2)).toBe(1);
+    });
+
+    it("1 core → 1 (floor; cores - 1 would be 0)", () => {
+      expect(resolveEmbedThreads({}, 1)).toBe(1);
+    });
+
+    it("non-finite / sub-1 cores still floor at 1", () => {
+      expect(resolveEmbedThreads({}, 0)).toBe(1);
+      expect(resolveEmbedThreads({}, -4)).toBe(1);
+      expect(resolveEmbedThreads({}, Number.NaN)).toBe(1);
+    });
+
+    it("no-arg form uses availableParallelism() - 1 (cgroup-aware, not os.cpus().length)", () => {
+      expect(resolveEmbedThreads()).toBe(Math.max(1, availableParallelism() - 1));
+    });
+  });
+
+  describe("FLAIR_EMBED_THREADS override", () => {
+    it("honors a positive integer", () => {
+      expect(resolveEmbedThreads({ FLAIR_EMBED_THREADS: "8" }, 4)).toBe(8);
+      expect(resolveEmbedThreads({ FLAIR_EMBED_THREADS: "1" }, 16)).toBe(1);
+    });
+
+    it("trims whitespace", () => {
+      expect(resolveEmbedThreads({ FLAIR_EMBED_THREADS: "  4  " }, 16)).toBe(4);
+    });
+
+    it("reads process.env when the env arg is omitted", () => {
+      process.env.FLAIR_EMBED_THREADS = "12";
+      expect(resolveEmbedThreads()).toBe(12);
+    });
+
+    it("falls through to the host-aware default on empty / non-integer / <1", () => {
+      for (const raw of ["", "   ", "abc", "0", "-1", "1.5", "8cpu", "NaN"]) {
+        expect(resolveEmbedThreads({ FLAIR_EMBED_THREADS: raw }, 8)).toBe(7);
+      }
+    });
+  });
+});
+
+describe("embeddings-boot register() plumbing (flair#1330)", () => {
+  it("passes threads: resolveEmbedThreads() into HFE register() config", () => {
+    const src = readFileSync(
+      join(import.meta.dir, "..", "..", "resources", "embeddings-boot.ts"),
+      "utf8",
+    );
+    expect(src).toContain("const threads = resolveEmbedThreads();");
+    expect(src).toMatch(/register\(\{[\s\S]*threads,/);
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #1330.

Embedder thread count was fixed at harper-fabric-embeddings' default 6 because flair's `embeddings-boot` never passed `threads`. On an 8-vCPU ingest host that left cores idle; on a 4-core host it oversubscribed.

**Fix.** `register({config})` now always includes `threads: resolveEmbedThreads()`.

**Default.** `max(1, availableParallelism() - 1)`, not `min(6, cores)` and not HFE's 6.
- `min(6, cores)` would still leave the measured 8-vCPU case idle at 6.
- Using every core would contend with Harper's JS worker (`THREADS_COUNT=1`) and the OS.
- `availableParallelism()` (not `os.cpus().length`) so a cgroup CPU quota (Docker / k8s / Fabric) is what we count.
- Floor at 1 so a 1-core host does not get 0.

**Override.** `FLAIR_EMBED_THREADS` — a positive integer. Invalid / empty values fall through to the default.

**Env, not `config.yaml`.** A Harper `models.embedding.default.threads` key would persist through the config-as-state path `embeddings-boot` exists to avoid (flair#694). Same channel as the other operator knobs (`FLAIR_HYBRID_RETRIEVAL`, `FLAIR_MODELS_DIR`). Documented with those in `docs/deployment.md`.

**Tests.** `test/unit/embeddings-boot-threads.test.ts` locks the 8→7 / 4→3 / 1→1 defaults, the env override, `availableParallelism()` as the no-arg source, and a source tripwire that `register()` actually passes `threads`.

**CI follow-up.** Integration Tests failed on `adk-flair-js` `ExplainPlan > tag drives pre-filter isolation`: that case writes 150 memories under bun's default 5s timeout. Host-aware threads made the miss real; the test now has a 60s budget, matching `metadata_and_list`. Default unchanged.

Changelog fragment: `.changelog/unreleased/changed-embed-threads-host-aware.md`.

**Assignment.** Could not assign this issue to heskew from the coordinator (GitHub assign 403). Do not block on assign.

Out of scope (not mixed in): #1351, #1314, #1313, #1312, #1338.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-876d786b-1aa9-4ef5-87c5-f0fa1f228033?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-876d786b-1aa9-4ef5-87c5-f0fa1f228033&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

