### PR TITLE
fix(engines): align node floor with Harper (flair#1385)

### DIFF
--- a/.changelog/unreleased/fixed-1385-engines-harper-floor.md
+++ b/.changelog/unreleased/fixed-1385-engines-harper-floor.md
@@ -1,0 +1,4 @@
+- **`engines.node` now matches Harper's floor.** Flair declared `>=22` while
+  the bundled Harper requires `^22.18.0 || >=24`. Node 22.0–22.17 installed
+  cleanly and then Harper refused to boot. The declared range is now Harper's
+  (flair#1385).

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "access": "public"
   },
   "engines": {
-    "node": ">=22"
+    "node": "^22.18.0 || >=24.0.0"
   },
   "dependencies": {
     "@harperfast/oauth": "2.5.0",

--- a/test/unit/engines-harper-floor.test.ts
+++ b/test/unit/engines-harper-floor.test.ts
@@ -10,8 +10,7 @@
 // second copy of Harper's range is a new thing to drift — Harper's floor
 // moved once and will move again, and nothing currently notices.
 import { describe, expect, test } from "bun:test";
-import { readFileSync } from "node:fs";
-import { createRequire } from "node:module";
+import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 
 const REPO_ROOT = join(import.meta.dir, "..", "..");
@@ -28,15 +27,13 @@ function enginesOf(pkg: Record<string, unknown>): { node?: unknown } | undefined
   return engines as { node?: unknown };
 }
 
-/** Same resolution order as readInstalledHarperVersion — the Harper we embed. */
+/** Same resolution order as readInstalledHarperVersion — the Harper we embed.
+ *  Filesystem lookup, not require.resolve: Harper's exports map does not
+ *  expose `./package.json`. */
 function installedHarperPkgPath(): string {
-  const require = createRequire(join(REPO_ROOT, "package.json"));
-  for (const spec of ["harper/package.json", "@harperfast/harper/package.json"]) {
-    try {
-      return require.resolve(spec);
-    } catch {
-      continue;
-    }
+  for (const name of ["harper", "@harperfast/harper"]) {
+    const pkgPath = join(REPO_ROOT, "node_modules", ...name.split("/"), "package.json");
+    if (existsSync(pkgPath)) return pkgPath;
   }
   throw new Error(
     "installed harper/package.json not found; cannot derive Harper's engines.node floor",

--- a/test/unit/engines-harper-floor.test.ts
+++ b/test/unit/engines-harper-floor.test.ts
@@ -1,0 +1,204 @@
+// flair#1385 — engines.node must not admit a Node Harper refuses.
+//
+// Flair declared `>=22`. Harper 5.2 declares `^22.18.0 || >=24`. The whole
+// band Node 22.0–22.17 (and every 23.x) satisfied our field and failed
+// Harper's. npm's engines check — the mechanism that exists to stop this —
+// passed, because we told it to. Then `flair init` installed Harper and
+// Harper refused on its own engines check. The user did nothing wrong.
+//
+// The floor is DERIVED from the installed harper/package.json. A hardcoded
+// second copy of Harper's range is a new thing to drift — Harper's floor
+// moved once and will move again, and nothing currently notices.
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { createRequire } from "node:module";
+import { join } from "node:path";
+
+const REPO_ROOT = join(import.meta.dir, "..", "..");
+
+type Triple = [number, number, number];
+
+function readJson(path: string): Record<string, unknown> {
+  return JSON.parse(readFileSync(path, "utf-8")) as Record<string, unknown>;
+}
+
+function enginesOf(pkg: Record<string, unknown>): { node?: unknown } | undefined {
+  const engines = pkg.engines;
+  if (!engines || typeof engines !== "object") return undefined;
+  return engines as { node?: unknown };
+}
+
+/** Same resolution order as readInstalledHarperVersion — the Harper we embed. */
+function installedHarperPkgPath(): string {
+  const require = createRequire(join(REPO_ROOT, "package.json"));
+  for (const spec of ["harper/package.json", "@harperfast/harper/package.json"]) {
+    try {
+      return require.resolve(spec);
+    } catch {
+      continue;
+    }
+  }
+  throw new Error(
+    "installed harper/package.json not found; cannot derive Harper's engines.node floor",
+  );
+}
+
+function readNodeRange(pkg: Record<string, unknown>, label: string): string {
+  const range = enginesOf(pkg)?.node;
+  if (typeof range !== "string" || !range.trim()) {
+    throw new Error(`${label} has no engines.node; cannot compare Node floors`);
+  }
+  return range.trim();
+}
+
+function parseTriple(raw: string): Triple | null {
+  const m = raw.trim().match(/^(\d+)(?:\.(\d+))?(?:\.(\d+))?/);
+  if (!m) return null;
+  return [Number(m[1]), Number(m[2] ?? 0), Number(m[3] ?? 0)];
+}
+
+function cmp(a: Triple, b: Triple): number {
+  if (a[0] !== b[0]) return a[0] - b[0];
+  if (a[1] !== b[1]) return a[1] - b[1];
+  return a[2] - b[2];
+}
+
+function satisfiesComparator(version: Triple, comparator: string): boolean {
+  const c = comparator.trim();
+  if (!c) return true;
+  if (c.startsWith("^")) {
+    const base = parseTriple(c.slice(1));
+    if (!base) return false;
+    const upper: Triple =
+      base[0] > 0 ? [base[0] + 1, 0, 0] :
+      base[1] > 0 ? [0, base[1] + 1, 0] :
+      [0, 0, base[2] + 1];
+    return cmp(version, base) >= 0 && cmp(version, upper) < 0;
+  }
+  const opMatch = c.match(/^(>=|<=|>|<|=)?\s*(.+)$/);
+  if (!opMatch) return false;
+  const op = opMatch[1] || "=";
+  const base = parseTriple(opMatch[2]);
+  if (!base) return false;
+  const d = cmp(version, base);
+  if (op === ">=") return d >= 0;
+  if (op === "<=") return d <= 0;
+  if (op === ">") return d > 0;
+  if (op === "<") return d < 0;
+  return d === 0;
+}
+
+/** npm-engines ranges: `||` unions, whitespace-separated AND comparators. */
+function satisfiesRange(version: string, range: string): boolean {
+  const v = parseTriple(version);
+  if (!v) return false;
+  return range.split("||").some((group) => {
+    const parts = group.trim().split(/\s+/).filter(Boolean);
+    return parts.length > 0 && parts.every((p) => satisfiesComparator(v, p));
+  });
+}
+
+function formatVersion(v: Triple): string {
+  return `${v[0]}.${v[1]}.${v[2]}`;
+}
+
+/** Versions mentioned in either range, plus the neighbors that expose a gap. */
+function probeVersions(flairRange: string, harperRange: string): string[] {
+  const mentioned = [...`${flairRange} ${harperRange}`.matchAll(/\d+(?:\.\d+){0,2}/g)]
+    .map((m) => parseTriple(m[0]))
+    .filter((v): v is Triple => v !== null);
+  const probes = new Set<string>();
+  const add = (v: Triple) => {
+    if (v[0] >= 0 && v[1] >= 0 && v[2] >= 0) probes.add(formatVersion(v));
+  };
+  for (const [maj, min, pat] of mentioned) {
+    add([maj, min, pat]);
+    add([maj, min, Math.max(0, pat - 1)]);
+    add([maj, min, pat + 1]);
+    add([maj, Math.max(0, min - 1), 0]);
+    add([maj, min + 1, 0]);
+    add([Math.max(0, maj - 1), 0, 0]);
+    add([maj + 1, 0, 0]);
+    add([maj, 0, 0]);
+  }
+  const majors = mentioned.map((v) => v[0]);
+  const lo = Math.max(0, Math.min(...majors, 22) - 1);
+  const hi = Math.max(...majors, 24) + 2;
+  for (let maj = lo; maj <= hi; maj++) {
+    for (const min of [0, 1, 17, 18, 19, 20, 99]) {
+      add([maj, min, 0]);
+    }
+  }
+  return [...probes];
+}
+
+function versionsAdmittedThatOtherRejects(flairRange: string, harperRange: string): string[] {
+  return probeVersions(flairRange, harperRange).filter(
+    (v) => satisfiesRange(v, flairRange) && !satisfiesRange(v, harperRange),
+  );
+}
+
+/** Null when flair's range is a subset of Harper's. Otherwise a message naming both. */
+function admissionFailure(flairRange: string, harperRange: string): string | null {
+  const offenders = versionsAdmittedThatOtherRejects(flairRange, harperRange);
+  if (offenders.length === 0) return null;
+  return (
+    `flair engines.node ${JSON.stringify(flairRange)} admits versions Harper rejects ` +
+    `(${JSON.stringify(harperRange)}); e.g. ${offenders.sort()[0]}`
+  );
+}
+
+describe("the range comparator (positive control)", () => {
+  test("Harper's caret+OR shape accepts 22.18 and 24, rejects 22.17 and 23", () => {
+    // A canned Harper-shaped range — not the live value. Proves the comparator
+    // itself can see the gap this bug lives in, so a green live-package test
+    // is not a comparator that never fails.
+    const harperShaped = "^22.18.0 || >=24.0.0";
+    expect(satisfiesRange("22.17.0", harperShaped)).toBe(false);
+    expect(satisfiesRange("22.18.0", harperShaped)).toBe(true);
+    expect(satisfiesRange("23.0.0", harperShaped)).toBe(false);
+    expect(satisfiesRange("24.0.0", harperShaped)).toBe(true);
+    expect(satisfiesRange("22.0.0", ">=22")).toBe(true);
+  });
+
+  test(">=22 against a Harper-shaped floor names both ranges", () => {
+    const harperShaped = "^22.18.0 || >=24.0.0";
+    const failure = admissionFailure(">=22", harperShaped);
+    expect(failure).not.toBeNull();
+    expect(failure!).toContain(">=22");
+    expect(failure!).toContain(harperShaped);
+  });
+});
+
+describe("flair engines.node vs installed Harper (flair#1385)", () => {
+  test("the floor is read from installed harper/package.json, not a literal in this file", () => {
+    const harperPath = installedHarperPkgPath();
+    const harper = readJson(harperPath);
+    const range = readNodeRange(harper, `installed ${harperPath}`);
+    // Presence + type only. Asserting a specific string here would be the
+    // hardcoded second copy this test exists to avoid.
+    expect(range.length).toBeGreaterThan(0);
+    expect(harperPath).toMatch(/node_modules/);
+  });
+
+  test("flair admits no version Harper rejects — failure names both ranges", () => {
+    const flairRange = readNodeRange(readJson(join(REPO_ROOT, "package.json")), "flair package.json");
+    const harperPath = installedHarperPkgPath();
+    const harperRange = readNodeRange(readJson(harperPath), `installed ${harperPath}`);
+    const failure = admissionFailure(flairRange, harperRange);
+    expect(failure).toBeNull();
+  });
+
+  test("the previously-shipped >=22 range is a superset of the installed Harper floor", () => {
+    // Powered shape: if this ever goes green, either Harper loosened to
+    // admit all of >=22 (then our engines can follow) or the comparator
+    // stopped seeing the gap. The live-package test above is the one that
+    // fails when someone widens flair's field back to >=22.
+    const harperPath = installedHarperPkgPath();
+    const harperRange = readNodeRange(readJson(harperPath), `installed ${harperPath}`);
+    const failure = admissionFailure(">=22", harperRange);
+    expect(failure).not.toBeNull();
+    expect(failure!).toContain(">=22");
+    expect(failure!).toContain(harperRange);
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #1385.

## Problem

`flair` declared `engines.node: ">=22"` while the bundled Harper (5.2.0) declares `^22.18.0 || >=24.0.0`. Node 22.0–22.17 (and every 23.x) satisfied our field, so `npm install -g @tpsdev-ai/flair` raised nothing; `flair init` then installed Harper and Harper refused on its own engines check.

## Change

Root `@tpsdev-ai/flair` `engines.node` is now `^22.18.0 || >=24.0.0` — Harper's constraint, since we embed and start it.

## Workspace packages — left looser on purpose

None of the workspace packages start Harper. They talk to a running Flair over HTTP/MCP, or (flair-bench) run embeddings via `node-llama-cpp`. No `harper` / `@harperfast/harper` dependency appears in any `packages/*/package.json`.

| Package | engines.node | Starts Harper? |
|---|---|---|
| `@tpsdev-ai/flair` (root) | `^22.18.0 \|\| >=24.0.0` | yes — this PR |
| `flair-mcp` | `>=22` | no |
| `flair-client` | `>=18` | no |
| `flair-bench` | `>=22` | no |
| `cursor-flair` | `>=22` | no (marketplace bundle) |
| `openclaw-flair` | `>=22` | no (flair-client) |
| `langgraph-flair` | `>=18` | no (flair-client) |
| `pi-flair` | `>=18` | no (flair-client) |
| `adk-flair-js` | `>=18` | no |
| `n8n-nodes-flair` | `>=18` | no |

`hermes-flair` / `adk-flair` are Python. The CLI preflight shim still checks major `>= 22` only — it still rejects Node 21 and below; the 22.0–22.17 band is now an npm engines warning. Teaching the ancient-safe shim the minor floor is a follow-up, not this fix.

No Cloud Agent env files and no #1248 work in this PR.

## Test

`test/unit/engines-harper-floor.test.ts` reads Harper's `engines.node` from the installed `harper/package.json` (same filesystem resolve order as `readInstalledHarperVersion` — Harper's `exports` map does not expose `./package.json`). It does not restate Harper's range as a literal. It asserts flair's declared range admits no version Harper rejects, and the failure names both ranges.

## Powered check

Temporarily set flair `engines.node` back to `>=22`, ran `bun test test/unit/engines-harper-floor.test.ts`, then restored.

The live-package test went red and named both ranges:

```
expect(received).toBeNull()
Received: "flair engines.node \">=22\" admits versions Harper rejects (\"^22.18.0 || >=24.0.0\"); e.g. 22.0.0"
```

After restore, the same file is 5 pass / 0 fail.

## Changelog

`.changelog/unreleased/fixed-1385-engines-harper-floor.md`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6564bd76-9d67-4239-b3b7-eaaf4ef5cd06?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6564bd76-9d67-4239-b3b7-eaaf4ef5cd06&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

