### PR TITLE
feat(bench): reader-determinism probe + artifactHash is a seal, not a proof (flair#1368)

### DIFF
--- a/.changelog/unreleased/added-1368-reader-determinism-probe.md
+++ b/.changelog/unreleased/added-1368-reader-determinism-probe.md
@@ -1,0 +1,19 @@
+- **The LongMemEval bench now measures and publishes its reader's
+  nondeterminism, and states what each hash actually proves.** "Re-run and
+  compare within variance" was an empty instruction: we published no variance to
+  compare against, so a re-runner whose completion text diverged from ours had
+  no way to tell normal from broken. Every run now probes the reader — N
+  byte-identical calls on a FIXED, recorded question sample — and records
+  distinct completions, common-prefix length and verdict-agreement rate in the
+  artifact's **unhashed provenance** partition. The probe issues the main run's
+  own reader request builder and takes no reader parameters of its own, so it
+  cannot drift into measuring a different configuration; the question sample is
+  a hardcoded constant so probes stay comparable across runs; and a probe id
+  missing from the dataset is fatal rather than a silent skip. Alongside it, the
+  reproducibility language is restated in three tiers: `configHash` is the
+  re-derivable anchor and leads, `runHash` is the decision set (re-derivable
+  locally, statistical under the cloud profile), and **`artifactHash` is a seal,
+  not a proof** — tamper-evidence for a signed-off artifact, never
+  reproducibility evidence. "Verify it yourself" rests on `configHash` plus the
+  exact prompts, dataset selection and judge rubric. Bench tooling only; nothing
+  in the shipped package changes.

--- a/test/bench/longmemeval/README.md
+++ b/test/bench/longmemeval/README.md
@@ -9,16 +9,20 @@ answer. It sits on top of the shared plumbing merged in #1216-a
 diverge on how memories are written or read (a divergence would be a silent
 confound).
 
-**Reproducibility is the edge.** Everything that can move the number is pinned
-and committed: the dataset (by HF commit + sha256), the judge and reader (by
-Ollama manifest digest — tags are mutable, digests are not), num_ctx, the
-retrieval config, the ingestion granularity, the store topology, and the exact
-judge/reader prompt strings (all folded into the config hash). Anyone re-runs
-the exact configuration with `ollama pull` — no OpenAI key, no per-run spend.
+**`configHash` is the anchor, and "verify it yourself" rests on it.** Everything
+that can move the number is pinned and committed: the dataset (by HF commit +
+sha256), the judge and reader (by Ollama manifest digest — tags are mutable,
+digests are not), num_ctx, the retrieval config, the ingestion granularity, the
+store topology, and the exact judge/reader prompt strings (all folded into the
+config hash). Anyone with the repo re-derives `configHash` exactly, and re-runs
+the same configuration with `ollama pull` — no OpenAI key, no per-run spend.
 
-Read "What 'reproducible' does and does not mean here" below before quoting
-that sentence at anyone: the config reproduces exactly, the reader's *text*
-does not under the cloud profile.
+**"Verify it yourself" rests on `configHash` plus the exact prompts, the dataset
+selection and the judge rubric — not on `artifactHash`.** `artifactHash` is a
+*seal*: tamper-evidence for a signed-off artifact. It is not a reproducibility
+proof and never was, even locally. Read
+"[What 'reproducible' does and does not mean here](#what-reproducible-does-and-does-not-mean-here)"
+below before quoting any of this at anyone.
 
 ## Arms
 
@@ -182,6 +186,7 @@ variant to hash — hashing it would content-address the breakage:
 | `LME_FLAIR_PKG_DIR`, `LME_HARPER_BIN_DIR` | locate the system under test | say *where* Flair lives, not how it behaves |
 | `LME_BENCH_HOST` | provenance label | lands in the artifact's unhashed provenance partition |
 | `LME_SHARED_COUNT_PROBE=1` | row-count probe logging | logging only |
+| `LME_DETERMINISM_SAMPLES` | N for the reader-determinism probe (default 10, minimum 2) | the probe CHARACTERISES the reader on a fixed sample outside the measured slice; it never feeds an answer, a verdict or a metric, and its record is unhashed provenance |
 
 ### Ingest-reuse (shared store, alternating mode)
 
@@ -202,23 +207,48 @@ reason it was reachable, not the reason it is correct.)
 ### Resume, and what the hashes actually guarantee
 
 `runHash` content-addresses the run's **decisions** (answer / verdict /
-tokensFed / extraction) and is resume-invariant. `configHash` is deterministic
-from the config.
+tokensFed / extraction) and is resume-invariant: banked `(question, arm)` pairs
+are replayed, never re-evaluated, so a resumed run and an uninterrupted one hold
+the same decision set.
 
 `artifactHash` covers the whole aggregate, which includes latency percentiles —
-wall clock. **Artifact hashes are therefore not host- or wall-clock invariant**;
-`configHash` and `runHash` are the reproducible identities. Banked journal lines
-carry their original `latencyMs` so a resumed run replays latency faithfully,
-but a journal written before that field existed falls back to `0`.
+wall clock. So an artifact hash is not wall-clock invariant, and that is fine,
+because **it is a seal rather than an identity to reproduce**. Banked journal
+lines carry their original `latencyMs` so a resumed run replays latency
+faithfully, but a journal written before that field existed falls back to `0`.
 
 ### What "reproducible" does and does not mean here
 
-Be precise about this, because the claim is the product.
+Be precise about this, because the claim is the product. There are three
+identities and they carry three different strengths of claim. Lead with the
+first one.
 
-**Reproducible:** `configHash`. It is a pure function of the pinned config, so
-any checkout with the same profile and slice derives it exactly. The
-reproduction of the published headline `configHash` from repo code is asserted
-in `test/unit/longmemeval-repro.test.ts`.
+#### Tier 1 — `configHash`: the anchor, re-derivable by anyone
+
+A pure function of the pinned config, so any checkout with the same profile and
+slice derives it **exactly**. It survives cloud nondeterminism because it hashes
+*configuration*, not output. This is what "did they run what they said they ran"
+actually rests on, and the reproduction of the published headline `configHash`
+from repo code is asserted in `test/unit/longmemeval-repro.test.ts`.
+
+#### Tier 2 — `runHash`: the decision set, statistical under `cloud`
+
+Content-addresses answer / verdict / tokensFed / extraction. Under `local` it is
+*expected* to re-derive — **expected, not measured**, so it is not claimed.
+Under `cloud` the answer *text* is not bitwise-stable, so `runHash` does not
+re-derive. The honest claim there: *accuracy is a statistical result — re-run
+and compare within variance; completion text is not bitwise-stable.* The
+variance to compare against is published in the artifact — see
+[the reader-determinism probe](#the-reader-determinism-probe) below.
+
+#### Tier 3 — `artifactHash`: a seal, not a proof
+
+It detects post-hoc modification of an artifact a human signed off on. **It is
+not reproducibility evidence and never was, even locally** — it covers wall-clock
+latency percentiles and, through the run hashes, completion text.
+
+So: **"verify it yourself" rests on `configHash` plus the exact prompts, the
+dataset selection and the judge rubric — not on `artifactHash`.**
 
 #### Reproducing a past run as the harness evolves
 
@@ -286,6 +316,70 @@ do not claim it without a measurement. (The cloud *judge* returned an identical
 verdict 4/4 in the same probe, but on a trivial 16-token prompt — that is not
 evidence of judge determinism on real rubric prompts.)
 
+### The reader-determinism probe
+
+*"Re-run and compare within variance"* is an **empty instruction unless the
+variance is published.** Someone re-running this benchmark against the same cloud
+reader will get different completion text than we did; without a published
+determinism measurement they cannot tell whether their divergence is normal or
+evidence that we got something wrong.
+
+So every run measures it and records it (`determinism.ts`, flair#1368). Per
+probed question:
+
+| field | meaning |
+|---|---|
+| `samples` | **N** — repeated calls with a byte-identical prompt (default 10) |
+| `distinctCompletions` | **M** — unique completion strings across the N calls |
+| `commonPrefixLength` | characters every completion shares before the first divergence |
+| `verdictAgreementRate` | (count of the modal verdict) / N — an unparseable verdict is its own bucket, never folded into a real one |
+
+Plus `questionIds` (the fixed sample), the resolved `reader` pin, and
+`promptConstruction`. A `summary` rolls the questions up with the aggregation
+named in each field: `maxDistinctCompletions`, `minCommonPrefixLength`,
+`minVerdictAgreementRate`.
+
+Four properties make the numbers worth comparing, and each is enforced rather
+than asked for:
+
+- **Identical reader configuration.** The probe issues `buildReaderRequest()`
+  from `eval.ts` — the single definition of a reader call that the main run also
+  issues — and calls `readerAnswer()` / `judgeOne()` themselves. It takes no
+  reader parameters of its own, so there is nothing to set on one path and
+  forget on the other. A probe that quietly measured different settings would be
+  *worse* than no probe, because its numbers would look authoritative.
+- **Fixed question sample.** `PROBE_QUESTION_IDS` is a hardcoded constant, not a
+  draw from the run's slice. A sample that moved per run would make probes
+  incomparable across runs — the one property the probe exists to provide. The
+  ids are written into the artifact, and a probe id missing from the dataset is
+  fatal, never a silent skip. **Changing that list breaks comparability with
+  every probe already published**; treat it as a new measurement if you must.
+- **Unhashed provenance.** The record lands in the artifact's provenance
+  partition. Determinism legitimately differs run to run, so if it fed
+  `artifactHash`, every honest re-run would look like tampering. Asserted, not
+  assumed (`test/unit/longmemeval-artifact.test.ts`).
+- **The judge is never sampled.** All N completions are scored.
+
+**Limitation, stated because it is real.** The probe does not retrieve from a
+live Flair. It builds a retrieval-*shaped* context deterministically from the
+question's own haystack and formats it through the harness's own pinned payload
+formatter, so the probe prompt is a pure function of (dataset, question id,
+pinned prompts, pinned payload format, `readerTopK`) and a re-runner rebuilds it
+**byte-identically** without needing our store or our index state. That
+reproducibility is the point — a probe whose own input could not be reproduced
+would not support the comparison it exists for. The trade is that the context is
+the same *shape* and comparable size as a real retrieval payload, not the same
+*content*.
+
+`LME_DETERMINISM_SAMPLES` raises or lowers N; the value used is recorded next to
+every number it produced. Below 2 is fatal rather than clamped — one call cannot
+measure agreement between calls, and "1 distinct completion" from a single
+sample would be a fabricated determinism claim.
+
+A failed probe is recorded **as an error in the artifact**, not omitted: "we did
+not probe" and "we probed and it broke" are different facts, and a probe failure
+does not abort the measurement run.
+
 ## The publish gate is structural
 
 The run emits a **content-addressed artifact** (`artifact.ts`): config hash +
@@ -295,6 +389,12 @@ gated human decision recorded against a specific `artifactHash` — spend and
 outward-publishing are the founder's gates. The full ≥5×500 publishable run is a
 separate gated execution; the default `--runs`/`--n` here are sized for
 validation.
+
+What the hash does *for this gate*: it binds a sign-off to one exact set of
+numbers, so "approved to publish artifact `<hash>`" cannot later be attached to
+a different set. That is tamper-evidence — a **seal**, not a reproducibility
+proof. Anyone checking that we ran what we said we ran should check
+`configHash`.
 
 ## Isolation
 

--- a/test/bench/longmemeval/artifact.ts
+++ b/test/bench/longmemeval/artifact.ts
@@ -8,17 +8,46 @@
  *
  *   artifactHash = sha256( canonical( configHash + per-run hashes + numbers ) )
  *
- * The artifact is partitioned into hashed CONTENT (schema, validationSlice,
- * configHash, config, runHashes, aggregate, gitCommit) and unhashed PROVENANCE
- * (generatedAt, host, notice, artifactHash). Provenance is stamped AFTER hashing
- * and stripped BEFORE verification, so two runs with identical content hash
- * identically regardless of wall clock or host — host-invariance IS the
- * reproducibility claim.
+ * ── artifactHash IS A SEAL, NOT A PROOF ──────────────────────────────────────
  *
- * A human sign-off is recorded against a specific artifactHash — "approved to
- * publish artifact <hash>", not "the number seemed fine at some point". A
- * reviewer can recompute the hash from the committed config + the recorded
- * per-run outputs and confirm the published number is the one that was signed.
+ * State this correction before anything else, because the file used to imply
+ * the opposite. `artifactHash` is TAMPER-EVIDENCE. It binds a human sign-off to
+ * one exact set of numbers — "approved to publish artifact <hash>", not "the
+ * number seemed fine at some point" — so a later edit to a published artifact is
+ * detectable. It is NOT a reproducibility proof and never was, even locally: it
+ * covers wall-clock latency percentiles and (through the run hashes) completion
+ * text, neither of which a faithful re-run reproduces.
+ *
+ * The three identities, in the order a reader should trust them (Sherlock,
+ * flair#1368):
+ *
+ *   configHash    THE ANCHOR. A pure function of the pinned config; anyone with
+ *                 the repo re-derives it exactly. It survives cloud
+ *                 nondeterminism because it hashes CONFIGURATION, not output.
+ *                 "Did they run what they said they ran" rests on this.
+ *   runHash       THE DECISION SET (answer / verdict / tokensFed / extraction).
+ *                 Expected re-derivable under the `local` profile — expected,
+ *                 not measured, so it is not claimed. Under `cloud` the
+ *                 completion text is not bitwise-stable, so this does not
+ *                 re-derive; accuracy is a statistical result there.
+ *   artifactHash  THE SEAL. Tamper-evidence for a signed-off artifact.
+ *
+ * "Verify it yourself" therefore rests on `configHash` plus the exact prompts,
+ * the dataset selection and the judge rubric — NOT on `artifactHash`.
+ *
+ * ── The partition ────────────────────────────────────────────────────────────
+ *
+ * Hashed CONTENT: schema, validationSlice, configHash, config, runHashes,
+ * aggregate, gitCommit. Unhashed PROVENANCE: generatedAt, host, notice,
+ * readerDeterminism, artifactHash. Provenance is stamped AFTER hashing and
+ * stripped BEFORE verification, so two runs with identical content hash
+ * identically regardless of wall clock, host, or measured reader
+ * nondeterminism.
+ *
+ * `readerDeterminism` (flair#1368) is provenance for a specific reason worth
+ * stating: a determinism measurement legitimately differs run to run, so if it
+ * fed the hash, every honest re-run would look like tampering — the seal would
+ * fire on exactly the thing it is not meant to detect.
  *
  * There is deliberately NO publish function and NO --publish flag here. The
  * artifact carries a NOTICE stating exactly that.
@@ -27,6 +56,7 @@ import { writeFileSync, mkdirSync } from "node:fs";
 import { join } from "node:path";
 import { canonicalJson, sha256hex } from "./config";
 import type { ArmAggregate, ArmRunMetrics } from "./metrics";
+import type { ReaderDeterminism } from "./determinism";
 
 export interface RunRecord {
   runIndex: number;
@@ -47,11 +77,22 @@ export interface Artifact {
   aggregate: ArmAggregate[];
 
   // ── Unhashed PROVENANCE — stamped AFTER hashing, stripped BEFORE verify. ──
-  // These describe WHERE/WHEN the number was produced, not WHAT it is, so they
-  // must never enter the hash (host-invariance IS the reproducibility claim).
+  // These describe WHERE/WHEN/HOW-STABLY the number was produced, not WHAT it
+  // is, so they must never enter the hash: the seal must fire on a changed
+  // NUMBER, and never on a different host, a different clock, or a different
+  // (honest) determinism reading.
   notice: string;
   generatedAt: string;
   host: { ollama: string; benchHost: string };
+  /** MEASURED reader nondeterminism (determinism.ts, flair#1368): N calls with a
+   *  byte-identical prompt, M distinct completions, common-prefix length, and
+   *  verdict-agreement rate, on a FIXED question sample recorded alongside.
+   *
+   *  This is the published variance that makes "re-run and compare within
+   *  variance" a checkable instruction instead of an empty one. It is
+   *  PROVENANCE, never content: it legitimately differs between honest runs, so
+   *  hashing it would make every faithful re-run look like tampering. */
+  readerDeterminism?: ReaderDeterminism;
   /** Filled in AFTER hashing (excluded from the hash — the hash addresses
    *  the content partition above it). */
   artifactHash?: string;
@@ -70,6 +111,11 @@ export interface BuildArtifactInput {
   ollamaHost: string;
   benchHost: string;
   validationSlice: boolean;
+  /** Optional so a caller that has no probe result (a failed probe supplies a
+   *  record with `error` set — see determinism.failedProbe) is not forced to
+   *  invent one. Omitted ⇒ the key is absent from the artifact entirely, which
+   *  is honestly different from "probed and found deterministic". */
+  readerDeterminism?: ReaderDeterminism;
 }
 
 /** Provenance fields — stamped AFTER hashing and stripped BEFORE verification.
@@ -77,7 +123,9 @@ export interface BuildArtifactInput {
  *  for the partition, so buildArtifact and verifyArtifactHash can never drift —
  *  and it is EXPORTED so a second artifact schema (the payload A/B) inherits
  *  the identical partition instead of re-deciding it. */
-export const PROVENANCE_KEYS = ["generatedAt", "host", "notice", "artifactHash"] as const;
+export const PROVENANCE_KEYS = [
+  "generatedAt", "host", "notice", "readerDeterminism", "artifactHash",
+] as const;
 
 /** The hashed-content partition of any artifact: everything except provenance. */
 export function hashedContent(art: object): Record<string, unknown> {
@@ -117,16 +165,20 @@ export function buildArtifact(input: BuildArtifactInput): Artifact {
     runHashes: input.runHashes,
     aggregate: input.aggregate,
   };
-  // Hash the CONTENT partition only — provenance (generatedAt, host, notice) is
-  // excluded so two runs with identical content hash identically regardless of
-  // wall clock or host. canonicalJson sorts keys, and artifactHash is absent at
+  if (input.readerDeterminism) art.readerDeterminism = input.readerDeterminism;
+  // Hash the CONTENT partition only — provenance (generatedAt, host, notice,
+  // readerDeterminism) is excluded so two runs with identical content hash
+  // identically regardless of wall clock, host, or measured reader
+  // nondeterminism. canonicalJson sorts keys, and artifactHash is absent at
   // this point, so it cannot address itself.
   return stampArtifactHash(art);
 }
 
 /** Recompute the hash of an artifact object (verification): strip the provenance
- *  partition (generatedAt, host, notice, artifactHash), canonicalise, sha256 —
- *  must equal the stored artifactHash. */
+ *  partition (generatedAt, host, notice, readerDeterminism, artifactHash),
+ *  canonicalise, sha256 — must equal the stored artifactHash. A match proves the
+ *  artifact has not been modified since sign-off; it does NOT prove the numbers
+ *  are reproducible. See the header. */
 export function verifyArtifactHash(art: Artifact): boolean {
   return verifyStampedHash(art);
 }

--- a/test/bench/longmemeval/config.ts
+++ b/test/bench/longmemeval/config.ts
@@ -9,9 +9,16 @@
  * that hash — so a reviewer can verify the reported number came from THIS
  * config, and config-shopping (run 10, publish the best) leaves a trace.
  *
- * Reproducibility is the edge (#1216): anyone re-runs the exact number locally
- * with `ollama pull` at the pinned digests + this dataset commit — no OpenAI
- * key, no spend. Pin by DIGEST, never by tag (tags are mutable).
+ * `configHash` is THE ANCHOR of the whole verification story (Sherlock,
+ * flair#1368): a pure function of pinned configuration that anyone with the repo
+ * re-derives exactly, with `ollama pull` at the pinned digests + this dataset
+ * commit — no OpenAI key, no spend. It survives cloud nondeterminism precisely
+ * because it hashes CONFIGURATION, not output.
+ *
+ * Say what it does and does not carry. It answers "did they run what they said
+ * they ran". It does not make the NUMBERS re-derivable: `runHash` re-derives
+ * only where the reader is bitwise-stable, and `artifactHash` is a seal, not a
+ * proof (artifact.ts). Pin by DIGEST, never by tag (tags are mutable).
  */
 import { createHash } from "node:crypto";
 import { JUDGE_PROMPT_TEMPLATES } from "./judge";

--- a/test/bench/longmemeval/determinism.ts
+++ b/test/bench/longmemeval/determinism.ts
@@ -1,0 +1,382 @@
+/**
+ * determinism.ts — the READER-DETERMINISM PROBE (flair#1368).
+ *
+ * WHY THIS EXISTS. Under the `cloud` profile the reader is not bitwise-stable
+ * at temperature 0 / seed 0: batched inference (MoE routing, mixed-precision
+ * kernels) is not reproducible across batch composition. So a published cloud
+ * accuracy is a STATISTICAL result, and the honest claim about it is "re-run
+ * and compare within variance."
+ *
+ * That instruction is EMPTY unless we publish the variance to compare against.
+ * Someone re-running this benchmark against the same cloud reader will get
+ * different completion text than we did, and without a published determinism
+ * measurement they cannot tell whether their divergence is normal or evidence
+ * that we got something wrong. This probe is what makes the instruction
+ * checkable: it records what OUR reader's nondeterminism measured, in the same
+ * units a re-runner can measure their own.
+ *
+ * WHAT IT RECORDS, per probed question:
+ *   samples               N — repeated calls with a BYTE-IDENTICAL prompt
+ *   distinctCompletions   M — unique completion strings across the N calls
+ *   commonPrefixLength    chars every completion shares before any two diverge
+ *   verdictAgreementRate  fraction of the N calls the judge scored the same way
+ *
+ * FOUR PROPERTIES THAT ARE EASY TO GET WRONG, and how each is enforced here:
+ *
+ * 1. IDENTICAL READER CONFIGURATION. The probe issues `buildReaderRequest()`
+ *    from eval.ts — the single definition of a reader call that the main run
+ *    also issues — and calls `readerAnswer()` / `judgeOne()` themselves. It
+ *    accepts NO reader parameters of its own: no model, no temperature, no
+ *    seed, no num_ctx, no prompt template. There is therefore nothing for a
+ *    later edit to change on one path and forget on the other. A probe that
+ *    quietly measured a different configuration would be worse than no probe,
+ *    because its numbers would look authoritative.
+ *
+ * 2. FIXED QUESTION SAMPLE. `PROBE_QUESTION_IDS` is a hardcoded constant, not a
+ *    draw from the run's slice and not a random sample. A sample that moved per
+ *    run would make probes incomparable ACROSS runs, destroying the single
+ *    property the probe exists to provide. The ids are also written into the
+ *    artifact, so a re-runner does not have to read this file to know what was
+ *    probed. A probe id missing from the dataset is FATAL, never a silent skip.
+ *
+ * 3. UNHASHED PROVENANCE. The result lands in the artifact's provenance
+ *    partition (artifact.ts PROVENANCE_KEYS), never in the hashed content. A
+ *    determinism measurement legitimately differs run to run; if it fed
+ *    `artifactHash`, every honest re-run would look like tampering. Asserted,
+ *    not assumed — test/unit/longmemeval-artifact.test.ts.
+ *
+ * 4. THE JUDGE IS NOT SAMPLED. Every one of the N completions is scored. The
+ *    judge is cheap relative to the reader, and scoring a subset would put a
+ *    second source of variance inside the number that is supposed to isolate
+ *    the reader's.
+ *
+ * WHAT THE PROBE'S CONTEXT IS, stated plainly because it is a real limitation.
+ * The probe does not retrieve from a live Flair — it builds a retrieval-SHAPED
+ * context deterministically from the question's own haystack (`probeContext`
+ * below) and formats it through the harness's own pinned payload formatter. So
+ * the probe's prompt is a pure function of (dataset, question id, pinned prompt
+ * strings, pinned payload format, readerTopK), and a re-runner reconstructs it
+ * BYTE-IDENTICALLY without needing our store, our index state or our run.
+ * That reproducibility is the point: a probe whose own input could not be
+ * reproduced would not support the comparison it exists for. The trade is that
+ * the context is not the retrieval the headline arms actually saw — it is the
+ * same SHAPE and comparable size, not the same content.
+ */
+import { READER, RETRIEVAL } from "./config";
+import {
+  formatRetrieved, READER_PAYLOAD_FORMAT, READER_PROMPT_VERSION, type Arm,
+} from "./arms";
+import { buildReaderRequest, readerAnswer, judgeOne } from "./eval";
+import { abilityOf, entryToSessions, isAbstention, type LmeEntry } from "./dataset";
+import type { Verdict } from "./judge";
+import type { RetrievedItem } from "../../../packages/flair-bench/lib/index";
+
+/**
+ * The FIXED question sample. Hardcoded ids from LongMemEval_s, deliberately not
+ * derived from `--n` / `--seed`: a probe drawn from the run's slice would move
+ * whenever the slice moved, and two runs' probes would stop being comparable —
+ * which is the one property the probe exists to provide.
+ *
+ * Two questions rather than one so a single unlucky question cannot be mistaken
+ * for a property of the reader. Both are answerable (non-`_abs`) questions from
+ * the published 500-question headline slice, so they are guaranteed present in
+ * the pinned dataset.
+ *
+ * CHANGING THIS LIST breaks comparability with every probe already published.
+ * If it must change, treat it as a new measurement: say so, and do not compare
+ * the new numbers to the old ones.
+ */
+export const PROBE_QUESTION_IDS: readonly string[] = ["001be529", "00ca467f"];
+
+/** The arm whose reader configuration is probed: the headline arm. Its num_ctx
+ *  is the pinned READER.numCtx (only `full-context` overrides it). */
+export const PROBE_ARM: Arm = "flair";
+
+/**
+ * N — repeated calls per probed question. 10 by default.
+ *
+ * `LME_DETERMINISM_SAMPLES` may raise or lower it, and whatever value ran is
+ * recorded in the artifact next to every number it produced, so the denominator
+ * travels with the measurement. Anything below 2 is FATAL rather than clamped:
+ * one call cannot measure agreement between calls, and a probe reporting
+ * "1 distinct completion" from a single sample would be a fabricated
+ * determinism claim, which is precisely the failure this file exists to
+ * prevent. A non-numeric value is fatal for the same reason.
+ */
+export const PROBE_SAMPLES: number = (() => {
+  const raw = process.env.LME_DETERMINISM_SAMPLES;
+  if (raw === undefined || raw === "") return 10;
+  const n = Number(raw);
+  if (!Number.isInteger(n) || n < 2) {
+    throw new Error(
+      `LME_DETERMINISM_SAMPLES must be an integer >= 2 (got "${raw}"). ` +
+      `A single sample cannot measure agreement between samples — it would report ` +
+      `"1 distinct completion" for a reader that is not deterministic at all.`,
+    );
+  }
+  return n;
+})();
+
+export const DETERMINISM_SCHEMA = "longmemeval-s.reader-determinism/1";
+
+export interface QuestionDeterminism {
+  questionId: string;
+  ability: string;
+  /** Assembled reader prompt size. Recorded because nondeterminism is
+   *  prompt-size dependent — a 32-token probe is not evidence about a
+   *  4000-token one, and a reader of this number must be able to see which
+   *  they are looking at. */
+  promptChars: number;
+  /** Prompt tokens as the MODEL reported them, per call. Constant across calls
+   *  for a byte-identical prompt; a varying value would mean the prompt itself
+   *  moved and the probe measured the wrong thing. */
+  promptTokens: number[];
+  /** N. Repeated here per question so no number in this record is separated
+   *  from its denominator. */
+  samples: number;
+  /** M — unique completion strings across the N calls. 1 ⇒ bitwise-stable. */
+  distinctCompletions: number;
+  /** Characters every completion shares before the first divergence. Equals the
+   *  completion length when M === 1. */
+  commonPrefixLength: number;
+  /** (count of the most common verdict) / N. 1 ⇒ every call graded the same,
+   *  which is the property the headline accuracy actually rests on. An
+   *  unparseable verdict is its own bucket (`JUDGE_ERROR`) — never folded into
+   *  a real verdict, and never a silent pass. */
+  verdictAgreementRate: number;
+  verdictCounts: Record<string, number>;
+  judgeErrors: number;
+  /** Completion LENGTHS, not the completions. The artifact must not carry N
+   *  copies of a reader answer. */
+  completionChars: number[];
+}
+
+export interface ReaderDeterminism {
+  schema: string;
+  measuredAt: string;
+  ollamaHost: string;
+  /** The reader pin ACTUALLY USED, read off the resolved request rather than
+   *  restated — so this record cannot disagree with what went on the wire. */
+  reader: Record<string, unknown>;
+  promptConstruction: {
+    arm: Arm;
+    numCtx: number;
+    readerPromptVersion: string;
+    readerPayloadFormat: string;
+    readerTopK: number;
+    contextSource: string;
+  };
+  samples: number;
+  questionIds: string[];
+  perQuestion: QuestionDeterminism[];
+  /** Roll-up across the fixed sample. Each field names its own aggregation, so
+   *  a reader never has to guess whether a number is a mean, a max or a min. */
+  summary: {
+    maxDistinctCompletions: number;
+    minCommonPrefixLength: number;
+    minVerdictAgreementRate: number;
+  } | null;
+  /** Null on success. A probe that could not run records WHY here and is still
+   *  emitted — an absent probe and a failed probe must never look the same. */
+  error: string | null;
+}
+
+/** Characters shared by every string before the first position where any two
+ *  differ. `[]` → 0; a single string → its own length. */
+export function commonPrefixLength(strings: string[]): number {
+  if (strings.length === 0) return 0;
+  const limit = Math.min(...strings.map((s) => s.length));
+  for (let i = 0; i < limit; i++) {
+    const c = strings[0]![i];
+    for (const s of strings) if (s[i] !== c) return i;
+  }
+  return limit;
+}
+
+/** The pure summary of one question's N samples. Separated from the call loop
+ *  so it can be asserted directly, but note that testing THIS alone would not
+ *  catch a call loop that issued one call and copied the result N times — which
+ *  is why the probe is also exercised end to end against a known-deterministic
+ *  and a known-nondeterministic reader. */
+export function summariseSamples(
+  completions: string[], verdicts: (Verdict | null)[],
+): Pick<QuestionDeterminism,
+  "distinctCompletions" | "commonPrefixLength" | "verdictAgreementRate" | "verdictCounts" | "judgeErrors"> {
+  const verdictCounts: Record<string, number> = {};
+  for (const v of verdicts) {
+    const key = v ?? "JUDGE_ERROR";
+    verdictCounts[key] = (verdictCounts[key] ?? 0) + 1;
+  }
+  const modal = Object.values(verdictCounts).reduce((a, b) => Math.max(a, b), 0);
+  return {
+    distinctCompletions: new Set(completions).size,
+    commonPrefixLength: commonPrefixLength(completions),
+    verdictAgreementRate: verdicts.length ? modal / verdicts.length : 0,
+    verdictCounts,
+    judgeErrors: verdictCounts.JUDGE_ERROR ?? 0,
+  };
+}
+
+/**
+ * The probe's reader context: the question's own first `RETRIEVAL.readerTopK`
+ * ingested events, run through the harness's OWN pinned payload formatter
+ * (`formatRetrieved`, i.e. READER_PAYLOAD_FORMAT).
+ *
+ * A pure function of the dataset entry and the pinned config — no store, no
+ * index, no retrieval. That is what lets a re-runner rebuild a byte-identical
+ * probe prompt and compare their measurement to ours. The ids/dates/content all
+ * come from `entryToSessions`, the same mapping the real ingest uses, so the
+ * lines are shaped exactly like retrieved memories.
+ */
+export function probeContext(entry: LmeEntry): string {
+  const items: RetrievedItem[] = entryToSessions(entry)
+    .flatMap((s) => s.events)
+    .slice(0, RETRIEVAL.readerTopK)
+    .map((ev, rank) => ({
+      id: ev.id,
+      score: 1 - rank / 1000, // rank-ordered; never read by the formatter
+      content: ev.content,
+      createdAt: typeof ev.createdAt === "string" ? ev.createdAt : undefined,
+    }));
+  return formatRetrieved(items);
+}
+
+/** The shape returned when the probe could not run. Defined here so a failed
+ *  probe and a successful one are the same record with `error` set, rather than
+ *  two shapes a consumer has to know about. */
+export function failedProbe(host: string, err: unknown): ReaderDeterminism {
+  return {
+    ...emptyProbe(host),
+    error: err instanceof Error ? err.message : String(err),
+  };
+}
+
+function emptyProbe(host: string): ReaderDeterminism {
+  // Derived from the SAME builder the real calls use, so even the failure path
+  // cannot record a reader configuration the run would not have used.
+  const reference = buildReaderRequest("", "", "", PROBE_ARM);
+  return {
+    schema: DETERMINISM_SCHEMA,
+    measuredAt: new Date().toISOString(),
+    ollamaHost: host,
+    reader: { ...(reference.spec as unknown as Record<string, unknown>) },
+    promptConstruction: {
+      arm: PROBE_ARM,
+      numCtx: reference.opts.numCtxOverride ?? reference.spec.numCtx,
+      readerPromptVersion: READER_PROMPT_VERSION,
+      readerPayloadFormat: READER_PAYLOAD_FORMAT,
+      readerTopK: RETRIEVAL.readerTopK,
+      contextSource:
+        "deterministic: first readerTopK haystack events of the probed question, " +
+        "formatted by formatRetrieved at the pinned payload format",
+    },
+    samples: PROBE_SAMPLES,
+    questionIds: [...PROBE_QUESTION_IDS],
+    perQuestion: [],
+    summary: null,
+    error: null,
+  };
+}
+
+/**
+ * Measure the reader's nondeterminism on the FIXED question sample.
+ *
+ * `entries` is the whole loaded dataset (not the run's slice) — the probe's
+ * questions are fixed independently of what the run happens to be measuring.
+ * A probe id absent from `entries` throws: a silently-skipped question would
+ * leave a probe that looks complete but measured less than it claims.
+ */
+export async function probeReaderDeterminism(
+  host: string, entries: LmeEntry[], opts: { log?: (s: string) => void } = {},
+): Promise<ReaderDeterminism> {
+  const log = opts.log ?? (() => {});
+  const out = emptyProbe(host);
+  const byId = new Map(entries.map((e) => [e.question_id, e]));
+
+  log(
+    `[determinism] probing reader ${out.reader.model} — ${PROBE_QUESTION_IDS.length} fixed question(s) ` +
+    `x ${PROBE_SAMPLES} identical calls (+ ${PROBE_SAMPLES} judge calls each)`,
+  );
+
+  for (const questionId of PROBE_QUESTION_IDS) {
+    const entry = byId.get(questionId);
+    if (!entry) {
+      throw new Error(
+        `determinism probe: fixed question "${questionId}" is not in the loaded dataset ` +
+        `(${entries.length} entries). The probe sample is pinned in determinism.ts and must ` +
+        `exist in the pinned dataset — skipping it would publish a probe that measured less ` +
+        `than it says it did.`,
+      );
+    }
+    const context = probeContext(entry);
+    const request = buildReaderRequest(entry.question, entry.question_date, context, PROBE_ARM);
+    const completions: string[] = [];
+    const promptTokens: number[] = [];
+    const verdicts: (Verdict | null)[] = [];
+    for (let i = 0; i < PROBE_SAMPLES; i++) {
+      // The SAME call the run makes — same builder, same client, same pin.
+      const r = await readerAnswer(host, entry.question, entry.question_date, context, PROBE_ARM);
+      completions.push(r.answer);
+      promptTokens.push(r.tokensFed);
+      // Every completion is judged; the judge is never sampled.
+      const j = await judgeOne(
+        host, entry.question_type, entry.question, entry.answer, r.answer, isAbstention(entry),
+      );
+      verdicts.push(j.verdict);
+    }
+    const summary = summariseSamples(completions, verdicts);
+    out.perQuestion.push({
+      questionId,
+      ability: abilityOf(entry),
+      promptChars: request.prompt.length,
+      promptTokens,
+      samples: PROBE_SAMPLES,
+      completionChars: completions.map((c) => c.length),
+      ...summary,
+    });
+    log(
+      `[determinism] ${questionId}: ${summary.distinctCompletions}/${PROBE_SAMPLES} distinct completions, ` +
+      `common prefix ${summary.commonPrefixLength} chars, verdict agreement ` +
+      `${(summary.verdictAgreementRate * 100).toFixed(0)}%`,
+    );
+  }
+
+  out.summary = {
+    maxDistinctCompletions: Math.max(...out.perQuestion.map((q) => q.distinctCompletions)),
+    minCommonPrefixLength: Math.min(...out.perQuestion.map((q) => q.commonPrefixLength)),
+    minVerdictAgreementRate: Math.min(...out.perQuestion.map((q) => q.verdictAgreementRate)),
+  };
+  return out;
+}
+
+/** Console report. Lives here so run.ts holds the orchestration and this file
+ *  holds everything that knows the probe's units. */
+export function printReaderDeterminism(d: ReaderDeterminism): void {
+  console.log(`\n── reader determinism (UNHASHED PROVENANCE — this is the variance to compare against) ──`);
+  if (d.error) {
+    console.log(`  PROBE FAILED: ${d.error}`);
+    console.log(`  Recorded in the artifact as an error. An absent probe and a failed probe are not the same thing.`);
+    return;
+  }
+  console.log(`  reader ${d.reader.model} @ temp ${d.reader.temperature} seed ${d.reader.seed} num_ctx ${d.promptConstruction.numCtx}`);
+  for (const q of d.perQuestion) {
+    console.log(
+      `  ${q.questionId.padEnd(16)} ${q.distinctCompletions}/${q.samples} distinct  ` +
+      `common prefix ${String(q.commonPrefixLength).padStart(5)} chars  ` +
+      `verdict agreement ${(q.verdictAgreementRate * 100).toFixed(0)}%  ` +
+      `(prompt ${q.promptChars} chars / ${q.promptTokens[0] ?? "?"} tokens)`,
+    );
+  }
+  if (d.summary) {
+    console.log(
+      `  worst case across the fixed sample: ${d.summary.maxDistinctCompletions} distinct completions, ` +
+      `${d.summary.minCommonPrefixLength}-char common prefix, ` +
+      `${(d.summary.minVerdictAgreementRate * 100).toFixed(0)}% verdict agreement`,
+    );
+  }
+  console.log(
+    `  A re-runner should measure the same quantities on the same fixed questions and compare.\n` +
+    `  Divergence in COMPLETION TEXT at this rate is expected; divergence in VERDICT agreement is the\n` +
+    `  signal that matters, because the headline accuracy is a function of verdicts, not of text.`,
+  );
+}

--- a/test/bench/longmemeval/eval.ts
+++ b/test/bench/longmemeval/eval.ts
@@ -21,7 +21,7 @@ import {
   type BenchClient, type TestAgent,
 } from "../../../packages/flair-bench/lib/index";
 import { OLLAMA_HOST, READER, JUDGE, RETRIEVAL, FULL_CONTEXT } from "./config";
-import { generate } from "./ollama";
+import { generate, type OllamaModelSpec } from "./ollama";
 import { buildJudgePrompt, parseVerdict, JudgeParseError, type LmeTask } from "./judge";
 import { buildReaderPrompt, formatRetrieved, formatFullContext, HARPER_ARMS, ALL_ARMS, type Arm } from "./arms";
 import { writeFileSync, rmSync, appendFileSync, readFileSync, existsSync } from "node:fs";
@@ -146,9 +146,13 @@ export function setJournalContext(configHash: string): void { JOURNAL_CFG = conf
 // `latencyMs`, so a journal written by this code replays latency faithfully;
 // but a line from BEFORE the journal recorded latencyMs falls back to 0 and
 // would drag those percentiles down. Accuracy metrics are exact either way.
-// Note this is a property of artifactHash generally, not of resume: artifact
-// hashes are not wall-clock invariant, so `configHash` + `runHash` are the
-// reproducible identities. (Tracked as a separate finding on #1366.)
+// Note this is a property of artifactHash generally, not of resume:
+// `artifactHash` IS A SEAL, NOT A PROOF — it detects post-hoc modification of a
+// signed-off artifact and was never a reproducibility claim, even locally.
+// `configHash` is the re-derivable anchor; `runHash` re-derives under the
+// `local` profile (unmeasured) and is statistical under `cloud`. See the
+// README section "What 'reproducible' does and does not mean here".
+// (Tracked as a separate finding on #1366.)
 //
 // Extraction is recomputed from the dataset rather than journalled, so an
 // extraction-method change cannot be silently inherited from an old journal.
@@ -197,19 +201,61 @@ export function writeProgress(patch: Partial<typeof progressState> = {}): void {
   try { writeFileSync(PROGRESS_FILE, JSON.stringify(progressState, null, 2)); } catch { /* progress is best-effort */ }
 }
 
-/** One reader call for a given assembled context. */
-async function readerAnswer(
+/**
+ * The FULLY RESOLVED reader request for one (question, arm): the model pin, its
+ * sampling parameters, the effective num_ctx, and the assembled prompt — in one
+ * object.
+ *
+ * This exists so the harness has exactly ONE definition of "what a reader call
+ * is". `readerAnswer()` below issues it, and the reader-determinism probe
+ * (determinism.ts, flair#1368) issues the SAME object rather than assembling a
+ * second one out of its own parameters.
+ *
+ * That is deliberate and it is the whole reason the probe is trustworthy. A
+ * probe that quietly used a different temperature, seed, num_ctx or prompt
+ * shape would be measuring a DIFFERENT system, and its numbers would be worse
+ * than no numbers at all because they would look authoritative. The drift is
+ * removed by SHAPE — the probe takes no reader parameters, so there is nothing
+ * for a future edit to set on one path and forget on the other — rather than by
+ * a comment asking the next editor to keep two call sites in step.
+ */
+export interface ReaderRequest {
+  /** The pinned reader spec — model, manifest digest, temperature, seed,
+   *  num_ctx, num_predict. Identical object for every arm (Kern §5a: the reader
+   *  is pinned across arms; only the CONTEXT differs). */
+  spec: OllamaModelSpec;
+  /** The assembled prompt, exactly as it goes on the wire. */
+  prompt: string;
+  /** Per-call overrides. Only the full-context arm sets one, and it is still
+   *  fixed and still hashed (config.FULL_CONTEXT). */
+  opts: { numCtxOverride?: number };
+}
+
+export function buildReaderRequest(
+  question: string, questionDate: string, context: string, arm: Arm,
+): ReaderRequest {
+  return {
+    spec: READER,
+    prompt: buildReaderPrompt(question, questionDate, context),
+    opts: { numCtxOverride: arm === "full-context" ? FULL_CONTEXT.numCtx : undefined },
+  };
+}
+
+/** One reader call for a given assembled context. Exported so the determinism
+ *  probe repeats THIS call rather than a lookalike of it. */
+export async function readerAnswer(
   host: string, question: string, questionDate: string, context: string, arm: Arm,
 ): Promise<{ answer: string; tokensFed: number; latencyMs: number }> {
-  const prompt = buildReaderPrompt(question, questionDate, context);
-  const numCtxOverride = arm === "full-context" ? FULL_CONTEXT.numCtx : undefined;
-  const g = await generate(host, READER, prompt, { numCtxOverride });
+  const req = buildReaderRequest(question, questionDate, context, arm);
+  const g = await generate(host, req.spec, req.prompt, req.opts);
   return { answer: clean(g.response), tokensFed: g.promptTokens, latencyMs: g.latencyMs };
 }
 
 /** One judge call. Returns verdict=null + judgeError on an unparseable verdict
- *  (never a silent pass). */
-async function judgeOne(
+ *  (never a silent pass). Exported for the same reason as readerAnswer: the
+ *  determinism probe scores its N completions through the run's OWN judge path,
+ *  not a re-implementation of it. */
+export async function judgeOne(
   host: string, task: LmeTask, question: string, answer: string, response: string, abstention: boolean,
 ): Promise<{ verdict: QuestionArmResult["verdict"]; judgeError?: string }> {
   const { prompt, allowed } = buildJudgePrompt({ task, question, answer, response, abstention });
@@ -719,7 +765,15 @@ export async function runOnce(runIndex: number, entries: LmeEntry[], opts: RunOp
   const armMetrics = SELECTED_ARMS.map((a) => aggregateArmRun(a, results));
 
   // Content-address the run by its DECISIONS (answer/verdict/tokens/extraction),
-  // NOT wall-clock latency — a faithful re-run reproduces this hash.
+  // NOT wall-clock latency.
+  //
+  // What re-derives, precisely (Sherlock's tier 2, flair#1368): because the
+  // answer TEXT is in here, this hash re-derives only where the reader is
+  // bitwise-stable. Under `local` that is expected but UNMEASURED, so it is not
+  // claimed. Under `cloud` it does not hold — batched inference is not
+  // bitwise-stable at temperature 0 / seed 0 — so a cloud accuracy is a
+  // statistical result to be compared within variance, and determinism.ts
+  // publishes the variance to compare against.
   const decisions = results
     .map((r) => ({
       questionId: r.questionId, arm: r.arm, answer: r.answer,

--- a/test/bench/longmemeval/ollama.ts
+++ b/test/bench/longmemeval/ollama.ts
@@ -1,8 +1,10 @@
 /**
  * ollama.ts — the ONE deterministic Ollama call path for the Layer 2 harness.
  *
- * Both the reader and the judge run LOCAL on Newton via Ollama. Reproducibility
- * is the edge (#1216 design), so this client is deliberately narrow:
+ * Under the `local` profile both the reader and the judge run on Newton via
+ * Ollama; under `cloud` the same call path talks to ollama.com. Either way the
+ * client is deliberately narrow, because every knob below is one that would
+ * otherwise put sampling noise inside the measurement:
  *
  *   - temperature 0 + a fixed seed + a fixed num_ctx — the run-to-run mean±std
  *     must reflect the memory layer, not sampling noise. A temp≠0 judge would
@@ -19,8 +21,11 @@
  *   - DIGEST-pinned. Ollama tags are MUTABLE; sha256 manifest digests are not.
  *     assertModelPinned() refuses to run if the model currently resolving on
  *     the host does not match the digest recorded in config.ts — so "I re-ran
- *     the exact number" means the exact weights, not whatever the tag points at
- *     today.
+ *     the exact CONFIGURATION" means the exact weights, not whatever the tag
+ *     points at today. Note the scope: this pins what was run. It does not make
+ *     the OUTPUT re-derivable — the cloud reader is not bitwise-stable at
+ *     temperature 0 / seed 0, which is what determinism.ts measures and
+ *     publishes.
  *
  * Pure transport + a pin check. No dataset, no prompts, no scoring.
  */
@@ -156,8 +161,10 @@ export async function generate(
 
 /**
  * Refuse to run unless the model's CURRENT manifest digest on the host matches
- * the digest pinned in config.ts. Tags are mutable; a silent re-tag would make
- * "re-run the number" reproduce a different model. Fail loud, never warn-and-go
+ * the digest pinned in config.ts. Tags are mutable; a silent re-tag would let a
+ * run that reports the pinned `configHash` have been served by different
+ * weights — the anchor would name a configuration that was not the one that
+ * ran. Fail loud, never warn-and-go
  * (a shipped default that resolves to whatever-is-there is a trust anchor —
  * MEMORY.md).
  */

--- a/test/bench/longmemeval/payload-ab.ts
+++ b/test/bench/longmemeval/payload-ab.ts
@@ -463,9 +463,15 @@ function report(
   };
 
   // Same partition discipline as the four-arm artifact (artifact.ts): hashed
-  // CONTENT above, unhashed PROVENANCE (generatedAt, host, notice, artifactHash)
-  // below, stamped after. resultsHash content-addresses the results alone so a
-  // reviewer can cite the numbers independently of the config they came from.
+  // CONTENT above, unhashed PROVENANCE below, stamped after. The provenance key
+  // set is artifact.PROVENANCE_KEYS — deliberately NOT restated here, so this
+  // artifact inherits the partition instead of holding a second copy of it that
+  // could fall out of date. resultsHash content-addresses the results alone so
+  // a reviewer can cite the numbers independently of the config they came from.
+  //
+  // As there: `artifactHash` is a SEAL (tamper-evidence for a signed-off
+  // artifact), not a reproducibility proof. `configHash` is the re-derivable
+  // anchor.
   const artifact = stampArtifactHash({
     schema: "longmemeval-s.payload-ab.artifact/1",
     validationSlice: true,
@@ -511,9 +517,9 @@ function report(
   console.log(`  gold ANSWER  hit rate (a has_answer turn retrieved)             : ${pct(answerHitRate)}`);
   console.log(`    with gold evidence    (n=${tEv.n}): A ${pct(tEv.v1Accuracy)} B ${pct(tEv.v2Accuracy)} | wins ${tEv.wins} losses ${tEv.losses} discordant ${mcEv.discordant} p=${mcEv.p.toFixed(4)}`);
   console.log(`    without gold evidence (n=${tNo.n}): A ${pct(tNo.v1Accuracy)} B ${pct(tNo.v2Accuracy)} | wins ${tNo.wins} losses ${tNo.losses} discordant ${mcNo.discordant} p=${mcNo.p.toFixed(4)}`);
-  console.log(`\n  configHash  : ${configHash}`);
+  console.log(`\n  configHash  : ${configHash}   (the anchor — re-derivable by anyone with the repo)`);
   console.log(`  resultsHash : ${artifact.resultsHash}`);
-  console.log(`  artifactHash: ${artifact.artifactHash}`);
+  console.log(`  artifactHash: ${artifact.artifactHash}   (a seal — tamper-evidence, not a reproducibility proof)`);
   console.log(`  self-verifies: ${verifyStampedHash(artifact)}`);
   console.log(`  written     : ${outPath}`);
   console.log(`\nNOTICE: ${artifact.notice}\n`);

--- a/test/bench/longmemeval/run.ts
+++ b/test/bench/longmemeval/run.ts
@@ -12,8 +12,18 @@
  *       Pins the dataset (sha256), the reader + judge (digest), num_ctx, and all
  *       configs. Produces a number; NEVER publishes one (artifact.ts NOTICE).
  *
- * Reproducibility: `ollama pull` the pinned digests + fetch the pinned dataset
- * (see README) and anyone re-runs the exact number locally — no OpenAI key.
+ * What a re-runner can verify: `ollama pull` the pinned digests + fetch the
+ * pinned dataset (see README) and anyone re-derives the `configHash` exactly —
+ * that is the anchor, and it is what "did they run what they said they ran"
+ * rests on, together with the exact prompts, the dataset selection and the judge
+ * rubric. No OpenAI key, no spend.
+ *
+ * The NUMBERS are a different claim. `runHash` re-derives only where the reader
+ * is bitwise-stable (expected under `local`, not under `cloud`), and
+ * `artifactHash` is a SEAL — tamper-evidence for a signed-off artifact — not a
+ * reproducibility proof. Under `cloud`, accuracy is a statistical result: re-run
+ * and compare within variance, using the reader-determinism probe this command
+ * records in the artifact's provenance as the variance to compare against.
  */
 import { existsSync } from "node:fs";
 import { fileURLToPath } from "node:url";
@@ -30,6 +40,9 @@ import { runOnce, SELECTED_ARMS, writeProgress, setJournalContext } from "./eval
 import { aggregateArmAcrossRuns, type ArmRunMetrics } from "./metrics";
 import { buildArtifact, writeArtifact, verifyArtifactHash } from "./artifact";
 import { formatReport } from "./report";
+import {
+  probeReaderDeterminism, failedProbe, printReaderDeterminism, type ReaderDeterminism,
+} from "./determinism";
 import { ALL_ARMS, type Arm } from "./arms";
 
 const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../../..");
@@ -165,6 +178,27 @@ async function runSlice(): Promise<void> {
   }
   console.log(`configHash: ${configHash}\n`);
 
+  // ── Reader-determinism probe (flair#1368) ──────────────────────────────────
+  // Runs BEFORE the measurement runs, on a FIXED question sample independent of
+  // the slice, so its numbers are comparable across every run this harness ever
+  // publishes. Its result lands in the artifact's UNHASHED provenance partition:
+  // determinism legitimately differs run to run, and hashing it would make every
+  // honest re-run look like tampering.
+  //
+  // A probe failure does NOT abort the run — the probe characterises the reader,
+  // it does not gate the measurement, and killing a multi-hour run over it would
+  // be the wrong trade. It is recorded as an error in the artifact instead, so
+  // "we did not probe" can never be mistaken for "we probed and found nothing".
+  let readerDeterminism: ReaderDeterminism;
+  try {
+    readerDeterminism = await probeReaderDeterminism(host, entries, { log: (s) => console.log(s) });
+  } catch (err) {
+    readerDeterminism = failedProbe(host, err);
+    console.error(`\n!! reader-determinism probe FAILED: ${readerDeterminism.error}`);
+    console.error(`   Recorded as an error in the artifact provenance; the run continues.\n`);
+  }
+  printReaderDeterminism(readerDeterminism);
+
   const perArmRuns = new Map<Arm, ArmRunMetrics[]>(SELECTED_ARMS.map((a) => [a, []]));
   const runHashes: string[] = [];
   for (let i = 1; i <= runs; i++) {
@@ -177,6 +211,7 @@ async function runSlice(): Promise<void> {
   const artifact = buildArtifact({
     configHash, config: manifest, runHashes, aggregate,
     gitCommit: gitCommit(), ollamaHost: host, benchHost: process.env.LME_BENCH_HOST ?? "rockit", validationSlice,
+    readerDeterminism,
   });
   const artifactPath = writeArtifact(artifact, outDir);
 
@@ -185,8 +220,9 @@ async function runSlice(): Promise<void> {
     console.log(line);
   }
   writeProgress({ done: true, artifactPath });
-  console.log(`\nartifactHash: ${artifact.artifactHash}`);
-  console.log(`artifact self-verifies: ${verifyArtifactHash(artifact)}`);
+  console.log(`\nconfigHash (THE ANCHOR — re-derivable by anyone with the repo): ${configHash}`);
+  console.log(`artifactHash (A SEAL — tamper-evidence, not a reproducibility proof): ${artifact.artifactHash}`);
+  console.log(`artifact self-verifies (unmodified since it was written): ${verifyArtifactHash(artifact)}`);
   console.log(`written: ${artifactPath}`);
   console.log(`\nNOTICE: ${artifact.notice}\n`);
 }

--- a/test/unit/longmemeval-artifact.test.ts
+++ b/test/unit/longmemeval-artifact.test.ts
@@ -2,13 +2,22 @@ import { describe, test, expect } from "bun:test";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
-import { buildArtifact, verifyArtifactHash, writeArtifact, hashRunResults } from "../bench/longmemeval/artifact";
+import {
+  buildArtifact, verifyArtifactHash, writeArtifact, hashRunResults, hashedContent, PROVENANCE_KEYS,
+} from "../bench/longmemeval/artifact";
 import { configManifest, hashConfig, canonicalJson } from "../bench/longmemeval/config";
 import { aggregateArmRun, aggregateArmAcrossRuns } from "../bench/longmemeval/metrics";
+import type { ReaderDeterminism } from "../bench/longmemeval/determinism";
 
 // The publish gate is STRUCTURAL (Sherlock #4): the run emits a content-
 // addressed artifact, and a human signs off on a specific artifactHash. These
 // tests pin that the hash actually addresses the content and self-verifies.
+//
+// What that buys, precisely: `artifactHash` is a SEAL, not a proof. It binds a
+// sign-off to one exact set of numbers so a later edit is detectable. It is not
+// evidence the numbers reproduce — `configHash` is the re-derivable anchor for
+// that. The tests below are about tamper-evidence and about the hashed /
+// provenance partition, never about reproducing a result.
 
 const baseInput = () => ({
   configHash: "deadbeef",
@@ -28,12 +37,13 @@ describe("artifact — content addressing", () => {
     expect(verifyArtifactHash(art)).toBe(true);
   });
 
-  test("identical inputs at different wall-times → identical artifactHash (reproducibility)", async () => {
+  test("identical inputs at different wall-times → identical artifactHash (the seal ignores provenance)", async () => {
     const a = buildArtifact(baseInput());
     await new Promise((r) => setTimeout(r, 5)); // force a different wall-clock ms
     const b = buildArtifact(baseInput());
     // The wall clock DID differ — but it is provenance, not content, so the
-    // hash must be identical. This is the whole reproducibility claim.
+    // hash must be identical. This says the seal does not fire on WHEN or WHERE
+    // an artifact was written; it does not say the numbers inside it reproduce.
     expect(a.generatedAt).not.toBe(b.generatedAt);
     expect(a.artifactHash).toBe(b.artifactHash);
   });
@@ -94,6 +104,127 @@ describe("artifact — content addressing", () => {
     const mod = await import("../bench/longmemeval/artifact");
     expect((mod as any).publish).toBeUndefined();
     expect((mod as any).publishArtifact).toBeUndefined();
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// The reader-determinism probe is UNHASHED PROVENANCE (flair#1368).
+//
+// The property: a determinism measurement legitimately differs between two
+// honest runs of the same config. If it fed `artifactHash`, every faithful
+// re-run would look like tampering — the seal would fire on exactly the thing
+// it is not meant to detect.
+//
+// PROVEN ABLE TO FAIL, not assumed: removing "readerDeterminism" from
+// PROVENANCE_KEYS turns "leaves artifactHash unchanged" and "two runs differing
+// only in measured determinism hash identically" RED. A green-from-the-start
+// test proves nothing about a partition it never saw violated.
+// ═══════════════════════════════════════════════════════════════════════════
+
+const probeFixture = (overrides: Partial<ReaderDeterminism> = {}): ReaderDeterminism => ({
+  schema: "longmemeval-s.reader-determinism/1",
+  measuredAt: "2026-08-24T00:00:00.000Z",
+  ollamaHost: "https://ollama.com",
+  reader: {
+    model: "qwen3.5:397b", manifestDigest: "sha256:b909ca2f1b7f", family: "qwen3_5",
+    temperature: 0, seed: 0, numCtx: 16384, numPredict: 256,
+  },
+  promptConstruction: {
+    arm: "flair", numCtx: 16384, readerPromptVersion: "1.0.0",
+    readerPayloadFormat: "v2-dated", readerTopK: 20, contextSource: "deterministic",
+  },
+  samples: 10,
+  questionIds: ["001be529", "00ca467f"],
+  perQuestion: [{
+    questionId: "001be529", ability: "information-extraction", promptChars: 4200,
+    promptTokens: [1400], samples: 10, distinctCompletions: 3, commonPrefixLength: 68,
+    verdictAgreementRate: 1, verdictCounts: { CORRECT: 10 }, judgeErrors: 0,
+    completionChars: [120, 131, 118],
+  }],
+  summary: { maxDistinctCompletions: 3, minCommonPrefixLength: 68, minVerdictAgreementRate: 1 },
+  error: null,
+  ...overrides,
+});
+
+describe("reader-determinism probe — unhashed provenance (#1368)", () => {
+  test("PROVENANCE_KEYS names it, so buildArtifact and verify can never drift", () => {
+    expect([...PROVENANCE_KEYS]).toContain("readerDeterminism");
+  });
+
+  test("adding the probe leaves artifactHash unchanged for otherwise-identical input", () => {
+    const without = buildArtifact(baseInput());
+    const withProbe = buildArtifact({ ...baseInput(), readerDeterminism: probeFixture() });
+
+    // Positive control on the FIXTURE FIRST. Without it, "the hashes are equal"
+    // would also pass if buildArtifact silently dropped the field — i.e. the
+    // assertion would hold for the wrong reason and the partition would be
+    // untested. Assert the probe actually landed, with its content intact.
+    expect(withProbe.readerDeterminism).toBeDefined();
+    expect(withProbe.readerDeterminism!.summary!.maxDistinctCompletions).toBe(3);
+    expect(withProbe.readerDeterminism!.questionIds).toEqual(["001be529", "00ca467f"]);
+    // And that it is genuinely OUTSIDE the hashed partition, not merely equal
+    // by luck of canonicalisation.
+    expect(Object.keys(hashedContent(withProbe))).not.toContain("readerDeterminism");
+
+    expect(withProbe.artifactHash).toBe(without.artifactHash);
+  });
+
+  test("two runs differing ONLY in measured determinism hash identically", () => {
+    // This is the property that matters operationally: an honest re-run whose
+    // reader diverged more (or less) than ours must not look like tampering.
+    const a = buildArtifact({ ...baseInput(), readerDeterminism: probeFixture() });
+    const b = buildArtifact({
+      ...baseInput(),
+      readerDeterminism: probeFixture({
+        measuredAt: "2027-01-01T00:00:00.000Z",
+        summary: { maxDistinctCompletions: 9, minCommonPrefixLength: 3, minVerdictAgreementRate: 0.6 },
+        perQuestion: [],
+      }),
+    });
+    expect(a.readerDeterminism!.summary).not.toEqual(b.readerDeterminism!.summary);
+    expect(a.artifactHash).toBe(b.artifactHash);
+  });
+
+  test("an artifact carrying the probe still self-verifies", () => {
+    const art = buildArtifact({ ...baseInput(), readerDeterminism: probeFixture() });
+    expect(verifyArtifactHash(art)).toBe(true);
+  });
+
+  test("a FAILED probe is recorded, not omitted — the two must be distinguishable", () => {
+    // "we did not probe" and "we probed and it broke" are different facts. A
+    // consumer must be able to tell them apart, so the failure path carries the
+    // same shape with `error` set rather than dropping the key.
+    const failed = buildArtifact({
+      ...baseInput(),
+      readerDeterminism: probeFixture({ error: "connect ECONNREFUSED", perQuestion: [], summary: null }),
+    });
+    const absent = buildArtifact(baseInput());
+    expect(failed.readerDeterminism!.error).toBe("connect ECONNREFUSED");
+    expect(absent.readerDeterminism).toBeUndefined();
+    // Still provenance in both cases: neither moves the seal.
+    expect(failed.artifactHash).toBe(absent.artifactHash);
+  });
+
+  test("a written artifact carrying the probe still verifies after a JSON round trip", () => {
+    // The artifact is consumed as a FILE. An in-memory-only assertion would miss
+    // a field that does not survive serialisation, and the probe record is the
+    // newest thing in the file.
+    const art = buildArtifact({ ...baseInput(), readerDeterminism: probeFixture() });
+    const path = writeArtifact(art, join(tmpdir(), "lme-artifact-test-1368"));
+    const written = JSON.parse(readFileSync(path, "utf8"));
+    expect(written.readerDeterminism.questionIds).toEqual(["001be529", "00ca467f"]);
+    expect(written.readerDeterminism.perQuestion[0].distinctCompletions).toBe(3);
+    expect(verifyArtifactHash(written)).toBe(true);
+  });
+
+  test("a CONTENT change still moves the hash — the seal has not been blunted", () => {
+    // Negative control for the whole block above: if adding provenance keys had
+    // accidentally disabled hashing, every test here would pass vacuously.
+    const a = buildArtifact({ ...baseInput(), readerDeterminism: probeFixture() });
+    const b = buildArtifact({
+      ...baseInput(), readerDeterminism: probeFixture(), configHash: "cafebabe",
+    });
+    expect(b.artifactHash).not.toBe(a.artifactHash);
   });
 });
 

--- a/test/unit/longmemeval-determinism.test.ts
+++ b/test/unit/longmemeval-determinism.test.ts
@@ -1,0 +1,336 @@
+import { describe, test, expect, mock, beforeEach } from "bun:test";
+import { READER, JUDGE, RETRIEVAL } from "../bench/longmemeval/config";
+import type { LmeEntry } from "../bench/longmemeval/dataset";
+
+/**
+ * Tests for the reader-determinism probe (flair#1368).
+ *
+ * THE FAILURE SHAPE THIS FILE DEFENDS AGAINST. A probe that reports "fully
+ * deterministic" for everything is indistinguishable from a probe that is not
+ * running at all — and a happy-path test cannot see the difference, because
+ * "1 distinct completion" is exactly what a working probe reports on a
+ * deterministic reader. So every behavioural test here runs the probe against
+ * BOTH a known-deterministic and a known-nondeterministic reader and asserts the
+ * outputs DIFFER in the expected direction. A probe stuck on either answer fails
+ * one of the two.
+ *
+ * HOW THE READER IS FAKED. `mock.module` replaces the ollama transport for every
+ * importer in this file — the probe AND the main run's `readerAnswer` go through
+ * the same fake. That is deliberate: it lets the config-drift assertion compare
+ * two ACTUAL wire requests rather than two computations of the same helper, and
+ * it means the production code carries no test seam that could itself drift.
+ *
+ * NO PAID CALLS. Nothing here touches a network. The reader is scripted.
+ */
+
+// ── The fake transport ──────────────────────────────────────────────────────
+interface WireCall { host: string; spec: any; prompt: string; opts: any }
+const wire: { reader: WireCall[]; judge: WireCall[] } = { reader: [], judge: [] };
+
+/** What the scripted reader returns on its i-th call (per question). */
+let readerScript: (callIndex: number, prompt: string) => string = () => "constant answer";
+/** What the scripted judge returns for a given reader completion. */
+let judgeScript: (completion: string) => string = () => "A";
+
+mock.module("../bench/longmemeval/ollama", () => ({
+  OllamaError: class OllamaError extends Error {},
+  assertModelPinned: async () => ({ actualDigest: "sha256:fake" }),
+  pingOllama: async () => [] as string[],
+  generate: async (host: string, spec: any, prompt: string, opts: any = {}) => {
+    const isJudge = spec.model === JUDGE.model;
+    const bucket = isJudge ? wire.judge : wire.reader;
+    bucket.push({ host, spec, prompt, opts });
+    const response = isJudge
+      ? judgeScript(lastCompletion)
+      : (lastCompletion = readerScript(bucket.length - 1, prompt));
+    return { response, promptTokens: Math.ceil(prompt.length / 4), evalTokens: 8, latencyMs: 1, doneReason: "stop" };
+  },
+}));
+let lastCompletion = "";
+
+const determinism = await import("../bench/longmemeval/determinism");
+const { buildReaderRequest, readerAnswer } = await import("../bench/longmemeval/eval");
+const {
+  probeReaderDeterminism, probeContext, commonPrefixLength, summariseSamples,
+  PROBE_QUESTION_IDS, PROBE_ARM, PROBE_SAMPLES, failedProbe,
+} = determinism;
+
+// ── Fixtures ────────────────────────────────────────────────────────────────
+function entry(id: string, over: Partial<LmeEntry> = {}): LmeEntry {
+  return {
+    question_id: id,
+    question_type: "single-session-user",
+    question: `What degree did I graduate with? (${id})`,
+    answer: "Business Administration",
+    question_date: "2023/06/01 (Thu) 09:00",
+    haystack_dates: ["2023/05/20 (Sat) 02:16", "2023/05/21 (Sun) 10:00"],
+    haystack_session_ids: [`${id}-a`, `${id}-b`],
+    haystack_sessions: [
+      Array.from({ length: 14 }, (_, i) => ({ role: i % 2 ? "assistant" : "user", content: `session A turn ${i}` })),
+      Array.from({ length: 14 }, (_, i) => ({ role: i % 2 ? "assistant" : "user", content: `session B turn ${i}` })),
+    ],
+    answer_session_ids: [`${id}-a`],
+    ...over,
+  };
+}
+/** The dataset the probe is handed: the fixed probe questions plus decoys, so a
+ *  probe that took "whatever it was given" would visibly pick up the decoys. */
+const dataset = (): LmeEntry[] => [
+  entry("decoy-before"),
+  ...PROBE_QUESTION_IDS.map((id) => entry(id)),
+  entry("decoy-after"),
+];
+
+const DETERMINISTIC = "The answer is Business Administration.";
+const NONDET = [
+  "Two is unusual because it is the only even prime number.",
+  "Two is unusual since it is the sole even prime.",
+  "Two is unusual — it is the only even prime there is.",
+];
+// Shared by all three (trailing space included), then they diverge — mirroring
+// the real measured shape: a common prefix followed by divergent continuations.
+const NONDET_PREFIX = "Two is unusual ";
+
+function scriptDeterministicReader(): void {
+  readerScript = () => DETERMINISTIC;
+  judgeScript = () => "A";
+}
+function scriptNondeterministicReader(): void {
+  // Cycles through three completions; the judge disagrees on one of them, so
+  // verdictAgreementRate is strictly between 0 and 1 rather than pinned at 1.
+  readerScript = (i) => NONDET[i % NONDET.length]!;
+  judgeScript = (c) => (c === NONDET[2] ? "B" : "A");
+}
+
+beforeEach(() => {
+  wire.reader = [];
+  wire.judge = [];
+  lastCompletion = "";
+  scriptDeterministicReader();
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// GATE: the probe must distinguish a deterministic reader from a
+// nondeterministic one. Both directions, or the probe is unfalsifiable.
+// ═══════════════════════════════════════════════════════════════════════════
+describe("probe — known-deterministic vs known-nondeterministic reader", () => {
+  test("a known-DETERMINISTIC reader reports M=1 and full agreement", async () => {
+    scriptDeterministicReader();
+    const d = await probeReaderDeterminism("http://fake", dataset());
+    expect(d.error).toBeNull();
+    expect(d.perQuestion).toHaveLength(PROBE_QUESTION_IDS.length);
+    for (const q of d.perQuestion) {
+      expect(q.samples).toBe(PROBE_SAMPLES);
+      expect(q.distinctCompletions).toBe(1);
+      // M===1 ⇒ the common prefix is the whole completion, not 0.
+      expect(q.commonPrefixLength).toBe(DETERMINISTIC.length);
+      expect(q.verdictAgreementRate).toBe(1);
+      expect(q.verdictCounts).toEqual({ CORRECT: PROBE_SAMPLES });
+      expect(q.judgeErrors).toBe(0);
+    }
+    expect(d.summary).toEqual({
+      maxDistinctCompletions: 1,
+      minCommonPrefixLength: DETERMINISTIC.length,
+      minVerdictAgreementRate: 1,
+    });
+  });
+
+  test("a known-NONDETERMINISTIC reader reports M>1, a short prefix and <100% agreement", async () => {
+    scriptNondeterministicReader();
+    const d = await probeReaderDeterminism("http://fake", dataset());
+    expect(d.error).toBeNull();
+    for (const q of d.perQuestion) {
+      expect(q.distinctCompletions).toBe(3);
+      expect(q.commonPrefixLength).toBe(NONDET_PREFIX.length);
+      // 10 samples cycling 3 completions ⇒ NONDET[2] appears 3×, judged B.
+      expect(q.verdictAgreementRate).toBeCloseTo(0.7, 10);
+      expect(q.verdictCounts).toEqual({ CORRECT: 7, INCORRECT: 3 });
+    }
+    expect(d.summary).toEqual({
+      maxDistinctCompletions: 3,
+      minCommonPrefixLength: NONDET_PREFIX.length,
+      minVerdictAgreementRate: 0.7,
+    });
+  });
+
+  test("the SAME probe code produces different readings for the two readers", async () => {
+    // The decisive assertion. A probe hard-wired to "deterministic" passes the
+    // first test above; a probe hard-wired to "nondeterministic" passes the
+    // second; neither passes this one.
+    scriptDeterministicReader();
+    const det = await probeReaderDeterminism("http://fake", dataset());
+    wire.reader = []; wire.judge = [];
+    scriptNondeterministicReader();
+    const nondet = await probeReaderDeterminism("http://fake", dataset());
+    expect(det.summary!.maxDistinctCompletions).toBeLessThan(nondet.summary!.maxDistinctCompletions);
+    expect(det.summary!.minVerdictAgreementRate).toBeGreaterThan(nondet.summary!.minVerdictAgreementRate);
+  });
+
+  test("the probe really issues N reader calls per question and judges every one", async () => {
+    // Catches the specific cheat a summary-only test cannot see: a call loop
+    // that generates ONCE and copies the result N times would report perfect
+    // determinism for any reader at all.
+    scriptNondeterministicReader();
+    await probeReaderDeterminism("http://fake", dataset());
+    const expected = PROBE_SAMPLES * PROBE_QUESTION_IDS.length;
+    expect(wire.reader).toHaveLength(expected);
+    expect(wire.judge).toHaveLength(expected); // the judge is never sampled
+    // Every judge prompt must carry the completion of the reader call before it,
+    // so the N verdicts describe the N completions rather than one of them.
+    // (`readerScript` is indexed by the GLOBAL reader-call counter, so call i
+    // returns NONDET[i % 3] regardless of which question it belongs to.)
+    for (let i = 0; i < expected; i++) {
+      expect(wire.judge[i]!.prompt).toContain(NONDET[i % NONDET.length]!);
+    }
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// GATE: config drift. The probe's resolved reader config must equal the main
+// run's — asserted on the ACTUAL wire requests, not on two calls to one helper.
+// ═══════════════════════════════════════════════════════════════════════════
+describe("probe — config-drift guard", () => {
+  test("the probe's wire request is byte-identical to the main run's for the same inputs", async () => {
+    const e = entry(PROBE_QUESTION_IDS[0]!);
+    const context = probeContext(e);
+
+    await probeReaderDeterminism("http://fake", dataset());
+    const fromProbe = wire.reader[0]!;
+
+    wire.reader = [];
+    // readerAnswer() is the function evalOne() calls for every (question, arm)
+    // in the real run. If a future edit adds an override at THAT call site and
+    // not to the shared builder, this comparison is what fires.
+    await readerAnswer("http://fake", e.question, e.question_date, context, PROBE_ARM);
+    const fromRun = wire.reader[0]!;
+
+    expect(fromProbe.spec).toBe(fromRun.spec);       // the same pinned object
+    expect(fromProbe.prompt).toBe(fromRun.prompt);   // the same assembled prompt
+    expect(fromProbe.opts).toEqual(fromRun.opts);    // the same num_ctx handling
+  });
+
+  test("both paths issue exactly what buildReaderRequest resolves — one builder, no second assembly", async () => {
+    const e = entry(PROBE_QUESTION_IDS[0]!);
+    const context = probeContext(e);
+    const expected = buildReaderRequest(e.question, e.question_date, context, PROBE_ARM);
+
+    await probeReaderDeterminism("http://fake", dataset());
+    expect(wire.reader[0]!.prompt).toBe(expected.prompt);
+    expect(wire.reader[0]!.spec).toBe(expected.spec);
+    expect(wire.reader[0]!.opts).toEqual(expected.opts);
+  });
+
+  test("the pinned sampling parameters actually reach the wire", async () => {
+    // Named individually because these are the parameters whose silent drift
+    // would make the probe measure a different system while still looking
+    // authoritative: model pin, temperature, seed, num_ctx.
+    await probeReaderDeterminism("http://fake", dataset());
+    for (const call of wire.reader) {
+      expect(call.spec.model).toBe(READER.model);
+      expect(call.spec.manifestDigest).toBe(READER.manifestDigest);
+      expect(call.spec.temperature).toBe(READER.temperature);
+      expect(call.spec.seed).toBe(READER.seed);
+      expect(call.spec.numPredict).toBe(READER.numPredict);
+      // `flair` does not override num_ctx, so the pinned reader window is used.
+      expect(call.opts.numCtxOverride).toBeUndefined();
+    }
+  });
+
+  test("the config RECORDED in the artifact is the config that was sent", async () => {
+    // Guards the other half: a hand-written literal in the record would look
+    // right and describe a run that did not happen.
+    const d = await probeReaderDeterminism("http://fake", dataset());
+    const sent = wire.reader[0]!;
+    expect(d.reader).toEqual({ ...(sent.spec as Record<string, unknown>) });
+    expect(d.promptConstruction.numCtx).toBe(sent.opts.numCtxOverride ?? sent.spec.numCtx);
+    expect(d.promptConstruction.numCtx).toBe(READER.numCtx);
+    expect(d.promptConstruction.arm).toBe(PROBE_ARM);
+    expect(d.promptConstruction.readerTopK).toBe(RETRIEVAL.readerTopK);
+    expect(d.samples).toBe(PROBE_SAMPLES);
+    // Each per-question record carries its own denominator.
+    for (const q of d.perQuestion) expect(q.samples).toBe(d.samples);
+  });
+
+  test("the failure record reports the same reader config as a successful one", async () => {
+    // A failed probe must not become a place where an unchecked config appears.
+    const ok = await probeReaderDeterminism("http://fake", dataset());
+    const bad = failedProbe("http://fake", new Error("connect ECONNREFUSED"));
+    expect(bad.reader).toEqual(ok.reader);
+    expect(bad.promptConstruction).toEqual(ok.promptConstruction);
+    expect(bad.error).toBe("connect ECONNREFUSED");
+    expect(bad.summary).toBeNull();
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// GATE: the question sample is FIXED and recorded — never sampled per run.
+// ═══════════════════════════════════════════════════════════════════════════
+describe("probe — fixed, recorded question sample", () => {
+  test("the probed ids are the pinned constant and are recorded in the result", async () => {
+    const d = await probeReaderDeterminism("http://fake", dataset());
+    expect(d.questionIds).toEqual([...PROBE_QUESTION_IDS]);
+    expect(d.perQuestion.map((q) => q.questionId)).toEqual([...PROBE_QUESTION_IDS]);
+    expect(PROBE_QUESTION_IDS.length).toBeGreaterThanOrEqual(2);
+  });
+
+  test("the sample does not follow the dataset it is handed", async () => {
+    // Decoys are present in `dataset()` and must never be probed; reordering the
+    // dataset must not change which questions are probed, or two runs' probes
+    // would not be comparable.
+    const forward = await probeReaderDeterminism("http://fake", dataset());
+    wire.reader = []; wire.judge = [];
+    const reversed = await probeReaderDeterminism("http://fake", [...dataset()].reverse());
+    expect(reversed.questionIds).toEqual(forward.questionIds);
+    expect(reversed.perQuestion.map((q) => q.questionId)).toEqual(forward.perQuestion.map((q) => q.questionId));
+    for (const call of wire.reader) expect(call.prompt).not.toContain("decoy");
+  });
+
+  test("the probe prompt is a pure function of the entry — a re-runner rebuilds it exactly", () => {
+    const e = entry(PROBE_QUESTION_IDS[0]!);
+    expect(probeContext(e)).toBe(probeContext(entry(PROBE_QUESTION_IDS[0]!)));
+    // ...and it is capped at the harness's own readerTopK, so the prompt is the
+    // shape and size a retrieval payload has.
+    expect(probeContext(e).split("\n")).toHaveLength(RETRIEVAL.readerTopK);
+  });
+
+  test("a probe id missing from the dataset is FATAL, not a silent skip", async () => {
+    // A silently-skipped question leaves a probe that looks complete but
+    // measured less than it claims.
+    await expect(
+      probeReaderDeterminism("http://fake", [entry("something-else")]),
+    ).rejects.toThrow(/not in the loaded dataset/);
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// The pure summarisers, asserted directly. These are necessary but NOT
+// sufficient — see the call-loop test above for why.
+// ═══════════════════════════════════════════════════════════════════════════
+describe("summarisers", () => {
+  test("commonPrefixLength", () => {
+    expect(commonPrefixLength([])).toBe(0);
+    expect(commonPrefixLength(["abc"])).toBe(3);            // one string ⇒ its own length
+    expect(commonPrefixLength(["abcdef", "abcxyz"])).toBe(3);
+    expect(commonPrefixLength(["abc", "abcdef"])).toBe(3);  // one is a prefix of the other
+    expect(commonPrefixLength(["xyz", "abc"])).toBe(0);
+    expect(commonPrefixLength(["", "abc"])).toBe(0);
+  });
+
+  test("summariseSamples counts distinct completions and modal verdict agreement", () => {
+    const s = summariseSamples(
+      ["aa", "aa", "ab", "ac"],
+      ["CORRECT", "CORRECT", "CORRECT", "INCORRECT"],
+    );
+    expect(s.distinctCompletions).toBe(3);
+    expect(s.commonPrefixLength).toBe(1);
+    expect(s.verdictAgreementRate).toBe(0.75);
+    expect(s.verdictCounts).toEqual({ CORRECT: 3, INCORRECT: 1 });
+  });
+
+  test("an unparseable verdict is its own bucket, never folded into a real one", () => {
+    const s = summariseSamples(["a", "a"], [null, "CORRECT"]);
+    expect(s.judgeErrors).toBe(1);
+    expect(s.verdictCounts).toEqual({ JUDGE_ERROR: 1, CORRECT: 1 });
+    expect(s.verdictAgreementRate).toBe(0.5); // not 1.0 — the error is a disagreement
+  });
+});


### PR DESCRIPTION
Implements the spec on #1368 (Sherlock's ruling recorded there). Two deliverables, both of which gate publishing any benchmark number.

Refs #1368, #1365.

## A — reader-determinism probe

*"Re-run and compare within variance"* was an **empty instruction**: we published no variance to compare against, so a re-runner whose completion text diverged from ours had no way to tell normal from broken.

`test/bench/longmemeval/determinism.ts` now measures it on every run and records, per probed question, `samples` (N), `distinctCompletions` (M), `commonPrefixLength`, `verdictAgreementRate` and `verdictCounts`, plus a `summary` whose field names state their own aggregation (`maxDistinctCompletions`, `minCommonPrefixLength`, `minVerdictAgreementRate`). It lands in the artifact's **unhashed provenance** partition.

The four easy-to-get-wrong properties are enforced by **shape**, not by comment:

- **Identical reader configuration.** `eval.ts` gains `buildReaderRequest()` — one definition of what a reader call is. `readerAnswer()` issues it, and the probe calls `readerAnswer()` / `judgeOne()` themselves. The probe takes **no reader parameters of its own**, so there is nothing to set on one path and forget on the other.
- **Fixed question sample.** `PROBE_QUESTION_IDS` is a hardcoded constant recorded in the artifact — never a draw from the run's slice. A probe id missing from the dataset is **fatal**, not a silent skip.
- **Unhashed provenance.** Determinism legitimately differs run to run; if it fed `artifactHash`, every honest re-run would look like tampering.
- **The judge is never sampled.** All N completions are scored.

**Stated limitation.** The probe does not retrieve from a live Flair. It builds a retrieval-*shaped* context deterministically from the question's own haystack through the pinned payload formatter, so the probe prompt is a pure function of (dataset, question id, pinned prompts, pinned payload format, `readerTopK`) and a re-runner rebuilds it **byte-identically** without our store or index state. That reproducibility is the point — a probe whose own input could not be reproduced would not support the comparison it exists for. The trade: same *shape* and comparable size as a real retrieval payload, not the same *content*. Documented in the README and in the module header.

A failed probe is recorded **as an error in the artifact**, not omitted, and does not abort the measurement run — "we did not probe" and "we probed and it broke" are different facts.

`LME_DETERMINISM_SAMPLES` (default 10) is recorded next to every number it produced. Below 2 is **fatal rather than clamped**: one call cannot measure agreement between calls, and "1 distinct completion" from a single sample would be a fabricated determinism claim.

## B — claim restatement, three tiers

| tier | identity | claim |
|---|---|---|
| 1 | **`configHash`** | **The anchor.** Pure function of pinned config, re-derivable by anyone with the repo. Leads everywhere. |
| 2 | `runHash` | The decision set. Re-derivable under `local` (expected, **unmeasured**, so not claimed); statistical under `cloud`. |
| 3 | `artifactHash` | **A seal, not a proof.** Tamper-evidence for a signed-off artifact. Never reproducibility evidence, even locally. |

The correcting sentence — ***"verify it yourself" rests on `configHash` plus the exact prompts, dataset selection and judge rubric, not on `artifactHash`*** — now appears in the README lede, the README's "What 'reproducible' does and does not mean here" section, and the `artifact.ts` header.

## Gates — each proven able to fail

A test never seen failing is not evidence, so each gate was mutated and observed red, then reverted and observed green.

| gate | mutation | result |
|---|---|---|
| **1. artifactHash unchanged** | remove `readerDeterminism` from `PROVENANCE_KEYS` (probe enters the hashed partition) | **13 pass / 4 fail** → reverted **17 pass / 0 fail** |
| **2. deterministic vs nondeterministic** | probe calls the reader **once and copies the result N times** | **13 pass / 3 fail** → reverted **16 pass / 0 fail** |
| **3. config drift** | add `numPredictOverride` at the **main-run call site only** | **15 pass / 1 fail** → reverted green |
| **4. fixed sample** | sample the first N entries of the dataset handed in | **11 pass / 5 fail** → reverted green |

Gate 2 is the important one: under that mutation **the known-deterministic test stayed GREEN** and only the nondeterministic and call-count tests fired. That is precisely why a happy-path test cannot see this failure shape — "1 distinct completion" is also what a *working* probe reports on a deterministic reader.

## Verification

- Unit lane `bun test test/unit/ test/*.test.ts` — baseline on unmodified `origin/main` (a77c08a6): **5121 pass / 0 fail, 263 files**. After: **5144 pass / 0 fail, 264 files** (+23 = 16 new in `longmemeval-determinism.test.ts`, 7 added to `longmemeval-artifact.test.ts`). No regressions.
- `test/unit-isolated/`, one file per process: **178 pass / 0 fail** across 6 files.
- `npx tsc --noEmit -p tsconfig.test.check.json` — exit 0. Confirmed the new files are in that program (`--listFiles`) and that the check fires on them (an injected type error produced `determinism.ts(384,7): error TS2322`).
- `node scripts/changelog-fragments.mjs check` — 17 fragments, 17 entries, clean.
- **No paid API calls.** The probe is exercised entirely against a scripted reader via `mock.module` on the ollama transport, so the production code carries no test seam.

## Deliberately not done

- **Run count untouched.** That is a cost decision and out of scope per the spec.
- `metrics.ts` not touched; nothing named `std` / `MeanStd` appears in any added line, and the single-run results formatter in `run.ts` is untouched — that belongs to #1376.
- `CHANGELOG.md:646` ("LongMemEval `artifactHash` is now reproducible") is a **released historical entry** and was left as-is; rewriting shipped changelog history would be worse than the stale claim. The correction lands in the new fragment and in every live doc.
- The `payload-ab` artifact inherits the provenance partition (its stale restatement of the key list is now a reference to `PROVENANCE_KEYS`) but does **not** run a determinism probe of its own. The spec scoped the probe to the main bench artifact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
