### PR TITLE
fix(flair-mcp): key auto-resolve via os.homedir at call time

### DIFF
--- a/.changelog/unreleased/fixed-1271-mcp-key-autoresolve.md
+++ b/.changelog/unreleased/fixed-1271-mcp-key-autoresolve.md
@@ -1,0 +1,1 @@
+- **flair-mcp key auto-resolve no longer misses a freshly-created `~/.flair/keys/<id>.key`.** Resolution calls `os.homedir()` at request time (never a cached miss, never a cwd-relative `~`), and a 401 names the agent, the paths that were looked in, and the remedy (flair#1271).

--- a/docs/quickstart-fabric.md
+++ b/docs/quickstart-fabric.md
@@ -119,7 +119,7 @@ Same connector, different panel. This is the field-verified sequence — includi
 
    Keep the pass file mode `0600`. Newer releases add `--admin-pass-file <path>`, which reads the file in-process (invisible to `ps`) — check `flair agent add --help` and prefer it when present.
 
-5. **Restart the MCP process** if it started before the key existed — it does not pick the key up mid-session. Still 401 with the key on disk? Set the key path explicitly in the agent's MCP env: `FLAIR_KEY_PATH=~/.flair/keys/grok-cos.key`. Known papercut, tracked in [flair#1271](https://github.com/tpsdev-ai/flair/issues/1271).
+5. The next tool call picks up the key — a miss is not cached. A 401 names the agent and the paths that were looked in. If those are not where `flair agent add` wrote the file, the MCP process's home differs from the shell; set `FLAIR_KEY_PATH` to the absolute path of the `.key` file.
 
 6. Verify: ask the agent to "load my Flair bootstrap". You should get soul + memories **including shared org context** — findings written by teammate agents. A shared-visibility write from this agent is now readable by every org agent.
 

--- a/packages/flair-client/src/auth.ts
+++ b/packages/flair-client/src/auth.ts
@@ -24,6 +24,13 @@ export function loadPrivateKey(path: string): KeyObject {
   return createPrivateKey({ key: der, format: "der", type: "pkcs8" });
 }
 
+/** Injectable homes so tests can diverge `$HOME` / `os.homedir()` / passwd home. */
+export interface HomeSources {
+  homedir: string;
+  envHome?: string;
+  userHomedir?: string;
+}
+
 /**
  * Homes to probe, computed at CALL TIME (flair#1271).
  *
@@ -35,12 +42,22 @@ export function loadPrivateKey(path: string): KeyObject {
  *
  * Empty / relative values are dropped: `path.resolve("")` is cwd, which is
  * exactly the footgun this function exists to refuse.
+ *
+ * `sources` is for tests: a fixture that puts the key only on `userHomedir`
+ * while `homedir`/`envHome` point at a sandbox must FAIL if the passwd-home
+ * probe is dropped.
  */
-export function callTimeHomes(): string[] {
+export function callTimeHomes(sources?: HomeSources): string[] {
   const homes: string[] = [];
   const push = (h: string | undefined) => {
     if (h && isAbsolute(h) && !homes.includes(h)) homes.push(h);
   };
+  if (sources) {
+    push(sources.homedir);
+    push(sources.envHome);
+    push(sources.userHomedir);
+    return homes;
+  }
   push(homedir());
   push(process.env.HOME);
   try {
@@ -72,8 +89,7 @@ function toAbsoluteKeyPath(p: string): string | null {
 }
 
 /** Candidate key files for `agentId`, in probe order. Deduplicated. */
-export function keyPathCandidates(agentId: string, keyPath?: string): string[] {
-  const homes = callTimeHomes();
+export function keyPathCandidates(agentId: string, keyPath?: string, homes: string[] = callTimeHomes()): string[] {
   const primaryHome = homes[0] ?? "";
 
   if (keyPath) {
@@ -97,6 +113,9 @@ export function keyPathCandidates(agentId: string, keyPath?: string): string[] {
   return [...new Set(out)];
 }
 
+/** How the request that failed was authenticated. */
+export type KeyAuthMethod = "ed25519" | "basic" | "none";
+
 /** Snapshot of a key-file lookup — attached to 401/403 so the error can name paths. */
 export interface KeyLookupState {
   agentId: string;
@@ -106,25 +125,33 @@ export interface KeyLookupState {
   resolvedPath: string | null;
   /** True when this request carried an Ed25519 Authorization header. */
   signed: boolean;
+  /** What was actually sent. Basic-auth 401s must not push FLAIR_KEY_PATH. */
+  authMethod?: KeyAuthMethod;
+}
+
+function authMethodOf(state: KeyLookupState): KeyAuthMethod {
+  if (state.authMethod) return state.authMethod;
+  return state.signed ? "ed25519" : "none";
 }
 
 /** Inspect standard key locations. Does not cache — call at request time (flair#1271). */
-export function inspectKeyLookup(agentId: string, keyPath?: string): Omit<KeyLookupState, "signed"> {
-  const candidates = keyPathCandidates(agentId, keyPath).map((path) => ({
+export function inspectKeyLookup(agentId: string, keyPath?: string, homes?: string[]): Omit<KeyLookupState, "signed" | "authMethod"> {
+  const resolvedHomes = homes ?? callTimeHomes();
+  const candidates = keyPathCandidates(agentId, keyPath, resolvedHomes).map((path) => ({
     path,
     exists: existsSync(path),
   }));
   return {
     agentId,
-    home: callTimeHomes()[0] ?? "",
+    home: resolvedHomes[0] ?? "",
     candidates,
     resolvedPath: candidates.find((c) => c.exists)?.path ?? null,
   };
 }
 
 /** Find the agent's private key file from standard locations. */
-export function resolveKeyPath(agentId: string, keyPath?: string): string | null {
-  return inspectKeyLookup(agentId, keyPath).resolvedPath;
+export function resolveKeyPath(agentId: string, keyPath?: string, homes?: string[]): string | null {
+  return inspectKeyLookup(agentId, keyPath, homes).resolvedPath;
 }
 
 /** Actor + state + remedy for a 401/403 (flair#1271). */
@@ -132,9 +159,12 @@ export function formatKeyLookup(state: KeyLookupState): string {
   const actor = state.agentId
     ? `agent '${state.agentId}'`
     : "this agent (FLAIR_AGENT_ID unset)";
-  const stateLine = state.signed
+  const method = authMethodOf(state);
+  const stateLine = method === "ed25519"
     ? `${actor} signed with ${state.resolvedPath}.`
-    : `${actor} sent this request without a signing key.`;
+    : method === "basic"
+      ? `${actor} sent this request with Basic admin credentials (FLAIR_ADMIN_USER / FLAIR_ADMIN_PASSWORD), not an Ed25519 key.`
+      : `${actor} sent this request without a signing key.`;
   const homeLine = `os.homedir() at lookup: ${state.home || "(empty — refused to fall back to cwd)"}`;
   const looked = state.candidates.length === 0
     ? "Looked for a key at: (no candidate paths — home could not be resolved)."
@@ -142,9 +172,11 @@ export function formatKeyLookup(state: KeyLookupState): string {
         "Looked for a key at:",
         ...state.candidates.map((c) => `  ${c.path} (${c.exists ? "found" : "missing"})`),
       ].join("\n");
-  const remedy = state.signed
+  const remedy = method === "ed25519"
     ? "The server rejected the signature. Confirm the agent is registered (`flair agent add <id>`) and this key matches the Agent record. A daemon restart can also produce this — check `flair status`."
-    : "If `flair agent add` wrote the key, this process's home may differ from that shell, or the file appeared after an earlier lookup. Retry the tool (misses are no longer cached). Still missing? Set FLAIR_KEY_PATH to the absolute path of the .key file.";
+    : method === "basic"
+      ? "The server rejected those admin credentials. Check FLAIR_ADMIN_USER and FLAIR_ADMIN_PASSWORD — this 401 is not a missing agent key."
+      : "If `flair agent add` wrote the key, this process's home may differ from that shell, or the file appeared after an earlier lookup. Retry the tool (misses are no longer cached). Still missing? Set FLAIR_KEY_PATH to the absolute path of the .key file.";
   return `${stateLine}\n${homeLine}\n${looked}\n${remedy}`;
 }
 

--- a/packages/flair-client/src/auth.ts
+++ b/packages/flair-client/src/auth.ts
@@ -7,8 +7,8 @@
 
 import { randomUUID, sign as ed25519Sign, createPrivateKey, type KeyObject } from "node:crypto";
 import { readFileSync, existsSync } from "node:fs";
-import { resolve } from "node:path";
-import { homedir } from "node:os";
+import { homedir, userInfo } from "node:os";
+import { isAbsolute, join, resolve } from "node:path";
 import { readEnvOrUnset } from "./env-guard.js";
 
 const PKCS8_ED25519_PREFIX = Buffer.from("302e020100300506032b657004220420", "hex");
@@ -24,22 +24,128 @@ export function loadPrivateKey(path: string): KeyObject {
   return createPrivateKey({ key: der, format: "der", type: "pkcs8" });
 }
 
-/** Find the agent's private key file from standard locations. */
-export function resolveKeyPath(agentId: string, keyPath?: string): string | null {
-  if (keyPath) {
-    const resolved = resolve(keyPath.replace(/^~/, homedir()));
-    return existsSync(resolved) ? resolved : null;
+/**
+ * Homes to probe, computed at CALL TIME (flair#1271).
+ *
+ * MCP hosts (npx under Cursor / Grok Bot / Claude Code) often have a different
+ * env than the shell that ran `flair agent add`. `os.homedir()` is the
+ * documented resolver — called here, not cached at module load — and we also
+ * keep `$HOME` and `os.userInfo().homedir` when they differ so a sanitized
+ * MCP `HOME` still finds `~/.flair/keys/<id>.key` on the real account home.
+ *
+ * Empty / relative values are dropped: `path.resolve("")` is cwd, which is
+ * exactly the footgun this function exists to refuse.
+ */
+export function callTimeHomes(): string[] {
+  const homes: string[] = [];
+  const push = (h: string | undefined) => {
+    if (h && isAbsolute(h) && !homes.includes(h)) homes.push(h);
+  };
+  push(homedir());
+  push(process.env.HOME);
+  try {
+    push(userInfo().homedir);
+  } catch {
+    // No passwd entry (some containers). Skip — do not fall back to cwd.
   }
+  return homes;
+}
+
+/** Expand a leading `~/` against `home`. Unexpanded `~` with no home is left intact. */
+export function expandHomePrefix(p: string, home: string): string {
+  if (p === "~") return home || p;
+  if ((p.startsWith("~/") || p.startsWith("~\\")) && home) {
+    return join(home, p.slice(2));
+  }
+  return p;
+}
+
+/**
+ * Make `p` absolute without turning an unexpanded `~` into a cwd-relative path.
+ * Operator-supplied relative paths (no `~`) still resolve against cwd.
+ */
+function toAbsoluteKeyPath(p: string): string | null {
+  if (!p) return null;
+  if (isAbsolute(p)) return p;
+  if (p.startsWith("~")) return null;
+  return resolve(p);
+}
+
+/** Candidate key files for `agentId`, in probe order. Deduplicated. */
+export function keyPathCandidates(agentId: string, keyPath?: string): string[] {
+  const homes = callTimeHomes();
+  const primaryHome = homes[0] ?? "";
+
+  if (keyPath) {
+    const abs = toAbsoluteKeyPath(expandHomePrefix(keyPath, primaryHome));
+    return abs ? [abs] : [];
+  }
+
+  const out: string[] = [];
   // flair#1254: an unsubstituted `${FLAIR_KEY_DIR}` literal reads as unset, so
   // key resolution falls through to the standard locations below instead of
   // probing a directory literally named "${FLAIR_KEY_DIR}".
   const keyDir = readEnvOrUnset("FLAIR_KEY_DIR");
-  const candidates = [
-    keyDir ? resolve(keyDir, `${agentId}.key`) : null,
-    resolve(homedir(), ".flair", "keys", `${agentId}.key`),
-    resolve(homedir(), ".tps", "secrets", "flair", `${agentId}-priv.key`),
-  ].filter(Boolean) as string[];
-  return candidates.find(existsSync) ?? null;
+  if (keyDir) {
+    const absDir = toAbsoluteKeyPath(expandHomePrefix(keyDir, primaryHome));
+    if (absDir) out.push(join(absDir, `${agentId}.key`));
+  }
+  for (const home of homes) {
+    out.push(join(home, ".flair", "keys", `${agentId}.key`));
+    out.push(join(home, ".tps", "secrets", "flair", `${agentId}-priv.key`));
+  }
+  return [...new Set(out)];
+}
+
+/** Snapshot of a key-file lookup — attached to 401/403 so the error can name paths. */
+export interface KeyLookupState {
+  agentId: string;
+  /** `os.homedir()` at lookup time (may be empty if it was unusable). */
+  home: string;
+  candidates: { path: string; exists: boolean }[];
+  resolvedPath: string | null;
+  /** True when this request carried an Ed25519 Authorization header. */
+  signed: boolean;
+}
+
+/** Inspect standard key locations. Does not cache — call at request time (flair#1271). */
+export function inspectKeyLookup(agentId: string, keyPath?: string): Omit<KeyLookupState, "signed"> {
+  const candidates = keyPathCandidates(agentId, keyPath).map((path) => ({
+    path,
+    exists: existsSync(path),
+  }));
+  return {
+    agentId,
+    home: callTimeHomes()[0] ?? "",
+    candidates,
+    resolvedPath: candidates.find((c) => c.exists)?.path ?? null,
+  };
+}
+
+/** Find the agent's private key file from standard locations. */
+export function resolveKeyPath(agentId: string, keyPath?: string): string | null {
+  return inspectKeyLookup(agentId, keyPath).resolvedPath;
+}
+
+/** Actor + state + remedy for a 401/403 (flair#1271). */
+export function formatKeyLookup(state: KeyLookupState): string {
+  const actor = state.agentId
+    ? `agent '${state.agentId}'`
+    : "this agent (FLAIR_AGENT_ID unset)";
+  const stateLine = state.signed
+    ? `${actor} signed with ${state.resolvedPath}.`
+    : `${actor} sent this request without a signing key.`;
+  const homeLine = `os.homedir() at lookup: ${state.home || "(empty — refused to fall back to cwd)"}`;
+  const looked = state.candidates.length === 0
+    ? "Looked for a key at: (no candidate paths — home could not be resolved)."
+    : [
+        "Looked for a key at:",
+        ...state.candidates.map((c) => `  ${c.path} (${c.exists ? "found" : "missing"})`),
+      ].join("\n");
+  const remedy = state.signed
+    ? "The server rejected the signature. Confirm the agent is registered (`flair agent add <id>`) and this key matches the Agent record. A daemon restart can also produce this — check `flair status`."
+    : "If `flair agent add` wrote the key, this process's home may differ from that shell, or the file appeared after an earlier lookup. Retry the tool (misses are no longer cached). Still missing? Set FLAIR_KEY_PATH to the absolute path of the .key file.";
+  return `${stateLine}\n${homeLine}\n${looked}\n${remedy}`;
 }
 
 /** Build an Authorization header for a Flair request. */

--- a/packages/flair-client/src/auth.ts
+++ b/packages/flair-client/src/auth.ts
@@ -160,11 +160,15 @@ export function formatKeyLookup(state: KeyLookupState): string {
     ? `agent '${state.agentId}'`
     : "this agent (FLAIR_AGENT_ID unset)";
   const method = authMethodOf(state);
+  if (method === "basic") {
+    return (
+      `${actor} sent this request with Basic admin credentials (FLAIR_ADMIN_USER / FLAIR_ADMIN_PASSWORD), not an Ed25519 key.\n` +
+      "The server rejected those admin credentials. Check FLAIR_ADMIN_USER and FLAIR_ADMIN_PASSWORD — this 401 is not a missing agent key."
+    );
+  }
   const stateLine = method === "ed25519"
     ? `${actor} signed with ${state.resolvedPath}.`
-    : method === "basic"
-      ? `${actor} sent this request with Basic admin credentials (FLAIR_ADMIN_USER / FLAIR_ADMIN_PASSWORD), not an Ed25519 key.`
-      : `${actor} sent this request without a signing key.`;
+    : `${actor} sent this request without a signing key.`;
   const homeLine = `os.homedir() at lookup: ${state.home || "(empty — refused to fall back to cwd)"}`;
   const looked = state.candidates.length === 0
     ? "Looked for a key at: (no candidate paths — home could not be resolved)."
@@ -174,9 +178,7 @@ export function formatKeyLookup(state: KeyLookupState): string {
       ].join("\n");
   const remedy = method === "ed25519"
     ? "The server rejected the signature. Confirm the agent is registered (`flair agent add <id>`) and this key matches the Agent record. A daemon restart can also produce this — check `flair status`."
-    : method === "basic"
-      ? "The server rejected those admin credentials. Check FLAIR_ADMIN_USER and FLAIR_ADMIN_PASSWORD — this 401 is not a missing agent key."
-      : "If `flair agent add` wrote the key, this process's home may differ from that shell, or the file appeared after an earlier lookup. Retry the tool (misses are no longer cached). Still missing? Set FLAIR_KEY_PATH to the absolute path of the .key file.";
+    : "If `flair agent add` wrote the key, this process's home may differ from that shell, or the file appeared after an earlier lookup. Retry the tool (misses are no longer cached). Still missing? Set FLAIR_KEY_PATH to the absolute path of the .key file.";
   return `${stateLine}\n${homeLine}\n${looked}\n${remedy}`;
 }
 

--- a/packages/flair-client/src/client.ts
+++ b/packages/flair-client/src/client.ts
@@ -90,6 +90,7 @@ export class FlairClient {
         candidates: [],
         resolvedPath: "(in-memory)",
         signed: true,
+        authMethod: "ed25519",
       };
       return this.privateKey;
     }
@@ -101,7 +102,11 @@ export class FlairClient {
       // Silent fallback to unauthenticated would be a security risk.
       this.privateKey = loadPrivateKey(lookup.resolvedPath);
     }
-    this.lastKeyLookup = { ...lookup, signed: this.privateKey != null };
+    this.lastKeyLookup = {
+      ...lookup,
+      signed: this.privateKey != null,
+      authMethod: this.privateKey ? "ed25519" : "none",
+    };
     return this.privateKey;
   }
 
@@ -113,6 +118,17 @@ export class FlairClient {
       headers["Authorization"] = signRequest(this.agentId, key, method, path);
     } else if (this.basicAuth) {
       headers["Authorization"] = this.basicAuth;
+      this.lastKeyLookup = {
+        ...(this.lastKeyLookup ?? {
+          agentId: this.agentId,
+          home: "",
+          candidates: [],
+          resolvedPath: null,
+          signed: false,
+        }),
+        signed: false,
+        authMethod: "basic",
+      };
     }
     const res = await fetch(`${this.url}${path}`, {
       method,

--- a/packages/flair-client/src/client.ts
+++ b/packages/flair-client/src/client.ts
@@ -118,14 +118,13 @@ export class FlairClient {
       headers["Authorization"] = signRequest(this.agentId, key, method, path);
     } else if (this.basicAuth) {
       headers["Authorization"] = this.basicAuth;
+      // Basic-only snapshot — do not spread a prior inspectKeyLookup result.
+      // A 401 here is about admin credentials, not key-file paths (review on #1390).
       this.lastKeyLookup = {
-        ...(this.lastKeyLookup ?? {
-          agentId: this.agentId,
-          home: "",
-          candidates: [],
-          resolvedPath: null,
-          signed: false,
-        }),
+        agentId: this.agentId,
+        home: "",
+        candidates: [],
+        resolvedPath: null,
         signed: false,
         authMethod: "basic",
       };

--- a/packages/flair-client/src/client.ts
+++ b/packages/flair-client/src/client.ts
@@ -10,7 +10,7 @@
 
 import type { KeyObject } from "node:crypto";
 import { createHash, createPrivateKey } from "node:crypto";
-import { loadPrivateKey, resolveKeyPath, signRequest } from "./auth.js";
+import { inspectKeyLookup, loadPrivateKey, signRequest, type KeyLookupState } from "./auth.js";
 import { readEnvOrUnset } from "./env-guard.js";
 import type {
   FlairClientConfig,
@@ -39,9 +39,10 @@ export class FlairClient {
   readonly claimedClient: string | undefined;
 
   private privateKey: KeyObject | null = null;
-  private keyResolved = false;
   private keyPath: string | undefined;
   private rawPrivateKey: string | KeyObject | undefined;
+  /** Last file-key lookup — attached to 401/403 so the error can name paths (flair#1271). */
+  private lastKeyLookup: KeyLookupState | undefined;
   private timeoutMs: number;
   private basicAuth: string | null = null;
 
@@ -71,8 +72,11 @@ export class FlairClient {
   }
 
   private resolveKey(): KeyObject | null {
-    if (this.keyResolved) return this.privateKey;
-    this.keyResolved = true;
+    // Cache a FOUND key only. A miss must be retried on the next request —
+    // flair#1271: `flair agent add` can write ~/.flair/keys/<id>.key after
+    // this client was constructed (or after an earlier probe), and a cached
+    // null left flair-mcp 401ing until FLAIR_KEY_PATH was set by hand.
+    if (this.privateKey) return this.privateKey;
     // In-memory key takes priority over file-based resolution.
     if (this.rawPrivateKey) {
       if (typeof this.rawPrivateKey === "string") {
@@ -80,14 +84,24 @@ export class FlairClient {
       } else {
         this.privateKey = this.rawPrivateKey;
       }
+      this.lastKeyLookup = {
+        agentId: this.agentId,
+        home: "",
+        candidates: [],
+        resolvedPath: "(in-memory)",
+        signed: true,
+      };
       return this.privateKey;
     }
-    const path = resolveKeyPath(this.agentId, this.keyPath);
-    if (path) {
+    // inspectKeyLookup calls os.homedir() at this moment — not a module-load
+    // snapshot, not cwd (flair#1271).
+    const lookup = inspectKeyLookup(this.agentId, this.keyPath);
+    if (lookup.resolvedPath) {
       // Key file exists — failure to parse is a hard error.
       // Silent fallback to unauthenticated would be a security risk.
-      this.privateKey = loadPrivateKey(path);
+      this.privateKey = loadPrivateKey(lookup.resolvedPath);
     }
+    this.lastKeyLookup = { ...lookup, signed: this.privateKey != null };
     return this.privateKey;
   }
 
@@ -108,7 +122,7 @@ export class FlairClient {
     });
     if (!res.ok) {
       const text = await res.text().catch(() => "");
-      throw new FlairError(method, path, res.status, text.slice(0, 500));
+      throw new FlairError(method, path, res.status, text.slice(0, 500), this.lastKeyLookup);
     }
     const text = await res.text();
     return text ? JSON.parse(text) : ({} as T);
@@ -543,6 +557,8 @@ export class FlairError extends Error {
     public readonly path: string,
     public readonly status: number,
     public readonly body: string,
+    /** Key-file lookup at the request that failed — named on 401/403 (flair#1271). */
+    public readonly keyLookup?: KeyLookupState,
   ) {
     super(`Flair ${method} ${path} → ${status}: ${body}`);
     this.name = "FlairError";

--- a/packages/flair-client/src/index.ts
+++ b/packages/flair-client/src/index.ts
@@ -9,7 +9,7 @@ export {
   callTimeHomes,
   expandHomePrefix,
 } from "./auth.js";
-export type { KeyLookupState } from "./auth.js";
+export type { KeyLookupState, KeyAuthMethod, HomeSources } from "./auth.js";
 export type {
   FlairClientConfig,
   Memory,

--- a/packages/flair-client/src/index.ts
+++ b/packages/flair-client/src/index.ts
@@ -1,5 +1,15 @@
 export { FlairClient, FlairError, canonicalRelationshipId } from "./client.js";
-export { loadPrivateKey, resolveKeyPath, signRequest } from "./auth.js";
+export {
+  loadPrivateKey,
+  resolveKeyPath,
+  signRequest,
+  inspectKeyLookup,
+  formatKeyLookup,
+  keyPathCandidates,
+  callTimeHomes,
+  expandHomePrefix,
+} from "./auth.js";
+export type { KeyLookupState } from "./auth.js";
 export type {
   FlairClientConfig,
   Memory,

--- a/packages/flair-client/test/client.test.ts
+++ b/packages/flair-client/test/client.test.ts
@@ -940,15 +940,20 @@ describe("privateKey config option", () => {
     resolveKeyPathSpy.mockRestore();
     loadPrivateKeySpy.mockRestore();
 
-    const resolveSpy = spyOn(authMod, "resolveKeyPath").mockImplementation(() => null);
+    const inspectSpy = spyOn(authMod, "inspectKeyLookup").mockImplementation(() => ({
+      agentId: "test",
+      home: "/tmp",
+      candidates: [],
+      resolvedPath: null,
+    }));
 
     const client = new FlairClient({ agentId: "test" });
     await client.health();
 
-    // resolveKeyPath SHOULD be called (no privateKey → file fallback)
-    expect(resolveSpy).toHaveBeenCalledTimes(1);
-    expect(resolveSpy).toHaveBeenCalledWith("test", undefined);
+    // inspectKeyLookup SHOULD be called (no privateKey → file fallback)
+    expect(inspectSpy).toHaveBeenCalledTimes(1);
+    expect(inspectSpy).toHaveBeenCalledWith("test", undefined);
 
-    resolveSpy.mockRestore();
+    inspectSpy.mockRestore();
   });
 });

--- a/packages/flair-client/test/key-resolve.test.ts
+++ b/packages/flair-client/test/key-resolve.test.ts
@@ -1,0 +1,187 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { randomBytes } from "node:crypto";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir, homedir } from "node:os";
+import { join } from "node:path";
+
+const { FlairClient, FlairError } = await import("../src/client.js");
+const {
+  expandHomePrefix,
+  formatKeyLookup,
+  inspectKeyLookup,
+  keyPathCandidates,
+  resolveKeyPath,
+} = await import("../src/auth.js");
+
+function uniqueId(label: string): string {
+  return `flair-1271-${label}-${randomBytes(4).toString("hex")}`;
+}
+
+describe("key path resolution (flair#1271)", () => {
+  const savedKeyDir = process.env.FLAIR_KEY_DIR;
+  const savedKeyPath = process.env.FLAIR_KEY_PATH;
+  let trash: string[] = [];
+
+  beforeEach(() => {
+    delete process.env.FLAIR_KEY_DIR;
+    delete process.env.FLAIR_KEY_PATH;
+    trash = [];
+  });
+
+  afterEach(() => {
+    if (savedKeyDir === undefined) delete process.env.FLAIR_KEY_DIR;
+    else process.env.FLAIR_KEY_DIR = savedKeyDir;
+    if (savedKeyPath === undefined) delete process.env.FLAIR_KEY_PATH;
+    else process.env.FLAIR_KEY_PATH = savedKeyPath;
+    for (const p of trash) rmSync(p, { recursive: true, force: true });
+  });
+
+  test("expandHomePrefix uses the provided home, not cwd", () => {
+    expect(expandHomePrefix("~/.flair/keys/x.key", "/home/agent")).toBe(
+      "/home/agent/.flair/keys/x.key",
+    );
+    expect(expandHomePrefix("~", "/home/agent")).toBe("/home/agent");
+    expect(expandHomePrefix("/abs/x.key", "/home/agent")).toBe("/abs/x.key");
+  });
+
+  test("FLAIR_KEY_DIR=~/... resolves via os.homedir at call time, not cwd", () => {
+    const agentId = uniqueId("tilde");
+    const rel = `.flair-1271-tilde-${randomBytes(4).toString("hex")}`;
+    const homeDir = join(homedir(), rel);
+    mkdirSync(homeDir, { recursive: true });
+    trash.push(homeDir);
+    const homeKey = join(homeDir, `${agentId}.key`);
+    writeFileSync(homeKey, randomBytes(32));
+
+    const cwdRoot = mkdtempSync(join(tmpdir(), "flair-1271-cwd-"));
+    trash.push(cwdRoot);
+    const decoyDir = join(cwdRoot, "~", rel);
+    mkdirSync(decoyDir, { recursive: true });
+    writeFileSync(join(decoyDir, `${agentId}.key`), Buffer.from("decoy-not-the-home-key"));
+
+    const savedCwd = process.cwd();
+    try {
+      process.chdir(cwdRoot);
+      process.env.FLAIR_KEY_DIR = `~/${rel}`;
+      const found = resolveKeyPath(agentId);
+      expect(found).toBe(homeKey);
+      expect(found).not.toContain(cwdRoot);
+    } finally {
+      process.chdir(savedCwd);
+    }
+  });
+
+  test("keyPathCandidates for auto-resolve are absolute (never cwd-relative ~)", () => {
+    const agentId = uniqueId("abs");
+    const candidates = keyPathCandidates(agentId);
+    expect(candidates.length).toBeGreaterThan(0);
+    for (const p of candidates) {
+      expect(p.startsWith("/")).toBe(true);
+      expect(p.includes("/~/") || p.startsWith("~/")).toBe(false);
+    }
+    expect(candidates.some((p) => p.endsWith(`/.flair/keys/${agentId}.key`))).toBe(true);
+  });
+
+  test("inspectKeyLookup names every candidate and whether it exists", () => {
+    const agentId = uniqueId("inspect");
+    const dir = mkdtempSync(join(tmpdir(), "flair-1271-inspect-"));
+    trash.push(dir);
+    process.env.FLAIR_KEY_DIR = dir;
+    const snapshot = inspectKeyLookup(agentId);
+    expect(snapshot.agentId).toBe(agentId);
+    expect(snapshot.resolvedPath).toBeNull();
+    expect(snapshot.candidates.some((c) => c.path === join(dir, `${agentId}.key`) && !c.exists)).toBe(true);
+    expect(snapshot.home).toBeTruthy();
+  });
+});
+
+describe("missed freshly-created key (flair#1271)", () => {
+  const originalFetch = globalThis.fetch;
+  const savedKeyDir = process.env.FLAIR_KEY_DIR;
+  let mockFetch: ReturnType<typeof mock>;
+  let dir: string;
+
+  beforeEach(() => {
+    mockFetch = mock(() => Promise.resolve(new Response("{}", { status: 200 })));
+    globalThis.fetch = mockFetch as typeof fetch;
+    dir = mkdtempSync(join(tmpdir(), "flair-1271-fresh-"));
+    process.env.FLAIR_KEY_DIR = dir;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    if (savedKeyDir === undefined) delete process.env.FLAIR_KEY_DIR;
+    else process.env.FLAIR_KEY_DIR = savedKeyDir;
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("a key written after the first miss is picked up on the next request", async () => {
+    const agentId = uniqueId("fresh");
+    const client = new FlairClient({ agentId });
+
+    await client.health();
+    const firstHeaders = (mockFetch as any).mock.calls[0][1].headers as Record<string, string>;
+    expect(firstHeaders.Authorization).toBeUndefined();
+
+    writeFileSync(join(dir, `${agentId}.key`), randomBytes(32));
+
+    await client.health();
+    const secondHeaders = (mockFetch as any).mock.calls[1][1].headers as Record<string, string>;
+    expect(secondHeaders.Authorization).toStartWith("TPS-Ed25519 ");
+    expect(secondHeaders.Authorization).toContain(agentId);
+  });
+
+  test("401 attaches the paths that were looked in", async () => {
+    const agentId = uniqueId("401");
+    mockFetch = mock(() => Promise.resolve(new Response("unauthorized", { status: 401 })));
+    globalThis.fetch = mockFetch as typeof fetch;
+
+    const client = new FlairClient({ agentId });
+    let caught: unknown;
+    try {
+      await client.health();
+    } catch (e) {
+      caught = e;
+    }
+    expect(caught).toBeInstanceOf(FlairError);
+    const err = caught as InstanceType<typeof FlairError>;
+    expect(err.status).toBe(401);
+    expect(err.keyLookup).toBeDefined();
+    expect(err.keyLookup!.agentId).toBe(agentId);
+    expect(err.keyLookup!.signed).toBe(false);
+    expect(err.keyLookup!.candidates.some((c) => c.path.endsWith(`${agentId}.key`))).toBe(true);
+  });
+});
+
+describe("formatKeyLookup (flair#1271)", () => {
+  test("unsigned 401 names actor, missing paths, and the FLAIR_KEY_PATH remedy", () => {
+    const text = formatKeyLookup({
+      agentId: "grok-cos",
+      home: "/home/agent",
+      candidates: [
+        { path: "/home/agent/.flair/keys/grok-cos.key", exists: false },
+        { path: "/home/agent/.tps/secrets/flair/grok-cos-priv.key", exists: false },
+      ],
+      resolvedPath: null,
+      signed: false,
+    });
+    expect(text).toContain("agent 'grok-cos'");
+    expect(text).toContain("without a signing key");
+    expect(text).toContain("/home/agent/.flair/keys/grok-cos.key (missing)");
+    expect(text).toContain("os.homedir() at lookup: /home/agent");
+    expect(text).toContain("FLAIR_KEY_PATH");
+  });
+
+  test("signed 401 names the path that was used", () => {
+    const text = formatKeyLookup({
+      agentId: "grok-cos",
+      home: "/home/agent",
+      candidates: [{ path: "/home/agent/.flair/keys/grok-cos.key", exists: true }],
+      resolvedPath: "/home/agent/.flair/keys/grok-cos.key",
+      signed: true,
+    });
+    expect(text).toContain("signed with /home/agent/.flair/keys/grok-cos.key");
+    expect(text).toContain("(found)");
+    expect(text).toContain("flair agent add");
+  });
+});

--- a/packages/flair-client/test/key-resolve.test.ts
+++ b/packages/flair-client/test/key-resolve.test.ts
@@ -6,6 +6,7 @@ import { join } from "node:path";
 
 const { FlairClient, FlairError } = await import("../src/client.js");
 const {
+  callTimeHomes,
   expandHomePrefix,
   formatKeyLookup,
   inspectKeyLookup,
@@ -82,6 +83,49 @@ describe("key path resolution (flair#1271)", () => {
     expect(candidates.some((p) => p.endsWith(`/.flair/keys/${agentId}.key`))).toBe(true);
   });
 
+  test("callTimeHomes merges passwd home when it diverges from os.homedir / $HOME", () => {
+    // Sanitized-MCP-HOME fixture: sandbox is what os.homedir()/$HOME would
+    // report; the key lives on the account home. Dropping the userHomedir
+    // probe makes before/after this fix look the same — so this must fail
+    // if that probe is removed.
+    expect(callTimeHomes({
+      homedir: "/var/mcp/sandbox",
+      envHome: "/var/mcp/sandbox",
+      userHomedir: "/home/agent",
+    })).toEqual(["/var/mcp/sandbox", "/home/agent"]);
+  });
+
+  test("resolveKeyPath finds a key only on the passwd home, not the MCP sandbox home", () => {
+    const agentId = uniqueId("althome");
+    const sandbox = mkdtempSync(join(tmpdir(), "flair-1271-sandbox-"));
+    const account = mkdtempSync(join(tmpdir(), "flair-1271-account-"));
+    trash.push(sandbox, account);
+    mkdirSync(join(account, ".flair", "keys"), { recursive: true });
+    const accountKey = join(account, ".flair", "keys", `${agentId}.key`);
+    writeFileSync(accountKey, randomBytes(32));
+    const found = resolveKeyPath(agentId, undefined, [sandbox, account]);
+    expect(found).toBe(accountKey);
+    expect(resolveKeyPath(agentId, undefined, [sandbox])).toBeNull();
+  });
+
+  test("$HOME is probed even when os.homedir() is a different path (Bun caches homedir)", () => {
+    const agentId = uniqueId("envhome");
+    const envHome = mkdtempSync(join(tmpdir(), "flair-1271-envhome-"));
+    trash.push(envHome);
+    mkdirSync(join(envHome, ".flair", "keys"), { recursive: true });
+    const envKey = join(envHome, ".flair", "keys", `${agentId}.key`);
+    writeFileSync(envKey, randomBytes(32));
+    const savedHome = process.env.HOME;
+    try {
+      process.env.HOME = envHome;
+      expect(callTimeHomes()).toContain(envHome);
+      expect(resolveKeyPath(agentId)).toBe(envKey);
+    } finally {
+      if (savedHome === undefined) delete process.env.HOME;
+      else process.env.HOME = savedHome;
+    }
+  });
+
   test("inspectKeyLookup names every candidate and whether it exists", () => {
     const agentId = uniqueId("inspect");
     const dir = mkdtempSync(join(tmpdir(), "flair-1271-inspect-"));
@@ -149,7 +193,34 @@ describe("missed freshly-created key (flair#1271)", () => {
     expect(err.keyLookup).toBeDefined();
     expect(err.keyLookup!.agentId).toBe(agentId);
     expect(err.keyLookup!.signed).toBe(false);
+    expect(err.keyLookup!.authMethod).toBe("none");
     expect(err.keyLookup!.candidates.some((c) => c.path.endsWith(`${agentId}.key`))).toBe(true);
+  });
+
+  test("401 after Basic auth does not push FLAIR_KEY_PATH", async () => {
+    const agentId = uniqueId("basic");
+    mockFetch = mock(() => Promise.resolve(new Response("unauthorized", { status: 401 })));
+    globalThis.fetch = mockFetch as typeof fetch;
+
+    const client = new FlairClient({
+      agentId,
+      adminUser: "admin",
+      adminPassword: "s3cret",
+    });
+    let caught: unknown;
+    try {
+      await client.health();
+    } catch (e) {
+      caught = e;
+    }
+    expect(caught).toBeInstanceOf(FlairError);
+    const err = caught as InstanceType<typeof FlairError>;
+    expect(err.keyLookup!.authMethod).toBe("basic");
+    expect(err.keyLookup!.signed).toBe(false);
+    const text = formatKeyLookup(err.keyLookup!);
+    expect(text).toContain("Basic admin credentials");
+    expect(text).toContain("FLAIR_ADMIN_PASSWORD");
+    expect(text).not.toContain("FLAIR_KEY_PATH");
   });
 });
 
@@ -170,6 +241,22 @@ describe("formatKeyLookup (flair#1271)", () => {
     expect(text).toContain("/home/agent/.flair/keys/grok-cos.key (missing)");
     expect(text).toContain("os.homedir() at lookup: /home/agent");
     expect(text).toContain("FLAIR_KEY_PATH");
+  });
+
+  test("basic-auth 401 names admin credentials, not FLAIR_KEY_PATH", () => {
+    const text = formatKeyLookup({
+      agentId: "grok-cos",
+      home: "/home/agent",
+      candidates: [{ path: "/home/agent/.flair/keys/grok-cos.key", exists: false }],
+      resolvedPath: null,
+      signed: false,
+      authMethod: "basic",
+    });
+    expect(text).toContain("Basic admin credentials");
+    expect(text).toContain("FLAIR_ADMIN_USER");
+    expect(text).toContain("FLAIR_ADMIN_PASSWORD");
+    expect(text).not.toContain("FLAIR_KEY_PATH");
+    expect(text).not.toContain("without a signing key");
   });
 
   test("signed 401 names the path that was used", () => {

--- a/packages/flair-client/test/key-resolve.test.ts
+++ b/packages/flair-client/test/key-resolve.test.ts
@@ -217,10 +217,16 @@ describe("missed freshly-created key (flair#1271)", () => {
     const err = caught as InstanceType<typeof FlairError>;
     expect(err.keyLookup!.authMethod).toBe("basic");
     expect(err.keyLookup!.signed).toBe(false);
+    expect(err.keyLookup!.candidates).toEqual([]);
+    expect(err.keyLookup!.home).toBe("");
+    expect(err.keyLookup!.resolvedPath).toBeNull();
     const text = formatKeyLookup(err.keyLookup!);
     expect(text).toContain("Basic admin credentials");
     expect(text).toContain("FLAIR_ADMIN_PASSWORD");
+    expect(text).not.toContain("Looked for a key at");
+    expect(text).not.toContain(".key");
     expect(text).not.toContain("FLAIR_KEY_PATH");
+    expect(text).not.toContain("os.homedir()");
   });
 });
 
@@ -252,10 +258,14 @@ describe("formatKeyLookup (flair#1271)", () => {
       signed: false,
       authMethod: "basic",
     });
+    expect(text).toContain("agent 'grok-cos'");
     expect(text).toContain("Basic admin credentials");
     expect(text).toContain("FLAIR_ADMIN_USER");
     expect(text).toContain("FLAIR_ADMIN_PASSWORD");
+    expect(text).not.toContain("Looked for a key at");
+    expect(text).not.toContain(".key");
     expect(text).not.toContain("FLAIR_KEY_PATH");
+    expect(text).not.toContain("os.homedir()");
     expect(text).not.toContain("without a signing key");
   });
 

--- a/packages/flair-mcp/src/index.ts
+++ b/packages/flair-mcp/src/index.ts
@@ -42,7 +42,7 @@
 
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
-import { FlairClient, FlairError } from "@tpsdev-ai/flair-client";
+import { FlairClient, FlairError, formatKeyLookup, inspectKeyLookup } from "@tpsdev-ai/flair-client";
 import { z } from "zod";
 import {
   deriveActivity,
@@ -57,19 +57,21 @@ import { serverInfo } from "./version.js";
 
 // ─── Error helpers ──────────────────────────────────────────────────────────
 
-function classifyError(err: unknown, flairUrl: string): string {
+export function classifyError(err: unknown, flairUrl: string): string {
   if (err instanceof FlairError) {
     const { status, body } = err;
     if (status === 400) return `validation_error: ${body}`;
     if (status === 401 || status === 403) {
-      // Auth failure on a previously-working session usually means the daemon
-      // restarted (config reload, Harper alter_user, port change). Tell the
-      // operator how to recover instead of just surfacing the raw 401 body.
-      return `auth_error: ${body}\n` +
-        `(Hint: this often follows a Flair daemon restart. Try:\n` +
-        `  1. Restart your MCP host (Claude Code, Cursor, etc) to spawn a fresh flair-mcp.\n` +
-        `  2. Check daemon: 'flair status' or 'curl ${flairUrl}/Health'.\n` +
-        `  3. Verify your agent key still matches the registered Agent record.)`;
+      // flair#1271: name the agent, the paths that were looked in, and the
+      // remedy. A cached-miss / wrong-HOME 401 is not a daemon-restart hint.
+      const lookup = err.keyLookup ?? {
+        ...inspectKeyLookup(
+          readEnvOrUnset("FLAIR_AGENT_ID") ?? "",
+          readEnvOrUnset("FLAIR_KEY_PATH"),
+        ),
+        signed: false,
+      };
+      return `auth_error: ${body}\n${formatKeyLookup(lookup)}`;
     }
     if (status === 413) return `payload_too_large: ${body}`;
     if (status === 429) return "rate_limited — retry after a moment";

--- a/packages/flair-mcp/src/index.ts
+++ b/packages/flair-mcp/src/index.ts
@@ -70,6 +70,7 @@ export function classifyError(err: unknown, flairUrl: string): string {
           readEnvOrUnset("FLAIR_KEY_PATH"),
         ),
         signed: false,
+        authMethod: "none" as const,
       };
       return `auth_error: ${body}\n${formatKeyLookup(lookup)}`;
     }

--- a/packages/flair-mcp/test/auth-error.test.ts
+++ b/packages/flair-mcp/test/auth-error.test.ts
@@ -28,6 +28,22 @@ describe("classifyError 401 names key lookup (flair#1271)", () => {
     expect(text).not.toContain("this often follows a Flair daemon restart");
   });
 
+  test("basic-auth 401 names admin credentials, not FLAIR_KEY_PATH", () => {
+    const lookup = {
+      agentId: "grok-cos",
+      home: "/home/agent",
+      candidates: [{ path: "/home/agent/.flair/keys/grok-cos.key", exists: false }],
+      resolvedPath: null,
+      signed: false as const,
+      authMethod: "basic" as const,
+    };
+    const err = new FlairError("POST", "/BootstrapMemories", 401, "unauthorized", lookup);
+    const text = classifyError(err, "https://hub.example.com");
+    expect(text).toContain("Basic admin credentials");
+    expect(text).toContain("FLAIR_ADMIN_PASSWORD");
+    expect(text).not.toContain("FLAIR_KEY_PATH");
+  });
+
   test("signed 401 names the key file that was used", () => {
     const lookup = {
       agentId: "grok-cos",

--- a/packages/flair-mcp/test/auth-error.test.ts
+++ b/packages/flair-mcp/test/auth-error.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, test } from "bun:test";
+import { FlairError, formatKeyLookup } from "@tpsdev-ai/flair-client";
+import { classifyError } from "../src/index.ts";
+
+/**
+ * flair#1271 — a 401 must name the agent, the paths that were looked in,
+ * and the remedy. The daemon-restart hint is the WRONG first guess when
+ * auto-resolve missed a key that is sitting on disk.
+ */
+describe("classifyError 401 names key lookup (flair#1271)", () => {
+  test("unsigned 401 includes actor, looked-in paths, and FLAIR_KEY_PATH remedy", () => {
+    const lookup = {
+      agentId: "grok-cos",
+      home: "/home/agent",
+      candidates: [
+        { path: "/home/agent/.flair/keys/grok-cos.key", exists: false },
+      ],
+      resolvedPath: null,
+      signed: false,
+    };
+    const err = new FlairError("POST", "/BootstrapMemories", 401, "unauthorized", lookup);
+    const text = classifyError(err, "https://hub.example.com");
+    expect(text).toStartWith("auth_error: unauthorized");
+    expect(text).toContain(formatKeyLookup(lookup));
+    expect(text).toContain("agent 'grok-cos'");
+    expect(text).toContain("/home/agent/.flair/keys/grok-cos.key (missing)");
+    expect(text).toContain("FLAIR_KEY_PATH");
+    expect(text).not.toContain("this often follows a Flair daemon restart");
+  });
+
+  test("signed 401 names the key file that was used", () => {
+    const lookup = {
+      agentId: "grok-cos",
+      home: "/home/agent",
+      candidates: [{ path: "/home/agent/.flair/keys/grok-cos.key", exists: true }],
+      resolvedPath: "/home/agent/.flair/keys/grok-cos.key",
+      signed: true,
+    };
+    const err = new FlairError("GET", "/Health", 401, "invalid_signature", lookup);
+    const text = classifyError(err, "http://127.0.0.1:19926");
+    expect(text).toContain("auth_error: invalid_signature");
+    expect(text).toContain("signed with /home/agent/.flair/keys/grok-cos.key");
+  });
+});

--- a/packages/flair-mcp/test/auth-error.test.ts
+++ b/packages/flair-mcp/test/auth-error.test.ts
@@ -31,8 +31,8 @@ describe("classifyError 401 names key lookup (flair#1271)", () => {
   test("basic-auth 401 names admin credentials, not FLAIR_KEY_PATH", () => {
     const lookup = {
       agentId: "grok-cos",
-      home: "/home/agent",
-      candidates: [{ path: "/home/agent/.flair/keys/grok-cos.key", exists: false }],
+      home: "",
+      candidates: [] as { path: string; exists: boolean }[],
       resolvedPath: null,
       signed: false as const,
       authMethod: "basic" as const,
@@ -41,7 +41,10 @@ describe("classifyError 401 names key lookup (flair#1271)", () => {
     const text = classifyError(err, "https://hub.example.com");
     expect(text).toContain("Basic admin credentials");
     expect(text).toContain("FLAIR_ADMIN_PASSWORD");
+    expect(text).not.toContain("Looked for a key at");
+    expect(text).not.toContain(".key");
     expect(text).not.toContain("FLAIR_KEY_PATH");
+    expect(text).not.toContain("os.homedir()");
   });
 
   test("signed 401 names the key file that was used", () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #1271.

## Problem

After `flair agent add` wrote `~/.flair/keys/<id>.key`, the CLI could sign but flair-mcp kept 401ing until `FLAIR_KEY_PATH` was set. Auto-resolve missed the fresh key even after an MCP restart. The plugin and docs promise auto-resolve on the npx host.

## Hypotheses

| Hypothesis | Verdict |
|---|---|
| HOME differs for MCP vs the shell that ran `agent add` | Plausible for the post-restart miss. Node's `os.homedir()` follows `$HOME`; a sanitized MCP env looks in the wrong tree. Explicit absolute `FLAIR_KEY_PATH` is what unblocked the field case. |
| cwd-relative resolution | **Confirmed footgun.** `path.resolve(homedir(), …)` becomes cwd if `homedir()` is empty (`HOME=""`). `FLAIR_KEY_DIR=~/.flair/keys` was not tilde-expanded (only an explicit `keyPath` was), so `resolve("~/.flair/keys", …)` is `{cwd}/~/.flair/keys/…`. |
| Stale key-dir cache | **Confirmed.** `FlairClient.resolveKey()` set `keyResolved = true` on the first miss and never retried. Matches the documented "restart if the process started before the key existed" papercut. Restart should have cleared it; the remaining post-restart 401 is the HOME/cwd class. |

## Fix

Smallest honest change, in `@tpsdev-ai/flair-client` (what flair-mcp actually calls):

1. Resolve via `os.homedir()` at **call time**. Also probe `$HOME` and `os.userInfo().homedir` when they differ, so a sanitized MCP `HOME` still finds the account home. Never treat an empty home as cwd. Expand `~` on `FLAIR_KEY_DIR` the same way as `FLAIR_KEY_PATH`.
2. Cache a **found** key only. A miss is retried on the next request — the file `agent add` just wrote is picked up without a restart or an explicit path.
3. A 401/403 names the actor (`agent '<id>'`), the paths that were looked in (found/missing), `os.homedir()` at lookup, and the remedy (`FLAIR_KEY_PATH` to the absolute `.key` file, or confirm registration if a key was used).

## Tests

No live cluster. `packages/flair-client/test/key-resolve.test.ts` locks the missed-fresh-key case (first request unsigned, write key, second request signed), tilde-not-cwd, and 401 path attachment. `packages/flair-mcp/test/auth-error.test.ts` locks the 401 text.

The Fabric quickstart no longer documents the restart + explicit-path papercut as current behavior.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3766d2bb-ce70-474a-a891-b858859386d6?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3766d2bb-ce70-474a-a891-b858859386d6&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

