### PR TITLE
fix(ci): exact-literal allowlist for English ops-* compounds in impl-term-leak gate

### DIFF
--- a/.changelog/unreleased/fixed-1381-impl-term-leak-compounds.md
+++ b/.changelog/unreleased/fixed-1381-impl-term-leak-compounds.md
@@ -1,0 +1,5 @@
+- **The impl-term-leak gate no longer treats English `ops-*` compounds as bead IDs**
+  (flair#1381). `ops-port`, `ops-api`, `ops-target`, and `ops-server` are an
+  exact-literal allowlist — not a heuristic. A real bead ID (`ops-xllz`) still
+  fails. Each finding now names the matched token and the rule that tripped,
+  e.g. `docs/integrations.md:41: matched bead-ID pattern on token "ops-xllz"`.

--- a/scripts/check-impl-term-leaks.sh
+++ b/scripts/check-impl-term-leaks.sh
@@ -16,6 +16,8 @@ PATTERNS="$BEAD_PATTERN|$LABEL_PATTERN"
 # Exact-literal allowlist of English ops-* compounds that are not bead IDs (flair#1381).
 # Not a regex. Not a heuristic. A real bead ID can only get onto this list by being
 # added here, in a diff, visibly. Membership is string equality against one line.
+# ops-api is three letters and the bead pattern requires four — listed anyway so
+# the exemption stays explicit if the pattern ever widens.
 ALLOWLIST_EXACT='
 ops-port
 ops-api
@@ -82,8 +84,12 @@ while IFS= read -r line; do
   [[ -n "$line" ]] && FILES+=("$line")
 done < "$TMPFILE"
 
+# -H (--with-filename) is required: grep omits the path when the corpus is a
+# single file, and the finding formatter below splits on file:line:content.
+# Without -H a one-file scan (the exact shape of the unit fixtures) would
+# print the raw line and never name the token or the rule (flair#1381).
 set +e
-OUTPUT=$(grep -n -E "$PATTERNS" "${FILES[@]}" 2>"$ERRFILE")
+OUTPUT=$(grep -n -H -E "$PATTERNS" "${FILES[@]}" 2>"$ERRFILE")
 GREP_RC=$?
 set -e
 
@@ -127,11 +133,13 @@ if [[ -n "$OUTPUT" ]]; then
     lineno="${rest%%:*}"
     content="${rest#*:}"
 
-    if [[ -z "$lineno" || "$file" == "$match" || "$lineno" == "$rest" ]]; then
-      FINDINGS="${FINDINGS}${match}"$'\n'
-      FINDING_COUNT=$((FINDING_COUNT + 1))
-      continue
-    fi
+    case "$lineno" in
+      ''|*[!0-9]*)
+        FINDINGS="${FINDINGS}${match}"$'\n'
+        FINDING_COUNT=$((FINDING_COUNT + 1))
+        continue
+        ;;
+    esac
 
     line_hits=0
 

--- a/scripts/check-impl-term-leaks.sh
+++ b/scripts/check-impl-term-leaks.sh
@@ -9,7 +9,19 @@ set -euo pipefail
 # Implementation labels: post-#.# or pre-#.# (where # is digit)
 # NB: portable ERE only — earlier \b word-boundary anchors were double-escaped inside
 #     the single-quoted string (\\b -> literal "\b"), so post-/pre- detection was dead.
-PATTERNS='(^|[^-a-z0-9])ops-[a-z0-9]{4,}|(^|[^-a-z0-9])(post|pre)-[0-9]+\.[0-9]+'
+BEAD_PATTERN='(^|[^-a-z0-9])ops-[a-z0-9]{4,}'
+LABEL_PATTERN='(^|[^-a-z0-9])(post|pre)-[0-9]+\.[0-9]+'
+PATTERNS="$BEAD_PATTERN|$LABEL_PATTERN"
+
+# Exact-literal allowlist of English ops-* compounds that are not bead IDs (flair#1381).
+# Not a regex. Not a heuristic. A real bead ID can only get onto this list by being
+# added here, in a diff, visibly. Membership is string equality against one line.
+ALLOWLIST_EXACT='
+ops-port
+ops-api
+ops-target
+ops-server
+'
 
 # Temporary file for list of files
 TMPFILE=$(mktemp)
@@ -81,8 +93,88 @@ if (( GREP_RC >= 2 )); then
   exit 1
 fi
 
+# Strip the optional 1-char leading token guard from a grep -oE hit.
+strip_guard() {
+  case "$1" in
+    ops-*|post-*|pre-*) printf '%s' "$1" ;;
+    *) printf '%s' "${1#?}" ;;
+  esac
+}
+
+# Exact string equality against ALLOWLIST_EXACT. Not regex membership.
+is_allowlisted() {
+  local allowed
+  for allowed in $ALLOWLIST_EXACT; do
+    if [ "$1" = "$allowed" ]; then
+      return 0
+    fi
+  done
+  return 1
+}
+
+# Turn grep's raw hits into named findings (file:line: rule + token).
+# Allowlisted compounds are dropped here so a real bead ID on the same line
+# still fails. If grep matched a line we cannot name a token on, fail closed.
+FINDINGS=""
+FINDING_COUNT=0
+
 if [[ -n "$OUTPUT" ]]; then
-  echo "$OUTPUT"
+  while IFS= read -r match; do
+    [[ -z "$match" ]] && continue
+
+    file="${match%%:*}"
+    rest="${match#*:}"
+    lineno="${rest%%:*}"
+    content="${rest#*:}"
+
+    if [[ -z "$lineno" || "$file" == "$match" || "$lineno" == "$rest" ]]; then
+      FINDINGS="${FINDINGS}${match}"$'\n'
+      FINDING_COUNT=$((FINDING_COUNT + 1))
+      continue
+    fi
+
+    line_hits=0
+
+    set +e
+    bead_raw=$(printf '%s\n' "$content" | grep -oE "$BEAD_PATTERN")
+    impl_raw=$(printf '%s\n' "$content" | grep -oE "$LABEL_PATTERN")
+    set -e
+
+    if [[ -n "${bead_raw:-}" ]]; then
+      while IFS= read -r hit; do
+        [[ -z "$hit" ]] && continue
+        token=$(strip_guard "$hit")
+        if is_allowlisted "$token"; then
+          continue
+        fi
+        FINDINGS="${FINDINGS}${file}:${lineno}: matched bead-ID pattern on token \"${token}\""$'\n'
+        FINDING_COUNT=$((FINDING_COUNT + 1))
+        line_hits=$((line_hits + 1))
+      done <<< "$bead_raw"
+    fi
+
+    if [[ -n "${impl_raw:-}" ]]; then
+      while IFS= read -r hit; do
+        [[ -z "$hit" ]] && continue
+        token=$(strip_guard "$hit")
+        FINDINGS="${FINDINGS}${file}:${lineno}: matched impl-label pattern on token \"${token}\""$'\n'
+        FINDING_COUNT=$((FINDING_COUNT + 1))
+        line_hits=$((line_hits + 1))
+      done <<< "$impl_raw"
+    fi
+
+    # grep said this line matched, but we named no token and filtered none.
+    # That is a parser hole, not a clean line — fail closed so the gate
+    # cannot go dark on a shape it does not understand.
+    if [[ "$line_hits" -eq 0 && -z "${bead_raw:-}" && -z "${impl_raw:-}" ]]; then
+      FINDINGS="${FINDINGS}${file}:${lineno}: matched implementation-term pattern (could not extract token)"$'\n'
+      FINDING_COUNT=$((FINDING_COUNT + 1))
+    fi
+  done <<< "$OUTPUT"
+fi
+
+if [[ "$FINDING_COUNT" -gt 0 ]]; then
+  printf '%s' "$FINDINGS"
   exit 1
 else
   echo "No leaks found across $FILE_COUNT file(s)."

--- a/test/unit/ci-gate-coverage.test.ts
+++ b/test/unit/ci-gate-coverage.test.ts
@@ -264,6 +264,19 @@ describe("the impl-term-leak gate cannot report clean without scanning", () => {
     // nonexistent paths — which the old code then reported as clean.
     expect(src).not.toMatch(/grep[^\n]*\$\(cat "\$TMPFILE"\)/);
   });
+
+  test("the ops-* allowlist is four exact literals compared by string equality (flair#1381)", () => {
+    // A regex or "looks like a word" heuristic would exempt a real bead ID
+    // the first time one happened to look English. The behavioural suite in
+    // impl-term-leaks.test.ts proves the list is load-bearing; this pins the
+    // committed shape so the exemption cannot widen in the source unnoticed.
+    expect(src).toMatch(/^ops-port$/m);
+    expect(src).toMatch(/^ops-api$/m);
+    expect(src).toMatch(/^ops-target$/m);
+    expect(src).toMatch(/^ops-server$/m);
+    expect(src).toContain('[ "$1" = "$allowed" ]');
+    expect(src).not.toMatch(/ops-\(port\|api\|target\|server\)/);
+  });
 });
 
 describe("the release script does not tag a partial publish", () => {

--- a/test/unit/ci-gate-coverage.test.ts
+++ b/test/unit/ci-gate-coverage.test.ts
@@ -248,7 +248,7 @@ describe("the impl-term-leak gate cannot report clean without scanning", () => {
     // argv overflow) into its "no matches" status (1). Verified empirically: a
     // grep over a chmod-000 file returns 2, and the old line printed
     // "No leaks found." and exited 0.
-    const grepLine = src.split("\n").find((l) => l.includes("grep -n -E \"$PATTERNS\"")) ?? "";
+    const grepLine = src.split("\n").find((l) => l.includes("grep -n -H -E \"$PATTERNS\"")) ?? "";
     expect(grepLine.length).toBeGreaterThan(0);
     expect(grepLine).not.toMatch(/\|\|\s*(true|:)/);
     expect(src).toContain("GREP_RC");

--- a/test/unit/impl-term-leaks.test.ts
+++ b/test/unit/impl-term-leaks.test.ts
@@ -1,0 +1,133 @@
+// Behaviour of scripts/check-impl-term-leaks.sh (flair#1381).
+//
+// The gate exists to keep bead IDs and impl labels out of user-facing docs.
+// Two defects landed together: English compounds such as "ops-port" were
+// indistinguishable from a bead ID, and a failure printed the line without
+// naming the token or the rule. These tests run the real script against a
+// throwaway corpus — asserting on exit code and stdout, the two things CI
+// and an author actually see.
+//
+// The mutation case is the load-bearing one: if the allowlist were a
+// heuristic (or were empty and the gate just stopped matching ops-*), every
+// happy-path test below would still pass.
+
+import { afterAll, describe, expect, test } from "bun:test";
+import { spawnSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const REPO_ROOT = join(import.meta.dir, "..", "..");
+const SCRIPT = join(REPO_ROOT, "scripts", "check-impl-term-leaks.sh");
+
+const ALLOWLISTED = ["ops-port", "ops-api", "ops-target", "ops-server"] as const;
+const REAL_BEAD_ID = "ops-xllz";
+
+const created: string[] = [];
+
+function fixture(body: string, filename = "integrations.md"): string {
+  const dir = mkdtempSync(join(tmpdir(), "flair-impl-term-leaks-"));
+  created.push(dir);
+  mkdirSync(join(dir, "docs"), { recursive: true });
+  mkdirSync(join(dir, "packages"), { recursive: true });
+  writeFileSync(join(dir, "docs", filename), body);
+  return dir;
+}
+
+function runGate(dir: string, scriptPath = SCRIPT) {
+  const r = spawnSync("bash", [scriptPath], {
+    cwd: dir,
+    encoding: "utf8",
+  });
+  return { status: r.status, out: `${r.stdout}${r.stderr}` };
+}
+
+afterAll(() => {
+  for (const d of created) {
+    rmSync(d, { recursive: true, force: true });
+  }
+});
+
+describe("impl-term-leak gate: real bead IDs still fail (flair#1381)", () => {
+  test(`a real bead ID (${REAL_BEAD_ID}) in a docs file FAILS and names token + rule`, () => {
+    const dir = fixture(`See the coordination note in ${REAL_BEAD_ID} for the write surface.\n`);
+    const res = runGate(dir);
+    expect(res.status).not.toBe(0);
+    expect(res.out).toContain(
+      `docs/integrations.md:1: matched bead-ID pattern on token "${REAL_BEAD_ID}"`,
+    );
+  });
+
+  test("an allowlisted compound on the same line does not hide a real bead ID", () => {
+    const dir = fixture(`the ops-port trap is not ${REAL_BEAD_ID}\n`);
+    const res = runGate(dir);
+    expect(res.status).not.toBe(0);
+    expect(res.out).toContain(`matched bead-ID pattern on token "${REAL_BEAD_ID}"`);
+    expect(res.out).not.toContain('token "ops-port"');
+  });
+});
+
+describe("impl-term-leak gate: exact-literal allowlist PASSES (flair#1381)", () => {
+  for (const compound of ALLOWLISTED) {
+    test(`${compound} in a docs file PASSES`, () => {
+      const dir = fixture(`Configure the ${compound} before registering the agent.\n`);
+      const res = runGate(dir);
+      expect(res.status).toBe(0);
+      expect(res.out).toContain("No leaks found");
+    });
+  }
+
+  test("all four allowlisted compounds together PASS", () => {
+    const dir = fixture(
+      `ops-port, ops-api, ops-target, and ops-server are English compounds.\n`,
+    );
+    const res = runGate(dir);
+    expect(res.status).toBe(0);
+  });
+
+  test("CLI flags with a leading hyphen still PASS (--ops-target)", () => {
+    const dir = fixture("flair agent add --ops-target <ops-url> --admin-pass-file <path>\n");
+    const res = runGate(dir);
+    expect(res.status).toBe(0);
+  });
+
+  test("a near-miss compound that is not on the allowlist still FAILS", () => {
+    // Proves the allowlist is exact literals, not a prefix or "looks like a word" heuristic.
+    const dir = fixture("the ops-portal is not an allowlisted compound\n");
+    const res = runGate(dir);
+    expect(res.status).not.toBe(0);
+    expect(res.out).toContain('matched bead-ID pattern on token "ops-portal"');
+  });
+});
+
+describe("impl-term-leak gate: findings name the token and the rule (flair#1381)", () => {
+  test("an impl-label hit names the impl-label rule and the token", () => {
+    const dir = fixture("shipped in post-1.2 as an implementation label\n");
+    const res = runGate(dir);
+    expect(res.status).not.toBe(0);
+    expect(res.out).toContain('docs/integrations.md:1: matched impl-label pattern on token "post-1.2"');
+  });
+});
+
+describe("impl-term-leak gate: allowlist mutation restores the failure (flair#1381)", () => {
+  test("removing ops-port from the allowlist makes that compound fail again", () => {
+    const src = readFileSync(SCRIPT, "utf8");
+    // The entry must sit on its own line so this replacement cannot silently
+    // no-op against a comment or a regex. If the allowlist is rewritten as a
+    // heuristic, this test goes red — which is the point.
+    expect(src).toMatch(/^ops-port$/m);
+    const mutated = src.replace(/^ops-port$/m, "");
+    expect(mutated).not.toMatch(/^ops-port$/m);
+
+    const dir = fixture("the ops-port trap\n");
+    const mutatedScript = join(dir, "check-impl-term-leaks.sh");
+    writeFileSync(mutatedScript, mutated, { mode: 0o755 });
+
+    const before = runGate(dir, SCRIPT);
+    expect(before.status).toBe(0);
+
+    const after = runGate(dir, mutatedScript);
+    expect(after.status).not.toBe(0);
+    expect(after.out).toContain('matched bead-ID pattern on token "ops-port"');
+  });
+});

--- a/test/unit/impl-term-leaks.test.ts
+++ b/test/unit/impl-term-leaks.test.ts
@@ -85,10 +85,18 @@ describe("impl-term-leak gate: exact-literal allowlist PASSES (flair#1381)", () 
     expect(res.status).toBe(0);
   });
 
-  test("CLI flags with a leading hyphen still PASS (--ops-target)", () => {
-    const dir = fixture("flair agent add --ops-target <ops-url> --admin-pass-file <path>\n");
+  test("a leading hyphen still excludes a non-allowlisted ops-* token", () => {
+    // The fixture used to prove the guard must not itself be on the allowlist.
+    // `--ops-target` would still exit 0 if the [^-a-z0-9] guard disappeared,
+    // because ops-target is exempt. `--ops-xllz` is a real bead-ID shape:
+    // bare it fails (test above); prefixed with `--` it passes only if the
+    // preceding hyphen excludes it.
+    const src = readFileSync(SCRIPT, "utf8");
+    expect(src).not.toMatch(/^ops-xllz$/m);
+    const dir = fixture("flair agent add --ops-xllz <ops-url>\n");
     const res = runGate(dir);
     expect(res.status).toBe(0);
+    expect(res.out).toContain("No leaks found");
   });
 
   test("a near-miss compound that is not on the allowlist still FAILS", () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #1381.

`scripts/check-impl-term-leaks.sh` blocked English compounds such as `ops-port` because a bead ID's suffix is four-plus `[a-z0-9]`, and so is the word *port*. The failure printed the line and nothing else — no token, no rule — so diagnosing it meant reading the script. Hit live on #1378.

## Fix

A narrow, exact-literal allowlist. Not a regex. Not a "looks like a word" heuristic.

- `ops-port`
- `ops-api`
- `ops-target`
- `ops-server`

Membership is string equality against one of those four. A real bead ID can only get onto the list by being added here, in a diff, visibly. `ops-api` is three letters and the current bead pattern requires four; it is listed anyway so the exemption stays explicit if the pattern ever widens.

Each finding now names the matched token and the rule:

```
docs/integrations.md:1: matched bead-ID pattern on token "ops-xllz"
```

`grep -H` is required for that format: without `--with-filename`, a one-file corpus (the unit-fixture shape, and any docs-only scan) omits the path and the formatter cannot split `file:line:content`.

The leading-hyphen guard for CLI flags (`--ops-target`) is unchanged.

## Tests

Behavioural, against a throwaway corpus, in `test/unit/impl-term-leaks.test.ts`:

- A real bead ID (`ops-xllz`) in a docs file still **fails**, and the output names the token and the bead-ID rule.
- Each allowlisted compound **passes**.
- Mutation: remove the `ops-port` line from the allowlist, confirm that compound fails again and names `token "ops-port"`.
- A near-miss (`ops-portal`) still fails — the allowlist is exact, not a prefix.

Also pins the committed allowlist shape in `test/unit/ci-gate-coverage.test.ts` so the exemption cannot widen into a regex unnoticed.

Locally: `bun test test/unit/impl-term-leaks.test.ts test/unit/ci-gate-coverage.test.ts` — 25 pass. The gate over the real repo reports clean (51 files).

## Out of scope

Does not restore the hyphenated "ops-port" phrasing that #1378 reworded around. Does not add any other exemption.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-17c605e1-c360-4bb8-8fc5-d2c377866204?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-17c605e1-c360-4bb8-8fc5-d2c377866204&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

