### PR TITLE
feat(hook): add Codex SessionStart harness (flair#1148)

### DIFF
--- a/.changelog/unreleased/added-1148-codex-hook-harness.md
+++ b/.changelog/unreleased/added-1148-codex-hook-harness.md
@@ -5,4 +5,7 @@
   Codex is detected; after install, trust the command with `/hooks`. Clients
   with no session-start hook get a documented AGENTS.md / GEMINI.md fallback
   in `docs/mcp-clients.md` so MCP wiring alone is not mistaken for done
-  (flair#1148).
+  (flair#1148). Continuity capture (`--continuity`) stays Claude Code only —
+  Codex status does not offer it, and `flair hook install --continuity
+  --harness codex` refuses rather than writing unused PostToolUse/Stop
+  entries.

--- a/.changelog/unreleased/added-1148-codex-hook-harness.md
+++ b/.changelog/unreleased/added-1148-codex-hook-harness.md
@@ -1,0 +1,8 @@
+- **`flair hook install --harness codex` writes a Codex SessionStart hook.** Same
+  `flair-session-start` command Claude Code already uses, merged into
+  `~/.codex/hooks.json` (Codex's hook file — same JSON schema). `uninstall` /
+  `status` take the same flag. `flair doctor` reports the Codex hook when
+  Codex is detected; after install, trust the command with `/hooks`. Clients
+  with no session-start hook get a documented AGENTS.md / GEMINI.md fallback
+  in `docs/mcp-clients.md` so MCP wiring alone is not mistaken for done
+  (flair#1148).

--- a/docs/mcp-clients.md
+++ b/docs/mcp-clients.md
@@ -96,10 +96,10 @@ flair hook status                # wired? correct shape? which agent/instance?
 flair hook uninstall             # removes only Flair's hook entry
 ```
 
-`--harness claude-code` is the only supported value today (it's also the
-default) — the flag exists so a future harness is an additive registry entry,
-not a breaking change. `flair doctor` already checks for this same hook (see
-below) and recognizes anything `flair hook install` writes.
+`--harness` defaults to `claude-code`. `codex` is also supported (writes
+`~/.codex/hooks.json` — see the Codex section below). `flair doctor` checks
+the same hook for each detected harness and recognizes anything
+`flair hook install` writes.
 
 Or wire it by hand — add a `SessionStart` hook to `~/.claude/settings.json`:
 
@@ -218,6 +218,46 @@ FLAIR_AGENT_ID = "my-project"
 For project-scoped trust (per Codex's MCP guide), the same block in `.codex/config.toml` at the project root.
 
 Restart your Codex CLI session and the `flair_*` tools become available to the agent.
+
+#### Auto-recall on session start (optional hook)
+
+Wiring the MCP server alone does not load memory at session start — Codex
+then has pull tools it never thinks to call. The same `flair-session-start`
+command Claude Code uses writes Codex's SessionStart hook (same JSON schema,
+into `~/.codex/hooks.json`):
+
+```bash
+flair hook install --harness codex
+flair hook status --harness codex
+flair hook uninstall --harness codex
+```
+
+`flair doctor` reports this hook when Codex is detected. After install, trust
+the new command in Codex with `/hooks` — untrusted hooks are listed and
+skipped.
+
+---
+
+## Hookless harnesses (Gemini, Cursor, and anything without SessionStart)
+
+Some clients have no session-start hook Flair can write. Wiring the MCP
+server is necessary but not sufficient — the model still has to choose to
+call `bootstrap`. Add a short instruction block to the file that client
+already loads (`AGENTS.md`, `GEMINI.md`, or the equivalent):
+
+```markdown
+## Flair memory
+
+At the start of every session, call the Flair `bootstrap` tool before
+responding. Before a deep-dive, `memory_search` for related prior work.
+At wrap, `memory_store` durable lessons.
+```
+
+Without that, a config that looks wired is the known failure shape
+([#989](https://github.com/tpsdev-ai/flair/issues/989),
+[#908](https://github.com/tpsdev-ai/flair/issues/908)): tools exist, memory
+never enters the working set. Use `flair hook install` when the client has
+a SessionStart hook; use this static block when it does not.
 
 ---
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -130,6 +130,7 @@ import {
   SUPPORTED_HARNESSES,
   hookSettingsPath,
   hookInstallHint,
+  harnessSupportsContinuity,
   resolveHookAgentId,
   type Harness,
 } from "./hook-install.js";
@@ -5258,6 +5259,9 @@ hook
     // status in every branch below. "absent" is NOT a failure: installing the
     // pair is the opt-in, so absence renders as "not enabled".
     const renderContinuity = (): void => {
+      // Continuity is Claude Code only. Do not tip `--continuity --harness
+      // <other>` — that writes Claude tool matchers into the wrong file.
+      if (!harnessSupportsContinuity(harness)) return;
       const cont = continuityHookStatus(home, harness);
       if (cont.state === "installed") {
         console.log(`  ${render.icons.ok} continuity capture: PostToolUse + Stop wired`);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -129,6 +129,8 @@ import {
   isSupportedHarness,
   SUPPORTED_HARNESSES,
   hookSettingsPath,
+  hookInstallHint,
+  resolveHookAgentId,
   type Harness,
 } from "./hook-install.js";
 import {
@@ -5130,17 +5132,6 @@ keys
 // section is pure CLI plumbing: option parsing, default resolution, and
 // rendering the pure functions' results.
 
-function resolveHookAgentId(opts: { agent?: string; agentId?: string }, homeDir: string, harness: Harness): string | undefined {
-  return (
-    opts.agent ||
-    opts.agentId ||
-    process.env.FLAIR_AGENT_ID ||
-    readClientMcpBlock(harness, homeDir).agentId ||
-    (harness !== "claude-code" ? readClientMcpBlock("claude-code", homeDir).agentId : undefined) ||
-    undefined
-  );
-}
-
 function resolveHookFlairUrl(opts: { url?: string }, homeDir: string, harness: Harness): string {
   return (
     opts.url ||
@@ -5271,10 +5262,10 @@ hook
       if (cont.state === "installed") {
         console.log(`  ${render.icons.ok} continuity capture: PostToolUse + Stop wired`);
       } else if (cont.state === "absent") {
-        console.log(`  ${render.icons.info} continuity capture: not enabled ${render.wrap(render.c.dim, "(opt-in: flair hook install --continuity)")}`);
+        console.log(`  ${render.icons.info} continuity capture: not enabled ${render.wrap(render.c.dim, `(opt-in: ${hookInstallHint(harness, "--continuity")})`)}`);
       } else {
         const missing = !cont.postToolUse.present ? "PostToolUse missing" : !cont.stop.present ? "Stop missing" : "stale form";
-        console.log(`  ${render.icons.warn} continuity capture: ${cont.state} (${missing}) ${render.wrap(render.c.dim, "— re-run: flair hook install --continuity")}`);
+        console.log(`  ${render.icons.warn} continuity capture: ${cont.state} (${missing}) ${render.wrap(render.c.dim, `— re-run: ${hookInstallHint(harness, "--continuity")}`)}`);
       }
     };
 
@@ -5290,8 +5281,7 @@ hook
 
     if (!status.wired) {
       console.log(`  ${render.icons.error} not wired`);
-      const installHint = status.harness === "claude-code" ? "flair hook install" : `flair hook install --harness ${status.harness}`;
-      console.log(`     ${render.wrap(render.c.dim, "Fix:")} ${installHint}`);
+      console.log(`     ${render.wrap(render.c.dim, "Fix:")} ${hookInstallHint(status.harness)}`);
       renderContinuity();
       console.log("");
       process.exit(1);
@@ -5312,7 +5302,7 @@ hook
     if (status.silenced) {
       console.log(`     ${render.wrap(render.c.dim, "On failure:")} silent (exit 0, no output)`);
     } else {
-      console.log(`     ${render.icons.warn} ${render.wrap(render.c.dim, "On failure:")} prints an error on every session — run \`flair hook install\` to adopt the silent form`);
+      console.log(`     ${render.icons.warn} ${render.wrap(render.c.dim, "On failure:")} prints an error on every session — run \`${hookInstallHint(status.harness)}\` to adopt the silent form`);
     }
     renderContinuity();
     console.log("");
@@ -14404,7 +14394,12 @@ program
                     client.id === "antigravity" ? wireAntigravity(wireEnv) :
                     wireCursor(wireEnv);
                   console.log(`     ${wireResult.ok ? render.icons.ok : render.icons.warn} ${wireResult.message}`);
-                  if (wireResult.ok) fixed++;
+                  if (wireResult.ok) {
+                    fixed++;
+                    if (client.id === "claude-code") claudeCodeAgentId = fixAgentId;
+                    if (client.id === "codex") codexAgentId = fixAgentId;
+                    anyKnownAgentId = anyKnownAgentId ?? fixAgentId;
+                  }
                 }
               }
             }
@@ -14688,7 +14683,7 @@ program
               if (!proceed) {
                 console.log(`     Skipped.`);
               } else {
-                const fixAgentId = codexAgentId || opts.agent || process.env.FLAIR_AGENT_ID;
+                const fixAgentId = resolveHookAgentId({ agent: opts.agent }, homedir(), "codex");
                 const fixRes = fixSessionStartHook(homedir(), fixAgentId, hook.path);
                 console.log(`     ${fixRes.ok ? render.icons.ok : render.icons.warn} ${fixRes.message}`);
                 if (fixRes.ok) fixed++;

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -128,6 +128,7 @@ import {
   continuityHookStatus,
   isSupportedHarness,
   SUPPORTED_HARNESSES,
+  hookSettingsPath,
   type Harness,
 } from "./hook-install.js";
 import {
@@ -5129,22 +5130,24 @@ keys
 // section is pure CLI plumbing: option parsing, default resolution, and
 // rendering the pure functions' results.
 
-function resolveHookAgentId(opts: { agent?: string; agentId?: string }, homeDir: string): string | undefined {
+function resolveHookAgentId(opts: { agent?: string; agentId?: string }, homeDir: string, harness: Harness): string | undefined {
   return (
     opts.agent ||
     opts.agentId ||
     process.env.FLAIR_AGENT_ID ||
-    readClientMcpBlock("claude-code", homeDir).agentId ||
+    readClientMcpBlock(harness, homeDir).agentId ||
+    (harness !== "claude-code" ? readClientMcpBlock("claude-code", homeDir).agentId : undefined) ||
     undefined
   );
 }
 
-function resolveHookFlairUrl(opts: { url?: string }, homeDir: string): string {
+function resolveHookFlairUrl(opts: { url?: string }, homeDir: string, harness: Harness): string {
   return (
     opts.url ||
     process.env.FLAIR_TARGET ||
     process.env.FLAIR_URL ||
-    readClientMcpBlock("claude-code", homeDir).flairUrl ||
+    readClientMcpBlock(harness, homeDir).flairUrl ||
+    (harness !== "claude-code" ? readClientMcpBlock("claude-code", homeDir).flairUrl : undefined) ||
     resolveBaseUrl({})
   );
 }
@@ -5165,21 +5168,21 @@ hook
   .description("Wire the Flair SessionStart hook into the harness config so memory loads automatically at session start")
   .option("--harness <name>", `Target harness (${SUPPORTED_HARNESSES.join(", ")})`, "claude-code")
   .option("--dry-run", "Print the exact JSON delta without writing")
-  .option("--agent <id>", "Agent ID to wire (else FLAIR_AGENT_ID, else the agent already wired for the claude-code MCP client)")
+  .option("--agent <id>", "Agent ID to wire (else FLAIR_AGENT_ID, else the agent already wired for this harness's MCP client)")
   .option("--agent-id <id>", "Alias for --agent")
-  .option("--url <url>", "Flair URL to wire (else FLAIR_TARGET/FLAIR_URL, else the existing claude-code MCP wiring, else the local default)")
+  .option("--url <url>", "Flair URL to wire (else FLAIR_TARGET/FLAIR_URL, else this harness's MCP wiring, else the local default)")
   .option("--continuity", "Wire the continuity capture hooks instead (PostToolUse + Stop — flair#1257; installing them IS the opt-in)")
   .action((opts) => {
     const harness = requireSupportedHarness(opts.harness);
     const home = homedir();
-    const agentId = resolveHookAgentId(opts, home);
+    const agentId = resolveHookAgentId(opts, home, harness);
     if (!agentId) {
       console.error(
         "No agent id known — pass --agent <id>, set FLAIR_AGENT_ID, or run `flair init` / `flair agent add` first.",
       );
       process.exit(1);
     }
-    const flairUrl = resolveHookFlairUrl(opts, home);
+    const flairUrl = resolveHookFlairUrl(opts, home, harness);
     const dryRun = !!opts.dryRun;
 
     if (opts.continuity) {
@@ -5287,7 +5290,8 @@ hook
 
     if (!status.wired) {
       console.log(`  ${render.icons.error} not wired`);
-      console.log(`     ${render.wrap(render.c.dim, "Fix:")} flair hook install`);
+      const installHint = status.harness === "claude-code" ? "flair hook install" : `flair hook install --harness ${status.harness}`;
+      console.log(`     ${render.wrap(render.c.dim, "Fix:")} ${installHint}`);
       renderContinuity();
       console.log("");
       process.exit(1);
@@ -14159,8 +14163,8 @@ program
     // Antigravity) the MCP block present + reachable + the configured agent
     // genuinely registered; for pi (a NATIVE EXTENSION host — flair#1342) the
     // pi-flair reference in pi's own settings, including the flair#1346
-    // npm:-under-"extensions" trap; plus CLAUDE.md + the SessionStart hook
-    // (Claude Code only, since only Claude Code has those mechanisms). Reuses
+    // npm:-under-"extensions" trap; plus CLAUDE.md (Claude Code) and the
+    // SessionStart hook (Claude Code + Codex — flair#1148). Reuses
     // detectClients() rather than reimplementing client detection.
     console.log(`\n  ${render.wrap(render.c.bold, "Client integration")}`);
 
@@ -14183,6 +14187,7 @@ program
       console.log(`  ${render.icons.info} No MCP client detected — skipping client-integration checks`);
     } else {
       let claudeCodeAgentId: string | undefined;
+      let codexAgentId: string | undefined;
       let anyKnownAgentId: string | undefined;
 
       // `doctor --fix` writes client configs through the same wire functions
@@ -14355,6 +14360,7 @@ program
 
         const block = readClientMcpBlock(client.id, homedir());
         if (client.id === "claude-code" && block.agentId) claudeCodeAgentId = block.agentId;
+        if (client.id === "codex" && block.agentId) codexAgentId = block.agentId;
         if (block.agentId) anyKnownAgentId = anyKnownAgentId ?? block.agentId;
 
         if (!block.present) {
@@ -14450,8 +14456,9 @@ program
         }
       }
 
-      // Claude-Code-specific: CLAUDE.md + SessionStart hook. Only Claude Code
-      // has these mechanisms, so only run them when claude-code was detected.
+      // Claude-Code-specific: CLAUDE.md + SessionStart hook + continuity.
+      // Codex has a SessionStart hook too (checked below); CLAUDE.md and
+      // continuity stay Claude Code only.
       if (detectedClients.some((c) => c.id === "claude-code")) {
         const claudeMd = checkClaudeMdBootstrap(process.cwd(), homedir());
         if (claudeMd.present) {
@@ -14615,6 +14622,80 @@ program
             }
           } else {
             console.log(`     ${render.wrap(render.c.dim, "Fix:")} flair doctor --fix ${render.wrap(render.c.dim, "(rewrites both entries to the current form — same agent, same instance)")}`);
+          }
+          issues++;
+        }
+      }
+
+      // Codex SessionStart hook (flair#1148) — same flair-session-start
+      // command Claude Code uses, written to ~/.codex/hooks.json. Continuity
+      // and CLAUDE.md stay Claude-Code-only; Codex's session-start mechanism
+      // is the hook file.
+      if (detectedClients.some((c) => c.id === "codex")) {
+        const hook = inspectSessionStartHook(homedir(), { settingsPath: hookSettingsPath(homedir(), "codex") });
+        if (hook.present) {
+          if (hook.execution === "broken") {
+            if (hook.silenced) {
+              console.log(`  ${render.icons.ok} SessionStart hook (codex): wired in ${render.wrap(render.c.dim, hook.path)} — not yet exercised`);
+              console.log(`     ${render.wrap(render.c.dim, hook.detail ?? "")}`);
+              console.log(`     ${render.wrap(render.c.dim, "The hook is correctly wired but the adapter has not been fetched yet.")}`);
+              console.log(`     ${render.wrap(render.c.dim, "This is normal on a fresh install — the first Codex session will warm the npx cache.")}`);
+              console.log(`     ${render.wrap(render.c.dim, "Codex requires /hooks to trust a newly written command before it runs.")}`);
+            } else {
+              console.log(`  ${render.icons.warn} SessionStart hook (codex): wired in ${render.wrap(render.c.dim, hook.path)}, but its command did not run just now`);
+              console.log(`     ${render.wrap(render.c.dim, hook.detail ?? "")}`);
+              console.log(`     ${render.wrap(render.c.dim, "Fix:")} flair hook install --harness codex ${render.wrap(render.c.dim, "(rewrites the hook to the current silent-failure form)")}`);
+            }
+          } else if (hook.execution === "unknown") {
+            console.log(`  ${render.icons.warn} SessionStart hook (codex): wired in ${render.wrap(render.c.dim, hook.path)}, but could not be verified ${render.wrap(render.c.dim, `(${hook.detail ?? "no detail"})`)}`);
+          } else if (!hook.ours) {
+            console.log(`  ${render.icons.ok} SessionStart hook (codex): wired in ${render.wrap(render.c.dim, hook.path)} ${render.wrap(render.c.dim, "(custom command — not verified, not modified)")}`);
+          } else {
+            console.log(`  ${render.icons.ok} SessionStart hook (codex): flair-session-start wired in ${render.wrap(render.c.dim, hook.path)} ${render.wrap(render.c.dim, "and still runs")}`);
+          }
+
+          if (!hook.silenced && hook.ours) {
+            console.log(`  ${render.icons.warn} SessionStart hook (codex): a failure would print an error on every session (this command predates the silent-failure fix)`);
+            if (hook.upgradable) {
+              if (autoFix) {
+                if (dryRun) {
+                  console.log(`     ${render.wrap(render.c.dim, "Would rewrite the hook command in")} ${hook.path}`);
+                } else {
+                  const proceed = await confirmFix(`  Rewrite the Flair SessionStart hook in ${hook.path} so failures stay silent? [y/N] `);
+                  if (!proceed) {
+                    console.log(`     Skipped.`);
+                  } else {
+                    const upgrade = upgradeSessionStartHookCommand(homedir(), hook.path);
+                    console.log(`     ${upgrade.ok ? render.icons.ok : render.icons.warn} ${upgrade.message}`);
+                    if (upgrade.ok && upgrade.changed) fixed++;
+                  }
+                }
+              } else {
+                console.log(`     ${render.wrap(render.c.dim, "Fix:")} flair hook install --harness codex ${render.wrap(render.c.dim, "(rewrites the hook command in place — same agent, same instance)")}`);
+              }
+            } else {
+              console.log(`     ${render.wrap(render.c.dim, "This hook was hand-edited, so Flair will not rewrite it. To adopt the current form:")} flair hook install --harness codex`);
+            }
+            issues++;
+          }
+        } else {
+          console.log(`  ${render.icons.error} SessionStart hook (codex): not found in ${render.wrap(render.c.dim, hook.path)}`);
+          if (autoFix) {
+            if (dryRun) {
+              console.log(`     ${render.wrap(render.c.dim, "Would add SessionStart hook to")} ${hook.path}`);
+            } else {
+              const proceed = await confirmFix(`  Add the flair-session-start SessionStart hook to ${hook.path}? [y/N] `);
+              if (!proceed) {
+                console.log(`     Skipped.`);
+              } else {
+                const fixAgentId = codexAgentId || opts.agent || process.env.FLAIR_AGENT_ID;
+                const fixRes = fixSessionStartHook(homedir(), fixAgentId, hook.path);
+                console.log(`     ${fixRes.ok ? render.icons.ok : render.icons.warn} ${fixRes.message}`);
+                if (fixRes.ok) fixed++;
+              }
+            }
+          } else {
+            console.log(`     ${render.wrap(render.c.dim, "Fix:")} flair hook install --harness codex`);
           }
           issues++;
         }

--- a/src/doctor-client.ts
+++ b/src/doctor-client.ts
@@ -77,7 +77,7 @@ export const SESSION_START_HOOK_MARKER = "flair-session-start";
 // spawns with `shell: true` and never consults $SHELL (verified against the
 // 2.1.220 bundle; the settings schema's claim that `"shell": "bash"` uses your
 // $SHELL is not what the code does on POSIX). So a bare POSIX fragment would
-// in fact be enough for the one harness we support today.
+// in fact be enough for the JSON-command harnesses we support today.
 //
 // It is still wrapped, because this string is not private to that harness:
 // SUPPORTED_HARNESSES (src/hook-install.ts) is a registry meant to grow, and
@@ -334,8 +334,8 @@ function continuityEventReport(config: any, event: ContinuityHookEvent): Continu
  * pure fs read, no probe. A missing or unparseable settings.json reads as
  * "absent" (not enabled), matching checkSessionStartHook's tolerance.
  */
-export function checkContinuityCaptureHooks(homeDir: string): ContinuityCaptureHookReport {
-  const path = join(homeDir, ".claude", "settings.json");
+export function checkContinuityCaptureHooks(homeDir: string, settingsPath?: string): ContinuityCaptureHookReport {
+  const path = settingsPath ?? join(homeDir, ".claude", "settings.json");
   let config: any = {};
   const raw = readTextFile(path);
   if (raw && raw.trim()) {
@@ -897,7 +897,7 @@ export function fixClaudeMdBootstrap(cwd: string): { ok: boolean; path: string; 
   }
 }
 
-// ── check 4: settings.json SessionStart hook (claude-code only) ────────────
+// ── check 4: SessionStart hook (claude-code settings.json; Codex hooks.json)
 
 export interface SessionStartHookCheckResult {
   present: boolean;
@@ -909,12 +909,14 @@ export interface SessionStartHookCheckResult {
 }
 
 /**
- * Pass when ~/.claude/settings.json exists, parses as JSON, and ANY hook
+ * Pass when the harness settings file exists, parses as JSON, and ANY hook
  * command anywhere under hooks.SessionStart[*].hooks[*].command contains the
  * flair-session-start marker (see docs/mcp-clients.md for the exact shape).
+ * `settingsPath` defaults to ~/.claude/settings.json; pass the Codex
+ * `~/.codex/hooks.json` path (or any other hookSettingsPath) for that harness.
  */
-export function checkSessionStartHook(homeDir: string): SessionStartHookCheckResult {
-  const path = join(homeDir, ".claude", "settings.json");
+export function checkSessionStartHook(homeDir: string, settingsPath?: string): SessionStartHookCheckResult {
+  const path = settingsPath ?? join(homeDir, ".claude", "settings.json");
   const raw = readTextFile(path);
   if (!raw || !raw.trim()) return { present: false, path };
   try {
@@ -1009,24 +1011,34 @@ export function detectWiredFlairMcp(homeDir: string): FlairMcpWiring {
     note(readTextFile(configPath));
   }
 
-  // 2. The SessionStart hook (claude-code). Establishes wiring; may carry a
-  //    pin, but never overrides a client pin already taken above.
-  const hook = checkSessionStartHook(homeDir);
-  if (hook.present && isFlairHookCommand(hook.command ?? "")) note(hook.command);
+  // 2. SessionStart hooks (claude-code settings.json + Codex hooks.json).
+  //    Establish wiring; may carry a pin, but NEVER override a client pin
+  //    already taken above — `note()` only sets pinnedVersion when it is still
+  //    unset, so THIS ORDERING IS THE PRECEDENCE RULE, not decoration. The
+  //    Codex path is additive (flair#1148); it must not reorder these two steps.
+  //    Paths match hookSettingsPath in src/hook-install.ts — listed here to
+  //    avoid a cycle (hook-install already imports this module).
+  for (const hookPath of [
+    join(homeDir, ".claude", "settings.json"),
+    join(homeDir, ".codex", "hooks.json"),
+  ]) {
+    const hook = checkSessionStartHook(homeDir, hookPath);
+    if (hook.present && isFlairHookCommand(hook.command ?? "")) note(hook.command);
+  }
 
   return { wired, pinnedVersion };
 }
 
 /**
- * Merge-safe insert of a Flair SessionStart hook group into
- * ~/.claude/settings.json — creates the file/array if absent, preserves any
- * other existing hooks/keys (read-parse-merge-write, mirroring wireJsonMcp's
- * merge safety in src/install/clients.ts; never a blind overwrite). Dedupes:
- * a no-op (ok:true) if a matching hook is already present, so it's safe to
- * call twice.
+ * Merge-safe insert of a Flair SessionStart hook group into the harness
+ * settings file (default ~/.claude/settings.json) — creates the file/array
+ * if absent, preserves any other existing hooks/keys (read-parse-merge-write,
+ * mirroring wireJsonMcp's merge safety in src/install/clients.ts; never a
+ * blind overwrite). Dedupes: a no-op (ok:true) if a matching hook is already
+ * present, so it's safe to call twice.
  */
-export function fixSessionStartHook(homeDir: string, agentId: string | undefined): { ok: boolean; path: string; message: string } {
-  const path = join(homeDir, ".claude", "settings.json");
+export function fixSessionStartHook(homeDir: string, agentId: string | undefined, settingsPath?: string): { ok: boolean; path: string; message: string } {
+  const path = settingsPath ?? join(homeDir, ".claude", "settings.json");
   if (!agentId) {
     return {
       ok: false,
@@ -1235,9 +1247,9 @@ export interface SessionStartHookCommandReport {
  */
 export function inspectSessionStartHook(
   homeDir: string,
-  opts: { probe?: HookProbeRunner | false; timeoutMs?: number } = {},
+  opts: { probe?: HookProbeRunner | false; timeoutMs?: number; settingsPath?: string } = {},
 ): SessionStartHookCommandReport {
-  const found = checkSessionStartHook(homeDir);
+  const found = checkSessionStartHook(homeDir, opts.settingsPath);
   if (!found.present || !found.command) {
     return { path: found.path, present: false, ours: false, silenced: false, upgradable: false, execution: null };
   }
@@ -1301,8 +1313,8 @@ export function classifyHookReadiness(report: SessionStartHookCommandReport): Ho
  * decision to un-wire ambient memory, and `flair hook uninstall` is the
  * command for that when the user does decide.
  */
-export function upgradeSessionStartHookCommand(homeDir: string): { ok: boolean; path: string; message: string; changed: boolean } {
-  const path = join(homeDir, ".claude", "settings.json");
+export function upgradeSessionStartHookCommand(homeDir: string, settingsPath?: string): { ok: boolean; path: string; message: string; changed: boolean } {
+  const path = settingsPath ?? join(homeDir, ".claude", "settings.json");
   try {
     const raw = readTextFile(path);
     if (!raw || !raw.trim()) return { ok: false, path, changed: false, message: `no ${path} to update` };

--- a/src/hook-install.ts
+++ b/src/hook-install.ts
@@ -72,10 +72,11 @@ import {
 
 // ── harness registry ────────────────────────────────────────────────────────
 
-/** v1 supports exactly one harness. The flag/type exist so a second harness
- *  is an additive registry entry, not a rewrite (Kern's #719 verdict: "a
- *  switch statement... is fine until we have 3+ harnesses"). */
-export const SUPPORTED_HARNESSES = ["claude-code"] as const;
+/** SessionStart hook harnesses. A second harness is an additive registry
+ *  entry, not a rewrite (Kern's #719 verdict: "a switch statement... is
+ *  fine until we have 3+ harnesses"). Codex writes the same JSON hook
+ *  schema Claude Code uses, into `~/.codex/hooks.json` (flair#1148). */
+export const SUPPORTED_HARNESSES = ["claude-code", "codex"] as const;
 export type Harness = (typeof SUPPORTED_HARNESSES)[number];
 
 export function isSupportedHarness(value: string): value is Harness {
@@ -89,6 +90,8 @@ export function hookSettingsPath(homeDir: string, harness: Harness): string {
   switch (harness) {
     case "claude-code":
       return join(homeDir, ".claude", "settings.json");
+    case "codex":
+      return join(homeDir, ".codex", "hooks.json");
   }
 }
 
@@ -702,10 +705,5 @@ export function uninstallContinuityHooks(opts: UninstallHookOptions): Continuity
 /** Read-only continuity status for `flair hook status` — the same report
  *  doctor's check consumes, resolved through the harness's settings path. */
 export function continuityHookStatus(homeDir: string, harness: Harness): ContinuityCaptureHookReport {
-  // hookSettingsPath and checkContinuityCaptureHooks both resolve
-  // ~/.claude/settings.json from homeDir; asserting through the harness
-  // registry keeps a future second harness from silently reading the wrong
-  // file.
-  void hookSettingsPath(homeDir, harness);
-  return checkContinuityCaptureHooks(homeDir);
+  return checkContinuityCaptureHooks(homeDir, hookSettingsPath(homeDir, harness));
 }

--- a/src/hook-install.ts
+++ b/src/hook-install.ts
@@ -65,6 +65,7 @@ import {
   hookCommandIsSilenced,
   isHookCommandValueSafe,
   isSessionStartHookInvocation,
+  readClientMcpBlock,
   type ContinuityCaptureHookReport,
   type ContinuityHookEvent,
   type ContinuityMutationAction,
@@ -93,6 +94,33 @@ export function hookSettingsPath(homeDir: string, harness: Harness): string {
     case "codex":
       return join(homeDir, ".codex", "hooks.json");
   }
+}
+
+/** Status/doctor hint for `flair hook install`. Claude Code stays the bare
+ *  default; every other harness is named so the hint cannot silently write
+ *  the wrong file (flair#1148 Bugbot). */
+export function hookInstallHint(harness: Harness, extraFlags = ""): string {
+  const parts = ["flair hook install"];
+  if (extraFlags) parts.push(extraFlags);
+  if (harness !== "claude-code") parts.push(`--harness ${harness}`);
+  return parts.join(" ");
+}
+
+/** Agent id for a hook install: flag, env, this harness's MCP block, then
+ *  Claude Code's block as a last resort (same agent is often shared). */
+export function resolveHookAgentId(
+  opts: { agent?: string; agentId?: string },
+  homeDir: string,
+  harness: Harness,
+): string | undefined {
+  return (
+    opts.agent ||
+    opts.agentId ||
+    process.env.FLAIR_AGENT_ID ||
+    readClientMcpBlock(harness, homeDir).agentId ||
+    (harness !== "claude-code" ? readClientMcpBlock("claude-code", homeDir).agentId : undefined) ||
+    undefined
+  );
 }
 
 /** Backup path convention: a single sibling `<path>.bak`, overwritten on

--- a/src/hook-install.ts
+++ b/src/hook-install.ts
@@ -96,6 +96,13 @@ export function hookSettingsPath(homeDir: string, harness: Harness): string {
   }
 }
 
+/** Continuity capture (PostToolUse + Stop) is Claude Code only. The matcher
+ *  is Claude tool names; writing it into another harness looks enabled and
+ *  never journals (flair#1148 Bugbot). SessionStart stays per-harness. */
+export function harnessSupportsContinuity(harness: Harness): boolean {
+  return harness === "claude-code";
+}
+
 /** Status/doctor hint for `flair hook install`. Claude Code stays the bare
  *  default; every other harness is named so the hint cannot silently write
  *  the wrong file (flair#1148 Bugbot). */
@@ -605,6 +612,14 @@ export function installContinuityHooks(opts: InstallHookOptions): ContinuityMuta
   const { homeDir, harness, agentId, flairUrl } = opts;
   const dryRun = !!opts.dryRun;
   const path = hookSettingsPath(homeDir, harness);
+
+  if (!harnessSupportsContinuity(harness)) {
+    return {
+      ok: false, path, harness, dryRun,
+      message: `continuity capture is Claude Code only — ${harness} has no PostToolUse/Stop matcher Flair can journal (SessionStart is still ${hookInstallHint(harness)})`,
+      backupPath: null, actions: null,
+    };
+  }
 
   for (const [label, value] of [["agent id", agentId], ["Flair URL", flairUrl]] as const) {
     if (!isHookCommandValueSafe(value)) {

--- a/test/unit/doctor-client.test.ts
+++ b/test/unit/doctor-client.test.ts
@@ -375,6 +375,21 @@ describe("fixSessionStartHook", () => {
     const res = checkSessionStartHook(isoHome);
     expect(res.present).toBe(true);
   });
+
+  it("codex path: fix + check write and read ~/.codex/hooks.json (flair#1148)", () => {
+    const path = join(isoHome, ".codex", "hooks.json");
+    const res = fixSessionStartHook(isoHome, "codexbot", path);
+    expect(res.ok).toBe(true);
+    expect(res.path).toBe(path);
+    expect(res.message).toContain(path);
+    expect(existsSync(join(isoHome, ".claude", "settings.json"))).toBe(false);
+
+    const check = checkSessionStartHook(isoHome, path);
+    expect(check.present).toBe(true);
+    expect(check.path).toBe(path);
+    expect(check.command).toContain("FLAIR_AGENT_ID=codexbot");
+    expect(checkSessionStartHook(isoHome).present).toBe(false);
+  });
 });
 
 /**

--- a/test/unit/doctor-session-start-hook-probe.test.ts
+++ b/test/unit/doctor-session-start-hook-probe.test.ts
@@ -129,6 +129,37 @@ describe("classifyHookProbe", () => {
   });
 });
 
+describe("inspectSessionStartHook — Codex hooks.json (flair#1148)", () => {
+  it("absent report names ~/.codex/hooks.json so doctor output is harness-specific", () => {
+    const path = join(isoHome, ".codex", "hooks.json");
+    const res = inspectSessionStartHook(isoHome, { settingsPath: path, probe: false });
+    expect(res.present).toBe(false);
+    expect(res.path).toBe(path);
+    expect(res.execution).toBeNull();
+  });
+
+  it("reads a Codex install and reports wired + ours on that path", () => {
+    const path = join(isoHome, ".codex", "hooks.json");
+    mkdirSync(join(isoHome, ".codex"), { recursive: true });
+    writeFileSync(
+      path,
+      JSON.stringify({
+        hooks: { SessionStart: [{ hooks: [{ type: "command", command: buildSessionStartHookCommand("codexbot") }] }] },
+      }),
+    );
+    const res = inspectSessionStartHook(isoHome, {
+      settingsPath: path,
+      probe: () => ({ exitCode: 0, stdout: "{}", stderr: "", timedOut: false, spawnError: null }),
+    });
+    expect(res.present).toBe(true);
+    expect(res.ours).toBe(true);
+    expect(res.silenced).toBe(true);
+    expect(res.path).toBe(path);
+    expect(res.execution).toBe("runs");
+    expect(inspectSessionStartHook(isoHome, { probe: false }).present).toBe(false);
+  });
+});
+
 describe("inspectSessionStartHook (injected probe)", () => {
   const brokenRunner = () => outcome({ exitCode: 127, stderr: "sh: npx: command not found" });
   const workingRunner = () => outcome({ exitCode: 0, stdout: "{}" });

--- a/test/unit/flair-mcp-detection.test.ts
+++ b/test/unit/flair-mcp-detection.test.ts
@@ -187,6 +187,36 @@ describe("detectWiredFlairMcp (reads actual config files under HOME)", () => {
     });
   });
 
+  test("Codex hook pin does not shadow a client pin (flair#1143 precedence)", () => {
+    // Same rule as the Claude Code case above, pinned on the Codex path so a
+    // rebase that inserts ~/.codex/hooks.json *before* ALL_CLIENTS goes red
+    // instead of silently inverting the #1393 client-first scan.
+    withTempHome((home) => {
+      mkdirSync(join(home, ".codex"), { recursive: true });
+      writeFileSync(
+        join(home, ".codex", "hooks.json"),
+        JSON.stringify({
+          hooks: { SessionStart: [{ hooks: [{ type: "command", command: buildSessionStartHookCommand("codexbot") }] }] },
+        }),
+      );
+      mkdirSync(join(home, ".gemini"), { recursive: true });
+      writeFileSync(
+        join(home, ".gemini", "settings.json"),
+        JSON.stringify({
+          mcpServers: {
+            flair: {
+              command: "npx",
+              args: ["-y", "@tpsdev-ai/flair-mcp@0.44.5"],
+              env: { FLAIR_AGENT_ID: "me", FLAIR_URL: "http://127.0.0.1:9926" },
+            },
+          },
+        }),
+      );
+      expect(detectWiredFlairMcp(home)).toEqual({ wired: true, pinnedVersion: "0.44.5" });
+      expect(flairCliVersion()).not.toBe("0.44.5");
+    });
+  });
+
   test("hook present but NO global install => resolves to current, NOT missing (issue #1208 acceptance)", () => {
     withTempHome((home) => {
       mkdirSync(join(home, ".claude"), { recursive: true });

--- a/test/unit/flair-mcp-detection.test.ts
+++ b/test/unit/flair-mcp-detection.test.ts
@@ -114,6 +114,19 @@ describe("detectWiredFlairMcp (reads actual config files under HOME)", () => {
     });
   });
 
+  test("Codex SessionStart hook in ~/.codex/hooks.json => wired, pin extracted (flair#1148)", () => {
+    withTempHome((home) => {
+      mkdirSync(join(home, ".codex"), { recursive: true });
+      writeFileSync(
+        join(home, ".codex", "hooks.json"),
+        JSON.stringify({
+          hooks: { SessionStart: [{ hooks: [{ type: "command", command: buildSessionStartHookCommand("codexbot") }] }] },
+        }),
+      );
+      expect(detectWiredFlairMcp(home)).toEqual({ wired: true, pinnedVersion: flairCliVersion() });
+    });
+  });
+
   test("client MCP config with a pinned flair server => wired, pin extracted", () => {
     withTempHome((home) => {
       mkdirSync(join(home, ".gemini"), { recursive: true });

--- a/test/unit/hook-install.test.ts
+++ b/test/unit/hook-install.test.ts
@@ -69,6 +69,12 @@ describe("harness registry", () => {
     expect(SUPPORTED_HARNESSES).toContain("claude-code");
   });
 
+  it("codex is supported (flair#1148) and writes ~/.codex/hooks.json", () => {
+    expect(isSupportedHarness("codex")).toBe(true);
+    expect(SUPPORTED_HARNESSES).toContain("codex");
+    expect(hookSettingsPath(isoHome, "codex")).toBe(join(isoHome, ".codex", "hooks.json"));
+  });
+
   it("an unknown harness is rejected", () => {
     expect(isSupportedHarness("cursor")).toBe(false);
     expect(isSupportedHarness("gemini")).toBe(false);
@@ -523,6 +529,64 @@ describe("hookStatus", () => {
       { label: "Agent", value: HOOK_STATUS_UNPARSED },
       { label: "Flair URL", value: HOOK_STATUS_UNPARSED },
     ]);
+  });
+});
+
+describe("codex harness — installer + doctor output (flair#1148)", () => {
+  it("fresh install creates ~/.codex/hooks.json and reports the add", () => {
+    const result = installHook({ homeDir: isoHome, harness: "codex", agentId: AGENT, flairUrl: URL });
+    expect(result.ok).toBe(true);
+    expect(result.delta?.action).toBe("add");
+    expect(result.message).toContain(join(isoHome, ".codex", "hooks.json"));
+    expect(result.message).toMatch(/added the SessionStart hook/);
+
+    const path = hookSettingsPath(isoHome, "codex");
+    expect(existsSync(path)).toBe(true);
+    expect(existsSync(join(isoHome, ".claude"))).toBe(false); // never touches Claude Code
+    const config = JSON.parse(readFileSync(path, "utf-8"));
+    const commands = config.hooks.SessionStart.flatMap((g: any) => g.hooks.map((h: any) => h.command));
+    expect(commands.some((c: string) => c.includes(SESSION_START_HOOK_MARKER) && c.includes(`FLAIR_AGENT_ID=${AGENT}`) && c.includes(`FLAIR_URL=${URL}`))).toBe(true);
+  });
+
+  it("status recovers agent/url and doctor sees the Codex path as present", () => {
+    installHook({ homeDir: isoHome, harness: "codex", agentId: AGENT, flairUrl: URL });
+    const status = hookStatus(isoHome, "codex");
+    expect(status.harness).toBe("codex");
+    expect(status.path).toBe(join(isoHome, ".codex", "hooks.json"));
+    expect(status.wired).toBe(true);
+    expect(status.correctShape).toBe(true);
+    expect(status.agentId).toBe(AGENT);
+    expect(status.flairUrl).toBe(URL);
+
+    const doctorView = checkSessionStartHook(isoHome, status.path);
+    expect(doctorView.present).toBe(true);
+    expect(doctorView.path).toBe(status.path);
+    expect(doctorView.command).toContain(SESSION_START_HOOK_MARKER);
+
+    // Default doctor check stays Claude-Code-scoped — a Codex-only install
+    // must not look like a Claude Code hook.
+    expect(checkSessionStartHook(isoHome).present).toBe(false);
+  });
+
+  it("uninstall removes only the Codex hook file entry and doctor then reports absent", () => {
+    installHook({ homeDir: isoHome, harness: "codex", agentId: AGENT, flairUrl: URL });
+    const result = uninstallHook({ homeDir: isoHome, harness: "codex" });
+    expect(result.ok).toBe(true);
+    expect(result.message).toMatch(/removed the Flair SessionStart hook/);
+    expect(result.message).toContain(join(isoHome, ".codex", "hooks.json"));
+
+    const status = hookStatus(isoHome, "codex");
+    expect(status.wired).toBe(false);
+    expect(checkSessionStartHook(isoHome, hookSettingsPath(isoHome, "codex")).present).toBe(false);
+  });
+
+  it("a Codex install does not satisfy a Claude Code status check (and vice versa)", () => {
+    installHook({ homeDir: isoHome, harness: "codex", agentId: AGENT, flairUrl: URL });
+    expect(hookStatus(isoHome, "claude-code").wired).toBe(false);
+    installHook({ homeDir: isoHome, harness: "claude-code", agentId: AGENT, flairUrl: URL });
+    expect(hookStatus(isoHome, "claude-code").wired).toBe(true);
+    expect(hookStatus(isoHome, "codex").wired).toBe(true);
+    expect(hookSettingsPath(isoHome, "claude-code")).not.toBe(hookSettingsPath(isoHome, "codex"));
   });
 });
 

--- a/test/unit/hook-install.test.ts
+++ b/test/unit/hook-install.test.ts
@@ -18,6 +18,7 @@ import {
   hookSettingsPath,
   hookBackupPath,
   hookInstallHint,
+  harnessSupportsContinuity,
   resolveHookAgentId,
   isSupportedHarness,
   SUPPORTED_HARNESSES,
@@ -88,6 +89,8 @@ describe("harness registry", () => {
     expect(hookInstallHint("claude-code", "--continuity")).toBe("flair hook install --continuity");
     expect(hookInstallHint("codex")).toBe("flair hook install --harness codex");
     expect(hookInstallHint("codex", "--continuity")).toBe("flair hook install --continuity --harness codex");
+    expect(harnessSupportsContinuity("claude-code")).toBe(true);
+    expect(harnessSupportsContinuity("codex")).toBe(false);
   });
 
   it("resolveHookAgentId prefers Codex MCP, then falls back to Claude Code (flair#1148)", () => {
@@ -758,6 +761,21 @@ describe("continuity hook install/uninstall/status wrappers", () => {
     expect(dry.ok).toBe(true);
     expect(dry.actions).toEqual({ PostToolUse: "remove", Stop: "remove" });
     expect(readFileSync(settingsPath(), "utf-8")).toBe(before);
+  });
+
+  it("Codex continuity install is refused and writes nothing (flair#1148)", () => {
+    const res = installContinuityHooks({ homeDir: isoHome, harness: "codex", agentId: AGENT, flairUrl: URL });
+    expect(res.ok).toBe(false);
+    expect(res.actions).toBeNull();
+    expect(existsSync(join(isoHome, ".codex"))).toBe(false);
+
+    const dry = installContinuityHooks({ homeDir: isoHome, harness: "codex", agentId: AGENT, flairUrl: URL, dryRun: true });
+    expect(dry.ok).toBe(false);
+    expect(existsSync(join(isoHome, ".codex"))).toBe(false);
+
+    const session = installHook({ homeDir: isoHome, harness: "codex", agentId: AGENT, flairUrl: URL });
+    expect(session.ok).toBe(true);
+    expect(existsSync(hookSettingsPath(isoHome, "codex"))).toBe(true);
   });
 
   it("continuity install never disturbs an existing SessionStart hook (and vice versa)", () => {

--- a/test/unit/hook-install.test.ts
+++ b/test/unit/hook-install.test.ts
@@ -17,6 +17,8 @@ import {
   parseHookCommandEnv,
   hookSettingsPath,
   hookBackupPath,
+  hookInstallHint,
+  resolveHookAgentId,
   isSupportedHarness,
   SUPPORTED_HARNESSES,
 } from "../../src/hook-install.ts";
@@ -79,6 +81,35 @@ describe("harness registry", () => {
     expect(isSupportedHarness("cursor")).toBe(false);
     expect(isSupportedHarness("gemini")).toBe(false);
     expect(isSupportedHarness("")).toBe(false);
+  });
+
+  it("hookInstallHint keeps claude-code as the bare default and names every other harness", () => {
+    expect(hookInstallHint("claude-code")).toBe("flair hook install");
+    expect(hookInstallHint("claude-code", "--continuity")).toBe("flair hook install --continuity");
+    expect(hookInstallHint("codex")).toBe("flair hook install --harness codex");
+    expect(hookInstallHint("codex", "--continuity")).toBe("flair hook install --continuity --harness codex");
+  });
+
+  it("resolveHookAgentId prefers Codex MCP, then falls back to Claude Code (flair#1148)", () => {
+    expect(resolveHookAgentId({}, isoHome, "codex")).toBeUndefined();
+
+    writeFileSync(
+      join(isoHome, ".claude.json"),
+      JSON.stringify({
+        mcpServers: {
+          flair: { command: "npx", args: ["-y", "@tpsdev-ai/flair-mcp"], env: { FLAIR_AGENT_ID: "claude-agent" } },
+        },
+      }),
+    );
+    expect(resolveHookAgentId({}, isoHome, "codex")).toBe("claude-agent");
+
+    mkdirSync(join(isoHome, ".codex"), { recursive: true });
+    writeFileSync(
+      join(isoHome, ".codex", "config.toml"),
+      ["[mcp_servers.flair]", 'command = "npx"', 'args = ["-y", "@tpsdev-ai/flair-mcp"]', "", "[mcp_servers.flair.env]", 'FLAIR_AGENT_ID = "codexbot"', ""].join("\n"),
+    );
+    expect(resolveHookAgentId({}, isoHome, "codex")).toBe("codexbot");
+    expect(resolveHookAgentId({ agent: "flag-agent" }, isoHome, "codex")).toBe("flag-agent");
   });
 });
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #1148.

`flair hook install` only supported `--harness claude-code`. Codex with the same MCP wiring and agent id then never loaded memory at session start, so the tools never entered the working set.

## What changed

- `--harness codex` is a registry entry on `flair hook install|uninstall|status`. It writes the same `flair-session-start` command Claude Code already uses into `~/.codex/hooks.json` (Codex's SessionStart hook file — same JSON schema). It does not touch `~/.codex/config.toml` MCP wiring.
- `flair doctor` reports the Codex hook when Codex is detected (path-specific inspect/fix). After install, Codex still requires `/hooks` to trust the new command.
- `docs/mcp-clients.md` documents the Codex hook path and the static AGENTS.md / GEMINI.md fallback for harnesses with no session-start mechanism.

## Tests

Installer and doctor coverage for the Codex path:

- `test/unit/hook-install.test.ts` — install/status/uninstall write `~/.codex/hooks.json`, doctor `checkSessionStartHook` sees that path, Claude Code and Codex stay isolated
- `test/unit/doctor-client.test.ts` — `fixSessionStartHook` / `checkSessionStartHook` against the Codex path
- `test/unit/doctor-session-start-hook-probe.test.ts` — `inspectSessionStartHook` doctor output names `~/.codex/hooks.json`
- `test/unit/flair-mcp-detection.test.ts` — a Codex-only hook counts as wired flair-mcp

## Out of scope

#1108, #1107, #1106, #1098, #1083, #1248. No changes to `.cursor/install.sh`.

Issue #1148 is assigned to heskew.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-89dde1ec-ea9a-43c6-a1f5-b89150caf808?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-89dde1ec-ea9a-43c6-a1f5-b89150caf808&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

