### PR TITLE
fix(bench): an unmeasured variance must not render as a measured zero (flair#1376)

### DIFF
--- a/.changelog/unreleased/fixed-1376-unmeasured-variance-not-zero.md
+++ b/.changelog/unreleased/fixed-1376-unmeasured-variance-not-zero.md
@@ -1,0 +1,9 @@
+- **LongMemEval bench: a single run no longer reports `± 0.0%`** (flair#1376).
+  The sample std returned `0` for `n < 2` and the report printed
+  `66.0% ± 0.0%`, which reads as "we ran it repeatedly and it agreed perfectly"
+  when it means "we never measured variance" — an absence rendered as the
+  strongest possible claim, on the path a published number travels. `std()` now
+  returns `null` when there is nothing to measure, each arm aggregate carries
+  `varianceMeasured`, and the headline renders
+  `66.0% (single run — variance unmeasured)`. Affects the bench harness only;
+  no change to Flair itself.

--- a/test/bench/longmemeval/README.md
+++ b/test/bench/longmemeval/README.md
@@ -273,6 +273,13 @@ differ. A published cloud number is a *statistical* result to be re-run and
 compared within variance, not a hash anyone can re-derive — which is why the
 run count and the reported std matter.
 
+At `--runs 1` there is **no** std to report, and the harness says so rather than
+printing one. `std` is `null` (never `0`), the arm aggregate carries
+`varianceMeasured: false`, and the headline renders
+`66.0% (single run — variance unmeasured)` instead of `66.0% ± 0.0%` (flair#1376).
+A zero would be indistinguishable from "we ran it repeatedly and it agreed
+perfectly", which is the opposite of what a single run establishes.
+
 The `local` profile runs single-stream against a pinned local digest and is
 expected to be closer to bitwise-stable, but that has **not** been measured;
 do not claim it without a measurement. (The cloud *judge* returned an identical

--- a/test/bench/longmemeval/metrics.ts
+++ b/test/bench/longmemeval/metrics.ts
@@ -71,10 +71,19 @@ export interface ArmRunMetrics {
 export function mean(xs: number[]): number {
   return xs.length ? xs.reduce((a, b) => a + b, 0) / xs.length : 0;
 }
-/** Sample std (n-1). 0 for n<2. */
-export function std(xs: number[]): number {
+/**
+ * Sample std (n-1). **null for n<2 — the spread was never measured** (#1376).
+ *
+ * The obvious sentinel here is `0`, and it is wrong: a single run has no
+ * spread to report, but `0` is the value that reads as the STRONGEST possible
+ * claim — "we ran it repeatedly and it agreed perfectly". An unknown must never
+ * resolve to the most confident-looking number. `null` forces every consumer to
+ * decide what to do about the absence instead of inheriting a fabricated zero,
+ * and the type says so.
+ */
+export function std(xs: number[]): number | null {
   const n = xs.length;
-  if (n < 2) return 0;
+  if (n < 2) return null;
   const m = mean(xs);
   return Math.sqrt(xs.reduce((a, b) => a + (b - m) ** 2, 0) / (n - 1));
 }
@@ -158,12 +167,20 @@ export function aggregateArmRun(arm: Arm, results: QuestionArmResult[]): ArmRunM
   };
 }
 
-export interface MeanStd { mean: number; std: number; runs: number[] }
+/** `std: null` means the variance was NOT measured (fewer than 2 runs) — it does
+ *  NOT mean the variance was zero. Consumers must render the two differently
+ *  (#1376). `runs` carries the underlying values either way. */
+export interface MeanStd { mean: number; std: number | null; runs: number[] }
 function ms(runs: number[]): MeanStd { return { mean: mean(runs), std: std(runs), runs }; }
 
 export interface ArmAggregate {
   arm: Arm;
   runs: number;
+  /** False when this aggregate came from a single run: every `std` below is
+   *  `null` because nothing was measured twice. Carried as its own boolean so a
+   *  downstream consumer reading the artifact cannot mistake an absent spread
+   *  for a measured one, without having to reason about null-vs-zero (#1376). */
+  varianceMeasured: boolean;
   overallAccuracy: MeanStd;
   /** Answerable-only accuracy across runs — the contamination-probe number. */
   overallAccuracyAnswerable: MeanStd;
@@ -190,6 +207,7 @@ export function aggregateArmAcrossRuns(arm: Arm, perRun: ArmRunMetrics[]): ArmAg
   return {
     arm,
     runs: perRun.length,
+    varianceMeasured: perRun.length >= 2,
     overallAccuracy: ms(perRun.map((r) => r.overallAccuracy)),
     overallAccuracyAnswerable: ms(perRun.map((r) => r.overallAccuracyAnswerable)),
     perAbility,

--- a/test/bench/longmemeval/report.ts
+++ b/test/bench/longmemeval/report.ts
@@ -6,11 +6,28 @@
  * harness and then prints; the printing itself is where a measured number
  * becomes a claim a reader acts on, and that deserves coverage of its own.
  */
-import type { ArmAggregate } from "./metrics";
+import type { ArmAggregate, MeanStd } from "./metrics";
 import type { Arm } from "./arms";
 
 export const fmt = (x: number, d = 3) => x.toFixed(d);
 export const pct = (x: number) => (x * 100).toFixed(1) + "%";
+
+/**
+ * Render `mean ± std` — or, when the spread was never measured, SAY SO rather
+ * than printing an interval that does not exist (#1376).
+ *
+ * `std === null` means fewer than two runs. The old code substituted `0` and
+ * printed `66.0% ± 0.0%`, which any reader takes as "we ran it repeatedly and
+ * it agreed perfectly" — the strongest possible claim, standing in for no claim
+ * at all. The absence has to be visible right next to the number, not left to
+ * be recovered from a field nobody inspects.
+ */
+function spread(m: MeanStd, f: (x: number) => string, style: "headline" | "row"): string {
+  if (m.std !== null) return `${f(m.mean)} ± ${f(m.std)}`;
+  if (style === "row") return `${f(m.mean)} (unmeasured)`;
+  const n = m.runs.length === 1 ? "single run" : `${m.runs.length} runs`;
+  return `${f(m.mean)} (${n} — variance unmeasured)`;
+}
 
 export interface ReportInput {
   aggregate: ArmAggregate[];
@@ -22,14 +39,18 @@ export interface ReportInput {
 /** Render the results report as lines. Pure: no console, no I/O. */
 export function formatReport({ aggregate, runs, validationSlice, selectedArms }: ReportInput): string[] {
   const out: string[] = [];
-  out.push(`\n${"═".repeat(64)}\n  RESULTS (${validationSlice ? "VALIDATION SLICE — NOT PUBLISHABLE" : "run"}) — ${runs} run(s), mean±std\n${"═".repeat(64)}`);
+  // Derived from the aggregate, not from the requested run count: the banner
+  // describes what was actually measured.
+  const measured = aggregate.length > 0 ? aggregate.every((a) => a.varianceMeasured) : runs >= 2;
+  const basis = measured ? ", mean±std" : " — variance NOT measured (needs ≥2 runs)";
+  out.push(`\n${"═".repeat(64)}\n  RESULTS (${validationSlice ? "VALIDATION SLICE — NOT PUBLISHABLE" : "run"}) — ${runs} run(s)${basis}\n${"═".repeat(64)}`);
   for (const a of aggregate) {
-    out.push(`\n[${a.arm}]  overall accuracy: ${pct(a.overallAccuracy.mean)} ± ${pct(a.overallAccuracy.std)}   (runs: ${a.overallAccuracy.runs.map((x) => pct(x)).join(", ")})`);
-    out.push(`    ${"overall (answerable only)".padEnd(28)} ${pct(a.overallAccuracyAnswerable.mean)} ± ${pct(a.overallAccuracyAnswerable.std)}`);
+    out.push(`\n[${a.arm}]  overall accuracy: ${spread(a.overallAccuracy, pct, "headline")}   (runs: ${a.overallAccuracy.runs.map((x) => pct(x)).join(", ")})`);
+    out.push(`    ${"overall (answerable only)".padEnd(28)} ${spread(a.overallAccuracyAnswerable, pct, "row")}`);
     for (const [ab, msd] of Object.entries(a.perAbility)) {
-      out.push(`    ${ab.padEnd(28)} ${pct(msd!.mean)} ± ${pct(msd!.std)}`);
+      out.push(`    ${ab.padEnd(28)} ${spread(msd!, pct, "row")}`);
     }
-    out.push(`    ${"abstention (broken out)".padEnd(28)} ${pct(a.abstentionAccuracy.mean)} ± ${pct(a.abstentionAccuracy.std)}`);
+    out.push(`    ${"abstention (broken out)".padEnd(28)} ${spread(a.abstentionAccuracy, pct, "row")}`);
     out.push(`    ${"not-attempted (answerable)".padEnd(28)} ${pct(a.notAttemptedRateAnswerable.mean)}`);
     out.push(`    ${"factual F1 (cross-check)".padEnd(28)} ${fmt(a.factualF1.mean)}   containment-EM ${fmt(a.factualContainmentEM.mean)}`);
     out.push(`    ${"tokens/query (mean)".padEnd(28)} ${a.tokensPerQueryMean.mean.toFixed(0)}`);

--- a/test/bench/longmemeval/report.ts
+++ b/test/bench/longmemeval/report.ts
@@ -1,0 +1,54 @@
+/**
+ * report.ts — the human-facing console report for a bench run, as a PURE
+ * function over the aggregate.
+ *
+ * Extracted verbatim from run.ts so the report can be TESTED. run.ts calls the
+ * harness and then prints; the printing itself is where a measured number
+ * becomes a claim a reader acts on, and that deserves coverage of its own.
+ */
+import type { ArmAggregate } from "./metrics";
+import type { Arm } from "./arms";
+
+export const fmt = (x: number, d = 3) => x.toFixed(d);
+export const pct = (x: number) => (x * 100).toFixed(1) + "%";
+
+export interface ReportInput {
+  aggregate: ArmAggregate[];
+  runs: number;
+  validationSlice: boolean;
+  selectedArms: readonly Arm[];
+}
+
+/** Render the results report as lines. Pure: no console, no I/O. */
+export function formatReport({ aggregate, runs, validationSlice, selectedArms }: ReportInput): string[] {
+  const out: string[] = [];
+  out.push(`\n${"═".repeat(64)}\n  RESULTS (${validationSlice ? "VALIDATION SLICE — NOT PUBLISHABLE" : "run"}) — ${runs} run(s), mean±std\n${"═".repeat(64)}`);
+  for (const a of aggregate) {
+    out.push(`\n[${a.arm}]  overall accuracy: ${pct(a.overallAccuracy.mean)} ± ${pct(a.overallAccuracy.std)}   (runs: ${a.overallAccuracy.runs.map((x) => pct(x)).join(", ")})`);
+    out.push(`    ${"overall (answerable only)".padEnd(28)} ${pct(a.overallAccuracyAnswerable.mean)} ± ${pct(a.overallAccuracyAnswerable.std)}`);
+    for (const [ab, msd] of Object.entries(a.perAbility)) {
+      out.push(`    ${ab.padEnd(28)} ${pct(msd!.mean)} ± ${pct(msd!.std)}`);
+    }
+    out.push(`    ${"abstention (broken out)".padEnd(28)} ${pct(a.abstentionAccuracy.mean)} ± ${pct(a.abstentionAccuracy.std)}`);
+    out.push(`    ${"not-attempted (answerable)".padEnd(28)} ${pct(a.notAttemptedRateAnswerable.mean)}`);
+    out.push(`    ${"factual F1 (cross-check)".padEnd(28)} ${fmt(a.factualF1.mean)}   containment-EM ${fmt(a.factualContainmentEM.mean)}`);
+    out.push(`    ${"tokens/query (mean)".padEnd(28)} ${a.tokensPerQueryMean.mean.toFixed(0)}`);
+    out.push(`    ${"latency p50 / p95 (ms)".padEnd(28)} ${a.latencyP50Ms.mean.toFixed(0)} / ${a.latencyP95Ms.mean.toFixed(0)}`);
+    if (a.judgeErrorsTotal > 0) out.push(`    !! judge errors: ${a.judgeErrorsTotal} (unparseable verdicts — NOT counted as pass)`);
+  }
+  // Contamination / validity reads — each only when its arm(s) ran.
+  const nc = aggregate.find((a) => a.arm === "no-context");
+  const fl = aggregate.find((a) => a.arm === "flair");
+  const fc = aggregate.find((a) => a.arm === "full-context");
+  out.push(`\n── contamination / validity reads (ANSWERABLE questions only) ──`);
+  if (nc) {
+    out.push(`  no-context accuracy = ${pct(nc.overallAccuracyAnswerable.mean)}  (HIGH ⇒ reader prior knowledge / contamination — number suspect)`);
+    out.push(`    (measured on answerable questions — an abstention question is trivially correct with no context, so it is excluded here)`);
+  }
+  if (fc && fl) {
+    out.push(`  full-context − flair = ${pct(fc.overallAccuracyAnswerable.mean - fl.overallAccuracyAnswerable.mean)}  (≈0 ⇒ measuring long-context not memory; large ⇒ retrieval losing info)`);
+  } else {
+    out.push(`  full-context − flair: NOT AVAILABLE (full-context arm not run — LME_ARMS=${selectedArms.join(",")})`);
+  }
+  return out;
+}

--- a/test/bench/longmemeval/run.ts
+++ b/test/bench/longmemeval/run.ts
@@ -29,6 +29,7 @@ import { loadDataset, selectSlice, abilityOf, isAbstention } from "./dataset";
 import { runOnce, SELECTED_ARMS, writeProgress, setJournalContext } from "./eval";
 import { aggregateArmAcrossRuns, type ArmRunMetrics } from "./metrics";
 import { buildArtifact, writeArtifact, verifyArtifactHash } from "./artifact";
+import { formatReport } from "./report";
 import { ALL_ARMS, type Arm } from "./arms";
 
 const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../../..");
@@ -38,8 +39,6 @@ function arg(flag: string, dflt?: string): string | undefined {
   return i >= 0 && process.argv[i + 1] ? process.argv[i + 1] : dflt;
 }
 const hasFlag = (f: string) => process.argv.includes(f);
-const fmt = (x: number, d = 3) => x.toFixed(d);
-const pct = (x: number) => (x * 100).toFixed(1) + "%";
 
 function gitCommit(): string | null {
   try { return execSync("git rev-parse HEAD", { cwd: REPO_ROOT }).toString().trim(); } catch { return null; }
@@ -181,34 +180,9 @@ async function runSlice(): Promise<void> {
   });
   const artifactPath = writeArtifact(artifact, outDir);
 
-  // ── report ──
-  console.log(`\n${"═".repeat(64)}\n  RESULTS (${validationSlice ? "VALIDATION SLICE — NOT PUBLISHABLE" : "run"}) — ${runs} run(s), mean±std\n${"═".repeat(64)}`);
-  for (const a of aggregate) {
-    console.log(`\n[${a.arm}]  overall accuracy: ${pct(a.overallAccuracy.mean)} ± ${pct(a.overallAccuracy.std)}   (runs: ${a.overallAccuracy.runs.map((x) => pct(x)).join(", ")})`);
-    console.log(`    ${"overall (answerable only)".padEnd(28)} ${pct(a.overallAccuracyAnswerable.mean)} ± ${pct(a.overallAccuracyAnswerable.std)}`);
-    for (const [ab, msd] of Object.entries(a.perAbility)) {
-      console.log(`    ${ab.padEnd(28)} ${pct(msd!.mean)} ± ${pct(msd!.std)}`);
-    }
-    console.log(`    ${"abstention (broken out)".padEnd(28)} ${pct(a.abstentionAccuracy.mean)} ± ${pct(a.abstentionAccuracy.std)}`);
-    console.log(`    ${"not-attempted (answerable)".padEnd(28)} ${pct(a.notAttemptedRateAnswerable.mean)}`);
-    console.log(`    ${"factual F1 (cross-check)".padEnd(28)} ${fmt(a.factualF1.mean)}   containment-EM ${fmt(a.factualContainmentEM.mean)}`);
-    console.log(`    ${"tokens/query (mean)".padEnd(28)} ${a.tokensPerQueryMean.mean.toFixed(0)}`);
-    console.log(`    ${"latency p50 / p95 (ms)".padEnd(28)} ${a.latencyP50Ms.mean.toFixed(0)} / ${a.latencyP95Ms.mean.toFixed(0)}`);
-    if (a.judgeErrorsTotal > 0) console.log(`    !! judge errors: ${a.judgeErrorsTotal} (unparseable verdicts — NOT counted as pass)`);
-  }
-  // Contamination / validity reads — each only when its arm(s) ran.
-  const nc = aggregate.find((a) => a.arm === "no-context");
-  const fl = aggregate.find((a) => a.arm === "flair");
-  const fc = aggregate.find((a) => a.arm === "full-context");
-  console.log(`\n── contamination / validity reads (ANSWERABLE questions only) ──`);
-  if (nc) {
-    console.log(`  no-context accuracy = ${pct(nc.overallAccuracyAnswerable.mean)}  (HIGH ⇒ reader prior knowledge / contamination — number suspect)`);
-    console.log(`    (measured on answerable questions — an abstention question is trivially correct with no context, so it is excluded here)`);
-  }
-  if (fc && fl) {
-    console.log(`  full-context − flair = ${pct(fc.overallAccuracyAnswerable.mean - fl.overallAccuracyAnswerable.mean)}  (≈0 ⇒ measuring long-context not memory; large ⇒ retrieval losing info)`);
-  } else {
-    console.log(`  full-context − flair: NOT AVAILABLE (full-context arm not run — LME_ARMS=${SELECTED_ARMS.join(",")})`);
+  // ── report ── (formatting lives in report.ts so it can be tested)
+  for (const line of formatReport({ aggregate, runs, validationSlice, selectedArms: SELECTED_ARMS })) {
+    console.log(line);
   }
   writeProgress({ done: true, artifactPath });
   console.log(`\nartifactHash: ${artifact.artifactHash}`);

--- a/test/unit/longmemeval-artifact.test.ts
+++ b/test/unit/longmemeval-artifact.test.ts
@@ -4,6 +4,7 @@ import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { buildArtifact, verifyArtifactHash, writeArtifact, hashRunResults } from "../bench/longmemeval/artifact";
 import { configManifest, hashConfig, canonicalJson } from "../bench/longmemeval/config";
+import { aggregateArmRun, aggregateArmAcrossRuns } from "../bench/longmemeval/metrics";
 
 // The publish gate is STRUCTURAL (Sherlock #4): the run emits a content-
 // addressed artifact, and a human signs off on a specific artifactHash. These
@@ -41,7 +42,10 @@ describe("artifact — content addressing", () => {
     const a = buildArtifact(baseInput());
     const b = buildArtifact({
       ...baseInput(),
-      aggregate: [{ arm: "flair", overallAccuracy: { mean: 0.42, std: 0, runs: [0.42] } }] as any,
+      aggregate: [{
+        arm: "flair", runs: 1, varianceMeasured: false,
+        overallAccuracy: { mean: 0.42, std: null, runs: [0.42] },
+      }] as any,
     });
     expect(b.artifactHash).not.toBe(a.artifactHash);
   });
@@ -66,6 +70,24 @@ describe("artifact — content addressing", () => {
     const art = buildArtifact(baseInput());
     expect(art.notice).toContain("NOT FOR PUBLICATION");
     expect(art.notice).toContain("sign-off");
+  });
+
+  test("a single-run aggregate lands in the artifact as varianceMeasured: false, std: null (#1376)", () => {
+    // The artifact is what a downstream reader consumes without ever seeing the
+    // console report. `std: 0` there would let them re-derive the same overclaim
+    // the headline used to make, so the absence has to survive serialisation as
+    // a distinct fact — asserted through JSON, because a `null` that a
+    // serializer drops is an absence that reads as "field not applicable".
+    const perRun = [aggregateArmRun("flair", [
+      { questionId: "q1", ability: "information-extraction", isAbstention: false, arm: "flair",
+        answer: "", verdict: "CORRECT", tokensFed: 10, latencyMs: 1 },
+    ])];
+    const art = buildArtifact({ ...baseInput(), aggregate: [aggregateArmAcrossRuns("flair", perRun)] });
+    const roundTripped = JSON.parse(JSON.stringify(art));
+    expect(roundTripped.aggregate[0].varianceMeasured).toBe(false);
+    expect(roundTripped.aggregate[0].overallAccuracy).toHaveProperty("std");
+    expect(roundTripped.aggregate[0].overallAccuracy.std).toBeNull();
+    expect(roundTripped.aggregate[0].overallAccuracy.std).not.toBe(0);
   });
 
   test("there is no publish function exported", async () => {

--- a/test/unit/longmemeval-metrics.test.ts
+++ b/test/unit/longmemeval-metrics.test.ts
@@ -15,10 +15,25 @@ function r(over: Partial<QuestionArmResult>): QuestionArmResult {
 describe("stats helpers", () => {
   test("mean / sample-std / percentile", () => {
     expect(mean([1, 2, 3])).toBe(2);
-    expect(std([2, 2, 2])).toBe(0);
-    expect(std([1])).toBe(0);            // n<2 → 0, never NaN
     expect(percentile([1, 2, 3, 4], 50)).toBe(2);
     expect(percentile([], 95)).toBe(0);
+  });
+
+  test("a MEASURED zero spread is 0 — three identical runs really did agree", () => {
+    expect(std([2, 2, 2])).toBe(0);
+  });
+
+  test("an UNMEASURED spread is null, not 0 (#1376)", () => {
+    // This assertion used to read `expect(std([1])).toBe(0)  // never NaN`, and
+    // that comment named the goal it achieved while missing the cost: it pinned
+    // the defect. Avoiding NaN was right; choosing 0 as the sentinel was not.
+    // One run has NO spread to report, and 0 is the value that reads as the
+    // strongest possible claim — a headline of "66.0% ± 0.0%" tells a reader we
+    // measured perfect agreement when we measured nothing at all.
+    expect(std([1])).toBeNull();
+    expect(std([])).toBeNull();
+    // The original goal still holds: null, and never NaN.
+    expect(std([1])).not.toBeNaN();
   });
 });
 
@@ -93,8 +108,34 @@ describe("aggregateArmAcrossRuns — mean±std (pass^k)", () => {
     const run2 = aggregateArmRun("flair", [r({ verdict: "CORRECT" }), r({ verdict: "CORRECT" })]);
     const agg = aggregateArmAcrossRuns("flair", [run1, run2]);
     expect(agg.runs).toBe(2);
+    expect(agg.varianceMeasured).toBe(true);
     expect(agg.overallAccuracy.mean).toBeCloseTo((0.5 + 1) / 2, 10);
     expect(agg.overallAccuracy.std).toBeGreaterThan(0);
     expect(agg.overallAccuracy.runs).toEqual([0.5, 1]);
+  });
+
+  test("a ONE-run aggregate reports varianceMeasured: false and a null std (#1376)", () => {
+    // The artifact is read by consumers that never see the console report, so
+    // the absence has to be a fact IN THE DATA — not something recoverable by
+    // noticing that `runs` has length 1. `std: null` and `varianceMeasured:
+    // false` say it twice, in the two shapes a consumer might look at.
+    const agg = aggregateArmAcrossRuns("flair", [
+      aggregateArmRun("flair", [r({ verdict: "CORRECT" }), r({ verdict: "INCORRECT" })]),
+    ]);
+    expect(agg.runs).toBe(1);
+    expect(agg.varianceMeasured).toBe(false);
+    expect(agg.overallAccuracy.mean).toBeCloseTo(0.5, 10);
+    expect(agg.overallAccuracy.std).toBeNull();
+    expect(agg.overallAccuracy.runs).toEqual([0.5]);
+    // Every other MeanStd in the aggregate carries the same absence — a
+    // consumer must not find one field honest and another fabricated.
+    for (const field of [
+      agg.overallAccuracyAnswerable, agg.abstentionAccuracy, agg.notAttemptedRateAnswerable,
+      agg.factualF1, agg.factualContainmentEM, agg.tokensPerQueryMean,
+      agg.latencyP50Ms, agg.latencyP95Ms,
+    ]) {
+      expect(field.std).toBeNull();
+    }
+    for (const msd of Object.values(agg.perAbility)) expect(msd!.std).toBeNull();
   });
 });

--- a/test/unit/longmemeval-report.test.ts
+++ b/test/unit/longmemeval-report.test.ts
@@ -1,0 +1,108 @@
+import { describe, test, expect } from "bun:test";
+import { formatReport } from "../bench/longmemeval/report";
+import { aggregateArmRun, aggregateArmAcrossRuns, type QuestionArmResult } from "../bench/longmemeval/metrics";
+import type { Arm } from "../bench/longmemeval/arms";
+
+/**
+ * The report is where a measured number becomes a claim (flair#1376).
+ *
+ * At `runs: 1` the sample std is undefined — nothing was measured twice, so
+ * there is no spread to report. The harness used to substitute `0` for that
+ * absence and print `66.0% ± 0.0%`, which reads to any human as "we ran it
+ * repeatedly and it agreed perfectly" when it actually means "we never looked".
+ * An absence must not render as the strongest possible claim.
+ *
+ * These tests assert the rendering directly, because the rendering IS the
+ * defect: the artifact already carried `runs: [0.66]` alongside, and nobody
+ * reads the array.
+ */
+
+/** One question outcome, with the fields the metrics layer reads. */
+function q(over: Partial<QuestionArmResult>): QuestionArmResult {
+  return {
+    questionId: "q", ability: "information-extraction", isAbstention: false, arm: "flair",
+    answer: "", verdict: "CORRECT", tokensFed: 1234, latencyMs: 210, ...over,
+  };
+}
+
+/**
+ * An 11-question run. Every derived number is deliberately non-zero AND chosen
+ * so that no legitimate value RENDERS as a string containing "0.0%" — which is
+ * what makes the `not.toContain("0.0%")` assertion below mean what it says. (A
+ * fixture accuracy of 70.0% would contain "0.0%" as a substring and the check
+ * would fire on a correct render; every percentage here avoids a whole ten.)
+ * In this fixture the only way "0.0%" can reach the output is a fabricated std.
+ *
+ *   overall            8/11 = 72.7%      answerable         6/8  = 75.0%
+ *   information-extr.  3/4  = 75.0%      multi-session      3/4  = 75.0%
+ *   abstention         2/3  = 66.7%      not-attempted      1/8  = 12.5%
+ *   factual F1 0.750, containment-EM 0.750, tokens 1234, latency 210/640
+ *
+ * `flip` swaps one verdict so a second run differs and the std is genuinely
+ * non-zero — the positive control.
+ */
+function runResults(flip: boolean): QuestionArmResult[] {
+  const ex = (f1: number, cem: number) => ({ f1, containmentEM: cem, strictEM: 0 });
+  return [
+    q({ questionId: "e1", verdict: "CORRECT", extraction: ex(0.9, 1), latencyMs: 640 }),
+    q({ questionId: "e2", verdict: "CORRECT", extraction: ex(0.8, 1) }),
+    q({ questionId: "e3", verdict: "CORRECT", extraction: ex(0.7, 0) }),
+    q({ questionId: "e4", verdict: "INCORRECT", extraction: ex(0.6, 1) }),
+    q({ questionId: "m1", ability: "multi-session", verdict: "CORRECT" }),
+    q({ questionId: "m2", ability: "multi-session", verdict: flip ? "INCORRECT" : "CORRECT" }),
+    q({ questionId: "m3", ability: "multi-session", verdict: "CORRECT" }),
+    q({ questionId: "m4", ability: "multi-session", verdict: "NOT_ATTEMPTED" }),
+    q({ questionId: "a1_abs", ability: "abstention", isAbstention: true, verdict: "CORRECT" }),
+    q({ questionId: "a2_abs", ability: "abstention", isAbstention: true, verdict: "CORRECT" }),
+    q({ questionId: "a3_abs", ability: "abstention", isAbstention: true, verdict: "INCORRECT" }),
+  ];
+}
+
+function render(nRuns: 1 | 2): string {
+  const perRun = Array.from({ length: nRuns }, (_, i) => aggregateArmRun("flair", runResults(i === 1)));
+  const aggregate = [aggregateArmAcrossRuns("flair", perRun)];
+  return formatReport({
+    aggregate, runs: nRuns, validationSlice: false, selectedArms: ["flair"] as Arm[],
+  }).join("\n");
+}
+
+describe("longmemeval report — an unmeasured spread must not render as a measured zero (#1376)", () => {
+  test("a SINGLE-run report prints no ± and no 0.0% anywhere", () => {
+    const out = render(1);
+    // Guard against a vacuous pass: a formatter returning "" would satisfy
+    // both negatives below. The report has to actually be a report.
+    expect(out).toContain("[flair]");
+    expect(out).toContain("72.7%"); // the measured mean IS printed
+
+    // The defect, stated as the two things a reader would misread.
+    expect(out).not.toContain("±");
+    expect(out).not.toContain("0.0%");
+  });
+
+  test("a SINGLE-run report says the variance was not measured, in the headline", () => {
+    const out = render(1);
+    const headline = out.split("\n").find((l) => l.includes("overall accuracy:"))!;
+    expect(headline).toContain("single run");
+    expect(headline).toContain("unmeasured");
+    // Recoverable-from-a-field is not a mitigation: it has to be on the line
+    // a human reads, next to the number it qualifies.
+    expect(headline).toContain("72.7%");
+  });
+
+  test("POSITIVE CONTROL — a TWO-run report does print mean ± std", () => {
+    // Without this, "no ±" could be satisfied by a formatter that never prints
+    // a spread at all, and the fix would silently delete a real measurement.
+    const out = render(2);
+    expect(out).toContain("±");
+    const headline = out.split("\n").find((l) => l.includes("overall accuracy:"))!;
+    // runs of 8/11 and 7/11 → mean 68.2%, sample std (1/11)/√2 = 6.4%
+    expect(headline).toContain("68.2% ± 6.4%");
+    expect(headline).not.toContain("unmeasured");
+  });
+
+  test("the single-run and two-run reports differ in exactly this respect", () => {
+    // The two renders come from the same fixture shape; if they were identical
+    // the assertions above would be measuring nothing.
+    expect(render(1)).not.toBe(render(2));
+  });
+});


### PR DESCRIPTION
Refs #1376.

`std()` returned `0` for `n < 2` and the report printed it unconditionally, so a single-run headline rendered as **`66.0% ± 0.0%`** — indistinguishable to any reader from "we ran it repeatedly and it agreed perfectly", when what it means is "we never measured variance". Avoiding `NaN` was the right goal; `0` was the wrong sentinel, because it is the value that looks like the *strongest possible claim*. A unit test pinned the behavior: `expect(std([1])).toBe(0)` with the comment `// n<2 → 0, never NaN` — naming the goal it achieved while missing the cost.

This sits on the publication path, and zero variance on an LLM-judged benchmark is the first number a skeptical reader attacks.

## What changed

1. **The type expresses the absence.** `std(): number | null`, `null` for `n < 2`. `MeanStd.std` is nullable.
2. **The formatter refuses to print an interval it does not have.** Headline: `72.7% (single run — variance unmeasured)`; rows: `(unmeasured)`; banner: `— 1 run(s) — variance NOT measured (needs ≥2 runs)` instead of `, mean±std`.
3. **A distinct fact in the artifact.** `ArmAggregate.varianceMeasured: boolean`. `std: null` says it in the value, `varianceMeasured` says it in a boolean — neither requires a consumer to notice that `runs[]` has length 1. Available-but-unread is not a mitigation.
4. **The pinning test is inverted.** `expect(std([1])).toBeNull()`, with the *measured* zero (`std([2,2,2]) === 0`) split into its own test so the two cases stay distinguishable, and `not.toBeNaN()` kept so the original goal is still asserted.

## Two commits, and why

`run.ts` calls `main()` at import time, so nothing in it could ever be imported by a test — including the report block. The first commit extracts the formatting into `report.ts` as a pure `formatReport(): string[]` with **no behavior change**: the block and `pct`/`fmt` were machine-extracted from `run.ts` rather than retyped, and both renderings were diffed line-by-line over four fixtures (1/2/5 runs, validation slice, with and without `full-context`) — byte-identical in all four. The second commit is the fix.

## Powered check

The formatter test was written **before** the fix and run against the pre-fix code. It failed on the real rendered string:

```
(fail) a SINGLE-run report prints no ± and no 0.0% anywhere
Expected to not contain: "±"
Received: "…  RESULTS (run) — 1 run(s), mean±std …
[flair]  overall accuracy: 72.7% ± 0.0%   (runs: 72.7%)
    overall (answerable only)    75.0% ± 0.0%
    information-extraction       75.0% ± 0.0% …"

(fail) a SINGLE-run report says the variance was not measured, in the headline
Expected to contain: "single run"
Received: "[flair]  overall accuracy: 72.7% ± 0.0%   (runs: 72.7%)"

 2 pass  2 fail
```

After the fix: **4 pass, 0 fail**.

Mutation-checked in both directions. Restoring `return 0` in `std()` fails **5** tests across 3 files; hardcoding `varianceMeasured: true` fails **3**; reverting each returns 27/27 green.

Two guards against an unpowered check:

- **Positive control** — a two-run render must still contain `±` and specifically `68.2% ± 6.4%`, so "no `±`" cannot be satisfied by a formatter that quietly stopped reporting spread at all.
- **The fixture is chosen so the assertion means what it says.** Every percentage avoids a whole ten, because `70.0%` contains `0.0%` as a substring and would have fired the check on a correct render. (That is not hypothetical — the first fixture used 70.0% and the assertion caught it.)

## Verification

- Unit lane (`bun test test/unit/ test/*.test.ts`): **5129 pass / 0 fail**, against a baseline I measured on unmodified `origin/main` in this same worktree: **5121 pass / 0 fail**. +8 = 4 new report tests, +2 from splitting the stats test, +1 one-run aggregate, +1 artifact.
- `npx tsc --noEmit -p tsconfig.test.check.json` — clean (these files are strict-typechecked; the nullable `std` breaks call sites if any were missed).
- `npx tsc --noEmit -p tsconfig.check.json` — clean.
- `node scripts/changelog-fragments.mjs check` — 17 fragments, no stray entries.
- `bun run test/bench/longmemeval/run.ts` prints usage — the CLI module graph still loads with the new import.

No Harper was started; every changed file is pure computation over in-memory fixtures.

## Deliberately not changed

- **`test/bench/longmemeval/results/longmemeval-s-artifact-635df13be42d3f30.json`** — the committed headline artifact, whose every `std` is `0` at `runs: 1`. It is content-addressed and pinned by `longmemeval-repro.test.ts`; editing it would invalidate its `artifactHash` and falsify the record of what was actually produced. The stale-looking zeros there are history, not a live claim. Re-running is the only honest way to change that number.
- **The run count.** Making the variance *known* — running the headline at `runs > 1` — is a separate decision with a cost implication, per the issue's own scope note.
- Unrelated `std` identifiers in `test/unit/temporal-scoring.test.ts`, `test/unit/b64.test.ts`, `resources/b64.ts` and `test/integration/durability-guard.test.ts` are local variables meaning "standard", not this statistic.
