### PR TITLE
fix(quality): project and bound the recall spot-check Memory GET

### DIFF
--- a/.changelog/unreleased/fixed-1360-quality-recall-fetch.md
+++ b/.changelog/unreleased/fixed-1360-quality-recall-fetch.md
@@ -1,0 +1,9 @@
+- **`flair quality` no longer pulls the Memory table with embeddings inline
+  to sample 10 memories (flair#1360).** The recall spot-check now GETs a
+  Harper-projected, recency-sorted, bounded window
+  (`select(id,subject,content,createdAt)` + `limit(0, 26)`) instead of an
+  unfiltered `GET /Memory?agentId=…` that returned every row's embedding
+  vector — 66 MB, twice per `--emit` run on a 3k-row production store, and
+  growing with store size. The previous-snapshot lookup uses the same
+  projection. Score, sample frame (most-recently-written), and auth path
+  are unchanged.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -14930,7 +14930,8 @@ program
 // from /HealthDetail at all — it's the one metric in this file that requires
 // live QUERIES, because it's checking whether querying itself still works.
 // For a sample of the querying agent's OWN memories (fetchRecallSpotCheckData
-// below, GET /Memory?agentId=<self>), a CUE is derived from each memory
+// below, a projected+bounded GET /Memory — flair#1360: never the unfiltered
+// collection with embeddings inline), a CUE is derived from each memory
 // (deriveRecallCue — its `subject` if present, else the leading ~8 words /
 // first sentence of `content`; a PARTIAL cue, never the full content) and
 // searched for through the EXACT SAME authenticated read path `flair memory
@@ -14996,6 +14997,69 @@ export const QUALITY_HASH_FALLBACK_DEGRADED_PCT = 10;
  *  "first-pass default, tunable later" spirit as the thresholds above. */
 export const QUALITY_RECALL_SAMPLE_SIZE = 10;
 export const QUALITY_RECALL_K = 5;
+
+/**
+ * Fields the recall spot-check and the quality-snapshot lookup actually
+ * read. Harper REST `select(...)` (same syntax adk-flair-js's listMemories
+ * already uses) projects these server-side so the nightly sweep never
+ * pulls embedding vectors inline — the defect in flair#1360 was an
+ * unfiltered `GET /Memory?agentId=…` that returned every row's 768-d
+ * vector (~66 MB × 2 per `--emit` run on a 3k-row store) just to sample
+ * 10 memories. `type` is intentionally omitted: it is not a declared
+ * Memory column (see schemas/memory.graphql); snapshot exclusion keys
+ * off `subject` (`quality-snapshot/…`).
+ */
+export const QUALITY_MEMORY_LIST_SELECT = ["id", "subject", "content", "createdAt"] as const;
+
+/**
+ * Extra most-recent rows fetched beyond `sampleSize` so
+ * `planRecallSpotCheck` can drop the sweep's own quality-snapshot
+ * bookkeeping and still fill a 10-row window — without scanning the
+ * table. Nightly `--emit` writes one snapshot per run; 16 is a buffer
+ * for a few extra `--emit`s in the same recency window, not a second
+ * full-table read.
+ */
+export const QUALITY_RECALL_SNAPSHOT_OVERFETCH = 16;
+
+/** Injectable GET/POST used by the quality I/O helpers so tests can lock
+ *  the Memory listing URL (flair#1360) without a live Harper. */
+export type QualityApi = (
+  method: string,
+  path: string,
+  body?: unknown,
+  options?: { baseUrl?: string; keysDir?: string; agentId?: string | null },
+) => Promise<any>;
+
+/**
+ * Harper REST collection path for the recall spot-check's sample fetch:
+ * agent-scoped, projected (never `embedding`), recency-sorted, bounded.
+ * `limit(start,end)` is Harper's offset window — same as
+ * packages/adk-flair-js/src/memory_service.ts.
+ */
+export function qualityRecallSamplePath(
+  agentId: string,
+  sampleSize: number = QUALITY_RECALL_SAMPLE_SIZE,
+): string {
+  const select = QUALITY_MEMORY_LIST_SELECT.join(",");
+  const end = sampleSize + QUALITY_RECALL_SNAPSHOT_OVERFETCH;
+  return `/Memory?agentId=${encodeURIComponent(agentId)}&select(${select})&sort(-createdAt)&limit(0,${end})`;
+}
+
+/**
+ * Harper REST collection path for the previous quality-snapshot lookup:
+ * same projection as the sample fetch (never `embedding`). Subject is
+ * passed as a query equals (indexed) plus a client-side re-filter —
+ * Memory.search() historically did not turn bare query params into
+ * conditions beyond the signed agent scope, so the client-side filter
+ * in fetchPreviousQualitySnapshot stays as defense in depth. No `limit`:
+ * a bounded window could miss yesterday's snapshot after a busy day of
+ * writes, and without a reliable server-side subject pushdown that
+ * would silently look like a first run.
+ */
+export function qualitySnapshotLookupPath(agentId: string, subject: string): string {
+  const select = QUALITY_MEMORY_LIST_SELECT.join(",");
+  return `/Memory?agentId=${encodeURIComponent(agentId)}&subject=${encodeURIComponent(subject)}&select(${select})&sort(-createdAt)`;
+}
 
 export interface QualityMetricGap {
   metric: string;
@@ -15569,20 +15633,23 @@ export function computeQualityReport(
  * `agentId`'s own memories and, for each, search for a cue derived from it.
  * Reuses the EXACT read path `flair memory search` / `flair memory list`
  * use — `api()` (→ authedRequest's 5-tier resolver) for both the
- * `GET /Memory?agentId=...` sample fetch and the `POST /SemanticSearch`
- * queries — so this has zero new endpoint and zero new auth mechanism; it
- * is scoped to `agentId`'s own memories exactly as those commands already
- * are. Never throws: every failure mode (no agentId, fewer than
- * `sampleSize` memories, a fetch/search error) returns `{ ok: false,
- * skipReason }` for computeQualityReport to turn into a `gaps` entry.
+ * projected, bounded `GET /Memory?…&select(…)&limit(…)` sample fetch
+ * (flair#1360 — never the unfiltered collection with embeddings inline)
+ * and the `POST /SemanticSearch` queries — so this has zero new endpoint
+ * and zero new auth mechanism; it is scoped to `agentId`'s own memories
+ * exactly as those commands already are. Never throws: every failure mode
+ * (no agentId, fewer than `sampleSize` memories, a fetch/search error)
+ * returns `{ ok: false, skipReason }` for computeQualityReport to turn
+ * into a `gaps` entry.
  */
-async function fetchRecallSpotCheckData(
+export async function fetchRecallSpotCheckData(
   agentId: string | null,
   baseUrl: string,
-  opts: { sampleSize?: number; k?: number } = {},
+  opts: { sampleSize?: number; k?: number; request?: QualityApi } = {},
 ): Promise<RecallSpotCheckFetchResult> {
   const sampleSize = opts.sampleSize ?? QUALITY_RECALL_SAMPLE_SIZE;
   const k = opts.k ?? QUALITY_RECALL_K;
+  const request = opts.request ?? api;
 
   if (!agentId) {
     return { ok: false, skipReason: "no agent identity to query as — pass --agent or set FLAIR_AGENT_ID" };
@@ -15590,8 +15657,7 @@ async function fetchRecallSpotCheckData(
 
   let all: any[];
   try {
-    const q = new URLSearchParams({ agentId }).toString();
-    const raw = await api("GET", `/Memory?${q}`, undefined, { baseUrl, agentId });
+    const raw = await request("GET", qualityRecallSamplePath(agentId, sampleSize), undefined, { baseUrl, agentId });
     all = Array.isArray(raw) ? raw : (raw?.results ?? raw?.items ?? []);
   } catch (err: any) {
     return { ok: false, agentId, skipReason: `could not fetch memories to sample: ${err?.message ?? String(err)}` };
@@ -15623,7 +15689,7 @@ async function fetchRecallSpotCheckData(
   try {
     for (const { id, cue } of plan.sampled) {
       const body = { agentId, q: cue, limit: k };
-      const res = await api("POST", "/SemanticSearch", body, { baseUrl, agentId });
+      const res = await request("POST", "/SemanticSearch", body, { baseUrl, agentId });
       const results: any[] = Array.isArray(res) ? res : (res?.results ?? []);
       sampledIds.push(id);
       perQueryResultIds.push(results.map((r: any) => String(r.id)));
@@ -15883,21 +15949,28 @@ export function qualitySnapshotSubject(baseUrl: string): string {
 }
 
 /** Fetch the most recent prior quality snapshot for `agentId` at `baseUrl`,
- *  via the exact same read path fetchRecallSpotCheckData uses (`api("GET",
- *  "/Memory?agentId=...")`, self-scoped by the signed request's own agent
- *  identity — no new endpoint). Filters client-side by subject (the server's
- *  `GET /Memory?...` doesn't translate query params into search conditions
- *  beyond the signed agentId scope — see resources/Memory.ts's search()),
- *  same client-side-filter pattern `memory list --hash-fallback` already
- *  uses. Returns null on: no prior snapshot, a fetch error, or a snapshot row
- *  whose content isn't parseable/versioned JSON (never throws — a corrupt or
- *  foreign row degrades to "no snapshot", same as a genuine first run, rather
- *  than crashing `--emit`). */
-async function fetchPreviousQualitySnapshot(agentId: string, baseUrl: string, subject: string): Promise<QualitySnapshotCore | null> {
+ *  via the same signed `GET /Memory` read path fetchRecallSpotCheckData
+ *  uses (self-scoped by the signed request's own agent identity — no new
+ *  endpoint). Projects the same fields (never embeddings — flair#1360) and
+ *  asks for `subject` as a query equals; still filters client-side by
+ *  subject because Memory.search() historically did not turn bare query
+ *  params into search conditions beyond the signed agentId scope (see
+ *  resources/Memory.ts's search()), same client-side-filter pattern
+ *  `memory list --hash-fallback` already uses. Returns null on: no prior
+ *  snapshot, a fetch error, or a snapshot row whose content isn't
+ *  parseable/versioned JSON (never throws — a corrupt or foreign row
+ *  degrades to "no snapshot", same as a genuine first run, rather than
+ *  crashing `--emit`). */
+export async function fetchPreviousQualitySnapshot(
+  agentId: string,
+  baseUrl: string,
+  subject: string,
+  opts: { request?: QualityApi } = {},
+): Promise<QualitySnapshotCore | null> {
+  const request = opts.request ?? api;
   let all: any[];
   try {
-    const q = new URLSearchParams({ agentId }).toString();
-    const raw = await api("GET", `/Memory?${q}`, undefined, { baseUrl, agentId });
+    const raw = await request("GET", qualitySnapshotLookupPath(agentId, subject), undefined, { baseUrl, agentId });
     all = Array.isArray(raw) ? raw : (raw?.results ?? raw?.items ?? []);
   } catch {
     return null;

--- a/test/unit/quality-recall-fetch-1360.test.ts
+++ b/test/unit/quality-recall-fetch-1360.test.ts
@@ -1,0 +1,191 @@
+/**
+ * quality-recall-fetch-1360.test.ts — the powered check for flair#1360.
+ *
+ * #1360 is a diagnosed defect, so these tests were written to FAIL on
+ * unmodified main first: `fetchRecallSpotCheckData` issued an unfiltered
+ * `GET /Memory?agentId=flint` (embeddings inline, whole table) to sample
+ * 10 memories, and `flair quality --emit` did it twice.
+ *
+ * Properties:
+ *  1. The sample URL projects only the fields the check reads and never
+ *     names `embedding` / `embeddingModel`.
+ *  2. The sample URL is bounded (`limit(0, sampleSize+overfetch)`), so a
+ *     10-row sample cannot pull the whole table.
+ *  3. `fetchRecallSpotCheckData` actually GETs that URL — one Memory
+ *     listing, not an unfiltered `?agentId=` collection — and the
+ *     snapshot lookup uses the same projection (no embeddings) rather
+ *     than a second full-table-with-vectors read.
+ *
+ * Positive control: a healthy 10-row window still runs the SemanticSearch
+ * probes and returns ok:true. A green run here is not vacuous.
+ */
+
+import { describe, test, expect } from "bun:test";
+import {
+  QUALITY_MEMORY_LIST_SELECT,
+  QUALITY_RECALL_SAMPLE_SIZE,
+  QUALITY_RECALL_SNAPSHOT_OVERFETCH,
+  QUALITY_RECALL_K,
+  fetchPreviousQualitySnapshot,
+  fetchRecallSpotCheckData,
+  qualityRecallSamplePath,
+  qualitySnapshotLookupPath,
+  qualitySnapshotSubject,
+  type QualityApi,
+} from "../../src/cli.ts";
+
+const SELECT_RE = /[?&]select\(([^)]*)\)/;
+const LIMIT_RE = /[?&]limit\((\d+),(\d+)\)/;
+
+function selectFields(path: string): string[] {
+  const m = path.match(SELECT_RE);
+  expect(m, `expected Harper select(...) in ${path}`).toBeTruthy();
+  return (m![1] ?? "").split(",").map((s) => s.trim()).filter(Boolean);
+}
+
+function assertNoEmbeddings(path: string): void {
+  const fields = selectFields(path);
+  expect(fields).not.toContain("embedding");
+  expect(fields).not.toContain("embeddingModel");
+  expect(path).not.toMatch(/embedding/i);
+}
+
+describe("flair#1360 — quality Memory listing is projected and bounded", () => {
+  test("QUALITY_MEMORY_LIST_SELECT is exactly the fields the planner/snapshot read — never embeddings", () => {
+    expect([...QUALITY_MEMORY_LIST_SELECT].sort()).toEqual(
+      ["content", "createdAt", "id", "subject"].sort(),
+    );
+    expect(QUALITY_MEMORY_LIST_SELECT).not.toContain("embedding");
+    expect(QUALITY_MEMORY_LIST_SELECT).not.toContain("embeddingModel");
+  });
+
+  test("qualityRecallSamplePath projects those fields, sorts by recency, and bounds the window", () => {
+    const path = qualityRecallSamplePath("flint");
+    expect(path.startsWith("/Memory?")).toBe(true);
+    expect(path).toContain("agentId=flint");
+    expect(selectFields(path)).toEqual([...QUALITY_MEMORY_LIST_SELECT]);
+    assertNoEmbeddings(path);
+    expect(path).toContain("sort(-createdAt)");
+    const limit = path.match(LIMIT_RE);
+    expect(limit, `expected Harper limit(start,end) in ${path}`).toBeTruthy();
+    expect(Number(limit![1])).toBe(0);
+    expect(Number(limit![2])).toBe(QUALITY_RECALL_SAMPLE_SIZE + QUALITY_RECALL_SNAPSHOT_OVERFETCH);
+    expect(Number(limit![2])).toBeLessThan(100);
+    expect(path).not.toBe("/Memory?agentId=flint");
+  });
+
+  test("a 10-row sample does not encode an unbounded / whole-table listing", () => {
+    const path = qualityRecallSamplePath("flint", 10);
+    const limit = path.match(LIMIT_RE);
+    const end = Number(limit![2]);
+    expect(end).toBe(10 + QUALITY_RECALL_SNAPSHOT_OVERFETCH);
+    expect(end).toBeGreaterThanOrEqual(10);
+    expect(end).toBeLessThan(10 * 10);
+  });
+
+  test("agent ids are percent-encoded in the sample path", () => {
+    const path = qualityRecallSamplePath("flint/prod");
+    expect(path).toContain("agentId=flint%2Fprod");
+    expect(path).not.toContain("agentId=flint/prod");
+  });
+
+  test("qualitySnapshotLookupPath uses the same projection (never embeddings) and does not add a sample-shaped limit", () => {
+    const subject = qualitySnapshotSubject("http://127.0.0.1:9926");
+    const path = qualitySnapshotLookupPath("flint", subject);
+    expect(path.startsWith("/Memory?")).toBe(true);
+    expect(path).toContain("agentId=flint");
+    expect(path).toContain(`subject=${encodeURIComponent(subject)}`);
+    expect(selectFields(path)).toEqual([...QUALITY_MEMORY_LIST_SELECT]);
+    assertNoEmbeddings(path);
+    expect(path).not.toMatch(LIMIT_RE);
+    expect(path).not.toBe("/Memory?agentId=flint");
+  });
+});
+
+function scorableRows(n: number): Array<{ id: string; subject: string; content: string; createdAt: string }> {
+  const t0 = Date.parse("2026-08-24T00:00:00.000Z");
+  return Array.from({ length: n }, (_, i) => ({
+    id: `mem-${i}`,
+    subject: `Harper upgrade note ${i}`,
+    content: `Harper 5.2 upgrade note ${i} with enough words to be a real cue`,
+    createdAt: new Date(t0 + i * 1000).toISOString(),
+  }));
+}
+
+describe("flair#1360 — fetchRecallSpotCheckData does not GET the whole table with embeddings", () => {
+  test("GETs the projected+bounded sample path once, never an unfiltered ?agentId= listing", async () => {
+    const calls: Array<{ method: string; path: string }> = [];
+    const rows = scorableRows(QUALITY_RECALL_SAMPLE_SIZE);
+    const request: QualityApi = async (method, path) => {
+      calls.push({ method, path });
+      if (method === "GET") {
+        expect(path).toBe(qualityRecallSamplePath("flint", QUALITY_RECALL_SAMPLE_SIZE));
+        assertNoEmbeddings(path);
+        expect(path).toMatch(LIMIT_RE);
+        return rows;
+      }
+      if (method === "POST" && path === "/SemanticSearch") {
+        const target = calls.filter((c) => c.method === "POST").length - 1;
+        return [{ id: rows[target]!.id }];
+      }
+      throw new Error(`unexpected ${method} ${path}`);
+    };
+
+    const result = await fetchRecallSpotCheckData("flint", "http://127.0.0.1:9926", { request });
+    expect(result.ok).toBe(true);
+    expect(result.sampledIds).toHaveLength(QUALITY_RECALL_SAMPLE_SIZE);
+
+    const memoryGets = calls.filter((c) => c.method === "GET" && c.path.startsWith("/Memory"));
+    expect(memoryGets).toHaveLength(1);
+    expect(memoryGets[0]!.path).not.toBe("/Memory?agentId=flint");
+    expect(memoryGets[0]!.path).not.toMatch(/^\/Memory\?agentId=[^&]+$/);
+    expect(calls.filter((c) => c.method === "POST" && c.path === "/SemanticSearch")).toHaveLength(QUALITY_RECALL_SAMPLE_SIZE);
+  });
+
+  test("a mocked 3k-row store with embeddings is never requested — the URL itself forbids it", async () => {
+    const request: QualityApi = async (method, path) => {
+      if (method === "GET") {
+        assertNoEmbeddings(path);
+        const limit = path.match(LIMIT_RE);
+        expect(Number(limit![2])).toBeLessThan(3000);
+        return scorableRows(5);
+      }
+      throw new Error("search should not run — too few rows");
+    };
+    const result = await fetchRecallSpotCheckData("flint", "http://127.0.0.1:9926", { request });
+    expect(result.ok).toBe(false);
+    expect(result.skipReason).toMatch(/fewer than the 10 needed/);
+  });
+});
+
+describe("flair#1360 — fetchPreviousQualitySnapshot does not pull embeddings", () => {
+  test("GETs the projected snapshot path, never an unfiltered collection", async () => {
+    const subject = qualitySnapshotSubject("http://127.0.0.1:9926");
+    const snapshot = {
+      schemaVersion: 1,
+      computedAt: "2026-08-23T00:00:00.000Z",
+      agentFilter: "flint",
+      embeddingCoverage: { coveragePct: 95 },
+      staleness: { stalePct: 5 },
+      recallSpotCheck: { recallAtK: 0.9, mrr: 0.8 },
+      quietAgents: { perAgent: [] },
+      dedupClusters: { clusterCount: 0 },
+    };
+    const calls: string[] = [];
+    const request: QualityApi = async (method, path) => {
+      expect(method).toBe("GET");
+      calls.push(path);
+      expect(path).toBe(qualitySnapshotLookupPath("flint", subject));
+      assertNoEmbeddings(path);
+      return [
+        { id: "other", subject: "unrelated", content: "{}", createdAt: "2026-08-22T00:00:00.000Z" },
+        { id: "snap", subject, content: JSON.stringify(snapshot), createdAt: "2026-08-23T00:00:00.000Z" },
+      ];
+    };
+
+    const got = await fetchPreviousQualitySnapshot("flint", "http://127.0.0.1:9926", subject, { request });
+    expect(got).toEqual(snapshot);
+    expect(calls).toEqual([qualitySnapshotLookupPath("flint", subject)]);
+    expect(calls[0]).not.toBe("/Memory?agentId=flint");
+  });
+});

--- a/test/unit/quality-recall-fetch-1360.test.ts
+++ b/test/unit/quality-recall-fetch-1360.test.ts
@@ -32,6 +32,7 @@ import {
   qualitySnapshotLookupPath,
   qualitySnapshotSubject,
   type QualityApi,
+  type QualitySnapshotCore,
 } from "../../src/cli.ts";
 
 const SELECT_RE = /[?&]select\(([^)]*)\)/;
@@ -53,7 +54,7 @@ function assertNoEmbeddings(path: string): void {
 describe("flair#1360 — quality Memory listing is projected and bounded", () => {
   test("QUALITY_MEMORY_LIST_SELECT is exactly the fields the planner/snapshot read — never embeddings", () => {
     expect([...QUALITY_MEMORY_LIST_SELECT].sort()).toEqual(
-      ["content", "createdAt", "id", "subject"].sort(),
+      ["content", "createdAt", "id", "subject"],
     );
     expect(QUALITY_MEMORY_LIST_SELECT).not.toContain("embedding");
     expect(QUALITY_MEMORY_LIST_SELECT).not.toContain("embeddingModel");
@@ -161,7 +162,7 @@ describe("flair#1360 — fetchRecallSpotCheckData does not GET the whole table w
 describe("flair#1360 — fetchPreviousQualitySnapshot does not pull embeddings", () => {
   test("GETs the projected snapshot path, never an unfiltered collection", async () => {
     const subject = qualitySnapshotSubject("http://127.0.0.1:9926");
-    const snapshot = {
+    const snapshot: QualitySnapshotCore = {
       schemaVersion: 1,
       computedAt: "2026-08-23T00:00:00.000Z",
       agentFilter: "flint",

--- a/test/unit/quality-report.test.ts
+++ b/test/unit/quality-report.test.ts
@@ -610,13 +610,13 @@ describe("computeQualityReport", () => {
  * flair-quality Slice 2 (quality OrgEvents): unit tests for the pure
  * snapshot/diff/threshold core behind `flair quality --emit` —
  * buildQualitySnapshot, diffQualitySnapshots, qualitySnapshotSubject. The
- * I/O halves (fetchPreviousQualitySnapshot, storeQualitySnapshot,
- * publishOrgEvent, and the `--emit` action wiring itself) are exercised the
- * same way the report's own I/O boundary (fetchHealthDetail /
- * fetchRecallSpotCheckData) is — not directly unit tested, same rationale as
- * this file's header doc: network + console.log plumbing is high-effort,
- * low-value to test directly; the decision logic underneath is what must be
- * airtight, and that's what's covered here.
+ * I/O halves (storeQualitySnapshot, publishOrgEvent, and the `--emit`
+ * action wiring itself) stay out of this file — network + console.log
+ * plumbing is high-effort, low-value to test directly; the decision logic
+ * underneath is what must be airtight, and that's what's covered here.
+ * The Memory listing URL itself is locked by
+ * test/unit/quality-recall-fetch-1360.test.ts (flair#1360: no embeddings,
+ * no whole-table fetch for a 10-row sample).
  */
 describe("flair-quality Slice 2 — snapshot + diff + OrgEvent thresholds", () => {
   function snap(overrides: Partial<QualitySnapshotCore> = {}): QualitySnapshotCore {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #1360.

## Problem

`fetchRecallSpotCheckData` issued an unfiltered `GET /Memory?agentId=flint`. On rockit production that response is ~66 MB (2816 rows with embedding vectors inline), and `flair quality --emit` did it twice — nightly — to sample 10 memories.

## Fix

CLI-only. Harper REST already supports the projection/limit syntax adk-flair-js's `listMemories` uses; Memory.search() already forwards `select` / `sort` / `limit` through `makeScopedSearch`.

- Recall sample fetch: `GET /Memory?agentId=…&select(id,subject,content,createdAt)&sort(-createdAt)&limit(0, 26)`
  - Projects only the fields `planRecallSpotCheck` / `deriveRecallCue` read
  - Never names `embedding` / `embeddingModel`
  - Bounds the window (`sampleSize + 16` overfetch so quality-snapshot bookkeeping can be dropped without scanning the table)
- Previous-snapshot lookup: same `select` (no embeddings). No `limit` — a bounded window could miss yesterday's snapshot after a busy day of writes, and Memory.search() historically does not turn bare query params into conditions.

Sampling frame is unchanged (most-recently-written). Auth path is unchanged (`api()` → authedRequest). Score math is unchanged.

Related #967 #1357 — not the same defect; not implemented here.

## Tests

`test/unit/quality-recall-fetch-1360.test.ts` locks:

1. The sample URL contains Harper `select(...)` without embedding fields
2. The sample URL contains a bounded `limit(0, sampleSize+overfetch)` — a 10-row sample cannot encode a whole-table listing
3. `fetchRecallSpotCheckData` actually GETs that URL once (not `/Memory?agentId=flint`)
4. `fetchPreviousQualitySnapshot` uses the same projection

Would fail on unmodified main, where both helpers GET `/Memory?agentId=…` with no select and no limit.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-95018aac-df77-4489-9c1e-8d4065981220?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-95018aac-df77-4489-9c1e-8d4065981220&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

