### PR TITLE
fix(hook): pin SessionStart npx spec to the CLI version

### DIFF
--- a/.changelog/unreleased/security-1143-session-start-hook-pin.md
+++ b/.changelog/unreleased/security-1143-session-start-hook-pin.md
@@ -2,4 +2,4 @@
 
   This is the #907 supply-chain posture applied to the other user-local npx path — the same package, every session. Public plugin `mcp.json` stays unpinned (flair#1308) so directory listings do not freeze on a shipped version; that is a catalog file, not a machine we just wired.
 
-  `flair hook status` still treats a pre-#1143 unpinned `-p` invocation as the correct shape. Re-run `flair hook install` to advance it to the running CLI's pin.
+  `flair hook status` still treats a pre-#1143 unpinned `-p` invocation as the correct shape. Re-run `flair hook install` to advance it to the running CLI's pin. A stale hook pin no longer shadows a client MCP pin, so `flair upgrade`'s client-config refresh can still clear an outdated flair-mcp finding.

--- a/.changelog/unreleased/security-1143-session-start-hook-pin.md
+++ b/.changelog/unreleased/security-1143-session-start-hook-pin.md
@@ -1,0 +1,5 @@
+- **SessionStart hook now pins `@tpsdev-ai/flair-mcp` the same way `flair init` pins client MCP configs.** `flair hook install`, `flair init`, and `flair doctor --fix` (when adding a missing hook) write `npx -y -p @tpsdev-ai/flair-mcp@<cli-version> flair-session-start` (flair#1143). A wired hook no longer self-updates to whatever was just published.
+
+  This is the #907 supply-chain posture applied to the other user-local npx path — the same package, every session. Public plugin `mcp.json` stays unpinned (flair#1308) so directory listings do not freeze on a shipped version; that is a catalog file, not a machine we just wired.
+
+  `flair hook status` still treats a pre-#1143 unpinned `-p` invocation as the correct shape. Re-run `flair hook install` to advance it to the running CLI's pin.

--- a/docs/mcp-clients.md
+++ b/docs/mcp-clients.md
@@ -111,7 +111,7 @@ Or wire it by hand — add a `SessionStart` hook to `~/.claude/settings.json`:
         "hooks": [
           {
             "type": "command",
-            "command": "sh -c 'out=$(FLAIR_AGENT_ID=me npx -y -p @tpsdev-ai/flair-mcp flair-session-start 2>/dev/null) && printf %s \"$out\" || true'"
+            "command": "sh -c 'out=$(FLAIR_AGENT_ID=me npx -y -p @tpsdev-ai/flair-mcp@<version> flair-session-start 2>/dev/null) && printf %s \"$out\" || true'"
           }
         ]
       }
@@ -120,12 +120,23 @@ Or wire it by hand — add a `SessionStart` hook to `~/.claude/settings.json`:
 }
 ```
 
-Swap `me` for your `FLAIR_AGENT_ID`. Unlike the MCP-server snippets above, this
-one is shown **unpinned**, because that is what `flair hook install` writes and
-what the tooling recognises: `flair hook status` matches the exact unpinned
-command, so a hand-pinned hook reports `wired: false` there (while `flair
-doctor` still sees it). Pinning this line is therefore not yet supported —
-prefer `flair hook install`.
+Swap `me` for your `FLAIR_AGENT_ID` and `<version>` for `flair --version`. This
+is the same pin `flair init` writes into client MCP configs (`mcpServerSpec()`,
+flair#907): a wired hook should not self-update to a freshly published
+`flair-mcp` any more than a wired MCP client should. `flair hook install`,
+`flair init`, and `flair doctor --fix` (when adding a missing hook) write that
+pin; re-run `flair hook install` to advance a stale or pre-#1143 unpinned hook
+to the running CLI's version.
+
+That is a different surface from public plugin `mcp.json` files, which stay
+**unpinned** on purpose (flair#1308) so directory listings that scrape them do
+not freeze on a shipped version. User-local wiring is pinned; catalog
+manifests are not.
+
+`flair hook status` recognises both the current pinned `-p` form and an older
+unpinned `-p` invocation as `correctShape`. The pre-#1166 form (no `-p`, which
+runs the MCP shim) is still flagged. Prefer `flair hook install` over
+hand-editing.
 
 The `sh -c ... || true` wrapper is not decoration. The invocation resolves a
 package binary through whatever Node runtime your shell exposes, and under a

--- a/packages/flair-mcp/src/session-start-hook.ts
+++ b/packages/flair-mcp/src/session-start-hook.ts
@@ -69,7 +69,7 @@
  *     "hooks": {
  *       "SessionStart": [
  *         { "hooks": [ { "type": "command",
- *           "command": "sh -c 'out=$(FLAIR_AGENT_ID=me npx -y @tpsdev-ai/flair-mcp flair-session-start 2>/dev/null) && printf %s \"$out\" || true'" } ] }
+ *           "command": "sh -c 'out=$(FLAIR_AGENT_ID=me npx -y -p @tpsdev-ai/flair-mcp@<version> flair-session-start 2>/dev/null) && printf %s \"$out\" || true'" } ] }
  *       ]
  *     }
  *   }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -3067,9 +3067,9 @@ export function upgradeStatusSuffix(name: string, status: UpgradeStatus): string
  *      is `flair doctor --fix`, never `npm install -g`.
  *   3. Wired with a concrete pin — that pin IS the installed version
  *      (current when it equals latest, else outdated → re-pin via doctor).
- *   4. Wired but unpinned (a bare npx spec / the SessionStart hook) — `npx -y`
- *      re-resolves latest every session, so the effective version IS latest →
- *      current.
+ *   4. Wired but unpinned (a bare npx spec / a pre-#1143 SessionStart hook) —
+ *      `npx -y` re-resolves latest every session, so the effective version IS
+ *      latest → current.
  */
 export function resolveFlairMcpFinding(
   globalProbe: string | null,
@@ -5198,6 +5198,10 @@ hook
 
     console.log(`\n${render.wrap(render.c.bold, "🪝 flair hook install")}${dryRun ? render.wrap(render.c.dim, " (dry run)") : ""}\n`);
     console.log(`  ${result.ok ? render.icons.ok : render.icons.error} ${result.message}`);
+    const pinWarning = unpinnedSpecWarning();
+    if (pinWarning && result.ok) {
+      for (const line of pinWarning.split("\n")) console.error(`   ⚠ ${line}`);
+    }
     if (result.backupPath) {
       console.log(`     ${render.wrap(render.c.dim, `backup: ${result.backupPath}`)}`);
     }

--- a/src/doctor-client.ts
+++ b/src/doctor-client.ts
@@ -972,6 +972,12 @@ export function extractFlairMcpPin(text: string): string | null {
  * version pinned in that wiring, or null when the only wiring found is unpinned
  * (a bare npx spec / a pre-#1143 SessionStart hook).
  *
+ * Client MCP pins win over the SessionStart hook pin. `flair upgrade`
+ * refreshes those client configs (#1135/#1324), not the hook; a stale hook
+ * pin must not shadow a just-refreshed client pin and keep flair-mcp marked
+ * outdated (flair#1143). The hook still establishes `wired` and contributes
+ * a pin only when no client config carries one.
+ *
  * Iterates the SAME client registry (ALL_CLIENTS) and per-client config paths
  * (clientConfigPath) that wiring uses, so a client added to the registry is
  * scanned here automatically — no second list to keep in step.
@@ -996,15 +1002,17 @@ export function detectWiredFlairMcp(homeDir: string): FlairMcpWiring {
     }
   };
 
-  // 1. The SessionStart hook (claude-code). Establishes wiring; may carry a pin.
-  const hook = checkSessionStartHook(homeDir);
-  if (hook.present && isFlairHookCommand(hook.command ?? "")) note(hook.command);
-
-  // 2. Every known client's MCP config — a wired flair block carries the spec.
+  // 1. Every known client's MCP config — a wired flair block carries the spec.
+  //    Scanned first so a client pin wins (see module note above).
   for (const client of ALL_CLIENTS) {
     const configPath = withHome(homeDir, () => clientConfigPath(client.id));
     note(readTextFile(configPath));
   }
+
+  // 2. The SessionStart hook (claude-code). Establishes wiring; may carry a
+  //    pin, but never overrides a client pin already taken above.
+  const hook = checkSessionStartHook(homeDir);
+  if (hook.present && isFlairHookCommand(hook.command ?? "")) note(hook.command);
 
   return { wired, pinnedVersion };
 }

--- a/src/doctor-client.ts
+++ b/src/doctor-client.ts
@@ -32,7 +32,7 @@ import {
   type ClientId,
   type PiSettingsScan,
 } from "./install/clients.js";
-import { FLAIR_MCP_PACKAGE } from "./lib/mcp-spec.js";
+import { FLAIR_MCP_PACKAGE, mcpServerSpec } from "./lib/mcp-spec.js";
 
 // The exact substring `flair init` writes into CLAUDE.md (src/cli.ts, the
 // `init` action) and that the doctor check + fix both key off of.
@@ -54,9 +54,10 @@ export const SESSION_START_HOOK_MARKER = "flair-session-start";
 //
 // WHY THE INVOCATION IS WRAPPED
 // -----------------------------
-// The hook runs `npx -y -p @tpsdev-ai/flair-mcp flair-session-start`: it resolves
-// a package binary through whatever Node runtime the user's shell happens to
-// expose. Under a Node version manager, globally installed packages are
+// The hook runs `npx -y -p @tpsdev-ai/flair-mcp@<version> flair-session-start`
+// (same mcpServerSpec() pin as `flair init`'s user-local MCP client configs —
+// flair#1143). It resolves a package binary through whatever Node runtime the
+// user's shell happens to expose. Under a Node version manager, globally installed packages are
 // per-runtime-version, so a routine and entirely unrelated runtime upgrade
 // orphans that binary. The command then stops resolving and the harness
 // reports a hook error on EVERY session, indefinitely, in wording that names
@@ -137,8 +138,25 @@ export function buildSessionStartHookCommand(agentId: string, flairUrl?: string)
     );
   }
   const env = flairUrl ? `FLAIR_AGENT_ID=${agentId} FLAIR_URL=${flairUrl}` : `FLAIR_AGENT_ID=${agentId}`;
-  const invocation = `${env} npx -y -p @tpsdev-ai/flair-mcp ${SESSION_START_HOOK_MARKER}`;
+  // Same pin as user-local MCP client configs (mcpServerSpec / flair#907).
+  // Public plugin mcp.json stays unpinned (flair#1308) — that is a scraped
+  // listing, not a machine we just wired.
+  const invocation = `${env} npx -y -p ${mcpServerSpec()} ${SESSION_START_HOOK_MARKER}`;
   return `sh -c 'out=$(${invocation} 2>/dev/null) && printf %s "$out" || true'`;
+}
+
+/**
+ * The `npx -y -p` invocation that runs `flair-session-start` — pinned
+ * (`@tpsdev-ai/flair-mcp@<ver>`) or the pre-#1143 unpinned form. Used by
+ * `flair hook status` so a freshly-pinned hook is not reported as
+ * hand-edited, and an older unpinned hook is not reported as broken.
+ * Rejects the pre-#1166 form (no `-p`), which runs the MCP shim.
+ */
+export const SESSION_START_HOOK_INVOCATION_RE =
+  /npx -y -p @tpsdev-ai\/flair-mcp(?:@[^\s"']+)? flair-session-start/;
+
+export function isSessionStartHookInvocation(command: string): boolean {
+  return typeof command === "string" && SESSION_START_HOOK_INVOCATION_RE.test(command);
 }
 
 /**
@@ -933,10 +951,9 @@ export function checkSessionStartHook(homeDir: string): SessionStartHookCheckRes
  * command. Returns the version when the spec is written
  * `@tpsdev-ai/flair-mcp@<ver>`; null for a bare/unpinned spec.
  *
- * The SessionStart hook is deliberately unpinned (`npx -y -p
- * @tpsdev-ai/flair-mcp`, buildSessionStartHookCommand above), so a hook
- * establishes that flair-mcp is wired but never carries a version — the pin
- * comes from the client MCP config.
+ * SessionStart hooks written since flair#1143 carry the same pin as a
+ * client MCP config (`mcpServerSpec()`). A pre-#1143 unpinned hook still
+ * establishes that flair-mcp is wired but contributes no version.
  */
 export function extractFlairMcpPin(text: string): string | null {
   if (typeof text !== "string") return null;
@@ -953,7 +970,7 @@ export function extractFlairMcpPin(text: string): string | null {
  * `wired` is true when a Flair SessionStart hook OR any known client's MCP
  * config references the flair-mcp package. `pinnedVersion` is the concrete
  * version pinned in that wiring, or null when the only wiring found is unpinned
- * (a bare npx spec / the SessionStart hook).
+ * (a bare npx spec / a pre-#1143 SessionStart hook).
  *
  * Iterates the SAME client registry (ALL_CLIENTS) and per-client config paths
  * (clientConfigPath) that wiring uses, so a client added to the registry is
@@ -979,7 +996,7 @@ export function detectWiredFlairMcp(homeDir: string): FlairMcpWiring {
     }
   };
 
-  // 1. The SessionStart hook (claude-code). Establishes wiring; unpinned by design.
+  // 1. The SessionStart hook (claude-code). Establishes wiring; may carry a pin.
   const hook = checkSessionStartHook(homeDir);
   if (hook.present && isFlairHookCommand(hook.command ?? "")) note(hook.command);
 

--- a/src/hook-install.ts
+++ b/src/hook-install.ts
@@ -64,6 +64,7 @@ import {
   computeContinuityHookRemoval,
   hookCommandIsSilenced,
   isHookCommandValueSafe,
+  isSessionStartHookInvocation,
   type ContinuityCaptureHookReport,
   type ContinuityHookEvent,
   type ContinuityMutationAction,
@@ -162,7 +163,7 @@ export interface HookStatusIdentityLine {
  *  Recovered values are shown. The installer-no-URL omit (flair#1325) is
  *  allowed ONLY when agentId was parsed — that is the real `flair init`
  *  shape (`FLAIR_AGENT_ID` set, `FLAIR_URL` omitted). correctShape alone
- *  is not enough: it is an npx-substring check and a wired correct-shape
+ *  is not enough: it is an npx-invocation check and a wired correct-shape
  *  command with no env assignments must still show the unknown lines,
  *  not a silent all-clear. */
 export function hookStatusIdentityLines(
@@ -495,10 +496,10 @@ export interface HookStatusResult {
   harness: Harness;
   path: string;
   wired: boolean;
-  /** True only when the matched hook entry is exactly the shape we write:
-   *  type "command", command containing the full expected invocation — not
-   *  just a loose marker substring match (a hand-edited/partial entry still
-   *  counts as `wired` for doctor-compat purposes but not `correctShape`). */
+  /** True only when the matched hook entry is the `npx -y -p` invocation
+   *  we write (pinned since flair#1143, or the older unpinned `-p` form) —
+   *  not just a loose marker substring match (a hand-edited/partial entry
+   *  still counts as `wired` for doctor-compat purposes but not `correctShape`). */
   correctShape: boolean;
   /** Does the wired command absorb its own failures, or would a command that
    *  stopped resolving print an error on every session start (flair#1007)? */
@@ -526,7 +527,7 @@ export function hookStatus(homeDir: string, harness: Harness): HookStatusResult 
 
   const hookEntry = config.hooks.SessionStart[existing.groupIndex].hooks[existing.hookIndex];
   const command: string = typeof hookEntry?.command === "string" ? hookEntry.command : "";
-  const correctShape = hookEntry?.type === "command" && command.includes(`npx -y -p @tpsdev-ai/flair-mcp ${SESSION_START_HOOK_MARKER}`);
+  const correctShape = hookEntry?.type === "command" && isSessionStartHookInvocation(command);
   const env = parseHookCommandEnv(command);
   return {
     harness, path, wired: true, correctShape,

--- a/test/unit/doctor-client.test.ts
+++ b/test/unit/doctor-client.test.ts
@@ -23,6 +23,7 @@ import {
   removeContinuityCaptureHooks,
   hookCommandIsSilenced,
 } from "../../src/doctor-client.ts";
+import { mcpServerSpec } from "../../src/lib/mcp-spec.ts";
 
 /**
  * flair#588 — `flair doctor` client-integration checks. Pure filesystem
@@ -323,6 +324,8 @@ describe("fixSessionStartHook", () => {
     const config = JSON.parse(readFileSync(res.path, "utf-8"));
     const commands = config.hooks.SessionStart.flatMap((g: any) => g.hooks.map((h: any) => h.command));
     expect(commands.some((c: string) => c.includes(SESSION_START_HOOK_MARKER) && c.includes("FLAIR_AGENT_ID=me"))).toBe(true);
+    // flair#1143: doctor --fix writes the same pin as flair init / hook install.
+    expect(commands.some((c: string) => c.includes(`npx -y -p ${mcpServerSpec()} ${SESSION_START_HOOK_MARKER}`))).toBe(true);
   });
 
   it("merge-safe: preserves other top-level keys and other hook types", () => {

--- a/test/unit/flair-mcp-detection.test.ts
+++ b/test/unit/flair-mcp-detection.test.ts
@@ -12,6 +12,7 @@ import {
   detectWiredFlairMcp,
   buildSessionStartHookCommand,
 } from "../../src/doctor-client";
+import { flairCliVersion } from "../../src/lib/mcp-spec";
 
 const LATEST = "0.44.9";
 
@@ -70,8 +71,12 @@ describe("extractFlairMcpPin", () => {
     expect(extractFlairMcpPin('"args": ["-y", "@tpsdev-ai/flair-mcp"]')).toBeNull();
   });
 
-  test("returns null for the (unpinned) SessionStart hook command", () => {
-    expect(extractFlairMcpPin(buildSessionStartHookCommand("me"))).toBeNull();
+  test("pulls the version from the SessionStart hook command (flair#1143)", () => {
+    expect(extractFlairMcpPin(buildSessionStartHookCommand("me"))).toBe(flairCliVersion());
+  });
+
+  test("returns null for a pre-#1143 unpinned SessionStart hook command", () => {
+    expect(extractFlairMcpPin(`FLAIR_AGENT_ID=me npx -y -p @tpsdev-ai/flair-mcp flair-session-start`)).toBeNull();
   });
 
   test("returns null when the package is absent entirely", () => {
@@ -96,7 +101,7 @@ describe("detectWiredFlairMcp (reads actual config files under HOME)", () => {
     });
   });
 
-  test("SessionStart hook present (unpinned) => wired, no pin", () => {
+  test("SessionStart hook present => wired, pin extracted (flair#1143)", () => {
     withTempHome((home) => {
       mkdirSync(join(home, ".claude"), { recursive: true });
       writeFileSync(
@@ -105,7 +110,7 @@ describe("detectWiredFlairMcp (reads actual config files under HOME)", () => {
           hooks: { SessionStart: [{ hooks: [{ type: "command", command: buildSessionStartHookCommand("me") }] }] },
         }),
       );
-      expect(detectWiredFlairMcp(home)).toEqual({ wired: true, pinnedVersion: null });
+      expect(detectWiredFlairMcp(home)).toEqual({ wired: true, pinnedVersion: flairCliVersion() });
     });
   });
 
@@ -137,10 +142,15 @@ describe("detectWiredFlairMcp (reads actual config files under HOME)", () => {
           hooks: { SessionStart: [{ hooks: [{ type: "command", command: buildSessionStartHookCommand("me") }] }] },
         }),
       );
-      // globalProbe null (not globally installed) + hook present.
-      const finding = resolveFlairMcpFinding(null, LATEST, detectWiredFlairMcp(home));
+      // globalProbe null (not globally installed) + hook present. The hook
+      // now carries a pin (flair#1143); treat that pin as latest so this
+      // test still asserts "not missing", not "outdated vs a fixture tag".
+      const wiring = detectWiredFlairMcp(home);
+      expect(wiring.wired).toBe(true);
+      expect(wiring.pinnedVersion).toBe(flairCliVersion());
+      const finding = resolveFlairMcpFinding(null, wiring.pinnedVersion!, wiring);
       expect(finding.status).not.toBe("missing");
-      expect(finding).toEqual({ installed: LATEST, status: "current" });
+      expect(finding).toEqual({ installed: wiring.pinnedVersion, status: "current" });
     });
   });
 });

--- a/test/unit/flair-mcp-detection.test.ts
+++ b/test/unit/flair-mcp-detection.test.ts
@@ -133,6 +133,47 @@ describe("detectWiredFlairMcp (reads actual config files under HOME)", () => {
     });
   });
 
+  test("stale hook pin does not shadow a refreshed client pin (flair#1143 / upgrade refresh)", () => {
+    // After `flair upgrade` the client MCP spec is re-pinned to latest, but
+    // the SessionStart hook is left alone until `flair hook install`. The
+    // hook used to be scanned first, so its stale pin kept flair-mcp marked
+    // outdated and the advertised client refresh could not clear it.
+    withTempHome((home) => {
+      mkdirSync(join(home, ".claude"), { recursive: true });
+      writeFileSync(
+        join(home, ".claude", "settings.json"),
+        JSON.stringify({
+          hooks: {
+            SessionStart: [
+              {
+                hooks: [
+                  {
+                    type: "command",
+                    command: `sh -c 'out=$(FLAIR_AGENT_ID=me npx -y -p @tpsdev-ai/flair-mcp@0.40.0 flair-session-start 2>/dev/null) && printf %s "$out" || true'`,
+                  },
+                ],
+              },
+            ],
+          },
+        }),
+      );
+      mkdirSync(join(home, ".gemini"), { recursive: true });
+      writeFileSync(
+        join(home, ".gemini", "settings.json"),
+        JSON.stringify({
+          mcpServers: {
+            flair: {
+              command: "npx",
+              args: ["-y", `@tpsdev-ai/flair-mcp@${LATEST}`],
+              env: { FLAIR_AGENT_ID: "me", FLAIR_URL: "http://127.0.0.1:9926" },
+            },
+          },
+        }),
+      );
+      expect(detectWiredFlairMcp(home)).toEqual({ wired: true, pinnedVersion: LATEST });
+    });
+  });
+
   test("hook present but NO global install => resolves to current, NOT missing (issue #1208 acceptance)", () => {
     withTempHome((home) => {
       mkdirSync(join(home, ".claude"), { recursive: true });

--- a/test/unit/hook-install.test.ts
+++ b/test/unit/hook-install.test.ts
@@ -28,6 +28,7 @@ import {
   checkSessionStartHook,
   fixSessionStartHook,
 } from "../../src/doctor-client.ts";
+import { mcpServerSpec } from "../../src/lib/mcp-spec.ts";
 // NOTE: the degradation-timeout test (Sherlock condition 5, "mock the
 // fetch") lives in packages/flair-mcp/test/session-start-hook.test.ts, NOT
 // here. That file already imports runHook (which transitively imports
@@ -79,7 +80,7 @@ describe("buildHookCommand / parseHookCommandEnv", () => {
   it("round-trips agentId and flairUrl through the command string", () => {
     const command = buildHookCommand(AGENT, URL);
     expect(command).toContain(SESSION_START_HOOK_MARKER);
-    expect(command).toContain("npx -y -p @tpsdev-ai/flair-mcp");
+    expect(command).toContain(`npx -y -p ${mcpServerSpec()} ${SESSION_START_HOOK_MARKER}`);
     const parsed = parseHookCommandEnv(command);
     expect(parsed.agentId).toBe(AGENT);
     expect(parsed.flairUrl).toBe(URL);
@@ -144,6 +145,23 @@ describe("installHook — idempotent re-run", () => {
     const config = JSON.parse(secondContent);
     expect(config.hooks.SessionStart.length).toBe(1);
     expect(config.hooks.SessionStart[0].hooks.length).toBe(1);
+  });
+
+  it("re-running upgrades a pre-#1143 unpinned hook to the current pin", () => {
+    const path = hookSettingsPath(isoHome, "claude-code");
+    mkdirSync(join(isoHome, ".claude"), { recursive: true });
+    const unpinned = `sh -c 'out=$(FLAIR_AGENT_ID=${AGENT} FLAIR_URL=${URL} npx -y -p @tpsdev-ai/flair-mcp ${SESSION_START_HOOK_MARKER} 2>/dev/null) && printf %s "$out" || true'`;
+    writeFileSync(
+      path,
+      JSON.stringify({ hooks: { SessionStart: [{ hooks: [{ type: "command", command: unpinned }] }] } }),
+    );
+    const result = installHook({ homeDir: isoHome, harness: "claude-code", agentId: AGENT, flairUrl: URL });
+    expect(result.ok).toBe(true);
+    expect(result.delta?.action).toBe("update");
+    const config = JSON.parse(readFileSync(path, "utf-8"));
+    const command = config.hooks.SessionStart[0].hooks[0].command;
+    expect(command).toContain(`npx -y -p ${mcpServerSpec()} ${SESSION_START_HOOK_MARKER}`);
+    expect(command).not.toBe(unpinned);
   });
 
   it("re-running with a different agent/url UPDATES the one entry in place (no duplicate)", () => {
@@ -358,6 +376,33 @@ describe("hookStatus", () => {
     expect(status.correctShape).toBe(true);
     expect(status.agentId).toBe(AGENT);
     expect(status.flairUrl).toBe(URL);
+    expect(status.command).toContain(`npx -y -p ${mcpServerSpec()} ${SESSION_START_HOOK_MARKER}`);
+  });
+
+  it("still treats a pre-#1143 unpinned -p invocation as correctShape", () => {
+    const path = hookSettingsPath(isoHome, "claude-code");
+    mkdirSync(join(isoHome, ".claude"), { recursive: true });
+    writeFileSync(
+      path,
+      JSON.stringify({
+        hooks: {
+          SessionStart: [
+            {
+              hooks: [
+                {
+                  type: "command",
+                  command: `sh -c 'out=$(FLAIR_AGENT_ID=${AGENT} npx -y -p @tpsdev-ai/flair-mcp ${SESSION_START_HOOK_MARKER} 2>/dev/null) && printf %s "$out" || true'`,
+                },
+              ],
+            },
+          ],
+        },
+      }),
+    );
+    const status = hookStatus(isoHome, "claude-code");
+    expect(status.wired).toBe(true);
+    expect(status.correctShape).toBe(true);
+    expect(status.agentId).toBe(AGENT);
   });
 
   it("wired but NOT correctShape for a hand-edited command that merely contains the marker", () => {
@@ -446,11 +491,10 @@ describe("hookStatus", () => {
   });
 
   it("wired correct-shape with no env assignments is not a silent all-clear", () => {
-    // correctShape is only `npx -y -p @tpsdev-ai/flair-mcp flair-session-start`
-    // as a substring. A command that matches that but carries no
-    // FLAIR_AGENT_ID is not the installer-no-URL form; omitting the
-    // unknown lines would print a clean wired result with neither values
-    // nor a parse warning.
+    // correctShape is the `npx -y -p` invocation (pinned or not). A command
+    // that matches that but carries no FLAIR_AGENT_ID is not the
+    // installer-no-URL form; omitting the unknown lines would print a clean
+    // wired result with neither values nor a parse warning.
     const path = hookSettingsPath(isoHome, "claude-code");
     mkdirSync(join(isoHome, ".claude"), { recursive: true });
     writeFileSync(

--- a/test/unit/session-start-hook-command.test.ts
+++ b/test/unit/session-start-hook-command.test.ts
@@ -10,8 +10,10 @@ import {
   hookCommandIsSilenced,
   isFlairHookCommand,
   isHookCommandValueSafe,
+  isSessionStartHookInvocation,
   parseLegacySessionStartHookCommand,
 } from "../../src/doctor-client.ts";
+import { mcpServerSpec } from "../../src/lib/mcp-spec.ts";
 
 /**
  * flair#1007 — the SessionStart hook must be SILENT when its `npx` invocation
@@ -138,6 +140,14 @@ describe("buildSessionStartHookCommand — shape", () => {
     expect(cmd).toContain(`FLAIR_AGENT_ID=${AGENT}`);
   });
 
+  it("pins the package to the running CLI version (flair#1143)", () => {
+    // Same mcpServerSpec() as `flair init` writes into client MCP configs —
+    // the hook is user-local wiring, not a public listing.
+    const cmd = buildSessionStartHookCommand(AGENT);
+    expect(cmd).toContain(`npx -y -p ${mcpServerSpec()} ${SESSION_START_HOOK_MARKER}`);
+    expect(isSessionStartHookInvocation(cmd)).toBe(true);
+  });
+
   it("includes FLAIR_URL only when one is given", () => {
     expect(buildSessionStartHookCommand(AGENT)).not.toContain("FLAIR_URL=");
     expect(buildSessionStartHookCommand(AGENT, "http://127.0.0.1:19926")).toContain("FLAIR_URL=http://127.0.0.1:19926");
@@ -151,6 +161,16 @@ describe("buildSessionStartHookCommand — shape", () => {
       expect(() => buildSessionStartHookCommand(bad)).toThrow();
     }
     expect(() => buildSessionStartHookCommand(AGENT, "http://x/'`id`")).toThrow();
+  });
+
+  it("isSessionStartHookInvocation accepts pinned and unpinned -p forms, rejects no -p", () => {
+    expect(isSessionStartHookInvocation(buildSessionStartHookCommand(AGENT))).toBe(true);
+    expect(isSessionStartHookInvocation(`npx -y -p @tpsdev-ai/flair-mcp ${SESSION_START_HOOK_MARKER}`)).toBe(true);
+    expect(isSessionStartHookInvocation(`npx -y -p @tpsdev-ai/flair-mcp@0.33.0 ${SESSION_START_HOOK_MARKER}`)).toBe(true);
+    // pre-#1166: no -p, runs the shim
+    expect(isSessionStartHookInvocation(`npx -y @tpsdev-ai/flair-mcp ${SESSION_START_HOOK_MARKER}`)).toBe(false);
+    expect(isSessionStartHookInvocation(`npx -y @tpsdev-ai/flair-mcp@0.33.0 ${SESSION_START_HOOK_MARKER}`)).toBe(false);
+    expect(isSessionStartHookInvocation("echo flair-session-start")).toBe(false);
   });
 
   it("is recognised as ours and as silenced; the legacy command is neither", () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #1143.

## What I verified on current main (do not assume the 2026-08-12 filing)

The filing said client config pins and the SessionStart hook does not. That split is still true:

- **User-local MCP client configs** (`flair init`, `doctor --fix` wiring, `flair upgrade` pin refresh) still write `@tpsdev-ai/flair-mcp@<cli-version>` via `mcpServerSpec()`. `#907` / `#1135` are load-bearing. `#1308` explicitly left this alone.
- **`docs/mcp-clients.md` and `README.md`** still document that pin. The `#1307` claim that “docs and `flair init` already use unpinned npx” was incorrect.
- **Public plugin `mcp.json`** is unpinned (`#1308`) so directory listings do not freeze on a shipped version. Different surface: a scraped catalog file, not a machine we just wired.
- **SessionStart hook** was still `npx -y -p @tpsdev-ai/flair-mcp` with no version. The existing “why unpinned” note in `docs/mcp-clients.md` was a matcher accident (`flair hook status` looked for the exact unpinned `-p` substring), not a second security posture.

No product fork: user-local wiring is pinned; catalog manifests are not. The hook is user-local wiring of the same package, so it belongs on the pin.

## What changed

`buildSessionStartHookCommand` now uses `mcpServerSpec()`. `flair hook install`, `flair init`, and `flair doctor --fix` (when adding a missing hook) write:

```
npx -y -p @tpsdev-ai/flair-mcp@<cli-version> flair-session-start
```

`flair hook status` recognises both the new pin and a pre-#1143 unpinned `-p` invocation as `correctShape`. The pre-#1166 form (no `-p`, runs the shim) is still flagged. Re-run `flair hook install` to advance an existing hook.

`detectWiredFlairMcp` now reads client MCP configs **before** the hook, so a stale hook pin cannot shadow the client spec that `flair upgrade` actually refreshes (Bugbot finding on the first commit).

Continuity capture hooks and public plugin `mcp.json` are unchanged (out of scope for #1143). Did not touch PR #1248.

## Tests

- `buildSessionStartHookCommand` asserts the CLI pin
- `installHook` upgrades a pre-#1143 unpinned hook in place
- `hookStatus` accepts pinned and unpinned `-p`, rejects no `-p`
- `fixSessionStartHook` / `detectWiredFlairMcp` / `extractFlairMcpPin` follow the pin
- stale hook pin + refreshed client pin → reports the client pin

```
bun test test/unit/session-start-hook-command.test.ts \
         test/unit/hook-install.test.ts \
         test/unit/flair-mcp-detection.test.ts \
         test/unit/doctor-client.test.ts \
         test/unit/doctor-session-start-hook-probe.test.ts \
         test/unit/mcp-spec-pinning.test.ts \
         test/unit/mcp-server-spec.test.ts
```

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7b1f2f80-831f-439b-b2f1-1ac57bd2c69d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7b1f2f80-831f-439b-b2f1-1ac57bd2c69d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

