### PR TITLE
test(pi-flair): live memory_store assertions — written:true + matchedId (closes #1384)

### DIFF
--- a/packages/pi-flair/test/index.test.ts
+++ b/packages/pi-flair/test/index.test.ts
@@ -1,6 +1,7 @@
-import { describe, test, expect } from "bun:test";
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
 import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
+import { FlairClient } from "@tpsdev-ai/flair-client";
 
 /**
  * pi-flair extension tests — validates tool registration and config resolution.
@@ -14,8 +15,10 @@ import { fileURLToPath } from "node:url";
  * Integration tests require running Flair server (not unit tests).
  */
 
-// Import the real classifyError function
-import { classifyError as classifyErrorReal, DEFAULT_FLAIR_URL } from "../src/index";
+// Real exports — classifyError is already a named export; the default export
+// is the extension installer whose memory_store execute we call below
+// (flair#1384). Do not reconstruct those responses as local literals.
+import registerPiFlair, { classifyError as classifyErrorReal, DEFAULT_FLAIR_URL } from "../src/index";
 
 // ─── Config Tests ─────────────────────────────────────────────────────────────
 
@@ -226,36 +229,102 @@ describe("Dedup Detection — explicit `deduped` flag (flair#449 fix)", () => {
   });
 });
 
-// ─── Response Shape Tests ────────────────────────────────────────────────────
+// ─── Response Shape Tests (flair#1384) ───────────────────────────────────────
+//
+// The previous block constructed `result` / `response` as local literals and
+// asserted on them. It never called src/index.ts, so it could not fail, and
+// it pinned the pre-#985 `mergedWith` / implicit-not-written contract. The
+// real execute path (src/index.ts memory_store) emits
+// `{ written: true, matchedId }` — a collision SIGNAL, never a dropped write.
+//
+// These tests import the default export, register it, invoke the real
+// execute, and assert on *its* output. FlairClient.prototype.request is
+// patched so no network happens; everything above that boundary (including
+// memory.write merge + the tool's details construction) runs unmodified —
+// same isolation shape as packages/openclaw-flair/test/plugin.test.ts.
 
-describe("memory_store response shape — programmatic dedup signal", () => {
-  // The PR adds a structured `details` field so callers can react to
-  // dedup programmatically (not just parse prose). LLMs sometimes
-  // compress the prose ("Similar memory exists") into "got the ID" and
-  // miss the dedup signal — see flair#449.
+function createMockPi() {
+  const tools = new Map<string, { name: string; execute: Function }>();
+  return {
+    registerTool(spec: { name: string; execute: Function }) {
+      tools.set(spec.name, spec);
+    },
+    on() {},
+    _tools: tools,
+  };
+}
 
-  test("dedup response includes details.deduplicated=true + mergedWith", () => {
-    const result = { id: "pi-test-existing-1", deduped: true, content: "existing" };
-    const wasDeduped = (result as any).deduped === true;
-    const response = {
-      content: [{ type: "text", text: "Similar memory ..." }],
-      details: wasDeduped
-        ? { deduplicated: true, mergedWith: result.id }
-        : { deduplicated: false, id: result.id },
-    };
-    expect(response.details).toEqual({ deduplicated: true, mergedWith: "pi-test-existing-1" });
+async function executeMemoryStore(
+  writeResponse: Record<string, unknown>,
+  params: { content: string; durability?: string; tags?: string[] },
+) {
+  (FlairClient.prototype as any).request = async () => writeResponse;
+  const pi = createMockPi();
+  registerPiFlair(pi as any);
+  const tool = pi._tools.get("memory_store");
+  if (!tool) throw new Error("memory_store was not registered");
+  return tool.execute("tool-call-1", params);
+}
+
+describe("memory_store response shape — real extension (flair#1384)", () => {
+  const originalRequest = FlairClient.prototype.request;
+  const originalAgentId = process.env.FLAIR_AGENT_ID;
+
+  beforeEach(() => {
+    process.env.FLAIR_AGENT_ID = "pi-test";
   });
 
-  test("success response includes details.deduplicated=false + id", () => {
-    const result = { id: "pi-test-new-uuid", content: "new" };
-    const wasDeduped = (result as any).deduped === true;
-    const response = {
-      content: [{ type: "text", text: "Memory stored ..." }],
-      details: wasDeduped
-        ? { deduplicated: true, mergedWith: result.id }
-        : { deduplicated: false, id: result.id },
-    };
-    expect(response.details).toEqual({ deduplicated: false, id: "pi-test-new-uuid" });
+  afterEach(() => {
+    FlairClient.prototype.request = originalRequest;
+    if (originalAgentId === undefined) {
+      delete process.env.FLAIR_AGENT_ID;
+    } else {
+      process.env.FLAIR_AGENT_ID = originalAgentId;
+    }
+  });
+
+  test("dedup collision: details.written=true + matchedId, never mergedWith", async () => {
+    const result = await executeMemoryStore(
+      {
+        id: "pi-test-new-1",
+        deduplicated: true,
+        matchedId: "pi-test-existing-1",
+        written: true,
+      },
+      { content: "collision content" },
+    );
+
+    expect(result.details).toEqual({
+      deduplicated: true,
+      id: "pi-test-new-1",
+      written: true,
+      matchedId: "pi-test-existing-1",
+    });
+    expect(result.details).not.toHaveProperty("mergedWith");
+    expect(result.content[0].text).toContain("Memory stored (id: pi-test-new-1)");
+    expect(result.content[0].text).toContain("similar to existing memory (id: pi-test-existing-1)");
+    expect(result.content[0].text).toContain("both are kept");
+  });
+
+  test("fresh write: details.written=true + id, no matchedId / no mergedWith", async () => {
+    const result = await executeMemoryStore(
+      {
+        id: "pi-test-new-uuid",
+        deduplicated: false,
+        written: true,
+      },
+      { content: "new distinct content" },
+    );
+
+    expect(result.details).toEqual({
+      deduplicated: false,
+      id: "pi-test-new-uuid",
+      written: true,
+    });
+    expect(result.details).not.toHaveProperty("matchedId");
+    expect(result.details).not.toHaveProperty("mergedWith");
+    expect(result.content[0].text).toContain("Memory stored (id: pi-test-new-uuid)");
+    expect(result.content[0].text).not.toContain("similar to existing");
   });
 });
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #1384. Refs #985.

## What was wrong

`packages/pi-flair/test/index.test.ts` constructed `result` and `response` as local object literals and asserted on them. It never imported the extension from `src/index.ts`. Two consequences:

1. **It could not fail.** No source change could turn it red.
2. **It pinned the pre-#985 contract** — `mergedWith` / no `written: true`. Real `memory_store` execute (`src/index.ts`) emits `{ written: true, matchedId }` because the server's gate is a collision *signal*, never a dropped write.

## What this does

Import the default export from `src/index.ts`, register it on a mock `pi`, invoke the real `memory_store` execute, and assert on **its** output.

`FlairClient.prototype.request` is patched so no network happens — same isolation shape as `packages/openclaw-flair/test/plugin.test.ts`. Everything above that boundary (including `memory.write` merge + the tool's details construction) runs unmodified.

Asserted contract:

- collision: `{ deduplicated: true, id, written: true, matchedId }` — no `mergedWith`
- fresh write: `{ deduplicated: false, id, written: true }` — no `matchedId` / no `mergedWith`
- prose still says "both are kept" on a collision

No production source change. Test-only.

## Liveness proof

The replacement was observed failing before it was trusted.

Broke `src/index.ts` `memory_store` details back to the pre-#985 shape:

```ts
details: { deduplicated, id, written: false, ...(wasDeduplicated ? { mergedWith: matchedId } : {}) }
```

`cd packages/pi-flair && bun test` → **2 fail / 34 pass**. Both new tests red:

```
expect(received).toEqual(expected)
-   "matchedId": "pi-test-existing-1",
-   "written": true,
+   "mergedWith": "pi-test-existing-1",
+   "written": false,
```

The old decorative blocks in the same file (Dedup Detection, Search Result Formatting, …) stayed green — they still cannot see the source.

Restored `written: true` + `matchedId`. `bun test` → **36 pass / 0 fail**.

## Sibling grep (`packages/*/test/`)

Same shape: assertion subject is a literal (or a local reimplementation of source) defined in the same block. **Not fixed here — scoped to #1384.**

### Same file — `packages/pi-flair/test/index.test.ts`

| Block | Why it's decorative |
|---|---|
| Dedup Detection (`result.deduped`) | Local literals; source uses `result.deduplicated`. Pins the pre-#449/#526 client-side flag. |
| Search Result Formatting | Reimplements the `map`/`join` locally; never calls source. |
| Bootstrap Response | Asserts on `{ context: "..." }` written in the test. |
| Tool Parameters | Asserts on locally-defined schema objects, not the TypeBox specs `registerTool` uses. |
| Edge Cases / empty search | `expect("No relevant memories found.").toBe("No relevant memories found.")` — tautology. |
| Secret Filtering | Local `SECRET_PATTERNS` copy; does not import source (and `containsSecrets` is not exported). |
| Error Classification (first describe) | Local `classifyError` copy. The later #1347 describe *does* call the real export. |

### Closest package sibling — `packages/flair-mcp/test/mcp.test.ts`

The file says it on the tin: *"we test the tool logic patterns rather than importing the module directly."*

| Block | Why it's decorative |
|---|---|
| `memory_store` dedup detection | Local literals + the **old** prefix-mismatch heuristic (`!id.startsWith(agentPrefix)`). That is the #449 contract. |
| Search result formatting | Same local reimplementation as pi-flair. |
| Bootstrap response | Same local `{ context }` literals as pi-flair. |
| `structuredContent always marks written:true` | `const structuredContent = { …, written: true }; expect(structuredContent.written).toBe(true)` — cannot fail. Encodes the current contract, but still never touches source. |

### Other `packages/*/test/` suites looked live

They import and call real functions / node classes / the plugin:

- `langgraph-flair` — `parseStoredId` / `hasNamespacePrefix`
- `openclaw-flair` — `plugin.register` + tool `execute` (the pattern this PR copies)
- `flair-client` — real client, mocked `fetch`
- `n8n-nodes-flair` — instantiates real node classes
- `flair-bench` — real scorer / prefix / sync checks
- `adk-flair-js` — real service, mocked `fetch`
- other `flair-mcp` files (`version`, `presence`, `env-guard`, hooks) — import real source

No changelog fragment: test-only, not user-visible.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d0fc1ccf-7a1c-4407-86ab-c8c21c14f1e5?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d0fc1ccf-7a1c-4407-86ab-c8c21c14f1e5&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

