### PR TITLE
fix(cli): name URL and setting when federation status fetch fails

### DIFF
--- a/.changelog/unreleased/fixed-1108-federation-status-fetch-failed.md
+++ b/.changelog/unreleased/fixed-1108-federation-status-fetch-failed.md
@@ -1,0 +1,1 @@
+- **`flair federation status` names the URL and the setting on fetch failure.** A probe that used to print only `fetch failed` now says what was contacted and which knob produced it (`FLAIR_URL`, `--port`, `--target`, or `FLAIR_TARGET`), so a healthy instance on a different port is a one-line fix (flair#1108).

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -7002,6 +7002,23 @@ export function isFederationStatusAuthFailure(err: unknown): boolean {
   return m.includes("missing_or_invalid_authorization") || /(?:^|\D)401(?:\D|$)/.test(m);
 }
 
+/**
+ * Whether to print the "set one of: FLAIR_AGENT_ID / FLAIR_ADMIN_PASS /
+ * FLAIR_TOKEN" block. Narrower than `isFederationStatusAuthFailure`: a
+ * 403 with credentials already sent (wrong password) is fatal, but the
+ * server's own body is the honest message — the credential-list remedy
+ * is for missing/invalid auth (401), not a rejected password (flair#634).
+ */
+export function isFederationStatusAuthRemedy(err: unknown): boolean {
+  if (!err || isFederationStatusConnectFailure(err)) return false;
+  const m = err instanceof Error
+    ? err.message
+    : String(typeof err === "object" && err && "message" in err
+      ? (err as { message?: unknown }).message ?? err
+      : err);
+  return m.includes("missing_or_invalid_authorization") || /(?:^|\D)401(?:\D|$)/.test(m);
+}
+
 federation
   .command("status")
   .description("Show federation status and peer connections")
@@ -7051,7 +7068,7 @@ federation
     if ((instanceErr && peersErr) || isFederationStatusAuthFailure(instanceErr) || isFederationStatusAuthFailure(peersErr)) {
       const primaryErr = instanceErr ?? peersErr;
       const msg = String(primaryErr.message ?? primaryErr);
-      if (isFederationStatusAuthFailure(primaryErr)) {
+      if (isFederationStatusAuthRemedy(primaryErr)) {
         console.error(`${render.icons.error} federation status requires auth.`);
         console.error(`  ${render.wrap(render.c.dim, "Set one of:")}`);
         console.error(`    ${render.wrap(render.c.cyan, "FLAIR_AGENT_ID=<your-agent-id>")}     ${render.wrap(render.c.dim, "(Ed25519 — uses ~/.flair/keys/<id>.key)")}`);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -6980,6 +6980,28 @@ export function rewriteFederationStatusFetchFailed(err: unknown, url: string, se
   return next;
 }
 
+/**
+ * Auth-shaped vs connect-level for `federation status`. A rewritten
+ * fetch-failed sentence embeds the probed URL; that URL can contain the
+ * digits `401` (e.g. `--port 4010`). The old `message.includes("401")`
+ * check then printed the credential remedy and hid the URL+setting this
+ * change exists to surface (Bugbot on flair#1108).
+ */
+export function isFederationStatusAuthFailure(err: unknown): boolean {
+  if (!err) return false;
+  if (isFederationStatusConnectFailure(err)) return false;
+  if (typeof err === "object" && "status" in err) {
+    const status = (err as { status?: unknown }).status;
+    if (status === 401 || status === 403) return true;
+  }
+  const m = err instanceof Error
+    ? err.message
+    : String(typeof err === "object" && err && "message" in err
+      ? (err as { message?: unknown }).message ?? err
+      : err);
+  return m.includes("missing_or_invalid_authorization") || /(?:^|\D)401(?:\D|$)/.test(m);
+}
+
 federation
   .command("status")
   .description("Show federation status and peer connections")
@@ -7023,20 +7045,13 @@ federation
     // property of the session's credentials, not of one endpoint — and
     // degrading it to "unverifiable" would swallow the actionable remedy
     // (flair#634's UX, kept). Only non-auth failures degrade independently.
-    const authShaped = (err: any): boolean => {
-      if (!err) return false;
-      if (err.status === 401 || err.status === 403) return true;
-      const m = String(err.message ?? err);
-      return m.includes("missing_or_invalid_authorization") || m.includes("401");
-    };
-
     // Both reads failed → nothing to render at all. Either way keep the
     // classic failure UX (auth remedy when it's an auth problem), exit
     // non-zero.
-    if ((instanceErr && peersErr) || authShaped(instanceErr) || authShaped(peersErr)) {
+    if ((instanceErr && peersErr) || isFederationStatusAuthFailure(instanceErr) || isFederationStatusAuthFailure(peersErr)) {
       const primaryErr = instanceErr ?? peersErr;
       const msg = String(primaryErr.message ?? primaryErr);
-      if (msg.includes("missing_or_invalid_authorization") || msg.includes("401")) {
+      if (isFederationStatusAuthFailure(primaryErr)) {
         console.error(`${render.icons.error} federation status requires auth.`);
         console.error(`  ${render.wrap(render.c.dim, "Set one of:")}`);
         console.error(`    ${render.wrap(render.c.cyan, "FLAIR_AGENT_ID=<your-agent-id>")}     ${render.wrap(render.c.dim, "(Ed25519 — uses ~/.flair/keys/<id>.key)")}`);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -6938,6 +6938,48 @@ function driverCheckAppliesTo(opts: { target?: string }): boolean {
   return !target || isLocalBase(target.replace(/\/$/, ""));
 }
 
+/**
+ * flair#1108: a bare undici/Node "fetch failed" names neither the URL
+ * that was probed nor the knob that would change it. These helpers are
+ * the operator-facing sentence and the setting that produced (or would
+ * change) that URL. Pure so the contract can be unit-tested without
+ * driving process.exit.
+ */
+export function federationStatusUrlSetting(opts: { target?: string; port?: string | number }): string {
+  if (opts.target) return "--target";
+  if (process.env.FLAIR_TARGET) return "FLAIR_TARGET";
+  if (process.env.FLAIR_URL) return "FLAIR_URL";
+  if (opts.port !== undefined && opts.port !== null && String(opts.port) !== "") return "--port";
+  return "FLAIR_URL or --port";
+}
+
+export function describeFederationStatusFetchFailed(url: string, setting: string): string {
+  return `fetch failed against ${url} (set ${setting})`;
+}
+
+/** True for a connect-level failure (no HTTP status): Node's undici
+ *  `TypeError: fetch failed`, Bun's `Unable to connect…`, or a cause
+ *  carrying a connect/DNS errno. Auth and HTTP errors stay out. */
+export function isFederationStatusConnectFailure(err: unknown): boolean {
+  const msg = err instanceof Error ? err.message : String(err);
+  if (/\bfetch failed\b/i.test(msg)) return true;
+  if (/unable to connect/i.test(msg)) return true;
+  const cause = err instanceof Error ? (err as { cause?: unknown }).cause : undefined;
+  const code = cause && typeof cause === "object" && cause && "code" in cause
+    ? String((cause as { code?: unknown }).code)
+    : "";
+  return /^(ECONNREFUSED|ENOTFOUND|ECONNRESET|ETIMEDOUT|EAI_AGAIN|EHOSTUNREACH)$/.test(code);
+}
+
+export function rewriteFederationStatusFetchFailed(err: unknown, url: string, setting: string): unknown {
+  if (!isFederationStatusConnectFailure(err)) return err;
+  const next = new Error(describeFederationStatusFetchFailed(url, setting));
+  if (err && typeof err === "object" && "status" in err) {
+    (next as { status?: unknown }).status = (err as { status?: unknown }).status;
+  }
+  return next;
+}
+
 federation
   .command("status")
   .description("Show federation status and peer connections")
@@ -6946,8 +6988,11 @@ federation
   .option("--ops-target <url>", "Explicit ops API URL (env: FLAIR_OPS_TARGET; bypasses port derivation)")
   .option("--json", "Emit JSON {instance, peers, driver} (also: pipe + FLAIR_OUTPUT=json)")
   .action(async (opts) => {
-    const target = resolveTarget(opts);
-    const baseUrl = target ? target.replace(/\/$/, "") : undefined;
+    // Same URL api() would have derived, including --port (the command
+    // advertised --port but previously dropped it on the floor). Naming
+    // that URL on fetch failure is only honest if it is the URL we probe.
+    const baseUrl = resolveBaseUrl(opts).replace(/\/$/, "");
+    const urlSetting = federationStatusUrlSetting(opts);
     const mode = render.resolveOutputMode(opts);
 
     // flair#1233: fetch instance and peers INDEPENDENTLY. One read failing
@@ -6958,19 +7003,19 @@ federation
     let instance: any = null;
     let instanceErr: any = null;
     try {
-      instance = await api("GET", "/FederationInstance", undefined, baseUrl ? { baseUrl } : undefined);
+      instance = await api("GET", "/FederationInstance", undefined, { baseUrl });
     } catch (err) {
-      instanceErr = err;
+      instanceErr = rewriteFederationStatusFetchFailed(err, baseUrl, urlSetting);
     }
 
     // peers: null = unverifiable (the read failed), [] = verified empty.
     let peers: any[] | null = null;
     let peersErr: any = null;
     try {
-      const r = await api("GET", "/FederationPeers", undefined, baseUrl ? { baseUrl } : undefined);
+      const r = await api("GET", "/FederationPeers", undefined, { baseUrl });
       peers = r.peers ?? [];
     } catch (err) {
-      peersErr = err;
+      peersErr = rewriteFederationStatusFetchFailed(err, baseUrl, urlSetting);
     }
 
     // Auth-shaped failures stay FATAL even when the other read succeeded:

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -7011,6 +7011,9 @@ export function isFederationStatusAuthFailure(err: unknown): boolean {
  */
 export function isFederationStatusAuthRemedy(err: unknown): boolean {
   if (!err || isFederationStatusConnectFailure(err)) return false;
+  if (typeof err === "object" && "status" in err && (err as { status?: unknown }).status === 401) {
+    return true;
+  }
   const m = err instanceof Error
     ? err.message
     : String(typeof err === "object" && err && "message" in err

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -6982,8 +6982,8 @@ export function rewriteFederationStatusFetchFailed(err: unknown, url: string, se
 
 /**
  * Auth-shaped vs connect-level for `federation status`. A rewritten
- * fetch-failed sentence embeds the probed URL; that URL can contain the
- * digits `401` (e.g. `--port 4010`). The old `message.includes("401")`
+ * fetch-failed sentence embeds the probed URL; that URL can contain a
+ * whole-token `401` (e.g. `--port 401`). The old `message.includes("401")`
  * check then printed the credential remedy and hid the URL+setting this
  * change exists to surface (Bugbot on flair#1108).
  */

--- a/test/unit/cli-federation-status-fetch.test.ts
+++ b/test/unit/cli-federation-status-fetch.test.ts
@@ -12,6 +12,7 @@ import { describe, test, expect, beforeEach, afterEach } from "bun:test";
 import {
   describeFederationStatusFetchFailed,
   federationStatusUrlSetting,
+  isFederationStatusAuthFailure,
   rewriteFederationStatusFetchFailed,
 } from "../../src/cli.ts";
 
@@ -107,5 +108,24 @@ describe("rewriteFederationStatusFetchFailed", () => {
   test("leaves a non-fetch error (auth, HTTP) unchanged", () => {
     const err = new Error("missing_or_invalid_authorization");
     expect(rewriteFederationStatusFetchFailed(err, "http://x", "FLAIR_URL")).toBe(err);
+  });
+});
+
+describe("isFederationStatusAuthFailure", () => {
+  test("a rewritten fetch-failed against a URL containing 401 is not auth", () => {
+    const rewritten = rewriteFederationStatusFetchFailed(
+      new TypeError("fetch failed"),
+      "http://127.0.0.1:4010",
+      "--port",
+    );
+    expect((rewritten as Error).message).toContain("4010");
+    expect(isFederationStatusAuthFailure(rewritten)).toBe(false);
+  });
+
+  test("status 401 / missing_or_invalid_authorization stay auth-shaped", () => {
+    const withStatus = new Error("HTTP 401");
+    (withStatus as { status?: number }).status = 401;
+    expect(isFederationStatusAuthFailure(withStatus)).toBe(true);
+    expect(isFederationStatusAuthFailure(new Error("missing_or_invalid_authorization"))).toBe(true);
   });
 });

--- a/test/unit/cli-federation-status-fetch.test.ts
+++ b/test/unit/cli-federation-status-fetch.test.ts
@@ -13,6 +13,7 @@ import {
   describeFederationStatusFetchFailed,
   federationStatusUrlSetting,
   isFederationStatusAuthFailure,
+  isFederationStatusAuthRemedy,
   rewriteFederationStatusFetchFailed,
 } from "../../src/cli.ts";
 
@@ -125,6 +126,7 @@ describe("isFederationStatusAuthFailure", () => {
     expect(msg).toContain("http://127.0.0.1:401");
     expect(msg).toMatch(/(?:^|\D)401(?:\D|$)/);
     expect(isFederationStatusAuthFailure(rewritten)).toBe(false);
+    expect(isFederationStatusAuthRemedy(rewritten)).toBe(false);
   });
 
   test("status 401 / missing_or_invalid_authorization stay auth-shaped", () => {
@@ -132,5 +134,17 @@ describe("isFederationStatusAuthFailure", () => {
     (withStatus as { status?: number }).status = 401;
     expect(isFederationStatusAuthFailure(withStatus)).toBe(true);
     expect(isFederationStatusAuthFailure(new Error("missing_or_invalid_authorization"))).toBe(true);
+  });
+
+  test("403 forbidden is fatal-auth but not the credential-list remedy", () => {
+    const forbidden = new Error("forbidden");
+    (forbidden as { status?: number }).status = 403;
+    expect(isFederationStatusAuthFailure(forbidden)).toBe(true);
+    expect(isFederationStatusAuthRemedy(forbidden)).toBe(false);
+  });
+
+  test("401 / missing_or_invalid_authorization get the credential-list remedy", () => {
+    expect(isFederationStatusAuthRemedy(new Error("missing_or_invalid_authorization"))).toBe(true);
+    expect(isFederationStatusAuthRemedy(new Error("HTTP 401"))).toBe(true);
   });
 });

--- a/test/unit/cli-federation-status-fetch.test.ts
+++ b/test/unit/cli-federation-status-fetch.test.ts
@@ -147,4 +147,15 @@ describe("isFederationStatusAuthFailure", () => {
     expect(isFederationStatusAuthRemedy(new Error("missing_or_invalid_authorization"))).toBe(true);
     expect(isFederationStatusAuthRemedy(new Error("HTTP 401"))).toBe(true);
   });
+
+  test("status 401 with a body that does not say 401 still gets the remedy", () => {
+    // ApiHttpError from a 401 whose body is e.g. unknown_agent — no digit
+    // 401 in the text. The status field is what must trigger the remedy;
+    // a message-only check would miss it.
+    const unknownAgent = new Error("unknown_agent");
+    (unknownAgent as { status?: number }).status = 401;
+    expect(unknownAgent.message).not.toMatch(/401/);
+    expect(isFederationStatusAuthRemedy(unknownAgent)).toBe(true);
+    expect(isFederationStatusAuthFailure(unknownAgent)).toBe(true);
+  });
 });

--- a/test/unit/cli-federation-status-fetch.test.ts
+++ b/test/unit/cli-federation-status-fetch.test.ts
@@ -1,0 +1,111 @@
+/**
+ * cli-federation-status-fetch.test.ts — flair#1108
+ *
+ * `flair federation status` used to print a bare "fetch failed" when the
+ * probe URL was wrong. The helpers below are the contract: the failure
+ * message names the URL that was attempted and the setting that controls
+ * it. The action callback itself calls api() + process.exit, so (same
+ * convention as cli-rem-rapid.test.ts) the helpers are what we unit-test.
+ */
+
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import {
+  describeFederationStatusFetchFailed,
+  federationStatusUrlSetting,
+  rewriteFederationStatusFetchFailed,
+} from "../../src/cli.ts";
+
+describe("describeFederationStatusFetchFailed", () => {
+  test("names the probed URL and the setting that controls it", () => {
+    const msg = describeFederationStatusFetchFailed(
+      "http://127.0.0.1:9926",
+      "FLAIR_URL or --port",
+    );
+    expect(msg).toContain("http://127.0.0.1:9926");
+    expect(msg).toContain("FLAIR_URL");
+    expect(msg).toBe("fetch failed against http://127.0.0.1:9926 (set FLAIR_URL or --port)");
+  });
+
+  test("names --target when that is the setting that produced the URL", () => {
+    const msg = describeFederationStatusFetchFailed(
+      "https://hub.example:8443",
+      "--target",
+    );
+    expect(msg).toContain("https://hub.example:8443");
+    expect(msg).toContain("--target");
+  });
+});
+
+describe("federationStatusUrlSetting", () => {
+  let origUrl: string | undefined;
+  let origTarget: string | undefined;
+
+  beforeEach(() => {
+    origUrl = process.env.FLAIR_URL;
+    origTarget = process.env.FLAIR_TARGET;
+    delete process.env.FLAIR_URL;
+    delete process.env.FLAIR_TARGET;
+  });
+
+  afterEach(() => {
+    if (origUrl === undefined) delete process.env.FLAIR_URL;
+    else process.env.FLAIR_URL = origUrl;
+    if (origTarget === undefined) delete process.env.FLAIR_TARGET;
+    else process.env.FLAIR_TARGET = origTarget;
+  });
+
+  test("default (no flag, no env) names FLAIR_URL or --port", () => {
+    expect(federationStatusUrlSetting({})).toBe("FLAIR_URL or --port");
+  });
+
+  test("--target wins over env", () => {
+    process.env.FLAIR_URL = "http://env-url";
+    process.env.FLAIR_TARGET = "http://env-target";
+    expect(federationStatusUrlSetting({ target: "http://flag-target", port: 19926 })).toBe("--target");
+  });
+
+  test("FLAIR_TARGET wins over FLAIR_URL", () => {
+    process.env.FLAIR_TARGET = "http://env-target";
+    process.env.FLAIR_URL = "http://env-url";
+    expect(federationStatusUrlSetting({})).toBe("FLAIR_TARGET");
+  });
+
+  test("FLAIR_URL is named when it produced the URL", () => {
+    process.env.FLAIR_URL = "http://127.0.0.1:19926";
+    expect(federationStatusUrlSetting({})).toBe("FLAIR_URL");
+  });
+
+  test("--port is named when it produced the URL", () => {
+    expect(federationStatusUrlSetting({ port: 19926 })).toBe("--port");
+  });
+});
+
+describe("rewriteFederationStatusFetchFailed", () => {
+  test("rewrites a TypeError('fetch failed') to name URL and setting", () => {
+    const rewritten = rewriteFederationStatusFetchFailed(
+      new TypeError("fetch failed"),
+      "http://127.0.0.1:9926",
+      "FLAIR_URL or --port",
+    );
+    expect(rewritten).toBeInstanceOf(Error);
+    const msg = (rewritten as Error).message;
+    expect(msg).toContain("http://127.0.0.1:9926");
+    expect(msg).toContain("FLAIR_URL");
+  });
+
+  test("rewrites Bun's Unable-to-connect error the same way", () => {
+    const rewritten = rewriteFederationStatusFetchFailed(
+      new Error("Unable to connect. Is the computer able to access the url?"),
+      "http://127.0.0.1:59999",
+      "--target",
+    );
+    const msg = (rewritten as Error).message;
+    expect(msg).toContain("http://127.0.0.1:59999");
+    expect(msg).toContain("--target");
+  });
+
+  test("leaves a non-fetch error (auth, HTTP) unchanged", () => {
+    const err = new Error("missing_or_invalid_authorization");
+    expect(rewriteFederationStatusFetchFailed(err, "http://x", "FLAIR_URL")).toBe(err);
+  });
+});

--- a/test/unit/cli-federation-status-fetch.test.ts
+++ b/test/unit/cli-federation-status-fetch.test.ts
@@ -112,13 +112,18 @@ describe("rewriteFederationStatusFetchFailed", () => {
 });
 
 describe("isFederationStatusAuthFailure", () => {
-  test("a rewritten fetch-failed against a URL containing 401 is not auth", () => {
+  test("a rewritten fetch-failed against a whole-token 401 URL is not auth", () => {
+    // `--port 401`, not 4010: the digit-boundary regex already rejects 4010,
+    // so that fixture would still pass if the connect-failure guard were
+    // removed. :401 is a whole token — without the guard this is auth-shaped.
     const rewritten = rewriteFederationStatusFetchFailed(
       new TypeError("fetch failed"),
-      "http://127.0.0.1:4010",
+      "http://127.0.0.1:401",
       "--port",
     );
-    expect((rewritten as Error).message).toContain("4010");
+    const msg = (rewritten as Error).message;
+    expect(msg).toContain("http://127.0.0.1:401");
+    expect(msg).toMatch(/(?:^|\D)401(?:\D|$)/);
     expect(isFederationStatusAuthFailure(rewritten)).toBe(false);
   });
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`flair federation status` printed only `✗ fetch failed` when the probe URL was wrong (healthy instance on a different port, no `FLAIR_URL`). Nothing named what was contacted or which knob would change it.

On a connect-level failure the command now prints:

```
✗ fetch failed against http://127.0.0.1:19926 (set FLAIR_URL or --port)
```

The URL is the one actually probed. The setting is the knob that produced it (`--target`, `FLAIR_TARGET`, `FLAIR_URL`, `--port`), or `FLAIR_URL or --port` when the default was used.

`--port` is now honored (it was advertised on the command but previously dropped). Auth and HTTP errors keep their existing remedies.

Follow-ups on this branch:
- `0b3a5a9` (Bugbot): a rewritten miss whose URL contains `401` is no longer classified as auth-shaped.
- `46c43de` (Bugbot): the unit test fixtures `--port 401` (a whole token), so it fails if the connect-failure guard is removed.
- `8343c1c` (CI): a 403 with credentials already sent (wrong password) still prints the server's `forbidden`, not the credential-list remedy.
- `58ce5bd` (Bugbot): `status === 401` (e.g. body `unknown_agent`) gets the credential-list remedy, not only messages that contain the digits `401`.

Closes #1108

## Test plan

- [x] Unit test: the failure message includes the URL and the setting name
- [x] Live CLI against a dead port names URL + `--target` / `--port` / `FLAIR_URL` / default `FLAIR_URL or --port`
- [x] Unit: rewritten miss against `:401` is not auth-shaped (would be, without the connect-failure guard)
- [x] `local-no-auth`: 403 with wrong password surfaces `forbidden`, not the credential-list remedy
- [x] Unit: status 401 + body `unknown_agent` gets the credential-list remedy
- [x] CI unit tests (all 33 checks green on `58ce5bd`)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e2a84176-3bd0-47d2-8f7d-99dbba604971?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e2a84176-3bd0-47d2-8f7d-99dbba604971&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

