### PR TITLE
docs: hosted-Flair adapter auth for the agent that just got a 404

### DIFF
--- a/.changelog/unreleased/added-hosted-flair-adapter-auth-docs.md
+++ b/.changelog/unreleased/added-hosted-flair-adapter-auth-docs.md
@@ -1,0 +1,9 @@
+- **Hosted-Flair auth guide for adapters.** If your agent just got a 404
+  against a hosted instance, identity is three things that must match
+  (Ed25519 keyfile + agent id + the `Agent` row on **that** instance),
+  the failure is one of three shapes (record missing / key mismatch /
+  config wrong), and a 404 on by-id routes is fail-closed ownership —
+  never an existence signal. Lives in `docs/integrations.md` (the shared
+  adapter home) and the adk-flair README hosted section; pointers from
+  auth, Fabric, troubleshooting, and mcp-clients. Docs slice of
+  flair#1338 only — not the canary / hosted-shape CI program.

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -39,6 +39,11 @@ flair agent add myagent
 
 This is the default and recommended auth for single-instance deployments.
 
+Adapter or hosted-Flair 404? Identity is three things (keyfile + agent id +
+the `Agent` row on **that** instance). A by-id 404 is fail-closed ownership,
+never an existence signal. The adapter write-up is
+[integrations.md — Hosted Flair auth](integrations.md#hosted-flair-auth--your-agent-got-a-404).
+
 ## Deployment shapes: personal vs org
 
 Flair has no `mode`/`shape` config setting — the shape you get is emergent from *how you provision principals*, not something you declare:

--- a/docs/hosted-on-fabric.md
+++ b/docs/hosted-on-fabric.md
@@ -138,6 +138,8 @@ flair agent add mybot --target "$FLAIR_URL" --ops-target <ops-url>
 
 Auth is the same protocol as standalone: Ed25519 signature of `agentId:timestamp:nonce:METHOD:/path`, 30-second replay window, nonce deduplication. The difference is purely the transport — HTTPS instead of localhost HTTP.
 
+An adapter that just got a 404 is almost never "Harper wants a different verb." Check the three identity pieces (keyfile, agent id, `Agent` row on **this** instance) and treat by-id 404 as fail-closed ownership, not an existence signal: [integrations.md — Hosted Flair auth](integrations.md#hosted-flair-auth--your-agent-got-a-404).
+
 See [secrets-and-keys.md](secrets-and-keys.md) for the full threat model.
 
 ---

--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -23,12 +23,64 @@ Where Flair already runs. Each integration shown here is a working surface — t
 | **n8n** | [`n8n-nodes-flair`](#n8n) | FlairApi credential | Three nodes (chat memory, search, store) |
 | **Hermes Agent** | [`hermes-flair`](#hermes-agent) | Ed25519 | Python `MemoryProvider` |
 | **Pi agent** | [`pi-flair`](#pi-agent) | Ed25519 | Native pi extension (pi has no MCP support); `flair init --client pi` wires it, `flair doctor` checks it |
+| **Google ADK** (Python) | [`adk-flair`](../packages/adk-flair/README.md) | Ed25519 | `BaseMemoryService`; see [hosted auth](#hosted-flair-auth--your-agent-got-a-404) if you just got a 404 |
+| **Google ADK** (JS/TS) | [`@tpsdev-ai/adk-flair`](../packages/adk-flair-js/README.md) | Ed25519 | Same identity model as the Python package |
 
 Don't see your harness? If it speaks **MCP** — Flair already works with `flair-mcp`. If it has a **custom memory protocol** like LangGraph's `BaseStore` or CrewAI's `RAGStorage`, an adapter is a ~200-line package; [open an issue](https://github.com/tpsdev-ai/flair/issues) or [send a PR](https://github.com/tpsdev-ai/flair).
 
 **Already running on Harper?** Every surface above reaches Flair over HTTP. If your application is itself a Harper app, you can skip the network entirely — load Flair as a component of the same instance and call its resources in-process. See [embedding-in-a-harper-app.md](embedding-in-a-harper-app.md), which also covers the table-vs-resource distinction that decides whether your memories are scoped.
 
 **Adjacent: memory bridges** — for moving memories between Flair and another memory product. Five bridges ship today (Mem0, ChatGPT exports, claude-project files, agentic-stack, markdown); see [bridges.md](bridges.md). Bridges are import/export plumbing, not live orchestrator integrations.
+
+---
+
+## Hosted Flair auth — your agent got a 404
+
+Written for the person whose adapter just got a 404 against a hosted Flair (Harper Fabric or any non-localhost URL). Laptop `flair init` on `127.0.0.1:19926` is a different machine from the one signing the request.
+
+The protocol lives in [auth.md](auth.md). Key lifecycle lives in [secrets-and-keys.md](secrets-and-keys.md). Fabric registration (including the ops-port trap) lives in [quickstart-fabric.md](quickstart-fabric.md). This section is only the identity check.
+
+### Identity is three things that must match
+
+Ed25519 agent auth is not a password. The server accepts a request only when all three line up:
+
+1. **Agent id** — `FLAIR_AGENT_ID`. This is the string inside the signature.
+2. **Keyfile on the machine that signs** — `FLAIR_KEYFILE` (adk-flair / adk-flair-js) or `FLAIR_KEY_PATH` (flair-mcp, Hermes, pi). The private key never leaves that host. `flair agent add` writes `~/.flair/keys/<id>.key`.
+3. **Server-side `Agent` row on the instance at `FLAIR_URL`** whose `publicKey` matches that keyfile. Registration is per instance. A key minted against localhost is not registered on Fabric until you run `flair agent add <id> --target` at that URL.
+
+The signed payload is `agentId:timestamp:nonce:METHOD:/path` (30-second replay window).
+
+Do not "fix" a 401 or 404 by pasting the Harper admin password into the agent's standing environment. Admin Basic auth is for registration, once. The first signed call against an unregistered id is **401 `unknown_agent`** — that is fail-closed working as designed.
+
+### The three failure shapes
+
+| Shape | What is true | What you see | What to do |
+|---|---|---|---|
+| **Record missing** | No `Agent` row for this id on **this** instance | `401 {"error":"unknown_agent"}` on every signed route | Register against the hosted URL: `flair agent add <id> --target "$FLAIR_URL" --ops-target <ops-url> --admin-pass-file <path>`. Fabric ops is not `data-port − 1` — see [quickstart-fabric.md](quickstart-fabric.md). |
+| **Key mismatch** | The id exists; the public key on the server is not the one in your keyfile | `401 {"error":"invalid_signature"}` | Same id, wrong key — copied from another host, rotated on one side only, or the env pointing at a different agent's file. Point the env at the key that matches **this** instance, or re-seed the hosted `Agent` row from the key on this machine: `flair agent add <id> --target "$FLAIR_URL" --ops-target <ops-url> --admin-pass-file <path>` (reuses the local keyfile). `flair agent rotate-key` is localhost-only. Restart the adapter so it reloads the key. |
+| **Config wrong** | Identity may be fine; you are not talking to the Flair you think | Timeouts, connection errors, or **404 from Harper's catch-all** | `FLAIR_URL` must be the origin the **signing process** can open (cloud-agent localhost is the VM, not your laptop). adk-flair also needs `FLAIR_ALLOW_REMOTE_URL=1` and a raised `FLAIR_HTTP_TIMEOUT` (defaults are localhost fail-fast). A `FLAIR_URL` with a path prefix sends every request to a route that does not exist. `/Health` can be 200 while `/Memory` is still 404 if the Flair app is not loaded yet. |
+
+Clock skew is a fourth, rarer 401: `timestamp_out_of_window`.
+
+`flair agent list` talks to **localhost**. It cannot tell you whether the hosted instance has your Agent row. The discriminator is the 401 body on a signed request.
+
+### 404 on by-id routes is not an existence signal
+
+`GET /Memory/{id}`, `PUT /Memory/{id}`, and the adapter/MCP wrappers (`memory_get`, a by-id update) return **404** both when the id is absent **and** when the record exists but your principal may not see it (another agent's `private` memory, or outside your read scope). Same status, same body shape. That is fail-closed ownership ([flair#1264](https://github.com/tpsdev-ai/flair/issues/1264)) — a 403 would confirm the id exists and can name the owner.
+
+**Do not treat that 404 as "the record is missing, so create it" or "Harper rejected the verb."** Creates go to `POST /Memory/` (id in the body). A by-id 404 after a write usually means you are not the owner the server thinks you are — go back to the three shapes above — not that you should switch PUT for POST.
+
+A verified agent that is not allowed the row gets 404, never 403. Anonymous by-id reads are denied at the gate.
+
+### Per-adapter env
+
+| Adapter | URL | Agent id | Keyfile | Hosted extras |
+|---|---|---|---|---|
+| **adk-flair** / **adk-flair-js** | `FLAIR_URL` | `FLAIR_AGENT_ID` | `FLAIR_KEYFILE` | `FLAIR_ALLOW_REMOTE_URL=1`, `FLAIR_HTTP_TIMEOUT` — [adk-flair README](../packages/adk-flair/README.md#hosted-flair) |
+| **flair-mcp** / Cursor plugin | `FLAIR_URL` | `FLAIR_AGENT_ID` | `FLAIR_KEY_PATH` (optional; auto-resolved) | Key must be on the **npx host** |
+| **Hermes / pi / LangGraph** | `FLAIR_URL` | `FLAIR_AGENT_ID` | `FLAIR_KEY_PATH` or client `keyPath` | Same Ed25519 model |
+
+n8n still uses Harper admin Basic auth — it is not this path. See [n8n.md](n8n.md#security).
 
 ---
 
@@ -209,7 +261,6 @@ If it has a custom memory protocol, the adapter pattern is small (~200 lines). L
 - CrewAI (Python `BaseRAGStorage` protocol)
 - AG2 / AutoGen (Python)
 - Mastra (TS, denser thread model)
-- ADK (Google, Python + TS)
 
 [Open an issue](https://github.com/tpsdev-ai/flair/issues) describing the harness and we'll triage. PRs welcome — see [`packages/langgraph-flair`](../packages/langgraph-flair) as the smallest-shape reference.
 
@@ -219,6 +270,7 @@ If it has a custom memory protocol, the adapter pattern is small (~200 lines). L
 
 - [Quickstart](quickstart.md) — `flair init` to working memory on a laptop
 - [Fabric Quickstart](quickstart-fabric.md) — `flair deploy` to a reachable Harper Fabric URL
+- [Hosted Flair auth](#hosted-flair-auth--your-agent-got-a-404) — Ed25519 identity, the three 401/404 shapes, why a by-id 404 is not an existence signal
 - [Embedding in a Harper app](embedding-in-a-harper-app.md) — run Flair as a component of your own Harper instance and call it in-process
 - [Memory bridges](bridges.md) — import/export Flair ↔ Mem0, ChatGPT, claude-project, markdown, agentic-stack (five bridges shipped)
 - [Federation](federation.md) — pair instances peer-to-peer for cross-machine sync

--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -38,7 +38,7 @@ Don't see your harness? If it speaks **MCP** — Flair already works with `flair
 
 Written for the person whose adapter just got a 404 against a hosted Flair (Harper Fabric or any non-localhost URL). Laptop `flair init` on `127.0.0.1:19926` is a different machine from the one signing the request.
 
-The protocol lives in [auth.md](auth.md). Key lifecycle lives in [secrets-and-keys.md](secrets-and-keys.md). Fabric registration (including the ops-port trap) lives in [quickstart-fabric.md](quickstart-fabric.md). This section is only the identity check.
+The protocol lives in [auth.md](auth.md). Key lifecycle lives in [secrets-and-keys.md](secrets-and-keys.md). Fabric registration (including the ops port trap) lives in [quickstart-fabric.md](quickstart-fabric.md). This section is only the identity check.
 
 ### Identity is three things that must match
 

--- a/docs/mcp-clients.md
+++ b/docs/mcp-clients.md
@@ -298,7 +298,7 @@ Future MCP-capable agent CLIs (and there are more landing every month) will work
 
 **"connection_error: could not reach Flair at http://127.0.0.1:19926".** The Flair server isn't running. Run `flair status` to check; `flair start` to bring it up.
 
-**"auth_error: …" on every call.** The agent identity doesn't match a registered key. Re-run `flair agent add <id>` (idempotent on re-add — won't lose existing memories).
+**"auth_error: …" on every call.** The agent identity doesn't match a registered key. Re-run `flair agent add <id>` (idempotent on re-add — won't lose existing memories). Against a hosted instance the same three shapes apply (record missing / key mismatch / config wrong), and a by-id 404 is fail-closed ownership, not an existence signal — [Hosted Flair auth](integrations.md#hosted-flair-auth--your-agent-got-a-404).
 
 **Tool calls succeed but the agent doesn't see results in subsequent turns.** Check that the CLI is actually invoking `bootstrap` at session start — most CLIs need an explicit prompt nudge ("call the bootstrap tool now") on first use. Subsequent turns should pick up automatically once the CLI sees the schema.
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -105,6 +105,31 @@ date
 
 If using the MCP server, restart Claude Code after rotating keys.
 
+`flair agent list` is localhost-only. Against a hosted instance, the
+discriminator is the 401 body on a signed request (`unknown_agent` vs
+`invalid_signature`), not a local agent list. Adapter-shaped walkthrough:
+[integrations.md — Hosted Flair auth](integrations.md#hosted-flair-auth--your-agent-got-a-404).
+
+### 404 on `GET`/`PUT /Memory/{id}`
+
+**Symptoms:** `memory_get`, a by-id update, or an adapter write/read against
+`/Memory/{id}` returns 404. The agent reports "not found" or "Harper rejected
+the verb."
+
+**This is not an existence signal.** By-id routes return the same 404 when
+the id is absent and when the record exists but the caller may not see it
+(fail-closed ownership, [flair#1264](https://github.com/tpsdev-ai/flair/issues/1264)).
+A 403 would confirm the id and can name the owner; Flair refuses that.
+
+**Also not this:** `401 unknown_agent` / `401 invalid_signature` (identity —
+see above). Harper's catch-all 404 when the Flair app is not loaded yet
+(`/Health` can already be 200). A `FLAIR_URL` with a path prefix.
+
+Creates go to `POST /Memory/` (id in the body). Do not treat a by-id 404 as
+a reason to paste admin credentials into the agent's environment.
+
+Full adapter guide: [integrations.md — Hosted Flair auth](integrations.md#hosted-flair-auth--your-agent-got-a-404).
+
 ### "signing key ... could not be parsed as an Ed25519 private key"
 
 **Symptoms:** `flair doctor` reports, naming the file:

--- a/packages/adk-flair-js/README.md
+++ b/packages/adk-flair-js/README.md
@@ -89,6 +89,12 @@ server.start();
 
 All values can also be passed directly to the constructor.
 
+Hosted Flair (non-localhost `FLAIR_URL`) uses the same Ed25519 triple as the
+Python package — agent id, keyfile, server-side `Agent` row with a matching
+public key. A 404 on `GET`/`PUT /Memory/{id}` is fail-closed ownership, not
+an existence signal. Walkthrough:
+[docs/integrations.md — Hosted Flair auth](../../docs/integrations.md#hosted-flair-auth--your-agent-got-a-404).
+
 ## Architecture
 
 ### Scope model

--- a/packages/adk-flair/README.md
+++ b/packages/adk-flair/README.md
@@ -160,6 +160,78 @@ wins over the env var.
 The resolved URL and the effective timeouts are logged once at WARNING on the
 first request.
 
+## Hosted Flair
+
+If your ADK agent just got a 404 against a hosted Flair, read this before
+changing verbs or pasting admin credentials into the environment.
+
+The same identity model applies to every Ed25519 adapter. The shared write-up
+is [docs/integrations.md — Hosted Flair auth](../../docs/integrations.md#hosted-flair-auth--your-agent-got-a-404).
+This section is the ADK-shaped version.
+
+### Identity is three things that must match
+
+`adk-flair` signs every request with an Ed25519 key. The hosted instance
+accepts the request only when all three line up:
+
+1. **`FLAIR_AGENT_ID`** — the id inside the signature. Must be the id you
+   registered, not a display name and not a different agent's id.
+2. **`FLAIR_KEYFILE`** — the private key on **this** machine (the one running
+   ADK). `flair agent add` writes `~/.flair/keys/<id>.key`. A leading `~` is
+   expanded. The private key never leaves the host.
+3. **A server-side `Agent` row on the instance at `FLAIR_URL`** whose
+   `publicKey` matches that keyfile. Registration is per instance. A key
+   minted by local `flair init` / `flair agent add` (no `--target`) is not
+   registered on Fabric.
+
+```bash
+export FLAIR_ALLOW_REMOTE_URL=1
+export FLAIR_URL=https://<cluster>.<org>.harperfabric.com
+export FLAIR_AGENT_ID=my-adk-app
+export FLAIR_KEYFILE=$HOME/.flair/keys/my-adk-app.key
+export FLAIR_HTTP_TIMEOUT=30   # defaults are localhost fail-fast; see above
+
+# Register THIS id against THAT instance (ops URL is not data-port − 1 on Fabric)
+flair agent add my-adk-app \
+  --target "$FLAIR_URL" \
+  --ops-target <ops-url> \
+  --admin-pass-file ~/.flair/fabric-admin-pass
+```
+
+The full Fabric registration sequence, including the ops-port trap and
+`--admin-pass-file`, is [docs/quickstart-fabric.md](../../docs/quickstart-fabric.md).
+Do not leave the Fabric admin password in the agent's standing env — it is
+for registration, once.
+
+### The three failure shapes
+
+| Shape | What is true | What you see | What to do |
+|---|---|---|---|
+| **Record missing** | No `Agent` row for `FLAIR_AGENT_ID` on this `FLAIR_URL` | `401 {"error":"unknown_agent"}` on every signed call (`add_memory`, search, list) | `flair agent add` with `--target` / `--ops-target` as above. `flair agent list` is localhost-only — it cannot see the hosted registry. |
+| **Key mismatch** | The id exists; the public key on the server is not the key in `FLAIR_KEYFILE` | `401 {"error":"invalid_signature"}` | Same id, wrong file — copied from another host, rotated on one side only, or `FLAIR_KEYFILE` pointing at a different agent's key. Point `FLAIR_KEYFILE` at the key that matches this instance, or re-seed the hosted row from this machine's key (`flair agent add my-adk-app --target "$FLAIR_URL" --ops-target <ops-url> --admin-pass-file <path>` reuses the local file). `flair agent rotate-key` is localhost-only. Restart the ADK process so it reloads the key. |
+| **Config wrong** | Identity may be fine; you are not hitting the Flair you think | Timeouts, `ConnectError`, or **404 from Harper's catch-all** | Confirm `FLAIR_ALLOW_REMOTE_URL=1`, a raised `FLAIR_HTTP_TIMEOUT`, and a `FLAIR_URL` with **no path prefix**. Cloud-agent localhost is the VM, not your laptop. `/Health` can be 200 while `/Memory` is still 404 if the Flair app is not loaded yet. |
+
+Clock skew is a fourth, rarer 401: `timestamp_out_of_window`.
+
+### 404 on by-id routes is not an existence signal
+
+`GET /Memory/{id}` and `PUT /Memory/{id}` return **404** both when the id is
+absent **and** when the record exists but this principal may not see it
+(another agent's `private` memory, or outside the read scope). Same status,
+same body. That is fail-closed ownership
+([flair#1264](https://github.com/tpsdev-ai/flair/issues/1264)) — a 403 would
+confirm the id exists and can name the owner.
+
+**Do not treat that 404 as "the record is missing, so create it" or "Harper
+rejected the verb."** This package already creates via `POST /Memory/` (id
+in the body) and falls back to PUT only on 409. A by-id 404 after a write
+usually means you are not the owner the server thinks you are — the three
+shapes above — not that you should switch POST for PUT.
+
+`search_memory` swallows transport failures to empty (ADK's contract).
+`list_memories` and the write path raise `FlairRequestError` with
+`.status_code` — read that status before guessing.
+
 ## Security
 
 ### Per-user isolation

--- a/packages/adk-flair/README.md
+++ b/packages/adk-flair/README.md
@@ -198,7 +198,7 @@ flair agent add my-adk-app \
   --admin-pass-file ~/.flair/fabric-admin-pass
 ```
 
-The full Fabric registration sequence, including the ops-port trap and
+The full Fabric registration sequence, including the ops port trap and
 `--admin-pass-file`, is [docs/quickstart-fabric.md](../../docs/quickstart-fabric.md).
 Do not leave the Fabric admin password in the agent's standing env — it is
 for registration, once.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Refs #1338. This is the **hosted-Flair auth docs slice** only. It does **not** close the canary / hosted-shape CI / Harper-matrix / adapter-PR checklist program on that issue.

Could not assign to @heskew from the coordinator (GitHub assign 403). Not blocking.

## What this is

The [seed comment](https://github.com/tpsdev-ai/flair/issues/1338#issuecomment-5381771148) asked for the investigation brief that unblocks an agent which just got a 404 — written into adk-flair's README hosted section and the shared adapter docs, not a second canon.

Shared adapter home is `docs/integrations.md` (already the integration catalog). The full guide lives there. The adk-flair README gets the ADK-shaped version. Pointers from `docs/auth.md`, `docs/hosted-on-fabric.md`, `docs/troubleshooting.md`, and `docs/mcp-clients.md` so people don't invent a second page.

## What it says

- Identity is three things that must match: Ed25519 keyfile + agent id + the `Agent` row on **that** instance (matching public key).
- Three failure shapes: **record missing** (`401 unknown_agent`) / **key mismatch** (`401 invalid_signature`) / **config wrong** (timeouts, catch-all 404, localhost-from-a-cloud-VM, URL with a path prefix).
- **404 on by-id routes is fail-closed ownership, never an existence signal** (flair#1264). Do not treat it as "the record is missing, so create it" or "Harper rejected the verb."

Honest about CLI limits: `flair agent list` and `flair agent rotate-key` are localhost-only. Hosted rematch is `flair agent add --target` (reuses the local keyfile). Admin password is for registration, once — not standing agent env.

## Out of scope (still on #1338)

- adk-flair canary harness
- Hosted-shape / Harper-matrix CI lane
- Adapter-PR README-quickstart checklist

No product code. Changelog fragment: `.changelog/unreleased/added-hosted-flair-adapter-auth-docs.md`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-feff8c4e-2dea-41a9-a935-079c8a22bd68?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-feff8c4e-2dea-41a9-a935-079c8a22bd68&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

